### PR TITLE
[TE] Gate eRDMA QP reconstruction behind USE_ERDMA so non-eRDMA reconnect flushes in-flight WRs

### DIFF
--- a/mooncake-common/common.cmake
+++ b/mooncake-common/common.cmake
@@ -43,8 +43,17 @@ endif()
 
 message(CMAKE_BUILD_TYPE ": ${CMAKE_BUILD_TYPE}")
 
-# Necessary if you are using Alibaba Cloud eRDMA
-add_definitions(-DCONFIG_ERDMA)
+# eRDMA QP-reconstruction workaround. Aliyun eRDMA cannot transition a QP from
+# RTS back to RTS, so reconnect must destroy+recreate QPs (RdmaEndPoint::
+# reconstruct) instead of the cheaper RESET state-transition path
+# (RdmaEndPoint::disconnectUnlocked). Standard RDMA (e.g. mlx5) does not need
+# this and benefits from the lighter path, which also exercises the
+# ERR-before-RESET flush in disconnectUnlocked. Default ON preserves historical
+# behavior; set -DUSE_ERDMA=OFF for standard-RDMA-only builds.
+option(USE_ERDMA "Enable Aliyun eRDMA QP-reconstruction workaround (CONFIG_ERDMA)" ON)
+if (USE_ERDMA)
+  add_definitions(-DCONFIG_ERDMA)
+endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 

