### PR TITLE
Add modular KVCache storage benchmark (v1)

### DIFF
--- a/benchmarks/storage_benchmark_v1/__init__.py
+++ b/benchmarks/storage_benchmark_v1/__init__.py
@@ -1,0 +1,41 @@
+"""
+Mooncake KVCache Storage Benchmark Library
+"""
+
+__version__ = "2.0.0"
+
+from benchmark import (
+    main,
+    run_benchmark,
+    print_results,
+    StorageBenchmark,
+    TraceReplay,
+    KVCacheRequest,
+)
+from storage import Storage, KVKey, KVValue, DiskHashTable, SSDStorage
+from layout import (
+    KVLayout, MLALayout, KVEntry, MLA_MODEL_CONFIG, get_model_config, create_layout,
+)
+
+__all__ = [
+    # Main
+    'main',
+    'run_benchmark',
+    'print_results',
+    'StorageBenchmark',
+    'TraceReplay',
+    'KVCacheRequest',
+    # Storage
+    'Storage',
+    'KVKey',
+    'KVValue',
+    'DiskHashTable',
+    'SSDStorage',
+    # Layout
+    'KVLayout',
+    'MLALayout',
+    'KVEntry',
+    'MLA_MODEL_CONFIG',
+    'get_model_config',
+    'create_layout',
+]

--- a/benchmarks/storage_benchmark_v1/__main__.py
+++ b/benchmarks/storage_benchmark_v1/__main__.py
@@ -1,0 +1,11 @@
+"""
+Entry point for running the benchmark as a module
+
+Usage:
+    python -m storage_benchmark --model=glm5 --scenario=toolagent --max-requests=100
+"""
+
+from benchmark import main
+
+if __name__ == '__main__':
+    main()

--- a/benchmarks/storage_benchmark_v1/benchmark.py
+++ b/benchmarks/storage_benchmark_v1/benchmark.py
@@ -7,16 +7,16 @@ Complete benchmark tool with CLI interface.
 
 import argparse
 import json
-import os
 import sys
 import time
 import statistics
+import signal
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterator, List, Dict, Any
 
-from storage import SSDStorage
-from layout import KVLayout, get_model_config, create_layout
+from storage import DiskHashTable
+from layout import get_model_config, create_layout
 
 
 # ============================================================================
@@ -25,7 +25,7 @@ from layout import KVLayout, get_model_config, create_layout
 
 @dataclass
 class KVCacheRequest:
-    """KVCache request"""
+    """KVCache request from trace"""
     timestamp: float
     hash_ids: List[int]
     input_length: int
@@ -42,25 +42,21 @@ class TraceReplay:
     def __init__(self, trace_path: str):
         self.trace_path = trace_path
 
-    def replay(self) -> Iterator[dict]:
-        """Replay trace workload"""
+    def load_all(self) -> List[KVCacheRequest]:
+        """Load all requests from trace file"""
+        requests = []
         with open(self.trace_path, 'r', encoding='utf-8') as f:
             for line in f:
                 line = line.strip()
                 if line:
-                    yield json.loads(line)
-
-    def load_all(self) -> List[KVCacheRequest]:
-        """Load all requests"""
-        return [
-            KVCacheRequest(
-                timestamp=req.get('timestamp', 0),
-                hash_ids=req.get('hash_ids', []),
-                input_length=req.get('input_length', 0),
-                output_length=req.get('output_length', 0),
-            )
-            for req in self.replay()
-        ]
+                    req = json.loads(line)
+                    requests.append(KVCacheRequest(
+                        timestamp=req.get('timestamp', 0),
+                        hash_ids=req.get('hash_ids', []),
+                        input_length=req.get('input_length', 0),
+                        output_length=req.get('output_length', 0),
+                    ))
+        return requests
 
 
 # ============================================================================
@@ -70,47 +66,29 @@ class TraceReplay:
 class StorageBenchmark:
     """KVCache storage benchmark
 
-    Uses KVLayout interface to support different architectures.
-    - MLA: Each (sequence_id, layer_id) pair maps to ONE complete entry
-    - Future: Other architectures can be added by implementing KVLayout
+    Processes KVCache requests using layout-generated access patterns.
     """
 
