### PR TITLE
[build] Migrate NPU wheel CI to cloud runners with ARM/x86 matrix

### DIFF
--- a/.github/workflows/release-npu.yaml
+++ b/.github/workflows/release-npu.yaml
@@ -180,6 +180,7 @@ jobs:
           files: mooncake-wheel/dist-release/*.whl
 
       - name: Publish package to PyPI
+        if: github.repository == 'kvcache-ai/Mooncake'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: mooncake-wheel/dist-release/

--- a/.github/workflows/release-npu.yaml
+++ b/.github/workflows/release-npu.yaml
@@ -5,114 +5,47 @@ on:
     tags:
       - 'v*'
 
+env:
+  CANN_VERSION: "9.0.0"
+
 jobs:
   build:
-    if: ${{ github.repository == 'kvcache-ai/Mooncake' && !contains(github.ref_name, '-') }}
+    if: ${{ !contains(github.ref_name, '-') }}
 
-    runs-on: self-hosted
+    strategy:
+      max-parallel: 2
+      matrix:
+        arch: [aarch64, x86_64]
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+        include:
+          - arch: aarch64
+            runner: ubuntu-22.04-arm
+            cann_arch: aarch64
+          - arch: x86_64
+            runner: ubuntu-22.04
+            cann_arch: x86_64
+
+    runs-on: ${{ matrix.runner }}
 
     permissions:
       contents: write
-
-    strategy:
-      max-parallel: 1
-      matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     env:
       BUILD_WITH_EP: "0"
       NPU_BUILD: "1"
 
-    container:
-      image: localhost:5000/mooncake-hixl-ci:v6-release
-
-      options: --privileged --user 0:0 --device /dev/davinci0 --device /dev/davinci1 --device /dev/davinci2 --device /dev/davinci3
-                    --device /dev/davinci4 --device /dev/davinci5 --device /dev/davinci6 --device /dev/davinci7
-                    --device /dev/davinci_manager --device /dev/devmm_svm --device /dev/hisi_hdc --ulimit nproc=65535:65535
-
-      volumes:
-        - /usr/local/dcmi:/usr/local/dcmi:ro
-        - /usr/local/Ascend/driver/:/usr/local/Ascend/driver/:ro
-        - /etc/ascend_install.info:/etc/ascend_install.info:ro
-        - /etc/hccn.conf:/etc/hccn.conf:ro
-
     steps:
-      - name: Configure GitHub fetch defaults
-        shell: bash
-        run: |
-          git config --global protocol.version 2
-          git config --global http.version HTTP/1.1
-          git config --global http.lowSpeedLimit 1024
-          git config --global http.lowSpeedTime 30
-
       - name: Checkout code
-        id: checkout_code
-        continue-on-error: true
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
-          persist-credentials: false
+          fetch-depth: 0
 
-      - name: Retry checkout via GitHub mirror
-        if: steps.checkout_code.outcome == 'failure'
-        shell: bash
-        env:
-          ASCEND_GITHUB_MIRROR_URLS: 'https://ghfast.top/'
-        run: |
-          set -euo pipefail
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
-          if [ -z "${ASCEND_GITHUB_MIRROR_URLS:-}" ]; then
-            echo "Checkout from GitHub failed and ASCEND_GITHUB_MIRROR_URLS is not set"
-            exit 1
-          fi
-
-          normalize_base() {
-            local base="$1"
-            base="${base#${base%%[![:space:]]*}}"
-            base="${base%${base##*[![:space:]]}}"
-            [ -n "$base" ] || return 1
-            [ "$base" != "https://github.com/" ] && base="${base%/}/"
-            printf '%s\n' "$base"
-          }
-
-          candidates=()
-          while IFS= read -r raw; do
-            base="$(normalize_base "$raw" || true)"
-            [ -n "$base" ] || continue
-            [ "$base" = "https://github.com/" ] && continue
-            candidates+=("$base")
-          done < <(printf '%s\n' "$ASCEND_GITHUB_MIRROR_URLS" | tr ',;' '\n')
-
-          if [ ${#candidates[@]} -eq 0 ]; then
-            echo "Checkout from GitHub failed and no valid mirror candidates were configured"
-            exit 1
-          fi
-
-          workdir="${GITHUB_WORKSPACE}"
-          git config --global --add safe.directory "$workdir"
-
-          for base in "${candidates[@]}"; do
-            mirror_url="${base}https://github.com/${GITHUB_REPOSITORY}.git"
-            echo "Retrying checkout with ${mirror_url}"
-
-            find "$workdir" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
-            git init "$workdir"
-            git -C "$workdir" remote add origin "$mirror_url"
-
-            if git -C "$workdir" fetch --depth=1 origin "${{ github.sha }}" && \
-               git -C "$workdir" checkout --force --detach FETCH_HEAD; then
-              echo "Mirror checkout succeeded via ${base}"
-              exit 0
-            fi
-
-            echo "Mirror checkout failed via ${base}"
-            rm -rf "$workdir/.git"
-          done
-
-          echo "Direct GitHub checkout failed and all mirror retries failed"
-          exit 1
-
-      - name: Use container Python ${{ matrix.python-version }}
+      - name: Set Python bin
         shell: bash
         run: |
           set -euo pipefail
@@ -121,29 +54,49 @@ jobs:
           "$PYTHON_BIN" -m pip --version
           echo "PYTHON_BIN=${PYTHON_BIN}" >> "$GITHUB_ENV"
 
-      - name: Install dependencies
+      - name: Install CANN Toolkit
         shell: bash
-        env:
-          ASCEND_GITHUB_MIRROR_URLS: 'https://ghfast.top/'
         run: |
           set -euo pipefail
-          source /usr/local/Ascend/cann-9.0.0/set_env.sh
-          if command -v apt-get >/dev/null 2>&1; then
-            bash -x dependencies.sh -y
-          else
-            bash -x scripts/ascend/dependencies_openeuler.sh -y
-          fi
-          bash scripts/ascend/dependencies_ascend_installation.sh
+          CANN_URL="https://ascend-repo.obs.cn-east-2.myhuaweicloud.com/CANN/CANN%20${{ env.CANN_VERSION }}/Ascend-cann-toolkit_${{ env.CANN_VERSION }}_linux-${{ matrix.cann_arch }}.run"
+          echo "Downloading CANN ${{ env.CANN_VERSION }} from ${CANN_URL}"
+          wget -q --show-progress -O /tmp/cann_toolkit.run "${CANN_URL}"
+          chmod +x /tmp/cann_toolkit.run
+          sudo /tmp/cann_toolkit.run --install --install-for-all --install-path=/usr/local/Ascend --quiet
+          rm -f /tmp/cann_toolkit.run
+
+      - name: Build and install HIXL
+        shell: bash
+        run: |
+          set -eo pipefail
+          export PYTHONPATH="${PYTHONPATH:-}"
+          export CMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH:-}"
+          source /usr/local/Ascend/cann/set_env.sh
+          sudo ${PYTHON_BIN} -m pip install setuptools
+          cd /tmp
+          git clone https://gitcode.com/cann/hixl.git
+          cd hixl
+          bash build.sh -j$(nproc)
+          sudo ./build_out/cann-hixl_*.run --full --quiet --pylocal --install-path=/usr/local/Ascend
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          set -eo pipefail
+          export PYTHONPATH="${PYTHONPATH:-}"
+          export CMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH:-}"
+          source /usr/local/Ascend/cann/set_env.sh
+          sudo bash -x dependencies.sh -y
+          sudo bash scripts/ascend/dependencies_ascend_installation.sh
           echo "PATH=/usr/local/go/bin:${PATH}" >> "$GITHUB_ENV"
-          echo "GOPROXY=https://goproxy.io|https://mirrors.aliyun.com/goproxy/|https://goproxy.cn|direct" >> "$GITHUB_ENV"
-          echo "GOSUMDB=sum.golang.google.cn" >> "$GITHUB_ENV"
-          /usr/local/go/bin/go env -w GOPROXY="https://goproxy.io|https://mirrors.aliyun.com/goproxy/|https://goproxy.cn|direct"
-          /usr/local/go/bin/go env -w GOSUMDB=sum.golang.google.cn
 
       - name: Configure project
         shell: bash
         run: |
-          source /usr/local/Ascend/cann-9.0.0/set_env.sh
+          set -eo pipefail
+          export PYTHONPATH="${PYTHONPATH:-}"
+          export CMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH:-}"
+          source /usr/local/Ascend/cann/set_env.sh
           rm -rf build
           mkdir build
           cd build
@@ -162,16 +115,15 @@ jobs:
 
       - name: Build project
         shell: bash
-        env:
-          GOPROXY: 'https://goproxy.io|https://mirrors.aliyun.com/goproxy/|https://goproxy.cn|direct'
-          GOSUMDB: sum.golang.google.cn
         run: |
-          set -euo pipefail
-          source /usr/local/Ascend/cann-9.0.0/set_env.sh
+          set -eo pipefail
+          export PYTHONPATH="${PYTHONPATH:-}"
+          export CMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH:-}"
+          source /usr/local/Ascend/cann/set_env.sh
           export PATH="/usr/local/go/bin:${PATH}"
           cd build
           cmake --build . -j"$(nproc)"
-          cmake --install .
+          sudo cmake --install .
 
       - name: Generate Python version tag
         id: generate_tag_release
@@ -182,14 +134,17 @@ jobs:
       - name: Build Python wheel
         shell: bash
         run: |
-          source /usr/local/Ascend/cann-9.0.0/set_env.sh
+          set -eo pipefail
+          export PYTHONPATH="${PYTHONPATH:-}"
+          export CMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH:-}"
+          source /usr/local/Ascend/cann/set_env.sh
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
           NPU_BUILD=1 PYTHON_VERSION=${{ matrix.python-version }} OUTPUT_DIR=dist-npu-py${{ steps.generate_tag_release.outputs.python_version_tag }} ./scripts/build_wheel.sh
 
       - name: Upload Python wheel artifact
         uses: actions/upload-artifact@v4
         with:
-          name: mooncake-wheel-npu-py${{ steps.generate_tag_release.outputs.python_version_tag }}
+          name: mooncake-wheel-npu-${{ matrix.arch }}-py${{ steps.generate_tag_release.outputs.python_version_tag }}
           path: mooncake-wheel/dist-npu-py${{ steps.generate_tag_release.outputs.python_version_tag }}/*.whl
 
   publish-release:
@@ -210,7 +165,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: mooncake-wheel/dist-all
-          pattern: mooncake-wheel-npu-py*
+          pattern: mooncake-wheel-npu-*
 
       - name: Prepare wheels for release
         run: |


### PR DESCRIPTION
## Description

Migrate the NPU wheel release pipeline from self-hosted runner to GitHub cloud runners, add HIXL source compilation, and unify ARM/x86 into a single workflow.

### 1. Cloud runner migration
- Replace self-hosted runner + Docker container with `ubuntu-22.04-arm` / `ubuntu-22.04` cloud runners
- Remove container, device mappings, volume mounts, and git mirror logic
- Install CANN toolkit from OBS on every build
- Produces `manylinux_2_35` wheels (ubuntu-22.04 glibc baseline)

### 2. HIXL source build
- Clone and compile [HIXL](https://gitcode.com/cann/hixl) from source for ADXL headers/libs
- Install `setuptools` for Python 3.12+ compatibility (distutils removal)

### 3. ARM/x86 unified matrix
- Single workflow: 2 architectures (aarch64, x86_64) × 4 Python versions (3.10–3.13)
- ARM and x86 builds run in parallel (`max-parallel: 2`)
- Artifact names include architecture: `mooncake-wheel-npu-{arch}-py{version}`

### 4. Build environment fixes
- Pre-set `PYTHONPATH` and `CMAKE_PREFIX_PATH` to fix CANN `set_env.sh` unbound variable errors
- Use `sudo` for dependency installation and `cmake --install`
- Use `/usr/local/Ascend/cann` symlink path for `set_env.sh`


## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
