### PR TITLE
[TE] Use MLU address range query for RDMA dmabuf

### DIFF
--- a/mooncake-transfer-engine/include/gpu_vendor/mlu.h
+++ b/mooncake-transfer-engine/include/gpu_vendor/mlu.h
@@ -23,7 +23,6 @@ using CUresult = CNresult;
 #define CU_MEMORYTYPE_HOST CN_MEMORYTYPE_HOST
 #define CU_MEMORYTYPE_DEVICE CN_MEMORYTYPE_DEVICE
 #define CU_POINTER_ATTRIBUTE_MEMORY_TYPE CN_MEM_ATTRIBUTE_TYPE
-#define CU_POINTER_ATTRIBUTE_RANGE_SIZE CN_MEM_ATTRIBUTE_RANGE_SIZE
 
 #define cudaSuccess cnrtSuccess
 #define cudaMemoryTypeUnregistered cnrtMemTypeUnregistered
@@ -158,16 +157,19 @@ static inline CUresult cuPointerGetAttribute(void *data, int attribute,
             }
             return CUDA_SUCCESS;
         }
-        case CU_POINTER_ATTRIBUTE_RANGE_SIZE: {
-            if (attributes.type != cudaMemoryTypeDevice) {
-                return CN_ERROR_INVALID_VALUE;
-            }
-            *static_cast<size_t *>(data) = attributes.size;
-            return CUDA_SUCCESS;
-        }
         default:
             return CN_ERROR_INVALID_VALUE;
     }
+}
+
+static inline CUresult cuMemGetAddressRange(CUdeviceptr *base, size_t *size,
+                                            CUdeviceptr ptr) {
+    cn_uint64_t bytes = 0;
+    auto ret = cnMemGetAddressRange(base, size ? &bytes : nullptr, ptr);
+    if (ret == CN_SUCCESS && size) {
+        *size = static_cast<size_t>(bytes);
+    }
+    return ret;
 }
 
 static inline CUresult cuMemGetHandleForAddressRange(void *handle,

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -392,24 +392,13 @@ int RdmaContext::registerMemoryRegionInternal(void *addr, size_t length,
 #endif
         CUdeviceptr allocBase;
         size_t allocSize;
-#if defined(USE_MLU)
-        allocBase = (CUdeviceptr)addr;
-        result = cuPointerGetAttribute(
-            &allocSize, CU_POINTER_ATTRIBUTE_RANGE_SIZE, (CUdeviceptr)addr);
-#else
         result =
             cuMemGetAddressRange(&allocBase, &allocSize, (CUdeviceptr)addr);
-#endif
         if (result != CUDA_SUCCESS) {
             const char *errStr;
             cuGetErrorString(result, &errStr);
-#if defined(USE_MLU)
-            LOG(ERROR) << "Failed to call cuPointerGetAttribute range size for "
-                       << (uintptr_t)addr << " cuda error=" << errStr;
-#else
             LOG(ERROR) << "Failed to call cuMemGetAddressRange for "
                        << (uintptr_t)addr << " cuda error=" << errStr;
-#endif
 #if defined(USE_CUDA)
             cuDevicePrimaryCtxRelease(cuDev);
 #endif


### PR DESCRIPTION
 ## Description

Fix RDMA-related compatibility issues on MLU and ensure RDMA end-to-end transfer works correctly in the MLU environment.This bugfix has been validated with RDMA end-to-end testing on MLU and is intended to be merged upstream into the community repository.

  ## Module

  - [x] Transfer Engine (`mooncake-transfer-engine`)
  - [ ] Mooncake Store (`mooncake-store`)
  - [ ] Mooncake EP (`mooncake-ep`)
  - [x] Integration (`mooncake-integration`)
  - [ ] P2P Store (`mooncake-p2p-store`)
  - [ ] Python Wheel (`mooncake-wheel`)
  - [ ] PyTorch Backend (`mooncake-pg`)
  - [ ] Mooncake RL (`mooncake-rl`)
  - [ ] CI/CD
  - [ ] Docs
  - [ ] Other

  ## Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor
  - [ ] Breaking change
  - [ ] Documentation update
  - [ ] Other

  ## How Has This Been Tested?

  RDMA end-to-end testing has been completed successfully on MLU.

  The test verified that RDMA transfer can be initialized and executed correctly in the MLU environment.

  ## Checklist

  - [x] I have performed a self-review of my own code.
  - [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
  - [ ] I have updated the documentation.
  - [ ] I have added tests to prove my changes are effective.
