### PR TITLE
[Store] Count LOCAL_DISK hits in cache stats

### DIFF
--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -1335,10 +1335,18 @@ auto MasterService::GetReplicaList(const std::string& key,
             return tl::make_unexpected(ErrorCode::REPLICA_IS_NOT_READY);
         }
 
+        bool has_memory_replica = false;
+        bool has_ssd_replica = false;
+        for (const auto& replica : replica_list) {
+            has_memory_replica |= replica.is_memory_replica();
+            has_ssd_replica |=
+                replica.is_disk_replica() || replica.is_local_disk_replica();
+        }
+
         // TODO: NoF SSD support (ranhaojia)
-        if (replica_list[0].is_memory_replica()) {
+        if (has_memory_replica) {
             MasterMetricManager::instance().inc_mem_cache_hit_nums();
-        } else if (replica_list[0].is_disk_replica()) {
+        } else if (has_ssd_replica) {
             MasterMetricManager::instance().inc_file_cache_hit_nums();
         }
         MasterMetricManager::instance().inc_valid_get_nums();

--- a/mooncake-store/tests/master_metrics_test.cpp
+++ b/mooncake-store/tests/master_metrics_test.cpp
@@ -623,6 +623,41 @@ static std::string PutKeyAndOffload(MasterService& svc, const UUID& client_id,
     return key;
 }
 
+TEST_F(MasterMetricsTest, LocalDiskOnlyReplicaCountsAsSsdHit) {
+    auto& metrics = MasterMetricManager::instance();
+    using CacheHitStat = MasterMetricManager::CacheHitStat;
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    MasterService svc(config);
+
+    UUID client_id = generate_uuid();
+    ASSERT_TRUE(svc.MountLocalDiskSegment(client_id, true).has_value());
+
+    const auto base_stats = metrics.calculate_cache_stats();
+    const double base_memory_hits = base_stats.at(CacheHitStat::MEMORY_HITS);
+    const double base_ssd_hits = base_stats.at(CacheHitStat::SSD_HITS);
+
+    constexpr uint64_t kValueSize = 4096;
+    const std::string key = "ssd_hit_local_disk_only_key";
+    StorageObjectMetadata meta;
+    meta.data_size = static_cast<int64_t>(kValueSize);
+    meta.transport_endpoint = "127.0.0.1:9999";
+    std::vector<OffloadTaskItem> tasks{
+        OffloadTaskItem{.tenant_id = "default",
+                        .key = key,
+                        .size = static_cast<int64_t>(kValueSize)}};
+
+    ASSERT_TRUE(svc.NotifyOffloadSuccess(client_id, tasks, {meta}).has_value());
+    auto replica_result = svc.GetReplicaList(key, "default");
+    ASSERT_TRUE(replica_result.has_value());
+    ASSERT_EQ(replica_result->replicas.size(), 1);
+    EXPECT_TRUE(replica_result->replicas[0].is_local_disk_replica());
+
+    const auto stats = metrics.calculate_cache_stats();
+    EXPECT_EQ(stats.at(CacheHitStat::MEMORY_HITS), base_memory_hits);
+    EXPECT_EQ(stats.at(CacheHitStat::SSD_HITS), base_ssd_hits + 1);
+}
+
 // Verify that creating a LocalDiskReplica (via NotifyOffloadSuccess) increments
 // file_allocated_size, and that removing the key decrements it back to zero.
 TEST_F(MasterMetricsTest, LocalDiskReplicaAllocatedSize) {


### PR DESCRIPTION
## Description

Fixes #2457.

`GetReplicaList()` used to classify master cache-hit metrics from only the first returned replica descriptor. That missed `LOCAL_DISK` replicas because they use `LocalDiskDescriptor`, not `DiskDescriptor`, so a LOCAL_DISK-only hit could increment `valid_get_nums` without incrementing either memory or SSD hits.

This changes the Store hit classification to scan the returned replica list:

- count a memory hit if any MEMORY replica is available
- otherwise count an SSD hit if any DISK or LOCAL_DISK replica is available
- keep valid-get accounting and NoF behavior unchanged

A focused metric test now creates a LOCAL_DISK-only object through `NotifyOffloadSuccess()`, calls `GetReplicaList()`, and checks that `ssd_hits` increases while `memory_hits` stays unchanged.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
git diff --check
pre-commit run --files mooncake-store/src/master_service.cpp mooncake-store/tests/master_metrics_test.cpp
git submodule update --init extern/pybind11 extern/yalantinglibs
cmake -S . -B build-master-metrics -G Ninja -DBUILD_UNIT_TESTS=ON -DWITH_STORE=ON -DWITH_TE=ON -DWITH_STORE_RUST=OFF -DWITH_EP=OFF -DWITH_P2P_STORE=OFF -DWITH_STORE_GO=OFF
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

`git diff --check` passed.

Scoped `pre-commit` results on Windows:
- `trim trailing whitespace`: passed
- `fix end of files`: passed
- `check for merge conflicts`: passed
- `check for added large files`: passed
- `codespell`: passed
- `clang-format`: passed
- `ruff` / `ruff-format`: skipped, no Python files
- `cmake-format`: skipped, no CMake files
- `mooncake-code-format`: failed because the Windows environment has no `/bin/bash` for `./scripts/code_format.sh`

A local CMake configure was attempted after initializing the two submodules, but this Windows environment is missing native Mooncake C++ dependencies (`gflags`, and also initially `glog`/`jsoncpp` were not found). I could not build or run `master_metrics_test` locally here.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex was used to inspect the issue path, make the small code/test change, and record the local validation steps. I reviewed the final diff before opening the PR.