### PR TITLE
[Store] Add P2P OpLog types and payload serialization

### DIFF
--- a/mooncake-store/include/ha/oplog/p2p_oplog_types.h
+++ b/mooncake-store/include/ha/oplog/p2p_oplog_types.h
@@ -1,0 +1,122 @@
+// mooncake-store/include/ha/oplog/p2p_oplog_types.h
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "ha/oplog/oplog_manager.h"
+#include "replica.h"
+#include "types.h"
+
+namespace mooncake {
+
+// ============================================================================
+// P2P OpType enum extensions
+// ============================================================================
+// Main branch uses OpType 1-4 (PUT_END, PUT_REVOKE, REMOVE, LEASE_RENEW).
+// P2P starts from 10 to avoid conflicts with future main extensions (5-9).
+
+// P2P-specific OpType values (use constexpr for switch-case)
+constexpr OpType OpType_ADD_REPLICA = static_cast<OpType>(10);
+constexpr OpType OpType_REMOVE_REPLICA = static_cast<OpType>(11);
+constexpr OpType OpType_MOUNT_SEGMENT = static_cast<OpType>(12);
+constexpr OpType OpType_UNMOUNT_SEGMENT = static_cast<OpType>(13);
+constexpr OpType OpType_REMOVE_ALL = static_cast<OpType>(14);
+constexpr OpType OpType_REGISTER_CLIENT = static_cast<OpType>(15);
+
+// ============================================================================
+// P2P Payload structures for OpLog entries
+// ============================================================================
+// Each payload is struct_pack-serialized and stored in OpLogEntry::payload.
+// On the apply side, P2POpLogApplier deserializes back to the struct.
+// Payload structs embed complex types (Segment, vector<Segment>) directly,
+// consistent with main branch's MetadataPayload which embeds
+// vector<Replica::Descriptor> the same way.
+
+/// Payload for REGISTER_CLIENT (OpType=15, sync).
+/// Records client registration info so Standby can reconstruct routing
+/// after promotion. Without this, Standby cannot serve GetWriteRoute.
+struct RegisterClientPayload {
+    UUID client_id{0, 0};
+    std::string ip_address;
+    uint16_t rpc_port = 0;
+    // Segments registered by this client at registration time.
+    std::vector<Segment> segments;
+
+    YLT_REFL(RegisterClientPayload, client_id, ip_address, rpc_port,
+              segments);
+};
+
+/// Payload for ADD_REPLICA (OpType=10, async).
+/// Records that a replica was added to an object.
+struct AddReplicaPayload {
+    std::string object_key;
+    UUID client_id{0, 0};
+    UUID segment_id{0, 0};
+    size_t size = 0;
+    int priority = 0;
+    std::vector<std::string> tags;
+    MemoryType memory_type = MemoryType::DRAM;
+
+    YLT_REFL(AddReplicaPayload, object_key, client_id, segment_id, size,
+              priority, tags, memory_type);
+};
+
+/// Payload for REMOVE_REPLICA (OpType=11, async).
+/// Records that a replica was removed from an object.
+struct RemoveReplicaPayload {
+    std::string object_key;
+    UUID client_id{0, 0};
+    UUID segment_id{0, 0};
+
+    YLT_REFL(RemoveReplicaPayload, object_key, client_id, segment_id);
+};
+
+/// Payload for MOUNT_SEGMENT (OpType=12, sync).
+/// Records that a segment was mounted by a client.
+struct MountSegmentPayload {
+    UUID client_id{0, 0};
+    Segment segment;
+
+    YLT_REFL(MountSegmentPayload, client_id, segment);
+};
+
+/// Payload for UNMOUNT_SEGMENT (OpType=13, sync).
+/// Records that a segment was unmounted. Standby must also remove
+/// all replicas referencing this segment (cascade delete).
+struct UnmountSegmentPayload {
+    UUID segment_id{0, 0};
+    UUID client_id{0, 0};
+
+    YLT_REFL(UnmountSegmentPayload, segment_id, client_id);
+};
+
+// ============================================================================
+// P2P OpLog payload serialization helpers
+// ============================================================================
+// Payloads are stored in OpLogEntry::payload as struct_pack binary,
+// consistent with main branch's ApplyPutEnd serialization format.
+// This allows potential future cross-branch compatibility.
+
+/// Serialize a P2P payload to binary (struct_pack format).
+std::string SerializeP2PPayload(const RegisterClientPayload& payload);
+std::string SerializeP2PPayload(const AddReplicaPayload& payload);
+std::string SerializeP2PPayload(const RemoveReplicaPayload& payload);
+std::string SerializeP2PPayload(const MountSegmentPayload& payload);
+std::string SerializeP2PPayload(const UnmountSegmentPayload& payload);
+
+/// Deserialize a binary payload to a P2P payload struct.
+/// Returns true on success, false on deserialization error.
+bool DeserializeP2PPayload(const std::string& data,
+                           RegisterClientPayload& payload);
+bool DeserializeP2PPayload(const std::string& data,
+                           AddReplicaPayload& payload);
+bool DeserializeP2PPayload(const std::string& data,
+                           RemoveReplicaPayload& payload);
+bool DeserializeP2PPayload(const std::string& data,
+                           MountSegmentPayload& payload);
+bool DeserializeP2PPayload(const std::string& data,
+                           UnmountSegmentPayload& payload);
+
+}  // namespace mooncake

