### PR TITLE
[TE/TENT] Allow building tebench without USE_TENT

### DIFF
--- a/mooncake-transfer-engine/CMakeLists.txt
+++ b/mooncake-transfer-engine/CMakeLists.txt
@@ -74,7 +74,12 @@ endif()
 
 if (USE_TENT)
   add_subdirectory(tent)
-  if (BUILD_BENCHMARK)
-    add_subdirectory(benchmark)
-  endif()
+endif()
+
+# tebench only needs the classic Transfer Engine for its default "classic"
+# backend; the TENT backend is compiled in conditionally (see benchmark/
+# CMakeLists.txt and main.cpp). Keep it gated solely on BUILD_BENCHMARK so it
+# can be built without enabling USE_TENT.
+if (BUILD_BENCHMARK)
+  add_subdirectory(benchmark)
 endif()

--- a/mooncake-transfer-engine/benchmark/CMakeLists.txt
+++ b/mooncake-transfer-engine/benchmark/CMakeLists.txt
@@ -17,8 +17,24 @@ else()
 endif()
 
 file(GLOB TEBENCH_SOURCES "*.cpp")
+# The TENT backend is only available when USE_TENT is enabled; drop its
+# translation unit (which pulls in tent/ headers) from non-TENT builds.
+if(NOT USE_TENT)
+  list(REMOVE_ITEM TEBENCH_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/tent_backend.cpp")
+endif()
 add_executable(tebench ${TEBENCH_SOURCES})
-target_link_libraries(tebench PUBLIC transfer_engine tent_link_group)
+target_link_libraries(tebench PUBLIC transfer_engine)
+if(USE_TENT)
+  target_compile_definitions(tebench PRIVATE USE_TENT)
+  # tent_link_group's interface brings in the tent/ header search path.
+  target_link_libraries(tebench PUBLIC tent_link_group)
+else()
+  # The classic backend still uses a couple of header-only helpers that live
+  # under tent/include (SimpleRandom in utils.h, bindToSocket in te_backend.cpp).
+  # Expose just the header path so tebench builds without the TENT library.
+  target_include_directories(tebench PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/../tent/include")
+endif()
 if(USE_CUDA)
   target_link_libraries(tebench PUBLIC CUDA::cudart)
 endif()

--- a/mooncake-transfer-engine/benchmark/main.cpp
+++ b/mooncake-transfer-engine/benchmark/main.cpp
@@ -16,7 +16,9 @@
 
 #include "bench_runner.h"
 #include "te_backend.h"
+#ifdef USE_TENT
 #include "tent_backend.h"
+#endif
 
 using namespace mooncake::tent;
 
@@ -101,10 +103,18 @@ int main(int argc, char* argv[]) {
     gflags::ParseCommandLineFlags(&argc, &argv, true);
     XferBenchConfig::loadFromFlags();
     std::unique_ptr<BenchRunner> runner;
-    if (XferBenchConfig::backend == "classic")
+    if (XferBenchConfig::backend == "classic") {
         runner = std::make_unique<TEBenchRunner>();
-    else
+    } else {
+#ifdef USE_TENT
         runner = std::make_unique<TENTBenchRunner>();
+#else
+        LOG(ERROR) << "Backend '" << XferBenchConfig::backend
+                   << "' requires building with -DUSE_TENT=ON; only the "
+                      "'classic' backend is available in this build";
+        return EXIT_FAILURE;
+#endif
+    }
     if (XferBenchConfig::target_seg_name.empty()) {
         std::cout << "\033[33mTo start initiators, run " << std::endl
                   << "  ./tebench --target_seg_name="


### PR DESCRIPTION
# Description

`tebench` supports two backends selected at runtime via `--backend`:

- `classic` — runs on the plain Transfer Engine
- `tent`    — runs on the TENT stack

In practice we sometimes want to benchmark the classic Transfer Engine using `tebench`, without pulling in the whole TENT build. The `classic` backend does not need TENT at all. 

This PR decouples the `tebench` build from `USE_TENT` so the benchmark can be built with only the classic backend.


## Changes

- When `USE_TENT=OFF`:
  - drop `tent_backend.cpp` from the sources (it pulls in `tent/` headers);
  - do not link `tent_link_group`; instead expose only the  `tent/include` header path, which is all the classic backend needs
    (it uses a couple of header-only helpers — `SimpleRandom` and  `bindToSocket`).
- When `USE_TENT=ON`: behavior is unchanged — `USE_TENT` is defined, `tent_link_group` is linked, and the TENT backend is compiled in.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

- `cmake -DUSE_TENT=OFF` → `tebench` builds; `--backend=classic` works, `--backend=tent` exits with the error above.
- `cmake -DUSE_TENT=ON` → unchanged; both backends available.

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
