### PR TITLE
[CI/Build] Add stale issue/PR bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,41 @@
+name: Close Stale Issues and PRs
+
+on:
+  schedule:
+    - cron: '37 2 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had
+            recent activity. It will be closed in 30 days if no further activity occurs.
+            If this issue is still relevant, please comment to keep it open.
+          stale-pr-message: >
+            This PR has been automatically marked as stale because it has not had
+            recent activity. It will be closed in 14 days if no further activity occurs.
+            Please update the PR or comment to keep it open.
+          close-issue-message: >
+            This issue was closed because it has been inactive for 120 days.
+            Feel free to reopen if this is still relevant.
+          close-pr-message: >
+            This PR was closed because it has been inactive for 104 days.
+            Feel free to reopen if you'd like to continue the work.
+          days-before-stale: 90
+          days-before-close: 30
+          days-before-pr-stale: 90
+          days-before-pr-close: 14
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          exempt-issue-labels: 'pinned,security,RFC'
+          exempt-pr-labels: 'pinned,work-in-progress'
+          operations-per-run: 100


### PR DESCRIPTION
## Summary
- Add `.github/workflows/stale.yml`
- Mark issues stale after 90 days, close after 120 days
- Mark PRs stale after 90 days, close after 104 days
- Exempt: pinned, security, RFC, work-in-progress labels

## Motivation
Reduce issue/PR clutter. Both vllm and sglang use stale bots.

## Module
- [x] CI/CD

## Type of Change
- [x] New feature

## AI Assistance Disclosure
- [x] AI tools were used (Claude Code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)