### PR TITLE
[TENT] Fix ThreadLocalStorage per-object aliasing

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/common/concurrent/thread_local_storage.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/concurrent/thread_local_storage.h
@@ -15,33 +15,59 @@
 #ifndef TENT_THREAD_LOCAL_STORAGE_H
 #define TENT_THREAD_LOCAL_STORAGE_H
 
+#include <atomic>
+#include <cstdint>
 #include <functional>
 #include <mutex>
 #include <thread>
+#include <unordered_map>
 #include <unordered_set>
 
 namespace mooncake {
 namespace tent {
 
+// Per-thread storage that also supports iterating every live thread's value
+// via forEach (e.g. to aggregate or clean up across worker threads). Each
+// object keeps independent per-thread values. The destructor frees this
+// object's per-thread holders, so get()/forEach must not run concurrently with
+// the object's own destruction (the usual "no use during destruction" rule).
 template <typename T>
 class ThreadLocalStorage {
    public:
-    ThreadLocalStorage() = default;
-    ~ThreadLocalStorage() = default;
+    ThreadLocalStorage() : id_(nextId()) {}
+
+    ~ThreadLocalStorage() {
+        // This object owns the per-thread holders created for it (one per
+        // thread that called get()). Detach them under the lock, then destroy
+        // them outside it so ~InstanceHolder can re-acquire global_mutex_
+        // without deadlocking.
+        std::unordered_set<InstanceHolder*> holders;
+        {
+            std::lock_guard<std::mutex> lock(global_mutex_);
+            holders.swap(instances_);
+        }
+        for (auto* holder : holders) delete holder;
+    }
 
     // Disable copy/move
     ThreadLocalStorage(const ThreadLocalStorage&) = delete;
     ThreadLocalStorage& operator=(const ThreadLocalStorage&) = delete;
 
-    // Access the thread-local instance (lock-free)
+    // Access the thread-local instance for THIS object (lock-free fast path).
     T& get() {
-        if (!instance_) {
-            instance_ = new InstanceHolder(this);
+        // Per-thread, per-object storage. Keyed by this object's unique id
+        // (not by `this`) so a recycled address cannot alias a destroyed
+        // object's leftover holder. The map is per type T per thread.
+        static thread_local std::unordered_map<uint64_t, InstanceHolder*>
+            holders;
+        auto& holder = holders[id_];
+        if (!holder) {
+            holder = new InstanceHolder(this);
         }
-        return instance_->value;
+        return holder->value;
     }
 
-    // Safe iteration over all instances (with locking)
+    // Safe iteration over all live threads' instances of THIS object.
     void forEach(const std::function<void(T&)>& fn) {
         std::lock_guard<std::mutex> lock(global_mutex_);
         for (auto* inst : instances_) {
@@ -51,7 +77,7 @@ class ThreadLocalStorage {
 
    private:
     struct InstanceHolder {
-        T value;
+        T value{};
         ThreadLocalStorage<T>* owner;
 
         InstanceHolder(ThreadLocalStorage<T>* owner) : owner(owner) {
@@ -65,18 +91,19 @@ class ThreadLocalStorage {
         }
     };
 
-    // Thread-local pointer to the per-thread instance
-    thread_local static InstanceHolder* instance_;
+    static uint64_t nextId() {
+        static std::atomic<uint64_t> counter{0};
+        return counter.fetch_add(1, std::memory_order_relaxed);
+    }
 
-    // Global list of all thread instances
+    // Unique id used to key the per-thread holder map, stable for this
+    // object's lifetime and never reused.
+    const uint64_t id_;
+
+    // All live thread instances created for THIS object.
     std::unordered_set<InstanceHolder*> instances_;
     std::mutex global_mutex_;
 };
-
-// Definition of thread_local variable (must be outside the class)
-template <typename T>
-thread_local typename ThreadLocalStorage<T>::InstanceHolder*
-    ThreadLocalStorage<T>::instance_ = nullptr;
 
 }  // namespace tent
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -135,3 +135,13 @@ target_include_directories(tent_progress_worker_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME tent_progress_worker_test
          COMMAND tent_progress_worker_test)
+
+# ThreadLocalStorage unit test: per-object isolation, forEach scoping, and that
+# a fresh object does not alias a destroyed one (header-only, CPU-only).
+add_executable(tent_thread_local_storage_test thread_local_storage_test.cpp)
+target_link_libraries(tent_thread_local_storage_test
+                      PRIVATE gtest gtest_main)
+target_include_directories(tent_thread_local_storage_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+add_test(NAME tent_thread_local_storage_test
+         COMMAND tent_thread_local_storage_test)

--- a/mooncake-transfer-engine/tent/tests/thread_local_storage_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/thread_local_storage_test.cpp
@@ -1,0 +1,90 @@
+// Copyright 2025 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tent/common/concurrent/thread_local_storage.h"
+
+#include <gtest/gtest.h>
+
+#include <thread>
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+// Two ThreadLocalStorage<T> objects of the same type must keep independent
+// per-thread values. (Before the per-object fix, the second object aliased the
+// first because the thread-local pointer was a per-type static.)
+TEST(ThreadLocalStorageTest, DistinctObjectsDoNotAlias) {
+    ThreadLocalStorage<int> a, b;
+    a.get() = 111;
+    EXPECT_EQ(b.get(), 0);
+    b.get() = 222;
+    EXPECT_EQ(a.get(), 111);
+    EXPECT_EQ(b.get(), 222);
+}
+
+// forEach must visit only the holders that belong to that object.
+TEST(ThreadLocalStorageTest, ForEachVisitsOnlyOwnInstances) {
+    ThreadLocalStorage<int> a, b;
+    a.get() = 5;
+    b.get() = 9;
+    int cnt_a = 0, sum_a = 0;
+    a.forEach([&](int& v) {
+        ++cnt_a;
+        sum_a += v;
+    });
+    int cnt_b = 0, sum_b = 0;
+    b.forEach([&](int& v) {
+        ++cnt_b;
+        sum_b += v;
+    });
+    EXPECT_EQ(cnt_a, 1);
+    EXPECT_EQ(sum_a, 5);
+    EXPECT_EQ(cnt_b, 1);
+    EXPECT_EQ(sum_b, 9);
+}
+
+// Each thread gets its own value; forEach aggregates across live threads.
+TEST(ThreadLocalStorageTest, PerThreadIsolationAndCrossThreadForEach) {
+    ThreadLocalStorage<int> s;
+    s.get() = 1;
+    std::thread t([&] {
+        s.get() = 2;
+        EXPECT_EQ(s.get(), 2);
+    });
+    t.join();
+    EXPECT_EQ(s.get(), 1);
+    int cnt = 0, total = 0;
+    s.forEach([&](int& v) {
+        ++cnt;
+        total += v;
+    });
+    EXPECT_EQ(cnt, 2);
+    EXPECT_EQ(total, 3);
+}
+
+// A freshly created object must not observe a destroyed object's leftover
+// value, even if the allocator recycles the same address/storage.
+TEST(ThreadLocalStorageTest, FreshObjectDoesNotAliasDestroyedOne) {
+    {
+        ThreadLocalStorage<int> a;
+        a.get() = 77;
+    }
+    ThreadLocalStorage<int> b;
+    EXPECT_EQ(b.get(), 0);
+}
+
+}  // namespace
+}  // namespace tent
+}  // namespace mooncake


### PR DESCRIPTION
## Problem
`ThreadLocalStorage<T>::get()` cached the per-thread holder in a **per-type** `thread_local static InstanceHolder* instance_`, shared by every `ThreadLocalStorage<T>` object on a thread, and only checked `if (!instance_)` (never `owner == this`). So a second same-type object on a thread returned the **first object's** value and never registered in its own `instances_` — `forEach()` then saw nothing. The holder was also `new`'d and never deleted (one leak per thread x object). `InstanceHolder::value` was left uninitialized for trivial `T`.

The per-object `instances_` set and per-holder `owner` field show multiple coexisting same-type objects were intended; today's callers are per-object members (`TransferEngineImpl::batch_set_`, `SegmentManager::tl_remote_cache_`), so the bug bites multi-engine / multi-SegmentManager on one thread.

## Fix (header-only)
- `get()` keys per-thread holders by a **unique per-object id**, giving true per-object isolation — also immune to address reuse (ABA).
- `~ThreadLocalStorage` frees its holders (fixes the leak).
- `InstanceHolder::value` is value-initialized.
- Documents the lifetime contract (get()/forEach must not race with the object's own destruction).

## Testing
New CPU-only unit test `tent_thread_local_storage_test` (per-object isolation, `forEach` scoping, per-thread isolation, ABA). Verified locally:
- **Discriminating**: against the old header the test fails 6 checks; against the fix all pass.
- **ASan + UBSan + LSan clean** (no use-after-free / leak / UB).

_Local verification was a standalone `g++` compile + the unit test + sanitizers (the header is CPU-only, no GPU/RDMA). The full CMake build is left to CI._

## Not in scope
- Does not touch the callers (`transfer_engine_impl` / `segment_manager`); the change is in the header only. Single-object usage (the common case) is unchanged in behavior.
- Pre-existing concerns left as-is: the value-content race between `forEach` and a concurrent `get()`-mutation, `forEach`-reentrant locking, and use-after-destruction.
- Minor: `get()` now does a `thread_local` map lookup instead of a single pointer deref (the map is required for correct per-object storage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)