### PR TITLE
[Store] Fix hot cache ref_count leak on size mismatch

### DIFF
--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -1465,6 +1465,7 @@ bool Client::RedirectToHotCache(const std::string& key,
 
     if (mem_desc.buffer_descriptor.size_ != blk->size) {
         LOG(ERROR) << "Cache hit but size mismatch for key: " << key;
+        hot_cache_->ReleaseHotKey(key);
         return false;
     }
 


### PR DESCRIPTION
## Summary
- `RedirectToHotCache`: `GetHotKey` increments `ref_count`, but the size-mismatch early return did not call `ReleaseHotKey`, permanently preventing the block from being evicted.
- Added `hot_cache_->ReleaseHotKey(key)` before `return false` on the size-mismatch path.

## What was NOT changed
- No changes to GetHotKey, ReleaseHotKey, or other callers

## Test plan
- [ ] CI build + existing test suite
- [ ] Code review: one release matches one acquire on every path

🤖 Generated with [Claude Code](https://claude.com/claude-code)