### PR TITLE
[TENT] Fix CUDA event leak in nvlink/mnnvl transports

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/transport/mnnvl/mnnvl_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/mnnvl/mnnvl_transport.h
@@ -23,6 +23,7 @@
 #include <queue>
 #include <string>
 #include <unordered_set>
+#include <vector>
 
 #include "tent/runtime/control_plane.h"
 #include "tent/runtime/transport.h"
@@ -45,6 +46,9 @@ struct MnnvlSubBatch : public Transport::SubBatch {
     size_t max_size;
     CUDAStreamHandle sync_stream;
     CUDAStreamHandle async_stream;
+    // Completion events created in startTransfer (one per submit). Owned here
+    // and destroyed in freeSubBatch so they are not leaked.
+    std::vector<cudaEvent_t> completion_events;
     virtual size_t size() const { return task_list.size(); }
 };
 

--- a/mooncake-transfer-engine/tent/include/tent/transport/mnnvl/mnnvl_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/mnnvl/mnnvl_transport.h
@@ -46,9 +46,13 @@ struct MnnvlSubBatch : public Transport::SubBatch {
     size_t max_size;
     CUDAStreamHandle sync_stream;
     CUDAStreamHandle async_stream;
-    // Completion events created in startTransfer (one per submit). Owned here
-    // and destroyed in freeSubBatch so they are not leaked.
+    // Completion events created in startTransfer (one per submit). Destroyed by
+    // the destructor (RAII); Slab<T>::deallocate() invokes ~MnnvlSubBatch()
+    // before reusing the storage, so this runs on every free.
     std::vector<cudaEvent_t> completion_events;
+    ~MnnvlSubBatch() {
+        for (auto event : completion_events) cudaEventDestroy(event);
+    }
     virtual size_t size() const { return task_list.size(); }
 };
 

--- a/mooncake-transfer-engine/tent/include/tent/transport/nvlink/nvlink_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/nvlink/nvlink_transport.h
@@ -49,9 +49,13 @@ struct NVLinkSubBatch : public Transport::SubBatch {
     size_t max_size;
     CUDAStreamHandle sync_stream;
     CUDAStreamHandle async_stream;
-    // Completion events created in startTransfer (one per submit). Owned here
-    // and destroyed in freeSubBatch so they are not leaked.
+    // Completion events created in startTransfer (one per submit). Destroyed by
+    // the destructor (RAII); Slab<T>::deallocate() invokes ~NVLinkSubBatch()
+    // before reusing the storage, so this runs on every free.
     std::vector<cudaEvent_t> completion_events;
+    ~NVLinkSubBatch() {
+        for (auto event : completion_events) cudaEventDestroy(event);
+    }
     virtual size_t size() const { return task_list.size(); }
 };
 

--- a/mooncake-transfer-engine/tent/include/tent/transport/nvlink/nvlink_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/nvlink/nvlink_transport.h
@@ -21,6 +21,7 @@
 #include <queue>
 #include <string>
 #include <unordered_set>
+#include <vector>
 
 #include <cuda.h>
 #include <cuda_runtime.h>
@@ -48,6 +49,9 @@ struct NVLinkSubBatch : public Transport::SubBatch {
     size_t max_size;
     CUDAStreamHandle sync_stream;
     CUDAStreamHandle async_stream;
+    // Completion events created in startTransfer (one per submit). Owned here
+    // and destroyed in freeSubBatch so they are not leaked.
+    std::vector<cudaEvent_t> completion_events;
     virtual size_t size() const { return task_list.size(); }
 };
 

