### PR TITLE
[Store] Fix ABBA deadlock between GracefulUnmountScheduler and snapshot_mutex_

### DIFF
--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -7212,6 +7212,10 @@ void MasterService::GracefulUnmountScheduler::TimerLoop() {
             queue_.pop();
         }
 
+        // Release the scheduler mutex before UnmountSegment (which takes
+        // snapshot_mutex_) to avoid a lock-order inversion deadlock.
+        lock.unlock();
+
         for (auto& rec : expired) {
             if (service_) {
                 auto result =


### PR DESCRIPTION
## Description

`GracefulUnmountScheduler::TimerLoop` and `GracefulUnmountSegment` acquire two locks — the scheduler's `mutex_` and the master's `snapshot_mutex_` — in **opposite orders**, which can deadlock (ABBA):

| Thread | holds | then waits for |
| --- | --- | --- |
| `GracefulUnmountSegment` (RPC) | `snapshot_mutex_` (exclusive, `master_service.cpp:853`) | scheduler `mutex_` via `Schedule()` (`:883` → `:7143`) |
| `TimerLoop` (background thread) | scheduler `mutex_` (`:7188`) | `snapshot_mutex_` (shared) via `UnmountSegment()` (`:7218` → `:819`) |

Run concurrently, each thread waits on the lock the other holds; because the `snapshot_mutex_` writer blocks `TimerLoop`'s reader acquire, both the RPC thread and the timer thread wedge permanently, and the scheduler's `Stop()`/`join()` on shutdown then hangs too. `GracefulUnmountSegment` is a wired RPC (`rpc_service.cpp`, `master_client.cpp`, `client_service.cpp`), so this is reachable in production under concurrent graceful unmounts.

**Fix:** `TimerLoop` already drains the expired records into a local vector before processing them; release the scheduler `mutex_` immediately after draining and **before** calling `UnmountSegment`. `TimerLoop` then never holds the scheduler lock while acquiring `snapshot_mutex_`, removing the ordering inversion. No state is shared across the unlock (the queue is already drained; the per-record loop only calls `UnmountSegment` and reads an atomic).

Other acquirers of the scheduler `mutex_` were checked and are **not** affected: `RemoveClientRecords` is called in `ClientMonitorFunc` *before* `snapshot_mutex_` is taken (not nested), and `Stop()` runs only from the destructor (not under `snapshot_mutex_`).

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

Built on Ubuntu 24.04 (`-DWITH_STORE=ON -DUSE_HTTP=ON -DUSE_ETCD=ON`):

- `master_service_test` — **129/129 passed**, including the 8 `GracefulUnmountSegment_*` tests; in particular `…_TimerExpiresAndUnmounts`, `…_EarlierTimerPreemptsWait`, and `…_PreventAllocation` exercise the exact `TimerLoop → UnmountSegment` path that was modified.
- `segment_test` — **11/11 passed**.

**Empirical confirmation.** A 16-thread stress harness that repeatedly mounts a segment and calls `GracefulUnmountSegment` with a 1 ms grace period (so the scheduler's `TimerLoop` fires constantly) **hangs the unfixed code** — killed after a 60 s `timeout` (exit 124), wedged exactly as analyzed — and **completes in ~2 s with this fix** (identical 16×600 workload, test passes). The harness is intentionally *not* included in the PR: it relies on hitting a timing race and detects the bug via a hang/timeout, which is unsuitable as a CI unit test.

A deterministic unit test for the deadlock itself is not practical (timing-dependent ABBA on a private mutex), so the committed coverage is the existing graceful-unmount tests above, which exercise the modified `TimerLoop → UnmountSegment` path; the fix itself is structural (the lock-order inversion is removed).

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code with `./scripts/code_format.sh` (clang-format-20) before submitting.
- [ ] I have updated the documentation. _(n/a — internal concurrency fix)_
- [x] I have added tests to prove my changes are effective. _(existing GracefulUnmount tests cover the modified path; see above)_
