### PR TITLE
[Store] Avoid busy-spin in non-event-driven transfer completion wait

### DIFF
--- a/mooncake-store/src/transfer_task.cpp
+++ b/mooncake-store/src/transfer_task.cpp
@@ -861,11 +861,16 @@ void TransferEngineOperationState::wait_for_completion() {
 
     while (true) {
         if (getCurrentTimeInMilli() - start_ts_ > timeout_milliseconds) {
-            LOG(ERROR) << "Failed to complete transfers after "
-                       << timeout_milliseconds << " milliseconds for batch "
-                       << batch_id_;
             std::lock_guard<std::mutex> lock(mutex_);
-            set_result_internal(ErrorCode::TRANSFER_FAIL);
+            // Another caller (e.g. is_completed()) may have set the result
+            // right at the timeout boundary; don't overwrite it or log a false
+            // timeout in that case.
+            if (!result_.has_value()) {
+                LOG(ERROR) << "Failed to complete transfers after "
+                           << timeout_milliseconds << " milliseconds for batch "
+                           << batch_id_;
+                set_result_internal(ErrorCode::TRANSFER_FAIL);
+            }
             return;
         }
 

--- a/mooncake-store/src/transfer_task.cpp
+++ b/mooncake-store/src/transfer_task.cpp
@@ -9,6 +9,7 @@
 #include <cstdlib>
 #include <sstream>
 #include <string>
+#include <thread>
 #include <vector>
 #include "gpu_staging_utils.h"
 #include "transfer_engine.h"
@@ -845,26 +846,49 @@ void TransferEngineOperationState::wait_for_completion() {
 #else
     VLOG(1) << "Starting transfer engine polling for batch " << batch_id_;
 
+    // Adaptive backoff. Each iteration already issues a getTransferStatus() for
+    // every task in the batch, so the previous lock-poll-repeat with no yield
+    // pinned a CPU core at 100% for the entire transfer (this is the default,
+    // non-event-driven completion path). Spin briefly to keep latency low for
+    // fast transfers, then yield, then sleep with a capped backoff so a slow
+    // transfer no longer burns a core. The mutex is released before backing
+    // off.
+    int poll_iter = 0;
+    constexpr int kSpinIters = 64;     // tight re-poll: lowest latency
+    constexpr int kYieldIters = 1024;  // cooperative yield phase
+    std::chrono::microseconds backoff{50};
+    constexpr std::chrono::microseconds kMaxBackoff{500};
+
     while (true) {
         if (getCurrentTimeInMilli() - start_ts_ > timeout_milliseconds) {
             LOG(ERROR) << "Failed to complete transfers after "
                        << timeout_milliseconds << " milliseconds for batch "
                        << batch_id_;
+            std::lock_guard<std::mutex> lock(mutex_);
             set_result_internal(ErrorCode::TRANSFER_FAIL);
             return;
         }
 
-        std::unique_lock<std::mutex> lock(mutex_);
-        check_task_status();
-        if (result_.has_value()) {
-            VLOG(1) << "Transfer engine operation completed for batch "
-                    << batch_id_
-                    << " with result: " << static_cast<int>(result_.value());
-            break;
+        {
+            std::unique_lock<std::mutex> lock(mutex_);
+            check_task_status();
+            if (result_.has_value()) {
+                VLOG(1) << "Transfer engine operation completed for batch "
+                        << batch_id_ << " with result: "
+                        << static_cast<int>(result_.value());
+                break;
+            }
+        }  // release mutex_ before backing off
+
+        if (poll_iter < kSpinIters) {
+            ++poll_iter;
+        } else if (poll_iter < kYieldIters) {
+            ++poll_iter;
+            std::this_thread::yield();
+        } else {
+            std::this_thread::sleep_for(backoff);
+            backoff = std::min(backoff * 2, kMaxBackoff);
         }
-        // Continue polling
-        VLOG(1) << "Transfer engine operation still pending for batch "
-                << batch_id_;
     }
 #endif
 }


### PR DESCRIPTION
## Description

`TransferEngineOperationState::wait_for_completion()` has two paths. The
event-driven one waits on a condition variable, but `USE_EVENT_DRIVEN_COMPLETION`
defaults to **OFF** (`mooncake-common/common.cmake`), so the default build uses
the polling `#else` branch:

```cpp
while (true) {
    if (timed out) { ... }
    std::unique_lock<std::mutex> lock(mutex_);
    check_task_status();              // getTransferStatus() for every task
    if (result_.has_value()) break;
    // no yield, no sleep -> tight re-poll
}
```

This re-checks status in a tight lock-poll-repeat with **no yield or sleep**, so the calling thread **pins a CPU core at 100%** for the entire duration of every synchronous `Get`/`Put`/`BatchGet`. With many concurrent in-flight operations this burns a core per op and can starve other threads.

**Fix:** adaptive backoff in the polling loop — spin for a short budget (keeps latency low for fast transfers), then `std::this_thread::yield()`, then `sleep_for` with a capped exponential backoff (50 µs → 500 µs). The mutex is released before backing off, and the timeout branch now sets the result under `mutex_` to match the completion path.

This only changes the non-event-driven wait; correctness is unchanged (each iteration still re-queries `check_task_status()`), and the short initial spin preserves fast-path latency.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

- **CPU model.** A standalone program reproducing the loop (a simulated 300 ms transfer, with a per-iteration poll cost) shows core utilization drop while completion latency is unchanged:

  | Version | wall | cpu | core-util |
  | --- | --- | --- | --- |
  | busy-spin (old) | 0.300 s | 0.298 s | **99%** |
  | adaptive backoff (new) | 0.300 s | 0.003 s | **1%** |

- **Functional.** Built on Ubuntu 24.04 (`-DWITH_STORE=ON -DUSE_HTTP=ON -DUSE_ETCD=ON`) and ran `client_local_hot_cache_test`, whose `Put`/`Get` tests exercise `wait_for_completion`: **33/33 passed**, no change in behavior or latency.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code with `./scripts/code_format.sh` (clang-format-20) before submitting.
- [ ] I have updated the documentation. _(n/a — internal behavior change, no public API/doc change)_
- [ ] I have added tests to prove my changes are effective. _(perf-only change; verified via the CPU model above and existing functional tests — a deterministic CPU-usage assertion is not practical as a unit test)_