--- a/mooncake-transfer-engine/tent/src/transport/mnnvl/mnnvl_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/mnnvl/mnnvl_transport.cpp
@@ -154,7 +154,11 @@ Status MnnvlTransport::freeSubBatch(SubBatchRef &batch) {
     auto mnnvl_batch = dynamic_cast<MnnvlSubBatch *>(batch);
     if (!mnnvl_batch)
         return Status::InvalidArgument("Invalid MNNVL sub-batch" LOC_MARK);
-    // CHECK_CUDA(cudaStreamDestroy(mnnvl_batch->stream));
+    // Destroy completion events created in startTransfer (each pushed exactly
+    // once, so no double-destroy). Streams are pool-managed and not destroyed.
+    for (auto event : mnnvl_batch->completion_events) {
+        cudaEventDestroy(event);
+    }
     Slab<MnnvlSubBatch>::Get().deallocate(mnnvl_batch);
     batch = nullptr;
     return Status::OK();
@@ -260,8 +264,15 @@ void MnnvlTransport::startTransfer(std::vector<MnnvlTask *> &tasks,
     }
 
     cudaEvent_t event;
-    cudaEventCreateWithFlags(&event, cudaEventDisableTiming);
+    auto event_err = cudaEventCreateWithFlags(&event, cudaEventDisableTiming);
+    if (event_err != cudaSuccess) {
+        LOG(ERROR) << "MnnvlTransport: cudaEventCreateWithFlags failed: "
+                   << cudaGetErrorString(event_err);
+        for (auto *task : tasks) task->status_word = TransferStatusEnum::FAILED;
+        return;
+    }
     cudaEventRecord(event, batch->async_stream.get());
+    batch->completion_events.push_back(event);
     for (auto *task : tasks) task->completion_event = event;
 }
 

--- a/mooncake-transfer-engine/tent/src/transport/mnnvl/mnnvl_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/mnnvl/mnnvl_transport.cpp
@@ -154,11 +154,9 @@ Status MnnvlTransport::freeSubBatch(SubBatchRef &batch) {
     auto mnnvl_batch = dynamic_cast<MnnvlSubBatch *>(batch);
     if (!mnnvl_batch)
         return Status::InvalidArgument("Invalid MNNVL sub-batch" LOC_MARK);
-    // Destroy completion events created in startTransfer (each pushed exactly
-    // once, so no double-destroy). Streams are pool-managed and not destroyed.
-    for (auto event : mnnvl_batch->completion_events) {
-        cudaEventDestroy(event);
-    }
+    // Completion events are destroyed by ~MnnvlSubBatch(), which Slab's
+    // deallocate() invokes before returning the storage. Streams are
+    // pool-managed and not destroyed here.
     Slab<MnnvlSubBatch>::Get().deallocate(mnnvl_batch);
     batch = nullptr;
     return Status::OK();
@@ -271,7 +269,14 @@ void MnnvlTransport::startTransfer(std::vector<MnnvlTask *> &tasks,
         for (auto *task : tasks) task->status_word = TransferStatusEnum::FAILED;
         return;
     }
-    cudaEventRecord(event, batch->async_stream.get());
+    auto record_err = cudaEventRecord(event, batch->async_stream.get());
+    if (record_err != cudaSuccess) {
+        LOG(ERROR) << "MnnvlTransport: cudaEventRecord failed: "
+                   << cudaGetErrorString(record_err);
+        cudaEventDestroy(event);
+        for (auto *task : tasks) task->status_word = TransferStatusEnum::FAILED;
+        return;
+    }
     batch->completion_events.push_back(event);
     for (auto *task : tasks) task->completion_event = event;
 }

--- a/mooncake-transfer-engine/tent/src/transport/nvlink/nvlink_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/nvlink/nvlink_transport.cpp
@@ -115,11 +115,9 @@ Status NVLinkTransport::freeSubBatch(SubBatchRef& batch) {
     auto shm_batch = dynamic_cast<NVLinkSubBatch*>(batch);
     if (!shm_batch)
         return Status::InvalidArgument("Invalid NVLink sub-batch" LOC_MARK);
-    // Destroy completion events created in startTransfer (each pushed exactly
-    // once, so no double-destroy). Streams are pool-managed and not destroyed.
-    for (auto event : shm_batch->completion_events) {
-        cudaEventDestroy(event);
-    }
+    // Completion events are destroyed by ~NVLinkSubBatch(), which Slab's
+    // deallocate() invokes before returning the storage. Streams are
+    // pool-managed and not destroyed here.
     Slab<NVLinkSubBatch>::Get().deallocate(shm_batch);
     batch = nullptr;
     return Status::OK();
@@ -232,7 +230,14 @@ void NVLinkTransport::startTransfer(std::vector<NVLinkTask*>& tasks,
         for (auto* task : tasks) task->status_word = TransferStatusEnum::FAILED;
         return;
     }
-    cudaEventRecord(event, batch->async_stream.get());
+    auto record_err = cudaEventRecord(event, batch->async_stream.get());
+    if (record_err != cudaSuccess) {
+        LOG(ERROR) << "NVLinkTransport: cudaEventRecord failed: "
+                   << cudaGetErrorString(record_err);
+        cudaEventDestroy(event);
+        for (auto* task : tasks) task->status_word = TransferStatusEnum::FAILED;
+        return;
+    }
     batch->completion_events.push_back(event);
     for (auto* task : tasks) task->completion_event = event;
 }

