### PR TITLE
[TE] Fix lock leak, missing transport_, and empty entries UB

### DIFF
--- a/mooncake-transfer-engine/include/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/include/transfer_engine_impl.h
@@ -136,6 +136,9 @@ class TransferEngineImpl {
     Status submitTransferWithNotify(BatchID batch_id,
                                     const std::vector<TransferRequest>& entries,
                                     TransferMetadata::NotifyDesc notify_msg) {
+        if (entries.empty()) {
+            return Status::InvalidArgument("entries must not be empty");
+        }
         auto target_id = entries[0].target_id;
         Status s = multi_transports_->submitTransfer(batch_id, entries);
         if (!s.ok()) {
@@ -194,6 +197,9 @@ class TransferEngineImpl {
     Status mp_submitTransferWithNotify(
         BatchID batch_id, const std::vector<TransferRequest>& entries,
         TransferMetadata::NotifyDesc notify_msg, std::string& proto) {
+        if (entries.empty()) {
+            return Status::InvalidArgument("entries must not be empty");
+        }
         auto target_id = entries[0].target_id;
         Status s =
             multi_transports_->mp_submitTransfer(batch_id, entries, proto);

--- a/mooncake-transfer-engine/src/multi_transport.cpp
+++ b/mooncake-transfer-engine/src/multi_transport.cpp
@@ -167,6 +167,7 @@ Status MultiTransport::mp_submitTransfer(
         assert(transport);
         auto& task = batch_desc.task_list[task_id];
         task.batch_id = batch_id;
+        task.transport_ = transport;
 #ifdef USE_ASCEND_HETEROGENEOUS
         task.request = const_cast<Transport::TransferRequest*>(&request);
 #else

--- a/mooncake-transfer-engine/src/transfer_metadata_dump.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata_dump.cpp
@@ -24,21 +24,21 @@ void TransferMetadata::SegmentDesc::dump() const {
     LOG(INFO) << "  protocol: " << protocol;
     LOG(INFO) << "  topology: " << topology.toString();
     LOG(INFO) << "  devices: ";
-    for (auto &device : devices) {
+    for (auto& device : devices) {
         LOG(INFO) << "    device name " << device.name << ", lid " << device.lid
                   << ", " << device.gid;
     }
     LOG(INFO) << "  buffers: ";
-    for (auto &buffer : buffers) {
+    for (auto& buffer : buffers) {
         LOG(INFO) << "    buffer type " << buffer.name << ", address "
-                  << (void *)buffer.addr << "--"
-                  << (void *)(buffer.addr + buffer.length);
+                  << (void*)buffer.addr << "--"
+                  << (void*)(buffer.addr + buffer.length);
     }
     LOG(INFO) << "  nvmeof buffers: " << nvmeof_buffers.size() << " items";
     LOG(INFO) << "  timestamp: " << timestamp;
 }
 
-void TransferMetadata::dumpMetadataContent(const std::string &segment_name,
+void TransferMetadata::dumpMetadataContent(const std::string& segment_name,
                                            uint64_t offset, uint64_t length) {
     thread_local uint64_t last_ts = 0;
     uint64_t current_ts = getCurrentTimeInNano();
@@ -54,8 +54,8 @@ void TransferMetadata::dumpMetadataContent(const std::string &segment_name,
 
     if (current_ts - last_ts > kMinDisplayThreshold || globalConfig().trace) {
         LOG(INFO) << "Failed to get segment descriptor for segment "
-                  << segment_name << " address " << (void *)offset << "--"
-                  << (void *)(offset + length);
+                  << segment_name << " address " << (void*)offset << "--"
+                  << (void*)(offset + length);
         dumpMetadataContentUnlocked();
         last_ts = current_ts;
     }
@@ -69,8 +69,8 @@ void TransferMetadata::dumpMetadataContentUnlocked() {
     LOG(INFO) << "TransferMetadata::dumpMetadataContent";
     LOG(INFO) << "-----------------------------------------------------------";
     LOG(INFO) << "=== Cached Segment Descriptors ===";
-    for (auto &entry : segment_id_to_desc_map_) {
-        auto &desc = entry.second;
+    for (auto& entry : segment_id_to_desc_map_) {
+        auto& desc = entry.second;
         if (!desc) {
             LOG(INFO) << "segment id: " << entry.first << ", ref object nil";
         } else {
@@ -83,7 +83,7 @@ void TransferMetadata::dumpMetadataContentUnlocked() {
     LOG(INFO) << "location: " << local_rpc_meta_.ip_or_host_name << ":"
               << local_rpc_meta_.rpc_port;
     LOG(INFO) << "=== Remote RPC Routes ===";
-    for (auto &entry : rpc_meta_map_) {
+    for (auto& entry : rpc_meta_map_) {
         LOG(INFO) << "segment name: " << entry.first
                   << ", location: " << entry.second.ip_or_host_name << ":"
                   << entry.second.rpc_port;

--- a/mooncake-transfer-engine/src/transfer_metadata_dump.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata_dump.cpp
@@ -47,6 +47,8 @@ void TransferMetadata::dumpMetadataContent(const std::string &segment_name,
     auto segment_locked = segment_lock_.tryLockShared();
     auto rpc_meta_locked = rpc_meta_lock_.tryLockShared();
     if (!segment_locked || !rpc_meta_locked) {
+        if (rpc_meta_locked) rpc_meta_lock_.unlockShared();
+        if (segment_locked) segment_lock_.unlockShared();
         return;
     }
 


### PR DESCRIPTION
## Summary
- Fix shared lock leak in `dumpMetadataContent()`: when `tryLockShared(segment)` succeeds but `tryLockShared(rpc_meta)` fails, the acquired lock was never released. Added proper cleanup before early return.
- Fix missing `task.transport_` assignment in `mp_submitTransfer()`: without this, `getTransferStatus()` falls through to the legacy polling path, causing transfers to appear stuck in WAITING state for transports requiring active polling (e.g., NVLink async).
- Fix undefined behavior in `submitTransferWithNotify()` and `mp_submitTransferWithNotify()`: accessing `entries[0]` without empty check. Added early return with `Status::InvalidArgument`.
- Fix pre-existing clang-format violations in `transfer_metadata_dump.cpp` (`auto &` → `auto&`, `(void *)` → `(void*)`).

## What was NOT changed
- No protocol or API changes
- No changes to `submitTransfer()` or `getTransferStatus()` logic
- No new features or abstractions

## Test plan
- [ ] CI build + existing test suite
- [ ] Manual review: lock acquire/release paths are symmetric
- [ ] Manual review: `mp_submitTransfer` now mirrors `submitTransfer` exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)