### PR TITLE
fix(ci): move sccache --show-stats to after build steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,10 +98,6 @@ jobs:
           core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
           core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
-    - name: Run sccache stat for check
-      shell: bash
-      run: ${SCCACHE_PATH} --show-stats
-
     - name: Configure project with coverage support
       run: |
         sudo apt update -y
@@ -117,6 +113,10 @@ jobs:
         cmake --build .
         sudo cmake --install .
       shell: bash
+
+    - name: Run sccache stat for check
+      shell: bash
+      run: ${SCCACHE_PATH} --show-stats
 
     - name: Build nvlink_allocator.so
       run: |
@@ -531,10 +531,6 @@ jobs:
           core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
           core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
-    - name: Run sccache stat for check
-      shell: bash
-      run: ${SCCACHE_PATH} --show-stats
-
     - name: Install dependencies
       run: |
         sudo apt update -y
@@ -654,6 +650,10 @@ jobs:
         export LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LIBRARY_PATH
         bash build.sh ../../build/mooncake-transfer-engine/nvlink-allocator/
       shell: bash
+
+    - name: Run sccache stat for check
+      shell: bash
+      run: ${SCCACHE_PATH} --show-stats
 
     - name: Generate Python version tag
       id: generate_tag_flags

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,10 +114,6 @@ jobs:
         sudo cmake --install .
       shell: bash
 
-    - name: Run sccache stat for check
-      shell: bash
-      run: ${SCCACHE_PATH} --show-stats
-
     - name: Build nvlink_allocator.so
       run: |
         mkdir -p build/mooncake-transfer-engine/nvlink-allocator
@@ -125,6 +121,10 @@ jobs:
         export LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LIBRARY_PATH
         bash build.sh ../../build/mooncake-transfer-engine/nvlink-allocator/
       shell: bash
+
+    - name: Run sccache stat for check
+      shell: bash
+      run: ${SCCACHE_PATH} --show-stats
 
     - name: Start Metadata Server
       run: |

--- a/.github/workflows/ci_cu13.yml
+++ b/.github/workflows/ci_cu13.yml
@@ -52,10 +52,6 @@ jobs:
           core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
           core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
-    - name: Run sccache stat for check
-      shell: bash
-      run: ${SCCACHE_PATH} --show-stats
-
     - name: Install dependencies
       run: |
         sudo apt update -y
@@ -105,6 +101,10 @@ jobs:
         export LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LIBRARY_PATH
         bash build.sh ../../build/mooncake-transfer-engine/nvlink-allocator/
       shell: bash
+
+    - name: Run sccache stat for check
+      shell: bash
+      run: ${SCCACHE_PATH} --show-stats
 
     - name: Generate Python version tag
       id: generate_tag

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -67,10 +67,6 @@ jobs:
             core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
-      - name: Run sccache stat for check
-        shell: bash
-        run: ${SCCACHE_PATH} --show-stats
-
       - name: Configure project
         run: |
           sudo apt update -y
@@ -97,6 +93,10 @@ jobs:
           cd mooncake-transfer-engine/nvlink-allocator
           bash build.sh ../../build/mooncake-transfer-engine/nvlink-allocator/
         shell: bash
+
+      - name: Run sccache stat for check
+        shell: bash
+        run: ${SCCACHE_PATH} --show-stats
 
       - name: Generate Python version tag
         id: generate_tag_release
@@ -156,10 +156,6 @@ jobs:
             core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
-      - name: Run sccache stat for check
-        shell: bash
-        run: ${SCCACHE_PATH} --show-stats
-
       - name: Configure project
         run: |
           sudo apt update -y
@@ -175,6 +171,10 @@ jobs:
           make -j
           sudo make install
         shell: bash
+
+      - name: Run sccache stat for check
+        shell: bash
+        run: ${SCCACHE_PATH} --show-stats
 
       - name: Generate Python version tag
         id: generate_tag_release
@@ -246,10 +246,6 @@ jobs:
             core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
-      - name: Run sccache stat for check
-        shell: bash
-        run: ${SCCACHE_PATH} --show-stats
-
       - name: Configure project
         run: |
           sudo apt update -y
@@ -276,6 +272,10 @@ jobs:
           cd mooncake-transfer-engine/nvlink-allocator
           bash build.sh ../../build/mooncake-transfer-engine/nvlink-allocator/
         shell: bash
+
+      - name: Run sccache stat for check
+        shell: bash
+        run: ${SCCACHE_PATH} --show-stats
 
       - name: Generate Python version tag
         id: generate_tag_release

--- a/.github/workflows/release-cuda13.yaml
+++ b/.github/workflows/release-cuda13.yaml
@@ -55,10 +55,6 @@ jobs:
             core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
-      - name: Run sccache stat for check
-        shell: bash
-        run: ${SCCACHE_PATH} --show-stats
-
       - name: Configure project
         run: |
           sudo apt update -y
@@ -85,6 +81,10 @@ jobs:
           cd mooncake-transfer-engine/nvlink-allocator
           bash build.sh ../../build/mooncake-transfer-engine/nvlink-allocator/
         shell: bash
+
+      - name: Run sccache stat for check
+        shell: bash
+        run: ${SCCACHE_PATH} --show-stats
 
       - name: Generate Python version tag
         id: generate_tag_release

--- a/.github/workflows/release-non-cuda.yaml
+++ b/.github/workflows/release-non-cuda.yaml
@@ -43,10 +43,6 @@ jobs:
             core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
-      - name: Run sccache stat for check
-        shell: bash
-        run: ${SCCACHE_PATH} --show-stats
-
       - name: Configure project
         run: |
           sudo apt update -y
@@ -62,6 +58,10 @@ jobs:
           make -j
           sudo make install
         shell: bash
+
+      - name: Run sccache stat for check
+        shell: bash
+        run: ${SCCACHE_PATH} --show-stats
 
       - name: Generate Python version tag
         id: generate_tag_release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,10 +56,6 @@ jobs:
             core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
-      - name: Run sccache stat for check
-        shell: bash
-        run: ${SCCACHE_PATH} --show-stats
-
       - name: Configure project
         run: |
           sudo apt update -y
@@ -86,6 +82,10 @@ jobs:
           cd mooncake-transfer-engine/nvlink-allocator
           bash build.sh ../../build/mooncake-transfer-engine/nvlink-allocator/
         shell: bash
+
+      - name: Run sccache stat for check
+        shell: bash
+        run: ${SCCACHE_PATH} --show-stats
 
       - name: Generate Python version tag
         id: generate_tag_release


### PR DESCRIPTION
## Description

The "Run sccache stat for check" step was running `${SCCACHE_PATH} --show-stats` before any build step in all 6 workflow files. This meant sccache always reported 0 cache hits and 0 cache misses, making the stats step useless for monitoring cache effectiveness.

This PR moves the sccache stats step to run after the build, so it reports actual cache statistics.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

Verified by checking the diff in all 6 workflow files:
- `ci.yml`: 2 sccache stat steps moved after builds
- `ci_cu13.yml`: 1 sccache stat step moved after build
- `release.yaml`: 1 sccache stat step moved after build
- `release-cuda13.yaml`: 1 sccache stat step moved after build
- `release-non-cuda.yaml`: 1 sccache stat step moved after build
- `pre-release.yaml`: 3 sccache stat steps moved after builds

In each case, the stats step now runs after the cmake/make build completes, so it will report non-zero cache statistics.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.