### PR TITLE
[Store] recover etcd client after leader hang (SIGSTOP)

### DIFF
--- a/mooncake-common/etcd/etcd_wrapper.go
+++ b/mooncake-common/etcd/etcd_wrapper.go
@@ -50,6 +50,10 @@ type prefixWatchInfo struct {
 	callbackContext unsafe.Pointer
 	// done is closed when the watch goroutine fully exits (no more callbacks).
 	done chan struct{}
+	// broken means this watch ended because reset/error made it untrustworthy.
+	broken bool
+	// brokenNotified prevents duplicate WATCH_BROKEN callbacks from exit races.
+	brokenNotified bool
 }
 
 // Use different etcd client so they are not affected by each other,
@@ -81,6 +85,36 @@ const (
 	snapshotMaxMsgSize = 2000 * 1000 * 1000 // 2GB
 	snapshotTimeout    = 60 * time.Second   // 1 minute for large files
 )
+
+const (
+	storeDialKeepAliveTime    = 10 * time.Second
+	storeDialKeepAliveTimeout = 3 * time.Second
+)
+
+func newStoreClientConfig(validEndpoints []string) clientv3.Config {
+	return clientv3.Config{
+		Endpoints:            validEndpoints,
+		DialTimeout:          5 * time.Second,
+		DialKeepAliveTime:    storeDialKeepAliveTime,
+		DialKeepAliveTimeout: storeDialKeepAliveTimeout,
+		PermitWithoutStream:  true,
+	}
+}
+
+func parseEtcdEndpoints(endpoints *C.char) []string {
+	endpointStr := C.GoString(endpoints)
+	endpointStr = strings.ReplaceAll(endpointStr, ",", ";")
+	endpointList := strings.Split(endpointStr, ";")
+
+	var validEndpoints []string
+	for _, ep := range endpointList {
+		ep = strings.TrimSpace(ep)
+		if ep != "" {
+			validEndpoints = append(validEndpoints, ep)
+		}
+	}
+	return validEndpoints
+}
 
 //export NewEtcdClient
 func NewEtcdClient(endpoints *C.char, errMsg **C.char) int {
@@ -197,6 +231,12 @@ func EtcdCloseWrapper() {
 	}
 }
 
