### PR TITLE
[Docs] Clarify non-CUDA quick start dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,9 +255,9 @@ pip install mooncake-transfer-engine-npu
 
 > [!IMPORTANT]
 > - The CUDA version (`mooncake-transfer-engine`) includes Mooncake-EP and GPU topology detection, requiring CUDA 12.1+.
-> - The non-CUDA version (`mooncake-transfer-engine-non-cuda`) is for environments without CUDA dependencies.
+> - The non-CUDA version (`mooncake-transfer-engine-non-cuda`) is for environments without CUDA dependencies, but it still needs system runtime libraries such as `libcurl4`, `libibverbs1`, `rdma-core`, `librdmacm1`, `libnuma1`, and `liburing2` on Ubuntu. In a fresh environment, run `sudo apt-get update` before installing them.
 > - MLU support is currently available through source builds with `-DUSE_MLU=ON`; there is no dedicated prebuilt MLU wheel yet.
-> - If users encounter problems such as missing `lib*.so`, they should uninstall the package they installed and build the binaries manually.
+> - If users encounter problems such as missing `lib*.so`, first install the corresponding system runtime libraries. If the issue persists, uninstall the package and build the binaries manually.
 
 ### Build From Source
 

--- a/docs/source/getting_started/build.md
+++ b/docs/source/getting_started/build.md
@@ -17,7 +17,7 @@ pip install mooncake-transfer-engine-non-cuda
 ```
 📦 **Package Details**: [https://pypi.org/project/mooncake-transfer-engine-non-cuda/](https://pypi.org/project/mooncake-transfer-engine-non-cuda/)
 
-> **Note**: The CUDA version includes Mooncake-EP and GPU topology detection, requiring CUDA 12.1+. The non-CUDA version is for environments without CUDA dependencies.
+> **Note**: The CUDA version includes Mooncake-EP and GPU topology detection, requiring CUDA 12.1+. The non-CUDA version is for environments without CUDA dependencies, but it still requires the system runtime libraries used by the transfer stack. On Ubuntu, install them with `sudo apt-get update && sudo apt-get install -y libcurl4 libibverbs1 rdma-core librdmacm1 libnuma1 liburing2`.
 > **Note**: MLU support is currently source-build only. If you need Cambricon MLU memory support, install Neuware and build with `-DUSE_MLU=ON`.
 
 ## Automatic Build
@@ -30,7 +30,7 @@ pip install mooncake-transfer-engine-non-cuda
 ### Steps
 1. Install dependencies, stable Internet connection is required:
    ```bash
-   bash dependencies.sh
+   sudo bash dependencies.sh
    ```
 
 2. In the root directory of this project, run the following commands:
@@ -51,7 +51,7 @@ To enable the NVMe-oF SSD pool, install the SPDK dependencies and build
 Mooncake with `USE_NOF` enabled:
 
 ```bash
-bash dependencies.sh --with-spdk
+sudo bash dependencies.sh --with-spdk
 
 mkdir build
 cd build

