### PR TITLE
[Store] Port OpLog storage layer from main for P2P HA

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -126,6 +126,7 @@ SYSTEM_PACKAGES="build-essential \
                   liburing-dev \
                   libjemalloc-dev \
                   libasio-dev \
+                  libxxhash-dev \
                   pkg-config \
                   patchelf \
                   libc6-dev \

--- a/mooncake-store/include/ha/oplog/localfs_oplog_store.h
+++ b/mooncake-store/include/ha/oplog/localfs_oplog_store.h
@@ -1,0 +1,146 @@
+// mooncake-store/include/localfs_oplog_store.h
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <deque>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "ha/oplog/oplog_manager.h"
+#include "ha/oplog/oplog_store.h"
+#include "types.h"
+
+namespace mooncake {
+
+class LocalFsOpLogStore : public OpLogStore {
+   public:
+    explicit LocalFsOpLogStore(const std::string& cluster_id,
+                               const std::string& root_dir,
+                               bool enable_batch_write,
+                               int poll_interval_ms = 1000);
+    ~LocalFsOpLogStore();
+
+    ErrorCode Init() override;
+    ErrorCode WriteOpLog(const OpLogEntry& entry, bool sync = true) override;
+    ErrorCode ReadOpLog(uint64_t sequence_id, OpLogEntry& entry) override;
+    ErrorCode ReadOpLogSince(uint64_t start_sequence_id, size_t limit,
+                             std::vector<OpLogEntry>& entries) override;
+    ErrorCode GetLatestSequenceId(uint64_t& sequence_id) override;
+    ErrorCode GetMaxSequenceId(uint64_t& sequence_id) override;
+    ErrorCode UpdateLatestSequenceId(uint64_t sequence_id) override;
+    ErrorCode RecordSnapshotSequenceId(const std::string& snapshot_id,
+                                       uint64_t sequence_id) override;
+    ErrorCode GetSnapshotSequenceId(const std::string& snapshot_id,
+                                    uint64_t& sequence_id) override;
+    ErrorCode CleanupOpLogBefore(uint64_t before_sequence_id) override;
+    std::unique_ptr<OpLogChangeNotifier> CreateChangeNotifier(
+        const std::string& cluster_id) override;
+
+   private:
+    // Segment file format: 32-byte header + length-prefixed entries
+    static constexpr char kSegmentMagic[4] = {'M', 'C', 'S', 'G'};
+    static constexpr uint32_t kSegmentVersion = 1;
+    static constexpr size_t kSegmentHeaderSize = 32;
+
+    // Segment header layout (all little-endian):
+    //   [0..3]   magic    "MCSG"
+    //   [4..7]   version  uint32_t
+    //   [8..15]  min_seq  uint64_t
+    //   [16..23] max_seq  uint64_t
+    //   [24..27] count    uint32_t
+    //   [28..31] reserved uint32_t (0)
+    struct SegmentHeader {
+        char magic[4];
+        uint32_t version;
+        uint64_t min_seq;
+        uint64_t max_seq;
+        uint32_t entry_count;
+        uint32_t reserved;
+    };
+    static_assert(sizeof(SegmentHeader) == kSegmentHeaderSize,
+                  "SegmentHeader must be 32 bytes");
+
+    // Segment file name info parsed from filename
+    struct SegmentInfo {
+        std::string filename;
+        uint64_t min_seq;
+        uint64_t max_seq;
+    };
+
+    // Group Commit batch entry
+    struct BatchEntry {
+        std::string serialized_value;
+        uint64_t sequence_id;
+        bool is_sync;
+    };
+
+    // Directory and path helpers
+    std::string SegmentsDir() const;
+    std::string SnapshotsDir() const;
+    std::string LatestFilePath() const;
+    std::string BuildSegmentFilename(uint64_t min_seq, uint64_t max_seq) const;
+    std::string BuildSnapshotPath(const std::string& snapshot_id) const;
+
+    // Segment I/O
+    ErrorCode WriteSegmentFile(const std::vector<BatchEntry>& entries);
+    ErrorCode ReadSegmentEntries(const std::string& filepath,
+                                 std::vector<OpLogEntry>& entries);
+    ErrorCode ReadSegmentHeader(const std::string& filepath,
+                                SegmentHeader& header);
+    std::vector<SegmentInfo> ListSegments() const;
+    static bool ParseSegmentFilename(const std::string& filename,
+                                     uint64_t& min_seq, uint64_t& max_seq);
+    ErrorCode NormalizeBatchEntries(std::vector<BatchEntry>& entries) const;
+    ErrorCode VerifyPersistedEntryMatches(uint64_t sequence_id,
+                                          const std::string& serialized_value);
+    ErrorCode RecoverPersistedState();
+
+    // Atomic file write: write to .tmp, fsync, rename
+    ErrorCode AtomicWriteFile(const std::string& target_path,
+                              const std::string& content);
+    ErrorCode AtomicWriteFile(const std::string& target_path, const void* data,
+                              size_t size);
+
+    // Cleanup temp files from previous crash
+    void CleanupTempFiles();
+
+    // Snapshot ID validation
+    static bool ValidateSnapshotId(const std::string& snapshot_id);
+
+    // Read a uint64 value from a single-value text file
+    ErrorCode ReadUint64FromFile(const std::string& filepath,
+                                 uint64_t& value) const;
+
+    // Batch write thread
+    void BatchWriteThread();
+    void FlushBatch();
+
+    // Members
+    std::string cluster_id_;
+    std::string root_dir_;
+    std::string cluster_dir_;  // root_dir_/cluster_id_
+    bool enable_batch_write_;
+    int poll_interval_ms_;
+
+    // Group Commit state
+    mutable std::mutex batch_mutex_;
+    std::deque<BatchEntry> pending_batch_;
+    std::condition_variable cv_batch_updated_;
+    std::condition_variable cv_sync_completed_;
+    std::atomic<bool> batch_write_running_{false};
+    std::thread batch_write_thread_;
+    std::atomic<uint64_t> last_persisted_seq_id_{0};
+
+    // Batch write configs
+    static constexpr size_t kBatchCountLimit = 100;
+    static constexpr int kBatchTimeoutMs = 100;
+    static constexpr int kSyncWaitTimeoutMs = 3000;
+    static constexpr int kFlushRetryCount = 3;
+    static constexpr int kFlushRetryIntervalMs = 50;
+};
+
+}  // namespace mooncake

--- a/mooncake-store/include/ha/oplog/oplog_change_notifier.h
+++ b/mooncake-store/include/ha/oplog/oplog_change_notifier.h
@@ -1,0 +1,40 @@
+// mooncake-store/include/oplog_change_notifier.h
+#pragma once
+
+#include <cstdint>
+#include <functional>
+
+#include "ha/oplog/oplog_manager.h"
+#include "types.h"
+
+namespace mooncake {
+
+// Abstract interface for watching OpLog changes.
+//
+// Delivery semantics:
+//   The notifier provides **at-most-once delivery**. Its internal cursor
+//   tracks *fetch progress* (where to read from next), NOT consumer
+//   processing progress. The cursor advances unconditionally after entries
+//   are dispatched to EntryCallback, regardless of whether the callback
+//   processed them successfully.
+//
+//   Consumers (e.g. OpLogApplier) must maintain their own cursor
+//   (expected_sequence_id_) and handle gaps, duplicates, and late arrivals
+//   independently.
+//
+// Implementations: EtcdOpLogChangeNotifier (push via Watch),
+//                  PollingOpLogChangeNotifier (poll via ReadOpLogSince)
+class OpLogChangeNotifier {
+   public:
+    virtual ~OpLogChangeNotifier() = default;
+
+    using EntryCallback = std::function<void(const OpLogEntry& entry)>;
+    using ErrorCallback = std::function<void(ErrorCode error)>;
+
+    virtual ErrorCode Start(uint64_t start_sequence_id, EntryCallback on_entry,
+                            ErrorCallback on_error) = 0;
+    virtual void Stop() = 0;
+    virtual bool IsHealthy() const = 0;
+};
+
+}  // namespace mooncake

--- a/mooncake-store/include/ha/oplog/oplog_manager.h
+++ b/mooncake-store/include/ha/oplog/oplog_manager.h
@@ -1,0 +1,154 @@
+#pragma once
+
+#include <cstdint>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <string>
+#include <vector>
+
+#include <ylt/util/tl/expected.hpp>
+
+#include "types.h"
+
+namespace mooncake {
+
+// Forward declaration
+class OpLogStore;
+
+// Operation types for hot-standby replication.
+// This is a minimal subset that can be extended later.
+enum class OpType : uint8_t {
+    PUT_END = 1,
+    PUT_REVOKE = 2,
+    REMOVE = 3,
+    // Deprecated: LEASE_RENEW is intentionally not recorded in OpLog in the
+    // current etcd-based hot-standby design (Standby relies on Primary DELETE
+    // operations).
+    LEASE_RENEW = 4,
+};
+
+// A single operation log entry.
+// Note: Payload contains JSON serialized MetadataPayload (defined in
+// metadata_store.h) for PUT_END operations, allowing Standby to restore
+// complete metadata.
+struct OpLogEntry {
+    uint64_t sequence_id{0};   // Monotonically increasing global sequence
+    uint64_t timestamp_ms{0};  // Logical timestamp in milliseconds
+    OpType op_type{OpType::PUT_END};
+    std::string object_key;  // Target object key
+    std::string payload;     // Serialized extra data (optional)
+    uint32_t checksum{0};    // Checksum of payload (implementation-defined)
+    uint32_t prefix_hash{
+        0};  // Hash of the entire key (for verification and optimization)
+};
+
+/**
+ * @brief In-memory operation log manager.
+ *
+ * This class is intentionally simple: it keeps a bounded deque of OpLogEntry
+ * and provides append / get-since primitives. It can later be extended to
+ * or to spill to disk if needed. OpLog entries are persisted to the
+ * configured OpLogStore backend (etcd, local filesystem, etc.).
+ */
+class OpLogManager {
+   public:
+    OpLogManager();
+
+    // Set the OpLogStore for writing OpLog to persistent storage (optional).
+    // If not set, OpLog will only be stored in memory buffer.
+    void SetOpLogStore(std::shared_ptr<OpLogStore> oplog_store);
+
+    // Append a new entry and return the assigned sequence_id.
+    // This is a best-effort (async) path: the entry is buffered in memory
+    // and enqueued to etcd without waiting for persistence.
+    // Only suitable for idempotent, lag-tolerant operations (PUT_END).
+    // For operations that MUST be durable before returning (REMOVE, etc.),
+    // use AppendAndPersist() instead.
+    uint64_t Append(OpType type, const std::string& key,
+                    const std::string& payload = std::string());
+
+    // Allocate a new OpLogEntry with a reserved sequence_id, append it to the
+    // in-memory buffer, and return the full entry.
+    //
+    // IMPORTANT: This will advance last_seq_id_ even if the caller later fails
+    // to persist it to etcd. This supports "seq pre-allocation" semantics where
+    // retries use the same (smaller) sequence_id.
+    OpLogEntry AllocateEntry(OpType type, const std::string& key,
+                             const std::string& payload = std::string());
+
+    // Persist an already-allocated entry to the store using its sequence_id.
+    // Does NOT modify sequence counters.
+    ErrorCode PersistEntry(const OpLogEntry& entry) const;
+
+    // Append a new entry and durably persist it to the store (if OpLogStore is
+    // set).
+    //
+    // This is intended for operations that may free/reuse memory (e.g. REMOVE),
+    // where best-effort replication is unsafe: Standby must observe the DELETE
+    // before promotion, otherwise it may return stale descriptors that point to
+    // reused memory and cause silent data corruption.
+    //
+    // Design (updated for seq pre-allocation):
+    // - sequence_id is allocated first and never reused.
+    // - If etcd write fails, caller may retry PersistEntry with the same
+    //   entry (sequence_id fixed and "smaller" than later entries).
+    tl::expected<uint64_t, ErrorCode> AppendAndPersist(
+        OpType type, const std::string& key,
+        const std::string& payload = std::string());
+
+    // Get the latest assigned sequence id. Returns 0 if no entry exists.
+    uint64_t GetLastSequenceId() const;
+
+    // Set the initial sequence ID (used when promoting Standby to Primary).
+    // This ensures the new Primary's OpLogManager continues from the correct
+    // sequence_id.
+    void SetInitialSequenceId(uint64_t sequence_id);
+
+    // Current number of entries in the buffer.
+    size_t GetEntryCount() const;
+
+    // Clean up OpLog entries in etcd before a given sequence_id.
+    // Delegates to EtcdOpLogStore::CleanupOpLogBefore.
+    ErrorCode CleanupOpLogBefore(uint64_t before_sequence_id);
+
+    // Verify checksum of an OpLogEntry payload.
+    // Returns true if checksum matches, false otherwise.
+    // This is public so OpLogReplicator and OpLogApplier can validate entries.
+    static bool VerifyChecksum(const OpLogEntry& entry);
+
+    // Basic DoS protection for externally sourced OpLog entries (etcd watch /
+    // reads). Enforce conservative bounds on key/payload sizes before
+    // parsing/applying.
+    static constexpr size_t kMaxObjectKeySize = 4096;            // 4 KiB
+    static constexpr size_t kMaxPayloadSize = 10 * 1024 * 1024;  // 10 MiB
+
+    // Validate OpLogEntry key/payload sizes. If invalid, returns false and
+    // optionally sets a human-readable reason.
+    static bool ValidateEntrySize(const OpLogEntry& entry,
+                                  std::string* reason = nullptr);
+
+   private:
+    static uint64_t NowMs();
+    static uint32_t ComputeChecksum(const std::string& data);
+    static uint32_t ComputePrefixHash(const std::string& key);
+
+    mutable std::shared_mutex mutex_;
+    std::deque<OpLogEntry> buffer_;
+    uint64_t first_seq_id_{1};  // sequence_id of buffer_.front()
+    uint64_t last_seq_id_{0};   // last assigned sequence_id
+
+    // Note: We removed key_sequence_map_ and key_remove_time_map_.
+    // Global sequence_id is sufficient for ordering guarantee.
+    // All operations are applied in sequence_id order, which ensures
+    // consistency.
+
+    // Optional OpLog store for persistent storage
+    std::shared_ptr<OpLogStore> oplog_store_;
+
+    // Simple bounds to avoid unbounded memory growth.
+    static constexpr size_t kMaxBufferEntries_ = 100000;
+};
+
+}  // namespace mooncake

--- a/mooncake-store/include/ha/oplog/oplog_serializer.h
+++ b/mooncake-store/include/ha/oplog/oplog_serializer.h
@@ -1,0 +1,18 @@
+// mooncake-store/include/oplog_serializer.h
+#pragma once
+
+#include <string>
+
+#include "ha/oplog/oplog_manager.h"
+
+namespace mooncake {
+
+// Serialize an OpLogEntry to JSON string (with base64-encoded payload).
+// Format is backend-agnostic; all storage backends should use this.
+std::string SerializeOpLogEntry(const OpLogEntry& entry);
+
+// Deserialize a JSON string to OpLogEntry.
+// Returns true on success, false on parse error or size validation failure.
+bool DeserializeOpLogEntry(const std::string& json_str, OpLogEntry& entry);
+
+}  // namespace mooncake

--- a/mooncake-store/include/ha/oplog/oplog_store.h
+++ b/mooncake-store/include/ha/oplog/oplog_store.h
@@ -1,0 +1,64 @@
+// mooncake-store/include/oplog_store.h
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "ha/oplog/oplog_change_notifier.h"
+#include "ha/oplog/oplog_manager.h"
+#include "types.h"
+
+namespace mooncake {
+
+// Normalize and validate cluster_id for OpLog key prefix construction.
+// Strips trailing slashes, then validates the remaining string.
+// Returns true if valid (or empty after normalization), false otherwise.
+inline bool NormalizeAndValidateClusterId(std::string& cluster_id) {
+    while (!cluster_id.empty() && cluster_id.back() == '/') {
+        cluster_id.pop_back();
+    }
+    return cluster_id.empty() || IsValidClusterIdComponent(cluster_id);
+}
+
+// Abstract interface for OpLog persistent storage.
+// Implementations: EtcdOpLogStore, (future) HdfsOpLogStore, etc.
+class OpLogStore {
+   public:
+    virtual ~OpLogStore() = default;
+    virtual ErrorCode Init() = 0;
+
+    // Write
+    virtual ErrorCode WriteOpLog(const OpLogEntry& entry, bool sync = true) = 0;
+
+    // Read
+    virtual ErrorCode ReadOpLog(uint64_t sequence_id, OpLogEntry& entry) = 0;
+    virtual ErrorCode ReadOpLogSince(uint64_t start_sequence_id, size_t limit,
+                                     std::vector<OpLogEntry>& entries) = 0;
+
+    // Sequence ID management
+    virtual ErrorCode GetLatestSequenceId(uint64_t& sequence_id) = 0;
+    virtual ErrorCode GetMaxSequenceId(uint64_t& sequence_id) = 0;
+    virtual ErrorCode UpdateLatestSequenceId(uint64_t sequence_id) = 0;
+
+    // Snapshot
+    virtual ErrorCode RecordSnapshotSequenceId(const std::string& snapshot_id,
+                                               uint64_t sequence_id) = 0;
+    virtual ErrorCode GetSnapshotSequenceId(const std::string& snapshot_id,
+                                            uint64_t& sequence_id) = 0;
+
+    // Cleanup
+    virtual ErrorCode CleanupOpLogBefore(uint64_t before_sequence_id) = 0;
+
+    // Create a change notifier for this store.
+    // Each backend provides its own notifier (e.g., etcd watch, polling).
+    // Returns nullptr if the backend does not support change notification.
+    virtual std::unique_ptr<OpLogChangeNotifier> CreateChangeNotifier(
+        const std::string& cluster_id) {
+        (void)cluster_id;
+        return nullptr;
+    }
+};
+
+}  // namespace mooncake

--- a/mooncake-store/include/ha/oplog/oplog_store_factory.h
+++ b/mooncake-store/include/ha/oplog/oplog_store_factory.h
@@ -1,0 +1,74 @@
+// mooncake-store/include/oplog_store_factory.h
+#pragma once
+
+#include <algorithm>
+#include <memory>
+#include <string>
+
+#include "ha/oplog/oplog_store.h"
+
+namespace mooncake {
+
+enum class OpLogStoreRole {
+    WRITER,  // Primary: enable batch_write + batch_update
+    READER,  // Standby: read-only
+};
+
+enum class OpLogStoreType {
+    ETCD,
+    LOCAL_FS,
+};
+
+#ifdef STORE_USE_ETCD
+static constexpr OpLogStoreType kDefaultOpLogStoreType = OpLogStoreType::ETCD;
+#else
+static constexpr OpLogStoreType kDefaultOpLogStoreType =
+    OpLogStoreType::LOCAL_FS;
+#endif
+
+// Parse string to OpLogStoreType (case-insensitive).
+// Parse string to OpLogStoreType (case-insensitive).
+// Returns kDefaultOpLogStoreType for unrecognized strings.
+inline OpLogStoreType ParseOpLogStoreType(const std::string& type_str) {
+    std::string lower = type_str;
+    std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+    if (lower == "localfs" || lower == "local_fs") {
+        return OpLogStoreType::LOCAL_FS;
+    }
+    if (lower == "etcd") {
+        return OpLogStoreType::ETCD;
+    }
+    return kDefaultOpLogStoreType;
+}
+
+inline std::string OpLogStoreTypeToString(OpLogStoreType type) {
+    switch (type) {
+        case OpLogStoreType::LOCAL_FS:
+            return "localfs";
+        case OpLogStoreType::ETCD:
+        default:
+            return "etcd";
+    }
+}
+
+// Default configuration values for LocalFS OpLog store
+static constexpr const char* kDefaultOpLogRootDir = "/tmp/mooncake_oplog";
+static constexpr int kDefaultOpLogPollIntervalMs = 1000;
+
+class OpLogStoreFactory {
+   public:
+    /**
+     * @brief Create and initialize an OpLogStore instance.
+     *
+     * The returned instance is fully initialized (Init() has already been
+     * called internally). Callers must NOT call Init() again.
+     * Returns nullptr if the requested backend is unavailable or
+     * initialization fails.
+     */
+    static std::unique_ptr<OpLogStore> Create(
+        OpLogStoreType type, const std::string& cluster_id, OpLogStoreRole role,
+        const std::string& oplog_root_dir = kDefaultOpLogRootDir,
+        int poll_interval_ms = kDefaultOpLogPollIntervalMs);
+};
+
+}  // namespace mooncake

--- a/mooncake-store/include/ha/oplog/polling_oplog_change_notifier.h
+++ b/mooncake-store/include/ha/oplog/polling_oplog_change_notifier.h
@@ -1,0 +1,45 @@
+// mooncake-store/include/polling_oplog_change_notifier.h
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
+#include "ha/oplog/oplog_change_notifier.h"
+#include "ha/oplog/oplog_store.h"
+
+namespace mooncake {
+
+class PollingOpLogChangeNotifier : public OpLogChangeNotifier {
+   public:
+    PollingOpLogChangeNotifier(OpLogStore* store, int poll_interval_ms);
+    ~PollingOpLogChangeNotifier();
+
+    ErrorCode Start(uint64_t start_sequence_id, EntryCallback on_entry,
+                    ErrorCallback on_error) override;
+    void Stop() override;
+    bool IsHealthy() const override;
+
+   private:
+    void PollLoop();
+
+    OpLogStore* store_;  // Not owned
+    int poll_interval_ms_;
+
+    EntryCallback on_entry_;
+    ErrorCallback on_error_;
+
+    std::atomic<bool> running_{false};
+    std::thread poll_thread_;
+    std::atomic<uint64_t> last_sequence_id_{0};
+    std::atomic<bool> healthy_{false};
+
+    // For interruptible sleep on Stop()
+    std::mutex stop_mutex_;
+    std::condition_variable stop_cv_;
+
+    static constexpr size_t kPollBatchSize = 1000;
+};
+
+}  // namespace mooncake

