### PR TITLE
[TENT] Reduce SegmentDesc fetch overhead on cold receive path

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/runtime/segment.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/segment.h
@@ -229,18 +229,16 @@ using SegmentDescRef = std::shared_ptr<SegmentDesc>;
 // routing-hint Regions. Each bucket emits one Region carrying the bucket's
 // majority NUMA label; receivers consume Region as a max-overlap NIC hint.
 inline std::vector<Region> coalesceRegions(
-    const std::vector<RangeLocation>& entries,
-    size_t max_buckets = 128,
+    const std::vector<RangeLocation>& entries, size_t max_buckets = 128,
     size_t min_bucket_bytes = static_cast<size_t>(1) << 20) {
     std::vector<Region> out;
     if (entries.empty()) return out;
 
     size_t total = 0;
     for (auto& e : entries) total += e.len;
-    size_t computed = max_buckets > 0
-                          ? total / max_buckets +
-                                (total % max_buckets != 0 ? 1 : 0)
-                          : 0;
+    size_t computed = max_buckets > 0 ? total / max_buckets +
+                                            (total % max_buckets != 0 ? 1 : 0)
+                                      : 0;
     // Defensive floor: bucket_bytes == 0 would loop forever / divide by zero.
     // Hit only when caller passes both min_bucket_bytes=0 and max_buckets=0.
     size_t bucket_bytes =

--- a/mooncake-transfer-engine/tent/include/tent/runtime/segment.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/segment.h
@@ -228,6 +228,17 @@ using SegmentDescRef = std::shared_ptr<SegmentDesc>;
 // Coalesce a contiguous per-page NUMA probe into a small list of
 // routing-hint Regions. Each bucket emits one Region carrying the bucket's
 // majority NUMA label; receivers consume Region as a max-overlap NIC hint.
+//
+// Precondition: `entries` must tile the buffer as a gap-free, address-ordered
+// sequence (as produced by Platform::getLocation). Passing a non-contiguous or
+// unsorted vector still yields a monotonic byte offset and therefore mislabels
+// the address space; sort/validate at the call site if a producer cannot
+// guarantee this.
+//
+// Invariants: sum(out[i].size) == sum(entries[i].len), and ordering is
+// preserved. The per-bucket NUMA label is the byte-weighted majority, so
+// sub-bucket labels are deliberately lost -- this is a lossy routing hint, not
+// a faithful copy of the fine-grained probe.
 inline std::vector<Region> coalesceRegions(
     const std::vector<RangeLocation>& entries, size_t max_buckets = 128,
     size_t min_bucket_bytes = static_cast<size_t>(1) << 20) {

--- a/mooncake-transfer-engine/tent/include/tent/runtime/segment.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/segment.h
@@ -18,6 +18,7 @@
 #include <glog/logging.h>
 #include <netdb.h>
 
+#include <algorithm>
 #include <atomic>
 #include <cstdint>
 #include <functional>
@@ -25,7 +26,9 @@
 #include <string>
 #include <thread>
 #include <unordered_map>
+#include <utility>
 #include <variant>
+#include <vector>
 
 #include "tent/common/concurrent/rw_spinlock.h"
 #include "tent/common/concurrent/thread_local_storage.h"
@@ -221,6 +224,64 @@ inline void from_json(const json& j, SegmentDesc& s) {
 }
 
 using SegmentDescRef = std::shared_ptr<SegmentDesc>;
+
+// Coalesce a contiguous per-page NUMA probe into a small list of
+// routing-hint Regions. Each bucket emits one Region carrying the bucket's
+// majority NUMA label; receivers consume Region as a max-overlap NIC hint.
+inline std::vector<Region> coalesceRegions(
+    const std::vector<RangeLocation>& entries,
+    size_t max_buckets = 128,
+    size_t min_bucket_bytes = static_cast<size_t>(1) << 20) {
+    std::vector<Region> out;
+    if (entries.empty()) return out;
+
+    size_t total = 0;
+    for (auto& e : entries) total += e.len;
+    size_t computed = max_buckets > 0
+                          ? total / max_buckets +
+                                (total % max_buckets != 0 ? 1 : 0)
+                          : 0;
+    // Defensive floor: bucket_bytes == 0 would loop forever / divide by zero.
+    // Hit only when caller passes both min_bucket_bytes=0 and max_buckets=0.
+    size_t bucket_bytes =
+        std::max<size_t>(1, std::max(min_bucket_bytes, computed));
+
+    std::vector<std::pair<std::string, size_t>> votes;
+    size_t bucket = 0;
+
+    auto add_vote = [&](const std::string& loc, size_t n) {
+        for (auto& v : votes) {
+            if (v.first == loc) {
+                v.second += n;
+                return;
+            }
+        }
+        votes.emplace_back(loc, n);
+    };
+    auto flush = [&]() {
+        if (bucket == 0) return;
+        const std::string* best = nullptr;
+        size_t best_n = 0;
+        for (auto& v : votes) {
+            // Strict > preserves "first-seen wins" on ties.
+            if (v.second > best_n) {
+                best_n = v.second;
+                best = &v.first;
+            }
+        }
+        out.push_back(Region{bucket, *best});
+        votes.clear();
+        bucket = 0;
+    };
+
+    for (auto& e : entries) {
+        add_vote(e.location, e.len);
+        bucket += e.len;
+        if (bucket >= bucket_bytes) flush();
+    }
+    flush();
+    return out;
+}
 
 }  // namespace tent
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tent/include/tent/runtime/segment_manager.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/segment_manager.h
@@ -31,6 +31,10 @@
 
 #include "tent/runtime/segment.h"
 
+// TTL for cached remote SegmentDesc. Remote SegmentUpdate push handles
+// invalidation, so this is only a fallback refresh interval.
+#define TENT_SEGMENT_DESC_TTL_MS (60 * 60 * 1000)  // 1h
+
 namespace mooncake {
 namespace tent {
 class SegmentRegistry;
@@ -154,8 +158,6 @@ class SegmentManager {
     std::unique_ptr<SegmentRegistry> registry_;
 
     std::string file_desc_basepath_;
-    uint64_t ttl_ms_ =
-        60 * 60 * 1000;  // 1h; remote SegmentUpdate push handles invalidation
 
     // shared_ptr to prevent UAF in async callbacks
     std::shared_ptr<RWSpinlock> subscribers_lock_;

--- a/mooncake-transfer-engine/tent/include/tent/runtime/segment_manager.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/segment_manager.h
@@ -22,6 +22,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -110,6 +111,14 @@ class SegmentManager {
    public:
     SegmentDescRef getLocal() { return local_desc_; }
 
+    // Returns a serialized JSON snapshot of local_desc_. The result is cached
+    // and shared across concurrent GetSegmentDesc RPC handlers; the cache is
+    // invalidated by synchronizeLocal() (which is called on every register /
+    // unregisterLocalMemory). This avoids re-dumping the full segment desc on
+    // every peer fetch — the previous behavior multiplied dump cost by the
+    // number of concurrent peer RPCs and dominated remote getRemote latency.
+    std::shared_ptr<const std::string> getLocalDumpedJson();
+
     Status synchronizeLocal();
 
     Status deleteLocal();
@@ -145,11 +154,15 @@ class SegmentManager {
     std::unique_ptr<SegmentRegistry> registry_;
 
     std::string file_desc_basepath_;
-    uint64_t ttl_ms_ = 10 * 1000;  // N.B. Frequent TTL harms p999
+    uint64_t ttl_ms_ = 60 * 60 * 1000;  // 1h; remote SegmentUpdate push handles invalidation
 
     // shared_ptr to prevent UAF in async callbacks
     std::shared_ptr<RWSpinlock> subscribers_lock_;
     std::shared_ptr<std::unordered_set<std::string>> subscribers_;
+
+    // Cache for the serialized JSON of local_desc_. Reset by synchronizeLocal.
+    std::mutex local_json_cache_mu_;
+    std::shared_ptr<const std::string> local_json_cache_;
 };
 }  // namespace tent
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tent/include/tent/runtime/segment_manager.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/segment_manager.h
@@ -31,9 +31,9 @@
 
 #include "tent/runtime/segment.h"
 
-// Fallback refresh interval for cached remote SegmentDesc. Invalidation normally
-// comes from the best-effort SegmentUpdate push; this TTL only bounds staleness
-// if a push is lost.
+// Fallback refresh interval for cached remote SegmentDesc. Invalidation
+// normally comes from the best-effort SegmentUpdate push; this TTL only bounds
+// staleness if a push is lost.
 #define TENT_SEGMENT_DESC_TTL_MS (60 * 60 * 1000)  // 1h
 
 namespace mooncake {

--- a/mooncake-transfer-engine/tent/include/tent/runtime/segment_manager.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/segment_manager.h
@@ -31,8 +31,9 @@
 
 #include "tent/runtime/segment.h"
 
-// TTL for cached remote SegmentDesc. Remote SegmentUpdate push handles
-// invalidation, so this is only a fallback refresh interval.
+// Fallback refresh interval for cached remote SegmentDesc. Invalidation normally
+// comes from the best-effort SegmentUpdate push; this TTL only bounds staleness
+// if a push is lost.
 #define TENT_SEGMENT_DESC_TTL_MS (60 * 60 * 1000)  // 1h
 
 namespace mooncake {

--- a/mooncake-transfer-engine/tent/include/tent/runtime/segment_manager.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/segment_manager.h
@@ -154,7 +154,8 @@ class SegmentManager {
     std::unique_ptr<SegmentRegistry> registry_;
 
     std::string file_desc_basepath_;
-    uint64_t ttl_ms_ = 60 * 60 * 1000;  // 1h; remote SegmentUpdate push handles invalidation
+    uint64_t ttl_ms_ =
+        60 * 60 * 1000;  // 1h; remote SegmentUpdate push handles invalidation
 
     // shared_ptr to prevent UAF in async callbacks
     std::shared_ptr<RWSpinlock> subscribers_lock_;

--- a/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
@@ -226,8 +226,9 @@ Status ControlService::start(uint16_t& port, bool ipv6_) {
 
 void ControlService::onGetSegmentDesc(const std::string_view& request,
                                       std::string& response) {
-    json j = *manager_->getLocal();
-    response = j.dump();
+    // Re-use the cached dump shared across concurrent peer fetches.
+    auto cached = manager_->getLocalDumpedJson();
+    response = *cached;
 }
 
 void ControlService::onBootstrapRdma(const std::string_view& request,

--- a/mooncake-transfer-engine/tent/src/runtime/segment_manager.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/segment_manager.cpp
@@ -97,11 +97,16 @@ Status SegmentManager::getRemoteCached(SegmentDesc *&desc, SegmentID handle) {
 }
 
 Status SegmentManager::getRemote(SegmentDescRef &desc, SegmentID handle) {
-    RWSpinlock::WriteGuard guard(lock_);
-    if (!id_to_name_map_.count(handle)) {
-        return Status::InvalidArgument("Invalid segment handle" LOC_MARK);
+    // Only the id_to_name lookup needs the lock.
+    std::string segment_name;
+    {
+        RWSpinlock::ReadGuard guard(lock_);
+        auto it = id_to_name_map_.find(handle);
+        if (it == id_to_name_map_.end()) {
+            return Status::InvalidArgument("Invalid segment handle" LOC_MARK);
+        }
+        segment_name = it->second;
     }
-    auto segment_name = id_to_name_map_[handle];
     if (segment_name.starts_with(kLocalFileSegmentPrefix)) {
         CHECK_STATUS(makeFileRemote(desc, segment_name));
     } else {
@@ -169,7 +174,26 @@ Status SegmentManager::makeFileRemote(SegmentDescRef &desc,
     return Status::OK();
 }
 
+std::shared_ptr<const std::string> SegmentManager::getLocalDumpedJson() {
+    {
+        std::lock_guard<std::mutex> g(local_json_cache_mu_);
+        if (local_json_cache_) return local_json_cache_;
+    }
+    json j = *local_desc_;
+    auto computed = std::make_shared<const std::string>(j.dump());
+
+    std::lock_guard<std::mutex> g(local_json_cache_mu_);
+    if (!local_json_cache_) {
+        local_json_cache_ = computed;
+    }
+    return local_json_cache_;
+}
+
 Status SegmentManager::synchronizeLocal() {
+    {
+        std::lock_guard<std::mutex> g(local_json_cache_mu_);
+        local_json_cache_.reset();
+    }
     CHECK_STATUS(registry_->putSegmentDesc(local_desc_));
 
     std::vector<std::string> subscribers_snapshot;

--- a/mooncake-transfer-engine/tent/src/runtime/segment_manager.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/segment_manager.cpp
@@ -64,7 +64,8 @@ Status SegmentManager::getRemoteCached(SegmentDesc *&desc, SegmentID handle) {
     auto &cache = tl_remote_cache_.get();
     auto current_ts = getCurrentTimeInNano();
     auto current_version = version_.load(std::memory_order_relaxed);
-    if (current_ts - cache.last_refresh > ttl_ms_ * 1000000 ||
+    if (current_ts - cache.last_refresh >
+            static_cast<uint64_t>(TENT_SEGMENT_DESC_TTL_MS) * 1000000 ||
         cache.version != current_version) {
         cache.id_to_desc_map.clear();
         cache.last_refresh = current_ts;

--- a/mooncake-transfer-engine/tent/src/runtime/segment_tracker.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/segment_tracker.cpp
@@ -66,8 +66,7 @@ Status SegmentTracker::add(uint64_t base, size_t length,
         new_desc.location = entries[0].location;
     else {
         new_desc.location = entries[0].location;
-        for (auto& entry : entries)
-            new_desc.regions.push_back(Region{entry.len, entry.location});
+        new_desc.regions = coalesceRegions(entries);
     }
     new_desc.ref_count = 1;
     auto status = callback(new_desc);

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -1083,7 +1083,8 @@ std::optional<BufferKey> toBufferKey(BufferDesc* buffer) {
 
 std::vector<RequestBoundaryInfo> resolveRequestBoundaries(
     ControlService* metadata, const std::vector<Request>& requests) {
-    // Group requests by target_id so withCachedSegment fires at most once per peer.
+    // Group requests by target_id so withCachedSegment fires at most once per
+    // peer.
     std::vector<RequestBoundaryInfo> boundaries(requests.size());
     auto* local_desc = metadata->segmentManager().getLocal().get();
 
@@ -1107,7 +1108,8 @@ std::vector<RequestBoundaryInfo> resolveRequestBoundaries(
                 bool any_missing = false;
                 for (size_t i : idxs) {
                     const auto& r = requests[i];
-                    auto* buffer = target_desc->findBuffer(r.target_offset, r.length);
+                    auto* buffer =
+                        target_desc->findBuffer(r.target_offset, r.length);
                     if (!buffer) {
                         any_missing = true;
                         boundaries[i].target_key = std::nullopt;

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -657,8 +657,7 @@ Status TransferEngineImpl::registerLocalMemory(std::vector<void*> addr_list,
             desc.location = entries[0].location;
         } else {
             desc.location = entries[0].location;
-            for (auto& entry : entries)
-                desc.regions.push_back(Region{entry.len, entry.location});
+            desc.regions = coalesceRegions(entries);
         }
         desc.ref_count = 1;
         if (options.location != kWildcardLocation)
@@ -1082,43 +1081,59 @@ std::optional<BufferKey> toBufferKey(BufferDesc* buffer) {
     return BufferKey{buffer->addr, buffer->length};
 }
 
-RequestBoundaryInfo resolveRequestBoundary(ControlService* metadata,
-                                           SegmentDesc* local_desc,
-                                           const Request& request) {
-    RequestBoundaryInfo boundary;
-
-    if (local_desc) {
-        auto source_addr =
-            static_cast<uint64_t>(reinterpret_cast<uintptr_t>(request.source));
-        boundary.source_key =
-            toBufferKey(local_desc->findBuffer(source_addr, request.length));
-    }
-
-    metadata->segmentManager().withCachedSegment(
-        request.target_id, [&](SegmentDesc* target_desc) {
-            auto buffer =
-                target_desc->findBuffer(request.target_offset, request.length);
-
-            if (!buffer) {
-                boundary.target_key = std::nullopt;
-                return Status::NeedsRefreshCache(
-                    "Requested address is not in registered buffer" LOC_MARK);
-            }
-
-            boundary.target_key = toBufferKey(buffer);
-            return Status::OK();
-        });
-    return boundary;
-}
-
 std::vector<RequestBoundaryInfo> resolveRequestBoundaries(
     ControlService* metadata, const std::vector<Request>& requests) {
-    std::vector<RequestBoundaryInfo> boundaries;
-    boundaries.reserve(requests.size());
+    // Group requests by target_id so withCachedSegment fires at most once per peer.
+    std::vector<RequestBoundaryInfo> boundaries(requests.size());
     auto* local_desc = metadata->segmentManager().getLocal().get();
-    for (const auto& request : requests) {
-        boundaries.push_back(
-            resolveRequestBoundary(metadata, local_desc, request));
+
+    if (local_desc) {
+        for (size_t i = 0; i < requests.size(); ++i) {
+            auto source_addr = static_cast<uint64_t>(
+                reinterpret_cast<uintptr_t>(requests[i].source));
+            boundaries[i].source_key = toBufferKey(
+                local_desc->findBuffer(source_addr, requests[i].length));
+        }
+    }
+
+    std::unordered_map<SegmentID, std::vector<size_t>> by_target;
+    for (size_t i = 0; i < requests.size(); ++i) {
+        by_target[requests[i].target_id].push_back(i);
+    }
+
+    for (auto& [target_id, idxs] : by_target) {
+        metadata->segmentManager().withCachedSegment(
+            target_id, [&](SegmentDesc* target_desc) {
+                bool any_missing = false;
+                for (size_t i : idxs) {
+                    const auto& r = requests[i];
+                    auto* buffer = target_desc->findBuffer(r.target_offset, r.length);
+                    if (!buffer) {
+                        any_missing = true;
+                        boundaries[i].target_key = std::nullopt;
+                    } else {
+                        boundaries[i].target_key = toBufferKey(buffer);
+                    }
+                }
+                // Invariant: when this lambda returns NeedsRefreshCache, all
+                // writes it made in this pass are wiped before it returns.
+                // Reason: withCachedSegment will invalidate the cache and try
+                // ONE refetch; if that refetch fails (e.g. peer RPC down) the
+                // retry pass never runs, and any tentative writes from this
+                // (stale) pass would leak downstream into mergeRequests. By
+                // clearing here we leave a clean nullopt state for the group,
+                // and the retry pass (if it does run) repopulates from the
+                // fresh desc so the wipe is harmless.
+                if (any_missing) {
+                    for (size_t i : idxs) {
+                        boundaries[i].target_key = std::nullopt;
+                    }
+                    return Status::NeedsRefreshCache(
+                        "Requested address is not in registered "
+                        "buffer" LOC_MARK);
+                }
+                return Status::OK();
+            });
     }
     return boundaries;
 }

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -33,6 +33,13 @@ target_include_directories(tent_ip_utils_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME tent_ip_utils_test COMMAND tent_ip_utils_test)
 
+add_executable(tent_coalesce_regions_test coalesce_regions_test.cpp)
+target_link_libraries(tent_coalesce_regions_test PRIVATE tent_common gtest
+                                                         gtest_main)
+target_include_directories(tent_coalesce_regions_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+add_test(NAME tent_coalesce_regions_test COMMAND tent_coalesce_regions_test)
+
 add_executable(request_merge_test request_merge_test.cpp)
 target_link_libraries(request_merge_test PRIVATE gtest gtest_main
                                                  tent_link_group)

--- a/mooncake-transfer-engine/tent/tests/coalesce_regions_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/coalesce_regions_test.cpp
@@ -1,0 +1,183 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "tent/runtime/segment.h"
+#include "tent/runtime/topology.h"
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+constexpr size_t kKiB = static_cast<size_t>(1) << 10;
+constexpr size_t kMiB = static_cast<size_t>(1) << 20;
+constexpr size_t kGiB = static_cast<size_t>(1) << 30;
+
+// Build an entries vector where each RangeLocation is address-adjacent to
+// the previous one. Mirrors what Platform::getLoader().getLocation produces.
+std::vector<RangeLocation> makeEntries(
+    const std::vector<std::pair<size_t, std::string>>& segs) {
+    std::vector<RangeLocation> out;
+    uint64_t cursor = 0;
+    out.reserve(segs.size());
+    for (auto& [len, loc] : segs) {
+        out.push_back(RangeLocation{cursor, len, loc});
+        cursor += len;
+    }
+    return out;
+}
+
+size_t sumLens(const std::vector<RangeLocation>& entries) {
+    size_t s = 0;
+    for (auto& e : entries) s += e.len;
+    return s;
+}
+
+size_t sumSizes(const std::vector<Region>& regions) {
+    size_t s = 0;
+    for (auto& r : regions) s += r.size;
+    return s;
+}
+
+// All these inputs are well under (128 buckets × 1 MiB floor), so the
+// effective bucket size is the 1 MiB default min_bucket_bytes floor.
+TEST(CoalesceRegionsTest, TieBreakIsDeterministic) {
+    auto entries = makeEntries({{256 * kKiB, "cpu:0"},
+                                {256 * kKiB, "cpu:1"},
+                                {256 * kKiB, "cpu:0"},
+                                {256 * kKiB, "cpu:1"}});
+    auto first = coalesceRegions(entries);
+    ASSERT_EQ(first.size(), 1u);
+    EXPECT_EQ(first[0].size, 1 * kMiB);
+    EXPECT_EQ(first[0].location, "cpu:0");
+
+    for (int i = 0; i < 100; ++i) {
+        auto run = coalesceRegions(entries);
+        ASSERT_EQ(run.size(), 1u);
+        EXPECT_EQ(run[0].location, "cpu:0") << "run " << i;
+    }
+}
+
+TEST(CoalesceRegionsTest, MajorityWins) {
+    auto entries =
+        makeEntries({{900 * kKiB, "cpu:0"}, {100 * kKiB, "cpu:1"}});
+    auto out = coalesceRegions(entries);
+    ASSERT_EQ(out.size(), 1u);
+    EXPECT_EQ(out[0].size, 1000 * kKiB);
+    EXPECT_EQ(out[0].location, "cpu:0");
+}
+
+TEST(CoalesceRegionsTest, SameLocationCoalesces) {
+    auto entries = makeEntries({{256 * kKiB, "cpu:0"},
+                                {256 * kKiB, "cpu:0"},
+                                {256 * kKiB, "cpu:0"},
+                                {256 * kKiB, "cpu:0"}});
+    auto out = coalesceRegions(entries);
+    ASSERT_EQ(out.size(), 1u);
+    EXPECT_EQ(out[0].size, 1 * kMiB);
+    EXPECT_EQ(out[0].location, "cpu:0");
+}
+
+TEST(CoalesceRegionsTest, EmptyInput) {
+    auto out = coalesceRegions({});
+    EXPECT_TRUE(out.empty());
+}
+
+TEST(CoalesceRegionsTest, TotalBytesPreserved) {
+    auto entries = makeEntries({{700 * kKiB, "cpu:0"},
+                                {300 * kKiB, "cpu:1"},
+                                {2 * kMiB, "cpu:0"},
+                                {500 * kKiB, "cpu:1"},
+                                {1500 * kKiB, "cpu:0"}});
+    auto out = coalesceRegions(entries);
+    EXPECT_EQ(sumSizes(out), sumLens(entries));
+}
+
+TEST(CoalesceRegionsTest, AutoBucketBoundedBy128) {
+    // 256 segments × 16 MiB alternating cpu:0 / cpu:1 = 4 GiB total.
+    // Auto bucket should land near 4 GiB / 128 = 32 MiB → at most 128
+    // regions.
+    std::vector<std::pair<size_t, std::string>> segs;
+    segs.reserve(256);
+    for (int i = 0; i < 256; ++i) {
+        segs.emplace_back(16 * kMiB, i % 2 == 0 ? "cpu:0" : "cpu:1");
+    }
+    auto entries = makeEntries(segs);
+    auto out = coalesceRegions(entries);  // all defaults: auto, 128, 1 MiB
+    EXPECT_LE(out.size(), 128u);
+    EXPECT_EQ(sumSizes(out), sumLens(entries));
+}
+
+TEST(CoalesceRegionsTest, AutoBucketRespectsMinFloor) {
+    auto entries =
+        makeEntries({{50 * kKiB, "cpu:0"}, {50 * kKiB, "cpu:0"}});
+    auto out = coalesceRegions(entries);  // auto: 1 MiB floor applies
+    ASSERT_EQ(out.size(), 1u);
+    EXPECT_EQ(out[0].size, 100 * kKiB);
+    EXPECT_EQ(out[0].location, "cpu:0");
+}
+
+// `max_buckets=0` and `min_bucket_bytes=0` together would historically
+// yield bucket_bytes=0 → divide-by-zero / take=0 infinite loop. Defensive
+// floor inside the helper must keep the call well-defined.
+TEST(CoalesceRegionsTest, DefensiveZeroParams) {
+    auto entries =
+        makeEntries({{256 * kKiB, "cpu:0"}, {256 * kKiB, "cpu:1"}});
+    auto out = coalesceRegions(entries,
+                               /*max_buckets=*/0,
+                               /*min_bucket_bytes=*/0);
+    EXPECT_FALSE(out.empty());
+    EXPECT_EQ(sumSizes(out), sumLens(entries));
+}
+
+// Documents the intentional precision/size tradeoff: a tiny minority
+// region inside a much larger bucket gets the majority label. This is the
+// designed behavior, not a bug — kept here so any future change that
+// "fixes" this case has to consciously remove the test.
+TEST(CoalesceRegionsTest, AcceptsApproximation) {
+    auto entries = makeEntries({{1 * kKiB, "cpu:0"}, {9 * kMiB, "cpu:1"}});
+    auto out = coalesceRegions(entries);  // auto bucket >> 1 KiB
+    ASSERT_FALSE(out.empty());
+    EXPECT_EQ(out.front().location, "cpu:1");
+    EXPECT_EQ(sumSizes(out), sumLens(entries));
+}
+
+// Verifies only spatially adjacent entries get merged into the same
+// Region: a 1 MiB bucket size + 6 alternating 256 KiB segments yields
+// (a) Regions in input order, (b) the second Region cannot pull cpu:0
+// votes from the first bucket back across the boundary.
+TEST(CoalesceRegionsTest, OnlyAdjacentMerged) {
+    auto entries = makeEntries({{256 * kKiB, "cpu:0"},
+                                {256 * kKiB, "cpu:1"},
+                                {256 * kKiB, "cpu:0"},
+                                {256 * kKiB, "cpu:1"},
+                                {256 * kKiB, "cpu:0"},
+                                {256 * kKiB, "cpu:1"}});
+    auto out = coalesceRegions(entries);
+    ASSERT_EQ(out.size(), 2u);
+    EXPECT_EQ(out[0].size, 1 * kMiB);
+    EXPECT_EQ(out[0].location, "cpu:0");  // 4-way tie, first-seen wins
+    EXPECT_EQ(out[1].size, 512 * kKiB);
+    EXPECT_EQ(out[1].location, "cpu:0");  // 2-way tie, first-seen wins
+    EXPECT_EQ(out[0].size + out[1].size, sumLens(entries));
+}
+
+}  // namespace
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/tests/coalesce_regions_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/coalesce_regions_test.cpp
@@ -75,8 +75,7 @@ TEST(CoalesceRegionsTest, TieBreakIsDeterministic) {
 }
 
 TEST(CoalesceRegionsTest, MajorityWins) {
-    auto entries =
-        makeEntries({{900 * kKiB, "cpu:0"}, {100 * kKiB, "cpu:1"}});
+    auto entries = makeEntries({{900 * kKiB, "cpu:0"}, {100 * kKiB, "cpu:1"}});
     auto out = coalesceRegions(entries);
     ASSERT_EQ(out.size(), 1u);
     EXPECT_EQ(out[0].size, 1000 * kKiB);
@@ -125,8 +124,7 @@ TEST(CoalesceRegionsTest, AutoBucketBoundedBy128) {
 }
 
 TEST(CoalesceRegionsTest, AutoBucketRespectsMinFloor) {
-    auto entries =
-        makeEntries({{50 * kKiB, "cpu:0"}, {50 * kKiB, "cpu:0"}});
+    auto entries = makeEntries({{50 * kKiB, "cpu:0"}, {50 * kKiB, "cpu:0"}});
     auto out = coalesceRegions(entries);  // auto: 1 MiB floor applies
     ASSERT_EQ(out.size(), 1u);
     EXPECT_EQ(out[0].size, 100 * kKiB);
@@ -137,8 +135,7 @@ TEST(CoalesceRegionsTest, AutoBucketRespectsMinFloor) {
 // yield bucket_bytes=0 → divide-by-zero / take=0 infinite loop. Defensive
 // floor inside the helper must keep the call well-defined.
 TEST(CoalesceRegionsTest, DefensiveZeroParams) {
-    auto entries =
-        makeEntries({{256 * kKiB, "cpu:0"}, {256 * kKiB, "cpu:1"}});
+    auto entries = makeEntries({{256 * kKiB, "cpu:0"}, {256 * kKiB, "cpu:1"}});
     auto out = coalesceRegions(entries,
                                /*max_buckets=*/0,
                                /*min_bucket_bytes=*/0);


### PR DESCRIPTION
## Description

`SegmentManager::getRemote` sits in the cold path of every freshly seen target segment and currently has two amplifiers stacked on each other:

1. `BufferDesc::regions` can be huge. `registerLocalMemory` calls `Platform::getLoader().getLocation(addr, size)` on each newly registered buffer. `CpuPlatform::getLocation` walks the buffer 4 KiB at a time with `numa_move_pages` and emits a new `RangeLocation` every time the NUMA label changes between adjacent pages. When registered memory has mixed-NUMA physical backing, the probe alternates page-by-page and produces tens of thousands of single-page entries per buffer. We have observed buffers with total ~1600k raw entries, whose serialized `SegmentDesc` reaches ~23 MiB. The same binary on memory with contiguous NUMA backing produces an 11 KiB segment for the same buffer count.

2. The sender re-runs `json::dump(*local_desc_)` on every `GetSegmentDesc` RPC. `ControlService::onGetSegmentDesc` recomputes the dump on each call, even when `local_desc_` has not changed since the last fetch. With concurrent peers and a multi-MiB payload, the dump cost dominates the RPC and scales linearly with peer fanout.

Both compound in the cold-fetch path: receivers pay 23 MiB of JSON parse, and senders pay full re-serialization for each concurrent fetch of the same unchanged descriptor. End-to-end this turns the first `getRemote` for a new peer into a multi-second stall in workloads where receiver-side fanout and large registered buffers coincide.

This PR reduces metadata send/receive overhead along the whole chain: payload size at the source, dump cost per concurrent peer, lock scope around the RPC, and the number of times a single batch re-issues the same lookup.

### Change

 Five independent optimizations along the cold-fetch chain. Each is separately verifiable but they compose multiplicatively:

1. Coalesce `BufferDesc::regions` into routing-hint buckets. New `coalesceRegions()` helper bucketizes the per-page NUMA probe output into ≤ `max_buckets` regions of ≥ `min_bucket_bytes` each, emitting one Region per bucket carrying the bucket's byte-weighted majority NUMA label. Used by both `registerLocalMemory` and `SegmentTracker::add` so both register paths produce identical region shape. The downstream consumer only picks a NIC by largest overlap, so a slightly approximated NUMA label per ~1 MiB bucket is functionally equivalent to the page-precise list.

2. Cache the serialized `local_desc_` JSON across concurrent peer fetches. New `SegmentManager::getLocalDumpedJson()` lazily computes and caches `json(*local_desc_).dump()`, invalidated by `synchronizeLocal()` (which already runs on every register / unregister). `ControlService::onGetSegmentDesc` now serves from the shared cached string instead of re-dumping per RPC. N concurrent peer fetches share one dump.

3. Drop the write lock around the RPC in `SegmentManager::getRemote`. The previous `WriteGuard` covered the entire function including the RPC and JSON parse. Only the `id_to_name_map_` lookup needs serialization, so the function now takes a `ReadGuard` for the name lookup and releases it before calling `makeFileRemote` / `registry_->getSegmentDesc`. Concurrent peer fetches against distinct segments no longer serialize, and concurrent fetches against the same segment no longer block the rest of `SegmentManager`.

4. Group `resolveRequestBoundaries` by `target_id`. The old loop did one `withCachedSegment(request.target_id, …)` per request. When a batch addresses a single peer segment with thousands of requests, this re-walked the TLS cache thousands of times. The rewrite groups requests by `target_id` and calls `withCachedSegment` once per unique peer, so a cache miss now refreshes once per peer per batch, not once per request. Added invariant: when the lambda returns `NeedsRefreshCache`, any per-request `target_key` writes it produced are wiped before returning, so a failed refetch can't leak stale boundaries into the downstream `mergeRequests` path.

5. Bump `ttl_ms_` from 10 s → 1 h. The previous 10 s TTL forced periodic re-execution of the full cold path under steady-state load with no functional benefit — `synchronizeLocal` already invalidates the local dump cache on register / unregister, and the sender pushes `SegmentUpdate` to subscribers on change. The 10 s value pre-dated those mechanisms.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

After all five changes land, cold `bound_us` for a 42500-request, single-peer batch on the heavy-fragmentation workload drops from ~4.7 s to ~95 ms (~50×), and sender JSON payload drops from 23 MiB to 1.30 MiB. The non-fragmented control is unchanged.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [x] AI tools were used (Claude Code for drafting this PR description; all code changes hand-written and reviewed)