### PR TITLE
[Store] add codec inference and recursive structure expansion

### DIFF
--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -1415,7 +1415,10 @@ def _can_numeric_sequence(values: list[Any]) -> _CodecDecision:
         if arr.dtype == object or not np.issubdtype(arr.dtype, np.number):
             return _CodecDecision(False, "typed_ragged", f"non-numeric dtype: {arr.dtype}", "numeric sequence")
         dtypes.append(arr.dtype)
-    dtype = np.result_type(*dtypes)
+    try:
+        dtype = np.result_type(*dtypes)
+    except (TypeError, ValueError, OverflowError):
+        return _CodecDecision(False, "typed_ragged", "cannot determine common dtype", "numeric sequence")
     return _CodecDecision(True, "typed_ragged", "all rows promote to common numeric dtype", "numeric sequence", {"dtype": str(dtype)})
 
 
@@ -1442,7 +1445,7 @@ def _can_json(values: list[Any]) -> _CodecDecision:
     for v in nn[:_INFER_MAX_SAMPLE_ROWS]:
         try:
             total_bytes += len(json.dumps(v, ensure_ascii=False, separators=(",", ":")).encode("utf-8"))
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, OverflowError, RecursionError):
             return _CodecDecision(False, "json_ragged", "serialization failed", "json")
     if total_bytes > _INFER_MAX_JSON_BYTES:
         return _CodecDecision(False, "json_ragged", "sampled payload too large", "json")

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -1337,16 +1337,26 @@ class _InferredLeaf:
     decision: _CodecDecision
 
 
+class _Missing:
+    """Sentinel for dict keys absent from a row (distinct from value-is-None)."""
+    __slots__ = ()
+    def __repr__(self) -> str:
+        return "<MISSING>"
+
+MISSING = _Missing()
+
+
 @dataclass
 class _InferredNode:
     path: str
     node_type: str
     children: list[Any]
     lengths: list[int] | None = None
+    row_mask: list[bool] | None = None
 
 
 def _non_null(values: list[Any]) -> list[Any]:
-    return [v for v in values if v is not None]
+    return [v for v in values if v is not None and not isinstance(v, _Missing)]
 
 
 def _is_pil_image(value: Any) -> bool:
@@ -1495,6 +1505,10 @@ def _try_expand_list(values: list[Any]) -> tuple[int, list[int]] | None:
     return max_len, lengths
 
 
