### PR TITLE
[Store] Fix local hot cache rejecting larger objects after block reuse

### DIFF
--- a/mooncake-store/src/local_hot_cache.cpp
+++ b/mooncake-store/src/local_hot_cache.cpp
@@ -310,8 +310,14 @@ bool LocalHotCacheHandler::SubmitPutTask(const std::string& key,
         return false;
     }
 
-    // Check size compatibility
-    if (slice.size > block->size) {
+    // Check size compatibility against the block's physical capacity.
+    // block->size carries the *logical* length of the last object stored in
+    // the block (set below and relied upon as the object length on the read
+    // path), and GetFreeBlock() does not reset it on reuse. Comparing against
+    // block->size would therefore reject any object larger than the previous
+    // one a recycled block happened to hold, permanently shrinking the block's
+    // usable capacity. The true capacity is the fixed block size.
+    if (slice.size > hot_cache_->GetBlockSize()) {
         // Slice too big for block, return block to pool
         block->key_.clear();
         hot_cache_->PutHotKey(block);

--- a/mooncake-store/tests/client_local_hot_cache_test.cpp
+++ b/mooncake-store/tests/client_local_hot_cache_test.cpp
@@ -518,6 +518,54 @@ TEST_F(LocalHotCacheTest, LocalHotCacheHandlerNullCache) {
     EXPECT_FALSE(handler.SubmitPutTask("key", slice));
 }
 
+// Regression test: a block recycled from the LRU must still accept objects up
+// to the full block capacity, even if it previously held a smaller object.
+// Before the fix, SubmitPutTask compared the new slice against block->size
+// (the previous object's logical length, which GetFreeBlock does not reset)
+// instead of the block capacity, so a recycled block permanently rejected any
+// object larger than the one it last held.
+TEST_F(LocalHotCacheTest, RecycledBlockAcceptsLargerObject) {
+    const size_t block_size = 64 * 1024;  // 64KB
+    // Single-block cache, so the second Put must recycle the first block.
+    auto cache = std::make_shared<LocalHotCache>(block_size, block_size);
+    ASSERT_EQ(cache->GetCacheSize(), 1u);
+    ASSERT_EQ(cache->GetBlockSize(), block_size);
+
+    LocalHotCacheHandler handler(cache, /*num_worker_threads=*/1,
+                                 /*max_queue_capacity=*/16);
+
+    // Wait until an async Put has been published into the cache.
+    auto wait_for_key = [&](const std::string& key) {
+        for (int i = 0; i < 400; ++i) {  // up to ~2s
+            if (cache->HasHotKey(key)) return true;
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        }
+        return cache->HasHotKey(key);
+    };
+
+    // 1) Cache a small object. The block's logical size shrinks to small_size.
+    const size_t small_size = 1024;  // 1KB
+    Slice small_slice = CreateSlice(small_size, 'S');
+    ASSERT_TRUE(handler.SubmitPutTask("small_key", small_slice));
+    ASSERT_TRUE(wait_for_key("small_key"));
+
+    // 2) Cache a larger object that still fits the block. This forces
+    //    GetFreeBlock() to recycle the block that held "small_key". Before the
+    //    fix this returned false (large_size > stale block->size of 1KB).
+    const size_t large_size = 32 * 1024;  // 32KB: > small_size, <= block_size
+    Slice large_slice = CreateSlice(large_size, 'L');
+    EXPECT_TRUE(handler.SubmitPutTask("large_key", large_slice));
+    ASSERT_TRUE(wait_for_key("large_key"));
+
+    // The larger object is fully cached with the correct length and data, and
+    // the evicted small object is gone.
+    HotMemBlock* block = cache->GetHotKey("large_key");
+    ASSERT_NE(block, nullptr);
+    VerifySliceData(block, large_size, 'L');
+    cache->ReleaseHotKey("large_key");
+    EXPECT_FALSE(cache->HasHotKey("small_key"));
+}
+
 // Test concurrent access to LocalHotCache
 TEST_F(LocalHotCacheTest, ConcurrentAccess) {
     const size_t cache_size = 128 * 1024 * 1024;  // 128MB = 8 blocks


### PR DESCRIPTION
## Description

`LocalHotCacheHandler::SubmitPutTask` decides whether an object fits a hot-cache block with:

```cpp
if (slice.size > block->size) {   // reject and return the block to the pool
```

But `block->size` is **not** the block capacity — it stores the *logical length of the last object written to the block*. It is set on the very next line (`block->size = slice.size;`) and read back as the object length on the read path (`RedirectToHotCache` compares `mem_desc.buffer_descriptor.size_ != blk->size`). `LocalHotCache::GetFreeBlock()` does **not** reset it when a block is recycled from the LRU.

So once a block has cached a small object, the admission check treats that small size as the block's capacity. After the block is recycled it **permanently rejects any object larger than the one it last held** — even though every block is physically `block_size_` bytes. On mixed-size workloads each block converges toward the smallest size it ever stored, so the hot cache silently stops admitting normal-sized objects and its hit rate degrades, with no error or log.

**Fix:** compare against the block's true, uniform capacity, `hot_cache_->GetBlockSize()` (`== block_size_`). The logical-size semantics of `block->size` are unchanged, so the read path is unaffected and the recycled block's stale `size` is overwritten on the next line as before.

## Module

- [x] Mooncake Store (`mooncake-store`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

Added a regression test `LocalHotCacheTest.RecycledBlockAcceptsLargerObject`: it fills a single-block cache with a 1 KB object, waits for it to be published, then submits a 32 KB object (≤ block capacity) to force the block to be recycled and asserts it is admitted and served back with the correct length and data.

Built and run on **Ubuntu 24.04 (x86_64, io_uring enabled)** with `-DWITH_STORE=ON -DUSE_HTTP=ON -DUSE_ETCD=ON -DSTORE_USE_ETCD=ON`:

| Check | Result |
| --- | --- |
| Full `client_local_hot_cache_test` suite | **34/34 passed** (incl. new test, no regressions) |
| Revert the one-line fix, rerun new test | **fails** (`SubmitPutTask` returns `false`) — confirms the test captures the bug |

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code with `./scripts/code_format.sh` (clang-format-20) before submitting.
- [ ] I have updated the documentation. _(n/a — internal behavior fix, no public API/doc change)_
- [x] I have added tests to prove my changes are effective.