--- a/docs/source/getting_started/quick-start.md
+++ b/docs/source/getting_started/quick-start.md
@@ -19,7 +19,10 @@ pip install mooncake-transfer-engine-non-cuda numpy pyzmq
 
 📦 **Package Details**: [https://pypi.org/project/mooncake-transfer-engine-non-cuda/](https://pypi.org/project/mooncake-transfer-engine-non-cuda/)
 
-> **Note**: The CUDA version includes Mooncake-EP and GPU topology detection, requiring CUDA 12.1+. The non-CUDA version is for environments without CUDA dependencies.
+> **Note**: The CUDA version includes Mooncake-EP and GPU topology detection, requiring CUDA 12.1+. The non-CUDA version is for environments without CUDA dependencies, but it still requires the system runtime libraries used by the transfer stack. On Ubuntu, install them with:
+> ```bash
+> sudo apt-get update && sudo apt-get install -y libcurl4 libibverbs1 rdma-core librdmacm1 libnuma1 liburing2
+> ```
 
 ## Transfer Engine Quick Start
 
@@ -41,7 +44,7 @@ def main():
 
     HOSTNAME = "localhost" # localhost for simple demo
     METADATA_SERVER = "P2PHANDSHAKE" # [ETCD_SERVER_URL, P2PHANDSHAKE, ...]
-    PROTOCOL = "rdma" # [rdma, tcp, ...]
+    PROTOCOL = "tcp" # use "rdma" on machines with RDMA devices configured
     DEVICE_NAME = "" # auto discovery if empty
 
     # Initialize server engine
@@ -59,12 +62,11 @@ def main():
     server_ptr = server_buffer.ctypes.data
     server_len = server_buffer.nbytes
 
-    # Register memory with Mooncake
-    if PROTOCOL == "rdma":
-        ret_value = server_engine.register_memory(server_ptr, server_len)
-        if ret_value != 0:
-            print("Mooncake memory registration failed.")
-            raise RuntimeError("Mooncake memory registration failed.")
+    # Register memory with Mooncake so the target address is advertised
+    ret_value = server_engine.register_memory(server_ptr, server_len)
+    if ret_value != 0:
+        print("Mooncake memory registration failed.")
+        raise RuntimeError("Mooncake memory registration failed.")
 
     print(f"Server initialized with session ID: {session_id}")
     print(f"Server buffer address: {server_ptr}, length: {server_len}")
@@ -86,11 +88,10 @@ def main():
         print("\nShutting down server...")
     finally:
         # Cleanup
-        if PROTOCOL == "rdma":
-            ret_value = server_engine.unregister_memory(server_ptr)
-            if ret_value != 0:
-                print("Mooncake memory deregistration failed.")
-                raise RuntimeError("Mooncake memory deregistration failed.")
+        ret_value = server_engine.unregister_memory(server_ptr)
+        if ret_value != 0:
+            print("Mooncake memory deregistration failed.")
+            raise RuntimeError("Mooncake memory deregistration failed.")
 
         socket.close()
         context.term()
@@ -127,7 +128,7 @@ def main():
     # Initialize client engine
     HOSTNAME = "localhost" # localhost for simple demo
     METADATA_SERVER = "P2PHANDSHAKE" # [ETCD_SERVER_URL, P2PHANDSHAKE, ...]
-    PROTOCOL = "rdma" # [rdma, tcp, ...]
+    PROTOCOL = "tcp" # use "rdma" on machines with RDMA devices configured
     DEVICE_NAME = "" # auto discovery if empty
 
     client_engine = TransferEngine()
@@ -144,12 +145,11 @@ def main():
     client_ptr = client_buffer.ctypes.data
     client_len = client_buffer.nbytes
 
-    # Register memory with Mooncake
-    if PROTOCOL == "rdma":
-        ret_value = client_engine.register_memory(client_ptr, client_len)
-        if ret_value != 0:
-            print("Mooncake memory registration failed.")
-            raise RuntimeError("Mooncake memory registration failed.")
+    # Register memory with Mooncake so the source address is advertised
+    ret_value = client_engine.register_memory(client_ptr, client_len)
+    if ret_value != 0:
+        print("Mooncake memory registration failed.")
+        raise RuntimeError("Mooncake memory registration failed.")
 
     print(f"Client initialized with session ID: {session_id}")
 
@@ -169,11 +169,10 @@ def main():
             print("Transfer failed!")
 
     # Cleanup
-    if PROTOCOL == "rdma":
-        ret_value = client_engine.unregister_memory(client_ptr)
-        if ret_value != 0:
-            print("Mooncake memory deregistration failed.")
-            raise RuntimeError("Mooncake memory deregistration failed.")
+    ret_value = client_engine.unregister_memory(client_ptr)
+    if ret_value != 0:
+        print("Mooncake memory deregistration failed.")
+        raise RuntimeError("Mooncake memory deregistration failed.")
 
     socket.close()
     context.term()


### PR DESCRIPTION
## Description

Clarifies the non-CUDA wheel setup docs and makes the quick-start example easier to run on machines without RDMA hardware.

Changes include:
- Document Ubuntu runtime libraries required by `mooncake-transfer-engine-non-cuda`.
- Recommend `sudo bash dependencies.sh`, matching the script's root permission requirement.
- Switch the Transfer Engine quick-start demo protocol from `rdma` to `tcp`, with a note to use `rdma` on configured RDMA machines.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Documentation-only change. Verified the diff and checked for whitespace errors.

**Test commands:**
```bash
git diff --check