### PR TITLE
[Common][Store][TE] Fix UB: passing signed char to ::tolower in std::transform

### DIFF
--- a/mooncake-common/src/environ.cpp
+++ b/mooncake-common/src/environ.cpp
@@ -3,6 +3,7 @@
 #include <climits>
 #include <cstring>
 #include <algorithm>
+#include <cctype>
 #include <iostream>
 
 namespace mooncake {
@@ -52,7 +53,8 @@ bool Environ::GetBool(const char* name, bool default_value) {
     const char* val = std::getenv(name);
     if (val) {
         std::string s(val);
-        std::transform(s.begin(), s.end(), s.begin(), ::tolower);
+        std::transform(s.begin(), s.end(), s.begin(),
+                       [](unsigned char c) { return std::tolower(c); });
         return s == "1" || s == "true" || s == "on" || s == "yes";
     }
     return default_value;

--- a/mooncake-store/src/transfer_task.cpp
+++ b/mooncake-store/src/transfer_task.cpp
@@ -929,7 +929,7 @@ TransferSubmitter::TransferSubmitter(TransferEngine& engine,
         std::string env_str(env_value);
         // Convert to lowercase for case-insensitive comparison
         std::transform(env_str.begin(), env_str.end(), env_str.begin(),
-                       ::tolower);
+                       [](unsigned char c) { return std::tolower(c); });
         if (env_str == "false" || env_str == "0" || env_str == "no" ||
             env_str == "off") {
             memcpy_enabled_ = false;

--- a/mooncake-transfer-engine/tent/src/common/config.cpp
+++ b/mooncake-transfer-engine/tent/src/common/config.cpp
@@ -16,6 +16,8 @@
 
 #include <glog/logging.h>
 
+#include <algorithm>
+#include <cctype>
 #include <sstream>
 
 namespace mooncake {
@@ -120,7 +122,7 @@ Status ConfigHelper::loadFromEnv(Config& config) {
 bool ConfigHelper::parseBool(const std::string& str, bool default_value) {
     std::string lower_str = str;
     std::transform(lower_str.begin(), lower_str.end(), lower_str.begin(),
-                   ::tolower);
+                   [](unsigned char c) { return std::tolower(c); });
 
     if (lower_str == "true" || lower_str == "1" || lower_str == "yes" ||
         lower_str == "on") {

--- a/mooncake-transfer-engine/tent/src/runtime/transport_selector.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transport_selector.cpp
@@ -19,6 +19,9 @@
 
 #include <glog/logging.h>
 
+#include <algorithm>
+#include <cctype>
+
 namespace mooncake {
 namespace tent {
 
@@ -155,7 +158,8 @@ void TransportSelector::loadPolicies() {
                     policy_json["priority"].get<std::string>();
                 // Convert to lowercase for case-insensitive matching
                 std::transform(prio_str.begin(), prio_str.end(),
-                               prio_str.begin(), ::tolower);
+                               prio_str.begin(),
+                               [](unsigned char c) { return std::tolower(c); });
                 if (prio_str == "high" || prio_str == "0") {
                     policy.priority = PRIO_HIGH;
                 } else if (prio_str == "medium" || prio_str == "1") {


### PR DESCRIPTION
## What

Replaces bare `::tolower` passed to `std::transform` with the standard-conforming `[](unsigned char c) { return std::tolower(c); }` idiom across the four places it occurs in the codebase, and adds the `<cctype>` / `<algorithm>` includes where they were previously only pulled in transitively.

## Why

`std::transform(s.begin(), s.end(), s.begin(), ::tolower)` passes each `std::string` element to `::tolower` as-is. `char` is signed on most platforms, so any byte greater than `0x7F` is sign-extended to a negative `int`. The C standard requires the argument to `tolower` to be representable as `unsigned char` or equal to `EOF`; anything else is **undefined behavior** — it may index out of bounds in the libc ctype lookup table and crash, or silently return wrong results.

This bites whenever an environment variable or config value contains a non-ASCII byte (UTF-8, stray high bytes, etc.). All affected sites parse user-controlled strings (env vars / JSON config), so the input is not guaranteed to be ASCII.

This was originally noted by @Chelseatr in #2222:

> Note: `Environ::GetBool` itself still uses `::tolower` on signed char, which is the same UB — happy to fix that in a separate PR if you'd like, but I left it out of this one to keep the diff focused.

This PR is that follow-up, and additionally fixes the three other identical occurrences found in the tree.

## Changes

| File | Function |
|------|----------|
| `mooncake-common/src/environ.cpp` | `Environ::GetBool` |
| `mooncake-store/src/transfer_task.cpp` | `TransferSubmitter` constructor |
| `mooncake-transfer-engine/tent/src/common/config.cpp` | `ConfigHelper::parseBool` |
| `mooncake-transfer-engine/tent/src/runtime/transport_selector.cpp` | `TransportSelector::loadPolicies` |

## Notes

- Behavior is unchanged for ASCII input; this only removes UB for non-ASCII bytes.
- No functional/API changes; purely a correctness hardening.
- `grep -rn '::tolower\|::toupper'` now reports no remaining bare C-locale ctype calls outside the `std::` namespace.
