### PR TITLE
[Integration] Reject failed Python buddy allocator backing buffer

### DIFF
--- a/mooncake-integration/transfer_engine/transfer_engine_py.cpp
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.cpp
@@ -276,6 +276,7 @@ int TransferEnginePy::findClassId(size_t size) {
 int TransferEnginePy::doBuddyAllocate(int class_id) {
     if (class_id == kMaxClassId) {
         auto buffer = allocateRawBuffer(kDefaultBufferCapacity);
+        if (!buffer) return -1;
         buffer_list_.push_back(buffer);
         for (size_t offset = 0; offset < kDefaultBufferCapacity;
              offset += 1024ull * kSlabSizeKB[kMaxClassId])


### PR DESCRIPTION
## Summary

- stop buddy allocation when the backing raw buffer allocation or registration fails
- leave `buffer_list_` and the slab free lists unchanged on failure
- propagate the failure to `allocateManagedBuffer`, which already returns a null address

## Problem

The max-class branch appended the result of `allocateRawBuffer` without checking it. On allocation failure or local-memory registration failure, this inserted `nullptr` into `buffer_list_` and derived invalid addresses into `free_list_`, while reporting success.

Fixes #2371.

## Validation

- `git diff --check`
- source-path review against current `upstream/main`

## To verify

- Mooncake integration C++ build and CI on Linux
- failure-injection coverage for raw backing-buffer allocation, where available