--- a/mooncake-store/include/ha/oplog/p2p_oplog_types.h
+++ b/mooncake-store/include/ha/oplog/p2p_oplog_types.h
@@ -44,8 +44,7 @@ struct RegisterClientPayload {
     // Segments registered by this client at registration time.
     std::vector<Segment> segments;
 
-    YLT_REFL(RegisterClientPayload, client_id, ip_address, rpc_port,
-              segments);
+    YLT_REFL(RegisterClientPayload, client_id, ip_address, rpc_port, segments);
 };
 
 /// Payload for ADD_REPLICA (OpType=10, async).
@@ -60,7 +59,7 @@ struct AddReplicaPayload {
     MemoryType memory_type = MemoryType::DRAM;
 
     YLT_REFL(AddReplicaPayload, object_key, client_id, segment_id, size,
-              priority, tags, memory_type);
+             priority, tags, memory_type);
 };
 
 /// Payload for REMOVE_REPLICA (OpType=11, async).
@@ -110,8 +109,7 @@ std::string SerializeP2PPayload(const UnmountSegmentPayload& payload);
 /// Returns true on success, false on deserialization error.
 bool DeserializeP2PPayload(const std::string& data,
                            RegisterClientPayload& payload);
-bool DeserializeP2PPayload(const std::string& data,
-                           AddReplicaPayload& payload);
+bool DeserializeP2PPayload(const std::string& data, AddReplicaPayload& payload);
 bool DeserializeP2PPayload(const std::string& data,
                            RemoveReplicaPayload& payload);
 bool DeserializeP2PPayload(const std::string& data,

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -69,6 +69,8 @@ set(MOONCAKE_STORE_SOURCES
     ha/oplog/oplog_store_factory.cpp
     ha/oplog/oplog_applier.cpp
     ha/oplog/oplog_replicator.cpp
+    # P2P HA OpLog components
+    ha/oplog/p2p_oplog_types.cpp
     standby_state_machine.cpp
     ha_metric_manager.cpp
 )

--- a/mooncake-store/src/ha/oplog/p2p_oplog_types.cpp
+++ b/mooncake-store/src/ha/oplog/p2p_oplog_types.cpp
@@ -1,41 +1,29 @@
 #include "ha/oplog/p2p_oplog_types.h"
 
 #include <string>
-#include <vector>
 
 #include <ylt/struct_pack.hpp>
 
 namespace mooncake {
 
-// ============================================================================
-// SerializeP2PPayload implementations
-// ============================================================================
-// struct_pack::serialize() returns std::vector<char>, so we convert to
-// std::string for storage in OpLogEntry::payload.
-
 std::string SerializeP2PPayload(const RegisterClientPayload& payload) {
-    auto buf = struct_pack::serialize(payload);
-    return std::string(buf.begin(), buf.end());
+    return struct_pack::serialize<std::string>(payload);
 }
 
 std::string SerializeP2PPayload(const AddReplicaPayload& payload) {
-    auto buf = struct_pack::serialize(payload);
-    return std::string(buf.begin(), buf.end());
+    return struct_pack::serialize<std::string>(payload);
 }
 
 std::string SerializeP2PPayload(const RemoveReplicaPayload& payload) {
-    auto buf = struct_pack::serialize(payload);
-    return std::string(buf.begin(), buf.end());
+    return struct_pack::serialize<std::string>(payload);
 }
 
 std::string SerializeP2PPayload(const MountSegmentPayload& payload) {
-    auto buf = struct_pack::serialize(payload);
-    return std::string(buf.begin(), buf.end());
+    return struct_pack::serialize<std::string>(payload);
 }
 
 std::string SerializeP2PPayload(const UnmountSegmentPayload& payload) {
-    auto buf = struct_pack::serialize(payload);
-    return std::string(buf.begin(), buf.end());
+    return struct_pack::serialize<std::string>(payload);
 }
 
 // ============================================================================

--- a/mooncake-store/src/ha/oplog/p2p_oplog_types.cpp
+++ b/mooncake-store/src/ha/oplog/p2p_oplog_types.cpp
@@ -1,0 +1,80 @@
+#include "ha/oplog/p2p_oplog_types.h"
+
+#include <string>
+#include <vector>
+
+#include <ylt/struct_pack.hpp>
+
+namespace mooncake {
+
+// ============================================================================
+// SerializeP2PPayload implementations
+// ============================================================================
+// struct_pack::serialize() returns std::vector<char>, so we convert to
+// std::string for storage in OpLogEntry::payload.
+
+std::string SerializeP2PPayload(const RegisterClientPayload& payload) {
+    auto buf = struct_pack::serialize(payload);
+    return std::string(buf.begin(), buf.end());
+}
+
+std::string SerializeP2PPayload(const AddReplicaPayload& payload) {
+    auto buf = struct_pack::serialize(payload);
+    return std::string(buf.begin(), buf.end());
+}
+
+std::string SerializeP2PPayload(const RemoveReplicaPayload& payload) {
+    auto buf = struct_pack::serialize(payload);
+    return std::string(buf.begin(), buf.end());
+}
+
+std::string SerializeP2PPayload(const MountSegmentPayload& payload) {
+    auto buf = struct_pack::serialize(payload);
+    return std::string(buf.begin(), buf.end());
+}
+
+std::string SerializeP2PPayload(const UnmountSegmentPayload& payload) {
+    auto buf = struct_pack::serialize(payload);
+    return std::string(buf.begin(), buf.end());
+}
+
+// ============================================================================
+// DeserializeP2PPayload implementations
+// ============================================================================
+
+bool DeserializeP2PPayload(const std::string& data,
+                           RegisterClientPayload& payload) {
+    auto result =
+        struct_pack::deserialize_to(payload, data.data(), data.size());
+    return result == struct_pack::errc::ok;
+}
+
+bool DeserializeP2PPayload(const std::string& data,
+                           AddReplicaPayload& payload) {
+    auto result =
+        struct_pack::deserialize_to(payload, data.data(), data.size());
+    return result == struct_pack::errc::ok;
+}
+
+bool DeserializeP2PPayload(const std::string& data,
+                           RemoveReplicaPayload& payload) {
+    auto result =
+        struct_pack::deserialize_to(payload, data.data(), data.size());
+    return result == struct_pack::errc::ok;
+}
+
+bool DeserializeP2PPayload(const std::string& data,
+                           MountSegmentPayload& payload) {
+    auto result =
+        struct_pack::deserialize_to(payload, data.data(), data.size());
+    return result == struct_pack::errc::ok;
+}
+
+bool DeserializeP2PPayload(const std::string& data,
+                           UnmountSegmentPayload& payload) {
+    auto result =
+        struct_pack::deserialize_to(payload, data.data(), data.size());
+    return result == struct_pack::errc::ok;
+}
+
+}  // namespace mooncake

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -72,6 +72,7 @@ add_store_test(standby_state_machine_test ha/oplog/standby_state_machine_test.cp
 add_store_test(ha_metric_manager_test ha/oplog/ha_metric_manager_test.cpp)
 add_store_test(oplog_applier_test ha/oplog/oplog_applier_test.cpp)
 add_store_test(oplog_replicator_test ha/oplog/oplog_replicator_test.cpp)
+add_store_test(p2p_oplog_test ha/oplog/p2p_oplog_test.cpp)
 add_subdirectory(e2e)
 
 add_executable(high_availability_test high_availability_test.cpp)

--- a/mooncake-store/tests/ha/oplog/p2p_oplog_test.cpp
+++ b/mooncake-store/tests/ha/oplog/p2p_oplog_test.cpp
@@ -2,6 +2,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <string>
 #include <vector>
 
@@ -201,7 +202,8 @@ TEST(P2POpLogTypesTest, RoundTrip_MountSegmentPayload) {
     original.segment.id = {70, 80};
     original.segment.name = "test_segment";
     original.segment.size = 2048;
-    original.segment.extra = P2PSegmentExtraData{1, {"tag1"}, MemoryType::DRAM, 0};
+    original.segment.extra =
+        P2PSegmentExtraData{1, {"tag1"}, MemoryType::DRAM, 0};
 
     std::string data = SerializeP2PPayload(original);
     MountSegmentPayload decoded;
@@ -275,7 +277,8 @@ TEST(P2POpLogTypesTest, Deserialize_EmptyData_ReturnsFalse) {
 }
 
 TEST(P2POpLogTypesTest, Deserialize_WrongType_ReturnsFalse) {
-    // Serialize an AddReplicaPayload, try to deserialize as RemoveReplicaPayload
+    // Serialize an AddReplicaPayload, try to deserialize as
+    // RemoveReplicaPayload
     AddReplicaPayload original;
     original.object_key = "cross_type_test";
     original.client_id = {1, 2};

--- a/mooncake-store/tests/ha/oplog/p2p_oplog_test.cpp
+++ b/mooncake-store/tests/ha/oplog/p2p_oplog_test.cpp
@@ -1,0 +1,296 @@
+#include "ha/oplog/p2p_oplog_types.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+namespace mooncake::test {
+
+// ============================================================================
+// OpType constants
+// ============================================================================
+
+TEST(P2POpLogTypesTest, OpTypeValuesDoNotConflictWithMain) {
+    // Main branch uses OpType 1-4 (PUT_END, PUT_REVOKE, REMOVE, LEASE_RENEW).
+    // P2P OpTypes start from 10.
+    EXPECT_EQ(static_cast<int>(OpType_ADD_REPLICA), 10);
+    EXPECT_EQ(static_cast<int>(OpType_REMOVE_REPLICA), 11);
+    EXPECT_EQ(static_cast<int>(OpType_MOUNT_SEGMENT), 12);
+    EXPECT_EQ(static_cast<int>(OpType_UNMOUNT_SEGMENT), 13);
+    EXPECT_EQ(static_cast<int>(OpType_REMOVE_ALL), 14);
+    EXPECT_EQ(static_cast<int>(OpType_REGISTER_CLIENT), 15);
+}
+
+TEST(P2POpLogTypesTest, OpTypeValuesAreDistinct) {
+    std::vector<int> values = {
+        static_cast<int>(OpType_ADD_REPLICA),
+        static_cast<int>(OpType_REMOVE_REPLICA),
+        static_cast<int>(OpType_MOUNT_SEGMENT),
+        static_cast<int>(OpType_UNMOUNT_SEGMENT),
+        static_cast<int>(OpType_REMOVE_ALL),
+        static_cast<int>(OpType_REGISTER_CLIENT),
+    };
+    std::sort(values.begin(), values.end());
+    for (size_t i = 1; i < values.size(); ++i) {
+        EXPECT_NE(values[i], values[i - 1])
+            << "Duplicate OpType value: " << values[i];
+    }
+}
+
+// ============================================================================
+// RegisterClientPayload round-trip
+// ============================================================================
+
+TEST(P2POpLogTypesTest, RoundTrip_RegisterClientPayload) {
+    RegisterClientPayload original;
+    original.client_id = {100, 200};
+    original.ip_address = "192.168.1.1";
+    original.rpc_port = 50051;
+    Segment seg;
+    seg.id = {300, 400};
+    seg.name = "seg_001";
+    seg.size = 1024;
+    seg.extra = P2PSegmentExtraData{1, {"tag1"}, MemoryType::DRAM, 0};
+    original.segments = {seg};
+
+    std::string data = SerializeP2PPayload(original);
+    ASSERT_FALSE(data.empty());
+
+    RegisterClientPayload decoded;
+    ASSERT_TRUE(DeserializeP2PPayload(data, decoded));
+
+    EXPECT_EQ(decoded.client_id.first, 100u);
+    EXPECT_EQ(decoded.client_id.second, 200u);
+    EXPECT_EQ(decoded.ip_address, "192.168.1.1");
+    EXPECT_EQ(decoded.rpc_port, 50051u);
+    ASSERT_EQ(decoded.segments.size(), 1u);
+    EXPECT_EQ(decoded.segments[0].id.first, 300u);
+    EXPECT_EQ(decoded.segments[0].id.second, 400u);
+    EXPECT_EQ(decoded.segments[0].name, "seg_001");
+    EXPECT_EQ(decoded.segments[0].size, 1024u);
+}
+
+TEST(P2POpLogTypesTest, RoundTrip_RegisterClientPayload_EmptyFields) {
+    RegisterClientPayload original;
+    // Use default values, including empty segments
+    original.client_id = {0, 0};
+    original.ip_address = "";
+    original.rpc_port = 0;
+
+    std::string data = SerializeP2PPayload(original);
+    RegisterClientPayload decoded;
+    ASSERT_TRUE(DeserializeP2PPayload(data, decoded));
+
+    EXPECT_EQ(decoded.client_id.first, 0u);
+    EXPECT_EQ(decoded.client_id.second, 0u);
+    EXPECT_EQ(decoded.ip_address, "");
+    EXPECT_EQ(decoded.rpc_port, 0u);
+    EXPECT_EQ(decoded.segments.size(), 0u);
+}
+
+TEST(P2POpLogTypesTest, RoundTrip_RegisterClientPayload_MultipleSegments) {
+    RegisterClientPayload original;
+    original.client_id = {100, 200};
+    original.ip_address = "10.0.0.1";
+    original.rpc_port = 50052;
+
+    Segment seg1;
+    seg1.id = {1, 2};
+    seg1.name = "dram_seg";
+    seg1.size = 4096;
+    seg1.extra = P2PSegmentExtraData{2, {"ssd", "gpu"}, MemoryType::DRAM, 512};
+
+    Segment seg2;
+    seg2.id = {3, 4};
+    seg2.name = "nvme_seg";
+    seg2.size = 8192;
+    seg2.extra = P2PSegmentExtraData{3, {"nvme"}, MemoryType::NVME, 1024};
+
+    original.segments = {seg1, seg2};
+
+    std::string data = SerializeP2PPayload(original);
+    RegisterClientPayload decoded;
+    ASSERT_TRUE(DeserializeP2PPayload(data, decoded));
+
+    ASSERT_EQ(decoded.segments.size(), 2u);
+    EXPECT_EQ(decoded.segments[0].id.first, 1u);
+    EXPECT_EQ(decoded.segments[0].name, "dram_seg");
+    EXPECT_EQ(decoded.segments[0].size, 4096u);
+    EXPECT_EQ(decoded.segments[1].id.first, 3u);
+    EXPECT_EQ(decoded.segments[1].name, "nvme_seg");
+    EXPECT_EQ(decoded.segments[1].size, 8192u);
+}
+
+// ============================================================================
+// AddReplicaPayload round-trip
+// ============================================================================
+
+TEST(P2POpLogTypesTest, RoundTrip_AddReplicaPayload) {
+    AddReplicaPayload original;
+    original.object_key = "obj_001";
+    original.client_id = {10, 20};
+    original.segment_id = {30, 40};
+    original.size = 4096;
+    original.priority = 1;
+    original.tags = {"tag1", "tag2"};
+    original.memory_type = MemoryType::DRAM;
+
+    std::string data = SerializeP2PPayload(original);
+    AddReplicaPayload decoded;
+    ASSERT_TRUE(DeserializeP2PPayload(data, decoded));
+
+    EXPECT_EQ(decoded.object_key, "obj_001");
+    EXPECT_EQ(decoded.client_id.first, 10u);
+    EXPECT_EQ(decoded.client_id.second, 20u);
+    EXPECT_EQ(decoded.segment_id.first, 30u);
+    EXPECT_EQ(decoded.segment_id.second, 40u);
+    EXPECT_EQ(decoded.size, 4096u);
+    EXPECT_EQ(decoded.priority, 1);
+    ASSERT_EQ(decoded.tags.size(), 2u);
+    EXPECT_EQ(decoded.tags[0], "tag1");
+    EXPECT_EQ(decoded.tags[1], "tag2");
+    EXPECT_EQ(decoded.memory_type, MemoryType::DRAM);
+}
+
+TEST(P2POpLogTypesTest, RoundTrip_AddReplicaPayload_EmptyTags) {
+    AddReplicaPayload original;
+    original.object_key = "obj_empty_tags";
+    original.client_id = {1, 2};
+    original.segment_id = {3, 4};
+    original.size = 1024;
+    original.priority = 0;
+    // tags intentionally left empty
+    original.memory_type = MemoryType::DRAM;
+
+    std::string data = SerializeP2PPayload(original);
+    AddReplicaPayload decoded;
+    ASSERT_TRUE(DeserializeP2PPayload(data, decoded));
+
+    EXPECT_EQ(decoded.tags.size(), 0u);
+}
+
+// ============================================================================
+// RemoveReplicaPayload round-trip
+// ============================================================================
+
+TEST(P2POpLogTypesTest, RoundTrip_RemoveReplicaPayload) {
+    RemoveReplicaPayload original;
+    original.object_key = "obj_to_remove";
+    original.client_id = {100, 200};
+    original.segment_id = {300, 400};
+
+    std::string data = SerializeP2PPayload(original);
+    RemoveReplicaPayload decoded;
+    ASSERT_TRUE(DeserializeP2PPayload(data, decoded));
+
+    EXPECT_EQ(decoded.object_key, "obj_to_remove");
+    EXPECT_EQ(decoded.client_id.first, 100u);
+    EXPECT_EQ(decoded.client_id.second, 200u);
+    EXPECT_EQ(decoded.segment_id.first, 300u);
+    EXPECT_EQ(decoded.segment_id.second, 400u);
+}
+
+// ============================================================================
+// MountSegmentPayload round-trip
+// ============================================================================
+
+TEST(P2POpLogTypesTest, RoundTrip_MountSegmentPayload) {
+    MountSegmentPayload original;
+    original.client_id = {50, 60};
+    original.segment.id = {70, 80};
+    original.segment.name = "test_segment";
+    original.segment.size = 2048;
+    original.segment.extra = P2PSegmentExtraData{1, {"tag1"}, MemoryType::DRAM, 0};
+
+    std::string data = SerializeP2PPayload(original);
+    MountSegmentPayload decoded;
+    ASSERT_TRUE(DeserializeP2PPayload(data, decoded));
+
+    EXPECT_EQ(decoded.client_id.first, 50u);
+    EXPECT_EQ(decoded.client_id.second, 60u);
+    EXPECT_EQ(decoded.segment.id.first, 70u);
+    EXPECT_EQ(decoded.segment.id.second, 80u);
+    EXPECT_EQ(decoded.segment.name, "test_segment");
+    EXPECT_EQ(decoded.segment.size, 2048u);
+}
+
+TEST(P2POpLogTypesTest, RoundTrip_MountSegmentPayload_MonostateExtra) {
+    // Segment with default (monostate) extra data
+    MountSegmentPayload original;
+    original.client_id = {1, 2};
+    original.segment.id = {3, 4};
+    original.segment.name = "default_seg";
+    original.segment.size = 512;
+
+    std::string data = SerializeP2PPayload(original);
+    MountSegmentPayload decoded;
+    ASSERT_TRUE(DeserializeP2PPayload(data, decoded));
+
+    EXPECT_EQ(decoded.segment.id.first, 3u);
+    EXPECT_EQ(decoded.segment.name, "default_seg");
+    EXPECT_EQ(decoded.segment.size, 512u);
+    EXPECT_TRUE(decoded.segment.IsEmpty());
+}
+
+// ============================================================================
+// UnmountSegmentPayload round-trip
+// ============================================================================
+
+TEST(P2POpLogTypesTest, RoundTrip_UnmountSegmentPayload) {
+    UnmountSegmentPayload original;
+    original.segment_id = {70, 80};
+    original.client_id = {90, 100};
+
+    std::string data = SerializeP2PPayload(original);
+    UnmountSegmentPayload decoded;
+    ASSERT_TRUE(DeserializeP2PPayload(data, decoded));
+
+    EXPECT_EQ(decoded.segment_id.first, 70u);
+    EXPECT_EQ(decoded.segment_id.second, 80u);
+    EXPECT_EQ(decoded.client_id.first, 90u);
+    EXPECT_EQ(decoded.client_id.second, 100u);
+}
+
+// ============================================================================
+// Deserialization error handling
+// ============================================================================
+
+TEST(P2POpLogTypesTest, Deserialize_GarbageData_ReturnsFalse) {
+    std::string garbage = "this is not valid struct_pack data";
+    RegisterClientPayload p1;
+    EXPECT_FALSE(DeserializeP2PPayload(garbage, p1));
+
+    AddReplicaPayload p2;
+    EXPECT_FALSE(DeserializeP2PPayload(garbage, p2));
+}
+
+TEST(P2POpLogTypesTest, Deserialize_EmptyData_ReturnsFalse) {
+    std::string empty;
+    RemoveReplicaPayload p1;
+    EXPECT_FALSE(DeserializeP2PPayload(empty, p1));
+
+    MountSegmentPayload p2;
+    EXPECT_FALSE(DeserializeP2PPayload(empty, p2));
+}
+
+TEST(P2POpLogTypesTest, Deserialize_WrongType_ReturnsFalse) {
+    // Serialize an AddReplicaPayload, try to deserialize as RemoveReplicaPayload
+    AddReplicaPayload original;
+    original.object_key = "cross_type_test";
+    original.client_id = {1, 2};
+    original.segment_id = {3, 4};
+    original.size = 100;
+
+    std::string data = SerializeP2PPayload(original);
+    RemoveReplicaPayload wrong;
+    // struct_pack should detect the type mismatch
+    EXPECT_FALSE(DeserializeP2PPayload(data, wrong));
+}
+
+}  // namespace mooncake::test
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Description

  Add P2P-specific OpLog type definitions and payload serialization layer for P2P Master HA.

  - P2P OpType enum: ADD_REPLICA, REMOVE_REPLICA, MOUNT_SEGMENT, UNMOUNT_SEGMENT, REMOVE_ALL, REGISTER_CLIENT — values start
  from 10 to avoid conflict with main branch OpTypes (1–4)
  - Payload structs: RegisterClientPayload, AddReplicaPayload, RemoveReplicaPayload, MountSegmentPayload, UnmountSegmentPayload
  with YLT_REFL for struct_pack
  - Serialization helpers: SerializeP2PPayload / DeserializeP2PPayload using struct_pack binary format, consistent with main
  branch OpLogSerializer

  Module

  - [ ] Transfer Engine (mooncake-transfer-engine)
  - [ ] Mooncake Store (mooncake-store)
  - [ ] Mooncake EP (mooncake-ep)
  - [ ] Mooncake PG (mooncake-pg)
  - [ ] Integration (mooncake-integration)
  - [x] P2P Store (mooncake-p2p-store)
  - [ ] Python Wheel (mooncake-wheel)
  - [ ] Common (mooncake-common)
  - [ ] Mooncake RL (mooncake-rl)
  - [ ] CI/CD
  - [ ] Docs
  - [ ] Other

  Type of Change

  - [ ] Bug fix
  - [x] New feature
  - [ ] Refactor
  - [ ] Breaking change
  - [ ] Documentation update
  - [ ] Performance improvement
  - [ ] Other

  How Has This Been Tested?

  Test commands:
  docker exec mooncake-dev bash -c "cd /workspace && rm -rf build && mkdir build && cd build && cmake ..
  -DCMAKE_BUILD_TYPE=Debug && make -j\$(nproc)"
  docker exec mooncake-dev bash -c "cd /workspace/build && ctest -R p2p_oplog -V"

  Test results:
  - [x] Unit tests pass
  - [ ] Integration tests pass (if applicable)
  - [ ] Manual testing done (describe below)

  14 test cases all passed (p2p_oplog_test): OpType value checks, round-trip serialization for all 5 payload types, error
  handling (garbage/empty/wrong-type data).

  Checklist

  - [x] I have performed a self-review of my own code
  - [x] I have formatted my code using ./scripts/code_format.sh
  - [ ] I have run pre-commit run --all-files and all hooks pass
  - [ ] I have updated the documentation (if applicable)
  - [x] I have added tests to prove my changes are effective
  - [ ] For changes >500 LOC: I have filed an RFC issue

  AI Assistance Disclosure

  - [ ] No AI tools were used
  - [x] AI tools were used (specify below)

  Claude Code assisted with commit message refinement.