### PR TITLE
[Store] Clean up tenant-aware master service APIs

### DIFF
--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -163,18 +163,18 @@ class MasterService {
      * @brief Check if an object exists
      * @return ErrorCode::OK if exists, otherwise return other ErrorCode
      */
-    auto ExistKey(const std::string& key) -> tl::expected<bool, ErrorCode>;
     auto ExistKey(const std::string& key, const std::string& tenant_id)
         -> tl::expected<bool, ErrorCode>;
 
     std::vector<tl::expected<bool, ErrorCode>> BatchExistKey(
-        const std::vector<std::string>& keys);
+        const std::vector<std::string>& keys, const std::string& tenant_id);
 
     /**
-     * @brief Fetch all keys
+     * @brief Fetch all keys for a single tenant.
      * @return ErrorCode::OK if exists
      */
-    auto GetAllKeys() -> tl::expected<std::vector<std::string>, ErrorCode>;
+    auto GetAllKeys(const std::string& tenant_id)
+        -> tl::expected<std::vector<std::string>, ErrorCode>;
 
     /**
      * @brief Fetch all segments, each node has a unique real client with fixed
@@ -255,10 +255,6 @@ class MasterService {
      * @return An expected object containing a map from object keys to their
      * replica descriptors on success, or an ErrorCode on failure.
      */
-    auto GetReplicaListByRegex(const std::string& regex_pattern)
-        -> tl::expected<
-            std::unordered_map<std::string, std::vector<Replica::Descriptor>>,
-            ErrorCode>;
     auto GetReplicaListByRegex(const std::string& regex_pattern,
                                const std::string& tenant_id)
         -> tl::expected<
@@ -271,8 +267,6 @@ class MasterService {
      * @return ErrorCode::OK on success, ErrorCode::REPLICA_IS_NOT_READY if not
      * ready
      */
-    auto GetReplicaList(const std::string& key)
-        -> tl::expected<GetReplicaListResponse, ErrorCode>;
     auto GetReplicaList(const std::string& key, const std::string& tenant_id)
         -> tl::expected<GetReplicaListResponse, ErrorCode>;
 
@@ -285,9 +279,6 @@ class MasterService {
      *         ErrorCode::INVALID_PARAMS if slice size is invalid
      */
     auto PutStart(const UUID& client_id, const std::string& key,
-                  const uint64_t slice_length, const ReplicateConfig& config)
-        -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode>;
-    auto PutStart(const UUID& client_id, const std::string& key,
                   const std::string& tenant_id, const uint64_t slice_length,
                   const ReplicateConfig& config)
         -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode>;
@@ -299,16 +290,12 @@ class MasterService {
      * found, ErrorCode::INVALID_WRITE if replica status is invalid
      */
     auto PutEnd(const UUID& client_id, const std::string& key,
-                ReplicaType replica_type) -> tl::expected<void, ErrorCode>;
-    auto PutEnd(const UUID& client_id, const std::string& key,
                 const std::string& tenant_id, ReplicaType replica_type)
         -> tl::expected<void, ErrorCode>;
 
     /**
      * @brief Adds a replica instance associated with the given client and key.
      */
-    auto AddReplica(const UUID& client_id, const std::string& key,
-                    Replica& replica) -> tl::expected<void, ErrorCode>;
     auto AddReplica(const UUID& client_id, const std::string& key,
                     const std::string& tenant_id, Replica& replica)
         -> tl::expected<void, ErrorCode>;
@@ -320,8 +307,6 @@ class MasterService {
      * found, ErrorCode::INVALID_WRITE if replica status is invalid
      */
     auto PutRevoke(const UUID& client_id, const std::string& key,
-                   ReplicaType replica_type) -> tl::expected<void, ErrorCode>;
-    auto PutRevoke(const UUID& client_id, const std::string& key,
                    const std::string& tenant_id, ReplicaType replica_type)
         -> tl::expected<void, ErrorCode>;
 
@@ -332,9 +317,6 @@ class MasterService {
      */
     std::vector<tl::expected<void, ErrorCode>> BatchPutEnd(
         const UUID& client_id, const std::vector<std::string>& keys,
-        ReplicaType replica_type = ReplicaType::ALL);
-    std::vector<tl::expected<void, ErrorCode>> BatchPutEnd(
-        const UUID& client_id, const std::vector<std::string>& keys,
         const std::string& tenant_id,
         ReplicaType replica_type = ReplicaType::ALL);
 
@@ -343,9 +325,6 @@ class MasterService {
      * @return ErrorCode::OK on success, ErrorCode::OBJECT_NOT_FOUND if not
      * found, ErrorCode::INVALID_WRITE if replica status is invalid
      */
-    std::vector<tl::expected<void, ErrorCode>> BatchPutRevoke(
-        const UUID& client_id, const std::vector<std::string>& keys,
-        ReplicaType replica_type = ReplicaType::ALL);
     std::vector<tl::expected<void, ErrorCode>> BatchPutRevoke(
         const UUID& client_id, const std::vector<std::string>& keys,
         const std::string& tenant_id,
@@ -361,9 +340,6 @@ class MasterService {
      * progress), OBJECT_REPLICA_BUSY (replicas have non-zero refcnt).
      */
     auto UpsertStart(const UUID& client_id, const std::string& key,
-                     const uint64_t slice_length, const ReplicateConfig& config)
-        -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode>;
-    auto UpsertStart(const UUID& client_id, const std::string& key,
                      const std::string& tenant_id, const uint64_t slice_length,
                      const ReplicateConfig& config)
         -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode>;
@@ -372,8 +348,6 @@ class MasterService {
      * @brief Complete an upsert operation. Delegates to PutEnd.
      */
     auto UpsertEnd(const UUID& client_id, const std::string& key,
-                   ReplicaType replica_type) -> tl::expected<void, ErrorCode>;
-    auto UpsertEnd(const UUID& client_id, const std::string& key,
                    const std::string& tenant_id, ReplicaType replica_type)
         -> tl::expected<void, ErrorCode>;
 
@@ -381,20 +355,12 @@ class MasterService {
      * @brief Revoke an upsert operation. Delegates to PutRevoke.
      */
     auto UpsertRevoke(const UUID& client_id, const std::string& key,
-                      ReplicaType replica_type)
-        -> tl::expected<void, ErrorCode>;
-    auto UpsertRevoke(const UUID& client_id, const std::string& key,
                       const std::string& tenant_id, ReplicaType replica_type)
         -> tl::expected<void, ErrorCode>;
 
     /**
      * @brief Start a batch of upsert operations.
      */
-    std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
-    BatchUpsertStart(const UUID& client_id,
-                     const std::vector<std::string>& keys,
-                     const std::vector<uint64_t>& slice_lengths,
-                     const ReplicateConfig& config);
     std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
     BatchUpsertStart(const UUID& client_id,
                      const std::vector<std::string>& keys,
@@ -406,16 +372,12 @@ class MasterService {
      * @brief Complete a batch of upsert operations. Delegates to BatchPutEnd.
      */
     std::vector<tl::expected<void, ErrorCode>> BatchUpsertEnd(
-        const UUID& client_id, const std::vector<std::string>& keys);
-    std::vector<tl::expected<void, ErrorCode>> BatchUpsertEnd(
         const UUID& client_id, const std::vector<std::string>& keys,
         const std::string& tenant_id);
 
     /**
      * @brief Revoke a batch of upsert operations. Delegates to BatchPutRevoke.
      */
-    std::vector<tl::expected<void, ErrorCode>> BatchUpsertRevoke(
-        const UUID& client_id, const std::vector<std::string>& keys);
     std::vector<tl::expected<void, ErrorCode>> BatchUpsertRevoke(
         const UUID& client_id, const std::vector<std::string>& keys,
         const std::string& tenant_id);
@@ -429,9 +391,6 @@ class MasterService {
      * @return ErrorCode::OK on success, OBJECT_NOT_FOUND if key missing
      */
     auto EvictDiskReplica(const UUID& client_id, const std::string& key,
-                          ReplicaType replica_type)
-        -> tl::expected<void, ErrorCode>;
-    auto EvictDiskReplica(const UUID& client_id, const std::string& key,
                           const std::string& tenant_id,
                           ReplicaType replica_type)
         -> tl::expected<void, ErrorCode>;
@@ -443,9 +402,6 @@ class MasterService {
      * @param replica_type DISK or LOCAL_DISK
      * @return Per-key results (OK or error code)
      */
-    std::vector<tl::expected<void, ErrorCode>> BatchEvictDiskReplica(
-        const UUID& client_id, const std::vector<std::string>& keys,
-        ReplicaType replica_type);
     std::vector<tl::expected<void, ErrorCode>> BatchEvictDiskReplica(
         const UUID& client_id, const std::vector<std::string>& keys,
         const std::string& tenant_id, ReplicaType replica_type);
@@ -465,21 +421,13 @@ class MasterService {
      */
     tl::expected<CopyStartResponse, ErrorCode> CopyStart(
         const UUID& client_id, const std::string& key,
-        const std::string& src_segment,
-        const std::vector<std::string>& tgt_segments);
-    tl::expected<CopyStartResponse, ErrorCode> CopyStart(
-        const UUID& client_id, const std::string& key,
         const std::string& tenant_id, const std::string& src_segment,
         const std::vector<std::string>& tgt_segments);
 
     tl::expected<void, ErrorCode> CopyEnd(const UUID& client_id,
-                                          const std::string& key);
-    tl::expected<void, ErrorCode> CopyEnd(const UUID& client_id,
                                           const std::string& key,
                                           const std::string& tenant_id);
 
-    tl::expected<void, ErrorCode> CopyRevoke(const UUID& client_id,
-                                             const std::string& key);
     tl::expected<void, ErrorCode> CopyRevoke(const UUID& client_id,
                                              const std::string& key,
                                              const std::string& tenant_id);
@@ -499,20 +447,13 @@ class MasterService {
      */
     tl::expected<MoveStartResponse, ErrorCode> MoveStart(
         const UUID& client_id, const std::string& key,
-        const std::string& src_segment, const std::string& tgt_segment);
-    tl::expected<MoveStartResponse, ErrorCode> MoveStart(
-        const UUID& client_id, const std::string& key,
         const std::string& tenant_id, const std::string& src_segment,
         const std::string& tgt_segment);
 
     tl::expected<void, ErrorCode> MoveEnd(const UUID& client_id,
-                                          const std::string& key);
-    tl::expected<void, ErrorCode> MoveEnd(const UUID& client_id,
                                           const std::string& key,
                                           const std::string& tenant_id);
 
-    tl::expected<void, ErrorCode> MoveRevoke(const UUID& client_id,
-                                             const std::string& key);
     tl::expected<void, ErrorCode> MoveRevoke(const UUID& client_id,
                                              const std::string& key,
                                              const std::string& tenant_id);
@@ -524,8 +465,6 @@ class MasterService {
      * @return ErrorCode::OK on success, ErrorCode::OBJECT_NOT_FOUND if not
      * found
      */
-    auto Remove(const std::string& key, bool force = false)
-        -> tl::expected<void, ErrorCode>;
     auto Remove(const std::string& key, const std::string& tenant_id,
                 bool force = false) -> tl::expected<void, ErrorCode>;
 
@@ -536,8 +475,6 @@ class MasterService {
      * @return An expected object containing the number of removed objects on
      * success, or an ErrorCode on failure.
      */
-    auto RemoveByRegex(const std::string& str, bool force = false)
-        -> tl::expected<long, ErrorCode>;
     auto RemoveByRegex(const std::string& str, const std::string& tenant_id,
                        bool force = false) -> tl::expected<long, ErrorCode>;
 
@@ -562,8 +499,6 @@ class MasterService {
      * @param force If true, skip lease and replication task checks.
      * @return Vector of expected results for each key.
      */
-    auto BatchRemove(const std::vector<std::string>& keys, bool force = false)
-        -> std::vector<tl::expected<void, ErrorCode>>;
     auto BatchRemove(const std::vector<std::string>& keys,
                      const std::string& tenant_id, bool force = false)
         -> std::vector<tl::expected<void, ErrorCode>>;
@@ -620,15 +555,11 @@ class MasterService {
     /**
      * @brief Notifies the master that offloading of specified objects has
      * succeeded.
-     * @param keys         A list of object keys (names) that were successfully
-     * offloaded.
+     * @param tasks        A list of tenant-scoped objects that were
+     * successfully offloaded.
      * @param metadatas    The corresponding metadata for each offloaded object,
      * including size, storage location, etc.
      */
-    auto NotifyOffloadSuccess(
-        const UUID& client_id, const std::vector<std::string>& keys,
-        const std::vector<StorageObjectMetadata>& metadatas)
-        -> tl::expected<void, ErrorCode>;
     auto NotifyOffloadSuccess(
         const UUID& client_id, const std::vector<OffloadTaskItem>& tasks,
         const std::vector<StorageObjectMetadata>& metadatas)
@@ -657,10 +588,6 @@ class MasterService {
      * arbitrary buffer size from a buggy or malicious caller.
      */
     auto PromotionAllocStart(const UUID& client_id, const std::string& key,
-                             uint64_t size,
-                             const std::vector<std::string>& preferred_segments)
-        -> tl::expected<PromotionAllocStartResponse, ErrorCode>;
-    auto PromotionAllocStart(const UUID& client_id, const std::string& key,
                              const std::string& tenant_id, uint64_t size,
                              const std::vector<std::string>& preferred_segments)
         -> tl::expected<PromotionAllocStartResponse, ErrorCode>;
@@ -670,8 +597,6 @@ class MasterService {
      * refcnt; erase per-shard and per-client task entries. Mirror of
      * NotifyOffloadSuccess.
      */
-    auto NotifyPromotionSuccess(const UUID& client_id, const std::string& key)
-        -> tl::expected<void, ErrorCode>;
     auto NotifyPromotionSuccess(const UUID& client_id, const std::string& key,
                                 const std::string& tenant_id)
         -> tl::expected<void, ErrorCode>;
@@ -694,8 +619,6 @@ class MasterService {
      * task, decrement the global in-flight counter, and clear the
      * holder's promotion_objects entry.
      */
-    auto NotifyPromotionFailure(const UUID& client_id, const std::string& key)
-        -> tl::expected<void, ErrorCode>;
     auto NotifyPromotionFailure(const UUID& client_id, const std::string& key,
                                 const std::string& tenant_id)
         -> tl::expected<void, ErrorCode>;
@@ -705,8 +628,6 @@ class MasterService {
      * @return Copy task ID on success, ErrorCode on failure
      */
     tl::expected<UUID, ErrorCode> CreateCopyTask(
-        const std::string& key, const std::vector<std::string>& targets);
-    tl::expected<UUID, ErrorCode> CreateCopyTask(
         const std::string& key, const std::string& tenant_id,
         const std::vector<std::string>& targets);
 
@@ -715,9 +636,6 @@ class MasterService {
      * to target segment
      * @return Move task ID on success, ErrorCode on failure
      */
-    tl::expected<UUID, ErrorCode> CreateMoveTask(const std::string& key,
-                                                 const std::string& source,
-                                                 const std::string& target);
     tl::expected<UUID, ErrorCode> CreateMoveTask(const std::string& key,
                                                  const std::string& tenant_id,
                                                  const std::string& source,
@@ -1469,9 +1387,6 @@ class MasterService {
     // Helper class for accessing metadata with automatic locking and cleanup
     class MetadataAccessorRW {
        public:
-        MetadataAccessorRW(MasterService* service, const std::string& key)
-            : MetadataAccessorRW(service, MakeObjectIdentity(key)) {}
-
         MetadataAccessorRW(MasterService* service,
                            const ObjectIdentity& object_id)
             : service_(service),
@@ -1680,9 +1595,6 @@ class MasterService {
     friend class MetadataAccessor;
     class MetadataAccessorRO {
        public:
-        MetadataAccessorRO(const MasterService* service, const std::string& key)
-            : MetadataAccessorRO(service, MakeObjectIdentity(key)) {}
-
         MetadataAccessorRO(const MasterService* service,
                            const ObjectIdentity& object_id)
             : service_(service),
@@ -1956,10 +1868,6 @@ class MasterService {
     std::string MakeDrainUnitKey(const std::string& tenant_id,
                                  const std::string& key,
                                  const std::string& source_segment) const;
-    std::string MakeDrainUnitKey(const std::string& key,
-                                 const std::string& source_segment) const {
-        return MakeDrainUnitKey("default", key, source_segment);
-    }
 
     std::thread job_dispatch_thread_;
     std::atomic<bool> job_dispatch_running_{false};

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1193,8 +1193,8 @@ class MasterService {
         SharedMutexLocker lock_;
     };
 
-    static ObjectIdentity MakeObjectIdentity(
-        const std::string& user_key, const std::string& tenant_id = "default") {
+    static ObjectIdentity MakeObjectIdentity(const std::string& user_key,
+                                             const std::string& tenant_id) {
         return {NormalizeTenantId(tenant_id), user_key};
     }
 
@@ -1226,7 +1226,6 @@ class MasterService {
         return std::hash<std::string>{}(key) % kNumShards;
     }
 
-    size_t getMetadataShardIndex(const std::string& key) const;
     size_t getMetadataShardIndex(const std::string& tenant_id,
                                  const std::string& key) const;
     std::optional<std::string> GetGroupRoute(const std::string& tenant_id,

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -933,11 +933,6 @@ auto MasterService::UnmountNoFSegment(const UUID& segment_id,
 #endif
 }
 
-auto MasterService::ExistKey(const std::string& key)
-    -> tl::expected<bool, ErrorCode> {
-    return ExistKey(key, "default");
-}
-
 auto MasterService::ExistKey(const std::string& key,
                              const std::string& tenant_id)
     -> tl::expected<bool, ErrorCode> {
@@ -966,21 +961,22 @@ auto MasterService::ExistKey(const std::string& key,
 }
 
 std::vector<tl::expected<bool, ErrorCode>> MasterService::BatchExistKey(
-    const std::vector<std::string>& keys) {
+    const std::vector<std::string>& keys, const std::string& tenant_id) {
     std::vector<tl::expected<bool, ErrorCode>> results;
     results.reserve(keys.size());
     for (const auto& key : keys) {
-        results.emplace_back(ExistKey(key));
+        results.emplace_back(ExistKey(key, tenant_id));
     }
     return results;
 }
 
-auto MasterService::GetAllKeys()
+auto MasterService::GetAllKeys(const std::string& tenant_id)
     -> tl::expected<std::vector<std::string>, ErrorCode> {
     std::vector<std::string> all_keys;
+    const auto normalized_tenant = NormalizeTenantId(tenant_id);
     for (size_t i = 0; i < kNumShards; i++) {
         MetadataShardAccessorRO shard(this, i);
-        auto tenant_it = shard->tenants.find("default");
+        auto tenant_it = shard->tenants.find(normalized_tenant);
         if (tenant_it == shard->tenants.end()) {
             continue;
         }
@@ -1120,7 +1116,8 @@ auto MasterService::BatchReplicaClear(
             LOG(WARNING) << "BatchReplicaClear: empty key, skipping";
             continue;
         }
-        MetadataAccessorRW accessor(this, key);
+        // BatchReplicaClear is a default-tenant compatibility/admin helper.
+        MetadataAccessorRW accessor(this, MakeObjectIdentity(key, "default"));
         if (!accessor.Exists()) {
             LOG(WARNING) << "BatchReplicaClear: key=" << key
                          << " not found, skipping";
@@ -1224,13 +1221,6 @@ auto MasterService::BatchReplicaClear(
     return cleared_keys;
 }
 
-auto MasterService::GetReplicaListByRegex(const std::string& regex_pattern)
-    -> tl::expected<
-        std::unordered_map<std::string, std::vector<Replica::Descriptor>>,
-        ErrorCode> {
-    return GetReplicaListByRegex(regex_pattern, "default");
-}
-
 auto MasterService::GetReplicaListByRegex(const std::string& regex_pattern,
                                           const std::string& tenant_id)
     -> tl::expected<
@@ -1278,11 +1268,6 @@ auto MasterService::GetReplicaListByRegex(const std::string& regex_pattern,
     }
 
     return results;
-}
-
-auto MasterService::GetReplicaList(const std::string& key)
-    -> tl::expected<GetReplicaListResponse, ErrorCode> {
-    return GetReplicaList(key, "default");
 }
 
 auto MasterService::GetReplicaList(const std::string& key,
@@ -1513,13 +1498,6 @@ auto MasterService::AllocateAndInsertMetadata(
 }
 
 auto MasterService::PutStart(const UUID& client_id, const std::string& key,
-                             const uint64_t slice_length,
-                             const ReplicateConfig& config)
-    -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode> {
-    return PutStart(client_id, key, "default", slice_length, config);
-}
-
-auto MasterService::PutStart(const UUID& client_id, const std::string& key,
                              const std::string& tenant_id,
                              const uint64_t slice_length,
                              const ReplicateConfig& config)
@@ -1644,12 +1622,6 @@ auto MasterService::PutStart(const UUID& client_id, const std::string& key,
 }
 
 auto MasterService::PutEnd(const UUID& client_id, const std::string& key,
-                           ReplicaType replica_type)
-    -> tl::expected<void, ErrorCode> {
-    return PutEnd(client_id, key, "default", replica_type);
-}
-
-auto MasterService::PutEnd(const UUID& client_id, const std::string& key,
                            const std::string& tenant_id,
                            ReplicaType replica_type)
     -> tl::expected<void, ErrorCode> {
@@ -1726,12 +1698,6 @@ auto MasterService::PutEnd(const UUID& client_id, const std::string& key,
 }
 
 auto MasterService::AddReplica(const UUID& client_id, const std::string& key,
-                               Replica& replica)
-    -> tl::expected<void, ErrorCode> {
-    return AddReplica(client_id, key, "default", replica);
-}
-
-auto MasterService::AddReplica(const UUID& client_id, const std::string& key,
                                const std::string& tenant_id, Replica& replica)
     -> tl::expected<void, ErrorCode> {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
@@ -1774,12 +1740,6 @@ auto MasterService::AddReplica(const UUID& client_id, const std::string& key,
                     .object_size;
         });
     return {};
-}
-
-auto MasterService::PutRevoke(const UUID& client_id, const std::string& key,
-                              ReplicaType replica_type)
-    -> tl::expected<void, ErrorCode> {
-    return PutRevoke(client_id, key, "default", replica_type);
 }
 
 auto MasterService::PutRevoke(const UUID& client_id, const std::string& key,
@@ -1842,12 +1802,6 @@ auto MasterService::PutRevoke(const UUID& client_id, const std::string& key,
 
 std::vector<tl::expected<void, ErrorCode>> MasterService::BatchPutEnd(
     const UUID& client_id, const std::vector<std::string>& keys,
-    ReplicaType replica_type) {
-    return BatchPutEnd(client_id, keys, "default", replica_type);
-}
-
-std::vector<tl::expected<void, ErrorCode>> MasterService::BatchPutEnd(
-    const UUID& client_id, const std::vector<std::string>& keys,
     const std::string& tenant_id, ReplicaType replica_type) {
     std::vector<tl::expected<void, ErrorCode>> results;
     results.reserve(keys.size());
@@ -1855,12 +1809,6 @@ std::vector<tl::expected<void, ErrorCode>> MasterService::BatchPutEnd(
         results.emplace_back(PutEnd(client_id, key, tenant_id, replica_type));
     }
     return results;
-}
-
-std::vector<tl::expected<void, ErrorCode>> MasterService::BatchPutRevoke(
-    const UUID& client_id, const std::vector<std::string>& keys,
-    ReplicaType replica_type) {
-    return BatchPutRevoke(client_id, keys, "default", replica_type);
 }
 
 std::vector<tl::expected<void, ErrorCode>> MasterService::BatchPutRevoke(
@@ -1889,13 +1837,6 @@ std::vector<tl::expected<void, ErrorCode>> MasterService::BatchPutRevoke(
 //
 // Note: during Case B the key is temporarily unreadable (all replicas are
 // PROCESSING).  Readers will get REPLICA_IS_NOT_READY until UpsertEnd.
-auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
-                                const uint64_t slice_length,
-                                const ReplicateConfig& config)
-    -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode> {
-    return UpsertStart(client_id, key, "default", slice_length, config);
-}
-
 auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
                                 const std::string& tenant_id,
                                 const uint64_t slice_length,
@@ -2152,12 +2093,6 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
 }
 
 auto MasterService::UpsertEnd(const UUID& client_id, const std::string& key,
-                              ReplicaType replica_type)
-    -> tl::expected<void, ErrorCode> {
-    return UpsertEnd(client_id, key, "default", replica_type);
-}
-
-auto MasterService::UpsertEnd(const UUID& client_id, const std::string& key,
                               const std::string& tenant_id,
                               ReplicaType replica_type)
     -> tl::expected<void, ErrorCode> {
@@ -2165,24 +2100,10 @@ auto MasterService::UpsertEnd(const UUID& client_id, const std::string& key,
 }
 
 auto MasterService::UpsertRevoke(const UUID& client_id, const std::string& key,
-                                 ReplicaType replica_type)
-    -> tl::expected<void, ErrorCode> {
-    return UpsertRevoke(client_id, key, "default", replica_type);
-}
-
-auto MasterService::UpsertRevoke(const UUID& client_id, const std::string& key,
                                  const std::string& tenant_id,
                                  ReplicaType replica_type)
     -> tl::expected<void, ErrorCode> {
     return PutRevoke(client_id, key, tenant_id, replica_type);
-}
-
-std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
-MasterService::BatchUpsertStart(const UUID& client_id,
-                                const std::vector<std::string>& keys,
-                                const std::vector<uint64_t>& slice_lengths,
-                                const ReplicateConfig& config) {
-    return BatchUpsertStart(client_id, keys, "default", slice_lengths, config);
 }
 
 std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>
@@ -2219,32 +2140,15 @@ MasterService::BatchUpsertStart(const UUID& client_id,
 }
 
 std::vector<tl::expected<void, ErrorCode>> MasterService::BatchUpsertEnd(
-    const UUID& client_id, const std::vector<std::string>& keys) {
-    return BatchUpsertEnd(client_id, keys, "default");
-}
-
-std::vector<tl::expected<void, ErrorCode>> MasterService::BatchUpsertEnd(
     const UUID& client_id, const std::vector<std::string>& keys,
     const std::string& tenant_id) {
     return BatchPutEnd(client_id, keys, tenant_id);
 }
 
 std::vector<tl::expected<void, ErrorCode>> MasterService::BatchUpsertRevoke(
-    const UUID& client_id, const std::vector<std::string>& keys) {
-    return BatchUpsertRevoke(client_id, keys, "default");
-}
-
-std::vector<tl::expected<void, ErrorCode>> MasterService::BatchUpsertRevoke(
     const UUID& client_id, const std::vector<std::string>& keys,
     const std::string& tenant_id) {
     return BatchPutRevoke(client_id, keys, tenant_id);
-}
-
-auto MasterService::EvictDiskReplica(const UUID& client_id,
-                                     const std::string& key,
-                                     ReplicaType replica_type)
-    -> tl::expected<void, ErrorCode> {
-    return EvictDiskReplica(client_id, key, "default", replica_type);
 }
 
 auto MasterService::EvictDiskReplica(const UUID& client_id,
@@ -2287,12 +2191,6 @@ auto MasterService::EvictDiskReplica(const UUID& client_id,
 
 std::vector<tl::expected<void, ErrorCode>> MasterService::BatchEvictDiskReplica(
     const UUID& client_id, const std::vector<std::string>& keys,
-    ReplicaType replica_type) {
-    return BatchEvictDiskReplica(client_id, keys, "default", replica_type);
-}
-
-std::vector<tl::expected<void, ErrorCode>> MasterService::BatchEvictDiskReplica(
-    const UUID& client_id, const std::vector<std::string>& keys,
     const std::string& tenant_id, ReplicaType replica_type) {
     std::vector<tl::expected<void, ErrorCode>> results;
     results.reserve(keys.size());
@@ -2301,13 +2199,6 @@ std::vector<tl::expected<void, ErrorCode>> MasterService::BatchEvictDiskReplica(
             EvictDiskReplica(client_id, key, tenant_id, replica_type));
     }
     return results;
-}
-
-tl::expected<CopyStartResponse, ErrorCode> MasterService::CopyStart(
-    const UUID& client_id, const std::string& key,
-    const std::string& src_segment,
-    const std::vector<std::string>& tgt_segments) {
-    return CopyStart(client_id, key, "default", src_segment, tgt_segments);
 }
 
 tl::expected<CopyStartResponse, ErrorCode> MasterService::CopyStart(
@@ -2407,11 +2298,6 @@ tl::expected<CopyStartResponse, ErrorCode> MasterService::CopyStart(
     return response;
 }
 
-tl::expected<void, ErrorCode> MasterService::CopyEnd(const UUID& client_id,
-                                                     const std::string& key) {
-    return CopyEnd(client_id, key, "default");
-}
-
 tl::expected<void, ErrorCode> MasterService::CopyEnd(
     const UUID& client_id, const std::string& key,
     const std::string& tenant_id) {
@@ -2485,11 +2371,6 @@ tl::expected<void, ErrorCode> MasterService::CopyEnd(
 }
 
 tl::expected<void, ErrorCode> MasterService::CopyRevoke(
-    const UUID& client_id, const std::string& key) {
-    return CopyRevoke(client_id, key, "default");
-}
-
-tl::expected<void, ErrorCode> MasterService::CopyRevoke(
     const UUID& client_id, const std::string& key,
     const std::string& tenant_id) {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
@@ -2541,12 +2422,6 @@ tl::expected<void, ErrorCode> MasterService::CopyRevoke(
     }
 
     return {};
-}
-
-tl::expected<MoveStartResponse, ErrorCode> MasterService::MoveStart(
-    const UUID& client_id, const std::string& key,
-    const std::string& src_segment, const std::string& tgt_segment) {
-    return MoveStart(client_id, key, "default", src_segment, tgt_segment);
 }
 
 tl::expected<MoveStartResponse, ErrorCode> MasterService::MoveStart(
@@ -2641,11 +2516,6 @@ tl::expected<MoveStartResponse, ErrorCode> MasterService::MoveStart(
     return response;
 }
 
-tl::expected<void, ErrorCode> MasterService::MoveEnd(const UUID& client_id,
-                                                     const std::string& key) {
-    return MoveEnd(client_id, key, "default");
-}
-
 tl::expected<void, ErrorCode> MasterService::MoveEnd(
     const UUID& client_id, const std::string& key,
     const std::string& tenant_id) {
@@ -2734,11 +2604,6 @@ tl::expected<void, ErrorCode> MasterService::MoveEnd(
 }
 
 tl::expected<void, ErrorCode> MasterService::MoveRevoke(
-    const UUID& client_id, const std::string& key) {
-    return MoveRevoke(client_id, key, "default");
-}
-
-tl::expected<void, ErrorCode> MasterService::MoveRevoke(
     const UUID& client_id, const std::string& key,
     const std::string& tenant_id) {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
@@ -2792,11 +2657,6 @@ tl::expected<void, ErrorCode> MasterService::MoveRevoke(
     return {};
 }
 
-auto MasterService::Remove(const std::string& key, bool force)
-    -> tl::expected<void, ErrorCode> {
-    return Remove(key, "default", force);
-}
-
 auto MasterService::Remove(const std::string& key, const std::string& tenant_id,
                            bool force) -> tl::expected<void, ErrorCode> {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
@@ -2834,11 +2694,6 @@ auto MasterService::Remove(const std::string& key, const std::string& tenant_id,
     ErasePromotionTaskIfPresent(tenant_state, key);
     accessor.Erase();
     return {};
-}
-
-auto MasterService::RemoveByRegex(const std::string& regex_pattern, bool force)
-    -> tl::expected<long, ErrorCode> {
-    return RemoveByRegex(regex_pattern, "default", force);
 }
 
 auto MasterService::RemoveByRegex(const std::string& regex_pattern,
@@ -2997,12 +2852,6 @@ long MasterService::RemoveAll(const std::string& tenant_id, bool force) {
             << ", removed_count=" << removed_count
             << ", total_freed_size=" << total_freed_size;
     return removed_count;
-}
-
-auto MasterService::BatchRemove(const std::vector<std::string>& keys,
-                                bool force)
-    -> std::vector<tl::expected<void, ErrorCode>> {
-    return BatchRemove(keys, "default", force);
 }
 
 auto MasterService::BatchRemove(const std::vector<std::string>& keys,
@@ -3311,19 +3160,6 @@ auto MasterService::ReportSsdCapacity(const UUID& client_id,
 }
 
 auto MasterService::NotifyOffloadSuccess(
-    const UUID& client_id, const std::vector<std::string>& keys,
-    const std::vector<StorageObjectMetadata>& metadatas)
-    -> tl::expected<void, ErrorCode> {
-    std::vector<OffloadTaskItem> tasks;
-    tasks.reserve(keys.size());
-    for (const auto& key : keys) {
-        tasks.push_back(
-            OffloadTaskItem{.tenant_id = "default", .key = key, .size = 0});
-    }
-    return NotifyOffloadSuccess(client_id, tasks, metadatas);
-}
-
-auto MasterService::NotifyOffloadSuccess(
     const UUID& client_id, const std::vector<OffloadTaskItem>& tasks,
     const std::vector<StorageObjectMetadata>& metadatas)
     -> tl::expected<void, ErrorCode> {
@@ -3462,13 +3298,15 @@ void MasterService::TryPushPromotionQueue(const ObjectIdentity& object_id) {
         return;
     }
     const auto& key = object_id.user_key;
+    const auto admission_key =
+        MakeTenantScopedStorageKey(object_id.tenant_id, key);
 
     // Frequency gate: bump and compare against the threshold. The sketch
     // returns uint8_t (saturating at 255); promotion_admission_threshold_
     // is clamped into [1, 255] at config parse time (see master.cpp), so
     // direct comparison is well-defined and threshold=0 (which would
     // bypass the gate entirely since freq is uint8_t) cannot reach here.
-    const uint8_t freq = promotion_sketch_->increment(key);
+    const uint8_t freq = promotion_sketch_->increment(admission_key);
     if (freq < promotion_admission_threshold_) {
         MasterMetricManager::instance().inc_promotion_rejected_frequency();
         return;
@@ -3588,14 +3426,6 @@ auto MasterService::PromotionObjectHeartbeat(const UUID& client_id)
 }
 
 auto MasterService::PromotionAllocStart(
-    const UUID& client_id, const std::string& key, uint64_t size,
-    const std::vector<std::string>& preferred_segments)
-    -> tl::expected<PromotionAllocStartResponse, ErrorCode> {
-    return PromotionAllocStart(client_id, key, "default", size,
-                               preferred_segments);
-}
-
-auto MasterService::PromotionAllocStart(
     const UUID& client_id, const std::string& key, const std::string& tenant_id,
     uint64_t size, const std::vector<std::string>& preferred_segments)
     -> tl::expected<PromotionAllocStartResponse, ErrorCode> {
@@ -3690,12 +3520,6 @@ auto MasterService::PromotionAllocStart(
 }
 
 auto MasterService::NotifyPromotionSuccess(const UUID& client_id,
-                                           const std::string& key)
-    -> tl::expected<void, ErrorCode> {
-    return NotifyPromotionSuccess(client_id, key, "default");
-}
-
-auto MasterService::NotifyPromotionSuccess(const UUID& client_id,
                                            const std::string& key,
                                            const std::string& tenant_id)
     -> tl::expected<void, ErrorCode> {
@@ -3768,12 +3592,6 @@ auto MasterService::NotifyPromotionSuccess(const UUID& client_id,
         return tl::make_unexpected(ErrorCode::REPLICA_IS_NOT_READY);
     }
     return {};
-}
-
-auto MasterService::NotifyPromotionFailure(const UUID& client_id,
-                                           const std::string& key)
-    -> tl::expected<void, ErrorCode> {
-    return NotifyPromotionFailure(client_id, key, "default");
 }
 
 auto MasterService::NotifyPromotionFailure(const UUID& client_id,
@@ -6570,11 +6388,6 @@ std::string MasterService::FormatTimestamp(
 }
 
 tl::expected<UUID, ErrorCode> MasterService::CreateCopyTask(
-    const std::string& key, const std::vector<std::string>& targets) {
-    return CreateCopyTask(key, "default", targets);
-}
-
-tl::expected<UUID, ErrorCode> MasterService::CreateCopyTask(
     const std::string& key, const std::string& tenant_id,
     const std::vector<std::string>& targets) {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
@@ -6630,12 +6443,6 @@ tl::expected<UUID, ErrorCode> MasterService::CreateCopyTask(
                             .key = object_id.user_key,
                             .source = selected_source_segment,
                             .targets = targets});
-}
-
-tl::expected<UUID, ErrorCode> MasterService::CreateMoveTask(
-    const std::string& key, const std::string& source,
-    const std::string& target) {
-    return CreateMoveTask(key, "default", source, target);
 }
 
 tl::expected<UUID, ErrorCode> MasterService::CreateMoveTask(

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -599,10 +599,6 @@ MasterService::getAliveClientsSnapshot() const {
     return ok_client_;
 }
 
-size_t MasterService::getMetadataShardIndex(const std::string& key) const {
-    return getMetadataShardIndex("default", key);
-}
-
 size_t MasterService::getMetadataShardIndex(const std::string& tenant_id,
                                             const std::string& key) const {
     const auto normalized_tenant = NormalizeTenantId(tenant_id);

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -1793,7 +1793,9 @@ tl::expected<std::string, ErrorCode> WrappedMasterService::ServiceReady() {
 
 tl::expected<std::vector<std::string>, ErrorCode>
 WrappedMasterService::GetAllKeysForAdmin() {
-    return master_service_.GetAllKeys();
+    // Compatibility endpoint: /get_all_keys historically listed only the
+    // default tenant's keys.
+    return master_service_.GetAllKeys("default");
 }
 
 tl::expected<std::vector<std::string>, ErrorCode>

--- a/mooncake-store/tests/ha/snapshot/master_service_promotion_test_for_snapshot.cpp
+++ b/mooncake-store/tests/ha/snapshot/master_service_promotion_test_for_snapshot.cpp
@@ -70,7 +70,8 @@ class MasterServicePromotionSnapshotTest
     bool InjectLocalDiskReplica(const UUID& client_id, const std::string& key,
                                 int64_t size,
                                 const std::string& transport_endpoint) {
-        std::vector<std::string> keys{key};
+        std::vector<OffloadTaskItem> tasks{
+            OffloadTaskItem{.tenant_id = "default", .key = key, .size = size}};
         StorageObjectMetadata sm;
         sm.bucket_id = 0;
         sm.offset = 0;
@@ -78,7 +79,7 @@ class MasterServicePromotionSnapshotTest
         sm.data_size = size;
         sm.transport_endpoint = transport_endpoint;
         std::vector<StorageObjectMetadata> metas{sm};
-        return service_->NotifyOffloadSuccess(client_id, keys, metas)
+        return service_->NotifyOffloadSuccess(client_id, tasks, metas)
             .has_value();
     }
 };
@@ -95,7 +96,7 @@ TEST_F(MasterServicePromotionSnapshotTest, LocalDiskReplicaRoundTrip) {
     ASSERT_TRUE(
         InjectLocalDiskReplica(client_id, "k_cold", 1024, "seg_a_endpoint"));
 
-    auto before = service_->GetReplicaList("k_cold");
+    auto before = service_->GetReplicaList("k_cold", "default");
     ASSERT_TRUE(before.has_value());
     ASSERT_EQ(before->replicas.size(), 1u);
     EXPECT_TRUE(before->replicas[0].is_local_disk_replica());
@@ -111,15 +112,17 @@ TEST_F(MasterServicePromotionSnapshotTest, MixedMemoryAndLocalDiskRoundTrip) {
     // Put a MEMORY replica.
     ReplicateConfig rc;
     rc.replica_num = 1;
-    ASSERT_TRUE(service_->PutStart(client_id, "k_mixed", 1024, rc).has_value());
-    ASSERT_TRUE(service_->PutEnd(client_id, "k_mixed", ReplicaType::MEMORY)
+    ASSERT_TRUE(service_->PutStart(client_id, "k_mixed", "default", 1024, rc)
                     .has_value());
+    ASSERT_TRUE(
+        service_->PutEnd(client_id, "k_mixed", "default", ReplicaType::MEMORY)
+            .has_value());
 
     // Add LOCAL_DISK alongside.
     ASSERT_TRUE(
         InjectLocalDiskReplica(client_id, "k_mixed", 1024, "seg_a_endpoint"));
 
-    auto descs = service_->GetReplicaList("k_mixed");
+    auto descs = service_->GetReplicaList("k_mixed", "default");
     ASSERT_TRUE(descs.has_value());
     EXPECT_EQ(descs->replicas.size(), 2u);
 }
@@ -150,8 +153,8 @@ TEST_F(MasterServicePromotionSnapshotTest, MultipleLocalDiskHoldersRoundTrip) {
     ASSERT_TRUE(
         InjectLocalDiskReplica(client_b, "k_b", 2048, "seg_b_endpoint"));
 
-    auto a = service_->GetReplicaList("k_a");
-    auto b = service_->GetReplicaList("k_b");
+    auto a = service_->GetReplicaList("k_a", "default");
+    auto b = service_->GetReplicaList("k_b", "default");
     ASSERT_TRUE(a.has_value());
     ASSERT_TRUE(b.has_value());
     EXPECT_EQ(a->replicas[0].get_local_disk_descriptor().client_id, client_a);
@@ -174,7 +177,7 @@ TEST_F(MasterServicePromotionSnapshotTest, InFlightPromotionTaskSnapshotSafe) {
     // Trigger promotion gate to enqueue a task. This pins the source
     // replica's refcnt and adds a per-shard PromotionTask plus a per-
     // segment promotion_objects entry.
-    auto get = service_->GetReplicaList("k_cold");
+    auto get = service_->GetReplicaList("k_cold", "default");
     ASSERT_TRUE(get.has_value());
 
     // The visible replica list should still expose exactly one LOCAL_DISK

--- a/mooncake-store/tests/ha/snapshot/master_service_ssd_test_for_snapshot.cpp
+++ b/mooncake-store/tests/ha/snapshot/master_service_ssd_test_for_snapshot.cpp
@@ -57,7 +57,7 @@ TEST_F(MasterServiceSSDSnapshotTest, PutEndBothReplica) {
     config.replica_num = 1;
 
     auto put_start_result =
-        service_->PutStart(client_id, key, slice_length, config);
+        service_->PutStart(client_id, key, "default", slice_length, config);
     ASSERT_TRUE(put_start_result.has_value());
     auto replicas = put_start_result.value();
     ASSERT_EQ(2, replicas.size());
@@ -70,17 +70,17 @@ TEST_F(MasterServiceSSDSnapshotTest, PutEndBothReplica) {
     EXPECT_TRUE(has_mem);
     EXPECT_TRUE(has_disk);
 
-    auto get_result = service_->GetReplicaList(key);
+    auto get_result = service_->GetReplicaList(key, "default");
     ASSERT_FALSE(get_result.has_value());
     EXPECT_EQ(ErrorCode::REPLICA_IS_NOT_READY, get_result.error());
 
     // PutEnd for both memory and disk
-    EXPECT_TRUE(
-        service_->PutEnd(client_id, key, ReplicaType::MEMORY).has_value());
-    EXPECT_TRUE(
-        service_->PutEnd(client_id, key, ReplicaType::DISK).has_value());
+    EXPECT_TRUE(service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY)
+                    .has_value());
+    EXPECT_TRUE(service_->PutEnd(client_id, key, "default", ReplicaType::DISK)
+                    .has_value());
 
-    get_result = service_->GetReplicaList(key);
+    get_result = service_->GetReplicaList(key, "default");
     ASSERT_TRUE(get_result.has_value());
     EXPECT_EQ(2, get_result.value().replicas.size());
 
@@ -112,19 +112,21 @@ TEST_F(MasterServiceSSDSnapshotTest, PutRevokeDiskReplica) {
     config.replica_num = 1;
 
     ASSERT_TRUE(
-        service_->PutStart(client_id, key, slice_length, config).has_value());
-    EXPECT_TRUE(
-        service_->PutEnd(client_id, key, ReplicaType::MEMORY).has_value());
+        service_->PutStart(client_id, key, "default", slice_length, config)
+            .has_value());
+    EXPECT_TRUE(service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY)
+                    .has_value());
 
-    auto get_result = service_->GetReplicaList(key);
+    auto get_result = service_->GetReplicaList(key, "default");
     ASSERT_TRUE(get_result.has_value());
     EXPECT_EQ(1, get_result.value().replicas.size());
     ASSERT_TRUE(get_result.value().replicas[0].is_memory_replica());
 
     EXPECT_TRUE(
-        service_->PutRevoke(client_id, key, ReplicaType::DISK).has_value());
+        service_->PutRevoke(client_id, key, "default", ReplicaType::DISK)
+            .has_value());
 
-    get_result = service_->GetReplicaList(key);
+    get_result = service_->GetReplicaList(key, "default");
     ASSERT_TRUE(get_result.has_value());
     EXPECT_EQ(1, get_result.value().replicas.size());
     ASSERT_TRUE(get_result.value().replicas[0].is_memory_replica());
@@ -153,17 +155,19 @@ TEST_F(MasterServiceSSDSnapshotTest, PutRevokeMemoryReplica) {
     config.replica_num = 1;
 
     ASSERT_TRUE(
-        service_->PutStart(client_id, key, slice_length, config).has_value());
+        service_->PutStart(client_id, key, "default", slice_length, config)
+            .has_value());
     EXPECT_TRUE(
-        service_->PutRevoke(client_id, key, ReplicaType::MEMORY).has_value());
+        service_->PutRevoke(client_id, key, "default", ReplicaType::MEMORY)
+            .has_value());
 
-    auto get_result = service_->GetReplicaList(key);
+    auto get_result = service_->GetReplicaList(key, "default");
     ASSERT_FALSE(get_result.has_value());
     EXPECT_EQ(ErrorCode::REPLICA_IS_NOT_READY, get_result.error());
 
-    EXPECT_TRUE(
-        service_->PutEnd(client_id, key, ReplicaType::DISK).has_value());
-    get_result = service_->GetReplicaList(key);
+    EXPECT_TRUE(service_->PutEnd(client_id, key, "default", ReplicaType::DISK)
+                    .has_value());
+    get_result = service_->GetReplicaList(key, "default");
     ASSERT_TRUE(get_result.has_value());
     EXPECT_EQ(1, get_result.value().replicas.size());
     ASSERT_TRUE(get_result.value().replicas[0].is_disk_replica());
@@ -192,17 +196,20 @@ TEST_F(MasterServiceSSDSnapshotTest, PutRevokeBothReplica) {
     config.replica_num = 1;
 
     ASSERT_TRUE(
-        service_->PutStart(client_id, key, slice_length, config).has_value());
+        service_->PutStart(client_id, key, "default", slice_length, config)
+            .has_value());
     EXPECT_TRUE(
-        service_->PutRevoke(client_id, key, ReplicaType::DISK).has_value());
+        service_->PutRevoke(client_id, key, "default", ReplicaType::DISK)
+            .has_value());
 
-    auto get_result = service_->GetReplicaList(key);
+    auto get_result = service_->GetReplicaList(key, "default");
     ASSERT_FALSE(get_result.has_value());
     EXPECT_EQ(ErrorCode::REPLICA_IS_NOT_READY, get_result.error());
 
     EXPECT_TRUE(
-        service_->PutRevoke(client_id, key, ReplicaType::MEMORY).has_value());
-    get_result = service_->GetReplicaList(key);
+        service_->PutRevoke(client_id, key, "default", ReplicaType::MEMORY)
+            .has_value());
+    get_result = service_->GetReplicaList(key, "default");
     ASSERT_FALSE(get_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, get_result.error());
 }
@@ -230,15 +237,16 @@ TEST_F(MasterServiceSSDSnapshotTest, RemoveKey) {
     config.replica_num = 1;
 
     ASSERT_TRUE(
-        service_->PutStart(client_id, key, slice_length, config).has_value());
-    EXPECT_TRUE(
-        service_->PutEnd(client_id, key, ReplicaType::MEMORY).has_value());
-    EXPECT_TRUE(
-        service_->PutEnd(client_id, key, ReplicaType::DISK).has_value());
+        service_->PutStart(client_id, key, "default", slice_length, config)
+            .has_value());
+    EXPECT_TRUE(service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY)
+                    .has_value());
+    EXPECT_TRUE(service_->PutEnd(client_id, key, "default", ReplicaType::DISK)
+                    .has_value());
 
-    EXPECT_TRUE(service_->Remove(key).has_value());
+    EXPECT_TRUE(service_->Remove(key, "default").has_value());
 
-    auto get_result = service_->GetReplicaList(key);
+    auto get_result = service_->GetReplicaList(key, "default");
     EXPECT_FALSE(get_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, get_result.error());
 }
@@ -271,12 +279,12 @@ TEST_F(MasterServiceSSDSnapshotTest, EvictObject) {
         ReplicateConfig config;
         config.replica_num = 1;
         auto put_start_result =
-            service_->PutStart(client_id, key, slice_length, config);
+            service_->PutStart(client_id, key, "default", slice_length, config);
         if (put_start_result.has_value()) {
-            auto put_end_mem_result =
-                service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+            auto put_end_mem_result = service_->PutEnd(
+                client_id, key, "default", ReplicaType::MEMORY);
             auto put_end_disk_result =
-                service_->PutEnd(client_id, key, ReplicaType::DISK);
+                service_->PutEnd(client_id, key, "default", ReplicaType::DISK);
             ASSERT_TRUE(put_end_mem_result.has_value());
             ASSERT_TRUE(put_end_disk_result.has_value());
             success_puts++;
@@ -291,7 +299,7 @@ TEST_F(MasterServiceSSDSnapshotTest, EvictObject) {
     int success_gets = 0;
     for (int i = 0; i < 1024 * 16 + 50; ++i) {
         std::string key = "test_key" + std::to_string(i);
-        auto get_result = service_->GetReplicaList(key);
+        auto get_result = service_->GetReplicaList(key, "default");
         if (get_result.has_value()) {
             success_gets++;
         }
@@ -342,7 +350,7 @@ TEST_F(MasterServiceSSDSnapshotTest, PutStartExpires) {
 
         // Put key, should success.
         auto put_start_result =
-            service_->PutStart(client_id, key, slice_length, config);
+            service_->PutStart(client_id, key, "default", slice_length, config);
         EXPECT_TRUE(put_start_result.has_value());
         auto replica_list = put_start_result.value();
         EXPECT_EQ(replica_list.size(), kReplicaCnt);
@@ -351,7 +359,8 @@ TEST_F(MasterServiceSSDSnapshotTest, PutStartExpires) {
         }
 
         // Complete the reserved replica.
-        auto put_end_result = service_->PutEnd(client_id, key, reserve_type);
+        auto put_end_result =
+            service_->PutEnd(client_id, key, "default", reserve_type);
         EXPECT_TRUE(put_end_result.has_value());
 
         // Wait for a while until the put-start expired.
@@ -361,7 +370,7 @@ TEST_F(MasterServiceSSDSnapshotTest, PutStartExpires) {
             auto result = service_->Ping(client_id);
             EXPECT_TRUE(result.has_value());
             // Protect the key from eviction.
-            auto get_result = service_->GetReplicaList(key);
+            auto get_result = service_->GetReplicaList(key, "default");
             EXPECT_TRUE(get_result.has_value());
             std::this_thread::sleep_for(std::chrono::seconds(1));
         }
@@ -369,7 +378,7 @@ TEST_F(MasterServiceSSDSnapshotTest, PutStartExpires) {
         // Put key again, should fail because the object has had an completed
         // replica.
         put_start_result =
-            service_->PutStart(client_id, key, slice_length, config);
+            service_->PutStart(client_id, key, "default", slice_length, config);
         EXPECT_FALSE(put_start_result.has_value());
         EXPECT_EQ(put_start_result.error(), ErrorCode::OBJECT_ALREADY_EXISTS);
 
@@ -380,17 +389,18 @@ TEST_F(MasterServiceSSDSnapshotTest, PutStartExpires) {
             auto result = service_->Ping(client_id);
             EXPECT_TRUE(result.has_value());
             // Protect the key from eviction.
-            auto get_result = service_->GetReplicaList(key);
+            auto get_result = service_->GetReplicaList(key, "default");
             EXPECT_TRUE(get_result.has_value());
             std::this_thread::sleep_for(std::chrono::seconds(1));
         }
 
         // Try PutEnd the discarded replica.
-        put_end_result = service_->PutEnd(client_id, key, discard_type);
+        put_end_result =
+            service_->PutEnd(client_id, key, "default", discard_type);
         EXPECT_TRUE(put_end_result.has_value());
 
         // Check that the key has only one replica.
-        auto get_result = service_->GetReplicaList(key);
+        auto get_result = service_->GetReplicaList(key, "default");
         EXPECT_TRUE(get_result.has_value());
         EXPECT_EQ(get_result.value().replicas.size(), 1);
         if (reserve_type == ReplicaType::MEMORY) {

--- a/mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot.cpp
+++ b/mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot.cpp
@@ -36,14 +36,14 @@ std::string GenerateKeyForSegment(const UUID& client_id,
         std::vector<Replica::Descriptor> replica_list;
 
         // Check if the key already exists.
-        auto exist_result = service->ExistKey(key);
+        auto exist_result = service->ExistKey(key, "default");
         if (exist_result.has_value() && exist_result.value()) {
             continue;  // Retry if the key already exists
         }
 
         // Attempt to put the key.
-        auto put_result =
-            service->PutStart(client_id, key, {1024}, {.replica_num = 1});
+        auto put_result = service->PutStart(client_id, key, "default", {1024},
+                                            {.replica_num = 1});
         if (put_result.has_value()) {
             replica_list = std::move(put_result.value());
         }
@@ -58,7 +58,7 @@ std::string GenerateKeyForSegment(const UUID& client_id,
                                      std::to_string(static_cast<int>(code)));
         }
         auto put_end_result =
-            service->PutEnd(client_id, key, ReplicaType::MEMORY);
+            service->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
         if (!put_end_result.has_value()) {
             throw std::runtime_error("PutEnd failed");
         }
@@ -68,7 +68,7 @@ std::string GenerateKeyForSegment(const UUID& client_id,
             return key;
         }
         // Clean up failed attempt
-        auto remove_result = service->Remove(key);
+        auto remove_result = service->Remove(key, "default");
         if (!remove_result.has_value()) {
             // Ignore cleanup failure
         }
@@ -206,13 +206,14 @@ TEST_F(MasterServiceSnapshotTest, PutStartInvalidParams) {
 
     // Test invalid replica_num
     config.replica_num = 0;
-    auto put_result1 = service_->PutStart(client_id, key, 1024, config);
+    auto put_result1 =
+        service_->PutStart(client_id, key, "default", 1024, config);
     EXPECT_FALSE(put_result1.has_value());
     EXPECT_EQ(ErrorCode::INVALID_PARAMS, put_result1.error());
 
     // Test zero slice_length
     config.replica_num = 1;
-    auto put_result2 = service_->PutStart(client_id, key, 0, config);
+    auto put_result2 = service_->PutStart(client_id, key, "default", 0, config);
     EXPECT_FALSE(put_result2.has_value());
     EXPECT_EQ(ErrorCode::INVALID_PARAMS, put_result2.error());
 }
@@ -231,38 +232,39 @@ TEST_F(MasterServiceSnapshotTest, PutStartEndFlow) {
     config.replica_num = 1;
 
     auto put_start_result =
-        service_->PutStart(client_id, key, value_length, config);
+        service_->PutStart(client_id, key, "default", value_length, config);
     EXPECT_TRUE(put_start_result.has_value());
     replica_list = put_start_result.value();
     EXPECT_FALSE(replica_list.empty());
     EXPECT_EQ(ReplicaStatus::PROCESSING, replica_list[0].status);
 
     // During put, Get/Remove should fail
-    auto get_replica_result = service_->GetReplicaList(key);
+    auto get_replica_result = service_->GetReplicaList(key, "default");
     EXPECT_FALSE(get_replica_result.has_value());
     EXPECT_EQ(ErrorCode::REPLICA_IS_NOT_READY, get_replica_result.error());
-    auto remove_result = service_->Remove(key);
+    auto remove_result = service_->Remove(key, "default");
     EXPECT_FALSE(remove_result.has_value());
     EXPECT_EQ(ErrorCode::REPLICA_IS_NOT_READY, remove_result.error());
 
     // PutEnd should fail if the client_id does not match.
-    auto put_end_fail_result =
-        service_->PutEnd(invalid_client_id, key, ReplicaType::MEMORY);
+    auto put_end_fail_result = service_->PutEnd(invalid_client_id, key,
+                                                "default", ReplicaType::MEMORY);
     EXPECT_FALSE(put_end_fail_result.has_value());
     EXPECT_EQ(put_end_fail_result.error(), ErrorCode::ILLEGAL_CLIENT);
 
     // PutRevoke should fail if the client_id does not match.
-    auto put_revoke_fail_result =
-        service_->PutRevoke(invalid_client_id, key, ReplicaType::MEMORY);
+    auto put_revoke_fail_result = service_->PutRevoke(
+        invalid_client_id, key, "default", ReplicaType::MEMORY);
     EXPECT_FALSE(put_revoke_fail_result.has_value());
     EXPECT_EQ(put_revoke_fail_result.error(), ErrorCode::ILLEGAL_CLIENT);
 
     // Test PutEnd
-    auto put_end_result = service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end_result =
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     EXPECT_TRUE(put_end_result.has_value());
 
     // Verify replica list after PutEnd
-    auto final_get_result = service_->GetReplicaList(key);
+    auto final_get_result = service_->GetReplicaList(key, "default");
     EXPECT_TRUE(final_get_result.has_value());
     replica_list = final_get_result.value().replicas;
     EXPECT_EQ(1, replica_list.size());
@@ -292,23 +294,24 @@ TEST_F(MasterServiceSnapshotTest, RandomPutStartEndFlow) {
     int random_number = dis(gen);
     config.replica_num = random_number;
     auto put_start_result =
-        service_->PutStart(client_id, key, value_length, config);
+        service_->PutStart(client_id, key, "default", value_length, config);
     EXPECT_TRUE(put_start_result.has_value());
     replica_list = put_start_result.value();
     EXPECT_FALSE(replica_list.empty());
     EXPECT_EQ(ReplicaStatus::PROCESSING, replica_list[0].status);
     // During put, Get/Remove should fail
-    auto get_result = service_->GetReplicaList(key);
+    auto get_result = service_->GetReplicaList(key, "default");
     EXPECT_FALSE(get_result.has_value());
     EXPECT_EQ(ErrorCode::REPLICA_IS_NOT_READY, get_result.error());
-    auto remove_result = service_->Remove(key);
+    auto remove_result = service_->Remove(key, "default");
     EXPECT_FALSE(remove_result.has_value());
     EXPECT_EQ(ErrorCode::REPLICA_IS_NOT_READY, remove_result.error());
     // Test PutEnd
-    auto put_end_result = service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end_result =
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     EXPECT_TRUE(put_end_result.has_value());
     // Verify replica list after PutEnd
-    auto get_result2 = service_->GetReplicaList(key);
+    auto get_result2 = service_->GetReplicaList(key, "default");
     EXPECT_TRUE(get_result2.has_value());
     replica_list = get_result2.value().replicas;
     EXPECT_EQ(random_number, replica_list.size());
@@ -325,7 +328,7 @@ TEST_F(MasterServiceSnapshotTest, GetReplicaListByRegex) {
     service_.reset(new MasterService(service_config));
     const UUID client_id = generate_uuid();
     // Test getting non-existent key
-    auto get_result = service_->GetReplicaList(".*non_existent.*");
+    auto get_result = service_->GetReplicaList(".*non_existent.*", "default");
     EXPECT_FALSE(get_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, get_result.error());
 
@@ -338,19 +341,19 @@ TEST_F(MasterServiceSnapshotTest, GetReplicaListByRegex) {
         ReplicateConfig config;
         config.replica_num = 1;
         auto put_start_result =
-            service_->PutStart(client_id, key, value_length, config);
+            service_->PutStart(client_id, key, "default", value_length, config);
         ASSERT_TRUE(put_start_result.has_value());
         auto put_end_result =
-            service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+            service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
         ASSERT_TRUE(put_end_result.has_value());
-        auto exist_result = service_->ExistKey(key);
+        auto exist_result = service_->ExistKey(key, "default");
         ASSERT_TRUE(exist_result.has_value());
     }
     // wait for all the lease to expire
     std::this_thread::sleep_for(std::chrono::milliseconds(kv_lease_ttl));
 
     // Test getting existing key
-    auto get_result2 = service_->GetReplicaListByRegex("^test_key");
+    auto get_result2 = service_->GetReplicaListByRegex("^test_key", "default");
     EXPECT_TRUE(get_result2.has_value());
     auto replica_list_local = get_result2.value();
     EXPECT_EQ(10, replica_list_local.size());
@@ -363,13 +366,14 @@ void put_object(MasterService& service, const UUID& client_id,
     ReplicateConfig config;
     config.replica_num = 1;
     auto put_start_result =
-        service.PutStart(client_id, key, value_length, config);
+        service.PutStart(client_id, key, "default", value_length, config);
     ASSERT_TRUE(put_start_result.has_value())
         << "Failed to PutStart for key: " << key;
-    auto put_end_result = service.PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end_result =
+        service.PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value())
         << "Failed to PutEnd for key: " << key;
-    auto exist_result = service.ExistKey(key);
+    auto exist_result = service.ExistKey(key, "default");
     ASSERT_TRUE(exist_result.has_value())
         << "Key does not exist after put: " << key;
 }
@@ -413,7 +417,7 @@ TEST_F(MasterServiceSnapshotTest, GetReplicaListByRegexComplex) {
 
     // Test 3.1: Simple prefix matching
     {
-        auto result = service_->GetReplicaListByRegex("^test_key_");
+        auto result = service_->GetReplicaListByRegex("^test_key_", "default");
         ASSERT_TRUE(result.has_value());
         EXPECT_EQ(result.value().size(),
                   3);  // Matches test_key_01, test_key_02, test_key_10
@@ -421,7 +425,8 @@ TEST_F(MasterServiceSnapshotTest, GetReplicaListByRegexComplex) {
 
     // Test 3.2: Matching with a wildcard for any number
     {
-        auto result = service_->GetReplicaListByRegex("^test_key_\\d+$");
+        auto result =
+            service_->GetReplicaListByRegex("^test_key_\\d+$", "default");
         ASSERT_TRUE(result.has_value());
         EXPECT_EQ(result.value().size(), 3);
     }
@@ -429,8 +434,8 @@ TEST_F(MasterServiceSnapshotTest, GetReplicaListByRegexComplex) {
     // Test 3.3: Matching a specific pattern with wildcards
     {
         // Matches "data_part_1_chunk_a" and "data_part_2_chunk_b"
-        auto result =
-            service_->GetReplicaListByRegex("^data_part_\\d_chunk_.$");
+        auto result = service_->GetReplicaListByRegex("^data_part_\\d_chunk_.$",
+                                                      "default");
         ASSERT_TRUE(result.has_value());
         EXPECT_EQ(result.value().size(), 2);
     }
@@ -438,7 +443,7 @@ TEST_F(MasterServiceSnapshotTest, GetReplicaListByRegexComplex) {
     // Test 3.4: Matching keys containing a specific substring
     {
         // Matches all keys with "key" in them
-        auto result = service_->GetReplicaListByRegex("key");
+        auto result = service_->GetReplicaListByRegex("key", "default");
         ASSERT_TRUE(result.has_value());
         // Expected: test_key_01, test_key_02, test_key_10,
         //           prod_key_alpha, prod_key_beta,
@@ -450,7 +455,7 @@ TEST_F(MasterServiceSnapshotTest, GetReplicaListByRegexComplex) {
     // Test 3.5: Matching based on file-like paths
     {
         // Match all .log files
-        auto result = service_->GetReplicaListByRegex("\\.log$");
+        auto result = service_->GetReplicaListByRegex("\\.log$", "default");
         ASSERT_TRUE(result.has_value());
         EXPECT_EQ(result.value().size(), 1);
         EXPECT_EQ(result.value().begin()->first, "logs/app-2025-08-13.log");
@@ -459,7 +464,8 @@ TEST_F(MasterServiceSnapshotTest, GetReplicaListByRegexComplex) {
     // Test 3.6: OR condition using |
     {
         // Match keys starting with "prod" OR ending with "json"
-        auto result = service_->GetReplicaListByRegex("^prod|\\.json$");
+        auto result =
+            service_->GetReplicaListByRegex("^prod|\\.json$", "default");
         ASSERT_TRUE(result.has_value());
         // Expected: prod_key_alpha, prod_key_beta, config/user/settings.json
         EXPECT_EQ(result.value().size(), 3);
@@ -467,7 +473,8 @@ TEST_F(MasterServiceSnapshotTest, GetReplicaListByRegexComplex) {
 
     // Test 3.7: Regex that should not match anything
     {
-        auto result = service_->GetReplicaListByRegex("^non_existent_prefix_");
+        auto result =
+            service_->GetReplicaListByRegex("^non_existent_prefix_", "default");
         // This should succeed but return an empty map.
         ASSERT_TRUE(result.has_value());
         EXPECT_TRUE(result.value().empty());
@@ -475,7 +482,7 @@ TEST_F(MasterServiceSnapshotTest, GetReplicaListByRegexComplex) {
 
     // Test 3.8: Exact match regex
     {
-        auto result = service_->GetReplicaListByRegex("^short$");
+        auto result = service_->GetReplicaListByRegex("^short$", "default");
         ASSERT_TRUE(result.has_value());
         EXPECT_EQ(result.value().size(), 1);
         EXPECT_EQ(result.value().begin()->first, "short");
@@ -483,8 +490,8 @@ TEST_F(MasterServiceSnapshotTest, GetReplicaListByRegexComplex) {
 
     // Test 3.9: Initial test for non-existent key (as a sanity check)
     {
-        auto get_result =
-            service_->GetReplicaListByRegex(".*absolutely_non_existent.*");
+        auto get_result = service_->GetReplicaListByRegex(
+            ".*absolutely_non_existent.*", "default");
         // Depending on implementation, this could return an empty map or an
         // error. Let's assume it returns an empty map for a valid regex with no
         // matches.
@@ -497,7 +504,7 @@ TEST_F(MasterServiceSnapshotTest, GetReplicaList) {
     service_.reset(new MasterService());
     const UUID client_id = generate_uuid();
     // Test getting non-existent key
-    auto get_result = service_->GetReplicaList("non_existent");
+    auto get_result = service_->GetReplicaList("non_existent", "default");
     EXPECT_FALSE(get_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, get_result.error());
 
@@ -508,13 +515,14 @@ TEST_F(MasterServiceSnapshotTest, GetReplicaList) {
     ReplicateConfig config;
     config.replica_num = 1;
     auto put_start_result =
-        service_->PutStart(client_id, key, value_length, config);
+        service_->PutStart(client_id, key, "default", value_length, config);
     ASSERT_TRUE(put_start_result.has_value());
-    auto put_end_result = service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end_result =
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value());
 
     // Test getting existing key
-    auto get_result2 = service_->GetReplicaList(key);
+    auto get_result2 = service_->GetReplicaList(key, "default");
     EXPECT_TRUE(get_result2.has_value());
     auto replica_list_local = get_result2.value().replicas;
     EXPECT_FALSE(replica_list_local.empty());
@@ -530,22 +538,23 @@ TEST_F(MasterServiceSnapshotTest, RemoveObject) {
     ReplicateConfig config;
     config.replica_num = 1;
     auto put_start_result =
-        service_->PutStart(client_id, key, value_length, config);
+        service_->PutStart(client_id, key, "default", value_length, config);
     ASSERT_TRUE(put_start_result.has_value());
-    auto put_end_result = service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end_result =
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value());
 
     // Test removing the object
-    auto remove_result = service_->Remove(key);
+    auto remove_result = service_->Remove(key, "default");
     EXPECT_TRUE(remove_result.has_value());
 
     // Verify object is removed
-    auto get_result = service_->GetReplicaList(key);
+    auto get_result = service_->GetReplicaList(key, "default");
     EXPECT_FALSE(get_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, get_result.error());
 
     // Test removing non-existent object
-    auto remove_result2 = service_->Remove("non_existent");
+    auto remove_result2 = service_->Remove("non_existent", "default");
     EXPECT_FALSE(remove_result2.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, remove_result2.error());
 }
@@ -564,18 +573,18 @@ TEST_F(MasterServiceSnapshotTest, RandomRemoveObject) {
         ReplicateConfig config;
         config.replica_num = 1;
         auto put_start_result =
-            service_->PutStart(client_id, key, value_length, config);
+            service_->PutStart(client_id, key, "default", value_length, config);
         ASSERT_TRUE(put_start_result.has_value());
         auto put_end_result =
-            service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+            service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
         ASSERT_TRUE(put_end_result.has_value());
 
         // Test removing the object
-        auto remove_result = service_->Remove(key);
+        auto remove_result = service_->Remove(key, "default");
         EXPECT_TRUE(remove_result.has_value());
 
         // Verify object is removed
-        auto get_result = service_->GetReplicaList(key);
+        auto get_result = service_->GetReplicaList(key, "default");
         EXPECT_FALSE(get_result.has_value());
         EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, get_result.error());
     }
@@ -596,23 +605,23 @@ TEST_F(MasterServiceSnapshotTest, RemoveByRegex) {
         ReplicateConfig config;
         config.replica_num = 1;
         auto put_start_result =
-            service_->PutStart(client_id, key, value_length, config);
+            service_->PutStart(client_id, key, "default", value_length, config);
         ASSERT_TRUE(put_start_result.has_value());
         auto put_end_result =
-            service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+            service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
         ASSERT_TRUE(put_end_result.has_value());
-        auto exist_result = service_->ExistKey(key);
+        auto exist_result = service_->ExistKey(key, "default");
         ASSERT_TRUE(exist_result.has_value());
     }
     // wait for all the lease to expire
     std::this_thread::sleep_for(std::chrono::milliseconds(kv_lease_ttl));
-    auto res = service_->RemoveByRegex("^test_key");
+    auto res = service_->RemoveByRegex("^test_key", "default");
     ASSERT_TRUE(res.has_value());
     ASSERT_EQ(10, res.value());
     times = 10;
     while (times--) {
         std::string key = "test_key" + std::to_string(times);
-        auto exist_result = service_->ExistKey(key);
+        auto exist_result = service_->ExistKey(key, "default");
         ASSERT_TRUE(exist_result.has_value());
         ASSERT_FALSE(exist_result.value());
     }
@@ -659,7 +668,7 @@ TEST_F(MasterServiceSnapshotTest, RemoveByRegexComplex) {
         populate_store();
 
         // Action: Remove keys starting with "test_key_"
-        auto remove_result = service_->RemoveByRegex("^test_key_");
+        auto remove_result = service_->RemoveByRegex("^test_key_", "default");
         ASSERT_TRUE(remove_result.has_value());
         EXPECT_EQ(remove_result.value(), 3);  // Should remove 3 keys
 
@@ -667,7 +676,7 @@ TEST_F(MasterServiceSnapshotTest, RemoveByRegexComplex) {
         std::vector<std::string> deleted_keys = {"test_key_01", "test_key_02",
                                                  "test_key_10"};
         for (const auto& key : deleted_keys) {
-            auto exist_result = service_->ExistKey(key);
+            auto exist_result = service_->ExistKey(key, "default");
             ASSERT_TRUE(exist_result.has_value());
             EXPECT_FALSE(exist_result.value())
                 << "Key " << key << " should have been deleted.";
@@ -676,7 +685,7 @@ TEST_F(MasterServiceSnapshotTest, RemoveByRegexComplex) {
         std::vector<std::string> remaining_keys = {
             "prod_key_alpha", "short", "test-key-extra"};  // Sample a few
         for (const auto& key : remaining_keys) {
-            auto exist_result = service_->ExistKey(key);
+            auto exist_result = service_->ExistKey(key, "default");
             ASSERT_TRUE(exist_result.has_value());
             EXPECT_TRUE(exist_result.value())
                 << "Key " << key << " should NOT have been deleted.";
@@ -699,12 +708,12 @@ TEST_F(MasterServiceSnapshotTest, RemoveByRegexComplex) {
         size_t total_keys = 13;  // Count from the keys_to_put vector
 
         // Action: Remove all keys
-        auto remove_result = service_->RemoveByRegex(".*");
+        auto remove_result = service_->RemoveByRegex(".*", "default");
         ASSERT_TRUE(remove_result.has_value());
         EXPECT_EQ(remove_result.value(), total_keys);
 
         // Verification: Check that no keys remain
-        auto get_all_result = service_->GetReplicaListByRegex(".*");
+        auto get_all_result = service_->GetReplicaListByRegex(".*", "default");
         ASSERT_TRUE(get_all_result.has_value());
         EXPECT_TRUE(get_all_result.value().empty());
     }
@@ -724,12 +733,13 @@ TEST_F(MasterServiceSnapshotTest, RemoveByRegexComplex) {
         size_t total_keys_before_remove = 13;
 
         // Action: Attempt to remove using a pattern that matches nothing
-        auto remove_result = service_->RemoveByRegex("^nonexistent-pattern-");
+        auto remove_result =
+            service_->RemoveByRegex("^nonexistent-pattern-", "default");
         ASSERT_TRUE(remove_result.has_value());
         EXPECT_EQ(remove_result.value(), 0);  // Should remove 0 keys
 
         // Verification: Check that all keys still exist
-        auto get_all_result = service_->GetReplicaListByRegex(".*");
+        auto get_all_result = service_->GetReplicaListByRegex(".*", "default");
         ASSERT_TRUE(get_all_result.has_value());
         EXPECT_EQ(get_all_result.value().size(), total_keys_before_remove);
     }
@@ -747,7 +757,7 @@ TEST_F(MasterServiceSnapshotTest, RemoveByRegexComplex) {
         populate_store();
 
         // Action: Remove all keys that contain a slash '/' OR end with a number
-        auto remove_result = service_->RemoveByRegex("/|\\d$");
+        auto remove_result = service_->RemoveByRegex("/|\\d$", "default");
         ASSERT_TRUE(remove_result.has_value());
         // Matches: "config/user/settings.json", "logs/app-2025-08-13.log",
         //          "test_key_01", "test_key_02", "test_key_10"
@@ -772,23 +782,25 @@ TEST_F(MasterServiceSnapshotTest, RemoveByRegexComplex) {
         populate_store();
 
         // Action: Remove all keys that contain "chunk" OR "config"
-        auto remove_result = service_->RemoveByRegex("chunk|config");
+        auto remove_result = service_->RemoveByRegex("chunk|config", "default");
         ASSERT_TRUE(remove_result.has_value());
         // Matches: "data_part_1_chunk_a", "data_part_2_chunk_b",
         // "config/user/settings.json"
         EXPECT_EQ(remove_result.value(), 3);
 
         // Verification
-        auto exist_result_chunk = service_->ExistKey("data_part_1_chunk_a");
+        auto exist_result_chunk =
+            service_->ExistKey("data_part_1_chunk_a", "default");
         ASSERT_TRUE(exist_result_chunk.has_value());
         EXPECT_FALSE(exist_result_chunk.value());
 
         auto exist_result_config =
-            service_->ExistKey("config/user/settings.json");
+            service_->ExistKey("config/user/settings.json", "default");
         ASSERT_TRUE(exist_result_config.has_value());
         EXPECT_FALSE(exist_result_config.value());
 
-        auto exist_result_untouched = service_->ExistKey("prod_key_alpha");
+        auto exist_result_untouched =
+            service_->ExistKey("prod_key_alpha", "default");
         ASSERT_TRUE(exist_result_untouched.has_value());
         EXPECT_TRUE(exist_result_untouched.value());
     }
@@ -809,12 +821,12 @@ TEST_F(MasterServiceSnapshotTest, RemoveAll) {
         ReplicateConfig config;
         config.replica_num = 1;
         auto put_start_result =
-            service_->PutStart(client_id, key, value_length, config);
+            service_->PutStart(client_id, key, "default", value_length, config);
         ASSERT_TRUE(put_start_result.has_value());
         auto put_end_result =
-            service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+            service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
         ASSERT_TRUE(put_end_result.has_value());
-        auto exist_result = service_->ExistKey(key);
+        auto exist_result = service_->ExistKey(key, "default");
         ASSERT_TRUE(exist_result.has_value());
     }
     // wait for all the lease to expire
@@ -823,7 +835,7 @@ TEST_F(MasterServiceSnapshotTest, RemoveAll) {
     // before TearDown snapshot verification ASSERT_EQ(10,
     // service_->RemoveAll()); times = 10; while (times--) {
     //     std::string key = "test_key" + std::to_string(times);
-    //     auto exist_result = service_->ExistKey(key);
+    //     auto exist_result = service_->ExistKey(key, "default");
     //     ASSERT_TRUE(exist_result.has_value());
     //     ASSERT_FALSE(exist_result.value());
     // }
@@ -858,7 +870,7 @@ TEST_F(MasterServiceSnapshotTest, SingleSliceMultiReplicaFlow) {
 
     // Test PutStart with multiple slices and replicas
     auto put_start_result =
-        service_->PutStart(client_id, key, slice_length, config);
+        service_->PutStart(client_id, key, "default", slice_length, config);
     ASSERT_TRUE(put_start_result.has_value());
     replica_list = put_start_result.value();
 
@@ -874,16 +886,17 @@ TEST_F(MasterServiceSnapshotTest, SingleSliceMultiReplicaFlow) {
     }
 
     // Test GetReplicaList during processing (should fail)
-    auto get_result = service_->GetReplicaList(key);
+    auto get_result = service_->GetReplicaList(key, "default");
     EXPECT_FALSE(get_result.has_value());
     EXPECT_EQ(ErrorCode::REPLICA_IS_NOT_READY, get_result.error());
 
     // Complete the put operation
-    auto put_end_result = service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end_result =
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value());
 
     // Test GetReplicaList after completion
-    auto get_result2 = service_->GetReplicaList(key);
+    auto get_result2 = service_->GetReplicaList(key, "default");
     ASSERT_TRUE(get_result2.has_value());
     auto retrieved_replicas = get_result2.value().replicas;
     ASSERT_EQ(num_replicas, retrieved_replicas.size());
@@ -917,13 +930,14 @@ TEST_F(MasterServiceSnapshotTest, CleanupStaleHandlesTest) {
 
     // Create the object
     auto put_start_result =
-        service_->PutStart(client_id, key, slice_length, config);
+        service_->PutStart(client_id, key, "default", slice_length, config);
     ASSERT_TRUE(put_start_result.has_value());
-    auto put_end_result = service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end_result =
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value());
 
     // Verify object exists
-    auto get_result = service_->GetReplicaList(key);
+    auto get_result = service_->GetReplicaList(key, "default");
     ASSERT_TRUE(get_result.has_value());
     auto retrieved_replicas = get_result.value().replicas;
     ASSERT_EQ(1, retrieved_replicas.size());
@@ -934,7 +948,7 @@ TEST_F(MasterServiceSnapshotTest, CleanupStaleHandlesTest) {
 
     // Try to get the object - it should be automatically removed since the
     // replica is invalid
-    auto get_result2 = service_->GetReplicaList(key);
+    auto get_result2 = service_->GetReplicaList(key, "default");
     EXPECT_FALSE(get_result2.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, get_result2.error());
 
@@ -945,14 +959,14 @@ TEST_F(MasterServiceSnapshotTest, CleanupStaleHandlesTest) {
     // Create another object
     std::string key2 = "another_segment_object";
     auto put_start_result2 =
-        service_->PutStart(client_id, key2, slice_length, config);
+        service_->PutStart(client_id, key2, "default", slice_length, config);
     ASSERT_TRUE(put_start_result2.has_value());
     auto put_end_result2 =
-        service_->PutEnd(client_id, key2, ReplicaType::MEMORY);
+        service_->PutEnd(client_id, key2, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result2.has_value());
 
     // Verify we can get it
-    auto get_result3 = service_->GetReplicaList(key2);
+    auto get_result3 = service_->GetReplicaList(key2, "default");
     ASSERT_TRUE(get_result3.has_value());
 
     // Unmount the segment
@@ -960,7 +974,7 @@ TEST_F(MasterServiceSnapshotTest, CleanupStaleHandlesTest) {
     ASSERT_TRUE(unmount_result2.has_value());
 
     // Try to remove the object that should already be cleaned up
-    auto remove_result = service_->Remove(key2);
+    auto remove_result = service_->Remove(key2, "default");
     EXPECT_FALSE(remove_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, remove_result.error());
 }
@@ -992,11 +1006,11 @@ TEST_F(MasterServiceSnapshotTest, ConcurrentWriteAndRemoveAll) {
                 config.replica_num = 1;
                 std::vector<Replica::Descriptor> replica_list;
 
-                auto put_start_result =
-                    service_->PutStart(client_id, key, slice_length, config);
+                auto put_start_result = service_->PutStart(
+                    client_id, key, "default", slice_length, config);
                 if (put_start_result.has_value()) {
-                    auto put_end_result =
-                        service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+                    auto put_end_result = service_->PutEnd(
+                        client_id, key, "default", ReplicaType::MEMORY);
                     if (put_end_result.has_value()) {
                         success_writes++;
                     }
@@ -1063,10 +1077,10 @@ TEST_F(MasterServiceSnapshotTest, ConcurrentReadAndRemoveAll) {
         config.replica_num = 1;
 
         auto put_start_result =
-            service_->PutStart(client_id, key, slice_length, config);
+            service_->PutStart(client_id, key, "default", slice_length, config);
         ASSERT_TRUE(put_start_result.has_value());
         auto put_end_result =
-            service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+            service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
         ASSERT_TRUE(put_end_result.has_value());
     }
 
@@ -1079,7 +1093,7 @@ TEST_F(MasterServiceSnapshotTest, ConcurrentReadAndRemoveAll) {
         readers.emplace_back([&]() {
             for (int j = 0; j < num_objects; ++j) {
                 std::string key = "pre_key_" + std::to_string(j);
-                auto get_result = service_->GetReplicaList(key);
+                auto get_result = service_->GetReplicaList(key, "default");
                 if (get_result.has_value()) {
                     success_reads++;
                 }
@@ -1124,7 +1138,7 @@ TEST_F(MasterServiceSnapshotTest, ConcurrentReadAndRemoveAll) {
     // // Verify all objects were removed
     // for (int i = 0; i < num_objects; ++i) {
     //     std::string key = "pre_key_" + std::to_string(i);
-    //     auto get_result = service_->GetReplicaList(key);
+    //     auto get_result = service_->GetReplicaList(key, "default");
     //     EXPECT_FALSE(get_result.has_value());
     //     EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, get_result.error());
     // }
@@ -1148,10 +1162,10 @@ TEST_F(MasterServiceSnapshotTest, ConcurrentRemoveAllOperations) {
         config.replica_num = 1;
 
         auto put_start_result =
-            service_->PutStart(client_id, key, slice_length, config);
+            service_->PutStart(client_id, key, "default", slice_length, config);
         ASSERT_TRUE(put_start_result.has_value());
         auto put_end_result =
-            service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+            service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
         ASSERT_TRUE(put_end_result.has_value());
     }
 
@@ -1179,7 +1193,7 @@ TEST_F(MasterServiceSnapshotTest, ConcurrentRemoveAllOperations) {
     // // Verify all objects were removed
     // for (int i = 0; i < num_objects; ++i) {
     //     std::string key = "pre_key_" + std::to_string(i);
-    //     auto get_result = service_->GetReplicaList(key);
+    //     auto get_result = service_->GetReplicaList(key, "default");
     //     EXPECT_FALSE(get_result.has_value());
     //     EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, get_result.error());
     // }
@@ -1216,23 +1230,23 @@ TEST_F(MasterServiceSnapshotTest, UnmountSegmentImmediateCleanup) {
     // Umount will remove all objects in the segment, include the key1
     ASSERT_EQ(1, service_->GetKeyCount());
     // Verify objects in segment1 is gone
-    auto get_result1 = service_->GetReplicaList(key1);
+    auto get_result1 = service_->GetReplicaList(key1, "default");
     ASSERT_FALSE(get_result1.has_value());
     ASSERT_EQ(ErrorCode::OBJECT_NOT_FOUND, get_result1.error());
 
     // Verify objects in segment2 is still there
-    auto get_result2 = service_->GetReplicaList(key2);
+    auto get_result2 = service_->GetReplicaList(key2, "default");
     ASSERT_TRUE(get_result2.has_value());
 
     // Verify put key1 will put into segment2 rather than segment1
     auto put_start_result =
-        service_->PutStart(client_id, key1, slice_length, config);
+        service_->PutStart(client_id, key1, "default", slice_length, config);
     ASSERT_TRUE(put_start_result.has_value());
     replica_list = put_start_result.value();
     auto put_end_result =
-        service_->PutEnd(client_id, key1, ReplicaType::MEMORY);
+        service_->PutEnd(client_id, key1, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value());
-    auto get_result3 = service_->GetReplicaList(key1);
+    auto get_result3 = service_->GetReplicaList(key1, "default");
     ASSERT_TRUE(get_result3.has_value());
     auto retrieved = get_result3.value();
     ASSERT_EQ(replica_list[0]
@@ -1265,14 +1279,14 @@ TEST_F(MasterServiceSnapshotTest, ReadableAfterPartialUnmountWithReplication) {
     config.replica_num = 2;
 
     auto put_start_result =
-        service_->PutStart(client_id, key, slice_length, config);
+        service_->PutStart(client_id, key, "default", slice_length, config);
     ASSERT_TRUE(put_start_result.has_value());
     ASSERT_EQ(2u, put_start_result->size());
-    ASSERT_TRUE(
-        service_->PutEnd(client_id, key, ReplicaType::MEMORY).has_value());
+    ASSERT_TRUE(service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY)
+                    .has_value());
 
     // Verify two replicas exist and they are on distinct segments
-    auto get_result = service_->GetReplicaList(key);
+    auto get_result = service_->GetReplicaList(key, "default");
     ASSERT_TRUE(get_result.has_value());
     auto replicas = get_result.value().replicas;
     ASSERT_EQ(2u, replicas.size());
@@ -1290,7 +1304,7 @@ TEST_F(MasterServiceSnapshotTest, ReadableAfterPartialUnmountWithReplication) {
     ASSERT_TRUE(service_->UnmountSegment(segment1.id, client_id).has_value());
 
     // Key should still be readable via the remaining replica
-    auto get_after_unmount = service_->GetReplicaList(key);
+    auto get_after_unmount = service_->GetReplicaList(key, "default");
     ASSERT_TRUE(get_after_unmount.has_value())
         << "Object should remain accessible with surviving replica";
 }
@@ -1340,7 +1354,7 @@ TEST_F(MasterServiceSnapshotTest, UnmountSegmentPerformance) {
 
     // Verify all keys are gone
     for (const auto& key : keys) {
-        auto get_result = service_->GetReplicaList(key);
+        auto get_result = service_->GetReplicaList(key, "default");
         EXPECT_FALSE(get_result.has_value());
         EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, get_result.error());
     }
@@ -1371,75 +1385,76 @@ TEST_F(MasterServiceSnapshotTest, RemoveLeasedObject) {
 
     // Verify lease is granted on ExistsKey
     auto put_start_result =
-        service_->PutStart(client_id, key, slice_length, config);
+        service_->PutStart(client_id, key, "default", slice_length, config);
     ASSERT_TRUE(put_start_result.has_value());
-    auto put_end_result = service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end_result =
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value());
-    auto exist_result = service_->ExistKey(key);
+    auto exist_result = service_->ExistKey(key, "default");
     ASSERT_TRUE(exist_result.has_value());
-    auto remove_result = service_->Remove(key);
+    auto remove_result = service_->Remove(key, "default");
     EXPECT_FALSE(remove_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_HAS_LEASE, remove_result.error());
     std::this_thread::sleep_for(std::chrono::milliseconds(kv_lease_ttl));
-    auto remove_result2 = service_->Remove(key);
+    auto remove_result2 = service_->Remove(key, "default");
     EXPECT_TRUE(remove_result2.has_value());
 
     // Verify lease is extended on successive ExistsKey
     auto put_start_result2 =
-        service_->PutStart(client_id, key, slice_length, config);
+        service_->PutStart(client_id, key, "default", slice_length, config);
     ASSERT_TRUE(put_start_result2.has_value());
     auto put_end_result2 =
-        service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result2.has_value());
-    auto exist_result2 = service_->ExistKey(key);
+    auto exist_result2 = service_->ExistKey(key, "default");
     ASSERT_TRUE(exist_result2.has_value());
     std::this_thread::sleep_for(std::chrono::milliseconds(kv_lease_ttl));
-    auto exist_result3 = service_->ExistKey(key);
+    auto exist_result3 = service_->ExistKey(key, "default");
     ASSERT_TRUE(exist_result3.has_value());
-    auto remove_result3 = service_->Remove(key);
+    auto remove_result3 = service_->Remove(key, "default");
     EXPECT_FALSE(remove_result3.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_HAS_LEASE, remove_result3.error());
     std::this_thread::sleep_for(std::chrono::milliseconds(kv_lease_ttl));
-    auto remove_result4 = service_->Remove(key);
+    auto remove_result4 = service_->Remove(key, "default");
     EXPECT_TRUE(remove_result4.has_value());
 
     // Verify lease is granted on GetReplicaList
     auto put_start_result3 =
-        service_->PutStart(client_id, key, slice_length, config);
+        service_->PutStart(client_id, key, "default", slice_length, config);
     ASSERT_TRUE(put_start_result3.has_value());
     auto put_end_result3 =
-        service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result3.has_value());
-    auto get_result = service_->GetReplicaList(key);
+    auto get_result = service_->GetReplicaList(key, "default");
     ASSERT_TRUE(get_result.has_value());
-    auto remove_result5 = service_->Remove(key);
+    auto remove_result5 = service_->Remove(key, "default");
     EXPECT_FALSE(remove_result5.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_HAS_LEASE, remove_result5.error());
     std::this_thread::sleep_for(std::chrono::milliseconds(kv_lease_ttl));
-    auto remove_result6 = service_->Remove(key);
+    auto remove_result6 = service_->Remove(key, "default");
     EXPECT_TRUE(remove_result6.has_value());
 
     // Verify lease is extended on successive GetReplicaList
     auto put_start_result4 =
-        service_->PutStart(client_id, key, slice_length, config);
+        service_->PutStart(client_id, key, "default", slice_length, config);
     ASSERT_TRUE(put_start_result4.has_value());
     auto put_end_result4 =
-        service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result4.has_value());
-    auto get_result2 = service_->GetReplicaList(key);
+    auto get_result2 = service_->GetReplicaList(key, "default");
     ASSERT_TRUE(get_result2.has_value());
     std::this_thread::sleep_for(std::chrono::milliseconds(kv_lease_ttl));
-    auto get_result3 = service_->GetReplicaList(key);
+    auto get_result3 = service_->GetReplicaList(key, "default");
     ASSERT_TRUE(get_result3.has_value());
-    auto remove_result7 = service_->Remove(key);
+    auto remove_result7 = service_->Remove(key, "default");
     EXPECT_FALSE(remove_result7.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_HAS_LEASE, remove_result7.error());
     std::this_thread::sleep_for(std::chrono::milliseconds(kv_lease_ttl));
-    auto remove_result8 = service_->Remove(key);
+    auto remove_result8 = service_->Remove(key, "default");
     EXPECT_TRUE(remove_result8.has_value());
 
     // Verify object is removed
-    auto get_result4 = service_->GetReplicaList(key);
+    auto get_result4 = service_->GetReplicaList(key, "default");
     EXPECT_FALSE(get_result4.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, get_result4.error());
 }
@@ -1458,13 +1473,13 @@ TEST_F(MasterServiceSnapshotTest, RemoveAllLeasedObject) {
         ReplicateConfig config;
         config.replica_num = 1;
         auto put_start_result =
-            service_->PutStart(client_id, key, slice_length, config);
+            service_->PutStart(client_id, key, "default", slice_length, config);
         ASSERT_TRUE(put_start_result.has_value());
         auto put_end_result =
-            service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+            service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
         ASSERT_TRUE(put_end_result.has_value());
         if (i >= 5) {
-            auto exist_result = service_->ExistKey(key);
+            auto exist_result = service_->ExistKey(key, "default");
             ASSERT_TRUE(exist_result.has_value());
         }
     }
@@ -1472,7 +1487,7 @@ TEST_F(MasterServiceSnapshotTest, RemoveAllLeasedObject) {
     // before TearDown snapshot verification ASSERT_EQ(5,
     // service_->RemoveAll()); for (int i = 0; i < 5; ++i) {
     //     std::string key = "test_key" + std::to_string(i);
-    //     auto exist_result = service_->ExistKey(key);
+    //     auto exist_result = service_->ExistKey(key, "default");
     //     ASSERT_FALSE(exist_result.value());
     // }
     // // wait for all the lease to expire
@@ -1480,7 +1495,7 @@ TEST_F(MasterServiceSnapshotTest, RemoveAllLeasedObject) {
     // ASSERT_EQ(5, service_->RemoveAll());
     // for (int i = 5; i < 10; ++i) {
     //     std::string key = "test_key" + std::to_string(i);
-    //     auto exist_result = service_->ExistKey(key);
+    //     auto exist_result = service_->ExistKey(key, "default");
     //     ASSERT_FALSE(exist_result.value());
     // }
 }
@@ -1511,10 +1526,10 @@ TEST_F(MasterServiceSnapshotTest, EvictObject) {
         ReplicateConfig config;
         config.replica_num = 1;
         auto put_start_result =
-            service_->PutStart(client_id, key, slice_length, config);
+            service_->PutStart(client_id, key, "default", slice_length, config);
         if (put_start_result.has_value()) {
-            auto put_end_result =
-                service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+            auto put_end_result = service_->PutEnd(client_id, key, "default",
+                                                   ReplicaType::MEMORY);
             ASSERT_TRUE(put_end_result.has_value());
             success_puts++;
         } else {
@@ -1556,13 +1571,13 @@ TEST_F(MasterServiceSnapshotTest, TryEvictLeasedObject) {
         ReplicateConfig config;
         config.replica_num = 1;
         auto put_start_result =
-            service_->PutStart(client_id, key, slice_length, config);
+            service_->PutStart(client_id, key, "default", slice_length, config);
         if (put_start_result.has_value()) {
-            auto put_end_result =
-                service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+            auto put_end_result = service_->PutEnd(client_id, key, "default",
+                                                   ReplicaType::MEMORY);
             ASSERT_TRUE(put_end_result.has_value());
             // the object is leased
-            auto get_result = service_->GetReplicaList(key);
+            auto get_result = service_->GetReplicaList(key, "default");
             ASSERT_TRUE(get_result.has_value());
             leased_keys.push_back(key);
             success_puts++;
@@ -1576,7 +1591,7 @@ TEST_F(MasterServiceSnapshotTest, TryEvictLeasedObject) {
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
     // All leased objects should be accessible
     for (const auto& key : leased_keys) {
-        auto get_result = service_->GetReplicaList(key);
+        auto get_result = service_->GetReplicaList(key, "default");
         ASSERT_TRUE(get_result.has_value());
     }
     // [Commented for snapshot test] The following RemoveAll would clear data
@@ -1612,19 +1627,21 @@ TEST_F(MasterServiceSnapshotTest, RemoveSoftPinObject) {
 
     // Verify soft pin does not block remove
     ASSERT_TRUE(
-        service_->PutStart(client_id, key, slice_length, config).has_value());
-    ASSERT_TRUE(
-        service_->PutEnd(client_id, key, ReplicaType::MEMORY).has_value());
-    EXPECT_TRUE(service_->Remove(key).has_value());
+        service_->PutStart(client_id, key, "default", slice_length, config)
+            .has_value());
+    ASSERT_TRUE(service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY)
+                    .has_value());
+    EXPECT_TRUE(service_->Remove(key, "default").has_value());
 
     // [Commented for snapshot test] The following RemoveAll would clear data
     // before TearDown snapshot verification
     // // Verify soft pin does not block RemoveAll
     // ASSERT_TRUE(
-    //     service_->PutStart(client_id, key, slice_length,
+    //     service_->PutStart(client_id, key, "default", slice_length, //
     //     config).has_value());
     // ASSERT_TRUE(
-    //     service_->PutEnd(client_id, key, ReplicaType::MEMORY).has_value());
+    //     service_->PutEnd(client_id, key, "default",
+    //     ReplicaType::MEMORY).has_value());
     // EXPECT_EQ(1, service_->RemoveAll());
 }
 
@@ -1662,11 +1679,12 @@ TEST_F(MasterServiceSnapshotTest, SoftPinObjectsNotEvictedBeforeOtherObjects) {
             soft_pin_config.with_soft_pin = true;
 
             ASSERT_TRUE(service_
-                            ->PutStart(client_id, pin_key, slice_length,
-                                       soft_pin_config)
+                            ->PutStart(client_id, pin_key, "default",
+                                       slice_length, soft_pin_config)
                             .has_value());
             ASSERT_TRUE(
-                service_->PutEnd(client_id, pin_key, ReplicaType::MEMORY)
+                service_
+                    ->PutEnd(client_id, pin_key, "default", ReplicaType::MEMORY)
                     .has_value());
         }
 
@@ -1677,10 +1695,12 @@ TEST_F(MasterServiceSnapshotTest, SoftPinObjectsNotEvictedBeforeOtherObjects) {
             uint64_t slice_length = value_size;
             ReplicateConfig config;
             config.replica_num = 1;
-            if (service_->PutStart(client_id, key, slice_length, config)
+            if (service_
+                    ->PutStart(client_id, key, "default", slice_length, config)
                     .has_value()) {
                 ASSERT_TRUE(
-                    service_->PutEnd(client_id, key, ReplicaType::MEMORY)
+                    service_
+                        ->PutEnd(client_id, key, "default", ReplicaType::MEMORY)
                         .has_value());
             } else {
                 failed_puts++;
@@ -1693,7 +1713,8 @@ TEST_F(MasterServiceSnapshotTest, SoftPinObjectsNotEvictedBeforeOtherObjects) {
         // pin_key should still be accessible
         for (int i = 0; i < 2; i++) {
             std::string pin_key = "pin_key" + std::to_string(i);
-            ASSERT_TRUE(service_->GetReplicaList(pin_key).has_value());
+            ASSERT_TRUE(
+                service_->GetReplicaList(pin_key, "default").has_value());
         }
 
         // wait for the lease to expire
@@ -1736,10 +1757,11 @@ TEST_F(MasterServiceSnapshotTest, SoftPinObjectsCanBeEvicted) {
         ReplicateConfig config;
         config.replica_num = 1;
         config.with_soft_pin = true;
-        if (service_->PutStart(client_id, key, slice_length, config)
+        if (service_->PutStart(client_id, key, "default", slice_length, config)
                 .has_value()) {
-            ASSERT_TRUE(service_->PutEnd(client_id, key, ReplicaType::MEMORY)
-                            .has_value());
+            ASSERT_TRUE(
+                service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY)
+                    .has_value());
             success_puts++;
         } else {
             // wait for eviction to work
@@ -1796,10 +1818,11 @@ TEST_F(MasterServiceSnapshotTest, SoftPinExtendedOnGet) {
             soft_pin_config.replica_num = 1;
             soft_pin_config.with_soft_pin = true;
 
-            ASSERT_TRUE(service_->PutStart(client_id, pin_key, slice_length,
-                                           soft_pin_config));
+            ASSERT_TRUE(service_->PutStart(client_id, pin_key, "default",
+                                           slice_length, soft_pin_config));
             ASSERT_TRUE(
-                service_->PutEnd(client_id, pin_key, ReplicaType::MEMORY)
+                service_
+                    ->PutEnd(client_id, pin_key, "default", ReplicaType::MEMORY)
                     .has_value());
         }
 
@@ -1809,7 +1832,8 @@ TEST_F(MasterServiceSnapshotTest, SoftPinExtendedOnGet) {
         // Get the pin_key to extend the soft pin
         for (int i = 0; i < 2; i++) {
             std::string pin_key = "pin_key" + std::to_string(i);
-            ASSERT_TRUE(service_->GetReplicaList(pin_key).has_value());
+            ASSERT_TRUE(
+                service_->GetReplicaList(pin_key, "default").has_value());
         }
 
         // Fill the segment to trigger eviction
@@ -1819,10 +1843,12 @@ TEST_F(MasterServiceSnapshotTest, SoftPinExtendedOnGet) {
             uint64_t slice_length = value_size;
             ReplicateConfig config;
             config.replica_num = 1;
-            if (service_->PutStart(client_id, key, slice_length, config)
+            if (service_
+                    ->PutStart(client_id, key, "default", slice_length, config)
                     .has_value()) {
                 ASSERT_TRUE(
-                    service_->PutEnd(client_id, key, ReplicaType::MEMORY)
+                    service_
+                        ->PutEnd(client_id, key, "default", ReplicaType::MEMORY)
                         .has_value());
             } else {
                 failed_puts++;
@@ -1836,7 +1862,8 @@ TEST_F(MasterServiceSnapshotTest, SoftPinExtendedOnGet) {
         // pin_key should still be accessible
         for (int i = 0; i < 2; i++) {
             std::string pin_key = "pin_key" + std::to_string(i);
-            ASSERT_TRUE(service_->GetReplicaList(pin_key).has_value());
+            ASSERT_TRUE(
+                service_->GetReplicaList(pin_key, "default").has_value());
         }
         // [Commented for snapshot test] The following RemoveAll would clear
         // data before TearDown snapshot verification Only remove all objects
@@ -1880,10 +1907,11 @@ TEST_F(MasterServiceSnapshotTest, SoftPinObjectsNotAllowEvict) {
         ReplicateConfig config;
         config.replica_num = 1;
         config.with_soft_pin = true;
-        if (service_->PutStart(client_id, key, slice_length, config)
+        if (service_->PutStart(client_id, key, "default", slice_length, config)
                 .has_value()) {
-            ASSERT_TRUE(service_->PutEnd(client_id, key, ReplicaType::MEMORY)
-                            .has_value());
+            ASSERT_TRUE(
+                service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY)
+                    .has_value());
             success_keys.push_back(key);
         } else {
             // wait for eviction to work
@@ -1893,7 +1921,7 @@ TEST_F(MasterServiceSnapshotTest, SoftPinObjectsNotAllowEvict) {
     ASSERT_LE(success_keys.size(), 17);
     // All soft pinned objects should be accessible
     for (const auto& key : success_keys) {
-        ASSERT_TRUE(service_->GetReplicaList(key).has_value());
+        ASSERT_TRUE(service_->GetReplicaList(key, "default").has_value());
     }
     // [Commented for snapshot test] The following RemoveAll would clear data
     // before TearDown snapshot verification
@@ -1921,7 +1949,7 @@ TEST_F(MasterServiceSnapshotTest, ReplicaSegmentsAreUnique) {
     config.replica_num = 10;
 
     auto put_start_result =
-        service_->PutStart(client_id, key, slice_length, config);
+        service_->PutStart(client_id, key, "default", slice_length, config);
     ASSERT_TRUE(put_start_result.has_value());
     auto replica_list_local = put_start_result.value();
     ASSERT_EQ(config.replica_num, replica_list_local.size());
@@ -1937,8 +1965,8 @@ TEST_F(MasterServiceSnapshotTest, ReplicaSegmentsAreUnique) {
     EXPECT_EQ(segment_names.size(), config.replica_num)
         << "Duplicate segment found";
 
-    ASSERT_TRUE(
-        service_->PutEnd(client_id, key, ReplicaType::MEMORY).has_value());
+    ASSERT_TRUE(service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY)
+                    .has_value());
 }
 
 TEST_F(MasterServiceSnapshotTest, ReplicationFactorTwoWithSingleSegment) {
@@ -1959,7 +1987,7 @@ TEST_F(MasterServiceSnapshotTest, ReplicationFactorTwoWithSingleSegment) {
     config.replica_num = 2;
 
     auto put_start_result =
-        service_->PutStart(client_id, key, slice_length, config);
+        service_->PutStart(client_id, key, "default", slice_length, config);
     ASSERT_TRUE(put_start_result.has_value());
     auto replicas = put_start_result.value();
 
@@ -1991,23 +2019,23 @@ TEST_F(MasterServiceSnapshotTest, BatchExistKeyTest) {
         ReplicateConfig config;
         config.replica_num = 1;
         uint64_t slice_length = value_size;
-        auto put_start_result =
-            service_->PutStart(client_id, test_keys[i], slice_length, config);
+        auto put_start_result = service_->PutStart(
+            client_id, test_keys[i], "default", slice_length, config);
         ASSERT_TRUE(put_start_result.has_value());
-        auto put_end_result =
-            service_->PutEnd(client_id, test_keys[i], ReplicaType::MEMORY);
+        auto put_end_result = service_->PutEnd(client_id, test_keys[i],
+                                               "default", ReplicaType::MEMORY);
         ASSERT_TRUE(put_end_result.has_value());
     }
 
     // Test individual ExistKey calls to verify the underlying functionality
     for (int i = 0; i < test_object_num; ++i) {
-        auto exist_result = service_->ExistKey(test_keys[i]);
+        auto exist_result = service_->ExistKey(test_keys[i], "default");
         EXPECT_TRUE(exist_result.value());
     }
 
     // Tets batch
     test_keys.push_back("non_existent_key");
-    auto exist_resp = service_->BatchExistKey(test_keys);
+    auto exist_resp = service_->BatchExistKey(test_keys, "default");
     for (int i = 0; i < test_object_num; ++i) {
         ASSERT_TRUE(exist_resp[i].value());
     }
@@ -2302,7 +2330,7 @@ TEST_F(MasterServiceSnapshotTest, PutStartExpiringTest) {
 
     // Put key_1, should success.
     auto put_start_result =
-        service_->PutStart(client_id, key_1, slice_length, config);
+        service_->PutStart(client_id, key_1, "default", slice_length, config);
     EXPECT_TRUE(put_start_result.has_value());
     replica_list = put_start_result.value();
     EXPECT_EQ(replica_list.size(), kReplicaCnt);
@@ -2312,7 +2340,7 @@ TEST_F(MasterServiceSnapshotTest, PutStartExpiringTest) {
 
     // Put key_1 again, should fail because the key exists.
     put_start_result =
-        service_->PutStart(client_id, key_1, slice_length, config);
+        service_->PutStart(client_id, key_1, "default", slice_length, config);
     EXPECT_FALSE(put_start_result.has_value());
     EXPECT_EQ(put_start_result.error(), ErrorCode::OBJECT_ALREADY_EXISTS);
 
@@ -2328,7 +2356,7 @@ TEST_F(MasterServiceSnapshotTest, PutStartExpiringTest) {
     // Put key_1 again, should success because the old one has expired and will
     // be discarded by this put.
     put_start_result =
-        service_->PutStart(client_id, key_1, slice_length, config);
+        service_->PutStart(client_id, key_1, "default", slice_length, config);
     EXPECT_TRUE(put_start_result.has_value());
     replica_list = put_start_result.value();
     EXPECT_EQ(replica_list.size(), kReplicaCnt);
@@ -2338,17 +2366,17 @@ TEST_F(MasterServiceSnapshotTest, PutStartExpiringTest) {
 
     // Complete key_1.
     auto put_end_result =
-        service_->PutEnd(client_id, key_1, ReplicaType::MEMORY);
+        service_->PutEnd(client_id, key_1, "default", ReplicaType::MEMORY);
     EXPECT_TRUE(put_end_result.has_value());
 
     // Protect key_1 from eviction.
-    auto get_result = service_->GetReplicaList(key_1);
+    auto get_result = service_->GetReplicaList(key_1, "default");
     EXPECT_TRUE(get_result.has_value());
 
     // Put key_2, should fail because the key_1 occupied 12MB (6MB processing,
     // 6MB discarded but not yet released) on each segment.
     put_start_result =
-        service_->PutStart(client_id, key_2, slice_length, config);
+        service_->PutStart(client_id, key_2, "default", slice_length, config);
     EXPECT_FALSE(put_start_result.has_value());
     EXPECT_EQ(put_start_result.error(), ErrorCode::NO_AVAILABLE_HANDLE);
 
@@ -2361,7 +2389,7 @@ TEST_F(MasterServiceSnapshotTest, PutStartExpiringTest) {
             EXPECT_TRUE(result.has_value());
         }
         // Protect key_1 from eviction.
-        auto get_result = service_->GetReplicaList(key_1);
+        auto get_result = service_->GetReplicaList(key_1, "default");
         EXPECT_TRUE(get_result.has_value());
         std::this_thread::sleep_for(std::chrono::seconds(1));
     }
@@ -2369,7 +2397,7 @@ TEST_F(MasterServiceSnapshotTest, PutStartExpiringTest) {
     // Put key_2 again, should success because the discarded replica has been
     // released.
     put_start_result =
-        service_->PutStart(client_id, key_2, slice_length, config);
+        service_->PutStart(client_id, key_2, "default", slice_length, config);
     EXPECT_TRUE(put_start_result.has_value());
     replica_list = put_start_result.value();
     EXPECT_EQ(replica_list.size(), kReplicaCnt);
@@ -2384,7 +2412,7 @@ TEST_F(MasterServiceSnapshotTest, PutStartExpiringTest) {
             EXPECT_TRUE(result.has_value());
         }
         // Protect key_1 from eviction.
-        auto get_result = service_->GetReplicaList(key_1);
+        auto get_result = service_->GetReplicaList(key_1, "default");
         EXPECT_TRUE(get_result.has_value());
         std::this_thread::sleep_for(std::chrono::seconds(1));
     }
@@ -2392,7 +2420,7 @@ TEST_F(MasterServiceSnapshotTest, PutStartExpiringTest) {
     // Put key_2 again, should fail because eviction has not been triggered. And
     // this PutStart should trigger the eviction.
     put_start_result =
-        service_->PutStart(client_id, key_2, slice_length, config);
+        service_->PutStart(client_id, key_2, "default", slice_length, config);
     EXPECT_FALSE(put_start_result.has_value());
     EXPECT_EQ(put_start_result.error(), ErrorCode::NO_AVAILABLE_HANDLE);
 
@@ -2402,7 +2430,7 @@ TEST_F(MasterServiceSnapshotTest, PutStartExpiringTest) {
     // Put key_2 again, should success because the previous one has been
     // discarded and released.
     put_start_result =
-        service_->PutStart(client_id, key_2, slice_length, config);
+        service_->PutStart(client_id, key_2, "default", slice_length, config);
     EXPECT_TRUE(put_start_result.has_value());
     replica_list = put_start_result.value();
     EXPECT_EQ(replica_list.size(), kReplicaCnt);
@@ -2411,7 +2439,8 @@ TEST_F(MasterServiceSnapshotTest, PutStartExpiringTest) {
     }
 
     // Complete key_2.
-    put_end_result = service_->PutEnd(client_id, key_2, ReplicaType::MEMORY);
+    put_end_result =
+        service_->PutEnd(client_id, key_2, "default", ReplicaType::MEMORY);
     EXPECT_TRUE(put_end_result.has_value());
 }
 
@@ -2528,16 +2557,16 @@ TEST_F(MasterServiceSnapshotTest, BatchReplicaClearAllSegments) {
         ReplicateConfig config;
         config.replica_num = 1;
         auto put_start_result =
-            service_->PutStart(client_id, key, value_length, config);
+            service_->PutStart(client_id, key, "default", value_length, config);
         ASSERT_TRUE(put_start_result.has_value());
         auto put_end_result =
-            service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+            service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
         ASSERT_TRUE(put_end_result.has_value());
     }
 
     // Verify objects exist
     for (const auto& key : keys) {
-        auto exist_result = service_->ExistKey(key);
+        auto exist_result = service_->ExistKey(key, "default");
         ASSERT_TRUE(exist_result.has_value());
         ASSERT_TRUE(exist_result.value());
     }
@@ -2554,7 +2583,7 @@ TEST_F(MasterServiceSnapshotTest, BatchReplicaClearAllSegments) {
 
     // Verify objects are removed
     for (const auto& key : keys) {
-        auto exist_result = service_->ExistKey(key);
+        auto exist_result = service_->ExistKey(key, "default");
         ASSERT_TRUE(exist_result.has_value());
         ASSERT_FALSE(exist_result.value())
             << "Key " << key << " should be removed";
@@ -2585,9 +2614,10 @@ TEST_F(MasterServiceSnapshotTest, BatchReplicaClearSpecificSegment) {
     config.preferred_segment =
         segment_name;  // Ensure object is placed on segment1
     auto put_start_result =
-        service_->PutStart(client_id, key, value_length, config);
+        service_->PutStart(client_id, key, "default", value_length, config);
     ASSERT_TRUE(put_start_result.has_value());
-    auto put_end_result = service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end_result =
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value());
 
     // 4. Wait for lease to expire and verify it's actually expired
@@ -2625,7 +2655,7 @@ TEST_F(MasterServiceSnapshotTest, BatchReplicaClearSpecificSegment) {
     const auto& cleared_keys = clear_result.value();
     ASSERT_EQ(1u, cleared_keys.size()) << "Key should be cleared";
 
-    auto exist_result = service_->ExistKey(key);
+    auto exist_result = service_->ExistKey(key, "default");
     ASSERT_TRUE(exist_result.has_value());
     ASSERT_FALSE(exist_result.value())
         << "Key should be removed after being cleared.";
@@ -2646,13 +2676,14 @@ TEST_F(MasterServiceSnapshotTest, BatchReplicaClearWithLeaseActive) {
     ReplicateConfig config;
     config.replica_num = 1;
     auto put_start_result =
-        service_->PutStart(client_id, key, value_length, config);
+        service_->PutStart(client_id, key, "default", value_length, config);
     ASSERT_TRUE(put_start_result.has_value());
-    auto put_end_result = service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end_result =
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value());
 
     // Grant a lease by calling GetReplicaList (similar to normal usage)
-    auto get_result = service_->GetReplicaList(key);
+    auto get_result = service_->GetReplicaList(key, "default");
     ASSERT_TRUE(get_result.has_value());
 
     // Try to clear immediately (lease should still be active)
@@ -2666,7 +2697,7 @@ TEST_F(MasterServiceSnapshotTest, BatchReplicaClearWithLeaseActive) {
         << "No keys should be cleared when lease is active";
 
     // Verify object still exists
-    auto exist_result = service_->ExistKey(key);
+    auto exist_result = service_->ExistKey(key, "default");
     ASSERT_TRUE(exist_result.has_value());
     ASSERT_TRUE(exist_result.value()) << "Key should still exist";
 }
@@ -2687,10 +2718,10 @@ TEST_F(MasterServiceSnapshotTest, BatchReplicaClearWithDifferentClientId) {
     ReplicateConfig config;
     config.replica_num = 1;
     auto put_start_result =
-        service_->PutStart(client_id1, key, value_length, config);
+        service_->PutStart(client_id1, key, "default", value_length, config);
     ASSERT_TRUE(put_start_result.has_value());
     auto put_end_result =
-        service_->PutEnd(client_id1, key, ReplicaType::MEMORY);
+        service_->PutEnd(client_id1, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value());
 
     // Wait for lease to expire
@@ -2707,7 +2738,7 @@ TEST_F(MasterServiceSnapshotTest, BatchReplicaClearWithDifferentClientId) {
         << "No keys should be cleared for different client_id";
 
     // Verify object still exists
-    auto exist_result = service_->ExistKey(key);
+    auto exist_result = service_->ExistKey(key, "default");
     ASSERT_TRUE(exist_result.has_value());
     ASSERT_TRUE(exist_result.value()) << "Key should still exist";
 }
@@ -2762,11 +2793,11 @@ TEST_F(MasterServiceSnapshotTest, BatchReplicaClearWithEmptyStringKeys) {
     uint64_t value_length = 1024;
     ReplicateConfig config;
     config.replica_num = 1;
-    auto put_start_result =
-        service_->PutStart(client_id, valid_key, value_length, config);
+    auto put_start_result = service_->PutStart(client_id, valid_key, "default",
+                                               value_length, config);
     ASSERT_TRUE(put_start_result.has_value());
     auto put_end_result =
-        service_->PutEnd(client_id, valid_key, ReplicaType::MEMORY);
+        service_->PutEnd(client_id, valid_key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value());
 
     // Wait for lease to expire
@@ -2804,22 +2835,25 @@ TEST_F(MasterServiceSnapshotTest, BatchReplicaClearMixedScenario) {
 
     // Create key1 and key2 with client_id1
     auto put_start1 =
-        service_->PutStart(client_id1, key1, value_length, config);
+        service_->PutStart(client_id1, key1, "default", value_length, config);
     ASSERT_TRUE(put_start1.has_value());
-    auto put_end1 = service_->PutEnd(client_id1, key1, ReplicaType::MEMORY);
+    auto put_end1 =
+        service_->PutEnd(client_id1, key1, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end1.has_value());
 
     auto put_start2 =
-        service_->PutStart(client_id1, key2, value_length, config);
+        service_->PutStart(client_id1, key2, "default", value_length, config);
     ASSERT_TRUE(put_start2.has_value());
-    auto put_end2 = service_->PutEnd(client_id1, key2, ReplicaType::MEMORY);
+    auto put_end2 =
+        service_->PutEnd(client_id1, key2, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end2.has_value());
 
     // Create key3 with client_id2
     auto put_start3 =
-        service_->PutStart(client_id2, key3, value_length, config);
+        service_->PutStart(client_id2, key3, "default", value_length, config);
     ASSERT_TRUE(put_start3.has_value());
-    auto put_end3 = service_->PutEnd(client_id2, key3, ReplicaType::MEMORY);
+    auto put_end3 =
+        service_->PutEnd(client_id2, key3, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end3.has_value());
 
     // Wait for lease to expire
@@ -2837,16 +2871,16 @@ TEST_F(MasterServiceSnapshotTest, BatchReplicaClearMixedScenario) {
         << "Only keys belonging to client_id1 should be cleared";
 
     // Verify key1 and key2 are cleared
-    auto exist1 = service_->ExistKey(key1);
+    auto exist1 = service_->ExistKey(key1, "default");
     ASSERT_TRUE(exist1.has_value());
     ASSERT_FALSE(exist1.value()) << "key1 should be cleared";
 
-    auto exist2 = service_->ExistKey(key2);
+    auto exist2 = service_->ExistKey(key2, "default");
     ASSERT_TRUE(exist2.has_value());
     ASSERT_FALSE(exist2.value()) << "key2 should be cleared";
 
     // Verify key3 still exists (different client_id)
-    auto exist3 = service_->ExistKey(key3);
+    auto exist3 = service_->ExistKey(key3, "default");
     ASSERT_TRUE(exist3.has_value());
     ASSERT_TRUE(exist3.value())
         << "key3 should still exist (different client_id)";
@@ -2882,15 +2916,15 @@ TEST_F(MasterServiceSnapshotTest, CreateCopyTaskTest) {
     config.replica_num = 1;
     config.preferred_segment = "segment_0";
     auto put_start_result =
-        service_->PutStart(client_id, key1, slice_length, config);
+        service_->PutStart(client_id, key1, "default", slice_length, config);
     EXPECT_TRUE(put_start_result.has_value());
     auto put_end_result =
-        service_->PutEnd(client_id, key1, ReplicaType::MEMORY);
+        service_->PutEnd(client_id, key1, "default", ReplicaType::MEMORY);
     EXPECT_TRUE(put_end_result.has_value());
 
     // Copy key1 to "segment_1" and "segment_2"
     auto copy_result =
-        service_->CreateCopyTask(key1, {"segment_1", "segment_2"});
+        service_->CreateCopyTask(key1, "default", {"segment_1", "segment_2"});
     EXPECT_TRUE(copy_result.has_value());
 
     // verify the copy task is created and assigned to the client who executed
@@ -2901,18 +2935,19 @@ TEST_F(MasterServiceSnapshotTest, CreateCopyTaskTest) {
     EXPECT_EQ(contexts[0].client_id, task.value().assigned_client);
 
     // Copy with empty targets should fail
-    auto copy_result1 = service_->CreateCopyTask(key1, {});
+    auto copy_result1 = service_->CreateCopyTask(key1, "default", {});
     EXPECT_FALSE(copy_result1.has_value());
     EXPECT_EQ(ErrorCode::INVALID_PARAMS, copy_result1.error());
 
     // Copy not exist key should fail
     auto copy_result2 =
-        service_->CreateCopyTask("not_exist_key", {"segment_1"});
+        service_->CreateCopyTask("not_exist_key", "default", {"segment_1"});
     EXPECT_FALSE(copy_result2.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, copy_result2.error());
 
     // Copy to segment that not mounted should fail
-    auto copy_result3 = service_->CreateCopyTask(key1, {"not_mounted_segment"});
+    auto copy_result3 =
+        service_->CreateCopyTask(key1, "default", {"not_mounted_segment"});
     EXPECT_FALSE(copy_result3.has_value());
     EXPECT_EQ(ErrorCode::INVALID_PARAMS, copy_result3.error());
 }
@@ -2947,14 +2982,15 @@ TEST_F(MasterServiceSnapshotTest, CreateMoveTaskTest) {
     config.replica_num = 1;
     config.preferred_segment = "segment_0";
     auto put_start_result =
-        service_->PutStart(client_id, key1, slice_length, config);
+        service_->PutStart(client_id, key1, "default", slice_length, config);
     EXPECT_TRUE(put_start_result.has_value());
     auto put_end_result =
-        service_->PutEnd(client_id, key1, ReplicaType::MEMORY);
+        service_->PutEnd(client_id, key1, "default", ReplicaType::MEMORY);
     EXPECT_TRUE(put_end_result.has_value());
 
     // Move key1 from "segment_0" to "segment_1"
-    auto move_result = service_->CreateMoveTask(key1, "segment_0", "segment_1");
+    auto move_result =
+        service_->CreateMoveTask(key1, "default", "segment_0", "segment_1");
     EXPECT_TRUE(move_result.has_value());
 
     // Verify the move task is created and assigned to the client owning the
@@ -2965,32 +3001,32 @@ TEST_F(MasterServiceSnapshotTest, CreateMoveTaskTest) {
     EXPECT_EQ(contexts[0].client_id, task.value().assigned_client);
 
     // Move non-existent key should fail
-    auto move_result1 =
-        service_->CreateMoveTask("not_exist_key", "segment_0", "segment_1");
+    auto move_result1 = service_->CreateMoveTask("not_exist_key", "default",
+                                                 "segment_0", "segment_1");
     EXPECT_FALSE(move_result1.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, move_result1.error());
 
     // Move to segment that is same as source should fail
     auto move_result_same =
-        service_->CreateMoveTask(key1, "segment_1", "segment_1");
+        service_->CreateMoveTask(key1, "default", "segment_1", "segment_1");
     EXPECT_FALSE(move_result_same.has_value());
     EXPECT_EQ(ErrorCode::INVALID_PARAMS, move_result_same.error());
 
     // Move to segment that is not mounted should fail
-    auto move_result2 =
-        service_->CreateMoveTask(key1, "segment_0", "not_mounted_segment");
+    auto move_result2 = service_->CreateMoveTask(key1, "default", "segment_0",
+                                                 "not_mounted_segment");
     EXPECT_FALSE(move_result2.has_value());
     EXPECT_EQ(ErrorCode::INVALID_PARAMS, move_result2.error());
 
     // Move from segment that does not have the replica should fail
     auto move_result3 =
-        service_->CreateMoveTask(key1, "segment_2", "segment_1");
+        service_->CreateMoveTask(key1, "default", "segment_2", "segment_1");
     EXPECT_FALSE(move_result3.has_value());
     EXPECT_EQ(ErrorCode::INVALID_PARAMS, move_result3.error());
 
     // Move from segment that is not mounted should fail
-    auto move_result4 =
-        service_->CreateMoveTask(key1, "not_mounted_segment", "segment_1");
+    auto move_result4 = service_->CreateMoveTask(
+        key1, "default", "not_mounted_segment", "segment_1");
     EXPECT_FALSE(move_result4.has_value());
     EXPECT_EQ(ErrorCode::INVALID_PARAMS, move_result4.error());
 }
@@ -3025,14 +3061,15 @@ TEST_F(MasterServiceSnapshotTest, QueryTaskTest) {
     config.replica_num = 1;
     config.preferred_segment = "segment_0";
     auto put_start_result =
-        service_->PutStart(client_id, key1, slice_length, config);
+        service_->PutStart(client_id, key1, "default", slice_length, config);
     EXPECT_TRUE(put_start_result.has_value());
     auto put_end_result =
-        service_->PutEnd(client_id, key1, ReplicaType::MEMORY);
+        service_->PutEnd(client_id, key1, "default", ReplicaType::MEMORY);
     EXPECT_TRUE(put_end_result.has_value());
 
     // Move key1 from "segment_0" to "segment_1"
-    auto move_result = service_->CreateMoveTask(key1, "segment_0", "segment_1");
+    auto move_result =
+        service_->CreateMoveTask(key1, "default", "segment_0", "segment_1");
     EXPECT_TRUE(move_result.has_value());
 
     // Query non-existent task should fail
@@ -3073,18 +3110,21 @@ TEST_F(MasterServiceSnapshotTest,
     config.replica_num = 1;
     config.preferred_segment = "segment_0";
 
+    ASSERT_TRUE(service_
+                    ->PutStart(put_client_id, key, "default",
+                               /*slice_length=*/1024, config)
+                    .has_value());
     ASSERT_TRUE(
-        service_->PutStart(put_client_id, key, /*slice_length=*/1024, config)
+        service_->PutEnd(put_client_id, key, "default", ReplicaType::MEMORY)
             .has_value());
-    ASSERT_TRUE(
-        service_->PutEnd(put_client_id, key, ReplicaType::MEMORY).has_value());
 
     // Create two tasks; both should be assigned to the client owning source
     // segment_0.
-    auto copy_task_id = service_->CreateCopyTask(key, {"segment_1"});
+    auto copy_task_id = service_->CreateCopyTask(key, "default", {"segment_1"});
     ASSERT_TRUE(copy_task_id.has_value());
 
-    auto move_task_id = service_->CreateMoveTask(key, "segment_0", "segment_1");
+    auto move_task_id =
+        service_->CreateMoveTask(key, "default", "segment_0", "segment_1");
     ASSERT_TRUE(move_task_id.has_value());
 
     // Fetch from client_0 should get both tasks (order not guaranteed).
@@ -3133,15 +3173,18 @@ TEST_F(MasterServiceSnapshotTest, FetchTasksRespectsBatchSize) {
     config.replica_num = 1;
     config.preferred_segment = "segment_0";
 
+    ASSERT_TRUE(service_
+                    ->PutStart(put_client_id, key, "default",
+                               /*slice_length=*/1024, config)
+                    .has_value());
     ASSERT_TRUE(
-        service_->PutStart(put_client_id, key, /*slice_length=*/1024, config)
+        service_->PutEnd(put_client_id, key, "default", ReplicaType::MEMORY)
             .has_value());
-    ASSERT_TRUE(
-        service_->PutEnd(put_client_id, key, ReplicaType::MEMORY).has_value());
 
-    auto t1 = service_->CreateCopyTask(key, {"segment_1"});
+    auto t1 = service_->CreateCopyTask(key, "default", {"segment_1"});
     ASSERT_TRUE(t1.has_value());
-    auto t2 = service_->CreateMoveTask(key, "segment_0", "segment_1");
+    auto t2 =
+        service_->CreateMoveTask(key, "default", "segment_0", "segment_1");
     ASSERT_TRUE(t2.has_value());
 
     auto fetch_first = service_->FetchTasks(ctx0.client_id, /*batch_size=*/1);
@@ -3182,14 +3225,16 @@ TEST_F(MasterServiceSnapshotTest, UpdateTaskSuccessFlow) {
     config.replica_num = 1;
     config.preferred_segment = "segment_0";
 
+    ASSERT_TRUE(service_
+                    ->PutStart(put_client_id, key, "default",
+                               /*slice_length=*/1024, config)
+                    .has_value());
     ASSERT_TRUE(
-        service_->PutStart(put_client_id, key, /*slice_length=*/1024, config)
+        service_->PutEnd(put_client_id, key, "default", ReplicaType::MEMORY)
             .has_value());
-    ASSERT_TRUE(
-        service_->PutEnd(put_client_id, key, ReplicaType::MEMORY).has_value());
 
     // Create a task assigned to client owning segment_0.
-    auto task_id_res = service_->CreateCopyTask(key, {"segment_1"});
+    auto task_id_res = service_->CreateCopyTask(key, "default", {"segment_1"});
     ASSERT_TRUE(task_id_res.has_value());
     const UUID task_id = task_id_res.value();
 
@@ -3238,13 +3283,16 @@ TEST_F(MasterServiceSnapshotTest, UpdateTaskRejectsWrongClient) {
     config.replica_num = 1;
     config.preferred_segment = "segment_0";
 
+    ASSERT_TRUE(service_
+                    ->PutStart(put_client_id, key, "default",
+                               /*slice_length=*/1024, config)
+                    .has_value());
     ASSERT_TRUE(
-        service_->PutStart(put_client_id, key, /*slice_length=*/1024, config)
+        service_->PutEnd(put_client_id, key, "default", ReplicaType::MEMORY)
             .has_value());
-    ASSERT_TRUE(
-        service_->PutEnd(put_client_id, key, ReplicaType::MEMORY).has_value());
 
-    auto task_id_res = service_->CreateMoveTask(key, "segment_0", "segment_1");
+    auto task_id_res =
+        service_->CreateMoveTask(key, "default", "segment_0", "segment_1");
     ASSERT_TRUE(task_id_res.has_value());
     const UUID task_id = task_id_res.value();
 
@@ -3301,8 +3349,8 @@ TEST_F(MasterServiceSnapshotTest, CopyStart) {
     UUID client_id = generate_uuid();
 
     // Test Case 1: CopyStart a non-existent key, should fail.
-    auto copy_result = service_->CopyStart(client_id, "non_existent_key",
-                                           "segment_1", {"segment_2"});
+    auto copy_result = service_->CopyStart(
+        client_id, "non_existent_key", "default", "segment_1", {"segment_2"});
     EXPECT_FALSE(copy_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, copy_result.error());
 
@@ -3315,22 +3363,23 @@ TEST_F(MasterServiceSnapshotTest, CopyStart) {
     config.preferred_segment = "segment_1";
 
     auto put_start_result =
-        service_->PutStart(client_id, key, slice_length, config);
+        service_->PutStart(client_id, key, "default", slice_length, config);
     ASSERT_TRUE(put_start_result.has_value());
 
     // Test Case 2: CopyStart to segment_2 and segment_3, should fail because
     // the only replica is not completed.
-    copy_result = service_->CopyStart(client_id, key, "segment_1",
+    copy_result = service_->CopyStart(client_id, key, "default", "segment_1",
                                       {"segment_2", "segment_3"});
     EXPECT_FALSE(copy_result.has_value());
     EXPECT_EQ(ErrorCode::REPLICA_NOT_FOUND, copy_result.error());
 
     // PutEnd the object.
-    auto put_end_result = service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end_result =
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value());
 
     // Test Case 3: CopyStart to segment_2 and segment_3, should success.
-    copy_result = service_->CopyStart(client_id, key, "segment_1",
+    copy_result = service_->CopyStart(client_id, key, "default", "segment_1",
                                       {"segment_2", "segment_3"});
     EXPECT_TRUE(copy_result.has_value());
     auto copy_response = copy_result.value();
@@ -3339,40 +3388,41 @@ TEST_F(MasterServiceSnapshotTest, CopyStart) {
     EXPECT_EQ(2, copy_response.targets.size());
 
     // Test Case 4: Try remove the object, should fail because it is copying.
-    auto remove_result = service_->Remove(key);
+    auto remove_result = service_->Remove(key, "default");
     EXPECT_FALSE(remove_result.has_value());
     EXPECT_EQ(ErrorCode::REPLICA_IS_NOT_READY, remove_result.error());
 
     // Test Case 5: CopyStart to segment_4, should fail because there is an
     // ongoing copy task.
-    copy_result =
-        service_->CopyStart(client_id, key, "segment_1", {"segment_4"});
+    copy_result = service_->CopyStart(client_id, key, "default", "segment_1",
+                                      {"segment_4"});
     EXPECT_FALSE(copy_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_HAS_REPLICATION_TASK, copy_result.error());
 
     // Test Case 6: CopyEnd, should success and the object now has 3 replicas.
-    auto copy_end_result = service_->CopyEnd(client_id, key);
+    auto copy_end_result = service_->CopyEnd(client_id, key, "default");
     EXPECT_TRUE(copy_end_result.has_value());
-    auto get_result = service_->GetReplicaList(key);
+    auto get_result = service_->GetReplicaList(key, "default");
     EXPECT_TRUE(get_result.has_value());
     EXPECT_EQ(3, get_result.value().replicas.size());
 
     // Test Case 7: Copy from a non-existent replica to segment_3 and
     // segment_4, should fail.
-    copy_result = service_->CopyStart(client_id, key, "non_existent_segment",
-                                      {"segment_3", "segment_4"});
+    copy_result =
+        service_->CopyStart(client_id, key, "default", "non_existent_segment",
+                            {"segment_3", "segment_4"});
     EXPECT_FALSE(copy_result.has_value());
     EXPECT_EQ(ErrorCode::REPLICA_NOT_FOUND, copy_result.error());
 
     // Test Case 8: Copy to segment_4 and a non-existent segment, should fail.
-    copy_result = service_->CopyStart(client_id, key, "segment_1",
+    copy_result = service_->CopyStart(client_id, key, "default", "segment_1",
                                       {"segment_4", "non_existent_segment"});
     EXPECT_FALSE(copy_result.has_value());
     EXPECT_EQ(ErrorCode::SEGMENT_NOT_FOUND, copy_result.error());
 
     // Test Case 9: Copy to segment_3 and segment_4, should skip segment_3 and
     // successfully copy to segment_4.
-    copy_result = service_->CopyStart(client_id, key, "segment_1",
+    copy_result = service_->CopyStart(client_id, key, "default", "segment_1",
                                       {"segment_3", "segment_4"});
     EXPECT_TRUE(copy_result.has_value());
     copy_response = copy_result.value();
@@ -3385,16 +3435,16 @@ TEST_F(MasterServiceSnapshotTest, CopyStart) {
                                .buffer_descriptor.transport_endpoint_);
 
     // End the copy operation to clean up state
-    copy_end_result = service_->CopyEnd(client_id, key);
+    copy_end_result = service_->CopyEnd(client_id, key, "default");
     EXPECT_TRUE(copy_end_result.has_value());
-    get_result = service_->GetReplicaList(key);
+    get_result = service_->GetReplicaList(key, "default");
     EXPECT_TRUE(get_result.has_value());
     EXPECT_EQ(4, get_result.value().replicas.size());
 
     // Test Case 10: Copy to segment_4 again, should skip because it's already
     // used.
-    copy_result =
-        service_->CopyStart(client_id, key, "segment_1", {"segment_4"});
+    copy_result = service_->CopyStart(client_id, key, "default", "segment_1",
+                                      {"segment_4"});
     EXPECT_TRUE(copy_result.has_value());
     copy_response = copy_result.value();
     EXPECT_EQ("segment_1", copy_response.source.get_memory_descriptor()
@@ -3407,19 +3457,19 @@ TEST_F(MasterServiceSnapshotTest, CopyStart) {
     std::this_thread::sleep_for(std::chrono::milliseconds(kv_lease_ttl * 2));
 
     // Test Case 11: Try remove the object, should fail because it is copying.
-    remove_result = service_->Remove(key);
+    remove_result = service_->Remove(key, "default");
     EXPECT_FALSE(remove_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_HAS_REPLICATION_TASK, remove_result.error());
 
     // Clean up the copy operation
-    // copy_end_result = service_->CopyEnd(client_id, key);
+    // copy_end_result = service_->CopyEnd(client_id, key, "default");
     // EXPECT_TRUE(copy_end_result.has_value());
 
     // Wait for the lease to expire
     // std::this_thread::sleep_for(std::chrono::milliseconds(kv_lease_ttl * 2));
 
     // Test Case 12: Try remove the object, should success.
-    // remove_result = service_->Remove(key);
+    // remove_result = service_->Remove(key, "default");
     // EXPECT_TRUE(remove_result.has_value());
 }
 
@@ -3439,7 +3489,8 @@ TEST_F(MasterServiceSnapshotTest, CopyEnd) {
     UUID invalid_client_id = generate_uuid();
 
     // Test Case 1: CopyEnd a non-existent key, should fail.
-    auto copy_end_result = service_->CopyEnd(client_id, "non_existent_key");
+    auto copy_end_result =
+        service_->CopyEnd(client_id, "non_existent_key", "default");
     EXPECT_FALSE(copy_end_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, copy_end_result.error());
 
@@ -3451,45 +3502,46 @@ TEST_F(MasterServiceSnapshotTest, CopyEnd) {
     config.preferred_segment = "segment_1";
 
     auto put_start_result =
-        service_->PutStart(client_id, key, slice_length, config);
+        service_->PutStart(client_id, key, "default", slice_length, config);
     ASSERT_TRUE(put_start_result.has_value());
-    auto put_end_result = service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end_result =
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value());
 
     // Test Case 2: CopyEnd the object, should fail because there is no ongoing
     // copy task.
-    copy_end_result = service_->CopyEnd(client_id, key);
+    copy_end_result = service_->CopyEnd(client_id, key, "default");
     EXPECT_FALSE(copy_end_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NO_REPLICATION_TASK, copy_end_result.error());
 
     // CopyStart the object to segment_2
-    auto copy_start_result =
-        service_->CopyStart(client_id, key, "segment_1", {"segment_2"});
+    auto copy_start_result = service_->CopyStart(client_id, key, "default",
+                                                 "segment_1", {"segment_2"});
     ASSERT_TRUE(copy_start_result.has_value());
 
     // Test Case 3: CopyEnd with an invalid client id, should fail.
-    copy_end_result = service_->CopyEnd(invalid_client_id, key);
+    copy_end_result = service_->CopyEnd(invalid_client_id, key, "default");
     EXPECT_FALSE(copy_end_result.has_value());
     EXPECT_EQ(ErrorCode::ILLEGAL_CLIENT, copy_end_result.error());
 
     // Test Case 4: MoveEnd the object, should fail because the ongoing task is
     // Copy.
-    auto move_end_result = service_->MoveEnd(client_id, key);
+    auto move_end_result = service_->MoveEnd(client_id, key, "default");
     EXPECT_FALSE(move_end_result.has_value());
     EXPECT_EQ(ErrorCode::INVALID_PARAMS, move_end_result.error());
 
     // Test Case 5: CopyEnd, should success.
-    copy_end_result = service_->CopyEnd(client_id, key);
+    copy_end_result = service_->CopyEnd(client_id, key, "default");
     EXPECT_TRUE(copy_end_result.has_value());
 
     // Verify we now have 2 replicas
-    auto get_result = service_->GetReplicaList(key);
+    auto get_result = service_->GetReplicaList(key, "default");
     EXPECT_TRUE(get_result.has_value());
     EXPECT_EQ(2, get_result.value().replicas.size());
 
     // CopyStart the object from segment_1 to segment_3, then unmount segment_1
-    copy_start_result =
-        service_->CopyStart(client_id, key, "segment_1", {"segment_3"});
+    copy_start_result = service_->CopyStart(client_id, key, "default",
+                                            "segment_1", {"segment_3"});
     ASSERT_TRUE(copy_start_result.has_value());
 
     // Unmount segment_1 to simulate source gone
@@ -3499,10 +3551,10 @@ TEST_F(MasterServiceSnapshotTest, CopyEnd) {
 
     // Test Case 6: CopyEnd, should fail because the source is gone, the object
     // should have only 1 replica from segment_2.
-    copy_end_result = service_->CopyEnd(client_id, key);
+    copy_end_result = service_->CopyEnd(client_id, key, "default");
     EXPECT_FALSE(copy_end_result.has_value());
     EXPECT_EQ(ErrorCode::REPLICA_IS_GONE, copy_end_result.error());
-    get_result = service_->GetReplicaList(key);
+    get_result = service_->GetReplicaList(key, "default");
     EXPECT_TRUE(get_result.has_value());
     auto& replicas = get_result.value().replicas;
     EXPECT_EQ(1, replicas.size());
@@ -3511,8 +3563,8 @@ TEST_F(MasterServiceSnapshotTest, CopyEnd) {
                                .buffer_descriptor.transport_endpoint_);
 
     // CopyStart the object from segment_2 to segment_3, then unmount segment_3
-    copy_start_result =
-        service_->CopyStart(client_id, key, "segment_2", {"segment_3"});
+    copy_start_result = service_->CopyStart(client_id, key, "default",
+                                            "segment_2", {"segment_3"});
     ASSERT_TRUE(copy_start_result.has_value());
 
     // Unmount segment_3 to simulate target gone
@@ -3522,10 +3574,10 @@ TEST_F(MasterServiceSnapshotTest, CopyEnd) {
 
     // Test Case 7: CopyEnd, should fail because the target is gone, the object
     // should have only 1 replica from segment_2.
-    copy_end_result = service_->CopyEnd(client_id, key);
+    copy_end_result = service_->CopyEnd(client_id, key, "default");
     EXPECT_FALSE(copy_end_result.has_value());
     EXPECT_EQ(ErrorCode::REPLICA_IS_GONE, copy_end_result.error());
-    get_result = service_->GetReplicaList(key);
+    get_result = service_->GetReplicaList(key, "default");
     EXPECT_TRUE(get_result.has_value());
     replicas = get_result.value().replicas;
     EXPECT_EQ(1, replicas.size());
@@ -3549,7 +3601,7 @@ TEST_F(MasterServiceSnapshotTest, CopyRevoke) {
 
     // Test Case 1: CopyRevoke a non-existent key, should fail.
     auto copy_revoke_result =
-        service_->CopyRevoke(client_id, "non_existent_key");
+        service_->CopyRevoke(client_id, "non_existent_key", "default");
     EXPECT_FALSE(copy_revoke_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, copy_revoke_result.error());
 
@@ -3561,47 +3613,49 @@ TEST_F(MasterServiceSnapshotTest, CopyRevoke) {
     config.preferred_segment = "segment_1";
 
     auto put_start_result =
-        service_->PutStart(client_id, key, slice_length, config);
+        service_->PutStart(client_id, key, "default", slice_length, config);
     ASSERT_TRUE(put_start_result.has_value());
-    auto put_end_result = service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end_result =
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value());
 
     // Test Case 2: CopyRevoke the object, should fail because there is no
     // ongoing copy task.
-    copy_revoke_result = service_->CopyRevoke(client_id, key);
+    copy_revoke_result = service_->CopyRevoke(client_id, key, "default");
     EXPECT_FALSE(copy_revoke_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NO_REPLICATION_TASK,
               copy_revoke_result.error());
 
     // CopyStart the object to segment_2
-    auto copy_start_result =
-        service_->CopyStart(client_id, key, "segment_1", {"segment_2"});
+    auto copy_start_result = service_->CopyStart(client_id, key, "default",
+                                                 "segment_1", {"segment_2"});
     ASSERT_TRUE(copy_start_result.has_value());
 
     // Test Case 3: CopyRevoke with an invalid client id, should fail.
-    copy_revoke_result = service_->CopyRevoke(invalid_client_id, key);
+    copy_revoke_result =
+        service_->CopyRevoke(invalid_client_id, key, "default");
     EXPECT_FALSE(copy_revoke_result.has_value());
     EXPECT_EQ(ErrorCode::ILLEGAL_CLIENT, copy_revoke_result.error());
 
     // Test Case 4: MoveRevoke the object, should fail because the ongoing task
     // is Copy.
-    auto move_revoke_result = service_->MoveRevoke(client_id, key);
+    auto move_revoke_result = service_->MoveRevoke(client_id, key, "default");
     EXPECT_FALSE(move_revoke_result.has_value());
     EXPECT_EQ(ErrorCode::INVALID_PARAMS, move_revoke_result.error());
 
     // Test Case 5: CopyRevoke, should success.
-    copy_revoke_result = service_->CopyRevoke(client_id, key);
+    copy_revoke_result = service_->CopyRevoke(client_id, key, "default");
     EXPECT_TRUE(copy_revoke_result.has_value());
 
     // Verify we still have 1 replica (the copy was revoked)
-    auto get_result = service_->GetReplicaList(key);
+    auto get_result = service_->GetReplicaList(key, "default");
     EXPECT_TRUE(get_result.has_value());
     EXPECT_EQ(1, get_result.value().replicas.size());
 
     // CopyStart the object from segment_1 to segment_2 again, then unmount
     // segment_1
-    copy_start_result =
-        service_->CopyStart(client_id, key, "segment_1", {"segment_2"});
+    copy_start_result = service_->CopyStart(client_id, key, "default",
+                                            "segment_1", {"segment_2"});
     ASSERT_TRUE(copy_start_result.has_value());
 
     // Unmount segment_1 to simulate source gone
@@ -3611,11 +3665,11 @@ TEST_F(MasterServiceSnapshotTest, CopyRevoke) {
 
     // Test Case 6: CopyRevoke, should success even though the source is gone,
     // the object should be erased too.
-    copy_revoke_result = service_->CopyRevoke(client_id, key);
+    copy_revoke_result = service_->CopyRevoke(client_id, key, "default");
     EXPECT_TRUE(copy_revoke_result.has_value());
 
     // Verify the object has been removed.
-    get_result = service_->GetReplicaList(key);
+    get_result = service_->GetReplicaList(key, "default");
     EXPECT_FALSE(get_result.has_value());
 }
 
@@ -3633,7 +3687,8 @@ TEST_F(MasterServiceSnapshotTest, MoveEnd) {
     UUID invalid_client_id = generate_uuid();
 
     // Test Case 1: MoveEnd a non-existent key, should fail.
-    auto move_end_result = service_->MoveEnd(client_id, "non_existent_key");
+    auto move_end_result =
+        service_->MoveEnd(client_id, "non_existent_key", "default");
     EXPECT_FALSE(move_end_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, move_end_result.error());
 
@@ -3645,46 +3700,47 @@ TEST_F(MasterServiceSnapshotTest, MoveEnd) {
     config.preferred_segment = "segment_1";
 
     auto put_start_result =
-        service_->PutStart(client_id, key, slice_length, config);
+        service_->PutStart(client_id, key, "default", slice_length, config);
     ASSERT_TRUE(put_start_result.has_value());
-    auto put_end_result = service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end_result =
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value());
 
     // Test Case 2: MoveEnd the object, should fail because there is no ongoing
     // move task.
-    move_end_result = service_->MoveEnd(client_id, key);
+    move_end_result = service_->MoveEnd(client_id, key, "default");
     EXPECT_FALSE(move_end_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NO_REPLICATION_TASK, move_end_result.error());
 
     // MoveStart the object to segment_2
-    auto move_start_result =
-        service_->MoveStart(client_id, key, "segment_1", "segment_2");
+    auto move_start_result = service_->MoveStart(client_id, key, "default",
+                                                 "segment_1", "segment_2");
     ASSERT_TRUE(move_start_result.has_value());
 
     // Test Case 3: MoveEnd with an invalid client id, should fail.
-    move_end_result = service_->MoveEnd(invalid_client_id, key);
+    move_end_result = service_->MoveEnd(invalid_client_id, key, "default");
     EXPECT_FALSE(move_end_result.has_value());
     EXPECT_EQ(ErrorCode::ILLEGAL_CLIENT, move_end_result.error());
 
     // Test Case 4: CopyEnd the object, should fail because the ongoing task is
     // Move.
-    auto copy_end_result = service_->CopyEnd(client_id, key);
+    auto copy_end_result = service_->CopyEnd(client_id, key, "default");
     EXPECT_FALSE(copy_end_result.has_value());
     EXPECT_EQ(ErrorCode::INVALID_PARAMS, copy_end_result.error());
 
     // Test Case 5: MoveEnd, should success.
-    move_end_result = service_->MoveEnd(client_id, key);
+    move_end_result = service_->MoveEnd(client_id, key, "default");
     EXPECT_TRUE(move_end_result.has_value());
 
     // Verify we still have 1 replica (the move was successful)
-    auto get_result = service_->GetReplicaList(key);
+    auto get_result = service_->GetReplicaList(key, "default");
     EXPECT_TRUE(get_result.has_value());
     EXPECT_EQ(1, get_result.value().replicas.size());
 
     // MoveStart the object from segment_2 to segment_1 again, then unmount
     // segment_2
-    move_start_result =
-        service_->MoveStart(client_id, key, "segment_2", "segment_1");
+    move_start_result = service_->MoveStart(client_id, key, "default",
+                                            "segment_2", "segment_1");
     ASSERT_TRUE(move_start_result.has_value());
 
     // Unmount segment_2 to simulate source gone
@@ -3693,7 +3749,7 @@ TEST_F(MasterServiceSnapshotTest, MoveEnd) {
     ASSERT_TRUE(unmount_result.has_value());
 
     // Test Case 6: MoveEnd, should fail because the source is gone.
-    move_end_result = service_->MoveEnd(client_id, key);
+    move_end_result = service_->MoveEnd(client_id, key, "default");
     EXPECT_FALSE(move_end_result.has_value());
     EXPECT_EQ(ErrorCode::REPLICA_IS_GONE, move_end_result.error());
 }
@@ -3712,7 +3768,7 @@ TEST_F(MasterServiceSnapshotTest, MoveRevoke) {
 
     // Test Case 1: MoveRevoke a non-existent key, should fail.
     auto move_revoke_result =
-        service_->MoveRevoke(client_id, "non_existent_key");
+        service_->MoveRevoke(client_id, "non_existent_key", "default");
     EXPECT_FALSE(move_revoke_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, move_revoke_result.error());
 
@@ -3724,40 +3780,42 @@ TEST_F(MasterServiceSnapshotTest, MoveRevoke) {
     config.preferred_segment = "segment_1";
 
     auto put_start_result =
-        service_->PutStart(client_id, key, slice_length, config);
+        service_->PutStart(client_id, key, "default", slice_length, config);
     ASSERT_TRUE(put_start_result.has_value());
-    auto put_end_result = service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end_result =
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value());
 
     // Test Case 2: MoveRevoke the object, should fail because there is no
     // ongoing move task.
-    move_revoke_result = service_->MoveRevoke(client_id, key);
+    move_revoke_result = service_->MoveRevoke(client_id, key, "default");
     EXPECT_FALSE(move_revoke_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NO_REPLICATION_TASK,
               move_revoke_result.error());
 
     // MoveStart the object from segment_1 to segment_2
-    auto move_start_result =
-        service_->MoveStart(client_id, key, "segment_1", "segment_2");
+    auto move_start_result = service_->MoveStart(client_id, key, "default",
+                                                 "segment_1", "segment_2");
     ASSERT_TRUE(move_start_result.has_value());
 
     // Test Case 3: MoveRevoke with an invalid client id, should fail.
-    move_revoke_result = service_->MoveRevoke(invalid_client_id, key);
+    move_revoke_result =
+        service_->MoveRevoke(invalid_client_id, key, "default");
     EXPECT_FALSE(move_revoke_result.has_value());
     EXPECT_EQ(ErrorCode::ILLEGAL_CLIENT, move_revoke_result.error());
 
     // Test Case 4: CopyRevoke the object, should fail because the ongoing task
     // is Move.
-    auto copy_revoke_result = service_->CopyRevoke(client_id, key);
+    auto copy_revoke_result = service_->CopyRevoke(client_id, key, "default");
     EXPECT_FALSE(copy_revoke_result.has_value());
     EXPECT_EQ(ErrorCode::INVALID_PARAMS, copy_revoke_result.error());
 
     // Test Case 5: MoveRevoke, should succeed.
-    move_revoke_result = service_->MoveRevoke(client_id, key);
+    move_revoke_result = service_->MoveRevoke(client_id, key, "default");
     EXPECT_TRUE(move_revoke_result.has_value());
 
     // Verify we still have 1 replica (the move was revoked)
-    auto get_result = service_->GetReplicaList(key);
+    auto get_result = service_->GetReplicaList(key, "default");
     EXPECT_TRUE(get_result.has_value());
     auto& replicas = get_result.value().replicas;
     EXPECT_EQ(1, replicas.size());
@@ -3767,8 +3825,8 @@ TEST_F(MasterServiceSnapshotTest, MoveRevoke) {
 
     // MoveStart the object from segment_1 to segment_2 again, then unmount
     // segment_1
-    move_start_result =
-        service_->MoveStart(client_id, key, "segment_1", "segment_2");
+    move_start_result = service_->MoveStart(client_id, key, "default",
+                                            "segment_1", "segment_2");
     ASSERT_TRUE(move_start_result.has_value());
 
     // Unmount segment_1 to simulate source gone
@@ -3777,11 +3835,11 @@ TEST_F(MasterServiceSnapshotTest, MoveRevoke) {
     ASSERT_TRUE(unmount_result.has_value());
 
     // Test Case 6: MoveRevoke, should succeed even though the source is gone.
-    move_revoke_result = service_->MoveRevoke(client_id, key);
+    move_revoke_result = service_->MoveRevoke(client_id, key, "default");
     EXPECT_TRUE(move_revoke_result.has_value());
 
     // The object should be erased as there is no replica left.
-    get_result = service_->GetReplicaList(key);
+    get_result = service_->GetReplicaList(key, "default");
     EXPECT_FALSE(get_result.has_value());
 }
 
@@ -3804,8 +3862,8 @@ TEST_F(MasterServiceSnapshotTest, MoveStart) {
     UUID client_id = generate_uuid();
 
     // Test Case 1: MoveStart a non-existent key, should fail.
-    auto move_start_result = service_->MoveStart(client_id, "non_existent_key",
-                                                 "segment_1", "segment_2");
+    auto move_start_result = service_->MoveStart(
+        client_id, "non_existent_key", "default", "segment_1", "segment_2");
     EXPECT_FALSE(move_start_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, move_start_result.error());
 
@@ -3817,36 +3875,37 @@ TEST_F(MasterServiceSnapshotTest, MoveStart) {
     config.preferred_segment = "segment_1";
 
     auto put_start_result =
-        service_->PutStart(client_id, key, slice_length, config);
+        service_->PutStart(client_id, key, "default", slice_length, config);
     ASSERT_TRUE(put_start_result.has_value());
 
     // Test Case 2: MoveStart the object, should fail because the only replica
     // is not completed.
-    move_start_result =
-        service_->MoveStart(client_id, key, "segment_1", "segment_2");
+    move_start_result = service_->MoveStart(client_id, key, "default",
+                                            "segment_1", "segment_2");
     EXPECT_FALSE(move_start_result.has_value());
     EXPECT_EQ(ErrorCode::REPLICA_NOT_FOUND, move_start_result.error());
 
     // PutEnd the object.
-    auto put_end_result = service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end_result =
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value());
 
     // Copy the object to segment_3.
-    auto copy_start_result =
-        service_->CopyStart(client_id, key, "segment_1", {"segment_3"});
+    auto copy_start_result = service_->CopyStart(client_id, key, "default",
+                                                 "segment_1", {"segment_3"});
     ASSERT_TRUE(copy_start_result.has_value());
-    auto copy_end_result = service_->CopyEnd(client_id, key);
+    auto copy_end_result = service_->CopyEnd(client_id, key, "default");
     ASSERT_TRUE(copy_end_result.has_value());
 
     // Test Case 3: MoveStart with source and target be the same, should fail.
-    move_start_result =
-        service_->MoveStart(client_id, key, "segment_1", "segment_1");
+    move_start_result = service_->MoveStart(client_id, key, "default",
+                                            "segment_1", "segment_1");
     EXPECT_FALSE(move_start_result.has_value());
     EXPECT_EQ(move_start_result.error(), ErrorCode::INVALID_PARAMS);
 
     // Test Case 4: MoveStart to segment_2, should succeed.
-    move_start_result =
-        service_->MoveStart(client_id, key, "segment_1", "segment_2");
+    move_start_result = service_->MoveStart(client_id, key, "default",
+                                            "segment_1", "segment_2");
     EXPECT_TRUE(move_start_result.has_value());
     auto move_response = move_start_result.value();
     EXPECT_EQ("segment_1", move_response.source.get_memory_descriptor()
@@ -3857,44 +3916,44 @@ TEST_F(MasterServiceSnapshotTest, MoveStart) {
                                .buffer_descriptor.transport_endpoint_);
 
     // Test Case 5: Try remove the object, should fail because it is moving.
-    auto remove_result = service_->Remove(key);
+    auto remove_result = service_->Remove(key, "default");
     EXPECT_FALSE(remove_result.has_value());
     EXPECT_EQ(ErrorCode::REPLICA_IS_NOT_READY, remove_result.error());
 
     // Test Case 6: MoveStart again, should fail because there is an ongoing
     // move task.
-    move_start_result =
-        service_->MoveStart(client_id, key, "segment_1", "segment_3");
+    move_start_result = service_->MoveStart(client_id, key, "default",
+                                            "segment_1", "segment_3");
     EXPECT_FALSE(move_start_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_HAS_REPLICATION_TASK,
               move_start_result.error());
 
     // Test Case 7: MoveEnd, should succeed and the object now has 2 replicas
     // from segment_2 and segment_3
-    auto move_end_result = service_->MoveEnd(client_id, key);
+    auto move_end_result = service_->MoveEnd(client_id, key, "default");
     EXPECT_TRUE(move_end_result.has_value());
 
-    auto get_result = service_->GetReplicaList(key);
+    auto get_result = service_->GetReplicaList(key, "default");
     EXPECT_TRUE(get_result.has_value());
     auto& replicas = get_result.value().replicas;
     EXPECT_EQ(2, replicas.size());
 
     // Test Case 8: Move from a non-existent replica to segment_1, should fail.
     move_start_result = service_->MoveStart(
-        client_id, key, "non_existent_segment", "segment_1");
+        client_id, key, "default", "non_existent_segment", "segment_1");
     EXPECT_FALSE(move_start_result.has_value());
     EXPECT_EQ(ErrorCode::REPLICA_NOT_FOUND, move_start_result.error());
 
     // Test Case 8.5: Move to a non-existent target segment, should fail.
-    move_start_result = service_->MoveStart(client_id, key, "segment_2",
-                                            "non_existent_segment");
+    move_start_result = service_->MoveStart(
+        client_id, key, "default", "segment_2", "non_existent_segment");
     EXPECT_FALSE(move_start_result.has_value());
     EXPECT_EQ(ErrorCode::SEGMENT_NOT_FOUND, move_start_result.error());
 
     // Test Case 9: Move to an already existing segment, should succeed but
     // return nullopt.
-    move_start_result =
-        service_->MoveStart(client_id, key, "segment_2", "segment_3");
+    move_start_result = service_->MoveStart(client_id, key, "default",
+                                            "segment_2", "segment_3");
     EXPECT_TRUE(move_start_result.has_value());
     move_response = move_start_result.value();
     EXPECT_EQ("segment_2", move_response.source.get_memory_descriptor()
@@ -3903,16 +3962,16 @@ TEST_F(MasterServiceSnapshotTest, MoveStart) {
 
     // Test Case 10: Try remove the object, should fail because it is moving.
     std::this_thread::sleep_for(std::chrono::milliseconds(kv_lease_ttl * 2));
-    remove_result = service_->Remove(key);
+    remove_result = service_->Remove(key, "default");
     EXPECT_FALSE(remove_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_HAS_REPLICATION_TASK, remove_result.error());
 
     // End the move.
-    move_end_result = service_->MoveEnd(client_id, key);
+    move_end_result = service_->MoveEnd(client_id, key, "default");
     EXPECT_TRUE(move_end_result.has_value());
 
     // Now the object should have only 1 replica on segment_3.
-    get_result = service_->GetReplicaList(key);
+    get_result = service_->GetReplicaList(key, "default");
     EXPECT_TRUE(get_result.has_value());
     replicas = get_result.value().replicas;
     EXPECT_EQ(1, replicas.size());
@@ -3922,7 +3981,7 @@ TEST_F(MasterServiceSnapshotTest, MoveStart) {
 
     // Test Case 11: Try remove the object, should succeed after lease expires.
     std::this_thread::sleep_for(std::chrono::milliseconds(kv_lease_ttl * 2));
-    remove_result = service_->Remove(key);
+    remove_result = service_->Remove(key, "default");
     EXPECT_TRUE(remove_result.has_value());
 }
 
@@ -3954,26 +4013,27 @@ TEST_F(MasterServiceSnapshotTest, ProtectCopyMoveSourceFromEviction) {
     config.preferred_segment = "segment_1";
 
     // Put two objects for move and copy tests.
-    auto put_start_result =
-        service_->PutStart(client_id, copy_key, slice_length, config);
+    auto put_start_result = service_->PutStart(client_id, copy_key, "default",
+                                               slice_length, config);
     ASSERT_TRUE(put_start_result.has_value());
     auto put_end_result =
-        service_->PutEnd(client_id, copy_key, ReplicaType::MEMORY);
+        service_->PutEnd(client_id, copy_key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value());
 
-    put_start_result =
-        service_->PutStart(client_id, move_key, slice_length, config);
+    put_start_result = service_->PutStart(client_id, move_key, "default",
+                                          slice_length, config);
     ASSERT_TRUE(put_start_result.has_value());
-    put_end_result = service_->PutEnd(client_id, move_key, ReplicaType::MEMORY);
+    put_end_result =
+        service_->PutEnd(client_id, move_key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value());
 
     // Start copy and move operations.
-    auto copy_start_result =
-        service_->CopyStart(client_id, copy_key, "segment_1", {"segment_2"});
+    auto copy_start_result = service_->CopyStart(client_id, copy_key, "default",
+                                                 "segment_1", {"segment_2"});
     ASSERT_TRUE(copy_start_result.has_value());
 
-    auto move_start_result =
-        service_->MoveStart(client_id, move_key, "segment_1", "segment_2");
+    auto move_start_result = service_->MoveStart(client_id, move_key, "default",
+                                                 "segment_1", "segment_2");
     ASSERT_TRUE(move_start_result.has_value());
 
     // Put more objects to trigger eviction. Do not prefer any segments.
@@ -3981,10 +4041,10 @@ TEST_F(MasterServiceSnapshotTest, ProtectCopyMoveSourceFromEviction) {
     for (size_t i = 0; i < 128 * (kSegmentSize * 2 / slice_length); ++i) {
         std::string key = "test_key_" + std::to_string(i);
         auto put_start_result =
-            service_->PutStart(client_id, key, slice_length, config);
+            service_->PutStart(client_id, key, "default", slice_length, config);
         if (put_start_result.has_value()) {
-            auto put_end_result =
-                service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+            auto put_end_result = service_->PutEnd(client_id, key, "default",
+                                                   ReplicaType::MEMORY);
             ASSERT_TRUE(put_end_result.has_value());
         } else {
             // wait for eviction to work
@@ -3998,10 +4058,10 @@ TEST_F(MasterServiceSnapshotTest, ProtectCopyMoveSourceFromEviction) {
     ASSERT_TRUE(remove_all_result > 0);
 
     // Try end copy and move operations, should success.
-    auto copy_end_result = service_->CopyEnd(client_id, copy_key);
+    auto copy_end_result = service_->CopyEnd(client_id, copy_key, "default");
     EXPECT_TRUE(copy_end_result.has_value());
 
-    auto move_end_result = service_->MoveEnd(client_id, move_key);
+    auto move_end_result = service_->MoveEnd(client_id, move_key, "default");
     EXPECT_TRUE(move_end_result.has_value());
 }
 

--- a/mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot_base.h
+++ b/mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot_base.h
@@ -204,7 +204,7 @@ class MasterServiceSnapshotTestBase : public ::testing::Test {
         ServiceStateSnapshot state;
 
         // === Basic State ===
-        auto keys_result = service->GetAllKeys();
+        auto keys_result = service->GetAllKeys("default");
         if (keys_result.has_value()) {
             state.all_keys = std::move(keys_result.value());
             std::sort(state.all_keys.begin(), state.all_keys.end());
@@ -217,7 +217,7 @@ class MasterServiceSnapshotTestBase : public ::testing::Test {
         }
 
         for (const auto& key : state.all_keys) {
-            auto replica_result = service->GetReplicaList(key);
+            auto replica_result = service->GetReplicaList(key, "default");
             if (replica_result.has_value()) {
                 state.replica_lists[key] = std::move(replica_result.value());
             }
@@ -529,8 +529,10 @@ class MasterServiceSnapshotTestBase : public ::testing::Test {
         const std::string key = "snapshot_putstart_consistency_key";
         const uint64_t slice_length = 1024;
 
-        auto before = original->PutStart(client_id, key, slice_length, config);
-        auto after = restored->PutStart(client_id, key, slice_length, config);
+        auto before =
+            original->PutStart(client_id, key, "default", slice_length, config);
+        auto after =
+            restored->PutStart(client_id, key, "default", slice_length, config);
 
         ASSERT_EQ(before.has_value(), after.has_value())
             << "PutStart has_value mismatch between original and restored "

--- a/mooncake-store/tests/ha/snapshot/snapshot_child_process_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/snapshot_child_process_test.cpp
@@ -475,11 +475,12 @@ TEST_F(SnapshotChildProcessTest, RestoreRebuildsGroupedObjectRouting) {
     replicate_config.group_ids = std::vector<std::string>{
         FindGroupIdOnDifferentShard(service_.get(), key)};
 
-    auto put_start = service_->PutStart(client_id, key, 1024, replicate_config);
+    auto put_start =
+        service_->PutStart(client_id, key, "default", 1024, replicate_config);
     ASSERT_TRUE(put_start.has_value()) << toString(put_start.error());
-    ASSERT_TRUE(
-        service_->PutEnd(client_id, key, ReplicaType::MEMORY).has_value());
-    ASSERT_TRUE(service_->ExistKey(key).value_or(false));
+    ASSERT_TRUE(service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY)
+                    .has_value());
+    ASSERT_TRUE(service_->ExistKey(key, "default").value_or(false));
 
     auto persist_result = CallPersistState("20240701_130000_000");
     ASSERT_TRUE(persist_result.has_value())
@@ -488,11 +489,11 @@ TEST_F(SnapshotChildProcessTest, RestoreRebuildsGroupedObjectRouting) {
     service_.reset();
     service_ = std::make_unique<MasterService>(make_config());
 
-    auto restored_replicas = service_->GetReplicaList(key);
+    auto restored_replicas = service_->GetReplicaList(key, "default");
     ASSERT_TRUE(restored_replicas.has_value())
         << "Grouped key should remain reachable by key after restore";
-    ASSERT_TRUE(service_->Remove(key, /*force=*/true).has_value());
-    EXPECT_FALSE(service_->ExistKey(key).value_or(true));
+    ASSERT_TRUE(service_->Remove(key, "default", /*force=*/true).has_value());
+    EXPECT_FALSE(service_->ExistKey(key, "default").value_or(true));
 }
 
 TEST_F(SnapshotChildProcessTest,
@@ -704,12 +705,14 @@ TEST_F(SnapshotChildProcessTest,
         << "MountSegment failed";
 
     const std::string key1 = "restore_fallback_key_1";
-    auto put1 = service_->PutStart(client_id, key1, {1024}, {.replica_num = 1});
+    auto put1 = service_->PutStart(client_id, key1, "default", {1024},
+                                   {.replica_num = 1});
     ASSERT_TRUE(put1.has_value()) << "PutStart for key1 failed";
     ASSERT_TRUE(
-        service_->PutEnd(client_id, key1, ReplicaType::MEMORY).has_value())
+        service_->PutEnd(client_id, key1, "default", ReplicaType::MEMORY)
+            .has_value())
         << "PutEnd for key1 failed";
-    EXPECT_TRUE(service_->ExistKey(key1).value_or(false))
+    EXPECT_TRUE(service_->ExistKey(key1, "default").value_or(false))
         << "ExistKey should refresh lease for key1 before snapshot1";
 
     const std::string snapshot_id1 = "20240702_120000_000";
@@ -719,12 +722,14 @@ TEST_F(SnapshotChildProcessTest,
         << persist_result.error().message;
 
     const std::string key2 = "restore_fallback_key_2";
-    auto put2 = service_->PutStart(client_id, key2, {1024}, {.replica_num = 1});
+    auto put2 = service_->PutStart(client_id, key2, "default", {1024},
+                                   {.replica_num = 1});
     ASSERT_TRUE(put2.has_value()) << "PutStart for key2 failed";
     ASSERT_TRUE(
-        service_->PutEnd(client_id, key2, ReplicaType::MEMORY).has_value())
+        service_->PutEnd(client_id, key2, "default", ReplicaType::MEMORY)
+            .has_value())
         << "PutEnd for key2 failed";
-    EXPECT_TRUE(service_->ExistKey(key2).value_or(false))
+    EXPECT_TRUE(service_->ExistKey(key2, "default").value_or(false))
         << "ExistKey should refresh lease for key2 before snapshot2";
 
     const std::string snapshot_id2 = "20240702_120500_000";
@@ -755,9 +760,9 @@ TEST_F(SnapshotChildProcessTest,
                               .build();
     auto restored_service = std::make_unique<MasterService>(restore_config);
 
-    EXPECT_TRUE(restored_service->ExistKey(key1).value_or(false))
+    EXPECT_TRUE(restored_service->ExistKey(key1, "default").value_or(false))
         << "Restore should fall back to the previous healthy snapshot";
-    EXPECT_FALSE(restored_service->ExistKey(key2).value_or(false))
+    EXPECT_FALSE(restored_service->ExistKey(key2, "default").value_or(false))
         << "Corrupted latest snapshot must not be partially restored";
 
     restored_service.reset();
@@ -828,22 +833,22 @@ TEST_F(SnapshotChildProcessTest, RestoreCleansNonCompleteReplica) {
 
     // Add a complete object (clean data)
     std::string clean_key = "clean_object";
-    auto put_result =
-        service_->PutStart(client_id, clean_key, {1024}, {.replica_num = 1});
+    auto put_result = service_->PutStart(client_id, clean_key, "default",
+                                         {1024}, {.replica_num = 1});
     ASSERT_TRUE(put_result.has_value()) << "PutStart clean failed";
     auto put_end_result =
-        service_->PutEnd(client_id, clean_key, ReplicaType::MEMORY);
+        service_->PutEnd(client_id, clean_key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value()) << "PutEnd clean failed";
 
     // Add an incomplete object (PutStart without PutEnd -> non-COMPLETE)
     std::string dirty_key = "dirty_incomplete";
-    auto put_dirty_result =
-        service_->PutStart(client_id, dirty_key, {1024}, {.replica_num = 1});
+    auto put_dirty_result = service_->PutStart(client_id, dirty_key, "default",
+                                               {1024}, {.replica_num = 1});
     ASSERT_TRUE(put_dirty_result.has_value()) << "PutStart dirty failed";
     // Intentionally NO PutEnd -> replica stays in PENDING status
 
     // Verify both keys exist in metadata before snapshot
-    EXPECT_TRUE(service_->ExistKey(clean_key).value_or(false));
+    EXPECT_TRUE(service_->ExistKey(clean_key, "default").value_or(false));
     EXPECT_TRUE(KeyExistsInMetadata(service_.get(), dirty_key))
         << "Dirty key should exist in raw metadata after PutStart";
 
@@ -866,7 +871,8 @@ TEST_F(SnapshotChildProcessTest, RestoreCleansNonCompleteReplica) {
     auto restored_service = std::make_unique<MasterService>(restore_config);
 
     // Step 4: Verify non-COMPLETE replica was cleaned, complete one remains
-    EXPECT_TRUE(restored_service->ExistKey(clean_key).value_or(false))
+    EXPECT_TRUE(
+        restored_service->ExistKey(clean_key, "default").value_or(false))
         << "Complete object should survive restore";
     EXPECT_FALSE(KeyExistsInMetadata(restored_service.get(), dirty_key))
         << "Non-COMPLETE object should be cleaned from metadata during restore";
@@ -902,23 +908,25 @@ TEST_F(SnapshotChildProcessTest, RestoreCleansExpiredLease) {
     // Add two complete objects via PutStart + PutEnd
     // Note: PutEnd calls GrantLease(0, ...) so lease is immediately expired
     std::string expired_key = "expired_lease_object";
-    auto put_exp =
-        service_->PutStart(client_id, expired_key, {1024}, {.replica_num = 1});
+    auto put_exp = service_->PutStart(client_id, expired_key, "default", {1024},
+                                      {.replica_num = 1});
     ASSERT_TRUE(put_exp.has_value()) << "PutStart expired failed";
-    ASSERT_TRUE(service_->PutEnd(client_id, expired_key, ReplicaType::MEMORY)
-                    .has_value())
+    ASSERT_TRUE(
+        service_->PutEnd(client_id, expired_key, "default", ReplicaType::MEMORY)
+            .has_value())
         << "PutEnd expired failed";
 
     std::string normal_key = "normal_lease_object";
-    auto put_norm =
-        service_->PutStart(client_id, normal_key, {1024}, {.replica_num = 1});
+    auto put_norm = service_->PutStart(client_id, normal_key, "default", {1024},
+                                       {.replica_num = 1});
     ASSERT_TRUE(put_norm.has_value()) << "PutStart normal failed";
-    ASSERT_TRUE(service_->PutEnd(client_id, normal_key, ReplicaType::MEMORY)
-                    .has_value())
+    ASSERT_TRUE(
+        service_->PutEnd(client_id, normal_key, "default", ReplicaType::MEMORY)
+            .has_value())
         << "PutEnd normal failed";
 
     // ExistKey grants a fresh lease (now + 600s) to normal_key
-    EXPECT_TRUE(service_->ExistKey(normal_key).value_or(false));
+    EXPECT_TRUE(service_->ExistKey(normal_key, "default").value_or(false));
     // Do NOT call ExistKey on expired_key, its lease stays expired from PutEnd
 
     // Step 2: Persist state
@@ -940,7 +948,8 @@ TEST_F(SnapshotChildProcessTest, RestoreCleansExpiredLease) {
     auto restored_service = std::make_unique<MasterService>(restore_config);
 
     // Step 4: Verify normal data retained, expired-lease data cleaned
-    EXPECT_TRUE(restored_service->ExistKey(normal_key).value_or(false))
+    EXPECT_TRUE(
+        restored_service->ExistKey(normal_key, "default").value_or(false))
         << "Normal object with valid lease should survive restore";
     EXPECT_FALSE(KeyExistsInMetadata(restored_service.get(), expired_key))
         << "Lease-expired object should be cleaned during restore";

--- a/mooncake-store/tests/master_metrics_test.cpp
+++ b/mooncake-store/tests/master_metrics_test.cpp
@@ -210,13 +210,13 @@ TEST_F(MasterMetricsTest, BasicRequestTest) {
     ASSERT_EQ(metrics.get_put_end_failures(), 0);
 
     // Test ExistKey request
-    auto exist_result = service_.ExistKey(key);
+    auto exist_result = service_.ExistKey(key, "default");
     ASSERT_TRUE(exist_result.has_value() && exist_result.value());
     ASSERT_EQ(metrics.get_exist_key_requests(), 1);
     ASSERT_EQ(metrics.get_exist_key_failures(), 0);
 
     // Test GetReplicaList request
-    auto get_replica_result = service_.GetReplicaList(key);
+    auto get_replica_result = service_.GetReplicaList(key, "default");
     ASSERT_TRUE(get_replica_result.has_value());
     ASSERT_EQ(metrics.get_get_replica_list_requests(), 1);
     ASSERT_EQ(metrics.get_get_replica_list_failures(), 0);
@@ -224,7 +224,7 @@ TEST_F(MasterMetricsTest, BasicRequestTest) {
     // Test Remove request
     std::this_thread::sleep_for(
         std::chrono::milliseconds(default_kv_lease_ttl));
-    auto remove_result = service_.Remove(key);
+    auto remove_result = service_.Remove(key, "default");
     ASSERT_TRUE(remove_result.has_value());
     ASSERT_EQ(metrics.get_remove_requests(), 1);
     ASSERT_EQ(metrics.get_remove_failures(), 0);
@@ -368,7 +368,7 @@ TEST_F(MasterMetricsTest, CalcCacheStatsTest) {
     ASSERT_EQ(stats_dict[CacheHitStat::MEMORY_HITS], base_memory_hits);
     ASSERT_EQ(stats_dict[CacheHitStat::MEMORY_TOTAL], base_memory_total + 1);
 
-    auto get_replica_result = service_.GetReplicaList(key);
+    auto get_replica_result = service_.GetReplicaList(key, "default");
     ASSERT_TRUE(get_replica_result.has_value());
     stats_dict = metrics.calculate_cache_stats();
     expect_aliases(stats_dict);
@@ -386,7 +386,7 @@ TEST_F(MasterMetricsTest, CalcCacheStatsTest) {
                                 stats_dict[CacheHitStat::MEMORY_HITS]) +
                1);
     for (int64_t i = 0; i < extra_gets; ++i) {
-        get_replica_result = service_.GetReplicaList(key);
+        get_replica_result = service_.GetReplicaList(key, "default");
         ASSERT_TRUE(get_replica_result.has_value());
     }
     stats_dict = metrics.calculate_cache_stats();
@@ -397,7 +397,7 @@ TEST_F(MasterMetricsTest, CalcCacheStatsTest) {
 
     std::this_thread::sleep_for(
         std::chrono::milliseconds(default_kv_lease_ttl));
-    auto remove_result = service_.Remove(key);
+    auto remove_result = service_.Remove(key, "default");
     ASSERT_TRUE(remove_result.has_value());
 }
 
@@ -497,7 +497,7 @@ TEST_F(MasterMetricsTest, BatchRequestTest) {
     ASSERT_TRUE(mount_result.has_value());
 
     // Test BatchExistKey request (should all return false initially)
-    auto batch_exist_result = service_.BatchExistKey(keys);
+    auto batch_exist_result = service_.BatchExistKey(keys, "default");
     ASSERT_EQ(batch_exist_result.size(), 3);
     ASSERT_EQ(metrics.get_batch_exist_key_requests(), 1);
     ASSERT_EQ(metrics.get_batch_exist_key_partial_successes(), 0);
@@ -534,7 +534,7 @@ TEST_F(MasterMetricsTest, BatchRequestTest) {
     ASSERT_EQ(metrics.get_batch_put_end_failed_items(), 0);
 
     // Test BatchExistKey again (should all return true now)
-    auto batch_exist_result2 = service_.BatchExistKey(keys);
+    auto batch_exist_result2 = service_.BatchExistKey(keys, "default");
     ASSERT_EQ(batch_exist_result2.size(), 3);
     ASSERT_EQ(metrics.get_batch_exist_key_requests(), 2);
     ASSERT_EQ(metrics.get_batch_exist_key_partial_successes(), 0);
@@ -593,14 +593,18 @@ static std::string PutKeyAndOffload(MasterService& svc, const UUID& client_id,
                                     const std::string& key) {
     ReplicateConfig cfg;
     cfg.replica_num = 1;
-    auto put_start = svc.PutStart(client_id, key, value_size, cfg);
+    auto put_start = svc.PutStart(client_id, key, "default", value_size, cfg);
     if (!put_start) return "";
-    svc.PutEnd(client_id, key, ReplicaType::MEMORY);
+    svc.PutEnd(client_id, key, "default", ReplicaType::MEMORY);
 
     StorageObjectMetadata meta;
     meta.data_size = static_cast<int64_t>(value_size);
     meta.transport_endpoint = "127.0.0.1:9999";
-    svc.NotifyOffloadSuccess(client_id, {key}, {meta});
+    std::vector<OffloadTaskItem> tasks{
+        OffloadTaskItem{.tenant_id = "default",
+                        .key = key,
+                        .size = static_cast<int64_t>(value_size)}};
+    svc.NotifyOffloadSuccess(client_id, tasks, {meta});
     return key;
 }
 
@@ -636,7 +640,7 @@ TEST_F(MasterMetricsTest, LocalDiskReplicaAllocatedSize) {
     EXPECT_EQ(metrics.get_allocated_file_size(), baseline + kValueSize);
 
     // After removing the key the LocalDiskReplica is destroyed; gauge resets.
-    ASSERT_TRUE(svc.Remove(key).has_value());
+    ASSERT_TRUE(svc.Remove(key, "default").has_value());
     EXPECT_EQ(metrics.get_allocated_file_size(), baseline);
 }
 

--- a/mooncake-store/tests/master_service_ssd_test.cpp
+++ b/mooncake-store/tests/master_service_ssd_test.cpp
@@ -50,7 +50,7 @@ TEST_F(MasterServiceSSDTest, PutEndBothReplica) {
     config.replica_num = 1;
 
     auto put_start_result =
-        service_->PutStart(client_id, key, slice_length, config);
+        service_->PutStart(client_id, key, "default", slice_length, config);
     ASSERT_TRUE(put_start_result.has_value());
     auto replicas = put_start_result.value();
     ASSERT_EQ(2, replicas.size());
@@ -63,17 +63,17 @@ TEST_F(MasterServiceSSDTest, PutEndBothReplica) {
     EXPECT_TRUE(has_mem);
     EXPECT_TRUE(has_disk);
 
-    auto get_result = service_->GetReplicaList(key);
+    auto get_result = service_->GetReplicaList(key, "default");
     ASSERT_FALSE(get_result.has_value());
     EXPECT_EQ(ErrorCode::REPLICA_IS_NOT_READY, get_result.error());
 
     // PutEnd for both memory and disk
-    EXPECT_TRUE(
-        service_->PutEnd(client_id, key, ReplicaType::MEMORY).has_value());
-    EXPECT_TRUE(
-        service_->PutEnd(client_id, key, ReplicaType::DISK).has_value());
+    EXPECT_TRUE(service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY)
+                    .has_value());
+    EXPECT_TRUE(service_->PutEnd(client_id, key, "default", ReplicaType::DISK)
+                    .has_value());
 
-    get_result = service_->GetReplicaList(key);
+    get_result = service_->GetReplicaList(key, "default");
     ASSERT_TRUE(get_result.has_value());
     EXPECT_EQ(2, get_result.value().replicas.size());
 
@@ -105,19 +105,21 @@ TEST_F(MasterServiceSSDTest, PutRevokeDiskReplica) {
     config.replica_num = 1;
 
     ASSERT_TRUE(
-        service_->PutStart(client_id, key, slice_length, config).has_value());
-    EXPECT_TRUE(
-        service_->PutEnd(client_id, key, ReplicaType::MEMORY).has_value());
+        service_->PutStart(client_id, key, "default", slice_length, config)
+            .has_value());
+    EXPECT_TRUE(service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY)
+                    .has_value());
 
-    auto get_result = service_->GetReplicaList(key);
+    auto get_result = service_->GetReplicaList(key, "default");
     ASSERT_TRUE(get_result.has_value());
     EXPECT_EQ(1, get_result.value().replicas.size());
     ASSERT_TRUE(get_result.value().replicas[0].is_memory_replica());
 
     EXPECT_TRUE(
-        service_->PutRevoke(client_id, key, ReplicaType::DISK).has_value());
+        service_->PutRevoke(client_id, key, "default", ReplicaType::DISK)
+            .has_value());
 
-    get_result = service_->GetReplicaList(key);
+    get_result = service_->GetReplicaList(key, "default");
     ASSERT_TRUE(get_result.has_value());
     EXPECT_EQ(1, get_result.value().replicas.size());
     ASSERT_TRUE(get_result.value().replicas[0].is_memory_replica());
@@ -146,17 +148,19 @@ TEST_F(MasterServiceSSDTest, PutRevokeMemoryReplica) {
     config.replica_num = 1;
 
     ASSERT_TRUE(
-        service_->PutStart(client_id, key, slice_length, config).has_value());
+        service_->PutStart(client_id, key, "default", slice_length, config)
+            .has_value());
     EXPECT_TRUE(
-        service_->PutRevoke(client_id, key, ReplicaType::MEMORY).has_value());
+        service_->PutRevoke(client_id, key, "default", ReplicaType::MEMORY)
+            .has_value());
 
-    auto get_result = service_->GetReplicaList(key);
+    auto get_result = service_->GetReplicaList(key, "default");
     ASSERT_FALSE(get_result.has_value());
     EXPECT_EQ(ErrorCode::REPLICA_IS_NOT_READY, get_result.error());
 
-    EXPECT_TRUE(
-        service_->PutEnd(client_id, key, ReplicaType::DISK).has_value());
-    get_result = service_->GetReplicaList(key);
+    EXPECT_TRUE(service_->PutEnd(client_id, key, "default", ReplicaType::DISK)
+                    .has_value());
+    get_result = service_->GetReplicaList(key, "default");
     ASSERT_TRUE(get_result.has_value());
     EXPECT_EQ(1, get_result.value().replicas.size());
     ASSERT_TRUE(get_result.value().replicas[0].is_disk_replica());
@@ -185,17 +189,20 @@ TEST_F(MasterServiceSSDTest, PutRevokeBothReplica) {
     config.replica_num = 1;
 
     ASSERT_TRUE(
-        service_->PutStart(client_id, key, slice_length, config).has_value());
+        service_->PutStart(client_id, key, "default", slice_length, config)
+            .has_value());
     EXPECT_TRUE(
-        service_->PutRevoke(client_id, key, ReplicaType::DISK).has_value());
+        service_->PutRevoke(client_id, key, "default", ReplicaType::DISK)
+            .has_value());
 
-    auto get_result = service_->GetReplicaList(key);
+    auto get_result = service_->GetReplicaList(key, "default");
     ASSERT_FALSE(get_result.has_value());
     EXPECT_EQ(ErrorCode::REPLICA_IS_NOT_READY, get_result.error());
 
     EXPECT_TRUE(
-        service_->PutRevoke(client_id, key, ReplicaType::MEMORY).has_value());
-    get_result = service_->GetReplicaList(key);
+        service_->PutRevoke(client_id, key, "default", ReplicaType::MEMORY)
+            .has_value());
+    get_result = service_->GetReplicaList(key, "default");
     ASSERT_FALSE(get_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, get_result.error());
 }
@@ -223,15 +230,16 @@ TEST_F(MasterServiceSSDTest, RemoveKey) {
     config.replica_num = 1;
 
     ASSERT_TRUE(
-        service_->PutStart(client_id, key, slice_length, config).has_value());
-    EXPECT_TRUE(
-        service_->PutEnd(client_id, key, ReplicaType::MEMORY).has_value());
-    EXPECT_TRUE(
-        service_->PutEnd(client_id, key, ReplicaType::DISK).has_value());
+        service_->PutStart(client_id, key, "default", slice_length, config)
+            .has_value());
+    EXPECT_TRUE(service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY)
+                    .has_value());
+    EXPECT_TRUE(service_->PutEnd(client_id, key, "default", ReplicaType::DISK)
+                    .has_value());
 
-    EXPECT_TRUE(service_->Remove(key).has_value());
+    EXPECT_TRUE(service_->Remove(key, "default").has_value());
 
-    auto get_result = service_->GetReplicaList(key);
+    auto get_result = service_->GetReplicaList(key, "default");
     EXPECT_FALSE(get_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, get_result.error());
 }
@@ -264,12 +272,12 @@ TEST_F(MasterServiceSSDTest, EvictObject) {
         ReplicateConfig config;
         config.replica_num = 1;
         auto put_start_result =
-            service_->PutStart(client_id, key, slice_length, config);
+            service_->PutStart(client_id, key, "default", slice_length, config);
         if (put_start_result.has_value()) {
-            auto put_end_mem_result =
-                service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+            auto put_end_mem_result = service_->PutEnd(
+                client_id, key, "default", ReplicaType::MEMORY);
             auto put_end_disk_result =
-                service_->PutEnd(client_id, key, ReplicaType::DISK);
+                service_->PutEnd(client_id, key, "default", ReplicaType::DISK);
             ASSERT_TRUE(put_end_mem_result.has_value());
             ASSERT_TRUE(put_end_disk_result.has_value());
             success_puts++;
@@ -284,7 +292,7 @@ TEST_F(MasterServiceSSDTest, EvictObject) {
     int success_gets = 0;
     for (int i = 0; i < 1024 * 16 + 50; ++i) {
         std::string key = "test_key" + std::to_string(i);
-        auto get_result = service_->GetReplicaList(key);
+        auto get_result = service_->GetReplicaList(key, "default");
         if (get_result.has_value()) {
             success_gets++;
         }
@@ -335,7 +343,7 @@ TEST_F(MasterServiceSSDTest, PutStartExpires) {
 
         // Put key, should success.
         auto put_start_result =
-            service_->PutStart(client_id, key, slice_length, config);
+            service_->PutStart(client_id, key, "default", slice_length, config);
         EXPECT_TRUE(put_start_result.has_value());
         auto replica_list = put_start_result.value();
         EXPECT_EQ(replica_list.size(), kReplicaCnt);
@@ -344,7 +352,8 @@ TEST_F(MasterServiceSSDTest, PutStartExpires) {
         }
 
         // Complete the reserved replica.
-        auto put_end_result = service_->PutEnd(client_id, key, reserve_type);
+        auto put_end_result =
+            service_->PutEnd(client_id, key, "default", reserve_type);
         EXPECT_TRUE(put_end_result.has_value());
 
         // Wait for a while until the put-start expired.
@@ -354,7 +363,7 @@ TEST_F(MasterServiceSSDTest, PutStartExpires) {
             auto result = service_->Ping(client_id);
             EXPECT_TRUE(result.has_value());
             // Protect the key from eviction.
-            auto get_result = service_->GetReplicaList(key);
+            auto get_result = service_->GetReplicaList(key, "default");
             EXPECT_TRUE(get_result.has_value());
             std::this_thread::sleep_for(std::chrono::seconds(1));
         }
@@ -362,7 +371,7 @@ TEST_F(MasterServiceSSDTest, PutStartExpires) {
         // Put key again, should fail because the object has had an completed
         // replica.
         put_start_result =
-            service_->PutStart(client_id, key, slice_length, config);
+            service_->PutStart(client_id, key, "default", slice_length, config);
         EXPECT_FALSE(put_start_result.has_value());
         EXPECT_EQ(put_start_result.error(), ErrorCode::OBJECT_ALREADY_EXISTS);
 
@@ -373,17 +382,18 @@ TEST_F(MasterServiceSSDTest, PutStartExpires) {
             auto result = service_->Ping(client_id);
             EXPECT_TRUE(result.has_value());
             // Protect the key from eviction.
-            auto get_result = service_->GetReplicaList(key);
+            auto get_result = service_->GetReplicaList(key, "default");
             EXPECT_TRUE(get_result.has_value());
             std::this_thread::sleep_for(std::chrono::seconds(1));
         }
 
         // Try PutEnd the discarded replica.
-        put_end_result = service_->PutEnd(client_id, key, discard_type);
+        put_end_result =
+            service_->PutEnd(client_id, key, "default", discard_type);
         EXPECT_TRUE(put_end_result.has_value());
 
         // Check that the key has only one replica.
-        auto get_result = service_->GetReplicaList(key);
+        auto get_result = service_->GetReplicaList(key, "default");
         EXPECT_TRUE(get_result.has_value());
         EXPECT_EQ(get_result.value().replicas.size(), 1);
         if (reserve_type == ReplicaType::MEMORY) {
@@ -423,27 +433,27 @@ TEST_F(MasterServiceSSDTest, EvictDiskReplica_RemovesDiskReplica) {
 
     std::string key = "evict_disk_key";
     auto put_result =
-        service_->PutStart(client_id, key, 1024, {.replica_num = 1});
+        service_->PutStart(client_id, key, "default", 1024, {.replica_num = 1});
     ASSERT_TRUE(put_result.has_value());
 
     // Complete both replicas
-    EXPECT_TRUE(
-        service_->PutEnd(client_id, key, ReplicaType::MEMORY).has_value());
-    EXPECT_TRUE(
-        service_->PutEnd(client_id, key, ReplicaType::DISK).has_value());
+    EXPECT_TRUE(service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY)
+                    .has_value());
+    EXPECT_TRUE(service_->PutEnd(client_id, key, "default", ReplicaType::DISK)
+                    .has_value());
 
     // Verify we have 2 replicas (MEM + DISK)
-    auto get_result = service_->GetReplicaList(key);
+    auto get_result = service_->GetReplicaList(key, "default");
     ASSERT_TRUE(get_result.has_value());
     EXPECT_EQ(2, get_result.value().replicas.size());
 
     // Evict disk replica
-    auto evict_result =
-        service_->EvictDiskReplica(client_id, key, ReplicaType::DISK);
+    auto evict_result = service_->EvictDiskReplica(client_id, key, "default",
+                                                   ReplicaType::DISK);
     ASSERT_TRUE(evict_result.has_value());
 
     // Verify only memory replica remains
-    get_result = service_->GetReplicaList(key);
+    get_result = service_->GetReplicaList(key, "default");
     ASSERT_TRUE(get_result.has_value());
     EXPECT_EQ(1, get_result.value().replicas.size());
     EXPECT_TRUE(get_result.value().replicas[0].is_memory_replica());
@@ -453,8 +463,8 @@ TEST_F(MasterServiceSSDTest, EvictDiskReplica_NonExistentKeyReturnsError) {
     auto service_ = CreateMasterServiceWithSSDFeat("/mnt/ssd");
 
     UUID client_id = generate_uuid();
-    auto evict_result = service_->EvictDiskReplica(client_id, "nonexistent_key",
-                                                   ReplicaType::DISK);
+    auto evict_result = service_->EvictDiskReplica(
+        client_id, "nonexistent_key", "default", ReplicaType::DISK);
     EXPECT_FALSE(evict_result.has_value());
     EXPECT_EQ(evict_result.error(), ErrorCode::OBJECT_NOT_FOUND);
 }
@@ -477,16 +487,16 @@ TEST_F(MasterServiceSSDTest, EvictDiskReplica_InvalidReplicaTypeReturnsError) {
 
     std::string key = "evict_invalid_type_key";
     auto put_result =
-        service_->PutStart(client_id, key, 1024, {.replica_num = 1});
+        service_->PutStart(client_id, key, "default", 1024, {.replica_num = 1});
     ASSERT_TRUE(put_result.has_value());
-    EXPECT_TRUE(
-        service_->PutEnd(client_id, key, ReplicaType::MEMORY).has_value());
-    EXPECT_TRUE(
-        service_->PutEnd(client_id, key, ReplicaType::DISK).has_value());
+    EXPECT_TRUE(service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY)
+                    .has_value());
+    EXPECT_TRUE(service_->PutEnd(client_id, key, "default", ReplicaType::DISK)
+                    .has_value());
 
     // Attempting to evict with MEMORY type should fail
-    auto evict_result =
-        service_->EvictDiskReplica(client_id, key, ReplicaType::MEMORY);
+    auto evict_result = service_->EvictDiskReplica(client_id, key, "default",
+                                                   ReplicaType::MEMORY);
     EXPECT_FALSE(evict_result.has_value());
     EXPECT_EQ(evict_result.error(), ErrorCode::INVALID_PARAMS);
 }

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -86,10 +86,12 @@ class MasterServiceTest : public ::testing::Test {
         config.replica_num = 1;
         config.preferred_segment = segment_name;
 
-        auto put_start = service.PutStart(client_id, key, slice_length, config);
+        auto put_start =
+            service.PutStart(client_id, key, "default", slice_length, config);
         EXPECT_TRUE(put_start.has_value());
         EXPECT_TRUE(
-            service.PutEnd(client_id, key, ReplicaType::MEMORY).has_value());
+            service.PutEnd(client_id, key, "default", ReplicaType::MEMORY)
+                .has_value());
         return key;
     }
 
@@ -112,12 +114,14 @@ class MasterServiceTest : public ::testing::Test {
                             const std::string& key,
                             const ReplicateConfig& config,
                             uint64_t slice_length = 1024) const {
-        auto put_start = service.PutStart(client_id, key, slice_length, config);
+        auto put_start =
+            service.PutStart(client_id, key, "default", slice_length, config);
         ASSERT_TRUE(put_start.has_value())
             << "PutStart failed for key=" << key
             << ", error=" << toString(put_start.error());
         ASSERT_TRUE(
-            service.PutEnd(client_id, key, ReplicaType::MEMORY).has_value());
+            service.PutEnd(client_id, key, "default", ReplicaType::MEMORY)
+                .has_value());
     }
 
     bool ExecutePendingMoveTasks(MasterService& service,
@@ -233,14 +237,14 @@ std::string GenerateKeyForSegment(const UUID& client_id,
         std::vector<Replica::Descriptor> replica_list;
 
         // Check if the key already exists.
-        auto exist_result = service->ExistKey(key);
+        auto exist_result = service->ExistKey(key, "default");
         if (exist_result.has_value() && exist_result.value()) {
             continue;  // Retry if the key already exists
         }
 
         // Attempt to put the key.
-        auto put_result =
-            service->PutStart(client_id, key, {1024}, {.replica_num = 1});
+        auto put_result = service->PutStart(client_id, key, "default", {1024},
+                                            {.replica_num = 1});
         if (put_result.has_value()) {
             replica_list = std::move(put_result.value());
         }
@@ -255,7 +259,7 @@ std::string GenerateKeyForSegment(const UUID& client_id,
                                      std::to_string(static_cast<int>(code)));
         }
         auto put_end_result =
-            service->PutEnd(client_id, key, ReplicaType::MEMORY);
+            service->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
         if (!put_end_result.has_value()) {
             throw std::runtime_error("PutEnd failed");
         }
@@ -265,7 +269,7 @@ std::string GenerateKeyForSegment(const UUID& client_id,
             return key;
         }
         // Clean up failed attempt
-        auto remove_result = service->Remove(key);
+        auto remove_result = service->Remove(key, "default");
         if (!remove_result.has_value()) {
             // Ignore cleanup failure
         }
@@ -479,20 +483,22 @@ TEST_F(MasterServiceTest, PutStartInvalidParams) {
     // Test invalid replica config
     config.replica_num = 0;
     config.nof_replica_num = 0;
-    auto put_result1 = service_->PutStart(client_id, key, 1024, config);
+    auto put_result1 =
+        service_->PutStart(client_id, key, "default", 1024, config);
     EXPECT_FALSE(put_result1.has_value());
     EXPECT_EQ(ErrorCode::INVALID_PARAMS, put_result1.error());
 
     // Test zero slice_length
     config.replica_num = 1;
-    auto put_result2 = service_->PutStart(client_id, key, 0, config);
+    auto put_result2 = service_->PutStart(client_id, key, "default", 0, config);
     EXPECT_FALSE(put_result2.has_value());
     EXPECT_EQ(ErrorCode::INVALID_PARAMS, put_result2.error());
 
     // Test prefer_alloc_in_same_node with nof replicas
     config.nof_replica_num = 1;
     config.prefer_alloc_in_same_node = true;
-    auto put_result3 = service_->PutStart(client_id, key, 1024, config);
+    auto put_result3 =
+        service_->PutStart(client_id, key, "default", 1024, config);
     EXPECT_FALSE(put_result3.has_value());
     EXPECT_EQ(ErrorCode::INVALID_PARAMS, put_result3.error());
 }
@@ -509,14 +515,15 @@ TEST_F(MasterServiceTest, PutEndAllCompletesMemoryAndNoFReplicas) {
     config.replica_num = 1;
     config.nof_replica_num = 1;
     auto put_start_result =
-        service_->PutStart(client_id, "test_key_all", 1024, config);
+        service_->PutStart(client_id, "test_key_all", "default", 1024, config);
     ASSERT_TRUE(put_start_result.has_value());
 
-    auto put_end_result =
-        service_->PutEnd(client_id, "test_key_all", ReplicaType::ALL);
+    auto put_end_result = service_->PutEnd(client_id, "test_key_all", "default",
+                                           ReplicaType::ALL);
     ASSERT_TRUE(put_end_result.has_value());
 
-    auto get_replica_result = service_->GetReplicaList("test_key_all");
+    auto get_replica_result =
+        service_->GetReplicaList("test_key_all", "default");
     ASSERT_TRUE(get_replica_result.has_value());
 
     bool has_complete_memory = false;
@@ -546,25 +553,27 @@ TEST_F(MasterServiceTest, PutEndMemoryDoesNotCompleteNoFReplica) {
     ReplicateConfig config;
     config.replica_num = 1;
     config.nof_replica_num = 1;
-    auto put_start_result =
-        service_->PutStart(client_id, "test_key_split", 1024, config);
+    auto put_start_result = service_->PutStart(client_id, "test_key_split",
+                                               "default", 1024, config);
     ASSERT_TRUE(put_start_result.has_value());
 
-    auto put_end_result =
-        service_->PutEnd(client_id, "test_key_split", ReplicaType::MEMORY);
+    auto put_end_result = service_->PutEnd(client_id, "test_key_split",
+                                           "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value());
 
-    auto get_replica_result = service_->GetReplicaList("test_key_split");
+    auto get_replica_result =
+        service_->GetReplicaList("test_key_split", "default");
     ASSERT_TRUE(get_replica_result.has_value());
     ASSERT_EQ(get_replica_result->replicas.size(), 1u);
     EXPECT_TRUE(get_replica_result->replicas[0].is_memory_replica());
     EXPECT_EQ(get_replica_result->replicas[0].status, ReplicaStatus::COMPLETE);
 
-    auto put_revoke_result =
-        service_->PutRevoke(client_id, "test_key_split", ReplicaType::NOF_SSD);
+    auto put_revoke_result = service_->PutRevoke(
+        client_id, "test_key_split", "default", ReplicaType::NOF_SSD);
     ASSERT_TRUE(put_revoke_result.has_value());
 
-    auto final_replica_result = service_->GetReplicaList("test_key_split");
+    auto final_replica_result =
+        service_->GetReplicaList("test_key_split", "default");
     ASSERT_TRUE(final_replica_result.has_value());
     ASSERT_EQ(final_replica_result->replicas.size(), 1u);
     EXPECT_TRUE(final_replica_result->replicas[0].is_memory_replica());
@@ -580,8 +589,8 @@ TEST_F(MasterServiceTest, PutStartOnePlusOneAllowsSingleAllocatedReplica) {
     ReplicateConfig config;
     config.replica_num = 1;
     config.nof_replica_num = 1;
-    auto put_start_result =
-        service_->PutStart(client_id, "test_key_one_plus_one", 1024, config);
+    auto put_start_result = service_->PutStart(
+        client_id, "test_key_one_plus_one", "default", 1024, config);
     ASSERT_TRUE(put_start_result.has_value());
     ASSERT_EQ(put_start_result->size(), 1u);
     EXPECT_TRUE(put_start_result->front().is_memory_replica());
@@ -597,25 +606,26 @@ TEST_F(MasterServiceTest, PutStartGroupIdsValidation) {
     config.replica_num = 1;
 
     config.group_ids = std::vector<std::string>{};
-    auto empty_group_ids =
-        service_->PutStart(client_id, "empty_group_ids", 1024, config);
+    auto empty_group_ids = service_->PutStart(client_id, "empty_group_ids",
+                                              "default", 1024, config);
     EXPECT_FALSE(empty_group_ids.has_value());
     EXPECT_EQ(ErrorCode::INVALID_PARAMS, empty_group_ids.error());
 
     config.group_ids = std::vector<std::string>{"g0", "g1"};
-    auto too_many_group_ids =
-        service_->PutStart(client_id, "too_many_group_ids", 1024, config);
+    auto too_many_group_ids = service_->PutStart(
+        client_id, "too_many_group_ids", "default", 1024, config);
     EXPECT_FALSE(too_many_group_ids.has_value());
     EXPECT_EQ(ErrorCode::INVALID_PARAMS, too_many_group_ids.error());
 
     config.group_ids = std::vector<std::string>{""};
-    auto ungrouped =
-        service_->PutStart(client_id, "explicit_ungrouped", 1024, config);
+    auto ungrouped = service_->PutStart(client_id, "explicit_ungrouped",
+                                        "default", 1024, config);
     ASSERT_TRUE(ungrouped.has_value());
-    ASSERT_TRUE(
-        service_->PutEnd(client_id, "explicit_ungrouped", ReplicaType::MEMORY)
-            .has_value());
-    auto exists = service_->ExistKey("explicit_ungrouped");
+    ASSERT_TRUE(service_
+                    ->PutEnd(client_id, "explicit_ungrouped", "default",
+                             ReplicaType::MEMORY)
+                    .has_value());
+    auto exists = service_->ExistKey("explicit_ungrouped", "default");
     ASSERT_TRUE(exists.has_value());
     EXPECT_TRUE(exists.value());
 }
@@ -633,13 +643,13 @@ TEST_F(MasterServiceTest, GroupedObjectRoutesKeyLevelLookupAndRemove) {
 
     PutCompletedObject(*service_, client_id, key, config);
 
-    auto exists = service_->ExistKey(key);
+    auto exists = service_->ExistKey(key, "default");
     ASSERT_TRUE(exists.has_value());
     EXPECT_TRUE(exists.value());
-    EXPECT_TRUE(service_->GetReplicaList(key).has_value());
+    EXPECT_TRUE(service_->GetReplicaList(key, "default").has_value());
 
-    ASSERT_TRUE(service_->Remove(key, /*force=*/true).has_value());
-    auto exists_after_remove = service_->ExistKey(key);
+    ASSERT_TRUE(service_->Remove(key, "default", /*force=*/true).has_value());
+    auto exists_after_remove = service_->ExistKey(key, "default");
     ASSERT_TRUE(exists_after_remove.has_value());
     EXPECT_FALSE(exists_after_remove.value());
 }
@@ -686,6 +696,67 @@ TEST_F(MasterServiceTest, GroupRoutingIsTenantScopedForSameUserKey) {
     ASSERT_TRUE(service_->Remove(key, tenant_a, /*force=*/true).has_value());
     EXPECT_FALSE(service_->GetReplicaList(key, tenant_a).has_value());
     EXPECT_TRUE(service_->GetReplicaList(key, tenant_b).has_value());
+}
+
+TEST_F(MasterServiceTest, GetAllKeysListsOnlyRequestedTenant) {
+    std::unique_ptr<MasterService> service_(new MasterService());
+    [[maybe_unused]] const auto context = PrepareSimpleSegment(*service_);
+    const UUID client_id = generate_uuid();
+    const std::string tenant_a = "tenant_get_all_keys_a";
+    const std::string shared_key = "shared_listing_key";
+    const std::string default_only_key = "default_listing_key";
+    const std::string tenant_only_key = "tenant_listing_key";
+
+    ReplicateConfig config;
+    config.replica_num = 1;
+    ASSERT_TRUE(
+        service_->PutStart(client_id, shared_key, "default", 1024, config)
+            .has_value());
+    ASSERT_TRUE(
+        service_->PutEnd(client_id, shared_key, "default", ReplicaType::MEMORY)
+            .has_value());
+    ASSERT_TRUE(
+        service_->PutStart(client_id, default_only_key, "default", 1024, config)
+            .has_value());
+    ASSERT_TRUE(service_
+                    ->PutEnd(client_id, default_only_key, "default",
+                             ReplicaType::MEMORY)
+                    .has_value());
+    ASSERT_TRUE(
+        service_->PutStart(client_id, shared_key, tenant_a, 1024, config)
+            .has_value());
+    ASSERT_TRUE(
+        service_->PutEnd(client_id, shared_key, tenant_a, ReplicaType::MEMORY)
+            .has_value());
+    ASSERT_TRUE(
+        service_->PutStart(client_id, tenant_only_key, tenant_a, 1024, config)
+            .has_value());
+    ASSERT_TRUE(
+        service_
+            ->PutEnd(client_id, tenant_only_key, tenant_a, ReplicaType::MEMORY)
+            .has_value());
+
+    auto default_keys = service_->GetAllKeys("default");
+    ASSERT_TRUE(default_keys.has_value());
+    EXPECT_NE(std::find(default_keys->begin(), default_keys->end(), shared_key),
+              default_keys->end());
+    EXPECT_NE(
+        std::find(default_keys->begin(), default_keys->end(), default_only_key),
+        default_keys->end());
+    EXPECT_EQ(
+        std::find(default_keys->begin(), default_keys->end(), tenant_only_key),
+        default_keys->end());
+
+    auto tenant_keys = service_->GetAllKeys(tenant_a);
+    ASSERT_TRUE(tenant_keys.has_value());
+    EXPECT_NE(std::find(tenant_keys->begin(), tenant_keys->end(), shared_key),
+              tenant_keys->end());
+    EXPECT_NE(
+        std::find(tenant_keys->begin(), tenant_keys->end(), tenant_only_key),
+        tenant_keys->end());
+    EXPECT_EQ(
+        std::find(tenant_keys->begin(), tenant_keys->end(), default_only_key),
+        tenant_keys->end());
 }
 
 TEST_F(MasterServiceTest,
@@ -834,16 +905,18 @@ TEST_F(MasterServiceTest, ExpiredGroupedPutCanBeReplacedByUngroupedPut) {
         std::vector<std::string>{FindGroupIdOnDifferentShard(key)};
 
     ASSERT_TRUE(
-        service_->PutStart(client_id, key, 1024, grouped_config).has_value());
+        service_->PutStart(client_id, key, "default", 1024, grouped_config)
+            .has_value());
     std::this_thread::sleep_for(std::chrono::milliseconds(2));
 
     ReplicateConfig ungrouped_config;
     ungrouped_config.replica_num = 1;
-    auto put_start = service_->PutStart(client_id, key, 1024, ungrouped_config);
+    auto put_start =
+        service_->PutStart(client_id, key, "default", 1024, ungrouped_config);
     ASSERT_TRUE(put_start.has_value()) << toString(put_start.error());
-    ASSERT_TRUE(
-        service_->PutEnd(client_id, key, ReplicaType::MEMORY).has_value());
-    EXPECT_TRUE(service_->ExistKey(key).value_or(false));
+    ASSERT_TRUE(service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY)
+                    .has_value());
+    EXPECT_TRUE(service_->ExistKey(key, "default").value_or(false));
 }
 
 TEST_F(MasterServiceTest, BatchRemoveUnregistersGroupedRoute) {
@@ -858,15 +931,15 @@ TEST_F(MasterServiceTest, BatchRemoveUnregistersGroupedRoute) {
         std::vector<std::string>{FindGroupIdOnDifferentShard(key)};
     PutCompletedObject(*service_, client_id, key, grouped_config);
 
-    auto remove_results =
-        service_->BatchRemove(std::vector<std::string>{key}, /*force=*/true);
+    auto remove_results = service_->BatchRemove(std::vector<std::string>{key},
+                                                "default", /*force=*/true);
     ASSERT_EQ(remove_results.size(), 1u);
     ASSERT_TRUE(remove_results[0].has_value());
 
     ReplicateConfig ungrouped_config;
     ungrouped_config.replica_num = 1;
     PutCompletedObject(*service_, client_id, key, ungrouped_config);
-    EXPECT_TRUE(service_->GetReplicaList(key).has_value());
+    EXPECT_TRUE(service_->GetReplicaList(key, "default").has_value());
 }
 
 TEST_F(MasterServiceTest, RemoveByRegexUnregistersGroupedRoute) {
@@ -881,15 +954,16 @@ TEST_F(MasterServiceTest, RemoveByRegexUnregistersGroupedRoute) {
         std::vector<std::string>{FindGroupIdOnDifferentShard(key)};
     PutCompletedObject(*service_, client_id, key, grouped_config);
 
-    auto removed = service_->RemoveByRegex("^regex_remove_grouped_route$",
-                                           /*force=*/true);
+    auto removed =
+        service_->RemoveByRegex("^regex_remove_grouped_route$", "default",
+                                /*force=*/true);
     ASSERT_TRUE(removed.has_value());
     EXPECT_EQ(removed.value(), 1);
 
     ReplicateConfig ungrouped_config;
     ungrouped_config.replica_num = 1;
     PutCompletedObject(*service_, client_id, key, ungrouped_config);
-    EXPECT_TRUE(service_->GetReplicaList(key).has_value());
+    EXPECT_TRUE(service_->GetReplicaList(key, "default").has_value());
 }
 
 TEST_F(MasterServiceTest, GroupedLeaseRefreshNearExpiryProtectsCurrentMembers) {
@@ -911,22 +985,22 @@ TEST_F(MasterServiceTest, GroupedLeaseRefreshNearExpiryProtectsCurrentMembers) {
     PutCompletedObject(*service_, client_id, key_a, config_a);
     PutCompletedObject(*service_, client_id, key_b, config_b);
 
-    auto exists = service_->ExistKey(key_a);
+    auto exists = service_->ExistKey(key_a, "default");
     ASSERT_TRUE(exists.has_value());
     ASSERT_TRUE(exists.value());
 
     std::this_thread::sleep_for(std::chrono::milliseconds(120));
-    exists = service_->ExistKey(key_a);
+    exists = service_->ExistKey(key_a, "default");
     ASSERT_TRUE(exists.has_value());
     ASSERT_TRUE(exists.value());
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
-    auto remove_group_peer = service_->Remove(key_b);
+    auto remove_group_peer = service_->Remove(key_b, "default");
     ASSERT_FALSE(remove_group_peer.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_HAS_LEASE, remove_group_peer.error());
 
-    EXPECT_TRUE(service_->Remove(key_a, /*force=*/true).has_value());
-    EXPECT_TRUE(service_->Remove(key_b, /*force=*/true).has_value());
+    EXPECT_TRUE(service_->Remove(key_a, "default", /*force=*/true).has_value());
+    EXPECT_TRUE(service_->Remove(key_b, "default", /*force=*/true).has_value());
 }
 
 TEST_F(MasterServiceTest,
@@ -946,22 +1020,22 @@ TEST_F(MasterServiceTest,
     config.group_ids = std::vector<std::string>{group_id};
 
     PutCompletedObject(*service_, client_id, key_a, config);
-    ASSERT_TRUE(service_->ExistKey(key_a).value_or(false));
+    ASSERT_TRUE(service_->ExistKey(key_a, "default").value_or(false));
 
     PutCompletedObject(*service_, client_id, key_b, config);
     std::this_thread::sleep_for(std::chrono::milliseconds(150));
 
-    auto exists = service_->ExistKey(key_a);
+    auto exists = service_->ExistKey(key_a, "default");
     ASSERT_TRUE(exists.has_value());
     ASSERT_TRUE(exists.value());
     std::this_thread::sleep_for(std::chrono::milliseconds(390));
 
-    auto remove_group_peer = service_->Remove(key_b);
+    auto remove_group_peer = service_->Remove(key_b, "default");
     ASSERT_FALSE(remove_group_peer.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_HAS_LEASE, remove_group_peer.error());
 
-    EXPECT_TRUE(service_->Remove(key_a, /*force=*/true).has_value());
-    EXPECT_TRUE(service_->Remove(key_b, /*force=*/true).has_value());
+    EXPECT_TRUE(service_->Remove(key_a, "default", /*force=*/true).has_value());
+    EXPECT_TRUE(service_->Remove(key_b, "default", /*force=*/true).has_value());
 }
 
 TEST_F(MasterServiceTest, RemoveGroupedMemberPreservesOtherMembers) {
@@ -979,15 +1053,15 @@ TEST_F(MasterServiceTest, RemoveGroupedMemberPreservesOtherMembers) {
     PutCompletedObject(*service_, client_id, key_a, config);
     PutCompletedObject(*service_, client_id, key_b, config);
 
-    ASSERT_TRUE(service_->Remove(key_a, /*force=*/true).has_value());
+    ASSERT_TRUE(service_->Remove(key_a, "default", /*force=*/true).has_value());
 
-    auto removed_exists = service_->ExistKey(key_a);
+    auto removed_exists = service_->ExistKey(key_a, "default");
     ASSERT_TRUE(removed_exists.has_value());
     EXPECT_FALSE(removed_exists.value());
-    EXPECT_TRUE(service_->GetReplicaList(key_b).has_value());
+    EXPECT_TRUE(service_->GetReplicaList(key_b, "default").has_value());
 
-    ASSERT_TRUE(service_->Remove(key_b, /*force=*/true).has_value());
-    auto group_empty = service_->ExistKey(key_b);
+    ASSERT_TRUE(service_->Remove(key_b, "default", /*force=*/true).has_value());
+    auto group_empty = service_->ExistKey(key_b, "default");
     ASSERT_TRUE(group_empty.has_value());
     EXPECT_FALSE(group_empty.value());
 }
@@ -1007,28 +1081,29 @@ TEST_F(MasterServiceTest, UpsertPreservesGroupMembership) {
 
     ReplicateConfig unset_group_config;
     unset_group_config.replica_num = 1;
-    auto preserve_result =
-        service_->UpsertStart(client_id, key, 1024, unset_group_config);
+    auto preserve_result = service_->UpsertStart(client_id, key, "default",
+                                                 1024, unset_group_config);
     ASSERT_TRUE(preserve_result.has_value())
         << "Unset group_ids should preserve existing group membership";
     ASSERT_TRUE(
-        service_->UpsertEnd(client_id, key, ReplicaType::MEMORY).has_value());
-    EXPECT_TRUE(service_->GetReplicaList(key).has_value());
+        service_->UpsertEnd(client_id, key, "default", ReplicaType::MEMORY)
+            .has_value());
+    EXPECT_TRUE(service_->GetReplicaList(key, "default").has_value());
 
     ReplicateConfig different_group_config;
     different_group_config.replica_num = 1;
     different_group_config.group_ids =
         std::vector<std::string>{FindGroupIdOnDifferentShard(key + "_other")};
-    auto different_group_result =
-        service_->UpsertStart(client_id, key, 1024, different_group_config);
+    auto different_group_result = service_->UpsertStart(
+        client_id, key, "default", 1024, different_group_config);
     ASSERT_FALSE(different_group_result.has_value());
     EXPECT_EQ(ErrorCode::INVALID_PARAMS, different_group_result.error());
 
     ReplicateConfig explicit_ungrouped_config;
     explicit_ungrouped_config.replica_num = 1;
     explicit_ungrouped_config.group_ids = std::vector<std::string>{""};
-    auto explicit_ungrouped_result =
-        service_->UpsertStart(client_id, key, 1024, explicit_ungrouped_config);
+    auto explicit_ungrouped_result = service_->UpsertStart(
+        client_id, key, "default", 1024, explicit_ungrouped_config);
     ASSERT_FALSE(explicit_ungrouped_result.has_value());
     EXPECT_EQ(ErrorCode::INVALID_PARAMS, explicit_ungrouped_result.error());
 }
@@ -1045,17 +1120,19 @@ TEST_F(MasterServiceTest, IncompleteGroupedUpsertCanBecomeUngrouped) {
         std::vector<std::string>{FindGroupIdOnDifferentShard(key)};
 
     ASSERT_TRUE(
-        service_->PutStart(client_id, key, 1024, grouped_config).has_value());
+        service_->PutStart(client_id, key, "default", 1024, grouped_config)
+            .has_value());
     std::this_thread::sleep_for(std::chrono::milliseconds(2));
 
     ReplicateConfig ungrouped_config;
     ungrouped_config.replica_num = 1;
-    auto upsert_start =
-        service_->UpsertStart(client_id, key, 1024, ungrouped_config);
+    auto upsert_start = service_->UpsertStart(client_id, key, "default", 1024,
+                                              ungrouped_config);
     ASSERT_TRUE(upsert_start.has_value()) << toString(upsert_start.error());
     ASSERT_TRUE(
-        service_->UpsertEnd(client_id, key, ReplicaType::MEMORY).has_value());
-    EXPECT_TRUE(service_->ExistKey(key).value_or(false));
+        service_->UpsertEnd(client_id, key, "default", ReplicaType::MEMORY)
+            .has_value());
+    EXPECT_TRUE(service_->ExistKey(key, "default").value_or(false));
 }
 
 TEST_F(MasterServiceTest, UpsertRejectsExistingUngroupedToGrouped) {
@@ -1073,11 +1150,11 @@ TEST_F(MasterServiceTest, UpsertRejectsExistingUngroupedToGrouped) {
     grouped_config.group_ids =
         std::vector<std::string>{FindGroupIdOnDifferentShard(key)};
     auto upsert_start =
-        service_->UpsertStart(client_id, key, 2048, grouped_config);
+        service_->UpsertStart(client_id, key, "default", 2048, grouped_config);
     ASSERT_FALSE(upsert_start.has_value());
     EXPECT_EQ(ErrorCode::INVALID_PARAMS, upsert_start.error());
 
-    EXPECT_TRUE(service_->GetReplicaList(key).has_value());
+    EXPECT_TRUE(service_->GetReplicaList(key, "default").has_value());
 }
 
 TEST_F(MasterServiceTest,
@@ -1108,15 +1185,16 @@ TEST_F(MasterServiceTest,
 
         ReplicateConfig trigger_config;
         trigger_config.replica_num = 1;
-        auto trigger_result = service_->PutStart(
-            client_id, "trigger_grouped_eviction", kObjectSize, trigger_config);
+        auto trigger_result =
+            service_->PutStart(client_id, "trigger_grouped_eviction", "default",
+                               kObjectSize, trigger_config);
         ASSERT_FALSE(trigger_result.has_value());
         EXPECT_EQ(ErrorCode::NO_AVAILABLE_HANDLE, trigger_result.error());
 
         std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
-        EXPECT_FALSE(service_->ExistKey(evict_key_a).value_or(true));
-        EXPECT_FALSE(service_->ExistKey(evict_key_b).value_or(true));
+        EXPECT_FALSE(service_->ExistKey(evict_key_a, "default").value_or(true));
+        EXPECT_FALSE(service_->ExistKey(evict_key_b, "default").value_or(true));
     }
 
     {
@@ -1138,7 +1216,7 @@ TEST_F(MasterServiceTest,
         PutCompletedObject(*service_, client_id, leased_key_b, leased_config,
                            kObjectSize);
 
-        auto exists = service_->ExistKey(leased_key_a);
+        auto exists = service_->ExistKey(leased_key_a, "default");
         ASSERT_TRUE(exists.has_value());
         ASSERT_TRUE(exists.value());
 
@@ -1146,14 +1224,16 @@ TEST_F(MasterServiceTest,
         trigger_config.replica_num = 1;
         auto trigger_result =
             service_->PutStart(client_id, "trigger_leased_group_eviction",
-                               kObjectSize, trigger_config);
+                               "default", kObjectSize, trigger_config);
         ASSERT_FALSE(trigger_result.has_value());
         EXPECT_EQ(ErrorCode::NO_AVAILABLE_HANDLE, trigger_result.error());
 
         std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
-        EXPECT_TRUE(service_->GetReplicaList(leased_key_a).has_value());
-        EXPECT_TRUE(service_->GetReplicaList(leased_key_b).has_value());
+        EXPECT_TRUE(
+            service_->GetReplicaList(leased_key_a, "default").has_value());
+        EXPECT_TRUE(
+            service_->GetReplicaList(leased_key_b, "default").has_value());
     }
 }
 
@@ -1185,15 +1265,17 @@ TEST_F(MasterServiceTest, GroupedEvictionSkipsUnsafeMembersAndEvictsSafePeers) {
     trigger_config.replica_num = 1;
     auto trigger_result =
         service_->PutStart(client_id, "trigger_mixed_safety_group_eviction",
-                           kObjectSize, trigger_config);
+                           "default", kObjectSize, trigger_config);
     ASSERT_FALSE(trigger_result.has_value());
     EXPECT_EQ(ErrorCode::NO_AVAILABLE_HANDLE, trigger_result.error());
 
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
-    EXPECT_FALSE(service_->ExistKey(safe_key).value_or(true));
-    EXPECT_TRUE(service_->GetReplicaList(hard_pinned_key).has_value());
-    EXPECT_TRUE(service_->Remove(hard_pinned_key, /*force=*/true).has_value());
+    EXPECT_FALSE(service_->ExistKey(safe_key, "default").value_or(true));
+    EXPECT_TRUE(
+        service_->GetReplicaList(hard_pinned_key, "default").has_value());
+    EXPECT_TRUE(service_->Remove(hard_pinned_key, "default", /*force=*/true)
+                    .has_value());
 }
 
 TEST_F(MasterServiceTest, BatchUpsertStartMixedGroupIdsPreservesOrder) {
@@ -1214,26 +1296,27 @@ TEST_F(MasterServiceTest, BatchUpsertStartMixedGroupIdsPreservesOrder) {
         std::vector<std::string>{FindGroupIdOnDifferentShard(keys[0]), "",
                                  FindGroupIdOnDifferentShard(keys[2])};
 
-    auto results = service_->BatchUpsertStart(client_id, keys, sizes, config);
+    auto results =
+        service_->BatchUpsertStart(client_id, keys, "default", sizes, config);
     ASSERT_EQ(results.size(), keys.size());
     for (const auto& result : results) {
         ASSERT_TRUE(result.has_value());
     }
 
-    auto end_results = service_->BatchUpsertEnd(client_id, keys);
+    auto end_results = service_->BatchUpsertEnd(client_id, keys, "default");
     ASSERT_EQ(end_results.size(), keys.size());
     for (const auto& result : end_results) {
         ASSERT_TRUE(result.has_value());
     }
 
     for (const auto& key : keys) {
-        EXPECT_TRUE(service_->GetReplicaList(key).has_value());
+        EXPECT_TRUE(service_->GetReplicaList(key, "default").has_value());
     }
 
     ReplicateConfig invalid_config = config;
     invalid_config.group_ids = std::vector<std::string>{"only_one"};
-    auto invalid_results =
-        service_->BatchUpsertStart(client_id, keys, sizes, invalid_config);
+    auto invalid_results = service_->BatchUpsertStart(
+        client_id, keys, "default", sizes, invalid_config);
     ASSERT_EQ(invalid_results.size(), keys.size());
     for (const auto& result : invalid_results) {
         ASSERT_FALSE(result.has_value());
@@ -1277,7 +1360,7 @@ TEST_F(MasterServiceTest, WrappedBatchPutStartMixedGroupIdsPreservesOrder) {
     }
 
     for (const auto& key : keys) {
-        EXPECT_TRUE(service_.GetReplicaList(key).has_value());
+        EXPECT_TRUE(service_.GetReplicaList(key, "default").has_value());
     }
 
     ReplicateConfig invalid_config = config;
@@ -1313,38 +1396,39 @@ TEST_F(MasterServiceTest, PutStartEndFlow) {
     config.replica_num = 1;
 
     auto put_start_result =
-        service_->PutStart(client_id, key, value_length, config);
+        service_->PutStart(client_id, key, "default", value_length, config);
     EXPECT_TRUE(put_start_result.has_value());
     replica_list = put_start_result.value();
     EXPECT_FALSE(replica_list.empty());
     EXPECT_EQ(ReplicaStatus::PROCESSING, replica_list[0].status);
 
     // During put, Get/Remove should fail
-    auto get_replica_result = service_->GetReplicaList(key);
+    auto get_replica_result = service_->GetReplicaList(key, "default");
     EXPECT_FALSE(get_replica_result.has_value());
     EXPECT_EQ(ErrorCode::REPLICA_IS_NOT_READY, get_replica_result.error());
-    auto remove_result = service_->Remove(key);
+    auto remove_result = service_->Remove(key, "default");
     EXPECT_FALSE(remove_result.has_value());
     EXPECT_EQ(ErrorCode::REPLICA_IS_NOT_READY, remove_result.error());
 
     // PutEnd should fail if the client_id does not match.
-    auto put_end_fail_result =
-        service_->PutEnd(invalid_client_id, key, ReplicaType::MEMORY);
+    auto put_end_fail_result = service_->PutEnd(invalid_client_id, key,
+                                                "default", ReplicaType::MEMORY);
     EXPECT_FALSE(put_end_fail_result.has_value());
     EXPECT_EQ(put_end_fail_result.error(), ErrorCode::ILLEGAL_CLIENT);
 
     // PutRevoke should fail if the client_id does not match.
-    auto put_revoke_fail_result =
-        service_->PutRevoke(invalid_client_id, key, ReplicaType::MEMORY);
+    auto put_revoke_fail_result = service_->PutRevoke(
+        invalid_client_id, key, "default", ReplicaType::MEMORY);
     EXPECT_FALSE(put_revoke_fail_result.has_value());
     EXPECT_EQ(put_revoke_fail_result.error(), ErrorCode::ILLEGAL_CLIENT);
 
     // Test PutEnd
-    auto put_end_result = service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end_result =
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     EXPECT_TRUE(put_end_result.has_value());
 
     // Verify replica list after PutEnd
-    auto final_get_result = service_->GetReplicaList(key);
+    auto final_get_result = service_->GetReplicaList(key, "default");
     EXPECT_TRUE(final_get_result.has_value());
     replica_list = final_get_result.value().replicas;
     EXPECT_EQ(1, replica_list.size());
@@ -1371,8 +1455,8 @@ TEST_F(MasterServiceTest, TenantPutGetRemoveIsolatesSameUserKey) {
     ASSERT_TRUE(service_->PutEnd(client_id, key, tenant_b, ReplicaType::MEMORY)
                     .has_value());
 
-    EXPECT_FALSE(service_->GetReplicaList(key).has_value());
-    EXPECT_FALSE(service_->ExistKey(key).value());
+    EXPECT_FALSE(service_->GetReplicaList(key, "default").has_value());
+    EXPECT_FALSE(service_->ExistKey(key, "default").value());
     EXPECT_TRUE(service_->ExistKey(key, tenant_a).value());
     EXPECT_TRUE(service_->ExistKey(key, tenant_b).value());
     EXPECT_TRUE(service_->GetReplicaList(key, tenant_a).has_value());
@@ -1396,9 +1480,10 @@ TEST_F(MasterServiceTest, RegexOperationsAreTenantScoped) {
     ReplicateConfig config;
     config.replica_num = 1;
 
-    ASSERT_TRUE(service_->PutStart(client_id, key, 1024, config).has_value());
-    ASSERT_TRUE(
-        service_->PutEnd(client_id, key, ReplicaType::MEMORY).has_value());
+    ASSERT_TRUE(service_->PutStart(client_id, key, "default", 1024, config)
+                    .has_value());
+    ASSERT_TRUE(service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY)
+                    .has_value());
     ASSERT_TRUE(
         service_->PutStart(client_id, key, tenant_a, 1024, config).has_value());
     ASSERT_TRUE(service_->PutEnd(client_id, key, tenant_a, ReplicaType::MEMORY)
@@ -1408,15 +1493,16 @@ TEST_F(MasterServiceTest, RegexOperationsAreTenantScoped) {
     ASSERT_TRUE(service_->PutEnd(client_id, key, tenant_b, ReplicaType::MEMORY)
                     .has_value());
 
-    auto default_matches = service_->GetReplicaListByRegex("^regex_shared");
+    auto default_matches =
+        service_->GetReplicaListByRegex("^regex_shared", "default");
     ASSERT_TRUE(default_matches.has_value());
     EXPECT_EQ(default_matches->size(), 1);
 
     auto remove_default =
-        service_->RemoveByRegex("^regex_shared", /*force=*/true);
+        service_->RemoveByRegex("^regex_shared", "default", /*force=*/true);
     ASSERT_TRUE(remove_default.has_value());
     EXPECT_EQ(remove_default.value(), 1);
-    EXPECT_FALSE(service_->GetReplicaList(key).has_value());
+    EXPECT_FALSE(service_->GetReplicaList(key, "default").has_value());
     EXPECT_TRUE(service_->GetReplicaList(key, tenant_a).has_value());
     EXPECT_TRUE(service_->GetReplicaList(key, tenant_b).has_value());
 
@@ -1467,7 +1553,7 @@ TEST_F(MasterServiceTest, TenantBatchUpsertAndRevokeAreScoped) {
     }
 
     for (const auto& key : keys) {
-        EXPECT_FALSE(svc->GetReplicaList(key).has_value());
+        EXPECT_FALSE(svc->GetReplicaList(key, "default").has_value());
         EXPECT_TRUE(svc->GetReplicaList(key, tenant_a).has_value());
         EXPECT_TRUE(svc->GetReplicaList(key, tenant_b).has_value());
     }
@@ -1494,9 +1580,11 @@ TEST_F(MasterServiceTest, TenantBatchRemoveAndRemoveAllAreScoped) {
     ReplicateConfig config;
     config.replica_num = 1;
 
-    ASSERT_TRUE(svc->PutStart(client_id, shared_key, 1024, config).has_value());
+    ASSERT_TRUE(svc->PutStart(client_id, shared_key, "default", 1024, config)
+                    .has_value());
     ASSERT_TRUE(
-        svc->PutEnd(client_id, shared_key, ReplicaType::MEMORY).has_value());
+        svc->PutEnd(client_id, shared_key, "default", ReplicaType::MEMORY)
+            .has_value());
     ASSERT_TRUE(svc->PutStart(client_id, shared_key, tenant_a, 1024, config)
                     .has_value());
     ASSERT_TRUE(
@@ -1512,15 +1600,15 @@ TEST_F(MasterServiceTest, TenantBatchRemoveAndRemoveAllAreScoped) {
     ASSERT_EQ(remove_a.size(), 1u);
     ASSERT_TRUE(remove_a[0].has_value());
     EXPECT_FALSE(svc->GetReplicaList(shared_key, tenant_a).has_value());
-    EXPECT_TRUE(svc->GetReplicaList(shared_key).has_value());
+    EXPECT_TRUE(svc->GetReplicaList(shared_key, "default").has_value());
     EXPECT_TRUE(svc->GetReplicaList(shared_key, tenant_b).has_value());
 
     EXPECT_EQ(svc->RemoveAll(tenant_b, /*force=*/true), 1);
     EXPECT_FALSE(svc->GetReplicaList(shared_key, tenant_b).has_value());
-    EXPECT_TRUE(svc->GetReplicaList(shared_key).has_value());
+    EXPECT_TRUE(svc->GetReplicaList(shared_key, "default").has_value());
 
     EXPECT_EQ(svc->RemoveAll(/*force=*/true), 1);
-    EXPECT_FALSE(svc->GetReplicaList(shared_key).has_value());
+    EXPECT_FALSE(svc->GetReplicaList(shared_key, "default").has_value());
 }
 
 TEST_F(MasterServiceTest, LegacyRemoveAllRemovesAllTenants) {
@@ -1535,8 +1623,10 @@ TEST_F(MasterServiceTest, LegacyRemoveAllRemovesAllTenants) {
     ReplicateConfig config;
     config.replica_num = 1;
 
-    ASSERT_TRUE(svc->PutStart(client_id, key, 1024, config).has_value());
-    ASSERT_TRUE(svc->PutEnd(client_id, key, ReplicaType::MEMORY).has_value());
+    ASSERT_TRUE(
+        svc->PutStart(client_id, key, "default", 1024, config).has_value());
+    ASSERT_TRUE(svc->PutEnd(client_id, key, "default", ReplicaType::MEMORY)
+                    .has_value());
     ASSERT_TRUE(
         svc->PutStart(client_id, key, tenant_a, 1024, config).has_value());
     ASSERT_TRUE(
@@ -1547,7 +1637,7 @@ TEST_F(MasterServiceTest, LegacyRemoveAllRemovesAllTenants) {
         svc->PutEnd(client_id, key, tenant_b, ReplicaType::MEMORY).has_value());
 
     EXPECT_EQ(svc->RemoveAll(/*force=*/true), 3);
-    EXPECT_FALSE(svc->GetReplicaList(key).has_value());
+    EXPECT_FALSE(svc->GetReplicaList(key, "default").has_value());
     EXPECT_FALSE(svc->GetReplicaList(key, tenant_a).has_value());
     EXPECT_FALSE(svc->GetReplicaList(key, tenant_b).has_value());
     EXPECT_EQ(svc->RemoveAll(/*force=*/true), 0);
@@ -1578,7 +1668,7 @@ TEST_F(MasterServiceTest, PutWithPreferredSegment) {
     config.preferred_segment = preferred_segment;
 
     auto put_start_result =
-        service_->PutStart(client_id, key, value_length, config);
+        service_->PutStart(client_id, key, "default", value_length, config);
     EXPECT_TRUE(put_start_result.has_value());
     replica_list = put_start_result.value();
     EXPECT_EQ(1, replica_list.size());
@@ -1588,7 +1678,8 @@ TEST_F(MasterServiceTest, PutWithPreferredSegment) {
               mem_desc.buffer_descriptor.transport_endpoint_);
 
     // Complete the Put operation
-    auto put_end_result = service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end_result =
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     EXPECT_TRUE(put_end_result.has_value());
 }
 
@@ -1616,7 +1707,7 @@ TEST_F(MasterServiceTest, PutWithPreferredSegments) {
     config.preferred_segments = preferred_segments;
 
     auto put_start_result =
-        service_->PutStart(client_id, key, value_length, config);
+        service_->PutStart(client_id, key, "default", value_length, config);
     EXPECT_TRUE(put_start_result.has_value());
     replica_list = put_start_result.value();
     EXPECT_EQ(2, replica_list.size());
@@ -1631,7 +1722,8 @@ TEST_F(MasterServiceTest, PutWithPreferredSegments) {
     EXPECT_TRUE(used_segments.find("segment_1") != used_segments.end());
 
     // Complete the Put operation
-    auto put_end_result = service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end_result =
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     EXPECT_TRUE(put_end_result.has_value());
 }
 
@@ -1658,23 +1750,24 @@ TEST_F(MasterServiceTest, RandomPutStartEndFlow) {
     int random_number = dis(gen);
     config.replica_num = random_number;
     auto put_start_result =
-        service_->PutStart(client_id, key, value_length, config);
+        service_->PutStart(client_id, key, "default", value_length, config);
     EXPECT_TRUE(put_start_result.has_value());
     replica_list = put_start_result.value();
     EXPECT_FALSE(replica_list.empty());
     EXPECT_EQ(ReplicaStatus::PROCESSING, replica_list[0].status);
     // During put, Get/Remove should fail
-    auto get_result = service_->GetReplicaList(key);
+    auto get_result = service_->GetReplicaList(key, "default");
     EXPECT_FALSE(get_result.has_value());
     EXPECT_EQ(ErrorCode::REPLICA_IS_NOT_READY, get_result.error());
-    auto remove_result = service_->Remove(key);
+    auto remove_result = service_->Remove(key, "default");
     EXPECT_FALSE(remove_result.has_value());
     EXPECT_EQ(ErrorCode::REPLICA_IS_NOT_READY, remove_result.error());
     // Test PutEnd
-    auto put_end_result = service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end_result =
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     EXPECT_TRUE(put_end_result.has_value());
     // Verify replica list after PutEnd
-    auto get_result2 = service_->GetReplicaList(key);
+    auto get_result2 = service_->GetReplicaList(key, "default");
     EXPECT_TRUE(get_result2.has_value());
     replica_list = get_result2.value().replicas;
     EXPECT_EQ(random_number, replica_list.size());
@@ -1691,7 +1784,7 @@ TEST_F(MasterServiceTest, GetReplicaListByRegex) {
     std::unique_ptr<MasterService> service_(new MasterService(service_config));
     const UUID client_id = generate_uuid();
     // Test getting non-existent key
-    auto get_result = service_->GetReplicaList(".*non_existent.*");
+    auto get_result = service_->GetReplicaList(".*non_existent.*", "default");
     EXPECT_FALSE(get_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, get_result.error());
 
@@ -1704,19 +1797,19 @@ TEST_F(MasterServiceTest, GetReplicaListByRegex) {
         ReplicateConfig config;
         config.replica_num = 1;
         auto put_start_result =
-            service_->PutStart(client_id, key, value_length, config);
+            service_->PutStart(client_id, key, "default", value_length, config);
         ASSERT_TRUE(put_start_result.has_value());
         auto put_end_result =
-            service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+            service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
         ASSERT_TRUE(put_end_result.has_value());
-        auto exist_result = service_->ExistKey(key);
+        auto exist_result = service_->ExistKey(key, "default");
         ASSERT_TRUE(exist_result.has_value());
     }
     // wait for all the lease to expire
     std::this_thread::sleep_for(std::chrono::milliseconds(kv_lease_ttl));
 
     // Test getting existing key
-    auto get_result2 = service_->GetReplicaListByRegex("^test_key");
+    auto get_result2 = service_->GetReplicaListByRegex("^test_key", "default");
     EXPECT_TRUE(get_result2.has_value());
     auto replica_list_local = get_result2.value();
     EXPECT_EQ(10, replica_list_local.size());
@@ -1729,13 +1822,14 @@ void put_object(MasterService& service, const UUID& client_id,
     ReplicateConfig config;
     config.replica_num = 1;
     auto put_start_result =
-        service.PutStart(client_id, key, value_length, config);
+        service.PutStart(client_id, key, "default", value_length, config);
     ASSERT_TRUE(put_start_result.has_value())
         << "Failed to PutStart for key: " << key;
-    auto put_end_result = service.PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end_result =
+        service.PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value())
         << "Failed to PutEnd for key: " << key;
-    auto exist_result = service.ExistKey(key);
+    auto exist_result = service.ExistKey(key, "default");
     ASSERT_TRUE(exist_result.has_value())
         << "Key does not exist after put: " << key;
 }
@@ -1779,7 +1873,7 @@ TEST_F(MasterServiceTest, GetReplicaListByRegexComplex) {
 
     // Test 3.1: Simple prefix matching
     {
-        auto result = service_->GetReplicaListByRegex("^test_key_");
+        auto result = service_->GetReplicaListByRegex("^test_key_", "default");
         ASSERT_TRUE(result.has_value());
         EXPECT_EQ(result.value().size(),
                   3);  // Matches test_key_01, test_key_02, test_key_10
@@ -1787,7 +1881,8 @@ TEST_F(MasterServiceTest, GetReplicaListByRegexComplex) {
 
     // Test 3.2: Matching with a wildcard for any number
     {
-        auto result = service_->GetReplicaListByRegex("^test_key_\\d+$");
+        auto result =
+            service_->GetReplicaListByRegex("^test_key_\\d+$", "default");
         ASSERT_TRUE(result.has_value());
         EXPECT_EQ(result.value().size(), 3);
     }
@@ -1795,8 +1890,8 @@ TEST_F(MasterServiceTest, GetReplicaListByRegexComplex) {
     // Test 3.3: Matching a specific pattern with wildcards
     {
         // Matches "data_part_1_chunk_a" and "data_part_2_chunk_b"
-        auto result =
-            service_->GetReplicaListByRegex("^data_part_\\d_chunk_.$");
+        auto result = service_->GetReplicaListByRegex("^data_part_\\d_chunk_.$",
+                                                      "default");
         ASSERT_TRUE(result.has_value());
         EXPECT_EQ(result.value().size(), 2);
     }
@@ -1804,7 +1899,7 @@ TEST_F(MasterServiceTest, GetReplicaListByRegexComplex) {
     // Test 3.4: Matching keys containing a specific substring
     {
         // Matches all keys with "key" in them
-        auto result = service_->GetReplicaListByRegex("key");
+        auto result = service_->GetReplicaListByRegex("key", "default");
         ASSERT_TRUE(result.has_value());
         // Expected: test_key_01, test_key_02, test_key_10,
         //           prod_key_alpha, prod_key_beta,
@@ -1816,7 +1911,7 @@ TEST_F(MasterServiceTest, GetReplicaListByRegexComplex) {
     // Test 3.5: Matching based on file-like paths
     {
         // Match all .log files
-        auto result = service_->GetReplicaListByRegex("\\.log$");
+        auto result = service_->GetReplicaListByRegex("\\.log$", "default");
         ASSERT_TRUE(result.has_value());
         EXPECT_EQ(result.value().size(), 1);
         EXPECT_EQ(result.value().begin()->first, "logs/app-2025-08-13.log");
@@ -1825,7 +1920,8 @@ TEST_F(MasterServiceTest, GetReplicaListByRegexComplex) {
     // Test 3.6: OR condition using |
     {
         // Match keys starting with "prod" OR ending with "json"
-        auto result = service_->GetReplicaListByRegex("^prod|\\.json$");
+        auto result =
+            service_->GetReplicaListByRegex("^prod|\\.json$", "default");
         ASSERT_TRUE(result.has_value());
         // Expected: prod_key_alpha, prod_key_beta, config/user/settings.json
         EXPECT_EQ(result.value().size(), 3);
@@ -1833,7 +1929,8 @@ TEST_F(MasterServiceTest, GetReplicaListByRegexComplex) {
 
     // Test 3.7: Regex that should not match anything
     {
-        auto result = service_->GetReplicaListByRegex("^non_existent_prefix_");
+        auto result =
+            service_->GetReplicaListByRegex("^non_existent_prefix_", "default");
         // This should succeed but return an empty map.
         ASSERT_TRUE(result.has_value());
         EXPECT_TRUE(result.value().empty());
@@ -1841,7 +1938,7 @@ TEST_F(MasterServiceTest, GetReplicaListByRegexComplex) {
 
     // Test 3.8: Exact match regex
     {
-        auto result = service_->GetReplicaListByRegex("^short$");
+        auto result = service_->GetReplicaListByRegex("^short$", "default");
         ASSERT_TRUE(result.has_value());
         EXPECT_EQ(result.value().size(), 1);
         EXPECT_EQ(result.value().begin()->first, "short");
@@ -1849,8 +1946,8 @@ TEST_F(MasterServiceTest, GetReplicaListByRegexComplex) {
 
     // Test 3.9: Initial test for non-existent key (as a sanity check)
     {
-        auto get_result =
-            service_->GetReplicaListByRegex(".*absolutely_non_existent.*");
+        auto get_result = service_->GetReplicaListByRegex(
+            ".*absolutely_non_existent.*", "default");
         // Depending on implementation, this could return an empty map or an
         // error. Let's assume it returns an empty map for a valid regex with no
         // matches.
@@ -1863,7 +1960,7 @@ TEST_F(MasterServiceTest, GetReplicaList) {
     std::unique_ptr<MasterService> service_(new MasterService());
     const UUID client_id = generate_uuid();
     // Test getting non-existent key
-    auto get_result = service_->GetReplicaList("non_existent");
+    auto get_result = service_->GetReplicaList("non_existent", "default");
     EXPECT_FALSE(get_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, get_result.error());
 
@@ -1874,13 +1971,14 @@ TEST_F(MasterServiceTest, GetReplicaList) {
     ReplicateConfig config;
     config.replica_num = 1;
     auto put_start_result =
-        service_->PutStart(client_id, key, value_length, config);
+        service_->PutStart(client_id, key, "default", value_length, config);
     ASSERT_TRUE(put_start_result.has_value());
-    auto put_end_result = service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end_result =
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value());
 
     // Test getting existing key
-    auto get_result2 = service_->GetReplicaList(key);
+    auto get_result2 = service_->GetReplicaList(key, "default");
     EXPECT_TRUE(get_result2.has_value());
     auto replica_list_local = get_result2.value().replicas;
     EXPECT_FALSE(replica_list_local.empty());
@@ -1896,22 +1994,23 @@ TEST_F(MasterServiceTest, RemoveObject) {
     ReplicateConfig config;
     config.replica_num = 1;
     auto put_start_result =
-        service_->PutStart(client_id, key, value_length, config);
+        service_->PutStart(client_id, key, "default", value_length, config);
     ASSERT_TRUE(put_start_result.has_value());
-    auto put_end_result = service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end_result =
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value());
 
     // Test removing the object
-    auto remove_result = service_->Remove(key);
+    auto remove_result = service_->Remove(key, "default");
     EXPECT_TRUE(remove_result.has_value());
 
     // Verify object is removed
-    auto get_result = service_->GetReplicaList(key);
+    auto get_result = service_->GetReplicaList(key, "default");
     EXPECT_FALSE(get_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, get_result.error());
 
     // Test removing non-existent object
-    auto remove_result2 = service_->Remove("non_existent");
+    auto remove_result2 = service_->Remove("non_existent", "default");
     EXPECT_FALSE(remove_result2.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, remove_result2.error());
 }
@@ -1930,18 +2029,18 @@ TEST_F(MasterServiceTest, RandomRemoveObject) {
         ReplicateConfig config;
         config.replica_num = 1;
         auto put_start_result =
-            service_->PutStart(client_id, key, value_length, config);
+            service_->PutStart(client_id, key, "default", value_length, config);
         ASSERT_TRUE(put_start_result.has_value());
         auto put_end_result =
-            service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+            service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
         ASSERT_TRUE(put_end_result.has_value());
 
         // Test removing the object
-        auto remove_result = service_->Remove(key);
+        auto remove_result = service_->Remove(key, "default");
         EXPECT_TRUE(remove_result.has_value());
 
         // Verify object is removed
-        auto get_result = service_->GetReplicaList(key);
+        auto get_result = service_->GetReplicaList(key, "default");
         EXPECT_FALSE(get_result.has_value());
         EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, get_result.error());
     }
@@ -1962,23 +2061,23 @@ TEST_F(MasterServiceTest, RemoveByRegex) {
         ReplicateConfig config;
         config.replica_num = 1;
         auto put_start_result =
-            service_->PutStart(client_id, key, value_length, config);
+            service_->PutStart(client_id, key, "default", value_length, config);
         ASSERT_TRUE(put_start_result.has_value());
         auto put_end_result =
-            service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+            service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
         ASSERT_TRUE(put_end_result.has_value());
-        auto exist_result = service_->ExistKey(key);
+        auto exist_result = service_->ExistKey(key, "default");
         ASSERT_TRUE(exist_result.has_value());
     }
     // wait for all the lease to expire
     std::this_thread::sleep_for(std::chrono::milliseconds(kv_lease_ttl));
-    auto res = service_->RemoveByRegex("^test_key");
+    auto res = service_->RemoveByRegex("^test_key", "default");
     ASSERT_TRUE(res.has_value());
     ASSERT_EQ(10, res.value());
     times = 10;
     while (times--) {
         std::string key = "test_key" + std::to_string(times);
-        auto exist_result = service_->ExistKey(key);
+        auto exist_result = service_->ExistKey(key, "default");
         ASSERT_TRUE(exist_result.has_value());
         ASSERT_FALSE(exist_result.value());
     }
@@ -2005,8 +2104,8 @@ TEST_F(MasterServiceTest, CopyStart) {
     UUID client_id = generate_uuid();
 
     // Test Case 1: CopyStart a non-existent key, should fail.
-    auto copy_result = service_->CopyStart(client_id, "non_existent_key",
-                                           "segment_1", {"segment_2"});
+    auto copy_result = service_->CopyStart(
+        client_id, "non_existent_key", "default", "segment_1", {"segment_2"});
     EXPECT_FALSE(copy_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, copy_result.error());
 
@@ -2019,22 +2118,23 @@ TEST_F(MasterServiceTest, CopyStart) {
     config.preferred_segment = "segment_1";
 
     auto put_start_result =
-        service_->PutStart(client_id, key, slice_length, config);
+        service_->PutStart(client_id, key, "default", slice_length, config);
     ASSERT_TRUE(put_start_result.has_value());
 
     // Test Case 2: CopyStart to segment_2 and segment_3, should fail because
     // the only replica is not completed.
-    copy_result = service_->CopyStart(client_id, key, "segment_1",
+    copy_result = service_->CopyStart(client_id, key, "default", "segment_1",
                                       {"segment_2", "segment_3"});
     EXPECT_FALSE(copy_result.has_value());
     EXPECT_EQ(ErrorCode::REPLICA_NOT_FOUND, copy_result.error());
 
     // PutEnd the object.
-    auto put_end_result = service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end_result =
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value());
 
     // Test Case 3: CopyStart to segment_2 and segment_3, should success.
-    copy_result = service_->CopyStart(client_id, key, "segment_1",
+    copy_result = service_->CopyStart(client_id, key, "default", "segment_1",
                                       {"segment_2", "segment_3"});
     EXPECT_TRUE(copy_result.has_value());
     auto copy_response = copy_result.value();
@@ -2043,40 +2143,41 @@ TEST_F(MasterServiceTest, CopyStart) {
     EXPECT_EQ(2, copy_response.targets.size());
 
     // Test Case 4: Try remove the object, should fail because it is copying.
-    auto remove_result = service_->Remove(key);
+    auto remove_result = service_->Remove(key, "default");
     EXPECT_FALSE(remove_result.has_value());
     EXPECT_EQ(ErrorCode::REPLICA_IS_NOT_READY, remove_result.error());
 
     // Test Case 5: CopyStart to segment_4, should fail because there is an
     // ongoing copy task.
-    copy_result =
-        service_->CopyStart(client_id, key, "segment_1", {"segment_4"});
+    copy_result = service_->CopyStart(client_id, key, "default", "segment_1",
+                                      {"segment_4"});
     EXPECT_FALSE(copy_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_HAS_REPLICATION_TASK, copy_result.error());
 
     // Test Case 6: CopyEnd, should success and the object now has 3 replicas.
-    auto copy_end_result = service_->CopyEnd(client_id, key);
+    auto copy_end_result = service_->CopyEnd(client_id, key, "default");
     EXPECT_TRUE(copy_end_result.has_value());
-    auto get_result = service_->GetReplicaList(key);
+    auto get_result = service_->GetReplicaList(key, "default");
     EXPECT_TRUE(get_result.has_value());
     EXPECT_EQ(3, get_result.value().replicas.size());
 
     // Test Case 7: Copy from a non-existent replica to segment_3 and
     // segment_4, should fail.
-    copy_result = service_->CopyStart(client_id, key, "non_existent_segment",
-                                      {"segment_3", "segment_4"});
+    copy_result =
+        service_->CopyStart(client_id, key, "default", "non_existent_segment",
+                            {"segment_3", "segment_4"});
     EXPECT_FALSE(copy_result.has_value());
     EXPECT_EQ(ErrorCode::REPLICA_NOT_FOUND, copy_result.error());
 
     // Test Case 8: Copy to segment_4 and a non-existent segment, should fail.
-    copy_result = service_->CopyStart(client_id, key, "segment_1",
+    copy_result = service_->CopyStart(client_id, key, "default", "segment_1",
                                       {"segment_4", "non_existent_segment"});
     EXPECT_FALSE(copy_result.has_value());
     EXPECT_EQ(ErrorCode::SEGMENT_NOT_FOUND, copy_result.error());
 
     // Test Case 9: Copy to segment_3 and segment_4, should skip segment_3 and
     // successfully copy to segment_4.
-    copy_result = service_->CopyStart(client_id, key, "segment_1",
+    copy_result = service_->CopyStart(client_id, key, "default", "segment_1",
                                       {"segment_3", "segment_4"});
     EXPECT_TRUE(copy_result.has_value());
     copy_response = copy_result.value();
@@ -2089,16 +2190,16 @@ TEST_F(MasterServiceTest, CopyStart) {
                                .buffer_descriptor.transport_endpoint_);
 
     // End the copy operation to clean up state
-    copy_end_result = service_->CopyEnd(client_id, key);
+    copy_end_result = service_->CopyEnd(client_id, key, "default");
     EXPECT_TRUE(copy_end_result.has_value());
-    get_result = service_->GetReplicaList(key);
+    get_result = service_->GetReplicaList(key, "default");
     EXPECT_TRUE(get_result.has_value());
     EXPECT_EQ(4, get_result.value().replicas.size());
 
     // Test Case 10: Copy to segment_4 again, should skip because it's already
     // used.
-    copy_result =
-        service_->CopyStart(client_id, key, "segment_1", {"segment_4"});
+    copy_result = service_->CopyStart(client_id, key, "default", "segment_1",
+                                      {"segment_4"});
     EXPECT_TRUE(copy_result.has_value());
     copy_response = copy_result.value();
     EXPECT_EQ("segment_1", copy_response.source.get_memory_descriptor()
@@ -2111,19 +2212,19 @@ TEST_F(MasterServiceTest, CopyStart) {
     std::this_thread::sleep_for(std::chrono::milliseconds(kv_lease_ttl * 2));
 
     // Test Case 11: Try remove the object, should fail because it is copying.
-    remove_result = service_->Remove(key);
+    remove_result = service_->Remove(key, "default");
     EXPECT_FALSE(remove_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_HAS_REPLICATION_TASK, remove_result.error());
 
     // Clean up the copy operation
-    copy_end_result = service_->CopyEnd(client_id, key);
+    copy_end_result = service_->CopyEnd(client_id, key, "default");
     EXPECT_TRUE(copy_end_result.has_value());
 
     // Wait for the lease to expire
     std::this_thread::sleep_for(std::chrono::milliseconds(kv_lease_ttl * 2));
 
     // Test Case 12: Try remove the object, should success.
-    remove_result = service_->Remove(key);
+    remove_result = service_->Remove(key, "default");
     EXPECT_TRUE(remove_result.has_value());
 }
 
@@ -2143,7 +2244,8 @@ TEST_F(MasterServiceTest, CopyEnd) {
     UUID invalid_client_id = generate_uuid();
 
     // Test Case 1: CopyEnd a non-existent key, should fail.
-    auto copy_end_result = service_->CopyEnd(client_id, "non_existent_key");
+    auto copy_end_result =
+        service_->CopyEnd(client_id, "non_existent_key", "default");
     EXPECT_FALSE(copy_end_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, copy_end_result.error());
 
@@ -2155,45 +2257,46 @@ TEST_F(MasterServiceTest, CopyEnd) {
     config.preferred_segment = "segment_1";
 
     auto put_start_result =
-        service_->PutStart(client_id, key, slice_length, config);
+        service_->PutStart(client_id, key, "default", slice_length, config);
     ASSERT_TRUE(put_start_result.has_value());
-    auto put_end_result = service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end_result =
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value());
 
     // Test Case 2: CopyEnd the object, should fail because there is no ongoing
     // copy task.
-    copy_end_result = service_->CopyEnd(client_id, key);
+    copy_end_result = service_->CopyEnd(client_id, key, "default");
     EXPECT_FALSE(copy_end_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NO_REPLICATION_TASK, copy_end_result.error());
 
     // CopyStart the object to segment_2
-    auto copy_start_result =
-        service_->CopyStart(client_id, key, "segment_1", {"segment_2"});
+    auto copy_start_result = service_->CopyStart(client_id, key, "default",
+                                                 "segment_1", {"segment_2"});
     ASSERT_TRUE(copy_start_result.has_value());
 
     // Test Case 3: CopyEnd with an invalid client id, should fail.
-    copy_end_result = service_->CopyEnd(invalid_client_id, key);
+    copy_end_result = service_->CopyEnd(invalid_client_id, key, "default");
     EXPECT_FALSE(copy_end_result.has_value());
     EXPECT_EQ(ErrorCode::ILLEGAL_CLIENT, copy_end_result.error());
 
     // Test Case 4: MoveEnd the object, should fail because the ongoing task is
     // Copy.
-    auto move_end_result = service_->MoveEnd(client_id, key);
+    auto move_end_result = service_->MoveEnd(client_id, key, "default");
     EXPECT_FALSE(move_end_result.has_value());
     EXPECT_EQ(ErrorCode::INVALID_PARAMS, move_end_result.error());
 
     // Test Case 5: CopyEnd, should success.
-    copy_end_result = service_->CopyEnd(client_id, key);
+    copy_end_result = service_->CopyEnd(client_id, key, "default");
     EXPECT_TRUE(copy_end_result.has_value());
 
     // Verify we now have 2 replicas
-    auto get_result = service_->GetReplicaList(key);
+    auto get_result = service_->GetReplicaList(key, "default");
     EXPECT_TRUE(get_result.has_value());
     EXPECT_EQ(2, get_result.value().replicas.size());
 
     // CopyStart the object from segment_1 to segment_3, then unmount segment_1
-    copy_start_result =
-        service_->CopyStart(client_id, key, "segment_1", {"segment_3"});
+    copy_start_result = service_->CopyStart(client_id, key, "default",
+                                            "segment_1", {"segment_3"});
     ASSERT_TRUE(copy_start_result.has_value());
 
     // Unmount segment_1 to simulate source gone
@@ -2203,10 +2306,10 @@ TEST_F(MasterServiceTest, CopyEnd) {
 
     // Test Case 6: CopyEnd, should fail because the source is gone, the object
     // should have only 1 replica from segment_2.
-    copy_end_result = service_->CopyEnd(client_id, key);
+    copy_end_result = service_->CopyEnd(client_id, key, "default");
     EXPECT_FALSE(copy_end_result.has_value());
     EXPECT_EQ(ErrorCode::REPLICA_IS_GONE, copy_end_result.error());
-    get_result = service_->GetReplicaList(key);
+    get_result = service_->GetReplicaList(key, "default");
     EXPECT_TRUE(get_result.has_value());
     auto& replicas = get_result.value().replicas;
     EXPECT_EQ(1, replicas.size());
@@ -2215,8 +2318,8 @@ TEST_F(MasterServiceTest, CopyEnd) {
                                .buffer_descriptor.transport_endpoint_);
 
     // CopyStart the object from segment_2 to segment_3, then unmount segment_3
-    copy_start_result =
-        service_->CopyStart(client_id, key, "segment_2", {"segment_3"});
+    copy_start_result = service_->CopyStart(client_id, key, "default",
+                                            "segment_2", {"segment_3"});
     ASSERT_TRUE(copy_start_result.has_value());
 
     // Unmount segment_3 to simulate target gone
@@ -2226,10 +2329,10 @@ TEST_F(MasterServiceTest, CopyEnd) {
 
     // Test Case 7: CopyEnd, should fail because the target is gone, the object
     // should have only 1 replica from segment_2.
-    copy_end_result = service_->CopyEnd(client_id, key);
+    copy_end_result = service_->CopyEnd(client_id, key, "default");
     EXPECT_FALSE(copy_end_result.has_value());
     EXPECT_EQ(ErrorCode::REPLICA_IS_GONE, copy_end_result.error());
-    get_result = service_->GetReplicaList(key);
+    get_result = service_->GetReplicaList(key, "default");
     EXPECT_TRUE(get_result.has_value());
     replicas = get_result.value().replicas;
     EXPECT_EQ(1, replicas.size());
@@ -2253,7 +2356,7 @@ TEST_F(MasterServiceTest, CopyRevoke) {
 
     // Test Case 1: CopyRevoke a non-existent key, should fail.
     auto copy_revoke_result =
-        service_->CopyRevoke(client_id, "non_existent_key");
+        service_->CopyRevoke(client_id, "non_existent_key", "default");
     EXPECT_FALSE(copy_revoke_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, copy_revoke_result.error());
 
@@ -2265,47 +2368,49 @@ TEST_F(MasterServiceTest, CopyRevoke) {
     config.preferred_segment = "segment_1";
 
     auto put_start_result =
-        service_->PutStart(client_id, key, slice_length, config);
+        service_->PutStart(client_id, key, "default", slice_length, config);
     ASSERT_TRUE(put_start_result.has_value());
-    auto put_end_result = service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end_result =
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value());
 
     // Test Case 2: CopyRevoke the object, should fail because there is no
     // ongoing copy task.
-    copy_revoke_result = service_->CopyRevoke(client_id, key);
+    copy_revoke_result = service_->CopyRevoke(client_id, key, "default");
     EXPECT_FALSE(copy_revoke_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NO_REPLICATION_TASK,
               copy_revoke_result.error());
 
     // CopyStart the object to segment_2
-    auto copy_start_result =
-        service_->CopyStart(client_id, key, "segment_1", {"segment_2"});
+    auto copy_start_result = service_->CopyStart(client_id, key, "default",
+                                                 "segment_1", {"segment_2"});
     ASSERT_TRUE(copy_start_result.has_value());
 
     // Test Case 3: CopyRevoke with an invalid client id, should fail.
-    copy_revoke_result = service_->CopyRevoke(invalid_client_id, key);
+    copy_revoke_result =
+        service_->CopyRevoke(invalid_client_id, key, "default");
     EXPECT_FALSE(copy_revoke_result.has_value());
     EXPECT_EQ(ErrorCode::ILLEGAL_CLIENT, copy_revoke_result.error());
 
     // Test Case 4: MoveRevoke the object, should fail because the ongoing task
     // is Copy.
-    auto move_revoke_result = service_->MoveRevoke(client_id, key);
+    auto move_revoke_result = service_->MoveRevoke(client_id, key, "default");
     EXPECT_FALSE(move_revoke_result.has_value());
     EXPECT_EQ(ErrorCode::INVALID_PARAMS, move_revoke_result.error());
 
     // Test Case 5: CopyRevoke, should success.
-    copy_revoke_result = service_->CopyRevoke(client_id, key);
+    copy_revoke_result = service_->CopyRevoke(client_id, key, "default");
     EXPECT_TRUE(copy_revoke_result.has_value());
 
     // Verify we still have 1 replica (the copy was revoked)
-    auto get_result = service_->GetReplicaList(key);
+    auto get_result = service_->GetReplicaList(key, "default");
     EXPECT_TRUE(get_result.has_value());
     EXPECT_EQ(1, get_result.value().replicas.size());
 
     // CopyStart the object from segment_1 to segment_2 again, then unmount
     // segment_1
-    copy_start_result =
-        service_->CopyStart(client_id, key, "segment_1", {"segment_2"});
+    copy_start_result = service_->CopyStart(client_id, key, "default",
+                                            "segment_1", {"segment_2"});
     ASSERT_TRUE(copy_start_result.has_value());
 
     // Unmount segment_1 to simulate source gone
@@ -2315,11 +2420,11 @@ TEST_F(MasterServiceTest, CopyRevoke) {
 
     // Test Case 6: CopyRevoke, should success even though the source is gone,
     // the object should be erased too.
-    copy_revoke_result = service_->CopyRevoke(client_id, key);
+    copy_revoke_result = service_->CopyRevoke(client_id, key, "default");
     EXPECT_TRUE(copy_revoke_result.has_value());
 
     // Verify the object has been removed.
-    get_result = service_->GetReplicaList(key);
+    get_result = service_->GetReplicaList(key, "default");
     EXPECT_FALSE(get_result.has_value());
 }
 
@@ -2342,8 +2447,8 @@ TEST_F(MasterServiceTest, MoveStart) {
     UUID client_id = generate_uuid();
 
     // Test Case 1: MoveStart a non-existent key, should fail.
-    auto move_start_result = service_->MoveStart(client_id, "non_existent_key",
-                                                 "segment_1", "segment_2");
+    auto move_start_result = service_->MoveStart(
+        client_id, "non_existent_key", "default", "segment_1", "segment_2");
     EXPECT_FALSE(move_start_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, move_start_result.error());
 
@@ -2355,36 +2460,37 @@ TEST_F(MasterServiceTest, MoveStart) {
     config.preferred_segment = "segment_1";
 
     auto put_start_result =
-        service_->PutStart(client_id, key, slice_length, config);
+        service_->PutStart(client_id, key, "default", slice_length, config);
     ASSERT_TRUE(put_start_result.has_value());
 
     // Test Case 2: MoveStart the object, should fail because the only replica
     // is not completed.
-    move_start_result =
-        service_->MoveStart(client_id, key, "segment_1", "segment_2");
+    move_start_result = service_->MoveStart(client_id, key, "default",
+                                            "segment_1", "segment_2");
     EXPECT_FALSE(move_start_result.has_value());
     EXPECT_EQ(ErrorCode::REPLICA_NOT_FOUND, move_start_result.error());
 
     // PutEnd the object.
-    auto put_end_result = service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end_result =
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value());
 
     // Copy the object to segment_3.
-    auto copy_start_result =
-        service_->CopyStart(client_id, key, "segment_1", {"segment_3"});
+    auto copy_start_result = service_->CopyStart(client_id, key, "default",
+                                                 "segment_1", {"segment_3"});
     ASSERT_TRUE(copy_start_result.has_value());
-    auto copy_end_result = service_->CopyEnd(client_id, key);
+    auto copy_end_result = service_->CopyEnd(client_id, key, "default");
     ASSERT_TRUE(copy_end_result.has_value());
 
     // Test Case 3: MoveStart with source and target be the same, should fail.
-    move_start_result =
-        service_->MoveStart(client_id, key, "segment_1", "segment_1");
+    move_start_result = service_->MoveStart(client_id, key, "default",
+                                            "segment_1", "segment_1");
     EXPECT_FALSE(move_start_result.has_value());
     EXPECT_EQ(move_start_result.error(), ErrorCode::INVALID_PARAMS);
 
     // Test Case 4: MoveStart to segment_2, should succeed.
-    move_start_result =
-        service_->MoveStart(client_id, key, "segment_1", "segment_2");
+    move_start_result = service_->MoveStart(client_id, key, "default",
+                                            "segment_1", "segment_2");
     EXPECT_TRUE(move_start_result.has_value());
     auto move_response = move_start_result.value();
     EXPECT_EQ("segment_1", move_response.source.get_memory_descriptor()
@@ -2395,44 +2501,44 @@ TEST_F(MasterServiceTest, MoveStart) {
                                .buffer_descriptor.transport_endpoint_);
 
     // Test Case 5: Try remove the object, should fail because it is moving.
-    auto remove_result = service_->Remove(key);
+    auto remove_result = service_->Remove(key, "default");
     EXPECT_FALSE(remove_result.has_value());
     EXPECT_EQ(ErrorCode::REPLICA_IS_NOT_READY, remove_result.error());
 
     // Test Case 6: MoveStart again, should fail because there is an ongoing
     // move task.
-    move_start_result =
-        service_->MoveStart(client_id, key, "segment_1", "segment_3");
+    move_start_result = service_->MoveStart(client_id, key, "default",
+                                            "segment_1", "segment_3");
     EXPECT_FALSE(move_start_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_HAS_REPLICATION_TASK,
               move_start_result.error());
 
     // Test Case 7: MoveEnd, should succeed and the object now has 2 replicas
     // from segment_2 and segment_3
-    auto move_end_result = service_->MoveEnd(client_id, key);
+    auto move_end_result = service_->MoveEnd(client_id, key, "default");
     EXPECT_TRUE(move_end_result.has_value());
 
-    auto get_result = service_->GetReplicaList(key);
+    auto get_result = service_->GetReplicaList(key, "default");
     EXPECT_TRUE(get_result.has_value());
     auto& replicas = get_result.value().replicas;
     EXPECT_EQ(2, replicas.size());
 
     // Test Case 8: Move from a non-existent replica to segment_1, should fail.
     move_start_result = service_->MoveStart(
-        client_id, key, "non_existent_segment", "segment_1");
+        client_id, key, "default", "non_existent_segment", "segment_1");
     EXPECT_FALSE(move_start_result.has_value());
     EXPECT_EQ(ErrorCode::REPLICA_NOT_FOUND, move_start_result.error());
 
     // Test Case 8.5: Move to a non-existent target segment, should fail.
-    move_start_result = service_->MoveStart(client_id, key, "segment_2",
-                                            "non_existent_segment");
+    move_start_result = service_->MoveStart(
+        client_id, key, "default", "segment_2", "non_existent_segment");
     EXPECT_FALSE(move_start_result.has_value());
     EXPECT_EQ(ErrorCode::SEGMENT_NOT_FOUND, move_start_result.error());
 
     // Test Case 9: Move to an already existing segment, should succeed but
     // return nullopt.
-    move_start_result =
-        service_->MoveStart(client_id, key, "segment_2", "segment_3");
+    move_start_result = service_->MoveStart(client_id, key, "default",
+                                            "segment_2", "segment_3");
     EXPECT_TRUE(move_start_result.has_value());
     move_response = move_start_result.value();
     EXPECT_EQ("segment_2", move_response.source.get_memory_descriptor()
@@ -2441,16 +2547,16 @@ TEST_F(MasterServiceTest, MoveStart) {
 
     // Test Case 10: Try remove the object, should fail because it is moving.
     std::this_thread::sleep_for(std::chrono::milliseconds(kv_lease_ttl * 2));
-    remove_result = service_->Remove(key);
+    remove_result = service_->Remove(key, "default");
     EXPECT_FALSE(remove_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_HAS_REPLICATION_TASK, remove_result.error());
 
     // End the move.
-    move_end_result = service_->MoveEnd(client_id, key);
+    move_end_result = service_->MoveEnd(client_id, key, "default");
     EXPECT_TRUE(move_end_result.has_value());
 
     // Now the object should have only 1 replica on segment_3.
-    get_result = service_->GetReplicaList(key);
+    get_result = service_->GetReplicaList(key, "default");
     EXPECT_TRUE(get_result.has_value());
     replicas = get_result.value().replicas;
     EXPECT_EQ(1, replicas.size());
@@ -2460,7 +2566,7 @@ TEST_F(MasterServiceTest, MoveStart) {
 
     // Test Case 11: Try remove the object, should succeed after lease expires.
     std::this_thread::sleep_for(std::chrono::milliseconds(kv_lease_ttl * 2));
-    remove_result = service_->Remove(key);
+    remove_result = service_->Remove(key, "default");
     EXPECT_TRUE(remove_result.has_value());
 }
 
@@ -2478,7 +2584,8 @@ TEST_F(MasterServiceTest, MoveEnd) {
     UUID invalid_client_id = generate_uuid();
 
     // Test Case 1: MoveEnd a non-existent key, should fail.
-    auto move_end_result = service_->MoveEnd(client_id, "non_existent_key");
+    auto move_end_result =
+        service_->MoveEnd(client_id, "non_existent_key", "default");
     EXPECT_FALSE(move_end_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, move_end_result.error());
 
@@ -2490,46 +2597,47 @@ TEST_F(MasterServiceTest, MoveEnd) {
     config.preferred_segment = "segment_1";
 
     auto put_start_result =
-        service_->PutStart(client_id, key, slice_length, config);
+        service_->PutStart(client_id, key, "default", slice_length, config);
     ASSERT_TRUE(put_start_result.has_value());
-    auto put_end_result = service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end_result =
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value());
 
     // Test Case 2: MoveEnd the object, should fail because there is no ongoing
     // move task.
-    move_end_result = service_->MoveEnd(client_id, key);
+    move_end_result = service_->MoveEnd(client_id, key, "default");
     EXPECT_FALSE(move_end_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NO_REPLICATION_TASK, move_end_result.error());
 
     // MoveStart the object to segment_2
-    auto move_start_result =
-        service_->MoveStart(client_id, key, "segment_1", "segment_2");
+    auto move_start_result = service_->MoveStart(client_id, key, "default",
+                                                 "segment_1", "segment_2");
     ASSERT_TRUE(move_start_result.has_value());
 
     // Test Case 3: MoveEnd with an invalid client id, should fail.
-    move_end_result = service_->MoveEnd(invalid_client_id, key);
+    move_end_result = service_->MoveEnd(invalid_client_id, key, "default");
     EXPECT_FALSE(move_end_result.has_value());
     EXPECT_EQ(ErrorCode::ILLEGAL_CLIENT, move_end_result.error());
 
     // Test Case 4: CopyEnd the object, should fail because the ongoing task is
     // Move.
-    auto copy_end_result = service_->CopyEnd(client_id, key);
+    auto copy_end_result = service_->CopyEnd(client_id, key, "default");
     EXPECT_FALSE(copy_end_result.has_value());
     EXPECT_EQ(ErrorCode::INVALID_PARAMS, copy_end_result.error());
 
     // Test Case 5: MoveEnd, should success.
-    move_end_result = service_->MoveEnd(client_id, key);
+    move_end_result = service_->MoveEnd(client_id, key, "default");
     EXPECT_TRUE(move_end_result.has_value());
 
     // Verify we still have 1 replica (the move was successful)
-    auto get_result = service_->GetReplicaList(key);
+    auto get_result = service_->GetReplicaList(key, "default");
     EXPECT_TRUE(get_result.has_value());
     EXPECT_EQ(1, get_result.value().replicas.size());
 
     // MoveStart the object from segment_2 to segment_1 again, then unmount
     // segment_2
-    move_start_result =
-        service_->MoveStart(client_id, key, "segment_2", "segment_1");
+    move_start_result = service_->MoveStart(client_id, key, "default",
+                                            "segment_2", "segment_1");
     ASSERT_TRUE(move_start_result.has_value());
 
     // Unmount segment_2 to simulate source gone
@@ -2538,7 +2646,7 @@ TEST_F(MasterServiceTest, MoveEnd) {
     ASSERT_TRUE(unmount_result.has_value());
 
     // Test Case 6: MoveEnd, should fail because the source is gone.
-    move_end_result = service_->MoveEnd(client_id, key);
+    move_end_result = service_->MoveEnd(client_id, key, "default");
     EXPECT_FALSE(move_end_result.has_value());
     EXPECT_EQ(ErrorCode::REPLICA_IS_GONE, move_end_result.error());
 }
@@ -2557,7 +2665,7 @@ TEST_F(MasterServiceTest, MoveRevoke) {
 
     // Test Case 1: MoveRevoke a non-existent key, should fail.
     auto move_revoke_result =
-        service_->MoveRevoke(client_id, "non_existent_key");
+        service_->MoveRevoke(client_id, "non_existent_key", "default");
     EXPECT_FALSE(move_revoke_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, move_revoke_result.error());
 
@@ -2569,40 +2677,42 @@ TEST_F(MasterServiceTest, MoveRevoke) {
     config.preferred_segment = "segment_1";
 
     auto put_start_result =
-        service_->PutStart(client_id, key, slice_length, config);
+        service_->PutStart(client_id, key, "default", slice_length, config);
     ASSERT_TRUE(put_start_result.has_value());
-    auto put_end_result = service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end_result =
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value());
 
     // Test Case 2: MoveRevoke the object, should fail because there is no
     // ongoing move task.
-    move_revoke_result = service_->MoveRevoke(client_id, key);
+    move_revoke_result = service_->MoveRevoke(client_id, key, "default");
     EXPECT_FALSE(move_revoke_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NO_REPLICATION_TASK,
               move_revoke_result.error());
 
     // MoveStart the object from segment_1 to segment_2
-    auto move_start_result =
-        service_->MoveStart(client_id, key, "segment_1", "segment_2");
+    auto move_start_result = service_->MoveStart(client_id, key, "default",
+                                                 "segment_1", "segment_2");
     ASSERT_TRUE(move_start_result.has_value());
 
     // Test Case 3: MoveRevoke with an invalid client id, should fail.
-    move_revoke_result = service_->MoveRevoke(invalid_client_id, key);
+    move_revoke_result =
+        service_->MoveRevoke(invalid_client_id, key, "default");
     EXPECT_FALSE(move_revoke_result.has_value());
     EXPECT_EQ(ErrorCode::ILLEGAL_CLIENT, move_revoke_result.error());
 
     // Test Case 4: CopyRevoke the object, should fail because the ongoing task
     // is Move.
-    auto copy_revoke_result = service_->CopyRevoke(client_id, key);
+    auto copy_revoke_result = service_->CopyRevoke(client_id, key, "default");
     EXPECT_FALSE(copy_revoke_result.has_value());
     EXPECT_EQ(ErrorCode::INVALID_PARAMS, copy_revoke_result.error());
 
     // Test Case 5: MoveRevoke, should succeed.
-    move_revoke_result = service_->MoveRevoke(client_id, key);
+    move_revoke_result = service_->MoveRevoke(client_id, key, "default");
     EXPECT_TRUE(move_revoke_result.has_value());
 
     // Verify we still have 1 replica (the move was revoked)
-    auto get_result = service_->GetReplicaList(key);
+    auto get_result = service_->GetReplicaList(key, "default");
     EXPECT_TRUE(get_result.has_value());
     auto& replicas = get_result.value().replicas;
     EXPECT_EQ(1, replicas.size());
@@ -2612,8 +2722,8 @@ TEST_F(MasterServiceTest, MoveRevoke) {
 
     // MoveStart the object from segment_1 to segment_2 again, then unmount
     // segment_1
-    move_start_result =
-        service_->MoveStart(client_id, key, "segment_1", "segment_2");
+    move_start_result = service_->MoveStart(client_id, key, "default",
+                                            "segment_1", "segment_2");
     ASSERT_TRUE(move_start_result.has_value());
 
     // Unmount segment_1 to simulate source gone
@@ -2622,11 +2732,11 @@ TEST_F(MasterServiceTest, MoveRevoke) {
     ASSERT_TRUE(unmount_result.has_value());
 
     // Test Case 6: MoveRevoke, should succeed even though the source is gone.
-    move_revoke_result = service_->MoveRevoke(client_id, key);
+    move_revoke_result = service_->MoveRevoke(client_id, key, "default");
     EXPECT_TRUE(move_revoke_result.has_value());
 
     // The object should be erased as there is no replica left.
-    get_result = service_->GetReplicaList(key);
+    get_result = service_->GetReplicaList(key, "default");
     EXPECT_FALSE(get_result.has_value());
 }
 
@@ -2658,26 +2768,27 @@ TEST_F(MasterServiceTest, ProtectCopyMoveSourceFromEviction) {
     config.preferred_segment = "segment_1";
 
     // Put two objects for move and copy tests.
-    auto put_start_result =
-        service_->PutStart(client_id, copy_key, slice_length, config);
+    auto put_start_result = service_->PutStart(client_id, copy_key, "default",
+                                               slice_length, config);
     ASSERT_TRUE(put_start_result.has_value());
     auto put_end_result =
-        service_->PutEnd(client_id, copy_key, ReplicaType::MEMORY);
+        service_->PutEnd(client_id, copy_key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value());
 
-    put_start_result =
-        service_->PutStart(client_id, move_key, slice_length, config);
+    put_start_result = service_->PutStart(client_id, move_key, "default",
+                                          slice_length, config);
     ASSERT_TRUE(put_start_result.has_value());
-    put_end_result = service_->PutEnd(client_id, move_key, ReplicaType::MEMORY);
+    put_end_result =
+        service_->PutEnd(client_id, move_key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value());
 
     // Start copy and move operations.
-    auto copy_start_result =
-        service_->CopyStart(client_id, copy_key, "segment_1", {"segment_2"});
+    auto copy_start_result = service_->CopyStart(client_id, copy_key, "default",
+                                                 "segment_1", {"segment_2"});
     ASSERT_TRUE(copy_start_result.has_value());
 
-    auto move_start_result =
-        service_->MoveStart(client_id, move_key, "segment_1", "segment_2");
+    auto move_start_result = service_->MoveStart(client_id, move_key, "default",
+                                                 "segment_1", "segment_2");
     ASSERT_TRUE(move_start_result.has_value());
 
     // Put more objects to trigger eviction. Do not prefer any segments.
@@ -2685,10 +2796,10 @@ TEST_F(MasterServiceTest, ProtectCopyMoveSourceFromEviction) {
     for (size_t i = 0; i < 128 * (kSegmentSize * 2 / slice_length); ++i) {
         std::string key = "test_key_" + std::to_string(i);
         auto put_start_result =
-            service_->PutStart(client_id, key, slice_length, config);
+            service_->PutStart(client_id, key, "default", slice_length, config);
         if (put_start_result.has_value()) {
-            auto put_end_result =
-                service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+            auto put_end_result = service_->PutEnd(client_id, key, "default",
+                                                   ReplicaType::MEMORY);
             ASSERT_TRUE(put_end_result.has_value());
         } else {
             // wait for eviction to work
@@ -2702,10 +2813,10 @@ TEST_F(MasterServiceTest, ProtectCopyMoveSourceFromEviction) {
     ASSERT_TRUE(remove_all_result > 0);
 
     // Try end copy and move operations, should success.
-    auto copy_end_result = service_->CopyEnd(client_id, copy_key);
+    auto copy_end_result = service_->CopyEnd(client_id, copy_key, "default");
     EXPECT_TRUE(copy_end_result.has_value());
 
-    auto move_end_result = service_->MoveEnd(client_id, move_key);
+    auto move_end_result = service_->MoveEnd(client_id, move_key, "default");
     EXPECT_TRUE(move_end_result.has_value());
 }
 
@@ -2742,26 +2853,27 @@ TEST_F(MasterServiceTest, DiscardTimeoutCopyMove) {
     config.preferred_segment = "segment_1";
 
     // Put two objects for move and copy tests.
-    auto put_start_result =
-        service_->PutStart(client_id, copy_key, slice_length, config);
+    auto put_start_result = service_->PutStart(client_id, copy_key, "default",
+                                               slice_length, config);
     ASSERT_TRUE(put_start_result.has_value());
     auto put_end_result =
-        service_->PutEnd(client_id, copy_key, ReplicaType::MEMORY);
+        service_->PutEnd(client_id, copy_key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value());
 
-    put_start_result =
-        service_->PutStart(client_id, move_key, slice_length, config);
+    put_start_result = service_->PutStart(client_id, move_key, "default",
+                                          slice_length, config);
     ASSERT_TRUE(put_start_result.has_value());
-    put_end_result = service_->PutEnd(client_id, move_key, ReplicaType::MEMORY);
+    put_end_result =
+        service_->PutEnd(client_id, move_key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value());
 
     // Start copy and move operations.
-    auto copy_start_result =
-        service_->CopyStart(client_id, copy_key, "segment_1", {"segment_2"});
+    auto copy_start_result = service_->CopyStart(client_id, copy_key, "default",
+                                                 "segment_1", {"segment_2"});
     ASSERT_TRUE(copy_start_result.has_value());
 
-    auto move_start_result =
-        service_->MoveStart(client_id, move_key, "segment_1", "segment_2");
+    auto move_start_result = service_->MoveStart(client_id, move_key, "default",
+                                                 "segment_1", "segment_2");
     ASSERT_TRUE(move_start_result.has_value());
 
     // Wait for the operations timeout.
@@ -2772,10 +2884,10 @@ TEST_F(MasterServiceTest, DiscardTimeoutCopyMove) {
     for (size_t i = 0; i < 128 * (kSegmentSize * 2 / slice_length); ++i) {
         std::string key = "test_key_" + std::to_string(i);
         auto put_start_result =
-            service_->PutStart(client_id, key, slice_length, config);
+            service_->PutStart(client_id, key, "default", slice_length, config);
         if (put_start_result.has_value()) {
-            auto put_end_result =
-                service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+            auto put_end_result = service_->PutEnd(client_id, key, "default",
+                                                   ReplicaType::MEMORY);
             ASSERT_TRUE(put_end_result.has_value());
         } else {
             // wait for eviction to work
@@ -2785,11 +2897,11 @@ TEST_F(MasterServiceTest, DiscardTimeoutCopyMove) {
 
     // Try end copy and move operations, should fail because the objects are
     // evicted.
-    auto copy_end_result = service_->CopyEnd(client_id, copy_key);
+    auto copy_end_result = service_->CopyEnd(client_id, copy_key, "default");
     EXPECT_FALSE(copy_end_result.has_value());
     EXPECT_EQ(copy_end_result.error(), ErrorCode::OBJECT_NOT_FOUND);
 
-    auto move_end_result = service_->MoveEnd(client_id, move_key);
+    auto move_end_result = service_->MoveEnd(client_id, move_key, "default");
     EXPECT_FALSE(move_end_result.has_value());
     EXPECT_EQ(move_end_result.error(), ErrorCode::OBJECT_NOT_FOUND);
 }
@@ -2835,7 +2947,7 @@ TEST_F(MasterServiceTest, RemoveByRegexComplex) {
         populate_store();
 
         // Action: Remove keys starting with "test_key_"
-        auto remove_result = service_->RemoveByRegex("^test_key_");
+        auto remove_result = service_->RemoveByRegex("^test_key_", "default");
         ASSERT_TRUE(remove_result.has_value());
         EXPECT_EQ(remove_result.value(), 3);  // Should remove 3 keys
 
@@ -2843,7 +2955,7 @@ TEST_F(MasterServiceTest, RemoveByRegexComplex) {
         std::vector<std::string> deleted_keys = {"test_key_01", "test_key_02",
                                                  "test_key_10"};
         for (const auto& key : deleted_keys) {
-            auto exist_result = service_->ExistKey(key);
+            auto exist_result = service_->ExistKey(key, "default");
             ASSERT_TRUE(exist_result.has_value());
             EXPECT_FALSE(exist_result.value())
                 << "Key " << key << " should have been deleted.";
@@ -2852,7 +2964,7 @@ TEST_F(MasterServiceTest, RemoveByRegexComplex) {
         std::vector<std::string> remaining_keys = {
             "prod_key_alpha", "short", "test-key-extra"};  // Sample a few
         for (const auto& key : remaining_keys) {
-            auto exist_result = service_->ExistKey(key);
+            auto exist_result = service_->ExistKey(key, "default");
             ASSERT_TRUE(exist_result.has_value());
             EXPECT_TRUE(exist_result.value())
                 << "Key " << key << " should NOT have been deleted.";
@@ -2875,12 +2987,12 @@ TEST_F(MasterServiceTest, RemoveByRegexComplex) {
         size_t total_keys = 13;  // Count from the keys_to_put vector
 
         // Action: Remove all keys
-        auto remove_result = service_->RemoveByRegex(".*");
+        auto remove_result = service_->RemoveByRegex(".*", "default");
         ASSERT_TRUE(remove_result.has_value());
         EXPECT_EQ(remove_result.value(), total_keys);
 
         // Verification: Check that no keys remain
-        auto get_all_result = service_->GetReplicaListByRegex(".*");
+        auto get_all_result = service_->GetReplicaListByRegex(".*", "default");
         ASSERT_TRUE(get_all_result.has_value());
         EXPECT_TRUE(get_all_result.value().empty());
     }
@@ -2900,12 +3012,13 @@ TEST_F(MasterServiceTest, RemoveByRegexComplex) {
         size_t total_keys_before_remove = 13;
 
         // Action: Attempt to remove using a pattern that matches nothing
-        auto remove_result = service_->RemoveByRegex("^nonexistent-pattern-");
+        auto remove_result =
+            service_->RemoveByRegex("^nonexistent-pattern-", "default");
         ASSERT_TRUE(remove_result.has_value());
         EXPECT_EQ(remove_result.value(), 0);  // Should remove 0 keys
 
         // Verification: Check that all keys still exist
-        auto get_all_result = service_->GetReplicaListByRegex(".*");
+        auto get_all_result = service_->GetReplicaListByRegex(".*", "default");
         ASSERT_TRUE(get_all_result.has_value());
         EXPECT_EQ(get_all_result.value().size(), total_keys_before_remove);
     }
@@ -2923,7 +3036,7 @@ TEST_F(MasterServiceTest, RemoveByRegexComplex) {
         populate_store();
 
         // Action: Remove all keys that contain a slash '/' OR end with a number
-        auto remove_result = service_->RemoveByRegex("/|\\d$");
+        auto remove_result = service_->RemoveByRegex("/|\\d$", "default");
         ASSERT_TRUE(remove_result.has_value());
         // Matches: "config/user/settings.json", "logs/app-2025-08-13.log",
         //          "test_key_01", "test_key_02", "test_key_10"
@@ -2948,23 +3061,25 @@ TEST_F(MasterServiceTest, RemoveByRegexComplex) {
         populate_store();
 
         // Action: Remove all keys that contain "chunk" OR "config"
-        auto remove_result = service_->RemoveByRegex("chunk|config");
+        auto remove_result = service_->RemoveByRegex("chunk|config", "default");
         ASSERT_TRUE(remove_result.has_value());
         // Matches: "data_part_1_chunk_a", "data_part_2_chunk_b",
         // "config/user/settings.json"
         EXPECT_EQ(remove_result.value(), 3);
 
         // Verification
-        auto exist_result_chunk = service_->ExistKey("data_part_1_chunk_a");
+        auto exist_result_chunk =
+            service_->ExistKey("data_part_1_chunk_a", "default");
         ASSERT_TRUE(exist_result_chunk.has_value());
         EXPECT_FALSE(exist_result_chunk.value());
 
         auto exist_result_config =
-            service_->ExistKey("config/user/settings.json");
+            service_->ExistKey("config/user/settings.json", "default");
         ASSERT_TRUE(exist_result_config.has_value());
         EXPECT_FALSE(exist_result_config.value());
 
-        auto exist_result_untouched = service_->ExistKey("prod_key_alpha");
+        auto exist_result_untouched =
+            service_->ExistKey("prod_key_alpha", "default");
         ASSERT_TRUE(exist_result_untouched.has_value());
         EXPECT_TRUE(exist_result_untouched.value());
     }
@@ -2985,12 +3100,12 @@ TEST_F(MasterServiceTest, RemoveAll) {
         ReplicateConfig config;
         config.replica_num = 1;
         auto put_start_result =
-            service_->PutStart(client_id, key, value_length, config);
+            service_->PutStart(client_id, key, "default", value_length, config);
         ASSERT_TRUE(put_start_result.has_value());
         auto put_end_result =
-            service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+            service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
         ASSERT_TRUE(put_end_result.has_value());
-        auto exist_result = service_->ExistKey(key);
+        auto exist_result = service_->ExistKey(key, "default");
         ASSERT_TRUE(exist_result.has_value());
     }
     // wait for all the lease to expire
@@ -2999,7 +3114,7 @@ TEST_F(MasterServiceTest, RemoveAll) {
     times = 10;
     while (times--) {
         std::string key = "test_key" + std::to_string(times);
-        auto exist_result = service_->ExistKey(key);
+        auto exist_result = service_->ExistKey(key, "default");
         ASSERT_TRUE(exist_result.has_value());
         ASSERT_FALSE(exist_result.value());
     }
@@ -3034,7 +3149,7 @@ TEST_F(MasterServiceTest, SingleSliceMultiReplicaFlow) {
 
     // Test PutStart with multiple slices and replicas
     auto put_start_result =
-        service_->PutStart(client_id, key, slice_length, config);
+        service_->PutStart(client_id, key, "default", slice_length, config);
     ASSERT_TRUE(put_start_result.has_value());
     replica_list = put_start_result.value();
 
@@ -3050,16 +3165,17 @@ TEST_F(MasterServiceTest, SingleSliceMultiReplicaFlow) {
     }
 
     // Test GetReplicaList during processing (should fail)
-    auto get_result = service_->GetReplicaList(key);
+    auto get_result = service_->GetReplicaList(key, "default");
     EXPECT_FALSE(get_result.has_value());
     EXPECT_EQ(ErrorCode::REPLICA_IS_NOT_READY, get_result.error());
 
     // Complete the put operation
-    auto put_end_result = service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end_result =
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value());
 
     // Test GetReplicaList after completion
-    auto get_result2 = service_->GetReplicaList(key);
+    auto get_result2 = service_->GetReplicaList(key, "default");
     ASSERT_TRUE(get_result2.has_value());
     auto retrieved_replicas = get_result2.value().replicas;
     ASSERT_EQ(num_replicas, retrieved_replicas.size());
@@ -3093,13 +3209,14 @@ TEST_F(MasterServiceTest, CleanupStaleHandlesTest) {
 
     // Create the object
     auto put_start_result =
-        service_->PutStart(client_id, key, slice_length, config);
+        service_->PutStart(client_id, key, "default", slice_length, config);
     ASSERT_TRUE(put_start_result.has_value());
-    auto put_end_result = service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end_result =
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value());
 
     // Verify object exists
-    auto get_result = service_->GetReplicaList(key);
+    auto get_result = service_->GetReplicaList(key, "default");
     ASSERT_TRUE(get_result.has_value());
     auto retrieved_replicas = get_result.value().replicas;
     ASSERT_EQ(1, retrieved_replicas.size());
@@ -3110,7 +3227,7 @@ TEST_F(MasterServiceTest, CleanupStaleHandlesTest) {
 
     // Try to get the object - it should be automatically removed since the
     // replica is invalid
-    auto get_result2 = service_->GetReplicaList(key);
+    auto get_result2 = service_->GetReplicaList(key, "default");
     EXPECT_FALSE(get_result2.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, get_result2.error());
 
@@ -3121,14 +3238,14 @@ TEST_F(MasterServiceTest, CleanupStaleHandlesTest) {
     // Create another object
     std::string key2 = "another_segment_object";
     auto put_start_result2 =
-        service_->PutStart(client_id, key2, slice_length, config);
+        service_->PutStart(client_id, key2, "default", slice_length, config);
     ASSERT_TRUE(put_start_result2.has_value());
     auto put_end_result2 =
-        service_->PutEnd(client_id, key2, ReplicaType::MEMORY);
+        service_->PutEnd(client_id, key2, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result2.has_value());
 
     // Verify we can get it
-    auto get_result3 = service_->GetReplicaList(key2);
+    auto get_result3 = service_->GetReplicaList(key2, "default");
     ASSERT_TRUE(get_result3.has_value());
 
     // Unmount the segment
@@ -3136,7 +3253,7 @@ TEST_F(MasterServiceTest, CleanupStaleHandlesTest) {
     ASSERT_TRUE(unmount_result2.has_value());
 
     // Try to remove the object that should already be cleaned up
-    auto remove_result = service_->Remove(key2);
+    auto remove_result = service_->Remove(key2, "default");
     EXPECT_FALSE(remove_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, remove_result.error());
 }
@@ -3168,11 +3285,11 @@ TEST_F(MasterServiceTest, ConcurrentWriteAndRemoveAll) {
                 config.replica_num = 1;
                 std::vector<Replica::Descriptor> replica_list;
 
-                auto put_start_result =
-                    service_->PutStart(client_id, key, slice_length, config);
+                auto put_start_result = service_->PutStart(
+                    client_id, key, "default", slice_length, config);
                 if (put_start_result.has_value()) {
-                    auto put_end_result =
-                        service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+                    auto put_end_result = service_->PutEnd(
+                        client_id, key, "default", ReplicaType::MEMORY);
                     if (put_end_result.has_value()) {
                         success_writes++;
                     }
@@ -3238,10 +3355,10 @@ TEST_F(MasterServiceTest, ConcurrentReadAndRemoveAll) {
         config.replica_num = 1;
 
         auto put_start_result =
-            service_->PutStart(client_id, key, slice_length, config);
+            service_->PutStart(client_id, key, "default", slice_length, config);
         ASSERT_TRUE(put_start_result.has_value());
         auto put_end_result =
-            service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+            service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
         ASSERT_TRUE(put_end_result.has_value());
     }
 
@@ -3254,7 +3371,7 @@ TEST_F(MasterServiceTest, ConcurrentReadAndRemoveAll) {
         readers.emplace_back([&]() {
             for (int j = 0; j < num_objects; ++j) {
                 std::string key = "pre_key_" + std::to_string(j);
-                auto get_result = service_->GetReplicaList(key);
+                auto get_result = service_->GetReplicaList(key, "default");
                 if (get_result.has_value()) {
                     success_reads++;
                 }
@@ -3295,7 +3412,7 @@ TEST_F(MasterServiceTest, ConcurrentReadAndRemoveAll) {
     // Verify all objects were removed
     for (int i = 0; i < num_objects; ++i) {
         std::string key = "pre_key_" + std::to_string(i);
-        auto get_result = service_->GetReplicaList(key);
+        auto get_result = service_->GetReplicaList(key, "default");
         EXPECT_FALSE(get_result.has_value());
         EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, get_result.error());
     }
@@ -3319,10 +3436,10 @@ TEST_F(MasterServiceTest, ConcurrentRemoveAllOperations) {
         config.replica_num = 1;
 
         auto put_start_result =
-            service_->PutStart(client_id, key, slice_length, config);
+            service_->PutStart(client_id, key, "default", slice_length, config);
         ASSERT_TRUE(put_start_result.has_value());
         auto put_end_result =
-            service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+            service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
         ASSERT_TRUE(put_end_result.has_value());
     }
 
@@ -3349,7 +3466,7 @@ TEST_F(MasterServiceTest, ConcurrentRemoveAllOperations) {
     // Verify all objects were removed
     for (int i = 0; i < num_objects; ++i) {
         std::string key = "pre_key_" + std::to_string(i);
-        auto get_result = service_->GetReplicaList(key);
+        auto get_result = service_->GetReplicaList(key, "default");
         EXPECT_FALSE(get_result.has_value());
         EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, get_result.error());
     }
@@ -3386,23 +3503,23 @@ TEST_F(MasterServiceTest, UnmountSegmentImmediateCleanup) {
     // Umount will remove all objects in the segment, include the key1
     ASSERT_EQ(1, service_->GetKeyCount());
     // Verify objects in segment1 is gone
-    auto get_result1 = service_->GetReplicaList(key1);
+    auto get_result1 = service_->GetReplicaList(key1, "default");
     ASSERT_FALSE(get_result1.has_value());
     ASSERT_EQ(ErrorCode::OBJECT_NOT_FOUND, get_result1.error());
 
     // Verify objects in segment2 is still there
-    auto get_result2 = service_->GetReplicaList(key2);
+    auto get_result2 = service_->GetReplicaList(key2, "default");
     ASSERT_TRUE(get_result2.has_value());
 
     // Verify put key1 will put into segment2 rather than segment1
     auto put_start_result =
-        service_->PutStart(client_id, key1, slice_length, config);
+        service_->PutStart(client_id, key1, "default", slice_length, config);
     ASSERT_TRUE(put_start_result.has_value());
     replica_list = put_start_result.value();
     auto put_end_result =
-        service_->PutEnd(client_id, key1, ReplicaType::MEMORY);
+        service_->PutEnd(client_id, key1, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value());
-    auto get_result3 = service_->GetReplicaList(key1);
+    auto get_result3 = service_->GetReplicaList(key1, "default");
     ASSERT_TRUE(get_result3.has_value());
     auto retrieved = get_result3.value();
     ASSERT_EQ(replica_list[0]
@@ -3435,14 +3552,14 @@ TEST_F(MasterServiceTest, ReadableAfterPartialUnmountWithReplication) {
     config.replica_num = 2;
 
     auto put_start_result =
-        service_->PutStart(client_id, key, slice_length, config);
+        service_->PutStart(client_id, key, "default", slice_length, config);
     ASSERT_TRUE(put_start_result.has_value());
     ASSERT_EQ(2u, put_start_result->size());
-    ASSERT_TRUE(
-        service_->PutEnd(client_id, key, ReplicaType::MEMORY).has_value());
+    ASSERT_TRUE(service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY)
+                    .has_value());
 
     // Verify two replicas exist and they are on distinct segments
-    auto get_result = service_->GetReplicaList(key);
+    auto get_result = service_->GetReplicaList(key, "default");
     ASSERT_TRUE(get_result.has_value());
     auto replicas = get_result.value().replicas;
     ASSERT_EQ(2u, replicas.size());
@@ -3460,7 +3577,7 @@ TEST_F(MasterServiceTest, ReadableAfterPartialUnmountWithReplication) {
     ASSERT_TRUE(service_->UnmountSegment(segment1.id, client_id).has_value());
 
     // Key should still be readable via the remaining replica
-    auto get_after_unmount = service_->GetReplicaList(key);
+    auto get_after_unmount = service_->GetReplicaList(key, "default");
     ASSERT_TRUE(get_after_unmount.has_value())
         << "Object should remain accessible with surviving replica";
 }
@@ -3510,7 +3627,7 @@ TEST_F(MasterServiceTest, UnmountSegmentPerformance) {
 
     // Verify all keys are gone
     for (const auto& key : keys) {
-        auto get_result = service_->GetReplicaList(key);
+        auto get_result = service_->GetReplicaList(key, "default");
         EXPECT_FALSE(get_result.has_value());
         EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, get_result.error());
     }
@@ -3541,75 +3658,76 @@ TEST_F(MasterServiceTest, RemoveLeasedObject) {
 
     // Verify lease is granted on ExistsKey
     auto put_start_result =
-        service_->PutStart(client_id, key, slice_length, config);
+        service_->PutStart(client_id, key, "default", slice_length, config);
     ASSERT_TRUE(put_start_result.has_value());
-    auto put_end_result = service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end_result =
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value());
-    auto exist_result = service_->ExistKey(key);
+    auto exist_result = service_->ExistKey(key, "default");
     ASSERT_TRUE(exist_result.has_value());
-    auto remove_result = service_->Remove(key);
+    auto remove_result = service_->Remove(key, "default");
     EXPECT_FALSE(remove_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_HAS_LEASE, remove_result.error());
     std::this_thread::sleep_for(std::chrono::milliseconds(kv_lease_ttl));
-    auto remove_result2 = service_->Remove(key);
+    auto remove_result2 = service_->Remove(key, "default");
     EXPECT_TRUE(remove_result2.has_value());
 
     // Verify lease is extended on successive ExistsKey
     auto put_start_result2 =
-        service_->PutStart(client_id, key, slice_length, config);
+        service_->PutStart(client_id, key, "default", slice_length, config);
     ASSERT_TRUE(put_start_result2.has_value());
     auto put_end_result2 =
-        service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result2.has_value());
-    auto exist_result2 = service_->ExistKey(key);
+    auto exist_result2 = service_->ExistKey(key, "default");
     ASSERT_TRUE(exist_result2.has_value());
     std::this_thread::sleep_for(std::chrono::milliseconds(kv_lease_ttl));
-    auto exist_result3 = service_->ExistKey(key);
+    auto exist_result3 = service_->ExistKey(key, "default");
     ASSERT_TRUE(exist_result3.has_value());
-    auto remove_result3 = service_->Remove(key);
+    auto remove_result3 = service_->Remove(key, "default");
     EXPECT_FALSE(remove_result3.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_HAS_LEASE, remove_result3.error());
     std::this_thread::sleep_for(std::chrono::milliseconds(kv_lease_ttl));
-    auto remove_result4 = service_->Remove(key);
+    auto remove_result4 = service_->Remove(key, "default");
     EXPECT_TRUE(remove_result4.has_value());
 
     // Verify lease is granted on GetReplicaList
     auto put_start_result3 =
-        service_->PutStart(client_id, key, slice_length, config);
+        service_->PutStart(client_id, key, "default", slice_length, config);
     ASSERT_TRUE(put_start_result3.has_value());
     auto put_end_result3 =
-        service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result3.has_value());
-    auto get_result = service_->GetReplicaList(key);
+    auto get_result = service_->GetReplicaList(key, "default");
     ASSERT_TRUE(get_result.has_value());
-    auto remove_result5 = service_->Remove(key);
+    auto remove_result5 = service_->Remove(key, "default");
     EXPECT_FALSE(remove_result5.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_HAS_LEASE, remove_result5.error());
     std::this_thread::sleep_for(std::chrono::milliseconds(kv_lease_ttl));
-    auto remove_result6 = service_->Remove(key);
+    auto remove_result6 = service_->Remove(key, "default");
     EXPECT_TRUE(remove_result6.has_value());
 
     // Verify lease is extended on successive GetReplicaList
     auto put_start_result4 =
-        service_->PutStart(client_id, key, slice_length, config);
+        service_->PutStart(client_id, key, "default", slice_length, config);
     ASSERT_TRUE(put_start_result4.has_value());
     auto put_end_result4 =
-        service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result4.has_value());
-    auto get_result2 = service_->GetReplicaList(key);
+    auto get_result2 = service_->GetReplicaList(key, "default");
     ASSERT_TRUE(get_result2.has_value());
     std::this_thread::sleep_for(std::chrono::milliseconds(kv_lease_ttl));
-    auto get_result3 = service_->GetReplicaList(key);
+    auto get_result3 = service_->GetReplicaList(key, "default");
     ASSERT_TRUE(get_result3.has_value());
-    auto remove_result7 = service_->Remove(key);
+    auto remove_result7 = service_->Remove(key, "default");
     EXPECT_FALSE(remove_result7.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_HAS_LEASE, remove_result7.error());
     std::this_thread::sleep_for(std::chrono::milliseconds(kv_lease_ttl));
-    auto remove_result8 = service_->Remove(key);
+    auto remove_result8 = service_->Remove(key, "default");
     EXPECT_TRUE(remove_result8.has_value());
 
     // Verify object is removed
-    auto get_result4 = service_->GetReplicaList(key);
+    auto get_result4 = service_->GetReplicaList(key, "default");
     EXPECT_FALSE(get_result4.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, get_result4.error());
 }
@@ -3628,20 +3746,20 @@ TEST_F(MasterServiceTest, RemoveAllLeasedObject) {
         ReplicateConfig config;
         config.replica_num = 1;
         auto put_start_result =
-            service_->PutStart(client_id, key, slice_length, config);
+            service_->PutStart(client_id, key, "default", slice_length, config);
         ASSERT_TRUE(put_start_result.has_value());
         auto put_end_result =
-            service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+            service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
         ASSERT_TRUE(put_end_result.has_value());
         if (i >= 5) {
-            auto exist_result = service_->ExistKey(key);
+            auto exist_result = service_->ExistKey(key, "default");
             ASSERT_TRUE(exist_result.has_value());
         }
     }
     ASSERT_EQ(5, service_->RemoveAll());
     for (int i = 0; i < 5; ++i) {
         std::string key = "test_key" + std::to_string(i);
-        auto exist_result = service_->ExistKey(key);
+        auto exist_result = service_->ExistKey(key, "default");
         ASSERT_FALSE(exist_result.value());
     }
     // wait for all the lease to expire
@@ -3649,7 +3767,7 @@ TEST_F(MasterServiceTest, RemoveAllLeasedObject) {
     ASSERT_EQ(5, service_->RemoveAll());
     for (int i = 5; i < 10; ++i) {
         std::string key = "test_key" + std::to_string(i);
-        auto exist_result = service_->ExistKey(key);
+        auto exist_result = service_->ExistKey(key, "default");
         ASSERT_FALSE(exist_result.value());
     }
 }
@@ -3680,10 +3798,10 @@ TEST_F(MasterServiceTest, EvictObject) {
         ReplicateConfig config;
         config.replica_num = 1;
         auto put_start_result =
-            service_->PutStart(client_id, key, slice_length, config);
+            service_->PutStart(client_id, key, "default", slice_length, config);
         if (put_start_result.has_value()) {
-            auto put_end_result =
-                service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+            auto put_end_result = service_->PutEnd(client_id, key, "default",
+                                                   ReplicaType::MEMORY);
             ASSERT_TRUE(put_end_result.has_value());
             success_puts++;
         } else {
@@ -3720,13 +3838,13 @@ TEST_F(MasterServiceTest, TryEvictLeasedObject) {
         ReplicateConfig config;
         config.replica_num = 1;
         auto put_start_result =
-            service_->PutStart(client_id, key, slice_length, config);
+            service_->PutStart(client_id, key, "default", slice_length, config);
         if (put_start_result.has_value()) {
-            auto put_end_result =
-                service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+            auto put_end_result = service_->PutEnd(client_id, key, "default",
+                                                   ReplicaType::MEMORY);
             ASSERT_TRUE(put_end_result.has_value());
             // the object is leased
-            auto get_result = service_->GetReplicaList(key);
+            auto get_result = service_->GetReplicaList(key, "default");
             ASSERT_TRUE(get_result.has_value());
             leased_keys.push_back(key);
             success_puts++;
@@ -3740,7 +3858,7 @@ TEST_F(MasterServiceTest, TryEvictLeasedObject) {
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
     // All leased objects should be accessible
     for (const auto& key : leased_keys) {
-        auto get_result = service_->GetReplicaList(key);
+        auto get_result = service_->GetReplicaList(key, "default");
         ASSERT_TRUE(get_result.has_value());
     }
     std::this_thread::sleep_for(std::chrono::milliseconds(kv_lease_ttl));
@@ -3774,16 +3892,18 @@ TEST_F(MasterServiceTest, RemoveSoftPinObject) {
 
     // Verify soft pin does not block remove
     ASSERT_TRUE(
-        service_->PutStart(client_id, key, slice_length, config).has_value());
-    ASSERT_TRUE(
-        service_->PutEnd(client_id, key, ReplicaType::MEMORY).has_value());
-    EXPECT_TRUE(service_->Remove(key).has_value());
+        service_->PutStart(client_id, key, "default", slice_length, config)
+            .has_value());
+    ASSERT_TRUE(service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY)
+                    .has_value());
+    EXPECT_TRUE(service_->Remove(key, "default").has_value());
 
     // Verify soft pin does not block RemoveAll
     ASSERT_TRUE(
-        service_->PutStart(client_id, key, slice_length, config).has_value());
-    ASSERT_TRUE(
-        service_->PutEnd(client_id, key, ReplicaType::MEMORY).has_value());
+        service_->PutStart(client_id, key, "default", slice_length, config)
+            .has_value());
+    ASSERT_TRUE(service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY)
+                    .has_value());
     EXPECT_EQ(1, service_->RemoveAll());
 }
 
@@ -3821,11 +3941,12 @@ TEST_F(MasterServiceTest, SoftPinObjectsNotEvictedBeforeOtherObjects) {
             soft_pin_config.with_soft_pin = true;
 
             ASSERT_TRUE(service_
-                            ->PutStart(client_id, pin_key, slice_length,
-                                       soft_pin_config)
+                            ->PutStart(client_id, pin_key, "default",
+                                       slice_length, soft_pin_config)
                             .has_value());
             ASSERT_TRUE(
-                service_->PutEnd(client_id, pin_key, ReplicaType::MEMORY)
+                service_
+                    ->PutEnd(client_id, pin_key, "default", ReplicaType::MEMORY)
                     .has_value());
         }
 
@@ -3836,10 +3957,12 @@ TEST_F(MasterServiceTest, SoftPinObjectsNotEvictedBeforeOtherObjects) {
             uint64_t slice_length = value_size;
             ReplicateConfig config;
             config.replica_num = 1;
-            if (service_->PutStart(client_id, key, slice_length, config)
+            if (service_
+                    ->PutStart(client_id, key, "default", slice_length, config)
                     .has_value()) {
                 ASSERT_TRUE(
-                    service_->PutEnd(client_id, key, ReplicaType::MEMORY)
+                    service_
+                        ->PutEnd(client_id, key, "default", ReplicaType::MEMORY)
                         .has_value());
             } else {
                 failed_puts++;
@@ -3852,7 +3975,8 @@ TEST_F(MasterServiceTest, SoftPinObjectsNotEvictedBeforeOtherObjects) {
         // pin_key should still be accessible
         for (int i = 0; i < 2; i++) {
             std::string pin_key = "pin_key" + std::to_string(i);
-            ASSERT_TRUE(service_->GetReplicaList(pin_key).has_value());
+            ASSERT_TRUE(
+                service_->GetReplicaList(pin_key, "default").has_value());
         }
 
         // wait for the lease to expire
@@ -3891,10 +4015,11 @@ TEST_F(MasterServiceTest, SoftPinObjectsCanBeEvicted) {
         ReplicateConfig config;
         config.replica_num = 1;
         config.with_soft_pin = true;
-        if (service_->PutStart(client_id, key, slice_length, config)
+        if (service_->PutStart(client_id, key, "default", slice_length, config)
                 .has_value()) {
-            ASSERT_TRUE(service_->PutEnd(client_id, key, ReplicaType::MEMORY)
-                            .has_value());
+            ASSERT_TRUE(
+                service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY)
+                    .has_value());
             success_puts++;
         } else {
             // wait for eviction to work
@@ -3943,10 +4068,11 @@ TEST_F(MasterServiceTest, SoftPinExtendedOnGet) {
             soft_pin_config.replica_num = 1;
             soft_pin_config.with_soft_pin = true;
 
-            ASSERT_TRUE(service_->PutStart(client_id, pin_key, slice_length,
-                                           soft_pin_config));
+            ASSERT_TRUE(service_->PutStart(client_id, pin_key, "default",
+                                           slice_length, soft_pin_config));
             ASSERT_TRUE(
-                service_->PutEnd(client_id, pin_key, ReplicaType::MEMORY)
+                service_
+                    ->PutEnd(client_id, pin_key, "default", ReplicaType::MEMORY)
                     .has_value());
         }
 
@@ -3956,7 +4082,8 @@ TEST_F(MasterServiceTest, SoftPinExtendedOnGet) {
         // Get the pin_key to extend the soft pin
         for (int i = 0; i < 2; i++) {
             std::string pin_key = "pin_key" + std::to_string(i);
-            ASSERT_TRUE(service_->GetReplicaList(pin_key).has_value());
+            ASSERT_TRUE(
+                service_->GetReplicaList(pin_key, "default").has_value());
         }
 
         // Fill the segment to trigger eviction
@@ -3966,10 +4093,12 @@ TEST_F(MasterServiceTest, SoftPinExtendedOnGet) {
             uint64_t slice_length = value_size;
             ReplicateConfig config;
             config.replica_num = 1;
-            if (service_->PutStart(client_id, key, slice_length, config)
+            if (service_
+                    ->PutStart(client_id, key, "default", slice_length, config)
                     .has_value()) {
                 ASSERT_TRUE(
-                    service_->PutEnd(client_id, key, ReplicaType::MEMORY)
+                    service_
+                        ->PutEnd(client_id, key, "default", ReplicaType::MEMORY)
                         .has_value());
             } else {
                 failed_puts++;
@@ -3983,7 +4112,8 @@ TEST_F(MasterServiceTest, SoftPinExtendedOnGet) {
         // pin_key should still be accessible
         for (int i = 0; i < 2; i++) {
             std::string pin_key = "pin_key" + std::to_string(i);
-            ASSERT_TRUE(service_->GetReplicaList(pin_key).has_value());
+            ASSERT_TRUE(
+                service_->GetReplicaList(pin_key, "default").has_value());
         }
 
         // wait for the lease to expire
@@ -4024,10 +4154,11 @@ TEST_F(MasterServiceTest, SoftPinObjectsNotAllowEvict) {
         ReplicateConfig config;
         config.replica_num = 1;
         config.with_soft_pin = true;
-        if (service_->PutStart(client_id, key, slice_length, config)
+        if (service_->PutStart(client_id, key, "default", slice_length, config)
                 .has_value()) {
-            ASSERT_TRUE(service_->PutEnd(client_id, key, ReplicaType::MEMORY)
-                            .has_value());
+            ASSERT_TRUE(
+                service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY)
+                    .has_value());
             success_keys.push_back(key);
         } else {
             // wait for eviction to work
@@ -4037,7 +4168,7 @@ TEST_F(MasterServiceTest, SoftPinObjectsNotAllowEvict) {
     ASSERT_LE(success_keys.size(), 17);
     // All soft pinned objects should be accessible
     for (const auto& key : success_keys) {
-        ASSERT_TRUE(service_->GetReplicaList(key).has_value());
+        ASSERT_TRUE(service_->GetReplicaList(key, "default").has_value());
     }
     std::this_thread::sleep_for(std::chrono::milliseconds(kv_lease_ttl));
     service_->RemoveAll();
@@ -4063,7 +4194,7 @@ TEST_F(MasterServiceTest, ReplicaSegmentsAreUnique) {
     config.replica_num = 10;
 
     auto put_start_result =
-        service_->PutStart(client_id, key, slice_length, config);
+        service_->PutStart(client_id, key, "default", slice_length, config);
     ASSERT_TRUE(put_start_result.has_value());
     auto replica_list_local = put_start_result.value();
     ASSERT_EQ(config.replica_num, replica_list_local.size());
@@ -4079,8 +4210,8 @@ TEST_F(MasterServiceTest, ReplicaSegmentsAreUnique) {
     EXPECT_EQ(segment_names.size(), config.replica_num)
         << "Duplicate segment found";
 
-    ASSERT_TRUE(
-        service_->PutEnd(client_id, key, ReplicaType::MEMORY).has_value());
+    ASSERT_TRUE(service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY)
+                    .has_value());
 }
 
 TEST_F(MasterServiceTest, ReplicationFactorTwoWithSingleSegment) {
@@ -4101,7 +4232,7 @@ TEST_F(MasterServiceTest, ReplicationFactorTwoWithSingleSegment) {
     config.replica_num = 2;
 
     auto put_start_result =
-        service_->PutStart(client_id, key, slice_length, config);
+        service_->PutStart(client_id, key, "default", slice_length, config);
     ASSERT_TRUE(put_start_result.has_value());
     auto replicas = put_start_result.value();
 
@@ -4133,23 +4264,23 @@ TEST_F(MasterServiceTest, BatchExistKeyTest) {
         ReplicateConfig config;
         config.replica_num = 1;
         uint64_t slice_length = value_size;
-        auto put_start_result =
-            service_->PutStart(client_id, test_keys[i], slice_length, config);
+        auto put_start_result = service_->PutStart(
+            client_id, test_keys[i], "default", slice_length, config);
         ASSERT_TRUE(put_start_result.has_value());
-        auto put_end_result =
-            service_->PutEnd(client_id, test_keys[i], ReplicaType::MEMORY);
+        auto put_end_result = service_->PutEnd(client_id, test_keys[i],
+                                               "default", ReplicaType::MEMORY);
         ASSERT_TRUE(put_end_result.has_value());
     }
 
     // Test individual ExistKey calls to verify the underlying functionality
     for (int i = 0; i < test_object_num; ++i) {
-        auto exist_result = service_->ExistKey(test_keys[i]);
+        auto exist_result = service_->ExistKey(test_keys[i], "default");
         EXPECT_TRUE(exist_result.value());
     }
 
     // Tets batch
     test_keys.push_back("non_existent_key");
-    auto exist_resp = service_->BatchExistKey(test_keys);
+    auto exist_resp = service_->BatchExistKey(test_keys, "default");
     for (int i = 0; i < test_object_num; ++i) {
         ASSERT_TRUE(exist_resp[i].value());
     }
@@ -4443,7 +4574,7 @@ TEST_F(MasterServiceTest, PutStartExpiringTest) {
 
     // Put key_1, should success.
     auto put_start_result =
-        service_->PutStart(client_id, key_1, slice_length, config);
+        service_->PutStart(client_id, key_1, "default", slice_length, config);
     EXPECT_TRUE(put_start_result.has_value());
     replica_list = put_start_result.value();
     EXPECT_EQ(replica_list.size(), kReplicaCnt);
@@ -4453,7 +4584,7 @@ TEST_F(MasterServiceTest, PutStartExpiringTest) {
 
     // Put key_1 again, should fail because the key exists.
     put_start_result =
-        service_->PutStart(client_id, key_1, slice_length, config);
+        service_->PutStart(client_id, key_1, "default", slice_length, config);
     EXPECT_FALSE(put_start_result.has_value());
     EXPECT_EQ(put_start_result.error(), ErrorCode::OBJECT_ALREADY_EXISTS);
 
@@ -4469,7 +4600,7 @@ TEST_F(MasterServiceTest, PutStartExpiringTest) {
     // Put key_1 again, should success because the old one has expired and will
     // be discarded by this put.
     put_start_result =
-        service_->PutStart(client_id, key_1, slice_length, config);
+        service_->PutStart(client_id, key_1, "default", slice_length, config);
     EXPECT_TRUE(put_start_result.has_value());
     replica_list = put_start_result.value();
     EXPECT_EQ(replica_list.size(), kReplicaCnt);
@@ -4479,17 +4610,17 @@ TEST_F(MasterServiceTest, PutStartExpiringTest) {
 
     // Complete key_1.
     auto put_end_result =
-        service_->PutEnd(client_id, key_1, ReplicaType::MEMORY);
+        service_->PutEnd(client_id, key_1, "default", ReplicaType::MEMORY);
     EXPECT_TRUE(put_end_result.has_value());
 
     // Protect key_1 from eviction.
-    auto get_result = service_->GetReplicaList(key_1);
+    auto get_result = service_->GetReplicaList(key_1, "default");
     EXPECT_TRUE(get_result.has_value());
 
     // Put key_2, should fail because the key_1 occupied 12MB (6MB processing,
     // 6MB discarded but not yet released) on each segment.
     put_start_result =
-        service_->PutStart(client_id, key_2, slice_length, config);
+        service_->PutStart(client_id, key_2, "default", slice_length, config);
     EXPECT_FALSE(put_start_result.has_value());
     EXPECT_EQ(put_start_result.error(), ErrorCode::NO_AVAILABLE_HANDLE);
 
@@ -4502,7 +4633,7 @@ TEST_F(MasterServiceTest, PutStartExpiringTest) {
             EXPECT_TRUE(result.has_value());
         }
         // Protect key_1 from eviction.
-        auto get_result = service_->GetReplicaList(key_1);
+        auto get_result = service_->GetReplicaList(key_1, "default");
         EXPECT_TRUE(get_result.has_value());
         std::this_thread::sleep_for(std::chrono::seconds(1));
     }
@@ -4510,7 +4641,7 @@ TEST_F(MasterServiceTest, PutStartExpiringTest) {
     // Put key_2 again, should success because the discarded replica has been
     // released.
     put_start_result =
-        service_->PutStart(client_id, key_2, slice_length, config);
+        service_->PutStart(client_id, key_2, "default", slice_length, config);
     EXPECT_TRUE(put_start_result.has_value());
     replica_list = put_start_result.value();
     EXPECT_EQ(replica_list.size(), kReplicaCnt);
@@ -4525,7 +4656,7 @@ TEST_F(MasterServiceTest, PutStartExpiringTest) {
             EXPECT_TRUE(result.has_value());
         }
         // Protect key_1 from eviction.
-        auto get_result = service_->GetReplicaList(key_1);
+        auto get_result = service_->GetReplicaList(key_1, "default");
         EXPECT_TRUE(get_result.has_value());
         std::this_thread::sleep_for(std::chrono::seconds(1));
     }
@@ -4533,7 +4664,7 @@ TEST_F(MasterServiceTest, PutStartExpiringTest) {
     // Put key_2 again, should fail because eviction has not been triggered. And
     // this PutStart should trigger the eviction.
     put_start_result =
-        service_->PutStart(client_id, key_2, slice_length, config);
+        service_->PutStart(client_id, key_2, "default", slice_length, config);
     EXPECT_FALSE(put_start_result.has_value());
     EXPECT_EQ(put_start_result.error(), ErrorCode::NO_AVAILABLE_HANDLE);
 
@@ -4543,7 +4674,7 @@ TEST_F(MasterServiceTest, PutStartExpiringTest) {
     // Put key_2 again, should success because the previous one has been
     // discarded and released.
     put_start_result =
-        service_->PutStart(client_id, key_2, slice_length, config);
+        service_->PutStart(client_id, key_2, "default", slice_length, config);
     EXPECT_TRUE(put_start_result.has_value());
     replica_list = put_start_result.value();
     EXPECT_EQ(replica_list.size(), kReplicaCnt);
@@ -4552,7 +4683,8 @@ TEST_F(MasterServiceTest, PutStartExpiringTest) {
     }
 
     // Complete key_2.
-    put_end_result = service_->PutEnd(client_id, key_2, ReplicaType::MEMORY);
+    put_end_result =
+        service_->PutEnd(client_id, key_2, "default", ReplicaType::MEMORY);
     EXPECT_TRUE(put_end_result.has_value());
 }
 
@@ -4669,16 +4801,16 @@ TEST_F(MasterServiceTest, BatchReplicaClearAllSegments) {
         ReplicateConfig config;
         config.replica_num = 1;
         auto put_start_result =
-            service_->PutStart(client_id, key, value_length, config);
+            service_->PutStart(client_id, key, "default", value_length, config);
         ASSERT_TRUE(put_start_result.has_value());
         auto put_end_result =
-            service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+            service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
         ASSERT_TRUE(put_end_result.has_value());
     }
 
     // Verify objects exist
     for (const auto& key : keys) {
-        auto exist_result = service_->ExistKey(key);
+        auto exist_result = service_->ExistKey(key, "default");
         ASSERT_TRUE(exist_result.has_value());
         ASSERT_TRUE(exist_result.value());
     }
@@ -4695,7 +4827,7 @@ TEST_F(MasterServiceTest, BatchReplicaClearAllSegments) {
 
     // Verify objects are removed
     for (const auto& key : keys) {
-        auto exist_result = service_->ExistKey(key);
+        auto exist_result = service_->ExistKey(key, "default");
         ASSERT_TRUE(exist_result.has_value());
         ASSERT_FALSE(exist_result.value())
             << "Key " << key << " should be removed";
@@ -4726,9 +4858,10 @@ TEST_F(MasterServiceTest, BatchReplicaClearSpecificSegment) {
     config.preferred_segment =
         segment_name;  // Ensure object is placed on segment1
     auto put_start_result =
-        service_->PutStart(client_id, key, value_length, config);
+        service_->PutStart(client_id, key, "default", value_length, config);
     ASSERT_TRUE(put_start_result.has_value());
-    auto put_end_result = service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end_result =
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value());
 
     // 4. Wait for lease to expire and verify it's actually expired
@@ -4766,7 +4899,7 @@ TEST_F(MasterServiceTest, BatchReplicaClearSpecificSegment) {
     const auto& cleared_keys = clear_result.value();
     ASSERT_EQ(1u, cleared_keys.size()) << "Key should be cleared";
 
-    auto exist_result = service_->ExistKey(key);
+    auto exist_result = service_->ExistKey(key, "default");
     ASSERT_TRUE(exist_result.has_value());
     ASSERT_FALSE(exist_result.value())
         << "Key should be removed after being cleared.";
@@ -4787,13 +4920,14 @@ TEST_F(MasterServiceTest, BatchReplicaClearWithLeaseActive) {
     ReplicateConfig config;
     config.replica_num = 1;
     auto put_start_result =
-        service_->PutStart(client_id, key, value_length, config);
+        service_->PutStart(client_id, key, "default", value_length, config);
     ASSERT_TRUE(put_start_result.has_value());
-    auto put_end_result = service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end_result =
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value());
 
     // Grant a lease by calling GetReplicaList (similar to normal usage)
-    auto get_result = service_->GetReplicaList(key);
+    auto get_result = service_->GetReplicaList(key, "default");
     ASSERT_TRUE(get_result.has_value());
 
     // Try to clear immediately (lease should still be active)
@@ -4807,7 +4941,7 @@ TEST_F(MasterServiceTest, BatchReplicaClearWithLeaseActive) {
         << "No keys should be cleared when lease is active";
 
     // Verify object still exists
-    auto exist_result = service_->ExistKey(key);
+    auto exist_result = service_->ExistKey(key, "default");
     ASSERT_TRUE(exist_result.has_value());
     ASSERT_TRUE(exist_result.value()) << "Key should still exist";
 }
@@ -4828,10 +4962,10 @@ TEST_F(MasterServiceTest, BatchReplicaClearWithDifferentClientId) {
     ReplicateConfig config;
     config.replica_num = 1;
     auto put_start_result =
-        service_->PutStart(client_id1, key, value_length, config);
+        service_->PutStart(client_id1, key, "default", value_length, config);
     ASSERT_TRUE(put_start_result.has_value());
     auto put_end_result =
-        service_->PutEnd(client_id1, key, ReplicaType::MEMORY);
+        service_->PutEnd(client_id1, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value());
 
     // Wait for lease to expire
@@ -4848,7 +4982,7 @@ TEST_F(MasterServiceTest, BatchReplicaClearWithDifferentClientId) {
         << "No keys should be cleared for different client_id";
 
     // Verify object still exists
-    auto exist_result = service_->ExistKey(key);
+    auto exist_result = service_->ExistKey(key, "default");
     ASSERT_TRUE(exist_result.has_value());
     ASSERT_TRUE(exist_result.value()) << "Key should still exist";
 }
@@ -4903,11 +5037,11 @@ TEST_F(MasterServiceTest, BatchReplicaClearWithEmptyStringKeys) {
     uint64_t value_length = 1024;
     ReplicateConfig config;
     config.replica_num = 1;
-    auto put_start_result =
-        service_->PutStart(client_id, valid_key, value_length, config);
+    auto put_start_result = service_->PutStart(client_id, valid_key, "default",
+                                               value_length, config);
     ASSERT_TRUE(put_start_result.has_value());
     auto put_end_result =
-        service_->PutEnd(client_id, valid_key, ReplicaType::MEMORY);
+        service_->PutEnd(client_id, valid_key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value());
 
     // Wait for lease to expire
@@ -4945,22 +5079,25 @@ TEST_F(MasterServiceTest, BatchReplicaClearMixedScenario) {
 
     // Create key1 and key2 with client_id1
     auto put_start1 =
-        service_->PutStart(client_id1, key1, value_length, config);
+        service_->PutStart(client_id1, key1, "default", value_length, config);
     ASSERT_TRUE(put_start1.has_value());
-    auto put_end1 = service_->PutEnd(client_id1, key1, ReplicaType::MEMORY);
+    auto put_end1 =
+        service_->PutEnd(client_id1, key1, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end1.has_value());
 
     auto put_start2 =
-        service_->PutStart(client_id1, key2, value_length, config);
+        service_->PutStart(client_id1, key2, "default", value_length, config);
     ASSERT_TRUE(put_start2.has_value());
-    auto put_end2 = service_->PutEnd(client_id1, key2, ReplicaType::MEMORY);
+    auto put_end2 =
+        service_->PutEnd(client_id1, key2, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end2.has_value());
 
     // Create key3 with client_id2
     auto put_start3 =
-        service_->PutStart(client_id2, key3, value_length, config);
+        service_->PutStart(client_id2, key3, "default", value_length, config);
     ASSERT_TRUE(put_start3.has_value());
-    auto put_end3 = service_->PutEnd(client_id2, key3, ReplicaType::MEMORY);
+    auto put_end3 =
+        service_->PutEnd(client_id2, key3, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end3.has_value());
 
     // Wait for lease to expire
@@ -4978,16 +5115,16 @@ TEST_F(MasterServiceTest, BatchReplicaClearMixedScenario) {
         << "Only keys belonging to client_id1 should be cleared";
 
     // Verify key1 and key2 are cleared
-    auto exist1 = service_->ExistKey(key1);
+    auto exist1 = service_->ExistKey(key1, "default");
     ASSERT_TRUE(exist1.has_value());
     ASSERT_FALSE(exist1.value()) << "key1 should be cleared";
 
-    auto exist2 = service_->ExistKey(key2);
+    auto exist2 = service_->ExistKey(key2, "default");
     ASSERT_TRUE(exist2.has_value());
     ASSERT_FALSE(exist2.value()) << "key2 should be cleared";
 
     // Verify key3 still exists (different client_id)
-    auto exist3 = service_->ExistKey(key3);
+    auto exist3 = service_->ExistKey(key3, "default");
     ASSERT_TRUE(exist3.has_value());
     ASSERT_TRUE(exist3.value())
         << "key3 should still exist (different client_id)";
@@ -5023,15 +5160,15 @@ TEST_F(MasterServiceTest, CreateCopyTaskTest) {
     config.replica_num = 1;
     config.preferred_segment = "segment_0";
     auto put_start_result =
-        service_->PutStart(client_id, key1, slice_length, config);
+        service_->PutStart(client_id, key1, "default", slice_length, config);
     EXPECT_TRUE(put_start_result.has_value());
     auto put_end_result =
-        service_->PutEnd(client_id, key1, ReplicaType::MEMORY);
+        service_->PutEnd(client_id, key1, "default", ReplicaType::MEMORY);
     EXPECT_TRUE(put_end_result.has_value());
 
     // Copy key1 to "segment_1" and "segment_2"
     auto copy_result =
-        service_->CreateCopyTask(key1, {"segment_1", "segment_2"});
+        service_->CreateCopyTask(key1, "default", {"segment_1", "segment_2"});
     EXPECT_TRUE(copy_result.has_value());
 
     // verify the copy task is created and assigned to the client who executed
@@ -5042,18 +5179,19 @@ TEST_F(MasterServiceTest, CreateCopyTaskTest) {
     EXPECT_EQ(contexts[0].client_id, task.value().assigned_client);
 
     // Copy with empty targets should fail
-    auto copy_result1 = service_->CreateCopyTask(key1, {});
+    auto copy_result1 = service_->CreateCopyTask(key1, "default", {});
     EXPECT_FALSE(copy_result1.has_value());
     EXPECT_EQ(ErrorCode::INVALID_PARAMS, copy_result1.error());
 
     // Copy not exist key should fail
     auto copy_result2 =
-        service_->CreateCopyTask("not_exist_key", {"segment_1"});
+        service_->CreateCopyTask("not_exist_key", "default", {"segment_1"});
     EXPECT_FALSE(copy_result2.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, copy_result2.error());
 
     // Copy to segment that not mounted should fail
-    auto copy_result3 = service_->CreateCopyTask(key1, {"not_mounted_segment"});
+    auto copy_result3 =
+        service_->CreateCopyTask(key1, "default", {"not_mounted_segment"});
     EXPECT_FALSE(copy_result3.has_value());
     EXPECT_EQ(ErrorCode::INVALID_PARAMS, copy_result3.error());
 }
@@ -5088,14 +5226,15 @@ TEST_F(MasterServiceTest, CreateMoveTaskTest) {
     config.replica_num = 1;
     config.preferred_segment = "segment_0";
     auto put_start_result =
-        service_->PutStart(client_id, key1, slice_length, config);
+        service_->PutStart(client_id, key1, "default", slice_length, config);
     EXPECT_TRUE(put_start_result.has_value());
     auto put_end_result =
-        service_->PutEnd(client_id, key1, ReplicaType::MEMORY);
+        service_->PutEnd(client_id, key1, "default", ReplicaType::MEMORY);
     EXPECT_TRUE(put_end_result.has_value());
 
     // Move key1 from "segment_0" to "segment_1"
-    auto move_result = service_->CreateMoveTask(key1, "segment_0", "segment_1");
+    auto move_result =
+        service_->CreateMoveTask(key1, "default", "segment_0", "segment_1");
     EXPECT_TRUE(move_result.has_value());
 
     // Verify the move task is created and assigned to the client owning the
@@ -5106,32 +5245,32 @@ TEST_F(MasterServiceTest, CreateMoveTaskTest) {
     EXPECT_EQ(contexts[0].client_id, task.value().assigned_client);
 
     // Move non-existent key should fail
-    auto move_result1 =
-        service_->CreateMoveTask("not_exist_key", "segment_0", "segment_1");
+    auto move_result1 = service_->CreateMoveTask("not_exist_key", "default",
+                                                 "segment_0", "segment_1");
     EXPECT_FALSE(move_result1.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, move_result1.error());
 
     // Move to segment that is same as source should fail
     auto move_result_same =
-        service_->CreateMoveTask(key1, "segment_1", "segment_1");
+        service_->CreateMoveTask(key1, "default", "segment_1", "segment_1");
     EXPECT_FALSE(move_result_same.has_value());
     EXPECT_EQ(ErrorCode::INVALID_PARAMS, move_result_same.error());
 
     // Move to segment that is not mounted should fail
-    auto move_result2 =
-        service_->CreateMoveTask(key1, "segment_0", "not_mounted_segment");
+    auto move_result2 = service_->CreateMoveTask(key1, "default", "segment_0",
+                                                 "not_mounted_segment");
     EXPECT_FALSE(move_result2.has_value());
     EXPECT_EQ(ErrorCode::INVALID_PARAMS, move_result2.error());
 
     // Move from segment that does not have the replica should fail
     auto move_result3 =
-        service_->CreateMoveTask(key1, "segment_2", "segment_1");
+        service_->CreateMoveTask(key1, "default", "segment_2", "segment_1");
     EXPECT_FALSE(move_result3.has_value());
     EXPECT_EQ(ErrorCode::INVALID_PARAMS, move_result3.error());
 
     // Move from segment that is not mounted should fail
-    auto move_result4 =
-        service_->CreateMoveTask(key1, "not_mounted_segment", "segment_1");
+    auto move_result4 = service_->CreateMoveTask(
+        key1, "default", "not_mounted_segment", "segment_1");
     EXPECT_FALSE(move_result4.has_value());
     EXPECT_EQ(ErrorCode::INVALID_PARAMS, move_result4.error());
 }
@@ -5166,14 +5305,15 @@ TEST_F(MasterServiceTest, QueryTaskTest) {
     config.replica_num = 1;
     config.preferred_segment = "segment_0";
     auto put_start_result =
-        service_->PutStart(client_id, key1, slice_length, config);
+        service_->PutStart(client_id, key1, "default", slice_length, config);
     EXPECT_TRUE(put_start_result.has_value());
     auto put_end_result =
-        service_->PutEnd(client_id, key1, ReplicaType::MEMORY);
+        service_->PutEnd(client_id, key1, "default", ReplicaType::MEMORY);
     EXPECT_TRUE(put_end_result.has_value());
 
     // Move key1 from "segment_0" to "segment_1"
-    auto move_result = service_->CreateMoveTask(key1, "segment_0", "segment_1");
+    auto move_result =
+        service_->CreateMoveTask(key1, "default", "segment_0", "segment_1");
     EXPECT_TRUE(move_result.has_value());
 
     // Query non-existent task should fail
@@ -5213,18 +5353,21 @@ TEST_F(MasterServiceTest, FetchTasksReturnsAssignedTasksOnlyAndDrainsQueue) {
     config.replica_num = 1;
     config.preferred_segment = "segment_0";
 
+    ASSERT_TRUE(service_
+                    ->PutStart(put_client_id, key, "default",
+                               /*slice_length=*/1024, config)
+                    .has_value());
     ASSERT_TRUE(
-        service_->PutStart(put_client_id, key, /*slice_length=*/1024, config)
+        service_->PutEnd(put_client_id, key, "default", ReplicaType::MEMORY)
             .has_value());
-    ASSERT_TRUE(
-        service_->PutEnd(put_client_id, key, ReplicaType::MEMORY).has_value());
 
     // Create two tasks; both should be assigned to the client owning source
     // segment_0.
-    auto copy_task_id = service_->CreateCopyTask(key, {"segment_1"});
+    auto copy_task_id = service_->CreateCopyTask(key, "default", {"segment_1"});
     ASSERT_TRUE(copy_task_id.has_value());
 
-    auto move_task_id = service_->CreateMoveTask(key, "segment_0", "segment_1");
+    auto move_task_id =
+        service_->CreateMoveTask(key, "default", "segment_0", "segment_1");
     ASSERT_TRUE(move_task_id.has_value());
 
     // Fetch from client_0 should get both tasks (order not guaranteed).
@@ -5348,15 +5491,18 @@ TEST_F(MasterServiceTest, FetchTasksRespectsBatchSize) {
     config.replica_num = 1;
     config.preferred_segment = "segment_0";
 
+    ASSERT_TRUE(service_
+                    ->PutStart(put_client_id, key, "default",
+                               /*slice_length=*/1024, config)
+                    .has_value());
     ASSERT_TRUE(
-        service_->PutStart(put_client_id, key, /*slice_length=*/1024, config)
+        service_->PutEnd(put_client_id, key, "default", ReplicaType::MEMORY)
             .has_value());
-    ASSERT_TRUE(
-        service_->PutEnd(put_client_id, key, ReplicaType::MEMORY).has_value());
 
-    auto t1 = service_->CreateCopyTask(key, {"segment_1"});
+    auto t1 = service_->CreateCopyTask(key, "default", {"segment_1"});
     ASSERT_TRUE(t1.has_value());
-    auto t2 = service_->CreateMoveTask(key, "segment_0", "segment_1");
+    auto t2 =
+        service_->CreateMoveTask(key, "default", "segment_0", "segment_1");
     ASSERT_TRUE(t2.has_value());
 
     auto fetch_first = service_->FetchTasks(ctx0.client_id, /*batch_size=*/1);
@@ -5397,14 +5543,16 @@ TEST_F(MasterServiceTest, UpdateTaskSuccessFlow) {
     config.replica_num = 1;
     config.preferred_segment = "segment_0";
 
+    ASSERT_TRUE(service_
+                    ->PutStart(put_client_id, key, "default",
+                               /*slice_length=*/1024, config)
+                    .has_value());
     ASSERT_TRUE(
-        service_->PutStart(put_client_id, key, /*slice_length=*/1024, config)
+        service_->PutEnd(put_client_id, key, "default", ReplicaType::MEMORY)
             .has_value());
-    ASSERT_TRUE(
-        service_->PutEnd(put_client_id, key, ReplicaType::MEMORY).has_value());
 
     // Create a task assigned to client owning segment_0.
-    auto task_id_res = service_->CreateCopyTask(key, {"segment_1"});
+    auto task_id_res = service_->CreateCopyTask(key, "default", {"segment_1"});
     ASSERT_TRUE(task_id_res.has_value());
     const UUID task_id = task_id_res.value();
 
@@ -5453,13 +5601,16 @@ TEST_F(MasterServiceTest, UpdateTaskRejectsWrongClient) {
     config.replica_num = 1;
     config.preferred_segment = "segment_0";
 
+    ASSERT_TRUE(service_
+                    ->PutStart(put_client_id, key, "default",
+                               /*slice_length=*/1024, config)
+                    .has_value());
     ASSERT_TRUE(
-        service_->PutStart(put_client_id, key, /*slice_length=*/1024, config)
+        service_->PutEnd(put_client_id, key, "default", ReplicaType::MEMORY)
             .has_value());
-    ASSERT_TRUE(
-        service_->PutEnd(put_client_id, key, ReplicaType::MEMORY).has_value());
 
-    auto task_id_res = service_->CreateMoveTask(key, "segment_0", "segment_1");
+    auto task_id_res =
+        service_->CreateMoveTask(key, "default", "segment_0", "segment_1");
     ASSERT_TRUE(task_id_res.has_value());
     const UUID task_id = task_id_res.value();
 
@@ -5523,7 +5674,7 @@ TEST_F(MasterServiceTest,
     config.preferred_segment = "segment_0";
 
     auto put_result = service_->PutStart(
-        ctx0.client_id, "drain_skip_allocation_key", 1024, config);
+        ctx0.client_id, "drain_skip_allocation_key", "default", 1024, config);
     ASSERT_TRUE(put_result.has_value());
     ASSERT_EQ(put_result->size(), 1u);
     EXPECT_EQ(put_result->front()
@@ -5532,7 +5683,7 @@ TEST_F(MasterServiceTest,
               "segment_1");
     ASSERT_TRUE(service_
                     ->PutEnd(ctx0.client_id, "drain_skip_allocation_key",
-                             ReplicaType::MEMORY)
+                             "default", ReplicaType::MEMORY)
                     .has_value());
 }
 
@@ -5576,7 +5727,7 @@ TEST_F(MasterServiceTest, DrainJobSchedulesMoveTaskAndConvergesToDrained) {
     ASSERT_TRUE(segment_status.has_value());
     EXPECT_EQ(segment_status.value(), SegmentStatus::DRAINED);
 
-    auto replicas = service_->GetReplicaList(key);
+    auto replicas = service_->GetReplicaList(key, "default");
     ASSERT_TRUE(replicas.has_value());
     std::unordered_set<std::string> segment_names;
     for (const auto& replica : replicas->replicas) {
@@ -5708,27 +5859,28 @@ TEST_F(MasterServiceTest, ForceRemoveLeasedObject) {
     ReplicateConfig config;
     config.replica_num = 1;
     auto put_start_result =
-        service_->PutStart(client_id, key, slice_length, config);
+        service_->PutStart(client_id, key, "default", slice_length, config);
     ASSERT_TRUE(put_start_result.has_value());
-    auto put_end_result = service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end_result =
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value());
 
     // Verify object exists
-    auto exist_result = service_->ExistKey(key);
+    auto exist_result = service_->ExistKey(key, "default");
     ASSERT_TRUE(exist_result.has_value());
     ASSERT_TRUE(exist_result.value());
 
     // Normal remove should fail because object has active lease
-    auto remove_result_no_force = service_->Remove(key, false);
+    auto remove_result_no_force = service_->Remove(key, "default", false);
     EXPECT_FALSE(remove_result_no_force.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_HAS_LEASE, remove_result_no_force.error());
 
     // Force remove should succeed even with active lease
-    auto remove_result_force = service_->Remove(key, true);
+    auto remove_result_force = service_->Remove(key, "default", true);
     EXPECT_TRUE(remove_result_force.has_value());
 
     // Verify object is removed
-    auto get_result = service_->GetReplicaList(key);
+    auto get_result = service_->GetReplicaList(key, "default");
     EXPECT_FALSE(get_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, get_result.error());
 }
@@ -5751,13 +5903,13 @@ TEST_F(MasterServiceTest, ForceRemoveByRegexLeasedObjects) {
         ReplicateConfig config;
         config.replica_num = 1;
         auto put_start_result =
-            service_->PutStart(client_id, key, slice_length, config);
+            service_->PutStart(client_id, key, "default", slice_length, config);
         ASSERT_TRUE(put_start_result.has_value());
         auto put_end_result =
-            service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+            service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
         ASSERT_TRUE(put_end_result.has_value());
         // Grant lease by reading the object
-        auto exist_result = service_->ExistKey(key);
+        auto exist_result = service_->ExistKey(key, "default");
         ASSERT_TRUE(exist_result.has_value());
         ASSERT_TRUE(exist_result.value());
     }
@@ -5765,28 +5917,28 @@ TEST_F(MasterServiceTest, ForceRemoveByRegexLeasedObjects) {
     // Normal RemoveByRegex should remove 0 because all objects have active
     // leases
     auto remove_result_no_force =
-        service_->RemoveByRegex("^force_regex_key_", false);
+        service_->RemoveByRegex("^force_regex_key_", "default", false);
     ASSERT_TRUE(remove_result_no_force.has_value());
     EXPECT_EQ(0, remove_result_no_force.value());
 
     // All objects should still exist
     for (int i = 0; i < 5; ++i) {
         std::string key = "force_regex_key_" + std::to_string(i);
-        auto exist_result = service_->ExistKey(key);
+        auto exist_result = service_->ExistKey(key, "default");
         ASSERT_TRUE(exist_result.has_value());
         ASSERT_TRUE(exist_result.value());
     }
 
     // Force RemoveByRegex should remove all 5 objects
     auto remove_result_force =
-        service_->RemoveByRegex("^force_regex_key_", true);
+        service_->RemoveByRegex("^force_regex_key_", "default", true);
     ASSERT_TRUE(remove_result_force.has_value());
     EXPECT_EQ(5, remove_result_force.value());
 
     // All objects should be removed
     for (int i = 0; i < 5; ++i) {
         std::string key = "force_regex_key_" + std::to_string(i);
-        auto exist_result = service_->ExistKey(key);
+        auto exist_result = service_->ExistKey(key, "default");
         ASSERT_TRUE(exist_result.has_value());
         ASSERT_FALSE(exist_result.value());
     }
@@ -5810,13 +5962,13 @@ TEST_F(MasterServiceTest, ForceRemoveAllLeasedObjects) {
         ReplicateConfig config;
         config.replica_num = 1;
         auto put_start_result =
-            service_->PutStart(client_id, key, slice_length, config);
+            service_->PutStart(client_id, key, "default", slice_length, config);
         ASSERT_TRUE(put_start_result.has_value());
         auto put_end_result =
-            service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+            service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
         ASSERT_TRUE(put_end_result.has_value());
         // Grant lease by reading the object
-        auto exist_result = service_->ExistKey(key);
+        auto exist_result = service_->ExistKey(key, "default");
         ASSERT_TRUE(exist_result.has_value());
         ASSERT_TRUE(exist_result.value());
     }
@@ -5827,7 +5979,7 @@ TEST_F(MasterServiceTest, ForceRemoveAllLeasedObjects) {
     // All objects should still exist
     for (int i = 0; i < 10; ++i) {
         std::string key = "force_all_key_" + std::to_string(i);
-        auto exist_result = service_->ExistKey(key);
+        auto exist_result = service_->ExistKey(key, "default");
         ASSERT_TRUE(exist_result.has_value());
         ASSERT_TRUE(exist_result.value());
     }
@@ -5838,7 +5990,7 @@ TEST_F(MasterServiceTest, ForceRemoveAllLeasedObjects) {
     // All objects should be removed
     for (int i = 0; i < 10; ++i) {
         std::string key = "force_all_key_" + std::to_string(i);
-        auto exist_result = service_->ExistKey(key);
+        auto exist_result = service_->ExistKey(key, "default");
         ASSERT_TRUE(exist_result.has_value());
         ASSERT_FALSE(exist_result.value());
     }
@@ -5857,23 +6009,24 @@ TEST_F(MasterServiceTest, UpsertNewKey) {
     config.replica_num = 1;
 
     auto upsert_result =
-        service_->UpsertStart(client_id, key, slice_length, config);
+        service_->UpsertStart(client_id, key, "default", slice_length, config);
     ASSERT_TRUE(upsert_result.has_value());
     auto replicas = upsert_result.value();
     EXPECT_EQ(1, replicas.size());
     EXPECT_EQ(ReplicaStatus::PROCESSING, replicas[0].status);
 
     // During upsert, GetReplicaList should return not ready
-    auto get_result = service_->GetReplicaList(key);
+    auto get_result = service_->GetReplicaList(key, "default");
     EXPECT_FALSE(get_result.has_value());
     EXPECT_EQ(ErrorCode::REPLICA_IS_NOT_READY, get_result.error());
 
     // UpsertEnd completes the operation
-    auto end_result = service_->UpsertEnd(client_id, key, ReplicaType::MEMORY);
+    auto end_result =
+        service_->UpsertEnd(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(end_result.has_value());
 
     // Verify replica is COMPLETE
-    auto final_result = service_->GetReplicaList(key);
+    auto final_result = service_->GetReplicaList(key, "default");
     ASSERT_TRUE(final_result.has_value());
     EXPECT_EQ(1, final_result.value().replicas.size());
     EXPECT_EQ(ReplicaStatus::COMPLETE, final_result.value().replicas[0].status);
@@ -5891,16 +6044,18 @@ TEST_F(MasterServiceTest, UpsertSameSize) {
     config.replica_num = 1;
 
     // First: PutStart + PutEnd to create the object
-    auto put_result = service_->PutStart(client_id, key, slice_length, config);
+    auto put_result =
+        service_->PutStart(client_id, key, "default", slice_length, config);
     ASSERT_TRUE(put_result.has_value());
     auto original_replicas = put_result.value();
-    auto put_end = service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end =
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end.has_value());
 
     // UpsertStart with same size — should reuse buffers
     const UUID new_client_id = generate_uuid();
-    auto upsert_result =
-        service_->UpsertStart(new_client_id, key, slice_length, config);
+    auto upsert_result = service_->UpsertStart(new_client_id, key, "default",
+                                               slice_length, config);
     ASSERT_TRUE(upsert_result.has_value());
     auto upsert_replicas = upsert_result.value();
     EXPECT_EQ(1, upsert_replicas.size());
@@ -5916,11 +6071,11 @@ TEST_F(MasterServiceTest, UpsertSameSize) {
 
     // UpsertEnd with the new client_id
     auto end_result =
-        service_->UpsertEnd(new_client_id, key, ReplicaType::MEMORY);
+        service_->UpsertEnd(new_client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(end_result.has_value());
 
     // Verify replica is COMPLETE again
-    auto final_result = service_->GetReplicaList(key);
+    auto final_result = service_->GetReplicaList(key, "default");
     ASSERT_TRUE(final_result.has_value());
     EXPECT_EQ(ReplicaStatus::COMPLETE, final_result.value().replicas[0].status);
 }
@@ -5939,23 +6094,26 @@ TEST_F(MasterServiceTest, UpsertSameSizeRefreshesMetadata) {
 
     // Create object with client_a
     auto put_result =
-        service_->PutStart(client_id_a, key, slice_length, config);
+        service_->PutStart(client_id_a, key, "default", slice_length, config);
     ASSERT_TRUE(put_result.has_value());
-    auto put_end = service_->PutEnd(client_id_a, key, ReplicaType::MEMORY);
+    auto put_end =
+        service_->PutEnd(client_id_a, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end.has_value());
 
     // UpsertStart with client_b
-    auto upsert_result =
-        service_->UpsertStart(client_id_b, key, slice_length, config);
+    auto upsert_result = service_->UpsertStart(client_id_b, key, "default",
+                                               slice_length, config);
     ASSERT_TRUE(upsert_result.has_value());
 
     // UpsertEnd with client_a should fail (client_id was refreshed to client_b)
-    auto end_fail = service_->UpsertEnd(client_id_a, key, ReplicaType::MEMORY);
+    auto end_fail =
+        service_->UpsertEnd(client_id_a, key, "default", ReplicaType::MEMORY);
     EXPECT_FALSE(end_fail.has_value());
     EXPECT_EQ(ErrorCode::ILLEGAL_CLIENT, end_fail.error());
 
     // UpsertEnd with client_b should succeed
-    auto end_ok = service_->UpsertEnd(client_id_b, key, ReplicaType::MEMORY);
+    auto end_ok =
+        service_->UpsertEnd(client_id_b, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(end_ok.has_value());
 }
 
@@ -5972,15 +6130,17 @@ TEST_F(MasterServiceTest, UpsertDifferentSize) {
     config.replica_num = 1;
 
     // Create object with original_size
-    auto put_result = service_->PutStart(client_id, key, original_size, config);
+    auto put_result =
+        service_->PutStart(client_id, key, "default", original_size, config);
     ASSERT_TRUE(put_result.has_value());
     auto original_replicas = put_result.value();
-    auto put_end = service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end =
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end.has_value());
 
     // UpsertStart with different size
     auto upsert_result =
-        service_->UpsertStart(client_id, key, new_size, config);
+        service_->UpsertStart(client_id, key, "default", new_size, config);
     ASSERT_TRUE(upsert_result.has_value());
     auto new_replicas = upsert_result.value();
     EXPECT_EQ(1, new_replicas.size());
@@ -5995,11 +6155,12 @@ TEST_F(MasterServiceTest, UpsertDifferentSize) {
                   .buffer_descriptor.buffer_address_);
 
     // UpsertEnd
-    auto end_result = service_->UpsertEnd(client_id, key, ReplicaType::MEMORY);
+    auto end_result =
+        service_->UpsertEnd(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(end_result.has_value());
 
     // Verify the object is complete
-    auto final_result = service_->GetReplicaList(key);
+    auto final_result = service_->GetReplicaList(key, "default");
     ASSERT_TRUE(final_result.has_value());
     EXPECT_EQ(ReplicaStatus::COMPLETE, final_result.value().replicas[0].status);
 }
@@ -6025,19 +6186,21 @@ TEST_F(MasterServiceTest, UpsertConflictReplicationTask) {
     config.preferred_segment = "segment_1";
 
     // Create object
-    auto put_result = service_->PutStart(client_id, key, slice_length, config);
+    auto put_result =
+        service_->PutStart(client_id, key, "default", slice_length, config);
     ASSERT_TRUE(put_result.has_value());
-    auto put_end = service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end =
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end.has_value());
 
     // Start a Copy
-    auto copy_result =
-        service_->CopyStart(client_id, key, "segment_1", {"segment_2"});
+    auto copy_result = service_->CopyStart(client_id, key, "default",
+                                           "segment_1", {"segment_2"});
     ASSERT_TRUE(copy_result.has_value());
 
     // UpsertStart should fail with OBJECT_HAS_REPLICATION_TASK
     auto upsert_result =
-        service_->UpsertStart(client_id, key, slice_length, config);
+        service_->UpsertStart(client_id, key, "default", slice_length, config);
     EXPECT_FALSE(upsert_result.has_value());
     EXPECT_EQ(ErrorCode::OBJECT_HAS_REPLICATION_TASK, upsert_result.error());
 }
@@ -6056,27 +6219,30 @@ TEST_F(MasterServiceTest, UpsertPreemptsInProgressPut) {
     config.replica_num = 1;
 
     // Client A starts a Put but doesn't finish
-    auto put_result = service_->PutStart(client_a, key, slice_length, config);
+    auto put_result =
+        service_->PutStart(client_a, key, "default", slice_length, config);
     ASSERT_TRUE(put_result.has_value());
 
     // Client B upserts the same key — should preempt client A
     auto upsert_result =
-        service_->UpsertStart(client_b, key, slice_length, config);
+        service_->UpsertStart(client_b, key, "default", slice_length, config);
     ASSERT_TRUE(upsert_result.has_value());
     auto upsert_replicas = upsert_result.value();
     EXPECT_EQ(1, upsert_replicas.size());
     EXPECT_EQ(ReplicaStatus::PROCESSING, upsert_replicas[0].status);
 
     // Client A's PutEnd should fail
-    auto put_end_a = service_->PutEnd(client_a, key, ReplicaType::MEMORY);
+    auto put_end_a =
+        service_->PutEnd(client_a, key, "default", ReplicaType::MEMORY);
     EXPECT_FALSE(put_end_a.has_value());
 
     // Client B's UpsertEnd should succeed
-    auto upsert_end = service_->UpsertEnd(client_b, key, ReplicaType::MEMORY);
+    auto upsert_end =
+        service_->UpsertEnd(client_b, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(upsert_end.has_value());
 
     // Verify final state
-    auto final_result = service_->GetReplicaList(key);
+    auto final_result = service_->GetReplicaList(key, "default");
     ASSERT_TRUE(final_result.has_value());
     EXPECT_EQ(ReplicaStatus::COMPLETE, final_result.value().replicas[0].status);
 }
@@ -6094,16 +6260,16 @@ TEST_F(MasterServiceTest, UpsertRevoke) {
 
     // UpsertStart (Case A — new key)
     auto upsert_result =
-        service_->UpsertStart(client_id, key, slice_length, config);
+        service_->UpsertStart(client_id, key, "default", slice_length, config);
     ASSERT_TRUE(upsert_result.has_value());
 
     // UpsertRevoke
     auto revoke_result =
-        service_->UpsertRevoke(client_id, key, ReplicaType::MEMORY);
+        service_->UpsertRevoke(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(revoke_result.has_value());
 
     // Key should be gone
-    auto exist_result = service_->ExistKey(key);
+    auto exist_result = service_->ExistKey(key, "default");
     ASSERT_TRUE(exist_result.has_value());
     EXPECT_FALSE(exist_result.value());
 }
@@ -6120,24 +6286,26 @@ TEST_F(MasterServiceTest, UpsertInPlaceThenRevoke) {
     config.replica_num = 1;
 
     // Create object first
-    auto put_result = service_->PutStart(client_id, key, slice_length, config);
+    auto put_result =
+        service_->PutStart(client_id, key, "default", slice_length, config);
     ASSERT_TRUE(put_result.has_value());
-    auto put_end = service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end =
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end.has_value());
 
     // UpsertStart in-place (same size)
     const UUID new_client = generate_uuid();
     auto upsert_result =
-        service_->UpsertStart(new_client, key, slice_length, config);
+        service_->UpsertStart(new_client, key, "default", slice_length, config);
     ASSERT_TRUE(upsert_result.has_value());
 
     // UpsertRevoke — replicas are PROCESSING, should be erased
     auto revoke_result =
-        service_->UpsertRevoke(new_client, key, ReplicaType::MEMORY);
+        service_->UpsertRevoke(new_client, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(revoke_result.has_value());
 
     // Key should be gone (no valid replicas left)
-    auto exist_result = service_->ExistKey(key);
+    auto exist_result = service_->ExistKey(key, "default");
     ASSERT_TRUE(exist_result.has_value());
     EXPECT_FALSE(exist_result.value());
 }
@@ -6152,23 +6320,25 @@ TEST_F(MasterServiceTest, BatchUpsertStart) {
     config.replica_num = 1;
 
     // Create key_1 with size 1024
-    auto put_result = service_->PutStart(client_id, "key_1", 1024, config);
+    auto put_result =
+        service_->PutStart(client_id, "key_1", "default", 1024, config);
     ASSERT_TRUE(put_result.has_value());
-    auto put_end = service_->PutEnd(client_id, "key_1", ReplicaType::MEMORY);
+    auto put_end =
+        service_->PutEnd(client_id, "key_1", "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end.has_value());
 
     // BatchUpsertStart: key_1 (same size), key_2 (new)
     std::vector<std::string> keys = {"key_1", "key_2"};
     std::vector<uint64_t> slice_lengths = {1024, 2048};
 
-    auto results =
-        service_->BatchUpsertStart(client_id, keys, slice_lengths, config);
+    auto results = service_->BatchUpsertStart(client_id, keys, "default",
+                                              slice_lengths, config);
     ASSERT_EQ(2, results.size());
     EXPECT_TRUE(results[0].has_value());  // key_1: Case B (in-place)
     EXPECT_TRUE(results[1].has_value());  // key_2: Case A (new)
 
     // Complete both
-    auto end_results = service_->BatchUpsertEnd(client_id, keys);
+    auto end_results = service_->BatchUpsertEnd(client_id, keys, "default");
     ASSERT_EQ(2, end_results.size());
     EXPECT_TRUE(end_results[0].has_value());
     EXPECT_TRUE(end_results[1].has_value());
@@ -6190,36 +6360,42 @@ TEST_F(MasterServiceTest, UpsertPreemptsInProgressUpsert) {
     config.replica_num = 1;
 
     // Step 1: Create the object via Put
-    auto put_result = service_->PutStart(client_a, key, slice_length, config);
+    auto put_result =
+        service_->PutStart(client_a, key, "default", slice_length, config);
     ASSERT_TRUE(put_result.has_value());
-    auto put_end = service_->PutEnd(client_a, key, ReplicaType::MEMORY);
+    auto put_end =
+        service_->PutEnd(client_a, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end.has_value());
 
     // Step 2: Client B starts in-place upsert (Case B) — marks COMPLETE →
     // PROCESSING
-    auto upsert_b = service_->UpsertStart(client_b, key, slice_length, config);
+    auto upsert_b =
+        service_->UpsertStart(client_b, key, "default", slice_length, config);
     ASSERT_TRUE(upsert_b.has_value());
 
     // Key should be unreadable now (all replicas are PROCESSING)
-    auto get_mid = service_->GetReplicaList(key);
+    auto get_mid = service_->GetReplicaList(key, "default");
     EXPECT_FALSE(get_mid.has_value());
     EXPECT_EQ(ErrorCode::REPLICA_IS_NOT_READY, get_mid.error());
 
     // Step 3: Client C upserts the same key — preempts Client B
-    auto upsert_c = service_->UpsertStart(client_c, key, slice_length, config);
+    auto upsert_c =
+        service_->UpsertStart(client_c, key, "default", slice_length, config);
     ASSERT_TRUE(upsert_c.has_value());
     EXPECT_EQ(1, upsert_c.value().size());
 
     // Step 4: Client B's UpsertEnd should fail (preempted)
-    auto end_b = service_->UpsertEnd(client_b, key, ReplicaType::MEMORY);
+    auto end_b =
+        service_->UpsertEnd(client_b, key, "default", ReplicaType::MEMORY);
     EXPECT_FALSE(end_b.has_value());
 
     // Step 5: Client C's UpsertEnd should succeed
-    auto end_c = service_->UpsertEnd(client_c, key, ReplicaType::MEMORY);
+    auto end_c =
+        service_->UpsertEnd(client_c, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(end_c.has_value());
 
     // Final verification
-    auto final_result = service_->GetReplicaList(key);
+    auto final_result = service_->GetReplicaList(key, "default");
     ASSERT_TRUE(final_result.has_value());
     EXPECT_EQ(1, final_result.value().replicas.size());
     EXPECT_EQ(ReplicaStatus::COMPLETE, final_result.value().replicas[0].status);
@@ -6240,29 +6416,31 @@ TEST_F(MasterServiceTest, UpsertDifferentSizeThenRevoke) {
     config.replica_num = 1;
 
     // Create object with original size
-    auto put_result = service_->PutStart(client_id, key, original_size, config);
+    auto put_result =
+        service_->PutStart(client_id, key, "default", original_size, config);
     ASSERT_TRUE(put_result.has_value());
-    auto put_end = service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end =
+        service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(put_end.has_value());
 
     // Verify the key exists
-    auto exist_before = service_->ExistKey(key);
+    auto exist_before = service_->ExistKey(key, "default");
     ASSERT_TRUE(exist_before.has_value());
     EXPECT_TRUE(exist_before.value());
 
     // UpsertStart with different size (Case C) — old replicas discarded,
     // new replicas allocated
     auto upsert_result =
-        service_->UpsertStart(client_id, key, new_size, config);
+        service_->UpsertStart(client_id, key, "default", new_size, config);
     ASSERT_TRUE(upsert_result.has_value());
 
     // Revoke — erase the newly allocated PROCESSING replicas
     auto revoke_result =
-        service_->UpsertRevoke(client_id, key, ReplicaType::MEMORY);
+        service_->UpsertRevoke(client_id, key, "default", ReplicaType::MEMORY);
     ASSERT_TRUE(revoke_result.has_value());
 
     // Key should be gone (old replicas in discarded, new replicas erased)
-    auto exist_after = service_->ExistKey(key);
+    auto exist_after = service_->ExistKey(key, "default");
     ASSERT_TRUE(exist_after.has_value());
     EXPECT_FALSE(exist_after.value());
 }
@@ -6290,12 +6468,13 @@ TEST_F(MasterServiceTest, HardPinObjectNotEvicted) {
         ReplicateConfig config;
         config.replica_num = 1;
         config.with_hard_pin = true;
-        auto result =
-            service_->PutStart(client_id, "pinned_model", value_size, config);
+        auto result = service_->PutStart(client_id, "pinned_model", "default",
+                                         value_size, config);
         ASSERT_TRUE(result.has_value());
-        ASSERT_TRUE(
-            service_->PutEnd(client_id, "pinned_model", ReplicaType::MEMORY)
-                .has_value());
+        ASSERT_TRUE(service_
+                        ->PutEnd(client_id, "pinned_model", "default",
+                                 ReplicaType::MEMORY)
+                        .has_value());
     }
 
     // Fill remaining space with normal objects to trigger eviction
@@ -6303,9 +6482,10 @@ TEST_F(MasterServiceTest, HardPinObjectNotEvicted) {
         std::string key = "filler_" + std::to_string(i);
         ReplicateConfig config;
         config.replica_num = 1;
-        auto result = service_->PutStart(client_id, key, value_size, config);
+        auto result =
+            service_->PutStart(client_id, key, "default", value_size, config);
         if (result.has_value()) {
-            service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+            service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
         }
     }
 
@@ -6313,14 +6493,15 @@ TEST_F(MasterServiceTest, HardPinObjectNotEvicted) {
     std::this_thread::sleep_for(std::chrono::milliseconds(kv_lease_ttl + 500));
 
     // Hard-pinned object must still be there
-    auto get_result = service_->GetReplicaList("pinned_model");
+    auto get_result = service_->GetReplicaList("pinned_model", "default");
     ASSERT_TRUE(get_result.has_value())
         << "Hard-pinned object was evicted, but it should never be";
 
     // Explicit Remove should still work on hard-pinned objects
-    auto remove_result = service_->Remove("pinned_model", /*force=*/true);
+    auto remove_result =
+        service_->Remove("pinned_model", "default", /*force=*/true);
     ASSERT_TRUE(remove_result.has_value());
-    auto exist_result = service_->ExistKey("pinned_model");
+    auto exist_result = service_->ExistKey("pinned_model", "default");
     ASSERT_TRUE(exist_result.has_value());
     ASSERT_FALSE(exist_result.value());
 
@@ -6354,12 +6535,14 @@ TEST_F(MasterServiceTest, HardPinWithSoftPinEvictionOrder) {
         ReplicateConfig config;
         config.replica_num = 1;
         config.with_hard_pin = true;
-        ASSERT_TRUE(
-            service_->PutStart(client_id, "hard_pinned", value_size, config)
-                .has_value());
-        ASSERT_TRUE(
-            service_->PutEnd(client_id, "hard_pinned", ReplicaType::MEMORY)
-                .has_value());
+        ASSERT_TRUE(service_
+                        ->PutStart(client_id, "hard_pinned", "default",
+                                   value_size, config)
+                        .has_value());
+        ASSERT_TRUE(service_
+                        ->PutEnd(client_id, "hard_pinned", "default",
+                                 ReplicaType::MEMORY)
+                        .has_value());
     }
 
     // Put a soft-pinned object
@@ -6367,12 +6550,14 @@ TEST_F(MasterServiceTest, HardPinWithSoftPinEvictionOrder) {
         ReplicateConfig config;
         config.replica_num = 1;
         config.with_soft_pin = true;
-        ASSERT_TRUE(
-            service_->PutStart(client_id, "soft_pinned", value_size, config)
-                .has_value());
-        ASSERT_TRUE(
-            service_->PutEnd(client_id, "soft_pinned", ReplicaType::MEMORY)
-                .has_value());
+        ASSERT_TRUE(service_
+                        ->PutStart(client_id, "soft_pinned", "default",
+                                   value_size, config)
+                        .has_value());
+        ASSERT_TRUE(service_
+                        ->PutEnd(client_id, "soft_pinned", "default",
+                                 ReplicaType::MEMORY)
+                        .has_value());
     }
 
     // Fill the rest
@@ -6380,9 +6565,10 @@ TEST_F(MasterServiceTest, HardPinWithSoftPinEvictionOrder) {
         std::string key = "normal_" + std::to_string(i);
         ReplicateConfig config;
         config.replica_num = 1;
-        auto result = service_->PutStart(client_id, key, value_size, config);
+        auto result =
+            service_->PutStart(client_id, key, "default", value_size, config);
         if (result.has_value()) {
-            service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+            service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY);
         }
     }
 
@@ -6390,7 +6576,7 @@ TEST_F(MasterServiceTest, HardPinWithSoftPinEvictionOrder) {
     std::this_thread::sleep_for(std::chrono::milliseconds(kv_lease_ttl + 500));
 
     // Hard-pinned always survives
-    ASSERT_TRUE(service_->GetReplicaList("hard_pinned").has_value())
+    ASSERT_TRUE(service_->GetReplicaList("hard_pinned", "default").has_value())
         << "Hard-pinned object was evicted";
 
     std::this_thread::sleep_for(std::chrono::milliseconds(kv_lease_ttl));
@@ -6413,22 +6599,27 @@ TEST_F(MasterServiceTest, HardPinDefaultIsFalse) {
     ReplicateConfig config;
     config.replica_num = 1;
     ASSERT_TRUE(
-        service_->PutStart(client_id, "normal_key", 1024, config).has_value());
-    ASSERT_TRUE(service_->PutEnd(client_id, "normal_key", ReplicaType::MEMORY)
-                    .has_value());
+        service_->PutStart(client_id, "normal_key", "default", 1024, config)
+            .has_value());
+    ASSERT_TRUE(
+        service_
+            ->PutEnd(client_id, "normal_key", "default", ReplicaType::MEMORY)
+            .has_value());
 
     // Put with hard_pin
     ReplicateConfig hp_config;
     hp_config.replica_num = 1;
     hp_config.with_hard_pin = true;
     ASSERT_TRUE(
-        service_->PutStart(client_id, "hp_key", 1024, hp_config).has_value());
+        service_->PutStart(client_id, "hp_key", "default", 1024, hp_config)
+            .has_value());
     ASSERT_TRUE(
-        service_->PutEnd(client_id, "hp_key", ReplicaType::MEMORY).has_value());
+        service_->PutEnd(client_id, "hp_key", "default", ReplicaType::MEMORY)
+            .has_value());
 
     // Both should exist
-    ASSERT_TRUE(service_->GetReplicaList("normal_key").has_value());
-    ASSERT_TRUE(service_->GetReplicaList("hp_key").has_value());
+    ASSERT_TRUE(service_->GetReplicaList("normal_key", "default").has_value());
+    ASSERT_TRUE(service_->GetReplicaList("hp_key", "default").has_value());
 
     service_->RemoveAll();
 }
@@ -6616,10 +6807,11 @@ TEST_F(MasterServiceTest, GracefulUnmountSegment_PreventAllocation) {
     config.replica_num = 1;
     config.preferred_segment = segment1.name;
 
-    auto put_start = service_->PutStart(client_id, key, 1024, config);
+    auto put_start =
+        service_->PutStart(client_id, key, "default", 1024, config);
     ASSERT_TRUE(put_start.has_value());
-    ASSERT_TRUE(
-        service_->PutEnd(client_id, key, ReplicaType::MEMORY).has_value());
+    ASSERT_TRUE(service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY)
+                    .has_value());
 
     // Graceful unmount segment1
     ASSERT_TRUE(service_->GracefulUnmountSegment(segment1.id, client_id, 1000)
@@ -6632,7 +6824,7 @@ TEST_F(MasterServiceTest, GracefulUnmountSegment_PreventAllocation) {
 
     // Existing replicas on the graceful segment should remain readable during
     // the grace window.
-    auto existing_replicas = service_->GetReplicaList(key);
+    auto existing_replicas = service_->GetReplicaList(key, "default");
     ASSERT_TRUE(existing_replicas.has_value());
     ASSERT_EQ(existing_replicas->replicas.size(), 1u);
     EXPECT_EQ(existing_replicas->replicas[0]
@@ -6650,7 +6842,8 @@ TEST_F(MasterServiceTest, GracefulUnmountSegment_PreventAllocation) {
     ReplicateConfig config2;
     config2.replica_num = 1;
 
-    auto put_start2 = service_->PutStart(client_id, key2, 1024, config2);
+    auto put_start2 =
+        service_->PutStart(client_id, key2, "default", 1024, config2);
     ASSERT_TRUE(put_start2.has_value());
     auto replicas = put_start2.value();
     ASSERT_EQ(replicas.size(), 1u);

--- a/mooncake-store/tests/object_data_type_test.cpp
+++ b/mooncake-store/tests/object_data_type_test.cpp
@@ -110,12 +110,13 @@ TEST_F(ObjectDataTypeTest, PutStartWithDataType) {
     config.replica_num = 1;
     config.data_type = ObjectDataType::WEIGHT;
 
-    auto result = service->PutStart(put_client, "key_weight", 1024, config);
+    auto result =
+        service->PutStart(put_client, "key_weight", "default", 1024, config);
     ASSERT_TRUE(result.has_value());
     EXPECT_FALSE(result.value().empty());
 
-    auto end_result =
-        service->PutEnd(put_client, "key_weight", ReplicaType::MEMORY);
+    auto end_result = service->PutEnd(put_client, "key_weight", "default",
+                                      ReplicaType::MEMORY);
     EXPECT_TRUE(end_result.has_value());
 }
 
@@ -132,7 +133,8 @@ TEST_F(ObjectDataTypeTest, PutStartDefaultDataType) {
     config.replica_num = 1;
     // data_type left as default (UNKNOWN)
 
-    auto result = service->PutStart(put_client, "key_default", 1024, config);
+    auto result =
+        service->PutStart(put_client, "key_default", "default", 1024, config);
     ASSERT_TRUE(result.has_value());
     EXPECT_FALSE(result.value().empty());
 }

--- a/mooncake-store/tests/offload_on_evict_test.cpp
+++ b/mooncake-store/tests/offload_on_evict_test.cpp
@@ -55,9 +55,11 @@ class OffloadOnEvictTest : public ::testing::Test {
                    const std::string& key, size_t size = 1024) {
         ReplicateConfig config;
         config.replica_num = 1;
-        auto put_start = service.PutStart(client_id, key, size, config);
+        auto put_start =
+            service.PutStart(client_id, key, "default", size, config);
         ASSERT_TRUE(put_start.has_value()) << "PutStart failed for key=" << key;
-        auto put_end = service.PutEnd(client_id, key, ReplicaType::MEMORY);
+        auto put_end =
+            service.PutEnd(client_id, key, "default", ReplicaType::MEMORY);
         ASSERT_TRUE(put_end.has_value()) << "PutEnd failed for key=" << key;
     }
 
@@ -101,9 +103,11 @@ class OffloadOnEvictTest : public ::testing::Test {
             std::string key = key_prefix + std::to_string(i);
             ReplicateConfig config;
             config.replica_num = 1;
-            auto result = service.PutStart(client_id, key, object_size, config);
+            auto result = service.PutStart(client_id, key, "default",
+                                           object_size, config);
             if (result.has_value()) {
-                auto end = service.PutEnd(client_id, key, ReplicaType::MEMORY);
+                auto end = service.PutEnd(client_id, key, "default",
+                                          ReplicaType::MEMORY);
                 EXPECT_TRUE(end.has_value());
                 success_puts++;
             } else {
@@ -224,10 +228,11 @@ TEST_F(OffloadOnEvictTest, ComboB_EvictionTriggersOffload) {
         std::string key = "evict_b_" + std::to_string(i);
         ReplicateConfig config;
         config.replica_num = 1;
-        auto result =
-            service->PutStart(ctx.client_id, key, object_size, config);
+        auto result = service->PutStart(ctx.client_id, key, "default",
+                                        object_size, config);
         if (result.has_value()) {
-            auto end = service->PutEnd(ctx.client_id, key, ReplicaType::MEMORY);
+            auto end = service->PutEnd(ctx.client_id, key, "default",
+                                       ReplicaType::MEMORY);
             ASSERT_TRUE(end.has_value());
             success_puts++;
         } else {

--- a/mooncake-store/tests/promotion_on_hit_test.cpp
+++ b/mooncake-store/tests/promotion_on_hit_test.cpp
@@ -79,9 +79,11 @@ class PromotionOnHitTest : public ::testing::Test {
                    const std::string& key, size_t size = 1024) {
         ReplicateConfig config;
         config.replica_num = 1;
-        auto put_start = service.PutStart(client_id, key, size, config);
+        auto put_start =
+            service.PutStart(client_id, key, "default", size, config);
         ASSERT_TRUE(put_start.has_value()) << "PutStart failed for key=" << key;
-        auto put_end = service.PutEnd(client_id, key, ReplicaType::MEMORY);
+        auto put_end =
+            service.PutEnd(client_id, key, "default", ReplicaType::MEMORY);
         ASSERT_TRUE(put_end.has_value()) << "PutEnd failed for key=" << key;
     }
 
@@ -90,8 +92,10 @@ class PromotionOnHitTest : public ::testing::Test {
     // LOCAL_DISK-only state without running the full offload pipeline.
     bool InjectLocalDiskReplica(MasterService& service, const UUID& client_id,
                                 const std::string& key, int64_t size,
-                                const std::string& transport_endpoint) {
-        std::vector<std::string> keys{key};
+                                const std::string& transport_endpoint,
+                                const std::string& tenant_id = "default") {
+        std::vector<OffloadTaskItem> tasks{
+            OffloadTaskItem{.tenant_id = tenant_id, .key = key, .size = size}};
         StorageObjectMetadata sm;
         sm.bucket_id = 0;
         sm.offset = 0;
@@ -99,7 +103,7 @@ class PromotionOnHitTest : public ::testing::Test {
         sm.data_size = size;
         sm.transport_endpoint = transport_endpoint;
         std::vector<StorageObjectMetadata> metas{sm};
-        auto res = service.NotifyOffloadSuccess(client_id, keys, metas);
+        auto res = service.NotifyOffloadSuccess(client_id, tasks, metas);
         return res.has_value();
     }
 
@@ -130,7 +134,7 @@ TEST_F(PromotionOnHitTest, DefaultOffNoPromotion) {
     // GetReplicaList many times. With promotion_on_hit=false, nothing should
     // appear in promotion_objects regardless of access count.
     for (int i = 0; i < 5; ++i) {
-        auto resp = service->GetReplicaList("k1");
+        auto resp = service->GetReplicaList("k1", "default");
         ASSERT_TRUE(resp.has_value());
     }
 
@@ -157,7 +161,7 @@ TEST_F(PromotionOnHitTest, NoLocalDiskNoPromotion) {
 
     PutObject(*service, ctx.client_id, "k_mem_only");
     for (int i = 0; i < 5; ++i) {
-        auto resp = service->GetReplicaList("k_mem_only");
+        auto resp = service->GetReplicaList("k_mem_only", "default");
         ASSERT_TRUE(resp.has_value());
     }
 
@@ -189,7 +193,7 @@ TEST_F(PromotionOnHitTest, MemoryReplicaPresentNoPromotion) {
                                        ctx.segment_name));
 
     for (int i = 0; i < 5; ++i) {
-        auto resp = service->GetReplicaList("k_dual");
+        auto resp = service->GetReplicaList("k_dual", "default");
         ASSERT_TRUE(resp.has_value());
     }
 
@@ -222,8 +226,8 @@ TEST_F(PromotionOnHitTest, AllocStartUnknownKey) {
     config.promotion_on_hit = true;
     auto service = std::make_unique<MasterService>(config);
 
-    auto resp =
-        service->PromotionAllocStart(generate_uuid(), "nonexistent", 1024, {});
+    auto resp = service->PromotionAllocStart(generate_uuid(), "nonexistent",
+                                             "default", 1024, {});
     ASSERT_FALSE(resp.has_value());
     EXPECT_EQ(resp.error(), ErrorCode::OBJECT_NOT_FOUND);
 }
@@ -236,7 +240,8 @@ TEST_F(PromotionOnHitTest, NotifyUnknownKey) {
     auto service = std::make_unique<MasterService>(config);
 
     UUID client_id = generate_uuid();
-    auto resp = service->NotifyPromotionSuccess(client_id, "nonexistent");
+    auto resp =
+        service->NotifyPromotionSuccess(client_id, "nonexistent", "default");
     ASSERT_FALSE(resp.has_value());
     EXPECT_EQ(resp.error(), ErrorCode::OBJECT_NOT_FOUND);
 }
@@ -271,7 +276,7 @@ TEST_F(PromotionOnHitTest, RacingReadersDedup) {
     for (int t = 0; t < kThreads; ++t) {
         threads.emplace_back([&service]() {
             for (int j = 0; j < kReadsPerThread; ++j) {
-                auto r = service->GetReplicaList("k_cold");
+                auto r = service->GetReplicaList("k_cold", "default");
                 EXPECT_TRUE(r.has_value());
             }
         });
@@ -321,7 +326,7 @@ TEST_F(PromotionOnHitTest, StalePromotionReaper) {
     // the per-shard PromotionTask intact (the heartbeat is best-effort GC,
     // not the authoritative state).
     {
-        auto r = service->GetReplicaList("k_cold");
+        auto r = service->GetReplicaList("k_cold", "default");
         ASSERT_TRUE(r.has_value());
         auto pending = service->PromotionObjectHeartbeat(ctx.client_id);
         ASSERT_TRUE(pending.has_value());
@@ -331,7 +336,7 @@ TEST_F(PromotionOnHitTest, StalePromotionReaper) {
     // Without reap, dedup blocks re-enqueue. Confirm: GetReplicaList again,
     // heartbeat must be empty because PromotionTask still pins the slot.
     {
-        auto r = service->GetReplicaList("k_cold");
+        auto r = service->GetReplicaList("k_cold", "default");
         ASSERT_TRUE(r.has_value());
         auto pending = service->PromotionObjectHeartbeat(ctx.client_id);
         ASSERT_TRUE(pending.has_value());
@@ -350,7 +355,7 @@ TEST_F(PromotionOnHitTest, StalePromotionReaper) {
     // Trigger #3: with the task reaped, dedup is unblocked and a fresh
     // GetReplicaList must enqueue again.
     {
-        auto r = service->GetReplicaList("k_cold");
+        auto r = service->GetReplicaList("k_cold", "default");
         ASSERT_TRUE(r.has_value());
         auto pending = service->PromotionObjectHeartbeat(ctx.client_id);
         ASSERT_TRUE(pending.has_value());
@@ -390,12 +395,12 @@ TEST_F(PromotionOnHitTest, RemoveDuringPromotion) {
 
     // Queue a promotion task.
     {
-        auto r = service->GetReplicaList("k_cold");
+        auto r = service->GetReplicaList("k_cold", "default");
         ASSERT_TRUE(r.has_value());
     }
 
     // Lease must expire before we can call non-force Remove (or use force).
-    auto rm = service->Remove("k_cold", /*force=*/true);
+    auto rm = service->Remove("k_cold", "default", /*force=*/true);
     // Remove returns REPLICA_IS_NOT_READY if any replica is non-COMPLETE.
     // The injected LOCAL_DISK replica is COMPLETE, so this should succeed.
     ASSERT_TRUE(rm.has_value())
@@ -407,7 +412,8 @@ TEST_F(PromotionOnHitTest, RemoveDuringPromotion) {
 
     // NotifyPromotionSuccess on the now-removed key must surface the missing
     // metadata cleanly, not crash.
-    auto notify = service->NotifyPromotionSuccess(ctx.client_id, "k_cold");
+    auto notify =
+        service->NotifyPromotionSuccess(ctx.client_id, "k_cold", "default");
     ASSERT_FALSE(notify.has_value());
     EXPECT_EQ(notify.error(), ErrorCode::OBJECT_NOT_FOUND);
 
@@ -421,7 +427,7 @@ TEST_F(PromotionOnHitTest, RemoveDuringPromotion) {
     ASSERT_TRUE(InjectLocalDiskReplica(*service, ctx.client_id, "k_cold", 1024,
                                        ctx.segment_name));
     {
-        auto r = service->GetReplicaList("k_cold");
+        auto r = service->GetReplicaList("k_cold", "default");
         ASSERT_TRUE(r.has_value());
         auto pending = service->PromotionObjectHeartbeat(ctx.client_id);
         ASSERT_TRUE(pending.has_value());
@@ -461,14 +467,14 @@ TEST_F(PromotionOnHitTest, MultiSegmentAllocPicksAvailableSegment) {
     // Seed the PromotionTask through the gate — PromotionAllocStart now
     // requires an in-flight task to exist (rejects orphaned-stage path).
     {
-        auto r = service->GetReplicaList("k_cold");
+        auto r = service->GetReplicaList("k_cold", "default");
         ASSERT_TRUE(r.has_value());
     }
 
     // PromotionAllocStart — test the segment-selection logic on top of
     // the gate-seeded task.
-    auto resp =
-        service->PromotionAllocStart(holder_client_id, "k_cold", 1024, {});
+    auto resp = service->PromotionAllocStart(holder_client_id, "k_cold",
+                                             "default", 1024, {});
     ASSERT_TRUE(resp.has_value())
         << "PromotionAllocStart should succeed when any DRAM segment has "
         << "capacity; error=" << resp.error();
@@ -511,12 +517,12 @@ TEST_F(PromotionOnHitTest, MultiSegmentAllocRespectsPreferred) {
     // Seed the PromotionTask through the gate so AllocStart's
     // task-existence check passes.
     {
-        auto r = service->GetReplicaList("k_cold");
+        auto r = service->GetReplicaList("k_cold", "default");
         ASSERT_TRUE(r.has_value());
     }
 
-    auto resp = service->PromotionAllocStart(seg_a.client_id, "k_cold", 1024,
-                                             {seg_b.segment_name});
+    auto resp = service->PromotionAllocStart(
+        seg_a.client_id, "k_cold", "default", 1024, {seg_b.segment_name});
     ASSERT_TRUE(resp.has_value());
     const auto& mem_desc = resp.value().memory_descriptor;
     EXPECT_EQ(
@@ -575,13 +581,13 @@ TEST_F(PromotionOnHitTest, QueueLimitRejectsBeyondCap) {
     const int64_t cap_rej_pre = mm.get_promotion_rejected_cap();
 
     // First read on k1 enqueues a task in shard S.
-    auto r1 = service->GetReplicaList(k1);
+    auto r1 = service->GetReplicaList(k1, "default");
     ASSERT_TRUE(r1.has_value());
 
     // Second read on k2 (same shard S, different key, so no dedup) must
     // be dropped by the cap gate: the cluster-wide in-flight counter is
     // already 1, which meets promotion_queue_limit_ = 1.
-    auto r2 = service->GetReplicaList(k2);
+    auto r2 = service->GetReplicaList(k2, "default");
     ASSERT_TRUE(r2.has_value()) << "read itself must still succeed; "
                                 << "queue gate is silent";
 
@@ -626,7 +632,7 @@ TEST_F(PromotionOnHitTest, HeartbeatBoundedBatchPreservesLeftovers) {
     for (const auto& k : keys) {
         ASSERT_TRUE(InjectLocalDiskReplica(*service, seg.client_id, k, 1024,
                                            seg.segment_name));
-        auto r = service->GetReplicaList(k);
+        auto r = service->GetReplicaList(k, "default");
         ASSERT_TRUE(r.has_value());
     }
 
@@ -665,7 +671,7 @@ TEST_F(PromotionOnHitTest, HeartbeatBoundedBatchPreservesLeftovers) {
     // (they're cleared by NotifyPromotionSuccess, not by Heartbeat), so the
     // source refcnts remain pinned until processed.
     for (const auto& k : keys) {
-        auto rl = service->GetReplicaList(k);
+        auto rl = service->GetReplicaList(k, "default");
         ASSERT_TRUE(rl.has_value()) << "key " << k << " should still exist";
     }
 
@@ -707,14 +713,14 @@ TEST_F(PromotionOnHitTest, ReaperPopsStagedMemoryReplicaOnExpiry) {
 
     // Trigger the gate to enqueue a PromotionTask.
     {
-        auto r = service->GetReplicaList("k_cold");
+        auto r = service->GetReplicaList("k_cold", "default");
         ASSERT_TRUE(r.has_value());
     }
     // Drive the AllocStart side so alloc_id != 0 — this is the exact
     // setup that produces an orphaned PROCESSING MEMORY replica if the
     // reaper does not pop it.
-    auto alloc =
-        service->PromotionAllocStart(ctx.client_id, "k_cold", 1024, {});
+    auto alloc = service->PromotionAllocStart(ctx.client_id, "k_cold",
+                                              "default", 1024, {});
     ASSERT_TRUE(alloc.has_value());
 
     // After AllocStart, the DRAM allocator must have committed bytes for
@@ -752,7 +758,8 @@ TEST_F(PromotionOnHitTest, ReaperPopsStagedMemoryReplicaOnExpiry) {
     // and must return REPLICA_IS_NOT_READY (the task entry is gone, so
     // the alloc_id lookup at the top of NotifyPromotionSuccess fails
     // fast).
-    auto notify = service->NotifyPromotionSuccess(ctx.client_id, "k_cold");
+    auto notify =
+        service->NotifyPromotionSuccess(ctx.client_id, "k_cold", "default");
     ASSERT_FALSE(notify.has_value());
     EXPECT_EQ(notify.error(), ErrorCode::REPLICA_IS_NOT_READY);
 
@@ -800,12 +807,12 @@ TEST_F(PromotionOnHitTest, QueueLimitRejectsCrossShard) {
     ASSERT_TRUE(InjectLocalDiskReplica(*service, seg.client_id, k2, 1024,
                                        seg.segment_name));
 
-    auto r1 = service->GetReplicaList(k1);
+    auto r1 = service->GetReplicaList(k1, "default");
     ASSERT_TRUE(r1.has_value());
 
     // k2 lives in a different shard, but the global cap is already met
     // by k1's task — k2 must be rejected.
-    auto r2 = service->GetReplicaList(k2);
+    auto r2 = service->GetReplicaList(k2, "default");
     ASSERT_TRUE(r2.has_value()) << "read itself still succeeds";
 
     auto heartbeat = service->PromotionObjectHeartbeat(seg.client_id);
@@ -879,7 +886,7 @@ TEST_F(PromotionOnHitTest, AllocStartResetsTaskDeadline) {
 
     // T=0 : admit. start_time = T=0.
     {
-        auto r = service->GetReplicaList("k_late");
+        auto r = service->GetReplicaList("k_late", "default");
         ASSERT_TRUE(r.has_value());
     }
 
@@ -888,8 +895,8 @@ TEST_F(PromotionOnHitTest, AllocStartResetsTaskDeadline) {
     // (the queue-wait phase's own window hasn't expired yet — 1.5 < 2).
     std::this_thread::sleep_for(std::chrono::milliseconds(1500));
 
-    auto alloc =
-        service->PromotionAllocStart(ctx.client_id, "k_late", 1024, {});
+    auto alloc = service->PromotionAllocStart(ctx.client_id, "k_late",
+                                              "default", 1024, {});
     ASSERT_TRUE(alloc.has_value())
         << "AllocStart must succeed before the queue-wait phase's TTL "
         << "expires (1.5s elapsed, TTL is 2s). If this fires the test "
@@ -959,7 +966,7 @@ TEST_F(PromotionOnHitTest, NotifySuccessDecrementsCounter) {
 
     // Admit task 1. promotion_in_flight_ goes from 0 -> 1.
     {
-        auto r = service->GetReplicaList("k_first");
+        auto r = service->GetReplicaList("k_first", "default");
         ASSERT_TRUE(r.has_value());
     }
 
@@ -967,11 +974,12 @@ TEST_F(PromotionOnHitTest, NotifySuccessDecrementsCounter) {
     // replica and records alloc_id; NotifyPromotionSuccess flips it
     // COMPLETE, drops the source LOCAL_DISK refcnt, erases the task, and
     // decrements the counter.
-    auto alloc =
-        service->PromotionAllocStart(seg.client_id, "k_first", 1024, {});
+    auto alloc = service->PromotionAllocStart(seg.client_id, "k_first",
+                                              "default", 1024, {});
     ASSERT_TRUE(alloc.has_value())
         << "AllocStart should succeed; error=" << alloc.error();
-    auto notify = service->NotifyPromotionSuccess(seg.client_id, "k_first");
+    auto notify =
+        service->NotifyPromotionSuccess(seg.client_id, "k_first", "default");
     ASSERT_TRUE(notify.has_value())
         << "NotifyPromotionSuccess happy path should succeed; if this "
         << "fires, AllocStart did not record alloc_id, or the staged "
@@ -982,7 +990,7 @@ TEST_F(PromotionOnHitTest, NotifySuccessDecrementsCounter) {
     // still saturated at 1 and TryPushPromotionQueue silently drops this
     // attempt.
     {
-        auto r = service->GetReplicaList("k_second");
+        auto r = service->GetReplicaList("k_second", "default");
         ASSERT_TRUE(r.has_value());
     }
     auto pending = service->PromotionObjectHeartbeat(seg.client_id);
@@ -1027,7 +1035,7 @@ TEST_F(PromotionOnHitTest, AllocStartRejectsReapedTask) {
 
     // Admit the task.
     {
-        auto r = service->GetReplicaList("k_cold");
+        auto r = service->GetReplicaList("k_cold", "default");
         ASSERT_TRUE(r.has_value());
     }
 
@@ -1044,8 +1052,8 @@ TEST_F(PromotionOnHitTest, AllocStartRejectsReapedTask) {
     // AllocStart on a reaped task must reject without allocating.
     // Allocating would leave an orphaned PROCESSING MEMORY replica
     // attached to the object.
-    auto alloc =
-        service->PromotionAllocStart(ctx.client_id, "k_cold", 1024, {});
+    auto alloc = service->PromotionAllocStart(ctx.client_id, "k_cold",
+                                              "default", 1024, {});
     ASSERT_FALSE(alloc.has_value())
         << "AllocStart must reject when the task has been reaped — "
         << "otherwise the staged PROCESSING MEMORY replica is orphaned";
@@ -1084,18 +1092,19 @@ TEST_F(PromotionOnHitTest, NotifyRejectsNonHolder) {
 
     // Admit + stage.
     {
-        auto r = service->GetReplicaList("k_cold");
+        auto r = service->GetReplicaList("k_cold", "default");
         ASSERT_TRUE(r.has_value());
     }
-    auto alloc =
-        service->PromotionAllocStart(holder.client_id, "k_cold", 1024, {});
+    auto alloc = service->PromotionAllocStart(holder.client_id, "k_cold",
+                                              "default", 1024, {});
     ASSERT_TRUE(alloc.has_value());
 
     // An unrelated client tries to Notify. Must be rejected as
     // INVALID_PARAMS so the staged replica stays PROCESSING.
     UUID intruder_id = generate_uuid();
     ASSERT_NE(intruder_id, holder.client_id);
-    auto bad_notify = service->NotifyPromotionSuccess(intruder_id, "k_cold");
+    auto bad_notify =
+        service->NotifyPromotionSuccess(intruder_id, "k_cold", "default");
     ASSERT_FALSE(bad_notify.has_value())
         << "Notify from a non-holder client must be rejected — otherwise "
         << "any client knowing the key can commit someone else's "
@@ -1107,7 +1116,7 @@ TEST_F(PromotionOnHitTest, NotifyRejectsNonHolder) {
     // GetReplicaList filters PROCESSING replicas, and pre-AllocStart
     // there are no COMPLETE replicas to read for a LOCAL_DISK-only key
     // (only the LOCAL_DISK descriptor itself).
-    auto r_check = service->GetReplicaList("k_cold");
+    auto r_check = service->GetReplicaList("k_cold", "default");
     ASSERT_TRUE(r_check.has_value());
     bool saw_complete_memory = false;
     for (const auto& d : r_check.value().replicas) {
@@ -1121,7 +1130,7 @@ TEST_F(PromotionOnHitTest, NotifyRejectsNonHolder) {
 
     // The legitimate holder must still be able to Notify successfully.
     auto good_notify =
-        service->NotifyPromotionSuccess(holder.client_id, "k_cold");
+        service->NotifyPromotionSuccess(holder.client_id, "k_cold", "default");
     ASSERT_TRUE(good_notify.has_value())
         << "Holder Notify on the same task must succeed after a rejected "
         << "intruder Notify — the task entry should be untouched by the "
@@ -1167,10 +1176,11 @@ TEST_F(PromotionOnHitTest, NotifyFailureReleasesStateImmediately) {
 
     // Admit + stage k_a. promotion_in_flight_ goes 0 -> 1.
     {
-        auto r = service->GetReplicaList("k_a");
+        auto r = service->GetReplicaList("k_a", "default");
         ASSERT_TRUE(r.has_value());
     }
-    auto alloc = service->PromotionAllocStart(seg.client_id, "k_a", 1024, {});
+    auto alloc =
+        service->PromotionAllocStart(seg.client_id, "k_a", "default", 1024, {});
     ASSERT_TRUE(alloc.has_value());
 
     // The staged PROCESSING MEMORY buffer is allocated.
@@ -1182,7 +1192,8 @@ TEST_F(PromotionOnHitTest, NotifyFailureReleasesStateImmediately) {
     // Holder reports failure (simulating SSD read error after AllocStart
     // succeeded). Master must immediately reap the staged replica and
     // decrement the slot counter.
-    auto failure = service->NotifyPromotionFailure(seg.client_id, "k_a");
+    auto failure =
+        service->NotifyPromotionFailure(seg.client_id, "k_a", "default");
     ASSERT_TRUE(failure.has_value())
         << "NotifyPromotionFailure on a valid in-flight task from the "
         << "legitimate holder must succeed; error=" << failure.error();
@@ -1204,7 +1215,7 @@ TEST_F(PromotionOnHitTest, NotifyFailureReleasesStateImmediately) {
     // succeed even though queue_limit=1. Without the failure-side
     // decrement the cap would stay saturated until reaper TTL.
     {
-        auto r = service->GetReplicaList("k_b");
+        auto r = service->GetReplicaList("k_b", "default");
         ASSERT_TRUE(r.has_value());
     }
     auto heartbeat = service->PromotionObjectHeartbeat(seg.client_id);
@@ -1217,7 +1228,8 @@ TEST_F(PromotionOnHitTest, NotifyFailureReleasesStateImmediately) {
 
     // Idempotency: repeated failure notification on the same key must be
     // safe (return OK without underflowing the counter).
-    auto failure_again = service->NotifyPromotionFailure(seg.client_id, "k_a");
+    auto failure_again =
+        service->NotifyPromotionFailure(seg.client_id, "k_a", "default");
     EXPECT_TRUE(failure_again.has_value())
         << "Repeated NotifyPromotionFailure should be idempotent (return "
         << "OK on already-released task), not error.";
@@ -1246,17 +1258,18 @@ TEST_F(PromotionOnHitTest, NotifyFailureRejectsNonHolder) {
                                        1024, holder.segment_name));
 
     {
-        auto r = service->GetReplicaList("k_cold");
+        auto r = service->GetReplicaList("k_cold", "default");
         ASSERT_TRUE(r.has_value());
     }
-    auto alloc =
-        service->PromotionAllocStart(holder.client_id, "k_cold", 1024, {});
+    auto alloc = service->PromotionAllocStart(holder.client_id, "k_cold",
+                                              "default", 1024, {});
     ASSERT_TRUE(alloc.has_value());
 
     // Intruder calls Failure with the wrong client_id.
     UUID intruder_id = generate_uuid();
     ASSERT_NE(intruder_id, holder.client_id);
-    auto bad_failure = service->NotifyPromotionFailure(intruder_id, "k_cold");
+    auto bad_failure =
+        service->NotifyPromotionFailure(intruder_id, "k_cold", "default");
     ASSERT_FALSE(bad_failure.has_value())
         << "Failure from a non-holder client must be rejected.";
     EXPECT_EQ(bad_failure.error(), ErrorCode::INVALID_PARAMS);
@@ -1265,7 +1278,7 @@ TEST_F(PromotionOnHitTest, NotifyFailureRejectsNonHolder) {
     // Notify-Success or release via Notify-Failure on the same task. Use
     // Notify-Failure here to exercise the surviving-task path.
     auto good_failure =
-        service->NotifyPromotionFailure(holder.client_id, "k_cold");
+        service->NotifyPromotionFailure(holder.client_id, "k_cold", "default");
     ASSERT_TRUE(good_failure.has_value())
         << "Holder Failure must succeed after a rejected intruder "
         << "Failure — the task entry should be untouched by the "
@@ -1299,14 +1312,14 @@ TEST_F(PromotionOnHitTest, AllocStartRejectsNonHolder) {
     const size_t used_baseline = seg_baseline->first;
 
     {
-        auto r = service->GetReplicaList("k_cold");
+        auto r = service->GetReplicaList("k_cold", "default");
         ASSERT_TRUE(r.has_value());
     }
 
     UUID intruder_id = generate_uuid();
     ASSERT_NE(intruder_id, holder.client_id);
-    auto bad_alloc =
-        service->PromotionAllocStart(intruder_id, "k_cold", 1024, {});
+    auto bad_alloc = service->PromotionAllocStart(intruder_id, "k_cold",
+                                                  "default", 1024, {});
     ASSERT_FALSE(bad_alloc.has_value())
         << "AllocStart from a non-holder client must be rejected — "
         << "otherwise an attacker that drained another's queue could "
@@ -1321,8 +1334,8 @@ TEST_F(PromotionOnHitTest, AllocStartRejectsNonHolder) {
 
     // The legitimate holder must still be able to AllocStart (task
     // untouched by the rejection).
-    auto good_alloc =
-        service->PromotionAllocStart(holder.client_id, "k_cold", 1024, {});
+    auto good_alloc = service->PromotionAllocStart(holder.client_id, "k_cold",
+                                                   "default", 1024, {});
     ASSERT_TRUE(good_alloc.has_value())
         << "Holder AllocStart on the same task must succeed after a "
         << "rejected intruder AllocStart; error=" << good_alloc.error();
@@ -1356,15 +1369,15 @@ TEST_F(PromotionOnHitTest, AllocStartRejectsSizeMismatch) {
     const size_t used_baseline = seg_baseline->first;
 
     {
-        auto r = service->GetReplicaList("k_cold");
+        auto r = service->GetReplicaList("k_cold", "default");
         ASSERT_TRUE(r.has_value());
     }
 
     // Mismatched-size requests must be rejected, regardless of direction.
     for (uint64_t bad_size : {static_cast<uint64_t>(kRealSize) / 2,
                               static_cast<uint64_t>(kRealSize) * 4}) {
-        auto bad_alloc = service->PromotionAllocStart(holder.client_id,
-                                                      "k_cold", bad_size, {});
+        auto bad_alloc = service->PromotionAllocStart(
+            holder.client_id, "k_cold", "default", bad_size, {});
         ASSERT_FALSE(bad_alloc.has_value())
             << "AllocStart with size=" << bad_size
             << " (task.object_size=" << kRealSize << ") must be rejected.";
@@ -1380,8 +1393,9 @@ TEST_F(PromotionOnHitTest, AllocStartRejectsSizeMismatch) {
 
     // Correct size must still work — the task was not consumed by the
     // rejections.
-    auto good_alloc = service->PromotionAllocStart(
-        holder.client_id, "k_cold", static_cast<uint64_t>(kRealSize), {});
+    auto good_alloc =
+        service->PromotionAllocStart(holder.client_id, "k_cold", "default",
+                                     static_cast<uint64_t>(kRealSize), {});
     ASSERT_TRUE(good_alloc.has_value())
         << "AllocStart with the correct size must succeed after rejected "
         << "size-mismatch attempts; error=" << good_alloc.error();
@@ -1426,7 +1440,7 @@ TEST_F(PromotionOnHitTest, ClientExpiryClearsPromotionTask) {
 
     // Admit the promotion. promotion_in_flight_ goes 0 -> 1.
     {
-        auto r = service->GetReplicaList("k_cold");
+        auto r = service->GetReplicaList("k_cold", "default");
         ASSERT_TRUE(r.has_value());
     }
 
@@ -1454,7 +1468,7 @@ TEST_F(PromotionOnHitTest, ClientExpiryClearsPromotionTask) {
                                        "k_other", 1024,
                                        second_holder.segment_name));
     {
-        auto r = service->GetReplicaList("k_other");
+        auto r = service->GetReplicaList("k_other", "default");
         ASSERT_TRUE(r.has_value());
     }
     auto pending_pre =
@@ -1487,7 +1501,7 @@ TEST_F(PromotionOnHitTest, ClientExpiryClearsPromotionTask) {
     // on the second holder; with queue_limit=1 this can only succeed if
     // the slot was freed.
     {
-        auto r = service->GetReplicaList("k_other");
+        auto r = service->GetReplicaList("k_other", "default");
         ASSERT_TRUE(r.has_value())
             << "GetReplicaList(k_other) failed with error=" << r.error();
     }
@@ -1569,7 +1583,7 @@ TEST_F(PromotionOnHitTest, RemoveErasesPromotionTask) {
 
     // Admit task 1.
     {
-        auto r = service->GetReplicaList("k_first");
+        auto r = service->GetReplicaList("k_first", "default");
         ASSERT_TRUE(r.has_value());
     }
     {
@@ -1581,7 +1595,7 @@ TEST_F(PromotionOnHitTest, RemoveErasesPromotionTask) {
     // Remove k_first with force=true. With the fix, this also wipes
     // k_first's promotion_tasks entry and decrements
     // promotion_in_flight_ back to 0.
-    auto rm = service->Remove("k_first", /*force=*/true);
+    auto rm = service->Remove("k_first", "default", /*force=*/true);
     ASSERT_TRUE(rm.has_value())
         << "Remove should succeed; error=" << rm.error();
 
@@ -1589,7 +1603,7 @@ TEST_F(PromotionOnHitTest, RemoveErasesPromotionTask) {
     // if the slot was freed by Remove. Without the in-flight cleanup,
     // it would stay pinned for the full 300s TTL.
     {
-        auto r = service->GetReplicaList("k_second");
+        auto r = service->GetReplicaList("k_second", "default");
         ASSERT_TRUE(r.has_value());
     }
     auto pending_post = service->PromotionObjectHeartbeat(holder.client_id);
@@ -1626,12 +1640,12 @@ TEST_F(PromotionOnHitTest, RemoveByRegexErasesPromotionTask) {
 
     // Admit task on regex_k1.
     {
-        auto r = service->GetReplicaList("regex_k1");
+        auto r = service->GetReplicaList("regex_k1", "default");
         ASSERT_TRUE(r.has_value());
     }
 
     // RemoveByRegex matches regex_k1 only.
-    auto removed = service->RemoveByRegex("^regex_", /*force=*/true);
+    auto removed = service->RemoveByRegex("^regex_", "default", /*force=*/true);
     ASSERT_TRUE(removed.has_value())
         << "RemoveByRegex should succeed; error=" << removed.error();
     EXPECT_EQ(removed.value(), 1) << "exactly one key (regex_k1) should match";
@@ -1639,7 +1653,7 @@ TEST_F(PromotionOnHitTest, RemoveByRegexErasesPromotionTask) {
     // Slot must be free — admit on other_k2 (different shard or same,
     // doesn't matter because counter is global).
     {
-        auto r = service->GetReplicaList("other_k2");
+        auto r = service->GetReplicaList("other_k2", "default");
         ASSERT_TRUE(r.has_value());
     }
     auto pending_post = service->PromotionObjectHeartbeat(holder.client_id);
@@ -1677,7 +1691,7 @@ TEST_F(PromotionOnHitTest, RemoveAllErasesPromotionTask) {
     const int64_t cancelled_pre = mm.get_promotion_cancelled();
 
     {
-        auto r = service->GetReplicaList("k_first");
+        auto r = service->GetReplicaList("k_first", "default");
         ASSERT_TRUE(r.has_value());
     }
     {
@@ -1696,7 +1710,7 @@ TEST_F(PromotionOnHitTest, RemoveAllErasesPromotionTask) {
     ASSERT_TRUE(InjectLocalDiskReplica(*service, holder.client_id, "k_second",
                                        1024, holder.segment_name));
     {
-        auto r = service->GetReplicaList("k_second");
+        auto r = service->GetReplicaList("k_second", "default");
         ASSERT_TRUE(r.has_value());
     }
     auto pending_post = service->PromotionObjectHeartbeat(holder.client_id);
@@ -1741,7 +1755,7 @@ TEST_F(PromotionOnHitTest, BatchRemoveErasesPromotionTask) {
     const int64_t cancelled_pre = mm.get_promotion_cancelled();
 
     {
-        auto r = service->GetReplicaList("k_first");
+        auto r = service->GetReplicaList("k_first", "default");
         ASSERT_TRUE(r.has_value());
     }
     {
@@ -1750,7 +1764,7 @@ TEST_F(PromotionOnHitTest, BatchRemoveErasesPromotionTask) {
         EXPECT_EQ(CountPromotionTask(*pending, "k_first"), 1u);
     }
 
-    auto results = service->BatchRemove({"k_first"}, /*force=*/true);
+    auto results = service->BatchRemove({"k_first"}, "default", /*force=*/true);
     ASSERT_EQ(results.size(), 1u);
     EXPECT_TRUE(results[0].has_value())
         << "BatchRemove should succeed; error=" << results[0].error();
@@ -1760,7 +1774,7 @@ TEST_F(PromotionOnHitTest, BatchRemoveErasesPromotionTask) {
         << "must bump promotion_cancelled_total.";
 
     {
-        auto r = service->GetReplicaList("k_second");
+        auto r = service->GetReplicaList("k_second", "default");
         ASSERT_TRUE(r.has_value());
     }
     auto pending_post = service->PromotionObjectHeartbeat(holder.client_id);
@@ -1797,7 +1811,7 @@ TEST_F(PromotionOnHitTest, BatchRemoveStaleHandleErasesPromotionTask) {
     const int64_t cancelled_pre = mm.get_promotion_cancelled();
 
     {
-        auto r = service->GetReplicaList("k_first");
+        auto r = service->GetReplicaList("k_first", "default");
         ASSERT_TRUE(r.has_value());
     }
     {
@@ -1806,7 +1820,7 @@ TEST_F(PromotionOnHitTest, BatchRemoveStaleHandleErasesPromotionTask) {
         EXPECT_EQ(CountPromotionTask(*pending, "k_first"), 1u);
     }
 
-    auto results = service->BatchRemove({"k_first"}, /*force=*/true);
+    auto results = service->BatchRemove({"k_first"}, "default", /*force=*/true);
     ASSERT_EQ(results.size(), 1u);
     EXPECT_FALSE(results[0].has_value())
         << "stale-handle path should report OBJECT_NOT_FOUND once the "
@@ -1830,7 +1844,7 @@ TEST_F(PromotionOnHitTest, BatchRemoveStaleHandleErasesPromotionTask) {
                                        "k_second", 1024,
                                        second_holder.segment_name));
     {
-        auto r = service->GetReplicaList("k_second");
+        auto r = service->GetReplicaList("k_second", "default");
         ASSERT_TRUE(r.has_value());
     }
     auto pending_post =
@@ -1871,17 +1885,18 @@ TEST_F(PromotionOnHitTest, MetricsFunnelTracksSuccessfulPromotion) {
 
     // Admit.
     {
-        auto r = service->GetReplicaList("k_hot");
+        auto r = service->GetReplicaList("k_hot", "default");
         ASSERT_TRUE(r.has_value());
     }
     EXPECT_EQ(mm.get_promotion_admitted() - admitted_pre, 1);
     EXPECT_EQ(mm.get_promotion_in_flight() - in_flight_pre, 1);
 
     // Drive AllocStart + NotifyPromotionSuccess.
-    auto alloc =
-        service->PromotionAllocStart(seg.client_id, "k_hot", kObjBytes, {});
+    auto alloc = service->PromotionAllocStart(seg.client_id, "k_hot", "default",
+                                              kObjBytes, {});
     ASSERT_TRUE(alloc.has_value());
-    auto notify = service->NotifyPromotionSuccess(seg.client_id, "k_hot");
+    auto notify =
+        service->NotifyPromotionSuccess(seg.client_id, "k_hot", "default");
     ASSERT_TRUE(notify.has_value());
 
     EXPECT_EQ(mm.get_promotion_completed() - completed_pre, 1);
@@ -1916,25 +1931,25 @@ TEST_F(PromotionOnHitTest, MetricsRejectionCountersIncrementOnGateMiss) {
 
     // 1st Get on k_a: freq=1, threshold=2 → rejected on frequency.
     {
-        auto r = service->GetReplicaList("k_a");
+        auto r = service->GetReplicaList("k_a", "default");
         ASSERT_TRUE(r.has_value());
     }
     EXPECT_EQ(mm.get_promotion_rejected_frequency() - freq_pre, 1);
 
     // 2nd Get on k_a: freq=2, admits. Now in-flight = 1 == limit.
     {
-        auto r = service->GetReplicaList("k_a");
+        auto r = service->GetReplicaList("k_a", "default");
         ASSERT_TRUE(r.has_value());
     }
     // Get on k_b: freq=1, threshold=2 → rejected on frequency.
     {
-        auto r = service->GetReplicaList("k_b");
+        auto r = service->GetReplicaList("k_b", "default");
         ASSERT_TRUE(r.has_value());
     }
     // Get on k_b again: freq=2, gets past frequency, but cap=1
     // saturated → rejected on cap.
     {
-        auto r = service->GetReplicaList("k_b");
+        auto r = service->GetReplicaList("k_b", "default");
         ASSERT_TRUE(r.has_value());
     }
     EXPECT_EQ(mm.get_promotion_rejected_cap() - cap_pre, 1);
@@ -1961,12 +1976,59 @@ TEST_F(PromotionOnHitTest, MetricsRejectionCountersIncrementOnGateMiss) {
 
     const int64_t wm_pre = mm.get_promotion_rejected_watermark();
     {
-        auto r = wm_service->GetReplicaList("k_w");
+        auto r = wm_service->GetReplicaList("k_w", "default");
         ASSERT_TRUE(r.has_value());
     }
     EXPECT_EQ(mm.get_promotion_rejected_watermark() - wm_pre, 1);
 
     wm_service->RemoveAll();
+}
+
+TEST_F(PromotionOnHitTest, AdmissionFrequencyIsTenantScoped) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 2;
+    config.default_kv_lease_ttl = 2000;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto seg =
+        PrepareSegment(*service, "seg_tenant", kDefaultSegmentBase, seg_size);
+    const std::string key = "shared_hot_key";
+    const std::string tenant_a = "tenant_promotion_a";
+    const std::string tenant_b = "tenant_promotion_b";
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, seg.client_id, key, 1024,
+                                       seg.segment_name, tenant_a));
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, seg.client_id, key, 1024,
+                                       seg.segment_name, tenant_b));
+
+    {
+        auto r = service->GetReplicaList(key, tenant_a);
+        ASSERT_TRUE(r.has_value());
+    }
+    {
+        auto r = service->GetReplicaList(key, tenant_b);
+        ASSERT_TRUE(r.has_value());
+    }
+    auto pending_after_one_each =
+        service->PromotionObjectHeartbeat(seg.client_id);
+    ASSERT_TRUE(pending_after_one_each.has_value());
+    EXPECT_TRUE(pending_after_one_each->empty())
+        << "same user key in two tenants must not share promotion heat";
+
+    {
+        auto r = service->GetReplicaList(key, tenant_a);
+        ASSERT_TRUE(r.has_value());
+    }
+    auto pending_after_tenant_a_second =
+        service->PromotionObjectHeartbeat(seg.client_id);
+    ASSERT_TRUE(pending_after_tenant_a_second.has_value());
+    ASSERT_EQ(pending_after_tenant_a_second->size(), 1u);
+    EXPECT_EQ((*pending_after_tenant_a_second)[0].tenant_id, tenant_a);
+    EXPECT_EQ((*pending_after_tenant_a_second)[0].key, key);
+
+    service->RemoveAll();
 }
 
 // promotion_max_per_heartbeat controls how many tasks
@@ -1989,7 +2051,7 @@ TEST_F(PromotionOnHitTest, MaxPerHeartbeatKnobControlsBatchSize) {
         const auto key = "k_" + std::to_string(i);
         ASSERT_TRUE(InjectLocalDiskReplica(*service, seg.client_id, key, 1024,
                                            seg.segment_name));
-        auto r = service->GetReplicaList(key);
+        auto r = service->GetReplicaList(key, "default");
         ASSERT_TRUE(r.has_value());
     }
 
@@ -2030,7 +2092,7 @@ TEST_F(PromotionOnHitTest, MaxPerHeartbeatZeroClampsToOne) {
     ASSERT_TRUE(InjectLocalDiskReplica(*service, seg.client_id, "k1", 1024,
                                        seg.segment_name));
     {
-        auto r = service->GetReplicaList("k1");
+        auto r = service->GetReplicaList("k1", "default");
         ASSERT_TRUE(r.has_value());
     }
 
@@ -2068,13 +2130,13 @@ TEST_F(PromotionOnHitTest, MetricsRemoveMidPromotionCountsAsCancelled) {
 
     // Admit a promotion. in_flight goes from 0 to 1.
     {
-        auto r = service->GetReplicaList("k_drop");
+        auto r = service->GetReplicaList("k_drop", "default");
         ASSERT_TRUE(r.has_value());
     }
     ASSERT_EQ(mm.get_promotion_admitted() - admitted_pre, 1);
     ASSERT_EQ(mm.get_promotion_in_flight() - in_flight_pre, 1);
 
-    auto rm = service->Remove("k_drop", /*force=*/true);
+    auto rm = service->Remove("k_drop", "default", /*force=*/true);
     ASSERT_TRUE(rm.has_value()) << "error=" << rm.error();
 
     EXPECT_EQ(mm.get_promotion_in_flight() - in_flight_pre, 0);


### PR DESCRIPTION
## Description

This PR performs the final cleanup after tenant-aware metadata and async task propagation. It removes redundant no-tenant `MasterService` object-operation overloads so internal callers must pass tenant scope explicitly, adds tenant-scoped `GetAllKeys(tenant_id)` and `BatchExistKey(keys, tenant_id)`, and keeps the existing `/get_all_keys` admin endpoint as default-tenant compatibility behavior. It also removes no-tenant metadata accessor helpers and dead drain-key helper code.

This PR also fixes a non-blocking PR3 follow-up in promotion admission: the CountMinSketch now uses a tenant-scoped key, so two tenants with the same user key no longer share promotion heat.

No documentation update is needed because this PR only cleans up internal Mooncake Store service APIs; public client, RPC, and HTTP surfaces remain unchanged.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

- `cmake --build build --target master_service_test -j2`
- `cmake --build build --target master_metrics_test -j2`
- `cmake --build build --target master_service_test_for_snapshot master_service_ssd_test_for_snapshot master_service_promotion_test_for_snapshot -j2`

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
