### PR TITLE
[Wheel] Validate MooncakeConfig fields with fail-fast errors

### DIFF
--- a/mooncake-wheel/mooncake/mooncake_config.py
+++ b/mooncake-wheel/mooncake/mooncake_config.py
@@ -20,6 +20,7 @@ Python API Level (Commonly Used):
 Transfer Engine C++ Level (Advanced):
 -------------------------------------
 In addition to tcp and rdma, the C++ Transfer Engine also supports:
+- efa: AWS Elastic Fabric Adapter transport (libfabric-based)
 - nvmeof: NVMe over Fabric for direct NVMe storage access
 - nvlink: NVIDIA NVLink for inter-GPU communication across nodes
 - nvlink_intra: NVIDIA NVLink for intra-node GPU communication
@@ -71,6 +72,7 @@ _SIZE_SUFFIXES = [
 _VALID_PROTOCOLS = frozenset({
     "tcp",
     "rdma",
+    "efa",
     "nvmeof",
     "nvlink",
     "nvlink_intra",

--- a/mooncake-wheel/mooncake/mooncake_config.py
+++ b/mooncake-wheel/mooncake/mooncake_config.py
@@ -65,6 +65,28 @@ _SIZE_SUFFIXES = [
     ("b", 1),
 ]
 
+# All protocols accepted by the Transfer Engine. The Python API commonly uses
+# "tcp" and "rdma"; the remaining values are handled at the C++ level. Keep this
+# in sync with the protocol list documented in the module docstring above.
+_VALID_PROTOCOLS = frozenset({
+    "tcp",
+    "rdma",
+    "nvmeof",
+    "nvlink",
+    "nvlink_intra",
+    "hip",
+    "barex",
+    "cxl",
+    "ascend",
+})
+
+# Required fields that must be present AND non-empty.
+_REQUIRED_NON_EMPTY_FIELDS = (
+    "local_hostname",
+    "metadata_server",
+    "master_server_address",
+)
+
 
 def _parse_segment_size(value) -> int:
     if isinstance(value, int):
@@ -140,6 +162,38 @@ class MooncakeConfig:
     master_server_address: str
     enable_ssd_offload: bool = False
     ssd_offload_path: str = ""
+
+    def __post_init__(self):
+        """Validate configuration invariants, failing fast with clear errors.
+
+        This runs for every ``MooncakeConfig`` instance regardless of how it is
+        constructed (``from_file``, ``load_from_env`` or direct instantiation),
+        so a misconfiguration is reported here with an actionable message
+        instead of surfacing as a cryptic failure deep inside the C++ engine.
+        """
+        if (
+            not isinstance(self.protocol, str)
+            or self.protocol.lower() not in _VALID_PROTOCOLS
+        ):
+            raise ValueError(
+                f"Invalid protocol: {self.protocol!r}. Supported protocols are: "
+                f"{', '.join(sorted(_VALID_PROTOCOLS))}."
+            )
+
+        for field_name in ("global_segment_size", "local_buffer_size"):
+            value = getattr(self, field_name)
+            if value < 0:
+                raise ValueError(
+                    f"Invalid {field_name}: {value}. Size must be non-negative."
+                )
+
+        for field_name in _REQUIRED_NON_EMPTY_FIELDS:
+            value = getattr(self, field_name)
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(
+                    f"Config field {field_name!r} must be a non-empty string, "
+                    f"got {value!r}."
+                )
 
     @staticmethod
     def from_file(file_path: str) -> 'MooncakeConfig':

--- a/mooncake-wheel/mooncake/mooncake_config.py
+++ b/mooncake-wheel/mooncake/mooncake_config.py
@@ -29,6 +29,19 @@ In addition to tcp and rdma, the C++ Transfer Engine also supports:
 - cxl: Compute Express Link for memory pooling and sharing
 - ascend: Huawei Ascend NPU communication (HCCL and direct transport)
 
+Store Surface (mooncake-store):
+-------------------------------
+MooncakeConfig also drives the Mooncake Store, which additionally accepts:
+- ub / ubshmem: Unified Bus transport and its shared-memory variant
+- maca: MetaX MACA GPU transport
+- sunrise_link: SunriseLink interconnect transport
+- rpc_only: Store-only mode with no Transfer Engine attached
+
+Protocol names are matched case-sensitively by the C++ engine, so the value is
+normalised to lowercase when a MooncakeConfig is constructed (e.g. "RDMA" ->
+"rdma"). Because the authoritative, build-flag-dependent set lives in C++, an
+unrecognised protocol is passed through with a warning rather than rejected.
+
 For most use cases, 'tcp' or 'rdma' is recommended. The default is 'tcp'.
 For RDMA, you also need to specify the device_name (e.g., 'mlx5_0', 'erdma_0')
 or use auto-discovery.
@@ -47,9 +60,12 @@ export MOONCAKE_PROTOCOL="rdma"
 export MOONCAKE_DEVICE="auto-discovery"
 """
 import json
+import logging
 import os
 from dataclasses import dataclass
 from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_GLOBAL_SEGMENT_SIZE = 3355443200  # 3.125 GiB
 DEFAULT_LOCAL_BUFFER_SIZE = 1073741824  # 1.0 GiB
@@ -66,10 +82,17 @@ _SIZE_SUFFIXES = [
     ("b", 1),
 ]
 
-# All protocols accepted by the Transfer Engine. The Python API commonly uses
-# "tcp" and "rdma"; the remaining values are handled at the C++ level. Keep this
-# in sync with the protocol list documented in the module docstring above.
-_VALID_PROTOCOLS = frozenset({
+# Protocols Mooncake is known to accept. This is a *diagnostic hint*, not an
+# authoritative gate: MooncakeConfig drives both the Transfer Engine and the
+# Store, and the C++ layer is the source of truth for what a given build
+# actually supports (several transports are gated behind USE_* build flags).
+# The C++ comparisons are exact and lowercase (multi_transport.cpp
+# installTransport, mooncake-store client_service.cpp), so the protocol is
+# canonicalised to lowercase below and an unrecognised value only warns.
+# Union of Transfer Engine transports and Store-only modes. Keep in sync with
+# the protocol list documented in the module docstring above.
+_KNOWN_PROTOCOLS = frozenset({
+    # Transfer Engine transports (mooncake-transfer-engine installTransport)
     "tcp",
     "rdma",
     "efa",
@@ -80,6 +103,12 @@ _VALID_PROTOCOLS = frozenset({
     "barex",
     "cxl",
     "ascend",
+    "ub",
+    "ubshmem",
+    "maca",
+    "sunrise_link",
+    # Store-only mode (mooncake-store client_service.cpp: no transfer engine)
+    "rpc_only",
 })
 
 # Required fields that must be present AND non-empty.
@@ -118,10 +147,14 @@ class MooncakeConfig:
         metadata_server (str): The address of the metadata server.
         global_segment_size (int): The size of each global segment in bytes.
         local_buffer_size (int): The size of the local buffer in bytes.
-        protocol (str): The communication protocol to use. Supported values:
+        protocol (str): The communication protocol to use. Common values:
             - "tcp" (default): Standard TCP/IP protocol
             - "rdma": RDMA protocol (requires RDMA-capable NICs and device_name)
-            See module docstring for full list of supported protocols.
+            The value is normalised to lowercase (the C++ engine matches
+            protocol names case-sensitively). The Transfer Engine and Store
+            together accept a wider set; see the module docstring. An
+            unrecognised value is passed through to the engine with a warning,
+            not rejected.
         device_name (Optional[str]): The name of the RDMA device to use
             (e.g., "mlx5_0", "erdma_0", or "auto-discovery").
             Required when protocol is "rdma", optional for other protocols.
@@ -166,20 +199,38 @@ class MooncakeConfig:
     ssd_offload_path: str = ""
 
     def __post_init__(self):
-        """Validate configuration invariants, failing fast with clear errors.
+        """Validate and normalise configuration invariants.
 
         This runs for every ``MooncakeConfig`` instance regardless of how it is
-        constructed (``from_file``, ``load_from_env`` or direct instantiation),
-        so a misconfiguration is reported here with an actionable message
-        instead of surfacing as a cryptic failure deep inside the C++ engine.
+        constructed (``from_file``, ``load_from_env`` or direct instantiation).
+        The protocol is canonicalised to lowercase (the C++ engine is
+        case-sensitive) and an unrecognised protocol is warned about but passed
+        through, because the authoritative set is decided in the
+        build-flag-dependent C++ layer. Genuine structural problems (a
+        non-string or empty protocol, a negative size, an empty required field)
+        are still reported here with an actionable message instead of surfacing
+        as a cryptic failure deep inside the C++ engine.
         """
-        if (
-            not isinstance(self.protocol, str)
-            or self.protocol.lower() not in _VALID_PROTOCOLS
-        ):
+        if not isinstance(self.protocol, str) or not self.protocol.strip():
             raise ValueError(
-                f"Invalid protocol: {self.protocol!r}. Supported protocols are: "
-                f"{', '.join(sorted(_VALID_PROTOCOLS))}."
+                f"Invalid protocol: {self.protocol!r}. Protocol must be a "
+                f"non-empty string, e.g. 'tcp' or 'rdma'."
+            )
+        # Canonicalise to lowercase. The C++ engine matches protocol names
+        # case-sensitively against lowercase literals, so e.g. "RDMA" would be
+        # silently accepted here but rejected deep in the engine; normalising
+        # turns that hidden misconfiguration into a working configuration.
+        self.protocol = self.protocol.strip().lower()
+        # Warn (do not reject) on values we do not recognise: MooncakeConfig
+        # drives both Transfer Engine and Store paths, and a given build may
+        # support protocols beyond this list. The C++ layer is authoritative and
+        # will reject a genuinely unsupported protocol with its own error.
+        if self.protocol not in _KNOWN_PROTOCOLS:
+            logger.warning(
+                "Unrecognised protocol %r; passing it through to the Mooncake "
+                "engine unchanged. Known protocols are: %s.",
+                self.protocol,
+                ", ".join(sorted(_KNOWN_PROTOCOLS)),
             )
 
         for field_name in ("global_segment_size", "local_buffer_size"):

--- a/mooncake-wheel/tests/test_mooncake_config.py
+++ b/mooncake-wheel/tests/test_mooncake_config.py
@@ -218,7 +218,7 @@ class TestMooncakeConfigValidation(unittest.TestCase):
         return MooncakeConfig(**kwargs)
 
     def test_valid_protocols_accepted(self):
-        for protocol in ["tcp", "rdma", "RDMA", "Tcp", "cxl", "ascend", "nvlink_intra"]:
+        for protocol in ["tcp", "rdma", "efa", "RDMA", "Tcp", "cxl", "ascend", "nvlink_intra"]:
             with self.subTest(protocol=protocol):
                 config = self.make(protocol=protocol)
                 self.assertEqual(config.protocol, protocol)

--- a/mooncake-wheel/tests/test_mooncake_config.py
+++ b/mooncake-wheel/tests/test_mooncake_config.py
@@ -199,5 +199,83 @@ class TestParseSegmentSize(unittest.TestCase):
         self.assertEqual(_parse_segment_size("  3 gb  "), 3 * 1024 ** 3)
 
 
+class TestMooncakeConfigValidation(unittest.TestCase):
+    """Tests for the field validation performed in MooncakeConfig.__post_init__."""
+
+    BASE_KWARGS = dict(
+        local_hostname="localhost",
+        metadata_server="localhost:8080",
+        global_segment_size=DEFAULT_GLOBAL_SEGMENT_SIZE,
+        local_buffer_size=DEFAULT_LOCAL_BUFFER_SIZE,
+        protocol="tcp",
+        device_name="",
+        master_server_address="localhost:8081",
+    )
+
+    def make(self, **overrides):
+        kwargs = dict(self.BASE_KWARGS)
+        kwargs.update(overrides)
+        return MooncakeConfig(**kwargs)
+
+    def test_valid_protocols_accepted(self):
+        for protocol in ["tcp", "rdma", "RDMA", "Tcp", "cxl", "ascend", "nvlink_intra"]:
+            with self.subTest(protocol=protocol):
+                config = self.make(protocol=protocol)
+                self.assertEqual(config.protocol, protocol)
+
+    def test_invalid_protocol_raises(self):
+        for protocol in ["rmda", "udp", "", "foo"]:
+            with self.subTest(protocol=protocol):
+                with self.assertRaises(ValueError) as cm:
+                    self.make(protocol=protocol)
+                self.assertIn("Invalid protocol", str(cm.exception))
+
+    def test_non_string_protocol_raises(self):
+        with self.assertRaises(ValueError):
+            self.make(protocol=None)
+
+    def test_zero_sizes_allowed(self):
+        # 0 is a documented sentinel (e.g. global_segment_size == 0 disables the
+        # store), so it must remain valid.
+        config = self.make(global_segment_size=0, local_buffer_size=0)
+        self.assertEqual(config.global_segment_size, 0)
+        self.assertEqual(config.local_buffer_size, 0)
+
+    def test_negative_sizes_raise(self):
+        with self.assertRaises(ValueError) as cm:
+            self.make(global_segment_size=-1)
+        self.assertIn("global_segment_size", str(cm.exception))
+        with self.assertRaises(ValueError) as cm:
+            self.make(local_buffer_size=-1024)
+        self.assertIn("local_buffer_size", str(cm.exception))
+
+    def test_empty_required_field_raises(self):
+        for field in ["local_hostname", "metadata_server", "master_server_address"]:
+            for bad in ["", "   "]:
+                with self.subTest(field=field, value=bad):
+                    with self.assertRaises(ValueError) as cm:
+                        self.make(**{field: bad})
+                    self.assertIn(field, str(cm.exception))
+
+    def test_from_file_rejects_invalid_protocol(self):
+        with open(self.config_path, "w") as f:
+            json.dump({
+                "local_hostname": "localhost",
+                "metadata_server": "localhost:8080",
+                "master_server_address": "localhost:8081",
+                "protocol": "rmda",  # typo
+            }, f)
+        with self.assertRaises(ValueError) as cm:
+            MooncakeConfig.from_file(self.config_path)
+        self.assertIn("Invalid protocol", str(cm.exception))
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.config_path = os.path.join(self._tmp.name, "config.json")
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/mooncake-wheel/tests/test_mooncake_config.py
+++ b/mooncake-wheel/tests/test_mooncake_config.py
@@ -3,6 +3,7 @@ import os
 import tempfile
 import unittest
 
+from mooncake import mooncake_config as _cfg_mod
 from mooncake.mooncake_config import (
     MooncakeConfig,
     DEFAULT_GLOBAL_SEGMENT_SIZE,
@@ -217,18 +218,54 @@ class TestMooncakeConfigValidation(unittest.TestCase):
         kwargs.update(overrides)
         return MooncakeConfig(**kwargs)
 
-    def test_valid_protocols_accepted(self):
-        for protocol in ["tcp", "rdma", "efa", "RDMA", "Tcp", "cxl", "ascend", "nvlink_intra"]:
-            with self.subTest(protocol=protocol):
-                config = self.make(protocol=protocol)
-                self.assertEqual(config.protocol, protocol)
+    def test_known_protocols_normalized_to_lowercase(self):
+        # Mixed-case input is canonicalised to lowercase so it matches the
+        # case-sensitive C++ engine; surrounding whitespace is trimmed. Known
+        # protocols (including Store modes the old hard allowlist rejected) do
+        # not warn.
+        cases = {
+            "tcp": "tcp",
+            "rdma": "rdma",
+            "efa": "efa",
+            "RDMA": "rdma",
+            "Tcp": "tcp",
+            "  rdma  ": "rdma",
+            "cxl": "cxl",
+            "ascend": "ascend",
+            "nvlink_intra": "nvlink_intra",
+            "ub": "ub",
+            "ubshmem": "ubshmem",
+            "maca": "maca",
+            "sunrise_link": "sunrise_link",
+            "rpc_only": "rpc_only",
+        }
+        for given, expected in cases.items():
+            with self.subTest(protocol=given):
+                config = self.make(protocol=given)
+                self.assertEqual(config.protocol, expected)
 
-    def test_invalid_protocol_raises(self):
-        for protocol in ["rmda", "udp", "", "foo"]:
+    def test_empty_protocol_raises(self):
+        # An empty or whitespace-only protocol is a caller error and still
+        # fails fast.
+        for protocol in ["", "   "]:
             with self.subTest(protocol=protocol):
                 with self.assertRaises(ValueError) as cm:
                     self.make(protocol=protocol)
                 self.assertIn("Invalid protocol", str(cm.exception))
+
+    def test_unknown_protocol_warns_but_is_passed_through(self):
+        # Unknown-but-non-empty values are no longer rejected in Python:
+        # MooncakeConfig drives both Transfer Engine and Store paths and the C++
+        # layer is the source of truth. We warn and pass the lowercased value
+        # through.
+        for given, expected in [("rmda", "rmda"), ("udp", "udp"), ("Foo", "foo")]:
+            with self.subTest(protocol=given):
+                with self.assertLogs(_cfg_mod.logger, level="WARNING") as cm:
+                    config = self.make(protocol=given)
+                self.assertEqual(config.protocol, expected)
+                self.assertTrue(
+                    any("Unrecognised protocol" in m for m in cm.output)
+                )
 
     def test_non_string_protocol_raises(self):
         with self.assertRaises(ValueError):
@@ -257,17 +294,18 @@ class TestMooncakeConfigValidation(unittest.TestCase):
                         self.make(**{field: bad})
                     self.assertIn(field, str(cm.exception))
 
-    def test_from_file_rejects_invalid_protocol(self):
+    def test_from_file_warns_on_unknown_protocol(self):
         with open(self.config_path, "w") as f:
             json.dump({
                 "local_hostname": "localhost",
                 "metadata_server": "localhost:8080",
                 "master_server_address": "localhost:8081",
-                "protocol": "rmda",  # typo
+                "protocol": "rmda",  # typo -> unknown, warned not rejected
             }, f)
-        with self.assertRaises(ValueError) as cm:
-            MooncakeConfig.from_file(self.config_path)
-        self.assertIn("Invalid protocol", str(cm.exception))
+        with self.assertLogs(_cfg_mod.logger, level="WARNING") as cm:
+            config = MooncakeConfig.from_file(self.config_path)
+        self.assertEqual(config.protocol, "rmda")
+        self.assertTrue(any("Unrecognised protocol" in m for m in cm.output))
 
     def setUp(self):
         self._tmp = tempfile.TemporaryDirectory()


### PR DESCRIPTION
### Motivation

`MooncakeConfig` currently accepts whatever values it is given. Invalid
settings only surface much later as cryptic failures inside the C++ Transfer
Engine (or as a hang), which makes misconfiguration hard to diagnose. The most
common cases are:

- a typo in `protocol` (e.g. `"rmda"` instead of `"rdma"`), which silently
  falls through to the engine;
- a negative `global_segment_size` / `local_buffer_size` (e.g. from a bad
  `MOONCAKE_GLOBAL_SEGMENT_SIZE` expansion);
- an empty required address field (`local_hostname`, `metadata_server`,
  `master_server_address`) — `from_file` only checks for *presence*, so an empty
  string slips through.

### Changes

Add field validation in `MooncakeConfig.__post_init__` so a misconfiguration is
reported at config-load time with an actionable message:

- `protocol` must be one of the documented supported protocols
  (`tcp`, `rdma`, `nvmeof`, `nvlink`, `nvlink_intra`, `hip`, `barex`, `cxl`,
  `ascend`) — matched case-insensitively.
- `global_segment_size` / `local_buffer_size` must be non-negative. `0` is
  intentionally preserved as the documented "disable" sentinel
  (`global_segment_size == 0` means do not set up the store).
- the required address fields must be non-empty strings.

Because the validation lives in `__post_init__`, it covers the `from_file`,
`load_from_env` and direct-construction paths uniformly, with no duplicated
checks.

### Compatibility

No behavior change for valid configurations — every previously valid config
still loads. The existing config tests pass unchanged. The only new behavior is
that a clearly-invalid config now raises `ValueError` instead of failing later.

One maintenance note: `_VALID_PROTOCOLS` must be kept in sync with the protocol
list in the module docstring (a comment marks this). The set mirrors the list
documented in #1435.

### Tests

Added `TestMooncakeConfigValidation` covering valid/invalid protocols
(incl. case-insensitivity), the `0`-size sentinel, negative sizes, empty
required fields, and the `from_file` path. Full file:

```
cd mooncake-wheel && python3 -m pytest tests/test_mooncake_config.py -q
26 passed
```