### PR TITLE
[Store] Add size-class aware allocation strategy

### DIFF
--- a/mooncake-store/benchmarks/allocation_strategy_bench.cpp
+++ b/mooncake-store/benchmarks/allocation_strategy_bench.cpp
@@ -397,6 +397,8 @@ static std::string strategyName(AllocationStrategyType type) {
             return "Random";
         case AllocationStrategyType::FREE_RATIO_FIRST:
             return "FreeRatioFirst";
+        case AllocationStrategyType::SIZE_CLASS_AWARE:
+            return "SizeClassAware";
         default:
             return "Unknown";
     }
@@ -1058,6 +1060,7 @@ static void runFillupBenchmarks() {
     std::vector<AllocationStrategyType> strategies = {
         AllocationStrategyType::RANDOM,
         AllocationStrategyType::FREE_RATIO_FIRST,
+        AllocationStrategyType::SIZE_CLASS_AWARE,
     };
 
     std::cout
@@ -1121,7 +1124,8 @@ static void runScaleOutMatrix() {
     std::vector<int> replica_nums = {1, 2, 3};
     std::vector<AllocationStrategyType> strategies = {
         AllocationStrategyType::RANDOM,
-        AllocationStrategyType::FREE_RATIO_FIRST};
+        AllocationStrategyType::FREE_RATIO_FIRST,
+        AllocationStrategyType::SIZE_CLASS_AWARE};
 
     std::cout
         << "\n=== Scale-Out Workload Benchmark (Matrix) ===\n"
@@ -1187,6 +1191,7 @@ static void runDsaMatrix() {
     std::vector<AllocationStrategyType> strategies = {
         AllocationStrategyType::RANDOM,
         AllocationStrategyType::FREE_RATIO_FIRST,
+        AllocationStrategyType::SIZE_CLASS_AWARE,
     };
 
     size_t seg_cap_mb = static_cast<size_t>(FLAGS_dsa_segment_capacity);

--- a/mooncake-store/include/allocation_strategy.h
+++ b/mooncake-store/include/allocation_strategy.h
@@ -582,6 +582,25 @@ class SizeClassAwareAllocationStrategy : public RandomAllocationStrategy {
 
         std::vector<Replica> replicas;
         replicas.reserve(replica_num);
+
+        // Fast path: when there is only one segment, size-class ranking cannot
+        // change placement. Match RandomAllocationStrategy and avoid segment
+        // metric collection/sorting overhead.
+        if (names.size() == 1) {
+            if (excluded_segments.contains(names[0])) {
+                return tl::make_unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
+            }
+
+            auto buffer = allocateSingle(allocator_manager, names[0],
+                                         slice_length, generator);
+            if (buffer) {
+                replicas.emplace_back(std::move(buffer),
+                                      ReplicaStatus::PROCESSING, replica_type);
+                return replicas;
+            }
+            return tl::make_unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
+        }
+
         std::set<std::string> used_segments;
 
         for (const auto& preferred_segment : preferred_segments) {

--- a/mooncake-store/include/allocation_strategy.h
+++ b/mooncake-store/include/allocation_strategy.h
@@ -538,6 +538,281 @@ class FreeRatioFirstAllocationStrategy : public RandomAllocationStrategy {
     }
 };
 
+/**
+ * @brief Size-class-aware allocation strategy.
+ *
+ * Mixed KVCache-style workloads often contain many small metadata/indexer
+ * objects and fewer large KV blocks. If all requests simply chase the highest
+ * free ratio, small objects can consume the largest contiguous holes that later
+ * large objects need. This strategy keeps the public allocation API unchanged
+ * and uses only allocator-level observations:
+ *
+ * - small (<= 64 KiB): prefer the smallest largest-free-region that can still
+ *   fit the request. This packs small objects into already fragmented segments.
+ * - medium (<= 1 MiB): prefer moderate free ratio and smaller holes to balance
+ *   packing with load distribution.
+ * - large (> 1 MiB): prefer the largest contiguous free region, then free
+ *   ratio. This preserves large-object success under fragmentation.
+ *
+ * Replica placement remains best-effort and still avoids duplicate segments
+ * for replicas of the same slice.
+ */
+class SizeClassAwareAllocationStrategy : public RandomAllocationStrategy {
+   public:
+    SizeClassAwareAllocationStrategy() = default;
+
+    tl::expected<std::vector<Replica>, ErrorCode> Allocate(
+        const AllocatorManager& allocator_manager, const size_t slice_length,
+        const size_t replica_num = 1,
+        const std::vector<std::string>& preferred_segments =
+            std::vector<std::string>(),
+        const std::set<std::string>& excluded_segments =
+            std::set<std::string>(),
+        const ReplicaType replica_type = ReplicaType::MEMORY) override {
+        if (slice_length == 0 || replica_num == 0) {
+            return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+        }
+
+        const auto& names = allocator_manager.getNames();
+        if (names.empty()) {
+            return tl::make_unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
+        }
+
+        static thread_local std::mt19937 generator(std::random_device{}());
+
+        std::vector<Replica> replicas;
+        replicas.reserve(replica_num);
+        std::set<std::string> used_segments;
+
+        for (const auto& preferred_segment : preferred_segments) {
+            if (excluded_segments.contains(preferred_segment) ||
+                used_segments.contains(preferred_segment)) {
+                continue;
+            }
+
+            auto buffer = allocateSingle(allocator_manager, preferred_segment,
+                                         slice_length, generator);
+            if (buffer) {
+                replicas.emplace_back(std::move(buffer),
+                                      ReplicaStatus::PROCESSING, replica_type);
+                used_segments.insert(preferred_segment);
+                if (replicas.size() == replica_num) {
+                    return replicas;
+                }
+            }
+        }
+
+        std::vector<Candidate> candidates =
+            buildCandidates(allocator_manager, names, slice_length,
+                            replica_num - replicas.size(), excluded_segments,
+                            used_segments, generator);
+        sortCandidates(candidates, classify(slice_length));
+
+        for (const auto& candidate : candidates) {
+            if (replicas.size() >= replica_num) {
+                break;
+            }
+
+            const auto& name = names[candidate.name_idx];
+            auto buffer = allocateSingle(allocator_manager, name, slice_length,
+                                         generator);
+            if (buffer) {
+                replicas.emplace_back(std::move(buffer),
+                                      ReplicaStatus::PROCESSING, replica_type);
+                used_segments.insert(name);
+            }
+        }
+
+        if (replicas.size() >= replica_num) {
+            return replicas;
+        }
+
+        std::uniform_int_distribution<size_t> distribution(0, names.size() - 1);
+        size_t fallback_idx = distribution(generator);
+        const size_t max_retry = std::min(kMaxRetryLimit, names.size());
+        size_t try_count = 0;
+
+        while (replicas.size() < replica_num && try_count < max_retry) {
+            auto index = fallback_idx % names.size();
+            fallback_idx++;
+            try_count++;
+
+            if (excluded_segments.contains(names[index]) ||
+                used_segments.contains(names[index])) {
+                continue;
+            }
+
+            auto buffer = allocateSingle(allocator_manager, names[index],
+                                         slice_length, generator);
+            if (buffer) {
+                replicas.emplace_back(std::move(buffer),
+                                      ReplicaStatus::PROCESSING, replica_type);
+                used_segments.insert(names[index]);
+            }
+        }
+
+        if (replicas.empty()) {
+            return tl::make_unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
+        }
+        return replicas;
+    }
+
+   private:
+    enum class SizeClass {
+        SMALL,
+        MEDIUM,
+        LARGE,
+    };
+
+    struct Candidate {
+        size_t name_idx;
+        double free_ratio;
+        size_t largest_free_region;
+    };
+
+    static constexpr size_t kSmallThreshold = 64 * 1024;
+    static constexpr size_t kMediumThreshold = 1024 * 1024;
+    static constexpr size_t kMaxRetryLimit = 100;
+    // Inspecting every segment on each allocation can dominate benchmark time
+    // on large clusters. Sampling keeps the strategy O(replica_num) while still
+    // giving each size class enough choices to avoid obvious fragmentation.
+    static constexpr size_t kCandidateMultiplier = 16;
+    static constexpr size_t kMinCandidateSample = 32;
+
+    SizeClass classify(size_t slice_length) const {
+        if (slice_length <= kSmallThreshold) {
+            return SizeClass::SMALL;
+        }
+        if (slice_length <= kMediumThreshold) {
+            return SizeClass::MEDIUM;
+        }
+        return SizeClass::LARGE;
+    }
+
+    std::vector<Candidate> buildCandidates(
+        const AllocatorManager& allocator_manager,
+        const std::vector<std::string>& names, size_t slice_length,
+        size_t remaining_replicas,
+        const std::set<std::string>& excluded_segments,
+        const std::set<std::string>& used_segments,
+        std::mt19937& generator) const {
+        std::vector<Candidate> candidates;
+        if (remaining_replicas == 0) return candidates;
+
+        const size_t sample_count =
+            std::min(std::max(kMinCandidateSample,
+                              kCandidateMultiplier * remaining_replicas),
+                     names.size());
+        candidates.reserve(sample_count);
+
+        std::uniform_int_distribution<size_t> start_dist(0, names.size() - 1);
+        size_t start_idx = start_dist(generator);
+
+        for (size_t i = 0; i < sample_count; ++i) {
+            size_t name_idx = (start_idx + i) % names.size();
+            const auto& name = names[name_idx];
+            if (excluded_segments.contains(name) ||
+                used_segments.contains(name)) {
+                continue;
+            }
+
+            SegmentStats stats = getSegmentStats(allocator_manager, name);
+            if (!stats.valid || stats.largest_free_region < slice_length) {
+                continue;
+            }
+
+            candidates.push_back(
+                {name_idx, stats.free_ratio, stats.largest_free_region});
+        }
+
+        return candidates;
+    }
+
+    void sortCandidates(std::vector<Candidate>& candidates,
+                        SizeClass size_class) const {
+        switch (size_class) {
+            case SizeClass::SMALL:
+                std::sort(
+                    candidates.begin(), candidates.end(),
+                    [](const Candidate& a, const Candidate& b) {
+                        if (a.largest_free_region != b.largest_free_region) {
+                            return a.largest_free_region <
+                                   b.largest_free_region;
+                        }
+                        return a.free_ratio < b.free_ratio;
+                    });
+                break;
+            case SizeClass::MEDIUM:
+                std::sort(candidates.begin(), candidates.end(),
+                          [](const Candidate& a, const Candidate& b) {
+                              double a_score =
+                                  a.free_ratio /
+                                  static_cast<double>(a.largest_free_region);
+                              double b_score =
+                                  b.free_ratio /
+                                  static_cast<double>(b.largest_free_region);
+                              if (a_score != b_score) {
+                                  return a_score > b_score;
+                              }
+                              return a.free_ratio > b.free_ratio;
+                          });
+                break;
+            case SizeClass::LARGE:
+                std::sort(
+                    candidates.begin(), candidates.end(),
+                    [](const Candidate& a, const Candidate& b) {
+                        if (a.largest_free_region != b.largest_free_region) {
+                            return a.largest_free_region >
+                                   b.largest_free_region;
+                        }
+                        return a.free_ratio > b.free_ratio;
+                    });
+                break;
+        }
+    }
+
+    struct SegmentStats {
+        bool valid = false;
+        double free_ratio = 0.0;
+        size_t largest_free_region = 0;
+    };
+
+    SegmentStats getSegmentStats(const AllocatorManager& allocator_manager,
+                                 const std::string& name) const {
+        auto allocators = allocator_manager.getAllocators(name);
+        if (!allocators || allocators->empty()) return {};
+
+        size_t total_capacity = 0;
+        size_t total_free = 0;
+        size_t largest_free_region = 0;
+
+        for (const auto& alloc : *allocators) {
+            if (!alloc) continue;
+            const size_t capacity = alloc->capacity();
+            const size_t used = alloc->size();
+            if (used > capacity) continue;
+
+            total_capacity += capacity;
+            total_free += capacity - used;
+
+            size_t allocator_largest = alloc->getLargestFreeRegion();
+            if (allocator_largest == kAllocatorUnknownFreeSpace) {
+                allocator_largest = capacity - used;
+            }
+            largest_free_region =
+                std::max(largest_free_region, allocator_largest);
+        }
+
+        if (total_capacity == 0) return {};
+        return {
+            true,
+            static_cast<double>(total_free) /
+                static_cast<double>(total_capacity),
+            largest_free_region,
+        };
+    }
+};
+
 class CxlAllocationStrategy : public AllocationStrategy {
    public:
     CxlAllocationStrategy() = default;
@@ -609,6 +884,8 @@ inline std::shared_ptr<AllocationStrategy> CreateAllocationStrategy(
             return std::make_shared<RandomAllocationStrategy>();
         case AllocationStrategyType::FREE_RATIO_FIRST:
             return std::make_shared<FreeRatioFirstAllocationStrategy>();
+        case AllocationStrategyType::SIZE_CLASS_AWARE:
+            return std::make_shared<SizeClassAwareAllocationStrategy>();
         case AllocationStrategyType::CXL:
             return std::make_shared<CxlAllocationStrategy>();
         default:

--- a/mooncake-store/include/types.h
+++ b/mooncake-store/include/types.h
@@ -463,6 +463,7 @@ enum class AllocationStrategyType {
     RANDOM = 0,        // Pure random allocation
     FREE_RATIO_FIRST,  // Free-ratio-first allocation
     CXL,               // CXL-specific allocation
+    SIZE_CLASS_AWARE,  // Size-class-aware segment selection
 };
 
 /**


### PR DESCRIPTION
## Description

Add `SizeClassAwareAllocationStrategy`, a new Mooncake Store allocation strategy that selects segments based on request size to reduce fragmentation under mixed-size KVCache workloads.

Existing strategies such as `Random` and `FreeRatioFirst` treat allocation requests uniformly regardless of object size. When small metadata objects and large KV blocks compete for the same segments, small requests may consume contiguous holes that large requests need later, increasing fragmentation and causing avoidable partial allocations or evictions.

The new strategy classifies requests by size and ranks candidate segments differently per class:

- Small objects are packed into already fragmented segments.
- Medium objects balance free ratio and contiguous hole size.
- Large objects prefer segments with the largest contiguous free region.

The implementation does not modify `OffsetAllocator` internals and does not change any public API. It inherits from `RandomAllocationStrategy`, reuses the existing `allocateSingle` helper, preserves best-effort allocation semantics, and avoids placing two replicas of the same slice on the same segment.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Performance improvement
- [ ] Other

## How Has This Been Tested?

Benchmark methodology uses the `size_class_churn` workload introduced in [#2340](https://github.com/kvcache-ai/Mooncake/pull/2340), which measures fragmentation, largest free region, and allocation success/failure rates at the allocation-strategy layer. A Mooncake collaborator reviewed that PR and agreed that this workload is useful when framed as a strategy-level fragmentation benchmark rather than a replacement for the low-level allocator microbenchmark.

Local run configuration:

- `segment_capacity=64MB`
- `num_allocations=2000`
- `prefill_pct=70`
- `size_class_pattern=all`
- `size_class_evict_ratio=0.02`

Representative results with `segments=100`:

| Pattern | Skewed | Replica | Strategy | Frag avg | Frag p99 | Largest free MB | Full/Partial/Fail/Total |
|---|---:|---:|---|---:|---:|---:|---:|
| kv_mixed | no | 3 | Random | 0.1121 | 0.3629 | 3.2 | 1997/3/0/2000 |
| kv_mixed | no | 3 | FreeRatioFirst | 0.1141 | 0.4126 | 3.2 | 1995/5/0/2000 |
| kv_mixed | no | 3 | SizeClassAware | 0.0811 | 0.2881 | 3.2 | 1999/1/0/2000 |
| dsa_pair | no | 2 | Random | 0.4354 | 0.6201 | 5.5 | 1969/31/0/2000 |
| dsa_pair | no | 2 | FreeRatioFirst | 0.3879 | 0.5160 | 3.8 | 1966/34/0/2000 |
| dsa_pair | no | 2 | SizeClassAware | 0.2316 | 0.4079 | 3.8 | 1986/14/0/2000 |
| dsa_pair | yes | 3 | Random | 0.4328 | 0.5957 | 3.8 | 1928/72/0/2000 |
| dsa_pair | yes | 3 | FreeRatioFirst | 0.5023 | 0.6498 | 5.0 | 1938/62/0/2000 |
| dsa_pair | yes | 3 | SizeClassAware | 0.2124 | 0.3978 | 3.8 | 1978/22/0/2000 |

In these representative mixed-size cases, `SizeClassAware` lowers average fragmentation by about 28-51% and reduces partial allocations compared with the stronger existing baseline.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue