### PR TITLE
[TE] Fix NVMeoF loop variable bug and NVMeoFBatchDesc leak

### DIFF
--- a/mooncake-transfer-engine/src/transport/nvmeof_transport/nvmeof_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/nvmeof_transport/nvmeof_transport.cpp
@@ -87,8 +87,7 @@ Status NVMeoFTransport::getTransferStatus(BatchID batch_id, size_t task_id,
     for (size_t i = slice_id; i < slice_id + slice_num; ++i) {
         // LOG(INFO) << "task " << task_id << " i " << i << " upper bound " <<
         // slice_num;
-        auto event =
-            desc_pool_->getTransferStatus(nvmeof_desc.desc_idx_, i);
+        auto event = desc_pool_->getTransferStatus(nvmeof_desc.desc_idx_, i);
         transfer_status.s = from_cufile_transfer_status(event.status);
         // TODO(FIXME): what to do if multi slices have different status?
         if (transfer_status.s == COMPLETED) {

--- a/mooncake-transfer-engine/src/transport/nvmeof_transport/nvmeof_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/nvmeof_transport/nvmeof_transport.cpp
@@ -88,7 +88,7 @@ Status NVMeoFTransport::getTransferStatus(BatchID batch_id, size_t task_id,
         // LOG(INFO) << "task " << task_id << " i " << i << " upper bound " <<
         // slice_num;
         auto event =
-            desc_pool_->getTransferStatus(nvmeof_desc.desc_idx_, slice_id);
+            desc_pool_->getTransferStatus(nvmeof_desc.desc_idx_, i);
         transfer_status.s = from_cufile_transfer_status(event.status);
         // TODO(FIXME): what to do if multi slices have different status?
         if (transfer_status.s == COMPLETED) {
@@ -206,12 +206,13 @@ Status NVMeoFTransport::submitTransfer(
 
 Status NVMeoFTransport::freeBatchID(BatchID batch_id) {
     auto &batch_desc = *((BatchDesc *)(batch_id));
-    auto &nvmeof_desc = *((NVMeoFBatchDesc *)(batch_desc.context));
-    int desc_idx = nvmeof_desc.desc_idx_;
+    auto *nvmeof_desc_ptr = (NVMeoFBatchDesc *)(batch_desc.context);
+    int desc_idx = nvmeof_desc_ptr->desc_idx_;
     Status rc = Transport::freeBatchID(batch_id);
     if (rc != Status::OK()) {
         return rc;
     }
+    delete nvmeof_desc_ptr;
     desc_pool_->freeCUfileDesc(desc_idx);
     return Status::OK();
 }


### PR DESCRIPTION
## Summary
- `getTransferStatus`: fix loop that always passes `slice_id` (constant) instead of `i` (iterator) to `desc_pool_->getTransferStatus()`, causing every iteration to query the same first slice. Multi-slice transfers reported wrong status and overcounted bytes.
- `freeBatchID`: delete `NVMeoFBatchDesc` after `Transport::freeBatchID` succeeds (via saved pointer), fixing per-batch memory leak. Delete is placed after the base class call to avoid use-after-free on the `BatchBusy` error path.

## What was NOT changed
- No changes to allocateBatchID, submitTransfer, or CUFileDescPool

## Test plan
- [ ] CI build (USE_NVMEOF path)
- [ ] Code review: delete order safe on both success and error paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)