### PR TITLE
[Store](fix) check actual disk space in eviction logic

### DIFF
--- a/mooncake-store/src/storage_backend.cpp
+++ b/mooncake-store/src/storage_backend.cpp
@@ -801,6 +801,28 @@ bool StorageBackend::CheckDiskSpace(size_t required_size) {
     bool has_enough_space = available_space_ >= required_size;
 
     if (has_enough_space) {
+        // Also check actual disk space to handle multiple instances
+        // sharing the same filesystem with independent quotas.
+        namespace fs = std::filesystem;
+        fs::path storage_root = fs::path(root_dir_) / GetActualFsdir();
+        std::error_code ec;
+        auto space_info = fs::space(storage_root, ec);
+        if (!ec) {
+            uint64_t actual_available = space_info.available;
+            constexpr uint64_t kMinFreeSpace = 256 * kMB;
+            if (actual_available < required_size + kMinFreeSpace) {
+                VLOG(1) << "Actual disk space low: available="
+                        << actual_available << ", required=" << required_size
+                        << ". Triggering eviction.";
+                has_enough_space = false;
+            }
+        } else {
+            LOG(WARNING) << "Failed to get disk space info for " << storage_root
+                         << ": " << ec.message();
+        }
+    }
+
+    if (has_enough_space) {
         used_space_ += required_size;
         available_space_ -= required_size;
         VLOG(2) << "Reserved space. New available: " << available_space_
@@ -2191,15 +2213,61 @@ BucketStorageBackend::PendingEviction BucketStorageBackend::PrepareEviction(
 
     SharedMutexLocker lock(&mutex_);
 
-    if (!buckets_.empty() &&
-        total_size_ + required_size > bucket_backend_config_.max_total_size) {
-        LOG(INFO) << "[Evict] triggered: total=" << total_size_ << "/"
-                  << bucket_backend_config_.max_total_size
-                  << " required=" << required_size;
+    // Check actual disk space once before the loop. PrepareEviction only
+    // removes metadata -- files are deleted later in FinalizeEviction -- so
+    // re-checking disk space inside the loop would yield the same result
+    // every iteration and is unnecessary.
+    //
+    // When disk is full, we calculate the space deficit and accumulate
+    // the estimated freed space (data_size + meta_size) per evicted
+    // bucket. Due to block alignment, actual disk usage >= data_size +
+    // meta_size, so this is a safe lower bound -- we will not under-evict.
+    bool initial_disk_full = false;
+    uint64_t deficit = 0;
+    {
+        namespace fs = std::filesystem;
+        std::error_code ec;
+        auto space_info = fs::space(storage_path_, ec);
+        if (!ec) {
+            uint64_t actual_available = space_info.available;
+            constexpr uint64_t kMinFreeSpace = 256 * kMB;
+            uint64_t req_sz =
+                required_size > 0 ? static_cast<uint64_t>(required_size) : 0;
+            initial_disk_full = actual_available < req_sz + kMinFreeSpace;
+            if (initial_disk_full) {
+                deficit = req_sz + kMinFreeSpace - actual_available;
+                LOG(WARNING)
+                    << "[Evict] Actual disk space too low: available="
+                    << actual_available << ", required=" << required_size
+                    << ", deficit=" << deficit
+                    << ". Will evict buckets to free space.";
+            }
+        } else {
+            LOG(WARNING) << "[Evict] Failed to get disk space info for "
+                         << storage_path_ << ": " << ec.message();
+        }
     }
 
-    while (!buckets_.empty() && total_size_ + required_size >
-                                    bucket_backend_config_.max_total_size) {
+    size_t evict_count = 0;
+    constexpr size_t kMaxEvictionBuckets = 1000;
+    uint64_t accumulated_freed_space = 0;
+
+    while (!buckets_.empty() && evict_count < kMaxEvictionBuckets) {
+        bool quota_exceeded =
+            total_size_ + required_size > bucket_backend_config_.max_total_size;
+
+        bool disk_still_full =
+            initial_disk_full && (accumulated_freed_space < deficit);
+
+        if (!quota_exceeded && !disk_still_full) break;
+
+        if (evict_count == 0) {
+            LOG(INFO) << "[Evict] triggered: total=" << total_size_ << "/"
+                      << bucket_backend_config_.max_total_size
+                      << " required=" << required_size
+                      << " disk_full=" << initial_disk_full;
+        }
+
         auto evict_it = SelectEvictionCandidate();
         if (evict_it == buckets_.end()) break;
 
@@ -2224,7 +2292,11 @@ BucketStorageBackend::PendingEviction BucketStorageBackend::PrepareEviction(
         for (const auto& key : evict_meta->keys) {
             result.keys.push_back(key);
         }
+        accumulated_freed_space +=
+            static_cast<uint64_t>(evict_meta->data_size) +
+            static_cast<uint64_t>(evict_meta->meta_size);
         result.buckets.emplace_back(evict_id, std::move(evict_meta));
+        evict_count++;
     }
 
     if (!result.buckets.empty()) {


### PR DESCRIPTION
## Description

Fix disk offload eviction not triggering when multiple `StorageBackend` or `BucketStorageBackend` instances share the same filesystem.

### Problem

Each TP rank in a vLLM worker creates its own mooncake store client, and each client initializes an independent storage backend with its own internal space counter (`used_space_` / `available_space_`). All instances on the same machine write to the same local disk, but their counters are completely isolated from each other.

Example with TP=2, 1 prefill + 1 decode (4 instances total), 130 GB disk, 110 GB quota per instance:

| Instance | Internal `used_space_` | Internal `available_space_` | Thinks |
|----------|------------------------|----------------------------|--------|
| Prefill TP0 | 0 GB | 110 GB | "I have 110 GB" |
| Prefill TP1 | 0 GB | 110 GB | "I have 110 GB" |
| Decode TP0 | 0 GB | 110 GB | "I have 110 GB" |
| Decode TP1 | 0 GB | 110 GB | "I have 110 GB" |
| **Total** | | **440 GB** | **Actual disk: 130 GB** |

Each instance only checks its own counter before writing. No instance knows about the others' writes. The disk fills up at 130 GB, but no single instance's counter reaches the 110 GB quota, so **eviction is never triggered** → `FILE_WRITE_FAIL`.

This affects any deployment where multiple TP ranks share the same offload disk — single-machine and multi-machine alike.

### Root Cause

- `StorageBackend::CheckDiskSpace()` (file-per-key): only checks `available_space_ >= required_size`.
- `BucketStorageBackend::PrepareEviction()` (bucket): only checks `total_size_ + required_size > max_total_size`.

Neither checks actual disk space.

### Fix

Add actual disk space checks (via `std::filesystem::space`) to both backends, in addition to internal quota counters.

**1. `StorageBackend::CheckDiskSpace` (file-per-key)**

After the internal counter check passes, call `std::filesystem::space()` on the storage root. If actual available space < `required_size + 256 MB`, return false to trigger eviction. This integrates cleanly with the existing `EnsureDiskSpace` → `EvictFile` loop: each eviction deletes a file, the next `std::filesystem::space()` call sees the freed space, and the loop converges.

Changed `LOG(WARNING)` to `VLOG(1)` to avoid log spam under high-frequency writes (the check triggers on every write when disk is near the threshold).

**2. `BucketStorageBackend::PrepareEviction` (bucket)**

The bucket backend has a two-phase eviction architecture: `PrepareEviction` removes metadata only, `FinalizeEviction` deletes the actual files. This means disk space checks inside the eviction loop would see unchanged results on every iteration — the freed space only appears after `FinalizeEviction`.

To handle this:
- Call `std::filesystem::space()` once before the loop to compute the space `deficit` (`required_size + kMinFreeSpace - actual_available`).
- Track `accumulated_freed_space` as buckets are evicted (sum of `data_size + meta_size` per bucket). Due to block alignment, actual disk usage >= `data_size + meta_size`, so this is a safe lower bound — we will not under-evict.
- Stop evicting when `accumulated_freed_space >= deficit` (disk space satisfied) or `total_size_ + required_size <= max_total_size` (quota satisfied).
- `kMaxEvictionBuckets = 1000` serves as a safety net against infinite loops.
- Uses `storage_path_` (class member) instead of `file_storage_config_.storage_filepath` for consistency.
- Defensive check: `required_size > 0` before casting to `uint64_t`.

### Style

- Use `std::filesystem::space` instead of platform-specific `statvfs()`, consistent with existing code in `StorageBackend::Init`.
- Use existing `kMB` constant instead of bit-shift magic numbers.
- `CheckDiskSpace`: `VLOG(1)` (high-frequency path, not an error).
- `PrepareEviction`: `LOG(WARNING)` (low-frequency path, once per `BatchOffload`).

### Known Limitation

`EnsureDiskSpace` (file-per-key) evicts one file per iteration and re-checks disk space each time. Under high-frequency small-file writes this results in many syscall cycles. A future optimization could batch-evict multiple files before rechecking. This PR does not address that.

## Module

- [x] Mooncake Store (`mooncake-store`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

- 4 concurrent StorageBackend instances (2 prefill TP + 2 decode TP) writing to a 130 GB disk image.
- **Before fix:** disk fills to 100%, `FILE_WRITE_FAIL` errors, master reports `Eviction: Success/Attempts=0/0`.
- **After fix:** eviction triggers when actual disk space is low, disk usage stabilizes around 256 MB free, no write failures.
- Verified both file-per-key and bucket backends independently.
- ~10-15% performance improvement observed in preliminary experiments.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [ ] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.
