### PR TITLE
[Store] Support tenant-aware async storage tasks

### DIFF
--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -65,6 +65,7 @@ class Client {
     virtual ~Client();
 
     const UUID& getClientId() const { return client_id_; }
+    const std::string& tenant_id() const { return master_client_.tenant_id(); }
 
     /**
      * @brief Creates and initializes a new Client instance
@@ -145,6 +146,9 @@ class Client {
      */
     std::vector<tl::expected<QueryResult, ErrorCode>> BatchQuery(
         const std::vector<std::string>& object_keys);
+    std::vector<tl::expected<QueryResult, ErrorCode>> BatchQuery(
+        const std::vector<std::string>& object_keys,
+        const std::string& tenant_id);
 
     /**
      * @brief Batch clear KV cache for specified object keys on a specific
@@ -275,9 +279,15 @@ class Client {
      */
     tl::expected<void, ErrorCode> EvictDiskReplica(const std::string& key,
                                                    ReplicaType replica_type);
+    tl::expected<void, ErrorCode> EvictDiskReplica(const std::string& key,
+                                                   const std::string& tenant_id,
+                                                   ReplicaType replica_type);
 
     std::vector<tl::expected<void, ErrorCode>> BatchEvictDiskReplica(
         const std::vector<std::string>& keys, ReplicaType replica_type);
+    std::vector<tl::expected<void, ErrorCode>> BatchEvictDiskReplica(
+        const std::vector<std::string>& keys, const std::string& tenant_id,
+        ReplicaType replica_type);
 
     /**
      * @brief Registers a memory segment to master for allocation
@@ -362,6 +372,9 @@ class Client {
      */
     tl::expected<UUID, ErrorCode> CreateCopyTask(
         const std::string& key, const std::vector<std::string>& targets);
+    tl::expected<UUID, ErrorCode> CreateCopyTask(
+        const std::string& key, const std::string& tenant_id,
+        const std::vector<std::string>& targets);
 
     /**
      * @brief Create a move task to move an object's replica from source segment
@@ -373,6 +386,10 @@ class Client {
      * failure
      */
     tl::expected<UUID, ErrorCode> CreateMoveTask(const std::string& key,
+                                                 const std::string& source,
+                                                 const std::string& target);
+    tl::expected<UUID, ErrorCode> CreateMoveTask(const std::string& key,
+                                                 const std::string& tenant_id,
                                                  const std::string& source,
                                                  const std::string& target);
 
@@ -401,25 +418,25 @@ class Client {
      * set of non-offloaded objects.
      * @param enable_offloading Indicates whether offloading is enabled for this
      * segment.
-     * @param offloading_objects On return, contains a map from object key to
-     * size (in bytes) for all objects that require offload.
+     * @param offloading_objects On return, contains the tenant-scoped object
+     * tasks that require offload.
      */
     tl::expected<void, ErrorCode> OffloadObjectHeartbeat(
         bool enable_offloading,
-        std::unordered_map<std::string, int64_t>& offloading_objects);
+        std::vector<OffloadTaskItem>& offloading_objects);
 
     tl::expected<void, ErrorCode> ReportSsdCapacity(
         int64_t ssd_total_capacity_bytes);
 
     /**
      * @brief Heartbeat-driven pull of pending L2->L1 promotion work for this
-     * client. Mirror of OffloadObjectHeartbeat. Returns key->size pairs the
+     * client. Mirror of OffloadObjectHeartbeat. Returns tenant-scoped tasks the
      * caller (FileStorage) must read from local SSD and stage as MEMORY
      * replicas via PromotionAllocStart + NotifyPromotionSuccess.
      */
     // Virtual to enable subclassing in unit tests.
     virtual tl::expected<void, ErrorCode> PromotionObjectHeartbeat(
-        std::unordered_map<std::string, int64_t>& promotion_objects);
+        std::vector<PromotionTaskItem>& promotion_objects);
 
     /**
      * @brief Stage a PROCESSING MEMORY replica for an existing key during
@@ -429,6 +446,10 @@ class Client {
     virtual tl::expected<PromotionAllocStartResponse, ErrorCode>
     PromotionAllocStart(const std::string& key, uint64_t size,
                         const std::vector<std::string>& preferred_segments);
+    virtual tl::expected<PromotionAllocStartResponse, ErrorCode>
+    PromotionAllocStart(const std::string& key, const std::string& tenant_id,
+                        uint64_t size,
+                        const std::vector<std::string>& preferred_segments);
 
     /**
      * @brief Commit a staged MEMORY replica to COMPLETE; called after the
@@ -436,6 +457,8 @@ class Client {
      */
     virtual tl::expected<void, ErrorCode> NotifyPromotionSuccess(
         const std::string& key);
+    virtual tl::expected<void, ErrorCode> NotifyPromotionSuccess(
+        const std::string& key, const std::string& tenant_id);
 
     /**
      * @brief Release master-side promotion task after a client-side failure
@@ -443,6 +466,8 @@ class Client {
      */
     virtual tl::expected<void, ErrorCode> NotifyPromotionFailure(
         const std::string& key);
+    virtual tl::expected<void, ErrorCode> NotifyPromotionFailure(
+        const std::string& key, const std::string& tenant_id);
 
     /**
      * @brief Write `slices` into the memory replica described by
@@ -482,6 +507,9 @@ class Client {
      */
     tl::expected<void, ErrorCode> NotifyOffloadSuccess(
         const std::vector<std::string>& keys,
+        const std::vector<StorageObjectMetadata>& metadatas);
+    tl::expected<void, ErrorCode> NotifyOffloadSuccess(
+        const std::vector<OffloadTaskItem>& tasks,
         const std::vector<StorageObjectMetadata>& metadatas);
 
     /**
@@ -844,6 +872,10 @@ class Client {
     tl::expected<void, ErrorCode> Copy(const std::string& key,
                                        const std::string& source,
                                        const std::vector<std::string>& targets);
+    tl::expected<void, ErrorCode> Copy(const std::string& key,
+                                       const std::string& tenant_id,
+                                       const std::string& source,
+                                       const std::vector<std::string>& targets);
 
     /**
      * @brief Move an object's replica from source segment to target segment
@@ -853,6 +885,10 @@ class Client {
      * @return tl::expected<void, ErrorCode> indicating success/failure
      */
     tl::expected<void, ErrorCode> Move(const std::string& key,
+                                       const std::string& source,
+                                       const std::string& target);
+    tl::expected<void, ErrorCode> Move(const std::string& key,
+                                       const std::string& tenant_id,
                                        const std::string& source,
                                        const std::string& target);
 

--- a/mooncake-store/include/file_storage.h
+++ b/mooncake-store/include/file_storage.h
@@ -75,7 +75,7 @@ class FileStorage {
      * @return tl::expected<void, ErrorCode> indicating operation status.
      */
     tl::expected<void, ErrorCode> OffloadObjects(
-        const std::unordered_map<std::string, int64_t>& offloading_objects);
+        const std::vector<OffloadTaskItem>& offloading_objects);
 
     /**
      * @brief Performs a heartbeat operation for the FileStorage component.
@@ -107,7 +107,7 @@ class FileStorage {
         std::unordered_map<std::string, Slice>& batch_object);
 
     tl::expected<void, ErrorCode> BatchQuerySegmentSlices(
-        const std::vector<std::string>& keys,
+        const std::vector<std::string>& keys, const std::string& tenant_id,
         std::unordered_map<std::string, std::vector<Slice>>& batched_slices);
 
     tl::expected<void, ErrorCode> RegisterLocalMemory();

--- a/mooncake-store/include/master_client.h
+++ b/mooncake-store/include/master_client.h
@@ -76,6 +76,8 @@ class MasterClient {
     }
     ~MasterClient();
 
+    const std::string& tenant_id() const { return tenant_id_; }
+
     MasterClient(const MasterClient&) = delete;
     MasterClient& operator=(const MasterClient&) = delete;
 
@@ -146,6 +148,8 @@ class MasterClient {
      */
     [[nodiscard]] tl::expected<GetReplicaListResponse, ErrorCode>
     GetReplicaList(const std::string& object_key);
+    [[nodiscard]] tl::expected<GetReplicaListResponse, ErrorCode>
+    GetReplicaList(const std::string& object_key, const std::string& tenant_id);
 
     /**
      * @brief Retrieves replica lists for object keys that match a regex
@@ -167,6 +171,9 @@ class MasterClient {
      */
     [[nodiscard]] std::vector<tl::expected<GetReplicaListResponse, ErrorCode>>
     BatchGetReplicaList(const std::vector<std::string>& object_keys);
+    [[nodiscard]] std::vector<tl::expected<GetReplicaListResponse, ErrorCode>>
+    BatchGetReplicaList(const std::vector<std::string>& object_keys,
+                        const std::string& tenant_id);
 
     /**
      * @brief Starts a put operation
@@ -406,8 +413,7 @@ class MasterClient {
      * @param enable_offloading Indicates whether persistence is enabled for
      * this segment.
      */
-    [[nodiscard]] tl::expected<std::unordered_map<std::string, int64_t>,
-                               ErrorCode>
+    [[nodiscard]] tl::expected<std::vector<OffloadTaskItem>, ErrorCode>
     OffloadObjectHeartbeat(const UUID& client_id, bool enable_offloading);
 
     [[nodiscard]] tl::expected<void, ErrorCode> ReportSsdCapacity(
@@ -423,15 +429,17 @@ class MasterClient {
     [[nodiscard]] tl::expected<void, ErrorCode> NotifyOffloadSuccess(
         const UUID& client_id, const std::vector<std::string>& keys,
         const std::vector<StorageObjectMetadata>& metadatas);
+    [[nodiscard]] tl::expected<void, ErrorCode> NotifyOffloadSuccess(
+        const UUID& client_id, const std::vector<OffloadTaskItem>& tasks,
+        const std::vector<StorageObjectMetadata>& metadatas);
 
     /**
      * @brief Heartbeat-driven pull of pending L2->L1 promotion work for a
-     * client. Returns key->size pairs the caller should read from local
+     * client. Returns tenant-scoped tasks the caller should read from local
      * SSD and stage as MEMORY replicas via PromotionAllocStart +
      * NotifyPromotionSuccess.
      */
-    [[nodiscard]] tl::expected<std::unordered_map<std::string, int64_t>,
-                               ErrorCode>
+    [[nodiscard]] tl::expected<std::vector<PromotionTaskItem>, ErrorCode>
     PromotionObjectHeartbeat(const UUID& client_id);
 
     /**
@@ -443,6 +451,10 @@ class MasterClient {
     PromotionAllocStart(const UUID& client_id, const std::string& key,
                         uint64_t size,
                         const std::vector<std::string>& preferred_segments);
+    [[nodiscard]] tl::expected<PromotionAllocStartResponse, ErrorCode>
+    PromotionAllocStart(const UUID& client_id, const std::string& key,
+                        const std::string& tenant_id, uint64_t size,
+                        const std::vector<std::string>& preferred_segments);
 
     /**
      * @brief Release master-side promotion task state after a client-side
@@ -451,6 +463,9 @@ class MasterClient {
      */
     [[nodiscard]] tl::expected<void, ErrorCode> NotifyPromotionFailure(
         const UUID& client_id, const std::string& key);
+    [[nodiscard]] tl::expected<void, ErrorCode> NotifyPromotionFailure(
+        const UUID& client_id, const std::string& key,
+        const std::string& tenant_id);
 
     /**
      * @brief Commit a staged MEMORY replica to COMPLETE; called after the
@@ -458,6 +473,9 @@ class MasterClient {
      */
     [[nodiscard]] tl::expected<void, ErrorCode> NotifyPromotionSuccess(
         const UUID& client_id, const std::string& key);
+    [[nodiscard]] tl::expected<void, ErrorCode> NotifyPromotionSuccess(
+        const UUID& client_id, const std::string& key,
+        const std::string& tenant_id);
 
     /**
      * @brief Start a copy operation
@@ -470,6 +488,10 @@ class MasterClient {
     [[nodiscard]] tl::expected<CopyStartResponse, ErrorCode> CopyStart(
         const std::string& key, const std::string& src_segment,
         const std::vector<std::string>& tgt_segments);
+    [[nodiscard]] tl::expected<CopyStartResponse, ErrorCode> CopyStart(
+        const std::string& key, const std::string& tenant_id,
+        const std::string& src_segment,
+        const std::vector<std::string>& tgt_segments);
 
     /**
      * @brief End a copy operation
@@ -477,6 +499,8 @@ class MasterClient {
      * @return tl::expected<void, ErrorCode> indicating success/failure
      */
     [[nodiscard]] tl::expected<void, ErrorCode> CopyEnd(const std::string& key);
+    [[nodiscard]] tl::expected<void, ErrorCode> CopyEnd(
+        const std::string& key, const std::string& tenant_id);
 
     /**
      * @brief Revoke a copy operation
@@ -485,6 +509,8 @@ class MasterClient {
      */
     [[nodiscard]] tl::expected<void, ErrorCode> CopyRevoke(
         const std::string& key);
+    [[nodiscard]] tl::expected<void, ErrorCode> CopyRevoke(
+        const std::string& key, const std::string& tenant_id);
 
     /**
      * @brief Start a move operation
@@ -497,6 +523,9 @@ class MasterClient {
     [[nodiscard]] tl::expected<MoveStartResponse, ErrorCode> MoveStart(
         const std::string& key, const std::string& src_segment,
         const std::string& tgt_segment);
+    [[nodiscard]] tl::expected<MoveStartResponse, ErrorCode> MoveStart(
+        const std::string& key, const std::string& tenant_id,
+        const std::string& src_segment, const std::string& tgt_segment);
 
     /**
      * @brief End a move operation
@@ -504,6 +533,8 @@ class MasterClient {
      * @return tl::expected<void, ErrorCode> indicating success/failure
      */
     [[nodiscard]] tl::expected<void, ErrorCode> MoveEnd(const std::string& key);
+    [[nodiscard]] tl::expected<void, ErrorCode> MoveEnd(
+        const std::string& key, const std::string& tenant_id);
 
     /**
      * @brief Revoke a move operation
@@ -512,6 +543,8 @@ class MasterClient {
      */
     [[nodiscard]] tl::expected<void, ErrorCode> MoveRevoke(
         const std::string& key);
+    [[nodiscard]] tl::expected<void, ErrorCode> MoveRevoke(
+        const std::string& key, const std::string& tenant_id);
 
     /**
      * @brief Create a task to copy an object's replica to target segments
@@ -522,6 +555,9 @@ class MasterClient {
      */
     [[nodiscard]] tl::expected<UUID, ErrorCode> CreateCopyTask(
         const std::string& key, const std::vector<std::string>& targets);
+    [[nodiscard]] tl::expected<UUID, ErrorCode> CreateCopyTask(
+        const std::string& key, const std::string& tenant_id,
+        const std::vector<std::string>& targets);
 
     /**
      * @brief Create a task to move an object's replica from source segment to
@@ -535,6 +571,9 @@ class MasterClient {
     [[nodiscard]] tl::expected<UUID, ErrorCode> CreateMoveTask(
         const std::string& key, const std::string& source,
         const std::string& target);
+    [[nodiscard]] tl::expected<UUID, ErrorCode> CreateMoveTask(
+        const std::string& key, const std::string& tenant_id,
+        const std::string& source, const std::string& target);
 
     /**
      * @brief Query a task by task id
@@ -570,6 +609,9 @@ class MasterClient {
      */
     [[nodiscard]] tl::expected<void, ErrorCode> EvictDiskReplica(
         const std::string& key, ReplicaType replica_type);
+    [[nodiscard]] tl::expected<void, ErrorCode> EvictDiskReplica(
+        const std::string& key, const std::string& tenant_id,
+        ReplicaType replica_type);
 
     /**
      * @brief Batch notify master that disk replicas were evicted locally.
@@ -580,6 +622,10 @@ class MasterClient {
      */
     [[nodiscard]] std::vector<tl::expected<void, ErrorCode>>
     BatchEvictDiskReplica(const std::vector<std::string>& keys,
+                          ReplicaType replica_type);
+    [[nodiscard]] std::vector<tl::expected<void, ErrorCode>>
+    BatchEvictDiskReplica(const std::vector<std::string>& keys,
+                          const std::string& tenant_id,
                           ReplicaType replica_type);
 
    private:

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -309,6 +309,9 @@ class MasterService {
      */
     auto AddReplica(const UUID& client_id, const std::string& key,
                     Replica& replica) -> tl::expected<void, ErrorCode>;
+    auto AddReplica(const UUID& client_id, const std::string& key,
+                    const std::string& tenant_id, Replica& replica)
+        -> tl::expected<void, ErrorCode>;
 
     /**
      * @brief Revoke a put operation, replica_type indicates the type of
@@ -428,6 +431,10 @@ class MasterService {
     auto EvictDiskReplica(const UUID& client_id, const std::string& key,
                           ReplicaType replica_type)
         -> tl::expected<void, ErrorCode>;
+    auto EvictDiskReplica(const UUID& client_id, const std::string& key,
+                          const std::string& tenant_id,
+                          ReplicaType replica_type)
+        -> tl::expected<void, ErrorCode>;
 
     /**
      * @brief Batch evict disk replicas for multiple keys.
@@ -439,6 +446,9 @@ class MasterService {
     std::vector<tl::expected<void, ErrorCode>> BatchEvictDiskReplica(
         const UUID& client_id, const std::vector<std::string>& keys,
         ReplicaType replica_type);
+    std::vector<tl::expected<void, ErrorCode>> BatchEvictDiskReplica(
+        const UUID& client_id, const std::vector<std::string>& keys,
+        const std::string& tenant_id, ReplicaType replica_type);
 
     /**
      * @brief Start a copy operation
@@ -457,12 +467,22 @@ class MasterService {
         const UUID& client_id, const std::string& key,
         const std::string& src_segment,
         const std::vector<std::string>& tgt_segments);
+    tl::expected<CopyStartResponse, ErrorCode> CopyStart(
+        const UUID& client_id, const std::string& key,
+        const std::string& tenant_id, const std::string& src_segment,
+        const std::vector<std::string>& tgt_segments);
 
     tl::expected<void, ErrorCode> CopyEnd(const UUID& client_id,
                                           const std::string& key);
+    tl::expected<void, ErrorCode> CopyEnd(const UUID& client_id,
+                                          const std::string& key,
+                                          const std::string& tenant_id);
 
     tl::expected<void, ErrorCode> CopyRevoke(const UUID& client_id,
                                              const std::string& key);
+    tl::expected<void, ErrorCode> CopyRevoke(const UUID& client_id,
+                                             const std::string& key,
+                                             const std::string& tenant_id);
 
     /**
      * @brief Start a move operation
@@ -480,12 +500,22 @@ class MasterService {
     tl::expected<MoveStartResponse, ErrorCode> MoveStart(
         const UUID& client_id, const std::string& key,
         const std::string& src_segment, const std::string& tgt_segment);
+    tl::expected<MoveStartResponse, ErrorCode> MoveStart(
+        const UUID& client_id, const std::string& key,
+        const std::string& tenant_id, const std::string& src_segment,
+        const std::string& tgt_segment);
 
     tl::expected<void, ErrorCode> MoveEnd(const UUID& client_id,
                                           const std::string& key);
+    tl::expected<void, ErrorCode> MoveEnd(const UUID& client_id,
+                                          const std::string& key,
+                                          const std::string& tenant_id);
 
     tl::expected<void, ErrorCode> MoveRevoke(const UUID& client_id,
                                              const std::string& key);
+    tl::expected<void, ErrorCode> MoveRevoke(const UUID& client_id,
+                                             const std::string& key,
+                                             const std::string& tenant_id);
 
     /**
      * @brief Remove an object and its replicas
@@ -581,7 +611,7 @@ class MasterService {
      * segment.
      */
     auto OffloadObjectHeartbeat(const UUID& client_id, bool enable_offloading)
-        -> tl::expected<std::unordered_map<std::string, int64_t>, ErrorCode>;
+        -> tl::expected<std::vector<OffloadTaskItem>, ErrorCode>;
 
     auto ReportSsdCapacity(const UUID& client_id,
                            int64_t ssd_total_capacity_bytes)
@@ -599,16 +629,20 @@ class MasterService {
         const UUID& client_id, const std::vector<std::string>& keys,
         const std::vector<StorageObjectMetadata>& metadatas)
         -> tl::expected<void, ErrorCode>;
+    auto NotifyOffloadSuccess(
+        const UUID& client_id, const std::vector<OffloadTaskItem>& tasks,
+        const std::vector<StorageObjectMetadata>& metadatas)
+        -> tl::expected<void, ErrorCode>;
 
     /**
      * @brief Heartbeat-driven pull of pending promotion work for a client.
-     * Returns the per-client promotion_objects map (key -> object size) and
-     * clears it. The per-shard promotion_tasks map remains populated as the
-     * source of truth until NotifyPromotionSuccess commits the new MEMORY
-     * replica.
+     * Returns tenant-scoped promotion tasks for the holder client and clears
+     * its per-client promotion_objects queue. The per-shard promotion_tasks
+     * map remains populated as the source of truth until NotifyPromotionSuccess
+     * commits the new MEMORY replica.
      */
     auto PromotionObjectHeartbeat(const UUID& client_id)
-        -> tl::expected<std::unordered_map<std::string, int64_t>, ErrorCode>;
+        -> tl::expected<std::vector<PromotionTaskItem>, ErrorCode>;
 
     /**
      * @brief Stage a PROCESSING MEMORY replica for an existing key. Allocates
@@ -626,6 +660,10 @@ class MasterService {
                              uint64_t size,
                              const std::vector<std::string>& preferred_segments)
         -> tl::expected<PromotionAllocStartResponse, ErrorCode>;
+    auto PromotionAllocStart(const UUID& client_id, const std::string& key,
+                             const std::string& tenant_id, uint64_t size,
+                             const std::vector<std::string>& preferred_segments)
+        -> tl::expected<PromotionAllocStartResponse, ErrorCode>;
 
     /**
      * @brief Commit a staged MEMORY replica to COMPLETE; decrement source
@@ -633,6 +671,9 @@ class MasterService {
      * NotifyOffloadSuccess.
      */
     auto NotifyPromotionSuccess(const UUID& client_id, const std::string& key)
+        -> tl::expected<void, ErrorCode>;
+    auto NotifyPromotionSuccess(const UUID& client_id, const std::string& key,
+                                const std::string& tenant_id)
         -> tl::expected<void, ErrorCode>;
 
     /**
@@ -655,6 +696,9 @@ class MasterService {
      */
     auto NotifyPromotionFailure(const UUID& client_id, const std::string& key)
         -> tl::expected<void, ErrorCode>;
+    auto NotifyPromotionFailure(const UUID& client_id, const std::string& key,
+                                const std::string& tenant_id)
+        -> tl::expected<void, ErrorCode>;
 
     /**
      * @brief Create a copy task to copy an object's replicas to target segments
@@ -662,6 +706,9 @@ class MasterService {
      */
     tl::expected<UUID, ErrorCode> CreateCopyTask(
         const std::string& key, const std::vector<std::string>& targets);
+    tl::expected<UUID, ErrorCode> CreateCopyTask(
+        const std::string& key, const std::string& tenant_id,
+        const std::vector<std::string>& targets);
 
     /**
      * @brief Create a move task to move an object's replica from source segment
@@ -669,6 +716,10 @@ class MasterService {
      * @return Move task ID on success, ErrorCode on failure
      */
     tl::expected<UUID, ErrorCode> CreateMoveTask(const std::string& key,
+                                                 const std::string& source,
+                                                 const std::string& target);
+    tl::expected<UUID, ErrorCode> CreateMoveTask(const std::string& key,
+                                                 const std::string& tenant_id,
                                                  const std::string& source,
                                                  const std::string& target);
 
@@ -1860,6 +1911,7 @@ class MasterService {
 
     struct ActiveDrainTask {
         UUID task_id;
+        std::string tenant_id;
         std::string key;
         std::string source_segment;
         std::string target_segment;

--- a/mooncake-store/include/rpc_service.h
+++ b/mooncake-store/include/rpc_service.h
@@ -184,29 +184,32 @@ class WrappedMasterService {
     tl::expected<void, ErrorCode> MountLocalDiskSegment(const UUID& client_id,
                                                         bool enable_offloading);
 
-    tl::expected<std::unordered_map<std::string, int64_t>, ErrorCode>
+    tl::expected<std::vector<OffloadTaskItem>, ErrorCode>
     OffloadObjectHeartbeat(const UUID& client_id, bool enable_offloading);
 
     tl::expected<void, ErrorCode> ReportSsdCapacity(
         const UUID& client_id, int64_t ssd_total_capacity_bytes);
 
     tl::expected<void, ErrorCode> NotifyOffloadSuccess(
-        const UUID& client_id, const std::vector<std::string>& keys,
+        const UUID& client_id, const std::vector<OffloadTaskItem>& tasks,
         const std::vector<StorageObjectMetadata>& metadatas);
 
     // Promotion-on-hit RPCs.
-    tl::expected<std::unordered_map<std::string, int64_t>, ErrorCode>
+    tl::expected<std::vector<PromotionTaskItem>, ErrorCode>
     PromotionObjectHeartbeat(const UUID& client_id);
 
     tl::expected<PromotionAllocStartResponse, ErrorCode> PromotionAllocStart(
-        const UUID& client_id, const std::string& key, uint64_t size,
+        const UUID& client_id, const std::string& key,
+        const std::string& tenant_id, uint64_t size,
         const std::vector<std::string>& preferred_segments);
 
     tl::expected<void, ErrorCode> NotifyPromotionSuccess(
-        const UUID& client_id, const std::string& key);
+        const UUID& client_id, const std::string& key,
+        const std::string& tenant_id);
 
     tl::expected<void, ErrorCode> NotifyPromotionFailure(
-        const UUID& client_id, const std::string& key);
+        const UUID& client_id, const std::string& key,
+        const std::string& tenant_id);
 
     tl::expected<UUID, ErrorCode> CreateDrainJob(
         const CreateDrainJobRequest& request);
@@ -220,9 +223,11 @@ class WrappedMasterService {
     tl::expected<SegmentStatus, ErrorCode> QuerySegmentStatusById(
         const UUID& segment_id);
     tl::expected<UUID, ErrorCode> CreateCopyTask(
-        const std::string& key, const std::vector<std::string>& targets);
+        const std::string& key, const std::string& tenant_id,
+        const std::vector<std::string>& targets);
 
     tl::expected<UUID, ErrorCode> CreateMoveTask(const std::string& key,
+                                                 const std::string& tenant_id,
                                                  const std::string& source,
                                                  const std::string& target);
 
@@ -236,32 +241,38 @@ class WrappedMasterService {
 
     tl::expected<CopyStartResponse, ErrorCode> CopyStart(
         const UUID& client_id, const std::string& key,
-        const std::string& src_segment,
+        const std::string& tenant_id, const std::string& src_segment,
         const std::vector<std::string>& tgt_segments);
 
     tl::expected<void, ErrorCode> CopyEnd(const UUID& client_id,
-                                          const std::string& key);
+                                          const std::string& key,
+                                          const std::string& tenant_id);
 
     tl::expected<void, ErrorCode> CopyRevoke(const UUID& client_id,
-                                             const std::string& key);
+                                             const std::string& key,
+                                             const std::string& tenant_id);
 
     tl::expected<MoveStartResponse, ErrorCode> MoveStart(
         const UUID& client_id, const std::string& key,
-        const std::string& src_segment, const std::string& tgt_segment);
+        const std::string& tenant_id, const std::string& src_segment,
+        const std::string& tgt_segment);
 
     tl::expected<void, ErrorCode> MoveEnd(const UUID& client_id,
-                                          const std::string& key);
+                                          const std::string& key,
+                                          const std::string& tenant_id);
 
     tl::expected<void, ErrorCode> MoveRevoke(const UUID& client_id,
-                                             const std::string& key);
+                                             const std::string& key,
+                                             const std::string& tenant_id);
 
     tl::expected<void, ErrorCode> EvictDiskReplica(const UUID& client_id,
                                                    const std::string& key,
+                                                   const std::string& tenant_id,
                                                    ReplicaType replica_type);
 
     std::vector<tl::expected<void, ErrorCode>> BatchEvictDiskReplica(
         const UUID& client_id, const std::vector<std::string>& keys,
-        ReplicaType replica_type);
+        const std::string& tenant_id, ReplicaType replica_type);
 
    private:
     MasterService master_service_;

