### PR TITLE
[Store][TE] Fix remaining signed-char ::tolower/::toupper UB missed by #2367

### DIFF
--- a/mooncake-store/include/ha/oplog/oplog_store_factory.h
+++ b/mooncake-store/include/ha/oplog/oplog_store_factory.h
@@ -33,7 +33,7 @@ static constexpr OpLogStoreType kDefaultOpLogStoreType =
 inline OpLogStoreType ParseOpLogStoreType(const std::string& type_str) {
     std::string lower = type_str;
     std::transform(lower.begin(), lower.end(), lower.begin(),
-                   [](unsigned char c) { return std::tolower(c); });
+                   [](unsigned char c) -> char { return std::tolower(c); });
     if (lower == "localfs" || lower == "local_fs") {
         return OpLogStoreType::LOCAL_FS;
     }

--- a/mooncake-store/include/ha/oplog/oplog_store_factory.h
+++ b/mooncake-store/include/ha/oplog/oplog_store_factory.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cctype>
 #include <memory>
 #include <string>
 
@@ -31,7 +32,8 @@ static constexpr OpLogStoreType kDefaultOpLogStoreType =
 // Returns kDefaultOpLogStoreType for unrecognized strings.
 inline OpLogStoreType ParseOpLogStoreType(const std::string& type_str) {
     std::string lower = type_str;
-    std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+    std::transform(lower.begin(), lower.end(), lower.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
     if (lower == "localfs" || lower == "local_fs") {
         return OpLogStoreType::LOCAL_FS;
     }

--- a/mooncake-store/include/utils.h
+++ b/mooncake-store/include/utils.h
@@ -222,7 +222,8 @@ std::string expected_to_str(const tl::expected<T, ErrorCode>& expected) {
     unit.erase(0, unit.find_first_not_of(" \t\r\n"));
 
     // Convert to uppercase for comparison
-    std::transform(unit.begin(), unit.end(), unit.begin(), ::toupper);
+    std::transform(unit.begin(), unit.end(), unit.begin(),
+                   [](unsigned char c) { return std::toupper(c); });
 
     // Apply unit multiplier
     const double KB = 1024.0;

--- a/mooncake-store/include/utils.h
+++ b/mooncake-store/include/utils.h
@@ -223,7 +223,7 @@ std::string expected_to_str(const tl::expected<T, ErrorCode>& expected) {
 
     // Convert to uppercase for comparison
     std::transform(unit.begin(), unit.end(), unit.begin(),
-                   [](unsigned char c) { return std::toupper(c); });
+                   [](unsigned char c) -> char { return std::toupper(c); });
 
     // Apply unit multiplier
     const double KB = 1024.0;

--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
@@ -20,6 +20,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cctype>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
@@ -603,7 +604,8 @@ struct TcpContext {
 TcpTransport::TcpTransport() : context_(nullptr), running_(false) {
     if (getenv("MC_TCP_ENABLE_CONNECTION_POOL") != nullptr) {
         std::string val(getenv("MC_TCP_ENABLE_CONNECTION_POOL"));
-        std::transform(val.begin(), val.end(), val.begin(), ::tolower);
+        std::transform(val.begin(), val.end(), val.begin(),
+                       [](unsigned char c) { return std::tolower(c); });
         if (val == "0" || val == "false" || val == "no") {
             enable_connection_pool_ = false;
         } else {

--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
@@ -605,7 +605,7 @@ TcpTransport::TcpTransport() : context_(nullptr), running_(false) {
     if (getenv("MC_TCP_ENABLE_CONNECTION_POOL") != nullptr) {
         std::string val(getenv("MC_TCP_ENABLE_CONNECTION_POOL"));
         std::transform(val.begin(), val.end(), val.begin(),
-                       [](unsigned char c) { return std::tolower(c); });
+                       [](unsigned char c) -> char { return std::tolower(c); });
         if (val == "0" || val == "false" || val == "no") {
             enable_connection_pool_ = false;
         } else {


### PR DESCRIPTION
Fixes #2487

## Description

Follow-up to #2367, which fixed UB from passing a (possibly signed) `char` to `::tolower`/`::toupper` via `std::transform`. Three sibling occurrences on operator/CLI-controlled input were missed and are still present on `main`:

| File | Input source |
|---|---|
| `mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp:606` | env `MC_TCP_ENABLE_CONNECTION_POOL` |
| `mooncake-store/include/utils.h:225` | size-string unit suffix (env `MC_MMAP_ARENA_POOL_SIZE`, `global_segment_size` CLI flag, config map) |
| `mooncake-store/include/ha/oplog/oplog_store_factory.h:34` | HA `oplog_store_type` config string |

Passing a byte > 0x7F to `::tolower`/`::toupper` sign-extends to a negative `int`, which is UB (the argument must be representable as `unsigned char` or equal `EOF`). All three sites take operator/attacker-controllable bytes, not kernel-generated ASCII.

Each is fixed with the exact idiom from #2367 — `[](unsigned char c) { return std::tolower(c); }` — and `<cctype>` is added to the two files where it was only available transitively (`utils.h` already includes it). Notably `utils.h:274` already uses the safe lambda; line 225 was simply overlooked in the original sweep.

Behavior is unchanged for ASCII input; this only removes the UB on non-ASCII bytes.

## Module

- [x] Mooncake Store (`mooncake-store`)
- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

**Test commands:**
```bash
# Ubuntu 22.04 (aarch64) container, cmake -DWITH_STORE_RUST=OFF -DUSE_HTTP=ON, ninja
ninja
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

This is the same class of fix as #2367, which shipped with no new test: the change is behavior-preserving for ASCII, and the UB is not portably observable (on glibc the ctype tables span -128..255, so it does not crash there). Validation is compile-only plus the existing suite: a full incremental build succeeds (all three headers/TUs and their dependents recompile cleanly with the added `<cctype>` includes), and the existing `tcp_transport` / store tests pass.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

(No new test, matching the precedent set by #2367 for this UB class; the fix is behavior-preserving for ASCII and the UB is not portably observable on the target platform.)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Claude Code (Claude Fable 5) located the three remaining sites missed by #2367, applied the established idiom, and verified the build in a local Linux container. I reviewed the changes and am responsible for them.