### PR TITLE
[TransferEngine] Fix: TENT TCP transport implicitly creates CUDA context on GPU 0

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/platform/cuda.h
+++ b/mooncake-transfer-engine/tent/include/tent/platform/cuda.h
@@ -20,6 +20,7 @@
 #include "tent/common/concurrent/rw_spinlock.h"
 
 #include <cuda_runtime.h>
+#include "tent/platform/cuda_utils.h"
 
 namespace mooncake {
 namespace tent {

--- a/mooncake-transfer-engine/tent/include/tent/platform/cuda_utils.h
+++ b/mooncake-transfer-engine/tent/include/tent/platform/cuda_utils.h
@@ -1,0 +1,41 @@
+// Copyright 2025 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TENT_PLATFORM_CUDA_UTILS_H
+#define TENT_PLATFORM_CUDA_UTILS_H
+
+#include <cuda.h>
+
+namespace mooncake {
+namespace tent {
+
+// Use the CUDA driver API to find the device ordinal for a pointer without
+// requiring an initialized runtime context (avoids GPU 0 context creation).
+// Returns the device index if ptr is device memory, or -1 for host memory.
+inline int getCudaDeviceForPtr(void* ptr) {
+    unsigned int memType = 0;
+    CUresult res = cuPointerGetAttribute(
+        &memType, CU_POINTER_ATTRIBUTE_MEMORY_TYPE, (CUdeviceptr)ptr);
+    if (res != CUDA_SUCCESS || memType != CU_MEMORYTYPE_DEVICE) return -1;
+    unsigned int devOrdinal = 0;
+    res = cuPointerGetAttribute(
+        &devOrdinal, CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL, (CUdeviceptr)ptr);
+    if (res != CUDA_SUCCESS) return -1;
+    return static_cast<int>(devOrdinal);
+}
+
+}  // namespace tent
+}  // namespace mooncake
+
+#endif  // TENT_PLATFORM_CUDA_UTILS_H

--- a/mooncake-transfer-engine/tent/plugins/cuda/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/plugins/cuda/CMakeLists.txt
@@ -14,7 +14,7 @@ set(TENT_CUDA_PLUGIN_SOURCES
 add_library(tent_cuda_plugin SHARED ${TENT_CUDA_PLUGIN_SOURCES})
 
 target_link_libraries(tent_cuda_plugin
-    PRIVATE CUDA::cudart tent_plugin
+    PRIVATE CUDA::cudart CUDA::cuda_driver tent_plugin
 )
 
 set_target_properties(tent_cuda_plugin PROPERTIES

--- a/mooncake-transfer-engine/tent/plugins/cuda/cuda_plugin.cpp
+++ b/mooncake-transfer-engine/tent/plugins/cuda/cuda_plugin.cpp
@@ -13,12 +13,15 @@
 // limitations under the License.
 
 #include "tent/device_plugin.h"
+#include "tent/platform/cuda_utils.h"
 
 #include <cuda_runtime.h>
 #include <string.h>
 #include <stdio.h>
 #include <string>
 #include <glog/logging.h>
+
+using mooncake::tent::getCudaDeviceForPtr;
 
 struct cuda_plugin_ctx_t {
     // reserved
@@ -86,17 +89,18 @@ static int cuda_alloc(void* ctx_, void** pptr, size_t size, const char* loc) {
 static int cuda_free(void* ctx_, void* ptr, size_t size) {
     (void)ctx_;
     (void)size;
-    cudaPointerAttributes attrs;
-    CHECK_CUDA(cudaPointerGetAttributes(&attrs, ptr));
-    if (attrs.type == cudaMemoryTypeDevice) {
-        CHECK_CUDA(cudaFree(ptr));
-        return 0;
-    }
-    return -2;
+    if (getCudaDeviceForPtr(ptr) < 0) return -2;
+    CHECK_CUDA(cudaFree(ptr));
+    return 0;
 }
 
 static int cuda_memcpy_sync(void* ctx_, void* dst, void* src, size_t length) {
     (void)ctx_;
+    int dev = getCudaDeviceForPtr(src);
+    if (dev < 0) dev = getCudaDeviceForPtr(dst);
+    if (dev < 0)
+        return -1;  // Neither pointer is device memory; let memcpy handle it
+    CHECK_CUDA(cudaSetDevice(dev));
     CHECK_CUDA(cudaMemcpy(dst, src, length, cudaMemcpyDefault));
     return 0;
 }
@@ -105,12 +109,11 @@ static int cuda_query_location(void* ctx_, void* addr, size_t size,
                                location_t* buf, size_t buf_count) {
     (void)ctx_;
     if (buf_count == 0) return -1;
-    cudaPointerAttributes attr{};
-    cudaError_t err = cudaPointerGetAttributes(&attr, addr);
-    if (err != cudaSuccess || attr.type != cudaMemoryTypeDevice) return 0;
+    int dev = getCudaDeviceForPtr(addr);
+    if (dev < 0) return 0;
     buf[0].start = addr;
     buf[0].length = size;
-    snprintf(buf[0].location, LOCATION_LEN, "cuda:%d", attr.device);
+    snprintf(buf[0].location, LOCATION_LEN, "cuda:%d", dev);
     return 1;
 }
 

--- a/mooncake-transfer-engine/tent/src/platform/cuda/cuda_allocator.cpp
+++ b/mooncake-transfer-engine/tent/src/platform/cuda/cuda_allocator.cpp
@@ -16,12 +16,13 @@
 #include "tent/common/status.h"
 
 #include <bits/stdint-uintn.h>
-#include <cuda_runtime.h>
 #include <numa.h>
 #include <glog/logging.h>
+#include <cstring>
 
 namespace mooncake {
 namespace tent {
+
 Status CudaPlatform::allocate(void** pptr, size_t size,
                               MemoryOptions& options) {
     LocationParser location(options.location);
@@ -42,26 +43,34 @@ Status CudaPlatform::allocate(void** pptr, size_t size,
 }
 
 Status CudaPlatform::free(void* ptr, size_t size) {
-    cudaPointerAttributes attributes;
-    CHECK_CUDA(cudaPointerGetAttributes(&attributes, ptr));
-    if (attributes.type == cudaMemoryTypeDevice) {
+    int dev = getCudaDeviceForPtr(ptr);
+    if (dev >= 0) {
         CHECK_CUDA(cudaFree(ptr));
-    } else if (attributes.type == cudaMemoryTypeHost ||
-               attributes.type == cudaMemoryTypeUnregistered) {
-        numa_free(ptr, size);
     } else {
-        LOG(ERROR) << "Unknown memory type, " << ptr << " " << attributes.type;
+        numa_free(ptr, size);
     }
     return Status::OK();
 }
 
 Status CudaPlatform::copy(void* dst, void* src, size_t length) {
+    // Determine which GPU (if any) owns src or dst before touching any CUDA
+    // runtime API, to avoid implicitly creating a primary context on GPU 0.
+    int dev = getCudaDeviceForPtr(src);
+    if (dev < 0) dev = getCudaDeviceForPtr(dst);
+    if (dev < 0) {
+        // Both pointers are host memory; plain memcpy is sufficient.
+        ::memcpy(dst, src, length);
+        return Status::OK();
+    }
+    // Set the device before any CUDA runtime call so the calling thread
+    // doesn't implicitly initialize GPU 0 as its current device.
+    CHECK_CUDA(cudaSetDevice(dev));
     // Use cudaMemcpyAsync with a non-blocking stream instead of cudaMemcpy(),
     // as the latter relies on the legacy default stream and can introduce
     // unintended synchronization or even deadlocks in downstream
     // components (e.g. mooncake-pg).
     CUDAStreamHandle stream;
-    CHECK_STATUS(getStreamFromPool(stream));
+    CHECK_STATUS(getStreamFromPool(stream, dev));
     CHECK_CUDA(
         cudaMemcpyAsync(dst, src, length, cudaMemcpyDefault, stream.get()));
     CHECK_CUDA(cudaStreamSynchronize(stream.get()));

--- a/mooncake-transfer-engine/tent/src/platform/cuda/cuda_probe.cpp
+++ b/mooncake-transfer-engine/tent/src/platform/cuda/cuda_probe.cpp
@@ -25,7 +25,6 @@
 #include <string>
 #include <utility>
 #include <vector>
-#include <cuda_runtime.h>
 #include <ctype.h>
 #include <dirent.h>
 #include <infiniband/verbs.h>
@@ -39,6 +38,7 @@
 
 namespace mooncake {
 namespace tent {
+
 static std::vector<Topology::NicEntry> listInfiniBandDevices() {
     int num_devices = 0;
     std::vector<Topology::NicEntry> devices;
@@ -263,16 +263,7 @@ Status CudaPlatform::probe(std::vector<Topology::NicEntry>& nic_list,
 }
 
 MemoryType CudaPlatform::getMemoryType(void* addr) {
-    cudaPointerAttributes attributes;
-    cudaError_t result;
-    result = cudaPointerGetAttributes(&attributes, addr);
-    if (result != cudaSuccess) {
-        LOG(WARNING) << "cudaPointerGetAttributes: "
-                     << cudaGetErrorString(result);
-        return MTYPE_UNKNOWN;
-    }
-    if (attributes.type == cudaMemoryTypeDevice) return MTYPE_CUDA;
-    return MTYPE_CPU;
+    return getCudaDeviceForPtr(addr) >= 0 ? MTYPE_CUDA : MTYPE_CPU;
 }
 
 static inline uintptr_t alignPage(uintptr_t address) {
@@ -296,20 +287,9 @@ const std::vector<RangeLocation> CudaPlatform::getLocation(void* start,
     const static size_t kPageSize = 4096;
     std::vector<RangeLocation> entries;
 
-    cudaPointerAttributes attributes;
-    cudaError_t result;
-
-    result = cudaPointerGetAttributes(&attributes, start);
-    if (result != cudaSuccess) {
-        LOG(WARNING) << "cudaPointerGetAttributes: "
-                     << cudaGetErrorString(result);
-        entries.push_back({(uint64_t)start, len, kWildcardLocation});
-        return entries;
-    }
-
-    if (attributes.type == cudaMemoryTypeDevice) {
-        entries.push_back(
-            {(uint64_t)start, len, genCudaNodeName(attributes.device)});
+    int cudaDev = getCudaDeviceForPtr(start);
+    if (cudaDev >= 0) {
+        entries.push_back({(uint64_t)start, len, genCudaNodeName(cudaDev)});
         return entries;
     }
 


### PR DESCRIPTION
## Problem

When using TENT's TCP transport to transfer GPU memory, processes that only use a specific GPU (e.g., GPU 7) or only DRAM would spuriously acquire a primary CUDA context on **GPU 0**, as observed via `nvidia-smi --query-compute-apps`.

This was reproduced using the script shared in PR #2307 comments by @chestnut-Q.

## Root Causes

Two categories of CUDA runtime calls silently trigger GPU 0 context creation on any thread with no prior `cudaSetDevice()`:

1. **`cudaPointerGetAttributes()`** — used in `cuda_free()`, `getMemoryType()`, `getLocation()`, and `cuda_query_location()` to classify host/device pointers. Calling it on a host pointer initializes the CUDA runtime with GPU 0 as the default device.

2. **`CudaPlatform::copy()`** — called `getStreamFromPool()` with `kCurrentDevice = -1`, which internally called `cudaGetDevice()` on a worker thread with no prior `cudaSetDevice()`, returning 0 and silently initializing GPU 0.

## Fix

- **New `cuda_utils.h`**: introduces `getCudaDeviceForPtr()` using the CUDA **driver API** (`cuPointerGetAttribute`). Unlike the runtime API, the driver API returns an error code for host pointers without initializing any context, making it safe to call from any thread.
- **`CudaPlatform::copy()`**: for host-to-host transfers (both pointers classify as non-device), falls back to `::memcpy` entirely — no CUDA involved. For GPU transfers, calls `cudaSetDevice(dev)` before any runtime API call to establish the correct device on the calling thread.
- **All `cudaPointerGetAttributes` call sites** in `cuda_allocator.cpp`, `cuda_probe.cpp`, and `cuda_plugin.cpp` are replaced with `getCudaDeviceForPtr()`.
- **`plugins/cuda/CMakeLists.txt`**: adds `CUDA::cuda_driver` to link the driver API.

## Verification

Tested with the two-process reproduction script (`test_tent_repro_2307.py`) on an 8×H200 machine:

**Before fix**: after 50× `transfer_sync_write` from initiator (GPU 7) to target (DRAM), both processes showed a compute context on GPU 0 in `nvidia-smi`.

**After fix**:
```
=== COMPUTE APPS ===
<initiator_pid>, GPU-...<GPU7_uuid>, 584 MiB   ← only GPU 7, correct
=== GPU MEM ===
0,   4 MiB   ← baseline only, no compute context
7, 593 MiB   ← initiator's alloc
```

No spurious GPU 0 context on either side.

## Relation to PR #2307

PR #2307 fixed the same issue in the non-TENT `TcpTransport`. This PR applies the equivalent fix to the TENT code path (`CudaPlatform` + `cuda_plugin`), as requested by @chestnut-Q in the review comments.