### PR TITLE
[Store] Make etcd master-view watch event-driven instead of polling

### DIFF
--- a/mooncake-common/etcd/etcd_wrapper.go
+++ b/mooncake-common/etcd/etcd_wrapper.go
@@ -844,6 +844,16 @@ func EtcdStoreWatchWithPrefixFromRevisionWrapper(prefix *C.char, prefixSize C.in
 		return -1
 	}
 	doneCh := make(chan struct{})
+	// createdCh reports whether the server-side watch was successfully
+	// established. The goroutine sends exactly one value: true once etcd
+	// confirms the watch (clientv3.WithCreatedNotify), or false if the
+	// goroutine exits before that confirmation. The wrapper blocks on it before
+	// returning, so callers can rely on "watch is live server-side" the moment
+	// WatchWithPrefixFromRevision returns OK. This closes the race where the
+	// goroutine had not yet issued storeClient.Watch() when the caller
+	// proceeded to read the current view. Buffered (size 1) so the goroutine
+	// never blocks on the send even if the wrapper has already timed out.
+	createdCh := make(chan bool, 1)
 	storePrefixWatchCtx[p] = prefixWatchInfo{
 		cancel:          cancel,
 		callbackContext: callbackContext,
@@ -851,16 +861,30 @@ func EtcdStoreWatchWithPrefixFromRevisionWrapper(prefix *C.char, prefixSize C.in
 	}
 	storePrefixWatchMutex.Unlock()
 
-	go func(doneCh chan struct{}) {
+	go func(doneCh chan struct{}, createdCh chan bool) {
+		// createdSignalled guards against sending on createdCh more than once.
+		createdSignalled := false
+		signalCreated := func(ok bool) {
+			if !createdSignalled {
+				createdSignalled = true
+				createdCh <- ok
+			}
+		}
 		defer func() {
-			// Remove watch entry and signal completion
+			// Report failure if the watch was never confirmed (e.g. the
+			// goroutine exits before any response), then remove the watch
+			// entry and signal completion. Ordering matters: the failure
+			// signal is sent before `done` is closed.
+			signalCreated(false)
 			storePrefixWatchMutex.Lock()
 			delete(storePrefixWatchCtx, p)
 			storePrefixWatchMutex.Unlock()
 			close(doneCh)
 		}()
 
-		opts := []clientv3.OpOption{clientv3.WithPrefix()}
+		// WithCreatedNotify makes etcd send an initial response with
+		// Created == true as soon as the watch is registered server-side.
+		opts := []clientv3.OpOption{clientv3.WithPrefix(), clientv3.WithCreatedNotify()}
 		if startRevision > 0 {
 			opts = append(opts, clientv3.WithRev(int64(startRevision)))
 		}
@@ -879,6 +903,11 @@ func EtcdStoreWatchWithPrefixFromRevisionWrapper(prefix *C.char, prefixSize C.in
 						C.call_watch_cb(callbackFunc, callbackContext, nil, 0, nil, 0, C.int(2) /*WATCH_BROKEN*/, C.longlong(0))
 						return
 					}
+				}
+				// The first response with Created == true confirms the
+				// server-side watch is established; release the waiter.
+				if watchResp.Created {
+					signalCreated(true)
 				}
 				if watchResp.Err() != nil {
 					// Watch error. Check if context was cancelled.
@@ -945,9 +974,35 @@ func EtcdStoreWatchWithPrefixFromRevisionWrapper(prefix *C.char, prefixSize C.in
 				return
 			}
 		}
-	}(doneCh)
+	}(doneCh, createdCh)
 
