### PR TITLE
[WIP][Docs] Rework Mooncake Store deployment docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,9 +27,9 @@ sys.path.append(os.path.abspath(REPO_ROOT))
 
 # -- Project information -----------------------------------------------------
 
-project = 'Mooncake'
-copyright = f'{datetime.datetime.now().year}, Mooncake Team'
-author = 'the Mooncake Team'
+project = "Mooncake"
+copyright = f"{datetime.datetime.now().year}, Mooncake Team"
+author = "the Mooncake Team"
 
 # -- General configuration ---------------------------------------------------
 
@@ -42,6 +42,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx_copybutton",
     "myst_parser",
+    "sphinx_dynamic_command_builder",
     "sphinxarg.ext",
     "sphinx_design",
     "sphinx_togglebutton",
@@ -53,7 +54,7 @@ myst_enable_extensions = [
 ]
 myst_fence_as_directive = ["mermaid"]
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -74,19 +75,19 @@ copybutton_prompt_is_regexp = True
 # a list of builtin themes.
 #
 html_title = project
-html_theme = 'sphinx_book_theme'
-html_logo = 'image/mooncake-icon.png'
-html_favicon = 'image/moonshot.ico'
+html_theme = "sphinx_book_theme"
+html_logo = "image/mooncake-icon.png"
+html_favicon = "image/moonshot.ico"
 html_theme_options = {
-    'path_to_docs': 'docs/source',
-    'repository_url': 'https://github.com/kvcache-ai/Mooncake',
-    'use_repository_button': True,
-    'use_edit_page_button': True,
+    "path_to_docs": "docs/source",
+    "repository_url": "https://github.com/kvcache-ai/Mooncake",
+    "use_repository_button": True,
+    "use_edit_page_button": True,
     # Prevents the full API being added to the left sidebar of every page.
     # Reduces build time by 2.5x and reduces build size from ~225MB to ~95MB.
-    'collapse_navbar': True,
+    "collapse_navbar": True,
     # Makes API visible in the right sidebar on API reference pages.
-    'show_toc_level': 3,
+    "show_toc_level": 3,
 }
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -97,19 +98,17 @@ html_css_files = ["custom.css"]
 
 myst_heading_anchors = 2
 myst_url_schemes = {
-    'http': None,
-    'https': None,
-    'mailto': None,
-    'ftp': None,
+    "http": None,
+    "https": None,
+    "mailto": None,
+    "ftp": None,
     "gh-issue": {
-        "url":
-        "https://github.com/kvcache-ai/Mooncake/issues/{{path}}#{{fragment}}",
+        "url": "https://github.com/kvcache-ai/Mooncake/issues/{{path}}#{{fragment}}",
         "title": "Issue #{{path}}",
         "classes": ["github"],
     },
     "gh-pr": {
-        "url":
-        "https://github.com/kvcache-ai/Mooncake/pull/{{path}}#{{fragment}}",
+        "url": "https://github.com/kvcache-ai/Mooncake/pull/{{path}}#{{fragment}}",
         "title": "Pull Request #{{path}}",
         "classes": ["github"],
     },
@@ -131,8 +130,7 @@ myst_url_schemes = {
 }
 
 # Always remove the warning banner
-header_file = os.path.join(os.path.dirname(__file__),
-                           "_templates/sections/header.html")
+header_file = os.path.join(os.path.dirname(__file__), "_templates/sections/header.html")
 if os.path.exists(header_file):
     os.remove(header_file)
 
@@ -156,8 +154,8 @@ def get_repo_base_and_branch(pr_number):
     response = requests.get(url)
     if response.status_code == 200:
         data = response.json()
-        _cached_base = data['head']['repo']['full_name']
-        _cached_branch = data['head']['ref']
+        _cached_base = data["head"]["repo"]["full_name"]
+        _cached_branch = data["head"]["ref"]
         return _cached_base, _cached_branch
     else:
         logger.error("Failed to fetch PR details: %s", response)
@@ -165,9 +163,9 @@ def get_repo_base_and_branch(pr_number):
 
 
 def linkcode_resolve(domain, info):
-    if domain != 'py':
+    if domain != "py":
         return None
-    if not info['module']:
+    if not info["module"]:
         return None
 
     # Get path from module name
@@ -181,8 +179,8 @@ def linkcode_resolve(domain, info):
     # Get the line number of the object
     with open(path) as f:
         lines = f.readlines()
-    name = info['fullname'].split(".")[-1]
-    pattern = fr"^( {{4}})*((def|class) )?{name}\b.*"
+    name = info["fullname"].split(".")[-1]
+    pattern = rf"^( {{4}})*((def|class) )?{name}\b.*"
     for lineno, line in enumerate(lines, 1):
         if not line or line.startswith("#"):
             continue
@@ -235,12 +233,12 @@ for mock_target in autodoc_mock_imports:
             "Potentially problematic mock target (%s) found; "
             "autodoc_mock_imports cannot mock modules that have already "
             "been loaded into sys.modules when the sphinx build starts.",
-            mock_target)
+            mock_target,
+        )
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    "typing_extensions":
-    ("https://typing-extensions.readthedocs.io/en/latest", None),
+    "typing_extensions": ("https://typing-extensions.readthedocs.io/en/latest", None),
     "aiohttp": ("https://docs.aiohttp.org/en/stable", None),
     "pillow": ("https://pillow.readthedocs.io/en/stable", None),
     "numpy": ("https://numpy.org/doc/stable", None),

--- a/docs/source/deployment/mooncake-store-configuration-reference.md
+++ b/docs/source/deployment/mooncake-store-configuration-reference.md
@@ -237,10 +237,10 @@ glog's standard flags (`--log_dir`, `--max_log_size`, `--logtostderr`, ...) cont
 | `--cluster_id` | `mooncake_cluster` | Cluster ID for HA persistence |
 
 ```{caution}
-Metadata Snapshot And Restore is experimental feature.
+Metadata Snapshot and Restore is an experimental feature.
 ```
 
-**Metadata Snapshot And Restore**
+**Metadata Snapshot and Restore**
 
 | Flag | Default | Description |
 |------|---------|-------------|

