### PR TITLE
[TE] Fix data race, double-close, uninit, and off-by-one in RDMA transport

### DIFF
--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -209,7 +209,7 @@ int RdmaContext::construct(size_t num_cq_list, size_t num_comp_channels,
     }
 
     num_comp_channel_ = num_comp_channels;
-    comp_channel_ = new ibv_comp_channel *[num_comp_channels];
+    comp_channel_ = new ibv_comp_channel *[num_comp_channels]();
     for (size_t i = 0; i < num_comp_channels; ++i) {
         comp_channel_[i] = ibv_create_comp_channel(context_);
         if (!comp_channel_[i]) {
@@ -228,6 +228,7 @@ int RdmaContext::construct(size_t num_cq_list, size_t num_comp_channels,
     if (joinNonblockingPollList(event_fd_, context_->async_fd)) {
         LOG(ERROR) << "Failed to register context async fd to epoll";
         close(event_fd_);
+        event_fd_ = -1;
         return ERR_CONTEXT;
     }
 
@@ -236,6 +237,7 @@ int RdmaContext::construct(size_t num_cq_list, size_t num_comp_channels,
             LOG(ERROR) << "Failed to register completion channel " << i
                        << " to epoll";
             close(event_fd_);
+            event_fd_ = -1;
             return ERR_CONTEXT;
         }
 
@@ -248,6 +250,7 @@ int RdmaContext::construct(size_t num_cq_list, size_t num_comp_channels,
         if (!cq) {
             PLOG(ERROR) << "Failed to create completion queue";
             close(event_fd_);
+            event_fd_ = -1;
             return ERR_CONTEXT;
         }
         cq_list_[i].native = cq;

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -67,6 +67,7 @@ static void rememberAutoGidSelection(
 RdmaEndPoint::RdmaEndPoint(RdmaContext &context)
     : context_(context),
       status_(INITIALIZING),
+      wr_depth_list_(nullptr),
       active_(true),
       cq_outstanding_(nullptr) {}
 
@@ -162,15 +163,18 @@ int RdmaEndPoint::deconstructLocked() {
     // Adjust cq_outstanding_ before destroying QPs, so the counter is
     // always corrected even if ibv_destroy_qp fails and we return early.
     bool displayed = false;
-    for (size_t i = 0; i < qp_list_.size(); ++i) {
-        if (wr_depth_list_[i] != 0) {
-            if (!displayed) {
-                LOG(WARNING) << "Outstanding work requests found, CQ will not "
-                                "be generated";
-                displayed = true;
+    if (wr_depth_list_) {
+        for (size_t i = 0; i < qp_list_.size(); ++i) {
+            if (wr_depth_list_[i] != 0) {
+                if (!displayed) {
+                    LOG(WARNING)
+                        << "Outstanding work requests found, CQ will not "
+                           "be generated";
+                    displayed = true;
+                }
+                __sync_fetch_and_sub(cq_outstanding_, wr_depth_list_[i]);
+                wr_depth_list_[i] = 0;
             }
-            __sync_fetch_and_sub(cq_outstanding_, wr_depth_list_[i]);
-            wr_depth_list_[i] = 0;
         }
     }
 

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -893,7 +893,7 @@ int RdmaEndPoint::doSetupConnection(int qp_index, const ibv_gid &peer_gid,
                                     uint16_t peer_lid, uint32_t peer_qp_num,
                                     int local_gid_index, std::string *reply_msg,
                                     SetupConnectionFailureInfo *failure_info) {
-    if (qp_index < 0 || qp_index > (int)qp_list_.size())
+    if (qp_index < 0 || qp_index >= (int)qp_list_.size())
         return ERR_INVALID_ARGUMENT;
     auto &qp = qp_list_[qp_index];
 

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -95,7 +95,7 @@ int RdmaEndPoint::construct(ibv_cq *cq, size_t num_qp_list,
     max_sge_per_wr_ = max_sge_per_wr;
     max_inline_bytes_ = max_inline_bytes;
 
-    wr_depth_list_ = new volatile int[num_qp_list];
+    wr_depth_list_ = new volatile int[num_qp_list]();
     if (!wr_depth_list_) {
         LOG(ERROR) << "Failed to allocate memory for work request depth list";
         return ERR_MEMORY;

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
@@ -207,7 +207,7 @@ int RdmaTransport::registerLocalMemoryInternal(void *addr, size_t length,
                                   IBV_ACCESS_REMOTE_WRITE |
                                   IBV_ACCESS_REMOTE_READ;
 
-    static int access_rights = kBaseAccessRights;
+    int access_rights = kBaseAccessRights;
     if (MCIbRelaxedOrderingEnabled) {
         access_rights |= IBV_ACCESS_RELAXED_ORDERING;
     }


### PR DESCRIPTION
## Summary

Five mechanical safety fixes in RDMA transport:

- **Data race** (`rdma_transport.cpp:210`): `static int access_rights` was shared across concurrent `registerLocalMemoryBatch` threads. The `|= IBV_ACCESS_RELAXED_ORDERING` is a non-atomic read-modify-write — UB under TSan. Removed `static` so each call uses a stack-local copy.
- **Double-close** (`rdma_context.cpp`): Three error paths in `construct()` called `close(event_fd_)` without resetting to -1. The destructor's `deconstruct()` then closed the same fd again — the fd number may have been reused by another thread. Added `event_fd_ = -1` after each close.
- **Uninitialized memory** (`rdma_context.cpp:212`): `comp_channel_` array allocated without zero-init. Partial `ibv_create_comp_channel` failure leaves garbage pointers that `deconstruct()` passes to `ibv_destroy_comp_channel`. Added `()` for value-initialization.
- **Sibling uninit bug** (`rdma_endpoint.cpp:98`): Same pattern in `wr_depth_list_`. Partial QP creation failure leaves garbage values that corrupt the CQ outstanding counter via `__sync_fetch_and_sub` in destructor. Added `()` for value-initialization.
- **Off-by-one** (`rdma_endpoint.cpp:896`): Bounds check used `>` instead of `>=`, allowing `qp_index == qp_list_.size()` to pass — OOB access on next line. Changed to `>=`.

## What's NOT changed

- No happy-path behavior changes
- No new dependencies
- No RDMA protocol changes

## Test plan

- [x] Adversarial workflow review (correctness + adversarial, sibling bug caught and fixed)
- [ ] Compilation: CI
- [ ] E2E: not verified — requires RDMA hardware

🤖 Generated with [Claude Code](https://claude.com/claude-code)