### PR TITLE
[TE] Harden config parsing: remove exit() and guard stoi

### DIFF
--- a/mooncake-transfer-engine/src/config.cpp
+++ b/mooncake-transfer-engine/src/config.cpp
@@ -158,7 +158,6 @@ void loadGlobalConfig(GlobalConfig& config) {
         else {
             LOG(ERROR) << "Ignore value from environment variable MC_MTU, it "
                           "should be 512|1024|2048|4096";
-            exit(EXIT_FAILURE);
         }
     }
 
@@ -232,12 +231,18 @@ void loadGlobalConfig(GlobalConfig& config) {
     const char* handshake_listen_backlog =
         std::getenv("MC_HANDSHAKE_LISTEN_BACKLOG");
     if (handshake_listen_backlog) {
-        int val = std::stoi(handshake_listen_backlog);
-        if (val > 0) {
-            config.handshake_listen_backlog = val;
-        } else {
-            LOG(WARNING) << "Ignore value from environment variable "
-                            "MC_HANDSHAKE_LISTEN_BACKLOG";
+        try {
+            int val = std::stoi(handshake_listen_backlog);
+            if (val > 0) {
+                config.handshake_listen_backlog = val;
+            } else {
+                LOG(WARNING) << "Ignore value from environment variable "
+                                "MC_HANDSHAKE_LISTEN_BACKLOG";
+            }
+        } catch (const std::exception& e) {
+            LOG(WARNING) << "Invalid MC_HANDSHAKE_LISTEN_BACKLOG environment "
+                            "value: "
+                         << handshake_listen_backlog << ". Error: " << e.what();
         }
     }
 


### PR DESCRIPTION
## Summary

两处 `config.cpp` 解析加固：

- **Remove `exit(EXIT_FAILURE)` on invalid `MC_MTU`**: Invalid MTU value previously crashed the entire process. Now logs `ERROR` and keeps the default `IBV_MTU_4096`. LOG(ERROR) retained because RDMA MTU misconfiguration is a serious issue worth loud logging.
- **Guard `std::stoi` on `MC_HANDSHAKE_LISTEN_BACKLOG`**: Unguarded `std::stoi` throws `std::invalid_argument` / `std::out_of_range` on non-numeric input, crashing the process. Wrapped in try-catch matching the existing `MC_PKEY_INDEX` / `MC_IB_TC` pattern.

## What's NOT changed

- No other env var parsing changed
- No default values changed
- No new env vars added

## Test plan

- [x] Verified via code analysis: exit() removal is safe (default value already set before the if-else chain); try-catch matches existing pattern
- [x] Adversarial workflow review
- [ ] Compilation (no RDMA/GPU hardware available locally)
- [ ] E2E: not verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)