### PR TITLE
[TransferEngine] Fix resource leaks in error paths

### DIFF
--- a/mooncake-transfer-engine/src/multi_transport.cpp
+++ b/mooncake-transfer-engine/src/multi_transport.cpp
@@ -422,6 +422,7 @@ Transport* MultiTransport::installTransport(const std::string& proto,
     }
 #endif
     if (transport->install(local_server_name_, metadata_, topo)) {
+        delete transport;
         return nullptr;
     }
 

--- a/mooncake-transfer-engine/src/transfer_engine_c.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine_c.cpp
@@ -203,8 +203,10 @@ notify_msg_t *getNotifsFromEngine(transfer_engine_t engine, int *size) {
     std::vector<TransferMetadata::NotifyDesc> notifies_desc;
     native->getNotifies(notifies_desc);
     *size = notifies_desc.size();
+    if (*size == 0) return nullptr;
     notify_msg_t *notifies =
         (notify_msg_t *)malloc(*size * sizeof(notify_msg_t));
+    if (!notifies) return nullptr;
     memset(notifies, 0, *size * sizeof(notify_msg_t));
     for (int i = 0; i < *size; i++) {
         notifies[i].name = (char *)malloc(notifies_desc[i].name.size() + 1);


### PR DESCRIPTION
## Summary

Fix two resource leaks in transfer engine error paths.

### 1. Transport object leaked when `install()` fails

`MultiTransport::installTransport()` allocates a `Transport` via `new` but returns `nullptr` without `delete` when `install()` fails (line 424-425). The raw pointer is leaked.

**Fix**: Add `delete transport` before the error return.

### 2. `getNotifsFromEngine` null dereference on malloc failure

`getNotifsFromEngine()` calls `malloc()` and immediately passes the result to `memset()` without a null check (line 206-208). On allocation failure, this is a null pointer dereference. Additionally, when `*size == 0`, `malloc(0)` has implementation-defined behavior.

**Fix**: Early return when size is 0; null check after malloc.

## What changed

| File | Change |
|------|--------|
| `multi_transport.cpp` | +1 line: `delete transport` before error return |
| `transfer_engine_c.cpp` | +2 lines: size-zero early return + malloc null check |

## What did NOT change

- No behavioral change on success paths
- No new dependencies
- No API changes

## Test plan

- [ ] CI build verification (no local RDMA/GPU hardware to test)
- Fixes are mechanically correct: they only add cleanup on error paths that previously leaked

🤖 Generated with [Claude Code](https://claude.com/claude-code)