### PR TITLE
 [Python] Add clean high-level declarative transfer API

### DIFF
--- a/docs/source/python-api-reference/transfer-engine.md
+++ b/docs/source/python-api-reference/transfer-engine.md
@@ -168,6 +168,43 @@ Gets the address of the first buffer in a specified segment.
 The optional `transport_hint` argument pins the request onto a named transport (`"rdma"`, `"tcp"`, ...), overriding policy-driven selection for that one call. **TENT backend only** (`MC_USE_TENT=1`); silently ignored on the classic backend. See [TENT transport selector](../design/tent/transport-selector.md) for more details.
 ```
 
+#### Declarative transfer()
+
+```python
+from mooncake.engine import TransferEngine
+from mooncake.transfer import local_buffer, remote_buffer, transfer
+
+engine = TransferEngine()
+engine.initialize("prefill-0:12345", "127.0.0.1:2379", "tcp", "")
+
+src = local_buffer(0x1000, length=4096)
+dst = remote_buffer("decode-0:12345", 0x2000)
+ret = transfer(src, dst, engine=engine)
+```
+
+The declarative helper describes the source and destination first, then maps
+the request onto the existing synchronous TransferEngine API:
+
+- `local_buffer(...) -> remote_buffer(...)` calls `transfer_sync_write()`
+- `remote_buffer(...) -> local_buffer(...)` calls `transfer_sync_read()`
+
+The length can be supplied on either endpoint or through `transfer(...,
+length=...)`. If multiple lengths are supplied, they must match. The helper
+currently supports one local endpoint and one remote endpoint per request.
+
+For reusable requests:
+
+```python
+from mooncake.transfer import TransferRequest, local_buffer, remote_buffer
+
+request = TransferRequest(
+    src=remote_buffer("prefill-0:12345", 0x2000, length=4096),
+    dst=local_buffer(0x1000),
+    transport_hint="tcp",
+)
+ret = request.execute(engine)
+```
+
 #### transfer_sync_write()
 
 ```python

--- a/mooncake-integration/CMakeLists.txt
+++ b/mooncake-integration/CMakeLists.txt
@@ -158,6 +158,7 @@ install(
     "${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-wheel/mooncake/transfer_engine_topology_dump.py"
     "${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-wheel/mooncake/mooncake_connector_v1.py"
     "${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-wheel/mooncake/vllm_v1_proxy_server.py"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-wheel/mooncake/transfer.py"
   DESTINATION ${PYTHON_SYS_PATH}/${PYTHON_PACKAGE_NAME})
 
 if(WITH_STORE)

--- a/mooncake-wheel/mooncake/__init__.py
+++ b/mooncake-wheel/mooncake/__init__.py
@@ -3,4 +3,3 @@
 from mooncake.buffer_pool import BufferPool, RegisteredBufferPool
 
 __all__ = ["BufferPool", "RegisteredBufferPool"]
-

