### PR TITLE
[CI/Build] Expand auto-labeling and add PR description cleanup

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -22,3 +22,43 @@ Mooncake EP:
 Installation:
   - changed-files:
     - any-glob-to-any-file: 'mooncake-wheel/**/*'
+
+P2P Store:
+  - changed-files:
+    - any-glob-to-any-file: 'mooncake-p2p-store/**/*'
+
+Integration:
+  - changed-files:
+    - any-glob-to-any-file: 'mooncake-integration/**/*'
+
+Common:
+  - changed-files:
+    - any-glob-to-any-file: 'mooncake-common/**/*'
+
+CI/Build:
+  - changed-files:
+    - any-glob-to-any-file:
+      - '.github/**/*'
+      - 'CMakeLists.txt'
+      - '.pre-commit-config.yaml'
+      - 'dependencies.sh'
+
+Documentation:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'docs/**/*'
+      - '*.md'
+
+Tests:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'scripts/test_*'
+      - 'mooncake-wheel/tests/**/*'
+      - 'scripts/tone_tests/**/*'
+
+Ascend/NPU:
+  - changed-files:
+    - any-glob-to-any-file:
+      - '**/ascend*/**'
+      - 'scripts/ascend/**'
+      - '.github/workflows/*ascend*'

--- a/.github/workflows/pr-tidy.yml
+++ b/.github/workflows/pr-tidy.yml
@@ -1,0 +1,31 @@
+name: PR Tidy
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  tidy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clean PR description
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            if (!pr.body) return;
+
+            // Remove HTML comment blocks (template instructions)
+            let body = pr.body.replace(/<!--[\s\S]*?-->/g, '').trim();
+
+            if (body !== pr.body) {
+              await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                body: body
+              });
+            }


### PR DESCRIPTION
## Summary
- Expand `.github/labeler.yml` with 7 new labels: P2P Store, Integration, Common, CI/Build, Documentation, Tests, Ascend/NPU
- Add `.github/workflows/pr-tidy.yml` to auto-clean HTML comments from PR descriptions

## Motivation
Better auto-triage and cleaner PR descriptions. Modeled after vllm's `new_pr_bot.yml`.

## Module
- [x] CI/CD

## Type of Change
- [x] New feature

## AI Assistance Disclosure
- [x] AI tools were used (Claude Code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)