### PR TITLE
[TE] Add MC_TE_FILTERS env var for IB device whitelist

### DIFF
--- a/docs/source/design/transfer-engine/index.md
+++ b/docs/source/design/transfer-engine/index.md
@@ -310,6 +310,7 @@ For advanced users, TransferEngine provides the following advanced runtime optio
 - `MC_MIN_RPC_PORT` Specifies the minimum port number for RPC service. The default value is 15000.
 - `MC_MAX_RPC_PORT` Specifies the maximum port number for RPC service. The default value is 17000.
 - `MC_PATH_ROUNDROBIN` Use round-robin mode in the RDMA path selection. This may be beneficial for transferring large bulks.
+- `MC_TE_FILTERS` Optional comma-separated whitelist of IB device names (e.g. `mlx5_0,mlx5_2`) for legacy Transfer Engine topology discovery. When unset, all available devices are discovered.
 - `WITH_NVIDIA_PEERMEM` When set to `1`, `ON`, or `TRUE`, Mooncake uses `ibv_reg_mr()` directly for GPU memory registration (requires the `nvidia-peermem` kernel module). By default (unset or `0`), Mooncake uses the DMA-BUF path which does not require `nvidia-peermem`.
 - `MC_ENDPOINT_STORE_TYPE` Choose FIFO Endpoint Store (`FIFO`) or Sieve Endpoint Store (`SIEVE`), default is `SIEVE`.
 - `MC_TCP_ENABLE_CONNECTION_POOL` Enable TCP Connection Pool to avoid excessive sockets.

--- a/docs/source/python-api-reference/transfer-engine.md
+++ b/docs/source/python-api-reference/transfer-engine.md
@@ -635,6 +635,7 @@ The Transfer Engine respects the following environment variables:
 - `MC_TCP_BIND_ADDRESS`: Specifies the TCP bind address
 - `MC_RDMA_BIND_ADDRESS`: Specifies the RDMA bind address for NIC path construction in dual-NIC environments. When set, RDMA NIC paths use this address while TCP handshake uses the address from `local_hostname`. This is useful when TCP and RDMA traffic use separate network interfaces (e.g., `eth0` for TCP and `rdma-net1` for RDMA).
 - `MC_CUSTOM_TOPO_JSON`: Path to custom topology JSON file
+- `MC_TE_FILTERS`: Optional comma-separated whitelist of IB device names (e.g. `mlx5_0,mlx5_2`) for legacy Transfer Engine topology discovery. When unset, all available devices are discovered.
 - `MC_TE_METRIC`: Enables metrics reporting (set to "1", "true", "yes", or "on"). **Note:** Not supported when using Transfer Engine TENT.
 - `MC_TE_METRIC_INTERVAL_SECONDS`: Sets metrics reporting interval in seconds
 

--- a/docs/source/zh_archive/transfer-engine-python.md
+++ b/docs/source/zh_archive/transfer-engine-python.md
@@ -289,6 +289,7 @@ TransferOpcode.WRITE  # 写操作
 - `MC_TCP_BIND_ADDRESS`: 指定TCP绑定地址
 - `MC_RDMA_BIND_ADDRESS`: 指定RDMA绑定地址，用于双网卡环境下的NIC路径构建。设置后，RDMA NIC路径使用此地址，而TCP握手使用 `local_hostname` 中的地址。适用于TCP和RDMA流量使用不同网络接口的场景（例如 `eth0` 用于TCP，`rdma-net1` 用于RDMA）。
 - `MC_CUSTOM_TOPO_JSON`: 自定义拓扑JSON文件路径
+- `MC_TE_FILTERS`: 可选，逗号分隔的 IB 设备名白名单（如 `mlx5_0,mlx5_2`），用于 Legacy Transfer Engine 拓扑自动发现；未设置时不限制。
 - `MC_TE_METRIC`: 启用指标报告（设置为"1"、"true"、"yes"或"on"）
 - `MC_TE_METRIC_INTERVAL_SECONDS`: 设置指标报告间隔（秒）
 

