### PR TITLE
[Store] fix: /query_key endpoint returns valid JSON response

### DIFF
--- a/docs/source/http-api-reference/http-service.md
+++ b/docs/source/http-api-reference/http-service.md
@@ -57,24 +57,22 @@ Retrieve replica information for a specific key, including memory locations and 
 curl "http://localhost:8080/query_key?key=my_object"
 ```
 
-**Success Response**:
+**Success Response** (HTTP 200):
 ```json
 {
   "success": true,
   "data": [
     {
-      "buffer_descriptor": {
-        "size_": 1073741824,
-        "buffer_address_": 140732000000000,
-        "protocol_": "rdma",
-        "transport_endpoint_": "192.168.1.100:12345"
-      }
+      "size_": 1073741824,
+      "buffer_address_": 140732000000000,
+      "protocol_": "rdma",
+      "transport_endpoint_": "192.168.1.100:12345"
     }
   ]
 }
 ```
 
-**Error Response** (key not found):
+**Error Response** (key not found, HTTP 404):
 ```json
 {
   "success": false,
@@ -83,11 +81,11 @@ curl "http://localhost:8080/query_key?key=my_object"
 }
 ```
 
-**Error Response** (service unavailable):
+**Error Response** (service unavailable, HTTP 503):
 ```json
 {
   "success": false,
-  "error_code": 503,
+  "error_code": -1011,
   "error_message": "service plane is not active"
 }
 ```

--- a/docs/source/http-api-reference/http-service.md
+++ b/docs/source/http-api-reference/http-service.md
@@ -49,19 +49,42 @@ Retrieve replica information for a specific key, including memory locations and 
 
 **Method**: `GET`
 **Parameters**: `key` (query parameter) - The object key to query
-**Content-Type**: `text/plain; version=0.0.4`
-**Response**: JSON-formatted replica descriptors for memory replicas
+**Content-Type**: `application/json; charset=utf-8`
+**Response**: JSON object with success status and replica data array
 
 **Example**:
 ```bash
 curl "http://localhost:8080/query_key?key=my_object"
 ```
 
-**Response Format**:
-```text
+**Success Response**:
+```json
 {
-  "transport_endpoint_": "hostname:port",
-  "buffer_descriptors": [...]
+  "success": true,
+  "data": [
+    {
+      "transport_endpoint_": "hostname:port",
+      "buffer_descriptor": {...}
+    }
+  ]
+}
+```
+
+**Error Response** (key not found):
+```json
+{
+  "success": false,
+  "error_code": -704,
+  "error_message": "OBJECT_NOT_FOUND"
+}
+```
+
+**Error Response** (service unavailable):
+```json
+{
+  "success": false,
+  "error_code": 503,
+  "error_message": "service plane is not active"
 }
 ```
 
@@ -205,7 +228,7 @@ Basic health check endpoint for service availability verification.
 **Method**: `GET`
 **Content-Type**: `text/plain; version=0.0.4`
 **Response**: `OK` when service is healthy
-**Status Codes**: 
+**Status Codes**:
 - `200 OK`: Service is healthy
 - Other: Service may be experiencing issues
 