--- a/docs/source/deployment/mooncake-store-configuration-reference.md
+++ b/docs/source/deployment/mooncake-store-configuration-reference.md
@@ -1,0 +1,390 @@
+# Mooncake Store Configuration Reference
+
+This page collects the `mooncake_master` command builder, client deployment
+modes, master startup flags, and client/engine environment variables used when
+deploying Mooncake Store.
+
+## Master Command Builder
+
+Use this builder to compose common `mooncake_master` startup commands. The
+flag tables below describe each option in detail.
+
+```{dynamic-command}
+base: mooncake_master
+command_label: Generated master startup command
+format:
+  line_break: options
+  indent: "  "
+options:
+  - label: RPC address
+    key: rpc_address
+    default: default
+    choices:
+      - label: default bind
+        value: default
+      - label: explicit host
+        value: host_ip
+        args: --rpc_address=10.0.0.1
+      - label: interface
+        value: interface
+        args: --rpc_interface=eth0
+  - label: Metadata backend
+    key: metadata
+    default: p2p
+    choices:
+      - label: P2P handshake
+        value: p2p
+      - label: embedded HTTP
+        value: embedded_http
+        args: --enable_http_metadata_server=true --http_metadata_server_host=0.0.0.0 --http_metadata_server_port=8080
+      - label: external etcd/Redis
+        value: external
+  - label: High availability
+    key: ha
+    default: disabled
+    choices:
+      - label: disabled
+        value: disabled
+      - label: etcd
+        value: etcd
+        args: '--enable_ha=true --ha_backend_type=etcd --etcd_endpoints="10.0.0.1:2379;10.0.0.2:2379;10.0.0.3:2379"'
+      - label: Redis
+        value: redis
+        args: '--enable_ha=true --ha_backend_type=redis --ha_backend_connstring="redis://127.0.0.1:6379"'
+  - label: Tiered storage
+    key: offload
+    default: disabled
+    choices:
+      - label: disabled
+        value: disabled
+      - label: eager offload
+        value: eager
+        args: --enable_offload=true --root_fs_dir=/mnt/ssd_cache
+      - label: offload on eviction
+        value: on_evict
+        args: --enable_offload=true --offload_on_evict=true --promotion_on_hit=true --promotion_admission_threshold=2 --root_fs_dir=/mnt/ssd_cache
+  - label: CXL memory
+    key: cxl
+    default: disabled
+    choices:
+      - label: disabled
+        value: disabled
+      - label: /dev/dax0.0
+        value: dax0
+        args: --enable_cxl=true --cxl_path=/dev/dax0.0 --cxl_size=17179869184 --allocation_strategy=cxl
+  - label: Snapshot
+    key: snapshot
+    default: disabled
+    choices:
+      - label: disabled
+        value: disabled
+      - label: local restore
+        value: local_restore
+        env: MOONCAKE_SNAPSHOT_LOCAL_PATH=/data/mooncake_snapshots
+        args: --enable_snapshot=true --snapshot_object_store_type=local --snapshot_interval_seconds=300 --snapshot_retention_count=5 --enable_snapshot_restore=true
+```
+
+## Client Deployment Modes
+
+### Standalone Real Client via RPC
+
+To run a resource-owning real client as a standalone RPC process:
+
+```bash
+mooncake_client \
+  --global_segment_size="4GB" \
+  --master_server_address="localhost:50051" \
+  --metadata_server="P2PHANDSHAKE"
+```
+
+The real client connects to the master and listens on port `50052` by default.
+Application processes such as vLLM or SGLang can then use dummy clients to
+forward requests to this real client.
+
+Common `mooncake_client` flags:
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--host` | `0.0.0.0` | Client service bind host |
+| `--port` | `50052` | Client service listen port |
+| `--global_segment_size` | `4GB` | Global segment size contributed by the client |
+| `--master_server_address` | `localhost:50051` | Master service address |
+| `--metadata_server` | `http://127.0.0.1:8080/metadata` | Transfer Engine metadata backend; use `P2PHANDSHAKE` for the smallest setup |
+| `--protocol` | `tcp` | Transfer protocol |
+| `--device_name` | empty | Transfer device name |
+| `--threads` | `1` | Client worker thread count |
+
+### Standalone Real Client via HTTP
+
+Use `python -m mooncake.mooncake_store_service` to start a real client with a
+lightweight HTTP API for manual `Get` and `Put` debugging.
+
+For a P2P handshake setup, no external metadata service is required:
+
+```bash
+python -m mooncake.mooncake_store_service \
+  --local_hostname=localhost \
+  --metadata_server=P2PHANDSHAKE \
+  --master_server=127.0.0.1:50051
+```
+
+Create a JSON config:
+
+```json
+{
+  "local_hostname": "localhost",
+  "metadata_server": "http://localhost:8080/metadata",
+  "global_segment_size": 268435456,
+  "local_buffer_size": 268435456,
+  "protocol": "tcp",
+  "device_name": "",
+  "master_server_address": "localhost:50051"
+}
+```
+
+Start the service:
+
+```bash
+python -m mooncake.mooncake_store_service --config=<config_path> --port=8081
+```
+
+The main startup parameters are `--config`, the path to the JSON configuration
+file, and `--port`, the HTTP server port.
+
+### Verify Installed Examples
+
+For a Python integration check, run
+`mooncake-store/tests/distributed_object_store_provider.py` after starting the
+metadata service and `mooncake_master`.
+
+For a C++ integration check, run `build/mooncake-store/tests/client_integration_test`
+after building tests and starting the required services.
+
+## Master Startup Flags
+
+### RPC
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--rpc_port` | `50051` | RPC listen port |
+| `--rpc_thread_num` | `min(4, CPU cores)` | RPC worker threads |
+| `--rpc_address` | `0.0.0.0` | RPC bind address |
+| `--rpc_interface` | empty | Network interface to resolve RPC address at startup (overrides `--rpc_address`) |
+| `--rpc_conn_timeout_seconds` | `0` | Idle connection timeout; `0` disables |
+| `--rpc_enable_tcp_no_delay` | `true` | Enable TCP_NODELAY |
+
+### Logging
+
+The master uses glog. When `--log_dir` is set, all severities are merged into a single journal file in that directory (`mooncake_master.INFO.<date>-<time>.<pid>`), reachable through the stable `mooncake_master.INFO` symlink.
+
+glog's standard flags (`--log_dir`, `--max_log_size`, `--logtostderr`, ...) control the rest.
+
+### Metrics
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--enable_metric_reporting` | `true` | Periodically log master metrics |
+| `--metrics_port` | `9003` | HTTP port for `/metrics` endpoints |
+
+### HTTP Metadata Server (Embedded)
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--enable_http_metadata_server` | `false` | Enable embedded HTTP metadata server |
+| `--http_metadata_server_host` | `0.0.0.0` | Metadata bind host |
+| `--http_metadata_server_port` | `8080` | Metadata TCP port |
+
+### Memory Allocator
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--memory_allocator` | `offset` | Memory allocator: `offset` (default) or `cachelib` |
+
+### Allocation Strategy
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--allocation_strategy` | `random` | `random` (pure random, fastest), `free_ratio_first` (best load balance), or `cxl` (prefer CXL memory) |
+
+### PutStart Timeouts
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--put_start_discard_timeout_sec` | `30` | Seconds before an uncompleted `PutStart` is discarded |
+| `--put_start_release_timeout_sec` | `300` (5 min) | Seconds before `PutStart`-allocated space is released |
+
+### Eviction & TTLs
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--default_kv_lease_ttl` | `5000` ms | Lease TTL for KV objects. Supports `5000ms`, `5s`, `30m`, `1h` |
+| `--default_kv_soft_pin_ttl` | `1800000` ms | Soft pin TTL (30 min) |
+| `--allow_evict_soft_pinned_objects` | `true` | Allow evicting soft-pinned objects |
+| `--eviction_ratio` | `0.05` | Fraction evicted at high watermark |
+| `--eviction_high_watermark_ratio` | `0.95` | Usage ratio triggering eviction |
+| `--client_ttl` | `10` s | Seconds before a silent client is considered disconnected |
+
+### High Availability
+
+**Master Node High Availability**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--enable_ha` | `false` | Enable HA mode |
+| `--ha_backend_type` | `etcd` | HA backend: `etcd`, `redis`, or `k8s` |
+| `--ha_backend_connstring` | empty | HA backend connection string |
+| `--etcd_endpoints` | empty | etcd endpoints, semicolon separated (when `--ha_backend_type=etcd`) |
+| `--cluster_id` | `mooncake_cluster` | Cluster ID for HA persistence |
+
+```{caution}
+Metadata Snapshot And Restore is experimental feature.
+```
+
+**Metadata Snapshot And Restore**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--enable_snapshot` | `false` | Enable periodic metadata snapshot |
+| `--snapshot_interval_seconds` | `300` (5 min) | Interval between snapshots |
+| `--snapshot_child_timeout_seconds` | `3600` (1 hour) | Timeout per snapshot child process |
+| `--snapshot_retention_count` | `10` | Number of recent snapshots retained |
+| `--snapshot_object_store_type` | required | Object store: `local` or `s3` |
+| `--snapshot_catalog_store_type` | empty | Catalog store: `embedded` or `redis` |
+| `--snapshot_catalog_store_connstring` | empty | Catalog store connection string (required for `redis`) |
+| `--snapshot_backup_dir` | empty | Optional local backup directory |
+| `--enable_snapshot_restore` | `false` | Restore from latest snapshot at startup |
+
+**Environment variable:** `MOONCAKE_SNAPSHOT_LOCAL_PATH` (required when `--snapshot_object_store_type=local`) — persistent directory for local snapshots.
+
+```{warning}
+The snapshot storage path is a **managed directory** exclusively controlled by Mooncake. Old snapshots exceeding `--snapshot_retention_count` are automatically deleted. Use a dedicated directory to avoid data loss.
+```
+
+### Task Manager
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--max_total_finished_tasks` | `10000` | Max finished tasks kept in memory |
+| `--max_total_pending_tasks` | `10000` | Max queued pending tasks |
+| `--max_total_processing_tasks` | `10000` | Max simultaneously processing tasks |
+| `--pending_task_timeout_sec` | `300` (5 min) | Timeout for pending tasks (`0` = no timeout) |
+| `--processing_task_timeout_sec` | `300` (5 min) | Timeout for processing tasks (`0` = no timeout) |
+| `--max_retry_attempts` | `10` | Max retries for failed tasks (`NO_AVAILABLE_HANDLE`) |
+
+### Offload / Tiered Storage
+
+Flags for controlling data movement between DRAM and SSD.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--enable_offload` | `false` | Enable offload from DRAM to SSD |
+| `--offload_on_evict` | `false` | Defer offload to eviction time rather than at `Put` |
+| `--offload_force_evict` | `false` | Force-evict objects exceeding capacity without offload |
+| `--promotion_on_hit` | `false` | Promote SSD-resident keys to DRAM on read hit |
+| `--promotion_admission_threshold` | `2` | Min CountMinSketch count to allow promotion (`1` = disable gating) |
+| `--promotion_queue_limit` | `50000` | Max in-flight promotion tasks |
+| `--quota_bytes` | `0` (90% of capacity) | Storage quota in bytes |
+| `--enable_disk_eviction` | `true` | Enable disk eviction |
+
+Start with `--enable_offload=true` for eager asynchronous SSD persistence after `Put` completion. Add `--offload_on_evict=true` when you want SSD writes to happen only when memory pressure selects an object for eviction. Add `--promotion_on_hit=true` to allow hot SSD-only data to be promoted back to DRAM, and tune `--promotion_admission_threshold` to control how many observed reads are required before promotion is queued.
+
+### CXL Memory
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--enable_cxl` | `false` | Enable CXL memory support |
+| `--cxl_path` | `/dev/dax0.0` | DAX device path for CXL memory |
+| `--cxl_size` | `8GB` (`8589934592`) | CXL memory size in bytes |
+
+When `--allocation_strategy=cxl` is set alongside `--enable_cxl=true`, the master preferentially allocates new objects on CXL memory.
+
+### DFS Storage
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--root_fs_dir` | empty | DFS mount directory for multi-layer storage backend |
+| `--global_file_segment_size` | `4GB` (`4294967296`) | Max available space for DFS segments |
+
+### Master Configuration File
+
+In addition to CLI flags, the master accepts JSON/YAML config files:
+
+```bash
+mooncake_master --config_path=mooncake-store/conf/master.yaml
+```
+
+```yaml
+rpc_interface: "eth0"
+rpc_port: 50051
+```
+
+## Client & Engine Tuning Environment Variables
+
+### Runtime Protocol
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MC_RPC_PROTOCOL` | `tcp` | RPC transport protocol between master and clients: `tcp` or `rdma` |
+| `MC_USE_TENT` / `MC_USE_TEV1` | unset | Set to any value to enable the TENT (next-gen) transfer engine |
+| `MC_STORE_CLUSTER_ID` | unset | Cluster ID label attached to client metrics |
+
+### Topology Discovery
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MC_MS_AUTO_DISC` | `1` | Auto-discover NIC/GPU topology. Set `0` to provide `rdma_devices` manually |
+| `MC_MS_FILTERS` | empty | Comma-separated NIC whitelist (e.g., `mlx5_0,mlx5_2`) |
+
+When `MC_MS_AUTO_DISC=0`, pass `rdma_devices` (comma-separated) to the Python `setup()` call.
+
+### Transfer Engine Metrics (disabled by default)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MC_TE_METRIC` | `0` | Set to `1` to enable engine metrics. Not supported with TENT |
+| `MC_TE_METRIC_INTERVAL_SECONDS` | `5` | Seconds between reports |
+
+### Client Metrics (enabled by default)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MC_STORE_CLIENT_METRIC` | `1` | Set `0` to disable |
+| `MC_STORE_CLIENT_METRIC_INTERVAL` | `0` | Reporting interval; `0` collects but does not periodically report |
+| `MC_STORE_CLIENT_MIN_PORT` | `12300` | Min local port for client connections |
+| `MC_STORE_CLIENT_MAX_PORT` | `14300` | Max local port for client connections |
+
+### Local Hot Cache
+
+Local hot cache provides a DRAM read cache on top of SSD-resident objects for faster access.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MC_STORE_LOCAL_HOT_CACHE_SIZE` | unset | Size of the local hot cache (e.g., `"8gb"`). Set to enable the hot cache |
+| `MC_STORE_LOCAL_HOT_BLOCK_SIZE` | unset | Block size for hot cache (e.g., `"2mb"`) |
+| `MC_STORE_LOCAL_HOT_CACHE_USE_SHM` | unset | Set `1` to use memfd-backed shared memory |
+| `MC_STORE_LOCAL_HOT_ADMISSION_THRESHOLD` | unset | Minimum CountMinSketch count before a key is admitted to hot cache |
+
+### Local Memory Optimization
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MC_STORE_MEMCPY` | `0` | Set `1` to prefer local memcpy when source/destination are on the same client |
+| `MC_STORE_CLIENT_SETUP_RETRIES` | `20` | Number of times to retry client registration on failure |
+| `MC_CXL_DEV_SIZE` | unset | CXL device size (overrides `--cxl_size` for client-side allocation) |
+
+### MMap Buffer & HugePages
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MC_STORE_USE_HUGEPAGE` | unset | Set `1` to request HugeTLB-backed `mmap()` |
+| `MC_STORE_HUGEPAGE_SIZE` | `2MB` | Supported: `2MB`, `1GB` |
+| `MC_MMAP_ARENA_POOL_SIZE` | unset | Pre-allocated arena pool size (e.g., `8gb`). Explicitly set to enable the arena |
+| `MC_DISABLE_MMAP_ARENA` | unset | Set `1` to disable arena, fall back to per-call `mmap()` |
+
+### yalantinglibs Log Level
+
+```bash
+export MC_YLT_LOG_LEVEL=info
+```
+
+Available: `trace`, `debug`, `info`, `warn` (or `warning`), `error`, `critical`.

--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -1,6 +1,7 @@
-# Mooncake Store Deployment & Tuning Guide
+# Mooncake Store Deployment Guide
 
-This guide covers minimal deployment, and operational tuning of Mooncake Store.
+This guide shows how to bring up a minimal Mooncake Store deployment and where
+to tune production settings.
 
 ## Architecture Overview
 
@@ -11,7 +12,7 @@ This guide covers minimal deployment, and operational tuning of Mooncake Store.
 
 **Client Node**: Each node contributes DRAM (and optionally VRAM/SSD) to form the distributed cache pool. Clients communicate with the master over RPC for control operations (`Put`/`Get`/`Remove`), but transfer actual data directly between each other via the Transfer Engine — the master is never in the data path.
 
-**Metadata Service**: A separate service (etcd, Redis, or HTTP) used by the Transfer Engine for peer discovery and configuration. The master's embedded HTTP metadata server can replace an external etcd/Redis for simple deployments. We also provide a P2P handshake mechanism (`P2PHANDSHAKE`) that enables decentralized metadata management by storing metadata locally on each node, eliminating the need for a centralized service — this is the simplest metadata handshake method and the recommended starting point (see [Quick Start](#quick-start)).
+**Metadata Discovery**: The Transfer Engine needs peer-discovery metadata before clients can exchange data. The recommended starting point is `P2PHANDSHAKE`, which stores handshake metadata locally and does not require an external metadata service.
 
 For a detailed design discussion, see the [Mooncake Store Design](../design/mooncake-store.md).
 
@@ -19,37 +20,20 @@ For a detailed design discussion, see the [Mooncake Store Design](../design/moon
 
 ## Quick Start
 
-Deploy a minimal single-node Mooncake Store in three steps.
+Deploy a minimal single-node TCP Mooncake Store with the P2P metadata handshake.
+No etcd, Redis, or HTTP metadata service is required.
 
-### 1. Start the Metadata Service
+```{figure} ../image/mooncake-store-quickstart-flow.svg
+:alt: Mooncake Store Quick Start runtime map
+:width: 100%
 
