### PR TITLE
[TENT] Fix fault tolerance when a single link fails

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -268,7 +268,7 @@ class TransferEngineImpl {
     int rdma_failure_count_{0};
     uint64_t rdma_failure_window_start_ns_{0};
     int rdma_failure_threshold_{3};
-    uint64_t rdma_failure_time_window_ns_{60000000000ULL}; // 60 seconds
+    uint64_t rdma_failure_time_window_ns_{60000000000ULL};  // 60 seconds
 
     // Guards alive_batches_ and serializes pollTaskStatus /
     // updateTaskStatusAfterPoll / lazyFreeBatch against the optional

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -265,8 +265,8 @@ class TransferEngineImpl {
     bool enable_progress_worker_{false};
 
     // Track RDMA failures to skip RDMA when threshold exceeded
-    int rdma_failure_count_{0};
-    uint64_t rdma_failure_window_start_ns_{0};
+    std::atomic<int> rdma_failure_count_{0};
+    std::atomic<uint64_t> rdma_failure_window_start_ns_{0};
     int rdma_failure_threshold_{3};
     uint64_t rdma_failure_time_window_ns_{60000000000ULL};  // 60 seconds
 

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -268,7 +268,7 @@ class TransferEngineImpl {
     std::atomic<int> rdma_failure_count_{0};
     std::atomic<uint64_t> rdma_failure_window_start_ns_{0};
     int rdma_failure_threshold_{3};
-    uint64_t rdma_failure_time_window_ns_{60000000000ULL};  // 60 seconds
+    uint64_t rdma_failure_time_window_ns_{300000000000ULL};  // 300 seconds (5 minutes)
 
     // Guards alive_batches_ and serializes pollTaskStatus /
     // updateTaskStatusAfterPoll / lazyFreeBatch against the optional

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -264,6 +264,12 @@ class TransferEngineImpl {
     bool enable_auto_failover_on_poll_{true};
     bool enable_progress_worker_{false};
 
+    // Track RDMA failures to skip RDMA when threshold exceeded
+    int rdma_failure_count_{0};
+    uint64_t rdma_failure_window_start_ns_{0};
+    int rdma_failure_threshold_{3};
+    uint64_t rdma_failure_time_window_ns_{60000000000ULL}; // 60 seconds
+
     // Guards alive_batches_ and serializes pollTaskStatus /
     // updateTaskStatusAfterPoll / lazyFreeBatch against the optional
     // ProgressWorker thread. Recursive because freeBatch -> lazyFreeBatch ->

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -268,7 +268,8 @@ class TransferEngineImpl {
     std::atomic<int> rdma_failure_count_{0};
     std::atomic<uint64_t> rdma_failure_window_start_ns_{0};
     int rdma_failure_threshold_{3};
-    uint64_t rdma_failure_time_window_ns_{300000000000ULL};  // 300 seconds (5 minutes)
+    uint64_t rdma_failure_time_window_ns_{
+        300000000000ULL};  // 300 seconds (5 minutes)
 
     // Guards alive_batches_ and serializes pollTaskStatus /
     // updateTaskStatusAfterPoll / lazyFreeBatch against the optional

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/context.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/context.h
@@ -19,6 +19,10 @@
 #include <glog/logging.h>
 #include <infiniband/verbs.h>
 
+#ifdef USE_MLX5DV
+#include <infiniband/mlx5dv.h>
+#endif
+
 #include <atomic>
 #include <condition_variable>
 #include <cstdint>
@@ -108,6 +112,8 @@ class RdmaContext {
 
     int eventFd() const { return event_fd_; }
 
+    uint8_t numLagPorts() const { return num_lag_ports_; }
+
     RdmaCQ *cq(int index);
 
     int cqCount() const { return params_->device.num_cq_list; }
@@ -142,6 +148,7 @@ class RdmaContext {
     uint16_t lid_ = 0;
     int gid_index_ = -1;
     ibv_gid gid_;
+    uint8_t num_lag_ports_ = 0;  // 0/1 = not in LAG; ≥2 = LAG active
 
     std::mutex mr_set_mutex_;
     std::unordered_set<ibv_mr *> mr_set_;

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint.h
@@ -128,6 +128,8 @@ class RdmaEndPoint : public std::enable_shared_from_this<RdmaEndPoint> {
 
     std::string name() const { return endpoint_name_; }
 
+    std::string peerNicName() const { return peer_nic_name_; }
+
     // Notification QP operations
     uint32_t notifyQpNum() const { return notify_qp_ ? notify_qp_->qp_num : 0; }
 

--- a/mooncake-transfer-engine/tent/src/common/config.cpp
+++ b/mooncake-transfer-engine/tent/src/common/config.cpp
@@ -133,7 +133,8 @@ Status ConfigHelper::loadFromEnv(Config& config) {
             try {
                 int val = std::stoi(item);
                 if (val < 0 || val > 65535) {
-                    LOG(WARNING) << "MC_MLX5_QP_UDP_SPORTS entry out of range: " << item;
+                    LOG(WARNING)
+                        << "MC_MLX5_QP_UDP_SPORTS entry out of range: " << item;
                     ok = false;
                     break;
                 }
@@ -148,15 +149,18 @@ Status ConfigHelper::loadFromEnv(Config& config) {
         if (ok && !ports.empty()) {
             config.set("transports/rdma/mlx5_qp_udp_sports", ports);
         } else if (!ok) {
-            LOG(WARNING) << "Ignore MC_MLX5_QP_UDP_SPORTS entirely due to parse errors";
+            LOG(WARNING)
+                << "Ignore MC_MLX5_QP_UDP_SPORTS entirely due to parse errors";
         }
     }
 
-    const char* mlx5_lag_balance_env = std::getenv("MC_MLX5_QP_LAG_PORT_BALANCE");
+    const char* mlx5_lag_balance_env =
+        std::getenv("MC_MLX5_QP_LAG_PORT_BALANCE");
     if (mlx5_lag_balance_env && *mlx5_lag_balance_env) {
         bool val = parseBool(mlx5_lag_balance_env, false);
         config.set("transports/rdma/mlx5_qp_lag_port_balance", val);
-        LOG(INFO) << "MC_MLX5_QP_LAG_PORT_BALANCE = " << (val ? "true" : "false");
+        LOG(INFO) << "MC_MLX5_QP_LAG_PORT_BALANCE = "
+                  << (val ? "true" : "false");
     }
 
     return status;

--- a/mooncake-transfer-engine/tent/src/common/config.cpp
+++ b/mooncake-transfer-engine/tent/src/common/config.cpp
@@ -116,6 +116,49 @@ Status ConfigHelper::loadFromEnv(Config& config) {
               "transports/rdma/workers/max_retry_count");
     setConfig(config, "MC_DISABLE_GPU_DIRECT_RDMA",
               "transports/rdma/disable_gpu_direct_rdma");
+
+    // MLX5 Direct Verbs configuration for UDP sport override and LAG balancing
+    const char* mlx5_udp_sports_env = std::getenv("MC_MLX5_QP_UDP_SPORTS");
+    if (mlx5_udp_sports_env && *mlx5_udp_sports_env) {
+        std::vector<uint16_t> ports;
+        std::stringstream ss(mlx5_udp_sports_env);
+        std::string item;
+        bool ok = true;
+        while (std::getline(ss, item, ',')) {
+            // Trim leading/trailing whitespace
+            auto l = item.find_first_not_of(" \t");
+            auto r = item.find_last_not_of(" \t");
+            if (l == std::string::npos) continue;
+            item = item.substr(l, r - l + 1);
+            try {
+                int val = std::stoi(item);
+                if (val < 0 || val > 65535) {
+                    LOG(WARNING) << "MC_MLX5_QP_UDP_SPORTS entry out of range: " << item;
+                    ok = false;
+                    break;
+                }
+                ports.push_back(static_cast<uint16_t>(val));
+            } catch (const std::exception& e) {
+                LOG(WARNING) << "Invalid MC_MLX5_QP_UDP_SPORTS entry: " << item
+                             << ". Error: " << e.what();
+                ok = false;
+                break;
+            }
+        }
+        if (ok && !ports.empty()) {
+            config.set("transports/rdma/mlx5_qp_udp_sports", ports);
+        } else if (!ok) {
+            LOG(WARNING) << "Ignore MC_MLX5_QP_UDP_SPORTS entirely due to parse errors";
+        }
+    }
+
+    const char* mlx5_lag_balance_env = std::getenv("MC_MLX5_QP_LAG_PORT_BALANCE");
+    if (mlx5_lag_balance_env && *mlx5_lag_balance_env) {
+        bool val = parseBool(mlx5_lag_balance_env, false);
+        config.set("transports/rdma/mlx5_qp_lag_port_balance", val);
+        LOG(INFO) << "MC_MLX5_QP_LAG_PORT_BALANCE = " << (val ? "true" : "false");
+    }
+
     return status;
 }
 

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -290,7 +290,7 @@ Status TransferEngineImpl::construct() {
 
     // Configure RDMA failure tracking
     rdma_failure_threshold_ = conf_->get("rdma_failure_threshold", 3);
-    int time_window_sec = conf_->get("rdma_failure_time_window_sec", 60);
+    int time_window_sec = conf_->get("rdma_failure_time_window_sec", 300);
     rdma_failure_time_window_ns_ = time_window_sec * 1000000000ULL;
     if (!hostname_.empty())
         CHECK_STATUS(checkLocalIpAddress(hostname_, ipv6_));

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -26,6 +26,7 @@
 
 #include "tent/common/config.h"
 #include "tent/common/status.h"
+#include "tent/common/utils/os.h"
 #include "tent/runtime/control_plane.h"
 #include "tent/runtime/segment.h"
 #include "tent/runtime/segment_tracker.h"
@@ -286,6 +287,11 @@ Status TransferEngineImpl::construct() {
     enable_auto_failover_on_poll_ =
         conf_->get("enable_auto_failover_on_poll", true);
     enable_progress_worker_ = conf_->get("enable_progress_worker", false);
+
+    // Configure RDMA failure tracking
+    rdma_failure_threshold_ = conf_->get("rdma_failure_threshold", 3);
+    int time_window_sec = conf_->get("rdma_failure_time_window_sec", 60);
+    rdma_failure_time_window_ns_ = time_window_sec * 1000000000ULL;
     if (!hostname_.empty())
         CHECK_STATUS(checkLocalIpAddress(hostname_, ipv6_));
     else
@@ -1190,7 +1196,18 @@ void TransferEngineImpl::findStagingPolicy(const Request& request,
 SelectionResult TransferEngineImpl::resolveTransport(const Request& req,
                                                      int transport_index,
                                                      bool invalidate_on_fail) {
-    auto result = getTransportType(req, transport_index);
+    // Skip RDMA if failure threshold exceeded and within time window
+    int adjusted_index = transport_index;
+    if (transport_index == 0 && rdma_failure_threshold_ > 0 &&
+        rdma_failure_count_ >= rdma_failure_threshold_) {
+        uint64_t current_ns = getCurrentTimeInNano();
+        if ((current_ns - rdma_failure_window_start_ns_) <= rdma_failure_time_window_ns_) {
+            // Bypass RDMA by incrementing transport index
+            adjusted_index = 1;
+        }
+    }
+
+    auto result = getTransportType(req, adjusted_index);
     if (result.transport == UNSPEC && invalidate_on_fail) {
         metadata_->segmentManager().invalidateRemote(req.target_id);
         result = getTransportType(req, transport_index);
@@ -1395,6 +1412,34 @@ Status TransferEngineImpl::resubmitTransferTask(Batch* batch, size_t task_id) {
               << " -> " << transportTypeName(type) << " (attempt "
               << task.failover_count << "/" << max_failover_attempts_ << ")";
     TENT_RECORD_TRANSPORT_FAILOVER();
+
+    // Track RDMA failures
+    if (prev_type == RDMA) {
+        uint64_t current_ns = getCurrentTimeInNano();
+        // Reset counter if time window has passed
+        if (rdma_failure_count_ > 0 &&
+            (current_ns - rdma_failure_window_start_ns_) > rdma_failure_time_window_ns_) {
+            rdma_failure_count_ = 0;
+            rdma_failure_window_start_ns_ = 0;
+            LOG(INFO) << "RDMA failure counter reset";
+        }
+        // Initialize window start time on first failure
+        if (rdma_failure_count_ == 0) {
+            rdma_failure_window_start_ns_ = current_ns;
+        }
+        rdma_failure_count_++;
+
+        LOG(WARNING) << "RDMA failure detected (count: "
+                     << rdma_failure_count_ << "/"
+                     << rdma_failure_threshold_ << ")";
+
+        if (rdma_failure_threshold_ > 0 &&
+            rdma_failure_count_ >= rdma_failure_threshold_) {
+            LOG(WARNING) << "RDMA failure threshold exceeded ("
+                         << rdma_failure_count_
+                         << " failures), will bypass RDMA for 1 minute";
+        }
+    }
 
     auto& transport = transport_list_[type];
     if (!batch->sub_batch[type])

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -1438,7 +1438,9 @@ Status TransferEngineImpl::resubmitTransferTask(Batch* batch, size_t task_id) {
             rdma_failure_count_ >= rdma_failure_threshold_) {
             LOG(WARNING) << "RDMA failure threshold exceeded ("
                          << rdma_failure_count_
-                         << " failures), will bypass RDMA for 1 minute";
+                         << " failures), will bypass RDMA for "
+                         << (rdma_failure_time_window_ns_ / 1000000000ULL)
+                         << " seconds";
         }
     }
 

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -1201,7 +1201,8 @@ SelectionResult TransferEngineImpl::resolveTransport(const Request& req,
     if (transport_index == 0 && rdma_failure_threshold_ > 0 &&
         rdma_failure_count_ >= rdma_failure_threshold_) {
         uint64_t current_ns = getCurrentTimeInNano();
-        if ((current_ns - rdma_failure_window_start_ns_) <= rdma_failure_time_window_ns_) {
+        if ((current_ns - rdma_failure_window_start_ns_) <=
+            rdma_failure_time_window_ns_) {
             // Bypass RDMA by incrementing transport index
             adjusted_index = 1;
         }
@@ -1418,7 +1419,8 @@ Status TransferEngineImpl::resubmitTransferTask(Batch* batch, size_t task_id) {
         uint64_t current_ns = getCurrentTimeInNano();
         // Reset counter if time window has passed
         if (rdma_failure_count_ > 0 &&
-            (current_ns - rdma_failure_window_start_ns_) > rdma_failure_time_window_ns_) {
+            (current_ns - rdma_failure_window_start_ns_) >
+                rdma_failure_time_window_ns_) {
             rdma_failure_count_ = 0;
             rdma_failure_window_start_ns_ = 0;
             LOG(INFO) << "RDMA failure counter reset";
@@ -1429,9 +1431,8 @@ Status TransferEngineImpl::resubmitTransferTask(Batch* batch, size_t task_id) {
         }
         rdma_failure_count_++;
 
-        LOG(WARNING) << "RDMA failure detected (count: "
-                     << rdma_failure_count_ << "/"
-                     << rdma_failure_threshold_ << ")";
+        LOG(WARNING) << "RDMA failure detected (count: " << rdma_failure_count_
+                     << "/" << rdma_failure_threshold_ << ")";
 
         if (rdma_failure_threshold_ > 0 &&
             rdma_failure_count_ >= rdma_failure_threshold_) {

--- a/mooncake-transfer-engine/tent/src/transport/rdma/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/CMakeLists.txt
@@ -3,4 +3,11 @@ if (IBVERBS_INCLUDE)
     add_library(tent_xport_rdma STATIC ${XPORT_SOURCES})
     target_include_directories(tent_xport_rdma PUBLIC ${IBVERBS_INCLUDE})
     target_link_libraries(tent_xport_rdma PUBLIC tent_common)
+
+    # MLX5 Direct Verbs support for UDP sport override and LAG balancing
+    if(USE_MLX5DV)
+        message(STATUS "TENT: Enabled USE_MLX5DV support (mlx5 direct verbs)")
+        target_link_libraries(tent_xport_rdma PUBLIC mlx5)
+        target_compile_definitions(tent_xport_rdma PUBLIC USE_MLX5DV)
+    endif()
 endif()

--- a/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
@@ -431,9 +431,19 @@ int RdmaContext::enable() {
         status_ = DEVICE_ENABLED;
     }
 
+#ifdef USE_MLX5DV
+    // Query MLX5 LAG port information for LAG balancing support
+    mlx5dv_context dv_ctx = {};
+    dv_ctx.comp_mask = MLX5DV_CONTEXT_MASK_NUM_LAG_PORTS;
+    if (mlx5dv_query_device(native_context_, &dv_ctx) == 0) {
+        num_lag_ports_ = dv_ctx.num_lag_ports;
+    }
+#endif
+
     if (params_->verbose) {
         LOG(INFO) << "Context " << device_name_ << " is enabled: "
-                  << "LID " << lid_ << ", GID [" << gid_index_ << "] " << gid();
+                  << "LID " << lid_ << ", GID [" << gid_index_ << "] " << gid()
+                  << ", num_lag_ports: " << (int)num_lag_ports_;
     }
     return 0;
 }

--- a/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
@@ -512,8 +512,10 @@ Status RdmaEndPoint::accept(const BootstrapDesc& peer_desc,
             // QPs, it means the peer has recreated its endpoint.
             if (incoming_peer_server == peer_server_name_ &&
                 incoming_peer_nic == peer_nic_name_) {
-                status_.store(EP_DESTROYING, std::memory_order_release);
-                destroy_start_time_ = getCurrentTimeInNano();
+                // Call beginDestroyNoLock() directly to properly transition QPs
+                // to ERR state before remove() is called. This prevents the
+                // QPs from remaining in RTS state and causing hangs/leaks.
+                beginDestroyNoLock();
                 need_remove_ep = true;
             } else {
                 // Fill local_desc before returning error

--- a/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
@@ -28,6 +28,11 @@
 #include "tent/transport/rdma/context.h"
 #include "tent/transport/rdma/endpoint_store.h"
 #include "tent/common/utils/os.h"
+#include "tent/common/utils/random.h"
+
+#ifdef USE_MLX5DV
+#include <infiniband/mlx5dv.h>
+#endif
 #include "tent/common/utils/string_builder.h"
 #include "tent/thirdparty/nlohmann/json.h"
 
@@ -394,6 +399,12 @@ Status RdmaEndPoint::connect(const std::string& peer_server_name,
         peer_lid = peer_desc.local_lid;
     }
 
+    // Check if peer returned valid QP list (empty means peer is in transition)
+    if (qp_num.empty()) {
+        return mooncake::tent::Status::InternalError(
+            "Peer returned empty QP list, endpoint may be in transition, retry later" LOC_MARK);
+    }
+
     if (peer_gid.empty()) {
         return mooncake::tent::Status::InvalidArgument(
             "Missing peer GID in bootstrap" LOC_MARK);
@@ -444,44 +455,90 @@ Status RdmaEndPoint::connect(const std::string& peer_server_name,
 
 Status RdmaEndPoint::accept(const BootstrapDesc& peer_desc,
                             BootstrapDesc& local_desc) {
-    RWSpinlock::WriteGuard guard(lock_);
-    if (status_.load(std::memory_order_relaxed) == EP_READY) {
-        // Idempotency check: if the incoming bootstrap is from the same peer
-        // and carries the same peer QP list as the established connection,
-        // this is a duplicate request (e.g. from a concurrent connect() on
-        // the initiator that released its lock during Phase 2). Re-using the
-        // existing connection is safe and avoids resetting QPs that may
-        // already have in-flight RDMA operations.
-        auto incoming_peer_server =
-            getServerNameFromNicPath(peer_desc.local_nic_path);
-        auto incoming_peer_nic =
-            getNicNameFromNicPath(peer_desc.local_nic_path);
-        if (incoming_peer_server == peer_server_name_ &&
-            incoming_peer_nic == peer_nic_name_ &&
-            peer_desc.qp_num == peer_qp_num_list_) {
-            LOG(INFO) << "Endpoint already established with " << peer_nic_name_
-                      << " of " << peer_server_name_
-                      << " (duplicate bootstrap, reusing connection)";
-            auto& transport = context_->transport_;
-            local_desc.local_nic_path =
-                MakeNicPath(transport.rdma_server_name_, context_->name());
-            local_desc.peer_nic_path = peer_desc.local_nic_path;
-            local_desc.qp_num = qpNum();
-            local_desc.local_lid = context_->lid();
-            local_desc.local_gid = context_->gid();
-            local_desc.notify_qp_num = notifyQpNum();
-            return mooncake::tent::Status::OK();
+    // First pass: check if we need random backoff before acquiring lock
+    auto incoming_peer_server = getServerNameFromNicPath(peer_desc.local_nic_path);
+    auto incoming_peer_nic = getNicNameFromNicPath(peer_desc.local_nic_path);
+
+    bool need_backoff = false;
+    {
+        RWSpinlock::ReadGuard read_guard(lock_);
+        auto current_status = status_.load(std::memory_order_relaxed);
+        // Only check for backoff if EP is READY (peer info is initialized)
+        if (current_status == EP_READY) {
+            if (incoming_peer_server == peer_server_name_ &&
+                incoming_peer_nic == peer_nic_name_ &&
+                peer_desc.qp_num != peer_qp_num_list_) {
+                need_backoff = true;
+            }
         }
-        // Endpoint already connected to a different peer - reject the request
-        // instead of resetting. Endpoints have unidirectional lifecycle and
-        // are never reset or reused. The caller should create a new endpoint.
-        LOG(ERROR)
-            << "Endpoint already established with " << peer_nic_name_ << " of "
-            << peer_server_name_
-            << ", cannot accept new connection (unidirectional lifecycle)";
-        return mooncake::tent::Status::InternalError(
-            "Endpoint already connected to different peer" LOC_MARK);
     }
+
+    // Random backoff: 0-200ms to avoid synchronized retries
+    if (need_backoff) {
+        usleep(SimpleRandom::Get().next(200000));
+    }
+
+    // Main logic with write lock
+    bool need_remove_ep = false;
+    {
+        RWSpinlock::WriteGuard guard(lock_);
+        if (status_.load(std::memory_order_relaxed) == EP_READY) {
+            // Idempotency check: if the incoming bootstrap is from the same peer
+            // and carries the same peer QP list as the established connection,
+            // this is a duplicate request (e.g. from a concurrent connect() on
+            // the initiator that released its lock during Phase 2). Re-using the
+            // existing connection is safe and avoids resetting QPs that may
+            // already have in-flight RDMA operations.
+            if (incoming_peer_server == peer_server_name_ &&
+                incoming_peer_nic == peer_nic_name_ &&
+                peer_desc.qp_num == peer_qp_num_list_) {
+                LOG(INFO) << "Endpoint already established with " << peer_nic_name_
+                          << " of " << peer_server_name_
+                          << " (duplicate bootstrap, reusing connection)";
+                auto& transport = context_->transport_;
+                local_desc.local_nic_path =
+                    MakeNicPath(transport.rdma_server_name_, context_->name());
+                local_desc.peer_nic_path = peer_desc.local_nic_path;
+                local_desc.qp_num = qpNum();
+                local_desc.local_lid = context_->lid();
+                local_desc.local_gid = context_->gid();
+                local_desc.notify_qp_num = notifyQpNum();
+                return mooncake::tent::Status::OK();
+            }
+
+            // If the incoming request is from the same peer but with different QPs,
+            // it means the peer has recreated its endpoint.
+            if (incoming_peer_server == peer_server_name_ &&
+                incoming_peer_nic == peer_nic_name_) {
+                status_.store(EP_DESTROYING, std::memory_order_release);
+                destroy_start_time_ = getCurrentTimeInNano();
+                need_remove_ep = true;
+            } else {
+                // Fill local_desc before returning error
+                auto& transport = context_->transport_;
+                local_desc.local_nic_path =
+                    MakeNicPath(transport.rdma_server_name_, context_->name());
+                local_desc.local_lid = context_->lid();
+                local_desc.local_gid = context_->gid();
+                return mooncake::tent::Status::InternalError(
+                    "Endpoint already connected to different peer" LOC_MARK);
+            }
+        }
+    }
+
+    // Remove from endpoint store outside of lock to avoid potential deadlock
+    if (need_remove_ep) {
+        context_->endpointStore()->remove(this);
+        // Fill local_desc before returning error so peer can retry properly
+        auto& transport = context_->transport_;
+        local_desc.local_nic_path =
+            MakeNicPath(transport.rdma_server_name_, context_->name());
+        local_desc.local_lid = context_->lid();
+        local_desc.local_gid = context_->gid();
+        return mooncake::tent::Status::InternalError(
+            "Peer endpoint recreated, need new connection" LOC_MARK);
+    }
+
     if (status_.load(std::memory_order_relaxed) != EP_HANDSHAKING) {
         LOG(ERROR) << "Endpoint not in handshaking state: "
                    << statusToString(status_.load(std::memory_order_relaxed));
@@ -844,6 +901,62 @@ int RdmaEndPoint::setupOneQP(int qp_index, const std::string& peer_gid,
         LOG(ERROR) << ss.str();
         if (reply_msg) *reply_msg = ss.str();
         return -1;
+    }
+
+    const auto& config = context_->transport_.config();
+    if (config->get("transports/rdma/mlx5_qp_lag_port_balance", false)) {
+#ifdef USE_MLX5DV
+        uint8_t n = context_->numLagPorts();
+        if (n > 1) {
+            uint8_t target = (uint8_t)(qp_index % n) + 1;
+            int lag_ret = mlx5dv_modify_qp_lag_port(qp, target);
+            if (lag_ret) {
+                LOG_FIRST_N(WARNING, 4)
+                    << "[RDMA] mlx5dv_modify_qp_lag_port failed"
+                    << " (qp_index=" << qp_index
+                    << ", target_port=" << (int)target
+                    << "): " << strerror(lag_ret);
+            } else {
+                uint8_t cfg = 0, active = 0;
+                if (mlx5dv_query_qp_lag_port(qp, &cfg, &active) == 0) {
+                    VLOG(1) << "[RDMA] QP[" << qp_index << "] qpn=" << qp->qp_num
+                           << " lag_port cfg=" << (int)cfg
+                           << " active=" << (int)active;
+                } else {
+                    LOG_FIRST_N(WARNING, 4)
+                        << "[RDMA] mlx5dv_query_qp_lag_port failed"
+                        << " (qp_index=" << qp_index << ")";
+                }
+            }
+        }
+#else
+        LOG_FIRST_N(WARNING, 1)
+            << "MC_MLX5_QP_LAG_PORT_BALANCE is set but binary was not built "
+               "with USE_MLX5DV; ignoring";
+#endif
+    }
+
+    // Optional: override the RoCEv2 UDP source port to spread QPs across
+    // different ECMP/LAG paths
+    auto udp_sports =
+        config->getArray<uint16_t>("transports/rdma/mlx5_qp_udp_sports");
+    if (!udp_sports.empty()) {
+#ifdef USE_MLX5DV
+        uint16_t sport = udp_sports[qp_index % udp_sports.size()];
+        int sp_ret = mlx5dv_modify_qp_udp_sport(qp, sport);
+        if (sp_ret) {
+            LOG_FIRST_N(WARNING, 4)
+                << "[RDMA] mlx5dv_modify_qp_udp_sport failed (qp_index="
+                << qp_index << ", sport=" << sport << "): " << strerror(sp_ret);
+        } else {
+            VLOG(1) << "[RDMA] QP[" << qp_index << "] qpn=" << qp->qp_num
+                   << " udp_sport=" << sport;
+        }
+#else
+        LOG_FIRST_N(WARNING, 1)
+            << "MC_MLX5_QP_UDP_SPORTS is set but binary was not built with "
+               "USE_MLX5DV; ignoring";
+#endif
     }
 
     return 0;

--- a/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
@@ -402,7 +402,8 @@ Status RdmaEndPoint::connect(const std::string& peer_server_name,
     // Check if peer returned valid QP list (empty means peer is in transition)
     if (qp_num.empty()) {
         return mooncake::tent::Status::InternalError(
-            "Peer returned empty QP list, endpoint may be in transition, retry later" LOC_MARK);
+            "Peer returned empty QP list, endpoint may be in transition, retry "
+            "later" LOC_MARK);
     }
 
     if (peer_gid.empty()) {
@@ -456,7 +457,8 @@ Status RdmaEndPoint::connect(const std::string& peer_server_name,
 Status RdmaEndPoint::accept(const BootstrapDesc& peer_desc,
                             BootstrapDesc& local_desc) {
     // First pass: check if we need random backoff before acquiring lock
-    auto incoming_peer_server = getServerNameFromNicPath(peer_desc.local_nic_path);
+    auto incoming_peer_server =
+        getServerNameFromNicPath(peer_desc.local_nic_path);
     auto incoming_peer_nic = getNicNameFromNicPath(peer_desc.local_nic_path);
 
     bool need_backoff = false;
@@ -483,17 +485,17 @@ Status RdmaEndPoint::accept(const BootstrapDesc& peer_desc,
     {
         RWSpinlock::WriteGuard guard(lock_);
         if (status_.load(std::memory_order_relaxed) == EP_READY) {
-            // Idempotency check: if the incoming bootstrap is from the same peer
-            // and carries the same peer QP list as the established connection,
-            // this is a duplicate request (e.g. from a concurrent connect() on
-            // the initiator that released its lock during Phase 2). Re-using the
-            // existing connection is safe and avoids resetting QPs that may
-            // already have in-flight RDMA operations.
+            // Idempotency check: if the incoming bootstrap is from the same
+            // peer and carries the same peer QP list as the established
+            // connection, this is a duplicate request (e.g. from a concurrent
+            // connect() on the initiator that released its lock during Phase
+            // 2). Re-using the existing connection is safe and avoids resetting
+            // QPs that may already have in-flight RDMA operations.
             if (incoming_peer_server == peer_server_name_ &&
                 incoming_peer_nic == peer_nic_name_ &&
                 peer_desc.qp_num == peer_qp_num_list_) {
-                LOG(INFO) << "Endpoint already established with " << peer_nic_name_
-                          << " of " << peer_server_name_
+                LOG(INFO) << "Endpoint already established with "
+                          << peer_nic_name_ << " of " << peer_server_name_
                           << " (duplicate bootstrap, reusing connection)";
                 auto& transport = context_->transport_;
                 local_desc.local_nic_path =
@@ -506,8 +508,8 @@ Status RdmaEndPoint::accept(const BootstrapDesc& peer_desc,
                 return mooncake::tent::Status::OK();
             }
 
-            // If the incoming request is from the same peer but with different QPs,
-            // it means the peer has recreated its endpoint.
+            // If the incoming request is from the same peer but with different
+            // QPs, it means the peer has recreated its endpoint.
             if (incoming_peer_server == peer_server_name_ &&
                 incoming_peer_nic == peer_nic_name_) {
                 status_.store(EP_DESTROYING, std::memory_order_release);
@@ -919,9 +921,10 @@ int RdmaEndPoint::setupOneQP(int qp_index, const std::string& peer_gid,
             } else {
                 uint8_t cfg = 0, active = 0;
                 if (mlx5dv_query_qp_lag_port(qp, &cfg, &active) == 0) {
-                    VLOG(1) << "[RDMA] QP[" << qp_index << "] qpn=" << qp->qp_num
-                           << " lag_port cfg=" << (int)cfg
-                           << " active=" << (int)active;
+                    VLOG(1)
+                        << "[RDMA] QP[" << qp_index << "] qpn=" << qp->qp_num
+                        << " lag_port cfg=" << (int)cfg
+                        << " active=" << (int)active;
                 } else {
                     LOG_FIRST_N(WARNING, 4)
                         << "[RDMA] mlx5dv_query_qp_lag_port failed"
@@ -950,7 +953,7 @@ int RdmaEndPoint::setupOneQP(int qp_index, const std::string& peer_gid,
                 << qp_index << ", sport=" << sport << "): " << strerror(sp_ret);
         } else {
             VLOG(1) << "[RDMA] QP[" << qp_index << "] qpn=" << qp->qp_num
-                   << " udp_sport=" << sport;
+                    << " udp_sport=" << sport;
         }
 #else
         LOG_FIRST_N(WARNING, 1)

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
@@ -566,7 +566,7 @@ int RdmaTransport::onSetupRdmaConnections(const BootstrapDesc& peer_desc,
     if (local_nic_name.empty() || !context_name_lookup_.count(local_nic_name)) {
         std::stringstream ss;
         ss << "No device found in local segment: " << local_nic_name;
-        LOG(ERROR) << ss.str();
+        LOG(WARNING) << ss.str();
         local_desc.reply_msg = ss.str();
         return -1;
     }
@@ -575,7 +575,7 @@ int RdmaTransport::onSetupRdmaConnections(const BootstrapDesc& peer_desc,
     if (context->status() == RdmaContext::DEVICE_DISABLED) {
         std::stringstream ss;
         ss << "Device is down: " << peer_desc.local_nic_path;
-        LOG(ERROR) << ss.str();
+        LOG(WARNING) << ss.str();
         local_desc.reply_msg = ss.str();
         return -1;
     }
@@ -584,13 +584,13 @@ int RdmaTransport::onSetupRdmaConnections(const BootstrapDesc& peer_desc,
     if (!endpoint) {
         std::stringstream ss;
         ss << "Cannot allocate endpoint: " << peer_desc.local_nic_path;
-        LOG(ERROR) << ss.str();
+        LOG(WARNING) << ss.str();
         local_desc.reply_msg = ss.str();
         return -1;
     }
     auto status = endpoint->accept(peer_desc, local_desc);
     if (!status.ok()) {
-        LOG(ERROR) << status.ToString();
+        LOG(WARNING) << status.ToString();
         local_desc.reply_msg = status.ToString();
         return -1;
     }

--- a/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
@@ -496,7 +496,8 @@ void Workers::asyncPollCq() {
                               << ", dest_addr: " << (void*)slice->target_addr
                               << ", length: " << slice->length
                               << ", local_nic: " << context->name()
-                              << ", remote_nic: " << (ep ? ep->peerNicName() : "unknown")
+                              << ", remote_nic: "
+                              << (ep ? ep->peerNicName() : "unknown")
                               << "): " << ibv_wc_status_str(wc[i].status);
                 }
                 slice->retry_count++;
@@ -796,7 +797,7 @@ Status Workers::selectFallbackDevice(RouteHint& source, RouteHint& target,
                 getOrCreateRail(worker.rails, target.segment->machine_id);
             if (!rail.ready() || target.topo != rail.remote())
                 rail.load(source.topo, target.topo, /*rail_topo_json=*/"",
-                        transport_->conf_.get());
+                          transport_->conf_.get());
             reachable = rail.available(sdev, tdev);
         }
 

--- a/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
@@ -496,6 +496,7 @@ void Workers::asyncPollCq() {
                               << ", dest_addr: " << (void*)slice->target_addr
                               << ", length: " << slice->length
                               << ", local_nic: " << context->name()
+                              << ", remote_nic: " << (ep ? ep->peerNicName() : "unknown")
                               << "): " << ibv_wc_status_str(wc[i].status);
                 }
                 slice->retry_count++;
@@ -737,23 +738,6 @@ Status Workers::selectOptimalDevice(RouteHint& source, RouteHint& target,
             break;
         }
     }
-    /*
-    if (slice->target_dev_id < 0) {
-        int mapped_dev_id = rail.findBestRemoteDevice(
-            slice->source_dev_id, target.topo_entry->numa_node);
-        for (size_t rank = 0; rank < Topology::DevicePriorityRanks; ++rank) {
-            auto &list = target.topo_entry->device_list[rank];
-            if (list.empty()) continue;
-            auto it = std::find(list.begin(), list.end(), mapped_dev_id);
-            if (it != list.end()) {
-                slice->target_dev_id = mapped_dev_id;
-                break;
-            }
-            slice->target_dev_id = list[SimpleRandom::Get().next(list.size())];
-            break;
-        }
-    }
-    */
 
     if (slice->target_dev_id < 0)
         return Status::DeviceNotFound(
@@ -810,6 +794,9 @@ Status Workers::selectFallbackDevice(RouteHint& source, RouteHint& target,
             auto& worker = worker_context_[tl_wid];
             auto& rail =
                 getOrCreateRail(worker.rails, target.segment->machine_id);
+            if (!rail.ready() || target.topo != rail.remote())
+                rail.load(source.topo, target.topo, /*rail_topo_json=*/"",
+                        transport_->conf_.get());
             reachable = rail.available(sdev, tdev);
         }
 


### PR DESCRIPTION
## Description

1. RDMA Failure Tracking and Bypass
  - Automatically bypass RDMA and use TCP when failure threshold is exceeded, which is configurable via rdma_failure_threshold (default: 3) and rdma_failure_time_window_sec (default: 300)
 
2. Endpoint Rebuild Logic
  - When alice reset a endpoint, it will be marked as destroying and evict the endpointStore immediately. However, the remote side still has the old endpoint, which refuse QP reconstruction. Therefore, we allow the remote side evict the old endpoint from endpointStore and create another one during the accept() logic. To avoid ping-pong problem we enforce random backoff during reinitialization.

## Module

- [X] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



**Test commands:**
```bash
# Example: bash scripts/run_ci_test.sh
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [ ] AI tools were used (specify below)