### PR TITLE
[TE] Support per-role Ascend protocol for co-located Transfer Engines

### DIFF
--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -628,6 +628,18 @@ ErrorCode Client::InitTransferEngine(
     const std::string& local_hostname, const std::string& metadata_connstring,
     const std::string& protocol,
     const std::optional<std::string>& device_names) {
+    // TEs created through the Store entry (Client::Create ->
+    // InitTransferEngine) are tagged so ascend_direct can resolve a per-role
+    // link config (e.g. Store=RoCE/D2H, P2P=HCCS/D2D). The flag only needs to
+    // be live while the ascend transport is installed below; reset it on every
+    // exit path. Assumes TE inits are serialized within the process.
+    struct StoreTeInitGuard {
+        ~StoreTeInitGuard() { globalConfig().ascend_store_te_init = false; }
+    } store_te_init_guard;
+    if (protocol == "ascend") {
+        globalConfig().ascend_store_te_init = true;
+    }
+
     // Check if using TENT mode - TENT handles transport configuration
     // internally
     bool use_tent = (std::getenv("MC_USE_TENT") != nullptr) ||

--- a/mooncake-transfer-engine/include/config.h
+++ b/mooncake-transfer-engine/include/config.h
@@ -85,6 +85,13 @@ struct GlobalConfig {
     int ib_pci_relaxed_ordering_mode = 0;
     bool ascend_use_fabric_mem = false;
     bool ascend_agent_mode = false;
+    // Transient flag scoped to a single TE init: set true by the Store entry
+    // (Client::InitTransferEngine) before installing the ascend transport, and
+    // reset to false right after. Lets ascend_direct distinguish a Store-init
+    // TE from a normal/P2P TE so each can resolve its own
+    // ASCEND_GLOBAL_RESOURCE_CONFIG (e.g. Store=RoCE, P2P=HCCS). Assumes TE
+    // inits are serialized within the process.
+    bool ascend_store_te_init = false;
     // ub config parameters
     size_t num_jfc_per_ctx = 2;
     size_t num_jfce_per_ctx = 2;

--- a/mooncake-transfer-engine/include/transport/ascend_transport/ascend_direct_transport/ascend_direct_transport.h
+++ b/mooncake-transfer-engine/include/transport/ascend_transport/ascend_direct_transport/ascend_direct_transport.h
@@ -77,8 +77,22 @@ class AscendDirectTransport : public Transport {
                                const std::string &host_ip, SegmentDesc *desc);
 
     int32_t base_port_ = 20000;
-    bool dummy_real_mode_{false};
+    // Mirrors globalConfig().ascend_agent_mode. ascend_agent_mode is enabled
+    // both by the dummy client (inference/GPU process) and by the standalone
+    // real client (real_client_main). The dummy client never installs this
+    // transport, so within AscendDirectTransport this flag effectively means
+    // "I am the independently-launched real client". In this mode the local
+    // segment enumerates every local NPU device via ContextManager (the real
+    // client owns all devices) instead of using the single current-device
+    // context.
+    bool agent_mode_{false};
     bool roce_mode_{false};
+    // Whether this TE uses Ascend fabric memory (host mem for Store, e.g. RoCE
+    // D2H/H2D). Captured once at install time from globalConfig() and gated on
+    // ascend_store_te_init, so a non-Store (e.g. P2P/HCCS) TE never inherits a
+    // Store TE's fabric setting that leaked into the process-global flag. All
+    // transfer-time decisions read this member, not the global.
+    bool use_fabric_mem_{false};
     std::vector<aclrtContext> local_engine_contexts_;
 
     std::unique_ptr<TransferExecutorBase> transfer_executor_;

--- a/mooncake-transfer-engine/include/transport/ascend_transport/ascend_direct_transport/transfer_executor_base.h
+++ b/mooncake-transfer-engine/include/transport/ascend_transport/ascend_direct_transport/transfer_executor_base.h
@@ -57,8 +57,9 @@ class TransferExecutorBase {
         bool auto_connect = true;
         bool use_short_connection = false;
         bool use_buffer_pool = false;
-        bool dummy_real_mode = false;
+        bool agent_mode = false;
         bool roce_mode = false;
+        bool use_fabric_mem = false;
     };
 
     explicit TransferExecutorBase(const InitParams& params);
@@ -77,7 +78,7 @@ class TransferExecutorBase {
     void processSliceList(const std::vector<Transport::Slice*>& slice_list);
 
     int registerMem(void* addr, size_t length, adxl::MemType mem_type,
-                    bool use_buffer_pool, bool roce_mode, bool dummy_real_mode);
+                    bool use_buffer_pool, bool roce_mode, bool agent_mode);
     int deregisterMem(void* addr);
 
     const size_t getNumEngines() const { return adxl_engines_.size(); }

--- a/mooncake-transfer-engine/include/transport/ascend_transport/ascend_direct_transport/utils.h
+++ b/mooncake-transfer-engine/include/transport/ascend_transport/ascend_direct_transport/utils.h
@@ -86,6 +86,16 @@ bool IsRoceModeEnabled();
 // Parse ASCEND_GLOBAL_RESOURCE_CONFIG JSON for roce protocol_desc only.
 bool HasRoceProtocolDescInGlobalResourceConfig(const char *config_str);
 
+// Resolve the effective ASCEND_GLOBAL_RESOURCE_CONFIG for the current TE role.
+// Schema: the top-level object is the default config (passed verbatim to adxl
+// for normal/P2P TEs); an optional "store" sub-object overrides it for a
+// Store-init TE (globalConfig().ascend_store_te_init == true).
+//   - null/empty or no "store" key  -> returned verbatim (backward compatible)
+//   - has "store" and store-init TE  -> the "store" sub-object, serialized
+//   - has "store" and normal TE      -> root with "store" removed, serialized
+// A Store TE with no "store" key falls back to the default config.
+std::string ResolveAscendGlobalResourceConfig(const char *config_str);
+
 int SetDeviceAndGetContext(int32_t device_id, aclrtContext *out_context);
 
 /**

--- a/mooncake-transfer-engine/src/transport/ascend_transport/ascend_allocator.cpp
+++ b/mooncake-transfer-engine/src/transport/ascend_transport/ascend_allocator.cpp
@@ -194,18 +194,19 @@ bool ascend_is_store_memory(void *addr, size_t length) {
 }
 
 void ascend_free_memory(const std::string &protocol, void *ptr) {
-    // make sure ascend_use_fabric_mem do not change between malloc and free
-    if (globalConfig().ascend_use_fabric_mem) {
+    // Route by the per-allocation record, not the process-global fabric flag:
+    // ascend_use_fabric_mem can differ between alloc time and free time (it is
+    // a process-global toggled during TE init), so it cannot be trusted here.
+    // Only fabric/VMM allocations are recorded in g_vmm_alloc_records;
+    // everything else is a plain aclrtMallocHost buffer.
 #ifdef ASCEND_SUPPORT_FABRIC_MEM
-        remove_store_memory_range(ptr);
-        std::lock_guard<std::mutex> lock(g_vmm_alloc_mutex);
-        auto it = g_vmm_alloc_records.find(ptr);
-        if (it == g_vmm_alloc_records.end()) {
-            LOG(INFO) << "Can not find record for va:" << ptr;
-            return;
-        }
+    std::unique_lock<std::mutex> lock(g_vmm_alloc_mutex);
+    auto it = g_vmm_alloc_records.find(ptr);
+    if (it != g_vmm_alloc_records.end()) {
         const AllocRecord alloc_record = it->second;
         g_vmm_alloc_records.erase(it);
+        lock.unlock();
+        remove_store_memory_range(ptr);
         if (!alloc_record.is_direct_alloc) {
             if (&adxl::AdxlEngine::FreeMem != nullptr) {
                 auto status = adxl::AdxlEngine::FreeMem(ptr);
@@ -231,9 +232,10 @@ void ascend_free_memory(const std::string &protocol, void *ptr) {
             LOG(ERROR) << "Failed to free physical mem: " << ptr;
             return;
         }
-#endif
         return;
     }
+    lock.unlock();
+#endif
 
     if (protocol == "ascend") {
         remove_store_memory_range(ptr);

--- a/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/ascend_direct_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/ascend_direct_transport.cpp
@@ -35,8 +35,8 @@
 namespace mooncake {
 namespace {
 
-int32_t ResolveCurrentEngineId(bool dummy_real_mode) {
-    if (!dummy_real_mode) {
+int32_t ResolveCurrentEngineId(bool agent_mode) {
+    if (!agent_mode) {
         return 0;
     }
     int32_t current_device_id = 0;
@@ -105,8 +105,9 @@ int AscendDirectTransport::install(std::string &local_server_name,
     TransferExecutorBase::InitParams exec_params;
     exec_params.metadata = metadata_;
     exec_params.local_engine_contexts = local_engine_contexts_;
-    exec_params.dummy_real_mode = dummy_real_mode_;
+    exec_params.agent_mode = agent_mode_;
     exec_params.roce_mode = roce_mode_;
+    exec_params.use_fabric_mem = use_fabric_mem_;
 
     transfer_executor_ = TransferExecutorBase::Create(exec_params);
     ret = transfer_executor_->initialize();
@@ -117,7 +118,7 @@ int AscendDirectTransport::install(std::string &local_server_name,
         return ret;
     }
 
-    if (dummy_real_mode_ && roce_mode_) {
+    if (agent_mode_ && roce_mode_) {
         dispatcher_ = std::make_unique<RoceDummyRealSliceDispatcher>(
             transfer_executor_.get(), local_engine_contexts_);
     } else {
@@ -148,11 +149,21 @@ int AscendDirectTransport::allocateLocalSegmentID() {
     desc->name = local_server_name_;
     desc->protocol = "ascend";
 
-    dummy_real_mode_ = globalConfig().ascend_agent_mode;
+    agent_mode_ = globalConfig().ascend_agent_mode;
     roce_mode_ = IsRoceModeEnabled();
-    if (roce_mode_) {
-        LOG(INFO) << "Roce mode is enabled.";
-    }
+    // Only a Store-init TE may use fabric mem; gate on ascend_store_te_init so
+    // a P2P/HCCS TE does not inherit a Store TE's fabric flag left in the
+    // process-global config.
+    use_fabric_mem_ = globalConfig().ascend_use_fabric_mem &&
+                      globalConfig().ascend_store_te_init;
+    LOG(INFO) << "[AscendTE] init local segment, te is created for store="
+              << (globalConfig().ascend_store_te_init ? "true" : "false")
+              << ", roce_mode=" << (roce_mode_ ? "true" : "false")
+              << ", use_fabric_mem=" << (use_fabric_mem_ ? "true" : "false")
+              << (agent_mode_
+                      ? ", launched as standalone real client (manages all "
+                        "local NPU devices)"
+                      : "");
     char *adxl_base_port = std::getenv("ASCEND_BASE_PORT");
     if (adxl_base_port) {
         std::optional<int32_t> base_port =
@@ -170,7 +181,7 @@ int AscendDirectTransport::allocateLocalSegmentID() {
     desc->rank_info.hostIp = host_ip;
     uint32_t device_count = 0;
     CHECK_ACL(aclrtGetDeviceCount(&device_count));
-    if (dummy_real_mode_) {
+    if (agent_mode_) {
         auto &ctx_mgr = ContextManager::getInstance();
         if (!ctx_mgr.isInitialized()) {
             LOG(ERROR) << "ContextManager is not initialized.";
@@ -217,7 +228,7 @@ Status AscendDirectTransport::submitTransfer(
             std::to_string(batch_id));
     }
 
-    const int32_t current_engine_id = ResolveCurrentEngineId(dummy_real_mode_);
+    const int32_t current_engine_id = ResolveCurrentEngineId(agent_mode_);
     if (current_engine_id < 0) {
         return Status::Context("aclrtGetDevice failed");
     }
@@ -245,7 +256,7 @@ Status AscendDirectTransport::submitTransfer(
 
 Status AscendDirectTransport::submitTransferTask(
     const std::vector<TransferTask *> &task_list) {
-    const int32_t current_engine_id = ResolveCurrentEngineId(dummy_real_mode_);
+    const int32_t current_engine_id = ResolveCurrentEngineId(agent_mode_);
     if (current_engine_id < 0) {
         return Status::Context("aclrtGetDevice failed");
     }
@@ -349,7 +360,7 @@ int AscendDirectTransport::registerLocalMemory(void *addr, size_t length,
 
     const int register_ret = transfer_executor_->registerMem(
         addr, length, mem_type, transfer_executor_->getUseBufferPool(),
-        roce_mode_, dummy_real_mode_);
+        roce_mode_, agent_mode_);
     if (register_ret == 0) {
         return 0;
     }

--- a/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/transfer_executor_base.cpp
+++ b/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/transfer_executor_base.cpp
@@ -191,15 +191,24 @@ int TransferExecutorBase::initEngines() {
         }
     }
 
-    if (globalConfig().ascend_use_fabric_mem) {
+    if (params_.use_fabric_mem) {
         options["EnableUseFabricMem"] = "1";
         LOG(INFO) << "Fabric mem mode is enabled.";
     }
 
+    const char* store_te =
+        globalConfig().ascend_store_te_init ? "true" : "false";
     char* global_resource_config = std::getenv("ASCEND_GLOBAL_RESOURCE_CONFIG");
-    if (global_resource_config) {
-        options["GlobalResourceConfig"] = global_resource_config;
-        LOG(INFO) << "Set GlobalResourceConfig to:" << global_resource_config;
+    std::string resolved_resource_config =
+        ResolveAscendGlobalResourceConfig(global_resource_config);
+    if (!resolved_resource_config.empty()) {
+        options["GlobalResourceConfig"] = resolved_resource_config.c_str();
+        LOG(INFO) << "[AscendTE] init adxl, te is created for store="
+                  << store_te
+                  << ", GlobalResourceConfig: " << resolved_resource_config;
+    } else {
+        LOG(INFO) << "[AscendTE] init adxl, te is created for store="
+                  << store_te << ", GlobalResourceConfig unset.";
     }
 
     if (params_.use_async_transfer) {
@@ -400,7 +409,7 @@ void TransferExecutorBase::rollbackRegisteredMem(
 int TransferExecutorBase::registerMem(void* addr, size_t length,
                                       adxl::MemType mem_type,
                                       bool use_buffer_pool, bool roce_mode,
-                                      bool dummy_real_mode) {
+                                      bool agent_mode) {
     if (mem_type == adxl::MEM_HOST && use_buffer_pool) {
         LOG(INFO) << "Ignore register host mem:" << addr
                   << " when buffer pool is enabled.";
@@ -422,7 +431,7 @@ int TransferExecutorBase::registerMem(void* addr, size_t length,
 
     std::vector<size_t> engine_indices;
     bool register_to_all =
-        (roce_mode && dummy_real_mode && ascend_is_store_memory(addr, length));
+        (roce_mode && agent_mode && ascend_is_store_memory(addr, length));
     if (register_to_all || adxl_engines_.size() == 1U) {
         engine_indices.resize(adxl_engines_.size());
         std::iota(engine_indices.begin(), engine_indices.end(), 0);
@@ -531,7 +540,7 @@ std::string TransferExecutorBase::resolveTargetAdxlEngineName(
     if (endpoints.empty()) return {};
 
     // Standard dummy-real RoCE: same-index pairing (unchanged)
-    if (params_.dummy_real_mode && params_.roce_mode) {
+    if (params_.agent_mode && params_.roce_mode) {
         if (engine_idx >= endpoints.size()) return {};
         return endpoints[engine_idx];
     }
@@ -539,7 +548,7 @@ std::string TransferExecutorBase::resolveTargetAdxlEngineName(
     // Standalone mode: non-dummy-real thin client without fabric mem.
     // RoCE/HCCS all use phy_dev mapping; same-host offset +1 avoids
     // connecting to the same physical device across processes.
-    if (!params_.dummy_real_mode && !globalConfig().ascend_use_fabric_mem) {
+    if (!params_.agent_mode && !params_.use_fabric_mem) {
         aclrtContext saved_ctx = nullptr;
         if (aclrtGetCurrentContext(&saved_ctx) != ACL_ERROR_NONE) {
             LOG(ERROR) << "aclrtGetCurrentContext failed in standalone resolve";
@@ -604,7 +613,7 @@ void TransferExecutorBase::processSliceList(
         return;
     }
     size_t local_engine_idx =
-        params_.dummy_real_mode ? slice_list[0]->ascend_direct.engine_id : 0;
+        params_.agent_mode ? slice_list[0]->ascend_direct.engine_id : 0;
     VLOG(1) << "processSliceList for dev:" << local_engine_idx;
     auto local_segment_desc = metadata_->getSegmentDescByID(LOCAL_SEGMENT_ID);
     if (!local_segment_desc ||
@@ -649,7 +658,7 @@ void TransferExecutorBase::processSliceList(
             return;
         }
 
-        auto need_local_copy = !globalConfig().ascend_use_fabric_mem &&
+        auto need_local_copy = !params_.use_fabric_mem &&
                                (target_adxl_engine_name == local_engine_name);
         if (need_local_copy && local_copy_engine_) {
             auto start = std::chrono::steady_clock::now();

--- a/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/utils.cpp
+++ b/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/utils.cpp
@@ -36,6 +36,13 @@ constexpr int32_t kMaxGenPortAttempts = 500;
 constexpr const char* kProtocolDescFlatKey =
     "comm_resource_config.protocol_desc";
 constexpr const char* kRocePrefix = "roce:";
+constexpr const char* kStoreConfigKey = "store";
+
+std::string SerializeCompactJson(const Json::Value& value) {
+    Json::StreamWriterBuilder writer;
+    writer["indentation"] = "";
+    return Json::writeString(writer, value);
+}
 
 bool IsRoceProtocolDesc(const std::string& desc) {
     return desc.size() >= std::strlen(kRocePrefix) &&
@@ -96,20 +103,58 @@ bool HasRoceProtocolDescInGlobalResourceConfig(const char* config_str) {
     return ProtocolDescValueContainsRoce(*protocol_desc);
 }
 
+std::string ResolveAscendGlobalResourceConfig(const char* config_str) {
+    if (config_str == nullptr || config_str[0] == '\0') {
+        return std::string();
+    }
+    Json::CharReaderBuilder builder;
+    builder["collectComments"] = false;
+    Json::Value root;
+    std::string errs;
+    const std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
+    if (!reader->parse(config_str, config_str + std::strlen(config_str), &root,
+                       &errs)) {
+        // Not valid JSON: leave it untouched and let adxl reject/handle it.
+        return std::string(config_str);
+    }
+    if (!root.isObject() || !root.isMember(kStoreConfigKey)) {
+        // Plain (legacy) config without a "store" override: pass verbatim.
+        return std::string(config_str);
+    }
+    if (globalConfig().ascend_store_te_init) {
+        return SerializeCompactJson(root[kStoreConfigKey]);
+    }
+    Json::Value normal = root;
+    normal.removeMember(kStoreConfigKey);
+    return SerializeCompactJson(normal);
+}
+
 bool IsRoceModeEnabled() {
+    const char* store_te =
+        globalConfig().ascend_store_te_init ? "true" : "false";
     char* roce_enable_str = std::getenv("HCCL_INTRA_ROCE_ENABLE");
+    LOG(INFO) << "[AscendTE] resolving link config, te is created for store="
+              << store_te << ", HCCL_INTRA_ROCE_ENABLE="
+              << (roce_enable_str ? roce_enable_str : "(unset)");
     if (roce_enable_str) {
         const auto roce_enable = parseFromString<int32_t>(roce_enable_str);
         if (roce_enable.has_value() && roce_enable.value() == 1) {
+            LOG(INFO) << "[AscendTE] roce mode enabled via "
+                         "HCCL_INTRA_ROCE_ENABLE.";
             return true;
         }
         LOG(WARNING) << "HCCL_INTRA_ROCE_ENABLE is not valid, value:"
                      << roce_enable_str;
     }
     char* global_resource_config = std::getenv("ASCEND_GLOBAL_RESOURCE_CONFIG");
-    if (HasRoceProtocolDescInGlobalResourceConfig(global_resource_config)) {
-        LOG(INFO) << "Roce mode is enabled via ASCEND_GLOBAL_RESOURCE_CONFIG "
-                     "protocol_desc.";
+    std::string resolved =
+        ResolveAscendGlobalResourceConfig(global_resource_config);
+    LOG(INFO) << "[AscendTE] resolved ASCEND_GLOBAL_RESOURCE_CONFIG "
+                 "(protocol_desc): "
+              << (resolved.empty() ? "(none)" : resolved);
+    if (HasRoceProtocolDescInGlobalResourceConfig(resolved.c_str())) {
+        LOG(INFO) << "[AscendTE] roce mode enabled via "
+                     "ASCEND_GLOBAL_RESOURCE_CONFIG protocol_desc.";
         return true;
     }
     return false;

--- a/mooncake-transfer-engine/tests/ascend_direct_transport_test.cpp
+++ b/mooncake-transfer-engine/tests/ascend_direct_transport_test.cpp
@@ -1840,7 +1840,10 @@ TEST_F(AscendDirectTransportTest, Standalone_SameHostOffset_WrapsAround) {
 
 TEST_F(AscendDirectTransportTest,
        Standalone_FabricMem_SameHostUsesFrontEndpoint) {
+    // Fabric mem is a Store-TE feature, so the TE must be store-init for the
+    // transport to capture use_fabric_mem_=true.
     globalConfig().ascend_agent_mode = false;
+    globalConfig().ascend_store_te_init = true;
     globalConfig().ascend_use_fabric_mem = true;
     unsetenv("HCCL_INTRA_ROCE_ENABLE");
     constexpr int kDeviceCount = 4;
@@ -1864,6 +1867,45 @@ TEST_F(AscendDirectTransportTest,
     EXPECT_FALSE(result.failed);
     EXPECT_EQ(adxl_mock::get_last_connect_target(), "127.0.0.1:8000")
         << "Fabric-mem standalone should not apply same-host offset";
+
+    globalConfig().ascend_use_fabric_mem = false;
+    globalConfig().ascend_store_te_init = false;
+}
+
+// A non-Store (e.g. P2P/HCCS) TE must NOT inherit a Store TE's fabric flag that
+// leaked into the process-global config: with ascend_use_fabric_mem=true but
+// ascend_store_te_init=false, the transport must capture use_fabric_mem_=false
+// and behave like a normal standalone TE (same-host offset +1), not the fabric
+// path (front endpoint).
+TEST_F(AscendDirectTransportTest,
+       Standalone_FabricFlagWithoutStoreTe_DoesNotInheritFabric) {
+    globalConfig().ascend_agent_mode = false;
+    globalConfig().ascend_store_te_init = false;
+    globalConfig().ascend_use_fabric_mem = true;
+    unsetenv("HCCL_INTRA_ROCE_ENABLE");
+    constexpr int kDeviceCount = 4;
+    mock_acl::set_device_count(kDeviceCount);
+    g_device_id = 1;
+    auto transport = createTransport();
+    ASSERT_NE(transport, nullptr);
+    ASSERT_EQ(transport->registerLocalMemory(test_buffer_src_, kRegisterMemSize,
+                                             "cpu:0", true, true),
+              0);
+
+    std::vector<std::string> endpoints = {"127.0.0.1:9000", "127.0.0.1:9100",
+                                          "127.0.0.1:9200", "127.0.0.1:9300"};
+    addMultiEndpointRemoteSegment(transport->meta(), 1, "p2p_no_fabric",
+                                  "127.0.0.1", endpoints);
+
+    initTestData(kTransferBufSize);
+    auto result = runRemoteTransfer(transport.get(), test_buffer_src_, 1,
+                                    0x10000, kTransferBufSize);
+    ASSERT_TRUE(result.finished);
+    EXPECT_FALSE(result.failed);
+    // phy_dev=1, same host, fabric NOT inherited -> offset +1 -> endpoints[2]
+    EXPECT_EQ(adxl_mock::get_last_connect_target(), "127.0.0.1:9200")
+        << "Non-Store TE must not inherit fabric; should apply same-host "
+           "offset";
 
     globalConfig().ascend_use_fabric_mem = false;
 }
@@ -1913,6 +1955,93 @@ TEST(RoceModeDetectionTest, IsRoceModeEnabled_FromHcclEnv) {
     setenv("HCCL_INTRA_ROCE_ENABLE", "1", 1);
     EXPECT_TRUE(IsRoceModeEnabled());
     unsetenv("HCCL_INTRA_ROCE_ENABLE");
+}
+
+// -----------------------------------------------------------------------------
+// Store vs P2P protocol split via a single ASCEND_GLOBAL_RESOURCE_CONFIG:
+// top-level = default (P2P, e.g. HCCS), optional "store" sub-object overrides
+// it for a Store-init TE (e.g. RoCE). Resolution is gated on
+// ascend_store_te_init.
+// -----------------------------------------------------------------------------
+
+namespace {
+// Top-level default = HCCS (P2P), "store" override = RoCE (Store).
+constexpr const char* kDualProtocolConfig =
+    R"({"comm_resource_config":{"protocol_desc":"hccs:device"},)"
+    R"("store":{"comm_resource_config":{"protocol_desc":"roce:device"}}})";
+
+struct StoreTeInitScope {
+    explicit StoreTeInitScope(bool v) {
+        globalConfig().ascend_store_te_init = v;
+    }
+    ~StoreTeInitScope() { globalConfig().ascend_store_te_init = false; }
+};
+}  // namespace
+
+TEST(StoreResourceConfigSplitTest, NoStoreKey_PassthroughVerbatimBothRoles) {
+    const char* cfg =
+        R"({"comm_resource_config":{"protocol_desc":"hccs:device"}})";
+    {
+        StoreTeInitScope store(true);
+        EXPECT_EQ(ResolveAscendGlobalResourceConfig(cfg), std::string(cfg));
+    }
+    {
+        StoreTeInitScope store(false);
+        EXPECT_EQ(ResolveAscendGlobalResourceConfig(cfg), std::string(cfg));
+    }
+}
+
+TEST(StoreResourceConfigSplitTest, EmptyOrNull_ReturnsEmpty) {
+    StoreTeInitScope store(true);
+    EXPECT_TRUE(ResolveAscendGlobalResourceConfig(nullptr).empty());
+    EXPECT_TRUE(ResolveAscendGlobalResourceConfig("").empty());
+}
+
+TEST(StoreResourceConfigSplitTest, StoreRole_SelectsStoreSubtreeRoce) {
+    StoreTeInitScope store(true);
+    std::string resolved =
+        ResolveAscendGlobalResourceConfig(kDualProtocolConfig);
+    // Store TE gets the "store" subtree (RoCE), with the "store" key stripped.
+    EXPECT_TRUE(HasRoceProtocolDescInGlobalResourceConfig(resolved.c_str()));
+    EXPECT_EQ(resolved.find("hccs"), std::string::npos);
+    EXPECT_EQ(resolved.find("\"store\""), std::string::npos);
+}
+
+TEST(StoreResourceConfigSplitTest, DefaultRole_StripsStoreKeyHccs) {
+    StoreTeInitScope store(false);
+    std::string resolved =
+        ResolveAscendGlobalResourceConfig(kDualProtocolConfig);
+    // P2P/default TE gets the top-level (HCCS) with the "store" key removed.
+    EXPECT_FALSE(HasRoceProtocolDescInGlobalResourceConfig(resolved.c_str()));
+    EXPECT_NE(resolved.find("hccs"), std::string::npos);
+    EXPECT_EQ(resolved.find("roce"), std::string::npos);
+    EXPECT_EQ(resolved.find("\"store\""), std::string::npos);
+}
+
+TEST(StoreResourceConfigSplitTest,
+     StoreRoleMissingStoreKey_FallsBackToDefault) {
+    const char* cfg =
+        R"({"comm_resource_config":{"protocol_desc":"hccs:device"}})";
+    StoreTeInitScope store(true);
+    // No "store" key -> store TE falls back to the (verbatim) default config.
+    EXPECT_EQ(ResolveAscendGlobalResourceConfig(cfg), std::string(cfg));
+    EXPECT_FALSE(HasRoceProtocolDescInGlobalResourceConfig(
+        ResolveAscendGlobalResourceConfig(cfg).c_str()));
+}
+
+// The headline case: one env var, Store TE -> RoCE, P2P TE -> HCCS.
+TEST(StoreResourceConfigSplitTest, IsRoceModeEnabled_StoreRoceP2pHccs) {
+    unsetenv("HCCL_INTRA_ROCE_ENABLE");
+    setenv("ASCEND_GLOBAL_RESOURCE_CONFIG", kDualProtocolConfig, 1);
+    {
+        StoreTeInitScope store(true);
+        EXPECT_TRUE(IsRoceModeEnabled()) << "Store TE should resolve to RoCE";
+    }
+    {
+        StoreTeInitScope store(false);
+        EXPECT_FALSE(IsRoceModeEnabled()) << "P2P TE should resolve to HCCS";
+    }
+    unsetenv("ASCEND_GLOBAL_RESOURCE_CONFIG");
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
## Description

Enable Transfer Engine (TE) instances that co-exist in the same process to
select **different Ascend link protocols by role**, for the MultiConnector
scenario. A Store-initialized TE and a direct/P2P TE can now run different
links from a single configuration — e.g. Store=RoCE/D2H, P2P=HCCS/D2D.

Key changes (Ascend-only; GPU/RDMA/TCP paths are untouched):

- **Role identification**: add a transient `GlobalConfig::ascend_store_te_init`
  flag, set/reset via an RAII guard in `Client::InitTransferEngine` only when
  `protocol == "ascend"`. The flag is live only while the ascend transport is
  installed and is reset on every exit path.
- **Configurable protocols**: extend `ASCEND_GLOBAL_RESOURCE_CONFIG` so the
  top-level object is the default (P2P) config passed through to ADXL, with an
  optional `"store"` sub-object overriding it for Store TEs.
  `ResolveAscendGlobalResourceConfig()` resolves the role-specific subtree
  (stripping the `store` key for the default role, falling back to the default
  when no `store` key is present); `IsRoceModeEnabled()` and `initEngines()`
  consume the resolved string. Existing single-TE deployments (no `store` key)
  pass through verbatim, so behavior is unchanged.
- **Fabric memory isolation**: the transport captures
  `use_fabric_mem_ = ascend_use_fabric_mem && ascend_store_te_init`, so a
  non-Store TE never inherits a Store TE's fabric flag left in the process
  global. `ascend_free_memory` now routes by per-allocation record
  (`g_vmm_alloc_records`) instead of the global flag, avoiding mis-routed frees
  when the global toggles between alloc and free time.
- **Logging**: add `[AscendTE]` INFO logs covering link-config resolution,
  `HCCL_INTRA_ROCE_ENABLE`, the resolved `protocol_desc`, and
  `te is created for store=true|false`.
- **Clarity**: rename the internal `dummy_real_mode_` to `agent_mode_` and add
  a clearer "launched as standalone real client" log.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

- `./scripts/code_format.sh -b upstream/main` — passed
- `ascend_direct_transport_test` (58 tests, incl. `StoreResourceConfigSplitTest`
  for the role-aware protocol split and `Standalone_Fabric*` for fabric gating)
  — passed
- Ascend Mooncake Store real workload — passed

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.