### PR TITLE
[Store] dynamic tenant quota master admission

### DIFF
--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -69,6 +69,9 @@ struct MasterConfig {
     // Storage backend eviction configuration
     bool enable_disk_eviction;
     uint64_t quota_bytes;
+    bool enable_tenant_quota = false;
+    uint64_t default_tenant_quota_bytes = 0;
+    uint64_t tenant_quota_pool_capacity_bytes = 0;
 
     bool enable_snapshot_restore;
     bool enable_snapshot;
@@ -160,6 +163,9 @@ class MasterServiceSupervisorConfig {
     uint64_t put_start_release_timeout_sec = DEFAULT_PUT_START_RELEASE_TIMEOUT;
     bool enable_disk_eviction = true;
     uint64_t quota_bytes = 0;
+    bool enable_tenant_quota = false;
+    uint64_t default_tenant_quota_bytes = 0;
+    uint64_t tenant_quota_pool_capacity_bytes = 0;
     uint32_t max_total_finished_tasks = DEFAULT_MAX_TOTAL_FINISHED_TASKS;
     uint32_t max_total_pending_tasks = DEFAULT_MAX_TOTAL_PENDING_TASKS;
     uint32_t max_total_processing_tasks = DEFAULT_MAX_TOTAL_PROCESSING_TASKS;
@@ -245,6 +251,10 @@ class MasterServiceSupervisorConfig {
         put_start_release_timeout_sec = config.put_start_release_timeout_sec;
         enable_disk_eviction = config.enable_disk_eviction;
         quota_bytes = config.quota_bytes;
+        enable_tenant_quota = config.enable_tenant_quota;
+        default_tenant_quota_bytes = config.default_tenant_quota_bytes;
+        tenant_quota_pool_capacity_bytes =
+            config.tenant_quota_pool_capacity_bytes;
 
         enable_snapshot_restore = config.enable_snapshot_restore;
         enable_snapshot = config.enable_snapshot;
@@ -371,6 +381,9 @@ class WrappedMasterServiceConfig {
     uint64_t put_start_release_timeout_sec = DEFAULT_PUT_START_RELEASE_TIMEOUT;
     bool enable_disk_eviction = true;
     uint64_t quota_bytes = 0;
+    bool enable_tenant_quota = false;
+    uint64_t default_tenant_quota_bytes = 0;
+    uint64_t tenant_quota_pool_capacity_bytes = 0;
 
     bool enable_snapshot_restore = false;
     bool enable_snapshot = false;
@@ -436,6 +449,10 @@ class WrappedMasterServiceConfig {
         global_file_segment_size = config.global_file_segment_size;
         enable_disk_eviction = config.enable_disk_eviction;
         quota_bytes = config.quota_bytes;
+        enable_tenant_quota = config.enable_tenant_quota;
+        default_tenant_quota_bytes = config.default_tenant_quota_bytes;
+        tenant_quota_pool_capacity_bytes =
+            config.tenant_quota_pool_capacity_bytes;
 
         // Convert string memory_allocator to BufferAllocatorType enum
         if (config.memory_allocator == "cachelib") {
@@ -523,6 +540,10 @@ class WrappedMasterServiceConfig {
         memory_allocator = config.memory_allocator;
         enable_disk_eviction = config.enable_disk_eviction;
         quota_bytes = config.quota_bytes;
+        enable_tenant_quota = config.enable_tenant_quota;
+        default_tenant_quota_bytes = config.default_tenant_quota_bytes;
+        tenant_quota_pool_capacity_bytes =
+            config.tenant_quota_pool_capacity_bytes;
         put_start_discard_timeout_sec = config.put_start_discard_timeout_sec;
         put_start_release_timeout_sec = config.put_start_release_timeout_sec;
 
@@ -584,6 +605,9 @@ class MasterServiceConfigBuilder {
         AllocationStrategyType::RANDOM;
     bool enable_disk_eviction_ = true;
     uint64_t quota_bytes_ = 0;
+    bool enable_tenant_quota_ = false;
+    uint64_t default_tenant_quota_bytes_ = 0;
+    uint64_t tenant_quota_pool_capacity_bytes_ = 0;
     uint64_t put_start_discard_timeout_sec_ = DEFAULT_PUT_START_DISCARD_TIMEOUT;
     uint64_t put_start_release_timeout_sec_ = DEFAULT_PUT_START_RELEASE_TIMEOUT;
     bool enable_snapshot_restore_ = false;
@@ -722,6 +746,22 @@ class MasterServiceConfigBuilder {
     MasterServiceConfigBuilder& set_allocation_strategy_type(
         AllocationStrategyType type) {
         allocation_strategy_type_ = type;
+        return *this;
+    }
+
+    MasterServiceConfigBuilder& set_enable_tenant_quota(bool enable) {
+        enable_tenant_quota_ = enable;
+        return *this;
+    }
+
+    MasterServiceConfigBuilder& set_default_tenant_quota_bytes(uint64_t bytes) {
+        default_tenant_quota_bytes_ = bytes;
+        return *this;
+    }
+
+    MasterServiceConfigBuilder& set_tenant_quota_pool_capacity_bytes(
+        uint64_t bytes) {
+        tenant_quota_pool_capacity_bytes_ = bytes;
         return *this;
     }
 
@@ -910,6 +950,9 @@ class MasterServiceConfig {
     uint64_t put_start_release_timeout_sec = DEFAULT_PUT_START_RELEASE_TIMEOUT;
     bool enable_disk_eviction = true;
     uint64_t quota_bytes = 0;
+    bool enable_tenant_quota = false;
+    uint64_t default_tenant_quota_bytes = 0;
+    uint64_t tenant_quota_pool_capacity_bytes = 0;
 
     bool enable_snapshot_restore = false;
     bool enable_snapshot = false;
@@ -972,6 +1015,10 @@ class MasterServiceConfig {
         allocation_strategy_type = config.allocation_strategy_type;
         enable_disk_eviction = config.enable_disk_eviction;
         quota_bytes = config.quota_bytes;
+        enable_tenant_quota = config.enable_tenant_quota;
+        default_tenant_quota_bytes = config.default_tenant_quota_bytes;
+        tenant_quota_pool_capacity_bytes =
+            config.tenant_quota_pool_capacity_bytes;
         put_start_discard_timeout_sec = config.put_start_discard_timeout_sec;
         put_start_release_timeout_sec = config.put_start_release_timeout_sec;
 
@@ -1035,6 +1082,9 @@ inline MasterServiceConfig MasterServiceConfigBuilder::build() const {
     config.put_start_release_timeout_sec = put_start_release_timeout_sec_;
     config.enable_disk_eviction = enable_disk_eviction_;
     config.quota_bytes = quota_bytes_;
+    config.enable_tenant_quota = enable_tenant_quota_;
+    config.default_tenant_quota_bytes = default_tenant_quota_bytes_;
+    config.tenant_quota_pool_capacity_bytes = tenant_quota_pool_capacity_bytes_;
     config.enable_snapshot_restore = enable_snapshot_restore_;
     config.enable_snapshot = enable_snapshot_;
     config.snapshot_backup_dir = snapshot_backup_dir_;

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1153,6 +1153,7 @@ class MasterService {
         ReplicaID source_id;    // the LOCAL_DISK replica being promoted
         ReplicaID alloc_id{0};  // the new MEMORY replica staged by AllocStart
         uint64_t object_size;
+        uint64_t reserved_quota_charge_bytes{0};
         std::chrono::system_clock::time_point start_time;
         UUID holder_id;  // owner of source LOCAL_DISK; only Notifier allowed
     };
@@ -1408,12 +1409,17 @@ class MasterService {
      */
     void TryPushPromotionQueue(const ObjectIdentity& object_id);
 
-    // Erase any in-flight PromotionTask for `key` and decrement the
-    // cluster-wide in-flight counter. Safe no-op if no task exists.
-    void ErasePromotionTaskIfPresent(TenantState& tenant_state,
-                                     const std::string& key)
-        NO_THREAD_SAFETY_ANALYSIS {
-        if (tenant_state.promotion_tasks.erase(key) > 0) {
+    // Erase any in-flight PromotionTask for `key`, abort any staged promotion
+    // quota reservation, and decrement the cluster-wide in-flight counter. Safe
+    // no-op if no task exists.
+    void ErasePromotionTaskIfPresent(
+        TenantState& tenant_state, const std::string& key,
+        const std::string& tenant_id) NO_THREAD_SAFETY_ANALYSIS {
+        auto task_it = tenant_state.promotion_tasks.find(key);
+        if (task_it != tenant_state.promotion_tasks.end()) {
+            AbortTenantQuota(tenant_id,
+                             task_it->second.reserved_quota_charge_bytes);
+            tenant_state.promotion_tasks.erase(task_it);
             promotion_in_flight_.fetch_sub(1, std::memory_order_relaxed);
             MasterMetricManager::instance().dec_promotion_in_flight();
             MasterMetricManager::instance().inc_promotion_cancelled();
@@ -1510,7 +1516,8 @@ class MasterService {
                     }
                     if (tenant_state_ != nullptr) {
                         service_->ErasePromotionTaskIfPresent(
-                            *tenant_state_, object_id_.user_key);
+                            *tenant_state_, object_id_.user_key,
+                            object_id_.tenant_id);
                         MaybeEraseEmptyTenant();
                     }
                 }

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -27,6 +27,7 @@
 #include "master_metric_manager.h"
 #include "mutex.h"
 #include "segment.h"
+#include "tenant_quota.h"
 #include "types.h"
 #include "master_config.h"
 #include "rpc_types.h"
@@ -56,6 +57,7 @@ class SnapshotChildProcessTest;
 // standing up a full snapshot catalog + child-process harness, and
 // exposing test-only accessors on MasterService itself.
 class PromotionOnHitTest;
+class MasterServiceTenantQuotaTest;
 }  // namespace test
 
 /*
@@ -63,13 +65,15 @@ class PromotionOnHitTest;
  * Lock order: To avoid deadlocks, the following lock order should be followed:
  * 1. client_mutex_
  * 2. metadata_shards_[shard_idx_].mutex
- * 3. segment_mutex_
+ * 3. tenant_quota_shards_[shard_idx_].mutex
+ * 4. segment_mutex_
  */
 class MasterService {
     // Test friend class for snapshot/restore testing
     friend class test::MasterServiceSnapshotTestBase;
     friend class test::SnapshotChildProcessTest;
     friend class test::PromotionOnHitTest;
+    friend class test::MasterServiceTenantQuotaTest;
 
    public:
     using NoFProbeFn =
@@ -84,6 +88,8 @@ class MasterService {
     bool IsNoFSegmentMountedForTesting(const UUID& segment_id);
     std::optional<uint32_t> GetNoFHeartbeatFailureCountForTesting(
         const UUID& segment_id);
+    std::optional<TenantQuotaSnapshot> GetTenantQuotaSnapshotForTesting(
+        const std::string& tenant_id) const;
 
     /**
      * @brief Mount a memory segment for buffer allocation. This function is
@@ -864,6 +870,9 @@ class MasterService {
         const bool hard_pinned{false};          // immutable, set at creation
         bool memory_cache_total_accounted{false};
         bool disk_cache_total_accounted{false};
+        uint64_t reserved_quota_charge_bytes{0};
+        uint64_t committed_quota_charge_bytes{0};
+        uint64_t pending_replaced_quota_charge_bytes{0};
 
         void AddReplicas(std::vector<Replica>&& replicas) {
             replicas_.insert(replicas_.end(),
@@ -1189,6 +1198,14 @@ class MasterService {
         ObjectMetadata& metadata,
         const std::function<bool(const Replica&)>& pred_fn);
 
+    static constexpr size_t kNumTenantQuotaShards = 1024;
+    struct TenantQuotaShard {
+        mutable std::mutex mutex;
+        std::unordered_map<std::string, TenantQuotaState> tenants
+            GUARDED_BY(mutex);
+    };
+    std::array<TenantQuotaShard, kNumTenantQuotaShards> tenant_quota_shards_;
+
     std::unordered_map<std::string, std::string> object_group_ids_
         GUARDED_BY(group_routing_mutex_);
     mutable std::unordered_set<std::string> groups_needing_lease_refresh_
@@ -1279,6 +1296,7 @@ class MasterService {
 
     size_t getMetadataShardIndex(const std::string& tenant_id,
                                  const std::string& key) const;
+    size_t getTenantQuotaShardIndex(const std::string& tenant_id) const;
     std::optional<std::string> GetGroupRoute(const std::string& tenant_id,
                                              const std::string& key) const;
     void RegisterGroupMember(TenantState& tenant_state,
@@ -1293,6 +1311,29 @@ class MasterService {
         TenantState& tenant_state,
         std::unordered_map<std::string, ObjectMetadata>::iterator it,
         const std::string& tenant_id);
+    enum class QuotaEraseMode {
+        kFull,
+        kPreserveOld,
+        kAbortOnly,
+    };
+    std::unordered_map<std::string, ObjectMetadata>::iterator EraseMetadata(
+        TenantState& tenant_state,
+        std::unordered_map<std::string, ObjectMetadata>::iterator it,
+        const std::string& tenant_id, QuotaEraseMode quota_mode);
+    uint64_t CompletedMemoryQuotaCharge(const ObjectMetadata& metadata) const;
+    uint64_t RequestedMemoryQuotaCharge(uint64_t value_length,
+                                        const ReplicateConfig& config) const;
+    tl::expected<void, ErrorCode> ReserveTenantQuota(
+        const std::string& tenant_id, uint64_t bytes);
+    void CommitTenantQuota(const std::string& tenant_id, uint64_t bytes);
+    void AbortTenantQuota(const std::string& tenant_id, uint64_t bytes);
+    void ReleaseTenantQuota(const std::string& tenant_id, uint64_t bytes);
+    void ReleaseTenantQuotaPartial(const std::string& tenant_id,
+                                   uint64_t bytes);
+    void ReleaseCommittedQuotaCharge(ObjectMetadata& metadata, uint64_t bytes);
+    void RecomputeTenantEffectiveQuotas();
+    void RebuildTenantQuotaUsageFromMetadata();
+    uint64_t GetTenantQuotaCapacityBytes();
     void RebuildGroupRoutingIndex();
     void GrantLeaseForGroup(const TenantState& tenant_state,
                             const std::string& key,
@@ -1447,10 +1488,18 @@ class MasterService {
                 // Erase invalid memory replicas (those with unmounted
                 // segments). No client_mutex_ needed since we only check memory
                 // replicas.
+                const uint64_t before_charge =
+                    service_->CompletedMemoryQuotaCharge(it_->second);
                 service_->EraseReplicasWithCacheTotalAccounting(
                     it_->second, [](const Replica& replica) {
                         return replica.has_invalid_mem_handle();
                     });
+                const uint64_t after_charge =
+                    service_->CompletedMemoryQuotaCharge(it_->second);
+                if (before_charge > after_charge) {
+                    service_->ReleaseCommittedQuotaCharge(
+                        it_->second, before_charge - after_charge);
+                }
                 // If no valid replicas remain, delete the whole object.
                 if (!it_->second.IsValid()) {
                     const bool had_processing =
@@ -1774,6 +1823,9 @@ class MasterService {
     // storage backend eviction configuration
     const bool enable_disk_eviction_;
     const uint64_t quota_bytes_;
+    const bool enable_tenant_quota_;
+    const uint64_t default_tenant_quota_bytes_;
+    const uint64_t tenant_quota_pool_capacity_bytes_;
 
     bool use_disk_replica_{false};
 

--- a/mooncake-store/include/types.h
+++ b/mooncake-store/include/types.h
@@ -407,6 +407,7 @@ enum class ErrorCode : int32_t {
     DFS_PERMISSION_DENIED = -1603,    ///< DFS permission denied.
     DFS_STALE_HANDLE = -1604,         ///< DFS file handle expired.
     DFS_PARTIAL_WRITE = -1605,        ///< DFS partial write success.
+    TENANT_QUOTA_EXCEEDED = -1700,    ///< Tenant memory quota exceeded.
 };
 
 int32_t toInt(ErrorCode errorCode) noexcept;

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -201,6 +201,13 @@ DEFINE_bool(enable_disk_eviction, true,
 DEFINE_uint64(
     quota_bytes, 0,
     "Quota for storage backend in bytes (0 = use default 90% of capacity)");
+DEFINE_bool(enable_tenant_quota, false,
+            "Enable per-tenant memory quota admission");
+DEFINE_uint64(default_tenant_quota_bytes, 0,
+              "Default per-tenant memory quota in bytes (0 = unlimited)");
+DEFINE_uint64(tenant_quota_pool_capacity_bytes, 0,
+              "Capacity used to compute effective tenant quotas "
+              "(0 = mounted memory capacity)");
 
 // Snapshot related configuration flags (migrated from global_flags)
 DEFINE_string(snapshot_backup_dir, "",
@@ -410,6 +417,15 @@ void InitMasterConf(const mooncake::DefaultConfig& default_config,
                            FLAGS_enable_disk_eviction);
     default_config.GetUInt64("quota_bytes", &master_config.quota_bytes,
                              FLAGS_quota_bytes);
+    default_config.GetBool("enable_tenant_quota",
+                           &master_config.enable_tenant_quota,
+                           FLAGS_enable_tenant_quota);
+    default_config.GetUInt64("default_tenant_quota_bytes",
+                             &master_config.default_tenant_quota_bytes,
+                             FLAGS_default_tenant_quota_bytes);
+    default_config.GetUInt64("tenant_quota_pool_capacity_bytes",
+                             &master_config.tenant_quota_pool_capacity_bytes,
+                             FLAGS_tenant_quota_pool_capacity_bytes);
 
     default_config.GetString("snapshot_backup_dir",
                              &master_config.snapshot_backup_dir,
@@ -775,6 +791,24 @@ void LoadConfigFromCmdline(mooncake::MasterConfig& master_config,
          !info.is_default) ||
         !conf_set) {
         master_config.quota_bytes = FLAGS_quota_bytes;
+    }
+    if ((google::GetCommandLineFlagInfo("enable_tenant_quota", &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.enable_tenant_quota = FLAGS_enable_tenant_quota;
+    }
+    if ((google::GetCommandLineFlagInfo("default_tenant_quota_bytes", &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.default_tenant_quota_bytes =
+            FLAGS_default_tenant_quota_bytes;
+    }
+    if ((google::GetCommandLineFlagInfo("tenant_quota_pool_capacity_bytes",
+                                        &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.tenant_quota_pool_capacity_bytes =
+            FLAGS_tenant_quota_pool_capacity_bytes;
     }
     if ((google::GetCommandLineFlagInfo("max_total_finished_tasks", &info) &&
          !info.is_default) ||

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -773,35 +773,92 @@ tl::expected<void, ErrorCode> MasterService::ReserveTenantQuota(
         return {};
     }
     const auto normalized_tenant = NormalizeTenantId(tenant_id);
+    auto exceeds_effective_quota = [](const TenantQuotaState& state,
+                                      uint64_t additional_bytes) {
+        return static_cast<unsigned __int128>(state.used_bytes) +
+                   state.reserved_bytes + additional_bytes >
+               state.effective_quota_bytes;
+    };
+    auto refresh_over_quota = [](TenantQuotaState& state) {
+        state.over_quota = state.effective_quota_bytes !=
+                               std::numeric_limits<uint64_t>::max() &&
+                           static_cast<unsigned __int128>(state.used_bytes) +
+                                   state.reserved_bytes >
+                               state.effective_quota_bytes;
+    };
+
     auto& shard =
         tenant_quota_shards_[getTenantQuotaShardIndex(normalized_tenant)];
-    std::lock_guard<std::mutex> lock(shard.mutex);
-    auto [it, did_insert] = shard.tenants.try_emplace(normalized_tenant);
-    auto& state = it->second;
-    if (did_insert) {
+    {
+        std::lock_guard<std::mutex> lock(shard.mutex);
+        auto it = shard.tenants.find(normalized_tenant);
+        if (it != shard.tenants.end()) {
+            auto& state = it->second;
+            if (exceeds_effective_quota(state, bytes)) {
+                return tl::make_unexpected(ErrorCode::TENANT_QUOTA_EXCEEDED);
+            }
+
+            state.reserved_bytes += bytes;
+            refresh_over_quota(state);
+            return {};
+        }
+
+        auto [insert_it, _] = shard.tenants.try_emplace(normalized_tenant);
+        auto& state = insert_it->second;
         state.requested_quota_bytes = default_tenant_quota_bytes_;
         state.effective_quota_bytes = default_tenant_quota_bytes_ == 0
                                           ? std::numeric_limits<uint64_t>::max()
-                                          : default_tenant_quota_bytes_;
+                                          : 0;
         state.over_quota = false;
-    }
 
-    if (static_cast<unsigned __int128>(state.used_bytes) +
-            state.reserved_bytes + bytes >
-        state.effective_quota_bytes) {
-        if (did_insert) {
-            shard.tenants.erase(it);
+        if (default_tenant_quota_bytes_ == 0) {
+            if (exceeds_effective_quota(state, bytes)) {
+                shard.tenants.erase(insert_it);
+                return tl::make_unexpected(ErrorCode::TENANT_QUOTA_EXCEEDED);
+            }
+            state.reserved_bytes += bytes;
+            return {};
         }
-        return tl::make_unexpected(ErrorCode::TENANT_QUOTA_EXCEEDED);
+
+        state.reserved_bytes = bytes;
     }
 
-    state.reserved_bytes += bytes;
-    state.over_quota =
-        state.effective_quota_bytes != std::numeric_limits<uint64_t>::max() &&
-        static_cast<unsigned __int128>(state.used_bytes) +
-                state.reserved_bytes >
-            state.effective_quota_bytes;
-    return {};
+    RecomputeTenantEffectiveQuotas();
+
+    bool rollback_needs_recompute = false;
+    {
+        std::lock_guard<std::mutex> lock(shard.mutex);
+        auto it = shard.tenants.find(normalized_tenant);
+        if (it == shard.tenants.end()) {
+            return tl::make_unexpected(ErrorCode::TENANT_QUOTA_EXCEEDED);
+        }
+
+        auto& state = it->second;
+        if (!exceeds_effective_quota(state, 0)) {
+            refresh_over_quota(state);
+            return {};
+        }
+
+        if (state.reserved_bytes < bytes) {
+            LOG(ERROR) << "tenant quota reserve rollback mismatch tenant="
+                       << normalized_tenant << ", bytes=" << bytes
+                       << ", reserved=" << state.reserved_bytes;
+            return tl::make_unexpected(ErrorCode::TENANT_QUOTA_EXCEEDED);
+        }
+        state.reserved_bytes -= bytes;
+        if (!state.has_explicit_policy && state.used_bytes == 0 &&
+            state.reserved_bytes == 0 && state.committed_count == 0) {
+            shard.tenants.erase(it);
+            rollback_needs_recompute = true;
+        } else {
+            refresh_over_quota(state);
+        }
+    }
+
+    if (rollback_needs_recompute) {
+        RecomputeTenantEffectiveQuotas();
+    }
+    return tl::make_unexpected(ErrorCode::TENANT_QUOTA_EXCEEDED);
 }
 
 void MasterService::CommitTenantQuota(const std::string& tenant_id,

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -712,17 +712,19 @@ void MasterService::RecomputeTenantEffectiveQuotas() {
     for (size_t i = 0; i < kNumTenantQuotaShards; ++i) {
         auto& shard = tenant_quota_shards_[i];
         std::lock_guard<std::mutex> lock(shard.mutex);
-        for (auto& [tenant_id, state] : shard.tenants) {
+        for (auto it = shard.tenants.begin(); it != shard.tenants.end();) {
+            const auto& tenant_id = it->first;
+            auto& state = it->second;
             if (!state.has_explicit_policy) {
                 state.requested_quota_bytes = default_tenant_quota_bytes_;
             }
             if (!state.has_explicit_policy && state.used_bytes == 0 &&
                 state.reserved_bytes == 0 && state.committed_count == 0) {
-                state.effective_quota_bytes = 0;
-                state.over_quota = false;
+                it = shard.tenants.erase(it);
                 continue;
             }
             active_tenants.emplace_back(i, tenant_id);
+            ++it;
         }
     }
 
@@ -730,7 +732,11 @@ void MasterService::RecomputeTenantEffectiveQuotas() {
         for (const auto& [shard_idx, tenant_id] : active_tenants) {
             auto& shard = tenant_quota_shards_[shard_idx];
             std::lock_guard<std::mutex> lock(shard.mutex);
-            auto& state = shard.tenants[tenant_id];
+            auto it = shard.tenants.find(tenant_id);
+            if (it == shard.tenants.end()) {
+                continue;
+            }
+            auto& state = it->second;
             state.effective_quota_bytes = std::numeric_limits<uint64_t>::max();
             state.over_quota = false;
         }
@@ -742,7 +748,11 @@ void MasterService::RecomputeTenantEffectiveQuotas() {
         const auto& [shard_idx, tenant_id] = active_tenants[ordinal];
         auto& shard = tenant_quota_shards_[shard_idx];
         std::lock_guard<std::mutex> lock(shard.mutex);
-        auto& state = shard.tenants[tenant_id];
+        auto it = shard.tenants.find(tenant_id);
+        if (it == shard.tenants.end()) {
+            continue;
+        }
+        auto& state = it->second;
         uint64_t effective = 0;
         if (active_count > 0 && capacity > 0) {
             effective = capacity / active_count;
@@ -779,6 +789,9 @@ tl::expected<void, ErrorCode> MasterService::ReserveTenantQuota(
     if (static_cast<unsigned __int128>(state.used_bytes) +
             state.reserved_bytes + bytes >
         state.effective_quota_bytes) {
+        if (did_insert) {
+            shard.tenants.erase(it);
+        }
         return tl::make_unexpected(ErrorCode::TENANT_QUOTA_EXCEEDED);
     }
 

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -906,26 +906,40 @@ void MasterService::AbortTenantQuota(const std::string& tenant_id,
     const auto normalized_tenant = NormalizeTenantId(tenant_id);
     auto& shard =
         tenant_quota_shards_[getTenantQuotaShardIndex(normalized_tenant)];
-    std::lock_guard<std::mutex> lock(shard.mutex);
-    auto it = shard.tenants.find(normalized_tenant);
-    if (it == shard.tenants.end()) {
-        LOG(ERROR) << "tenant quota abort mismatch tenant=" << normalized_tenant
-                   << ", bytes=" << bytes << ", reserved=0";
-        return;
+    bool recompute_needed = false;
+    {
+        std::lock_guard<std::mutex> lock(shard.mutex);
+        auto it = shard.tenants.find(normalized_tenant);
+        if (it == shard.tenants.end()) {
+            LOG(ERROR) << "tenant quota abort mismatch tenant="
+                       << normalized_tenant << ", bytes=" << bytes
+                       << ", reserved=0";
+            return;
+        }
+        auto& state = it->second;
+        if (state.reserved_bytes < bytes) {
+            LOG(ERROR) << "tenant quota abort mismatch tenant="
+                       << normalized_tenant << ", bytes=" << bytes
+                       << ", reserved=" << state.reserved_bytes;
+            return;
+        }
+        state.reserved_bytes -= bytes;
+        if (!state.has_explicit_policy && state.used_bytes == 0 &&
+            state.reserved_bytes == 0 && state.committed_count == 0) {
+            shard.tenants.erase(it);
+            recompute_needed = true;
+        } else {
+            state.over_quota =
+                state.effective_quota_bytes !=
+                    std::numeric_limits<uint64_t>::max() &&
+                static_cast<unsigned __int128>(state.used_bytes) +
+                        state.reserved_bytes >
+                    state.effective_quota_bytes;
+        }
     }
-    auto& state = it->second;
-    if (state.reserved_bytes < bytes) {
-        LOG(ERROR) << "tenant quota abort mismatch tenant=" << normalized_tenant
-                   << ", bytes=" << bytes
-                   << ", reserved=" << state.reserved_bytes;
-        return;
+    if (recompute_needed) {
+        RecomputeTenantEffectiveQuotas();
     }
-    state.reserved_bytes -= bytes;
-    state.over_quota =
-        state.effective_quota_bytes != std::numeric_limits<uint64_t>::max() &&
-        static_cast<unsigned __int128>(state.used_bytes) +
-                state.reserved_bytes >
-            state.effective_quota_bytes;
 }
 
 void MasterService::ReleaseTenantQuota(const std::string& tenant_id,
@@ -936,29 +950,43 @@ void MasterService::ReleaseTenantQuota(const std::string& tenant_id,
     const auto normalized_tenant = NormalizeTenantId(tenant_id);
     auto& shard =
         tenant_quota_shards_[getTenantQuotaShardIndex(normalized_tenant)];
-    std::lock_guard<std::mutex> lock(shard.mutex);
-    auto it = shard.tenants.find(normalized_tenant);
-    if (it == shard.tenants.end()) {
-        LOG(ERROR) << "tenant quota release mismatch tenant="
-                   << normalized_tenant << ", bytes=" << bytes << ", used=0";
-        return;
+    bool recompute_needed = false;
+    {
+        std::lock_guard<std::mutex> lock(shard.mutex);
+        auto it = shard.tenants.find(normalized_tenant);
+        if (it == shard.tenants.end()) {
+            LOG(ERROR) << "tenant quota release mismatch tenant="
+                       << normalized_tenant << ", bytes=" << bytes
+                       << ", used=0";
+            return;
+        }
+        auto& state = it->second;
+        if (state.used_bytes < bytes) {
+            LOG(ERROR) << "tenant quota release mismatch tenant="
+                       << normalized_tenant << ", bytes=" << bytes
+                       << ", used=" << state.used_bytes;
+            return;
+        }
+        state.used_bytes -= bytes;
+        if (state.committed_count > 0) {
+            --state.committed_count;
+        }
+        if (!state.has_explicit_policy && state.used_bytes == 0 &&
+            state.reserved_bytes == 0 && state.committed_count == 0) {
+            shard.tenants.erase(it);
+            recompute_needed = true;
+        } else {
+            state.over_quota =
+                state.effective_quota_bytes !=
+                    std::numeric_limits<uint64_t>::max() &&
+                static_cast<unsigned __int128>(state.used_bytes) +
+                        state.reserved_bytes >
+                    state.effective_quota_bytes;
+        }
     }
-    auto& state = it->second;
-    if (state.used_bytes < bytes) {
-        LOG(ERROR) << "tenant quota release mismatch tenant="
-                   << normalized_tenant << ", bytes=" << bytes
-                   << ", used=" << state.used_bytes;
-        return;
+    if (recompute_needed) {
+        RecomputeTenantEffectiveQuotas();
     }
-    state.used_bytes -= bytes;
-    if (state.committed_count > 0) {
-        --state.committed_count;
-    }
-    state.over_quota =
-        state.effective_quota_bytes != std::numeric_limits<uint64_t>::max() &&
-        static_cast<unsigned __int128>(state.used_bytes) +
-                state.reserved_bytes >
-            state.effective_quota_bytes;
 }
 
 void MasterService::ReleaseTenantQuotaPartial(const std::string& tenant_id,

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -1262,7 +1262,8 @@ void MasterService::ClearInvalidHandles(
                     tenant_state.processing_keys.erase(it->first);
                     tenant_state.replication_tasks.erase(it->first);
                     tenant_state.offloading_tasks.erase(it->first);
-                    ErasePromotionTaskIfPresent(tenant_state, it->first);
+                    ErasePromotionTaskIfPresent(tenant_state, it->first,
+                                                tenant_it->first);
                     it = EraseMetadata(tenant_state, it, tenant_it->first);
                 } else {
                     ++it;
@@ -2267,7 +2268,8 @@ auto MasterService::PutStart(const UUID& client_id, const std::string& key,
                 tenant_state.processing_keys.erase(key);
                 tenant_state.replication_tasks.erase(key);
                 tenant_state.offloading_tasks.erase(key);
-                ErasePromotionTaskIfPresent(tenant_state, key);
+                ErasePromotionTaskIfPresent(tenant_state, key,
+                                            object_id.tenant_id);
                 EraseMetadata(tenant_state, it, object_id.tenant_id);
                 it = tenant_state.metadata.end();
             } else {
@@ -2637,7 +2639,7 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
         if (it != tenant_state.metadata.end() &&
             CleanupStaleHandles(it->second, alive_clients)) {
             tenant_state.processing_keys.erase(key);
-            ErasePromotionTaskIfPresent(tenant_state, key);
+            ErasePromotionTaskIfPresent(tenant_state, key, object_id.tenant_id);
             EraseMetadata(tenant_state, it, object_id.tenant_id);
             it = tenant_state.metadata.end();
         }
@@ -2690,7 +2692,8 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
                 // If no COMPLETE replicas survive the preemption, this key
                 // effectively does not exist — fall through to Case A.
                 if (!metadata.HasReplica(&Replica::fn_is_completed)) {
-                    ErasePromotionTaskIfPresent(tenant_state, key);
+                    ErasePromotionTaskIfPresent(tenant_state, key,
+                                                object_id.tenant_id);
                     EraseMetadata(tenant_state, it, object_id.tenant_id);
                     it = tenant_state.metadata.end();
                 }
@@ -3455,7 +3458,7 @@ auto MasterService::Remove(const std::string& key, const std::string& tenant_id,
     }
 
     auto& tenant_state = accessor.GetTenantState();
-    ErasePromotionTaskIfPresent(tenant_state, key);
+    ErasePromotionTaskIfPresent(tenant_state, key, object_id.tenant_id);
     accessor.Erase();
     return {};
 }
@@ -3518,7 +3521,8 @@ auto MasterService::RemoveByRegex(const std::string& regex_pattern,
 
                 VLOG(1) << "key=" << it->first
                         << " matched by regex. Removing.";
-                ErasePromotionTaskIfPresent(tenant_state, it->first);
+                ErasePromotionTaskIfPresent(tenant_state, it->first,
+                                            normalized_tenant);
                 it = EraseMetadata(tenant_state, it, normalized_tenant);
                 removed_count++;
             } else {
@@ -3554,7 +3558,8 @@ long MasterService::RemoveAll(bool force) {
                     auto mem_rep_count = it->second.CountReplicas(
                         &Replica::fn_is_memory_replica);
                     total_freed_size += it->second.size * mem_rep_count;
-                    ErasePromotionTaskIfPresent(tenant_state, it->first);
+                    ErasePromotionTaskIfPresent(tenant_state, it->first,
+                                                tenant_it->first);
                     it = EraseMetadata(tenant_state, it, tenant_it->first);
                     removed_count++;
                 } else {
@@ -3599,7 +3604,8 @@ long MasterService::RemoveAll(const std::string& tenant_id, bool force) {
                 auto mem_rep_count =
                     it->second.CountReplicas(&Replica::fn_is_memory_replica);
                 total_freed_size += it->second.size * mem_rep_count;
-                ErasePromotionTaskIfPresent(tenant_state, it->first);
+                ErasePromotionTaskIfPresent(tenant_state, it->first,
+                                            normalized_tenant);
                 it = EraseMetadata(tenant_state, it, normalized_tenant);
                 removed_count++;
             } else {
@@ -3669,7 +3675,8 @@ auto MasterService::BatchRemove(const std::vector<std::string>& keys,
                 tenant_state.processing_keys.erase(key);
                 tenant_state.replication_tasks.erase(key);
                 tenant_state.offloading_tasks.erase(key);
-                ErasePromotionTaskIfPresent(tenant_state, key);
+                ErasePromotionTaskIfPresent(tenant_state, key,
+                                            normalized_tenant);
                 EraseMetadata(tenant_state, it, normalized_tenant);
                 if (tenant_state.Empty()) {
                     shard->tenants.erase(tenant_it);
@@ -3709,7 +3716,7 @@ auto MasterService::BatchRemove(const std::vector<std::string>& keys,
             }
 
             // Remove object metadata
-            ErasePromotionTaskIfPresent(tenant_state, key);
+            ErasePromotionTaskIfPresent(tenant_state, key, normalized_tenant);
             EraseMetadata(tenant_state, it, normalized_tenant);
             if (tenant_state.Empty()) {
                 shard->tenants.erase(tenant_it);
@@ -4236,6 +4243,23 @@ auto MasterService::PromotionAllocStart(
     if (task_it->second.object_size != size) {
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
+    if (metadata.HasReplica(&Replica::fn_is_memory_replica)) {
+        return tl::make_unexpected(ErrorCode::REPLICA_IS_NOT_READY);
+    }
+    if (task_it->second.alloc_id != 0 ||
+        task_it->second.reserved_quota_charge_bytes != 0) {
+        return tl::make_unexpected(ErrorCode::REPLICA_IS_NOT_READY);
+    }
+
+    const uint64_t reserved_quota_charge = size;
+    auto quota_result =
+        ReserveTenantQuota(object_id.tenant_id, reserved_quota_charge);
+    if (!quota_result) {
+        return tl::make_unexpected(quota_result.error());
+    }
+    auto abort_reserved_quota = [&] {
+        AbortTenantQuota(object_id.tenant_id, reserved_quota_charge);
+    };
 
     // Allocate a single MEMORY replica via the existing strategy, biased to
     // the holder's mem segment when possible.
@@ -4253,11 +4277,13 @@ auto MasterService::PromotionAllocStart(
         auto allocation_result = allocation_strategy_->Allocate(
             allocator_manager, size, config.replica_num, preferred_segments);
         if (!allocation_result) {
+            abort_reserved_quota();
             return tl::make_unexpected(allocation_result.error());
         }
         staged_replicas = std::move(allocation_result.value());
     }
     if (staged_replicas.empty()) {
+        abort_reserved_quota();
         return tl::make_unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
     }
 
@@ -4285,6 +4311,7 @@ auto MasterService::PromotionAllocStart(
     // (alloc_id == 0) is bounded by its own original start_time window
     // during which the reaper's EraseReplicaByID branch is a no-op.
     task_it->second.alloc_id = new_id;
+    task_it->second.reserved_quota_charge_bytes = reserved_quota_charge;
     task_it->second.start_time = std::chrono::system_clock::now();
     return PromotionAllocStartResponse{std::move(desc)};
 }
@@ -4332,6 +4359,25 @@ auto MasterService::NotifyPromotionSuccess(const UUID& client_id,
         source->dec_refcnt();
     }
     const uint64_t completed_bytes = task_it->second.object_size;
+    const uint64_t reserved_quota_charge =
+        task_it->second.reserved_quota_charge_bytes;
+    if (committed) {
+        const uint64_t actual_charge = CompletedMemoryQuotaCharge(metadata);
+        const uint64_t commit_charge =
+            actual_charge > metadata.committed_quota_charge_bytes
+                ? actual_charge - metadata.committed_quota_charge_bytes
+                : 0;
+        const uint64_t abort_charge =
+            reserved_quota_charge > commit_charge
+                ? reserved_quota_charge - commit_charge
+                : 0;
+        CommitTenantQuota(object_id.tenant_id, commit_charge);
+        AbortTenantQuota(object_id.tenant_id, abort_charge);
+        metadata.committed_quota_charge_bytes = actual_charge;
+    } else {
+        AbortTenantQuota(object_id.tenant_id, reserved_quota_charge);
+    }
+    task_it->second.reserved_quota_charge_bytes = 0;
     tenant_state.promotion_tasks.erase(task_it);
     promotion_in_flight_.fetch_sub(1, std::memory_order_relaxed);
     MasterMetricManager::instance().dec_promotion_in_flight();
@@ -4405,6 +4451,9 @@ auto MasterService::NotifyPromotionFailure(const UUID& client_id,
                 return replica.id() == alloc_id;
             });
     }
+    AbortTenantQuota(object_id.tenant_id,
+                     task_it->second.reserved_quota_charge_bytes);
+    task_it->second.reserved_quota_charge_bytes = 0;
     tenant_state.promotion_tasks.erase(task_it);
     promotion_in_flight_.fetch_sub(1, std::memory_order_relaxed);
     MasterMetricManager::instance().dec_promotion_in_flight();
@@ -4620,6 +4669,9 @@ void MasterService::DiscardExpiredProcessingReplicas(
                         });
                 }
             }
+            AbortTenantQuota(tenant_it->first,
+                             task_it->second.reserved_quota_charge_bytes);
+            task_it->second.reserved_quota_charge_bytes = 0;
             LOG(WARNING) << "Promotion task expired for key: "
                          << task_it->first;
             task_it = tenant_state.promotion_tasks.erase(task_it);
@@ -5749,15 +5801,21 @@ void MasterService::BatchEvict(double evict_ratio_target,
     };
 
     auto evict_replicas =
-        [&](ObjectMetadata& metadata,
-            std::vector<std::vector<Replica>>& deferred_replicas) {
+        [&, this](ObjectMetadata& metadata,
+                  std::vector<std::vector<Replica>>& deferred_replicas) {
+            const uint64_t before_charge = CompletedMemoryQuotaCharge(metadata);
             auto replicas = PopReplicasWithCacheTotalAccounting(
                 metadata, is_evictable_memory_replica);
             const size_t replica_count = replicas.size();
             if (!replicas.empty()) {
                 deferred_replicas.emplace_back(std::move(replicas));
             }
-            return replica_count;
+            const uint64_t after_charge = CompletedMemoryQuotaCharge(metadata);
+            if (before_charge > after_charge) {
+                ReleaseCommittedQuotaCharge(metadata,
+                                            before_charge - after_charge);
+            }
+            return metadata.size * replica_count;
         };
 
     // --- Offload-on-evict support ---
@@ -5783,12 +5841,12 @@ void MasterService::BatchEvict(double evict_ratio_target,
             std::vector<std::vector<Replica>>& deferred_replicas) -> uint64_t {
         if (!offload_on_evict_) {
             // Original behavior
-            return metadata.size * evict_replicas(metadata, deferred_replicas);
+            return evict_replicas(metadata, deferred_replicas);
         }
 
         // LOCAL_DISK replica already exists — safe to delete MEMORY immediately
         if (has_local_disk_replica(metadata)) {
-            return metadata.size * evict_replicas(metadata, deferred_replicas);
+            return evict_replicas(metadata, deferred_replicas);
         }
 
         // Force-evict cap: if force_evict enabled and cap reached, force
@@ -5796,7 +5854,7 @@ void MasterService::BatchEvict(double evict_ratio_target,
         // flooding.
         if (offload_force_evict_ && offload_queued_this_cycle >= offload_cap) {
             offload_cap_forced_count++;
-            return metadata.size * evict_replicas(metadata, deferred_replicas);
+            return evict_replicas(metadata, deferred_replicas);
         }
 
         // Queue one MEMORY replica for offload; others will be evicted below.
@@ -5825,7 +5883,7 @@ void MasterService::BatchEvict(double evict_ratio_target,
             // Any remaining MEMORY replicas with refcnt==0 are redundant copies
             // (data survives via the pinned replica → disk). Evict them now to
             // reclaim memory immediately rather than waiting another cycle.
-            return metadata.size * evict_replicas(metadata, deferred_replicas);
+            return evict_replicas(metadata, deferred_replicas);
         }
 
         // PushOffloadingQueue failed. Default (data-preserving) behavior is to
@@ -5834,7 +5892,7 @@ void MasterService::BatchEvict(double evict_ratio_target,
         // prevent silent data loss when the queue is unavailable.
         if (offload_force_evict_) {
             offload_push_failed_forced++;
-            return metadata.size * evict_replicas(metadata, deferred_replicas);
+            return evict_replicas(metadata, deferred_replicas);
         }
         return 0;
     };

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -502,39 +502,42 @@ MasterService::GetTenantQuotaSnapshotForTesting(
 auto MasterService::MountSegment(const Segment& segment, const UUID& client_id)
     -> tl::expected<void, ErrorCode> {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    ScopedSegmentAccess segment_access = segment_manager_.getSegmentAccess();
-
-    // Tell the client monitor thread to start timing for this client. To
-    // avoid the following undesired situations, this message must be sent
-    // after locking the segment mutex and before the mounting operation
-    // completes:
-    // 1. Sending the message before the lock: the client expires and
-    // unmouting invokes before this mounting are completed, which prevents
-    // this segment being able to be unmounted forever;
-    // 2. Sending the message after mounting the segment: After mounting
-    // this segment, when trying to push id to the queue, the queue is
-    // already full. However, at this point, the message must be sent,
-    // otherwise this client cannot be monitored and expired.
     {
-        PodUUID pod_client_id;
-        pod_client_id.first = client_id.first;
-        pod_client_id.second = client_id.second;
-        if (!client_ping_queue_.push(pod_client_id)) {
-            LOG(ERROR) << "segment_name=" << segment.name
-                       << ", error=client_ping_queue_full";
-            return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+        ScopedSegmentAccess segment_access =
+            segment_manager_.getSegmentAccess();
+
+        // Tell the client monitor thread to start timing for this client. To
+        // avoid the following undesired situations, this message must be sent
+        // after locking the segment mutex and before the mounting operation
+        // completes:
+        // 1. Sending the message before the lock: the client expires and
+        // unmouting invokes before this mounting are completed, which prevents
+        // this segment being able to be unmounted forever;
+        // 2. Sending the message after mounting the segment: After mounting
+        // this segment, when trying to push id to the queue, the queue is
+        // already full. However, at this point, the message must be sent,
+        // otherwise this client cannot be monitored and expired.
+        {
+            PodUUID pod_client_id;
+            pod_client_id.first = client_id.first;
+            pod_client_id.second = client_id.second;
+            if (!client_ping_queue_.push(pod_client_id)) {
+                LOG(ERROR) << "segment_name=" << segment.name
+                           << ", error=client_ping_queue_full";
+                return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+            }
         }
-    }
 
-    LOG(INFO) << "client_id=" << client_id
-              << ", action=mount_segment, segment_name=" << segment.name;
+        LOG(INFO) << "client_id=" << client_id
+                  << ", action=mount_segment, segment_name=" << segment.name;
 
-    auto err = segment_access.MountSegment(segment, client_id);
-    if (err == ErrorCode::SEGMENT_ALREADY_EXISTS) {
-        // Return OK because this is an idempotent operation
-        return {};
-    } else if (err != ErrorCode::OK) {
-        return tl::make_unexpected(err);
+        auto err = segment_access.MountSegment(segment, client_id);
+        if (err == ErrorCode::SEGMENT_ALREADY_EXISTS) {
+            // Return OK because this is an idempotent operation
+            return {};
+        } else if (err != ErrorCode::OK) {
+            return tl::make_unexpected(err);
+        }
     }
     RecomputeTenantEffectiveQuotas();
     return {};
@@ -570,44 +573,50 @@ auto MasterService::ReMountSegment(const std::vector<Segment>& segments,
                                    const UUID& client_id)
     -> tl::expected<void, ErrorCode> {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    std::unique_lock<std::shared_mutex> lock(client_mutex_);
-    if (ok_client_.contains(client_id)) {
-        LOG(WARNING) << "client_id=" << client_id
-                     << ", warn=client_already_remounted";
-        // Return OK because this is an idempotent operation
-        return {};
+    {
+        std::unique_lock<std::shared_mutex> lock(client_mutex_);
+        if (ok_client_.contains(client_id)) {
+            LOG(WARNING) << "client_id=" << client_id
+                         << ", warn=client_already_remounted";
+            // Return OK because this is an idempotent operation
+            return {};
+        }
+
+        {
+            ScopedSegmentAccess segment_access =
+                segment_manager_.getSegmentAccess();
+
+            // Tell the client monitor thread to start timing for this client.
+            // To avoid the following undesired situations, this message must be
+            // sent after locking the segment mutex or client mutex and before
+            // the remounting operation completes:
+            // 1. Sending the message before the lock: the client expires and
+            // unmouting invokes before this remounting are completed, which
+            // prevents this segment being able to be unmounted forever;
+            // 2. Sending the message after remounting the segments: After
+            // remounting these segments, when trying to push id to the queue,
+            // the queue is already full. However, at this point, the message
+            // must be sent, otherwise this client cannot be monitored and
+            // expired.
+            PodUUID pod_client_id;
+            pod_client_id.first = client_id.first;
+            pod_client_id.second = client_id.second;
+            if (!client_ping_queue_.push(pod_client_id)) {
+                LOG(ERROR) << "client_id=" << client_id
+                           << ", error=client_ping_queue_full";
+                return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+            }
+
+            ErrorCode err = segment_access.ReMountSegment(segments, client_id);
+            if (err != ErrorCode::OK) {
+                return tl::make_unexpected(err);
+            }
+        }
+
+        // Change the client status to OK
+        ok_client_.insert(client_id);
+        MasterMetricManager::instance().inc_active_clients();
     }
-
-    ScopedSegmentAccess segment_access = segment_manager_.getSegmentAccess();
-
-    // Tell the client monitor thread to start timing for this client. To
-    // avoid the following undesired situations, this message must be sent
-    // after locking the segment mutex or client mutex and before the remounting
-    // operation completes:
-    // 1. Sending the message before the lock: the client expires and
-    // unmouting invokes before this remounting are completed, which prevents
-    // this segment being able to be unmounted forever;
-    // 2. Sending the message after remounting the segments: After remounting
-    // these segments, when trying to push id to the queue, the queue is
-    // already full. However, at this point, the message must be sent,
-    // otherwise this client cannot be monitored and expired.
-    PodUUID pod_client_id;
-    pod_client_id.first = client_id.first;
-    pod_client_id.second = client_id.second;
-    if (!client_ping_queue_.push(pod_client_id)) {
-        LOG(ERROR) << "client_id=" << client_id
-                   << ", error=client_ping_queue_full";
-        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
-    }
-
-    ErrorCode err = segment_access.ReMountSegment(segments, client_id);
-    if (err != ErrorCode::OK) {
-        return tl::make_unexpected(err);
-    }
-
-    // Change the client status to OK
-    ok_client_.insert(client_id);
-    MasterMetricManager::instance().inc_active_clients();
     RecomputeTenantEffectiveQuotas();
 
     return {};
@@ -1304,11 +1313,14 @@ auto MasterService::UnmountSegment(const UUID& segment_id,
     ClearInvalidHandles();
 
     // 3. Commit the unmount operation
-    ScopedSegmentAccess segment_access = segment_manager_.getSegmentAccess();
-    auto err = segment_access.CommitUnmountSegment(segment_id, client_id,
-                                                   metrics_dec_capacity);
-    if (err != ErrorCode::OK) {
-        return tl::make_unexpected(err);
+    {
+        ScopedSegmentAccess segment_access =
+            segment_manager_.getSegmentAccess();
+        auto err = segment_access.CommitUnmountSegment(segment_id, client_id,
+                                                       metrics_dec_capacity);
+        if (err != ErrorCode::OK) {
+            return tl::make_unexpected(err);
+        }
     }
     RecomputeTenantEffectiveQuotas();
     return {};
@@ -2339,7 +2351,12 @@ auto MasterService::PutEnd(const UUID& client_id, const std::string& key,
         },
         [](Replica& replica) { replica.mark_complete(); });
 
-    if (metadata.reserved_quota_charge_bytes > 0) {
+    const bool has_memory_replica = metadata.HasMemReplica();
+    const bool should_settle_quota =
+        replica_type == ReplicaType::MEMORY ||
+        (replica_type == ReplicaType::ALL && has_memory_replica) ||
+        !has_memory_replica;
+    if (metadata.reserved_quota_charge_bytes > 0 && should_settle_quota) {
         const uint64_t actual_charge = CompletedMemoryQuotaCharge(metadata);
         const uint64_t commit_charge =
             actual_charge > metadata.committed_quota_charge_bytes

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -160,6 +160,10 @@ MasterService::MasterService(const MasterServiceConfig& config)
       global_file_segment_size_(config.global_file_segment_size),
       enable_disk_eviction_(config.enable_disk_eviction),
       quota_bytes_(config.quota_bytes),
+      enable_tenant_quota_(config.enable_tenant_quota),
+      default_tenant_quota_bytes_(config.default_tenant_quota_bytes),
+      tenant_quota_pool_capacity_bytes_(
+          config.tenant_quota_pool_capacity_bytes),
       segment_manager_(config.memory_allocator, config.enable_cxl),
       nof_segment_manager_(config.memory_allocator),
       memory_allocator_type_(config.memory_allocator),
@@ -472,6 +476,29 @@ std::optional<uint32_t> MasterService::GetNoFHeartbeatFailureCountForTesting(
     return it->second.consecutive_failures;
 }
 
+std::optional<TenantQuotaSnapshot>
+MasterService::GetTenantQuotaSnapshotForTesting(
+    const std::string& tenant_id) const {
+    const auto normalized_tenant = NormalizeTenantId(tenant_id);
+    const auto shard_idx = getTenantQuotaShardIndex(normalized_tenant);
+    const auto& shard = tenant_quota_shards_[shard_idx];
+    std::lock_guard<std::mutex> lock(shard.mutex);
+    auto it = shard.tenants.find(normalized_tenant);
+    if (it == shard.tenants.end()) {
+        return std::nullopt;
+    }
+    const auto& state = it->second;
+    return TenantQuotaSnapshot{
+        .tenant_id = normalized_tenant,
+        .requested_quota_bytes = state.requested_quota_bytes,
+        .effective_quota_bytes = state.effective_quota_bytes,
+        .used_bytes = state.used_bytes,
+        .reserved_bytes = state.reserved_bytes,
+        .committed_count = state.committed_count,
+        .has_explicit_policy = state.has_explicit_policy,
+        .over_quota = state.over_quota};
+}
+
 auto MasterService::MountSegment(const Segment& segment, const UUID& client_id)
     -> tl::expected<void, ErrorCode> {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
@@ -509,6 +536,7 @@ auto MasterService::MountSegment(const Segment& segment, const UUID& client_id)
     } else if (err != ErrorCode::OK) {
         return tl::make_unexpected(err);
     }
+    RecomputeTenantEffectiveQuotas();
     return {};
 }
 
@@ -580,6 +608,7 @@ auto MasterService::ReMountSegment(const std::vector<Segment>& segments,
     // Change the client status to OK
     ok_client_.insert(client_id);
     MasterMetricManager::instance().inc_active_clients();
+    RecomputeTenantEffectiveQuotas();
 
     return {};
 }
@@ -619,6 +648,327 @@ size_t MasterService::getMetadataShardIndex(const std::string& tenant_id,
         return getShardIndex(normalized_tenant, key);
     }
     return getShardIndex(it->second);
+}
+
+size_t MasterService::getTenantQuotaShardIndex(
+    const std::string& tenant_id) const {
+    return std::hash<std::string>{}(NormalizeTenantId(tenant_id)) %
+           kNumTenantQuotaShards;
+}
+
+uint64_t MasterService::CompletedMemoryQuotaCharge(
+    const ObjectMetadata& metadata) const {
+    return static_cast<uint64_t>(metadata.size) *
+           metadata.CountReplicas([](const Replica& replica) {
+               return replica.is_memory_replica() && replica.is_completed();
+           });
+}
+
+uint64_t MasterService::RequestedMemoryQuotaCharge(
+    uint64_t value_length, const ReplicateConfig& config) const {
+    const unsigned __int128 charge =
+        static_cast<unsigned __int128>(value_length) * config.replica_num;
+    if (charge > std::numeric_limits<uint64_t>::max()) {
+        return std::numeric_limits<uint64_t>::max();
+    }
+    return static_cast<uint64_t>(charge);
+}
+
+uint64_t MasterService::GetTenantQuotaCapacityBytes() {
+    if (tenant_quota_pool_capacity_bytes_ != 0) {
+        return tenant_quota_pool_capacity_bytes_;
+    }
+    uint64_t capacity = 0;
+    ScopedSegmentAccess segment_access = segment_manager_.getSegmentAccess();
+    std::vector<std::pair<Segment, UUID>> segments;
+    if (segment_access.GetAllSegments(segments) != ErrorCode::OK) {
+        return 0;
+    }
+    for (const auto& [segment, _] : segments) {
+        if (capacity > std::numeric_limits<uint64_t>::max() - segment.size) {
+            return std::numeric_limits<uint64_t>::max();
+        }
+        capacity += segment.size;
+    }
+    return capacity;
+}
+
+void MasterService::RecomputeTenantEffectiveQuotas() {
+    if (!enable_tenant_quota_) {
+        return;
+    }
+    const uint64_t capacity = GetTenantQuotaCapacityBytes();
+
+    std::vector<std::pair<size_t, std::string>> active_tenants;
+    for (size_t i = 0; i < kNumTenantQuotaShards; ++i) {
+        auto& shard = tenant_quota_shards_[i];
+        std::lock_guard<std::mutex> lock(shard.mutex);
+        for (auto& [tenant_id, state] : shard.tenants) {
+            if (!state.has_explicit_policy) {
+                state.requested_quota_bytes = default_tenant_quota_bytes_;
+            }
+            if (!state.has_explicit_policy && state.used_bytes == 0 &&
+                state.reserved_bytes == 0 && state.committed_count == 0) {
+                state.effective_quota_bytes = 0;
+                state.over_quota = false;
+                continue;
+            }
+            active_tenants.emplace_back(i, tenant_id);
+        }
+    }
+
+    if (default_tenant_quota_bytes_ == 0) {
+        for (const auto& [shard_idx, tenant_id] : active_tenants) {
+            auto& shard = tenant_quota_shards_[shard_idx];
+            std::lock_guard<std::mutex> lock(shard.mutex);
+            auto& state = shard.tenants[tenant_id];
+            state.effective_quota_bytes = std::numeric_limits<uint64_t>::max();
+            state.over_quota = false;
+        }
+        return;
+    }
+
+    const uint64_t active_count = active_tenants.size();
+    for (size_t ordinal = 0; ordinal < active_tenants.size(); ++ordinal) {
+        const auto& [shard_idx, tenant_id] = active_tenants[ordinal];
+        auto& shard = tenant_quota_shards_[shard_idx];
+        std::lock_guard<std::mutex> lock(shard.mutex);
+        auto& state = shard.tenants[tenant_id];
+        uint64_t effective = 0;
+        if (active_count > 0 && capacity > 0) {
+            effective = capacity / active_count;
+            if (ordinal < capacity % active_count) {
+                ++effective;
+            }
+        }
+        state.effective_quota_bytes = effective;
+        state.over_quota = static_cast<unsigned __int128>(state.used_bytes) +
+                               state.reserved_bytes >
+                           state.effective_quota_bytes;
+    }
+}
+
+tl::expected<void, ErrorCode> MasterService::ReserveTenantQuota(
+    const std::string& tenant_id, uint64_t bytes) {
+    if (!enable_tenant_quota_ || bytes == 0) {
+        return {};
+    }
+    const auto normalized_tenant = NormalizeTenantId(tenant_id);
+    auto& shard =
+        tenant_quota_shards_[getTenantQuotaShardIndex(normalized_tenant)];
+    std::lock_guard<std::mutex> lock(shard.mutex);
+    auto [it, did_insert] = shard.tenants.try_emplace(normalized_tenant);
+    auto& state = it->second;
+    if (did_insert) {
+        state.requested_quota_bytes = default_tenant_quota_bytes_;
+        state.effective_quota_bytes = default_tenant_quota_bytes_ == 0
+                                          ? std::numeric_limits<uint64_t>::max()
+                                          : default_tenant_quota_bytes_;
+        state.over_quota = false;
+    }
+
+    if (static_cast<unsigned __int128>(state.used_bytes) +
+            state.reserved_bytes + bytes >
+        state.effective_quota_bytes) {
+        return tl::make_unexpected(ErrorCode::TENANT_QUOTA_EXCEEDED);
+    }
+
+    state.reserved_bytes += bytes;
+    state.over_quota =
+        state.effective_quota_bytes != std::numeric_limits<uint64_t>::max() &&
+        static_cast<unsigned __int128>(state.used_bytes) +
+                state.reserved_bytes >
+            state.effective_quota_bytes;
+    return {};
+}
+
+void MasterService::CommitTenantQuota(const std::string& tenant_id,
+                                      uint64_t bytes) {
+    if (!enable_tenant_quota_ || bytes == 0) {
+        return;
+    }
+    const auto normalized_tenant = NormalizeTenantId(tenant_id);
+    auto& shard =
+        tenant_quota_shards_[getTenantQuotaShardIndex(normalized_tenant)];
+    std::lock_guard<std::mutex> lock(shard.mutex);
+    auto it = shard.tenants.find(normalized_tenant);
+    if (it == shard.tenants.end()) {
+        LOG(ERROR) << "tenant quota commit mismatch tenant="
+                   << normalized_tenant << ", bytes=" << bytes
+                   << ", reserved=0";
+        return;
+    }
+    auto& state = it->second;
+    if (state.reserved_bytes < bytes) {
+        LOG(ERROR) << "tenant quota commit mismatch tenant="
+                   << normalized_tenant << ", bytes=" << bytes
+                   << ", reserved=" << state.reserved_bytes;
+        return;
+    }
+    state.reserved_bytes -= bytes;
+    if (state.used_bytes > std::numeric_limits<uint64_t>::max() - bytes) {
+        state.used_bytes = std::numeric_limits<uint64_t>::max();
+    } else {
+        state.used_bytes += bytes;
+    }
+    ++state.committed_count;
+    state.over_quota =
+        state.effective_quota_bytes != std::numeric_limits<uint64_t>::max() &&
+        static_cast<unsigned __int128>(state.used_bytes) +
+                state.reserved_bytes >
+            state.effective_quota_bytes;
+}
+
+void MasterService::AbortTenantQuota(const std::string& tenant_id,
+                                     uint64_t bytes) {
+    if (!enable_tenant_quota_ || bytes == 0) {
+        return;
+    }
+    const auto normalized_tenant = NormalizeTenantId(tenant_id);
+    auto& shard =
+        tenant_quota_shards_[getTenantQuotaShardIndex(normalized_tenant)];
+    std::lock_guard<std::mutex> lock(shard.mutex);
+    auto it = shard.tenants.find(normalized_tenant);
+    if (it == shard.tenants.end()) {
+        LOG(ERROR) << "tenant quota abort mismatch tenant=" << normalized_tenant
+                   << ", bytes=" << bytes << ", reserved=0";
+        return;
+    }
+    auto& state = it->second;
+    if (state.reserved_bytes < bytes) {
+        LOG(ERROR) << "tenant quota abort mismatch tenant=" << normalized_tenant
+                   << ", bytes=" << bytes
+                   << ", reserved=" << state.reserved_bytes;
+        return;
+    }
+    state.reserved_bytes -= bytes;
+    state.over_quota =
+        state.effective_quota_bytes != std::numeric_limits<uint64_t>::max() &&
+        static_cast<unsigned __int128>(state.used_bytes) +
+                state.reserved_bytes >
+            state.effective_quota_bytes;
+}
+
+void MasterService::ReleaseTenantQuota(const std::string& tenant_id,
+                                       uint64_t bytes) {
+    if (!enable_tenant_quota_ || bytes == 0) {
+        return;
+    }
+    const auto normalized_tenant = NormalizeTenantId(tenant_id);
+    auto& shard =
+        tenant_quota_shards_[getTenantQuotaShardIndex(normalized_tenant)];
+    std::lock_guard<std::mutex> lock(shard.mutex);
+    auto it = shard.tenants.find(normalized_tenant);
+    if (it == shard.tenants.end()) {
+        LOG(ERROR) << "tenant quota release mismatch tenant="
+                   << normalized_tenant << ", bytes=" << bytes << ", used=0";
+        return;
+    }
+    auto& state = it->second;
+    if (state.used_bytes < bytes) {
+        LOG(ERROR) << "tenant quota release mismatch tenant="
+                   << normalized_tenant << ", bytes=" << bytes
+                   << ", used=" << state.used_bytes;
+        return;
+    }
+    state.used_bytes -= bytes;
+    if (state.committed_count > 0) {
+        --state.committed_count;
+    }
+    state.over_quota =
+        state.effective_quota_bytes != std::numeric_limits<uint64_t>::max() &&
+        static_cast<unsigned __int128>(state.used_bytes) +
+                state.reserved_bytes >
+            state.effective_quota_bytes;
+}
+
+void MasterService::ReleaseTenantQuotaPartial(const std::string& tenant_id,
+                                              uint64_t bytes) {
+    if (!enable_tenant_quota_ || bytes == 0) {
+        return;
+    }
+    const auto normalized_tenant = NormalizeTenantId(tenant_id);
+    auto& shard =
+        tenant_quota_shards_[getTenantQuotaShardIndex(normalized_tenant)];
+    std::lock_guard<std::mutex> lock(shard.mutex);
+    auto it = shard.tenants.find(normalized_tenant);
+    if (it == shard.tenants.end()) {
+        LOG(ERROR) << "tenant quota partial release mismatch tenant="
+                   << normalized_tenant << ", bytes=" << bytes << ", used=0";
+        return;
+    }
+    auto& state = it->second;
+    if (state.used_bytes < bytes) {
+        LOG(ERROR) << "tenant quota partial release mismatch tenant="
+                   << normalized_tenant << ", bytes=" << bytes
+                   << ", used=" << state.used_bytes;
+        return;
+    }
+    state.used_bytes -= bytes;
+    state.over_quota =
+        state.effective_quota_bytes != std::numeric_limits<uint64_t>::max() &&
+        static_cast<unsigned __int128>(state.used_bytes) +
+                state.reserved_bytes >
+            state.effective_quota_bytes;
+}
+
+void MasterService::ReleaseCommittedQuotaCharge(ObjectMetadata& metadata,
+                                                uint64_t bytes) {
+    if (!enable_tenant_quota_ || bytes == 0) {
+        return;
+    }
+    const uint64_t release_bytes =
+        std::min(bytes, metadata.committed_quota_charge_bytes);
+    if (release_bytes == metadata.committed_quota_charge_bytes) {
+        ReleaseTenantQuota(metadata.tenant_id, release_bytes);
+    } else {
+        ReleaseTenantQuotaPartial(metadata.tenant_id, release_bytes);
+    }
+    metadata.committed_quota_charge_bytes -= release_bytes;
+}
+
+void MasterService::RebuildTenantQuotaUsageFromMetadata() {
+    if (!enable_tenant_quota_) {
+        return;
+    }
+
+    std::unordered_map<std::string, uint64_t> used_by_tenant;
+    std::unordered_map<std::string, uint64_t> committed_count_by_tenant;
+    for (size_t i = 0; i < kNumShards; ++i) {
+        MetadataShardAccessorRW shard(this, i);
+        for (auto& [tenant_id, tenant_state] : shard->tenants) {
+            for (auto& [_, metadata] : tenant_state.metadata) {
+                const uint64_t charge = CompletedMemoryQuotaCharge(metadata);
+                metadata.reserved_quota_charge_bytes = 0;
+                metadata.committed_quota_charge_bytes = charge;
+                metadata.pending_replaced_quota_charge_bytes = 0;
+                if (charge == 0) {
+                    continue;
+                }
+                used_by_tenant[tenant_id] += charge;
+                committed_count_by_tenant[tenant_id]++;
+            }
+        }
+    }
+
+    for (size_t i = 0; i < kNumTenantQuotaShards; ++i) {
+        auto& shard = tenant_quota_shards_[i];
+        std::lock_guard<std::mutex> lock(shard.mutex);
+        for (auto& [_, state] : shard.tenants) {
+            state.used_bytes = 0;
+            state.reserved_bytes = 0;
+            state.committed_count = 0;
+        }
+    }
+    for (const auto& [tenant_id, used_bytes] : used_by_tenant) {
+        auto& shard = tenant_quota_shards_[getTenantQuotaShardIndex(tenant_id)];
+        std::lock_guard<std::mutex> lock(shard.mutex);
+        auto& state = shard.tenants[tenant_id];
+        state.requested_quota_bytes = default_tenant_quota_bytes_;
+        state.used_bytes = used_bytes;
+        state.committed_count = committed_count_by_tenant[tenant_id];
+    }
+    RecomputeTenantEffectiveQuotas();
 }
 
 std::optional<std::string> MasterService::GetGroupRoute(
@@ -772,9 +1122,33 @@ MasterService::EraseMetadata(
     TenantState& tenant_state,
     std::unordered_map<std::string, ObjectMetadata>::iterator it,
     const std::string& tenant_id) {
+    return EraseMetadata(tenant_state, it, tenant_id, QuotaEraseMode::kFull);
+}
+
+std::unordered_map<std::string, MasterService::ObjectMetadata>::iterator
+MasterService::EraseMetadata(
+    TenantState& tenant_state,
+    std::unordered_map<std::string, ObjectMetadata>::iterator it,
+    const std::string& tenant_id, QuotaEraseMode quota_mode) {
     const std::string key = it->first;
     const std::string group_id = it->second.group_id;
-    AccountCacheTotalRemoval(it->second);
+    auto& metadata = it->second;
+    AccountCacheTotalRemoval(metadata);
+    switch (quota_mode) {
+        case QuotaEraseMode::kFull:
+            AbortTenantQuota(tenant_id, metadata.reserved_quota_charge_bytes);
+            ReleaseTenantQuota(tenant_id,
+                               metadata.committed_quota_charge_bytes);
+            ReleaseTenantQuota(tenant_id,
+                               metadata.pending_replaced_quota_charge_bytes);
+            break;
+        case QuotaEraseMode::kPreserveOld:
+            AbortTenantQuota(tenant_id, metadata.reserved_quota_charge_bytes);
+            break;
+        case QuotaEraseMode::kAbortOnly:
+            AbortTenantQuota(tenant_id, metadata.reserved_quota_charge_bytes);
+            break;
+    }
     auto next = tenant_state.metadata.erase(it);
     UnregisterGroupMember(tenant_state, tenant_id, key, group_id);
     return next;
@@ -936,6 +1310,7 @@ auto MasterService::UnmountSegment(const UUID& segment_id,
     if (err != ErrorCode::OK) {
         return tl::make_unexpected(err);
     }
+    RecomputeTenantEffectiveQuotas();
     return {};
 }
 
@@ -1643,6 +2018,16 @@ auto MasterService::AllocateAndInsertMetadata(
         return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
     }
 
+    const uint64_t reserved_quota_charge =
+        RequestedMemoryQuotaCharge(value_length, config);
+    auto quota_result = ReserveTenantQuota(tenant_id, reserved_quota_charge);
+    if (!quota_result) {
+        return tl::make_unexpected(quota_result.error());
+    }
+    auto abort_reserved_quota = [&] {
+        AbortTenantQuota(tenant_id, reserved_quota_charge);
+    };
+
     std::vector<Replica> replicas;
     const auto write_mode = DetermineReplicaWriteMode(config);
     size_t allocated_memory_replicas = 0;
@@ -1667,11 +2052,13 @@ auto MasterService::AllocateAndInsertMetadata(
             VLOG(1) << "Failed to allocate replicas for key=" << key
                     << ", error: " << allocation_result.error();
             if (allocation_result.error() == ErrorCode::INVALID_PARAMS) {
+                abort_reserved_quota();
                 return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
             }
             if (write_mode != ReplicaWriteMode::FLEXIBLE_DUAL_REPLICA) {
                 MasterMetricManager::instance().inc_put_start_alloc_failures();
                 need_mem_eviction_ = true;
+                abort_reserved_quota();
                 return tl::make_unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
             }
         } else {
@@ -1698,11 +2085,13 @@ auto MasterService::AllocateAndInsertMetadata(
             VLOG(1) << "Failed to allocate nof replicas for key=" << key
                     << ", error: " << allocation_result.error();
             if (allocation_result.error() == ErrorCode::INVALID_PARAMS) {
+                abort_reserved_quota();
                 return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
             }
             if (write_mode != ReplicaWriteMode::FLEXIBLE_DUAL_REPLICA) {
                 MasterMetricManager::instance().inc_put_start_alloc_failures();
                 need_nof_eviction_ = true;
+                abort_reserved_quota();
                 return tl::make_unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
             }
         } else {
@@ -1735,6 +2124,7 @@ auto MasterService::AllocateAndInsertMetadata(
                 << ", allocated_memory_replicas=" << allocated_memory_replicas
                 << ", requested_nof_replicas=" << config.nof_replica_num
                 << ", allocated_nof_replicas=" << allocated_nof_replicas;
+        abort_reserved_quota();
         return tl::make_unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
     }
 
@@ -1776,8 +2166,10 @@ auto MasterService::AllocateAndInsertMetadata(
                               config.data_type, group_id, tenant_id, key));
     if (!inserted) {
         LOG(INFO) << "key=" << key << ", info=object_already_exists";
+        abort_reserved_quota();
         return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
     }
+    it->second.reserved_quota_charge_bytes = reserved_quota_charge;
     RegisterGroupMember(tenant_state, tenant_id, key, group_id);
     tenant_state.processing_keys.insert(key);
 
@@ -1947,6 +2339,25 @@ auto MasterService::PutEnd(const UUID& client_id, const std::string& key,
         },
         [](Replica& replica) { replica.mark_complete(); });
 
+    if (metadata.reserved_quota_charge_bytes > 0) {
+        const uint64_t actual_charge = CompletedMemoryQuotaCharge(metadata);
+        const uint64_t commit_charge =
+            actual_charge > metadata.committed_quota_charge_bytes
+                ? actual_charge - metadata.committed_quota_charge_bytes
+                : 0;
+        const uint64_t abort_charge =
+            metadata.reserved_quota_charge_bytes > commit_charge
+                ? metadata.reserved_quota_charge_bytes - commit_charge
+                : 0;
+        CommitTenantQuota(object_id.tenant_id, commit_charge);
+        AbortTenantQuota(object_id.tenant_id, abort_charge);
+        metadata.reserved_quota_charge_bytes = 0;
+        metadata.committed_quota_charge_bytes = actual_charge;
+        ReleaseTenantQuota(object_id.tenant_id,
+                           metadata.pending_replaced_quota_charge_bytes);
+        metadata.pending_replaced_quota_charge_bytes = 0;
+    }
+
     if (enable_offload_ && !offload_on_evict_) {
         auto& tenant_state = accessor.GetTenantState();
         metadata.VisitReplicas(
@@ -1984,7 +2395,8 @@ auto MasterService::AddReplica(const UUID& client_id, const std::string& key,
                                const std::string& tenant_id, Replica& replica)
     -> tl::expected<void, ErrorCode> {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    MetadataAccessorRW accessor(this, MakeObjectIdentity(key, tenant_id));
+    const auto object_id = MakeObjectIdentity(key, tenant_id);
+    MetadataAccessorRW accessor(this, object_id);
     if (!accessor.Exists()) {
         accessor.Create(
             client_id,
@@ -2030,7 +2442,8 @@ auto MasterService::PutRevoke(const UUID& client_id, const std::string& key,
                               ReplicaType replica_type)
     -> tl::expected<void, ErrorCode> {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    MetadataAccessorRW accessor(this, MakeObjectIdentity(key, tenant_id));
+    const auto object_id = MakeObjectIdentity(key, tenant_id);
+    MetadataAccessorRW accessor(this, object_id);
     if (!accessor.Exists()) {
         LOG(INFO) << "key=" << key << ", info=object_not_found";
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
@@ -2057,6 +2470,7 @@ auto MasterService::PutRevoke(const UUID& client_id, const std::string& key,
         return tl::make_unexpected(ErrorCode::INVALID_WRITE);
     }
 
+    const uint64_t before_charge = CompletedMemoryQuotaCharge(metadata);
     EraseReplicasWithCacheTotalAccounting(
         metadata, [replica_type](const Replica& replica) {
             if (replica_type == ReplicaType::ALL) {
@@ -2064,6 +2478,15 @@ auto MasterService::PutRevoke(const UUID& client_id, const std::string& key,
             }
             return replica.type() == replica_type;
         });
+    const uint64_t after_charge = CompletedMemoryQuotaCharge(metadata);
+    if (before_charge > after_charge) {
+        ReleaseCommittedQuotaCharge(metadata, before_charge - after_charge);
+    }
+    if (!metadata.HasReplica(&Replica::fn_is_memory_replica)) {
+        AbortTenantQuota(object_id.tenant_id,
+                         metadata.reserved_quota_charge_bytes);
+        metadata.reserved_quota_charge_bytes = 0;
+    }
 
     // If the object is completed, remove it from the processing set.
     if (metadata.AllReplicas(&Replica::fn_is_completed) &&
@@ -2339,6 +2762,10 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
                 merged_config.with_soft_pin || metadata.IsSoftPinned();
 
             const std::string existing_group_id = metadata.group_id;
+            const uint64_t old_quota_charge =
+                metadata.committed_quota_charge_bytes != 0
+                    ? metadata.committed_quota_charge_bytes
+                    : CompletedMemoryQuotaCharge(metadata);
             auto old_replicas = PopReplicasWithCacheTotalAccounting(metadata);
             if (!old_replicas.empty()) {
                 std::lock_guard lock(discarded_replicas_mutex_);
@@ -2346,13 +2773,24 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
                     std::move(old_replicas),
                     now + put_start_release_timeout_sec_);
             }
-            EraseMetadata(tenant_state, it, object_id.tenant_id);
+            EraseMetadata(tenant_state, it, object_id.tenant_id,
+                          QuotaEraseMode::kPreserveOld);
 
             VLOG(1) << "key=" << key
                     << ", action=upsert_start_case_c_reallocate";
-            return AllocateAndInsertMetadata(
+            auto allocate_result = AllocateAndInsertMetadata(
                 shard, client_id, key, slice_length, merged_config,
                 existing_group_id, object_id.tenant_id, now);
+            if (!allocate_result) {
+                ReleaseTenantQuota(object_id.tenant_id, old_quota_charge);
+                return allocate_result;
+            }
+            auto new_it = tenant_state.metadata.find(key);
+            if (new_it != tenant_state.metadata.end()) {
+                new_it->second.pending_replaced_quota_charge_bytes =
+                    old_quota_charge;
+            }
+            return allocate_result;
         }
     }
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
@@ -2526,6 +2964,9 @@ tl::expected<CopyStartResponse, ErrorCode> MasterService::CopyStart(
     std::vector<Replica> replicas;
     replicas.reserve(tgt_segments.size());
     {
+        // PR2 limitation: Copy can allocate extra physical MEMORY replicas
+        // without tenant quota admission. It does not change the logical
+        // object set; full quota-aware Copy admission is deferred.
         ScopedAllocatorAccess allocator_access =
             segment_manager_.getAllocatorAccess();
         const auto& allocator_manager = allocator_access.getAllocatorManager();
@@ -2757,6 +3198,9 @@ tl::expected<MoveStartResponse, ErrorCode> MasterService::MoveStart(
 
     std::vector<Replica> replicas;
     if (metadata.GetReplicaBySegmentName(tgt_segment) == nullptr) {
+        // PR2 limitation: Move can allocate a replacement physical MEMORY
+        // replica without tenant quota admission. Logical object accounting is
+        // unchanged; full quota-aware Move admission is deferred.
         ScopedAllocatorAccess allocator_access =
             segment_manager_.getAllocatorAccess();
         const auto& allocator_manager = allocator_access.getAllocatorManager();
@@ -3252,6 +3696,7 @@ bool MasterService::CleanupStaleHandles(
     const std::unordered_set<UUID, boost::hash<UUID>>& alive_clients) {
     // Remove those with invalid allocators (memory replicas on unmounted
     // segments) and local_disk replicas whose owner client is no longer alive.
+    const uint64_t before_charge = CompletedMemoryQuotaCharge(metadata);
     EraseReplicasWithCacheTotalAccounting(
         metadata, [&alive_clients](const Replica& replica) {
             return (replica.has_invalid_mem_handle() ||
@@ -3259,6 +3704,10 @@ bool MasterService::CleanupStaleHandles(
                     replica.has_stale_local_disk_client(alive_clients)) &&
                    replica.is_completed();
         });
+    const uint64_t after_charge = CompletedMemoryQuotaCharge(metadata);
+    if (before_charge > after_charge) {
+        ReleaseCommittedQuotaCharge(metadata, before_charge - after_charge);
+    }
 
     // Return true if no valid replicas remain after cleanup
     return !metadata.IsValid();
@@ -5206,6 +5655,7 @@ bool MasterService::TryRestoreStateFromSnapshot(
 
         LOG(INFO) << "[Restore] Successfully restored state from snapshot: "
                   << state_id;
+        RebuildTenantQuotaUsageFromMetadata();
         return true;
     } catch (const std::exception& e) {
         return fail_restore("exception during state restoration: " +
@@ -5916,6 +6366,7 @@ void MasterService::ClientMonitorFunc() {
                     segment_access.UnmountLocalDiskSegment(client_id);
                 }
             }
+            RecomputeTenantEffectiveQuotas();
         }
 
         std::this_thread::sleep_for(

--- a/mooncake-store/src/types.cpp
+++ b/mooncake-store/src/types.cpp
@@ -67,7 +67,14 @@ const std::string& toString(ErrorCode errorCode) noexcept {
         {ErrorCode::PERSISTENT_FAIL, "PERSISTENT_FAIL"},
         {ErrorCode::TASK_NOT_FOUND, "TASK_NOT_FOUND"},
         {ErrorCode::TASK_PENDING_LIMIT_EXCEEDED, "TASK_PENDING_LIMIT_EXCEEDED"},
-        {ErrorCode::JOB_NOT_FOUND, "JOB_NOT_FOUND"}};
+        {ErrorCode::JOB_NOT_FOUND, "JOB_NOT_FOUND"},
+        {ErrorCode::DFS_NETWORK_TIMEOUT, "DFS_NETWORK_TIMEOUT"},
+        {ErrorCode::DFS_SERVICE_UNAVAILABLE, "DFS_SERVICE_UNAVAILABLE"},
+        {ErrorCode::DFS_QUOTA_EXCEEDED, "DFS_QUOTA_EXCEEDED"},
+        {ErrorCode::DFS_PERMISSION_DENIED, "DFS_PERMISSION_DENIED"},
+        {ErrorCode::DFS_STALE_HANDLE, "DFS_STALE_HANDLE"},
+        {ErrorCode::DFS_PARTIAL_WRITE, "DFS_PARTIAL_WRITE"},
+        {ErrorCode::TENANT_QUOTA_EXCEEDED, "TENANT_QUOTA_EXCEEDED"}};
 
     auto it = errorCodeMap.find(errorCode);
     static const std::string unknownError = "UNKNOWN_ERROR";

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -38,6 +38,8 @@ add_store_test(allocation_strategy_test allocation_strategy_test.cpp)
 add_store_test(eviction_strategy_test eviction_strategy_test.cpp)
 add_store_test(deadline_scheduler_test deadline_scheduler_test.cpp)
 add_store_test(master_service_test master_service_test.cpp)
+add_store_test(master_service_tenant_quota_test
+               master_service_tenant_quota_test.cpp)
 add_store_test(batch_remove_test batch_remove_test.cpp)
 add_store_test(master_service_ssd_test master_service_ssd_test.cpp)
 add_store_test(offload_on_evict_test offload_on_evict_test.cpp)

--- a/mooncake-store/tests/master_service_tenant_quota_test.cpp
+++ b/mooncake-store/tests/master_service_tenant_quota_test.cpp
@@ -3,6 +3,7 @@
 #include <limits>
 #include <mutex>
 #include <string>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -48,6 +49,17 @@ class MasterServiceTenantQuotaTest : public ::testing::Test {
         return config;
     }
 
+    MasterServiceConfig MakeOffloadConfig(uint64_t default_quota,
+                                          uint64_t pool_capacity) {
+        auto config = MakeConfig(default_quota, pool_capacity);
+        config.enable_offload = true;
+        config.offload_on_evict = true;
+        config.promotion_on_hit = true;
+        config.promotion_admission_threshold = 1;
+        config.default_kv_lease_ttl = 0;
+        return config;
+    }
+
     void PutComplete(MasterService& service, const UUID& client_id,
                      const std::string& key, const std::string& tenant_id,
                      uint64_t size) {
@@ -57,6 +69,28 @@ class MasterServiceTenantQuotaTest : public ::testing::Test {
         auto end =
             service.PutEnd(client_id, key, tenant_id, ReplicaType::MEMORY);
         ASSERT_TRUE(end.has_value()) << toString(end.error());
+    }
+
+    void MountLocalDiskSegment(MasterService& service, const UUID& client_id) {
+        auto mount = service.MountLocalDiskSegment(client_id, true);
+        ASSERT_TRUE(mount.has_value()) << toString(mount.error());
+    }
+
+    void InjectLocalDiskReplica(MasterService& service, const UUID& client_id,
+                                const std::string& key,
+                                const std::string& tenant_id, int64_t size,
+                                const std::string& transport_endpoint) {
+        std::vector<OffloadTaskItem> tasks{
+            OffloadTaskItem{.tenant_id = tenant_id, .key = key, .size = size}};
+        StorageObjectMetadata metadata;
+        metadata.bucket_id = 0;
+        metadata.offset = 0;
+        metadata.key_size = static_cast<int64_t>(key.size());
+        metadata.data_size = size;
+        metadata.transport_endpoint = transport_endpoint;
+        std::vector<StorageObjectMetadata> metadatas{metadata};
+        auto result = service.NotifyOffloadSuccess(client_id, tasks, metadatas);
+        ASSERT_TRUE(result.has_value()) << toString(result.error());
     }
 
     TenantQuotaSnapshot Snapshot(MasterService& service,
@@ -94,6 +128,11 @@ class MasterServiceTenantQuotaTest : public ::testing::Test {
 
     void RecomputeTenantQuotas(MasterService& service) {
         service.RecomputeTenantEffectiveQuotas();
+    }
+
+    void BatchEvict(MasterService& service) {
+        service.BatchEvict(/*evict_ratio_target=*/1.0,
+                           /*evict_ratio_lowerbound=*/1.0);
     }
 
     void SetExplicitTenantPolicy(MasterService& service,
@@ -315,6 +354,79 @@ TEST_F(MasterServiceTenantQuotaTest, RemoveReleasesCommittedCharge) {
     ASSERT_TRUE(service.Remove("key", "tenant-a", /*force=*/true).has_value());
     EXPECT_EQ(Snapshot(service, "tenant-a").used_bytes, 0);
     EXPECT_EQ(Snapshot(service, "tenant-a").reserved_bytes, 0);
+}
+
+TEST_F(MasterServiceTenantQuotaTest,
+       BatchEvictReleasesEvictedMemoryReplicaCharge) {
+    MasterService service(MakeOffloadConfig(/*default_quota=*/1000,
+                                            /*pool_capacity=*/1000));
+    UUID client_id =
+        MountSegment(service, /*size=*/4096, "quota_evict_segment");
+    MountLocalDiskSegment(service, client_id);
+
+    PutComplete(service, client_id, "key", "tenant-a", 400);
+    InjectLocalDiskReplica(service, client_id, "key", "tenant-a", 400,
+                           "quota_evict_segment");
+    ASSERT_EQ(Snapshot(service, "tenant-a").used_bytes, 400);
+
+    BatchEvict(service);
+
+    EXPECT_EQ(Snapshot(service, "tenant-a").used_bytes, 0);
+    EXPECT_EQ(Snapshot(service, "tenant-a").committed_count, 0);
+    auto reserve = service.PutStart(client_id, "after-evict", "tenant-a", 1000,
+                                    MemoryConfig());
+    ASSERT_TRUE(reserve.has_value()) << toString(reserve.error());
+    auto revoke = service.PutRevoke(client_id, "after-evict", "tenant-a",
+                                    ReplicaType::MEMORY);
+    ASSERT_TRUE(revoke.has_value()) << toString(revoke.error());
+}
+
+TEST_F(MasterServiceTenantQuotaTest, PromotionSuccessCommitsTenantQuota) {
+    MasterService service(MakeOffloadConfig(/*default_quota=*/1000,
+                                            /*pool_capacity=*/1000));
+    UUID client_id =
+        MountSegment(service, /*size=*/4096, "quota_promotion_segment");
+    MountLocalDiskSegment(service, client_id);
+    InjectLocalDiskReplica(service, client_id, "cold", "tenant-a", 400,
+                           "quota_promotion_segment");
+
+    auto replicas = service.GetReplicaList("cold", "tenant-a");
+    ASSERT_TRUE(replicas.has_value()) << toString(replicas.error());
+    auto alloc = service.PromotionAllocStart(client_id, "cold", "tenant-a", 400,
+                                             {"quota_promotion_segment"});
+    ASSERT_TRUE(alloc.has_value()) << toString(alloc.error());
+    EXPECT_EQ(Snapshot(service, "tenant-a").used_bytes, 0);
+    EXPECT_EQ(Snapshot(service, "tenant-a").reserved_bytes, 400);
+
+    auto notify = service.NotifyPromotionSuccess(client_id, "cold", "tenant-a");
+    ASSERT_TRUE(notify.has_value()) << toString(notify.error());
+
+    EXPECT_EQ(Snapshot(service, "tenant-a").used_bytes, 400);
+    EXPECT_EQ(Snapshot(service, "tenant-a").reserved_bytes, 0);
+    auto over_quota = service.PutStart(client_id, "too-much", "tenant-a", 700,
+                                       MemoryConfig());
+    ASSERT_FALSE(over_quota.has_value());
+    EXPECT_EQ(over_quota.error(), ErrorCode::TENANT_QUOTA_EXCEEDED);
+}
+
+TEST_F(MasterServiceTenantQuotaTest, PromotionAllocStartRejectsOverQuota) {
+    MasterService service(MakeOffloadConfig(/*default_quota=*/300,
+                                            /*pool_capacity=*/300));
+    UUID client_id =
+        MountSegment(service, /*size=*/4096, "quota_promotion_reject_segment");
+    MountLocalDiskSegment(service, client_id);
+    InjectLocalDiskReplica(service, client_id, "cold", "tenant-a", 400,
+                           "quota_promotion_reject_segment");
+
+    auto replicas = service.GetReplicaList("cold", "tenant-a");
+    ASSERT_TRUE(replicas.has_value()) << toString(replicas.error());
+    auto alloc = service.PromotionAllocStart(
+        client_id, "cold", "tenant-a", 400, {"quota_promotion_reject_segment"});
+
+    ASSERT_FALSE(alloc.has_value());
+    EXPECT_EQ(alloc.error(), ErrorCode::TENANT_QUOTA_EXCEEDED);
+    EXPECT_FALSE(
+        service.GetTenantQuotaSnapshotForTesting("tenant-a").has_value());
 }
 
 TEST_F(MasterServiceTenantQuotaTest,

--- a/mooncake-store/tests/master_service_tenant_quota_test.cpp
+++ b/mooncake-store/tests/master_service_tenant_quota_test.cpp
@@ -1,0 +1,303 @@
+#include "master_service.h"
+
+#include <limits>
+
+#include <gtest/gtest.h>
+
+#include "types.h"
+
+namespace mooncake::test {
+
+class MasterServiceTenantQuotaTest : public ::testing::Test {
+   protected:
+    static constexpr size_t kSegmentBase = 0x500000000;
+
+    MasterServiceConfig MakeConfig(uint64_t default_quota,
+                                   uint64_t pool_capacity,
+                                   bool enable_quota = true) {
+        return MasterServiceConfig::builder()
+            .set_root_fs_dir("")
+            .set_enable_tenant_quota(enable_quota)
+            .set_default_tenant_quota_bytes(default_quota)
+            .set_tenant_quota_pool_capacity_bytes(pool_capacity)
+            .build();
+    }
+
+    UUID MountSegment(MasterService& service, size_t size = 4096,
+                      std::string name = "quota_segment") {
+        Segment segment;
+        segment.id = generate_uuid();
+        segment.name = std::move(name);
+        segment.base = kSegmentBase + next_segment_offset_;
+        segment.size = size;
+        segment.te_endpoint = segment.name;
+        next_segment_offset_ += size + 4096;
+
+        UUID client_id = generate_uuid();
+        auto result = service.MountSegment(segment, client_id);
+        EXPECT_TRUE(result.has_value());
+        return client_id;
+    }
+
+    ReplicateConfig MemoryConfig() {
+        ReplicateConfig config;
+        config.replica_num = 1;
+        return config;
+    }
+
+    void PutComplete(MasterService& service, const UUID& client_id,
+                     const std::string& key, const std::string& tenant_id,
+                     uint64_t size) {
+        auto start =
+            service.PutStart(client_id, key, tenant_id, size, MemoryConfig());
+        ASSERT_TRUE(start.has_value()) << toString(start.error());
+        auto end =
+            service.PutEnd(client_id, key, tenant_id, ReplicaType::MEMORY);
+        ASSERT_TRUE(end.has_value()) << toString(end.error());
+    }
+
+    TenantQuotaSnapshot Snapshot(MasterService& service,
+                                 const std::string& tenant_id) {
+        auto snapshot = service.GetTenantQuotaSnapshotForTesting(tenant_id);
+        EXPECT_TRUE(snapshot.has_value());
+        return *snapshot;
+    }
+
+    tl::expected<void, ErrorCode> ReserveQuota(MasterService& service,
+                                               const std::string& tenant_id,
+                                               uint64_t bytes) {
+        return service.ReserveTenantQuota(tenant_id, bytes);
+    }
+
+    void CommitQuota(MasterService& service, const std::string& tenant_id,
+                     uint64_t bytes) {
+        service.CommitTenantQuota(tenant_id, bytes);
+    }
+
+    void AbortQuota(MasterService& service, const std::string& tenant_id,
+                    uint64_t bytes) {
+        service.AbortTenantQuota(tenant_id, bytes);
+    }
+
+    void ReleaseQuota(MasterService& service, const std::string& tenant_id,
+                      uint64_t bytes) {
+        service.ReleaseTenantQuota(tenant_id, bytes);
+    }
+
+    void ReleaseQuotaPartial(MasterService& service,
+                             const std::string& tenant_id, uint64_t bytes) {
+        service.ReleaseTenantQuotaPartial(tenant_id, bytes);
+    }
+
+    void ExpectSameAccounting(const TenantQuotaSnapshot& before,
+                              const TenantQuotaSnapshot& after) {
+        EXPECT_EQ(after.requested_quota_bytes, before.requested_quota_bytes);
+        EXPECT_EQ(after.effective_quota_bytes, before.effective_quota_bytes);
+        EXPECT_EQ(after.used_bytes, before.used_bytes);
+        EXPECT_EQ(after.reserved_bytes, before.reserved_bytes);
+        EXPECT_EQ(after.committed_count, before.committed_count);
+        EXPECT_EQ(after.has_explicit_policy, before.has_explicit_policy);
+        EXPECT_EQ(after.over_quota, before.over_quota);
+    }
+
+    size_t next_segment_offset_ = 0;
+};
+
+TEST_F(MasterServiceTenantQuotaTest, DisabledPreservesLegacyPutRemove) {
+    MasterService service(MakeConfig(/*default_quota=*/128,
+                                     /*pool_capacity=*/128,
+                                     /*enable_quota=*/false));
+    UUID client_id = MountSegment(service);
+
+    PutComplete(service, client_id, "large", "tenant-a", 512);
+    EXPECT_TRUE(
+        service.Remove("large", "tenant-a", /*force=*/true).has_value());
+    EXPECT_FALSE(
+        service.GetTenantQuotaSnapshotForTesting("tenant-a").has_value());
+}
+
+TEST_F(MasterServiceTenantQuotaTest, SameKeyDifferentTenantsIndependent) {
+    MasterService service(MakeConfig(/*default_quota=*/1000,
+                                     /*pool_capacity=*/2000));
+    UUID client_id = MountSegment(service);
+
+    PutComplete(service, client_id, "shared-key", "tenant-a", 800);
+    PutComplete(service, client_id, "shared-key", "tenant-b", 800);
+
+    EXPECT_EQ(Snapshot(service, "tenant-a").used_bytes, 800);
+    EXPECT_EQ(Snapshot(service, "tenant-b").used_bytes, 800);
+}
+
+TEST_F(MasterServiceTenantQuotaTest, SameTenantSharesQuotaAcrossKeys) {
+    MasterService service(MakeConfig(/*default_quota=*/1000,
+                                     /*pool_capacity=*/1000));
+    UUID client_id = MountSegment(service);
+
+    PutComplete(service, client_id, "key-a", "tenant-a", 600);
+    auto over_quota =
+        service.PutStart(client_id, "key-b", "tenant-a", 500, MemoryConfig());
+
+    ASSERT_FALSE(over_quota.has_value());
+    EXPECT_EQ(over_quota.error(), ErrorCode::TENANT_QUOTA_EXCEEDED);
+    EXPECT_EQ(Snapshot(service, "tenant-a").used_bytes, 600);
+    EXPECT_EQ(Snapshot(service, "tenant-a").reserved_bytes, 0);
+}
+
+TEST_F(MasterServiceTenantQuotaTest,
+       FirstTenantPutStartUsesInlineDefaultWithoutRecompute) {
+    MasterService service(MakeConfig(/*default_quota=*/1000,
+                                     /*pool_capacity=*/100));
+    UUID client_id = MountSegment(service);
+
+    auto start =
+        service.PutStart(client_id, "key", "tenant-a", 800, MemoryConfig());
+
+    ASSERT_TRUE(start.has_value()) << toString(start.error());
+    auto snapshot = Snapshot(service, "tenant-a");
+    EXPECT_EQ(snapshot.requested_quota_bytes, 1000);
+    EXPECT_EQ(snapshot.effective_quota_bytes, 1000);
+    EXPECT_EQ(snapshot.used_bytes, 0);
+    EXPECT_EQ(snapshot.reserved_bytes, 800);
+    AbortQuota(service, "tenant-a", 800);
+}
+
+TEST_F(MasterServiceTenantQuotaTest,
+       ZeroDefaultQuotaInitializesNewTenantAsUnlimited) {
+    MasterService service(MakeConfig(/*default_quota=*/0,
+                                     /*pool_capacity=*/1));
+
+    auto reserve = ReserveQuota(service, "tenant-a", 4096);
+
+    ASSERT_TRUE(reserve.has_value()) << toString(reserve.error());
+    auto snapshot = Snapshot(service, "tenant-a");
+    EXPECT_EQ(snapshot.requested_quota_bytes, 0);
+    EXPECT_EQ(snapshot.effective_quota_bytes,
+              std::numeric_limits<uint64_t>::max());
+    EXPECT_EQ(snapshot.reserved_bytes, 4096);
+}
+
+TEST_F(MasterServiceTenantQuotaTest,
+       OverQuotaReserveDoesNotChangeReservedBytes) {
+    MasterService service(MakeConfig(/*default_quota=*/100,
+                                     /*pool_capacity=*/100));
+    ASSERT_TRUE(ReserveQuota(service, "tenant-a", 80).has_value());
+    auto before = Snapshot(service, "tenant-a");
+
+    auto reserve = ReserveQuota(service, "tenant-a", 30);
+
+    ASSERT_FALSE(reserve.has_value());
+    EXPECT_EQ(reserve.error(), ErrorCode::TENANT_QUOTA_EXCEEDED);
+    ExpectSameAccounting(before, Snapshot(service, "tenant-a"));
+}
+
+TEST_F(MasterServiceTenantQuotaTest, CommitMismatchDoesNotMutateAccounting) {
+    MasterService service(MakeConfig(/*default_quota=*/100,
+                                     /*pool_capacity=*/100));
+    ASSERT_TRUE(ReserveQuota(service, "tenant-a", 40).has_value());
+    auto before = Snapshot(service, "tenant-a");
+
+    CommitQuota(service, "tenant-a", 50);
+
+    ExpectSameAccounting(before, Snapshot(service, "tenant-a"));
+}
+
+TEST_F(MasterServiceTenantQuotaTest, AbortMismatchDoesNotMutateAccounting) {
+    MasterService service(MakeConfig(/*default_quota=*/100,
+                                     /*pool_capacity=*/100));
+    ASSERT_TRUE(ReserveQuota(service, "tenant-a", 40).has_value());
+    auto before = Snapshot(service, "tenant-a");
+
+    AbortQuota(service, "tenant-a", 50);
+
+    ExpectSameAccounting(before, Snapshot(service, "tenant-a"));
+}
+
+TEST_F(MasterServiceTenantQuotaTest, ReleaseMismatchDoesNotMutateAccounting) {
+    MasterService service(MakeConfig(/*default_quota=*/100,
+                                     /*pool_capacity=*/100));
+    ASSERT_TRUE(ReserveQuota(service, "tenant-a", 40).has_value());
+    CommitQuota(service, "tenant-a", 40);
+    auto before = Snapshot(service, "tenant-a");
+
+    ReleaseQuota(service, "tenant-a", 50);
+
+    ExpectSameAccounting(before, Snapshot(service, "tenant-a"));
+}
+
+TEST_F(MasterServiceTenantQuotaTest,
+       ReleasePartialMismatchDoesNotMutateAccounting) {
+    MasterService service(MakeConfig(/*default_quota=*/100,
+                                     /*pool_capacity=*/100));
+    ASSERT_TRUE(ReserveQuota(service, "tenant-a", 40).has_value());
+    CommitQuota(service, "tenant-a", 40);
+    auto before = Snapshot(service, "tenant-a");
+
+    ReleaseQuotaPartial(service, "tenant-a", 50);
+
+    ExpectSameAccounting(before, Snapshot(service, "tenant-a"));
+}
+
+TEST_F(MasterServiceTenantQuotaTest,
+       PhysicalAllocationFailureKeepsAllocatorError) {
+    MasterService service(MakeConfig(/*default_quota=*/4096,
+                                     /*pool_capacity=*/4096));
+    UUID client_id = MountSegment(service, /*size=*/512);
+
+    auto result = service.PutStart(client_id, "too-large", "tenant-a", 1024,
+                                   MemoryConfig());
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), ErrorCode::NO_AVAILABLE_HANDLE);
+    EXPECT_EQ(Snapshot(service, "tenant-a").reserved_bytes, 0);
+}
+
+TEST_F(MasterServiceTenantQuotaTest, RemoveReleasesCommittedCharge) {
+    MasterService service(MakeConfig(/*default_quota=*/1000,
+                                     /*pool_capacity=*/1000));
+    UUID client_id = MountSegment(service);
+
+    PutComplete(service, client_id, "key", "tenant-a", 400);
+    ASSERT_EQ(Snapshot(service, "tenant-a").used_bytes, 400);
+
+    ASSERT_TRUE(service.Remove("key", "tenant-a", /*force=*/true).has_value());
+    EXPECT_EQ(Snapshot(service, "tenant-a").used_bytes, 0);
+    EXPECT_EQ(Snapshot(service, "tenant-a").reserved_bytes, 0);
+}
+
+TEST_F(MasterServiceTenantQuotaTest, ChangedSizeUpsertSuccessSwapsCharge) {
+    MasterService service(MakeConfig(/*default_quota=*/1000,
+                                     /*pool_capacity=*/1000));
+    UUID client_id = MountSegment(service);
+
+    PutComplete(service, client_id, "key", "tenant-a", 400);
+    auto start =
+        service.UpsertStart(client_id, "key", "tenant-a", 600, MemoryConfig());
+    ASSERT_TRUE(start.has_value()) << toString(start.error());
+    EXPECT_EQ(Snapshot(service, "tenant-a").used_bytes, 400);
+    EXPECT_EQ(Snapshot(service, "tenant-a").reserved_bytes, 600);
+
+    auto end =
+        service.UpsertEnd(client_id, "key", "tenant-a", ReplicaType::MEMORY);
+    ASSERT_TRUE(end.has_value()) << toString(end.error());
+    EXPECT_EQ(Snapshot(service, "tenant-a").used_bytes, 600);
+    EXPECT_EQ(Snapshot(service, "tenant-a").reserved_bytes, 0);
+}
+
+TEST_F(MasterServiceTenantQuotaTest, ChangedSizeUpsertRevokeReleasesOldAndNew) {
+    MasterService service(MakeConfig(/*default_quota=*/1000,
+                                     /*pool_capacity=*/1000));
+    UUID client_id = MountSegment(service);
+
+    PutComplete(service, client_id, "key", "tenant-a", 400);
+    auto start =
+        service.UpsertStart(client_id, "key", "tenant-a", 600, MemoryConfig());
+    ASSERT_TRUE(start.has_value()) << toString(start.error());
+
+    auto revoke =
+        service.UpsertRevoke(client_id, "key", "tenant-a", ReplicaType::MEMORY);
+    ASSERT_TRUE(revoke.has_value()) << toString(revoke.error());
+    EXPECT_EQ(Snapshot(service, "tenant-a").used_bytes, 0);
+    EXPECT_EQ(Snapshot(service, "tenant-a").reserved_bytes, 0);
+}
+
+}  // namespace mooncake::test

--- a/mooncake-store/tests/master_service_tenant_quota_test.cpp
+++ b/mooncake-store/tests/master_service_tenant_quota_test.cpp
@@ -1,6 +1,7 @@
 #include "master_service.h"
 
 #include <limits>
+#include <mutex>
 #include <string>
 
 #include <gtest/gtest.h>
@@ -89,6 +90,25 @@ class MasterServiceTenantQuotaTest : public ::testing::Test {
     void ReleaseQuotaPartial(MasterService& service,
                              const std::string& tenant_id, uint64_t bytes) {
         service.ReleaseTenantQuotaPartial(tenant_id, bytes);
+    }
+
+    void RecomputeTenantQuotas(MasterService& service) {
+        service.RecomputeTenantEffectiveQuotas();
+    }
+
+    void SetExplicitTenantPolicy(MasterService& service,
+                                 const std::string& tenant_id,
+                                 uint64_t requested_quota_bytes) {
+        const auto normalized_tenant = NormalizeTenantId(tenant_id);
+        const auto shard_idx =
+            service.getTenantQuotaShardIndex(normalized_tenant);
+        auto& shard = service.tenant_quota_shards_[shard_idx];
+        std::lock_guard<std::mutex> lock(shard.mutex);
+        auto& state = shard.tenants[normalized_tenant];
+        state.requested_quota_bytes = requested_quota_bytes;
+        state.effective_quota_bytes = requested_quota_bytes;
+        state.has_explicit_policy = true;
+        state.over_quota = false;
     }
 
     void ExpectSameAccounting(const TenantQuotaSnapshot& before,
@@ -190,6 +210,37 @@ TEST_F(MasterServiceTenantQuotaTest,
     ASSERT_FALSE(reserve.has_value());
     EXPECT_EQ(reserve.error(), ErrorCode::TENANT_QUOTA_EXCEEDED);
     ExpectSameAccounting(before, Snapshot(service, "tenant-a"));
+}
+
+TEST_F(MasterServiceTenantQuotaTest,
+       FirstOverQuotaReserveDoesNotCreateTenantState) {
+    MasterService service(MakeConfig(/*default_quota=*/100,
+                                     /*pool_capacity=*/100));
+
+    auto reserve = ReserveQuota(service, "tenant-a", 101);
+
+    ASSERT_FALSE(reserve.has_value());
+    EXPECT_EQ(reserve.error(), ErrorCode::TENANT_QUOTA_EXCEEDED);
+    EXPECT_FALSE(
+        service.GetTenantQuotaSnapshotForTesting("tenant-a").has_value());
+}
+
+TEST_F(MasterServiceTenantQuotaTest, RecomputePrunesEmptyInheritedTenantState) {
+    MasterService service(MakeConfig(/*default_quota=*/100,
+                                     /*pool_capacity=*/1000));
+    ASSERT_TRUE(ReserveQuota(service, "tenant-a", 40).has_value());
+    AbortQuota(service, "tenant-a", 40);
+    ASSERT_TRUE(
+        service.GetTenantQuotaSnapshotForTesting("tenant-a").has_value());
+    SetExplicitTenantPolicy(service, "tenant-explicit", 200);
+
+    RecomputeTenantQuotas(service);
+
+    EXPECT_FALSE(
+        service.GetTenantQuotaSnapshotForTesting("tenant-a").has_value());
+    auto explicit_snapshot = Snapshot(service, "tenant-explicit");
+    EXPECT_TRUE(explicit_snapshot.has_explicit_policy);
+    EXPECT_EQ(explicit_snapshot.requested_quota_bytes, 200);
 }
 
 TEST_F(MasterServiceTenantQuotaTest, CommitMismatchDoesNotMutateAccounting) {

--- a/mooncake-store/tests/master_service_tenant_quota_test.cpp
+++ b/mooncake-store/tests/master_service_tenant_quota_test.cpp
@@ -1,6 +1,7 @@
 #include "master_service.h"
 
 #include <limits>
+#include <string>
 
 #include <gtest/gtest.h>
 
@@ -14,9 +15,10 @@ class MasterServiceTenantQuotaTest : public ::testing::Test {
 
     MasterServiceConfig MakeConfig(uint64_t default_quota,
                                    uint64_t pool_capacity,
-                                   bool enable_quota = true) {
+                                   bool enable_quota = true,
+                                   std::string root_fs_dir = "") {
         return MasterServiceConfig::builder()
-            .set_root_fs_dir("")
+            .set_root_fs_dir(root_fs_dir)
             .set_enable_tenant_quota(enable_quota)
             .set_default_tenant_quota_bytes(default_quota)
             .set_tenant_quota_pool_capacity_bytes(pool_capacity)
@@ -261,6 +263,32 @@ TEST_F(MasterServiceTenantQuotaTest, RemoveReleasesCommittedCharge) {
 
     ASSERT_TRUE(service.Remove("key", "tenant-a", /*force=*/true).has_value());
     EXPECT_EQ(Snapshot(service, "tenant-a").used_bytes, 0);
+    EXPECT_EQ(Snapshot(service, "tenant-a").reserved_bytes, 0);
+}
+
+TEST_F(MasterServiceTenantQuotaTest,
+       DiskPutEndBeforeMemoryKeepsQuotaReservation) {
+    MasterService service(
+        MakeConfig(/*default_quota=*/1000, /*pool_capacity=*/1000,
+                   /*enable_quota=*/true, /*root_fs_dir=*/"/tmp/mooncake"));
+    UUID client_id = MountSegment(service);
+
+    auto start =
+        service.PutStart(client_id, "key", "tenant-a", 400, MemoryConfig());
+    ASSERT_TRUE(start.has_value()) << toString(start.error());
+    EXPECT_EQ(Snapshot(service, "tenant-a").used_bytes, 0);
+    EXPECT_EQ(Snapshot(service, "tenant-a").reserved_bytes, 400);
+
+    auto disk_end =
+        service.PutEnd(client_id, "key", "tenant-a", ReplicaType::DISK);
+    ASSERT_TRUE(disk_end.has_value()) << toString(disk_end.error());
+    EXPECT_EQ(Snapshot(service, "tenant-a").used_bytes, 0);
+    EXPECT_EQ(Snapshot(service, "tenant-a").reserved_bytes, 400);
+
+    auto memory_end =
+        service.PutEnd(client_id, "key", "tenant-a", ReplicaType::MEMORY);
+    ASSERT_TRUE(memory_end.has_value()) << toString(memory_end.error());
+    EXPECT_EQ(Snapshot(service, "tenant-a").used_bytes, 400);
     EXPECT_EQ(Snapshot(service, "tenant-a").reserved_bytes, 0);
 }
 

--- a/mooncake-store/tests/master_service_tenant_quota_test.cpp
+++ b/mooncake-store/tests/master_service_tenant_quota_test.cpp
@@ -150,6 +150,20 @@ class MasterServiceTenantQuotaTest : public ::testing::Test {
         state.over_quota = false;
     }
 
+    void SetEmptyInheritedTenantState(MasterService& service,
+                                      const std::string& tenant_id) {
+        const auto normalized_tenant = NormalizeTenantId(tenant_id);
+        const auto shard_idx =
+            service.getTenantQuotaShardIndex(normalized_tenant);
+        auto& shard = service.tenant_quota_shards_[shard_idx];
+        std::lock_guard<std::mutex> lock(shard.mutex);
+        auto& state = shard.tenants[normalized_tenant];
+        state.requested_quota_bytes = service.default_tenant_quota_bytes_;
+        state.effective_quota_bytes = service.default_tenant_quota_bytes_;
+        state.has_explicit_policy = false;
+        state.over_quota = false;
+    }
+
     void ExpectSameAccounting(const TenantQuotaSnapshot& before,
                               const TenantQuotaSnapshot& after) {
         EXPECT_EQ(after.requested_quota_bytes, before.requested_quota_bytes);
@@ -274,8 +288,7 @@ TEST_F(MasterServiceTenantQuotaTest,
 TEST_F(MasterServiceTenantQuotaTest, RecomputePrunesEmptyInheritedTenantState) {
     MasterService service(MakeConfig(/*default_quota=*/100,
                                      /*pool_capacity=*/1000));
-    ASSERT_TRUE(ReserveQuota(service, "tenant-a", 40).has_value());
-    AbortQuota(service, "tenant-a", 40);
+    SetEmptyInheritedTenantState(service, "tenant-a");
     ASSERT_TRUE(
         service.GetTenantQuotaSnapshotForTesting("tenant-a").has_value());
     SetExplicitTenantPolicy(service, "tenant-explicit", 200);
@@ -287,6 +300,47 @@ TEST_F(MasterServiceTenantQuotaTest, RecomputePrunesEmptyInheritedTenantState) {
     auto explicit_snapshot = Snapshot(service, "tenant-explicit");
     EXPECT_TRUE(explicit_snapshot.has_explicit_policy);
     EXPECT_EQ(explicit_snapshot.requested_quota_bytes, 200);
+}
+
+TEST_F(MasterServiceTenantQuotaTest,
+       AbortPrunesInactiveInheritedTenantAndRecomputesQuotas) {
+    MasterService service(MakeConfig(/*default_quota=*/1000,
+                                     /*pool_capacity=*/100));
+
+    ASSERT_TRUE(ReserveQuota(service, "tenant-a", 50).has_value());
+    ASSERT_TRUE(ReserveQuota(service, "tenant-b", 40).has_value());
+    EXPECT_EQ(Snapshot(service, "tenant-b").effective_quota_bytes, 50);
+
+    AbortQuota(service, "tenant-a", 50);
+
+    EXPECT_FALSE(
+        service.GetTenantQuotaSnapshotForTesting("tenant-a").has_value());
+    EXPECT_EQ(Snapshot(service, "tenant-b").effective_quota_bytes, 100);
+    ASSERT_TRUE(ReserveQuota(service, "tenant-b", 60).has_value());
+    EXPECT_EQ(Snapshot(service, "tenant-b").reserved_bytes, 100);
+    AbortQuota(service, "tenant-b", 100);
+}
+
+TEST_F(MasterServiceTenantQuotaTest,
+       FullReleasePrunesInactiveInheritedTenantAndRecomputesQuotas) {
+    MasterService service(MakeConfig(/*default_quota=*/1000,
+                                     /*pool_capacity=*/100));
+    UUID client_id = MountSegment(service);
+    PutComplete(service, client_id, "key-a", "tenant-a", 50);
+    PutComplete(service, client_id, "key-b", "tenant-b", 40);
+    EXPECT_EQ(Snapshot(service, "tenant-b").effective_quota_bytes, 50);
+
+    ASSERT_TRUE(
+        service.Remove("key-a", "tenant-a", /*force=*/true).has_value());
+
+    EXPECT_FALSE(
+        service.GetTenantQuotaSnapshotForTesting("tenant-a").has_value());
+    EXPECT_EQ(Snapshot(service, "tenant-b").effective_quota_bytes, 100);
+    auto reserve = service.PutStart(client_id, "key-b-extra", "tenant-b", 60,
+                                    MemoryConfig());
+    ASSERT_TRUE(reserve.has_value()) << toString(reserve.error());
+    EXPECT_EQ(Snapshot(service, "tenant-b").reserved_bytes, 60);
+    AbortQuota(service, "tenant-b", 60);
 }
 
 TEST_F(MasterServiceTenantQuotaTest, CommitMismatchDoesNotMutateAccounting) {
@@ -347,7 +401,8 @@ TEST_F(MasterServiceTenantQuotaTest,
 
     ASSERT_FALSE(result.has_value());
     EXPECT_EQ(result.error(), ErrorCode::NO_AVAILABLE_HANDLE);
-    EXPECT_EQ(Snapshot(service, "tenant-a").reserved_bytes, 0);
+    EXPECT_FALSE(
+        service.GetTenantQuotaSnapshotForTesting("tenant-a").has_value());
 }
 
 TEST_F(MasterServiceTenantQuotaTest, RemoveReleasesCommittedCharge) {
@@ -359,8 +414,8 @@ TEST_F(MasterServiceTenantQuotaTest, RemoveReleasesCommittedCharge) {
     ASSERT_EQ(Snapshot(service, "tenant-a").used_bytes, 400);
 
     ASSERT_TRUE(service.Remove("key", "tenant-a", /*force=*/true).has_value());
-    EXPECT_EQ(Snapshot(service, "tenant-a").used_bytes, 0);
-    EXPECT_EQ(Snapshot(service, "tenant-a").reserved_bytes, 0);
+    EXPECT_FALSE(
+        service.GetTenantQuotaSnapshotForTesting("tenant-a").has_value());
 }
 
 TEST_F(MasterServiceTenantQuotaTest,
@@ -378,11 +433,12 @@ TEST_F(MasterServiceTenantQuotaTest,
 
     BatchEvict(service);
 
-    EXPECT_EQ(Snapshot(service, "tenant-a").used_bytes, 0);
-    EXPECT_EQ(Snapshot(service, "tenant-a").committed_count, 0);
+    EXPECT_FALSE(
+        service.GetTenantQuotaSnapshotForTesting("tenant-a").has_value());
     auto reserve = service.PutStart(client_id, "after-evict", "tenant-a", 1000,
                                     MemoryConfig());
     ASSERT_TRUE(reserve.has_value()) << toString(reserve.error());
+    EXPECT_EQ(Snapshot(service, "tenant-a").reserved_bytes, 1000);
     auto revoke = service.PutRevoke(client_id, "after-evict", "tenant-a",
                                     ReplicaType::MEMORY);
     ASSERT_TRUE(revoke.has_value()) << toString(revoke.error());
@@ -494,8 +550,8 @@ TEST_F(MasterServiceTenantQuotaTest, ChangedSizeUpsertRevokeReleasesOldAndNew) {
     auto revoke =
         service.UpsertRevoke(client_id, "key", "tenant-a", ReplicaType::MEMORY);
     ASSERT_TRUE(revoke.has_value()) << toString(revoke.error());
-    EXPECT_EQ(Snapshot(service, "tenant-a").used_bytes, 0);
-    EXPECT_EQ(Snapshot(service, "tenant-a").reserved_bytes, 0);
+    EXPECT_FALSE(
+        service.GetTenantQuotaSnapshotForTesting("tenant-a").has_value());
 }
 
 }  // namespace mooncake::test

--- a/mooncake-store/tests/master_service_tenant_quota_test.cpp
+++ b/mooncake-store/tests/master_service_tenant_quota_test.cpp
@@ -204,22 +204,29 @@ TEST_F(MasterServiceTenantQuotaTest, SameTenantSharesQuotaAcrossKeys) {
     EXPECT_EQ(Snapshot(service, "tenant-a").reserved_bytes, 0);
 }
 
-TEST_F(MasterServiceTenantQuotaTest,
-       FirstTenantPutStartUsesInlineDefaultWithoutRecompute) {
+TEST_F(MasterServiceTenantQuotaTest, FirstTenantPutStartUsesPoolCapacity) {
     MasterService service(MakeConfig(/*default_quota=*/1000,
                                      /*pool_capacity=*/100));
     UUID client_id = MountSegment(service);
 
+    auto over_quota =
+        service.PutStart(client_id, "large", "tenant-a", 800, MemoryConfig());
+
+    ASSERT_FALSE(over_quota.has_value());
+    EXPECT_EQ(over_quota.error(), ErrorCode::TENANT_QUOTA_EXCEEDED);
+    EXPECT_FALSE(
+        service.GetTenantQuotaSnapshotForTesting("tenant-a").has_value());
+
     auto start =
-        service.PutStart(client_id, "key", "tenant-a", 800, MemoryConfig());
+        service.PutStart(client_id, "small", "tenant-a", 80, MemoryConfig());
 
     ASSERT_TRUE(start.has_value()) << toString(start.error());
     auto snapshot = Snapshot(service, "tenant-a");
     EXPECT_EQ(snapshot.requested_quota_bytes, 1000);
-    EXPECT_EQ(snapshot.effective_quota_bytes, 1000);
+    EXPECT_EQ(snapshot.effective_quota_bytes, 100);
     EXPECT_EQ(snapshot.used_bytes, 0);
-    EXPECT_EQ(snapshot.reserved_bytes, 800);
-    AbortQuota(service, "tenant-a", 800);
+    EXPECT_EQ(snapshot.reserved_bytes, 80);
+    AbortQuota(service, "tenant-a", 80);
 }
 
 TEST_F(MasterServiceTenantQuotaTest,


### PR DESCRIPTION
## Description

This PR adds Mooncake Store master-side tenant quota admission and accounting for memory-backed objects. This is part of the Dynamic Tenant Quota work tracked by RFC https://github.com/kvcache-ai/Mooncake/issues/2153.

Focused changes:

- Avoid full tenant quota recomputation on the `PutStart` hot path. New tenants are initialized inline under the target quota shard lock, and reserve uses a check-then-mutate flow.
- Keep tenant quota accounting mismatch paths non-mutating. Commit, abort, release, and partial release mismatches now log an error and return without changing quota state.
- Add tenant quota config flags, the `TENANT_QUOTA_EXCEEDED` error code, quota charge tracking on metadata, capacity-change recompute hooks, restore usage rebuild, and lifecycle release coverage for memory replica teardown paths.
- Add focused Store tests for tenant isolation, quota admission failures, inline default initialization, unlimited default quota, allocation rollback, and non-mutating accounting mismatch behavior.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Focused tenant quota tests, broader master service tests, and diff hygiene checks were run locally.

**Test commands:**
```bash
cmake --build build --target master_service_tenant_quota_test -j 4
ctest --test-dir build -R 'tenant_quota_test|master_service_tenant_quota_test' --output-on-failure
git diff --check
ctest --test-dir build -R '^master_service_test$' --output-on-failure
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex was used to help implement the tenant quota review fixes. I reviewed and edited the generated code before submission.