### PR TITLE
[TE] nvlink: evict idle imported mappings

### DIFF
--- a/docs/source/getting_started/supported-protocols.md
+++ b/docs/source/getting_started/supported-protocols.md
@@ -216,6 +216,26 @@ export MC_FORCE_MNNVL=true
 - NVIDIA NVLink hardware
 - Compiled with `USE_INTRA_NVLINK=ON`
 
+**Imported Mapping Reclamation:**
+
+Both MNNVL fabric mappings and intra-node CUDA IPC mappings are reclaimed
+after an idle timeout. The settings are read when the transport is created:
+
+```bash
+# Idle timeout in seconds. Default: 120. Set to 0 or a negative value to disable.
+export MC_NVLINK_IMPORT_TTL=120
+
+# Background scan interval in seconds. Default: 30. Must be positive.
+export MC_NVLINK_EVICT_INTERVAL=30
+```
+
+A mapping is not reclaimed while it has an in-flight asynchronous transfer.
+Completion is tracked per submission, so later work queued on the same CUDA
+stream does not delay an earlier mapping's idle timestamp. Each scan attempts
+all eligible mappings; there is no fixed per-scan release limit.
+If CUDA cannot establish that a failed stream is quiescent, the mapping remains
+pinned until process exit rather than risking an unmap during DMA.
+
 ### HIP Transport (hip)
 
 **Description:** AMD ROCm/HIP transport for GPU communication using IPC handles or Shareable handles.

--- a/mooncake-transfer-engine/include/gpu_vendor/musa.h
+++ b/mooncake-transfer-engine/include/gpu_vendor/musa.h
@@ -110,6 +110,7 @@ const static std::string GPU_PREFIX = "musa:";
 #define cudaEventCreateWithFlags musaEventCreateWithFlags
 #define cudaEventDisableTiming musaEventDisableTiming
 #define cudaEventDestroy musaEventDestroy
+#define cudaEventQuery musaEventQuery
 #define cudaEventRecord musaEventRecord
 #define cudaEventSynchronize musaEventSynchronize
 #define cudaDeviceProp musaDeviceProp
@@ -127,6 +128,7 @@ const static std::string GPU_PREFIX = "musa:";
 #define cuInit muInit
 #define cuDevicePrimaryCtxRetain muDevicePrimaryCtxRetain
 #define cuDevicePrimaryCtxRelease muDevicePrimaryCtxRelease
+#define cuCtxGetCurrent muCtxGetCurrent
 #define cuCtxSetCurrent muCtxSetCurrent
 #define cudaHostRegisterMapped musaHostRegisterMapped
 #define cudaHostRegisterIoMemory musaHostRegisterIoMemory

--- a/mooncake-transfer-engine/include/transport/intranode_nvlink_transport/intranode_nvlink_transport.h
+++ b/mooncake-transfer-engine/include/transport/intranode_nvlink_transport/intranode_nvlink_transport.h
@@ -5,12 +5,15 @@
 
 #include "cuda_alike.h"
 
+#include <atomic>
+#include <condition_variable>
 #include <functional>
 #include <iostream>
 #include <memory>
 #include <mutex>
 #include <queue>
 #include <string>
+#include <thread>
 #include <unordered_set>
 #include <vector>
 #include <utility>
@@ -61,25 +64,97 @@ class IntraNodeNvlinkTransport : public Transport {
         const std::vector<void*>& addr_list) override;
 
     int relocateSharedMemoryAddress(uint64_t& dest_addr, uint64_t length,
-                                    uint64_t target_id);
+                                    uint64_t target_id,
+                                    uint64_t& mapping_base_addr);
 
     const char* getName() const override { return "nvlink_intraNode"; }
 
    private:
-    std::atomic_bool running_;
+    std::atomic_bool running_{false};
+
+    struct ReleaseState {
+        std::mutex mutex;
+        std::condition_variable cv;
+        bool done = false;
+        bool failed = false;
+    };
 
     struct OpenedShmEntry {
-        void* shm_addr;
-        uint64_t length;
+        void* shm_addr = nullptr;
+        uint64_t length = 0;
+        uint64_t target_id = 0;
+        uint64_t mapping_base_addr = 0;
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
+        CUcontext import_context = nullptr;
+#endif
+        int device_id = -1;
+        bool mapped = false;
+        bool releasing = false;
+        std::shared_ptr<ReleaseState> release_state;
+        std::atomic<int64_t> last_active_ns{0};
+        std::atomic<uint64_t> in_flight{0};
+
+        OpenedShmEntry() = default;
+        OpenedShmEntry(const OpenedShmEntry& other)
+            : shm_addr(other.shm_addr),
+              length(other.length),
+              target_id(other.target_id),
+              mapping_base_addr(other.mapping_base_addr),
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
+              import_context(other.import_context),
+#endif
+              device_id(other.device_id),
+              mapped(other.mapped),
+              releasing(other.releasing),
+              release_state(other.release_state),
+              last_active_ns(
+                  other.last_active_ns.load(std::memory_order_relaxed)),
+              in_flight(other.in_flight.load(std::memory_order_relaxed)) {
+        }
+        OpenedShmEntry& operator=(const OpenedShmEntry& other) {
+            shm_addr = other.shm_addr;
+            length = other.length;
+            target_id = other.target_id;
+            mapping_base_addr = other.mapping_base_addr;
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
+            import_context = other.import_context;
+#endif
+            device_id = other.device_id;
+            mapped = other.mapped;
+            releasing = other.releasing;
+            release_state = other.release_state;
+            last_active_ns.store(
+                other.last_active_ns.load(std::memory_order_relaxed),
+                std::memory_order_relaxed);
+            in_flight.store(other.in_flight.load(std::memory_order_relaxed),
+                            std::memory_order_relaxed);
+            return *this;
+        }
     };
+
+    bool releaseImportedEntry(OpenedShmEntry& entry);
+    void releaseMappingRef(uint64_t target_id, uint64_t mapping_base_addr);
+    void releaseSliceMappingRef(Slice* slice);
+    int retryPendingReleases();
+    int evictIdleSegments(double ttl_s);
+    void evictLoop();
 
     std::unordered_map<std::pair<uint64_t, uint64_t>, OpenedShmEntry, PairHash>
         remap_entries_;
+    std::vector<OpenedShmEntry> pending_releases_;
     RWSpinlock remap_lock_;
     // bool use_fabric_mem_;
 
     std::mutex register_mutex_;
     std::unordered_set<uint64_t> registered_base_addrs_;
+    std::thread evict_thread_;
+    std::condition_variable evict_cv_;
+    std::mutex evict_cv_mutex_;
+    double import_ttl_s_ = 0.0;
+    double evict_interval_s_ = 30.0;
 };
 
 }  // namespace mooncake

--- a/mooncake-transfer-engine/include/transport/nvlink_transport/nvlink_transport.h
+++ b/mooncake-transfer-engine/include/transport/nvlink_transport/nvlink_transport.h
@@ -5,14 +5,17 @@
 
 #include "cuda_alike.h"
 
+#include <atomic>
+#include <condition_variable>
 #include <functional>
 #include <iostream>
 #include <memory>
 #include <mutex>
 #include <queue>
 #include <string>
-#include <vector>
+#include <thread>
 #include <utility>
+#include <vector>
 
 #include "common/hash_utils.h"
 #include "topology.h"
@@ -60,24 +63,105 @@ class NvlinkTransport : public Transport {
         const std::vector<void*>& addr_list) override;
 
     int relocateSharedMemoryAddress(uint64_t& dest_addr, uint64_t length,
-                                    uint64_t target_id);
+                                    uint64_t target_id,
+                                    uint64_t& mapping_base_addr);
 
     const char* getName() const override { return "nvlink"; }
 
    private:
-    std::atomic_bool running_;
+    std::atomic_bool running_{false};
+
+    struct ReleaseState {
+        std::mutex mutex;
+        std::condition_variable cv;
+        bool done = false;
+        bool failed = false;
+    };
 
     struct OpenedShmEntry {
-        void* shm_addr;
-        uint64_t length;
+        void* shm_addr = nullptr;
+        uint64_t length = 0;
+        uint64_t target_id = 0;
+        uint64_t mapping_base_addr = 0;
+        CUmemGenericAllocationHandle import_handle{};
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
+        CUcontext import_context = nullptr;
+#endif
+        int device_id = -1;
+        bool mapped = false;
+        bool releasing = false;
+        std::shared_ptr<ReleaseState> release_state;
+        bool handle_valid = false;
+        bool address_reserved = false;
+        std::atomic<int64_t> last_active_ns{0};
+        std::atomic<uint64_t> in_flight{0};
+
+        OpenedShmEntry() = default;
+        OpenedShmEntry(const OpenedShmEntry& other)
+            : shm_addr(other.shm_addr),
+              length(other.length),
+              target_id(other.target_id),
+              mapping_base_addr(other.mapping_base_addr),
+              import_handle(other.import_handle),
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
+              import_context(other.import_context),
+#endif
+              device_id(other.device_id),
+              mapped(other.mapped),
+              releasing(other.releasing),
+              release_state(other.release_state),
+              handle_valid(other.handle_valid),
+              address_reserved(other.address_reserved),
+              last_active_ns(
+                  other.last_active_ns.load(std::memory_order_relaxed)),
+              in_flight(other.in_flight.load(std::memory_order_relaxed)) {
+        }
+        OpenedShmEntry& operator=(const OpenedShmEntry& other) {
+            shm_addr = other.shm_addr;
+            length = other.length;
+            target_id = other.target_id;
+            mapping_base_addr = other.mapping_base_addr;
+            import_handle = other.import_handle;
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
+            import_context = other.import_context;
+#endif
+            device_id = other.device_id;
+            mapped = other.mapped;
+            releasing = other.releasing;
+            release_state = other.release_state;
+            handle_valid = other.handle_valid;
+            address_reserved = other.address_reserved;
+            last_active_ns.store(
+                other.last_active_ns.load(std::memory_order_relaxed),
+                std::memory_order_relaxed);
+            in_flight.store(other.in_flight.load(std::memory_order_relaxed),
+                            std::memory_order_relaxed);
+            return *this;
+        }
     };
+
+    bool releaseImportedEntry(OpenedShmEntry& entry);
+    void releaseMappingRef(uint64_t target_id, uint64_t mapping_base_addr);
+    void releaseSliceMappingRef(Slice* slice);
+    int retryPendingReleases();
+    int evictIdleSegments(double ttl_s);
+    void evictLoop();
 
     std::unordered_map<std::pair<uint64_t, uint64_t>, OpenedShmEntry, PairHash>
         remap_entries_;
+    std::vector<OpenedShmEntry> pending_releases_;
     RWSpinlock remap_lock_;
     bool use_fabric_mem_;
 
     std::mutex register_mutex_;
+    std::thread evict_thread_;
+    std::condition_variable evict_cv_;
+    std::mutex evict_cv_mutex_;
+    double import_ttl_s_ = 0.0;
+    double evict_interval_s_ = 30.0;
 };
 
 }  // namespace mooncake