-    def __init__(self, storage_dir: str, model_config: dict = None,
-                 layout: KVLayout = None,
-                 page_size_tokens: int = 64,
+    def __init__(self, storage_dir: str, model_config: dict,
+                 page_size_tokens: int = 512,
                  max_pages: int = 100000,
                  fsync_mode: str = 'none', fsync_batch_size: int = 100):
         """Initialize benchmark
 
         Args:
             storage_dir: Directory for storage files
-            model_config: Model configuration dict (used if layout not provided)
-            layout: KVLayout instance (overrides model_config if provided)
-            page_size_tokens: Tokens per page (default 64)
-            max_pages: Maximum number of pages to store
+            model_config: Model configuration dict
+            page_size_tokens: Tokens per page (default: 512)
+            max_pages: Maximum number of pages
             fsync_mode: When to fsync ('none', 'batch', 'always', 'end')
             fsync_batch_size: Number of writes between fsync in batch mode
         """
-        if layout is None:
-            if model_config is None:
-                # Use default model config
-                model_config = get_model_config("glm5")
-            self.model_config = model_config
-            self.layout = create_layout(model_config, page_size_tokens)
-        else:
-            self.layout = layout
-            self.model_config = model_config or {}
-
-        # Get layout metadata
-        self.num_layers = self._get_num_layers()
-        self.has_indexer = self._get_has_indexer()
-
-        # Get page size from layout
-        # All KVLayout implementations must provide value_size_bytes
+        self.model_config = model_config
+        self.layout = create_layout(model_config, page_size_tokens)
         self.page_size_bytes = self.layout.value_size_bytes
 
         # Initialize storage
-        self.storage = SSDStorage(
+        self.storage = DiskHashTable(
             storage_dir=storage_dir,
             page_size=self.page_size_bytes,
             max_pages=max_pages,
@@ -128,58 +106,41 @@ class StorageBenchmark:
             'request_latencies_ms': [],
         }
 
-    def _get_num_layers(self) -> int:
-        """Get number of layers from layout or config"""
-        # For MLA layout, we can get this from the layout instance
-        if hasattr(self.layout, 'num_layers'):
-            return self.layout.num_layers
-        return self.model_config.get('num_layers', 0)
-
-    def _get_has_indexer(self) -> bool:
-        """Check if layout uses indexer"""
-        if hasattr(self.layout, 'index_head_dim'):
-            return self.layout.index_head_dim > 0
-        return self.model_config.get('index_head_dim', 0) > 0
-
     def process_request(self, req: KVCacheRequest) -> float:
-        """Process a KVCache request using the layout interface"""
+        """Process a KVCache request
+
+        Args:
+            req: KVCache request
+
+        Returns:
+            Total latency in milliseconds
+        """
         self.stats['total_requests'] += 1
+        self.stats['total_tokens'] += req.input_length + req.output_length
 
-        total_tokens = req.input_length + req.output_length
-        self.stats['total_tokens'] += total_tokens
-
-        start_time = time.perf_counter()
         total_latency = 0.0
-        io_operations = 0
 
-        # Use layout to generate keys for this request
-        for entry in self.layout.get_entries(req):
-            key = entry.key
-            if self.storage.exists(key):
-                start_io = time.perf_counter()
-                val = self.storage.get(key)
-                latency = (time.perf_counter() - start_io) * 1000.0
-                if val is not None:
-                    total_latency += latency
-                    io_operations += 1
+        # Process each access requirement from layout
+        for access in self.layout.get_operations(req):
+            if self.storage.exists(access.page_id):
+                # Page exists, perform READ
+                total_latency += self.storage.read(
+                    access.page_id,
+                    offset_in_page=access.offset_in_page,
+                    length=access.length
+                )
                 self.stats['read_pages'] += 1
                 self.stats['page_hits'] += 1
             else:
-                from storage.interface import KVValue
-                dummy_value = KVValue(data=bytes(entry.value_size_bytes), page_count=1, token_count=self.layout.page_size_tokens)
-                start_io = time.perf_counter()
-                self.storage.put(key, dummy_value)
-                latency = (time.perf_counter() - start_io) * 1000.0
-                total_latency += latency
-                io_operations += 1
+                # Page doesn't exist, perform WRITE
+                total_latency += self.storage.write(
+                    access.page_id,
+                    offset_in_page=access.offset_in_page,
+                    length=access.length
+                )
                 self.stats['write_pages'] += 1
 
-        # Only record latency if we actually performed IO operations
-        if io_operations > 0 and total_latency > 0:
-            latency_ms = total_latency
-        else:
-            latency_ms = 0.0
-
+        latency_ms = total_latency if total_latency > 0 else 0.0
         if latency_ms > 0:
             self.stats['request_latencies_ms'].append(latency_ms)
         return latency_ms
@@ -217,8 +178,6 @@ class StorageBenchmark:
             'page_hits': self.stats['page_hits'],
             'page_hit_rate': self.stats['read_pages'] / total_pages if total_pages > 0 else 0,
             'write_ratio': self.stats['write_pages'] / total_pages if total_pages > 0 else 0,
-            'num_layers': self.num_layers,
-            'has_indexer': self.has_indexer,
             'latency': latency_stats,
             'storage': storage_stats,
         }
@@ -238,12 +197,33 @@ class StorageBenchmark:
 # Benchmark Runner
 # ============================================================================
 
+def get_max_page_id(requests: List[KVCacheRequest]) -> int:
+    max_id = 0
+    for req in requests:
+        if req.hash_ids:
+            max_id = max(max_id, max(req.hash_ids))
+    return max_id
+
+
 def run_benchmark(trace_path: str, storage_dir: str, model_config: dict,
-                  max_requests: int = None, max_pages: int = 100000,
-                  page_size_tokens: int = 64,
-                  replay_timestamps: bool = False, time_scale: float = 1.0,
+                  max_requests: int = None, max_pages: int = None,
+                  page_size_tokens: int = 512,
                   fsync_mode: str = 'none', fsync_batch_size: int = 100) -> Dict:
-    """Run benchmark"""
+    """Run benchmark
+
+    Args:
+        trace_path: Trace file path
+        storage_dir: Storage directory
+        model_config: Model configuration
+        max_requests: Maximum number of requests (None = all)
+        max_pages: Maximum number of pages (None = auto-calculate)
+        page_size_tokens: Tokens per page
+        fsync_mode: When to fsync
+        fsync_batch_size: Number of writes between fsync
+
+    Returns:
+        Benchmark results dictionary
+    """
     print(f"\n{'='*80}")
     print(f"Running: {Path(trace_path).name}")
     print(f"Model: {model_config['name']}")
@@ -260,6 +240,45 @@ def run_benchmark(trace_path: str, storage_dir: str, model_config: dict,
 
     print(f"Loaded {len(requests)} requests")
 
+    # Find max page_id from trace
+    max_page_id = get_max_page_id(requests)
+    max_pages_needed = max_page_id + 1  # page_id is 0-based
+
+    # Create layout to get page size
+    layout = create_layout(model_config, page_size_tokens)
+    page_size_bytes = layout.value_size_bytes
+
+    # Determine max_pages
+    if max_pages is None:
+        # Use max page_id from trace
+        max_pages = max_pages_needed
+        # Round up to next thousand for cleaner numbers
+        max_pages = ((max_pages + 999) // 1000) * 1000
+    else:
+        # User specified max_pages
+        pass
+
+    max_size_gb = max_pages * page_size_bytes / (1024**3)
+    trace_size_gb = max_pages_needed * page_size_bytes / (1024**3)
+
+    print(f"\n[Storage Configuration]")
+    print(f"  Max page_id in trace:             {max_page_id:,}")
+    print(f"  Pages needed (trace):             {max_pages_needed:,}")
+    print(f"  Trace storage size:               {trace_size_gb:.2f} GB")
+    print(f"  Max pages configured:             {max_pages:,}")
+    print(f"  Max storage available:            {max_size_gb:.2f} GB")
+
+    if max_pages_needed > max_pages:
+        shortfall = max_pages_needed - max_pages
+        shortfall_gb = shortfall * page_size_bytes / (1024**3)
+        compression_ratio = max_pages / max_pages_needed
+        print(f"\n  ⚠️  Storage insufficient: {shortfall:,} pages shortfall ({shortfall_gb:.2f} GB)")
+        print(f"  ⚠️  Consider increasing --max-pages to at least {max_pages_needed:,} for full simulation")
+    else:
+        surplus = max_pages - max_pages_needed
+        surplus_pct = (surplus / max_pages) * 100 if max_pages > 0 else 0
+        print(f"  ✓ Direct mapping: all {max_pages_needed:,} logical pages uniquely mapped")
+
     # Run benchmark
     with StorageBenchmark(
         storage_dir=storage_dir,
@@ -269,38 +288,53 @@ def run_benchmark(trace_path: str, storage_dir: str, model_config: dict,
         fsync_mode=fsync_mode,
         fsync_batch_size=fsync_batch_size
     ) as benchmark:
-
         start_time = time.perf_counter()
-        total_io_time = 0.0
-        last_timestamp = None
-
-        for i, req in enumerate(requests):
-            if replay_timestamps and last_timestamp is not None:
-                delta_ms = req.timestamp - last_timestamp
-                sleep_time = delta_ms / 1000.0 / time_scale
-                if sleep_time > 0:
-                    time.sleep(sleep_time)
-
-            req_start = time.perf_counter()
-            benchmark.process_request(req)
-            req_io_time = time.perf_counter() - req_start
-            total_io_time += req_io_time
-
-            last_timestamp = req.timestamp
-
-            if (i + 1) % 100 == 0:
-                print(f"  Processed {i + 1}/{len(requests)}...")
+        try:
+            for i, req in enumerate(requests):
+                benchmark.process_request(req)
+                # Print progress for each request
+                elapsed = time.perf_counter() - start_time
+                qps = (i + 1) / elapsed if elapsed > 0 else 0
+                stats = benchmark.get_stats()
+                storage = stats.get('storage', {})
+                read_latency = storage.get('read', {}).get('avg_ms', 0)
+                write_latency = storage.get('write', {}).get('avg_ms', 0)
+                read_mb = storage.get('read', {}).get('mb', 0)
+                write_mb = storage.get('write', {}).get('mb', 0)
+                read_time = storage.get('read', {}).get('time_s', 0)
+                write_time = storage.get('write', {}).get('time_s', 0)
+                read_mbps = read_mb / read_time if read_time > 0 else 0
+                write_mbps = write_mb / write_time if write_time > 0 else 0
+                print(f"  [{i+1:5d}/{len(requests)}] ids={len(req.hash_ids):3d} "
+                      f"tokens={req.input_length+req.output_length:6d} | "
+                      f"QPS={qps:7.2f} | "
+                      f"R={stats['read_pages']:6d} ({read_latency:6.2f}ms, {read_mbps:6.1f}MB/s) | "
+                      f"W={stats['write_pages']:6d} ({write_latency:6.2f}ms, {write_mbps:6.1f}MB/s)")
+        except KeyboardInterrupt:
+            print(f"\n\n{'='*80}")
+            print(f"Interrupted! Showing partial results:")
+            print(f"{'='*80}")
+            elapsed = time.perf_counter() - start_time
+            stats = benchmark.get_stats()
+            print_results([{
+                'trace_file': Path(trace_path).name,
+                'total_requests': i + 1,
+                'io_time_s': elapsed,
+                'requests_per_second': (i + 1) / elapsed if elapsed > 0 else 0,
+                'model': model_config['name'],
+                'fsync_mode': fsync_mode,
+                **stats,
+            }])
+            sys.exit(0)
 
         elapsed = time.perf_counter() - start_time
         stats = benchmark.get_stats()
 
-    io_time = total_io_time if replay_timestamps else elapsed
-
     return {
         'trace_file': Path(trace_path).name,
         'total_requests': len(requests),
-        'io_time_s': io_time,
-        'requests_per_second': len(requests) / io_time if io_time > 0 else 0,
+        'io_time_s': elapsed,
+        'requests_per_second': len(requests) / elapsed if elapsed > 0 else 0,
         'model': model_config['name'],
         'fsync_mode': fsync_mode,
         **stats,
@@ -311,31 +345,68 @@ def run_benchmark(trace_path: str, storage_dir: str, model_config: dict,
 # Output Formatting
 # ============================================================================
 
+def format_storage_stats(stats: Dict, title: str = "Storage"):
+    """Format storage statistics with clear read/write separation"""
+    storage = stats.get('storage', {})
+    read_stats = storage.get('read', {})
+    write_stats = storage.get('write', {})
+
+    output = []
+    output.append(f"\n[{title}]")
+
+    # General info
+    output.append(f"\n[General]")
+    output.append(f"  Model:            {stats.get('model', 'N/A')}")
+    output.append(f"  Requests:         {stats.get('total_requests', 0):,}")
+    output.append(f"  Tokens:           {stats.get('total_tokens', 0):,}")
+    output.append(f"  Total I/O Time:    {stats.get('io_time_s', 0):.3f} s")
+    output.append(f"  QPS:              {stats.get('requests_per_second', 0):.2f}")
+    output.append(f"  Hit Rate:         {stats.get('page_hit_rate', 0):.2%}")
+
+    # Read Stats
+    output.append(f"\n[Read Operations]")
+    output.append(f"  Count:            {read_stats.get('count', 0):,}")
+    output.append(f"  Data Volume:      {read_stats.get('mb', 0):.2f} MB")
+    read_time = read_stats.get('time_s', 0)
+    read_mbps = read_stats.get('mb', 0) / read_time if read_time > 0 else 0
+    output.append(f"  Total Time:       {read_time:.3f} s")
+    output.append(f"  Bandwidth:        {read_mbps:.2f} MB/s")
+    output.append(f"  Latency:")
+    output.append(f"    Avg:            {read_stats.get('avg_ms', 0):.3f} ms")
+    output.append(f"    P50:            {read_stats.get('p50_ms', 0):.3f} ms")
+    output.append(f"    P95:            {read_stats.get('p95_ms', 0):.3f} ms")
+    output.append(f"    P99:            {read_stats.get('p99_ms', 0):.3f} ms")
+
+    # Write Stats
+    output.append(f"\n[Write Operations]")
+    output.append(f"  Count:            {write_stats.get('count', 0):,}")
+    output.append(f"  Data Volume:      {write_stats.get('mb', 0):.2f} MB")
+    write_time = write_stats.get('time_s', 0)
+    write_mbps = write_stats.get('mb', 0) / write_time if write_time > 0 else 0
+    output.append(f"  Total Time:       {write_time:.3f} s")
+    output.append(f"  Bandwidth:        {write_mbps:.2f} MB/s")
+    output.append(f"  Latency:")
+    output.append(f"    Avg:            {write_stats.get('avg_ms', 0):.3f} ms")
+    output.append(f"    P50:            {write_stats.get('p50_ms', 0):.3f} ms")
+    output.append(f"    P95:            {write_stats.get('p95_ms', 0):.3f} ms")
+    output.append(f"    P99:            {write_stats.get('p99_ms', 0):.3f} ms")
+
+    # Storage Info
+    output.append(f"\n[Storage Info]")
+    output.append(f"  Max Pages:        {storage.get('max_pages', 0):,}")
+    output.append(f"  Written Pages:    {storage.get('written_pages', 0):,}")
+    output.append(f"  Sync Count:       {storage.get('sync_count', 0):,}")
+
+    return "\n".join(output)
+
+
 def print_results(results: List[Dict]):
     """Print benchmark results"""
     for i, r in enumerate(results, 1):
         print(f"\n{'='*80}")
         print(f"  [{i}/{len(results)}] {r['trace_file']}")
         print(f"{'='*80}")
-
-        print(f"\n[Performance]")
-        print(f"  Model:           {r.get('model', 'N/A')}")
-        print(f"  Requests:        {r['total_requests']:,}")
-        print(f"  Tokens:          {r.get('total_tokens', 0):,}")
-        print(f"  QPS:             {r['requests_per_second']:.2f}")
-        print(f"  Hit Rate:        {r['page_hit_rate']:.2%}")
-
-        latency = r.get('latency', {})
-        print(f"\n[Latency]")
-        print(f"  Avg:  {latency.get('avg_ms', 0):.3f} ms")
-        print(f"  P50:  {latency.get('p50_ms', 0):.3f} ms")
-        print(f"  P95:  {latency.get('p95_ms', 0):.3f} ms")
-        print(f"  P99:  {latency.get('p99_ms', 0):.3f} ms")
-
-        storage = r.get('storage', {})
-        print(f"\n[Storage]")
-        print(f"  Read:  {storage.get('read', {}).get('count', 0):,} ops ({storage.get('read', {}).get('mb', 0):.2f} MB)")
-        print(f"  Write: {storage.get('write', {}).get('count', 0):,} ops ({storage.get('write', {}).get('mb', 0):.2f} MB)")
+        print(format_storage_stats(r))
 
 
 # ============================================================================
@@ -357,11 +428,11 @@ def main():
                        help='Storage directory')
     parser.add_argument('--model', type=str, default='glm5', choices=['glm5', 'kimi-k2.6'],
                        help='Model preset')
-    parser.add_argument('--page-size-tokens', type=int, default=64,
-                       help='Page size in tokens (default: 64)')
+    parser.add_argument('--page-size-tokens', type=int, default=512,
+                       help='Page size in tokens (default: 512)')
     parser.add_argument('--max-requests', type=int, default=None,
                        help='Maximum number of requests')
-    parser.add_argument('--max-pages', type=int, default=100000,
+    parser.add_argument('--max-pages', type=int, default=2000,
                        help='Maximum number of pages')
     parser.add_argument('--fsync-mode', type=str, choices=['batch', 'always', 'end', 'none'],
                        default='none', help='When to fsync')
@@ -397,8 +468,6 @@ def main():
                 args.max_requests,
                 args.max_pages,
                 args.page_size_tokens,
-                False,
-                1.0,
                 args.fsync_mode,
                 args.fsync_batch_size
             )
@@ -406,7 +475,6 @@ def main():
         else:
             print(f"Warning: Trace file not found: {trace_path}")
 
-    # Print results
     # Print results
     if results:
         print_results(results)

--- a/benchmarks/storage_benchmark_v1/benchmark.py
+++ b/benchmarks/storage_benchmark_v1/benchmark.py
@@ -1,0 +1,411 @@
+#!/usr/bin/env python3
+"""
+Mooncake KVCache Storage Benchmark
+
+Complete benchmark tool with CLI interface.
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+import statistics
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator, List, Dict, Any
+
+from storage import SSDStorage
+from layout import KVLayout, get_model_config, create_layout
+
+
+# ============================================================================
+# Data Structures
+# ============================================================================
+
+@dataclass
+class KVCacheRequest:
+    """KVCache request"""
+    timestamp: float
+    hash_ids: List[int]
+    input_length: int
+    output_length: int
+
+
+# ============================================================================
+# Trace Replay
+# ============================================================================
+
+class TraceReplay:
+    """Trace replay handler"""
+
+    def __init__(self, trace_path: str):
+        self.trace_path = trace_path
+
+    def replay(self) -> Iterator[dict]:
+        """Replay trace workload"""
+        with open(self.trace_path, 'r') as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    yield json.loads(line)
+
+    def load_all(self) -> List[KVCacheRequest]:
+        """Load all requests"""
+        return [
+            KVCacheRequest(
+                timestamp=req.get('timestamp', 0),
+                hash_ids=req.get('hash_ids', []),
+                input_length=req.get('input_length', 0),
+                output_length=req.get('output_length', 0),
+            )
+            for req in self.replay()
+        ]
+
+
+# ============================================================================
+# Storage Benchmark
+# ============================================================================
+
+class StorageBenchmark:
+    """KVCache storage benchmark
+
+    Uses KVLayout interface to support different architectures.
+    - MLA: Each (sequence_id, layer_id) pair maps to ONE complete entry
+    - Future: Other architectures can be added by implementing KVLayout
+    """
+
+    def __init__(self, storage_dir: str, model_config: dict = None,
+                 layout: KVLayout = None,
+                 page_size_tokens: int = 64,
+                 max_pages: int = 100000,
+                 fsync_mode: str = 'none', fsync_batch_size: int = 100):
+        """Initialize benchmark
+
+        Args:
+            storage_dir: Directory for storage files
+            model_config: Model configuration dict (used if layout not provided)
+            layout: KVLayout instance (overrides model_config if provided)
+            page_size_tokens: Tokens per page (default 64)
+            max_pages: Maximum number of pages to store
+            fsync_mode: When to fsync ('none', 'batch', 'always', 'end')
+            fsync_batch_size: Number of writes between fsync in batch mode
+        """
+        if layout is None:
+            if model_config is None:
+                # Use default model config
+                model_config = get_model_config("glm5")
+            self.model_config = model_config
+            self.layout = create_layout(model_config, page_size_tokens)
+        else:
+            self.layout = layout
+            self.model_config = model_config or {}
+
+        # Get layout metadata
+        self.num_layers = self._get_num_layers()
+        self.has_indexer = self._get_has_indexer()
+
+        # Get page size from layout
+        # All KVLayout implementations must provide value_size_bytes
+        self.page_size_bytes = self.layout.value_size_bytes
+
+        # Initialize storage
+        self.storage = SSDStorage(
+            storage_dir=storage_dir,
+            page_size=self.page_size_bytes,
+            max_pages=max_pages,
+            fsync_mode=fsync_mode,
+            fsync_batch_size=fsync_batch_size
+        )
+
+        # Statistics
+        self.stats = {
+            'total_requests': 0,
+            'total_tokens': 0,
+            'read_pages': 0,
+            'write_pages': 0,
+            'page_hits': 0,
+            'request_latencies_ms': [],
+        }
+
+    def _get_num_layers(self) -> int:
+        """Get number of layers from layout or config"""
+        # For MLA layout, we can get this from the layout instance
+        if hasattr(self.layout, 'num_layers'):
+            return self.layout.num_layers
+        return self.model_config.get('num_layers', 0)
+
+    def _get_has_indexer(self) -> bool:
+        """Check if layout uses indexer"""
+        if hasattr(self.layout, 'index_head_dim'):
+            return self.layout.index_head_dim > 0
+        return self.model_config.get('index_head_dim', 0) > 0
+
+    def process_request(self, req: KVCacheRequest) -> float:
+        """Process a KVCache request using the layout interface"""
+        self.stats['total_requests'] += 1
+
+        total_tokens = req.input_length + req.output_length
+        self.stats['total_tokens'] += total_tokens
+
+        start_time = time.perf_counter()
+        total_latency = 0.0
+        io_operations = 0
+
+        # Use layout to generate keys for this request
+        for entry in self.layout.get_entries(req):
+            # Convert KVKey to tuple for storage (storage uses tuple keys internally)
+            key = (entry.key.sequence_id, entry.key.layer_id)
+
+            if self.storage.exists(key):
+                latency = self.storage.read(key)
+                if latency > 0:  # Only count successful reads
+                    total_latency += latency
+                    io_operations += 1
+                self.stats['read_pages'] += 1
+                self.stats['page_hits'] += 1
+            else:
+                latency = self.storage.write(key)
+                total_latency += latency
+                io_operations += 1
+                self.stats['write_pages'] += 1
+
+        # Only record latency if we actually performed IO operations
+        if io_operations > 0 and total_latency > 0:
+            latency_ms = total_latency
+        else:
+            latency_ms = 0.0
+
+        if latency_ms > 0:
+            self.stats['request_latencies_ms'].append(latency_ms)
+        return latency_ms
+
+    def get_stats(self) -> Dict:
+        """Get statistics"""
+        storage_stats = self.storage.get_stats()
+        request_latencies = self.stats['request_latencies_ms']
+
+        if request_latencies:
+            sorted_latencies = sorted(request_latencies)
+            n = len(sorted_latencies)
+
+            def get_percentile(p: float) -> float:
+                idx = int(n * p)
+                return sorted_latencies[idx] if idx < n else sorted_latencies[-1]
+
+            latency_stats = {
+                'avg_ms': statistics.mean(request_latencies),
+                'p50_ms': sorted_latencies[n // 2],
+                'p95_ms': get_percentile(0.95),
+                'p99_ms': get_percentile(0.99),
+            }
+        else:
+            latency_stats = {'avg_ms': 0, 'p50_ms': 0, 'p95_ms': 0, 'p99_ms': 0}
+
+        total_pages = self.stats['read_pages'] + self.stats['write_pages']
+
+        return {
+            'total_requests': self.stats['total_requests'],
+            'total_tokens': self.stats['total_tokens'],
+            'total_pages': total_pages,
+            'read_pages': self.stats['read_pages'],
+            'write_pages': self.stats['write_pages'],
+            'page_hits': self.stats['page_hits'],
+            'page_hit_rate': self.stats['read_pages'] / total_pages if total_pages > 0 else 0,
+            'write_ratio': self.stats['write_pages'] / total_pages if total_pages > 0 else 0,
+            'num_layers': self.num_layers,
+            'has_indexer': self.has_indexer,
+            'latency': latency_stats,
+            'storage': storage_stats,
+        }
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+        return False
+
+    def close(self, force_sync: bool = True):
+        self.storage.close(force_sync=force_sync)
+
+
+# ============================================================================
+# Benchmark Runner
+# ============================================================================
+
+def run_benchmark(trace_path: str, storage_dir: str, model_config: dict,
+                  max_requests: int = None, max_pages: int = 100000,
+                  page_size_tokens: int = 64,
+                  replay_timestamps: bool = False, time_scale: float = 1.0,
+                  fsync_mode: str = 'none', fsync_batch_size: int = 100) -> Dict:
+    """Run benchmark"""
+    print(f"\n{'='*80}")
+    print(f"Running: {Path(trace_path).name}")
+    print(f"Model: {model_config['name']}")
+    print(f"Layers: {model_config['num_layers']}")
+    print(f"Page size: {page_size_tokens} tokens")
+    print(f"{'='*80}")
+
+    # Load trace
+    replay = TraceReplay(trace_path)
+    requests = replay.load_all()
+
+    if max_requests:
+        requests = requests[:max_requests]
+
+    print(f"Loaded {len(requests)} requests")
+
+    # Run benchmark
+    with StorageBenchmark(
+        storage_dir=storage_dir,
+        model_config=model_config,
+        page_size_tokens=page_size_tokens,
+        max_pages=max_pages,
+        fsync_mode=fsync_mode,
+        fsync_batch_size=fsync_batch_size
+    ) as benchmark:
+
+        start_time = time.perf_counter()
+        total_io_time = 0.0
+        last_timestamp = None
+
+        for i, req in enumerate(requests):
+            if replay_timestamps and last_timestamp is not None:
+                delta_ms = req.timestamp - last_timestamp
+                sleep_time = delta_ms / 1000.0 / time_scale
+                if sleep_time > 0:
+                    time.sleep(sleep_time)
+
+            req_start = time.perf_counter()
+            benchmark.process_request(req)
+            req_io_time = time.perf_counter() - req_start
+            total_io_time += req_io_time
+
+            last_timestamp = req.timestamp
+
+            if (i + 1) % 100 == 0:
+                print(f"  Processed {i + 1}/{len(requests)}...")
+
+        elapsed = time.perf_counter() - start_time
+        stats = benchmark.get_stats()
+
+    io_time = total_io_time if replay_timestamps else elapsed
+
+    return {
+        'trace_file': Path(trace_path).name,
+        'total_requests': len(requests),
+        'io_time_s': io_time,
+        'requests_per_second': len(requests) / io_time if io_time > 0 else 0,
+        'model': model_config['name'],
+        'fsync_mode': fsync_mode,
+        **stats,
+    }
+
+
+# ============================================================================
+# Output Formatting
+# ============================================================================
+
+def print_results(results: List[Dict]):
+    """Print benchmark results"""
+    for i, r in enumerate(results, 1):
+        print(f"\n{'='*80}")
+        print(f"  [{i}/{len(results)}] {r['trace_file']}")
+        print(f"{'='*80}")
+
+        print(f"\n[Performance]")
+        print(f"  Model:           {r.get('model', 'N/A')}")
+        print(f"  Requests:        {r['total_requests']:,}")
+        print(f"  Tokens:          {r.get('total_tokens', 0):,}")
+        print(f"  QPS:             {r['requests_per_second']:.2f}")
+        print(f"  Hit Rate:        {r['page_hit_rate']:.2%}")
+
+        latency = r.get('latency', {})
+        print(f"\n[Latency]")
+        print(f"  Avg:  {latency.get('avg_ms', 0):.3f} ms")
+        print(f"  P50:  {latency.get('p50_ms', 0):.3f} ms")
+        print(f"  P95:  {latency.get('p95_ms', 0):.3f} ms")
+        print(f"  P99:  {latency.get('p99_ms', 0):.3f} ms")
+
+        storage = r.get('storage', {})
+        print(f"\n[Storage]")
+        print(f"  Read:  {storage.get('read', {}).get('count', 0):,} ops ({storage.get('read', {}).get('mb', 0):.2f} MB)")
+        print(f"  Write: {storage.get('write', {}).get('count', 0):,} ops ({storage.get('write', {}).get('mb', 0):.2f} MB)")
+
+
+# ============================================================================
+# CLI Entry Point
+# ============================================================================
+
+def main():
+    """Main entry point"""
+    parser = argparse.ArgumentParser(
+        description='Mooncake KVCache Storage Benchmark',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    parser.add_argument('--trace-dir', type=str, default='../../FAST25-release/traces',
+                       help='Trace files directory')
+    parser.add_argument('--scenario', type=str, choices=['conversation', 'synthetic', 'toolagent', 'all'],
+                       default='toolagent', help='Test scenario')
+    parser.add_argument('--storage-dir', type=str, default='/tmp/mooncake_bench',
+                       help='Storage directory')
+    parser.add_argument('--model', type=str, default='glm5', choices=['glm5', 'kimi-k2.6'],
+                       help='Model preset')
+    parser.add_argument('--page-size-tokens', type=int, default=64,
+                       help='Page size in tokens (default: 64)')
+    parser.add_argument('--max-requests', type=int, default=None,
+                       help='Maximum number of requests')
+    parser.add_argument('--max-pages', type=int, default=100000,
+                       help='Maximum number of pages')
+    parser.add_argument('--fsync-mode', type=str, choices=['batch', 'always', 'end', 'none'],
+                       default='none', help='When to fsync')
+    parser.add_argument('--fsync-batch-size', type=int, default=100,
+                       help='Number of writes between fsync')
+
+    args = parser.parse_args()
+
+    print(f"\n{'='*80}")
+    print(f"{'Mooncake KVCache Storage Benchmark':^80}")
+    print(f"{'='*80}")
+
+    model_config = get_model_config(args.model)
+    print(f"Model: {args.model} ({model_config['num_layers']} layers)")
+
+    # Determine scenarios
+    scenarios = ['conversation', 'synthetic', 'toolagent'] if args.scenario == 'all' else [args.scenario]
+    trace_files = {
+        'conversation': 'conversation_trace.jsonl',
+        'synthetic': 'synthetic_trace.jsonl',
+        'toolagent': 'toolagent_trace.jsonl'
+    }
+
+    # Run benchmarks
+    results = []
+    for scenario in scenarios:
+        trace_path = Path(args.trace_dir) / trace_files[scenario]
+        if trace_path.exists():
+            result = run_benchmark(
+                str(trace_path),
+                str(Path(args.storage_dir) / scenario),
+                model_config,
+                args.max_requests,
+                args.max_pages,
+                args.page_size_tokens,
+                False,
+                1.0,
+                args.fsync_mode,
+                args.fsync_batch_size
+            )
+            results.append(result)
+        else:
+            print(f"Warning: Trace file not found: {trace_path}")
+
+    # Print results
+    if results:
+        print_results(results)
+
+
+if __name__ == '__main__':
+    main()

--- a/benchmarks/storage_benchmark_v1/benchmark.py
+++ b/benchmarks/storage_benchmark_v1/benchmark.py
@@ -44,7 +44,7 @@ class TraceReplay:
 
     def replay(self) -> Iterator[dict]:
         """Replay trace workload"""
-        with open(self.trace_path, 'r') as f:
+        with open(self.trace_path, 'r', encoding='utf-8') as f:
             for line in f:
                 line = line.strip()
                 if line:
@@ -154,18 +154,22 @@ class StorageBenchmark:
 
         # Use layout to generate keys for this request
         for entry in self.layout.get_entries(req):
-            # Convert KVKey to tuple for storage (storage uses tuple keys internally)
-            key = (entry.key.sequence_id, entry.key.layer_id)
-
+            key = entry.key
             if self.storage.exists(key):
-                latency = self.storage.read(key)
-                if latency > 0:  # Only count successful reads
+                start_io = time.perf_counter()
+                val = self.storage.get(key)
+                latency = (time.perf_counter() - start_io) * 1000.0
+                if val is not None:
                     total_latency += latency
                     io_operations += 1
                 self.stats['read_pages'] += 1
                 self.stats['page_hits'] += 1
             else:
-                latency = self.storage.write(key)
+                from storage.interface import KVValue
+                dummy_value = KVValue(data=bytes(entry.value_size_bytes), page_count=1, token_count=self.layout.page_size_tokens)
+                start_io = time.perf_counter()
+                self.storage.put(key, dummy_value)
+                latency = (time.perf_counter() - start_io) * 1000.0
                 total_latency += latency
                 io_operations += 1
                 self.stats['write_pages'] += 1
@@ -403,9 +407,12 @@ def main():
             print(f"Warning: Trace file not found: {trace_path}")
 
     # Print results
+    # Print results
     if results:
         print_results(results)
-
+    else:
+        print("Error: No trace files were successfully processed.", file=sys.stderr)
+        sys.exit(1)
 
 if __name__ == '__main__':
     main()

--- a/benchmarks/storage_benchmark_v1/doc/README.md
+++ b/benchmarks/storage_benchmark_v1/doc/README.md
@@ -1,0 +1,120 @@
+# KVCache Storage Benchmark v1
+
+## Overview
+
+The KVCache Storage Benchmark is a tool for evaluating storage performance of KVCache workloads. It simulates real-world cache access patterns using trace replay and measures storage I/O performance with detailed statistics.
+
+## Usage
+
+### Basic Usage
+
+```bash
+python benchmark.py --scenario conversation \
+                    --trace-dir /path/to/Mooncake/FAST25-release/traces \
+                    --storage-dir /path/to/test/drive
+```
+
+### Command Line Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--trace-dir` | `../../FAST25-release/traces` | Directory containing trace files |
+| `--scenario` | `toolagent` | Test scenario: `conversation`, `synthetic`, `toolagent`, or `all` |
+| `--storage-dir` | `/tmp/mooncake_bench` | Directory for storage files |
+| `--model` | `glm5` | Model preset: `glm5` or `kimi-k2.6` |
+| `--page-size-tokens` | `512` | Page size in tokens |
+| `--max-requests` | `None` | Maximum number of requests to process |
+| `--max-pages` | `2000` | Maximum number of pages (creates modulo mapping if trace is larger) |
+| `--fsync-mode` | `none` | When to fsync: `none`, `batch`, `always` |
+| `--fsync-batch-size` | `100` | Number of writes between fsync in batch mode |
+
+## Output Format
+
+### Progress Output
+
+During execution, each request displays real-time statistics:
+
+```
+[    10/12031] ids= 35 tokens= 18060 | QPS=   2.45 | R=    36 ( 22.01ms, 2435.2MB/s) | W=   963 ( 19.35ms, 2770.1MB/s)
+```
+
+Fields:
+- `[N/Total]`: Current request progress
+- `ids=N`: Number of hash_ids in this request
+- `tokens=N`: Total tokens (input + output)
+- `QPS=X`: Queries per second (overall)
+- `R=N (latency, bandwidth)`: Read count, average latency, bandwidth
+- `W=N (latency, bandwidth)`: Write count, average latency, bandwidth
+
+### Final Results
+
+```
+================================================================================
+  [1/1] toolagent_trace.jsonl
+================================================================================
+
+[General]
+  Model:            glm5
+  Requests:         12031
+  Tokens:           123456789
+  Total I/O Time:   245.123 s
+  QPS:              49.07
+  Hit Rate:         3.25%
+
+[Read Operations]
+  Count:            390
+  Data Volume:      20919.62 MB
+  Total Time:       8.590 s
+  Bandwidth:         2435.67 MB/s
+  Latency:
+    Avg:             22.032 ms
+    P50:             21.456 ms
+    P95:             28.912 ms
+    P99:             35.234 ms
+
+[Write Operations]
+  Count:            11641
+  Data Volume:      654321.45 MB
+  Total Time:       236.533 s
+  Bandwidth:         2765.89 MB/s
+  Latency:
+    Avg:             20.312 ms
+    P50:             19.876 ms
+    P95:             25.123 ms
+    P99:             31.456 ms
+
+[Storage Info]
+  Max Pages:        2000
+  Written Pages:    2000
+  Sync Count:       0
+```
+
+## Modulo Mapping
+
+When the trace requires more pages than `--max-pages`, modulo mapping is enabled:
+
+```
+physical_page_id = logical_page_id % max_pages
+```
+
+This allows simulating large traces (millions of pages) with limited storage (thousands of pages). The first-hit/read-then-write logic is preserved by tracking written logical pages in memory.
+
+**Example**: With `--max-pages 2000`, logical page IDs 0-1999 map directly to physical pages 0-1999. Logical page 2000 maps to physical page 0, logical page 2001 maps to physical page 1, etc.
+
+## Graceful Interruption
+
+Press `Ctrl-C` at any time to stop the benchmark and view partial results. The output will display all statistics collected up to the interruption point, using the same format as final results.
+
+## Troubleshooting
+
+### Insufficient Storage Warning
+```
+⚠️  Modulo mapping ENABLED (limited storage)
+⚠️  Storage insufficient: 14,257,620 pages shortfall (762.34 GB)
+```
+Increase `--max-pages` to reduce modulo mapping effects.
+
+### Low Bandwidth or High Latency
+- Check fsync mode (`--fsync-mode none` for best performance)
+- Verify disk performance with `fio` or `dd`
+- Verify storage device health

--- a/benchmarks/storage_benchmark_v1/layout/__init__.py
+++ b/benchmarks/storage_benchmark_v1/layout/__init__.py
@@ -4,13 +4,13 @@ KVCache Layout Module
 Provides layout interface and implementations for different model architectures.
 """
 
-from .interface import KVLayout
-from .mla import MLALayout, KVEntry, MLA_MODEL_CONFIG, get_model_config, create_layout
+from .interface import KVLayout, StorageAccess
+from .mla import MLALayout, MLA_MODEL_CONFIG, get_model_config, create_layout
 
 __all__ = [
     'KVLayout',
+    'StorageAccess',
     'MLALayout',
-    'KVEntry',
     'MLA_MODEL_CONFIG',
     'get_model_config',
     'create_layout',

--- a/benchmarks/storage_benchmark_v1/layout/__init__.py
+++ b/benchmarks/storage_benchmark_v1/layout/__init__.py
@@ -1,0 +1,17 @@
+"""
+KVCache Layout Module
+
+Provides layout interface and implementations for different model architectures.
+"""
+
+from .interface import KVLayout
+from .mla import MLALayout, KVEntry, MLA_MODEL_CONFIG, get_model_config, create_layout
+
+__all__ = [
+    'KVLayout',
+    'MLALayout',
+    'KVEntry',
+    'MLA_MODEL_CONFIG',
+    'get_model_config',
+    'create_layout',
+]

--- a/benchmarks/storage_benchmark_v1/layout/interface.py
+++ b/benchmarks/storage_benchmark_v1/layout/interface.py
@@ -2,63 +2,54 @@
 KVCache Layout Interface
 
 Defines the abstract interface for KVCache storage layouts.
+Layout layer converts normalized requests into storage access requirements.
 """
 
 from abc import ABC, abstractmethod
 from typing import Iterator, Any
+from dataclasses import dataclass
 
-from storage.interface import KVKey
 
+@dataclass
+class StorageAccess:
+    """Storage access requirement
+
+    Represents a need to access a page. Whether to READ or WRITE is determined
+    by the upper layer based on whether the page already exists.
+    """
+    page_id: int             # Page ID (hash_id from trace)
+    offset_in_page: int = 0  # Offset within the page (default: 0)
+    length: int = None       # Number of bytes (default: entire page)
+
+    def __repr__(self):
+        if self.offset_in_page == 0 and self.length is None:
+            return f"Access(page_id={self.page_id})"
+        else:
+            return f"Access(page_id={self.page_id}, offset={self.offset_in_page}, length={self.length})"
 
 
 class KVLayout(ABC):
     """Abstract interface for KVCache storage layout
 
-    Different model architectures have different KVCache access patterns.
-    This captures both key generation and value sizing.
+    Converts normalized KVCache requests into storage access requirements.
+
+    Request format:
+        - hash_ids: List[int] - chunk/page identifiers
+        - input_length: int - input token count
+        - output_length: int - output token count
+
+    Output:
+        - Iterator of StorageAccess (page access requirements)
     """
 
     @abstractmethod
-    def get_entries(self, request: Any) -> Iterator:
-        """Generate storage entries for a request
+    def get_operations(self, request: Any) -> Iterator[StorageAccess]:
+        """Generate storage access requirements for a request
 
         Args:
             request: KVCache request with hash_ids, input_length, output_length
 
         Yields:
-            KVEntry: Each entry with key and value size
-        """
-        pass
-
-    @abstractmethod
-    def get_key_count(self, request: Any) -> int:
-        """Get the total number of keys for a request
-
-        Args:
-            request: KVCache request
-
-        Returns:
-            int: Total number of storage keys
-        """
-        pass
-
-    @abstractmethod
-    def get_value_size(self, key: KVKey) -> int:
-        """Get value size for a given key
-
-        Args:
-            key: KVKey
-
-        Returns:
-            int: Value size in bytes
-        """
-        pass
-
-    @abstractmethod
-    def keys_per_layer(self) -> int:
-        """Number of keys per (sequence, layer) pair
-
-        Returns:
-            int: Keys per layer
+            StorageAccess: Page access requirements (READ vs WRITE decided by upper layer)
         """
         pass

--- a/benchmarks/storage_benchmark_v1/layout/interface.py
+++ b/benchmarks/storage_benchmark_v1/layout/interface.py
@@ -1,0 +1,64 @@
+"""
+KVCache Layout Interface
+
+Defines the abstract interface for KVCache storage layouts.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Iterator, Any
+
+from storage.interface import KVKey
+
+
+
+class KVLayout(ABC):
+    """Abstract interface for KVCache storage layout
+
+    Different model architectures have different KVCache access patterns.
+    This captures both key generation and value sizing.
+    """
+
+    @abstractmethod
+    def get_entries(self, request: Any) -> Iterator:
+        """Generate storage entries for a request
+
+        Args:
+            request: KVCache request with hash_ids, input_length, output_length
+
+        Yields:
+            KVEntry: Each entry with key and value size
+        """
+        pass
+
+    @abstractmethod
+    def get_key_count(self, request: Any) -> int:
+        """Get the total number of keys for a request
+
+        Args:
+            request: KVCache request
+
+        Returns:
+            int: Total number of storage keys
+        """
+        pass
+
+    @abstractmethod
+    def get_value_size(self, key: KVKey) -> int:
+        """Get value size for a given key
+
+        Args:
+            key: KVKey
+
+        Returns:
+            int: Value size in bytes
+        """
+        pass
+
+    @abstractmethod
+    def keys_per_layer(self) -> int:
+        """Number of keys per (sequence, layer) pair
+
+        Returns:
+            int: Keys per layer
+        """
+        pass

--- a/benchmarks/storage_benchmark_v1/layout/mla.py
+++ b/benchmarks/storage_benchmark_v1/layout/mla.py
@@ -4,11 +4,9 @@ MLA (Multi-head Latent Attention) KVCache Layout
 Implements the KVLayout interface for MLA architecture.
 """
 
-from typing import Iterator, Any, Dict
-from dataclasses import dataclass
+from typing import Iterator, Any
 
-from .interface import KVLayout
-from storage.interface import KVKey
+from .interface import KVLayout, StorageAccess
 
 
 # ============================================================================
@@ -47,38 +45,31 @@ MLA_MODEL_CONFIG = {
 }
 
 
-@dataclass
-class KVEntry:
-    """Key-value entry for storage
-
-    Contains both the key and the value size information.
-    """
-    key: KVKey
-    value_size_bytes: int
-
-
 class MLALayout(KVLayout):
     """MLA (Multi-head Latent Attention) KVCache layout
 
     MLA Architecture:
-    - Each (sequence_id, layer_id) pair maps to ONE complete entry
-    - Entry contains KV + Indexer data for up to 64 tokens in that layer
-    - Value size is fixed per layer
+    - Each hash_id corresponds to a 512-token chunk
+    - Each hash_id maps to ONE complete entry containing all layers
+    - Entry contains KV + Indexer data for all layers for 512 tokens
+    - Value size is fixed per hash_id (includes all layers)
 
-    Value Size Calculation (per layer entry):
-        value_size = page_size_tokens × (kv_lora_rank + qk_rope_head_dim + index_head_dim) × precision_bytes
+    Value Size Calculation (per hash_id entry):
+        per_layer_size = 512 × (kv_lora_rank + qk_rope_head_dim + index_head_dim) × precision_bytes
+        value_size = per_layer_size × num_layers
 
-    For GLM-5 with 64 tokens per entry:
-        value_size = 64 × (512 + 64 + 128) × 2 = 90,112 bytes = 88 KiB
+    For GLM-5 with 512 tokens per entry:
+        per_layer_size = 512 × (512 + 64 + 128) × 2 = 720,896 bytes
+        value_size = 720,896 × 78 = 56,229,888 bytes = 53.6 MiB
 
-    Key Pattern: (sequence_id, layer_id)
-    Total Keys = len(hash_ids) × num_layers
+    Key Pattern: hash_id → single entry (all layers included)
+    Total Keys = len(hash_ids)
 
     Used in: GLM-5, Kimi-K2.6
     """
 
     def __init__(self, num_layers: int, kv_lora_rank: int, qk_rope_head_dim: int,
-                 index_head_dim: int, precision_bytes: int, page_size_tokens: int = 64):
+                 index_head_dim: int, precision_bytes: int, page_size_tokens: int = 512):
         """Initialize MLA layout
 
         Args:
@@ -87,7 +78,7 @@ class MLALayout(KVLayout):
             qk_rope_head_dim: QK rope head dimension
             index_head_dim: Indexer head dimension
             precision_bytes: Precision in bytes (BF16=2, INT8=1, INT4=0.5)
-            page_size_tokens: Tokens per page (default 64)
+            page_size_tokens: Tokens per page (default: 512)
         """
         self.num_layers = num_layers
         self.kv_lora_rank = kv_lora_rank
@@ -96,50 +87,35 @@ class MLALayout(KVLayout):
         self.precision_bytes = precision_bytes
         self.page_size_tokens = page_size_tokens
 
-        # Calculate fixed value size per entry (per layer)
-        # Each entry contains KV + Indexer for 64 tokens in that layer
-        self.value_size_bytes = (
-            page_size_tokens *
-            (kv_lora_rank + qk_rope_head_dim + index_head_dim) *
-            precision_bytes
-        )
+        # Calculate fixed value size per entry (per hash_id)
+        # Each entry contains KV + Indexer for all layers for page_size_tokens
+        # Per layer: page_size_tokens × (kv_lora_rank + qk_rope_head_dim + index_head_dim) × precision_bytes
+        # Total: per_layer_size × num_layers
+        per_layer_size = page_size_tokens * (kv_lora_rank + qk_rope_head_dim + index_head_dim) * precision_bytes
+        self.value_size_bytes = per_layer_size * num_layers
 
-    def get_entries(self, request: Any) -> Iterator[KVEntry]:
-        """Generate MLA storage entries
+        # Store page_size for backward compatibility
+        self.page_size = self.value_size_bytes
 
-        For each sequence_id in hash_ids, generate one entry per layer.
+    def get_operations(self, request: Any) -> Iterator[StorageAccess]:
+        """Generate storage access requirements for a request
+
+        For MLA architecture:
+        - Each hash_id corresponds to one complete page (512 tokens, all layers)
+        - Generate one access requirement per hash_id
+
+        Args:
+            request: KVCache request with hash_ids, input_length, output_length
 
         Yields:
-            KVEntry: (key, value_size) for each layer
+            StorageAccess: Page access requirements
         """
-        for sequence_id in request.hash_ids:
-            for layer_id in range(self.num_layers):
-                yield KVEntry(
-                    key=KVKey(sequence_id=sequence_id, layer_id=layer_id),
-                    value_size_bytes=self.value_size_bytes
-                )
-
-    def get_key_count(self, request: Any) -> int:
-        """Total keys for MLA request
-
-        Returns:
-            int: len(hash_ids) × num_layers
-        """
-        return len(request.hash_ids) * self.num_layers
-
-    def get_value_size(self, key: KVKey) -> int:
-        """Get value size for MLA entry
-
-        All MLA entries have the same size.
-
-        Returns:
-            int: Value size in bytes
-        """
-        return self.value_size_bytes
-
-    def keys_per_layer(self) -> int:
-        """MLA has 1 key per (sequence, layer)"""
-        return 1
+        for hash_id in request.hash_ids:
+            yield StorageAccess(
+                page_id=hash_id,
+                offset_in_page=0,
+                length=self.value_size_bytes
+            )
 
 
 # ============================================================================

--- a/benchmarks/storage_benchmark_v1/layout/mla.py
+++ b/benchmarks/storage_benchmark_v1/layout/mla.py
@@ -1,0 +1,198 @@
+"""
+MLA (Multi-head Latent Attention) KVCache Layout
+
+Implements the KVLayout interface for MLA architecture.
+"""
+
+from typing import Iterator, Any, Dict
+from dataclasses import dataclass
+
+from .interface import KVLayout
+from storage.interface import KVKey
+
+
+# ============================================================================
+# MLA Model Configurations
+# ============================================================================
+
+# MLA Model configurations
+# Source: https://kvcache.ai/tools/kv-cache-calculator/
+# MLA architecture: hash_id -> {layer_0: [pages], layer_1: [pages], ...}
+MLA_MODEL_CONFIG = {
+    # GLM-5: 78 layers, 64 tokens/page
+    # KV: 78 layers × 64 tokens × (512+64+128) × 2 = 90,112 bytes/page
+    # Per token: 1,408 bytes
+    "glm5": {
+        "name": "glm5",
+        "num_layers": 78,
+        "kv_lora_rank": 512,
+        "qk_rope_head_dim": 64,
+        "index_head_dim": 128,
+        "kv_precision_bytes": 2,  # BF16
+        "indexer_precision_bytes": 2,  # BF16
+    },
+
+    # Kimi-K2.6: 61 layers, 64 tokens/page
+    # KV: 61 layers × 64 tokens × (512+64) × 2 = 73,728 bytes/page
+    # Per token: 1,152 bytes
+    "kimi-k2.6": {
+        "name": "kimi-k2.6",
+        "num_layers": 61,
+        "kv_lora_rank": 512,
+        "qk_rope_head_dim": 64,
+        "index_head_dim": 0,  # Kimi doesn't use separate indexer
+        "kv_precision_bytes": 2,  # BF16
+        "indexer_precision_bytes": 0,
+    },
+}
+
+
+@dataclass
+class KVEntry:
+    """Key-value entry for storage
+
+    Contains both the key and the value size information.
+    """
+    key: KVKey
+    value_size_bytes: int
+
+
+class MLALayout(KVLayout):
+    """MLA (Multi-head Latent Attention) KVCache layout
+
+    MLA Architecture:
+    - Each (sequence_id, layer_id) pair maps to ONE complete entry
+    - Entry contains KV + Indexer data for up to 64 tokens in that layer
+    - Value size is fixed per layer
+
+    Value Size Calculation (per layer entry):
+        value_size = page_size_tokens × (kv_lora_rank + qk_rope_head_dim + index_head_dim) × precision_bytes
+
+    For GLM-5 with 64 tokens per entry:
+        value_size = 64 × (512 + 64 + 128) × 2 = 90,112 bytes = 88 KiB
+
+    Key Pattern: (sequence_id, layer_id)
+    Total Keys = len(hash_ids) × num_layers
+
+    Used in: GLM-5, Kimi-K2.6
+    """
+
+    def __init__(self, num_layers: int, kv_lora_rank: int, qk_rope_head_dim: int,
+                 index_head_dim: int, precision_bytes: int, page_size_tokens: int = 64):
+        """Initialize MLA layout
+
+        Args:
+            num_layers: Number of transformer layers
+            kv_lora_rank: KV LoRA rank dimension
+            qk_rope_head_dim: QK rope head dimension
+            index_head_dim: Indexer head dimension
+            precision_bytes: Precision in bytes (BF16=2, INT8=1, INT4=0.5)
+            page_size_tokens: Tokens per page (default 64)
+        """
+        self.num_layers = num_layers
+        self.kv_lora_rank = kv_lora_rank
+        self.qk_rope_head_dim = qk_rope_head_dim
+        self.index_head_dim = index_head_dim
+        self.precision_bytes = precision_bytes
+        self.page_size_tokens = page_size_tokens
+
+        # Calculate fixed value size per entry (per layer)
+        # Each entry contains KV + Indexer for 64 tokens in that layer
+        self.value_size_bytes = (
+            page_size_tokens *
+            (kv_lora_rank + qk_rope_head_dim + index_head_dim) *
+            precision_bytes
+        )
+
+    def get_entries(self, request: Any) -> Iterator[KVEntry]:
+        """Generate MLA storage entries
+
+        For each sequence_id in hash_ids, generate one entry per layer.
+
+        Yields:
+            KVEntry: (key, value_size) for each layer
+        """
+        for sequence_id in request.hash_ids:
+            for layer_id in range(self.num_layers):
+                yield KVEntry(
+                    key=KVKey(sequence_id=sequence_id, layer_id=layer_id),
+                    value_size_bytes=self.value_size_bytes
+                )
+
+    def get_key_count(self, request: Any) -> int:
+        """Total keys for MLA request
+
+        Returns:
+            int: len(hash_ids) × num_layers
+        """
+        return len(request.hash_ids) * self.num_layers
+
+    def get_value_size(self, key: KVKey) -> int:
+        """Get value size for MLA entry
+
+        All MLA entries have the same size.
+
+        Returns:
+            int: Value size in bytes
+        """
+        return self.value_size_bytes
+
+    def keys_per_layer(self) -> int:
+        """MLA has 1 key per (sequence, layer)"""
+        return 1
+
+
+# ============================================================================
+# Utility Functions
+# ============================================================================
+
+def get_model_config(model_name: str) -> dict:
+    """Get MLA model configuration by name
+
+    Args:
+        model_name: Model identifier (e.g., 'glm5', 'kimi-k2.6')
+
+    Returns:
+        dict: Model configuration
+
+    Raises:
+        KeyError: If model name is not found
+    """
+    if model_name not in MLA_MODEL_CONFIG:
+        available = ", ".join(MLA_MODEL_CONFIG.keys())
+        raise KeyError(f"Unknown model: {model_name}. Available: {available}")
+    return MLA_MODEL_CONFIG[model_name].copy()
+
+
+def create_layout(model_config: dict, page_size_tokens: int = 64) -> MLALayout:
+    """Create an MLALayout instance from model configuration
+
+    Args:
+        model_config: Model configuration dictionary with fields:
+            - num_layers: Number of transformer layers
+            - kv_lora_rank: KV LoRA rank dimension
+            - qk_rope_head_dim: QK rope head dimension
+            - index_head_dim: Indexer head dimension
+            - kv_precision_bytes: Precision in bytes (BF16=2, INT8=1)
+        page_size_tokens: Tokens per page (default 64)
+
+    Returns:
+        MLALayout: Layout instance for MLA architecture
+
+    Raises:
+        ValueError: If model configuration is invalid
+    """
+    required_fields = ['num_layers', 'kv_lora_rank', 'qk_rope_head_dim',
+                       'index_head_dim', 'kv_precision_bytes']
+    for field in required_fields:
+        if field not in model_config:
+            raise ValueError(f"Missing required field: {field}")
+
+    return MLALayout(
+        num_layers=model_config['num_layers'],
+        kv_lora_rank=model_config['kv_lora_rank'],
+        qk_rope_head_dim=model_config['qk_rope_head_dim'],
+        index_head_dim=model_config['index_head_dim'],
+        precision_bytes=model_config['kv_precision_bytes'],
+        page_size_tokens=page_size_tokens,
+    )

--- a/benchmarks/storage_benchmark_v1/storage/__init__.py
+++ b/benchmarks/storage_benchmark_v1/storage/__init__.py
@@ -4,13 +4,10 @@ KVCache Storage Module
 Provides storage backend implementations for KVCache systems.
 """
 
-from .interface import Storage, KVKey, KVValue
-from .disk import DiskHashTable, SSDStorage
+from .interface import Storage
+from .disk import DiskHashTable
 
 __all__ = [
     'Storage',
-    'KVKey',
-    'KVValue',
     'DiskHashTable',
-    'SSDStorage',
 ]

--- a/benchmarks/storage_benchmark_v1/storage/__init__.py
+++ b/benchmarks/storage_benchmark_v1/storage/__init__.py
@@ -1,0 +1,16 @@
+"""
+KVCache Storage Module
+
+Provides storage backend implementations for KVCache systems.
+"""
+
+from .interface import Storage, KVKey, KVValue
+from .disk import DiskHashTable, SSDStorage
+
+__all__ = [
+    'Storage',
+    'KVKey',
+    'KVValue',
+    'DiskHashTable',
+    'SSDStorage',
+]

--- a/benchmarks/storage_benchmark_v1/storage/disk.py
+++ b/benchmarks/storage_benchmark_v1/storage/disk.py
@@ -1,0 +1,337 @@
+"""
+Simple SSD Hash Table Storage
+
+Each key maps to a complete page entry.
+"""
+
+import os
+import time
+from pathlib import Path
+from typing import Dict, Optional, Any
+
+from .interface import Storage, KVKey, KVValue
+
+
+def calc_percentiles(data):
+    """Calculate latency percentiles"""
+    if not data:
+        return {'avg_ms': 0, 'p50_ms': 0, 'p95_ms': 0, 'p99_ms': 0}
+    import statistics
+    sorted_data = sorted(data)
+    n = len(sorted_data)
+    def get_percentile(p):
+        idx = int(n * p / 100)
+        if idx >= n: idx = n - 1
+        return sorted_data[idx]
+    return {
+        'avg_ms': statistics.mean(data),
+        'p50_ms': get_percentile(50),
+        'p95_ms': get_percentile(95),
+        'p99_ms': get_percentile(99),
+    }
+
+
+class DiskHashTable(Storage):
+    """Simple disk-based hash table
+
+    Architecture:
+    -----------
+    - In-memory map: key -> page_id (offset)
+    - On-disk: fixed-size pages at page_id * page_size
+
+    Storage:
+    --------
+    - Each entry is ONE complete page
+    - Key = (sequence_id, layer_id)
+    - Value = complete page data for that layer
+
+    """
+
+    def __init__(self, storage_dir: str, page_size: int,
+                 max_pages: int = 100000,
+                 fsync_mode: str = 'batch', fsync_batch_size: int = 100):
+        """Initialize disk hash table
+
+        Args:
+            storage_dir: Storage directory
+            page_size: Size of each entry (page) in bytes
+            max_pages: Maximum number of entries
+            fsync_mode: When to fsync ('batch', 'always', 'end', 'none')
+            fsync_batch_size: Writes between fsync
+        """
+        self.storage_dir = Path(storage_dir)
+        self.page_size = page_size
+        self.max_pages = max_pages
+        self.fsync_mode = fsync_mode
+        self.fsync_batch_size = fsync_batch_size
+
+        # In-memory index: key -> page_id
+        self.index: Dict[tuple, int] = {}
+
+        # Next page ID
+        self.next_page_id = 0
+
+        # Storage file
+        self.storage_dir.mkdir(parents=True, exist_ok=True)
+        self.storage_file = self.storage_dir / "data.bin"
+
+        # Pre-allocate
+        self._allocate_file()
+
+        # File descriptor
+        self.fd = None
+
+        # Write buffer
+        self._buffer = bytes(page_size)
+
+        # Stats
+        self.stats = {
+            'read_count': 0,
+            'write_count': 0,
+            'read_bytes': 0,
+            'write_bytes': 0,
+            'read_latencies_ms': [],
+            'write_latencies_ms': [],
+            'sync_count': 0,
+            'hit': 0,
+            'miss': 0,
+        }
+
+        self._pending_syncs = 0
+
+    def _allocate_file(self):
+        """Pre-allocate disk space"""
+        file_size = self.max_pages * self.page_size
+        if not self.storage_file.exists():
+            with open(self.storage_file, 'wb') as f:
+                f.seek(file_size - 1)
+                f.write(b'\0')
+                f.flush()
+                os.fsync(f.fileno())
+
+    def _get_fd(self):
+        if self.fd is None:
+            self.fd = os.open(self.storage_file, os.O_RDWR | os.O_CREAT)
+        return self.fd
+
+    # ========================================================================
+    # Core operations
+    # ========================================================================
+
+    def read(self, key: tuple) -> float:
+        """Read entry from disk
+
+        Args:
+            key: Tuple (sequence_id, layer_id)
+
+        Returns:
+            Read latency in ms if found, 0.0 if cache miss (not found)
+        """
+        page_id = self.index.get(key)
+        if page_id is None:
+            return 0.0
+
+        offset = page_id * self.page_size
+        start = time.perf_counter()
+
+        try:
+            fd = self._get_fd()
+            os.pread(fd, self.page_size, offset)
+
+            latency = (time.perf_counter() - start) * 1000.0
+            self.stats['read_count'] += 1
+            self.stats['read_bytes'] += self.page_size
+            self.stats['read_latencies_ms'].append(latency)
+            self.stats['hit'] += 1
+            return latency
+        except OSError as e:
+            print(f"Read error: {e}")
+            return 0.0
+
+    def write(self, key: tuple) -> float:
+        """Write entry to disk
+
+        Args:
+            key: Tuple (sequence_id, layer_id)
+
+        Returns:
+            Write latency in ms, 0.0 if capacity exceeded
+        """
+        # Check capacity
+        if self.next_page_id >= self.max_pages:
+            print(f"Warning: Storage capacity exceeded (max_pages={self.max_pages})")
+            return 0.0
+
+        page_id = self.next_page_id
+        self.next_page_id += 1
+        self.index[key] = page_id
+
+        offset = page_id * self.page_size
+        start = time.perf_counter()
+
+        try:
+            fd = self._get_fd()
+            os.pwrite(fd, self._buffer, offset)
+            write_done = time.perf_counter()
+
+            # Fsync
+            if self.fsync_mode == 'always':
+                os.fsync(fd)
+                self.stats['sync_count'] += 1
+                self._pending_syncs = 0
+                latency = (time.perf_counter() - start) * 1000.0
+
+            elif self.fsync_mode == 'batch':
+                self._pending_syncs += 1
+                if self._pending_syncs >= self.fsync_batch_size:
+                    os.fsync(fd)
+                    self.stats['sync_count'] += 1
+                    self._pending_syncs = 0
+                latency = (write_done - start) * 1000.0
+
+            elif self.fsync_mode == 'none':
+                latency = (write_done - start) * 1000.0
+
+            else:  # 'end'
+                latency = (write_done - start) * 1000.0
+
+            # Evict from cache
+            os.posix_fadvise(fd, offset, self.page_size, os.POSIX_FADV_DONTNEED)
+
+            self.stats['write_count'] += 1
+            self.stats['write_bytes'] += self.page_size
+            self.stats['write_latencies_ms'].append(latency)
+            self.stats['miss'] += 1
+            return latency
+        except OSError as e:
+            print(f"Write error: {e}")
+            return 0.0
+
+    # ========================================================================
+    # Storage interface
+    # ========================================================================
+
+    def get(self, key) -> Optional[KVValue]:
+        """Get entry for a key
+
+        Args:
+            key: Either KVKey or tuple (sequence_id, layer_id)
+
+        Returns:
+            KVValue if found, None otherwise
+        """
+        # Handle both KVKey and tuple keys
+        if hasattr(key, 'sequence_id'):
+            tuple_key = (key.sequence_id, key.layer_id)
+        else:
+            tuple_key = key
+        latency = self.read(tuple_key)
+        if latency > 0:
+            return KVValue(data=b'', page_count=1, token_count=64)
+        return None
+
+    def put(self, key: KVKey, value: KVValue) -> None:
+        """Store entry for a key"""
+        tuple_key = (key.sequence_id, key.layer_id)
+        self.write(tuple_key)
+
+    def exists(self, key) -> bool:
+        """Check if entry exists
+
+        Args:
+            key: Either KVKey or tuple (sequence_id, layer_id)
+
+        Returns:
+            True if key exists in index
+        """
+        # Handle both KVKey and tuple keys
+        if hasattr(key, 'sequence_id'):
+            tuple_key = (key.sequence_id, key.layer_id)
+        else:
+            tuple_key = key
+        return tuple_key in self.index
+
+    def delete(self, key) -> bool:
+        """Delete entry
+
+        Args:
+            key: Either KVKey or tuple (sequence_id, layer_id)
+
+        Returns:
+            True if key was deleted, False if not found
+        """
+        # Handle both KVKey and tuple keys
+        if hasattr(key, 'sequence_id'):
+            tuple_key = (key.sequence_id, key.layer_id)
+        else:
+            tuple_key = key
+        if tuple_key in self.index:
+            del self.index[tuple_key]
+            return True
+        return False
+
+    def get_sequence_keys(self, sequence_id: int) -> list[KVKey]:
+        """Get all keys for a sequence"""
+        keys = []
+        for k in self.index.keys():
+            if k[0] == sequence_id:
+                keys.append(KVKey(sequence_id=k[0], layer_id=k[1]))
+        return keys
+
+    def get_stats(self) -> Dict[str, Any]:
+        """Get statistics"""
+        import statistics
+
+        def calc_stats(latencies):
+            if not latencies:
+                return {'avg_ms': 0, 'p50_ms': 0, 'p95_ms': 0, 'p99_ms': 0}
+            return {
+                'avg_ms': statistics.mean(latencies),
+                **calc_percentiles(latencies),
+            }
+
+        return {
+            'read': {
+                'count': self.stats['read_count'],
+                'mb': self.stats['read_bytes'] / 1024 / 1024,
+                **calc_stats(self.stats['read_latencies_ms'])
+            },
+            'write': {
+                'count': self.stats['write_count'],
+                'mb': self.stats['write_bytes'] / 1024 / 1024,
+                **calc_stats(self.stats['write_latencies_ms'])
+            },
+            'sync_count': self.stats['sync_count'],
+            'total_pages': self.next_page_id,
+            'total_keys': len(self.index),
+            'page_hits': self.stats['hit'],
+            'page_misses': self.stats['miss'],
+        }
+
+    # ========================================================================
+    # Resource management
+    # ========================================================================
+
+    def close(self, force_sync: bool = True):
+        """Close file"""
+        if force_sync and self.fsync_mode in ['end', 'batch']:
+            if self.fd:
+                try:
+                    os.fsync(self.fd)
+                    self.stats['sync_count'] += 1
+                except: pass
+
+        if self.fd:
+            os.close(self.fd)
+            self.fd = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+        return False
+
+
+# Alias
+SSDStorage = DiskHashTable

--- a/benchmarks/storage_benchmark_v1/storage/disk.py
+++ b/benchmarks/storage_benchmark_v1/storage/disk.py
@@ -7,7 +7,7 @@ Each key maps to a complete page entry.
 import os
 import time
 from pathlib import Path
-from typing import Dict, Optional, Any
+from typing import Dict, List, Optional, Any
 
 from .interface import Storage, KVKey, KVValue
 
@@ -82,7 +82,8 @@ class DiskHashTable(Storage):
         self.fd = None
 
         # Write buffer
-        self._buffer = bytes(page_size)
+        # Write buffer (use random bytes to prevent SSD compression/deduplication from skewing results)
+        self._buffer = os.urandom(page_size)
 
         # Stats
         self.stats = {
@@ -110,8 +111,9 @@ class DiskHashTable(Storage):
                 os.fsync(f.fileno())
 
     def _get_fd(self):
+    def _get_fd(self):
         if self.fd is None:
-            self.fd = os.open(self.storage_file, os.O_RDWR | os.O_CREAT)
+            self.fd = os.open(self.storage_file, os.O_RDWR | os.O_CREAT, 0o644)
         return self.fd
 
     # ========================================================================
@@ -159,8 +161,7 @@ class DiskHashTable(Storage):
         """
         # Check capacity
         if self.next_page_id >= self.max_pages:
-            print(f"Warning: Storage capacity exceeded (max_pages={self.max_pages})")
-            return 0.0
+            raise OSError(f"Storage capacity exceeded (max_pages={self.max_pages})")
 
         page_id = self.next_page_id
         self.next_page_id += 1
@@ -196,7 +197,8 @@ class DiskHashTable(Storage):
                 latency = (write_done - start) * 1000.0
 
             # Evict from cache
-            os.posix_fadvise(fd, offset, self.page_size, os.POSIX_FADV_DONTNEED)
+            if hasattr(os, 'posix_fadvise'):
+                os.posix_fadvise(fd, offset, self.page_size, os.POSIX_FADV_DONTNEED)
 
             self.stats['write_count'] += 1
             self.stats['write_bytes'] += self.page_size
@@ -270,7 +272,7 @@ class DiskHashTable(Storage):
             return True
         return False
 
-    def get_sequence_keys(self, sequence_id: int) -> list[KVKey]:
+    def get_sequence_keys(self, sequence_id: int) -> List[KVKey]:
         """Get all keys for a sequence"""
         keys = []
         for k in self.index.keys():
@@ -315,14 +317,18 @@ class DiskHashTable(Storage):
     def close(self, force_sync: bool = True):
         """Close file"""
         if force_sync and self.fsync_mode in ['end', 'batch']:
-            if self.fd:
+            if self.fd is not None:
                 try:
                     os.fsync(self.fd)
                     self.stats['sync_count'] += 1
-                except: pass
+                except OSError:
+                    pass
 
-        if self.fd:
-            os.close(self.fd)
+        if self.fd is not None:
+            try:
+                os.close(self.fd)
+            except OSError:
+                pass
             self.fd = None
 
     def __enter__(self):

--- a/benchmarks/storage_benchmark_v1/storage/disk.py
+++ b/benchmarks/storage_benchmark_v1/storage/disk.py
@@ -9,7 +9,7 @@ import time
 from pathlib import Path
 from typing import Dict, List, Optional, Any
 
-from .interface import Storage, KVKey, KVValue
+from .interface import Storage
 
 
 def calc_percentiles(data):
@@ -34,17 +34,16 @@ def calc_percentiles(data):
 class DiskHashTable(Storage):
     """Simple disk-based hash table
 
-    Architecture:
-    -----------
-    - In-memory map: key -> page_id (offset)
-    - On-disk: fixed-size pages at page_id * page_size
+    File Layout:
+    Page 0: offset = 0 * page_size
+    Page 1: offset = 1 * page_size
+    Page 2: offset = 2 * page_size
+    ...
+    Page N: offset = N * page_size
 
-    Storage:
-    --------
-    - Each entry is ONE complete page
-    - Key = (sequence_id, layer_id)
-    - Value = complete page data for that layer
-
+    When max_pages < actual page_id range, uses modulo mapping:
+    actual_page_id = page_id % max_pages
+    This allows simulating large traces with limited storage.
     """
 
     def __init__(self, storage_dir: str, page_size: int,
@@ -55,37 +54,21 @@ class DiskHashTable(Storage):
         Args:
             storage_dir: Storage directory
             page_size: Size of each entry (page) in bytes
-            max_pages: Maximum number of entries
+            max_pages: Maximum number of entries (creates circular mapping if trace is larger)
             fsync_mode: When to fsync ('batch', 'always', 'end', 'none')
             fsync_batch_size: Writes between fsync
         """
         self.storage_dir = Path(storage_dir)
         self.page_size = page_size
         self.max_pages = max_pages
+        self.max_page_id = max_pages - 1
         self.fsync_mode = fsync_mode
         self.fsync_batch_size = fsync_batch_size
-
-        # In-memory index: key -> page_id
-        self.index: Dict[tuple, int] = {}
-
-        # Next page ID
-        self.next_page_id = 0
-
-        # Storage file
         self.storage_dir.mkdir(parents=True, exist_ok=True)
         self.storage_file = self.storage_dir / "data.bin"
-
-        # Pre-allocate
         self._allocate_file()
-
-        # File descriptor
         self.fd = None
-
-        # Write buffer
-        # Write buffer (use random bytes to prevent SSD compression/deduplication from skewing results)
         self._buffer = os.urandom(page_size)
-
-        # Stats
         self.stats = {
             'read_count': 0,
             'write_count': 0,
@@ -93,86 +76,141 @@ class DiskHashTable(Storage):
             'write_bytes': 0,
             'read_latencies_ms': [],
             'write_latencies_ms': [],
+            'read_time_s': 0.0,
+            'write_time_s': 0.0,
             'sync_count': 0,
             'hit': 0,
             'miss': 0,
         }
-
         self._pending_syncs = 0
+        self._written_pages: set = set()
 
     def _allocate_file(self):
-        """Pre-allocate disk space"""
+        """Pre-allocate disk space efficiently"""
         file_size = self.max_pages * self.page_size
         if not self.storage_file.exists():
-            with open(self.storage_file, 'wb') as f:
-                f.seek(file_size - 1)
-                f.write(b'\0')
-                f.flush()
-                os.fsync(f.fileno())
+            print(f"  [Storage] Creating file: {self.storage_file}")
+            print(f"  [Storage] Requested size: {file_size / (1024**3):.2f} GB ({self.max_pages:,} pages × {self.page_size} bytes = {file_size:,} bytes)")
+            # Use fallocate for efficient preallocation (Linux)
+            fd = os.open(self.storage_file, os.O_RDWR | os.O_CREAT | os.O_TRUNC, 0o644)
+            try:
+                # Try fallocate first (Linux specific, much faster)
+                try:
+                    import fcntl
+                    fcntl.fallocate(fd, 0, file_size)
+                    method = "fallocate"
+                except (ImportError, AttributeError, OSError):
+                    # Fallback to seek+write method
+                    os.lseek(fd, file_size - 1, os.SEEK_SET)
+                    os.write(fd, b'\0')
+                    os.fsync(fd)
+                    method = "seek+write"
+            finally:
+                os.close(fd)
+            actual_size = self.storage_file.stat().st_size if self.storage_file.exists() else 0
+            print(f"  [Storage] Pre-allocated {actual_size / (1024**3):.2f} GB using {method}")
+        else:
+            actual_size = self.storage_file.stat().st_size
+            actual_pages = actual_size // self.page_size
+            print(f"  [Storage] Reusing existing file: {self.storage_file}")
+            print(f"  [Storage] Current file size: {actual_size / (1024**3):.2f} GB ({actual_pages:,} pages × {self.page_size} bytes = {actual_size:,} bytes)")
 
     def _get_fd(self):
-    def _get_fd(self):
         if self.fd is None:
+            print(f"  [Storage] Opening file: {self.storage_file}")
             self.fd = os.open(self.storage_file, os.O_RDWR | os.O_CREAT, 0o644)
+            if self.storage_file.exists():
+                actual_size = self.storage_file.stat().st_size
+                actual_pages = actual_size // self.page_size
+                print(f"  [Storage] File size: {actual_size / (1024**3):.2f} GB ({actual_pages:,} pages × {self.page_size} bytes = {actual_size:,} bytes)")
         return self.fd
 
     # ========================================================================
     # Core operations
     # ========================================================================
 
-    def read(self, key: tuple) -> float:
+    def _map_page_id(self, page_id: int) -> int:
+        """Map logical page_id to physical page_id using modulo
+
+        This allows simulating large traces with limited storage space.
+
+        Args:
+            page_id: Logical page_id (from trace)
+
+        Returns:
+            Physical page_id in storage (0 to max_pages-1)
+        """
+        return page_id % self.max_pages
+
+    def read(self, page_id: int, offset_in_page: int = 0, length: int = None) -> float:
         """Read entry from disk
 
         Args:
-            key: Tuple (sequence_id, layer_id)
+            page_id: Logical page ID (hash_id from trace)
+            offset_in_page: Offset within the page (default: 0)
+            length: Number of bytes to read (default: entire page)
 
         Returns:
-            Read latency in ms if found, 0.0 if cache miss (not found)
+            Read latency in ms
         """
-        page_id = self.index.get(key)
-        if page_id is None:
-            return 0.0
+        if length is None:
+            length = self.page_size - offset_in_page
 
-        offset = page_id * self.page_size
+        # Validate parameters
+        if offset_in_page < 0 or offset_in_page >= self.page_size:
+            raise ValueError(f"offset_in_page {offset_in_page} out of range [0, {self.page_size})")
+        if length <= 0 or offset_in_page + length > self.page_size:
+            raise ValueError(f"length {length} invalid with offset_in_page {offset_in_page} (page_size={self.page_size})")
+
+        # Map to physical page_id and calculate offset
+        physical_page_id = self._map_page_id(page_id)
+        offset = physical_page_id * self.page_size + offset_in_page
         start = time.perf_counter()
 
         try:
             fd = self._get_fd()
-            os.pread(fd, self.page_size, offset)
+            os.pread(fd, length, offset)
 
             latency = (time.perf_counter() - start) * 1000.0
             self.stats['read_count'] += 1
-            self.stats['read_bytes'] += self.page_size
+            self.stats['read_bytes'] += length
             self.stats['read_latencies_ms'].append(latency)
+            self.stats['read_time_s'] += latency / 1000.0
             self.stats['hit'] += 1
             return latency
         except OSError as e:
-            print(f"Read error: {e}")
+            print(f"Read error (page_id={page_id}, physical_page_id={physical_page_id}): {e}")
             return 0.0
 
-    def write(self, key: tuple) -> float:
+    def write(self, page_id: int, offset_in_page: int = 0, length: int = None) -> float:
         """Write entry to disk
 
         Args:
-            key: Tuple (sequence_id, layer_id)
+            page_id: Logical page ID (hash_id from trace)
+            offset_in_page: Offset within the page (default: 0)
+            length: Number of bytes to write (default: entire page)
 
         Returns:
-            Write latency in ms, 0.0 if capacity exceeded
+            Write latency in ms
         """
-        # Check capacity
-        if self.next_page_id >= self.max_pages:
-            raise OSError(f"Storage capacity exceeded (max_pages={self.max_pages})")
+        if length is None:
+            length = self.page_size - offset_in_page
 
-        page_id = self.next_page_id
-        self.next_page_id += 1
-        self.index[key] = page_id
+        # Validate parameters
+        if offset_in_page < 0 or offset_in_page >= self.page_size:
+            raise ValueError(f"offset_in_page {offset_in_page} out of range [0, {self.page_size})")
+        if length <= 0 or offset_in_page + length > self.page_size:
+            raise ValueError(f"length {length} invalid with offset_in_page {offset_in_page} (page_size={self.page_size})")
 
-        offset = page_id * self.page_size
+        # Map to physical page_id and calculate offset
+        physical_page_id = self._map_page_id(page_id)
+        offset = physical_page_id * self.page_size + offset_in_page
         start = time.perf_counter()
 
         try:
             fd = self._get_fd()
-            os.pwrite(fd, self._buffer, offset)
+            # Use corresponding portion of buffer
+            os.pwrite(fd, self._buffer[:length], offset)
             write_done = time.perf_counter()
 
             # Fsync
@@ -181,7 +219,6 @@ class DiskHashTable(Storage):
                 self.stats['sync_count'] += 1
                 self._pending_syncs = 0
                 latency = (time.perf_counter() - start) * 1000.0
-
             elif self.fsync_mode == 'batch':
                 self._pending_syncs += 1
                 if self._pending_syncs >= self.fsync_batch_size:
@@ -189,96 +226,46 @@ class DiskHashTable(Storage):
                     self.stats['sync_count'] += 1
                     self._pending_syncs = 0
                 latency = (write_done - start) * 1000.0
-
-            elif self.fsync_mode == 'none':
+            else:
                 latency = (write_done - start) * 1000.0
 
-            else:  # 'end'
-                latency = (write_done - start) * 1000.0
-
-            # Evict from cache
-            if hasattr(os, 'posix_fadvise'):
-                os.posix_fadvise(fd, offset, self.page_size, os.POSIX_FADV_DONTNEED)
-
+            self._written_pages.add(page_id)
             self.stats['write_count'] += 1
-            self.stats['write_bytes'] += self.page_size
+            self.stats['write_bytes'] += length
             self.stats['write_latencies_ms'].append(latency)
+            self.stats['write_time_s'] += latency / 1000.0
             self.stats['miss'] += 1
             return latency
         except OSError as e:
-            print(f"Write error: {e}")
+            print(f"Write error (page_id={page_id}, offset_in_page={offset_in_page}, length={length}): {e}")
             return 0.0
 
     # ========================================================================
-    # Storage interface
+    # Storage interface methods
     # ========================================================================
 
-    def get(self, key) -> Optional[KVValue]:
-        """Get entry for a key
+    def exists(self, page_id: int) -> bool:
+        """Check if logical page has been written
 
         Args:
-            key: Either KVKey or tuple (sequence_id, layer_id)
+            page_id: Logical page ID (hash_id from trace)
 
         Returns:
-            KVValue if found, None otherwise
+            True if this logical page has been written before
         """
-        # Handle both KVKey and tuple keys
-        if hasattr(key, 'sequence_id'):
-            tuple_key = (key.sequence_id, key.layer_id)
-        else:
-            tuple_key = key
-        latency = self.read(tuple_key)
-        if latency > 0:
-            return KVValue(data=b'', page_count=1, token_count=64)
-        return None
+        return page_id in self._written_pages
 
-    def put(self, key: KVKey, value: KVValue) -> None:
-        """Store entry for a key"""
-        tuple_key = (key.sequence_id, key.layer_id)
-        self.write(tuple_key)
-
-    def exists(self, key) -> bool:
-        """Check if entry exists
+    def delete(self, page_id: int) -> bool:
+        """Delete page (no-op in direct mapping)
 
         Args:
-            key: Either KVKey or tuple (sequence_id, layer_id)
+            page_id: Page ID to delete
 
         Returns:
-            True if key exists in index
+            True (always succeeds in direct mapping)
         """
-        # Handle both KVKey and tuple keys
-        if hasattr(key, 'sequence_id'):
-            tuple_key = (key.sequence_id, key.layer_id)
-        else:
-            tuple_key = key
-        return tuple_key in self.index
-
-    def delete(self, key) -> bool:
-        """Delete entry
-
-        Args:
-            key: Either KVKey or tuple (sequence_id, layer_id)
-
-        Returns:
-            True if key was deleted, False if not found
-        """
-        # Handle both KVKey and tuple keys
-        if hasattr(key, 'sequence_id'):
-            tuple_key = (key.sequence_id, key.layer_id)
-        else:
-            tuple_key = key
-        if tuple_key in self.index:
-            del self.index[tuple_key]
-            return True
-        return False
-
-    def get_sequence_keys(self, sequence_id: int) -> List[KVKey]:
-        """Get all keys for a sequence"""
-        keys = []
-        for k in self.index.keys():
-            if k[0] == sequence_id:
-                keys.append(KVKey(sequence_id=k[0], layer_id=k[1]))
-        return keys
+        # No-op since we don't track which pages have been written
+        return True
 
     def get_stats(self) -> Dict[str, Any]:
         """Get statistics"""
@@ -296,16 +283,18 @@ class DiskHashTable(Storage):
             'read': {
                 'count': self.stats['read_count'],
                 'mb': self.stats['read_bytes'] / 1024 / 1024,
+                'time_s': self.stats['read_time_s'],
                 **calc_stats(self.stats['read_latencies_ms'])
             },
             'write': {
                 'count': self.stats['write_count'],
                 'mb': self.stats['write_bytes'] / 1024 / 1024,
+                'time_s': self.stats['write_time_s'],
                 **calc_stats(self.stats['write_latencies_ms'])
             },
             'sync_count': self.stats['sync_count'],
-            'total_pages': self.next_page_id,
-            'total_keys': len(self.index),
+            'max_pages': self.max_pages,
+            'written_pages': len(self._written_pages),
             'page_hits': self.stats['hit'],
             'page_misses': self.stats['miss'],
         }
@@ -337,7 +326,3 @@ class DiskHashTable(Storage):
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
         return False
-
-
-# Alias
-SSDStorage = DiskHashTable

--- a/benchmarks/storage_benchmark_v1/storage/interface.py
+++ b/benchmarks/storage_benchmark_v1/storage/interface.py
@@ -1,0 +1,136 @@
+"""
+KVCache Storage Interface
+
+Defines the key-value interface for KVCache storage systems.
+This provides a clean abstraction for different storage backends.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Optional, Dict, Any
+from dataclasses import dataclass
+
+
+@dataclass
+class KVKey:
+    """Key for KVCache storage
+
+    Represents a unique identifier for a KVCache entry.
+    """
+    sequence_id: int      # Sequence identifier (hash_id)
+    layer_id: int         # Layer number (0 to num_layers-1)
+
+    def __hash__(self):
+        return hash((self.sequence_id, self.layer_id))
+
+    def __eq__(self, other):
+        if not isinstance(other, KVKey):
+            return False
+        return (self.sequence_id == other.sequence_id and
+                self.layer_id == other.layer_id)
+
+    def __repr__(self):
+        return f"KVKey(seq={self.sequence_id}, layer={self.layer_id})"
+
+
+@dataclass
+class KVValue:
+    """Value for KVCache storage
+
+    Contains the KV tensor data and metadata.
+    """
+    data: bytes           # Raw KV data bytes
+    page_count: int       # Number of pages
+    token_count: int      # Number of tokens
+
+    def size_bytes(self) -> int:
+        """Get size in bytes"""
+        return len(self.data)
+
+
+class Storage(ABC):
+    """Abstract base class for KVCache storage
+
+    Manages key-value storage for KVCache entries.
+    Key: (sequence_id, layer_id)
+    Value: KV tensor data for that sequence and layer
+
+    Core operations: get, put, exists, delete.
+    """
+
+    @abstractmethod
+    def get(self, key: KVKey) -> Optional[KVValue]:
+        """Get KVCache value for a given key
+
+        Args:
+            key: KVKey containing (sequence_id, layer_id)
+
+        Returns:
+            KVValue if found, None otherwise
+        """
+        pass
+
+    @abstractmethod
+    def put(self, key: KVKey, value: KVValue) -> None:
+        """Store KVCache value for a given key
+
+        Args:
+            key: KVKey containing (sequence_id, layer_id)
+            value: KVValue to store
+        """
+        pass
+
+    @abstractmethod
+    def exists(self, key: KVKey) -> bool:
+        """Check if KVCache entry exists
+
+        Args:
+            key: KVKey containing (sequence_id, layer_id)
+
+        Returns:
+            True if exists, False otherwise
+        """
+        pass
+
+    @abstractmethod
+    def delete(self, key: KVKey) -> bool:
+        """Delete KVCache entry
+
+        Args:
+            key: KVKey containing (sequence_id, layer_id)
+
+        Returns:
+            True if deleted, False if not found
+        """
+        pass
+
+    @abstractmethod
+    def get_sequence_keys(self, sequence_id: int) -> list[KVKey]:
+        """Get all keys for a sequence
+
+        Args:
+            sequence_id: Sequence identifier
+
+        Returns:
+            List of KVKeys for all layers of the sequence
+        """
+        pass
+
+    @abstractmethod
+    def get_stats(self) -> Dict[str, Any]:
+        """Get storage statistics
+
+        Returns:
+            Dictionary containing storage statistics
+        """
+        pass
+
+    def close(self):
+        """Close the storage and release resources"""
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+        return False

--- a/benchmarks/storage_benchmark_v1/storage/interface.py
+++ b/benchmarks/storage_benchmark_v1/storage/interface.py
@@ -1,117 +1,74 @@
 """
 KVCache Storage Interface
 
-Defines the key-value interface for KVCache storage systems.
-This provides a clean abstraction for different storage backends.
+Simplified storage interface for KVCache benchmark.
+Key = page_id (int), Value = fixed-size bytes.
 """
 
 from abc import ABC, abstractmethod
-from typing import Optional, Dict, Any
-from dataclasses import dataclass
-
-
-@dataclass
-class KVKey:
-    """Key for KVCache storage
-
-    Represents a unique identifier for a KVCache entry.
-    """
-    sequence_id: int      # Sequence identifier (hash_id)
-    layer_id: int         # Layer number (0 to num_layers-1)
-
-    def __hash__(self):
-        return hash((self.sequence_id, self.layer_id))
-
-    def __eq__(self, other):
-        if not isinstance(other, KVKey):
-            return False
-        return (self.sequence_id == other.sequence_id and
-                self.layer_id == other.layer_id)
-
-    def __repr__(self):
-        return f"KVKey(seq={self.sequence_id}, layer={self.layer_id})"
-
-
-@dataclass
-class KVValue:
-    """Value for KVCache storage
-
-    Contains the KV tensor data and metadata.
-    """
-    data: bytes           # Raw KV data bytes
-    page_count: int       # Number of pages
-    token_count: int      # Number of tokens
-
-    def size_bytes(self) -> int:
-        """Get size in bytes"""
-        return len(self.data)
+from typing import Dict, Any
 
 
 class Storage(ABC):
     """Abstract base class for KVCache storage
 
-    Manages key-value storage for KVCache entries.
-    Key: (sequence_id, layer_id)
-    Value: KV tensor data for that sequence and layer
+    Simplified design:
+    - Key: page_id (int, hash_id from trace)
+    - Value: fixed-size bytes (page_size)
+    - Direct mapping: page_id -> offset -> payload
 
-    Core operations: get, put, exists, delete.
+    Core operations: read, write, exists, delete.
     """
 
     @abstractmethod
-    def get(self, key: KVKey) -> Optional[KVValue]:
-        """Get KVCache value for a given key
+    def read(self, page_id: int, offset_in_page: int = 0, length: int = None) -> float:
+        """Read page from disk
 
         Args:
-            key: KVKey containing (sequence_id, layer_id)
+            page_id: Page ID (hash_id from trace)
+            offset_in_page: Offset within the page (default: 0)
+            length: Number of bytes to read (default: entire page)
 
         Returns:
-            KVValue if found, None otherwise
+            Read latency in milliseconds
         """
         pass
 
     @abstractmethod
-    def put(self, key: KVKey, value: KVValue) -> None:
-        """Store KVCache value for a given key
+    def write(self, page_id: int, offset_in_page: int = 0, length: int = None) -> float:
+        """Write page to disk
 
         Args:
-            key: KVKey containing (sequence_id, layer_id)
-            value: KVValue to store
+            page_id: Page ID (hash_id from trace)
+            offset_in_page: Offset within the page (default: 0)
+            length: Number of bytes to write (default: entire page)
+
+        Returns:
+            Write latency in milliseconds
         """
         pass
 
     @abstractmethod
-    def exists(self, key: KVKey) -> bool:
-        """Check if KVCache entry exists
+    def exists(self, page_id: int) -> bool:
+        """Check if page exists
 
         Args:
-            key: KVKey containing (sequence_id, layer_id)
+            page_id: Page ID (hash_id from trace)
 
         Returns:
-            True if exists, False otherwise
+            True if page_id is within valid range
         """
         pass
 
     @abstractmethod
-    def delete(self, key: KVKey) -> bool:
-        """Delete KVCache entry
+    def delete(self, page_id: int) -> bool:
+        """Delete page (no-op in direct mapping)
 
         Args:
-            key: KVKey containing (sequence_id, layer_id)
+            page_id: Page ID to delete
 
         Returns:
-            True if deleted, False if not found
-        """
-        pass
-
-    @abstractmethod
-    def get_sequence_keys(self, sequence_id: int) -> list[KVKey]:
-        """Get all keys for a sequence
-
-        Args:
-            sequence_id: Sequence identifier
-
-        Returns:
-            List of KVKeys for all layers of the sequence
+            True (always succeeds in direct mapping)
         """
         pass
 


### PR DESCRIPTION

## Description

- Refactored benchmark into modular architecture
- Separated concerns: benchmark logic, layout implementations, storage backends
- Added KVLayout interface for architecture extensibility (currently MLA)
- Made page_size_tokens configurable via CLI
- Support for multiple models (glm5, kimi-k2.6) and fsync modes
- Clean separation: benchmark.py depends only on storage, layout contains architecture details
- 
## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [X] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
