### PR TITLE
[Store] feat: add GetSegmentsDetail API to expose segment info via ad…

### DIFF
--- a/docs/source/http-api-reference/http-service.md
+++ b/docs/source/http-api-reference/http-service.md
@@ -146,6 +146,57 @@ Used(bytes): 1073741824
 Capacity(bytes): 4294967296
 ```
 
+#### `/get_segments_detail`
+Get detailed information of all segments in JSON format, including segment metadata, allocator usage, and status.
+
+**Method**: `GET`
+**Content-Type**: `application/json; charset=utf-8`
+**Response**: JSON object containing an array of segment details
+
+**Example**:
+```bash
+curl http://localhost:8080/get_segments_detail
+```
+
+**Response Format**:
+```json
+{
+  "total_segments": 2,
+  "segments": [
+    {
+      "segment_name": "segment_0",
+      "segment_id": "00000000-0000-0000-0000-000000000001",
+      "client_id": "00000000-0000-0000-0000-000000000002",
+      "base_address": "0x300000000",
+      "size_bytes": 17179869184,
+      "size_human": "16 GiB",
+      "te_endpoint": "192.168.1.1:12345",
+      "protocol": "rdma",
+      "status": "MOUNTED",
+      "allocator_used_bytes": 1073741824,
+      "allocator_capacity_bytes": 17179869184,
+      "allocator_usage_percent": 6.25
+    }
+  ]
+}
+```
+
+**Fields**:
+- `total_segments` (integer): Total number of segments in the cluster
+- `segments` (array): Array of segment detail objects
+  - `segment_name` (string): Name of the segment
+  - `segment_id` (string): UUID of the segment
+  - `client_id` (string): UUID of the client that owns the segment
+  - `base_address` (string): Base memory address in hex
+  - `size_bytes` (integer): Segment size in bytes
+  - `size_human` (string): Human-readable segment size
+  - `te_endpoint` (string): Transport endpoint address
+  - `protocol` (string): Transfer protocol (e.g., rdma, tcp)
+  - `status` (string): Current segment status
+  - `allocator_used_bytes` (integer): Bytes currently allocated
+  - `allocator_capacity_bytes` (integer): Total allocator capacity in bytes
+  - `allocator_usage_percent` (number): Percentage of allocator capacity used
+
 ### Health Check Endpoints
 
 #### `/health`

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -203,6 +203,33 @@ class MasterService {
         -> tl::expected<std::vector<NoFSegmentOwnerInfo>, ErrorCode>;
 
     /**
+     * @brief Detailed information about a single segment.
+     * Keeps original types so callers can use values directly without
+     * needing to parse strings back to uuid/address/enum.
+     */
+    struct SegmentDetailInfo {
+        std::string segment_name;
+        UUID segment_id{0, 0};
+        UUID client_id{0, 0};
+        uintptr_t base_address{0};
+        uint64_t size_bytes{0};
+        std::string te_endpoint;
+        std::string protocol;
+        SegmentStatus status{SegmentStatus::UNDEFINED};
+        uint64_t allocator_used_bytes{0};
+        uint64_t allocator_capacity_bytes{0};
+    };
+
+    /**
+     * @brief Get detailed information of all segments, including the
+     * relationships between segment_id, client_id, segment_name, status,
+     * allocator used/capacity, etc.
+     * @return A vector of SegmentDetailInfo on success, error code otherwise.
+     */
+    auto GetSegmentsDetail()
+        -> tl::expected<std::vector<SegmentDetailInfo>, ErrorCode>;
+
+    /**
      * @brief Query a segment's capacity and used size in bytes.
      * Conductor should use these information to schedule new requests.
      * @return ErrorCode::OK if exists

--- a/mooncake-store/include/rpc_service.h
+++ b/mooncake-store/include/rpc_service.h
@@ -178,6 +178,9 @@ class WrappedMasterService {
 
     tl::expected<std::vector<std::string>, ErrorCode> GetAllSegmentsForAdmin();
 
+    tl::expected<std::vector<MasterService::SegmentDetailInfo>, ErrorCode>
+    GetSegmentsDetailForAdmin();
+
     tl::expected<std::pair<uint64_t, uint64_t>, ErrorCode> QuerySegmentForAdmin(
         const std::string& segment);
 

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -6,6 +6,7 @@
 #include <limits>
 #include <random>
 #include <shared_mutex>
+#include <sstream>
 #include <regex>
 #include <unordered_set>
 #include <unistd.h>
@@ -1020,6 +1021,45 @@ auto MasterService::GetAllNoFSegments()
 auto MasterService::GetNoFSegmentsByName(const std::string& segment_name)
     -> tl::expected<std::vector<NoFSegmentOwnerInfo>, ErrorCode> {
     return nof_segment_manager_.GetSegmentsByName(segment_name);
+}
+
+auto MasterService::GetSegmentsDetail()
+    -> tl::expected<std::vector<SegmentDetailInfo>, ErrorCode> {
+    ScopedSegmentAccess segment_access = segment_manager_.getSegmentAccess();
+
+    // Get full info of all segments (including Segment and client_id)
+    std::vector<std::pair<Segment, UUID>> all_segments;
+    auto err = segment_access.GetAllSegments(all_segments);
+    if (err != ErrorCode::OK) {
+        return tl::make_unexpected(err);
+    }
+
+    std::vector<SegmentDetailInfo> result;
+    result.reserve(all_segments.size());
+
+    for (const auto& [segment, client_id] : all_segments) {
+        SegmentDetailInfo info;
+        info.segment_name = segment.name;
+        info.segment_id = segment.id;
+        info.client_id = client_id;
+        info.base_address = segment.base;
+        info.size_bytes = segment.size;
+        info.te_endpoint = segment.te_endpoint;
+        info.protocol = segment.protocol;
+
+        // Query segment status
+        segment_access.GetSegmentStatusByName(segment.name, info.status);
+
+        // Query allocator used/capacity
+        size_t used = 0, capacity = 0;
+        segment_access.QuerySegments(segment.name, used, capacity);
+        info.allocator_used_bytes = used;
+        info.allocator_capacity_bytes = capacity;
+
+        result.push_back(std::move(info));
+    }
+
+    return result;
 }
 
 auto MasterService::QuerySegments(const std::string& segment)

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -138,6 +138,31 @@ struct HttpSegmentStatusResponse {
 YLT_REFL(HttpSegmentStatusResponse, success, segment, status, status_name,
          error_code, error_message);
 
+struct HttpSegmentDetailItem {
+    std::string segment_name;
+    std::string segment_id;
+    std::string client_id;
+    std::string base_address;
+    uint64_t size_bytes{0};
+    std::string size_human;
+    std::string te_endpoint;
+    std::string protocol;
+    std::string status;
+    uint64_t allocator_used_bytes{0};
+    uint64_t allocator_capacity_bytes{0};
+    double allocator_usage_percent{0.0};
+};
+YLT_REFL(HttpSegmentDetailItem, segment_name, segment_id, client_id,
+         base_address, size_bytes, size_human, te_endpoint, protocol, status,
+         allocator_used_bytes, allocator_capacity_bytes,
+         allocator_usage_percent);
+
+struct HttpSegmentsDetailResponse {
+    uint64_t total_segments{0};
+    std::vector<HttpSegmentDetailItem> segments;
+};
+YLT_REFL(HttpSegmentsDetailResponse, total_segments, segments);
+
 template <typename T>
 void WriteJsonResponse(coro_http::coro_http_response& resp,
                        coro_http::status_type status, const T& payload) {
@@ -505,6 +530,56 @@ void MasterAdminServer::InitHttpServer() {
                 body += "\n";
             }
             resp.set_status_and_content(status_type::ok, std::move(body));
+        });
+
+    http_server_.set_http_handler<GET>(
+        "/get_segments_detail",
+        [this](coro_http_request&, coro_http_response& resp) {
+            auto service = GetActiveService();
+            if (!service) {
+                SetServiceUnavailable(resp, "service plane is not active");
+                return;
+            }
+
+            auto result = service->GetSegmentsDetailForAdmin();
+            if (!result) {
+                WriteErrorResponse(resp, status_type::internal_server_error,
+                                   result.error(),
+                                   "Failed to get segments detail");
+                return;
+            }
+
+            HttpSegmentsDetailResponse payload;
+            payload.total_segments = result.value().size();
+            for (const auto& info : result.value()) {
+                HttpSegmentDetailItem item;
+                item.segment_name = info.segment_name;
+                item.segment_id = UuidToString(info.segment_id);
+                item.client_id = UuidToString(info.client_id);
+
+                std::ostringstream addr_oss;
+                addr_oss << "0x" << std::hex << info.base_address;
+                item.base_address = addr_oss.str();
+
+                item.size_bytes = info.size_bytes;
+                std::ostringstream size_oss;
+                size_oss << (info.size_bytes / 1024.0 / 1024.0 / 1024.0)
+                         << " GiB";
+                item.size_human = size_oss.str();
+
+                item.te_endpoint = info.te_endpoint;
+                item.protocol = info.protocol;
+                item.status = EnumToString(info.status);
+                item.allocator_used_bytes = info.allocator_used_bytes;
+                item.allocator_capacity_bytes = info.allocator_capacity_bytes;
+                item.allocator_usage_percent =
+                    info.allocator_capacity_bytes > 0
+                        ? (static_cast<double>(info.allocator_used_bytes) /
+                           info.allocator_capacity_bytes * 100.0)
+                        : 0.0;
+                payload.segments.push_back(std::move(item));
+            }
+            WriteJsonResponse(resp, status_type::ok, payload);
         });
 
     http_server_.set_http_handler<GET>(
@@ -1799,6 +1874,11 @@ WrappedMasterService::GetAllKeysForAdmin() {
 tl::expected<std::vector<std::string>, ErrorCode>
 WrappedMasterService::GetAllSegmentsForAdmin() {
     return master_service_.GetAllSegments();
+}
+
+tl::expected<std::vector<MasterService::SegmentDetailInfo>, ErrorCode>
+WrappedMasterService::GetSegmentsDetailForAdmin() {
+    return master_service_.GetSegmentsDetail();
 }
 
 tl::expected<std::pair<uint64_t, uint64_t>, ErrorCode>

--- a/mooncake-store/tests/master_metrics_test.cpp
+++ b/mooncake-store/tests/master_metrics_test.cpp
@@ -431,6 +431,11 @@ TEST_F(MasterMetricsTest, AdminServerExposesStandbyStateWithoutService) {
     EXPECT_NE(segments_resp.body.find("service plane is not active"),
               std::string::npos);
 
+    auto detail_resp = FetchUrl(http_port, "/get_segments_detail");
+    EXPECT_EQ(detail_resp.http_status, 503);
+    EXPECT_NE(detail_resp.body.find("service plane is not active"),
+              std::string::npos);
+
     admin_server.Stop();
 }
 
@@ -465,6 +470,16 @@ TEST_F(MasterMetricsTest, AdminServerRoutesServiceEndpointsWhenAvailable) {
     EXPECT_EQ(query_resp.http_status, 200);
     EXPECT_NE(query_resp.body.find(segment.name), std::string::npos);
     EXPECT_NE(query_resp.body.find("Capacity(bytes)"), std::string::npos);
+
+    auto detail_resp = FetchUrl(http_port, "/get_segments_detail");
+    EXPECT_EQ(detail_resp.http_status, 200);
+    EXPECT_NE(detail_resp.body.find("\"total_segments\""), std::string::npos);
+    EXPECT_NE(detail_resp.body.find("\"segments\""), std::string::npos);
+    EXPECT_NE(detail_resp.body.find(segment.name), std::string::npos);
+    EXPECT_NE(detail_resp.body.find("\"allocator_used_bytes\""),
+              std::string::npos);
+    EXPECT_NE(detail_resp.body.find("\"allocator_capacity_bytes\""),
+              std::string::npos);
 
     admin_server.Stop();
 }


### PR DESCRIPTION
## Description

Add a new admin HTTP API endpoint `GET /get_segments_detail` that returns detailed JSON information about all registered segments, including:
- `segment_name`, `segment_id`, `client_id`
- `base_address`, size (bytes and human-readable)
- `te_endpoint`, `protocol`
- segment status
- allocator used/capacity and usage percentage

This is useful for debugging and monitoring the cluster's memory segment allocation state.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other

## How Has This Been Tested?

- Added unit tests in `mooncake-store/tests/master_metrics_test.cpp`:
  - **Standby state test**: Verifies `/get_segments_detail` returns HTTP 503 with "service plane is not active" message when the service is not yet active.
  - **Serving state test**: Verifies `/get_segments_detail` returns HTTP 200 with valid JSON containing `total_segments`, `segments` array, segment name, `allocator_used_bytes`, and `allocator_capacity_bytes` fields.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