--- a/mooncake-store/include/ha_metric_manager.h
+++ b/mooncake-store/include/ha_metric_manager.h
@@ -1,0 +1,215 @@
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <mutex>
+#include <string>
+
+#include "ylt/metric/counter.hpp"
+#include "ylt/metric/gauge.hpp"
+#include "ylt/metric/histogram.hpp"
+
+namespace mooncake {
+
+/**
+ * @brief Singleton manager for High Availability (HA) related metrics.
+ *
+ * This class provides metrics for monitoring the health and performance
+ * of the OpLog replication system, including:
+ * - OpLog sequence tracking
+ * - Standby replication lag
+ * - Error counters (checksum failures, skipped entries)
+ * - Performance histograms (etcd write latency)
+ * - Queue sizes (pending mutations)
+ */
+class HAMetricManager {
+   public:
+    // --- Singleton Access ---
+    static HAMetricManager& instance();
+
+    HAMetricManager(const HAMetricManager&) = delete;
+    HAMetricManager& operator=(const HAMetricManager&) = delete;
+    HAMetricManager(HAMetricManager&&) = delete;
+    HAMetricManager& operator=(HAMetricManager&&) = delete;
+
+    // ========== OpLog Sequence Metrics (Gauge) ==========
+
+    /**
+     * @brief Set the latest OpLog sequence ID on Primary
+     */
+    void set_oplog_last_sequence_id(int64_t seq_id);
+    int64_t get_oplog_last_sequence_id();
+
+    /**
+     * @brief Set the Standby's applied sequence ID
+     */
+    void set_oplog_applied_sequence_id(int64_t seq_id);
+    int64_t get_oplog_applied_sequence_id();
+
+    /**
+     * @brief Set the replication lag (entries behind Primary)
+     */
+    void set_oplog_standby_lag(int64_t lag);
+    int64_t get_oplog_standby_lag();
+
+    /**
+     * @brief Set the number of pending (out-of-order) entries in OpLogApplier
+     */
+    void set_oplog_pending_entries(int64_t count);
+    int64_t get_oplog_pending_entries();
+
+    /**
+     * @brief Set the pending mutation queue size (retry queue)
+     */
+    void set_pending_mutation_queue_size(int64_t size);
+    int64_t get_pending_mutation_queue_size();
+
+    // ========== Error Counters ==========
+
+    /**
+     * @brief Increment counter for skipped OpLog entries
+     */
+    void inc_oplog_skipped_entries(int64_t val = 1);
+    int64_t get_oplog_skipped_entries_total();
+
+    /**
+     * @brief Increment counter for checksum verification failures
+     */
+    void inc_oplog_checksum_failures(int64_t val = 1);
+    int64_t get_oplog_checksum_failures_total();
+
+    /**
+     * @brief Increment counter for gap resolve attempts
+     */
+    void inc_oplog_gap_resolve_attempts(int64_t val = 1);
+    int64_t get_oplog_gap_resolve_attempts_total();
+
+    /**
+     * @brief Increment counter for successful gap resolves
+     */
+    void inc_oplog_gap_resolve_success(int64_t val = 1);
+    int64_t get_oplog_gap_resolve_success_total();
+
+    /**
+     * @brief Increment counter for etcd write failures
+     */
+    void inc_oplog_etcd_write_failures(int64_t val = 1);
+    int64_t get_oplog_etcd_write_failures_total();
+
+    /**
+     * @brief Increment counter for etcd write retries
+     */
+    void inc_oplog_etcd_write_retries(int64_t val = 1);
+    int64_t get_oplog_etcd_write_retries_total();
+
+    /**
+     * @brief Increment counter for watch disconnections
+     */
+    void inc_oplog_watch_disconnections(int64_t val = 1);
+    int64_t get_oplog_watch_disconnections_total();
+
+    /**
+     * @brief Increment counter for successfully applied OpLog entries
+     */
+    void inc_oplog_applied_entries(int64_t val = 1);
+    int64_t get_oplog_applied_entries_total();
+
+    /**
+     * @brief Increment counter for dropped PUT_END operations (late arrival
+     * after skip)
+     */
+    void inc_oplog_dropped_put_end(int64_t val = 1);
+    int64_t get_oplog_dropped_put_end_total();
+
+    /**
+     * @brief Increase the total number of OpLog batch commits (Group Commit)
+     */
+    void inc_oplog_batch_commits(int64_t count = 1);
+    int64_t get_oplog_batch_commits_total();
+
+    /**
+     * @brief Increase the number of sync batch commits (triggered by
+     * DELETE/Sync ops)
+     */
+    void inc_oplog_sync_batch_commits(int64_t count = 1);
+    int64_t get_oplog_sync_batch_commits_total();
+
+    // ========== Latency Histograms ==========
+
+    /**
+     * @brief Record etcd write latency in microseconds
+     */
+    void observe_oplog_etcd_write_latency_us(int64_t latency_us);
+
+    /**
+     * @brief Record OpLog apply latency in microseconds
+     */
+    void observe_oplog_apply_latency_us(int64_t latency_us);
+
+    // ========== State Machine Metrics ==========
+
+    /**
+     * @brief Set the current Standby state (as integer for Prometheus)
+     * @param state_value Integer representation of StandbyState
+     */
+    void set_standby_state(int64_t state_value);
+    int64_t get_standby_state();
+
+    /**
+     * @brief Increment state transition counter
+     */
+    void inc_state_transitions(int64_t val = 1);
+    int64_t get_state_transitions_total();
+
+    // ========== Serialization ==========
+
+    /**
+     * @brief Serializes all HA metrics into Prometheus text format.
+     * @return A string containing the metrics in Prometheus format.
+     */
+    std::string serialize_metrics();
+
+    /**
+     * @brief Generates a concise, human-readable summary of HA metrics.
+     * @return A string containing the formatted summary.
+     */
+    std::string get_summary_string();
+
+   private:
+    // --- Private Constructor & Destructor ---
+    HAMetricManager();
+    ~HAMetricManager() = default;
+
+    // --- Metric Members ---
+
+    // OpLog Sequence Gauges
+    ylt::metric::gauge_t oplog_last_sequence_id_;
+    ylt::metric::gauge_t oplog_applied_sequence_id_;
+    ylt::metric::gauge_t oplog_standby_lag_;
+    ylt::metric::gauge_t oplog_pending_entries_;
+    ylt::metric::gauge_t pending_mutation_queue_size_;
+
+    // Error Counters
+    ylt::metric::counter_t oplog_skipped_entries_total_;
+    ylt::metric::counter_t oplog_checksum_failures_total_;
+    ylt::metric::counter_t oplog_gap_resolve_attempts_total_;
+    ylt::metric::counter_t oplog_gap_resolve_success_total_;
+    ylt::metric::counter_t oplog_etcd_write_failures_total_;
+    ylt::metric::counter_t oplog_etcd_write_retries_total_;
+    ylt::metric::counter_t oplog_watch_disconnections_total_;
+    ylt::metric::counter_t oplog_applied_entries_total_;
+    ylt::metric::counter_t oplog_dropped_put_end_total_;
+    ylt::metric::counter_t oplog_batch_commits_total_;
+    ylt::metric::counter_t oplog_sync_batch_commits_total_;
+
+    // Latency Histograms (buckets in microseconds: 100us, 500us, 1ms, 5ms,
+    // 10ms, 50ms, 100ms, 500ms, 1s)
+    ylt::metric::histogram_t oplog_etcd_write_latency_us_;
+    ylt::metric::histogram_t oplog_apply_latency_us_;
+
+    // State Machine
+    ylt::metric::gauge_t standby_state_;
+    ylt::metric::counter_t state_transitions_total_;
+};
+
+}  // namespace mooncake

--- a/mooncake-store/include/standby_state_machine.h
+++ b/mooncake-store/include/standby_state_machine.h
@@ -1,0 +1,343 @@
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <functional>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace mooncake {
+
+/**
+ * @brief Standby service states
+ *
+ * State transition diagram:
+ *
+ *     ┌─────────┐
+ *     │ STOPPED │◄───────────────────────────────────────┐
+ *     └────┬────┘                                        │
+ *          │ Start()                                     │ Stop()/Error
+ *          ▼                                             │
+ *     ┌─────────────┐                                    │
+ *     │ CONNECTING  │                                    │
+ *     └──────┬──────┘                                    │
+ *            │ Connected                                 │
+ *            ▼                              Connected    │
+ *     ┌─────────────┐ Error/Disconnect ┌────────────┐    │
+ *     │   SYNCING   │────────────────► │RECONNECTING│────┤
+ *     └──────┬──────┘◄──────────────── └──────┬─────┘    │
+ *            │ Sync complete               ▲  │          │
+ *            ▼                             │  │Watch     │
+ *     ┌─────────────┐  Watch broken/   ────┘  │healthy   │
+ *     │  WATCHING   │── Disconnect            │          │
+ *     └──────┬──────┘◄────────────────────────┘          │
+ *            │         Max errors      ┌────────────┐    │
+ *            │────────────────────────►│ RECOVERING │────┤
+ *            │                         └────────────┘    │
+ *            │ Promote()                                 │
+ *            ▼                                           │
+ *     ┌─────────────┐                                    │
+ *     │  PROMOTING  │────────────────────────────────────┤
+ *     └──────┬──────┘                                    │
+ *            │ Success                                   │
+ *            ▼                                           │
+ *     ┌─────────────┐                                    │
+ *     │  PROMOTED   │────────────────────────────────────┘
+ *     └─────────────┘
+ */
+enum class StandbyState : uint8_t {
+    // Initial state, service not started
+    STOPPED = 0,
+
+    // Connecting to etcd cluster
+    CONNECTING = 1,
+
+    // Initial sync: reading historical OpLog entries
+    SYNCING = 2,
+
+    // Normal operation: watching for new OpLog entries
+    WATCHING = 3,
+
+    // Recovering from error: re-syncing missed entries
+    RECOVERING = 4,
+
+    // Reconnecting after watch failure
+    RECONNECTING = 5,
+
+    // Promotion in progress: final catch-up before becoming Primary
+    PROMOTING = 6,
+
+    // Successfully promoted to Primary
+    PROMOTED = 7,
+
+    // Fatal error, cannot recover
+    FAILED = 8,
+};
+
+/**
+ * @brief Get human-readable state name
+ */
+inline const char* StandbyStateToString(StandbyState state) {
+    switch (state) {
+        case StandbyState::STOPPED:
+            return "STOPPED";
+        case StandbyState::CONNECTING:
+            return "CONNECTING";
+        case StandbyState::SYNCING:
+            return "SYNCING";
+        case StandbyState::WATCHING:
+            return "WATCHING";
+        case StandbyState::RECOVERING:
+            return "RECOVERING";
+        case StandbyState::RECONNECTING:
+            return "RECONNECTING";
+        case StandbyState::PROMOTING:
+            return "PROMOTING";
+        case StandbyState::PROMOTED:
+            return "PROMOTED";
+        case StandbyState::FAILED:
+            return "FAILED";
+        default:
+            return "UNKNOWN";
+    }
+}
+
+/**
+ * @brief Events that trigger state transitions
+ */
+enum class StandbyEvent : uint8_t {
+    // User/system actions
+    START,    // Start() called
+    STOP,     // Stop() called
+    PROMOTE,  // Promote() called
+
+    // Connection events
+    CONNECTED,          // Successfully connected to etcd
+    CONNECTION_FAILED,  // Failed to connect to etcd
+    DISCONNECTED,       // Connection lost
+
+    // Sync events
+    SYNC_COMPLETE,  // Initial sync completed
+    SYNC_FAILED,    // Sync failed
+
+    // Watch events
+    WATCH_HEALTHY,  // Watch is healthy and receiving events
+    WATCH_BROKEN,   // Watch connection broken
+
+    // Recovery events
+    RECOVERY_SUCCESS,  // Successfully recovered from error
+    RECOVERY_FAILED,   // Recovery failed
+
+    // Promotion events
+    PROMOTION_SUCCESS,  // Successfully promoted
+    PROMOTION_FAILED,   // Promotion failed
+
+    // Error events
+    MAX_ERRORS_REACHED,  // Too many consecutive errors
+    FATAL_ERROR,         // Unrecoverable error
+};
+
+inline const char* StandbyEventToString(StandbyEvent event) {
+    switch (event) {
+        case StandbyEvent::START:
+            return "START";
+        case StandbyEvent::STOP:
+            return "STOP";
+        case StandbyEvent::PROMOTE:
+            return "PROMOTE";
+        case StandbyEvent::CONNECTED:
+            return "CONNECTED";
+        case StandbyEvent::CONNECTION_FAILED:
+            return "CONNECTION_FAILED";
+        case StandbyEvent::DISCONNECTED:
+            return "DISCONNECTED";
+        case StandbyEvent::SYNC_COMPLETE:
+            return "SYNC_COMPLETE";
+        case StandbyEvent::SYNC_FAILED:
+            return "SYNC_FAILED";
+        case StandbyEvent::WATCH_HEALTHY:
+            return "WATCH_HEALTHY";
+        case StandbyEvent::WATCH_BROKEN:
+            return "WATCH_BROKEN";
+        case StandbyEvent::RECOVERY_SUCCESS:
+            return "RECOVERY_SUCCESS";
+        case StandbyEvent::RECOVERY_FAILED:
+            return "RECOVERY_FAILED";
+        case StandbyEvent::PROMOTION_SUCCESS:
+            return "PROMOTION_SUCCESS";
+        case StandbyEvent::PROMOTION_FAILED:
+            return "PROMOTION_FAILED";
+        case StandbyEvent::MAX_ERRORS_REACHED:
+            return "MAX_ERRORS_REACHED";
+        case StandbyEvent::FATAL_ERROR:
+            return "FATAL_ERROR";
+        default:
+            return "UNKNOWN";
+    }
+}
+
+/**
+ * @brief State transition result
+ */
+struct StateTransitionResult {
+    bool allowed{false};
+    StandbyState old_state{StandbyState::STOPPED};
+    StandbyState new_state{StandbyState::STOPPED};
+    std::string reason;
+};
+
+/**
+ * @brief Callback for state transition notifications
+ */
+using StateChangeCallback = std::function<void(
+    StandbyState old_state, StandbyState new_state, StandbyEvent event)>;
+
+/**
+ * @brief Standby State Machine
+ *
+ * Thread-safe state machine for managing Standby service lifecycle.
+ * All state transitions are explicit and logged.
+ */
+class StandbyStateMachine {
+   public:
+    StandbyStateMachine();
+
+    /**
+     * @brief Get current state (thread-safe)
+     */
+    StandbyState GetState() const {
+        return current_state_.load(std::memory_order_acquire);
+    }
+
+    /**
+     * @brief Check if in a specific state
+     */
+    bool IsInState(StandbyState state) const { return GetState() == state; }
+
+    /**
+     * @brief Check if service is running (SYNCING, WATCHING, RECOVERING,
+     * RECONNECTING, PROMOTING)
+     */
+    bool IsRunning() const {
+        StandbyState s = GetState();
+        return s == StandbyState::SYNCING || s == StandbyState::WATCHING ||
+               s == StandbyState::RECOVERING ||
+               s == StandbyState::RECONNECTING || s == StandbyState::PROMOTING;
+    }
+
+    /**
+     * @brief Check if connected to etcd
+     */
+    bool IsConnected() const {
+        StandbyState s = GetState();
+        return s == StandbyState::SYNCING || s == StandbyState::WATCHING ||
+               s == StandbyState::RECOVERING || s == StandbyState::PROMOTING;
+    }
+
+    /**
+     * @brief Check if watch is healthy
+     */
+    bool IsWatchHealthy() const { return GetState() == StandbyState::WATCHING; }
+
+    /**
+     * @brief Check if ready for promotion
+     */
+    bool IsReadyForPromotion() const {
+        return GetState() == StandbyState::WATCHING;
+    }
+
+    /**
+     * @brief Process an event and perform state transition
+     * @param event The event to process
+     * @return Result indicating if transition was allowed and new state
+     */
+    StateTransitionResult ProcessEvent(StandbyEvent event);
+
+    /**
+     * @brief Register a callback for state change notifications
+     */
+    void RegisterCallback(StateChangeCallback callback);
+
+    /**
+     * @brief State transition record for debugging
+     */
+    struct TransitionRecord {
+        std::chrono::steady_clock::time_point timestamp;
+        StandbyState from_state;
+        StandbyState to_state;
+        StandbyEvent event;
+    };
+
+    /**
+     * @brief Get state transition history (for debugging)
+     */
+    std::vector<TransitionRecord> GetTransitionHistory(
+        size_t max_records = 100) const;
+
+    /**
+     * @brief Get time spent in current state
+     */
+    std::chrono::milliseconds GetTimeInCurrentState() const;
+
+    /**
+     * @brief Get consecutive error count
+     */
+    int GetConsecutiveErrors() const { return consecutive_errors_.load(); }
+
+    /**
+     * @brief Increment consecutive error count
+     * @return New error count
+     */
+    int IncrementErrors();
+
+    /**
+     * @brief Reset consecutive error count
+     */
+    void ResetErrors() { consecutive_errors_.store(0); }
+
+    /**
+     * @brief Get reconnect attempt count
+     */
+    int GetReconnectCount() const { return reconnect_count_.load(); }
+
+    /**
+     * @brief Increment reconnect count
+     */
+    void IncrementReconnectCount() { reconnect_count_.fetch_add(1); }
+
+    /**
+     * @brief Reset reconnect count
+     */
+    void ResetReconnectCount() { reconnect_count_.store(0); }
+
+    // Constants
+    static constexpr int kMaxConsecutiveErrors = 10;
+    static constexpr int kMaxReconnectAttempts = 100;
+
+   private:
+    /**
+     * @brief Check if a transition is valid and get new state
+     */
+    StateTransitionResult ValidateTransition(StandbyState from,
+                                             StandbyEvent event) const;
+
+    /**
+     * @brief Notify all registered callbacks
+     */
+    void NotifyCallbacks(StandbyState old_state, StandbyState new_state,
+                         StandbyEvent event);
+
+    std::atomic<StandbyState> current_state_{StandbyState::STOPPED};
+    std::atomic<int> consecutive_errors_{0};
+    std::atomic<int> reconnect_count_{0};
+    std::chrono::steady_clock::time_point state_enter_time_;
+
+    mutable std::mutex mutex_;
+    std::vector<StateChangeCallback> callbacks_;
+    std::vector<TransitionRecord> transition_history_;
+
+    static constexpr size_t kMaxHistorySize = 1000;
+};
+
+}  // namespace mooncake

