### PR TITLE
[PG] Build the MUSA PG extension through torchada

### DIFF
--- a/mooncake-pg/include/mooncake_backend.h
+++ b/mooncake-pg/include/mooncake_backend.h
@@ -14,37 +14,9 @@
 #include <torch/csrc/distributed/c10d/ProcessGroup.hpp>
 #include <transfer_engine.h>
 
-#ifdef MOONCAKE_EP_USE_MUSA
-#include <ATen/musa/MUSAContext.h>
-#else
 #include <ATen/cuda/CUDAContext.h>
-#endif
 
 namespace mooncake {
-
-#ifdef MOONCAKE_EP_USE_MUSA
-static inline auto getCurrentGPUStream(int device_index = -1) {
-    return at::musa::getCurrentMUSAStream(device_index);
-}
-static inline auto getGPUStreamFromPool(bool non_blocking = false,
-                                        int device_index = -1) {
-    return at::musa::getStreamFromPool(non_blocking, device_index);
-}
-static inline int currentGPUDevice() { return at::musa::current_device(); }
-static inline constexpr auto kGPUDevice = c10::DeviceType::PrivateUse1;
-static inline constexpr auto kGPUDeviceType = at::musa::kMUSA;
-#else
-static inline auto getCurrentGPUStream(int device_index = -1) {
-    return at::cuda::getCurrentCUDAStream(device_index);
-}
-static inline auto getGPUStreamFromPool(bool non_blocking = false,
-                                        int device_index = -1) {
-    return at::cuda::getStreamFromPool(non_blocking, device_index);
-}
-static inline int currentGPUDevice() { return at::cuda::current_device(); }
-static inline constexpr auto kGPUDevice = torch::kCUDA;
-static inline constexpr auto kGPUDeviceType = c10::DeviceType::CUDA;
-#endif
 
 // Forward declaration – MooncakeP2PShim holds a non-owning pointer to
 // MooncakeBackend, which is defined below.

--- a/mooncake-pg/include/mooncake_worker.cuh
+++ b/mooncake-pg/include/mooncake_worker.cuh
@@ -2,12 +2,8 @@
 #define MOONCAKE_WORKER_CUH
 
 #if !defined(__MUSA__)
-#ifdef MOONCAKE_EP_USE_MUSA
-#include <ATen/musa/MUSAContext.h>
-#else
-#include <ATen/cuda/CUDAContext.h>
-#endif
 #include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
 #include <c10/util/intrusive_ptr.h>
 #include <torch/csrc/distributed/c10d/Types.hpp>
 #include <torch/csrc/distributed/c10d/Work.hpp>
@@ -28,30 +24,7 @@
 #include <unordered_map>
 #include <vector>
 
-#ifdef MOONCAKE_EP_USE_MUSA
-#define cudaDeviceSynchronize musaDeviceSynchronize
-#define cudaError cudaError_t
-#define cudaErrorNotReady musaErrorNotReady
-#define cudaEventCreateWithFlags musaEventCreateWithFlags
-#define cudaEventDestroy musaEventDestroy
-#define cudaEventDisableTiming musaEventDisableTiming
-#define cudaEventQuery musaEventQuery
-#define cudaEventRecord musaEventRecord
-#define cudaFuncAttributes musaFuncAttributes
-#define cudaFuncGetAttributes musaFuncGetAttributes
-#define cudaHostAlloc musaHostAlloc
-#define cudaHostAllocMapped musaHostAllocMapped
-#endif
-
 namespace mooncake {
-
-#if !defined(__MUSA__)
-#ifdef MOONCAKE_EP_USE_MUSA
-using GPUStream = at::musa::MUSAStream;
-#else
-using GPUStream = at::cuda::CUDAStream;
-#endif
-#endif
 
 static constexpr size_t kBufferSize = 1u << 24;
 static constexpr size_t kMaxNumRanks = 64;
@@ -133,11 +106,11 @@ class MooncakeWorker {
         c10d::OpType opType, size_t tensorSize, int64_t broadcastRoot,
         const std::shared_ptr<TransferGroupMeta>& meta,
         const std::shared_ptr<ConnectionContext>& connection_ctx,
-        const GPUStream& issue_stream,
+        const at::cuda::CUDAStream& issue_stream,
         const std::function<void(void* dst, size_t pos, size_t realSize,
-                                 const GPUStream&)>& tensorToBuffer,
+                                 const at::cuda::CUDAStream&)>& tensorToBuffer,
         const std::function<void(void* src, size_t pos, size_t realSize,
-                                 const GPUStream&)>& bufferToTensor);
+                                 const at::cuda::CUDAStream&)>& bufferToTensor);
 
     void Start();
 

--- a/mooncake-pg/setup.py
+++ b/mooncake-pg/setup.py
@@ -1,7 +1,5 @@
 import os
 import re
-import subprocess
-import sys
 
 from setuptools import setup
 import torch
