### PR TITLE
[Store] add structured object copy-mode policy

### DIFF
--- a/docs/source/python-api-reference/mooncake-store.md
+++ b/docs/source/python-api-reference/mooncake-store.md
@@ -183,6 +183,29 @@ prompt_ids = result.objects["prompt_ids"]
 metadata = result.metadata
 ```
 
+### Structured object transfer policy
+
+By default, structured object writes use `BundleTransferPolicy(copy_mode="auto")`. This keeps the existing behavior: Mooncake uses the zero-copy `batch_put_from` fast path when buffer registration is available, and falls back to ordinary `store.put` when the fast path is unavailable.
+
+For very large tensors, buffer registration capacity can be exhausted. If the upper layer does not handle this failure mode yet, force the non-zero-copy path with `copy_mode="copy"`:
+
+```python
+from mooncake.structured_object_store import BundleTransferPolicy
+
+ref = transfer.put_structured_object(
+    payload,
+    policy=BundleTransferPolicy(copy_mode="copy"),
+)
+```
+
+Available modes:
+
+- `auto`: prefer zero-copy and fall back to regular `store.put` when zero-copy support is unavailable;
+- `copy`: force the non-zero-copy `store.put` path;
+- `zero_copy`: require the zero-copy `batch_put_from` path and raise an error if it is unavailable.
+
+If a caller has already registered a structured member buffer, pass `pre_registered_buffers={"member_name": True}` to avoid duplicate registration. The buffer must be the same writable, contiguous buffer used for transfer; read-only, non-contiguous, or internally copied buffers are rejected.
+
 ### Partial reads
 
 Read narrowing happens on top of `read_spec(ref)`:

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -231,16 +231,20 @@ class _StructuredObjectLayer:
         pre_registered_buffers: Optional[Mapping[str, bool]],
     ) -> RemoteBundleRef:
         metadata, buffers = _encode_structured_fields(payload.metadata, payload.buffers)
-        _validate_pre_registered_structured_buffers(
-            payload.buffers, buffers, pre_registered_buffers
+        transfer_policy = self._bundle_store._policy(
+            policy, max_inflight_put=max_inflight_put
         )
+        if transfer_policy.copy_mode != "copy":
+            _validate_pre_registered_structured_buffers(
+                payload.buffers, buffers, pre_registered_buffers
+            )
         return self._bundle_store.put_bundle(
             meta=_encode_structured_metadata(metadata),
             buffers=buffers,
             partition=partition,
             chunk_bytes=chunk_bytes,
-            policy=policy,
-            max_inflight_put=max_inflight_put,
+            policy=transfer_policy,
+            max_inflight_put=None,
             pre_registered_buffers=pre_registered_buffers,
         )
 
@@ -934,6 +938,8 @@ class _MooncakePayloadTransport:
         registered_ptrs: list[int] = []
         try:
             for ptr, size in zip(buffer_ptrs, sizes):
+                if size == 0:
+                    continue
                 register_status = register_buffer(ptr, size)
                 if register_status == 0:
                     registered_ptrs.append(ptr)
@@ -1110,6 +1116,9 @@ def _bytes_view(value: Any, name: str) -> memoryview:
 
 
 def _prepare_chunk_source_buffer(chunk: memoryview) -> tuple[Any, int, int]:
+    if len(chunk) == 0:
+        copied = ctypes.create_string_buffer(0)
+        return copied, ctypes.addressof(copied), 0
     if chunk.c_contiguous and not chunk.readonly:
         return chunk, ctypes.addressof(ctypes.c_char.from_buffer(chunk)), len(chunk)
     copied = ctypes.create_string_buffer(bytes(chunk))
@@ -1265,12 +1274,14 @@ def _is_same_writable_buffer(original: Any, encoded: Any) -> bool:
         encoded_view = memoryview(encoded)
     except TypeError:
         return False
-    if not original_view.contiguous or not encoded_view.c_contiguous:
+    if not original_view.c_contiguous or not encoded_view.c_contiguous:
         return False
     if original_view.readonly or encoded_view.readonly:
         return False
     if original_view.nbytes != encoded_view.nbytes:
         return False
+    if original_view.nbytes == 0:
+        return True
     try:
         original_bytes = original_view.cast("B")
         encoded_bytes = encoded_view.cast("B")

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -33,6 +33,7 @@ class BundleTransferPolicy:
 
     max_inflight_put: int = 1
     put_mode: Literal["auto", "batch", "parallel"] = "auto"
+    copy_mode: Literal["auto", "zero_copy", "copy"] = "auto"
 
 
 @dataclass
@@ -185,6 +186,7 @@ class MooncakeBundleTransfer:
         chunk_bytes: Optional[int] = None,
         policy: Optional[BundleTransferPolicy] = None,
         max_inflight_put: Optional[int] = None,
+        pre_registered_buffers: Optional[Mapping[str, bool]] = None,
     ) -> RemoteBundleRef:
         """Store a structured object described by JSON metadata plus named members."""
         return self._structured_store.put_structured_object(
@@ -193,6 +195,7 @@ class MooncakeBundleTransfer:
             chunk_bytes=chunk_bytes,
             policy=policy,
             max_inflight_put=max_inflight_put,
+            pre_registered_buffers=pre_registered_buffers,
         )
 
     def read_spec(
@@ -225,8 +228,12 @@ class _StructuredObjectLayer:
         chunk_bytes: Optional[int],
         policy: Optional[BundleTransferPolicy],
         max_inflight_put: Optional[int],
+        pre_registered_buffers: Optional[Mapping[str, bool]],
     ) -> RemoteBundleRef:
         metadata, buffers = _encode_structured_fields(payload.metadata, payload.buffers)
+        _validate_pre_registered_structured_buffers(
+            payload.buffers, buffers, pre_registered_buffers
+        )
         return self._bundle_store.put_bundle(
             meta=_encode_structured_metadata(metadata),
             buffers=buffers,
@@ -234,6 +241,7 @@ class _StructuredObjectLayer:
             chunk_bytes=chunk_bytes,
             policy=policy,
             max_inflight_put=max_inflight_put,
+            pre_registered_buffers=pre_registered_buffers,
         )
 
     def read_spec(
@@ -506,12 +514,16 @@ class _BundleManifestStore:
         result = policy or BundleTransferPolicy()
         if max_inflight_put is not None:
             result = BundleTransferPolicy(
-                max_inflight_put=max_inflight_put, put_mode=result.put_mode
+                max_inflight_put=max_inflight_put,
+                put_mode=result.put_mode,
+                copy_mode=result.copy_mode,
             )
         if result.max_inflight_put < 1:
             raise ValueError("max_inflight_put must be positive")
         if result.put_mode not in {"auto", "batch", "parallel"}:
             raise ValueError(f"unsupported put_mode: {result.put_mode}")
+        if result.copy_mode not in {"auto", "zero_copy", "copy"}:
+            raise ValueError(f"unsupported copy_mode: {result.copy_mode}")
         return result
 
     def _validate_manifest(self, manifest: Mapping[str, Any]) -> None:
@@ -607,7 +619,13 @@ class _MooncakePayloadTransport:
         transfer_policy: BundleTransferPolicy,
         pre_registered: bool,
     ) -> list[str]:
+        if transfer_policy.copy_mode == "copy":
+            return self._put_chunks_direct(chunk_keys, chunks)
         if not self._has_batch_put_support():
+            if transfer_policy.copy_mode == "zero_copy":
+                raise RuntimeError(
+                    "zero-copy put requested but batch_put_from is unavailable"
+                )
             return self._put_chunks_direct(chunk_keys, chunks)
         put_mode = self._resolve_put_mode(chunks, transfer_policy)
         if put_mode == "batch":
@@ -1221,6 +1239,46 @@ def _encode_structured_field(value: Any) -> tuple[dict[str, Any], Any]:
             "shape": list(array.shape),
         }, array.view(np.uint8).reshape(-1)
     return {"encoding": "bytes"}, value
+
+
+def _validate_pre_registered_structured_buffers(
+    original_buffers: Mapping[str, Any],
+    encoded_buffers: Mapping[str, Any],
+    pre_registered_buffers: Optional[Mapping[str, bool]],
+) -> None:
+    if not pre_registered_buffers:
+        return
+    for name, pre_registered in pre_registered_buffers.items():
+        if not pre_registered:
+            continue
+        if name not in original_buffers or name not in encoded_buffers:
+            raise ValueError(f"unknown pre-registered structured buffer: {name}")
+        if not _is_same_writable_buffer(original_buffers[name], encoded_buffers[name]):
+            raise ValueError(
+                f"pre-registered structured buffer {name} must be the same writable contiguous buffer used for transfer"
+            )
+
+
+def _is_same_writable_buffer(original: Any, encoded: Any) -> bool:
+    try:
+        original_view = memoryview(original)
+        encoded_view = memoryview(encoded)
+    except TypeError:
+        return False
+    if not original_view.contiguous or not encoded_view.c_contiguous:
+        return False
+    if original_view.readonly or encoded_view.readonly:
+        return False
+    if original_view.nbytes != encoded_view.nbytes:
+        return False
+    try:
+        original_bytes = original_view.cast("B")
+        encoded_bytes = encoded_view.cast("B")
+        original_ptr = ctypes.addressof(ctypes.c_char.from_buffer(original_bytes))
+        encoded_ptr = ctypes.addressof(ctypes.c_char.from_buffer(encoded_bytes))
+    except (BufferError, TypeError, ValueError):
+        return False
+    return original_ptr == encoded_ptr
 
 
 def _structured_field_specs(metadata: Mapping[str, Any]) -> dict[str, Any]:

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -371,6 +371,24 @@ def test_bundle_copy_mode_forces_store_put() -> None:
     assert result.objects["payload"] == payload
 
 
+def test_structured_object_copy_mode_skips_pre_registered_validation() -> None:
+    store, transfer = make_transfer()
+    payload = np.arange(64, dtype=np.uint8).reshape(8, 8).T
+
+    ref = transfer.put_structured_object(
+        structured_payload(payload=payload),
+        policy=BundleTransferPolicy(copy_mode="copy"),
+        pre_registered_buffers={"payload": True},
+    )
+
+    assert store.batch_put_from_calls == 0
+    assert store.register_buffer_calls == 0
+    assert store.unregister_buffer_calls == 0
+
+    result = transfer.materialize(transfer.read_spec(ref))
+    assert np.array_equal(result.objects["payload"], payload)
+
+
 def test_bundle_zero_copy_mode_requires_batch_put_support() -> None:
     _store, transfer = make_transfer(MinimalStore())
 
@@ -425,6 +443,19 @@ def test_structured_object_pre_registered_rejects_copied_buffers() -> None:
             structured_payload(payload=bytearray(b"data")),
             pre_registered_buffers={"missing": True},
         )
+
+
+def test_structured_object_pre_registered_empty_buffer() -> None:
+    _store, transfer = make_transfer()
+    payload = bytearray()
+
+    ref = transfer.put_structured_object(
+        structured_payload(payload=payload),
+        pre_registered_buffers={"payload": True},
+    )
+
+    result = transfer.materialize(transfer.read_spec(ref))
+    assert result.objects["payload"] == b""
 
 
 def test_structured_object_roundtrip() -> None:

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -22,6 +22,8 @@ class InMemoryStore:
         self.objects: dict[str, bytes] = {}
         self.lock = threading.Lock()
         self.registered: set[int] = set()
+        self.register_buffer_calls = 0
+        self.unregister_buffer_calls = 0
         self.max_active_puts = 0
         self.max_active_gets = 0
         self.active_puts = 0
@@ -29,6 +31,7 @@ class InMemoryStore:
         self.get_into_calls = 0
         self.get_into_ranges_calls = 0
         self.batch_get_into_calls = 0
+        self.batch_put_from_calls = 0
         self.batch_remove_calls = 0
 
     def _enter_put(self) -> None:
@@ -82,6 +85,7 @@ class InMemoryStore:
     def batch_put_from(
         self, keys: list[str], buffer_ptrs: list[int], sizes: list[int]
     ) -> list[int]:
+        self.batch_put_from_calls += 1
         results: list[int] = []
         for key, ptr, size in zip(keys, buffer_ptrs, sizes):
             data = ctypes.string_at(ptr, size)
@@ -89,10 +93,12 @@ class InMemoryStore:
         return results
 
     def register_buffer(self, buffer_ptr: int, size: int) -> int:
+        self.register_buffer_calls += 1
         self.registered.add(buffer_ptr)
         return 0
 
     def unregister_buffer(self, buffer_ptr: int) -> int:
+        self.unregister_buffer_calls += 1
         self.registered.remove(buffer_ptr)
         return 0
 
@@ -345,6 +351,80 @@ def test_bundle_uses_configurable_default_chunk_size() -> None:
 
     assert len(ref.manifest["buffers"]["payload"]["chunks"]) > 1
     assert ref.manifest["buffers"]["payload"]["chunks"][0]["bytes"] == 17
+
+
+def test_bundle_copy_mode_forces_store_put() -> None:
+    store, transfer = make_transfer()
+    payload = bytes(range(128))
+
+    ref = transfer.put_structured_object(
+        structured_payload(payload=payload),
+        chunk_bytes=17,
+        policy=BundleTransferPolicy(copy_mode="copy"),
+    )
+
+    assert store.batch_put_from_calls == 0
+    assert store.register_buffer_calls == 0
+    assert store.unregister_buffer_calls == 0
+
+    result = transfer.materialize(transfer.read_spec(ref))
+    assert result.objects["payload"] == payload
+
+
+def test_bundle_zero_copy_mode_requires_batch_put_support() -> None:
+    _store, transfer = make_transfer(MinimalStore())
+
+    with pytest.raises(RuntimeError, match="zero-copy put requested"):
+        transfer.put_structured_object(
+            structured_payload(payload=b"data"),
+            policy=BundleTransferPolicy(copy_mode="zero_copy"),
+        )
+
+
+def test_structured_object_pre_registered_buffers_passthrough() -> None:
+    store, transfer = make_transfer()
+    payload = np.arange(64, dtype=np.uint8).reshape(8, 8)
+    payload_ptr = ctypes.addressof(ctypes.c_char.from_buffer(payload))
+    assert store.register_buffer(payload_ptr, int(payload.nbytes)) == 0
+    store.register_buffer_calls = 0
+    store.unregister_buffer_calls = 0
+
+    ref = transfer.put_structured_object(
+        structured_payload(payload=payload),
+        pre_registered_buffers={"payload": True},
+    )
+
+    assert store.batch_put_from_calls > 0
+    assert store.register_buffer_calls == 1
+    assert store.unregister_buffer_calls == 1
+    assert payload_ptr in store.registered
+
+    result = transfer.materialize(transfer.read_spec(ref))
+    assert np.array_equal(result.objects["payload"], payload)
+    store.unregister_buffer(payload_ptr)
+
+
+def test_structured_object_pre_registered_rejects_copied_buffers() -> None:
+    _store, transfer = make_transfer()
+    non_contiguous = np.arange(64, dtype=np.uint8).reshape(8, 8).T
+
+    with pytest.raises(ValueError, match="pre-registered structured buffer"):
+        transfer.put_structured_object(
+            structured_payload(payload=non_contiguous),
+            pre_registered_buffers={"payload": True},
+        )
+
+    with pytest.raises(ValueError, match="pre-registered structured buffer"):
+        transfer.put_structured_object(
+            structured_payload(payload=b"readonly"),
+            pre_registered_buffers={"payload": True},
+        )
+
+    with pytest.raises(ValueError, match="unknown pre-registered"):
+        transfer.put_structured_object(
+            structured_payload(payload=bytearray(b"data")),
+            pre_registered_buffers={"missing": True},
+        )
 
 
 def test_structured_object_roundtrip() -> None:
@@ -677,6 +757,12 @@ def test_bundle_invalid_policy_and_chunk_size_raise() -> None:
         )
     with pytest.raises(ValueError, match="chunk_bytes"):
         transfer.put_bundle(b"meta", {"payload": b"data"}, chunk_bytes=0)
+    with pytest.raises(ValueError, match="copy_mode"):
+        transfer.put_bundle(
+            b"meta",
+            {"payload": b"data"},
+            policy=BundleTransferPolicy(copy_mode="invalid"),
+        )
 
 
 def test_bundle_invalid_name_and_prefix_raise() -> None:


### PR DESCRIPTION
## Motivation                                                                                                           
                                                                                                                          
  Some upper-layer frameworks may transfer very large tensors through the structured object interface. The zero-copy path 
  can fail when there is not enough registered buffer capacity, while these frameworks may not yet have proper handling for this failure mode. This change adds an explicit non-zero-copy transfer option as a fallback to avoid such failures. 
                                                                                                                          
  ## Description                                                                                                          
                                                                                                                          
  - Add `copy_mode` to `BundleTransferPolicy`:                                                                            
    - `auto`: preserve existing behavior, prefer zero-copy fast path and fallback when unavailable.                       
    - `zero_copy`: require the zero-copy `batch_put_from` path and fail if unsupported.                                   
    - `copy`: force the non-zero-copy `store.put` path.                                                                   
  - Expose `pre_registered_buffers` through `put_structured_object()`.                                                    
  - Validate pre-registered structured buffers to avoid treating copied, read-only, or non-contiguous buffers as already  
  registered.                                                                                                             
                                                                                                                          
  ## Test                                                                                                                 
                                                                                                                          
  ```bash                                                                                                                 
  PYTHONPATH=/root/Mooncake/mooncake-wheel \                                                                              
  /root/sglang-venv/bin/python -m pytest \                                                                                
  /root/Mooncake/mooncake-wheel/tests/test_structured_object_store.py                                                     
   ```                                                                                                                       
  Result:                                                                                                                 
                                                                                                                          
  33 passed                                                                                                               
                                                                                                                          
  Also checked:                                                                                                           
                                                                                                                          
  PYTHONPATH=/root/Mooncake/mooncake-wheel \                                                                              
  /root/sglang-venv/bin/python -m py_compile \                                                                            
  /root/Mooncake/mooncake-wheel/mooncake/structured_object_store.py \                                                     
  /root/Mooncake/mooncake-wheel/tests/test_structured_object_store.py


**Test results:**
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [x] Other


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Claude Code assisted with code exploration, implementation, formatting/build/test execution, and review of zero-sized tensor edge cases. I reviewed and validated the final changes.