### PR TITLE
[Doc] Rework Mooncake Store deployment guide: P2P-first quick start, three client deployment methods, flag fixes

### DIFF
--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -46,6 +46,7 @@ Master service listening on 0.0.0.0:50051
 
 The master's default RPC port is `50051`. (To embed an HTTP metadata server instead of using P2P, add `--enable_http_metadata_server=true --http_metadata_server_port=8080`.)
 
+(start-a-store-client)=
 ### 3. Start a Store Client
 
 A client contributes DRAM (and optionally SSD) to the cluster. The simplest way is to embed Mooncake in a Python process and call `store.setup(...)` with `metadata_server="P2PHANDSHAKE"`:

--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -446,6 +446,7 @@ rpc_port: 50051
 
 ---
 
+(reference-client-configuration-tuning)=
 ## Reference: Client Configuration & Tuning
 
 A client is configured through one of the **methods** introduced in [Start a Store Client](#start-a-store-client), plus a shared family of engine-tuning variables:

--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -23,33 +23,16 @@ Deploy a minimal single-node Mooncake Store in three steps.
 
 ### 1. Start the Metadata Service
 
-Choose one option:
+This quick start uses **P2P handshake** — the simplest option, with **nothing to start**: each node exchanges and stores Transfer Engine metadata locally during connection setup. You just pass the literal string `P2PHANDSHAKE` as the client's `metadata_server` (step 3).
 
-```bash
-# Option A: P2P handshake — the simplest metadata handshake method (recommended)
-# Nothing to start here. There is no metadata service to deploy: each node
-# exchanges and stores metadata locally during connection setup. Just set the
-# client's metadata_server to the literal string "P2PHANDSHAKE" (see step 3).
-
-# Option B: Embed HTTP metadata server in the master
-# (configured in step 2 via --enable_http_metadata_server)
-
-# Option C: External etcd
-etcd --listen-client-urls http://0.0.0.0:2379 \
-     --advertise-client-urls http://localhost:2379
-```
-
-> **Tip:** P2P handshake is the easiest way to get started — it is decentralized
-> and requires no etcd/Redis/HTTP metadata service. Prefer it for development and
-> simple deployments; use an external etcd/Redis for large, long-lived clusters.
+For large or long-lived clusters, use the master's embedded HTTP metadata server or an external etcd/Redis instead — see [Deployment Scenarios](#deployment-scenarios).
 
 ### 2. Start the Master Service
 
+With P2P handshake the master needs no metadata-server flags:
+
 ```bash
-mooncake_master \
-  --enable_http_metadata_server=true \
-  --http_metadata_server_host=0.0.0.0 \
-  --http_metadata_server_port=8080
+mooncake_master
 ```
 
 On success the log shows:
@@ -61,71 +44,34 @@ Max threads: 4
 Master service listening on 0.0.0.0:50051
 ```
 
-The master's default RPC port is `50051`. The HTTP metadata server serves on port `8080` in this example.
+The master's default RPC port is `50051`. (To embed an HTTP metadata server instead of using P2P, add `--enable_http_metadata_server=true --http_metadata_server_port=8080`.)
 
 ### 3. Start a Store Client
 
-Use the Python sample program to bring up a client that contributes 3.2 GB of DRAM to the cluster:
+A client contributes DRAM (and optionally SSD) to the cluster. The simplest way is to embed Mooncake in a Python process and call `store.setup(...)` with `metadata_server="P2PHANDSHAKE"`:
 
 ```python
-# stress_cluster_benchmark.py
-import os
-from distributed_object_store import DistributedObjectStore
+from mooncake.store import MooncakeDistributedStore
 
-store = DistributedObjectStore()
+store = MooncakeDistributedStore()
 store.setup(
-    local_hostname=os.getenv("LOCAL_HOSTNAME", "localhost"),
-    metadata_server=os.getenv("METADATA_ADDR", "http://127.0.0.1:8080/metadata"),
-    global_segment_size=3200 * 1024 * 1024,  # DRAM contributed to the cluster
-    local_buffer_size=512 * 1024 * 1024,     # Transfer Engine buffer
-    protocol=os.getenv("PROTOCOL", "tcp"),
-    device_name=os.getenv("DEVICE_NAME", ""),
-    master_server_address=os.getenv("MASTER_SERVER", "127.0.0.1:50051"),
+    local_hostname="localhost",
+    metadata_server="P2PHANDSHAKE",           # decentralized; no metadata service
+    global_segment_size=3200 * 1024 * 1024,   # DRAM contributed to the cluster
+    local_buffer_size=512 * 1024 * 1024,      # Transfer Engine buffer
+    protocol="tcp",
+    rdma_devices="",                          # keyword is rdma_devices (not device_name)
+    master_server_addr="127.0.0.1:50051",     # keyword is master_server_addr
 )
 ```
 
-```bash
-python3 stress_cluster_benchmark.py
-```
-
-To use **P2P handshake** instead of an HTTP/etcd metadata service, pass the
-literal string `P2PHANDSHAKE` as `metadata_server` — no other change is needed:
-
-```python
-store.setup(
-    local_hostname=os.getenv("LOCAL_HOSTNAME", "localhost"),
-    metadata_server="P2PHANDSHAKE",          # decentralized, no metadata service
-    global_segment_size=3200 * 1024 * 1024,
-    local_buffer_size=512 * 1024 * 1024,
-    protocol=os.getenv("PROTOCOL", "tcp"),
-    device_name=os.getenv("DEVICE_NAME", ""),
-    master_server_address=os.getenv("MASTER_SERVER", "127.0.0.1:50051"),
-)
-```
-
-The standalone store service accepts the same value:
-
-```bash
-python -m mooncake.mooncake_store_service \
-  --local_hostname=localhost \
-  --metadata_server=P2PHANDSHAKE \
-  --master_server=127.0.0.1:50051
-```
+There are **three ways** to run a client — programmatic (above), a standalone `mooncake_store_service` process (configured via `MOONCAKE_*`), and the `mooncake_client` real-client RPC process. See [Reference: Client Configuration & Tuning](#reference-client-configuration-tuning) for all three, with full parameter/env tables.
 
 **What just happened:**
 
 1. The client registered itself with the master via RPC.
 2. The master allocated a 3.2 GB segment on this node and added it to the cluster's memory pool.
 3. The client is now ready to serve `Put`/`Get`/`Remove` requests.
-
-You can also deploy a standalone store service process that hosts memory/SSD without an inference application:
-
-```bash
-python -m mooncake.mooncake_store_service \
-  --local_hostname=localhost \
-  --metadata_server=http://127.0.0.1:8080/metadata \
-  --master_server=127.0.0.1:50051
-```
 
 ### Run the Stress Benchmark
 
@@ -152,58 +98,6 @@ ROLE=decode MC_MS_AUTO_DISC=1 MC_MS_FILTERS="mlx5_1,mlx5_2" python3 mooncake-sto
 ```
 
 The absence of errors indicates successful data transfer.
-
-### Standalone Real Client via RPC
-
-To run a resource-owning real client as a standalone RPC process:
-
-```bash
-mooncake_client \
-  --global_segment_size="4GB" \
-  --master_server_address="localhost:50051" \
-  --metadata_server="http://localhost:8080/metadata"
-```
-
-The real client connects to the master and listens on port `50052` by default. Application processes such as vLLM or SGLang can then use dummy clients to forward requests to this real client.
-
-Common `mooncake_client` flags:
-
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--host` | `0.0.0.0` | Client service bind host |
-| `--port` | `50052` | Client service listen port |
-| `--global_segment_size` | `4GB` | Global segment size contributed by the client |
-| `--master_server_address` | `localhost:50051` | Master service address |
-| `--metadata_server` | `http://localhost:8080/metadata` | Transfer Engine metadata service |
-| `--protocol` | `tcp` | Transfer protocol |
-| `--device_name` | empty | Transfer device name |
-| `--threads` | `1` | Client worker thread count |
-
-### Standalone Real Client via HTTP
-
-Use `python -m mooncake.mooncake_store_service` to start a real client with a lightweight HTTP API for manual `Get` and `Put` debugging.
-
-Create a JSON config:
-
-```json
-{
-  "local_hostname": "localhost",
-  "metadata_server": "http://localhost:8080/metadata",
-  "global_segment_size": 268435456,
-  "local_buffer_size": 268435456,
-  "protocol": "tcp",
-  "device_name": "",
-  "master_server_address": "localhost:50051"
-}
-```
-
-Start the service:
-
-```bash
-python -m mooncake.mooncake_store_service --config=<config_path> --port=8081
-```
-
-The main startup parameters are `--config`, the path to the JSON configuration file, and `--port`, the HTTP server port.
 
 ### Verify Installed Examples
 
@@ -247,9 +141,9 @@ Runs a cluster of master instances coordinated through etcd. If the leader fails
 ```bash
 # Start each master instance with:
 mooncake_master \
-  --enable-ha=true \
-  --etcd-endpoints="10.0.0.1:2379;10.0.0.2:2379;10.0.0.3:2379" \
-  --rpc-address=10.0.0.1
+  --enable_ha=true \
+  --etcd_endpoints="10.0.0.1:2379;10.0.0.2:2379;10.0.0.3:2379" \
+  --rpc_address=10.0.0.1
 ```
 
 Each instance must specify its own reachable `--rpc-address`. The etcd cluster used for HA can be shared with or separate from the Transfer Engine's metadata etcd.
@@ -262,10 +156,10 @@ Same HA semantics but using Redis instead of etcd for leader election:
 
 ```bash
 mooncake_master \
-  --enable-ha=true \
+  --enable_ha=true \
   --ha_backend_type=redis \
   --ha_backend_connstring="redis://127.0.0.1:6379" \
-  --rpc-address=10.0.0.1
+  --rpc_address=10.0.0.1
 ```
 
 
@@ -427,7 +321,7 @@ glog's standard flags (`--log_dir`, `--max_log_size`, `--logtostderr`, ...) cont
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--put_start_discard_timeout_sec` | `30` | Seconds before an uncompleted `PutStart` is discarded |
-| `--put_start_release_timeout_sec` | `300` (5 min) | Seconds before `PutStart`-allocated space is released
+| `--put_start_release_timeout_sec` | `600` (10 min) | Seconds before `PutStart`-allocated space is released
 
 ### Eviction & TTLs
 
@@ -460,9 +354,9 @@ Metadata Snapshot And Restore is experimental feature.
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--enable_snapshot` | `false` | Enable periodic metadata snapshot |
-| `--snapshot_interval_seconds` | `300` (5 min) | Interval between snapshots |
-| `--snapshot_child_timeout_seconds` | `3600` (1 hour) | Timeout per snapshot child process |
-| `--snapshot_retention_count` | `10` | Number of recent snapshots retained |
+| `--snapshot_interval_seconds` | `600` (10 min) | Interval between snapshots |
+| `--snapshot_child_timeout_seconds` | `300` (5 min) | Timeout per snapshot child process |
+| `--snapshot_retention_count` | `2` | Number of recent snapshots retained |
 | `--snapshot_object_store_type` | required | Object store: `local` or `s3` |
 | `--snapshot_catalog_store_type` | empty | Catalog store: `embedded` or `redis` |
 | `--snapshot_catalog_store_connstring` | empty | Catalog store connection string (required for `redis`) |
@@ -497,6 +391,7 @@ Flags for controlling data movement between DRAM and SSD.
 | `--offload_force_evict` | `false` | Force-evict objects exceeding capacity without offload |
 | `--promotion_on_hit` | `false` | Promote SSD-resident keys to DRAM on read hit |
 | `--promotion_admission_threshold` | `2` | Min CountMinSketch count to allow promotion (`1` = disable gating) |
+| `--promotion_max_per_heartbeat` | `1` | Max promotion tasks handed to a single client per heartbeat. Each task is a synchronous SSD-read + RDMA-write on the client; serializing them avoids blocking past the client-liveness window |
 | `--promotion_queue_limit` | `50000` | Max in-flight promotion tasks |
 | `--quota_bytes` | `0` (90% of capacity) | Storage quota in bytes |
 | `--enable_disk_eviction` | `true` | Enable disk eviction |
@@ -518,7 +413,23 @@ When `--allocation_strategy=cxl` is set alongside `--enable_cxl=true`, the maste
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--root_fs_dir` | empty | DFS mount directory for multi-layer storage backend |
-| `--global_file_segment_size` | `4GB` (`4294967296`) | Max available space for DFS segments |
+| `--global_file_segment_size` | `INT64_MAX` (unlimited) | Max available space for DFS segments; default does not cap DFS usage |
+
+### NoF (NVMe-oF SSD Pool)
+
+```{caution}
+NVMe-oF SSD Pool (NoF) is an experimental feature.
+```
+
+Master-side flags for the NVMe-oF SSD pool. They control eviction within the NoF SSD tier and the heartbeat used to detect and unmount unresponsive NoF segments. For the client-side NoF I/O tuning (`MC_NOF_*`), see the [NVMe-oF SSD Pool Deployment Guide](nvmf-ssd-deployment-guide.md).
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--nof_eviction_ratio` | `0.05` | Fraction of objects evicted when NoF SSD space is full |
+| `--nof_eviction_high_watermark_ratio` | `0.95` | Usage ratio that triggers eviction in the NoF SSD tier |
+| `--nof_heartbeat_interval_sec` | `10` | How often the master probes each mounted NoF segment |
+| `--nof_heartbeat_probe_timeout_ms` | `1000` | Timeout for a single NoF heartbeat probe |
+| `--nof_heartbeat_failures_threshold` | `3` | Consecutive NoF heartbeat failures before a segment is unmounted |
 
 ### Master Configuration File
 
@@ -535,9 +446,129 @@ rpc_port: 50051
 
 ---
 
-## Reference: Client & Engine Tuning (Env Vars)
+## Reference: Client Configuration & Tuning
 
-### Runtime Protocol
+A client is configured through one of the **methods** introduced in [Start a Store Client](#start-a-store-client), plus a shared family of engine-tuning variables:
+
+- **Method A — Programmatic (`setup()` arguments)**: you pass configuration as explicit Python arguments. `MOONCAKE_*` variables are **not** read in this method.
+- **Method B — Service / Integration (`MOONCAKE_*` + CLI)**: `mooncake.mooncake_store_service` and the vLLM/SGLang connectors read `MOONCAKE_*` environment variables (via `MooncakeConfig`).
+- **Method C — Resource-owning real client (`mooncake_client`)**: configured through `mooncake_client` CLI flags (see the **Method C** subsection below).
+- **Engine runtime tuning (`MC_*`)**: low-level variables read by the C++ Transfer Engine / store client at runtime. They are orthogonal to the above and **apply to all methods**.
+
+The Method A arguments and the `MOONCAKE_*` variables are the **same logical fields in two forms** (Method B maps onto Method A); note that the `mooncake_client` CLI (Method C) uses yet another spelling for some of them (e.g. `--device_names`, `--master_server_address`).
+
+### Method A — Programmatic (`setup()` arguments)
+
+Arguments of `MooncakeDistributedStore.setup(...)`:
+
+| Argument | Type | Default | Description |
+|----------|------|---------|-------------|
+| `local_hostname` | str | required | This node's hostname / IP |
+| `metadata_server` | str | required | `P2PHANDSHAKE` / `http://…:8080/metadata` / etcd address |
+| `global_segment_size` | int (bytes) | `16777216` (16 MB) | DRAM contributed to the cluster; set explicitly (the sample uses 3.2 GB) |
+| `local_buffer_size` | int (bytes) | `16777216` (16 MB) | Transfer Engine buffer |
+| `protocol` | str | `tcp` | `tcp` / `rdma` / `cxl` / `ascend` |
+| `rdma_devices` | str | empty | RDMA NIC(s), comma-separated (rdma only). **Keyword is `rdma_devices`, not `device_name`** |
+| `master_server_addr` | str | `127.0.0.1:50051` | Master `host:port`. **Keyword is `master_server_addr`, not `master_server_address`** |
+| `engine` | TransferEngine | `None` | *(advanced)* Reuse an existing Transfer Engine instance instead of creating one |
+| `enable_ssd_offload` | bool | `false` | *(advanced)* Enable client-side SSD offload |
+| `ssd_offload_path` | str | empty | *(advanced)* SSD offload directory |
+| `tenant_id` | str | `default` | *(advanced)* Tenant identifier |
+
+```{note}
+In Method A, only the `MC_*` engine variables below have any effect — `MOONCAKE_*` are ignored. Configuration must be passed as explicit arguments.
+```
+
+### Method B — Service / Integration (`MOONCAKE_*` + CLI)
+
+`python -m mooncake.mooncake_store_service` (and the vLLM/SGLang connectors) build their configuration through `MooncakeConfig`, resolved in this order:
+
+1. `--config <path>` CLI argument → load from that JSON file.
+2. Otherwise `MOONCAKE_CONFIG_PATH` (if set) → load from that file; else read the `MOONCAKE_*` variables below.
+3. `-D key=value` CLI overrides individual fields (keys must match the `MooncakeConfig` field names, e.g. `-Dmaster_server_address=...`).
+
+```{note}
+The store service CLI only accepts `--config`, `-D/--define`, `--port`, and `--max-wait-time`. There are **no** `--local_hostname` / `--metadata_server` / `--master_server` flags — use the `MOONCAKE_*` variables (or `-D`) instead.
+```
+
+| Variable | Maps to (`setup()` arg) | Default | Description |
+|----------|-------------------------|---------|-------------|
+| `MOONCAKE_MASTER` | `master_server_addr` | — (required unless `MOONCAKE_CONFIG_PATH`) | Master `host:port` |
+| `MOONCAKE_TE_META_DATA_SERVER` | `metadata_server` | `P2PHANDSHAKE` | `P2PHANDSHAKE` / `http://…:8080/metadata` / etcd address |
+| `MOONCAKE_PROTOCOL` | `protocol` | `tcp` | `tcp` / `rdma` / `cxl` / `ascend` |
+| `MOONCAKE_DEVICE` | `rdma_devices` | empty | RDMA device(s), comma-separated; `auto-discovery` supported |
+| `MOONCAKE_GLOBAL_SEGMENT_SIZE` | `global_segment_size` | `3355443200` (3.125 GiB) | DRAM contributed; accepts byte integer **or** suffixed form like `500gb` |
+| `MOONCAKE_LOCAL_BUFFER_SIZE` | `local_buffer_size` | `1073741824` (1 GiB) | Transfer Engine buffer; same parsing as above |
+| `MOONCAKE_LOCAL_HOSTNAME` | `local_hostname` | `localhost` | |
+| `MOONCAKE_OFFLOAD_ENABLED` | `enable_ssd_offload` | `false` | Client-side SSD offload |
+| `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH` | `ssd_offload_path` | empty | Offload directory |
+| `MOONCAKE_CONFIG_PATH` | — | unset | Path to a JSON config file (takes precedence over the variables above) |
+
+```{note}
+Note the default-value difference: `MooncakeConfig` defaults `global_segment_size`/`local_buffer_size` to 3.125 GiB / 1 GiB, whereas a bare `setup()` (Method A) defaults them to 16 MB. Unlike `MC_STORE_LOCAL_HOT_CACHE_SIZE` (raw bytes only), `MOONCAKE_GLOBAL_SEGMENT_SIZE` / `MOONCAKE_LOCAL_BUFFER_SIZE` accept human-readable suffixes (`kb`/`mb`/`gb`/…) because they are parsed by `MooncakeConfig`.
+```
+
+**Launch examples:**
+
+```bash
+# P2P handshake
+MOONCAKE_MASTER=127.0.0.1:50051 \
+MOONCAKE_TE_META_DATA_SERVER=P2PHANDSHAKE \
+python -m mooncake.mooncake_store_service
+
+# HTTP metadata server
+MOONCAKE_MASTER=127.0.0.1:50051 \
+MOONCAKE_TE_META_DATA_SERVER=http://127.0.0.1:8080/metadata \
+python -m mooncake.mooncake_store_service
+```
+
+Or via a JSON config file. The service also exposes a lightweight HTTP API (on `--port`, default `8080`) for manual `Get`/`Put` debugging:
+
+```json
+{
+  "local_hostname": "localhost",
+  "metadata_server": "http://127.0.0.1:8080/metadata",
+  "global_segment_size": 268435456,
+  "local_buffer_size": 268435456,
+  "protocol": "tcp",
+  "device_name": "",
+  "master_server_address": "127.0.0.1:50051"
+}
+```
+
+```bash
+python -m mooncake.mooncake_store_service --config=<config_path> --port=8081
+```
+
+### Method C — Resource-owning Real Client (`mooncake_client`)
+
+Run the `mooncake_client` binary as a standalone RPC process that owns storage resources; application processes (vLLM / SGLang) use lightweight **dummy clients** to forward requests to it. It connects to the master and listens on port `50052` by default.
+
+```bash
+mooncake_client \
+  --global_segment_size="4GB" \
+  --master_server_address="127.0.0.1:50051" \
+  --metadata_server="http://127.0.0.1:8080/metadata"
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--host` | `0.0.0.0` | Client service bind host |
+| `--port` | `50052` | Client service listen port |
+| `--global_segment_size` | `4 GB` | Global segment size contributed by the client |
+| `--master_server_address` | `127.0.0.1:50051` | Master service address |
+| `--metadata_server` | `http://127.0.0.1:8080/metadata` | Transfer Engine metadata service |
+| `--protocol` | `tcp` | Transfer protocol |
+| `--device_names` | empty | Transfer device name(s), comma-separated |
+| `--threads` | `1` | Client worker thread count |
+| `--enable_offload` | `false` | Enable client-side SSD offload |
+| `--start_offload_rpc_server` | `true` | Start the offload RPC server for dummy clients |
+
+### Engine Runtime Tuning (`MC_*`)
+
+The following `MC_*` variables are read directly by the engine/client at runtime and **apply to all methods (A, B, and C)**.
+
+#### Runtime Protocol
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -547,23 +578,23 @@ rpc_port: 50051
 | `MC_USE_TENT` / `MC_USE_TEV1` | unset | Set to any value to enable the TENT (next-gen) transfer engine |
 | `MC_STORE_CLUSTER_ID` | unset | Cluster ID label attached to client metrics |
 
-### Topology Discovery
+#### Topology Discovery
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `MC_MS_AUTO_DISC` | `1` | Auto-discover NIC/GPU topology. Set `0` to provide `rdma_devices` manually |
+| `MC_MS_AUTO_DISC` | unset | Auto-discover NIC/GPU topology. Set `1` to force on, `0` to provide `rdma_devices` manually. When unset, auto-discovery is **off** except for `rdma`/`efa` protocols when no `rdma_devices` are given, where it defaults **on**. Ignored when TENT is enabled |
 | `MC_MS_FILTERS` | empty | Comma-separated NIC whitelist (e.g., `mlx5_0,mlx5_2`) |
 
 When `MC_MS_AUTO_DISC=0`, pass `rdma_devices` (comma-separated) to the Python `setup()` call.
 
-### Transfer Engine Metrics (disabled by default)
+#### Transfer Engine Metrics (disabled by default)
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `MC_TE_METRIC` | `0` | Set to `1` to enable engine metrics. Not supported with TENT |
 | `MC_TE_METRIC_INTERVAL_SECONDS` | `5` | Seconds between reports |
 
-### Client Metrics (enabled by default)
+#### Client Metrics (enabled by default)
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -572,38 +603,38 @@ When `MC_MS_AUTO_DISC=0`, pass `rdma_devices` (comma-separated) to the Python `s
 | `MC_STORE_CLIENT_MIN_PORT` | `12300` | Min local port for client connections |
 | `MC_STORE_CLIENT_MAX_PORT` | `14300` | Max local port for client connections |
 
-### Local Hot Cache
+#### Local Hot Cache
 
 Local hot cache provides a DRAM read cache on top of SSD-resident objects for faster access.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `MC_STORE_LOCAL_HOT_CACHE_SIZE` | unset | Size of the local hot cache (e.g., `"8gb"`). Set to enable the hot cache |
-| `MC_STORE_LOCAL_HOT_BLOCK_SIZE` | unset | Block size for hot cache (e.g., `"2mb"`) |
+| `MC_STORE_LOCAL_HOT_CACHE_SIZE` | unset | Size of the local hot cache **in raw bytes** (decimal integer, e.g., `8589934592` for 8 GB). Suffixed forms like `"8gb"` are **not** parsed. Set to a positive value to enable the hot cache |
+| `MC_STORE_LOCAL_HOT_BLOCK_SIZE` | `16777216` (16 MB) | Block size for hot cache **in raw bytes** (decimal integer, e.g., `2097152` for 2 MB). Suffixed forms like `"2mb"` are **not** parsed. Only read when the hot cache is enabled |
 | `MC_STORE_LOCAL_HOT_CACHE_USE_SHM` | unset | Set `1` to use memfd-backed shared memory |
 | `MC_STORE_LOCAL_HOT_ADMISSION_THRESHOLD` | unset | Minimum CountMinSketch count before a key is admitted to hot cache |
 
-### Local Memory Optimization
+#### Local Memory Optimization
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `MC_STORE_MEMCPY` | `0` | Set `1` to prefer local memcpy when source/destination are on the same client |
+| `MC_STORE_MEMCPY` | auto | Prefer local memcpy when source/destination are on the same client. When unset, auto-detected by transport: **enabled** in a TCP-only environment, **disabled** when an RDMA/other transport is available. Accepts `1`/`true`/`yes`/`on` or `0`/`false`/`no`/`off` to override |
 | `MC_STORE_CLIENT_SETUP_RETRIES` | `20` | Number of times to retry client registration on failure |
-| `MC_CXL_DEV_SIZE` | unset | CXL device size (overrides `--cxl_size` for client-side allocation) |
+| `MC_CXL_DEV_SIZE` | unset | CXL device size in raw bytes for client-side allocation. **Required when `protocol="cxl"`** — the client aborts at startup if it is missing |
 
-### MMap Buffer & HugePages
+#### MMap Buffer & HugePages
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `MC_STORE_USE_HUGEPAGE` | unset | Set `1` to request HugeTLB-backed `mmap()` |
 | `MC_STORE_HUGEPAGE_SIZE` | `2MB` | Supported: `2MB`, `1GB` |
 | `MC_MMAP_ARENA_POOL_SIZE` | unset | Pre-allocated arena pool size (e.g., `8gb`). Explicitly set to enable the arena |
-| `MC_DISABLE_MMAP_ARENA` | unset | Set `1` to disable arena, fall back to per-call `mmap()` |
+| `MC_DISABLE_MMAP_ARENA` | unset | Disable arena, fall back to per-call `mmap()`. Accepts `1`/`true`/`yes`/`on` (or `0`/`false`/`no`/`off`) |
 
-### yalantinglibs Log Level
+#### yalantinglibs Log Level
 
 ```bash
 export MC_YLT_LOG_LEVEL=info
 ```
 
-Available: `trace`, `debug`, `info`, `warn` (or `warning`), `error`, `critical`.
+Available: `trace`, `debug`, `info`, `warn` (or `warning`), `error`, `critical`. When unset (or set to an unrecognized value), the level defaults to `warn`.

--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -35,13 +35,10 @@ With P2P handshake the master needs no metadata-server flags:
 mooncake_master
 ```
 
-On success the log shows:
+On success the master logs a single line like:
 
 ```
-Starting Mooncake Master Service
-Port: 50051
-Max threads: 4
-Master service listening on 0.0.0.0:50051
+Master service started on port 50051, max_threads=4, ...
 ```
 
 The master's default RPC port is `50051`. (To embed an HTTP metadata server instead of using P2P, add `--enable_http_metadata_server=true --http_metadata_server_port=8080`.)
@@ -78,24 +75,25 @@ There are **three ways** to run a client — programmatic (above), a standalone 
 
 Mooncake Store includes sample programs for validating C++ and Python integrations. The [stress benchmark script](gh-file:mooncake-store/tests/stress_cluster_benchmark.py) can be used to verify a two-role prefill/decode setup.
 
-Configure the script for your network:
+Configure the script with command-line flags (run with `--help` for the full list):
 
-- `local_hostname`: the local machine's reachable IP address or hostname.
-- `metadata_server`: the Transfer Engine metadata service, for example `P2PHANDSHAKE`, `http://127.0.0.1:8080/metadata`, or an etcd address.
-- `master_server_address`: the Mooncake Store master address. Use `IP:Port` in default mode, or `etcd://IP:Port;IP:Port;...;IP:Port` in etcd-backed HA mode.
+- `--local-hostname`: the local machine's reachable IP address or hostname.
+- `--metadata-server`: the Transfer Engine metadata service, e.g. `P2PHANDSHAKE`, `http://127.0.0.1:8080/metadata`, or an etcd address.
+- `--master-server`: the Mooncake Store master address. Use `IP:Port` in default mode, or `etcd://IP:Port;IP:Port;...;IP:Port` in etcd-backed HA mode.
+- `--protocol`: transport, `tcp` / `rdma` / `cxl` / `ascend` (defaults to `rdma`).
 
 Then start the roles:
 
 ```bash
-ROLE=prefill python3 mooncake-store/tests/stress_cluster_benchmark.py
-ROLE=decode python3 mooncake-store/tests/stress_cluster_benchmark.py
+python3 mooncake-store/tests/stress_cluster_benchmark.py --role prefill
+python3 mooncake-store/tests/stress_cluster_benchmark.py --role decode
 ```
 
 For RDMA, topology auto-discovery and NIC filters can be passed through environment variables:
 
 ```bash
-ROLE=prefill MC_MS_AUTO_DISC=1 MC_MS_FILTERS="mlx5_1,mlx5_2" python3 mooncake-store/tests/stress_cluster_benchmark.py
-ROLE=decode MC_MS_AUTO_DISC=1 MC_MS_FILTERS="mlx5_1,mlx5_2" python3 mooncake-store/tests/stress_cluster_benchmark.py
+MC_MS_AUTO_DISC=1 MC_MS_FILTERS="mlx5_1,mlx5_2" python3 mooncake-store/tests/stress_cluster_benchmark.py --role prefill
+MC_MS_AUTO_DISC=1 MC_MS_FILTERS="mlx5_1,mlx5_2" python3 mooncake-store/tests/stress_cluster_benchmark.py --role decode
 ```
 
 The absence of errors indicates successful data transfer.
@@ -147,7 +145,9 @@ mooncake_master \
   --rpc_address=10.0.0.1
 ```
 
-Each instance must specify its own reachable `--rpc-address`. The etcd cluster used for HA can be shared with or separate from the Transfer Engine's metadata etcd.
+Each instance must specify its own reachable `--rpc_address`. The etcd cluster used for HA can be shared with or separate from the Transfer Engine's metadata etcd.
+
+**Client addressing:** to reach an HA cluster, clients must use the `etcd://` master-address form (so they can discover the current leader) instead of a single `IP:Port` — set `master_server_addr` (Method A) / `MOONCAKE_MASTER` (Method B) / `--master_server_address` (Method C) to `etcd://10.0.0.1:2379;10.0.0.2:2379;...`.
 
 ---
 
@@ -162,6 +162,8 @@ mooncake_master \
   --ha_backend_connstring="redis://127.0.0.1:6379" \
   --rpc_address=10.0.0.1
 ```
+
+**Client addressing:** clients reach a Redis-backed HA cluster with the `redis://connstring` master-address form (e.g. `redis://127.0.0.1:6379`) for `master_server_addr` / `MOONCAKE_MASTER` / `--master_server_address`, instead of a single `IP:Port`.
 
 
 ---
@@ -277,8 +279,8 @@ HF3FS Plugin (Experimental)<../getting_started/plugin-usage/3FS-USRBIO-Plugin>
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--rpc_port` | `50051` | RPC listen port |
-| `--rpc_thread_num` | `min(4, CPU cores)` | RPC worker threads |
+| `--rpc_port` | `0` → effective `50051` | RPC listen port. The literal default is `0`, which falls back to the deprecated `--port` (default `50051`) |
+| `--rpc_thread_num` | `0` → effective `min(4, CPU cores)` | RPC worker threads. The literal default is `0`, which falls back to the deprecated `--max_threads` → `min(4, CPU cores)` |
 | `--rpc_address` | `0.0.0.0` | RPC bind address |
 | `--rpc_interface` | empty | Network interface to resolve RPC address at startup (overrides `--rpc_address`) |
 | `--rpc_conn_timeout_seconds` | `0` | Idle connection timeout; `0` disables |
@@ -467,18 +469,18 @@ Arguments of `MooncakeDistributedStore.setup(...)`:
 |----------|------|---------|-------------|
 | `local_hostname` | str | required | This node's hostname / IP |
 | `metadata_server` | str | required | `P2PHANDSHAKE` / `http://…:8080/metadata` / etcd address |
-| `global_segment_size` | int (bytes) | `16777216` (16 MB) | DRAM contributed to the cluster; set explicitly (the sample uses 3.2 GB) |
-| `local_buffer_size` | int (bytes) | `16777216` (16 MB) | Transfer Engine buffer |
-| `protocol` | str | `tcp` | `tcp` / `rdma` / `cxl` / `ascend` |
-| `rdma_devices` | str | empty | RDMA NIC(s), comma-separated (rdma only). **Keyword is `rdma_devices`, not `device_name`** |
-| `master_server_addr` | str | `127.0.0.1:50051` | Master `host:port`. **Keyword is `master_server_addr`, not `master_server_address`** |
+| `global_segment_size` | int (bytes) | required | DRAM contributed to the cluster (the sample uses 3.2 GB) |
+| `local_buffer_size` | int (bytes) | required | Transfer Engine buffer |
+| `protocol` | str | required | `tcp` / `rdma` / `cxl` / `ascend` |
+| `rdma_devices` | str | required | RDMA NIC(s), comma-separated (pass `""` for non-RDMA). **Keyword is `rdma_devices`, not `device_name`** |
+| `master_server_addr` | str | required | Master `host:port`. **Keyword is `master_server_addr`, not `master_server_address`** |
 | `engine` | TransferEngine | `None` | *(advanced)* Reuse an existing Transfer Engine instance instead of creating one |
 | `enable_ssd_offload` | bool | `false` | *(advanced)* Enable client-side SSD offload |
 | `ssd_offload_path` | str | empty | *(advanced)* SSD offload directory |
 | `tenant_id` | str | `default` | *(advanced)* Tenant identifier |
 
 ```{note}
-In Method A, only the `MC_*` engine variables below have any effect — `MOONCAKE_*` are ignored. Configuration must be passed as explicit arguments.
+The first seven arguments have **no Python default** — the C++ defaults are not exposed by the pybind binding, so they must all be supplied (a bare `setup(local_hostname, metadata_server)` raises `TypeError`). Only `engine` / `enable_ssd_offload` / `ssd_offload_path` / `tenant_id` are optional. Also, in Method A only the `MC_*` engine variables below have any effect — `MOONCAKE_*` are ignored.
 ```
 
 ### Method B — Service / Integration (`MOONCAKE_*` + CLI)
@@ -507,7 +509,7 @@ The store service CLI only accepts `--config`, `-D/--define`, `--port`, and `--m
 | `MOONCAKE_CONFIG_PATH` | — | unset | Path to a JSON config file (takes precedence over the variables above) |
 
 ```{note}
-Note the default-value difference: `MooncakeConfig` defaults `global_segment_size`/`local_buffer_size` to 3.125 GiB / 1 GiB, whereas a bare `setup()` (Method A) defaults them to 16 MB. Unlike `MC_STORE_LOCAL_HOT_CACHE_SIZE` (raw bytes only), `MOONCAKE_GLOBAL_SEGMENT_SIZE` / `MOONCAKE_LOCAL_BUFFER_SIZE` accept human-readable suffixes (`kb`/`mb`/`gb`/…) because they are parsed by `MooncakeConfig`.
+`MooncakeConfig` (Method B) defaults `global_segment_size`/`local_buffer_size` to 3.125 GiB / 1 GiB. A direct `setup()` (Method A) has **no** default for these — they are required arguments. Unlike `MC_STORE_LOCAL_HOT_CACHE_SIZE` (raw bytes only), `MOONCAKE_GLOBAL_SEGMENT_SIZE` / `MOONCAKE_LOCAL_BUFFER_SIZE` accept human-readable suffixes (`kb`/`mb`/`gb`/…) because they are parsed by `MooncakeConfig`.
 ```
 
 **Launch examples:**


### PR DESCRIPTION
## Description

Reworks the Mooncake Store Deployment & Tuning Guide to make the quick start minimal and P2P-first, consolidate the client deployment options into three clearly-separated methods, and fix a number of inaccuracies in the command examples and flag reference (verified against the source). Documentation-only; no code changes.

**The guide had accumulated several problems:**

1. The quick start demonstrated the HTTP metadata path even though it recommended P2P handshake, and step 3 had grown to inline three deployment methods plus full flag tables.
2. Multiple command examples did not actually work (wrong module/keyword names, non-existent CLI flags).
3. Several master-flag defaults in the reference were stale, and some flags were undocumented.

## Changes
**Quick Start — P2P handshake, end to end**
1. Step 1 (metadata): P2P handshake is the demonstrated path — nothing to start; HTTP/etcd alternatives are linked to Deployment Scenarios.
2. Step 2 (master): launches a plain mooncake_master (no metadata-server flags needed under P2P).
3. Step 3 (client): a single programmatic store.setup(metadata_server="P2PHANDSHAKE") example, with a pointer to the full reference.

**Client Configuration & Tuning reference — three methods**
1. Renamed and restructured into clearly-separated methods, with detail moved out of the quick start:
- Method A — Programmatic (store.setup() argument table).
- Method B — Service / Integration (mooncake_store_service via MOONCAKE_* env vars, --config JSON, and -D overrides; launch examples).
- Method C — Resource-owning real client (mooncake_client RPC process + flag table).

2. Engine runtime tuning (MC_*) — clarified as orthogonal and applying to all methods.

3. Documented that MOONCAKE_* (config) and MC_* (engine runtime) are distinct families, and that the same logical field is spelled differently across setup() / MOONCAKE_* / mooncake_client.

**Correctness fixes**
1. setup() sample: correct import (mooncake.store.MooncakeDistributedStore) and keyword args (rdma_devices, master_server_addr — not device_name / master_server_address).
2. mooncake_store_service examples no longer use the non-existent --local_hostname / --metadata_server / --master_server flags.
3. mooncake_client table: --device_name → --device_names; default host corrected to 127.0.0.1.
4. HA examples: dashed flags (--enable-ha, --etcd-endpoints, --rpc-address) → underscore form matching the actual flag names.
5. Corrected stale master-flag defaults: put_start_release_timeout_sec 300→600, snapshot_interval_seconds 300→600, snapshot_child_timeout_seconds 3600→300, snapshot_retention_count 10→2, global_file_segment_size 4GB→INT64_MAX (unlimited).

**Newly documented flags**
1. Added --promotion_max_per_heartbeat to the Offload reference.
2. Added a NoF (NVMe-oF SSD Pool) master-flag section (--nof_eviction_*, --nof_heartbeat_*), marked experimental.




## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?


**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [ ] AI tools were used (specify below)