-Choose one option:
-
-```bash
-# Option A: P2P handshake — the simplest metadata handshake method (recommended)
-# Nothing to start here. There is no metadata service to deploy: each node
-# exchanges and stores metadata locally during connection setup. Just set the
-# client's metadata_server to the literal string "P2PHANDSHAKE" (see step 3).
-
-# Option B: Embed HTTP metadata server in the master
-# (configured in step 2 via --enable_http_metadata_server)
-
-# Option C: External etcd
-etcd --listen-client-urls http://0.0.0.0:2379 \
-     --advertise-client-urls http://localhost:2379
+Runtime map for the Quick Start path: the master handles control RPC while clients discover peers through the selected metadata handshake and exchange data directly.
 ```
 
-> **Tip:** P2P handshake is the easiest way to get started — it is decentralized
-> and requires no etcd/Redis/HTTP metadata service. Prefer it for development and
-> simple deployments; use an external etcd/Redis for large, long-lived clusters.
-
-### 2. Start the Master Service
+### 1. Start the Master Service
 
 ```bash
-mooncake_master \
-  --enable_http_metadata_server=true \
-  --http_metadata_server_host=0.0.0.0 \
-  --http_metadata_server_port=8080
+mooncake_master
 ```
 
 On success the log shows:
@@ -61,21 +45,22 @@ Max threads: 4
 Master service listening on 0.0.0.0:50051
 ```
 
-The master's default RPC port is `50051`. The HTTP metadata server serves on port `8080` in this example.
+The master's default RPC port is `50051`. This Quick Start does not enable the
+embedded HTTP metadata server because clients use `P2PHANDSHAKE`.
 
-### 3. Start a Store Client
+### 2. Start a Store Client
 
 Use the Python sample program to bring up a client that contributes 3.2 GB of DRAM to the cluster:
 
 ```python
