### PR TITLE
[PG] Fix null-deref on MNNVL disconnect and activeRanks leak

### DIFF
--- a/mooncake-pg/src/connection_poller.cpp
+++ b/mooncake-pg/src/connection_poller.cpp
@@ -450,8 +450,10 @@ bool ConnectionContext::pollPeer(int pollingRank) {
             }
 
             // Reset warmup region
-            *reinterpret_cast<volatile int32_t*>(
-                &warmup_recv_region_[pollingRank]) = 0;
+            if (warmup_recv_region_) {
+                *reinterpret_cast<volatile int32_t*>(
+                    &warmup_recv_region_[pollingRank]) = 0;
+            }
 
             // Reset P2PProxy states
             p2p_proxy_->resetPeerState(pollingRank);

--- a/mooncake-pg/src/mooncake_backend.cpp
+++ b/mooncake-pg/src/mooncake_backend.cpp
@@ -1014,6 +1014,7 @@ void MooncakeBackend::shutdown() {
             cudaFreeHost(meta_->activeRanks);
         }
         meta_->activeRanks = nullptr;
+        meta_->activeRanksDevice = nullptr;
     }
 }
 

--- a/mooncake-pg/src/mooncake_backend.cpp
+++ b/mooncake-pg/src/mooncake_backend.cpp
@@ -1008,6 +1008,12 @@ void MooncakeBackend::shutdown() {
                 cudaFree(recv_buffer_[i]);
             }
         }
+        if (isCpu_) {
+            delete[] meta_->activeRanks;
+        } else {
+            cudaFreeHost(meta_->activeRanks);
+        }
+        meta_->activeRanks = nullptr;
     }
 }
 


### PR DESCRIPTION
## Summary

- **Null-deref crash on MNNVL peer disconnect** (`connection_poller.cpp:453`): On MNNVL/fabric clusters (`skip_warmup_==true`), `warmup_recv_region_` is set to `nullptr` in the constructor (line 70). Peers reach CONNECTED state via the skip_warmup fast path (lines 291-296). When a connected peer later disconnects, the disconnect path unconditionally dereferences `warmup_recv_region_[pollingRank]` to reset the warmup region — null-pointer dereference. Added `if (warmup_recv_region_)` guard, matching the destructor pattern (lines 103-105).
- **activeRanks memory leak** (`mooncake_backend.cpp shutdown()`): `meta_->activeRanks` is allocated via `new bool[]` (CPU) or `cudaHostAlloc` (GPU) at init but never freed in `shutdown()`. Added `delete[]`/`cudaFreeHost` cleanup matching the allocation pattern, inside the `!has_hung_operation` block consistent with surrounding resource cleanup.

## What's NOT changed

- No non-MNNVL path affected by the null guard
- activeRanks cleanup follows existing shutdown pattern (intentional leak on hung operations)

## Test plan

- [x] Adversarial workflow review (correctness + adversarial, no issues found)
- [ ] Compilation: CI
- [ ] E2E: not verified — requires MNNVL/GPU cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)