### PR TITLE
feat(store): scope S3 snapshot path by cluster_id to support multi-cl…

### DIFF
--- a/mooncake-store/include/ha/snapshot/catalog/backends/embedded/embedded_snapshot_catalog_store.h
+++ b/mooncake-store/include/ha/snapshot/catalog/backends/embedded/embedded_snapshot_catalog_store.h
@@ -10,7 +10,8 @@ namespace embedded {
 
 class EmbeddedSnapshotCatalogStore : public SnapshotCatalogStore {
    public:
-    explicit EmbeddedSnapshotCatalogStore(SnapshotObjectStore* object_store);
+    EmbeddedSnapshotCatalogStore(SnapshotObjectStore* object_store,
+                                 const std::string& cluster_id);
 
     ErrorCode Publish(const SnapshotDescriptor& snapshot) override;
 
@@ -22,8 +23,13 @@ class EmbeddedSnapshotCatalogStore : public SnapshotCatalogStore {
 
     ErrorCode Delete(const SnapshotId& snapshot_id) override;
 
+    const std::string& GetSnapshotRoot() const override {
+        return snapshot_root_;
+    }
+
    private:
     SnapshotObjectStore* object_store_;
+    std::string snapshot_root_;
 };
 
 }  // namespace embedded

--- a/mooncake-store/include/ha/snapshot/catalog/backends/redis/redis_snapshot_catalog_store.h
+++ b/mooncake-store/include/ha/snapshot/catalog/backends/redis/redis_snapshot_catalog_store.h
@@ -26,6 +26,10 @@ class RedisSnapshotCatalogStore final : public SnapshotCatalogStore {
 
     ErrorCode Delete(const SnapshotId& snapshot_id) override;
 
+    const std::string& GetSnapshotRoot() const override {
+        return snapshot_root_;
+    }
+
    private:
     static ClusterNamespace ResolveClusterNamespace(
         const ClusterNamespace& cluster_namespace);
@@ -36,6 +40,7 @@ class RedisSnapshotCatalogStore final : public SnapshotCatalogStore {
     SnapshotObjectStore* object_store_;
     std::string connstring_;
     ClusterNamespace cluster_namespace_;
+    std::string snapshot_root_;
     std::string latest_key_;
     std::string index_key_;
 };

--- a/mooncake-store/include/ha/snapshot/catalog/snapshot_catalog_store.h
+++ b/mooncake-store/include/ha/snapshot/catalog/snapshot_catalog_store.h
@@ -18,10 +18,23 @@ namespace ha {
 
 namespace snapshot_catalog_store_detail {
 
-constexpr std::string_view kSnapshotRoot = "mooncake_master_snapshot/";
+constexpr std::string_view kSnapshotRootBase = "mooncake_master_snapshot";
 constexpr std::string_view kSnapshotLatest = "latest.txt";
 constexpr std::string_view kSnapshotManifest = "manifest.txt";
 constexpr std::string_view kSnapshotDescriptor = "descriptor.txt";
+
+/// Build the per-cluster snapshot root path.
+/// When cluster_id is non-empty: "mooncake_master_snapshot/{cluster_id}/"
+/// When cluster_id is empty:     "mooncake_master_snapshot/"
+inline std::string BuildSnapshotRoot(const std::string& cluster_id) {
+    std::string root(kSnapshotRootBase);
+    root += '/';
+    if (!cluster_id.empty()) {
+        root += cluster_id;
+        root += '/';
+    }
+    return root;
+}
 
 inline bool IsAsciiDigit(char ch) {
     return std::isdigit(static_cast<unsigned char>(ch)) != 0;
@@ -59,28 +72,33 @@ inline std::string TrimAsciiWhitespace(std::string value) {
     return value.substr(first, last - first + 1);
 }
 
-inline std::string BuildSnapshotPrefix(const SnapshotId& snapshot_id) {
-    return std::string(kSnapshotRoot) + snapshot_id + "/";
+inline std::string BuildSnapshotPrefix(const std::string& snapshot_root,
+                                       const SnapshotId& snapshot_id) {
+    return snapshot_root + snapshot_id + "/";
 }
 
-inline std::string BuildManifestKey(const SnapshotId& snapshot_id) {
-    return BuildSnapshotPrefix(snapshot_id) + std::string(kSnapshotManifest);
+inline std::string BuildManifestKey(const std::string& snapshot_root,
+                                    const SnapshotId& snapshot_id) {
+    return BuildSnapshotPrefix(snapshot_root, snapshot_id) +
+           std::string(kSnapshotManifest);
 }
 
-inline std::string BuildDescriptorKey(const SnapshotId& snapshot_id) {
-    return BuildSnapshotPrefix(snapshot_id) + std::string(kSnapshotDescriptor);
+inline std::string BuildDescriptorKey(const std::string& snapshot_root,
+                                      const SnapshotId& snapshot_id) {
+    return BuildSnapshotPrefix(snapshot_root, snapshot_id) +
+           std::string(kSnapshotDescriptor);
 }
 
-inline std::string BuildLatestKey() {
-    return std::string(kSnapshotRoot) + std::string(kSnapshotLatest);
+inline std::string BuildLatestKey(const std::string& snapshot_root) {
+    return snapshot_root + std::string(kSnapshotLatest);
 }
 
 inline SnapshotDescriptor MakeSnapshotDescriptor(
-    const SnapshotId& snapshot_id) {
+    const std::string& snapshot_root, const SnapshotId& snapshot_id) {
     SnapshotDescriptor descriptor;
     descriptor.snapshot_id = snapshot_id;
-    descriptor.manifest_key = BuildManifestKey(snapshot_id);
-    descriptor.object_prefix = BuildSnapshotPrefix(snapshot_id);
+    descriptor.manifest_key = BuildManifestKey(snapshot_root, snapshot_id);
+    descriptor.object_prefix = BuildSnapshotPrefix(snapshot_root, snapshot_id);
     return descriptor;
 }
 
@@ -100,7 +118,8 @@ inline std::string SerializeSnapshotDescriptor(
 }
 
 inline tl::expected<SnapshotDescriptor, ErrorCode>
-DeserializeSnapshotDescriptor(const SnapshotId& snapshot_id,
+DeserializeSnapshotDescriptor(const std::string& snapshot_root,
+                              const SnapshotId& snapshot_id,
                               std::string_view payload) {
     const auto first = payload.find('|');
     const auto second = first == std::string_view::npos
@@ -110,7 +129,8 @@ DeserializeSnapshotDescriptor(const SnapshotId& snapshot_id,
         return tl::make_unexpected(ErrorCode::DESERIALIZE_FAIL);
     }
 
-    SnapshotDescriptor descriptor = MakeSnapshotDescriptor(snapshot_id);
+    SnapshotDescriptor descriptor =
+        MakeSnapshotDescriptor(snapshot_root, snapshot_id);
     if (!ParseDecimal(payload.substr(0, first), descriptor.last_included_seq) ||
         !ParseDecimal(payload.substr(first + 1, second - first - 1),
                       descriptor.producer_view_version) ||
@@ -135,6 +155,9 @@ class SnapshotCatalogStore {
         size_t limit) = 0;
 
     virtual ErrorCode Delete(const SnapshotId& snapshot_id) = 0;
+
+    /// Returns the per-cluster snapshot root path used by this catalog store.
+    virtual const std::string& GetSnapshotRoot() const = 0;
 };
 
 }  // namespace ha

--- a/mooncake-store/src/ha/snapshot/catalog/backends/embedded/embedded_snapshot_catalog_store.cpp
+++ b/mooncake-store/src/ha/snapshot/catalog/backends/embedded/embedded_snapshot_catalog_store.cpp
@@ -19,10 +19,12 @@ ErrorCode ValidateObjectStore(SnapshotObjectStore* object_store) {
 }
 
 tl::expected<SnapshotDescriptor, ErrorCode> LoadSnapshotDescriptor(
-    SnapshotObjectStore* object_store, const SnapshotId& snapshot_id) {
+    SnapshotObjectStore* object_store, const std::string& snapshot_root,
+    const SnapshotId& snapshot_id) {
     std::string descriptor_payload;
     auto get_result = object_store->DownloadString(
-        snapshot_catalog_store_detail::BuildDescriptorKey(snapshot_id),
+        snapshot_catalog_store_detail::BuildDescriptorKey(snapshot_root,
+                                                          snapshot_id),
         descriptor_payload);
     if (!get_result) {
         return tl::make_unexpected(ErrorCode::PERSISTENT_FAIL);
@@ -30,7 +32,7 @@ tl::expected<SnapshotDescriptor, ErrorCode> LoadSnapshotDescriptor(
 
     auto descriptor =
         snapshot_catalog_store_detail::DeserializeSnapshotDescriptor(
-            snapshot_id, descriptor_payload);
+            snapshot_root, snapshot_id, descriptor_payload);
     if (!descriptor) {
         return tl::make_unexpected(descriptor.error());
     }
@@ -40,8 +42,10 @@ tl::expected<SnapshotDescriptor, ErrorCode> LoadSnapshotDescriptor(
 }  // namespace
 
 EmbeddedSnapshotCatalogStore::EmbeddedSnapshotCatalogStore(
-    SnapshotObjectStore* object_store)
-    : object_store_(object_store) {}
+    SnapshotObjectStore* object_store, const std::string& cluster_id)
+    : object_store_(object_store),
+      snapshot_root_(
+          snapshot_catalog_store_detail::BuildSnapshotRoot(cluster_id)) {}
 
 ErrorCode EmbeddedSnapshotCatalogStore::Publish(
     const SnapshotDescriptor& snapshot) {
@@ -55,14 +59,16 @@ ErrorCode EmbeddedSnapshotCatalogStore::Publish(
     }
 
     auto descriptor_result = object_store_->UploadString(
-        snapshot_catalog_store_detail::BuildDescriptorKey(snapshot.snapshot_id),
+        snapshot_catalog_store_detail::BuildDescriptorKey(snapshot_root_,
+                                                          snapshot.snapshot_id),
         snapshot_catalog_store_detail::SerializeSnapshotDescriptor(snapshot));
     if (!descriptor_result) {
         return ErrorCode::PERSISTENT_FAIL;
     }
 
     auto publish_result = object_store_->UploadString(
-        snapshot_catalog_store_detail::BuildLatestKey(), snapshot.snapshot_id);
+        snapshot_catalog_store_detail::BuildLatestKey(snapshot_root_),
+        snapshot.snapshot_id);
     if (!publish_result) {
         return ErrorCode::PERSISTENT_FAIL;
     }
@@ -79,7 +85,8 @@ EmbeddedSnapshotCatalogStore::GetLatest() {
 
     std::string latest_snapshot_id;
     auto get_result = object_store_->DownloadString(
-        snapshot_catalog_store_detail::BuildLatestKey(), latest_snapshot_id);
+        snapshot_catalog_store_detail::BuildLatestKey(snapshot_root_),
+        latest_snapshot_id);
     if (!get_result) {
         if (object_store_->IsNotFoundError(get_result.error())) {
             return std::optional<SnapshotDescriptor>();
@@ -98,7 +105,8 @@ EmbeddedSnapshotCatalogStore::GetLatest() {
 
     std::string descriptor_payload;
     auto descriptor_result = object_store_->DownloadString(
-        snapshot_catalog_store_detail::BuildDescriptorKey(latest_snapshot_id),
+        snapshot_catalog_store_detail::BuildDescriptorKey(snapshot_root_,
+                                                          latest_snapshot_id),
         descriptor_payload);
     if (!descriptor_result) {
         return tl::make_unexpected(ErrorCode::PERSISTENT_FAIL);
@@ -106,7 +114,7 @@ EmbeddedSnapshotCatalogStore::GetLatest() {
 
     auto descriptor =
         snapshot_catalog_store_detail::DeserializeSnapshotDescriptor(
-            latest_snapshot_id, descriptor_payload);
+            snapshot_root_, latest_snapshot_id, descriptor_payload);
     if (!descriptor) {
         return tl::make_unexpected(descriptor.error());
     }
@@ -121,22 +129,20 @@ EmbeddedSnapshotCatalogStore::List(size_t limit) {
     }
 
     std::vector<std::string> object_keys;
-    auto list_result = object_store_->ListObjectsWithPrefix(
-        std::string(snapshot_catalog_store_detail::kSnapshotRoot), object_keys);
+    auto list_result =
+        object_store_->ListObjectsWithPrefix(snapshot_root_, object_keys);
     if (!list_result) {
         return tl::make_unexpected(ErrorCode::PERSISTENT_FAIL);
     }
 
     std::set<SnapshotId, std::greater<>> snapshot_ids;
     for (const auto& object_key : object_keys) {
-        if (object_key.size() <=
-            snapshot_catalog_store_detail::kSnapshotRoot.size()) {
+        if (object_key.size() <= snapshot_root_.size()) {
             continue;
         }
 
         std::string_view suffix(object_key);
-        suffix.remove_prefix(
-            snapshot_catalog_store_detail::kSnapshotRoot.size());
+        suffix.remove_prefix(snapshot_root_.size());
         const size_t slash_pos = suffix.find('/');
         if (slash_pos == std::string_view::npos) {
             continue;
@@ -163,7 +169,8 @@ EmbeddedSnapshotCatalogStore::List(size_t limit) {
         if (limit != 0 && snapshots.size() >= limit) {
             break;
         }
-        auto descriptor = LoadSnapshotDescriptor(object_store_, snapshot_id);
+        auto descriptor =
+            LoadSnapshotDescriptor(object_store_, snapshot_root_, snapshot_id);
         if (!descriptor) {
             LOG(WARNING) << "Skipping unreadable embedded snapshot descriptor, "
                          << "snapshot_id=" << snapshot_id
@@ -209,7 +216,8 @@ ErrorCode EmbeddedSnapshotCatalogStore::Delete(const SnapshotId& snapshot_id) {
     }
 
     auto delete_result = object_store_->DeleteObjectsWithPrefix(
-        snapshot_catalog_store_detail::BuildSnapshotPrefix(snapshot_id));
+        snapshot_catalog_store_detail::BuildSnapshotPrefix(snapshot_root_,
+                                                           snapshot_id));
     if (!delete_result) {
         return ErrorCode::PERSISTENT_FAIL;
     }
@@ -220,7 +228,7 @@ ErrorCode EmbeddedSnapshotCatalogStore::Delete(const SnapshotId& snapshot_id) {
 
     if (next_latest.has_value()) {
         auto publish_result = object_store_->UploadString(
-            snapshot_catalog_store_detail::BuildLatestKey(),
+            snapshot_catalog_store_detail::BuildLatestKey(snapshot_root_),
             next_latest->snapshot_id);
         if (!publish_result) {
             return ErrorCode::PERSISTENT_FAIL;
@@ -229,7 +237,7 @@ ErrorCode EmbeddedSnapshotCatalogStore::Delete(const SnapshotId& snapshot_id) {
     }
 
     auto clear_result = object_store_->DeleteObjectsWithPrefix(
-        snapshot_catalog_store_detail::BuildLatestKey());
+        snapshot_catalog_store_detail::BuildLatestKey(snapshot_root_));
     if (!clear_result) {
         return ErrorCode::PERSISTENT_FAIL;
     }

--- a/mooncake-store/src/ha/snapshot/catalog/backends/redis/redis_snapshot_catalog_store.cpp
+++ b/mooncake-store/src/ha/snapshot/catalog/backends/redis/redis_snapshot_catalog_store.cpp
@@ -51,14 +51,16 @@ tl::expected<long long, ErrorCode> ParseSnapshotScore(
 }
 
 tl::expected<SnapshotDescriptor, ErrorCode> LoadSnapshotDescriptor(
-    SnapshotObjectStore* object_store, const SnapshotId& snapshot_id) {
+    SnapshotObjectStore* object_store, const std::string& snapshot_root,
+    const SnapshotId& snapshot_id) {
     if (object_store == nullptr) {
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
 
     std::string descriptor_payload;
     auto get_result = object_store->DownloadString(
-        snapshot_catalog_store_detail::BuildDescriptorKey(snapshot_id),
+        snapshot_catalog_store_detail::BuildDescriptorKey(snapshot_root,
+                                                          snapshot_id),
         descriptor_payload);
     if (!get_result) {
         return tl::make_unexpected(ErrorCode::PERSISTENT_FAIL);
@@ -66,7 +68,7 @@ tl::expected<SnapshotDescriptor, ErrorCode> LoadSnapshotDescriptor(
 
     auto descriptor =
         snapshot_catalog_store_detail::DeserializeSnapshotDescriptor(
-            snapshot_id, descriptor_payload);
+            snapshot_root, snapshot_id, descriptor_payload);
     if (!descriptor) {
         return tl::make_unexpected(descriptor.error());
     }
@@ -102,6 +104,8 @@ RedisSnapshotCatalogStore::RedisSnapshotCatalogStore(
     : object_store_(object_store),
       connstring_(std::move(connstring)),
       cluster_namespace_(ResolveClusterNamespace(cluster_namespace)),
+      snapshot_root_(
+          snapshot_catalog_store_detail::BuildSnapshotRoot(cluster_namespace_)),
       latest_key_(BuildLatestKey(cluster_namespace_)),
       index_key_(BuildIndexKey(cluster_namespace_)) {}
 
@@ -155,7 +159,8 @@ ErrorCode RedisSnapshotCatalogStore::Publish(
     }
 
     auto descriptor_result = object_store_->UploadString(
-        snapshot_catalog_store_detail::BuildDescriptorKey(snapshot.snapshot_id),
+        snapshot_catalog_store_detail::BuildDescriptorKey(snapshot_root_,
+                                                          snapshot.snapshot_id),
         snapshot_catalog_store_detail::SerializeSnapshotDescriptor(snapshot));
     if (!descriptor_result) {
         return ErrorCode::PERSISTENT_FAIL;
@@ -218,7 +223,8 @@ RedisSnapshotCatalogStore::GetLatest() {
 
     std::string descriptor_payload;
     auto descriptor_result = object_store_->DownloadString(
-        snapshot_catalog_store_detail::BuildDescriptorKey(latest_snapshot_id),
+        snapshot_catalog_store_detail::BuildDescriptorKey(snapshot_root_,
+                                                          latest_snapshot_id),
         descriptor_payload);
     if (!descriptor_result) {
         return tl::make_unexpected(ErrorCode::PERSISTENT_FAIL);
@@ -226,7 +232,7 @@ RedisSnapshotCatalogStore::GetLatest() {
 
     auto descriptor =
         snapshot_catalog_store_detail::DeserializeSnapshotDescriptor(
-            latest_snapshot_id, descriptor_payload);
+            snapshot_root_, latest_snapshot_id, descriptor_payload);
     if (!descriptor) {
         return tl::make_unexpected(descriptor.error());
     }
@@ -272,7 +278,8 @@ RedisSnapshotCatalogStore::List(size_t limit) {
             continue;
         }
 
-        auto descriptor = LoadSnapshotDescriptor(object_store_, snapshot_id);
+        auto descriptor =
+            LoadSnapshotDescriptor(object_store_, snapshot_root_, snapshot_id);
         if (!descriptor) {
             LOG(WARNING) << "Skipping unreadable Redis snapshot descriptor, "
                          << "snapshot_id=" << snapshot_id
@@ -305,7 +312,8 @@ ErrorCode RedisSnapshotCatalogStore::Delete(const SnapshotId& snapshot_id) {
     }
 
     auto delete_result = object_store_->DeleteObjectsWithPrefix(
-        snapshot_catalog_store_detail::BuildSnapshotPrefix(snapshot_id));
+        snapshot_catalog_store_detail::BuildSnapshotPrefix(snapshot_root_,
+                                                           snapshot_id));
     if (!delete_result) {
         LOG(ERROR) << "Failed to delete snapshot objects after Redis catalog "
                       "update, snapshot_id="

--- a/mooncake-store/src/ha/snapshot/catalog_backed_snapshot_provider.cpp
+++ b/mooncake-store/src/ha/snapshot/catalog_backed_snapshot_provider.cpp
@@ -335,7 +335,7 @@ class CatalogBackedSnapshotProvider final : public SnapshotProvider {
             case SnapshotCatalogBackendKind::kEmbedded:
                 catalog_store_ = std::make_unique<
                     ha::backends::embedded::EmbeddedSnapshotCatalogStore>(
-                    object_store_.get());
+                    object_store_.get(), cluster_id_);
                 break;
             case SnapshotCatalogBackendKind::kRedis: {
 #ifndef STORE_USE_REDIS
@@ -385,7 +385,7 @@ class CatalogBackedSnapshotProvider final : public SnapshotProvider {
         if (object_prefix.empty()) {
             object_prefix =
                 ha::snapshot_catalog_store_detail::BuildSnapshotPrefix(
-                    descriptor.snapshot_id);
+                    catalog_store_->GetSnapshotRoot(), descriptor.snapshot_id);
         }
 
         std::string manifest_path = descriptor.manifest_key;

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -43,7 +43,6 @@ static const std::string SNAPSHOT_SEGMENTS_FILE = "segments";
 static const std::string SNAPSHOT_TASK_MANAGER_FILE = "task_manager";
 static const std::string SNAPSHOT_MANIFEST_FILE = "manifest.txt";
 static const std::string SNAPSHOT_LATEST_FILE = "latest.txt";
-static const std::string SNAPSHOT_ROOT = "mooncake_master_snapshot";
 static const std::string SNAPSHOT_BACKUP_SAVE_DIR =
     "mooncake_snapshot_save_backup";
 static const std::string SNAPSHOT_BACKUP_RESTORE_DIR =
@@ -357,7 +356,7 @@ MasterService::CreateSnapshotCatalogStore() {
         case SnapshotCatalogBackendKind::kEmbedded:
             return std::make_unique<
                 ha::backends::embedded::EmbeddedSnapshotCatalogStore>(
-                snapshot_object_store_.get());
+                snapshot_object_store_.get(), cluster_id_);
         case SnapshotCatalogBackendKind::kRedis: {
 #ifndef STORE_USE_REDIS
             throw std::invalid_argument(
@@ -3940,7 +3939,9 @@ void MasterService::SnapshotThreadFunc() {
             continue;
         }
 
-        const std::string path_prefix = SNAPSHOT_ROOT + "/" + snapshot_id + "/";
+        const std::string& snapshot_root =
+            snapshot_catalog_store_->GetSnapshotRoot();
+        const std::string path_prefix = snapshot_root + snapshot_id + "/";
         const std::string manifest_path = path_prefix + SNAPSHOT_MANIFEST_FILE;
         auto descriptor =
             BuildSnapshotDescriptor(snapshot_id, manifest_path, path_prefix);
@@ -4248,8 +4249,10 @@ MasterService::BuildSnapshotDescriptor(const std::string& snapshot_id,
         return tl::make_unexpected(sequence_id.error());
     }
 
-    auto descriptor =
-        ha::snapshot_catalog_store_detail::MakeSnapshotDescriptor(snapshot_id);
+    const std::string& snapshot_root =
+        snapshot_catalog_store_->GetSnapshotRoot();
+    auto descriptor = ha::snapshot_catalog_store_detail::MakeSnapshotDescriptor(
+        snapshot_root, snapshot_id);
     descriptor.last_included_seq = sequence_id.value();
     descriptor.producer_view_version = view_version_;
     descriptor.manifest_key = manifest_path;
@@ -4260,7 +4263,9 @@ MasterService::BuildSnapshotDescriptor(const std::string& snapshot_id,
 
 tl::expected<void, SerializationError> MasterService::PersistState(
     const std::string& snapshot_id) {
-    const std::string path_prefix = SNAPSHOT_ROOT + "/" + snapshot_id + "/";
+    const std::string& snapshot_root =
+        snapshot_catalog_store_->GetSnapshotRoot();
+    const std::string path_prefix = snapshot_root + snapshot_id + "/";
     const std::string manifest_path = path_prefix + SNAPSHOT_MANIFEST_FILE;
     auto descriptor =
         BuildSnapshotDescriptor(snapshot_id, manifest_path, path_prefix);
@@ -4428,7 +4433,8 @@ tl::expected<void, SerializationError> MasterService::PersistState(
         }
 
         // Publish snapshot catalog entry and advance the latest marker.
-        std::string latest_path = SNAPSHOT_ROOT + "/" + SNAPSHOT_LATEST_FILE;
+        std::string latest_path =
+            snapshot_catalog_store->GetSnapshotRoot() + SNAPSHOT_LATEST_FILE;
         std::string latest_content = snapshot_id;
 
         auto publish_result = snapshot_catalog_store->Publish(descriptor);
@@ -4658,7 +4664,8 @@ bool MasterService::TryRestoreStateFromSnapshot(
     const std::string& state_id = snapshot.snapshot_id;
     std::string path_prefix = snapshot.object_prefix;
     if (path_prefix.empty()) {
-        path_prefix = SNAPSHOT_ROOT + "/" + state_id + "/";
+        path_prefix =
+            snapshot_catalog_store_->GetSnapshotRoot() + state_id + "/";
     }
 
     std::string manifest_path = snapshot.manifest_key;

--- a/mooncake-store/tests/ha/snapshot/catalog/backends/embedded/embedded_snapshot_catalog_store_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/catalog/backends/embedded/embedded_snapshot_catalog_store_test.cpp
@@ -109,7 +109,7 @@ class EmbeddedSnapshotCatalogStoreTest : public ::testing::Test {
     }
 
     FakeSnapshotObjectStore backend_;
-    ha::backends::embedded::EmbeddedSnapshotCatalogStore store_{&backend_};
+    ha::backends::embedded::EmbeddedSnapshotCatalogStore store_{&backend_, ""};
 };
 
 TEST_F(EmbeddedSnapshotCatalogStoreTest, PublishAndGetLatestRoundTrip) {
@@ -205,7 +205,7 @@ TEST_F(EmbeddedSnapshotCatalogStoreTest,
 
 TEST(EmbeddedSnapshotCatalogStoreStandaloneTest,
      ListReturnsInvalidParamsWhenObjectStoreMissing) {
-    ha::backends::embedded::EmbeddedSnapshotCatalogStore store(nullptr);
+    ha::backends::embedded::EmbeddedSnapshotCatalogStore store(nullptr, "");
 
     auto snapshots = store.List(0);
     ASSERT_FALSE(snapshots.has_value());

--- a/mooncake-store/tests/ha/snapshot/catalog/backends/redis/redis_snapshot_catalog_store_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/catalog/backends/redis/redis_snapshot_catalog_store_test.cpp
@@ -78,12 +78,12 @@ class FakeObjectStore final : public SnapshotObjectStore {
     std::unordered_map<std::string, std::string> objects_;
 };
 
-ha::SnapshotDescriptor MakeDescriptor(const std::string& snapshot_id) {
+ha::SnapshotDescriptor MakeDescriptor(const std::string& snapshot_root,
+                                      const std::string& snapshot_id) {
     ha::SnapshotDescriptor descriptor;
     descriptor.snapshot_id = snapshot_id;
-    descriptor.manifest_key =
-        "mooncake_master_snapshot/" + snapshot_id + "/manifest.txt";
-    descriptor.object_prefix = "mooncake_master_snapshot/" + snapshot_id + "/";
+    descriptor.manifest_key = snapshot_root + snapshot_id + "/manifest.txt";
+    descriptor.object_prefix = snapshot_root + snapshot_id + "/";
     descriptor.last_included_seq = 42;
     descriptor.producer_view_version = 7;
     descriptor.created_at_ms = 1700000000000;
@@ -122,6 +122,15 @@ class RedisSnapshotCatalogStoreTest : public ::testing::Test {
         ASSERT_NE(reply->type, REDIS_REPLY_ERROR);
     }
 
+    ha::SnapshotDescriptor MakeDesc(const std::string& snapshot_id) {
+        return MakeDescriptor(store_->GetSnapshotRoot(), snapshot_id);
+    }
+
+    std::string DescriptorKey(const std::string& snapshot_id) {
+        return ha::snapshot_catalog_store_detail::BuildDescriptorKey(
+            store_->GetSnapshotRoot(), snapshot_id);
+    }
+
     FakeObjectStore object_store_;
     std::string cluster_namespace_;
     std::unique_ptr<ha::backends::redis::RedisSnapshotCatalogStore> store_;
@@ -134,17 +143,15 @@ TEST_F(RedisSnapshotCatalogStoreTest, GetLatestReturnsEmptyWhenCatalogMissing) {
 }
 
 TEST_F(RedisSnapshotCatalogStoreTest, PublishListAndGetLatestRoundTrip) {
-    ASSERT_EQ(store_->Publish(MakeDescriptor("20240301_120000_001")),
-              ErrorCode::OK);
-    ASSERT_EQ(store_->Publish(MakeDescriptor("20240302_120000_001")),
-              ErrorCode::OK);
+    ASSERT_EQ(store_->Publish(MakeDesc("20240301_120000_001")), ErrorCode::OK);
+    ASSERT_EQ(store_->Publish(MakeDesc("20240302_120000_001")), ErrorCode::OK);
 
     auto latest = store_->GetLatest();
     ASSERT_TRUE(latest.has_value());
     ASSERT_TRUE(latest->has_value());
     EXPECT_EQ(latest->value().snapshot_id, "20240302_120000_001");
     EXPECT_EQ(latest->value().manifest_key,
-              "mooncake_master_snapshot/20240302_120000_001/manifest.txt");
+              store_->GetSnapshotRoot() + "20240302_120000_001/manifest.txt");
     EXPECT_EQ(latest->value().last_included_seq, 42u);
     EXPECT_EQ(latest->value().producer_view_version, 7u);
     EXPECT_EQ(latest->value().created_at_ms, 1700000000000);
@@ -161,10 +168,9 @@ TEST_F(RedisSnapshotCatalogStoreTest, PublishListAndGetLatestRoundTrip) {
 TEST_F(RedisSnapshotCatalogStoreTest,
        GetLatestReturnsErrorWhenDescriptorMissing) {
     const std::string snapshot_id = "20240302_120000_001";
-    ASSERT_EQ(store_->Publish(MakeDescriptor(snapshot_id)), ErrorCode::OK);
+    ASSERT_EQ(store_->Publish(MakeDesc(snapshot_id)), ErrorCode::OK);
 
-    object_store_.objects_.erase(
-        ha::snapshot_catalog_store_detail::BuildDescriptorKey(snapshot_id));
+    object_store_.objects_.erase(DescriptorKey(snapshot_id));
 
     auto latest = store_->GetLatest();
     ASSERT_FALSE(latest.has_value());
@@ -173,10 +179,9 @@ TEST_F(RedisSnapshotCatalogStoreTest,
 
 TEST_F(RedisSnapshotCatalogStoreTest, ListSkipsSnapshotsWhenDescriptorMissing) {
     const std::string snapshot_id = "20240302_120000_001";
-    ASSERT_EQ(store_->Publish(MakeDescriptor(snapshot_id)), ErrorCode::OK);
+    ASSERT_EQ(store_->Publish(MakeDesc(snapshot_id)), ErrorCode::OK);
 
-    object_store_.objects_.erase(
-        ha::snapshot_catalog_store_detail::BuildDescriptorKey(snapshot_id));
+    object_store_.objects_.erase(DescriptorKey(snapshot_id));
 
     auto snapshots = store_->List(0);
     ASSERT_TRUE(snapshots.has_value());
@@ -195,14 +200,10 @@ TEST(RedisSnapshotCatalogStoreStandaloneTest,
 
 TEST_F(RedisSnapshotCatalogStoreTest,
        ListSkipsUnreadableSnapshotsAndKeepsHealthyEntries) {
-    ASSERT_EQ(store_->Publish(MakeDescriptor("20240301_120000_001")),
-              ErrorCode::OK);
-    ASSERT_EQ(store_->Publish(MakeDescriptor("20240302_120000_001")),
-              ErrorCode::OK);
+    ASSERT_EQ(store_->Publish(MakeDesc("20240301_120000_001")), ErrorCode::OK);
+    ASSERT_EQ(store_->Publish(MakeDesc("20240302_120000_001")), ErrorCode::OK);
 
-    object_store_.objects_.erase(
-        ha::snapshot_catalog_store_detail::BuildDescriptorKey(
-            "20240302_120000_001"));
+    object_store_.objects_.erase(DescriptorKey("20240302_120000_001"));
 
     auto snapshots = store_->List(0);
     ASSERT_TRUE(snapshots.has_value());
@@ -212,10 +213,8 @@ TEST_F(RedisSnapshotCatalogStoreTest,
 
 TEST_F(RedisSnapshotCatalogStoreTest,
        DeleteUpdatesLatestAndDeletesPayloadPrefix) {
-    ASSERT_EQ(store_->Publish(MakeDescriptor("20240301_120000_001")),
-              ErrorCode::OK);
-    ASSERT_EQ(store_->Publish(MakeDescriptor("20240302_120000_001")),
-              ErrorCode::OK);
+    ASSERT_EQ(store_->Publish(MakeDesc("20240301_120000_001")), ErrorCode::OK);
+    ASSERT_EQ(store_->Publish(MakeDesc("20240302_120000_001")), ErrorCode::OK);
 
     ASSERT_EQ(store_->Delete("20240302_120000_001"), ErrorCode::OK);
 

--- a/mooncake-store/tests/ha/snapshot/catalog_backed_snapshot_provider_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/catalog_backed_snapshot_provider_test.cpp
@@ -44,7 +44,7 @@ class CatalogBackedSnapshotProviderTest
             GetParam(), object_store_.get(), cluster_id_, FLAGS_redis_endpoint);
         ASSERT_NE(catalog_store_, nullptr);
 
-        descriptor_ = MakeTestSnapshotDescriptor();
+        descriptor_ = MakeTestSnapshotDescriptor(cluster_id_);
     }
 
     void TearDown() override {

--- a/mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot_base.h
+++ b/mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot_base.h
@@ -188,7 +188,10 @@ class MasterServiceSnapshotTestBase : public ::testing::Test {
 
     // Get msgpack snapshot directory path
     std::string GetSnapshotDir(const std::string& snapshot_id) const {
-        return tmp_dir() + "/mooncake_master_snapshot/" + snapshot_id + "/";
+        return tmp_dir() + "/" +
+               ha::snapshot_catalog_store_detail::BuildSnapshotRoot(
+                   DEFAULT_CLUSTER_ID) +
+               snapshot_id + "/";
     }
 
     // Get backup directory path

--- a/mooncake-store/tests/ha/snapshot/snapshot_child_process_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/snapshot_child_process_test.cpp
@@ -34,6 +34,13 @@ class SnapshotChildProcessTest : public ::testing::Test {
    protected:
     const std::string& tmp_dir() const { return tmp_dir_; }
 
+    // Returns the snapshot root path used by the default service (with default
+    // cluster_id).
+    std::string default_snapshot_root() const {
+        return ha::snapshot_catalog_store_detail::BuildSnapshotRoot(
+            DEFAULT_CLUSTER_ID);
+    }
+
     std::unique_ptr<MasterService> service_;
 
     static constexpr const char* kEnvSnapshotLocalPath =
@@ -298,20 +305,22 @@ TEST_F(SnapshotChildProcessTest, CleanupOldSnapshot_KeepsRecentDeletesOld) {
         "20240101_000000_000", "20240102_000000_000", "20240103_000000_000",
         "20240104_000000_000", "20240105_000000_000"};
 
+    const std::string snapshot_root = default_snapshot_root();
     for (const auto& id : snapshot_ids) {
-        std::string key = "mooncake_master_snapshot/" + id + "/metadata";
+        std::string key = snapshot_root + id + "/metadata";
         backend->UploadString(key, "dummy_metadata");
-        std::string manifest_key =
-            "mooncake_master_snapshot/" + id + "/manifest.txt";
+        std::string manifest_key = snapshot_root + id + "/manifest.txt";
         backend->UploadString(manifest_key, "messagepack|1.0.0|" + id);
 
         auto descriptor =
-            ha::snapshot_catalog_store_detail::MakeSnapshotDescriptor(id);
+            ha::snapshot_catalog_store_detail::MakeSnapshotDescriptor(
+                snapshot_root, id);
         auto descriptor_payload =
             ha::snapshot_catalog_store_detail::SerializeSnapshotDescriptor(
                 descriptor);
         auto descriptor_key =
-            ha::snapshot_catalog_store_detail::BuildDescriptorKey(id);
+            ha::snapshot_catalog_store_detail::BuildDescriptorKey(snapshot_root,
+                                                                  id);
         backend->UploadString(descriptor_key, descriptor_payload);
     }
 
@@ -320,7 +329,7 @@ TEST_F(SnapshotChildProcessTest, CleanupOldSnapshot_KeepsRecentDeletesOld) {
 
     // Verify: list remaining objects
     std::vector<std::string> remaining;
-    backend->ListObjectsWithPrefix("mooncake_master_snapshot/", remaining);
+    backend->ListObjectsWithPrefix(snapshot_root, remaining);
 
     // Only the 2 newest (20240104, 20240105) should remain
     for (const auto& key : remaining) {
@@ -370,7 +379,7 @@ TEST_F(SnapshotChildProcessTest, AutoSnapshot_GeneratesFiles) {
 
     // Check if latest.txt was generated
     std::string latest_path =
-        tmp_dir() + "/mooncake_master_snapshot/latest.txt";
+        tmp_dir() + "/" + default_snapshot_root() + "latest.txt";
     bool found = fs::exists(latest_path);
 
     // Destroy service to stop snapshot thread before assertions
@@ -403,9 +412,9 @@ TEST_F(SnapshotChildProcessTest, PersistState_PublishesSnapshotDescriptor) {
 
     EXPECT_EQ(latest->value().snapshot_id, snapshot_id);
     EXPECT_EQ(latest->value().manifest_key,
-              "mooncake_master_snapshot/" + snapshot_id + "/manifest.txt");
+              default_snapshot_root() + snapshot_id + "/manifest.txt");
     EXPECT_EQ(latest->value().object_prefix,
-              "mooncake_master_snapshot/" + snapshot_id + "/");
+              default_snapshot_root() + snapshot_id + "/");
     EXPECT_EQ(latest->value().last_included_seq, 0u);
     EXPECT_EQ(latest->value().producer_view_version, kViewVersion);
     const auto created_at_ms = latest->value().created_at_ms;
@@ -417,13 +426,11 @@ TEST_F(SnapshotChildProcessTest, PersistState_UsesFrozenSnapshotDescriptor) {
     const std::string snapshot_id = "20240601_120000_124";
     CreateDefaultService();
 
-    auto descriptor =
-        ha::snapshot_catalog_store_detail::MakeSnapshotDescriptor(snapshot_id);
+    const std::string snapshot_root = default_snapshot_root();
+    auto descriptor = ha::snapshot_catalog_store_detail::MakeSnapshotDescriptor(
+        snapshot_root, snapshot_id);
     descriptor.last_included_seq = 123;
     descriptor.producer_view_version = 41;
-    descriptor.manifest_key =
-        "mooncake_master_snapshot/" + snapshot_id + "/manifest.txt";
-    descriptor.object_prefix = "mooncake_master_snapshot/" + snapshot_id + "/";
     descriptor.created_at_ms = 1717243200123;
 
     auto persist_result = CallPersistState(descriptor);
@@ -739,8 +746,8 @@ TEST_F(SnapshotChildProcessTest,
         << persist_result.error().message;
 
     const fs::path corrupted_metadata = fs::path(tmp_dir()) /
-                                        "mooncake_master_snapshot" /
-                                        snapshot_id2 / "metadata";
+                                        default_snapshot_root() / snapshot_id2 /
+                                        "metadata";
     std::ofstream corrupt_stream(corrupted_metadata, std::ios::binary);
     ASSERT_TRUE(corrupt_stream.is_open())
         << "Failed to corrupt latest snapshot metadata";

--- a/mooncake-store/tests/ha/snapshot/snapshot_test_utils.h
+++ b/mooncake-store/tests/ha/snapshot/snapshot_test_utils.h
@@ -249,11 +249,13 @@ inline std::vector<uint8_t> BuildMetadataPayloadWithDeclaredReplicaCount(
 }
 
 inline ha::SnapshotDescriptor MakeTestSnapshotDescriptor(
+    const std::string& cluster_id = "",
     std::string_view snapshot_id = kDefaultTestSnapshotId,
     uint64_t last_included_seq = kDefaultTestSnapshotSeq,
     uint64_t producer_view_version = kDefaultTestProducerViewVersion,
     int64_t created_at_ms = kDefaultTestCreatedAtMs) {
     auto descriptor = ha::snapshot_catalog_store_detail::MakeSnapshotDescriptor(
+        ha::snapshot_catalog_store_detail::BuildSnapshotRoot(cluster_id),
         std::string(snapshot_id));
     descriptor.last_included_seq = last_included_seq;
     descriptor.producer_view_version = producer_view_version;
@@ -280,7 +282,8 @@ inline std::unique_ptr<ha::SnapshotCatalogStore> CreateCatalogStoreForTest(
     const std::string& cluster_id, const std::string& redis_endpoint) {
     if (param.catalog_store_type == "embedded") {
         return std::make_unique<
-            ha::backends::embedded::EmbeddedSnapshotCatalogStore>(object_store);
+            ha::backends::embedded::EmbeddedSnapshotCatalogStore>(object_store,
+                                                                  cluster_id);
     }
 
 #ifdef STORE_USE_REDIS

--- a/mooncake-store/tests/ha/standby/hot_standby_snapshot_bootstrap_test.cpp
+++ b/mooncake-store/tests/ha/standby/hot_standby_snapshot_bootstrap_test.cpp
@@ -47,7 +47,7 @@ class HotStandbySnapshotBootstrapTest
             GetParam(), object_store_.get(), cluster_id_, FLAGS_redis_endpoint);
         ASSERT_NE(catalog_store_, nullptr);
 
-        descriptor_ = MakeTestSnapshotDescriptor();
+        descriptor_ = MakeTestSnapshotDescriptor(cluster_id_);
     }
 
     void TearDown() override {


### PR DESCRIPTION
## Description

Previously, all clusters sharing a single S3 bucket used the same hardcoded path prefix `"mooncake_master_snapshot"` for snapshots. When multiple Mooncake Store clusters point to the same bucket, their snapshot files would collide, causing data corruption or restore failures.

This PR introduces `MasterService::GetSnapshotRoot()` which returns `"mooncake_master_snapshot/{cluster_id}"` as the S3 path prefix, scoping each cluster's snapshots into its own directory. This allows multiple independent clusters to safely share one S3 bucket without path conflicts.

Changes:
- Add `GetSnapshotRoot()` helper method to `MasterService`
- Remove the static `SNAPSHOT_ROOT` constant
- Replace all usages of `SNAPSHOT_ROOT` with `GetSnapshotRoot()`

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

Verified that when two clusters (with different `cluster_id` values) share the same S3 bucket, their snapshots are stored under separate prefixes (`mooncake_master_snapshot/cluster_a/` and `mooncake_master_snapshot/cluster_b/`), with no path collision during save and restore operations.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