--- a/mooncake-store/include/segment.h
+++ b/mooncake-store/include/segment.h
@@ -86,14 +86,14 @@ struct LocalDiskSegment {
     mutable Mutex offloading_mutex_;
     bool enable_offloading;
     int64_t ssd_total_capacity_bytes = 0;  // last reported by client heartbeat
-    std::unordered_map<std::string, int64_t> GUARDED_BY(offloading_mutex_)
-        offloading_objects;
+    std::unordered_map<std::string, OffloadTaskItem> GUARDED_BY(
+        offloading_mutex_) offloading_objects;
     // Promotion-on-hit pending work for this client. Populated by master's
     // TryPushPromotionQueue when a Get hits a LOCAL_DISK-only key on this
     // client. Drained by PromotionObjectHeartbeat. Same locking as
     // offloading_objects (offloading_mutex_).
-    std::unordered_map<std::string, int64_t> GUARDED_BY(offloading_mutex_)
-        promotion_objects;
+    std::unordered_map<std::string, PromotionTaskItem> GUARDED_BY(
+        offloading_mutex_) promotion_objects;
     explicit LocalDiskSegment(bool enable_offloading)
         : enable_offloading(enable_offloading) {}
 

--- a/mooncake-store/include/task_manager.h
+++ b/mooncake-store/include/task_manager.h
@@ -92,18 +92,20 @@ struct Task {
 };
 
 struct ReplicaCopyPayload {
+    std::string tenant_id = "default";
     std::string key;
     std::string source;
     std::vector<std::string> targets;
 };
-YLT_REFL(ReplicaCopyPayload, key, source, targets);
+YLT_REFL(ReplicaCopyPayload, tenant_id, key, source, targets);
 
 struct ReplicaMovePayload {
+    std::string tenant_id = "default";
     std::string key;
     std::string source;
     std::string target;
 };
-YLT_REFL(ReplicaMovePayload, key, source, target);
+YLT_REFL(ReplicaMovePayload, tenant_id, key, source, target);
 
 template <TaskType T>
 struct TaskPayloadTraits;

--- a/mooncake-store/include/types.h
+++ b/mooncake-store/include/types.h
@@ -227,6 +227,51 @@ inline std::string NormalizeTenantId(const std::string& tenant_id) {
     return tenant_id.empty() ? "default" : tenant_id;
 }
 
+inline std::string MakeTenantScopedStorageKey(const std::string& tenant_id,
+                                              const std::string& key) {
+    const auto normalized_tenant = NormalizeTenantId(tenant_id);
+    std::string scoped_key;
+    scoped_key.reserve(normalized_tenant.size() + key.size() + 1);
+    scoped_key.append(normalized_tenant);
+    scoped_key.push_back('\0');
+    scoped_key.append(key);
+    return scoped_key;
+}
+
+inline std::pair<std::string, std::string> ParseTenantScopedStorageKey(
+    const std::string& storage_key) {
+    const auto separator = storage_key.find('\0');
+    if (separator == std::string::npos) {
+        return {"default", storage_key};
+    }
+    return {NormalizeTenantId(storage_key.substr(0, separator)),
+            storage_key.substr(separator + 1)};
+}
+
+struct OffloadTaskItem {
+    std::string tenant_id;
+    std::string key;
+    int64_t size;
+
+    bool operator==(const OffloadTaskItem& other) const {
+        return tenant_id == other.tenant_id && key == other.key &&
+               size == other.size;
+    }
+};
+YLT_REFL(OffloadTaskItem, tenant_id, key, size);
+
+struct PromotionTaskItem {
+    std::string tenant_id;
+    std::string key;
+    int64_t size;
+
+    bool operator==(const PromotionTaskItem& other) const {
+        return tenant_id == other.tenant_id && key == other.key &&
+               size == other.size;
+    }
+};
+YLT_REFL(PromotionTaskItem, tenant_id, key, size);
+
 // Store client configuration validation limits
 static constexpr size_t MIN_SEGMENT_SIZE = 1024;                          // 1KB
 static constexpr size_t MAX_SEGMENT_SIZE = 1024ULL * 1024 * 1024 * 1024;  // 1TB

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -1014,9 +1014,14 @@ tl::expected<QueryResult, ErrorCode> Client::Query(
 
 std::vector<tl::expected<QueryResult, ErrorCode>> Client::BatchQuery(
     const std::vector<std::string>& object_keys) {
+    return BatchQuery(object_keys, master_client_.tenant_id());
+}
+
+std::vector<tl::expected<QueryResult, ErrorCode>> Client::BatchQuery(
+    const std::vector<std::string>& object_keys, const std::string& tenant_id) {
     std::chrono::steady_clock::time_point start_time =
         std::chrono::steady_clock::now();
-    auto response = master_client_.BatchGetReplicaList(object_keys);
+    auto response = master_client_.BatchGetReplicaList(object_keys, tenant_id);
 
     // Check if we got the expected number of responses
     if (response.size() != object_keys.size()) {
@@ -2547,9 +2552,21 @@ tl::expected<void, ErrorCode> Client::EvictDiskReplica(
     return master_client_.EvictDiskReplica(key, replica_type);
 }
 
+tl::expected<void, ErrorCode> Client::EvictDiskReplica(
+    const std::string& key, const std::string& tenant_id,
+    ReplicaType replica_type) {
+    return master_client_.EvictDiskReplica(key, tenant_id, replica_type);
+}
+
 std::vector<tl::expected<void, ErrorCode>> Client::BatchEvictDiskReplica(
     const std::vector<std::string>& keys, ReplicaType replica_type) {
     return master_client_.BatchEvictDiskReplica(keys, replica_type);
+}
+
+std::vector<tl::expected<void, ErrorCode>> Client::BatchEvictDiskReplica(
+    const std::vector<std::string>& keys, const std::string& tenant_id,
+    ReplicaType replica_type) {
+    return master_client_.BatchEvictDiskReplica(keys, tenant_id, replica_type);
 }
 
 std::vector<int> Client::GetNicNumaNodes() const {
@@ -2875,8 +2892,7 @@ tl::expected<void, ErrorCode> Client::MountLocalDiskSegment(
 }
 
 tl::expected<void, ErrorCode> Client::OffloadObjectHeartbeat(
-    bool enable_offloading,
-    std::unordered_map<std::string, int64_t>& offloading_objects) {
+    bool enable_offloading, std::vector<OffloadTaskItem>& offloading_objects) {
     auto response =
         master_client_.OffloadObjectHeartbeat(client_id_, enable_offloading);
     if (!response) {
@@ -2928,8 +2944,14 @@ tl::expected<void, ErrorCode> Client::NotifyOffloadSuccess(
     return response;
 }
 
+tl::expected<void, ErrorCode> Client::NotifyOffloadSuccess(
+    const std::vector<OffloadTaskItem>& tasks,
+    const std::vector<StorageObjectMetadata>& metadatas) {
+    return master_client_.NotifyOffloadSuccess(client_id_, tasks, metadatas);
+}
+
 tl::expected<void, ErrorCode> Client::PromotionObjectHeartbeat(
-    std::unordered_map<std::string, int64_t>& promotion_objects) {
+    std::vector<PromotionTaskItem>& promotion_objects) {
     auto response = master_client_.PromotionObjectHeartbeat(client_id_);
     if (!response) {
         return tl::make_unexpected(response.error());
@@ -2946,14 +2968,32 @@ Client::PromotionAllocStart(
                                               preferred_segments);
 }
 
+tl::expected<PromotionAllocStartResponse, ErrorCode>
+Client::PromotionAllocStart(
+    const std::string& key, const std::string& tenant_id, uint64_t size,
+    const std::vector<std::string>& preferred_segments) {
+    return master_client_.PromotionAllocStart(client_id_, key, tenant_id, size,
+                                              preferred_segments);
+}
+
 tl::expected<void, ErrorCode> Client::NotifyPromotionSuccess(
     const std::string& key) {
     return master_client_.NotifyPromotionSuccess(client_id_, key);
 }
 
+tl::expected<void, ErrorCode> Client::NotifyPromotionSuccess(
+    const std::string& key, const std::string& tenant_id) {
+    return master_client_.NotifyPromotionSuccess(client_id_, key, tenant_id);
+}
+
 tl::expected<void, ErrorCode> Client::NotifyPromotionFailure(
     const std::string& key) {
     return master_client_.NotifyPromotionFailure(client_id_, key);
+}
+
+tl::expected<void, ErrorCode> Client::NotifyPromotionFailure(
+    const std::string& key, const std::string& tenant_id) {
+    return master_client_.NotifyPromotionFailure(client_id_, key, tenant_id);
 }
 
 ErrorCode Client::PromotionWrite(const Replica::Descriptor& memory_descriptor,
@@ -2966,10 +3006,22 @@ tl::expected<UUID, ErrorCode> Client::CreateCopyTask(
     return master_client_.CreateCopyTask(key, targets);
 }
 
+tl::expected<UUID, ErrorCode> Client::CreateCopyTask(
+    const std::string& key, const std::string& tenant_id,
+    const std::vector<std::string>& targets) {
+    return master_client_.CreateCopyTask(key, tenant_id, targets);
+}
+
 tl::expected<UUID, ErrorCode> Client::CreateMoveTask(
     const std::string& key, const std::string& source,
     const std::string& target) {
     return master_client_.CreateMoveTask(key, source, target);
+}
+
+tl::expected<UUID, ErrorCode> Client::CreateMoveTask(
+    const std::string& key, const std::string& tenant_id,
+    const std::string& source, const std::string& target) {
+    return master_client_.CreateMoveTask(key, tenant_id, source, target);
 }
 
 tl::expected<void, ErrorCode> Client::ExecuteReplicaTransfer(
@@ -3032,11 +3084,18 @@ tl::expected<void, ErrorCode> Client::ExecuteReplicaTransfer(
 tl::expected<void, ErrorCode> Client::Copy(
     const std::string& key, const std::string& source,
     const std::vector<std::string>& targets) {
+    return Copy(key, master_client_.tenant_id(), source, targets);
+}
+
+tl::expected<void, ErrorCode> Client::Copy(
+    const std::string& key, const std::string& tenant_id,
+    const std::string& source, const std::vector<std::string>& targets) {
     LOG(INFO) << "action=replica_copy_start" << ", key=" << key
               << ", targets_count=" << targets.size();
 
     // Call CopyStart first - it validates existence and allocates replicas
-    auto start_result = master_client_.CopyStart(key, source, targets);
+    auto start_result =
+        master_client_.CopyStart(key, tenant_id, source, targets);
     if (!start_result.has_value()) {
         ErrorCode error = start_result.error();
         LOG(ERROR) << "action=replica_copy_failed" << ", key=" << key
@@ -3050,7 +3109,7 @@ tl::expected<void, ErrorCode> Client::Copy(
         LOG(INFO) << "action=replica_copy_skipped" << ", key=" << key
                   << ", info=target_replicas_already_exist";
         // Target replicas already exist, consider it success
-        auto copy_end_result = master_client_.CopyEnd(key);
+        auto copy_end_result = master_client_.CopyEnd(key, tenant_id);
         if (!copy_end_result.has_value()) {
             ErrorCode error = copy_end_result.error();
             LOG(ERROR) << "action=replica_copy_failed" << ", key=" << key
@@ -3061,9 +3120,9 @@ tl::expected<void, ErrorCode> Client::Copy(
     }
 
     auto result = ExecuteReplicaTransfer(
-        key, "copy", [&]() { return master_client_.CopyEnd(key); },
-        [&]() { return master_client_.CopyRevoke(key); }, response.source,
-        response.targets);
+        key, "copy", [&]() { return master_client_.CopyEnd(key, tenant_id); },
+        [&]() { return master_client_.CopyRevoke(key, tenant_id); },
+        response.source, response.targets);
 
     if (result.has_value()) {
         LOG(INFO) << "action=replica_copy_success" << ", key=" << key
@@ -3076,12 +3135,20 @@ tl::expected<void, ErrorCode> Client::Copy(
 tl::expected<void, ErrorCode> Client::Move(const std::string& key,
                                            const std::string& source,
                                            const std::string& target) {
+    return Move(key, master_client_.tenant_id(), source, target);
+}
+
+tl::expected<void, ErrorCode> Client::Move(const std::string& key,
+                                           const std::string& tenant_id,
+                                           const std::string& source,
+                                           const std::string& target) {
     LOG(INFO) << "action=replica_move_start" << ", key=" << key
               << ", source_segment=" << source << ", target_segment=" << target;
 
     // Call MoveStart first - it validates existence and allocates replica if
     // needed
-    auto move_start_result = master_client_.MoveStart(key, source, target);
+    auto move_start_result =
+        master_client_.MoveStart(key, tenant_id, source, target);
     if (!move_start_result.has_value()) {
         ErrorCode error = move_start_result.error();
         LOG(ERROR) << "action=replica_move_failed" << ", key=" << key
@@ -3095,7 +3162,7 @@ tl::expected<void, ErrorCode> Client::Move(const std::string& key,
         LOG(INFO) << "action=replica_move_skipped" << ", key=" << key
                   << ", info=target_replica_already_exists";
         // Target already exists, consider it success
-        auto move_end_result = master_client_.MoveEnd(key);
+        auto move_end_result = master_client_.MoveEnd(key, tenant_id);
         if (!move_end_result.has_value()) {
             ErrorCode error = move_end_result.error();
             LOG(ERROR) << "action=replica_move_failed" << ", key=" << key
@@ -3108,9 +3175,9 @@ tl::expected<void, ErrorCode> Client::Move(const std::string& key,
     std::vector<Replica::Descriptor> targets = {response.target.value()};
 
     auto result = ExecuteReplicaTransfer(
-        key, "move", [&]() { return master_client_.MoveEnd(key); },
-        [&]() { return master_client_.MoveRevoke(key); }, response.source,
-        targets);
+        key, "move", [&]() { return master_client_.MoveEnd(key, tenant_id); },
+        [&]() { return master_client_.MoveRevoke(key, tenant_id); },
+        response.source, targets);
 
     if (result.has_value()) {
         LOG(INFO) << "action=replica_move_success" << ", key=" << key
@@ -3383,8 +3450,8 @@ void Client::ExecuteTask(const ClientTask& client_task) {
             case TaskType::REPLICA_COPY: {
                 ReplicaCopyPayload payload;
                 struct_json::from_json(payload, assignment.payload);
-                auto copy_result =
-                    Copy(payload.key, payload.source, payload.targets);
+                auto copy_result = Copy(payload.key, payload.tenant_id,
+                                        payload.source, payload.targets);
                 if (copy_result.has_value()) {
                     result = ErrorCode::OK;
                 } else {
@@ -3395,8 +3462,8 @@ void Client::ExecuteTask(const ClientTask& client_task) {
             case TaskType::REPLICA_MOVE: {
                 ReplicaMovePayload payload;
                 struct_json::from_json(payload, assignment.payload);
-                auto move_result =
-                    Move(payload.key, payload.source, payload.target);
+                auto move_result = Move(payload.key, payload.tenant_id,
+                                        payload.source, payload.target);
                 if (move_result.has_value()) {
                     result = ErrorCode::OK;
                 } else {

--- a/mooncake-store/src/file_storage.cpp
+++ b/mooncake-store/src/file_storage.cpp
@@ -18,6 +18,26 @@ using gpu_staging::CopyDeviceToHost;
 using gpu_staging::IsDevicePointer;
 using gpu_staging::SetDevice;
 
+namespace {
+
+std::vector<OffloadTaskItem> BuildOffloadTasksFromStorageKeys(
+    const std::vector<std::string>& storage_keys,
+    const std::vector<StorageObjectMetadata>& metadatas) {
+    std::vector<OffloadTaskItem> tasks;
+    tasks.reserve(storage_keys.size());
+    for (size_t i = 0; i < storage_keys.size(); ++i) {
+        auto [tenant_id, key] = ParseTenantScopedStorageKey(storage_keys[i]);
+        const int64_t size =
+            i < metadatas.size() ? metadatas[i].data_size : int64_t{0};
+        tasks.push_back(OffloadTaskItem{.tenant_id = std::move(tenant_id),
+                                        .key = std::move(key),
+                                        .size = size});
+    }
+    return tasks;
+}
+
+}  // namespace
+
 FileStorageConfig FileStorageConfig::FromEnvironment() {
     FileStorageConfig config;
 
@@ -264,8 +284,9 @@ tl::expected<void, ErrorCode> FileStorage::Init() {
             for (auto& metadata : metadatas) {
                 metadata.transport_endpoint = local_rpc_addr_;
             }
+            auto tasks = BuildOffloadTasksFromStorageKeys(keys, metadatas);
             auto add_object_result =
-                client_->NotifyOffloadSuccess(keys, metadatas);
+                client_->NotifyOffloadSuccess(tasks, metadatas);
             if (!add_object_result) {
                 LOG(ERROR) << "Failed to add object to master: "
                            << add_object_result.error();
@@ -339,15 +360,26 @@ tl::expected<FileStorage::BatchGetResult, ErrorCode> FileStorage::BatchGet(
 }
 
 tl::expected<void, ErrorCode> FileStorage::OffloadObjects(
-    const std::unordered_map<std::string, int64_t>& offloading_objects) {
+    const std::vector<OffloadTaskItem>& offloading_objects) {
     if (offloading_objects.empty()) {
         return {};
     }
+    std::unordered_map<std::string, int64_t> storage_object_sizes;
+    std::unordered_map<std::string, OffloadTaskItem> task_by_storage_key;
+    storage_object_sizes.reserve(offloading_objects.size());
+    task_by_storage_key.reserve(offloading_objects.size());
+    for (const auto& task : offloading_objects) {
+        const auto storage_key =
+            MakeTenantScopedStorageKey(task.tenant_id, task.key);
+        storage_object_sizes.emplace(storage_key, task.size);
+        task_by_storage_key.emplace(storage_key, task);
+    }
+
     std::vector<std::vector<std::string>> buckets_keys;
     if (auto bucket_backend =
             std::dynamic_pointer_cast<BucketStorageBackend>(storage_backend_)) {
         auto allocate_res = bucket_backend->AllocateOffloadingBuckets(
-            offloading_objects, buckets_keys);
+            storage_object_sizes, buckets_keys);
         if (!allocate_res) {
             LOG(ERROR) << "AllocateOffloadingBuckets failed with error: "
                        << allocate_res.error();
@@ -355,21 +387,32 @@ tl::expected<void, ErrorCode> FileStorage::OffloadObjects(
         }
     } else {
         std::vector<std::string> keys;
-        keys.reserve(offloading_objects.size());
-        for (const auto& it : offloading_objects) {
+        keys.reserve(storage_object_sizes.size());
+        for (const auto& it : storage_object_sizes) {
             keys.emplace_back(it.first);
         }
         buckets_keys.emplace_back(std::move(keys));
     }
 
     auto complete_handler =
-        [this](const std::vector<std::string>& keys,
-               std::vector<StorageObjectMetadata>& metadatas) -> ErrorCode {
+        [this, &task_by_storage_key](
+            const std::vector<std::string>& keys,
+            std::vector<StorageObjectMetadata>& metadatas) -> ErrorCode {
         VLOG(1) << "Success to store objects, keys count: " << keys.size();
         for (auto& metadata : metadatas) {
             metadata.transport_endpoint = local_rpc_addr_;
         }
-        auto result = client_->NotifyOffloadSuccess(keys, metadatas);
+        std::vector<OffloadTaskItem> tasks;
+        tasks.reserve(keys.size());
+        for (const auto& key : keys) {
+            auto it = task_by_storage_key.find(key);
+            if (it == task_by_storage_key.end()) {
+                LOG(ERROR) << "Offload task not found for storage key";
+                return ErrorCode::INVALID_KEY;
+            }
+            tasks.push_back(it->second);
+        }
+        auto result = client_->NotifyOffloadSuccess(tasks, metadatas);
         if (!result) {
             LOG(ERROR) << "NotifyOffloadSuccess failed with error: "
                        << result.error();
@@ -380,24 +423,63 @@ tl::expected<void, ErrorCode> FileStorage::OffloadObjects(
 
     for (const auto& keys : buckets_keys) {
         std::unordered_map<std::string, std::vector<Slice>> batch_object;
-        auto query_result = BatchQuerySegmentSlices(keys, batch_object);
-        if (!query_result) {
-            LOG(ERROR) << "BatchQuerySlices failed with error: "
-                       << query_result.error();
+        std::unordered_map<std::string, std::vector<std::string>>
+            storage_keys_by_tenant;
+        for (const auto& storage_key : keys) {
+            const auto it = task_by_storage_key.find(storage_key);
+            if (it != task_by_storage_key.end()) {
+                storage_keys_by_tenant[it->second.tenant_id].push_back(
+                    storage_key);
+            }
+        }
+        for (const auto& [tenant_id, storage_keys] : storage_keys_by_tenant) {
+            std::vector<std::string> user_keys;
+            user_keys.reserve(storage_keys.size());
+            for (const auto& storage_key : storage_keys) {
+                user_keys.push_back(task_by_storage_key[storage_key].key);
+            }
+            std::unordered_map<std::string, std::vector<Slice>>
+                user_batch_object;
+            auto query_result = BatchQuerySegmentSlices(user_keys, tenant_id,
+                                                        user_batch_object);
+            if (!query_result) {
+                LOG(ERROR) << "BatchQuerySlices failed with error: "
+                           << query_result.error();
+                continue;
+            }
+            for (size_t i = 0; i < storage_keys.size(); ++i) {
+                auto it = user_batch_object.find(user_keys[i]);
+                if (it != user_batch_object.end()) {
+                    batch_object.emplace(storage_keys[i],
+                                         std::move(it->second));
+                }
+            }
+        }
+        if (batch_object.empty()) {
             continue;
         }
 
         auto eviction_handler = [this](const std::vector<std::string>&
                                            evicted_keys) {
             if (evicted_keys.empty()) return;
-            auto results = client_->BatchEvictDiskReplica(
-                evicted_keys, ReplicaType::LOCAL_DISK);
-            for (size_t i = 0; i < results.size(); ++i) {
-                if (!results[i]) {
-                    LOG(WARNING)
-                        << "Failed to notify master about evicted local disk "
-                           "key: "
-                        << evicted_keys[i] << ", error: " << results[i].error();
+            std::unordered_map<std::string, std::vector<std::string>>
+                keys_by_tenant;
+            for (const auto& storage_key : evicted_keys) {
+                auto [tenant_id, key] =
+                    ParseTenantScopedStorageKey(storage_key);
+                keys_by_tenant[tenant_id].push_back(key);
+            }
+            for (const auto& [tenant_id, keys] : keys_by_tenant) {
+                auto results = client_->BatchEvictDiskReplica(
+                    keys, tenant_id, ReplicaType::LOCAL_DISK);
+                for (size_t i = 0; i < results.size(); ++i) {
+                    if (!results[i]) {
+                        LOG(WARNING)
+                            << "Failed to notify master about evicted local "
+                               "disk key: "
+                            << keys[i] << ", tenant_id=" << tenant_id
+                            << ", error: " << results[i].error();
+                    }
                 }
             }
         };
@@ -521,7 +603,7 @@ tl::expected<void, ErrorCode> FileStorage::Heartbeat() {
         });
     }
 
-    std::unordered_map<std::string, int64_t>
+    std::vector<OffloadTaskItem>
         offloading_objects;  // Objects selected for offloading
 
     // === STEP 1: Send heartbeat and get offloading decisions ===
@@ -605,7 +687,7 @@ tl::expected<void, ErrorCode> FileStorage::ProcessPromotionTasks() {
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
 
-    std::unordered_map<std::string, int64_t> promotion_objects;
+    std::vector<PromotionTaskItem> promotion_objects;
     auto heartbeat_result =
         client_->PromotionObjectHeartbeat(promotion_objects);
     if (!heartbeat_result) {
@@ -636,7 +718,11 @@ tl::expected<void, ErrorCode> FileStorage::ProcessPromotionTasks() {
     // work stays queued in the master's promotion_objects map and is
     // returned on subsequent heartbeats; we process whatever we received
     // here without a second client-side cap.
-    for (const auto& [key, size] : promotion_objects) {
+    for (const auto& task : promotion_objects) {
+        const auto& key = task.key;
+        const auto& tenant_id = task.tenant_id;
+        const int64_t size = task.size;
+        const auto storage_key = MakeTenantScopedStorageKey(tenant_id, key);
         if (size <= 0) {
             LOG(WARNING) << "Skipping promotion for key=" << key
                          << " with non-positive size=" << size;
@@ -644,7 +730,7 @@ tl::expected<void, ErrorCode> FileStorage::ProcessPromotionTasks() {
         }
 
         auto alloc_result = client_->PromotionAllocStart(
-            key, static_cast<uint64_t>(size), preferred_segments);
+            key, tenant_id, static_cast<uint64_t>(size), preferred_segments);
         if (!alloc_result) {
             // AllocStart failed (typically NO_AVAILABLE_HANDLE under
             // DRAM pressure). No staged buffer to release, but the
@@ -657,7 +743,7 @@ tl::expected<void, ErrorCode> FileStorage::ProcessPromotionTasks() {
             VLOG(1) << "PromotionAllocStart failed for key=" << key
                     << ", error=" << alloc_result.error()
                     << " (likely no free DRAM); releasing master slot";
-            auto release = client_->NotifyPromotionFailure(key);
+            auto release = client_->NotifyPromotionFailure(key, tenant_id);
             if (!release) {
                 VLOG(1) << "Promotion: NotifyPromotionFailure failed for key="
                         << key << ", error=" << release.error()
@@ -673,8 +759,8 @@ tl::expected<void, ErrorCode> FileStorage::ProcessPromotionTasks() {
         // throttling or RDMA flakes saturate promotion_queue_limit_
         // for the full reaper TTL. NotifyPromotionFailure is
         // idempotent and best-effort — the reaper is the long-stop.
-        auto release_master_state = [this, &key]() {
-            auto release = client_->NotifyPromotionFailure(key);
+        auto release_master_state = [this, &key, &tenant_id]() {
+            auto release = client_->NotifyPromotionFailure(key, tenant_id);
             if (!release) {
                 VLOG(1) << "Promotion: NotifyPromotionFailure failed for key="
                         << key << ", error=" << release.error()
@@ -686,7 +772,7 @@ tl::expected<void, ErrorCode> FileStorage::ProcessPromotionTasks() {
         // from the local SSD backend into it. AllocateBatch returns a
         // shared_ptr<AllocatedBatch> whose BufferHandles RAII-release the
         // staging space when the local goes out of scope.
-        std::vector<std::string> single_key{key};
+        std::vector<std::string> single_key{storage_key};
         std::vector<int64_t> single_size{size};
         auto allocate_res = AllocateBatch(single_key, single_size);
         if (!allocate_res) {
@@ -707,7 +793,7 @@ tl::expected<void, ErrorCode> FileStorage::ProcessPromotionTasks() {
         // (b) TE-write from the staging slice into the freshly-allocated
         // MEMORY replica. Slice ptr may have been bumped by O_DIRECT offset
         // correction in BatchLoad, so re-read it from the slice map.
-        auto slice_it = staging->slices.find(key);
+        auto slice_it = staging->slices.find(storage_key);
         if (slice_it == staging->slices.end()) {
             LOG(WARNING) << "Promotion: staging slice missing for key=" << key;
             release_master_state();
@@ -725,7 +811,7 @@ tl::expected<void, ErrorCode> FileStorage::ProcessPromotionTasks() {
 
         // (c) Commit. Master flips the PROCESSING replica to COMPLETE and it
         // becomes visible to readers.
-        auto notify_res = client_->NotifyPromotionSuccess(key);
+        auto notify_res = client_->NotifyPromotionSuccess(key, tenant_id);
         if (!notify_res) {
             // The write landed but the commit failed. We can't retry the
             // commit (the success path is one-shot via alloc_id), and we
@@ -775,9 +861,9 @@ tl::expected<void, ErrorCode> FileStorage::BatchLoad(
 }
 
 tl::expected<void, ErrorCode> FileStorage::BatchQuerySegmentSlices(
-    const std::vector<std::string>& keys,
+    const std::vector<std::string>& keys, const std::string& tenant_id,
     std::unordered_map<std::string, std::vector<Slice>>& batched_slices) {
-    auto batched_query_results = client_->BatchQuery(keys);
+    auto batched_query_results = client_->BatchQuery(keys, tenant_id);
     if (batched_query_results.empty())
         return tl::make_unexpected(ErrorCode::INVALID_REPLICA);
     for (size_t i = 0; i < batched_query_results.size(); ++i) {
@@ -958,8 +1044,9 @@ tl::expected<void, ErrorCode> FileStorage::ReRegisterOffloadedObjects() {
                 for (auto& metadata : metadatas) {
                     metadata.transport_endpoint = local_rpc_addr_;
                 }
+                auto tasks = BuildOffloadTasksFromStorageKeys(keys, metadatas);
                 auto add_object_result =
-                    client_->NotifyOffloadSuccess(keys, metadatas);
+                    client_->NotifyOffloadSuccess(tasks, metadatas);
                 if (!add_object_result) {
                     total_failures++;
                     LOG(ERROR)

--- a/mooncake-store/src/master_client.cpp
+++ b/mooncake-store/src/master_client.cpp
@@ -516,23 +516,35 @@ MasterClient::GetReplicaListByRegex(const std::string& str) {
 
 tl::expected<GetReplicaListResponse, ErrorCode> MasterClient::GetReplicaList(
     const std::string& object_key) {
+    return GetReplicaList(object_key, tenant_id_);
+}
+
+tl::expected<GetReplicaListResponse, ErrorCode> MasterClient::GetReplicaList(
+    const std::string& object_key, const std::string& tenant_id) {
     ScopedVLogTimer timer(1, "MasterClient::GetReplicaList");
-    timer.LogRequest("object_key=", object_key);
+    timer.LogRequest("object_key=", object_key, ", tenant_id=", tenant_id);
 
     auto result = invoke_rpc<&WrappedMasterService::GetReplicaList,
-                             GetReplicaListResponse>(object_key, tenant_id_);
+                             GetReplicaListResponse>(object_key, tenant_id);
     timer.LogResponseExpected(result);
     return result;
 }
 
 std::vector<tl::expected<GetReplicaListResponse, ErrorCode>>
 MasterClient::BatchGetReplicaList(const std::vector<std::string>& object_keys) {
+    return BatchGetReplicaList(object_keys, tenant_id_);
+}
+
+std::vector<tl::expected<GetReplicaListResponse, ErrorCode>>
+MasterClient::BatchGetReplicaList(const std::vector<std::string>& object_keys,
+                                  const std::string& tenant_id) {
     ScopedVLogTimer timer(1, "MasterClient::BatchGetReplicaList");
-    timer.LogRequest("keys_count=", object_keys.size());
+    timer.LogRequest("keys_count=", object_keys.size(),
+                     ", tenant_id=", tenant_id);
 
     auto result = invoke_batch_rpc<&WrappedMasterService::BatchGetReplicaList,
                                    GetReplicaListResponse>(
-        object_keys.size(), object_keys, tenant_id_);
+        object_keys.size(), object_keys, tenant_id);
     timer.LogResponse("result=", result.size(), " operations");
     return result;
 }
@@ -921,11 +933,18 @@ tl::expected<void, ErrorCode> MasterClient::MountLocalDiskSegment(
 
 tl::expected<UUID, ErrorCode> MasterClient::CreateCopyTask(
     const std::string& key, const std::vector<std::string>& targets) {
-    ScopedVLogTimer timer(1, "MasterClient::CreateCopyTask");
-    timer.LogRequest("key=", key, ", targets_size=", targets.size());
+    return CreateCopyTask(key, tenant_id_, targets);
+}
 
-    auto result =
-        invoke_rpc<&WrappedMasterService::CreateCopyTask, UUID>(key, targets);
+tl::expected<UUID, ErrorCode> MasterClient::CreateCopyTask(
+    const std::string& key, const std::string& tenant_id,
+    const std::vector<std::string>& targets) {
+    ScopedVLogTimer timer(1, "MasterClient::CreateCopyTask");
+    timer.LogRequest("key=", key, ", tenant_id=", tenant_id,
+                     ", targets_size=", targets.size());
+
+    auto result = invoke_rpc<&WrappedMasterService::CreateCopyTask, UUID>(
+        key, tenant_id, targets);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -933,25 +952,32 @@ tl::expected<UUID, ErrorCode> MasterClient::CreateCopyTask(
 tl::expected<UUID, ErrorCode> MasterClient::CreateMoveTask(
     const std::string& key, const std::string& source,
     const std::string& target) {
+    return CreateMoveTask(key, tenant_id_, source, target);
+}
+
+tl::expected<UUID, ErrorCode> MasterClient::CreateMoveTask(
+    const std::string& key, const std::string& tenant_id,
+    const std::string& source, const std::string& target) {
     ScopedVLogTimer timer(1, "MasterClient::CreateMoveTask");
-    timer.LogRequest("key=", key, ", source=", source, ", target=", target);
+    timer.LogRequest("key=", key, ", tenant_id=", tenant_id,
+                     ", source=", source, ", target=", target);
 
     auto result = invoke_rpc<&WrappedMasterService::CreateMoveTask, UUID>(
-        key, source, target);
+        key, tenant_id, source, target);
     timer.LogResponseExpected(result);
     return result;
 }
 
-tl::expected<std::unordered_map<std::string, int64_t>, ErrorCode>
+tl::expected<std::vector<OffloadTaskItem>, ErrorCode>
 MasterClient::OffloadObjectHeartbeat(const UUID& client_id,
                                      bool enable_offloading) {
     ScopedVLogTimer timer(1, "MasterClient::OffloadObjectHeartbeat");
     timer.LogRequest("client_id=", client_id,
                      ", enable_offloading=", enable_offloading);
 
-    auto result = invoke_rpc<&WrappedMasterService::OffloadObjectHeartbeat,
-                             std::unordered_map<std::string, int64_t>>(
-        client_id, enable_offloading);
+    auto result =
+        invoke_rpc<&WrappedMasterService::OffloadObjectHeartbeat,
+                   std::vector<OffloadTaskItem>>(client_id, enable_offloading);
     return result;
 }
 
@@ -967,56 +993,91 @@ tl::expected<void, ErrorCode> MasterClient::ReportSsdCapacity(
 tl::expected<void, ErrorCode> MasterClient::NotifyOffloadSuccess(
     const UUID& client_id, const std::vector<std::string>& keys,
     const std::vector<StorageObjectMetadata>& metadatas) {
+    std::vector<OffloadTaskItem> tasks;
+    tasks.reserve(keys.size());
+    for (const auto& key : keys) {
+        tasks.push_back(
+            OffloadTaskItem{.tenant_id = tenant_id_, .key = key, .size = 0});
+    }
+    return NotifyOffloadSuccess(client_id, tasks, metadatas);
+}
+
+tl::expected<void, ErrorCode> MasterClient::NotifyOffloadSuccess(
+    const UUID& client_id, const std::vector<OffloadTaskItem>& tasks,
+    const std::vector<StorageObjectMetadata>& metadatas) {
     ScopedVLogTimer timer(1, "MasterClient::NotifyOffloadSuccess");
-    timer.LogRequest("client_id=", client_id, ", keys_count=", keys.size(),
+    timer.LogRequest("client_id=", client_id, ", tasks_count=", tasks.size(),
                      ", metadatas_count=", metadatas.size());
 
     auto result = invoke_rpc<&WrappedMasterService::NotifyOffloadSuccess, void>(
-        client_id, keys, metadatas);
+        client_id, tasks, metadatas);
     timer.LogResponseExpected(result);
     return result;
 }
 
-tl::expected<std::unordered_map<std::string, int64_t>, ErrorCode>
+tl::expected<std::vector<PromotionTaskItem>, ErrorCode>
 MasterClient::PromotionObjectHeartbeat(const UUID& client_id) {
     ScopedVLogTimer timer(1, "MasterClient::PromotionObjectHeartbeat");
     timer.LogRequest("client_id=", client_id);
     return invoke_rpc<&WrappedMasterService::PromotionObjectHeartbeat,
-                      std::unordered_map<std::string, int64_t>>(client_id);
+                      std::vector<PromotionTaskItem>>(client_id);
 }
 
 tl::expected<PromotionAllocStartResponse, ErrorCode>
 MasterClient::PromotionAllocStart(
     const UUID& client_id, const std::string& key, uint64_t size,
     const std::vector<std::string>& preferred_segments) {
+    return PromotionAllocStart(client_id, key, tenant_id_, size,
+                               preferred_segments);
+}
+
+tl::expected<PromotionAllocStartResponse, ErrorCode>
+MasterClient::PromotionAllocStart(
+    const UUID& client_id, const std::string& key, const std::string& tenant_id,
+    uint64_t size, const std::vector<std::string>& preferred_segments) {
     ScopedVLogTimer timer(1, "MasterClient::PromotionAllocStart");
-    timer.LogRequest("client_id=", client_id, ", key=", key, ", size=", size,
+    timer.LogRequest("client_id=", client_id, ", key=", key,
+                     ", tenant_id=", tenant_id, ", size=", size,
                      ", preferred_count=", preferred_segments.size());
     auto result = invoke_rpc<&WrappedMasterService::PromotionAllocStart,
-                             PromotionAllocStartResponse>(client_id, key, size,
-                                                          preferred_segments);
+                             PromotionAllocStartResponse>(
+        client_id, key, tenant_id, size, preferred_segments);
     timer.LogResponseExpected(result);
     return result;
 }
 
 tl::expected<void, ErrorCode> MasterClient::NotifyPromotionSuccess(
     const UUID& client_id, const std::string& key) {
+    return NotifyPromotionSuccess(client_id, key, tenant_id_);
+}
+
+tl::expected<void, ErrorCode> MasterClient::NotifyPromotionSuccess(
+    const UUID& client_id, const std::string& key,
+    const std::string& tenant_id) {
     ScopedVLogTimer timer(1, "MasterClient::NotifyPromotionSuccess");
-    timer.LogRequest("client_id=", client_id, ", key=", key);
+    timer.LogRequest("client_id=", client_id, ", key=", key,
+                     ", tenant_id=", tenant_id);
     auto result =
         invoke_rpc<&WrappedMasterService::NotifyPromotionSuccess, void>(
-            client_id, key);
+            client_id, key, tenant_id);
     timer.LogResponseExpected(result);
     return result;
 }
 
 tl::expected<void, ErrorCode> MasterClient::NotifyPromotionFailure(
     const UUID& client_id, const std::string& key) {
+    return NotifyPromotionFailure(client_id, key, tenant_id_);
+}
+
+tl::expected<void, ErrorCode> MasterClient::NotifyPromotionFailure(
+    const UUID& client_id, const std::string& key,
+    const std::string& tenant_id) {
     ScopedVLogTimer timer(1, "MasterClient::NotifyPromotionFailure");
-    timer.LogRequest("client_id=", client_id, ", key=", key);
+    timer.LogRequest("client_id=", client_id, ", key=", key,
+                     ", tenant_id=", tenant_id);
     auto result =
         invoke_rpc<&WrappedMasterService::NotifyPromotionFailure, void>(
-            client_id, key);
+            client_id, key, tenant_id);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -1024,13 +1085,21 @@ tl::expected<void, ErrorCode> MasterClient::NotifyPromotionFailure(
 tl::expected<CopyStartResponse, ErrorCode> MasterClient::CopyStart(
     const std::string& key, const std::string& src_segment,
     const std::vector<std::string>& tgt_segments) {
+    return CopyStart(key, tenant_id_, src_segment, tgt_segments);
+}
+
+tl::expected<CopyStartResponse, ErrorCode> MasterClient::CopyStart(
+    const std::string& key, const std::string& tenant_id,
+    const std::string& src_segment,
+    const std::vector<std::string>& tgt_segments) {
     ScopedVLogTimer timer(1, "MasterClient::CopyStart");
-    timer.LogRequest("key=", key, ", src_segment=", src_segment,
+    timer.LogRequest("key=", key, ", tenant_id=", tenant_id,
+                     ", src_segment=", src_segment,
                      ", tgt_segments_count=", tgt_segments.size());
 
     auto result =
         invoke_rpc<&WrappedMasterService::CopyStart, CopyStartResponse>(
-            client_id_, key, src_segment, tgt_segments);
+            client_id_, key, tenant_id, src_segment, tgt_segments);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -1048,11 +1117,16 @@ tl::expected<QueryTaskResponse, ErrorCode> MasterClient::QueryTask(
 }
 
 tl::expected<void, ErrorCode> MasterClient::CopyEnd(const std::string& key) {
-    ScopedVLogTimer timer(1, "MasterClient::CopyEnd");
-    timer.LogRequest("key=", key);
+    return CopyEnd(key, tenant_id_);
+}
 
-    auto result =
-        invoke_rpc<&WrappedMasterService::CopyEnd, void>(client_id_, key);
+tl::expected<void, ErrorCode> MasterClient::CopyEnd(
+    const std::string& key, const std::string& tenant_id) {
+    ScopedVLogTimer timer(1, "MasterClient::CopyEnd");
+    timer.LogRequest("key=", key, ", tenant_id=", tenant_id);
+
+    auto result = invoke_rpc<&WrappedMasterService::CopyEnd, void>(
+        client_id_, key, tenant_id);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -1069,11 +1143,16 @@ tl::expected<std::vector<TaskAssignment>, ErrorCode> MasterClient::FetchTasks(
 }
 
 tl::expected<void, ErrorCode> MasterClient::CopyRevoke(const std::string& key) {
-    ScopedVLogTimer timer(1, "MasterClient::CopyRevoke");
-    timer.LogRequest("key=", key);
+    return CopyRevoke(key, tenant_id_);
+}
 
-    auto result =
-        invoke_rpc<&WrappedMasterService::CopyRevoke, void>(client_id_, key);
+tl::expected<void, ErrorCode> MasterClient::CopyRevoke(
+    const std::string& key, const std::string& tenant_id) {
+    ScopedVLogTimer timer(1, "MasterClient::CopyRevoke");
+    timer.LogRequest("key=", key, ", tenant_id=", tenant_id);
+
+    auto result = invoke_rpc<&WrappedMasterService::CopyRevoke, void>(
+        client_id_, key, tenant_id);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -1081,33 +1160,50 @@ tl::expected<void, ErrorCode> MasterClient::CopyRevoke(const std::string& key) {
 tl::expected<MoveStartResponse, ErrorCode> MasterClient::MoveStart(
     const std::string& key, const std::string& src_segment,
     const std::string& tgt_segment) {
+    return MoveStart(key, tenant_id_, src_segment, tgt_segment);
+}
+
+tl::expected<MoveStartResponse, ErrorCode> MasterClient::MoveStart(
+    const std::string& key, const std::string& tenant_id,
+    const std::string& src_segment, const std::string& tgt_segment) {
     ScopedVLogTimer timer(1, "MasterClient::MoveStart");
-    timer.LogRequest("key=", key, ", src_segment=", src_segment,
+    timer.LogRequest("key=", key, ", tenant_id=", tenant_id,
+                     ", src_segment=", src_segment,
                      ", tgt_segment=", tgt_segment);
 
     auto result =
         invoke_rpc<&WrappedMasterService::MoveStart, MoveStartResponse>(
-            client_id_, key, src_segment, tgt_segment);
+            client_id_, key, tenant_id, src_segment, tgt_segment);
     timer.LogResponseExpected(result);
     return result;
 }
 
 tl::expected<void, ErrorCode> MasterClient::MoveEnd(const std::string& key) {
-    ScopedVLogTimer timer(1, "MasterClient::MoveEnd");
-    timer.LogRequest("key=", key);
+    return MoveEnd(key, tenant_id_);
+}
 
-    auto result =
-        invoke_rpc<&WrappedMasterService::MoveEnd, void>(client_id_, key);
+tl::expected<void, ErrorCode> MasterClient::MoveEnd(
+    const std::string& key, const std::string& tenant_id) {
+    ScopedVLogTimer timer(1, "MasterClient::MoveEnd");
+    timer.LogRequest("key=", key, ", tenant_id=", tenant_id);
+
+    auto result = invoke_rpc<&WrappedMasterService::MoveEnd, void>(
+        client_id_, key, tenant_id);
     timer.LogResponseExpected(result);
     return result;
 }
 
 tl::expected<void, ErrorCode> MasterClient::MoveRevoke(const std::string& key) {
-    ScopedVLogTimer timer(1, "MasterClient::MoveRevoke");
-    timer.LogRequest("key=", key);
+    return MoveRevoke(key, tenant_id_);
+}
 
-    auto result =
-        invoke_rpc<&WrappedMasterService::MoveRevoke, void>(client_id_, key);
+tl::expected<void, ErrorCode> MasterClient::MoveRevoke(
+    const std::string& key, const std::string& tenant_id) {
+    ScopedVLogTimer timer(1, "MasterClient::MoveRevoke");
+    timer.LogRequest("key=", key, ", tenant_id=", tenant_id);
+
+    auto result = invoke_rpc<&WrappedMasterService::MoveRevoke, void>(
+        client_id_, key, tenant_id);
     timer.LogResponseExpected(result);
     return result;
 }
@@ -1124,24 +1220,37 @@ tl::expected<void, ErrorCode> MasterClient::MarkTaskToComplete(
 
 tl::expected<void, ErrorCode> MasterClient::EvictDiskReplica(
     const std::string& key, ReplicaType replica_type) {
+    return EvictDiskReplica(key, tenant_id_, replica_type);
+}
+
+tl::expected<void, ErrorCode> MasterClient::EvictDiskReplica(
+    const std::string& key, const std::string& tenant_id,
+    ReplicaType replica_type) {
     ScopedVLogTimer timer(1, "MasterClient::EvictDiskReplica");
-    timer.LogRequest("key=", key, ", replica_type=", replica_type);
+    timer.LogRequest("key=", key, ", tenant_id=", tenant_id,
+                     ", replica_type=", replica_type);
 
     auto result = invoke_rpc<&WrappedMasterService::EvictDiskReplica, void>(
-        client_id_, key, replica_type);
+        client_id_, key, tenant_id, replica_type);
     timer.LogResponseExpected(result);
     return result;
 }
 
 std::vector<tl::expected<void, ErrorCode>> MasterClient::BatchEvictDiskReplica(
     const std::vector<std::string>& keys, ReplicaType replica_type) {
+    return BatchEvictDiskReplica(keys, tenant_id_, replica_type);
+}
+
+std::vector<tl::expected<void, ErrorCode>> MasterClient::BatchEvictDiskReplica(
+    const std::vector<std::string>& keys, const std::string& tenant_id,
+    ReplicaType replica_type) {
     ScopedVLogTimer timer(1, "MasterClient::BatchEvictDiskReplica");
-    timer.LogRequest("keys_count=", keys.size(),
+    timer.LogRequest("keys_count=", keys.size(), ", tenant_id=", tenant_id,
                      ", replica_type=", replica_type);
 
     auto result =
         invoke_batch_rpc<&WrappedMasterService::BatchEvictDiskReplica, void>(
-            keys.size(), client_id_, keys, replica_type);
+            keys.size(), client_id_, keys, tenant_id, replica_type);
     timer.LogResponse("result=", result.size(), " operations");
     return result;
 }

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -1728,8 +1728,14 @@ auto MasterService::PutEnd(const UUID& client_id, const std::string& key,
 auto MasterService::AddReplica(const UUID& client_id, const std::string& key,
                                Replica& replica)
     -> tl::expected<void, ErrorCode> {
+    return AddReplica(client_id, key, "default", replica);
+}
+
+auto MasterService::AddReplica(const UUID& client_id, const std::string& key,
+                               const std::string& tenant_id, Replica& replica)
+    -> tl::expected<void, ErrorCode> {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    MetadataAccessorRW accessor(this, key);
+    MetadataAccessorRW accessor(this, MakeObjectIdentity(key, tenant_id));
     if (!accessor.Exists()) {
         accessor.Create(
             client_id,
@@ -2238,9 +2244,19 @@ auto MasterService::EvictDiskReplica(const UUID& client_id,
                                      const std::string& key,
                                      ReplicaType replica_type)
     -> tl::expected<void, ErrorCode> {
-    MetadataAccessorRW accessor(this, key);
+    return EvictDiskReplica(client_id, key, "default", replica_type);
+}
+
+auto MasterService::EvictDiskReplica(const UUID& client_id,
+                                     const std::string& key,
+                                     const std::string& tenant_id,
+                                     ReplicaType replica_type)
+    -> tl::expected<void, ErrorCode> {
+    const auto object_id = MakeObjectIdentity(key, tenant_id);
+    MetadataAccessorRW accessor(this, object_id);
     if (!accessor.Exists()) {
-        LOG(INFO) << "key=" << key << ", info=object_not_found_for_eviction";
+        LOG(INFO) << "key=" << key << ", tenant_id=" << object_id.tenant_id
+                  << ", info=object_not_found_for_eviction";
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
     }
 
@@ -2272,10 +2288,17 @@ auto MasterService::EvictDiskReplica(const UUID& client_id,
 std::vector<tl::expected<void, ErrorCode>> MasterService::BatchEvictDiskReplica(
     const UUID& client_id, const std::vector<std::string>& keys,
     ReplicaType replica_type) {
+    return BatchEvictDiskReplica(client_id, keys, "default", replica_type);
+}
+
+std::vector<tl::expected<void, ErrorCode>> MasterService::BatchEvictDiskReplica(
+    const UUID& client_id, const std::vector<std::string>& keys,
+    const std::string& tenant_id, ReplicaType replica_type) {
     std::vector<tl::expected<void, ErrorCode>> results;
     results.reserve(keys.size());
     for (const auto& key : keys) {
-        results.push_back(EvictDiskReplica(client_id, key, replica_type));
+        results.push_back(
+            EvictDiskReplica(client_id, key, tenant_id, replica_type));
     }
     return results;
 }
@@ -2284,7 +2307,15 @@ tl::expected<CopyStartResponse, ErrorCode> MasterService::CopyStart(
     const UUID& client_id, const std::string& key,
     const std::string& src_segment,
     const std::vector<std::string>& tgt_segments) {
+    return CopyStart(client_id, key, "default", src_segment, tgt_segments);
+}
+
+tl::expected<CopyStartResponse, ErrorCode> MasterService::CopyStart(
+    const UUID& client_id, const std::string& key, const std::string& tenant_id,
+    const std::string& src_segment,
+    const std::vector<std::string>& tgt_segments) {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+    const auto object_id = MakeObjectIdentity(key, tenant_id);
     {
         ScopedSegmentAccess segment_access =
             segment_manager_.getSegmentAccess();
@@ -2302,7 +2333,7 @@ tl::expected<CopyStartResponse, ErrorCode> MasterService::CopyStart(
             }
         }
     }
-    MetadataAccessorRW accessor(this, key);
+    MetadataAccessorRW accessor(this, object_id);
     if (!accessor.Exists()) {
         LOG(ERROR) << "key=" << key << ", object not found";
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
@@ -2378,8 +2409,14 @@ tl::expected<CopyStartResponse, ErrorCode> MasterService::CopyStart(
 
 tl::expected<void, ErrorCode> MasterService::CopyEnd(const UUID& client_id,
                                                      const std::string& key) {
+    return CopyEnd(client_id, key, "default");
+}
+
+tl::expected<void, ErrorCode> MasterService::CopyEnd(
+    const UUID& client_id, const std::string& key,
+    const std::string& tenant_id) {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    MetadataAccessorRW accessor(this, key);
+    MetadataAccessorRW accessor(this, MakeObjectIdentity(key, tenant_id));
     if (!accessor.Exists()) {
         LOG(ERROR) << "key=" << key << ", error=object_not_found";
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
@@ -2449,8 +2486,14 @@ tl::expected<void, ErrorCode> MasterService::CopyEnd(const UUID& client_id,
 
 tl::expected<void, ErrorCode> MasterService::CopyRevoke(
     const UUID& client_id, const std::string& key) {
+    return CopyRevoke(client_id, key, "default");
+}
+
+tl::expected<void, ErrorCode> MasterService::CopyRevoke(
+    const UUID& client_id, const std::string& key,
+    const std::string& tenant_id) {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    MetadataAccessorRW accessor(this, key);
+    MetadataAccessorRW accessor(this, MakeObjectIdentity(key, tenant_id));
     if (!accessor.Exists()) {
         LOG(ERROR) << "key=" << key << ", error=object_not_found";
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
@@ -2503,7 +2546,14 @@ tl::expected<void, ErrorCode> MasterService::CopyRevoke(
 tl::expected<MoveStartResponse, ErrorCode> MasterService::MoveStart(
     const UUID& client_id, const std::string& key,
     const std::string& src_segment, const std::string& tgt_segment) {
+    return MoveStart(client_id, key, "default", src_segment, tgt_segment);
+}
+
+tl::expected<MoveStartResponse, ErrorCode> MasterService::MoveStart(
+    const UUID& client_id, const std::string& key, const std::string& tenant_id,
+    const std::string& src_segment, const std::string& tgt_segment) {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+    const auto object_id = MakeObjectIdentity(key, tenant_id);
     if (src_segment == tgt_segment) {
         LOG(ERROR) << "key=" << key << ", move_tgt=" << tgt_segment
                    << " cannot be the same as move_src=" << src_segment;
@@ -2525,7 +2575,7 @@ tl::expected<MoveStartResponse, ErrorCode> MasterService::MoveStart(
         }
     }
 
-    MetadataAccessorRW accessor(this, key);
+    MetadataAccessorRW accessor(this, object_id);
     if (!accessor.Exists()) {
         LOG(ERROR) << "key=" << key << ", object not found";
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
@@ -2593,8 +2643,14 @@ tl::expected<MoveStartResponse, ErrorCode> MasterService::MoveStart(
 
 tl::expected<void, ErrorCode> MasterService::MoveEnd(const UUID& client_id,
                                                      const std::string& key) {
+    return MoveEnd(client_id, key, "default");
+}
+
+tl::expected<void, ErrorCode> MasterService::MoveEnd(
+    const UUID& client_id, const std::string& key,
+    const std::string& tenant_id) {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    MetadataAccessorRW accessor(this, key);
+    MetadataAccessorRW accessor(this, MakeObjectIdentity(key, tenant_id));
     if (!accessor.Exists()) {
         LOG(ERROR) << "key=" << key << ", error=object_not_found";
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
@@ -2679,8 +2735,14 @@ tl::expected<void, ErrorCode> MasterService::MoveEnd(const UUID& client_id,
 
 tl::expected<void, ErrorCode> MasterService::MoveRevoke(
     const UUID& client_id, const std::string& key) {
+    return MoveRevoke(client_id, key, "default");
+}
+
+tl::expected<void, ErrorCode> MasterService::MoveRevoke(
+    const UUID& client_id, const std::string& key,
+    const std::string& tenant_id) {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    MetadataAccessorRW accessor(this, key);
+    MetadataAccessorRW accessor(this, MakeObjectIdentity(key, tenant_id));
     if (!accessor.Exists()) {
         LOG(ERROR) << "key=" << key << ", error=object_not_found";
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
@@ -3153,7 +3215,7 @@ auto MasterService::MountLocalDiskSegment(const UUID& client_id,
 
 auto MasterService::OffloadObjectHeartbeat(const UUID& client_id,
                                            bool enable_offloading)
-    -> tl::expected<std::unordered_map<std::string, int64_t>, ErrorCode> {
+    -> tl::expected<std::vector<OffloadTaskItem>, ErrorCode> {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
     ScopedLocalDiskSegmentAccess local_disk_segment_access =
         segment_manager_.getLocalDiskSegmentAccess();
@@ -3165,12 +3227,20 @@ auto MasterService::OffloadObjectHeartbeat(const UUID& client_id,
                    << client_id;
         return tl::make_unexpected(ErrorCode::SEGMENT_NOT_FOUND);
     }
-    std::unordered_map<std::string, int64_t> offloading_objects_copy;
+    std::unordered_map<std::string, OffloadTaskItem> offloading_objects_copy;
     {
         MutexLocker locker(&local_disk_segment_it->second->offloading_mutex_);
         local_disk_segment_it->second->enable_offloading = enable_offloading;
         if (enable_offloading) {
-            return std::move(local_disk_segment_it->second->offloading_objects);
+            std::vector<OffloadTaskItem> result;
+            result.reserve(
+                local_disk_segment_it->second->offloading_objects.size());
+            for (const auto& [_, task] :
+                 local_disk_segment_it->second->offloading_objects) {
+                result.push_back(task);
+            }
+            local_disk_segment_it->second->offloading_objects.clear();
+            return result;
         }
         // Offloading is disabled: clear the pending queue to prevent
         // unbounded growth that would trigger KEYS_ULTRA_LIMIT in
@@ -3185,11 +3255,13 @@ auto MasterService::OffloadObjectHeartbeat(const UUID& client_id,
             std::move(local_disk_segment_it->second->offloading_objects);
     }
 
-    for (auto& [key, size] : offloading_objects_copy) {
-        MetadataAccessorRW accessor(this, key);
+    for (auto& [_, task] : offloading_objects_copy) {
+        const auto object_id = MakeObjectIdentity(task.key, task.tenant_id);
+        MetadataAccessorRW accessor(this, object_id);
         if (accessor.Exists()) {
             auto& tenant_state = accessor.GetTenantState();
-            auto task_it = tenant_state.offloading_tasks.find(key);
+            auto task_it =
+                tenant_state.offloading_tasks.find(object_id.user_key);
             if (task_it != tenant_state.offloading_tasks.end()) {
                 auto source =
                     accessor.Get().GetReplicaByID(task_it->second.source_id);
@@ -3242,17 +3314,35 @@ auto MasterService::NotifyOffloadSuccess(
     const UUID& client_id, const std::vector<std::string>& keys,
     const std::vector<StorageObjectMetadata>& metadatas)
     -> tl::expected<void, ErrorCode> {
-    for (size_t i = 0; i < keys.size(); ++i) {
-        const auto& key = keys[i];
+    std::vector<OffloadTaskItem> tasks;
+    tasks.reserve(keys.size());
+    for (const auto& key : keys) {
+        tasks.push_back(
+            OffloadTaskItem{.tenant_id = "default", .key = key, .size = 0});
+    }
+    return NotifyOffloadSuccess(client_id, tasks, metadatas);
+}
+
+auto MasterService::NotifyOffloadSuccess(
+    const UUID& client_id, const std::vector<OffloadTaskItem>& tasks,
+    const std::vector<StorageObjectMetadata>& metadatas)
+    -> tl::expected<void, ErrorCode> {
+    if (tasks.size() != metadatas.size()) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+    for (size_t i = 0; i < tasks.size(); ++i) {
+        const auto& task = tasks[i];
         const auto& metadata = metadatas[i];
+        const auto object_id = MakeObjectIdentity(task.key, task.tenant_id);
 
         // Release refcnt and clear offloading task.
         {
-            MetadataAccessorRW accessor(this, key);
+            MetadataAccessorRW accessor(this, object_id);
             if (accessor.Exists()) {
                 auto& obj_metadata = accessor.Get();
                 auto& tenant_state = accessor.GetTenantState();
-                auto task_it = tenant_state.offloading_tasks.find(key);
+                auto task_it =
+                    tenant_state.offloading_tasks.find(object_id.user_key);
                 if (task_it != tenant_state.offloading_tasks.end()) {
                     auto source =
                         obj_metadata.GetReplicaByID(task_it->second.source_id);
@@ -3267,10 +3357,13 @@ auto MasterService::NotifyOffloadSuccess(
         // Add LOCAL_DISK replica.
         Replica replica(client_id, metadata.data_size,
                         metadata.transport_endpoint, ReplicaStatus::COMPLETE);
-        auto res = AddReplica(client_id, key, replica);
+        auto res = AddReplica(client_id, object_id.user_key,
+                              object_id.tenant_id, replica);
         if (!res && res.error() != ErrorCode::OBJECT_NOT_FOUND) {
             LOG(ERROR) << "Failed to add replica: error=" << res.error()
-                       << ", client_id=" << client_id << ", key=" << key;
+                       << ", client_id=" << client_id
+                       << ", tenant_id=" << object_id.tenant_id
+                       << ", key=" << object_id.user_key;
             return tl::make_unexpected(res.error());
         }
     }
@@ -3279,12 +3372,6 @@ auto MasterService::NotifyOffloadSuccess(
 
 tl::expected<void, ErrorCode> MasterService::PushOffloadingQueue(
     const ObjectIdentity& object_id, Replica& replica) {
-    if (object_id.tenant_id != "default") {
-        VLOG(1) << "key=" << object_id.user_key
-                << ", tenant_id=" << object_id.tenant_id
-                << ", action=skip_offload_for_non_default_tenant";
-        return tl::make_unexpected(ErrorCode::UNABLE_OFFLOADING);
-    }
     const auto& segment_names = replica.get_segment_names();
     if (segment_names.empty()) {
         return {};
@@ -3317,10 +3404,14 @@ tl::expected<void, ErrorCode> MasterService::PushOffloadingQueue(
             offloading_queue_limit_) {
             return tl::make_unexpected(ErrorCode::KEYS_ULTRA_LIMIT);
         }
+        const int64_t size = replica.get_descriptor()
+                                 .get_memory_descriptor()
+                                 .buffer_descriptor.size_;
         auto res = local_disk_segment_it->second->offloading_objects.emplace(
-            object_id.user_key, replica.get_descriptor()
-                                    .get_memory_descriptor()
-                                    .buffer_descriptor.size_);
+            MakeTenantScopedStorageKey(object_id.tenant_id, object_id.user_key),
+            OffloadTaskItem{.tenant_id = object_id.tenant_id,
+                            .key = object_id.user_key,
+                            .size = size});
         if (!res.second) {
             return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
         }
@@ -3353,10 +3444,13 @@ tl::expected<void, ErrorCode> MasterService::PushPromotionQueue(
     }
     MutexLocker locker(&local_disk_segment_it->second->offloading_mutex_);
     auto res = local_disk_segment_it->second->promotion_objects.emplace(
-        object_id.user_key,
-        static_cast<int64_t>(source_replica.get_descriptor()
-                                 .get_local_disk_descriptor()
-                                 .object_size));
+        MakeTenantScopedStorageKey(object_id.tenant_id, object_id.user_key),
+        PromotionTaskItem{
+            .tenant_id = object_id.tenant_id,
+            .key = object_id.user_key,
+            .size = static_cast<int64_t>(source_replica.get_descriptor()
+                                             .get_local_disk_descriptor()
+                                             .object_size)});
     if (!res.second) {
         return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
     }
@@ -3466,7 +3560,7 @@ void MasterService::TryPushPromotionQueue(const ObjectIdentity& object_id) {
 }
 
 auto MasterService::PromotionObjectHeartbeat(const UUID& client_id)
-    -> tl::expected<std::unordered_map<std::string, int64_t>, ErrorCode> {
+    -> tl::expected<std::vector<PromotionTaskItem>, ErrorCode> {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
     ScopedLocalDiskSegmentAccess local_disk_segment_access =
         segment_manager_.getLocalDiskSegmentAccess();
@@ -3485,10 +3579,10 @@ auto MasterService::PromotionObjectHeartbeat(const UUID& client_id)
     // cap must live here (server side) rather than on the client so
     // leftover work isn't silently dropped.
     auto& src = local_disk_segment_it->second->promotion_objects;
-    std::unordered_map<std::string, int64_t> result;
+    std::vector<PromotionTaskItem> result;
     while (result.size() < promotion_max_per_heartbeat_ && !src.empty()) {
         auto node = src.extract(src.begin());
-        result.insert(std::move(node));
+        result.push_back(std::move(node.mapped()));
     }
     return result;
 }
@@ -3497,8 +3591,17 @@ auto MasterService::PromotionAllocStart(
     const UUID& client_id, const std::string& key, uint64_t size,
     const std::vector<std::string>& preferred_segments)
     -> tl::expected<PromotionAllocStartResponse, ErrorCode> {
+    return PromotionAllocStart(client_id, key, "default", size,
+                               preferred_segments);
+}
+
+auto MasterService::PromotionAllocStart(
+    const UUID& client_id, const std::string& key, const std::string& tenant_id,
+    uint64_t size, const std::vector<std::string>& preferred_segments)
+    -> tl::expected<PromotionAllocStartResponse, ErrorCode> {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    MetadataAccessorRW accessor(this, key);
+    const auto object_id = MakeObjectIdentity(key, tenant_id);
+    MetadataAccessorRW accessor(this, object_id);
     if (!accessor.Exists()) {
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
     }
@@ -3516,7 +3619,7 @@ auto MasterService::PromotionAllocStart(
     // removed or evicted. The shard mutex is held for the rest of this
     // function, so the iterator stays valid across the allocation step.
     auto& tenant_state = accessor.GetTenantState();
-    auto task_it = tenant_state.promotion_tasks.find(key);
+    auto task_it = tenant_state.promotion_tasks.find(object_id.user_key);
     if (task_it == tenant_state.promotion_tasks.end()) {
         return tl::make_unexpected(ErrorCode::REPLICA_IS_NOT_READY);
     }
@@ -3589,8 +3692,16 @@ auto MasterService::PromotionAllocStart(
 auto MasterService::NotifyPromotionSuccess(const UUID& client_id,
                                            const std::string& key)
     -> tl::expected<void, ErrorCode> {
+    return NotifyPromotionSuccess(client_id, key, "default");
+}
+
+auto MasterService::NotifyPromotionSuccess(const UUID& client_id,
+                                           const std::string& key,
+                                           const std::string& tenant_id)
+    -> tl::expected<void, ErrorCode> {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    MetadataAccessorRW accessor(this, key);
+    const auto object_id = MakeObjectIdentity(key, tenant_id);
+    MetadataAccessorRW accessor(this, object_id);
     if (!accessor.Exists()) {
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
     }
@@ -3602,7 +3713,7 @@ auto MasterService::NotifyPromotionSuccess(const UUID& client_id,
     // replicas, so we must not just "mark first PROCESSING memory
     // complete" — that would risk committing someone else's half-written
     // replica.
-    auto task_it = tenant_state.promotion_tasks.find(key);
+    auto task_it = tenant_state.promotion_tasks.find(object_id.user_key);
     if (task_it == tenant_state.promotion_tasks.end() ||
         task_it->second.alloc_id == 0) {
         return tl::make_unexpected(ErrorCode::REPLICA_IS_NOT_READY);
@@ -3648,7 +3759,8 @@ auto MasterService::NotifyPromotionSuccess(const UUID& client_id,
         auto it = client_local_disk_segment.find(client_id);
         if (it != client_local_disk_segment.end()) {
             MutexLocker locker(&it->second->offloading_mutex_);
-            it->second->promotion_objects.erase(key);
+            it->second->promotion_objects.erase(MakeTenantScopedStorageKey(
+                object_id.tenant_id, object_id.user_key));
         }
     }
 
@@ -3661,15 +3773,23 @@ auto MasterService::NotifyPromotionSuccess(const UUID& client_id,
 auto MasterService::NotifyPromotionFailure(const UUID& client_id,
                                            const std::string& key)
     -> tl::expected<void, ErrorCode> {
+    return NotifyPromotionFailure(client_id, key, "default");
+}
+
+auto MasterService::NotifyPromotionFailure(const UUID& client_id,
+                                           const std::string& key,
+                                           const std::string& tenant_id)
+    -> tl::expected<void, ErrorCode> {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    MetadataAccessorRW accessor(this, key);
+    const auto object_id = MakeObjectIdentity(key, tenant_id);
+    MetadataAccessorRW accessor(this, object_id);
     if (!accessor.Exists()) {
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
     }
     auto& metadata = accessor.Get();
     auto& tenant_state = accessor.GetTenantState();
 
-    auto task_it = tenant_state.promotion_tasks.find(key);
+    auto task_it = tenant_state.promotion_tasks.find(object_id.user_key);
     if (task_it == tenant_state.promotion_tasks.end()) {
         // No task to release. Either the reaper already swept it, or the
         // client never had a task here. Return OK to keep this RPC
@@ -3708,7 +3828,8 @@ auto MasterService::NotifyPromotionFailure(const UUID& client_id,
         auto it = client_local_disk_segment.find(client_id);
         if (it != client_local_disk_segment.end()) {
             MutexLocker locker(&it->second->offloading_mutex_);
-            it->second->promotion_objects.erase(key);
+            it->second->promotion_objects.erase(MakeTenantScopedStorageKey(
+                object_id.tenant_id, object_id.user_key));
         }
     }
 
@@ -5047,10 +5168,6 @@ void MasterService::BatchEvict(double evict_ratio_target,
         if (!offload_on_evict_) {
             // Original behavior
             return metadata.size * evict_replicas(metadata);
-        }
-
-        if (tenant_id != "default") {
-            return 0;
         }
 
         // LOCAL_DISK replica already exists — safe to delete MEMORY immediately
@@ -6442,12 +6559,19 @@ std::string MasterService::FormatTimestamp(
 
 tl::expected<UUID, ErrorCode> MasterService::CreateCopyTask(
     const std::string& key, const std::vector<std::string>& targets) {
+    return CreateCopyTask(key, "default", targets);
+}
+
+tl::expected<UUID, ErrorCode> MasterService::CreateCopyTask(
+    const std::string& key, const std::string& tenant_id,
+    const std::vector<std::string>& targets) {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+    const auto object_id = MakeObjectIdentity(key, tenant_id);
     if (targets.empty()) {
         LOG(ERROR) << "key=" << key << ", error=empty_targets";
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
-    MetadataAccessorRO accessor(this, key);
+    MetadataAccessorRO accessor(this, object_id);
     if (!accessor.Exists()) {
         VLOG(1) << "key=" << key << ", info=object_not_found";
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
@@ -6490,7 +6614,8 @@ tl::expected<UUID, ErrorCode> MasterService::CreateCopyTask(
     }
     return task_manager_.get_write_access()
         .submit_task_typed<TaskType::REPLICA_COPY>(
-            select_client, {.key = key,
+            select_client, {.tenant_id = object_id.tenant_id,
+                            .key = object_id.user_key,
                             .source = selected_source_segment,
                             .targets = targets});
 }
@@ -6498,8 +6623,15 @@ tl::expected<UUID, ErrorCode> MasterService::CreateCopyTask(
 tl::expected<UUID, ErrorCode> MasterService::CreateMoveTask(
     const std::string& key, const std::string& source,
     const std::string& target) {
+    return CreateMoveTask(key, "default", source, target);
+}
+
+tl::expected<UUID, ErrorCode> MasterService::CreateMoveTask(
+    const std::string& key, const std::string& tenant_id,
+    const std::string& source, const std::string& target) {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    MetadataAccessorRO accessor(this, key);
+    const auto object_id = MakeObjectIdentity(key, tenant_id);
+    MetadataAccessorRO accessor(this, object_id);
     if (!accessor.Exists()) {
         VLOG(1) << "key=" << key << ", info=object_not_found";
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
@@ -6545,7 +6677,10 @@ tl::expected<UUID, ErrorCode> MasterService::CreateMoveTask(
 
     return task_manager_.get_write_access()
         .submit_task_typed<TaskType::REPLICA_MOVE>(
-            select_client, {.key = key, .source = source, .target = target});
+            select_client, {.tenant_id = object_id.tenant_id,
+                            .key = object_id.user_key,
+                            .source = source,
+                            .target = target});
 }
 
 tl::expected<QueryTaskResponse, ErrorCode> MasterService::QueryTask(
@@ -6851,6 +6986,7 @@ void MasterService::ScheduleDrainJobTasks(DrainJob& job) {
     }
 
     struct DrainPlan {
+        std::string tenant_id;
         std::string key;
         std::string source_segment;
         std::string target_segment;
@@ -6890,7 +7026,7 @@ void MasterService::ScheduleDrainJobTasks(DrainJob& job) {
                             continue;
                         }
 
-                        if (tenant_id != "default" || metadata.IsHardPinned() ||
+                        if (metadata.IsHardPinned() ||
                             !metadata.IsLeaseExpired() ||
                             !metadata.AllReplicas(&Replica::fn_is_completed) ||
                             tenant_state.replication_tasks.contains(key)) {
@@ -6907,8 +7043,8 @@ void MasterService::ScheduleDrainJobTasks(DrainJob& job) {
                         }
 
                         if (plans.size() < slots) {
-                            plans.push_back({key, source_segment, *target,
-                                             metadata.size, unit_key});
+                            plans.push_back({tenant_id, key, source_segment,
+                                             *target, metadata.size, unit_key});
                         }
                     }
                 }
@@ -6919,11 +7055,12 @@ void MasterService::ScheduleDrainJobTasks(DrainJob& job) {
     job.blocked_units = blocked_unit_keys.size();
 
     for (const auto& plan : plans) {
-        auto task_id =
-            CreateMoveTask(plan.key, plan.source_segment, plan.target_segment);
+        auto task_id = CreateMoveTask(plan.key, plan.tenant_id,
+                                      plan.source_segment, plan.target_segment);
         if (task_id.has_value()) {
             ActiveDrainTask active_task;
             active_task.task_id = task_id.value();
+            active_task.tenant_id = plan.tenant_id;
             active_task.key = plan.key;
             active_task.source_segment = plan.source_segment;
             active_task.target_segment = plan.target_segment;

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -5483,15 +5483,18 @@ RealClient::batch_get_into_offload_object_internal(
     offload_rpc_read_count_.fetch_add(1, std::memory_order_relaxed);
     auto start_time = std::chrono::steady_clock::now();
     std::vector<std::string> keys;
+    std::vector<std::string> storage_keys;
     std::vector<int64_t> sizes;
     for (const auto &object_it : objects) {
         keys.emplace_back(object_it.first);
+        storage_keys.emplace_back(
+            MakeTenantScopedStorageKey(client_->tenant_id(), object_it.first));
         int64_t total = 0;
         for (const auto &s : object_it.second) total += s.size;
         sizes.emplace_back(total);
     }
     auto batchGetResp = client_requester_->batch_get_offload_object(
-        target_rpc_service_addr, keys, sizes);
+        target_rpc_service_addr, storage_keys, sizes);
     if (!batchGetResp) {
         LOG(ERROR) << "Batch get offload object failed with error: "
                    << batchGetResp.error();

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -1535,17 +1535,18 @@ WrappedMasterService::GetNoFSegmentsByName(const std::string& segment_name) {
 }
 
 tl::expected<CopyStartResponse, ErrorCode> WrappedMasterService::CopyStart(
-    const UUID& client_id, const std::string& key,
+    const UUID& client_id, const std::string& key, const std::string& tenant_id,
     const std::string& src_segment,
     const std::vector<std::string>& tgt_segments) {
     return execute_rpc(
         "CopyStart",
         [&] {
-            return master_service_.CopyStart(client_id, key, src_segment,
-                                             tgt_segments);
+            return master_service_.CopyStart(client_id, key, tenant_id,
+                                             src_segment, tgt_segments);
         },
         [&](auto& timer) {
             timer.LogRequest("client_id=", client_id, ", key=", key,
+                             ", tenant_id=", tenant_id,
                              ", src_segment=", src_segment,
                              ", tgt_segments_count=", tgt_segments.size());
         },
@@ -1554,39 +1555,45 @@ tl::expected<CopyStartResponse, ErrorCode> WrappedMasterService::CopyStart(
 }
 
 tl::expected<void, ErrorCode> WrappedMasterService::CopyEnd(
-    const UUID& client_id, const std::string& key) {
+    const UUID& client_id, const std::string& key,
+    const std::string& tenant_id) {
     return execute_rpc(
-        "CopyEnd", [&] { return master_service_.CopyEnd(client_id, key); },
+        "CopyEnd",
+        [&] { return master_service_.CopyEnd(client_id, key, tenant_id); },
         [&](auto& timer) {
-            timer.LogRequest("client_id=", client_id, ", key=", key);
+            timer.LogRequest("client_id=", client_id, ", key=", key,
+                             ", tenant_id=", tenant_id);
         },
         [] { MasterMetricManager::instance().inc_copy_end_requests(); },
         [] { MasterMetricManager::instance().inc_copy_end_failures(); });
 }
 
 tl::expected<void, ErrorCode> WrappedMasterService::CopyRevoke(
-    const UUID& client_id, const std::string& key) {
+    const UUID& client_id, const std::string& key,
+    const std::string& tenant_id) {
     return execute_rpc(
         "CopyRevoke",
-        [&] { return master_service_.CopyRevoke(client_id, key); },
+        [&] { return master_service_.CopyRevoke(client_id, key, tenant_id); },
         [&](auto& timer) {
-            timer.LogRequest("client_id=", client_id, ", key=", key);
+            timer.LogRequest("client_id=", client_id, ", key=", key,
+                             ", tenant_id=", tenant_id);
         },
         [] { MasterMetricManager::instance().inc_copy_revoke_requests(); },
         [] { MasterMetricManager::instance().inc_copy_revoke_failures(); });
 }
 
 tl::expected<MoveStartResponse, ErrorCode> WrappedMasterService::MoveStart(
-    const UUID& client_id, const std::string& key,
+    const UUID& client_id, const std::string& key, const std::string& tenant_id,
     const std::string& src_segment, const std::string& tgt_segment) {
     return execute_rpc(
         "MoveStart",
         [&] {
-            return master_service_.MoveStart(client_id, key, src_segment,
-                                             tgt_segment);
+            return master_service_.MoveStart(client_id, key, tenant_id,
+                                             src_segment, tgt_segment);
         },
         [&](auto& timer) {
             timer.LogRequest("client_id=", client_id, ", key=", key,
+                             ", tenant_id=", tenant_id,
                              ", src_segment=", src_segment,
                              ", tgt_segment=", tgt_segment);
         },
@@ -1595,38 +1602,45 @@ tl::expected<MoveStartResponse, ErrorCode> WrappedMasterService::MoveStart(
 }
 
 tl::expected<void, ErrorCode> WrappedMasterService::MoveEnd(
-    const UUID& client_id, const std::string& key) {
+    const UUID& client_id, const std::string& key,
+    const std::string& tenant_id) {
     return execute_rpc(
-        "MoveEnd", [&] { return master_service_.MoveEnd(client_id, key); },
+        "MoveEnd",
+        [&] { return master_service_.MoveEnd(client_id, key, tenant_id); },
         [&](auto& timer) {
-            timer.LogRequest("client_id=", client_id, ", key=", key);
+            timer.LogRequest("client_id=", client_id, ", key=", key,
+                             ", tenant_id=", tenant_id);
         },
         [] { MasterMetricManager::instance().inc_move_end_requests(); },
         [] { MasterMetricManager::instance().inc_move_end_failures(); });
 }
 
 tl::expected<void, ErrorCode> WrappedMasterService::MoveRevoke(
-    const UUID& client_id, const std::string& key) {
+    const UUID& client_id, const std::string& key,
+    const std::string& tenant_id) {
     return execute_rpc(
         "MoveRevoke",
-        [&] { return master_service_.MoveRevoke(client_id, key); },
+        [&] { return master_service_.MoveRevoke(client_id, key, tenant_id); },
         [&](auto& timer) {
-            timer.LogRequest("client_id=", client_id, ", key=", key);
+            timer.LogRequest("client_id=", client_id, ", key=", key,
+                             ", tenant_id=", tenant_id);
         },
         [] { MasterMetricManager::instance().inc_move_revoke_requests(); },
         [] { MasterMetricManager::instance().inc_move_revoke_failures(); });
 }
 
 tl::expected<void, ErrorCode> WrappedMasterService::EvictDiskReplica(
-    const UUID& client_id, const std::string& key, ReplicaType replica_type) {
+    const UUID& client_id, const std::string& key, const std::string& tenant_id,
+    ReplicaType replica_type) {
     return execute_rpc(
         "EvictDiskReplica",
         [&] {
-            return master_service_.EvictDiskReplica(client_id, key,
+            return master_service_.EvictDiskReplica(client_id, key, tenant_id,
                                                     replica_type);
         },
         [&](auto& timer) {
             timer.LogRequest("client_id=", client_id, ", key=", key,
+                             ", tenant_id=", tenant_id,
                              ", replica_type=", replica_type);
         },
         [] {
@@ -1640,15 +1654,16 @@ tl::expected<void, ErrorCode> WrappedMasterService::EvictDiskReplica(
 std::vector<tl::expected<void, ErrorCode>>
 WrappedMasterService::BatchEvictDiskReplica(
     const UUID& client_id, const std::vector<std::string>& keys,
-    ReplicaType replica_type) {
+    const std::string& tenant_id, ReplicaType replica_type) {
     ScopedVLogTimer timer(1, "BatchEvictDiskReplica");
     const size_t total_keys = keys.size();
     timer.LogRequest("client_id=", client_id, ", keys_count=", total_keys,
+                     ", tenant_id=", tenant_id,
                      ", replica_type=", replica_type);
     MasterMetricManager::instance().inc_evict_disk_replica_requests();
 
-    auto results =
-        master_service_.BatchEvictDiskReplica(client_id, keys, replica_type);
+    auto results = master_service_.BatchEvictDiskReplica(
+        client_id, keys, tenant_id, replica_type);
 
     size_t failure_count = 0;
     for (size_t i = 0; i < results.size(); ++i) {
@@ -1670,12 +1685,14 @@ WrappedMasterService::BatchEvictDiskReplica(
 }
 
 tl::expected<UUID, ErrorCode> WrappedMasterService::CreateCopyTask(
-    const std::string& key, const std::vector<std::string>& targets) {
+    const std::string& key, const std::string& tenant_id,
+    const std::vector<std::string>& targets) {
     return execute_rpc(
         "CreateCopyTask",
-        [&] { return master_service_.CreateCopyTask(key, targets); },
+        [&] { return master_service_.CreateCopyTask(key, tenant_id, targets); },
         [&](auto& timer) {
-            timer.LogRequest("key=", key, ", targets_size=", targets.size());
+            timer.LogRequest("key=", key, ", tenant_id=", tenant_id,
+                             ", targets_size=", targets.size());
         },
         [] { MasterMetricManager::instance().inc_create_copy_task_requests(); },
         [] {
@@ -1684,14 +1701,17 @@ tl::expected<UUID, ErrorCode> WrappedMasterService::CreateCopyTask(
 }
 
 tl::expected<UUID, ErrorCode> WrappedMasterService::CreateMoveTask(
-    const std::string& key, const std::string& source,
-    const std::string& target) {
+    const std::string& key, const std::string& tenant_id,
+    const std::string& source, const std::string& target) {
     return execute_rpc(
         "CreateMoveTask",
-        [&] { return master_service_.CreateMoveTask(key, source, target); },
+        [&] {
+            return master_service_.CreateMoveTask(key, tenant_id, source,
+                                                  target);
+        },
         [&](auto& timer) {
-            timer.LogRequest("key=", key, ", source=", source,
-                             ", target=", target);
+            timer.LogRequest("key=", key, ", tenant_id=", tenant_id,
+                             ", source=", source, ", target=", target);
         },
         [] { MasterMetricManager::instance().inc_create_move_task_requests(); },
         [] {
@@ -1799,8 +1819,7 @@ tl::expected<void, ErrorCode> WrappedMasterService::MountLocalDiskSegment(
     return result;
 }
 
-tl::expected<std::unordered_map<std::string, int64_t, std::hash<std::string>>,
-             ErrorCode>
+tl::expected<std::vector<OffloadTaskItem>, ErrorCode>
 WrappedMasterService::OffloadObjectHeartbeat(const UUID& client_id,
                                              bool enable_offloading) {
     ScopedVLogTimer timer(1, "OffloadObjectHeartbeat");
@@ -1820,18 +1839,18 @@ tl::expected<void, ErrorCode> WrappedMasterService::ReportSsdCapacity(
 }
 
 tl::expected<void, ErrorCode> WrappedMasterService::NotifyOffloadSuccess(
-    const UUID& client_id, const std::vector<std::string>& keys,
+    const UUID& client_id, const std::vector<OffloadTaskItem>& tasks,
     const std::vector<StorageObjectMetadata>& metadatas) {
     ScopedVLogTimer timer(1, "NotifyOffloadSuccess");
     timer.LogRequest("action=notify_offload_success");
 
     auto result =
-        master_service_.NotifyOffloadSuccess(client_id, keys, metadatas);
+        master_service_.NotifyOffloadSuccess(client_id, tasks, metadatas);
     timer.LogResponseExpected(result);
     return result;
 }
 
-tl::expected<std::unordered_map<std::string, int64_t>, ErrorCode>
+tl::expected<std::vector<PromotionTaskItem>, ErrorCode>
 WrappedMasterService::PromotionObjectHeartbeat(const UUID& client_id) {
     ScopedVLogTimer timer(1, "PromotionObjectHeartbeat");
     timer.LogRequest("action=promotion_object_heartbeat");
@@ -1840,30 +1859,34 @@ WrappedMasterService::PromotionObjectHeartbeat(const UUID& client_id) {
 
 tl::expected<PromotionAllocStartResponse, ErrorCode>
 WrappedMasterService::PromotionAllocStart(
-    const UUID& client_id, const std::string& key, uint64_t size,
-    const std::vector<std::string>& preferred_segments) {
+    const UUID& client_id, const std::string& key, const std::string& tenant_id,
+    uint64_t size, const std::vector<std::string>& preferred_segments) {
     ScopedVLogTimer timer(1, "PromotionAllocStart");
     timer.LogRequest("action=promotion_alloc_start");
-    auto result = master_service_.PromotionAllocStart(client_id, key, size,
-                                                      preferred_segments);
+    auto result = master_service_.PromotionAllocStart(client_id, key, tenant_id,
+                                                      size, preferred_segments);
     timer.LogResponseExpected(result);
     return result;
 }
 
 tl::expected<void, ErrorCode> WrappedMasterService::NotifyPromotionSuccess(
-    const UUID& client_id, const std::string& key) {
+    const UUID& client_id, const std::string& key,
+    const std::string& tenant_id) {
     ScopedVLogTimer timer(1, "NotifyPromotionSuccess");
     timer.LogRequest("action=notify_promotion_success");
-    auto result = master_service_.NotifyPromotionSuccess(client_id, key);
+    auto result =
+        master_service_.NotifyPromotionSuccess(client_id, key, tenant_id);
     timer.LogResponseExpected(result);
     return result;
 }
 
 tl::expected<void, ErrorCode> WrappedMasterService::NotifyPromotionFailure(
-    const UUID& client_id, const std::string& key) {
+    const UUID& client_id, const std::string& key,
+    const std::string& tenant_id) {
     ScopedVLogTimer timer(1, "NotifyPromotionFailure");
     timer.LogRequest("action=notify_promotion_failure");
-    auto result = master_service_.NotifyPromotionFailure(client_id, key);
+    auto result =
+        master_service_.NotifyPromotionFailure(client_id, key, tenant_id);
     timer.LogResponseExpected(result);
     return result;
 }

--- a/mooncake-store/src/segment.cpp
+++ b/mooncake-store/src/segment.cpp
@@ -573,10 +573,10 @@ SegmentSerializer::Serialize() {
             segment_manager_->client_local_disk_segment_.at(client_uuid);
         packer.pack(UuidToString(client_uuid));
 
-        // Serialize LocalDiskSegment: [enable_offloading, count, key1, ts1,
-        // key2, ts2, ...] Sort keys to ensure determinism
+        // Serialize LocalDiskSegment: [enable_offloading, count, storage_key1,
+        // task1, storage_key2, task2, ...] Sort keys to ensure determinism.
         std::vector<std::string> sorted_keys;
-        for (const auto& [key, ts] : segment->offloading_objects) {
+        for (const auto& [key, _] : segment->offloading_objects) {
             sorted_keys.push_back(key);
         }
         std::sort(sorted_keys.begin(), sorted_keys.end());
@@ -587,7 +587,11 @@ SegmentSerializer::Serialize() {
 
         for (const auto& key : sorted_keys) {
             packer.pack(key);
-            packer.pack(segment->offloading_objects.at(key));
+            const auto& task = segment->offloading_objects.at(key);
+            packer.pack_array(3);
+            packer.pack(task.tenant_id);
+            packer.pack(task.key);
+            packer.pack(task.size);
         }
     }
 
@@ -902,8 +906,8 @@ tl::expected<void, SerializationError> SegmentSerializer::Deserialize(
                                 client_uuid_str)));
             }
 
-            // Parse LocalDiskSegment array: [enable_offloading, count, key1,
-            // ts1, ...]
+            // Parse LocalDiskSegment array: [enable_offloading, count,
+            // storage_key1, task1, ...]
             if (client_value.type != msgpack::type::ARRAY ||
                 client_value.via.array.size < 2) {
                 return tl::unexpected(
@@ -921,19 +925,43 @@ tl::expected<void, SerializationError> SegmentSerializer::Deserialize(
             // Parse offloading_objects
             for (uint64_t k = 0; k < count; ++k) {
                 size_t key_idx = 2 + k * 2;
-                size_t ts_idx = 2 + k * 2 + 1;
-                if (ts_idx >= client_value.via.array.size) {
+                size_t task_idx = 2 + k * 2 + 1;
+                if (task_idx >= client_value.via.array.size) {
                     return tl::unexpected(
                         SerializationError(ErrorCode::DESERIALIZE_FAIL,
                                            "deserialize local_disk_segments "
                                            "offloading_objects out of bounds"));
                 }
 
+                if (client_value.via.array.ptr[key_idx].type !=
+                    msgpack::type::STR) {
+                    return tl::unexpected(SerializationError(
+                        ErrorCode::DESERIALIZE_FAIL,
+                        "deserialize local_disk_segments offloading key is "
+                        "not string"));
+                }
                 std::string key(
                     client_value.via.array.ptr[key_idx].via.str.ptr,
                     client_value.via.array.ptr[key_idx].via.str.size);
-                int64_t ts = client_value.via.array.ptr[ts_idx].as<int64_t>();
-                segment->offloading_objects[key] = ts;
+                const auto& task_obj = client_value.via.array.ptr[task_idx];
+                if (task_obj.type == msgpack::type::ARRAY &&
+                    task_obj.via.array.size == 3) {
+                    OffloadTaskItem task;
+                    task.tenant_id =
+                        task_obj.via.array.ptr[0].as<std::string>();
+                    task.key = task_obj.via.array.ptr[1].as<std::string>();
+                    task.size = task_obj.via.array.ptr[2].as<int64_t>();
+                    segment->offloading_objects[key] = std::move(task);
+                } else {
+                    // Backward compatibility for snapshots whose
+                    // offloading_objects value was key -> size.
+                    auto [tenant_id, user_key] =
+                        ParseTenantScopedStorageKey(key);
+                    segment->offloading_objects[key] =
+                        OffloadTaskItem{.tenant_id = std::move(tenant_id),
+                                        .key = std::move(user_key),
+                                        .size = task_obj.as<int64_t>()};
+                }
             }
 
             segment_manager_->client_local_disk_segment_[client_id] =

--- a/mooncake-store/src/segment.cpp
+++ b/mooncake-store/src/segment.cpp
@@ -20,6 +20,11 @@ bool HasAllocator(const AllocatorManager& allocator_manager,
            allocators->end();
 }
 
+bool IsMsgpackInteger(const msgpack::object& object) {
+    return object.type == msgpack::type::POSITIVE_INTEGER ||
+           object.type == msgpack::type::NEGATIVE_INTEGER;
+}
+
 }  // namespace
 
 ErrorCode ScopedSegmentAccess::MountSegment(const Segment& segment,
@@ -946,6 +951,19 @@ tl::expected<void, SerializationError> SegmentSerializer::Deserialize(
                 const auto& task_obj = client_value.via.array.ptr[task_idx];
                 if (task_obj.type == msgpack::type::ARRAY &&
                     task_obj.via.array.size == 3) {
+                    if (task_obj.via.array.ptr[0].type != msgpack::type::STR ||
+                        task_obj.via.array.ptr[1].type != msgpack::type::STR) {
+                        return tl::unexpected(SerializationError(
+                            ErrorCode::DESERIALIZE_FAIL,
+                            "deserialize local_disk_segments offloading task "
+                            "fields are not strings"));
+                    }
+                    if (!IsMsgpackInteger(task_obj.via.array.ptr[2])) {
+                        return tl::unexpected(SerializationError(
+                            ErrorCode::DESERIALIZE_FAIL,
+                            "deserialize local_disk_segments offloading task "
+                            "size is not integer"));
+                    }
                     OffloadTaskItem task;
                     task.tenant_id =
                         task_obj.via.array.ptr[0].as<std::string>();
@@ -955,6 +973,12 @@ tl::expected<void, SerializationError> SegmentSerializer::Deserialize(
                 } else {
                     // Backward compatibility for snapshots whose
                     // offloading_objects value was key -> size.
+                    if (!IsMsgpackInteger(task_obj)) {
+                        return tl::unexpected(SerializationError(
+                            ErrorCode::DESERIALIZE_FAIL,
+                            "deserialize local_disk_segments legacy "
+                            "offloading size is not integer"));
+                    }
                     auto [tenant_id, user_key] =
                         ParseTenantScopedStorageKey(key);
                     segment->offloading_objects[key] =

--- a/mooncake-store/src/utils.cpp
+++ b/mooncake-store/src/utils.cpp
@@ -559,8 +559,9 @@ static std::string SanitizeKey(const std::string &key) {
 
     for (char c : key) {
         // Replace invalid characters with underscore
-        sanitized_key.push_back(
-            kInvalidChars.find(c) != std::string_view::npos ? '_' : c);
+        const bool invalid =
+            c == '\0' || kInvalidChars.find(c) != std::string_view::npos;
+        sanitized_key.push_back(invalid ? '_' : c);
     }
     return sanitized_key;
 }

--- a/mooncake-store/tests/file_storage_promotion_test.cpp
+++ b/mooncake-store/tests/file_storage_promotion_test.cpp
@@ -30,12 +30,12 @@ class FakeClient : public Client {
                  /*labels=*/{}) {}
 
     // Drives the queue returned to the heartbeat caller.
-    std::unordered_map<std::string, int64_t> heartbeat_queue;
+    std::vector<PromotionTaskItem> heartbeat_queue;
     tl::expected<void, ErrorCode> heartbeat_result =
         tl::expected<void, ErrorCode>{};
 
     tl::expected<void, ErrorCode> PromotionObjectHeartbeat(
-        std::unordered_map<std::string, int64_t>& promotion_objects) override {
+        std::vector<PromotionTaskItem>& promotion_objects) override {
         heartbeat_calls.fetch_add(1);
         if (!heartbeat_result.has_value()) {
             return tl::make_unexpected(heartbeat_result.error());
@@ -50,8 +50,8 @@ class FakeClient : public Client {
         promotion_objects.clear();
         while (promotion_objects.size() < kMaxPerHeartbeat &&
                !heartbeat_queue.empty()) {
-            auto node = heartbeat_queue.extract(heartbeat_queue.begin());
-            promotion_objects.insert(std::move(node));
+            promotion_objects.push_back(std::move(heartbeat_queue.back()));
+            heartbeat_queue.pop_back();
         }
         return {};
     }
@@ -65,6 +65,13 @@ class FakeClient : public Client {
     tl::expected<PromotionAllocStartResponse, ErrorCode> PromotionAllocStart(
         const std::string& key, uint64_t size,
         const std::vector<std::string>& preferred_segments) override {
+        return PromotionAllocStart(key, "default", size, preferred_segments);
+    }
+
+    tl::expected<PromotionAllocStartResponse, ErrorCode> PromotionAllocStart(
+        const std::string& key, const std::string& tenant_id, uint64_t size,
+        const std::vector<std::string>& preferred_segments) override {
+        (void)tenant_id;
         (void)size;
         (void)preferred_segments;
         alloc_calls.fetch_add(1);
@@ -99,6 +106,12 @@ class FakeClient : public Client {
 
     tl::expected<void, ErrorCode> NotifyPromotionSuccess(
         const std::string& key) override {
+        return NotifyPromotionSuccess(key, "default");
+    }
+
+    tl::expected<void, ErrorCode> NotifyPromotionSuccess(
+        const std::string& key, const std::string& tenant_id) override {
+        (void)tenant_id;
         notify_calls.fetch_add(1);
         notify_keys.push_back(key);
         auto it = notify_overrides.find(key);
@@ -116,6 +129,12 @@ class FakeClient : public Client {
     // notify the master.
     tl::expected<void, ErrorCode> NotifyPromotionFailure(
         const std::string& key) override {
+        return NotifyPromotionFailure(key, "default");
+    }
+
+    tl::expected<void, ErrorCode> NotifyPromotionFailure(
+        const std::string& key, const std::string& tenant_id) override {
+        (void)tenant_id;
         notify_failure_calls.fetch_add(1);
         notify_failure_keys.push_back(key);
         return {};
@@ -185,7 +204,12 @@ class FileStoragePromotionTest : public ::testing::Test {
         tl::expected<void, ErrorCode> last_res{};
         while (!remaining.empty()) {
             std::string before = fake->last_alloc_key;
-            fake->heartbeat_queue = remaining;
+            fake->heartbeat_queue.clear();
+            fake->heartbeat_queue.reserve(remaining.size());
+            for (const auto& [key, size] : remaining) {
+                fake->heartbeat_queue.push_back(PromotionTaskItem{
+                    .tenant_id = "default", .key = key, .size = size});
+            }
             last_res = CallProcessPromotionTasks();
             if (!last_res.has_value()) return last_res;
             if (fake->last_alloc_key == before ||
@@ -231,7 +255,9 @@ TEST_F(FileStoragePromotionTest, HeartbeatHardErrorPropagates) {
 
 // Non-positive size in queue: skip that key, continue.
 TEST_F(FileStoragePromotionTest, NonPositiveSizeSkipped) {
-    fake->heartbeat_queue = {{"k_bad", 0}, {"k_good", 1024}};
+    fake->heartbeat_queue = {
+        {.tenant_id = "default", .key = "k_bad", .size = 0},
+        {.tenant_id = "default", .key = "k_good", .size = 1024}};
     auto res = CallProcessPromotionTasks();
     EXPECT_TRUE(res.has_value());
     // Only k_good should reach AllocStart.
@@ -255,7 +281,8 @@ TEST_F(FileStoragePromotionTest, AllocStartFailureSkipsKey) {
 // BatchLoad failure (SSD file missing): no PromotionWrite, no Notify.
 // Master-side reaper handles the orphaned PROCESSING replica.
 TEST_F(FileStoragePromotionTest, BatchLoadFailureLeavesNoNotify) {
-    fake->heartbeat_queue = {{"k_missing", 1024}};
+    fake->heartbeat_queue = {
+        {.tenant_id = "default", .key = "k_missing", .size = 1024}};
     // Default alloc succeeds; BatchLoad will fail because there's no file
     // at data_path/k_missing for the storage backend to read.
     auto res = CallProcessPromotionTasks();
@@ -270,7 +297,8 @@ TEST_F(FileStoragePromotionTest, BatchLoadFailureLeavesNoNotify) {
 
 // PromotionWrite failure: no Notify.
 TEST_F(FileStoragePromotionTest, TransferWriteFailureLeavesNoNotify) {
-    fake->heartbeat_queue = {{"k_te_fail", 1024}};
+    fake->heartbeat_queue = {
+        {.tenant_id = "default", .key = "k_te_fail", .size = 1024}};
     fake->default_write_result = ErrorCode::TRANSFER_FAIL;
     auto res = CallProcessPromotionTasks();
     EXPECT_TRUE(res.has_value());
@@ -313,7 +341,8 @@ TEST_F(FileStoragePromotionTest, PerKeyFailuresAreIndependent) {
 // put_start_release_timeout_sec_ (~10 min default), turning a transient
 // DRAM-pressure spike into a sustained outage of promotion_queue_limit_.
 TEST_F(FileStoragePromotionTest, AllocStartFailureNotifiesMaster) {
-    fake->heartbeat_queue = {{"k_alloc_fail", 1024}};
+    fake->heartbeat_queue = {
+        {.tenant_id = "default", .key = "k_alloc_fail", .size = 1024}};
     fake->alloc_overrides["k_alloc_fail"] = ErrorCode::NO_AVAILABLE_HANDLE;
     auto res = CallProcessPromotionTasks();
     EXPECT_TRUE(res.has_value());

--- a/mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot.cpp
+++ b/mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot.cpp
@@ -1,5 +1,6 @@
 #include "master_service_test_for_snapshot_base.h"
 
+#include <algorithm>
 #include <atomic>
 #include <random>
 #include <unordered_set>
@@ -2480,8 +2481,11 @@ TEST_F(MasterServiceSnapshotTest, OffloadObjectHeartbeat) {
     }
     ASSERT_EQ(res->size(), keys.size());
     for (auto& key : keys) {
-        ASSERT_TRUE(res.value().find(key) != res.value().end());
-        ASSERT_EQ(res.value().find(key)->second, 1024);
+        auto it = std::find_if(
+            res->begin(), res->end(),
+            [&key](const OffloadTaskItem& task) { return task.key == key; });
+        ASSERT_TRUE(it != res->end());
+        ASSERT_EQ(it->size, 1024);
     }
 
     keys.clear();
@@ -2497,8 +2501,11 @@ TEST_F(MasterServiceSnapshotTest, OffloadObjectHeartbeat) {
     }
     ASSERT_EQ(res->size(), keys.size());
     for (auto& key : keys) {
-        ASSERT_TRUE(res.value().find(key) != res.value().end());
-        ASSERT_EQ(res.value().find(key)->second, 1024);
+        auto it = std::find_if(
+            res->begin(), res->end(),
+            [&key](const OffloadTaskItem& task) { return task.key == key; });
+        ASSERT_TRUE(it != res->end());
+        ASSERT_EQ(it->size, 1024);
     }
 }
 

--- a/mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot_base.h
+++ b/mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot_base.h
@@ -72,8 +72,8 @@ class MasterServiceSnapshotTestBase : public ::testing::Test {
     // LocalDiskSegment state for comparison
     struct LocalDiskSegmentState {
         bool enable_offloading = false;
-        std::map<std::string, int64_t>
-            offloading_objects;  // key -> timestamp (sorted)
+        std::map<std::string, OffloadTaskItem>
+            offloading_objects;  // storage key -> task (sorted)
     };
 
     // Task state for comparison
@@ -247,9 +247,8 @@ class MasterServiceSnapshotTestBase : public ::testing::Test {
                 seg_state.enable_offloading = segment->enable_offloading;
                 // Copy offloading_objects to sorted map
                 std::lock_guard<Mutex> lock(segment->offloading_mutex_);
-                for (const auto& [key, timestamp] :
-                     segment->offloading_objects) {
-                    seg_state.offloading_objects[key] = timestamp;
+                for (const auto& [key, task] : segment->offloading_objects) {
+                    seg_state.offloading_objects[key] = task;
                 }
                 state.local_disk_segments[client_id] = std::move(seg_state);
             }

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -137,10 +137,13 @@ class MasterServiceTest : public ::testing::Test {
             ReplicaMovePayload payload;
             struct_json::from_json(payload, assignment.payload);
 
-            auto move_start = service.MoveStart(client_id, payload.key,
-                                                payload.source, payload.target);
+            auto move_start =
+                service.MoveStart(client_id, payload.key, payload.tenant_id,
+                                  payload.source, payload.target);
             EXPECT_TRUE(move_start.has_value());
-            EXPECT_TRUE(service.MoveEnd(client_id, payload.key).has_value());
+            EXPECT_TRUE(
+                service.MoveEnd(client_id, payload.key, payload.tenant_id)
+                    .has_value());
 
             TaskCompleteRequest complete_request;
             complete_request.id = assignment.id;
@@ -198,6 +201,27 @@ class MasterServiceTest : public ::testing::Test {
 
     void TearDown() override { google::ShutdownGoogleLogging(); }
 };
+
+TEST(TenantScopedStorageKeyTest, RoundTripsAndParsesLegacyKeys) {
+    const auto scoped =
+        MakeTenantScopedStorageKey("tenant:with:colon", "path/key:with:colon");
+    EXPECT_NE(scoped.find('\0'), std::string::npos);
+
+    auto [tenant_id, key] = ParseTenantScopedStorageKey(scoped);
+    EXPECT_EQ(tenant_id, "tenant:with:colon");
+    EXPECT_EQ(key, "path/key:with:colon");
+
+    auto [default_tenant, default_key] = ParseTenantScopedStorageKey("raw_key");
+    EXPECT_EQ(default_tenant, "default");
+    EXPECT_EQ(default_key, "raw_key");
+
+    std::string legacy = "legacy_tenant";
+    legacy.push_back('\0');
+    legacy.append("legacy_key");
+    auto [legacy_tenant, legacy_key] = ParseTenantScopedStorageKey(legacy);
+    EXPECT_EQ(legacy_tenant, "legacy_tenant");
+    EXPECT_EQ(legacy_key, "legacy_key");
+}
 
 std::string GenerateKeyForSegment(const UUID& client_id,
                                   const std::unique_ptr<MasterService>& service,
@@ -4598,8 +4622,11 @@ TEST_F(MasterServiceTest, OffloadObjectHeartbeat) {
     }
     ASSERT_EQ(res->size(), keys.size());
     for (auto& key : keys) {
-        ASSERT_TRUE(res.value().find(key) != res.value().end());
-        ASSERT_EQ(res.value().find(key)->second, 1024);
+        auto it = std::find_if(
+            res->begin(), res->end(),
+            [&key](const OffloadTaskItem& task) { return task.key == key; });
+        ASSERT_TRUE(it != res->end());
+        ASSERT_EQ(it->size, 1024);
     }
 
     keys.clear();
@@ -4615,8 +4642,11 @@ TEST_F(MasterServiceTest, OffloadObjectHeartbeat) {
     }
     ASSERT_EQ(res->size(), keys.size());
     for (auto& key : keys) {
-        ASSERT_TRUE(res.value().find(key) != res.value().end());
-        ASSERT_EQ(res.value().find(key)->second, 1024);
+        auto it = std::find_if(
+            res->begin(), res->end(),
+            [&key](const OffloadTaskItem& task) { return task.key == key; });
+        ASSERT_TRUE(it != res->end());
+        ASSERT_EQ(it->size, 1024);
     }
 }
 
@@ -5226,6 +5256,81 @@ TEST_F(MasterServiceTest, FetchTasksReturnsAssignedTasksOnlyAndDrainsQueue) {
     auto fetch0_again = service_->FetchTasks(ctx0.client_id, /*batch_size=*/16);
     ASSERT_TRUE(fetch0_again.has_value());
     EXPECT_TRUE(fetch0_again->empty());
+}
+
+TEST_F(MasterServiceTest, TenantTasksCarryTenantInPayload) {
+    auto service = std::make_unique<MasterService>();
+    const auto ctx0 = PrepareSimpleSegment(*service, "segment_0", 0x300000000,
+                                           kDefaultSegmentSize);
+    [[maybe_unused]] const auto ctx1 = PrepareSimpleSegment(
+        *service, "segment_1", 0x400000000, kDefaultSegmentSize);
+
+    const UUID put_client_id = generate_uuid();
+    const std::string key = "tenant_task_key";
+    const std::string tenant_id = "tenant_for_async_task";
+
+    ReplicateConfig config;
+    config.replica_num = 1;
+    config.preferred_segment = "segment_0";
+
+    ASSERT_TRUE(service
+                    ->PutStart(put_client_id, key, tenant_id,
+                               /*slice_length=*/1024, config)
+                    .has_value());
+    ASSERT_TRUE(
+        service->PutEnd(put_client_id, key, tenant_id, ReplicaType::MEMORY)
+            .has_value());
+
+    auto copy_task_id = service->CreateCopyTask(key, tenant_id, {"segment_1"});
+    ASSERT_TRUE(copy_task_id.has_value());
+    auto move_task_id =
+        service->CreateMoveTask(key, tenant_id, "segment_0", "segment_1");
+    ASSERT_TRUE(move_task_id.has_value());
+
+    auto fetched = service->FetchTasks(ctx0.client_id, /*batch_size=*/16);
+    ASSERT_TRUE(fetched.has_value());
+    ASSERT_EQ(fetched->size(), 2u);
+
+    bool saw_copy = false;
+    bool saw_move = false;
+    for (const auto& assignment : *fetched) {
+        if (assignment.id == copy_task_id.value()) {
+            ReplicaCopyPayload payload;
+            struct_json::from_json(payload, assignment.payload);
+            EXPECT_EQ(payload.tenant_id, tenant_id);
+            EXPECT_EQ(payload.key, key);
+            saw_copy = true;
+        } else if (assignment.id == move_task_id.value()) {
+            ReplicaMovePayload payload;
+            struct_json::from_json(payload, assignment.payload);
+            EXPECT_EQ(payload.tenant_id, tenant_id);
+            EXPECT_EQ(payload.key, key);
+            saw_move = true;
+        }
+    }
+    EXPECT_TRUE(saw_copy);
+    EXPECT_TRUE(saw_move);
+}
+
+TEST_F(MasterServiceTest, LegacyTaskPayloadDefaultsTenant) {
+    ReplicaCopyPayload copy_payload;
+    struct_json::from_json(
+        copy_payload,
+        R"({"key":"legacy_copy_key","source":"segment_0","targets":["segment_1"]})");
+    EXPECT_EQ(copy_payload.tenant_id, "default");
+    EXPECT_EQ(copy_payload.key, "legacy_copy_key");
+    EXPECT_EQ(copy_payload.source, "segment_0");
+    ASSERT_EQ(copy_payload.targets.size(), 1u);
+    EXPECT_EQ(copy_payload.targets[0], "segment_1");
+
+    ReplicaMovePayload move_payload;
+    struct_json::from_json(
+        move_payload,
+        R"({"key":"legacy_move_key","source":"segment_0","target":"segment_1"})");
+    EXPECT_EQ(move_payload.tenant_id, "default");
+    EXPECT_EQ(move_payload.key, "legacy_move_key");
+    EXPECT_EQ(move_payload.source, "segment_0");
+    EXPECT_EQ(move_payload.target, "segment_1");
 }
 
 TEST_F(MasterServiceTest, FetchTasksRespectsBatchSize) {

--- a/mooncake-store/tests/offload_on_evict_test.cpp
+++ b/mooncake-store/tests/offload_on_evict_test.cpp
@@ -68,7 +68,11 @@ class OffloadOnEvictTest : public ::testing::Test {
         if (!res) {
             return {};
         }
-        return std::move(res.value());
+        std::unordered_map<std::string, int64_t> queued;
+        for (const auto& task : res.value()) {
+            queued[task.key] = task.size;
+        }
+        return queued;
     }
 
     template <typename Predicate>

--- a/mooncake-store/tests/promotion_on_hit_test.cpp
+++ b/mooncake-store/tests/promotion_on_hit_test.cpp
@@ -7,6 +7,7 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <chrono>
 #include <memory>
 #include <string>
@@ -16,6 +17,13 @@
 #include "types.h"
 
 namespace mooncake::test {
+
+size_t CountPromotionTask(const std::vector<PromotionTaskItem>& tasks,
+                          const std::string& key) {
+    return std::count_if(
+        tasks.begin(), tasks.end(),
+        [&key](const PromotionTaskItem& task) { return task.key == key; });
+}
 
 class PromotionOnHitTest : public ::testing::Test {
    protected:
@@ -193,7 +201,7 @@ TEST_F(PromotionOnHitTest, MemoryReplicaPresentNoPromotion) {
     service->RemoveAll();
 }
 
-// PromotionObjectHeartbeat returns an empty map when called against a
+// PromotionObjectHeartbeat returns an empty task list when called against a
 // client that has no LocalDiskSegment registered.
 TEST_F(PromotionOnHitTest, HeartbeatReturnsErrorForUnknownClient) {
     MasterServiceConfig config;
@@ -275,7 +283,7 @@ TEST_F(PromotionOnHitTest, RacingReadersDedup) {
     EXPECT_EQ(pending->size(), 1u)
         << "Concurrent readers (" << kThreads << " x " << kReadsPerThread
         << ") must dedupe to a single promotion task";
-    ASSERT_TRUE(pending->count("k_cold"));
+    ASSERT_TRUE(CountPromotionTask(*pending, "k_cold"));
 
     service->RemoveAll();
 }
@@ -583,9 +591,9 @@ TEST_F(PromotionOnHitTest, QueueLimitRejectsBeyondCap) {
     EXPECT_EQ(heartbeat->size(), 1u)
         << "promotion_queue_limit=1 should admit only the first task "
         << "globally; k2's enqueue must be dropped";
-    EXPECT_EQ(heartbeat->count(k1), 1u)
+    EXPECT_EQ(CountPromotionTask(*heartbeat, k1), 1u)
         << "k1 was read first and should be the surviving task";
-    EXPECT_EQ(heartbeat->count(k2), 0u)
+    EXPECT_EQ(CountPromotionTask(*heartbeat, k2), 0u)
         << "k2 was rejected by the cap gate; should not appear";
     EXPECT_EQ(mm.get_promotion_rejected_cap() - cap_rej_pre, 1)
         << "k2's rejection must increment promotion_rejected_cap";
@@ -627,14 +635,14 @@ TEST_F(PromotionOnHitTest, HeartbeatBoundedBatchPreservesLeftovers) {
     ASSERT_TRUE(tick1.has_value());
     EXPECT_EQ(tick1->size(), 1u)
         << "heartbeat should return at most kMaxPerHeartbeat=1 entry";
-    std::string first_key = tick1->begin()->first;
+    std::string first_key = tick1->begin()->key;
     EXPECT_TRUE(std::find(keys.begin(), keys.end(), first_key) != keys.end());
 
     // Second heartbeat returns another key (a different one).
     auto tick2 = service->PromotionObjectHeartbeat(seg.client_id);
     ASSERT_TRUE(tick2.has_value());
     EXPECT_EQ(tick2->size(), 1u);
-    std::string second_key = tick2->begin()->first;
+    std::string second_key = tick2->begin()->key;
     EXPECT_NE(second_key, first_key)
         << "second heartbeat must drain a different leftover key, not "
         << "re-return the one already extracted";
@@ -643,7 +651,7 @@ TEST_F(PromotionOnHitTest, HeartbeatBoundedBatchPreservesLeftovers) {
     auto tick3 = service->PromotionObjectHeartbeat(seg.client_id);
     ASSERT_TRUE(tick3.has_value());
     EXPECT_EQ(tick3->size(), 1u);
-    std::string third_key = tick3->begin()->first;
+    std::string third_key = tick3->begin()->key;
     EXPECT_NE(third_key, first_key);
     EXPECT_NE(third_key, second_key);
 
@@ -808,8 +816,8 @@ TEST_F(PromotionOnHitTest, QueueLimitRejectsCrossShard) {
         << " must be rejected by the global gate. A per-shard heuristic "
         << "would admit it here since the destination shard's local "
         << "count is 0.";
-    EXPECT_EQ(heartbeat->count(k1), 1u);
-    EXPECT_EQ(heartbeat->count(k2), 0u);
+    EXPECT_EQ(CountPromotionTask(*heartbeat, k1), 1u);
+    EXPECT_EQ(CountPromotionTask(*heartbeat, k2), 0u);
 
     service->RemoveAll();
 }
@@ -984,7 +992,7 @@ TEST_F(PromotionOnHitTest, NotifySuccessDecrementsCounter) {
         << "in-flight counter must decrement on the NotifyPromotionSuccess "
         << "success path. Without fetch_sub, the cap stays saturated and "
         << "k_second is silently dropped.";
-    EXPECT_EQ(pending->count("k_second"), 1u);
+    EXPECT_EQ(CountPromotionTask(*pending, "k_second"), 1u);
 
     service->RemoveAll();
 }
@@ -1201,7 +1209,7 @@ TEST_F(PromotionOnHitTest, NotifyFailureReleasesStateImmediately) {
     }
     auto heartbeat = service->PromotionObjectHeartbeat(seg.client_id);
     ASSERT_TRUE(heartbeat.has_value());
-    EXPECT_EQ(heartbeat->count("k_b"), 1u)
+    EXPECT_EQ(CountPromotionTask(*heartbeat, "k_b"), 1u)
         << "k_b admission must succeed after k_a's failure released the "
         << "slot. If this fires, NotifyPromotionFailure did not decrement "
         << "promotion_in_flight_, and transient client-side errors "
@@ -1452,7 +1460,7 @@ TEST_F(PromotionOnHitTest, ClientExpiryClearsPromotionTask) {
     auto pending_pre =
         service->PromotionObjectHeartbeat(second_holder.client_id);
     ASSERT_TRUE(pending_pre.has_value());
-    EXPECT_EQ(pending_pre->count("k_other"), 0u)
+    EXPECT_EQ(CountPromotionTask(*pending_pre, "k_other"), 0u)
         << "Sanity: queue_limit=1 should block the second admission "
         << "while the first task is in flight.";
 
@@ -1486,7 +1494,7 @@ TEST_F(PromotionOnHitTest, ClientExpiryClearsPromotionTask) {
     auto pending_post =
         service->PromotionObjectHeartbeat(second_holder.client_id);
     ASSERT_TRUE(pending_post.has_value());
-    EXPECT_EQ(pending_post->count("k_other"), 1u)
+    EXPECT_EQ(CountPromotionTask(*pending_post, "k_other"), 1u)
         << "After the holder expired, ClearInvalidHandles must have "
         << "erased its promotion_tasks entry and decremented "
         << "promotion_in_flight_. Otherwise the global cap remains "
@@ -1567,7 +1575,7 @@ TEST_F(PromotionOnHitTest, RemoveErasesPromotionTask) {
     {
         auto pending = service->PromotionObjectHeartbeat(holder.client_id);
         ASSERT_TRUE(pending.has_value());
-        EXPECT_EQ(pending->count("k_first"), 1u);
+        EXPECT_EQ(CountPromotionTask(*pending, "k_first"), 1u);
     }
 
     // Remove k_first with force=true. With the fix, this also wipes
@@ -1586,7 +1594,7 @@ TEST_F(PromotionOnHitTest, RemoveErasesPromotionTask) {
     }
     auto pending_post = service->PromotionObjectHeartbeat(holder.client_id);
     ASSERT_TRUE(pending_post.has_value());
-    EXPECT_EQ(pending_post->count("k_second"), 1u)
+    EXPECT_EQ(CountPromotionTask(*pending_post, "k_second"), 1u)
         << "k_second must be admittable after Remove of k_first — Remove "
         << "must erase the in-flight promotion_tasks entry and decrement "
         << "promotion_in_flight_, otherwise queue_limit=1 stays saturated.";
@@ -1636,7 +1644,7 @@ TEST_F(PromotionOnHitTest, RemoveByRegexErasesPromotionTask) {
     }
     auto pending_post = service->PromotionObjectHeartbeat(holder.client_id);
     ASSERT_TRUE(pending_post.has_value());
-    EXPECT_EQ(pending_post->count("other_k2"), 1u)
+    EXPECT_EQ(CountPromotionTask(*pending_post, "other_k2"), 1u)
         << "other_k2 must be admittable after RemoveByRegex of regex_k1 "
         << "— RemoveByRegex must erase the in-flight promotion_tasks "
         << "entry. Otherwise queue_limit=1 stays saturated.";
@@ -1675,7 +1683,7 @@ TEST_F(PromotionOnHitTest, RemoveAllErasesPromotionTask) {
     {
         auto pending = service->PromotionObjectHeartbeat(holder.client_id);
         ASSERT_TRUE(pending.has_value());
-        EXPECT_EQ(pending->count("k_first"), 1u);
+        EXPECT_EQ(CountPromotionTask(*pending, "k_first"), 1u);
     }
 
     auto removed = service->RemoveAll(/*force=*/true);
@@ -1693,7 +1701,7 @@ TEST_F(PromotionOnHitTest, RemoveAllErasesPromotionTask) {
     }
     auto pending_post = service->PromotionObjectHeartbeat(holder.client_id);
     ASSERT_TRUE(pending_post.has_value());
-    EXPECT_EQ(pending_post->count("k_second"), 1u)
+    EXPECT_EQ(CountPromotionTask(*pending_post, "k_second"), 1u)
         << "k_second must be admittable after RemoveAll of k_first — "
         << "otherwise queue_limit=1 stays saturated until reaper TTL.";
 
@@ -1739,7 +1747,7 @@ TEST_F(PromotionOnHitTest, BatchRemoveErasesPromotionTask) {
     {
         auto pending = service->PromotionObjectHeartbeat(holder.client_id);
         ASSERT_TRUE(pending.has_value());
-        EXPECT_EQ(pending->count("k_first"), 1u);
+        EXPECT_EQ(CountPromotionTask(*pending, "k_first"), 1u);
     }
 
     auto results = service->BatchRemove({"k_first"}, /*force=*/true);
@@ -1757,7 +1765,7 @@ TEST_F(PromotionOnHitTest, BatchRemoveErasesPromotionTask) {
     }
     auto pending_post = service->PromotionObjectHeartbeat(holder.client_id);
     ASSERT_TRUE(pending_post.has_value());
-    EXPECT_EQ(pending_post->count("k_second"), 1u)
+    EXPECT_EQ(CountPromotionTask(*pending_post, "k_second"), 1u)
         << "k_second must be admittable after BatchRemove of k_first — "
         << "otherwise queue_limit=1 stays saturated until reaper TTL.";
 
@@ -1795,7 +1803,7 @@ TEST_F(PromotionOnHitTest, BatchRemoveStaleHandleErasesPromotionTask) {
     {
         auto pending = service->PromotionObjectHeartbeat(holder.client_id);
         ASSERT_TRUE(pending.has_value());
-        EXPECT_EQ(pending->count("k_first"), 1u);
+        EXPECT_EQ(CountPromotionTask(*pending, "k_first"), 1u);
     }
 
     auto results = service->BatchRemove({"k_first"}, /*force=*/true);
@@ -1828,7 +1836,7 @@ TEST_F(PromotionOnHitTest, BatchRemoveStaleHandleErasesPromotionTask) {
     auto pending_post =
         service->PromotionObjectHeartbeat(second_holder.client_id);
     ASSERT_TRUE(pending_post.has_value());
-    EXPECT_EQ(pending_post->count("k_second"), 1u)
+    EXPECT_EQ(CountPromotionTask(*pending_post, "k_second"), 1u)
         << "k_second must be admittable after the stale-handle "
         << "BatchRemove — otherwise queue_limit=1 stays saturated until "
         << "reaper TTL.";


### PR DESCRIPTION
## Description

This PR completes tenant propagation for Mooncake Store async task-backed flows. It extends copy, move, offload, promotion, drain, and disk replica eviction paths so that async RPCs, worker callbacks, task payloads, heartbeat task items, local disk storage keys, and snapshot/offload recovery preserve tenant identity instead of implicitly operating on the default tenant.

Key changes:

- Add tenant-aware overloads and forwarding paths for async Store operations in `Client`, `MasterClient`, `WrappedMasterService`, and `MasterService`.
- Carry `tenant_id` in copy/move task payloads and default it to `"default"` for backward compatibility with old in-flight task payloads.
- Replace offload/promotion heartbeat task maps with typed task items that carry `tenant_id`, `key`, and `size`.
- Encode tenant identity in local-disk storage keys and preserve compatibility with legacy unscoped keys by falling back to the default tenant.
- Make drain and disk-replica eviction tenant-aware.
- Update snapshot/offload serialization and recovery paths to handle both new tenant-aware entries and legacy entries.
- Update affected Store tests and add focused coverage for tenant-scoped storage keys, tenant-aware task payloads, and legacy task payload deserialization.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

Ran focused checks for the task payload compatibility fix:

```bash
cmake --build build --target master_service_test -j2
build/mooncake-store/tests/master_service_test --gtest_filter='*Payload*:MasterServiceTest.TenantTasksCarryTenantInPayload'
```

The filtered `master_service_test` run passed:

- `MasterServiceTest.TenantTasksCarryTenantInPayload`
- `MasterServiceTest.LegacyTaskPayloadDefaultsTenant`

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
