### PR TITLE
fix(store): don't fail bundle cleanup when per-key remove retry succeeds

### DIFF
--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -1263,7 +1263,6 @@ def _is_duplicate_buffer_registration(status: Any) -> bool:
 
 
 def _cleanup_keys(store: BundleStore, keys: Sequence[str], strict: bool) -> None:
-    errors = []
     pending_keys = list(dict.fromkeys(keys))
     batch_remove = getattr(store, "batch_remove", None)
     if callable(batch_remove) and pending_keys:
@@ -1283,7 +1282,6 @@ def _cleanup_keys(store: BundleStore, keys: Sequence[str], strict: bool) -> None
             ]
             if not failed_results:
                 return
-            errors.extend(failed_results)
             pending_keys = [key for key, _status in failed_results]
         except Exception:
             if strict:
@@ -1301,9 +1299,7 @@ def _cleanup_keys(store: BundleStore, keys: Sequence[str], strict: bool) -> None
             continue
         if status not in (None, 0, MISSING_OBJECT_ERROR):
             retry_errors.append((key, status))
-    if retry_errors:
-        errors = retry_errors
-    if errors and strict:
+    if retry_errors and strict:
         raise RuntimeError(
-            f"failed to remove {len(errors)} Mooncake keys: {errors[:3]}"
+            f"failed to remove {len(retry_errors)} Mooncake keys: {retry_errors[:3]}"
         )

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -236,6 +236,25 @@ class ForceTrackingStore(InMemoryStore):
         return super().batch_remove(keys, force)
 
 
+class TransientBatchRemoveStore(InMemoryStore):
+    """batch_remove reports a transient failure for one key without deleting it.
+
+    The inherited per-key remove() retry then succeeds and deletes the key, so
+    cleanup should end with no outstanding error.
+    """
+
+    def batch_remove(self, keys: list[str], force: bool = False) -> list[int]:
+        self.batch_remove_calls += 1
+        results: list[int] = []
+        for index, key in enumerate(keys):
+            if index == 0:
+                results.append(-1)  # transient failure, key left in place
+            else:
+                self.remove(key, force)
+                results.append(0)
+        return results
+
+
 class StrictRegisterStore(InMemoryStore):
     def register_buffer(self, buffer_ptr: int, size: int) -> int:
         if buffer_ptr in self.registered:
@@ -578,6 +597,16 @@ def test_bundle_remove_uses_force_batch_remove_when_available() -> None:
 
     assert store.batch_remove_forces == [True]
     assert store.objects == {}
+
+
+def test_bundle_remove_recovers_after_transient_batch_failure() -> None:
+    store, transfer = make_transfer(TransientBatchRemoveStore())
+
+    ref = transfer.put_bundle(b"meta", {"a": b"x", "b": b"y", "c": b"z"})
+    transfer.remove_bundle(ref)
+
+    assert store.objects == {}
+    assert store.batch_remove_calls == 1
 
 
 def test_bundle_concurrent_put_and_read_spec_full_read() -> None:


### PR DESCRIPTION
## Description

`_cleanup_keys` in `mooncake-wheel/mooncake/structured_object_store.py` removes a bundle's payload and manifest keys. It first tries `batch_remove`, then falls back to a per-key `remove()` retry for any keys the batch call reported as failed.

The bug: when `batch_remove` reports a transient failure for a key (non-zero status, key left in place) but the per-key `remove()` retry then succeeds, the function still raises. The batch failures were accumulated into `errors` up front, and `errors` was only overwritten by the retry results when `retry_errors` was non-empty:

```python
if retry_errors:
    errors = retry_errors
if errors and strict:
    raise RuntimeError(...)
```

So a successful retry left the stale batch failure in `errors`, and `remove_bundle` (which calls with `strict=True`) raised `RuntimeError: failed to remove N Mooncake keys` even though every key was gone.

## Fix

The retry pass runs over exactly the keys the batch pass failed on (batch-succeeded keys are already deleted and never retried), so its result set is the authoritative final error set. Use `retry_errors` directly and drop the premature `errors` accumulation. Genuine retry failures still raise as before.

## Module

- [x] Python Wheel (`mooncake-wheel`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

Added `test_bundle_remove_recovers_after_transient_batch_failure`: a store whose `batch_remove` flags one key as a transient failure without deleting it, while the inherited `remove()` retry succeeds. It fails on current `main` (the `RuntimeError` above) and passes with the fix.

**Test commands:**
```bash
cd mooncake-wheel && PYTHONPATH=. python -m pytest tests/test_structured_object_store.py -q
```

**Test results:**
- [x] Unit tests pass (30 passed, including the new test; `ruff check` clean on both files)

Did not run native/CUDA or integration suites; this change is pure Python on the cleanup path.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests to prove my changes are effective

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

Used Claude Code to help locate the defect and draft the test. I reviewed the logic, ran the tests, and stand behind the change.