### PR TITLE
[Integration] Return documented failure sentinel 0 from uint64 async transfer APIs

### DIFF
--- a/docs/source/python-api-reference/transfer-engine.md
+++ b/docs/source/python-api-reference/transfer-engine.md
@@ -240,7 +240,7 @@ Submits an asynchronous write operation and returns immediately.
 - `transport_hint` (str, optional): TENT-only per-request transport pin. See the note above. Default `""` (policy-driven).
 
 **Returns:**
-- `int`: Batch ID for tracking the operation, or negative value on failure
+- `int`: Batch ID for tracking the operation, or 0 on failure
 
 #### transfer_check_status()
 

--- a/docs/source/zh_archive/transfer-engine-python.md
+++ b/docs/source/zh_archive/transfer-engine-python.md
@@ -186,7 +186,7 @@ transfer_submit_write(target_hostname, buffer, peer_buffer_address, length)
 - `length` (int): 要传输的字节数
 
 **返回值：**
-- `int`: 用于跟踪操作的批次ID，失败时返回负值
+- `int`: 用于跟踪操作的批次ID，失败时返回0
 
 #### transfer_check_status()
 

--- a/mooncake-integration/transfer_engine/transfer_engine_py.cpp
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.cpp
@@ -606,7 +606,9 @@ batch_id_t TransferEnginePy::batchTransferAsync(
             handle = handle_map_[target_hostname];
         } else {
             handle = engine_->openSegment(target_hostname);
-            if (handle == (Transport::SegmentHandle)-1) return -1;
+            // batch_id_t is unsigned; 0 is the documented failure sentinel
+            // (-1 would surface as 2^64 - 1 in Python).
+            if (handle == (Transport::SegmentHandle)-1) return 0;
             handle_map_[target_hostname] = handle;
         }
     }
@@ -730,7 +732,9 @@ batch_id_t TransferEnginePy::transferSubmitWrite(
             handle = handle_map_[target_hostname];
         } else {
             handle = engine_->openSegment(target_hostname);
-            if (handle == (Transport::SegmentHandle)-1) return -1;
+            // batch_id_t is unsigned; 0 is the documented failure sentinel
+            // (-1 would surface as 2^64 - 1 in Python).
+            if (handle == (Transport::SegmentHandle)-1) return 0;
             handle_map_[target_hostname] = handle;
         }
     }
@@ -745,7 +749,10 @@ batch_id_t TransferEnginePy::transferSubmitWrite(
     entry.transport_hint = parseTransportHint(transport_hint);
 
     Status s = engine_->submitTransfer(batch_id, {entry});
-    if (!s.ok()) return -1;
+    if (!s.ok()) {
+        engine_->freeBatchID(batch_id);
+        return 0;
+    }
 
     return batch_id;
 }

--- a/mooncake-wheel/tests/transfer_engine_initiator_test.py
+++ b/mooncake-wheel/tests/transfer_engine_initiator_test.py
@@ -268,6 +268,31 @@ class TestVLLMAdaptorTransfer(unittest.TestCase):
             f"[✓] {circles} rounds of batch_write_async_read passed, batch size {batch_size}."
         )
 
+    def test_async_submit_to_unknown_peer_returns_zero(self):
+        """Async submit APIs return the documented failure sentinel 0.
+
+        openSegment failure used to surface as -1 cast through the unsigned
+        batch_id_t, i.e. 2**64 - 1, which passes the documented
+        `batch_id != 0` failure check and crashes get_batch_transfer_status.
+        """
+        # "unreachable_peer:9" is not registered with the metadata server, so
+        # openSegment fails before any buffer address is dereferenced.
+        batch_id = self.adaptor.batch_transfer_async_write(
+            "unreachable_peer:9", [0], [0], [16]
+        )
+        self.assertEqual(
+            batch_id,
+            0,
+            f"batch_transfer_async_write to unknown peer returned {batch_id}",
+        )
+
+        batch_id = self.adaptor.transfer_submit_write("unreachable_peer:9", 0, 0, 16)
+        self.assertEqual(
+            batch_id,
+            0,
+            f"transfer_submit_write to unknown peer returned {batch_id}",
+        )
+
     def test_send_probe_reachable_peer(self):
         """send_probe against a registered, reachable peer returns 0."""
         rc = self.adaptor.send_probe(self.target_server_name)


### PR DESCRIPTION
## Description

Fixes #2432

`batchTransferAsync` and `transferSubmitWrite` return `batch_id_t` (`uint64_t`), but on `openSegment` failure they `return -1;`, which Python receives as `18446744073709551615` — not the documented failure sentinel:

- The Python API reference documents `batch_transfer_async*` as returning "Batch ID for tracking the operation, **or 0 on failure**", and the other failure paths of `batchTransferAsync` already return `0`.
- `mooncake-wheel/tests/transfer_engine_initiator_test.py` follows the documented contract (`assertNotEqual(batch_id, 0, ...)`), so a caller doing the right thing treats `2**64 - 1` as a valid batch id and passes it to `get_batch_transfer_status`, which `reinterpret_cast`s it to `BatchDesc*` and dereferences it → SIGSEGV.
- `transfer_submit_write` documents "negative value on failure", which a `uint64_t` return can never satisfy from Python, so its failures are undetectable.

Changes:

| File | Change |
|---|---|
| `mooncake-integration/transfer_engine/transfer_engine_py.cpp` | `batchTransferAsync`: return `0` (documented sentinel) instead of `-1` on `openSegment` failure; `transferSubmitWrite`: same at both failure sites, and free the allocated batch on submit failure, matching the sibling error path in `batchTransferAsync` |
| `docs/source/python-api-reference/transfer-engine.md` | `transfer_submit_write`: "negative value on failure" → "0 on failure" |
| `docs/source/zh_archive/transfer-engine-python.md` | same contract fix in the archived zh doc |
| `mooncake-wheel/tests/transfer_engine_initiator_test.py` | regression test: both APIs return `0` for an unknown peer (pre-fix they return `2**64 - 1`) |

`0` is safe as the failure sentinel: batch ids are heap `BatchDesc*` values, never null. No in-repo caller relies on the old value; external callers checking `< 0` per the old doc had dead checks anyway (a Python `uint64` is never negative).

## Module

- [x] Integration (`mooncake-integration`)
- [x] Docs

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

**Test commands:**
```bash
# Ubuntu 22.04 (aarch64) container, cmake -DWITH_STORE_RUST=OFF -DUSE_HTTP=ON, ninja
mooncake_http_metadata_server --port 8080 &
cd mooncake-wheel/tests
MC_METADATA_SERVER=http://127.0.0.1:8080/metadata MC_FORCE_TCP=true python transfer_engine_target.py &
MC_METADATA_SERVER=http://127.0.0.1:8080/metadata MC_FORCE_TCP=true python transfer_engine_initiator_test.py
```

**Before the fix** (repro: initialize with tcp + HTTP metadata, submit to a nonexistent target):
```
batch_transfer_async_write -> 18446744073709551615
transfer_submit_write -> 18446744073709551615
passing the id to get_batch_transfer_status ... Segmentation fault
```

**After the fix:**
```
batch_transfer_async_write -> 0
transfer_submit_write -> 0
```
and the full `transfer_engine_initiator_test.py` suite passes, including the new regression test.

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

No RDMA hardware involved; validation used the tcp transport (the bug is protocol-independent — the failing path is the metadata lookup in `openSegment`).

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Claude Code (Claude Fable 5) found the inconsistency, wrote the fix and the regression test, and validated them in a local Linux container. I reviewed the changes and am responsible for them.