### PR TITLE
[TENT] Fix stale getTransferStatus in nvlink/mnnvl/ascend transports

### DIFF
--- a/mooncake-transfer-engine/tent/src/transport/ascend/ascend_direct_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/ascend/ascend_direct_transport.cpp
@@ -380,9 +380,9 @@ Status AscendDirectTransport::getTransferStatus(SubBatchRef batch, int task_id,
         return Status::InvalidArgument("Invalid task id" LOC_MARK);
     }
     auto &task = hixl_batch->task_list[task_id];
-    status = TransferStatus{task.status_word, task.transferred_bytes};
     if (task.status_word == TransferStatusEnum::PENDING) {
         if (task.req_handle == nullptr) {
+            status = TransferStatus{task.status_word, task.transferred_bytes};
             return Status::OK();
         }
         std::lock_guard<std::mutex> lock(req_mutex_);
@@ -396,6 +396,7 @@ Status AscendDirectTransport::getTransferStatus(SubBatchRef batch, int task_id,
             if (--req_map_[task.req_handle].second == 0) {
                 req_map_.erase(task.req_handle);
             }
+            status = TransferStatus{task.status_word, task.transferred_bytes};
             return Status::OK();
         }
         uint64_t current_ts = getCurrentTimeInNano();
@@ -406,6 +407,7 @@ Status AscendDirectTransport::getTransferStatus(SubBatchRef batch, int task_id,
                 req_map_[task.req_handle] =
                     std::make_pair(task.status_word, task.batch_size - 1);
             }
+            status = TransferStatus{task.status_word, task.transferred_bytes};
             return Status::OK();
         }
         hixl::TransferStatus xfer_status;
@@ -415,6 +417,7 @@ Status AscendDirectTransport::getTransferStatus(SubBatchRef batch, int task_id,
             xfer_status = hixl::TransferStatus::FAILED;
         }
         if (xfer_status == hixl::TransferStatus::WAITING) {
+            status = TransferStatus{task.status_word, task.transferred_bytes};
             return Status::OK();
         }
         if (xfer_status == hixl::TransferStatus::COMPLETED) {
@@ -430,6 +433,9 @@ Status AscendDirectTransport::getTransferStatus(SubBatchRef batch, int task_id,
         req_map_[task.req_handle] =
             std::make_pair(task.status_word, task.batch_size - 1);
     }
+    // Read status AFTER the poll so a just-observed completion/failure is
+    // reported on this call rather than one poll cycle late.
+    status = TransferStatus{task.status_word, task.transferred_bytes};
     return Status::OK();
 }
 

--- a/mooncake-transfer-engine/tent/src/transport/mnnvl/mnnvl_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/mnnvl/mnnvl_transport.cpp
@@ -272,7 +272,6 @@ Status MnnvlTransport::getTransferStatus(SubBatchRef batch, int task_id,
         return Status::InvalidArgument("Invalid task id" LOC_MARK);
     }
     auto &task = mnnvl_batch->task_list[task_id];
-    status = TransferStatus{task.status_word, task.transferred_bytes};
     if (task.status_word == TransferStatusEnum::PENDING) {
         auto err = cudaEventQuery(task.completion_event);
         if (err == cudaSuccess) {
@@ -282,6 +281,9 @@ Status MnnvlTransport::getTransferStatus(SubBatchRef batch, int task_id,
             task.status_word = TransferStatusEnum::FAILED;
         }
     }
+    // Read status AFTER the poll so a just-observed completion/failure is
+    // reported on this call rather than one poll cycle late.
+    status = TransferStatus{task.status_word, task.transferred_bytes};
     return Status::OK();
 }
 

--- a/mooncake-transfer-engine/tent/src/transport/nvlink/nvlink_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/nvlink/nvlink_transport.cpp
@@ -233,7 +233,6 @@ Status NVLinkTransport::getTransferStatus(SubBatchRef batch, int task_id,
         return Status::InvalidArgument("Invalid task id" LOC_MARK);
     }
     auto& task = shm_batch->task_list[task_id];
-    status = TransferStatus{task.status_word, task.transferred_bytes};
     if (task.status_word == TransferStatusEnum::PENDING) {
         auto err = cudaEventQuery(task.completion_event);
         if (err == cudaSuccess) {
@@ -243,6 +242,9 @@ Status NVLinkTransport::getTransferStatus(SubBatchRef batch, int task_id,
             task.status_word = TransferStatusEnum::FAILED;
         }
     }
+    // Read status AFTER the poll so a just-observed completion/failure is
+    // reported on this call rather than one poll cycle late.
+    status = TransferStatus{task.status_word, task.transferred_bytes};
     return Status::OK();
 }
 


### PR DESCRIPTION
## Description

`getTransferStatus` in the NVLink, MNNVL, and AscendDirect TENT transports snapshots the output `status` **before** polling the hardware (`cudaEventQuery` / `hixl GetTransferStatus`). When the poll transitions the task to COMPLETED/FAILED/TIMEOUT, only the `task` is updated — the output `status` keeps the pre-poll PENDING value. The caller therefore sees the completion **one poll cycle late**.

This is the same class of bug already fixed for the io_uring/gds transports. The fix moves the `status = TransferStatus{...}` read to **after** the poll on every return path:
- nvlink / mnnvl: single linear path — one move.
- ascend: 5 OK-return paths (req_handle==nullptr, req_map hit, timeout, WAITING, terminal fallthrough); each now refreshes `status` from `task` before returning. The bad-`task_id` `InvalidArgument` return (before `task` is bound) intentionally leaves `status` untouched, since callers must not read an out-param on a non-OK Status.

No behavior change other than the timing fix. `transferred_bytes` semantics are unchanged (set only on COMPLETED, as before; callers gate on `status.s`).

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

- Verified statically: every return path was enumerated and confirmed to refresh `status` from the (possibly just-updated) `task`; the only path that does not is the pre-`task` `InvalidArgument` error return, which is correct.
- **Not** validated on hardware — I do not have NVLink / MNNVL / Ascend 910B devices locally, so this is a static/correctness review rather than an end-to-end run. CI build (with the relevant `USE_*` flags) validates compilation; a reviewer with the hardware can confirm the timing behavior.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have added tests (these paths require GPU/NPU hardware to exercise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)