### PR TITLE
[Store] Fix cache total metrics accounting on metadata removal

### DIFF
--- a/mooncake-store/include/master_metric_manager.h
+++ b/mooncake-store/include/master_metric_manager.h
@@ -37,6 +37,7 @@ class MasterMetricManager {
     void inc_file_cache_nums(int64_t val = 1);
     void dec_mem_cache_nums(int64_t val = 1);
     void dec_file_cache_nums(int64_t val = 1);
+    void reset_cache_total_nums();
 
     void inc_valid_get_nums(int64_t val = 1);
     void inc_total_get_nums(int64_t val = 1);

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1172,7 +1172,6 @@ class MasterService {
     static bool HasCompletedDiskCacheReplica(const ObjectMetadata& metadata);
     static void SyncCacheTotalAccounting(ObjectMetadata& metadata);
     void RebuildCacheTotalAccounting();
-    static void RefreshCacheTotalAfterReplicaRemoval(ObjectMetadata& metadata);
     static void AccountCacheTotalRemoval(ObjectMetadata& metadata);
     std::vector<Replica> PopReplicasWithCacheTotalAccounting(
         ObjectMetadata& metadata,

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1171,6 +1171,7 @@ class MasterService {
     static bool HasCompletedMemoryCacheReplica(const ObjectMetadata& metadata);
     static bool HasCompletedDiskCacheReplica(const ObjectMetadata& metadata);
     static void SyncCacheTotalAccounting(ObjectMetadata& metadata);
+    void RebuildCacheTotalAccounting();
     static void RefreshCacheTotalAfterReplicaRemoval(ObjectMetadata& metadata);
     static void AccountCacheTotalRemoval(ObjectMetadata& metadata);
     std::vector<Replica> PopReplicasWithCacheTotalAccounting(

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -855,6 +855,8 @@ class MasterService {
             soft_pin_timeout GUARDED_BY(lock);  // optional soft pin, only
                                                 // set for vip objects
         const bool hard_pinned{false};          // immutable, set at creation
+        bool memory_cache_total_accounted{false};
+        bool disk_cache_total_accounted{false};
 
         void AddReplicas(std::vector<Replica>&& replicas) {
             replicas_.insert(replicas_.end(),
@@ -1166,6 +1168,25 @@ class MasterService {
     };
     std::array<MetadataShard, kNumShards> metadata_shards_;
 
+    static bool HasCompletedMemoryCacheReplica(const ObjectMetadata& metadata);
+    static bool HasCompletedDiskCacheReplica(const ObjectMetadata& metadata);
+    static void SyncCacheTotalAccounting(ObjectMetadata& metadata);
+    static void RefreshCacheTotalAfterReplicaRemoval(ObjectMetadata& metadata);
+    static void AccountCacheTotalRemoval(ObjectMetadata& metadata);
+    std::vector<Replica> PopReplicasWithCacheTotalAccounting(
+        ObjectMetadata& metadata,
+        const std::function<bool(const Replica&)>& pred_fn);
+    std::vector<Replica> PopReplicasWithCacheTotalAccounting(
+        ObjectMetadata& metadata);
+    size_t EraseReplicasWithCacheTotalAccounting(
+        ObjectMetadata& metadata,
+        const std::function<bool(const Replica&)>& pred_fn);
+    std::unordered_map<std::string, ObjectMetadata>::iterator
+    EraseMetadataWithCacheTotalAccounting(
+        TenantState& tenant_state,
+        std::unordered_map<std::string, ObjectMetadata>::iterator it,
+        const std::string& tenant_id);
+
     std::unordered_map<std::string, std::string> object_group_ids_
         GUARDED_BY(group_routing_mutex_);
     mutable std::unordered_set<std::string> groups_needing_lease_refresh_
@@ -1424,9 +1445,10 @@ class MasterService {
                 // Erase invalid memory replicas (those with unmounted
                 // segments). No client_mutex_ needed since we only check memory
                 // replicas.
-                it_->second.EraseReplicas([](const Replica& replica) {
-                    return replica.has_invalid_mem_handle();
-                });
+                service_->EraseReplicasWithCacheTotalAccounting(
+                    it_->second, [](const Replica& replica) {
+                        return replica.has_invalid_mem_handle();
+                    });
                 // If no valid replicas remain, delete the whole object.
                 if (!it_->second.IsValid()) {
                     const bool had_processing =
@@ -1480,7 +1502,8 @@ class MasterService {
 
         // Delete current metadata (for PutRevoke or Remove operations)
         void Erase() NO_THREAD_SAFETY_ANALYSIS {
-            service_->EraseMetadata(*tenant_state_, it_, object_id_.tenant_id);
+            service_->EraseMetadataWithCacheTotalAccounting(
+                *tenant_state_, it_, object_id_.tenant_id);
             it_ = tenant_state_->metadata.end();
             MaybeEraseEmptyTenant();
         }

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1181,11 +1181,6 @@ class MasterService {
     size_t EraseReplicasWithCacheTotalAccounting(
         ObjectMetadata& metadata,
         const std::function<bool(const Replica&)>& pred_fn);
-    std::unordered_map<std::string, ObjectMetadata>::iterator
-    EraseMetadataWithCacheTotalAccounting(
-        TenantState& tenant_state,
-        std::unordered_map<std::string, ObjectMetadata>::iterator it,
-        const std::string& tenant_id);
 
     std::unordered_map<std::string, std::string> object_group_ids_
         GUARDED_BY(group_routing_mutex_);
@@ -1502,8 +1497,7 @@ class MasterService {
 
         // Delete current metadata (for PutRevoke or Remove operations)
         void Erase() NO_THREAD_SAFETY_ANALYSIS {
-            service_->EraseMetadataWithCacheTotalAccounting(
-                *tenant_state_, it_, object_id_.tenant_id);
+            service_->EraseMetadata(*tenant_state_, it_, object_id_.tenant_id);
             it_ = tenant_state_->metadata.end();
             MaybeEraseEmptyTenant();
         }

--- a/mooncake-store/src/master_metric_manager.cpp
+++ b/mooncake-store/src/master_metric_manager.cpp
@@ -836,6 +836,10 @@ void MasterMetricManager::dec_mem_cache_nums(int64_t val) {
 void MasterMetricManager::dec_file_cache_nums(int64_t val) {
     file_cache_nums_.dec(val);
 }
+void MasterMetricManager::reset_cache_total_nums() {
+    mem_cache_nums_.reset();
+    file_cache_nums_.reset();
+}
 void MasterMetricManager::inc_valid_get_nums(int64_t val) {
     valid_get_nums_.inc(val);
 }

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -774,18 +774,10 @@ MasterService::EraseMetadata(
     const std::string& tenant_id) {
     const std::string key = it->first;
     const std::string group_id = it->second.group_id;
+    AccountCacheTotalRemoval(it->second);
     auto next = tenant_state.metadata.erase(it);
     UnregisterGroupMember(tenant_state, tenant_id, key, group_id);
     return next;
-}
-
-std::unordered_map<std::string, MasterService::ObjectMetadata>::iterator
-MasterService::EraseMetadataWithCacheTotalAccounting(
-    TenantState& tenant_state,
-    std::unordered_map<std::string, ObjectMetadata>::iterator it,
-    const std::string& tenant_id) {
-    AccountCacheTotalRemoval(it->second);
-    return EraseMetadata(tenant_state, it, tenant_id);
 }
 
 void MasterService::RebuildGroupRoutingIndex() {
@@ -875,8 +867,7 @@ void MasterService::ClearInvalidHandles(
                     tenant_state.replication_tasks.erase(it->first);
                     tenant_state.offloading_tasks.erase(it->first);
                     ErasePromotionTaskIfPresent(tenant_state, it->first);
-                    it = EraseMetadataWithCacheTotalAccounting(
-                        tenant_state, it, tenant_it->first);
+                    it = EraseMetadata(tenant_state, it, tenant_it->first);
                 } else {
                     ++it;
                 }
@@ -1744,8 +1735,7 @@ auto MasterService::PutStart(const UUID& client_id, const std::string& key,
                 tenant_state.replication_tasks.erase(key);
                 tenant_state.offloading_tasks.erase(key);
                 ErasePromotionTaskIfPresent(tenant_state, key);
-                EraseMetadataWithCacheTotalAccounting(tenant_state, it,
-                                                      object_id.tenant_id);
+                EraseMetadata(tenant_state, it, object_id.tenant_id);
                 it = tenant_state.metadata.end();
             } else {
                 auto& metadata = it->second;
@@ -1767,8 +1757,7 @@ auto MasterService::PutStart(const UUID& client_id, const std::string& key,
                             put_start_release_timeout_sec_);
                 }
                 tenant_state.processing_keys.erase(key);
-                EraseMetadataWithCacheTotalAccounting(tenant_state, it,
-                                                      object_id.tenant_id);
+                EraseMetadata(tenant_state, it, object_id.tenant_id);
                 it = tenant_state.metadata.end();
             }
         }
@@ -2080,8 +2069,7 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
             CleanupStaleHandles(it->second, alive_clients)) {
             tenant_state.processing_keys.erase(key);
             ErasePromotionTaskIfPresent(tenant_state, key);
-            EraseMetadataWithCacheTotalAccounting(tenant_state, it,
-                                                  object_id.tenant_id);
+            EraseMetadata(tenant_state, it, object_id.tenant_id);
             it = tenant_state.metadata.end();
         }
 
@@ -2134,8 +2122,7 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
                 // effectively does not exist — fall through to Case A.
                 if (!metadata.HasReplica(&Replica::fn_is_completed)) {
                     ErasePromotionTaskIfPresent(tenant_state, key);
-                    EraseMetadataWithCacheTotalAccounting(tenant_state, it,
-                                                          object_id.tenant_id);
+                    EraseMetadata(tenant_state, it, object_id.tenant_id);
                     it = tenant_state.metadata.end();
                 }
             }
@@ -2243,8 +2230,7 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
                     std::move(old_replicas),
                     now + put_start_release_timeout_sec_);
             }
-            EraseMetadataWithCacheTotalAccounting(tenant_state, it,
-                                                  object_id.tenant_id);
+            EraseMetadata(tenant_state, it, object_id.tenant_id);
 
             VLOG(1) << "key=" << key
                     << ", action=upsert_start_case_c_reallocate";
@@ -2943,8 +2929,7 @@ auto MasterService::RemoveByRegex(const std::string& regex_pattern,
                 VLOG(1) << "key=" << it->first
                         << " matched by regex. Removing.";
                 ErasePromotionTaskIfPresent(tenant_state, it->first);
-                it = EraseMetadataWithCacheTotalAccounting(tenant_state, it,
-                                                           normalized_tenant);
+                it = EraseMetadata(tenant_state, it, normalized_tenant);
                 removed_count++;
             } else {
                 ++it;
@@ -2980,8 +2965,7 @@ long MasterService::RemoveAll(bool force) {
                         &Replica::fn_is_memory_replica);
                     total_freed_size += it->second.size * mem_rep_count;
                     ErasePromotionTaskIfPresent(tenant_state, it->first);
-                    it = EraseMetadataWithCacheTotalAccounting(
-                        tenant_state, it, tenant_it->first);
+                    it = EraseMetadata(tenant_state, it, tenant_it->first);
                     removed_count++;
                 } else {
                     ++it;
@@ -3026,8 +3010,7 @@ long MasterService::RemoveAll(const std::string& tenant_id, bool force) {
                     it->second.CountReplicas(&Replica::fn_is_memory_replica);
                 total_freed_size += it->second.size * mem_rep_count;
                 ErasePromotionTaskIfPresent(tenant_state, it->first);
-                it = EraseMetadataWithCacheTotalAccounting(tenant_state, it,
-                                                           normalized_tenant);
+                it = EraseMetadata(tenant_state, it, normalized_tenant);
                 removed_count++;
             } else {
                 ++it;
@@ -3097,8 +3080,7 @@ auto MasterService::BatchRemove(const std::vector<std::string>& keys,
                 tenant_state.replication_tasks.erase(key);
                 tenant_state.offloading_tasks.erase(key);
                 ErasePromotionTaskIfPresent(tenant_state, key);
-                EraseMetadataWithCacheTotalAccounting(tenant_state, it,
-                                                      normalized_tenant);
+                EraseMetadata(tenant_state, it, normalized_tenant);
                 if (tenant_state.Empty()) {
                     shard->tenants.erase(tenant_it);
                 }
@@ -3138,8 +3120,7 @@ auto MasterService::BatchRemove(const std::vector<std::string>& keys,
 
             // Remove object metadata
             ErasePromotionTaskIfPresent(tenant_state, key);
-            EraseMetadataWithCacheTotalAccounting(tenant_state, it,
-                                                  normalized_tenant);
+            EraseMetadata(tenant_state, it, normalized_tenant);
             if (tenant_state.Empty()) {
                 shard->tenants.erase(tenant_it);
             }
@@ -3937,8 +3918,7 @@ void MasterService::DiscardExpiredProcessingReplicas(
             if (!metadata.IsValid() ||
                 metadata.AllReplicas(&Replica::fn_is_completed)) {
                 if (!metadata.IsValid()) {
-                    EraseMetadataWithCacheTotalAccounting(tenant_state, it,
-                                                          tenant_it->first);
+                    EraseMetadata(tenant_state, it, tenant_it->first);
                 }
                 key_it = tenant_state.processing_keys.erase(key_it);
                 continue;
@@ -3953,8 +3933,7 @@ void MasterService::DiscardExpiredProcessingReplicas(
                     discarded_replicas.emplace_back(std::move(replicas), ttl);
                 }
                 if (!metadata.IsValid()) {
-                    EraseMetadataWithCacheTotalAccounting(tenant_state, it,
-                                                          tenant_it->first);
+                    EraseMetadata(tenant_state, it, tenant_it->first);
                 }
                 key_it = tenant_state.processing_keys.erase(key_it);
                 continue;
@@ -3996,8 +3975,7 @@ void MasterService::DiscardExpiredProcessingReplicas(
                 discarded_replicas.emplace_back(std::move(replicas), ttl);
             }
             if (!metadata.IsValid()) {
-                EraseMetadataWithCacheTotalAccounting(tenant_state, metadata_it,
-                                                      tenant_it->first);
+                EraseMetadata(tenant_state, metadata_it, tenant_it->first);
             }
             task_it = tenant_state.replication_tasks.erase(task_it);
         }
@@ -5016,8 +4994,8 @@ bool MasterService::TryRestoreStateFromSnapshot(
                                 (it->second.IsLeaseExpired(cleanup_now) &&
                                  !it->second.IsSoftPinned(cleanup_now))) {
                                 VLOG(1) << "clear metadata key=" << it->first;
-                                it = EraseMetadataWithCacheTotalAccounting(
-                                    tenant_state, it, tenant_it->first);
+                                it = EraseMetadata(tenant_state, it,
+                                                   tenant_it->first);
                             } else {
                                 ++it;
                             }
@@ -5321,8 +5299,7 @@ void MasterService::BatchEvict(double evict_ratio_target,
                 result.evicted_objects++;
             }
             if (member_key != key && !member_metadata.IsValid()) {
-                EraseMetadataWithCacheTotalAccounting(tenant_state, member_it,
-                                                      tenant_id);
+                EraseMetadata(tenant_state, member_it, tenant_id);
             }
         }
         return result;
@@ -5406,8 +5383,8 @@ void MasterService::BatchEvict(double evict_ratio_target,
                                 /*allow_soft_pinned=*/false);
                             total_freed_size += evict_result.freed_bytes;
                             if (it->second.IsValid() == false) {
-                                it = EraseMetadataWithCacheTotalAccounting(
-                                    tenant_state, it, tenant_it->first);
+                                it = EraseMetadata(tenant_state, it,
+                                                   tenant_it->first);
                             } else {
                                 ++it;
                             }
@@ -5482,8 +5459,8 @@ void MasterService::BatchEvict(double evict_ratio_target,
                                     /*allow_soft_pinned=*/false);
                                 total_freed_size += evict_result.freed_bytes;
                                 if (!it->second.IsValid()) {
-                                    it = EraseMetadataWithCacheTotalAccounting(
-                                        tenant_state, it, tenant_it->first);
+                                    it = EraseMetadata(tenant_state, it,
+                                                       tenant_it->first);
                                 } else {
                                     ++it;
                                 }
@@ -5548,8 +5525,8 @@ void MasterService::BatchEvict(double evict_ratio_target,
                                     /*allow_soft_pinned=*/true);
                                 total_freed_size += evict_result.freed_bytes;
                                 if (!it->second.IsValid()) {
-                                    it = EraseMetadataWithCacheTotalAccounting(
-                                        tenant_state, it, tenant_it->first);
+                                    it = EraseMetadata(tenant_state, it,
+                                                       tenant_it->first);
                                 } else {
                                     ++it;
                                 }
@@ -5684,8 +5661,7 @@ void MasterService::NoFBatchEvict(double evict_ratio_target,
                 total_freed_size += metadata.size * erased;
                 shard_evicted_count++;
                 if (!metadata.IsValid()) {
-                    it = EraseMetadataWithCacheTotalAccounting(
-                        tenant_state, it, tenant_it->first);
+                    it = EraseMetadata(tenant_state, it, tenant_it->first);
                 } else {
                     ++it;
                 }

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -722,20 +722,6 @@ void MasterService::SyncCacheTotalAccounting(ObjectMetadata& metadata) {
     }
 }
 
-void MasterService::RefreshCacheTotalAfterReplicaRemoval(
-    ObjectMetadata& metadata) {
-    if (metadata.memory_cache_total_accounted &&
-        !HasCompletedMemoryCacheReplica(metadata)) {
-        MasterMetricManager::instance().dec_mem_cache_nums();
-        metadata.memory_cache_total_accounted = false;
-    }
-    if (metadata.disk_cache_total_accounted &&
-        !HasCompletedDiskCacheReplica(metadata)) {
-        MasterMetricManager::instance().dec_file_cache_nums();
-        metadata.disk_cache_total_accounted = false;
-    }
-}
-
 void MasterService::AccountCacheTotalRemoval(ObjectMetadata& metadata) {
     if (metadata.memory_cache_total_accounted) {
         MasterMetricManager::instance().dec_mem_cache_nums();
@@ -762,14 +748,14 @@ std::vector<Replica> MasterService::PopReplicasWithCacheTotalAccounting(
     ObjectMetadata& metadata,
     const std::function<bool(const Replica&)>& pred_fn) {
     auto replicas = metadata.PopReplicas(pred_fn);
-    RefreshCacheTotalAfterReplicaRemoval(metadata);
+    SyncCacheTotalAccounting(metadata);
     return replicas;
 }
 
 std::vector<Replica> MasterService::PopReplicasWithCacheTotalAccounting(
     ObjectMetadata& metadata) {
     auto replicas = metadata.PopReplicas();
-    RefreshCacheTotalAfterReplicaRemoval(metadata);
+    SyncCacheTotalAccounting(metadata);
     return replicas;
 }
 

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -747,6 +747,17 @@ void MasterService::AccountCacheTotalRemoval(ObjectMetadata& metadata) {
     }
 }
 
+void MasterService::RebuildCacheTotalAccounting() {
+    MasterMetricManager::instance().reset_cache_total_nums();
+    for (auto& shard : metadata_shards_) {
+        for (auto& tenant_entry : shard.tenants) {
+            for (auto& metadata_entry : tenant_entry.second.metadata) {
+                SyncCacheTotalAccounting(metadata_entry.second);
+            }
+        }
+    }
+}
+
 std::vector<Replica> MasterService::PopReplicasWithCacheTotalAccounting(
     ObjectMetadata& metadata,
     const std::function<bool(const Replica&)>& pred_fn) {
@@ -5035,6 +5046,7 @@ bool MasterService::TryRestoreStateFromSnapshot(
             }
 
             MasterMetricManager::instance().reset_allocated_mem_size();
+            RebuildCacheTotalAccounting();
             for (auto& segment_name : segment_names) {
                 MasterMetricManager::instance()
                     .reset_segment_allocated_mem_size(segment_name);
@@ -5142,6 +5154,7 @@ void MasterService::ResetStateAfterFailedRestoreAttempt() {
 
     MasterMetricManager::instance().reset_allocated_mem_size();
     MasterMetricManager::instance().reset_total_mem_capacity();
+    MasterMetricManager::instance().reset_cache_total_nums();
 }
 
 ha::SnapshotCatalogStore* MasterService::GetSnapshotCatalogStore() {

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -685,6 +685,91 @@ void MasterService::UnregisterGroupMember(TenantState& tenant_state,
     }
 }
 
+bool MasterService::HasCompletedMemoryCacheReplica(
+    const ObjectMetadata& metadata) {
+    return metadata.HasReplica([](const Replica& replica) {
+        return replica.is_memory_replica() && replica.is_completed();
+    });
+}
+
+bool MasterService::HasCompletedDiskCacheReplica(
+    const ObjectMetadata& metadata) {
+    return metadata.HasReplica([](const Replica& replica) {
+        return replica.is_disk_replica() && replica.is_completed();
+    });
+}
+
+void MasterService::SyncCacheTotalAccounting(ObjectMetadata& metadata) {
+    const bool has_memory_cache_replica =
+        HasCompletedMemoryCacheReplica(metadata);
+    const bool has_disk_cache_replica = HasCompletedDiskCacheReplica(metadata);
+
+    if (!metadata.memory_cache_total_accounted && has_memory_cache_replica) {
+        MasterMetricManager::instance().inc_mem_cache_nums();
+        metadata.memory_cache_total_accounted = true;
+    } else if (metadata.memory_cache_total_accounted &&
+               !has_memory_cache_replica) {
+        MasterMetricManager::instance().dec_mem_cache_nums();
+        metadata.memory_cache_total_accounted = false;
+    }
+
+    if (!metadata.disk_cache_total_accounted && has_disk_cache_replica) {
+        MasterMetricManager::instance().inc_file_cache_nums();
+        metadata.disk_cache_total_accounted = true;
+    } else if (metadata.disk_cache_total_accounted && !has_disk_cache_replica) {
+        MasterMetricManager::instance().dec_file_cache_nums();
+        metadata.disk_cache_total_accounted = false;
+    }
+}
+
+void MasterService::RefreshCacheTotalAfterReplicaRemoval(
+    ObjectMetadata& metadata) {
+    if (metadata.memory_cache_total_accounted &&
+        !HasCompletedMemoryCacheReplica(metadata)) {
+        MasterMetricManager::instance().dec_mem_cache_nums();
+        metadata.memory_cache_total_accounted = false;
+    }
+    if (metadata.disk_cache_total_accounted &&
+        !HasCompletedDiskCacheReplica(metadata)) {
+        MasterMetricManager::instance().dec_file_cache_nums();
+        metadata.disk_cache_total_accounted = false;
+    }
+}
+
+void MasterService::AccountCacheTotalRemoval(ObjectMetadata& metadata) {
+    if (metadata.memory_cache_total_accounted) {
+        MasterMetricManager::instance().dec_mem_cache_nums();
+        metadata.memory_cache_total_accounted = false;
+    }
+    if (metadata.disk_cache_total_accounted) {
+        MasterMetricManager::instance().dec_file_cache_nums();
+        metadata.disk_cache_total_accounted = false;
+    }
+}
+
+std::vector<Replica> MasterService::PopReplicasWithCacheTotalAccounting(
+    ObjectMetadata& metadata,
+    const std::function<bool(const Replica&)>& pred_fn) {
+    auto replicas = metadata.PopReplicas(pred_fn);
+    RefreshCacheTotalAfterReplicaRemoval(metadata);
+    return replicas;
+}
+
+std::vector<Replica> MasterService::PopReplicasWithCacheTotalAccounting(
+    ObjectMetadata& metadata) {
+    auto replicas = metadata.PopReplicas();
+    RefreshCacheTotalAfterReplicaRemoval(metadata);
+    return replicas;
+}
+
+size_t MasterService::EraseReplicasWithCacheTotalAccounting(
+    ObjectMetadata& metadata,
+    const std::function<bool(const Replica&)>& pred_fn) {
+    auto erased_replicas =
+        PopReplicasWithCacheTotalAccounting(metadata, pred_fn);
+    return erased_replicas.size();
+}
+
 std::unordered_map<std::string, MasterService::ObjectMetadata>::iterator
 MasterService::EraseMetadata(
     TenantState& tenant_state,
@@ -695,6 +780,15 @@ MasterService::EraseMetadata(
     auto next = tenant_state.metadata.erase(it);
     UnregisterGroupMember(tenant_state, tenant_id, key, group_id);
     return next;
+}
+
+std::unordered_map<std::string, MasterService::ObjectMetadata>::iterator
+MasterService::EraseMetadataWithCacheTotalAccounting(
+    TenantState& tenant_state,
+    std::unordered_map<std::string, ObjectMetadata>::iterator it,
+    const std::string& tenant_id) {
+    AccountCacheTotalRemoval(it->second);
+    return EraseMetadata(tenant_state, it, tenant_id);
 }
 
 void MasterService::RebuildGroupRoutingIndex() {
@@ -784,7 +878,8 @@ void MasterService::ClearInvalidHandles(
                     tenant_state.replication_tasks.erase(it->first);
                     tenant_state.offloading_tasks.erase(it->first);
                     ErasePromotionTaskIfPresent(tenant_state, it->first);
-                    it = EraseMetadata(tenant_state, it, tenant_it->first);
+                    it = EraseMetadataWithCacheTotalAccounting(
+                        tenant_state, it, tenant_it->first);
                 } else {
                     ++it;
                 }
@@ -1255,15 +1350,6 @@ auto MasterService::BatchReplicaClear(
                 continue;
             }
 
-            metadata.VisitReplicas(
-                &Replica::fn_is_completed, [](Replica& replica) {
-                    if (replica.is_memory_replica()) {
-                        MasterMetricManager::instance().dec_mem_cache_nums();
-                    } else if (replica.is_disk_replica()) {
-                        MasterMetricManager::instance().dec_file_cache_nums();
-                    }
-                });
-
             // Erase the entire metadata (all replicas will be deallocated)
             accessor.Erase();
             cleared_keys.emplace_back(key);
@@ -1288,15 +1374,8 @@ auto MasterService::BatchReplicaClear(
                 return false;
             };
 
-            metadata.VisitReplicas(
-                match_replica_on_segment, [&](Replica& replica) {
-                    has_replica_on_segment = true;
-                    if (replica.is_memory_replica()) {
-                        MasterMetricManager::instance().dec_mem_cache_nums();
-                    } else if (replica.is_disk_replica()) {
-                        MasterMetricManager::instance().dec_file_cache_nums();
-                    }
-                });
+            has_replica_on_segment =
+                metadata.HasReplica(match_replica_on_segment);
 
             if (!has_replica_on_segment) {
                 LOG(WARNING)
@@ -1306,7 +1385,8 @@ auto MasterService::BatchReplicaClear(
                 continue;
             }
 
-            metadata.EraseReplicas(match_replica_on_segment);
+            EraseReplicasWithCacheTotalAccounting(metadata,
+                                                  match_replica_on_segment);
 
             // If no valid replicas remain, erase the entire metadata
             if (!metadata.IsValid()) {
@@ -1667,7 +1747,8 @@ auto MasterService::PutStart(const UUID& client_id, const std::string& key,
                 tenant_state.replication_tasks.erase(key);
                 tenant_state.offloading_tasks.erase(key);
                 ErasePromotionTaskIfPresent(tenant_state, key);
-                EraseMetadata(tenant_state, it, object_id.tenant_id);
+                EraseMetadataWithCacheTotalAccounting(tenant_state, it,
+                                                      object_id.tenant_id);
                 it = tenant_state.metadata.end();
             } else {
                 auto& metadata = it->second;
@@ -1689,7 +1770,8 @@ auto MasterService::PutStart(const UUID& client_id, const std::string& key,
                             put_start_release_timeout_sec_);
                 }
                 tenant_state.processing_keys.erase(key);
-                EraseMetadata(tenant_state, it, object_id.tenant_id);
+                EraseMetadataWithCacheTotalAccounting(tenant_state, it,
+                                                      object_id.tenant_id);
                 it = tenant_state.metadata.end();
             }
         }
@@ -1787,12 +1869,8 @@ auto MasterService::PutEnd(const UUID& client_id, const std::string& key,
         accessor.EraseFromProcessing();
     }
 
-    if (replica_type == ReplicaType::MEMORY ||
-        (replica_type == ReplicaType::ALL && metadata.HasMemReplica())) {
-        MasterMetricManager::instance().inc_mem_cache_nums();
-    } else if (replica_type == ReplicaType::DISK) {
-        MasterMetricManager::instance().inc_file_cache_nums();
-    }  // TODO: add inc_nof_cache_nums() (ranhaojia)
+    SyncCacheTotalAccounting(metadata);
+    // TODO: add inc_nof_cache_nums() (ranhaojia)
     // 1. Set lease timeout to now, indicating that the object has no lease
     // at beginning. 2. If this object has soft pin enabled, set it to be soft
     // pinned.
@@ -1877,19 +1955,13 @@ auto MasterService::PutRevoke(const UUID& client_id, const std::string& key,
         return tl::make_unexpected(ErrorCode::INVALID_WRITE);
     }
 
-    if (replica_type == ReplicaType::MEMORY ||
-        (replica_type == ReplicaType::ALL && metadata.HasMemReplica())) {
-        MasterMetricManager::instance().dec_mem_cache_nums();
-    } else if (replica_type == ReplicaType::DISK) {
-        MasterMetricManager::instance().dec_file_cache_nums();
-    }
-
-    metadata.EraseReplicas([replica_type](const Replica& replica) {
-        if (replica_type == ReplicaType::ALL) {
-            return replica.is_memory_replica() || replica.is_nof_replica();
-        }
-        return replica.type() == replica_type;
-    });
+    EraseReplicasWithCacheTotalAccounting(
+        metadata, [replica_type](const Replica& replica) {
+            if (replica_type == ReplicaType::ALL) {
+                return replica.is_memory_replica() || replica.is_nof_replica();
+            }
+            return replica.type() == replica_type;
+        });
 
     // If the object is completed, remove it from the processing set.
     if (metadata.AllReplicas(&Replica::fn_is_completed) &&
@@ -2011,7 +2083,8 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
             CleanupStaleHandles(it->second, alive_clients)) {
             tenant_state.processing_keys.erase(key);
             ErasePromotionTaskIfPresent(tenant_state, key);
-            EraseMetadata(tenant_state, it, object_id.tenant_id);
+            EraseMetadataWithCacheTotalAccounting(tenant_state, it,
+                                                  object_id.tenant_id);
             it = tenant_state.metadata.end();
         }
 
@@ -2064,7 +2137,8 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
                 // effectively does not exist — fall through to Case A.
                 if (!metadata.HasReplica(&Replica::fn_is_completed)) {
                     ErasePromotionTaskIfPresent(tenant_state, key);
-                    EraseMetadata(tenant_state, it, object_id.tenant_id);
+                    EraseMetadataWithCacheTotalAccounting(tenant_state, it,
+                                                          object_id.tenant_id);
                     it = tenant_state.metadata.end();
                 }
             }
@@ -2132,6 +2206,7 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
                 metadata.VisitReplicas(
                     &Replica::fn_is_completed,
                     [](Replica& replica) { replica.mark_processing(); });
+                SyncCacheTotalAccounting(metadata);
 
                 tenant_state.processing_keys.insert(key);
 
@@ -2164,14 +2239,15 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
                 merged_config.with_soft_pin || metadata.IsSoftPinned();
 
             const std::string existing_group_id = metadata.group_id;
-            auto old_replicas = metadata.PopReplicas();
+            auto old_replicas = PopReplicasWithCacheTotalAccounting(metadata);
             if (!old_replicas.empty()) {
                 std::lock_guard lock(discarded_replicas_mutex_);
                 discarded_replicas_.emplace_back(
                     std::move(old_replicas),
                     now + put_start_release_timeout_sec_);
             }
-            EraseMetadata(tenant_state, it, object_id.tenant_id);
+            EraseMetadataWithCacheTotalAccounting(tenant_state, it,
+                                                  object_id.tenant_id);
 
             VLOG(1) << "key=" << key
                     << ", action=upsert_start_case_c_reallocate";
@@ -2270,9 +2346,9 @@ auto MasterService::EvictDiskReplica(const UUID& client_id,
     auto& metadata = accessor.Get();
 
     if (replica_type == ReplicaType::DISK) {
-        metadata.EraseReplicas(
+        EraseReplicasWithCacheTotalAccounting(
+            metadata,
             [](const Replica& replica) { return replica.is_disk_replica(); });
-        MasterMetricManager::instance().dec_file_cache_nums();
     } else if (replica_type == ReplicaType::LOCAL_DISK) {
         metadata.EraseReplicas([&client_id](const Replica& replica) {
             return replica.is_local_disk_replica() &&
@@ -2438,10 +2514,12 @@ tl::expected<void, ErrorCode> MasterService::CopyEnd(
                    << ", status=" << (source == nullptr ? "nullptr" : "invalid")
                    << ", copy source becomes invalid during data transfer";
         // Discard target replicas and clear the replication task.
-        metadata.EraseReplicas([&task](const Replica& replica) {
-            return std::find(task.replica_ids.begin(), task.replica_ids.end(),
-                             replica.id()) != task.replica_ids.end();
-        });
+        EraseReplicasWithCacheTotalAccounting(
+            metadata, [&task](const Replica& replica) {
+                return std::find(task.replica_ids.begin(),
+                                 task.replica_ids.end(),
+                                 replica.id()) != task.replica_ids.end();
+            });
         accessor.EraseReplicationTask();
         if (!metadata.IsValid()) {
             // Remove the object if it does not have any replicas.
@@ -2466,6 +2544,7 @@ tl::expected<void, ErrorCode> MasterService::CopyEnd(
             replica->mark_complete();
         }
     }
+    SyncCacheTotalAccounting(metadata);
 
     accessor.EraseReplicationTask();
 
@@ -2514,7 +2593,10 @@ tl::expected<void, ErrorCode> MasterService::CopyRevoke(
 
     // Erase all replica_ids
     for (const auto& replica_id : task.replica_ids) {
-        metadata.EraseReplicaByID(replica_id);
+        EraseReplicasWithCacheTotalAccounting(
+            metadata, [&replica_id](const Replica& replica) {
+                return replica.id() == replica_id;
+            });
     }
 
     accessor.EraseReplicationTask();
@@ -2656,10 +2738,12 @@ tl::expected<void, ErrorCode> MasterService::MoveEnd(
                    << ", status=" << (source == nullptr ? "nullptr" : "invalid")
                    << ", move source becomes invalid during data transfer";
         // Discard target replica and clear the replication task.
-        metadata.EraseReplicas([&task](const Replica& replica) {
-            return std::find(task.replica_ids.begin(), task.replica_ids.end(),
-                             replica.id()) != task.replica_ids.end();
-        });
+        EraseReplicasWithCacheTotalAccounting(
+            metadata, [&task](const Replica& replica) {
+                return std::find(task.replica_ids.begin(),
+                                 task.replica_ids.end(),
+                                 replica.id()) != task.replica_ids.end();
+            });
         accessor.EraseReplicationTask();
         if (!metadata.IsValid()) {
             // Remove the object if it does not have any replicas.
@@ -2687,11 +2771,12 @@ tl::expected<void, ErrorCode> MasterService::MoveEnd(
 
         // Mark replica as complete
         replica->mark_complete();
+        SyncCacheTotalAccounting(metadata);
     }
 
     // Remove the source replica and release its space later.
-    auto source_replica =
-        metadata.PopReplicas([&source_id](const Replica& replica) {
+    auto source_replica = PopReplicasWithCacheTotalAccounting(
+        metadata, [&source_id](const Replica& replica) {
             return replica.id() == source_id;
         });
     if (!source_replica.empty()) {
@@ -2747,7 +2832,10 @@ tl::expected<void, ErrorCode> MasterService::MoveRevoke(
 
     // Erase all replica_ids (in MOVE operation, there should be at most one)
     for (const auto& replica_id : task.replica_ids) {
-        metadata.EraseReplicaByID(replica_id);
+        EraseReplicasWithCacheTotalAccounting(
+            metadata, [&replica_id](const Replica& replica) {
+                return replica.id() == replica_id;
+            });
     }
 
     accessor.EraseReplicationTask();
@@ -2858,7 +2946,8 @@ auto MasterService::RemoveByRegex(const std::string& regex_pattern,
                 VLOG(1) << "key=" << it->first
                         << " matched by regex. Removing.";
                 ErasePromotionTaskIfPresent(tenant_state, it->first);
-                it = EraseMetadata(tenant_state, it, normalized_tenant);
+                it = EraseMetadataWithCacheTotalAccounting(tenant_state, it,
+                                                           normalized_tenant);
                 removed_count++;
             } else {
                 ++it;
@@ -2894,7 +2983,8 @@ long MasterService::RemoveAll(bool force) {
                         &Replica::fn_is_memory_replica);
                     total_freed_size += it->second.size * mem_rep_count;
                     ErasePromotionTaskIfPresent(tenant_state, it->first);
-                    it = EraseMetadata(tenant_state, it, tenant_it->first);
+                    it = EraseMetadataWithCacheTotalAccounting(
+                        tenant_state, it, tenant_it->first);
                     removed_count++;
                 } else {
                     ++it;
@@ -2939,7 +3029,8 @@ long MasterService::RemoveAll(const std::string& tenant_id, bool force) {
                     it->second.CountReplicas(&Replica::fn_is_memory_replica);
                 total_freed_size += it->second.size * mem_rep_count;
                 ErasePromotionTaskIfPresent(tenant_state, it->first);
-                it = EraseMetadata(tenant_state, it, normalized_tenant);
+                it = EraseMetadataWithCacheTotalAccounting(tenant_state, it,
+                                                           normalized_tenant);
                 removed_count++;
             } else {
                 ++it;
@@ -3009,7 +3100,8 @@ auto MasterService::BatchRemove(const std::vector<std::string>& keys,
                 tenant_state.replication_tasks.erase(key);
                 tenant_state.offloading_tasks.erase(key);
                 ErasePromotionTaskIfPresent(tenant_state, key);
-                EraseMetadata(tenant_state, it, normalized_tenant);
+                EraseMetadataWithCacheTotalAccounting(tenant_state, it,
+                                                      normalized_tenant);
                 if (tenant_state.Empty()) {
                     shard->tenants.erase(tenant_it);
                 }
@@ -3049,7 +3141,8 @@ auto MasterService::BatchRemove(const std::vector<std::string>& keys,
 
             // Remove object metadata
             ErasePromotionTaskIfPresent(tenant_state, key);
-            EraseMetadata(tenant_state, it, normalized_tenant);
+            EraseMetadataWithCacheTotalAccounting(tenant_state, it,
+                                                  normalized_tenant);
             if (tenant_state.Empty()) {
                 shard->tenants.erase(tenant_it);
             }
@@ -3065,12 +3158,13 @@ bool MasterService::CleanupStaleHandles(
     const std::unordered_set<UUID, boost::hash<UUID>>& alive_clients) {
     // Remove those with invalid allocators (memory replicas on unmounted
     // segments) and local_disk replicas whose owner client is no longer alive.
-    metadata.EraseReplicas([&alive_clients](const Replica& replica) {
-        return (replica.has_invalid_mem_handle() ||
-                replica.has_invalid_nof_handle() ||
-                replica.has_stale_local_disk_client(alive_clients)) &&
-               replica.is_completed();
-    });
+    EraseReplicasWithCacheTotalAccounting(
+        metadata, [&alive_clients](const Replica& replica) {
+            return (replica.has_invalid_mem_handle() ||
+                    replica.has_invalid_nof_handle() ||
+                    replica.has_stale_local_disk_client(alive_clients)) &&
+                   replica.is_completed();
+        });
 
     // Return true if no valid replicas remain after cleanup
     return !metadata.IsValid();
@@ -3669,6 +3763,7 @@ auto MasterService::NotifyPromotionSuccess(const UUID& client_id,
     promotion_in_flight_.fetch_sub(1, std::memory_order_relaxed);
     MasterMetricManager::instance().dec_promotion_in_flight();
     if (committed) {
+        SyncCacheTotalAccounting(metadata);
         MasterMetricManager::instance().inc_promotion_completed();
         MasterMetricManager::instance().inc_promotion_completed_bytes(
             static_cast<int64_t>(completed_bytes));
@@ -3731,7 +3826,11 @@ auto MasterService::NotifyPromotionFailure(const UUID& client_id,
         source->dec_refcnt();
     }
     if (task_it->second.alloc_id != 0) {
-        metadata.EraseReplicaByID(task_it->second.alloc_id);
+        const ReplicaID alloc_id = task_it->second.alloc_id;
+        EraseReplicasWithCacheTotalAccounting(
+            metadata, [alloc_id](const Replica& replica) {
+                return replica.id() == alloc_id;
+            });
     }
     tenant_state.promotion_tasks.erase(task_it);
     promotion_in_flight_.fetch_sub(1, std::memory_order_relaxed);
@@ -3841,7 +3940,8 @@ void MasterService::DiscardExpiredProcessingReplicas(
             if (!metadata.IsValid() ||
                 metadata.AllReplicas(&Replica::fn_is_completed)) {
                 if (!metadata.IsValid()) {
-                    EraseMetadata(tenant_state, it, tenant_it->first);
+                    EraseMetadataWithCacheTotalAccounting(tenant_state, it,
+                                                          tenant_it->first);
                 }
                 key_it = tenant_state.processing_keys.erase(key_it);
                 continue;
@@ -3856,7 +3956,8 @@ void MasterService::DiscardExpiredProcessingReplicas(
                     discarded_replicas.emplace_back(std::move(replicas), ttl);
                 }
                 if (!metadata.IsValid()) {
-                    EraseMetadata(tenant_state, it, tenant_it->first);
+                    EraseMetadataWithCacheTotalAccounting(tenant_state, it,
+                                                          tenant_it->first);
                 }
                 key_it = tenant_state.processing_keys.erase(key_it);
                 continue;
@@ -3888,8 +3989,8 @@ void MasterService::DiscardExpiredProcessingReplicas(
             }
 
             auto& replica_ids = task_it->second.replica_ids;
-            auto replicas =
-                metadata.PopReplicas([&replica_ids](const Replica& replica) {
+            auto replicas = PopReplicasWithCacheTotalAccounting(
+                metadata, [&replica_ids](const Replica& replica) {
                     auto it = std::find(replica_ids.begin(), replica_ids.end(),
                                         replica.id());
                     return it != replica_ids.end();
@@ -3898,7 +3999,8 @@ void MasterService::DiscardExpiredProcessingReplicas(
                 discarded_replicas.emplace_back(std::move(replicas), ttl);
             }
             if (!metadata.IsValid()) {
-                EraseMetadata(tenant_state, metadata_it, tenant_it->first);
+                EraseMetadataWithCacheTotalAccounting(tenant_state, metadata_it,
+                                                      tenant_it->first);
             }
             task_it = tenant_state.replication_tasks.erase(task_it);
         }
@@ -3940,8 +4042,12 @@ void MasterService::DiscardExpiredProcessingReplicas(
                     source->dec_refcnt();
                 }
                 if (task_it->second.alloc_id != 0) {
-                    metadata_it->second.EraseReplicaByID(
-                        task_it->second.alloc_id);
+                    const ReplicaID alloc_id = task_it->second.alloc_id;
+                    EraseReplicasWithCacheTotalAccounting(
+                        metadata_it->second,
+                        [alloc_id](const Replica& replica) {
+                            return replica.id() == alloc_id;
+                        });
                 }
             }
             LOG(WARNING) << "Promotion task expired for key: "
@@ -4913,8 +5019,8 @@ bool MasterService::TryRestoreStateFromSnapshot(
                                 (it->second.IsLeaseExpired(cleanup_now) &&
                                  !it->second.IsSoftPinned(cleanup_now))) {
                                 VLOG(1) << "clear metadata key=" << it->first;
-                                it = EraseMetadata(tenant_state, it,
-                                                   tenant_it->first);
+                                it = EraseMetadataWithCacheTotalAccounting(
+                                    tenant_state, it, tenant_it->first);
                             } else {
                                 ++it;
                             }
@@ -5072,7 +5178,8 @@ void MasterService::BatchEvict(double evict_ratio_target,
     auto evict_replicas =
         [&](ObjectMetadata& metadata,
             std::vector<std::vector<Replica>>& deferred_replicas) {
-            auto replicas = metadata.PopReplicas(is_evictable_memory_replica);
+            auto replicas = PopReplicasWithCacheTotalAccounting(
+                metadata, is_evictable_memory_replica);
             const size_t replica_count = replicas.size();
             if (!replicas.empty()) {
                 deferred_replicas.emplace_back(std::move(replicas));
@@ -5215,7 +5322,8 @@ void MasterService::BatchEvict(double evict_ratio_target,
                 result.evicted_objects++;
             }
             if (member_key != key && !member_metadata.IsValid()) {
-                EraseMetadata(tenant_state, member_it, tenant_id);
+                EraseMetadataWithCacheTotalAccounting(tenant_state, member_it,
+                                                      tenant_id);
             }
         }
         return result;
@@ -5299,8 +5407,8 @@ void MasterService::BatchEvict(double evict_ratio_target,
                                 /*allow_soft_pinned=*/false);
                             total_freed_size += evict_result.freed_bytes;
                             if (it->second.IsValid() == false) {
-                                it = EraseMetadata(tenant_state, it,
-                                                   tenant_it->first);
+                                it = EraseMetadataWithCacheTotalAccounting(
+                                    tenant_state, it, tenant_it->first);
                             } else {
                                 ++it;
                             }
@@ -5375,8 +5483,8 @@ void MasterService::BatchEvict(double evict_ratio_target,
                                     /*allow_soft_pinned=*/false);
                                 total_freed_size += evict_result.freed_bytes;
                                 if (!it->second.IsValid()) {
-                                    it = EraseMetadata(tenant_state, it,
-                                                       tenant_it->first);
+                                    it = EraseMetadataWithCacheTotalAccounting(
+                                        tenant_state, it, tenant_it->first);
                                 } else {
                                     ++it;
                                 }
@@ -5441,8 +5549,8 @@ void MasterService::BatchEvict(double evict_ratio_target,
                                     /*allow_soft_pinned=*/true);
                                 total_freed_size += evict_result.freed_bytes;
                                 if (!it->second.IsValid()) {
-                                    it = EraseMetadata(tenant_state, it,
-                                                       tenant_it->first);
+                                    it = EraseMetadataWithCacheTotalAccounting(
+                                        tenant_state, it, tenant_it->first);
                                 } else {
                                     ++it;
                                 }
@@ -5577,7 +5685,8 @@ void MasterService::NoFBatchEvict(double evict_ratio_target,
                 total_freed_size += metadata.size * erased;
                 shard_evicted_count++;
                 if (!metadata.IsValid()) {
-                    it = EraseMetadata(tenant_state, it, tenant_it->first);
+                    it = EraseMetadataWithCacheTotalAccounting(
+                        tenant_state, it, tenant_it->first);
                 } else {
                     ++it;
                 }

--- a/mooncake-store/tests/ha/snapshot/master_service_ssd_test_for_snapshot.cpp
+++ b/mooncake-store/tests/ha/snapshot/master_service_ssd_test_for_snapshot.cpp
@@ -89,6 +89,65 @@ TEST_F(MasterServiceSSDSnapshotTest, PutEndBothReplica) {
     }
 }
 
+TEST_F(MasterServiceSSDSnapshotTest, RestorePreservesCacheTotalMetrics) {
+    MasterMetricManager::instance().reset_cache_total_nums();
+
+    CreateMasterServiceWithSSDFeat("/mnt/ssd");
+    EnsureSnapshotStores(service_.get());
+
+    constexpr size_t buffer = 0x330000000;
+    constexpr size_t size = 1024 * 1024 * 64;
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = "test_segment_restore_cache_totals";
+    segment.base = buffer;
+    segment.size = size;
+    segment.te_endpoint = segment.name;
+    UUID client_id = generate_uuid();
+
+    ASSERT_TRUE(service_->MountSegment(segment, client_id).has_value());
+
+    std::string key = "restore_cache_total_metric_key";
+    ASSERT_TRUE(
+        service_->PutStart(client_id, key, "default", 1024, {.replica_num = 1})
+            .has_value());
+    EXPECT_TRUE(service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY)
+                    .has_value());
+    EXPECT_TRUE(service_->PutEnd(client_id, key, "default", ReplicaType::DISK)
+                    .has_value());
+
+    auto& metrics = MasterMetricManager::instance();
+    using CacheHitStat = MasterMetricManager::CacheHitStat;
+    auto stats = metrics.calculate_cache_stats();
+    ASSERT_EQ(stats[CacheHitStat::MEMORY_TOTAL], 1);
+    ASSERT_EQ(stats[CacheHitStat::SSD_TOTAL], 1);
+
+    std::string snapshot_id = GenerateSnapshotId();
+    auto persist_result = CallPersistState(service_.get(), snapshot_id);
+    ASSERT_TRUE(persist_result.has_value())
+        << "Failed to persist state: " << persist_result.error().message;
+
+    metrics.reset_cache_total_nums();
+
+    ::setenv("MOONCAKE_MASTER_SERVICE_SNAPSHOT_TEST_SKIP_CLEANUP", "1", 1);
+    auto restore_config = MasterServiceConfig::builder()
+                              .set_enable_snapshot_restore(true)
+                              .set_snapshot_object_store_type("local")
+                              .set_root_fs_dir("/mnt/ssd")
+                              .build();
+    std::unique_ptr<MasterService> restored_service(
+        new MasterService(restore_config));
+    ::unsetenv("MOONCAKE_MASTER_SERVICE_SNAPSHOT_TEST_SKIP_CLEANUP");
+
+    stats = metrics.calculate_cache_stats();
+    EXPECT_EQ(stats[CacheHitStat::MEMORY_TOTAL], 1);
+    EXPECT_EQ(stats[CacheHitStat::SSD_TOTAL], 1);
+
+    auto get_result = restored_service->GetReplicaList(key, "default");
+    ASSERT_TRUE(get_result.has_value());
+    EXPECT_EQ(2, get_result.value().replicas.size());
+}
+
 TEST_F(MasterServiceSSDSnapshotTest, PutRevokeDiskReplica) {
     CreateMasterServiceWithSSDFeat("/mnt/ssd");
 

--- a/mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot_base.h
+++ b/mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot_base.h
@@ -54,6 +54,7 @@ class MasterServiceSnapshotTestBase : public ::testing::Test {
         // eviction behavior inconsistency and snapshot comparison failures
         MasterMetricManager::instance().reset_allocated_mem_size();
         MasterMetricManager::instance().reset_total_mem_capacity();
+        MasterMetricManager::instance().reset_cache_total_nums();
 
         // Create a unique temporary directory for this test
         namespace fs = std::filesystem;
@@ -163,6 +164,18 @@ class MasterServiceSnapshotTestBase : public ::testing::Test {
     static tl::expected<void, SerializationError> CallPersistState(
         MasterService* service, const std::string& snapshot_id) {
         return service->PersistState(snapshot_id);
+    }
+
+    static void EnsureSnapshotStores(MasterService* service) {
+        if (!service->snapshot_object_store_) {
+            service->snapshot_object_store_ = SnapshotObjectStore::Create(
+                SnapshotObjectStoreType::LOCAL_FILE);
+        }
+        if (!service->snapshot_catalog_store_ &&
+            service->snapshot_object_store_) {
+            service->snapshot_catalog_store_ =
+                service->CreateSnapshotCatalogStore();
+        }
     }
 
     // Generate unique snapshot ID (timestamp format)
@@ -792,19 +805,10 @@ class MasterServiceSnapshotTestBase : public ::testing::Test {
             << "Use 'service_.reset(new MasterService(...))' instead of "
                "'std::unique_ptr<MasterService> service_(...)'";
 
-        // Ensure snapshot_object_store_ is initialized for PersistState
         // Some test configs may not enable snapshot/restore, so the backend
         // is not created in the constructor. We create it here for TearDown
         // validation.
-        if (!service_->snapshot_object_store_) {
-            service_->snapshot_object_store_ = SnapshotObjectStore::Create(
-                SnapshotObjectStoreType::LOCAL_FILE);
-        }
-        if (!service_->snapshot_catalog_store_ &&
-            service_->snapshot_object_store_) {
-            service_->snapshot_catalog_store_ =
-                service_->CreateSnapshotCatalogStore();
-        }
+        EnsureSnapshotStores(service_.get());
 
         // Test snapshot and restore functionality for all test cases
         TestSnapshotAndRestore(service_);

--- a/mooncake-store/tests/master_service_ssd_test.cpp
+++ b/mooncake-store/tests/master_service_ssd_test.cpp
@@ -7,6 +7,7 @@
 #include <thread>
 #include <vector>
 
+#include "master_metric_manager.h"
 #include "types.h"
 
 namespace mooncake::test {
@@ -123,6 +124,51 @@ TEST_F(MasterServiceSSDTest, PutRevokeDiskReplica) {
     ASSERT_TRUE(get_result.has_value());
     EXPECT_EQ(1, get_result.value().replicas.size());
     ASSERT_TRUE(get_result.value().replicas[0].is_memory_replica());
+}
+
+TEST_F(MasterServiceSSDTest, PutRevokeProcessingDiskKeepsSsdTotal) {
+    auto service_ = CreateMasterServiceWithSSDFeat("/mnt/ssd");
+    auto& metrics = MasterMetricManager::instance();
+    using CacheHitStat = MasterMetricManager::CacheHitStat;
+    const auto base_stats = metrics.calculate_cache_stats();
+    const double base_memory_total = base_stats.at(CacheHitStat::MEMORY_TOTAL);
+    const double base_ssd_total = base_stats.at(CacheHitStat::SSD_TOTAL);
+
+    constexpr size_t buffer = 0x310000000;
+    constexpr size_t size = 1024 * 1024 * 64;
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = "test_segment_revoke_processing_disk";
+    segment.base = buffer;
+    segment.size = size;
+    segment.te_endpoint = segment.name;
+    UUID client_id = generate_uuid();
+
+    ASSERT_TRUE(service_->MountSegment(segment, client_id).has_value());
+
+    std::string key = "revoke_processing_disk_metric_key";
+    ASSERT_TRUE(
+        service_->PutStart(client_id, key, "default", 1024, {.replica_num = 1})
+            .has_value());
+    EXPECT_TRUE(service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY)
+                    .has_value());
+
+    auto stats = metrics.calculate_cache_stats();
+    EXPECT_EQ(stats[CacheHitStat::MEMORY_TOTAL], base_memory_total + 1);
+    EXPECT_EQ(stats[CacheHitStat::SSD_TOTAL], base_ssd_total);
+
+    EXPECT_TRUE(
+        service_->PutRevoke(client_id, key, "default", ReplicaType::DISK)
+            .has_value());
+
+    stats = metrics.calculate_cache_stats();
+    EXPECT_EQ(stats[CacheHitStat::MEMORY_TOTAL], base_memory_total + 1);
+    EXPECT_EQ(stats[CacheHitStat::SSD_TOTAL], base_ssd_total);
+
+    ASSERT_TRUE(service_->Remove(key, "default", /*force=*/true).has_value());
+    stats = metrics.calculate_cache_stats();
+    EXPECT_EQ(stats[CacheHitStat::MEMORY_TOTAL], base_memory_total);
+    EXPECT_EQ(stats[CacheHitStat::SSD_TOTAL], base_ssd_total);
 }
 
 TEST_F(MasterServiceSSDTest, PutRevokeMemoryReplica) {
@@ -457,6 +503,46 @@ TEST_F(MasterServiceSSDTest, EvictDiskReplica_RemovesDiskReplica) {
     ASSERT_TRUE(get_result.has_value());
     EXPECT_EQ(1, get_result.value().replicas.size());
     EXPECT_TRUE(get_result.value().replicas[0].is_memory_replica());
+}
+
+TEST_F(MasterServiceSSDTest, RemoveDecrementsCacheTotalMetrics) {
+    auto service_ = CreateMasterServiceWithSSDFeat("/mnt/ssd");
+    auto& metrics = MasterMetricManager::instance();
+    using CacheHitStat = MasterMetricManager::CacheHitStat;
+    const auto base_stats = metrics.calculate_cache_stats();
+    const double base_memory_total = base_stats.at(CacheHitStat::MEMORY_TOTAL);
+    const double base_ssd_total = base_stats.at(CacheHitStat::SSD_TOTAL);
+
+    constexpr size_t buffer = 0x320000000;
+    constexpr size_t size = 1024 * 1024 * 64;
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = "test_segment_remove_metrics";
+    segment.base = buffer;
+    segment.size = size;
+    segment.te_endpoint = segment.name;
+    UUID client_id = generate_uuid();
+
+    ASSERT_TRUE(service_->MountSegment(segment, client_id).has_value());
+
+    std::string key = "remove_cache_total_metric_key";
+    ASSERT_TRUE(
+        service_->PutStart(client_id, key, "default", 1024, {.replica_num = 1})
+            .has_value());
+    EXPECT_TRUE(service_->PutEnd(client_id, key, "default", ReplicaType::MEMORY)
+                    .has_value());
+    EXPECT_TRUE(service_->PutEnd(client_id, key, "default", ReplicaType::DISK)
+                    .has_value());
+
+    auto stats = metrics.calculate_cache_stats();
+    EXPECT_EQ(stats[CacheHitStat::MEMORY_TOTAL], base_memory_total + 1);
+    EXPECT_EQ(stats[CacheHitStat::SSD_TOTAL], base_ssd_total + 1);
+
+    ASSERT_TRUE(service_->Remove(key, "default", /*force=*/true).has_value());
+
+    stats = metrics.calculate_cache_stats();
+    EXPECT_EQ(stats[CacheHitStat::MEMORY_TOTAL], base_memory_total);
+    EXPECT_EQ(stats[CacheHitStat::SSD_TOTAL], base_ssd_total);
 }
 
 TEST_F(MasterServiceSSDTest, EvictDiskReplica_NonExistentKeyReturnsError) {


### PR DESCRIPTION
## Description

Fixes #2457.

This PR fixes Mooncake Store cache-total accounting drift for `MEMORY_TOTAL` and `SSD_TOTAL`:

- Tracks per-object MEMORY/DISK cache-total accounting state.
- Updates totals when completed replicas are added, removed, or whole metadata entries are erased.
- Rebuilds cache-total metrics after snapshot restore.
- Adds regression coverage for remove paths, uncounted processing-DISK revoke, and snapshot restore.

## Module

- [x] Mooncake Store (`mooncake-store`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

```bash
PATH="/opt/homebrew/opt/llvm@20/bin:$PATH" pre-commit run --files \
  mooncake-store/include/master_metric_manager.h \
  mooncake-store/src/master_metric_manager.cpp \
  mooncake-store/include/master_service.h \
  mooncake-store/src/master_service.cpp \
  mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot_base.h \
  mooncake-store/tests/ha/snapshot/master_service_ssd_test_for_snapshot.cpp

# Ubuntu 24.04
cmake -S . -B build-master-metrics -G Ninja \
  -DBUILD_UNIT_TESTS=ON -DWITH_STORE=ON -DWITH_TE=ON \
  -DWITH_STORE_RUST=OFF -DWITH_EP=OFF -DWITH_P2P_STORE=OFF -DWITH_STORE_GO=OFF
cmake --build build-master-metrics --target \
  master_service_ssd_test master_service_ssd_test_for_snapshot master_metrics_test -j 8
cd build-master-metrics && ctest -R "^(master_service_ssd_test|master_service_ssd_test_for_snapshot|master_metrics_test)$" --output-on-failure
```

Result: 3/3 selected tests passed on Ubuntu 24.04.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run focused `pre-commit run --files` and all selected hooks pass
- [x] I have updated the documentation (not applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue (not applicable)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used: Codex assisted with code changes, validation, and PR preparation.
