### PR TITLE
[TENT] Validate minimum request size before XferDataDesc cast

### DIFF
--- a/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
@@ -243,6 +243,10 @@ void ControlService::onBootstrapRdma(const std::string_view& request,
 
 void ControlService::onSendData(const std::string_view& request,
                                 std::string& response) {
+    if (request.size() < sizeof(XferDataDesc)) {
+        response = "SendData failed: request too short";
+        return;
+    }
     XferDataDesc* desc = (XferDataDesc*)request.data();
     auto local_desc = manager_->getLocal().get();
     auto peer_mem_addr = le64toh(desc->peer_mem_addr);
@@ -263,6 +267,10 @@ void ControlService::onSendData(const std::string_view& request,
 
 void ControlService::onRecvData(const std::string_view& request,
                                 std::string& response) {
+    if (request.size() < sizeof(XferDataDesc)) {
+        response = "RecvData failed: request too short";
+        return;
+    }
     XferDataDesc* desc = (XferDataDesc*)request.data();
     auto local_desc = manager_->getLocal().get();
     auto peer_mem_addr = le64toh(desc->peer_mem_addr);


### PR DESCRIPTION
## Summary
- Add minimum request size check in `onSendData()` and `onRecvData()` before casting `request.data()` to `XferDataDesc*`. Without this, a short or empty RPC request causes out-of-bounds read on the `peer_mem_addr` and `length` fields.
- The existing size check in `onSendData` (`sizeof(XferDataDesc) + length`) validates the payload, but it happens AFTER the cast and field dereferences — so the header fields are already read from potentially invalid memory before the check.

## What was NOT changed
- No changes to `ControlClient` (the sender side already constructs correctly sized requests)
- No changes to the `onRecvData` kMaxTransferSize check (it remains as a second layer of defense)
- No protocol format changes

## Test plan
- [ ] CI build + existing test suite
- [ ] Code review: check is placed before any field dereference

🤖 Generated with [Claude Code](https://claude.com/claude-code)