### PR TITLE
[TransferEngine] Fix batch retry RNIC hint advancement

### DIFF
--- a/mooncake-integration/CMakeLists.txt
+++ b/mooncake-integration/CMakeLists.txt
@@ -75,7 +75,7 @@ if(WITH_TE)
     target_link_libraries(engine PRIVATE CUDA::cudart)
   endif()
 
-  if(BUILD_TESTING)
+  if(BUILD_UNIT_TESTS)
     add_executable(transfer_retry_hint_test
                    transfer_engine/retry_utils_test.cpp)
     target_include_directories(transfer_retry_hint_test PRIVATE

--- a/mooncake-integration/CMakeLists.txt
+++ b/mooncake-integration/CMakeLists.txt
@@ -74,6 +74,16 @@ if(WITH_TE)
     find_package(CUDAToolkit REQUIRED)
     target_link_libraries(engine PRIVATE CUDA::cudart)
   endif()
+
+  if(BUILD_TESTING)
+    add_executable(transfer_retry_hint_test
+                   transfer_engine/retry_utils_test.cpp)
+    target_include_directories(transfer_retry_hint_test PRIVATE
+                               transfer_engine)
+    target_link_libraries(transfer_retry_hint_test PRIVATE transfer_engine
+                          gtest gtest_main)
+    add_test(NAME transfer_retry_hint_test COMMAND transfer_retry_hint_test)
+  endif()
 endif()
 
 set(ALLOCATOR_SO_PATH

--- a/mooncake-integration/transfer_engine/retry_utils.h
+++ b/mooncake-integration/transfer_engine/retry_utils.h
@@ -21,6 +21,9 @@
 namespace mooncake {
 namespace integration {
 
+#if defined(__GNUC__) || defined(__clang__)
+__attribute__((cold, noinline))
+#endif
 inline void updateRetryHints(std::vector<TransferRequest>& entries, int retry) {
     for (auto& entry : entries) entry.advise_retry_cnt = retry;
 }

--- a/mooncake-integration/transfer_engine/retry_utils.h
+++ b/mooncake-integration/transfer_engine/retry_utils.h
@@ -22,11 +22,15 @@ namespace mooncake {
 namespace integration {
 
 #if defined(__GNUC__) || defined(__clang__)
-__attribute__((cold, noinline))
+#define MOONCAKE_RETRY_COLD __attribute__((cold, noinline))
+#else
+#define MOONCAKE_RETRY_COLD
 #endif
-inline void updateRetryHints(std::vector<TransferRequest>& entries, int retry) {
+MOONCAKE_RETRY_COLD inline void updateRetryHints(
+    std::vector<TransferRequest>& entries, int retry) {
     for (auto& entry : entries) entry.advise_retry_cnt = retry;
 }
+#undef MOONCAKE_RETRY_COLD
 
 }  // namespace integration
 }  // namespace mooncake

--- a/mooncake-integration/transfer_engine/retry_utils.h
+++ b/mooncake-integration/transfer_engine/retry_utils.h
@@ -1,0 +1,29 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <vector>
+
+#include "transfer_engine.h"
+
+namespace mooncake {
+namespace integration {
+
+inline void updateRetryHints(std::vector<TransferRequest>& entries, int retry) {
+    for (auto& entry : entries) entry.advise_retry_cnt = retry;
+}
+
+}  // namespace integration
+}  // namespace mooncake

--- a/mooncake-integration/transfer_engine/retry_utils_test.cpp
+++ b/mooncake-integration/transfer_engine/retry_utils_test.cpp
@@ -1,0 +1,41 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "retry_utils.h"
+
+namespace mooncake {
+namespace integration {
+namespace {
+
+TEST(RetryUtilsTest, AdvancesEveryEntryOnEachRetry) {
+    std::vector<TransferRequest> entries(3);
+    for (int retry = 0; retry < 4; ++retry) {
+        updateRetryHints(entries, retry);
+        for (const auto& entry : entries) {
+            EXPECT_EQ(entry.advise_retry_cnt, retry);
+        }
+    }
+}
+
+TEST(RetryUtilsTest, EmptyBatchIsSafe) {
+    std::vector<TransferRequest> entries;
+    updateRetryHints(entries, 2);
+    EXPECT_TRUE(entries.empty());
+}
+
+}  // namespace
+}  // namespace integration
+}  // namespace mooncake

--- a/mooncake-integration/transfer_engine/transfer_engine_py.cpp
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.cpp
@@ -360,18 +360,18 @@ int TransferEnginePy::transferSyncRead(const char* target_hostname,
 }
 
 int TransferEnginePy::batchTransferSyncWrite(
-    const char* target_hostname, std::vector<uintptr_t> buffers,
-    std::vector<uintptr_t> peer_buffer_addresses, std::vector<size_t> lengths,
-    const std::string& transport_hint) {
+    const char* target_hostname, const std::vector<uintptr_t>& buffers,
+    const std::vector<uintptr_t>& peer_buffer_addresses,
+    const std::vector<size_t>& lengths, const std::string& transport_hint) {
     return batchTransferSync(target_hostname, buffers, peer_buffer_addresses,
                              lengths, TransferOpcode::WRITE, nullptr,
                              transport_hint);
 }
 
 int TransferEnginePy::batchTransferSyncRead(
-    const char* target_hostname, std::vector<uintptr_t> buffers,
-    std::vector<uintptr_t> peer_buffer_addresses, std::vector<size_t> lengths,
-    const std::string& transport_hint) {
+    const char* target_hostname, const std::vector<uintptr_t>& buffers,
+    const std::vector<uintptr_t>& peer_buffer_addresses,
+    const std::vector<size_t>& lengths, const std::string& transport_hint) {
     return batchTransferSync(target_hostname, buffers, peer_buffer_addresses,
                              lengths, TransferOpcode::READ, nullptr,
                              transport_hint);
@@ -489,10 +489,10 @@ int TransferEnginePy::transferSync(const char* target_hostname,
 }
 
 int TransferEnginePy::batchTransferSync(
-    const char* target_hostname, std::vector<uintptr_t> buffers,
-    std::vector<uintptr_t> peer_buffer_addresses, std::vector<size_t> lengths,
-    TransferOpcode opcode, TransferNotify* notify,
-    const std::string& transport_hint) {
+    const char* target_hostname, const std::vector<uintptr_t>& buffers,
+    const std::vector<uintptr_t>& peer_buffer_addresses,
+    const std::vector<size_t>& lengths, TransferOpcode opcode,
+    TransferNotify* notify, const std::string& transport_hint) {
     pybind11::gil_scoped_release release;
     Transport::SegmentHandle handle;
     {
@@ -518,6 +518,7 @@ int TransferEnginePy::batchTransferSync(
     auto total_length = std::accumulate(lengths.begin(), lengths.end(), 0ull);
     auto batch_size = buffers.size();
     std::vector<TransferRequest> entries;
+    entries.reserve(batch_size);
     for (size_t i = 0; i < batch_size; ++i) {
         TransferRequest entry;
         if (opcode == TransferOpcode::WRITE) {
@@ -623,6 +624,7 @@ batch_id_t TransferEnginePy::batchTransferAsync(
     const int max_retry = engine_->numContexts() + 1;
     auto batch_size = buffers.size();
     std::vector<TransferRequest> entries;
+    entries.reserve(batch_size);
     batch_id_t batch_id = 0;
     for (size_t i = 0; i < batch_size; ++i) {
         TransferRequest entry;
@@ -923,6 +925,7 @@ void TransferEnginePy::batchTransferOnCuda(
 
     size_t batch_size = buffers.size();
     std::vector<TransferRequest> entries;
+    entries.reserve(batch_size);
     uint64_t total_bytes = 0;
     for (size_t i = 0; i < batch_size; ++i) {
         TransferRequest entry;

--- a/mooncake-integration/transfer_engine/transfer_engine_py.cpp
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.cpp
@@ -570,6 +570,9 @@ int TransferEnginePy::batchTransferSync(
             } else if (status.s == TransferStatusEnum::FAILED) {
                 engine_->freeBatchID(batch_id);
                 already_freed = true;
+                if (retry + 1 < max_retry) {
+                    mooncake::integration::updateRetryHints(entries, retry + 1);
+                }
                 completed = true;
             } else if (status.s == TransferStatusEnum::TIMEOUT) {
                 LOG(INFO) << "Sync data transfer timeout";
@@ -589,9 +592,6 @@ int TransferEnginePy::batchTransferSync(
                 }
                 return -1;
             }
-        }
-        if (retry + 1 < max_retry) {
-            mooncake::integration::updateRetryHints(entries, retry + 1);
         }
     }
     return -1;

--- a/mooncake-integration/transfer_engine/transfer_engine_py.cpp
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.cpp
@@ -536,6 +536,10 @@ int TransferEnginePy::batchTransferSync(
     }
 
     for (int retry = 0; retry < max_retry; ++retry) {
+        for (auto& entry : entries) {
+            entry.advise_retry_cnt = retry;
+        }
+
         auto batch_id = engine_->allocateBatchID(batch_size);
         Status s =
             notify
@@ -643,6 +647,10 @@ batch_id_t TransferEnginePy::batchTransferAsync(
     }
 
     for (int retry = 0; retry < max_retry; ++retry) {
+        for (auto& entry : entries) {
+            entry.advise_retry_cnt = retry;
+        }
+
         batch_id = engine_->allocateBatchID(batch_size);
         auto batch_desc = reinterpret_cast<BatchDesc*>(batch_id);
 

--- a/mooncake-integration/transfer_engine/transfer_engine_py.cpp
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.cpp
@@ -536,10 +536,6 @@ int TransferEnginePy::batchTransferSync(
     }
 
     for (int retry = 0; retry < max_retry; ++retry) {
-        // Entries are initialized with hint 0; only touch the whole batch when
-        // advancing to another RNIC/context after an actual failure.
-        if (retry != 0) mooncake::integration::updateRetryHints(entries, retry);
-
         auto batch_id = engine_->allocateBatchID(batch_size);
         Status s =
             notify
@@ -594,6 +590,9 @@ int TransferEnginePy::batchTransferSync(
                 return -1;
             }
         }
+        if (retry + 1 < max_retry) {
+            mooncake::integration::updateRetryHints(entries, retry + 1);
+        }
     }
     return -1;
 }
@@ -647,8 +646,6 @@ batch_id_t TransferEnginePy::batchTransferAsync(
     }
 
     for (int retry = 0; retry < max_retry; ++retry) {
-        if (retry != 0) mooncake::integration::updateRetryHints(entries, retry);
-
         batch_id = engine_->allocateBatchID(batch_size);
         auto batch_desc = reinterpret_cast<BatchDesc*>(batch_id);
 
@@ -658,7 +655,8 @@ batch_id_t TransferEnginePy::batchTransferAsync(
         Status s = engine_->submitTransfer(batch_id, entries);
         if (!s.ok()) {
             engine_->freeBatchID(batch_id);
-            return 0;
+            if (retry + 1 == max_retry) return 0;
+            mooncake::integration::updateRetryHints(entries, retry + 1);
         } else {
             break;
         }

--- a/mooncake-integration/transfer_engine/transfer_engine_py.cpp
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.cpp
@@ -519,7 +519,6 @@ int TransferEnginePy::batchTransferSync(
     auto total_length = std::accumulate(lengths.begin(), lengths.end(), 0ull);
     auto batch_size = buffers.size();
     std::vector<TransferRequest> entries;
-    entries.reserve(batch_size);
     for (size_t i = 0; i < batch_size; ++i) {
         TransferRequest entry;
         if (opcode == TransferOpcode::WRITE) {

--- a/mooncake-integration/transfer_engine/transfer_engine_py.cpp
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.cpp
@@ -537,7 +537,9 @@ int TransferEnginePy::batchTransferSync(
     }
 
     for (int retry = 0; retry < max_retry; ++retry) {
-        mooncake::integration::updateRetryHints(entries, retry);
+        // Entries are initialized with hint 0; only touch the whole batch when
+        // advancing to another RNIC/context after an actual failure.
+        if (retry != 0) mooncake::integration::updateRetryHints(entries, retry);
 
         auto batch_id = engine_->allocateBatchID(batch_size);
         Status s =
@@ -646,7 +648,7 @@ batch_id_t TransferEnginePy::batchTransferAsync(
     }
 
     for (int retry = 0; retry < max_retry; ++retry) {
-        mooncake::integration::updateRetryHints(entries, retry);
+        if (retry != 0) mooncake::integration::updateRetryHints(entries, retry);
 
         batch_id = engine_->allocateBatchID(batch_size);
         auto batch_desc = reinterpret_cast<BatchDesc*>(batch_id);

--- a/mooncake-integration/transfer_engine/transfer_engine_py.cpp
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.cpp
@@ -361,18 +361,18 @@ int TransferEnginePy::transferSyncRead(const char* target_hostname,
 }
 
 int TransferEnginePy::batchTransferSyncWrite(
-    const char* target_hostname, const std::vector<uintptr_t>& buffers,
-    const std::vector<uintptr_t>& peer_buffer_addresses,
-    const std::vector<size_t>& lengths, const std::string& transport_hint) {
+    const char* target_hostname, std::vector<uintptr_t> buffers,
+    std::vector<uintptr_t> peer_buffer_addresses, std::vector<size_t> lengths,
+    const std::string& transport_hint) {
     return batchTransferSync(target_hostname, buffers, peer_buffer_addresses,
                              lengths, TransferOpcode::WRITE, nullptr,
                              transport_hint);
 }
 
 int TransferEnginePy::batchTransferSyncRead(
-    const char* target_hostname, const std::vector<uintptr_t>& buffers,
-    const std::vector<uintptr_t>& peer_buffer_addresses,
-    const std::vector<size_t>& lengths, const std::string& transport_hint) {
+    const char* target_hostname, std::vector<uintptr_t> buffers,
+    std::vector<uintptr_t> peer_buffer_addresses, std::vector<size_t> lengths,
+    const std::string& transport_hint) {
     return batchTransferSync(target_hostname, buffers, peer_buffer_addresses,
                              lengths, TransferOpcode::READ, nullptr,
                              transport_hint);

--- a/mooncake-integration/transfer_engine/transfer_engine_py.cpp
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.cpp
@@ -490,10 +490,10 @@ int TransferEnginePy::transferSync(const char* target_hostname,
 }
 
 int TransferEnginePy::batchTransferSync(
-    const char* target_hostname, const std::vector<uintptr_t>& buffers,
-    const std::vector<uintptr_t>& peer_buffer_addresses,
-    const std::vector<size_t>& lengths, TransferOpcode opcode,
-    TransferNotify* notify, const std::string& transport_hint) {
+    const char* target_hostname, std::vector<uintptr_t> buffers,
+    std::vector<uintptr_t> peer_buffer_addresses, std::vector<size_t> lengths,
+    TransferOpcode opcode, TransferNotify* notify,
+    const std::string& transport_hint) {
     pybind11::gil_scoped_release release;
     Transport::SegmentHandle handle;
     {

--- a/mooncake-integration/transfer_engine/transfer_engine_py.cpp
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.cpp
@@ -19,6 +19,7 @@
 #include <fstream>
 
 #include <pybind11/stl.h>
+#include "retry_utils.h"
 #include "transport/rpc_communicator/rpc_interface.h"
 
 #ifdef USE_TENT
@@ -536,9 +537,7 @@ int TransferEnginePy::batchTransferSync(
     }
 
     for (int retry = 0; retry < max_retry; ++retry) {
-        for (auto& entry : entries) {
-            entry.advise_retry_cnt = retry;
-        }
+        mooncake::integration::updateRetryHints(entries, retry);
 
         auto batch_id = engine_->allocateBatchID(batch_size);
         Status s =
@@ -647,9 +646,7 @@ batch_id_t TransferEnginePy::batchTransferAsync(
     }
 
     for (int retry = 0; retry < max_retry; ++retry) {
-        for (auto& entry : entries) {
-            entry.advise_retry_cnt = retry;
-        }
+        mooncake::integration::updateRetryHints(entries, retry);
 
         batch_id = engine_->allocateBatchID(batch_size);
         auto batch_desc = reinterpret_cast<BatchDesc*>(batch_id);

--- a/mooncake-integration/transfer_engine/transfer_engine_py.h
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.h
@@ -84,17 +84,17 @@ class TransferEnginePy {
                          uintptr_t peer_buffer_address, size_t length,
                          const std::string &transport_hint = "");
 
-    int batchTransferSyncWrite(const char *target_hostname,
-                               std::vector<uintptr_t> buffers,
-                               std::vector<uintptr_t> peer_buffer_addresses,
-                               std::vector<size_t> lengths,
-                               const std::string &transport_hint = "");
+    int batchTransferSyncWrite(
+        const char *target_hostname, const std::vector<uintptr_t> &buffers,
+        const std::vector<uintptr_t> &peer_buffer_addresses,
+        const std::vector<size_t> &lengths,
+        const std::string &transport_hint = "");
 
-    int batchTransferSyncRead(const char *target_hostname,
-                              std::vector<uintptr_t> buffers,
-                              std::vector<uintptr_t> peer_buffer_addresses,
-                              std::vector<size_t> lengths,
-                              const std::string &transport_hint = "");
+    int batchTransferSyncRead(
+        const char *target_hostname, const std::vector<uintptr_t> &buffers,
+        const std::vector<uintptr_t> &peer_buffer_addresses,
+        const std::vector<size_t> &lengths,
+        const std::string &transport_hint = "");
 
     batch_id_t batchTransferAsyncWrite(
         const char *target_hostname, const std::vector<uintptr_t> &buffers,
@@ -117,9 +117,10 @@ class TransferEnginePy {
     // may be affected when using the batchTransferSync API. We currently
     // found this issue only in multi-node NVLink transfers.
     int batchTransferSync(const char *target_hostname,
-                          std::vector<uintptr_t> buffers,
-                          std::vector<uintptr_t> peer_buffer_addresses,
-                          std::vector<size_t> lengths, TransferOpcode opcode,
+                          const std::vector<uintptr_t> &buffers,
+                          const std::vector<uintptr_t> &peer_buffer_addresses,
+                          const std::vector<size_t> &lengths,
+                          TransferOpcode opcode,
                           TransferNotify *notify = nullptr,
                           const std::string &transport_hint = "");
 

--- a/mooncake-integration/transfer_engine/transfer_engine_py.h
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.h
@@ -85,15 +85,15 @@ class TransferEnginePy {
                          const std::string &transport_hint = "");
 
     int batchTransferSyncWrite(
-        const char *target_hostname, const std::vector<uintptr_t> &buffers,
-        const std::vector<uintptr_t> &peer_buffer_addresses,
-        const std::vector<size_t> &lengths,
+        const char *target_hostname, std::vector<uintptr_t> buffers,
+        std::vector<uintptr_t> peer_buffer_addresses,
+        std::vector<size_t> lengths,
         const std::string &transport_hint = "");
 
     int batchTransferSyncRead(
-        const char *target_hostname, const std::vector<uintptr_t> &buffers,
-        const std::vector<uintptr_t> &peer_buffer_addresses,
-        const std::vector<size_t> &lengths,
+        const char *target_hostname, std::vector<uintptr_t> buffers,
+        std::vector<uintptr_t> peer_buffer_addresses,
+        std::vector<size_t> lengths,
         const std::string &transport_hint = "");
 
     batch_id_t batchTransferAsyncWrite(

--- a/mooncake-integration/transfer_engine/transfer_engine_py.h
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.h
@@ -117,10 +117,9 @@ class TransferEnginePy {
     // may be affected when using the batchTransferSync API. We currently
     // found this issue only in multi-node NVLink transfers.
     int batchTransferSync(const char *target_hostname,
-                          const std::vector<uintptr_t> &buffers,
-                          const std::vector<uintptr_t> &peer_buffer_addresses,
-                          const std::vector<size_t> &lengths,
-                          TransferOpcode opcode,
+                          std::vector<uintptr_t> buffers,
+                          std::vector<uintptr_t> peer_buffer_addresses,
+                          std::vector<size_t> lengths, TransferOpcode opcode,
                           TransferNotify *notify = nullptr,
                           const std::string &transport_hint = "");
 

--- a/mooncake-integration/transfer_engine/transfer_engine_py.h
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.h
@@ -84,17 +84,17 @@ class TransferEnginePy {
                          uintptr_t peer_buffer_address, size_t length,
                          const std::string &transport_hint = "");
 
-    int batchTransferSyncWrite(
-        const char *target_hostname, std::vector<uintptr_t> buffers,
-        std::vector<uintptr_t> peer_buffer_addresses,
-        std::vector<size_t> lengths,
-        const std::string &transport_hint = "");
+    int batchTransferSyncWrite(const char *target_hostname,
+                               std::vector<uintptr_t> buffers,
+                               std::vector<uintptr_t> peer_buffer_addresses,
+                               std::vector<size_t> lengths,
+                               const std::string &transport_hint = "");
 
-    int batchTransferSyncRead(
-        const char *target_hostname, std::vector<uintptr_t> buffers,
-        std::vector<uintptr_t> peer_buffer_addresses,
-        std::vector<size_t> lengths,
-        const std::string &transport_hint = "");
+    int batchTransferSyncRead(const char *target_hostname,
+                              std::vector<uintptr_t> buffers,
+                              std::vector<uintptr_t> peer_buffer_addresses,
+                              std::vector<size_t> lengths,
+                              const std::string &transport_hint = "");
 
     batch_id_t batchTransferAsyncWrite(
         const char *target_hostname, const std::vector<uintptr_t> &buffers,


### PR DESCRIPTION
## Description

Fix the synchronous and asynchronous batch retry loops so a failed attempt actually advances `advise_retry_cnt` and can select the next local RNIC/context.

Previously every attempt reused hint 0. The async loop was additionally returning after the first submit failure, so it never retried at all despite being structured as a retry loop.

## Implementation

- Sync: after a `FAILED` completion, update every entry to `retry + 1` before the next attempt.
- Async: on submit failure, free the failed batch, advance hints, and continue until all contexts are exhausted.
- Keep the successful first-attempt hot path untouched; hint rewriting is only executed after a real failure and is outlined as a cold/noinline helper.
- Retain `entries.reserve(batch_size)` for async and CUDA batch construction. The sync reserve/const-ref experiment was removed after cluster A/B did not reproduce the old performance claim.
- Add `transfer_retry_hint_test` and register it with `BUILD_UNIT_TESTS`.

## Validation

- Retry helper test: 2/2 passed (all entries advance across retries; empty batch is safe).
- Real Python → C++ → RDMA batch READ completed on two H20/RoCE nodes for 64 KiB and 1 MiB blocks, batch=32.
- Baseline and patch were rebuilt with matching `RelWithDebInfo`, HTTP, RDMA, GID, and NIC-filter settings.

The previous `+13.5%` claim is removed: it was not reproducible in the controlled A/B. The matched rerun also showed that throughput varies with corrected retry/fallback behavior, so this PR is intentionally presented as a retry-correctness fix rather than a performance optimization. No throughput gain is claimed.

## Test plan

- [x] Build the Python `engine` module from the PR branch.
- [x] Unit-test retry hint advancement.
- [x] Exercise Python batch sync READ over real RDMA.
- [x] Compare baseline/patch with matching build flags.
- [ ] CI matrix (running).

## AI Assistance Disclosure

- [x] AI tools were used for code navigation, implementation, and cluster validation.