### PR TITLE
[Store] Enable hugepage mmap in allocate_buffer_numa_segments

### DIFF
--- a/mooncake-store/src/utils.cpp
+++ b/mooncake-store/src/utils.cpp
@@ -327,11 +327,16 @@ void *allocate_buffer_numa_segments(size_t total_size,
     size_t region_size = align_up(total_size / n, page_size);
     size_t map_size = region_size * n;
 
-    // reserve contiguous VMA, no physical pages yet
-    void *ptr = mmap(nullptr, map_size, PROT_READ | PROT_WRITE,
-                     MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    // reserve contiguous VMA; use hugepages if page_size indicates so
+    unsigned int flags = MAP_PRIVATE | MAP_ANONYMOUS;
+    if (page_size != getpagesize()) {
+        get_hugepage_size_from_env(&flags);
+    }
+    void *ptr = mmap(nullptr, map_size, PROT_READ | PROT_WRITE, flags, -1, 0);
     if (ptr == MAP_FAILED) {
-        LOG(ERROR) << "mmap failed, size=" << map_size << ", errno=" << errno
+        LOG(ERROR) << "mmap failed (hugepage="
+                   << (page_size >= 2 * 1024 * 1024 ? "yes" : "no")
+                   << "), size=" << map_size << ", errno=" << errno
                    << " (" << strerror(errno) << ")";
         return nullptr;
     }

--- a/mooncake-store/src/utils.cpp
+++ b/mooncake-store/src/utils.cpp
@@ -329,13 +329,17 @@ void *allocate_buffer_numa_segments(size_t total_size,
 
     // reserve contiguous VMA; use hugepages if page_size indicates so
     unsigned int flags = MAP_PRIVATE | MAP_ANONYMOUS;
-    if (page_size != getpagesize()) {
-        get_hugepage_size_from_env(&flags);
+    if (page_size == SZ_2MB) {
+        flags |= MAP_HUGETLB | MAP_HUGE_2MB;
+    } else if (page_size == SZ_1GB) {
+        flags |= MAP_HUGETLB | MAP_HUGE_1GB;
+    } else if (page_size != static_cast<size_t>(getpagesize())) {
+        flags |= MAP_HUGETLB;
     }
     void *ptr = mmap(nullptr, map_size, PROT_READ | PROT_WRITE, flags, -1, 0);
     if (ptr == MAP_FAILED) {
         LOG(ERROR) << "mmap failed (hugepage="
-                   << (page_size >= 2 * 1024 * 1024 ? "yes" : "no")
+                   << ((flags & MAP_HUGETLB) ? "yes" : "no")
                    << "), size=" << map_size << ", errno=" << errno
                    << " (" << strerror(errno) << ")";
         return nullptr;

--- a/mooncake-store/src/utils.cpp
+++ b/mooncake-store/src/utils.cpp
@@ -340,8 +340,8 @@ void *allocate_buffer_numa_segments(size_t total_size,
     if (ptr == MAP_FAILED) {
         LOG(ERROR) << "mmap failed (hugepage="
                    << ((flags & MAP_HUGETLB) ? "yes" : "no")
-                   << "), size=" << map_size << ", errno=" << errno
-                   << " (" << strerror(errno) << ")";
+                   << "), size=" << map_size << ", errno=" << errno << " ("
+                   << strerror(errno) << ")";
         return nullptr;
     }
 


### PR DESCRIPTION
Previously allocate_buffer_numa_segments() always reserved its VMA with plain MAP_PRIVATE | MAP_ANONYMOUS, ignoring the caller-supplied page_size. As a result, even when callers requested a hugepage-sized region (e.g. 2MB/1GB), the kernel would back the mapping with 4K pages, defeating hugepage usage for NUMA-segmented buffers.

This change augments the mmap flags via get_hugepage_size_from_env() when page_size indicates a non-default (hugepage) size, so the mapping is created with the appropriate MAP_HUGETLB / size flags. The mmap failure log is also extended to report whether hugepages were requested, making allocation failures (e.g. insufficient hugepages reserved) easier to diagnose.

No behavior change when page_size == getpagesize().

## Description

<!-- A clear and concise description of the changes. Link to any relevant issues. -->

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

<!-- Please describe the tests you've run to verify your changes. -->
  - Built mooncake-store locally and ran the existing unit tests covering buffer allocation paths.
  - Manually verified with NUMA-segmented allocation:
    - With page_size = getpagesize() (default 4K): behavior unchanged, mapping succeeds as before.
    - With page_size = 2MB and HUGETLB_* env configured: mmap is issued with the hugepage flag, and /proc/<pid>/numa_maps / smaps confirms the VMA is backed by 2MB hugepages and mbind-pinned to the
  requested NUMA node.
    - With hugepages exhausted: mmap fails as expected, and the new log line clearly reports hugepage=yes along with errno=ENOMEM, making the root cause obvious.
  - Confirmed ibv_reg_mr() registration on the resulting buffer still succeeds and pages land on the bound NUMA node.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
