### PR TITLE
[Store] Fix crash on non-numeric config and silent failure in async_start

### DIFF
--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -2781,8 +2781,8 @@ tl::expected<UUID, ErrorCode> Client::MountSegmentAndGetId(
             }
         }
 
-        int rc = transfer_engine_->registerLocalMemory(const_cast<void*>(buffer), size,
-                                                       location, true, true);
+        int rc = transfer_engine_->registerLocalMemory(
+            const_cast<void*>(buffer), size, location, true, true);
         if (rc != 0) {
             LOG(ERROR) << "register_local_memory_failed base=" << buffer
                        << " size=" << size << ", error=" << rc;
@@ -2806,8 +2806,8 @@ tl::expected<UUID, ErrorCode> Client::MountSegmentAndGetId(
             ErrorCode err = mount_result.error();
             LOG(ERROR) << "mount_segment_to_master_failed base=" << buffer
                        << " size=" << size << ", error=" << err;
-            int unreg_rc =
-                transfer_engine_->unregisterLocalMemory(const_cast<void*>(buffer));
+            int unreg_rc = transfer_engine_->unregisterLocalMemory(
+                const_cast<void*>(buffer));
             if (unreg_rc != 0) {
                 LOG(WARNING) << "unregisterLocalMemory failed during cleanup"
                              << ", rc=" << unreg_rc;

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -2781,7 +2781,7 @@ tl::expected<UUID, ErrorCode> Client::MountSegmentAndGetId(
             }
         }
 
-        int rc = transfer_engine_->registerLocalMemory((void*)buffer, size,
+        int rc = transfer_engine_->registerLocalMemory(const_cast<void*>(buffer), size,
                                                        location, true, true);
         if (rc != 0) {
             LOG(ERROR) << "register_local_memory_failed base=" << buffer
@@ -2807,7 +2807,7 @@ tl::expected<UUID, ErrorCode> Client::MountSegmentAndGetId(
             LOG(ERROR) << "mount_segment_to_master_failed base=" << buffer
                        << " size=" << size << ", error=" << err;
             int unreg_rc =
-                transfer_engine_->unregisterLocalMemory((void*)buffer);
+                transfer_engine_->unregisterLocalMemory(const_cast<void*>(buffer));
             if (unreg_rc != 0) {
                 LOG(WARNING) << "unregisterLocalMemory failed during cleanup"
                              << ", rc=" << unreg_rc;

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -2806,12 +2806,6 @@ tl::expected<UUID, ErrorCode> Client::MountSegmentAndGetId(
             ErrorCode err = mount_result.error();
             LOG(ERROR) << "mount_segment_to_master_failed base=" << buffer
                        << " size=" << size << ", error=" << err;
-            int unreg_rc = transfer_engine_->unregisterLocalMemory(
-                const_cast<void*>(buffer));
-            if (unreg_rc != 0) {
-                LOG(WARNING) << "unregisterLocalMemory failed during cleanup"
-                             << ", rc=" << unreg_rc;
-            }
             return tl::unexpected(err);
         }
 

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -2806,7 +2806,12 @@ tl::expected<UUID, ErrorCode> Client::MountSegmentAndGetId(
             ErrorCode err = mount_result.error();
             LOG(ERROR) << "mount_segment_to_master_failed base=" << buffer
                        << " size=" << size << ", error=" << err;
-            transfer_engine_->unregisterLocalMemory((void*)buffer);
+            int unreg_rc =
+                transfer_engine_->unregisterLocalMemory((void*)buffer);
+            if (unreg_rc != 0) {
+                LOG(WARNING) << "unregisterLocalMemory failed during cleanup"
+                             << ", rc=" << unreg_rc;
+            }
             return tl::unexpected(err);
         }
 

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -393,23 +393,26 @@ Client::~Client() {
 static std::optional<bool> get_auto_discover() {
     const char* ev_ad = std::getenv("MC_MS_AUTO_DISC");
     if (ev_ad) {
-        try {
-            int iv = std::stoi(ev_ad);
-            if (iv == 1) {
-                LOG(INFO) << "auto discovery set by env MC_MS_AUTO_DISC";
-                return true;
-            } else if (iv == 0) {
-                LOG(INFO) << "auto discovery not set by env MC_MS_AUTO_DISC";
-                return false;
-            }
-        } catch (const std::exception&) {
-            // A non-numeric or out-of-range value makes std::stoi throw; fall
-            // through to the warning below and use the default instead of
-            // letting the exception abort client initialization.
+        char* end = nullptr;
+        errno = 0;
+        long iv = std::strtol(ev_ad, &end, 10);
+        if (errno != 0 || end == ev_ad || *end != '\0') {
+            LOG(WARNING)
+                << "invalid MC_MS_AUTO_DISC value: " << ev_ad
+                << ", should be 0 or 1, using default: auto discovery not set";
+            return std::nullopt;
         }
-        LOG(WARNING)
-            << "invalid MC_MS_AUTO_DISC value: " << ev_ad
-            << ", should be 0 or 1, using default: auto discovery not set";
+        if (iv == 1) {
+            LOG(INFO) << "auto discovery set by env MC_MS_AUTO_DISC";
+            return true;
+        } else if (iv == 0) {
+            LOG(INFO) << "auto discovery not set by env MC_MS_AUTO_DISC";
+            return false;
+        } else {
+            LOG(WARNING)
+                << "invalid MC_MS_AUTO_DISC value: " << ev_ad
+                << ", should be 0 or 1, using default: auto discovery not set";
+        }
     }
     return std::nullopt;
 }
@@ -2803,6 +2806,7 @@ tl::expected<UUID, ErrorCode> Client::MountSegmentAndGetId(
             ErrorCode err = mount_result.error();
             LOG(ERROR) << "mount_segment_to_master_failed base=" << buffer
                        << " size=" << size << ", error=" << err;
+            transfer_engine_->unregisterLocalMemory((void*)buffer);
             return tl::unexpected(err);
         }
 

--- a/mooncake-store/src/http_metadata_server.cpp
+++ b/mooncake-store/src/http_metadata_server.cpp
@@ -112,7 +112,12 @@ bool HttpMetadataServer::start() {
         return true;
     }
 
-    server_->async_start();
+    auto ec = server_->async_start();
+    if (ec.hasResult()) {
+        LOG(ERROR) << "Failed to start HTTP metadata server on " << host_ << ":"
+                   << port_;
+        return false;
+    }
     running_ = true;
     LOG(INFO) << "HTTP metadata server started on " << host_ << ":" << port_;
     return true;


### PR DESCRIPTION
## Summary

- **Fix crash on non-numeric `MC_MS_AUTO_DISC`** (`client_service.cpp`): `get_auto_discover()` used unguarded `std::stoi`, which throws `std::invalid_argument` on inputs like `"true"` or `"yes"`. Replaced with `strtol` + error checking, matching `GetConfiguredNumaSocketId` pattern in the same file.
- **Check `async_start()` return in `HttpMetadataServer::start()`** (`http_metadata_server.cpp`): Port-bind failures were silently ignored. Now checks `ec.hasResult()` and returns false, matching `rpc_service.cpp:233` and `real_client.cpp:1644` patterns.

> **Note**: The RDMA memory leak fix on `MountSegment` failure has been deferred to #2364 for a more thorough review.

## What's NOT changed

- No behavior change on success paths
- No new dependencies
- No other env var parsing changed

## Test plan

- [x] Adversarial workflow review (correctness + adversarial, all issues addressed)
- [x] Review feedback incorporated
- [ ] Compilation: CI
- [ ] E2E: not verified — requires cluster environment
