### PR TITLE
[TransferEngine] fix: reset last_wait_ts after work to avoid skipping…

### DIFF
--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -417,6 +417,7 @@ void WorkerPool::transferWorker(int thread_id) {
 #ifndef USE_FAKE_POST_SEND
         performPollCq(thread_id);
 #endif
+        last_wait_ts = getCurrentTimeInNano();
     }
 }
 


### PR DESCRIPTION
## Description

When a worker thread finishes processing slices and becomes idle again, last_wait_ts was not reset, causing the next idle period to immediately exceed the 100ms threshold and skip the busy-spin phase, degrading latency.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Performance improvement
- [ ] Other


## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [x] No AI tools were used
- [ ] AI tools were used (specify below)