### PR TITLE
[PG] Fix data race: make running_ atomic

### DIFF
--- a/mooncake-pg/include/mooncake_worker.cuh
+++ b/mooncake-pg/include/mooncake_worker.cuh
@@ -167,7 +167,7 @@ class MooncakeWorker {
     static constexpr size_t kPingTimeoutMicroseconds_ = 100;
     static constexpr size_t kDrainTasksTimeoutMs = 5000;  // 5s
 
-    bool running_ = false;
+    std::atomic<bool> running_{false};
     std::atomic<bool> started_{false};
     int cuda_device_index_;
 


### PR DESCRIPTION
## Summary
- Change `MooncakeWorker::running_` from `bool` to `std::atomic<bool>`. The field is written by the destructor thread (`running_ = false`) and read by the worker thread loop (`while (running_)`), which is a data race (undefined behavior under C++ memory model).
- `started_` (line 171) is already `std::atomic<bool>`, confirming this is the intended pattern for cross-thread flags in this class. `<atomic>` is already included.

## What was NOT changed
- No changes to worker thread logic or lifecycle
- No changes to `started_` or other atomic members
- No memory order relaxation (uses default seq_cst)

## Test plan
- [ ] CI build (including MUSA/CUDA paths)
- [ ] Code review: all `running_` usage sites are compatible with `std::atomic<bool>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)