### PR TITLE
fix(ep): add -DUSE_CUDA to setup.py compile flags

### DIFF
--- a/mooncake-ep/setup.py
+++ b/mooncake-ep/setup.py
@@ -41,8 +41,8 @@ setup(
                 "src/mooncake_ep_kernel.cu",
             ],
             extra_compile_args={
-                "cxx": [f"-D_GLIBCXX_USE_CXX11_ABI={abi_flag}", "-std=c++20", "-O3", "-g0"],
-                "nvcc": [f"-D_GLIBCXX_USE_CXX11_ABI={abi_flag}", "-std=c++20", "-Xcompiler", "-O3", "-Xcompiler", "-g0"],
+                "cxx": [f"-D_GLIBCXX_USE_CXX11_ABI={abi_flag}", "-std=c++20", "-O3", "-g0", "-DUSE_CUDA"],
+                "nvcc": [f"-D_GLIBCXX_USE_CXX11_ABI={abi_flag}", "-std=c++20", "-Xcompiler", "-O3", "-Xcompiler", "-g0", "-DUSE_CUDA"],
             },
             libraries=cuda_libraries,
             library_dirs=cuda_library_dirs,


### PR DESCRIPTION
## Problem

The `build-wheel-cu13` CI job fails because `mooncake-ep/setup.py` compiles `mooncake_ep_buffer.cpp` without `-DUSE_CUDA`, but `transfer_engine.h` guards `getOrCreateP2pTransport()` and `getOrCreateRdmaTransport()` behind `#if defined(USE_CUDA) || defined(USE_MUSA)`.

```
error: 'class mooncake::TransferEngine' has no member named 'getOrCreateP2pTransport'
error: 'class mooncake::TransferEngine' has no member named 'getOrCreateRdmaTransport'
```

## Root Cause

When building via cmake, `USE_CUDA` is defined globally. But the `build-wheel-cu13` CI job builds the EP extension through `BuildEpExt.cmake` → `setup.py build_ext`, and `setup.py` is a standalone Python script that doesn't inherit cmake's macro definitions.

## Fix

Add `-DUSE_CUDA` to both `cxx` and `nvcc` `extra_compile_args` in `mooncake-ep/setup.py`.

Fixes CI failure in https://github.com/kvcache-ai/Mooncake/actions/runs/27195784373/job/80294488411