### PR TITLE
[Store] Clean up HTTP metadata on client timeout for separately-deployed metadata servers (follow-up to #1363)

### DIFF
--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -380,6 +380,56 @@ glog's standard flags (`--log_dir`, `--max_log_size`, `--logtostderr`, ...) cont
 | `--enable_http_metadata_server` | `false` | Enable embedded HTTP metadata server |
 | `--http_metadata_server_host` | `0.0.0.0` | Metadata bind host |
 | `--http_metadata_server_port` | `8080` | Metadata TCP port |
+| `--enable_metadata_cleanup_on_timeout` | `false` | Delete a client's stale HTTP metadata (`mooncake/[<cluster>/]ram/<segment>` and `mooncake/[<cluster>/]rpc_meta/<segment>`) when its heartbeat times out (see below) |
+
+### Stale Metadata Cleanup on Client Timeout
+
+When a client crashes or is force-killed (`kill -9`, OOM, node failure), it cannot
+run its normal cleanup, leaving stale entries on the HTTP metadata server
+(`mooncake/[<cluster>/]ram/<segment>` and `mooncake/[<cluster>/]rpc_meta/<segment>`).
+The HTTP metadata server has no heartbeat of its own, so these entries linger and
+can mislead nodes that later connect or restart with different RDMA parameters.
+
+With `--enable_metadata_cleanup_on_timeout=true`, the Master Service reuses its
+existing client-heartbeat monitor: when a client's `--client_ttl` expires, in
+addition to unmounting the segment it also removes that client's `ram/` and
+`rpc_meta/` keys from the HTTP metadata server. It supports both deployment
+topologies:
+
+- **Co-located** (`--enable_http_metadata_server=true`): the master removes the
+  keys via a direct in-process call (no network overhead).
+- **Separately deployed** HTTP metadata server: the master derives the metadata
+  server address from the cluster's existing configuration and removes the keys
+  via HTTP `DELETE`. The address is read, in priority order, from:
+  1. the `MOONCAKE_TE_META_DATA_SERVER` environment variable (the same Transfer
+     Engine metadata connection string the clients use, e.g.
+     `http://host:8080/metadata`), then
+  2. the `metadata_server` field of the JSON file pointed to by
+     `MOONCAKE_CONFIG_PATH`.
+
+Notes:
+- Only `http(s)` metadata servers are supported; `etcd`/`redis`/`P2PHANDSHAKE`
+  backends are not cleaned up (a warning is logged and cleanup stays disabled).
+- The feature is opt-in and best-effort: if no co-located server is enabled and
+  no HTTP metadata address can be derived, the master logs a warning and
+  disables cleanup. Remote `DELETE` failures are logged but never block the
+  client-monitor thread or the main process.
+- Respects `MC_METADATA_CLUSTER_ID` for custom key prefixes (matching the
+  Transfer Engine).
+
+```bash
+# Co-located metadata server
+mooncake_master \
+  --enable_http_metadata_server=true \
+  --enable_metadata_cleanup_on_timeout=true \
+  --client_ttl=10
+
+# Separately-deployed HTTP metadata server (address derived from the env var)
+export MOONCAKE_TE_META_DATA_SERVER=http://metadata-host:8080/metadata
+mooncake_master \
+  --enable_metadata_cleanup_on_timeout=true \
+  --client_ttl=10
+```
 
 ### Memory Allocator
 

--- a/mooncake-store/include/http_metadata_server.h
+++ b/mooncake-store/include/http_metadata_server.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <unordered_map>
 #include <mutex>
+#include <vector>
 
 #include <ylt/coro_http/coro_http_server.hpp>
 
@@ -34,6 +35,14 @@ class HttpMetadataServer {
 
     // Check if the server is running
     bool is_running() const { return running_; }
+
+    // Remove a key from the metadata store (for internal use by MasterService)
+    // Returns true if key was found and removed, false if key did not exist
+    bool removeKey(const std::string& key);
+
+    // Remove multiple keys from the metadata store
+    // Returns the number of keys that were successfully removed
+    size_t removeKeys(const std::vector<std::string>& keys);
 
     // Non-copyable
     HttpMetadataServer(const HttpMetadataServer&) = delete;

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -11,8 +11,7 @@
 
 namespace mooncake {
 
-// Forward declaration for the optional co-located HTTP metadata server pointer
-// carried through to the HA serve phase (see MasterServiceSupervisorConfig).
+// Forwarded to the HA serve phase via MasterServiceSupervisorConfig.
 class HttpMetadataServer;
 
 inline std::string ResolveConfiguredHABackendConnstring(
@@ -213,15 +212,9 @@ class MasterServiceSupervisorConfig {
     std::string pod_name;
     std::string pod_namespace;
 
-    // Metadata cleanup on client timeout. Not derived from MasterConfig: the
-    // co-located server pointer and the derived remote URL are resolved in
-    // main() and set explicitly before the supervisor starts. The serving
-    // primary forwards them to WrappedMasterService so cleanup works in HA the
-    // same way it does in the non-HA path.
-    // - http_metadata_server: in-process server when co-located
-    //   (enable_http_metadata_server=true); nullptr otherwise.
-    // - http_metadata_remote_url: http(s) endpoint when the metadata server is
-    //   deployed separately; empty otherwise.
+    // Metadata cleanup on client timeout. Resolved in main() (not from
+    // MasterConfig) and forwarded to the serving primary's WrappedMasterService.
+    // Co-located: in-process server pointer; separate: derived http(s) URL.
     HttpMetadataServer* http_metadata_server = nullptr;
     std::string http_metadata_remote_url;
 

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -62,6 +62,10 @@ struct MasterConfig {
     bool enable_http_metadata_server;
     uint32_t http_metadata_server_port;
     std::string http_metadata_server_host;
+    // Enable cleanup of HTTP metadata (mooncake/ram/*, mooncake/rpc_meta/*)
+    // when client heartbeat times out. Only effective when
+    // enable_http_metadata_server is true.
+    bool enable_metadata_cleanup_on_timeout;
 
     // Pod identity for K8s label-based routing
     std::string pod_name;

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -11,6 +11,10 @@
 
 namespace mooncake {
 
+// Forward declaration for the optional co-located HTTP metadata server pointer
+// carried through to the HA serve phase (see MasterServiceSupervisorConfig).
+class HttpMetadataServer;
+
 inline std::string ResolveConfiguredHABackendConnstring(
     std::string_view ha_backend_type, std::string_view ha_backend_connstring,
     std::string_view etcd_endpoints) {
@@ -208,6 +212,18 @@ class MasterServiceSupervisorConfig {
     // Pod identity for K8s label-based routing
     std::string pod_name;
     std::string pod_namespace;
+
+    // Metadata cleanup on client timeout. Not derived from MasterConfig: the
+    // co-located server pointer and the derived remote URL are resolved in
+    // main() and set explicitly before the supervisor starts. The serving
+    // primary forwards them to WrappedMasterService so cleanup works in HA the
+    // same way it does in the non-HA path.
+    // - http_metadata_server: in-process server when co-located
+    //   (enable_http_metadata_server=true); nullptr otherwise.
+    // - http_metadata_remote_url: http(s) endpoint when the metadata server is
+    //   deployed separately; empty otherwise.
+    HttpMetadataServer* http_metadata_server = nullptr;
+    std::string http_metadata_remote_url;
 
     MasterServiceSupervisorConfig() = default;
 

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -63,8 +63,9 @@ struct MasterConfig {
     uint32_t http_metadata_server_port;
     std::string http_metadata_server_host;
     // Enable cleanup of HTTP metadata (mooncake/ram/*, mooncake/rpc_meta/*)
-    // when client heartbeat times out. Only effective when
-    // enable_http_metadata_server is true.
+    // when client heartbeat times out. Works in two modes: (1) co-located
+    // (enable_http_metadata_server=true) via in-process removal, or
+    // (2) separately-deployed metadata server via async HTTP DELETE.
     bool enable_metadata_cleanup_on_timeout;
 
     // Pod identity for K8s label-based routing

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -213,8 +213,9 @@ class MasterServiceSupervisorConfig {
     std::string pod_namespace;
 
     // Metadata cleanup on client timeout. Resolved in main() (not from
-    // MasterConfig) and forwarded to the serving primary's WrappedMasterService.
-    // Co-located: in-process server pointer; separate: derived http(s) URL.
+    // MasterConfig) and forwarded to the serving primary's
+    // WrappedMasterService. Co-located: in-process server pointer; separate:
+    // derived http(s) URL.
     HttpMetadataServer* http_metadata_server = nullptr;
     std::string http_metadata_remote_url;
 

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1896,19 +1896,15 @@ class MasterService {
     // nullptr means cleanup is disabled
     HttpMetadataServer* http_metadata_server_{nullptr};
 
-    // Remote HTTP metadata storage client, used when the metadata server is
-    // deployed separately from the master (not co-located). nullptr means no
-    // remote cleanup. Mutually exclusive with http_metadata_server_ in
-    // practice (co-located prefers the in-process pointer).
+    // Remote HTTP metadata client, used when the metadata server is deployed
+    // separately. nullptr = no remote cleanup (co-located prefers the pointer).
     std::shared_ptr<MetadataStoragePlugin> http_metadata_remote_;
 
     // Cached HTTP metadata key prefix (initialized once at startup)
     std::string http_metadata_prefix_;
 
-    // Async cleanup worker for remote HTTP metadata removal.
-    // Segments are enqueued from the client monitor thread and processed
-    // asynchronously so that slow/unreachable metadata servers never block
-    // heartbeat processing or segment operations.
+    // Async worker for remote cleanup: segments are enqueued from the client
+    // monitor thread so a slow/unreachable server never blocks heartbeats.
     std::thread http_metadata_cleanup_thread_;
     std::atomic<bool> http_metadata_cleanup_running_{false};
     std::mutex http_metadata_cleanup_mutex_;

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -47,6 +47,7 @@ class EtcdOpLogStore;
 class AllocationStrategy;
 class EvictionStrategy;
 class HttpMetadataServer;
+struct MetadataStoragePlugin;
 
 // Forward declarations for test classes
 namespace test {
@@ -750,6 +751,17 @@ class MasterService {
      * disabled.
      */
     void setHttpMetadataServer(HttpMetadataServer* server);
+
+    /**
+     * @brief Configure cleanup against a separately-deployed HTTP metadata
+     * server (not co-located in the master process). The master sends HTTP
+     * DELETE requests to this endpoint when a client times out. Only http://
+     * and https:// connection strings are supported; other schemes (etcd /
+     * redis / P2PHANDSHAKE) are ignored with a warning and leave cleanup
+     * disabled.
+     * @param metadata_connstring e.g. "http://host:8080/metadata".
+     */
+    void setHttpMetadataRemoteUrl(const std::string& metadata_connstring);
 
    private:
     void SnapshotThreadFunc();
@@ -1883,6 +1895,12 @@ class MasterService {
     // HTTP metadata server pointer for cleanup on client timeout
     // nullptr means cleanup is disabled
     HttpMetadataServer* http_metadata_server_{nullptr};
+
+    // Remote HTTP metadata storage client, used when the metadata server is
+    // deployed separately from the master (not co-located). nullptr means no
+    // remote cleanup. Mutually exclusive with http_metadata_server_ in
+    // practice (co-located prefers the in-process pointer).
+    std::shared_ptr<MetadataStoragePlugin> http_metadata_remote_;
 
     // Cached HTTP metadata key prefix (initialized once at startup)
     std::string http_metadata_prefix_;

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -46,6 +46,7 @@ class EtcdOpLogStore;
 // Forward declarations
 class AllocationStrategy;
 class EvictionStrategy;
+class HttpMetadataServer;
 
 // Forward declarations for test classes
 namespace test {
@@ -742,6 +743,13 @@ class MasterService {
      */
     tl::expected<void, ErrorCode> MarkTaskToComplete(
         const UUID& client_id, const TaskCompleteRequest& request);
+
+    /**
+     * @brief Set the HttpMetadataServer pointer for cleanup on client timeout.
+     * @param server Pointer to HttpMetadataServer. If nullptr, cleanup is
+     * disabled.
+     */
+    void setHttpMetadataServer(HttpMetadataServer* server);
 
    private:
     void SnapshotThreadFunc();
@@ -1871,6 +1879,17 @@ class MasterService {
     std::atomic<uint64_t> default_tenant_quota_bytes_;
     const uint64_t tenant_quota_pool_capacity_bytes_;
     mutable std::mutex tenant_quota_recompute_mutex_;
+
+    // HTTP metadata server pointer for cleanup on client timeout
+    // nullptr means cleanup is disabled
+    HttpMetadataServer* http_metadata_server_{nullptr};
+
+    // Cached HTTP metadata key prefix (initialized once at startup)
+    std::string http_metadata_prefix_;
+
+    // Clean up HTTP metadata (mooncake/ram/*, mooncake/rpc_meta/*) for a
+    // segment
+    void cleanupHttpMetadata(const std::string& segment_name);
 
     bool use_disk_replica_{false};
 

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1905,8 +1905,21 @@ class MasterService {
     // Cached HTTP metadata key prefix (initialized once at startup)
     std::string http_metadata_prefix_;
 
+    // Async cleanup worker for remote HTTP metadata removal.
+    // Segments are enqueued from the client monitor thread and processed
+    // asynchronously so that slow/unreachable metadata servers never block
+    // heartbeat processing or segment operations.
+    std::thread http_metadata_cleanup_thread_;
+    std::atomic<bool> http_metadata_cleanup_running_{false};
+    std::mutex http_metadata_cleanup_mutex_;
+    std::condition_variable http_metadata_cleanup_cv_;
+    std::vector<std::string> http_metadata_cleanup_queue_;
+
+    void HttpMetadataCleanupThreadFunc();
+
     // Clean up HTTP metadata (mooncake/ram/*, mooncake/rpc_meta/*) for a
-    // segment
+    // segment. For the co-located case this is synchronous (no network I/O);
+    // for the remote case it enqueues to the async cleanup worker.
     void cleanupHttpMetadata(const std::string& segment_name);
 
     bool use_disk_replica_{false};

--- a/mooncake-store/include/rpc_service.h
+++ b/mooncake-store/include/rpc_service.h
@@ -16,9 +16,14 @@
 
 namespace mooncake {
 
+// Forward declaration
+class HttpMetadataServer;
 class WrappedMasterService {
    public:
-    WrappedMasterService(const WrappedMasterServiceConfig& config);
+    // Constructor with optional HttpMetadataServer pointer for cleanup on
+    // timeout If http_metadata_server is nullptr, cleanup is disabled
+    WrappedMasterService(const WrappedMasterServiceConfig& config,
+                         HttpMetadataServer* http_metadata_server = nullptr);
 
     ~WrappedMasterService();
 

--- a/mooncake-store/include/rpc_service.h
+++ b/mooncake-store/include/rpc_service.h
@@ -20,10 +20,16 @@ namespace mooncake {
 class HttpMetadataServer;
 class WrappedMasterService {
    public:
-    // Constructor with optional HttpMetadataServer pointer for cleanup on
-    // timeout If http_metadata_server is nullptr, cleanup is disabled
+    // Constructor with optional metadata-cleanup-on-timeout configuration.
+    // - http_metadata_server: in-process pointer used when the HTTP metadata
+    //   server is co-located in the master process (nullptr = not co-located).
+    // - http_metadata_remote_url: http(s) connection string used when the
+    //   metadata server is deployed separately (empty = none). Only consulted
+    //   when http_metadata_server is nullptr. If both are unset, cleanup is
+    //   disabled.
     WrappedMasterService(const WrappedMasterServiceConfig& config,
-                         HttpMetadataServer* http_metadata_server = nullptr);
+                         HttpMetadataServer* http_metadata_server = nullptr,
+                         const std::string& http_metadata_remote_url = "");
 
     ~WrappedMasterService();
 

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -297,6 +297,7 @@ target_link_libraries(
           pthread
           ibverbs
           mooncake_common
+          JsonCpp::JsonCpp
           ${ETCD_WRAPPER_LIB}
           ${MASTER_EXTRA_LIBS}
           asio_shared)

--- a/mooncake-store/src/ha/leadership/master_service_supervisor.cpp
+++ b/mooncake-store/src/ha/leadership/master_service_supervisor.cpp
@@ -379,9 +379,13 @@ int RunSupervisorLoop(const HABackendSpec& spec,
             server.init_ibv();
         }
 
+        // Only the serving primary creates a WrappedMasterService, and it is
+        // the node handling heartbeats/unmounts, so forward the metadata
+        // cleanup configuration here just like the non-HA path does.
         auto wrapped_master_service = std::make_shared<WrappedMasterService>(
             mooncake::WrappedMasterServiceConfig(
-                config, leadership_session->view.view_version));
+                config, leadership_session->view.view_version),
+            config.http_metadata_server, config.http_metadata_remote_url);
         mooncake::RegisterRpcService(server, *wrapped_master_service);
 
         auto serve_preflight =

--- a/mooncake-store/src/ha/leadership/master_service_supervisor.cpp
+++ b/mooncake-store/src/ha/leadership/master_service_supervisor.cpp
@@ -379,9 +379,8 @@ int RunSupervisorLoop(const HABackendSpec& spec,
             server.init_ibv();
         }
 
-        // Only the serving primary creates a WrappedMasterService, and it is
-        // the node handling heartbeats/unmounts, so forward the metadata
-        // cleanup configuration here just like the non-HA path does.
+        // The serving primary handles heartbeats/unmounts, so forward the
+        // metadata cleanup config here like the non-HA path does.
         auto wrapped_master_service = std::make_shared<WrappedMasterService>(
             mooncake::WrappedMasterServiceConfig(
                 config, leadership_session->view.view_version),

--- a/mooncake-store/src/http_metadata_server.cpp
+++ b/mooncake-store/src/http_metadata_server.cpp
@@ -135,4 +135,25 @@ KVPoll HttpMetadataServer::poll() const {
     return KVPoll::Success;
 }
 
+bool HttpMetadataServer::removeKey(const std::string& key) {
+    std::lock_guard<std::mutex> lock(store_mutex_);
+    if (store_.erase(key) > 0) {
+        LOG(INFO) << "HttpMetadataServer: removed key=" << key;
+        return true;
+    }
+    return false;
+}
+
+size_t HttpMetadataServer::removeKeys(const std::vector<std::string>& keys) {
+    std::lock_guard<std::mutex> lock(store_mutex_);
+    size_t removed = 0;
+    for (const auto& key : keys) {
+        if (store_.erase(key) > 0) {
+            LOG(INFO) << "HttpMetadataServer: removed key=" << key;
+            ++removed;
+        }
+    }
+    return removed;
+}
+
 }  // namespace mooncake

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -92,13 +92,18 @@ std::string ResolveMetadataServerForCleanup() {
                     Json::Value root;
                     std::string errs;
                     if (Json::parseFromStream(builder, fin, &root, &errs) &&
-                        root.isMember("metadata_server")) {
+                        root.isMember("metadata_server") &&
+                        root["metadata_server"].isString()) {
                         return root["metadata_server"].asString();
                     }
                     if (!errs.empty()) {
                         LOG(WARNING) << "Failed to parse MOONCAKE_CONFIG_PATH ("
                                      << cfg << "): " << errs;
                     }
+                } else {
+                    LOG(WARNING)
+                        << "Cannot open MOONCAKE_CONFIG_PATH (" << cfg
+                        << "): file does not exist or is not readable";
                 }
             } catch (const std::exception& e) {
                 LOG(WARNING) << "Error reading MOONCAKE_CONFIG_PATH (" << cfg
@@ -241,8 +246,9 @@ DEFINE_string(http_metadata_server_host, "0.0.0.0",
 DEFINE_bool(
     enable_metadata_cleanup_on_timeout, false,
     "Enable cleanup of HTTP metadata (mooncake/ram/*, mooncake/rpc_meta/*) "
-    "when client heartbeat times out. Only effective when "
-    "enable_http_metadata_server is true.");
+    "when client heartbeat times out. Works in two modes: (1) co-located "
+    "(enable_http_metadata_server=true) via in-process removal, or "
+    "(2) separately-deployed metadata server via async HTTP DELETE.");
 
 DEFINE_string(pod_name, "",
               "Pod name for K8s label-based routing (default: $POD_NAME)");

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -1279,9 +1279,21 @@ int main(int argc, char* argv[]) {
         std::this_thread::sleep_for(std::chrono::seconds(1));
     }
 
+    // Wire metadata cleanup on client timeout into the serving primary. The
+    // stale-metadata problem is identical in HA mode (the primary still handles
+    // heartbeats and unmounts), so prefer the co-located in-process server,
+    // otherwise use the separately-deployed HTTP endpoint derived above.
+    mooncake::HttpMetadataServer* metadata_server_ptr = nullptr;
+    if (master_config.enable_metadata_cleanup_on_timeout &&
+        master_config.enable_http_metadata_server) {
+        metadata_server_ptr = http_metadata_server.get();
+    }
+
     if (master_config.enable_ha) {
-        mooncake::ha::MasterServiceSupervisor supervisor(
-            mooncake::MasterServiceSupervisorConfig{master_config});
+        mooncake::MasterServiceSupervisorConfig supervisor_config{master_config};
+        supervisor_config.http_metadata_server = metadata_server_ptr;
+        supervisor_config.http_metadata_remote_url = http_metadata_remote_url;
+        mooncake::ha::MasterServiceSupervisor supervisor(supervisor_config);
         return supervisor.Start();
     } else {
         // version is not used in non-HA mode, just pass a dummy value
@@ -1295,15 +1307,6 @@ int main(int argc, char* argv[]) {
         if (value && std::string_view(value) == "rdma") {
             server.init_ibv();
         }
-        // Wire metadata cleanup on client timeout. Prefer the co-located
-        // in-process server; otherwise use the separately-deployed HTTP
-        // metadata server derived from the cluster configuration above.
-        mooncake::HttpMetadataServer* metadata_server_ptr = nullptr;
-        if (master_config.enable_metadata_cleanup_on_timeout &&
-            master_config.enable_http_metadata_server) {
-            metadata_server_ptr = http_metadata_server.get();
-        }
-
         auto wrapped_master_service =
             std::make_shared<mooncake::WrappedMasterService>(
                 mooncake::WrappedMasterServiceConfig(master_config, version),

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -1179,7 +1179,8 @@ int main(int argc, char* argv[]) {
                 << "enable_metadata_cleanup_on_timeout is set to true but "
                    "enable_http_metadata_server is false and no HTTP metadata "
                    "server address could be derived from the cluster config "
-                   "(set MOONCAKE_TE_META_DATA_SERVER=http://host:port/metadata "
+                   "(set "
+                   "MOONCAKE_TE_META_DATA_SERVER=http://host:port/metadata "
                    "or MOONCAKE_CONFIG_PATH). Disabling metadata cleanup on "
                    "timeout.";
             master_config.enable_metadata_cleanup_on_timeout = false;

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -189,6 +189,11 @@ DEFINE_int32(http_metadata_server_port, 8080,
              "Port for HTTP metadata server to listen on");
 DEFINE_string(http_metadata_server_host, "0.0.0.0",
               "Host for HTTP metadata server to bind to");
+DEFINE_bool(
+    enable_metadata_cleanup_on_timeout, false,
+    "Enable cleanup of HTTP metadata (mooncake/ram/*, mooncake/rpc_meta/*) "
+    "when client heartbeat times out. Only effective when "
+    "enable_http_metadata_server is true.");
 
 DEFINE_string(pod_name, "",
               "Pod name for K8s label-based routing (default: $POD_NAME)");
@@ -418,6 +423,9 @@ void InitMasterConf(const mooncake::DefaultConfig& default_config,
                              FLAGS_pod_name);
     default_config.GetString("pod_namespace", &master_config.pod_namespace,
                              FLAGS_pod_namespace);
+    default_config.GetBool("enable_metadata_cleanup_on_timeout",
+                           &master_config.enable_metadata_cleanup_on_timeout,
+                           FLAGS_enable_metadata_cleanup_on_timeout);
     default_config.GetUInt64("put_start_discard_timeout_sec",
                              &master_config.put_start_discard_timeout_sec,
                              FLAGS_put_start_discard_timeout_sec);
@@ -790,6 +798,13 @@ void LoadConfigFromCmdline(mooncake::MasterConfig& master_config,
         !conf_set) {
         master_config.pod_namespace = FLAGS_pod_namespace;
     }
+    if ((google::GetCommandLineFlagInfo("enable_metadata_cleanup_on_timeout",
+                                        &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.enable_metadata_cleanup_on_timeout =
+            FLAGS_enable_metadata_cleanup_on_timeout;
+    }
     if ((google::GetCommandLineFlagInfo("put_start_discard_timeout_sec",
                                         &info) &&
          !info.is_default) ||
@@ -1088,6 +1103,17 @@ int main(int argc, char* argv[]) {
     if (value && std::string_view(value) == "rdma") {
         protocol = "rdma";
     }
+
+    // Validate: enable_metadata_cleanup_on_timeout requires
+    // enable_http_metadata_server
+    if (master_config.enable_metadata_cleanup_on_timeout &&
+        !master_config.enable_http_metadata_server) {
+        LOG(WARNING) << "enable_metadata_cleanup_on_timeout is set to true but "
+                     << "enable_http_metadata_server is false. "
+                     << "Disabling metadata cleanup on timeout.";
+        master_config.enable_metadata_cleanup_on_timeout = false;
+    }
+
     LOG(INFO)
         << "Master service started on port " << master_config.rpc_port
         << ", max_threads=" << master_config.rpc_thread_num
@@ -1127,6 +1153,8 @@ int main(int argc, char* argv[]) {
         << master_config.http_metadata_server_port
         << ", http_metadata_server_host="
         << master_config.http_metadata_server_host
+        << ", enable_metadata_cleanup_on_timeout="
+        << master_config.enable_metadata_cleanup_on_timeout
         << ", put_start_discard_timeout_sec="
         << master_config.put_start_discard_timeout_sec
         << ", put_start_release_timeout_sec="
@@ -1188,9 +1216,18 @@ int main(int argc, char* argv[]) {
         if (value && std::string_view(value) == "rdma") {
             server.init_ibv();
         }
+        // Only pass HttpMetadataServer pointer if cleanup is enabled
+        // Note: enable_metadata_cleanup_on_timeout is automatically disabled
+        // if enable_http_metadata_server is false (validated earlier)
+        mooncake::HttpMetadataServer* metadata_server_ptr = nullptr;
+        if (master_config.enable_metadata_cleanup_on_timeout) {
+            metadata_server_ptr = http_metadata_server.get();
+        }
+
         auto wrapped_master_service =
             std::make_shared<mooncake::WrappedMasterService>(
-                mooncake::WrappedMasterServiceConfig(master_config, version));
+                mooncake::WrappedMasterServiceConfig(master_config, version),
+                metadata_server_ptr);
         mooncake::MasterAdminServer admin_server(
             static_cast<uint16_t>(master_config.metrics_port),
             master_config.enable_metric_reporting);

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -95,9 +95,8 @@ std::string ResolveMetadataServerForCleanup() {
                                      << cfg << "): " << errs;
                     }
                 } else {
-                    LOG(WARNING)
-                        << "Cannot open MOONCAKE_CONFIG_PATH (" << cfg
-                        << "): file does not exist or is not readable";
+                    LOG(WARNING) << "Cannot open MOONCAKE_CONFIG_PATH (" << cfg
+                                 << "): file does not exist or is not readable";
                 }
             } catch (const std::exception& e) {
                 LOG(WARNING) << "Error reading MOONCAKE_CONFIG_PATH (" << cfg
@@ -1282,7 +1281,8 @@ int main(int argc, char* argv[]) {
     }
 
     if (master_config.enable_ha) {
-        mooncake::MasterServiceSupervisorConfig supervisor_config{master_config};
+        mooncake::MasterServiceSupervisorConfig supervisor_config{
+            master_config};
         supervisor_config.http_metadata_server = metadata_server_ptr;
         supervisor_config.http_metadata_remote_url = http_metadata_remote_url;
         mooncake::ha::MasterServiceSupervisor supervisor(supervisor_config);

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -5,8 +5,11 @@
 #include <chrono>  // For std::chrono
 #include <csignal>
 #include <cstdlib>  // For std::getenv
+#include <fstream>  // For std::ifstream
 #include <memory>   // For std::unique_ptr
-#include <thread>   // For std::thread
+#include <string>
+#include <thread>  // For std::thread
+#include <json/json.h>
 #include <ylt/coro_rpc/coro_rpc_server.hpp>
 #include <ylt/easylog/record.hpp>
 
@@ -59,6 +62,52 @@ uint64_t ParseDurationFlagOrDie(const char* flag_name,
                    << ". " << error;
     }
     return parsed_value;
+}
+
+// Derive the metadata server connection string from the cluster's existing
+// configuration so that the master can clean up stale HTTP metadata when the
+// metadata server is deployed separately (not co-located in this process).
+// Sources, in priority order:
+//   1) MOONCAKE_TE_META_DATA_SERVER  (the Transfer Engine metadata connstring
+//      shared cluster-wide, e.g. "http://host:8080/metadata")
+//   2) MOONCAKE_CONFIG_PATH json -> "metadata_server"
+// Returns an empty string if nothing usable is found. The caller is
+// responsible for validating the scheme (only http(s) is supported).
+std::string ResolveMetadataServerForCleanup() {
+    if (const char* env = std::getenv("MOONCAKE_TE_META_DATA_SERVER")) {
+        std::string value(env);
+        // "P2PHANDSHAKE" is a peer-to-peer mode with no central metadata
+        // server, so there is nothing to clean up remotely.
+        if (!value.empty() && value != "P2PHANDSHAKE") {
+            return value;
+        }
+    }
+
+    if (const char* cfg = std::getenv("MOONCAKE_CONFIG_PATH")) {
+        if (cfg[0] != '\0') {
+            try {
+                std::ifstream fin(cfg);
+                if (fin) {
+                    Json::CharReaderBuilder builder;
+                    Json::Value root;
+                    std::string errs;
+                    if (Json::parseFromStream(builder, fin, &root, &errs) &&
+                        root.isMember("metadata_server")) {
+                        return root["metadata_server"].asString();
+                    }
+                    if (!errs.empty()) {
+                        LOG(WARNING) << "Failed to parse MOONCAKE_CONFIG_PATH ("
+                                     << cfg << "): " << errs;
+                    }
+                }
+            } catch (const std::exception& e) {
+                LOG(WARNING) << "Error reading MOONCAKE_CONFIG_PATH (" << cfg
+                             << "): " << e.what();
+            }
+        }
+    }
+
+    return {};
 }
 
 }  // namespace
@@ -1104,14 +1153,37 @@ int main(int argc, char* argv[]) {
         protocol = "rdma";
     }
 
-    // Validate: enable_metadata_cleanup_on_timeout requires
-    // enable_http_metadata_server
+    // enable_metadata_cleanup_on_timeout requires a reachable HTTP metadata
+    // server. Two topologies are supported:
+    //   1) Co-located: enable_http_metadata_server=true -> the master cleans
+    //      up via the in-process server (no network overhead).
+    //   2) Separately deployed: the master derives the metadata server address
+    //      from the cluster's existing configuration
+    //      (MOONCAKE_TE_META_DATA_SERVER, or MOONCAKE_CONFIG_PATH json's
+    //      "metadata_server") and cleans up via HTTP DELETE. Only http(s)
+    //      endpoints are supported for now (etcd/redis left for future work).
+    // If neither is available, cleanup is disabled with a warning so the main
+    // process is never affected.
+    std::string http_metadata_remote_url;
     if (master_config.enable_metadata_cleanup_on_timeout &&
         !master_config.enable_http_metadata_server) {
-        LOG(WARNING) << "enable_metadata_cleanup_on_timeout is set to true but "
-                     << "enable_http_metadata_server is false. "
-                     << "Disabling metadata cleanup on timeout.";
-        master_config.enable_metadata_cleanup_on_timeout = false;
+        std::string derived = ResolveMetadataServerForCleanup();
+        if (derived.rfind("http://", 0) == 0 ||
+            derived.rfind("https://", 0) == 0) {
+            http_metadata_remote_url = std::move(derived);
+            LOG(INFO) << "enable_metadata_cleanup_on_timeout: HTTP metadata "
+                         "server is deployed separately; cleanup will target "
+                      << http_metadata_remote_url;
+        } else {
+            LOG(WARNING)
+                << "enable_metadata_cleanup_on_timeout is set to true but "
+                   "enable_http_metadata_server is false and no HTTP metadata "
+                   "server address could be derived from the cluster config "
+                   "(set MOONCAKE_TE_META_DATA_SERVER=http://host:port/metadata "
+                   "or MOONCAKE_CONFIG_PATH). Disabling metadata cleanup on "
+                   "timeout.";
+            master_config.enable_metadata_cleanup_on_timeout = false;
+        }
     }
 
     LOG(INFO)
@@ -1216,18 +1288,19 @@ int main(int argc, char* argv[]) {
         if (value && std::string_view(value) == "rdma") {
             server.init_ibv();
         }
-        // Only pass HttpMetadataServer pointer if cleanup is enabled
-        // Note: enable_metadata_cleanup_on_timeout is automatically disabled
-        // if enable_http_metadata_server is false (validated earlier)
+        // Wire metadata cleanup on client timeout. Prefer the co-located
+        // in-process server; otherwise use the separately-deployed HTTP
+        // metadata server derived from the cluster configuration above.
         mooncake::HttpMetadataServer* metadata_server_ptr = nullptr;
-        if (master_config.enable_metadata_cleanup_on_timeout) {
+        if (master_config.enable_metadata_cleanup_on_timeout &&
+            master_config.enable_http_metadata_server) {
             metadata_server_ptr = http_metadata_server.get();
         }
 
         auto wrapped_master_service =
             std::make_shared<mooncake::WrappedMasterService>(
                 mooncake::WrappedMasterServiceConfig(master_config, version),
-                metadata_server_ptr);
+                metadata_server_ptr, http_metadata_remote_url);
         mooncake::MasterAdminServer admin_server(
             static_cast<uint16_t>(master_config.metrics_port),
             master_config.enable_metric_reporting);

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -64,20 +64,14 @@ uint64_t ParseDurationFlagOrDie(const char* flag_name,
     return parsed_value;
 }
 
-// Derive the metadata server connection string from the cluster's existing
-// configuration so that the master can clean up stale HTTP metadata when the
-// metadata server is deployed separately (not co-located in this process).
-// Sources, in priority order:
-//   1) MOONCAKE_TE_META_DATA_SERVER  (the Transfer Engine metadata connstring
-//      shared cluster-wide, e.g. "http://host:8080/metadata")
-//   2) MOONCAKE_CONFIG_PATH json -> "metadata_server"
-// Returns an empty string if nothing usable is found. The caller is
-// responsible for validating the scheme (only http(s) is supported).
+// Derive the metadata server address for cleanup when it is deployed
+// separately. Priority: MOONCAKE_TE_META_DATA_SERVER, then the
+// "metadata_server" field of MOONCAKE_CONFIG_PATH. Returns "" if none found;
+// the caller validates the scheme (only http(s) is supported).
 std::string ResolveMetadataServerForCleanup() {
     if (const char* env = std::getenv("MOONCAKE_TE_META_DATA_SERVER")) {
         std::string value(env);
-        // "P2PHANDSHAKE" is a peer-to-peer mode with no central metadata
-        // server, so there is nothing to clean up remotely.
+        // P2PHANDSHAKE has no central metadata server, nothing to clean up.
         if (!value.empty() && value != "P2PHANDSHAKE") {
             return value;
         }
@@ -1279,10 +1273,8 @@ int main(int argc, char* argv[]) {
         std::this_thread::sleep_for(std::chrono::seconds(1));
     }
 
-    // Wire metadata cleanup on client timeout into the serving primary. The
-    // stale-metadata problem is identical in HA mode (the primary still handles
-    // heartbeats and unmounts), so prefer the co-located in-process server,
-    // otherwise use the separately-deployed HTTP endpoint derived above.
+    // Metadata cleanup on client timeout (used by both the HA and non-HA
+    // paths): prefer the co-located in-process server, else the separate URL.
     mooncake::HttpMetadataServer* metadata_server_ptr = nullptr;
     if (master_config.enable_metadata_cleanup_on_timeout &&
         master_config.enable_http_metadata_server) {

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -8774,10 +8774,8 @@ void MasterService::setHttpMetadataServer(HttpMetadataServer* server) {
 void MasterService::setHttpMetadataRemoteUrl(
     const std::string& metadata_connstring) {
 #ifdef USE_HTTP
-    // Only http/https metadata servers are supported for remote cleanup. Guard
-    // the scheme here to avoid MetadataStoragePlugin::Create()'s LOG(FATAL)
-    // path for unsupported backends (etcd / redis / P2PHANDSHAKE), which are
-    // left for a future change.
+    // Only http(s) is supported; guard the scheme to avoid
+    // MetadataStoragePlugin::Create()'s LOG(FATAL) on other backends.
     if (metadata_connstring.rfind("http://", 0) == 0 ||
         metadata_connstring.rfind("https://", 0) == 0) {
         try {
@@ -8815,8 +8813,7 @@ void MasterService::setHttpMetadataRemoteUrl(
 }
 
 void MasterService::cleanupHttpMetadata(const std::string& segment_name) {
-    // Co-located metadata server: remove via direct in-process call (no
-    // network overhead). Safe to run inline — no I/O leaves the process.
+    // Co-located: remove in-process, safe to run inline (no network I/O).
     if (http_metadata_server_) {
         const std::string ram_key =
             http_metadata_prefix_ + "ram/" + segment_name;
@@ -8830,8 +8827,8 @@ void MasterService::cleanupHttpMetadata(const std::string& segment_name) {
         return;
     }
 
-    // Separately-deployed metadata server: enqueue for async cleanup so that
-    // slow/unreachable metadata servers never block the client monitor thread.
+    // Separately-deployed: enqueue for async cleanup so a slow/unreachable
+    // server never blocks the client monitor thread.
     if (http_metadata_remote_) {
         {
             std::lock_guard<std::mutex> lk(http_metadata_cleanup_mutex_);

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -3,6 +3,7 @@
 #include <cassert>
 #include <cmath>
 #include <cstdint>
+#include <cstring>
 #include <limits>
 #include <random>
 #include <shared_mutex>
@@ -15,6 +16,7 @@
 #include <ylt/util/tl/expected.hpp>
 #include <boost/algorithm/string.hpp>
 
+#include "http_metadata_server.h"
 #include "master_metric_manager.h"
 #include "common.h"
 #include "segment.h"
@@ -212,6 +214,17 @@ MasterService::MasterService(const MasterServiceConfig& config)
       cxl_path_(config.cxl_path),
       cxl_size_(config.cxl_size),
       enable_cxl_(config.enable_cxl) {
+    // Initialize HTTP metadata key prefix (read env var once at startup)
+    const char* custom_prefix = std::getenv("MC_METADATA_CLUSTER_ID");
+    if (custom_prefix && std::strlen(custom_prefix) > 0) {
+        http_metadata_prefix_ = "mooncake/" + std::string(custom_prefix);
+        if (http_metadata_prefix_.back() != '/') {
+            http_metadata_prefix_ += '/';
+        }
+    } else {
+        http_metadata_prefix_ = "mooncake/";
+    }
+
     if (enable_snapshot_ || enable_snapshot_restore_) {
         try {
             auto object_store_type =
@@ -7032,6 +7045,8 @@ void MasterService::ClientMonitorFunc() {
                     LOG(INFO) << "client_id=" << client_ids[i]
                               << ", segment_name=" << segment_names[i]
                               << ", action=unmount_expired_mem_segment";
+                    // Clean up HTTP metadata if enabled
+                    cleanupHttpMetadata(segment_names[i]);
                 }
                 for (auto& client_id : expired_clients) {
                     segment_access.UnmountLocalDiskSegment(client_id);
@@ -8734,6 +8749,29 @@ MasterService::MetadataSerializer::DeserializeDiscardedReplicas(
     }
 
     return {};
+}
+
+void MasterService::setHttpMetadataServer(HttpMetadataServer* server) {
+    http_metadata_server_ = server;
+    if (server) {
+        LOG(INFO) << "HTTP metadata cleanup on client timeout: enabled";
+    }
+}
+
+void MasterService::cleanupHttpMetadata(const std::string& segment_name) {
+    if (!http_metadata_server_) {
+        return;
+    }
+
+    std::string ram_key = http_metadata_prefix_ + "ram/" + segment_name;
+    bool ram_removed = http_metadata_server_->removeKey(ram_key);
+
+    std::string rpc_key = http_metadata_prefix_ + "rpc_meta/" + segment_name;
+    bool rpc_removed = http_metadata_server_->removeKey(rpc_key);
+
+    LOG(INFO) << "Cleaned up HTTP metadata for segment: " << segment_name
+              << ", ram_key_removed=" << ram_removed
+              << ", rpc_key_removed=" << rpc_removed;
 }
 
 }  // namespace mooncake

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -373,6 +373,10 @@ MasterService::MasterService(const MasterServiceConfig& config)
         std::thread(&MasterService::TaskCleanupThreadFunc, this);
     VLOG(1) << "action=start_task_cleanup_thread";
 
+    // NOTE: The async HTTP metadata cleanup worker is started lazily in
+    // setHttpMetadataRemoteUrl() once http_metadata_remote_ is initialized,
+    // since that happens after this constructor returns (in WrappedMasterService).
+
     job_dispatch_running_ = true;
     job_dispatch_thread_ =
         std::thread(&MasterService::JobDispatchThreadFunc, this);
@@ -446,6 +450,7 @@ MasterService::~MasterService() {
     snapshot_running_ = false;
     task_cleanup_running_ = false;
     job_dispatch_running_ = false;
+    http_metadata_cleanup_running_ = false;
     graceful_unmount_scheduler_.Stop();
 #ifdef USE_NOF
     nof_heartbeat_running_ = false;
@@ -453,6 +458,7 @@ MasterService::~MasterService() {
 
     // Wake sleepers so join() doesn't block for long sleep intervals.
     task_cleanup_cv_.notify_all();
+    http_metadata_cleanup_cv_.notify_all();
 
     if (eviction_thread_.joinable()) {
         eviction_thread_.join();
@@ -470,6 +476,9 @@ MasterService::~MasterService() {
     }
     if (task_cleanup_thread_.joinable()) {
         task_cleanup_thread_.join();
+    }
+    if (http_metadata_cleanup_thread_.joinable()) {
+        http_metadata_cleanup_thread_.join();
     }
     if (job_dispatch_thread_.joinable()) {
         job_dispatch_thread_.join();
@@ -8777,6 +8786,11 @@ void MasterService::setHttpMetadataRemoteUrl(
             LOG(INFO) << "HTTP metadata cleanup on client timeout: enabled "
                          "(remote metadata server "
                       << metadata_connstring << ")";
+            // Start async cleanup worker now that http_metadata_remote_ is ready
+            http_metadata_cleanup_running_ = true;
+            http_metadata_cleanup_thread_ =
+                std::thread(&MasterService::HttpMetadataCleanupThreadFunc, this);
+            LOG(INFO) << "HTTP metadata cleanup worker thread started";
         } catch (const std::exception& e) {
             LOG(WARNING) << "Failed to initialize remote HTTP metadata client "
                             "for "
@@ -8801,13 +8815,13 @@ void MasterService::setHttpMetadataRemoteUrl(
 }
 
 void MasterService::cleanupHttpMetadata(const std::string& segment_name) {
-    const std::string ram_key = http_metadata_prefix_ + "ram/" + segment_name;
-    const std::string rpc_key =
-        http_metadata_prefix_ + "rpc_meta/" + segment_name;
-
     // Co-located metadata server: remove via direct in-process call (no
-    // network overhead).
+    // network overhead). Safe to run inline — no I/O leaves the process.
     if (http_metadata_server_) {
+        const std::string ram_key =
+            http_metadata_prefix_ + "ram/" + segment_name;
+        const std::string rpc_key =
+            http_metadata_prefix_ + "rpc_meta/" + segment_name;
         bool ram_removed = http_metadata_server_->removeKey(ram_key);
         bool rpc_removed = http_metadata_server_->removeKey(rpc_key);
         LOG(INFO) << "Cleaned up HTTP metadata for segment: " << segment_name
@@ -8816,26 +8830,67 @@ void MasterService::cleanupHttpMetadata(const std::string& segment_name) {
         return;
     }
 
-    // Separately-deployed metadata server: best-effort removal over HTTP.
-    // Failures/exceptions must never escape into the client-monitor thread.
+    // Separately-deployed metadata server: enqueue for async cleanup so that
+    // slow/unreachable metadata servers never block the client monitor thread.
     if (http_metadata_remote_) {
-        bool ram_removed = false;
-        bool rpc_removed = false;
-        try {
-            ram_removed = http_metadata_remote_->remove(ram_key);
-            rpc_removed = http_metadata_remote_->remove(rpc_key);
-        } catch (const std::exception& e) {
-            LOG(WARNING) << "Remote HTTP metadata cleanup failed for segment: "
-                         << segment_name << ": " << e.what();
-            return;
+        {
+            std::lock_guard<std::mutex> lk(http_metadata_cleanup_mutex_);
+            http_metadata_cleanup_queue_.push_back(segment_name);
         }
-        LOG(INFO) << "Cleaned up remote HTTP metadata for segment: "
-                  << segment_name << ", ram_key_removed=" << ram_removed
-                  << ", rpc_key_removed=" << rpc_removed;
+        http_metadata_cleanup_cv_.notify_one();
         return;
     }
 
     // Neither configured: cleanup is disabled, nothing to do.
+}
+
+void MasterService::HttpMetadataCleanupThreadFunc() {
+    LOG(INFO) << "HTTP metadata cleanup worker started";
+    while (http_metadata_cleanup_running_) {
+        std::vector<std::string> batch;
+        {
+            std::unique_lock<std::mutex> lk(http_metadata_cleanup_mutex_);
+            http_metadata_cleanup_cv_.wait(lk, [&] {
+                return !http_metadata_cleanup_queue_.empty() ||
+                       !http_metadata_cleanup_running_.load();
+            });
+            if (!http_metadata_cleanup_running_ &&
+                http_metadata_cleanup_queue_.empty()) {
+                break;
+            }
+            batch.swap(http_metadata_cleanup_queue_);
+        }
+
+        for (const auto& segment_name : batch) {
+            const std::string ram_key =
+                http_metadata_prefix_ + "ram/" + segment_name;
+            const std::string rpc_key =
+                http_metadata_prefix_ + "rpc_meta/" + segment_name;
+
+            // Each key attempted independently so one failure does not
+            // prevent cleanup of the other.
+            bool ram_removed = false;
+            bool rpc_removed = false;
+            try {
+                ram_removed = http_metadata_remote_->remove(ram_key);
+            } catch (const std::exception& e) {
+                LOG(WARNING)
+                    << "Remote HTTP metadata cleanup failed for ram_key: "
+                    << ram_key << ": " << e.what();
+            }
+            try {
+                rpc_removed = http_metadata_remote_->remove(rpc_key);
+            } catch (const std::exception& e) {
+                LOG(WARNING)
+                    << "Remote HTTP metadata cleanup failed for rpc_key: "
+                    << rpc_key << ": " << e.what();
+            }
+            LOG(INFO) << "Cleaned up remote HTTP metadata for segment: "
+                      << segment_name << ", ram_key_removed=" << ram_removed
+                      << ", rpc_key_removed=" << rpc_removed;
+        }
+    }
+    LOG(INFO) << "HTTP metadata cleanup worker stopped";
 }
 
 }  // namespace mooncake

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -375,7 +375,8 @@ MasterService::MasterService(const MasterServiceConfig& config)
 
     // NOTE: The async HTTP metadata cleanup worker is started lazily in
     // setHttpMetadataRemoteUrl() once http_metadata_remote_ is initialized,
-    // since that happens after this constructor returns (in WrappedMasterService).
+    // since that happens after this constructor returns (in
+    // WrappedMasterService).
 
     job_dispatch_running_ = true;
     job_dispatch_thread_ =
@@ -8784,10 +8785,11 @@ void MasterService::setHttpMetadataRemoteUrl(
             LOG(INFO) << "HTTP metadata cleanup on client timeout: enabled "
                          "(remote metadata server "
                       << metadata_connstring << ")";
-            // Start async cleanup worker now that http_metadata_remote_ is ready
+            // Start async cleanup worker now that http_metadata_remote_ is
+            // ready
             http_metadata_cleanup_running_ = true;
-            http_metadata_cleanup_thread_ =
-                std::thread(&MasterService::HttpMetadataCleanupThreadFunc, this);
+            http_metadata_cleanup_thread_ = std::thread(
+                &MasterService::HttpMetadataCleanupThreadFunc, this);
             LOG(INFO) << "HTTP metadata cleanup worker thread started";
         } catch (const std::exception& e) {
             LOG(WARNING) << "Failed to initialize remote HTTP metadata client "

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -20,6 +20,9 @@
 #include "master_metric_manager.h"
 #include "common.h"
 #include "segment.h"
+#ifdef USE_HTTP
+#include "transfer_metadata_plugin.h"
+#endif
 #ifdef USE_NOF
 #include "spdk/spdk_wrapper.h"
 #endif
@@ -8754,24 +8757,85 @@ MasterService::MetadataSerializer::DeserializeDiscardedReplicas(
 void MasterService::setHttpMetadataServer(HttpMetadataServer* server) {
     http_metadata_server_ = server;
     if (server) {
-        LOG(INFO) << "HTTP metadata cleanup on client timeout: enabled";
+        LOG(INFO) << "HTTP metadata cleanup on client timeout: enabled "
+                     "(co-located metadata server)";
     }
 }
 
+void MasterService::setHttpMetadataRemoteUrl(
+    const std::string& metadata_connstring) {
+#ifdef USE_HTTP
+    // Only http/https metadata servers are supported for remote cleanup. Guard
+    // the scheme here to avoid MetadataStoragePlugin::Create()'s LOG(FATAL)
+    // path for unsupported backends (etcd / redis / P2PHANDSHAKE), which are
+    // left for a future change.
+    if (metadata_connstring.rfind("http://", 0) == 0 ||
+        metadata_connstring.rfind("https://", 0) == 0) {
+        try {
+            http_metadata_remote_ =
+                MetadataStoragePlugin::Create(metadata_connstring);
+            LOG(INFO) << "HTTP metadata cleanup on client timeout: enabled "
+                         "(remote metadata server "
+                      << metadata_connstring << ")";
+        } catch (const std::exception& e) {
+            LOG(WARNING) << "Failed to initialize remote HTTP metadata client "
+                            "for "
+                         << metadata_connstring << ": " << e.what()
+                         << ". Metadata cleanup on timeout disabled.";
+            http_metadata_remote_.reset();
+        }
+        return;
+    }
+    LOG(WARNING) << "enable_metadata_cleanup_on_timeout is set but the "
+                    "configured metadata server '"
+                 << metadata_connstring
+                 << "' is not an HTTP endpoint; remote cleanup currently "
+                    "supports only http(s). Metadata cleanup on timeout "
+                    "disabled.";
+#else
+    (void)metadata_connstring;
+    LOG(WARNING) << "enable_metadata_cleanup_on_timeout is set but this build "
+                    "has no HTTP metadata support (USE_HTTP=OFF); metadata "
+                    "cleanup on timeout disabled.";
+#endif
+}
+
 void MasterService::cleanupHttpMetadata(const std::string& segment_name) {
-    if (!http_metadata_server_) {
+    const std::string ram_key = http_metadata_prefix_ + "ram/" + segment_name;
+    const std::string rpc_key =
+        http_metadata_prefix_ + "rpc_meta/" + segment_name;
+
+    // Co-located metadata server: remove via direct in-process call (no
+    // network overhead).
+    if (http_metadata_server_) {
+        bool ram_removed = http_metadata_server_->removeKey(ram_key);
+        bool rpc_removed = http_metadata_server_->removeKey(rpc_key);
+        LOG(INFO) << "Cleaned up HTTP metadata for segment: " << segment_name
+                  << ", ram_key_removed=" << ram_removed
+                  << ", rpc_key_removed=" << rpc_removed;
         return;
     }
 
-    std::string ram_key = http_metadata_prefix_ + "ram/" + segment_name;
-    bool ram_removed = http_metadata_server_->removeKey(ram_key);
+    // Separately-deployed metadata server: best-effort removal over HTTP.
+    // Failures/exceptions must never escape into the client-monitor thread.
+    if (http_metadata_remote_) {
+        bool ram_removed = false;
+        bool rpc_removed = false;
+        try {
+            ram_removed = http_metadata_remote_->remove(ram_key);
+            rpc_removed = http_metadata_remote_->remove(rpc_key);
+        } catch (const std::exception& e) {
+            LOG(WARNING) << "Remote HTTP metadata cleanup failed for segment: "
+                         << segment_name << ": " << e.what();
+            return;
+        }
+        LOG(INFO) << "Cleaned up remote HTTP metadata for segment: "
+                  << segment_name << ", ram_key_removed=" << ram_removed
+                  << ", rpc_key_removed=" << rpc_removed;
+        return;
+    }
 
-    std::string rpc_key = http_metadata_prefix_ + "rpc_meta/" + segment_name;
-    bool rpc_removed = http_metadata_server_->removeKey(rpc_key);
-
-    LOG(INFO) << "Cleaned up HTTP metadata for segment: " << segment_name
-              << ", ram_key_removed=" << ram_removed
-              << ", rpc_key_removed=" << rpc_removed;
+    // Neither configured: cleanup is disabled, nothing to do.
 }
 
 }  // namespace mooncake

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -13,8 +13,12 @@
 namespace mooncake {
 
 WrappedMasterService::WrappedMasterService(
-    const WrappedMasterServiceConfig& config)
-    : master_service_(MasterServiceConfig(config)) {}
+    const WrappedMasterServiceConfig& config,
+    HttpMetadataServer* http_metadata_server)
+    : master_service_(MasterServiceConfig(config)) {
+    // Set HttpMetadataServer reference for cleanup on client timeout
+    master_service_.setHttpMetadataServer(http_metadata_server);
+}
 
 WrappedMasterService::~WrappedMasterService() = default;
 

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -14,10 +14,17 @@ namespace mooncake {
 
 WrappedMasterService::WrappedMasterService(
     const WrappedMasterServiceConfig& config,
-    HttpMetadataServer* http_metadata_server)
+    HttpMetadataServer* http_metadata_server,
+    const std::string& http_metadata_remote_url)
     : master_service_(MasterServiceConfig(config)) {
-    // Set HttpMetadataServer reference for cleanup on client timeout
-    master_service_.setHttpMetadataServer(http_metadata_server);
+    // Configure metadata cleanup on client timeout. Prefer the co-located
+    // in-process server; otherwise fall back to a separately-deployed HTTP
+    // metadata server derived from the cluster configuration.
+    if (http_metadata_server) {
+        master_service_.setHttpMetadataServer(http_metadata_server);
+    } else if (!http_metadata_remote_url.empty()) {
+        master_service_.setHttpMetadataRemoteUrl(http_metadata_remote_url);
+    }
 }
 
 WrappedMasterService::~WrappedMasterService() = default;


### PR DESCRIPTION
## Description

Follow-up to #1363. That PR cleans up stale HTTP metadata
(`mooncake/[<cluster>/]ram/<segment>`, `mooncake/[<cluster>/]rpc_meta/<segment>`)
when a client heartbeat times out, but **only when the HTTP metadata server is
co-located in the master process** (direct in-process `removeKey`). This PR
extends the same opt-in feature to the common topology where the **HTTP metadata
server is deployed separately** from the master.

> Note: this branch is stacked on #1363 — the first commit is #1363's, the
> second commit is this change. Please merge #1363 first (or review the second
> commit here).

## Problem

When `enable_metadata_cleanup_on_timeout=true` but `enable_http_metadata_server=false`
(i.e. the metadata server runs as a separate process/pod), the master has no
in-process pointer to the metadata server, so the existing cleanup is a no-op
and stale `ram/` + `rpc_meta/` entries still leak after a client crash.

## Solution

When the metadata server is not co-located, the master derives its address from
the cluster's **existing** configuration (no new flag) and removes the keys via
HTTP `DELETE`, reusing the Transfer Engine's `MetadataStoragePlugin`. The
address is read, in priority order, from:

1. `MOONCAKE_TE_META_DATA_SERVER` — the Transfer Engine metadata connection
   string the clients already use (e.g. `http://host:8080/metadata`); then
2. the `metadata_server` field of the JSON file at `MOONCAKE_CONFIG_PATH`.

The cleanup path now selects:
- **Co-located** (`enable_http_metadata_server=true`): in-process `removeKey`
  (unchanged fast path).
- **Separate**: HTTP `DELETE` to the derived endpoint.

### Design notes
- Only `http(s)` endpoints are supported; `etcd`/`redis`/`P2PHANDSHAKE` are
  skipped with a warning (left for future work). The scheme is checked before
  calling `MetadataStoragePlugin::Create()` to avoid its `LOG(FATAL)` path.
- Opt-in and **best-effort**: if neither a co-located server nor a derivable
  HTTP address is available, a warning is logged and cleanup is disabled.
  Remote `DELETE` failures are caught/logged and never block the
  client-monitor thread or the main process.
- Respects `MC_METADATA_CLUSTER_ID` for custom key prefixes.

## Changes
- `master_service.{h,cpp}`: `setHttpMetadataRemoteUrl()`; `cleanupHttpMetadata()`
  now removes via the remote plugin when not co-located.
- `rpc_service.{h,cpp}`: `WrappedMasterService` accepts an optional
  `http_metadata_remote_url`.
- `master.cpp`: derive the metadata server address from the cluster config,
  relax the validation, and wire the remote URL.
- `mooncake-store/src/CMakeLists.txt`: link `JsonCpp::JsonCpp` to
  `mooncake_master` (for `MOONCAKE_CONFIG_PATH` parsing).
- Docs: usage section in the mooncake-store deployment guide.

## Usage

```bash
# Co-located metadata server
mooncake_master --enable_http_metadata_server=true \
  --enable_metadata_cleanup_on_timeout=true --client_ttl=10

# Separately-deployed HTTP metadata server (address derived from the env var)
export MOONCAKE_TE_META_DATA_SERVER=http://metadata-host:8080/metadata
mooncake_master --enable_metadata_cleanup_on_timeout=true --client_ttl=10
```

## Testing

Validated end-to-end (master + a real client + standalone/embedded metadata
server, `client_ttl=20`, `kill -9` the client):

- **Separate deployment**: standalone `mooncake_http_metadata_server`; master
  started without `--enable_http_metadata_server`, with
  `MOONCAKE_TE_META_DATA_SERVER=http://127.0.0.1:8090/metadata`. On timeout:
  `Cleaned up remote HTTP metadata for segment: ..., ram_key_removed=1, rpc_key_removed=1`,
  and both keys returned `metadata not found` afterwards.
- **No config**: cleanup on, http server off, no env → warns and auto-disables
  (`enable_metadata_cleanup_on_timeout=0`); main process unaffected.
- **Co-located regression**: `--enable_http_metadata_server=true` still removes
  both keys via the in-process path (`ram_key_removed=1, rpc_key_removed=1`).