### PR TITLE
[Doc]: publish built-in skills and add plugin marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
+  "name": "mooncake",
+  "owner": {
+    "name": "Mooncake Team"
+  },
+  "metadata": {
+    "description": "Built-in Claude Code skills for working with Mooncake: deployment troubleshooting, local CI validation, and the Python API."
+  },
+  "plugins": [
+    {
+      "name": "mooncake-troubleshoot",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/kvcache-ai/Mooncake.git",
+        "path": ".claude/skills/mooncake-troubleshoot"
+      },
+      "description": "Systematically diagnose Mooncake deployment and runtime issues (services, RDMA, env vars, connectivity, logs) and propose fixes.",
+      "homepage": "https://kvcache-ai.github.io/Mooncake/skills/mooncake-troubleshoot.html"
+    },
+    {
+      "name": "mooncake-ci-local",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/kvcache-ai/Mooncake.git",
+        "path": ".claude/skills/mooncake-ci-local"
+      },
+      "description": "Run Mooncake pre-PR local validation via scripts/run_ci_test.sh, reproducing the reproducible parts of GitHub Actions.",
+      "homepage": "https://kvcache-ai.github.io/Mooncake/skills/mooncake-ci-local.html"
+    },
+    {
+      "name": "mooncake-api",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/kvcache-ai/Mooncake.git",
+        "path": ".claude/skills/mooncake-api"
+      },
+      "description": "Work with the Mooncake Store, Transfer Engine, and EP/Backend Python APIs.",
+      "homepage": "https://kvcache-ai.github.io/Mooncake/skills/mooncake-api.html"
+    }
+  ]
+}

--- a/.claude/skills/mooncake-api/.claude-plugin/plugin.json
+++ b/.claude/skills/mooncake-api/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "mooncake-api",
+  "description": "Work with the Mooncake Store, Transfer Engine, and EP/Backend Python APIs.",
+  "author": {
+    "name": "Mooncake Team"
+  },
+  "homepage": "https://kvcache-ai.github.io/Mooncake/skills/mooncake-api.html",
+  "repository": "https://github.com/kvcache-ai/Mooncake",
+  "license": "Apache-2.0",
+  "keywords": ["mooncake", "python", "api", "transfer-engine", "store"]
+}

--- a/.claude/skills/mooncake-api/SKILL.md
+++ b/.claude/skills/mooncake-api/SKILL.md
@@ -1,4 +1,7 @@
-<!-- Let's perfect this skill together. -->
+---
+name: mooncake-api
+description: Help users work with the Mooncake Python APIs for distributed storage and high-performance data transfer. Use when working with Mooncake Store (distributed KV cache), Transfer Engine (RDMA/TCP transfers), service setup (master, metadata server), PyTorch tensors in the Store, zero-copy/buffer management, batch operations and replication, or Mooncake EP / Backend (Expert Parallelism). Trigger on questions about MooncakeDistributedStore, TransferEngine, put/get, put_tensor, register_buffer, ReplicateConfig, or the mooncake.store / mooncake.engine / mooncake.pg Python modules.
+---
 
 # Mooncake Python API Skill
 

--- a/.claude/skills/mooncake-ci-local/.claude-plugin/plugin.json
+++ b/.claude/skills/mooncake-ci-local/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "mooncake-ci-local",
+  "description": "Run Mooncake pre-PR local validation via scripts/run_ci_test.sh, reproducing the reproducible parts of GitHub Actions.",
+  "author": {
+    "name": "Mooncake Team"
+  },
+  "homepage": "https://kvcache-ai.github.io/Mooncake/skills/mooncake-ci-local.html",
+  "repository": "https://github.com/kvcache-ai/Mooncake",
+  "license": "Apache-2.0",
+  "keywords": ["mooncake", "ci", "validation", "pre-pr"]
+}

--- a/.claude/skills/mooncake-troubleshoot/.claude-plugin/plugin.json
+++ b/.claude/skills/mooncake-troubleshoot/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "mooncake-troubleshoot",
+  "description": "Systematically diagnose Mooncake deployment and runtime issues (services, RDMA, env vars, connectivity, logs) and propose fixes.",
+  "author": {
+    "name": "Mooncake Team"
+  },
+  "homepage": "https://kvcache-ai.github.io/Mooncake/skills/mooncake-troubleshoot.html",
+  "repository": "https://github.com/kvcache-ai/Mooncake",
+  "license": "Apache-2.0",
+  "keywords": ["mooncake", "troubleshooting", "rdma", "deployment"]
+}

