### PR TITLE
[Store]  Make P2P SSD tier ephemeral: wipe storage path on startup and exit

### DIFF
--- a/mooncake-store/include/storage_backend.h
+++ b/mooncake-store/include/storage_backend.h
@@ -172,6 +172,14 @@ class StorageBackendInterface {
         // Default: no-op (no test failures injected)
     }
 
+    // Removes every file and subdirectory under
+    // file_storage_config_.storage_filepath, keeping the directory itself.
+    // This is a no-op when the path is missing or empty. It is intentionally
+    // NOT invoked by the backends themselves; only the P2P tiered-cache path
+    // (StorageTier) calls it, so the centralized FileStorage path keeps its
+    // persist/recover-across-restart behavior unchanged.
+    void CleanStoragePath();
+
     FileStorageConfig file_storage_config_;
 };
 

--- a/mooncake-store/src/storage_backend.cpp
+++ b/mooncake-store/src/storage_backend.cpp
@@ -175,6 +175,58 @@ StorageBackendInterface::StorageBackendInterface(
     const FileStorageConfig& config)
     : file_storage_config_(config) {}
 
+void StorageBackendInterface::CleanStoragePath() {
+    namespace fs = std::filesystem;
+    const std::string& path = file_storage_config_.storage_filepath;
+    if (path.empty()) {
+        LOG(WARNING) << "CleanStoragePath: storage path is empty, skipping";
+        return;
+    }
+
+    // Refuse to wipe obviously unsafe roots to avoid catastrophic deletions
+    // from a misconfigured path.
+    fs::path normalized = fs::path(path).lexically_normal();
+    if (normalized == normalized.root_path()) {
+        LOG(ERROR) << "CleanStoragePath: refusing to clean filesystem root: "
+                   << path;
+        return;
+    }
+
+    std::error_code ec;
+    if (!fs::exists(path, ec) || ec) {
+        return;  // Nothing to clean.
+    }
+    if (!fs::is_directory(path, ec) || ec) {
+        LOG(WARNING) << "CleanStoragePath: not a directory, skipping: " << path;
+        return;
+    }
+
+    // Snapshot entries first so removal does not invalidate the iterator.
+    std::vector<fs::path> entries;
+    for (const auto& entry : fs::directory_iterator(path, ec)) {
+        if (ec) {
+            LOG(ERROR) << "CleanStoragePath: failed to iterate " << path
+                       << ", error: " << ec.message();
+            break;
+        }
+        entries.push_back(entry.path());
+    }
+
+    size_t removed = 0;
+    for (const auto& entry : entries) {
+        std::error_code rm_ec;
+        fs::remove_all(entry, rm_ec);
+        if (rm_ec) {
+            LOG(ERROR) << "CleanStoragePath: failed to remove " << entry
+                       << ", error: " << rm_ec.message();
+        } else {
+            ++removed;
+        }
+    }
+    LOG(INFO) << "CleanStoragePath: wiped storage path " << path << ", removed "
+              << removed << " top-level entries";
+}
+
 std::string StorageBackend::GetActualFsdir() const {
     std::string actual_fsdir = fsdir_;
     if (actual_fsdir.rfind("moon_", 0) == 0) {

--- a/mooncake-store/src/storage_backend.cpp
+++ b/mooncake-store/src/storage_backend.cpp
@@ -177,54 +177,75 @@ StorageBackendInterface::StorageBackendInterface(
 
 void StorageBackendInterface::CleanStoragePath() {
     namespace fs = std::filesystem;
-    const std::string& path = file_storage_config_.storage_filepath;
-    if (path.empty()) {
-        LOG(WARNING) << "CleanStoragePath: storage path is empty, skipping";
-        return;
-    }
-
-    // Refuse to wipe obviously unsafe roots to avoid catastrophic deletions
-    // from a misconfigured path.
-    fs::path normalized = fs::path(path).lexically_normal();
-    if (normalized == normalized.root_path()) {
-        LOG(ERROR) << "CleanStoragePath: refusing to clean filesystem root: "
-                   << path;
-        return;
-    }
-
-    std::error_code ec;
-    if (!fs::exists(path, ec) || ec) {
-        return;  // Nothing to clean.
-    }
-    if (!fs::is_directory(path, ec) || ec) {
-        LOG(WARNING) << "CleanStoragePath: not a directory, skipping: " << path;
-        return;
-    }
-
-    // Snapshot entries first so removal does not invalidate the iterator.
-    std::vector<fs::path> entries;
-    for (const auto& entry : fs::directory_iterator(path, ec)) {
-        if (ec) {
-            LOG(ERROR) << "CleanStoragePath: failed to iterate " << path
-                       << ", error: " << ec.message();
-            break;
+    // This is best-effort cleanup and is invoked from StorageTier's destructor,
+    // which is implicitly noexcept. Wrap the whole body so that no exception
+    // (filesystem_error from iteration, bad_alloc, ...) can escape into the
+    // destructor and trip std::terminate().
+    try {
+        const std::string& path = file_storage_config_.storage_filepath;
+        if (path.empty()) {
+            LOG(WARNING) << "CleanStoragePath: storage path is empty, skipping";
+            return;
         }
-        entries.push_back(entry.path());
-    }
 
-    size_t removed = 0;
-    for (const auto& entry : entries) {
-        std::error_code rm_ec;
-        fs::remove_all(entry, rm_ec);
-        if (rm_ec) {
-            LOG(ERROR) << "CleanStoragePath: failed to remove " << entry
-                       << ", error: " << rm_ec.message();
-        } else {
-            ++removed;
+        // Refuse to wipe dangerous paths. Requiring an absolute, non-root
+        // directory rejects "", ".", ".." and any relative path, so a
+        // misconfigured storage_filepath cannot wipe the current working
+        // directory, its parent, or the filesystem root.
+        const fs::path normalized = fs::path(path).lexically_normal();
+        if (!normalized.is_absolute() || normalized == normalized.root_path()) {
+            LOG(ERROR) << "CleanStoragePath: refusing to clean unsafe path "
+                          "(must be an absolute, non-root directory): "
+                       << path;
+            return;
         }
+
+        std::error_code ec;
+        if (!fs::exists(normalized, ec) || ec) {
+            return;  // Nothing to clean (missing path or stat error).
+        }
+        if (!fs::is_directory(normalized, ec) || ec) {
+            LOG(WARNING) << "CleanStoragePath: not a directory, skipping: "
+                         << path;
+            return;
+        }
+
+        // Snapshot entries first so removal does not invalidate the iterator.
+        // Use the non-throwing increment(ec) overload: a range-based for loop
+        // would call the throwing operator++(), which ignores the ec passed to
+        // the constructor and raises filesystem_error if the directory changes
+        // mid-traversal.
+        std::vector<fs::path> entries;
+        for (fs::directory_iterator it(normalized, ec), end; it != end;
+             it.increment(ec)) {
+            if (ec) {
+                LOG(ERROR) << "CleanStoragePath: failed to iterate " << path
+                           << ", error: " << ec.message();
+                break;
+            }
+            entries.push_back(it->path());
+        }
+
+        size_t removed = 0;
+        for (const auto& entry : entries) {
+            std::error_code rm_ec;
+            fs::remove_all(entry, rm_ec);
+            if (rm_ec) {
+                LOG(ERROR) << "CleanStoragePath: failed to remove " << entry
+                           << ", error: " << rm_ec.message();
+            } else {
+                ++removed;
+            }
+        }
+        LOG(INFO) << "CleanStoragePath: wiped storage path " << path
+                  << ", removed " << removed << " top-level entries";
+    } catch (const std::exception& e) {
+        LOG(ERROR) << "CleanStoragePath: unexpected exception, skipping: "
+                   << e.what();
+    } catch (...) {
+        LOG(ERROR) << "CleanStoragePath: unexpected non-standard exception, "
+                      "skipping";
     }
-    LOG(INFO) << "CleanStoragePath: wiped storage path " << path << ", removed "
-              << removed << " top-level entries";
 }
 
 std::string StorageBackend::GetActualFsdir() const {

--- a/mooncake-store/src/tiered_cache/tiers/storage_tier.cpp
+++ b/mooncake-store/src/tiered_cache/tiers/storage_tier.cpp
@@ -65,6 +65,16 @@ StorageTier::~StorageTier() {
 
     staging_allocator_.reset();
     staging_memory_.reset();
+
+    // P2P tiered cache treats SSD as ephemeral: wipe the storage path on exit
+    // so nothing is left behind for the next run. Wipe while the backend is
+    // still alive (CleanStoragePath unlinks the files), then destroy it so its
+    // worker threads stop and file handles close, releasing the inodes. Scoped
+    // to the P2P path only (centralized FileStorage is unaffected).
+    if (storage_backend_) {
+        storage_backend_->CleanStoragePath();
+        storage_backend_.reset();
+    }
 }
 
 tl::expected<void, ErrorCode> StorageTier::Init(TieredBackend* backend,
@@ -137,6 +147,12 @@ tl::expected<void, ErrorCode> StorageTier::Init(
             return tl::make_unexpected(backend_res.error());
         }
         storage_backend_ = backend_res.value();
+
+        // P2P tiered cache treats SSD as a purely ephemeral tier: wipe any
+        // leftover contents from a previous run on startup, before the backend
+        // scans the path. This is scoped to the P2P path only; the centralized
+        // FileStorage path keeps its persist/recover-across-restart behavior.
+        storage_backend_->CleanStoragePath();
 
         auto init_res = storage_backend_->Init();
         if (!init_res) {

--- a/mooncake-store/tests/storage_tier_test.cpp
+++ b/mooncake-store/tests/storage_tier_test.cpp
@@ -3,6 +3,7 @@
 #include <atomic>
 #include <chrono>
 #include <filesystem>
+#include <fstream>
 #include <thread>
 #include <vector>
 #include <limits>
@@ -432,6 +433,90 @@ TEST_F(StorageTierTest, StorageTierBucket) {
 
     // Cleanup
     fs::remove_all("/tmp/mooncake_test_bucket");
+}
+
+// The P2P tiered cache treats SSD as a purely ephemeral tier: it wipes the
+// configured storage path both on startup (before the backend scans it) and on
+// exit (when the tier is destroyed). This is scoped to the P2P path only; the
+// centralized FileStorage path keeps its persist/recover-across-restart
+// behavior (covered by storage_backend_test).
+TEST_F(StorageTierTest, StorageTierWipesStoragePathOnStartupAndExit) {
+    const std::string storage_path = "/tmp/mooncake_test_ephemeral_wipe";
+    setenv("MOONCAKE_OFFLOAD_STORAGE_BACKEND_DESCRIPTOR",
+           "bucket_storage_backend", 1);
+    setenv("MOONCAKE_OFFLOAD_FILE_STORAGE_PATH", storage_path.c_str(), 1);
+
+    // Simulate leftovers from a previous run: a stray file and a stale subdir.
+    fs::remove_all(storage_path);
+    fs::create_directories(storage_path);
+    {
+        std::ofstream leftover(storage_path + "/leftover_from_previous_run.bin",
+                               std::ios::binary);
+        leftover << "stale data that must be wiped on startup";
+    }
+    fs::create_directories(storage_path + "/stale_subdir");
+    ASSERT_GT(std::distance(fs::directory_iterator(storage_path),
+                            fs::directory_iterator{}),
+              0);
+
+    std::string json_config_str = R"({
+        "tiers": [
+            {
+                "type": "STORAGE",
+                "capacity": 1073741824,
+                "priority": 5,
+                "tags": ["ssd"]
+            }
+        ]
+    })";
+    Json::Value config;
+    ASSERT_TRUE(parseJsonString(json_config_str, config));
+
+    {
+        TieredBackend backend;
+        auto init_res = InitTieredBackendForTest(backend, config);
+        ASSERT_TRUE(init_res.has_value())
+            << "Init failed: " << init_res.error();
+
+        // Startup wipe: the leftovers must be gone after init.
+        EXPECT_FALSE(
+            fs::exists(storage_path + "/leftover_from_previous_run.bin"))
+            << "startup wipe should remove the stale file";
+        EXPECT_FALSE(fs::exists(storage_path + "/stale_subdir"))
+            << "startup wipe should remove the stale subdir";
+
+        // Write + commit + flush so real bucket files land on disk.
+        const size_t data_size = 1024;
+        {
+            auto alloc_result = backend.Allocate(data_size);
+            ASSERT_TRUE(alloc_result.has_value());
+            AllocationHandle handle = alloc_result.value();
+
+            auto test_buffer = CreateTestBuffer(data_size);
+            DataSource source;
+            source.buffer = std::make_unique<TempDRAMBuffer>(
+                std::move(test_buffer), data_size);
+            source.type = MemoryType::DRAM;
+            ASSERT_TRUE(backend.Write(source, handle).has_value());
+            ASSERT_TRUE(backend.Commit("ephemeral_key", handle).has_value());
+        }  // handle released here
+
+        auto tier_views = backend.GetTierViews();
+        ASSERT_FALSE(tier_views.empty());
+        auto tier = backend.GetTier(tier_views[0].id);
+        ASSERT_TRUE(const_cast<CacheTier*>(tier)->Flush().has_value());
+        EXPECT_GT(CountFilesWithExtension(storage_path, ".bucket"), 0)
+            << "flushed data should produce a .bucket file";
+    }  // backend (and its StorageTier) destroyed here -> exit wipe
+
+    // Exit wipe: the storage path is emptied, but the directory itself stays.
+    ASSERT_TRUE(fs::exists(storage_path));
+    EXPECT_EQ(std::distance(fs::directory_iterator(storage_path),
+                            fs::directory_iterator{}),
+              0)
+        << "exit wipe should remove everything left in the storage path";
+
+    fs::remove_all(storage_path);
 }
 
 TEST_F(StorageTierTest, BucketBackendRejectsOffloadWhenPhysicalSpaceTooLow) {


### PR DESCRIPTION
## Description

The P2P tiered cache treats SSD as a purely ephemeral tier, but previously the
underlying storage backend persisted bucket data across runs and recovered it on
the next startup, leaving stale files behind on exit.

This PR makes the P2P SSD tier ephemeral: its configured storage path
(`MOONCAKE_OFFLOAD_FILE_STORAGE_PATH`) is wiped both on **startup** (before the
backend scans it) and on **exit** (when the tier is destroyed), so nothing is
carried across runs.

Implementation:

- Add `StorageBackendInterface::CleanStoragePath()`, a reusable helper that
  removes everything under `file_storage_config_.storage_filepath` (keeps the
  directory itself; guards against an empty path and the filesystem root).
- Invoke it **only** from `StorageTier` (the P2P path): in `Init()` before the
  backend scans the path, and in `~StorageTier()` after the flush thread stops.
  The tier is refcounted by outstanding `AllocationHandle`s, so the exit wipe
  never removes data an in-flight handle still needs.

Scope / compatibility:

- Change is scoped to the **P2P tiered-cache path only**. The centralized
  `FileStorage` path keeps its persist/recover-across-restart behavior (its
  existing recovery tests pass unchanged).
- Behavior change for P2P: SSD data no longer survives a tier/backend restart,
  consistent with it being an ephemeral cache tier.

Files changed:

- `mooncake-store/include/storage_backend.h`
- `mooncake-store/src/storage_backend.cpp`
- `mooncake-store/src/tiered_cache/tiers/storage_tier.cpp`
- `mooncake-store/tests/storage_tier_test.cpp`

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [X] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Built and tested in the `mooncake-dev` devcontainer (`clang-format-20` 20.1.8,
GCC, Unix Makefiles, `BUILD_UNIT_TESTS=ON`). Added
`StorageTierWipesStoragePathOnStartupAndExit`, which seeds stale leftovers,
asserts they are gone after `Init()` (startup wipe), writes + flushes real bucket
data, then asserts the storage path is emptied after the tier and all handles are
destroyed (exit wipe). Logs confirm both `CleanStoragePath` calls fire.

**Test commands:**

```bash
# Inside the mooncake-dev devcontainer:
cd /workspaces/Mooncake/build
make mooncake_store storage_tier_test tiered_backend_test \
     storage_backend_test file_storage_test -j"$(nproc)"
ctest -R "storage_tier_test|tiered_backend_test|storage_backend_test|file_storage_test" \
      --output-on-failure
```

**Test results:**

```
1/4 Test #31: storage_backend_test ............   Passed    3.10 sec
2/4 Test #32: storage_tier_test ...............   Passed    0.04 sec
3/4 Test #34: file_storage_test ...............   Passed    0.08 sec
4/4 Test #35: tiered_backend_test .............   Passed    0.06 sec
100% tests passed, 0 tests failed out of 4
```

- `storage_tier_test` / `tiered_backend_test`: P2P path, including the new wipe
  test and `StorageHandleKeepsPersistedDataAliveAfterBackendDestruction`.
- `storage_backend_test`: centralized/direct backend — confirms the recovery
  tests still pass, i.e. the centralized path is unaffected.
- `file_storage_test`: centralized path.

- [X] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [X] Manual testing done (describe below)

Manual: verified via the new test's logs that `CleanStoragePath` runs once on
startup (removing seeded leftovers) and once on exit (emptying the path).

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [X] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue (N/A — change is < 500 LOC)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [X] AI tools were used (specify below)

AI tool: Claude Code (Claude Opus 4.8). It helped scope the change to the P2P
tiered-cache path, implement `CleanStoragePath()` and the `StorageTier`
startup/exit wiring, add the test, and build/run the suites in the devcontainer.
The human submitter is responsible for understanding and defending all changes.