### PR TITLE
fix(efa): declare FI_HMEM in caps for GPU builds

### DIFF
--- a/mooncake-transfer-engine/src/transport/efa_transport/efa_context.cpp
+++ b/mooncake-transfer-engine/src/transport/efa_transport/efa_context.cpp
@@ -73,7 +73,20 @@ int EfaContext::construct(size_t num_cq_list, size_t max_cqe,
     }
 
     hints_->caps =
-        FI_MSG | FI_RMA | FI_READ | FI_WRITE | FI_REMOTE_READ | FI_REMOTE_WRITE;
+        FI_MSG | FI_RMA | FI_READ | FI_WRITE | FI_REMOTE_READ |
+        FI_REMOTE_WRITE
+#if defined(USE_CUDA) || defined(USE_HIP)
+        // Declare FI_HMEM so the provider wires up HMEM-aware copy routines
+        // (cudaMemcpy) on every data path, including the intra-node SHM SAR
+        // segmentation/reassembly path. Registering device memory via
+        // FI_MR_HMEM alone is NOT enough: without FI_HMEM in caps the SHM
+        // sub-provider initializes its copy callbacks in plain-host mode and
+        // does a host memcpy() straight into a CUDA device VA during SAR,
+        // which SIGSEGVs in __memcpy_avx512_unaligned_erms.
+        // See https://github.com/ofiwg/libfabric/issues/12328.
+        | FI_HMEM
+#endif
+        ;
     hints_->mode = FI_CONTEXT;
     hints_->ep_attr->type = FI_EP_RDM;  // EFA uses RDM endpoints
     hints_->fabric_attr->prov_name = strdup("efa");


### PR DESCRIPTION
## Description

The EFA RDM provider routes intra-node transfers through its SHM sub-provider. For transfers above the SHM inline limit, SHM performs Segmentation And Reassembly (SAR), copying the payload through a bounce buffer.

Registering device memory with `FI_MR_HMEM` (in `mr_mode`) alone is **not** sufficient: without `FI_HMEM` in `hints->caps`, the SHM copy callbacks are initialized in plain-host mode, so SAR does a host `memcpy()` directly into a CUDA device virtual address and **SIGSEGVs in `__memcpy_avx512_unaligned_erms`** — on the send path (`smr_copy_to_sar`) or on the CQ-poller receive path (`smr_copy_from_sar`).

This affects **cross-process, same-node GPU-to-GPU transfers** (e.g. two ranks colocated on one node). The same-process self-loopback fast path (`tryLoopbackCopy`, #2298) does not cover these, since cross-process peers carry distinct RPC ports and still route through libfabric → EFA RDM → SHM SAR.

This PR adds `FI_HMEM` to `caps` (guarded on `USE_CUDA`/`USE_HIP`, matching the existing `FI_MR_HMEM` gating). The provider then wires up HMEM-aware copies (`cudaMemcpy`/`cuMemcpy`) on every path, including SHM SAR. This keeps the fast intra-node SHM path enabled, unlike the `FI_EFA_ENABLE_SHM_TRANSFER=0` workaround.

Ref: https://github.com/ofiwg/libfabric/issues/12328

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Tested on **2× p5en.48xlarge (NVIDIA H200)**, libfabric `2.4.0amzn1.0`, EFA driver `3.0.0g`, CUDA 13, kernel `6.17.0-1017-aws`.

**A/B test** with `transfer_engine_bench` over EFA with GPU (VRAM) buffers, two processes on the **same node** (target on GPU 0, initiator on GPU 1), 64 KB blocks (above the SHM SAR threshold). The only difference between the two runs is this one-line `caps` change:

**Test commands:**
```bash
# build (AWS DLAMI /opt/pytorch env, CUDA toolkit from pip nvidia packages)
source /opt/pytorch/bin/activate
export CUDA_HOME=/opt/pytorch/lib/python3.13/site-packages/nvidia/cu13
export PATH=$CUDA_HOME/bin:$PATH
export CPLUS_INCLUDE_PATH=$CUDA_HOME/include:$CPLUS_INCLUDE_PATH
export LD_LIBRARY_PATH=$CUDA_HOME/lib:$LD_LIBRARY_PATH
export LIBRARY_PATH=$CUDA_HOME/lib:$LIBRARY_PATH
cd build && cmake .. -DUSE_EFA=ON -DUSE_CUDA=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo && make -j$(nproc)

# target (GPU 0)
./transfer_engine_bench --mode=target --protocol=efa --use_vram=true --gpu_id=0 \
    --metadata_server=P2PHANDSHAKE --local_server_name=$IP:17801 \
    --buffer_size=$((256*1024*1024))

# initiator (GPU 1) -> writes to target over EFA SHM (same node)
./transfer_engine_bench --mode=initiator --protocol=efa --use_vram=true --gpu_id=1 \
    --operation=write --metadata_server=P2PHANDSHAKE --local_server_name=$IP:17802 \
    --segment_id=$IP:<target_port> --buffer_size=$((256*1024*1024)) \
    --block_size=65536 --batch_size=16 --threads=4 --duration=8
```

**Test results:**

| Build | Result |
|-------|--------|
| **Without** this fix (`caps` lacks `FI_HMEM`) | SIGSEGV in `__memcpy_avx512_unaligned_erms` inside `libfabric.so.1` (SHM SAR copy), on both the submit thread and the CQ-poller thread — matches ofiwg/libfabric#12328 |
| **With** this fix (`caps` includes `FI_HMEM`) | Completes cleanly, ~1.05 GB/s, exit 0 |

Crash backtrace (without fix), confirming the SHM SAR memcpy-into-device-VA:
```
#0  __memcpy_avx512_unaligned_erms ()
#1-#8  ... in libfabric.so.1   [smr_copy_*_sar / ofi_copy_*_mr_iov / efa_rdm_*]
```

- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (cross-process same-node GPU↔GPU EFA transfer; A/B isolates this change as the fix)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Claude Code (Claude Opus) assisted with the libfabric capability-flag analysis, building/running the A/B reproducer on EFA hardware, and drafting this PR. The submitter has reviewed and validated all changes and test results.