### PR TITLE
[BugFix]adapt dram tier to ascend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ endif()
 
 option(STORE_USE_JEMALLOC "Use jemalloc in mooncake store master" OFF)
 option(USE_ASCEND_CACHE_TIER "Enable Ascend NPU cache tier support" OFF)
+option(USE_ASCEND_DRAM_TIER "Enable Ascend ACL Host memory for DRAM tier (aclrtMallocHost)" OFF)
 
 # Define ASIO macros before adding mooncake-asio subdirectory
 add_compile_definitions(ASIO_SEPARATE_COMPILATION ASIO_DYN_LINK)

--- a/mooncake-store/include/tiered_cache/tiers/dram_tier.h
+++ b/mooncake-store/include/tiered_cache/tiers/dram_tier.h
@@ -34,6 +34,12 @@ class DramCacheTier : public CacheTier {
     MemoryType GetMemoryType() const override { return MemoryType::DRAM; }
 
    private:
+    tl::expected<std::string, ErrorCode> AllocateMemory();
+    tl::expected<void, ErrorCode> RegisterWithEngine(
+        const std::string& location);
+    tl::expected<std::shared_ptr<BufferAllocatorBase>, ErrorCode>
+    CreateAllocator();
+
     UUID tier_id_;
     size_t capacity_;
     std::vector<std::string> tags_;

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -81,6 +81,11 @@ if(USE_ASCEND_CACHE_TIER)
   message(STATUS "Ascend Cache Tier enabled")
 endif()
 
+# Ascend DRAM Tier support (aclrtMallocHost-based DRAM allocation)
+if(USE_ASCEND_DRAM_TIER)
+  message(STATUS "Ascend DRAM Tier enabled")
+endif()
+
 # The cache_allocator library
 include_directories(${Python3_INCLUDE_DIRS})
 add_library(mooncake_store ${MOONCAKE_STORE_SOURCES})
@@ -126,6 +131,34 @@ if(USE_ASCEND_CACHE_TIER)
 
     # Only define USE_ASCEND_CACHE_TIER when library is found
     target_compile_definitions(mooncake_store PUBLIC USE_ASCEND_CACHE_TIER)
+  endif()
+endif()
+
+# Link Ascend ACL library if USE_ASCEND_DRAM_TIER is enabled
+if(USE_ASCEND_DRAM_TIER)
+  if(NOT ASCENDCL_LIB)
+    set(ASCEND_SEARCH_PATHS
+        $ENV{ASCEND_HOME}/lib64
+        /usr/local/Ascend/ascend-toolkit/latest/lib64
+        /usr/local/Ascend/nnrt/latest/lib64
+    )
+    find_library(ASCENDCL_LIB ascendcl PATHS ${ASCEND_SEARCH_PATHS} NO_DEFAULT_PATH)
+  endif()
+
+  if(NOT ASCENDCL_LIB)
+    message(FATAL_ERROR "ascendcl library not found, USE_ASCEND_DRAM_TIER requires it")
+  else()
+    message(STATUS "Found ascendcl library for DRAM tier: ${ASCENDCL_LIB}")
+    if(NOT USE_ASCEND_CACHE_TIER)
+      target_link_libraries(mooncake_store PUBLIC ${ASCENDCL_LIB})
+      set(ASCEND_INCLUDE_PATHS
+          $ENV{ASCEND_HOME}/include
+          /usr/local/Ascend/ascend-toolkit/latest/include
+          /usr/local/Ascend/nnrt/latest/include
+      )
+      target_include_directories(mooncake_store PUBLIC ${ASCEND_INCLUDE_PATHS})
+    endif()
+    target_compile_definitions(mooncake_store PUBLIC USE_ASCEND_DRAM_TIER)
   endif()
 endif()
 if (STORE_USE_ETCD)

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -136,7 +136,9 @@ endif()
 
 # Link Ascend ACL library if USE_ASCEND_DRAM_TIER is enabled
 if(USE_ASCEND_DRAM_TIER)
+  set(NEED_LINK_ASCEND FALSE)
   if(NOT ASCENDCL_LIB)
+    set(NEED_LINK_ASCEND TRUE)
     set(ASCEND_SEARCH_PATHS
         $ENV{ASCEND_HOME}/lib64
         /usr/local/Ascend/ascend-toolkit/latest/lib64
@@ -149,7 +151,7 @@ if(USE_ASCEND_DRAM_TIER)
     message(FATAL_ERROR "ascendcl library not found, USE_ASCEND_DRAM_TIER requires it")
   else()
     message(STATUS "Found ascendcl library for DRAM tier: ${ASCENDCL_LIB}")
-    if(NOT USE_ASCEND_CACHE_TIER)
+    if(NEED_LINK_ASCEND)
       target_link_libraries(mooncake_store PUBLIC ${ASCENDCL_LIB})
       set(ASCEND_INCLUDE_PATHS
           $ENV{ASCEND_HOME}/include

--- a/mooncake-store/src/tiered_cache/data_copier.cpp
+++ b/mooncake-store/src/tiered_cache/data_copier.cpp
@@ -2,6 +2,10 @@
 #include <memory>
 #include <utility>
 
+#ifdef USE_ASCEND_DRAM_TIER
+#include "acl/acl.h"
+#endif
+
 #include "tiered_cache/tiers/cache_tier.h"
 #include "tiered_cache/copier_registry.h"
 #include "tiered_cache/data_copier.h"
@@ -42,7 +46,18 @@ tl::expected<void, ErrorCode> CopyDramToDram(const DataSource& src,
         return tl::unexpected(ErrorCode::BUFFER_OVERFLOW);
     }
 
+    #ifdef USE_ASCEND_DRAM_TIER
+    aclError acl_ret = aclrtMemcpy(dest_ptr, dest.buffer->size(),
+                                    src_ptr, size,
+                                    ACL_MEMCPY_HOST_TO_HOST);
+    if (acl_ret != ACL_SUCCESS) {
+        LOG(ERROR) << "aclrtMemcpy(HOST_TO_HOST) failed for " << size
+                   << " bytes, ACL error: " << acl_ret;
+        return tl::unexpected(ErrorCode::DATA_COPY_FAILED);
+    }
+#else
     memcpy(dest_ptr, src_ptr, size);
+#endif
     return tl::expected<void, ErrorCode>{};
 }
 

--- a/mooncake-store/src/tiered_cache/data_copier.cpp
+++ b/mooncake-store/src/tiered_cache/data_copier.cpp
@@ -2,10 +2,6 @@
 #include <memory>
 #include <utility>
 
-#ifdef USE_ASCEND_DRAM_TIER
-#include "acl/acl.h"
-#endif
-
 #include "tiered_cache/tiers/cache_tier.h"
 #include "tiered_cache/copier_registry.h"
 #include "tiered_cache/data_copier.h"
@@ -46,18 +42,7 @@ tl::expected<void, ErrorCode> CopyDramToDram(const DataSource& src,
         return tl::unexpected(ErrorCode::BUFFER_OVERFLOW);
     }
 
-    #ifdef USE_ASCEND_DRAM_TIER
-    aclError acl_ret = aclrtMemcpy(dest_ptr, dest.buffer->size(),
-                                    src_ptr, size,
-                                    ACL_MEMCPY_HOST_TO_HOST);
-    if (acl_ret != ACL_SUCCESS) {
-        LOG(ERROR) << "aclrtMemcpy(HOST_TO_HOST) failed for " << size
-                   << " bytes, ACL error: " << acl_ret;
-        return tl::unexpected(ErrorCode::DATA_COPY_FAILED);
-    }
-#else
     memcpy(dest_ptr, src_ptr, size);
-#endif
     return tl::expected<void, ErrorCode>{};
 }
 

--- a/mooncake-store/src/tiered_cache/tiers/dram_tier.cpp
+++ b/mooncake-store/src/tiered_cache/tiers/dram_tier.cpp
@@ -244,15 +244,25 @@ tl::expected<void, ErrorCode> DramCacheTier::Init(TieredBackend* backend,
     if (engine != nullptr) engine_ = engine;
 
     auto alloc_result = AllocateMemory();
-    if (!alloc_result) return tl::unexpected(alloc_result.error());
+    if (!alloc_result) {
+        LOG(ERROR) << "DramCacheTier " << tier_id_
+                   << " Init failed: AllocateMemory error";
+        return tl::unexpected(alloc_result.error());
+    }
 
     if (engine_) {
         auto reg = RegisterWithEngine(*alloc_result);
-        if (!reg) return tl::unexpected(reg.error());
+        if (!reg) {
+            LOG(ERROR) << "DramCacheTier " << tier_id_
+                       << " Init failed: RegisterWithEngine error";
+            return tl::unexpected(reg.error());
+        }
     }
 
     auto alloc = CreateAllocator();
     if (!alloc) {
+        LOG(ERROR) << "DramCacheTier " << tier_id_
+                   << " Init failed: CreateAllocator error, rolling back";
         if (engine_) engine_->unregisterLocalMemory(memory_buffer_.get());
         return tl::unexpected(alloc.error());
     }

--- a/mooncake-store/src/tiered_cache/tiers/dram_tier.cpp
+++ b/mooncake-store/src/tiered_cache/tiers/dram_tier.cpp
@@ -75,12 +75,8 @@ DramCacheTier::~DramCacheTier() {
     }
 }
 
-tl::expected<void, ErrorCode> DramCacheTier::Init(TieredBackend* backend,
-                                                  TransferEngine* engine) {
-    backend_ = backend;
-    if (engine != nullptr) engine_ = engine;
-
 #ifdef USE_ASCEND_DRAM_TIER
+tl::expected<std::string, ErrorCode> DramCacheTier::AllocateMemory() {
     int current_device = -1;
     aclError acl_ret = aclrtGetDevice(&current_device);
     if (acl_ret != ACL_SUCCESS) {
@@ -101,11 +97,20 @@ tl::expected<void, ErrorCode> DramCacheTier::Init(TieredBackend* backend,
         return tl::unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
     }
     memory_buffer_ = std::unique_ptr<char[], std::function<void(char*)>>(
-        static_cast<char*>(host_ptr),
-        [](char* p) { aclrtFreeHost(static_cast<void*>(p)); });
+        static_cast<char*>(host_ptr), [current_device](char* p) {
+            int dev = -1;
+            if (aclrtGetDevice(&dev) != ACL_SUCCESS) {
+                aclrtSetDevice(current_device);
+            }
+            aclrtFreeHost(static_cast<void*>(p));
+        });
     LOG(INFO) << "Allocated " << capacity_ << " bytes (ACL Host Pinned) "
               << "for DramCacheTier " << tier_id_;
+
+    return std::string(kWildcardLocation);
+}
 #else
+tl::expected<std::string, ErrorCode> DramCacheTier::AllocateMemory() {
     int node = -1;
 
     const bool use_hugepage = (std::getenv("MC_STORE_USE_HUGEPAGE") != nullptr);
@@ -186,61 +191,77 @@ tl::expected<void, ErrorCode> DramCacheTier::Init(TieredBackend* backend,
         LOG(INFO) << "Allocated " << capacity_ << " bytes for DramCacheTier "
                   << tier_id_;
     }
-#endif
-    char* mem_ptr = memory_buffer_.get();
 
-#ifdef USE_ASCEND_DRAM_TIER
-    std::string location = kWildcardLocation;
-#else
-    std::string location;
     if (node != -1) {
-        location = "cpu:" + std::to_string(node);
-    } else {
-        location = kWildcardLocation;
+        return "cpu:" + std::to_string(node);
     }
+    return std::string(kWildcardLocation);
+}
 #endif
 
-    if (engine_) {
-        int rc = engine_->registerLocalMemory(mem_ptr, capacity_, location);
-        if (rc != 0) {
-            LOG(ERROR) << "Failed to register memory with TransferEngine for "
-                          "DramCacheTier "
-                       << tier_id_ << ", engine ret is " << rc;
-            return tl::unexpected(ErrorCode::INTERNAL_ERROR);
-        } else {
-            LOG(INFO)
-                << "registered memory with TransferEngine for DramCacheTier "
-                << tier_id_ << " at " << static_cast<void*>(mem_ptr);
-        }
+tl::expected<void, ErrorCode> DramCacheTier::RegisterWithEngine(
+    const std::string& location) {
+    char* mem_ptr = memory_buffer_.get();
+    int rc = engine_->registerLocalMemory(mem_ptr, capacity_, location);
+    if (rc != 0) {
+        LOG(ERROR) << "Failed to register memory with TransferEngine for "
+                      "DramCacheTier "
+                   << tier_id_ << ", engine ret is " << rc;
+        return tl::unexpected(ErrorCode::INTERNAL_ERROR);
     }
+    LOG(INFO) << "registered memory with TransferEngine for DramCacheTier "
+              << tier_id_ << " at " << static_cast<void*>(mem_ptr);
+    return {};
+}
 
-    // Use the address of this registered block as the base_address for the
-    // allocator.
-    const uintptr_t base_address = reinterpret_cast<uintptr_t>(mem_ptr);
+tl::expected<std::shared_ptr<BufferAllocatorBase>, ErrorCode>
+DramCacheTier::CreateAllocator() {
+    const uintptr_t base_address =
+        reinterpret_cast<uintptr_t>(memory_buffer_.get());
     std::string segment_name = "dram_tier_" + std::to_string(tier_id_.first) +
                                "-" + std::to_string(tier_id_.second);
 
+    std::shared_ptr<BufferAllocatorBase> allocator;
     switch (allocator_type_) {
         case BufferAllocatorType::OFFSET:
-            allocator_ = std::make_shared<OffsetBufferAllocator>(
+            allocator = std::make_shared<OffsetBufferAllocator>(
                 segment_name, base_address, capacity_, segment_name, tier_id_);
             break;
         case BufferAllocatorType::CACHELIB:
-            allocator_ = std::make_shared<CachelibBufferAllocator>(
+            allocator = std::make_shared<CachelibBufferAllocator>(
                 segment_name, base_address, capacity_, segment_name, tier_id_);
             break;
         default:
             LOG(ERROR) << "Unsupported allocator type for DramCacheTier";
-            if (engine_) {
-                engine_->unregisterLocalMemory(mem_ptr);
-            }
             return tl::unexpected(ErrorCode::INVALID_PARAMS);
     }
+    return allocator;
+}
+
+tl::expected<void, ErrorCode> DramCacheTier::Init(TieredBackend* backend,
+                                                  TransferEngine* engine) {
+    backend_ = backend;
+    if (engine != nullptr) engine_ = engine;
+
+    auto alloc_result = AllocateMemory();
+    if (!alloc_result) return tl::unexpected(alloc_result.error());
+
+    if (engine_) {
+        auto reg = RegisterWithEngine(*alloc_result);
+        if (!reg) return tl::unexpected(reg.error());
+    }
+
+    auto alloc = CreateAllocator();
+    if (!alloc) {
+        if (engine_) engine_->unregisterLocalMemory(memory_buffer_.get());
+        return tl::unexpected(alloc.error());
+    }
+    allocator_ = std::move(*alloc);
 
     LOG(INFO) << "DramCacheTier " << tier_id_ << " initialized and registered "
               << capacity_ << " bytes at base address 0x" << std::hex
-              << base_address;
-    return tl::expected<void, ErrorCode>{};
+              << reinterpret_cast<uintptr_t>(memory_buffer_.get());
+    return {};
 }
 
 size_t DramCacheTier::GetUsage() const {

--- a/mooncake-store/src/tiered_cache/tiers/dram_tier.cpp
+++ b/mooncake-store/src/tiered_cache/tiers/dram_tier.cpp
@@ -76,7 +76,7 @@ DramCacheTier::~DramCacheTier() {
 }
 
 tl::expected<void, ErrorCode> DramCacheTier::Init(TieredBackend* backend,
-                                                   TransferEngine* engine) {
+                                                  TransferEngine* engine) {
     backend_ = backend;
     if (engine != nullptr) engine_ = engine;
 
@@ -101,9 +101,8 @@ tl::expected<void, ErrorCode> DramCacheTier::Init(TieredBackend* backend,
         return tl::unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
     }
     memory_buffer_ = std::unique_ptr<char[], std::function<void(char*)>>(
-        static_cast<char*>(host_ptr), [](char* p) {
-            aclrtFreeHost(static_cast<void*>(p));
-        });
+        static_cast<char*>(host_ptr),
+        [](char* p) { aclrtFreeHost(static_cast<void*>(p)); });
     LOG(INFO) << "Allocated " << capacity_ << " bytes (ACL Host Pinned) "
               << "for DramCacheTier " << tier_id_;
 #else

--- a/mooncake-store/src/tiered_cache/tiers/dram_tier.cpp
+++ b/mooncake-store/src/tiered_cache/tiers/dram_tier.cpp
@@ -1,8 +1,13 @@
 #include <glog/logging.h>
-#include <numa.h>
 #include <chrono>
 #include <cstdlib>
 #include <thread>
+
+#ifdef USE_ASCEND_DRAM_TIER
+#include "acl/acl.h"
+#else
+#include <numa.h>
+#endif
 
 #include "tiered_cache/tiers/dram_tier.h"
 #include "utils.h"
@@ -71,14 +76,39 @@ DramCacheTier::~DramCacheTier() {
 }
 
 tl::expected<void, ErrorCode> DramCacheTier::Init(TieredBackend* backend,
-                                                  TransferEngine* engine) {
-    int node = -1;
-    std::string location;
-
+                                                   TransferEngine* engine) {
     backend_ = backend;
     if (engine != nullptr) engine_ = engine;
 
-    // Allocate a contiguous memory block.
+#ifdef USE_ASCEND_DRAM_TIER
+    int current_device = -1;
+    aclError acl_ret = aclrtGetDevice(&current_device);
+    if (acl_ret != ACL_SUCCESS) {
+        LOG(ERROR) << "USE_ASCEND_DRAM_TIER enabled but no ACL Device Context "
+                   << "on current thread (aclrtGetDevice returned " << acl_ret
+                   << "). Ensure aclInit and aclrtSetDevice/aclrtCreateContext "
+                   << "have been called before DramCacheTier::Init().";
+        return tl::unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+    LOG(INFO) << "ACL Device Context found (device " << current_device
+              << "), using aclrtMallocHost for DRAM tier " << tier_id_;
+
+    void* host_ptr = nullptr;
+    acl_ret = aclrtMallocHost(&host_ptr, capacity_);
+    if (acl_ret != ACL_SUCCESS || host_ptr == nullptr) {
+        LOG(ERROR) << "aclrtMallocHost failed for " << capacity_
+                   << " bytes, ACL error: " << acl_ret;
+        return tl::unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
+    }
+    memory_buffer_ = std::unique_ptr<char[], std::function<void(char*)>>(
+        static_cast<char*>(host_ptr), [](char* p) {
+            aclrtFreeHost(static_cast<void*>(p));
+        });
+    LOG(INFO) << "Allocated " << capacity_ << " bytes (ACL Host Pinned) "
+              << "for DramCacheTier " << tier_id_;
+#else
+    int node = -1;
+
     const bool use_hugepage = (std::getenv("MC_STORE_USE_HUGEPAGE") != nullptr);
     if (use_hugepage) {
         const size_t hugepage_size = get_hugepage_size_from_env();
@@ -157,15 +187,21 @@ tl::expected<void, ErrorCode> DramCacheTier::Init(TieredBackend* backend,
         LOG(INFO) << "Allocated " << capacity_ << " bytes for DramCacheTier "
                   << tier_id_;
     }
+#endif
     char* mem_ptr = memory_buffer_.get();
 
-    // Register this newly allocated memory with the TransferEngine.
+#ifdef USE_ASCEND_DRAM_TIER
+    std::string location = kWildcardLocation;
+#else
+    std::string location;
+    if (node != -1) {
+        location = "cpu:" + std::to_string(node);
+    } else {
+        location = kWildcardLocation;
+    }
+#endif
+
     if (engine_) {
-        if (node != -1) {
-            location = "cpu:" + std::to_string(node);
-        } else {
-            location = kWildcardLocation;
-        }
         int rc = engine_->registerLocalMemory(mem_ptr, capacity_, location);
         if (rc != 0) {
             LOG(ERROR) << "Failed to register memory with TransferEngine for "

--- a/mooncake-store/tests/tiered_backend_test.cpp
+++ b/mooncake-store/tests/tiered_backend_test.cpp
@@ -5,6 +5,10 @@
 #include <filesystem>
 #include <cstdlib>
 
+#ifdef USE_ASCEND_DRAM_TIER
+#include "acl/acl.h"
+#endif
+
 #include "tiered_cache/tiered_backend.h"
 #include "utils/common.h"
 
@@ -39,11 +43,23 @@ static constexpr size_t SMALL_CAPACITY = 1 * 1024 * 1024;            // 1MB
 class TieredBackendTest : public ::testing::Test {
    protected:
     void SetUp() override {
-        // glog is already initialized by gtest_main
+#ifdef USE_ASCEND_DRAM_TIER
+        aclError ret = aclInit(nullptr);
+        if (ret != ACL_SUCCESS && ret != ACL_ERROR_REPEAT_INITIALIZE) {
+            GTEST_SKIP() << "ACL init failed (" << ret << "), skipping tests";
+        }
+        ret = aclrtSetDevice(0);
+        if (ret != ACL_SUCCESS) {
+            GTEST_SKIP() << "aclrtSetDevice(0) failed (" << ret
+                         << "), no NPU device available";
+        }
+#endif
     }
 
     void TearDown() override {
-        // Cleanup storage directories created by tests
+#ifdef USE_ASCEND_DRAM_TIER
+        aclrtResetDevice(0);
+#endif
         std::filesystem::remove_all("/tmp/mooncake_test_storage");
         std::filesystem::remove_all("/tmp/mooncake_test_bucket");
         std::filesystem::remove_all("/tmp/mooncake_test_multitier");


### PR DESCRIPTION
## Description
To solve "ascend_direct_transport.cpp:713] location of local addr is not supported.", use aclrtMallocHost aclrtFreeHost to allocate\free dram memory when USE_ASCEND_DRAM_TIER=ON, so that the buffer can be recognized by Transfer Engine.


## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



**Test commands:**
```bash
./Mooncake/build/mooncake-store/tests/tiered_backend_test
```

**Test results:**
- [ ] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

[----------] 33 tests from TieredBackendTest (53515 ms total)

[----------] Global test environment tear-down
[==========] 33 tests from 1 test suite ran. (53516 ms total)
[  PASSED  ] 33 tests.

E2E test on A2
before:
E20260529 12:44:12.690241   322 ascend_direct_transport.cpp:713] location of local addr is not supported.
E20260529 12:44:12.690404  1134 data_manager.cpp:1009] Transfer task 0 for batch 281423773119664 for segment endpoint '10.250.26.27:15395' failed with status 6
E20260529 12:44:12.690428  1134 data_manager.cpp:1021] Transfer failed in batch_id 281423773119664
E20260529 12:44:12.690464  1134 data_manager.cpp:948] Transfer failed for segment endpoint '10.250.26.27:15395', error: TRANSFER_FAIL, batch_id: 281423773119664, index: 0, total_batches: 1, num_tasks: 72
E20260529 12:44:12.690483  1134 data_manager.cpp:240] WaitAllTransferBatches failed, key=b968826d9c46dd6066d109eabc6255188de91218@pcp0@dcp0@head_or_tp_rank:1@pp_rank:0@e5550653318a1d8a315743445dcacc69b2ac401e39270774cf2f874f76249df5, error_code=TRANSFER_FAIL
I20260529 12:44:12.690496  1134 scoped_vlog_timer.h:121] DataManager::PutViaTe finished, latency=307us
E20260529 12:44:12.690539  1134 p2p_client_service.cpp:972] Write candidate failed, key: b968826d9c46dd6066d109eabc6255188de91218@pcp0@dcp0@head_or_tp_rank:1@pp_rank:0@e5550653318a1d8a315743445dcacc69b2ac401e39270774cf2f874f76249df5, route: local, retry_cnt: 0, error: TRANSFER_FAIL
after:
Put success without error when USE_ASCEND_DRAM_TIER enabled.
I20260611 06:44:48.669035  2435 scoped_vlog_timer.h:63] MasterClient::BatchExistKey response: result=1 keys, latency=454us
I20260611 06:44:48.669159  2433 scoped_vlog_timer.h:46] DataManager::PreWrite request: key=b968826d9c46dd6066d109eabc6255188de91218@pcp0@dcp0@head_or_tp_rank:3@pp_rank:0@8a6dc7ca10562f848d0fe7f26145c4065f6f4fe1e81ca8f585ac7f69124e2944size_bytes=4718592
I20260611 06:44:48.669195  2433 allocator.cpp:242] allocation_succeeded size=4718592 segment=dram_tier_11478675450424891214-12940591315257891210 address=0x12c2c0000000
(Worker_TP2 pid=114) INFO 06-11 06:44:48 [kv_transfer.py:166] Storing KV cache for 1 out of 1 blocks (skip_block_num=0) for request cmpl-a6c7df102ae1544a-0
I20260611 06:44:48.669992  1668 scoped_vlog_timer.h:46] ClientRpcService::WriteRemoteData request: key=b968826d9c46dd6066d109eabc6255188de91218@pcp0@dcp0@head_or_tp_rank:0@pp_rank:0@8a6dc7ca10562f848d0fe7f26145c4065f6f4fe1e81ca8f585ac7f69124e2944buffer_count=72
I20260611 06:44:48.670110  1668 scoped_vlog_timer.h:46] DataManager::WriteRemoteData request: key=b968826d9c46dd6066d109eabc6255188de91218@pcp0@dcp0@head_or_tp_rank:0@pp_rank:0@8a6dc7ca10562f848d0fe7f26145c4065f6f4fe1e81ca8f585ac7f69124e2944buffer_count=72
I20260611 06:44:48.670131  1668 scoped_vlog_timer.h:46] DataManager::PreWrite request: key=b968826d9c46dd6066d109eabc6255188de91218@pcp0@dcp0@head_or_tp_rank:0@pp_rank:0@8a6dc7ca10562f848d0fe7f26145c4065f6f4fe1e81ca8f585ac7f69124e2944size_bytes=4718592
I20260611 06:44:48.670168  1668 allocator.cpp:242] allocation_succeeded size=4718592 segment=dram_tier_11478675450424891214-12940591315257891210 address=0x12c2c0480000
(Worker_TP2 pid=114) INFO 06-11 06:44:48 [mooncake_backend.py:48] MOONCAKE_CLIENT_MODE is set as p2p
I20260611 06:44:48.670552  2435 scoped_vlog_timer.h:46] P2PClientService::BatchPut request: batch_size=1
I20260611 06:44:48.670590  2435 scoped_vlog_timer.h:46] P2PMasterClient::BatchGetWriteRoute request: key_count=1
I20260611 06:44:48.670661  2434 scoped_vlog_timer.h:63] DataManager::PreWrite response: error_code=OK, latency=1850us
I20260611 06:44:48.670771  2435 scoped_vlog_timer.h:90] P2PMasterClient::BatchGetWriteRoute response: status=success, value={"responses":[{"candidates":[{"replica":{"client_id":"1823544566330609478":4996793392496612254,"segment_id":"11478675450424891214":12940591315257891210,"ip_address":"","rpc_port":33529,"object_size":4718592},"available_capacity":4294967296,"priority":10},{"replica":{"client_id":"5422649456279189307":17501238543866509232,"segment_id":"9533259898601198778":8029126802095662773,"ip_address":"","rpc_port":45125,"object_size":4718592},"available_capacity":4294967296,"priority":10}]}],"error_codes":[0]}, latency=172us
I20260611 06:44:48.670816  2434 scoped_vlog_timer.h:46] DataManager::PutViaTe request: key=b968826d9c46dd6066d109eabc6255188de91218@pcp0@dcp0@head_or_tp_rank:1@pp_rank:0@8a6dc7ca10562f848d0fe7f26145c4065f6f4fe1e81ca8f585ac7f69124e2944
I20260611 06:44:48.670956  2433 scoped_vlog_timer.h:63] DataManager::PreWrite response: error_code=OK, latency=1797us
I20260611 06:44:48.670961  1668 scoped_vlog_timer.h:63] DataManager::PreWrite response: error_code=OK, latency=827us
I20260611 06:44:48.671136  2433 scoped_vlog_timer.h:46] DataManager::PutViaTe request: key=b968826d9c46dd6066d109eabc6255188de91218@pcp0@dcp0@head_or_tp_rank:3@pp_rank:0@8a6dc7ca10562f848d0fe7f26145c4065f6f4fe1e81ca8f585ac7f69124e2944
I20260611 06:44:48.671213   515 ascend_direct_transport.cpp:1045] Copy with aclrtMemcpyBatch suc.
I20260611 06:44:48.671257   515 ascend_direct_transport.cpp:806] Local copy time: 390us
I20260611 06:44:48.671315  2434 data_manager.cpp:1727] All transfers completed for batch 281442429459792 for segment endpoint '10.250.40.151:15075'
make ok but transfer failed if USE_ASCEND_DRAM_TIER is off and dram tier is used.
<img width="2207" height="845" alt="image" src="https://github.com/user-attachments/assets/45e12511-0fd8-4b6a-b7c9-5e837c47e5fd" />

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [x] AI tools were used (specify below)


Opencode+GLM5.1 is used to implement according to the design