--- a/docs/source/zh_archive/transfer-engine.md
+++ b/docs/source/zh_archive/transfer-engine.md
@@ -423,5 +423,6 @@ int init(const std::string &metadata_conn_string,
 - `MC_MIN_RPC_PORT` 指定 RPC 服务使用的最小端口号。默认值为 15000。
 - `MC_MAX_RPC_PORT` 指定 RPC 服务使用的最大端口号。默认值为 17000。
 - `MC_PATH_ROUNDROBIN` 指定 RDMA 路径选择使用 Round Robin 模式，这对于传输大块数据可能有利。
+- `MC_TE_FILTERS` 可选，逗号分隔的 IB 设备名白名单（如 `mlx5_0,mlx5_2`），用于 Legacy Transfer Engine 拓扑自动发现时限制可见 RDMA 网卡；未设置时不限制。
 - `WITH_NVIDIA_PEERMEM` 设置为 `1`、`ON` 或 `TRUE` 时，Mooncake 使用 `ibv_reg_mr()` 直接注册 GPU 内存（需要 `nvidia-peermem` 内核模块）。默认情况下（未设置或为 `0`），Mooncake 使用不需要 `nvidia-peermem` 的 DMA-BUF 路径。
 - `MC_ENDPOINT_STORE_TYPE` 选择 FIFO Endpoint Store (`FIFO`) 或者 Sieve Endpoint Store (`SIEVE`)，模式是 `SIEVE`。

--- a/mooncake-transfer-engine/src/topology.cpp
+++ b/mooncake-transfer-engine/src/topology.cpp
@@ -14,6 +14,7 @@
 
 #include <glog/logging.h>
 
+#include <algorithm>
 #include <fstream>
 #include <iostream>
 #include <map>
@@ -142,10 +143,55 @@ struct InfinibandDevice {
     int numa_node;
 };
 
+static inline void ltrim(std::string &s) {
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](unsigned char ch) {
+                return !std::isspace(ch);
+            }));
+}
+
+static inline void rtrim(std::string &s) {
+    s.erase(std::find_if(s.rbegin(), s.rend(),
+                         [](unsigned char ch) { return !std::isspace(ch); })
+                .base(),
+            s.end());
+}
+
+static std::set<std::string> getIbvDeviceWhitelist() {
+    std::set<std::string> whitelist;
+    const char *env = std::getenv("MC_TE_FILTERS");
+    if (!env || !*env) {
+        return whitelist;
+    }
+
+    LOG(INFO) << "IB device whitelist: " << env;
+    std::string env_str(env);
+    size_t start = 0;
+    size_t pos = 0;
+    while ((pos = env_str.find(',', start)) != std::string::npos) {
+        std::string token = env_str.substr(start, pos - start);
+        ltrim(token);
+        rtrim(token);
+        if (!token.empty()) {
+            whitelist.insert(std::move(token));
+        }
+        start = pos + 1;
+    }
+    if (start < env_str.length()) {
+        std::string token = env_str.substr(start);
+        ltrim(token);
+        rtrim(token);
+        if (!token.empty()) {
+            whitelist.insert(std::move(token));
+        }
+    }
+    return whitelist;
+}
+
 static std::vector<InfinibandDevice> listInfiniBandDevices(
     const std::vector<std::string> &filter) {
     int num_devices = 0;
     std::vector<InfinibandDevice> devices;
+    const auto whitelist = getIbvDeviceWhitelist();
 
     struct ibv_device **device_list = ibv_get_device_list(&num_devices);
     if (!device_list) {
@@ -163,6 +209,12 @@ static std::vector<InfinibandDevice> listInfiniBandDevices(
         if (!filter.empty() && std::find(filter.begin(), filter.end(),
                                          device_name) == filter.end())
             continue;
+
+        if (!whitelist.empty() &&
+            whitelist.find(device_name) == whitelist.end()) {
+            LOG(INFO) << "Skipping device: " << device_name;
+            continue;
+        }
 
         // Check device availability before adding to the list
         if (!isIbDeviceAvailable(device_list[i])) {

--- a/mooncake-transfer-engine/tests/topology_test.cpp
+++ b/mooncake-transfer-engine/tests/topology_test.cpp
@@ -2,6 +2,7 @@
 
 #include <glog/logging.h>
 #include <gtest/gtest.h>
+#include <cstdlib>
 
 #include "transfer_metadata.h"
 #include "memory_location.h"
@@ -14,6 +15,13 @@ TEST(ToplogyTest, GetTopologyMatrix) {
     topology.clear();
     topology.parse(json_str);
     ASSERT_EQ(topology.toString(), json_str);
+}
+
+TEST(ToplogyTest, DiscoverWithMcTeFilters) {
+    ASSERT_EQ(::setenv("MC_TE_FILTERS", "erdma_0", 1), 0);
+    mooncake::Topology topology;
+    EXPECT_EQ(topology.discover(), 0);
+    ::unsetenv("MC_TE_FILTERS");
 }
 
 TEST(ToplogyTest, TestEmpty) {


### PR DESCRIPTION
## Description

Add the MC_TE_FILTERS environment variable to restrict InfiniBand device discovery during Transfer Engine topology construction.
When MC_TE_FILTERS is set, listInfiniBandDevices() only considers devices whose ibv device names appear in the comma-separated whitelist. All other devices are skipped and logged at INFO level. When the variable is unset or empty, behavior is unchanged and all accessible IB devices are discovered as before.
This is useful on multi-NIC hosts where only a subset of HCAs should participate in topology construction (e.g. mlx5_0, mlx5_1), without manually specifying the full topology.

Example: export MC_TE_FILTERS=mlx5_0,mlx5_1

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Tests**

Mooncake Transfer Engine Benchmark — verified that topology discovery respects MC_TE_FILTERS and that RDMA transfer completes successfully with only whitelisted devices.
vLLM with Mooncake Transfer Engine Benchmark — verified end-to-end KV transfer in a vLLM + Mooncake integration scenario with the device filter applied.
Mooncake Store Benchmark — verified that Store workloads function correctly when Transfer Engine uses a filtered IB device set.
Mooncake SSD Offload Benchmark — verified that SSD offload paths remain stable with MC_TE_FILTERS enabled.

**Test results:**
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing done

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [x] No AI tools were used
- [ ] AI tools were used (specify below)