### PR TITLE
[CI/Build] Add AI issue triage with keyword-based auto-labeling

### DIFF
--- a/.github/workflows/issue-ai-triage.yml
+++ b/.github/workflows/issue-ai-triage.yml
@@ -1,0 +1,77 @@
+name: AI Issue Triage
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  triage:
+    if: github.repository == 'kvcache-ai/Mooncake'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto-label by keywords
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const title = issue.title.toLowerCase();
+            const body = (issue.body || '').toLowerCase();
+            const text = title + ' ' + body;
+
+            const labelMap = {
+              'transfer engine': 'Transfer Engine',
+              'transferengine': 'Transfer Engine',
+              'rdma': 'Transfer Engine',
+              'transport': 'Transfer Engine',
+              'store': 'store',
+              'kvcache': 'store',
+              'hicache': 'store',
+              'expert parallel': 'Mooncake EP',
+              'mooncake-ep': 'Mooncake EP',
+              'moe': 'Mooncake EP',
+              'pytorch backend': 'PyTorch Backend',
+              'mooncake-pg': 'PyTorch Backend',
+              'process group': 'PyTorch Backend',
+              'nccl': 'PyTorch Backend',
+              'pip install': 'Installation',
+              'wheel': 'Installation',
+              'build error': 'Installation',
+              'cmake': 'Installation',
+              'vllm': 'Integration',
+              'sglang': 'Integration',
+              'lmdeploy': 'Integration',
+              'ascend': 'Ascend/NPU',
+              'npu': 'Ascend/NPU',
+              'cann': 'Ascend/NPU',
+            };
+
+            const labelsToAdd = [];
+            for (const [keyword, label] of Object.entries(labelMap)) {
+              if (text.includes(keyword) && !labelsToAdd.includes(label)) {
+                labelsToAdd.push(label);
+              }
+            }
+
+            if (labelsToAdd.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: labelsToAdd,
+              });
+            }
+
+            // Add 'ai-ready' label for well-structured feature requests
+            const isFeatureRequest = issue.labels?.some(l => l.name === 'feature request');
+            const hasDescription = body.length > 200;
+            if (isFeatureRequest && hasDescription) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: ['ai-ready'],
+              });
+            }


### PR DESCRIPTION
## Summary

- Auto-label new issues by module based on keywords in title and body
- Maps keywords to labels: Transfer Engine, store, Mooncake EP, PyTorch Backend, Installation, Integration, Ascend/NPU
- Marks well-structured feature requests (>200 chars body) as `ai-ready` for AI agent pickup
- Complements existing issue-bot.yml (welcome + stale) without overlap

## Test plan

- [ ] Verify workflow triggers only on issue `opened` events
- [ ] Verify keyword-to-label mapping covers all major modules
- [ ] Verify `ai-ready` label is only added for well-described feature requests
- [ ] Verify no conflict with existing `issue-bot.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)