### PR TITLE
[CI/Build] Enhance pre-commit hooks with actionlint, shellcheck, and additional checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,9 +19,14 @@ repos:
       - id: end-of-file-fixer
         exclude: '^(build/|extern/|mooncake-wheel/repaired_wheels_.*|.*/build/|FAST25-release/)'
       - id: check-yaml
+      - id: check-toml
       - id: check-merge-conflict
       - id: check-added-large-files
         args: ['--maxkb=1024']
+      - id: check-symlinks
+      - id: detect-private-key
+      - id: no-commit-to-branch
+        args: ['--branch', 'main']
 
   - repo: local
     hooks:
@@ -62,3 +67,16 @@ repos:
       - id: cmake-format
         files: 'CMakeLists\.txt|.*\.cmake'
         exclude: '^(extern/|build/|.*/build/|FAST25-release/)'
+
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+        args: ['--severity=warning']
+        exclude: '^(extern/|FAST25-release/)'
+
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.7
+    hooks:
+      - id: actionlint
+        files: '\.github/workflows/.*\.ya?ml$'


### PR DESCRIPTION
## Summary
- Add `actionlint` for GitHub Actions workflow validation
- Add `shellcheck` for shell script linting
- Add `check-toml`, `check-symlinks`, `detect-private-key`, `no-commit-to-branch` hooks

## Motivation
Close the gap with vllm (25+ hooks) and sglang (13+ hooks). Currently Mooncake has 7 hooks; this brings it to 13.

## Module
- [x] CI/CD

## Type of Change
- [x] New feature

## AI Assistance Disclosure
- [x] AI tools were used (Claude Code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)