-# stress_cluster_benchmark.py
+# quickstart_store_client.py
 import os
 from distributed_object_store import DistributedObjectStore
 
 store = DistributedObjectStore()
 store.setup(
     local_hostname=os.getenv("LOCAL_HOSTNAME", "localhost"),
-    metadata_server=os.getenv("METADATA_ADDR", "http://127.0.0.1:8080/metadata"),
+    metadata_server=os.getenv("METADATA_ADDR", "P2PHANDSHAKE"),
     global_segment_size=3200 * 1024 * 1024,  # DRAM contributed to the cluster
     local_buffer_size=512 * 1024 * 1024,     # Transfer Engine buffer
     protocol=os.getenv("PROTOCOL", "tcp"),
@@ -85,31 +70,7 @@ store.setup(
 ```
 
 ```bash
-python3 stress_cluster_benchmark.py
-```
-
-To use **P2P handshake** instead of an HTTP/etcd metadata service, pass the
-literal string `P2PHANDSHAKE` as `metadata_server` — no other change is needed:
-
-```python
-store.setup(
-    local_hostname=os.getenv("LOCAL_HOSTNAME", "localhost"),
-    metadata_server="P2PHANDSHAKE",          # decentralized, no metadata service
-    global_segment_size=3200 * 1024 * 1024,
-    local_buffer_size=512 * 1024 * 1024,
-    protocol=os.getenv("PROTOCOL", "tcp"),
-    device_name=os.getenv("DEVICE_NAME", ""),
-    master_server_address=os.getenv("MASTER_SERVER", "127.0.0.1:50051"),
-)
-```
-
-The standalone store service accepts the same value:
-
-```bash
-python -m mooncake.mooncake_store_service \
-  --local_hostname=localhost \
-  --metadata_server=P2PHANDSHAKE \
-  --master_server=127.0.0.1:50051
+python3 quickstart_store_client.py
 ```
 
 **What just happened:**
@@ -118,18 +79,22 @@ python -m mooncake.mooncake_store_service \
 2. The master allocated a 3.2 GB segment on this node and added it to the cluster's memory pool.
 3. The client is now ready to serve `Put`/`Get`/`Remove` requests.
 
-You can also deploy a standalone store service process that hosts memory/SSD without an inference application:
+### 3. Verify
 
 ```bash
-python -m mooncake.mooncake_store_service \
-  --local_hostname=localhost \
-  --metadata_server=http://127.0.0.1:8080/metadata \
-  --master_server=127.0.0.1:50051
+# Health check — master metrics endpoint
+curl -s http://localhost:9003/metrics/summary
 ```
 
-### Run the Stress Benchmark
+The client should remain running without registration or transfer-engine setup
+errors.
 
-Mooncake Store includes sample programs for validating C++ and Python integrations. The [stress benchmark script](gh-file:mooncake-store/tests/stress_cluster_benchmark.py) can be used to verify a two-role prefill/decode setup.
+## Stress Benchmark
+
+Mooncake Store includes sample programs for validating C++ and Python
+integrations. The [stress benchmark script](gh-file:mooncake-store/tests/stress_cluster_benchmark.py)
+can be used to verify a two-role prefill/decode setup after the master is
+running.
 
 Configure the script for your network:
 
@@ -144,7 +109,8 @@ ROLE=prefill python3 mooncake-store/tests/stress_cluster_benchmark.py
 ROLE=decode python3 mooncake-store/tests/stress_cluster_benchmark.py
 ```
 
-For RDMA, topology auto-discovery and NIC filters can be passed through environment variables:
+For RDMA, topology auto-discovery and NIC filters can be passed through
+environment variables:
 
 ```bash
 ROLE=prefill MC_MS_AUTO_DISC=1 MC_MS_FILTERS="mlx5_1,mlx5_2" python3 mooncake-store/tests/stress_cluster_benchmark.py
@@ -152,193 +118,6 @@ ROLE=decode MC_MS_AUTO_DISC=1 MC_MS_FILTERS="mlx5_1,mlx5_2" python3 mooncake-sto
 ```
 
 The absence of errors indicates successful data transfer.
-
-### Standalone Real Client via RPC
-
-To run a resource-owning real client as a standalone RPC process:
-
-```bash
-mooncake_client \
-  --global_segment_size="4GB" \
-  --master_server_address="localhost:50051" \
-  --metadata_server="http://localhost:8080/metadata"
-```
-
-The real client connects to the master and listens on port `50052` by default. Application processes such as vLLM or SGLang can then use dummy clients to forward requests to this real client.
-
-Common `mooncake_client` flags:
-
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--host` | `0.0.0.0` | Client service bind host |
-| `--port` | `50052` | Client service listen port |
-| `--global_segment_size` | `4GB` | Global segment size contributed by the client |
-| `--master_server_address` | `localhost:50051` | Master service address |
-| `--metadata_server` | `http://localhost:8080/metadata` | Transfer Engine metadata service |
-| `--protocol` | `tcp` | Transfer protocol |
-| `--device_name` | empty | Transfer device name |
-| `--threads` | `1` | Client worker thread count |
-
-### Standalone Real Client via HTTP
-
-Use `python -m mooncake.mooncake_store_service` to start a real client with a lightweight HTTP API for manual `Get` and `Put` debugging.
-
-Create a JSON config:
-
-```json
-{
-  "local_hostname": "localhost",
-  "metadata_server": "http://localhost:8080/metadata",
-  "global_segment_size": 268435456,
-  "local_buffer_size": 268435456,
-  "protocol": "tcp",
-  "device_name": "",
-  "master_server_address": "localhost:50051"
-}
-```
-
-Start the service:
-
-```bash
-python -m mooncake.mooncake_store_service --config=<config_path> --port=8081
-```
-
-The main startup parameters are `--config`, the path to the JSON configuration file, and `--port`, the HTTP server port.
-
-### Verify Installed Examples
-
-For a Python integration check, run `mooncake-store/tests/distributed_object_store_provider.py` after starting the metadata service and `mooncake_master`.
-
-For a C++ integration check, run `build/mooncake-store/tests/client_integration_test` after building tests and starting the required services.
-
-### Verify
-
-```bash
-# Health check — master metrics endpoint
-curl -s http://localhost:9003/metrics/summary
-
-# List registered clients
-# (exposed through the store's Python API or RPC)
-```
-
----
-
-## Deployment Scenarios
-
-### Single-Node (TCP) — Development / Quick Evaluation
-
-The simplest deployment, as shown in [Quick Start](#quick-start). A single `mooncake_master` orchestrates clients over TCP. Suitable for development, testing, and single-host evaluation.
-
-```bash
-mooncake_master \
-  --enable_http_metadata_server=true \
-  --http_metadata_server_host=0.0.0.0 \
-  --http_metadata_server_port=8080
-```
-
-Limitation: the master is a single point of failure. If it crashes, cluster operations pause until it is restored.
-
----
-
-### High-Availability (etcd) — Production HA
-
-Runs a cluster of master instances coordinated through etcd. If the leader fails, the remaining instances elect a new leader automatically.
-
-```bash
-# Start each master instance with:
-mooncake_master \
-  --enable-ha=true \
-  --etcd-endpoints="10.0.0.1:2379;10.0.0.2:2379;10.0.0.3:2379" \
-  --rpc-address=10.0.0.1
-```
-
-Each instance must specify its own reachable `--rpc-address`. The etcd cluster used for HA can be shared with or separate from the Transfer Engine's metadata etcd.
-
----
-
-### High-Availability (Redis) — Alternative HA Backend
-
-Same HA semantics but using Redis instead of etcd for leader election:
-
-```bash
-mooncake_master \
-  --enable-ha=true \
-  --ha_backend_type=redis \
-  --ha_backend_connstring="redis://127.0.0.1:6379" \
-  --rpc-address=10.0.0.1
-```
-
-
----
-
-### Snapshot & Restore — Backup / Disaster Recovery
-
-```{caution}
-Metadata Snapshot And Restore is experimental feature.
-```
-
-Periodically persist master metadata to local disk or S3, enabling recovery from a recent snapshot after a crash.
-
-```bash
-export MOONCAKE_SNAPSHOT_LOCAL_PATH=/data/mooncake_snapshots
-
-mooncake_master \
-  --enable_snapshot=true \
-  --snapshot_interval_seconds=300 \
-  --snapshot_retention_count=5 \
-  --snapshot_object_store_type=local \
-  --enable_snapshot_restore=true
-```
-
----
-
-### Tiered Storage with SSD Offload — Cost-Effective Capacity
-
-Extends the cache pool from DRAM to SSD while keeping normal reads and writes on the distributed memory path. With `--enable_offload=true`, completed memory writes are queued for asynchronous SSD persistence through the master control plane. Set `--offload_on_evict=true` to defer that SSD write until the memory eviction path selects an object for reclamation. When `--promotion_on_hit=true`, SSD-only objects can be promoted back to DRAM after repeated reads; admission is gated by `--promotion_admission_threshold`.
-
-```bash
-mooncake_master \
-  --enable_offload=true \
-  --offload_on_evict=true \
-  --promotion_on_hit=true \
-  --promotion_admission_threshold=2 \
-  --root_fs_dir=/mnt/ssd_cache \
-  --enable_http_metadata_server=true \
-  --http_metadata_server_port=8080
-```
-
----
-
-### CXL-Aware Allocation — Memory Tiering
-
-When the host has CXL-attached memory, the master can preferentially allocate new objects on the CXL tier, reserving local DRAM for latency-sensitive operations.
-
-```bash
-mooncake_master \
-  --enable_cxl=true \
-  --cxl_path=/dev/dax0.0 \
-  --cxl_size=17179869184 \
-  --allocation_strategy=cxl
-```
-
----
-
-### Container / Dynamic Network Interface
-
-When the master runs in a container with a dynamic IP, use `--rpc_interface` to resolve the RPC address from a stable interface name:
-
-```bash
-mooncake_master \
-  --rpc_interface=eth0 \
-  --enable_http_metadata_server=true \
-  --http_metadata_server_host=0.0.0.0 \
-  --http_metadata_server_port=8080
-```
-
-The master resolves the current IPv4 address of `eth0` at startup and uses it as the advertised RPC address.
-
-
----
 
 ## Metrics Endpoints
 
@@ -354,254 +133,35 @@ curl -s http://<master_host>:9003/metrics/summary
 
 ---
 
-## Quick Tips
+## Next Steps
 
-- Scale `--rpc_thread_num` with available CPU cores and workload.
-- Start with default eviction settings; adjust `--eviction_high_watermark_ratio` and `--eviction_ratio` based on memory pressure and object churn.
-- Use `/metrics/summary` during bring-up; integrate `/metrics` with Prometheus/Grafana for production.
-- For detailed SSD offload configuration (storage backends, eviction policies, io_uring), see the [SSD Offload guide](ssd-offload).
-- For NVMe-oF SSD pool configuration see the [NVMe-oF SSD Pool Deployment Guide](nvmf-ssd-deployment-guide)
-- For experimental 3FS (USRBIO) integration as a persistent storage backend, see the [3FS USRBIO Plugin guide](../getting_started/plugin-usage/3FS-USRBIO-Plugin).
-- For detailed monitoring and observation see [Observability](../getting_started/observability)
+### Compose Commands and Runtime Modes
+
+Use the [Configuration Reference](mooncake-store-configuration-reference) for the
+master command builder, standalone Real Client deployment modes, startup flags,
+and client/engine environment variables. Common first adjustments are
+`--rpc_thread_num`, eviction watermarks, and storage-related flags.
+
+### Add Storage Backends
+
+Choose a storage guide when the in-memory quick start is not enough:
+
+- [SSD Offload](ssd-offload): local SSD capacity, eviction policy, and io_uring settings.
+- [NVMe-oF SSD Pool](nvmf-ssd-deployment-guide): remote NVMe-oF SSD pool deployment.
+- [3FS USRBIO Plugin](../getting_started/plugin-usage/3FS-USRBIO-Plugin): experimental 3FS-backed persistent storage.
+
+### Validate and Observe
+
+- Use [Stress Benchmark](#stress-benchmark) for two-role prefill/decode validation.
+- [Observability](../getting_started/observability): metrics collection and production monitoring.
 
 :::{toctree}
 :maxdepth: 1
 :hidden:
 
+Mooncake Store Configuration Reference<mooncake-store-configuration-reference>
 ssd-offload
 NvMe-Of SSD Pool<nvmf-ssd-deployment-guide>
 HF3FS Plugin (Experimental)<../getting_started/plugin-usage/3FS-USRBIO-Plugin>
 ../getting_started/observability
 :::
-
----
-
-## Reference: Master Startup Flags
-
-### RPC
-
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--rpc_port` | `50051` | RPC listen port |
-| `--rpc_thread_num` | `min(4, CPU cores)` | RPC worker threads |
-| `--rpc_address` | `0.0.0.0` | RPC bind address |
-| `--rpc_interface` | empty | Network interface to resolve RPC address at startup (overrides `--rpc_address`) |
-| `--rpc_conn_timeout_seconds` | `0` | Idle connection timeout; `0` disables |
-| `--rpc_enable_tcp_no_delay` | `true` | Enable TCP_NODELAY |
-
-### Logging
-
-The master uses glog. When `--log_dir` is set, all severities are merged into a single journal file in that directory (`mooncake_master.INFO.<date>-<time>.<pid>`), reachable through the stable `mooncake_master.INFO` symlink.
-
-glog's standard flags (`--log_dir`, `--max_log_size`, `--logtostderr`, ...) control the rest.
-
-### Metrics
-
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--enable_metric_reporting` | `true` | Periodically log master metrics |
-| `--metrics_port` | `9003` | HTTP port for `/metrics` endpoints |
-
-### HTTP Metadata Server (Embedded)
-
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--enable_http_metadata_server` | `false` | Enable embedded HTTP metadata server |
-| `--http_metadata_server_host` | `0.0.0.0` | Metadata bind host |
-| `--http_metadata_server_port` | `8080` | Metadata TCP port |
-
-### Memory Allocator
-
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--memory_allocator` | `offset` | Memory allocator: `offset` (default) or `cachelib` |
-
-### Allocation Strategy
-
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--allocation_strategy` | `random` | `random` (pure random, fastest), `free_ratio_first` (best load balance), or `cxl` (prefer CXL memory) |
-
-### PutStart Timeouts
-
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--put_start_discard_timeout_sec` | `30` | Seconds before an uncompleted `PutStart` is discarded |
-| `--put_start_release_timeout_sec` | `300` (5 min) | Seconds before `PutStart`-allocated space is released
-
-### Eviction & TTLs
-
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--default_kv_lease_ttl` | `5000` ms | Lease TTL for KV objects. Supports `5000ms`, `5s`, `30m`, `1h` |
-| `--default_kv_soft_pin_ttl` | `1800000` ms | Soft pin TTL (30 min) |
-| `--allow_evict_soft_pinned_objects` | `true` | Allow evicting soft-pinned objects |
-| `--eviction_ratio` | `0.05` | Fraction evicted at high watermark |
-| `--eviction_high_watermark_ratio` | `0.95` | Usage ratio triggering eviction |
-| `--client_ttl` | `10` s | Seconds before a silent client is considered disconnected |
-
-### High Availability
-
-**Master Node High Availability**
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--enable_ha` | `false` | Enable HA mode |
-| `--ha_backend_type` | `etcd` | HA backend: `etcd`, `redis`, or `k8s` |
-| `--ha_backend_connstring` | empty | HA backend connection string |
-| `--etcd_endpoints` | empty | etcd endpoints, semicolon separated (when `--ha_backend_type=etcd`) |
-| `--cluster_id` | `mooncake_cluster` | Cluster ID for HA persistence |
-
-```{caution}
-Metadata Snapshot And Restore is experimental feature.
-```
-
-**Metadata Snapshot And Restore**
-
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--enable_snapshot` | `false` | Enable periodic metadata snapshot |
-| `--snapshot_interval_seconds` | `300` (5 min) | Interval between snapshots |
-| `--snapshot_child_timeout_seconds` | `3600` (1 hour) | Timeout per snapshot child process |
-| `--snapshot_retention_count` | `10` | Number of recent snapshots retained |
-| `--snapshot_object_store_type` | required | Object store: `local` or `s3` |
-| `--snapshot_catalog_store_type` | empty | Catalog store: `embedded` or `redis` |
-| `--snapshot_catalog_store_connstring` | empty | Catalog store connection string (required for `redis`) |
-| `--snapshot_backup_dir` | empty | Optional local backup directory |
-| `--enable_snapshot_restore` | `false` | Restore from latest snapshot at startup |
-
-**Environment variable:** `MOONCAKE_SNAPSHOT_LOCAL_PATH` (required when `--snapshot_object_store_type=local`) — persistent directory for local snapshots.
-
-```{warning}
-The snapshot storage path is a **managed directory** exclusively controlled by Mooncake. Old snapshots exceeding `--snapshot_retention_count` are automatically deleted. Use a dedicated directory to avoid data loss.
-```
-
-### Task Manager
-
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--max_total_finished_tasks` | `10000` | Max finished tasks kept in memory |
-| `--max_total_pending_tasks` | `10000` | Max queued pending tasks |
-| `--max_total_processing_tasks` | `10000` | Max simultaneously processing tasks |
-| `--pending_task_timeout_sec` | `300` (5 min) | Timeout for pending tasks (`0` = no timeout) |
-| `--processing_task_timeout_sec` | `300` (5 min) | Timeout for processing tasks (`0` = no timeout) |
-| `--max_retry_attempts` | `10` | Max retries for failed tasks (`NO_AVAILABLE_HANDLE`) |
-
-### Offload / Tiered Storage
-
-Flags for controlling data movement between DRAM and SSD.
-
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--enable_offload` | `false` | Enable offload from DRAM to SSD |
-| `--offload_on_evict` | `false` | Defer offload to eviction time rather than at `Put` |
-| `--offload_force_evict` | `false` | Force-evict objects exceeding capacity without offload |
-| `--promotion_on_hit` | `false` | Promote SSD-resident keys to DRAM on read hit |
-| `--promotion_admission_threshold` | `2` | Min CountMinSketch count to allow promotion (`1` = disable gating) |
-| `--promotion_queue_limit` | `50000` | Max in-flight promotion tasks |
-| `--quota_bytes` | `0` (90% of capacity) | Storage quota in bytes |
-| `--enable_disk_eviction` | `true` | Enable disk eviction |
-
-Start with `--enable_offload=true` for eager asynchronous SSD persistence after `Put` completion. Add `--offload_on_evict=true` when you want SSD writes to happen only when memory pressure selects an object for eviction. Add `--promotion_on_hit=true` to allow hot SSD-only data to be promoted back to DRAM, and tune `--promotion_admission_threshold` to control how many observed reads are required before promotion is queued.
-
-### CXL Memory
-
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--enable_cxl` | `false` | Enable CXL memory support |
-| `--cxl_path` | `/dev/dax0.0` | DAX device path for CXL memory |
-| `--cxl_size` | `8GB` (`8589934592`) | CXL memory size in bytes |
-
-When `--allocation_strategy=cxl` is set alongside `--enable_cxl=true`, the master preferentially allocates new objects on CXL memory.
-
-### DFS Storage
-
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--root_fs_dir` | empty | DFS mount directory for multi-layer storage backend |
-| `--global_file_segment_size` | `4GB` (`4294967296`) | Max available space for DFS segments |
-
-### Master Configuration File
-
-In addition to CLI flags, the master accepts JSON/YAML config files:
-
-```bash
-mooncake_master --config_path=mooncake-store/conf/master.yaml
-```
-
-```yaml
-rpc_interface: "eth0"
-rpc_port: 50051
-```
-
----
-
-## Reference: Client & Engine Tuning (Env Vars)
-
-### Runtime Protocol
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `MC_RPC_PROTOCOL` | `tcp` | RPC transport protocol between master and clients: `tcp` or `rdma` |
-| `MC_USE_TENT` / `MC_USE_TEV1` | unset | Set to any value to enable the TENT (next-gen) transfer engine |
-| `MC_STORE_CLUSTER_ID` | unset | Cluster ID label attached to client metrics |
-
-### Topology Discovery
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `MC_MS_AUTO_DISC` | `1` | Auto-discover NIC/GPU topology. Set `0` to provide `rdma_devices` manually |
-| `MC_MS_FILTERS` | empty | Comma-separated NIC whitelist (e.g., `mlx5_0,mlx5_2`) |
-
-When `MC_MS_AUTO_DISC=0`, pass `rdma_devices` (comma-separated) to the Python `setup()` call.
-
-### Transfer Engine Metrics (disabled by default)
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `MC_TE_METRIC` | `0` | Set to `1` to enable engine metrics. Not supported with TENT |
-| `MC_TE_METRIC_INTERVAL_SECONDS` | `5` | Seconds between reports |
-
-### Client Metrics (enabled by default)
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `MC_STORE_CLIENT_METRIC` | `1` | Set `0` to disable |
-| `MC_STORE_CLIENT_METRIC_INTERVAL` | `0` | Reporting interval; `0` collects but does not periodically report |
-| `MC_STORE_CLIENT_MIN_PORT` | `12300` | Min local port for client connections |
-| `MC_STORE_CLIENT_MAX_PORT` | `14300` | Max local port for client connections |
-
-### Local Hot Cache
-
-Local hot cache provides a DRAM read cache on top of SSD-resident objects for faster access.
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `MC_STORE_LOCAL_HOT_CACHE_SIZE` | unset | Size of the local hot cache (e.g., `"8gb"`). Set to enable the hot cache |
-| `MC_STORE_LOCAL_HOT_BLOCK_SIZE` | unset | Block size for hot cache (e.g., `"2mb"`) |
-| `MC_STORE_LOCAL_HOT_CACHE_USE_SHM` | unset | Set `1` to use memfd-backed shared memory |
-| `MC_STORE_LOCAL_HOT_ADMISSION_THRESHOLD` | unset | Minimum CountMinSketch count before a key is admitted to hot cache |
-
-### Local Memory Optimization
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `MC_STORE_MEMCPY` | `0` | Set `1` to prefer local memcpy when source/destination are on the same client |
-| `MC_STORE_CLIENT_SETUP_RETRIES` | `20` | Number of times to retry client registration on failure |
-| `MC_CXL_DEV_SIZE` | unset | CXL device size (overrides `--cxl_size` for client-side allocation) |
-
-### MMap Buffer & HugePages
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `MC_STORE_USE_HUGEPAGE` | unset | Set `1` to request HugeTLB-backed `mmap()` |
-| `MC_STORE_HUGEPAGE_SIZE` | `2MB` | Supported: `2MB`, `1GB` |
-| `MC_MMAP_ARENA_POOL_SIZE` | unset | Pre-allocated arena pool size (e.g., `8gb`). Explicitly set to enable the arena |
-| `MC_DISABLE_MMAP_ARENA` | unset | Set `1` to disable arena, fall back to per-call `mmap()` |
-
-### yalantinglibs Log Level
-
-```bash
-export MC_YLT_LOG_LEVEL=info
-```
-
-Available: `trace`, `debug`, `info`, `warn` (or `warning`), `error`, `critical`.

--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -137,7 +137,7 @@ curl -s http://<master_host>:9003/metrics/summary
 
 ### Compose Commands and Runtime Modes
 
-Use the [Configuration Reference](mooncake-store-configuration-reference) for the
+Use the [Configuration Reference](mooncake-store-configuration-reference.md) for the
 master command builder, standalone Real Client deployment modes, startup flags,
 and client/engine environment variables. Common first adjustments are
 `--rpc_thread_num`, eviction watermarks, and storage-related flags.
@@ -146,22 +146,22 @@ and client/engine environment variables. Common first adjustments are
 
 Choose a storage guide when the in-memory quick start is not enough:
 
-- [SSD Offload](ssd-offload): local SSD capacity, eviction policy, and io_uring settings.
-- [NVMe-oF SSD Pool](nvmf-ssd-deployment-guide): remote NVMe-oF SSD pool deployment.
-- [3FS USRBIO Plugin](../getting_started/plugin-usage/3FS-USRBIO-Plugin): experimental 3FS-backed persistent storage.
+- [SSD Offload](ssd-offload.md): local SSD capacity, eviction policy, and io_uring settings.
+- [NVMe-oF SSD Pool](nvmf-ssd-deployment-guide.md): remote NVMe-oF SSD pool deployment.
+- [3FS USRBIO Plugin](../getting_started/plugin-usage/3FS-USRBIO-Plugin.md): experimental 3FS-backed persistent storage.
 
 ### Validate and Observe
 
 - Use [Stress Benchmark](#stress-benchmark) for two-role prefill/decode validation.
-- [Observability](../getting_started/observability): metrics collection and production monitoring.
+- [Observability](../getting_started/observability.md): metrics collection and production monitoring.
 
 :::{toctree}
 :maxdepth: 1
 :hidden:
 
-Mooncake Store Configuration Reference<mooncake-store-configuration-reference>
+Mooncake Store Configuration Reference <mooncake-store-configuration-reference>
 ssd-offload
-NvMe-Of SSD Pool<nvmf-ssd-deployment-guide>
-HF3FS Plugin (Experimental)<../getting_started/plugin-usage/3FS-USRBIO-Plugin>
+NvMe-Of SSD Pool <nvmf-ssd-deployment-guide>
+HF3FS Plugin (Experimental) <../getting_started/plugin-usage/3FS-USRBIO-Plugin>
 ../getting_started/observability
 :::

--- a/docs/source/getting_started/quick-start.md
+++ b/docs/source/getting_started/quick-start.md
@@ -246,7 +246,7 @@ store.close()
 
 ### More Examples and Documentation
 
-Please refer to the [Mooncake Store Python API](../python-api-reference/mooncake-store.md), [Mooncake Store](../design/mooncake-store.md) and [Mooncake Store Deployment & Tuning Guide](../deployment/mooncake-store-deployment-guide.md) for more examples and documentation.
+Please refer to the [Mooncake Store Python API](../python-api-reference/mooncake-store.md), [Mooncake Store](../design/mooncake-store.md), and [Mooncake Store Deployment Guide](../deployment/mooncake-store-deployment-guide.md) for more examples and documentation.
 
 ## Skills for AI Coding Assistants
 

--- a/docs/source/image/mooncake-store-quickstart-flow.svg
+++ b/docs/source/image/mooncake-store-quickstart-flow.svg
@@ -1,0 +1,136 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 560" role="img" aria-labelledby="title desc">
+  <title id="title">Mooncake Store Quick Start runtime map</title>
+  <desc id="desc">Architecture flow showing metadata discovery, RPC control, client API calls, and direct client-to-client data transfer.</desc>
+  <style>
+    .bg { fill: url(#bg); }
+    .panel { fill: #fff; stroke: #d5dde8; stroke-width: 1.2; }
+    .stage { fill: #fbfdff; stroke: #e4eaf2; stroke-width: 1.2; }
+    .node { fill: rgba(255,255,255,.97); stroke: #d5dde8; stroke-width: 1.2; filter: url(#shadow); }
+    .title { fill: #172033; font: 700 18px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; dominant-baseline: middle; }
+    .hint { fill: #5f6f86; font: 400 13px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; dominant-baseline: middle; }
+    .role { font: 700 11px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; letter-spacing: .8px; dominant-baseline: middle; text-anchor: middle; }
+    .node-title { fill: #172033; font: 700 17px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    .node-text { fill: #5f6f86; font: 400 14px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    .line-base, .line-run { fill: none; stroke-linecap: round; stroke-linejoin: round; }
+    .line-base { opacity: .28; }
+    .line-run { stroke-dasharray: 14 16; animation: flow 1.8s linear infinite; }
+    .control { stroke: #2563eb; stroke-width: 3; }
+    .metadata { stroke: #c26a13; stroke-width: 3; stroke-dasharray: 8 8; }
+    .api { stroke: #7c3aed; stroke-width: 3; }
+    .data { stroke: #059669; stroke-width: 5; }
+    .legend { fill: #5f6f86; font: 400 13px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; dominant-baseline: middle; }
+    @keyframes flow { to { stroke-dashoffset: -60; } }
+    @media (prefers-reduced-motion: reduce) { .line-run { animation: none; } }
+  </style>
+
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#ffffff"/>
+      <stop offset="1" stop-color="#f8fafc"/>
+    </linearGradient>
+    <radialGradient id="warm" cx="20%" cy="25%" r="40%">
+      <stop offset="0" stop-color="#c26a13" stop-opacity=".10"/>
+      <stop offset="1" stop-color="#c26a13" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="cool" cx="82%" cy="74%" r="42%">
+      <stop offset="0" stop-color="#059669" stop-opacity=".10"/>
+      <stop offset="1" stop-color="#059669" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="150%">
+      <feDropShadow dx="0" dy="10" stdDeviation="10" flood-color="#0f172a" flood-opacity=".10"/>
+    </filter>
+    <marker id="arrow-control" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0 10 5 0 10z" fill="#2563eb"/>
+    </marker>
+    <marker id="arrow-metadata" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0 0 10 5 0 10z" fill="#c26a13"/>
+    </marker>
+    <marker id="arrow-api" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0 0 10 5 0 10z" fill="#7c3aed"/>
+    </marker>
+    <marker id="arrow-data" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0 0 10 5 0 10z" fill="#059669"/>
+    </marker>
+  </defs>
+
+  <rect class="panel" x="8" y="8" width="944" height="544" rx="8"/>
+  <text class="title" x="28" y="36">Quick Start runtime map</text>
+  <text class="hint" x="540" y="36">Control, metadata, and data paths are intentionally separate.</text>
+
+  <rect class="stage" x="28" y="62" width="904" height="414" rx="8"/>
+  <rect x="28" y="62" width="904" height="414" rx="8" fill="url(#warm)"/>
+  <rect x="28" y="62" width="904" height="414" rx="8" fill="url(#cool)"/>
+
+  <path class="line-base metadata" d="M246 177 C338 204 360 282 420 320" marker-end="url(#arrow-metadata)"/>
+  <path class="line-run metadata" d="M246 177 C338 204 360 282 420 320"/>
+
+  <path class="line-base control" d="M510 192 C510 238 510 278 510 315" marker-start="url(#arrow-control)" marker-end="url(#arrow-control)"/>
+  <path class="line-run control" d="M510 192 C510 238 510 278 510 315"/>
+
+  <path class="line-base api" d="M246 350 C302 350 352 350 412 350" marker-end="url(#arrow-api)"/>
+  <path class="line-run api" d="M246 350 C302 350 352 350 412 350"/>
+
+  <path class="line-base data" d="M608 350 C660 350 705 350 756 350" marker-start="url(#arrow-data)" marker-end="url(#arrow-data)"/>
+  <path class="line-run data" d="M608 350 C660 350 705 350 756 350"/>
+
+  <g transform="translate(56 102)">
+    <rect class="node" width="196" height="150" rx="8"/>
+    <rect x="16" y="20" width="82" height="28" rx="14" fill="#f7eadb"/>
+    <text class="role" x="57" y="34" fill="#8a3f00">METADATA</text>
+    <text class="node-title" x="16" y="74">Peer discovery</text>
+    <text class="node-text" x="16" y="102">P2PHANDSHAKE,</text>
+    <text class="node-text" x="16" y="122">embedded HTTP metadata,</text>
+    <text class="node-text" x="16" y="142">or external etcd.</text>
+  </g>
+
+  <g transform="translate(390 102)">
+    <rect class="node" width="196" height="150" rx="8"/>
+    <rect x="16" y="20" width="120" height="28" rx="14" fill="#e4ecff"/>
+    <text class="role" x="76" y="34" fill="#1d4ed8">CONTROL PLANE</text>
+    <text class="node-title" x="16" y="74">mooncake_master</text>
+    <text class="node-text" x="16" y="102">Controls membership,</text>
+    <text class="node-text" x="16" y="122">placement, eviction,</text>
+    <text class="node-text" x="16" y="142">and metrics.</text>
+  </g>
+
+  <g transform="translate(56 310)">
+    <rect class="node" width="196" height="150" rx="8"/>
+    <rect x="16" y="20" width="108" height="28" rx="14" fill="#eee5ff"/>
+    <text class="role" x="70" y="34" fill="#6d28d9">APPLICATION</text>
+    <text class="node-title" x="16" y="74">Python or service</text>
+    <text class="node-title" x="16" y="95">process</text>
+    <text class="node-text" x="16" y="123">Calls Put, Get, and</text>
+    <text class="node-text" x="16" y="143">Remove through the API.</text>
+  </g>
+
+  <g transform="translate(390 310)">
+    <rect class="node" width="196" height="150" rx="8"/>
+    <rect x="16" y="20" width="104" height="28" rx="14" fill="#ddf5ed"/>
+    <text class="role" x="68" y="34" fill="#047857">STORE CLIENT</text>
+    <text class="node-title" x="16" y="74">Store Client</text>
+    <text class="node-text" x="16" y="102">Registers memory and</text>
+    <text class="node-text" x="16" y="122">owns the local Transfer</text>
+    <text class="node-text" x="16" y="142">Engine.</text>
+  </g>
+
+  <g transform="translate(724 310)">
+    <rect class="node" width="196" height="150" rx="8"/>
+    <rect x="16" y="20" width="92" height="28" rx="14" fill="#ddf5ed"/>
+    <text class="role" x="62" y="34" fill="#047857">PEER CLIENT</text>
+    <text class="node-title" x="16" y="74">Other Store Client</text>
+    <text class="node-text" x="16" y="102">Sends and receives</text>
+    <text class="node-text" x="16" y="122">object data directly</text>
+    <text class="node-text" x="16" y="142">when more clients join.</text>
+  </g>
+
+  <g transform="translate(28 506)">
+    <line x1="0" y1="0" x2="34" y2="0" class="control"/>
+    <text class="legend" x="42" y="0">RPC control: registration and placement</text>
+    <line x1="318" y1="0" x2="352" y2="0" class="metadata"/>
+    <text class="legend" x="360" y="0">Metadata: peer discovery and transfer setup</text>
+    <line x1="674" y1="0" x2="708" y2="0" class="api"/>
+    <text class="legend" x="716" y="0">Client API: application calls</text>
+    <line x1="0" y1="34" x2="34" y2="34" class="data"/>
+    <text class="legend" x="42" y="34">Data: direct client-to-client transfer</text>
+  </g>
+</svg>

--- a/docs/source/image/mooncake-store-quickstart-flow.svg
+++ b/docs/source/image/mooncake-store-quickstart-flow.svg
@@ -61,11 +61,15 @@
   <rect x="28" y="62" width="904" height="414" rx="8" fill="url(#warm)"/>
   <rect x="28" y="62" width="904" height="414" rx="8" fill="url(#cool)"/>
 
-  <path class="line-base metadata" d="M246 177 C338 204 360 282 420 320" marker-end="url(#arrow-metadata)"/>
-  <path class="line-run metadata" d="M246 177 C338 204 360 282 420 320"/>
+  <path class="line-base metadata" d="M246 174 C334 198 356 282 420 320" marker-end="url(#arrow-metadata)"/>
+  <path class="line-run metadata" d="M246 174 C334 198 356 282 420 320"/>
+  <path class="line-base metadata" d="M246 198 C426 224 622 282 754 320" marker-end="url(#arrow-metadata)"/>
+  <path class="line-run metadata" d="M246 198 C426 224 622 282 754 320"/>
 
-  <path class="line-base control" d="M510 192 C510 238 510 278 510 315" marker-start="url(#arrow-control)" marker-end="url(#arrow-control)"/>
-  <path class="line-run control" d="M510 192 C510 238 510 278 510 315"/>
+  <path class="line-base control" d="M488 252 C488 276 488 296 488 315" marker-start="url(#arrow-control)" marker-end="url(#arrow-control)"/>
+  <path class="line-run control" d="M488 252 C488 276 488 296 488 315"/>
+  <path class="line-base control" d="M570 252 C642 272 760 288 822 315" marker-start="url(#arrow-control)" marker-end="url(#arrow-control)"/>
+  <path class="line-run control" d="M570 252 C642 272 760 288 822 315"/>
 
   <path class="line-base api" d="M246 350 C302 350 352 350 412 350" marker-end="url(#arrow-api)"/>
   <path class="line-run api" d="M246 350 C302 350 352 350 412 350"/>

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -3,6 +3,7 @@ sphinx-argparse==0.5.2
 sphinx-book-theme==1.1.4
 sphinx-copybutton==0.5.2
 sphinx-design==0.6.1
+sphinx-dynamic-command-builder==0.2.2
 sphinx-togglebutton==0.3.2
 sphinxcontrib-mermaid==2.0.1
 myst-parser==3.0.1  # `myst-parser==4.0.1` breaks inline code in titles


### PR DESCRIPTION
## Description

**WIP / not ready for review yet.**

This draft PR reorganizes the Mooncake Store deployment documentation so the main deployment guide focuses on the quick-start path, validation, metrics, and next-step navigation.

Changes included:

- Add a `sphinx-dynamic-command-builder` based master command builder.
- Move master flags, client deployment modes, and client/engine environment variables into a dedicated Mooncake Store configuration reference page.
- Move stress benchmark validation into the deployment guide.
- Add a standalone SVG runtime map for the quick-start architecture.
- Update the Quick Start link text to point to the renamed deployment guide.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
/private/tmp/mooncake-docs-venv/bin/sphinx-build -E -a -b html docs/source docs/build/html
git diff --check
pre-commit hooks via git commit
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

Manual testing:

- Verified the generated deployment guide in the local browser.
- Verified the generated configuration reference page in the local browser.
- Confirmed the old Mooncake Store Client Examples page/link is no longer present in generated docs navigation.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

AI tools were used to reorganize and edit the documentation, generate the SVG architecture map, build the docs locally, and prepare this draft PR.