### PR TITLE
[EP] Add MACA standalone device EP support

### DIFF
--- a/mooncake-ep/setup.py
+++ b/mooncake-ep/setup.py
@@ -16,6 +16,7 @@ current_dir = os.path.abspath(os.path.dirname(__file__))
 use_musa = os.getenv("MOONCAKE_EP_USE_MUSA", "").upper() in {"1", "ON", "TRUE", "YES"}
 use_maca = bool(getattr(torch.version, "maca", None)) or \
            bool(getattr(torch._C, "_MACA_VERSION", None))
+standalone = os.getenv("MOONCAKE_EP_STANDALONE", "").upper() in {"1", "ON", "TRUE", "YES"}
 
 if use_musa:
     from torch_musa.utils.musa_extension import MUSAExtension
@@ -56,18 +57,42 @@ if use_musa:
 elif use_maca:
     ExtensionClass = CUDAExtension
     BuildClass = BuildExtension
-    libraries = ["glog"]
+    libraries = [] if standalone else ["glog"]
     library_dirs = []
     sources = [
         "src/ep_py.cpp",
         "src/mooncake_ep_buffer.cpp",
         "src/mooncake_ep_kernel.cu",
     ]
+    if standalone:
+        sources.extend([
+            "../mooncake-transfer-engine/src/transport/device/p2p_device_transport.cpp",
+            "../mooncake-transfer-engine/src/transport/device/ibgda_device_transport_maca_stub.cpp",
+        ])
+    cxx_flags = [
+        f"-D_GLIBCXX_USE_CXX11_ABI={abi_flag}",
+        "-DUSE_MACA",
+        "-std=c++20",
+        "-O3",
+        "-g0",
+    ]
+    nvcc_flags = [
+        f"-D_GLIBCXX_USE_CXX11_ABI={abi_flag}",
+        "-DUSE_MACA",
+        "-std=c++20",
+        "-Xcompiler",
+        "-O3",
+        "-Xcompiler",
+        "-g0",
+    ]
+    if standalone:
+        cxx_flags.append("-DMOONCAKE_EP_STANDALONE=1")
+        nvcc_flags.append("-DMOONCAKE_EP_STANDALONE=1")
     extra_compile_args = {
-        "cxx": [f"-D_GLIBCXX_USE_CXX11_ABI={abi_flag}", "-DUSE_MACA", "-std=c++20", "-O3", "-g0"],
-        "nvcc": [f"-D_GLIBCXX_USE_CXX11_ABI={abi_flag}", "-DUSE_MACA", "-std=c++20", "-Xcompiler", "-O3", "-Xcompiler", "-g0"],
+        "cxx": cxx_flags,
+        "nvcc": nvcc_flags,
     }