+func getStoreClient() *clientv3.Client {
+	storeMutex.Lock()
+	defer storeMutex.Unlock()
+	return storeClient
+}
+
 //export NewStoreEtcdClient
 func NewStoreEtcdClient(endpoints *C.char, errMsg **C.char) int {
 	storeMutex.Lock()
@@ -206,29 +246,13 @@ func NewStoreEtcdClient(endpoints *C.char, errMsg **C.char) int {
 		return -2
 	}
 
-	endpointStr := C.GoString(endpoints)
-	// Support multiple endpoints separated by comma or semicolon.
-	endpointStr = strings.ReplaceAll(endpointStr, ",", ";")
-	endpointList := strings.Split(endpointStr, ";")
-
-	// Filter out any empty strings that might result from splitting
-	var validEndpoints []string
-	for _, ep := range endpointList {
-		ep = strings.TrimSpace(ep)
-		if ep != "" {
-			validEndpoints = append(validEndpoints, ep)
-		}
-	}
-
+	validEndpoints := parseEtcdEndpoints(endpoints)
 	if len(validEndpoints) == 0 {
 		*errMsg = C.CString("no valid endpoints provided")
 		return -1
 	}
 
-	cli, err := clientv3.New(clientv3.Config{
-		Endpoints:   validEndpoints,
-		DialTimeout: 5 * time.Second,
-	})
+	cli, err := clientv3.New(newStoreClientConfig(validEndpoints))
 
 	if err != nil {
 		*errMsg = C.CString(err.Error())
@@ -236,6 +260,36 @@ func NewStoreEtcdClient(endpoints *C.char, errMsg **C.char) int {
 	}
 
 	storeClient = cli
+	return 0
+}
+
+//export EtcdStoreResetClientWrapper
+func EtcdStoreResetClientWrapper(endpoints *C.char, errMsg **C.char) int {
+	validEndpoints := parseEtcdEndpoints(endpoints)
+	if len(validEndpoints) == 0 {
+		*errMsg = C.CString("no valid endpoints provided")
+		return -1
+	}
+
+	cli, err := clientv3.New(newStoreClientConfig(validEndpoints))
+	if err != nil {
+		*errMsg = C.CString(err.Error())
+		return -1
+	}
+
+	cancelAllStoreKeepAlives()
+	cancelAllStoreWatches()
+	cancelAllStorePrefixWatches()
+
+	storeMutex.Lock()
+	oldClient := storeClient
+	storeClient = cli
+	storeMutex.Unlock()
+
+	if oldClient != nil {
+		oldClient.Close()
+	}
+
 	return 0
 }
 
@@ -286,14 +340,15 @@ func NewSnapshotEtcdClient(endpoints *C.char, errMsg **C.char) int {
 //export EtcdStoreGetWrapper
 func EtcdStoreGetWrapper(key *C.char, keySize C.int, value **C.char,
 	valueSize *C.int, revisionId *int64, errMsg **C.char) int {
-	if storeClient == nil {
+	cli := getStoreClient()
+	if cli == nil {
 		*errMsg = C.CString("etcd client not initialized")
 		return -1
 	}
 	k := C.GoStringN(key, keySize)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	resp, err := storeClient.Get(ctx, k)
+	resp, err := cli.Get(ctx, k)
 	if err != nil {
 		*errMsg = C.CString(err.Error())
 		return -1
@@ -312,13 +367,14 @@ func EtcdStoreGetWrapper(key *C.char, keySize C.int, value **C.char,
 
 //export EtcdStoreGrantLeaseWrapper
 func EtcdStoreGrantLeaseWrapper(ttl int64, leaseId *int64, errMsg **C.char) int {
-	if storeClient == nil {
+	cli := getStoreClient()
+	if cli == nil {
 		*errMsg = C.CString("etcd client not initialized")
 		return -1
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	resp, err := storeClient.Grant(ctx, ttl)
+	resp, err := cli.Grant(ctx, ttl)
 	if err != nil {
 		*errMsg = C.CString(err.Error())
 		return -1
@@ -329,13 +385,14 @@ func EtcdStoreGrantLeaseWrapper(ttl int64, leaseId *int64, errMsg **C.char) int 
 
 //export EtcdStoreRevokeLeaseWrapper
 func EtcdStoreRevokeLeaseWrapper(leaseId int64, errMsg **C.char) int {
-	if storeClient == nil {
+	cli := getStoreClient()
+	if cli == nil {
 		*errMsg = C.CString("etcd client not initialized")
 		return -1
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	_, err := storeClient.Revoke(ctx, clientv3.LeaseID(leaseId))
+	_, err := cli.Revoke(ctx, clientv3.LeaseID(leaseId))
 	if err != nil {
 		if errors.Is(err, rpctypes.ErrLeaseNotFound) {
 			return 0
@@ -349,7 +406,8 @@ func EtcdStoreRevokeLeaseWrapper(leaseId int64, errMsg **C.char) int {
 //export EtcdStoreCreateWithLeaseWrapper
 func EtcdStoreCreateWithLeaseWrapper(key *C.char, keySize C.int, value *C.char, valueSize C.int,
 	leaseId int64, revisionId *int64, errMsg **C.char) int {
-	if storeClient == nil {
+	cli := getStoreClient()
+	if cli == nil {
 		*errMsg = C.CString("etcd client not initialized")
 		return -1
 	}
@@ -359,7 +417,7 @@ func EtcdStoreCreateWithLeaseWrapper(key *C.char, keySize C.int, value *C.char, 
 	defer cancel()
 
 	// Create a transaction
-	txn := storeClient.Txn(ctx)
+	txn := cli.Txn(ctx)
 
 	// Only put the key if it does not exist
 	resp, err := txn.If(clientv3.Compare(clientv3.CreateRevision(k), "=", 0)).
@@ -401,9 +459,81 @@ func cancelAndDeleteWatch(k string) int {
 	return -1
 }
 
+func cancelAllStoreKeepAlives() {
+	storeKeepAliveMutex.Lock()
+	cancels := make([]context.CancelFunc, 0, len(storeKeepAliveCtx))
+	for leaseId, cancel := range storeKeepAliveCtx {
+		cancels = append(cancels, cancel)
+		delete(storeKeepAliveCtx, leaseId)
+	}
+	storeKeepAliveMutex.Unlock()
+
+	for _, cancel := range cancels {
+		cancel()
+	}
+}
+
+func cancelAllStoreWatches() {
+	storeWatchMutex.Lock()
+	cancels := make([]context.CancelFunc, 0, len(storeWatchCtx))
+	for key, cancel := range storeWatchCtx {
+		cancels = append(cancels, cancel)
+		delete(storeWatchCtx, key)
+	}
+	storeWatchMutex.Unlock()
+
+	for _, cancel := range cancels {
+		cancel()
+	}
+}
+
+func cancelAllStorePrefixWatches() {
+	storePrefixWatchMutex.Lock()
+	cancels := make([]context.CancelFunc, 0, len(storePrefixWatchCtx))
+	for prefix, watchInfo := range storePrefixWatchCtx {
+		watchInfo.broken = true
+		storePrefixWatchCtx[prefix] = watchInfo
+		cancels = append(cancels, watchInfo.cancel)
+		// Do not delete map entries here; let goroutine defer clean up.
+	}
+	storePrefixWatchMutex.Unlock()
+
+	for _, cancel := range cancels {
+		cancel()
+	}
+}
+
+// notifyStorePrefixWatchBrokenOnce delivers a WATCH_BROKEN callback for the
+// prefix watch `p` at most once. If markBroken is true the watch is first
+// marked broken (used by reset/error exit paths); explicit cancel passes
+// markBroken=false so a normal shutdown does not generate a spurious
+// WATCH_BROKEN. The cgo callback is invoked outside storePrefixWatchMutex
+// to avoid deadlocks from cgo re-entry while holding a Go mutex.
+func notifyStorePrefixWatchBrokenOnce(p string, callbackContext unsafe.Pointer, callbackFunc unsafe.Pointer, markBroken bool) {
+	shouldNotify := false
+
+	storePrefixWatchMutex.Lock()
+	if watchInfo, exists := storePrefixWatchCtx[p]; exists {
+		if markBroken {
+			watchInfo.broken = true
+		}
+		if watchInfo.broken && !watchInfo.brokenNotified {
+			watchInfo.brokenNotified = true
+			shouldNotify = true
+		}
+		storePrefixWatchCtx[p] = watchInfo
+	}
+	storePrefixWatchMutex.Unlock()
+
+	if shouldNotify {
+		C.call_watch_cb(callbackFunc, callbackContext, nil, 0, nil, 0, C.int(2) /*WATCH_BROKEN*/, C.longlong(0))
+	}
+}
+
 //export EtcdStoreWatchUntilDeletedWrapper
 func EtcdStoreWatchUntilDeletedWrapper(key *C.char, keySize C.int, errMsg **C.char) int {
-	if storeClient == nil {
+	cli := getStoreClient()
+	if cli == nil {
 		*errMsg = C.CString("etcd client not initialized")
 		return -1
 	}
@@ -426,7 +556,7 @@ func EtcdStoreWatchUntilDeletedWrapper(key *C.char, keySize C.int, errMsg **C.ch
 	defer cancelAndDeleteWatch(k)
 
 	// Start watching the key
-	watchChan := storeClient.Watch(ctx, k)
+	watchChan := cli.Watch(ctx, k)
 
 	// Wait for the key to be deleted
 	for {
@@ -490,7 +620,8 @@ func hasKeepAliveContext(leaseId int64) bool {
 
 //export EtcdStoreKeepAliveWrapper
 func EtcdStoreKeepAliveWrapper(leaseId int64, errMsg **C.char) int {
-	if storeClient == nil {
+	cli := getStoreClient()
+	if cli == nil {
 		*errMsg = C.CString("etcd client not initialized")
 		return -1
 	}
@@ -511,7 +642,7 @@ func EtcdStoreKeepAliveWrapper(leaseId int64, errMsg **C.char) int {
 	defer cancelAndDeleteKeepAlive(leaseId)
 
 	// Start keep alive
-	keepAliveChan, err := storeClient.KeepAlive(ctx, clientv3.LeaseID(leaseId))
+	keepAliveChan, err := cli.KeepAlive(ctx, clientv3.LeaseID(leaseId))
 	if err != nil {
 		*errMsg = C.CString(err.Error())
 		return -1
@@ -564,7 +695,8 @@ func EtcdStoreWaitKeepAliveReadyWrapper(leaseId int64, timeoutMs int, errMsg **C
 
 //export EtcdStorePutWrapper
 func EtcdStorePutWrapper(key *C.char, keySize C.int, value *C.char, valueSize C.int, errMsg **C.char) int {
-	if storeClient == nil {
+	cli := getStoreClient()
+	if cli == nil {
 		*errMsg = C.CString("etcd client not initialized")
 		return -1
 	}
@@ -572,7 +704,7 @@ func EtcdStorePutWrapper(key *C.char, keySize C.int, value *C.char, valueSize C.
 	v := C.GoStringN(value, valueSize)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	_, err := storeClient.Put(ctx, k, v)
+	_, err := cli.Put(ctx, k, v)
 	if err != nil {
 		*errMsg = C.CString(err.Error())
 		return -1
@@ -588,7 +720,8 @@ func EtcdStorePutWrapper(key *C.char, keySize C.int, value *C.char, valueSize C.
 //
 //export EtcdStoreCreateWrapper
 func EtcdStoreCreateWrapper(key *C.char, keySize C.int, value *C.char, valueSize C.int, errMsg **C.char) int {
-	if storeClient == nil {
+	cli := getStoreClient()
+	if cli == nil {
 		*errMsg = C.CString("etcd client not initialized")
 		return -1
 	}
@@ -597,7 +730,7 @@ func EtcdStoreCreateWrapper(key *C.char, keySize C.int, value *C.char, valueSize
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	txn := storeClient.Txn(ctx)
+	txn := cli.Txn(ctx)
 	resp, err := txn.If(clientv3.Compare(clientv3.CreateRevision(k), "=", 0)).
 		Then(clientv3.OpPut(k, v)).
 		Commit()
@@ -614,7 +747,8 @@ func EtcdStoreCreateWrapper(key *C.char, keySize C.int, value *C.char, valueSize
 
 //export EtcdStoreBatchCreateWrapper
 func EtcdStoreBatchCreateWrapper(keys **C.char, values **C.char, count C.int, errMsg **C.char) int {
-	if storeClient == nil {
+	cli := getStoreClient()
+	if cli == nil {
 		*errMsg = C.CString("etcd client not initialized")
 		return -1
 	}
@@ -642,7 +776,7 @@ func EtcdStoreBatchCreateWrapper(keys **C.char, values **C.char, count C.int, er
 	defer cancel()
 
 	// Use Txn to ensure atomicity of the batch
-	resp, err := storeClient.Txn(ctx).If(cmps...).Then(ops...).Commit()
+	resp, err := cli.Txn(ctx).If(cmps...).Then(ops...).Commit()
 	if err != nil {
 		*errMsg = C.CString(err.Error())
 		return -1
@@ -657,14 +791,15 @@ func EtcdStoreBatchCreateWrapper(keys **C.char, values **C.char, count C.int, er
 
 //export EtcdStoreGetWithPrefixWrapper
 func EtcdStoreGetWithPrefixWrapper(prefix *C.char, prefixSize C.int, keys **C.char, keySizes **C.int, values **C.char, valueSizes **C.int, count *C.int, errMsg **C.char) int {
-	if storeClient == nil {
+	cli := getStoreClient()
+	if cli == nil {
 		*errMsg = C.CString("etcd client not initialized")
 		return -1
 	}
 	p := C.GoStringN(prefix, prefixSize)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	resp, err := storeClient.Get(ctx, p, clientv3.WithPrefix(), clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend))
+	resp, err := cli.Get(ctx, p, clientv3.WithPrefix(), clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend))
 	if err != nil {
 		*errMsg = C.CString(err.Error())
 		return -1
@@ -702,7 +837,8 @@ func EtcdStoreGetWithPrefixWrapper(prefix *C.char, prefixSize C.int, keys **C.ch
 
 //export EtcdStoreGetRangeAsJsonWrapper
 func EtcdStoreGetRangeAsJsonWrapper(startKey *C.char, startKeySize C.int, endKey *C.char, endKeySize C.int, limit C.int, outJson **C.char, outJsonSize *C.int, revisionId *C.longlong, errMsg **C.char) int {
-	if storeClient == nil {
+	cli := getStoreClient()
+	if cli == nil {
 		*errMsg = C.CString("etcd client not initialized")
 		return -1
 	}
@@ -719,7 +855,7 @@ func EtcdStoreGetRangeAsJsonWrapper(startKey *C.char, startKeySize C.int, endKey
 	if limit > 0 {
 		opts = append(opts, clientv3.WithLimit(int64(limit)))
 	}
-	resp, err := storeClient.Get(ctx, start, opts...)
+	resp, err := cli.Get(ctx, start, opts...)
 	if err != nil {
 		*errMsg = C.CString(err.Error())
 		return -1
@@ -752,14 +888,15 @@ func EtcdStoreGetRangeAsJsonWrapper(startKey *C.char, startKeySize C.int, endKey
 
 //export EtcdStoreGetFirstKeyWithPrefixWrapper
 func EtcdStoreGetFirstKeyWithPrefixWrapper(prefix *C.char, prefixSize C.int, firstKey **C.char, firstKeySize *C.int, errMsg **C.char) int {
-	if storeClient == nil {
+	cli := getStoreClient()
+	if cli == nil {
 		*errMsg = C.CString("etcd client not initialized")
 		return -1
 	}
 	p := C.GoStringN(prefix, prefixSize)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	resp, err := storeClient.Get(ctx, p, clientv3.WithPrefix(), clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend), clientv3.WithLimit(1))
+	resp, err := cli.Get(ctx, p, clientv3.WithPrefix(), clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend), clientv3.WithLimit(1))
 	if err != nil {
 		*errMsg = C.CString(err.Error())
 		return -1
@@ -776,7 +913,8 @@ func EtcdStoreGetFirstKeyWithPrefixWrapper(prefix *C.char, prefixSize C.int, fir
 
 //export EtcdStoreGetLastKeyWithPrefixWrapper
 func EtcdStoreGetLastKeyWithPrefixWrapper(prefix *C.char, prefixSize C.int, lastKey **C.char, lastKeySize *C.int, errMsg **C.char) int {
-	if storeClient == nil {
+	cli := getStoreClient()
+	if cli == nil {
 		*errMsg = C.CString("etcd client not initialized")
 		return -1
 	}
@@ -784,7 +922,7 @@ func EtcdStoreGetLastKeyWithPrefixWrapper(prefix *C.char, prefixSize C.int, last
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	resp, err := storeClient.Get(
+	resp, err := cli.Get(
 		ctx, p,
 		clientv3.WithPrefix(),
 		clientv3.WithSort(clientv3.SortByKey, clientv3.SortDescend),
@@ -806,7 +944,8 @@ func EtcdStoreGetLastKeyWithPrefixWrapper(prefix *C.char, prefixSize C.int, last
 
 //export EtcdStoreDeleteRangeWrapper
 func EtcdStoreDeleteRangeWrapper(startKey *C.char, startKeySize C.int, endKey *C.char, endKeySize C.int, errMsg **C.char) int {
-	if storeClient == nil {
+	cli := getStoreClient()
+	if cli == nil {
 		*errMsg = C.CString("etcd client not initialized")
 		return -1
 	}
@@ -814,7 +953,7 @@ func EtcdStoreDeleteRangeWrapper(startKey *C.char, startKeySize C.int, endKey *C
 	end := C.GoStringN(endKey, endKeySize)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	_, err := storeClient.Delete(ctx, start, clientv3.WithRange(end))
+	_, err := cli.Delete(ctx, start, clientv3.WithRange(end))
 	if err != nil {
 		*errMsg = C.CString(err.Error())
 		return -1
@@ -824,7 +963,8 @@ func EtcdStoreDeleteRangeWrapper(startKey *C.char, startKeySize C.int, endKey *C
 
 //export EtcdStoreWatchWithPrefixFromRevisionWrapper
 func EtcdStoreWatchWithPrefixFromRevisionWrapper(prefix *C.char, prefixSize C.int, startRevision C.longlong, callbackContext unsafe.Pointer, callbackFunc unsafe.Pointer, errMsg **C.char) int {
-	if storeClient == nil {
+	cli := getStoreClient()
+	if cli == nil {
 		*errMsg = C.CString("etcd client not initialized")
 		return -1
 	}
@@ -848,6 +988,8 @@ func EtcdStoreWatchWithPrefixFromRevisionWrapper(prefix *C.char, prefixSize C.in
 		cancel:          cancel,
 		callbackContext: callbackContext,
 		done:            doneCh,
+		broken:          false,
+		brokenNotified:  false,
 	}
 	storePrefixWatchMutex.Unlock()
 
@@ -864,7 +1006,7 @@ func EtcdStoreWatchWithPrefixFromRevisionWrapper(prefix *C.char, prefixSize C.in
 		if startRevision > 0 {
 			opts = append(opts, clientv3.WithRev(int64(startRevision)))
 		}
-		watchChan := storeClient.Watch(ctx, p, opts...)
+		watchChan := cli.Watch(ctx, p, opts...)
 
 		for {
 			select {
@@ -873,10 +1015,11 @@ func EtcdStoreWatchWithPrefixFromRevisionWrapper(prefix *C.char, prefixSize C.in
 					// Channel closed. Check if context was cancelled.
 					select {
 					case <-ctx.Done():
+						notifyStorePrefixWatchBrokenOnce(p, callbackContext, callbackFunc, false)
 						return
 					default:
 						// Channel closed unexpectedly (not cancelled). Notify C++ watcher to reconnect.
-						C.call_watch_cb(callbackFunc, callbackContext, nil, 0, nil, 0, C.int(2) /*WATCH_BROKEN*/, C.longlong(0))
+						notifyStorePrefixWatchBrokenOnce(p, callbackContext, callbackFunc, true)
 						return
 					}
 				}
@@ -884,9 +1027,10 @@ func EtcdStoreWatchWithPrefixFromRevisionWrapper(prefix *C.char, prefixSize C.in
 					// Watch error. Check if context was cancelled.
 					select {
 					case <-ctx.Done():
+						notifyStorePrefixWatchBrokenOnce(p, callbackContext, callbackFunc, false)
 						return
 					default:
-						C.call_watch_cb(callbackFunc, callbackContext, nil, 0, nil, 0, C.int(2) /*WATCH_BROKEN*/, C.longlong(0))
+						notifyStorePrefixWatchBrokenOnce(p, callbackContext, callbackFunc, true)
 						return
 					}
 				}
@@ -900,6 +1044,7 @@ func EtcdStoreWatchWithPrefixFromRevisionWrapper(prefix *C.char, prefixSize C.in
 				for _, event := range watchResp.Events {
 					select {
 					case <-ctx.Done():
+						notifyStorePrefixWatchBrokenOnce(p, callbackContext, callbackFunc, false)
 						return
 					default:
 					}
@@ -942,6 +1087,7 @@ func EtcdStoreWatchWithPrefixFromRevisionWrapper(prefix *C.char, prefixSize C.in
 					}
 				}
 			case <-ctx.Done():
+				notifyStorePrefixWatchBrokenOnce(p, callbackContext, callbackFunc, false)
 				return
 			}
 		}

--- a/mooncake-common/etcd/etcd_wrapper.go
+++ b/mooncake-common/etcd/etcd_wrapper.go
@@ -102,6 +102,9 @@ func newStoreClientConfig(validEndpoints []string) clientv3.Config {
 }
 
 func parseEtcdEndpoints(endpoints *C.char) []string {
+	if endpoints == nil {
+		return nil
+	}
 	endpointStr := C.GoString(endpoints)
 	endpointStr = strings.ReplaceAll(endpointStr, ",", ";")
 	endpointList := strings.Split(endpointStr, ";")

--- a/mooncake-store/include/etcd_helper.h
+++ b/mooncake-store/include/etcd_helper.h
@@ -27,6 +27,15 @@ class EtcdHelper {
         const std::string& etcd_endpoints);
 
     /*
+     * @brief Reset the global store etcd client and reconnect to the given
+     *        endpoints. This cancels active store watches/keepalives in the Go
+     *        wrapper and creates a fresh clientv3.Client.
+     * @param etcd_endpoints: The endpoints of the etcd store client.
+     * @return: Error code.
+     */
+    static ErrorCode ResetEtcdStoreClient(const std::string& etcd_endpoints);
+
+    /*
      * @brief Get the value of a key from the etcd.
      * @param key: The key to get the value of.
      * @param key_size: The size of the key in bytes.

--- a/mooncake-store/include/ha/leadership/backends/etcd/etcd_leader_coordinator.h
+++ b/mooncake-store/include/ha/leadership/backends/etcd/etcd_leader_coordinator.h
@@ -50,6 +50,7 @@ class EtcdLeaderCoordinator final : public LeaderCoordinator {
     static LeadershipLossReason ClassifyLeadershipLossReason(ErrorCode err);
 
     ErrorCode EnsureConnected();
+    ErrorCode ResetConnection();
     ErrorCode ShutdownKeepAliveThread();
     void ClearLeadershipMonitorStateLocked();
     bool IsSameViewVersion(const std::optional<MasterView>& current_view,

--- a/mooncake-store/src/etcd_helper.cpp
+++ b/mooncake-store/src/etcd_helper.cpp
@@ -42,6 +42,26 @@ ErrorCode EtcdHelper::ConnectToEtcdStoreClient(
     }
 }
 
+ErrorCode EtcdHelper::ResetEtcdStoreClient(const std::string& etcd_endpoints) {
+    std::lock_guard<std::mutex> lock(etcd_mutex_);
+
+    char* err_msg = nullptr;
+    int ret = EtcdStoreResetClientWrapper(
+        const_cast<char*>(etcd_endpoints.c_str()), &err_msg);
+    if (ret != 0) {
+        LOG(ERROR) << "Failed to reset etcd store client: "
+                   << (err_msg == nullptr ? "" : err_msg);
+        if (err_msg != nullptr) {
+            free(err_msg);
+        }
+        return ErrorCode::ETCD_OPERATION_ERROR;
+    }
+
+    connected_endpoints_ = etcd_endpoints;
+    etcd_connected_ = true;
+    return ErrorCode::OK;
+}
+
 ErrorCode EtcdHelper::Get(const char* key, const size_t key_size,
                           std::string& value, EtcdRevisionId& revision_id) {
     char* err_msg = nullptr;
@@ -400,6 +420,11 @@ ErrorCode EtcdHelper::ConnectToEtcdStoreClient(
     (void)etcd_endpoints;
     LOG(FATAL) << "Etcd is not enabled in compilation";
     return ErrorCode::ETCD_OPERATION_ERROR;
+}
+
+ErrorCode EtcdHelper::ResetEtcdStoreClient(const std::string& etcd_endpoints) {
+    (void)etcd_endpoints;
+    return ErrorCode::UNAVAILABLE_IN_CURRENT_MODE;
 }
 
 ErrorCode EtcdHelper::Get(const char* key, const size_t key_size,

--- a/mooncake-store/src/ha/leadership/backends/etcd/etcd_leader_coordinator.cpp
+++ b/mooncake-store/src/ha/leadership/backends/etcd/etcd_leader_coordinator.cpp
@@ -61,6 +61,16 @@ ErrorCode EtcdLeaderCoordinator::Connect() {
     return err;
 }
 
+ErrorCode EtcdLeaderCoordinator::ResetConnection() {
+    auto err = EtcdHelper::ResetEtcdStoreClient(spec_.connstring);
+    if (err != ErrorCode::OK) {
+        connected_ = false;
+        return err;
+    }
+    connected_ = true;
+    return ErrorCode::OK;
+}
+
 tl::expected<std::optional<MasterView>, ErrorCode>
 EtcdLeaderCoordinator::ReadCurrentView() {
     auto err = EnsureConnected();
@@ -94,6 +104,7 @@ EtcdLeaderCoordinator::TryAcquireLeadership(const std::string& leader_address) {
     EtcdLeaseId lease_id = 0;
     err = EtcdHelper::GrantLease(DEFAULT_MASTER_VIEW_LEASE_TTL_SEC, lease_id);
     if (err != ErrorCode::OK) {
+        (void)ResetConnection();
         return tl::make_unexpected(err);
     }
 
@@ -117,9 +128,13 @@ EtcdLeaderCoordinator::TryAcquireLeadership(const std::string& leader_address) {
         };
     }
     if (err != ErrorCode::OK) {
+        (void)ResetConnection();  // Reset first to get off the stale client
+
         auto revoke_err = EtcdHelper::RevokeLease(lease_id);
         if (revoke_err != ErrorCode::OK) {
-            return tl::make_unexpected(revoke_err);
+            LOG(WARNING)
+                << "Failed to revoke lease after CreateWithLease failure: "
+                << static_cast<int>(revoke_err);
         }
         return tl::make_unexpected(err);
     }
@@ -194,6 +209,9 @@ tl::expected<bool, ErrorCode> EtcdLeaderCoordinator::RenewLeadership(
             started_keepalive = true;
             keepalive_thread_ = std::thread([this, lease = lease_id.value()]() {
                 auto rc = EtcdHelper::KeepAlive(lease);
+                if (rc == ErrorCode::ETCD_OPERATION_ERROR) {
+                    (void)EtcdHelper::ResetEtcdStoreClient(spec_.connstring);
+                }
                 std::shared_ptr<std::atomic<bool>> monitor_armed;
                 LeadershipLostCallback on_leadership_lost;
                 LeadershipLossReason loss_reason =

--- a/mooncake-store/tests/ha/leadership/etcd_leader_hang_e2e.sh
+++ b/mooncake-store/tests/ha/leadership/etcd_leader_hang_e2e.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.." && pwd)"
+WORK_DIR="${WORK_DIR:-/tmp/mooncake-etcd-leader-hang-e2e}"
+ETCD_BIN="${ETCD_BIN:-etcd}"
+ETCDCTL_BIN="${ETCDCTL_BIN:-etcdctl}"
+MASTER_BIN="${MASTER_BIN:-${ROOT_DIR}/build/mooncake-store/src/mooncake_master}"
+CLUSTER_ID="${CLUSTER_ID:-mooncake_cluster}"
+MASTER_VIEW_KEY="${MASTER_VIEW_KEY:-mooncake-store/${CLUSTER_ID}/master_view}"
+MASTER_ADDR="${MASTER_ADDR:-127.0.0.1}"
+MASTER_PORT="${MASTER_PORT:-50051}"
+MASTER_METRICS_PORT="${MASTER_METRICS_PORT:-9003}"
+ENDPOINTS="127.0.0.1:23791,127.0.0.1:23792,127.0.0.1:23793"
+ETCD_QUORUM_SIZE="${ETCD_QUORUM_SIZE:-2}"
+
+mkdir -p "${WORK_DIR}"
+
+ETCD_PIDS=()
+MASTER_PID=""
+
+cleanup() {
+  set +e
+  if [[ -n "${MASTER_PID}" ]]; then
+    kill "${MASTER_PID}" 2>/dev/null || true
+  fi
+  for pid in "${ETCD_PIDS[@]}"; do
+    kill -CONT "${pid}" 2>/dev/null || true
+    kill "${pid}" 2>/dev/null || true
+  done
+  wait 2>/dev/null || true
+  rm -rf "${WORK_DIR}"
+}
+trap cleanup EXIT
+
+start_etcd_node() {
+  local name="$1"
+  local client_port="$2"
+  local peer_port="$3"
+  local data_dir="${WORK_DIR}/${name}"
+
+  "${ETCD_BIN}" \
+    --name "${name}" \
+    --data-dir "${data_dir}" \
+    --listen-client-urls "http://127.0.0.1:${client_port}" \
+    --advertise-client-urls "http://127.0.0.1:${client_port}" \
+    --listen-peer-urls "http://127.0.0.1:${peer_port}" \
+    --initial-advertise-peer-urls "http://127.0.0.1:${peer_port}" \
+    --initial-cluster "etcd1=http://127.0.0.1:23891,etcd2=http://127.0.0.1:23892,etcd3=http://127.0.0.1:23893" \
+    --initial-cluster-state new \
+    >"${WORK_DIR}/${name}.log" 2>&1 &
+  ETCD_PIDS+=("$!")
+}
+
+healthy_endpoints_csv() {
+  local endpoints=()
+  IFS=',' read -r -a all_endpoints <<<"${ENDPOINTS}"
+  for endpoint in "${all_endpoints[@]}"; do
+    if "${ETCDCTL_BIN}" --endpoints="${endpoint}" endpoint health >/dev/null 2>&1; then
+      endpoints+=("${endpoint}")
+    fi
+  done
+  local IFS=,
+  echo "${endpoints[*]}"
+}
+
+healthy_endpoint_count() {
+  local healthy
+  healthy="$(healthy_endpoints_csv)"
+  if [[ -z "${healthy}" ]]; then
+    echo 0
+    return
+  fi
+  awk -F',' '{print NF}' <<<"${healthy}"
+}
+
+dump_logs() {
+  set +e
+  echo "---- mooncake_master.log ----" >&2
+  tail -n 80 "${WORK_DIR}/mooncake_master.log" 2>/dev/null >&2 || true
+  for name in etcd1 etcd2 etcd3; do
+    echo "---- ${name}.log ----" >&2
+    tail -n 40 "${WORK_DIR}/${name}.log" 2>/dev/null >&2 || true
+  done
+}
+
+wait_for_etcd() {
+  for _ in $(seq 1 60); do
+    if (( $(healthy_endpoint_count) >= ETCD_QUORUM_SIZE )); then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "etcd quorum did not become healthy" >&2
+  dump_logs
+  return 1
+}
+
+leader_pid() {
+  local live_endpoints
+  live_endpoints="$(healthy_endpoints_csv)"
+  if [[ -z "${live_endpoints}" ]]; then
+    echo "no healthy etcd endpoints" >&2
+    return 1
+  fi
+
+  local leader_client_url
+  leader_client_url="$("${ETCDCTL_BIN}" --endpoints="${live_endpoints}" endpoint status -w json \
+    | python3 -c 'import json,sys; data=json.load(sys.stdin); leaders=[x["Endpoint"] for x in data if x["Status"].get("leader")==x["Status"].get("header",{}).get("member_id")]; print(leaders[0] if leaders else "")')"
+
+  case "${leader_client_url}" in
+    *23791*) echo "${ETCD_PIDS[0]}" ;;
+    *23792*) echo "${ETCD_PIDS[1]}" ;;
+    *23793*) echo "${ETCD_PIDS[2]}" ;;
+    *) echo "unknown leader endpoint ${leader_client_url}" >&2; return 1 ;;
+  esac
+}
+
+wait_for_master_view() {
+  local expected="$1"
+  for _ in $(seq 1 90); do
+    local live_endpoints
+    live_endpoints="$(healthy_endpoints_csv)"
+    if [[ -z "${live_endpoints}" ]]; then
+      sleep 1
+      continue
+    fi
+
+    local value
+    value="$("${ETCDCTL_BIN}" --endpoints="${live_endpoints}" get "${MASTER_VIEW_KEY}" --print-value-only 2>/dev/null || true)"
+    if [[ "${value}" == "${expected}" ]]; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "master_view ${MASTER_VIEW_KEY} did not recover to ${expected}" >&2
+  dump_logs
+  return 1
+}
+
+start_master() {
+  "${MASTER_BIN}" \
+    --enable_ha=true \
+    --ha_backend_type=etcd \
+    --etcd_endpoints="${ENDPOINTS}" \
+    --cluster_id="${CLUSTER_ID}" \
+    --rpc_address="${MASTER_ADDR}" \
+    --rpc_port="${MASTER_PORT}" \
+    --metrics_port="${MASTER_METRICS_PORT}" \
+    >"${WORK_DIR}/mooncake_master.log" 2>&1 &
+  MASTER_PID="$!"
+}
+
+start_etcd_node etcd1 23791 23891
+start_etcd_node etcd2 23792 23892
+start_etcd_node etcd3 23793 23893
+wait_for_etcd
+
+start_master
+wait_for_master_view "${MASTER_ADDR}:${MASTER_PORT}"
+
+STOPPED_LEADER_PID="$(leader_pid)"
+kill -STOP "${STOPPED_LEADER_PID}"
+wait_for_etcd
+wait_for_master_view "${MASTER_ADDR}:${MASTER_PORT}"
+kill -CONT "${STOPPED_LEADER_PID}"
+
+KILLED_LEADER_PID="$(leader_pid)"
+kill -KILL "${KILLED_LEADER_PID}"
+wait_for_etcd
+wait_for_master_view "${MASTER_ADDR}:${MASTER_PORT}"
+
+echo "etcd leader hang e2e passed"

--- a/mooncake-store/tests/ha/leadership/high_availability_test.cpp
+++ b/mooncake-store/tests/ha/leadership/high_availability_test.cpp
@@ -7,6 +7,7 @@
 #include <mutex>
 #include <optional>
 #include <string>
+#include <thread>
 
 #ifdef STORE_USE_ETCD
 #include "etcd_helper.h"
@@ -352,6 +353,229 @@ TEST_F(HighAvailabilityTest, LeadershipMonitorReportsKeepAliveLoss) {
 
     monitor.value()->Stop();
     ASSERT_EQ(ErrorCode::OK, coordinator->ReleaseLeadership(session));
+}
+
+TEST_F(HighAvailabilityTest, EtcdStoreClientResetKeepsBasicOperationsWorking) {
+    if (auto skip_reason = GetEtcdSkipReason(); skip_reason.has_value()) {
+        GTEST_SKIP() << *skip_reason;
+    }
+
+    const std::string key =
+        FLAGS_etcd_test_key_prefix + "reset_basic_operation";
+    const std::string value_before = "before_reset";
+    const std::string value_after = "after_reset";
+
+    ASSERT_EQ(ErrorCode::OK,
+              EtcdHelper::Put(key.c_str(), key.size(), value_before.c_str(),
+                              value_before.size()));
+
+    std::string got;
+    EtcdRevisionId rev = 0;
+    ASSERT_EQ(ErrorCode::OK,
+              EtcdHelper::Get(key.c_str(), key.size(), got, rev));
+    ASSERT_EQ(value_before, got);
+
+    ASSERT_EQ(ErrorCode::OK,
+              EtcdHelper::ResetEtcdStoreClient(FLAGS_etcd_endpoints));
+
+    ASSERT_EQ(ErrorCode::OK,
+              EtcdHelper::Put(key.c_str(), key.size(), value_after.c_str(),
+                              value_after.size()));
+    ASSERT_EQ(ErrorCode::OK,
+              EtcdHelper::Get(key.c_str(), key.size(), got, rev));
+    ASSERT_EQ(value_after, got);
+
+    EtcdLeaseId lease_id = 0;
+    ASSERT_EQ(ErrorCode::OK, EtcdHelper::GrantLease(10, lease_id));
+    ASSERT_EQ(ErrorCode::OK, EtcdHelper::RevokeLease(lease_id));
+}
+
+TEST_F(HighAvailabilityTest, EtcdStoreClientResetStopsOldKeepAlive) {
+    if (auto skip_reason = GetEtcdSkipReason(); skip_reason.has_value()) {
+        GTEST_SKIP() << *skip_reason;
+    }
+
+    EtcdLeaseId lease_id = 0;
+    ASSERT_EQ(ErrorCode::OK, EtcdHelper::GrantLease(10, lease_id));
+
+    std::promise<ErrorCode> promise;
+    auto future = promise.get_future();
+    std::thread keep_alive_thread(
+        [&]() { promise.set_value(EtcdHelper::KeepAlive(lease_id)); });
+
+    auto cleanup_keep_alive = [&]() {
+        if (keep_alive_thread.joinable()) {
+            (void)EtcdHelper::CancelKeepAlive(lease_id);
+            keep_alive_thread.join();
+        }
+    };
+
+    auto ready_err = EtcdHelper::WaitKeepAliveReady(lease_id, 1000);
+    if (ready_err != ErrorCode::OK) {
+        cleanup_keep_alive();
+    }
+    ASSERT_EQ(ErrorCode::OK, ready_err);
+
+    auto reset_err = EtcdHelper::ResetEtcdStoreClient(FLAGS_etcd_endpoints);
+    if (reset_err != ErrorCode::OK) {
+        cleanup_keep_alive();
+    }
+    ASSERT_EQ(ErrorCode::OK, reset_err);
+
+    auto keep_alive_status = future.wait_for(std::chrono::seconds(5));
+    if (keep_alive_status != std::future_status::ready) {
+        cleanup_keep_alive();
+    }
+    ASSERT_EQ(keep_alive_status, std::future_status::ready);
+    EXPECT_NE(ErrorCode::OK, future.get());
+    keep_alive_thread.join();
+
+    EtcdLeaseId new_lease_id = 0;
+    ASSERT_EQ(ErrorCode::OK, EtcdHelper::GrantLease(10, new_lease_id));
+    ASSERT_EQ(ErrorCode::OK, EtcdHelper::RevokeLease(new_lease_id));
+}
+
+// Static data for prefix watch callback (C-linkage required for Go callback)
+static std::atomic<int> g_prefix_watch_event_count{0};
+static std::atomic<int> g_prefix_watch_broken_count{0};
+
+extern "C" void PrefixWatchTestCallback(void* /*ctx*/, const char* /*key*/,
+                                        size_t /*key_size*/,
+                                        const char* /*value*/,
+                                        size_t /*value_size*/, int event_type,
+                                        int64_t /*mod_revision*/) {
+    if (event_type == 2) {
+        g_prefix_watch_broken_count.fetch_add(1);
+    } else {
+        g_prefix_watch_event_count.fetch_add(1);
+    }
+}
+
+bool WaitForAtomicAtLeast(const std::atomic<int>& value, int expected,
+                          std::chrono::milliseconds timeout) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (value.load() >= expected) {
+            return true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    return value.load() >= expected;
+}
+
+TEST_F(HighAvailabilityTest,
+       EtcdStoreClientResetTriggersPrefixWatchBrokenAndReconnect) {
+    if (auto skip_reason = GetEtcdSkipReason(); skip_reason.has_value()) {
+        GTEST_SKIP() << *skip_reason;
+    }
+
+    const std::string prefix =
+        FLAGS_etcd_test_key_prefix + "reset_prefix_watch/";
+    const std::string key1 = prefix + "key1";
+    const std::string value1 = "value1";
+    const std::string value2 = "value2";
+
+    // Clean up any leftover keys
+    std::string prefix_end = prefix;
+    if (!prefix_end.empty()) prefix_end.back()++;
+    (void)EtcdHelper::DeleteRange(prefix.c_str(), prefix.size(),
+                                  prefix_end.c_str(), prefix_end.size());
+
+    // Reset counters and start prefix watch
+    g_prefix_watch_event_count.store(0);
+    g_prefix_watch_broken_count.store(0);
+
+    ASSERT_EQ(ErrorCode::OK,
+              EtcdHelper::WatchWithPrefixFromRevision(
+                  prefix.c_str(), prefix.size(), /*start_revision=*/0,
+                  /*callback_context=*/nullptr, PrefixWatchTestCallback));
+
+    // Allow watch to establish
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+    // Write first value -- watch should receive it
+    ASSERT_EQ(ErrorCode::OK, EtcdHelper::Put(key1.c_str(), key1.size(),
+                                             value1.c_str(), value1.size()));
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    EXPECT_GE(g_prefix_watch_event_count.load(), 1);
+
+    // Trigger reset
+    ASSERT_EQ(ErrorCode::OK,
+              EtcdHelper::ResetEtcdStoreClient(FLAGS_etcd_endpoints));
+
+    // Wait for WATCH_BROKEN callback
+    ASSERT_TRUE(WaitForAtomicAtLeast(g_prefix_watch_broken_count, 1,
+                                     std::chrono::seconds(5)))
+        << "Expected WATCH_BROKEN after reset";
+    EXPECT_EQ(1, g_prefix_watch_broken_count.load());
+
+    // Wait for old goroutine to fully exit
+    ASSERT_EQ(ErrorCode::OK, EtcdHelper::WaitWatchWithPrefixStopped(
+                                 prefix.c_str(), prefix.size(), 5000));
+
+    // Start a new watch -- should succeed (old entry cleaned up by defer)
+    g_prefix_watch_event_count.store(0);
+    g_prefix_watch_broken_count.store(0);
+
+    ASSERT_EQ(ErrorCode::OK,
+              EtcdHelper::WatchWithPrefixFromRevision(
+                  prefix.c_str(), prefix.size(), /*start_revision=*/0,
+                  /*callback_context=*/nullptr, PrefixWatchTestCallback));
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+    // Write second value -- new watch should receive it
+    ASSERT_EQ(ErrorCode::OK, EtcdHelper::Put(key1.c_str(), key1.size(),
+                                             value2.c_str(), value2.size()));
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    EXPECT_GE(g_prefix_watch_event_count.load(), 1)
+        << "New watch should receive events after reset";
+
+    // Clean up
+    ASSERT_EQ(ErrorCode::OK,
+              EtcdHelper::CancelWatchWithPrefix(prefix.c_str(), prefix.size()));
+    ASSERT_EQ(ErrorCode::OK, EtcdHelper::WaitWatchWithPrefixStopped(
+                                 prefix.c_str(), prefix.size(), 5000));
+}
+
+TEST_F(HighAvailabilityTest, EtcdStorePrefixWatchCancelDoesNotReportBroken) {
+    if (auto skip_reason = GetEtcdSkipReason(); skip_reason.has_value()) {
+        GTEST_SKIP() << *skip_reason;
+    }
+
+    const std::string prefix =
+        FLAGS_etcd_test_key_prefix + "cancel_prefix_watch/";
+    const std::string key = prefix + "key";
+    const std::string value = "value";
+
+    std::string prefix_end = prefix;
+    if (!prefix_end.empty()) prefix_end.back()++;
+    (void)EtcdHelper::DeleteRange(prefix.c_str(), prefix.size(),
+                                  prefix_end.c_str(), prefix_end.size());
+
+    g_prefix_watch_event_count.store(0);
+    g_prefix_watch_broken_count.store(0);
+
+    ASSERT_EQ(ErrorCode::OK,
+              EtcdHelper::WatchWithPrefixFromRevision(
+                  prefix.c_str(), prefix.size(), /*start_revision=*/0,
+                  /*callback_context=*/nullptr, PrefixWatchTestCallback));
+
+    ASSERT_EQ(ErrorCode::OK, EtcdHelper::Put(key.c_str(), key.size(),
+                                             value.c_str(), value.size()));
+    ASSERT_TRUE(WaitForAtomicAtLeast(g_prefix_watch_event_count, 1,
+                                     std::chrono::seconds(5)));
+
+    ASSERT_EQ(ErrorCode::OK,
+              EtcdHelper::CancelWatchWithPrefix(prefix.c_str(), prefix.size()));
+    ASSERT_EQ(ErrorCode::OK, EtcdHelper::WaitWatchWithPrefixStopped(
+                                 prefix.c_str(), prefix.size(), 5000));
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    EXPECT_EQ(0, g_prefix_watch_broken_count.load())
+        << "Explicit cancel should not report WATCH_BROKEN";
 }
 
 #endif


### PR DESCRIPTION
## Description

Issue: kvcache-ai/Mooncake#2253

When the current etcd leader is suspended with SIGSTOP (kill -19), the TCP connection remains half-open. Mooncake master detects the lease keepalive failure and stops serving, but recovery attempts reuse the same stale storeClient, causing GrantLease/CreateWithLease to timeout with 'context deadline exceeded'.

Changes:

- Go wrapper: configure gRPC keepalive (10s/3s/PermitWithoutStream) to detect half-open connections faster; add synchronized getStoreClient() accessor; add EtcdStoreResetClientWrapper that cancels all active keepalive/watch contexts, creates a fresh clientv3.Client, and closes the old one.

- Go wrapper (review fix): cancelAllStorePrefixWatches() no longer deletes map entries early; let goroutine defer clean up to avoid race with new watch registration. Watch goroutine now sends WATCH_BROKEN on all ctx.Done() paths, allowing C++ watchers to detect reset and reconnect.

- C++ EtcdHelper: add ResetEtcdStoreClient() API.

- C++ HA coordinator: trigger ResetConnection() after GrantLease or CreateWithLease failures in TryAcquireLeadership, and after ETCD_OPERATION_ERROR in the keepalive thread.

- C++ HA coordinator (review fix): on CreateWithLease non-transaction failure, reset the etcd client FIRST before attempting RevokeLease. This ensures the stale client is always replaced even if RevokeLease also fails on the same broken connection.

- Tests: add gtest cases verifying basic operations, keepalive termination, and prefix watch broken/reconnect after reset. Add e2e bash script for 3-node etcd SIGSTOP and SIGKILL regression testing.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

- Added/updated tests:
  - Added coverage for prefix watch reset recovery in `high_availability_test.cpp`.
    - Verifies that `EtcdStoreResetClient()` triggers exactly one `WATCH_BROKEN` callback.
    - Verifies that the old watch goroutine stops and a new prefix watch can be registered.
    - Verifies that the new watch receives events after reset.
  - Added `EtcdStorePrefixWatchCancelDoesNotReportBroken`.
    - Verifies that explicit `CancelWatchWithPrefix()` does not emit a misleading `WATCH_BROKEN`.
  - Updated `etcd_leader_hang_e2e.sh`.
    - Uses the scoped master view key: `mooncake-store/${CLUSTER_ID}/master_view`.
    - Starts `mooncake_master` with the matching `--cluster_id`.
    - Treats etcd as healthy when quorum is available, so the script can validate `SIGSTOP` / `SIGKILL` leader-failure scenarios.

- Unit / integration test status:
  - `./build/mooncake-store/tests/high_availability_test` was executed.
  - All 9 tests passed, including the two touched by this PR:
    - EtcdStoreClientResetTriggersPrefixWatchBrokenAndReconnect (updated) — strict exact-once WATCH_BROKEN assertion holds; the new watch re-registers and receives events.
    - EtcdStorePrefixWatchCancelDoesNotReportBroken (new) — WATCH_BROKEN count is 0 after explicit cancel.

- E2E status:
  - `etcd_leader_hang_e2e.sh` was executed; it completed the full SIGSTOP → recover → SIGKILL → recover cycle and printed etcd leader hang e2e passed (exit 0).
  - The script should be run in an environment with `etcd`, `etcdctl`, `mooncake_master`, local port access, and process signaling support.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
