### PR TITLE
[TE][Fix] Fix excessive memory allocation in submitPostSend

### DIFF
--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -730,8 +730,15 @@ int RdmaEndPoint::submitPostSend(
     if (slice_list.empty()) return 0;
     const size_t requested = slice_list.size();
     int cq_remaining = int(globalConfig().max_cqe) - *cq_outstanding_;
-    std::vector<ibv_send_wr> wr_list(requested, ibv_send_wr{});
-    std::vector<ibv_sge> sge_list(requested);
+    if (cq_remaining <= 0) return 0;
+
+    // Only allocate for the max number of WRs we can actually post per QP,
+    // not the entire requested slice count. Each QP iteration reuses the
+    // wr_list/sge_list from index 0, so we only need max_wr_depth_ entries.
+    size_t max_postable_per_qp =
+        std::min({(size_t)max_wr_depth_, (size_t)cq_remaining, requested});
+    std::vector<ibv_send_wr> wr_list(max_postable_per_qp, ibv_send_wr{});
+    std::vector<ibv_sge> sge_list(max_postable_per_qp);
     size_t total_posted = 0;
     size_t cursor = 0;
 


### PR DESCRIPTION
## Description

The `wr_list` and `sge_list` vectors in `RdmaEndPoint::submitPostSend()` were allocated with size equal to the entire requested slice count (`slice_list.size()`). However, each QP iteration reuses these arrays from index 0, and `ibv_post_send` always starts from `wr_list.data()`. The actual maximum usage per QP is bounded by `max_wr_depth_` (default 256).

For large transfers (e.g., 55GB with default 64KB slice size), this caused allocation of **~112MB** per `submitPostSend` call (877,952 × 128B), leading to 17-23ms overhead per call and creating a positive feedback loop where the growing queue caused even larger allocations, ultimately resulting in transfer timeouts.

**Fix:** Allocate `wr_list`/`sge_list` with size = `min(max_wr_depth_, cq_remaining, requested)` instead of the full requested count. This reduces allocation from ~112MB to ~32KB (256 entries).

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix
- [x] Performance improvement

## How Has This Been Tested?

Tested with a real RDMA transfer of 55GB (GPU memory, peermem) between two nodes using the default 64KB slice size.

| Scenario | Before Fix | After Fix |
|----------|-----------|-----------|
| 55GB RDMA read (64KB slice) | ❌ FAIL (timeout after 87.67s) | ✅ OK in 1.72s |
| Allocation per call | ~112MB (877,952 entries) | ~32KB (256 entries) |

- [x] Manual testing done

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue