### PR TITLE
[Store] Group BatchGetReplicaList metadata lookup by shard

### DIFF
--- a/mooncake-store/benchmarks/CMakeLists.txt
+++ b/mooncake-store/benchmarks/CMakeLists.txt
@@ -8,6 +8,11 @@ add_executable(master_bench master_bench.cpp)
 target_link_libraries(master_bench PRIVATE cachelib_memory_allocator
                                            mooncake_store)
 
+# Add BatchGetReplicaList latency benchmark executable
+add_executable(batch_get_replica_bench batch_get_replica_bench.cpp)
+target_link_libraries(batch_get_replica_bench PRIVATE cachelib_memory_allocator
+                                                       mooncake_store)
+
 # Add file interface benchmark executable
 add_executable(file_interface_bench file_interface_bench.cpp)
 target_link_libraries(file_interface_bench PRIVATE mooncake_store glog::glog)

--- a/mooncake-store/benchmarks/batch_get_replica_bench.cpp
+++ b/mooncake-store/benchmarks/batch_get_replica_bench.cpp
@@ -1,0 +1,717 @@
+// Copyright 2026 Alibaba Cloud and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <fstream>
+#include <future>
+#include <iomanip>
+#include <iostream>
+#include <latch>
+#include <limits>
+#include <numeric>
+#include <random>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <pthread.h>
+
+#include "gflags/gflags.h"
+#include "glog/logging.h"
+
+#include "master_client.h"
+
+static constexpr uint64_t KiB = 1024;
+static constexpr uint64_t MiB = 1024 * KiB;
+static constexpr uint64_t GiB = 1024 * MiB;
+static constexpr uintptr_t kSegmentBase = 0x100000000ULL;
+
+DEFINE_string(master_server, "127.0.0.1:50051", "Master server address");
+DEFINE_string(label, "run", "Label written to text and CSV output");
+DEFINE_string(csv_path, "", "Optional CSV output path");
+DEFINE_string(key_prefix, "batchget_bench", "Object key prefix");
+DEFINE_uint64(num_segments, 1, "Number of segments to mount");
+DEFINE_uint64(segment_size, 48 * GiB, "Size of each mounted segment");
+DEFINE_uint64(num_objects, 20 * 1000 * 1000,
+              "Number of objects to prefill and sample from");
+DEFINE_uint64(prefill_threads, 8, "Number of concurrent prefill threads");
+DEFINE_uint64(prefill_batch_size, 30000, "Batch size used by prefill writes");
+DEFINE_uint64(lookup_threads, 56,
+              "Number of concurrent BatchGetReplicaList threads");
+DEFINE_uint64(batch_size, 30000, "Keys per BatchGetReplicaList request");
+DEFINE_uint64(value_size, 2048, "Object value size used for master allocation");
+DEFINE_uint64(duration, 120, "Measured duration per cycle in seconds");
+DEFINE_uint64(cycles, 2, "Number of measured lookup cycles");
+DEFINE_uint64(requests_per_thread, 0,
+              "Fixed BatchGetReplicaList requests per lookup thread per "
+              "cycle. 0 uses duration-based cycles");
+DEFINE_uint64(lookup_interval_ms, 500,
+              "Sleep interval after each lookup request per thread");
+DEFINE_uint64(refill_threads, 0,
+              "Optional writer threads running during measured lookup");
+DEFINE_uint64(refill_batch_size, 30000,
+              "Batch size used by optional refill writer threads");
+DEFINE_uint64(refill_interval_ms, 0,
+              "Sleep interval after each refill write batch");
+DEFINE_uint64(random_seed, 1, "Base RNG seed for lookup threads");
+DEFINE_bool(skip_prefill, false,
+            "Skip prefill and assume keys already exist on the master");
+DEFINE_bool(log_progress, true, "Log prefill/refill progress");
+
+static inline void unset_cpu_affinity() {
+    cpu_set_t cpuset;
+    memset(&cpuset, -1, sizeof(cpuset));
+    pthread_setaffinity_np(pthread_self(), sizeof(cpuset), &cpuset);
+}
+
+class SegmentClient {
+   public:
+    SegmentClient(const std::string& name, const std::string& master_server,
+                  uintptr_t segment_base, uint64_t segment_size)
+        : master_client_(mooncake::generate_uuid()) {
+        auto ec = master_client_.Connect(master_server);
+        if (ec != mooncake::ErrorCode::OK) {
+            throw std::runtime_error("Cannot connect to master server at " +
+                                     master_server + ", ec=" + toString(ec));
+        }
+
+        segment_.id = mooncake::generate_uuid();
+        segment_.name = name;
+        segment_.base = segment_base;
+        segment_.size = segment_size;
+        segment_.te_endpoint = name;
+        auto mount_ec = master_client_.MountSegment(segment_);
+        if (!mount_ec.has_value()) {
+            throw std::runtime_error("Failed to mount segment " + name +
+                                     ", ec=" + toString(mount_ec.error()));
+        }
+    }
+
+    ~SegmentClient() {
+        if (remount_future_.valid()) {
+            remount_future_.wait();
+        }
+
+        auto unmount_result = master_client_.UnmountSegment(segment_.id);
+        if (!unmount_result.has_value()) {
+            LOG(ERROR) << "Failed to unmount segment " << segment_.name;
+        }
+    }
+
+    void Ping() {
+        if (remount_future_.valid() &&
+            remount_future_.wait_for(std::chrono::seconds(0)) ==
+                std::future_status::ready) {
+            remount_future_.get();
+            remount_future_ = std::future<void>();
+        }
+
+        auto ping_result = master_client_.Ping();
+        if (!ping_result.has_value()) {
+            throw std::runtime_error("Failed to ping master server");
+        }
+
+        if (ping_result.value().client_status ==
+                mooncake::ClientStatus::NEED_REMOUNT &&
+            !remount_future_.valid()) {
+            remount_future_ = std::async(std::launch::async, [&]() {
+                auto remount_ec = master_client_.ReMountSegment({segment_});
+                if (!remount_ec.has_value()) {
+                    throw std::runtime_error("Failed to remount segment");
+                }
+            });
+        }
+    }
+
+   private:
+    mooncake::MasterClient master_client_;
+    mooncake::Segment segment_;
+    std::future<void> remount_future_;
+};
+
+struct WriteStats {
+    uint64_t started = 0;
+    uint64_t completed = 0;
+    uint64_t start_failed = 0;
+    uint64_t end_failed = 0;
+
+    void Add(const WriteStats& other) {
+        started += other.started;
+        completed += other.completed;
+        start_failed += other.start_failed;
+        end_failed += other.end_failed;
+    }
+};
+
+struct ThreadStats {
+    std::vector<double> latency_ms;
+    uint64_t requests = 0;
+    uint64_t keys = 0;
+    uint64_t success_keys = 0;
+    uint64_t object_not_found = 0;
+    uint64_t replica_not_ready = 0;
+    uint64_t other_failures = 0;
+    uint64_t bad_responses = 0;
+
+    void Add(ThreadStats&& other) {
+        requests += other.requests;
+        keys += other.keys;
+        success_keys += other.success_keys;
+        object_not_found += other.object_not_found;
+        replica_not_ready += other.replica_not_ready;
+        other_failures += other.other_failures;
+        bad_responses += other.bad_responses;
+        latency_ms.insert(latency_ms.end(),
+                          std::make_move_iterator(other.latency_ms.begin()),
+                          std::make_move_iterator(other.latency_ms.end()));
+    }
+};
+
+struct ResultRow {
+    std::string label;
+    std::string cycle;
+    uint64_t requests = 0;
+    uint64_t keys = 0;
+    double duration_sec = 0;
+    double batch_per_sec = 0;
+    double key_per_sec = 0;
+    double avg_ms = 0;
+    double p50_ms = 0;
+    double p90_ms = 0;
+    double p99_ms = 0;
+    double max_ms = 0;
+    double object_not_found_rate = 0;
+    uint64_t success_keys = 0;
+    uint64_t object_not_found = 0;
+    uint64_t replica_not_ready = 0;
+    uint64_t other_failures = 0;
+    uint64_t bad_responses = 0;
+};
+
+std::string MakeKey(uint64_t id) {
+    std::ostringstream ss;
+    ss << FLAGS_key_prefix << "_" << std::setw(16) << std::setfill('0') << id;
+    return ss.str();
+}
+
+std::vector<std::string> MakeSequentialKeys(uint64_t start_id, uint64_t count) {
+    std::vector<std::string> keys;
+    keys.reserve(count);
+    for (uint64_t i = 0; i < count; ++i) {
+        keys.push_back(MakeKey(start_id + i));
+    }
+    return keys;
+}
+
+std::vector<std::vector<uint64_t>> MakeSliceLengths(size_t count) {
+    return std::vector<std::vector<uint64_t>>(
+        count, std::vector<uint64_t>{FLAGS_value_size});
+}
+
+WriteStats PutCompletedBatch(mooncake::MasterClient& client,
+                             const std::vector<std::string>& keys) {
+    WriteStats stats;
+    const mooncake::ReplicateConfig config;
+    auto put_start_result =
+        client.BatchPutStart(keys, MakeSliceLengths(keys.size()), config);
+
+    std::vector<std::string> started_keys;
+    started_keys.reserve(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        if (i < put_start_result.size() && put_start_result[i].has_value()) {
+            started_keys.push_back(keys[i]);
+            ++stats.started;
+        } else {
+            ++stats.start_failed;
+        }
+    }
+
+    if (started_keys.empty()) {
+        return stats;
+    }
+
+    auto put_end_result =
+        client.BatchPutEnd(started_keys, mooncake::ReplicaType::MEMORY);
+    for (const auto& result : put_end_result) {
+        if (result.has_value()) {
+            ++stats.completed;
+        } else {
+            ++stats.end_failed;
+        }
+    }
+    if (put_end_result.size() < started_keys.size()) {
+        stats.end_failed += started_keys.size() - put_end_result.size();
+    }
+    return stats;
+}
+
+WriteStats PrefillObjects() {
+    std::atomic<uint64_t> next_id{0};
+    std::atomic<uint64_t> completed{0};
+    std::atomic<uint64_t> started{0};
+    std::atomic<uint64_t> start_failed{0};
+    std::atomic<uint64_t> end_failed{0};
+
+    const uint64_t thread_count = std::max<uint64_t>(1, FLAGS_prefill_threads);
+    std::vector<std::thread> threads;
+    threads.reserve(thread_count);
+
+    auto started_at = std::chrono::steady_clock::now();
+    for (uint64_t thread_idx = 0; thread_idx < thread_count; ++thread_idx) {
+        threads.emplace_back([&, thread_idx] {
+            unset_cpu_affinity();
+            mooncake::MasterClient client(mooncake::generate_uuid());
+            auto ec = client.Connect(FLAGS_master_server);
+            if (ec != mooncake::ErrorCode::OK) {
+                throw std::runtime_error("Prefill client cannot connect, ec=" +
+                                         toString(ec));
+            }
+
+            uint64_t next_log = 100000;
+            while (true) {
+                const uint64_t start_id =
+                    next_id.fetch_add(FLAGS_prefill_batch_size);
+                if (start_id >= FLAGS_num_objects) {
+                    break;
+                }
+                const uint64_t count = std::min<uint64_t>(
+                    FLAGS_prefill_batch_size, FLAGS_num_objects - start_id);
+                auto stats = PutCompletedBatch(
+                    client, MakeSequentialKeys(start_id, count));
+                started.fetch_add(stats.started);
+                completed.fetch_add(stats.completed);
+                start_failed.fetch_add(stats.start_failed);
+                end_failed.fetch_add(stats.end_failed);
+
+                if (FLAGS_log_progress && thread_idx == 0 &&
+                    completed.load() >= next_log) {
+                    const auto elapsed =
+                        std::chrono::duration<double>(
+                            std::chrono::steady_clock::now() - started_at)
+                            .count();
+                    LOG(INFO)
+                        << "Prefill progress: completed=" << completed.load()
+                        << "/" << FLAGS_num_objects << ", elapsed=" << elapsed
+                        << "s";
+                    next_log += 100000;
+                }
+            }
+        });
+    }
+
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    return {.started = started.load(),
+            .completed = completed.load(),
+            .start_failed = start_failed.load(),
+            .end_failed = end_failed.load()};
+}
+
+void RunRefillWorker(std::atomic<bool>& running, std::atomic<uint64_t>& next_id,
+                     WriteStats& stats) {
+    unset_cpu_affinity();
+    mooncake::MasterClient client(mooncake::generate_uuid());
+    auto ec = client.Connect(FLAGS_master_server);
+    if (ec != mooncake::ErrorCode::OK) {
+        throw std::runtime_error("Refill client cannot connect, ec=" +
+                                 toString(ec));
+    }
+
+    while (running.load(std::memory_order_relaxed)) {
+        const uint64_t start_id = next_id.fetch_add(FLAGS_refill_batch_size);
+        auto batch_stats = PutCompletedBatch(
+            client, MakeSequentialKeys(start_id, FLAGS_refill_batch_size));
+        stats.Add(batch_stats);
+        if (FLAGS_refill_interval_ms > 0) {
+            std::this_thread::sleep_for(
+                std::chrono::milliseconds(FLAGS_refill_interval_ms));
+        }
+    }
+}
+
+ThreadStats RunLookupWorker(uint64_t thread_idx,
+                            std::chrono::steady_clock::time_point deadline,
+                            std::shared_ptr<std::latch> barrier) {
+    unset_cpu_affinity();
+    ThreadStats stats;
+    stats.latency_ms.reserve(
+        FLAGS_lookup_interval_ms > 0
+            ? std::max<uint64_t>(
+                  1, FLAGS_duration * 1000 / FLAGS_lookup_interval_ms + 1)
+            : 1024);
+
+    mooncake::MasterClient client(mooncake::generate_uuid());
+    auto ec = client.Connect(FLAGS_master_server);
+    if (ec != mooncake::ErrorCode::OK) {
+        throw std::runtime_error("Lookup client cannot connect, ec=" +
+                                 toString(ec));
+    }
+
+    std::mt19937_64 rng(FLAGS_random_seed + thread_idx);
+    std::uniform_int_distribution<uint64_t> key_dist(0, FLAGS_num_objects - 1);
+
+    barrier->arrive_and_wait();
+    uint64_t request_idx = 0;
+    while (true) {
+        const bool fixed_request_mode = FLAGS_requests_per_thread > 0;
+        if (fixed_request_mode) {
+            if (request_idx >= FLAGS_requests_per_thread) {
+                break;
+            }
+        } else if (std::chrono::steady_clock::now() >= deadline) {
+            break;
+        }
+
+        std::vector<std::string> keys;
+        keys.reserve(FLAGS_batch_size);
+        for (uint64_t i = 0; i < FLAGS_batch_size; ++i) {
+            keys.push_back(MakeKey(key_dist(rng)));
+        }
+
+        const auto started_at = std::chrono::steady_clock::now();
+        auto results = client.BatchGetReplicaList(keys);
+        const auto finished_at = std::chrono::steady_clock::now();
+        const double latency_ms =
+            std::chrono::duration<double, std::milli>(finished_at - started_at)
+                .count();
+
+        stats.latency_ms.push_back(latency_ms);
+        ++stats.requests;
+        ++request_idx;
+        stats.keys += keys.size();
+
+        if (results.size() != keys.size()) {
+            ++stats.bad_responses;
+            stats.other_failures += keys.size();
+        } else {
+            for (const auto& result : results) {
+                if (result.has_value()) {
+                    ++stats.success_keys;
+                    continue;
+                }
+                switch (result.error()) {
+                    case mooncake::ErrorCode::OBJECT_NOT_FOUND:
+                        ++stats.object_not_found;
+                        break;
+                    case mooncake::ErrorCode::REPLICA_IS_NOT_READY:
+                        ++stats.replica_not_ready;
+                        break;
+                    default:
+                        ++stats.other_failures;
+                        break;
+                }
+            }
+        }
+
+        if (FLAGS_lookup_interval_ms > 0) {
+            const auto interval =
+                std::chrono::milliseconds(FLAGS_lookup_interval_ms);
+            if (fixed_request_mode) {
+                std::this_thread::sleep_until(finished_at + interval);
+            } else {
+                std::this_thread::sleep_until(
+                    std::min(finished_at + interval, deadline));
+            }
+        }
+    }
+    return stats;
+}
+
+double Percentile(const std::vector<double>& sorted_values, double percentile) {
+    if (sorted_values.empty()) {
+        return 0;
+    }
+    if (sorted_values.size() == 1) {
+        return sorted_values.front();
+    }
+    const double rank = percentile * (sorted_values.size() - 1);
+    const auto low = static_cast<size_t>(std::floor(rank));
+    const auto high = static_cast<size_t>(std::ceil(rank));
+    if (low == high) {
+        return sorted_values[low];
+    }
+    return sorted_values[low] +
+           (sorted_values[high] - sorted_values[low]) * (rank - low);
+}
+
+ResultRow BuildResultRow(const std::string& cycle, ThreadStats&& stats,
+                         double duration_sec) {
+    std::sort(stats.latency_ms.begin(), stats.latency_ms.end());
+    const double sum_ms =
+        std::accumulate(stats.latency_ms.begin(), stats.latency_ms.end(), 0.0);
+    ResultRow row;
+    row.label = FLAGS_label;
+    row.cycle = cycle;
+    row.requests = stats.requests;
+    row.keys = stats.keys;
+    row.duration_sec = duration_sec;
+    row.batch_per_sec = duration_sec > 0
+                            ? static_cast<double>(stats.requests) / duration_sec
+                            : 0;
+    row.key_per_sec =
+        duration_sec > 0 ? static_cast<double>(stats.keys) / duration_sec : 0;
+    row.avg_ms =
+        stats.latency_ms.empty() ? 0 : sum_ms / stats.latency_ms.size();
+    row.p50_ms = Percentile(stats.latency_ms, 0.50);
+    row.p90_ms = Percentile(stats.latency_ms, 0.90);
+    row.p99_ms = Percentile(stats.latency_ms, 0.99);
+    row.max_ms = stats.latency_ms.empty() ? 0 : stats.latency_ms.back();
+    row.object_not_found_rate =
+        stats.keys > 0 ? static_cast<double>(stats.object_not_found) /
+                             static_cast<double>(stats.keys)
+                       : 0;
+    row.success_keys = stats.success_keys;
+    row.object_not_found = stats.object_not_found;
+    row.replica_not_ready = stats.replica_not_ready;
+    row.other_failures = stats.other_failures;
+    row.bad_responses = stats.bad_responses;
+    return row;
+}
+
+ResultRow RunLookupCycle(uint64_t cycle_idx) {
+    std::atomic<bool> refill_running{true};
+    std::atomic<uint64_t> next_refill_id{FLAGS_num_objects +
+                                         cycle_idx * 1000000000ULL};
+    std::vector<WriteStats> refill_stats(FLAGS_refill_threads);
+    std::vector<std::thread> refill_threads;
+    refill_threads.reserve(FLAGS_refill_threads);
+    for (uint64_t i = 0; i < FLAGS_refill_threads; ++i) {
+        refill_threads.emplace_back(RunRefillWorker, std::ref(refill_running),
+                                    std::ref(next_refill_id),
+                                    std::ref(refill_stats[i]));
+    }
+
+    const auto started_at = std::chrono::steady_clock::now();
+    const auto deadline = started_at + std::chrono::seconds(FLAGS_duration);
+    auto barrier = std::make_shared<std::latch>(FLAGS_lookup_threads + 1);
+    std::vector<ThreadStats> per_thread_stats(FLAGS_lookup_threads);
+    std::vector<std::thread> lookup_threads;
+    lookup_threads.reserve(FLAGS_lookup_threads);
+
+    for (uint64_t i = 0; i < FLAGS_lookup_threads; ++i) {
+        lookup_threads.emplace_back([&, i] {
+            per_thread_stats[i] = RunLookupWorker(i, deadline, barrier);
+        });
+    }
+
+    barrier->arrive_and_wait();
+    for (auto& thread : lookup_threads) {
+        thread.join();
+    }
+    const auto finished_at = std::chrono::steady_clock::now();
+
+    refill_running.store(false, std::memory_order_relaxed);
+    for (auto& thread : refill_threads) {
+        thread.join();
+    }
+
+    if (FLAGS_refill_threads > 0) {
+        WriteStats total_refill;
+        for (const auto& stats : refill_stats) {
+            total_refill.Add(stats);
+        }
+        LOG(INFO) << "cycle=" << cycle_idx
+                  << " refill completed=" << total_refill.completed
+                  << ", start_failed=" << total_refill.start_failed
+                  << ", end_failed=" << total_refill.end_failed;
+    }
+
+    ThreadStats merged;
+    for (auto& stats : per_thread_stats) {
+        merged.Add(std::move(stats));
+    }
+    const double duration_sec =
+        std::chrono::duration<double>(finished_at - started_at).count();
+    return BuildResultRow(std::to_string(cycle_idx), std::move(merged),
+                          duration_sec);
+}
+
+ThreadStats RowsAsStats(const std::vector<ResultRow>& rows) {
+    ThreadStats stats;
+    for (const auto& row : rows) {
+        stats.requests += row.requests;
+        stats.keys += row.keys;
+        stats.success_keys += row.success_keys;
+        stats.object_not_found += row.object_not_found;
+        stats.replica_not_ready += row.replica_not_ready;
+        stats.other_failures += row.other_failures;
+        stats.bad_responses += row.bad_responses;
+    }
+    return stats;
+}
+
+void PrintRows(const std::vector<ResultRow>& rows) {
+    std::cout << std::fixed << std::setprecision(3);
+    std::cout << "\nBatchGetReplicaList latency summary\n";
+    std::cout << "label=" << FLAGS_label << ", objects=" << FLAGS_num_objects
+              << ", lookup_threads=" << FLAGS_lookup_threads
+              << ", batch_size=" << FLAGS_batch_size
+              << ", lookup_interval_ms=" << FLAGS_lookup_interval_ms
+              << ", requests_per_thread=" << FLAGS_requests_per_thread
+              << ", refill_threads=" << FLAGS_refill_threads << "\n";
+    std::cout << std::left << std::setw(8) << "cycle" << std::right
+              << std::setw(10) << "requests" << std::setw(14) << "keys/s"
+              << std::setw(12) << "batch/s" << std::setw(12) << "avg(ms)"
+              << std::setw(12) << "p50(ms)" << std::setw(12) << "p90(ms)"
+              << std::setw(12) << "p99(ms)" << std::setw(12) << "max(ms)"
+              << std::setw(12) << "miss(%)" << std::setw(14) << "not_found"
+              << "\n";
+    for (const auto& row : rows) {
+        std::cout << std::left << std::setw(8) << row.cycle << std::right
+                  << std::setw(10) << row.requests << std::setw(14)
+                  << row.key_per_sec << std::setw(12) << row.batch_per_sec
+                  << std::setw(12) << row.avg_ms << std::setw(12) << row.p50_ms
+                  << std::setw(12) << row.p90_ms << std::setw(12) << row.p99_ms
+                  << std::setw(12) << row.max_ms << std::setw(14)
+                  << row.object_not_found_rate * 100.0 << std::setw(14)
+                  << row.object_not_found << "\n";
+    }
+}
+
+void WriteCsv(const std::vector<ResultRow>& rows) {
+    if (FLAGS_csv_path.empty()) {
+        return;
+    }
+
+    const bool append_header = !std::ifstream(FLAGS_csv_path).good() ||
+                               std::ifstream(FLAGS_csv_path).peek() ==
+                                   std::ifstream::traits_type::eof();
+    std::ofstream out(FLAGS_csv_path, std::ios::app);
+    if (!out) {
+        throw std::runtime_error("Cannot open CSV output path: " +
+                                 FLAGS_csv_path);
+    }
+
+    if (append_header) {
+        out << "label,cycle,requests,total_keys,duration_sec,batch_per_sec,"
+               "key_per_sec,avg_ms,p50_ms,p90_ms,p99_ms,max_ms,"
+               "object_not_found_rate,success_keys,object_not_found,"
+               "replica_not_ready,other_failures,bad_responses\n";
+    }
+
+    out << std::fixed << std::setprecision(6);
+    for (const auto& row : rows) {
+        out << row.label << "," << row.cycle << "," << row.requests << ","
+            << row.keys << "," << row.duration_sec << "," << row.batch_per_sec
+            << "," << row.key_per_sec << "," << row.avg_ms << "," << row.p50_ms
+            << "," << row.p90_ms << "," << row.p99_ms << "," << row.max_ms
+            << "," << row.object_not_found_rate << "," << row.success_keys
+            << "," << row.object_not_found << "," << row.replica_not_ready
+            << "," << row.other_failures << "," << row.bad_responses << "\n";
+    }
+}
+
+void ValidateFlags() {
+    if (FLAGS_num_objects == 0 || FLAGS_batch_size == 0 ||
+        FLAGS_lookup_threads == 0 || FLAGS_cycles == 0 ||
+        FLAGS_prefill_batch_size == 0 || FLAGS_refill_batch_size == 0) {
+        throw std::invalid_argument(
+            "num_objects, batch_size, lookup_threads, cycles, "
+            "prefill_batch_size, and refill_batch_size must be positive");
+    }
+    if (FLAGS_requests_per_thread == 0 && FLAGS_duration == 0) {
+        throw std::invalid_argument(
+            "duration must be positive when requests_per_thread is 0");
+    }
+}
+
+int main(int argc, char** argv) {
+    google::InitGoogleLogging("BatchGetReplicaBench");
+    FLAGS_logtostderr = true;
+    gflags::ParseCommandLineFlags(&argc, &argv, false);
+
+    try {
+        ValidateFlags();
+
+        std::vector<std::unique_ptr<SegmentClient>> segment_clients;
+        std::mutex segment_clients_mutex;
+        std::jthread ping_thread([&](std::stop_token stop_token) {
+            static const auto OneSecond = std::chrono::seconds(1);
+            unset_cpu_affinity();
+            while (!stop_token.stop_requested()) {
+                const auto started_at = std::chrono::steady_clock::now();
+                {
+                    std::lock_guard<std::mutex> guard(segment_clients_mutex);
+                    for (auto& segment_client : segment_clients) {
+                        segment_client->Ping();
+                    }
+                }
+                const auto elapsed =
+                    std::chrono::steady_clock::now() - started_at;
+                if (elapsed < OneSecond) {
+                    std::this_thread::sleep_for(OneSecond - elapsed);
+                }
+            }
+        });
+
+        LOG(INFO) << "Mounting " << FLAGS_num_segments << " segments";
+        for (uint64_t i = 0; i < FLAGS_num_segments; ++i) {
+            auto segment_client = std::make_unique<SegmentClient>(
+                "batch_get_bench_segment_" + std::to_string(i),
+                FLAGS_master_server, kSegmentBase + i * FLAGS_segment_size,
+                FLAGS_segment_size);
+            std::lock_guard<std::mutex> guard(segment_clients_mutex);
+            segment_clients.push_back(std::move(segment_client));
+        }
+
+        if (!FLAGS_skip_prefill) {
+            LOG(INFO) << "Prefilling objects: objects=" << FLAGS_num_objects
+                      << ", threads=" << FLAGS_prefill_threads
+                      << ", batch_size=" << FLAGS_prefill_batch_size
+                      << ", value_size=" << FLAGS_value_size;
+            const auto prefill_started_at = std::chrono::steady_clock::now();
+            const auto prefill_stats = PrefillObjects();
+            const auto prefill_sec =
+                std::chrono::duration<double>(std::chrono::steady_clock::now() -
+                                              prefill_started_at)
+                    .count();
+            LOG(INFO) << "Prefill done: completed=" << prefill_stats.completed
+                      << ", started=" << prefill_stats.started
+                      << ", start_failed=" << prefill_stats.start_failed
+                      << ", end_failed=" << prefill_stats.end_failed
+                      << ", elapsed=" << prefill_sec << "s";
+        }
+
+        std::vector<ResultRow> rows;
+        rows.reserve(FLAGS_cycles);
+        for (uint64_t cycle = 1; cycle <= FLAGS_cycles; ++cycle) {
+            LOG(INFO) << "Starting lookup cycle " << cycle << "/"
+                      << FLAGS_cycles;
+            rows.push_back(RunLookupCycle(cycle));
+        }
+
+        PrintRows(rows);
+        WriteCsv(rows);
+
+        if (ping_thread.joinable()) {
+            ping_thread.request_stop();
+            ping_thread.join();
+        }
+        segment_clients.clear();
+        google::ShutdownGoogleLogging();
+        return 0;
+    } catch (const std::exception& ex) {
+        LOG(ERROR) << "benchmark failed: " << ex.what();
+        google::ShutdownGoogleLogging();
+        return 1;
+    }
+}

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -299,6 +299,13 @@ class MasterService {
         -> tl::expected<GetReplicaListResponse, ErrorCode>;
 
     /**
+     * @brief Get replica lists for a batch of objects.
+     */
+    std::vector<tl::expected<GetReplicaListResponse, ErrorCode>>
+    BatchGetReplicaList(const std::vector<std::string>& keys,
+                        const std::string& tenant_id);
+
+    /**
      * @brief Start a put operation for an object
      * @param[out] replica_list Vector to store replica information for the
      * slice

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -1474,7 +1474,6 @@ MasterService::BatchGetReplicaList(const std::vector<std::string>& keys,
         }
     }
 
-    std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
     const size_t start_shard = RandomIndex(kNumShards);
     for (size_t scanned = 0; scanned < kNumShards; ++scanned) {
         const size_t shard_idx =
@@ -1484,6 +1483,7 @@ MasterService::BatchGetReplicaList(const std::vector<std::string>& keys,
         }
 
         std::vector<ObjectIdentity> promotion_candidates;
+        std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
         {
             MetadataShardAccessorRO shard(this, shard_idx);
             const auto tenant_it = shard->tenants.find(normalized_tenant);

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -1442,6 +1442,116 @@ auto MasterService::GetReplicaList(const std::string& key,
     return resp;
 }
 
+std::vector<tl::expected<GetReplicaListResponse, ErrorCode>>
+MasterService::BatchGetReplicaList(const std::vector<std::string>& keys,
+                                   const std::string& tenant_id) {
+    using GetResult = tl::expected<GetReplicaListResponse, ErrorCode>;
+
+    std::vector<GetResult> results(
+        keys.size(), tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND));
+    if (keys.empty()) {
+        return results;
+    }
+
+    const auto normalized_tenant = NormalizeTenantId(tenant_id);
+    std::vector<std::vector<size_t>> keys_by_shard(kNumShards);
+    {
+        std::shared_lock<std::shared_mutex> lock(group_routing_mutex_);
+        for (size_t i = 0; i < keys.size(); ++i) {
+            const auto scoped_key =
+                MakeTenantScopedKey(normalized_tenant, keys[i]);
+            const auto route_it = object_group_ids_.find(scoped_key);
+            const size_t shard_idx =
+                route_it == object_group_ids_.end()
+                    ? getShardIndex(normalized_tenant, keys[i])
+                    : getShardIndex(route_it->second);
+            keys_by_shard[shard_idx].push_back(i);
+        }
+    }
+
+    std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+    const size_t start_shard = RandomIndex(kNumShards);
+    for (size_t scanned = 0; scanned < kNumShards; ++scanned) {
+        const size_t shard_idx =
+            (start_shard + kNumShards - scanned) % kNumShards;
+        const auto& key_indexes = keys_by_shard[shard_idx];
+        if (key_indexes.empty()) {
+            continue;
+        }
+
+        std::vector<ObjectIdentity> promotion_candidates;
+        {
+            MetadataShardAccessorRO shard(this, shard_idx);
+            const auto tenant_it = shard->tenants.find(normalized_tenant);
+            for (const auto original_idx : key_indexes) {
+                const std::string& key = keys[original_idx];
+                MasterMetricManager::instance().inc_total_get_nums();
+
+                if (tenant_it == shard->tenants.end()) {
+                    VLOG(1) << "key=" << key << ", info=object_not_found";
+                    results[original_idx] =
+                        tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
+                    continue;
+                }
+
+                const auto& tenant_state = tenant_it->second;
+                const auto metadata_it = tenant_state.metadata.find(key);
+                if (metadata_it == tenant_state.metadata.end() ||
+                    !metadata_it->second.IsValid()) {
+                    VLOG(1) << "key=" << key << ", info=object_not_found";
+                    results[original_idx] =
+                        tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
+                    continue;
+                }
+
+                const auto& metadata = metadata_it->second;
+                std::vector<Replica::Descriptor> replica_list;
+                metadata.VisitReplicas(
+                    &Replica::fn_is_completed,
+                    [&replica_list](const Replica& replica) {
+                        replica_list.emplace_back(replica.get_descriptor());
+                    });
+
+                if (replica_list.empty()) {
+                    LOG(WARNING)
+                        << "key=" << key << ", error=replica_not_ready";
+                    results[original_idx] =
+                        tl::make_unexpected(ErrorCode::REPLICA_IS_NOT_READY);
+                    continue;
+                }
+
+                if (replica_list[0].is_memory_replica()) {
+                    MasterMetricManager::instance().inc_mem_cache_hit_nums();
+                } else if (replica_list[0].is_disk_replica()) {
+                    MasterMetricManager::instance().inc_file_cache_hit_nums();
+                }
+                MasterMetricManager::instance().inc_valid_get_nums();
+                GrantLeaseForGroup(tenant_state, key, metadata);
+
+                if (promotion_on_hit_) {
+                    const bool any_memory =
+                        metadata.HasReplica(&Replica::fn_is_memory_replica);
+                    const bool any_local_disk =
+                        metadata.HasReplica(&Replica::fn_is_local_disk_replica);
+                    if (!any_memory && any_local_disk) {
+                        promotion_candidates.push_back(
+                            MakeObjectIdentity(key, normalized_tenant));
+                    }
+                }
+
+                results[original_idx] = GetReplicaListResponse(
+                    std::move(replica_list), default_kv_lease_ttl_);
+            }
+        }
+
+        for (const auto& object_id : promotion_candidates) {
+            TryPushPromotionQueue(object_id);
+        }
+    }
+
+    return results;
+}
+
 auto MasterService::AllocateAndInsertMetadata(
     MetadataShardAccessorRW& shard, const UUID& client_id,
     const std::string& key, uint64_t value_length,

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -1454,18 +1454,23 @@ MasterService::BatchGetReplicaList(const std::vector<std::string>& keys,
     }
 
     const auto normalized_tenant = NormalizeTenantId(tenant_id);
-    std::vector<std::vector<size_t>> keys_by_shard(kNumShards);
+    constexpr size_t kInvalidKeyIndex = std::numeric_limits<size_t>::max();
+    std::array<size_t, kNumShards> key_list_heads;
+    key_list_heads.fill(kInvalidKeyIndex);
+    std::vector<size_t> next_key_indexes(keys.size(), kInvalidKeyIndex);
     {
         std::shared_lock<std::shared_mutex> lock(group_routing_mutex_);
-        for (size_t i = 0; i < keys.size(); ++i) {
+        for (size_t i = keys.size(); i > 0; --i) {
+            const size_t original_idx = i - 1;
             const auto scoped_key =
-                MakeTenantScopedKey(normalized_tenant, keys[i]);
+                MakeTenantScopedKey(normalized_tenant, keys[original_idx]);
             const auto route_it = object_group_ids_.find(scoped_key);
             const size_t shard_idx =
                 route_it == object_group_ids_.end()
-                    ? getShardIndex(normalized_tenant, keys[i])
+                    ? getShardIndex(normalized_tenant, keys[original_idx])
                     : getShardIndex(route_it->second);
-            keys_by_shard[shard_idx].push_back(i);
+            next_key_indexes[original_idx] = key_list_heads[shard_idx];
+            key_list_heads[shard_idx] = original_idx;
         }
     }
 
@@ -1474,8 +1479,7 @@ MasterService::BatchGetReplicaList(const std::vector<std::string>& keys,
     for (size_t scanned = 0; scanned < kNumShards; ++scanned) {
         const size_t shard_idx =
             (start_shard + kNumShards - scanned) % kNumShards;
-        const auto& key_indexes = keys_by_shard[shard_idx];
-        if (key_indexes.empty()) {
+        if (key_list_heads[shard_idx] == kInvalidKeyIndex) {
             continue;
         }
 
@@ -1483,7 +1487,9 @@ MasterService::BatchGetReplicaList(const std::vector<std::string>& keys,
         {
             MetadataShardAccessorRO shard(this, shard_idx);
             const auto tenant_it = shard->tenants.find(normalized_tenant);
-            for (const auto original_idx : key_indexes) {
+            for (size_t original_idx = key_list_heads[shard_idx];
+                 original_idx != kInvalidKeyIndex;
+                 original_idx = next_key_indexes[original_idx]) {
                 const std::string& key = keys[original_idx];
                 MasterMetricManager::instance().inc_total_get_nums();
 

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -1004,9 +1004,7 @@ WrappedMasterService::BatchGetReplicaList(const std::vector<std::string>& keys,
     std::vector<tl::expected<GetReplicaListResponse, ErrorCode>> results;
     results.reserve(keys.size());
 
-    for (const auto& key : keys) {
-        results.emplace_back(master_service_.GetReplicaList(key, tenant_id));
-    }
+    results = master_service_.BatchGetReplicaList(keys, tenant_id);
 
     size_t failure_count = 0;
     for (size_t i = 0; i < results.size(); ++i) {

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -713,6 +713,93 @@ TEST_F(MasterServiceTest, GroupRoutingIsTenantScopedForSameUserKey) {
     EXPECT_TRUE(service_->GetReplicaList(key, tenant_b).has_value());
 }
 
+TEST_F(MasterServiceTest, BatchGetReplicaListPreservesOrderWithGroupedKeys) {
+    std::unique_ptr<MasterService> service_(new MasterService());
+    [[maybe_unused]] const auto context = PrepareSimpleSegment(*service_);
+    const UUID client_id = generate_uuid();
+
+    const std::string grouped_key_a = "batch_get_grouped_a";
+    const std::string missing_key = "batch_get_missing";
+    const std::string ungrouped_key = "batch_get_ungrouped";
+    const std::string grouped_key_b = "batch_get_grouped_b";
+    const std::string pending_key = "batch_get_pending";
+
+    ReplicateConfig grouped_config_a;
+    grouped_config_a.replica_num = 1;
+    grouped_config_a.group_ids =
+        std::vector<std::string>{FindGroupIdOnDifferentShard(grouped_key_a)};
+    PutCompletedObject(*service_, client_id, grouped_key_a, grouped_config_a);
+
+    ReplicateConfig ungrouped_config;
+    ungrouped_config.replica_num = 1;
+    PutCompletedObject(*service_, client_id, ungrouped_key, ungrouped_config);
+
+    ReplicateConfig grouped_config_b;
+    grouped_config_b.replica_num = 1;
+    grouped_config_b.group_ids =
+        std::vector<std::string>{FindGroupIdOnDifferentShard(grouped_key_b)};
+    PutCompletedObject(*service_, client_id, grouped_key_b, grouped_config_b);
+
+    ASSERT_TRUE(service_
+                    ->PutStart(client_id, pending_key, "default", 1024,
+                               ungrouped_config)
+                    .has_value());
+
+    const std::vector<std::string> keys = {
+        grouped_key_a, missing_key, ungrouped_key, grouped_key_b, pending_key};
+    auto results = service_->BatchGetReplicaList(keys, "default");
+
+    ASSERT_EQ(results.size(), keys.size());
+    ASSERT_TRUE(results[0].has_value());
+    EXPECT_FALSE(results[0]->replicas.empty());
+    ASSERT_FALSE(results[1].has_value());
+    EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, results[1].error());
+    ASSERT_TRUE(results[2].has_value());
+    EXPECT_FALSE(results[2]->replicas.empty());
+    ASSERT_TRUE(results[3].has_value());
+    EXPECT_FALSE(results[3]->replicas.empty());
+    ASSERT_FALSE(results[4].has_value());
+    EXPECT_EQ(ErrorCode::REPLICA_IS_NOT_READY, results[4].error());
+}
+
+TEST_F(MasterServiceTest, BatchGetReplicaListKeepsTenantIsolation) {
+    std::unique_ptr<MasterService> service_(new MasterService());
+    [[maybe_unused]] const auto context = PrepareSimpleSegment(*service_);
+    const UUID client_id = generate_uuid();
+
+    const std::string key = "batch_get_tenant_shared_key";
+    const std::string tenant_a = "batch_get_tenant_a";
+    const std::string tenant_b = "batch_get_tenant_b";
+
+    ReplicateConfig config_a;
+    config_a.replica_num = 1;
+    config_a.group_ids =
+        std::vector<std::string>{FindGroupIdOnDifferentShard(key)};
+    ASSERT_TRUE(service_->PutStart(client_id, key, tenant_a, 1024, config_a)
+                    .has_value());
+    ASSERT_TRUE(service_->PutEnd(client_id, key, tenant_a, ReplicaType::MEMORY)
+                    .has_value());
+
+    ReplicateConfig config_b;
+    config_b.replica_num = 1;
+    ASSERT_TRUE(service_->PutStart(client_id, key, tenant_b, 2048, config_b)
+                    .has_value());
+    ASSERT_TRUE(service_->PutEnd(client_id, key, tenant_b, ReplicaType::MEMORY)
+                    .has_value());
+
+    auto tenant_a_results = service_->BatchGetReplicaList({key}, tenant_a);
+    auto tenant_b_results = service_->BatchGetReplicaList({key}, tenant_b);
+    auto default_results = service_->BatchGetReplicaList({key}, "default");
+
+    ASSERT_EQ(tenant_a_results.size(), 1u);
+    ASSERT_EQ(tenant_b_results.size(), 1u);
+    ASSERT_EQ(default_results.size(), 1u);
+    EXPECT_TRUE(tenant_a_results[0].has_value());
+    EXPECT_TRUE(tenant_b_results[0].has_value());
+    ASSERT_FALSE(default_results[0].has_value());
+    EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, default_results[0].error());
+}
+
 TEST_F(MasterServiceTest, GetAllKeysListsOnlyRequestedTenant) {
     std::unique_ptr<MasterService> service_(new MasterService());
     [[maybe_unused]] const auto context = PrepareSimpleSegment(*service_);

--- a/mooncake-store/tests/promotion_on_hit_test.cpp
+++ b/mooncake-store/tests/promotion_on_hit_test.cpp
@@ -205,6 +205,54 @@ TEST_F(PromotionOnHitTest, MemoryReplicaPresentNoPromotion) {
     service->RemoveAll();
 }
 
+TEST_F(PromotionOnHitTest, BatchGetReplicaListPromotesLocalDiskOnlyObject) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;
+    config.promotion_max_per_heartbeat = 2;
+    config.default_kv_lease_ttl = 2000;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto ctx =
+        PrepareSegment(*service, "test_segment", kDefaultSegmentBase, seg_size);
+
+    const std::string single_key = "k_single_get_promote";
+    const std::string batch_key = "k_batch_get_promote";
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, ctx.client_id, single_key,
+                                       1024, ctx.segment_name));
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, ctx.client_id, batch_key, 1024,
+                                       ctx.segment_name));
+
+    auto& mm = MasterMetricManager::instance();
+    const int64_t admitted_pre = mm.get_promotion_admitted();
+    const int64_t in_flight_pre = mm.get_promotion_in_flight();
+
+    auto single_result = service->GetReplicaList(single_key, "default");
+    ASSERT_TRUE(single_result.has_value());
+    ASSERT_EQ(single_result->replicas.size(), 1u);
+    EXPECT_TRUE(single_result->replicas[0].is_local_disk_replica());
+
+    auto batch_result = service->BatchGetReplicaList(
+        std::vector<std::string>{batch_key}, "default");
+    ASSERT_EQ(batch_result.size(), 1u);
+    ASSERT_TRUE(batch_result[0].has_value());
+    ASSERT_EQ(batch_result[0]->replicas.size(), 1u);
+    EXPECT_TRUE(batch_result[0]->replicas[0].is_local_disk_replica());
+
+    EXPECT_EQ(mm.get_promotion_admitted() - admitted_pre, 2);
+    EXPECT_EQ(mm.get_promotion_in_flight() - in_flight_pre, 2);
+
+    auto pending = service->PromotionObjectHeartbeat(ctx.client_id);
+    ASSERT_TRUE(pending.has_value());
+    EXPECT_EQ(pending->size(), 2u);
+    EXPECT_EQ(CountPromotionTask(*pending, single_key), 1u);
+    EXPECT_EQ(CountPromotionTask(*pending, batch_key), 1u);
+
+    service->RemoveAll();
+}
+
 // PromotionObjectHeartbeat returns an empty task list when called against a
 // client that has no LocalDiskSegment registered.
 TEST_F(PromotionOnHitTest, HeartbeatReturnsErrorForUnknownClient) {


### PR DESCRIPTION
## Description

This PR is a follow-up to #2405.

#2405 reduced Mooncake Store lookup-side metadata shard lock contention by avoiding fully per-key metadata lookup behavior. `BatchGetReplicaList` still used the old path: the wrapped RPC batch handler iterated over keys and called `GetReplicaList` once per key.

This PR adds a batch-aware `MasterService::BatchGetReplicaList` implementation and routes the wrapped RPC batch handler to it directly. The new path groups keys by metadata shard before accessing metadata, instead of issuing one service lookup per key.

The new path:

1. Groups batch keys by metadata shard.
   - Bucket input keys by the shard selected from tenant-aware key routing.
   - Respect grouped-object routing through `object_group_ids_`.
   - Acquire each touched shard accessor once per batch.
   - Preserve the original response order.

2. Preserves existing `GetReplicaList` behavior.
   - Keep not-found and not-ready replica semantics unchanged.
   - Keep tenant isolation unchanged.
   - Keep lease granting behavior unchanged.
   - Keep existing get metrics behavior unchanged.
   - Keep promotion-on-hit behavior unchanged.

3. Follows the shard traversal direction used by #2405.
   - Start from a randomized shard.
   - Traverse shards in reverse order from that start point.
   - Skip untouched shards.

This keeps public API behavior, request ordering, tenant semantics, lease behavior, metrics, and promotion policy unchanged. No user-facing API or configuration behavior is changed.

This PR also adds `mooncake-store/benchmarks/batch_get_replica_bench`, a benchmark for measuring `MasterClient::BatchGetReplicaList` against a running master. The benchmark supports fixed-request mode for fair baseline/current comparisons and optional CSV output for external result aggregation.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

Performance optimization.

## How Has This Been Tested?

Unit/build tests:

- `clang-format --dry-run --Werror mooncake-store/include/master_service.h mooncake-store/src/master_service.cpp mooncake-store/src/rpc_service.cpp mooncake-store/tests/master_service_test.cpp mooncake-store/benchmarks/batch_get_replica_bench.cpp`
- `git diff --check`
- `cmake --build build --target master_service_test -j8`
- `./build/mooncake-store/tests/master_service_test --gtest_filter='MasterServiceTest.BatchGetReplicaListPreservesOrderWithGroupedKeys:MasterServiceTest.BatchGetReplicaListKeepsTenantIsolation'`

Additional local benchmark:

- Single development machine
- Baseline master: latest `kvcache/main` after #2405 was merged
- Baseline commit: `8b884bcd`
- Current master: this PR branch rebased on the same `kvcache/main`
- Same benchmark binary used for both runs
- Benchmark target: `mooncake-store/benchmarks/batch_get_replica_bench`
- Measures `MasterClient::BatchGetReplicaList`
- Focuses on the master metadata lookup RPC path, not end-to-end object data transfer
- 20M objects
- 56 lookup threads
- 30,000 keys per `BatchGetReplicaList`
- 180 requests per lookup thread
- 10,080 requests per cycle
- 500ms sleep between lookups per thread
- `rpc_thread_num=56`
- `segment_gb=48`
- `eviction_high_watermark_ratio=0.55`
- `eviction_ratio=0.25`
- `refill_threads=0`
- 2 benchmark cycles

Benchmark reproduction:

Build current branch:

```bash
cmake -S . -B build \
  -DBUILD_UNIT_TESTS=ON \
  -DBUILD_BENCHMARK=ON \
  -DWITH_STORE_RUST=OFF \
  -DCMAKE_BUILD_TYPE=RelWithDebInfo

cmake --build build --target mooncake_master batch_get_replica_bench -j8
```

Build baseline master from `origin/main` in a separate worktree:

```bash
git worktree add ../Mooncake-main origin/main

cmake -S ../Mooncake-main -B ../Mooncake-main/build-bench \
  -DBUILD_UNIT_TESTS=ON \
  -DBUILD_BENCHMARK=ON \
  -DWITH_STORE_RUST=OFF \
  -DCMAKE_BUILD_TYPE=RelWithDebInfo

cmake --build ../Mooncake-main/build-bench --target mooncake_master -j8
```

Start baseline master:

```bash
../Mooncake-main/build-bench/mooncake-store/src/mooncake_master \
  --rpc_port=50051 \
  --rpc_thread_num=56 \
  --metrics_port=19003 \
  --client_ttl=300 \
  --eviction_high_watermark_ratio=0.55 \
  --eviction_ratio=0.25 \
  --enable_metric_reporting=false \
  --logtostderr=true
```

Run benchmark against baseline master:

```bash
./build/mooncake-store/benchmarks/batch_get_replica_bench \
  --master_server=127.0.0.1:50051 \
  --label=baseline \
  --csv_path=/tmp/batchget-baseline-fixed.csv \
  --num_segments=1 \
  --segment_size=51539607552 \
  --num_objects=20000000 \
  --prefill_threads=8 \
  --prefill_batch_size=30000 \
  --lookup_threads=56 \
  --batch_size=30000 \
  --duration=120 \
  --requests_per_thread=180 \
  --cycles=2 \
  --lookup_interval_ms=500 \
  --value_size=2048 \
  --logtostderr=true
```

Then stop the baseline master, start the current master:

```bash
./build/mooncake-store/src/mooncake_master \
  --rpc_port=50051 \
  --rpc_thread_num=56 \
  --metrics_port=19003 \
  --client_ttl=300 \
  --eviction_high_watermark_ratio=0.55 \
  --eviction_ratio=0.25 \
  --enable_metric_reporting=false \
  --logtostderr=true
```

Run benchmark against current master:

```bash
./build/mooncake-store/benchmarks/batch_get_replica_bench \
  --master_server=127.0.0.1:50051 \
  --label=current \
  --csv_path=/tmp/batchget-current-fixed.csv \
  --num_segments=1 \
  --segment_size=51539607552 \
  --num_objects=20000000 \
  --prefill_threads=8 \
  --prefill_batch_size=30000 \
  --lookup_threads=56 \
  --batch_size=30000 \
  --duration=120 \
  --requests_per_thread=180 \
  --cycles=2 \
  --lookup_interval_ms=500 \
  --value_size=2048 \
  --logtostderr=true
```

Eviction-active `BatchGetReplicaList` latency, fixed request count:

| Version | key/s | batch/s | avg | p50 | p90 | p99 | max | miss rate |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| baseline `kvcache/main` @ `8b884bcd` | 2,265,758.21 | 75.53 | 166.233ms | 137.147ms | 256.391ms | 353.019ms | 2319.008ms | 35.015% |
| this PR | 2,417,796.61 | 80.59 | 124.982ms | 110.473ms | 154.123ms | 243.121ms | 1602.496ms | 30.650% |

Current vs baseline:

| Metric | Change |
|---|---:|
| key/s | +6.71% |
| batch/s | +6.71% |
| avg latency | -24.82% |
| p50 latency | -19.45% |
| p90 latency | -39.89% |
| p99 latency | -31.13% |
| max latency | -30.90% |
| miss rate | -4.365 pp |

This benchmark was rerun after #2405 had already been merged into `kvcache/main`. Both baseline and current are based on the same latest main commit (`8b884bcd`), so the result measures the additional impact of this PR on top of #2405.

The benchmark uses a fixed request count for the main comparison. Both baseline and current process the same number of `BatchGetReplicaList` requests per cycle, which avoids giving the faster implementation more completed requests within the same fixed-duration window.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `clang-format` before submitting.
- [ ] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.