### PR TITLE
[TE] Fix error-path safety: freeaddrinfo leak, null deref, OOB read

### DIFF
--- a/mooncake-transfer-engine/include/common.h
+++ b/mooncake-transfer-engine/include/common.h
@@ -458,6 +458,11 @@ static inline std::pair<HandShakeRequestType, std::string> readString(int fd) {
         return {type, ""};
     }
 
+    if (length == 0) {
+        LOG(ERROR) << "readString: zero length from socket";
+        return {type, ""};
+    }
+
     std::string str;
     std::vector<char> buffer(length);
     n = readFully(fd, buffer.data(), length);

--- a/mooncake-transfer-engine/src/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine_impl.cpp
@@ -430,6 +430,10 @@ int TransferEngineImpl::getNotifies(
 int TransferEngineImpl::sendNotifyByID(
     SegmentID target_id, TransferMetadata::NotifyDesc notify_msg) {
     auto desc = metadata_->getSegmentDescByID(target_id);
+    if (!desc) {
+        LOG(ERROR) << "sendNotifyByID: invalid segment ID " << target_id;
+        return ERR_METADATA;
+    }
     Transport::NotifyDesc peer_desc;
     int ret = metadata_->sendNotify(desc->name, notify_msg, peer_desc);
     return ret;

--- a/mooncake-transfer-engine/src/transfer_metadata_plugin.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata_plugin.cpp
@@ -856,6 +856,7 @@ struct SocketHandShakePlugin : public HandShakePlugin {
                 return 0;
             }
             if (ret == ERR_MALFORMED_JSON) {
+                freeaddrinfo(result);
                 return ret;
             }
         }
@@ -891,6 +892,7 @@ struct SocketHandShakePlugin : public HandShakePlugin {
                 return 0;
             }
             if (ret == ERR_MALFORMED_JSON) {
+                freeaddrinfo(result);
                 return ret;
             }
         }
@@ -926,6 +928,7 @@ struct SocketHandShakePlugin : public HandShakePlugin {
                 return 0;
             }
             if (ret == ERR_MALFORMED_JSON) {
+                freeaddrinfo(result);
                 return ret;
             }
         }
@@ -1034,6 +1037,7 @@ struct SocketHandShakePlugin : public HandShakePlugin {
                 return 0;
             }
             if (ret == ERR_MALFORMED_JSON) {
+                freeaddrinfo(result);
                 return ret;
             }
         }


### PR DESCRIPTION
## Summary

Three mechanical safety fixes in transfer engine error paths:

- **freeaddrinfo leak** (`transfer_metadata_plugin.cpp`): `sendNotify`, `sendProbe`, `send`, and `exchangeMetadata` all call `getaddrinfo` which allocates `result`, then loop over addresses calling `doSend*`. On `ERR_MALFORMED_JSON` early return, `result` was leaked. Added `freeaddrinfo(result)` before each such return (4 sites).
- **Null pointer dereference** (`transfer_engine_impl.cpp`): `sendNotifyByID` calls `getSegmentDescByID(target_id)` then dereferences `desc->name` without null check. Added null guard returning `ERR_METADATA`, matching the existing `probePeerAliveByID` pattern at line 445.
- **OOB read on zero-length input** (`common.h`): `readString` creates `buffer(length)` then accesses `buffer[0]`. When peer sends `length=0`, this is an out-of-bounds read. Added early return on zero length.

## What's NOT changed

- No protocol changes
- No behavior change on success paths
- No new dependencies

## Test plan

- [x] Verified via code analysis: each fix is a single guard on an error path
- [x] Adversarial workflow review (correctness + adversarial reviewers per fix)
- [ ] Compilation (no RDMA/GPU hardware available locally)
- [ ] E2E: not verified — requires metadata server + RDMA environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)