### PR TITLE
[TransferEngine] Fix: TCP transport implicitly creates CUDA context on GPU0

### DIFF
--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
@@ -47,10 +47,17 @@ struct SessionHeader {
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX)
+static bool isCudaMemory(void* addr) {
+    cudaPointerAttributes attributes;
+    auto status = cudaPointerGetAttributes(&attributes, addr);
+    if (status != cudaSuccess) return false;
+    return attributes.type == cudaMemoryTypeDevice;
+}
+
 // Returns the CUDA device ordinal if addr is device memory, or -1 otherwise.
-// Uses cudaPointerGetAttributes which requires a current CUDA context; callers
-// must call cudaSetDevice before any cudaMemcpy to avoid implicit GPU0 init.
-static int getCudaDevice(void* addr) {
+// Callers must call cudaSetDevice before any cudaMemcpy to avoid implicit
+// GPU 0 context creation.
+static int getCudaDeviceId(void* addr) {
     cudaPointerAttributes attributes;
     auto status = cudaPointerGetAttributes(&attributes, addr);
     if (status != cudaSuccess) return -1;
@@ -127,7 +134,7 @@ struct ServerSession : public std::enable_shared_from_this<ServerSession> {
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX)
-        cuda_device = getCudaDevice(addr);
+        cuda_device = getCudaDeviceId(addr);
         if (cuda_device >= 0) {
             dram_buffer = new char[buffer_size];
             cudaSetDevice(cuda_device);
@@ -191,7 +198,7 @@ struct ServerSession : public std::enable_shared_from_this<ServerSession> {
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX)
-        cuda_device = getCudaDevice(addr);
+        cuda_device = getCudaDeviceId(addr);
         if (cuda_device >= 0) {
             dram_buffer = new char[buffer_size];
         }
@@ -323,7 +330,7 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX)
-        cuda_device = getCudaDevice(addr);
+        cuda_device = getCudaDeviceId(addr);
         if (cuda_device >= 0) {
             dram_buffer = new char[buffer_size];
         }
@@ -421,7 +428,7 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX)
-        cuda_device = getCudaDevice(addr);
+        cuda_device = getCudaDeviceId(addr);
         if (cuda_device >= 0) {
             dram_buffer = new char[buffer_size];
             cudaSetDevice(cuda_device);

--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
@@ -47,12 +47,15 @@ struct SessionHeader {
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX)
-static bool isCudaMemory(void* addr) {
+// Returns the CUDA device ordinal if addr is device memory, or -1 otherwise.
+// Uses cudaPointerGetAttributes which requires a current CUDA context; callers
+// must call cudaSetDevice before any cudaMemcpy to avoid implicit GPU0 init.
+static int getCudaDevice(void* addr) {
     cudaPointerAttributes attributes;
     auto status = cudaPointerGetAttributes(&attributes, addr);
-    if (status != cudaSuccess) return false;
-    if (attributes.type == cudaMemoryTypeDevice) return true;
-    return false;
+    if (status != cudaSuccess) return -1;
+    if (attributes.type == cudaMemoryTypeDevice) return attributes.device;
+    return -1;
 }
 #endif
 
@@ -119,12 +122,15 @@ struct ServerSession : public std::enable_shared_from_this<ServerSession> {
         }
 
         char* dram_buffer = addr + total_transferred_bytes_;
+        int cuda_device = -1;
 
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX)
-        if (isCudaMemory(addr)) {
+        cuda_device = getCudaDevice(addr);
+        if (cuda_device >= 0) {
             dram_buffer = new char[buffer_size];
+            cudaSetDevice(cuda_device);
             cudaError_t cuda_status =
                 cudaMemcpy(dram_buffer, addr + total_transferred_bytes_,
                            buffer_size, cudaMemcpyDefault);
@@ -141,12 +147,12 @@ struct ServerSession : public std::enable_shared_from_this<ServerSession> {
 
         asio::async_write(
             *socket_, asio::buffer(dram_buffer, buffer_size),
-            [this, addr, dram_buffer, self](const asio::error_code& ec,
-                                            std::size_t transferred_bytes) {
+            [this, addr, dram_buffer, cuda_device, self](
+                const asio::error_code& ec, std::size_t transferred_bytes) {
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX)
-                if (isCudaMemory(addr)) {
+                if (cuda_device >= 0) {
                     delete[] dram_buffer;
                 }
 #endif
@@ -180,21 +186,20 @@ struct ServerSession : public std::enable_shared_from_this<ServerSession> {
         }
 
         char* dram_buffer = addr + total_transferred_bytes_;
+        int cuda_device = -1;
 
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX)
-        bool is_cuda_memory = isCudaMemory(addr);
-        if (is_cuda_memory) {
+        cuda_device = getCudaDevice(addr);
+        if (cuda_device >= 0) {
             dram_buffer = new char[buffer_size];
         }
-#else
-        bool is_cuda_memory = false;
 #endif
 
         asio::async_read(
             *socket_, asio::buffer(dram_buffer, buffer_size),
-            [this, addr, dram_buffer, is_cuda_memory, self](
+            [this, addr, dram_buffer, cuda_device, self](
                 const asio::error_code& ec, std::size_t transferred_bytes) {
                 if (ec) {
                     // If client closed connection (EOF), this is normal - don't
@@ -209,18 +214,15 @@ struct ServerSession : public std::enable_shared_from_this<ServerSession> {
                             << " (value: " << ec.value() << ")";
                     }
                     session_mutex_.unlock();
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
-    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
-    defined(USE_COREX)
-                    if (is_cuda_memory) delete[] dram_buffer;
-#endif
+                    if (cuda_device >= 0) delete[] dram_buffer;
                     return;  // Connection will be closed
                 }
 
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX)
-                if (is_cuda_memory) {
+                if (cuda_device >= 0) {
+                    cudaSetDevice(cuda_device);
                     cudaError_t cuda_status =
                         cudaMemcpy(addr + total_transferred_bytes_, dram_buffer,
                                    transferred_bytes, cudaMemcpyDefault);
@@ -316,21 +318,20 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
         }
 
         char* dram_buffer = addr + total_transferred_bytes_;
+        int cuda_device = -1;
 
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX)
-        bool is_cuda_memory = isCudaMemory(addr);
-        if (is_cuda_memory) {
+        cuda_device = getCudaDevice(addr);
+        if (cuda_device >= 0) {
             dram_buffer = new char[buffer_size];
         }
-#else
-        bool is_cuda_memory = false;
 #endif
 
         asio::async_read(
             *socket_, asio::buffer(dram_buffer, buffer_size),
-            [this, addr, dram_buffer, is_cuda_memory, self](
+            [this, addr, dram_buffer, cuda_device, self](
                 const asio::error_code& ec, std::size_t transferred_bytes) {
                 if (ec) {
                     LOG(ERROR)
@@ -342,7 +343,7 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
                     // Post entire cleanup to ensure it runs after callback
                     // returns
                     asio::post(socket_->get_executor(),
-                               [this, self, dram_buffer, is_cuda_memory,
+                               [this, self, dram_buffer, cuda_device,
                                 on_finalize = std::move(on_finalize_),
                                 on_complete = std::move(on_complete_)]() {
                                    if (on_finalize)
@@ -350,7 +351,7 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX)
-                                   if (is_cuda_memory) delete[] dram_buffer;
+                                   if (cuda_device >= 0) delete[] dram_buffer;
 #endif
                                    session_mutex_.unlock();
                                    if (on_complete) on_complete();
@@ -361,7 +362,8 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX)
-                if (is_cuda_memory) {
+                if (cuda_device >= 0) {
+                    cudaSetDevice(cuda_device);
                     cudaError_t cuda_status =
                         cudaMemcpy(addr + total_transferred_bytes_, dram_buffer,
                                    transferred_bytes, cudaMemcpyDefault);
@@ -414,12 +416,15 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
         }
 
         char* dram_buffer = addr + total_transferred_bytes_;
+        int cuda_device = -1;
 
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX)
-        if (isCudaMemory(addr)) {
+        cuda_device = getCudaDevice(addr);
+        if (cuda_device >= 0) {
             dram_buffer = new char[buffer_size];
+            cudaSetDevice(cuda_device);
             cudaError_t cuda_status =
                 cudaMemcpy(dram_buffer, addr + total_transferred_bytes_,
                            buffer_size, cudaMemcpyDefault);
@@ -445,15 +450,11 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
 
         asio::async_write(
             *socket_, asio::buffer(dram_buffer, buffer_size),
-            [this, addr, dram_buffer, self](const asio::error_code& ec,
-                                            std::size_t transferred_bytes) {
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
-    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
-    defined(USE_COREX)
-                if (isCudaMemory(addr)) {
+            [this, addr, dram_buffer, cuda_device, self](
+                const asio::error_code& ec, std::size_t transferred_bytes) {
+                if (cuda_device >= 0) {
                     delete[] dram_buffer;
                 }
-#endif
                 if (ec) {
                     LOG(ERROR)
                         << "ClientSession::writeBody failed. "


### PR DESCRIPTION
## Summary

When TCP transport transfers GPU memory, asio worker threads (which never call `cudaSetDevice`) execute `cudaMemcpy`, causing the CUDA Runtime to implicitly initialize a primary context on the default device (GPU0). This wastes ~520 MiB of GPU0 memory per worker process on H200 clusters.

## Root Cause

`isCudaMemory()` only checks whether an address is CUDA device memory but does not return the device ordinal. Without knowing which device owns the memory, the code cannot call `cudaSetDevice()` before `cudaMemcpy()`, so the CUDA Runtime defaults to GPU0.

## Fix

- Replace `isCudaMemory()` with `getCudaDevice()` which returns the CUDA device ordinal (or -1 for non-device memory)
- Call `cudaSetDevice(cuda_device)` before every `cudaMemcpy` so the Runtime uses the correct GPU
- All `is_cuda_memory` boolean checks replaced with `cuda_device >= 0`

## Verification

Verified on H200 cluster: TCP transfer +521 MiB on GPU0 before fix, +0 MiB after fix.

**before:**

```
Thu Jun  4 11:34:21 2026
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 570.148.08             Driver Version: 570.148.08     CUDA Version: 12.9     |
|-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA H200                    On  |   00000000:18:00.0 Off |                    0 |
| N/A   31C    P0            119W /  700W |  143054MiB / 143771MiB |    100%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   1  NVIDIA H200                    On  |   00000000:2A:00.0 Off |                    0 |
| N/A   32C    P0            120W /  700W |  140122MiB / 143771MiB |     99%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   2  NVIDIA H200                    On  |   00000000:3A:00.0 Off |                    0 |
| N/A   33C    P0            124W /  700W |  140216MiB / 143771MiB |     99%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   3  NVIDIA H200                    On  |   00000000:5D:00.0 Off |                    0 |
| N/A   29C    P0             97W /  700W |  139910MiB / 143771MiB |    100%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   4  NVIDIA H200                    On  |   00000000:9A:00.0 Off |                    0 |
| N/A   32C    P0            124W /  700W |  139668MiB / 143771MiB |    100%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   5  NVIDIA H200                    On  |   00000000:AB:00.0 Off |                    0 |
| N/A   33C    P0            128W /  700W |  139934MiB / 143771MiB |    100%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   6  NVIDIA H200                    On  |   00000000:BA:00.0 Off |                    0 |
| N/A   33C    P0            123W /  700W |  141466MiB / 143771MiB |    100%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   7  NVIDIA H200                    On  |   00000000:DB:00.0 Off |                    0 |
| N/A   31C    P0            121W /  700W |  142740MiB / 143771MiB |    100%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+

+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|    0   N/A  N/A          413355      C   sglang::scheduler_DP8_TP8_EP8         13984... |
|    0   N/A  N/A          413356      C   sglang::scheduler_DP9_TP9_EP9           520MiB |
|    0   N/A  N/A          413357      C   sglang::scheduler_DP10_TP10_EP10        520MiB |
|    0   N/A  N/A          413358      C   sglang::scheduler_DP11_TP11_EP11        520MiB |
|    0   N/A  N/A          413359      C   sglang::scheduler_DP12_TP12_EP12        520MiB |
|    0   N/A  N/A          413360      C   sglang::scheduler_DP13_TP13_EP13        520MiB |
|    0   N/A  N/A          413362      C   sglang::scheduler_DP15_TP15_EP15        520MiB |
|    1   N/A  N/A          413356      C   sglang::scheduler_DP9_TP9_EP9         14010... |
|    2   N/A  N/A          413357      C   sglang::scheduler_DP10_TP10_EP10      14020... |
|    3   N/A  N/A          413358      C   sglang::scheduler_DP11_TP11_EP11      13989... |
|    4   N/A  N/A          413359      C   sglang::scheduler_DP12_TP12_EP12      13965... |
|    5   N/A  N/A          413360      C   sglang::scheduler_DP13_TP13_EP13      13991... |
|    6   N/A  N/A          413361      C   sglang::scheduler_DP14_TP14_EP14      14145... |
|    7   N/A  N/A          413362      C   sglang::scheduler_DP15_TP15_EP15      14272... |
+-----------------------------------------------------------------------------------------+
```

**after:**

```
Thu Jun  4 11:48:35 2026
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 570.148.08             Driver Version: 570.148.08     CUDA Version: 12.9     |
|-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA H200                    On  |   00000000:18:00.0 Off |                    0 |
| N/A   43C    P0            527W /  700W |  139920MiB / 143771MiB |     98%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   1  NVIDIA H200                    On  |   00000000:2A:00.0 Off |                    0 |
| N/A   37C    P0            279W /  700W |  139800MiB / 143771MiB |     88%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   2  NVIDIA H200                    On  |   00000000:3A:00.0 Off |                    0 |
| N/A   45C    P0            521W /  700W |  139784MiB / 143771MiB |     97%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   3  NVIDIA H200                    On  |   00000000:5D:00.0 Off |                    0 |
| N/A   34C    P0            444W /  700W |  139590MiB / 143771MiB |     98%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   4  NVIDIA H200                    On  |   00000000:9A:00.0 Off |                    0 |
| N/A   34C    P0            272W /  700W |  139640MiB / 143771MiB |     88%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   5  NVIDIA H200                    On  |   00000000:AB:00.0 Off |                    0 |
| N/A   46C    P0            529W /  700W |  139740MiB / 143771MiB |     99%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   6  NVIDIA H200                    On  |   00000000:BA:00.0 Off |                    0 |
| N/A   37C    P0            261W /  700W |  139624MiB / 143771MiB |     99%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   7  NVIDIA H200                    On  |   00000000:DB:00.0 Off |                    0 |
| N/A   43C    P0            519W /  700W |  140842MiB / 143771MiB |     98%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+

+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|    0   N/A  N/A          419536      C   sglang::scheduler_DP8_TP8_EP8         13990... |
|    1   N/A  N/A          419537      C   sglang::scheduler_DP9_TP9_EP9         13978... |
|    2   N/A  N/A          419538      C   sglang::scheduler_DP10_TP10_EP10      13976... |
|    3   N/A  N/A          419539      C   sglang::scheduler_DP11_TP11_EP11      13957... |
|    4   N/A  N/A          419540      C   sglang::scheduler_DP12_TP12_EP12      13962... |
|    5   N/A  N/A          419541      C   sglang::scheduler_DP13_TP13_EP13      13972... |
|    6   N/A  N/A          419542      C   sglang::scheduler_DP14_TP14_EP14      13960... |
|    7   N/A  N/A          419543      C   sglang::scheduler_DP15_TP15_EP15      14082... |
+-----------------------------------------------------------------------------------------+
```