--- a/mooncake-transfer-engine/include/config.h
+++ b/mooncake-transfer-engine/include/config.h
@@ -56,6 +56,12 @@ struct GlobalConfig {
     int log_level = google::INFO;
     bool trace = false;
     int64_t slice_timeout = -1;
+    // Bounded wait (milliseconds) for a disconnected endpoint's outstanding
+    // WRs to drain (flush as CQEs) before the next reconnect transitions its
+    // QPs to RESET. Prevents re-orphaning still-in-flight WRs. 0 disables the
+    // wait (immediate post-RESET counter compensation). Override via
+    // MC_QP_DRAIN_TIMEOUT_MS.
+    int qp_drain_timeout_ms = 100;
     uint16_t rpc_min_port = 15000;
     uint16_t rpc_max_port = 17000;
     bool use_ipv6 = false;

--- a/mooncake-transfer-engine/include/config.h
+++ b/mooncake-transfer-engine/include/config.h
@@ -62,12 +62,13 @@ struct GlobalConfig {
     int log_level = google::INFO;
     bool trace = false;
     int64_t slice_timeout = -1;
-    // Bounded wait (milliseconds) for a disconnected endpoint's outstanding
-    // WRs to drain (flush as CQEs) before the next reconnect transitions its
-    // QPs to RESET. Prevents re-orphaning still-in-flight WRs. 0 disables the
-    // wait (immediate post-RESET counter compensation). Override via
+    // Bounded spin (milliseconds, with lock_ held) for a disconnected
+    // endpoint's outstanding WRs to drain (flush as CQEs) before the next
+    // reconnect reuses/destroys its QPs, so in-flight WRs aren't re-orphaned.
+    // It busy-spins rather than sleeps because lock_ is a spinlock, so it is
+    // kept small and capped at 1000ms. 0 disables the wait. Override via
     // MC_QP_DRAIN_TIMEOUT_MS.
-    int qp_drain_timeout_ms = 100;
+    int qp_drain_timeout_ms = 50;
     uint16_t rpc_min_port = 15000;
     uint16_t rpc_max_port = 17000;
     bool use_ipv6 = false;

--- a/mooncake-transfer-engine/include/config.h
+++ b/mooncake-transfer-engine/include/config.h
@@ -69,6 +69,14 @@ struct GlobalConfig {
     // kept small and capped at 1000ms. 0 disables the wait. Override via
     // MC_QP_DRAIN_TIMEOUT_MS.
     int qp_drain_timeout_ms = 50;
+    // Active-connect circuit-breaker. After an endpoint to a peer is torn down
+    // (path failure / QP fatal), pause active reconnection to that peer's
+    // address for this many milliseconds, so the (single) CQ poller is not
+    // blocked re-handshaking a likely-gone peer (a k8s rolling restart brings
+    // the pod back at a different podIP:port, so the old address is dead). The
+    // not-yet-posted slices fail/redispatch instead of hanging. 0 disables.
+    // Override via MC_CONN_PAUSE_TTL_MS.
+    int conn_pause_ttl_ms = 0;
     uint16_t rpc_min_port = 15000;
     uint16_t rpc_max_port = 17000;
     bool use_ipv6 = false;

--- a/mooncake-transfer-engine/include/transport/rdma_transport/connect_pause_tracker.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/connect_pause_tracker.h
@@ -1,0 +1,85 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CONNECT_PAUSE_TRACKER_H
+#define CONNECT_PAUSE_TRACKER_H
+
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+namespace mooncake {
+
+// Active-connect circuit-breaker state: per peer server name (peer IP), a
+// "pause active reconnection until" timestamp. After an endpoint to a peer is
+// torn down (path failure / QP fatal), the peer is paused so the CQ poller is
+// not blocked re-handshaking a likely-gone peer. The clock is injected so the
+// TTL/expiry/prune logic is unit-testable without RDMA hardware or real sleeps.
+// All methods are thread-safe.
+class ConnectPauseTracker {
+   public:
+    using Clock = std::function<uint64_t()>;  // nanosecond timestamp source
+
+    explicit ConnectPauseTracker(Clock clock) : clock_(std::move(clock)) {}
+
+    // Arm/refresh the pause for `server` until the absolute timestamp
+    // `until_ns`.
+    void pause(const std::string &server, uint64_t until_ns) {
+        std::lock_guard<std::mutex> lock(mu_);
+        until_ns_[server] = until_ns;
+    }
+
+    // Whether `server` is currently paused. Expired entries are deleted on
+    // access (lazy expiry).
+    bool isPaused(const std::string &server) {
+        std::lock_guard<std::mutex> lock(mu_);
+        auto it = until_ns_.find(server);
+        if (it == until_ns_.end()) return false;
+        if (clock_() >= it->second) {
+            until_ns_.erase(it);  // expired -> delete
+            return false;
+        }
+        return true;
+    }
+
+    // Drop all expired entries (so the map doesn't grow for peers that are
+    // never re-checked after their pause lapses). Intended for a periodic tick.
+    void prune() {
+        uint64_t now = clock_();
+        std::lock_guard<std::mutex> lock(mu_);
+        for (auto it = until_ns_.begin(); it != until_ns_.end();) {
+            if (now >= it->second)
+                it = until_ns_.erase(it);
+            else
+                ++it;
+        }
+    }
+
+    // For tests / diagnostics.
+    size_t size() {
+        std::lock_guard<std::mutex> lock(mu_);
+        return until_ns_.size();
+    }
+
+   private:
+    const Clock clock_;
+    std::mutex mu_;
+    std::unordered_map<std::string, uint64_t> until_ns_;
+};
+
+}  // namespace mooncake
+
+#endif  // CONNECT_PAUSE_TRACKER_H

--- a/mooncake-transfer-engine/include/transport/rdma_transport/endpoint_store.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/endpoint_store.h
@@ -43,7 +43,15 @@ class EndpointStore {
     virtual std::shared_ptr<RdmaEndPoint> insertEndpoint(
         const std::string &peer_nic_path, RdmaContext *context) = 0;
     virtual int deleteEndpoint(const std::string &peer_nic_path) = 0;
-    virtual int deleteEndpointByPtr(const RdmaEndPoint *endpoint_ptr) = 0;
+    // Deletes the endpoint matching endpoint_ptr (by pointer identity, under
+    // the store lock -- the pointer is never dereferenced, so a stale/freed
+    // pointer is safe and simply does not match). If found and
+    // deleted_peer_nic_path is non-null, it is set to that endpoint's peer NIC
+    // path (read from the live map key) so callers can act on the path without
+    // touching the raw pointer.
+    virtual int deleteEndpointByPtr(
+        const RdmaEndPoint *endpoint_ptr,
+        std::string *deleted_peer_nic_path = nullptr) = 0;
     virtual void evictEndpoint() = 0;
     // Takes endpoint_map_lock_; caller must not hold it (RWSpinlock is
     // non-reentrant, so recursive acquisition deadlocks).
@@ -77,7 +85,9 @@ class FIFOEndpointStore : public EndpointStore {
     std::shared_ptr<RdmaEndPoint> insertEndpoint(
         const std::string &peer_nic_path, RdmaContext *context) override;
     int deleteEndpoint(const std::string &peer_nic_path) override;
-    int deleteEndpointByPtr(const RdmaEndPoint *endpoint_ptr) override;
+    int deleteEndpointByPtr(
+        const RdmaEndPoint *endpoint_ptr,
+        std::string *deleted_peer_nic_path = nullptr) override;
     void evictEndpoint() override;
     void reclaimEndpoint() override;
     size_t getSize() override;
@@ -117,7 +127,9 @@ class SIEVEEndpointStore : public EndpointStore {
     std::shared_ptr<RdmaEndPoint> insertEndpoint(
         const std::string &peer_nic_path, RdmaContext *context) override;
     int deleteEndpoint(const std::string &peer_nic_path) override;
-    int deleteEndpointByPtr(const RdmaEndPoint *endpoint_ptr) override;
+    int deleteEndpointByPtr(
+        const RdmaEndPoint *endpoint_ptr,
+        std::string *deleted_peer_nic_path = nullptr) override;
     void evictEndpoint() override;
     void reclaimEndpoint() override;
     size_t getSize() override;

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
@@ -37,6 +37,7 @@
 #include "common.h"
 #include "rdma_gid_probe.h"
 #include "rdma_transport.h"
+#include "transport/rdma_transport/connect_pause_tracker.h"
 #include "transport/transport.h"
 
 namespace mooncake {
@@ -126,6 +127,16 @@ class RdmaContext {
 
     int deleteEndpoint(const std::string &peer_nic_path);
     int deleteEndpointByPtr(const RdmaEndPoint *endpoint_ptr);
+
+    // Active-connect circuit-breaker. After deleteEndpointByPtr tears an
+    // endpoint down, active reconnection to that peer's address is paused for
+    // globalConfig().conn_pause_ttl_ms so the CQ poller isn't blocked
+    // re-handshaking a likely-gone peer. Entries expire (lazily on
+    // isConnectPaused, and via pruneConnectPause from the monitor tick). All
+    // no-ops when the TTL is 0. Keyed by peer server name (the peer IP).
+    void pauseConnect(const std::string &peer_nic_path);
+    bool isConnectPaused(const std::string &peer_nic_path);
+    void pruneConnectPause();
 
     // Drain the endpoint store's waiting list. Safe to call on any thread;
     // intended to be invoked periodically from monitorWorker so reclaim is
@@ -244,6 +255,9 @@ class RdmaContext {
     std::vector<RdmaCq> cq_list_;
 
     std::shared_ptr<EndpointStore> endpoint_store_;
+
+    // Active-connect circuit-breaker (keyed by peer server name).
+    ConnectPauseTracker connect_pause_;
 
     std::vector<std::thread> background_thread_;
     std::atomic<bool> threads_running_;

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_endpoint.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_endpoint.h
@@ -113,6 +113,14 @@ class RdmaEndPoint {
    private:
     int disconnectUnlocked();
 
+    // Bounded wait for this endpoint's outstanding WRs to drain to zero
+    // (i.e. all flush CQEs from a prior disconnectUnlocked have been polled).
+    // Caller must hold lock_. Returns true if fully drained, false on timeout
+    // (globalConfig().qp_drain_timeout_ms). Called before doSetupConnection
+    // transitions QPs back through RESET so in-flight WRs are not re-orphaned;
+    // on a fresh endpoint the counters are already zero and this is a no-op.
+    bool drainWrDepthLocked();
+
     // Resets the connection.
     //
     // The main difference between this function and `disconnectUnlocked`

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_endpoint.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_endpoint.h
@@ -92,8 +92,6 @@ class RdmaEndPoint {
         return status_.load(std::memory_order_relaxed) == CONNECTED;
     }
 
-    const std::string &peerNicPath() const { return peer_nic_path_; }
-
     // Interrupts the connection, which can be triggered by user or by internal
     // error. Use setupConnectionsByActive or setupConnectionsByPassive to
     // reconnect

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_endpoint.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_endpoint.h
@@ -92,6 +92,8 @@ class RdmaEndPoint {
         return status_.load(std::memory_order_relaxed) == CONNECTED;
     }
 
+    const std::string &peerNicPath() const { return peer_nic_path_; }
+
     // Interrupts the connection, which can be triggered by user or by internal
     // error. Use setupConnectionsByActive or setupConnectionsByPassive to
     // reconnect

--- a/mooncake-transfer-engine/src/config.cpp
+++ b/mooncake-transfer-engine/src/config.cpp
@@ -317,6 +317,28 @@ void loadGlobalConfig(GlobalConfig& config) {
         }
     }
 
+    const char* conn_pause_ttl_env = std::getenv("MC_CONN_PAUSE_TTL_MS");
+    if (conn_pause_ttl_env) {
+        // Robust parse (not atoi): a non-numeric typo must keep the default
+        // rather than silently resolve to 0. 0 is a valid explicit "disable";
+        // negative / out-of-range / garbage are rejected, preserving the
+        // default.
+        try {
+            int val = std::stoi(conn_pause_ttl_env);
+            if (val >= 0 && val <= 600000) {
+                config.conn_pause_ttl_ms = val;
+            } else {
+                LOG(WARNING) << "Ignore value from environment variable "
+                                "MC_CONN_PAUSE_TTL_MS, value "
+                             << conn_pause_ttl_env
+                             << " out of range (should be 0-600000)";
+            }
+        } catch (const std::exception& e) {
+            LOG(WARNING) << "Invalid MC_CONN_PAUSE_TTL_MS environment value: "
+                         << conn_pause_ttl_env << ". Error: " << e.what();
+        }
+    }
+
     const char* log_dir_path = std::getenv("MC_LOG_DIR");
     if (log_dir_path) {
         google::InitGoogleLogging("mooncake-transfer-engine");

--- a/mooncake-transfer-engine/src/config.cpp
+++ b/mooncake-transfer-engine/src/config.cpp
@@ -303,13 +303,13 @@ void loadGlobalConfig(GlobalConfig& config) {
         // rejected, preserving the default.
         try {
             int val = std::stoi(qp_drain_timeout_env);
-            if (val >= 0 && val < 65536) {
+            if (val >= 0 && val <= 1000) {
                 config.qp_drain_timeout_ms = val;
             } else {
                 LOG(WARNING) << "Ignore value from environment variable "
                                 "MC_QP_DRAIN_TIMEOUT_MS, value "
                              << qp_drain_timeout_env
-                             << " out of range (should be 0-65535)";
+                             << " out of range (should be 0-1000)";
             }
         } catch (const std::exception& e) {
             LOG(WARNING) << "Invalid MC_QP_DRAIN_TIMEOUT_MS environment value: "

--- a/mooncake-transfer-engine/src/config.cpp
+++ b/mooncake-transfer-engine/src/config.cpp
@@ -284,6 +284,28 @@ void loadGlobalConfig(GlobalConfig& config) {
                 << "Ignore value from environment variable MC_SLICE_TIMEOUT";
     }
 
+    const char* qp_drain_timeout_env = std::getenv("MC_QP_DRAIN_TIMEOUT_MS");
+    if (qp_drain_timeout_env) {
+        // Robust parse (not atoi): a non-numeric typo must keep the default
+        // rather than silently resolve to 0 and disable the drain-wait. 0 is a
+        // valid explicit "disable"; negative / out-of-range / garbage are
+        // rejected, preserving the default.
+        try {
+            int val = std::stoi(qp_drain_timeout_env);
+            if (val >= 0 && val < 65536) {
+                config.qp_drain_timeout_ms = val;
+            } else {
+                LOG(WARNING) << "Ignore value from environment variable "
+                                "MC_QP_DRAIN_TIMEOUT_MS, value "
+                             << qp_drain_timeout_env
+                             << " out of range (should be 0-65535)";
+            }
+        } catch (const std::exception& e) {
+            LOG(WARNING) << "Invalid MC_QP_DRAIN_TIMEOUT_MS environment value: "
+                         << qp_drain_timeout_env << ". Error: " << e.what();
+        }
+    }
+
     const char* log_dir_path = std::getenv("MC_LOG_DIR");
     if (log_dir_path) {
         google::InitGoogleLogging("mooncake-transfer-engine");

--- a/mooncake-transfer-engine/src/transport/rdma_transport/endpoint_store.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/endpoint_store.cpp
@@ -94,8 +94,8 @@ int FIFOEndpointStore::deleteEndpoint(const std::string &peer_nic_path) {
     return 0;
 }
 
-int FIFOEndpointStore::deleteEndpointByPtr(
-    const RdmaEndPoint *endpoint_ptr, std::string *deleted_peer_nic_path) {
+int FIFOEndpointStore::deleteEndpointByPtr(const RdmaEndPoint *endpoint_ptr,
+                                           std::string *deleted_peer_nic_path) {
     RWSpinlock::WriteGuard guard(endpoint_map_lock_);
     // Find endpoint by pointer
     for (auto iter = endpoint_map_.begin(); iter != endpoint_map_.end();

--- a/mooncake-transfer-engine/src/transport/rdma_transport/endpoint_store.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/endpoint_store.cpp
@@ -94,13 +94,15 @@ int FIFOEndpointStore::deleteEndpoint(const std::string &peer_nic_path) {
     return 0;
 }
 
-int FIFOEndpointStore::deleteEndpointByPtr(const RdmaEndPoint *endpoint_ptr) {
+int FIFOEndpointStore::deleteEndpointByPtr(
+    const RdmaEndPoint *endpoint_ptr, std::string *deleted_peer_nic_path) {
     RWSpinlock::WriteGuard guard(endpoint_map_lock_);
     // Find endpoint by pointer
     for (auto iter = endpoint_map_.begin(); iter != endpoint_map_.end();
          ++iter) {
         if (iter->second.get() == endpoint_ptr) {
             std::string peer_nic_path = iter->first;
+            if (deleted_peer_nic_path) *deleted_peer_nic_path = peer_nic_path;
             waiting_list_len_++;
             iter->second->beginDestroy();
             waiting_list_.insert(iter->second);
@@ -248,13 +250,15 @@ int SIEVEEndpointStore::deleteEndpoint(const std::string &peer_nic_path) {
     return 0;
 }
 
-int SIEVEEndpointStore::deleteEndpointByPtr(const RdmaEndPoint *endpoint_ptr) {
+int SIEVEEndpointStore::deleteEndpointByPtr(
+    const RdmaEndPoint *endpoint_ptr, std::string *deleted_peer_nic_path) {
     RWSpinlock::WriteGuard guard(endpoint_map_lock_);
     // Find endpoint by pointer
     for (auto iter = endpoint_map_.begin(); iter != endpoint_map_.end();
          ++iter) {
         if (iter->second.first.get() == endpoint_ptr) {
             std::string peer_nic_path = iter->first;
+            if (deleted_peer_nic_path) *deleted_peer_nic_path = peer_nic_path;
             iter->second.first->beginDestroy();
             waiting_list_len_++;
             waiting_list_.insert(iter->second.first);

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -654,9 +654,18 @@ int RdmaContext::deleteEndpoint(const std::string &peer_nic_path) {
 int RdmaContext::deleteEndpointByPtr(const RdmaEndPoint *endpoint_ptr) {
     // Tearing an endpoint down (path failure / QP fatal) means this peer is
     // failing; pause active reconnection to its address so the CQ poller isn't
-    // blocked re-handshaking a likely-gone peer. No-op when the TTL is 0.
-    if (endpoint_ptr) pauseConnect(endpoint_ptr->peerNicPath());
-    return endpoint_store_->deleteEndpointByPtr(endpoint_ptr);
+    // blocked re-handshaking a likely-gone peer.
+    //
+    // Resolve the peer path *inside* the store, under its lock: the raw pointer
+    // may already be freed (e.g. an IBV_EVENT_QP_FATAL racing endpoint
+    // destruction), so we must not dereference it here. The store only compares
+    // pointer identity and returns the path from the live map key, and we arm
+    // the pause only if the endpoint was actually found. No-op when TTL is 0.
+    std::string deleted_peer_nic_path;
+    int ret =
+        endpoint_store_->deleteEndpointByPtr(endpoint_ptr, &deleted_peer_nic_path);
+    if (!deleted_peer_nic_path.empty()) pauseConnect(deleted_peer_nic_path);
+    return ret;
 }
 
 void RdmaContext::pauseConnect(const std::string &peer_nic_path) {

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -160,6 +160,8 @@ std::string gidBytesToString(const uint8_t *raw) {
 RdmaContext::RdmaContext(RdmaTransport &engine, const std::string &device_name)
     : device_name_(device_name),
       engine_(engine),
+      connect_pause_(
+          [] { return static_cast<uint64_t>(getCurrentTimeInNano()); }),
       next_comp_channel_index_(0),
       next_comp_vector_index_(0),
       next_cq_list_index_(0),
@@ -650,8 +652,31 @@ int RdmaContext::deleteEndpoint(const std::string &peer_nic_path) {
 }
 
 int RdmaContext::deleteEndpointByPtr(const RdmaEndPoint *endpoint_ptr) {
+    // Tearing an endpoint down (path failure / QP fatal) means this peer is
+    // failing; pause active reconnection to its address so the CQ poller isn't
+    // blocked re-handshaking a likely-gone peer. No-op when the TTL is 0.
+    if (endpoint_ptr) pauseConnect(endpoint_ptr->peerNicPath());
     return endpoint_store_->deleteEndpointByPtr(endpoint_ptr);
 }
+
+void RdmaContext::pauseConnect(const std::string &peer_nic_path) {
+    int ttl_ms = globalConfig().conn_pause_ttl_ms;
+    if (ttl_ms <= 0) return;  // disabled
+    auto server_name = getServerNameFromNicPath(peer_nic_path);
+    if (server_name.empty()) return;
+    uint64_t until =
+        getCurrentTimeInNano() + static_cast<uint64_t>(ttl_ms) * 1000000ull;
+    connect_pause_.pause(server_name, until);
+}
+
+bool RdmaContext::isConnectPaused(const std::string &peer_nic_path) {
+    if (globalConfig().conn_pause_ttl_ms <= 0) return false;  // disabled
+    auto server_name = getServerNameFromNicPath(peer_nic_path);
+    if (server_name.empty()) return false;
+    return connect_pause_.isPaused(server_name);
+}
+
+void RdmaContext::pruneConnectPause() { connect_pause_.prune(); }
 
 void RdmaContext::reclaimEndpoints() { endpoint_store_->reclaimEndpoint(); }
 

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -662,8 +662,8 @@ int RdmaContext::deleteEndpointByPtr(const RdmaEndPoint *endpoint_ptr) {
     // pointer identity and returns the path from the live map key, and we arm
     // the pause only if the endpoint was actually found. No-op when TTL is 0.
     std::string deleted_peer_nic_path;
-    int ret =
-        endpoint_store_->deleteEndpointByPtr(endpoint_ptr, &deleted_peer_nic_path);
+    int ret = endpoint_store_->deleteEndpointByPtr(endpoint_ptr,
+                                                   &deleted_peer_nic_path);
     if (!deleted_peer_nic_path.empty()) pauseConnect(deleted_peer_nic_path);
     return ret;
 }

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -699,8 +699,8 @@ int RdmaEndPoint::disconnectUnlocked() {
         ibv_qp_attr cur_attr;
         ibv_qp_init_attr cur_init_attr;
         bool qp_in_reset = false;
-        if (ibv_query_qp(qp_list_[i], &cur_attr, IBV_QP_STATE, &cur_init_attr) ==
-            0) {
+        if (ibv_query_qp(qp_list_[i], &cur_attr, IBV_QP_STATE,
+                         &cur_init_attr) == 0) {
             qp_in_reset = (cur_attr.qp_state == IBV_QPS_RESET);
         }
 

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -311,6 +311,16 @@ int RdmaEndPoint::setupConnectionsByActive() {
             return doSetupConnection(context_.gid(), context_.lid(), qpNum());
         }
 
+        // Active-connect circuit-breaker: if we recently tore down an endpoint
+        // to this peer (path failure / QP fatal), skip the handshake for the
+        // configured pause window instead of blocking the (single) CQ poller on
+        // an RPC to a likely-gone peer. Fail fast; performPostSend then
+        // redispatches or fails the (not-yet-posted) slices. No-op when
+        // conn_pause_ttl_ms is 0.
+        if (context_.isConnectPaused(peer_nic_path_)) {
+            return ERR_ENDPOINT;
+        }
+
         // Only proceed with RPC if we are the first to transition from
         // UNCONNECTED. This prevents duplicate concurrent handshake attempts
         // from the same endpoint.
@@ -680,26 +690,47 @@ int RdmaEndPoint::disconnectUnlocked() {
     attr.qp_state = IBV_QPS_ERR;
     int ret = 0;
     for (size_t i = 0; i < qp_list_.size(); ++i) {
-        if (ibv_modify_qp(qp_list_[i], &attr, IBV_QP_STATE) == 0) {
-            // Success: leave the counters alone; the flush CQEs will drain
-            // them via performPollCq.
-            continue;
+        // RESET -> ERR is an illegal transition (the kernel rejects it with
+        // EINVAL), and a QP already in RESET holds no inflight WRs in hardware
+        // to flush. So query the current state first and only attempt the ERR
+        // flush from a state ERR is reachable from. A failed/aborted setup
+        // commonly leaves the QP in RESET; skipping the doomed ERR there avoids
+        // the EINVAL log flood (and the bogus reset error it propagates).
+        ibv_qp_attr cur_attr;
+        ibv_qp_init_attr cur_init_attr;
+        bool qp_in_reset = false;
+        if (ibv_query_qp(qp_list_[i], &cur_attr, IBV_QP_STATE, &cur_init_attr) ==
+            0) {
+            qp_in_reset = (cur_attr.qp_state == IBV_QPS_RESET);
         }
-        PLOG(ERROR) << "Failed to modify QP to ERR, falling back to RESET";
-        ret = ERR_ENDPOINT;
 
-        // ERR failed, so no flush CQEs will be generated for this QP. Fall
-        // back to the legacy RESET transition and compensate the counters
-        // directly, since the discarded WRs will never produce completions.
-        ibv_qp_attr reset_attr;
-        memset(&reset_attr, 0, sizeof(reset_attr));
-        reset_attr.qp_state = IBV_QPS_RESET;
-        if (ibv_modify_qp(qp_list_[i], &reset_attr, IBV_QP_STATE)) {
-            // Both ERR and RESET failed; the QP may still be live and could
-            // yet generate completions, so leave the counters untouched.
-            PLOG(ERROR) << "Failed to modify QP to RESET after ERR failure";
-            continue;
+        if (!qp_in_reset) {
+            if (ibv_modify_qp(qp_list_[i], &attr, IBV_QP_STATE) == 0) {
+                // Success: leave the counters alone; the flush CQEs will drain
+                // them via performPollCq.
+                continue;
+            }
+            PLOG(ERROR) << "Failed to modify QP to ERR, falling back to RESET";
+            ret = ERR_ENDPOINT;
+
+            // ERR failed, so no flush CQEs will be generated for this QP. Fall
+            // back to the legacy RESET transition.
+            ibv_qp_attr reset_attr;
+            memset(&reset_attr, 0, sizeof(reset_attr));
+            reset_attr.qp_state = IBV_QPS_RESET;
+            if (ibv_modify_qp(qp_list_[i], &reset_attr, IBV_QP_STATE)) {
+                // Both ERR and RESET failed; the QP may still be live and could
+                // yet generate completions, so leave the counters untouched.
+                PLOG(ERROR) << "Failed to modify QP to RESET after ERR failure";
+                continue;
+            }
         }
+
+        // Reached either because the QP was already in RESET (no flush
+        // possible) or because ERR failed and we forced it to RESET. In both
+        // cases the discarded WRs will never produce a completion, so
+        // compensate the counters directly.
+        // TODO(orphan-fix): also markFailed the slices bound to these WRs.
         if (wr_depth_list_[i] != 0) {
             __sync_fetch_and_sub(cq_outstanding_, wr_depth_list_[i]);
             wr_depth_list_[i] = 0;

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -655,24 +655,52 @@ int RdmaEndPoint::disconnectUnlocked() {
     auto curr_status = status_.load(std::memory_order_acquire);
     if (curr_status != CONNECTED && curr_status != CONNECTING) return 0;
 
+    // Why ERR instead of RESET: when a peer dies mid-transfer (e.g. a rolling
+    // restart) we may still have WRs posted to it. Transitioning the QP
+    // straight to RESET silently discards those outstanding WRs WITHOUT
+    // generating any CQE -- so their slices are never marked failed, the owning
+    // task never reaches a terminal state, and mooncake-store waits out its
+    // full per-batch deadline (~60s) for every poisoned batch while the vLLM
+    // recv queue backs up and wedges. That orphaning is the root cause this
+    // change targets.
+    //
+    // Moving the QP to ERR instead makes the local HCA flush every outstanding
+    // WR to the CQ as IBV_WC_WR_FLUSH_ERR. performPollCq then drains them
+    // through the normal completion path (markFailed) in milliseconds, which
+    // both terminates the slices (so the task fails fast and the caller can
+    // recompute) and decrements wr_depth_list_/cq_outstanding_ for us. This is
+    // the same flush-then-drain mechanism beginDestroy() already relies on.
+    //
+    // The next reconnect's drain-wait (drainWrDepthLocked) lets that flush
+    // finish before any RESET reuses these QPs; if it times out, the
+    // ERR-generated CQEs survive the RESET and still drain the counters as they
+    // are polled (doSetupConnection only logs the residual, never compensates).
     ibv_qp_attr attr;
     memset(&attr, 0, sizeof(attr));
-    attr.qp_state = IBV_QPS_RESET;
+    attr.qp_state = IBV_QPS_ERR;
     int ret = 0;
     for (size_t i = 0; i < qp_list_.size(); ++i) {
-        int curr_ret = ibv_modify_qp(qp_list_[i], &attr, IBV_QP_STATE);
-        if (curr_ret) {
-            PLOG(ERROR) << "Failed to modify QP to RESET";
-            ret = ERR_ENDPOINT;
+        if (ibv_modify_qp(qp_list_[i], &attr, IBV_QP_STATE) == 0) {
+            // Success: leave the counters alone; the flush CQEs will drain
+            // them via performPollCq.
+            continue;
         }
-        // After resetting QP, the wr_depth_list_ won't change
-        bool displayed = false;
+        PLOG(ERROR) << "Failed to modify QP to ERR, falling back to RESET";
+        ret = ERR_ENDPOINT;
+
+        // ERR failed, so no flush CQEs will be generated for this QP. Fall
+        // back to the legacy RESET transition and compensate the counters
+        // directly, since the discarded WRs will never produce completions.
+        ibv_qp_attr reset_attr;
+        memset(&reset_attr, 0, sizeof(reset_attr));
+        reset_attr.qp_state = IBV_QPS_RESET;
+        if (ibv_modify_qp(qp_list_[i], &reset_attr, IBV_QP_STATE)) {
+            // Both ERR and RESET failed; the QP may still be live and could
+            // yet generate completions, so leave the counters untouched.
+            PLOG(ERROR) << "Failed to modify QP to RESET after ERR failure";
+            continue;
+        }
         if (wr_depth_list_[i] != 0) {
-            if (!displayed) {
-                LOG(WARNING) << "Outstanding work requests found, CQ will not "
-                                "be generated";
-                displayed = true;
-            }
             __sync_fetch_and_sub(cq_outstanding_, wr_depth_list_[i]);
             wr_depth_list_[i] = 0;
         }
@@ -719,6 +747,18 @@ const std::string RdmaEndPoint::toString() const {
 int RdmaEndPoint::submitPostSend(
     std::vector<Transport::Slice *> &slice_list,
     std::vector<Transport::Slice *> &failed_slice_list) {
+    // Lock-free fast reject before contending for lock_. A reconnect may hold
+    // lock_ across a bounded drain-wait (drainWrDepthLocked); in the default
+    // single-CQ topology the worker that posts is also the only CQ poller, so
+    // blocking it here on lock_ would stall the very CQ drain the reconnect is
+    // waiting for. Bailing early when not CONNECTED keeps that poller free.
+    // The under-lock check below remains authoritative.
+    if (status_.load(std::memory_order_acquire) != CONNECTED) {
+        for (auto &slice : slice_list) failed_slice_list.push_back(slice);
+        slice_list.clear();
+        return 0;
+    }
+
     RWSpinlock::WriteGuard guard(lock_);
     if (!active_ || status_.load(std::memory_order_relaxed) != CONNECTED) {
         for (auto &slice : slice_list) failed_slice_list.push_back(slice);
@@ -848,11 +888,66 @@ static int parseGidString(const std::string &gid_str, ibv_gid &gid_out) {
     return 0;
 }
 
+bool RdmaEndPoint::drainWrDepthLocked() {
+    // Safe to wait while holding lock_: wr_depth_list_ is decremented by
+    // performPollCq on a worker thread, which never takes lock_, so the drain
+    // makes progress under the lock. submitPostSend's lock-free pre-check keeps
+    // that poller from blocking on lock_ here (critical in the default 1-CQ
+    // topology, where the posting worker is also the only poller).
+    auto all_drained = [this]() {
+        for (size_t i = 0; i < qp_list_.size(); ++i) {
+            if (__atomic_load_n(&wr_depth_list_[i], __ATOMIC_ACQUIRE) != 0)
+                return false;
+        }
+        return true;
+    };
+
+    if (all_drained()) return true;
+
+    const int timeout_ms = globalConfig().qp_drain_timeout_ms;
+    if (timeout_ms <= 0) return false;  // wait disabled
+
+    // Reuse the handshake-wait backoff: spin briefly, then sleep with
+    // exponential backoff. A peer that just died flushes its WRs within the
+    // RDMA retry window, so the common drain finishes in the spin phase.
+    const uint64_t deadline_ns =
+        getCurrentTimeInNano() + static_cast<uint64_t>(timeout_ms) * 1000000ull;
+    uint32_t spin_count = 0;
+    uint32_t sleep_us = kWaitExistingHandshakeInitialSleepUs;
+    while (!all_drained()) {
+        if (getCurrentTimeInNano() > deadline_ns) return false;
+        if (spin_count < kWaitExistingHandshakeSpinCount) {
+            PAUSE();
+        } else {
+            std::this_thread::sleep_for(std::chrono::microseconds(sleep_us));
+            uint32_t next = sleep_us * 2;
+            sleep_us = next > kWaitExistingHandshakeMaxSleepUs
+                           ? kWaitExistingHandshakeMaxSleepUs
+                           : next;
+        }
+        ++spin_count;
+    }
+    return true;
+}
+
 int RdmaEndPoint::doSetupConnection(const std::string &peer_gid,
                                     uint16_t peer_lid,
                                     std::vector<uint32_t> peer_qp_num_list,
                                     std::string *reply_msg,
                                     SetupConnectionFailureInfo *failure_info) {
+    // If this endpoint was just disconnected (QPs in ERR), wait for its
+    // outstanding WRs to flush as CQEs and be polled before the per-QP
+    // "any state -> RESET" below. Skips instantly when nothing is outstanding
+    // (the fresh-endpoint case). A timeout here is not fatal: the ERR-generated
+    // flush CQEs survive the subsequent RESET and drain the counters as they
+    // are polled, so reuse remains correctly accounted.
+    if (!drainWrDepthLocked()) {
+        LOG(WARNING) << "Outstanding WRs did not drain within "
+                     << globalConfig().qp_drain_timeout_ms
+                     << " ms before reconnect, peer_nic_path="
+                     << peer_nic_path_;
+    }
+
     if (qp_list_.size() != peer_qp_num_list.size()) {
         std::string message =
             "QP count mismatch in peer and local endpoints, check "
@@ -915,6 +1010,25 @@ int RdmaEndPoint::doSetupConnection(int qp_index, const ibv_gid &peer_gid,
             failure_info->sys_errno = errno;
         }
         return ERR_ENDPOINT;
+    }
+
+    // If this QP still shows outstanding WRs here, they are flush CQEs that a
+    // prior disconnectUnlocked (successful ERR transition) already generated
+    // but the drain-wait did not observe polled in time. Those CQEs survive
+    // the RESET above and will be polled normally, decrementing
+    // wr_depth_list_/cq_outstanding_ themselves -- each is the matching -1 for
+    // a +1 charged at post time. We therefore must NOT compensate here; doing
+    // so would zero out the +1 prematurely and double-count once the CQE
+    // drains. (The only place a discarded WR produces no CQE is the
+    // ERR-failure RESET fallback in disconnectUnlocked, which compensates
+    // there.) Log the residual purely as an observability signal for the rare
+    // drain-timeout path; it is 0 on the healthy path.
+    int residual = __atomic_load_n(&wr_depth_list_[qp_index], __ATOMIC_ACQUIRE);
+    if (residual > 0) {
+        LOG(WARNING) << "Reset QP with " << residual
+                     << " outstanding WR(s) pending flush-CQE drain, "
+                        "peer_nic_path="
+                     << peer_nic_path_;
     }
 
     // RESET -> INIT

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -889,11 +889,23 @@ static int parseGidString(const std::string &gid_str, ibv_gid &gid_out) {
 }
 
 bool RdmaEndPoint::drainWrDepthLocked() {
-    // Safe to wait while holding lock_: wr_depth_list_ is decremented by
-    // performPollCq on a worker thread, which never takes lock_, so the drain
-    // makes progress under the lock. submitPostSend's lock-free pre-check keeps
-    // that poller from blocking on lock_ here (critical in the default 1-CQ
-    // topology, where the posting worker is also the only poller).
+    // Called with lock_ (a ticket spinlock) held. wr_depth_list_ is decremented
+    // by performPollCq on a worker thread, which never takes lock_, so the
+    // drain makes progress while we hold the lock; submitPostSend's lock-free
+    // pre-check keeps that poller (the only poller in the default 1-CQ
+    // topology) from blocking on lock_ here.
+    //
+    // We busy-spin rather than sleep. Sleeping while holding a spinlock would
+    // force any other lock_ contender to burn a core spinning for the whole
+    // sleep (priority inversion / potential starvation). We also cannot release
+    // lock_ around a sleep: a concurrent reconnect could then acquire it and
+    // run deconstructLocked() -- which delete[]s wr_depth_list_ -- out from
+    // under this loop (use-after-free). So the wait is a short bounded spin
+    // (qp_drain_timeout_ms, capped at 1000ms; default 50ms). On the enabled
+    // non-eRDMA path it is best-effort anyway: the ERR-generated flush CQEs
+    // survive the subsequent RESET and still drain the counters as they are
+    // polled, so an early return only defers termination to the next poll
+    // cycle -- it does not orphan.
     auto all_drained = [this]() {
         for (size_t i = 0; i < qp_list_.size(); ++i) {
             if (__atomic_load_n(&wr_depth_list_[i], __ATOMIC_ACQUIRE) != 0)
@@ -907,25 +919,11 @@ bool RdmaEndPoint::drainWrDepthLocked() {
     const int timeout_ms = globalConfig().qp_drain_timeout_ms;
     if (timeout_ms <= 0) return false;  // wait disabled
 
-    // Reuse the handshake-wait backoff: spin briefly, then sleep with
-    // exponential backoff. A peer that just died flushes its WRs within the
-    // RDMA retry window, so the common drain finishes in the spin phase.
     const uint64_t deadline_ns =
         getCurrentTimeInNano() + static_cast<uint64_t>(timeout_ms) * 1000000ull;
-    uint32_t spin_count = 0;
-    uint32_t sleep_us = kWaitExistingHandshakeInitialSleepUs;
     while (!all_drained()) {
         if (getCurrentTimeInNano() > deadline_ns) return false;
-        if (spin_count < kWaitExistingHandshakeSpinCount) {
-            PAUSE();
-        } else {
-            std::this_thread::sleep_for(std::chrono::microseconds(sleep_us));
-            uint32_t next = sleep_us * 2;
-            sleep_us = next > kWaitExistingHandshakeMaxSleepUs
-                           ? kWaitExistingHandshakeMaxSleepUs
-                           : next;
-        }
-        ++spin_count;
+        PAUSE();
     }
     return true;
 }
@@ -984,7 +982,9 @@ int RdmaEndPoint::doSetupConnection(const std::string &peer_gid,
     }
 
     peer_qp_num_list_ = std::move(peer_qp_num_list);
-    status_.store(CONNECTED, std::memory_order_relaxed);
+    // Release so the lock-free acquire-load in submitPostSend() that observes
+    // CONNECTED also sees the fully-initialized peer_qp_num_list_ and QP state.
+    status_.store(CONNECTED, std::memory_order_release);
     return 0;
 }
 

--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -555,6 +555,9 @@ void WorkerPool::monitorWorker() {
             // from RdmaContext::endpoint() and the waiting list grows
             // unboundedly under failure load. See issue #1845.
             context_.reclaimEndpoints();
+            // Drop expired active-connect pause entries so the map doesn't grow
+            // for peers that are never re-attempted after their pause lapses.
+            context_.pruneConnectPause();
             last_reset_ts = current_ts;
         }
         struct epoll_event event;

--- a/mooncake-transfer-engine/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tests/CMakeLists.txt
@@ -43,6 +43,14 @@ if (UNIX AND NOT APPLE)
         "-Wl,--wrap=ibv_modify_qp"
         "-Wl,--wrap=ibv_query_gid"
         "-Wl,--wrap=_ibv_query_gid_ex")
+    # ibv_create_qp is wrapped only for non-eRDMA builds, where the
+    # DisconnectIssuesErrBeforeResetOnReconnect test tracks QP generations.
+    # The matching __wrap_ibv_create_qp is guarded by #ifndef CONFIG_ERDMA, so
+    # the flag must be gated identically or the link fails on an undefined wrap.
+    if (NOT USE_ERDMA)
+        target_link_options(rdma_endpoint_reestablish_test PRIVATE
+            "-Wl,--wrap=ibv_create_qp")
+    endif()
 endif()
 add_test(NAME rdma_endpoint_reestablish_test COMMAND rdma_endpoint_reestablish_test)
 set_tests_properties(rdma_endpoint_reestablish_test PROPERTIES LABELS "rdma")

--- a/mooncake-transfer-engine/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tests/CMakeLists.txt
@@ -49,7 +49,8 @@ if (UNIX AND NOT APPLE)
     # the flag must be gated identically or the link fails on an undefined wrap.
     if (NOT USE_ERDMA)
         target_link_options(rdma_endpoint_reestablish_test PRIVATE
-            "-Wl,--wrap=ibv_create_qp")
+            "-Wl,--wrap=ibv_create_qp"
+            "-Wl,--wrap=ibv_query_qp")
     endif()
 endif()
 add_test(NAME rdma_endpoint_reestablish_test COMMAND rdma_endpoint_reestablish_test)
@@ -76,6 +77,13 @@ endif()
 add_executable(tcp_address_validation_test ${WORKSPACE}/tcp_address_validation_test.cpp)
 target_link_libraries(tcp_address_validation_test PUBLIC gtest gtest_main)
 add_test(NAME tcp_address_validation_test COMMAND tcp_address_validation_test)
+
+# Hardware-free unit test for the active-connect circuit-breaker state
+# (ConnectPauseTracker is header-only and clock-injectable), runs on every CI
+# runner.
+add_executable(connect_pause_tracker_test ${WORKSPACE}/connect_pause_tracker_test.cpp)
+target_link_libraries(connect_pause_tracker_test PUBLIC gtest gtest_main pthread)
+add_test(NAME connect_pause_tracker_test COMMAND connect_pause_tracker_test)
 
 if (USE_MNNVL)
     add_executable(nvlink_transport_test ${WORKSPACE}/nvlink_transport_test.cpp)

--- a/mooncake-transfer-engine/tests/config_test.cpp
+++ b/mooncake-transfer-engine/tests/config_test.cpp
@@ -105,47 +105,51 @@ TEST_F(PkeyIndexEnvTest, AutoGidRetriesRejectsOutOfRangeOverride) {
     EXPECT_EQ(config.auto_gid_max_retries, 5);
 }
 
-// MC_QP_DRAIN_TIMEOUT_MS bounds the wait for a disconnected endpoint's
-// outstanding WRs to flush before the next reconnect transitions its QPs back
-// through RESET. Unlike most knobs, 0 is a valid value (disables the wait), so
-// these cases pin down that 0 is accepted while garbage/negative/out-of-range
-// preserve the default -- a typo must not silently disable the safety wait.
+// MC_QP_DRAIN_TIMEOUT_MS bounds the spin for a disconnected endpoint's
+// outstanding WRs to flush before the next reconnect reuses/destroys its QPs.
+// Unlike most knobs, 0 is a valid value (disables the wait); the range is
+// capped at 1000ms because the drain spins with a spinlock held. These cases
+// pin down that 0 is accepted while garbage/negative/out-of-range/trailing
+// junk preserve the default -- a typo must not silently disable or mis-set the
+// safety wait.
 class QpDrainTimeoutEnvTest : public ::testing::Test {
    protected:
     void TearDown() override { ::unsetenv("MC_QP_DRAIN_TIMEOUT_MS"); }
 };
 
-TEST_F(QpDrainTimeoutEnvTest, DefaultIsOneHundredWhenUnset) {
+TEST_F(QpDrainTimeoutEnvTest, DefaultIsFiftyWhenUnset) {
     ::unsetenv("MC_QP_DRAIN_TIMEOUT_MS");
-    GlobalConfig config;
-    loadGlobalConfig(config);
-    EXPECT_EQ(config.qp_drain_timeout_ms, 100);
-}
-
-TEST_F(QpDrainTimeoutEnvTest, ValidOverrideIsApplied) {
-    ASSERT_EQ(::setenv("MC_QP_DRAIN_TIMEOUT_MS", "50", 1), 0);
     GlobalConfig config;
     loadGlobalConfig(config);
     EXPECT_EQ(config.qp_drain_timeout_ms, 50);
 }
 
+TEST_F(QpDrainTimeoutEnvTest, ValidOverrideIsApplied) {
+    // Use a value distinct from the default so the test fails if the override
+    // is silently ignored and the default is kept instead.
+    ASSERT_EQ(::setenv("MC_QP_DRAIN_TIMEOUT_MS", "30", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.qp_drain_timeout_ms, 30);
+}
+
 TEST_F(QpDrainTimeoutEnvTest, ZeroIsAcceptedAndDisablesWait) {
     ASSERT_EQ(::setenv("MC_QP_DRAIN_TIMEOUT_MS", "0", 1), 0);
     GlobalConfig config;
-    config.qp_drain_timeout_ms = 100;  // sentinel must be overwritten by 0
+    config.qp_drain_timeout_ms = 50;  // sentinel must be overwritten by 0
     loadGlobalConfig(config);
     EXPECT_EQ(config.qp_drain_timeout_ms, 0);
 }
 
 TEST_F(QpDrainTimeoutEnvTest, MaxBoundaryIsApplied) {
-    ASSERT_EQ(::setenv("MC_QP_DRAIN_TIMEOUT_MS", "65535", 1), 0);
+    ASSERT_EQ(::setenv("MC_QP_DRAIN_TIMEOUT_MS", "1000", 1), 0);
     GlobalConfig config;
     loadGlobalConfig(config);
-    EXPECT_EQ(config.qp_drain_timeout_ms, 65535);
+    EXPECT_EQ(config.qp_drain_timeout_ms, 1000);
 }
 
 TEST_F(QpDrainTimeoutEnvTest, OutOfRangeIsIgnored) {
-    ASSERT_EQ(::setenv("MC_QP_DRAIN_TIMEOUT_MS", "65536", 1), 0);
+    ASSERT_EQ(::setenv("MC_QP_DRAIN_TIMEOUT_MS", "1001", 1), 0);
     GlobalConfig config;
     config.qp_drain_timeout_ms = 7;  // sentinel preserved when rejected
     loadGlobalConfig(config);

--- a/mooncake-transfer-engine/tests/config_test.cpp
+++ b/mooncake-transfer-engine/tests/config_test.cpp
@@ -105,5 +105,76 @@ TEST_F(PkeyIndexEnvTest, AutoGidRetriesRejectsOutOfRangeOverride) {
     EXPECT_EQ(config.auto_gid_max_retries, 5);
 }
 
+// MC_QP_DRAIN_TIMEOUT_MS bounds the wait for a disconnected endpoint's
+// outstanding WRs to flush before the next reconnect transitions its QPs back
+// through RESET. Unlike most knobs, 0 is a valid value (disables the wait), so
+// these cases pin down that 0 is accepted while garbage/negative/out-of-range
+// preserve the default -- a typo must not silently disable the safety wait.
+class QpDrainTimeoutEnvTest : public ::testing::Test {
+   protected:
+    void TearDown() override { ::unsetenv("MC_QP_DRAIN_TIMEOUT_MS"); }
+};
+
+TEST_F(QpDrainTimeoutEnvTest, DefaultIsOneHundredWhenUnset) {
+    ::unsetenv("MC_QP_DRAIN_TIMEOUT_MS");
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.qp_drain_timeout_ms, 100);
+}
+
+TEST_F(QpDrainTimeoutEnvTest, ValidOverrideIsApplied) {
+    ASSERT_EQ(::setenv("MC_QP_DRAIN_TIMEOUT_MS", "50", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.qp_drain_timeout_ms, 50);
+}
+
+TEST_F(QpDrainTimeoutEnvTest, ZeroIsAcceptedAndDisablesWait) {
+    ASSERT_EQ(::setenv("MC_QP_DRAIN_TIMEOUT_MS", "0", 1), 0);
+    GlobalConfig config;
+    config.qp_drain_timeout_ms = 100;  // sentinel must be overwritten by 0
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.qp_drain_timeout_ms, 0);
+}
+
+TEST_F(QpDrainTimeoutEnvTest, MaxBoundaryIsApplied) {
+    ASSERT_EQ(::setenv("MC_QP_DRAIN_TIMEOUT_MS", "65535", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.qp_drain_timeout_ms, 65535);
+}
+
+TEST_F(QpDrainTimeoutEnvTest, OutOfRangeIsIgnored) {
+    ASSERT_EQ(::setenv("MC_QP_DRAIN_TIMEOUT_MS", "65536", 1), 0);
+    GlobalConfig config;
+    config.qp_drain_timeout_ms = 7;  // sentinel preserved when rejected
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.qp_drain_timeout_ms, 7);
+}
+
+TEST_F(QpDrainTimeoutEnvTest, NegativeIsIgnored) {
+    ASSERT_EQ(::setenv("MC_QP_DRAIN_TIMEOUT_MS", "-1", 1), 0);
+    GlobalConfig config;
+    config.qp_drain_timeout_ms = 11;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.qp_drain_timeout_ms, 11);
+}
+
+TEST_F(QpDrainTimeoutEnvTest, NonNumericKeepsDefault) {
+    ASSERT_EQ(::setenv("MC_QP_DRAIN_TIMEOUT_MS", "abc", 1), 0);
+    GlobalConfig config;
+    config.qp_drain_timeout_ms = 13;  // a typo must NOT silently disable
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.qp_drain_timeout_ms, 13);
+}
+
+TEST_F(QpDrainTimeoutEnvTest, EmptyStringKeepsDefault) {
+    ASSERT_EQ(::setenv("MC_QP_DRAIN_TIMEOUT_MS", "", 1), 0);
+    GlobalConfig config;
+    config.qp_drain_timeout_ms = 17;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.qp_drain_timeout_ms, 17);
+}
+
 }  // namespace
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tests/config_test.cpp
+++ b/mooncake-transfer-engine/tests/config_test.cpp
@@ -110,7 +110,7 @@ TEST_F(PkeyIndexEnvTest, AutoGidRetriesRejectsOutOfRangeOverride) {
 // Unlike most knobs, 0 is a valid value (disables the wait); the range is
 // capped at 1000ms because the drain spins with a spinlock held. These cases
 // pin down that 0 is accepted while garbage/negative/out-of-range/trailing
-// junk preserve the default -- a typo must not silently disable or mis-set the
+// junk preserve the default -- a typo must not silently disable the
 // safety wait.
 class QpDrainTimeoutEnvTest : public ::testing::Test {
    protected:
@@ -178,6 +178,78 @@ TEST_F(QpDrainTimeoutEnvTest, EmptyStringKeepsDefault) {
     config.qp_drain_timeout_ms = 17;
     loadGlobalConfig(config);
     EXPECT_EQ(config.qp_drain_timeout_ms, 17);
+}
+
+// MC_CONN_PAUSE_TTL_MS arms the active-connect circuit-breaker: after an
+// endpoint to a peer is torn down, active reconnection to that peer's address
+// is paused for this many ms so the CQ poller isn't blocked re-handshaking a
+// gone peer. 0 disables (and is the default); the range is capped at 600000ms.
+// As with the other knobs, a typo / out-of-range value must preserve the
+// default rather than silently change behavior.
+class ConnPauseTtlEnvTest : public ::testing::Test {
+   protected:
+    void TearDown() override { ::unsetenv("MC_CONN_PAUSE_TTL_MS"); }
+};
+
+TEST_F(ConnPauseTtlEnvTest, DefaultIsZeroWhenUnset) {
+    ::unsetenv("MC_CONN_PAUSE_TTL_MS");
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.conn_pause_ttl_ms, 0);
+}
+
+TEST_F(ConnPauseTtlEnvTest, ValidOverrideIsApplied) {
+    ASSERT_EQ(::setenv("MC_CONN_PAUSE_TTL_MS", "5000", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.conn_pause_ttl_ms, 5000);
+}
+
+TEST_F(ConnPauseTtlEnvTest, ZeroIsAcceptedAndDisables) {
+    ASSERT_EQ(::setenv("MC_CONN_PAUSE_TTL_MS", "0", 1), 0);
+    GlobalConfig config;
+    config.conn_pause_ttl_ms = 99;  // sentinel must be overwritten by 0
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.conn_pause_ttl_ms, 0);
+}
+
+TEST_F(ConnPauseTtlEnvTest, MaxBoundaryIsApplied) {
+    ASSERT_EQ(::setenv("MC_CONN_PAUSE_TTL_MS", "600000", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.conn_pause_ttl_ms, 600000);
+}
+
+TEST_F(ConnPauseTtlEnvTest, OutOfRangeIsIgnored) {
+    ASSERT_EQ(::setenv("MC_CONN_PAUSE_TTL_MS", "600001", 1), 0);
+    GlobalConfig config;
+    config.conn_pause_ttl_ms = 7;  // sentinel preserved when rejected
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.conn_pause_ttl_ms, 7);
+}
+
+TEST_F(ConnPauseTtlEnvTest, NegativeIsIgnored) {
+    ASSERT_EQ(::setenv("MC_CONN_PAUSE_TTL_MS", "-1", 1), 0);
+    GlobalConfig config;
+    config.conn_pause_ttl_ms = 11;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.conn_pause_ttl_ms, 11);
+}
+
+TEST_F(ConnPauseTtlEnvTest, NonNumericKeepsDefault) {
+    ASSERT_EQ(::setenv("MC_CONN_PAUSE_TTL_MS", "abc", 1), 0);
+    GlobalConfig config;
+    config.conn_pause_ttl_ms = 13;  // a typo must NOT silently change behavior
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.conn_pause_ttl_ms, 13);
+}
+
+TEST_F(ConnPauseTtlEnvTest, EmptyStringKeepsDefault) {
+    ASSERT_EQ(::setenv("MC_CONN_PAUSE_TTL_MS", "", 1), 0);
+    GlobalConfig config;
+    config.conn_pause_ttl_ms = 17;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.conn_pause_ttl_ms, 17);
 }
 
 }  // namespace

--- a/mooncake-transfer-engine/tests/connect_pause_tracker_test.cpp
+++ b/mooncake-transfer-engine/tests/connect_pause_tracker_test.cpp
@@ -1,0 +1,125 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Hardware-free unit tests for ConnectPauseTracker (the active-connect
+// circuit-breaker state). The tracker takes an injected clock, so the
+// TTL/expiry/prune logic is exercised deterministically with no RDMA device
+// and no real sleeps. The header is inline-only, so the test links just gtest.
+
+#include "transport/rdma_transport/connect_pause_tracker.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+using mooncake::ConnectPauseTracker;
+
+namespace {
+
+// Manually-advanced clock so expiry transitions are deterministic.
+struct FakeClock {
+    std::atomic<uint64_t> now{0};
+    uint64_t operator()() const { return now.load(std::memory_order_relaxed); }
+};
+
+ConnectPauseTracker makeTracker(std::shared_ptr<FakeClock> clk) {
+    return ConnectPauseTracker([clk] { return (*clk)(); });
+}
+
+TEST(ConnectPauseTracker, UnknownPeerNotPaused) {
+    auto clk = std::make_shared<FakeClock>();
+    auto t = makeTracker(clk);
+    EXPECT_FALSE(t.isPaused("10.0.0.1:1234"));
+    EXPECT_EQ(t.size(), 0u);
+}
+
+TEST(ConnectPauseTracker, PausedUntilExpiry) {
+    auto clk = std::make_shared<FakeClock>();
+    auto t = makeTracker(clk);
+    const std::string peer = "10.0.0.1:1234";
+    t.pause(peer, 1000);  // paused until ts == 1000
+    EXPECT_TRUE(t.isPaused(peer));  // now == 0
+    clk->now = 999;
+    EXPECT_TRUE(t.isPaused(peer));  // just before expiry
+    clk->now = 1000;                // at expiry (>= until)
+    EXPECT_FALSE(t.isPaused(peer));  // expired
+    EXPECT_EQ(t.size(), 0u);         // and lazily deleted on the failing check
+}
+
+TEST(ConnectPauseTracker, RefreshExtendsWindow) {
+    auto clk = std::make_shared<FakeClock>();
+    auto t = makeTracker(clk);
+    const std::string peer = "p";
+    t.pause(peer, 100);
+    clk->now = 50;
+    t.pause(peer, 200);  // re-arm while still paused -> extend
+    clk->now = 150;
+    EXPECT_TRUE(t.isPaused(peer));  // within the extended window
+    clk->now = 200;
+    EXPECT_FALSE(t.isPaused(peer));
+}
+
+TEST(ConnectPauseTracker, PruneDropsOnlyExpired) {
+    auto clk = std::make_shared<FakeClock>();
+    auto t = makeTracker(clk);
+    t.pause("a", 100);
+    t.pause("b", 300);
+    EXPECT_EQ(t.size(), 2u);
+    clk->now = 200;  // "a" expired, "b" still paused
+    t.prune();
+    EXPECT_EQ(t.size(), 1u);
+    EXPECT_FALSE(t.isPaused("a"));
+    EXPECT_TRUE(t.isPaused("b"));
+}
+
+TEST(ConnectPauseTracker, PerPeerIndependent) {
+    auto clk = std::make_shared<FakeClock>();
+    auto t = makeTracker(clk);
+    t.pause("a", 100);
+    t.pause("b", 1000);
+    clk->now = 150;
+    EXPECT_FALSE(t.isPaused("a"));  // a's window lapsed
+    EXPECT_TRUE(t.isPaused("b"));   // b's has not
+}
+
+// Hammer all entry points concurrently; primarily a ThreadSanitizer target
+// (run under -fsanitize=thread). The clock is pinned far in the future so
+// entries don't expire mid-run, isolating the data-race check.
+TEST(ConnectPauseTracker, ConcurrentAccessIsRaceFree) {
+    auto clk = std::make_shared<FakeClock>();
+    auto t = makeTracker(clk);
+    constexpr int kIters = 5000;
+    constexpr uint64_t kFarFuture = 1ull << 40;
+    std::vector<std::thread> threads;
+    for (int i = 0; i < 4; ++i)
+        threads.emplace_back([&t, i] {
+            std::string s = "peer" + std::to_string(i % 3);
+            for (int k = 0; k < kIters; ++k) t.pause(s, kFarFuture);
+        });
+    for (int i = 0; i < 4; ++i)
+        threads.emplace_back([&t] {
+            for (int k = 0; k < kIters; ++k) (void)t.isPaused("peer0");
+        });
+    threads.emplace_back([&t] {
+        for (int k = 0; k < kIters; ++k) t.prune();
+    });
+    for (auto& th : threads) th.join();
+    SUCCEED();  // TSan asserts the absence of data races
+}
+
+}  // namespace

--- a/mooncake-transfer-engine/tests/connect_pause_tracker_test.cpp
+++ b/mooncake-transfer-engine/tests/connect_pause_tracker_test.cpp
@@ -52,11 +52,11 @@ TEST(ConnectPauseTracker, PausedUntilExpiry) {
     auto clk = std::make_shared<FakeClock>();
     auto t = makeTracker(clk);
     const std::string peer = "10.0.0.1:1234";
-    t.pause(peer, 1000);  // paused until ts == 1000
+    t.pause(peer, 1000);            // paused until ts == 1000
     EXPECT_TRUE(t.isPaused(peer));  // now == 0
     clk->now = 999;
-    EXPECT_TRUE(t.isPaused(peer));  // just before expiry
-    clk->now = 1000;                // at expiry (>= until)
+    EXPECT_TRUE(t.isPaused(peer));   // just before expiry
+    clk->now = 1000;                 // at expiry (>= until)
     EXPECT_FALSE(t.isPaused(peer));  // expired
     EXPECT_EQ(t.size(), 0u);         // and lazily deleted on the failing check
 }

--- a/mooncake-transfer-engine/tests/rdma_endpoint_reestablish_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_endpoint_reestablish_test.cpp
@@ -89,6 +89,92 @@ struct RtrFaultInjectionState {
     std::unordered_map<std::string, std::vector<std::string>> rtr_gid_history;
 } g_rtr_fault_injection_state;
 
+// QP-state tracking and the DisconnectIssuesErrBeforeResetOnReconnect test
+// below are compiled only for non-eRDMA builds (USE_ERDMA=OFF). When
+// CONFIG_ERDMA is defined, RdmaEndPoint::resetConnection() reconnects via
+// reconstruct() (destroy+recreate QPs) rather than disconnectUnlocked(), so the
+// ERR-before-RESET state transition this asserts never occurs. See
+// RdmaEndPoint::resetConnection() and mooncake-common/common.cmake (USE_ERDMA).
+#ifndef CONFIG_ERDMA
+
+// Records QP state transitions to verify the disconnect ordering on reconnect:
+// a re-established endpoint must move its QP to IBV_QPS_ERR (flushing inflight
+// WRs to the CQ) BEFORE the reconnect drives the same QP back through
+// IBV_QPS_RESET. Resetting a connected QP directly, without first transitioning
+// to ERR, silently discards outstanding WRs (no CQE is generated for them).
+//
+// QPs are keyed by (pointer, generation). The generation is bumped each time a
+// pointer is handed out by ibv_create_qp, so a destroyed-then-reallocated QP
+// reusing the same address gets a fresh generation and is never conflated with
+// the QP that previously lived there. That makes the ERR-then-RESET signature
+// unambiguous: within a single generation it can only come from the
+// disconnect->reconnect path, never from beginDestroy() (which moves to ERR and
+// then destroys the QP, never RESET) nor from a fresh endpoint bring-up (which
+// starts at RESET and never sees ERR).
+struct QpStateTrackingState {
+    std::mutex mu;
+    bool enabled = false;
+    std::unordered_map<ibv_qp*, int> generation;
+    struct Event {
+        ibv_qp* qp;
+        int generation;
+        ibv_qp_state state;
+    };
+    std::vector<Event> events;
+} g_qp_state_tracking;
+
+void resetQpStateTracking() {
+    std::lock_guard<std::mutex> guard(g_qp_state_tracking.mu);
+    g_qp_state_tracking.enabled = false;
+    g_qp_state_tracking.generation.clear();
+    g_qp_state_tracking.events.clear();
+}
+
+void enableQpStateTracking() {
+    std::lock_guard<std::mutex> guard(g_qp_state_tracking.mu);
+    g_qp_state_tracking.enabled = true;
+}
+
+void recordQpCreate(ibv_qp* qp) {
+    std::lock_guard<std::mutex> guard(g_qp_state_tracking.mu);
+    ++g_qp_state_tracking.generation[qp];
+}
+
+void recordQpStateTransition(ibv_qp* qp, ibv_qp_state state) {
+    if (state != IBV_QPS_ERR && state != IBV_QPS_RESET) return;
+    std::lock_guard<std::mutex> guard(g_qp_state_tracking.mu);
+    if (!g_qp_state_tracking.enabled) return;
+    int gen = g_qp_state_tracking.generation[qp];
+    g_qp_state_tracking.events.push_back({qp, gen, state});
+}
+
+bool sawErrBeforeResetWithinGeneration() {
+    std::lock_guard<std::mutex> guard(g_qp_state_tracking.mu);
+    const auto& events = g_qp_state_tracking.events;
+    for (size_t i = 0; i < events.size(); ++i) {
+        if (events[i].state != IBV_QPS_ERR) continue;
+        for (size_t j = i + 1; j < events.size(); ++j) {
+            if (events[j].qp == events[i].qp &&
+                events[j].generation == events[i].generation &&
+                events[j].state == IBV_QPS_RESET) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+int countQpTransitions(ibv_qp_state state) {
+    std::lock_guard<std::mutex> guard(g_qp_state_tracking.mu);
+    int count = 0;
+    for (const auto& event : g_qp_state_tracking.events) {
+        if (event.state == state) ++count;
+    }
+    return count;
+}
+
+#endif  // !CONFIG_ERDMA
+
 std::string formatGidBytes(const uint8_t* raw) {
     std::ostringstream oss;
     oss << std::hex << std::setfill('0');
@@ -274,6 +360,9 @@ class RDMAEndpointReestablishTest : public ::testing::Test {
    protected:
     void SetUp() override {
         resetRtrFaultInjectionState();
+#ifndef CONFIG_ERDMA
+        resetQpStateTracking();
+#endif
         google::InitGoogleLogging("RDMAEndpointReestablishTest");
         FLAGS_logtostderr = true;
 
@@ -307,6 +396,9 @@ class RDMAEndpointReestablishTest : public ::testing::Test {
     void TearDown() override {
         google::ShutdownGoogleLogging();
         resetRtrFaultInjectionState();
+#ifndef CONFIG_ERDMA
+        resetQpStateTracking();
+#endif
     }
 
     void runEndpointReestablishScenario(const std::string& target_device,
@@ -431,6 +523,45 @@ TEST_F(RDMAEndpointReestablishTest,
         [&](const std::string& gid) { return gid != gid_history.front(); }));
 }
 
+// Covers the disconnect ordering on reconnect for non-eRDMA builds. When an
+// already-connected endpoint is re-established, disconnectUnlocked() must
+// transition its QP to IBV_QPS_ERR (so the HCA flushes outstanding WRs as
+// completions, which performPollCq drains through the normal failure path)
+// before the reconnect drives the same QP back through IBV_QPS_RESET. Resetting
+// the QP straight from a connected state drops inflight WRs without ever
+// generating a CQE. See disconnectUnlocked() in rdma_endpoint.cpp.
+//
+// Triggering the re-establish requires the restarted peer to reconnect under
+// the SAME nic_path with new QPs, which only happens when peer names are stable
+// across the restart -- i.e. a real metadata server. Under P2PHANDSHAKE every
+// restart gets a fresh random RPC port, so the endpoint is never reused and the
+// disconnect path is not exercised; skip in that case.
+#ifndef CONFIG_ERDMA
+TEST_F(RDMAEndpointReestablishTest, DisconnectIssuesErrBeforeResetOnReconnect) {
+    if (usesP2PHandshake(metadata_server)) {
+        GTEST_SKIP() << "Re-establish (and thus the ERR disconnect path) is not "
+                        "triggered under P2PHANDSHAKE; run with a metadata "
+                        "server (e.g. MC_METADATA_SERVER=http://host:port/"
+                        "metadata) and stable MC_*_SERVER_NAME to exercise it";
+    }
+
+    enableQpStateTracking();
+    runEndpointReestablishScenario(target_device_name, initiator_device_name);
+
+    // The reconnect must have flushed at least one QP through ERR. If the
+    // disconnect path reset QPs directly (no ERR transition) this would be zero.
+    EXPECT_GT(countQpTransitions(IBV_QPS_ERR), 0)
+        << "Expected the reconnect to flush QPs via IBV_QPS_ERR, but no ERR "
+           "transition was observed";
+
+    // The core invariant: within a single QP generation, ERR precedes RESET.
+    EXPECT_TRUE(sawErrBeforeResetWithinGeneration())
+        << "Expected a QP to be moved to IBV_QPS_ERR before being reset on "
+           "reconnect; the disconnect path must not RESET a connected QP "
+           "directly (that silently discards inflight WRs without CQEs)";
+}
+#endif  // !CONFIG_ERDMA
+
 }  // namespace
 
 extern "C" int __real__ibv_query_gid_ex(ibv_context* context, uint8_t port_num,
@@ -458,11 +589,32 @@ extern "C" int __wrap_ibv_query_gid(ibv_context* context, uint8_t port_num,
     return __real_ibv_query_gid(context, port_num, wrapped_gid_index, gid);
 }
 
+// Only wrapped for non-eRDMA builds; the linker --wrap flag is added in
+// CMakeLists.txt under the same USE_ERDMA guard.
+#ifndef CONFIG_ERDMA
+extern "C" struct ibv_qp* __real_ibv_create_qp(struct ibv_pd* pd,
+                                               struct ibv_qp_init_attr* attr);
+
+extern "C" struct ibv_qp* __wrap_ibv_create_qp(struct ibv_pd* pd,
+                                               struct ibv_qp_init_attr* attr) {
+    struct ibv_qp* qp = __real_ibv_create_qp(pd, attr);
+    if (qp != nullptr) {
+        recordQpCreate(qp);
+    }
+    return qp;
+}
+#endif  // !CONFIG_ERDMA
+
 extern "C" int __real_ibv_modify_qp(ibv_qp* qp, ibv_qp_attr* attr,
                                     int attr_mask);
 
 extern "C" int __wrap_ibv_modify_qp(ibv_qp* qp, ibv_qp_attr* attr,
                                     int attr_mask) {
+#ifndef CONFIG_ERDMA
+    if (qp != nullptr && attr != nullptr && (attr_mask & IBV_QP_STATE)) {
+        recordQpStateTransition(qp, attr->qp_state);
+    }
+#endif  // !CONFIG_ERDMA
     if (qp != nullptr && attr != nullptr && attr->qp_state == IBV_QPS_RTR &&
         (attr_mask & IBV_QP_AV)) {
         const std::string device_name =

--- a/mooncake-transfer-engine/tests/rdma_endpoint_reestablish_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_endpoint_reestablish_test.cpp
@@ -550,7 +550,8 @@ TEST_F(RDMAEndpointReestablishTest, DisconnectIssuesErrBeforeResetOnReconnect) {
     runEndpointReestablishScenario(target_device_name, initiator_device_name);
 
     // The reconnect must have flushed at least one QP through ERR. If the
-    // disconnect path reset QPs directly (no ERR transition) this would be zero.
+    // disconnect path reset QPs directly (no ERR transition) this would be
+    // zero.
     EXPECT_GT(countQpTransitions(IBV_QPS_ERR), 0)
         << "Expected the reconnect to flush QPs via IBV_QPS_ERR, but no ERR "
            "transition was observed";

--- a/mooncake-transfer-engine/tests/rdma_endpoint_reestablish_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_endpoint_reestablish_test.cpp
@@ -539,10 +539,11 @@ TEST_F(RDMAEndpointReestablishTest,
 #ifndef CONFIG_ERDMA
 TEST_F(RDMAEndpointReestablishTest, DisconnectIssuesErrBeforeResetOnReconnect) {
     if (usesP2PHandshake(metadata_server)) {
-        GTEST_SKIP() << "Re-establish (and thus the ERR disconnect path) is not "
-                        "triggered under P2PHANDSHAKE; run with a metadata "
-                        "server (e.g. MC_METADATA_SERVER=http://host:port/"
-                        "metadata) and stable MC_*_SERVER_NAME to exercise it";
+        GTEST_SKIP()
+            << "Re-establish (and thus the ERR disconnect path) is not "
+               "triggered under P2PHANDSHAKE; run with a metadata "
+               "server (e.g. MC_METADATA_SERVER=http://host:port/"
+               "metadata) and stable MC_*_SERVER_NAME to exercise it";
     }
 
     enableQpStateTracking();

--- a/mooncake-transfer-engine/tests/rdma_endpoint_reestablish_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_endpoint_reestablish_test.cpp
@@ -29,6 +29,7 @@
  */
 
 #include <algorithm>
+#include <atomic>
 #include <cerrno>
 #include <cstdlib>
 #include <fstream>
@@ -122,6 +123,12 @@ struct QpStateTrackingState {
     };
     std::vector<Event> events;
 } g_qp_state_tracking;
+
+// When set, the wrapped ibv_query_qp reports IBV_QPS_RESET, exercising the
+// disconnectUnlocked() guard that skips the QP->ERR flush for an already-RESET
+// QP (RESET->ERR is illegal and returns EINVAL). Drives
+// SkipsErrFlushWhenQpReportedReset.
+std::atomic<bool> g_force_qp_state_reset{false};
 
 void resetQpStateTracking() {
     std::lock_guard<std::mutex> guard(g_qp_state_tracking.mu);
@@ -562,6 +569,35 @@ TEST_F(RDMAEndpointReestablishTest, DisconnectIssuesErrBeforeResetOnReconnect) {
            "reconnect; the disconnect path must not RESET a connected QP "
            "directly (that silently discards inflight WRs without CQEs)";
 }
+
+// Covers the disconnectUnlocked() guard that skips the QP->ERR flush when the
+// QP is already in RESET (RESET->ERR is illegal and returns EINVAL[22], the
+// log-flood the guard removes). With ibv_query_qp forced to report RESET, the
+// reconnect's disconnect must NOT attempt the ERR flush, so the reused QP
+// generation goes to RESET with no preceding ERR -- the ERR-before-RESET
+// signature that DisconnectIssuesErrBeforeResetOnReconnect asserts is absent.
+// (beginDestroy's ERR-then-destroy never produces ERR-before-RESET within a
+// generation, so it can't make this assertion pass spuriously.)
+TEST_F(RDMAEndpointReestablishTest, SkipsErrFlushWhenQpReportedReset) {
+    if (usesP2PHandshake(metadata_server)) {
+        GTEST_SKIP()
+            << "Re-establish (and thus the disconnect path) is not triggered "
+               "under P2PHANDSHAKE; run with a metadata server and stable "
+               "MC_*_SERVER_NAME to exercise it";
+    }
+
+    enableQpStateTracking();
+    // Make disconnectUnlocked()'s state query see RESET for the duration of the
+    // scenario so its guard skips the ERR flush.
+    g_force_qp_state_reset.store(true, std::memory_order_relaxed);
+    runEndpointReestablishScenario(target_device_name, initiator_device_name);
+    g_force_qp_state_reset.store(false, std::memory_order_relaxed);
+
+    EXPECT_FALSE(sawErrBeforeResetWithinGeneration())
+        << "Expected disconnectUnlocked to SKIP the QP->ERR flush when the QP "
+           "is reported RESET (the guard), so no ERR-before-RESET transition "
+           "should be recorded for the reused QP generation";
+}
 #endif  // !CONFIG_ERDMA
 
 }  // namespace
@@ -604,6 +640,23 @@ extern "C" struct ibv_qp* __wrap_ibv_create_qp(struct ibv_pd* pd,
         recordQpCreate(qp);
     }
     return qp;
+}
+
+// Wrapped (non-eRDMA only) so SkipsErrFlushWhenQpReportedReset can make
+// disconnectUnlocked()'s state query report RESET on demand. Delegates to the
+// real call and only overrides the reported state when the toggle is set, so
+// it is a no-op for every other caller and when the toggle is off.
+extern "C" int __real_ibv_query_qp(ibv_qp* qp, ibv_qp_attr* attr, int attr_mask,
+                                   ibv_qp_init_attr* init_attr);
+
+extern "C" int __wrap_ibv_query_qp(ibv_qp* qp, ibv_qp_attr* attr, int attr_mask,
+                                   ibv_qp_init_attr* init_attr) {
+    int rc = __real_ibv_query_qp(qp, attr, attr_mask, init_attr);
+    if (rc == 0 && attr != nullptr &&
+        g_force_qp_state_reset.load(std::memory_order_relaxed)) {
+        attr->qp_state = IBV_QPS_RESET;
+    }
+    return rc;
 }
 #endif  // !CONFIG_ERDMA
 


### PR DESCRIPTION
## Description

### Motivation

During a rolling restart — or any time a peer process exits mid-transfer — the local NIC still has RDMA work requests posted to the now-dead peer. When the endpoint is later re-established, its QP must be torn down before it can be reused, and that teardown is where the bug bites.

Tearing a QP down by transitioning it straight to `RESET` (or destroying it) **silently discards any still-outstanding WRs without generating a completion**. The transfer engine drives slice/task completion entirely off CQEs (`markSuccess()` / `markFailed()`), so a WR that never produces a CQE leaves its slice stuck in `POSTED` forever: the owning task's `success_slice_count + failed_slice_count` never reaches `slice_count`, the task never reaches a terminal state, and `getTransferStatus()` keeps reporting non-terminal.

The only backstop is the store-layer per-batch wait, a hardcoded ~60s deadline. So instead of failing fast in ~0.5s (the normal `IBV_WC_RETRY_EXC_ERR` a dead peer produces, which terminates the slice and lets the caller recompute), **every batch carrying an orphaned slice stalls for the full ~60s**. In a serial receive path that head-of-line-blocks everything queued behind it and pins the buffers those requests hold, so a single rolling restart can wedge workers for far longer than the restart itself — failures that should have been ~0.5s become minutes.

The correct teardown is the one `beginDestroy()` already uses: move the QP to `IBV_QPS_ERR` **first**, so the HCA *flushes* every outstanding WR to the CQ as `IBV_WC_WR_FLUSH_ERR`. `performPollCq` then drains them through the normal `markFailed()` path — the slices terminate in milliseconds, the task fails fast, and the caller recomputes instead of stalling.

### Root cause

`disconnectUnlocked()` already performs this ERR-before-RESET flush. But `CONFIG_ERDMA` was defined **unconditionally** in `mooncake-common/common.cmake`, so every build — including standard mlx5 RDMA — took the eRDMA-only `resetConnection()` → `reconstruct()` path instead. `reconstruct()` destroys and recreates the QPs via `deconstructLocked()`, which drops in-flight WRs (`"Outstanding work requests found, CQ will not be generated"`) — exactly the orphaning described above. eRDMA genuinely needs `reconstruct()` (an eRDMA QP cannot transition `RTS → RTS`), but standard RDMA does not, and should get the flush.

### Fix (non-eRDMA)

- Gate the eRDMA workaround behind a new cmake option `USE_ERDMA` (default **ON**, preserving current behavior). Non-eRDMA builds (`-DUSE_ERDMA=OFF`) now take `disconnectUnlocked()`'s ERR-before-RESET flush path.
- Add `MC_QP_DRAIN_TIMEOUT_MS` + `drainWrDepthLocked()`: before the reconnect re-`RESET`s a QP, wait (bounded, default 100 ms) for the ERR-generated flush CQEs to drain so the WRs aren't re-orphaned. A timeout is not fatal — the flush CQEs survive the RESET and still drain the counters as they are polled, so the per-QP path only logs the residual rather than compensating (which would double-count).
- A lock-free status pre-check in `submitPostSend()` lets a posting worker bail before contending for `lock_`, so it can't block the CQ poller that the reconnect's drain depends on — relevant in the default single-CQ topology, where the posting worker is also the only poller.

### Why gate onto `disconnectUnlocked()` rather than patch `reconstruct()`?

A natural alternative is to add the ERR-flush directly to the eRDMA `reconstruct()` path. We chose the gate instead because the two teardown mechanisms **degrade differently when the bounded drain times out**, due to how each disposes of the QP's not-yet-polled flush CQEs:

- **RESET-reuse (`disconnectUnlocked`, this fix):** transitioning to `RESET` *retains* already-generated CQEs in the CQ. On a drain timeout, the flush CQEs survive the RESET and are polled on the next `performPollCq` cycle (sub-second), so the slices still terminate — just slightly later. The drain is a promptness optimization, **not** a correctness dependency.
- **Destroy-and-recreate (`reconstruct`):** `ibv_destroy_qp` *purges* the QP's unpolled CQEs (it must, to avoid completions with dangling `wr_id`s into freed slices). On a drain timeout there, those CQEs are gone, the slices are orphaned, and the batch falls back to the full deadline — i.e. **a drain timeout re-introduces the original bug**. Such a fix would also only be as good as eRDMA actually flushing on ERR, which the existing `finishDestroy()` 30s-timeout fallback suggests is not fully trusted.

So routing standard RDMA through `disconnectUnlocked()` isn't merely less code — it lands on the mechanism that **degrades gracefully** (timeout → slightly slower, still fixed) instead of the one that degrades back to the bug (timeout → orphan → full deadline). Hardening `reconstruct()` for genuine eRDMA deployments is worthwhile as a follow-up, but needs eRDMA-hardware validation and is out of scope here.

> **Note on the default:** `USE_ERDMA=ON` is kept as the default because defaulting OFF would route eRDMA builds down `disconnectUnlocked()` (the illegal `RTS → RTS`) unless they explicitly opt back in. Non-eRDMA deployments should build with `-DUSE_ERDMA=OFF` to get the fix. Happy to flip the default if maintainers prefer.

**eRDMA behavior is unchanged.**

### Also in this PR: keep the CQ poller free under peer churn

The ERR-flush above is correct, but it only helps if `performPollCq` actually **drains** the flush CQEs before the QP is destroyed. In the default single-CQ topology the one poller thread is *also* the thread that runs the blocking `setupConnectionsByActive` handshake (connections are established lazily on the posting path). During a rolling deploy a peer is **replaced at a different podIP:port** — the old address is dead — but the worker still has slices bound to it, so it keeps blocking on handshakes that hang to their RPC timeout. While blocked it isn't draining the flush CQEs, so the 30s `finishDestroy` force-destroys those QPs and `ibv_destroy_qp` discards the un-polled CQEs — re-orphaning the slices and re-introducing the wedge despite the ERR-flush. The starvation, not a missing terminal path, is what's left.

Two changes keep the poller free (both non-eRDMA-scoped):

- **Active-connect circuit-breaker** (`MC_CONN_PAUSE_TTL_MS`, default `0` = disabled). When `deleteEndpointByPtr` tears an endpoint down (path failure / QP fatal), it arms a per-`RdmaContext` pause for that peer's address. `setupConnectionsByActive` then fast-fails while the pause is in effect instead of blocking on a handshake to a likely-gone peer, so the sole CQ poller stays free and drains the flush CQEs before `finishDestroy`'s deadline. The not-yet-posted slices fail/redispatch. Entries are keyed by peer **server name** (a replacement pod at a new podIP is a fresh key, never blocked) and expire by TTL — lazily on check and via a `monitorWorker` prune tick. Set the TTL to roughly the peer/client liveness window to enable.
- **Skip the illegal `RESET → ERR`** in `disconnectUnlocked()`: query the QP state and only attempt the `→ERR` flush when the QP is not already in `RESET` (`RESET → ERR` is rejected with `EINVAL[22]`). This removes the `EINVAL[22]` / `error=-201` log floods and the pointless RESET-fallback while preserving the counter compensation; a teardown of an already-RESET QP no longer returns a spurious error.

A CQE-independent terminal path (per-QP inflight-slice registry that `markFailed`s after `ibv_destroy_qp`) was considered as a hard guarantee for the residual cases the breaker doesn't cover (an extreme multi-peer storm that blocks the poller > 30s, or a genuine hardware `RTS→ERR` failure). It is deferred — under the always-flush-before-RESET invariant the breaker is sufficient — and can be added as a follow-up if orphans persist under load.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [x] Common (`mooncake-common`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

**Test commands:**
```bash
# Unit (CI, no hardware): MC_QP_DRAIN_TIMEOUT_MS parsing
ctest -R config_test

# RDMA hardware (2x mlx5), non-eRDMA build, with a metadata server for stable names:
cmake -DBUILD_UNIT_TESTS=ON -DUSE_ERDMA=OFF ...
MC_METADATA_SERVER=http://127.0.0.1:8080/metadata \
  MC_TARGET_SERVER_NAME=127.0.0.1:12345 MC_INITIATOR_SERVER_NAME=127.0.0.1:12346 \
  MC_TARGET_DEVICE_NAME=mlx5_0 MC_INITIATOR_DEVICE_NAME=mlx5_1 \
  ./rdma_endpoint_reestablish_test --gtest_filter='*DisconnectIssuesErrBeforeResetOnReconnect*'
```

**Test results (on 2× mlx5):**
- `config_test`: pass.
- `DisconnectIssuesErrBeforeResetOnReconnect`:
  - `USE_ERDMA=OFF` + http metadata + stable names → **PASS** (re-establish issues ERR before RESET per QP generation; data reads back correctly).
  - `USE_ERDMA=OFF` + `P2PHANDSHAKE` → **SKIPPED** (re-establish not triggered without stable peer names).
  - `USE_ERDMA=ON` (default) → the case is compiled out; the other four cases in the binary are unchanged.

**Follow-up changes (circuit-breaker + skip-`RESET→ERR`):** compile-checked on `USE_ERDMA=ON` and `OFF`, with tests:
- `config_test` — 8 `ConnPauseTtlEnvTest` cases for `MC_CONN_PAUSE_TTL_MS` parsing (default 0 / valid / zero / max 600000 / out-of-range / negative / non-numeric / empty). CI, pass.
- `connect_pause_tracker_test` — 6 cases for the circuit-breaker state (`ConnectPauseTracker`, extracted as a clock-injectable header so its TTL / expiry / prune logic is unit-testable without hardware): unknown-peer, pause-until-expiry, refresh-extends, prune-drops-only-expired, per-peer-independent, and concurrent (ThreadSanitizer-clean). CI, pass.
- `rdma_endpoint_reestablish_test::SkipsErrFlushWhenQpReportedReset` — wraps `ibv_query_qp` to report RESET and asserts `disconnectUnlocked` skips the `→ERR` flush (no ERR-before-RESET for the reused QP generation). HW-gated (`GTEST_SKIP` without a metadata server + ≥2 devices), `USE_ERDMA=OFF`.

The circuit-breaker is **default-off**, so it is a no-op unless `MC_CONN_PAUSE_TTL_MS` is set; the skip-`RESET→ERR` guard preserves the existing counter compensation. Also validated manually with the 2-pod kill test below.

- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (RDMA hardware, see above)

Manual test by running 2 pods and killing one. Verified logs and the remaining pod recovered quickly. Rolled out with more nodes:

<img width="762" height="201" alt="Screenshot 2026-06-12 at 8 47 30 PM" src="https://github.com/user-attachments/assets/1a4bcd63-3bd1-4306-ad7b-f8ce6a89e03a" />
<img width="1527" height="291" alt="Screenshot 2026-06-12 at 8 47 35 PM" src="https://github.com/user-attachments/assets/9fb27a80-783a-4b8e-a972-cc17f8124cd7" />


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh` (clang-format-20 was unavailable in my environment; please confirm via CI)
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue (N/A — diff is < 500 LOC)

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

Claude Code (Anthropic) assisted with: root-causing the unconditionally-defined `CONFIG_ERDMA` that bypassed the ERR-flush on the reconnect path, tracing the orphaned-slice → non-terminal-task → ~60s store-deadline impact chain, designing the `USE_ERDMA` cmake option, and writing the `DisconnectIssuesErrBeforeResetOnReconnect` test (QP-generation tracking via `ibv_create_qp` / `ibv_modify_qp` `--wrap` hooks). It also assisted with the follow-up that keeps the CQ poller free during peer churn — establishing that the residual wedge is poller starvation (flush CQEs discarded by `finishDestroy` while the poller is blocked re-handshaking a replaced peer), and designing the `MC_CONN_PAUSE_TTL_MS` active-connect circuit-breaker and the skip-illegal-`RESET→ERR` guard in `disconnectUnlocked`. The submitter has reviewed and is responsible for all changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