@@ -10,9 +8,11 @@ use_musa = os.getenv("MOONCAKE_EP_USE_MUSA", "").upper() in {"1", "ON", "TRUE", 
 if use_musa:
     try:
         import torchada  # noqa: F401
-    except ImportError:
-        subprocess.check_call([sys.executable, "-m", "pip", "install", "torchada"])
-        import torchada  # noqa: F401
+    except ImportError as e:
+        raise ImportError(
+            "torchada is required to build the MUSA PG extension. "
+            "Please install it first using 'pip install torchada'."
+        ) from e
 
 
 from torch.utils.cpp_extension import (  # noqa: E402

--- a/mooncake-pg/setup.py
+++ b/mooncake-pg/setup.py
@@ -1,9 +1,25 @@
 import os
 import re
+import subprocess
+import sys
 
 from setuptools import setup
 import torch
-from torch.utils.cpp_extension import BuildExtension, CUDAExtension, CUDA_HOME
+
+use_musa = os.getenv("MOONCAKE_EP_USE_MUSA", "").upper() in {"1", "ON", "TRUE", "YES"}
+if use_musa:
+    try:
+        import torchada  # noqa: F401
+    except ImportError:
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "torchada"])
+        import torchada  # noqa: F401
+
+
+from torch.utils.cpp_extension import (  # noqa: E402
+    BuildExtension,
+    CUDAExtension,
+    CUDA_HOME,
+)
 
 
 torch_version = re.match(r"\d+(?:\.\d+)*", torch.__version__).group()
@@ -13,67 +29,35 @@ module_name = "mooncake.pg" + version_suffix
 abi_flag = int(torch._C._GLIBCXX_USE_CXX11_ABI)
 current_dir = os.path.abspath(os.path.dirname(__file__))
 
-use_musa = os.getenv("MOONCAKE_EP_USE_MUSA", "").upper() in {"1", "ON", "TRUE", "YES"}
+abi_define = f"-D_GLIBCXX_USE_CXX11_ABI={abi_flag}"
+cxx_args = [abi_define, "-std=c++20", "-O3", "-g0"]
+
+cuda_libraries = ["ibverbs", "mlx5"]
+cuda_library_dirs = []
 
 if use_musa:
-    from torch_musa.utils.musa_extension import MUSAExtension
-    from torch_musa.utils.musa_extension import BuildExtension as MUSABuildExtension
-
-    setup(
-        name=module_name,
-        ext_modules=[
-            MUSAExtension(
-                name=module_name,
-                include_dirs=[
-                    os.path.join(current_dir, "include"),
-                    os.path.join(current_dir, "../mooncake-transfer-engine/include"),
-                ],
-                sources=[
-                    "src/pg_py.cpp",
-                    "src/mooncake_backend.cpp",
-                    "src/p2p_proxy.cpp",
-                    "src/mooncake_worker.mu",
-                    "src/mooncake_worker_host.cpp",
-                    "src/mooncake_worker_thread.cpp",
-                    "src/connection_poller.cpp",
-                ],
-                extra_compile_args={
-                    "cxx": [
-                        f"-D_GLIBCXX_USE_CXX11_ABI={abi_flag}",
-                        "-DUSE_MUSA",
-                        "-DMOONCAKE_EP_USE_MUSA=1",
-                        "-std=c++20",
-                        "-O3",
-                        "-g0",
-                    ],
-                    "mcc": [
-                        f"-D_GLIBCXX_USE_CXX11_ABI={abi_flag}",
-                        "-DUSE_MUSA",
-                        "-DMOONCAKE_EP_USE_MUSA=1",
-                        "-std=c++20",
-                        "--cuda-gpu-arch=mp_21",
-                        "--cuda-gpu-arch=mp_31",
-                        "-O3",
-                    ],
-                },
-                libraries=["ibverbs", "mlx5"],
-                extra_link_args=[
-                    "-Wl,-rpath,$ORIGIN",
-                    "-L" + os.path.join(current_dir, "../mooncake-wheel/mooncake"),
-                    "-Wl,--push-state,--no-as-needed",
-                    "-l:engine.so",
-                    "-Wl,--pop-state",
-                ],
-            )
-        ],
-        cmdclass={"build_ext": MUSABuildExtension},
-    )
+    musa_defines = ["-DUSE_MUSA", "-DMOONCAKE_EP_USE_MUSA=1"]
+    cxx_args += musa_defines
+    # torchada maps the "nvcc" key to "mcc".
+    device_args = [
+        abi_define,
+        *musa_defines,
+        "-std=c++20",
+        "--cuda-gpu-arch=mp_21",
+        "--cuda-gpu-arch=mp_31",
+        "-O3",
+    ]
 else:
+    device_args = [
+        abi_define,
+        "-std=c++20",
+        "-Xcompiler",
+        "-O3",
+        "-Xcompiler",
+        "-g0",
+    ]
     # Link against the CUDA driver stub library if available.
     # Same approach as mooncake-ep/setup.py.
-    cuda_libraries = ["ibverbs", "mlx5"]
-    cuda_library_dirs = []
-
     if CUDA_HOME is not None:
         cuda_stub_dir = os.path.join(CUDA_HOME, "lib64", "stubs")
         cuda_stub_lib = os.path.join(cuda_stub_dir, "libcuda.so")
@@ -81,50 +65,35 @@ else:
             cuda_libraries.insert(0, "cuda")
             cuda_library_dirs.append(cuda_stub_dir)
 