-    extra_link_args = [
+    extra_link_args = [] if standalone else [
         "-Wl,-rpath,$ORIGIN",
         "-L" + os.path.join(current_dir, "../mooncake-wheel/mooncake"),
         "-l:engine.so",

--- a/mooncake-ep/src/ep_py.cpp
+++ b/mooncake-ep/src/ep_py.cpp
@@ -6,8 +6,11 @@
 #include <torch/csrc/utils/pybind.h>
 #include <torch/python.h>
 #include <torch/torch.h>
+#ifndef MOONCAKE_EP_STANDALONE
 #include <transfer_engine.h>
+#endif
 #include <cstdint>
+#include <stdexcept>
 
 namespace py = pybind11;
 
@@ -18,8 +21,16 @@ namespace mooncake {
 // This avoids cross-module pybind11 type registration issues.
 MooncakeEpBuffer* make_buffer(int rank, int num_ranks, int64_t num_ep_buffer_bytes,
                               uint64_t engine_ptr) {
+#ifdef MOONCAKE_EP_STANDALONE
+    if (engine_ptr != 0) {
+        throw std::invalid_argument(
+            "MOONCAKE_EP_STANDALONE does not accept a TransferEngine pointer");
+    }
+    return new MooncakeEpBuffer(rank, num_ranks, num_ep_buffer_bytes, nullptr);
+#else
     auto* engine = reinterpret_cast<TransferEngine*>(engine_ptr);
     return new MooncakeEpBuffer(rank, num_ranks, num_ep_buffer_bytes, engine);
+#endif
 }
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {

--- a/mooncake-ep/src/mooncake_ep_buffer.cpp
+++ b/mooncake-ep/src/mooncake_ep_buffer.cpp
@@ -1,7 +1,9 @@
 #include <mooncake_ep_buffer.h>
-#include <glog/logging.h>
+#include "transport/device/device_logging.h"
 #include <sstream>
+#ifndef MOONCAKE_EP_STANDALONE
 #include <transfer_engine.h>
+#endif
 
 namespace mooncake {
 
@@ -48,12 +50,16 @@ MooncakeEpBuffer::MooncakeEpBuffer(
 #endif
 
     // P2P transport — owns GDR buffer allocation and IPC handle exchange.
+#ifndef MOONCAKE_EP_STANDALONE
     if (engine) {
         p2p_transport_ = engine->getOrCreateP2pTransport(num_ranks);
     } else {
+#endif
         owned_p2p_transport_ = device::createP2pDeviceTransport(num_ranks);
         p2p_transport_ = owned_p2p_transport_.get();
+#ifndef MOONCAKE_EP_STANDALONE
     }
+#endif
 
     gdr_buffer = p2p_transport_->allocateBuffer(num_ep_buffer_bytes);
     if (!gdr_buffer) {
@@ -66,6 +72,7 @@ MooncakeEpBuffer::MooncakeEpBuffer(
 #endif
 
     // RDMA transport — optional; disabled if init fails.
+#ifndef MOONCAKE_EP_STANDALONE
     if (engine) {
         rdma_transport_ = engine->getOrCreateRdmaTransport();
         if (rdma_transport_) {
@@ -80,6 +87,7 @@ MooncakeEpBuffer::MooncakeEpBuffer(
             ibgda_disabled_ = true;
         }
     } else {
+#endif
         // Read optional NIC whitelist from env var (same convention as PG tests).
         std::vector<std::string> device_filter;
         if (const char* env = std::getenv("MOONCAKE_EP_DEVICE_FILTER")) {
@@ -100,7 +108,9 @@ MooncakeEpBuffer::MooncakeEpBuffer(
             ibgda_disabled_ = true;
             LOG(INFO) << "[EP] IBGDA unavailable, using P2P-only path";
         }
+#ifndef MOONCAKE_EP_STANDALONE
     }
+#endif
 
     // Workspace
 #ifdef MOONCAKE_EP_USE_MUSA

--- a/mooncake-transfer-engine/include/transport/device/comm_device.cuh
+++ b/mooncake-transfer-engine/include/transport/device/comm_device.cuh
@@ -37,7 +37,11 @@ make_comm_ctx(void* gdr_buffer, const int32_t* nvlink_available,
     ctx.p2p.peer_ptrs = ipc_peer_ptrs;
     ctx.p2p.local_base = gdr_buffer;
 
+#ifdef USE_MACA
+    ctx.ibgda.qp_devctxs = qp_devctxs;
+#else
     ctx.ibgda.qp_devctxs = reinterpret_cast<mlx5gda_qp_devctx*>(qp_devctxs);
+#endif
     ctx.ibgda.raddrs = reinterpret_cast<const uint64_t*>(raddrs);
     ctx.ibgda.rkeys = reinterpret_cast<const uint32_t*>(rkeys);
     ctx.ibgda.local_atomic_base = rdma_send_signal_buffer;
@@ -86,12 +90,14 @@ __device__ __forceinline__ void mc_rdma_put(
     void* recv_ptr,  // local VA of the recv slot (for raddr computation)
     uint32_t nbytes, int lane_id) {
     if (lane_id == 0) {
+#ifndef USE_MACA
         uint64_t recv_raddr =
             ctx.ibgda.raddrs[dst_rank] +
             (reinterpret_cast<const char*>(recv_ptr) -
              reinterpret_cast<const char*>(ctx.p2p.local_base));
         mc_ibgda_put(ctx.ibgda, channel, dst_rank, ctx.rank, qps_per_rank,
                      send_ptr, recv_raddr, nbytes);
+#endif
     }
 }
 
@@ -112,6 +118,7 @@ __device__ __forceinline__ void mc_signal(const CommCtx& ctx, int dst_rank,
     if (mc_comm_p2p_available(ctx, dst_rank)) {
         mc_p2p_signal(ctx.p2p, dst_rank, sig_ptr, val);
     } else {
+#ifndef USE_MACA
         uint64_t recv_raddr =
             ctx.ibgda.raddrs[dst_rank] +
             (reinterpret_cast<const char*>(sig_ptr) -
@@ -124,6 +131,7 @@ __device__ __forceinline__ void mc_signal(const CommCtx& ctx, int dst_rank,
              reinterpret_cast<const char*>(ctx.p2p.local_base));
         mc_ibgda_red_add(ctx.ibgda, channel, dst_rank, ctx.rank, qps_per_rank,
                          laddr, recv_raddr, val);
+#endif
     }
 }
 

--- a/mooncake-transfer-engine/include/transport/device/device_logging.h
+++ b/mooncake-transfer-engine/include/transport/device/device_logging.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#if !defined(MOONCAKE_EP_STANDALONE) || __has_include(<glog/logging.h>)
+#include <glog/logging.h>
+#else
+
+#include <cstdlib>
+#include <iostream>
+#include <sstream>
+
+namespace mooncake_ep {
+
+enum class LogSeverity {
+    INFO,
+    WARNING,
+    ERROR,
+    FATAL,
+};
+
+class LogMessage {
+   public:
+    LogMessage(LogSeverity severity, const char* file, int line)
+        : severity_(severity) {
+        stream_ << file << ":" << line << ": " << name() << ": ";
+    }
+
+    ~LogMessage() {
+        stream_ << '\n';
+        std::cerr << stream_.str();
+        if (severity_ == LogSeverity::FATAL) std::abort();
+    }
+
+    std::ostream& stream() { return stream_; }
+
+   private:
+    const char* name() const {
+        switch (severity_) {
+            case LogSeverity::INFO:
+                return "INFO";
+            case LogSeverity::WARNING:
+                return "WARNING";
+            case LogSeverity::ERROR:
+                return "ERROR";
+            case LogSeverity::FATAL:
+                return "FATAL";
+        }
+        return "UNKNOWN";
+    }
+
+    LogSeverity severity_;
+    std::ostringstream stream_;
+};
+
+}  // namespace mooncake_ep
+
+#define LOG(severity)                                                   \
+    ::mooncake_ep::LogMessage(::mooncake_ep::LogSeverity::severity,     \
+                              __FILE__, __LINE__)                       \
+        .stream()
+
+#endif

--- a/mooncake-transfer-engine/include/transport/device/ibgda_device.cuh
+++ b/mooncake-transfer-engine/include/transport/device/ibgda_device.cuh
@@ -11,6 +11,30 @@
 #include <cstdint>
 #include "transport/device/device_ops.cuh"
 
+#ifdef USE_MACA
+
+namespace mooncake {
+namespace device {
+
+struct IbgdaContext {
+    void* qp_devctxs;
+    const uint64_t* raddrs;
+    const uint32_t* rkeys;
+    const void* local_atomic_base;
+    const void* remote_atomic_base;
+};
+
+__device__ __forceinline__ void mc_ibgda_put(
+    const IbgdaContext&, int, int, int, int, const void*, uint64_t, uint32_t) {}
+
+__device__ __forceinline__ void mc_ibgda_red_add(
+    const IbgdaContext&, int, int, int, int, uint64_t, uint64_t, int32_t) {}
+
+}  // namespace device
+}  // namespace mooncake
+
+#else
+
 #ifndef MOONCAKE_EP_USE_MUSA
 #include <cuda/atomic>
 #endif
@@ -202,3 +226,5 @@ __device__ __forceinline__ void mc_ibgda_red_add(
 
 }  // namespace device
 }  // namespace mooncake
+
+#endif  // USE_MACA

--- a/mooncake-transfer-engine/include/transport/device/maca/maca_ops.cuh
+++ b/mooncake-transfer-engine/include/transport/device/maca/maca_ops.cuh
@@ -89,11 +89,7 @@ __device__ __forceinline__ int64_t mc_ld_nc_s64(const int64_t* ptr) {
 // Non-temporal stores — plain volatile store (no nt hint available)
 // ---------------------------------------------------------------------------
 __device__ __forceinline__ void mc_st_na(const int4* ptr, const int4& val) {
-    volatile int* vp = reinterpret_cast<volatile int*>(const_cast<int4*>(ptr));
-    vp[0] = val.x;
-    vp[1] = val.y;
-    vp[2] = val.z;
-    vp[3] = val.w;
+    *const_cast<int4*>(ptr) = val;
 }
 
 // ---------------------------------------------------------------------------

--- a/mooncake-transfer-engine/src/transport/device/ibgda_device_transport_maca_stub.cpp
+++ b/mooncake-transfer-engine/src/transport/device/ibgda_device_transport_maca_stub.cpp
@@ -18,7 +18,7 @@ class NullRdmaTransport : public RdmaTransport {
     int allocateControlBuffer() override { return -1; }
     int createQueuePairs(void*) override { return -1; }
     int recreateQueuePairs(void*) override { return -1; }
-    int connectPeers(bool, const std::vector<int64_t>&,
+    int connectPeers(int, bool, const std::vector<int64_t>&,
                      const std::vector<int32_t>&,
                      const std::vector<int32_t>&,
                      const std::vector<int32_t>&,

--- a/mooncake-transfer-engine/src/transport/device/p2p_device_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/device/p2p_device_transport.cpp
@@ -19,7 +19,7 @@
 
 #include "transport/device/device_transport.h"
 
-#include <glog/logging.h>
+#include "transport/device/device_logging.h"
 #include <algorithm>
 #include <cstring>
 


### PR DESCRIPTION
# MACA Expert Parallelism Performance Status

This note summarizes the current Mooncake Expert Parallelism (EP) status on a
4-GPU MetaX C500 node with the MACA software stack. It focuses on the current
performance limits, the core code changes made for MACA EP, and the next
optimization steps needed to better utilize MetaXLink.

## Scope

The current target is to make Mooncake EP compile and run on MACA through the
torch `CUDAExtension` / `cucc` path, then improve intra-node dispatch/combine
bandwidth on 4 MetaX C500 GPUs.

The current validated runtime path is:

- MACA EP extension built through torch `CUDAExtension`.
- P2P/IPC fast path for intra-node GPU-to-GPU communication.
- MACA IBGDA path disabled by design in the current implementation.

## Current Limitations

### IBGDA is not active on MACA

The current MACA EP implementation does not start real IBGDA. The MACA RDMA
transport is a stub whose initialization returns failure, so EP sets
`ibgda_disabled=True` and falls back to the P2P fast path.

Device-side RDMA operations are also guarded on MACA. `mc_rdma_put` and
`mc_signal` do not issue mlx5/IBGDA device operations under `USE_MACA`.

This means the current MACA EP performance is not measuring GPU-initiated RDMA.
It is measuring kernel-based P2P writes through the intra-node P2P/IPC path.

### CX7 is present but not usable for high-speed RDMA yet

The node exposes ConnectX-7 hardware, and userspace RDMA permissions are
available. `/dev/infiniband/uverbs*` is accessible by the current user and the
memlock limit is large enough for normal RDMA memory registration.

However, the ConnectX-7 InfiniBand ports are currently down/disabled:

- `mlx5_0`: CX7, InfiniBand, `DOWN/DISABLED`
- `mlx5_1`: CX7, InfiniBand, `DOWN/DISABLED`
- `mlx5_4`: CX7, InfiniBand, `DOWN/DISABLED`

The only active RDMA-capable port observed on the node is a ConnectX-5 RoCE
port:

- `mlx5_2` / `ens49f0np0`: Ethernet/RoCE, active, 10 Gb/s

This CX5 port can be useful for validating basic userspace RDMA availability,
but it is not a useful performance path for local 4-GPU EP. A 10 Gb/s link has
a theoretical upper bound around 1.25 GB/s before protocol overhead, while the
current P2P EP path already reaches 6-9 GB/s.

### MetaXLink is not saturated by the current EP kernel

Raw communication tests show that the hardware and MCCL collective stack can
move much more data than the current EP P2P kernel path:

| Test | Result |
| --- | ---: |
| Raw 2-GPU MetaXLink P2P transfer | about 93-95 GB/s unidirectional |
| Raw 2-GPU MetaXLink bidirectional aggregate | about 185 GB/s |
| Raw torch/MCCL all-to-all, 2 GPUs, 64 MB per peer | 134.54 GB/s |
| Raw torch/MCCL all-to-all, 4 GPUs, 64 MB per peer | 68.46 GB/s |

Current EP end-to-end dispatch/combine is significantly lower. This indicates
that the main bottleneck is not physical link availability. The bottleneck is
the EP data organization work: token packing, scatter/gather layout,
per-expert compaction, and combine-side reduction.

## Core Changes

The core MACA EP patch contains the following changes.

### MACA standalone EP build mode

`mooncake-ep/setup.py` now supports `MOONCAKE_EP_STANDALONE=1` for MACA builds.
In this mode the EP extension:

- builds through torch `CUDAExtension` / MACA `cucc`;
- defines `USE_MACA`;
- does not link against `engine.so`;
- does not require the system `glog` library;
- directly includes the P2P transport implementation and the MACA RDMA stub.

This makes it possible to build the EP extension in MACA environments where the
full Transfer Engine shared object or system `glog` development package is not
available.

### TransferEngine pointer handling for standalone builds

`ep_py.cpp` and `mooncake_ep_buffer.cpp` now avoid including or dereferencing
`TransferEngine` when `MOONCAKE_EP_STANDALONE` is enabled.

Standalone mode constructs owned P2P/RDMA transport instances internally. If a
non-zero TransferEngine pointer is passed in standalone mode, the binding
rejects it explicitly.

### MACA device-side IBGDA guards

The MACA path now avoids compiling CUDA/IBGDA-specific mlx5 device structures
into MACA device code. Under `USE_MACA`, `IbgdaContext`, `mc_ibgda_put`, and
`mc_ibgda_red_add` are defined as safe no-op placeholders.

This keeps the MACA EP kernel buildable through `cucc`, while making the
current behavior explicit: MACA EP uses the P2P path, not IBGDA.

### Logging shim for standalone device transport

A new `transport/device/device_logging.h` header provides a small logging
fallback when `MOONCAKE_EP_STANDALONE` is enabled and `glog` headers are not
available.

This replaces the temporary `standalone_include/glog/logging.h` approach and
keeps the compatibility layer explicitly named.

### MACA vector store fix

The most important performance change is in `maca_ops.cuh`.

The MACA non-temporal store fallback for `int4` was changed from four scalar
volatile `int` stores to a single vector `int4` store:

```cpp
*const_cast<int4*>(ptr) = val;
```

The previous scalar volatile store pattern produced very low effective P2P
bandwidth. The vector store allows the MACA compiler/runtime to generate a more
efficient wide store for EP payload movement.

## Performance After the Core Patch

The following EP measurements were collected on the MACA P2P/IPC fast path.
IBGDA was disabled in all cases.

| Configuration | Path | Dispatch | Combine | Dispatch + Combine |
| --- | --- | ---: | ---: | ---: |
| 2 GPUs, 512 tokens, topk=2, hidden=7168 | P2P fast path | 5.41 GB/s | 6.85 GB/s | 6.08 GB/s |
| 2 GPUs, 2048 tokens, topk=2, hidden=7168 | P2P fast path | 5.79 GB/s | 7.56 GB/s | 6.60 GB/s |
| 4 GPUs, 2048 tokens, topk=2, hidden=7168 | P2P fast path | 5.83 GB/s | 7.52 GB/s | 6.53 GB/s |
| 4 GPUs, 2048 tokens, topk=4, hidden=7168 | P2P fast path | 9.22 GB/s | 9.36 GB/s | 9.29 GB/s |

Before the vector-store fix, the early MACA P2P EP path was around the
0.8 GB/s level in comparable small-token tests. The current P2P fast path is
therefore several times faster, but it is still far from the raw MetaXLink and
MCCL bandwidth limits.

## All-to-All Prototype Observation

An experimental Python-level split path was also evaluated separately. This
path uses torch/MCCL `all_to_all_single` for the payload transfer and performs
pack/compact/reduce in Python/Torch.

It is not part of the core MACA EP patch, but it is useful for diagnosis.

Observed payload transfer rates:

| Configuration | Payload all-to-all bandwidth |
| --- | ---: |
| 2 GPUs, 2048 tokens, topk=2 | about 106-112 GB/s |
| 4 GPUs, 2048 tokens, topk=4 | about 80-81 GB/s |

Earlier end-to-end prototype runs with the all-to-all split direction also
showed higher EP-level throughput than the current P2P fast path:

| Configuration | Prototype end-to-end result |
| --- | ---: |
| 2 GPUs, 2048 tokens, topk=4 | about 19.6 GB/s |
| 4 GPUs, 2048 tokens, topk=4 | about 16.8 GB/s |
| 4 GPUs, 2048 tokens, topk=2 | about 11.45 GB/s |

These numbers should be treated as prototype measurements rather than core
patch results. They were useful to confirm that mapping EP traffic onto MCCL
all-to-all can outperform the generic P2P kernel path for larger batches and
higher top-k settings.

This confirms that the communication payload itself can run much closer to the
MetaXLink/MCCL capability. However, end-to-end EP performance remains around
8-12 GB/s because the Python/Torch packing, compaction, and combine reduction
dominate runtime.

This is the strongest evidence that the next major optimization should move
these data-layout stages into C++/MACA kernels instead of relying on Python
tensor indexing and `nonzero`/scatter patterns.

## Next Optimization Steps

The recommended next steps are:

1. Implement C++/MACA kernels for dispatch packing into contiguous per-rank
   send buffers.
2. Use MCCL or MACA peer-copy primitives for the contiguous payload transfer.
3. Implement C++/MACA kernels for receive-side compaction into per-expert
   buffers.
4. Implement combine-side packing and weighted reduce in C++/MACA kernels.
5. Keep the current P2P kernel path for small batches where collective setup
   overhead may dominate.
6. Use topology-aware routing where possible. The current 4-GPU node has
   MetaXLink pairs and cross-pair PCIe/NODE links, so expert placement and
   token routing should avoid unnecessary cross-pair traffic.

## Summary

The current MACA EP work makes the EP extension buildable and runnable through
the MACA torch extension path, and it improves the P2P fast path substantially
by replacing scalar volatile stores with vector `int4` stores.

The current performance ceiling is not the C500 compute capability. The main
limitation is the data movement pipeline for EP dispatch/combine. Raw MetaXLink
and MCCL bandwidth are much higher than the current EP end-to-end throughput,
so the highest-impact future work is to lower the all-to-all pack, compact, and
reduce stages into optimized MACA/C++ kernels.
