### PR TITLE
[Integration] Fix double-free in buffer_to_tensor error path

### DIFF
--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -237,6 +237,7 @@ pybind11::object buffer_to_tensor(BufferHandle *buffer_handle, char *usr_buffer,
         return pybind11::none();
     }
 
+    bool ownership_transferred = false;
     try {
         if (tensor_size == 0) {
             py::object dtype = tensor_dtype_to_torch_dtype(dtype_enum);
@@ -259,6 +260,7 @@ pybind11::object buffer_to_tensor(BufferHandle *buffer_handle, char *usr_buffer,
         bool take_ownership = !!buffer_handle;
         py::object np_array = array_creators[dtype_index](
             exported_data, data_offset, tensor_size, take_ownership);
+        ownership_transferred = take_ownership;
 
         // Reshape
         if (ndim > 0) {
@@ -282,7 +284,7 @@ pybind11::object buffer_to_tensor(BufferHandle *buffer_handle, char *usr_buffer,
 
     } catch (const std::exception &e) {
         LOG(ERROR) << "Failed to convert buffer to tensor: " << e.what();
-        if (take_ownership) {
+        if (take_ownership && !ownership_transferred) {
             delete[] exported_data;
         }
         return pybind11::none();

--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -237,30 +237,24 @@ pybind11::object buffer_to_tensor(BufferHandle *buffer_handle, char *usr_buffer,
         return pybind11::none();
     }
 
-    bool ownership_transferred = false;
+    std::unique_ptr<char[]> exported_data_guard(take_ownership ? exported_data
+                                                               : nullptr);
     try {
         if (tensor_size == 0) {
             py::object dtype = tensor_dtype_to_torch_dtype(dtype_enum);
             if (dtype.is_none()) {
-                if (take_ownership) {
-                    delete[] exported_data;
-                }
                 LOG(ERROR) << "Unsupported dtype enum: " << dtype_index;
                 return pybind11::none();
             }
             py::object tensor = torch_module().attr("empty")(
                 tensor_shape_tuple(metadata), py::arg("dtype") = dtype);
-            if (take_ownership) {
-                delete[] exported_data;
-            }
             return tensor;
         }
 
         // Construct numpy array
-        bool take_ownership = !!buffer_handle;
         py::object np_array = array_creators[dtype_index](
             exported_data, data_offset, tensor_size, take_ownership);
-        ownership_transferred = take_ownership;
+        exported_data_guard.release();
 
         // Reshape
         if (ndim > 0) {
@@ -284,9 +278,6 @@ pybind11::object buffer_to_tensor(BufferHandle *buffer_handle, char *usr_buffer,
 
     } catch (const std::exception &e) {
         LOG(ERROR) << "Failed to convert buffer to tensor: " << e.what();
-        if (take_ownership && !ownership_transferred) {
-            delete[] exported_data;
-        }
         return pybind11::none();
     }
 }


### PR DESCRIPTION
## Description

`buffer_to_tensor` (the `get_tensor` / `batch_get_tensor` path) has a heap **double-free** on its error path.

On the owning path (`buffer_handle != nullptr`) it allocates the buffer itself:

```cpp
exported_data = new char[total_length];        // function-owned
...
bool take_ownership = !!buffer_handle;          // true
py::object np_array = array_creators[dtype_index](
    exported_data, sizeof(TensorMetadata), tensor_size, take_ownership);  // (1)
```

`create_typed_array(take_ownership=true)` transfers ownership of `exported_data` to the numpy array's `py::capsule`, whose deleter is `delete[]` (`integration_utils.h:48-49`). If any **later** step in the same `try` throws a Python exception — `reshape()` with a shape that doesn't match the data length, `from_numpy()`, or `.view(float8_e4m3fn/e5m2)` on a torch build without float8 — then:

1. during stack unwinding, `np_array` is destroyed → the capsule runs `delete[] exported_data` (first free);
2. the `catch` block runs `delete[] exported_data` **again** (second free):

```cpp
} catch (const std::exception &e) {
    ...
    if (take_ownership) { delete[] exported_data; }   // double-free
}
```

→ heap double-free (crash / corruption). So any error while materializing the tensor turns a recoverable failure (which should just log + return `None`) into a **worker crash**.

**Fix:** track whether ownership has been handed to the capsule and only `delete[]` in the `catch` when it has *not* (i.e. the throw happened before/at array construction). The early-return paths before the `try` are unaffected.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [x] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

Reproduced with a standalone **AddressSanitizer** program that uses the real `pybind11` + `numpy` machinery — verbatim `create_typed_array` (capsule + `delete[]`), then a numpy `reshape` `ValueError` thrown **after** the ownership transfer (the exact bug shape):

| Build | Result |
| --- | --- |
| unfixed logic | `==ERROR: AddressSanitizer: attempting double-free ... in operator delete[]` (exit 1) |
| fixed logic | catches `ValueError: cannot reshape array of size 4 into shape (100,)`, **returns cleanly** (exit 0) |

A deterministic Python regression isn't included because triggering this specific path via the public API requires crafting tensor-metadata bytes that pass `ParseTensorMetadata` but carry an inconsistent shape (fragile); the CI build runs with `-DENABLE_ASAN=ON`, which guards the integration path going forward.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code with `./scripts/code_format.sh` (clang-format-20) before submitting.
- [ ] I have updated the documentation. _(n/a — internal bug fix)_
- [ ] I have added tests to prove my changes are effective. _(verified via the standalone ASAN reproduction above; a committed Python regression is impractical for this path — see note)_
