### PR TITLE
[TE] fix(efa): short-circuit same-process GPU loopback to avoid libfabric SHM segfault

### DIFF
--- a/docs/source/design/transfer-engine/efa_transport.md
+++ b/docs/source/design/transfer-engine/efa_transport.md
@@ -120,7 +120,7 @@ result = te.initialize('127.0.0.1', 'P2PHANDSHAKE', 'efa', '')
 print(f'Initialize result: {result}')  # Should be 0
 
 # You should see logs like:
-# EFA device (libfabric): rdmap79s0, domain: rdmap79s0-rdm, provider: efa
+# EFA device (libfabric): rdmap79s0, domain: rdmap79s0-rdm, fabric: efa, provider: efa
 ```
 
 ## Unit Tests
@@ -374,18 +374,60 @@ Tested on two p5.48xlarge instances (AMD EPYC 7R13, 8× H100 80GB, 32 EFA device
 
 ### Single-host loopback
 
-EFA NICs have no hardware loopback short-circuit: even when both endpoints resolve to the same host, `fi_write`/`fi_read` drive a real DMA round-trip through the EFA device. For deployments where the producer and consumer run as **separate processes on the same host** (single-machine development, benchmarks, co-located workers), this is strictly slower than libfabric's emulated RDMA path, which resolves the same-host case to a memcpy and skips the NIC entirely.
+EFA NICs have no hardware loopback short-circuit: when a transfer's source and
+destination resolve to the same host, the data does not go out on the wire as
+GPUDirect/device RDMA. libfabric handles the same-host case in software, and
+there are **two distinct provider knobs** that select how:
 
-Set `FI_EFA_USE_DEVICE_RDMA=0` (a libfabric provider env, [documented by the EFA installer](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-runtime-tuning.html)) on processes that only do same-host transfers; leave it unset (default `1`) on cross-host or mixed processes. Mooncake does not wrap this knob — it is a provider-level flag resolved at `fi_getinfo` time, and a single `EfaTransport` instance may serve a mix of loopback and cross-host peers, so flipping it disables device RDMA for **every** transfer in the process. Apply it per-process based on that process's traffic pattern.
+- **`FI_EFA_ENABLE_SHM_TRANSFER`** (default `1`, on): when on, the EFA
+  provider routes same-host peers through the **`shm` provider** — verifiable
+  at runtime, where libfabric reports `Opened fabric: shm` alongside
+  `Opened fabric: efa` even on a default (device-RDMA-enabled) configuration.
+  This SHM path is the one that supplies the same-host memcpy fast path; it is
+  active **by default**, independent of `FI_EFA_USE_DEVICE_RDMA`.
+- **`FI_EFA_USE_DEVICE_RDMA`** (default `1` after #2041): controls whether the
+  EFA RDM data path uses device RDMA vs libfabric's emulated RDM path. It is a
+  provider-level flag resolved at `fi_getinfo` time; Mooncake does not wrap it.
 
-Measured on p5.48xlarge (1 NIC, ~1.2 GiB per `put_from` call, same-host producer/consumer):
+```{warning}
+**GPU (FI_HMEM_CUDA) buffers — known segfault.** The default same-host **SHM**
+path (`FI_EFA_ENABLE_SHM_TRANSFER=1`) performs a **host `memcpy` into the
+destination buffer** during SHM SAR reassembly, *without* honoring an
+`FI_HMEM_CUDA` destination's iface. On a GPU buffer this writes host memory
+straight into a device pointer and **segfaults** on the first same-host
+transfer — `__memcpy_avx_unaligned` ← `ofi_copy_to_mr_iov` ← `smr_copy_from_sar`
+← `efa_rdm_cq_readfrom` ← `fi_cq_read`. Reported upstream as
+[ofiwg/libfabric#12328](https://github.com/ofiwg/libfabric/issues/12328).
 
-| `FI_EFA_USE_DEVICE_RDMA` | per-write latency |
+- **Same-process self-loopback** (e.g. a TP-colocated rank reading its own
+  registered GPU weights — checkpoint-engine p2p weight update) is handled
+  inside Mooncake: `EfaContext::tryLoopbackCopy` detects a same-process peer
+  (matched on `local_server_name`, which embeds this process's unique RPC
+  port) and satisfies the transfer with a local `cudaMemcpy` instead of routing
+  it over EFA, so it never reaches the broken SHM path.
+- **Same-host cross-process GPU transfers** are *not* short-circuited (the
+  peer is a different process / address space). Until libfabric#12328 is fixed,
+  set `FI_EFA_ENABLE_SHM_TRANSFER=0` on such processes — same-host transfers
+  then fall back to device RDMA, which is GPU-aware and correct.
+```
+
+For **host (DRAM) buffers** the SHM memcpy path is safe (host→host copy) and is
+the same-host fast path the measurements below exercise.
+
+Measured on p5.48xlarge (1 NIC, ~1.2 GiB per `put_from` call, host DRAM buffer,
+same-host producer/consumer in **separate processes**):
+
+| same-host path | per-write latency |
 |---|---:|
-| `1` (default after #2041, device RDMA) | ~830 ms |
-| `0` (emulated, same-host memcpy fast path) | ~390 ms |
+| device RDMA (NIC round-trip, no fast-path for loopback) | ~830 ms |
+| SHM memcpy fast path (default) | ~390 ms |
 
-For reference, a cross-host `put_from` of the same payload (device RDMA, 1 NIC) is ~340 ms — i.e., device RDMA on a same-host loopback is *slower* than going over the wire to another host, because the NIC has no fast-path for loopback. Cross-host benchmarks are unaffected by this env: leave `FI_EFA_USE_DEVICE_RDMA` at its default on any process that also talks to remote peers.
+For reference, a cross-host `put_from` of the same payload (device RDMA, 1 NIC)
+is ~340 ms — i.e., driving a same-host loopback through the NIC is *slower* than
+going over the wire to another host, because the NIC has no fast-path for
+loopback. Cross-host transfers always use device RDMA and are unaffected by
+`FI_EFA_ENABLE_SHM_TRANSFER`: leave it at its default on any process that also
+talks to remote peers.
 
 ### Tuning Tips
 

--- a/mooncake-transfer-engine/include/transport/efa_transport/efa_context.h
+++ b/mooncake-transfer-engine/include/transport/efa_transport/efa_context.h
@@ -125,6 +125,19 @@ class EfaContext {
     // Submit slices for transfer
     int submitPostSend(const std::vector<Transport::Slice*>& slice_list);
 
+    // Same-process self-loopback fast path.  When a slice's resolved peer
+    // NIC path equals our own (same server_name — which embeds the
+    // per-process RPC port — AND same device), source and destination are
+    // both valid pointers in THIS process's address space.  We satisfy the
+    // copy with a local memcpy / cudaMemcpy instead of issuing it over EFA.
+    //
+    // This avoids libfabric's EFA SHM intra-node path, which performs a
+    // host memcpy into FI_HMEM_CUDA device buffers and segfaults
+    // (ofiwg/libfabric#12328).  Returns true if the slice was handled here
+    // (and marked success/failed); false if it should fall through to the
+    // normal EFA submit path.
+    bool tryLoopbackCopy(Transport::Slice* slice);
+
     // Hot-path submit: post a batch of slices to `peer_fi_addr` via the
     // shared endpoint.  Handles WR / CQ reservation, MR descriptor prep,
     // and the fi_write / fi_read burst under post_lock_.  Called by

--- a/mooncake-transfer-engine/src/transport/efa_transport/efa_context.cpp
+++ b/mooncake-transfer-engine/src/transport/efa_transport/efa_context.cpp
@@ -193,6 +193,7 @@ int EfaContext::construct(size_t num_cq_list, size_t max_cqe,
 
     LOG(INFO) << "EFA device (libfabric): " << device_name_
               << ", domain: " << fi_info_->domain_attr->name
+              << ", fabric: " << fi_info_->fabric_attr->name
               << ", provider: " << fi_info_->fabric_attr->prov_name
               << " (shared endpoint, max_wr=" << max_wr_depth_ << ")";
 

--- a/mooncake-transfer-engine/src/transport/efa_transport/efa_context.cpp
+++ b/mooncake-transfer-engine/src/transport/efa_transport/efa_context.cpp
@@ -626,6 +626,72 @@ void EfaContext::removePeerAddr(fi_addr_t fi_addr) {
     }
 }
 
+bool EfaContext::tryLoopbackCopy(Transport::Slice* slice) {
+    // Only intra-process self-transfers qualify.  We compare the SERVER name
+    // (host:rpc_port), NOT the full nic path: local_server_name embeds this
+    // process's unique RPC port, so a server-name match guarantees the peer
+    // is *this very process* — meaning both source_addr and dest_addr are
+    // pointers we can dereference directly.  We deliberately ignore the
+    // device suffix: with multiple NICs the source slice is routed by its
+    // source buffer's device while peer_nic_path names the destination
+    // buffer's device, so the two device names often differ even for a pure
+    // self-loopback.  Same-host *cross-process* peers carry a different RPC
+    // port and never match, so we never memcpy across address spaces.
+    if (getServerNameFromNicPath(slice->peer_nic_path) !=
+        engine_.local_server_name()) {
+        return false;
+    }
+
+    // Direction depends on opcode, mirroring fi_read / fi_write below:
+    //   WRITE: fi_write(buf=source_addr -> addr=dest_addr)  data src->dst
+    //   READ : fi_read (buf=source_addr <- addr=dest_addr)  data dst->src
+    // source_addr and rdma.dest_addr are two distinct local buffers here, so
+    // the copy is NOT symmetric — we must honor the opcode's direction.
+    void* local_buf = slice->source_addr;
+    void* remote_buf = reinterpret_cast<void*>(slice->rdma.dest_addr);
+    void* dst;
+    void* src;
+    if (slice->opcode == Transport::TransferRequest::READ) {
+        dst = local_buf;   // read INTO local
+        src = remote_buf;  // FROM remote (== local) buffer
+    } else {
+        dst = remote_buf;  // write INTO remote (== local) buffer
+        src = local_buf;   // FROM local
+    }
+    size_t len = slice->length;
+    // GPU-aware copy.  Guard on the SAME backends that register GPU memory
+    // as FI_HMEM (see the FI_MR_HMEM hint and the registration path: only
+    // USE_CUDA / USE_HIP tag MRs with a device iface).  Every other build —
+    // including non-EFA GPU backends such as MUSA/MLU/MACA, which never run
+    // on AWS EFA hardware — registers loopback buffers as host memory, so a
+    // plain memcpy is both correct and the only portable option (those
+    // backends do not expose the cuda* symbols).  *MemcpyDefault picks
+    // H2H/H2D/D2H/D2D from the pointer attributes.
+#if defined(USE_CUDA)
+    auto rc = cudaMemcpy(dst, src, len, cudaMemcpyDefault);
+    if (rc != cudaSuccess) {
+        LOG(ERROR) << "EFA loopback cudaMemcpy failed: "
+                   << cudaGetErrorString(rc) << " (dst=" << dst
+                   << ", src=" << src << ", len=" << len << ")";
+        slice->markFailed();
+        return true;
+    }
+#elif defined(USE_HIP)
+    auto rc = hipMemcpy(dst, src, len, hipMemcpyDefault);
+    if (rc != hipSuccess) {
+        LOG(ERROR) << "EFA loopback hipMemcpy failed: " << hipGetErrorString(rc)
+                   << " (dst=" << dst << ", src=" << src << ", len=" << len
+                   << ")";
+        slice->markFailed();
+        return true;
+    }
+#else
+    memcpy(dst, src, len);
+#endif
+    slice->markSuccess();
+    return true;
+}
+
 int EfaContext::submitPostSend(
     const std::vector<Transport::Slice*>& slice_list) {
     // Route slices to appropriate peer handles.  Group by peer NIC path.
@@ -638,6 +704,8 @@ int EfaContext::submitPostSend(
         // Fast path: peer info already filled in by the caller
         // (dest_rkey and peer_nic_path set on the slice before dispatch).
         if (!slice->peer_nic_path.empty()) {
+            // Self-loopback: satisfy locally, skip EFA entirely.
+            if (tryLoopbackCopy(slice)) continue;
             slices_by_peer[slice->peer_nic_path].push_back(slice);
             continue;
         }
@@ -669,6 +737,8 @@ int EfaContext::submitPostSend(
                                     "@" +
                                     peer_segment_desc->devices[device_id].name;
         slice->peer_nic_path = peer_nic_path;
+        // Self-loopback: satisfy locally, skip EFA entirely.
+        if (tryLoopbackCopy(slice)) continue;
         slices_by_peer[peer_nic_path].push_back(slice);
     }
 

--- a/mooncake-transfer-engine/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tests/CMakeLists.txt
@@ -84,6 +84,32 @@ if (USE_EFA)
 
     add_executable(efa_transfer_test ${WORKSPACE}/efa_transfer_test.cpp)
     target_link_libraries(efa_transfer_test PUBLIC transfer_engine gflags::gflags glog::glog)
+
+    # GPU (CUDA device memory) loopback test — reproduces the EFA SHM
+    # intra-node segfault on FI_HMEM_CUDA buffers (ofiwg/libfabric#12328)
+    # and validates EfaContext::tryLoopbackCopy.  Needs CUDA headers/libs.
+    if (USE_CUDA)
+        add_executable(efa_gpu_loopback_test ${WORKSPACE}/efa_gpu_loopback_test.cpp)
+        # Resolve CUDA include dirs / runtime via CUDAToolkit instead of a
+        # hardcoded /usr/local/cuda/include, so the test builds wherever CUDA
+        # lives (e.g. the DLAMI pip venv layout).  find_package is idempotent
+        # and may not have run yet in this scope (top-level only calls it under
+        # WITH_EP), so request it here; fall back to the legacy path if the
+        # module variant is unavailable.
+        find_package(CUDAToolkit QUIET)
+        if (CUDAToolkit_FOUND)
+            target_include_directories(efa_gpu_loopback_test
+                PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
+            target_link_libraries(efa_gpu_loopback_test
+                PUBLIC transfer_engine gtest gtest_main CUDA::cudart)
+        else()
+            target_include_directories(efa_gpu_loopback_test
+                PRIVATE /usr/local/cuda/include)
+            target_link_libraries(efa_gpu_loopback_test
+                PUBLIC transfer_engine gtest gtest_main cudart)
+        endif()
+        add_test(NAME efa_gpu_loopback_test COMMAND efa_gpu_loopback_test)
+    endif()
 endif()
 
 # UB transport test with URMA endpoint and mock support

--- a/mooncake-transfer-engine/tests/efa_gpu_loopback_test.cpp
+++ b/mooncake-transfer-engine/tests/efa_gpu_loopback_test.cpp
@@ -1,0 +1,324 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// EFA GPU (CUDA device memory) loopback test.
+//
+// This is the GPU-memory counterpart of efa_transport_test.cpp, which only
+// exercises loopback on host (numa) buffers.  The distinction matters: the
+// libfabric EFA provider's SHM intra-node path does a host memcpy into
+// FI_HMEM_CUDA device buffers and segfaults on the first same-host transfer
+// (ofiwg/libfabric#12328).  Host-memory loopback never hits that bug, so it
+// went unnoticed by the existing tests.
+//
+// Mooncake's fix (EfaContext::tryLoopbackCopy) detects same-process
+// self-loopback and satisfies it with a GPU-aware cudaMemcpy instead of
+// routing it over EFA.  This test reproduces the crash WITHOUT the fix and
+// verifies correct, byte-accurate data movement WITH it — for both WRITE and
+// READ opcodes (the two copy in opposite directions).
+//
+// Requires EFA hardware (fi_info -p efa) AND at least one CUDA GPU.  Self-
+// skips cleanly when either is absent.
+
+#include <cuda_runtime.h>
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <memory>
+#include <vector>
+
+#include "transfer_engine.h"
+#include "transport/efa_transport/efa_transport.h"
+#include "transport/transport.h"
+
+using namespace mooncake;
+
+namespace mooncake {
+
+namespace {
+bool cudaAvailable() {
+    int n = 0;
+    return cudaGetDeviceCount(&n) == cudaSuccess && n > 0;
+}
+}  // namespace
+
+class EFAGpuLoopbackTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        google::InitGoogleLogging("EFAGpuLoopbackTest");
+        FLAGS_logtostderr = 1;
+
+        const char *env = std::getenv("MC_METADATA_SERVER");
+        metadata_server_ = env ? env : "P2PHANDSHAKE";
+
+        env = std::getenv("MC_LOCAL_SERVER_NAME");
+        local_server_name_ = env ? env : "127.0.0.1:12345";
+    }
+
+    void TearDown() override { google::ShutdownGoogleLogging(); }
+
+    struct EngineSetup {
+        std::unique_ptr<TransferEngine> engine;
+        Transport *xport = nullptr;
+        void *dev_buf = nullptr;  // CUDA device buffer
+        size_t buffer_size = 0;
+        SegmentID segment_id = 0;
+        bool ok = false;
+    };
+
+    // Create engine, install EFA transport, allocate + register a CUDA
+    // device buffer, and open our own segment for loopback.
+    EngineSetup createEngine(size_t buffer_size = 1ull << 26 /* 64 MB */) {
+        EngineSetup s;
+        s.buffer_size = buffer_size;
+
+        if (cudaSetDevice(0) != cudaSuccess) {
+            LOG(WARNING) << "cudaSetDevice(0) failed";
+            return s;
+        }
+
+        s.engine = std::make_unique<TransferEngine>(false);
+        s.engine->getLocalTopology()->discover({});
+        auto hp = parseHostNameWithPort(local_server_name_);
+        int rc = s.engine->init(metadata_server_, local_server_name_,
+                                hp.first.c_str(), hp.second);
+        EXPECT_EQ(rc, 0) << "engine->init failed";
+        if (rc != 0) return s;
+
+        s.xport = s.engine->installTransport("efa", nullptr);
+        EXPECT_NE(s.xport, nullptr) << "installTransport(\"efa\") failed";
+        if (!s.xport) return s;
+
+        cudaError_t cerr = cudaMalloc(&s.dev_buf, buffer_size);
+        EXPECT_EQ(cerr, cudaSuccess)
+            << "cudaMalloc failed: " << cudaGetErrorString(cerr);
+        if (cerr != cudaSuccess) return s;
+
+        // Register as GPU memory so the EFA transport tags the MR with
+        // FI_HMEM_CUDA (the registration path under test).
+        rc = s.engine->registerLocalMemory(s.dev_buf, buffer_size, "cuda:0");
+        EXPECT_EQ(rc, 0) << "registerLocalMemory(cuda:0) failed";
+        if (rc != 0) return s;
+
+        auto actual_addr = s.engine->getLocalIpAndPort();
+        s.segment_id = s.engine->openSegment(actual_addr);
+        s.ok = true;
+        return s;
+    }
+
+    void destroyEngine(EngineSetup &s) {
+        if (s.engine && s.dev_buf) {
+            s.engine->unregisterLocalMemory(s.dev_buf);
+        }
+        if (s.dev_buf) {
+            cudaFree(s.dev_buf);
+            s.dev_buf = nullptr;
+        }
+    }
+
+    bool submitAndWait(TransferEngine *engine, SegmentID segment_id,
+                       void *source, uint64_t target_offset, size_t length,
+                       TransferRequest::OpCode opcode) {
+        auto batch_id = engine->allocateBatchID(1);
+        TransferRequest entry;
+        entry.opcode = opcode;
+        entry.length = length;
+        entry.source = (uint8_t *)source;
+        entry.target_id = segment_id;
+        entry.target_offset = target_offset;
+
+        Status s = engine->submitTransfer(batch_id, {entry});
+        if (!s.ok()) {
+            LOG(ERROR) << "submitTransfer failed: " << s.ToString();
+            engine->freeBatchID(batch_id);
+            return false;
+        }
+
+        TransferStatus status;
+        const int kMaxPollIterations = 2000000;
+        for (int i = 0; i < kMaxPollIterations; ++i) {
+            s = engine->getTransferStatus(batch_id, 0, status);
+            if (!s.ok()) {
+                engine->freeBatchID(batch_id);
+                return false;
+            }
+            if (status.s == TransferStatusEnum::COMPLETED) {
+                engine->freeBatchID(batch_id);
+                return true;
+            }
+            if (status.s == TransferStatusEnum::FAILED) {
+                LOG(ERROR) << "Transfer FAILED";
+                engine->freeBatchID(batch_id);
+                return false;
+            }
+        }
+        LOG(ERROR) << "Transfer timed out";
+        engine->freeBatchID(batch_id);
+        return false;
+    }
+
+    std::string metadata_server_;
+    std::string local_server_name_;
+};
+
+// Test 1: GPU loopback WRITE must not crash.
+//
+// Without the fix this segfaults inside the EFA provider's SHM path
+// (host memcpy into a device pointer).  With the fix it completes via a
+// local cudaMemcpy.
+TEST_F(EFAGpuLoopbackTest, GpuLoopbackWrite) {
+    if (!cudaAvailable()) GTEST_SKIP() << "No CUDA GPU present";
+    auto setup = createEngine();
+    if (!setup.ok) GTEST_SKIP() << "EFA/CUDA setup unavailable";
+
+    auto segment_desc =
+        setup.engine->getMetadata()->getSegmentDescByID(setup.segment_id);
+    ASSERT_NE(segment_desc, nullptr);
+    uint64_t remote_base = (uint64_t)segment_desc->buffers[0].addr;
+
+    const size_t kDataLength = 4096;
+    ASSERT_EQ(cudaMemset(setup.dev_buf, 0xAB, kDataLength), cudaSuccess);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+    // Write src(=dev_buf) -> remote(=dev_buf + offset), both on the GPU.
+    bool ok = submitAndWait(setup.engine.get(), setup.segment_id, setup.dev_buf,
+                            remote_base + (setup.buffer_size / 2), kDataLength,
+                            TransferRequest::WRITE);
+    EXPECT_TRUE(ok) << "GPU loopback write should succeed";
+
+    destroyEngine(setup);
+}
+
+// Test 2: GPU loopback WRITE then READ, with byte-accurate verification.
+//
+// The first half holds the source pattern; we WRITE it into the second
+// half, scribble the first half, then READ the second half back into the
+// first half and compare.  This exercises BOTH copy directions of
+// tryLoopbackCopy (WRITE: src->dst, READ: dst->src) and proves the data is
+// actually moved correctly, not merely "did not crash".
+TEST_F(EFAGpuLoopbackTest, GpuLoopbackWriteThenRead) {
+    if (!cudaAvailable()) GTEST_SKIP() << "No CUDA GPU present";
+    auto setup = createEngine();
+    if (!setup.ok) GTEST_SKIP() << "EFA/CUDA setup unavailable";
+
+    auto segment_desc =
+        setup.engine->getMetadata()->getSegmentDescByID(setup.segment_id);
+    ASSERT_NE(segment_desc, nullptr);
+    uint64_t remote_base = (uint64_t)segment_desc->buffers[0].addr;
+
+    const size_t kDataLength = 4ull << 20;  // 4 MB
+    ASSERT_LE(2 * kDataLength, setup.buffer_size);
+
+    uint8_t *dev = (uint8_t *)setup.dev_buf;
+    const uint64_t second_half = setup.buffer_size / 2;
+
+    // Build a known pattern on the host and copy it into the first half.
+    std::vector<uint8_t> pattern(kDataLength);
+    for (size_t i = 0; i < kDataLength; ++i)
+        pattern[i] = (uint8_t)(i * 131 + 7);
+    ASSERT_EQ(
+        cudaMemcpy(dev, pattern.data(), kDataLength, cudaMemcpyHostToDevice),
+        cudaSuccess);
+
+    // WRITE: first half -> second half (loopback).
+    ASSERT_TRUE(submitAndWait(setup.engine.get(), setup.segment_id, dev,
+                              remote_base + second_half, kDataLength,
+                              TransferRequest::WRITE))
+        << "WRITE should succeed";
+
+    // Corrupt the first half so the READ-back has to actually move bytes.
+    ASSERT_EQ(cudaMemset(dev, 0x00, kDataLength), cudaSuccess);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+    // READ: second half -> first half (loopback, opposite direction).
+    ASSERT_TRUE(submitAndWait(setup.engine.get(), setup.segment_id, dev,
+                              remote_base + second_half, kDataLength,
+                              TransferRequest::READ))
+        << "READ should succeed";
+
+    // Verify the first half now matches the original pattern.
+    std::vector<uint8_t> readback(kDataLength, 0xFF);
+    ASSERT_EQ(
+        cudaMemcpy(readback.data(), dev, kDataLength, cudaMemcpyDeviceToHost),
+        cudaSuccess);
+    EXPECT_EQ(0, memcmp(readback.data(), pattern.data(), kDataLength))
+        << "READ-back GPU data should match the written pattern";
+
+    destroyEngine(setup);
+}
+
+// Test 3: batch of GPU loopback writes (multiple slices), to exercise the
+// per-slice loopback short-circuit inside the grouping loop.
+TEST_F(EFAGpuLoopbackTest, GpuLoopbackMultiWrite) {
+    if (!cudaAvailable()) GTEST_SKIP() << "No CUDA GPU present";
+    auto setup = createEngine();
+    if (!setup.ok) GTEST_SKIP() << "EFA/CUDA setup unavailable";
+
+    auto segment_desc =
+        setup.engine->getMetadata()->getSegmentDescByID(setup.segment_id);
+    ASSERT_NE(segment_desc, nullptr);
+    uint64_t remote_base = (uint64_t)segment_desc->buffers[0].addr;
+
+    const size_t kSliceLen = 65536;
+    const int kBatchSize = 16;
+    const uint64_t dst_region = setup.buffer_size / 2;
+    ASSERT_LE(dst_region + (uint64_t)kBatchSize * kSliceLen, setup.buffer_size);
+
+    ASSERT_EQ(cudaMemset(setup.dev_buf, 0x5A, kBatchSize * kSliceLen),
+              cudaSuccess);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+    auto batch_id = setup.engine->allocateBatchID(kBatchSize);
+    std::vector<TransferRequest> requests;
+    for (int i = 0; i < kBatchSize; ++i) {
+        TransferRequest entry;
+        entry.opcode = TransferRequest::WRITE;
+        entry.length = kSliceLen;
+        entry.source = (uint8_t *)setup.dev_buf + i * kSliceLen;
+        entry.target_id = setup.segment_id;
+        entry.target_offset = remote_base + dst_region + i * kSliceLen;
+        requests.push_back(entry);
+    }
+
+    Status s = setup.engine->submitTransfer(batch_id, requests);
+    ASSERT_TRUE(s.ok()) << "submitTransfer failed: " << s.ToString();
+
+    for (int task_id = 0; task_id < kBatchSize; ++task_id) {
+        TransferStatus status;
+        const int kMaxPollIterations = 2000000;
+        for (int i = 0; i < kMaxPollIterations; ++i) {
+            s = setup.engine->getTransferStatus(batch_id, task_id, status);
+            ASSERT_TRUE(s.ok());
+            if (status.s == TransferStatusEnum::COMPLETED) break;
+            ASSERT_NE(status.s, TransferStatusEnum::FAILED)
+                << "task " << task_id << " failed";
+        }
+        ASSERT_EQ(status.s, TransferStatusEnum::COMPLETED)
+            << "task " << task_id << " did not complete";
+    }
+
+    s = setup.engine->freeBatchID(batch_id);
+    ASSERT_TRUE(s.ok());
+
+    destroyEngine(setup);
+}
+
+}  // namespace mooncake
+
+int main(int argc, char **argv) {
+    gflags::ParseCommandLineFlags(&argc, &argv, false);
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Description

When a transfer's source and destination live in the **same process** (e.g. a TP-colocated rank reading its own registered GPU weights — checkpoint-engine p2p weight update to a vLLM worker), the EFA transport routes it over libfabric like any other peer. On GPU (`FI_HMEM_CUDA`) buffers this **segfaults** on the first such transfer:

```
#0  __memcpy_avx_unaligned_erms          ← SIGSEGV
#1  ofi_memcpy
#2  ofi_copy_mr_iov
#3  ofi_copy_to_mr_iov
#4  smr_copy_from_sar                     ← prov/shm SAR reassembly
#5  smr_ep_progress
#6  ofi_cq_progress
#7  ofi_peer_cq_read
#8  efa_rdm_cq_readfrom
#9  fi_cq_read
#10 mooncake::EfaContext::pollCq
```

**Root cause:** the EFA provider's same-host **SHM** path (`FI_EFA_ENABLE_SHM_TRANSFER`, on by default) does a host `memcpy` into the destination during SAR reassembly **without honoring an `FI_HMEM_CUDA` destination's iface**, writing host memory straight into a device pointer. Reported upstream as [ofiwg/libfabric#12328](https://github.com/ofiwg/libfabric/issues/12328) — the EFA maintainers confirmed EFA+SHM is *expected* to support `FI_HMEM_CUDA`, so this is a libfabric bug. This PR is the application-side fix while that is addressed.

**Fix:** `EfaContext::tryLoopbackCopy` detects a **same-process self-loopback** and satisfies it with a local `cudaMemcpy` (host `memcpy` on non-CUDA builds) instead of issuing it over EFA, so it never reaches the broken SHM path. The same-process check compares `local_server_name` (host:rpc_port), which embeds this process's unique RPC port — a match guarantees the peer is this very process, so `source_addr` and `dest_addr` are both valid pointers in this address space. Same-host **cross-process** peers carry a different RPC port and never match, so they still go over EFA (we never `memcpy` across address spaces). The copy honors the slice opcode (WRITE: src→dst, READ: dst→src) since the two buffers are distinct; `cudaMemcpyDefault` makes it correct for host or device memory. Per the libfabric maintainers, intra-node should stay on `fabric: efa` (full protocol) rather than `efa-direct`, and a local copy is faster than either NIC loopback or the SHM path, so this short-circuit loses no performance.

Related issue: ofiwg/libfabric#12328

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other

## How Has This Been Tested?

On a p5.48xlarge (8× H100, 32 EFA, CUDA build, single libfabric):

**Unit tests — 17/17 pass:**
- `efa_transport_test` 10/10 — existing host-mem loopback tests are now routed through the new short-circuit and still pass.
- `efa_gpu_loopback_test` 3/3 (new) — reproduces the crash **without** the fix; with it, byte-accurate WRITE and READ verified by `memcmp`. Self-skips without EFA+CUDA.
- `efa_c_api_test` 4/4.

**End-to-end (real checkpoint-engine p2p + vLLM TP=8), without any env workaround:**
- Single-host, 8 ranks: all complete, **no core dump** (vs. a guaranteed SIGSEGV before the fix).
- 2-node, 16 ranks: both nodes complete, no core dump — each node's intra-node loopback is short-circuited (`loopback connection established` count drops 1→0). `FI_EFA_ENABLE_SHM_TRANSFER=0` is no longer needed.

Code formatted with `./scripts/code_format.sh` (clang-format-20).

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