-    setup(
-        name=module_name,
-        ext_modules=[
-            CUDAExtension(
-                name=module_name,
-                include_dirs=[
-                    os.path.join(current_dir, "include"),
-                    os.path.join(current_dir, "../mooncake-transfer-engine/include"),
-                ],
-                sources=[
-                    "src/pg_py.cpp",
-                    "src/mooncake_backend.cpp",
-                    "src/p2p_proxy.cpp",
-                    "src/mooncake_worker.cu",
-                    "src/mooncake_worker_host.cpp",
-                    "src/mooncake_worker_thread.cpp",
-                    "src/connection_poller.cpp",
-                ],
-                extra_compile_args={
-                    "cxx": [
-                        f"-D_GLIBCXX_USE_CXX11_ABI={abi_flag}",
-                        "-std=c++20",
-                        "-O3",
-                        "-g0",
-                    ],
-                    "nvcc": [
-                        f"-D_GLIBCXX_USE_CXX11_ABI={abi_flag}",
-                        "-std=c++20",
-                        "-Xcompiler",
-                        "-O3",
-                        "-Xcompiler",
-                        "-g0",
-                    ],
-                },
-                libraries=cuda_libraries,
-                library_dirs=cuda_library_dirs,
-                extra_link_args=[
-                    "-Wl,-rpath,$ORIGIN",
-                    "-L" + os.path.join(current_dir, "../mooncake-wheel/mooncake"),
-                    "-Wl,--push-state,--no-as-needed",
-                    "-l:engine.so",
-                    "-Wl,--pop-state",
-                ],
-            )
-        ],
-        cmdclass={"build_ext": BuildExtension},
-    )
+setup(
+    name=module_name,
+    ext_modules=[
+        CUDAExtension(
+            name=module_name,
+            include_dirs=[
+                os.path.join(current_dir, "include"),
+                os.path.join(current_dir, "../mooncake-transfer-engine/include"),
+            ],
+            sources=[
+                "src/pg_py.cpp",
+                "src/mooncake_backend.cpp",
+                "src/p2p_proxy.cpp",
+                "src/mooncake_worker.cu",
+                "src/mooncake_worker_host.cpp",
+                "src/mooncake_worker_thread.cpp",
+                "src/connection_poller.cpp",
+            ],
+            extra_compile_args={"cxx": cxx_args, "nvcc": device_args},
+            libraries=cuda_libraries,
+            library_dirs=cuda_library_dirs,
+            extra_link_args=[
+                "-Wl,-rpath,$ORIGIN",
+                "-L" + os.path.join(current_dir, "../mooncake-wheel/mooncake"),
+                "-Wl,--push-state,--no-as-needed",
+                "-l:engine.so",
+                "-Wl,--pop-state",
+            ],
+        )
+    ],
+    cmdclass={"build_ext": BuildExtension},
+)

--- a/mooncake-pg/src/mooncake_backend.cpp
+++ b/mooncake-pg/src/mooncake_backend.cpp
@@ -1,8 +1,4 @@
-#ifdef MOONCAKE_EP_USE_MUSA
-#include <ATen/musa/MUSAContext.h>
-#else
 #include <ATen/cuda/CUDAContext.h>
-#endif
 #include <cuda_alike.h>
 #include <torch/torch.h>
 #include <torch/csrc/distributed/c10d/Backend.hpp>
