### PR TITLE
[Store] Add P2P peer metrics and local rollback RPC metrics for forward transfer paths

### DIFF
--- a/mooncake-store/include/p2p_client_metric.h
+++ b/mooncake-store/include/p2p_client_metric.h
@@ -4,7 +4,7 @@
 
 namespace mooncake {
 
-// Request metrics for Get/Put operations
+// Local Get/Put metrics (BatchPut / BatchGet).
 struct RequestMetric {
     // Get metrics
     ylt::metric::counter_t get_requests;
@@ -22,6 +22,17 @@ struct RequestMetric {
     ylt::metric::histogram_t put_latency_success;
     ylt::metric::histogram_t put_latency_failure;
 
+    // Outgoing rollback RPCs (initiator cleanup after transfer failure).
+    ylt::metric::counter_t write_revoke_requests;
+    ylt::metric::counter_t write_revoke_failures;
+    ylt::metric::histogram_t write_revoke_latency_success;
+    ylt::metric::histogram_t write_revoke_latency_failure;
+
+    ylt::metric::counter_t unpin_key_requests;
+    ylt::metric::counter_t unpin_key_failures;
+    ylt::metric::histogram_t unpin_key_latency_success;
+    ylt::metric::histogram_t unpin_key_latency_failure;
+
     explicit RequestMetric(
         const std::string& prefix,
         const std::map<std::string, std::string>& labels = {});
@@ -30,12 +41,43 @@ struct RequestMetric {
     std::string summary_metrics();
 };
 
-// P2P client metrics for local storage operations
+// Per-RPC metrics for peer incoming handlers.
+struct RpcHandlerMetric {
+    ylt::metric::counter_t requests;
+    ylt::metric::counter_t hits;
+    ylt::metric::counter_t misses;
+    ylt::metric::counter_t failures;
+    ylt::metric::histogram_t latency_success;
+    ylt::metric::histogram_t latency_failure;
+
+    RpcHandlerMetric(const std::string& metric_prefix,
+                     const std::string& rpc_name,
+                     const std::map<std::string, std::string>& labels = {});
+
+    void serialize(std::string& str) const;
+    std::string summary_line(const std::string& display_name) const;
+};
+
+struct PeerRequestMetrics {
+    RpcHandlerMetric read_remote_data;
+    RpcHandlerMetric write_remote_data;
+    RpcHandlerMetric prewrite;
+    RpcHandlerMetric write_commit;
+    RpcHandlerMetric write_revoke;
+    RpcHandlerMetric pin_key;
+    RpcHandlerMetric unpin_key;
+
+    explicit PeerRequestMetrics(
+        const std::string& prefix = "mooncake_p2p_peer",
+        const std::map<std::string, std::string>& labels = {});
+
+    void serialize(std::string& str);
+    std::string summary_metrics();
+};
+
 struct P2PClientMetric : public ClientMetric {
-    // Local request metrics (Get/Put)
     RequestMetric local_request;
-    // Peer request metrics (requests from other clients)
-    RequestMetric peer_request;
+    PeerRequestMetrics peer_request_metrics;
 
     /**
      * @brief Creates a P2PClientMetric instance based on environment variables

--- a/mooncake-store/include/p2p_client_metric.h
+++ b/mooncake-store/include/p2p_client_metric.h
@@ -44,8 +44,6 @@ struct RequestMetric {
 // Per-RPC metrics for peer incoming handlers.
 struct RpcHandlerMetric {
     ylt::metric::counter_t requests;
-    ylt::metric::counter_t hits;
-    ylt::metric::counter_t misses;
     ylt::metric::counter_t failures;
     ylt::metric::histogram_t latency_success;
     ylt::metric::histogram_t latency_failure;
@@ -58,13 +56,26 @@ struct RpcHandlerMetric {
     std::string summary_line(const std::string& display_name);
 };
 
+// Read-semantics peer RPC metrics (ReadRemoteData, PinKey).
+struct ReadRpcHandlerMetric : RpcHandlerMetric {
+    ylt::metric::counter_t hits;
+    ylt::metric::counter_t misses;
+
+    ReadRpcHandlerMetric(const std::string& metric_prefix,
+                         const std::string& rpc_name,
+                         const std::map<std::string, std::string>& labels = {});
+
+    void serialize(std::string& str);
+    std::string summary_line(const std::string& display_name);
+};
+
 struct PeerRequestMetrics {
-    RpcHandlerMetric read_remote_data;
+    ReadRpcHandlerMetric read_remote_data;
     RpcHandlerMetric write_remote_data;
     RpcHandlerMetric prewrite;
     RpcHandlerMetric write_commit;
     RpcHandlerMetric write_revoke;
-    RpcHandlerMetric pin_key;
+    ReadRpcHandlerMetric pin_key;
     RpcHandlerMetric unpin_key;
 
     explicit PeerRequestMetrics(

--- a/mooncake-store/include/p2p_client_metric.h
+++ b/mooncake-store/include/p2p_client_metric.h
@@ -54,8 +54,8 @@ struct RpcHandlerMetric {
                      const std::string& rpc_name,
                      const std::map<std::string, std::string>& labels = {});
 
-    void serialize(std::string& str) const;
-    std::string summary_line(const std::string& display_name) const;
+    void serialize(std::string& str);
+    std::string summary_line(const std::string& display_name);
 };
 
 struct PeerRequestMetrics {

--- a/mooncake-store/include/p2p_client_service.h
+++ b/mooncake-store/include/p2p_client_service.h
@@ -320,16 +320,18 @@ class P2PClientService final : public ClientService {
             const std::vector<RemoteBufferDesc>& dest_buffers)>;
 
         PeerClient* peer_ptr;
+        P2PClientMetric* metrics;
         std::shared_ptr<RemoteWriteRequest> write_req;
         std::string endpoint;
         std::vector<Slice>* slices;
         TeTransferFn te_transfer;
 
-        RemoteForwardWriteOp(PeerClient* p,
+        RemoteForwardWriteOp(PeerClient* p, P2PClientMetric* m,
                              std::shared_ptr<RemoteWriteRequest> wr,
                              std::string ep, std::vector<Slice>* s,
                              TeTransferFn transfer)
             : peer_ptr(p),
+              metrics(m),
               write_req(std::move(wr)),
               endpoint(std::move(ep)),
               slices(s),
@@ -341,7 +343,7 @@ class P2PClientService final : public ClientService {
        private:
         static async_simple::coro::Lazy<void> RunForwardRemotePut(
             std::shared_ptr<WritePromise> promise, PeerClient* peer,
-            TeTransferFn te_transfer,
+            P2PClientMetric* metrics, TeTransferFn te_transfer,
             std::shared_ptr<RemoteWriteRequest> write_req,
             std::vector<Slice>* slices);
     };

--- a/mooncake-store/src/client_rpc_service.cpp
+++ b/mooncake-store/src/client_rpc_service.cpp
@@ -11,12 +11,6 @@ namespace mooncake {
 
 namespace {
 
-size_t CalculateBufferSize(const std::vector<RemoteBufferDesc>& buffers) {
-    size_t total = 0;
-    for (const auto& buf : buffers) total += buf.size;
-    return total;
-}
-
 bool IsValidRequest(const RemoteReadRequest& request) {
     if (request.key.empty()) {
         LOG(ERROR) << "RemoteReadRequest: empty key";
@@ -68,15 +62,16 @@ tl::expected<void, ErrorCode> ClientRpcService::ReadRemoteData(
                      "buffer_count=", request.dest_buffers.size());
 
     if (metrics_) {
-        metrics_->peer_request.get_requests.inc();
+        metrics_->peer_request_metrics.read_remote_data.requests.inc();
     }
     Stopwatch sw;
 
     if (!IsValidRequest(request)) {
         timer.LogResponse("error_code=", ErrorCode::INVALID_PARAMS);
         if (metrics_) {
-            metrics_->peer_request.get_failures.inc();
-            metrics_->peer_request.get_latency_failure.observe(sw.elapsed_us());
+            metrics_->peer_request_metrics.read_remote_data.failures.inc();
+            metrics_->peer_request_metrics.read_remote_data.latency_failure.observe(
+                sw.elapsed_us());
         }
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
@@ -94,21 +89,21 @@ tl::expected<void, ErrorCode> ClientRpcService::ReadRemoteData(
         }
         if (metrics_) {
             if (result.error() == ErrorCode::OBJECT_NOT_FOUND) {
-                metrics_->peer_request.get_misses.inc();
+                metrics_->peer_request_metrics.read_remote_data.misses.inc();
             } else {
-                metrics_->peer_request.get_failures.inc();
+                metrics_->peer_request_metrics.read_remote_data.failures.inc();
             }
-            metrics_->peer_request.get_latency_failure.observe(sw.elapsed_us());
+            metrics_->peer_request_metrics.read_remote_data.latency_failure.observe(
+                sw.elapsed_us());
         }
         return result;
     }
 
-    // Record successful get: hits + bytes + latency
+    // Record successful get: latency
     if (metrics_) {
-        metrics_->peer_request.get_hits.inc();
-        metrics_->peer_request.get_bytes.inc(
-            CalculateBufferSize(request.dest_buffers));
-        metrics_->peer_request.get_latency_success.observe(sw.elapsed_us());
+        metrics_->peer_request_metrics.read_remote_data.hits.inc();
+        metrics_->peer_request_metrics.read_remote_data.latency_success.observe(
+            sw.elapsed_us());
     }
 
     timer.LogResponse("error_code=", ErrorCode::OK);
@@ -122,15 +117,16 @@ tl::expected<UUID, ErrorCode> ClientRpcService::WriteRemoteData(
                      "buffer_count=", request.src_buffers.size());
 
     if (metrics_) {
-        metrics_->peer_request.put_requests.inc();
+        metrics_->peer_request_metrics.write_remote_data.requests.inc();
     }
     Stopwatch sw;
 
     if (!IsValidRequest(request)) {
         timer.LogResponse("error_code=", ErrorCode::INVALID_PARAMS);
         if (metrics_) {
-            metrics_->peer_request.put_failures.inc();
-            metrics_->peer_request.put_latency_failure.observe(sw.elapsed_us());
+            metrics_->peer_request_metrics.write_remote_data.failures.inc();
+            metrics_->peer_request_metrics.write_remote_data.latency_failure.observe(
+                sw.elapsed_us());
         }
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
@@ -144,36 +140,40 @@ tl::expected<UUID, ErrorCode> ClientRpcService::WriteRemoteData(
                    << ", error: " << toString(result.error());
         timer.LogResponse("error_code=", result.error());
         if (metrics_) {
-            metrics_->peer_request.put_failures.inc();
-            metrics_->peer_request.put_latency_failure.observe(sw.elapsed_us());
+            metrics_->peer_request_metrics.write_remote_data.failures.inc();
+            metrics_->peer_request_metrics.write_remote_data.latency_failure.observe(
+                sw.elapsed_us());
         }
         return result;
     }
 
-    // Record successful put: bytes + latency
     if (metrics_) {
-        metrics_->peer_request.put_bytes.inc(
-            CalculateBufferSize(request.src_buffers));
-        metrics_->peer_request.put_latency_success.observe(sw.elapsed_us());
+        metrics_->peer_request_metrics.write_remote_data.latency_success.observe(
+            sw.elapsed_us());
     }
 
     timer.LogResponse("error_code=", ErrorCode::OK);
     return result;
 }
 
-// TODO(metrics): Add peer_request metrics for forward TE control-plane RPCs
-// below (PreWrite, WriteCommit, WriteRevoke, PinKey, UnPinKey), following the
-// same pattern as WriteRemoteData/ReadRemoteData (Stopwatch, requests/failures/
-// bytes, latency histograms). Follow-up PR.
-
 tl::expected<PreWriteResponse, ErrorCode> ClientRpcService::PreWrite(
     const PreWriteRequest& request) {
     ScopedVLogTimer timer(1, "ClientRpcService::PreWrite");
     timer.LogRequest("key=", request.key, "size_bytes=", request.size_bytes);
 
+    if (metrics_) {
+        metrics_->peer_request_metrics.prewrite.requests.inc();
+    }
+    Stopwatch sw;
+
     if (request.key.empty() || request.size_bytes == 0) {
         LOG(ERROR) << "PreWriteRequest: invalid key or size";
         timer.LogResponse("error_code=", ErrorCode::INVALID_PARAMS);
+        if (metrics_) {
+            metrics_->peer_request_metrics.prewrite.failures.inc();
+            metrics_->peer_request_metrics.prewrite.latency_failure.observe(
+                sw.elapsed_us());
+        }
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
 
@@ -183,7 +183,17 @@ tl::expected<PreWriteResponse, ErrorCode> ClientRpcService::PreWrite(
         LOG(ERROR) << "PreWrite failed for key: " << request.key
                    << ", error: " << toString(result.error());
         timer.LogResponse("error_code=", result.error());
+        if (metrics_) {
+            metrics_->peer_request_metrics.prewrite.failures.inc();
+            metrics_->peer_request_metrics.prewrite.latency_failure.observe(
+                sw.elapsed_us());
+        }
         return tl::make_unexpected(result.error());
+    }
+
+    if (metrics_) {
+        metrics_->peer_request_metrics.prewrite.latency_success.observe(
+            sw.elapsed_us());
     }
 
     timer.LogResponse("error_code=", ErrorCode::OK);
@@ -195,9 +205,19 @@ tl::expected<void, ErrorCode> ClientRpcService::WriteCommit(
     ScopedVLogTimer timer(1, "ClientRpcService::WriteCommit");
     timer.LogRequest("key=", request.key);
 
+    if (metrics_) {
+        metrics_->peer_request_metrics.write_commit.requests.inc();
+    }
+    Stopwatch sw;
+
     if (request.key.empty() || IsZeroUUID(request.write_operation_id)) {
         LOG(ERROR) << "WriteCommitRequest: invalid key or token";
         timer.LogResponse("error_code=", ErrorCode::INVALID_PARAMS);
+        if (metrics_) {
+            metrics_->peer_request_metrics.write_commit.failures.inc();
+            metrics_->peer_request_metrics.write_commit.latency_failure.observe(
+                sw.elapsed_us());
+        }
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
 
@@ -207,7 +227,17 @@ tl::expected<void, ErrorCode> ClientRpcService::WriteCommit(
         LOG(ERROR) << "WriteCommit failed for key: " << request.key
                    << ", error: " << toString(result.error());
         timer.LogResponse("error_code=", result.error());
+        if (metrics_) {
+            metrics_->peer_request_metrics.write_commit.failures.inc();
+            metrics_->peer_request_metrics.write_commit.latency_failure.observe(
+                sw.elapsed_us());
+        }
         return result;
+    }
+
+    if (metrics_) {
+        metrics_->peer_request_metrics.write_commit.latency_success.observe(
+            sw.elapsed_us());
     }
 
     timer.LogResponse("error_code=", ErrorCode::OK);
@@ -219,9 +249,19 @@ tl::expected<void, ErrorCode> ClientRpcService::WriteRevoke(
     ScopedVLogTimer timer(1, "ClientRpcService::WriteRevoke");
     timer.LogRequest("key=", request.key);
 
+    if (metrics_) {
+        metrics_->peer_request_metrics.write_revoke.requests.inc();
+    }
+    Stopwatch sw;
+
     if (request.key.empty() || IsZeroUUID(request.write_operation_id)) {
         LOG(ERROR) << "WriteRevokeRequest: invalid key or token";
         timer.LogResponse("error_code=", ErrorCode::INVALID_PARAMS);
+        if (metrics_) {
+            metrics_->peer_request_metrics.write_revoke.failures.inc();
+            metrics_->peer_request_metrics.write_revoke.latency_failure.observe(
+                sw.elapsed_us());
+        }
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
 
@@ -231,7 +271,17 @@ tl::expected<void, ErrorCode> ClientRpcService::WriteRevoke(
         LOG(ERROR) << "WriteRevoke failed for key: " << request.key
                    << ", error: " << toString(result.error());
         timer.LogResponse("error_code=", result.error());
+        if (metrics_) {
+            metrics_->peer_request_metrics.write_revoke.failures.inc();
+            metrics_->peer_request_metrics.write_revoke.latency_failure.observe(
+                sw.elapsed_us());
+        }
         return result;
+    }
+
+    if (metrics_) {
+        metrics_->peer_request_metrics.write_revoke.latency_success.observe(
+            sw.elapsed_us());
     }
 
     timer.LogResponse("error_code=", ErrorCode::OK);
@@ -243,9 +293,19 @@ tl::expected<PinKeyResponse, ErrorCode> ClientRpcService::PinKey(
     ScopedVLogTimer timer(1, "ClientRpcService::PinKey");
     timer.LogRequest("key=", request.key);
 
+    if (metrics_) {
+        metrics_->peer_request_metrics.pin_key.requests.inc();
+    }
+    Stopwatch sw;
+
     if (request.key.empty()) {
         LOG(ERROR) << "PinKeyRequest: empty key";
         timer.LogResponse("error_code=", ErrorCode::INVALID_PARAMS);
+        if (metrics_) {
+            metrics_->peer_request_metrics.pin_key.failures.inc();
+            metrics_->peer_request_metrics.pin_key.latency_failure.observe(
+                sw.elapsed_us());
+        }
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
 
@@ -254,7 +314,22 @@ tl::expected<PinKeyResponse, ErrorCode> ClientRpcService::PinKey(
         LOG(ERROR) << "PinKey failed for key: " << request.key
                    << ", error: " << toString(result.error());
         timer.LogResponse("error_code=", result.error());
+        if (metrics_) {
+            if (result.error() == ErrorCode::OBJECT_NOT_FOUND) {
+                metrics_->peer_request_metrics.pin_key.misses.inc();
+            } else {
+                metrics_->peer_request_metrics.pin_key.failures.inc();
+            }
+            metrics_->peer_request_metrics.pin_key.latency_failure.observe(
+                sw.elapsed_us());
+        }
         return tl::make_unexpected(result.error());
+    }
+
+    if (metrics_) {
+        metrics_->peer_request_metrics.pin_key.hits.inc();
+        metrics_->peer_request_metrics.pin_key.latency_success.observe(
+            sw.elapsed_us());
     }
 
     timer.LogResponse("error_code=", ErrorCode::OK);
@@ -266,9 +341,19 @@ tl::expected<void, ErrorCode> ClientRpcService::UnPinKey(
     ScopedVLogTimer timer(1, "ClientRpcService::UnPinKey");
     timer.LogRequest("key=", request.key);
 
+    if (metrics_) {
+        metrics_->peer_request_metrics.unpin_key.requests.inc();
+    }
+    Stopwatch sw;
+
     if (request.key.empty() || IsZeroUUID(request.read_operation_id)) {
         LOG(ERROR) << "UnPinKeyRequest: invalid key or token";
         timer.LogResponse("error_code=", ErrorCode::INVALID_PARAMS);
+        if (metrics_) {
+            metrics_->peer_request_metrics.unpin_key.failures.inc();
+            metrics_->peer_request_metrics.unpin_key.latency_failure.observe(
+                sw.elapsed_us());
+        }
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
 
@@ -278,7 +363,17 @@ tl::expected<void, ErrorCode> ClientRpcService::UnPinKey(
         LOG(ERROR) << "UnPinKey failed for key: " << request.key
                    << ", error: " << toString(result.error());
         timer.LogResponse("error_code=", result.error());
+        if (metrics_) {
+            metrics_->peer_request_metrics.unpin_key.failures.inc();
+            metrics_->peer_request_metrics.unpin_key.latency_failure.observe(
+                sw.elapsed_us());
+        }
         return result;
+    }
+
+    if (metrics_) {
+        metrics_->peer_request_metrics.unpin_key.latency_success.observe(
+            sw.elapsed_us());
     }
 
     timer.LogResponse("error_code=", ErrorCode::OK);

--- a/mooncake-store/src/client_rpc_service.cpp
+++ b/mooncake-store/src/client_rpc_service.cpp
@@ -70,8 +70,8 @@ tl::expected<void, ErrorCode> ClientRpcService::ReadRemoteData(
         timer.LogResponse("error_code=", ErrorCode::INVALID_PARAMS);
         if (metrics_) {
             metrics_->peer_request_metrics.read_remote_data.failures.inc();
-            metrics_->peer_request_metrics.read_remote_data.latency_failure.observe(
-                sw.elapsed_us());
+            metrics_->peer_request_metrics.read_remote_data.latency_failure
+                .observe(sw.elapsed_us());
         }
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
@@ -93,8 +93,8 @@ tl::expected<void, ErrorCode> ClientRpcService::ReadRemoteData(
             } else {
                 metrics_->peer_request_metrics.read_remote_data.failures.inc();
             }
-            metrics_->peer_request_metrics.read_remote_data.latency_failure.observe(
-                sw.elapsed_us());
+            metrics_->peer_request_metrics.read_remote_data.latency_failure
+                .observe(sw.elapsed_us());
         }
         return result;
     }
@@ -125,8 +125,8 @@ tl::expected<UUID, ErrorCode> ClientRpcService::WriteRemoteData(
         timer.LogResponse("error_code=", ErrorCode::INVALID_PARAMS);
         if (metrics_) {
             metrics_->peer_request_metrics.write_remote_data.failures.inc();
-            metrics_->peer_request_metrics.write_remote_data.latency_failure.observe(
-                sw.elapsed_us());
+            metrics_->peer_request_metrics.write_remote_data.latency_failure
+                .observe(sw.elapsed_us());
         }
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
@@ -141,15 +141,15 @@ tl::expected<UUID, ErrorCode> ClientRpcService::WriteRemoteData(
         timer.LogResponse("error_code=", result.error());
         if (metrics_) {
             metrics_->peer_request_metrics.write_remote_data.failures.inc();
-            metrics_->peer_request_metrics.write_remote_data.latency_failure.observe(
-                sw.elapsed_us());
+            metrics_->peer_request_metrics.write_remote_data.latency_failure
+                .observe(sw.elapsed_us());
         }
         return result;
     }
 
     if (metrics_) {
-        metrics_->peer_request_metrics.write_remote_data.latency_success.observe(
-            sw.elapsed_us());
+        metrics_->peer_request_metrics.write_remote_data.latency_success
+            .observe(sw.elapsed_us());
     }
 
     timer.LogResponse("error_code=", ErrorCode::OK);

--- a/mooncake-store/src/p2p_client_metric.cpp
+++ b/mooncake-store/src/p2p_client_metric.cpp
@@ -30,7 +30,31 @@ RequestMetric::RequestMetric(const std::string& prefix,
                           kLatencyBucket, labels),
       put_latency_failure(prefix + "_put_latency_failure_us",
                           "Put latency for failed requests (us)",
-                          kLatencyBucket, labels) {}
+                          kLatencyBucket, labels),
+      write_revoke_requests(prefix + "_write_revoke_requests_total",
+                            "Total outgoing WriteRevoke rollback RPCs", labels),
+      write_revoke_failures(prefix + "_write_revoke_failures_total",
+                            "Total failed WriteRevoke rollback RPCs", labels),
+      write_revoke_latency_success(
+          prefix + "_write_revoke_latency_success_us",
+          "WriteRevoke rollback RPC latency for successful requests (us)",
+          kLatencyBucket, labels),
+      write_revoke_latency_failure(
+          prefix + "_write_revoke_latency_failure_us",
+          "WriteRevoke rollback RPC latency for failed requests (us)",
+          kLatencyBucket, labels),
+      unpin_key_requests(prefix + "_unpin_key_requests_total",
+                         "Total outgoing UnPinKey rollback RPCs", labels),
+      unpin_key_failures(prefix + "_unpin_key_failures_total",
+                         "Total failed UnPinKey rollback RPCs", labels),
+      unpin_key_latency_success(prefix + "_unpin_key_latency_success_us",
+                                "UnPinKey rollback RPC latency for successful "
+                                "requests (us)",
+                                kLatencyBucket, labels),
+      unpin_key_latency_failure(prefix + "_unpin_key_latency_failure_us",
+                                "UnPinKey rollback RPC latency for failed "
+                                "requests (us)",
+                                kLatencyBucket, labels) {}
 
 void RequestMetric::serialize(std::string& str) {
     get_requests.serialize(str);
@@ -45,6 +69,14 @@ void RequestMetric::serialize(std::string& str) {
     put_bytes.serialize(str);
     put_latency_success.serialize(str);
     put_latency_failure.serialize(str);
+    write_revoke_requests.serialize(str);
+    write_revoke_failures.serialize(str);
+    write_revoke_latency_success.serialize(str);
+    write_revoke_latency_failure.serialize(str);
+    unpin_key_requests.serialize(str);
+    unpin_key_failures.serialize(str);
+    unpin_key_latency_success.serialize(str);
+    unpin_key_latency_failure.serialize(str);
 }
 
 std::string RequestMetric::summary_metrics() {
@@ -57,6 +89,79 @@ std::string RequestMetric::summary_metrics() {
        << put_failures.value() << " failures, "
        << byte_size_to_string(put_bytes.value()) << " written\n";
 
+    ss << "WriteRevoke rollback: " << write_revoke_requests.value()
+       << " requests, " << write_revoke_failures.value() << " failures\n";
+    ss << "UnPinKey rollback: " << unpin_key_requests.value() << " requests, "
+       << unpin_key_failures.value() << " failures\n";
+
+    return ss.str();
+}
+
+RpcHandlerMetric::RpcHandlerMetric(
+    const std::string& metric_prefix, const std::string& rpc_name,
+    const std::map<std::string, std::string>& labels)
+    : requests(metric_prefix + "_" + rpc_name + "_requests_total",
+               "Total incoming " + rpc_name + " RPC requests", labels),
+      hits(metric_prefix + "_" + rpc_name + "_hits_total",
+           "Total successful " + rpc_name + " RPC requests", labels),
+      misses(metric_prefix + "_" + rpc_name + "_misses_total",
+             "Total " + rpc_name + " RPC misses (not found)", labels),
+      failures(metric_prefix + "_" + rpc_name + "_failures_total",
+               "Total failed " + rpc_name + " RPC requests", labels),
+      latency_success(metric_prefix + "_" + rpc_name + "_latency_success_us",
+                      rpc_name + " RPC latency for successful requests (us)",
+                      kLatencyBucket, labels),
+      latency_failure(metric_prefix + "_" + rpc_name + "_latency_failure_us",
+                      rpc_name + " RPC latency for failed requests (us)",
+                      kLatencyBucket, labels) {}
+
+void RpcHandlerMetric::serialize(std::string& str) const {
+    requests.serialize(str);
+    hits.serialize(str);
+    misses.serialize(str);
+    failures.serialize(str);
+    latency_success.serialize(str);
+    latency_failure.serialize(str);
+}
+
+std::string RpcHandlerMetric::summary_line(
+    const std::string& display_name) const {
+    std::stringstream ss;
+    ss << display_name << ": " << requests.value() << " requests, "
+       << hits.value() << " hits, " << misses.value() << " misses, "
+       << failures.value() << " failures\n";
+    return ss.str();
+}
+
+PeerRequestMetrics::PeerRequestMetrics(
+    const std::string& prefix, const std::map<std::string, std::string>& labels)
+    : read_remote_data(prefix, "read_remote_data", labels),
+      write_remote_data(prefix, "write_remote_data", labels),
+      prewrite(prefix, "prewrite", labels),
+      write_commit(prefix, "write_commit", labels),
+      write_revoke(prefix, "write_revoke", labels),
+      pin_key(prefix, "pin_key", labels),
+      unpin_key(prefix, "unpin_key", labels) {}
+
+void PeerRequestMetrics::serialize(std::string& str) {
+    read_remote_data.serialize(str);
+    write_remote_data.serialize(str);
+    prewrite.serialize(str);
+    write_commit.serialize(str);
+    write_revoke.serialize(str);
+    pin_key.serialize(str);
+    unpin_key.serialize(str);
+}
+
+std::string PeerRequestMetrics::summary_metrics() {
+    std::stringstream ss;
+    ss << read_remote_data.summary_line("ReadRemoteData");
+    ss << write_remote_data.summary_line("WriteRemoteData");
+    ss << prewrite.summary_line("PreWrite");
+    ss << write_commit.summary_line("WriteCommit");
+    ss << write_revoke.summary_line("WriteRevoke");
+    ss << pin_key.summary_line("PinKey");
+    ss << unpin_key.summary_line("UnPinKey");
     return ss.str();
 }
 
@@ -64,7 +169,7 @@ P2PClientMetric::P2PClientMetric(
     uint64_t interval_seconds, const std::map<std::string, std::string>& labels)
     : ClientMetric(interval_seconds, labels),
       local_request("mooncake_p2p_local", labels),
-      peer_request("mooncake_p2p_peer", labels) {}
+      peer_request_metrics("mooncake_p2p_peer", labels) {}
 
 void P2PClientMetric::serialize(std::string& str) {
     // Call base class serialize first
@@ -72,7 +177,7 @@ void P2PClientMetric::serialize(std::string& str) {
 
     // Then serialize P2P-specific metrics
     local_request.serialize(str);
-    peer_request.serialize(str);
+    peer_request_metrics.serialize(str);
 }
 
 std::string P2PClientMetric::summary_metrics() {
@@ -85,7 +190,7 @@ std::string P2PClientMetric::summary_metrics() {
     ss << local_request.summary_metrics();
 
     ss << "=== P2P Peer Request Metrics ===\n";
-    ss << peer_request.summary_metrics();
+    ss << peer_request_metrics.summary_metrics();
 
     return ss.str();
 }

--- a/mooncake-store/src/p2p_client_metric.cpp
+++ b/mooncake-store/src/p2p_client_metric.cpp
@@ -115,7 +115,7 @@ RpcHandlerMetric::RpcHandlerMetric(
                       rpc_name + " RPC latency for failed requests (us)",
                       kLatencyBucket, labels) {}
 
-void RpcHandlerMetric::serialize(std::string& str) const {
+void RpcHandlerMetric::serialize(std::string& str) {
     requests.serialize(str);
     hits.serialize(str);
     misses.serialize(str);
@@ -125,7 +125,7 @@ void RpcHandlerMetric::serialize(std::string& str) const {
 }
 
 std::string RpcHandlerMetric::summary_line(
-    const std::string& display_name) const {
+    const std::string& display_name) {
     std::stringstream ss;
     ss << display_name << ": " << requests.value() << " requests, "
        << hits.value() << " hits, " << misses.value() << " misses, "

--- a/mooncake-store/src/p2p_client_metric.cpp
+++ b/mooncake-store/src/p2p_client_metric.cpp
@@ -102,10 +102,6 @@ RpcHandlerMetric::RpcHandlerMetric(
     const std::map<std::string, std::string>& labels)
     : requests(metric_prefix + "_" + rpc_name + "_requests_total",
                "Total incoming " + rpc_name + " RPC requests", labels),
-      hits(metric_prefix + "_" + rpc_name + "_hits_total",
-           "Total successful " + rpc_name + " RPC requests", labels),
-      misses(metric_prefix + "_" + rpc_name + "_misses_total",
-             "Total " + rpc_name + " RPC misses (not found)", labels),
       failures(metric_prefix + "_" + rpc_name + "_failures_total",
                "Total failed " + rpc_name + " RPC requests", labels),
       latency_success(metric_prefix + "_" + rpc_name + "_latency_success_us",
@@ -117,14 +113,35 @@ RpcHandlerMetric::RpcHandlerMetric(
 
 void RpcHandlerMetric::serialize(std::string& str) {
     requests.serialize(str);
-    hits.serialize(str);
-    misses.serialize(str);
     failures.serialize(str);
     latency_success.serialize(str);
     latency_failure.serialize(str);
 }
 
 std::string RpcHandlerMetric::summary_line(const std::string& display_name) {
+    std::stringstream ss;
+    ss << display_name << ": " << requests.value() << " requests, "
+       << failures.value() << " failures\n";
+    return ss.str();
+}
+
+ReadRpcHandlerMetric::ReadRpcHandlerMetric(
+    const std::string& metric_prefix, const std::string& rpc_name,
+    const std::map<std::string, std::string>& labels)
+    : RpcHandlerMetric(metric_prefix, rpc_name, labels),
+      hits(metric_prefix + "_" + rpc_name + "_hits_total",
+           "Total successful " + rpc_name + " RPC requests", labels),
+      misses(metric_prefix + "_" + rpc_name + "_misses_total",
+             "Total " + rpc_name + " RPC misses (not found)", labels) {}
+
+void ReadRpcHandlerMetric::serialize(std::string& str) {
+    RpcHandlerMetric::serialize(str);
+    hits.serialize(str);
+    misses.serialize(str);
+}
+
+std::string ReadRpcHandlerMetric::summary_line(
+    const std::string& display_name) {
     std::stringstream ss;
     ss << display_name << ": " << requests.value() << " requests, "
        << hits.value() << " hits, " << misses.value() << " misses, "

--- a/mooncake-store/src/p2p_client_metric.cpp
+++ b/mooncake-store/src/p2p_client_metric.cpp
@@ -124,8 +124,7 @@ void RpcHandlerMetric::serialize(std::string& str) {
     latency_failure.serialize(str);
 }
 
-std::string RpcHandlerMetric::summary_line(
-    const std::string& display_name) {
+std::string RpcHandlerMetric::summary_line(const std::string& display_name) {
     std::stringstream ss;
     ss << display_name << ": " << requests.value() << " requests, "
        << hits.value() << " hits, " << misses.value() << " misses, "

--- a/mooncake-store/src/p2p_client_service.cpp
+++ b/mooncake-store/src/p2p_client_service.cpp
@@ -943,9 +943,8 @@ P2PClientService::RemoteForwardWriteOp::Dispatch() {
     }
     auto promise = std::make_shared<WritePromise>();
     auto future = promise->getFuture();
-    RemoteForwardWriteOp::RunForwardRemotePut(std::move(promise), peer_ptr,
-                                              metrics, te_transfer, write_req,
-                                              slices)
+    RemoteForwardWriteOp::RunForwardRemotePut(
+        std::move(promise), peer_ptr, metrics, te_transfer, write_req, slices)
         .start([](auto&&) {});
     return FutureHandle<void>::Create(write_req, std::move(future));
 }
@@ -1523,12 +1522,12 @@ async_simple::coro::Lazy<ErrorCode> P2PClientService::RunForwardReadOnRoute(
         UnPinKeyRequest cleanup;
         cleanup.key = req->key;
         cleanup.read_operation_id = pin.value().read_operation_id;
-        if (metrics_) {
-            metrics_->local_request.unpin_key_requests.inc();
-        }
         Stopwatch rollback_sw;
         tl::expected<void, ErrorCode> cleanup_unpin;
         for (int attempt = 0; attempt < kRevokeRetryMaxCnt; ++attempt) {
+            if (metrics_) {
+                metrics_->local_request.unpin_key_requests.inc();
+            }
             cleanup_unpin = co_await route.peer->AsyncUnPinKey(cleanup);
             if (cleanup_unpin) {
                 break;
@@ -2101,12 +2100,12 @@ P2PClientService::RemoteForwardWriteOp::RunForwardRemotePut(
         WriteRevokeRequest revoke_req;
         revoke_req.key = write_req->key;
         revoke_req.write_operation_id = pre.value().write_operation_id;
-        if (metrics) {
-            metrics->local_request.write_revoke_requests.inc();
-        }
         Stopwatch rollback_sw;
         tl::expected<void, ErrorCode> revoke_res;
         for (int attempt = 0; attempt < kRevokeRetryMaxCnt; ++attempt) {
+            if (metrics) {
+                metrics->local_request.write_revoke_requests.inc();
+            }
             revoke_res = co_await peer->AsyncWriteRevoke(revoke_req);
             if (revoke_res) {
                 break;

--- a/mooncake-store/src/p2p_client_service.cpp
+++ b/mooncake-store/src/p2p_client_service.cpp
@@ -882,7 +882,7 @@ auto P2PClientService::BuildWriteOps(std::string_view key,
                                             Transport::TransferRequest::WRITE);
                 };
                 write_ops.push_back(std::make_unique<RemoteForwardWriteOp>(
-                    peer, write_req, endpoint, &slices,
+                    peer, metrics_.get(), write_req, endpoint, &slices,
                     std::move(te_transfer)));
             } else {
                 write_ops.push_back(std::make_unique<RemoteReverseWriteOp>(
@@ -944,7 +944,8 @@ P2PClientService::RemoteForwardWriteOp::Dispatch() {
     auto promise = std::make_shared<WritePromise>();
     auto future = promise->getFuture();
     RemoteForwardWriteOp::RunForwardRemotePut(std::move(promise), peer_ptr,
-                                              te_transfer, write_req, slices)
+                                              metrics, te_transfer, write_req,
+                                              slices)
         .start([](auto&&) {});
     return FutureHandle<void>::Create(write_req, std::move(future));
 }
@@ -1522,6 +1523,10 @@ async_simple::coro::Lazy<ErrorCode> P2PClientService::RunForwardReadOnRoute(
         UnPinKeyRequest cleanup;
         cleanup.key = req->key;
         cleanup.read_operation_id = pin.value().read_operation_id;
+        if (metrics_) {
+            metrics_->local_request.unpin_key_requests.inc();
+        }
+        Stopwatch rollback_sw;
         tl::expected<void, ErrorCode> cleanup_unpin;
         for (int attempt = 0; attempt < kRevokeRetryMaxCnt; ++attempt) {
             cleanup_unpin = co_await route.peer->AsyncUnPinKey(cleanup);
@@ -1537,6 +1542,16 @@ async_simple::coro::Lazy<ErrorCode> P2PClientService::RunForwardReadOnRoute(
                     << "AsyncUnPinKey retry after TE failure, key=" << req->key
                     << ", attempt=" << (attempt + 1)
                     << ", error=" << cleanup_unpin.error();
+            }
+        }
+        if (metrics_) {
+            if (cleanup_unpin) {
+                metrics_->local_request.unpin_key_latency_success.observe(
+                    rollback_sw.elapsed_us());
+            } else {
+                metrics_->local_request.unpin_key_failures.inc();
+                metrics_->local_request.unpin_key_latency_failure.observe(
+                    rollback_sw.elapsed_us());
             }
         }
         if (!cleanup_unpin) {
@@ -2046,8 +2061,8 @@ PeerClient& P2PClientService::GetOrCreatePeerClient(
 async_simple::coro::Lazy<void>
 P2PClientService::RemoteForwardWriteOp::RunForwardRemotePut(
     std::shared_ptr<WritePromise> promise, PeerClient* peer,
-    TeTransferFn te_transfer, std::shared_ptr<RemoteWriteRequest> write_req,
-    std::vector<Slice>* slices) {
+    P2PClientMetric* metrics, TeTransferFn te_transfer,
+    std::shared_ptr<RemoteWriteRequest> write_req, std::vector<Slice>* slices) {
     if (!peer || !te_transfer || !write_req || !slices) {
         promise->setValue(tl::expected<void, ErrorCode>(
             tl::unexpected(ErrorCode::INTERNAL_ERROR)));
@@ -2086,6 +2101,10 @@ P2PClientService::RemoteForwardWriteOp::RunForwardRemotePut(
         WriteRevokeRequest revoke_req;
         revoke_req.key = write_req->key;
         revoke_req.write_operation_id = pre.value().write_operation_id;
+        if (metrics) {
+            metrics->local_request.write_revoke_requests.inc();
+        }
+        Stopwatch rollback_sw;
         tl::expected<void, ErrorCode> revoke_res;
         for (int attempt = 0; attempt < kRevokeRetryMaxCnt; ++attempt) {
             revoke_res = co_await peer->AsyncWriteRevoke(revoke_req);
@@ -2100,6 +2119,16 @@ P2PClientService::RemoteForwardWriteOp::RunForwardRemotePut(
                 LOG(WARNING) << "AsyncWriteRevoke retry after TE failure, key="
                              << write_req->key << ", attempt=" << (attempt + 1)
                              << ", error=" << revoke_res.error();
+            }
+        }
+        if (metrics) {
+            if (revoke_res) {
+                metrics->local_request.write_revoke_latency_success.observe(
+                    rollback_sw.elapsed_us());
+            } else {
+                metrics->local_request.write_revoke_failures.inc();
+                metrics->local_request.write_revoke_latency_failure.observe(
+                    rollback_sw.elapsed_us());
             }
         }
         if (!revoke_res) {

--- a/mooncake-store/tests/client_http_metrics_test.cpp
+++ b/mooncake-store/tests/client_http_metrics_test.cpp
@@ -502,18 +502,23 @@ TEST_F(ClientHttpMetricsTest, P2PClientPeerMetricsHttpEndpointsTest) {
     p2p_metrics->local_request.unpin_key_failures.inc(1);
     p2p_metrics->local_request.unpin_key_latency_success.observe(55);
 
-    // Peer per-RPC metrics (write: no bytes, aligned with local put minus bytes)
+    // Peer per-RPC metrics (write: no bytes, aligned with local put minus
+    // bytes)
     p2p_metrics->peer_request_metrics.write_remote_data.requests.inc(30);
     p2p_metrics->peer_request_metrics.write_remote_data.failures.inc(2);
-    p2p_metrics->peer_request_metrics.write_remote_data.latency_success.observe(250);
-    p2p_metrics->peer_request_metrics.write_remote_data.latency_failure.observe(350);
+    p2p_metrics->peer_request_metrics.write_remote_data.latency_success.observe(
+        250);
+    p2p_metrics->peer_request_metrics.write_remote_data.latency_failure.observe(
+        350);
 
     p2p_metrics->peer_request_metrics.read_remote_data.requests.inc(200);
     p2p_metrics->peer_request_metrics.read_remote_data.hits.inc(150);
     p2p_metrics->peer_request_metrics.read_remote_data.misses.inc(40);
     p2p_metrics->peer_request_metrics.read_remote_data.failures.inc(10);
-    p2p_metrics->peer_request_metrics.read_remote_data.latency_success.observe(120);
-    p2p_metrics->peer_request_metrics.read_remote_data.latency_failure.observe(180);
+    p2p_metrics->peer_request_metrics.read_remote_data.latency_success.observe(
+        120);
+    p2p_metrics->peer_request_metrics.read_remote_data.latency_failure.observe(
+        180);
 
     // Create and start HTTP server
     coro_http::coro_http_server server(1, test_port);
@@ -586,9 +591,10 @@ TEST_F(ClientHttpMetricsTest, P2PClientPeerMetricsHttpEndpointsTest) {
                         "mooncake_p2p_peer_read_remote_data_failures_total") !=
                     std::string::npos)
             << "Metrics should contain peer read_remote_data failures";
-        EXPECT_TRUE(resp.resp_body.find(
-                        "mooncake_p2p_peer_read_remote_data_latency_success_us") !=
-                    std::string::npos)
+        EXPECT_TRUE(
+            resp.resp_body.find(
+                "mooncake_p2p_peer_read_remote_data_latency_success_us") !=
+            std::string::npos)
             << "Metrics should contain peer read_remote_data latency success";
         EXPECT_TRUE(resp.resp_body.find(
                         "mooncake_p2p_peer_write_remote_data_requests_total") !=
@@ -598,38 +604,36 @@ TEST_F(ClientHttpMetricsTest, P2PClientPeerMetricsHttpEndpointsTest) {
                         "mooncake_p2p_peer_write_remote_data_failures_total") !=
                     std::string::npos)
             << "Metrics should contain peer write_remote_data failures";
-        EXPECT_TRUE(resp.resp_body.find(
-                        "mooncake_p2p_peer_write_remote_data_latency_success_us") !=
-                    std::string::npos)
+        EXPECT_TRUE(
+            resp.resp_body.find(
+                "mooncake_p2p_peer_write_remote_data_latency_success_us") !=
+            std::string::npos)
             << "Metrics should contain peer write_remote_data latency success";
-        EXPECT_TRUE(resp.resp_body.find(
-                        "mooncake_p2p_peer_write_remote_data_latency_failure_us") !=
-                    std::string::npos)
+        EXPECT_TRUE(
+            resp.resp_body.find(
+                "mooncake_p2p_peer_write_remote_data_latency_failure_us") !=
+            std::string::npos)
             << "Metrics should contain peer write_remote_data latency failure";
 
-        EXPECT_TRUE(
-            resp.resp_body.find(
-                "mooncake_p2p_peer_read_remote_data_requests_total") !=
-                std::string::npos &&
-            resp.resp_body.find("} 200\n") != std::string::npos)
+        EXPECT_TRUE(resp.resp_body.find(
+                        "mooncake_p2p_peer_read_remote_data_requests_total") !=
+                        std::string::npos &&
+                    resp.resp_body.find("} 200\n") != std::string::npos)
             << "Peer read_remote_data requests should be 200";
-        EXPECT_TRUE(
-            resp.resp_body.find(
-                "mooncake_p2p_peer_read_remote_data_hits_total") !=
-                std::string::npos &&
-            resp.resp_body.find("} 150\n") != std::string::npos)
+        EXPECT_TRUE(resp.resp_body.find(
+                        "mooncake_p2p_peer_read_remote_data_hits_total") !=
+                        std::string::npos &&
+                    resp.resp_body.find("} 150\n") != std::string::npos)
             << "Peer read_remote_data hits should be 150";
-        EXPECT_TRUE(
-            resp.resp_body.find(
-                "mooncake_p2p_peer_write_remote_data_requests_total") !=
-                std::string::npos &&
-            resp.resp_body.find("} 30\n") != std::string::npos)
+        EXPECT_TRUE(resp.resp_body.find(
+                        "mooncake_p2p_peer_write_remote_data_requests_total") !=
+                        std::string::npos &&
+                    resp.resp_body.find("} 30\n") != std::string::npos)
             << "Peer write_remote_data requests should be 30";
-        EXPECT_TRUE(
-            resp.resp_body.find(
-                "mooncake_p2p_peer_write_remote_data_failures_total") !=
-                std::string::npos &&
-            resp.resp_body.find("} 2\n") != std::string::npos)
+        EXPECT_TRUE(resp.resp_body.find(
+                        "mooncake_p2p_peer_write_remote_data_failures_total") !=
+                        std::string::npos &&
+                    resp.resp_body.find("} 2\n") != std::string::npos)
             << "Peer write_remote_data failures should be 2";
     }
 

--- a/mooncake-store/tests/client_http_metrics_test.cpp
+++ b/mooncake-store/tests/client_http_metrics_test.cpp
@@ -495,21 +495,25 @@ TEST_F(ClientHttpMetricsTest, P2PClientPeerMetricsHttpEndpointsTest) {
     p2p_metrics->local_request.get_bytes.inc(20 * 1024 * 1024);  // 20 MB
     p2p_metrics->local_request.get_latency_success.observe(100);
 
-    // Peer Put metrics
-    p2p_metrics->peer_request.put_requests.inc(30);
-    p2p_metrics->peer_request.put_bytes.inc(15 * 1024 * 1024);  // 15 MB
-    p2p_metrics->peer_request.put_failures.inc(2);
-    p2p_metrics->peer_request.put_latency_success.observe(250);
-    p2p_metrics->peer_request.put_latency_failure.observe(350);
+    p2p_metrics->local_request.write_revoke_requests.inc(2);
+    p2p_metrics->local_request.write_revoke_failures.inc(1);
+    p2p_metrics->local_request.write_revoke_latency_success.observe(70);
+    p2p_metrics->local_request.unpin_key_requests.inc(4);
+    p2p_metrics->local_request.unpin_key_failures.inc(1);
+    p2p_metrics->local_request.unpin_key_latency_success.observe(55);
 
-    // Peer Get metrics
-    p2p_metrics->peer_request.get_requests.inc(200);
-    p2p_metrics->peer_request.get_hits.inc(150);
-    p2p_metrics->peer_request.get_misses.inc(40);
-    p2p_metrics->peer_request.get_failures.inc(10);
-    p2p_metrics->peer_request.get_bytes.inc(40 * 1024 * 1024);  // 40 MB
-    p2p_metrics->peer_request.get_latency_success.observe(120);
-    p2p_metrics->peer_request.get_latency_failure.observe(220);
+    // Peer per-RPC metrics (write: no bytes, aligned with local put minus bytes)
+    p2p_metrics->peer_request_metrics.write_remote_data.requests.inc(30);
+    p2p_metrics->peer_request_metrics.write_remote_data.failures.inc(2);
+    p2p_metrics->peer_request_metrics.write_remote_data.latency_success.observe(250);
+    p2p_metrics->peer_request_metrics.write_remote_data.latency_failure.observe(350);
+
+    p2p_metrics->peer_request_metrics.read_remote_data.requests.inc(200);
+    p2p_metrics->peer_request_metrics.read_remote_data.hits.inc(150);
+    p2p_metrics->peer_request_metrics.read_remote_data.misses.inc(40);
+    p2p_metrics->peer_request_metrics.read_remote_data.failures.inc(10);
+    p2p_metrics->peer_request_metrics.read_remote_data.latency_success.observe(120);
+    p2p_metrics->peer_request_metrics.read_remote_data.latency_failure.observe(180);
 
     // Create and start HTTP server
     coro_http::coro_http_server server(1, test_port);
@@ -556,68 +560,77 @@ TEST_F(ClientHttpMetricsTest, P2PClientPeerMetricsHttpEndpointsTest) {
             resp.resp_body.find("mooncake_p2p_local_put_requests_total") !=
             std::string::npos)
             << "Metrics should contain local put requests metric";
+        EXPECT_TRUE(resp.resp_body.find(
+                        "mooncake_p2p_local_write_revoke_requests_total") !=
+                    std::string::npos)
+            << "Metrics should contain local write_revoke rollback requests";
+        EXPECT_TRUE(resp.resp_body.find(
+                        "mooncake_p2p_local_unpin_key_requests_total") !=
+                    std::string::npos)
+            << "Metrics should contain local unpin_key rollback requests";
 
-        // Check peer metrics are present
-        EXPECT_TRUE(
-            resp.resp_body.find("mooncake_p2p_peer_get_requests_total") !=
-            std::string::npos)
-            << "Metrics should contain peer get requests metric";
-        EXPECT_TRUE(resp.resp_body.find("mooncake_p2p_peer_get_hits_total") !=
+        // Check peer per-RPC metrics are present
+        EXPECT_TRUE(resp.resp_body.find(
+                        "mooncake_p2p_peer_read_remote_data_requests_total") !=
                     std::string::npos)
-            << "Metrics should contain peer get hits metric";
-        EXPECT_TRUE(resp.resp_body.find("mooncake_p2p_peer_get_misses_total") !=
+            << "Metrics should contain peer read_remote_data requests";
+        EXPECT_TRUE(resp.resp_body.find(
+                        "mooncake_p2p_peer_read_remote_data_hits_total") !=
                     std::string::npos)
-            << "Metrics should contain peer get misses metric";
-        EXPECT_TRUE(
-            resp.resp_body.find("mooncake_p2p_peer_get_failures_total") !=
-            std::string::npos)
-            << "Metrics should contain peer get failures metric";
-        EXPECT_TRUE(resp.resp_body.find("mooncake_p2p_peer_get_bytes_total") !=
+            << "Metrics should contain peer read_remote_data hits";
+        EXPECT_TRUE(resp.resp_body.find(
+                        "mooncake_p2p_peer_read_remote_data_misses_total") !=
                     std::string::npos)
-            << "Metrics should contain peer get bytes metric";
-        EXPECT_TRUE(
-            resp.resp_body.find("mooncake_p2p_peer_get_latency_success_us") !=
-            std::string::npos)
-            << "Metrics should contain peer get latency success metric";
-        EXPECT_TRUE(
-            resp.resp_body.find("mooncake_p2p_peer_get_latency_failure_us") !=
-            std::string::npos)
-            << "Metrics should contain peer get latency failure metric";
-        EXPECT_TRUE(
-            resp.resp_body.find("mooncake_p2p_peer_put_requests_total") !=
-            std::string::npos)
-            << "Metrics should contain peer put requests metric";
-        EXPECT_TRUE(
-            resp.resp_body.find("mooncake_p2p_peer_put_failures_total") !=
-            std::string::npos)
-            << "Metrics should contain peer put failures metric";
-        EXPECT_TRUE(resp.resp_body.find("mooncake_p2p_peer_put_bytes_total") !=
+            << "Metrics should contain peer read_remote_data misses";
+        EXPECT_TRUE(resp.resp_body.find(
+                        "mooncake_p2p_peer_read_remote_data_failures_total") !=
                     std::string::npos)
-            << "Metrics should contain peer put bytes metric";
-        EXPECT_TRUE(
-            resp.resp_body.find("mooncake_p2p_peer_put_latency_success_us") !=
-            std::string::npos)
-            << "Metrics should contain peer put latency success metric";
-        EXPECT_TRUE(
-            resp.resp_body.find("mooncake_p2p_peer_put_latency_failure_us") !=
-            std::string::npos)
-            << "Metrics should contain peer put latency failure metric";
+            << "Metrics should contain peer read_remote_data failures";
+        EXPECT_TRUE(resp.resp_body.find(
+                        "mooncake_p2p_peer_read_remote_data_latency_success_us") !=
+                    std::string::npos)
+            << "Metrics should contain peer read_remote_data latency success";
+        EXPECT_TRUE(resp.resp_body.find(
+                        "mooncake_p2p_peer_write_remote_data_requests_total") !=
+                    std::string::npos)
+            << "Metrics should contain peer write_remote_data requests";
+        EXPECT_TRUE(resp.resp_body.find(
+                        "mooncake_p2p_peer_write_remote_data_failures_total") !=
+                    std::string::npos)
+            << "Metrics should contain peer write_remote_data failures";
+        EXPECT_TRUE(resp.resp_body.find(
+                        "mooncake_p2p_peer_write_remote_data_latency_success_us") !=
+                    std::string::npos)
+            << "Metrics should contain peer write_remote_data latency success";
+        EXPECT_TRUE(resp.resp_body.find(
+                        "mooncake_p2p_peer_write_remote_data_latency_failure_us") !=
+                    std::string::npos)
+            << "Metrics should contain peer write_remote_data latency failure";
 
-        // Check actual values
         EXPECT_TRUE(
-            resp.resp_body.find("mooncake_p2p_peer_get_requests_total") !=
+            resp.resp_body.find(
+                "mooncake_p2p_peer_read_remote_data_requests_total") !=
                 std::string::npos &&
             resp.resp_body.find("} 200\n") != std::string::npos)
-            << "Peer get requests should be 200";
-        EXPECT_TRUE(resp.resp_body.find("mooncake_p2p_peer_get_hits_total") !=
-                        std::string::npos &&
-                    resp.resp_body.find("} 150\n") != std::string::npos)
-            << "Peer get hits should be 150";
+            << "Peer read_remote_data requests should be 200";
         EXPECT_TRUE(
-            resp.resp_body.find("mooncake_p2p_peer_put_requests_total") !=
+            resp.resp_body.find(
+                "mooncake_p2p_peer_read_remote_data_hits_total") !=
+                std::string::npos &&
+            resp.resp_body.find("} 150\n") != std::string::npos)
+            << "Peer read_remote_data hits should be 150";
+        EXPECT_TRUE(
+            resp.resp_body.find(
+                "mooncake_p2p_peer_write_remote_data_requests_total") !=
                 std::string::npos &&
             resp.resp_body.find("} 30\n") != std::string::npos)
-            << "Peer put requests should be 30";
+            << "Peer write_remote_data requests should be 30";
+        EXPECT_TRUE(
+            resp.resp_body.find(
+                "mooncake_p2p_peer_write_remote_data_failures_total") !=
+                std::string::npos &&
+            resp.resp_body.find("} 2\n") != std::string::npos)
+            << "Peer write_remote_data failures should be 2";
     }
 
     // Test /metrics/summary endpoint for P2P peer metrics
@@ -642,19 +655,23 @@ TEST_F(ClientHttpMetricsTest, P2PClientPeerMetricsHttpEndpointsTest) {
         EXPECT_TRUE(resp.resp_body.find("80 hits") != std::string::npos)
             << "Summary should show 80 local get hits";
 
-        // Check peer metrics in summary
-        EXPECT_TRUE(resp.resp_body.find("200 requests") != std::string::npos)
-            << "Summary should show 200 peer get requests";
+        // Check peer per-RPC metrics in summary
+        EXPECT_TRUE(resp.resp_body.find("ReadRemoteData: 200 requests") !=
+                    std::string::npos)
+            << "Summary should show peer ReadRemoteData requests";
         EXPECT_TRUE(resp.resp_body.find("150 hits") != std::string::npos)
-            << "Summary should show 150 peer get hits";
-        EXPECT_TRUE(resp.resp_body.find("40 misses") != std::string::npos)
-            << "Summary should show 40 peer get misses";
-        EXPECT_TRUE(resp.resp_body.find("10 failures") != std::string::npos)
-            << "Summary should show 10 peer get failures";
-        EXPECT_TRUE(resp.resp_body.find("40.00 MB") != std::string::npos)
-            << "Summary should show 40.00 MB read for peer";
-        EXPECT_TRUE(resp.resp_body.find("15.00 MB") != std::string::npos)
-            << "Summary should show 15.00 MB written for peer";
+            << "Summary should show peer ReadRemoteData hits";
+        EXPECT_TRUE(resp.resp_body.find("WriteRemoteData: 30 requests") !=
+                    std::string::npos)
+            << "Summary should show peer WriteRemoteData requests";
+        EXPECT_TRUE(resp.resp_body.find("2 failures") != std::string::npos)
+            << "Summary should show peer WriteRemoteData failures";
+        EXPECT_TRUE(resp.resp_body.find("WriteRevoke rollback: 2 requests") !=
+                    std::string::npos)
+            << "Summary should show local WriteRevoke rollback requests";
+        EXPECT_TRUE(resp.resp_body.find("UnPinKey rollback: 4 requests") !=
+                    std::string::npos)
+            << "Summary should show local UnPinKey rollback requests";
     }
 
     server.stop();

--- a/mooncake-store/tests/client_metrics_test.cpp
+++ b/mooncake-store/tests/client_metrics_test.cpp
@@ -352,12 +352,12 @@ TEST_F(ClientMetricsTest, P2PClientMetricSerializeTest) {
     // Verify Prometheus format output
     EXPECT_TRUE(serialized.find("mooncake_p2p_local_put_requests_total 100") !=
                 std::string::npos);
-    EXPECT_TRUE(serialized.find(
-                    "mooncake_p2p_local_write_revoke_requests_total 4") !=
-                std::string::npos);
-    EXPECT_TRUE(serialized.find(
-                    "mooncake_p2p_local_unpin_key_requests_total 6") !=
-                std::string::npos);
+    EXPECT_TRUE(
+        serialized.find("mooncake_p2p_local_write_revoke_requests_total 4") !=
+        std::string::npos);
+    EXPECT_TRUE(
+        serialized.find("mooncake_p2p_local_unpin_key_requests_total 6") !=
+        std::string::npos);
     EXPECT_TRUE(
         serialized.find("mooncake_p2p_local_put_bytes_total 52428800") !=
         std::string::npos);
@@ -461,12 +461,12 @@ TEST_F(ClientMetricsTest, P2PClientMetricPeerRequestTest) {
     EXPECT_TRUE(serialized.find(
                     "mooncake_p2p_peer_read_remote_data_requests_total 100") !=
                 std::string::npos);
-    EXPECT_TRUE(serialized.find(
-                    "mooncake_p2p_peer_read_remote_data_hits_total 80") !=
-                std::string::npos);
-    EXPECT_TRUE(serialized.find(
-                    "mooncake_p2p_peer_read_remote_data_misses_total 15") !=
-                std::string::npos);
+    EXPECT_TRUE(
+        serialized.find("mooncake_p2p_peer_read_remote_data_hits_total 80") !=
+        std::string::npos);
+    EXPECT_TRUE(
+        serialized.find("mooncake_p2p_peer_read_remote_data_misses_total 15") !=
+        std::string::npos);
     EXPECT_TRUE(serialized.find(
                     "mooncake_p2p_peer_read_remote_data_failures_total 5") !=
                 std::string::npos);
@@ -476,9 +476,9 @@ TEST_F(ClientMetricsTest, P2PClientMetricPeerRequestTest) {
     EXPECT_TRUE(serialized.find(
                     "mooncake_p2p_peer_write_remote_data_requests_total 50") !=
                 std::string::npos);
-    EXPECT_TRUE(serialized.find(
-                    "mooncake_p2p_peer_prewrite_requests_total 20") !=
-                std::string::npos);
+    EXPECT_TRUE(
+        serialized.find("mooncake_p2p_peer_prewrite_requests_total 20") !=
+        std::string::npos);
 
     std::string summary = metrics.summary_metrics();
     EXPECT_TRUE(summary.find("P2P Peer Request Metrics") != std::string::npos);
@@ -510,8 +510,9 @@ TEST_F(ClientMetricsTest, P2PClientMetricBothLocalAndPeerTest) {
 
     EXPECT_TRUE(serialized.find("mooncake_p2p_local_get_requests_total 1000") !=
                 std::string::npos);
-    EXPECT_TRUE(serialized.find("mooncake_p2p_peer_pin_key_requests_total 500") !=
-                std::string::npos);
+    EXPECT_TRUE(
+        serialized.find("mooncake_p2p_peer_pin_key_requests_total 500") !=
+        std::string::npos);
     EXPECT_TRUE(serialized.find("mooncake_p2p_local_get_hits_total 900") !=
                 std::string::npos);
     EXPECT_TRUE(serialized.find("mooncake_p2p_peer_pin_key_hits_total 400") !=

--- a/mooncake-store/tests/client_metrics_test.cpp
+++ b/mooncake-store/tests/client_metrics_test.cpp
@@ -275,6 +275,10 @@ TEST_F(ClientMetricsTest, P2PClientMetricBasicTest) {
     std::string summary = metrics.summary_metrics();
     EXPECT_TRUE(summary.find("Get: 0 requests") != std::string::npos);
     EXPECT_TRUE(summary.find("Put: 0 requests") != std::string::npos);
+    EXPECT_TRUE(summary.find("WriteRevoke rollback: 0 requests") !=
+                std::string::npos);
+    EXPECT_TRUE(summary.find("UnPinKey rollback: 0 requests") !=
+                std::string::npos);
 
     // Add put data
     metrics.local_request.put_requests.inc();
@@ -284,6 +288,16 @@ TEST_F(ClientMetricsTest, P2PClientMetricBasicTest) {
     metrics.local_request.put_latency_success.observe(200);
     metrics.local_request.put_latency_success.observe(300);
     metrics.local_request.put_latency_failure.observe(500);
+
+    metrics.local_request.write_revoke_requests.inc(3);
+    metrics.local_request.write_revoke_failures.inc(1);
+    metrics.local_request.write_revoke_latency_success.observe(80);
+    metrics.local_request.write_revoke_latency_failure.observe(120);
+
+    metrics.local_request.unpin_key_requests.inc(5);
+    metrics.local_request.unpin_key_failures.inc(2);
+    metrics.local_request.unpin_key_latency_success.observe(60);
+    metrics.local_request.unpin_key_latency_failure.observe(90);
 
     // Add get data
     metrics.local_request.get_requests.inc();
@@ -304,6 +318,10 @@ TEST_F(ClientMetricsTest, P2PClientMetricBasicTest) {
     EXPECT_TRUE(summary.find("2.00 MB read") != std::string::npos);
     EXPECT_TRUE(summary.find("1 misses") != std::string::npos);
     EXPECT_TRUE(summary.find("1 hits") != std::string::npos);
+    EXPECT_TRUE(summary.find("WriteRevoke rollback: 3 requests") !=
+                std::string::npos);
+    EXPECT_TRUE(summary.find("UnPinKey rollback: 5 requests") !=
+                std::string::npos);
 
     std::cout << "P2P Client Metrics Summary:\n" << summary << std::endl;
 }
@@ -325,12 +343,20 @@ TEST_F(ClientMetricsTest, P2PClientMetricSerializeTest) {
     metrics.local_request.put_latency_failure.observe(500);
     metrics.local_request.get_latency_success.observe(100);
     metrics.local_request.get_latency_failure.observe(400);
+    metrics.local_request.write_revoke_requests.inc(4);
+    metrics.local_request.unpin_key_requests.inc(6);
 
     std::string serialized;
     metrics.serialize(serialized);
 
     // Verify Prometheus format output
     EXPECT_TRUE(serialized.find("mooncake_p2p_local_put_requests_total 100") !=
+                std::string::npos);
+    EXPECT_TRUE(serialized.find(
+                    "mooncake_p2p_local_write_revoke_requests_total 4") !=
+                std::string::npos);
+    EXPECT_TRUE(serialized.find(
+                    "mooncake_p2p_local_unpin_key_requests_total 6") !=
                 std::string::npos);
     EXPECT_TRUE(
         serialized.find("mooncake_p2p_local_put_bytes_total 52428800") !=
@@ -413,104 +439,84 @@ TEST_F(ClientMetricsTest, P2PClientMetricInheritanceTest) {
     EXPECT_TRUE(summary.find("Put: 50 requests") != std::string::npos);
 }
 
-// Test P2PClientMetric peer_request metrics
+// Test P2PClientMetric peer_request_metrics (per-RPC peer metrics)
 TEST_F(ClientMetricsTest, P2PClientMetricPeerRequestTest) {
     P2PClientMetric metrics;
 
-    // Test peer_request metrics are present and work correctly
-    metrics.peer_request.get_requests.inc(100);
-    metrics.peer_request.get_hits.inc(80);
-    metrics.peer_request.get_misses.inc(15);
-    metrics.peer_request.get_failures.inc(5);
-    metrics.peer_request.get_bytes.inc(10 * 1024 * 1024);  // 10 MB
-    metrics.peer_request.get_latency_success.observe(100);
-    metrics.peer_request.get_latency_success.observe(200);
-    metrics.peer_request.get_latency_failure.observe(500);
-    metrics.peer_request.get_latency_failure.observe(600);
+    metrics.peer_request_metrics.read_remote_data.requests.inc(100);
+    metrics.peer_request_metrics.read_remote_data.hits.inc(80);
+    metrics.peer_request_metrics.read_remote_data.misses.inc(15);
+    metrics.peer_request_metrics.read_remote_data.failures.inc(5);
+    metrics.peer_request_metrics.read_remote_data.latency_success.observe(120);
 
-    metrics.peer_request.put_requests.inc(50);
-    metrics.peer_request.put_failures.inc(2);
-    metrics.peer_request.put_bytes.inc(5 * 1024 * 1024);  // 5 MB
-    metrics.peer_request.put_latency_success.observe(300);
-    metrics.peer_request.put_latency_success.observe(400);
-    metrics.peer_request.put_latency_failure.observe(700);
-    metrics.peer_request.put_latency_failure.observe(800);
+    metrics.peer_request_metrics.write_remote_data.requests.inc(50);
+    metrics.peer_request_metrics.write_remote_data.failures.inc(2);
+    metrics.peer_request_metrics.write_remote_data.latency_success.observe(300);
 
-    // Test serialize includes peer_request metrics
+    metrics.peer_request_metrics.prewrite.requests.inc(20);
+
     std::string serialized;
     metrics.serialize(serialized);
 
-    // Verify peer_request metrics are present with correct prefix
-    EXPECT_TRUE(serialized.find("mooncake_p2p_peer_get_requests_total 100") !=
+    EXPECT_TRUE(serialized.find(
+                    "mooncake_p2p_peer_read_remote_data_requests_total 100") !=
                 std::string::npos);
-    EXPECT_TRUE(serialized.find("mooncake_p2p_peer_get_hits_total 80") !=
+    EXPECT_TRUE(serialized.find(
+                    "mooncake_p2p_peer_read_remote_data_hits_total 80") !=
                 std::string::npos);
-    EXPECT_TRUE(serialized.find("mooncake_p2p_peer_get_misses_total 15") !=
+    EXPECT_TRUE(serialized.find(
+                    "mooncake_p2p_peer_read_remote_data_misses_total 15") !=
                 std::string::npos);
-    EXPECT_TRUE(serialized.find("mooncake_p2p_peer_get_failures_total 5") !=
+    EXPECT_TRUE(serialized.find(
+                    "mooncake_p2p_peer_read_remote_data_failures_total 5") !=
                 std::string::npos);
-    EXPECT_TRUE(serialized.find("mooncake_p2p_peer_get_bytes_total") !=
+    EXPECT_TRUE(serialized.find(
+                    "mooncake_p2p_peer_read_remote_data_latency_success_us") !=
                 std::string::npos);
-    EXPECT_TRUE(serialized.find("mooncake_p2p_peer_get_latency_success_us") !=
+    EXPECT_TRUE(serialized.find(
+                    "mooncake_p2p_peer_write_remote_data_requests_total 50") !=
                 std::string::npos);
-    EXPECT_TRUE(serialized.find("mooncake_p2p_peer_get_latency_failure_us") !=
-                std::string::npos);
-    EXPECT_TRUE(serialized.find("mooncake_p2p_peer_put_requests_total 50") !=
-                std::string::npos);
-    EXPECT_TRUE(serialized.find("mooncake_p2p_peer_put_failures_total 2") !=
-                std::string::npos);
-    EXPECT_TRUE(serialized.find("mooncake_p2p_peer_put_bytes_total") !=
-                std::string::npos);
-    EXPECT_TRUE(serialized.find("mooncake_p2p_peer_put_latency_success_us") !=
-                std::string::npos);
-    EXPECT_TRUE(serialized.find("mooncake_p2p_peer_put_latency_failure_us") !=
+    EXPECT_TRUE(serialized.find(
+                    "mooncake_p2p_peer_prewrite_requests_total 20") !=
                 std::string::npos);
 
-    // Test summary_metrics includes peer_request metrics
     std::string summary = metrics.summary_metrics();
     EXPECT_TRUE(summary.find("P2P Peer Request Metrics") != std::string::npos);
-    EXPECT_TRUE(summary.find("Get: 100 requests") != std::string::npos);
+    EXPECT_TRUE(summary.find("ReadRemoteData: 100 requests") !=
+                std::string::npos);
     EXPECT_TRUE(summary.find("80 hits") != std::string::npos);
     EXPECT_TRUE(summary.find("15 misses") != std::string::npos);
     EXPECT_TRUE(summary.find("5 failures") != std::string::npos);
-    EXPECT_TRUE(summary.find("Put: 50 requests") != std::string::npos);
-    EXPECT_TRUE(summary.find("2 failures") != std::string::npos);
-
-    std::cout << "P2P Peer Request Metrics Summary:\n" << summary << std::endl;
+    EXPECT_TRUE(summary.find("WriteRemoteData: 50 requests") !=
+                std::string::npos);
+    EXPECT_TRUE(summary.find("PreWrite: 20 requests") != std::string::npos);
 }
 
-// Test both local_request and peer_request together
+// Test both local_request and peer_request_metrics together
 TEST_F(ClientMetricsTest, P2PClientMetricBothLocalAndPeerTest) {
     P2PClientMetric metrics;
 
-    // Add data to both local_request and peer_request
     metrics.local_request.get_requests.inc(1000);
     metrics.local_request.get_hits.inc(900);
     metrics.local_request.get_misses.inc(50);
     metrics.local_request.get_failures.inc(50);
     metrics.local_request.get_bytes.inc(100 * 1024 * 1024);  // 100 MB
 
-    metrics.peer_request.get_requests.inc(500);
-    metrics.peer_request.get_hits.inc(400);
-    metrics.peer_request.get_misses.inc(80);
-    metrics.peer_request.get_failures.inc(20);
-    metrics.peer_request.get_bytes.inc(50 * 1024 * 1024);  // 50 MB
+    metrics.peer_request_metrics.pin_key.requests.inc(500);
+    metrics.peer_request_metrics.pin_key.hits.inc(400);
 
-    // Test serialize includes both
     std::string serialized;
     metrics.serialize(serialized);
 
-    // Verify both local and peer metrics are present
     EXPECT_TRUE(serialized.find("mooncake_p2p_local_get_requests_total 1000") !=
                 std::string::npos);
-    EXPECT_TRUE(serialized.find("mooncake_p2p_peer_get_requests_total 500") !=
+    EXPECT_TRUE(serialized.find("mooncake_p2p_peer_pin_key_requests_total 500") !=
                 std::string::npos);
     EXPECT_TRUE(serialized.find("mooncake_p2p_local_get_hits_total 900") !=
                 std::string::npos);
-    EXPECT_TRUE(serialized.find("mooncake_p2p_peer_get_hits_total 400") !=
+    EXPECT_TRUE(serialized.find("mooncake_p2p_peer_pin_key_hits_total 400") !=
                 std::string::npos);
 
-    // Test summary_metrics includes both
     std::string summary = metrics.summary_metrics();
     EXPECT_TRUE(summary.find("P2P Local Request Metrics") != std::string::npos);
     EXPECT_TRUE(summary.find("P2P Peer Request Metrics") != std::string::npos);

--- a/mooncake-store/tests/p2p_client_http_endpoints_test.cpp
+++ b/mooncake-store/tests/p2p_client_http_endpoints_test.cpp
@@ -11,7 +11,6 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
-
 #include <csignal>
 #include <cstdint>
 #include <memory>


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

Refactors P2P client metrics into local and peer layers for forward transfer observability.

Peer side (ClientRpcService)

- Replaces aggregated peer_request (put_* / get_*) with per-RPC PeerRequestMetrics for 7 handlers: read_remote_data, write_remote_data, prewrite, write_commit, write_revoke, pin_key, unpin_key.
- Each handler records requests, failures, and success/failure latency.
- Read-semantics RPCs (read_remote_data, pin_key) also record hits / misses for OBJECT_NOT_FOUND.
- Write-semantics RPCs do not use hits/misses; failures are counted as failures only (aligned with local put, no bytes).

Local side (P2PClientService)

- BatchPut / BatchGet continue to use local_request.put_* / get_*.
- Adds outgoing rollback RPC metrics: write_revoke_* and unpin_key_* (requests, failures, latency), instrumented when TE transfer fails and cleanup RPCs are issued (AsyncWriteRevoke on forward write, AsyncUnPinKey on forward read).

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

- Updated client_metrics_test.cpp — serialization, Prometheus output, and summary for local/peer/rollback metrics.
- Updated client_http_metrics_test.cpp — /metrics and /metrics/summary HTTP endpoints for peer per-RPC and local rollback counters.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
