### PR TITLE
[CI] Change options to speed up ci for ascend.

### DIFF
--- a/.github/workflows/ci_ascend.yml
+++ b/.github/workflows/ci_ascend.yml
@@ -164,7 +164,8 @@ jobs:
           -DUSE_ASCEND_DIRECT=ON \
           -DBUILD_EXAMPLES=OFF \
           -DBUILD_UNIT_TESTS=OFF \
-          -DENABLE_DEBUG_SYMBOLS=OFF
+          -DENABLE_DEBUG_SYMBOLS=OFF \
+          -DBUILD_BENCHMARK=OFF
 
     - name: Build
       shell: bash
@@ -172,7 +173,7 @@ jobs:
         source /usr/local/Ascend/cann-9.0.0/set_env.sh
         echo "Building..."
         cd build
-        cmake --build . -j$(nproc)
+        cmake --build . -j48
         cmake --install .
         echo "Mooncake installed successfully."
 


### PR DESCRIPTION
## Description


  1. Added -DBUILD_BENCHMARK=OFF to the CMake config — disables benchmark compilation in the CI pipeline.
  2. Changed cmake --build . -j$(nproc) to -j48 — hardcodes 48 parallel build jobs instead of using the runner's CPU
  count.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [x] Other

## How Has This Been Tested?



The self-host runner on my forked repository, the build time was reduced to [～10mins](https://github.com/VNightMare/Mooncake/actions/runs/27346000090/job/80794700322)

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [x] No AI tools were used
- [ ] AI tools were used (specify below)