--- a/mooncake-wheel/mooncake/transfer.py
+++ b/mooncake-wheel/mooncake/transfer.py
@@ -1,0 +1,154 @@
+"""Declarative Python helpers for Mooncake TransferEngine transfers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class TransferEndpoint:
+    """A local or remote memory range used by ``transfer``."""
+
+    address: int
+    length: Optional[int] = None
+    hostname: Optional[str] = None
+
+    @classmethod
+    def local(cls, address: int, length: Optional[int] = None) -> "TransferEndpoint":
+        return cls(address=address, length=length)
+
+    @classmethod
+    def remote(
+        cls, hostname: str, address: int, length: Optional[int] = None
+    ) -> "TransferEndpoint":
+        return cls(address=address, length=length, hostname=hostname)
+
+    def __post_init__(self) -> None:
+        if not _is_non_bool_int(self.address) or self.address < 0:
+            raise ValueError("endpoint address must be a non-negative integer")
+
+        if self.length is not None:
+            if not _is_non_bool_int(self.length) or self.length < 0:
+                raise ValueError("endpoint length must be a non-negative integer")
+
+        if self.hostname is not None:
+            if not isinstance(self.hostname, str) or not self.hostname:
+                raise ValueError("remote endpoint hostname must be a non-empty string")
+
+    @property
+    def is_remote(self) -> bool:
+        return self.hostname is not None
+
+    @property
+    def is_local(self) -> bool:
+        return self.hostname is None
+
+
+@dataclass(frozen=True)
+class TransferRequest:
+    """A declarative synchronous transfer request."""
+
+    src: TransferEndpoint
+    dst: TransferEndpoint
+    length: Optional[int] = None
+    transport_hint: str = ""
+
+    def execute(self, engine):
+        return transfer(
+            self.src,
+            self.dst,
+            engine=engine,
+            length=self.length,
+            transport_hint=self.transport_hint,
+        )
+
+
+def local_buffer(address: int, length: Optional[int] = None) -> TransferEndpoint:
+    """Create a local endpoint from a registered local memory address."""
+
+    return TransferEndpoint.local(address, length)
+
+
+def remote_buffer(
+    hostname: str, address: int, length: Optional[int] = None
+) -> TransferEndpoint:
+    """Create a remote endpoint from a peer hostname and memory address."""
+
+    return TransferEndpoint.remote(hostname, address, length)
+
+
+def transfer(
+    src: TransferEndpoint,
+    dst: TransferEndpoint,
+    *,
+    engine,
+    length: Optional[int] = None,
+    transport_hint: str = "",
+):
+    """Synchronously transfer one memory range between local and remote endpoints.
+
+    ``src`` and ``dst`` must contain exactly one local endpoint and one remote
+    endpoint. Local-to-remote transfers call ``transfer_sync_write``; remote-to-
+    local transfers call ``transfer_sync_read``.
+    """
+
+    if not isinstance(src, TransferEndpoint) or not isinstance(dst, TransferEndpoint):
+        raise TypeError("src and dst must be TransferEndpoint instances")
+
+    resolved_length = _resolve_length(src, dst, length)
+
+    if src.is_local and dst.is_remote:
+        return engine.transfer_sync_write(
+            dst.hostname,
+            src.address,
+            dst.address,
+            resolved_length,
+            transport_hint,
+        )
+
+    if src.is_remote and dst.is_local:
+        return engine.transfer_sync_read(
+            src.hostname,
+            dst.address,
+            src.address,
+            resolved_length,
+            transport_hint,
+        )
+
+    raise ValueError("transfer requires exactly one remote endpoint")
+
+
+def _resolve_length(
+    src: TransferEndpoint,
+    dst: TransferEndpoint,
+    explicit_length: Optional[int],
+) -> int:
+    lengths = [
+        value for value in (explicit_length, src.length, dst.length) if value is not None
+    ]
+
+    if not lengths:
+        raise ValueError("transfer length must be provided")
+
+    for value in lengths:
+        if not _is_non_bool_int(value) or value <= 0:
+            raise ValueError("transfer length must be a positive integer")
+
+    if len(set(lengths)) != 1:
+        raise ValueError("transfer has conflicting endpoint lengths")
+
+    return lengths[0]
+
+
+def _is_non_bool_int(value) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+__all__ = [
+    "TransferEndpoint",
+    "TransferRequest",
+    "local_buffer",
+    "remote_buffer",
+    "transfer",
+]

--- a/mooncake-wheel/tests/test_declarative_transfer_api.py
+++ b/mooncake-wheel/tests/test_declarative_transfer_api.py
@@ -1,0 +1,168 @@
+import unittest
+import types
+
+from mooncake.transfer import (
+    TransferEndpoint,
+    TransferRequest,
+    local_buffer,
+    remote_buffer,
+    transfer,
+)
+
+
+class FakeEngine:
+    def __init__(self):
+        self.calls = []
+
+    def transfer_sync_write(
+        self, target_hostname, buffer, peer_buffer_address, length, transport_hint=""
+    ):
+        self.calls.append(
+            (
+                "write",
+                target_hostname,
+                buffer,
+                peer_buffer_address,
+                length,
+                transport_hint,
+            )
+        )
+        return 0
+
+    def transfer_sync_read(
+        self, target_hostname, buffer, peer_buffer_address, length, transport_hint=""
+    ):
+        self.calls.append(
+            (
+                "read",
+                target_hostname,
+                buffer,
+                peer_buffer_address,
+                length,
+                transport_hint,
+            )
+        )
+        return 0
+
+
+class TestDeclarativeTransferApi(unittest.TestCase):
+    def test_transfer_submodule_imports_as_module(self):
+        import mooncake.transfer as transfer_module
+
+        self.assertIsInstance(transfer_module, types.ModuleType)
+        self.assertIs(transfer_module.transfer, transfer)
+
+    def test_transfer_from_local_to_remote_uses_sync_write(self):
+        engine = FakeEngine()
+        src = local_buffer(0x1000, length=4096)
+        dst = remote_buffer("decoder-0:12345", 0x2000)
+
+        ret = transfer(src, dst, engine=engine, transport_hint="tcp")
+
+        self.assertEqual(ret, 0)
+        self.assertEqual(
+            engine.calls,
+            [("write", "decoder-0:12345", 0x1000, 0x2000, 4096, "tcp")],
+        )
+
+    def test_transfer_from_remote_to_local_uses_sync_read(self):
+        engine = FakeEngine()
+        src = remote_buffer("prefill-0:12345", 0x3000, length=8192)
+        dst = local_buffer(0x4000)
+
+        ret = transfer(src, dst, engine=engine)
+
+        self.assertEqual(ret, 0)
+        self.assertEqual(
+            engine.calls,
+            [("read", "prefill-0:12345", 0x4000, 0x3000, 8192, "")],
+        )
+
+    def test_transfer_request_executes_with_explicit_length(self):
+        engine = FakeEngine()
+        request = TransferRequest(
+            src=local_buffer(0x5000),
+            dst=remote_buffer("decoder-1:12345", 0x6000),
+            length=1024,
+            transport_hint="rdma",
+        )
+
+        ret = request.execute(engine)
+
+        self.assertEqual(ret, 0)
+        self.assertEqual(
+            engine.calls,
+            [("write", "decoder-1:12345", 0x5000, 0x6000, 1024, "rdma")],
+        )
+
+    def test_transfer_requires_one_local_and_one_remote_endpoint(self):
+        engine = FakeEngine()
+
+        with self.assertRaisesRegex(ValueError, "exactly one remote endpoint"):
+            transfer(local_buffer(0x1000, 1), local_buffer(0x2000, 1), engine=engine)
+
+        with self.assertRaisesRegex(ValueError, "exactly one remote endpoint"):
+            transfer(
+                remote_buffer("prefill-0:12345", 0x1000, 1),
+                remote_buffer("decoder-0:12345", 0x2000, 1),
+                engine=engine,
+            )
+
+    def test_transfer_requires_positive_length(self):
+        engine = FakeEngine()
+
+        with self.assertRaisesRegex(ValueError, "length"):
+            transfer(
+                local_buffer(0x1000),
+                remote_buffer("decoder-0:12345", 0x2000),
+                engine=engine,
+            )
+
+        with self.assertRaisesRegex(ValueError, "positive"):
+            transfer(
+                local_buffer(0x1000),
+                remote_buffer("decoder-0:12345", 0x2000),
+                engine=engine,
+                length=0,
+            )
+
+    def test_transfer_rejects_conflicting_endpoint_lengths(self):
+        engine = FakeEngine()
+
+        with self.assertRaisesRegex(ValueError, "conflicting endpoint lengths"):
+            transfer(
+                local_buffer(0x1000, length=128),
+                remote_buffer("decoder-0:12345", 0x2000, length=256),
+                engine=engine,
+            )
+
+    def test_endpoint_validation_catches_bad_values(self):
+        with self.assertRaisesRegex(ValueError, "address"):
+            TransferEndpoint.local(-1)
+
+        with self.assertRaisesRegex(ValueError, "address"):
+            TransferEndpoint.local(True)
+
+        with self.assertRaisesRegex(ValueError, "hostname"):
+            TransferEndpoint.remote("", 0x1000)
+
+        with self.assertRaisesRegex(ValueError, "length"):
+            TransferEndpoint.local(0x1000, length=-1)
+
+        with self.assertRaisesRegex(ValueError, "length"):
+            TransferEndpoint.local(0x1000, length=True)
+
+    def test_transfer_rejects_non_endpoint_values(self):
+        engine = FakeEngine()
+
+        with self.assertRaisesRegex(TypeError, "TransferEndpoint"):
+            transfer(
+                0x1000, remote_buffer("decoder-0:12345", 0x2000, 1), engine=engine
+            )
+
+        with self.assertRaisesRegex(TypeError, "TransferEndpoint"):
+            transfer(local_buffer(0x1000, 1), 0x2000, engine=engine)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

  Implements the unchecked roadmap item from #1058: **Clean high-level declarative Python API**.

  This PR adds a small pure-Python declarative wrapper for the existing Python TransferEngine APIs:

  - `TransferEndpoint`
  - `TransferRequest`
  - `local_buffer(...)`
  - `remote_buffer(...)`
  - `transfer(src, dst, engine=...)`

  The helper maps declarative endpoints onto the existing synchronous APIs:

  - `local_buffer(...) -> remote_buffer(...)` calls `transfer_sync_write(...)`
  - `remote_buffer(...) -> local_buffer(...)` calls `transfer_sync_read(...)`

  It also validates endpoint types, addresses, lengths, hostname values, conflicting lengths, and preserves `transport_hint` forwarding.

  Docs are updated in the Python Transfer Engine API reference, and `transfer.py` is included in the CMake install path.

  ## Module

  - [ ] Transfer Engine (`mooncake-transfer-engine`)
  - [ ] Mooncake Store (`mooncake-store`)
  - [ ] Mooncake EP (`mooncake-ep`)
  - [ ] Mooncake PG (`mooncake-pg`)
  - [x] Integration (`mooncake-integration`)
  - [ ] P2P Store (`mooncake-p2p-store`)
  - [x] Python Wheel (`mooncake-wheel`)
  - [ ] Common (`mooncake-common`)
  - [ ] Mooncake RL (`mooncake-rl`)
  - [ ] CI/CD
  - [x] Docs
  - [ ] Other

  ## Type of Change

  - [ ] Bug fix
  - [x] New feature
  - [ ] Refactor
  - [ ] Breaking change
  - [x] Documentation update
  - [ ] Performance improvement
  - [ ] Other

  ## How Has This Been Tested?

  **Test commands:**
  ```bash
  PYTHONPYCACHEPREFIX=/tmp/mooncake-pycache \
  PYTHONPATH=mooncake-wheel \
  /root/autodl-tmp/.conda-envs/mooncake-py312/bin/python \
  mooncake-wheel/tests/test_declarative_transfer_api.py

  PYTHONPYCACHEPREFIX=/tmp/mooncake-pycache \
  /root/autodl-tmp/.conda-envs/mooncake-py312/bin/python -m py_compile \
  mooncake-wheel/mooncake/transfer.py \
  mooncake-wheel/mooncake/__init__.py \
  mooncake-wheel/tests/test_declarative_transfer_api.py

  git diff --check HEAD

  Test results:

  - [x] Unit tests pass
  - [ ] Integration tests pass (if applicable)
  - [x] Manual testing done (describe below)

  Manual testing:

  - Verified from mooncake.transfer import transfer works from the source package.
  - Verified import mooncake.transfer as transfer_module imports the submodule, not the transfer function.
  - Verified local-to-remote and remote-to-local requests dispatch to the expected existing sync APIs via a fake engine.

  ## Checklist

  - [x] I have performed a self-review of my own code
  - [ ] I have formatted my code using ./scripts/code_format.sh
  - [ ] I have run pre-commit run --all-files and all hooks pass
  - [x] I have updated the documentation (if applicable)
  - [x] I have added tests to prove my changes are effective
  - [ ] For changes >500 LOC: I have filed an RFC issue

  ## AI Assistance Disclosure

  - [ ] No AI tools were used
  - [x] AI tools were used (specify below)

  AI tools were used to help inspect the existing Python TransferEngine API surface, add tests and documentation.