### PR TITLE
[TENT] Add local admission queue prototype

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
@@ -108,6 +108,7 @@ class LocalTransferAdmissionQueue {
     };
 
     QueueLimits limits_;
+    Status limits_status_;
     QueueOwnerId next_owner_id_{1};
     std::map<QueueOwnerId, QueueOwner> owners_;
     std::map<std::pair<uint64_t, size_t>, QueueOwnerId> public_to_owner_;

--- a/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
@@ -1,0 +1,124 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ADMISSION_QUEUE_H_
+#define ADMISSION_QUEUE_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <map>
+#include <utility>
+#include <vector>
+
+#include "tent/common/status.h"
+#include "tent/common/types.h"
+
+namespace mooncake {
+namespace tent {
+
+using QueueOwnerId = uint64_t;
+
+// Owner kind is used only for admission accounting. It is not a dispatch
+// priority.
+enum class QueueOwnerKind {
+    User,
+    StagingInternal,
+};
+
+struct QueueLimits {
+    size_t max_outstanding_owners{0};
+    size_t max_outstanding_bytes{0};
+    size_t staging_owner_reserve{0};
+    size_t staging_byte_reserve{0};
+};
+
+struct QueueOwnerInput {
+    // Absolute task id within the caller's Batch, not relative to this submit.
+    size_t owner_task_id{0};
+    std::vector<size_t> derived_task_ids;
+    Request request{};
+    QueueOwnerKind kind{QueueOwnerKind::User};
+};
+
+struct QueueSubmit {
+    uint64_t batch_token{0};
+    // Caller-computed remaining public task slots for this submit.
+    size_t batch_slots_left{0};
+    std::vector<QueueOwnerInput> owners;
+};
+
+// Runtime-private admission model. It is intentionally single-threaded; the
+// eventual TransferEngineImpl integration owns synchronization.
+class LocalTransferAdmissionQueue {
+   public:
+    explicit LocalTransferAdmissionQueue(QueueLimits limits);
+
+    LocalTransferAdmissionQueue(const LocalTransferAdmissionQueue&) = delete;
+    LocalTransferAdmissionQueue& operator=(const LocalTransferAdmissionQueue&) =
+        delete;
+    LocalTransferAdmissionQueue(LocalTransferAdmissionQueue&&) = delete;
+    LocalTransferAdmissionQueue& operator=(LocalTransferAdmissionQueue&&) =
+        delete;
+
+    Status tryAdmit(const QueueSubmit& submit,
+                    std::vector<QueueOwnerId>& admitted_owner_ids);
+
+    std::vector<QueueOwnerId> pickForDispatch(size_t max_owners,
+                                              size_t max_bytes);
+
+    Status complete(QueueOwnerId owner_id, TransferStatusEnum terminal_status);
+
+    Status retireBatch(uint64_t batch_token);
+
+    Status resolveOwner(uint64_t batch_token, size_t public_task_id,
+                        QueueOwnerId& owner_id) const;
+
+    Status getPublicStatus(uint64_t batch_token, size_t public_task_id,
+                           TransferStatusEnum& status) const;
+
+    size_t outstandingOwners() const;
+
+    size_t outstandingBytes() const;
+
+   private:
+    enum class QueueState {
+        Queued,
+        Dispatching,
+        Completed,
+        Failed,
+    };
+
+    struct QueueOwner {
+        uint64_t batch_token{0};
+        Request request{};
+        QueueOwnerKind kind{QueueOwnerKind::User};
+        QueueState state{QueueState::Queued};
+    };
+
+    QueueLimits limits_;
+    QueueOwnerId next_owner_id_{1};
+    std::map<QueueOwnerId, QueueOwner> owners_;
+    std::map<std::pair<uint64_t, size_t>, QueueOwnerId> public_to_owner_;
+    std::deque<QueueOwnerId> fifo_;
+    size_t outstanding_owners_{0};
+    size_t outstanding_bytes_{0};
+    size_t outstanding_user_owners_{0};
+    size_t outstanding_user_bytes_{0};
+};
+
+}  // namespace tent
+}  // namespace mooncake
+
+#endif  // ADMISSION_QUEUE_H_

--- a/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
@@ -61,12 +61,12 @@ Status validateLimits(const QueueLimits& limits) {
 }  // namespace
 
 LocalTransferAdmissionQueue::LocalTransferAdmissionQueue(QueueLimits limits)
