### PR TITLE
[TransferEngine] Bound handshake-port connect() with a timeout

### DIFF
--- a/docs/source/design/transfer-engine/index.md
+++ b/docs/source/design/transfer-engine/index.md
@@ -295,6 +295,7 @@ For advanced users, TransferEngine provides the following advanced runtime optio
 - `MC_LOG_LEVEL` This option can be set as `TRACE`/`INFO`/`WARNING`/`ERROR` (see [glog doc](https://github.com/google/glog/blob/master/docs/logging.md)), and more detailed logs will be output during runtime
 - `MC_DISABLE_METACACHE` Disable local meta cache to prevent transfer failure due to dynamic memory registrations, which may downgrades the performance
 - `MC_HANDSHAKE_LISTEN_BACKLOG` The backlog size of socket listening for handshaking, default value is 128
+- `MC_HANDSHAKE_CONNECT_TIMEOUT` Connect timeout in seconds for outbound handshake-port requests (QP handshake, probe, notify, metadata exchange), default value is 5. Bounds the stall when the peer address is unreachable; without it, a connect to an unroutable address (e.g. a removed node) blocks for the kernel's full TCP SYN retry cycle, which can take minutes
 - `MC_HANDSHAKE_MAX_LENGTH` The maximum handshake message length in bytes for P2P mode. Valid range: 1MB to 128MB. Default value is 1MB (1048576 bytes). Increase this value when using a single RDMA instance with many registered memory buffers (>10,000) to avoid handshake failures. Example: set to 10485760 for 10MB
 - `MC_LOG_DIR` Specify the directory path for log redirection files. If invalid, log to stderr instead.
 - `MC_REDIS_PASSWORD` The password for Redis storage plugin, only takes effect when Redis is specified as the metadata server. If not set, no authentication will be attempted to log in to the Redis.

--- a/mooncake-transfer-engine/include/config.h
+++ b/mooncake-transfer-engine/include/config.h
@@ -52,6 +52,12 @@ struct GlobalConfig {
     int retry_cnt = 9;
     int auto_gid_max_retries = 2;
     int handshake_listen_backlog = 128;
+    // Connect timeout (seconds) for outbound handshake-port RPCs (QP
+    // handshake, probe, notify, metadata exchange). A plain blocking
+    // connect() has no deadline: to an unroutable address (e.g. a
+    // torn-down pod IP) it stalls for the kernel's full SYN-retry cycle,
+    // which is minutes. Override via MC_HANDSHAKE_CONNECT_TIMEOUT.
+    int handshake_connect_timeout = 5;
     bool metacache = true;
     int log_level = google::INFO;
     bool trace = false;

--- a/mooncake-transfer-engine/src/config.cpp
+++ b/mooncake-transfer-engine/src/config.cpp
@@ -258,6 +258,17 @@ void loadGlobalConfig(GlobalConfig& config) {
         }
     }
 
+    const char* handshake_connect_timeout =
+        std::getenv("MC_HANDSHAKE_CONNECT_TIMEOUT");
+    if (handshake_connect_timeout) {
+        int val = atoi(handshake_connect_timeout);
+        if (val > 0 && val < 3600)
+            config.handshake_connect_timeout = val;
+        else
+            LOG(WARNING) << "Ignore value from environment variable "
+                            "MC_HANDSHAKE_CONNECT_TIMEOUT";
+    }
+
     const char* log_level = std::getenv("MC_LOG_LEVEL");
     config.trace = false;
     if (log_level) {

--- a/mooncake-transfer-engine/src/transfer_metadata_plugin.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata_plugin.cpp
@@ -16,10 +16,12 @@
 
 #include <arpa/inet.h>
 #include <bits/stdint-uintn.h>
+#include <fcntl.h>
 #include <ifaddrs.h>
 #include <json/value.h>
 #include <net/if.h>
 #include <netdb.h>
+#include <poll.h>
 #include <sys/socket.h>
 
 #include <random>
@@ -960,9 +962,74 @@ struct SocketHandShakePlugin : public HandShakePlugin {
             return ERR_SOCKET;
         }
 
+        // SO_RCVTIMEO does not apply to connect(). A blocking connect() to
+        // an unroutable address (e.g. a torn-down pod IP) stalls for the
+        // kernel's full SYN-retry cycle -- minutes -- and this runs on RDMA
+        // worker threads, where the stall also blocks CQ polling. Connect in
+        // non-blocking mode and bound the wait with poll().
+        int flags = fcntl(conn_fd, F_GETFL, 0);
+        if (flags == -1 || fcntl(conn_fd, F_SETFL, flags | O_NONBLOCK) == -1) {
+            PLOG(ERROR) << "SocketHandShakePlugin: fcntl(O_NONBLOCK)";
+            close(conn_fd);
+            return ERR_SOCKET;
+        }
+
         if (connect(conn_fd, addr->ai_addr, addr->ai_addrlen)) {
-            PLOG(ERROR) << "SocketHandShakePlugin: connect()"
-                        << getNetworkAddress(addr->ai_addr);
+            if (errno != EINPROGRESS) {
+                PLOG(ERROR) << "SocketHandShakePlugin: connect()"
+                            << getNetworkAddress(addr->ai_addr);
+                close(conn_fd);
+                return ERR_SOCKET;
+            }
+
+            const int64_t deadline_ms =
+                getCurrentTimeInMilli() +
+                globalConfig().handshake_connect_timeout * 1000;
+            struct pollfd pfd;
+            pfd.fd = conn_fd;
+            pfd.events = POLLOUT;
+            while (true) {
+                const int64_t remaining_ms =
+                    deadline_ms - getCurrentTimeInMilli();
+                if (remaining_ms <= 0) {
+                    errno = ETIMEDOUT;
+                    PLOG(ERROR) << "SocketHandShakePlugin: connect() "
+                                << getNetworkAddress(addr->ai_addr);
+                    close(conn_fd);
+                    return ERR_SOCKET;
+                }
+                int ret = poll(&pfd, 1, (int)remaining_ms);
+                if (ret > 0) break;
+                if (ret < 0 && errno != EINTR) {
+                    PLOG(ERROR) << "SocketHandShakePlugin: poll()";
+                    close(conn_fd);
+                    return ERR_SOCKET;
+                }
+                // ret == 0 (poll timeout) re-checks the deadline; EINTR
+                // retries with the remaining time.
+            }
+
+            int conn_err = 0;
+            socklen_t err_len = sizeof(conn_err);
+            if (getsockopt(conn_fd, SOL_SOCKET, SO_ERROR, &conn_err,
+                           &err_len)) {
+                PLOG(ERROR) << "SocketHandShakePlugin: getsockopt(SO_ERROR)";
+                close(conn_fd);
+                return ERR_SOCKET;
+            }
+            if (conn_err) {
+                errno = conn_err;
+                PLOG(ERROR) << "SocketHandShakePlugin: connect()"
+                            << getNetworkAddress(addr->ai_addr);
+                close(conn_fd);
+                return ERR_SOCKET;
+            }
+        }
+
+        // Restore blocking mode; the request/response exchange relies on
+        // blocking reads bounded by SO_RCVTIMEO.
+        if (fcntl(conn_fd, F_SETFL, flags) == -1) {
+            PLOG(ERROR) << "SocketHandShakePlugin: fcntl(restore flags)";
             close(conn_fd);
             return ERR_SOCKET;
         }

--- a/mooncake-transfer-engine/src/transfer_metadata_plugin.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata_plugin.cpp
@@ -991,22 +991,25 @@ struct SocketHandShakePlugin : public HandShakePlugin {
             while (true) {
                 const int64_t remaining_ms =
                     deadline_ms - getCurrentTimeInMilli();
-                if (remaining_ms <= 0) {
+                // poll() returning 0 already means the timeout expired; an
+                // exhausted deadline (only reachable after EINTR) is the
+                // same condition.
+                int ret =
+                    remaining_ms <= 0 ? 0 : poll(&pfd, 1, (int)remaining_ms);
+                if (ret > 0) break;
+                if (ret == 0) {
                     errno = ETIMEDOUT;
                     PLOG(ERROR) << "SocketHandShakePlugin: connect() "
                                 << getNetworkAddress(addr->ai_addr);
                     close(conn_fd);
                     return ERR_SOCKET;
                 }
-                int ret = poll(&pfd, 1, (int)remaining_ms);
-                if (ret > 0) break;
-                if (ret < 0 && errno != EINTR) {
+                if (errno != EINTR) {
                     PLOG(ERROR) << "SocketHandShakePlugin: poll()";
                     close(conn_fd);
                     return ERR_SOCKET;
                 }
-                // ret == 0 (poll timeout) re-checks the deadline; EINTR
-                // retries with the remaining time.
+                // EINTR: retry with the remaining time.
             }
 
             int conn_err = 0;


### PR DESCRIPTION
## Description

`SocketHandShakePlugin::doConnect` uses a blocking `connect()` with no deadline. `SO_RCVTIMEO` does not apply to `connect()`, so a connect to an unroutable address blocks for the kernel's full TCP SYN-retry cycle — about 2 minutes with default `tcp_syn_retries=6`.

**Motivation:** in our production deployment, rolling restarts tear down peer pods whose IPs become unroutable (blackholed) for a window. Outbound handshakes to those peers run on RDMA worker threads (`WorkerPool::performPostSend` → `setupConnectionsByActive`), and the worker loop is post-then-poll — so one stalled `connect()` also freezes CQ polling on that thread, delaying completion delivery for in-flight transfers to *healthy* peers. During a rollout we observed worker threads wedged for minutes at a time on connects to torn-down pods, amplifying recovery time well beyond the failed transfers themselves.

**Change:** connect in non-blocking mode, bound the wait with `poll()` against a deadline, read the handshake verdict via `getsockopt(SO_ERROR)`, then restore blocking mode for the request/response exchange (which keeps relying on `SO_RCVTIMEO`). Fast-failing peers (RST) still fail in ~1 RTT with the real errno; only genuinely unreachable peers hit the timeout.

Since every outbound plugin op funnels through `doConnect`, this bounds the QP handshake, probe, notify, and metadata exchange alike.

New config: `handshake_connect_timeout` (default 5 s), tunable via `MC_HANDSHAKE_CONNECT_TIMEOUT`; documented in the transfer-engine env list.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [x] Docs

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

**Test commands:**
```bash
# format (same clang-format major as CI):
clang-format-20 --dry-run --Werror mooncake-transfer-engine/src/transfer_metadata_plugin.cpp \
  mooncake-transfer-engine/src/config.cpp mooncake-transfer-engine/include/config.h
# spell:
typos <changed files>
```

**Test results:**
- [x] clang-format 20 check passes on all touched files
- [x] typos passes on all touched files
- [ ] Compile + ctest: deferred to GitHub CI (development machine is macOS without an ibverbs stack)
- Manual validation recipe: point a client's handshake at an unroutable TEST-NET address (e.g. `192.0.2.1`); before this change `connect()` blocks ~2 minutes, after it fails with `ETIMEDOUT` at the configured timeout. A peer that refuses (RST) still fails immediately.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code (clang-format 20 directly; same version `scripts/code_format.sh` pins)
- [x] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective (no unit-test harness exists for the socket plugin; suggestions welcome)
- [ ] For changes >500 LOC: I have filed an RFC issue (N/A, ~90 LOC)

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

Claude Code was used to investigate the stall (tracing the blocking connect from the RDMA worker-thread handshake path) and to draft this patch. The change was reviewed and is understood/defended by the human submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)