### PR TITLE
chore(Doc): update clang-format installation instructions in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ git commit -m "chore: pre-commit autoupdate"
 
 If clang-format is missing, install it (Ubuntu example):
 ```bash
-sudo apt-get update && sudo apt-get install -y clang-format
+sudo apt-get update && sudo apt-get install -y clang-format-20
 ```
 
 You can temporarily skip hooks:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,4 +5,4 @@ pre-commit==3.7.1
 ruff==0.6.9
 codespell==2.2.6
 cmake-format==0.6.13
-# clang-format is provided via system package (e.g., apt install clang-format) or toolchain
+# clang-format is provided via system package (e.g., sudo apt-get install -y clang-format-20) or toolchain


### PR DESCRIPTION


## Description
This PR fixes the clang-format installation instructions in the contributing documentation and dev requirements file to explicitly specify version `clang-format-20` instead of the generic clang-format package.

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
