### PR TITLE
[TE] Handle TIMEOUT in getBatchTransferStatus

### DIFF
--- a/mooncake-transfer-engine/src/multi_transport.cpp
+++ b/mooncake-transfer-engine/src/multi_transport.cpp
@@ -287,8 +287,8 @@ Status MultiTransport::getBatchTransferStatus(BatchID batch_id,
         if (task_status.s == Transport::TransferStatusEnum::COMPLETED) {
             status.transferred_bytes += task_status.transferred_bytes;
             success_count++;
-        } else if (task_status.s == Transport::TransferStatusEnum::FAILED ||
-                   task_status.s == Transport::TransferStatusEnum::TIMEOUT) {
+        } else if (task_status.s != Transport::TransferStatusEnum::WAITING &&
+                   task_status.s != Transport::TransferStatusEnum::PENDING) {
             status.s = task_status.s;
             return Status::OK();
         }

--- a/mooncake-transfer-engine/src/multi_transport.cpp
+++ b/mooncake-transfer-engine/src/multi_transport.cpp
@@ -287,8 +287,9 @@ Status MultiTransport::getBatchTransferStatus(BatchID batch_id,
         if (task_status.s == Transport::TransferStatusEnum::COMPLETED) {
             status.transferred_bytes += task_status.transferred_bytes;
             success_count++;
-        } else if (task_status.s == Transport::TransferStatusEnum::FAILED) {
-            status.s = Transport::TransferStatusEnum::FAILED;
+        } else if (task_status.s == Transport::TransferStatusEnum::FAILED ||
+                   task_status.s == Transport::TransferStatusEnum::TIMEOUT) {
+            status.s = task_status.s;
             return Status::OK();
         }
     }


### PR DESCRIPTION
## Summary
- `getBatchTransferStatus()` only checked for `COMPLETED` and `FAILED`. A task with `TIMEOUT` status fell through to neither bucket, so `success_count < task_count` and the batch was reported as `WAITING` forever.
- Fix: treat `TIMEOUT` as a terminal status (same as `FAILED`) and return early, propagating the actual status to callers.

## What was NOT changed
- `getTransferStatus()` (per-task) is unchanged
- No new status values introduced
- Callers already handle TIMEOUT (e.g., Python binding polling loop)

## Test plan
- [ ] CI build + existing test suite
- [ ] Code review: TIMEOUT is now terminal, batch polling terminates

🤖 Generated with [Claude Code](https://claude.com/claude-code)