### PR TITLE
[TE] Expand config env-var test coverage

### DIFF
--- a/mooncake-transfer-engine/tests/config_test.cpp
+++ b/mooncake-transfer-engine/tests/config_test.cpp
@@ -21,6 +21,8 @@
 namespace mooncake {
 namespace {
 
+// --- MC_PKEY_INDEX (stoi with try-catch, range 0-65535) ---
+
 class PkeyIndexEnvTest : public ::testing::Test {
    protected:
     void TearDown() override {
@@ -156,6 +158,254 @@ TEST_F(PkeyIndexEnvTest, IbSlNonNumericKeepsDefault) {
     config.ib_service_level = 9;
     loadGlobalConfig(config);
     EXPECT_EQ(config.ib_service_level, 9);
+}
+
+// --- MC_NUM_CQ_PER_CTX (atoi, range 1-255) ---
+
+class NumCqEnvTest : public ::testing::Test {
+   protected:
+    void TearDown() override { ::unsetenv("MC_NUM_CQ_PER_CTX"); }
+};
+
+TEST_F(NumCqEnvTest, DefaultIsOneWhenUnset) {
+    ::unsetenv("MC_NUM_CQ_PER_CTX");
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.num_cq_per_ctx, 1u);
+}
+
+TEST_F(NumCqEnvTest, ValidOverride) {
+    ASSERT_EQ(::setenv("MC_NUM_CQ_PER_CTX", "4", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.num_cq_per_ctx, 4u);
+}
+
+TEST_F(NumCqEnvTest, ZeroIsRejected) {
+    ASSERT_EQ(::setenv("MC_NUM_CQ_PER_CTX", "0", 1), 0);
+    GlobalConfig config;
+    config.num_cq_per_ctx = 1;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.num_cq_per_ctx, 1u);
+}
+
+TEST_F(NumCqEnvTest, OverMaxIsRejected) {
+    ASSERT_EQ(::setenv("MC_NUM_CQ_PER_CTX", "256", 1), 0);
+    GlobalConfig config;
+    config.num_cq_per_ctx = 1;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.num_cq_per_ctx, 1u);
+}
+
+TEST_F(NumCqEnvTest, AlsoSetsJfcAndJfce) {
+    ASSERT_EQ(::setenv("MC_NUM_CQ_PER_CTX", "8", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.num_jfc_per_ctx, 8u);
+    EXPECT_EQ(config.num_jfce_per_ctx, 8u);
+}
+
+// --- MC_SLICE_SIZE (atoi to size_t, val > 0) ---
+
+class SliceSizeEnvTest : public ::testing::Test {
+   protected:
+    void TearDown() override { ::unsetenv("MC_SLICE_SIZE"); }
+};
+
+TEST_F(SliceSizeEnvTest, DefaultIs65536) {
+    ::unsetenv("MC_SLICE_SIZE");
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.slice_size, 65536u);
+}
+
+TEST_F(SliceSizeEnvTest, ValidOverride) {
+    ASSERT_EQ(::setenv("MC_SLICE_SIZE", "131072", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.slice_size, 131072u);
+}
+
+TEST_F(SliceSizeEnvTest, ZeroIsRejected) {
+    ASSERT_EQ(::setenv("MC_SLICE_SIZE", "0", 1), 0);
+    GlobalConfig config;
+    config.slice_size = 65536;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.slice_size, 65536u);
+}
+
+// --- MC_LOG_LEVEL (string match) ---
+
+class LogLevelEnvTest : public ::testing::Test {
+   protected:
+    void TearDown() override { ::unsetenv("MC_LOG_LEVEL"); }
+};
+
+TEST_F(LogLevelEnvTest, InfoLevel) {
+    ASSERT_EQ(::setenv("MC_LOG_LEVEL", "INFO", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.log_level, google::INFO);
+    EXPECT_FALSE(config.trace);
+}
+
+TEST_F(LogLevelEnvTest, WarningLevel) {
+    ASSERT_EQ(::setenv("MC_LOG_LEVEL", "WARNING", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.log_level, google::WARNING);
+}
+
+TEST_F(LogLevelEnvTest, ErrorLevel) {
+    ASSERT_EQ(::setenv("MC_LOG_LEVEL", "ERROR", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.log_level, google::ERROR);
+}
+
+TEST_F(LogLevelEnvTest, TraceEnablesTrace) {
+    ASSERT_EQ(::setenv("MC_LOG_LEVEL", "TRACE", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.log_level, google::INFO);
+    EXPECT_TRUE(config.trace);
+}
+
+// --- MC_DISABLE_METACACHE (presence check) ---
+
+class MetacacheEnvTest : public ::testing::Test {
+   protected:
+    void TearDown() override { ::unsetenv("MC_DISABLE_METACACHE"); }
+};
+
+TEST_F(MetacacheEnvTest, DefaultEnabled) {
+    ::unsetenv("MC_DISABLE_METACACHE");
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_TRUE(config.metacache);
+}
+
+TEST_F(MetacacheEnvTest, DisabledWhenSet) {
+    ASSERT_EQ(::setenv("MC_DISABLE_METACACHE", "1", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_FALSE(config.metacache);
+}
+
+// --- MC_IB_TC (stoi with try-catch, range 0-255) ---
+
+class IbTrafficClassEnvTest : public ::testing::Test {
+   protected:
+    void TearDown() override { ::unsetenv("MC_IB_TC"); }
+};
+
+TEST_F(IbTrafficClassEnvTest, DefaultIsNegativeOne) {
+    ::unsetenv("MC_IB_TC");
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.ib_traffic_class, -1);
+}
+
+TEST_F(IbTrafficClassEnvTest, ValidOverride) {
+    ASSERT_EQ(::setenv("MC_IB_TC", "106", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.ib_traffic_class, 106);
+}
+
+TEST_F(IbTrafficClassEnvTest, ZeroIsValid) {
+    ASSERT_EQ(::setenv("MC_IB_TC", "0", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.ib_traffic_class, 0);
+}
+
+TEST_F(IbTrafficClassEnvTest, OverMaxIsRejected) {
+    ASSERT_EQ(::setenv("MC_IB_TC", "256", 1), 0);
+    GlobalConfig config;
+    config.ib_traffic_class = -1;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.ib_traffic_class, -1);
+}
+
+TEST_F(IbTrafficClassEnvTest, NonNumericKeepsDefault) {
+    ASSERT_EQ(::setenv("MC_IB_TC", "xyz", 1), 0);
+    GlobalConfig config;
+    config.ib_traffic_class = -1;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.ib_traffic_class, -1);
+}
+
+// --- MC_ENDPOINT_STORE_TYPE (string enum) ---
+
+class EndpointStoreTypeEnvTest : public ::testing::Test {
+   protected:
+    void TearDown() override { ::unsetenv("MC_ENDPOINT_STORE_TYPE"); }
+};
+
+TEST_F(EndpointStoreTypeEnvTest, DefaultIsSieve) {
+    ::unsetenv("MC_ENDPOINT_STORE_TYPE");
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.endpoint_store_type, EndpointStoreType::SIEVE);
+}
+
+TEST_F(EndpointStoreTypeEnvTest, FifoOverride) {
+    ASSERT_EQ(::setenv("MC_ENDPOINT_STORE_TYPE", "FIFO", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.endpoint_store_type, EndpointStoreType::FIFO);
+}
+
+TEST_F(EndpointStoreTypeEnvTest, InvalidIsRejected) {
+    ASSERT_EQ(::setenv("MC_ENDPOINT_STORE_TYPE", "LRU", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.endpoint_store_type, EndpointStoreType::SIEVE);
+}
+
+// --- ValidatePortRange (pure function) ---
+
+TEST(ValidatePortRangeTest, ValidRangePassesThrough) {
+    auto [min_p, max_p] = ValidatePortRange(15000, 17000, 15000, 17000);
+    EXPECT_EQ(min_p, 15000);
+    EXPECT_EQ(max_p, 17000);
+}
+
+TEST(ValidatePortRangeTest, CustomValidRange) {
+    auto [min_p, max_p] = ValidatePortRange(2000, 3000, 15000, 17000);
+    EXPECT_EQ(min_p, 2000);
+    EXPECT_EQ(max_p, 3000);
+}
+
+TEST(ValidatePortRangeTest, MinGreaterThanMaxFallsBack) {
+    auto [min_p, max_p] = ValidatePortRange(5000, 4000, 15000, 17000);
+    EXPECT_EQ(min_p, 15000);
+    EXPECT_EQ(max_p, 17000);
+}
+
+TEST(ValidatePortRangeTest, WellKnownPortRejected) {
+    auto [min_p, max_p] = ValidatePortRange(80, 443, 15000, 17000);
+    EXPECT_EQ(min_p, 15000);
+    EXPECT_EQ(max_p, 17000);
+}
+
+TEST(ValidatePortRangeTest, EphemeralPortRejected) {
+    auto [min_p, max_p] = ValidatePortRange(32768, 40000, 15000, 17000);
+    EXPECT_EQ(min_p, 15000);
+    EXPECT_EQ(max_p, 17000);
+}
+
+TEST(ValidatePortRangeTest, BoundaryJustAboveEphemeral) {
+    auto [min_p, max_p] = ValidatePortRange(61000, 65000, 15000, 17000);
+    EXPECT_EQ(min_p, 61000);
+    EXPECT_EQ(max_p, 65000);
+}
+
+TEST(ValidatePortRangeTest, MaxPort65535IsValid) {
+    auto [min_p, max_p] = ValidatePortRange(61000, 65535, 15000, 17000);
+    EXPECT_EQ(min_p, 61000);
+    EXPECT_EQ(max_p, 65535);
 }
 
 }  // namespace

--- a/mooncake-transfer-engine/tests/config_test.cpp
+++ b/mooncake-transfer-engine/tests/config_test.cpp
@@ -234,6 +234,16 @@ TEST_F(SliceSizeEnvTest, ZeroIsRejected) {
     EXPECT_EQ(config.slice_size, 99999u);
 }
 
+TEST_F(SliceSizeEnvTest, NegativeWrapsToLargeValue) {
+    ASSERT_EQ(::setenv("MC_SLICE_SIZE", "-100", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    // atoi("-100") returns -100, cast to size_t wraps to a large value.
+    // val > 0 passes, so config.slice_size gets the wrapped value.
+    // This documents existing (buggy) behavior.
+    EXPECT_NE(config.slice_size, 65536u);
+}
+
 // --- MC_LOG_LEVEL (string match) ---
 
 class LogLevelEnvTest : public ::testing::Test {
@@ -269,6 +279,14 @@ TEST_F(LogLevelEnvTest, TraceEnablesTrace) {
     loadGlobalConfig(config);
     EXPECT_EQ(config.log_level, google::INFO);
     EXPECT_TRUE(config.trace);
+}
+
+TEST_F(LogLevelEnvTest, InvalidLevelKeepsDefault) {
+    ASSERT_EQ(::setenv("MC_LOG_LEVEL", "INVALID", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.log_level, google::INFO);
+    EXPECT_FALSE(config.trace);
 }
 
 // --- MC_DISABLE_METACACHE (presence check) ---
@@ -360,8 +378,9 @@ TEST_F(EndpointStoreTypeEnvTest, FifoOverride) {
 TEST_F(EndpointStoreTypeEnvTest, InvalidIsRejected) {
     ASSERT_EQ(::setenv("MC_ENDPOINT_STORE_TYPE", "LRU", 1), 0);
     GlobalConfig config;
+    config.endpoint_store_type = EndpointStoreType::FIFO;
     loadGlobalConfig(config);
-    EXPECT_EQ(config.endpoint_store_type, EndpointStoreType::SIEVE);
+    EXPECT_EQ(config.endpoint_store_type, EndpointStoreType::FIFO);
 }
 
 // --- ValidatePortRange (pure function) ---

--- a/mooncake-transfer-engine/tests/config_test.cpp
+++ b/mooncake-transfer-engine/tests/config_test.cpp
@@ -184,17 +184,17 @@ TEST_F(NumCqEnvTest, ValidOverride) {
 TEST_F(NumCqEnvTest, ZeroIsRejected) {
     ASSERT_EQ(::setenv("MC_NUM_CQ_PER_CTX", "0", 1), 0);
     GlobalConfig config;
-    config.num_cq_per_ctx = 1;
+    config.num_cq_per_ctx = 42;
     loadGlobalConfig(config);
-    EXPECT_EQ(config.num_cq_per_ctx, 1u);
+    EXPECT_EQ(config.num_cq_per_ctx, 42u);
 }
 
 TEST_F(NumCqEnvTest, OverMaxIsRejected) {
     ASSERT_EQ(::setenv("MC_NUM_CQ_PER_CTX", "256", 1), 0);
     GlobalConfig config;
-    config.num_cq_per_ctx = 1;
+    config.num_cq_per_ctx = 42;
     loadGlobalConfig(config);
-    EXPECT_EQ(config.num_cq_per_ctx, 1u);
+    EXPECT_EQ(config.num_cq_per_ctx, 42u);
 }
 
 TEST_F(NumCqEnvTest, AlsoSetsJfcAndJfce) {
@@ -229,9 +229,9 @@ TEST_F(SliceSizeEnvTest, ValidOverride) {
 TEST_F(SliceSizeEnvTest, ZeroIsRejected) {
     ASSERT_EQ(::setenv("MC_SLICE_SIZE", "0", 1), 0);
     GlobalConfig config;
-    config.slice_size = 65536;
+    config.slice_size = 99999;
     loadGlobalConfig(config);
-    EXPECT_EQ(config.slice_size, 65536u);
+    EXPECT_EQ(config.slice_size, 99999u);
 }
 
 // --- MC_LOG_LEVEL (string match) ---
@@ -406,6 +406,66 @@ TEST(ValidatePortRangeTest, MaxPort65535IsValid) {
     auto [min_p, max_p] = ValidatePortRange(61000, 65535, 15000, 17000);
     EXPECT_EQ(min_p, 61000);
     EXPECT_EQ(max_p, 65535);
+}
+
+TEST(ValidatePortRangeTest, FirstValidPort1024) {
+    auto [min_p, max_p] = ValidatePortRange(1024, 2000, 15000, 17000);
+    EXPECT_EQ(min_p, 1024);
+    EXPECT_EQ(max_p, 2000);
+}
+
+TEST(ValidatePortRangeTest, LastBeforeEphemeral32767) {
+    auto [min_p, max_p] = ValidatePortRange(1024, 32767, 15000, 17000);
+    EXPECT_EQ(min_p, 1024);
+    EXPECT_EQ(max_p, 32767);
+}
+
+TEST(ValidatePortRangeTest, AboveMaxRejected) {
+    auto [min_p, max_p] = ValidatePortRange(61000, 65536, 15000, 17000);
+    EXPECT_EQ(min_p, 15000);
+    EXPECT_EQ(max_p, 17000);
+}
+
+// --- MC_MTU (valid values only; invalid causes exit()) ---
+
+class MtuEnvTest : public ::testing::Test {
+   protected:
+    void TearDown() override { ::unsetenv("MC_MTU"); }
+};
+
+TEST_F(MtuEnvTest, DefaultIs4096) {
+    ::unsetenv("MC_MTU");
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.mtu_length, IBV_MTU_4096);
+}
+
+TEST_F(MtuEnvTest, Mtu512) {
+    ASSERT_EQ(::setenv("MC_MTU", "512", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.mtu_length, IBV_MTU_512);
+}
+
+TEST_F(MtuEnvTest, Mtu1024) {
+    ASSERT_EQ(::setenv("MC_MTU", "1024", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.mtu_length, IBV_MTU_1024);
+}
+
+TEST_F(MtuEnvTest, Mtu2048) {
+    ASSERT_EQ(::setenv("MC_MTU", "2048", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.mtu_length, IBV_MTU_2048);
+}
+
+TEST_F(MtuEnvTest, Mtu4096) {
+    ASSERT_EQ(::setenv("MC_MTU", "4096", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.mtu_length, IBV_MTU_4096);
 }
 
 }  // namespace

--- a/mooncake-transfer-engine/tests/config_test.cpp
+++ b/mooncake-transfer-engine/tests/config_test.cpp
@@ -527,17 +527,17 @@ TEST_F(NumCqEnvTest, ValidOverride) {
 TEST_F(NumCqEnvTest, ZeroIsRejected) {
     ASSERT_EQ(::setenv("MC_NUM_CQ_PER_CTX", "0", 1), 0);
     GlobalConfig config;
-    config.num_cq_per_ctx = 1;
+    config.num_cq_per_ctx = 42;
     loadGlobalConfig(config);
-    EXPECT_EQ(config.num_cq_per_ctx, 1u);
+    EXPECT_EQ(config.num_cq_per_ctx, 42u);
 }
 
 TEST_F(NumCqEnvTest, OverMaxIsRejected) {
     ASSERT_EQ(::setenv("MC_NUM_CQ_PER_CTX", "256", 1), 0);
     GlobalConfig config;
-    config.num_cq_per_ctx = 1;
+    config.num_cq_per_ctx = 42;
     loadGlobalConfig(config);
-    EXPECT_EQ(config.num_cq_per_ctx, 1u);
+    EXPECT_EQ(config.num_cq_per_ctx, 42u);
 }
 
 TEST_F(NumCqEnvTest, AlsoSetsJfcAndJfce) {
@@ -572,9 +572,9 @@ TEST_F(SliceSizeEnvTest, ValidOverride) {
 TEST_F(SliceSizeEnvTest, ZeroIsRejected) {
     ASSERT_EQ(::setenv("MC_SLICE_SIZE", "0", 1), 0);
     GlobalConfig config;
-    config.slice_size = 65536;
+    config.slice_size = 99999;
     loadGlobalConfig(config);
-    EXPECT_EQ(config.slice_size, 65536u);
+    EXPECT_EQ(config.slice_size, 99999u);
 }
 
 // --- MC_LOG_LEVEL (string match) ---
@@ -749,6 +749,66 @@ TEST(ValidatePortRangeTest, MaxPort65535IsValid) {
     auto [min_p, max_p] = ValidatePortRange(61000, 65535, 15000, 17000);
     EXPECT_EQ(min_p, 61000);
     EXPECT_EQ(max_p, 65535);
+}
+
+TEST(ValidatePortRangeTest, FirstValidPort1024) {
+    auto [min_p, max_p] = ValidatePortRange(1024, 2000, 15000, 17000);
+    EXPECT_EQ(min_p, 1024);
+    EXPECT_EQ(max_p, 2000);
+}
+
+TEST(ValidatePortRangeTest, LastBeforeEphemeral32767) {
+    auto [min_p, max_p] = ValidatePortRange(1024, 32767, 15000, 17000);
+    EXPECT_EQ(min_p, 1024);
+    EXPECT_EQ(max_p, 32767);
+}
+
+TEST(ValidatePortRangeTest, AboveMaxRejected) {
+    auto [min_p, max_p] = ValidatePortRange(61000, 65536, 15000, 17000);
+    EXPECT_EQ(min_p, 15000);
+    EXPECT_EQ(max_p, 17000);
+}
+
+// --- MC_MTU (valid values only; invalid causes exit()) ---
+
+class MtuEnvTest : public ::testing::Test {
+   protected:
+    void TearDown() override { ::unsetenv("MC_MTU"); }
+};
+
+TEST_F(MtuEnvTest, DefaultIs4096) {
+    ::unsetenv("MC_MTU");
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.mtu_length, IBV_MTU_4096);
+}
+
+TEST_F(MtuEnvTest, Mtu512) {
+    ASSERT_EQ(::setenv("MC_MTU", "512", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.mtu_length, IBV_MTU_512);
+}
+
+TEST_F(MtuEnvTest, Mtu1024) {
+    ASSERT_EQ(::setenv("MC_MTU", "1024", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.mtu_length, IBV_MTU_1024);
+}
+
+TEST_F(MtuEnvTest, Mtu2048) {
+    ASSERT_EQ(::setenv("MC_MTU", "2048", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.mtu_length, IBV_MTU_2048);
+}
+
+TEST_F(MtuEnvTest, Mtu4096) {
+    ASSERT_EQ(::setenv("MC_MTU", "4096", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.mtu_length, IBV_MTU_4096);
 }
 
 }  // namespace

--- a/mooncake-transfer-engine/tests/config_test.cpp
+++ b/mooncake-transfer-engine/tests/config_test.cpp
@@ -788,7 +788,7 @@ TEST(ValidatePortRangeTest, AboveMaxRejected) {
     EXPECT_EQ(max_p, 17000);
 }
 
-// --- MC_MTU (valid values only; invalid causes exit()) ---
+// --- MC_MTU (valid values only; invalid is logged and ignored) ---
 
 class MtuEnvTest : public ::testing::Test {
    protected:
@@ -825,6 +825,13 @@ TEST_F(MtuEnvTest, Mtu2048) {
 
 TEST_F(MtuEnvTest, Mtu4096) {
     ASSERT_EQ(::setenv("MC_MTU", "4096", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.mtu_length, IBV_MTU_4096);
+}
+
+TEST_F(MtuEnvTest, InvalidIsIgnored) {
+    ASSERT_EQ(::setenv("MC_MTU", "1500", 1), 0);
     GlobalConfig config;
     loadGlobalConfig(config);
     EXPECT_EQ(config.mtu_length, IBV_MTU_4096);

--- a/mooncake-transfer-engine/tests/config_test.cpp
+++ b/mooncake-transfer-engine/tests/config_test.cpp
@@ -577,6 +577,16 @@ TEST_F(SliceSizeEnvTest, ZeroIsRejected) {
     EXPECT_EQ(config.slice_size, 99999u);
 }
 
+TEST_F(SliceSizeEnvTest, NegativeWrapsToLargeValue) {
+    ASSERT_EQ(::setenv("MC_SLICE_SIZE", "-100", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    // atoi("-100") returns -100, cast to size_t wraps to a large value.
+    // val > 0 passes, so config.slice_size gets the wrapped value.
+    // This documents existing (buggy) behavior.
+    EXPECT_NE(config.slice_size, 65536u);
+}
+
 // --- MC_LOG_LEVEL (string match) ---
 
 class LogLevelEnvTest : public ::testing::Test {
@@ -612,6 +622,14 @@ TEST_F(LogLevelEnvTest, TraceEnablesTrace) {
     loadGlobalConfig(config);
     EXPECT_EQ(config.log_level, google::INFO);
     EXPECT_TRUE(config.trace);
+}
+
+TEST_F(LogLevelEnvTest, InvalidLevelKeepsDefault) {
+    ASSERT_EQ(::setenv("MC_LOG_LEVEL", "INVALID", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.log_level, google::INFO);
+    EXPECT_FALSE(config.trace);
 }
 
 // --- MC_DISABLE_METACACHE (presence check) ---
@@ -703,8 +721,9 @@ TEST_F(EndpointStoreTypeEnvTest, FifoOverride) {
 TEST_F(EndpointStoreTypeEnvTest, InvalidIsRejected) {
     ASSERT_EQ(::setenv("MC_ENDPOINT_STORE_TYPE", "LRU", 1), 0);
     GlobalConfig config;
+    config.endpoint_store_type = EndpointStoreType::FIFO;
     loadGlobalConfig(config);
-    EXPECT_EQ(config.endpoint_store_type, EndpointStoreType::SIEVE);
+    EXPECT_EQ(config.endpoint_store_type, EndpointStoreType::FIFO);
 }
 
 // --- ValidatePortRange (pure function) ---

--- a/mooncake-transfer-engine/tests/config_test.cpp
+++ b/mooncake-transfer-engine/tests/config_test.cpp
@@ -21,6 +21,8 @@
 namespace mooncake {
 namespace {
 
+// --- MC_PKEY_INDEX (stoi with try-catch, range 0-65535) ---
+
 class PkeyIndexEnvTest : public ::testing::Test {
    protected:
     void TearDown() override {
@@ -499,6 +501,254 @@ TEST_F(MaxWrEnvTest, OutOfRangeDoesNotSetFlag) {
     loadGlobalConfig(config);
     EXPECT_FALSE(config.max_wr_from_env);
     EXPECT_EQ(config.max_wr, 256u);
+}
+
+// --- MC_NUM_CQ_PER_CTX (atoi, range 1-255) ---
+
+class NumCqEnvTest : public ::testing::Test {
+   protected:
+    void TearDown() override { ::unsetenv("MC_NUM_CQ_PER_CTX"); }
+};
+
+TEST_F(NumCqEnvTest, DefaultIsOneWhenUnset) {
+    ::unsetenv("MC_NUM_CQ_PER_CTX");
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.num_cq_per_ctx, 1u);
+}
+
+TEST_F(NumCqEnvTest, ValidOverride) {
+    ASSERT_EQ(::setenv("MC_NUM_CQ_PER_CTX", "4", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.num_cq_per_ctx, 4u);
+}
+
+TEST_F(NumCqEnvTest, ZeroIsRejected) {
+    ASSERT_EQ(::setenv("MC_NUM_CQ_PER_CTX", "0", 1), 0);
+    GlobalConfig config;
+    config.num_cq_per_ctx = 1;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.num_cq_per_ctx, 1u);
+}
+
+TEST_F(NumCqEnvTest, OverMaxIsRejected) {
+    ASSERT_EQ(::setenv("MC_NUM_CQ_PER_CTX", "256", 1), 0);
+    GlobalConfig config;
+    config.num_cq_per_ctx = 1;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.num_cq_per_ctx, 1u);
+}
+
+TEST_F(NumCqEnvTest, AlsoSetsJfcAndJfce) {
+    ASSERT_EQ(::setenv("MC_NUM_CQ_PER_CTX", "8", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.num_jfc_per_ctx, 8u);
+    EXPECT_EQ(config.num_jfce_per_ctx, 8u);
+}
+
+// --- MC_SLICE_SIZE (atoi to size_t, val > 0) ---
+
+class SliceSizeEnvTest : public ::testing::Test {
+   protected:
+    void TearDown() override { ::unsetenv("MC_SLICE_SIZE"); }
+};
+
+TEST_F(SliceSizeEnvTest, DefaultIs65536) {
+    ::unsetenv("MC_SLICE_SIZE");
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.slice_size, 65536u);
+}
+
+TEST_F(SliceSizeEnvTest, ValidOverride) {
+    ASSERT_EQ(::setenv("MC_SLICE_SIZE", "131072", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.slice_size, 131072u);
+}
+
+TEST_F(SliceSizeEnvTest, ZeroIsRejected) {
+    ASSERT_EQ(::setenv("MC_SLICE_SIZE", "0", 1), 0);
+    GlobalConfig config;
+    config.slice_size = 65536;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.slice_size, 65536u);
+}
+
+// --- MC_LOG_LEVEL (string match) ---
+
+class LogLevelEnvTest : public ::testing::Test {
+   protected:
+    void TearDown() override { ::unsetenv("MC_LOG_LEVEL"); }
+};
+
+TEST_F(LogLevelEnvTest, InfoLevel) {
+    ASSERT_EQ(::setenv("MC_LOG_LEVEL", "INFO", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.log_level, google::INFO);
+    EXPECT_FALSE(config.trace);
+}
+
+TEST_F(LogLevelEnvTest, WarningLevel) {
+    ASSERT_EQ(::setenv("MC_LOG_LEVEL", "WARNING", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.log_level, google::WARNING);
+}
+
+TEST_F(LogLevelEnvTest, ErrorLevel) {
+    ASSERT_EQ(::setenv("MC_LOG_LEVEL", "ERROR", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.log_level, google::ERROR);
+}
+
+TEST_F(LogLevelEnvTest, TraceEnablesTrace) {
+    ASSERT_EQ(::setenv("MC_LOG_LEVEL", "TRACE", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.log_level, google::INFO);
+    EXPECT_TRUE(config.trace);
+}
+
+// --- MC_DISABLE_METACACHE (presence check) ---
+
+class MetacacheEnvTest : public ::testing::Test {
+   protected:
+    void TearDown() override { ::unsetenv("MC_DISABLE_METACACHE"); }
+};
+
+TEST_F(MetacacheEnvTest, DefaultEnabled) {
+    ::unsetenv("MC_DISABLE_METACACHE");
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_TRUE(config.metacache);
+}
+
+TEST_F(MetacacheEnvTest, DisabledWhenSet) {
+    ASSERT_EQ(::setenv("MC_DISABLE_METACACHE", "1", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_FALSE(config.metacache);
+}
+
+// --- MC_IB_TC (stoi with try-catch, range 0-255) ---
+
+class IbTrafficClassEnvTest : public ::testing::Test {
+   protected:
+    void TearDown() override { ::unsetenv("MC_IB_TC"); }
+};
+
+TEST_F(IbTrafficClassEnvTest, DefaultIsNegativeOne) {
+    ::unsetenv("MC_IB_TC");
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.ib_traffic_class, -1);
+}
+
+TEST_F(IbTrafficClassEnvTest, ValidOverride) {
+    ASSERT_EQ(::setenv("MC_IB_TC", "106", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.ib_traffic_class, 106);
+}
+
+TEST_F(IbTrafficClassEnvTest, ZeroIsValid) {
+    ASSERT_EQ(::setenv("MC_IB_TC", "0", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.ib_traffic_class, 0);
+}
+
+TEST_F(IbTrafficClassEnvTest, OverMaxIsRejected) {
+    ASSERT_EQ(::setenv("MC_IB_TC", "256", 1), 0);
+    GlobalConfig config;
+    config.ib_traffic_class = -1;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.ib_traffic_class, -1);
+}
+
+TEST_F(IbTrafficClassEnvTest, NonNumericKeepsDefault) {
+    ASSERT_EQ(::setenv("MC_IB_TC", "xyz", 1), 0);
+    GlobalConfig config;
+    config.ib_traffic_class = -1;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.ib_traffic_class, -1);
+}
+
+// --- MC_ENDPOINT_STORE_TYPE (string enum) ---
+
+class EndpointStoreTypeEnvTest : public ::testing::Test {
+   protected:
+    void TearDown() override { ::unsetenv("MC_ENDPOINT_STORE_TYPE"); }
+};
+
+TEST_F(EndpointStoreTypeEnvTest, DefaultIsSieve) {
+    ::unsetenv("MC_ENDPOINT_STORE_TYPE");
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.endpoint_store_type, EndpointStoreType::SIEVE);
+}
+
+TEST_F(EndpointStoreTypeEnvTest, FifoOverride) {
+    ASSERT_EQ(::setenv("MC_ENDPOINT_STORE_TYPE", "FIFO", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.endpoint_store_type, EndpointStoreType::FIFO);
+}
+
+TEST_F(EndpointStoreTypeEnvTest, InvalidIsRejected) {
+    ASSERT_EQ(::setenv("MC_ENDPOINT_STORE_TYPE", "LRU", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.endpoint_store_type, EndpointStoreType::SIEVE);
+}
+
+// --- ValidatePortRange (pure function) ---
+
+TEST(ValidatePortRangeTest, ValidRangePassesThrough) {
+    auto [min_p, max_p] = ValidatePortRange(15000, 17000, 15000, 17000);
+    EXPECT_EQ(min_p, 15000);
+    EXPECT_EQ(max_p, 17000);
+}
+
+TEST(ValidatePortRangeTest, CustomValidRange) {
+    auto [min_p, max_p] = ValidatePortRange(2000, 3000, 15000, 17000);
+    EXPECT_EQ(min_p, 2000);
+    EXPECT_EQ(max_p, 3000);
+}
+
+TEST(ValidatePortRangeTest, MinGreaterThanMaxFallsBack) {
+    auto [min_p, max_p] = ValidatePortRange(5000, 4000, 15000, 17000);
+    EXPECT_EQ(min_p, 15000);
+    EXPECT_EQ(max_p, 17000);
+}
+
+TEST(ValidatePortRangeTest, WellKnownPortRejected) {
+    auto [min_p, max_p] = ValidatePortRange(80, 443, 15000, 17000);
+    EXPECT_EQ(min_p, 15000);
+    EXPECT_EQ(max_p, 17000);
+}
+
+TEST(ValidatePortRangeTest, EphemeralPortRejected) {
+    auto [min_p, max_p] = ValidatePortRange(32768, 40000, 15000, 17000);
+    EXPECT_EQ(min_p, 15000);
+    EXPECT_EQ(max_p, 17000);
+}
+
+TEST(ValidatePortRangeTest, BoundaryJustAboveEphemeral) {
+    auto [min_p, max_p] = ValidatePortRange(61000, 65000, 15000, 17000);
+    EXPECT_EQ(min_p, 61000);
+    EXPECT_EQ(max_p, 65000);
+}
+
+TEST(ValidatePortRangeTest, MaxPort65535IsValid) {
+    auto [min_p, max_p] = ValidatePortRange(61000, 65535, 15000, 17000);
+    EXPECT_EQ(min_p, 61000);
+    EXPECT_EQ(max_p, 65535);
 }
 
 }  // namespace


### PR DESCRIPTION
## Description

Expand `config_test.cpp` from 7 tests (MC_PKEY_INDEX only) to 30 tests covering 7 additional env-var parsing patterns and the `ValidatePortRange` utility function.

New test fixtures:
- **MC_NUM_CQ_PER_CTX**: range [1,255], verifies JFC/JFCE side-assignment
- **MC_SLICE_SIZE**: atoi to size_t, zero rejection
- **MC_LOG_LEVEL**: string enum (TRACE/INFO/WARNING/ERROR), trace flag
- **MC_DISABLE_METACACHE**: presence-based boolean
- **MC_IB_TC**: stoi with try-catch, range [0,255], non-numeric rejection
- **MC_ENDPOINT_STORE_TYPE**: string enum (FIFO/SIEVE)
- **ValidatePortRange**: 7 cases covering valid ranges, min>max, well-known ports (0-1023), ephemeral ports (32768-60999), boundary values

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Other (test coverage expansion)

## How Has This Been Tested?

- Tests follow the existing `PkeyIndexEnvTest` pattern (setenv/unsetenv in fixture)
- Each assertion verified against config.cpp source code
- CI will run via `ctest` in the existing test suite

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have added tests to prove my changes are effective.

🤖 Generated with [Claude Code](https://claude.com/claude-code)