### PR TITLE
[CI] guard sccache stats when unavailable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,7 @@ jobs:
       shell: bash
 
     - name: Run sccache stat for check
+      if: ${{ env.SCCACHE_PATH != '' }}
       shell: bash
       run: ${SCCACHE_PATH} --show-stats
 
@@ -652,6 +653,7 @@ jobs:
       shell: bash
 
     - name: Run sccache stat for check
+      if: ${{ env.SCCACHE_PATH != '' }}
       shell: bash
       run: ${SCCACHE_PATH} --show-stats
 

--- a/.github/workflows/ci_cu13.yml
+++ b/.github/workflows/ci_cu13.yml
@@ -104,6 +104,7 @@ jobs:
       shell: bash
 
     - name: Run sccache stat for check
+      if: ${{ env.SCCACHE_PATH != '' }}
       shell: bash
       run: ${SCCACHE_PATH} --show-stats
 

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -95,6 +95,7 @@ jobs:
         shell: bash
 
       - name: Run sccache stat for check
+        if: ${{ env.SCCACHE_PATH != '' }}
         shell: bash
         run: ${SCCACHE_PATH} --show-stats
 
@@ -173,6 +174,7 @@ jobs:
         shell: bash
 
       - name: Run sccache stat for check
+        if: ${{ env.SCCACHE_PATH != '' }}
         shell: bash
         run: ${SCCACHE_PATH} --show-stats
 
@@ -274,6 +276,7 @@ jobs:
         shell: bash
 
       - name: Run sccache stat for check
+        if: ${{ env.SCCACHE_PATH != '' }}
         shell: bash
         run: ${SCCACHE_PATH} --show-stats
 

--- a/.github/workflows/release-cuda13.yaml
+++ b/.github/workflows/release-cuda13.yaml
@@ -83,6 +83,7 @@ jobs:
         shell: bash
 
       - name: Run sccache stat for check
+        if: ${{ env.SCCACHE_PATH != '' }}
         shell: bash
         run: ${SCCACHE_PATH} --show-stats
 

--- a/.github/workflows/release-non-cuda.yaml
+++ b/.github/workflows/release-non-cuda.yaml
@@ -60,6 +60,7 @@ jobs:
         shell: bash
 
       - name: Run sccache stat for check
+        if: ${{ env.SCCACHE_PATH != '' }}
         shell: bash
         run: ${SCCACHE_PATH} --show-stats
 
@@ -121,4 +122,3 @@ jobs:
         with:
           packages-dir: mooncake-wheel/dist-release/
           password: ${{ secrets.PYPI_API_TOKEN }}
-

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -84,6 +84,7 @@ jobs:
         shell: bash
 
       - name: Run sccache stat for check
+        if: ${{ env.SCCACHE_PATH != '' }}
         shell: bash
         run: ${SCCACHE_PATH} --show-stats
 


### PR DESCRIPTION
## Description

Guard the sccache stats check steps so they only run when `SCCACHE_PATH` is set. This prevents CI and release workflows from failing on `${SCCACHE_PATH} --show-stats` when the sccache action does not provide a usable path, while leaving the sccache configuration steps unchanged.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

- Ran `git diff --check`
- Parsed the modified workflow YAML files with Ruby's YAML parser
- Commit hooks passed, including whitespace checks, end-of-file fixer, YAML check, Mooncake code format script, and codespell

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
