### PR TITLE
[Wheel] Fix _parse_segment_size to support KB/MB/TB suffixes and fix handle_put None crash

### DIFF
--- a/mooncake-wheel/mooncake/mooncake_config.py
+++ b/mooncake-wheel/mooncake/mooncake_config.py
@@ -53,17 +53,17 @@ from typing import Optional
 DEFAULT_GLOBAL_SEGMENT_SIZE = 3355443200  # 3.125 GiB
 DEFAULT_LOCAL_BUFFER_SIZE = 1073741824  # 1.0 GiB
 
-_SIZE_SUFFIXES = {
-    "kb": 1024,
-    "k": 1024,
-    "mb": 1024 ** 2,
-    "m": 1024 ** 2,
-    "gb": 1024 ** 3,
-    "g": 1024 ** 3,
-    "tb": 1024 ** 4,
-    "t": 1024 ** 4,
-    "b": 1,
-}
+_SIZE_SUFFIXES = [
+    ("kb", 1024),
+    ("mb", 1024 ** 2),
+    ("gb", 1024 ** 3),
+    ("tb", 1024 ** 4),
+    ("k", 1024),
+    ("m", 1024 ** 2),
+    ("g", 1024 ** 3),
+    ("t", 1024 ** 4),
+    ("b", 1),
+]
 
 def _parse_segment_size(value) -> int:
     if isinstance(value, (int, float)):
@@ -72,9 +72,7 @@ def _parse_segment_size(value) -> int:
         s = value.strip().lower()
         if not s:
             raise ValueError("Invalid segment size: empty string")
-        for suffix, multiplier in sorted(
-            _SIZE_SUFFIXES.items(), key=lambda x: -len(x[0])
-        ):
+        for suffix, multiplier in _SIZE_SUFFIXES:
             if s.endswith(suffix):
                 num = s[: -len(suffix)].strip()
                 if not num:

--- a/mooncake-wheel/mooncake/mooncake_config.py
+++ b/mooncake-wheel/mooncake/mooncake_config.py
@@ -53,19 +53,36 @@ from typing import Optional
 DEFAULT_GLOBAL_SEGMENT_SIZE = 3355443200  # 3.125 GiB
 DEFAULT_LOCAL_BUFFER_SIZE = 1073741824  # 1.0 GiB
 
+_SIZE_SUFFIXES = {
+    "kb": 1024,
+    "k": 1024,
+    "mb": 1024 ** 2,
+    "m": 1024 ** 2,
+    "gb": 1024 ** 3,
+    "g": 1024 ** 3,
+    "tb": 1024 ** 4,
+    "t": 1024 ** 4,
+    "b": 1,
+}
+
 def _parse_segment_size(value) -> int:
-    if isinstance(value, int):
-        return value
+    if isinstance(value, (int, float)):
+        return int(value)
     if isinstance(value, str):
         s = value.strip().lower()
-        if s.endswith("gb"):
-            num = s[:-2].strip()
-            if not num:
-                raise ValueError(
-                    "Invalid segment size: missing number before 'gb'"
-                )
-            return int(num) * 1024 * 1024 * 1024
-        return int(s)
+        if not s:
+            raise ValueError("Invalid segment size: empty string")
+        for suffix, multiplier in sorted(
+            _SIZE_SUFFIXES.items(), key=lambda x: -len(x[0])
+        ):
+            if s.endswith(suffix):
+                num = s[: -len(suffix)].strip()
+                if not num:
+                    raise ValueError(
+                        f"Invalid segment size: missing number before '{suffix}'"
+                    )
+                return int(float(num) * multiplier)
+        return int(float(s))
     return int(value)
 
 @dataclass

--- a/mooncake-wheel/mooncake/mooncake_config.py
+++ b/mooncake-wheel/mooncake/mooncake_config.py
@@ -65,9 +65,10 @@ _SIZE_SUFFIXES = [
     ("b", 1),
 ]
 