-	return 0
+	// Block until the server confirms the watch is established. Returning OK
+	// then guarantees the watch is live server-side, so a caller that arms the
+	// watch before reading state will not miss an event in between.
+	const watchCreatedTimeout = 5 * time.Second
+	select {
+	case created := <-createdCh:
+		if !created {
+			// The goroutine exited before the watch was confirmed (e.g. the
+			// Watch RPC failed). It has already torn itself down; wait for it
+			// to finish so the prefix entry is gone and no callback is in
+			// flight, then report failure.
+			cancel()
+			<-doneCh
+			*errMsg = C.CString("etcd watch goroutine exited before the watch was established")
+			return -1
+		}
+		return 0
+	case <-time.After(watchCreatedTimeout):
+		// The watch was not established within the timeout. Tear down the
+		// goroutine and report failure so the caller can fall back. Wait for
+		// the goroutine to fully exit so the prefix entry is removed and no
+		// callback can be in flight when we return.
+		cancel()
+		<-doneCh
+		*errMsg = C.CString("timeout waiting for etcd watch to be created")
+		return -1
+	}
 }
 
 func cancelAndDeletePrefixWatch(p string) int {

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -577,7 +577,14 @@ ErrorCode Client::SwitchLeader(const ha::MasterView& target_view) {
 }
 
 void Client::LeaderMonitorThreadMain() {
-    constexpr auto kViewChangeTimeout = std::chrono::milliseconds(1000);
+    // WaitForViewChange now blocks on a backend watch and returns as soon as
+    // leadership actually changes, so this timeout no longer drives polling
+    // cadence -- it is only a periodic re-sync safety net that re-reads the
+    // current view in case a watch event was missed (e.g. a connection blip).
+    // Keeping it long (30s instead of 1s) collapses steady-state backend load
+    // from ~1 read/sec/client to ~1 read/30s/client without affecting failover
+    // responsiveness, which is driven by the watch.
+    constexpr auto kViewChangeTimeout = std::chrono::milliseconds(30000);
     constexpr auto kErrorRetryInterval = std::chrono::milliseconds(1000);
 
     while (leader_monitor_running_.load()) {

--- a/mooncake-store/src/ha/leadership/backends/etcd/etcd_leader_coordinator.cpp
+++ b/mooncake-store/src/ha/leadership/backends/etcd/etcd_leader_coordinator.cpp
@@ -61,20 +61,43 @@ void ViewChangeWatchCallback(void* context, const char* /*key*/,
 }
 
 // RAII guard that tears the prefix watch down (and waits for the goroutine to
-// exit, so no further callbacks can run) before the associated
-// ViewChangeWatchState is destroyed. Declared after the state so it is
-// destroyed first.
+// exit, so no further callbacks can run) before the heap-allocated
+// ViewChangeWatchState it owns is released.
+//
+// The watch state is HEAP-allocated (not stack-scoped) on purpose. The Go watch
+// goroutine holds a raw pointer to it and may still invoke the callback until
+// it has fully stopped. CancelWatchWithPrefix + WaitWatchWithPrefixStopped are
+// used to drain it, but WaitWatchWithPrefixStopped can time out. If it does, a
+// callback may still fire later, so freeing the state would be a
+// use-after-free. Mirroring the oplog notifier's policy, the guard therefore
+// only deletes the state when the stop wait SUCCEEDS; on timeout/failure it
+// intentionally LEAKS the state (and logs a warning) to avoid UAF.
 class PrefixWatchGuard {
    public:
-    explicit PrefixWatchGuard(std::string prefix)
-        : prefix_(std::move(prefix)) {}
+    PrefixWatchGuard(std::string prefix, ViewChangeWatchState* state)
+        : prefix_(std::move(prefix)), state_(state) {}
     ~PrefixWatchGuard() {
         if (!active_) {
+            // Watch was never armed: no goroutine ever received the pointer, so
+            // it is safe to free the state unconditionally.
+            delete state_;
             return;
         }
         EtcdHelper::CancelWatchWithPrefix(prefix_.c_str(), prefix_.size());
-        EtcdHelper::WaitWatchWithPrefixStopped(prefix_.c_str(), prefix_.size(),
-                                               kWatchStopTimeoutMs);
+        ErrorCode wait_err = EtcdHelper::WaitWatchWithPrefixStopped(
+            prefix_.c_str(), prefix_.size(), kWatchStopTimeoutMs);
+        if (wait_err == ErrorCode::OK) {
+            // Goroutine has fully exited; no callback can be in flight.
+            delete state_;
+        } else {
+            // The watch goroutine did not stop in time. It may still invoke the
+            // callback with `state_`, so we intentionally leak the state to
+            // avoid a use-after-free.
+            LOG(WARNING) << "Prefix watch goroutine did not stop in time for "
+                            "prefix "
+                         << prefix_
+                         << "; leaking ViewChangeWatchState to avoid UAF";
+        }
     }
 
     PrefixWatchGuard(const PrefixWatchGuard&) = delete;
@@ -84,6 +107,7 @@ class PrefixWatchGuard {
 
    private:
     std::string prefix_;
+    ViewChangeWatchState* state_ = nullptr;
     bool active_ = false;
 };
 
@@ -311,6 +335,15 @@ EtcdLeaderCoordinator::WaitForViewChange(
         return tl::make_unexpected(err);
     }
 
+    // LIMITATION: prefix watches are keyed globally by prefix in the etcd Go
+    // wrapper (storePrefixWatchCtx is a map<prefix, ...>). Because every waiter
+    // here watches the same `master_view_key_` prefix, only a SINGLE waiter per
+    // process per prefix is supported: a second concurrent WaitForViewChange on
+    // the same prefix would collide on that registration. The intended
+    // deployment model is one waiter per process/prefix, which holds for the
+    // store client. Revisit (e.g. per-waiter watch IDs) if multiple
+    // same-process clients ever need to watch the same master_view
+    // concurrently.
     const auto deadline = std::chrono::steady_clock::now() + timeout;
     while (true) {
         if (timeout <= std::chrono::milliseconds::zero() ||
@@ -335,11 +368,13 @@ EtcdLeaderCoordinator::WaitForViewChange(
         // starts from the current revision (start_revision = 0), which also
         // avoids depending on a possibly-compacted historical revision.
         //
-        // `state` must outlive `guard`: the guard cancels the watch and waits
-        // for the goroutine to exit (no more callbacks) in its destructor,
-        // before `state` is destroyed. Declaration order guarantees this.
-        ViewChangeWatchState state;
-        PrefixWatchGuard guard(master_view_key_);
+        // The watch state is heap-allocated and owned by `guard`. The guard
+        // cancels the watch and waits for the goroutine to exit before
+        // releasing the state in its destructor; if the goroutine fails to stop
+        // in time it leaks the state instead of freeing it, so an in-flight
+        // callback can never reference freed memory (see PrefixWatchGuard).
+        auto* state = new ViewChangeWatchState();
+        PrefixWatchGuard guard(master_view_key_, state);
 
         bool watching = false;
         if (remaining > kViewChangeFallbackPollInterval) {
@@ -352,7 +387,7 @@ EtcdLeaderCoordinator::WaitForViewChange(
                                                    kWatchStopTimeoutMs);
             auto watch_err = EtcdHelper::WatchWithPrefixFromRevision(
                 master_view_key_.c_str(), master_view_key_.size(),
-                /*start_revision=*/0, &state, &ViewChangeWatchCallback);
+                /*start_revision=*/0, state, &ViewChangeWatchCallback);
             if (watch_err == ErrorCode::OK) {
                 watching = true;
                 guard.Arm();
@@ -383,9 +418,9 @@ EtcdLeaderCoordinator::WaitForViewChange(
         // elapses. Either way we loop and re-read: an event tells us the view
         // changed (re-read returns it), a timeout falls through to the deadline
         // check above and returns timed_out.
-        std::unique_lock<std::mutex> lock(state.mutex);
-        state.cv.wait_for(lock, remaining,
-                          [&state]() { return state.changed; });
+        std::unique_lock<std::mutex> lock(state->mutex);
+        state->cv.wait_for(lock, remaining,
+                           [state]() { return state->changed; });
     }
 }
 

--- a/mooncake-store/src/ha/leadership/backends/etcd/etcd_leader_coordinator.cpp
+++ b/mooncake-store/src/ha/leadership/backends/etcd/etcd_leader_coordinator.cpp
@@ -3,8 +3,10 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <cstdlib>
 #include <cstring>
+#include <mutex>
 #include <optional>
 #include <thread>
 
@@ -21,7 +23,69 @@ namespace etcd {
 namespace {
 
 constexpr int kKeepAliveReadyTimeoutMs = 1000;
-constexpr auto kViewChangePollInterval = std::chrono::milliseconds(200);
+// Fallback poll interval used only when a watch cannot be armed (e.g. the watch
+// RPC fails, or the remaining timeout is too small to be worth a watch). The
+// steady-state path blocks on an etcd watch and does not poll.
+constexpr auto kViewChangeFallbackPollInterval = std::chrono::milliseconds(200);
+// Upper bound for waiting on the watch goroutine to fully stop before the
+// watch context is destroyed. Mirrors the value used by the oplog notifier.
+constexpr int kWatchStopTimeoutMs = 5000;
+
+// Shared state between WaitForViewChange and the etcd watch callback. The
+// callback only flips `changed` and wakes the waiter; the waiter decides what
+// the change means by re-reading the view.
+struct ViewChangeWatchState {
+    std::mutex mutex;
+    std::condition_variable cv;
+    bool changed = false;
+};
+
+// C-style trampoline invoked by the etcd watch goroutine for every event on the
+// watched prefix (PUT / DELETE / WATCH_BROKEN). Any event is treated as "the
+// view may have changed"; the waiter re-reads to find out what actually
+// happened. The watch context outlives every callback because the waiter calls
+// CancelWatchWithPrefix + WaitWatchWithPrefixStopped before it is destroyed.
+void ViewChangeWatchCallback(void* context, const char* /*key*/,
+                             size_t /*key_size*/, const char* /*value*/,
+                             size_t /*value_size*/, int /*event_type*/,
+                             int64_t /*mod_revision*/) {
+    auto* state = static_cast<ViewChangeWatchState*>(context);
+    if (state == nullptr) {
+        return;
+    }
+    {
+        std::lock_guard<std::mutex> lock(state->mutex);
+        state->changed = true;
+    }
+    state->cv.notify_all();
+}
+
+// RAII guard that tears the prefix watch down (and waits for the goroutine to
+// exit, so no further callbacks can run) before the associated
+// ViewChangeWatchState is destroyed. Declared after the state so it is
+// destroyed first.
+class PrefixWatchGuard {
+   public:
+    explicit PrefixWatchGuard(std::string prefix)
+        : prefix_(std::move(prefix)) {}
+    ~PrefixWatchGuard() {
+        if (!active_) {
+            return;
+        }
+        EtcdHelper::CancelWatchWithPrefix(prefix_.c_str(), prefix_.size());
+        EtcdHelper::WaitWatchWithPrefixStopped(prefix_.c_str(), prefix_.size(),
+                                               kWatchStopTimeoutMs);
+    }
+
+    PrefixWatchGuard(const PrefixWatchGuard&) = delete;
+    PrefixWatchGuard& operator=(const PrefixWatchGuard&) = delete;
+
+    void Arm() { active_ = true; }
+
+   private:
+    std::string prefix_;
+    bool active_ = false;
+};
 
 class EtcdLeadershipMonitorHandle final : public LeadershipMonitorHandle {
    public:
@@ -249,19 +313,6 @@ EtcdLeaderCoordinator::WaitForViewChange(
 
     const auto deadline = std::chrono::steady_clock::now() + timeout;
     while (true) {
-        auto current_view = ReadCurrentView();
-        if (!current_view) {
-            return tl::make_unexpected(current_view.error());
-        }
-
-        if (!IsSameViewVersion(current_view.value(), known_version)) {
-            return ViewChangeResult{
-                .changed = true,
-                .timed_out = false,
-                .current_view = current_view.value(),
-            };
-        }
-
         if (timeout <= std::chrono::milliseconds::zero() ||
             std::chrono::steady_clock::now() >= deadline) {
             return ViewChangeResult{
@@ -274,8 +325,67 @@ EtcdLeaderCoordinator::WaitForViewChange(
         const auto remaining =
             std::chrono::duration_cast<std::chrono::milliseconds>(
                 deadline - std::chrono::steady_clock::now());
-        std::this_thread::sleep_for(
-            std::min(kViewChangePollInterval, remaining));
+
+        // Arm the watch BEFORE reading the view. The watch is established at
+        // some etcd revision R_watch; the subsequent read observes a revision
+        // R_read >= R_watch. Any change to master_view at revision C is then
+        // caught by exactly one of the two: C < R_read (the read sees it) or
+        // C >= R_watch (the watch delivers it), and the two ranges overlap, so
+        // a change happening between read and watch cannot be missed. The watch
+        // starts from the current revision (start_revision = 0), which also
+        // avoids depending on a possibly-compacted historical revision.
+        //
+        // `state` must outlive `guard`: the guard cancels the watch and waits
+        // for the goroutine to exit (no more callbacks) in its destructor,
+        // before `state` is destroyed. Declaration order guarantees this.
+        ViewChangeWatchState state;
+        PrefixWatchGuard guard(master_view_key_);
+
+        bool watching = false;
+        if (remaining > kViewChangeFallbackPollInterval) {
+            // Defensively clear any lingering watch on this key, then arm a new
+            // one. Both calls are no-ops when nothing is registered.
+            EtcdHelper::CancelWatchWithPrefix(master_view_key_.c_str(),
+                                              master_view_key_.size());
+            EtcdHelper::WaitWatchWithPrefixStopped(master_view_key_.c_str(),
+                                                   master_view_key_.size(),
+                                                   kWatchStopTimeoutMs);
+            auto watch_err = EtcdHelper::WatchWithPrefixFromRevision(
+                master_view_key_.c_str(), master_view_key_.size(),
+                /*start_revision=*/0, &state, &ViewChangeWatchCallback);
+            if (watch_err == ErrorCode::OK) {
+                watching = true;
+                guard.Arm();
+            }
+        }
+
+        auto current_view = ReadCurrentView();
+        if (!current_view) {
+            return tl::make_unexpected(current_view.error());
+        }
+        if (!IsSameViewVersion(current_view.value(), known_version)) {
+            return ViewChangeResult{
+                .changed = true,
+                .timed_out = false,
+                .current_view = current_view.value(),
+            };
+        }
+
+        if (!watching) {
+            // Could not arm a watch (RPC failed, or too little time left).
+            // Fall back to a short poll so a change is still picked up.
+            std::this_thread::sleep_for(
+                std::min(kViewChangeFallbackPollInterval, remaining));
+            continue;
+        }
+
+        // Block until the watch reports an event or the caller's deadline
+        // elapses. Either way we loop and re-read: an event tells us the view
+        // changed (re-read returns it), a timeout falls through to the deadline
+        // check above and returns timed_out.
+        std::unique_lock<std::mutex> lock(state.mutex);
+        state.cv.wait_for(lock, remaining,
+                          [&state]() { return state.changed; });
     }
 }
 

--- a/mooncake-store/tests/ha/leadership/high_availability_test.cpp
+++ b/mooncake-store/tests/ha/leadership/high_availability_test.cpp
@@ -7,6 +7,7 @@
 #include <mutex>
 #include <optional>
 #include <string>
+#include <thread>
 
 #ifdef STORE_USE_ETCD
 #include "etcd_helper.h"
@@ -316,6 +317,118 @@ TEST_F(HighAvailabilityTest, BasicMasterViewOperations) {
 }
 
 #ifdef STORE_USE_ETCD
+
+// WaitForViewChange must return promptly when the leader's master_view key is
+// deleted, driven by the etcd watch rather than the timeout. We give it a long
+// (5s) timeout but delete the key after ~300ms; a watch-based implementation
+// returns shortly after the deletion, well before the timeout would fire.
+TEST_F(HighAvailabilityTest, WaitForViewChangeReturnsPromptlyOnLeaderLoss) {
+    if (auto skip_reason = GetEtcdSkipReason(); skip_reason.has_value()) {
+        GTEST_SKIP() << *skip_reason;
+    }
+
+    auto coordinator = CreateEtcdCoordinatorOrNull(FLAGS_etcd_endpoints);
+    ASSERT_NE(coordinator, nullptr);
+
+    auto acquire = coordinator->TryAcquireLeadership("0.0.0.0:5555");
+    ASSERT_TRUE(acquire.has_value());
+    ASSERT_EQ(ha::AcquireLeadershipStatus::ACQUIRED, acquire->status);
+    ASSERT_TRUE(acquire->session.has_value());
+    const auto session = *acquire->session;
+
+    auto renew = coordinator->RenewLeadership(session);
+    ASSERT_TRUE(renew.has_value());
+    ASSERT_TRUE(renew.value());
+
+    // Release leadership from another thread after a short delay; this revokes
+    // the lease and deletes the master_view key, which the watch observes.
+    std::thread releaser([&]() {
+        std::this_thread::sleep_for(std::chrono::milliseconds(300));
+        coordinator->ReleaseLeadership(session);
+    });
+
+    const auto start = std::chrono::steady_clock::now();
+    auto changed = coordinator->WaitForViewChange(session.view.view_version,
+                                                  std::chrono::seconds(5));
+    const auto elapsed = std::chrono::steady_clock::now() - start;
+    releaser.join();
+
+    ASSERT_TRUE(changed.has_value());
+    EXPECT_TRUE(changed->changed);
+    EXPECT_FALSE(changed->current_view.has_value());
+    // Must be driven by the watch (key deleted at ~300ms), not the 5s timeout.
+    EXPECT_LT(elapsed, std::chrono::seconds(3));
+}
+
+// WaitForViewChange must honor its timeout when the leader is stable: the watch
+// blocks with no deletion event, and the timer cancels it so the call returns
+// timed_out at roughly the requested deadline -- neither returning early nor
+// hanging past it.
+TEST_F(HighAvailabilityTest, WaitForViewChangeTimesOutWhenStable) {
+    if (auto skip_reason = GetEtcdSkipReason(); skip_reason.has_value()) {
+        GTEST_SKIP() << *skip_reason;
+    }
+
+    auto coordinator = CreateEtcdCoordinatorOrNull(FLAGS_etcd_endpoints);
+    ASSERT_NE(coordinator, nullptr);
+
+    auto acquire = coordinator->TryAcquireLeadership("0.0.0.0:4444");
+    ASSERT_TRUE(acquire.has_value());
+    ASSERT_EQ(ha::AcquireLeadershipStatus::ACQUIRED, acquire->status);
+    ASSERT_TRUE(acquire->session.has_value());
+    const auto session = *acquire->session;
+
+    auto renew = coordinator->RenewLeadership(session);
+    ASSERT_TRUE(renew.has_value());
+    ASSERT_TRUE(renew.value());
+
+    const auto timeout = std::chrono::milliseconds(500);
+    const auto start = std::chrono::steady_clock::now();
+    auto result =
+        coordinator->WaitForViewChange(session.view.view_version, timeout);
+    const auto elapsed = std::chrono::steady_clock::now() - start;
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_FALSE(result->changed);
+    EXPECT_TRUE(result->timed_out);
+    // Did not return early (watch did not spuriously fire) ...
+    EXPECT_GE(elapsed, std::chrono::milliseconds(400));
+    // ... and did not hang past the deadline (timer cancelled the watch).
+    EXPECT_LT(elapsed, std::chrono::seconds(3));
+
+    ASSERT_EQ(ErrorCode::OK, coordinator->ReleaseLeadership(session));
+}
+
+// When the observed view already differs from the caller's known version,
+// WaitForViewChange returns immediately via the initial read, without arming a
+// watch. Passing no known version while a leader exists is one such case.
+TEST_F(HighAvailabilityTest, WaitForViewChangeReturnsCurrentViewImmediately) {
+    if (auto skip_reason = GetEtcdSkipReason(); skip_reason.has_value()) {
+        GTEST_SKIP() << *skip_reason;
+    }
+
+    auto coordinator = CreateEtcdCoordinatorOrNull(FLAGS_etcd_endpoints);
+    ASSERT_NE(coordinator, nullptr);
+
+    auto acquire = coordinator->TryAcquireLeadership("0.0.0.0:3333");
+    ASSERT_TRUE(acquire.has_value());
+    ASSERT_EQ(ha::AcquireLeadershipStatus::ACQUIRED, acquire->status);
+    ASSERT_TRUE(acquire->session.has_value());
+    const auto session = *acquire->session;
+
+    const auto start = std::chrono::steady_clock::now();
+    auto result =
+        coordinator->WaitForViewChange(std::nullopt, std::chrono::seconds(5));
+    const auto elapsed = std::chrono::steady_clock::now() - start;
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_TRUE(result->changed);
+    ASSERT_TRUE(result->current_view.has_value());
+    EXPECT_EQ(result->current_view->view_version, session.view.view_version);
+    EXPECT_LT(elapsed, std::chrono::seconds(1));
+
+    ASSERT_EQ(ErrorCode::OK, coordinator->ReleaseLeadership(session));
+}
 
 TEST_F(HighAvailabilityTest, LeadershipMonitorReportsKeepAliveLoss) {
     if (auto skip_reason = GetEtcdSkipReason(); skip_reason.has_value()) {

--- a/mooncake-store/tests/ha/leadership/high_availability_test.cpp
+++ b/mooncake-store/tests/ha/leadership/high_availability_test.cpp
@@ -400,8 +400,10 @@ TEST_F(HighAvailabilityTest, WaitForViewChangeTimesOutWhenStable) {
 }
 
 // When the observed view already differs from the caller's known version,
-// WaitForViewChange returns immediately via the initial read, without arming a
-// watch. Passing no known version while a leader exists is one such case.
+// WaitForViewChange returns promptly: it arms the watch (now established
+// synchronously via WithCreatedNotify) and then the initial read short-circuits
+// on the version mismatch before any event is awaited. Passing no known version
+// while a leader exists is one such case.
 TEST_F(HighAvailabilityTest, WaitForViewChangeReturnsCurrentViewImmediately) {
     if (auto skip_reason = GetEtcdSkipReason(); skip_reason.has_value()) {
         GTEST_SKIP() << *skip_reason;


### PR DESCRIPTION
## Description

### Why this matters (impact at scale)

Mooncake clients are **per GPU rank**, so a 10k-GPU cluster means ~10k clients
all watching the master view. Today `EtcdLeaderCoordinator::WaitForViewChange`
**polls** the `master_view` key every 200ms, and the client leader monitor
(`Client::LeaderMonitorThreadMain`) re-issues it with a 1s timeout, so each
client effectively reads etcd ~5-6 times/sec **even while leadership is
perfectly stable and nothing is changing**.

At cluster scale this is not free:

- **~50-60k reads/sec of pure no-op polling** against etcd at 10k clients, and
  it grows **linearly** with the cluster — exactly the wrong scaling property
  for the component that is supposed to coordinate the whole fleet.
- That load lands on the **same etcd that runs master leader election**. The
  idle polling competes for etcd CPU / IO / request budget with the traffic
  that actually matters (lease keepalives, and the burst of view reads during a
  real failover), eating the headroom you most need precisely when a failover
  storm hits.
- It makes etcd sizing a function of fleet size for no functional reason, and
  pushes operators toward over-provisioning or sharding etcd to absorb traffic
  that carries zero information.

In short, the control plane pays a large, ever-growing tax to learn "nothing
changed." A 10k-client deployment should be able to run its HA backend on a
small etcd; with polling it cannot.

This polling was introduced in #1678; earlier the coordinator used a
`WatchUntilDeleted` watch, and the k8s Lease RFC (#1648) likewise describes
clients *watching* the view rather than polling it. This PR restores
event-driven behavior, collapsing steady-state load to ~1 read/30s/client
(prototype: ~88x reduction at 8k clients, etcd CPU ≈ 0) with no change to
failover responsiveness.

This PR makes the etcd `WaitForViewChange` event-driven via
`WatchWithPrefixFromRevision`:

- **Watch armed before the read.** The watch is established at revision
  `R_watch`; the subsequent read observes `R_read >= R_watch`. Any `master_view`
  change at revision `C` is caught by either `C < R_read` (the read sees it) or
  `C >= R_watch` (the watch delivers it), and the ranges overlap, so a change
  occurring between the read and the watch cannot be missed. The watch starts
  from the current revision (`start_revision = 0`), which keeps the race closed
  while avoiding any dependency on a possibly-compacted historical revision. It
  delivers `PUT` (new leader), `DELETE` (leadership lost) and `WATCH_BROKEN`
  (forces a re-read), so a newly elected leader is also picked up promptly.
- **Timeout via a condition variable.** The waiter blocks on a CV bounded by the
  caller's timeout and is woken by the watch callback. There is no separate
  timer thread and no out-of-band cancel, so there is no cancel-vs-registration
  race. The watch state is stack-scoped and an RAII guard runs
  `CancelWatchWithPrefix` + `WaitWatchWithPrefixStopped` (so no callback is in
  flight) before the state is destroyed — teardown is exception-safe without a
  manually joined thread.
- **Short-poll fallback** only when a watch cannot be armed (RPC failure or
  negligible remaining time).
- **Client monitor timeout 1s → 30s** (`client_service.cpp`): with a watch this
  no longer drives polling cadence; it is only a periodic re-sync safety net in
  case a watch event is missed (e.g. a connection blip), bounding worst-case
  staleness while collapsing steady-state load from ~1 read/s/client to
  ~1 read/30s/client.

The initial-read short-circuit, `IsSameViewVersion` semantics, and the
`timed_out` / `changed` result contract are unchanged, so failover, fencing and
leader self-demotion behavior are unaffected — only the wait mechanism changes.
`master_service_supervisor` (standby masters) also calls `WaitForViewChange` and
benefits transparently.

The redis backend's keyspace-notification watch needs a server-side
`notify-keyspace-events` configuration and is left to a separate PR.

## Module

- [x] Mooncake Store (`mooncake-store`)

## Type of Change

- [x] Performance improvement

## How Has This Been Tested?

Built with etcd support and unit tests, and ran `high_availability_test`
against a real etcd:

```bash
cmake -G Ninja .. -DUSE_ETCD=ON -DSTORE_USE_ETCD=ON -DBUILD_UNIT_TESTS=ON \
  -DWITH_STORE=ON -DWITH_TE=ON -DCMAKE_BUILD_TYPE=Release
ninja high_availability_test
./mooncake-store/tests/high_availability_test --etcd_endpoints=127.0.0.1:2379
```

Three tests were added to assert the watch behavior directly, alongside the
existing suite:

| Check | Result |
| --- | --- |
| Full `high_availability_test` suite (etcd) | **8/8 passed**, no regressions |
| `WaitForViewChangeReturnsPromptlyOnLeaderLoss` — delete `master_view` after ~300ms under a 5s timeout | returns at **~302ms** (watch-driven, not the timeout) |
| `WaitForViewChangeTimesOutWhenStable` — stable leader, 500ms timeout | returns `timed_out` at **~502ms** (timer cancels the watch; neither early nor hung) |
| `WaitForViewChangeReturnsCurrentViewImmediately` — observed view already differs | returns at **~1ms** via the initial read, no watch armed |

- [x] Unit tests pass
- [x] Manual testing done (described above)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh` (clang-format-20)
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (n/a — internal behavior, no public API/doc change)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue (n/a — ~180 LOC)

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

Implementation, tests and this description were drafted with Claude Code (AI
assistant). The human submitter reviewed all changes and validated them against
a real etcd cluster before submitting, and is responsible for the code.
