### PR TITLE
[TENT] feat: add per-request transport_hint for fine-grained transport selection in tent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 .vscode
 build
 build_ofed4
-build-new
 old
 local_test
 go.sum

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .vscode
 build
 build_ofed4
+build-new
 old
 local_test
 go.sum

--- a/docs/source/design/tent/cpp-api.md
+++ b/docs/source/design/tent/cpp-api.md
@@ -189,6 +189,9 @@ struct Request {
     SegmentID target_id;
     uint64_t target_offset;
     size_t length;
+    int priority = PRIO_HIGH;
+    std::optional<std::string> policy_name;
+    TransportType transport_hint = UNSPEC;
 };
 ```
 
@@ -197,6 +200,9 @@ struct Request {
 - `target_id`: Segment ID obtained from `openSegment`.
 - `target_offset`: Offset within the target segment.
 - `length`: Number of bytes to transfer.
+- `priority`: Scheduling priority. Used by the QoS layer; see [qos.md](qos.md).
+- `policy_name`: Optional. When set, the request matches the named entry instead of the first-matching policy.
+- `transport_hint`: Optional. `UNSPEC` (default) defers to `TransportSelector`. Any other `TransportType` pins this request onto that transport for its first try.
 
 #### TransferStatus
 
@@ -522,7 +528,8 @@ Location strings identify device affinity: `"cpu:0"`, `"cuda:0"`, `"cuda:1"`, et
 
 ```cpp
 enum TransportType {
-    RDMA = 0,
+    UNSPEC = 0,
+    RDMA,
     MNNVL,
     SHM,
     NVLINK,
@@ -530,7 +537,7 @@ enum TransportType {
     IOURING,
     TCP,
     AscendDirect,
-    UNSPEC
+    SUNRISE_LINK,
 };
 ```
 

--- a/docs/source/design/tent/transport-selector.md
+++ b/docs/source/design/tent/transport-selector.md
@@ -124,6 +124,26 @@ For programmatic control, the `transport_index` parameter selects which transpor
 auto result = selector.select(context, transports, transport_index);
 ```
 
+## Per-request override (`transport_hint`)
+
+`Request::transport_hint` lets a caller bypass the policy lookup for one request at a time. It's the per-request analogue of `transport_index` and sits on top of the configured policies, so callers can keep the global policy config as the default while still pinning specific requests.
+
+```cpp
+Request r{};
+r.opcode = Request::WRITE;
+r.source = local_ptr;
+r.target_id = seg;
+r.target_offset = 0;
+r.length = 4096;
+r.transport_hint = TransportType::TCP;   // UNSPEC (default) defers to policy
+engine.submitTransfer(batch_id, {r});
+```
+
+### Semantics
+
+* **`UNSPEC` (default)**: unchanged — `TransportSelector::select(...)` runs as documented above.
+* **Pinned**: the request's first attempt uses the hinted transport. On failover (when enabled), the engine asks the selector for the next candidate **with the hint excluded**, so failover never loops back onto the transport that already failed.
+
 ## Default Behavior
 
 If no `policy` is configured, TENT falls back to original behavior:

--- a/docs/source/python-api-reference/transfer-engine.md
+++ b/docs/source/python-api-reference/transfer-engine.md
@@ -164,10 +164,14 @@ Gets the address of the first buffer in a specified segment.
 
 ### Data Transfer Operations
 
+```{note}
+The optional `transport_hint` argument pins the request onto a named transport (`"rdma"`, `"tcp"`, ...), overriding policy-driven selection for that one call. **TENT backend only** (`MC_USE_TENT=1`); silently ignored on the classic backend. See [TENT transport selector](../design/tent/transport-selector.md) for more details.
+```
+
 #### transfer_sync_write()
 
 ```python
-transfer_sync_write(target_hostname, buffer, peer_buffer_address, length)
+transfer_sync_write(target_hostname, buffer, peer_buffer_address, length, transport_hint="")
 ```
 
 Performs a synchronous write operation to transfer data from local buffer to remote buffer.
@@ -177,6 +181,7 @@ Performs a synchronous write operation to transfer data from local buffer to rem
 - `buffer` (int): The local buffer address
 - `peer_buffer_address` (int): The remote buffer address
 - `length` (int): The number of bytes to transfer
+- `transport_hint` (str, optional): TENT-only per-request transport pin. See the note above. Default `""` (policy-driven).
 
 **Returns:**
 - `int`: 0 on success, negative value on failure
@@ -184,7 +189,7 @@ Performs a synchronous write operation to transfer data from local buffer to rem
 #### transfer_sync_read()
 
 ```python
-transfer_sync_read(target_hostname, buffer, peer_buffer_address, length)
+transfer_sync_read(target_hostname, buffer, peer_buffer_address, length, transport_hint="")
 ```
 
 Performs a synchronous read operation to transfer data from remote buffer to local buffer.
@@ -194,6 +199,7 @@ Performs a synchronous read operation to transfer data from remote buffer to loc
 - `buffer` (int): The local buffer address
 - `peer_buffer_address` (int): The remote buffer address
 - `length` (int): The number of bytes to transfer
+- `transport_hint` (str, optional): TENT-only per-request transport pin. See the note above. Default `""` (policy-driven).
 
 **Returns:**
 - `int`: 0 on success, negative value on failure
@@ -201,7 +207,7 @@ Performs a synchronous read operation to transfer data from remote buffer to loc
 #### transfer_sync()
 
 ```python
-transfer_sync(target_hostname, buffer, peer_buffer_address, length, opcode, notify=None)
+transfer_sync(target_hostname, buffer, peer_buffer_address, length, opcode, notify=None, transport_hint="")
 ```
 
 Performs a synchronous transfer operation with specified opcode and optional notification.
@@ -213,6 +219,7 @@ Performs a synchronous transfer operation with specified opcode and optional not
 - `length` (int): The number of bytes to transfer
 - `opcode` (TransferOpcode): The transfer operation type (READ or WRITE)
 - `notify` (TransferNotify, optional): Notification object to send after transfer completion
+- `transport_hint` (str, optional): TENT-only per-request transport pin. See the note above. Default `""` (policy-driven).
 
 **Returns:**
 - `int`: 0 on success, negative value on failure
@@ -220,7 +227,7 @@ Performs a synchronous transfer operation with specified opcode and optional not
 #### transfer_submit_write()
 
 ```python
-transfer_submit_write(target_hostname, buffer, peer_buffer_address, length)
+transfer_submit_write(target_hostname, buffer, peer_buffer_address, length, transport_hint="")
 ```
 
 Submits an asynchronous write operation and returns immediately.
@@ -230,6 +237,7 @@ Submits an asynchronous write operation and returns immediately.
 - `buffer` (int): The local buffer address
 - `peer_buffer_address` (int): The remote buffer address
 - `length` (int): The number of bytes to transfer
+- `transport_hint` (str, optional): TENT-only per-request transport pin. See the note above. Default `""` (policy-driven).
 
 **Returns:**
 - `int`: Batch ID for tracking the operation, or negative value on failure
@@ -255,7 +263,7 @@ Checks the status of an asynchronous transfer operation.
 #### transfer_write_on_cuda()
 
 ```python
-transfer_write_on_cuda(target_hostname, buffer, peer_buffer_address, length, stream_ptr)
+transfer_write_on_cuda(target_hostname, buffer, peer_buffer_address, length, stream_ptr=0, transport_hint="")
 ```
 
 Performs a write operation to transfer data from local buffer to remote buffer on a given cuda stream.
@@ -266,6 +274,7 @@ Performs a write operation to transfer data from local buffer to remote buffer o
 - `peer_buffer_address` (int): The remote buffer address
 - `length` (int): The number of bytes to transfer
 - `stream_ptr` (int): The integer representation of a CUDA stream pointer (`cudaStream_t`). For example, from a PyTorch stream, this can be obtained via `stream.cuda_stream`.
+- `transport_hint` (str, optional): TENT-only per-request transport pin. See the note at the top of this section. Default `""` (policy-driven).
 
 **Returns:**
 - `None`: The function returns immediately after successfully scheduling the transfer callback.
@@ -279,7 +288,7 @@ Performs a write operation to transfer data from local buffer to remote buffer o
 #### transfer_read_on_cuda()
 
 ```python
-transfer_read_on_cuda(target_hostname, buffer, peer_buffer_address, length, stream_ptr)
+transfer_read_on_cuda(target_hostname, buffer, peer_buffer_address, length, stream_ptr=0, transport_hint="")
 ```
 
 Performs a read operation to transfer data from remote buffer to local buffer on a given cuda stream.
@@ -290,6 +299,7 @@ Performs a read operation to transfer data from remote buffer to local buffer on
 - `peer_buffer_address` (int): The remote buffer address
 - `length` (int): The number of bytes to transfer
 - `stream_ptr` (int): The integer representation of a CUDA stream pointer (`cudaStream_t`). For example, from a PyTorch stream, this can be obtained via `stream.cuda_stream`.
+- `transport_hint` (str, optional): TENT-only per-request transport pin. See the note at the top of this section. Default `""` (policy-driven).
 
 **Returns:**
 - `None`: The function returns immediately after successfully scheduling the transfer callback.
@@ -307,7 +317,7 @@ Performs a read operation to transfer data from remote buffer to local buffer on
 #### batch_transfer_sync_write()
 
 ```python
-batch_transfer_sync_write(target_hostname, buffers, peer_buffer_addresses, lengths)
+batch_transfer_sync_write(target_hostname, buffers, peer_buffer_addresses, lengths, transport_hint="")
 ```
 
 Performs a batch synchronous write operation to transfer multiple data chunks from local buffers to remote buffers.
@@ -317,6 +327,7 @@ Performs a batch synchronous write operation to transfer multiple data chunks fr
 - `buffers` (List[int]): List of local buffer addresses
 - `peer_buffer_addresses` (List[int]): List of remote buffer addresses
 - `lengths` (List[int]): List of byte lengths for each transfer
+- `transport_hint` (str, optional): TENT-only per-batch transport pin. Default `""` (policy-driven).
 
 **Returns:**
 - `int`: 0 on success, negative value on failure
@@ -324,7 +335,7 @@ Performs a batch synchronous write operation to transfer multiple data chunks fr
 #### batch_transfer_sync_read()
 
 ```python
-batch_transfer_sync_read(target_hostname, buffers, peer_buffer_addresses, lengths)
+batch_transfer_sync_read(target_hostname, buffers, peer_buffer_addresses, lengths, transport_hint="")
 ```
 
 Performs a batch synchronous read operation to transfer multiple data chunks from remote buffers to local buffers.
@@ -334,6 +345,7 @@ Performs a batch synchronous read operation to transfer multiple data chunks fro
 - `buffers` (List[int]): List of local buffer addresses
 - `peer_buffer_addresses` (List[int]): List of remote buffer addresses
 - `lengths` (List[int]): List of byte lengths for each transfer
+- `transport_hint` (str, optional): TENT-only per-batch transport pin. Default `""` (policy-driven).
 
 **Returns:**
 - `int`: 0 on success, negative value on failure
@@ -341,7 +353,7 @@ Performs a batch synchronous read operation to transfer multiple data chunks fro
 #### batch_transfer_sync()
 
 ```python
-batch_transfer_sync(target_hostname, buffers, peer_buffer_addresses, lengths, opcode, notify=None)
+batch_transfer_sync(target_hostname, buffers, peer_buffer_addresses, lengths, opcode, notify=None, transport_hint="")
 ```
 
 Performs a batch synchronous transfer operation with specified opcode and optional notification.
@@ -353,6 +365,7 @@ Performs a batch synchronous transfer operation with specified opcode and option
 - `lengths` (List[int]): List of byte lengths for each transfer
 - `opcode` (TransferOpcode): The transfer operation type (READ or WRITE)
 - `notify` (TransferNotify, optional): Notification object to send after transfer completion
+- `transport_hint` (str, optional): TENT-only per-batch transport pin. Default `""` (policy-driven).
 
 **Returns:**
 - `int`: 0 on success, negative value on failure
@@ -360,7 +373,7 @@ Performs a batch synchronous transfer operation with specified opcode and option
 #### batch_transfer_async_write()
 
 ```python
-batch_transfer_async_write(target_hostname, buffers, peer_buffer_addresses, lengths)
+batch_transfer_async_write(target_hostname, buffers, peer_buffer_addresses, lengths, transport_hint="")
 ```
 
 Submits a batch asynchronous write operation and returns immediately.
@@ -370,6 +383,7 @@ Submits a batch asynchronous write operation and returns immediately.
 - `buffers` (List[int]): List of local buffer addresses
 - `peer_buffer_addresses` (List[int]): List of remote buffer addresses
 - `lengths` (List[int]): List of byte lengths for each transfer
+- `transport_hint` (str, optional): TENT-only per-batch transport pin. Default `""` (policy-driven).
 
 **Returns:**
 - `int`: Batch ID for tracking the operation, or 0 on failure
@@ -377,7 +391,7 @@ Submits a batch asynchronous write operation and returns immediately.
 #### batch_transfer_async_read()
 
 ```python
-batch_transfer_async_read(target_hostname, buffers, peer_buffer_addresses, lengths)
+batch_transfer_async_read(target_hostname, buffers, peer_buffer_addresses, lengths, transport_hint="")
 ```
 
 Submits a batch asynchronous read operation and returns immediately.
@@ -387,6 +401,7 @@ Submits a batch asynchronous read operation and returns immediately.
 - `buffers` (List[int]): List of local buffer addresses
 - `peer_buffer_addresses` (List[int]): List of remote buffer addresses
 - `lengths` (List[int]): List of byte lengths for each transfer
+- `transport_hint` (str, optional): TENT-only per-batch transport pin. Default `""` (policy-driven).
 
 **Returns:**
 - `int`: Batch ID for tracking the operation, or 0 on failure
@@ -394,7 +409,7 @@ Submits a batch asynchronous read operation and returns immediately.
 #### batch_transfer_async()
 
 ```python
-batch_transfer_async(target_hostname, buffers, peer_buffer_addresses, lengths, opcode)
+batch_transfer_async(target_hostname, buffers, peer_buffer_addresses, lengths, opcode, transport_hint="")
 ```
 
 Submits a batch asynchronous transfer operation with specified opcode and returns immediately.
@@ -405,6 +420,7 @@ Submits a batch asynchronous transfer operation with specified opcode and return
 - `peer_buffer_addresses` (List[int]): List of remote buffer addresses
 - `lengths` (List[int]): List of byte lengths for each transfer
 - `opcode` (TransferOpcode): The transfer operation type (READ or WRITE)
+- `transport_hint` (str, optional): TENT-only per-batch transport pin. Default `""` (policy-driven).
 
 **Returns:**
 - `int`: Batch ID for tracking the operation, or 0 on failure
@@ -426,7 +442,7 @@ Waits for multiple batch asynchronous transfer operations to complete.
 #### batch_transfer_write_on_cuda()
 
 ```python
-batch_transfer_write_on_cuda(target_hostname, buffers, peer_buffer_addresses, lengths, stream_ptr)
+batch_transfer_write_on_cuda(target_hostname, buffers, peer_buffer_addresses, lengths, stream_ptr=0, transport_hint="")
 ```
 
 Performs a batch write operation to transfer multiple data chunks from local buffers to remote buffers on a given cuda stream.
@@ -437,6 +453,7 @@ Performs a batch write operation to transfer multiple data chunks from local buf
 - `peer_buffer_addresses` (List[int]): List of remote buffer addresses
 - `lengths` (List[int]): List of byte lengths for each transfer
 - `stream_ptr` (int): The integer representation of a CUDA stream pointer (`cudaStream_t`). For example, from a PyTorch stream, this can be obtained via `stream.cuda_stream`.
+- `transport_hint` (str, optional): TENT-only per-batch transport pin. Default `""` (policy-driven).
 
 **Returns:**
 - `None`: The function returns immediately after successfully scheduling the transfer callback.
@@ -450,7 +467,7 @@ Performs a batch write operation to transfer multiple data chunks from local buf
 #### batch_transfer_read_on_cuda()
 
 ```python
-batch_transfer_read_on_cuda(target_hostname, buffers, peer_buffer_addresses, lengths, stream_ptr)
+batch_transfer_read_on_cuda(target_hostname, buffers, peer_buffer_addresses, lengths, stream_ptr=0, transport_hint="")
 ```
 
 Performs a batch read operation to transfer multiple data chunks from remote buffers to local buffers on a given cuda stream.
@@ -461,6 +478,7 @@ Performs a batch read operation to transfer multiple data chunks from remote buf
 - `peer_buffer_addresses` (List[int]): List of remote buffer addresses
 - `lengths` (List[int]): List of byte lengths for each transfer
 - `stream_ptr` (int): The integer representation of a CUDA stream pointer (`cudaStream_t`). For example, from a PyTorch stream, this can be obtained via `stream.cuda_stream`.
+- `transport_hint` (str, optional): TENT-only per-batch transport pin. Default `""` (policy-driven).
 
 **Returns:**
 - `None`: The function returns immediately after successfully scheduling the transfer callback.

--- a/mooncake-integration/CMakeLists.txt
+++ b/mooncake-integration/CMakeLists.txt
@@ -53,6 +53,11 @@ if(WITH_TE)
     target_compile_definitions(engine PRIVATE USE_EFA)
   endif()
 
+  # Propagate USE_TENT compile definition to engine target
+  if(USE_TENT)
+    target_compile_definitions(engine PRIVATE USE_TENT)
+  endif()
+
   target_link_libraries(engine PRIVATE $<TARGET_OBJECTS:rpc_communicator>)
 
   target_link_libraries(engine PRIVATE ${Python3_LIBRARIES})

--- a/mooncake-integration/transfer_engine/transfer_engine_py.cpp
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.cpp
@@ -21,6 +21,10 @@
 #include <pybind11/stl.h>
 #include "transport/rpc_communicator/rpc_interface.h"
 
+#ifdef USE_TENT
+#include "tent/runtime/transport_selector.h"
+#endif
+
 #ifdef USE_EFA
 #include "transport/efa_transport/efa_transport.h"
 #endif
@@ -321,19 +325,12 @@ int TransferEnginePy::freeManagedBuffer(uintptr_t buffer_addr, size_t length) {
 }
 
 static int parseTransportHint(const std::string& name) {
-    if (name.empty() || name == "unspec") return 0;
-    if (name == "rdma") return 1;
-    if (name == "mnnvl") return 2;
-    if (name == "shm") return 3;
-    if (name == "nvlink") return 4;
-    if (name == "gds") return 5;
-    if (name == "io_uring") return 6;
-    if (name == "tcp") return 7;
-    if (name == "ascend") return 8;
-    if (name == "sunrise_link") return 9;
-    LOG(WARNING) << "Unknown transport_hint '" << name
-                 << "', falling back to policy-driven selection";
+#ifdef USE_TENT
+    if (name.empty()) return mooncake::tent::UNSPEC;
+    return mooncake::tent::TransportSelector::parseTransportType(name);
+#else
     return 0;
+#endif
 }
 
 int TransferEnginePy::transferSyncWrite(const char* target_hostname,

--- a/mooncake-integration/transfer_engine/transfer_engine_py.cpp
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.cpp
@@ -320,57 +320,80 @@ int TransferEnginePy::freeManagedBuffer(uintptr_t buffer_addr, size_t length) {
     return 0;
 }
 
+static int parseTransportHint(const std::string& name) {
+    if (name.empty() || name == "unspec") return 0;
+    if (name == "rdma") return 1;
+    if (name == "mnnvl") return 2;
+    if (name == "shm") return 3;
+    if (name == "nvlink") return 4;
+    if (name == "gds") return 5;
+    if (name == "io_uring") return 6;
+    if (name == "tcp") return 7;
+    if (name == "ascend") return 8;
+    if (name == "sunrise_link") return 9;
+    LOG(WARNING) << "Unknown transport_hint '" << name
+                 << "', falling back to policy-driven selection";
+    return 0;
+}
+
 int TransferEnginePy::transferSyncWrite(const char* target_hostname,
                                         uintptr_t buffer,
                                         uintptr_t peer_buffer_address,
-                                        size_t length) {
+                                        size_t length,
+                                        const std::string& transport_hint) {
     return transferSync(target_hostname, buffer, peer_buffer_address, length,
-                        TransferOpcode::WRITE);
+                        TransferOpcode::WRITE, nullptr, transport_hint);
 }
 
 int TransferEnginePy::transferSyncRead(const char* target_hostname,
                                        uintptr_t buffer,
                                        uintptr_t peer_buffer_address,
-                                       size_t length) {
+                                       size_t length,
+                                       const std::string& transport_hint) {
     return transferSync(target_hostname, buffer, peer_buffer_address, length,
-                        TransferOpcode::READ);
+                        TransferOpcode::READ, nullptr, transport_hint);
 }
 
 int TransferEnginePy::batchTransferSyncWrite(
     const char* target_hostname, std::vector<uintptr_t> buffers,
-    std::vector<uintptr_t> peer_buffer_addresses, std::vector<size_t> lengths) {
+    std::vector<uintptr_t> peer_buffer_addresses, std::vector<size_t> lengths,
+    const std::string& transport_hint) {
     return batchTransferSync(target_hostname, buffers, peer_buffer_addresses,
-                             lengths, TransferOpcode::WRITE);
+                             lengths, TransferOpcode::WRITE, nullptr,
+                             transport_hint);
 }
 
 int TransferEnginePy::batchTransferSyncRead(
     const char* target_hostname, std::vector<uintptr_t> buffers,
-    std::vector<uintptr_t> peer_buffer_addresses, std::vector<size_t> lengths) {
+    std::vector<uintptr_t> peer_buffer_addresses, std::vector<size_t> lengths,
+    const std::string& transport_hint) {
     return batchTransferSync(target_hostname, buffers, peer_buffer_addresses,
-                             lengths, TransferOpcode::READ);
+                             lengths, TransferOpcode::READ, nullptr,
+                             transport_hint);
 }
 
 batch_id_t TransferEnginePy::batchTransferAsyncWrite(
     const char* target_hostname, const std::vector<uintptr_t>& buffers,
     const std::vector<uintptr_t>& peer_buffer_addresses,
-    const std::vector<size_t>& lengths) {
+    const std::vector<size_t>& lengths, const std::string& transport_hint) {
     return batchTransferAsync(target_hostname, buffers, peer_buffer_addresses,
-                              lengths, TransferOpcode::WRITE);
+                              lengths, TransferOpcode::WRITE, transport_hint);
 }
 
 batch_id_t TransferEnginePy::batchTransferAsyncRead(
     const char* target_hostname, const std::vector<uintptr_t>& buffers,
     const std::vector<uintptr_t>& peer_buffer_addresses,
-    const std::vector<size_t>& lengths) {
+    const std::vector<size_t>& lengths, const std::string& transport_hint) {
     return batchTransferAsync(target_hostname, buffers, peer_buffer_addresses,
-                              lengths, TransferOpcode::READ);
+                              lengths, TransferOpcode::READ, transport_hint);
 }
 
 int TransferEnginePy::transferSync(const char* target_hostname,
                                    uintptr_t buffer,
                                    uintptr_t peer_buffer_address, size_t length,
                                    TransferOpcode opcode,
-                                   TransferNotify* notify) {
+                                   TransferNotify* notify,
+                                   const std::string& transport_hint) {
     pybind11::gil_scoped_release release;
     Transport::SegmentHandle handle;
     {
@@ -408,6 +431,7 @@ int TransferEnginePy::transferSync(const char* target_hostname,
         entry.target_id = handle;
         entry.target_offset = peer_buffer_address;
         entry.advise_retry_cnt = retry;
+        entry.transport_hint = parseTransportHint(transport_hint);
 
         Status s =
             notify
@@ -462,7 +486,8 @@ int TransferEnginePy::transferSync(const char* target_hostname,
 int TransferEnginePy::batchTransferSync(
     const char* target_hostname, std::vector<uintptr_t> buffers,
     std::vector<uintptr_t> peer_buffer_addresses, std::vector<size_t> lengths,
-    TransferOpcode opcode, TransferNotify* notify) {
+    TransferOpcode opcode, TransferNotify* notify,
+    const std::string& transport_hint) {
     pybind11::gil_scoped_release release;
     Transport::SegmentHandle handle;
     {
@@ -500,6 +525,7 @@ int TransferEnginePy::batchTransferSync(
         entry.target_id = handle;
         entry.target_offset = peer_buffer_addresses[i];
         entry.advise_retry_cnt = 0;
+        entry.transport_hint = parseTransportHint(transport_hint);
         entries.push_back(entry);
     }
 
@@ -565,7 +591,8 @@ int TransferEnginePy::batchTransferSync(
 batch_id_t TransferEnginePy::batchTransferAsync(
     const char* target_hostname, const std::vector<uintptr_t>& buffers,
     const std::vector<uintptr_t>& peer_buffer_addresses,
-    const std::vector<size_t>& lengths, TransferOpcode opcode) {
+    const std::vector<size_t>& lengths, TransferOpcode opcode,
+    const std::string& transport_hint) {
     pybind11::gil_scoped_release release;
     Transport::SegmentHandle handle;
     {
@@ -602,6 +629,7 @@ batch_id_t TransferEnginePy::batchTransferAsync(
         entry.target_id = handle;
         entry.target_offset = peer_buffer_addresses[i];
         entry.advise_retry_cnt = 0;
+        entry.transport_hint = parseTransportHint(transport_hint);
         entries.push_back(entry);
     }
 
@@ -685,10 +713,10 @@ int TransferEnginePy::getBatchTransferStatus(
     return failed_or_timeout ? -1 : 0;
 }
 
-batch_id_t TransferEnginePy::transferSubmitWrite(const char* target_hostname,
-                                                 uintptr_t buffer,
-                                                 uintptr_t peer_buffer_address,
-                                                 size_t length) {
+batch_id_t TransferEnginePy::transferSubmitWrite(
+    const char* target_hostname, uintptr_t buffer,
+    uintptr_t peer_buffer_address, size_t length,
+    const std::string& transport_hint) {
     pybind11::gil_scoped_release release;
     Transport::SegmentHandle handle;
     {
@@ -709,6 +737,7 @@ batch_id_t TransferEnginePy::transferSubmitWrite(const char* target_hostname,
     entry.source = (void*)buffer;
     entry.target_id = handle;
     entry.target_offset = peer_buffer_address;
+    entry.transport_hint = parseTransportHint(transport_hint);
 
     Status s = engine_->submitTransfer(batch_id, {entry});
     if (!s.ok()) return -1;
@@ -857,7 +886,7 @@ void TransferEnginePy::batchTransferOnCuda(
     const char* target_hostname, const std::vector<uintptr_t>& buffers,
     const std::vector<uintptr_t>& peer_buffer_addresses,
     const std::vector<size_t>& lengths, TransferOpcode opcode,
-    uintptr_t stream_ptr) {
+    uintptr_t stream_ptr, const std::string& transport_hint) {
     pybind11::gil_scoped_release release;
     Transport::SegmentHandle handle;
     {
@@ -892,6 +921,7 @@ void TransferEnginePy::batchTransferOnCuda(
         entry.source = (void*)buffers[i];
         entry.target_id = handle;
         entry.target_offset = peer_buffer_addresses[i];
+        entry.transport_hint = parseTransportHint(transport_hint);
         entries.push_back(entry);
         total_bytes += lengths[i];
     }
@@ -917,10 +947,11 @@ void TransferEnginePy::batchTransferOnCuda(
 void TransferEnginePy::transferWriteOnCuda(const char* target_hostname,
                                            uintptr_t buffer,
                                            uintptr_t peer_buffer_address,
-                                           size_t length,
-                                           uintptr_t stream_ptr) {
+                                           size_t length, uintptr_t stream_ptr,
+                                           const std::string& transport_hint) {
     batchTransferOnCuda(target_hostname, {buffer}, {peer_buffer_address},
-                        {length}, TransferOpcode::WRITE, stream_ptr);
+                        {length}, TransferOpcode::WRITE, stream_ptr,
+                        transport_hint);
 }
 
 /**
@@ -929,9 +960,11 @@ void TransferEnginePy::transferWriteOnCuda(const char* target_hostname,
 void TransferEnginePy::transferReadOnCuda(const char* target_hostname,
                                           uintptr_t buffer,
                                           uintptr_t peer_buffer_address,
-                                          size_t length, uintptr_t stream_ptr) {
+                                          size_t length, uintptr_t stream_ptr,
+                                          const std::string& transport_hint) {
     batchTransferOnCuda(target_hostname, {buffer}, {peer_buffer_address},
-                        {length}, TransferOpcode::READ, stream_ptr);
+                        {length}, TransferOpcode::READ, stream_ptr,
+                        transport_hint);
 }
 
 /**
@@ -940,9 +973,11 @@ void TransferEnginePy::transferReadOnCuda(const char* target_hostname,
 void TransferEnginePy::batchTransferWriteOnCuda(
     const char* target_hostname, const std::vector<uintptr_t>& buffers,
     const std::vector<uintptr_t>& peer_buffer_addresses,
-    const std::vector<size_t>& lengths, uintptr_t stream_ptr) {
+    const std::vector<size_t>& lengths, uintptr_t stream_ptr,
+    const std::string& transport_hint) {
     batchTransferOnCuda(target_hostname, buffers, peer_buffer_addresses,
-                        lengths, TransferOpcode::WRITE, stream_ptr);
+                        lengths, TransferOpcode::WRITE, stream_ptr,
+                        transport_hint);
 }
 
 /**
@@ -951,9 +986,11 @@ void TransferEnginePy::batchTransferWriteOnCuda(
 void TransferEnginePy::batchTransferReadOnCuda(
     const char* target_hostname, const std::vector<uintptr_t>& buffers,
     const std::vector<uintptr_t>& peer_buffer_addresses,
-    const std::vector<size_t>& lengths, uintptr_t stream_ptr) {
+    const std::vector<size_t>& lengths, uintptr_t stream_ptr,
+    const std::string& transport_hint) {
     batchTransferOnCuda(target_hostname, buffers, peer_buffer_addresses,
-                        lengths, TransferOpcode::READ, stream_ptr);
+                        lengths, TransferOpcode::READ, stream_ptr,
+                        transport_hint);
 }
 #endif
 
@@ -1086,47 +1123,76 @@ PYBIND11_MODULE(engine, m) {
             .def("allocate_managed_buffer",
                  &TransferEnginePy::allocateManagedBuffer)
             .def("free_managed_buffer", &TransferEnginePy::freeManagedBuffer)
-            .def("transfer_sync_write", &TransferEnginePy::transferSyncWrite)
-            .def("transfer_sync_read", &TransferEnginePy::transferSyncRead)
+            .def("transfer_sync_write", &TransferEnginePy::transferSyncWrite,
+                 py::arg("target_hostname"), py::arg("buffer"),
+                 py::arg("peer_buffer_address"), py::arg("length"),
+                 py::arg("transport_hint") = "")
+            .def("transfer_sync_read", &TransferEnginePy::transferSyncRead,
+                 py::arg("target_hostname"), py::arg("buffer"),
+                 py::arg("peer_buffer_address"), py::arg("length"),
+                 py::arg("transport_hint") = "")
             .def("batch_transfer_sync_write",
-                 &TransferEnginePy::batchTransferSyncWrite)
+                 &TransferEnginePy::batchTransferSyncWrite,
+                 py::arg("target_hostname"), py::arg("buffers"),
+                 py::arg("peer_buffer_addresses"), py::arg("lengths"),
+                 py::arg("transport_hint") = "")
             .def("batch_transfer_sync_read",
-                 &TransferEnginePy::batchTransferSyncRead)
+                 &TransferEnginePy::batchTransferSyncRead,
+                 py::arg("target_hostname"), py::arg("buffers"),
+                 py::arg("peer_buffer_addresses"), py::arg("lengths"),
+                 py::arg("transport_hint") = "")
             .def("batch_transfer_async_write",
-                 &TransferEnginePy::batchTransferAsyncWrite)
+                 &TransferEnginePy::batchTransferAsyncWrite,
+                 py::arg("target_hostname"), py::arg("buffers"),
+                 py::arg("peer_buffer_addresses"), py::arg("lengths"),
+                 py::arg("transport_hint") = "")
             .def("batch_transfer_async_read",
-                 &TransferEnginePy::batchTransferAsyncRead)
+                 &TransferEnginePy::batchTransferAsyncRead,
+                 py::arg("target_hostname"), py::arg("buffers"),
+                 py::arg("peer_buffer_addresses"), py::arg("lengths"),
+                 py::arg("transport_hint") = "")
             .def("transfer_sync", &TransferEnginePy::transferSync,
                  py::arg("target_hostname"), py::arg("buffer"),
                  py::arg("peer_buffer_address"), py::arg("length"),
-                 py::arg("opcode"), py::arg("notify") = nullptr)
-            .def("batch_transfer_sync", &TransferEnginePy::batchTransferSync)
-            .def("batch_transfer_async", &TransferEnginePy::batchTransferAsync)
+                 py::arg("opcode"), py::arg("notify") = nullptr,
+                 py::arg("transport_hint") = "")
+            .def("batch_transfer_sync", &TransferEnginePy::batchTransferSync,
+                 py::arg("target_hostname"), py::arg("buffers"),
+                 py::arg("peer_buffer_addresses"), py::arg("lengths"),
+                 py::arg("opcode"), py::arg("notify") = nullptr,
+                 py::arg("transport_hint") = "")
+            .def("batch_transfer_async", &TransferEnginePy::batchTransferAsync,
+                 py::arg("target_hostname"), py::arg("buffers"),
+                 py::arg("peer_buffer_addresses"), py::arg("lengths"),
+                 py::arg("opcode"), py::arg("transport_hint") = "")
 #ifdef USE_CUDA
             .def("transfer_write_on_cuda",
                  &TransferEnginePy::transferWriteOnCuda,
                  py::arg("target_hostname"), py::arg("buffer"),
                  py::arg("peer_buffer_address"), py::arg("length"),
-                 py::arg("stream_ptr") = 0)
+                 py::arg("stream_ptr") = 0, py::arg("transport_hint") = "")
             .def("transfer_read_on_cuda", &TransferEnginePy::transferReadOnCuda,
                  py::arg("target_hostname"), py::arg("buffer"),
                  py::arg("peer_buffer_address"), py::arg("length"),
-                 py::arg("stream_ptr") = 0)
+                 py::arg("stream_ptr") = 0, py::arg("transport_hint") = "")
             .def("batch_transfer_write_on_cuda",
                  &TransferEnginePy::batchTransferWriteOnCuda,
                  py::arg("target_hostname"), py::arg("buffers"),
                  py::arg("peer_buffer_addresses"), py::arg("lengths"),
-                 py::arg("stream_ptr") = 0)
+                 py::arg("stream_ptr") = 0, py::arg("transport_hint") = "")
             .def("batch_transfer_read_on_cuda",
                  &TransferEnginePy::batchTransferReadOnCuda,
                  py::arg("target_hostname"), py::arg("buffers"),
                  py::arg("peer_buffer_addresses"), py::arg("lengths"),
-                 py::arg("stream_ptr") = 0)
+                 py::arg("stream_ptr") = 0, py::arg("transport_hint") = "")
 #endif
             .def("get_batch_transfer_status",
                  &TransferEnginePy::getBatchTransferStatus)
             .def("transfer_submit_write",
-                 &TransferEnginePy::transferSubmitWrite)
+                 &TransferEnginePy::transferSubmitWrite,
+                 py::arg("target_hostname"), py::arg("buffer"),
+                 py::arg("peer_buffer_address"), py::arg("length"),
+                 py::arg("transport_hint") = "")
             .def("transfer_check_status",
                  &TransferEnginePy::transferCheckStatus)
             .def("write_bytes_to_buffer", &TransferEnginePy::writeBytesToBuffer)

--- a/mooncake-integration/transfer_engine/transfer_engine_py.cpp
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.cpp
@@ -327,7 +327,14 @@ int TransferEnginePy::freeManagedBuffer(uintptr_t buffer_addr, size_t length) {
 static int parseTransportHint(const std::string& name) {
 #ifdef USE_TENT
     if (name.empty()) return mooncake::tent::UNSPEC;
-    return mooncake::tent::TransportSelector::parseTransportType(name);
+    auto type = mooncake::tent::TransportSelector::parseTransportType(name);
+    if (type == mooncake::tent::UNSPEC && name != "unspec") {
+        throw std::invalid_argument(
+            "Unknown transport_hint '" + name +
+            "' (valid: rdma, mnnvl, shm, nvlink, gds, io_uring, tcp, "
+            "ascend, sunrise_link, unspec, or empty string for no hint)");
+    }
+    return type;
 #else
     return 0;
 #endif

--- a/mooncake-integration/transfer_engine/transfer_engine_py.h
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.h
@@ -70,41 +70,48 @@ class TransferEnginePy {
     int freeManagedBuffer(uintptr_t user_tensor, size_t length);
 
     int transferSyncWrite(const char *target_hostname, uintptr_t buffer,
-                          uintptr_t peer_buffer_address, size_t length);
+                          uintptr_t peer_buffer_address, size_t length,
+                          const std::string &transport_hint = "");
 
     batch_id_t transferSubmitWrite(const char *target_hostname,
                                    uintptr_t buffer,
-                                   uintptr_t peer_buffer_address,
-                                   size_t length);
+                                   uintptr_t peer_buffer_address, size_t length,
+                                   const std::string &transport_hint = "");
 
     int transferCheckStatus(batch_id_t batch_id);
 
     int transferSyncRead(const char *target_hostname, uintptr_t buffer,
-                         uintptr_t peer_buffer_address, size_t length);
+                         uintptr_t peer_buffer_address, size_t length,
+                         const std::string &transport_hint = "");
 
     int batchTransferSyncWrite(const char *target_hostname,
                                std::vector<uintptr_t> buffers,
                                std::vector<uintptr_t> peer_buffer_addresses,
-                               std::vector<size_t> lengths);
+                               std::vector<size_t> lengths,
+                               const std::string &transport_hint = "");
 
     int batchTransferSyncRead(const char *target_hostname,
                               std::vector<uintptr_t> buffers,
                               std::vector<uintptr_t> peer_buffer_addresses,
-                              std::vector<size_t> lengths);
+                              std::vector<size_t> lengths,
+                              const std::string &transport_hint = "");
 
     batch_id_t batchTransferAsyncWrite(
         const char *target_hostname, const std::vector<uintptr_t> &buffers,
         const std::vector<uintptr_t> &peer_buffer_addresses,
-        const std::vector<size_t> &lengths);
+        const std::vector<size_t> &lengths,
+        const std::string &transport_hint = "");
 
     batch_id_t batchTransferAsyncRead(
         const char *target_hostname, const std::vector<uintptr_t> &buffers,
         const std::vector<uintptr_t> &peer_buffer_addresses,
-        const std::vector<size_t> &lengths);
+        const std::vector<size_t> &lengths,
+        const std::string &transport_hint = "");
 
     int transferSync(const char *target_hostname, uintptr_t buffer,
                      uintptr_t peer_buffer_address, size_t length,
-                     TransferOpcode opcode, TransferNotify *notify = nullptr);
+                     TransferOpcode opcode, TransferNotify *notify = nullptr,
+                     const std::string &transport_hint = "");
 
     // Known issue: in a few inference engines and benchmarks, accuracy
     // may be affected when using the batchTransferSync API. We currently
@@ -113,12 +120,14 @@ class TransferEnginePy {
                           std::vector<uintptr_t> buffers,
                           std::vector<uintptr_t> peer_buffer_addresses,
                           std::vector<size_t> lengths, TransferOpcode opcode,
-                          TransferNotify *notify = nullptr);
+                          TransferNotify *notify = nullptr,
+                          const std::string &transport_hint = "");
 
     batch_id_t batchTransferAsync(
         const char *target_hostname, const std::vector<uintptr_t> &buffers,
         const std::vector<uintptr_t> &peer_buffer_addresses,
-        const std::vector<size_t> &lengths, TransferOpcode opcode);
+        const std::vector<size_t> &lengths, TransferOpcode opcode,
+        const std::string &transport_hint = "");
 
     int getBatchTransferStatus(const std::vector<batch_id_t> &batch_ids);
 
@@ -127,25 +136,29 @@ class TransferEnginePy {
         const char *target_hostname, const std::vector<uintptr_t> &buffers,
         const std::vector<uintptr_t> &peer_buffer_addresses,
         const std::vector<size_t> &lengths, TransferOpcode opcode,
-        uintptr_t stream_ptr = 0);
+        uintptr_t stream_ptr = 0, const std::string &transport_hint = "");
 
     void transferWriteOnCuda(const char *target_hostname, uintptr_t buffer,
                              uintptr_t peer_buffer_address, size_t length,
-                             uintptr_t stream_ptr = 0);
+                             uintptr_t stream_ptr = 0,
+                             const std::string &transport_hint = "");
 
     void transferReadOnCuda(const char *target_hostname, uintptr_t buffer,
                             uintptr_t peer_buffer_address, size_t length,
-                            uintptr_t stream_ptr = 0);
+                            uintptr_t stream_ptr = 0,
+                            const std::string &transport_hint = "");
 
     void batchTransferWriteOnCuda(
         const char *target_hostname, const std::vector<uintptr_t> &buffers,
         const std::vector<uintptr_t> &peer_buffer_addresses,
-        const std::vector<size_t> &lengths, uintptr_t stream_ptr = 0);
+        const std::vector<size_t> &lengths, uintptr_t stream_ptr = 0,
+        const std::string &transport_hint = "");
 
     void batchTransferReadOnCuda(
         const char *target_hostname, const std::vector<uintptr_t> &buffers,
         const std::vector<uintptr_t> &peer_buffer_addresses,
-        const std::vector<size_t> &lengths, uintptr_t stream_ptr = 0);
+        const std::vector<size_t> &lengths, uintptr_t stream_ptr = 0,
+        const std::string &transport_hint = "");
 #endif
 
     uintptr_t getFirstBufferAddress(const std::string &segment_name);

--- a/mooncake-transfer-engine/benchmark/tent_backend.cpp
+++ b/mooncake-transfer-engine/benchmark/tent_backend.cpp
@@ -180,6 +180,8 @@ TENTBenchRunner::TENTBenchRunner() {
     signal(SIGINT, signalHandlerV1);
     signal(SIGTERM, signalHandlerV1);
     engine_ = std::make_unique<TransferEngine>(loadConfig());
+    transport_hint_ = TransportSelector::parseTransportType(
+        XferBenchConfig::tent_transport_hint);
     allocateBuffers();
 }
 
@@ -305,8 +307,6 @@ double TENTBenchRunner::runSingleTransfer(uint64_t local_addr,
                                           uint64_t batch_size, OpCode opcode) {
     auto batch_id = engine_->allocateBatch(batch_size);
     std::vector<Request> requests;
-    const TransportType hint = TransportSelector::parseTransportType(
-        XferBenchConfig::tent_transport_hint);
     for (uint64_t i = 0; i < batch_size; ++i) {
         Request entry;
         entry.opcode = opcode == READ ? Request::READ : Request::WRITE;
@@ -314,7 +314,7 @@ double TENTBenchRunner::runSingleTransfer(uint64_t local_addr,
         entry.source = (void*)(local_addr + block_size * i);
         entry.target_id = handle_;
         entry.target_offset = target_addr + block_size * i;
-        entry.transport_hint = hint;
+        entry.transport_hint = transport_hint_;
         requests.emplace_back(entry);
     }
     XferBenchTimer timer;

--- a/mooncake-transfer-engine/benchmark/tent_backend.cpp
+++ b/mooncake-transfer-engine/benchmark/tent_backend.cpp
@@ -17,6 +17,7 @@
 #include "tent/common/types.h"
 #include "tent/runtime/platform.h"
 #include "tent/runtime/topology.h"
+#include "tent/runtime/transport_selector.h"
 
 #ifdef USE_CUDA
 #include <cuda_runtime.h>
@@ -304,6 +305,8 @@ double TENTBenchRunner::runSingleTransfer(uint64_t local_addr,
                                           uint64_t batch_size, OpCode opcode) {
     auto batch_id = engine_->allocateBatch(batch_size);
     std::vector<Request> requests;
+    const TransportType hint = TransportSelector::parseTransportType(
+        XferBenchConfig::tent_transport_hint);
     for (uint64_t i = 0; i < batch_size; ++i) {
         Request entry;
         entry.opcode = opcode == READ ? Request::READ : Request::WRITE;
@@ -311,6 +314,7 @@ double TENTBenchRunner::runSingleTransfer(uint64_t local_addr,
         entry.source = (void*)(local_addr + block_size * i);
         entry.target_id = handle_;
         entry.target_offset = target_addr + block_size * i;
+        entry.transport_hint = hint;
         requests.emplace_back(entry);
     }
     XferBenchTimer timer;

--- a/mooncake-transfer-engine/benchmark/tent_backend.h
+++ b/mooncake-transfer-engine/benchmark/tent_backend.h
@@ -86,6 +86,7 @@ class TENTBenchRunner : public BenchRunner {
     std::vector<void*> pinned_buffer_list_;
     SegmentID handle_;
     SegmentInfo info_;
+    TransportType transport_hint_{UNSPEC};
 
     std::vector<std::function<int(int)>> current_task_;
     std::vector<std::thread> threads_;

--- a/mooncake-transfer-engine/benchmark/utils.cpp
+++ b/mooncake-transfer-engine/benchmark/utils.cpp
@@ -48,6 +48,10 @@ DEFINE_string(xport_type, "", "Transport type: rdma|shm|mnnvl|gds|iouring");
 DEFINE_string(backend, "tent", "Transport backend: classic|tent");
 DEFINE_bool(notifi, false,
             "Enable RDMA notification for performance measurement.");
+DEFINE_string(
+    tent_transport_hint, "unspec",
+    "tent only: per-request transport_hint. "
+    "unspec|rdma|tcp|shm|nvlink|gds|io_uring|mnnvl|ascend|sunrise_link");
 
 namespace mooncake {
 namespace tent {
@@ -72,6 +76,7 @@ int XferBenchConfig::rpc_server_port = 0;
 std::string XferBenchConfig::xport_type;
 std::string XferBenchConfig::backend;
 bool XferBenchConfig::notifi = false;
+std::string XferBenchConfig::tent_transport_hint;
 
 int XferBenchConfig::local_gpu_id = 0;
 int XferBenchConfig::target_gpu_id = 0;
@@ -99,6 +104,7 @@ void XferBenchConfig::loadFromFlags() {
     xport_type = FLAGS_xport_type;
     backend = FLAGS_backend;
     notifi = FLAGS_notifi;
+    tent_transport_hint = FLAGS_tent_transport_hint;
 
     local_gpu_id = FLAGS_local_gpu_id;
     target_gpu_id = FLAGS_target_gpu_id;

--- a/mooncake-transfer-engine/benchmark/utils.h
+++ b/mooncake-transfer-engine/benchmark/utils.h
@@ -73,6 +73,7 @@ struct XferBenchConfig {
     static std::string xport_type;
     static std::string backend;
     static bool notifi;
+    static std::string tent_transport_hint;
 
     static int local_gpu_id;
     static int target_gpu_id;

--- a/mooncake-transfer-engine/include/transport/transport.h
+++ b/mooncake-transfer-engine/include/transport/transport.h
@@ -64,6 +64,8 @@ class Transport {
         uint64_t target_offset;
         size_t length;
         int advise_retry_cnt = 0;
+        // Per-request transport pin, TENT only.
+        int transport_hint = 0;
     };
 
     enum TransferStatusEnum {

--- a/mooncake-transfer-engine/src/transfer_engine.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine.cpp
@@ -460,6 +460,8 @@ Status TransferEngine::submitTransfer(
             req.source = item.source;
             req.target_id = item.target_id;
             req.target_offset = item.target_offset;
+            req.transport_hint =
+                mooncake::tent::c_to_transport_hint(item.transport_hint);
             requests.push_back(req);
         }
         auto status = impl_tent_->submitTransfer(batch_id, requests);
@@ -484,6 +486,8 @@ Status TransferEngine::submitTransferWithNotify(
             req.source = item.source;
             req.target_id = item.target_id;
             req.target_offset = item.target_offset;
+            req.transport_hint =
+                mooncake::tent::c_to_transport_hint(item.transport_hint);
             requests.push_back(req);
         }
         mooncake::tent::Notification notifi;

--- a/mooncake-transfer-engine/tent/include/tent/common/types.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/types.h
@@ -43,6 +43,26 @@ struct Notification {
 #define LOCAL_SEGMENT_ID (0ull)
 #endif
 
+enum TransportType {
+    UNSPEC = 0,
+    RDMA,
+    MNNVL,
+    SHM,
+    NVLINK,
+    GDS,
+    IOURING,
+    TCP,
+    AscendDirect,
+    SUNRISE_LINK,
+};
+
+const static int kSupportedTransportTypes = (int)SUNRISE_LINK + 1;
+
+inline TransportType c_to_transport_hint(int v) {
+    if (v < 0 || v >= kSupportedTransportTypes) return UNSPEC;
+    return static_cast<TransportType>(v);
+}
+
 struct Request {
     enum OpCode { READ, WRITE };
     OpCode opcode;
@@ -54,6 +74,9 @@ struct Request {
         PRIO_HIGH;  // Request priority (PRIO_HIGH, PRIO_MEDIUM, PRIO_LOW)
     std::optional<std::string>
         policy_name;  // Optional: bind to specific policy by name
+    TransportType transport_hint =
+        UNSPEC;  // UNSPEC = follow policy; otherwise pin this request to the
+                 // name transport.
 };
 
 enum TransferStatusEnum {
@@ -79,20 +102,6 @@ enum Permission {
 
 using Location = std::string;
 const static std::string kWildcardLocation = "*";
-
-enum TransportType {
-    RDMA = 0,
-    MNNVL,
-    SHM,
-    NVLINK,
-    GDS,
-    IOURING,
-    TCP,
-    AscendDirect,
-    SUNRISE_LINK,
-    UNSPEC
-};
-const static int kSupportedTransportTypes = (int)TransportType::UNSPEC;
 
 struct MemoryOptions {
     Location location = kWildcardLocation;

--- a/mooncake-transfer-engine/tent/include/tent/common/types.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/types.h
@@ -54,9 +54,11 @@ enum TransportType {
     TCP,
     AscendDirect,
     SUNRISE_LINK,
+    // Sentinel: must remain the last enumerator.
+    kNumTransportTypes,
 };
 
-const static int kSupportedTransportTypes = (int)SUNRISE_LINK + 1;
+const static int kSupportedTransportTypes = (int)kNumTransportTypes;
 
 inline TransportType c_to_transport_hint(int v) {
     if (v < 0 || v >= kSupportedTransportTypes) return UNSPEC;

--- a/mooncake-transfer-engine/tent/include/tent/common/types.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/types.h
@@ -43,7 +43,7 @@ struct Notification {
 #define LOCAL_SEGMENT_ID (0ull)
 #endif
 
-enum TransportType {
+enum TransportType : int {
     UNSPEC = 0,
     RDMA,
     MNNVL,

--- a/mooncake-transfer-engine/tent/include/tent/runtime/topology.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/topology.h
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef TOPOLOGY_H
-#define TOPOLOGY_H
+// NOTE: Guard renamed from TOPOLOGY_H to avoid collision with the classic
+// transfer-engine's mooncake-transfer-engine/include/topology.h, which also
+// uses TOPOLOGY_H. 
+#ifndef TENT_TOPOLOGY_H
+#define TENT_TOPOLOGY_H
 
 #include <glog/logging.h>
 #include <netdb.h>
@@ -137,4 +140,4 @@ struct RangeLocation {
 }  // namespace tent
 }  // namespace mooncake
 
-#endif  // TOPOLOGY_H
+#endif  // TENT_TOPOLOGY_H

--- a/mooncake-transfer-engine/tent/include/tent/runtime/topology.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/topology.h
@@ -14,7 +14,7 @@
 
 // NOTE: Guard renamed from TOPOLOGY_H to avoid collision with the classic
 // transfer-engine's mooncake-transfer-engine/include/topology.h, which also
-// uses TOPOLOGY_H. 
+// uses TOPOLOGY_H.
 #ifndef TENT_TOPOLOGY_H
 #define TENT_TOPOLOGY_H
 

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -210,6 +210,9 @@ class TransferEngineImpl {
     SelectionResult resolveTransport(const Request& req, int transport_index,
                                      bool invalidate_on_fail = true);
 
+    // Verify that req.transport_hint is usable for this request
+    Status validateTransportHint(const Request& req, size_t request_index);
+
     Status loadTransports();
 
     void findStagingPolicy(const Request& req,

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transport_selector.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transport_selector.h
@@ -169,6 +169,8 @@ class TransportSelector {
 
     static std::string transportTypeName(TransportType type);
     static TransportType parseTransportType(const std::string& str);
+    static std::optional<std::vector<TransportType>> reorderWithHint(
+        const std::vector<TransportType>& raw, TransportType hint);
 
    private:
     std::vector<SelectionPolicy> getDefaultPolicies();

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transport_selector.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transport_selector.h
@@ -147,13 +147,15 @@ class TransportSelector {
      * @param available_transports Array of available transports
      * @param transport_index Transport selection index (0 = first choice, 1 =
      * second, ...)
+     * @param hint The caller's preferred transport for this request;
+     * UNSPEC means no hint.
      * @return Selection result with transport type and device mask
      */
     SelectionResult select(
         const SelectionContext& context,
         const std::array<std::shared_ptr<Transport>, kSupportedTransportTypes>&
             available_transports,
-        int transport_index = 0);
+        int transport_index = 0, TransportType hint = UNSPEC);
 
     /**
      * @brief Enable legacy mode (skip TransportSelector, use original logic)

--- a/mooncake-transfer-engine/tent/include/tent/transfer_engine.h
+++ b/mooncake-transfer-engine/tent/include/tent/transfer_engine.h
@@ -32,6 +32,9 @@ extern "C" {
 #define OPCODE_READ (0)
 #define OPCODE_WRITE (1)
 
+/* IMPORTANT: callers MUST zero-initialize this struct
+ * (e.g. `tent_request_t r = {0};`). transport_hint relies on
+ * UNSPEC == 0 for the no-hint default. */
 struct tent_request {
     int opcode;
     void* source;

--- a/mooncake-transfer-engine/tent/include/tent/transfer_engine.h
+++ b/mooncake-transfer-engine/tent/include/tent/transfer_engine.h
@@ -38,7 +38,8 @@ struct tent_request {
     tent_segment_id_t target_id;
     uint64_t target_offset;
     uint64_t length;
-    int priority; /* Request priority (0=HIGH, 1=MEDIUM, 2=LOW) */
+    int priority;       /* Request priority (0=HIGH, 1=MEDIUM, 2=LOW) */
+    int transport_hint; /* TRANSPORT_UNSPEC=follow policy, else pin transport */
 };
 
 typedef struct tent_request tent_request_t;
@@ -95,15 +96,16 @@ typedef struct tent_notifi_info tent_notifi_info;
 #define PERM_GLOBAL_READ_ONLY (1)
 #define PERM_GLOBAL_READ_WRITE (2)
 
-#define TRANSPORT_RDMA (0)
-#define TRANSPORT_MNNVL (1)
-#define TRANSPORT_SHM (2)
-#define TRANSPORT_NVLINK (3)
-#define TRANSPORT_GDS (4)
-#define TRANSPORT_IOURING (5)
-#define TRANSPORT_TCP (6)
-#define TRANSPORT_ASCEND_DIRECT (7)
-#define TRANSPORT_UNSPEC (8)
+#define TRANSPORT_UNSPEC (0)
+#define TRANSPORT_RDMA (1)
+#define TRANSPORT_MNNVL (2)
+#define TRANSPORT_SHM (3)
+#define TRANSPORT_NVLINK (4)
+#define TRANSPORT_GDS (5)
+#define TRANSPORT_IOURING (6)
+#define TRANSPORT_TCP (7)
+#define TRANSPORT_ASCEND_DIRECT (8)
+#define TRANSPORT_SUNRISE_LINK (9)
 
 struct tent_memory_options {
     char location[64];

--- a/mooncake-transfer-engine/tent/src/python/pybind.cpp
+++ b/mooncake-transfer-engine/tent/src/python/pybind.cpp
@@ -289,6 +289,7 @@ PYBIND11_MODULE(tent, m) {
         .export_values();
 
     py::enum_<TransportType>(m, "TransportType")
+        .value("UNSPEC", TransportType::UNSPEC)
         .value("RDMA", TransportType::RDMA)
         .value("MNNVL", TransportType::MNNVL)
         .value("SHM", TransportType::SHM)
@@ -297,7 +298,7 @@ PYBIND11_MODULE(tent, m) {
         .value("IOURING", TransportType::IOURING)
         .value("TCP", TransportType::TCP)
         .value("AscendDirect", TransportType::AscendDirect)
-        .value("UNSPEC", TransportType::UNSPEC)
+        .value("SUNRISE_LINK", TransportType::SUNRISE_LINK)
         .export_values();
 
     py::enum_<SegmentInfo::Type>(m, "SegmentInfoType")
@@ -319,7 +320,8 @@ PYBIND11_MODULE(tent, m) {
         .def(py::init<>())
         .def(py::init([](Request::OpCode opcode, uint64_t source,
                          uint64_t target_id, uint64_t target_offset,
-                         size_t length, int priority) {
+                         size_t length, int priority,
+                         TransportType transport_hint) {
                  Request r;
                  r.opcode = opcode;
                  r.source = U64ToPtr(source);
@@ -327,11 +329,13 @@ PYBIND11_MODULE(tent, m) {
                  r.target_offset = target_offset;
                  r.length = length;
                  r.priority = priority;
+                 r.transport_hint = transport_hint;
                  return r;
              }),
              py::arg("opcode"), py::arg("source"), py::arg("target_id"),
              py::arg("target_offset"), py::arg("length"),
-             py::arg("priority") = PRIO_HIGH)
+             py::arg("priority") = PRIO_HIGH,
+             py::arg("transport_hint") = TransportType::UNSPEC)
         .def_property(
             "opcode", [](const Request& r) { return r.opcode; },
             [](Request& r, Request::OpCode op) { r.opcode = op; })
@@ -341,7 +345,8 @@ PYBIND11_MODULE(tent, m) {
         .def_readwrite("target_id", &Request::target_id)
         .def_readwrite("target_offset", &Request::target_offset)
         .def_readwrite("length", &Request::length)
-        .def_readwrite("priority", &Request::priority);
+        .def_readwrite("priority", &Request::priority)
+        .def_readwrite("transport_hint", &Request::transport_hint);
 
     py::class_<TransferStatus>(m, "TransferStatus")
         .def(py::init<>())

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -870,22 +870,13 @@ SelectionResult TransferEngineImpl::getTransportType(const Request& request,
             }
         }
 
-        bool prepend_hint = false;
-        if (hint != UNSPEC) {
-            if (std::find(raw.begin(), raw.end(), hint) == raw.end()) {
-                return result;  // UNSPEC: hint not authorized for this req
-            }
-            prepend_hint = true;
-        }
-        std::vector<TransportType> candidates;
-        if (prepend_hint) candidates.push_back(hint);
-        for (auto type : raw) {
-            if (prepend_hint && type == hint) continue;
-            candidates.push_back(type);
+        auto candidates = TransportSelector::reorderWithHint(raw, hint);
+        if (!candidates) {
+            return result;  // UNSPEC: hint not authorized for this req
         }
         if (transport_index >= 0 &&
-            (size_t)transport_index < candidates.size()) {
-            result.transport = candidates[transport_index];
+            (size_t)transport_index < candidates->size()) {
+            result.transport = (*candidates)[transport_index];
         }
         return result;
     }

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -607,14 +607,14 @@ std::vector<TransportType> TransferEngineImpl::getSupportedTransports(
         }
         return result;
     }
-    if (transport_list_[MNNVL]) result.push_back(MNNVL);
-    if (transport_list_[NVLINK]) result.push_back(NVLINK);
     if (transport_list_[RDMA]) result.push_back(RDMA);
-    if (transport_list_[SUNRISE_LINK]) result.push_back(SUNRISE_LINK);
-    if (transport_list_[AscendDirect]) result.push_back(AscendDirect);
+    if (transport_list_[MNNVL]) result.push_back(MNNVL);
     if (transport_list_[SHM]) result.push_back(SHM);
-    if (transport_list_[TCP]) result.push_back(TCP);
+    if (transport_list_[NVLINK]) result.push_back(NVLINK);
     if (transport_list_[GDS]) result.push_back(GDS);
+    if (transport_list_[TCP]) result.push_back(TCP);
+    if (transport_list_[AscendDirect]) result.push_back(AscendDirect);
+    if (transport_list_[SUNRISE_LINK]) result.push_back(SUNRISE_LINK);
     return result;
 }
 
@@ -804,6 +804,25 @@ static MemoryType getTypeEnum(const std::string& type) {
     return MTYPE_UNKNOWN;
 }
 
+Status TransferEngineImpl::validateTransportHint(const Request& req,
+                                                 size_t request_index) {
+    if (req.transport_hint == UNSPEC) return Status::OK();
+    if ((int)req.transport_hint < 0 ||
+        (int)req.transport_hint >= kSupportedTransportTypes) {
+        return Status::InvalidArgument(
+            "transport_hint out of range for request[" +
+            std::to_string(request_index) + "]" LOC_MARK);
+    }
+    if (!transport_list_[req.transport_hint]) {
+        return Status::InvalidArgument(
+            "transport_hint=" +
+            TransportSelector::transportTypeName(req.transport_hint) +
+            " is not enabled in config (request[" +
+            std::to_string(request_index) + "])" LOC_MARK);
+    }
+    return Status::OK();
+}
+
 SelectionResult TransferEngineImpl::getTransportType(const Request& request,
                                                      int transport_index) {
     SegmentDesc* desc;
@@ -816,16 +835,17 @@ SelectionResult TransferEngineImpl::getTransportType(const Request& request,
     }
     auto local_mtype = Platform::getLoader().getMemoryType(request.source);
 
+    const TransportType hint = request.transport_hint;
+
     // Legacy mode: use original logic (before TransportSelector)
     if (transport_selector_ && transport_selector_->isLegacyMode()) {
         SelectionResult result;
+        std::vector<TransportType> raw;
         if (desc->type == SegmentType::File) {
-            if (checkAvailability(transport_list_[GDS], local_mtype)) {
-                if (transport_index-- == 0) result.transport = GDS;
-            }
-            if (checkAvailability(transport_list_[IOURING], local_mtype)) {
-                if (transport_index-- == 0) result.transport = IOURING;
-            }
+            if (checkAvailability(transport_list_[GDS], local_mtype))
+                raw.push_back(GDS);
+            if (checkAvailability(transport_list_[IOURING], local_mtype))
+                raw.push_back(IOURING);
         } else {
             auto entry =
                 desc->findBuffer(request.target_offset, request.length);
@@ -844,19 +864,34 @@ SelectionResult TransferEngineImpl::getTransportType(const Request& request,
                         continue;
                     if (checkAvailability(transport_list_[type], local_mtype,
                                           remote_mtype)) {
-                        if (transport_index-- == 0) {
-                            result.transport = type;
-                            break;
-                        }
+                        raw.push_back(type);
                     }
                 }
             }
         }
+
+        bool prepend_hint = false;
+        if (hint != UNSPEC) {
+            if (std::find(raw.begin(), raw.end(), hint) == raw.end()) {
+                return result;  // UNSPEC: hint not authorized for this req
+            }
+            prepend_hint = true;
+        }
+        std::vector<TransportType> candidates;
+        if (prepend_hint) candidates.push_back(hint);
+        for (auto type : raw) {
+            if (prepend_hint && type == hint) continue;
+            candidates.push_back(type);
+        }
+        if (transport_index >= 0 &&
+            (size_t)transport_index < candidates.size()) {
+            result.transport = candidates[transport_index];
+        }
         return result;
     }
 
-    // New TransportSelector-based logic
-    // Build selection context
+    // Selector mode: build ctx, then defer everything to
+    // TransportSelector::select().
     SelectionContext ctx;
     ctx.transfer_size = request.length;
     ctx.priority_level =
@@ -870,9 +905,6 @@ SelectionResult TransferEngineImpl::getTransportType(const Request& request,
         ctx.local_memory_type = local_mtype;
         ctx.remote_memory_type = MTYPE_CPU;
         ctx.buffer_transports = nullptr;  // Empty - use policy priority
-
-        return transport_selector_->select(ctx, transport_list_,
-                                           transport_index);
     } else {
         // Memory segment
         auto entry = desc->findBuffer(request.target_offset, request.length);
@@ -887,14 +919,16 @@ SelectionResult TransferEngineImpl::getTransportType(const Request& request,
         ctx.local_memory_type = local_mtype;
         ctx.remote_memory_type = remote_mtype;
         ctx.buffer_transports = &entry->transports;
-
-        return transport_selector_->select(ctx, transport_list_,
-                                           transport_index);
     }
+
+    return transport_selector_->select(ctx, transport_list_, transport_index,
+                                       hint);
 }
 
 static const char* transportTypeName(TransportType type) {
     switch (type) {
+        case UNSPEC:
+            return "UNSPEC";
         case RDMA:
             return "RDMA";
         case MNNVL:
@@ -911,9 +945,10 @@ static const char* transportTypeName(TransportType type) {
             return "TCP";
         case AscendDirect:
             return "AscendDirect";
-        default:
-            return "UNSPEC";
+        case SUNRISE_LINK:
+            return "SUNRISE_LINK";
     }
+    return "UNKNOWN";
 }
 
 std::string printRequest(const Request& request) {
@@ -989,6 +1024,8 @@ MergeResult mergeRequests(const std::vector<Request>& requests,
         if (a.req.opcode != b.req.opcode) return a.req.opcode < b.req.opcode;
         if (a.req.target_id != b.req.target_id)
             return a.req.target_id < b.req.target_id;
+        if (a.req.transport_hint != b.req.transport_hint)
+            return a.req.transport_hint < b.req.transport_hint;
         if (a.req.target_offset != b.req.target_offset)
             return a.req.target_offset < b.req.target_offset;
         return requestSourceAddr(a.req) < requestSourceAddr(b.req);
@@ -997,6 +1034,10 @@ MergeResult mergeRequests(const std::vector<Request>& requests,
     auto can_merge = [](const Item& last, const Item& curr) {
         if (last.req.opcode != curr.req.opcode ||
             last.req.target_id != curr.req.target_id) {
+            return false;
+        }
+        // Mixed transport_hint inside one batch must not be merged.
+        if (last.req.transport_hint != curr.req.transport_hint) {
             return false;
         }
         if (!last.boundary.source_key || !curr.boundary.source_key ||
@@ -1169,6 +1210,11 @@ Status TransferEngineImpl::submitTransfer(
     BatchID batch_id, const std::vector<Request>& request_list) {
     if (!batch_id) return Status::InvalidArgument("Invalid batch ID" LOC_MARK);
     Batch* batch = (Batch*)(batch_id);
+
+    for (size_t i = 0; i < request_list.size(); ++i) {
+        auto st = validateTransportHint(request_list[i], i);
+        if (!st.ok()) return st;
+    }
 
     std::vector<Request> classified_request_list[kSupportedTransportTypes];
     std::vector<size_t> task_id_list[kSupportedTransportTypes];

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -946,7 +946,8 @@ std::string printRequest(const Request& request) {
     std::stringstream ss;
     ss << "opcode " << request.opcode << " source " << request.source
        << " target_id " << request.target_id << " target_offset "
-       << (void*)request.target_offset << " length " << request.length;
+       << (void*)request.target_offset << " length " << request.length
+       << " transport_hint " << transportTypeName(request.transport_hint);
     return ss.str();
 }
 

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -607,14 +607,14 @@ std::vector<TransportType> TransferEngineImpl::getSupportedTransports(
         }
         return result;
     }
-    if (transport_list_[RDMA]) result.push_back(RDMA);
     if (transport_list_[MNNVL]) result.push_back(MNNVL);
-    if (transport_list_[SHM]) result.push_back(SHM);
     if (transport_list_[NVLINK]) result.push_back(NVLINK);
-    if (transport_list_[GDS]) result.push_back(GDS);
-    if (transport_list_[TCP]) result.push_back(TCP);
-    if (transport_list_[AscendDirect]) result.push_back(AscendDirect);
+    if (transport_list_[RDMA]) result.push_back(RDMA);
     if (transport_list_[SUNRISE_LINK]) result.push_back(SUNRISE_LINK);
+    if (transport_list_[AscendDirect]) result.push_back(AscendDirect);
+    if (transport_list_[SHM]) result.push_back(SHM);
+    if (transport_list_[TCP]) result.push_back(TCP);
+    if (transport_list_[GDS]) result.push_back(GDS);
     return result;
 }
 

--- a/mooncake-transfer-engine/tent/src/runtime/transport_selector.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transport_selector.cpp
@@ -17,6 +17,7 @@
 #include "tent/runtime/platform.h"
 #include "tent/thirdparty/nlohmann/json.h"
 
+#include <algorithm>
 #include <glog/logging.h>
 
 namespace mooncake {
@@ -408,39 +409,24 @@ SelectionResult TransportSelector::select(
     if (transport_index < 0) return result;
     const int original_index = transport_index;
 
-    // hint, if present, occupies slot 0.
+    auto candidates = reorderWithHint(raw, hint);
+    if (!candidates) return result;  // UNSPEC -> task FAILED downstream
+
     const bool has_hint = (hint != UNSPEC);
-    if (has_hint) {
-        bool in_raw = false;
-        for (TransportType t : raw) {
-            if (t == hint) {
-                in_raw = true;
-                break;
-            }
-        }
-        if (!in_raw ||
-            !isTransportAvailable(hint, context, available_transports)) {
-            return result;  // UNSPEC -> task FAILED downstream
+    for (size_t i = 0; i < candidates->size(); ++i) {
+        TransportType type = (*candidates)[i];
+        if (!isTransportAvailable(type, context, available_transports)) {
+            // The pinned hint at slot 0 must be available; if it isn't,
+            // reject the request rather than falling through to another
+            // transport the caller did not ask for.
+            if (has_hint && i == 0) return result;
+            continue;
         }
         if (transport_index == 0) {
-            result.transport = hint;
-        } else {
-            --transport_index;
+            result.transport = type;
+            break;
         }
-    }
-
-    // Walk raw skipping hint and decrement transport_index until it hits zero.
-    if (result.transport == UNSPEC) {
-        for (TransportType type : raw) {
-            if (has_hint && type == hint) continue;
-            if (!isTransportAvailable(type, context, available_transports))
-                continue;
-            if (transport_index == 0) {
-                result.transport = type;
-                break;
-            }
-            --transport_index;
-        }
+        --transport_index;
     }
     if (result.transport == UNSPEC) return result;
     VLOG(1) << "Selected transport " << transportTypeName(result.transport)
@@ -449,6 +435,21 @@ SelectionResult TransportSelector::select(
             << "), device_mask=0x" << std::hex << result.device_mask
             << std::dec;
     return result;
+}
+
+std::optional<std::vector<TransportType>> TransportSelector::reorderWithHint(
+    const std::vector<TransportType>& raw, TransportType hint) {
+    if (hint == UNSPEC) return raw;
+    if (std::find(raw.begin(), raw.end(), hint) == raw.end()) {
+        return std::nullopt;
+    }
+    std::vector<TransportType> out;
+    out.reserve(raw.size());
+    out.push_back(hint);
+    for (TransportType t : raw) {
+        if (t != hint) out.push_back(t);
+    }
+    return out;
 }
 
 }  // namespace tent

--- a/mooncake-transfer-engine/tent/src/runtime/transport_selector.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transport_selector.cpp
@@ -25,16 +25,20 @@ namespace tent {
 // Transport type name mapping
 static const std::unordered_map<std::string, TransportType> kTransportNameMap =
     {
-        {"rdma", RDMA},           {"tcp", TCP},     {"shm", SHM},
-        {"nvlink", NVLINK},       {"gds", GDS},     {"io_uring", IOURING},
-        {"ascend", AscendDirect}, {"mnnvl", MNNVL},
+        {"unspec", UNSPEC},       {"rdma", RDMA},
+        {"mnnvl", MNNVL},         {"shm", SHM},
+        {"nvlink", NVLINK},       {"gds", GDS},
+        {"io_uring", IOURING},    {"tcp", TCP},
+        {"ascend", AscendDirect}, {"sunrise_link", SUNRISE_LINK},
 };
 
 static const std::unordered_map<TransportType, std::string>
     kTransportTypeNames = {
-        {RDMA, "rdma"},           {TCP, "tcp"},     {SHM, "shm"},
-        {NVLINK, "nvlink"},       {GDS, "gds"},     {IOURING, "io_uring"},
-        {AscendDirect, "ascend"}, {MNNVL, "mnnvl"}, {UNSPEC, "unspec"},
+        {UNSPEC, "unspec"},       {RDMA, "rdma"},
+        {MNNVL, "mnnvl"},         {SHM, "shm"},
+        {NVLINK, "nvlink"},       {GDS, "gds"},
+        {IOURING, "io_uring"},    {TCP, "tcp"},
+        {AscendDirect, "ascend"}, {SUNRISE_LINK, "sunrise_link"},
 };
 
 // Memory type name mapping for pattern matching
@@ -354,7 +358,7 @@ SelectionResult TransportSelector::select(
     const SelectionContext& context,
     const std::array<std::shared_ptr<Transport>, kSupportedTransportTypes>&
         available_transports,
-    int transport_index) {
+    int transport_index, TransportType hint) {
     SelectionResult result;
 
     // Find the first matching policy (JSON order wins)
@@ -392,41 +396,58 @@ SelectionResult TransportSelector::select(
         }
     }
 
-    // If policy has transports list, use it
-    if (!matching_policy->transports.empty()) {
-        int priority_index = transport_index;
-        for (size_t i = 0; i < matching_policy->transports.size(); ++i) {
-            TransportType type = matching_policy->transports[i];
-            if (isTransportAvailable(type, context, available_transports)) {
-                if (priority_index-- <= 0) {
-                    result.transport = type;
-                    VLOG(1) << "Selected transport " << transportTypeName(type)
-                            << " for policy " << matching_policy->name
-                            << ", device_mask=0x" << std::hex
-                            << result.device_mask << std::dec;
-                    return result;
-                }
+    // The "raw" candidate set is whatever the matching policy authorizes:
+    // the policy's explicit transports list, or the buffer's registered
+    // transports as a fallback.
+    static const std::vector<TransportType> kEmpty;
+    const auto& raw = !matching_policy->transports.empty()
+                          ? matching_policy->transports
+                      : context.buffer_transports ? *context.buffer_transports
+                                                  : kEmpty;
+
+    if (transport_index < 0) return result;
+    const int original_index = transport_index;
+
+    // hint, if present, occupies slot 0.
+    const bool has_hint = (hint != UNSPEC);
+    if (has_hint) {
+        bool in_raw = false;
+        for (TransportType t : raw) {
+            if (t == hint) {
+                in_raw = true;
+                break;
             }
         }
-        return result;  // UNSPEC
-    }
-
-    // Otherwise, use buffer_transports order (original behavior)
-    if (context.buffer_transports) {
-        for (auto type : *context.buffer_transports) {
-            if (isTransportAvailable(type, context, available_transports)) {
-                if (transport_index-- <= 0) {
-                    result.transport = type;
-                    VLOG(1) << "Selected transport " << transportTypeName(type)
-                            << " from buffer_transports"
-                            << ", device_mask=0x" << std::hex
-                            << result.device_mask << std::dec;
-                    return result;
-                }
-            }
+        if (!in_raw ||
+            !isTransportAvailable(hint, context, available_transports)) {
+            return result;  // UNSPEC -> task FAILED downstream
+        }
+        if (transport_index == 0) {
+            result.transport = hint;
+        } else {
+            --transport_index;
         }
     }
 
+    // Walk raw skipping hint and decrement transport_index until it hits zero.
+    if (result.transport == UNSPEC) {
+        for (TransportType type : raw) {
+            if (has_hint && type == hint) continue;
+            if (!isTransportAvailable(type, context, available_transports))
+                continue;
+            if (transport_index == 0) {
+                result.transport = type;
+                break;
+            }
+            --transport_index;
+        }
+    }
+    if (result.transport == UNSPEC) return result;
+    VLOG(1) << "Selected transport " << transportTypeName(result.transport)
+            << " for policy " << matching_policy->name << " at index "
+            << original_index << " (hint=" << transportTypeName(hint)
+            << "), device_mask=0x" << std::hex << result.device_mask
+            << std::dec;
     return result;
 }
 

--- a/mooncake-transfer-engine/tent/src/transfer_engine_c.cpp
+++ b/mooncake-transfer-engine/tent/src/transfer_engine_c.cpp
@@ -217,6 +217,8 @@ int tent_submit(tent_engine_t engine, tent_batch_id_t batch_id,
         req_list[index].target_offset = entries[index].target_offset;
         req_list[index].length = entries[index].length;
         req_list[index].priority = entries[index].priority;
+        req_list[index].transport_hint =
+            mooncake::tent::c_to_transport_hint(entries[index].transport_hint);
     }
     auto status = CAST(engine)->submitTransfer(batch_id, req_list);
     if (!status.ok()) {
@@ -243,6 +245,8 @@ int tent_submit_notif(tent_engine_t engine, tent_batch_id_t batch_id,
         req_list[index].target_offset = entries[index].target_offset;
         req_list[index].length = entries[index].length;
         req_list[index].priority = entries[index].priority;
+        req_list[index].transport_hint =
+            mooncake::tent::c_to_transport_hint(entries[index].transport_hint);
     }
     mooncake::tent::Notification notifi;
     notifi.name = name;

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -123,6 +123,18 @@ target_include_directories(tent_engine_failover_e2e_test
 add_test(NAME tent_engine_failover_e2e_test
          COMMAND tent_engine_failover_e2e_test)
 
+# Per-request transport_hint: validates submitTransfer parameter, routing,
+# disabled-transport rejection, out-of-range rejection, mixed-hint batches.
+add_executable(tent_transport_hint_test transport_hint_test.cpp)
+target_link_libraries(tent_transport_hint_test
+                      PRIVATE gtest gtest_main tent_link_group)
+if(TARGET asio_shared)
+  target_link_libraries(tent_transport_hint_test PRIVATE asio_shared)
+endif()
+target_include_directories(tent_transport_hint_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+add_test(NAME tent_transport_hint_test COMMAND tent_transport_hint_test)
+
 # ProgressWorker skeleton test: covers default-off behavior, event-driven
 # progress without poll-failover, and freeBatch races (issue #2116).
 add_executable(tent_progress_worker_test progress_worker_test.cpp)

--- a/mooncake-transfer-engine/tent/tests/failover_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/failover_test.cpp
@@ -134,7 +134,8 @@ TEST(TransportTypeTest, UnspecIsZeroSlot) {
     // rather than silently pinning to whichever transport happened
     // to occupy slot 0.
     EXPECT_EQ(static_cast<int>(UNSPEC), 0);
-    EXPECT_EQ(kSupportedTransportTypes, static_cast<int>(SUNRISE_LINK) + 1);
+    EXPECT_EQ(kSupportedTransportTypes, static_cast<int>(kNumTransportTypes));
+    EXPECT_GT(kSupportedTransportTypes, static_cast<int>(UNSPEC));
 }
 
 // ---------------------------------------------------------------------------

--- a/mooncake-transfer-engine/tent/tests/failover_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/failover_test.cpp
@@ -128,11 +128,13 @@ TEST(FailoverConfigTest, AutoFailoverOnPollCanBeDisabled) {
 // verify the enum values are well-defined and usable in switch)
 // ---------------------------------------------------------------------------
 
-TEST(TransportTypeTest, UnspecIsSentinel) {
-    // UNSPEC must be the last enum value so that types [0, UNSPEC) are the
-    // valid transport types and kSupportedTransportTypes == (int)UNSPEC.
-    EXPECT_GT(kSupportedTransportTypes, 0);
-    EXPECT_EQ(kSupportedTransportTypes, static_cast<int>(UNSPEC));
+TEST(TransportTypeTest, UnspecIsZeroSlot) {
+    // UNSPEC must be value 0 so that zero-initialized tent_request /
+    // tent_memory_options structs (the C ABI) default to UNSPEC
+    // rather than silently pinning to whichever transport happened 
+    // to occupy slot 0.
+    EXPECT_EQ(static_cast<int>(UNSPEC), 0);
+    EXPECT_EQ(kSupportedTransportTypes, static_cast<int>(SUNRISE_LINK) + 1);
 }
 
 // ---------------------------------------------------------------------------

--- a/mooncake-transfer-engine/tent/tests/failover_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/failover_test.cpp
@@ -131,7 +131,7 @@ TEST(FailoverConfigTest, AutoFailoverOnPollCanBeDisabled) {
 TEST(TransportTypeTest, UnspecIsZeroSlot) {
     // UNSPEC must be value 0 so that zero-initialized tent_request /
     // tent_memory_options structs (the C ABI) default to UNSPEC
-    // rather than silently pinning to whichever transport happened 
+    // rather than silently pinning to whichever transport happened
     // to occupy slot 0.
     EXPECT_EQ(static_cast<int>(UNSPEC), 0);
     EXPECT_EQ(kSupportedTransportTypes, static_cast<int>(SUNRISE_LINK) + 1);

--- a/mooncake-transfer-engine/tent/tests/request_merge_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/request_merge_test.cpp
@@ -113,6 +113,105 @@ TEST(RequestMergeTest, KeepsNonContiguousRequestsSplit) {
     EXPECT_EQ(merged.task_lookup.at(1), 1u);
 }
 
+TEST(RequestMergeTest, DoesNotMergeAcrossDifferentTransportHint) {
+    std::array<char, 2048> source{};
+    const auto source_addr =
+        static_cast<uint64_t>(reinterpret_cast<uintptr_t>(source.data()));
+
+    std::vector<Request> requests = {
+        makeWriteRequest(source.data(), 0, 4096, 1024),
+        makeWriteRequest(source.data(), 1024, 5120, 1024),
+    };
+    requests[0].transport_hint = TransportType::RDMA;
+    requests[1].transport_hint = TransportType::TCP;
+
+    std::vector<RequestBoundaryInfo> boundaries = {
+        {makeBufferKey(source_addr, 2048), makeBufferKey(4096, 2048)},
+        {makeBufferKey(source_addr, 2048), makeBufferKey(4096, 2048)},
+    };
+
+    auto merged = mergeRequests(requests, boundaries, true);
+
+    // Mixed hints across an otherwise-contiguous run must stay split,
+    // otherwise the merged request would carry only one hint and the
+    // other half's pinning would silently disappear.
+    ASSERT_EQ(merged.request_list.size(), 2u);
+    EXPECT_EQ(merged.request_list[0].length, 1024u);
+    EXPECT_EQ(merged.request_list[1].length, 1024u);
+    EXPECT_NE(merged.request_list[0].transport_hint,
+              merged.request_list[1].transport_hint);
+}
+
+TEST(RequestMergeTest, MergesAdjacentRequestsWithSameTransportHint) {
+    std::array<char, 2048> source{};
+    const auto source_addr =
+        static_cast<uint64_t>(reinterpret_cast<uintptr_t>(source.data()));
+
+    std::vector<Request> requests = {
+        makeWriteRequest(source.data(), 0, 4096, 1024),
+        makeWriteRequest(source.data(), 1024, 5120, 1024),
+    };
+    requests[0].transport_hint = TransportType::TCP;
+    requests[1].transport_hint = TransportType::TCP;
+
+    std::vector<RequestBoundaryInfo> boundaries = {
+        {makeBufferKey(source_addr, 2048), makeBufferKey(4096, 2048)},
+        {makeBufferKey(source_addr, 2048), makeBufferKey(4096, 2048)},
+    };
+
+    auto merged = mergeRequests(requests, boundaries, true);
+
+    // Regression guard: adding transport_hint must not break merging
+    // when the hint is the same on both sides.
+    ASSERT_EQ(merged.request_list.size(), 1u);
+    EXPECT_EQ(merged.request_list[0].length, 2048u);
+    EXPECT_EQ(merged.request_list[0].transport_hint, TransportType::TCP);
+    EXPECT_EQ(merged.task_lookup.at(0), 0u);
+    EXPECT_EQ(merged.task_lookup.at(1), 0u);
+}
+
+TEST(RequestMergeTest, MixedHintBatchStillMergesPerHint) {
+    std::array<char, 4096> source{};
+    const auto source_addr =
+        static_cast<uint64_t>(reinterpret_cast<uintptr_t>(source.data()));
+
+    // Four requests interleave RDMA / TCP in submission order, but within
+    // each hint group both source and target are contiguous. After the
+    // hint-aware sort, the two RDMA requests fold into one, and the two
+    // TCP requests fold into the other.
+    //
+    // RDMA source pair: bytes [0, 2048) -> target [4096, 6144)
+    // TCP  source pair: bytes [2048, 4096) -> target [8192, 10240)
+    std::vector<Request> requests = {
+        makeWriteRequest(source.data(), 0, 4096, 1024),     // RDMA
+        makeWriteRequest(source.data(), 2048, 8192, 1024),  // TCP
+        makeWriteRequest(source.data(), 1024, 5120, 1024),  // RDMA (contig)
+        makeWriteRequest(source.data(), 3072, 9216, 1024),  // TCP  (contig)
+    };
+    requests[0].transport_hint = TransportType::RDMA;
+    requests[1].transport_hint = TransportType::TCP;
+    requests[2].transport_hint = TransportType::RDMA;
+    requests[3].transport_hint = TransportType::TCP;
+
+    std::vector<RequestBoundaryInfo> boundaries = {
+        {makeBufferKey(source_addr, 4096), makeBufferKey(4096, 6144)},
+        {makeBufferKey(source_addr, 4096), makeBufferKey(8192, 2048)},
+        {makeBufferKey(source_addr, 4096), makeBufferKey(4096, 6144)},
+        {makeBufferKey(source_addr, 4096), makeBufferKey(8192, 2048)},
+    };
+
+    auto merged = mergeRequests(requests, boundaries, true);
+
+    ASSERT_EQ(merged.request_list.size(), 2u);
+    // 0,2 (RDMA, contiguous on src+target) → one merged request, len 2048.
+    // 1,3 (TCP, contiguous on src+target)  → one merged request, len 2048.
+    EXPECT_EQ(merged.request_list[0].length, 2048u);
+    EXPECT_EQ(merged.request_list[1].length, 2048u);
+    EXPECT_EQ(merged.task_lookup.at(0), merged.task_lookup.at(2));
+    EXPECT_EQ(merged.task_lookup.at(1), merged.task_lookup.at(3));
+    EXPECT_NE(merged.task_lookup.at(0), merged.task_lookup.at(1));
+}
+
 }  // namespace
 }  // namespace tent
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tent/tests/transport_hint_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/transport_hint_test.cpp
@@ -1,0 +1,351 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// End-to-end tests for Request::transport_hint added to
+// TransferEngineImpl::submitTransfer:
+//   * hint == UNSPEC keeps existing policy-driven behavior;
+//   * hint pinned to RDMA / TCP routes the request onto that transport;
+//   * hint to a disabled / capability-mismatched transport returns
+//     InvalidArgument and does not mutate batch state;
+//   * out-of-range hint is rejected up front.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "tent/common/config.h"
+#include "tent/common/types.h"
+#include "tent/runtime/segment.h"
+#include "tent/runtime/transfer_engine_impl.h"
+#include "tent/runtime/transport.h"
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+// ---------------------------------------------------------------------------
+// FakeTransport: minimal Transport that records itself on BufferDesc, claims
+// dram_to_dram capability, and completes transfers synchronously. The
+// per-instance submit_calls counter is what each test inspects to learn
+// which transport the engine routed onto for a given request.
+// ---------------------------------------------------------------------------
+class FakeSubBatch : public Transport::SubBatch {
+   public:
+    size_t size() const override { return task_count; }
+    size_t task_count = 0;
+    std::vector<TransferStatus> statuses;
+};
+
+class FakeTransport : public Transport {
+   public:
+    explicit FakeTransport(TransportType self_type) : self_type_(self_type) {
+        caps.dram_to_dram = true;
+    }
+
+    std::atomic<int> submit_calls{0};
+
+    Status install(std::string&, std::shared_ptr<ControlService>,
+                   std::shared_ptr<Topology>,
+                   std::shared_ptr<Config> = nullptr) override {
+        return Status::OK();
+    }
+
+    Status allocateSubBatch(SubBatchRef& batch, size_t) override {
+        batch = new FakeSubBatch();
+        return Status::OK();
+    }
+    Status freeSubBatch(SubBatchRef& batch) override {
+        delete batch;
+        batch = nullptr;
+        return Status::OK();
+    }
+
+    Status submitTransferTasks(SubBatchRef batch,
+                               const std::vector<Request>& reqs) override {
+        ++submit_calls;
+        auto* fb = static_cast<FakeSubBatch*>(batch);
+        for (const auto& req : reqs) {
+            fb->statuses.push_back({TransferStatusEnum::COMPLETED, req.length});
+            fb->task_count++;
+        }
+        return Status::OK();
+    }
+
+    Status getTransferStatus(SubBatchRef batch, int task_id,
+                             TransferStatus& status) override {
+        auto* fb = static_cast<FakeSubBatch*>(batch);
+        if (task_id < 0 || task_id >= (int)fb->statuses.size())
+            return Status::InvalidArgument("bad task_id" LOC_MARK);
+        status = fb->statuses[task_id];
+        return Status::OK();
+    }
+
+    Status addMemoryBuffer(BufferDesc& desc, const MemoryOptions&) override {
+        desc.transports.push_back(self_type_);
+        return Status::OK();
+    }
+    Status addMemoryBuffer(std::vector<BufferDesc>& list,
+                           const MemoryOptions& options) override {
+        for (auto& d : list) {
+            auto s = addMemoryBuffer(d, options);
+            if (!s.ok()) return s;
+        }
+        return Status::OK();
+    }
+    Status removeMemoryBuffer(BufferDesc&) override { return Status::OK(); }
+
+    Status allocateLocalMemory(void** addr, size_t size,
+                               MemoryOptions&) override {
+        *addr = std::malloc(size);
+        return *addr ? Status::OK()
+                     : Status::InternalError("malloc failed" LOC_MARK);
+    }
+    Status freeLocalMemory(void* addr, size_t) override {
+        std::free(addr);
+        return Status::OK();
+    }
+    bool warmupMemory(void*, size_t) override { return false; }
+    const char* getName() const override {
+        return self_type_ == RDMA ? "<fake-rdma>" : "<fake-tcp>";
+    }
+
+   private:
+    TransportType self_type_;
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+std::shared_ptr<Config> makeMinimalP2PConfig() {
+    auto cfg = std::make_shared<Config>();
+    cfg->set("metadata_type", "p2p");
+    cfg->set("metadata_servers", "");
+    cfg->set("rpc_server_hostname", "127.0.0.1");
+    cfg->set("rpc_server_port", "0");
+    cfg->set("log_level", "warning");
+    cfg->set("merge_requests", false);
+    cfg->set("transports/tcp/enable", false);
+    cfg->set("transports/shm/enable", false);
+    cfg->set("transports/rdma/enable", false);
+    cfg->set("transports/io_uring/enable", false);
+    cfg->set("transports/nvlink/enable", false);
+    cfg->set("transports/mnnvl/enable", false);
+    cfg->set("transports/gds/enable", false);
+    cfg->set("transports/ascend_direct/enable", false);
+    return cfg;
+}
+
+void installFakeRdmaAndTcp(TransferEngineImpl& engine,
+                           std::shared_ptr<FakeTransport>& rdma,
+                           std::shared_ptr<FakeTransport>& tcp) {
+    rdma = std::make_shared<FakeTransport>(RDMA);
+    tcp = std::make_shared<FakeTransport>(TCP);
+    std::string seg_name = engine.getSegmentName();
+    ASSERT_TRUE(rdma->install(seg_name, nullptr, nullptr).ok());
+    ASSERT_TRUE(tcp->install(seg_name, nullptr, nullptr).ok());
+    engine.swapTransportForTest(RDMA, rdma);
+    engine.swapTransportForTest(TCP, tcp);
+}
+
+Request makeLocalWriteRequest(uint8_t* buf, size_t len) {
+    Request r;
+    r.opcode = Request::WRITE;
+    r.source = buf;
+    r.target_id = LOCAL_SEGMENT_ID;
+    r.target_offset = reinterpret_cast<uint64_t>(buf);
+    r.length = len;
+    return r;
+}
+
+// ---------------------------------------------------------------------------
+// 1. hint=RDMA / hint=TCP routing
+// ---------------------------------------------------------------------------
+
+TEST(TransportHint, RoutesPinnedRequestsToHintedTransport) {
+    auto cfg = makeMinimalP2PConfig();
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    std::shared_ptr<FakeTransport> fake_rdma, fake_tcp;
+    installFakeRdmaAndTcp(engine, fake_rdma, fake_tcp);
+
+    constexpr size_t kBufLen = 4096;
+    std::vector<uint8_t> buf(kBufLen, 0x01);
+    ASSERT_TRUE(engine.registerLocalMemory(buf.data(), kBufLen).ok());
+
+    // Two batches, each with one hinted request. Use separate batches so
+    // submit_calls is unambiguous about which transport handled which.
+    BatchID b_rdma = engine.allocateBatch(2);
+    BatchID b_tcp = engine.allocateBatch(2);
+    ASSERT_NE(b_rdma, (BatchID)0);
+    ASSERT_NE(b_tcp, (BatchID)0);
+
+    Request r_rdma = makeLocalWriteRequest(buf.data(), kBufLen);
+    r_rdma.transport_hint = RDMA;
+    Request r_tcp = makeLocalWriteRequest(buf.data(), kBufLen);
+    r_tcp.transport_hint = TCP;
+
+    ASSERT_TRUE(engine.submitTransfer(b_rdma, {r_rdma}).ok());
+    ASSERT_TRUE(engine.submitTransfer(b_tcp, {r_tcp}).ok());
+
+    EXPECT_EQ(fake_rdma->submit_calls.load(), 1)
+        << "RDMA hint should route onto the RDMA fake exactly once";
+    EXPECT_EQ(fake_tcp->submit_calls.load(), 1)
+        << "TCP hint should route onto the TCP fake exactly once";
+
+    EXPECT_TRUE(engine.freeBatch(b_rdma).ok());
+    EXPECT_TRUE(engine.freeBatch(b_tcp).ok());
+    EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), kBufLen).ok());
+}
+
+// ---------------------------------------------------------------------------
+// 2. Disabled transport rejected before batch state mutates
+// ---------------------------------------------------------------------------
+
+TEST(TransportHint, RejectsHintForTransportNotInstalled) {
+    auto cfg = makeMinimalP2PConfig();
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    std::shared_ptr<FakeTransport> fake_rdma, fake_tcp;
+    installFakeRdmaAndTcp(engine, fake_rdma, fake_tcp);
+    // Intentionally leave GDS uninstalled.
+
+    constexpr size_t kBufLen = 1024;
+    std::vector<uint8_t> buf(kBufLen, 0x77);
+    ASSERT_TRUE(engine.registerLocalMemory(buf.data(), kBufLen).ok());
+
+    BatchID batch_id = engine.allocateBatch(2);
+    Request bad = makeLocalWriteRequest(buf.data(), kBufLen);
+    bad.transport_hint = GDS;
+
+    auto status = engine.submitTransfer(batch_id, {bad});
+    EXPECT_FALSE(status.ok());
+    EXPECT_TRUE(status.IsInvalidArgument());
+    EXPECT_EQ(fake_rdma->submit_calls.load(), 0);
+    EXPECT_EQ(fake_tcp->submit_calls.load(), 0);
+
+    EXPECT_TRUE(engine.freeBatch(batch_id).ok());
+    EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), kBufLen).ok());
+}
+
+// ---------------------------------------------------------------------------
+// 3. Out-of-range hint value rejected (defends against uninitialized C
+//    struct fields and stray casts)
+// ---------------------------------------------------------------------------
+
+TEST(TransportHint, RejectsHintWithOutOfRangeValue) {
+    auto cfg = makeMinimalP2PConfig();
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    std::shared_ptr<FakeTransport> fake_rdma, fake_tcp;
+    installFakeRdmaAndTcp(engine, fake_rdma, fake_tcp);
+
+    constexpr size_t kBufLen = 1024;
+    std::vector<uint8_t> buf(kBufLen);
+    ASSERT_TRUE(engine.registerLocalMemory(buf.data(), kBufLen).ok());
+
+    BatchID batch_id = engine.allocateBatch(2);
+
+    Request too_big = makeLocalWriteRequest(buf.data(), kBufLen);
+    too_big.transport_hint = static_cast<TransportType>(123);
+    EXPECT_TRUE(engine.submitTransfer(batch_id, {too_big}).IsInvalidArgument());
+
+    Request negative = makeLocalWriteRequest(buf.data(), kBufLen);
+    negative.transport_hint = static_cast<TransportType>(-1);
+    EXPECT_TRUE(
+        engine.submitTransfer(batch_id, {negative}).IsInvalidArgument());
+
+    // Neither submission should have reached any transport.
+    EXPECT_EQ(fake_rdma->submit_calls.load(), 0);
+    EXPECT_EQ(fake_tcp->submit_calls.load(), 0);
+
+    EXPECT_TRUE(engine.freeBatch(batch_id).ok());
+    EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), kBufLen).ok());
+}
+
+// ---------------------------------------------------------------------------
+// 4. UNSPEC keeps original policy-driven behavior intact
+// ---------------------------------------------------------------------------
+
+TEST(TransportHint, UnspecHintPreservesPolicyDrivenSelection) {
+    auto cfg = makeMinimalP2PConfig();
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    std::shared_ptr<FakeTransport> fake_rdma, fake_tcp;
+    installFakeRdmaAndTcp(engine, fake_rdma, fake_tcp);
+
+    constexpr size_t kBufLen = 4096;
+    std::vector<uint8_t> buf(kBufLen, 0xAA);
+    ASSERT_TRUE(engine.registerLocalMemory(buf.data(), kBufLen).ok());
+
+    BatchID batch_id = engine.allocateBatch(2);
+    Request r = makeLocalWriteRequest(buf.data(), kBufLen);
+    // r.transport_hint defaults to UNSPEC.
+
+    ASSERT_TRUE(engine.submitTransfer(batch_id, {r}).ok());
+
+    // The default policy prefers RDMA over TCP for memory segments, so
+    // an UNSPEC request should land on RDMA. This guards the early-out
+    // path that the change explicitly preserves.
+    EXPECT_EQ(fake_rdma->submit_calls.load(), 1);
+    EXPECT_EQ(fake_tcp->submit_calls.load(), 0);
+
+    EXPECT_TRUE(engine.freeBatch(batch_id).ok());
+    EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), kBufLen).ok());
+}
+
+// ---------------------------------------------------------------------------
+// 5. Mixed hints in one batch: each request lands on its hinted transport
+// ---------------------------------------------------------------------------
+
+TEST(TransportHint, MixedHintsInBatchSplitAcrossTransports) {
+    auto cfg = makeMinimalP2PConfig();
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    std::shared_ptr<FakeTransport> fake_rdma, fake_tcp;
+    installFakeRdmaAndTcp(engine, fake_rdma, fake_tcp);
+
+    constexpr size_t kBufLen = 8192;
+    std::vector<uint8_t> buf(kBufLen, 0xBB);
+    ASSERT_TRUE(engine.registerLocalMemory(buf.data(), kBufLen).ok());
+
+    BatchID batch_id = engine.allocateBatch(4);
+
+    Request r_rdma = makeLocalWriteRequest(buf.data(), 4096);
+    r_rdma.transport_hint = RDMA;
+    Request r_tcp = makeLocalWriteRequest(buf.data() + 4096, 4096);
+    r_tcp.transport_hint = TCP;
+
+    ASSERT_TRUE(engine.submitTransfer(batch_id, {r_rdma, r_tcp}).ok());
+
+    EXPECT_EQ(fake_rdma->submit_calls.load(), 1);
+    EXPECT_EQ(fake_tcp->submit_calls.load(), 1);
+
+    EXPECT_TRUE(engine.freeBatch(batch_id).ok());
+    EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), kBufLen).ok());
+}
+
+}  // namespace
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/tests/transport_hint_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/transport_hint_test.cpp
@@ -71,7 +71,7 @@ class FakeTransport : public Transport {
         return Status::OK();
     }
     Status freeSubBatch(SubBatchRef& batch) override {
-        delete batch;
+        delete static_cast<FakeSubBatch*>(batch);
         batch = nullptr;
         return Status::OK();
     }

--- a/mooncake-transfer-engine/tent/tests/transport_selector_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/transport_selector_test.cpp
@@ -173,25 +173,31 @@ TEST(TransportSelectorTest, DefaultPoliciesMemorySegment) {
 // ---------------------------------------------------------------------------
 
 TEST(TransportSelectorTest, TransportTypeNameMapping) {
+    EXPECT_EQ(TransportSelector::transportTypeName(UNSPEC), "unspec");
     EXPECT_EQ(TransportSelector::transportTypeName(RDMA), "rdma");
-    EXPECT_EQ(TransportSelector::transportTypeName(TCP), "tcp");
+    EXPECT_EQ(TransportSelector::transportTypeName(MNNVL), "mnnvl");
     EXPECT_EQ(TransportSelector::transportTypeName(SHM), "shm");
     EXPECT_EQ(TransportSelector::transportTypeName(NVLINK), "nvlink");
     EXPECT_EQ(TransportSelector::transportTypeName(GDS), "gds");
     EXPECT_EQ(TransportSelector::transportTypeName(IOURING), "io_uring");
+    EXPECT_EQ(TransportSelector::transportTypeName(TCP), "tcp");
     EXPECT_EQ(TransportSelector::transportTypeName(AscendDirect), "ascend");
-    EXPECT_EQ(TransportSelector::transportTypeName(MNNVL), "mnnvl");
+    EXPECT_EQ(TransportSelector::transportTypeName(SUNRISE_LINK),
+              "sunrise_link");
 }
 
 TEST(TransportSelectorTest, ParseTransportType) {
+    EXPECT_EQ(TransportSelector::parseTransportType("unspec"), UNSPEC);
     EXPECT_EQ(TransportSelector::parseTransportType("rdma"), RDMA);
-    EXPECT_EQ(TransportSelector::parseTransportType("tcp"), TCP);
+    EXPECT_EQ(TransportSelector::parseTransportType("mnnvl"), MNNVL);
     EXPECT_EQ(TransportSelector::parseTransportType("shm"), SHM);
     EXPECT_EQ(TransportSelector::parseTransportType("nvlink"), NVLINK);
     EXPECT_EQ(TransportSelector::parseTransportType("gds"), GDS);
     EXPECT_EQ(TransportSelector::parseTransportType("io_uring"), IOURING);
+    EXPECT_EQ(TransportSelector::parseTransportType("tcp"), TCP);
     EXPECT_EQ(TransportSelector::parseTransportType("ascend"), AscendDirect);
-    EXPECT_EQ(TransportSelector::parseTransportType("mnnvl"), MNNVL);
+    EXPECT_EQ(TransportSelector::parseTransportType("sunrise_link"),
+              SUNRISE_LINK);
     EXPECT_EQ(TransportSelector::parseTransportType("unknown"), UNSPEC);
 }
 
@@ -539,6 +545,100 @@ TEST(TransportSelectorTest, ConfigBasedPolicySelection) {
     auto result = selector.select(ctx, transports);
     // With default policies, should use buffer_transports order (RDMA first)
     EXPECT_EQ(result.transport, RDMA);
+}
+
+// ---------------------------------------------------------------------------
+// hint: per-request transport_hint hook on select()
+// ---------------------------------------------------------------------------
+
+TEST(TransportSelectorTest, FailoverFromHintAdvancesByIndex) {
+    // Policy order [TCP, RDMA], hint=RDMA. Hint is prepended; failover by
+    // bumping transport_index walks past the hint into the rest of raw
+    // (with RDMA de-duped), so index=1 returns TCP — never returns RDMA
+    // again.
+    auto conf = std::make_shared<Config>();
+    TransportSelector selector(conf);
+
+    std::array<std::shared_ptr<Transport>, kSupportedTransportTypes>
+        transports{};
+    transports[RDMA] = std::make_shared<FakeTransport>(RDMA);
+    transports[TCP] = std::make_shared<FakeTransport>(TCP);
+    static_cast<FakeTransport*>(transports[RDMA].get())->setDramToDram(true);
+    static_cast<FakeTransport*>(transports[TCP].get())->setDramToDram(true);
+
+    std::vector<TransportType> buffer_transports = {TCP, RDMA};
+    SelectionContext ctx;
+    ctx.segment_type = SegmentType::Memory;
+    ctx.same_machine = false;
+    ctx.local_memory_type = MTYPE_CPU;
+    ctx.remote_memory_type = MTYPE_CPU;
+    ctx.buffer_transports = &buffer_transports;
+
+    EXPECT_EQ(
+        selector.select(ctx, transports, /*index=*/0, /*hint=*/RDMA).transport,
+        RDMA);
+    EXPECT_EQ(
+        selector.select(ctx, transports, /*index=*/1, /*hint=*/RDMA).transport,
+        TCP);
+    // Past the end -> UNSPEC.
+    EXPECT_EQ(
+        selector.select(ctx, transports, /*index=*/2, /*hint=*/RDMA).transport,
+        UNSPEC);
+}
+
+TEST(TransportSelectorTest, HintIsPrependedToCandidateList) {
+    auto conf = std::make_shared<Config>();
+    TransportSelector selector(conf);
+
+    std::array<std::shared_ptr<Transport>, kSupportedTransportTypes>
+        transports{};
+    transports[RDMA] = std::make_shared<FakeTransport>(RDMA);
+    transports[TCP] = std::make_shared<FakeTransport>(TCP);
+    static_cast<FakeTransport*>(transports[RDMA].get())->setDramToDram(true);
+    static_cast<FakeTransport*>(transports[TCP].get())->setDramToDram(true);
+
+    // Default-policy memory path uses buffer_transports order = [RDMA, TCP].
+    // hint=TCP must put TCP first, RDMA second.
+    std::vector<TransportType> buffer_transports = {RDMA, TCP};
+    SelectionContext ctx;
+    ctx.segment_type = SegmentType::Memory;
+    ctx.same_machine = false;
+    ctx.local_memory_type = MTYPE_CPU;
+    ctx.remote_memory_type = MTYPE_CPU;
+    ctx.buffer_transports = &buffer_transports;
+
+    auto r0 = selector.select(ctx, transports, /*index=*/0, /*hint=*/TCP);
+    EXPECT_EQ(r0.transport, TCP);
+    auto r1 = selector.select(ctx, transports, /*index=*/1, /*hint=*/TCP);
+    EXPECT_EQ(r1.transport, RDMA);
+}
+
+TEST(TransportSelectorTest, HintNotInMatchingPolicyReturnsUnspec) {
+    // Selector mode: the matching policy's transports list is the
+    // authorization whitelist. A hint that is not in it produces UNSPEC
+    // (downstream the engine turns this into task = FAILED).
+    auto conf = std::make_shared<Config>();
+    TransportSelector selector(conf);
+
+    std::array<std::shared_ptr<Transport>, kSupportedTransportTypes>
+        transports{};
+    transports[RDMA] = std::make_shared<FakeTransport>(RDMA);
+    transports[TCP] = std::make_shared<FakeTransport>(TCP);
+    static_cast<FakeTransport*>(transports[RDMA].get())->setDramToDram(true);
+    static_cast<FakeTransport*>(transports[TCP].get())->setDramToDram(true);
+
+    // Buffer is only registered with TCP. hint=RDMA must fail even though
+    // RDMA is installed and capable.
+    std::vector<TransportType> buffer_transports = {TCP};
+    SelectionContext ctx;
+    ctx.segment_type = SegmentType::Memory;
+    ctx.same_machine = false;
+    ctx.local_memory_type = MTYPE_CPU;
+    ctx.remote_memory_type = MTYPE_CPU;
+    ctx.buffer_transports = &buffer_transports;
+
+    auto r = selector.select(ctx, transports, /*index=*/0, /*hint=*/RDMA);
+    EXPECT_EQ(r.transport, UNSPEC);
 }
 
 }  // namespace


### PR DESCRIPTION
## Description

Adds a per-request transport_hint to TENT's Request struct, letting callers pin an individual transfer (or a whole batch) onto a specific transport (RDMA, TCP, …) while leaving the global policy config as the default for everything else. 

Exposed end-to-end through the C ABI (tent_request.transport_hint), the C++ TENT API (Request::transport_hint), the pybind tent module (Request(..., transport_hint=...)), and the high-level Python transfer-engine API (optional transport_hint="rdma"|"tcp"|... argument on all transfer entry points).

Hint semantics:
  - UNSPEC (default): unchanged — TransportSelector::select(...) runs as before.
  - Pinned to a transport T: the matching policy's transport list is the authorization whitelist. If T is in that list and available, the request's first attempt uses T; otherwise submitTransfer fails with InvalidArgument (engine-level: disabled / out-of-range) or the task is marked FAILED (selector-level: hint not authorized by matching policy). On failover, the engine advances transport_index and the selector walks past the hint into the rest of raw so failover never loops back onto the transport that already failed.
  - Request merging is now hint-aware: requests with different hints are not merged across, even when contiguous, so per-request pinning is never silently lost.

## Breaking change

cc @staryxchen, plz give comments on this.

TransportType enum is renumbered: UNSPEC moves from the last slot to slot 0. Reason: zero-initialized C structs (tent_request, tent_memory_options) must default to "no hint" rather than silently pinning to whichever transport happens to occupy slot 0. The new transport_hint field in the C ABI defaults to 0, so UNSPEC = 0 is the only safe assignment. The matching TRANSPORT_* C macros (TRANSPORT_UNSPEC=0, TRANSPORT_RDMA=1, …) and the pybind TransportType enum are renumbered to match. SUNRISE_LINK is now an explicit enum value (previously only present in the name maps).

Downstream impact:
  - Any code that hard-coded the integer value of a TransportType (e.g. wire format, persisted config, FFI integer passing rather than enum passing) needs to remap.  I have checked and there is no external integer-type TransportType interface.
  - failover_test.cpp::TransportTypeTest.UnspecIsSentinel was rewritten as UnspecIsZeroSlot to assert the new invariant.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

 - [x] ctest on mooncake-transfer-engine/tent/tests (new suites + updated failover_test)
 - [x] Existing TENT integration tests still pass with UNSPEC = 0
 - [x] Bench: tent_backend --tent_transport_hint=tcp actually routes onto TCP

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
