### PR TITLE
[TE] Guard stoull in EFA getMaxPteEntries against invalid input

### DIFF
--- a/mooncake-transfer-engine/src/transport/efa_transport/efa_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/efa_transport/efa_transport.cpp
@@ -83,8 +83,8 @@ static size_t getMaxPteEntries() {
         if (env) {
             try {
                 if (env[0] == '-') {
-                    LOG(ERROR) << "Invalid MC_EFA_MAX_PTE_ENTRIES value: "
-                               << env;
+                    LOG(ERROR)
+                        << "Invalid MC_EFA_MAX_PTE_ENTRIES value: " << env;
                 } else {
                     size_t val = std::stoull(env);
                     if (val > 0) {

--- a/mooncake-transfer-engine/src/transport/efa_transport/efa_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/efa_transport/efa_transport.cpp
@@ -81,10 +81,14 @@ static size_t getMaxPteEntries() {
     static size_t cached = []() {
         const char* env = std::getenv("MC_EFA_MAX_PTE_ENTRIES");
         if (env) {
-            size_t val = std::stoull(env);
-            if (val > 0) {
-                LOG(INFO) << "MC_EFA_MAX_PTE_ENTRIES override: " << val;
-                return val;
+            try {
+                size_t val = std::stoull(env);
+                if (val > 0) {
+                    LOG(INFO) << "MC_EFA_MAX_PTE_ENTRIES override: " << val;
+                    return val;
+                }
+            } catch (const std::exception& e) {
+                LOG(ERROR) << "Invalid MC_EFA_MAX_PTE_ENTRIES value: " << env;
             }
         }
         return kDefaultMaxPteEntries;

--- a/mooncake-transfer-engine/src/transport/efa_transport/efa_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/efa_transport/efa_transport.cpp
@@ -77,27 +77,7 @@ static size_t detectBufferPageSize(void* addr) {
     return fallback;
 }
 
-static constexpr size_t kMaxAllowedPteEntries = 100ULL * 1024 * 1024;  // 100M
-
-static size_t getMaxPteEntries() {
-    static size_t cached = []() {
-        const char* env = std::getenv("MC_EFA_MAX_PTE_ENTRIES");
-        if (env) {
-            try {
-                size_t val = std::stoull(env);
-                if (val > 0 && val <= kMaxAllowedPteEntries) {
-                    LOG(INFO) << "MC_EFA_MAX_PTE_ENTRIES override: " << val;
-                    return val;
-                }
-                LOG(ERROR) << "MC_EFA_MAX_PTE_ENTRIES out of range: " << env;
-            } catch (const std::exception& e) {
-                LOG(ERROR) << "Invalid MC_EFA_MAX_PTE_ENTRIES value: " << env;
-            }
-        }
-        return kDefaultMaxPteEntries;
-    }();
-    return cached;
-}
+static size_t getMaxPteEntries() { return kDefaultMaxPteEntries; }
 
 EfaTransport::EfaTransport() {
     LOG(INFO) << "[EFA] AWS Elastic Fabric Adapter transport initialized";

--- a/mooncake-transfer-engine/src/transport/efa_transport/efa_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/efa_transport/efa_transport.cpp
@@ -45,7 +45,6 @@ namespace mooncake {
 // roughly 24 million PTEs per NIC, but we use 22M as a conservative default.
 // With 4KB pages: 22M × 4KB ≈ 88GB per NIC.
 // With 2MB hugepages: 22M × 2MB ≈ 44TB per NIC (effectively unlimited).
-// Override via MC_EFA_MAX_PTE_ENTRIES environment variable.
 static constexpr size_t kDefaultMaxPteEntries = 22ULL * 1024 * 1024;  // 22M
 
 // Detect the kernel page size backing the memory at `addr` by reading

--- a/mooncake-transfer-engine/src/transport/efa_transport/efa_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/efa_transport/efa_transport.cpp
@@ -77,22 +77,19 @@ static size_t detectBufferPageSize(void* addr) {
     return fallback;
 }
 
+static constexpr size_t kMaxAllowedPteEntries = 100ULL * 1024 * 1024;  // 100M
+
 static size_t getMaxPteEntries() {
     static size_t cached = []() {
         const char* env = std::getenv("MC_EFA_MAX_PTE_ENTRIES");
         if (env) {
             try {
-                if (env[0] == '-') {
-                    LOG(ERROR)
-                        << "Invalid MC_EFA_MAX_PTE_ENTRIES value: " << env;
-                } else {
-                    size_t val = std::stoull(env);
-                    if (val > 0) {
-                        LOG(INFO)
-                            << "MC_EFA_MAX_PTE_ENTRIES override: " << val;
-                        return val;
-                    }
+                size_t val = std::stoull(env);
+                if (val > 0 && val <= kMaxAllowedPteEntries) {
+                    LOG(INFO) << "MC_EFA_MAX_PTE_ENTRIES override: " << val;
+                    return val;
                 }
+                LOG(ERROR) << "MC_EFA_MAX_PTE_ENTRIES out of range: " << env;
             } catch (const std::exception& e) {
                 LOG(ERROR) << "Invalid MC_EFA_MAX_PTE_ENTRIES value: " << env;
             }

--- a/mooncake-transfer-engine/src/transport/efa_transport/efa_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/efa_transport/efa_transport.cpp
@@ -82,10 +82,16 @@ static size_t getMaxPteEntries() {
         const char* env = std::getenv("MC_EFA_MAX_PTE_ENTRIES");
         if (env) {
             try {
-                size_t val = std::stoull(env);
-                if (val > 0) {
-                    LOG(INFO) << "MC_EFA_MAX_PTE_ENTRIES override: " << val;
-                    return val;
+                if (env[0] == '-') {
+                    LOG(ERROR) << "Invalid MC_EFA_MAX_PTE_ENTRIES value: "
+                               << env;
+                } else {
+                    size_t val = std::stoull(env);
+                    if (val > 0) {
+                        LOG(INFO)
+                            << "MC_EFA_MAX_PTE_ENTRIES override: " << val;
+                        return val;
+                    }
                 }
             } catch (const std::exception& e) {
                 LOG(ERROR) << "Invalid MC_EFA_MAX_PTE_ENTRIES value: " << env;


### PR DESCRIPTION
## Description

Simplify `getMaxPteEntries()` in EFA transport by removing the unused `MC_EFA_MAX_PTE_ENTRIES` environment variable override. The env-var parsing used `std::stoull` without exception handling, which could crash the process on invalid input. Since no downstream users depend on this env var (no docs, tests, or external references), the simplest fix is to remove it entirely and return `kDefaultMaxPteEntries` directly, per @whn09's suggestion.

Also removed the stale comment referencing the deleted env var.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

- Code review: the change is a pure deletion (env-var parsing removed, function returns constant)
- CI `build-flags` job compiles with `-DUSE_EFA=ON` and validates the EFA transport builds correctly
- No local EFA build — EFA SDK not available on this machine

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.

🤖 Generated with [Claude Code](https://claude.com/claude-code)