### PR TITLE
[Store] Reduce lookup eviction contention

### DIFF
--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -966,9 +966,18 @@ std::vector<tl::expected<bool, ErrorCode>> MasterService::BatchExistKey(
     }
 
     std::vector<std::vector<size_t>> indices_by_shard(kNumShards);
-    for (size_t i = 0; i < keys.size(); ++i) {
-        indices_by_shard[getMetadataShardIndex(normalized_tenant, keys[i])]
-            .push_back(i);
+    {
+        std::shared_lock<std::shared_mutex> group_routing_lock(
+            group_routing_mutex_);
+        for (size_t i = 0; i < keys.size(); ++i) {
+            auto route_it = object_group_ids_.find(
+                MakeTenantScopedKey(normalized_tenant, keys[i]));
+            const size_t shard_idx =
+                route_it == object_group_ids_.end()
+                    ? getShardIndex(normalized_tenant, keys[i])
+                    : getShardIndex(route_it->second);
+            indices_by_shard[shard_idx].push_back(i);
+        }
     }
 
     const size_t start_shard = RandomIndex(kNumShards);
@@ -998,8 +1007,7 @@ std::vector<tl::expected<bool, ErrorCode>> MasterService::BatchExistKey(
             const auto& key = keys[i];
             auto it = tenant_state.metadata.find(key);
             if (it == tenant_state.metadata.end() || !it->second.IsValid()) {
-                VLOG(1) << "key=" << key
-                        << ", tenant_id=" << normalized_tenant
+                VLOG(1) << "key=" << key << ", tenant_id=" << normalized_tenant
                         << ", info=object_not_found";
                 results[i] = false;
                 continue;
@@ -5035,19 +5043,25 @@ void MasterService::BatchEvict(double evict_ratio_target,
     std::vector<std::chrono::system_clock::time_point> no_pin_objects;
     std::vector<std::chrono::system_clock::time_point> soft_pin_objects;
 
-    auto can_evict_replicas = [](const ObjectMetadata& metadata) {
-        return metadata.HasReplica([](const Replica& replica) {
-            return replica.is_memory_replica() && replica.is_completed() &&
-                   replica.get_refcnt() == 0;
-        });
+    auto is_evictable_memory_replica = [](const Replica& replica) {
+        return replica.is_memory_replica() && replica.is_completed() &&
+               replica.get_refcnt() == 0;
     };
 
-    auto evict_replicas = [](ObjectMetadata& metadata) {
-        return metadata.EraseReplicas([](const Replica& replica) {
-            return replica.is_memory_replica() && replica.is_completed() &&
-                   replica.get_refcnt() == 0;
-        });
+    auto can_evict_replicas = [&](const ObjectMetadata& metadata) {
+        return metadata.HasReplica(is_evictable_memory_replica);
     };
+
+    auto evict_replicas =
+        [&](ObjectMetadata& metadata,
+            std::vector<std::vector<Replica>>& deferred_replicas) {
+            auto replicas = metadata.PopReplicas(is_evictable_memory_replica);
+            const size_t replica_count = replicas.size();
+            if (!replicas.empty()) {
+                deferred_replicas.emplace_back(std::move(replicas));
+            }
+            return replica_count;
+        };
 
     // --- Offload-on-evict support ---
     long offload_queued_this_cycle = 0;
@@ -5066,17 +5080,18 @@ void MasterService::BatchEvict(double evict_ratio_target,
     // Returns freed bytes. Returns 0 if offload-queued and no additional
     // replicas were evicted (all MEMORY replicas of the key are now pinned).
     auto try_evict_or_offload =
-        [&, this](const std::string& tenant_id, const std::string& key,
-                  ObjectMetadata& metadata,
-                  TenantState& tenant_state) -> uint64_t {
+        [&, this](
+            const std::string& tenant_id, const std::string& key,
+            ObjectMetadata& metadata, TenantState& tenant_state,
+            std::vector<std::vector<Replica>>& deferred_replicas) -> uint64_t {
         if (!offload_on_evict_) {
             // Original behavior
-            return metadata.size * evict_replicas(metadata);
+            return metadata.size * evict_replicas(metadata, deferred_replicas);
         }
 
         // LOCAL_DISK replica already exists — safe to delete MEMORY immediately
         if (has_local_disk_replica(metadata)) {
-            return metadata.size * evict_replicas(metadata);
+            return metadata.size * evict_replicas(metadata, deferred_replicas);
         }
 
         // Force-evict cap: if force_evict enabled and cap reached, force
@@ -5084,7 +5099,7 @@ void MasterService::BatchEvict(double evict_ratio_target,
         // flooding.
         if (offload_force_evict_ && offload_queued_this_cycle >= offload_cap) {
             offload_cap_forced_count++;
-            return metadata.size * evict_replicas(metadata);
+            return metadata.size * evict_replicas(metadata, deferred_replicas);
         }
 
         // Queue one MEMORY replica for offload; others will be evicted below.
@@ -5113,7 +5128,7 @@ void MasterService::BatchEvict(double evict_ratio_target,
             // Any remaining MEMORY replicas with refcnt==0 are redundant copies
             // (data survives via the pinned replica → disk). Evict them now to
             // reclaim memory immediately rather than waiting another cycle.
-            return metadata.size * evict_replicas(metadata);
+            return metadata.size * evict_replicas(metadata, deferred_replicas);
         }
 
         // PushOffloadingQueue failed. Default (data-preserving) behavior is to
@@ -5122,7 +5137,7 @@ void MasterService::BatchEvict(double evict_ratio_target,
         // prevent silent data loss when the queue is unavailable.
         if (offload_force_evict_) {
             offload_push_failed_forced++;
-            return metadata.size * evict_replicas(metadata);
+            return metadata.size * evict_replicas(metadata, deferred_replicas);
         }
         return 0;
     };
@@ -5136,17 +5151,18 @@ void MasterService::BatchEvict(double evict_ratio_target,
         [&, this](const std::string& tenant_id, const std::string& key,
                   ObjectMetadata& metadata, MetadataShardAccessorRW& shard,
                   TenantState& tenant_state,
+                  std::vector<std::vector<Replica>>& deferred_replicas,
                   bool allow_soft_pinned) -> EvictionResult {
         if (!metadata.IsGrouped()) {
-            uint64_t freed =
-                try_evict_or_offload(tenant_id, key, metadata, tenant_state);
+            uint64_t freed = try_evict_or_offload(
+                tenant_id, key, metadata, tenant_state, deferred_replicas);
             return {.freed_bytes = freed, .evicted_objects = freed > 0 ? 1 : 0};
         }
 
         auto group_it = tenant_state.group_members.find(metadata.group_id);
         if (group_it == tenant_state.group_members.end()) {
-            uint64_t freed =
-                try_evict_or_offload(tenant_id, key, metadata, tenant_state);
+            uint64_t freed = try_evict_or_offload(
+                tenant_id, key, metadata, tenant_state, deferred_replicas);
             return {.freed_bytes = freed, .evicted_objects = freed > 0 ? 1 : 0};
         }
 
@@ -5174,8 +5190,9 @@ void MasterService::BatchEvict(double evict_ratio_target,
                 continue;
             }
 
-            uint64_t freed = try_evict_or_offload(
-                tenant_id, member_key, member_metadata, tenant_state);
+            uint64_t freed =
+                try_evict_or_offload(tenant_id, member_key, member_metadata,
+                                     tenant_state, deferred_replicas);
             result.freed_bytes += freed;
             if (freed > 0) {
                 result.evicted_objects++;
@@ -5193,93 +5210,99 @@ void MasterService::BatchEvict(double evict_ratio_target,
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
 
     // First pass: evict objects without soft pin and lease expired
+    std::vector<std::vector<Replica>> deferred_replicas;
     for (size_t i = 0; i < kNumShards; i++) {
-        MetadataShardAccessorRW shard(this, (start_idx + i) % kNumShards);
+        {
+            MetadataShardAccessorRW shard(this, (start_idx + i) % kNumShards);
 
-        // Discard expired processing keys first so that they won't be counted
-        // in later evictions.
-        DiscardExpiredProcessingReplicas(shard, now);
+            // Discard expired processing keys first so that they won't be
+            // counted in later evictions.
+            DiscardExpiredProcessingReplicas(shard, now);
 
-        size_t shard_object_count = 0;
-        for (const auto& [tenant_id, tenant_state] : shard->tenants) {
-            shard_object_count += tenant_state.metadata.size();
-        }
-        object_count += shard_object_count;
-
-        // To achieve evicted_count / object_count = evict_ratio_target,
-        // ideally how many object should be evicted in this shard
-        const long ideal_evict_num =
-            std::ceil(object_count * evict_ratio_target) - evicted_count;
-
-        std::vector<std::chrono::system_clock::time_point>
-            candidates;  // can be removed
-        for (const auto& [tenant_id, tenant_state] : shard->tenants) {
-            for (auto it = tenant_state.metadata.begin();
-                 it != tenant_state.metadata.end(); it++) {
-                if (it->second.IsHardPinned()) {
-                    continue;
-                }
-                if (!it->second.IsLeaseExpired(now) ||
-                    !can_evict_replicas(it->second)) {
-                    continue;
-                }
-                if (!it->second.IsSoftPinned(now)) {
-                    if (ideal_evict_num > 0) {
-                        candidates.push_back(it->second.lease_timeout);
-                    } else {
-                        no_pin_objects.push_back(it->second.lease_timeout);
-                    }
-                } else if (allow_evict_soft_pinned_objects_) {
-                    soft_pin_objects.push_back(it->second.lease_timeout);
-                }
+            size_t shard_object_count = 0;
+            for (const auto& [tenant_id, tenant_state] : shard->tenants) {
+                shard_object_count += tenant_state.metadata.size();
             }
-        }
+            object_count += shard_object_count;
 
-        if (ideal_evict_num > 0 && !candidates.empty()) {
-            long evict_num = std::min(ideal_evict_num, (long)candidates.size());
-            long shard_evicted_count =
-                0;  // number of objects evicted from this shard
-            std::nth_element(candidates.begin(),
-                             candidates.begin() + (evict_num - 1),
-                             candidates.end());
-            auto target_timeout = candidates[evict_num - 1];
-            for (auto tenant_it = shard->tenants.begin();
-                 tenant_it != shard->tenants.end();) {
-                auto& tenant_state = tenant_it->second;
-                auto it = tenant_state.metadata.begin();
-                while (it != tenant_state.metadata.end()) {
-                    if (it->second.IsHardPinned() ||
-                        !it->second.IsLeaseExpired(now) ||
-                        it->second.IsSoftPinned(now) ||
-                        !can_evict_replicas(it->second)) {
-                        ++it;
+            // To achieve evicted_count / object_count = evict_ratio_target,
+            // ideally how many object should be evicted in this shard
+            const long ideal_evict_num =
+                std::ceil(object_count * evict_ratio_target) - evicted_count;
+
+            std::vector<std::chrono::system_clock::time_point>
+                candidates;  // can be removed
+            for (const auto& [tenant_id, tenant_state] : shard->tenants) {
+                for (auto it = tenant_state.metadata.begin();
+                     it != tenant_state.metadata.end(); it++) {
+                    if (it->second.IsHardPinned()) {
                         continue;
                     }
-                    if (it->second.lease_timeout <= target_timeout) {
-                        auto evict_result = try_evict_group_or_object(
-                            tenant_it->first, it->first, it->second, shard,
-                            tenant_state, /*allow_soft_pinned=*/false);
-                        total_freed_size += evict_result.freed_bytes;
-                        if (it->second.IsValid() == false) {
-                            it = EraseMetadata(tenant_state, it,
-                                               tenant_it->first);
+                    if (!it->second.IsLeaseExpired(now) ||
+                        !can_evict_replicas(it->second)) {
+                        continue;
+                    }
+                    if (!it->second.IsSoftPinned(now)) {
+                        if (ideal_evict_num > 0) {
+                            candidates.push_back(it->second.lease_timeout);
                         } else {
-                            ++it;
+                            no_pin_objects.push_back(it->second.lease_timeout);
                         }
-                        shard_evicted_count += evict_result.evicted_objects;
-                    } else {
-                        no_pin_objects.push_back(it->second.lease_timeout);
-                        ++it;
+                    } else if (allow_evict_soft_pinned_objects_) {
+                        soft_pin_objects.push_back(it->second.lease_timeout);
                     }
                 }
-                if (tenant_state.Empty()) {
-                    tenant_it = shard->tenants.erase(tenant_it);
-                } else {
-                    ++tenant_it;
-                }
             }
-            evicted_count += shard_evicted_count;
+
+            if (ideal_evict_num > 0 && !candidates.empty()) {
+                long evict_num =
+                    std::min(ideal_evict_num, (long)candidates.size());
+                long shard_evicted_count =
+                    0;  // number of objects evicted from this shard
+                std::nth_element(candidates.begin(),
+                                 candidates.begin() + (evict_num - 1),
+                                 candidates.end());
+                auto target_timeout = candidates[evict_num - 1];
+                for (auto tenant_it = shard->tenants.begin();
+                     tenant_it != shard->tenants.end();) {
+                    auto& tenant_state = tenant_it->second;
+                    auto it = tenant_state.metadata.begin();
+                    while (it != tenant_state.metadata.end()) {
+                        if (it->second.IsHardPinned() ||
+                            !it->second.IsLeaseExpired(now) ||
+                            it->second.IsSoftPinned(now) ||
+                            !can_evict_replicas(it->second)) {
+                            ++it;
+                            continue;
+                        }
+                        if (it->second.lease_timeout <= target_timeout) {
+                            auto evict_result = try_evict_group_or_object(
+                                tenant_it->first, it->first, it->second, shard,
+                                tenant_state, deferred_replicas,
+                                /*allow_soft_pinned=*/false);
+                            total_freed_size += evict_result.freed_bytes;
+                            if (it->second.IsValid() == false) {
+                                it = EraseMetadata(tenant_state, it,
+                                                   tenant_it->first);
+                            } else {
+                                ++it;
+                            }
+                            shard_evicted_count += evict_result.evicted_objects;
+                        } else {
+                            no_pin_objects.push_back(it->second.lease_timeout);
+                            ++it;
+                        }
+                    }
+                    if (tenant_state.Empty()) {
+                        tenant_it = shard->tenants.erase(tenant_it);
+                    } else {
+                        ++tenant_it;
+                    }
+                }
+                evicted_count += shard_evicted_count;
+            }
         }
+        deferred_replicas.clear();
     }
 
     // Try releasing discarded replicas before we decide whether to do the
@@ -5314,42 +5337,47 @@ void MasterService::BatchEvict(double evict_ratio_target,
             // Evict objects with lease timeout less than or equal to target.
             // Stop when the target is reached.
             for (size_t i = 0; i < kNumShards && target_evict_num > 0; i++) {
-                MetadataShardAccessorRW shard(this,
-                                              (start_idx + i) % kNumShards);
-                for (auto tenant_it = shard->tenants.begin();
-                     tenant_it != shard->tenants.end() &&
-                     target_evict_num > 0;) {
-                    auto& tenant_state = tenant_it->second;
-                    auto it = tenant_state.metadata.begin();
-                    while (it != tenant_state.metadata.end() &&
-                           target_evict_num > 0) {
-                        if (!it->second.IsHardPinned() &&
-                            it->second.IsLeaseExpired(now) &&
-                            it->second.lease_timeout <= target_timeout &&
-                            !it->second.IsSoftPinned(now) &&
-                            can_evict_replicas(it->second)) {
-                            auto evict_result = try_evict_group_or_object(
-                                tenant_it->first, it->first, it->second, shard,
-                                tenant_state, /*allow_soft_pinned=*/false);
-                            total_freed_size += evict_result.freed_bytes;
-                            if (!it->second.IsValid()) {
-                                it = EraseMetadata(tenant_state, it,
-                                                   tenant_it->first);
+                {
+                    MetadataShardAccessorRW shard(this,
+                                                  (start_idx + i) % kNumShards);
+                    for (auto tenant_it = shard->tenants.begin();
+                         tenant_it != shard->tenants.end() &&
+                         target_evict_num > 0;) {
+                        auto& tenant_state = tenant_it->second;
+                        auto it = tenant_state.metadata.begin();
+                        while (it != tenant_state.metadata.end() &&
+                               target_evict_num > 0) {
+                            if (!it->second.IsHardPinned() &&
+                                it->second.IsLeaseExpired(now) &&
+                                it->second.lease_timeout <= target_timeout &&
+                                !it->second.IsSoftPinned(now) &&
+                                can_evict_replicas(it->second)) {
+                                auto evict_result = try_evict_group_or_object(
+                                    tenant_it->first, it->first, it->second,
+                                    shard, tenant_state, deferred_replicas,
+                                    /*allow_soft_pinned=*/false);
+                                total_freed_size += evict_result.freed_bytes;
+                                if (!it->second.IsValid()) {
+                                    it = EraseMetadata(tenant_state, it,
+                                                       tenant_it->first);
+                                } else {
+                                    ++it;
+                                }
+                                evicted_count += evict_result.evicted_objects;
+                                target_evict_num -=
+                                    evict_result.evicted_objects;
                             } else {
                                 ++it;
                             }
-                            evicted_count += evict_result.evicted_objects;
-                            target_evict_num -= evict_result.evicted_objects;
+                        }
+                        if (tenant_state.Empty()) {
+                            tenant_it = shard->tenants.erase(tenant_it);
                         } else {
-                            ++it;
+                            ++tenant_it;
                         }
                     }
-                    if (tenant_state.Empty()) {
-                        tenant_it = shard->tenants.erase(tenant_it);
-                    } else {
-                        ++tenant_it;
-                    }
                 }
+                deferred_replicas.clear();
             }
         } else if (!soft_pin_objects.empty()) {
             // allow_evict_soft_pinned_objects_ is implicitly true if
@@ -5370,46 +5398,52 @@ void MasterService::BatchEvict(double evict_ratio_target,
 
             // Stop when the target is reached.
             for (size_t i = 0; i < kNumShards && target_evict_num > 0; i++) {
-                MetadataShardAccessorRW shard(this,
-                                              (start_idx + i) % kNumShards);
+                {
+                    MetadataShardAccessorRW shard(this,
+                                                  (start_idx + i) % kNumShards);
 
-                for (auto tenant_it = shard->tenants.begin();
-                     tenant_it != shard->tenants.end() &&
-                     target_evict_num > 0;) {
-                    auto& tenant_state = tenant_it->second;
-                    auto it = tenant_state.metadata.begin();
-                    while (it != tenant_state.metadata.end() &&
-                           target_evict_num > 0) {
-                        if (it->second.IsHardPinned() ||
-                            !it->second.IsLeaseExpired(now) ||
-                            !can_evict_replicas(it->second)) {
-                            ++it;
-                            continue;
-                        }
-                        if (!it->second.IsSoftPinned(now) ||
-                            it->second.lease_timeout <= soft_target_timeout) {
-                            auto evict_result = try_evict_group_or_object(
-                                tenant_it->first, it->first, it->second, shard,
-                                tenant_state, /*allow_soft_pinned=*/true);
-                            total_freed_size += evict_result.freed_bytes;
-                            if (!it->second.IsValid()) {
-                                it = EraseMetadata(tenant_state, it,
-                                                   tenant_it->first);
+                    for (auto tenant_it = shard->tenants.begin();
+                         tenant_it != shard->tenants.end() &&
+                         target_evict_num > 0;) {
+                        auto& tenant_state = tenant_it->second;
+                        auto it = tenant_state.metadata.begin();
+                        while (it != tenant_state.metadata.end() &&
+                               target_evict_num > 0) {
+                            if (it->second.IsHardPinned() ||
+                                !it->second.IsLeaseExpired(now) ||
+                                !can_evict_replicas(it->second)) {
+                                ++it;
+                                continue;
+                            }
+                            if (!it->second.IsSoftPinned(now) ||
+                                it->second.lease_timeout <=
+                                    soft_target_timeout) {
+                                auto evict_result = try_evict_group_or_object(
+                                    tenant_it->first, it->first, it->second,
+                                    shard, tenant_state, deferred_replicas,
+                                    /*allow_soft_pinned=*/true);
+                                total_freed_size += evict_result.freed_bytes;
+                                if (!it->second.IsValid()) {
+                                    it = EraseMetadata(tenant_state, it,
+                                                       tenant_it->first);
+                                } else {
+                                    ++it;
+                                }
+                                evicted_count += evict_result.evicted_objects;
+                                target_evict_num -=
+                                    evict_result.evicted_objects;
                             } else {
                                 ++it;
                             }
-                            evicted_count += evict_result.evicted_objects;
-                            target_evict_num -= evict_result.evicted_objects;
+                        }
+                        if (tenant_state.Empty()) {
+                            tenant_it = shard->tenants.erase(tenant_it);
                         } else {
-                            ++it;
+                            ++tenant_it;
                         }
                     }
-                    if (tenant_state.Empty()) {
-                        tenant_it = shard->tenants.erase(tenant_it);
-                    } else {
-                        ++tenant_it;
-                    }
                 }
+                deferred_replicas.clear();
             }
         } else {
             // This should not happen.

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -959,10 +959,60 @@ auto MasterService::ExistKey(const std::string& key,
 
 std::vector<tl::expected<bool, ErrorCode>> MasterService::BatchExistKey(
     const std::vector<std::string>& keys, const std::string& tenant_id) {
-    std::vector<tl::expected<bool, ErrorCode>> results;
-    results.reserve(keys.size());
-    for (const auto& key : keys) {
-        results.emplace_back(ExistKey(key, tenant_id));
+    const std::string normalized_tenant = NormalizeTenantId(tenant_id);
+    std::vector<tl::expected<bool, ErrorCode>> results(keys.size());
+    if (keys.empty()) {
+        return results;
+    }
+
+    std::vector<std::vector<size_t>> indices_by_shard(kNumShards);
+    for (size_t i = 0; i < keys.size(); ++i) {
+        indices_by_shard[getMetadataShardIndex(normalized_tenant, keys[i])]
+            .push_back(i);
+    }
+
+    const size_t start_shard = RandomIndex(kNumShards);
+    for (size_t scanned = 0; scanned < kNumShards; ++scanned) {
+        const size_t shard_idx =
+            (start_shard + kNumShards - scanned) % kNumShards;
+        const auto& key_indices = indices_by_shard[shard_idx];
+        if (key_indices.empty()) {
+            continue;
+        }
+
+        std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+        MetadataShardAccessorRO shard(this, shard_idx);
+        auto tenant_it = shard->tenants.find(normalized_tenant);
+        if (tenant_it == shard->tenants.end()) {
+            for (const size_t i : key_indices) {
+                VLOG(1) << "key=" << keys[i]
+                        << ", tenant_id=" << normalized_tenant
+                        << ", info=object_not_found";
+                results[i] = false;
+            }
+            continue;
+        }
+
+        const auto& tenant_state = tenant_it->second;
+        for (const size_t i : key_indices) {
+            const auto& key = keys[i];
+            auto it = tenant_state.metadata.find(key);
+            if (it == tenant_state.metadata.end() || !it->second.IsValid()) {
+                VLOG(1) << "key=" << key
+                        << ", tenant_id=" << normalized_tenant
+                        << ", info=object_not_found";
+                results[i] = false;
+                continue;
+            }
+
+            const auto& metadata = it->second;
+            if (metadata.HasReplica(&Replica::fn_is_completed)) {
+                GrantLeaseForGroup(tenant_state, key, metadata);
+                results[i] = true;
+            } else {
+                results[i] = false;
+            }
+        }
     }
     return results;
 }

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -844,11 +844,7 @@ std::vector<tl::expected<bool, ErrorCode>> WrappedMasterService::BatchExistKey(
     timer.LogRequest("keys_count=", total_keys);
     MasterMetricManager::instance().inc_batch_exist_key_requests(total_keys);
 
-    std::vector<tl::expected<bool, ErrorCode>> result;
-    result.reserve(keys.size());
-    for (const auto& key : keys) {
-        result.emplace_back(master_service_.ExistKey(key, tenant_id));
-    }
+    auto result = master_service_.BatchExistKey(keys, tenant_id);
 
     size_t failure_count = 0;
     for (size_t i = 0; i < result.size(); ++i) {

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -132,8 +132,7 @@ class MasterServiceTest : public ::testing::Test {
         auto put_start =
             service.PutStart(client_id, key, tenant_id, slice_length, config);
         ASSERT_TRUE(put_start.has_value())
-            << "PutStart failed for key=" << key
-            << ", tenant_id=" << tenant_id
+            << "PutStart failed for key=" << key << ", tenant_id=" << tenant_id
             << ", error=" << toString(put_start.error());
         ASSERT_TRUE(
             service.PutEnd(client_id, key, tenant_id, ReplicaType::MEMORY)
@@ -4327,9 +4326,9 @@ TEST_F(MasterServiceTest, BatchExistKeyGroupedAndIncompletePreservesOrder) {
     PutCompletedObject(*service_, client_id, completed_key, config);
 
     const std::string incomplete_key = "batch_incomplete_key";
-    ASSERT_TRUE(service_->PutStart(client_id, incomplete_key, "default", 1024,
-                                   config)
-                    .has_value());
+    ASSERT_TRUE(
+        service_->PutStart(client_id, incomplete_key, "default", 1024, config)
+            .has_value());
 
     const std::string missing_key = "batch_missing_key";
     std::vector<std::string> keys = {grouped_key_a, completed_key,
@@ -4367,15 +4366,16 @@ TEST_F(MasterServiceTest, BatchExistKeyTenantAwarePreservesOrder) {
     const std::string incomplete_key = "batch_tenant_incomplete";
     const std::string missing_key = "batch_tenant_missing";
 
-    PutCompletedObject(*service_, client_id, tenant_only_key, tenant_id, config);
+    PutCompletedObject(*service_, client_id, tenant_only_key, tenant_id,
+                       config);
     PutCompletedObject(*service_, client_id, default_only_key, config);
-    ASSERT_TRUE(service_->PutStart(client_id, incomplete_key, tenant_id, 1024,
-                                   config)
-                    .has_value());
+    ASSERT_TRUE(
+        service_->PutStart(client_id, incomplete_key, tenant_id, 1024, config)
+            .has_value());
 
-    std::vector<std::string> tenant_keys = {
-        tenant_only_key, default_only_key, missing_key, incomplete_key,
-        tenant_only_key};
+    std::vector<std::string> tenant_keys = {tenant_only_key, default_only_key,
+                                            missing_key, incomplete_key,
+                                            tenant_only_key};
     auto tenant_resp = service_->BatchExistKey(tenant_keys, tenant_id);
     ASSERT_EQ(tenant_resp.size(), tenant_keys.size());
     EXPECT_TRUE(tenant_resp[0].value());
@@ -4411,16 +4411,14 @@ TEST_F(MasterServiceTest, WrappedBatchExistKeyUsesTenantAwareBatchPath) {
 
     std::vector<std::string> tenant_keys = {tenant_key_a, tenant_key_b};
     std::vector<uint64_t> tenant_sizes = {1024, 2048};
-    auto tenant_put_start =
-        service_.BatchPutStart(client_id, tenant_keys, tenant_sizes, config,
-                               tenant_id);
+    auto tenant_put_start = service_.BatchPutStart(
+        client_id, tenant_keys, tenant_sizes, config, tenant_id);
     ASSERT_EQ(tenant_put_start.size(), tenant_keys.size());
     for (const auto& result : tenant_put_start) {
         ASSERT_TRUE(result.has_value()) << toString(result.error());
     }
-    auto tenant_put_end =
-        service_.BatchPutEnd(client_id, tenant_keys, ReplicaType::MEMORY,
-                             tenant_id);
+    auto tenant_put_end = service_.BatchPutEnd(client_id, tenant_keys,
+                                               ReplicaType::MEMORY, tenant_id);
     ASSERT_EQ(tenant_put_end.size(), tenant_keys.size());
     for (const auto& result : tenant_put_end) {
         ASSERT_TRUE(result.has_value()) << toString(result.error());
@@ -4429,8 +4427,9 @@ TEST_F(MasterServiceTest, WrappedBatchExistKeyUsesTenantAwareBatchPath) {
     auto default_put_start =
         service_.PutStart(client_id, default_only_key, 1024, config);
     ASSERT_TRUE(default_put_start.has_value());
-    ASSERT_TRUE(service_.PutEnd(client_id, default_only_key, ReplicaType::MEMORY)
-                    .has_value());
+    ASSERT_TRUE(
+        service_.PutEnd(client_id, default_only_key, ReplicaType::MEMORY)
+            .has_value());
 
     auto& metrics = MasterMetricManager::instance();
     const auto base_requests = metrics.get_batch_exist_key_requests();
@@ -4439,8 +4438,8 @@ TEST_F(MasterServiceTest, WrappedBatchExistKeyUsesTenantAwareBatchPath) {
     const auto base_partial = metrics.get_batch_exist_key_partial_successes();
     const auto base_failed_items = metrics.get_batch_exist_key_failed_items();
 
-    std::vector<std::string> lookup_keys = {
-        tenant_key_a, default_only_key, missing_key, tenant_key_b};
+    std::vector<std::string> lookup_keys = {tenant_key_a, default_only_key,
+                                            missing_key, tenant_key_b};
     auto resp = service_.BatchExistKey(lookup_keys, tenant_id);
     ASSERT_EQ(resp.size(), lookup_keys.size());
     EXPECT_TRUE(resp[0].value());

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -124,6 +124,22 @@ class MasterServiceTest : public ::testing::Test {
                 .has_value());
     }
 
+    void PutCompletedObject(MasterService& service, const UUID& client_id,
+                            const std::string& key,
+                            const std::string& tenant_id,
+                            const ReplicateConfig& config,
+                            uint64_t slice_length = 1024) const {
+        auto put_start =
+            service.PutStart(client_id, key, tenant_id, slice_length, config);
+        ASSERT_TRUE(put_start.has_value())
+            << "PutStart failed for key=" << key
+            << ", tenant_id=" << tenant_id
+            << ", error=" << toString(put_start.error());
+        ASSERT_TRUE(
+            service.PutEnd(client_id, key, tenant_id, ReplicaType::MEMORY)
+                .has_value());
+    }
+
     bool ExecutePendingMoveTasks(MasterService& service,
                                  const UUID& client_id) const {
         auto fetched = service.FetchTasks(client_id, /*batch_size=*/16);
@@ -4285,6 +4301,159 @@ TEST_F(MasterServiceTest, BatchExistKeyTest) {
         ASSERT_TRUE(exist_resp[i].value());
     }
     ASSERT_FALSE(exist_resp[test_object_num].value());
+}
+
+TEST_F(MasterServiceTest, BatchExistKeyGroupedAndIncompletePreservesOrder) {
+    std::unique_ptr<MasterService> service_(new MasterService());
+    const UUID client_id = generate_uuid();
+
+    constexpr size_t buffer = 0x300000000;
+    constexpr size_t size = 1024 * 1024 * 128;
+    [[maybe_unused]] const auto context =
+        PrepareSimpleSegment(*service_, "test_segment", buffer, size);
+
+    const std::string grouped_key_a = "batch_grouped_key_a";
+    const std::string grouped_key_b = "batch_grouped_key_b";
+    const std::string group_id = FindGroupIdOnDifferentShard(grouped_key_a);
+    ReplicateConfig grouped_config;
+    grouped_config.replica_num = 1;
+    grouped_config.group_ids = std::vector<std::string>{group_id};
+    PutCompletedObject(*service_, client_id, grouped_key_a, grouped_config);
+    PutCompletedObject(*service_, client_id, grouped_key_b, grouped_config);
+
+    const std::string completed_key = "batch_completed_key";
+    ReplicateConfig config;
+    config.replica_num = 1;
+    PutCompletedObject(*service_, client_id, completed_key, config);
+
+    const std::string incomplete_key = "batch_incomplete_key";
+    ASSERT_TRUE(service_->PutStart(client_id, incomplete_key, "default", 1024,
+                                   config)
+                    .has_value());
+
+    const std::string missing_key = "batch_missing_key";
+    std::vector<std::string> keys = {grouped_key_a, completed_key,
+                                     incomplete_key, missing_key,
+                                     grouped_key_b};
+
+    auto resp = service_->BatchExistKey(keys, "default");
+    ASSERT_EQ(resp.size(), keys.size());
+    ASSERT_TRUE(resp[0].has_value());
+    ASSERT_TRUE(resp[1].has_value());
+    ASSERT_TRUE(resp[2].has_value());
+    ASSERT_TRUE(resp[3].has_value());
+    ASSERT_TRUE(resp[4].has_value());
+    EXPECT_TRUE(resp[0].value());
+    EXPECT_TRUE(resp[1].value());
+    EXPECT_FALSE(resp[2].value());
+    EXPECT_FALSE(resp[3].value());
+    EXPECT_TRUE(resp[4].value());
+}
+
+TEST_F(MasterServiceTest, BatchExistKeyTenantAwarePreservesOrder) {
+    std::unique_ptr<MasterService> service_(new MasterService());
+    const UUID client_id = generate_uuid();
+
+    constexpr size_t buffer = 0x300000000;
+    constexpr size_t size = 1024 * 1024 * 128;
+    [[maybe_unused]] const auto context =
+        PrepareSimpleSegment(*service_, "test_segment", buffer, size);
+
+    ReplicateConfig config;
+    config.replica_num = 1;
+    const std::string tenant_id = "tenant_batch_exist";
+    const std::string tenant_only_key = "batch_tenant_only";
+    const std::string default_only_key = "batch_default_only";
+    const std::string incomplete_key = "batch_tenant_incomplete";
+    const std::string missing_key = "batch_tenant_missing";
+
+    PutCompletedObject(*service_, client_id, tenant_only_key, tenant_id, config);
+    PutCompletedObject(*service_, client_id, default_only_key, config);
+    ASSERT_TRUE(service_->PutStart(client_id, incomplete_key, tenant_id, 1024,
+                                   config)
+                    .has_value());
+
+    std::vector<std::string> tenant_keys = {
+        tenant_only_key, default_only_key, missing_key, incomplete_key,
+        tenant_only_key};
+    auto tenant_resp = service_->BatchExistKey(tenant_keys, tenant_id);
+    ASSERT_EQ(tenant_resp.size(), tenant_keys.size());
+    EXPECT_TRUE(tenant_resp[0].value());
+    EXPECT_FALSE(tenant_resp[1].value());
+    EXPECT_FALSE(tenant_resp[2].value());
+    EXPECT_FALSE(tenant_resp[3].value());
+    EXPECT_TRUE(tenant_resp[4].value());
+
+    std::vector<std::string> default_keys = {tenant_only_key, default_only_key};
+    auto default_resp = service_->BatchExistKey(default_keys, "default");
+    ASSERT_EQ(default_resp.size(), default_keys.size());
+    EXPECT_FALSE(default_resp[0].value());
+    EXPECT_TRUE(default_resp[1].value());
+}
+
+TEST_F(MasterServiceTest, WrappedBatchExistKeyUsesTenantAwareBatchPath) {
+    WrappedMasterServiceConfig service_config;
+    service_config.default_kv_lease_ttl = 100;
+    service_config.enable_metric_reporting = false;
+    WrappedMasterService service_(service_config);
+
+    Segment segment = MakeSegment("wrapped_batch_exist_segment");
+    const UUID client_id = generate_uuid();
+    ASSERT_TRUE(service_.MountSegment(segment, client_id).has_value());
+
+    ReplicateConfig config;
+    config.replica_num = 1;
+    const std::string tenant_id = "wrapped_batch_exist_tenant";
+    const std::string tenant_key_a = "wrapped_batch_tenant_a";
+    const std::string tenant_key_b = "wrapped_batch_tenant_b";
+    const std::string default_only_key = "wrapped_batch_default_only";
+    const std::string missing_key = "wrapped_batch_missing";
+
+    std::vector<std::string> tenant_keys = {tenant_key_a, tenant_key_b};
+    std::vector<uint64_t> tenant_sizes = {1024, 2048};
+    auto tenant_put_start =
+        service_.BatchPutStart(client_id, tenant_keys, tenant_sizes, config,
+                               tenant_id);
+    ASSERT_EQ(tenant_put_start.size(), tenant_keys.size());
+    for (const auto& result : tenant_put_start) {
+        ASSERT_TRUE(result.has_value()) << toString(result.error());
+    }
+    auto tenant_put_end =
+        service_.BatchPutEnd(client_id, tenant_keys, ReplicaType::MEMORY,
+                             tenant_id);
+    ASSERT_EQ(tenant_put_end.size(), tenant_keys.size());
+    for (const auto& result : tenant_put_end) {
+        ASSERT_TRUE(result.has_value()) << toString(result.error());
+    }
+
+    auto default_put_start =
+        service_.PutStart(client_id, default_only_key, 1024, config);
+    ASSERT_TRUE(default_put_start.has_value());
+    ASSERT_TRUE(service_.PutEnd(client_id, default_only_key, ReplicaType::MEMORY)
+                    .has_value());
+
+    auto& metrics = MasterMetricManager::instance();
+    const auto base_requests = metrics.get_batch_exist_key_requests();
+    const auto base_items = metrics.get_batch_exist_key_items();
+    const auto base_failures = metrics.get_batch_exist_key_failures();
+    const auto base_partial = metrics.get_batch_exist_key_partial_successes();
+    const auto base_failed_items = metrics.get_batch_exist_key_failed_items();
+
+    std::vector<std::string> lookup_keys = {
+        tenant_key_a, default_only_key, missing_key, tenant_key_b};
+    auto resp = service_.BatchExistKey(lookup_keys, tenant_id);
+    ASSERT_EQ(resp.size(), lookup_keys.size());
+    EXPECT_TRUE(resp[0].value());
+    EXPECT_FALSE(resp[1].value());
+    EXPECT_FALSE(resp[2].value());
+    EXPECT_TRUE(resp[3].value());
+
+    EXPECT_EQ(base_requests + 1, metrics.get_batch_exist_key_requests());
+    EXPECT_EQ(base_items + lookup_keys.size(),
+              metrics.get_batch_exist_key_items());
+    EXPECT_EQ(base_failures, metrics.get_batch_exist_key_failures());
+    EXPECT_EQ(base_partial, metrics.get_batch_exist_key_partial_successes());
+    EXPECT_EQ(base_failed_items, metrics.get_batch_exist_key_failed_items());
 }
 
 TEST_F(MasterServiceTest, BatchQueryIpTest) {


### PR DESCRIPTION
## Description

This PR reduces Mooncake Store metadata shard lock contention between large batch lookup requests and eviction.

### Motivation

In production-like vLLM workloads, a single prefill can issue large `BatchExistKey` requests. For example, with long prompts and common KV-cache block settings, one lookup can contain tens of thousands of keys. The previous `BatchExistKey` path effectively processed keys one by one, causing repeated metadata shard lock acquisitions. When eviction is active and scanning metadata shards with write locks, these large lookup batches can repeatedly collide with eviction and produce high tail latency.

This PR addresses the issue in two parts:

1. Optimize `BatchExistKey` by grouping keys by metadata shard.
   - Bucket input keys by `getMetadataShardIndex(...)`.
   - Acquire each touched shard's metadata lock once per batch.
   - Support the current tenant-aware metadata layout.
   - Route the wrapped RPC batch handler directly to the batch fast path instead of looping over per-key `ExistKey`.

2. Reduce eviction write-lock hold time by moving evicted replica destruction outside the metadata shard RW lock.
   - Eviction still performs metadata mutation under the shard write lock.
   - Evicted memory replicas are popped from `ObjectMetadata` while holding the lock.
   - The popped replicas are destroyed immediately after the current shard lock is released.
   - This avoids running replica/buffer destruction and allocator free work inside the metadata shard write lock.

This keeps public API behavior, request ordering, tenant semantics, group lease behavior, and eviction policy unchanged. No user-facing API or configuration behavior is changed.

A lot of thanks to @Dao007forever and @Sebastian-dong for proposing and discussing the shard-grouped `BatchExistKey` / batch metadata fast-path direction in #2272 and #2221. This PR builds on that direction and adapts it to the current tenant-aware metadata layout, while also adding the eviction-side lock hold reduction.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

Performance optimization.

## How Has This Been Tested?

Unit/build tests:

- `./scripts/code_format.sh`
- `cmake --build build --target master_service_test mooncake_master -j$(nproc)`
- `ctest --test-dir build -R '^master_service_test$' --output-on-failure`

Additional local benchmark:

- Single development machine
- 20M objects
- 56 lookup threads
- 30,000 keys per `BatchExistKey`
- 500ms sleep between lookups per thread
- `rpc_thread_num=56`
- `segment_gb=48`
- `eviction_high_watermark_ratio=0.55`
- `eviction_ratio=0.25`
- 2 benchmark cycles

Eviction-active lookup latency, excluding refill/put overlap:

| Version | avg | p50 | p90 | p99 | max |
|---|---:|---:|---:|---:|---:|
| baseline main | 957.9ms | 786.2ms | 1738.1ms | 2856.3ms | 3893.6ms |
| shard-grouped lookup only | 142.8ms | 112.6ms | 173.4ms | 1504.2ms | 2200.2ms |
| this PR | 105.6ms | 93.8ms | 147.4ms | 304.0ms | 854.8ms |

Eviction-active lookup latency including refill/put overlap:

| Version | avg | p50 | p90 | p99 | max |
|---|---:|---:|---:|---:|---:|
| baseline main | 991.5ms | 809.5ms | 1828.1ms | 2910.7ms | 4208.5ms |
| shard-grouped lookup only | 143.7ms | 115.3ms | 179.0ms | 908.8ms | 2200.2ms |
| this PR | 106.4ms | 94.7ms | 150.1ms | 296.1ms | 854.8ms |


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.