+def _escape_key(key: str) -> str:
+    return key.replace("\\", "\\\\").replace(".", "\\.").replace("[", "\\[")
+
+
 def infer_structure(
     path: str,
     values: list[Any],
@@ -1506,23 +1520,29 @@ def infer_structure(
     """Recursively expand *values* into leaves and interior nodes.
 
     *leaves* and *nodes* are output accumulators populated during recursion.
+    Absent dict keys are represented as ``MISSING`` in child columns
+    (distinct from ``None`` values).  Each interior node carries a
+    ``row_mask`` that records which rows had a real parent container.
     """
     if _depth > _INFER_MAX_DEPTH:
         raise ValueError(f"infer_structure exceeded max depth {_INFER_MAX_DEPTH} at {path!r}")
     dict_keys = _try_expand_dict(values)
     if dict_keys is not None:
-        nodes.append(_InferredNode(path, "dict", dict_keys))
+        row_mask = [isinstance(v, dict) for v in values]
+        nodes.append(_InferredNode(path, "dict", dict_keys, row_mask=row_mask))
         for key in dict_keys:
-            child = [v.get(key) if isinstance(v, dict) else None for v in values]
-            infer_structure(f"{path}.{key}", child, leaves, nodes, _depth=_depth + 1)
+            child = [v.get(key, MISSING) if isinstance(v, dict) else None for v in values]
+            infer_structure(f"{path}.{_escape_key(key)}", child, leaves, nodes, _depth=_depth + 1)
         return
     list_result = _try_expand_list(values)
     if list_result is not None:
         max_len, lengths = list_result
-        nodes.append(_InferredNode(path, "list", list(range(max_len)), lengths))
+        row_mask = [isinstance(v, (list, tuple)) for v in values]
+        nodes.append(_InferredNode(path, "list", list(range(max_len)), lengths, row_mask=row_mask))
         for index in range(max_len):
             child = [
-                v[index] if isinstance(v, (list, tuple)) and index < len(v) else None
+                v[index] if isinstance(v, (list, tuple)) and index < len(v) else
+                (MISSING if isinstance(v, (list, tuple)) else None)
                 for v in values
             ]
             infer_structure(f"{path}[{index}]", child, leaves, nodes, _depth=_depth + 1)

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -1391,6 +1391,9 @@ def _can_tensor(values: list[Any]) -> _CodecDecision:
     dtypes = sorted({str(v.dtype) for v in nn})
     if len(dtypes) != 1:
         return _CodecDecision(False, "ragged_tensor", f"mixed dtypes: {dtypes}", "torch.Tensor")
+    ndims = {v.ndim for v in nn}
+    if len(ndims) != 1:
+        return _CodecDecision(False, "ragged_tensor", f"mixed dimensions: {ndims}", "torch.Tensor")
     return _CodecDecision(True, "ragged_tensor", "all non-null rows are Tensor", "torch.Tensor", {"dtype": dtypes[0]})
 
 
@@ -1424,7 +1427,7 @@ def _can_numeric_scalar(values: list[Any]) -> _CodecDecision:
         return _CodecDecision(False, "ndarray", "not all rows are numeric scalar", "numeric scalar")
     try:
         dtype = np.result_type(*nn)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         return _CodecDecision(False, "ndarray", "cannot determine common dtype", "numeric scalar")
     if not np.issubdtype(dtype, np.number) and not np.issubdtype(dtype, np.bool_):
         return _CodecDecision(False, "ndarray", f"non-numeric dtype: {dtype}", "numeric scalar")
@@ -1483,7 +1486,7 @@ def _try_expand_list(values: list[Any]) -> tuple[int, list[int]] | None:
     max_len = max(len(v) for v in nn)
     if max_len > _INFER_MAX_LIST_LEN:
         return None
-    if not all(isinstance(item, (dict, list, tuple)) for v in nn for item in v):
+    if not all(item is None or isinstance(item, (dict, list, tuple)) for v in nn for item in v):
         return None
     lengths = [len(v) if isinstance(v, (list, tuple)) else 0 for v in values]
     return max_len, lengths

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -5,7 +5,7 @@ import json
 import uuid
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Iterator, Literal, Mapping, Optional, Protocol, Sequence
 
 import numpy as np
@@ -1303,3 +1303,222 @@ def _cleanup_keys(store: BundleStore, keys: Sequence[str], strict: bool) -> None
         raise RuntimeError(
             f"failed to remove {len(retry_errors)} Mooncake keys: {retry_errors[:3]}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Codec inference and recursive structure expansion
+# ---------------------------------------------------------------------------
+
+_INFER_MAX_STRUCT_KEYS = 64
+_INFER_MAX_LIST_LEN = 8
+_INFER_MAX_SAMPLE_ROWS = 128
+_INFER_MAX_JSON_BYTES = 1 << 20
+_INFER_MAX_DEPTH = 32
+
+try:
+    import torch as _torch
+except Exception:  # pragma: no cover
+    _torch = None  # type: ignore[assignment]
+
+
+@dataclass
+class _CodecDecision:
+    accepted: bool
+    codec: str
+    reason: str
+    normalized_type: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class _InferredLeaf:
+    path: str
+    values: list[Any]
+    decision: _CodecDecision
+
+
+@dataclass
+class _InferredNode:
+    path: str
+    node_type: str
+    children: list[Any]
+    lengths: list[int] | None = None
+
+
+def _non_null(values: list[Any]) -> list[Any]:
+    return [v for v in values if v is not None]
+
+
+def _is_pil_image(value: Any) -> bool:
+    module = getattr(value.__class__, "__module__", None) or ""
+    return module.startswith("PIL.") and hasattr(value, "save")
+
+
+def _is_bytes_like(value: Any) -> bool:
+    return isinstance(value, (bytes, bytearray, memoryview))
+
+
+def _is_media_list(value: Any) -> bool:
+    return (
+        isinstance(value, (list, tuple))
+        and len(value) > 0
+        and all(_is_pil_image(item) or _is_bytes_like(item) for item in value)
+    )
+
+
+def _check_all(
+    values: list[Any],
+    predicate: Any,
+    codec: str,
+    normalized_type: str,
+) -> _CodecDecision:
+    nn = _non_null(values)
+    if not nn:
+        return _CodecDecision(False, codec, "all rows are null", normalized_type)
+    if not all(predicate(v) for v in nn):
+        return _CodecDecision(False, codec, f"not all rows are {normalized_type}", normalized_type)
+    return _CodecDecision(True, codec, f"all non-null rows are {normalized_type}", normalized_type)
+
+
+def _can_tensor(values: list[Any]) -> _CodecDecision:
+    if _torch is None:
+        return _CodecDecision(False, "ragged_tensor", "torch is not available", "torch.Tensor")
+    nn = _non_null(values)
+    if not nn:
+        return _CodecDecision(False, "ragged_tensor", "all rows are null", "torch.Tensor")
+    if not all(isinstance(v, _torch.Tensor) for v in nn):
+        return _CodecDecision(False, "ragged_tensor", "not all rows are Tensor", "torch.Tensor")
+    dtypes = sorted({str(v.dtype) for v in nn})
+    if len(dtypes) != 1:
+        return _CodecDecision(False, "ragged_tensor", f"mixed dtypes: {dtypes}", "torch.Tensor")
+    return _CodecDecision(True, "ragged_tensor", "all non-null rows are Tensor", "torch.Tensor", {"dtype": dtypes[0]})
+
+
+def _can_numeric_sequence(values: list[Any]) -> _CodecDecision:
+    nn = _non_null(values)
+    if not nn:
+        return _CodecDecision(False, "typed_ragged", "all rows are null", "numeric sequence")
+    dtypes = []
+    for v in nn:
+        if isinstance(v, np.ndarray):
+            arr = v
+        elif isinstance(v, (list, tuple)):
+            try:
+                arr = np.asarray(v)
+            except (ValueError, TypeError):
+                return _CodecDecision(False, "typed_ragged", "row cannot be converted to ndarray", "numeric sequence")
+        else:
+            return _CodecDecision(False, "typed_ragged", "row is not array-like", "numeric sequence")
+        if arr.dtype == object or not np.issubdtype(arr.dtype, np.number):
+            return _CodecDecision(False, "typed_ragged", f"non-numeric dtype: {arr.dtype}", "numeric sequence")
+        dtypes.append(arr.dtype)
+    dtype = np.result_type(*dtypes)
+    return _CodecDecision(True, "typed_ragged", "all rows promote to common numeric dtype", "numeric sequence", {"dtype": str(dtype)})
+
+
+def _can_numeric_scalar(values: list[Any]) -> _CodecDecision:
+    nn = _non_null(values)
+    if not nn:
+        return _CodecDecision(False, "ndarray", "all rows are null", "numeric scalar")
+    if not all(isinstance(v, (bool, int, float, np.number)) for v in nn):
+        return _CodecDecision(False, "ndarray", "not all rows are numeric scalar", "numeric scalar")
+    try:
+        dtype = np.result_type(*nn)
+    except (TypeError, ValueError):
+        return _CodecDecision(False, "ndarray", "cannot determine common dtype", "numeric scalar")
+    if not np.issubdtype(dtype, np.number) and not np.issubdtype(dtype, np.bool_):
+        return _CodecDecision(False, "ndarray", f"non-numeric dtype: {dtype}", "numeric scalar")
+    return _CodecDecision(True, "ndarray", "all rows are numeric scalar", "numeric scalar", {"dtype": str(dtype)})
+
+
+def _can_json(values: list[Any]) -> _CodecDecision:
+    nn = _non_null(values)
+    if not nn:
+        return _CodecDecision(False, "json_ragged", "all rows are null", "json")
+    total_bytes = 0
+    for v in nn[:_INFER_MAX_SAMPLE_ROWS]:
+        try:
+            total_bytes += len(json.dumps(v, ensure_ascii=False, separators=(",", ":")).encode("utf-8"))
+        except (TypeError, ValueError):
+            return _CodecDecision(False, "json_ragged", "serialization failed", "json")
+    if total_bytes > _INFER_MAX_JSON_BYTES:
+        return _CodecDecision(False, "json_ragged", "sampled payload too large", "json")
+    return _CodecDecision(True, "json_ragged", "sampled rows pass JSON serialization", "json")
+
+
+_CODEC_PREDICATES: tuple[Any, ...] = (
+    _can_tensor,
+    lambda v: _check_all(v, _is_media_list, "media_list_ragged", "media list"),
+    _can_numeric_sequence,
+    _can_numeric_scalar,
+    lambda v: _check_all(v, _is_bytes_like, "bytes_ragged", "bytes-like"),
+    lambda v: _check_all(v, _is_pil_image, "media_bytes", "media"),
+    lambda v: _check_all(v, lambda x: isinstance(x, str), "utf8_ragged", "str"),
+    _can_json,
+)
+
+
+def _choose_leaf_codec(values: list[Any]) -> _CodecDecision:
+    for predicate in _CODEC_PREDICATES:
+        decision = predicate(values)
+        if decision.accepted:
+            return decision
+    return _CodecDecision(False, "pickle_ragged_fallback", "no optimized codec matched", "python object")
+
+
+def _try_expand_dict(values: list[Any]) -> list[str] | None:
+    nn = _non_null(values)
+    if not nn or not all(isinstance(v, dict) for v in nn):
+        return None
+    keys = {k for v in nn for k in v.keys()}
+    if not all(isinstance(k, str) for k in keys) or len(keys) > _INFER_MAX_STRUCT_KEYS:
+        return None
+    return sorted(keys)
+
+
+def _try_expand_list(values: list[Any]) -> tuple[int, list[int]] | None:
+    nn = _non_null(values)
+    if not nn or not all(isinstance(v, (list, tuple)) for v in nn):
+        return None
+    max_len = max(len(v) for v in nn)
+    if max_len > _INFER_MAX_LIST_LEN:
+        return None
+    if not all(isinstance(item, (dict, list, tuple)) for v in nn for item in v):
+        return None
+    lengths = [len(v) if isinstance(v, (list, tuple)) else 0 for v in values]
+    return max_len, lengths
+
+
+def infer_structure(
+    path: str,
+    values: list[Any],
+    leaves: list[_InferredLeaf],
+    nodes: list[_InferredNode],
+    *,
+    _depth: int = 0,
+) -> None:
+    """Recursively expand *values* into leaves and interior nodes.
+
+    *leaves* and *nodes* are output accumulators populated during recursion.
+    """
+    if _depth > _INFER_MAX_DEPTH:
+        raise ValueError(f"infer_structure exceeded max depth {_INFER_MAX_DEPTH} at {path!r}")
+    dict_keys = _try_expand_dict(values)
+    if dict_keys is not None:
+        nodes.append(_InferredNode(path, "dict", dict_keys))
+        for key in dict_keys:
+            child = [v.get(key) if isinstance(v, dict) else None for v in values]
+            infer_structure(f"{path}.{key}", child, leaves, nodes, _depth=_depth + 1)
+        return
+    list_result = _try_expand_list(values)
+    if list_result is not None:
+        max_len, lengths = list_result
+        nodes.append(_InferredNode(path, "list", list(range(max_len)), lengths))
+        for index in range(max_len):
+            child = [
+                v[index] if isinstance(v, (list, tuple)) and index < len(v) else None
+                for v in values
+            ]
+            infer_structure(f"{path}[{index}]", child, leaves, nodes, _depth=_depth + 1)
+        return
+    leaves.append(_InferredLeaf(path, values, _choose_leaf_codec(values)))

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -1451,15 +1451,17 @@ def _can_json(values: list[Any]) -> _CodecDecision:
     nn = _non_null(values)
     if not nn:
         return _CodecDecision(False, "json_ragged", "all rows are null", "json")
-    total_bytes = 0
-    for v in nn[:_INFER_MAX_SAMPLE_ROWS]:
+    sampled_bytes = 0
+    for i, v in enumerate(nn):
         try:
-            total_bytes += len(json.dumps(v, ensure_ascii=False, separators=(",", ":")).encode("utf-8"))
+            encoded = json.dumps(v, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
         except (TypeError, ValueError, OverflowError, RecursionError):
             return _CodecDecision(False, "json_ragged", "serialization failed", "json")
-    if total_bytes > _INFER_MAX_JSON_BYTES:
+        if i < _INFER_MAX_SAMPLE_ROWS:
+            sampled_bytes += len(encoded)
+    if sampled_bytes > _INFER_MAX_JSON_BYTES:
         return _CodecDecision(False, "json_ragged", "sampled payload too large", "json")
-    return _CodecDecision(True, "json_ragged", "sampled rows pass JSON serialization", "json")
+    return _CodecDecision(True, "json_ragged", "all rows pass JSON serialization", "json")
 
 
 _CODEC_PREDICATES: tuple[Any, ...] = (

--- a/mooncake-wheel/tests/test_put_get_tensor.py
+++ b/mooncake-wheel/tests/test_put_get_tensor.py
@@ -236,7 +236,9 @@ class TestDistributedObjectStore(unittest.TestCase):
 
 
 from mooncake.structured_object_store import (
+    MISSING,
     _choose_leaf_codec,
+    _escape_key,
     infer_structure,
 )
 
@@ -347,6 +349,27 @@ class TestCodecInference(unittest.TestCase):
         infer_structure("r", [[{"k": 1}, None], [{"k": 2}, None]], leaves, nodes)
         list_nodes = [n for n in nodes if n.node_type == "list"]
         self.assertEqual(len(list_nodes), 1)
+
+    def test_dict_missing_key_vs_none_value(self):
+        leaves, nodes = [], []
+        infer_structure("r", [{"x": None}, {"y": 2}, None], leaves, nodes)
+        self.assertIsNotNone(nodes[0].row_mask)
+        self.assertEqual(nodes[0].row_mask, [True, True, False])
+        x_leaf = next(l for l in leaves if l.path == "r.x")
+        self.assertIsNone(x_leaf.values[0])
+        self.assertIsInstance(x_leaf.values[1], type(MISSING))
+        self.assertIsNone(x_leaf.values[2])
+
+    def test_escape_key_in_path(self):
+        self.assertEqual(_escape_key("simple"), "simple")
+        self.assertEqual(_escape_key("a.b"), "a\\.b")
+        self.assertEqual(_escape_key("a[0]"), "a\\[0]")
+        self.assertEqual(_escape_key("a\\b"), "a\\\\b")
+
+    def test_dict_with_dot_key(self):
+        leaves, nodes = [], []
+        infer_structure("r", [{"a.b": 1}, {"a.b": 2}], leaves, nodes)
+        self.assertEqual(leaves[0].path, "r.a\\.b")
 
     def test_depth_limit(self):
         deep = 1

--- a/mooncake-wheel/tests/test_put_get_tensor.py
+++ b/mooncake-wheel/tests/test_put_get_tensor.py
@@ -235,5 +235,115 @@ class TestDistributedObjectStore(unittest.TestCase):
             self.store.remove(f"{key}_tp_{rank}")
 
 
+from mooncake.structured_object_store import (
+    _choose_leaf_codec,
+    infer_structure,
+)
+
+
+class TestCodecInference(unittest.TestCase):
+
+    def test_tensor(self):
+        import torch
+        d = _choose_leaf_codec([torch.tensor([1, 2]), torch.tensor([3])])
+        self.assertTrue(d.accepted)
+        self.assertEqual(d.codec, "ragged_tensor")
+
+    def test_tensor_mixed_dtype_rejected(self):
+        import torch
+        d = _choose_leaf_codec([torch.tensor([1], dtype=torch.float32), torch.tensor([1], dtype=torch.int64)])
+        self.assertFalse(d.accepted)
+
+    def test_numeric_sequence(self):
+        d = _choose_leaf_codec([[1, 2, 3], [4, 5]])
+        self.assertTrue(d.accepted)
+        self.assertEqual(d.codec, "typed_ragged")
+
+    def test_bytes(self):
+        d = _choose_leaf_codec([b"hello", b"world"])
+        self.assertTrue(d.accepted)
+        self.assertEqual(d.codec, "bytes_ragged")
+
+    def test_text(self):
+        d = _choose_leaf_codec(["hello", "world"])
+        self.assertTrue(d.accepted)
+        self.assertEqual(d.codec, "utf8_ragged")
+
+    def test_json(self):
+        d = _choose_leaf_codec([{"a": 1}, {"b": 2}])
+        self.assertTrue(d.accepted)
+        self.assertEqual(d.codec, "json_ragged")
+
+    def test_scalar(self):
+        d = _choose_leaf_codec([1, 2.0, 3])
+        self.assertTrue(d.accepted)
+        self.assertEqual(d.codec, "ndarray")
+
+    def test_fallback(self):
+        d = _choose_leaf_codec([object(), object()])
+        self.assertFalse(d.accepted)
+        self.assertEqual(d.codec, "pickle_ragged_fallback")
+
+    def test_with_nulls(self):
+        d = _choose_leaf_codec(["hello", None, "world"])
+        self.assertTrue(d.accepted)
+        self.assertEqual(d.codec, "utf8_ragged")
+
+    def test_empty_values(self):
+        d = _choose_leaf_codec([])
+        self.assertFalse(d.accepted)
+
+    def test_all_none(self):
+        d = _choose_leaf_codec([None, None, None])
+        self.assertFalse(d.accepted)
+
+    def test_infer_flat(self):
+        leaves, nodes = [], []
+        infer_structure("root", ["a", "b", "c"], leaves, nodes)
+        self.assertEqual(len(leaves), 1)
+        self.assertEqual(len(nodes), 0)
+        self.assertEqual(leaves[0].decision.codec, "utf8_ragged")
+
+    def test_infer_dict(self):
+        leaves, nodes = [], []
+        infer_structure("root", [{"x": 1, "y": "a"}, {"x": 2, "y": "b"}], leaves, nodes)
+        self.assertEqual(len(nodes), 1)
+        self.assertEqual(nodes[0].node_type, "dict")
+        self.assertEqual(sorted(nodes[0].children), ["x", "y"])
+        self.assertEqual(sorted(l.path for l in leaves), ["root.x", "root.y"])
+
+    def test_infer_dict_with_none_rows(self):
+        leaves, nodes = [], []
+        infer_structure("r", [{"x": 1}, None, {"x": 3}], leaves, nodes)
+        self.assertEqual(len(nodes), 1)
+        self.assertEqual(len(leaves), 1)
+        self.assertEqual(leaves[0].path, "r.x")
+
+    def test_infer_nested(self):
+        leaves, nodes = [], []
+        infer_structure("r", [{"a": {"b": 1}}, {"a": {"b": 2}}], leaves, nodes)
+        self.assertEqual(len(nodes), 2)
+        self.assertEqual(leaves[0].path, "r.a.b")
+        self.assertEqual(leaves[0].decision.codec, "ndarray")
+
+    def test_infer_list(self):
+        leaves, nodes = [], []
+        infer_structure("r", [[{"k": 1}], [{"k": 2}]], leaves, nodes)
+        list_nodes = [n for n in nodes if n.node_type == "list"]
+        self.assertEqual(len(list_nodes), 1)
+        self.assertEqual(list_nodes[0].lengths, [1, 1])
+        dict_nodes = [n for n in nodes if n.node_type == "dict"]
+        self.assertEqual(len(dict_nodes), 1)
+        self.assertEqual(len(leaves), 1)
+        self.assertEqual(leaves[0].path, "r[0].k")
+
+    def test_depth_limit(self):
+        deep = 1
+        for _ in range(40):
+            deep = {"a": deep}
+        with self.assertRaises(ValueError):
+            infer_structure("r", [deep, deep], [], [])
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/mooncake-wheel/tests/test_put_get_tensor.py
+++ b/mooncake-wheel/tests/test_put_get_tensor.py
@@ -254,6 +254,11 @@ class TestCodecInference(unittest.TestCase):
         d = _choose_leaf_codec([torch.tensor([1], dtype=torch.float32), torch.tensor([1], dtype=torch.int64)])
         self.assertFalse(d.accepted)
 
+    def test_tensor_mixed_ndim_rejected(self):
+        import torch
+        d = _choose_leaf_codec([torch.tensor([1]), torch.tensor([[1, 2]])])
+        self.assertFalse(d.accepted)
+
     def test_numeric_sequence(self):
         d = _choose_leaf_codec([[1, 2, 3], [4, 5]])
         self.assertTrue(d.accepted)
@@ -336,6 +341,12 @@ class TestCodecInference(unittest.TestCase):
         self.assertEqual(len(dict_nodes), 1)
         self.assertEqual(len(leaves), 1)
         self.assertEqual(leaves[0].path, "r[0].k")
+
+    def test_infer_list_with_none_items(self):
+        leaves, nodes = [], []
+        infer_structure("r", [[{"k": 1}, None], [{"k": 2}, None]], leaves, nodes)
+        list_nodes = [n for n in nodes if n.node_type == "list"]
+        self.assertEqual(len(list_nodes), 1)
 
     def test_depth_limit(self):
         deep = 1

--- a/mooncake-wheel/tests/test_put_get_tensor.py
+++ b/mooncake-wheel/tests/test_put_get_tensor.py
@@ -281,6 +281,11 @@ class TestCodecInference(unittest.TestCase):
         self.assertTrue(d.accepted)
         self.assertEqual(d.codec, "json_ragged")
 
+    def test_json_rejects_late_non_serializable(self):
+        values = [{"ok": i} for i in range(200)] + [object()]
+        d = _choose_leaf_codec(values)
+        self.assertFalse(d.accepted)
+
     def test_scalar(self):
         d = _choose_leaf_codec([1, 2.0, 3])
         self.assertTrue(d.accepted)
@@ -317,7 +322,7 @@ class TestCodecInference(unittest.TestCase):
         self.assertEqual(len(nodes), 1)
         self.assertEqual(nodes[0].node_type, "dict")
         self.assertEqual(sorted(nodes[0].children), ["x", "y"])
-        self.assertEqual(sorted(l.path for l in leaves), ["root.x", "root.y"])
+        self.assertEqual(sorted(leaf.path for leaf in leaves), ["root.x", "root.y"])
 
     def test_infer_dict_with_none_rows(self):
         leaves, nodes = [], []
@@ -355,7 +360,7 @@ class TestCodecInference(unittest.TestCase):
         infer_structure("r", [{"x": None}, {"y": 2}, None], leaves, nodes)
         self.assertIsNotNone(nodes[0].row_mask)
         self.assertEqual(nodes[0].row_mask, [True, True, False])
-        x_leaf = next(l for l in leaves if l.path == "r.x")
+        x_leaf = next(leaf for leaf in leaves if leaf.path == "r.x")
         self.assertIsNone(x_leaf.values[0])
         self.assertIsInstance(x_leaf.values[1], type(MISSING))
         self.assertIsNone(x_leaf.values[2])


### PR DESCRIPTION
## Description
  
  ### Background & Motivation

  In RLHF (Reinforcement Learning from Human Feedback) training pipelines, the actor and learner stages exchange rollout data through mooncake store. A single rollout batch (typically represented as a `DataProto` object) contains  heterogeneous fields: dense tensors for token IDs and attention masks, ragged tensors for variable-length responses, byte arrays for serialized reward signals, strings for prompts, JSON metadata, and nested dicts/lists that group these fields hierarchically.

  Today, the caller must manually serialize each field, choose an appropriate wire format, and manage the Mooncake put/get lifecycle per field. This is error-prone, verbose, and prevents Mooncake from applying type-specific optimizations (e.g., zero-copy tensor transfer via registered buffers vs. pickle fallback for opaque Python objects).
  
  PR #2050 introduced a complete DataProto transfer framework that automates this: it inspects the runtime structure of a rollout batch, recursively decomposes nested dicts/lists into flat leaf columns, selects the best codec for each leaf, and encodes/decodes them through Mooncake's structured object store. That PR was large (~3000 lines) and is being split into reviewable pieces by functional layer.

  ### What this PR does (PR 3 of the #2050 series)

  This PR adds the **first two layers** of the encoding pipeline — the parts that run before any actual serialization or I/O:

  1. **Recursive structure expansion** (`infer_structure`): Given a batch of N rows where each row is an arbitrary Python value (dict, list, tensor, string, etc.), recursively decomposes dict and short-list rows into child columns. For example, N rows of `{"tokens": tensor, "meta": {"step": int, "lr": float}}` become three flat leaf columns: `tokens`, `meta.step`, and `meta.lr`. Interior nodes (dict expansions, list expansions) are recorded for later reconstruction.

  2. **Codec inference** (`_choose_leaf_codec`): For each leaf column (a list of N homogeneous-typed values), selects the optimal storage codec by trying type predicates in priority order: `ragged_tensor` → `media_list_ragged` → `typed_ragged` → `ndarray` → `bytes_ragged` → `media_bytes` → `utf8_ragged` → `json_ragged` → `pickle_ragged_fallback`.
  The decision includes the codec name and any type metadata (e.g., tensor dtype, numpy result dtype) needed by the encoder in the next PR.

  ### What this PR does NOT do

  - No actual encoding/decoding (PR 4)
  - No integration into `put_structured_object` / `materialize` (PR 5)
  - No store I/O, no buffer registration, no network calls

  This is a pure-function layer with no side effects, making it independently testable and reviewable.

  ### Split plan from #2050
  
  - **PR 1** — Buffer pool (local buffer backing) — *Merged*
  - **PR 2** — Structured object interfaces (tensor APIs) — *Merged*
  - **PR 3 (this)** — **Codec inference + recursive structure expansion** — *This PR*
  - **PR 4** — Leaf encoders/decoders (ragged tensor, typed ragged, bytes, media, text, json, pickle) — *Planned*
  - **PR 5** — Integration into put/materialize paths + end-to-end DataProto transfer — *Planned*

  ### Design decisions

  - **Expansion before codec inference**: `infer_structure` tries dict/list expansion *before* calling
  `_choose_leaf_codec`. Otherwise, `[{"x": 1}, {"x": 2}]` would be accepted as `json_ragged` instead of being expanded into a scalar column `x` with `ndarray` codec — losing the opportunity for zero-copy numeric transfer.
  - **`_try_expand_dict` / `_try_expand_list` return computed data**: The expansion check and the actual expansion need the same derived values (sorted keys, max length, per-row lengths). These functions return the computed data on success (`list[str]` or `(int, list[int])`) and `None` on rejection, avoiding a second traversal in `infer_structure`.
  - **`_check_all` helper**: Five of the eight codec predicates follow an identical "filter nulls → type-check all → accept/reject" pattern. `_check_all` factors this out; the remaining three predicates (`_can_tensor`, `_can_numeric_sequence`, `_can_numeric_scalar`) have extra logic (dtype uniformity check, `np.result_type` promotion) and stay as standalone functions.
  - **Recursion depth limit**: Capped at 32 levels with a descriptive `ValueError`. Prevents stack overflow on pathological inputs.
  - **Internal symbols**: All new names except `infer_structure` are underscore-prefixed — `_CodecDecision`,
  `_InferredLeaf`, `_InferredNode`, `_choose_leaf_codec`, etc.

  ## Module
  
  - [x] Python Wheel (`mooncake-wheel`)

  ## Type of Change

  - [x] New feature

  ## How Has This Been Tested?

  **Test commands:**
  ```bash
  PYTHONPATH=mooncake-wheel python -m pytest tests/test_put_get_tensor.py::TestCodecInference -v
  ```
  Test results (18 tests):

  Codec selection:
  - tensor, mixed-dtype rejection, numeric sequence, bytes, text, json, scalar, fallback, with-nulls, empty input, all-None

  Structure expansion:
  - flat leaf, dict expansion, dict with None rows, nested dict, list expansion with full path/lengths verification, depth limit
  - [x] Unit tests pass
  - [x] No store or network dependency — runs in pure Python + numpy + torch-cpu

  Checklist

  - [x] I have performed a self-review of my own code
  - [x] I have added tests to prove my changes are effective                                           
  - [ ] For changes >500 LOC: I have filed an RFC issue

  AI Assistance Disclosure

  - [x] AI tools were used (specify below)
  
  Claude Opus 4.6 assisted with code generation, review (3 parallel agents covering simplicity/safety/performance), and test writing. All changes reviewed and validated by the human submitter.