### PR TITLE
[Py] Fix batch_id leak on timeout and submit failure paths

### DIFF
--- a/mooncake-integration/transfer_engine/transfer_engine_py.cpp
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.cpp
@@ -478,6 +478,7 @@ int TransferEnginePy::transferSync(const char* target_hostname,
                       TransferMetadata::NotifyDesc{notify->name, notify->msg})
                 : engine_->submitTransfer(batch_id, {entry});
         if (!s.ok()) {
+            engine_->freeBatchID(batch_id);
             Status segment_status = engine_->CheckSegmentStatus(handle);
             if (!segment_status.ok()) {
                 LOG(WARNING)
@@ -491,8 +492,8 @@ int TransferEnginePy::transferSync(const char* target_hostname,
             return -1;
         }
 
-        TransferStatus status;
         bool completed = false;
+        TransferStatus status;
         while (!completed) {
             Status s = engine_->getTransferStatus(batch_id, 0, status);
             LOG_ASSERT(s.ok());
@@ -504,8 +505,10 @@ int TransferEnginePy::transferSync(const char* target_hostname,
                 completed = true;
             } else if (status.s == TransferStatusEnum::TIMEOUT) {
                 LOG(INFO) << "Sync data transfer timeout";
+                engine_->freeBatchID(batch_id);
                 completed = true;
             }
+            if (completed) break;
             auto current_ts = getCurrentTimeInNano();
             const int64_t timeout =
                 transfer_timeout_nsec_ + length;  // 1GiB per second
@@ -514,6 +517,7 @@ int TransferEnginePy::transferSync(const char* target_hostname,
                           << current_ts - start_ts << "ns, local buffer "
                           << (void*)buffer << " remote buffer "
                           << (void*)peer_buffer_address << " length " << length;
+                engine_->freeBatchID(batch_id);
                 return -1;
             }
         }
@@ -590,9 +594,8 @@ int TransferEnginePy::batchTransferSync(
             return -1;
         }
 
-        TransferStatus status;
         bool completed = false;
-        bool already_freed = false;
+        TransferStatus status;
         while (!completed) {
             Status s = engine_->getBatchTransferStatus(batch_id, status);
             LOG_ASSERT(s.ok());
@@ -601,12 +604,13 @@ int TransferEnginePy::batchTransferSync(
                 return 0;
             } else if (status.s == TransferStatusEnum::FAILED) {
                 engine_->freeBatchID(batch_id);
-                already_freed = true;
                 completed = true;
             } else if (status.s == TransferStatusEnum::TIMEOUT) {
                 LOG(INFO) << "Sync data transfer timeout";
+                engine_->freeBatchID(batch_id);
                 completed = true;
             }
+            if (completed) break;
             auto current_ts = getCurrentTimeInNano();
             const int64_t timeout =
                 transfer_timeout_nsec_ + total_length;  // 1GiB per second
@@ -616,9 +620,7 @@ int TransferEnginePy::batchTransferSync(
                 // TODO: as @doujiang24 mentioned, early free(while there are
                 // still waiting tasks) the batch_id may fail and cause memory
                 // leak(a known issue).
-                if (!already_freed) {
-                    engine_->freeBatchID(batch_id);
-                }
+                engine_->freeBatchID(batch_id);
                 return -1;
             }
         }


### PR DESCRIPTION
## Problem

`transferSync()` and `batchTransferSync()` leak `batch_id` on several exit paths:

1. **`submitTransfer` failure** (`transferSync`) — `allocateBatchID` succeeded but `freeBatchID` is never called before the error return.
2. **TIMEOUT status** (both functions) — the polling loop sets `completed = true` without freeing.
3. **Hard timeout** (`transferSync`) — `return -1` without freeing.

## Fix

Add `freeBatchID(batch_id)` on each leaking path, and insert `if (completed) break;` after the status checks so that a status-based exit skips the hard-timeout block (which would otherwise double-free or miss the free).

In `batchTransferSync`, the `already_freed` flag is removed — each exit path now calls `freeBatchID` immediately before `return` or `break`, making double-free impossible by construction.

## What is NOT changed

- Success path and normal polling loop
- Outer retry loop structure
- No new error-handling patterns introduced

## Test plan

- [ ] CI build + existing test suite
- [ ] Code review: verify no double-free on any path (each `freeBatchID` is followed by immediate `return` or `break`)