--- a/README.md
+++ b/README.md
@@ -278,6 +278,27 @@ sudo make install # optional, make it ready to be used by vLLM/SGLang
 
 For custom accelerator backends, Docker deployment, NVMe-oF, EFA, CXL, Redis / HTTP metadata, Rust bindings, or other advanced build options, see the [Build Guide](https://kvcache-ai.github.io/Mooncake/getting_started/build.html).
 
+### Skills for AI coding assistants
+
+Mooncake ships a set of **built-in skills** under [`.claude/skills`](.claude/skills) — reusable, task-focused playbooks that an AI coding assistant (such as Claude Code) invokes automatically when your request matches, or that you can run as a slash command:
+
+| Skill | Description |
+|-------|-------------|
+| `/mooncake-troubleshoot` | Diagnose Mooncake deployment and runtime issues (services, RDMA, env vars, logs). |
+| `/mooncake-ci-local` | Run pre-PR local validation via `scripts/run_ci_test.sh`. |
+| `/mooncake-api` | Work with the Mooncake Store, Transfer Engine, and EP/Backend Python APIs. |
+
+Install them without cloning the repository via the [Claude Code plugin marketplace](https://code.claude.com/docs/en/plugin-marketplaces):
+
+```text
+/plugin marketplace add kvcache-ai/Mooncake --sparse .claude-plugin
+/plugin install mooncake-troubleshoot@mooncake
+/plugin install mooncake-ci-local@mooncake
+/plugin install mooncake-api@mooncake
+```
+
+The `--sparse .claude-plugin` flag fetches only the marketplace catalog, and each plugin is published as a `git-subdir` source, so installing one fetches only that single skill directory — never the whole repo. If you are already working inside a Mooncake checkout, the skills under `.claude/skills/` load automatically with no setup.
+
 <h2 id="trace">📦 Open Source Trace</h2>
 
 ```json

--- a/docs/source/getting_started/quick-start.md
+++ b/docs/source/getting_started/quick-start.md
@@ -247,3 +247,24 @@ store.close()
 ### More Examples and Documentation
 
 Please refer to the [Mooncake Store Python API](../python-api-reference/mooncake-store.md), [Mooncake Store](../design/mooncake-store.md) and [Mooncake Store Deployment & Tuning Guide](../deployment/mooncake-store-deployment-guide.md) for more examples and documentation.
+
+## Skills for AI Coding Assistants
+
+Mooncake ships a set of **built-in skills** under [`.claude/skills`](https://github.com/kvcache-ai/Mooncake/tree/main/.claude/skills) — reusable, task-focused playbooks that an AI coding assistant (such as Claude Code) invokes automatically when your request matches, or that you can run as a slash command:
+
+| Skill | Description |
+|-------|-------------|
+| `/mooncake-troubleshoot` | Diagnose Mooncake deployment and runtime issues (services, RDMA, env vars, logs). |
+| `/mooncake-ci-local` | Run pre-PR local validation via `scripts/run_ci_test.sh`. |
+| `/mooncake-api` | Work with the Mooncake Store, Transfer Engine, and EP/Backend Python APIs. |
+
+Install them without cloning the repository via the [Claude Code plugin marketplace](https://code.claude.com/docs/en/plugin-marketplaces):
+
+```text
+/plugin marketplace add kvcache-ai/Mooncake --sparse .claude-plugin
+/plugin install mooncake-troubleshoot@mooncake
+/plugin install mooncake-ci-local@mooncake
+/plugin install mooncake-api@mooncake
+```
+
+The `--sparse .claude-plugin` flag fetches only the marketplace catalog, and each plugin is published as a `git-subdir` source, so installing one fetches only that single skill directory — never the whole repo. If you are already working inside a Mooncake checkout, the skills under `.claude/skills/` load automatically with no setup.


### PR DESCRIPTION
## Description

Mooncake ships built-in Claude Code skills under `.claude/skills/`, but they were neither documented on the generated docs site nor installable without cloning the whole repository. This PR makes them discoverable and easy to install:

- **Docs site**: adds a new "Skills" section to the documentation with an overview page and one page per skill (Troubleshoot, Local CI, Python API), cross-linked to existing troubleshooting and Python API reference pages.
- **Slash commands**: adds YAML frontmatter (`name` / `description`) to `mooncake-api`'s `SKILL.md` so it registers as a `/mooncake-api` slash command and auto-triggers on matching requests (the other two skills already had valid frontmatter).
- **Plugin marketplace**: adds `.claude-plugin/marketplace.json` plus a per-skill `.claude-plugin/plugin.json` so users can install any skill via `/plugin marketplace add kvcache-ai/Mooncake --sparse .claude-plugin` followed by `/plugin install <skill>@mooncake`. Sources use `git-subdir`, so installing a skill fetches only that single directory via a sparse partial clone — users never clone the full repository.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other

## How Has This Been Tested?

- Ran `claude plugin validate` against the marketplace and each per-skill plugin manifest (non-strict validation, which governs install, passes).
- Built the Sphinx docs locally with `make html` and confirmed the new Skills section, overview page, and per-skill pages render and that all cross-references resolve.
- Verified `mooncake-api` registers as a `/mooncake-api` slash command after adding the frontmatter.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [ ] I have added tests to prove my changes are effective.

---

*AI assistance disclosure: this change was prepared with the help of Claude Code.*