--- a/mooncake-store/include/types.h
+++ b/mooncake-store/include/types.h
@@ -171,6 +171,7 @@ enum class ErrorCode : int32_t {
     ETCD_KEY_NOT_EXIST = -1001,     ///< key not found in etcd.
     ETCD_TRANSACTION_FAIL = -1002,  ///< etcd transaction failed.
     ETCD_CTX_CANCELLED = -1003,     ///< etcd context cancelled.
+    OPLOG_ENTRY_NOT_FOUND = -1004,  ///< OpLog entry not found.
     UNAVAILABLE_IN_CURRENT_STATUS =
         -1010,  ///< Request cannot be done in current status.
     UNAVAILABLE_IN_CURRENT_MODE =
@@ -518,6 +519,48 @@ inline std::ostream& operator<<(std::ostream& os,
             break;
     }
     return os;
+}
+
+inline bool IsValidClusterIdComponent(const std::string& cluster_id) {
+    if (cluster_id.empty()) {
+        return false;
+    }
+    if (cluster_id.size() > 128) {
+        return false;
+    }
+    for (unsigned char c : cluster_id) {
+        const bool ok = (c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z') ||
+                        (c >= 'a' && c <= 'z') || c == '_' || c == '-' ||
+                        c == '.';
+        if (!ok) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// Sequence ID comparison utilities for OpLog and HA components.
+// These use signed difference to handle uint64_t wrap-around correctly:
+//   IsSequenceNewer(0, UINT64_MAX) = true  (0 is newer after wrap)
+//   IsSequenceNewer(UINT64_MAX, 0) = false (UINT64_MAX is older before wrap)
+//
+// Assumes gap < 2^63, which is always true for sequence IDs in practice.
+inline bool IsSequenceNewer(uint64_t a, uint64_t b) {
+    return static_cast<int64_t>(a - b) > 0;
+}
+
+inline bool IsSequenceOlder(uint64_t a, uint64_t b) {
+    return static_cast<int64_t>(a - b) < 0;
+}
+
+inline bool IsSequenceEqual(uint64_t a, uint64_t b) { return a == b; }
+
+inline bool IsSequenceNewerOrEqual(uint64_t a, uint64_t b) {
+    return a == b || static_cast<int64_t>(a - b) > 0;
+}
+
+inline bool IsSequenceOlderOrEqual(uint64_t a, uint64_t b) {
+    return a == b || static_cast<int64_t>(a - b) < 0;
 }
 
 }  // namespace mooncake

--- a/mooncake-store/include/utils/base64.h
+++ b/mooncake-store/include/utils/base64.h
@@ -1,0 +1,121 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace mooncake {
+namespace base64 {
+
+// Base64 encoding for binary payload.
+// JsonCpp treats strings as UTF-8, so we must encode binary data.
+inline std::string Encode(const std::string& data) {
+    static const char base64_chars[] =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+    std::string result;
+    result.reserve(((data.size() + 2) / 3) * 4);
+
+    size_t i = 0;
+    size_t data_len = data.size();
+
+    // Process 3 bytes at a time
+    while (i + 2 < data_len) {
+        uint32_t octet_a = static_cast<unsigned char>(data[i++]);
+        uint32_t octet_b = static_cast<unsigned char>(data[i++]);
+        uint32_t octet_c = static_cast<unsigned char>(data[i++]);
+
+        uint32_t triple = (octet_a << 16) | (octet_b << 8) | octet_c;
+
+        result.push_back(base64_chars[(triple >> 18) & 0x3F]);
+        result.push_back(base64_chars[(triple >> 12) & 0x3F]);
+        result.push_back(base64_chars[(triple >> 6) & 0x3F]);
+        result.push_back(base64_chars[triple & 0x3F]);
+    }
+
+    // Handle remaining bytes
+    size_t remaining = data_len - i;
+    if (remaining > 0) {
+        uint32_t octet_a = static_cast<unsigned char>(data[i++]);
+        uint32_t octet_b =
+            (remaining > 1) ? static_cast<unsigned char>(data[i++]) : 0;
+        uint32_t octet_c = 0;
+
+        uint32_t triple = (octet_a << 16) | (octet_b << 8) | octet_c;
+
+        result.push_back(base64_chars[(triple >> 18) & 0x3F]);
+        result.push_back(base64_chars[(triple >> 12) & 0x3F]);
+        result.push_back((remaining > 1) ? base64_chars[(triple >> 6) & 0x3F]
+                                         : '=');
+        result.push_back('=');
+    }
+
+    return result;
+}
+
+// Base64 decoding for binary payload.
+inline std::string Decode(const std::string& encoded) {
+    static const unsigned char decode_table[256] = {
+        64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+        64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+        64, 64, 64, 64, 64, 64, 64, 62, 64, 64, 64, 63, 52, 53, 54, 55, 56, 57,
+        58, 59, 60, 61, 64, 64, 64, 64, 64, 64, 64, 0,  1,  2,  3,  4,  5,  6,
+        7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+        25, 64, 64, 64, 64, 64, 64, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36,
+        37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 64, 64, 64,
+        64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+        64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+        64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+        64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+        64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+        64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+        64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+        64, 64, 64, 64};
+
+    std::string result;
+    result.reserve((encoded.size() * 3) / 4);
+
+    size_t i = 0;
+    while (i < encoded.size()) {
+        // Skip whitespace and invalid chars
+        while (i < encoded.size() &&
+               (encoded[i] == ' ' || encoded[i] == '\n' || encoded[i] == '\r' ||
+                encoded[i] == '\t')) {
+            i++;
+        }
+        if (i >= encoded.size()) break;
+
+        uint32_t sextet_a =
+            decode_table[static_cast<unsigned char>(encoded[i++])];
+        if (i >= encoded.size() || sextet_a == 64) break;
+
+        uint32_t sextet_b =
+            decode_table[static_cast<unsigned char>(encoded[i++])];
+        if (sextet_b == 64) break;
+
+        uint32_t sextet_c =
+            (i < encoded.size())
+                ? decode_table[static_cast<unsigned char>(encoded[i++])]
+                : 64;
+        uint32_t sextet_d =
+            (i < encoded.size())
+                ? decode_table[static_cast<unsigned char>(encoded[i++])]
+                : 64;
+
+        uint32_t triple = (sextet_a << 18) | (sextet_b << 12) |
+                          ((sextet_c != 64) ? (sextet_c << 6) : 0) |
+                          ((sextet_d != 64) ? sextet_d : 0);
+
+        result.push_back(static_cast<char>((triple >> 16) & 0xFF));
+        if (sextet_c != 64) {
+            result.push_back(static_cast<char>((triple >> 8) & 0xFF));
+        }
+        if (sextet_d != 64) {
+            result.push_back(static_cast<char>(triple & 0xFF));
+        }
+    }
+
+    return result;
+}
+
+}  // namespace base64
+}  // namespace mooncake

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -61,9 +61,37 @@ set(MOONCAKE_STORE_SOURCES
     tiered_cache/scheduler/lru_policy.cpp
     tiered_cache/scheduler/client_scheduler.cpp
     task_manager.cpp
+    # HA OpLog components (ported from main branch)
+    ha/oplog/oplog_manager.cpp
+    ha/oplog/oplog_serializer.cpp
+    ha/oplog/localfs_oplog_store.cpp
+    ha/oplog/polling_oplog_change_notifier.cpp
+    ha/oplog/oplog_store_factory.cpp
+    standby_state_machine.cpp
+    ha_metric_manager.cpp
 )
 
 set(EXTRA_LIBS "")
+
+# Find xxHash (required for ComputeChecksum)
+find_path(
+  XXHASH_INCLUDE_DIR
+  NAMES xxhash.h
+  PATHS /usr/include /usr/local/include)
+find_library(
+  XXHASH_LIBRARY
+  NAMES xxhash libxxhash
+  PATHS /usr/lib /usr/local/lib /usr/lib64)
+if(XXHASH_INCLUDE_DIR AND XXHASH_LIBRARY)
+  message(
+    STATUS "Found xxHash: include=${XXHASH_INCLUDE_DIR} lib=${XXHASH_LIBRARY}")
+  list(APPEND MASTER_EXTRA_INCS ${XXHASH_INCLUDE_DIR})
+else()
+  message(
+    FATAL_ERROR
+      "xxHash library/header not found. Please install xxhash (development headers) and try again."
+  )
+endif()
 
 if(USE_3FS)
   add_subdirectory(hf3fs)
@@ -87,6 +115,7 @@ add_library(mooncake_store ${MOONCAKE_STORE_SOURCES})
 # Note: transfer_engine is PRIVATE to avoid propagating its dependencies (e.g., vendor-specific hardware)
 # to targets that don't need it (e.g., mooncake_master).
 # Targets that need transfer_engine should link it explicitly.
+target_include_directories(mooncake_store PUBLIC ${XXHASH_INCLUDE_DIR})
 target_link_libraries(mooncake_store
     PUBLIC
         cachelib_memory_allocator
@@ -94,6 +123,7 @@ target_link_libraries(mooncake_store
         glog::glog
         gflags::gflags
         JsonCpp::JsonCpp
+        ${XXHASH_LIBRARY}
         ${EXTRA_LIBS}
         asio_shared
     PRIVATE

--- a/mooncake-store/src/ha/oplog/localfs_oplog_store.cpp
+++ b/mooncake-store/src/ha/oplog/localfs_oplog_store.cpp
@@ -1,0 +1,788 @@
+#include "ha/oplog/localfs_oplog_store.h"
+
+#include <glog/logging.h>
+
+#include <algorithm>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include "ha/oplog/oplog_serializer.h"
+#include "ha/oplog/polling_oplog_change_notifier.h"
+
+namespace fs = std::filesystem;
+
+namespace mooncake {
+
+// ============================================================
+// Constructor / Destructor
+// ============================================================
+
+LocalFsOpLogStore::LocalFsOpLogStore(const std::string& cluster_id,
+                                     const std::string& root_dir,
+                                     bool enable_batch_write,
+                                     int poll_interval_ms)
+    : cluster_id_(cluster_id),
+      root_dir_(root_dir),
+      cluster_dir_(root_dir + "/" + cluster_id),
+      enable_batch_write_(enable_batch_write),
+      poll_interval_ms_(poll_interval_ms) {
+    if (!NormalizeAndValidateClusterId(cluster_id_)) {
+        LOG(FATAL) << "Invalid cluster_id for LocalFsOpLogStore: '"
+                   << cluster_id
+                   << "'. Allowed chars: [A-Za-z0-9_.-], max_len=128.";
+    }
+    // Rebuild cluster_dir_ after normalization.
+    cluster_dir_ = root_dir_ + "/" + cluster_id_;
+}
+
+LocalFsOpLogStore::~LocalFsOpLogStore() {
+    if (batch_write_running_.load()) {
+        batch_write_running_.store(false);
+        cv_batch_updated_.notify_all();
+        if (batch_write_thread_.joinable()) {
+            batch_write_thread_.join();
+        }
+    }
+    // Final flush of any remaining entries
+    if (!pending_batch_.empty()) {
+        FlushBatch();
+    }
+    // Notify any sync waiters so they don't block forever
+    cv_sync_completed_.notify_all();
+}
+
+// ============================================================
+// Init
+// ============================================================
+
+ErrorCode LocalFsOpLogStore::Init() {
+    try {
+        fs::create_directories(SegmentsDir());
+    } catch (const fs::filesystem_error& e) {
+        LOG(ERROR) << "LocalFsOpLogStore::Init: failed to create directories: "
+                   << e.what();
+        return ErrorCode::INTERNAL_ERROR;
+    }
+
+    CleanupTempFiles();
+
+    if (enable_batch_write_) {
+        // Writer: initialize latest file if not exists
+        std::string latest_path = LatestFilePath();
+        if (!fs::exists(latest_path)) {
+            auto err = AtomicWriteFile(latest_path, "0");
+            if (err != ErrorCode::OK) {
+                LOG(ERROR) << "LocalFsOpLogStore::Init: failed to create "
+                              "latest file";
+                return err;
+            }
+        }
+
+        auto recover_err = RecoverPersistedState();
+        if (recover_err != ErrorCode::OK) {
+            LOG(ERROR) << "LocalFsOpLogStore::Init: failed to recover "
+                          "persisted state";
+            return recover_err;
+        }
+
+        // Start batch write thread
+        batch_write_running_.store(true);
+        batch_write_thread_ =
+            std::thread(&LocalFsOpLogStore::BatchWriteThread, this);
+    }
+
+    return ErrorCode::OK;
+}
+
+// ============================================================
+// Path helpers
+// ============================================================
+
+std::string LocalFsOpLogStore::SegmentsDir() const {
+    return cluster_dir_ + "/segments";
+}
+
+std::string LocalFsOpLogStore::SnapshotsDir() const {
+    return cluster_dir_ + "/snapshots";
+}
+
+std::string LocalFsOpLogStore::LatestFilePath() const {
+    return cluster_dir_ + "/latest";
+}
+
+std::string LocalFsOpLogStore::BuildSegmentFilename(uint64_t min_seq,
+                                                    uint64_t max_seq) const {
+    char buf[128];
+    snprintf(buf, sizeof(buf), "seg_%020lu_%020lu", min_seq, max_seq);
+    return SegmentsDir() + "/" + buf;
+}
+
+std::string LocalFsOpLogStore::BuildSnapshotPath(
+    const std::string& snapshot_id) const {
+    return SnapshotsDir() + "/" + snapshot_id;
+}
+
+// ============================================================
+// Atomic file write
+// ============================================================
+
+ErrorCode LocalFsOpLogStore::AtomicWriteFile(const std::string& target_path,
+                                             const std::string& content) {
+    return AtomicWriteFile(target_path, content.data(), content.size());
+}
+
+ErrorCode LocalFsOpLogStore::AtomicWriteFile(const std::string& target_path,
+                                             const void* data, size_t size) {
+    std::string tmp_path = target_path + ".tmp";
+    int fd = ::open(tmp_path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (fd < 0) {
+        LOG(ERROR) << "AtomicWriteFile: open failed: " << tmp_path
+                   << ", errno=" << errno;
+        return ErrorCode::INTERNAL_ERROR;
+    }
+
+    const char* ptr = static_cast<const char*>(data);
+    size_t remaining = size;
+    while (remaining > 0) {
+        ssize_t written = ::write(fd, ptr, remaining);
+        if (written < 0) {
+            if (errno == EINTR) continue;
+            LOG(ERROR) << "AtomicWriteFile: write failed: " << tmp_path
+                       << ", errno=" << errno;
+            ::close(fd);
+            ::unlink(tmp_path.c_str());
+            return ErrorCode::INTERNAL_ERROR;
+        }
+        ptr += written;
+        remaining -= static_cast<size_t>(written);
+    }
+
+    if (::fsync(fd) != 0) {
+        LOG(ERROR) << "AtomicWriteFile: fsync failed: " << tmp_path
+                   << ", errno=" << errno;
+        ::close(fd);
+        ::unlink(tmp_path.c_str());
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    ::close(fd);
+
+    if (::rename(tmp_path.c_str(), target_path.c_str()) != 0) {
+        LOG(ERROR) << "AtomicWriteFile: rename failed: " << tmp_path << " -> "
+                   << target_path << ", errno=" << errno;
+        ::unlink(tmp_path.c_str());
+        return ErrorCode::INTERNAL_ERROR;
+    }
+
+    // fsync parent directory to ensure the new directory entry is durable.
+    // Critical for DFS mounts where rename visibility is not guaranteed
+    // without an explicit directory sync.
+    std::string parent_dir = fs::path(target_path).parent_path().string();
+    int dir_fd = ::open(parent_dir.c_str(), O_RDONLY | O_DIRECTORY);
+    if (dir_fd >= 0) {
+        ::fsync(dir_fd);
+        ::close(dir_fd);
+    }
+
+    return ErrorCode::OK;
+}
+
+// ============================================================
+// Cleanup temp files
+// ============================================================
+
+void LocalFsOpLogStore::CleanupTempFiles() {
+    try {
+        for (auto& dir : {SegmentsDir(), cluster_dir_}) {
+            if (!fs::exists(dir)) continue;
+            for (auto& entry : fs::directory_iterator(dir)) {
+                if (entry.path().extension() == ".tmp") {
+                    fs::remove(entry.path());
+                    LOG(INFO) << "Cleaned up temp file: " << entry.path();
+                }
+            }
+        }
+    } catch (const fs::filesystem_error& e) {
+        LOG(WARNING) << "CleanupTempFiles: " << e.what();
+    }
+}
+
+// ============================================================
+// File read helper
+// ============================================================
+
+ErrorCode LocalFsOpLogStore::ReadUint64FromFile(const std::string& filepath,
+                                                uint64_t& value) const {
+    std::ifstream f(filepath);
+    if (!f) {
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    std::string content;
+    f >> content;
+    try {
+        value = std::stoull(content);
+    } catch (...) {
+        LOG(ERROR) << "ReadUint64FromFile: invalid content in " << filepath
+                   << ": " << content;
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    return ErrorCode::OK;
+}
+
+// ============================================================
+// Snapshot ID validation
+// ============================================================
+
+bool LocalFsOpLogStore::ValidateSnapshotId(const std::string& snapshot_id) {
+    if (snapshot_id.empty()) return false;
+    if (snapshot_id.find('/') != std::string::npos) return false;
+    if (snapshot_id.find("..") != std::string::npos) return false;
+    if (snapshot_id.find('\0') != std::string::npos) return false;
+    return true;
+}
+
+// ============================================================
+// Segment filename parsing
+// ============================================================
+
+bool LocalFsOpLogStore::ParseSegmentFilename(const std::string& filename,
+                                             uint64_t& min_seq,
+                                             uint64_t& max_seq) {
+    // Expected format: seg_XXXXXXXXXXXXXXXXXXXX_XXXXXXXXXXXXXXXXXXXX
+    if (filename.size() < 45) return false;
+    if (filename.substr(0, 4) != "seg_") return false;
+    try {
+        min_seq = std::stoull(filename.substr(4, 20));
+        max_seq = std::stoull(filename.substr(25, 20));
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+std::vector<LocalFsOpLogStore::SegmentInfo> LocalFsOpLogStore::ListSegments()
+    const {
+    std::vector<SegmentInfo> segments;
+    std::string seg_dir = SegmentsDir();
+    if (!fs::exists(seg_dir)) return segments;
+
+    try {
+        for (auto& entry : fs::directory_iterator(seg_dir)) {
+            if (entry.path().extension() == ".tmp") continue;
+            std::string filename = entry.path().filename().string();
+            uint64_t min_seq = 0, max_seq = 0;
+            if (ParseSegmentFilename(filename, min_seq, max_seq)) {
+                segments.push_back({filename, min_seq, max_seq});
+            }
+        }
+    } catch (const fs::filesystem_error& e) {
+        LOG(WARNING) << "ListSegments: " << e.what();
+    }
+
+    // Sort by min_seq
+    std::sort(segments.begin(), segments.end(),
+              [](const SegmentInfo& a, const SegmentInfo& b) {
+                  return a.min_seq < b.min_seq;
+              });
+    return segments;
+}
+
+ErrorCode LocalFsOpLogStore::NormalizeBatchEntries(
+    std::vector<BatchEntry>& entries) const {
+    if (entries.empty()) {
+        return ErrorCode::OK;
+    }
+
+    std::sort(entries.begin(), entries.end(),
+              [](const BatchEntry& a, const BatchEntry& b) {
+                  return a.sequence_id < b.sequence_id;
+              });
+
+    std::vector<BatchEntry> normalized;
+    normalized.reserve(entries.size());
+    for (auto& entry : entries) {
+        if (normalized.empty() ||
+            normalized.back().sequence_id != entry.sequence_id) {
+            normalized.push_back(std::move(entry));
+            continue;
+        }
+
+        if (normalized.back().serialized_value != entry.serialized_value) {
+            LOG(ERROR) << "NormalizeBatchEntries: fencing violation for seq="
+                       << entry.sequence_id << " inside pending batch";
+            return ErrorCode::INTERNAL_ERROR;
+        }
+
+        normalized.back().is_sync = normalized.back().is_sync || entry.is_sync;
+    }
+
+    entries = std::move(normalized);
+    return ErrorCode::OK;
+}
+
+ErrorCode LocalFsOpLogStore::VerifyPersistedEntryMatches(
+    uint64_t sequence_id, const std::string& serialized_value) {
+    OpLogEntry existing_entry;
+    ErrorCode err = ReadOpLog(sequence_id, existing_entry);
+    if (err != ErrorCode::OK) {
+        if (err != ErrorCode::OPLOG_ENTRY_NOT_FOUND) {
+            LOG(ERROR) << "VerifyPersistedEntryMatches: seq=" << sequence_id
+                       << " marked persisted but read failed, err="
+                       << static_cast<int>(err);
+        }
+        return err;
+    }
+
+    if (SerializeOpLogEntry(existing_entry) != serialized_value) {
+        LOG(ERROR) << "VerifyPersistedEntryMatches: fencing violation for "
+                   << "persisted seq=" << sequence_id;
+        return ErrorCode::INTERNAL_ERROR;
+    }
+
+    return ErrorCode::OK;
+}
+
+ErrorCode LocalFsOpLogStore::RecoverPersistedState() {
+    uint64_t max_seq = 0;
+    ErrorCode err = GetMaxSequenceId(max_seq);
+    if (err == ErrorCode::OPLOG_ENTRY_NOT_FOUND) {
+        last_persisted_seq_id_.store(0);
+        return UpdateLatestSequenceId(0);
+    }
+    if (err != ErrorCode::OK) {
+        LOG(ERROR) << "RecoverPersistedState: failed to inspect segments, err="
+                   << static_cast<int>(err);
+        return err;
+    }
+
+    last_persisted_seq_id_.store(max_seq);
+
+    uint64_t latest_seq = 0;
+    ErrorCode latest_err = GetLatestSequenceId(latest_seq);
+    if (latest_err != ErrorCode::OK || latest_seq != max_seq) {
+        ErrorCode update_err = UpdateLatestSequenceId(max_seq);
+        if (update_err != ErrorCode::OK) {
+            LOG(ERROR) << "RecoverPersistedState: failed to refresh latest "
+                          "file to seq="
+                       << max_seq;
+            return update_err;
+        }
+    }
+
+    return ErrorCode::OK;
+}
+
+// ============================================================
+// Segment file I/O
+// ============================================================
+
+ErrorCode LocalFsOpLogStore::WriteSegmentFile(
+    const std::vector<BatchEntry>& entries) {
+    if (entries.empty()) return ErrorCode::OK;
+
+    uint64_t min_seq = entries.front().sequence_id;
+    uint64_t max_seq = entries.back().sequence_id;
+
+    // Build file content: header + length-prefixed entries
+    std::string content;
+
+    // Reserve approximate size
+    size_t estimated_size = kSegmentHeaderSize;
+    for (const auto& e : entries) {
+        estimated_size += sizeof(uint32_t) + e.serialized_value.size();
+    }
+    content.reserve(estimated_size);
+
+    // Header
+    SegmentHeader header;
+    std::memcpy(header.magic, kSegmentMagic, 4);
+    header.version = kSegmentVersion;
+    header.min_seq = min_seq;
+    header.max_seq = max_seq;
+    header.entry_count = static_cast<uint32_t>(entries.size());
+    header.reserved = 0;
+
+    content.append(reinterpret_cast<const char*>(&header), sizeof(header));
+
+    // Entries: [uint32_t length][serialized_value]
+    for (const auto& e : entries) {
+        uint32_t len = static_cast<uint32_t>(e.serialized_value.size());
+        content.append(reinterpret_cast<const char*>(&len), sizeof(len));
+        content.append(e.serialized_value);
+    }
+
+    std::string filepath = BuildSegmentFilename(min_seq, max_seq);
+    return AtomicWriteFile(filepath, content.data(), content.size());
+}
+
+ErrorCode LocalFsOpLogStore::ReadSegmentHeader(const std::string& filepath,
+                                               SegmentHeader& header) {
+    std::ifstream f(filepath, std::ios::binary);
+    if (!f) {
+        LOG(ERROR) << "ReadSegmentHeader: cannot open " << filepath;
+        return ErrorCode::INTERNAL_ERROR;
+    }
+
+    f.read(reinterpret_cast<char*>(&header), sizeof(header));
+    if (!f || static_cast<size_t>(f.gcount()) < sizeof(header)) {
+        LOG(ERROR) << "ReadSegmentHeader: truncated header in " << filepath;
+        return ErrorCode::INTERNAL_ERROR;
+    }
+
+    if (std::memcmp(header.magic, kSegmentMagic, 4) != 0) {
+        LOG(ERROR) << "ReadSegmentHeader: bad magic in " << filepath;
+        return ErrorCode::INTERNAL_ERROR;
+    }
+
+    if (header.version != kSegmentVersion) {
+        LOG(ERROR) << "ReadSegmentHeader: unsupported version "
+                   << header.version << " in " << filepath;
+        return ErrorCode::INTERNAL_ERROR;
+    }
+
+    return ErrorCode::OK;
+}
+
+ErrorCode LocalFsOpLogStore::ReadSegmentEntries(
+    const std::string& filepath, std::vector<OpLogEntry>& entries) {
+    SegmentHeader header;
+    auto err = ReadSegmentHeader(filepath, header);
+    if (err != ErrorCode::OK) return err;
+
+    // Re-open and skip past header to read entries
+    std::ifstream f(filepath, std::ios::binary);
+    if (!f) {
+        LOG(ERROR) << "ReadSegmentEntries: cannot open " << filepath;
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    f.seekg(sizeof(SegmentHeader));
+
+    for (uint32_t i = 0; i < header.entry_count; ++i) {
+        uint32_t len = 0;
+        f.read(reinterpret_cast<char*>(&len), sizeof(len));
+        if (!f) {
+            LOG(ERROR) << "ReadSegmentEntries: truncated entry length at "
+                       << "entry " << i << " in " << filepath;
+            return ErrorCode::INTERNAL_ERROR;
+        }
+
+        std::string buf(len, '\0');
+        f.read(buf.data(), len);
+        if (!f) {
+            LOG(ERROR) << "ReadSegmentEntries: truncated entry data at "
+                       << "entry " << i << " in " << filepath;
+            return ErrorCode::INTERNAL_ERROR;
+        }
+
+        OpLogEntry entry;
+        if (!DeserializeOpLogEntry(buf, entry)) {
+            LOG(ERROR) << "ReadSegmentEntries: failed to deserialize entry "
+                       << i << " in " << filepath;
+            return ErrorCode::INTERNAL_ERROR;
+        }
+        entries.push_back(std::move(entry));
+    }
+
+    return ErrorCode::OK;
+}
+
+// ============================================================
+// Write path (Group Commit)
+// ============================================================
+
+ErrorCode LocalFsOpLogStore::WriteOpLog(const OpLogEntry& entry, bool sync) {
+    if (!enable_batch_write_) {
+        LOG(ERROR) << "WriteOpLog called on READER instance";
+        return ErrorCode::INVALID_PARAMS;
+    }
+
+    if (!batch_write_running_.load()) {
+        LOG(ERROR) << "WriteOpLog called after shutdown";
+        return ErrorCode::INTERNAL_ERROR;
+    }
+
+    // Serialize entry
+    std::string serialized = SerializeOpLogEntry(entry);
+
+    // Idempotent retry / fencing check for already-persisted sequence IDs.
+    // Note: last_persisted_seq_id_ is only a high watermark. With pre-
+    // allocated sequence IDs, larger seq may flush before a smaller retry.
+    // So a cache hit here must still verify the concrete persisted record.
+    if (last_persisted_seq_id_.load() >= entry.sequence_id) {
+        ErrorCode verify_err =
+            VerifyPersistedEntryMatches(entry.sequence_id, serialized);
+        if (verify_err == ErrorCode::OK) {
+            return ErrorCode::OK;
+        }
+        if (verify_err != ErrorCode::OPLOG_ENTRY_NOT_FOUND) {
+            return verify_err;
+        }
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(batch_mutex_);
+        pending_batch_.push_back({serialized, entry.sequence_id, sync});
+    }
+
+    // Always notify — spurious wakeup is cheap, data race is not
+    cv_batch_updated_.notify_one();
+
+    if (sync) {
+        // Wait for the specific sequence to become durably readable.
+        std::unique_lock<std::mutex> lock(batch_mutex_);
+        bool flushed = cv_sync_completed_.wait_for(
+            lock, std::chrono::milliseconds(kSyncWaitTimeoutMs), [&] {
+                if (last_persisted_seq_id_.load() < entry.sequence_id) {
+                    return false;
+                }
+                return VerifyPersistedEntryMatches(entry.sequence_id,
+                                                   serialized) == ErrorCode::OK;
+            });
+        if (!flushed) {
+            LOG(ERROR) << "WriteOpLog sync wait timed out for seq="
+                       << entry.sequence_id;
+            return ErrorCode::INTERNAL_ERROR;
+        }
+    }
+
+    return ErrorCode::OK;
+}
+
+void LocalFsOpLogStore::BatchWriteThread() {
+    while (batch_write_running_.load()) {
+        {
+            std::unique_lock<std::mutex> lock(batch_mutex_);
+            if (pending_batch_.empty()) {
+                cv_batch_updated_.wait_for(
+                    lock, std::chrono::milliseconds(kBatchTimeoutMs));
+            }
+            if (!batch_write_running_.load() && pending_batch_.empty()) {
+                break;
+            }
+        }
+        FlushBatch();
+    }
+}
+
+void LocalFsOpLogStore::FlushBatch() {
+    std::deque<BatchEntry> batch_to_write;
+    {
+        std::lock_guard<std::mutex> lock(batch_mutex_);
+        if (pending_batch_.empty()) return;
+        batch_to_write.swap(pending_batch_);
+    }
+
+    std::vector<BatchEntry> entries(
+        std::make_move_iterator(batch_to_write.begin()),
+        std::make_move_iterator(batch_to_write.end()));
+    ErrorCode normalize_err = NormalizeBatchEntries(entries);
+    if (normalize_err != ErrorCode::OK) {
+        LOG(ERROR) << "FlushBatch: invalid duplicate sequence detected in "
+                      "pending batch";
+        cv_sync_completed_.notify_all();
+        return;
+    }
+
+    // Retry on failure
+    ErrorCode err = ErrorCode::INTERNAL_ERROR;
+    for (int retry = 0; retry < kFlushRetryCount; ++retry) {
+        err = WriteSegmentFile(entries);
+        if (err == ErrorCode::OK) break;
+        LOG(WARNING) << "FlushBatch: WriteSegmentFile failed, retry "
+                     << (retry + 1) << "/" << kFlushRetryCount;
+        if (retry + 1 < kFlushRetryCount) {
+            std::this_thread::sleep_for(
+                std::chrono::milliseconds(kFlushRetryIntervalMs));
+        }
+    }
+
+    if (err != ErrorCode::OK) {
+        LOG(ERROR) << "FlushBatch: all retries failed, " << entries.size()
+                   << " entries lost (seq " << entries.front().sequence_id
+                   << " - " << entries.back().sequence_id << ")";
+        // Notify sync waiters so they don't block forever
+        cv_sync_completed_.notify_all();
+        return;
+    }
+
+    // Update last_persisted_seq_id_
+    uint64_t max_seq = entries.back().sequence_id;
+    last_persisted_seq_id_.store(max_seq);
+
+    // Update latest file
+    AtomicWriteFile(LatestFilePath(), std::to_string(max_seq));
+
+    // Notify sync waiters
+    cv_sync_completed_.notify_all();
+}
+
+// ============================================================
+// Read path
+// ============================================================
+
+ErrorCode LocalFsOpLogStore::ReadOpLog(uint64_t sequence_id,
+                                       OpLogEntry& entry) {
+    auto segments = ListSegments();
+
+    // Binary search for the segment containing sequence_id
+    auto it = std::lower_bound(
+        segments.begin(), segments.end(), sequence_id,
+        [](const SegmentInfo& seg, uint64_t seq) { return seg.max_seq < seq; });
+
+    if (it == segments.end()) {
+        return ErrorCode::OPLOG_ENTRY_NOT_FOUND;
+    }
+
+    // Check if sequence_id is within this segment's range
+    if (sequence_id < it->min_seq || sequence_id > it->max_seq) {
+        return ErrorCode::OPLOG_ENTRY_NOT_FOUND;
+    }
+
+    std::string filepath = SegmentsDir() + "/" + it->filename;
+    std::vector<OpLogEntry> entries;
+    auto err = ReadSegmentEntries(filepath, entries);
+    if (err != ErrorCode::OK) return err;
+
+    for (auto& e : entries) {
+        if (e.sequence_id == sequence_id) {
+            entry = std::move(e);
+            return ErrorCode::OK;
+        }
+    }
+
+    return ErrorCode::OPLOG_ENTRY_NOT_FOUND;
+}
+
+ErrorCode LocalFsOpLogStore::ReadOpLogSince(uint64_t start_sequence_id,
+                                            size_t limit,
+                                            std::vector<OpLogEntry>& entries) {
+    entries.clear();
+    auto segments = ListSegments();
+
+    // Find first segment that could contain entries after start_sequence_id
+    auto it =
+        std::lower_bound(segments.begin(), segments.end(), start_sequence_id,
+                         [](const SegmentInfo& seg, uint64_t seq) {
+                             return seg.max_seq <= seq;
+                         });
+
+    for (; it != segments.end() && entries.size() < limit; ++it) {
+        std::string filepath = SegmentsDir() + "/" + it->filename;
+        std::vector<OpLogEntry> seg_entries;
+        auto err = ReadSegmentEntries(filepath, seg_entries);
+        if (err != ErrorCode::OK) {
+            LOG(ERROR) << "ReadOpLogSince: corrupted segment " << it->filename
+                       << ", aborting read to prevent oplog gaps";
+            return err;
+        }
+
+        for (auto& e : seg_entries) {
+            if (e.sequence_id > start_sequence_id) {
+                entries.push_back(std::move(e));
+                if (entries.size() >= limit) break;
+            }
+        }
+    }
+
+    return ErrorCode::OK;
+}
+
+// ============================================================
+// Sequence ID management
+// ============================================================
+
+ErrorCode LocalFsOpLogStore::GetLatestSequenceId(uint64_t& sequence_id) {
+    std::string latest_path = LatestFilePath();
+    auto err = ReadUint64FromFile(latest_path, sequence_id);
+    if (err != ErrorCode::OK) {
+        // File doesn't exist yet — default to 0
+        sequence_id = 0;
+        return ErrorCode::OK;
+    }
+    return ErrorCode::OK;
+}
+
+ErrorCode LocalFsOpLogStore::GetMaxSequenceId(uint64_t& sequence_id) {
+    auto segments = ListSegments();
+    if (segments.empty()) {
+        return ErrorCode::OPLOG_ENTRY_NOT_FOUND;
+    }
+
+    sequence_id = segments.back().max_seq;
+    return ErrorCode::OK;
+}
+
+ErrorCode LocalFsOpLogStore::UpdateLatestSequenceId(uint64_t sequence_id) {
+    return AtomicWriteFile(LatestFilePath(), std::to_string(sequence_id));
+}
+
+// ============================================================
+// Snapshot operations
+// ============================================================
+
+ErrorCode LocalFsOpLogStore::RecordSnapshotSequenceId(
+    const std::string& snapshot_id, uint64_t sequence_id) {
+    if (!ValidateSnapshotId(snapshot_id)) {
+        return ErrorCode::INVALID_PARAMS;
+    }
+    // Create snapshots directory lazily on first write
+    try {
+        fs::create_directories(SnapshotsDir());
+    } catch (const fs::filesystem_error& e) {
+        LOG(ERROR) << "RecordSnapshotSequenceId: failed to create dir: "
+                   << e.what();
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    return AtomicWriteFile(BuildSnapshotPath(snapshot_id),
+                           std::to_string(sequence_id));
+}
+
+ErrorCode LocalFsOpLogStore::GetSnapshotSequenceId(
+    const std::string& snapshot_id, uint64_t& sequence_id) {
+    if (!ValidateSnapshotId(snapshot_id)) {
+        return ErrorCode::INVALID_PARAMS;
+    }
+
+    std::string path = BuildSnapshotPath(snapshot_id);
+    auto err = ReadUint64FromFile(path, sequence_id);
+    if (err != ErrorCode::OK) {
+        return ErrorCode::OPLOG_ENTRY_NOT_FOUND;
+    }
+
+    return ErrorCode::OK;
+}
+
+// ============================================================
+// Cleanup
+// ============================================================
+
+ErrorCode LocalFsOpLogStore::CleanupOpLogBefore(uint64_t before_sequence_id) {
+    auto segments = ListSegments();
+    for (const auto& seg : segments) {
+        if (seg.max_seq < before_sequence_id) {
+            std::string filepath = SegmentsDir() + "/" + seg.filename;
+            try {
+                fs::remove(filepath);
+            } catch (const fs::filesystem_error& e) {
+                LOG(WARNING) << "CleanupOpLogBefore: failed to remove "
+                             << filepath << ": " << e.what();
+            }
+        }
+    }
+    return ErrorCode::OK;
+}
+
+// ============================================================
+// Change notifier
+// ============================================================
+
+std::unique_ptr<OpLogChangeNotifier> LocalFsOpLogStore::CreateChangeNotifier(
+    const std::string& /*cluster_id*/) {
+    return std::make_unique<PollingOpLogChangeNotifier>(this,
+                                                        poll_interval_ms_);
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/ha/oplog/oplog_manager.cpp
+++ b/mooncake-store/src/ha/oplog/oplog_manager.cpp
@@ -1,0 +1,190 @@
+#include "ha/oplog/oplog_manager.h"
+
+#include <algorithm>
+#include <chrono>
+#include <xxhash.h>
+#include <glog/logging.h>
+
+#include "ha/oplog/oplog_store.h"
+
+namespace mooncake {
+
+OpLogManager::OpLogManager() = default;
+
+void OpLogManager::SetOpLogStore(std::shared_ptr<OpLogStore> oplog_store) {
+    std::unique_lock<std::shared_mutex> lock(mutex_);
+    oplog_store_ = oplog_store;
+}
+
+uint64_t OpLogManager::Append(OpType type, const std::string& key,
+                              const std::string& payload) {
+    OpLogEntry entry;
+    entry.op_type = type;
+    entry.object_key = key;
+    entry.payload = payload;
+    entry.timestamp_ms = NowMs();
+    entry.checksum = ComputeChecksum(entry.payload);
+    entry.prefix_hash = ComputePrefixHash(entry.object_key);
+
+    std::unique_lock<std::shared_mutex> lock(mutex_);
+    entry.sequence_id = ++last_seq_id_;
+    const uint64_t seq = entry.sequence_id;  // save before potential unlock
+
+    if (buffer_.size() >= kMaxBufferEntries_) {
+        buffer_.pop_front();
+        ++first_seq_id_;
+    }
+
+    buffer_.emplace_back(entry);  // Copy entry to buffer
+
+    // Write to etcd if EtcdOpLogStore is set.
+    // Strategy: PUT_END is async (sync=false) — only pushes to batch queue
+    // (microsecond-level), safe to hold mutex_.
+    // REMOVE / PUT_REVOKE are sync (sync=true) — blocks until etcd confirms
+    // persistence; must release mutex_ to avoid blocking other Append calls
+    // during the wait.  The caller relies on sync semantics to know the
+    // entry is durable before freeing/reusing associated memory.
+    if (oplog_store_) {
+        bool sync = (type != OpType::PUT_END);
+        if (sync) {
+            // Release lock before the blocking wait to avoid holding
+            // mutex_ for the entire etcd round-trip.
+            lock.unlock();
+        }
+        ErrorCode err = oplog_store_->WriteOpLog(entry, sync);
+        if (err != ErrorCode::OK) {
+            LOG(WARNING) << "Failed to write OpLog to store, sequence_id="
+                         << seq << ", but entry is in memory buffer";
+        }
+    }
+
+    return seq;
+}
+
+OpLogEntry OpLogManager::AllocateEntry(OpType type, const std::string& key,
+                                       const std::string& payload) {
+    OpLogEntry entry;
+    entry.op_type = type;
+    entry.object_key = key;
+    entry.payload = payload;
+    entry.timestamp_ms = NowMs();
+    entry.checksum = ComputeChecksum(entry.payload);
+    entry.prefix_hash = ComputePrefixHash(entry.object_key);
+
+    std::unique_lock<std::shared_mutex> lock(mutex_);
+    entry.sequence_id = ++last_seq_id_;
+
+    if (buffer_.size() >= kMaxBufferEntries_) {
+        buffer_.pop_front();
+        ++first_seq_id_;
+    }
+    buffer_.emplace_back(entry);
+    return entry;
+}
+
+ErrorCode OpLogManager::PersistEntry(const OpLogEntry& entry) const {
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    auto store = oplog_store_;
+    lock.unlock();
+    if (!store) {
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    // Strategy 2+: PUT_END is Async, REMOVE (and others) are Sync
+    bool sync = (entry.op_type != OpType::PUT_END);
+    return store->WriteOpLog(entry, sync);
+}
+
+tl::expected<uint64_t, ErrorCode> OpLogManager::AppendAndPersist(
+    OpType type, const std::string& key, const std::string& payload) {
+    // Seq pre-allocation semantics: allocate first, then persist.
+    OpLogEntry entry = AllocateEntry(type, key, payload);
+    ErrorCode err = PersistEntry(entry);
+    if (err != ErrorCode::OK) {
+        return tl::make_unexpected(err);
+    }
+    return entry.sequence_id;
+}
+
+uint64_t OpLogManager::GetLastSequenceId() const {
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    return last_seq_id_;
+}
+
+void OpLogManager::SetInitialSequenceId(uint64_t sequence_id) {
+    std::unique_lock<std::shared_mutex> lock(mutex_);
+    if (last_seq_id_ == 0 && buffer_.empty()) {
+        // Only allow setting initial sequence_id if OpLogManager is empty
+        last_seq_id_ = sequence_id;
+        first_seq_id_ = sequence_id +
+                        1;  // first_seq_id_ should be > last_seq_id_ when empty
+        LOG(INFO) << "OpLogManager initial sequence_id set to " << sequence_id;
+    } else {
+        LOG(WARNING)
+            << "Cannot set initial sequence_id: OpLogManager is not empty "
+            << "(last_seq_id_=" << last_seq_id_
+            << ", buffer_size=" << buffer_.size() << ")";
+    }
+}
+
+size_t OpLogManager::GetEntryCount() const {
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    return buffer_.size();
+}
+
+ErrorCode OpLogManager::CleanupOpLogBefore(uint64_t before_sequence_id) {
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    if (!oplog_store_) {
+        return ErrorCode::OK;
+    }
+    return oplog_store_->CleanupOpLogBefore(before_sequence_id);
+}
+
+uint64_t OpLogManager::NowMs() {
+    using namespace std::chrono;
+    return duration_cast<milliseconds>(steady_clock::now().time_since_epoch())
+        .count();
+}
+
+uint32_t OpLogManager::ComputeChecksum(const std::string& data) {
+    // Use xxHash XXH32 for a fast, deterministic 32-bit checksum.
+    // Requires linking against xxHash (e.g., libxxhash) and including
+    // <xxhash.h>.
+    return static_cast<uint32_t>(XXH32(data.data(), data.size(), 0));
+}
+
+uint32_t OpLogManager::ComputePrefixHash(const std::string& key) {
+    if (key.empty()) {
+        return 0;
+    }
+    // Use XXH32 for consistency with ComputeChecksum and better performance.
+    // XXH32 provides faster hashing and lower collision rate than std::hash.
+    // Computing hash for the entire key ensures better distribution and fewer
+    // collisions.
+    return static_cast<uint32_t>(XXH32(key.data(), key.size(), 0));
+}
+
+bool OpLogManager::VerifyChecksum(const OpLogEntry& entry) {
+    uint32_t computed = ComputeChecksum(entry.payload);
+    return computed == entry.checksum;
+}
+
+bool OpLogManager::ValidateEntrySize(const OpLogEntry& entry,
+                                     std::string* reason) {
+    if (entry.object_key.size() > kMaxObjectKeySize) {
+        if (reason) {
+            *reason = "object_key too large: size=" +
+                      std::to_string(entry.object_key.size());
+        }
+        return false;
+    }
+    if (entry.payload.size() > kMaxPayloadSize) {
+        if (reason) {
+            *reason = "payload too large: size=" +
+                      std::to_string(entry.payload.size());
+        }
+        return false;
+    }
+    return true;
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/ha/oplog/oplog_serializer.cpp
+++ b/mooncake-store/src/ha/oplog/oplog_serializer.cpp
@@ -1,0 +1,73 @@
+#include "ha/oplog/oplog_serializer.h"
+
+#include <glog/logging.h>
+#include <sstream>
+
+#if __has_include(<jsoncpp/json/json.h>)
+#include <jsoncpp/json/json.h>
+#else
+#include <json/json.h>
+#endif
+
+#include "utils/base64.h"
+
+namespace mooncake {
+
+std::string SerializeOpLogEntry(const OpLogEntry& entry) {
+    Json::Value root;
+    root["sequence_id"] = static_cast<Json::UInt64>(entry.sequence_id);
+    root["timestamp_ms"] = static_cast<Json::UInt64>(entry.timestamp_ms);
+    root["op_type"] = static_cast<int>(entry.op_type);
+    root["object_key"] = entry.object_key;
+    // CRITICAL: Base64 encode binary payload to prevent UTF-8 corruption in
+    // JSON
+    root["payload"] = base64::Encode(entry.payload);
+    root["checksum"] = static_cast<Json::UInt>(entry.checksum);
+    root["prefix_hash"] = static_cast<Json::UInt>(entry.prefix_hash);
+
+    Json::StreamWriterBuilder builder;
+    builder["indentation"] = "";  // Compact format
+    std::unique_ptr<Json::StreamWriter> writer(builder.newStreamWriter());
+    std::ostringstream oss;
+    writer->write(root, &oss);
+    return oss.str();
+}
+
+bool DeserializeOpLogEntry(const std::string& json_str, OpLogEntry& entry) {
+    Json::Value root;
+    Json::CharReaderBuilder builder;
+    std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
+    std::string errors;
+
+    if (!reader->parse(json_str.data(), json_str.data() + json_str.size(),
+                       &root, &errors)) {
+        LOG(ERROR) << "Failed to parse JSON: " << errors;
+        return false;
+    }
+
+    try {
+        entry.sequence_id = root["sequence_id"].asUInt64();
+        entry.timestamp_ms = root["timestamp_ms"].asUInt64();
+        entry.op_type = static_cast<OpType>(root["op_type"].asInt());
+        entry.object_key = root["object_key"].asString();
+        // CRITICAL: Base64 decode payload to restore binary data
+        entry.payload = base64::Decode(root["payload"].asString());
+        entry.checksum = root["checksum"].asUInt();
+        entry.prefix_hash = root["prefix_hash"].asUInt();
+    } catch (const std::exception& e) {
+        LOG(ERROR) << "Failed to deserialize OpLogEntry: " << e.what();
+        return false;
+    }
+
+    std::string size_reason;
+    if (!OpLogManager::ValidateEntrySize(entry, &size_reason)) {
+        LOG(ERROR) << "OpLogSerializer: entry size rejected, sequence_id="
+                   << entry.sequence_id << ", key=" << entry.object_key
+                   << ", reason=" << size_reason;
+        return false;
+    }
+
+    return true;
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/ha/oplog/oplog_store_factory.cpp
+++ b/mooncake-store/src/ha/oplog/oplog_store_factory.cpp
@@ -1,0 +1,40 @@
+#include "ha/oplog/oplog_store_factory.h"
+
+#include <glog/logging.h>
+
+#include "ha/oplog/localfs_oplog_store.h"
+
+namespace mooncake {
+
+std::unique_ptr<OpLogStore> OpLogStoreFactory::Create(
+    OpLogStoreType type, const std::string& cluster_id, OpLogStoreRole role,
+    const std::string& oplog_root_dir, int poll_interval_ms) {
+    switch (type) {
+        case OpLogStoreType::ETCD: {
+            // EtcdOpLogStore is not yet ported to this branch.
+            // Use LocalFs instead or wait for the full port.
+            LOG(ERROR)
+                << "OpLogStoreFactory: ETCD store not supported in this build";
+            return nullptr;
+        }
+        case OpLogStoreType::LOCAL_FS: {
+            bool enable_batch_write = (role == OpLogStoreRole::WRITER);
+            auto store = std::make_unique<LocalFsOpLogStore>(
+                cluster_id, oplog_root_dir, enable_batch_write,
+                poll_interval_ms);
+            if (store->Init() != ErrorCode::OK) {
+                LOG(ERROR)
+                    << "OpLogStoreFactory: failed to init LocalFsOpLogStore"
+                    << ", cluster_id=" << cluster_id
+                    << ", root_dir=" << oplog_root_dir;
+                return nullptr;
+            }
+            return store;
+        }
+        default:
+            LOG(ERROR) << "OpLogStoreFactory: unknown store type";
+            return nullptr;
+    }
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/ha/oplog/polling_oplog_change_notifier.cpp
+++ b/mooncake-store/src/ha/oplog/polling_oplog_change_notifier.cpp
@@ -1,0 +1,75 @@
+#include "ha/oplog/polling_oplog_change_notifier.h"
+
+#include <glog/logging.h>
+
+namespace mooncake {
+
+PollingOpLogChangeNotifier::PollingOpLogChangeNotifier(OpLogStore* store,
+                                                       int poll_interval_ms)
+    : store_(store), poll_interval_ms_(poll_interval_ms) {}
+
+PollingOpLogChangeNotifier::~PollingOpLogChangeNotifier() { Stop(); }
+
+ErrorCode PollingOpLogChangeNotifier::Start(uint64_t start_sequence_id,
+                                            EntryCallback on_entry,
+                                            ErrorCallback on_error) {
+    if (running_.load()) {
+        return ErrorCode::INTERNAL_ERROR;
+    }
+
+    on_entry_ = std::move(on_entry);
+    on_error_ = std::move(on_error);
+    last_sequence_id_.store(start_sequence_id);
+    running_.store(true);
+    healthy_.store(true);
+    poll_thread_ = std::thread(&PollingOpLogChangeNotifier::PollLoop, this);
+
+    return ErrorCode::OK;
+}
+
+void PollingOpLogChangeNotifier::Stop() {
+    running_.store(false);
+    stop_cv_.notify_all();
+    if (poll_thread_.joinable()) {
+        poll_thread_.join();
+    }
+    healthy_.store(false);
+}
+
+bool PollingOpLogChangeNotifier::IsHealthy() const {
+    return running_.load() && healthy_.load();
+}
+
+void PollingOpLogChangeNotifier::PollLoop() {
+    while (running_.load()) {
+        uint64_t last_seq = last_sequence_id_.load();
+        std::vector<OpLogEntry> entries;
+        auto err = store_->ReadOpLogSince(last_seq, kPollBatchSize, entries);
+
+        if (err == ErrorCode::OK && !entries.empty()) {
+            for (const auto& entry : entries) {
+                if (!running_.load()) break;
+                on_entry_(entry);
+            }
+            last_sequence_id_.store(entries.back().sequence_id);
+            healthy_.store(true);
+            // Data available — poll again immediately to drain backlog
+            continue;
+        } else if (err != ErrorCode::OK) {
+            if (on_error_) {
+                on_error_(err);
+            }
+            healthy_.store(false);
+        }
+
+        // Interruptible sleep: wakes immediately on Stop()
+        {
+            std::unique_lock<std::mutex> lock(stop_mutex_);
+            stop_cv_.wait_for(lock,
+                              std::chrono::milliseconds(poll_interval_ms_),
+                              [&] { return !running_.load(); });
+        }
+    }
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/ha_metric_manager.cpp
+++ b/mooncake-store/src/ha_metric_manager.cpp
@@ -1,0 +1,314 @@
+#include "ha_metric_manager.h"
+
+#include <glog/logging.h>
+
+#include <iomanip>
+#include <sstream>
+
+namespace mooncake {
+
+// --- Singleton Instance ---
+HAMetricManager& HAMetricManager::instance() {
+    static HAMetricManager static_instance;
+    return static_instance;
+}
+
+// --- Constructor ---
+HAMetricManager::HAMetricManager()
+    // OpLog Sequence Gauges
+    : oplog_last_sequence_id_("ha_oplog_last_sequence_id",
+                              "Latest OpLog sequence ID written by Primary"),
+      oplog_applied_sequence_id_("ha_oplog_applied_sequence_id",
+                                 "Latest OpLog sequence ID applied by Standby"),
+      oplog_standby_lag_("ha_oplog_standby_lag",
+                         "Number of OpLog entries Standby is behind Primary"),
+      oplog_pending_entries_(
+          "ha_oplog_pending_entries",
+          "Number of out-of-order entries waiting in OpLogApplier"),
+      pending_mutation_queue_size_(
+          "ha_pending_mutation_queue_size",
+          "Number of mutations pending etcd write retry"),
+
+      // Error Counters
+      oplog_skipped_entries_total_(
+          "ha_oplog_skipped_entries_total",
+          "Total number of OpLog entries skipped due to timeout"),
+      oplog_checksum_failures_total_(
+          "ha_oplog_checksum_failures_total",
+          "Total number of OpLog entries with checksum verification failures"),
+      oplog_gap_resolve_attempts_total_(
+          "ha_oplog_gap_resolve_attempts_total",
+          "Total number of attempts to resolve missing OpLog entries"),
+      oplog_gap_resolve_success_total_(
+          "ha_oplog_gap_resolve_success_total",
+          "Total number of successfully resolved missing OpLog entries"),
+      oplog_etcd_write_failures_total_(
+          "ha_oplog_etcd_write_failures_total",
+          "Total number of failed etcd write operations"),
+      oplog_etcd_write_retries_total_(
+          "ha_oplog_etcd_write_retries_total",
+          "Total number of etcd write retry attempts"),
+      oplog_watch_disconnections_total_(
+          "ha_oplog_watch_disconnections_total",
+          "Total number of OpLog watch disconnections"),
+      oplog_applied_entries_total_(
+          "ha_oplog_applied_entries_total",
+          "Total number of OpLog entries successfully applied"),
+      oplog_dropped_put_end_total_("ha_oplog_dropped_put_end_total",
+                                   "Total number of dropped PUT_END operations "
+                                   "due to late arrival after "
+                                   "skip"),
+      oplog_batch_commits_total_(
+          "ha_oplog_batch_commits_total",
+          "Total number of Group Commit batches flushed to etcd"),
+      oplog_sync_batch_commits_total_(
+          "ha_oplog_sync_batch_commits_total",
+          "Total number of sync batches (triggered by DELETE/Sync ops)"),
+
+      // Latency Histograms (buckets in microseconds)
+      // 100us, 500us, 1ms, 5ms, 10ms, 50ms, 100ms, 500ms, 1s, 5s
+      oplog_etcd_write_latency_us_(
+          "ha_oplog_etcd_write_latency_us",
+          "Latency of etcd write operations in microseconds",
+          {100, 500, 1000, 5000, 10000, 50000, 100000, 500000, 1000000,
+           5000000}),
+      oplog_apply_latency_us_(
+          "ha_oplog_apply_latency_us",
+          "Latency of OpLog entry application in microseconds",
+          {10, 50, 100, 500, 1000, 5000, 10000, 50000, 100000}),
+
+      // State Machine
+      standby_state_(
+          "ha_standby_state",
+          "Current state of the Standby service (0=STOPPED, 1=CONNECTING, "
+          "2=SYNCING, 3=WATCHING, 4=RECOVERING, 5=RECONNECTING, "
+          "6=PROMOTING, 7=PROMOTED, 8=FAILED)"),
+      state_transitions_total_(
+          "ha_state_transitions_total",
+          "Total number of Standby state machine transitions") {
+    // Initialize gauges to 0 for proper Prometheus output
+    oplog_last_sequence_id_.update(0);
+    oplog_applied_sequence_id_.update(0);
+    oplog_standby_lag_.update(0);
+    oplog_pending_entries_.update(0);
+    pending_mutation_queue_size_.update(0);
+    standby_state_.update(0);
+}
+
+// ========== OpLog Sequence Metrics (Gauge) ==========
+
+void HAMetricManager::set_oplog_last_sequence_id(int64_t seq_id) {
+    oplog_last_sequence_id_.update(seq_id);
+}
+
+int64_t HAMetricManager::get_oplog_last_sequence_id() {
+    return static_cast<int64_t>(oplog_last_sequence_id_.value());
+}
+
+void HAMetricManager::set_oplog_applied_sequence_id(int64_t seq_id) {
+    oplog_applied_sequence_id_.update(seq_id);
+}
+
+int64_t HAMetricManager::get_oplog_applied_sequence_id() {
+    return static_cast<int64_t>(oplog_applied_sequence_id_.value());
+}
+
+void HAMetricManager::set_oplog_standby_lag(int64_t lag) {
+    oplog_standby_lag_.update(lag);
+}
+
+int64_t HAMetricManager::get_oplog_standby_lag() {
+    return static_cast<int64_t>(oplog_standby_lag_.value());
+}
+
+void HAMetricManager::set_oplog_pending_entries(int64_t count) {
+    oplog_pending_entries_.update(count);
+}
+
+int64_t HAMetricManager::get_oplog_pending_entries() {
+    return static_cast<int64_t>(oplog_pending_entries_.value());
+}
+
+void HAMetricManager::set_pending_mutation_queue_size(int64_t size) {
+    pending_mutation_queue_size_.update(size);
+}
+
+int64_t HAMetricManager::get_pending_mutation_queue_size() {
+    return static_cast<int64_t>(pending_mutation_queue_size_.value());
+}
+
+// ========== Error Counters ==========
+
+void HAMetricManager::inc_oplog_skipped_entries(int64_t val) {
+    oplog_skipped_entries_total_.inc(val);
+}
+
+int64_t HAMetricManager::get_oplog_skipped_entries_total() {
+    return static_cast<int64_t>(oplog_skipped_entries_total_.value());
+}
+
+void HAMetricManager::inc_oplog_checksum_failures(int64_t val) {
+    oplog_checksum_failures_total_.inc(val);
+}
+
+int64_t HAMetricManager::get_oplog_checksum_failures_total() {
+    return static_cast<int64_t>(oplog_checksum_failures_total_.value());
+}
+
+void HAMetricManager::inc_oplog_gap_resolve_attempts(int64_t val) {
+    oplog_gap_resolve_attempts_total_.inc(val);
+}
+
+int64_t HAMetricManager::get_oplog_gap_resolve_attempts_total() {
+    return static_cast<int64_t>(oplog_gap_resolve_attempts_total_.value());
+}
+
+void HAMetricManager::inc_oplog_gap_resolve_success(int64_t val) {
+    oplog_gap_resolve_success_total_.inc(val);
+}
+
+int64_t HAMetricManager::get_oplog_gap_resolve_success_total() {
+    return static_cast<int64_t>(oplog_gap_resolve_success_total_.value());
+}
+
+void HAMetricManager::inc_oplog_etcd_write_failures(int64_t val) {
+    oplog_etcd_write_failures_total_.inc(val);
+}
+
+int64_t HAMetricManager::get_oplog_etcd_write_failures_total() {
+    return static_cast<int64_t>(oplog_etcd_write_failures_total_.value());
+}
+
+void HAMetricManager::inc_oplog_etcd_write_retries(int64_t val) {
+    oplog_etcd_write_retries_total_.inc(val);
+}
+
+int64_t HAMetricManager::get_oplog_etcd_write_retries_total() {
+    return static_cast<int64_t>(oplog_etcd_write_retries_total_.value());
+}
+
+void HAMetricManager::inc_oplog_watch_disconnections(int64_t val) {
+    oplog_watch_disconnections_total_.inc(val);
+}
+
+int64_t HAMetricManager::get_oplog_watch_disconnections_total() {
+    return static_cast<int64_t>(oplog_watch_disconnections_total_.value());
+}
+
+void HAMetricManager::inc_oplog_applied_entries(int64_t val) {
+    oplog_applied_entries_total_.inc(val);
+}
+
+int64_t HAMetricManager::get_oplog_applied_entries_total() {
+    return static_cast<int64_t>(oplog_applied_entries_total_.value());
+}
+
+void HAMetricManager::inc_oplog_dropped_put_end(int64_t val) {
+    oplog_dropped_put_end_total_.inc(val);
+}
+
+int64_t HAMetricManager::get_oplog_dropped_put_end_total() {
+    return static_cast<int64_t>(oplog_dropped_put_end_total_.value());
+}
+
+void HAMetricManager::inc_oplog_batch_commits(int64_t val) {
+    oplog_batch_commits_total_.inc(val);
+}
+
+void HAMetricManager::inc_oplog_sync_batch_commits(int64_t val) {
+    oplog_sync_batch_commits_total_.inc(val);
+}
+
+int64_t HAMetricManager::get_oplog_batch_commits_total() {
+    return static_cast<int64_t>(oplog_batch_commits_total_.value());
+}
+
+int64_t HAMetricManager::get_oplog_sync_batch_commits_total() {
+    return static_cast<int64_t>(oplog_sync_batch_commits_total_.value());
+}
+
+// ========== Latency Histograms ==========
+
+void HAMetricManager::observe_oplog_etcd_write_latency_us(int64_t latency_us) {
+    oplog_etcd_write_latency_us_.observe(latency_us);
+}
+
+void HAMetricManager::observe_oplog_apply_latency_us(int64_t latency_us) {
+    oplog_apply_latency_us_.observe(latency_us);
+}
+
+// ========== State Machine Metrics ==========
+
+void HAMetricManager::set_standby_state(int64_t state_value) {
+    standby_state_.update(state_value);
+}
+
+int64_t HAMetricManager::get_standby_state() {
+    return static_cast<int64_t>(standby_state_.value());
+}
+
+void HAMetricManager::inc_state_transitions(int64_t val) {
+    state_transitions_total_.inc(val);
+}
+
+int64_t HAMetricManager::get_state_transitions_total() {
+    return static_cast<int64_t>(state_transitions_total_.value());
+}
+
+// ========== Serialization ==========
+
+std::string HAMetricManager::serialize_metrics() {
+    std::stringstream ss;
+
+    // Helper lambda to serialize a metric
+    auto serialize_metric = [&ss](auto& metric) {
+        std::string metric_str;
+        metric.serialize(metric_str);
+        ss << metric_str;
+    };
+
+    // Gauges
+    serialize_metric(oplog_last_sequence_id_);
+    serialize_metric(oplog_applied_sequence_id_);
+    serialize_metric(oplog_standby_lag_);
+    serialize_metric(oplog_pending_entries_);
+    serialize_metric(pending_mutation_queue_size_);
+    serialize_metric(standby_state_);
+
+    // Counters
+    serialize_metric(oplog_skipped_entries_total_);
+    serialize_metric(oplog_checksum_failures_total_);
+    serialize_metric(oplog_gap_resolve_attempts_total_);
+    serialize_metric(oplog_gap_resolve_success_total_);
+    serialize_metric(oplog_etcd_write_failures_total_);
+    serialize_metric(oplog_etcd_write_retries_total_);
+    serialize_metric(oplog_watch_disconnections_total_);
+    serialize_metric(oplog_applied_entries_total_);
+    serialize_metric(state_transitions_total_);
+
+    // Histograms
+    serialize_metric(oplog_etcd_write_latency_us_);
+    serialize_metric(oplog_apply_latency_us_);
+
+    return ss.str();
+}
+
+std::string HAMetricManager::get_summary_string() {
+    std::stringstream ss;
+    ss << "HA Metrics Summary: ";
+    ss << "last_seq=" << get_oplog_last_sequence_id();
+    ss << ", applied_seq=" << get_oplog_applied_sequence_id();
+    ss << ", lag=" << get_oplog_standby_lag();
+    ss << ", pending=" << get_oplog_pending_entries();
+    ss << ", mutation_queue=" << get_pending_mutation_queue_size();
+    ss << ", batch_commits=" << get_oplog_batch_commits_total();
+    ss << ", sync_commits=" << get_oplog_sync_batch_commits_total();
+    ss << ", skipped=" << get_oplog_skipped_entries_total();
+    ss << ", checksum_fail=" << get_oplog_checksum_failures_total();
+    ss << ", etcd_fail=" << get_oplog_etcd_write_failures_total();
+    ss << ", watch_disconn=" << get_oplog_watch_disconnections_total();
+    ss << ", state=" << get_standby_state();
+    return ss.str();
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/standby_state_machine.cpp
+++ b/mooncake-store/src/standby_state_machine.cpp
@@ -1,0 +1,301 @@
+#include "standby_state_machine.h"
+
+#include <glog/logging.h>
+
+namespace mooncake {
+
+StandbyStateMachine::StandbyStateMachine()
+    : state_enter_time_(std::chrono::steady_clock::now()) {}
+
+StateTransitionResult StandbyStateMachine::ValidateTransition(
+    StandbyState from, StandbyEvent event) const {
+    StateTransitionResult result;
+    result.allowed = false;
+    result.old_state = from;
+    result.new_state = from;
+
+    // State transition table
+    switch (from) {
+        case StandbyState::STOPPED:
+            if (event == StandbyEvent::START) {
+                result.allowed = true;
+                result.new_state = StandbyState::CONNECTING;
+            }
+            break;
+
+        case StandbyState::CONNECTING:
+            switch (event) {
+                case StandbyEvent::CONNECTED:
+                    result.allowed = true;
+                    result.new_state = StandbyState::SYNCING;
+                    break;
+                case StandbyEvent::CONNECTION_FAILED:
+                case StandbyEvent::FATAL_ERROR:
+                    result.allowed = true;
+                    result.new_state = StandbyState::FAILED;
+                    break;
+                case StandbyEvent::STOP:
+                    result.allowed = true;
+                    result.new_state = StandbyState::STOPPED;
+                    break;
+                default:
+                    break;
+            }
+            break;
+
+        case StandbyState::SYNCING:
+            switch (event) {
+                case StandbyEvent::SYNC_COMPLETE:
+                    result.allowed = true;
+                    result.new_state = StandbyState::WATCHING;
+                    break;
+                case StandbyEvent::SYNC_FAILED:
+                case StandbyEvent::DISCONNECTED:
+                    result.allowed = true;
+                    result.new_state = StandbyState::RECONNECTING;
+                    break;
+                case StandbyEvent::STOP:
+                    result.allowed = true;
+                    result.new_state = StandbyState::STOPPED;
+                    break;
+                case StandbyEvent::FATAL_ERROR:
+                    result.allowed = true;
+                    result.new_state = StandbyState::FAILED;
+                    break;
+                default:
+                    break;
+            }
+            break;
+
+        case StandbyState::WATCHING:
+            switch (event) {
+                case StandbyEvent::WATCH_BROKEN:
+                case StandbyEvent::DISCONNECTED:
+                    result.allowed = true;
+                    result.new_state = StandbyState::RECONNECTING;
+                    break;
+                case StandbyEvent::MAX_ERRORS_REACHED:
+                    result.allowed = true;
+                    result.new_state = StandbyState::RECOVERING;
+                    break;
+                case StandbyEvent::PROMOTE:
+                    result.allowed = true;
+                    result.new_state = StandbyState::PROMOTING;
+                    break;
+                case StandbyEvent::STOP:
+                    result.allowed = true;
+                    result.new_state = StandbyState::STOPPED;
+                    break;
+                case StandbyEvent::FATAL_ERROR:
+                    result.allowed = true;
+                    result.new_state = StandbyState::FAILED;
+                    break;
+                // WATCH_HEALTHY in WATCHING state is a no-op (stay in WATCHING)
+                case StandbyEvent::WATCH_HEALTHY:
+                    result.allowed = true;
+                    result.new_state = StandbyState::WATCHING;
+                    break;
+                default:
+                    break;
+            }
+            break;
+
+        case StandbyState::RECOVERING:
+            switch (event) {
+                case StandbyEvent::RECOVERY_SUCCESS:
+                    result.allowed = true;
+                    result.new_state = StandbyState::WATCHING;
+                    break;
+                case StandbyEvent::RECOVERY_FAILED:
+                case StandbyEvent::DISCONNECTED:
+                    result.allowed = true;
+                    result.new_state = StandbyState::RECONNECTING;
+                    break;
+                case StandbyEvent::STOP:
+                    result.allowed = true;
+                    result.new_state = StandbyState::STOPPED;
+                    break;
+                case StandbyEvent::FATAL_ERROR:
+                    result.allowed = true;
+                    result.new_state = StandbyState::FAILED;
+                    break;
+                default:
+                    break;
+            }
+            break;
+
+        case StandbyState::RECONNECTING:
+            switch (event) {
+                case StandbyEvent::CONNECTED:
+                    result.allowed = true;
+                    result.new_state = StandbyState::SYNCING;
+                    break;
+                case StandbyEvent::WATCH_HEALTHY:
+                    // Watch successfully re-established after reconnect
+                    result.allowed = true;
+                    result.new_state = StandbyState::WATCHING;
+                    break;
+                case StandbyEvent::RECOVERY_SUCCESS:
+                    // Missed entries synced — ready to watch again
+                    result.allowed = true;
+                    result.new_state = StandbyState::WATCHING;
+                    break;
+                case StandbyEvent::RECOVERY_FAILED:
+                    // Sync failed — stay in RECONNECTING and retry
+                    result.allowed = true;
+                    result.new_state = StandbyState::RECONNECTING;
+                    break;
+                case StandbyEvent::MAX_ERRORS_REACHED:
+                case StandbyEvent::FATAL_ERROR:
+                    result.allowed = true;
+                    result.new_state = StandbyState::FAILED;
+                    break;
+                case StandbyEvent::STOP:
+                    result.allowed = true;
+                    result.new_state = StandbyState::STOPPED;
+                    break;
+                default:
+                    break;
+            }
+            break;
+
+        case StandbyState::PROMOTING:
+            switch (event) {
+                case StandbyEvent::PROMOTION_SUCCESS:
+                    result.allowed = true;
+                    result.new_state = StandbyState::PROMOTED;
+                    break;
+                case StandbyEvent::PROMOTION_FAILED:
+                    result.allowed = true;
+                    result.new_state = StandbyState::FAILED;
+                    break;
+                case StandbyEvent::STOP:
+                    result.allowed = true;
+                    result.new_state = StandbyState::STOPPED;
+                    break;
+                default:
+                    break;
+            }
+            break;
+
+        case StandbyState::PROMOTED:
+            if (event == StandbyEvent::STOP) {
+                result.allowed = true;
+                result.new_state = StandbyState::STOPPED;
+            }
+            break;
+
+        case StandbyState::FAILED:
+            if (event == StandbyEvent::STOP) {
+                result.allowed = true;
+                result.new_state = StandbyState::STOPPED;
+            } else if (event == StandbyEvent::START) {
+                // Allow restart from FAILED state
+                result.allowed = true;
+                result.new_state = StandbyState::CONNECTING;
+            }
+            break;
+    }
+
+    if (!result.allowed) {
+        result.reason = std::string("Invalid transition from ") +
+                        StandbyStateToString(from) + " on event " +
+                        StandbyEventToString(event);
+    }
+
+    return result;
+}
+
+StateTransitionResult StandbyStateMachine::ProcessEvent(StandbyEvent event) {
+    StandbyState old_state = current_state_.load(std::memory_order_acquire);
+    StateTransitionResult result = ValidateTransition(old_state, event);
+
+    std::vector<StateChangeCallback> callbacks_copy;
+    if (result.allowed && result.new_state != old_state) {
+        std::lock_guard<std::mutex> lock(mutex_);
+
+        // Double-check state hasn't changed (compare-and-swap pattern)
+        StandbyState current = current_state_.load(std::memory_order_acquire);
+        if (current != old_state) {
+            // State changed by another thread, re-validate
+            result = ValidateTransition(current, event);
+            old_state = current;
+            result.old_state = current;
+            if (!result.allowed || result.new_state == old_state) {
+                return result;
+            }
+        }
+
+        // Record transition
+        TransitionRecord record;
+        record.timestamp = std::chrono::steady_clock::now();
+        record.from_state = old_state;
+        record.to_state = result.new_state;
+        record.event = event;
+
+        transition_history_.push_back(record);
+        if (transition_history_.size() > kMaxHistorySize) {
+            transition_history_.erase(transition_history_.begin());
+        }
+
+        // Update state
+        current_state_.store(result.new_state, std::memory_order_release);
+        state_enter_time_ = record.timestamp;
+
+        LOG(INFO) << "Standby state transition: "
+                  << StandbyStateToString(old_state) << " -> "
+                  << StandbyStateToString(result.new_state)
+                  << " (event: " << StandbyEventToString(event) << ")";
+
+        // Copy callbacks while holding the lock; invoke them after releasing
+        // the lock to avoid deadlock (callbacks may re-enter ProcessEvent).
+        callbacks_copy = callbacks_;
+    } else if (!result.allowed) {
+        VLOG(1) << "Standby state transition rejected: " << result.reason;
+    }
+
+    // Notify callbacks outside the lock to avoid deadlock when callbacks
+    // re-enter ProcessEvent (e.g. IncrementErrors -> MAX_ERRORS_REACHED).
+    for (const auto& callback : callbacks_copy) {
+        if (callback) {
+            callback(old_state, result.new_state, event);
+        }
+    }
+
+    return result;
+}
+
+void StandbyStateMachine::RegisterCallback(StateChangeCallback callback) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    callbacks_.push_back(std::move(callback));
+}
+
+std::vector<StandbyStateMachine::TransitionRecord>
+StandbyStateMachine::GetTransitionHistory(size_t max_records) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    if (transition_history_.size() <= max_records) {
+        return transition_history_;
+    }
+
+    return std::vector<TransitionRecord>(
+        transition_history_.end() - max_records, transition_history_.end());
+}
+
+std::chrono::milliseconds StandbyStateMachine::GetTimeInCurrentState() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto now = std::chrono::steady_clock::now();
+    return std::chrono::duration_cast<std::chrono::milliseconds>(
+        now - state_enter_time_);
+}
+
+int StandbyStateMachine::IncrementErrors() {
+    int new_count = consecutive_errors_.fetch_add(1) + 1;
+    if (new_count >= kMaxConsecutiveErrors) {
+        // Trigger MAX_ERRORS_REACHED event
+        ProcessEvent(StandbyEvent::MAX_ERRORS_REACHED);
+    }
+    return new_count;
+}
+
+}  // namespace mooncake

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -63,6 +63,13 @@ add_store_test(async_metadata_notifier_test async_metadata_notifier_test.cpp)
 add_store_test(ha_recovery_manager_test ha_recovery_manager_test.cpp)
 add_store_test(ha_integration_test ha_integration_test.cpp)
 add_store_test(task_manager_test task_manager_test.cpp)
+
+# HA OpLog ported tests
+add_store_test(oplog_manager_test ha/oplog/oplog_manager_test.cpp)
+add_store_test(oplog_serializer_test ha/oplog/oplog_serializer_test.cpp)
+add_store_test(localfs_oplog_store_test ha/oplog/localfs_oplog_store_test.cpp)
+add_store_test(standby_state_machine_test ha/oplog/standby_state_machine_test.cpp)
+add_store_test(ha_metric_manager_test ha/oplog/ha_metric_manager_test.cpp)
 add_subdirectory(e2e)
 
 add_executable(high_availability_test high_availability_test.cpp)

--- a/mooncake-store/tests/ha/oplog/ha_metric_manager_test.cpp
+++ b/mooncake-store/tests/ha/oplog/ha_metric_manager_test.cpp
@@ -1,0 +1,181 @@
+#include "ha_metric_manager.h"
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <string>
+#include <thread>
+
+namespace mooncake::test {
+
+class HAMetricManagerTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        google::InitGoogleLogging("HAMetricManagerTest");
+        FLAGS_logtostderr = 1;
+    }
+
+    void TearDown() override { google::ShutdownGoogleLogging(); }
+
+    HAMetricManager& M() { return HAMetricManager::instance(); }
+};
+
+// ========== 7.1.1 Metric update tests ==========
+
+TEST_F(HAMetricManagerTest, TestSetOpLogLastSequenceId) {
+    M().set_oplog_last_sequence_id(123);
+    EXPECT_EQ(123, M().get_oplog_last_sequence_id());
+}
+
+TEST_F(HAMetricManagerTest, TestSetOpLogAppliedSequenceId) {
+    M().set_oplog_applied_sequence_id(456);
+    EXPECT_EQ(456, M().get_oplog_applied_sequence_id());
+}
+
+TEST_F(HAMetricManagerTest, TestSetOpLogStandbyLag) {
+    M().set_oplog_standby_lag(10);
+    EXPECT_EQ(10, M().get_oplog_standby_lag());
+}
+
+TEST_F(HAMetricManagerTest, TestSetOpLogPendingEntries) {
+    M().set_oplog_pending_entries(7);
+    EXPECT_EQ(7, M().get_oplog_pending_entries());
+}
+
+TEST_F(HAMetricManagerTest, TestSetPendingMutationQueueSize) {
+    M().set_pending_mutation_queue_size(5);
+    EXPECT_EQ(5, M().get_pending_mutation_queue_size());
+}
+
+TEST_F(HAMetricManagerTest, TestIncOpLogSkippedEntries) {
+    auto before = M().get_oplog_skipped_entries_total();
+    M().inc_oplog_skipped_entries();
+    EXPECT_EQ(before + 1, M().get_oplog_skipped_entries_total());
+}
+
+TEST_F(HAMetricManagerTest, TestIncOpLogChecksumFailures) {
+    auto before = M().get_oplog_checksum_failures_total();
+    M().inc_oplog_checksum_failures(2);
+    EXPECT_EQ(before + 2, M().get_oplog_checksum_failures_total());
+}
+
+TEST_F(HAMetricManagerTest, TestIncGapResolveCounters) {
+    auto before_attempts = M().get_oplog_gap_resolve_attempts_total();
+    auto before_success = M().get_oplog_gap_resolve_success_total();
+
+    M().inc_oplog_gap_resolve_attempts(3);
+    M().inc_oplog_gap_resolve_success(1);
+
+    EXPECT_EQ(before_attempts + 3, M().get_oplog_gap_resolve_attempts_total());
+    EXPECT_EQ(before_success + 1, M().get_oplog_gap_resolve_success_total());
+}
+
+TEST_F(HAMetricManagerTest, TestIncOpLogEtcdWriteFailuresAndRetries) {
+    auto before_failures = M().get_oplog_etcd_write_failures_total();
+    auto before_retries = M().get_oplog_etcd_write_retries_total();
+
+    M().inc_oplog_etcd_write_failures(4);
+    M().inc_oplog_etcd_write_retries(5);
+
+    EXPECT_EQ(before_failures + 4, M().get_oplog_etcd_write_failures_total());
+    EXPECT_EQ(before_retries + 5, M().get_oplog_etcd_write_retries_total());
+}
+
+TEST_F(HAMetricManagerTest, TestIncWatchDisconnectionsAndAppliedEntries) {
+    auto before_disc = M().get_oplog_watch_disconnections_total();
+    auto before_applied = M().get_oplog_applied_entries_total();
+
+    M().inc_oplog_watch_disconnections(2);
+    M().inc_oplog_applied_entries(10);
+
+    EXPECT_EQ(before_disc + 2, M().get_oplog_watch_disconnections_total());
+    EXPECT_EQ(before_applied + 10, M().get_oplog_applied_entries_total());
+}
+
+TEST_F(HAMetricManagerTest, TestRecordOpLogEtcdWriteLatency) {
+    // Call histogram observe functions, mainly to ensure they do not crash
+    M().observe_oplog_etcd_write_latency_us(100);
+    M().observe_oplog_etcd_write_latency_us(5000);
+    SUCCEED();
+}
+
+TEST_F(HAMetricManagerTest, TestRecordOpLogApplyLatency) {
+    M().observe_oplog_apply_latency_us(50);
+    M().observe_oplog_apply_latency_us(1000);
+    SUCCEED();
+}
+
+// ========== 7.1.2 Metric serialization tests ==========
+
+TEST_F(HAMetricManagerTest, TestSerializeMetrics) {
+    M().set_oplog_last_sequence_id(1);
+    M().set_oplog_applied_sequence_id(1);
+    M().set_oplog_standby_lag(0);
+
+    std::string text = M().serialize_metrics();
+    EXPECT_FALSE(text.empty());
+
+    // Basic fields should appear in the Prometheus text output
+    EXPECT_NE(std::string::npos, text.find("ha_oplog_last_sequence_id"));
+    EXPECT_NE(std::string::npos, text.find("ha_oplog_applied_sequence_id"));
+    EXPECT_NE(std::string::npos, text.find("ha_oplog_standby_lag"));
+}
+
+TEST_F(HAMetricManagerTest, TestGetSummaryString) {
+    M().set_oplog_last_sequence_id(100);
+    M().set_oplog_applied_sequence_id(95);
+    M().set_oplog_standby_lag(5);
+
+    std::string summary = M().get_summary_string();
+    EXPECT_FALSE(summary.empty());
+    // Summary string should contain key fields
+    EXPECT_NE(std::string::npos, summary.find("last_seq"));
+    EXPECT_NE(std::string::npos, summary.find("applied_seq"));
+}
+
+// ========== 7.1.3 Singleton tests ==========
+
+TEST_F(HAMetricManagerTest, TestSingletonInstance) {
+    HAMetricManager& a = HAMetricManager::instance();
+    HAMetricManager& b = HAMetricManager::instance();
+
+    EXPECT_EQ(&a, &b);
+
+    a.set_oplog_last_sequence_id(1234);
+    EXPECT_EQ(1234, b.get_oplog_last_sequence_id());
+}
+
+TEST_F(HAMetricManagerTest, TestConcurrentAccess) {
+    constexpr int kThreads = 8;
+    constexpr int kIncrementsPerThread = 1000;
+
+    auto& mgr = HAMetricManager::instance();
+    auto before = mgr.get_oplog_applied_entries_total();
+
+    std::vector<std::thread> threads;
+    threads.reserve(kThreads);
+
+    for (int i = 0; i < kThreads; ++i) {
+        threads.emplace_back([&mgr]() {
+            for (int j = 0; j < kIncrementsPerThread; ++j) {
+                mgr.inc_oplog_applied_entries();
+            }
+        });
+    }
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    auto after = mgr.get_oplog_applied_entries_total();
+    EXPECT_EQ(before + kThreads * kIncrementsPerThread, after);
+}
+
+}  // namespace mooncake::test
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/mooncake-store/tests/ha/oplog/localfs_oplog_store_test.cpp
+++ b/mooncake-store/tests/ha/oplog/localfs_oplog_store_test.cpp
@@ -1,0 +1,567 @@
+#include <gtest/gtest.h>
+#include <glog/logging.h>
+#include <filesystem>
+#include <fstream>
+
+#include "ha/oplog/localfs_oplog_store.h"
+#include "ha/oplog/oplog_store_factory.h"
+
+namespace fs = std::filesystem;
+
+namespace mooncake {
+namespace {
+
+class LocalFsOpLogStoreTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        test_dir_ = "/tmp/localfs_oplog_test_" + std::to_string(::getpid()) +
+                    "_" + std::to_string(test_counter_++);
+        fs::create_directories(test_dir_);
+        cluster_id_ = "test_cluster";
+    }
+
+    void TearDown() override { fs::remove_all(test_dir_); }
+
+    std::unique_ptr<LocalFsOpLogStore> CreateWriter() {
+        auto store = std::make_unique<LocalFsOpLogStore>(
+            cluster_id_, test_dir_, /*enable_batch_write=*/true);
+        EXPECT_EQ(ErrorCode::OK, store->Init());
+        return store;
+    }
+
+    std::unique_ptr<LocalFsOpLogStore> CreateReader() {
+        auto store = std::make_unique<LocalFsOpLogStore>(
+            cluster_id_, test_dir_, /*enable_batch_write=*/false);
+        EXPECT_EQ(ErrorCode::OK, store->Init());
+        return store;
+    }
+
+    OpLogEntry MakeEntry(uint64_t seq_id, const std::string& key = "test_key") {
+        OpLogEntry entry;
+        entry.sequence_id = seq_id;
+        entry.op_type = OpType::PUT_END;
+        entry.object_key = key;
+        entry.payload = "payload_" + std::to_string(seq_id);
+        return entry;
+    }
+
+    std::string test_dir_;
+    std::string cluster_id_;
+    static inline int test_counter_ = 0;
+};
+
+// --- Init tests ---
+
+TEST_F(LocalFsOpLogStoreTest, InitCreatesDirectoryStructure) {
+    auto store = CreateWriter();
+    EXPECT_TRUE(fs::exists(test_dir_ + "/" + cluster_id_ + "/segments"));
+    // snapshots dir is created lazily on first RecordSnapshotSequenceId
+    EXPECT_FALSE(fs::exists(test_dir_ + "/" + cluster_id_ + "/snapshots"));
+    EXPECT_TRUE(fs::exists(test_dir_ + "/" + cluster_id_ + "/latest"));
+}
+
+TEST_F(LocalFsOpLogStoreTest, InitWriterCreatesLatestFile) {
+    auto store = CreateWriter();
+    std::string latest_path = test_dir_ + "/" + cluster_id_ + "/latest";
+    std::ifstream f(latest_path);
+    std::string content;
+    f >> content;
+    EXPECT_EQ("0", content);
+}
+
+TEST_F(LocalFsOpLogStoreTest, InitReaderDoesNotCreateLatestFile) {
+    // Remove the test dir so Init starts fresh
+    fs::remove_all(test_dir_);
+    fs::create_directories(test_dir_);
+    auto store = std::make_unique<LocalFsOpLogStore>(
+        cluster_id_, test_dir_, /*enable_batch_write=*/false);
+    EXPECT_EQ(ErrorCode::OK, store->Init());
+    // Reader should create dirs but NOT create latest file
+    EXPECT_TRUE(fs::exists(test_dir_ + "/" + cluster_id_ + "/segments"));
+    EXPECT_FALSE(fs::exists(test_dir_ + "/" + cluster_id_ + "/latest"));
+}
+
+TEST_F(LocalFsOpLogStoreTest, InitCleansTmpFiles) {
+    // Create directory structure manually
+    std::string seg_dir = test_dir_ + "/" + cluster_id_ + "/segments";
+    fs::create_directories(seg_dir);
+    // Create a stale .tmp file
+    std::ofstream(seg_dir +
+                  "/seg_00000000000000000001_00000000000000000010.tmp")
+        << "stale data";
+    EXPECT_TRUE(fs::exists(
+        seg_dir + "/seg_00000000000000000001_00000000000000000010.tmp"));
+
+    auto store = CreateWriter();
+    EXPECT_FALSE(fs::exists(
+        seg_dir + "/seg_00000000000000000001_00000000000000000010.tmp"));
+}
+
+// --- Write tests ---
+
+TEST_F(LocalFsOpLogStoreTest, WriteSyncEntry) {
+    auto store = CreateWriter();
+    auto entry = MakeEntry(1);
+    EXPECT_EQ(ErrorCode::OK, store->WriteOpLog(entry, /*sync=*/true));
+
+    // Verify it was flushed to a segment file
+    auto segments_path = test_dir_ + "/" + cluster_id_ + "/segments";
+    int file_count = 0;
+    for (auto& p : fs::directory_iterator(segments_path)) {
+        if (p.path().extension() != ".tmp") file_count++;
+    }
+    EXPECT_GE(file_count, 1);
+}
+
+TEST_F(LocalFsOpLogStoreTest, WriteAsyncBatchFlush) {
+    auto store = CreateWriter();
+    // Write several async entries
+    for (uint64_t i = 1; i <= 5; i++) {
+        EXPECT_EQ(ErrorCode::OK,
+                  store->WriteOpLog(MakeEntry(i), /*sync=*/false));
+    }
+    // Force flush by writing a sync entry
+    EXPECT_EQ(ErrorCode::OK, store->WriteOpLog(MakeEntry(6), /*sync=*/true));
+
+    // All entries should be readable
+    OpLogEntry read_entry;
+    for (uint64_t i = 1; i <= 6; i++) {
+        EXPECT_EQ(ErrorCode::OK, store->ReadOpLog(i, read_entry));
+        EXPECT_EQ(i, read_entry.sequence_id);
+    }
+}
+
+TEST_F(LocalFsOpLogStoreTest, WriteReaderReturnsError) {
+    auto store = CreateReader();
+    auto entry = MakeEntry(1);
+    EXPECT_EQ(ErrorCode::INVALID_PARAMS, store->WriteOpLog(entry, true));
+}
+
+TEST_F(LocalFsOpLogStoreTest, WriteUpdatesLatestFile) {
+    auto store = CreateWriter();
+    for (uint64_t i = 1; i <= 3; i++) {
+        store->WriteOpLog(MakeEntry(i), /*sync=*/false);
+    }
+    store->WriteOpLog(MakeEntry(4), /*sync=*/true);
+
+    uint64_t latest = 0;
+    EXPECT_EQ(ErrorCode::OK, store->GetLatestSequenceId(latest));
+    EXPECT_EQ(4, latest);
+}
+
+TEST_F(LocalFsOpLogStoreTest, WriteOutOfOrderBatchStillReadableBySequenceId) {
+    auto store = CreateWriter();
+
+    EXPECT_EQ(ErrorCode::OK, store->WriteOpLog(MakeEntry(2), /*sync=*/false));
+    EXPECT_EQ(ErrorCode::OK, store->WriteOpLog(MakeEntry(1), /*sync=*/true));
+
+    OpLogEntry entry1;
+    OpLogEntry entry2;
+    EXPECT_EQ(ErrorCode::OK, store->ReadOpLog(1, entry1));
+    EXPECT_EQ(ErrorCode::OK, store->ReadOpLog(2, entry2));
+    EXPECT_EQ(1u, entry1.sequence_id);
+    EXPECT_EQ(2u, entry2.sequence_id);
+
+    std::vector<OpLogEntry> entries;
+    EXPECT_EQ(ErrorCode::OK, store->ReadOpLogSince(0, 10, entries));
+    ASSERT_EQ(2u, entries.size());
+    EXPECT_EQ(1u, entries[0].sequence_id);
+    EXPECT_EQ(2u, entries[1].sequence_id);
+}
+
+TEST_F(LocalFsOpLogStoreTest,
+       RewritePersistedSequenceWithDifferentPayloadFails) {
+    auto store = CreateWriter();
+    auto entry = MakeEntry(1);
+    ASSERT_EQ(ErrorCode::OK, store->WriteOpLog(entry, /*sync=*/true));
+
+    auto conflicting = entry;
+    conflicting.payload = "different_payload";
+    EXPECT_NE(ErrorCode::OK, store->WriteOpLog(conflicting, /*sync=*/true));
+
+    OpLogEntry persisted;
+    ASSERT_EQ(ErrorCode::OK, store->ReadOpLog(1, persisted));
+    EXPECT_EQ(entry.payload, persisted.payload);
+}
+
+TEST_F(LocalFsOpLogStoreTest,
+       RewritePersistedSequenceAfterRestartWithDifferentPayloadFails) {
+    {
+        auto store = CreateWriter();
+        auto entry = MakeEntry(1);
+        ASSERT_EQ(ErrorCode::OK, store->WriteOpLog(entry, /*sync=*/true));
+    }
+
+    auto reopened = CreateWriter();
+    auto conflicting = MakeEntry(1);
+    conflicting.payload = "payload_after_restart_conflict";
+    EXPECT_NE(ErrorCode::OK, reopened->WriteOpLog(conflicting, /*sync=*/true));
+
+    OpLogEntry persisted;
+    ASSERT_EQ(ErrorCode::OK, reopened->ReadOpLog(1, persisted));
+    EXPECT_EQ("payload_1", persisted.payload);
+}
+
+// --- Read tests ---
+
+TEST_F(LocalFsOpLogStoreTest, ReadOpLogSingleEntry) {
+    auto store = CreateWriter();
+    store->WriteOpLog(MakeEntry(1), true);
+
+    OpLogEntry entry;
+    EXPECT_EQ(ErrorCode::OK, store->ReadOpLog(1, entry));
+    EXPECT_EQ(1, entry.sequence_id);
+    EXPECT_EQ("test_key", entry.object_key);
+}
+
+TEST_F(LocalFsOpLogStoreTest, ReadOpLogNotFound) {
+    auto store = CreateWriter();
+    OpLogEntry entry;
+    EXPECT_EQ(ErrorCode::OPLOG_ENTRY_NOT_FOUND, store->ReadOpLog(999, entry));
+}
+
+TEST_F(LocalFsOpLogStoreTest, ReadOpLogSinceBasic) {
+    auto store = CreateWriter();
+    for (uint64_t i = 1; i <= 10; i++) {
+        store->WriteOpLog(MakeEntry(i), /*sync=*/(i == 10));
+    }
+
+    std::vector<OpLogEntry> entries;
+    EXPECT_EQ(ErrorCode::OK, store->ReadOpLogSince(0, 100, entries));
+    EXPECT_EQ(10, entries.size());
+    EXPECT_EQ(1, entries.front().sequence_id);
+    EXPECT_EQ(10, entries.back().sequence_id);
+}
+
+TEST_F(LocalFsOpLogStoreTest, ReadOpLogSinceWithOffset) {
+    auto store = CreateWriter();
+    for (uint64_t i = 1; i <= 10; i++) {
+        store->WriteOpLog(MakeEntry(i), /*sync=*/(i == 10));
+    }
+
+    std::vector<OpLogEntry> entries;
+    EXPECT_EQ(ErrorCode::OK, store->ReadOpLogSince(5, 100, entries));
+    EXPECT_EQ(5, entries.size());
+    EXPECT_EQ(6, entries.front().sequence_id);
+}
+
+TEST_F(LocalFsOpLogStoreTest, ReadOpLogSinceWithLimit) {
+    auto store = CreateWriter();
+    for (uint64_t i = 1; i <= 10; i++) {
+        store->WriteOpLog(MakeEntry(i), /*sync=*/(i == 10));
+    }
+
+    std::vector<OpLogEntry> entries;
+    EXPECT_EQ(ErrorCode::OK, store->ReadOpLogSince(0, 3, entries));
+    EXPECT_EQ(3, entries.size());
+}
+
+TEST_F(LocalFsOpLogStoreTest, ReadOpLogSinceAcrossSegments) {
+    auto store = CreateWriter();
+    // Write entries with sync=true to force separate segments
+    for (uint64_t i = 1; i <= 3; i++) {
+        store->WriteOpLog(MakeEntry(i), /*sync=*/true);
+    }
+
+    std::vector<OpLogEntry> entries;
+    EXPECT_EQ(ErrorCode::OK, store->ReadOpLogSince(0, 100, entries));
+    EXPECT_EQ(3, entries.size());
+}
+
+TEST_F(LocalFsOpLogStoreTest, GetLatestSequenceIdFirstBoot) {
+    auto store = CreateWriter();
+    uint64_t seq = 999;
+    EXPECT_EQ(ErrorCode::OK, store->GetLatestSequenceId(seq));
+    EXPECT_EQ(0, seq);
+}
+
+TEST_F(LocalFsOpLogStoreTest, GetMaxSequenceIdEmpty) {
+    auto store = CreateWriter();
+    uint64_t seq = 0;
+    EXPECT_EQ(ErrorCode::OPLOG_ENTRY_NOT_FOUND, store->GetMaxSequenceId(seq));
+}
+
+TEST_F(LocalFsOpLogStoreTest, GetMaxSequenceIdAfterWrite) {
+    auto store = CreateWriter();
+    for (uint64_t i = 1; i <= 5; i++) {
+        store->WriteOpLog(MakeEntry(i), /*sync=*/(i == 5));
+    }
+    uint64_t seq = 0;
+    EXPECT_EQ(ErrorCode::OK, store->GetMaxSequenceId(seq));
+    EXPECT_EQ(5, seq);
+}
+
+// --- Corrupted segment file tests ---
+
+TEST_F(LocalFsOpLogStoreTest, ReadCorruptedSegmentBadMagic) {
+    auto store = CreateWriter();
+    store->WriteOpLog(MakeEntry(1), /*sync=*/true);
+
+    // Corrupt the segment file by overwriting magic bytes
+    auto seg_dir = test_dir_ + "/" + cluster_id_ + "/segments";
+    for (auto& p : fs::directory_iterator(seg_dir)) {
+        if (p.path().extension() != ".tmp") {
+            std::fstream f(p.path(),
+                           std::ios::in | std::ios::out | std::ios::binary);
+            f.write("XXXX", 4);  // corrupt magic
+            f.close();
+            break;
+        }
+    }
+
+    OpLogEntry entry;
+    EXPECT_EQ(ErrorCode::INTERNAL_ERROR, store->ReadOpLog(1, entry));
+}
+
+TEST_F(LocalFsOpLogStoreTest, ReadCorruptedSegmentWrongVersion) {
+    auto store = CreateWriter();
+    store->WriteOpLog(MakeEntry(1), /*sync=*/true);
+
+    auto seg_dir = test_dir_ + "/" + cluster_id_ + "/segments";
+    for (auto& p : fs::directory_iterator(seg_dir)) {
+        if (p.path().extension() != ".tmp") {
+            std::fstream f(p.path(),
+                           std::ios::in | std::ios::out | std::ios::binary);
+            f.seekp(4);  // skip magic, write bad version
+            uint32_t bad_version = 99;
+            f.write(reinterpret_cast<const char*>(&bad_version),
+                    sizeof(bad_version));
+            f.close();
+            break;
+        }
+    }
+
+    OpLogEntry entry;
+    EXPECT_EQ(ErrorCode::INTERNAL_ERROR, store->ReadOpLog(1, entry));
+}
+
+TEST_F(LocalFsOpLogStoreTest, ReadCorruptedSegmentTruncated) {
+    auto store = CreateWriter();
+    store->WriteOpLog(MakeEntry(1), /*sync=*/true);
+
+    auto seg_dir = test_dir_ + "/" + cluster_id_ + "/segments";
+    for (auto& p : fs::directory_iterator(seg_dir)) {
+        if (p.path().extension() != ".tmp") {
+            // Truncate to just 16 bytes (less than header size)
+            fs::resize_file(p.path(), 16);
+            break;
+        }
+    }
+
+    OpLogEntry entry;
+    EXPECT_EQ(ErrorCode::INTERNAL_ERROR, store->ReadOpLog(1, entry));
+}
+
+// --- Snapshot tests ---
+
+TEST_F(LocalFsOpLogStoreTest, SnapshotRecordAndGet) {
+    auto store = CreateWriter();
+    EXPECT_EQ(ErrorCode::OK, store->RecordSnapshotSequenceId("snap1", 42));
+
+    uint64_t seq = 0;
+    EXPECT_EQ(ErrorCode::OK, store->GetSnapshotSequenceId("snap1", seq));
+    EXPECT_EQ(42, seq);
+}
+
+TEST_F(LocalFsOpLogStoreTest, SnapshotNotFound) {
+    auto store = CreateWriter();
+    uint64_t seq = 0;
+    EXPECT_NE(ErrorCode::OK, store->GetSnapshotSequenceId("nonexistent", seq));
+}
+
+TEST_F(LocalFsOpLogStoreTest, SnapshotIdValidation) {
+    auto store = CreateWriter();
+    EXPECT_EQ(ErrorCode::INVALID_PARAMS,
+              store->RecordSnapshotSequenceId("../escape", 1));
+    EXPECT_EQ(ErrorCode::INVALID_PARAMS,
+              store->RecordSnapshotSequenceId("path/slash", 1));
+    EXPECT_EQ(ErrorCode::INVALID_PARAMS,
+              store->RecordSnapshotSequenceId(std::string("null\0byte", 9), 1));
+}
+
+// --- Cleanup tests ---
+
+TEST_F(LocalFsOpLogStoreTest, CleanupRemovesOldSegments) {
+    auto store = CreateWriter();
+    // Write entries in separate segments (sync=true each time)
+    for (uint64_t i = 1; i <= 5; i++) {
+        store->WriteOpLog(MakeEntry(i), /*sync=*/true);
+    }
+
+    // Count segments before cleanup
+    auto seg_dir = test_dir_ + "/" + cluster_id_ + "/segments";
+    int before_count = 0;
+    for (auto& p : fs::directory_iterator(seg_dir)) {
+        (void)p;
+        before_count++;
+    }
+    EXPECT_EQ(5, before_count);
+
+    // Cleanup entries before seq 4 (should remove segments with max_seq < 4)
+    EXPECT_EQ(ErrorCode::OK, store->CleanupOpLogBefore(4));
+
+    // Entries 4 and 5 should still be readable
+    OpLogEntry entry;
+    EXPECT_EQ(ErrorCode::OK, store->ReadOpLog(4, entry));
+    EXPECT_EQ(ErrorCode::OK, store->ReadOpLog(5, entry));
+}
+
+TEST_F(LocalFsOpLogStoreTest, CleanupEmptyDir) {
+    auto store = CreateWriter();
+    EXPECT_EQ(ErrorCode::OK, store->CleanupOpLogBefore(100));
+}
+
+// --- ChangeNotifier tests ---
+
+TEST_F(LocalFsOpLogStoreTest, ChangeNotifierBasic) {
+    auto writer = CreateWriter();
+    auto reader = CreateReader();
+
+    auto notifier = reader->CreateChangeNotifier(cluster_id_);
+    ASSERT_NE(nullptr, notifier);
+
+    std::vector<OpLogEntry> received;
+    std::mutex received_mutex;
+    std::condition_variable received_cv;
+
+    auto on_entry = [&](const OpLogEntry& entry) {
+        std::lock_guard<std::mutex> lock(received_mutex);
+        received.push_back(entry);
+        received_cv.notify_one();
+    };
+    auto on_error = [](ErrorCode) {};
+
+    EXPECT_EQ(ErrorCode::OK, notifier->Start(0, on_entry, on_error));
+    EXPECT_TRUE(notifier->IsHealthy());
+
+    // Write an entry from writer
+    writer->WriteOpLog(MakeEntry(1), /*sync=*/true);
+
+    // Wait for notifier to deliver it (with timeout)
+    {
+        std::unique_lock<std::mutex> lock(received_mutex);
+        EXPECT_TRUE(received_cv.wait_for(lock, std::chrono::seconds(5),
+                                         [&] { return received.size() >= 1; }));
+    }
+    EXPECT_EQ(1, received.size());
+    EXPECT_EQ(1, received[0].sequence_id);
+
+    notifier->Stop();
+}
+
+TEST_F(LocalFsOpLogStoreTest, ChangeNotifierCatchUp) {
+    auto writer = CreateWriter();
+    // Write entries BEFORE starting notifier
+    for (uint64_t i = 1; i <= 5; i++) {
+        writer->WriteOpLog(MakeEntry(i), /*sync=*/(i == 5));
+    }
+
+    auto reader = CreateReader();
+    auto notifier = reader->CreateChangeNotifier(cluster_id_);
+    ASSERT_NE(nullptr, notifier);
+
+    std::vector<OpLogEntry> received;
+    std::mutex received_mutex;
+    std::condition_variable received_cv;
+
+    auto on_entry = [&](const OpLogEntry& entry) {
+        std::lock_guard<std::mutex> lock(received_mutex);
+        received.push_back(entry);
+        received_cv.notify_one();
+    };
+    auto on_error = [](ErrorCode) {};
+
+    // Start from 0 should catch up with existing entries
+    EXPECT_EQ(ErrorCode::OK, notifier->Start(0, on_entry, on_error));
+
+    {
+        std::unique_lock<std::mutex> lock(received_mutex);
+        EXPECT_TRUE(received_cv.wait_for(lock, std::chrono::seconds(5),
+                                         [&] { return received.size() >= 5; }));
+    }
+    EXPECT_EQ(5, received.size());
+    EXPECT_EQ(1, received[0].sequence_id);
+    EXPECT_EQ(5, received[4].sequence_id);
+
+    notifier->Stop();
+}
+
+TEST_F(LocalFsOpLogStoreTest, ChangeNotifierStopNoMoreCallbacks) {
+    auto writer = CreateWriter();
+    auto reader = CreateReader();
+
+    auto notifier = reader->CreateChangeNotifier(cluster_id_);
+    ASSERT_NE(nullptr, notifier);
+
+    std::atomic<int> callback_count{0};
+    auto on_entry = [&](const OpLogEntry&) { callback_count++; };
+    auto on_error = [](ErrorCode) {};
+
+    EXPECT_EQ(ErrorCode::OK, notifier->Start(0, on_entry, on_error));
+    notifier->Stop();
+
+    // Write after stop - should not trigger callback
+    writer->WriteOpLog(MakeEntry(1), /*sync=*/true);
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    EXPECT_EQ(0, callback_count.load());
+}
+
+// --- Factory tests ---
+
+TEST_F(LocalFsOpLogStoreTest, FactoryCreateWriter) {
+    auto store =
+        OpLogStoreFactory::Create(OpLogStoreType::LOCAL_FS, cluster_id_,
+                                  OpLogStoreRole::WRITER, test_dir_, 100);
+    ASSERT_NE(nullptr, store);
+
+    // Should be able to write
+    OpLogEntry entry;
+    entry.sequence_id = 1;
+    entry.op_type = OpType::PUT_END;
+    entry.object_key = "factory_test";
+    entry.payload = "data";
+    EXPECT_EQ(ErrorCode::OK, store->WriteOpLog(entry, /*sync=*/true));
+
+    // Should be able to read back
+    OpLogEntry read_entry;
+    EXPECT_EQ(ErrorCode::OK, store->ReadOpLog(1, read_entry));
+    EXPECT_EQ(1, read_entry.sequence_id);
+}
+
+TEST_F(LocalFsOpLogStoreTest, FactoryCreateReader) {
+    // First create some data with a writer
+    {
+        auto writer =
+            OpLogStoreFactory::Create(OpLogStoreType::LOCAL_FS, cluster_id_,
+                                      OpLogStoreRole::WRITER, test_dir_, 100);
+        ASSERT_NE(nullptr, writer);
+        OpLogEntry entry;
+        entry.sequence_id = 1;
+        entry.op_type = OpType::PUT_END;
+        entry.object_key = "key";
+        entry.payload = "data";
+        writer->WriteOpLog(entry, /*sync=*/true);
+    }
+
+    // Reader should be able to read but not write
+    auto reader =
+        OpLogStoreFactory::Create(OpLogStoreType::LOCAL_FS, cluster_id_,
+                                  OpLogStoreRole::READER, test_dir_, 100);
+    ASSERT_NE(nullptr, reader);
+
+    OpLogEntry read_entry;
+    EXPECT_EQ(ErrorCode::OK, reader->ReadOpLog(1, read_entry));
+    EXPECT_EQ(1, read_entry.sequence_id);
+
+    // Writer should fail on reader
+    OpLogEntry new_entry;
+    new_entry.sequence_id = 2;
+    new_entry.op_type = OpType::PUT_END;
+    new_entry.object_key = "key2";
+    new_entry.payload = "data2";
+    EXPECT_EQ(ErrorCode::INVALID_PARAMS,
+              reader->WriteOpLog(new_entry, /*sync=*/true));
+}
+
+}  // namespace
+}  // namespace mooncake

--- a/mooncake-store/tests/ha/oplog/oplog_manager_test.cpp
+++ b/mooncake-store/tests/ha/oplog/oplog_manager_test.cpp
@@ -1,0 +1,323 @@
+#include "ha/oplog/oplog_manager.h"
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <limits>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace mooncake::test {
+
+class OpLogManagerTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        google::InitGoogleLogging("OpLogManagerTest");
+        FLAGS_logtostderr = 1;
+        manager_ = std::make_unique<OpLogManager>();
+    }
+
+    void TearDown() override { google::ShutdownGoogleLogging(); }
+
+    OpLogManager& M() { return *manager_; }
+
+    std::unique_ptr<OpLogManager> manager_;
+};
+
+// ========== 2.1.1 Basic functionality tests ==========
+
+TEST_F(OpLogManagerTest, TestAppendEntry) {
+    uint64_t id = M().Append(OpType::PUT_END, "key1", "value1");
+
+    EXPECT_LT(0u, id);
+    EXPECT_EQ(id, M().GetLastSequenceId());
+    EXPECT_EQ(1u, M().GetEntryCount());
+}
+
+TEST_F(OpLogManagerTest, TestSequenceIdIncrement) {
+    uint64_t id1 = M().Append(OpType::PUT_END, "key1", "value1");
+    uint64_t id2 = M().Append(OpType::PUT_END, "key2", "value2");
+    uint64_t id3 = M().Append(OpType::REMOVE, "key3", "");
+
+    EXPECT_LT(0u, id1);
+    EXPECT_EQ(id1 + 1, id2);
+    EXPECT_EQ(id2 + 1, id3);
+    EXPECT_EQ(id3, M().GetLastSequenceId());
+    EXPECT_EQ(3u, M().GetEntryCount());
+}
+
+TEST_F(OpLogManagerTest, TestAllocateEntry) {
+    OpLogEntry e1 = M().AllocateEntry(OpType::PUT_END, "key1", "value1");
+    OpLogEntry e2 = M().AllocateEntry(OpType::PUT_END, "key2", "value2");
+
+    EXPECT_LT(0u, e1.sequence_id);
+    EXPECT_EQ(e1.sequence_id + 1, e2.sequence_id);
+    EXPECT_EQ(e2.sequence_id, M().GetLastSequenceId());
+    EXPECT_EQ(2u, M().GetEntryCount());
+
+    // Basic field validation
+    EXPECT_EQ(OpType::PUT_END, e1.op_type);
+    EXPECT_EQ("key1", e1.object_key);
+    EXPECT_EQ("value1", e1.payload);
+    EXPECT_NE(0u, e1.timestamp_ms);
+    EXPECT_NE(0u, e1.checksum);
+    EXPECT_NE(0u, e1.prefix_hash);
+}
+
+TEST_F(OpLogManagerTest, TestPersistEntry) {
+    // Without an OpLogStore configured, PersistEntry should return an
+    // error
+    OpLogEntry entry =
+        M().AllocateEntry(OpType::PUT_END, "key", "payload-data");
+
+    ErrorCode err = M().PersistEntry(entry);
+    EXPECT_EQ(ErrorCode::INTERNAL_ERROR, err);
+}
+
+TEST_F(OpLogManagerTest, TestAppendAndPersist) {
+    // Without an EtcdOpLogStore configured, AppendAndPersist should return an
+    // error
+    auto res = M().AppendAndPersist(OpType::REMOVE, "key", "");
+    ASSERT_FALSE(res.has_value());
+    EXPECT_EQ(ErrorCode::INTERNAL_ERROR, res.error());
+}
+
+// ========== Initial Sequence Id Tests ==========
+
+TEST_F(OpLogManagerTest, SetInitialSequenceIdOnEmptyManager) {
+    EXPECT_EQ(0u, M().GetLastSequenceId());
+    EXPECT_EQ(0u, M().GetEntryCount());
+
+    M().SetInitialSequenceId(100);
+    EXPECT_EQ(100u, M().GetLastSequenceId());
+
+    // The first appended entry should have sequence_id 101
+    uint64_t id = M().Append(OpType::PUT_END, "key", "value");
+    EXPECT_EQ(101u, id);
+}
+
+TEST_F(OpLogManagerTest, SetInitialSequenceIdIgnoredWhenNotEmpty) {
+    uint64_t id1 = M().Append(OpType::PUT_END, "key1", "value1");
+    EXPECT_EQ(id1, M().GetLastSequenceId());
+
+    // Setting initial sequence id on a non-empty manager should be ignored
+    M().SetInitialSequenceId(500);
+    EXPECT_EQ(id1, M().GetLastSequenceId());
+}
+
+// ========== 2.1.2 Checksum tests ==========
+
+TEST_F(OpLogManagerTest, TestChecksumComputation) {
+    // Same payload => same checksum; different payload => different checksum
+    OpLogEntry e1 = M().AllocateEntry(OpType::PUT_END, "k1", "payload-X");
+    OpLogEntry e2 = M().AllocateEntry(OpType::PUT_END, "k2", "payload-X");
+    OpLogEntry e3 = M().AllocateEntry(OpType::PUT_END, "k3", "payload-Y");
+
+    EXPECT_EQ(e1.checksum, e2.checksum);
+    EXPECT_NE(e1.checksum, e3.checksum);
+}
+
+TEST_F(OpLogManagerTest, TestPrefixHashComputation) {
+    // Same key => same prefix_hash; different key => (with high probability)
+    // different prefix_hash
+    OpLogEntry e1 = M().AllocateEntry(OpType::PUT_END, "same-key", "v1");
+    OpLogEntry e2 = M().AllocateEntry(OpType::PUT_END, "same-key", "v2");
+    OpLogEntry e3 = M().AllocateEntry(OpType::PUT_END, "other-key", "v3");
+
+    EXPECT_EQ(e1.prefix_hash, e2.prefix_hash);
+    EXPECT_NE(e1.prefix_hash, e3.prefix_hash);
+}
+
+TEST_F(OpLogManagerTest, TestVerifyChecksum) {
+    OpLogEntry entry =
+        M().AllocateEntry(OpType::PUT_END, "key", "payload-data");
+    EXPECT_TRUE(OpLogManager::VerifyChecksum(entry));
+
+    // Verification should fail after tampering with the payload
+    entry.payload = "tampered";
+    EXPECT_FALSE(OpLogManager::VerifyChecksum(entry));
+}
+
+// ========== 2.1.3 Size validation tests ==========
+
+TEST_F(OpLogManagerTest, TestValidateEntrySize_Valid) {
+    OpLogEntry entry;
+    entry.object_key = "normal-key";
+    entry.payload = "small-payload";
+
+    std::string reason;
+    EXPECT_TRUE(OpLogManager::ValidateEntrySize(entry, &reason));
+    EXPECT_TRUE(reason.empty());
+}
+
+TEST_F(OpLogManagerTest, TestValidateEntrySize_KeyTooLarge) {
+    OpLogEntry entry;
+    entry.object_key.assign(OpLogManager::kMaxObjectKeySize + 1, 'k');
+    entry.payload = "payload";
+
+    std::string reason;
+    EXPECT_FALSE(OpLogManager::ValidateEntrySize(entry, &reason));
+    EXPECT_FALSE(reason.empty());
+}
+
+TEST_F(OpLogManagerTest, TestValidateEntrySize_PayloadTooLarge) {
+    OpLogEntry entry;
+    entry.object_key = "key";
+    entry.payload.assign(OpLogManager::kMaxPayloadSize + 1, 'p');
+
+    std::string reason;
+    EXPECT_FALSE(OpLogManager::ValidateEntrySize(entry, &reason));
+    EXPECT_FALSE(reason.empty());
+}
+
+TEST_F(OpLogManagerTest, TestValidateEntrySize_EmptyKey) {
+    // Current implementation only enforces upper bounds; empty keys are
+    // accepted
+    OpLogEntry entry;
+    entry.object_key = "";
+    entry.payload = "payload";
+
+    std::string reason;
+    EXPECT_TRUE(OpLogManager::ValidateEntrySize(entry, &reason));
+}
+
+// ========== 2.1.4 Etcd integration tests (placeholder) ==========
+
+TEST_F(OpLogManagerTest, TestWriteToEtcd_Success) {
+#if defined(STORE_USE_ETCD)
+    GTEST_SKIP()
+        << "TODO: requires real EtcdOpLogStore and running etcd cluster.";
+#else
+    GTEST_SKIP() << "STORE_USE_ETCD is disabled.";
+#endif
+}
+
+TEST_F(OpLogManagerTest, TestWriteToEtcd_Failure) {
+    OpLogEntry entry =
+        M().AllocateEntry(OpType::PUT_END, "key", "payload-data");
+    ErrorCode err = M().PersistEntry(entry);
+    EXPECT_EQ(ErrorCode::INTERNAL_ERROR, err);
+}
+
+TEST_F(OpLogManagerTest, TestWriteToEtcd_Retry) {
+    GTEST_SKIP() << "TODO: retry / idempotent semantics are tested at "
+                    "EtcdOpLogStore level.";
+}
+
+TEST_F(OpLogManagerTest, TestIdempotentWrite) {
+    GTEST_SKIP() << "TODO: idempotent write belongs to "
+                    "EtcdOpLogStore::WriteOpLog tests.";
+}
+
+// ========== 2.1.5 Boundary condition tests ==========
+
+TEST_F(OpLogManagerTest, TestSequenceIdWrapAround) {
+    // Theoretical wrap-around test: set initial value near UINT64_MAX and
+    // verify wrap-around semantics
+    uint64_t near_max = std::numeric_limits<uint64_t>::max() - 2;
+    M().SetInitialSequenceId(near_max);
+
+    std::vector<uint64_t> ids;
+    ids.push_back(M().Append(OpType::PUT_END, "k1", "v1"));  // max-1
+    ids.push_back(M().Append(OpType::PUT_END, "k2", "v2"));  // max
+    ids.push_back(M().Append(OpType::PUT_END, "k3", "v3"));  // 0 (wrap)
+
+    ASSERT_EQ(3u, ids.size());
+    // Use wrap-around-safe comparison helpers to verify monotonic increase
+    EXPECT_TRUE(IsSequenceNewer(ids[1], ids[0]));
+    EXPECT_TRUE(IsSequenceNewer(
+        ids[2], ids[1]));  // 0 is considered newer than UINT64_MAX
+}
+
+TEST_F(OpLogManagerTest, TestConcurrentAppend) {
+    constexpr int kThreads = 8;
+    constexpr int kPerThread = 1000;
+
+    std::vector<uint64_t> ids;
+    ids.reserve(kThreads * kPerThread);
+    std::mutex m;
+
+    auto worker = [&]() {
+        for (int i = 0; i < kPerThread; ++i) {
+            uint64_t id = M().Append(OpType::PUT_END, "key", "value");
+            std::lock_guard<std::mutex> lock(m);
+            ids.push_back(id);
+        }
+    };
+
+    std::vector<std::thread> threads;
+    for (int i = 0; i < kThreads; ++i) {
+        threads.emplace_back(worker);
+    }
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    EXPECT_EQ(static_cast<size_t>(kThreads * kPerThread), ids.size());
+
+    std::sort(ids.begin(), ids.end());
+    // Ensure there are no duplicates and sequence IDs are strictly increasing
+    for (size_t i = 1; i < ids.size(); ++i) {
+        EXPECT_GT(ids[i], ids[i - 1]);
+    }
+}
+
+TEST_F(OpLogManagerTest, TestLargePayload) {
+    // Construct a payload close to the upper limit and verify it passes
+    // validation and appends successfully
+    std::string key = "large-payload-key";
+    std::string payload(OpLogManager::kMaxPayloadSize - 1, 'x');
+
+    OpLogEntry entry;
+    entry.object_key = key;
+    entry.payload = payload;
+
+    std::string reason;
+    EXPECT_TRUE(OpLogManager::ValidateEntrySize(entry, &reason));
+
+    uint64_t id = M().Append(OpType::PUT_END, key, payload);
+    EXPECT_LT(0u, id);
+    EXPECT_EQ(1u, M().GetEntryCount());
+}
+
+TEST_F(OpLogManagerTest, TestAppendMultipleTypes) {
+    uint64_t id1 = M().Append(OpType::PUT_END, "k1", "payload");
+    uint64_t id2 = M().Append(OpType::PUT_REVOKE, "k2", "");
+    uint64_t id3 = M().Append(OpType::REMOVE, "k3", "");
+    EXPECT_EQ(id1 + 1, id2);
+    EXPECT_EQ(id2 + 1, id3);
+    EXPECT_EQ(3u, M().GetEntryCount());
+}
+
+TEST_F(OpLogManagerTest, TestBufferEviction) {
+    for (int i = 0; i < 10; ++i) {
+        M().Append(OpType::PUT_END, "key_" + std::to_string(i), "val");
+    }
+    EXPECT_EQ(10u, M().GetEntryCount());
+}
+
+TEST_F(OpLogManagerTest, TestAllocateEntry_ChecksumValid) {
+    OpLogEntry e = M().AllocateEntry(OpType::REMOVE, "del-key", "some-data");
+    EXPECT_TRUE(OpLogManager::VerifyChecksum(e));
+}
+
+TEST_F(OpLogManagerTest, TestAllocateEntry_FieldsComplete) {
+    OpLogEntry e = M().AllocateEntry(OpType::REMOVE, "del-key", "");
+    EXPECT_EQ(OpType::REMOVE, e.op_type);
+    EXPECT_EQ("del-key", e.object_key);
+    EXPECT_EQ("", e.payload);
+    EXPECT_NE(0u, e.timestamp_ms);
+    EXPECT_TRUE(OpLogManager::VerifyChecksum(e));
+    // "del-key" prefix hash
+    EXPECT_NE(0u, e.prefix_hash);
+}
+
+}  // namespace mooncake::test
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/mooncake-store/tests/ha/oplog/oplog_serializer_test.cpp
+++ b/mooncake-store/tests/ha/oplog/oplog_serializer_test.cpp
@@ -1,0 +1,142 @@
+#include "ha/oplog/oplog_serializer.h"
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+#include <xxhash.h>
+
+#include <string>
+
+namespace mooncake::test {
+
+class OpLogSerializerTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        google::InitGoogleLogging("OpLogSerializerTest");
+        FLAGS_logtostderr = 1;
+    }
+    void TearDown() override { google::ShutdownGoogleLogging(); }
+
+    static OpLogEntry MakeEntry(uint64_t seq, OpType type,
+                                const std::string& key,
+                                const std::string& payload) {
+        OpLogEntry e;
+        e.sequence_id = seq;
+        e.timestamp_ms = 1234567890;
+        e.op_type = type;
+        e.object_key = key;
+        e.payload = payload;
+        e.checksum =
+            static_cast<uint32_t>(XXH32(payload.data(), payload.size(), 0));
+        e.prefix_hash =
+            key.empty()
+                ? 0
+                : static_cast<uint32_t>(XXH32(key.data(), key.size(), 0));
+        return e;
+    }
+};
+
+TEST_F(OpLogSerializerTest, RoundTrip_PutEnd) {
+    OpLogEntry in = MakeEntry(1, OpType::PUT_END, "key1", "value1");
+    std::string json = SerializeOpLogEntry(in);
+    OpLogEntry out;
+    ASSERT_TRUE(DeserializeOpLogEntry(json, out));
+    EXPECT_EQ(in.sequence_id, out.sequence_id);
+    EXPECT_EQ(in.timestamp_ms, out.timestamp_ms);
+    EXPECT_EQ(in.op_type, out.op_type);
+    EXPECT_EQ(in.object_key, out.object_key);
+    EXPECT_EQ(in.payload, out.payload);
+    EXPECT_EQ(in.checksum, out.checksum);
+    EXPECT_EQ(in.prefix_hash, out.prefix_hash);
+}
+
+TEST_F(OpLogSerializerTest, RoundTrip_Remove) {
+    OpLogEntry in = MakeEntry(42, OpType::REMOVE, "obj/to/remove", "");
+    std::string json = SerializeOpLogEntry(in);
+    OpLogEntry out;
+    ASSERT_TRUE(DeserializeOpLogEntry(json, out));
+    EXPECT_EQ(in.sequence_id, out.sequence_id);
+    EXPECT_EQ(in.op_type, out.op_type);
+    EXPECT_EQ(in.object_key, out.object_key);
+    EXPECT_EQ(in.payload, out.payload);
+}
+
+TEST_F(OpLogSerializerTest, RoundTrip_PutRevoke) {
+    OpLogEntry in = MakeEntry(99, OpType::PUT_REVOKE, "revoked_key", "meta");
+    std::string json = SerializeOpLogEntry(in);
+    OpLogEntry out;
+    ASSERT_TRUE(DeserializeOpLogEntry(json, out));
+    EXPECT_EQ(in.op_type, out.op_type);
+    EXPECT_EQ(in.payload, out.payload);
+}
+
+TEST_F(OpLogSerializerTest, RoundTrip_BinaryPayload) {
+    // Payload with null bytes, high bytes — must survive base64 round-trip
+    std::string binary_payload;
+    for (int i = 0; i < 256; ++i) {
+        binary_payload.push_back(static_cast<char>(i));
+    }
+    OpLogEntry in = MakeEntry(7, OpType::PUT_END, "bin_key", binary_payload);
+    std::string json = SerializeOpLogEntry(in);
+    OpLogEntry out;
+    ASSERT_TRUE(DeserializeOpLogEntry(json, out));
+    EXPECT_EQ(in.payload, out.payload);
+}
+
+TEST_F(OpLogSerializerTest, RoundTrip_EmptyPayload) {
+    OpLogEntry in = MakeEntry(10, OpType::REMOVE, "key", "");
+    std::string json = SerializeOpLogEntry(in);
+    OpLogEntry out;
+    ASSERT_TRUE(DeserializeOpLogEntry(json, out));
+    EXPECT_EQ("", out.payload);
+}
+
+TEST_F(OpLogSerializerTest, RoundTrip_EmptyKey) {
+    OpLogEntry in = MakeEntry(11, OpType::PUT_END, "", "payload");
+    std::string json = SerializeOpLogEntry(in);
+    OpLogEntry out;
+    ASSERT_TRUE(DeserializeOpLogEntry(json, out));
+    EXPECT_EQ("", out.object_key);
+    EXPECT_EQ(0u, out.prefix_hash);
+}
+
+TEST_F(OpLogSerializerTest, Deserialize_InvalidJson) {
+    OpLogEntry out;
+    EXPECT_FALSE(DeserializeOpLogEntry("{ not valid json }", out));
+}
+
+TEST_F(OpLogSerializerTest, Deserialize_EmptyString) {
+    OpLogEntry out;
+    EXPECT_FALSE(DeserializeOpLogEntry("", out));
+}
+
+TEST_F(OpLogSerializerTest, Deserialize_MissingFields) {
+    // JSON with only partial fields — should fail or produce defaults
+    std::string partial = R"({"sequence_id": 1})";
+    OpLogEntry out;
+    // Behavior depends on JsonCpp defaults for missing fields.
+    // At minimum, should not crash.
+    (void)DeserializeOpLogEntry(partial, out);
+}
+
+TEST_F(OpLogSerializerTest, Deserialize_KeyTooLarge) {
+    OpLogEntry in = MakeEntry(1, OpType::PUT_END, "k", "v");
+    in.object_key.assign(OpLogManager::kMaxObjectKeySize + 1, 'k');
+    std::string json = SerializeOpLogEntry(in);
+    OpLogEntry out;
+    EXPECT_FALSE(DeserializeOpLogEntry(json, out));
+}
+
+TEST_F(OpLogSerializerTest, Deserialize_PayloadTooLarge) {
+    OpLogEntry in = MakeEntry(1, OpType::PUT_END, "k", "");
+    in.payload.assign(OpLogManager::kMaxPayloadSize + 1, 'p');
+    std::string json = SerializeOpLogEntry(in);
+    OpLogEntry out;
+    EXPECT_FALSE(DeserializeOpLogEntry(json, out));
+}
+
+}  // namespace mooncake::test
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/mooncake-store/tests/ha/oplog/standby_state_machine_test.cpp
+++ b/mooncake-store/tests/ha/oplog/standby_state_machine_test.cpp
@@ -1,0 +1,731 @@
+#include "standby_state_machine.h"
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <vector>
+
+namespace mooncake::test {
+
+class StandbyStateMachineTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        google::InitGoogleLogging("StandbyStateMachineTest");
+        FLAGS_logtostderr = true;
+        machine_ = std::make_unique<StandbyStateMachine>();
+    }
+
+    void TearDown() override { google::ShutdownGoogleLogging(); }
+
+    std::unique_ptr<StandbyStateMachine> machine_;
+
+    // Helper function to reach WATCHING state
+    void ReachWatchingState() {
+        machine_->ProcessEvent(StandbyEvent::START);
+        machine_->ProcessEvent(StandbyEvent::CONNECTED);
+        machine_->ProcessEvent(StandbyEvent::SYNC_COMPLETE);
+        EXPECT_EQ(StandbyState::WATCHING, machine_->GetState());
+    }
+
+    // Helper function to reach SYNCING state
+    void ReachSyncingState() {
+        machine_->ProcessEvent(StandbyEvent::START);
+        machine_->ProcessEvent(StandbyEvent::CONNECTED);
+        EXPECT_EQ(StandbyState::SYNCING, machine_->GetState());
+    }
+};
+
+// ========== Initial State Tests ==========
+
+TEST_F(StandbyStateMachineTest, TestInitialState) {
+    EXPECT_EQ(StandbyState::STOPPED, machine_->GetState());
+    EXPECT_FALSE(machine_->IsRunning());
+    EXPECT_FALSE(machine_->IsConnected());
+    EXPECT_FALSE(machine_->IsWatchHealthy());
+    EXPECT_FALSE(machine_->IsReadyForPromotion());
+    EXPECT_EQ(0, machine_->GetConsecutiveErrors());
+    EXPECT_EQ(0, machine_->GetReconnectCount());
+}
+
+// ========== Basic State Transition Tests ==========
+
+TEST_F(StandbyStateMachineTest, TestStartTransition) {
+    auto result = machine_->ProcessEvent(StandbyEvent::START);
+    EXPECT_TRUE(result.allowed);
+    EXPECT_EQ(StandbyState::STOPPED, result.old_state);
+    EXPECT_EQ(StandbyState::CONNECTING, result.new_state);
+    EXPECT_EQ(StandbyState::CONNECTING, machine_->GetState());
+    // In CONNECTING state, syncing has not actually started yet, so
+    // IsRunning/IsConnected should both be false
+    EXPECT_FALSE(machine_->IsRunning());
+    EXPECT_FALSE(machine_->IsConnected());
+}
+
+TEST_F(StandbyStateMachineTest, TestConnectedTransition) {
+    machine_->ProcessEvent(StandbyEvent::START);
+    EXPECT_EQ(StandbyState::CONNECTING, machine_->GetState());
+
+    auto result = machine_->ProcessEvent(StandbyEvent::CONNECTED);
+    EXPECT_TRUE(result.allowed);
+    EXPECT_EQ(StandbyState::CONNECTING, result.old_state);
+    EXPECT_EQ(StandbyState::SYNCING, result.new_state);
+    EXPECT_EQ(StandbyState::SYNCING, machine_->GetState());
+    EXPECT_TRUE(machine_->IsRunning());
+    EXPECT_TRUE(machine_->IsConnected());
+}
+
+TEST_F(StandbyStateMachineTest, TestSyncCompleteTransition) {
+    ReachSyncingState();
+
+    auto result = machine_->ProcessEvent(StandbyEvent::SYNC_COMPLETE);
+    EXPECT_TRUE(result.allowed);
+    EXPECT_EQ(StandbyState::SYNCING, result.old_state);
+    EXPECT_EQ(StandbyState::WATCHING, result.new_state);
+    EXPECT_EQ(StandbyState::WATCHING, machine_->GetState());
+    EXPECT_TRUE(machine_->IsRunning());
+    EXPECT_TRUE(machine_->IsConnected());
+    EXPECT_TRUE(machine_->IsWatchHealthy());
+    EXPECT_TRUE(machine_->IsReadyForPromotion());
+}
+
+TEST_F(StandbyStateMachineTest, TestWatchHealthyNoOp) {
+    ReachWatchingState();
+
+    // WATCH_HEALTHY in WATCHING state is a no-op (stays in WATCHING)
+    auto result = machine_->ProcessEvent(StandbyEvent::WATCH_HEALTHY);
+    EXPECT_TRUE(result.allowed);
+    EXPECT_EQ(StandbyState::WATCHING, result.old_state);
+    EXPECT_EQ(StandbyState::WATCHING, result.new_state);
+    EXPECT_EQ(StandbyState::WATCHING, machine_->GetState());
+}
+
+TEST_F(StandbyStateMachineTest, TestWatchBrokenTransition) {
+    ReachWatchingState();
+
+    auto result = machine_->ProcessEvent(StandbyEvent::WATCH_BROKEN);
+    EXPECT_TRUE(result.allowed);
+    EXPECT_EQ(StandbyState::WATCHING, result.old_state);
+    EXPECT_EQ(StandbyState::RECONNECTING, result.new_state);
+    EXPECT_EQ(StandbyState::RECONNECTING, machine_->GetState());
+    EXPECT_TRUE(machine_->IsRunning());
+    EXPECT_FALSE(machine_->IsWatchHealthy());
+    EXPECT_FALSE(machine_->IsReadyForPromotion());
+}
+
+TEST_F(StandbyStateMachineTest, TestDisconnectedFromWatching) {
+    ReachWatchingState();
+
+    auto result = machine_->ProcessEvent(StandbyEvent::DISCONNECTED);
+    EXPECT_TRUE(result.allowed);
+    EXPECT_EQ(StandbyState::WATCHING, result.old_state);
+    EXPECT_EQ(StandbyState::RECONNECTING, result.new_state);
+    EXPECT_EQ(StandbyState::RECONNECTING, machine_->GetState());
+}
+
+TEST_F(StandbyStateMachineTest, TestPromoteTransition) {
+    ReachWatchingState();
+
+    auto result = machine_->ProcessEvent(StandbyEvent::PROMOTE);
+    EXPECT_TRUE(result.allowed);
+    EXPECT_EQ(StandbyState::WATCHING, result.old_state);
+    EXPECT_EQ(StandbyState::PROMOTING, result.new_state);
+    EXPECT_EQ(StandbyState::PROMOTING, machine_->GetState());
+    EXPECT_TRUE(machine_->IsRunning());
+    EXPECT_TRUE(machine_->IsConnected());
+    EXPECT_FALSE(machine_->IsWatchHealthy());
+    EXPECT_FALSE(machine_->IsReadyForPromotion());
+}
+
+TEST_F(StandbyStateMachineTest, TestPromotionSuccessTransition) {
+    ReachWatchingState();
+    machine_->ProcessEvent(StandbyEvent::PROMOTE);
+    EXPECT_EQ(StandbyState::PROMOTING, machine_->GetState());
+
+    auto result = machine_->ProcessEvent(StandbyEvent::PROMOTION_SUCCESS);
+    EXPECT_TRUE(result.allowed);
+    EXPECT_EQ(StandbyState::PROMOTING, result.old_state);
+    EXPECT_EQ(StandbyState::PROMOTED, result.new_state);
+    EXPECT_EQ(StandbyState::PROMOTED, machine_->GetState());
+    EXPECT_FALSE(machine_->IsRunning());
+    EXPECT_FALSE(machine_->IsConnected());
+}
+
+TEST_F(StandbyStateMachineTest, TestPromotionFailedTransition) {
+    ReachWatchingState();
+    machine_->ProcessEvent(StandbyEvent::PROMOTE);
+    EXPECT_EQ(StandbyState::PROMOTING, machine_->GetState());
+
+    auto result = machine_->ProcessEvent(StandbyEvent::PROMOTION_FAILED);
+    EXPECT_TRUE(result.allowed);
+    EXPECT_EQ(StandbyState::PROMOTING, result.old_state);
+    EXPECT_EQ(StandbyState::FAILED, result.new_state);
+    EXPECT_EQ(StandbyState::FAILED, machine_->GetState());
+    EXPECT_FALSE(machine_->IsRunning());
+}
+
+TEST_F(StandbyStateMachineTest, TestStopTransition) {
+    ReachWatchingState();
+
+    auto result = machine_->ProcessEvent(StandbyEvent::STOP);
+    EXPECT_TRUE(result.allowed);
+    EXPECT_EQ(StandbyState::WATCHING, result.old_state);
+    EXPECT_EQ(StandbyState::STOPPED, result.new_state);
+    EXPECT_EQ(StandbyState::STOPPED, machine_->GetState());
+    EXPECT_FALSE(machine_->IsRunning());
+    EXPECT_FALSE(machine_->IsConnected());
+}
+
+// ========== Error and Failure State Tests ==========
+
+TEST_F(StandbyStateMachineTest, TestConnectionFailedFromConnecting) {
+    machine_->ProcessEvent(StandbyEvent::START);
+    EXPECT_EQ(StandbyState::CONNECTING, machine_->GetState());
+
+    auto result = machine_->ProcessEvent(StandbyEvent::CONNECTION_FAILED);
+    EXPECT_TRUE(result.allowed);
+    EXPECT_EQ(StandbyState::CONNECTING, result.old_state);
+    EXPECT_EQ(StandbyState::FAILED, result.new_state);
+    EXPECT_EQ(StandbyState::FAILED, machine_->GetState());
+    EXPECT_FALSE(machine_->IsRunning());
+}
+
+TEST_F(StandbyStateMachineTest, TestFatalErrorFromConnecting) {
+    machine_->ProcessEvent(StandbyEvent::START);
+    EXPECT_EQ(StandbyState::CONNECTING, machine_->GetState());
+
+    auto result = machine_->ProcessEvent(StandbyEvent::FATAL_ERROR);
+    EXPECT_TRUE(result.allowed);
+    EXPECT_EQ(StandbyState::CONNECTING, result.old_state);
+    EXPECT_EQ(StandbyState::FAILED, result.new_state);
+    EXPECT_EQ(StandbyState::FAILED, machine_->GetState());
+}
+
+TEST_F(StandbyStateMachineTest, TestSyncFailedFromSyncing) {
+    ReachSyncingState();
+
+    auto result = machine_->ProcessEvent(StandbyEvent::SYNC_FAILED);
+    EXPECT_TRUE(result.allowed);
+    EXPECT_EQ(StandbyState::SYNCING, result.old_state);
+    EXPECT_EQ(StandbyState::RECONNECTING, result.new_state);
+    EXPECT_EQ(StandbyState::RECONNECTING, machine_->GetState());
+    EXPECT_TRUE(machine_->IsRunning());
+}
+
+TEST_F(StandbyStateMachineTest, TestDisconnectedFromSyncing) {
+    ReachSyncingState();
+
+    auto result = machine_->ProcessEvent(StandbyEvent::DISCONNECTED);
+    EXPECT_TRUE(result.allowed);
+    EXPECT_EQ(StandbyState::SYNCING, result.old_state);
+    EXPECT_EQ(StandbyState::RECONNECTING, result.new_state);
+    EXPECT_EQ(StandbyState::RECONNECTING, machine_->GetState());
+}
+
+TEST_F(StandbyStateMachineTest, TestFatalErrorFromSyncing) {
+    ReachSyncingState();
+
+    auto result = machine_->ProcessEvent(StandbyEvent::FATAL_ERROR);
+    EXPECT_TRUE(result.allowed);
+    EXPECT_EQ(StandbyState::SYNCING, result.old_state);
+    EXPECT_EQ(StandbyState::FAILED, result.new_state);
+    EXPECT_EQ(StandbyState::FAILED, machine_->GetState());
+}
+
+TEST_F(StandbyStateMachineTest, TestFatalErrorFromWatching) {
+    ReachWatchingState();
+
+    auto result = machine_->ProcessEvent(StandbyEvent::FATAL_ERROR);
+    EXPECT_TRUE(result.allowed);
+    EXPECT_EQ(StandbyState::WATCHING, result.old_state);
+    EXPECT_EQ(StandbyState::FAILED, result.new_state);
+    EXPECT_EQ(StandbyState::FAILED, machine_->GetState());
+}
+
+// ========== Reconnecting State Tests ==========
+
+TEST_F(StandbyStateMachineTest, TestReconnectingToSyncing) {
+    ReachWatchingState();
+    machine_->ProcessEvent(StandbyEvent::WATCH_BROKEN);
+    EXPECT_EQ(StandbyState::RECONNECTING, machine_->GetState());
+
+    auto result = machine_->ProcessEvent(StandbyEvent::CONNECTED);
+    EXPECT_TRUE(result.allowed);
+    EXPECT_EQ(StandbyState::RECONNECTING, result.old_state);
+    EXPECT_EQ(StandbyState::SYNCING, result.new_state);
+    EXPECT_EQ(StandbyState::SYNCING, machine_->GetState());
+}
+
+TEST_F(StandbyStateMachineTest, TestReconnectingToFailed) {
+    ReachWatchingState();
+    machine_->ProcessEvent(StandbyEvent::WATCH_BROKEN);
+    EXPECT_EQ(StandbyState::RECONNECTING, machine_->GetState());
+
+    auto result = machine_->ProcessEvent(StandbyEvent::FATAL_ERROR);
+    EXPECT_TRUE(result.allowed);
+    EXPECT_EQ(StandbyState::RECONNECTING, result.old_state);
+    EXPECT_EQ(StandbyState::FAILED, result.new_state);
+    EXPECT_EQ(StandbyState::FAILED, machine_->GetState());
+}
+
+TEST_F(StandbyStateMachineTest, TestReconnectingMaxErrors) {
+    ReachWatchingState();
+    machine_->ProcessEvent(StandbyEvent::WATCH_BROKEN);
+    EXPECT_EQ(StandbyState::RECONNECTING, machine_->GetState());
+
+    auto result = machine_->ProcessEvent(StandbyEvent::MAX_ERRORS_REACHED);
+    EXPECT_TRUE(result.allowed);
+    EXPECT_EQ(StandbyState::RECONNECTING, result.old_state);
+    EXPECT_EQ(StandbyState::FAILED, result.new_state);
+    EXPECT_EQ(StandbyState::FAILED, machine_->GetState());
+}
+
+// ========== Recovering State Tests ==========
+
+TEST_F(StandbyStateMachineTest, TestRecoveringToWatching) {
+    ReachWatchingState();
+    machine_->ProcessEvent(StandbyEvent::MAX_ERRORS_REACHED);
+    EXPECT_EQ(StandbyState::RECOVERING, machine_->GetState());
+
+    auto result = machine_->ProcessEvent(StandbyEvent::RECOVERY_SUCCESS);
+    EXPECT_TRUE(result.allowed);
+    EXPECT_EQ(StandbyState::RECOVERING, result.old_state);
+    EXPECT_EQ(StandbyState::WATCHING, result.new_state);
+    EXPECT_EQ(StandbyState::WATCHING, machine_->GetState());
+}
+
+TEST_F(StandbyStateMachineTest, TestRecoveringToReconnecting) {
+    ReachWatchingState();
+    machine_->ProcessEvent(StandbyEvent::MAX_ERRORS_REACHED);
+    EXPECT_EQ(StandbyState::RECOVERING, machine_->GetState());
+
+    auto result = machine_->ProcessEvent(StandbyEvent::RECOVERY_FAILED);
+    EXPECT_TRUE(result.allowed);
+    EXPECT_EQ(StandbyState::RECOVERING, result.old_state);
+    EXPECT_EQ(StandbyState::RECONNECTING, result.new_state);
+    EXPECT_EQ(StandbyState::RECONNECTING, machine_->GetState());
+}
+
+TEST_F(StandbyStateMachineTest, TestRecoveringDisconnected) {
+    ReachWatchingState();
+    machine_->ProcessEvent(StandbyEvent::MAX_ERRORS_REACHED);
+    EXPECT_EQ(StandbyState::RECOVERING, machine_->GetState());
+
+    auto result = machine_->ProcessEvent(StandbyEvent::DISCONNECTED);
+    EXPECT_TRUE(result.allowed);
+    EXPECT_EQ(StandbyState::RECOVERING, result.old_state);
+    EXPECT_EQ(StandbyState::RECONNECTING, result.new_state);
+    EXPECT_EQ(StandbyState::RECONNECTING, machine_->GetState());
+}
+
+TEST_F(StandbyStateMachineTest, TestRecoveringFatalError) {
+    ReachWatchingState();
+    machine_->ProcessEvent(StandbyEvent::MAX_ERRORS_REACHED);
+    EXPECT_EQ(StandbyState::RECOVERING, machine_->GetState());
+
+    auto result = machine_->ProcessEvent(StandbyEvent::FATAL_ERROR);
+    EXPECT_TRUE(result.allowed);
+    EXPECT_EQ(StandbyState::RECOVERING, result.old_state);
+    EXPECT_EQ(StandbyState::FAILED, result.new_state);
+    EXPECT_EQ(StandbyState::FAILED, machine_->GetState());
+}
+
+// ========== Failed State Tests ==========
+
+TEST_F(StandbyStateMachineTest, TestFailedToStopped) {
+    machine_->ProcessEvent(StandbyEvent::START);
+    machine_->ProcessEvent(StandbyEvent::FATAL_ERROR);
+    EXPECT_EQ(StandbyState::FAILED, machine_->GetState());
+
+    auto result = machine_->ProcessEvent(StandbyEvent::STOP);
+    EXPECT_TRUE(result.allowed);
+    EXPECT_EQ(StandbyState::FAILED, result.old_state);
+    EXPECT_EQ(StandbyState::STOPPED, result.new_state);
+    EXPECT_EQ(StandbyState::STOPPED, machine_->GetState());
+}
+
+TEST_F(StandbyStateMachineTest, TestFailedToConnecting) {
+    machine_->ProcessEvent(StandbyEvent::START);
+    machine_->ProcessEvent(StandbyEvent::FATAL_ERROR);
+    EXPECT_EQ(StandbyState::FAILED, machine_->GetState());
+
+    // Allow restart from FAILED state
+    auto result = machine_->ProcessEvent(StandbyEvent::START);
+    EXPECT_TRUE(result.allowed);
+    EXPECT_EQ(StandbyState::FAILED, result.old_state);
+    EXPECT_EQ(StandbyState::CONNECTING, result.new_state);
+    EXPECT_EQ(StandbyState::CONNECTING, machine_->GetState());
+}
+
+// ========== Promoted State Tests ==========
+
+TEST_F(StandbyStateMachineTest, TestPromotedToStopped) {
+    ReachWatchingState();
+    machine_->ProcessEvent(StandbyEvent::PROMOTE);
+    machine_->ProcessEvent(StandbyEvent::PROMOTION_SUCCESS);
+    EXPECT_EQ(StandbyState::PROMOTED, machine_->GetState());
+
+    auto result = machine_->ProcessEvent(StandbyEvent::STOP);
+    EXPECT_TRUE(result.allowed);
+    EXPECT_EQ(StandbyState::PROMOTED, result.old_state);
+    EXPECT_EQ(StandbyState::STOPPED, result.new_state);
+    EXPECT_EQ(StandbyState::STOPPED, machine_->GetState());
+}
+
+// ========== Invalid Transition Tests ==========
+
+TEST_F(StandbyStateMachineTest, TestInvalidTransitions) {
+    // Cannot transition from STOPPED directly to WATCHING
+    auto result1 = machine_->ProcessEvent(StandbyEvent::SYNC_COMPLETE);
+    EXPECT_FALSE(result1.allowed);
+    EXPECT_EQ(StandbyState::STOPPED, machine_->GetState());
+
+    // Cannot promote when not in WATCHING state
+    ReachSyncingState();
+    auto result2 = machine_->ProcessEvent(StandbyEvent::PROMOTE);
+    EXPECT_FALSE(result2.allowed);
+    EXPECT_EQ(StandbyState::SYNCING, machine_->GetState());
+
+    // Cannot transition from STOPPED to CONNECTED
+    machine_->ProcessEvent(StandbyEvent::STOP);
+    auto result3 = machine_->ProcessEvent(StandbyEvent::CONNECTED);
+    EXPECT_FALSE(result3.allowed);
+    EXPECT_EQ(StandbyState::STOPPED, machine_->GetState());
+}
+
+// ========== Error Handling Tests ==========
+
+TEST_F(StandbyStateMachineTest, TestConsecutiveErrors) {
+    ReachWatchingState();
+
+    // Simulate multiple errors
+    for (int i = 0; i < 5; ++i) {
+        machine_->IncrementErrors();
+    }
+    EXPECT_EQ(5, machine_->GetConsecutiveErrors());
+
+    // Reset errors
+    machine_->ResetErrors();
+    EXPECT_EQ(0, machine_->GetConsecutiveErrors());
+}
+
+TEST_F(StandbyStateMachineTest, TestMaxErrorsReachedAutoTransition) {
+    ReachWatchingState();
+
+    // IncrementErrors() automatically triggers MAX_ERRORS_REACHED when
+    // threshold is reached
+    for (int i = 0; i < StandbyStateMachine::kMaxConsecutiveErrors; ++i) {
+        machine_->IncrementErrors();
+    }
+
+    // Should have transitioned to RECOVERING (from WATCHING on
+    // MAX_ERRORS_REACHED)
+    EXPECT_EQ(StandbyState::RECOVERING, machine_->GetState());
+    EXPECT_EQ(StandbyStateMachine::kMaxConsecutiveErrors,
+              machine_->GetConsecutiveErrors());
+}
+
+TEST_F(StandbyStateMachineTest, TestMaxErrorsReachedManual) {
+    ReachWatchingState();
+
+    // Manually trigger MAX_ERRORS_REACHED
+    auto result = machine_->ProcessEvent(StandbyEvent::MAX_ERRORS_REACHED);
+    EXPECT_TRUE(result.allowed);
+    EXPECT_EQ(StandbyState::WATCHING, result.old_state);
+    EXPECT_EQ(StandbyState::RECOVERING, result.new_state);
+    EXPECT_EQ(StandbyState::RECOVERING, machine_->GetState());
+}
+
+TEST_F(StandbyStateMachineTest, TestReconnectCount) {
+    EXPECT_EQ(0, machine_->GetReconnectCount());
+
+    machine_->IncrementReconnectCount();
+    EXPECT_EQ(1, machine_->GetReconnectCount());
+
+    machine_->IncrementReconnectCount();
+    EXPECT_EQ(2, machine_->GetReconnectCount());
+
+    machine_->ResetReconnectCount();
+    EXPECT_EQ(0, machine_->GetReconnectCount());
+}
+
+// ========== Callback Tests ==========
+
+TEST_F(StandbyStateMachineTest, TestStateChangeCallback) {
+    std::vector<StandbyState> state_history;
+    std::vector<StandbyEvent> event_history;
+
+    machine_->RegisterCallback([&](StandbyState old_state,
+                                   StandbyState new_state, StandbyEvent event) {
+        state_history.push_back(new_state);
+        event_history.push_back(event);
+    });
+
+    // Trigger state transitions
+    machine_->ProcessEvent(StandbyEvent::START);
+    machine_->ProcessEvent(StandbyEvent::CONNECTED);
+    machine_->ProcessEvent(StandbyEvent::SYNC_COMPLETE);
+
+    // Verify callbacks were called
+    EXPECT_EQ(3, state_history.size());
+    EXPECT_EQ(StandbyState::CONNECTING, state_history[0]);
+    EXPECT_EQ(StandbyState::SYNCING, state_history[1]);
+    EXPECT_EQ(StandbyState::WATCHING, state_history[2]);
+    EXPECT_EQ(StandbyEvent::START, event_history[0]);
+    EXPECT_EQ(StandbyEvent::CONNECTED, event_history[1]);
+    EXPECT_EQ(StandbyEvent::SYNC_COMPLETE, event_history[2]);
+}
+
+TEST_F(StandbyStateMachineTest, TestMultipleCallbacks) {
+    int callback1_count = 0;
+    int callback2_count = 0;
+
+    machine_->RegisterCallback(
+        [&](StandbyState, StandbyState, StandbyEvent) { callback1_count++; });
+    machine_->RegisterCallback(
+        [&](StandbyState, StandbyState, StandbyEvent) { callback2_count++; });
+
+    // Trigger state transitions
+    machine_->ProcessEvent(StandbyEvent::START);
+    machine_->ProcessEvent(StandbyEvent::CONNECTED);
+
+    // Both callbacks should be called
+    EXPECT_EQ(2, callback1_count);
+    EXPECT_EQ(2, callback2_count);
+}
+
+TEST_F(StandbyStateMachineTest, TestCallbackExceptionHandling) {
+    bool callback_called = false;
+
+    machine_->RegisterCallback([&](StandbyState, StandbyState, StandbyEvent) {
+        callback_called = true;
+    });
+
+    // Callback should be invoked and must not interfere with state transitions
+    auto result = machine_->ProcessEvent(StandbyEvent::START);
+    EXPECT_TRUE(result.allowed);
+    EXPECT_EQ(StandbyState::CONNECTING, machine_->GetState());
+    EXPECT_TRUE(callback_called);
+}
+
+// ========== History Tests ==========
+
+TEST_F(StandbyStateMachineTest, TestTransitionHistory) {
+    // Perform several transitions
+    machine_->ProcessEvent(StandbyEvent::START);
+    machine_->ProcessEvent(StandbyEvent::CONNECTED);
+    machine_->ProcessEvent(StandbyEvent::SYNC_COMPLETE);
+
+    auto history = machine_->GetTransitionHistory(10);
+    EXPECT_EQ(3, history.size());
+    EXPECT_EQ(StandbyState::STOPPED, history[0].from_state);
+    EXPECT_EQ(StandbyState::CONNECTING, history[0].to_state);
+    EXPECT_EQ(StandbyEvent::START, history[0].event);
+
+    EXPECT_EQ(StandbyState::CONNECTING, history[1].from_state);
+    EXPECT_EQ(StandbyState::SYNCING, history[1].to_state);
+    EXPECT_EQ(StandbyEvent::CONNECTED, history[1].event);
+
+    EXPECT_EQ(StandbyState::SYNCING, history[2].from_state);
+    EXPECT_EQ(StandbyState::WATCHING, history[2].to_state);
+    EXPECT_EQ(StandbyEvent::SYNC_COMPLETE, history[2].event);
+}
+
+TEST_F(StandbyStateMachineTest, TestTransitionHistoryLimit) {
+    // Perform many transitions to test history limit
+    for (int i = 0; i < 20; ++i) {
+        machine_->ProcessEvent(StandbyEvent::START);
+        machine_->ProcessEvent(StandbyEvent::STOP);
+    }
+
+    // Request limited history
+    auto history = machine_->GetTransitionHistory(5);
+    EXPECT_LE(history.size(), 5);
+}
+
+TEST_F(StandbyStateMachineTest, TestTimeInState) {
+    machine_->ProcessEvent(StandbyEvent::START);
+
+    // Wait a bit
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    auto time_in_state = machine_->GetTimeInCurrentState();
+    EXPECT_GE(time_in_state.count(), 100);
+    EXPECT_LE(time_in_state.count(),
+              200);  // Allow some margin for test execution
+}
+
+// ========== Concurrent Tests ==========
+
+TEST_F(StandbyStateMachineTest, TestConcurrentStateQueries) {
+    ReachWatchingState();
+
+    // Multiple threads querying state concurrently
+    std::vector<std::thread> threads;
+    std::atomic<int> success_count{0};
+
+    for (int i = 0; i < 10; ++i) {
+        threads.emplace_back([&]() {
+            for (int j = 0; j < 100; ++j) {
+                StandbyState state = machine_->GetState();
+                if (state == StandbyState::WATCHING) {
+                    success_count++;
+                }
+            }
+        });
+    }
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    EXPECT_EQ(1000, success_count.load());
+}
+
+TEST_F(StandbyStateMachineTest, TestConcurrentEventProcessing) {
+    ReachWatchingState();
+
+    // Multiple threads trying to process events concurrently
+    // Only one should succeed (state machine should serialize)
+    std::vector<std::thread> threads;
+    std::atomic<int> success_count{0};
+    std::atomic<int> failure_count{0};
+
+    for (int i = 0; i < 10; ++i) {
+        threads.emplace_back([&]() {
+            auto result = machine_->ProcessEvent(StandbyEvent::STOP);
+            if (result.allowed) {
+                success_count++;
+            } else {
+                failure_count++;
+            }
+        });
+    }
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    // Only one STOP should succeed (transition to STOPPED)
+    EXPECT_EQ(1, success_count.load());
+    EXPECT_EQ(9, failure_count.load());
+    EXPECT_EQ(StandbyState::STOPPED, machine_->GetState());
+}
+
+// ========== State Query Tests ==========
+
+TEST_F(StandbyStateMachineTest, TestIsRunning) {
+    EXPECT_FALSE(machine_->IsRunning());  // STOPPED
+
+    machine_->ProcessEvent(StandbyEvent::START);
+    // CONNECTING only means establishing connection; sync has not started, so
+    // it is not considered "running"
+    EXPECT_FALSE(machine_->IsRunning());  // CONNECTING
+
+    machine_->ProcessEvent(StandbyEvent::CONNECTED);
+    EXPECT_TRUE(machine_->IsRunning());  // SYNCING
+
+    machine_->ProcessEvent(StandbyEvent::SYNC_COMPLETE);
+    EXPECT_TRUE(machine_->IsRunning());  // WATCHING
+
+    machine_->ProcessEvent(StandbyEvent::STOP);
+    EXPECT_FALSE(machine_->IsRunning());  // STOPPED
+}
+
+TEST_F(StandbyStateMachineTest, TestIsConnected) {
+    EXPECT_FALSE(machine_->IsConnected());  // STOPPED
+
+    machine_->ProcessEvent(StandbyEvent::START);
+    EXPECT_FALSE(machine_->IsConnected());  // CONNECTING
+
+    machine_->ProcessEvent(StandbyEvent::CONNECTED);
+    EXPECT_TRUE(machine_->IsConnected());  // SYNCING
+
+    machine_->ProcessEvent(StandbyEvent::SYNC_COMPLETE);
+    EXPECT_TRUE(machine_->IsConnected());  // WATCHING
+
+    machine_->ProcessEvent(StandbyEvent::STOP);
+    EXPECT_FALSE(machine_->IsConnected());  // STOPPED
+}
+
+TEST_F(StandbyStateMachineTest, TestIsWatchHealthy) {
+    EXPECT_FALSE(machine_->IsWatchHealthy());  // STOPPED
+
+    ReachWatchingState();
+    EXPECT_TRUE(machine_->IsWatchHealthy());  // WATCHING
+
+    machine_->ProcessEvent(StandbyEvent::WATCH_BROKEN);
+    EXPECT_FALSE(machine_->IsWatchHealthy());  // RECONNECTING
+}
+
+TEST_F(StandbyStateMachineTest, TestIsReadyForPromotion) {
+    EXPECT_FALSE(machine_->IsReadyForPromotion());  // STOPPED
+
+    ReachWatchingState();
+    EXPECT_TRUE(machine_->IsReadyForPromotion());  // WATCHING
+
+    machine_->ProcessEvent(StandbyEvent::PROMOTE);
+    EXPECT_FALSE(machine_->IsReadyForPromotion());  // PROMOTING
+}
+
+// ========== Complete State Machine Flow Tests ==========
+
+TEST_F(StandbyStateMachineTest, TestCompleteNormalFlow) {
+    // Complete flow: STOPPED -> CONNECTING -> SYNCING -> WATCHING
+    EXPECT_EQ(StandbyState::STOPPED, machine_->GetState());
+
+    machine_->ProcessEvent(StandbyEvent::START);
+    EXPECT_EQ(StandbyState::CONNECTING, machine_->GetState());
+
+    machine_->ProcessEvent(StandbyEvent::CONNECTED);
+    EXPECT_EQ(StandbyState::SYNCING, machine_->GetState());
+
+    machine_->ProcessEvent(StandbyEvent::SYNC_COMPLETE);
+    EXPECT_EQ(StandbyState::WATCHING, machine_->GetState());
+    EXPECT_TRUE(machine_->IsReadyForPromotion());
+}
+
+TEST_F(StandbyStateMachineTest, TestCompletePromotionFlow) {
+    // Complete promotion flow
+    ReachWatchingState();
+
+    machine_->ProcessEvent(StandbyEvent::PROMOTE);
+    EXPECT_EQ(StandbyState::PROMOTING, machine_->GetState());
+
+    machine_->ProcessEvent(StandbyEvent::PROMOTION_SUCCESS);
+    EXPECT_EQ(StandbyState::PROMOTED, machine_->GetState());
+}
+
+TEST_F(StandbyStateMachineTest, TestCompleteReconnectFlow) {
+    // Complete reconnect flow: WATCHING -> RECONNECTING -> SYNCING -> WATCHING
+    ReachWatchingState();
+
+    machine_->ProcessEvent(StandbyEvent::WATCH_BROKEN);
+    EXPECT_EQ(StandbyState::RECONNECTING, machine_->GetState());
+
+    machine_->ProcessEvent(StandbyEvent::CONNECTED);
+    EXPECT_EQ(StandbyState::SYNCING, machine_->GetState());
+
+    machine_->ProcessEvent(StandbyEvent::SYNC_COMPLETE);
+    EXPECT_EQ(StandbyState::WATCHING, machine_->GetState());
+}
+
+TEST_F(StandbyStateMachineTest, TestCompleteRecoveryFlow) {
+    // Complete recovery flow: WATCHING -> RECOVERING -> WATCHING
+    ReachWatchingState();
+
+    machine_->ProcessEvent(StandbyEvent::MAX_ERRORS_REACHED);
+    EXPECT_EQ(StandbyState::RECOVERING, machine_->GetState());
+
+    machine_->ProcessEvent(StandbyEvent::RECOVERY_SUCCESS);
+    EXPECT_EQ(StandbyState::WATCHING, machine_->GetState());
+}
+
+}  // namespace mooncake::test
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/mooncake-store/tests/p2p_client_http_endpoints_test.cpp
+++ b/mooncake-store/tests/p2p_client_http_endpoints_test.cpp
@@ -11,7 +11,6 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
-
 #include <csignal>
 #include <cstdint>
 #include <memory>


### PR DESCRIPTION
Description

  Port the self-contained OpLog components (layer 0-2) that have no dependency on Centralized-mode types (MetadataStore,
  Replica::Descriptor, Snapshot, etc.), enabling P2P Master HA development on top.

  Ported from main:
  - standby_state_machine, ha_metric_manager, base64 (layer 0, zero-dep)
  - oplog_manager, oplog_change_notifier, oplog_serializer (layer 1)
  - oplog_store, polling_oplog_change_notifier, localfs_oplog_store, oplog_store_factory (layer 2)
  - 5 unit test files (122 test cases, all passing)

  P2P adaptations:
  - types.h: add OPLOG_ENTRY_NOT_FOUND, IsValidClusterIdComponent(), IsSequenceNewer() and related sequence comparison
  utilities
  - oplog_store_factory: add TBASE enum placeholder for future TBase backend
  - CMake: add xxhash link dependency and new source/test targets

  Not ported (depend on MetadataStore / HotStandbyService):
  oplog_applier, oplog_replicator, hot_standby_service,
  standby_controller, etcd_oplog_store, snapshot/

  Module

  - [ ] Transfer Engine (mooncake-transfer-engine)
  - [] Mooncake Store (mooncake-store)
  - [ ] Mooncake EP (mooncake-ep)
  - [ ] Mooncake PG (mooncake-pg)
  - [ ] Integration (mooncake-integration)
  - [x] P2P Store (mooncake-p2p-store)
  - [ ] Python Wheel (mooncake-wheel)
  - [ ] Common (mooncake-common)
  - [ ] Mooncake RL (mooncake-rl)
  - [ ] CI/CD
  - [ ] Docs
  - [ ] Other

  Type of Change

  - [ ] Bug fix
  - [x] New feature
  - [ ] Refactor
  - [ ] Breaking change
  - [ ] Documentation update
  - [ ] Performance improvement
  - [ ] Other

  How Has This Been Tested?

  Test commands:
  # Build
  docker exec mooncake-dev bash -c "cd /workspace && rm -rf build && mkdir build && cd build && cmake ..
  -DCMAKE_BUILD_TYPE=Debug && make oplog_manager_test oplog_serializer_test localfs_oplog_store_test standby_state_machine_test
  ha_metric_manager_test -j3"

  # Run tests
  docker exec mooncake-dev bash -c "cd /workspace/build && ctest -R
  'oplog_manager_test|oplog_serializer_test|localfs_oplog_store_test|standby_state_machine_test|ha_metric_manager_test' -V"

  Test results:
  - [x] Unit tests pass
  - [ ] Integration tests pass (if applicable)
  - [ ] Manual testing done (describe below)

  5/5 tests passed, 122 test cases total:
    oplog_manager_test         — 25 cases (21 passed, 3 skipped [etcd])
    oplog_serializer_test      — 12 cases
    localfs_oplog_store_test   — 21 cases
    standby_state_machine_test — 48 cases
    ha_metric_manager_test     — 16 cases

  Checklist

  - [x] I have performed a self-review of my own code
  - [ ] I have formatted my code using ./scripts/code_format.sh
  - [ ] I have run pre-commit run --all-files and all hooks pass
  - [ ] I have updated the documentation (if applicable)
  - [x] I have added tests to prove my changes are effective
  - [ ] For changes >500 LOC: I have filed an RFC issue

  AI Assistance Disclosure

  - [ ] No AI tools were used
  - [x] AI tools were used (specify below)

  Claude Code was used for dependency analysis and code porting. All changes were reviewed and verified by the submitter.