### PR TITLE
[TENT] Add policy name binding to transport selector

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/common/types.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/types.h
@@ -18,6 +18,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -51,6 +52,7 @@ struct Request {
     size_t length;
     int priority =
         PRIO_HIGH;  // Request priority (PRIO_HIGH, PRIO_MEDIUM, PRIO_LOW)
+    std::optional<std::string> policy_name;  // Optional: bind to specific policy by name
 };
 
 enum TransferStatusEnum {

--- a/mooncake-transfer-engine/tent/include/tent/common/types.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/types.h
@@ -52,7 +52,8 @@ struct Request {
     size_t length;
     int priority =
         PRIO_HIGH;  // Request priority (PRIO_HIGH, PRIO_MEDIUM, PRIO_LOW)
-    std::optional<std::string> policy_name;  // Optional: bind to specific policy by name
+    std::optional<std::string>
+        policy_name;  // Optional: bind to specific policy by name
 };
 
 enum TransferStatusEnum {

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transport_selector.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transport_selector.h
@@ -80,7 +80,8 @@ struct SelectionContext {
         buffer_transports;  // Pointer to transports in buffer
     size_t transfer_size;   // Transfer size in bytes
     int priority_level;     // Request priority level (lower = more urgent)
-    std::optional<std::string> policy_name;  // Optional: bind to specific policy by name
+    std::optional<std::string>
+        policy_name;  // Optional: bind to specific policy by name
 };
 
 /**

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transport_selector.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transport_selector.h
@@ -80,6 +80,7 @@ struct SelectionContext {
         buffer_transports;  // Pointer to transports in buffer
     size_t transfer_size;   // Transfer size in bytes
     int priority_level;     // Request priority level (lower = more urgent)
+    std::optional<std::string> policy_name;  // Optional: bind to specific policy by name
 };
 
 /**

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -861,6 +861,7 @@ SelectionResult TransferEngineImpl::getTransportType(const Request& request,
     ctx.transfer_size = request.length;
     ctx.priority_level =
         request.priority;  // Use request priority for selection
+    ctx.policy_name = request.policy_name;  // Optional: bind to specific policy
 
     if (desc->type == SegmentType::File) {
         // File segment: use selector with empty buffer_transports

--- a/mooncake-transfer-engine/tent/src/runtime/transport_selector.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transport_selector.cpp
@@ -237,9 +237,10 @@ bool TransportSelector::matchesMemoryPattern(const std::string& pattern,
 
 bool TransportSelector::matchesPolicy(const SelectionPolicy& policy,
                                       const SelectionContext& context) const {
-    // If context specifies a policy_name, only match that exact policy
+    // If context specifies a policy_name, only match that exact policy with matching segment type
     if (context.policy_name.has_value()) {
-        return context.policy_name.value() == policy.name;
+        return context.policy_name.value() == policy.name &&
+               policy.segment_type == context.segment_type;
     }
 
     // Check segment type

--- a/mooncake-transfer-engine/tent/src/runtime/transport_selector.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transport_selector.cpp
@@ -237,6 +237,11 @@ bool TransportSelector::matchesMemoryPattern(const std::string& pattern,
 
 bool TransportSelector::matchesPolicy(const SelectionPolicy& policy,
                                       const SelectionContext& context) const {
+    // If context specifies a policy_name, only match that exact policy
+    if (context.policy_name.has_value()) {
+        return context.policy_name.value() == policy.name;
+    }
+
     // Check segment type
     if (policy.segment_type != context.segment_type) {
         return false;

--- a/mooncake-transfer-engine/tent/src/runtime/transport_selector.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transport_selector.cpp
@@ -237,7 +237,8 @@ bool TransportSelector::matchesMemoryPattern(const std::string& pattern,
 
 bool TransportSelector::matchesPolicy(const SelectionPolicy& policy,
                                       const SelectionContext& context) const {
-    // If context specifies a policy_name, only match that exact policy with matching segment type
+    // If context specifies a policy_name, only match that exact policy with
+    // matching segment type
     if (context.policy_name.has_value()) {
         return context.policy_name.value() == policy.name &&
                policy.segment_type == context.segment_type;


### PR DESCRIPTION
## Description

Add ability to bind a request to a specific transport policy by name via `request.policy_name`. When specified, the selector matches policies by exact name instead of pattern-based conditions (segment_type, priority, etc.). This makes the policy `name` field in configuration actually useful for explicit policy selection.

## Module

- [X] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [X] I have performed a self-review of my own code.
- [X] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
