### PR TITLE
feat(engine): add attributes in python package for compile flags

### DIFF
--- a/docs/source/python-api-reference/transfer-engine.md
+++ b/docs/source/python-api-reference/transfer-engine.md
@@ -817,3 +817,32 @@ The Transfer Engine Python API is thread-safe for most operations. However, it's
 2. **Transfer Failures**: Verify target hostname is correct and network connectivity is established
 3. **Memory Issues**: Ensure sufficient system memory and proper buffer alignment
 4. **Performance Issues**: Check RDMA device configuration and network topology
+
+## Compile-time Feature Support Attributes
+
+The `mooncake.engine` module provides boolean attributes that indicate whether specific features were enabled during compilation:
+
+### Module Attributes
+
+- `engine.SUPPORT_CUDA`: Whether CUDA support is enabled
+- `engine.SUPPORT_EFA`: Whether EFA (Elastic Fabric Adapter) support is enabled
+- `engine.SUPPORT_HIP`: Whether HIP (Heterogeneous-compute Interface for Portability) support is enabled
+- `engine.SUPPORT_MNNVL`: Whether MNNVL transport protocol support is enabled
+- `engine.SUPPORT_INTRA_NVLINK`: Whether intra-node NVLink support is enabled
+
+### Usage Example
+
+```python
+from mooncake import engine
+
+# Check if CUDA is supported
+if engine.SUPPORT_CUDA:
+    print("CUDA support is available")
+
+# Check all features
+print(f"CUDA: {engine.SUPPORT_CUDA}")
+print(f"EFA: {engine.SUPPORT_EFA}")
+print(f"HIP: {engine.SUPPORT_HIP}")
+print(f"MNNVL: {engine.SUPPORT_MNNVL}")
+print(f"Intra-NVLink: {engine.SUPPORT_INTRA_NVLINK}")
+```

--- a/mooncake-integration/transfer_engine/transfer_engine_py.cpp
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.cpp
@@ -1034,6 +1034,36 @@ void bind_coro_rpc_interface(py::module_& m) {
 }
 
 PYBIND11_MODULE(engine, m) {
+#ifdef USE_EFA
+    m.attr("SUPPORT_EFA") = true;
+#else
+    m.attr("SUPPORT_EFA") = false;
+#endif
+
+#ifdef USE_HIP
+    m.attr("SUPPORT_HIP") = true;
+#else
+    m.attr("SUPPORT_HIP") = false;
+#endif
+
+#ifdef USE_MNNVL
+    m.attr("SUPPORT_MNNVL") = true;
+#else
+    m.attr("SUPPORT_MNNVL") = false;
+#endif
+
+#ifdef USE_INTRA_NVLINK
+    m.attr("SUPPORT_INTRA_NVLINK") = true;
+#else
+    m.attr("SUPPORT_INTRA_NVLINK") = false;
+#endif
+
+#ifdef USE_CUDA
+    m.attr("SUPPORT_CUDA") = true;
+#else
+    m.attr("SUPPORT_CUDA") = false;
+#endif
+
     py::enum_<TransferEnginePy::TransferOpcode> transfer_opcode(
         m, "TransferOpcode", py::arithmetic());
     transfer_opcode.value("Read", TransferEnginePy::TransferOpcode::READ)


### PR DESCRIPTION
…le flags

## Description

Provides following boolean attributes that indicate whether specific features were enabled during compilation:

- `engine.SUPPORT_CUDA`: Whether CUDA support is enabled
- `engine.SUPPORT_EFA`: Whether EFA (Elastic Fabric Adapter) support is enabled
- `engine.SUPPORT_HIP`: Whether HIP (Heterogeneous-compute Interface for Portability) support is enabled
- `engine.SUPPORT_MNNVL`: Whether MNNVL transport protocol support is enabled
- `engine.SUPPORT_INTRA_NVLINK`: Whether intra-node NVLink support is enabled

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [x] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other

## How Has This Been Tested?

compiled wheel package contains added attributes 

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
