### PR TITLE
[TransferEngine] Clean up failed io_uring sub-batch initialization

### DIFF
--- a/mooncake-transfer-engine/tent/src/transport/io_uring/io_uring_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/io_uring/io_uring_transport.cpp
@@ -117,14 +117,16 @@ Status IOUringTransport::allocateSubBatch(SubBatchRef& batch, size_t max_size) {
     auto io_uring_batch = Slab<IOUringSubBatch>::Get().allocate();
     if (!io_uring_batch)
         return Status::InternalError("Unable to allocate IO Uring sub-batch");
-    batch = io_uring_batch;
     io_uring_batch->max_size = max_size;
     io_uring_batch->task_list.reserve(max_size);
     int rc = io_uring_queue_init(max_size, &io_uring_batch->ring, 0);
-    if (rc)
+    if (rc) {
+        Slab<IOUringSubBatch>::Get().deallocate(io_uring_batch);
         return Status::InternalError(
             std::string("io_uring_queue_init failed: ") + strerror(-rc) +
             LOC_MARK);
+    }
+    batch = io_uring_batch;
     return Status::OK();
 }
 


### PR DESCRIPTION
## Summary

- keep the output sub-batch unchanged until `io_uring_queue_init` succeeds
- return the temporary `IOUringSubBatch` to its slab when ring initialization fails
- prevent callers from later freeing an uninitialized ring

## Problem

`allocateSubBatch` published the newly allocated object before initializing its ring. If `io_uring_queue_init` failed, the function returned an error but left the caller holding the invalid object and leaked its slab allocation.

Fixes #2370.

## Validation

- `git diff --check`
- source-path review against current `upstream/main`

## To verify

- TENT C++ build and CI on a Linux host with `liburing`
- failure-path coverage for `io_uring_queue_init`, where available
