### PR TITLE
[Bugfix] Support EulerOS in dependencies installer

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -24,6 +24,7 @@ NC="\033[0m" # No Color
 REPO_ROOT=`pwd`
 GITHUB_PROXY=${GITHUB_PROXY:-"https://github.com"}
 GOVER=1.25.9
+OS_RELEASE_FILE=${OS_RELEASE_FILE:-/etc/os-release}
 
 # Function to print section headers
 print_section() {
@@ -50,14 +51,14 @@ check_success() {
 
 # Function to detect OS
 detect_os() {
-    if [ -f /etc/os-release ]; then
-        . /etc/os-release
+    if [ -f "$OS_RELEASE_FILE" ]; then
+        . "$OS_RELEASE_FILE"
         OS=$(echo "$ID" | tr '[:upper:]' '[:lower:]')
         OS_VERSION=$VERSION_ID
     elif [ -f /etc/redhat-release ]; then
         OS="centos"
     else
-        print_error "Cannot detect OS. Supported OS: Ubuntu, Debian, CentOS, RHEL, Rocky, AlmaLinux, and openEuler."
+        print_error "Cannot detect OS. Supported OS: Ubuntu, Debian, CentOS, RHEL, Rocky, AlmaLinux, EulerOS, and openEuler."
     fi
 
     echo -e "${GREEN}Detected OS: $OS ${OS_VERSION:-unknown}${NC}"
@@ -120,7 +121,7 @@ print_section "Updating package lists"
 if [ "$OS" = "ubuntu" ] || [ "$OS" = "debian" ]; then
     apt-get update
     check_success "Failed to update package lists"
-elif [ "$OS" = "centos" ] || [ "$OS" = "rhel" ] || [ "$OS" = "rocky" ] || [ "$OS" = "almalinux" ] || [ "$OS" = "openeuler" ]; then
+elif [ "$OS" = "centos" ] || [ "$OS" = "rhel" ] || [ "$OS" = "rocky" ] || [ "$OS" = "almalinux" ] || [ "$OS" = "euleros" ] || [ "$OS" = "openeuler" ]; then
     yum clean all
     yum makecache
     check_success "Failed to update package lists"
@@ -169,7 +170,7 @@ if [ "$OS" = "ubuntu" ] || [ "$OS" = "debian" ]; then
     apt-get install -y $SYSTEM_PACKAGES
     check_success "Failed to install system packages"
 
-elif [ "$OS" = "centos" ] || [ "$OS" = "rhel" ] || [ "$OS" = "rocky" ] || [ "$OS" = "almalinux" ] || [ "$OS" = "openeuler" ]; then
+elif [ "$OS" = "centos" ] || [ "$OS" = "rhel" ] || [ "$OS" = "rocky" ] || [ "$OS" = "almalinux" ] || [ "$OS" = "euleros" ] || [ "$OS" = "openeuler" ]; then
     SYSTEM_PACKAGES="@development \
                      cmake \
                      git \

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -49,10 +49,24 @@ check_success() {
     fi
 }
 
+read_os_release_value() {
+    local key="$1"
+    awk -F= -v key="$key" '
+        $1 == key {
+            value = $0
+            sub(/^[^=]*=/, "", value)
+            gsub(/^"|"$/, "", value)
+            print value
+            exit
+        }
+    ' "$OS_RELEASE_FILE"
+}
+
 # Function to detect OS
 detect_os() {
     if [ -f "$OS_RELEASE_FILE" ]; then
-        . "$OS_RELEASE_FILE"
+        ID=$(read_os_release_value ID)
+        VERSION_ID=$(read_os_release_value VERSION_ID)
         OS=$(echo "$ID" | tr '[:upper:]' '[:lower:]')
         OS_VERSION=$VERSION_ID
     elif [ -f /etc/redhat-release ]; then


### PR DESCRIPTION
## Summary

`dependencies.sh` reads `/etc/os-release` and lowercases `ID`, but the RHEL-like branch only accepts `centos`, `rhel`, `rocky`, `almalinux`, and `openeuler`. On EulerOS hosts where `/etc/os-release` reports `ID=euleros`, the installer reaches the unsupported-OS path even though the package flow is the same yum-based family.

This adds `euleros` to the RHEL-like branches and keeps the unsupported-OS message aligned with the accepted list. I also made the os-release path overridable so the detection logic can be smoke-tested without changing the host `/etc/os-release`.

Fixes #2385.

## Validation

To verify:

- `"C:\Program Files\Git\bin\bash.exe" -lc 'cd /c/dev/GITHUB-clean/Mooncake-2385; bash -n dependencies.sh; tmp=$(mktemp); printf "ID=euleros\nVERSION_ID=2.0\n" > "$tmp"; test_script=$(mktemp); { echo "GREEN=; RED=; NC="; echo "print_error(){ echo ERROR: \"\$1\"; exit 1; }"; echo "OS_RELEASE_FILE=\"$tmp\""; awk "/^detect_os\(\)/,/^}/" dependencies.sh; echo "detect_os >/dev/null"; echo "test \"\$OS\" = euleros"; echo "test \"\$OS_VERSION\" = 2.0"; } > "$test_script"; bash "$test_script"; rm -f "$tmp" "$test_script"; echo ok'`
- `git diff --check`