### PR TITLE
[Store] Stop snapshot thread promptly during shutdown

### DIFF
--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1402,6 +1402,8 @@ class MasterService {
 
     std::thread snapshot_thread_;
     std::atomic<bool> snapshot_running_{false};
+    std::mutex snapshot_thread_mutex_;
+    std::condition_variable snapshot_thread_cv_;
     // Task cleanup thread related members
     std::thread task_cleanup_thread_;
     std::atomic<bool> task_cleanup_running_{false};

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -395,7 +395,10 @@ MasterService::~MasterService() {
     // Stop and join the threads
     eviction_running_ = false;
     client_monitor_running_ = false;
-    snapshot_running_ = false;
+    {
+        std::lock_guard<std::mutex> lk(snapshot_thread_mutex_);
+        snapshot_running_ = false;
+    }
     task_cleanup_running_ = false;
     job_dispatch_running_ = false;
     graceful_unmount_scheduler_.Stop();

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -404,6 +404,7 @@ MasterService::~MasterService() {
 #endif
 
     // Wake sleepers so join() doesn't block for long sleep intervals.
+    snapshot_thread_cv_.notify_all();
     task_cleanup_cv_.notify_all();
 
     if (eviction_thread_.joinable()) {
@@ -4181,8 +4182,18 @@ uint64_t MasterService::ReleaseExpiredDiscardedReplicas(
 void MasterService::SnapshotThreadFunc() {
     LOG(INFO) << "[Snapshot] snapshot_thread started";
     while (snapshot_running_) {
-        std::this_thread::sleep_for(
-            std::chrono::seconds(snapshot_interval_seconds_));
+        // Wait for the next snapshot cycle, but allow fast shutdown.
+        {
+            std::unique_lock<std::mutex> lk(snapshot_thread_mutex_);
+            snapshot_thread_cv_.wait_for(
+                lk, std::chrono::seconds(snapshot_interval_seconds_),
+                [&] { return !snapshot_running_.load(); });
+        }
+
+        if (!snapshot_running_) {
+            break;
+        }
+
         if (!enable_snapshot_) {
             // Snapshot is disabled
             LOG(INFO)

--- a/mooncake-store/tests/ha/snapshot/snapshot_child_process_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/snapshot_child_process_test.cpp
@@ -360,6 +360,33 @@ TEST_F(SnapshotChildProcessTest, UploadSnapshotPayloadFile_Success) {
 
 // ========== Auto Snapshot Thread ==========
 
+TEST_F(SnapshotChildProcessTest, DestructorInterruptsSnapshotThreadSleep) {
+    auto config = MasterServiceConfigBuilder()
+                      .set_enable_snapshot(true)
+                      .set_enable_snapshot_restore(false)
+                      .set_snapshot_backup_dir(tmp_dir() + "/backup")
+                      .set_snapshot_interval_seconds(4)
+                      .set_snapshot_child_timeout_seconds(60)
+                      .set_snapshot_retention_count(3)
+                      .set_snapshot_object_store_type("local")
+                      .build();
+    auto auto_service = std::make_unique<MasterService>(config);
+
+    // Let the background thread enter its snapshot interval wait.
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    const auto destroy_start = std::chrono::steady_clock::now();
+    auto_service.reset();
+    const auto elapsed_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - destroy_start)
+            .count();
+
+    EXPECT_LT(elapsed_ms, 2500)
+        << "MasterService shutdown should not wait for the full snapshot "
+           "interval";
+}
+
 TEST_F(SnapshotChildProcessTest, AutoSnapshot_GeneratesFiles) {
     // Create a service with snapshot enabled and short interval
     auto config = MasterServiceConfigBuilder()

--- a/mooncake-store/tests/ha/snapshot/snapshot_child_process_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/snapshot_child_process_test.cpp
@@ -365,7 +365,7 @@ TEST_F(SnapshotChildProcessTest, DestructorInterruptsSnapshotThreadSleep) {
                       .set_enable_snapshot(true)
                       .set_enable_snapshot_restore(false)
                       .set_snapshot_backup_dir(tmp_dir() + "/backup")
-                      .set_snapshot_interval_seconds(4)
+                      .set_snapshot_interval_seconds(30)
                       .set_snapshot_child_timeout_seconds(60)
                       .set_snapshot_retention_count(3)
                       .set_snapshot_object_store_type("local")
@@ -382,7 +382,7 @@ TEST_F(SnapshotChildProcessTest, DestructorInterruptsSnapshotThreadSleep) {
             std::chrono::steady_clock::now() - destroy_start)
             .count();
 
-    EXPECT_LT(elapsed_ms, 2500)
+    EXPECT_LT(elapsed_ms, 5000)
         << "MasterService shutdown should not wait for the full snapshot "
            "interval";
 }


### PR DESCRIPTION
## Description

Fixes Mooncake Store shutdown latency when the periodic snapshot thread is sleeping.

- Replaces the snapshot thread sleep with an interruptible condition-variable wait.
- Notifies the snapshot thread during `MasterService` teardown and re-checks `snapshot_running_` before snapshot work.
- Adds coverage for destroying a snapshot-enabled `MasterService` while the snapshot thread is waiting.

## Module

- [x] Mooncake Store (`mooncake-store`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

**Test commands:**
```bash
git diff --check upstream/main...HEAD
 ./scripts/code_format.sh --check -b upstream/main
pre-commit run --files mooncake-store/include/master_service.h mooncake-store/src/master_service.cpp mooncake-store/tests/ha/snapshot/snapshot_child_process_test.cpp
cmake -S . -B build-snapshot-thread -G Ninja -DBUILD_UNIT_TESTS=ON -DWITH_STORE=ON -DWITH_TE=ON -DWITH_STORE_RUST=OFF -DWITH_EP=OFF -DWITH_P2P_STORE=OFF -DWITH_STORE_GO=OFF && cmake --build build-snapshot-thread --target snapshot_child_process_test -j 8 && cd build-snapshot-thread && ./mooncake-store/tests/snapshot_child_process_test --gtest_filter=SnapshotChildProcessTest.DestructorInterruptsSnapshotThreadSleep --gtest_color=no && ./mooncake-store/tests/snapshot_child_process_test --gtest_color=no'
```

**Test results:**
- [x] Unit tests pass (`snapshot_child_process_test`, 23/23 on Ubuntu)
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass (targeted pre-commit passed; repository-wide all-files currently reports unrelated existing lint/codespell findings)
- [x] I have updated the documentation (if applicable; not applicable for this bug fix)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue (not applicable; this PR changes 42 insertions / 2 deletions)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used: Codex assisted with implementation and validation.