--- a/mooncake-transfer-engine/include/transport/transport.h
+++ b/mooncake-transfer-engine/include/transport/transport.h
@@ -149,8 +149,11 @@ class Transport {
             } ub;
             struct {
                 void *dest_addr;
-                void *cuda_stream;  // cudaStream_t, used by async NVLink
-                                    // transport
+                void *cuda_stream;      // cudaStream_t, used by async NVLink
+                                        // transport
+                void *cuda_completion;  // Shared per-submission completion
+                uint64_t mapping_base_addr;
+                int cuda_device_id;
             } local;
             struct {
                 uint64_t dest_addr;
@@ -180,17 +183,17 @@ class Transport {
 
        public:
         void markSuccess() {
-            status = Slice::SUCCESS;
             __atomic_fetch_add(&task->transferred_bytes, length,
                                __ATOMIC_RELAXED);
             __atomic_fetch_add(&task->success_slice_count, 1, __ATOMIC_RELAXED);
+            __atomic_store_n(&status, Slice::SUCCESS, __ATOMIC_RELEASE);
 
             check_batch_completion(false);
         }
 
         void markFailed() {
-            status = Slice::FAILED;
             __atomic_fetch_add(&task->failed_slice_count, 1, __ATOMIC_RELAXED);
+            __atomic_store_n(&status, Slice::FAILED, __ATOMIC_RELEASE);
 
             check_batch_completion(true);
         }

--- a/mooncake-transfer-engine/src/multi_transport.cpp
+++ b/mooncake-transfer-engine/src/multi_transport.cpp
@@ -273,33 +273,38 @@ Status MultiTransport::getBatchTransferStatus(BatchID batch_id,
 
     if (batch_desc.is_finished.load(std::memory_order_acquire) ||
         task_count == 0) {
-        status.s = Transport::TransferStatusEnum::COMPLETED;
+        status.s = batch_desc.has_failure.load(std::memory_order_acquire)
+                       ? Transport::TransferStatusEnum::FAILED
+                       : Transport::TransferStatusEnum::COMPLETED;
         status.transferred_bytes =
             batch_desc.finished_transfer_bytes.load(std::memory_order_relaxed);
         return Status::OK();
     }
 
-    size_t success_count = 0;
+    size_t terminal_count = 0;
+    bool has_failure = batch_desc.has_failure.load(std::memory_order_acquire);
     for (size_t task_id = 0; task_id < task_count; task_id++) {
         TransferStatus task_status;
         auto ret = getTransferStatus(batch_id, task_id, task_status);
 
         if (!ret.ok()) {
-            status.s = Transport::TransferStatusEnum::FAILED;
-            return Status::OK();
+            has_failure = true;
+            continue;
         }
 
         if (task_status.s == Transport::TransferStatusEnum::COMPLETED) {
             status.transferred_bytes += task_status.transferred_bytes;
-            success_count++;
+            terminal_count++;
         } else if (task_status.s == Transport::TransferStatusEnum::FAILED) {
-            status.s = Transport::TransferStatusEnum::FAILED;
-            return Status::OK();
+            has_failure = true;
+            terminal_count++;
         }
     }
 
-    status.s = (success_count == task_count)
-                   ? Transport::TransferStatusEnum::COMPLETED
+    batch_desc.has_failure.store(has_failure, std::memory_order_release);
+    status.s = terminal_count == task_count
+                   ? has_failure ? Transport::TransferStatusEnum::FAILED
+                                 : Transport::TransferStatusEnum::COMPLETED
                    : Transport::TransferStatusEnum::WAITING;
     if (status.s == Transport::TransferStatusEnum::COMPLETED) {
         batch_desc.is_finished.store(true, std::memory_order_release);

--- a/mooncake-transfer-engine/src/transport/intranode_nvlink_transport/intranode_nvlink_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/intranode_nvlink_transport/intranode_nvlink_transport.cpp
@@ -20,10 +20,16 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cerrno>
+#include <chrono>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <iomanip>
+#include <limits>
 #include <memory>
+#include <thread>
 #include <vector>
 
 #include "common.h"
@@ -168,9 +174,181 @@ static CudaStreamEntry getStreamForRequest(const void *source) {
     return tl_device_stream_pool.getOrCreate(device_id);
 }
 
+static double readDurationEnv(const char *name, double default_value,
+                              bool allow_nonpositive) {
+    const char *raw = std::getenv(name);
+    if (!raw || !*raw) return default_value;
+
+    errno = 0;
+    char *end = nullptr;
+    double value = std::strtod(raw, &end);
+    constexpr double kMinDurationSeconds = 1e-9;
+    constexpr double kMaxDurationSeconds =
+        static_cast<double>(std::numeric_limits<int64_t>::max()) / 1e9;
+    bool valid =
+        errno != ERANGE && end != raw && *end == '\0' && std::isfinite(value) &&
+        std::abs(value) <= kMaxDurationSeconds &&
+        (allow_nonpositive ? (value <= 0 || value >= kMinDurationSeconds)
+                           : value >= kMinDurationSeconds);
+    if (!valid) {
+        LOG(WARNING) << "IntraNodeNvlinkTransport: ignoring invalid " << name
+                     << "='" << raw << "'; using " << default_value;
+        return default_value;
+    }
+    return value;
+}
+
 }  // anonymous namespace
 
 using Slice = Transport::Slice;
+
+namespace {
+
+struct BatchCompletion {
+    cudaEvent_t event = nullptr;
+    int device_id = -1;
+    std::atomic<uint64_t> remaining_slices{0};
+    std::atomic_bool reusable{true};
+};
+
+class CompletionEventPool {
+   public:
+    cudaError_t acquire(int device_id, cudaEvent_t *event) {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            auto &events = events_[device_id];
+            if (!events.empty()) {
+                *event = events.back();
+                events.pop_back();
+                return cudaSuccess;
+            }
+        }
+        return cudaEventCreateWithFlags(event, cudaEventDisableTiming);
+    }
+
+    void recycle(int device_id, cudaEvent_t event) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        events_[device_id].push_back(event);
+    }
+
+    ~CompletionEventPool() {
+        int previous_device = -1;
+        cudaGetDevice(&previous_device);
+        for (auto &device_events : events_) {
+            cudaSetDevice(device_events.first);
+            for (auto event : device_events.second) cudaEventDestroy(event);
+        }
+        if (previous_device >= 0) cudaSetDevice(previous_device);
+    }
+
+   private:
+    std::mutex mutex_;
+    std::unordered_map<int, std::vector<cudaEvent_t>> events_;
+};
+
+static CompletionEventPool completion_event_pool;
+
+class AggressiveWriteGuard {
+   public:
+    explicit AggressiveWriteGuard(RWSpinlock &lock) : lock_(lock) {
+        lock_.writeLockAggressive();
+    }
+    ~AggressiveWriteGuard() { lock_.unlock(); }
+
+    AggressiveWriteGuard(const AggressiveWriteGuard &) = delete;
+    AggressiveWriteGuard &operator=(const AggressiveWriteGuard &) = delete;
+
+   private:
+    RWSpinlock &lock_;
+};
+
+enum class CompletionAttachResult {
+    kAttached,
+    kCompletedSynchronously,
+    kUnsafeFailure,
+};
+
+static CompletionAttachResult attachBatchCompletion(
+    const std::vector<Slice *> &slices, cudaStream_t stream, int device_id) {
+    uint64_t posted_count = 0;
+    for (auto *slice : slices) {
+        if (slice->status == Slice::POSTED) ++posted_count;
+    }
+    if (posted_count == 0) return CompletionAttachResult::kAttached;
+
+    auto *completion = new BatchCompletion;
+    completion->device_id = device_id;
+    completion->remaining_slices.store(posted_count, std::memory_order_relaxed);
+
+    int previous_device = -1;
+    cudaError_t setup_error = cudaGetDevice(&previous_device);
+    if (setup_error == cudaSuccess) setup_error = cudaSetDevice(device_id);
+    if (setup_error == cudaSuccess) {
+        setup_error =
+            completion_event_pool.acquire(device_id, &completion->event);
+    }
+    if (setup_error == cudaSuccess) {
+        setup_error = cudaEventRecord(completion->event, stream);
+    }
+
+    if (setup_error == cudaSuccess) {
+        for (auto *slice : slices) {
+            if (slice->status == Slice::POSTED) {
+                slice->local.cuda_completion = completion;
+            }
+        }
+        cudaError_t restore_error = cudaSetDevice(previous_device);
+        if (restore_error != cudaSuccess) {
+            LOG(ERROR) << "IntraNodeNvlinkTransport: failed to restore device "
+                       << previous_device
+                       << " after recording batch completion: "
+                       << cudaGetErrorString(restore_error);
+        }
+        return CompletionAttachResult::kAttached;
+    }
+
+    LOG(ERROR) << "IntraNodeNvlinkTransport: failed to record batch "
+                  "completion event: "
+               << cudaGetErrorString(setup_error);
+    cudaError_t sync_error = cudaStreamSynchronize(stream);
+    bool quiescent = sync_error == cudaSuccess;
+    if (!quiescent) {
+        LOG(ERROR) << "IntraNodeNvlinkTransport: cannot establish stream "
+                      "quiescence after completion-event failure: "
+                   << cudaGetErrorString(sync_error);
+    }
+    if (completion->event) cudaEventDestroy(completion->event);
+    if (previous_device >= 0) cudaSetDevice(previous_device);
+    delete completion;
+
+    return quiescent ? CompletionAttachResult::kCompletedSynchronously
+                     : CompletionAttachResult::kUnsafeFailure;
+}
+
+static void releaseBatchCompletion(BatchCompletion *completion) {
+    if (!completion || completion->remaining_slices.fetch_sub(
+                           1, std::memory_order_acq_rel) != 1) {
+        return;
+    }
+
+    int previous_device = -1;
+    cudaError_t error = cudaGetDevice(&previous_device);
+    if (error == cudaSuccess) error = cudaSetDevice(completion->device_id);
+    if (error == cudaSuccess && completion->reusable.load()) {
+        completion_event_pool.recycle(completion->device_id, completion->event);
+    } else if (error == cudaSuccess) {
+        error = cudaEventDestroy(completion->event);
+    }
+    if (error != cudaSuccess) {
+        LOG(ERROR) << "IntraNodeNvlinkTransport: failed to destroy batch "
+                      "completion event: "
+                   << cudaGetErrorString(error);
+    }
+    if (previous_device >= 0) cudaSetDevice(previous_device);
+    delete completion;
+}
+
+}  // anonymous namespace
 
 /// Submit batched memcpy operations using cudaMemcpyBatchAsync when available
 /// (CUDA 12.8+), falling back to per-slice cudaMemcpyAsync otherwise.
@@ -179,13 +357,15 @@ using Slice = Transport::Slice;
 /// insert the necessary memory barriers for P2P access, causing segfaults.
 /// The caller must also establish GPU-level stream synchronization
 /// (via cudaEventRecord + cudaStreamWaitEvent) before calling this function.
-/// Individual slice errors are tracked so that slices whose memcpy failed
-/// are marked as FAILED while successfully submitted ones are POSTED.
+/// Individual slice errors are returned through handle_failure while
+/// successfully submitted ones are marked POSTED.
+template <typename FailureHandler>
 static void submitBatchMemcpy(const std::vector<Slice *> &slices,
                               const std::vector<void *> &srcs,
                               const std::vector<void *> &dsts,
                               const std::vector<size_t> &sizes,
-                              cudaStream_t stream) {
+                              cudaStream_t stream,
+                              FailureHandler &&handle_failure) {
     if (slices.empty()) return;
 
     const size_t count = slices.size();
@@ -231,13 +411,22 @@ static void submitBatchMemcpy(const std::vector<Slice *> &slices,
     if (err != cudaSuccess) {
         LOG(ERROR) << "IntraNodeNvlinkTransport: cudaMemcpyBatchAsync "
                    << "failed: " << cudaGetErrorString(err);
-        // CUDA >= 13.0 does not return fail_idx; conservatively mark all
-        // as FAILED since we cannot determine which copies succeeded.
+        // CUDA >= 13.0 does not return fail_idx. Synchronize once to determine
+        // whether it is safe for the caller to release mapping references for
+        // the slices that must all be reported as failed.
+        cudaError_t sync_error = cudaStreamSynchronize(stream);
+        bool failed_slices_quiescent = sync_error == cudaSuccess;
+        if (!failed_slices_quiescent) {
+            LOG(ERROR) << "IntraNodeNvlinkTransport: cannot establish stream "
+                          "quiescence after batch submission failure: "
+                       << cudaGetErrorString(sync_error);
+        }
         for (size_t i = 0; i < count; ++i) {
             if (slices[i]->status == Slice::PENDING) {
-                slices[i]->markFailed();
+                handle_failure(slices[i], failed_slices_quiescent);
             }
         }
+        return;
     } else {
         for (size_t i = 0; i < count; ++i) {
             slices[i]->status = Slice::POSTED;
@@ -270,7 +459,7 @@ static void submitBatchMemcpy(const std::vector<Slice *> &slices,
         }
         for (size_t i = fail_idx; i < count; ++i) {
             if (slices[i]->status == Slice::PENDING) {
-                slices[i]->markFailed();
+                handle_failure(slices[i], true);
             }
         }
     } else {
@@ -288,7 +477,7 @@ static void submitBatchMemcpy(const std::vector<Slice *> &slices,
             LOG(ERROR) << "IntraNodeNvlinkTransport: cudaMemcpyAsync failed at "
                        << "index " << i << ": "
                        << cudaGetErrorString(single_err);
-            slices[i]->markFailed();
+            handle_failure(slices[i], true);
             continue;
         }
         slices[i]->status = Slice::POSTED;
@@ -361,7 +550,22 @@ static bool enableP2PAccess(int src_device_id, int dst_device_id) {
 
     return true;
 }
-IntraNodeNvlinkTransport::IntraNodeNvlinkTransport() {}
+IntraNodeNvlinkTransport::IntraNodeNvlinkTransport() {
+    import_ttl_s_ = readDurationEnv("MC_NVLINK_IMPORT_TTL", 120.0, true);
+    evict_interval_s_ =
+        readDurationEnv("MC_NVLINK_EVICT_INTERVAL", 30.0, false);
+
+    running_.store(true);
+    if (import_ttl_s_ > 0) {
+        evict_thread_ = std::thread(&IntraNodeNvlinkTransport::evictLoop, this);
+        LOG(INFO) << "IntraNodeNvlinkTransport: idle-import evictor on (ttl "
+                  << import_ttl_s_ << "s, scan " << evict_interval_s_ << "s)";
+    } else {
+        LOG(INFO) << "IntraNodeNvlinkTransport: idle-import evictor OFF (ttl "
+                  << import_ttl_s_
+                  << " <= 0); imported IPC mappings held until process exit";
+    }
+}
 
 // IntraNodeNvlinkTransport::IntraNodeNvlinkTransport() :
 // use_fabric_mem_(supportFabricMem()) {}
@@ -394,11 +598,240 @@ IntraNodeNvlinkTransport::IntraNodeNvlinkTransport() {}
 //     }
 // }
 
-IntraNodeNvlinkTransport::~IntraNodeNvlinkTransport() {
-    for (auto &entry : remap_entries_) {
-        cudaIpcCloseMemHandle(entry.second.shm_addr);
+bool IntraNodeNvlinkTransport::releaseImportedEntry(OpenedShmEntry &entry) {
+    if (entry.in_flight.load(std::memory_order_relaxed) != 0) {
+        LOG(WARNING) << "IntraNodeNvlinkTransport: refusing to release an "
+                        "imported mapping with in-flight transfers";
+        return false;
     }
-    remap_entries_.clear();
+    if (!entry.mapped) return true;
+
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
+    if (!entry.import_context) {
+        LOG(ERROR) << "IntraNodeNvlinkTransport: imported IPC mapping has no "
+                      "CUDA context";
+        return false;
+    }
+    CUcontext previous_context = nullptr;
+    CUresult result = cuCtxGetCurrent(&previous_context);
+    if (result == CUDA_SUCCESS) {
+        result = cuCtxSetCurrent(entry.import_context);
+    }
+    if (result != CUDA_SUCCESS) {
+        LOG(ERROR) << "IntraNodeNvlinkTransport: failed to activate IPC "
+                      "import context during release: "
+                   << result;
+        return false;
+    }
+    cudaError_t error = cudaIpcCloseMemHandle(entry.shm_addr);
+    if (error == cudaSuccess) entry.mapped = false;
+    result = cuCtxSetCurrent(previous_context);
+    if (result != CUDA_SUCCESS) {
+        LOG(ERROR) << "IntraNodeNvlinkTransport: failed to restore CUDA "
+                      "context after IPC release: "
+                   << result;
+    }
+    if (error != cudaSuccess) {
+        LOG(ERROR) << "IntraNodeNvlinkTransport: cudaIpcCloseMemHandle failed "
+                      "during release: "
+                   << cudaGetErrorString(error);
+        return false;
+    }
+    return true;
+#else
+    int previous_device = -1;
+    cudaError_t error = cudaGetDevice(&previous_device);
+    if (error != cudaSuccess || entry.device_id < 0) {
+        LOG(ERROR) << "IntraNodeNvlinkTransport: cannot select the import "
+                      "device before cudaIpcCloseMemHandle";
+        return false;
+    }
+    error = cudaSetDevice(entry.device_id);
+    if (error != cudaSuccess) {
+        LOG(ERROR) << "IntraNodeNvlinkTransport: cudaSetDevice("
+                   << entry.device_id
+                   << ") failed before cudaIpcCloseMemHandle: "
+                   << cudaGetErrorString(error);
+        return false;
+    }
+    error = cudaIpcCloseMemHandle(entry.shm_addr);
+    cudaError_t restore_error = cudaSetDevice(previous_device);
+    if (restore_error != cudaSuccess) {
+        LOG(ERROR) << "IntraNodeNvlinkTransport: cudaSetDevice("
+                   << previous_device
+                   << ") failed after cudaIpcCloseMemHandle: "
+                   << cudaGetErrorString(restore_error);
+    }
+    if (error != cudaSuccess) {
+        LOG(ERROR) << "IntraNodeNvlinkTransport: cudaIpcCloseMemHandle failed "
+                      "during release: "
+                   << cudaGetErrorString(error);
+        return false;
+    }
+    entry.mapped = false;
+    return true;
+#endif
+}
+
+static inline int64_t steadyNowNs() {
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(
+               std::chrono::steady_clock::now().time_since_epoch())
+        .count();
+}
+
+void IntraNodeNvlinkTransport::releaseMappingRef(uint64_t target_id,
+                                                 uint64_t mapping_base_addr) {
+    RWSpinlock::ReadGuard lock_guard(remap_lock_);
+    auto it = remap_entries_.find({target_id, mapping_base_addr});
+    if (it == remap_entries_.end()) {
+        LOG(ERROR) << "IntraNodeNvlinkTransport: mapping reference not found "
+                      "for target "
+                   << target_id << ", base " << (void *)mapping_base_addr;
+        return;
+    }
+
+    auto &entry = it->second;
+    uint64_t previous = entry.in_flight.load(std::memory_order_relaxed);
+    while (previous != 0 &&
+           !entry.in_flight.compare_exchange_weak(previous, previous - 1,
+                                                  std::memory_order_relaxed)) {
+    }
+    if (previous == 0) {
+        LOG(ERROR) << "IntraNodeNvlinkTransport: mapping reference underflow "
+                      "for target "
+                   << target_id << ", base " << (void *)mapping_base_addr;
+    } else if (previous == 1) {
+        entry.last_active_ns.store(steadyNowNs(), std::memory_order_relaxed);
+    }
+}
+
+void IntraNodeNvlinkTransport::releaseSliceMappingRef(Slice *slice) {
+    if (!slice || slice->target_id == LOCAL_SEGMENT_ID) return;
+    releaseMappingRef(slice->target_id, slice->local.mapping_base_addr);
+}
+
+int IntraNodeNvlinkTransport::retryPendingReleases() {
+    std::vector<OpenedShmEntry> retry_entries;
+    {
+        AggressiveWriteGuard lock_guard(remap_lock_);
+        retry_entries.swap(pending_releases_);
+    }
+
+    int released = 0;
+    for (auto &entry : retry_entries) {
+        bool previous_attempt_done = false;
+        if (entry.release_state) {
+            std::lock_guard<std::mutex> lock(entry.release_state->mutex);
+            previous_attempt_done = entry.release_state->done;
+        }
+        if (!entry.release_state || previous_attempt_done) {
+            entry.release_state = std::make_shared<ReleaseState>();
+            AggressiveWriteGuard lock_guard(remap_lock_);
+            auto it =
+                remap_entries_.find({entry.target_id, entry.mapping_base_addr});
+            if (it != remap_entries_.end() && it->second.releasing) {
+                it->second.release_state = entry.release_state;
+            }
+        }
+        bool success = releaseImportedEntry(entry);
+        {
+            AggressiveWriteGuard lock_guard(remap_lock_);
+            auto key = std::make_pair(entry.target_id, entry.mapping_base_addr);
+            if (success) {
+                remap_entries_.erase(key);
+            } else {
+                auto it = remap_entries_.find(key);
+                if (it != remap_entries_.end()) it->second = entry;
+                pending_releases_.push_back(entry);
+            }
+        }
+        {
+            std::lock_guard<std::mutex> lock(entry.release_state->mutex);
+            entry.release_state->failed = !success;
+            entry.release_state->done = true;
+        }
+        entry.release_state->cv.notify_all();
+        if (success) {
+            ++released;
+        }
+    }
+    return released;
+}
+
+int IntraNodeNvlinkTransport::evictIdleSegments(double ttl_s) {
+    if (ttl_s <= 0) return 0;
+
+    const int64_t now_ns = steadyNowNs();
+    const int64_t ttl_ns = static_cast<int64_t>(ttl_s * 1e9);
+    {
+        AggressiveWriteGuard lock_guard(remap_lock_);
+        for (auto it = remap_entries_.begin(); it != remap_entries_.end();) {
+            int64_t last_active =
+                it->second.last_active_ns.load(std::memory_order_relaxed);
+            bool idle =
+                it->second.in_flight.load(std::memory_order_relaxed) == 0 &&
+                !it->second.releasing && last_active != 0 &&
+                now_ns - last_active > ttl_ns;
+            if (idle) {
+                it->second.releasing = true;
+                it->second.release_state = std::make_shared<ReleaseState>();
+                pending_releases_.push_back(it->second);
+            }
+            ++it;
+        }
+    }
+
+    return retryPendingReleases();
+}
+
+void IntraNodeNvlinkTransport::evictLoop() {
+    while (running_.load()) {
+        {
+            std::unique_lock<std::mutex> lock(evict_cv_mutex_);
+            evict_cv_.wait_for(lock,
+                               std::chrono::duration<double>(evict_interval_s_),
+                               [this] { return !running_.load(); });
+        }
+        if (!running_.load()) break;
+
+        int released = evictIdleSegments(import_ttl_s_);
+        if (released > 0) {
+            LOG(INFO) << "IntraNodeNvlinkTransport: released " << released
+                      << " idle imported IPC mapping(s) (idle > "
+                      << import_ttl_s_ << "s)";
+        }
+    }
+}
+
+IntraNodeNvlinkTransport::~IntraNodeNvlinkTransport() {
+    {
+        std::lock_guard<std::mutex> lock(evict_cv_mutex_);
+        running_.store(false);
+    }
+    evict_cv_.notify_all();
+    if (evict_thread_.joinable()) evict_thread_.join();
+
+    {
+        RWSpinlock::WriteGuard lock_guard(remap_lock_);
+        for (auto &entry : remap_entries_) {
+            if (!entry.second.releasing) {
+                entry.second.releasing = true;
+                entry.second.release_state = std::make_shared<ReleaseState>();
+                pending_releases_.push_back(entry.second);
+            }
+        }
+    }
+    retryPendingReleases();
+    size_t pending_count = 0;
+    {
+        RWSpinlock::ReadGuard lock_guard(remap_lock_);
+        pending_count = pending_releases_.size();
+    }
+    if (pending_count != 0) {
+        LOG(ERROR) << "IntraNodeNvlinkTransport: " << pending_count
+                   << " imported mapping(s) remain after teardown";
+    }
 }
 
 int IntraNodeNvlinkTransport::install(
@@ -465,15 +898,25 @@ Status IntraNodeNvlinkTransport::submitTransfer(
         TransferTask &task = batch_desc.task_list[task_id];
         ++task_id;
         uint64_t dest_addr = request.target_offset;
+        uint64_t mapping_base_addr = 0;
         if (request.target_id != LOCAL_SEGMENT_ID) {
             int rc = relocateSharedMemoryAddress(dest_addr, request.length,
-                                                 request.target_id);
-            if (rc) return Status::Memory("device memory not registered");
+                                                 request.target_id,
+                                                 mapping_base_addr);
+            if (rc) {
+                for (auto *prepared_slice : slices) {
+                    releaseSliceMappingRef(prepared_slice);
+                }
+                return Status::Memory("device memory not registered");
+            }
         }
         task.total_bytes = request.length;
         Slice *slice = getSliceCache().allocate();
         slice->source_addr = (char *)request.source;
         slice->local.dest_addr = (char *)dest_addr;
+        slice->local.cuda_completion = nullptr;
+        slice->local.mapping_base_addr = mapping_base_addr;
+        slice->local.cuda_device_id = stream_entry.device_id;
         slice->length = request.length;
         slice->opcode = request.opcode;
         slice->task = &task;
@@ -496,7 +939,36 @@ Status IntraNodeNvlinkTransport::submitTransfer(
     }
 
     // Phase 2: Submit all memcpy operations
-    submitBatchMemcpy(slices, srcs, dsts, sizes, stream);
+    std::vector<Slice *> refs_to_release;
+    std::vector<std::pair<Slice *, bool>> terminal_slices;
+    submitBatchMemcpy(slices, srcs, dsts, sizes, stream,
+                      [&](Slice *slice, bool quiescent) {
+                          if (quiescent) refs_to_release.push_back(slice);
+                          terminal_slices.push_back({slice, false});
+                      });
+    CompletionAttachResult completion_result =
+        attachBatchCompletion(slices, stream, stream_entry.device_id);
+    if (completion_result == CompletionAttachResult::kCompletedSynchronously) {
+        for (auto *slice : slices) {
+            if (slice->status == Slice::POSTED) {
+                refs_to_release.push_back(slice);
+                terminal_slices.push_back({slice, true});
+            }
+        }
+    } else if (completion_result == CompletionAttachResult::kUnsafeFailure) {
+        for (auto *slice : slices) {
+            if (slice->status == Slice::POSTED) {
+                terminal_slices.push_back({slice, false});
+            }
+        }
+    }
+    for (auto *slice : refs_to_release) releaseSliceMappingRef(slice);
+    for (const auto &terminal : terminal_slices) {
+        if (terminal.second)
+            terminal.first->markSuccess();
+        else
+            terminal.first->markFailed();
+    }
 
     return Status::OK();
 }
@@ -513,39 +985,143 @@ Status IntraNodeNvlinkTransport::getTransferStatus(BatchID batch_id,
             std::to_string(batch_id));
     }
     auto &task = batch_desc.task_list[task_id];
-    // Poll POSTED slices for async completion via cudaStreamQuery.
-    std::unordered_map<cudaStream_t, cudaError_t> stream_status_cache;
+    // Poll the completion event recorded after this submission. Unlike querying
+    // the shared per-device stream, this lets an earlier batch complete even
+    // while newer batches remain queued on that stream.
+    struct EventStatus {
+        cudaError_t query_result;
+        bool quiescent;
+    };
+    std::unordered_map<BatchCompletion *, EventStatus> event_status_cache;
+    std::vector<std::pair<Slice *, bool>> terminal_slices;
     for (auto *slice : task.slice_list) {
-        if (slice && slice->status == Slice::POSTED) {
-            cudaStream_t stream = (cudaStream_t)slice->local.cuda_stream;
-            auto it = stream_status_cache.find(stream);
-            cudaError_t cuda_err;
-            if (it == stream_status_cache.end()) {
-                cuda_err = cudaStreamQuery(stream);
-                stream_status_cache[stream] = cuda_err;
-            } else {
-                cuda_err = it->second;
+        if (slice && __atomic_load_n(&slice->status, __ATOMIC_ACQUIRE) ==
+                         Slice::POSTED) {
+            Slice::SliceStatus expected = Slice::POSTED;
+            if (!__atomic_compare_exchange_n(
+                    &slice->status, &expected, Slice::PENDING, false,
+                    __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)) {
+                continue;
             }
-            if (cuda_err == cudaSuccess) {
-                slice->markSuccess();
-            } else if (cuda_err != cudaErrorNotReady) {
-                slice->markFailed();
+            auto *completion =
+                static_cast<BatchCompletion *>(slice->local.cuda_completion);
+            if (!completion) {
+                LOG(ERROR) << "IntraNodeNvlinkTransport: POSTED slice has no "
+                              "completion event";
+                __atomic_store_n(&slice->status, Slice::POSTED,
+                                 __ATOMIC_RELEASE);
+                continue;
+            }
+            auto it = event_status_cache.find(completion);
+            EventStatus event_status;
+            if (it == event_status_cache.end()) {
+                int previous_device = -1;
+                cudaError_t cuda_err = cudaGetDevice(&previous_device);
+                if (cuda_err != cudaSuccess ||
+                    cudaSetDevice(completion->device_id) != cudaSuccess) {
+                    LOG(ERROR)
+                        << "IntraNodeNvlinkTransport: cannot activate device "
+                        << completion->device_id
+                        << " to query the batch completion event";
+                    __atomic_store_n(&slice->status, Slice::POSTED,
+                                     __ATOMIC_RELEASE);
+                    continue;
+                }
+                event_status.query_result = cudaEventQuery(completion->event);
+                event_status.quiescent =
+                    event_status.query_result == cudaSuccess;
+                if (event_status.query_result != cudaSuccess &&
+                    event_status.query_result != cudaErrorNotReady) {
+                    completion->reusable.store(false,
+                                               std::memory_order_relaxed);
+                    cudaError_t sync_error =
+                        cudaEventSynchronize(completion->event);
+                    event_status.quiescent = sync_error == cudaSuccess;
+                    if (sync_error != cudaSuccess) {
+                        LOG(ERROR) << "IntraNodeNvlinkTransport: failed to "
+                                      "establish batch quiescence after event "
+                                      "query error: "
+                                   << cudaGetErrorString(sync_error);
+                    }
+                }
+                cudaError_t restore_error = cudaSetDevice(previous_device);
+                if (restore_error != cudaSuccess) {
+                    LOG(ERROR) << "IntraNodeNvlinkTransport: failed to restore "
+                                  "device "
+                               << previous_device
+                               << " after querying the completion event: "
+                               << cudaGetErrorString(restore_error);
+                }
+                event_status_cache[completion] = event_status;
+            } else {
+                event_status = it->second;
+            }
+            cudaError_t cuda_err = event_status.query_result;
+            if (cuda_err != cudaSuccess && cuda_err != cudaErrorNotReady) {
+                LOG(ERROR) << "IntraNodeNvlinkTransport: cudaEventQuery failed "
+                              "on device "
+                           << completion->device_id << ": "
+                           << cudaGetErrorString(cuda_err);
+            }
+            if (cuda_err != cudaErrorNotReady) {
+                if (cuda_err == cudaSuccess) {
+                    releaseSliceMappingRef(slice);
+                    terminal_slices.push_back({slice, true});
+                } else {
+                    if (event_status.quiescent) {
+                        releaseSliceMappingRef(slice);
+                    }
+                    // If synchronization also failed, keep the mapping pinned:
+                    // the DMA state is unknown and teardown will refuse to
+                    // unmap it while the reference remains outstanding.
+                    terminal_slices.push_back({slice, false});
+                }
+                releaseBatchCompletion(completion);
+            } else {
+                __atomic_store_n(&slice->status, Slice::POSTED,
+                                 __ATOMIC_RELEASE);
             }
         }
     }
-    status.transferred_bytes = task.transferred_bytes;
     uint64_t success_slice_count = task.success_slice_count;
     uint64_t failed_slice_count = task.failed_slice_count;
+    uint64_t transferred_bytes = task.transferred_bytes;
+    for (const auto &terminal : terminal_slices) {
+        if (terminal.second) {
+            ++success_slice_count;
+            transferred_bytes += terminal.first->length;
+        } else {
+            ++failed_slice_count;
+        }
+    }
+    status.transferred_bytes = transferred_bytes;
     if (success_slice_count + failed_slice_count == task.slice_count) {
         if (failed_slice_count) {
             status.s = TransferStatusEnum::FAILED;
         } else {
             status.s = TransferStatusEnum::COMPLETED;
         }
-        task.is_finished = true;
     } else {
         status.s = TransferStatusEnum::WAITING;
     }
+#ifndef USE_EVENT_DRIVEN_COMPLETION
+    for (const auto &terminal : terminal_slices) {
+        if (terminal.second)
+            terminal.first->markSuccess();
+        else
+            terminal.first->markFailed();
+    }
+    if (success_slice_count + failed_slice_count == task.slice_count) {
+        task.is_finished = true;
+    }
+#else
+    for (const auto &terminal : terminal_slices) {
+        if (terminal.second)
+            terminal.first->markSuccess();
+        else
+            terminal.first->markFailed();
+    }
+#endif
     return Status::OK();
 }
 
@@ -583,15 +1159,25 @@ Status IntraNodeNvlinkTransport::submitTransferTask(
         assert(task.request);
         auto &request = *task.request;
         uint64_t dest_addr = request.target_offset;
+        uint64_t mapping_base_addr = 0;
         if (request.target_id != LOCAL_SEGMENT_ID) {
             int rc = relocateSharedMemoryAddress(dest_addr, request.length,
-                                                 request.target_id);
-            if (rc) return Status::Memory("device memory not registered");
+                                                 request.target_id,
+                                                 mapping_base_addr);
+            if (rc) {
+                for (auto *prepared_slice : slices) {
+                    releaseSliceMappingRef(prepared_slice);
+                }
+                return Status::Memory("device memory not registered");
+            }
         }
         task.total_bytes = request.length;
         Slice *slice = getSliceCache().allocate();
         slice->source_addr = (char *)request.source;
         slice->local.dest_addr = (char *)dest_addr;
+        slice->local.cuda_completion = nullptr;
+        slice->local.mapping_base_addr = mapping_base_addr;
+        slice->local.cuda_device_id = stream_entry.device_id;
         slice->length = request.length;
         slice->opcode = request.opcode;
         slice->task = &task;
@@ -614,7 +1200,36 @@ Status IntraNodeNvlinkTransport::submitTransferTask(
     }
 
     // Phase 2: Submit all memcpy operations
-    submitBatchMemcpy(slices, srcs, dsts, sizes, stream);
+    std::vector<Slice *> refs_to_release;
+    std::vector<std::pair<Slice *, bool>> terminal_slices;
+    submitBatchMemcpy(slices, srcs, dsts, sizes, stream,
+                      [&](Slice *slice, bool quiescent) {
+                          if (quiescent) refs_to_release.push_back(slice);
+                          terminal_slices.push_back({slice, false});
+                      });
+    CompletionAttachResult completion_result =
+        attachBatchCompletion(slices, stream, stream_entry.device_id);
+    if (completion_result == CompletionAttachResult::kCompletedSynchronously) {
+        for (auto *slice : slices) {
+            if (slice->status == Slice::POSTED) {
+                refs_to_release.push_back(slice);
+                terminal_slices.push_back({slice, true});
+            }
+        }
+    } else if (completion_result == CompletionAttachResult::kUnsafeFailure) {
+        for (auto *slice : slices) {
+            if (slice->status == Slice::POSTED) {
+                terminal_slices.push_back({slice, false});
+            }
+        }
+    }
+    for (auto *slice : refs_to_release) releaseSliceMappingRef(slice);
+    for (const auto &terminal : terminal_slices) {
+        if (terminal.second)
+            terminal.first->markSuccess();
+        else
+            terminal.first->markFailed();
+    }
 
     return Status::OK();
 }
@@ -703,54 +1318,137 @@ int IntraNodeNvlinkTransport::unregisterLocalMemory(void *addr,
     return metadata_->removeLocalMemoryBuffer(key_ptr, update_metadata);
 }
 
-int IntraNodeNvlinkTransport::relocateSharedMemoryAddress(uint64_t &dest_addr,
-                                                          uint64_t length,
-                                                          uint64_t target_id) {
+int IntraNodeNvlinkTransport::relocateSharedMemoryAddress(
+    uint64_t &dest_addr, uint64_t length, uint64_t target_id,
+    uint64_t &mapping_base_addr) {
     auto desc = metadata_->getSegmentDescByID(target_id);
     int index = 0;
     for (auto &entry : desc->buffers) {
         if (!entry.shm_name.empty() && entry.addr <= dest_addr &&
             dest_addr + length <= entry.addr + entry.length) {
+        retry_mapping:
             remap_lock_.lockShared();
-            if (remap_entries_.count(std::make_pair(target_id, entry.addr))) {
-                auto shm_addr =
-                    remap_entries_[std::make_pair(target_id, entry.addr)]
-                        .shm_addr;
+            auto key = std::make_pair(target_id, entry.addr);
+            auto cache_it = remap_entries_.find(key);
+            if (cache_it != remap_entries_.end()) {
+                if (cache_it->second.releasing) {
+                    auto release_state = cache_it->second.release_state;
+                    remap_lock_.unlockShared();
+                    if (!release_state) {
+                        std::this_thread::yield();
+                        goto retry_mapping;
+                    }
+                    std::unique_lock<std::mutex> lock(release_state->mutex);
+                    release_state->cv.wait(lock,
+                                           [&] { return release_state->done; });
+                    if (release_state->failed) return -1;
+                    goto retry_mapping;
+                }
+                auto &mapped = cache_it->second;
+                mapped.last_active_ns.store(steadyNowNs(),
+                                            std::memory_order_relaxed);
+                mapped.in_flight.fetch_add(1, std::memory_order_relaxed);
+                auto shm_addr = mapped.shm_addr;
                 remap_lock_.unlockShared();
+                mapping_base_addr = entry.addr;
                 dest_addr = dest_addr - entry.addr + ((uint64_t)shm_addr);
                 return 0;
             }
             remap_lock_.unlockShared();
-            RWSpinlock::WriteGuard lock_guard(remap_lock_);
-            if (!remap_entries_.count(std::make_pair(target_id, entry.addr))) {
-                std::vector<unsigned char> output_buffer;
-                deserializeBinaryData(entry.shm_name, output_buffer);
-                if (output_buffer.size() == sizeof(cudaIpcMemHandle_t)) {
-                    cudaIpcMemHandle_t handle;
-                    memcpy(&handle, output_buffer.data(), sizeof(handle));
-                    void *shm_addr = nullptr;
-                    cudaError_t err = cudaIpcOpenMemHandle(
-                        &shm_addr, handle, cudaIpcMemLazyEnablePeerAccess);
-                    if (err != cudaSuccess) {
-                        LOG(ERROR) << "IntraNodeNvlinkTransport: "
-                                      "cudaIpcOpenMemHandle failed: "
-                                   << cudaGetErrorString(err);
+            std::shared_ptr<ReleaseState> release_state;
+            bool releasing_entry = false;
+            {
+                RWSpinlock::WriteGuard lock_guard(remap_lock_);
+                auto existing = remap_entries_.find(key);
+                if (existing != remap_entries_.end() &&
+                    existing->second.releasing) {
+                    releasing_entry = true;
+                    release_state = existing->second.release_state;
+                } else if (existing == remap_entries_.end()) {
+                    std::vector<unsigned char> output_buffer;
+                    deserializeBinaryData(entry.shm_name, output_buffer);
+                    if (output_buffer.size() == sizeof(cudaIpcMemHandle_t)) {
+                        cudaIpcMemHandle_t handle;
+                        memcpy(&handle, output_buffer.data(), sizeof(handle));
+                        void *shm_addr = nullptr;
+                        cudaError_t err = cudaIpcOpenMemHandle(
+                            &shm_addr, handle, cudaIpcMemLazyEnablePeerAccess);
+                        if (err != cudaSuccess) {
+                            LOG(ERROR) << "IntraNodeNvlinkTransport: "
+                                          "cudaIpcOpenMemHandle failed: "
+                                       << cudaGetErrorString(err);
+                            return -1;
+                        }
+                        OpenedShmEntry shm_entry;
+                        shm_entry.shm_addr = shm_addr;
+                        shm_entry.length = entry.length;
+                        shm_entry.target_id = target_id;
+                        shm_entry.mapping_base_addr = entry.addr;
+                        shm_entry.mapped = true;
+                        err = cudaGetDevice(&shm_entry.device_id);
+                        if (err != cudaSuccess) {
+                            LOG(ERROR)
+                                << "IntraNodeNvlinkTransport: cudaGetDevice "
+                                   "failed after cudaIpcOpenMemHandle: "
+                                << cudaGetErrorString(err);
+                            cudaError_t close_error =
+                                cudaIpcCloseMemHandle(shm_addr);
+                            if (close_error != cudaSuccess) {
+                                LOG(ERROR)
+                                    << "IntraNodeNvlinkTransport: cleanup "
+                                       "after cudaGetDevice failure also "
+                                       "failed: "
+                                    << cudaGetErrorString(close_error);
+                            }
+                            return -1;
+                        }
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
+                        CUresult context_result =
+                            cuCtxGetCurrent(&shm_entry.import_context);
+                        if (context_result != CUDA_SUCCESS ||
+                            !shm_entry.import_context) {
+                            LOG(ERROR) << "IntraNodeNvlinkTransport: "
+                                          "cuCtxGetCurrent failed after "
+                                          "cudaIpcOpenMemHandle: "
+                                       << context_result;
+                            cudaError_t close_error =
+                                cudaIpcCloseMemHandle(shm_addr);
+                            if (close_error != cudaSuccess) {
+                                LOG(ERROR)
+                                    << "IntraNodeNvlinkTransport: cleanup "
+                                       "after cuCtxGetCurrent failure also "
+                                       "failed: "
+                                    << cudaGetErrorString(close_error);
+                            }
+                            return -1;
+                        }
+#endif
+                        remap_entries_[key] = shm_entry;
+                    } else {
+                        LOG(ERROR) << "Mismatched NVLink data transfer method";
                         return -1;
                     }
-                    OpenedShmEntry shm_entry;
-                    shm_entry.shm_addr = shm_addr;
-                    shm_entry.length = entry.length;
-                    remap_entries_[std::make_pair(target_id, entry.addr)] =
-                        shm_entry;
-                } else {
-                    LOG(ERROR) << "Mismatched NVLink data transfer method";
-                    return -1;
+                }
+                if (!releasing_entry) {
+                    auto &mapped = remap_entries_[key];
+                    mapped.last_active_ns.store(steadyNowNs(),
+                                                std::memory_order_relaxed);
+                    mapped.in_flight.fetch_add(1, std::memory_order_relaxed);
+                    auto shm_addr = mapped.shm_addr;
+                    mapping_base_addr = entry.addr;
+                    dest_addr = dest_addr - entry.addr + ((uint64_t)shm_addr);
+                    return 0;
                 }
             }
-            auto shm_addr =
-                remap_entries_[std::make_pair(target_id, entry.addr)].shm_addr;
-            dest_addr = dest_addr - entry.addr + ((uint64_t)shm_addr);
-            return 0;
+            if (!release_state) {
+                std::this_thread::yield();
+                goto retry_mapping;
+            }
+            std::unique_lock<std::mutex> lock(release_state->mutex);
+            release_state->cv.wait(lock, [&] { return release_state->done; });
+            if (release_state->failed) return -1;
+            goto retry_mapping;
         }
         index++;
     }

--- a/mooncake-transfer-engine/src/transport/nvlink_transport/nvlink_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/nvlink_transport/nvlink_transport.cpp
@@ -20,10 +20,16 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cerrno>
+#include <chrono>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <iomanip>
+#include <limits>
 #include <memory>
+#include <thread>
 #include <vector>
 
 #include "common.h"
@@ -33,7 +39,7 @@
 #include "transfer_metadata.h"
 #include "transport/transport.h"
 
-static bool checkCudaErrorReturn(cudaError_t result, const char *message) {
+static bool checkCudaErrorReturn(cudaError_t result, const char* message) {
     if (result != cudaSuccess) {
         LOG(ERROR) << message << " (Error code: " << result << " - "
                    << cudaGetErrorString(result) << ")" << std::endl;
@@ -84,7 +90,7 @@ class PerDeviceStreamPool {
                   std::to_string(prop.pciBusID) + ":" +
                   std::to_string(prop.pciDeviceID);
         }
-        const char *visible = getenv("CUDA_VISIBLE_DEVICES");
+        const char* visible = getenv("CUDA_VISIBLE_DEVICES");
         LOG(INFO) << "NvlinkTransport: NVLink CUDA stream created on device "
                   << device_id << " [physical: " << pci
                   << "] CUDA_VISIBLE_DEVICES="
@@ -95,7 +101,7 @@ class PerDeviceStreamPool {
     ~PerDeviceStreamPool() {
         int saved_device = 0;
         cudaGetDevice(&saved_device);
-        for (auto &kv : pool_) {
+        for (auto& kv : pool_) {
             cudaSetDevice(kv.first);
             if (kv.second.stream) cudaStreamDestroy(kv.second.stream);
         }
@@ -136,7 +142,7 @@ class PerDeviceEventPool {
     ~PerDeviceEventPool() {
         int saved_device = 0;
         cudaGetDevice(&saved_device);
-        for (auto &kv : pool_) {
+        for (auto& kv : pool_) {
             cudaSetDevice(kv.first);
             if (kv.second) cudaEventDestroy(kv.second);
         }
@@ -155,7 +161,7 @@ static cudaEvent_t getCallerSyncEvent() {
     return tl_device_event_pool.getOrCreate(current_device);
 }
 
-static int getDeviceForPointer(const void *ptr) {
+static int getDeviceForPointer(const void* ptr) {
     cudaPointerAttributes attr;
     if (cudaPointerGetAttributes(&attr, ptr) != cudaSuccess) {
         cudaGetLastError();
@@ -164,7 +170,7 @@ static int getDeviceForPointer(const void *ptr) {
     return (attr.type == cudaMemoryTypeDevice) ? attr.device : -1;
 }
 
-static CudaStreamEntry getStreamForRequest(const void *source) {
+static CudaStreamEntry getStreamForRequest(const void* source) {
     int device_id = getDeviceForPointer(source);
     if (device_id < 0) {
         cudaGetDevice(&device_id);
@@ -173,9 +179,180 @@ static CudaStreamEntry getStreamForRequest(const void *source) {
     return tl_device_stream_pool.getOrCreate(device_id);
 }
 
+static double readDurationEnv(const char* name, double default_value,
+                              bool allow_nonpositive) {
+    const char* raw = std::getenv(name);
+    if (!raw || !*raw) return default_value;
+
+    errno = 0;
+    char* end = nullptr;
+    double value = std::strtod(raw, &end);
+    constexpr double kMinDurationSeconds = 1e-9;
+    constexpr double kMaxDurationSeconds =
+        static_cast<double>(std::numeric_limits<int64_t>::max()) / 1e9;
+    bool valid =
+        errno != ERANGE && end != raw && *end == '\0' && std::isfinite(value) &&
+        std::abs(value) <= kMaxDurationSeconds &&
+        (allow_nonpositive ? (value <= 0 || value >= kMinDurationSeconds)
+                           : value >= kMinDurationSeconds);
+    if (!valid) {
+        LOG(WARNING) << "NvlinkTransport: ignoring invalid " << name << "='"
+                     << raw << "'; using " << default_value;
+        return default_value;
+    }
+    return value;
+}
+
 }  // anonymous namespace
 
 using Slice = Transport::Slice;
+
+namespace {
+
+struct BatchCompletion {
+    cudaEvent_t event = nullptr;
+    int device_id = -1;
+    std::atomic<uint64_t> remaining_slices{0};
+    std::atomic_bool reusable{true};
+};
+
+class CompletionEventPool {
+   public:
+    cudaError_t acquire(int device_id, cudaEvent_t* event) {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            auto& events = events_[device_id];
+            if (!events.empty()) {
+                *event = events.back();
+                events.pop_back();
+                return cudaSuccess;
+            }
+        }
+        return cudaEventCreateWithFlags(event, cudaEventDisableTiming);
+    }
+
+    void recycle(int device_id, cudaEvent_t event) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        events_[device_id].push_back(event);
+    }
+
+    ~CompletionEventPool() {
+        int previous_device = -1;
+        cudaGetDevice(&previous_device);
+        for (auto& device_events : events_) {
+            cudaSetDevice(device_events.first);
+            for (auto event : device_events.second) cudaEventDestroy(event);
+        }
+        if (previous_device >= 0) cudaSetDevice(previous_device);
+    }
+
+   private:
+    std::mutex mutex_;
+    std::unordered_map<int, std::vector<cudaEvent_t>> events_;
+};
+
+static CompletionEventPool completion_event_pool;
+
+class AggressiveWriteGuard {
+   public:
+    explicit AggressiveWriteGuard(RWSpinlock& lock) : lock_(lock) {
+        lock_.writeLockAggressive();
+    }
+    ~AggressiveWriteGuard() { lock_.unlock(); }
+
+    AggressiveWriteGuard(const AggressiveWriteGuard&) = delete;
+    AggressiveWriteGuard& operator=(const AggressiveWriteGuard&) = delete;
+
+   private:
+    RWSpinlock& lock_;
+};
+
+enum class CompletionAttachResult {
+    kAttached,
+    kCompletedSynchronously,
+    kUnsafeFailure,
+};
+
+static CompletionAttachResult attachBatchCompletion(
+    const std::vector<Slice*>& slices, cudaStream_t stream, int device_id) {
+    uint64_t posted_count = 0;
+    for (auto* slice : slices) {
+        if (slice->status == Slice::POSTED) ++posted_count;
+    }
+    if (posted_count == 0) return CompletionAttachResult::kAttached;
+
+    auto* completion = new BatchCompletion;
+    completion->device_id = device_id;
+    completion->remaining_slices.store(posted_count, std::memory_order_relaxed);
+
+    int previous_device = -1;
+    cudaError_t setup_error = cudaGetDevice(&previous_device);
+    if (setup_error == cudaSuccess) setup_error = cudaSetDevice(device_id);
+    if (setup_error == cudaSuccess) {
+        setup_error =
+            completion_event_pool.acquire(device_id, &completion->event);
+    }
+    if (setup_error == cudaSuccess) {
+        setup_error = cudaEventRecord(completion->event, stream);
+    }
+
+    if (setup_error == cudaSuccess) {
+        for (auto* slice : slices) {
+            if (slice->status == Slice::POSTED) {
+                slice->local.cuda_completion = completion;
+            }
+        }
+        cudaError_t restore_error = cudaSetDevice(previous_device);
+        if (restore_error != cudaSuccess) {
+            LOG(ERROR) << "NvlinkTransport: failed to restore device "
+                       << previous_device
+                       << " after recording batch completion: "
+                       << cudaGetErrorString(restore_error);
+        }
+        return CompletionAttachResult::kAttached;
+    }
+
+    LOG(ERROR) << "NvlinkTransport: failed to record batch completion event: "
+               << cudaGetErrorString(setup_error);
+    cudaError_t sync_error = cudaStreamSynchronize(stream);
+    bool quiescent = sync_error == cudaSuccess;
+    if (!quiescent) {
+        LOG(ERROR) << "NvlinkTransport: cannot establish stream quiescence "
+                      "after completion-event failure: "
+                   << cudaGetErrorString(sync_error);
+    }
+    if (completion->event) cudaEventDestroy(completion->event);
+    if (previous_device >= 0) cudaSetDevice(previous_device);
+    delete completion;
+
+    return quiescent ? CompletionAttachResult::kCompletedSynchronously
+                     : CompletionAttachResult::kUnsafeFailure;
+}
+
+static void releaseBatchCompletion(BatchCompletion* completion) {
+    if (!completion || completion->remaining_slices.fetch_sub(
+                           1, std::memory_order_acq_rel) != 1) {
+        return;
+    }
+
+    int previous_device = -1;
+    cudaError_t error = cudaGetDevice(&previous_device);
+    if (error == cudaSuccess) error = cudaSetDevice(completion->device_id);
+    if (error == cudaSuccess && completion->reusable.load()) {
+        completion_event_pool.recycle(completion->device_id, completion->event);
+    } else if (error == cudaSuccess) {
+        error = cudaEventDestroy(completion->event);
+    }
+    if (error != cudaSuccess) {
+        LOG(ERROR) << "NvlinkTransport: failed to destroy batch completion "
+                      "event: "
+                   << cudaGetErrorString(error);
+    }
+    if (previous_device >= 0) cudaSetDevice(previous_device);
+    delete completion;
+}
+
+}  // anonymous namespace
 
 /// Submit batched memcpy operations using cudaMemcpyBatchAsync when available
 /// (CUDA 12.8+), falling back to per-slice cudaMemcpyAsync otherwise.
@@ -184,13 +361,15 @@ using Slice = Transport::Slice;
 /// insert the necessary memory barriers for P2P access, causing segfaults.
 /// The caller must also establish GPU-level stream synchronization
 /// (via cudaEventRecord + cudaStreamWaitEvent) before calling this function.
-/// Individual slice errors are tracked so that slices whose memcpy failed
-/// are marked as FAILED while successfully submitted ones are POSTED.
-static void submitBatchMemcpy(const std::vector<Slice *> &slices,
-                              const std::vector<void *> &srcs,
-                              const std::vector<void *> &dsts,
-                              const std::vector<size_t> &sizes,
-                              cudaStream_t stream) {
+/// Individual slice errors are returned through handle_failure while
+/// successfully submitted ones are marked POSTED.
+template <typename FailureHandler>
+static void submitBatchMemcpy(const std::vector<Slice*>& slices,
+                              const std::vector<void*>& srcs,
+                              const std::vector<void*>& dsts,
+                              const std::vector<size_t>& sizes,
+                              cudaStream_t stream,
+                              FailureHandler&& handle_failure) {
     if (slices.empty()) return;
 
     const size_t count = slices.size();
@@ -228,29 +407,38 @@ static void submitBatchMemcpy(const std::vector<Slice *> &slices,
 #endif
 
 #if CUDART_VERSION >= 13000
-    err = cudaMemcpyBatchAsync(const_cast<const void **>(dsts.data()),
-                               const_cast<const void **>(srcs.data()),
+    err = cudaMemcpyBatchAsync(const_cast<const void**>(dsts.data()),
+                               const_cast<const void**>(srcs.data()),
                                mutable_sizes.data(), static_cast<size_t>(count),
                                &attr, &attrs_idx, 1, stream);
     if (err != cudaSuccess) {
         LOG(ERROR) << "NvlinkTransport: cudaMemcpyBatchAsync "
                    << "failed: " << cudaGetErrorString(err);
-        // CUDA >= 13.0 does not return fail_idx; conservatively mark all
-        // as FAILED since we cannot determine which copies succeeded.
+        // CUDA >= 13.0 does not return fail_idx. Synchronize once to determine
+        // whether it is safe for the caller to release mapping references for
+        // the slices that must all be reported as failed.
+        cudaError_t sync_error = cudaStreamSynchronize(stream);
+        bool failed_slices_quiescent = sync_error == cudaSuccess;
+        if (!failed_slices_quiescent) {
+            LOG(ERROR) << "NvlinkTransport: cannot establish stream "
+                          "quiescence after batch submission failure: "
+                       << cudaGetErrorString(sync_error);
+        }
         for (size_t i = 0; i < count; ++i) {
             if (slices[i]->status == Slice::PENDING) {
-                slices[i]->markFailed();
+                handle_failure(slices[i], failed_slices_quiescent);
             }
         }
+        return;
     } else {
         for (size_t i = 0; i < count; ++i) {
             slices[i]->status = Slice::POSTED;
-            slices[i]->local.cuda_stream = (void *)stream;
+            slices[i]->local.cuda_stream = (void*)stream;
         }
     }
 #elif CUDART_VERSION >= 12080
-    err = cudaMemcpyBatchAsync(const_cast<void **>(dsts.data()),
-                               const_cast<void **>(srcs.data()),
+    err = cudaMemcpyBatchAsync(const_cast<void**>(dsts.data()),
+                               const_cast<void**>(srcs.data()),
                                mutable_sizes.data(), static_cast<size_t>(count),
                                &attr, &attrs_idx, 1, &fail_idx, stream);
     if (err != cudaSuccess) {
@@ -270,17 +458,17 @@ static void submitBatchMemcpy(const std::vector<Slice *> &slices,
         // Copies (fail_idx, count) were never submitted → FAILED.
         for (size_t i = 0; i < fail_idx; ++i) {
             slices[i]->status = Slice::POSTED;
-            slices[i]->local.cuda_stream = (void *)stream;
+            slices[i]->local.cuda_stream = (void*)stream;
         }
         for (size_t i = fail_idx; i < count; ++i) {
             if (slices[i]->status == Slice::PENDING) {
-                slices[i]->markFailed();
+                handle_failure(slices[i], true);
             }
         }
     } else {
         for (size_t i = 0; i < count; ++i) {
             slices[i]->status = Slice::POSTED;
-            slices[i]->local.cuda_stream = (void *)stream;
+            slices[i]->local.cuda_stream = (void*)stream;
         }
     }
 #else
@@ -292,11 +480,11 @@ static void submitBatchMemcpy(const std::vector<Slice *> &slices,
             LOG(ERROR) << "NvlinkTransport: cudaMemcpyAsync failed at "
                        << "index " << i << ": "
                        << cudaGetErrorString(single_err);
-            slices[i]->markFailed();
+            handle_failure(slices[i], true);
             continue;
         }
         slices[i]->status = Slice::POSTED;
-        slices[i]->local.cuda_stream = (void *)stream;
+        slices[i]->local.cuda_stream = (void*)stream;
     }
     return;  // Slice states already set above
 #endif
@@ -392,7 +580,22 @@ static bool enableP2PAccess(int src_device_id, int dst_device_id) {
     return true;
 }
 
-NvlinkTransport::NvlinkTransport() : use_fabric_mem_(supportFabricMem()) {}
+NvlinkTransport::NvlinkTransport() : use_fabric_mem_(supportFabricMem()) {
+    import_ttl_s_ = readDurationEnv("MC_NVLINK_IMPORT_TTL", 120.0, true);
+    evict_interval_s_ =
+        readDurationEnv("MC_NVLINK_EVICT_INTERVAL", 30.0, false);
+
+    running_.store(true);
+    if (use_fabric_mem_ && import_ttl_s_ > 0) {
+        evict_thread_ = std::thread(&NvlinkTransport::evictLoop, this);
+        LOG(INFO) << "NvlinkTransport: idle-import evictor on (ttl "
+                  << import_ttl_s_ << "s, scan " << evict_interval_s_ << "s)";
+    } else if (use_fabric_mem_) {
+        LOG(INFO) << "NvlinkTransport: idle-import evictor OFF (ttl "
+                  << import_ttl_s_
+                  << " <= 0); imported fabric segments held until process exit";
+    }
+}
 //     int num_devices = getNumDevices();
 //     if (globalConfig().trace) {
 //         LOG(INFO) << "NvlinkTransport: use_fabric_mem_:" << use_fabric_mem_
@@ -420,20 +623,277 @@ NvlinkTransport::NvlinkTransport() : use_fabric_mem_(supportFabricMem()) {}
 //     }
 // }
 
-NvlinkTransport::~NvlinkTransport() {
-    if (use_fabric_mem_) {
-        for (auto &entry : remap_entries_) {
-            freePinnedLocalMemory(entry.second.shm_addr);
-        }
-    } else {
-        for (auto &entry : remap_entries_) {
-            cudaIpcCloseMemHandle(entry.second.shm_addr);
-        }
+bool NvlinkTransport::releaseImportedEntry(OpenedShmEntry& entry) {
+    if (entry.in_flight.load(std::memory_order_relaxed) != 0) {
+        LOG(WARNING) << "NvlinkTransport: refusing to release an imported "
+                        "mapping with in-flight transfers";
+        return false;
     }
-    remap_entries_.clear();
+
+    if (!use_fabric_mem_) {
+        if (!entry.mapped) return true;
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
+        if (!entry.import_context) {
+            LOG(ERROR)
+                << "NvlinkTransport: imported IPC mapping has no CUDA context";
+            return false;
+        }
+        CUcontext previous_context = nullptr;
+        CUresult result = cuCtxGetCurrent(&previous_context);
+        if (result == CUDA_SUCCESS) {
+            result = cuCtxSetCurrent(entry.import_context);
+        }
+        if (result != CUDA_SUCCESS) {
+            LOG(ERROR) << "NvlinkTransport: failed to activate IPC import "
+                          "context during release: "
+                       << result;
+            return false;
+        }
+        cudaError_t error = cudaIpcCloseMemHandle(entry.shm_addr);
+        if (error == cudaSuccess) entry.mapped = false;
+        result = cuCtxSetCurrent(previous_context);
+        if (result != CUDA_SUCCESS) {
+            LOG(ERROR) << "NvlinkTransport: failed to restore CUDA context "
+                          "after IPC release: "
+                       << result;
+        }
+        if (error != cudaSuccess) {
+            LOG(ERROR) << "NvlinkTransport: cudaIpcCloseMemHandle failed "
+                          "during release: "
+                       << cudaGetErrorString(error);
+            return false;
+        }
+        return true;
+#else
+        int previous_device = -1;
+        cudaError_t error = cudaGetDevice(&previous_device);
+        if (error != cudaSuccess || entry.device_id < 0) {
+            LOG(ERROR) << "NvlinkTransport: cannot select the import device "
+                          "before cudaIpcCloseMemHandle";
+            return false;
+        }
+        error = cudaSetDevice(entry.device_id);
+        if (error != cudaSuccess) {
+            LOG(ERROR) << "NvlinkTransport: cudaSetDevice(" << entry.device_id
+                       << ") failed before cudaIpcCloseMemHandle: "
+                       << cudaGetErrorString(error);
+            return false;
+        }
+        error = cudaIpcCloseMemHandle(entry.shm_addr);
+        cudaError_t restore_error = cudaSetDevice(previous_device);
+        if (restore_error != cudaSuccess) {
+            LOG(ERROR) << "NvlinkTransport: cudaSetDevice(" << previous_device
+                       << ") failed after cudaIpcCloseMemHandle: "
+                       << cudaGetErrorString(restore_error);
+        }
+        if (error != cudaSuccess) {
+            LOG(ERROR) << "NvlinkTransport: cudaIpcCloseMemHandle failed "
+                          "during release: "
+                       << cudaGetErrorString(error);
+            return false;
+        }
+        entry.mapped = false;
+        return true;
+#endif
+    }
+
+    bool complete = false;
+    CUresult result;
+    if (entry.mapped) {
+        result = cuMemUnmap((CUdeviceptr)entry.shm_addr, entry.length);
+        if (result != CUDA_SUCCESS) {
+            LOG(ERROR) << "NvlinkTransport: cuMemUnmap failed during release: "
+                       << result;
+            return false;
+        }
+        entry.mapped = false;
+    }
+    if (entry.handle_valid) {
+        result = cuMemRelease(entry.import_handle);
+        if (result != CUDA_SUCCESS) {
+            LOG(ERROR) << "NvlinkTransport: cuMemRelease(import_handle) failed "
+                          "during release: "
+                       << result;
+            return false;
+        }
+        entry.handle_valid = false;
+    }
+    if (entry.address_reserved) {
+        result = cuMemAddressFree((CUdeviceptr)entry.shm_addr, entry.length);
+        if (result != CUDA_SUCCESS) {
+            LOG(ERROR)
+                << "NvlinkTransport: cuMemAddressFree failed during release: "
+                << result;
+            return false;
+        }
+        entry.address_reserved = false;
+    }
+    complete = true;
+    return complete;
 }
 
-int NvlinkTransport::install(std::string &local_server_name,
+NvlinkTransport::~NvlinkTransport() {
+    {
+        std::lock_guard<std::mutex> lock(evict_cv_mutex_);
+        running_.store(false);
+    }
+    evict_cv_.notify_all();
+    if (evict_thread_.joinable()) evict_thread_.join();
+
+    {
+        RWSpinlock::WriteGuard lock_guard(remap_lock_);
+        for (auto& entry : remap_entries_) {
+            if (!entry.second.releasing) {
+                entry.second.releasing = true;
+                entry.second.release_state = std::make_shared<ReleaseState>();
+                pending_releases_.push_back(entry.second);
+            }
+        }
+    }
+    retryPendingReleases();
+    size_t pending_count = 0;
+    {
+        RWSpinlock::ReadGuard lock_guard(remap_lock_);
+        pending_count = pending_releases_.size();
+    }
+    if (pending_count != 0) {
+        LOG(ERROR) << "NvlinkTransport: " << pending_count
+                   << " imported mapping(s) remain after teardown";
+    }
+}
+
+static inline int64_t steadyNowNs() {
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(
+               std::chrono::steady_clock::now().time_since_epoch())
+        .count();
+}
+
+void NvlinkTransport::releaseMappingRef(uint64_t target_id,
+                                        uint64_t mapping_base_addr) {
+    RWSpinlock::ReadGuard lock_guard(remap_lock_);
+    auto it = remap_entries_.find({target_id, mapping_base_addr});
+    if (it == remap_entries_.end()) {
+        LOG(ERROR) << "NvlinkTransport: mapping reference not found for target "
+                   << target_id << ", base " << (void*)mapping_base_addr;
+        return;
+    }
+
+    auto& entry = it->second;
+    uint64_t previous = entry.in_flight.load(std::memory_order_relaxed);
+    while (previous != 0 &&
+           !entry.in_flight.compare_exchange_weak(previous, previous - 1,
+                                                  std::memory_order_relaxed)) {
+    }
+    if (previous == 0) {
+        LOG(ERROR) << "NvlinkTransport: mapping reference underflow for target "
+                   << target_id << ", base " << (void*)mapping_base_addr;
+    } else if (previous == 1) {
+        entry.last_active_ns.store(steadyNowNs(), std::memory_order_relaxed);
+    }
+}
+
+void NvlinkTransport::releaseSliceMappingRef(Slice* slice) {
+    if (!slice || !use_fabric_mem_ || slice->target_id == LOCAL_SEGMENT_ID) {
+        return;
+    }
+    releaseMappingRef(slice->target_id, slice->local.mapping_base_addr);
+}
+
+int NvlinkTransport::retryPendingReleases() {
+    std::vector<OpenedShmEntry> retry_entries;
+    {
+        AggressiveWriteGuard lock_guard(remap_lock_);
+        retry_entries.swap(pending_releases_);
+    }
+
+    int released = 0;
+    for (auto& entry : retry_entries) {
+        bool previous_attempt_done = false;
+        if (entry.release_state) {
+            std::lock_guard<std::mutex> lock(entry.release_state->mutex);
+            previous_attempt_done = entry.release_state->done;
+        }
+        if (!entry.release_state || previous_attempt_done) {
+            entry.release_state = std::make_shared<ReleaseState>();
+            AggressiveWriteGuard lock_guard(remap_lock_);
+            auto it =
+                remap_entries_.find({entry.target_id, entry.mapping_base_addr});
+            if (it != remap_entries_.end() && it->second.releasing) {
+                it->second.release_state = entry.release_state;
+            }
+        }
+        bool success = releaseImportedEntry(entry);
+        {
+            AggressiveWriteGuard lock_guard(remap_lock_);
+            auto key = std::make_pair(entry.target_id, entry.mapping_base_addr);
+            if (success) {
+                remap_entries_.erase(key);
+            } else {
+                auto it = remap_entries_.find(key);
+                if (it != remap_entries_.end()) it->second = entry;
+                pending_releases_.push_back(entry);
+            }
+        }
+        {
+            std::lock_guard<std::mutex> lock(entry.release_state->mutex);
+            entry.release_state->failed = !success;
+            entry.release_state->done = true;
+        }
+        entry.release_state->cv.notify_all();
+        if (success) {
+            ++released;
+        }
+    }
+    return released;
+}
+
+int NvlinkTransport::evictIdleSegments(double ttl_s) {
+    if (ttl_s <= 0) return 0;
+
+    const int64_t now_ns = steadyNowNs();
+    const int64_t ttl_ns = static_cast<int64_t>(ttl_s * 1e9);
+    {
+        AggressiveWriteGuard lock_guard(remap_lock_);
+        for (auto it = remap_entries_.begin(); it != remap_entries_.end();) {
+            int64_t last_active =
+                it->second.last_active_ns.load(std::memory_order_relaxed);
+            bool idle =
+                it->second.in_flight.load(std::memory_order_relaxed) == 0 &&
+                !it->second.releasing && last_active != 0 &&
+                now_ns - last_active > ttl_ns;
+            if (idle) {
+                it->second.releasing = true;
+                it->second.release_state = std::make_shared<ReleaseState>();
+                pending_releases_.push_back(it->second);
+            }
+            ++it;
+        }
+    }
+
+    return retryPendingReleases();
+}
+
+void NvlinkTransport::evictLoop() {
+    while (running_.load()) {
+        {
+            std::unique_lock<std::mutex> lock(evict_cv_mutex_);
+            evict_cv_.wait_for(lock,
+                               std::chrono::duration<double>(evict_interval_s_),
+                               [this] { return !running_.load(); });
+        }
+        if (!running_.load()) break;
+
+        int released = evictIdleSegments(import_ttl_s_);
+        if (released > 0) {
+            LOG(INFO) << "NvlinkTransport: released " << released
+                      << " idle imported segment(s) (idle > " << import_ttl_s_
+                      << "s)";
+        }
+    }
+}
+
+int NvlinkTransport::install(std::string& local_server_name,
                              std::shared_ptr<TransferMetadata> metadata,
                              std::shared_ptr<Topology> topology) {
     metadata_ = metadata;
@@ -449,8 +909,8 @@ int NvlinkTransport::install(std::string &local_server_name,
 }
 
 Status NvlinkTransport::submitTransfer(
-    BatchID batch_id, const std::vector<TransferRequest> &entries) {
-    auto &batch_desc = *((BatchDesc *)(batch_id));
+    BatchID batch_id, const std::vector<TransferRequest>& entries) {
+    auto& batch_desc = *((BatchDesc*)(batch_id));
     if (batch_desc.task_list.size() + entries.size() > batch_desc.batch_size) {
         LOG(ERROR)
             << "NvlinkTransport: Exceed the limitation of current batch's "
@@ -491,23 +951,33 @@ Status NvlinkTransport::submitTransfer(
     }
 
     // Phase 1: Prepare slices and collect memcpy parameters
-    std::vector<void *> dsts, srcs;
+    std::vector<void*> dsts, srcs;
     std::vector<size_t> sizes;
-    std::vector<Slice *> slices;
+    std::vector<Slice*> slices;
 
-    for (auto &request : entries) {
-        TransferTask &task = batch_desc.task_list[task_id];
+    for (auto& request : entries) {
+        TransferTask& task = batch_desc.task_list[task_id];
         ++task_id;
         uint64_t dest_addr = request.target_offset;
+        uint64_t mapping_base_addr = 0;
         if (request.target_id != LOCAL_SEGMENT_ID) {
             int rc = relocateSharedMemoryAddress(dest_addr, request.length,
-                                                 request.target_id);
-            if (rc) return Status::Memory("device memory not registered");
+                                                 request.target_id,
+                                                 mapping_base_addr);
+            if (rc) {
+                for (auto* prepared_slice : slices) {
+                    releaseSliceMappingRef(prepared_slice);
+                }
+                return Status::Memory("device memory not registered");
+            }
         }
         task.total_bytes = request.length;
-        Slice *slice = getSliceCache().allocate();
-        slice->source_addr = (char *)request.source;
-        slice->local.dest_addr = (char *)dest_addr;
+        Slice* slice = getSliceCache().allocate();
+        slice->source_addr = (char*)request.source;
+        slice->local.dest_addr = (char*)dest_addr;
+        slice->local.cuda_completion = nullptr;
+        slice->local.mapping_base_addr = mapping_base_addr;
+        slice->local.cuda_device_id = stream_entry.device_id;
         slice->length = request.length;
         slice->opcode = request.opcode;
         slice->task = &task;
@@ -517,12 +987,12 @@ Status NvlinkTransport::submitTransfer(
         task.slice_list.push_back(slice);
         __sync_fetch_and_add(&task.slice_count, 1);
 
-        void *src = (request.opcode == TransferRequest::READ)
-                        ? (void *)slice->local.dest_addr
-                        : (void *)slice->source_addr;
-        void *dst = (request.opcode == TransferRequest::READ)
+        void* src = (request.opcode == TransferRequest::READ)
+                        ? (void*)slice->local.dest_addr
+                        : (void*)slice->source_addr;
+        void* dst = (request.opcode == TransferRequest::READ)
                         ? slice->source_addr
-                        : (void *)slice->local.dest_addr;
+                        : (void*)slice->local.dest_addr;
         srcs.push_back(src);
         dsts.push_back(dst);
         sizes.push_back(slice->length);
@@ -530,63 +1000,190 @@ Status NvlinkTransport::submitTransfer(
     }
 
     // Phase 2: Submit all memcpy operations
-    submitBatchMemcpy(slices, srcs, dsts, sizes, stream);
+    std::vector<Slice*> refs_to_release;
+    std::vector<std::pair<Slice*, bool>> terminal_slices;
+    submitBatchMemcpy(slices, srcs, dsts, sizes, stream,
+                      [&](Slice* slice, bool quiescent) {
+                          if (quiescent) refs_to_release.push_back(slice);
+                          terminal_slices.push_back({slice, false});
+                      });
+    CompletionAttachResult completion_result =
+        attachBatchCompletion(slices, stream, stream_entry.device_id);
+    if (completion_result == CompletionAttachResult::kCompletedSynchronously) {
+        for (auto* slice : slices) {
+            if (slice->status == Slice::POSTED) {
+                refs_to_release.push_back(slice);
+                terminal_slices.push_back({slice, true});
+            }
+        }
+    } else if (completion_result == CompletionAttachResult::kUnsafeFailure) {
+        for (auto* slice : slices) {
+            if (slice->status == Slice::POSTED) {
+                terminal_slices.push_back({slice, false});
+            }
+        }
+    }
+    for (auto* slice : refs_to_release) releaseSliceMappingRef(slice);
+    for (const auto& terminal : terminal_slices) {
+        if (terminal.second)
+            terminal.first->markSuccess();
+        else
+            terminal.first->markFailed();
+    }
 
     return Status::OK();
 }
 
 Status NvlinkTransport::getTransferStatus(BatchID batch_id, size_t task_id,
-                                          TransferStatus &status) {
-    auto &batch_desc = *((BatchDesc *)(batch_id));
+                                          TransferStatus& status) {
+    auto& batch_desc = *((BatchDesc*)(batch_id));
     const size_t task_count = batch_desc.task_list.size();
     if (task_id >= task_count) {
         return Status::InvalidArgument(
             "NvlinkTransport::getTransportStatus invalid argument, batch id: " +
             std::to_string(batch_id));
     }
-    auto &task = batch_desc.task_list[task_id];
-    // Poll POSTED slices for async completion via cudaStreamQuery.
-    // Cache the query result per stream to avoid redundant driver calls.
-    // With SGLang-side torch.cuda.device(gpu_id), the calling thread's
-    // active device matches the stream's device, so no device switching
-    // is needed.
-    std::unordered_map<cudaStream_t, cudaError_t> stream_status_cache;
-    for (auto *slice : task.slice_list) {
-        if (slice && slice->status == Slice::POSTED) {
-            cudaStream_t stream = (cudaStream_t)slice->local.cuda_stream;
-            auto it = stream_status_cache.find(stream);
-            cudaError_t cuda_err;
-            if (it == stream_status_cache.end()) {
-                cuda_err = cudaStreamQuery(stream);
-                stream_status_cache[stream] = cuda_err;
-            } else {
-                cuda_err = it->second;
+    auto& task = batch_desc.task_list[task_id];
+    // Poll the completion event recorded after this submission. Unlike querying
+    // the shared per-device stream, this lets an earlier batch complete even
+    // while newer batches remain queued on that stream.
+    struct EventStatus {
+        cudaError_t query_result;
+        bool quiescent;
+    };
+    std::unordered_map<BatchCompletion*, EventStatus> event_status_cache;
+    std::vector<std::pair<Slice*, bool>> terminal_slices;
+    for (auto* slice : task.slice_list) {
+        if (slice && __atomic_load_n(&slice->status, __ATOMIC_ACQUIRE) ==
+                         Slice::POSTED) {
+            Slice::SliceStatus expected = Slice::POSTED;
+            if (!__atomic_compare_exchange_n(
+                    &slice->status, &expected, Slice::PENDING, false,
+                    __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)) {
+                continue;
             }
-            if (cuda_err == cudaSuccess) {
-                slice->markSuccess();
-            } else if (cuda_err != cudaErrorNotReady) {
-                slice->markFailed();
+            auto* completion =
+                static_cast<BatchCompletion*>(slice->local.cuda_completion);
+            if (!completion) {
+                LOG(ERROR) << "NvlinkTransport: POSTED slice has no completion "
+                              "event";
+                __atomic_store_n(&slice->status, Slice::POSTED,
+                                 __ATOMIC_RELEASE);
+                continue;
+            }
+            auto it = event_status_cache.find(completion);
+            EventStatus event_status;
+            if (it == event_status_cache.end()) {
+                int previous_device = -1;
+                cudaError_t cuda_err = cudaGetDevice(&previous_device);
+                if (cuda_err != cudaSuccess ||
+                    cudaSetDevice(completion->device_id) != cudaSuccess) {
+                    LOG(ERROR) << "NvlinkTransport: cannot activate device "
+                               << completion->device_id
+                               << " to query the batch completion event";
+                    __atomic_store_n(&slice->status, Slice::POSTED,
+                                     __ATOMIC_RELEASE);
+                    continue;
+                }
+                event_status.query_result = cudaEventQuery(completion->event);
+                event_status.quiescent =
+                    event_status.query_result == cudaSuccess;
+                if (event_status.query_result != cudaSuccess &&
+                    event_status.query_result != cudaErrorNotReady) {
+                    completion->reusable.store(false,
+                                               std::memory_order_relaxed);
+                    cudaError_t sync_error =
+                        cudaEventSynchronize(completion->event);
+                    event_status.quiescent = sync_error == cudaSuccess;
+                    if (sync_error != cudaSuccess) {
+                        LOG(ERROR) << "NvlinkTransport: failed to establish "
+                                      "batch quiescence after event query "
+                                      "error: "
+                                   << cudaGetErrorString(sync_error);
+                    }
+                }
+                cudaError_t restore_error = cudaSetDevice(previous_device);
+                if (restore_error != cudaSuccess) {
+                    LOG(ERROR) << "NvlinkTransport: failed to restore device "
+                               << previous_device
+                               << " after querying the completion event: "
+                               << cudaGetErrorString(restore_error);
+                }
+                event_status_cache[completion] = event_status;
+            } else {
+                event_status = it->second;
+            }
+            cudaError_t cuda_err = event_status.query_result;
+            if (cuda_err != cudaSuccess && cuda_err != cudaErrorNotReady) {
+                LOG(ERROR) << "NvlinkTransport: cudaEventQuery failed on "
+                              "device "
+                           << completion->device_id << ": "
+                           << cudaGetErrorString(cuda_err);
+            }
+            if (cuda_err != cudaErrorNotReady) {
+                if (cuda_err == cudaSuccess) {
+                    releaseSliceMappingRef(slice);
+                    terminal_slices.push_back({slice, true});
+                } else {
+                    if (event_status.quiescent) {
+                        releaseSliceMappingRef(slice);
+                    }
+                    // If synchronization also failed, keep the mapping pinned:
+                    // the DMA state is unknown and teardown will refuse to
+                    // unmap it while the reference remains outstanding.
+                    terminal_slices.push_back({slice, false});
+                }
+                releaseBatchCompletion(completion);
+            } else {
+                __atomic_store_n(&slice->status, Slice::POSTED,
+                                 __ATOMIC_RELEASE);
             }
         }
     }
-    status.transferred_bytes = task.transferred_bytes;
     uint64_t success_slice_count = task.success_slice_count;
     uint64_t failed_slice_count = task.failed_slice_count;
+    uint64_t transferred_bytes = task.transferred_bytes;
+    for (const auto& terminal : terminal_slices) {
+        if (terminal.second) {
+            ++success_slice_count;
+            transferred_bytes += terminal.first->length;
+        } else {
+            ++failed_slice_count;
+        }
+    }
+    status.transferred_bytes = transferred_bytes;
     if (success_slice_count + failed_slice_count == task.slice_count) {
         if (failed_slice_count) {
             status.s = TransferStatusEnum::FAILED;
         } else {
             status.s = TransferStatusEnum::COMPLETED;
         }
-        task.is_finished = true;
     } else {
         status.s = TransferStatusEnum::WAITING;
     }
+#ifndef USE_EVENT_DRIVEN_COMPLETION
+    for (const auto& terminal : terminal_slices) {
+        if (terminal.second)
+            terminal.first->markSuccess();
+        else
+            terminal.first->markFailed();
+    }
+    if (success_slice_count + failed_slice_count == task.slice_count) {
+        task.is_finished = true;
+    }
+#else
+    for (const auto& terminal : terminal_slices) {
+        if (terminal.second)
+            terminal.first->markSuccess();
+        else
+            terminal.first->markFailed();
+    }
+#endif
     return Status::OK();
 }
 
 Status NvlinkTransport::submitTransferTask(
-    const std::vector<TransferTask *> &task_list) {
+    const std::vector<TransferTask*>& task_list) {
     // Get per-device transfer stream. See submitTransfer() for rationale.
     CudaStreamEntry stream_entry = getStreamForRequest(
         task_list.empty() ? nullptr : task_list[0]->request->source);
@@ -610,25 +1207,35 @@ Status NvlinkTransport::submitTransferTask(
     }
 
     // Phase 1: Prepare slices and collect memcpy parameters
-    std::vector<void *> dsts, srcs;
+    std::vector<void*> dsts, srcs;
     std::vector<size_t> sizes;
-    std::vector<Slice *> slices;
+    std::vector<Slice*> slices;
 
     for (size_t index = 0; index < task_list.size(); ++index) {
         assert(task_list[index]);
-        auto &task = *task_list[index];
+        auto& task = *task_list[index];
         assert(task.request);
-        auto &request = *task.request;
+        auto& request = *task.request;
         uint64_t dest_addr = request.target_offset;
+        uint64_t mapping_base_addr = 0;
         if (request.target_id != LOCAL_SEGMENT_ID) {
             int rc = relocateSharedMemoryAddress(dest_addr, request.length,
-                                                 request.target_id);
-            if (rc) return Status::Memory("device memory not registered");
+                                                 request.target_id,
+                                                 mapping_base_addr);
+            if (rc) {
+                for (auto* prepared_slice : slices) {
+                    releaseSliceMappingRef(prepared_slice);
+                }
+                return Status::Memory("device memory not registered");
+            }
         }
         task.total_bytes = request.length;
-        Slice *slice = getSliceCache().allocate();
-        slice->source_addr = (char *)request.source;
-        slice->local.dest_addr = (char *)dest_addr;
+        Slice* slice = getSliceCache().allocate();
+        slice->source_addr = (char*)request.source;
+        slice->local.dest_addr = (char*)dest_addr;
+        slice->local.cuda_completion = nullptr;
+        slice->local.mapping_base_addr = mapping_base_addr;
+        slice->local.cuda_device_id = stream_entry.device_id;
         slice->length = request.length;
         slice->opcode = request.opcode;
         slice->task = &task;
@@ -638,12 +1245,12 @@ Status NvlinkTransport::submitTransferTask(
         task.slice_list.push_back(slice);
         __sync_fetch_and_add(&task.slice_count, 1);
 
-        void *src = (request.opcode == TransferRequest::READ)
-                        ? (void *)slice->local.dest_addr
-                        : (void *)slice->source_addr;
-        void *dst = (request.opcode == TransferRequest::READ)
+        void* src = (request.opcode == TransferRequest::READ)
+                        ? (void*)slice->local.dest_addr
+                        : (void*)slice->source_addr;
+        void* dst = (request.opcode == TransferRequest::READ)
                         ? slice->source_addr
-                        : (void *)slice->local.dest_addr;
+                        : (void*)slice->local.dest_addr;
         srcs.push_back(src);
         dsts.push_back(dst);
         sizes.push_back(slice->length);
@@ -651,13 +1258,42 @@ Status NvlinkTransport::submitTransferTask(
     }
 
     // Phase 2: Submit all memcpy operations
-    submitBatchMemcpy(slices, srcs, dsts, sizes, stream);
+    std::vector<Slice*> refs_to_release;
+    std::vector<std::pair<Slice*, bool>> terminal_slices;
+    submitBatchMemcpy(slices, srcs, dsts, sizes, stream,
+                      [&](Slice* slice, bool quiescent) {
+                          if (quiescent) refs_to_release.push_back(slice);
+                          terminal_slices.push_back({slice, false});
+                      });
+    CompletionAttachResult completion_result =
+        attachBatchCompletion(slices, stream, stream_entry.device_id);
+    if (completion_result == CompletionAttachResult::kCompletedSynchronously) {
+        for (auto* slice : slices) {
+            if (slice->status == Slice::POSTED) {
+                refs_to_release.push_back(slice);
+                terminal_slices.push_back({slice, true});
+            }
+        }
+    } else if (completion_result == CompletionAttachResult::kUnsafeFailure) {
+        for (auto* slice : slices) {
+            if (slice->status == Slice::POSTED) {
+                terminal_slices.push_back({slice, false});
+            }
+        }
+    }
+    for (auto* slice : refs_to_release) releaseSliceMappingRef(slice);
+    for (const auto& terminal : terminal_slices) {
+        if (terminal.second)
+            terminal.first->markSuccess();
+        else
+            terminal.first->markFailed();
+    }
 
     return Status::OK();
 }
 
-int NvlinkTransport::registerLocalMemory(void *addr, size_t length,
-                                         const std::string &location,
+int NvlinkTransport::registerLocalMemory(void* addr, size_t length,
+                                         const std::string& location,
                                          bool remote_accessible,
                                          bool update_metadata) {
     std::lock_guard<std::mutex> lock(register_mutex_);
@@ -704,9 +1340,9 @@ int NvlinkTransport::registerLocalMemory(void *addr, size_t length,
         }
 
         // Find whole physical page for memory registration
-        void *real_addr;
+        void* real_addr;
         size_t real_size;
-        result = cuMemGetAddressRange((CUdeviceptr *)&real_addr, &real_size,
+        result = cuMemGetAddressRange((CUdeviceptr*)&real_addr, &real_size,
                                       (CUdeviceptr)addr);
         if (result != CUDA_SUCCESS) {
             LOG(WARNING) << "NvlinkTransport: cuMemGetAddressRange failed: "
@@ -737,138 +1373,263 @@ int NvlinkTransport::registerLocalMemory(void *addr, size_t length,
     }
 }
 
-int NvlinkTransport::unregisterLocalMemory(void *addr, bool update_metadata) {
+int NvlinkTransport::unregisterLocalMemory(void* addr, bool update_metadata) {
     return metadata_->removeLocalMemoryBuffer(addr, update_metadata);
 }
 
-int NvlinkTransport::relocateSharedMemoryAddress(uint64_t &dest_addr,
+int NvlinkTransport::relocateSharedMemoryAddress(uint64_t& dest_addr,
                                                  uint64_t length,
-                                                 uint64_t target_id) {
+                                                 uint64_t target_id,
+                                                 uint64_t& mapping_base_addr) {
     auto desc = metadata_->getSegmentDescByID(target_id);
     int index = 0;
-    for (auto &entry : desc->buffers) {
+    for (auto& entry : desc->buffers) {
         if (!entry.shm_name.empty() && entry.addr <= dest_addr &&
             dest_addr + length <= entry.addr + entry.length) {
+        retry_mapping:
             remap_lock_.lockShared();
-            if (remap_entries_.count(std::make_pair(target_id, entry.addr))) {
-                auto shm_addr =
-                    remap_entries_[std::make_pair(target_id, entry.addr)]
-                        .shm_addr;
+            auto key = std::make_pair(target_id, entry.addr);
+            auto cache_it = remap_entries_.find(key);
+            if (cache_it != remap_entries_.end()) {
+                if (cache_it->second.releasing) {
+                    auto release_state = cache_it->second.release_state;
+                    remap_lock_.unlockShared();
+                    if (!release_state) {
+                        std::this_thread::yield();
+                        goto retry_mapping;
+                    }
+                    std::unique_lock<std::mutex> lock(release_state->mutex);
+                    release_state->cv.wait(lock,
+                                           [&] { return release_state->done; });
+                    if (release_state->failed) return -1;
+                    goto retry_mapping;
+                }
+                auto& mapped = cache_it->second;
+                mapped.last_active_ns.store(steadyNowNs(),
+                                            std::memory_order_relaxed);
+                if (use_fabric_mem_) {
+                    mapped.in_flight.fetch_add(1, std::memory_order_relaxed);
+                }
+                auto shm_addr = mapped.shm_addr;
                 remap_lock_.unlockShared();
+                mapping_base_addr = entry.addr;
                 dest_addr = dest_addr - entry.addr + ((uint64_t)shm_addr);
                 return 0;
             }
             remap_lock_.unlockShared();
-            RWSpinlock::WriteGuard lock_guard(remap_lock_);
-            if (!remap_entries_.count(std::make_pair(target_id, entry.addr))) {
-                std::vector<unsigned char> output_buffer;
-                deserializeBinaryData(entry.shm_name, output_buffer);
-                if (output_buffer.size() == sizeof(cudaIpcMemHandle_t) &&
-                    !use_fabric_mem_) {
-                    cudaIpcMemHandle_t handle;
-                    memcpy(&handle, output_buffer.data(), sizeof(handle));
-                    void *shm_addr = nullptr;
-                    cudaError_t err = cudaIpcOpenMemHandle(
-                        &shm_addr, handle, cudaIpcMemLazyEnablePeerAccess);
-                    if (err != cudaSuccess) {
-                        LOG(ERROR)
-                            << "NvlinkTransport: cudaIpcOpenMemHandle failed: "
-                            << cudaGetErrorString(err);
-                        return -1;
-                    }
-                    OpenedShmEntry shm_entry;
-                    shm_entry.shm_addr = shm_addr;
-                    shm_entry.length = entry.length;
-                    remap_entries_[std::make_pair(target_id, entry.addr)] =
-                        shm_entry;
-                } else if (output_buffer.size() == sizeof(CUmemFabricHandle) &&
-                           use_fabric_mem_) {
-                    CUmemFabricHandle export_handle;
-                    memcpy(&export_handle, output_buffer.data(),
-                           sizeof(export_handle));
-                    void *shm_addr = nullptr;
-                    CUmemGenericAllocationHandle handle;
-                    auto result = cuMemImportFromShareableHandle(
-                        &handle, &export_handle, CU_MEM_HANDLE_TYPE_FABRIC);
-                    if (result != CUDA_SUCCESS) {
-                        LOG(ERROR) << "NvlinkTransport: "
-                                      "cuMemImportFromShareableHandle failed: "
-                                   << result;
-                        return -1;
-                    }
-                    result = cuMemAddressReserve((CUdeviceptr *)&shm_addr,
-                                                 entry.length, 0, 0, 0);
-                    if (result != CUDA_SUCCESS) {
-                        LOG(ERROR)
-                            << "NvlinkTransport: cuMemAddressReserve failed: "
-                            << result;
-                        return -1;
-                    }
-                    result = cuMemMap((CUdeviceptr)shm_addr, entry.length, 0,
-                                      handle, 0);
-                    if (result != CUDA_SUCCESS) {
-                        LOG(ERROR)
-                            << "NvlinkTransport: cuMemMap failed: " << result;
-                        return -1;
-                    }
+            std::shared_ptr<ReleaseState> release_state;
+            bool releasing_entry = false;
+            {
+                RWSpinlock::WriteGuard lock_guard(remap_lock_);
+                auto existing = remap_entries_.find(key);
+                if (existing != remap_entries_.end() &&
+                    existing->second.releasing) {
+                    releasing_entry = true;
+                    release_state = existing->second.release_state;
+                }
+                auto queue_failed_release = [&](OpenedShmEntry& failed_entry) {
+                    failed_entry.releasing = true;
+                    failed_entry.release_state =
+                        std::make_shared<ReleaseState>();
+                    failed_entry.release_state->done = true;
+                    failed_entry.release_state->failed = true;
+                    remap_entries_[key] = failed_entry;
+                    pending_releases_.push_back(failed_entry);
+                };
+                if (!releasing_entry && existing == remap_entries_.end()) {
+                    std::vector<unsigned char> output_buffer;
+                    deserializeBinaryData(entry.shm_name, output_buffer);
+                    if (output_buffer.size() == sizeof(cudaIpcMemHandle_t) &&
+                        !use_fabric_mem_) {
+                        cudaIpcMemHandle_t handle;
+                        memcpy(&handle, output_buffer.data(), sizeof(handle));
+                        void* shm_addr = nullptr;
+                        cudaError_t err = cudaIpcOpenMemHandle(
+                            &shm_addr, handle, cudaIpcMemLazyEnablePeerAccess);
+                        if (err != cudaSuccess) {
+                            LOG(ERROR) << "NvlinkTransport: "
+                                          "cudaIpcOpenMemHandle failed: "
+                                       << cudaGetErrorString(err);
+                            return -1;
+                        }
+                        OpenedShmEntry shm_entry;
+                        shm_entry.shm_addr = shm_addr;
+                        shm_entry.length = entry.length;
+                        shm_entry.target_id = target_id;
+                        shm_entry.mapping_base_addr = entry.addr;
+                        shm_entry.mapped = true;
+                        err = cudaGetDevice(&shm_entry.device_id);
+                        if (err != cudaSuccess) {
+                            LOG(ERROR)
+                                << "NvlinkTransport: cudaGetDevice failed "
+                                   "after cudaIpcOpenMemHandle: "
+                                << cudaGetErrorString(err);
+                            cudaError_t close_error =
+                                cudaIpcCloseMemHandle(shm_addr);
+                            if (close_error != cudaSuccess) {
+                                LOG(ERROR)
+                                    << "NvlinkTransport: cleanup after "
+                                       "cudaGetDevice failure also failed: "
+                                    << cudaGetErrorString(close_error);
+                            }
+                            return -1;
+                        }
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
+                        CUresult context_result =
+                            cuCtxGetCurrent(&shm_entry.import_context);
+                        if (context_result != CUDA_SUCCESS ||
+                            !shm_entry.import_context) {
+                            LOG(ERROR) << "NvlinkTransport: cuCtxGetCurrent "
+                                          "failed after "
+                                          "cudaIpcOpenMemHandle: "
+                                       << context_result;
+                            cudaError_t close_error =
+                                cudaIpcCloseMemHandle(shm_addr);
+                            if (close_error != cudaSuccess) {
+                                LOG(ERROR) << "NvlinkTransport: cleanup after "
+                                              "cuCtxGetCurrent failure also "
+                                              "failed: "
+                                           << cudaGetErrorString(close_error);
+                            }
+                            return -1;
+                        }
+#endif
+                        remap_entries_[key] = shm_entry;
+                    } else if (output_buffer.size() ==
+                                   sizeof(CUmemFabricHandle) &&
+                               use_fabric_mem_) {
+                        CUmemFabricHandle export_handle;
+                        memcpy(&export_handle, output_buffer.data(),
+                               sizeof(export_handle));
+                        OpenedShmEntry shm_entry;
+                        shm_entry.length = entry.length;
+                        shm_entry.target_id = target_id;
+                        shm_entry.mapping_base_addr = entry.addr;
+                        auto result = cuMemImportFromShareableHandle(
+                            &shm_entry.import_handle, &export_handle,
+                            CU_MEM_HANDLE_TYPE_FABRIC);
+                        if (result != CUDA_SUCCESS) {
+                            LOG(ERROR)
+                                << "NvlinkTransport: "
+                                   "cuMemImportFromShareableHandle failed: "
+                                << result;
+                            return -1;
+                        }
+                        shm_entry.handle_valid = true;
+                        result = cuMemAddressReserve(
+                            (CUdeviceptr*)&shm_entry.shm_addr, entry.length, 0,
+                            0, 0);
+                        if (result != CUDA_SUCCESS) {
+                            LOG(ERROR) << "NvlinkTransport: "
+                                          "cuMemAddressReserve failed: "
+                                       << result;
+                            if (!releaseImportedEntry(shm_entry)) {
+                                queue_failed_release(shm_entry);
+                            }
+                            return -1;
+                        }
+                        shm_entry.address_reserved = true;
+                        result = cuMemMap((CUdeviceptr)shm_entry.shm_addr,
+                                          entry.length, 0,
+                                          shm_entry.import_handle, 0);
+                        if (result != CUDA_SUCCESS) {
+                            LOG(ERROR) << "NvlinkTransport: cuMemMap failed: "
+                                       << result;
+                            if (!releaseImportedEntry(shm_entry)) {
+                                queue_failed_release(shm_entry);
+                            }
+                            return -1;
+                        }
+                        shm_entry.mapped = true;
 
-                    int device_count;
-                    cudaGetDeviceCount(&device_count);
-                    CUmemAccessDesc accessDesc[device_count];
-                    for (int device_id = 0; device_id < device_count;
-                         ++device_id) {
-                        accessDesc[device_id].location.type =
-                            CU_MEM_LOCATION_TYPE_DEVICE;
-                        accessDesc[device_id].location.id = device_id;
-                        accessDesc[device_id].flags =
-                            CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
-                    }
-                    result = cuMemSetAccess((CUdeviceptr)shm_addr, entry.length,
-                                            accessDesc, device_count);
-                    if (result != CUDA_SUCCESS) {
-                        LOG(ERROR) << "NvlinkTransport: cuMemSetAccess failed: "
-                                   << result;
+                        int device_count = 0;
+                        cudaError_t count_error =
+                            cudaGetDeviceCount(&device_count);
+                        if (count_error != cudaSuccess || device_count <= 0) {
+                            LOG(ERROR)
+                                << "NvlinkTransport: cudaGetDeviceCount failed "
+                                   "while importing fabric memory: "
+                                << cudaGetErrorString(count_error);
+                            if (!releaseImportedEntry(shm_entry)) {
+                                queue_failed_release(shm_entry);
+                            }
+                            return -1;
+                        }
+                        std::vector<CUmemAccessDesc> access_desc(device_count);
+                        for (int device_id = 0; device_id < device_count;
+                             ++device_id) {
+                            access_desc[device_id].location.type =
+                                CU_MEM_LOCATION_TYPE_DEVICE;
+                            access_desc[device_id].location.id = device_id;
+                            access_desc[device_id].flags =
+                                CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+                        }
+                        result = cuMemSetAccess(
+                            (CUdeviceptr)shm_entry.shm_addr, entry.length,
+                            access_desc.data(), access_desc.size());
+                        if (result != CUDA_SUCCESS) {
+                            LOG(ERROR)
+                                << "NvlinkTransport: cuMemSetAccess failed: "
+                                << result;
+                            if (!releaseImportedEntry(shm_entry)) {
+                                queue_failed_release(shm_entry);
+                            }
+                            return -1;
+                        }
+                        remap_entries_[key] = shm_entry;
+                    } else {
+                        LOG(ERROR) << "Mismatched NVLink data transfer method";
                         return -1;
                     }
-                    OpenedShmEntry shm_entry;
-                    shm_entry.shm_addr = shm_addr;
-                    shm_entry.length = entry.length;
-                    remap_entries_[std::make_pair(target_id, entry.addr)] =
-                        shm_entry;
-                } else {
-                    LOG(ERROR) << "Mismatched NVLink data transfer method";
-                    return -1;
+                }
+                if (!releasing_entry) {
+                    auto& mapped = remap_entries_[key];
+                    mapped.last_active_ns.store(steadyNowNs(),
+                                                std::memory_order_relaxed);
+                    if (use_fabric_mem_) {
+                        mapped.in_flight.fetch_add(1,
+                                                   std::memory_order_relaxed);
+                    }
+                    auto shm_addr = mapped.shm_addr;
+                    mapping_base_addr = entry.addr;
+                    dest_addr = dest_addr - entry.addr + ((uint64_t)shm_addr);
+                    return 0;
                 }
             }
-            auto shm_addr =
-                remap_entries_[std::make_pair(target_id, entry.addr)].shm_addr;
-            dest_addr = dest_addr - entry.addr + ((uint64_t)shm_addr);
-            return 0;
+            if (!release_state) {
+                std::this_thread::yield();
+                goto retry_mapping;
+            }
+            std::unique_lock<std::mutex> lock(release_state->mutex);
+            release_state->cv.wait(lock, [&] { return release_state->done; });
+            if (release_state->failed) return -1;
+            goto retry_mapping;
         }
         index++;
     }
-    LOG(ERROR) << "Requested address " << (void *)dest_addr << " to "
-               << (void *)(dest_addr + length) << " not found!";
+    LOG(ERROR) << "Requested address " << (void*)dest_addr << " to "
+               << (void*)(dest_addr + length) << " not found!";
     return ERR_INVALID_ARGUMENT;
 }
 
 int NvlinkTransport::registerLocalMemoryBatch(
-    const std::vector<Transport::BufferEntry> &buffer_list,
-    const std::string &location) {
-    for (auto &buffer : buffer_list)
+    const std::vector<Transport::BufferEntry>& buffer_list,
+    const std::string& location) {
+    for (auto& buffer : buffer_list)
         registerLocalMemory(buffer.addr, buffer.length, location, true, false);
     return metadata_->updateLocalSegmentDesc();
 }
 
 int NvlinkTransport::unregisterLocalMemoryBatch(
-    const std::vector<void *> &addr_list) {
-    for (auto &addr : addr_list) unregisterLocalMemory(addr, false);
+    const std::vector<void*>& addr_list) {
+    for (auto& addr : addr_list) unregisterLocalMemory(addr, false);
     return metadata_->updateLocalSegmentDesc();
 }
 
-void *NvlinkTransport::allocatePinnedLocalMemory(size_t size) {
+void* NvlinkTransport::allocatePinnedLocalMemory(size_t size) {
     if (!supportFabricMem()) {
-        void *ptr = nullptr;
+        void* ptr = nullptr;
         cudaMalloc(&ptr, size);
         return ptr;
     }
@@ -876,7 +1637,7 @@ void *NvlinkTransport::allocatePinnedLocalMemory(size_t size) {
     CUdevice currentDev;
     CUmemAllocationProp prop = {};
     CUmemGenericAllocationHandle handle;
-    void *ptr = nullptr;
+    void* ptr = nullptr;
     int cudaDev;
     int flag = 0;
     cudaError_t err = cudaGetDevice(&cudaDev);
@@ -918,7 +1679,7 @@ void *NvlinkTransport::allocatePinnedLocalMemory(size_t size) {
         LOG(ERROR) << "NvlinkTransport: cuMemCreate failed: " << result;
         return nullptr;
     }
-    result = cuMemAddressReserve((CUdeviceptr *)&ptr, size, granularity, 0, 0);
+    result = cuMemAddressReserve((CUdeviceptr*)&ptr, size, granularity, 0, 0);
     if (result != CUDA_SUCCESS) {
         LOG(ERROR) << "NvlinkTransport: cuMemAddressReserve failed: " << result;
         cuMemRelease(handle);
@@ -950,7 +1711,7 @@ void *NvlinkTransport::allocatePinnedLocalMemory(size_t size) {
     return ptr;
 }
 
-void NvlinkTransport::freePinnedLocalMemory(void *ptr) {
+void NvlinkTransport::freePinnedLocalMemory(void* ptr) {
     if (!supportFabricMem()) {
         cudaFree(ptr);
         return;


### PR DESCRIPTION
## Description

Reclaim idle imported NVLink mappings at runtime so stale peer imports do not keep device memory pinned until process exit.

This change covers both Transfer Engine NVLink backends:

- `NvlinkTransport`: imported MNNVL fabric/VMM mappings.
- `IntraNodeNvlinkTransport`: imported CUDA IPC mappings used by `MC_INTRANODE_NVLINK`.

Each imported mapping tracks its last activity and in-flight DMA count. A background evictor marks every mapping that has no in-flight transfer and has exceeded the configured TTL; there is no fixed per-scan release limit. Writer-preferred acquisition prevents the eviction scan from being starved by continuous readers, while CUDA teardown runs outside the remap spinlock.

Async completion is tracked with a pooled, per-submission CUDA event instead of querying the tail of the shared per-device stream. This lets an earlier submission release its mapping references even while later work remains queued. Mapping references are claimed and released exactly once; error paths release them only after stream/event synchronization proves DMA quiescence. If quiescence cannot be established, the mapping remains pinned rather than risking an unmap during DMA.

Physical release uses a per-mapping tombstone so the same key cannot be re-imported while `cudaIpcCloseMemHandle` or VMM cleanup is in progress. Fabric cleanup is staged as `cuMemUnmap -> cuMemRelease -> cuMemAddressFree`; partial failures preserve their state and retry on the next scan. Waiters are notified per mapping as each release finishes, while the evictor continues draining the rest of the queue.

Batch status polling records failures but continues polling every task until all tasks are terminal. This prevents one failed task from leaving later async NVLink tasks unpolled and their mapping references permanently pinned.

Configuration is read when the transport is constructed:

- `MC_NVLINK_IMPORT_TTL`: idle TTL in seconds; default `120`; `<= 0` disables automatic eviction.
- `MC_NVLINK_EVICT_INTERVAL`: scan interval in seconds; default `30`; must be positive.

Invalid, non-finite, or out-of-range values fall back to the defaults. No manual release API is added to TransferEngine, Python bindings, or a control plane.

### Scope and limitations

- The classic `NvlinkTransport` CUDA IPC fallback selected by `MC_USE_NVLINK_IPC` is unchanged; automatic CUDA IPC eviction is implemented in `IntraNodeNvlinkTransport`.
- TENT is not changed.
- In-flight references reach zero through the existing completion-polling contract. An abandoned task that is never polled remains pinned.
- Fatal CUDA errors that cannot prove quiescence intentionally fail closed and may remain pinned until process exit.
- CUDA/MUSA vendor builds and GPU runtime eviction tests require CI or a GPU environment and remain pending.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [x] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
PATH="/Users/jiruixian/Library/Python/3.9/bin:$PATH" ./scripts/code_format.sh --check --base origin/main
git diff --check origin/main...HEAD
```

**Test results:**
- [x] clang-format 20 checks pass for all changed C/C++ files
- [x] Diff whitespace checks pass
- [x] Repeated independent source reviews found no remaining P0/P1/P2 issues
- [ ] CUDA/MUSA build and GPU runtime eviction tests (pending CI / GPU environment)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used

Codex helped rebase the original change onto current `main`, remove the manual API path, adapt lifecycle protection to the current asynchronous NVLink implementation, and run repeated independent source reviews. The submitter remains responsible for the change.