@@ -259,7 +255,7 @@ MooncakeBackend::MooncakeBackend(
 
     } else {
         for (size_t i = 0; i < 2; i++) {
-            cudaError err = cudaMalloc(&send_buffer_[i], kBufferSize);
+            cudaError_t err = cudaMalloc(&send_buffer_[i], kBufferSize);
             TORCH_CHECK(!err, c10::str("Failed to allocate CUDA send buffer"));
 
             int rc = engine_->registerLocalMemory(send_buffer_[i], kBufferSize,
@@ -268,7 +264,7 @@ MooncakeBackend::MooncakeBackend(
         }
 
         for (size_t i = 0; i < 2; i++) {
-            cudaError err = cudaMalloc(&recv_buffer_[i], kBufferSize);
+            cudaError_t err = cudaMalloc(&recv_buffer_[i], kBufferSize);
             TORCH_CHECK(!err, c10::str("Failed to allocate CUDA recv buffer"));
 
             int rc = engine_->registerLocalMemory(recv_buffer_[i], kBufferSize,
@@ -297,7 +293,7 @@ MooncakeBackend::MooncakeBackend(
     }
 
     auto& dev_worker_mgr = P2PDeviceWorkerManager::getInstance();
-    int cuda_device_index = isCpu_ ? -1 : currentGPUDevice();
+    int cuda_device_index = isCpu_ ? -1 : at::cuda::current_device();
 
     if (isCpu_)
         p2p_device_worker_ = dev_worker_mgr.getCPUWorker(engine_);
@@ -389,7 +385,7 @@ MooncakeBackend::MooncakeBackend(
                         "activeRanks must be on CPU.");
         } else {
             TORCH_CHECK(
-                options_->activeRanks_.device().type() == kGPUDeviceType,
+                options_->activeRanks_.device().type() == c10::DeviceType::CUDA,
                 "activeRanks must be on GPU.");
         }
         if (max_size != size) {
@@ -399,9 +395,9 @@ MooncakeBackend::MooncakeBackend(
         }
         meta_->activeRanksTensor = options_->activeRanks_;
     } else {
-        meta_->activeRanksTensor =
-            at::ones({max_size}, torch::dtype(torch::kInt32)
-                                     .device(isCpu ? torch::kCPU : kGPUDevice));
+        meta_->activeRanksTensor = at::ones(
+            {max_size}, torch::dtype(torch::kInt32)
+                            .device(isCpu ? torch::kCPU : torch::kCUDA));
         if (max_size != size) {
             meta_->activeRanksTensor.slice(0, size, max_size).fill_(0);
         }
@@ -425,7 +421,7 @@ MooncakeBackend::MooncakeBackend(
     // Register a lightweight Backend shim so that PyTorch's P2P dispatch path
     // (batch_isend_irecv → _get_backend → getBackend) can find a registered
     // Backend for this ProcessGroup.  The shim delegates send/recv back to us.
-    auto deviceType = isCpu ? c10::DeviceType::CPU : kGPUDeviceType;
+    auto deviceType = isCpu ? c10::DeviceType::CPU : c10::DeviceType::CUDA;
     auto shim = c10::make_intrusive<MooncakeP2PShim>(this);
     setBackend(deviceType, BackendType::CUSTOM, shim);
 #ifndef MOONCAKE_EP_USE_MUSA
@@ -486,7 +482,8 @@ c10::intrusive_ptr<c10d::Work> MooncakeBackend::send(
         P2PProxy::OpStatus::kPending);
     cudaStream_t stream = nullptr;
     if (!isCpu_) {
-        auto current_stream = getCurrentGPUStream(contiguous.device().index());
+        auto current_stream =
+            at::cuda::getCurrentCUDAStream(contiguous.device().index());
         stream = current_stream.stream();
     }
 
@@ -518,7 +515,8 @@ c10::intrusive_ptr<c10d::Work> MooncakeBackend::recv(
         P2PProxy::OpStatus::kPending);
     cudaStream_t stream = nullptr;
     if (!isCpu_) {
-        auto current_stream = getCurrentGPUStream(target.device().index());
+        auto current_stream =
+            at::cuda::getCurrentCUDAStream(target.device().index());
         stream = current_stream.stream();
     }
 
@@ -553,12 +551,13 @@ c10::intrusive_ptr<c10d::Work> MooncakeBackend::broadcast(
                 memcpy((char*)tensor.data_ptr() + pos, src, realSize);
             });
     } else {
-        GPUStream stream = getCurrentGPUStream(tensor.device().index());
+        at::cuda::CUDAStream stream =
+            at::cuda::getCurrentCUDAStream(tensor.device().index());
         return worker_->putTaskCuda(
             c10d::OpType::BROADCAST, tensorSize, root, meta_, connection_ctx_,
             stream,
             [=](void* dst, size_t pos, size_t realSize,
-                const GPUStream& enq_stream) {
+                const at::cuda::CUDAStream& enq_stream) {
                 if (isRoot) {
                     cudaMemcpyAsync(dst, (char*)tensor.data_ptr() + pos,
                                     realSize, cudaMemcpyDeviceToDevice,
@@ -566,7 +565,7 @@ c10::intrusive_ptr<c10d::Work> MooncakeBackend::broadcast(
                 }
             },
             [=](void* src, size_t pos, size_t realSize,
-                const GPUStream& enq_stream) {
+                const at::cuda::CUDAStream& enq_stream) {
                 cudaMemcpyAsync((char*)tensor.data_ptr() + pos, src, realSize,
                                 cudaMemcpyDeviceToDevice, enq_stream);
             });
@@ -592,17 +591,17 @@ c10::intrusive_ptr<c10d::Work> MooncakeBackend::allreduce(
                                 opts.reduceOp, meta_->activeRanks);
             });
     } else {
-        auto stream = getCurrentGPUStream(tensor.device().index());
+        auto stream = at::cuda::getCurrentCUDAStream(tensor.device().index());
         return worker_->putTaskCuda(
             c10d::OpType::ALLREDUCE, tensorSize, 0, meta_, connection_ctx_,
             stream,
             [=](void* dst, size_t pos, size_t realSize,
-                const GPUStream& enq_stream) {
+                const at::cuda::CUDAStream& enq_stream) {
                 cudaMemcpyAsync(dst, (char*)tensor.data_ptr() + pos, realSize,
                                 cudaMemcpyDeviceToDevice, enq_stream);
             },
             [=, this](void* src, size_t pos, size_t realSize,
-                      const GPUStream& enq_stream) {
+                      const at::cuda::CUDAStream& enq_stream) {
                 cudaMemsetAsync((char*)tensor.data_ptr() + pos, 0, realSize,
                                 enq_stream);
                 launchReduceKernel(tensor, pos, realSize, src, meta_->size,
@@ -633,17 +632,18 @@ c10::intrusive_ptr<c10d::Work> MooncakeBackend::allgather(
                 }
             });
     } else {
-        auto stream = getCurrentGPUStream(inputTensor.device().index());
+        auto stream =
+            at::cuda::getCurrentCUDAStream(inputTensor.device().index());
         return worker_->putTaskCuda(
             c10d::OpType::ALLGATHER, tensorSize, 0, meta_, connection_ctx_,
             stream,
             [=](void* dst, size_t pos, size_t realSize,
-                const GPUStream& enq_stream) {
+                const at::cuda::CUDAStream& enq_stream) {
                 cudaMemcpyAsync(dst, (char*)inputTensor.data_ptr() + pos,
                                 realSize, cudaMemcpyDeviceToDevice, enq_stream);
             },
             [=](void* src, size_t pos, size_t realSize,
-                const GPUStream& enq_stream) {
+                const at::cuda::CUDAStream& enq_stream) {
                 for (const auto j : c10::irange(outputTensors_.size())) {
                     cudaMemcpyAsync((char*)outputTensors_[j].data_ptr() + pos,
                                     (char*)src + j * realSize, realSize,
@@ -673,17 +673,18 @@ c10::intrusive_ptr<c10d::Work> MooncakeBackend::_allgather_base(
                 }
             });
     } else {
-        auto stream = getCurrentGPUStream(inputBuffer.device().index());
+        auto stream =
+            at::cuda::getCurrentCUDAStream(inputBuffer.device().index());
         return worker_->putTaskCuda(
             c10d::OpType::_ALLGATHER_BASE, tensorSize, 0, meta_,
             connection_ctx_, stream,
             [=](void* dst, size_t pos, size_t realSize,
-                const GPUStream& enq_stream) {
+                const at::cuda::CUDAStream& enq_stream) {
                 cudaMemcpyAsync(dst, (char*)inputBuffer.data_ptr() + pos,
                                 realSize, cudaMemcpyDeviceToDevice, enq_stream);
             },
             [=, this](void* src, size_t pos, size_t realSize,
-                      const GPUStream& enq_stream) {
+                      const at::cuda::CUDAStream& enq_stream) {
                 for (int j = 0; j < meta_->size; ++j) {
                     if (!meta_->activeRanks[j]) continue;
                     cudaMemcpyAsync(
@@ -718,12 +719,13 @@ c10::intrusive_ptr<c10d::Work> MooncakeBackend::_reduce_scatter_base(
                                 opts.reduceOp, meta_->activeRanks);
             });
     } else {
-        auto stream = getCurrentGPUStream(inputBuffer.device().index());
+        auto stream =
+            at::cuda::getCurrentCUDAStream(inputBuffer.device().index());
         return worker_->putTaskCuda(
             c10d::OpType::_REDUCE_SCATTER_BASE, tensorSize, 0, meta_,
             connection_ctx_, stream,
             [=, this](void* dst, size_t pos, size_t realSize,
-                      const GPUStream& enq_stream) {
+                      const at::cuda::CUDAStream& enq_stream) {
                 for (int j = 0; j < meta_->size; ++j) {
                     if (!meta_->activeRanks[j]) continue;
                     cudaMemcpyAsync(
@@ -733,7 +735,7 @@ c10::intrusive_ptr<c10d::Work> MooncakeBackend::_reduce_scatter_base(
                 }
             },
             [=, this](void* src, size_t pos, size_t realSize,
-                      const GPUStream& enq_stream) {
+                      const at::cuda::CUDAStream& enq_stream) {
                 cudaMemsetAsync((char*)outputBuffer.data_ptr() + pos, 0,
                                 realSize, enq_stream);
                 launchReduceKernel(outputBuffer, pos, realSize, src,
@@ -764,12 +766,13 @@ c10::intrusive_ptr<c10d::Work> MooncakeBackend::alltoall(
                 }
             });
     } else {
-        auto stream = getCurrentGPUStream(inputTensors[0].device().index());
+        auto stream =
+            at::cuda::getCurrentCUDAStream(inputTensors[0].device().index());
         return worker_->putTaskCuda(
             c10d::OpType::ALLTOALL, tensorSize, 0, meta_, connection_ctx_,
             stream,
             [=](void* dst, size_t pos, size_t realSize,
-                const GPUStream& enq_stream) {
+                const at::cuda::CUDAStream& enq_stream) {
                 for (const auto j : c10::irange(inputTensors.size())) {
                     cudaMemcpyAsync((char*)dst + j * realSize,
                                     (char*)inputTensors[j].data_ptr() + pos,
@@ -778,7 +781,7 @@ c10::intrusive_ptr<c10d::Work> MooncakeBackend::alltoall(
                 }
             },
             [=](void* src, size_t pos, size_t realSize,
-                const GPUStream& enq_stream) {
+                const at::cuda::CUDAStream& enq_stream) {
                 for (const auto j : c10::irange(outputTensors.size())) {
                     cudaMemcpyAsync((char*)outputTensors[j].data_ptr() + pos,
                                     (char*)src + j * realSize, realSize,
@@ -797,13 +800,13 @@ c10::intrusive_ptr<c10d::Work> MooncakeBackend::barrier(
             connection_ctx_, [=](void*, size_t, size_t) {},
             [=](void*, size_t, size_t) {});
     } else {
-        auto device_index = currentGPUDevice();
-        auto stream = getCurrentGPUStream(device_index);
+        auto device_index = at::cuda::current_device();
+        auto stream = at::cuda::getCurrentCUDAStream(device_index);
         return worker_->putTaskCuda(
             c10d::OpType::BARRIER, kBarrierDummyTensorSize, 0, meta_,
             connection_ctx_, stream,
-            [=](void*, size_t, size_t, const GPUStream&) {},
-            [=](void*, size_t, size_t, const GPUStream&) {});
+            [=](void*, size_t, size_t, const at::cuda::CUDAStream&) {},
+            [=](void*, size_t, size_t, const at::cuda::CUDAStream&) {});
     }
 }
 
@@ -829,17 +832,17 @@ c10::intrusive_ptr<c10d::Work> MooncakeBackend::reduce(
                 }
             });
     } else {
-        auto stream = getCurrentGPUStream(tensor.device().index());
+        auto stream = at::cuda::getCurrentCUDAStream(tensor.device().index());
         return worker_->putTaskCuda(
             c10d::OpType::REDUCE, tensorSize, root, meta_, connection_ctx_,
             stream,
             [=](void* dst, size_t pos, size_t realSize,
-                const GPUStream& enq_stream) {
+                const at::cuda::CUDAStream& enq_stream) {
                 cudaMemcpyAsync(dst, (char*)tensor.data_ptr() + pos, realSize,
                                 cudaMemcpyDeviceToDevice, enq_stream);
             },
             [=, this](void* src, size_t pos, size_t realSize,
-                      const GPUStream& enq_stream) {
+                      const at::cuda::CUDAStream& enq_stream) {
                 if (isRoot) {
                     cudaMemsetAsync((char*)tensor.data_ptr() + pos, 0, realSize,
                                     enq_stream);
@@ -878,17 +881,18 @@ c10::intrusive_ptr<c10d::Work> MooncakeBackend::gather(
                 }
             });
     } else {
-        auto stream = getCurrentGPUStream(inputTensor.device().index());
+        auto stream =
+            at::cuda::getCurrentCUDAStream(inputTensor.device().index());
         return worker_->putTaskCuda(
             c10d::OpType::GATHER, tensorSize, root, meta_, connection_ctx_,
             stream,
             [=](void* dst, size_t pos, size_t realSize,
-                const GPUStream& enq_stream) {
+                const at::cuda::CUDAStream& enq_stream) {
                 cudaMemcpyAsync(dst, (char*)inputTensor.data_ptr() + pos,
                                 realSize, cudaMemcpyDeviceToDevice, enq_stream);
             },
             [=](void* src, size_t pos, size_t realSize,
-                const GPUStream& enq_stream) {
+                const at::cuda::CUDAStream& enq_stream) {
                 if (isRoot) {
                     auto outputTensors_ = outputTensors.back();
                     for (const auto j : c10::irange(outputTensors_.size())) {
@@ -931,12 +935,13 @@ c10::intrusive_ptr<c10d::Work> MooncakeBackend::scatter(
                 memcpy((char*)outputTensor.data_ptr() + pos, src, realSize);
             });
     } else {
-        auto stream = getCurrentGPUStream(outputTensor.device().index());
+        auto stream =
+            at::cuda::getCurrentCUDAStream(outputTensor.device().index());
         return worker_->putTaskCuda(
             c10d::OpType::SCATTER, tensorSize, root, meta_, connection_ctx_,
             stream,
             [=](void* dst, size_t pos, size_t realSize,
-                const GPUStream& enq_stream) {
+                const at::cuda::CUDAStream& enq_stream) {
                 if (isRoot) {
                     auto inputTensors_ = inputTensors.back();
                     for (const auto j : c10::irange(inputTensors_.size())) {
@@ -948,7 +953,7 @@ c10::intrusive_ptr<c10d::Work> MooncakeBackend::scatter(
                 }
             },
             [=](void* src, size_t pos, size_t realSize,
-                const GPUStream& enq_stream) {
+                const at::cuda::CUDAStream& enq_stream) {
                 cudaMemcpyAsync((char*)outputTensor.data_ptr() + pos, src,
                                 realSize, cudaMemcpyDeviceToDevice, enq_stream);
             });
@@ -1021,7 +1026,7 @@ void MooncakeBackend::syncActiveRanksTensor() {
     if (!meta_->activeRanksTensor.defined() ||
         meta_->activeRanksTensor.size(0) != meta_->size) {
         meta_->activeRanksTensor =
-            cpu_tensor.to(isCpu_ ? torch::kCPU : kGPUDevice);
+            cpu_tensor.to(isCpu_ ? torch::kCPU : torch::kCUDA);
         return;
     }
 
@@ -1102,14 +1107,15 @@ int MooncakeBackend::getNumSyncedRanks() {
     std::vector<at::Tensor> tensors;
     tensors.emplace_back(torch::tensor(
         connection_ctx_->getTotalConnectedPeers(),
-        torch::dtype(torch::kInt).device(isCpu_ ? torch::kCPU : kGPUDevice)));
+        torch::dtype(torch::kInt).device(isCpu_ ? torch::kCPU : torch::kCUDA)));
     c10d::AllreduceOptions opts{
         .reduceOp = c10d::ReduceOp::MIN,
     };
     auto work = allreduce(tensors, opts);
     work->wait();
     if (!isCpu_) {
-        auto stream = getCurrentGPUStream(tensors[0].device().index());
+        auto stream =
+            at::cuda::getCurrentCUDAStream(tensors[0].device().index());
         cudaStreamSynchronize(stream);
     }
     return tensors[0].cpu().item<int>();
@@ -1172,14 +1178,15 @@ std::vector<bool> MooncakeBackend::getPeerState(const std::vector<int>& ranks) {
         std::vector<at::Tensor> tensors;
         tensors.emplace_back(torch::tensor(
             input, torch::dtype(torch::kInt)
-                       .device(isCpu_ ? torch::kCPU : kGPUDevice)));
+                       .device(isCpu_ ? torch::kCPU : torch::kCUDA)));
         c10d::AllreduceOptions opts{
             .reduceOp = c10d::ReduceOp::MIN,
         };
         auto work = allreduce(tensors, opts);
         work->wait();
         if (!isCpu_) {
-            auto stream = getCurrentGPUStream(tensors[0].device().index());
+            auto stream =
+                at::cuda::getCurrentCUDAStream(tensors[0].device().index());
             cudaStreamSynchronize(stream);
         }
         bool activeRanksChanged = false;

--- a/mooncake-pg/src/mooncake_worker.mu
+++ b/mooncake-pg/src/mooncake_worker.mu
@@ -1,1 +1,0 @@
-mooncake_worker.cu

--- a/mooncake-pg/src/mooncake_worker_host.cpp
+++ b/mooncake-pg/src/mooncake_worker_host.cpp
@@ -8,21 +8,9 @@
 #include <thread>
 #include <mooncake_worker.cuh>
 #include <mooncake_worker_kernels.cuh>
-#ifdef MOONCAKE_EP_USE_MUSA
-#include <ATen/musa/MUSAGraphsUtils.muh>
-#else
 #include <ATen/cuda/CUDAGraphsUtils.cuh>
-#endif
 
 #include "pg_utils.h"
-
-#ifdef MOONCAKE_EP_USE_MUSA
-namespace gpu_capture = at::musa;
-namespace gpu_c10 = c10::musa;
-#else
-namespace gpu_capture = at::cuda;
-namespace gpu_c10 = c10::cuda;
-#endif
 
 namespace mooncake {
 
@@ -105,8 +93,8 @@ class MooncakeWorkCuda : public ::c10d::Work {
         // waitUntilTasksSubmitted is totally unnecessary, but we keep it for
         // uniform behavior to avoid invasive changes to TE/TENT.
         bool submitted = true;
-        if (gpu_capture::currentStreamCaptureStatus() ==
-            gpu_c10::CaptureStatus::None) {
+        if (at::cuda::currentStreamCaptureStatus() ==
+            c10::cuda::CaptureStatus::None) {
             // Normal execution: block until tasks are submitted.
             submitted =
                 worker_->waitUntilTasksSubmitted(submitted_tasks_, timeout);
@@ -134,7 +122,7 @@ class MooncakeWorkCuda : public ::c10d::Work {
         //    until the operation is completed. In the case of CUDA collectives,
         //    will block the currently active CUDA stream until the operation
         //    is completed (but will not block the CPU)."
-        auto current_stream = getCurrentGPUStream();
+        auto current_stream = at::cuda::getCurrentCUDAStream();
         event_->block(current_stream);
         return true;
     }
@@ -153,12 +141,12 @@ class MooncakeBarrierWorkCuda : public MooncakeWorkCuda {
     bool wait(std::chrono::milliseconds timeout) override {
         // Skip host-side synchronization during CUDA graph capture.
         // cudaEventSynchronize is not permitted while a stream is capturing.
-        if (gpu_capture::currentStreamCaptureStatus() !=
-            gpu_c10::CaptureStatus::None) {
+        if (at::cuda::currentStreamCaptureStatus() !=
+            c10::cuda::CaptureStatus::None) {
             // We still need stream-level synchronization so that subsequent
             // operations on the capture stream are ordered after the barrier
             // task on the enqueue stream.
-            auto current_stream = getCurrentGPUStream();
+            auto current_stream = at::cuda::getCurrentCUDAStream();
             event_->block(current_stream);
             return true;
         }
@@ -309,7 +297,7 @@ void launchReduceCpu(at::Tensor dst, size_t pos, size_t realSize, void* src,
 MooncakeWorker::MooncakeWorker(int cuda_device_index)
     : cuda_device_index_(cuda_device_index) {
     int deviceCount = 0;
-    cudaError err = cudaGetDeviceCount(&deviceCount);
+    cudaError_t err = cudaGetDeviceCount(&deviceCount);
     if (!err && deviceCount > 0) {
         cudaHostAlloc(&tasks_, kNumTasks_ * sizeof(Task), cudaHostAllocMapped);
         cudaHostGetDevicePointer(&tasks_device_, tasks_, 0);
@@ -411,19 +399,19 @@ c10::intrusive_ptr<c10d::Work> MooncakeWorker::putTaskCuda(
     c10d::OpType opType, size_t tensorSize, int64_t broadcastRoot,
     const std::shared_ptr<TransferGroupMeta>& meta,
     const std::shared_ptr<ConnectionContext>& connection_ctx,
-    const GPUStream& issue_stream,
+    const at::cuda::CUDAStream& issue_stream,
     const std::function<void(void* dst, size_t pos, size_t realSize,
-                             const GPUStream&)>& tensorToBuffer,
+                             const at::cuda::CUDAStream&)>& tensorToBuffer,
     const std::function<void(void* src, size_t pos, size_t realSize,
-                             const GPUStream&)>& bufferToTensor) {
+                             const at::cuda::CUDAStream&)>& bufferToTensor) {
     connection_ctx->waitUntilNewRanksConnected();
 
     size_t chunkSize = ((kBufferSize - 1) / meta->size) & ~(size_t)7;
 
-    GPUStream enq_stream =
-        getGPUStreamFromPool(false, issue_stream.device_index());
+    at::cuda::CUDAStream enq_stream =
+        at::cuda::getStreamFromPool(false, issue_stream.device_index());
 
-    auto event_start = std::make_shared<torch::Event>(kGPUDevice);
+    auto event_start = std::make_shared<torch::Event>(torch::kCUDA);
     event_start->record(issue_stream);
     event_start->block(enq_stream);
 
@@ -455,7 +443,7 @@ c10::intrusive_ptr<c10d::Work> MooncakeWorker::putTaskCuda(
         ++meta->taskCount;
     }
 
-    auto event_end = std::make_shared<torch::Event>(kGPUDevice);
+    auto event_end = std::make_shared<torch::Event>(torch::kCUDA);
     event_end->record(enq_stream);
 
     if (opType == c10d::OpType::BARRIER) {

--- a/mooncake-pg/src/p2p_proxy.cpp
+++ b/mooncake-pg/src/p2p_proxy.cpp
@@ -8,7 +8,6 @@
 #include <cstring>
 #include <limits>
 #include <thread>
-#include "cuda_alike.h"
 #include "memory_location.h"
 #include "pg_utils.h"
 


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

PR #2329 added MUSA build support for the PG extension by duplicating the
`CUDAExtension` `setup()` into a separate `MUSAExtension` branch and guarding the
C++ sources with `#ifdef MOONCAKE_EP_USE_MUSA` for every `at::cuda` / `at::musa`
difference. This PR uses [torchada](https://github.com/MooreThreads/torchada),
Moore Threads' CUDA→MUSA compatibility layer, so NVIDIA and MUSA build from a
single code path.

### Changes

- **`setup.py`** — one `CUDAExtension` / `BuildExtension`. On MUSA, importing
  `torchada` before `torch.utils.cpp_extension` redirects `CUDAExtension` to
  `MUSAExtension`, maps the `nvcc` compile-args key to `mcc`, and resolves
  `CUDA_HOME` → `MUSA_HOME`. The import is gated on `MOONCAKE_EP_USE_MUSA` (set
  by `BuildPgExt.cmake`) and `pip install`s torchada if it is missing. The
  hand-rolled `MUSAExtension` branch is gone.
- **C++ sources** — now call the plain CUDA torch/ATen API
  (`at::cuda::getCurrentCUDAStream`, `torch::kCUDA`, `c10::DeviceType::CUDA`, …);
  torchada ports them to `at::musa::*` / `kPrivateUse1` at build time. This
  removes the mechanical `#ifdef MOONCAKE_EP_USE_MUSA` include/type/API arms and
  the `getCurrentGPUStream` / `GPUStream` / `kGPUDevice` / `gpu_capture`
  abstraction that #2329 added.
- **Kept on purpose**:
  - `cuda_alike.h` for the multi-vendor runtime API + `GPU_PREFIX` (it still
    serves the other vendors and the CMake engine build — untouched).
  - The three genuinely MUSA-specific guards: no NVLink fabric memory, no
    `setDefaultBackend`, `"musa"` device registration.
  - The `#if !defined(__MUSA__)` header split — mcc's device frontend
    (clang-14) segfaults on the full torch/ATen + c10d headers, so the kernel
    translation unit must not pull them in.
- Removed the now-unused `mooncake_worker.mu` symlink (torchada recognizes
  `.cu`).

### Test plan

Built and tested on **8× MTT S5000** (torch_musa 2.9.0, mcc 5.1.0, torchada
0.1.58):

- `MOONCAKE_EP_USE_MUSA=1 python setup.py build_ext` → PG extension compiles
  with mcc and loads cleanly (`from mooncake import pg`).
- `python mooncake-pg/tests/test_pg_collectives.py`:
  - **MUSA backend (world_size=2): 14/14 pass** — `Ran 14 tests … OK`
  - **CPU backend (world_size=4): 14/14 pass**
  - Coverage: allreduce (sum/min/max/product), broadcast, all_gather ×2,
    reduce_scatter, barrier, gather, scatter, reduce, async allreduce.
  - Run with the NIC pinned (`MOONCAKE_PGTEST_DEVICE_FILTERS=mlx5_2`,
    `MC_IB_HCA=mlx5_2`).

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [x] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
