### PR TITLE
[Store] fix: register local hot cache memory with transfer engine

### DIFF
--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -702,6 +702,11 @@ class Client {
     ErrorCode InitLocalHotCache();
 
     /**
+     * @brief Unregister local hot cache backing memory from TransferEngine.
+     */
+    void UnregisterLocalHotCacheMemory();
+
+    /**
      * @brief Read MC_STORE_LOCAL_HOT_CACHE_SIZE from environment variable
      * @return Cache size in bytes, or 0 if not set or invalid
      */
@@ -905,6 +910,7 @@ class Client {
     // Local hot cache and async handler
     std::shared_ptr<LocalHotCache> hot_cache_;
     std::unique_ptr<LocalHotCacheHandler> hot_cache_handler_;
+    bool hot_cache_memory_registered_{false};
 
     // Frequency admission: only cache keys whose CMS count >= threshold
     std::unique_ptr<CountMinSketch> admission_sketch_;

--- a/mooncake-store/include/local_hot_cache.h
+++ b/mooncake-store/include/local_hot_cache.h
@@ -113,6 +113,16 @@ class LocalHotCache {
     size_t GetBlockSize() const { return block_size_; }
 
     /**
+     * @brief Get the base address of the bulk allocation.
+     */
+    void* GetBaseAddress() const { return bulk_memory_standard_; }
+
+    /**
+     * @brief Get the total size of the bulk allocation in bytes.
+     */
+    size_t GetTotalSize() const { return bulk_memory_size_; }
+
+    /**
      * @brief Get the shm segment backing this cache.
      * Only valid when constructed with use_shm=true.
      * @return shared_ptr to the ShmSegment, or nullptr if shm is disabled.

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -3905,7 +3905,7 @@ ErrorCode Client::InitLocalHotCache() {
             hot_cache_->GetBaseAddress(), hot_cache_->GetTotalSize(),
             kWildcardLocation, true, true);
         if (rc != 0) {
-            MC_LOG(ERROR)
+            LOG(ERROR)
                 << "Failed to register local hot cache memory with transfer "
                    "engine, base="
                 << hot_cache_->GetBaseAddress()
@@ -3963,7 +3963,7 @@ void Client::UnregisterLocalHotCacheMemory() {
     int rc = transfer_engine_->unregisterLocalMemory(
         hot_cache_->GetBaseAddress(), true);
     if (rc != 0 && rc != ERR_ADDRESS_NOT_REGISTERED) {
-        MC_LOG(ERROR)
+        LOG(ERROR)
             << "Failed to unregister local hot cache memory from transfer "
                "engine, base="
             << hot_cache_->GetBaseAddress()

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -384,8 +384,9 @@ Client::~Client() {
         }
     }
 
-    // Stop hot cache handler and hot cache
+    // Stop hot cache handler before unregistering/freeing its backing memory.
     hot_cache_handler_.reset();
+    UnregisterLocalHotCacheMemory();
     hot_cache_.reset();
 }
 
@@ -3857,6 +3858,11 @@ size_t Client::GetLocalHotBlockSizeFromEnv(size_t default_value) {
 }
 
 ErrorCode Client::InitLocalHotCache() {
+    hot_cache_handler_.reset();
+    UnregisterLocalHotCacheMemory();
+    hot_cache_.reset();
+    admission_sketch_.reset();
+
     // Defaults: hot cache is disabled unless MC_STORE_LOCAL_HOT_CACHE_SIZE is
     // set to a positive value; when enabled, default block size is 16MB and
     // thread_num is 2.
@@ -3867,9 +3873,6 @@ ErrorCode Client::InitLocalHotCache() {
     size_t total_cache = GetLocalHotCacheSizeFromEnv();
     if (total_cache == 0) {
         // Environment variable not set or invalid, disable cache
-        hot_cache_.reset();
-        hot_cache_handler_.reset();
-        admission_sketch_.reset();
         return ErrorCode::OK;
     }
 
@@ -3897,10 +3900,29 @@ ErrorCode Client::InitLocalHotCache() {
             admission_sketch_.reset();
             return ErrorCode::INVALID_PARAMS;
         }
+
+        int rc = transfer_engine_->registerLocalMemory(
+            hot_cache_->GetBaseAddress(), hot_cache_->GetTotalSize(),
+            kWildcardLocation, true, true);
+        if (rc != 0) {
+            MC_LOG(ERROR)
+                << "Failed to register local hot cache memory with transfer "
+                   "engine, base="
+                << hot_cache_->GetBaseAddress() << ", size="
+                << hot_cache_->GetTotalSize() << ", ret=" << rc;
+            hot_cache_.reset();
+            hot_cache_handler_.reset();
+            admission_sketch_.reset();
+            hot_cache_memory_registered_ = false;
+            return ErrorCode::INVALID_PARAMS;
+        }
+        hot_cache_memory_registered_ = true;
+
         LOG(INFO) << "Local hot cache enabled with cache size=" << total_cache
                   << ", block size=" << block_size
                   << ", block amount=" << hot_cache_->GetCacheSize()
-                  << ", shm=" << (use_shm ? "on" : "off");
+                  << ", shm=" << (use_shm ? "on" : "off")
+                  << ", transfer engine registered=on";
         // Create async handler with 2 worker threads
         hot_cache_handler_ =
             std::make_unique<LocalHotCacheHandler>(hot_cache_, thread_num);
@@ -3927,6 +3949,27 @@ ErrorCode Client::InitLocalHotCache() {
         }
     }
     return ErrorCode::OK;
+}
+
+void Client::UnregisterLocalHotCacheMemory() {
+    if (!(hot_cache_ && hot_cache_memory_registered_)) {
+        return;
+    }
+    if (!transfer_engine_) {
+        hot_cache_memory_registered_ = false;
+        return;
+    }
+
+    int rc = transfer_engine_->unregisterLocalMemory(
+        hot_cache_->GetBaseAddress(), true);
+    if (rc != 0 && rc != ERR_ADDRESS_NOT_REGISTERED) {
+        MC_LOG(ERROR)
+            << "Failed to unregister local hot cache memory from transfer "
+               "engine, base="
+            << hot_cache_->GetBaseAddress() << ", size="
+            << hot_cache_->GetTotalSize() << ", ret=" << rc;
+    }
+    hot_cache_memory_registered_ = false;
 }
 
 void Client::ProcessSlicesAsync(const std::string& key,

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -3908,8 +3908,8 @@ ErrorCode Client::InitLocalHotCache() {
             MC_LOG(ERROR)
                 << "Failed to register local hot cache memory with transfer "
                    "engine, base="
-                << hot_cache_->GetBaseAddress() << ", size="
-                << hot_cache_->GetTotalSize() << ", ret=" << rc;
+                << hot_cache_->GetBaseAddress()
+                << ", size=" << hot_cache_->GetTotalSize() << ", ret=" << rc;
             hot_cache_.reset();
             hot_cache_handler_.reset();
             admission_sketch_.reset();
@@ -3966,8 +3966,8 @@ void Client::UnregisterLocalHotCacheMemory() {
         MC_LOG(ERROR)
             << "Failed to unregister local hot cache memory from transfer "
                "engine, base="
-            << hot_cache_->GetBaseAddress() << ", size="
-            << hot_cache_->GetTotalSize() << ", ret=" << rc;
+            << hot_cache_->GetBaseAddress()
+            << ", size=" << hot_cache_->GetTotalSize() << ", ret=" << rc;
     }
     hot_cache_memory_registered_ = false;
 }


### PR DESCRIPTION
## Description

When `MC_STORE_LOCAL_HOT_CACHE_SIZE` is enabled with local segment-size set to 0 and remote segment-size > 0, all transfer operations fail with error `-800` (TRANSFER_FAIL):

```
E0609 15:55:28.095067 1212796 transfer_task.cpp:759] Batch 281445516383920 completed with task failures: task_ids=[0]
E0609 15:55:28.095104 1212796 client_service.cpp:1408] Transfer failed for key: verify_0000000000000950 with error: -800
E0609 15:55:28.096179 1212796 real_client.cpp:2957] BatchGet failed for key 'verify_0000000000000265': TRANSFER_FAIL
```

Reproduction command:

```bash
export MC_STORE_LOCAL_HOT_CACHE_SIZE=17179869184
python3 mooncake-store/benchmarks/store_kv_bench.py --scenario mixed_rw --io-api plain \
  --local-hostname 127.0.0.1:50071 --metadata-server http://192.168.64.9:8080/metadata \
  --master-server 192.168.64.9:50051 --protocol rdma --global-segment-size $((0*1024*1024*1024)) \
  --nr-objects 1000 --batch-size 8 --key-prefix verify --key-size 200 --value-size 1048576 \
  --memory-replica-num 1 --nof-replica-num 0 --verify --pattern 0xab --device-name rocep133s0f0 --runtime=10
```

## Root Cause

`InitLocalHotCache()` allocates bulk memory for the hot cache but never registers it with the transfer engine. When there is no local segment (size=0), the transfer engine attempts RDMA operations directly on the unregistered hot cache memory, causing all transfers to fail.

## Fix

- Register hot cache memory with `transfer_engine_->registerLocalMemory()` during `InitLocalHotCache()`
- Add `UnregisterLocalHotCacheMemory()` to properly unregister during destruction and re-initialization
- Add `hot_cache_memory_registered_` flag to track registration state
- Expose `GetBaseAddress()` and `GetTotalSize()` on `LocalHotCache` for registration
- Fix destruction order: stop handler → unregister memory → free cache

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
