### PR TITLE
[Store] Rust: don't force-link the ASan runtime in non-sanitized builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,12 @@ jobs:
         export MOONCAKE_BUILD_DIR=$GITHUB_WORKSPACE/build
         export MOONCAKE_STORE_LIB_DIR=$GITHUB_WORKSPACE/build/mooncake-store/src
         export MOONCAKE_STORE_INCLUDE_DIR=$GITHUB_WORKSPACE/mooncake-store/include
+        # This job builds Mooncake with -DENABLE_ASAN=ON, so the C++ libraries
+        # the Rust crate links against carry undefined __asan_* references. Opt
+        # in to linking the ASan runtime; build.rs emits -lasan first, which
+        # keeps libasan first in the initial library list as ASan requires.
+        # Non-sanitized builds leave this unset and link without ASan.
+        export MOONCAKE_LINK_ASAN=1
         export MC_METADATA_SERVER=http://127.0.0.1:8080/metadata
         export MC_RUST_STORE_RUN_INTEGRATION=true
         export MC_RUST_STORE_MASTER_ADDR=127.0.0.1:50051

--- a/mooncake-store/rust/build.rs
+++ b/mooncake-store/rust/build.rs
@@ -287,21 +287,34 @@ fn main() {
     push_env_paths(&mut search_dirs, "LD_LIBRARY_PATH");
     push_env_paths(&mut search_dirs, "LIBRARY_PATH");
 
-    let asan_runtime_so = compiler_runtime_library("libasan.so");
-    if let Some(path) = asan_runtime_so.as_ref() {
-        if let Some(parent) = path.parent() {
-            push_existing_dir(&mut search_dirs, parent.to_path_buf());
+    // Only link the AddressSanitizer runtime when explicitly requested via
+    // MOONCAKE_LINK_ASAN. Linking libasan whenever the toolchain merely *ships*
+    // it (gcc always does) pulls the ASan runtime into an otherwise
+    // non-sanitized build, even though a Release Mooncake has no `__asan_*`
+    // symbols. Any consumer that `dlopen()`s the resulting library then aborts
+    // at load with "ASan runtime does not come first in the initial library
+    // list", since a late-loaded plugin can never be first. Default to NOT
+    // linking it; sanitized builds opt in with `MOONCAKE_LINK_ASAN=1` (and run
+    // with `LD_PRELOAD=$(gcc -print-file-name=libasan.so)`).
+    let want_asan = env::var_os("MOONCAKE_LINK_ASAN").is_some();
+    let has_asan_runtime = if want_asan {
+        let asan_runtime_so = compiler_runtime_library("libasan.so");
+        if let Some(path) = asan_runtime_so.as_ref() {
+            if let Some(parent) = path.parent() {
+                push_existing_dir(&mut search_dirs, parent.to_path_buf());
+            }
         }
-    }
-    let has_asan_runtime = asan_runtime_so.is_some()
-        || add_compiler_runtime_search_dir(&mut search_dirs, "libasan.a");
+        asan_runtime_so.is_some() || add_compiler_runtime_search_dir(&mut search_dirs, "libasan.a")
+    } else {
+        false
+    };
     let has_gcov_runtime = add_compiler_runtime_search_dir(&mut search_dirs, "libgcov.a")
         || add_compiler_runtime_search_dir(&mut search_dirs, "libgcov.so");
 
     emit_link_searches(&search_dirs);
     emit_runtime_rpaths(&search_dirs);
 
-    if has_asan_runtime || has_library(&search_dirs, &["asan"]) {
+    if want_asan && (has_asan_runtime || has_library(&search_dirs, &["asan"])) {
         println!("cargo:rustc-link-lib=asan");
     }
 
@@ -356,6 +369,7 @@ fn main() {
     println!("cargo:rerun-if-env-changed=LIBRARY_PATH");
     println!("cargo:rerun-if-env-changed=CC");
     println!("cargo:rerun-if-env-changed=CXX");
+    println!("cargo:rerun-if-env-changed=MOONCAKE_LINK_ASAN");
 
     let bindings = bindgen::Builder::default()
         .header(&header)

--- a/mooncake-store/rust/build.rs
+++ b/mooncake-store/rust/build.rs
@@ -296,7 +296,14 @@ fn main() {
     // list", since a late-loaded plugin can never be first. Default to NOT
     // linking it; sanitized builds opt in with `MOONCAKE_LINK_ASAN=1` (and run
     // with `LD_PRELOAD=$(gcc -print-file-name=libasan.so)`).
-    let want_asan = env::var_os("MOONCAKE_LINK_ASAN").is_some();
+    let want_asan = env::var("MOONCAKE_LINK_ASAN")
+        .map(|value| {
+            !matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "" | "0" | "false" | "off" | "no"
+            )
+        })
+        .unwrap_or(false);
     let has_asan_runtime = if want_asan {
         let asan_runtime_so = compiler_runtime_library("libasan.so");
         if let Some(path) = asan_runtime_so.as_ref() {


### PR DESCRIPTION
## Problem

`mooncake-store/rust/build.rs` links `libasan` whenever the toolchain merely *ships* it (gcc always does):

```rust
let has_asan_runtime = compiler_runtime_library("libasan.so").is_some()
    || add_compiler_runtime_search_dir(&mut search_dirs, "libasan.a");
...
if has_asan_runtime || has_library(&search_dirs, &["asan"]) {
    println!("cargo:rustc-link-lib=asan");
}
```

The trigger keys off *"does the compiler have libasan available"*, not *"was Mooncake actually built with AddressSanitizer"*. So a normal Release build — which has no `__asan_*` symbols — still force-links the ASan runtime into the resulting library.

Any consumer that `dlopen()`s that library (e.g. a Python extension that statically links `mooncake_store`) then aborts at load with:

```
==N==ERROR: ... ASan runtime does not come first in initial library list;
you should can not link with shared libasan after the program is started
```

ASan must be the **first** library in the process's initial load order so it can install its allocator/init hooks before anything else. A library that is `dlopen()`ed after the program has started can never satisfy that, so the only outcome of the spurious link is a hard crash for non-sanitized dependents.

## Fix

Gate the ASan link behind an explicit `MOONCAKE_LINK_ASAN` opt-in (default **off**):

- Release / normal builds link cleanly with **no** ASan dependency.
- Sanitized builds set `MOONCAKE_LINK_ASAN=1` and launch with `LD_PRELOAD=$(gcc -print-file-name=libasan.so)` as usual.

The probe for the libasan runtime is also skipped unless opted in, so there's no behavior change for a build that was already passing sanitizer flags through `CFLAGS`/`CXXFLAGS` other than that it now requests the runtime link explicitly.

## Testing

Built a dependent Rust `cdylib` (a PyO3 extension) against a Release Mooncake:

- **Before:** the extension carried a `libasan` `DT_NEEDED` and crashed at `dlopen()` with the message above.
- **After:** `readelf -d` shows no `libasan` `DT_NEEDED` (only the real `libmooncake_store` / `libasio` / `libjsoncpp` deps), and the extension loads and runs cleanly.

Single-file, build-only change; no runtime/API change.