-    : limits_(limits) {}
+    : limits_(limits), limits_status_(validateLimits(limits)) {}
 
 Status LocalTransferAdmissionQueue::tryAdmit(
     const QueueSubmit& submit, std::vector<QueueOwnerId>& admitted_owner_ids) {
     admitted_owner_ids.clear();
-    CHECK_STATUS(validateLimits(limits_));
+    CHECK_STATUS(limits_status_);
     if (submit.batch_token == 0) {
         return Status::InvalidArgument("invalid batch token" LOC_MARK);
     }

--- a/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
@@ -249,30 +249,40 @@ Status LocalTransferAdmissionQueue::retireBatch(uint64_t batch_token) {
         return Status::InvalidArgument("invalid batch token" LOC_MARK);
     }
 
-    for (const auto& entry : owners_) {
-        const auto& owner = entry.second;
+    const PublicTaskKey batch_begin{batch_token, 0};
+    auto public_begin = public_to_owner_.lower_bound(batch_begin);
+    auto public_end = public_to_owner_.upper_bound(
+        {batch_token, std::numeric_limits<size_t>::max()});
+
+    std::set<QueueOwnerId> owner_ids;
+    for (auto it = public_begin; it != public_end; ++it) {
+        owner_ids.insert(it->second);
+    }
+
+    for (const auto owner_id : owner_ids) {
+        auto owner_it = owners_.find(owner_id);
+        if (owner_it == owners_.end()) {
+            return Status::InternalError(
+                "queue owner mapping is stale" LOC_MARK);
+        }
+
+        const auto& owner = owner_it->second;
+        if (owner.batch_token != batch_token) {
+            return Status::InternalError(
+                "queue owner batch token mismatch" LOC_MARK);
+        }
         const bool terminal = owner.state == QueueState::Completed ||
                               owner.state == QueueState::Failed;
-        if (owner.batch_token == batch_token && !terminal) {
+        if (!terminal) {
             return Status::InvalidEntry(
                 "batch has non-terminal queue owners" LOC_MARK);
         }
     }
 
-    for (auto it = owners_.begin(); it != owners_.end();) {
-        if (it->second.batch_token == batch_token) {
-            it = owners_.erase(it);
-        } else {
-            ++it;
-        }
+    for (const auto owner_id : owner_ids) {
+        owners_.erase(owner_id);
     }
-    for (auto it = public_to_owner_.begin(); it != public_to_owner_.end();) {
-        if (it->first.first == batch_token) {
-            it = public_to_owner_.erase(it);
-        } else {
-            ++it;
-        }
-    }
+    public_to_owner_.erase(public_begin, public_end);
     return Status::OK();
 }
 

--- a/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
@@ -23,6 +23,11 @@ namespace {
 
 using PublicTaskKey = std::pair<uint64_t, size_t>;
 
+bool isSupportedTerminalStatus(TransferStatusEnum status) {
+    return status == TransferStatusEnum::COMPLETED ||
+           status == TransferStatusEnum::FAILED;
+}
+
 bool isSupportedOwnerKind(QueueOwnerKind kind) {
     switch (kind) {
         case QueueOwnerKind::User:
@@ -179,23 +184,94 @@ Status LocalTransferAdmissionQueue::tryAdmit(
 
 std::vector<QueueOwnerId> LocalTransferAdmissionQueue::pickForDispatch(
     size_t max_owners, size_t max_bytes) {
-    (void)max_owners;
-    (void)max_bytes;
-    return {};
+    std::vector<QueueOwnerId> picked;
+    if (max_owners == 0 || max_bytes == 0) return picked;
+
+    size_t used_owners = 0;
+    size_t used_bytes = 0;
+    while (!fifo_.empty() && used_owners < max_owners) {
+        auto owner_id = fifo_.front();
+        auto owner_it = owners_.find(owner_id);
+        // Non-queued entries should not normally remain in fifo_, but stale
+        // entries are skipped defensively so retireBatch() does not need to
+        // scan the dispatch queue.
+        if (owner_it == owners_.end() ||
+            owner_it->second.state != QueueState::Queued) {
+            fifo_.pop_front();
+            continue;
+        }
+
+        const auto& owner = owner_it->second;
+        const size_t remaining_bytes = max_bytes - used_bytes;
+        if (owner.request.length > remaining_bytes) break;
+
+        fifo_.pop_front();
+        owner_it->second.state = QueueState::Dispatching;
+        picked.push_back(owner_id);
+        ++used_owners;
+        used_bytes += owner.request.length;
+    }
+    return picked;
 }
 
 Status LocalTransferAdmissionQueue::complete(
     QueueOwnerId owner_id, TransferStatusEnum terminal_status) {
-    (void)terminal_status;
     if (owner_id == 0) {
         return Status::InvalidArgument("invalid queue owner id" LOC_MARK);
     }
-    return Status::NotImplemented("queue completion is not wired" LOC_MARK);
+    if (!isSupportedTerminalStatus(terminal_status)) {
+        return Status::InvalidArgument("unsupported terminal status" LOC_MARK);
+    }
+
+    auto owner_it = owners_.find(owner_id);
+    if (owner_it == owners_.end()) {
+        return Status::InvalidEntry("queue owner not found" LOC_MARK);
+    }
+    auto& owner = owner_it->second;
+    if (owner.state != QueueState::Dispatching) {
+        return Status::InvalidEntry("queue owner is not dispatching" LOC_MARK);
+    }
+
+    owner.state = terminal_status == TransferStatusEnum::COMPLETED
+                      ? QueueState::Completed
+                      : QueueState::Failed;
+    --outstanding_owners_;
+    outstanding_bytes_ -= owner.request.length;
+    if (owner.kind == QueueOwnerKind::User) {
+        --outstanding_user_owners_;
+        outstanding_user_bytes_ -= owner.request.length;
+    }
+    return Status::OK();
 }
 
 Status LocalTransferAdmissionQueue::retireBatch(uint64_t batch_token) {
     if (batch_token == 0) {
         return Status::InvalidArgument("invalid batch token" LOC_MARK);
+    }
+
+    for (const auto& entry : owners_) {
+        const auto& owner = entry.second;
+        const bool terminal = owner.state == QueueState::Completed ||
+                              owner.state == QueueState::Failed;
+        if (owner.batch_token == batch_token && !terminal) {
+            return Status::InvalidEntry(
+                "batch has non-terminal queue owners" LOC_MARK);
+        }
+    }
+
+    for (auto it = owners_.begin(); it != owners_.end();) {
+        if (it->second.batch_token == batch_token) {
+            it = owners_.erase(it);
+        } else {
+            ++it;
+        }
+    }
+    for (auto it = public_to_owner_.begin(); it != public_to_owner_.end();) {
+        if (it->first.first == batch_token) {
+            it = public_to_owner_.erase(it);
+        } else {
+            ++it;
+        }
     }
     return Status::OK();
 }
@@ -217,12 +293,25 @@ Status LocalTransferAdmissionQueue::resolveOwner(uint64_t batch_token,
 Status LocalTransferAdmissionQueue::getPublicStatus(
     uint64_t batch_token, size_t public_task_id,
     TransferStatusEnum& status) const {
-    (void)public_task_id;
-    status = TransferStatusEnum::INVALID;
-    if (batch_token == 0) {
-        return Status::InvalidArgument("invalid batch token" LOC_MARK);
+    QueueOwnerId owner_id = 0;
+    CHECK_STATUS(resolveOwner(batch_token, public_task_id, owner_id));
+    auto owner_it = owners_.find(owner_id);
+    if (owner_it == owners_.end()) {
+        return Status::InternalError("queue owner mapping is stale" LOC_MARK);
     }
-    return Status::InvalidEntry("public task id not found" LOC_MARK);
+    switch (owner_it->second.state) {
+        case QueueState::Queued:
+        case QueueState::Dispatching:
+            status = TransferStatusEnum::PENDING;
+            break;
+        case QueueState::Completed:
+            status = TransferStatusEnum::COMPLETED;
+            break;
+        case QueueState::Failed:
+            status = TransferStatusEnum::FAILED;
+            break;
+    }
+    return Status::OK();
 }
 
 size_t LocalTransferAdmissionQueue::outstandingOwners() const {

--- a/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
@@ -1,0 +1,89 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tent/runtime/admission_queue.h"
+
+namespace mooncake {
+namespace tent {
+
+LocalTransferAdmissionQueue::LocalTransferAdmissionQueue(QueueLimits limits)
+    : limits_(limits) {}
+
+Status LocalTransferAdmissionQueue::tryAdmit(
+    const QueueSubmit& submit, std::vector<QueueOwnerId>& admitted_owner_ids) {
+    admitted_owner_ids.clear();
+    if (submit.batch_token == 0) {
+        return Status::InvalidArgument("invalid batch token" LOC_MARK);
+    }
+    if (!submit.owners.empty()) {
+        return Status::NotImplemented("queue admission is not wired" LOC_MARK);
+    }
+    return Status::OK();
+}
+
+std::vector<QueueOwnerId> LocalTransferAdmissionQueue::pickForDispatch(
+    size_t max_owners, size_t max_bytes) {
+    (void)max_owners;
+    (void)max_bytes;
+    return {};
+}
+
+Status LocalTransferAdmissionQueue::complete(
+    QueueOwnerId owner_id, TransferStatusEnum terminal_status) {
+    (void)terminal_status;
+    if (owner_id == 0) {
+        return Status::InvalidArgument("invalid queue owner id" LOC_MARK);
+    }
+    return Status::NotImplemented("queue completion is not wired" LOC_MARK);
+}
+
+Status LocalTransferAdmissionQueue::retireBatch(uint64_t batch_token) {
+    if (batch_token == 0) {
+        return Status::InvalidArgument("invalid batch token" LOC_MARK);
+    }
+    return Status::OK();
+}
+
+Status LocalTransferAdmissionQueue::resolveOwner(uint64_t batch_token,
+                                                 size_t public_task_id,
+                                                 QueueOwnerId& owner_id) const {
+    (void)public_task_id;
+    owner_id = 0;
+    if (batch_token == 0) {
+        return Status::InvalidArgument("invalid batch token" LOC_MARK);
+    }
+    return Status::InvalidEntry("public task id not found" LOC_MARK);
+}
+
+Status LocalTransferAdmissionQueue::getPublicStatus(
+    uint64_t batch_token, size_t public_task_id,
+    TransferStatusEnum& status) const {
+    (void)public_task_id;
+    status = TransferStatusEnum::INVALID;
+    if (batch_token == 0) {
+        return Status::InvalidArgument("invalid batch token" LOC_MARK);
+    }
+    return Status::InvalidEntry("public task id not found" LOC_MARK);
+}
+
+size_t LocalTransferAdmissionQueue::outstandingOwners() const {
+    return outstanding_owners_;
+}
+
+size_t LocalTransferAdmissionQueue::outstandingBytes() const {
+    return outstanding_bytes_;
+}
+
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
@@ -14,8 +14,46 @@
 
 #include "tent/runtime/admission_queue.h"
 
+#include <limits>
+#include <set>
+
 namespace mooncake {
 namespace tent {
+namespace {
+
+using PublicTaskKey = std::pair<uint64_t, size_t>;
+
+bool isSupportedOwnerKind(QueueOwnerKind kind) {
+    switch (kind) {
+        case QueueOwnerKind::User:
+        case QueueOwnerKind::StagingInternal:
+            return true;
+    }
+    return false;
+}
+
+Status checkedAdd(size_t lhs, size_t rhs, size_t& out) {
+    if (rhs > std::numeric_limits<size_t>::max() - lhs) {
+        return Status::InvalidArgument(
+            "admission queue charge overflow" LOC_MARK);
+    }
+    out = lhs + rhs;
+    return Status::OK();
+}
+
+Status validateLimits(const QueueLimits& limits) {
+    if (limits.staging_owner_reserve > limits.max_outstanding_owners) {
+        return Status::InvalidArgument(
+            "staging owner reserve exceeds owner limit" LOC_MARK);
+    }
+    if (limits.staging_byte_reserve > limits.max_outstanding_bytes) {
+        return Status::InvalidArgument(
+            "staging byte reserve exceeds byte limit" LOC_MARK);
+    }
+    return Status::OK();
+}
+
+}  // namespace
 
 LocalTransferAdmissionQueue::LocalTransferAdmissionQueue(QueueLimits limits)
     : limits_(limits) {}
@@ -23,12 +61,119 @@ LocalTransferAdmissionQueue::LocalTransferAdmissionQueue(QueueLimits limits)
 Status LocalTransferAdmissionQueue::tryAdmit(
     const QueueSubmit& submit, std::vector<QueueOwnerId>& admitted_owner_ids) {
     admitted_owner_ids.clear();
+    CHECK_STATUS(validateLimits(limits_));
     if (submit.batch_token == 0) {
         return Status::InvalidArgument("invalid batch token" LOC_MARK);
     }
-    if (!submit.owners.empty()) {
-        return Status::NotImplemented("queue admission is not wired" LOC_MARK);
+    if (submit.owners.empty()) return Status::OK();
+
+    std::set<PublicTaskKey> public_keys;
+    size_t byte_charge = 0;
+    size_t user_owner_charge = 0;
+    size_t user_byte_charge = 0;
+
+    for (const auto& owner : submit.owners) {
+        if (!isSupportedOwnerKind(owner.kind)) {
+            return Status::InvalidArgument(
+                "unsupported queue owner kind" LOC_MARK);
+        }
+        if (owner.request.length == 0) {
+            return Status::InvalidArgument("empty transfer request" LOC_MARK);
+        }
+
+        const PublicTaskKey owner_key{submit.batch_token, owner.owner_task_id};
+        if (!public_keys.insert(owner_key).second) {
+            return Status::InvalidArgument("duplicate public task id" LOC_MARK);
+        }
+        for (const auto derived_task_id : owner.derived_task_ids) {
+            if (derived_task_id == owner.owner_task_id) {
+                return Status::InvalidArgument(
+                    "owner task id appears in derived task ids" LOC_MARK);
+            }
+            const PublicTaskKey derived_key{submit.batch_token,
+                                            derived_task_id};
+            if (!public_keys.insert(derived_key).second) {
+                return Status::InvalidArgument(
+                    "duplicate public task id" LOC_MARK);
+            }
+        }
+
+        CHECK_STATUS(
+            checkedAdd(byte_charge, owner.request.length, byte_charge));
+        if (owner.kind == QueueOwnerKind::User) {
+            CHECK_STATUS(checkedAdd(user_owner_charge, 1, user_owner_charge));
+            CHECK_STATUS(checkedAdd(user_byte_charge, owner.request.length,
+                                    user_byte_charge));
+        }
     }
+
+    if (public_keys.size() > submit.batch_slots_left) {
+        return Status::TooManyRequests(
+            "batch public task capacity exceeded" LOC_MARK);
+    }
+
+    for (const auto& key : public_keys) {
+        if (public_to_owner_.count(key)) {
+            return Status::InvalidEntry(
+                "public task id already admitted" LOC_MARK);
+        }
+    }
+
+    const size_t owner_charge = submit.owners.size();
+    size_t next_outstanding_owners = 0;
+    size_t next_outstanding_bytes = 0;
+    size_t next_user_owners = 0;
+    size_t next_user_bytes = 0;
+    CHECK_STATUS(
+        checkedAdd(outstanding_owners_, owner_charge, next_outstanding_owners));
+    CHECK_STATUS(
+        checkedAdd(outstanding_bytes_, byte_charge, next_outstanding_bytes));
+    CHECK_STATUS(checkedAdd(outstanding_user_owners_, user_owner_charge,
+                            next_user_owners));
+    CHECK_STATUS(
+        checkedAdd(outstanding_user_bytes_, user_byte_charge, next_user_bytes));
+
+    const size_t user_owner_limit =
+        limits_.max_outstanding_owners - limits_.staging_owner_reserve;
+    const size_t user_byte_limit =
+        limits_.max_outstanding_bytes - limits_.staging_byte_reserve;
+
+    if (next_outstanding_owners > limits_.max_outstanding_owners) {
+        return Status::TooManyRequests(
+            "queue owner capacity exceeded" LOC_MARK);
+    }
+    if (next_outstanding_bytes > limits_.max_outstanding_bytes) {
+        return Status::TooManyRequests("queue byte capacity exceeded" LOC_MARK);
+    }
+    if (next_user_owners > user_owner_limit) {
+        return Status::TooManyRequests("user owner capacity exceeded" LOC_MARK);
+    }
+    if (next_user_bytes > user_byte_limit) {
+        return Status::TooManyRequests("user byte capacity exceeded" LOC_MARK);
+    }
+
+    admitted_owner_ids.reserve(submit.owners.size());
+    for (const auto& owner_input : submit.owners) {
+        const QueueOwnerId owner_id = next_owner_id_++;
+        QueueOwner owner;
+        owner.batch_token = submit.batch_token;
+        owner.request = owner_input.request;
+        owner.kind = owner_input.kind;
+        owners_.emplace(owner_id, owner);
+
+        public_to_owner_[{submit.batch_token, owner_input.owner_task_id}] =
+            owner_id;
+        for (const auto derived_task_id : owner_input.derived_task_ids) {
+            public_to_owner_[{submit.batch_token, derived_task_id}] = owner_id;
+        }
+        fifo_.push_back(owner_id);
+        admitted_owner_ids.push_back(owner_id);
+    }
+
+    outstanding_owners_ = next_outstanding_owners;
+    outstanding_bytes_ = next_outstanding_bytes;
+    outstanding_user_owners_ = next_user_owners;
+    outstanding_user_bytes_ = next_user_bytes;
     return Status::OK();
 }
 
@@ -58,12 +203,15 @@ Status LocalTransferAdmissionQueue::retireBatch(uint64_t batch_token) {
 Status LocalTransferAdmissionQueue::resolveOwner(uint64_t batch_token,
                                                  size_t public_task_id,
                                                  QueueOwnerId& owner_id) const {
-    (void)public_task_id;
-    owner_id = 0;
     if (batch_token == 0) {
         return Status::InvalidArgument("invalid batch token" LOC_MARK);
     }
-    return Status::InvalidEntry("public task id not found" LOC_MARK);
+    auto it = public_to_owner_.find({batch_token, public_task_id});
+    if (it == public_to_owner_.end()) {
+        return Status::InvalidEntry("public task id not found" LOC_MARK);
+    }
+    owner_id = it->second;
+    return Status::OK();
 }
 
 Status LocalTransferAdmissionQueue::getPublicStatus(

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -20,6 +20,13 @@ target_include_directories(metrics_config_loader_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME metrics_config_loader_test COMMAND metrics_config_loader_test)
 
+add_executable(admission_queue_test admission_queue_test.cpp
+                                    ../src/runtime/admission_queue.cpp)
+target_link_libraries(admission_queue_test PRIVATE tent_common gtest gtest_main)
+target_include_directories(admission_queue_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+add_test(NAME admission_queue_test COMMAND admission_queue_test)
+
 add_executable(tent_ip_utils_test ip_utils_test.cpp)
 target_link_libraries(tent_ip_utils_test PRIVATE tent_common gtest gtest_main)
 target_include_directories(tent_ip_utils_test

--- a/mooncake-transfer-engine/tent/tests/admission_queue_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/admission_queue_test.cpp
@@ -60,6 +60,19 @@ TEST(AdmissionQueueTest, AllowsEmptySubmitAsNoOp) {
     EXPECT_EQ(queue.outstandingBytes(), 0u);
 }
 
+TEST(AdmissionQueueTest, RejectsSubmitWhenQueueLimitsAreInvalid) {
+    LocalTransferAdmissionQueue queue({1, 128, 2, 0});
+    std::vector<QueueOwnerId> admitted_ids{99};
+
+    auto status =
+        queue.tryAdmit(makeSubmit(1, 1, {makeOwner(0, 16)}), admitted_ids);
+
+    EXPECT_EQ(status.code(), Status::Code::kInvalidArgument);
+    EXPECT_TRUE(admitted_ids.empty());
+    EXPECT_EQ(queue.outstandingOwners(), 0u);
+    EXPECT_EQ(queue.outstandingBytes(), 0u);
+}
+
 TEST(AdmissionQueueTest, RejectsInvalidInputsWithoutPartialAdmission) {
     LocalTransferAdmissionQueue queue({4, 128, 0, 0});
     std::vector<QueueOwnerId> admitted_ids{99};

--- a/mooncake-transfer-engine/tent/tests/admission_queue_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/admission_queue_test.cpp
@@ -142,6 +142,19 @@ TEST(AdmissionQueueTest, RejectsExistingPublicTaskConflictWithoutMutation) {
     QueueOwnerId owner_id = 0;
     status = queue.resolveOwner(1, 1, owner_id);
     EXPECT_EQ(status.code(), Status::Code::kInvalidEntry);
+
+    auto picked = queue.pickForDispatch(1, 16);
+    ASSERT_EQ(picked.size(), 1u);
+    status = queue.complete(picked[0], TransferStatusEnum::COMPLETED);
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+    status = queue.retireBatch(1);
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+
+    status = queue.tryAdmit(makeSubmit(2, 1, {makeOwner(0, 16)}), admitted_ids);
+
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+    ASSERT_EQ(admitted_ids.size(), 1u);
+    EXPECT_EQ(admitted_ids[0], 2u);
 }
 
 TEST(AdmissionQueueTest, AccountsPublicSlotsSeparatelyFromQueueOwners) {
@@ -201,6 +214,146 @@ TEST(AdmissionQueueTest, PreservesStagingReserveForStagingInternalOwners) {
     EXPECT_EQ(admitted_ids[0], 2u);
     EXPECT_EQ(queue.outstandingOwners(), 2u);
     EXPECT_EQ(queue.outstandingBytes(), 100u);
+}
+
+TEST(AdmissionQueueTest, KeepsAdmissionOrderForDispatch) {
+    LocalTransferAdmissionQueue queue({4, 128, 0, 0});
+    std::vector<QueueOwnerId> admitted_ids;
+
+    auto status = queue.tryAdmit(
+        makeSubmit(1, 2,
+                   {makeOwner(0, 60),
+                    makeOwner(1, 10, QueueOwnerKind::StagingInternal)}),
+        admitted_ids);
+
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+    ASSERT_EQ(admitted_ids.size(), 2u);
+    const std::vector<QueueOwnerId> expected_ids{1, 2};
+    EXPECT_EQ(admitted_ids, expected_ids);
+
+    EXPECT_TRUE(queue.pickForDispatch(2, 50).empty());
+
+    auto picked = queue.pickForDispatch(2, 70);
+
+    EXPECT_EQ(picked, expected_ids);
+}
+
+TEST(AdmissionQueueTest, RequiresDispatchBeforeTerminalCompletion) {
+    LocalTransferAdmissionQueue queue({2, 128, 0, 0});
+    std::vector<QueueOwnerId> admitted_ids;
+
+    auto status =
+        queue.tryAdmit(makeSubmit(1, 1, {makeOwner(0, 16)}), admitted_ids);
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+    ASSERT_EQ(admitted_ids.size(), 1u);
+
+    status = queue.complete(admitted_ids[0], TransferStatusEnum::COMPLETED);
+    EXPECT_EQ(status.code(), Status::Code::kInvalidEntry);
+    status = queue.complete(admitted_ids[0], TransferStatusEnum::PENDING);
+    EXPECT_EQ(status.code(), Status::Code::kInvalidArgument);
+    EXPECT_EQ(queue.outstandingOwners(), 1u);
+    EXPECT_EQ(queue.outstandingBytes(), 16u);
+
+    auto picked = queue.pickForDispatch(1, 16);
+    ASSERT_EQ(picked.size(), 1u);
+
+    status = queue.complete(picked[0], TransferStatusEnum::COMPLETED);
+    EXPECT_EQ(status.code(), Status::Code::kOk);
+    EXPECT_EQ(queue.outstandingOwners(), 0u);
+    EXPECT_EQ(queue.outstandingBytes(), 0u);
+
+    status = queue.complete(picked[0], TransferStatusEnum::COMPLETED);
+    EXPECT_EQ(status.code(), Status::Code::kInvalidEntry);
+}
+
+TEST(AdmissionQueueTest, RetainsTerminalStatusUntilBatchRetire) {
+    LocalTransferAdmissionQueue queue({2, 128, 0, 0});
+    std::vector<QueueOwnerId> admitted_ids;
+
+    auto status = queue.tryAdmit(
+        makeSubmit(1, 2, {makeOwner(0, 16, QueueOwnerKind::User, {1})}),
+        admitted_ids);
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+
+    TransferStatusEnum public_status = TransferStatusEnum::INVALID;
+    status = queue.getPublicStatus(1, 1, public_status);
+    EXPECT_EQ(status.code(), Status::Code::kOk);
+    EXPECT_EQ(public_status, TransferStatusEnum::PENDING);
+
+    auto picked = queue.pickForDispatch(1, 16);
+    ASSERT_EQ(picked.size(), 1u);
+    status = queue.complete(picked[0], TransferStatusEnum::FAILED);
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+
+    status = queue.getPublicStatus(1, 0, public_status);
+    EXPECT_EQ(status.code(), Status::Code::kOk);
+    EXPECT_EQ(public_status, TransferStatusEnum::FAILED);
+    status = queue.getPublicStatus(1, 1, public_status);
+    EXPECT_EQ(status.code(), Status::Code::kOk);
+    EXPECT_EQ(public_status, TransferStatusEnum::FAILED);
+
+    status = queue.retireBatch(1);
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+
+    QueueOwnerId resolved_owner = 0;
+    status = queue.resolveOwner(1, 0, resolved_owner);
+    EXPECT_EQ(status.code(), Status::Code::kInvalidEntry);
+    status = queue.getPublicStatus(1, 1, public_status);
+    EXPECT_EQ(status.code(), Status::Code::kInvalidEntry);
+}
+
+TEST(AdmissionQueueTest, RejectsRetireWithNonTerminalOwners) {
+    LocalTransferAdmissionQueue queue({2, 128, 0, 0});
+    std::vector<QueueOwnerId> admitted_ids;
+
+    auto status = queue.tryAdmit(
+        makeSubmit(1, 2, {makeOwner(0, 16), makeOwner(1, 16)}), admitted_ids);
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+
+    auto picked = queue.pickForDispatch(1, 16);
+    ASSERT_EQ(picked.size(), 1u);
+    status = queue.complete(picked[0], TransferStatusEnum::COMPLETED);
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+
+    status = queue.retireBatch(1);
+    EXPECT_EQ(status.code(), Status::Code::kInvalidEntry);
+
+    picked = queue.pickForDispatch(1, 16);
+    ASSERT_EQ(picked.size(), 1u);
+    status = queue.complete(picked[0], TransferStatusEnum::COMPLETED);
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+
+    status = queue.retireBatch(1);
+    EXPECT_EQ(status.code(), Status::Code::kOk);
+}
+
+TEST(AdmissionQueueTest, AllowsBatchTokenReuseAfterRetire) {
+    LocalTransferAdmissionQueue queue({1, 128, 0, 0});
+    std::vector<QueueOwnerId> admitted_ids;
+
+    auto status =
+        queue.tryAdmit(makeSubmit(1, 1, {makeOwner(0, 16)}), admitted_ids);
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+    ASSERT_EQ(admitted_ids.size(), 1u);
+    EXPECT_EQ(admitted_ids[0], 1u);
+
+    auto picked = queue.pickForDispatch(1, 16);
+    ASSERT_EQ(picked.size(), 1u);
+    status = queue.complete(picked[0], TransferStatusEnum::COMPLETED);
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+    status = queue.retireBatch(1);
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+
+    status = queue.tryAdmit(makeSubmit(1, 1, {makeOwner(0, 16)}), admitted_ids);
+
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+    ASSERT_EQ(admitted_ids.size(), 1u);
+    EXPECT_EQ(admitted_ids[0], 2u);
+
+    QueueOwnerId resolved_owner = 0;
+    status = queue.resolveOwner(1, 0, resolved_owner);
+    EXPECT_EQ(status.code(), Status::Code::kOk);
+    EXPECT_EQ(resolved_owner, 2u);
 }
 
 }  // namespace

--- a/mooncake-transfer-engine/tent/tests/admission_queue_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/admission_queue_test.cpp
@@ -23,6 +23,22 @@ namespace mooncake {
 namespace tent {
 namespace {
 
+QueueOwnerInput makeOwner(
+    size_t public_task_id, size_t length,
+    QueueOwnerKind kind = QueueOwnerKind::User,
+    std::vector<size_t> derived_task_ids = std::vector<size_t>()) {
+    QueueOwnerInput owner;
+    owner.owner_task_id = public_task_id;
+    owner.derived_task_ids = std::move(derived_task_ids);
+    owner.request.opcode = Request::WRITE;
+    owner.request.source = nullptr;
+    owner.request.target_id = 1;
+    owner.request.target_offset = public_task_id * 4096;
+    owner.request.length = length;
+    owner.kind = kind;
+    return owner;
+}
+
 QueueSubmit makeSubmit(uint64_t batch_token, size_t batch_slots_left,
                        std::vector<QueueOwnerInput> owners) {
     QueueSubmit submit;
@@ -42,6 +58,149 @@ TEST(AdmissionQueueTest, AllowsEmptySubmitAsNoOp) {
     EXPECT_TRUE(admitted_ids.empty());
     EXPECT_EQ(queue.outstandingOwners(), 0u);
     EXPECT_EQ(queue.outstandingBytes(), 0u);
+}
+
+TEST(AdmissionQueueTest, RejectsInvalidInputsWithoutPartialAdmission) {
+    LocalTransferAdmissionQueue queue({4, 128, 0, 0});
+    std::vector<QueueOwnerId> admitted_ids{99};
+
+    auto status = queue.tryAdmit(
+        makeSubmit(
+            1, 2,
+            {makeOwner(0, 16, QueueOwnerKind::User, {1}), makeOwner(1, 16)}),
+        admitted_ids);
+
+    EXPECT_EQ(status.code(), Status::Code::kInvalidArgument);
+    EXPECT_TRUE(admitted_ids.empty());
+    EXPECT_EQ(queue.outstandingOwners(), 0u);
+    EXPECT_EQ(queue.outstandingBytes(), 0u);
+
+    status = queue.tryAdmit(makeSubmit(1, 1, {makeOwner(2, 16)}), admitted_ids);
+
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+    ASSERT_EQ(admitted_ids.size(), 1u);
+    EXPECT_EQ(admitted_ids[0], 1u);
+}
+
+TEST(AdmissionQueueTest, RejectsUnsupportedOwnerKindWithoutPartialAdmission) {
+    LocalTransferAdmissionQueue queue({4, 128, 0, 0});
+    std::vector<QueueOwnerId> admitted_ids{99};
+
+    auto invalid_owner = makeOwner(0, 16, static_cast<QueueOwnerKind>(99), {1});
+    auto status = queue.tryAdmit(makeSubmit(1, 2, {std::move(invalid_owner)}),
+                                 admitted_ids);
+
+    EXPECT_EQ(status.code(), Status::Code::kInvalidArgument);
+    EXPECT_TRUE(admitted_ids.empty());
+    EXPECT_EQ(queue.outstandingOwners(), 0u);
+    EXPECT_EQ(queue.outstandingBytes(), 0u);
+
+    status = queue.tryAdmit(makeSubmit(1, 1, {makeOwner(2, 16)}), admitted_ids);
+
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+    ASSERT_EQ(admitted_ids.size(), 1u);
+    EXPECT_EQ(admitted_ids[0], 1u);
+}
+
+TEST(AdmissionQueueTest, RejectsCapacityExceededWithoutPartialAdmission) {
+    LocalTransferAdmissionQueue queue({1, 64, 0, 0});
+    std::vector<QueueOwnerId> admitted_ids;
+
+    auto status = queue.tryAdmit(
+        makeSubmit(1, 2, {makeOwner(0, 16), makeOwner(1, 16)}), admitted_ids);
+
+    EXPECT_EQ(status.code(), Status::Code::kTooManyRequests);
+    EXPECT_TRUE(admitted_ids.empty());
+    EXPECT_EQ(queue.outstandingOwners(), 0u);
+    EXPECT_EQ(queue.outstandingBytes(), 0u);
+
+    status = queue.tryAdmit(makeSubmit(1, 1, {makeOwner(0, 16)}), admitted_ids);
+
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+    ASSERT_EQ(admitted_ids.size(), 1u);
+    EXPECT_EQ(admitted_ids[0], 1u);
+}
+
+TEST(AdmissionQueueTest, RejectsExistingPublicTaskConflictWithoutMutation) {
+    LocalTransferAdmissionQueue queue({4, 128, 0, 0});
+    std::vector<QueueOwnerId> admitted_ids;
+
+    auto status =
+        queue.tryAdmit(makeSubmit(1, 1, {makeOwner(0, 16)}), admitted_ids);
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+    ASSERT_EQ(admitted_ids.size(), 1u);
+    EXPECT_EQ(admitted_ids[0], 1u);
+
+    status = queue.tryAdmit(
+        makeSubmit(1, 2, {makeOwner(1, 16), makeOwner(0, 16)}), admitted_ids);
+
+    EXPECT_EQ(status.code(), Status::Code::kInvalidEntry);
+    EXPECT_TRUE(admitted_ids.empty());
+    EXPECT_EQ(queue.outstandingOwners(), 1u);
+    EXPECT_EQ(queue.outstandingBytes(), 16u);
+
+    QueueOwnerId owner_id = 0;
+    status = queue.resolveOwner(1, 1, owner_id);
+    EXPECT_EQ(status.code(), Status::Code::kInvalidEntry);
+}
+
+TEST(AdmissionQueueTest, AccountsPublicSlotsSeparatelyFromQueueOwners) {
+    LocalTransferAdmissionQueue queue({2, 128, 0, 0});
+    std::vector<QueueOwnerId> admitted_ids;
+
+    auto status = queue.tryAdmit(
+        makeSubmit(1, 2, {makeOwner(7, 32, QueueOwnerKind::User, {8, 9})}),
+        admitted_ids);
+
+    EXPECT_EQ(status.code(), Status::Code::kTooManyRequests);
+    EXPECT_TRUE(admitted_ids.empty());
+    EXPECT_EQ(queue.outstandingOwners(), 0u);
+
+    status = queue.tryAdmit(
+        makeSubmit(1, 3, {makeOwner(7, 32, QueueOwnerKind::User, {8, 9})}),
+        admitted_ids);
+
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+    ASSERT_EQ(admitted_ids.size(), 1u);
+    EXPECT_EQ(queue.outstandingOwners(), 1u);
+    EXPECT_EQ(queue.outstandingBytes(), 32u);
+
+    QueueOwnerId resolved_owner = 0;
+    status = queue.resolveOwner(1, 7, resolved_owner);
+    EXPECT_EQ(status.code(), Status::Code::kOk);
+    EXPECT_EQ(resolved_owner, admitted_ids[0]);
+    status = queue.resolveOwner(1, 8, resolved_owner);
+    EXPECT_EQ(status.code(), Status::Code::kOk);
+    EXPECT_EQ(resolved_owner, admitted_ids[0]);
+    status = queue.resolveOwner(1, 9, resolved_owner);
+    EXPECT_EQ(status.code(), Status::Code::kOk);
+    EXPECT_EQ(resolved_owner, admitted_ids[0]);
+    status = queue.resolveOwner(1, 0, resolved_owner);
+    EXPECT_EQ(status.code(), Status::Code::kInvalidEntry);
+}
+
+TEST(AdmissionQueueTest, PreservesStagingReserveForStagingInternalOwners) {
+    LocalTransferAdmissionQueue queue({2, 100, 1, 40});
+    std::vector<QueueOwnerId> admitted_ids;
+
+    auto status =
+        queue.tryAdmit(makeSubmit(1, 1, {makeOwner(0, 60)}), admitted_ids);
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+
+    status = queue.tryAdmit(makeSubmit(2, 1, {makeOwner(0, 1)}), admitted_ids);
+    EXPECT_EQ(status.code(), Status::Code::kTooManyRequests);
+    EXPECT_TRUE(admitted_ids.empty());
+    EXPECT_EQ(queue.outstandingOwners(), 1u);
+    EXPECT_EQ(queue.outstandingBytes(), 60u);
+
+    status = queue.tryAdmit(
+        makeSubmit(3, 1, {makeOwner(0, 40, QueueOwnerKind::StagingInternal)}),
+        admitted_ids);
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+    ASSERT_EQ(admitted_ids.size(), 1u);
+    EXPECT_EQ(admitted_ids[0], 2u);
+    EXPECT_EQ(queue.outstandingOwners(), 2u);
+    EXPECT_EQ(queue.outstandingBytes(), 100u);
 }
 
 }  // namespace

--- a/mooncake-transfer-engine/tent/tests/admission_queue_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/admission_queue_test.cpp
@@ -1,0 +1,49 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tent/runtime/admission_queue.h"
+
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+QueueSubmit makeSubmit(uint64_t batch_token, size_t batch_slots_left,
+                       std::vector<QueueOwnerInput> owners) {
+    QueueSubmit submit;
+    submit.batch_token = batch_token;
+    submit.batch_slots_left = batch_slots_left;
+    submit.owners = std::move(owners);
+    return submit;
+}
+
+TEST(AdmissionQueueTest, AllowsEmptySubmitAsNoOp) {
+    LocalTransferAdmissionQueue queue({2, 128, 0, 0});
+    std::vector<QueueOwnerId> admitted_ids{99};
+
+    auto status = queue.tryAdmit(makeSubmit(1, 0, {}), admitted_ids);
+
+    EXPECT_EQ(status.code(), Status::Code::kOk);
+    EXPECT_TRUE(admitted_ids.empty());
+    EXPECT_EQ(queue.outstandingOwners(), 0u);
+    EXPECT_EQ(queue.outstandingBytes(), 0u);
+}
+
+}  // namespace
+}  // namespace tent
+}  // namespace mooncake


### PR DESCRIPTION
## Description

 This is the first local admission queue prototype for the TENT work discussed in #2132.

 The patch adds a small runtime-side queue model without wiring it into the current `TransferEngineImpl::submitTransfer()` path yet. It models the pieces that are hard to retrofit later: public task ids and derived task ids resolve to one queue owner, admission is checked and committed all-or-nothing, staging-internal work has reserved capacity, and dispatch is bounded by both owner count and byte window.

 The model also keeps terminal queue status until the batch is retired, so status lookup and batch-token reuse have an explicit lifecycle in the prototype.

 The existing direct-submit path stays unchanged. This PR does not add public APIs, submit queued work to real transports, or change `ProxyManager` remote delegate behavior.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

Built and ran the queue test:
``` bash
cmake --build build --target admission_queue_test tent_runtime
  ./build/mooncake-transfer-engine/tent/tests/admission_queue_test
```

Ran nearby regression tests:
``` bash
cmake --build build --target request_merge_test metrics_config_loader_test transfer_engine_config_override_test
  ./build/mooncake-transfer-engine/tent/tests/request_merge_test
  ./build/mooncake-transfer-engine/tent/tests/metrics_config_loader_test
  ./build/mooncake-transfer-engine/tent/tests/transfer_engine_config_override_test

```

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
