### PR TITLE
[TransferEngine] Apply configured SL/TC to the TENT notification QP

### DIFF
--- a/mooncake-transfer-engine/tent/src/common/config.cpp
+++ b/mooncake-transfer-engine/tent/src/common/config.cpp
@@ -107,6 +107,7 @@ Status ConfigHelper::loadFromEnv(Config& config) {
     setConfig(config, "MC_PKEY_INDEX", "transports/rdma/endpoint/pkey_index");
     setConfig(config, "MC_MTU", "transports/rdma/endpoint/path_mtu");
     setConfig(config, "MC_IB_TC", "transports/rdma/endpoint/traffic_class");
+    setConfig(config, "MC_IB_SL", "transports/rdma/endpoint/service_level");
     setConfig(config, "MC_IB_PCI_RELAXED_ORDERING",
               "transports/rdma/pci_relaxed_ordering");
     setConfig(config, "MC_WORKERS_PER_CTX",

--- a/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
@@ -54,8 +54,9 @@ static inline const std::string statusToString(
 static int setupNotifyQpConnection(ibv_qp* qp, RdmaContext* ctx,
                                    const std::string& peer_gid_str,
                                    uint16_t peer_lid, uint32_t peer_qp_num,
-                                   uint16_t pkey_index, uint8_t service_level,
-                                   uint8_t traffic_class);
+                                   uint16_t pkey_index,
+                                   uint8_t service_level = 0,
+                                   uint8_t traffic_class = 0);
 
 RdmaEndPoint::RdmaEndPoint() : status_(EP_UNINIT) {}
 

--- a/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
@@ -54,7 +54,8 @@ static inline const std::string statusToString(
 static int setupNotifyQpConnection(ibv_qp* qp, RdmaContext* ctx,
                                    const std::string& peer_gid_str,
                                    uint16_t peer_lid, uint32_t peer_qp_num,
-                                   uint16_t pkey_index);
+                                   uint16_t pkey_index, uint8_t service_level,
+                                   uint8_t traffic_class);
 
 RdmaEndPoint::RdmaEndPoint() : status_(EP_UNINIT) {}
 
@@ -424,9 +425,10 @@ Status RdmaEndPoint::connect(const std::string& peer_server_name,
 
         // Setup notification QP connection if peer supports it
         if (peer_desc.notify_qp_num != 0 && notify_qp_) {
-            rc = setupNotifyQpConnection(notify_qp_, context_, peer_gid,
-                                         peer_lid, peer_desc.notify_qp_num,
-                                         params_->pkey_index);
+            rc = setupNotifyQpConnection(
+                notify_qp_, context_, peer_gid, peer_lid,
+                peer_desc.notify_qp_num, params_->pkey_index,
+                params_->service_level, params_->traffic_class);
             if (rc) {
                 LOG(WARNING)
                     << "Failed to setup notification QP, notification disabled";
@@ -520,7 +522,8 @@ Status RdmaEndPoint::accept(const BootstrapDesc& peer_desc,
     if (peer_desc.notify_qp_num != 0 && notify_qp_) {
         rc = setupNotifyQpConnection(
             notify_qp_, context_, peer_desc.local_gid, peer_desc.local_lid,
-            peer_desc.notify_qp_num, params_->pkey_index);
+            peer_desc.notify_qp_num, params_->pkey_index,
+            params_->service_level, params_->traffic_class);
         if (rc) {
             notify_connected_ = false;
         } else {
@@ -880,7 +883,8 @@ void RdmaEndPoint::repostAllNotifyRecvs() {
 static int setupNotifyQpConnection(ibv_qp* qp, RdmaContext* ctx,
                                    const std::string& peer_gid_str,
                                    uint16_t peer_lid, uint32_t peer_qp_num,
-                                   uint16_t pkey_index) {
+                                   uint16_t pkey_index, uint8_t service_level,
+                                   uint8_t traffic_class) {
     // Reconnect path may call this when QP is already in RTS; force a clean
     // state machine: RESET -> INIT -> RTR -> RTS.
     ibv_qp_attr qp_attr = {};
@@ -924,14 +928,14 @@ static int setupNotifyQpConnection(ibv_qp* qp, RdmaContext* ctx,
     qp_attr.min_rnr_timer = 0x12;
     qp_attr.ah_attr.is_global = 1;
     qp_attr.ah_attr.dlid = peer_lid;
-    qp_attr.ah_attr.sl = 0;
+    qp_attr.ah_attr.sl = service_level;
     qp_attr.ah_attr.src_path_bits = 0;
     qp_attr.ah_attr.port_num = ctx->portNum();
     memcpy(&qp_attr.ah_attr.grh.dgid, &peer_gid, 16);
     qp_attr.ah_attr.grh.flow_label = 0;
     qp_attr.ah_attr.grh.sgid_index = ctx->gidIndex();
     qp_attr.ah_attr.grh.hop_limit = 255;
-    qp_attr.ah_attr.grh.traffic_class = 0;
+    qp_attr.ah_attr.grh.traffic_class = traffic_class;
 
     ret = ibv_modify_qp(qp, &qp_attr,
                         IBV_QP_STATE | IBV_QP_PATH_MTU | IBV_QP_DEST_QPN |


### PR DESCRIPTION
## Description

The TENT RDMA **data-path** QP picks up `params_->service_level` and
`params_->traffic_class` (`endpoint.cpp`, `setupOneQP`), but the
**control-path** notification QP hard-codes `ah_attr.sl = 0` and
`ah_attr.grh.traffic_class = 0` in `setupNotifyQpConnection`.

As a result, when a user configures an SL/TC for QoS isolation — e.g. to
steer Mooncake traffic into a dedicated InfiniBand Virtual Lane, away
from EP all-to-all traffic that shares the same NIC in MoE inference —
the KV-arrival **notification** messages still leak onto the default
lane, so the isolation is incomplete.

This threads the endpoint's `service_level` / `traffic_class` through
`setupNotifyQpConnection` so the notification QP follows the same fabric
QoS settings as the data QPs.

**Behavior-preserving**: both fields default to `0` in `RdmaParams`, so
an unconfigured deployment sets `sl=0` / `traffic_class=0` exactly as
before. This complements #2525 (which exposes `MC_IB_SL` for the main
transfer-engine), making SL/TC consistent across data and control QPs.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

This touches the IB QP setup path, which requires real RDMA hardware to
exercise end-to-end. The change is a behavior-preserving plumbing fix
(threads two already-existing `RdmaParams` fields, both defaulting to 0)
that mirrors how the data-path QP (`setupOneQP`) already applies them.

- [ ] Unit tests pass (N/A — IB QP setup path)
- [ ] Integration tests pass
- [ ] Manual testing done

> Note: not built locally (no IB toolchain on my dev machine); relying
> on CI for the build.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using clang-format (v20.1.8, repo `.clang-format`)
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [x] For changes >500 LOC: I have filed an RFC issue — N/A (~12 LOC)

## AI Assistance Disclosure

- [x] AI tools were used (Claude Code) for code navigation and drafting.