+
 def _parse_segment_size(value) -> int:
-    if isinstance(value, (int, float)):
-        return int(value)
+    if isinstance(value, int):
+        return value
     if isinstance(value, str):
         s = value.strip().lower()
         if not s:
@@ -82,6 +83,7 @@ def _parse_segment_size(value) -> int:
                 return int(float(num) * multiplier)
         return int(float(s))
     return int(value)
+
 
 @dataclass
 class MooncakeConfig:

--- a/mooncake-wheel/mooncake/mooncake_store_service.py
+++ b/mooncake-wheel/mooncake/mooncake_store_service.py
@@ -461,15 +461,16 @@ class MooncakeStoreService:
         try:
             data = await request.json()
             key = data.get('key')
-            value = data.get('value').encode()
+            raw_value = data.get('value')
 
-            if not key or not value:
+            if not key or raw_value is None:
                 return web.Response(
                     status=400,
                     text=json.dumps({'error': 'Missing key or value'}),
                     content_type='application/json'
                 )
 
+            value = raw_value.encode()
             ret = self.store.put(key, value)
             if ret != 0:
                 return web.Response(

--- a/mooncake-wheel/tests/test_mooncake_config.py
+++ b/mooncake-wheel/tests/test_mooncake_config.py
@@ -3,7 +3,7 @@ import os
 import tempfile
 import unittest
 
-from mooncake.mooncake_config import MooncakeConfig, DEFAULT_GLOBAL_SEGMENT_SIZE, DEFAULT_LOCAL_BUFFER_SIZE
+from mooncake.mooncake_config import MooncakeConfig, DEFAULT_GLOBAL_SEGMENT_SIZE, DEFAULT_LOCAL_BUFFER_SIZE, _parse_segment_size
 
 class TestMooncakeConfig(unittest.TestCase):
     def setUp(self):
@@ -129,6 +129,68 @@ class TestMooncakeConfig(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             MooncakeConfig.load_from_env()
         self.assertIn("Neither the environment variable 'MOONCAKE_CONFIG_PATH' nor 'MOONCAKE_MASTER' is set.", str(cm.exception))
+
+class TestParseSegmentSize(unittest.TestCase):
+    def test_integer_passthrough(self):
+        self.assertEqual(_parse_segment_size(1024), 1024)
+        self.assertEqual(_parse_segment_size(0), 0)
+
+    def test_float_passthrough(self):
+        self.assertEqual(_parse_segment_size(1.5), 1)
+
+    def test_bytes_string(self):
+        self.assertEqual(_parse_segment_size("1024"), 1024)
+        self.assertEqual(_parse_segment_size("  2048  "), 2048)
+
+    def test_kb_suffix(self):
+        self.assertEqual(_parse_segment_size("1kb"), 1024)
+        self.assertEqual(_parse_segment_size("1KB"), 1024)
+        self.assertEqual(_parse_segment_size("512k"), 512 * 1024)
+        self.assertEqual(_parse_segment_size("1.5kb"), int(1.5 * 1024))
+
+    def test_mb_suffix(self):
+        self.assertEqual(_parse_segment_size("1mb"), 1024 ** 2)
+        self.assertEqual(_parse_segment_size("512MB"), 512 * 1024 ** 2)
+        self.assertEqual(_parse_segment_size("1m"), 1024 ** 2)
+
+    def test_gb_suffix(self):
+        self.assertEqual(_parse_segment_size("1gb"), 1024 ** 3)
+        self.assertEqual(_parse_segment_size("3GB"), 3 * 1024 ** 3)
+        self.assertEqual(_parse_segment_size("1g"), 1024 ** 3)
+        self.assertEqual(_parse_segment_size("1.5gb"), int(1.5 * 1024 ** 3))
+
+    def test_tb_suffix(self):
+        self.assertEqual(_parse_segment_size("1tb"), 1024 ** 4)
+        self.assertEqual(_parse_segment_size("1TB"), 1024 ** 4)
+        self.assertEqual(_parse_segment_size("1t"), 1024 ** 4)
+
+    def test_b_suffix(self):
+        self.assertEqual(_parse_segment_size("4096b"), 4096)
+        self.assertEqual(_parse_segment_size("4096B"), 4096)
+
+    def test_empty_string_raises(self):
+        with self.assertRaises(ValueError):
+            _parse_segment_size("")
+        with self.assertRaises(ValueError):
+            _parse_segment_size("   ")
+
+    def test_missing_number_raises(self):
+        with self.assertRaises(ValueError):
+            _parse_segment_size("gb")
+        with self.assertRaises(ValueError):
+            _parse_segment_size("mb")
+
+    def test_bare_float_string(self):
+        self.assertEqual(_parse_segment_size("1.5"), 1)
+        self.assertEqual(_parse_segment_size("1e9"), 1000000000)
+
+    def test_invalid_string_raises(self):
+        with self.assertRaises(ValueError):
+            _parse_segment_size("abc")
+
+    def test_whitespace_handling(self):
+        self.assertEqual(_parse_segment_size("  3 gb  "), 3 * 1024 ** 3)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/mooncake-wheel/tests/test_mooncake_config.py
+++ b/mooncake-wheel/tests/test_mooncake_config.py
@@ -3,7 +3,13 @@ import os
 import tempfile
 import unittest
 
-from mooncake.mooncake_config import MooncakeConfig, DEFAULT_GLOBAL_SEGMENT_SIZE, DEFAULT_LOCAL_BUFFER_SIZE, _parse_segment_size
+from mooncake.mooncake_config import (
+    MooncakeConfig,
+    DEFAULT_GLOBAL_SEGMENT_SIZE,
+    DEFAULT_LOCAL_BUFFER_SIZE,
+    _parse_segment_size,
+)
+
 
 class TestMooncakeConfig(unittest.TestCase):
     def setUp(self):
@@ -129,6 +135,7 @@ class TestMooncakeConfig(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             MooncakeConfig.load_from_env()
         self.assertIn("Neither the environment variable 'MOONCAKE_CONFIG_PATH' nor 'MOONCAKE_MASTER' is set.", str(cm.exception))
+
 
 class TestParseSegmentSize(unittest.TestCase):
     def test_integer_passthrough(self):


### PR DESCRIPTION
## Summary

Fixes #2320

- **Fix**: `_parse_segment_size` now supports KB/MB/GB/TB/B/K/M/G/T suffixes with float values (e.g. `"1.5gb"`, `"512mb"`), matching C++ `try_string_to_byte_size`. Previously only `"gb"` was recognized.
- **Fix**: Bare float strings without suffix (e.g. `"1.5"`, `"1e9"`) now handled via `int(float(s))` instead of crashing with `ValueError`.
- **Fix**: `handle_put` guards against `value=None` before calling `.encode()`, preventing `AttributeError` crash on malformed PUT requests.
- **Tests**: 13 new test cases for `_parse_segment_size` covering all suffixes, float values, empty strings, missing numbers, bare floats, and invalid input.

## What changed

| File | Change |
|------|--------|
| `mooncake_config.py` | Rewrite `_parse_segment_size` with `_SIZE_SUFFIXES` dict, longest-first matching, `float()` parsing |
| `mooncake_store_service.py` | Guard `raw_value = data.get('value')` + `is None` check before `.encode()` |
| `test_mooncake_config.py` | 13 new `TestParseSegmentSize` test cases |

## What did NOT change

- `MooncakeConfig` dataclass and `from_file`/`load_from_env` logic unchanged
- Existing valid inputs (`"3gb"`, `"3355443200"`, integer values) produce identical results
- No new dependencies

## Test plan

- [x] 19 tests pass (6 existing + 13 new) with Python 3.11
- [x] Workflow review: 1 should_fix (bare float fallback) addressed
- [ ] CI verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)