--- a/docs/source/http-api-reference/http-service.md
+++ b/docs/source/http-api-reference/http-service.md
@@ -63,8 +63,12 @@ curl "http://localhost:8080/query_key?key=my_object"
   "success": true,
   "data": [
     {
-      "transport_endpoint_": "hostname:port",
-      "buffer_descriptor": {...}
+      "buffer_descriptor": {
+        "size_": 1073741824,
+        "buffer_address_": 140732000000000,
+        "protocol_": "rdma",
+        "transport_endpoint_": "192.168.1.100:12345"
+      }
     }
   ]
 }

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -485,7 +485,9 @@ void MasterAdminServer::InitHttpServer() {
 
             resp.set_status_and_content(
                 status_type::not_found,
-                std::string("{\"success\":false,\"error\":\"") +
+                std::string("{\"success\":false,\"error_code\":") +
+                    std::to_string(toInt(get_result.error())) +
+                    ",\"error_message\":\"" +
                     EscapeJson(toString(get_result.error())) + "\"}");
         });
 

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -460,10 +460,11 @@ void MasterAdminServer::InitHttpServer() {
             auto key = req.get_query_value("key");
             auto get_result =
                 service->GetReplicaList(std::string(key), "default");
-            resp.add_header("Content-Type", "text/plain; version=0.0.4");
+            resp.add_header("Content-Type", "application/json; charset=utf-8");
             if (get_result) {
-                std::string ss;
+                std::string ss = "{\"success\":true,\"data\":[";
                 const auto& replicas = get_result.value().replicas;
+                bool first = true;
                 for (const auto& replica : replicas) {
                     if (!replica.is_memory_replica()) {
                         continue;
@@ -471,15 +472,21 @@ void MasterAdminServer::InitHttpServer() {
                     std::string tmp;
                     struct_json::to_json(
                         replica.get_memory_descriptor().buffer_descriptor, tmp);
+                    if (!first) {
+                        ss += ",";
+                    }
                     ss += tmp;
-                    ss += "\n";
+                    first = false;
                 }
+                ss += "]}";
                 resp.set_status_and_content(status_type::ok, std::move(ss));
                 return;
             }
 
-            resp.set_status_and_content(status_type::not_found,
-                                        toString(get_result.error()));
+            resp.set_status_and_content(
+                status_type::not_found,
+                std::string("{\"success\":false,\"error\":\"") +
+                    EscapeJson(toString(get_result.error())) + "\"}");
         });
 
     http_server_.set_http_handler<GET>(


### PR DESCRIPTION
## Description

part of https://github.com/kvcache-ai/Mooncake/issues/2400

The `/query_key` endpoint had an inconsistent response format within the same handler:

- **Error path** (`SetServiceUnavailable`): returns valid JSON with correct `Content-Type: application/json`
- **Success path**: returns NDJSON (newline-delimited JSON) with `Content-Type: text/plain; version=0.0.4`

This PR aligns both paths to return the same JSON format, making the endpoint self-consistent and consistent with other admin endpoints like `/batch_query_keys`.

**Note: This is a breaking change.** The previous success response was NDJSON, which is itself a valid and widely-used format. An alternative fix would be to keep NDJSON but only correct the Content-Type. This change is debatable and reviewers should decide whether consistency or backward compatibility is the higher priority. If preferred, this PR can be closed in favor of a Content-Type-only fix.

### Changes

1. **Content-Type**: `text/plain; version=0.0.4` → `application/json; charset=utf-8`
2. **Success response**: NDJSON → `{"success":true,"data":[{...},{...}]}`
3. **Error response**: plain text → `{"success":false,"error":"..."}`

### Before vs After

Before (inconsistent):
```
# Success response — NDJSON, Content-Type: text/plain
{"buffer_address_":...}
{"buffer_address_":...}

# Error response (service unavailable) — JSON, Content-Type: application/json
{"success":false,"error_code":...,"error_message":"service plane is not active"}

# Error response (key not found) — plain text
Object not found
```

After (consistent, all JSON):
```json
// Success
{"success":true,"data":[{...},{...}]}

// Error
{"success":false,"error":"Object not found"}
```

## Module

- [x] Mooncake Store (`mooncake-store`)

## Type of Change

- [x] Bug fix (format inconsistency)

## How Has This Been Tested?

Existing tests in `master_admin_server_test.cpp` cover this endpoint and remain backward-compatible with the response format change.

## Checklist

- [x] I have performed a self-review of my own code
- [x] The change follows existing patterns in the codebase (e.g., `/batch_query_keys` uses the same JSON structure)
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass

## AI Assistance Disclosure

- [x] AI tools were used (OpenCode). Every lines of change reviewed by author.