### PR TITLE
[PG] Add experimental MACA PG support

### DIFF
--- a/mooncake-pg/setup.py
+++ b/mooncake-pg/setup.py
@@ -34,6 +34,7 @@ cxx_args = [abi_define, "-std=c++20", "-O3", "-g0"]
 
 cuda_libraries = ["ibverbs", "mlx5"]
 cuda_library_dirs = []
+use_maca = hasattr(torch.version, "maca") and torch.version.maca is not None
 
 if use_musa:
     musa_defines = ["-DUSE_MUSA", "-DMOONCAKE_EP_USE_MUSA=1"]
@@ -48,6 +49,8 @@ if use_musa:
         "-O3",
     ]
 else:
+    if use_maca:
+        cxx_args.append("-DUSE_MACA")
     device_args = [
         abi_define,
         "-std=c++20",
@@ -56,6 +59,8 @@ else:
         "-Xcompiler",
         "-g0",
     ]
+    if use_maca:
+        device_args.append("-DUSE_MACA")
     # Link against the CUDA driver stub library if available.
     # Same approach as mooncake-ep/setup.py.
     if CUDA_HOME is not None:

--- a/mooncake-pg/src/connection_poller.cpp
+++ b/mooncake-pg/src/connection_poller.cpp
@@ -20,7 +20,7 @@ namespace mooncake {
 // On MNNVL clusters all GPUs support fabric mem handles, meaning
 // NVLink transport can only access cuMemCreate(FABRIC) memory
 // cross-node -- CPU heap buffers are invisible to remote peers.
-#ifndef MOONCAKE_EP_USE_MUSA
+#if !defined(MOONCAKE_EP_USE_MUSA) && !defined(USE_MACA)
 static bool supportFabricMem() {
     const char* nvlink_ipc = getenv("MC_USE_NVLINK_IPC");
 
@@ -40,7 +40,7 @@ static bool supportFabricMem() {
     return true;
 }
 #else
-// MUSA does not support NVLink fabric memory handles.
+// MUSA and MACA do not use NVIDIA NVLink fabric memory handles here.
 static bool supportFabricMem() { return false; }
 #endif
 ConnectionContext::ConnectionContext(int backendIndex, int rank, int size,
@@ -433,7 +433,9 @@ bool ConnectionContext::pollPeer(int pollingRank) {
             global_peerConnected_[globalPollingRank] = false;
             meta_->peerConnected[pollingRank] = false;
             meta_->activeRanks[pollingRank] = false;
-            meta_->activeRanksTensor[pollingRank] = 0;
+            if (meta_->activeRanksTensor.device().is_cpu()) {
+                meta_->activeRanksTensor[pollingRank] = 0;
+            }
 
             // Reset store
             try {

--- a/mooncake-pg/src/mooncake_backend.cpp
+++ b/mooncake-pg/src/mooncake_backend.cpp
@@ -7,6 +7,7 @@
 #include <thread>
 #include <chrono>
 #include <atomic>
+#include <cstdlib>
 #include <memory>
 #include "connection_poller.h"
 #include "memory_location.h"
@@ -14,6 +15,18 @@
 #include "pg_utils.h"
 
 namespace mooncake {
+namespace {
+
+#ifdef USE_MACA
+static void requireMacaHostTransport() {
+    TORCH_CHECK(std::getenv("MC_MACA_HOST_TRANSPORT") != nullptr,
+                "MACA PG requires MC_MACA_HOST_TRANSPORT=1 so the transfer "
+                "engine uses a host transport.");
+}
+
+#endif
+
+}  // namespace
 
 constexpr const char* REGISTER_BUFFER_ERROR_MSG =
     "Failed to register local memory.";
@@ -211,6 +224,9 @@ MooncakeBackend::MooncakeBackend(
         engine_ = externalEngine_;
         engineInitialized_ = true;
     } else if (!engineInitialized_) {
+#ifdef USE_MACA
+        requireMacaHostTransport();
+#endif
         engine_->init(P2PHANDSHAKE, hostIp_);
         engineInitialized_ = true;
     }
@@ -253,6 +269,28 @@ MooncakeBackend::MooncakeBackend(
             TORCH_CHECK(!rc, REGISTER_BUFFER_ERROR_MSG);
         }
 
+#ifdef USE_MACA
+    } else {
+        for (size_t i = 0; i < 2; i++) {
+            cudaError_t err = cudaMalloc(&send_buffer_[i], kBufferSize);
+            TORCH_CHECK(!err,
+                        c10::str("Failed to allocate MACA GPU send buffer"));
+
+            int rc = engine_->registerLocalMemory(send_buffer_[i], kBufferSize,
+                                                  location);
+            TORCH_CHECK(!rc, REGISTER_BUFFER_ERROR_MSG);
+        }
+
+        for (size_t i = 0; i < 2; i++) {
+            cudaError_t err = cudaMalloc(&recv_buffer_[i], kBufferSize);
+            TORCH_CHECK(!err,
+                        c10::str("Failed to allocate MACA GPU recv buffer"));
+
+            int rc = engine_->registerLocalMemory(recv_buffer_[i], kBufferSize,
+                                                  location);
+            TORCH_CHECK(!rc, REGISTER_BUFFER_ERROR_MSG);
+        }
+#else
     } else {
         for (size_t i = 0; i < 2; i++) {
             cudaError_t err = cudaMalloc(&send_buffer_[i], kBufferSize);
@@ -271,6 +309,7 @@ MooncakeBackend::MooncakeBackend(
                                                   location);
             TORCH_CHECK(!rc, REGISTER_BUFFER_ERROR_MSG);
         }
+#endif
     }
 
     // Register CPU sync regions

--- a/mooncake-pg/src/mooncake_worker_host.cpp
+++ b/mooncake-pg/src/mooncake_worker_host.cpp
@@ -373,8 +373,10 @@ c10::intrusive_ptr<c10d::Work> MooncakeWorker::putTaskCpu(
         callbacks_[taskId] = [this, processNextChunk, state, meta,
                               bufferToTensor, bufferOffset, realSize,
                               future]() {
-            for (int i = 0; i < meta->size; ++i) {
-                meta->activeRanksTensor[i] = meta->activeRanks[i] ? 1 : 0;
+            if (meta->activeRanksTensor.device().is_cpu()) {
+                for (int i = 0; i < meta->size; ++i) {
+                    meta->activeRanksTensor[i] = meta->activeRanks[i] ? 1 : 0;
+                }
             }
             bufferToTensor(
                 (void*)meta->segmentInfos[meta->rank].recv_buffer[bufferOffset],

--- a/mooncake-pg/src/mooncake_worker_thread.cpp
+++ b/mooncake-pg/src/mooncake_worker_thread.cpp
@@ -16,6 +16,13 @@ enum WorkerTaskStatus {
 
 static constexpr size_t kInvalidTaskId = static_cast<size_t>(-1);
 
+static void setActiveRanksTensorValue(TransferGroupMeta* group, int rank,
+                                      int value) {
+    if (group->activeRanksTensor.device().is_cpu()) {
+        group->activeRanksTensor[rank] = value;
+    }
+}
+
 void MooncakeWorker::Start() {
     bool expected = false;
     if (started_.compare_exchange_strong(expected, true)) {
@@ -209,7 +216,7 @@ void MooncakeWorker::startWorker() {
                                     // connection poller to reconnect it.
                                     group->peerConnected[j] = false;
                                     group->activeRanks[j] = false;
-                                    group->activeRanksTensor[j] = 0;
+                                    setActiveRanksTensorValue(group, j, 0);
                                 } else {
                                     batch_done = false;
                                     break;
@@ -298,7 +305,7 @@ void MooncakeWorker::startWorker() {
                                 // connection poller to reconnect it.
                                 group->peerConnected[j] = false;
                                 group->activeRanks[j] = false;
-                                group->activeRanksTensor[j] = 0;
+                                setActiveRanksTensorValue(group, j, 0);
                             } else {
                                 task_done = false;
                                 break;

--- a/mooncake-pg/src/p2p_proxy.cpp
+++ b/mooncake-pg/src/p2p_proxy.cpp
@@ -320,7 +320,9 @@ void P2PProxy::reportBrokenPeer(int peer_rank) {
     // Set peerConnected to notify the connection poller to reconnect it.
     meta_->peerConnected[peer_rank] = false;
     meta_->activeRanks[peer_rank] = false;
-    meta_->activeRanksTensor[peer_rank] = 0;
+    if (meta_->activeRanksTensor.device().is_cpu()) {
+        meta_->activeRanksTensor[peer_rank] = 0;
+    }
     LOG(ERROR) << "Rank " << meta_->rank << " marking peer " << peer_rank
                << " as broken during P2P transfer.";
 }

--- a/mooncake-transfer-engine/include/gpu_vendor/maca.h
+++ b/mooncake-transfer-engine/include/gpu_vendor/maca.h
@@ -8,6 +8,10 @@
 // First-stage MACA integration: provide a CUDA-like API surface.
 const static std::string GPU_PREFIX = "maca:";
 
+// torch-maca's cu-bridge already defines CUDA/CU compatibility macros after
+// ATen/cuda headers are included. Keep this fallback mapping for translation
+// units that include Mooncake's cuda_alike.h without cu-bridge first.
+#ifndef __CUDA_TO_MACA_ADAPTOR_H__
 #define CUdevice MCdevice
 #define CUdeviceptr mcDeviceptr_t
 #define CUmemorytype MCmemorytype
@@ -70,16 +74,36 @@ static inline CUresult cuGetErrorString(CUresult error, const char **err_str) {
 
 #define cudaDeviceCanAccessPeer mcDeviceCanAccessPeer
 #define cudaDeviceEnablePeerAccess mcDeviceEnablePeerAccess
+#define cudaDeviceGetAttribute mcDeviceGetAttribute
 #define cudaDeviceGetPCIBusId mcDeviceGetPCIBusId
+#define cudaDeviceSynchronize mcDeviceSynchronize
+#define cudaDevAttrMultiProcessorCount mcDeviceAttributeMultiProcessorCount
+#define cudaErrorNotReady mcErrorNotReady
 #define cudaErrorPeerAccessAlreadyEnabled mcErrorPeerAccessAlreadyEnabled
 #define cudaError_t mcError_t
+#define cudaEvent_t mcEvent_t
+#define cudaEventCreate mcEventCreate
+#define cudaEventCreateWithFlags mcEventCreateWithFlags
+#define cudaEventDestroy mcEventDestroy
+#define cudaEventDisableTiming mcEventDisableTiming
+#define cudaEventElapsedTime mcEventElapsedTime
+#define cudaEventQuery mcEventQuery
+#define cudaEventRecord mcEventRecord
+#define cudaEventSynchronize mcEventSynchronize
 #define cudaFree mcFree
 #define cudaFreeHost mcFreeHost
+#define cudaFuncAttributes mcFuncAttributes
 #define cudaGetDevice mcGetDevice
 #define cudaGetDeviceCount mcGetDeviceCount
 #define cudaGetErrorString mcGetErrorString
 #define cudaGetLastError mcGetLastError
+#define cudaHostAlloc mcMallocHost
+#define cudaHostAllocDefault mcMallocHostDefault
+#define cudaHostAllocMapped mcMallocHostMapped
+#define cudaHostAllocPortable mcMallocHostPortable
+#define cudaHostAllocWriteCombined mcMallocHostWriteCombined
 #define cudaHostRegister mcHostRegister
+#define cudaHostRegisterMapped mcHostRegisterMapped
 #define cudaHostRegisterPortable mcHostRegisterPortable
 #define cudaHostUnregister mcHostUnregister
 #define cudaIpcCloseMemHandle mcIpcCloseMemHandle
@@ -92,8 +116,10 @@ static inline CUresult cuGetErrorString(CUresult error, const char **err_str) {
 #define cudaMemcpy mcMemcpy
 #define cudaMemcpyAsync mcMemcpyAsync
 #define cudaMemcpyDefault mcMemcpyDefault
+#define cudaMemcpyDeviceToDevice mcMemcpyDeviceToDevice
 #define cudaMemcpyDeviceToHost mcMemcpyDeviceToHost
 #define cudaMemcpyHostToDevice mcMemcpyHostToDevice
+#define cudaMemcpyKind mcMemcpyKind
 #define cudaMemset mcMemset
 #define cudaMemsetAsync mcMemsetAsync
 #define cudaMemoryTypeDevice mcMemoryTypeDevice
@@ -103,7 +129,36 @@ static inline CUresult cuGetErrorString(CUresult error, const char **err_str) {
 #define cudaPointerGetAttributes mcPointerGetAttributes
 #define cudaSetDevice mcSetDevice
 #define cudaStreamCreate mcStreamCreate
+#define cudaStreamCreateWithFlags mcStreamCreateWithFlags
 #define cudaStreamDestroy mcStreamDestroy
+#define cudaStreamNonBlocking mcStreamNonBlocking
+#define cudaStreamPerThread mcStreamPerThread
 #define cudaStreamSynchronize mcStreamSynchronize
 #define cudaStream_t mcStream_t
+#define cudaStreamWaitEvent mcStreamWaitEvent
 #define cudaSuccess mcSuccess
+
+static inline mcError_t cudaFuncGetAttributes(mcFuncAttributes *attr,
+                                              const void *func) {
+    return mcFuncGetAttributes(attr, func);
+}
+
+#ifdef __cplusplus
+template <class T>
+static inline mcError_t cudaFuncGetAttributes(mcFuncAttributes *attr, T func) {
+    return mcFuncGetAttributes(attr, reinterpret_cast<const void *>(func));
+}
+
+template <class T>
+static inline mcError_t cudaHostGetDevicePointer(T **dev_ptr, void *host_ptr,
+                                                 unsigned int flags) {
+    return mcHostGetDevicePointer(reinterpret_cast<void **>(dev_ptr), host_ptr,
+                                  flags);
+}
+#else
+static inline mcError_t cudaHostGetDevicePointer(void **dev_ptr, void *host_ptr,
+                                                 unsigned int flags) {
+    return mcHostGetDevicePointer(dev_ptr, host_ptr, flags);
+}
+#endif
+#endif  // __CUDA_TO_MACA_ADAPTOR_H__

--- a/mooncake-transfer-engine/src/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine_impl.cpp
@@ -270,12 +270,40 @@ int TransferEngineImpl::init(const std::string& metadata_conn_string,
         }
 #elif defined(USE_MACA)
 
-        Transport* t = multi_transports_->installTransport("maca", nullptr);
-        if (!t) {
-            LOG(ERROR) << "Failed to install MACA transport";
-            return -1;
+        if (getenv("MC_MACA_HOST_TRANSPORT")) {
+            if ((local_topology_->getHcaList().size() > 0 &&
+                 !getenv("MC_FORCE_TCP")) ||
+                getenv("MC_FORCE_HCA")) {
+                Transport* t = multi_transports_->installTransport(
+                    "rdma", local_topology_);
+                if (!t) {
+                    LOG(ERROR) << "Failed to install RDMA transport for MACA";
+                    return -1;
+                }
+                LOG(INFO) << "Using RDMA host transport for MACA";
+            } else {
+#ifdef USE_TCP
+                Transport* t =
+                    multi_transports_->installTransport("tcp", nullptr);
+                if (!t) {
+                    LOG(ERROR) << "Failed to install TCP transport for MACA";
+                    return -1;
+                }
+                LOG(INFO) << "Using TCP host transport for MACA";
+#else
+                LOG(ERROR)
+                    << "MC_MACA_HOST_TRANSPORT requires RDMA HCAs or USE_TCP";
+                return -1;
+#endif
+            }
+        } else {
+            Transport* t = multi_transports_->installTransport("maca", nullptr);
+            if (!t) {
+                LOG(ERROR) << "Failed to install MACA transport";
+                return -1;
+            }
+            LOG(INFO) << "Using MACA transport";
         }
-        LOG(INFO) << "Using MACA transport";
 
 #elif defined(USE_MNNVL) || defined(USE_INTRA_NVLINK)
 

--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
@@ -75,6 +75,23 @@ static int getCudaDeviceId(void* addr) {
     if (attributes.type == cudaMemoryTypeDevice) return attributes.device;
     return -1;
 }
+
+#ifdef USE_MACA
+static cudaError_t copyTcpCudaMemory(void* dst, const void* src, size_t size) {
+    cudaStream_t stream;
+    cudaError_t status =
+        cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking);
+    if (status != cudaSuccess) return status;
+
+    status = cudaMemcpyAsync(dst, src, size, cudaMemcpyDefault, stream);
+    if (status == cudaSuccess) {
+        status = cudaStreamSynchronize(stream);
+    }
+
+    cudaError_t destroy_status = cudaStreamDestroy(stream);
+    return status == cudaSuccess ? destroy_status : status;
+}
+#endif
 #endif
 
 // Forward declaration
@@ -162,9 +179,14 @@ struct ServerSession : public std::enable_shared_from_this<ServerSession> {
         if (cuda_device >= 0) {
             dram_buffer = new char[buffer_size];
             cudaSetDevice(cuda_device);
+#ifdef USE_MACA
+            cudaError_t cuda_status = copyTcpCudaMemory(
+                dram_buffer, addr + total_transferred_bytes_, buffer_size);
+#else
             cudaError_t cuda_status =
                 cudaMemcpy(dram_buffer, addr + total_transferred_bytes_,
                            buffer_size, cudaMemcpyDefault);
+#endif
             if (cuda_status != cudaSuccess) {
                 LOG(ERROR) << "ServerSession::writeBody failed to copy from "
                               "CUDA memory. "
@@ -254,9 +276,15 @@ struct ServerSession : public std::enable_shared_from_this<ServerSession> {
     defined(USE_COREX)
                 if (cuda_device >= 0) {
                     cudaSetDevice(cuda_device);
+#ifdef USE_MACA
+                    cudaError_t cuda_status =
+                        copyTcpCudaMemory(addr + total_transferred_bytes_,
+                                          dram_buffer, transferred_bytes);
+#else
                     cudaError_t cuda_status =
                         cudaMemcpy(addr + total_transferred_bytes_, dram_buffer,
                                    transferred_bytes, cudaMemcpyDefault);
+#endif
                     if (cuda_status != cudaSuccess) {
                         LOG(ERROR)
                             << "ServerSession::readBody failed to copy to CUDA "
@@ -395,9 +423,15 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
     defined(USE_COREX)
                 if (cuda_device >= 0) {
                     cudaSetDevice(cuda_device);
+#ifdef USE_MACA
+                    cudaError_t cuda_status =
+                        copyTcpCudaMemory(addr + total_transferred_bytes_,
+                                          dram_buffer, transferred_bytes);
+#else
                     cudaError_t cuda_status =
                         cudaMemcpy(addr + total_transferred_bytes_, dram_buffer,
                                    transferred_bytes, cudaMemcpyDefault);
+#endif
                     if (cuda_status != cudaSuccess) {
                         LOG(ERROR)
                             << "ClientSession::readBody failed to copy to CUDA "
@@ -456,9 +490,14 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
         if (cuda_device >= 0) {
             dram_buffer = new char[buffer_size];
             cudaSetDevice(cuda_device);
+#ifdef USE_MACA
+            cudaError_t cuda_status = copyTcpCudaMemory(
+                dram_buffer, addr + total_transferred_bytes_, buffer_size);
+#else
             cudaError_t cuda_status =
                 cudaMemcpy(dram_buffer, addr + total_transferred_bytes_,
                            buffer_size, cudaMemcpyDefault);
+#endif
             if (cuda_status != cudaSuccess) {
                 LOG(ERROR) << "ClientSession::writeBody failed to copy from "
                               "CUDA memory. "


### PR DESCRIPTION
# MACA PG Experimental Support Status

This note records the current experimental MACA support work for Mooncake PG
(ProcessGroup). It is written as an issue/PR-ready summary for the `maca-pg`
branch.

## Description

Route MACA PG through explicit TransferEngine transports and validate MACA
device-buffer PG communication on a 4-GPU MetaX/MACA node.

Mooncake EP can already start on MACA, but using only the Gloo fallback does not
exercise Mooncake's TransferEngine-backed communication path. This experiment
therefore focuses on making Mooncake PG functional on the torch-maca stack with
the smallest MACA-specific adaptation surface.

The current implementation supports two MACA PG modes:

- host-staged mode: PG data and control buffers are CPU buffers and use a host
  transport, either TCP or RDMA;
- direct MACA mode: PG data buffers are device buffers registered with the
  MACA transport, while synchronization and control buffers still use a host
  transport, either TCP or RDMA.

Direct MACA mode is enabled with `MC_MACA_PG_DIRECT=1`. The control transport is
selected with `MC_MACA_PG_CONTROL_TRANSPORT=tcp` or
`MC_MACA_PG_CONTROL_TRANSPORT=rdma`.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [x] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [x] Other: experimental hardware enablement

## What Changed

### MACA PG transport routing

PG now carries separate data and control transport hints through
`TransferGroupMeta`.

- `dataTransferProtocol` selects the protocol used by PG data transfers.
- `controlTransferProtocol` selects the protocol used by warmup, credit, ack,
  barrier, and CPU synchronization transfers.

For normal CPU and non-MACA paths, these hints are null and the existing
TransferEngine transport selection behavior is preserved.

For MACA direct mode:

- data transfers use the `maca` transport;
- control transfers use `tcp` or `rdma`;
- `MC_MACA_PG_CONTROL_TRANSPORT` selects the control transport, defaulting to
  `tcp`.

This keeps host synchronization buffers away from the MACA device transport,
because MACA device transport only accepts device memory registrations.

### TransferEngine explicit transport APIs

TransferEngine now has explicit protocol-targeted helpers for the PG use case:

- `registerLocalMemoryForTransport`
- `unregisterLocalMemoryForTransport`
- `submitTransferByTransport`

These APIs allow PG to register and submit CPU control buffers to TCP/RDMA while
registering and submitting device data buffers to the MACA transport in the same
process group.

### MACA host transport selection

The MACA branch in `transfer_engine_impl.cpp` now supports two PG-specific
paths.

Host-staged mode is selected with `MC_MACA_HOST_TRANSPORT`. It installs a
host-capable transport:

- RDMA when an HCA is available and TCP is not forced;
- TCP when `MC_FORCE_TCP=1` is set or RDMA is not available.

Direct mode is selected with `MC_MACA_DUAL_TRANSPORT`. It installs:

- one host control transport, `tcp` or `rdma`;
- the MACA transport for device data buffers.

The logs explicitly report the chosen route, for example:

```text
Using TCP host transport for MACA
Using RDMA host transport for MACA
Using tcp control transport and MACA data transport
Using rdma control transport and MACA data transport
```

### MACA metadata compatibility

The MACA segment descriptor handling in `transfer_metadata.cpp` now preserves
enough metadata for mixed MACA data and host control registration.

For MACA descriptors:

- device/topology metadata can be encoded when present;
- `shm_name` is optional, so host control buffers in the same MACA segment do
  not fail descriptor validation;
- optional `rkey` and `lkey` arrays can be decoded when MACA metadata carries
  host RDMA registration data.

This is needed because direct MACA mode installs both a MACA data transport and
a host control transport in the same TransferEngine instance.

### MACA transport descriptor preservation

When the MACA transport is installed after the host control transport, it
preserves the existing local segment descriptor instead of replacing it. This
allows the local descriptor to contain both host-control and MACA-device buffer
entries.

`MacaTransport::unregisterLocalMemory` now returns
`ERR_ADDRESS_NOT_REGISTERED` when `cuMemGetAddressRange` cannot resolve the
provided pointer. This avoids accidentally removing a host-control metadata
entry through the MACA transport.

### RDMA host memory registration on MACA

The RDMA path now treats non-device MACA pointers as host memory for
`ibv_reg_mr`. This fixes host-staged RDMA and RDMA control-buffer registration
under MACA.

The practical failure before this fix was a missing `lkey/rkey` for MACA host
buffers, followed by local protection errors or PG warmup timeouts.

### Host-staged MACA fallback

When `MC_MACA_PG_DIRECT` is not enabled, MACA device allreduce uses the
host-staged fallback:

1. copy the local device tensor to a CPU staging buffer;
2. exchange rank data through the selected host transport;
3. reduce on CPU;
4. copy the reduced result back to the original MACA tensor.

This mode remains useful as a conservative functional fallback.

## Current Scope and Limitations

The current patch is for functional exploration, not performance.

- Validated device PG coverage is focused on init/allreduce smoke tests.
- Direct MACA mode uses GPU device buffers for PG data.
- Direct MACA mode still uses host transport for PG control and synchronization.
- RDMA in direct mode is currently the control transport; this is not GPU RDMA
  direct data movement.
- Validation so far is single-node, up to 4 local MACA GPUs.
- Other device collectives may still need MACA-specific validation.
- No MUSA-specific code was changed for this experiment.

## How Has This Been Tested?

### Build environment

The local validation used the MACA torch environment under
`/opt/miniconda3/envs/py310` and the MACA SDK under `/opt/maca`.

Common runtime environment:

```bash
PYTHONPATH=/home/zhouyuhan/Mooncake/mooncake-wheel:/home/zhouyuhan/Mooncake/mooncake-pg/tests
LD_LIBRARY_PATH=/home/zhouyuhan/Mooncake/.deps/sysroot/usr/lib/x86_64-linux-gnu:/home/zhouyuhan/Mooncake/.deps/build-maca-pg/mooncake-common:/opt/maca/mxgpu_llvm/lib:/opt/maca/lib:/opt/maca/lib64:/opt/maca/ompi/lib:/opt/miniconda3/envs/py310/lib:/opt/miniconda3/envs/py310/lib/python3.10/site-packages/torch/lib:/home/zhouyuhan/Mooncake/mooncake-wheel/mooncake
MACA_PATH=/opt/maca
```

Additional PG extension build environment:

```bash
LIBRARY_PATH=/home/zhouyuhan/Mooncake/.deps/sysroot/usr/lib/x86_64-linux-gnu
CPLUS_INCLUDE_PATH=/home/zhouyuhan/Mooncake/.deps/sysroot/usr/include:/home/zhouyuhan/Mooncake/.deps/sysroot/usr/include/jsoncpp:/home/zhouyuhan/Mooncake/.deps/sysroot/usr/include/libnl3
CPATH=/home/zhouyuhan/Mooncake/.deps/sysroot/usr/include:/home/zhouyuhan/Mooncake/.deps/sysroot/usr/include/jsoncpp:/home/zhouyuhan/Mooncake/.deps/sysroot/usr/include/libnl3
TORCH_CUDA_ARCH_LIST=8.0
MAX_JOBS=8
```

### Build checks

TransferEngine:

```bash
LIBRARY_PATH=/home/zhouyuhan/Mooncake/.deps/sysroot/usr/lib/x86_64-linux-gnu \
cmake --build .deps/build-maca-pg -j 8
```

Result: passed.

PG extension:

```bash
cd mooncake-pg
python setup.py build_ext --build-lib . --force
cp mooncake/pg_2_8_0.cpython-310-x86_64-linux-gnu.so \
  ../mooncake-wheel/mooncake/pg_2_8_0.cpython-310-x86_64-linux-gnu.so
```

Result: passed.

### Two-rank MACA PG smoke matrix

A temporary two-rank allreduce probe was run against the rebuilt PG extension.
The expected sum was `3`.

| Mode | Environment | Result |
| --- | --- | --- |
| host-staged TCP | `MC_FORCE_TCP=1` | passed, both ranks returned `3` |
| host-staged RDMA | `MC_FORCE_HCA=1` | passed, both ranks returned `3` |
| direct MACA data + TCP control | `MC_MACA_PG_DIRECT=1 MC_MACA_PG_CONTROL_TRANSPORT=tcp` | passed, both ranks returned `3` |
| direct MACA data + RDMA control | `MC_MACA_PG_DIRECT=1 MC_MACA_PG_CONTROL_TRANSPORT=rdma` | passed, both ranks returned `3` |

### Four-rank MACA PG smoke

The direct MACA data path was also validated with four local ranks:

```bash
MACA_PG_PROBE_WORLD_SIZE=4 \
MC_MACA_PG_DIRECT=1 \
MC_MACA_PG_CONTROL_TRANSPORT=rdma \
MACA_PG_PROBE_TIMEOUT=240 \
timeout 300s python /tmp/maca_pg_probe.py
```

Result:

```text
ROWS [
  {'ok': True, 'rank': 0, 'value': 10},
  {'ok': True, 'rank': 1, 'value': 10},
  {'ok': True, 'rank': 2, 'value': 10},
  {'ok': True, 'rank': 3, 'value': 10}
]
OK
```

The log reported:

```text
Using rdma control transport and MACA data transport
```

The expected allreduce sum was `1 + 2 + 3 + 4 = 10`.

### Sanity checks

```bash
git diff --check
```

Result: passed.

The repository formatter was not run locally because `clang-format-20` was not
available in this environment.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.

Notes:

- No new automated MACA-specific test files were added in this experiment.
- Existing PG test utilities were reused in the torch-maca environment.
- The default PG spawn timeout can be too short on this node; manual probes used
  120 to 240 seconds.

## Follow-up Work

1. Add focused automated MACA PG tests when the CI/runtime environment can
   expose MACA devices.
2. Extend validation beyond init and allreduce.
3. Decide whether host-staged MACA allreduce should remain as a functional
   fallback after direct MACA mode matures.
4. Investigate cross-node behavior separately. Current direct-mode validation is
   single-node MACA device data plus host TCP/RDMA control.
5. Run the repository formatter with `clang-format-20` before preparing a final
   upstream PR.

## Acknowledgements

This MACA PG experiment used the MUSA PG adaptation work as reference material,
especially the build-system and platform-separation experience from:

- [kvcache-ai/Mooncake#2353](https://github.com/kvcache-ai/Mooncake/pull/2353)
  (`[PG] Build the MUSA PG extension through torchada`)
- [kvcache-ai/Mooncake#2329](https://github.com/kvcache-ai/Mooncake/pull/2329)
  (`[PG] Add MUSA build support`)