--- a/mooncake-transfer-engine/tent/src/transport/nvlink/nvlink_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/nvlink/nvlink_transport.cpp
@@ -115,7 +115,11 @@ Status NVLinkTransport::freeSubBatch(SubBatchRef& batch) {
     auto shm_batch = dynamic_cast<NVLinkSubBatch*>(batch);
     if (!shm_batch)
         return Status::InvalidArgument("Invalid NVLink sub-batch" LOC_MARK);
-    // CHECK_CUDA(cudaStreamDestroy(shm_batch->stream));
+    // Destroy completion events created in startTransfer (each pushed exactly
+    // once, so no double-destroy). Streams are pool-managed and not destroyed.
+    for (auto event : shm_batch->completion_events) {
+        cudaEventDestroy(event);
+    }
     Slab<NVLinkSubBatch>::Get().deallocate(shm_batch);
     batch = nullptr;
     return Status::OK();
@@ -221,8 +225,15 @@ void NVLinkTransport::startTransfer(std::vector<NVLinkTask*>& tasks,
     }
 
     cudaEvent_t event;
-    cudaEventCreateWithFlags(&event, cudaEventDisableTiming);
+    auto event_err = cudaEventCreateWithFlags(&event, cudaEventDisableTiming);
+    if (event_err != cudaSuccess) {
+        LOG(ERROR) << "NVLinkTransport: cudaEventCreateWithFlags failed: "
+                   << cudaGetErrorString(event_err);
+        for (auto* task : tasks) task->status_word = TransferStatusEnum::FAILED;
+        return;
+    }
     cudaEventRecord(event, batch->async_stream.get());
+    batch->completion_events.push_back(event);
     for (auto* task : tasks) task->completion_event = event;
 }
 


### PR DESCRIPTION
## Description

`startTransfer()` in the NVLink and MNNVL TENT transports creates a `cudaEvent` per submit (`cudaEventCreateWithFlags`) and assigns it to every task in that submit, but nothing ever calls `cudaEventDestroy` — so each submit leaks one event for the lifetime of the process. (`freeSubBatch` only Slab-deallocated the sub-batch; the streams are intentionally pool-managed, but the manually-created events had no owner.) Confirmed there is no `cudaEventDestroy` anywhere under `tent/`.

Fix:
- Add a SubBatch-level `std::vector<cudaEvent_t> completion_events`. `startTransfer` pushes the event there once per **successful** create.
- `freeSubBatch` destroys every event in that vector. Because `submitTransferTasks` can be called multiple times on one SubBatch, a SubBatch may own several distinct events — the vector frees all of them, each exactly once. The event is shared across a submit's tasks, so it is stored once (keyed by submit, not by task), which avoids the double-free a per-task destroy would cause.
- Also check the `cudaEventCreateWithFlags` return value: on failure, mark the tasks FAILED and return without recording/storing an uninitialized handle (previously the garbage handle was assigned to tasks and later polled).
- Added the explicit `#include <vector>` the two headers were relying on transitively.

This is a follow-up to the discussion on #2505 (the events were flagged there; that PR was scoped to the status-staleness fix).

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

- Verified statically: every created event is pushed exactly once and destroyed exactly once; multiple submits each add and free their event; the create-failure path stores no handle; events are destroyed before `Slab::deallocate`; `cudaEventDestroy` on an in-flight event is legal (driver defers reclamation).
- **Not** validated on hardware — I do not have NVLink / MNNVL devices locally. CI builds the relevant `USE_*` paths; a reviewer with the hardware can confirm at runtime.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have added tests (these paths require GPU hardware to exercise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)