### PR TITLE
[Store] Complete dynamic tenant quota admin, eviction, metrics, and snapshots

### DIFF
--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -352,6 +352,80 @@ curl -s http://<master_host>:9003/metrics
 curl -s http://<master_host>:9003/metrics/summary
 ```
 
+When tenant quota is enabled, `/metrics` also includes per-tenant quota gauges and quota counters:
+
+- `mooncake_tenant_quota_requested_bytes{tenant_id}`
+- `mooncake_tenant_quota_effective_bytes{tenant_id}`
+- `mooncake_tenant_quota_used_bytes{tenant_id}`
+- `mooncake_tenant_quota_reserved_bytes{tenant_id}`
+- `mooncake_tenant_quota_committed_count{tenant_id}`
+- `mooncake_tenant_quota_over_quota{tenant_id}`
+- `mooncake_tenant_quota_explicit_policy{tenant_id}`
+- `mooncake_tenant_quota_reject_total{tenant_id,reason}`
+- `mooncake_tenant_evict_bytes_total{tenant_id}`
+- `mooncake_tenant_quota_allocatable_capacity_bytes`
+- `mooncake_tenant_quota_requested_bytes_sum`
+- `mooncake_tenant_quota_effective_bytes_sum`
+
+---
+
+## Tenant Quota Management
+
+Tenant quota admission is disabled by default. Enable it on the master when you want memory writes admitted against per-tenant quota:
+
+```bash
+mooncake_master \
+  --enable_tenant_quota=true \
+  --default_tenant_quota_bytes=1073741824 \
+  --tenant_quota_pool_capacity_bytes=0
+```
+
+`tenant_quota_pool_capacity_bytes=0` uses the full registered memory capacity as the quota allocation pool. A nonzero value caps the capacity used to compute effective tenant quotas.
+
+The same HTTP port used for metrics exposes the tenant quota admin API:
+
+```bash
+# List tenant quota snapshots
+curl -s http://<master_host>:9003/api/v1/tenant_quotas
+
+# Query one tenant
+curl -s "http://<master_host>:9003/api/v1/tenant_quotas?tenant_id=tenant-a"
+
+# Upsert an explicit policy. Explicit tenant policies must be positive.
+curl -s -X PUT "http://<master_host>:9003/api/v1/tenant_quotas?tenant_id=tenant-a" \
+  -H 'Content-Type: application/json' \
+  -d '{"requested_quota_bytes":2147483648}'
+
+# Delete an explicit policy so the tenant inherits the default policy again.
+curl -s -X DELETE "http://<master_host>:9003/api/v1/tenant_quotas?tenant_id=tenant-a"
+
+# Query or update the default requested quota. The default may be 0.
+curl -s http://<master_host>:9003/api/v1/tenant_quotas/default
+curl -s -X PUT http://<master_host>:9003/api/v1/tenant_quotas/default \
+  -H 'Content-Type: application/json' \
+  -d '{"requested_quota_bytes":1073741824}'
+```
+
+Each tenant quota snapshot returns:
+
+```json
+{
+  "success": true,
+  "data": {
+    "tenant_id": "tenant-a",
+    "requested_quota_bytes": 2147483648,
+    "effective_quota_bytes": 2147483648,
+    "used_bytes": 0,
+    "reserved_bytes": 0,
+    "committed_count": 0,
+    "over_quota": false,
+    "has_explicit_policy": true
+  }
+}
+```
+
+In HA mode, quota admin requests are served only by the active master service. Standby, candidate, or inactive services return HTTP 503. If tenant quota is disabled, the quota admin API returns HTTP 409 with `UNAVAILABLE_IN_CURRENT_MODE`.
+
 ---
 
 ## Quick Tips
@@ -439,6 +513,14 @@ glog's standard flags (`--log_dir`, `--max_log_size`, `--logtostderr`, ...) cont
 | `--eviction_ratio` | `0.05` | Fraction evicted at high watermark |
 | `--eviction_high_watermark_ratio` | `0.95` | Usage ratio triggering eviction |
 | `--client_ttl` | `10` s | Seconds before a silent client is considered disconnected |
+
+### Tenant Quota
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--enable_tenant_quota` | `false` | Enable per-tenant memory quota admission |
+| `--default_tenant_quota_bytes` | `0` | Default requested quota for tenants without explicit policy; `0` is allowed and inherited-default tenants still share capacity left by explicit tenants |
+| `--tenant_quota_pool_capacity_bytes` | `0` | Capacity used to compute effective tenant quotas; `0` means total registered memory capacity |
 
 ### High Availability
 

--- a/docs/source/design/mooncake-store.md
+++ b/docs/source/design/mooncake-store.md
@@ -91,6 +91,36 @@ To reduce cache warm-up time after a master restart, the Master Service supports
 >
 > The snapshot storage location is **exclusively managed** by the Mooncake snapshot system. Old snapshots are automatically deleted during cleanup. **DO NOT store other files in this location.** Use a dedicated, isolated storage for snapshots.
 
+### Tenant Quota
+
+The Master Service can optionally enforce memory quota admission per tenant. This feature is disabled by default. When `enable_tenant_quota=false`, existing allocation and eviction behavior is preserved, and tenant quota management requests return `UNAVAILABLE_IN_CURRENT_MODE`.
+
+When tenant quota is enabled, each tenant has a requested quota policy and an effective quota. Explicit tenant policies are set through the master admin HTTP API. Tenants without an explicit policy inherit the default requested quota. The default policy may be `0`; explicit tenant policies must be positive.
+
+Effective quota is recomputed from the current registered memory capacity and the optional tenant quota pool cap:
+
+- The allocatable capacity is the smaller of total registered memory and `tenant_quota_pool_capacity_bytes`; a pool cap of `0` means total registered memory.
+- If explicit tenant requests fit within the allocatable capacity, explicit tenants receive their requested quotas and the remaining capacity is split evenly among active inherited-default tenants.
+- If explicit tenant requests exceed the allocatable capacity, only explicit tenants receive quota, scaled proportionally by request size. Inherited-default tenants receive `0` effective quota until capacity is available.
+- Remainders are assigned deterministically by tenant ID, so repeated recomputes produce stable results.
+
+`PutStart` and size-changing `UpsertStart` charge quota before memory is allocated. If the first reservation fails, the master performs tenant-scoped memory eviction for the target tenant and retries the reservation. The retry is bounded to two eviction attempts. Tenant quota eviction scans only the target tenant, skips hard-pinned objects, honors soft-pin eviction configuration, and preserves grouped-object lease safety checks.
+
+The admin HTTP API exposes:
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/v1/tenant_quotas` | List quota snapshots for active or explicit tenants |
+| `GET` | `/api/v1/tenant_quotas?tenant_id=<tenant>` | Query one tenant quota snapshot |
+| `PUT` | `/api/v1/tenant_quotas?tenant_id=<tenant>` | Upsert an explicit tenant quota policy |
+| `DELETE` | `/api/v1/tenant_quotas?tenant_id=<tenant>` | Delete an explicit tenant quota policy |
+| `GET` | `/api/v1/tenant_quotas/default` | Query the default requested quota policy |
+| `PUT` | `/api/v1/tenant_quotas/default` | Set the default requested quota policy |
+
+Tenant quota snapshots include `tenant_id`, `requested_quota_bytes`, `effective_quota_bytes`, `used_bytes`, `reserved_bytes`, `committed_count`, `over_quota`, and `has_explicit_policy`.
+
+When snapshots are enabled, tenant quota policies are written to a separate `tenant_quota_policy` snapshot object. This file stores only requested policy: the default requested quota and explicit tenant requested quotas. Effective quota, usage, reservations, and committed object charge are rebuilt from restored metadata and current capacity. Older snapshots without `tenant_quota_policy` remain valid and use the configured default quota on restore.
+
 ### Master Service APIs
 
 The protobuf definition between Master and Client is as follows:

--- a/mooncake-store/include/master_admin_service.h
+++ b/mooncake-store/include/master_admin_service.h
@@ -51,6 +51,8 @@ class MasterAdminServer {
 
     std::string BuildMetricsText() const;
 
+    std::string BuildTenantQuotaMetricsText() const;
+
     std::string BuildMetricsSummaryText() const;
 
     std::shared_ptr<WrappedMasterService> GetActiveService() const;

--- a/mooncake-store/include/master_admin_service.h
+++ b/mooncake-store/include/master_admin_service.h
@@ -91,6 +91,16 @@ class MasterAdminServer {
                              coro_http::coro_http_response& resp);
     void HandleBatchQueryKeys(coro_http::coro_http_request& req,
                               coro_http::coro_http_response& resp);
+    void HandleGetTenantQuotas(coro_http::coro_http_request& req,
+                               coro_http::coro_http_response& resp);
+    void HandleUpsertTenantQuota(coro_http::coro_http_request& req,
+                                 coro_http::coro_http_response& resp);
+    void HandleDeleteTenantQuota(coro_http::coro_http_request& req,
+                                 coro_http::coro_http_response& resp);
+    void HandleGetDefaultTenantQuota(coro_http::coro_http_request& req,
+                                     coro_http::coro_http_response& resp);
+    void HandleSetDefaultTenantQuota(coro_http::coro_http_request& req,
+                                     coro_http::coro_http_response& resp);
 
     void RegisterHandler();
 

--- a/mooncake-store/include/master_metric_manager.h
+++ b/mooncake-store/include/master_metric_manager.h
@@ -309,6 +309,11 @@ class MasterMetricManager {
     void inc_promotion_rejected_watermark(int64_t val = 1);
     void inc_promotion_rejected_cap(int64_t val = 1);
 
+    // Tenant quota metrics
+    void inc_tenant_quota_reject(const std::string& tenant_id,
+                                 const std::string& reason, int64_t val = 1);
+    void inc_tenant_evict_bytes(const std::string& tenant_id, int64_t bytes);
+
     // Promotion-on-hit Metrics Getters
     int64_t get_promotion_in_flight();
     int64_t get_promotion_admitted();
@@ -669,6 +674,9 @@ class MasterMetricManager {
     ylt::metric::counter_t promotion_rejected_frequency_;
     ylt::metric::counter_t promotion_rejected_watermark_;
     ylt::metric::counter_t promotion_rejected_cap_;
+
+    ylt::metric::dynamic_counter_2t tenant_quota_reject_total_;
+    ylt::metric::dynamic_counter_1t tenant_evict_bytes_total_;
 
     // Snapshot Metrics
     ylt::metric::histogram_t snapshot_duration_ms_;

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -90,6 +90,17 @@ class MasterService {
         const UUID& segment_id);
     std::optional<TenantQuotaSnapshot> GetTenantQuotaSnapshotForTesting(
         const std::string& tenant_id) const;
+    bool IsTenantQuotaEnabled() const;
+    std::vector<TenantQuotaSnapshot> ListTenantQuotaSnapshots() const;
+    std::optional<TenantQuotaSnapshot> GetTenantQuotaSnapshot(
+        const std::string& tenant_id) const;
+    tl::expected<TenantQuotaSnapshot, ErrorCode> UpsertTenantQuotaPolicy(
+        const std::string& tenant_id, uint64_t requested_quota_bytes);
+    std::optional<TenantQuotaSnapshot> DeleteTenantQuotaPolicy(
+        const std::string& tenant_id);
+    uint64_t GetDefaultTenantQuotaPolicy() const;
+    void SetDefaultTenantQuotaPolicy(uint64_t requested_quota_bytes);
+    uint64_t GetTenantQuotaAllocatableCapacityBytes();
 
     /**
      * @brief Mount a memory segment for buffer allocation. This function is
@@ -783,6 +794,12 @@ class MasterService {
     void BatchEvict(double evict_ratio_target, double evict_ratio_lowerbound);
     void NoFBatchEvict(double evict_ratio_target,
                        double evict_ratio_lowerbound);
+    struct TenantQuotaEvictionResult {
+        uint64_t freed_bytes{0};
+        uint64_t evicted_objects{0};
+    };
+    TenantQuotaEvictionResult EvictTenantMemoryForQuota(
+        const std::string& tenant_id, uint64_t target_bytes);
 
     // Helper to get a snapshot of alive clients (under client_mutex_ shared
     // lock)
@@ -1324,6 +1341,8 @@ class MasterService {
     uint64_t CompletedMemoryQuotaCharge(const ObjectMetadata& metadata) const;
     uint64_t RequestedMemoryQuotaCharge(uint64_t value_length,
                                         const ReplicateConfig& config) const;
+    uint64_t ComputeTenantQuotaDeficit(const std::string& tenant_id,
+                                       uint64_t incoming_quota_charge);
     tl::expected<void, ErrorCode> ReserveTenantQuota(
         const std::string& tenant_id, uint64_t bytes);
     void CommitTenantQuota(const std::string& tenant_id, uint64_t bytes);
@@ -1677,6 +1696,20 @@ class MasterService {
             const msgpack::object& obj);
     };
 
+    class TenantQuotaPolicySerializer {
+       public:
+        TenantQuotaPolicySerializer(MasterService* service)
+            : service_(service) {}
+
+        tl::expected<std::vector<uint8_t>, SerializationError> Serialize();
+        tl::expected<void, SerializationError> Deserialize(
+            const std::vector<uint8_t>& data);
+        void Reset();
+
+       private:
+        MasterService* service_;
+    };
+
     friend class MetadataAccessor;
     class MetadataAccessorRO {
        public:
@@ -1831,8 +1864,13 @@ class MasterService {
     const bool enable_disk_eviction_;
     const uint64_t quota_bytes_;
     const bool enable_tenant_quota_;
-    const uint64_t default_tenant_quota_bytes_;
+    // Startup default used when restoring legacy snapshots without
+    // tenant_quota_policy.
+    const uint64_t configured_default_tenant_quota_bytes_;
+    // Runtime default policy, mutable through the tenant quota admin API.
+    std::atomic<uint64_t> default_tenant_quota_bytes_;
     const uint64_t tenant_quota_pool_capacity_bytes_;
+    mutable std::mutex tenant_quota_recompute_mutex_;
 
     bool use_disk_replica_{false};
 

--- a/mooncake-store/include/rpc_service.h
+++ b/mooncake-store/include/rpc_service.h
@@ -166,6 +166,19 @@ class WrappedMasterService {
 
     tl::expected<std::string, ErrorCode> ServiceReady();
 
+    tl::expected<std::vector<TenantQuotaSnapshot>, ErrorCode>
+    ListTenantQuotaSnapshots();
+    tl::expected<TenantQuotaSnapshot, ErrorCode> GetTenantQuotaSnapshot(
+        const std::string& tenant_id);
+    tl::expected<TenantQuotaSnapshot, ErrorCode> UpsertTenantQuotaPolicy(
+        const std::string& tenant_id, uint64_t requested_quota_bytes);
+    tl::expected<std::optional<TenantQuotaSnapshot>, ErrorCode>
+    DeleteTenantQuotaPolicy(const std::string& tenant_id);
+    tl::expected<uint64_t, ErrorCode> GetDefaultTenantQuotaPolicy();
+    tl::expected<void, ErrorCode> SetDefaultTenantQuotaPolicy(
+        uint64_t requested_quota_bytes);
+    tl::expected<uint64_t, ErrorCode> GetTenantQuotaAllocatableCapacityBytes();
+
     tl::expected<std::vector<std::string>, ErrorCode> GetAllKeysForAdmin();
 
     tl::expected<std::vector<std::string>, ErrorCode> GetAllSegmentsForAdmin();

--- a/mooncake-store/include/tenant_quota.h
+++ b/mooncake-store/include/tenant_quota.h
@@ -31,6 +31,11 @@ struct TenantQuotaSnapshot {
     bool over_quota = false;
 };
 
+struct TenantQuotaAssignment {
+    std::string tenant_id;
+    uint64_t effective_quota_bytes = 0;
+};
+
 enum class TenantQuotaError {
     kQuotaExceeded,
     kInvalidArgument,
@@ -38,6 +43,11 @@ enum class TenantQuotaError {
 };
 
 using TenantQuotaResult = tl::expected<void, TenantQuotaError>;
+
+std::vector<TenantQuotaAssignment> BuildEffectiveQuotaAssignments(
+    const std::map<std::string, TenantQuotaState>& tenants,
+    uint64_t default_requested_quota_bytes,
+    uint64_t allocatable_capacity_bytes);
 
 class TenantQuotaTable {
    public:

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -204,7 +204,8 @@ DEFINE_uint64(
 DEFINE_bool(enable_tenant_quota, false,
             "Enable per-tenant memory quota admission");
 DEFINE_uint64(default_tenant_quota_bytes, 0,
-              "Default per-tenant memory quota in bytes (0 = unlimited)");
+              "Default requested per-tenant memory quota in bytes "
+              "(0 is allowed; inherited tenants share remaining capacity)");
 DEFINE_uint64(tenant_quota_pool_capacity_bytes, 0,
               "Capacity used to compute effective tenant quotas "
               "(0 = mounted memory capacity)");

--- a/mooncake-store/src/master_admin_service.cpp
+++ b/mooncake-store/src/master_admin_service.cpp
@@ -71,7 +71,11 @@ coro_http::status_type ErrorCodeToHttpStatus(ErrorCode error) {
             return coro_http::status_type::bad_request;
         case ErrorCode::JOB_NOT_FOUND:
         case ErrorCode::SEGMENT_NOT_FOUND:
+        case ErrorCode::OBJECT_NOT_FOUND:
             return coro_http::status_type::not_found;
+        case ErrorCode::UNAVAILABLE_IN_CURRENT_MODE:
+        case ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS:
+            return coro_http::status_type::conflict;
         default:
             return coro_http::status_type::internal_server_error;
     }
@@ -141,6 +145,110 @@ std::string EscapeJson(std::string_view input) {
         }
     }
     return escaped;
+}
+
+std::string EscapePrometheusLabel(std::string_view input) {
+    std::string escaped;
+    escaped.reserve(input.size());
+    for (char ch : input) {
+        switch (ch) {
+            case '\\':
+                escaped += "\\\\";
+                break;
+            case '"':
+                escaped += "\\\"";
+                break;
+            case '\n':
+                escaped += "\\n";
+                break;
+            default:
+                escaped.push_back(ch);
+                break;
+        }
+    }
+    return escaped;
+}
+
+struct HttpTenantQuotaSnapshot {
+    std::string tenant_id;
+    uint64_t requested_quota_bytes{0};
+    uint64_t effective_quota_bytes{0};
+    uint64_t used_bytes{0};
+    uint64_t reserved_bytes{0};
+    uint64_t committed_count{0};
+    bool over_quota{false};
+    bool has_explicit_policy{false};
+};
+YLT_REFL(HttpTenantQuotaSnapshot, tenant_id, requested_quota_bytes,
+         effective_quota_bytes, used_bytes, reserved_bytes, committed_count,
+         over_quota, has_explicit_policy);
+
+HttpTenantQuotaSnapshot ToHttpTenantQuotaSnapshot(
+    const TenantQuotaSnapshot& snapshot) {
+    return HttpTenantQuotaSnapshot{
+        .tenant_id = snapshot.tenant_id,
+        .requested_quota_bytes = snapshot.requested_quota_bytes,
+        .effective_quota_bytes = snapshot.effective_quota_bytes,
+        .used_bytes = snapshot.used_bytes,
+        .reserved_bytes = snapshot.reserved_bytes,
+        .committed_count = snapshot.committed_count,
+        .over_quota = snapshot.over_quota,
+        .has_explicit_policy = snapshot.has_explicit_policy,
+    };
+}
+
+struct HttpTenantQuotaListResponse {
+    bool success{true};
+    std::vector<HttpTenantQuotaSnapshot> data;
+};
+YLT_REFL(HttpTenantQuotaListResponse, success, data);
+
+struct HttpTenantQuotaResponse {
+    bool success{true};
+    HttpTenantQuotaSnapshot data;
+};
+YLT_REFL(HttpTenantQuotaResponse, success, data);
+
+struct HttpTenantQuotaDeleteResponse {
+    bool success{true};
+    std::optional<HttpTenantQuotaSnapshot> data;
+};
+YLT_REFL(HttpTenantQuotaDeleteResponse, success, data);
+
+struct HttpTenantQuotaPolicyRequest {
+    uint64_t requested_quota_bytes{0};
+};
+YLT_REFL(HttpTenantQuotaPolicyRequest, requested_quota_bytes);
+
+struct HttpDefaultTenantQuotaResponse {
+    bool success{true};
+    uint64_t requested_quota_bytes{0};
+};
+YLT_REFL(HttpDefaultTenantQuotaResponse, success, requested_quota_bytes);
+
+tl::expected<std::string, ErrorCode> ParseAdminTenantId(
+    coro_http::coro_http_request& req) {
+    auto tenant_id_view = req.get_decode_query_value("tenant_id");
+    if (tenant_id_view.empty()) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+    std::string tenant_id = NormalizeTenantId(std::string(tenant_id_view));
+    if (tenant_id.empty() || tenant_id.front() == '_') {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+    return tenant_id;
+}
+
+tl::expected<HttpTenantQuotaPolicyRequest, std::string> ParseQuotaPolicyBody(
+    coro_http::coro_http_request& req) {
+    HttpTenantQuotaPolicyRequest request;
+    try {
+        struct_json::from_json(request, req.get_body());
+    } catch (const std::exception& e) {
+        return tl::make_unexpected(std::string("Invalid JSON body: ") +
+                                   e.what());
+    }
+    return request;
 }
 
 }  // namespace
@@ -253,9 +361,84 @@ MasterAdminServer::RuntimeSnapshot MasterAdminServer::SnapshotState() const {
 }
 
 std::string MasterAdminServer::BuildMetricsText() const {
-    return AppendMetricSections(
+    std::string metrics = AppendMetricSections(
         MasterMetricManager::instance().serialize_metrics(),
         HAMetricManager::instance().serialize_metrics());
+    auto service = GetActiveService();
+    if (!service) {
+        return metrics;
+    }
+    auto snapshots_result = service->ListTenantQuotaSnapshots();
+    auto capacity_result = service->GetTenantQuotaAllocatableCapacityBytes();
+    if (!snapshots_result || !capacity_result) {
+        return metrics;
+    }
+
+    const auto& snapshots = snapshots_result.value();
+    uint64_t requested_sum = 0;
+    uint64_t effective_sum = 0;
+    std::ostringstream tenant_metrics;
+    tenant_metrics
+        << "# HELP mooncake_tenant_quota_requested_bytes Requested tenant "
+           "quota policy in bytes\n"
+        << "# TYPE mooncake_tenant_quota_requested_bytes gauge\n"
+        << "# HELP mooncake_tenant_quota_effective_bytes Effective tenant "
+           "quota in bytes\n"
+        << "# TYPE mooncake_tenant_quota_effective_bytes gauge\n"
+        << "# HELP mooncake_tenant_quota_used_bytes Tenant committed quota "
+           "usage in bytes\n"
+        << "# TYPE mooncake_tenant_quota_used_bytes gauge\n"
+        << "# HELP mooncake_tenant_quota_reserved_bytes Tenant reserved quota "
+           "usage in bytes\n"
+        << "# TYPE mooncake_tenant_quota_reserved_bytes gauge\n"
+        << "# HELP mooncake_tenant_quota_committed_count Tenant committed "
+           "object count\n"
+        << "# TYPE mooncake_tenant_quota_committed_count gauge\n"
+        << "# HELP mooncake_tenant_quota_over_quota Tenant over-quota flag\n"
+        << "# TYPE mooncake_tenant_quota_over_quota gauge\n"
+        << "# HELP mooncake_tenant_quota_explicit_policy Tenant explicit "
+           "policy flag\n"
+        << "# TYPE mooncake_tenant_quota_explicit_policy gauge\n";
+    for (const auto& snapshot : snapshots) {
+        requested_sum += snapshot.requested_quota_bytes;
+        effective_sum += snapshot.effective_quota_bytes;
+        const auto tenant = EscapePrometheusLabel(snapshot.tenant_id);
+        tenant_metrics << "mooncake_tenant_quota_requested_bytes{tenant_id=\""
+                       << tenant << "\"} " << snapshot.requested_quota_bytes
+                       << "\n";
+        tenant_metrics << "mooncake_tenant_quota_effective_bytes{tenant_id=\""
+                       << tenant << "\"} " << snapshot.effective_quota_bytes
+                       << "\n";
+        tenant_metrics << "mooncake_tenant_quota_used_bytes{tenant_id=\""
+                       << tenant << "\"} " << snapshot.used_bytes << "\n";
+        tenant_metrics << "mooncake_tenant_quota_reserved_bytes{tenant_id=\""
+                       << tenant << "\"} " << snapshot.reserved_bytes << "\n";
+        tenant_metrics << "mooncake_tenant_quota_committed_count{tenant_id=\""
+                       << tenant << "\"} " << snapshot.committed_count << "\n";
+        tenant_metrics << "mooncake_tenant_quota_over_quota{tenant_id=\""
+                       << tenant << "\"} " << (snapshot.over_quota ? 1 : 0)
+                       << "\n";
+        tenant_metrics << "mooncake_tenant_quota_explicit_policy{tenant_id=\""
+                       << tenant << "\"} "
+                       << (snapshot.has_explicit_policy ? 1 : 0) << "\n";
+    }
+    tenant_metrics
+        << "# HELP mooncake_tenant_quota_allocatable_capacity_bytes Global "
+           "tenant quota allocatable capacity in bytes\n"
+        << "# TYPE mooncake_tenant_quota_allocatable_capacity_bytes gauge\n"
+        << "mooncake_tenant_quota_allocatable_capacity_bytes "
+        << capacity_result.value() << "\n"
+        << "# HELP mooncake_tenant_quota_requested_bytes_sum Global requested "
+           "tenant quota sum in bytes\n"
+        << "# TYPE mooncake_tenant_quota_requested_bytes_sum gauge\n"
+        << "mooncake_tenant_quota_requested_bytes_sum " << requested_sum << "\n"
+        << "# HELP mooncake_tenant_quota_effective_bytes_sum Global effective "
+           "tenant quota sum in bytes\n"
+        << "# TYPE mooncake_tenant_quota_effective_bytes_sum gauge\n"
+        << "mooncake_tenant_quota_effective_bytes_sum " << effective_sum
+        << "\n";
+
+    return AppendMetricSections(std::move(metrics), tenant_metrics.str());
 }
 
 std::string MasterAdminServer::BuildMetricsSummaryText() const {
@@ -799,6 +982,147 @@ void MasterAdminServer::HandleBatchQueryKeys(
     WriteJsonResponse(resp, coro_http::status_type::ok, payload);
 }
 
+void MasterAdminServer::HandleGetTenantQuotas(
+    coro_http::coro_http_request& req, coro_http::coro_http_response& resp) {
+    auto tenant_id_view = req.get_decode_query_value("tenant_id");
+    WithActiveService(resp, [&](auto service) {
+        if (tenant_id_view.empty()) {
+            auto result = service->ListTenantQuotaSnapshots();
+            if (!result.has_value()) {
+                WriteErrorResponse(resp, ErrorCodeToHttpStatus(result.error()),
+                                   result.error());
+                return;
+            }
+            HttpTenantQuotaListResponse payload;
+            payload.data.reserve(result->size());
+            for (const auto& snapshot : result.value()) {
+                payload.data.push_back(ToHttpTenantQuotaSnapshot(snapshot));
+            }
+            WriteJsonResponse(resp, coro_http::status_type::ok, payload);
+            return;
+        }
+
+        auto tenant_id_result = ParseAdminTenantId(req);
+        if (!tenant_id_result.has_value()) {
+            WriteErrorResponse(resp, coro_http::status_type::bad_request,
+                               ErrorCode::INVALID_PARAMS, "Invalid tenant_id");
+            return;
+        }
+        auto result = service->GetTenantQuotaSnapshot(tenant_id_result.value());
+        if (!result.has_value()) {
+            WriteErrorResponse(resp, ErrorCodeToHttpStatus(result.error()),
+                               result.error());
+            return;
+        }
+        WriteJsonResponse(
+            resp, coro_http::status_type::ok,
+            HttpTenantQuotaResponse{
+                .data = ToHttpTenantQuotaSnapshot(result.value())});
+    });
+}
+
+void MasterAdminServer::HandleUpsertTenantQuota(
+    coro_http::coro_http_request& req, coro_http::coro_http_response& resp) {
+    auto tenant_id_result = ParseAdminTenantId(req);
+    if (!tenant_id_result.has_value()) {
+        WriteErrorResponse(resp, coro_http::status_type::bad_request,
+                           tenant_id_result.error(),
+                           "Missing or invalid tenant_id");
+        return;
+    }
+    auto body_result = ParseQuotaPolicyBody(req);
+    if (!body_result.has_value()) {
+        WriteErrorResponse(resp, coro_http::status_type::bad_request,
+                           ErrorCode::INVALID_PARAMS, body_result.error());
+        return;
+    }
+    if (body_result->requested_quota_bytes == 0) {
+        WriteErrorResponse(resp, coro_http::status_type::bad_request,
+                           ErrorCode::INVALID_PARAMS,
+                           "Tenant quota must be positive");
+        return;
+    }
+
+    WithActiveService(resp, [&](auto service) {
+        auto result = service->UpsertTenantQuotaPolicy(
+            tenant_id_result.value(), body_result->requested_quota_bytes);
+        if (!result.has_value()) {
+            WriteErrorResponse(resp, ErrorCodeToHttpStatus(result.error()),
+                               result.error());
+            return;
+        }
+        WriteJsonResponse(
+            resp, coro_http::status_type::ok,
+            HttpTenantQuotaResponse{
+                .data = ToHttpTenantQuotaSnapshot(result.value())});
+    });
+}
+
+void MasterAdminServer::HandleDeleteTenantQuota(
+    coro_http::coro_http_request& req, coro_http::coro_http_response& resp) {
+    auto tenant_id_result = ParseAdminTenantId(req);
+    if (!tenant_id_result.has_value()) {
+        WriteErrorResponse(resp, coro_http::status_type::bad_request,
+                           tenant_id_result.error(),
+                           "Missing or invalid tenant_id");
+        return;
+    }
+
+    WithActiveService(resp, [&](auto service) {
+        auto result =
+            service->DeleteTenantQuotaPolicy(tenant_id_result.value());
+        if (!result.has_value()) {
+            WriteErrorResponse(resp, ErrorCodeToHttpStatus(result.error()),
+                               result.error());
+            return;
+        }
+        HttpTenantQuotaDeleteResponse payload;
+        if (result.value().has_value()) {
+            payload.data = ToHttpTenantQuotaSnapshot(result.value().value());
+        }
+        WriteJsonResponse(resp, coro_http::status_type::ok, payload);
+    });
+}
+
+void MasterAdminServer::HandleGetDefaultTenantQuota(
+    coro_http::coro_http_request&, coro_http::coro_http_response& resp) {
+    WithActiveService(resp, [&](auto service) {
+        auto result = service->GetDefaultTenantQuotaPolicy();
+        if (!result.has_value()) {
+            WriteErrorResponse(resp, ErrorCodeToHttpStatus(result.error()),
+                               result.error());
+            return;
+        }
+        WriteJsonResponse(resp, coro_http::status_type::ok,
+                          HttpDefaultTenantQuotaResponse{
+                              .requested_quota_bytes = result.value()});
+    });
+}
+
+void MasterAdminServer::HandleSetDefaultTenantQuota(
+    coro_http::coro_http_request& req, coro_http::coro_http_response& resp) {
+    auto body_result = ParseQuotaPolicyBody(req);
+    if (!body_result.has_value()) {
+        WriteErrorResponse(resp, coro_http::status_type::bad_request,
+                           ErrorCode::INVALID_PARAMS, body_result.error());
+        return;
+    }
+
+    WithActiveService(resp, [&](auto service) {
+        auto result = service->SetDefaultTenantQuotaPolicy(
+            body_result->requested_quota_bytes);
+        if (!result.has_value()) {
+            WriteErrorResponse(resp, ErrorCodeToHttpStatus(result.error()),
+                               result.error());
+            return;
+        }
+        WriteJsonResponse(
+            resp, coro_http::status_type::ok,
+            HttpDefaultTenantQuotaResponse{
+                .requested_quota_bytes = body_result->requested_quota_bytes});
+    });
+}
+
 void MasterAdminServer::RegisterHandler() {
     using namespace coro_http;
 
@@ -871,6 +1195,31 @@ void MasterAdminServer::RegisterHandler() {
         "/api/v1/segments/status",
         [this](coro_http_request& req, coro_http_response& resp) {
             HandleSegmentStatus(req, resp);
+        });
+    http_server_.set_http_handler<GET>(
+        "/api/v1/tenant_quotas",
+        [this](coro_http_request& req, coro_http_response& resp) {
+            HandleGetTenantQuotas(req, resp);
+        });
+    http_server_.set_http_handler<PUT>(
+        "/api/v1/tenant_quotas",
+        [this](coro_http_request& req, coro_http_response& resp) {
+            HandleUpsertTenantQuota(req, resp);
+        });
+    http_server_.set_http_handler<DEL>(
+        "/api/v1/tenant_quotas",
+        [this](coro_http_request& req, coro_http_response& resp) {
+            HandleDeleteTenantQuota(req, resp);
+        });
+    http_server_.set_http_handler<GET>(
+        "/api/v1/tenant_quotas/default",
+        [this](coro_http_request& req, coro_http_response& resp) {
+            HandleGetDefaultTenantQuota(req, resp);
+        });
+    http_server_.set_http_handler<PUT>(
+        "/api/v1/tenant_quotas/default",
+        [this](coro_http_request& req, coro_http_response& resp) {
+            HandleSetDefaultTenantQuota(req, resp);
         });
     http_server_.set_http_handler<GET>(
         "/batch_query_keys",

--- a/mooncake-store/src/master_admin_service.cpp
+++ b/mooncake-store/src/master_admin_service.cpp
@@ -364,14 +364,22 @@ std::string MasterAdminServer::BuildMetricsText() const {
     std::string metrics = AppendMetricSections(
         MasterMetricManager::instance().serialize_metrics(),
         HAMetricManager::instance().serialize_metrics());
+    auto tenant_metrics = BuildTenantQuotaMetricsText();
+    if (tenant_metrics.empty()) {
+        return metrics;
+    }
+    return AppendMetricSections(std::move(metrics), std::move(tenant_metrics));
+}
+
+std::string MasterAdminServer::BuildTenantQuotaMetricsText() const {
     auto service = GetActiveService();
     if (!service) {
-        return metrics;
+        return "";
     }
     auto snapshots_result = service->ListTenantQuotaSnapshots();
     auto capacity_result = service->GetTenantQuotaAllocatableCapacityBytes();
     if (!snapshots_result || !capacity_result) {
-        return metrics;
+        return "";
     }
 
     const auto& snapshots = snapshots_result.value();
@@ -438,7 +446,7 @@ std::string MasterAdminServer::BuildMetricsText() const {
         << "mooncake_tenant_quota_effective_bytes_sum " << effective_sum
         << "\n";
 
-    return AppendMetricSections(std::move(metrics), tenant_metrics.str());
+    return tenant_metrics.str();
 }
 
 std::string MasterAdminServer::BuildMetricsSummaryText() const {

--- a/mooncake-store/src/master_metric_manager.cpp
+++ b/mooncake-store/src/master_metric_manager.cpp
@@ -368,6 +368,13 @@ MasterMetricManager::MasterMetricManager()
           "master_promotion_rejected_cap_total",
           "Promotion attempts rejected because promotion_in_flight was at "
           "promotion_queue_limit"),
+      tenant_quota_reject_total_(
+          "mooncake_tenant_quota_reject_total",
+          "Total number of tenant quota admission rejects",
+          {"tenant_id", "reason"}),
+      tenant_evict_bytes_total_(
+          "mooncake_tenant_evict_bytes_total",
+          "Total bytes evicted by tenant-scoped quota eviction", {"tenant_id"}),
 
       // Snapshot Metrics
       snapshot_duration_ms_(
@@ -1113,6 +1120,17 @@ void MasterMetricManager::inc_promotion_rejected_cap(int64_t val) {
     promotion_rejected_cap_.inc(val);
 }
 
+void MasterMetricManager::inc_tenant_quota_reject(const std::string& tenant_id,
+                                                  const std::string& reason,
+                                                  int64_t val) {
+    tenant_quota_reject_total_.inc({tenant_id, reason}, val);
+}
+
+void MasterMetricManager::inc_tenant_evict_bytes(const std::string& tenant_id,
+                                                 int64_t bytes) {
+    tenant_evict_bytes_total_.inc({tenant_id}, bytes);
+}
+
 void MasterMetricManager::set_snapshot_duration_ms(int64_t size) {
     snapshot_duration_ms_.observe(size);
 }
@@ -1780,6 +1798,8 @@ std::string MasterMetricManager::serialize_metrics() {
     serialize_metric(promotion_rejected_frequency_);
     serialize_metric(promotion_rejected_watermark_);
     serialize_metric(promotion_rejected_cap_);
+    serialize_metric(tenant_quota_reject_total_);
+    serialize_metric(tenant_evict_bytes_total_);
 
     // Serialize Snapshot Metrics
     serialize_metric(snapshot_duration_ms_);

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -41,6 +41,8 @@ namespace mooncake {
 static const std::string SNAPSHOT_METADATA_FILE = "metadata";
 static const std::string SNAPSHOT_SEGMENTS_FILE = "segments";
 static const std::string SNAPSHOT_TASK_MANAGER_FILE = "task_manager";
+static const std::string SNAPSHOT_TENANT_QUOTA_POLICY_FILE =
+    "tenant_quota_policy";
 static const std::string SNAPSHOT_MANIFEST_FILE = "manifest.txt";
 static const std::string SNAPSHOT_LATEST_FILE = "latest.txt";
 static const std::string SNAPSHOT_BACKUP_SAVE_DIR =
@@ -53,6 +55,7 @@ static const std::string SNAPSHOT_SERIALIZER_TYPE = "messagepack";
 namespace {
 
 constexpr size_t kUnlimitedSnapshotList = 0;
+constexpr int kMaxTenantQuotaEvictionRetries = 2;
 
 // Per-cycle offload cap as a fraction of `offloading_queue_limit_`. Used only
 // when offload-on-evict mode is active. Defers memory eviction for at most
@@ -103,6 +106,30 @@ bool HasExpectedReplicaAllocation(const ReplicateConfig& config,
     }
     return allocated_memory_replicas == config.replica_num &&
            allocated_nof_replicas == config.nof_replica_num;
+}
+
+bool IsLazyEmptyTenantQuotaState(const TenantQuotaState& state) {
+    return !state.has_explicit_policy && state.used_bytes == 0 &&
+           state.reserved_bytes == 0 && state.committed_count == 0;
+}
+
+void RefreshTenantQuotaOverQuota(TenantQuotaState& state) {
+    state.over_quota = static_cast<unsigned __int128>(state.used_bytes) +
+                           state.reserved_bytes >
+                       state.effective_quota_bytes;
+}
+
+TenantQuotaSnapshot MakeTenantQuotaSnapshot(const std::string& tenant_id,
+                                            const TenantQuotaState& state) {
+    return TenantQuotaSnapshot{
+        .tenant_id = tenant_id,
+        .requested_quota_bytes = state.requested_quota_bytes,
+        .effective_quota_bytes = state.effective_quota_bytes,
+        .used_bytes = state.used_bytes,
+        .reserved_bytes = state.reserved_bytes,
+        .committed_count = state.committed_count,
+        .has_explicit_policy = state.has_explicit_policy,
+        .over_quota = state.over_quota};
 }
 
 tl::expected<std::string, ErrorCode> GetGroupIdForKey(
@@ -161,6 +188,7 @@ MasterService::MasterService(const MasterServiceConfig& config)
       enable_disk_eviction_(config.enable_disk_eviction),
       quota_bytes_(config.quota_bytes),
       enable_tenant_quota_(config.enable_tenant_quota),
+      configured_default_tenant_quota_bytes_(config.default_tenant_quota_bytes),
       default_tenant_quota_bytes_(config.default_tenant_quota_bytes),
       tenant_quota_pool_capacity_bytes_(
           config.tenant_quota_pool_capacity_bytes),
@@ -487,16 +515,116 @@ MasterService::GetTenantQuotaSnapshotForTesting(
     if (it == shard.tenants.end()) {
         return std::nullopt;
     }
-    const auto& state = it->second;
-    return TenantQuotaSnapshot{
-        .tenant_id = normalized_tenant,
-        .requested_quota_bytes = state.requested_quota_bytes,
-        .effective_quota_bytes = state.effective_quota_bytes,
-        .used_bytes = state.used_bytes,
-        .reserved_bytes = state.reserved_bytes,
-        .committed_count = state.committed_count,
-        .has_explicit_policy = state.has_explicit_policy,
-        .over_quota = state.over_quota};
+    return MakeTenantQuotaSnapshot(normalized_tenant, it->second);
+}
+
+bool MasterService::IsTenantQuotaEnabled() const {
+    return enable_tenant_quota_;
+}
+
+std::vector<TenantQuotaSnapshot> MasterService::ListTenantQuotaSnapshots()
+    const {
+    std::vector<TenantQuotaSnapshot> snapshots;
+    for (size_t i = 0; i < kNumTenantQuotaShards; ++i) {
+        const auto& shard = tenant_quota_shards_[i];
+        std::lock_guard<std::mutex> lock(shard.mutex);
+        for (const auto& [tenant_id, state] : shard.tenants) {
+            if (IsLazyEmptyTenantQuotaState(state)) {
+                continue;
+            }
+            snapshots.push_back(MakeTenantQuotaSnapshot(tenant_id, state));
+        }
+    }
+    std::sort(snapshots.begin(), snapshots.end(),
+              [](const auto& lhs, const auto& rhs) {
+                  return lhs.tenant_id < rhs.tenant_id;
+              });
+    return snapshots;
+}
+
+std::optional<TenantQuotaSnapshot> MasterService::GetTenantQuotaSnapshot(
+    const std::string& tenant_id) const {
+    return GetTenantQuotaSnapshotForTesting(tenant_id);
+}
+
+tl::expected<TenantQuotaSnapshot, ErrorCode>
+MasterService::UpsertTenantQuotaPolicy(const std::string& tenant_id,
+                                       uint64_t requested_quota_bytes) {
+    if (!enable_tenant_quota_) {
+        return tl::make_unexpected(ErrorCode::UNAVAILABLE_IN_CURRENT_MODE);
+    }
+    if (requested_quota_bytes == 0) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    const auto normalized_tenant = NormalizeTenantId(tenant_id);
+    auto& shard =
+        tenant_quota_shards_[getTenantQuotaShardIndex(normalized_tenant)];
+    {
+        std::lock_guard<std::mutex> lock(shard.mutex);
+        auto& state = shard.tenants[normalized_tenant];
+        state.requested_quota_bytes = requested_quota_bytes;
+        state.has_explicit_policy = true;
+    }
+
+    RecomputeTenantEffectiveQuotas();
+    auto snapshot = GetTenantQuotaSnapshot(normalized_tenant);
+    if (!snapshot.has_value()) {
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+    return snapshot.value();
+}
+
+std::optional<TenantQuotaSnapshot> MasterService::DeleteTenantQuotaPolicy(
+    const std::string& tenant_id) {
+    if (!enable_tenant_quota_) {
+        return std::nullopt;
+    }
+
+    const auto normalized_tenant = NormalizeTenantId(tenant_id);
+    auto& shard =
+        tenant_quota_shards_[getTenantQuotaShardIndex(normalized_tenant)];
+    {
+        std::lock_guard<std::mutex> lock(shard.mutex);
+        auto it = shard.tenants.find(normalized_tenant);
+        if (it == shard.tenants.end()) {
+            return std::nullopt;
+        }
+
+        auto& state = it->second;
+        state.has_explicit_policy = false;
+        state.requested_quota_bytes =
+            default_tenant_quota_bytes_.load(std::memory_order_relaxed);
+        if (IsLazyEmptyTenantQuotaState(state)) {
+            shard.tenants.erase(it);
+        }
+    }
+
+    RecomputeTenantEffectiveQuotas();
+    return GetTenantQuotaSnapshot(normalized_tenant);
+}
+
+uint64_t MasterService::GetDefaultTenantQuotaPolicy() const {
+    return default_tenant_quota_bytes_.load(std::memory_order_relaxed);
+}
+
+void MasterService::SetDefaultTenantQuotaPolicy(
+    uint64_t requested_quota_bytes) {
+    if (!enable_tenant_quota_) {
+        return;
+    }
+    default_tenant_quota_bytes_.store(requested_quota_bytes,
+                                      std::memory_order_relaxed);
+    for (size_t i = 0; i < kNumTenantQuotaShards; ++i) {
+        auto& shard = tenant_quota_shards_[i];
+        std::lock_guard<std::mutex> lock(shard.mutex);
+        for (auto& [_, state] : shard.tenants) {
+            if (!state.has_explicit_policy) {
+                state.requested_quota_bytes = requested_quota_bytes;
+            }
+        }
+    }
+    RecomputeTenantEffectiveQuotas();
 }
 
 auto MasterService::MountSegment(const Segment& segment, const UUID& client_id)
@@ -683,10 +811,33 @@ uint64_t MasterService::RequestedMemoryQuotaCharge(
     return static_cast<uint64_t>(charge);
 }
 
-uint64_t MasterService::GetTenantQuotaCapacityBytes() {
-    if (tenant_quota_pool_capacity_bytes_ != 0) {
-        return tenant_quota_pool_capacity_bytes_;
+uint64_t MasterService::ComputeTenantQuotaDeficit(
+    const std::string& tenant_id, uint64_t incoming_quota_charge) {
+    uint64_t deficit = incoming_quota_charge;
+    const auto normalized_tenant = NormalizeTenantId(tenant_id);
+    auto& quota_shard =
+        tenant_quota_shards_[getTenantQuotaShardIndex(normalized_tenant)];
+    std::lock_guard<std::mutex> lock(quota_shard.mutex);
+    auto quota_it = quota_shard.tenants.find(normalized_tenant);
+    if (quota_it == quota_shard.tenants.end()) {
+        return deficit;
     }
+
+    const auto& state = quota_it->second;
+    const unsigned __int128 demand =
+        static_cast<unsigned __int128>(state.used_bytes) +
+        state.reserved_bytes + incoming_quota_charge;
+    if (demand <= state.effective_quota_bytes) {
+        return 0;
+    }
+
+    const unsigned __int128 raw_deficit = demand - state.effective_quota_bytes;
+    return raw_deficit > std::numeric_limits<uint64_t>::max()
+               ? std::numeric_limits<uint64_t>::max()
+               : static_cast<uint64_t>(raw_deficit);
+}
+
+uint64_t MasterService::GetTenantQuotaCapacityBytes() {
     uint64_t capacity = 0;
     ScopedSegmentAccess segment_access = segment_manager_.getSegmentAccess();
     std::vector<std::pair<Segment, UUID>> segments;
@@ -702,13 +853,24 @@ uint64_t MasterService::GetTenantQuotaCapacityBytes() {
     return capacity;
 }
 
+uint64_t MasterService::GetTenantQuotaAllocatableCapacityBytes() {
+    const uint64_t total_registered_memory = GetTenantQuotaCapacityBytes();
+    if (tenant_quota_pool_capacity_bytes_ == 0) {
+        return total_registered_memory;
+    }
+    return std::min(total_registered_memory, tenant_quota_pool_capacity_bytes_);
+}
+
 void MasterService::RecomputeTenantEffectiveQuotas() {
     if (!enable_tenant_quota_) {
         return;
     }
-    const uint64_t capacity = GetTenantQuotaCapacityBytes();
+    std::lock_guard<std::mutex> recompute_lock(tenant_quota_recompute_mutex_);
+    const uint64_t default_requested_quota_bytes =
+        default_tenant_quota_bytes_.load(std::memory_order_relaxed);
+    const uint64_t capacity = GetTenantQuotaAllocatableCapacityBytes();
 
-    std::vector<std::pair<size_t, std::string>> active_tenants;
+    std::map<std::string, TenantQuotaState> active_tenants;
     for (size_t i = 0; i < kNumTenantQuotaShards; ++i) {
         auto& shard = tenant_quota_shards_[i];
         std::lock_guard<std::mutex> lock(shard.mutex);
@@ -716,54 +878,29 @@ void MasterService::RecomputeTenantEffectiveQuotas() {
             const auto& tenant_id = it->first;
             auto& state = it->second;
             if (!state.has_explicit_policy) {
-                state.requested_quota_bytes = default_tenant_quota_bytes_;
+                state.requested_quota_bytes = default_requested_quota_bytes;
             }
-            if (!state.has_explicit_policy && state.used_bytes == 0 &&
-                state.reserved_bytes == 0 && state.committed_count == 0) {
+            if (IsLazyEmptyTenantQuotaState(state)) {
                 it = shard.tenants.erase(it);
                 continue;
             }
-            active_tenants.emplace_back(i, tenant_id);
+            active_tenants.emplace(tenant_id, state);
             ++it;
         }
     }
 
-    if (default_tenant_quota_bytes_ == 0) {
-        for (const auto& [shard_idx, tenant_id] : active_tenants) {
-            auto& shard = tenant_quota_shards_[shard_idx];
-            std::lock_guard<std::mutex> lock(shard.mutex);
-            auto it = shard.tenants.find(tenant_id);
-            if (it == shard.tenants.end()) {
-                continue;
-            }
-            auto& state = it->second;
-            state.effective_quota_bytes = std::numeric_limits<uint64_t>::max();
-            state.over_quota = false;
-        }
-        return;
-    }
-
-    const uint64_t active_count = active_tenants.size();
-    for (size_t ordinal = 0; ordinal < active_tenants.size(); ++ordinal) {
-        const auto& [shard_idx, tenant_id] = active_tenants[ordinal];
-        auto& shard = tenant_quota_shards_[shard_idx];
+    for (const auto& assignment : BuildEffectiveQuotaAssignments(
+             active_tenants, default_requested_quota_bytes, capacity)) {
+        auto& shard = tenant_quota_shards_[getTenantQuotaShardIndex(
+            assignment.tenant_id)];
         std::lock_guard<std::mutex> lock(shard.mutex);
-        auto it = shard.tenants.find(tenant_id);
+        auto it = shard.tenants.find(assignment.tenant_id);
         if (it == shard.tenants.end()) {
             continue;
         }
         auto& state = it->second;
-        uint64_t effective = 0;
-        if (active_count > 0 && capacity > 0) {
-            effective = capacity / active_count;
-            if (ordinal < capacity % active_count) {
-                ++effective;
-            }
-        }
-        state.effective_quota_bytes = effective;
-        state.over_quota = static_cast<unsigned __int128>(state.used_bytes) +
-                               state.reserved_bytes >
-                           state.effective_quota_bytes;
+        state.effective_quota_bytes = assignment.effective_quota_bytes;
+        RefreshTenantQuotaOverQuota(state);
     }
 }
 
@@ -779,14 +916,6 @@ tl::expected<void, ErrorCode> MasterService::ReserveTenantQuota(
                    state.reserved_bytes + additional_bytes >
                state.effective_quota_bytes;
     };
-    auto refresh_over_quota = [](TenantQuotaState& state) {
-        state.over_quota = state.effective_quota_bytes !=
-                               std::numeric_limits<uint64_t>::max() &&
-                           static_cast<unsigned __int128>(state.used_bytes) +
-                                   state.reserved_bytes >
-                               state.effective_quota_bytes;
-    };
-
     auto& shard =
         tenant_quota_shards_[getTenantQuotaShardIndex(normalized_tenant)];
     {
@@ -799,26 +928,16 @@ tl::expected<void, ErrorCode> MasterService::ReserveTenantQuota(
             }
 
             state.reserved_bytes += bytes;
-            refresh_over_quota(state);
+            RefreshTenantQuotaOverQuota(state);
             return {};
         }
 
         auto [insert_it, _] = shard.tenants.try_emplace(normalized_tenant);
         auto& state = insert_it->second;
-        state.requested_quota_bytes = default_tenant_quota_bytes_;
-        state.effective_quota_bytes = default_tenant_quota_bytes_ == 0
-                                          ? std::numeric_limits<uint64_t>::max()
-                                          : 0;
+        state.requested_quota_bytes =
+            default_tenant_quota_bytes_.load(std::memory_order_relaxed);
+        state.effective_quota_bytes = 0;
         state.over_quota = false;
-
-        if (default_tenant_quota_bytes_ == 0) {
-            if (exceeds_effective_quota(state, bytes)) {
-                shard.tenants.erase(insert_it);
-                return tl::make_unexpected(ErrorCode::TENANT_QUOTA_EXCEEDED);
-            }
-            state.reserved_bytes += bytes;
-            return {};
-        }
 
         state.reserved_bytes = bytes;
     }
@@ -835,7 +954,7 @@ tl::expected<void, ErrorCode> MasterService::ReserveTenantQuota(
 
         auto& state = it->second;
         if (!exceeds_effective_quota(state, 0)) {
-            refresh_over_quota(state);
+            RefreshTenantQuotaOverQuota(state);
             return {};
         }
 
@@ -851,7 +970,7 @@ tl::expected<void, ErrorCode> MasterService::ReserveTenantQuota(
             shard.tenants.erase(it);
             rollback_needs_recompute = true;
         } else {
-            refresh_over_quota(state);
+            RefreshTenantQuotaOverQuota(state);
         }
     }
 
@@ -891,11 +1010,7 @@ void MasterService::CommitTenantQuota(const std::string& tenant_id,
         state.used_bytes += bytes;
     }
     ++state.committed_count;
-    state.over_quota =
-        state.effective_quota_bytes != std::numeric_limits<uint64_t>::max() &&
-        static_cast<unsigned __int128>(state.used_bytes) +
-                state.reserved_bytes >
-            state.effective_quota_bytes;
+    RefreshTenantQuotaOverQuota(state);
 }
 
 void MasterService::AbortTenantQuota(const std::string& tenant_id,
@@ -929,12 +1044,7 @@ void MasterService::AbortTenantQuota(const std::string& tenant_id,
             shard.tenants.erase(it);
             recompute_needed = true;
         } else {
-            state.over_quota =
-                state.effective_quota_bytes !=
-                    std::numeric_limits<uint64_t>::max() &&
-                static_cast<unsigned __int128>(state.used_bytes) +
-                        state.reserved_bytes >
-                    state.effective_quota_bytes;
+            RefreshTenantQuotaOverQuota(state);
         }
     }
     if (recompute_needed) {
@@ -976,12 +1086,7 @@ void MasterService::ReleaseTenantQuota(const std::string& tenant_id,
             shard.tenants.erase(it);
             recompute_needed = true;
         } else {
-            state.over_quota =
-                state.effective_quota_bytes !=
-                    std::numeric_limits<uint64_t>::max() &&
-                static_cast<unsigned __int128>(state.used_bytes) +
-                        state.reserved_bytes >
-                    state.effective_quota_bytes;
+            RefreshTenantQuotaOverQuota(state);
         }
     }
     if (recompute_needed) {
@@ -1012,11 +1117,7 @@ void MasterService::ReleaseTenantQuotaPartial(const std::string& tenant_id,
         return;
     }
     state.used_bytes -= bytes;
-    state.over_quota =
-        state.effective_quota_bytes != std::numeric_limits<uint64_t>::max() &&
-        static_cast<unsigned __int128>(state.used_bytes) +
-                state.reserved_bytes >
-            state.effective_quota_bytes;
+    RefreshTenantQuotaOverQuota(state);
 }
 
 void MasterService::ReleaseCommittedQuotaCharge(ObjectMetadata& metadata,
@@ -1070,8 +1171,12 @@ void MasterService::RebuildTenantQuotaUsageFromMetadata() {
     for (const auto& [tenant_id, used_bytes] : used_by_tenant) {
         auto& shard = tenant_quota_shards_[getTenantQuotaShardIndex(tenant_id)];
         std::lock_guard<std::mutex> lock(shard.mutex);
-        auto& state = shard.tenants[tenant_id];
-        state.requested_quota_bytes = default_tenant_quota_bytes_;
+        auto [it, inserted] = shard.tenants.try_emplace(tenant_id);
+        auto& state = it->second;
+        if (inserted || !state.has_explicit_policy) {
+            state.requested_quota_bytes =
+                default_tenant_quota_bytes_.load(std::memory_order_relaxed);
+        }
         state.used_bytes = used_bytes;
         state.committed_count = committed_count_by_tenant[tenant_id];
     }
@@ -2337,79 +2442,107 @@ auto MasterService::PutStart(const UUID& client_id, const std::string& key,
 
     [[maybe_unused]] auto object_operation_lock =
         AcquireObjectOperationLock(object_id.tenant_id, object_id.user_key);
-    const auto now = std::chrono::system_clock::now();
-    std::optional<size_t> retry_shard_idx;
-    {
-        auto alive_clients = getAliveClientsSnapshot();
-        std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-        const size_t lookup_shard_idx =
-            getMetadataShardIndex(object_id.tenant_id, object_id.user_key);
-        MetadataShardAccessorRW shard(this, lookup_shard_idx);
-        auto& tenant_state = shard->tenants[object_id.tenant_id];
+    const uint64_t requested_quota_charge =
+        RequestedMemoryQuotaCharge(slice_length, config);
 
-        auto it = tenant_state.metadata.find(key);
-        if (it != tenant_state.metadata.end()) {
-            if (CleanupStaleHandles(it->second, alive_clients)) {
-                tenant_state.processing_keys.erase(key);
-                tenant_state.replication_tasks.erase(key);
-                tenant_state.offloading_tasks.erase(key);
-                ErasePromotionTaskIfPresent(tenant_state, key,
-                                            object_id.tenant_id);
-                EraseMetadata(tenant_state, it, object_id.tenant_id);
-                it = tenant_state.metadata.end();
-            } else {
-                auto& metadata = it->second;
-                if (metadata.HasReplica(&Replica::fn_is_completed) ||
-                    metadata.put_start_time + put_start_discard_timeout_sec_ >=
-                        now) {
-                    LOG(INFO)
-                        << "key=" << key << ", info=object_already_exists";
-                    return tl::make_unexpected(
-                        ErrorCode::OBJECT_ALREADY_EXISTS);
-                }
-                auto replicas =
-                    metadata.PopReplicas(&Replica::fn_is_processing);
-                if (!replicas.empty()) {
-                    std::lock_guard lock(discarded_replicas_mutex_);
-                    discarded_replicas_.emplace_back(
-                        std::move(replicas),
+    auto attempt_once =
+        [&]() -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode> {
+        auto now = std::chrono::system_clock::now();
+        std::optional<size_t> retry_shard_idx;
+        {
+            auto alive_clients = getAliveClientsSnapshot();
+            std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+            const size_t lookup_shard_idx =
+                getMetadataShardIndex(object_id.tenant_id, object_id.user_key);
+            MetadataShardAccessorRW shard(this, lookup_shard_idx);
+            auto& tenant_state = shard->tenants[object_id.tenant_id];
+
+            auto it = tenant_state.metadata.find(key);
+            if (it != tenant_state.metadata.end()) {
+                if (CleanupStaleHandles(it->second, alive_clients)) {
+                    tenant_state.processing_keys.erase(key);
+                    tenant_state.replication_tasks.erase(key);
+                    tenant_state.offloading_tasks.erase(key);
+                    ErasePromotionTaskIfPresent(tenant_state, key,
+                                                object_id.tenant_id);
+                    EraseMetadata(tenant_state, it, object_id.tenant_id);
+                    it = tenant_state.metadata.end();
+                } else {
+                    auto& metadata = it->second;
+                    if (metadata.HasReplica(&Replica::fn_is_completed) ||
                         metadata.put_start_time +
-                            put_start_release_timeout_sec_);
+                                put_start_discard_timeout_sec_ >=
+                            now) {
+                        LOG(INFO)
+                            << "key=" << key << ", info=object_already_exists";
+                        return tl::make_unexpected(
+                            ErrorCode::OBJECT_ALREADY_EXISTS);
+                    }
+                    auto replicas =
+                        metadata.PopReplicas(&Replica::fn_is_processing);
+                    if (!replicas.empty()) {
+                        std::lock_guard lock(discarded_replicas_mutex_);
+                        discarded_replicas_.emplace_back(
+                            std::move(replicas),
+                            metadata.put_start_time +
+                                put_start_release_timeout_sec_);
+                    }
+                    tenant_state.processing_keys.erase(key);
+                    EraseMetadata(tenant_state, it, object_id.tenant_id);
+                    it = tenant_state.metadata.end();
                 }
-                tenant_state.processing_keys.erase(key);
-                EraseMetadata(tenant_state, it, object_id.tenant_id);
-                it = tenant_state.metadata.end();
+            }
+
+            if (it == tenant_state.metadata.end()) {
+                const size_t target_shard_idx =
+                    group_id.empty()
+                        ? getShardIndex(object_id.tenant_id, object_id.user_key)
+                        : getShardIndex(group_id);
+                if (target_shard_idx != lookup_shard_idx) {
+                    retry_shard_idx = target_shard_idx;
+                    if (tenant_state.Empty()) {
+                        shard->tenants.erase(object_id.tenant_id);
+                    }
+                } else {
+                    return AllocateAndInsertMetadata(
+                        shard, client_id, key, slice_length, config, group_id,
+                        object_id.tenant_id, now);
+                }
             }
         }
 
-        if (it == tenant_state.metadata.end()) {
-            const size_t target_shard_idx =
-                group_id.empty()
-                    ? getShardIndex(object_id.tenant_id, object_id.user_key)
-                    : getShardIndex(group_id);
-            if (target_shard_idx != lookup_shard_idx) {
-                retry_shard_idx = target_shard_idx;
-                if (tenant_state.Empty()) {
-                    shard->tenants.erase(object_id.tenant_id);
-                }
-            } else {
-                return AllocateAndInsertMetadata(shard, client_id, key,
-                                                 slice_length, config, group_id,
-                                                 object_id.tenant_id, now);
-            }
+        std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+        MetadataShardAccessorRW shard(this, retry_shard_idx.value());
+        auto& retry_tenant_state = shard->tenants[object_id.tenant_id];
+        if (GetGroupRoute(object_id.tenant_id, object_id.user_key)
+                .has_value() ||
+            retry_tenant_state.metadata.contains(key)) {
+            LOG(INFO) << "key=" << key << ", info=object_already_exists";
+            return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
         }
+        return AllocateAndInsertMetadata(shard, client_id, key, slice_length,
+                                         config, group_id, object_id.tenant_id,
+                                         now);
+    };
+
+    for (int attempt = 0; attempt <= kMaxTenantQuotaEvictionRetries;
+         ++attempt) {
+        auto result = attempt_once();
+        if (result.has_value() ||
+            result.error() != ErrorCode::TENANT_QUOTA_EXCEEDED) {
+            return result;
+        }
+        if (attempt == kMaxTenantQuotaEvictionRetries) {
+            MasterMetricManager::instance().inc_tenant_quota_reject(
+                object_id.tenant_id, "quota_exceeded");
+            return result;
+        }
+        EvictTenantMemoryForQuota(
+            object_id.tenant_id,
+            ComputeTenantQuotaDeficit(object_id.tenant_id,
+                                      requested_quota_charge));
     }
-    std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    MetadataShardAccessorRW shard(this, retry_shard_idx.value());
-    auto& retry_tenant_state = shard->tenants[object_id.tenant_id];
-    if (GetGroupRoute(object_id.tenant_id, object_id.user_key).has_value() ||
-        retry_tenant_state.metadata.contains(key)) {
-        LOG(INFO) << "key=" << key << ", info=object_already_exists";
-        return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
-    }
-    return AllocateAndInsertMetadata(shard, client_id, key, slice_length,
-                                     config, group_id, object_id.tenant_id,
-                                     now);
+    return tl::make_unexpected(ErrorCode::TENANT_QUOTA_EXCEEDED);
 }
 
 auto MasterService::PutEnd(const UUID& client_id, const std::string& key,
@@ -2705,225 +2838,261 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
 
     [[maybe_unused]] auto object_operation_lock =
         AcquireObjectOperationLock(object_id.tenant_id, object_id.user_key);
-    const auto now = std::chrono::system_clock::now();
-    std::optional<size_t> case_a_retry_shard_idx;
-    {
-        // --- Lock acquisition ---
-        auto alive_clients = getAliveClientsSnapshot();
-        std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-        // Use getMetadataShardIndex to find the object at its current shard
-        // (handles both grouped and ungrouped routing).
-        const size_t lookup_shard_idx =
-            getMetadataShardIndex(object_id.tenant_id, object_id.user_key);
-        MetadataShardAccessorRW shard(this, lookup_shard_idx);
-        auto& tenant_state = shard->tenants[object_id.tenant_id];
+    const uint64_t requested_quota_charge =
+        RequestedMemoryQuotaCharge(slice_length, config);
 
-        auto it = tenant_state.metadata.find(key);
+    auto attempt_once =
+        [&]() -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode> {
+        auto now = std::chrono::system_clock::now();
+        std::optional<size_t> case_a_retry_shard_idx;
+        {
+            // --- Lock acquisition ---
+            auto alive_clients = getAliveClientsSnapshot();
+            std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+            // Use getMetadataShardIndex to find the object at its current shard
+            // (handles both grouped and ungrouped routing).
+            const size_t lookup_shard_idx =
+                getMetadataShardIndex(object_id.tenant_id, object_id.user_key);
+            MetadataShardAccessorRW shard(this, lookup_shard_idx);
+            auto& tenant_state = shard->tenants[object_id.tenant_id];
 
-        // --- Step 0: stale handle cleanup ---
-        if (it != tenant_state.metadata.end() &&
-            CleanupStaleHandles(it->second, alive_clients)) {
-            tenant_state.processing_keys.erase(key);
-            ErasePromotionTaskIfPresent(tenant_state, key, object_id.tenant_id);
-            EraseMetadata(tenant_state, it, object_id.tenant_id);
-            it = tenant_state.metadata.end();
-        }
+            auto it = tenant_state.metadata.find(key);
 
-        // --- Step 1: safety checks and preemption (only if key exists) ---
-        if (it != tenant_state.metadata.end()) {
-            auto& metadata = it->second;
-
-            // Reject if the caller tries to change group membership.
-            // Group membership is immutable while an object exists.
-            if (config.group_ids.has_value() && metadata.group_id != group_id) {
-                LOG(ERROR) << "key=" << key
-                           << ", error=group_membership_is_immutable";
-                return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
-            }
-
-            // Reject if a Copy/Move task is actively reading this key's
-            // replicas.
-            if (tenant_state.replication_tasks.count(key) > 0) {
-                LOG(INFO) << "key=" << key
-                          << ", error=object_has_replication_task";
-                return tl::make_unexpected(
-                    ErrorCode::OBJECT_HAS_REPLICATION_TASK);
-            }
-
-            // Reject if an offload-to-disk task is in progress (same reason).
-            if (tenant_state.offloading_tasks.count(key) > 0) {
-                LOG(INFO) << "key=" << key
-                          << ", error=object_has_offloading_task";
-                return tl::make_unexpected(
-                    ErrorCode::OBJECT_HAS_REPLICATION_TASK);
-            }
-
-            // Preempt an in-progress Put/Upsert on the same key.  The previous
-            // writer's PROCESSING replicas are moved to discarded_replicas_
-            // with a TTL so they are not freed while the old writer may still
-            // be doing RDMA writes.  Unlike PutStart (which only preempts after
-            // a timeout), UpsertStart preempts immediately.
-            if (tenant_state.processing_keys.count(key) > 0) {
-                auto processing_replicas =
-                    metadata.PopReplicas(&Replica::fn_is_processing);
-                if (!processing_replicas.empty()) {
-                    std::lock_guard lock(discarded_replicas_mutex_);
-                    discarded_replicas_.emplace_back(
-                        std::move(processing_replicas),
-                        now + put_start_release_timeout_sec_);
-                }
+            // --- Step 0: stale handle cleanup ---
+            if (it != tenant_state.metadata.end() &&
+                CleanupStaleHandles(it->second, alive_clients)) {
                 tenant_state.processing_keys.erase(key);
+                ErasePromotionTaskIfPresent(tenant_state, key,
+                                            object_id.tenant_id);
+                EraseMetadata(tenant_state, it, object_id.tenant_id);
+                it = tenant_state.metadata.end();
+            }
 
-                // If no COMPLETE replicas survive the preemption, this key
-                // effectively does not exist — fall through to Case A.
-                if (!metadata.HasReplica(&Replica::fn_is_completed)) {
-                    ErasePromotionTaskIfPresent(tenant_state, key,
-                                                object_id.tenant_id);
-                    EraseMetadata(tenant_state, it, object_id.tenant_id);
-                    it = tenant_state.metadata.end();
+            // --- Step 1: safety checks and preemption (only if key exists) ---
+            if (it != tenant_state.metadata.end()) {
+                auto& metadata = it->second;
+
+                // Reject if the caller tries to change group membership.
+                // Group membership is immutable while an object exists.
+                if (config.group_ids.has_value() &&
+                    metadata.group_id != group_id) {
+                    LOG(ERROR) << "key=" << key
+                               << ", error=group_membership_is_immutable";
+                    return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
                 }
-            }
-        }
 
-        // --- Case A: key does not exist (or was erased above) ---
-        // Allocate fresh buffers, identical to PutStart.
-        if (it == tenant_state.metadata.end()) {
-            VLOG(1) << "key=" << key << ", action=upsert_start_case_a";
-            const size_t case_a_shard_idx =
-                group_id.empty()
-                    ? getShardIndex(object_id.tenant_id, object_id.user_key)
-                    : getShardIndex(group_id);
-            if (case_a_shard_idx != lookup_shard_idx) {
-                case_a_retry_shard_idx = case_a_shard_idx;
-                if (tenant_state.Empty()) {
-                    shard->tenants.erase(object_id.tenant_id);
+                // Reject if a Copy/Move task is actively reading this key's
+                // replicas.
+                if (tenant_state.replication_tasks.count(key) > 0) {
+                    LOG(INFO) << "key=" << key
+                              << ", error=object_has_replication_task";
+                    return tl::make_unexpected(
+                        ErrorCode::OBJECT_HAS_REPLICATION_TASK);
                 }
-            } else {
-                return AllocateAndInsertMetadata(shard, client_id, key,
-                                                 slice_length, config, group_id,
-                                                 object_id.tenant_id, now);
-            }
-        } else {
-            // --- Step 2: key exists with COMPLETE replicas → Case B or C ---
-            auto& metadata = it->second;
 
-            // Reject if any reader holds a reference (refcnt > 0).  Overwriting
-            // a buffer that an RDMA read is streaming from would cause data
-            // corruption. The client should retry after readers finish.
-            if (metadata.HasReplica(&Replica::fn_is_busy)) {
-                LOG(INFO) << "key=" << key << ", error=object_replica_busy";
-                return tl::make_unexpected(ErrorCode::OBJECT_REPLICA_BUSY);
-            }
+                // Reject if an offload-to-disk task is in progress (same
+                // reason).
+                if (tenant_state.offloading_tasks.count(key) > 0) {
+                    LOG(INFO) << "key=" << key
+                              << ", error=object_has_offloading_task";
+                    return tl::make_unexpected(
+                        ErrorCode::OBJECT_HAS_REPLICATION_TASK);
+                }
 
-            if (metadata.size == slice_length) {
-                // --- Case B: same size — in-place update ---
-                // Reuse existing buffer addresses.  No allocation or
-                // deallocation. The client will RDMA-write new data to the same
-                // addresses.
-                //
-                // hard_pinned is const and preserved automatically — upsert
-                // does not change the eviction protection level of an existing
-                // object.
-                metadata.client_id = client_id;
-                metadata.put_start_time = now;
+                // Preempt an in-progress Put/Upsert on the same key.  The
+                // previous writer's PROCESSING replicas are moved to
+                // discarded_replicas_ with a TTL so they are not freed while
+                // the old writer may still be doing RDMA writes.  Unlike
+                // PutStart (which only preempts after a timeout), UpsertStart
+                // preempts immediately.
+                if (tenant_state.processing_keys.count(key) > 0) {
+                    auto processing_replicas =
+                        metadata.PopReplicas(&Replica::fn_is_processing);
+                    if (!processing_replicas.empty()) {
+                        std::lock_guard lock(discarded_replicas_mutex_);
+                        discarded_replicas_.emplace_back(
+                            std::move(processing_replicas),
+                            now + put_start_release_timeout_sec_);
+                    }
+                    tenant_state.processing_keys.erase(key);
 
-                // Reconcile soft_pin state with the incoming config.
-                {
-                    SpinLocker locker(&metadata.lock);
-                    if (config.with_soft_pin && !metadata.soft_pin_timeout) {
-                        metadata.soft_pin_timeout.emplace();
-                        MasterMetricManager::instance().inc_soft_pin_key_count(
-                            1);
-                    } else if (!config.with_soft_pin &&
-                               metadata.soft_pin_timeout) {
-                        metadata.soft_pin_timeout.reset();
-                        MasterMetricManager::instance().dec_soft_pin_key_count(
-                            1);
+                    // If no COMPLETE replicas survive the preemption, this key
+                    // effectively does not exist — fall through to Case A.
+                    if (!metadata.HasReplica(&Replica::fn_is_completed)) {
+                        ErasePromotionTaskIfPresent(tenant_state, key,
+                                                    object_id.tenant_id);
+                        EraseMetadata(tenant_state, it, object_id.tenant_id);
+                        it = tenant_state.metadata.end();
                     }
                 }
+            }
 
-                // Mark COMPLETE → PROCESSING so readers won't see stale data
-                // mid-transfer.  The key becomes unreadable until UpsertEnd.
-                metadata.VisitReplicas(
-                    &Replica::fn_is_completed,
-                    [](Replica& replica) { replica.mark_processing(); });
-                SyncCacheTotalAccounting(metadata);
+            // --- Case A: key does not exist (or was erased above) ---
+            // Allocate fresh buffers, identical to PutStart.
+            if (it == tenant_state.metadata.end()) {
+                VLOG(1) << "key=" << key << ", action=upsert_start_case_a";
+                const size_t case_a_shard_idx =
+                    group_id.empty()
+                        ? getShardIndex(object_id.tenant_id, object_id.user_key)
+                        : getShardIndex(group_id);
+                if (case_a_shard_idx != lookup_shard_idx) {
+                    case_a_retry_shard_idx = case_a_shard_idx;
+                    if (tenant_state.Empty()) {
+                        shard->tenants.erase(object_id.tenant_id);
+                    }
+                } else {
+                    return AllocateAndInsertMetadata(
+                        shard, client_id, key, slice_length, config, group_id,
+                        object_id.tenant_id, now);
+                }
+            } else {
+                // --- Step 2: key exists with COMPLETE replicas → Case B or C
+                // ---
+                auto& metadata = it->second;
 
-                tenant_state.processing_keys.insert(key);
-
-                // Return the existing descriptors — same buffer addresses as
-                // before.
-                std::vector<Replica::Descriptor> replica_list;
-                const auto& all_replicas = metadata.GetAllReplicas();
-                replica_list.reserve(all_replicas.size());
-                for (const auto& replica : all_replicas) {
-                    replica_list.emplace_back(replica.get_descriptor());
+                // Reject if any reader holds a reference (refcnt > 0).
+                // Overwriting a buffer that an RDMA read is streaming from
+                // would cause data corruption. The client should retry after
+                // readers finish.
+                if (metadata.HasReplica(&Replica::fn_is_busy)) {
+                    LOG(INFO) << "key=" << key << ", error=object_replica_busy";
+                    return tl::make_unexpected(ErrorCode::OBJECT_REPLICA_BUSY);
                 }
 
+                if (metadata.size == slice_length) {
+                    // --- Case B: same size — in-place update ---
+                    // Reuse existing buffer addresses.  No allocation or
+                    // deallocation. The client will RDMA-write new data to the
+                    // same addresses.
+                    //
+                    // hard_pinned is const and preserved automatically — upsert
+                    // does not change the eviction protection level of an
+                    // existing object.
+                    metadata.client_id = client_id;
+                    metadata.put_start_time = now;
+
+                    // Reconcile soft_pin state with the incoming config.
+                    {
+                        SpinLocker locker(&metadata.lock);
+                        if (config.with_soft_pin &&
+                            !metadata.soft_pin_timeout) {
+                            metadata.soft_pin_timeout.emplace();
+                            MasterMetricManager::instance()
+                                .inc_soft_pin_key_count(1);
+                        } else if (!config.with_soft_pin &&
+                                   metadata.soft_pin_timeout) {
+                            metadata.soft_pin_timeout.reset();
+                            MasterMetricManager::instance()
+                                .dec_soft_pin_key_count(1);
+                        }
+                    }
+
+                    // Mark COMPLETE → PROCESSING so readers won't see stale
+                    // data mid-transfer.  The key becomes unreadable until
+                    // UpsertEnd.
+                    metadata.VisitReplicas(
+                        &Replica::fn_is_completed,
+                        [](Replica& replica) { replica.mark_processing(); });
+                    SyncCacheTotalAccounting(metadata);
+
+                    tenant_state.processing_keys.insert(key);
+
+                    // Return the existing descriptors — same buffer addresses
+                    // as before.
+                    std::vector<Replica::Descriptor> replica_list;
+                    const auto& all_replicas = metadata.GetAllReplicas();
+                    replica_list.reserve(all_replicas.size());
+                    for (const auto& replica : all_replicas) {
+                        replica_list.emplace_back(replica.get_descriptor());
+                    }
+
+                    VLOG(1) << "key=" << key
+                            << ", action=upsert_start_case_b_inplace";
+                    return replica_list;
+                }
+
+                // --- Case C: different size — discard old replicas and
+                // reallocate
+                // --- Old buffers cannot be reused.  Move them to
+                // discarded_replicas_ for delayed release (readers may still
+                // hold descriptors without refcnt), then allocate fresh buffers
+                // at the new size.
+                //
+                // Preserve hard_pin and soft_pin from the old metadata so that
+                // eviction protection survives a size-changing upsert (RFC
+                // §2.2.2).
+                ReplicateConfig merged_config = config;
+                merged_config.with_hard_pin =
+                    merged_config.with_hard_pin || metadata.IsHardPinned();
+                merged_config.with_soft_pin =
+                    merged_config.with_soft_pin || metadata.IsSoftPinned();
+
+                const std::string existing_group_id = metadata.group_id;
+                const uint64_t old_quota_charge =
+                    metadata.committed_quota_charge_bytes != 0
+                        ? metadata.committed_quota_charge_bytes
+                        : CompletedMemoryQuotaCharge(metadata);
+                auto old_replicas =
+                    PopReplicasWithCacheTotalAccounting(metadata);
+                if (!old_replicas.empty()) {
+                    std::lock_guard lock(discarded_replicas_mutex_);
+                    discarded_replicas_.emplace_back(
+                        std::move(old_replicas),
+                        now + put_start_release_timeout_sec_);
+                }
+                EraseMetadata(tenant_state, it, object_id.tenant_id,
+                              QuotaEraseMode::kPreserveOld);
+
                 VLOG(1) << "key=" << key
-                        << ", action=upsert_start_case_b_inplace";
-                return replica_list;
-            }
-
-            // --- Case C: different size — discard old replicas and reallocate
-            // --- Old buffers cannot be reused.  Move them to
-            // discarded_replicas_ for delayed release (readers may still hold
-            // descriptors without refcnt), then allocate fresh buffers at the
-            // new size.
-            //
-            // Preserve hard_pin and soft_pin from the old metadata so that
-            // eviction protection survives a size-changing upsert (RFC §2.2.2).
-            ReplicateConfig merged_config = config;
-            merged_config.with_hard_pin =
-                merged_config.with_hard_pin || metadata.IsHardPinned();
-            merged_config.with_soft_pin =
-                merged_config.with_soft_pin || metadata.IsSoftPinned();
-
-            const std::string existing_group_id = metadata.group_id;
-            const uint64_t old_quota_charge =
-                metadata.committed_quota_charge_bytes != 0
-                    ? metadata.committed_quota_charge_bytes
-                    : CompletedMemoryQuotaCharge(metadata);
-            auto old_replicas = PopReplicasWithCacheTotalAccounting(metadata);
-            if (!old_replicas.empty()) {
-                std::lock_guard lock(discarded_replicas_mutex_);
-                discarded_replicas_.emplace_back(
-                    std::move(old_replicas),
-                    now + put_start_release_timeout_sec_);
-            }
-            EraseMetadata(tenant_state, it, object_id.tenant_id,
-                          QuotaEraseMode::kPreserveOld);
-
-            VLOG(1) << "key=" << key
-                    << ", action=upsert_start_case_c_reallocate";
-            auto allocate_result = AllocateAndInsertMetadata(
-                shard, client_id, key, slice_length, merged_config,
-                existing_group_id, object_id.tenant_id, now);
-            if (!allocate_result) {
-                ReleaseTenantQuota(object_id.tenant_id, old_quota_charge);
+                        << ", action=upsert_start_case_c_reallocate";
+                auto allocate_result = AllocateAndInsertMetadata(
+                    shard, client_id, key, slice_length, merged_config,
+                    existing_group_id, object_id.tenant_id, now);
+                if (!allocate_result) {
+                    ReleaseTenantQuota(object_id.tenant_id, old_quota_charge);
+                    return allocate_result;
+                }
+                auto new_it = tenant_state.metadata.find(key);
+                if (new_it != tenant_state.metadata.end()) {
+                    new_it->second.pending_replaced_quota_charge_bytes =
+                        old_quota_charge;
+                }
                 return allocate_result;
             }
-            auto new_it = tenant_state.metadata.find(key);
-            if (new_it != tenant_state.metadata.end()) {
-                new_it->second.pending_replaced_quota_charge_bytes =
-                    old_quota_charge;
-            }
-            return allocate_result;
         }
+        std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+        MetadataShardAccessorRW shard(this, case_a_retry_shard_idx.value());
+        auto& retry_tenant_state = shard->tenants[object_id.tenant_id];
+        const auto current_route =
+            GetGroupRoute(object_id.tenant_id, object_id.user_key);
+        if (current_route.has_value() ||
+            retry_tenant_state.metadata.contains(key)) {
+            LOG(INFO) << "key=" << key << ", info=object_already_exists";
+            return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
+        }
+        return AllocateAndInsertMetadata(shard, client_id, key, slice_length,
+                                         config, group_id, object_id.tenant_id,
+                                         now);
+    };
+
+    for (int attempt = 0; attempt <= kMaxTenantQuotaEvictionRetries;
+         ++attempt) {
+        auto result = attempt_once();
+        if (result.has_value() ||
+            result.error() != ErrorCode::TENANT_QUOTA_EXCEEDED) {
+            return result;
+        }
+        if (attempt == kMaxTenantQuotaEvictionRetries) {
+            MasterMetricManager::instance().inc_tenant_quota_reject(
+                object_id.tenant_id, "quota_exceeded");
+            return result;
+        }
+        EvictTenantMemoryForQuota(
+            object_id.tenant_id,
+            ComputeTenantQuotaDeficit(object_id.tenant_id,
+                                      requested_quota_charge));
     }
-    std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    MetadataShardAccessorRW shard(this, case_a_retry_shard_idx.value());
-    auto& retry_tenant_state = shard->tenants[object_id.tenant_id];
-    const auto current_route =
-        GetGroupRoute(object_id.tenant_id, object_id.user_key);
-    if (current_route.has_value() ||
-        retry_tenant_state.metadata.contains(key)) {
-        LOG(INFO) << "key=" << key << ", info=object_already_exists";
-        return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
-    }
-    return AllocateAndInsertMetadata(shard, client_id, key, slice_length,
-                                     config, group_id, object_id.tenant_id,
-                                     now);
+    return tl::make_unexpected(ErrorCode::TENANT_QUOTA_EXCEEDED);
 }
 
 auto MasterService::UpsertEnd(const UUID& client_id, const std::string& key,
@@ -5177,6 +5346,7 @@ tl::expected<void, SerializationError> MasterService::PersistState(
         MetadataSerializer metadata_serializer(this);
         SegmentSerializer segment_serializer(&segment_manager_);
         TaskManagerSerializer task_manager_serializer(&task_manager_);
+        TenantQuotaPolicySerializer tenant_quota_policy_serializer(this);
 
         auto metadata_result = metadata_serializer.Serialize();
         if (!metadata_result) {
@@ -5217,6 +5387,27 @@ tl::expected<void, SerializationError> MasterService::PersistState(
         SNAP_LOG_INFO(
             "[Snapshot] task manager serialization_successful, snapshot_id={}",
             snapshot_id);
+
+        std::vector<uint8_t> serialized_tenant_quota_policy;
+        if (enable_tenant_quota_) {
+            auto tenant_quota_policy_result =
+                tenant_quota_policy_serializer.Serialize();
+            if (!tenant_quota_policy_result) {
+                SNAP_LOG_ERROR(
+                    "[Snapshot] tenant quota policy serialization failed, "
+                    "snapshot_id={}, code={}, msg={}",
+                    snapshot_id,
+                    toString(tenant_quota_policy_result.error().code),
+                    tenant_quota_policy_result.error().message);
+                return tl::make_unexpected(tenant_quota_policy_result.error());
+            }
+            serialized_tenant_quota_policy =
+                std::move(tenant_quota_policy_result.value());
+            SNAP_LOG_INFO(
+                "[Snapshot] tenant quota policy serialization_successful, "
+                "snapshot_id={}",
+                snapshot_id);
+        }
 
         const auto& serialized_metadata = metadata_result.value();
         const auto& serialized_segment = segment_result.value();
@@ -5284,6 +5475,27 @@ tl::expected<void, SerializationError> MasterService::PersistState(
             }
             error_msg.append(upload_result.error().message + "\n");
             upload_success = false;
+        }
+
+        if (enable_tenant_quota_) {
+            std::string tenant_quota_policy_path =
+                path_prefix + SNAPSHOT_TENANT_QUOTA_POLICY_FILE;
+            upload_result = UploadSnapshotPayloadFile(
+                serialized_tenant_quota_policy, tenant_quota_policy_path,
+                SNAPSHOT_TENANT_QUOTA_POLICY_FILE, snapshot_id);
+            if (!upload_result) {
+                SNAP_LOG_ERROR(
+                    "[Snapshot] tenant_quota_policy upload failed, "
+                    "snapshot_id={}, path={}, code={}, msg={}",
+                    snapshot_id, tenant_quota_policy_path,
+                    toString(upload_result.error().code),
+                    upload_result.error().message);
+                if (!use_snapshot_backup_dir_) {
+                    return tl::make_unexpected(upload_result.error());
+                }
+                error_msg.append(upload_result.error().message + "\n");
+                upload_success = false;
+            }
         }
 
         // Upload manifest
@@ -5670,9 +5882,50 @@ bool MasterService::TryRestoreStateFromSnapshot(
         }
         LOG(INFO) << "[Restore] Download task manager file success";
 
+        bool has_tenant_quota_policy = false;
+        std::vector<uint8_t> tenant_quota_policy_content;
+        if (enable_tenant_quota_) {
+            std::string tenant_quota_policy_path =
+                path_prefix + SNAPSHOT_TENANT_QUOTA_POLICY_FILE;
+            download_result = snapshot_object_store_->DownloadBuffer(
+                tenant_quota_policy_path, tenant_quota_policy_content);
+            if (!download_result) {
+                if (snapshot_object_store_->IsNotFoundError(
+                        download_result.error())) {
+                    LOG(INFO)
+                        << "[Restore] Tenant quota policy file is missing in "
+                           "snapshot "
+                        << state_id << ", treating as legacy snapshot";
+                } else {
+                    return fail_restore(
+                        "failed to download tenant_quota_policy '" +
+                        tenant_quota_policy_path +
+                        "': " + download_result.error());
+                }
+            } else {
+                has_tenant_quota_policy = true;
+                if (use_snapshot_backup_dir_) {
+                    auto save_result = FileUtil::SaveBinaryToFile(
+                        tenant_quota_policy_content,
+                        fs::path(snapshot_backup_dir_) /
+                            SNAPSHOT_BACKUP_RESTORE_DIR /
+                            SNAPSHOT_TENANT_QUOTA_POLICY_FILE);
+                    if (!save_result) {
+                        LOG(ERROR)
+                            << "[Restore] Failed to save tenant quota policy "
+                               "to file: "
+                            << save_result.error();
+                    }
+                }
+                LOG(INFO)
+                    << "[Restore] Download tenant quota policy file success";
+            }
+        }
+
         SegmentSerializer segment_serializer(&segment_manager_);
         MetadataSerializer metadata_serializer(this);
         TaskManagerSerializer task_manager_serializer(&task_manager_);
+        TenantQuotaPolicySerializer tenant_quota_policy_serializer(this);
 
         auto segments_result = segment_serializer.Deserialize(segments_content);
         if (!segments_result) {
@@ -5692,6 +5945,19 @@ bool MasterService::TryRestoreStateFromSnapshot(
                             metadata_result.error().message));
         }
         LOG(INFO) << "[Restore] Deserialize metadata success";
+
+        if (has_tenant_quota_policy) {
+            auto tenant_quota_policy_result =
+                tenant_quota_policy_serializer.Deserialize(
+                    tenant_quota_policy_content);
+            if (!tenant_quota_policy_result) {
+                return fail_restore(fmt::format(
+                    "failed to deserialize tenant quota policy: {} - {}",
+                    static_cast<int>(tenant_quota_policy_result.error().code),
+                    tenant_quota_policy_result.error().message));
+            }
+            LOG(INFO) << "[Restore] Deserialize tenant quota policy success";
+        }
 
         auto task_manager_result =
             task_manager_serializer.Deserialize(task_manager_content);
@@ -5836,8 +6102,10 @@ void MasterService::ResetStateAfterFailedRestoreAttempt() {
     SegmentSerializer segment_serializer(&segment_manager_);
     MetadataSerializer metadata_serializer(this);
     TaskManagerSerializer task_manager_serializer(&task_manager_);
+    TenantQuotaPolicySerializer tenant_quota_policy_serializer(this);
 
     task_manager_serializer.Reset();
+    tenant_quota_policy_serializer.Reset();
     metadata_serializer.Reset();
     segment_serializer.Reset();
 
@@ -5856,6 +6124,236 @@ void MasterService::ResetStateAfterFailedRestoreAttempt() {
 
 ha::SnapshotCatalogStore* MasterService::GetSnapshotCatalogStore() {
     return snapshot_catalog_store_.get();
+}
+
+MasterService::TenantQuotaEvictionResult
+MasterService::EvictTenantMemoryForQuota(const std::string& tenant_id,
+                                         uint64_t target_bytes) {
+    TenantQuotaEvictionResult total;
+    if (!enable_tenant_quota_ || target_bytes == 0) {
+        return total;
+    }
+
+    const auto normalized_tenant = NormalizeTenantId(tenant_id);
+    auto now = std::chrono::system_clock::now();
+    std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+
+    auto is_evictable_memory_replica = [](const Replica& replica) {
+        return replica.is_memory_replica() && replica.is_completed() &&
+               replica.get_refcnt() == 0;
+    };
+    auto can_evict_replicas = [&](const ObjectMetadata& metadata) {
+        return metadata.HasReplica(is_evictable_memory_replica);
+    };
+    auto has_local_disk_replica = [](const ObjectMetadata& metadata) {
+        return metadata.HasReplica(&Replica::fn_is_local_disk_replica);
+    };
+    auto evict_replicas =
+        [&, this](ObjectMetadata& metadata,
+                  std::vector<std::vector<Replica>>& deferred_replicas) {
+            const uint64_t before_charge = CompletedMemoryQuotaCharge(metadata);
+            auto replicas = PopReplicasWithCacheTotalAccounting(
+                metadata, is_evictable_memory_replica);
+            const uint64_t replica_count = replicas.size();
+            if (!replicas.empty()) {
+                deferred_replicas.emplace_back(std::move(replicas));
+            }
+            const uint64_t after_charge = CompletedMemoryQuotaCharge(metadata);
+            if (before_charge > after_charge) {
+                ReleaseCommittedQuotaCharge(metadata,
+                                            before_charge - after_charge);
+            }
+            return metadata.size * replica_count;
+        };
+    long offload_queued_this_call = 0;
+    long offload_deferred_count = 0;
+    long offload_cap_forced_count = 0;
+    long offload_push_failed_forced = 0;
+    const long offload_cap =
+        offload_on_evict_
+            ? static_cast<long>(offloading_queue_limit_ * kOffloadCapRatio)
+            : 0;
+
+    auto try_evict_or_offload =
+        [&, this](const std::string& key, ObjectMetadata& metadata,
+                  TenantState& tenant_state,
+                  std::vector<std::vector<Replica>>& deferred_replicas) {
+            if (!offload_on_evict_) {
+                return evict_replicas(metadata, deferred_replicas);
+            }
+
+            if (has_local_disk_replica(metadata)) {
+                return evict_replicas(metadata, deferred_replicas);
+            }
+
+            if (offload_force_evict_ &&
+                offload_queued_this_call >= offload_cap) {
+                ++offload_cap_forced_count;
+                return evict_replicas(metadata, deferred_replicas);
+            }
+
+            bool queued = false;
+            metadata.VisitReplicas(
+                is_evictable_memory_replica,
+                [this, &key, &normalized_tenant, &tenant_state, &queued,
+                 &now](Replica& replica) {
+                    if (queued) {
+                        return;
+                    }
+                    auto result = PushOffloadingQueue(
+                        MakeObjectIdentity(key, normalized_tenant), replica);
+                    if (result) {
+                        replica.inc_refcnt();
+                        tenant_state.offloading_tasks.emplace(
+                            key, OffloadingTask{replica.id(), now});
+                        queued = true;
+                    }
+                });
+
+            if (queued) {
+                ++offload_queued_this_call;
+                ++offload_deferred_count;
+                return evict_replicas(metadata, deferred_replicas);
+            }
+
+            if (offload_force_evict_) {
+                ++offload_push_failed_forced;
+                return evict_replicas(metadata, deferred_replicas);
+            }
+            return uint64_t{0};
+        };
+
+    auto try_evict_group_or_object =
+        [&, this](const std::string& key, ObjectMetadata& metadata,
+                  TenantState& tenant_state,
+                  std::vector<std::vector<Replica>>& deferred_replicas,
+                  bool allow_soft_pinned) -> TenantQuotaEvictionResult {
+        if (!metadata.IsGrouped()) {
+            uint64_t freed = try_evict_or_offload(key, metadata, tenant_state,
+                                                  deferred_replicas);
+            return {.freed_bytes = freed,
+                    .evicted_objects = freed > 0 ? 1U : 0U};
+        }
+
+        auto group_it = tenant_state.group_members.find(metadata.group_id);
+        if (group_it == tenant_state.group_members.end()) {
+            uint64_t freed = try_evict_or_offload(key, metadata, tenant_state,
+                                                  deferred_replicas);
+            return {.freed_bytes = freed,
+                    .evicted_objects = freed > 0 ? 1U : 0U};
+        }
+
+        for (const auto& member_key : group_it->second) {
+            auto member_it = tenant_state.metadata.find(member_key);
+            if (member_it != tenant_state.metadata.end() &&
+                !member_it->second.IsLeaseExpired(now)) {
+                return {};
+            }
+        }
+
+        TenantQuotaEvictionResult result;
+        std::vector<std::string> member_keys(group_it->second.begin(),
+                                             group_it->second.end());
+        for (const auto& member_key : member_keys) {
+            auto member_it = tenant_state.metadata.find(member_key);
+            if (member_it == tenant_state.metadata.end()) {
+                continue;
+            }
+            auto& member_metadata = member_it->second;
+            if (member_metadata.IsHardPinned() ||
+                !member_metadata.IsLeaseExpired(now) ||
+                (!allow_soft_pinned && member_metadata.IsSoftPinned(now)) ||
+                !can_evict_replicas(member_metadata)) {
+                continue;
+            }
+
+            const uint64_t freed = try_evict_or_offload(
+                member_key, member_metadata, tenant_state, deferred_replicas);
+            result.freed_bytes += freed;
+            if (freed > 0) {
+                ++result.evicted_objects;
+            }
+            if (member_key != key && !member_metadata.IsValid()) {
+                EraseMetadata(tenant_state, member_it, normalized_tenant);
+            }
+        }
+        return result;
+    };
+
+    auto pass = [&](bool allow_soft_pinned) {
+        for (size_t shard_idx = 0;
+             shard_idx < kNumShards && total.freed_bytes < target_bytes;
+             ++shard_idx) {
+            std::vector<std::vector<Replica>> deferred_replicas;
+            {
+                MetadataShardAccessorRW shard(this, shard_idx);
+                auto tenant_it = shard->tenants.find(normalized_tenant);
+                if (tenant_it == shard->tenants.end()) {
+                    continue;
+                }
+                auto& tenant_state = tenant_it->second;
+                for (auto it = tenant_state.metadata.begin();
+                     it != tenant_state.metadata.end() &&
+                     total.freed_bytes < target_bytes;) {
+                    auto& metadata = it->second;
+                    if (metadata.IsHardPinned() ||
+                        !metadata.IsLeaseExpired(now) ||
+                        (!allow_soft_pinned && metadata.IsSoftPinned(now)) ||
+                        !can_evict_replicas(metadata)) {
+                        ++it;
+                        continue;
+                    }
+
+                    auto evict_result = try_evict_group_or_object(
+                        it->first, metadata, tenant_state, deferred_replicas,
+                        allow_soft_pinned);
+                    total.freed_bytes += evict_result.freed_bytes;
+                    total.evicted_objects += evict_result.evicted_objects;
+                    if (!metadata.IsValid()) {
+                        it = EraseMetadata(tenant_state, it, normalized_tenant);
+                    } else {
+                        ++it;
+                    }
+                }
+                if (tenant_state.Empty()) {
+                    shard->tenants.erase(tenant_it);
+                }
+            }
+        }
+    };
+
+    pass(/*allow_soft_pinned=*/false);
+    if (allow_evict_soft_pinned_objects_ && total.freed_bytes < target_bytes) {
+        pass(/*allow_soft_pinned=*/true);
+    }
+
+    if (total.freed_bytes > 0) {
+        MasterMetricManager::instance().inc_tenant_evict_bytes(
+            normalized_tenant,
+            static_cast<int64_t>(std::min<uint64_t>(
+                total.freed_bytes,
+                static_cast<uint64_t>(std::numeric_limits<int64_t>::max()))));
+    }
+    if (offload_on_evict_ && total.freed_bytes == 0 &&
+        offload_deferred_count > 0) {
+        LOG(WARNING) << "[TENANT-EVICT] No memory freed for tenant "
+                     << normalized_tenant << "; " << offload_deferred_count
+                     << " object(s) deferred for disk offload.";
+    }
+    if (offload_cap_forced_count > 0) {
+        LOG(WARNING) << "[TENANT-EVICT] Offload cap (" << offload_cap
+                     << ") reached for tenant " << normalized_tenant
+                     << "; force-evicted " << offload_cap_forced_count
+                     << " object(s) without disk offload.";
+    }
+    if (offload_push_failed_forced > 0) {
+        LOG(WARNING) << "[TENANT-EVICT] PushOffloadingQueue failed for tenant "
+                     << normalized_tenant << " on "
+                     << offload_push_failed_forced
+                     << " object(s); force-evicted without disk offload "
+                        "(offload_force_evict=true).";
+    }
+    return total;
 }
 
 void MasterService::BatchEvict(double evict_ratio_target,
@@ -6780,6 +7278,150 @@ void MasterService::NofHeartbeatThreadFunc() {
         if (should_unmount) {
             TryUnmountNoFSegmentByHeartbeat(*probe_target, error_reason);
         }
+    }
+}
+
+tl::expected<std::vector<uint8_t>, SerializationError>
+MasterService::TenantQuotaPolicySerializer::Serialize() {
+    if (!service_) {
+        return tl::make_unexpected(
+            SerializationError(ErrorCode::SERIALIZE_FAIL,
+                               "serialize TenantQuotaPolicy service_ is null"));
+    }
+
+    std::map<std::string, uint64_t> explicit_policies;
+    for (size_t i = 0; i < kNumTenantQuotaShards; ++i) {
+        const auto& shard = service_->tenant_quota_shards_[i];
+        std::lock_guard<std::mutex> lock(shard.mutex);
+        for (const auto& [tenant_id, state] : shard.tenants) {
+            if (state.has_explicit_policy) {
+                explicit_policies[tenant_id] = state.requested_quota_bytes;
+            }
+        }
+    }
+
+    msgpack::sbuffer sbuf;
+    msgpack::packer<msgpack::sbuffer> packer(&sbuf);
+    packer.pack_array(3);
+    packer.pack(static_cast<uint32_t>(1));
+    packer.pack(
+        service_->default_tenant_quota_bytes_.load(std::memory_order_relaxed));
+    packer.pack_array(explicit_policies.size());
+    for (const auto& [tenant_id, requested_quota_bytes] : explicit_policies) {
+        packer.pack_array(2);
+        packer.pack(tenant_id);
+        packer.pack(requested_quota_bytes);
+    }
+
+    return std::vector<uint8_t>(
+        reinterpret_cast<const uint8_t*>(sbuf.data()),
+        reinterpret_cast<const uint8_t*>(sbuf.data()) + sbuf.size());
+}
+
+tl::expected<void, SerializationError>
+MasterService::TenantQuotaPolicySerializer::Deserialize(
+    const std::vector<uint8_t>& data) {
+    if (!service_) {
+        return tl::make_unexpected(SerializationError(
+            ErrorCode::DESERIALIZE_FAIL,
+            "deserialize TenantQuotaPolicy service_ is null"));
+    }
+
+    msgpack::object_handle oh;
+    try {
+        oh = msgpack::unpack(reinterpret_cast<const char*>(data.data()),
+                             data.size());
+    } catch (const std::exception& e) {
+        return tl::make_unexpected(SerializationError(
+            ErrorCode::DESERIALIZE_FAIL,
+            "failed to unpack tenant quota policy msgpack: " +
+                std::string(e.what())));
+    }
+
+    const msgpack::object& obj = oh.get();
+    if (obj.type != msgpack::type::ARRAY || obj.via.array.size != 3) {
+        return tl::make_unexpected(
+            SerializationError(ErrorCode::DESERIALIZE_FAIL,
+                               "invalid tenant quota policy root format"));
+    }
+
+    const auto* fields = obj.via.array.ptr;
+    uint32_t version = 0;
+    uint64_t default_requested_quota_bytes = 0;
+    try {
+        version = fields[0].as<uint32_t>();
+        default_requested_quota_bytes = fields[1].as<uint64_t>();
+    } catch (const std::exception& e) {
+        return tl::make_unexpected(SerializationError(
+            ErrorCode::DESERIALIZE_FAIL,
+            "invalid tenant quota policy header: " + std::string(e.what())));
+    }
+    if (version != 1) {
+        return tl::make_unexpected(
+            SerializationError(ErrorCode::DESERIALIZE_FAIL,
+                               "unsupported tenant quota policy version: " +
+                                   std::to_string(version)));
+    }
+
+    const msgpack::object& policies = fields[2];
+    if (policies.type != msgpack::type::ARRAY) {
+        return tl::make_unexpected(
+            SerializationError(ErrorCode::DESERIALIZE_FAIL,
+                               "invalid tenant quota policy list format"));
+    }
+
+    std::map<std::string, uint64_t> explicit_policies;
+    for (uint32_t i = 0; i < policies.via.array.size; ++i) {
+        const auto& policy = policies.via.array.ptr[i];
+        if (policy.type != msgpack::type::ARRAY || policy.via.array.size != 2) {
+            return tl::make_unexpected(
+                SerializationError(ErrorCode::DESERIALIZE_FAIL,
+                                   "invalid tenant quota policy entry format"));
+        }
+        try {
+            std::string tenant_id =
+                NormalizeTenantId(policy.via.array.ptr[0].as<std::string>());
+            uint64_t requested_quota_bytes =
+                policy.via.array.ptr[1].as<uint64_t>();
+            if (requested_quota_bytes == 0) {
+                return tl::make_unexpected(SerializationError(
+                    ErrorCode::DESERIALIZE_FAIL,
+                    "explicit tenant quota policy must be positive"));
+            }
+            explicit_policies[std::move(tenant_id)] = requested_quota_bytes;
+        } catch (const std::exception& e) {
+            return tl::make_unexpected(SerializationError(
+                ErrorCode::DESERIALIZE_FAIL,
+                "invalid tenant quota policy entry: " + std::string(e.what())));
+        }
+    }
+
+    Reset();
+    service_->default_tenant_quota_bytes_.store(default_requested_quota_bytes,
+                                                std::memory_order_relaxed);
+    for (const auto& [tenant_id, requested_quota_bytes] : explicit_policies) {
+        auto& shard =
+            service_->tenant_quota_shards_[service_->getTenantQuotaShardIndex(
+                tenant_id)];
+        std::lock_guard<std::mutex> lock(shard.mutex);
+        auto& state = shard.tenants[tenant_id];
+        state.requested_quota_bytes = requested_quota_bytes;
+        state.has_explicit_policy = true;
+    }
+    return {};
+}
+
+void MasterService::TenantQuotaPolicySerializer::Reset() {
+    if (!service_) {
+        return;
+    }
+    service_->default_tenant_quota_bytes_.store(
+        service_->configured_default_tenant_quota_bytes_,
+        std::memory_order_relaxed);
+    for (size_t i = 0; i < kNumTenantQuotaShards; ++i) {
+        auto& shard = service_->tenant_quota_shards_[i];
+        std::lock_guard<std::mutex> lock(shard.mutex);
+        shard.tenants.clear();
     }
 }
 

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -1054,6 +1054,73 @@ tl::expected<std::string, ErrorCode> WrappedMasterService::ServiceReady() {
     return GetMooncakeStoreVersion();
 }
 
+tl::expected<std::vector<TenantQuotaSnapshot>, ErrorCode>
+WrappedMasterService::ListTenantQuotaSnapshots() {
+    if (!master_service_.IsTenantQuotaEnabled()) {
+        return tl::make_unexpected(ErrorCode::UNAVAILABLE_IN_CURRENT_MODE);
+    }
+    return master_service_.ListTenantQuotaSnapshots();
+}
+
+tl::expected<TenantQuotaSnapshot, ErrorCode>
+WrappedMasterService::GetTenantQuotaSnapshot(const std::string& tenant_id) {
+    if (!master_service_.IsTenantQuotaEnabled()) {
+        return tl::make_unexpected(ErrorCode::UNAVAILABLE_IN_CURRENT_MODE);
+    }
+    auto snapshot = master_service_.GetTenantQuotaSnapshot(tenant_id);
+    if (!snapshot.has_value()) {
+        return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
+    }
+    return snapshot.value();
+}
+
+tl::expected<TenantQuotaSnapshot, ErrorCode>
+WrappedMasterService::UpsertTenantQuotaPolicy(const std::string& tenant_id,
+                                              uint64_t requested_quota_bytes) {
+    if (!master_service_.IsTenantQuotaEnabled()) {
+        return tl::make_unexpected(ErrorCode::UNAVAILABLE_IN_CURRENT_MODE);
+    }
+    return master_service_.UpsertTenantQuotaPolicy(tenant_id,
+                                                   requested_quota_bytes);
+}
+
+tl::expected<std::optional<TenantQuotaSnapshot>, ErrorCode>
+WrappedMasterService::DeleteTenantQuotaPolicy(const std::string& tenant_id) {
+    if (!master_service_.IsTenantQuotaEnabled()) {
+        return tl::make_unexpected(ErrorCode::UNAVAILABLE_IN_CURRENT_MODE);
+    }
+    auto before = master_service_.GetTenantQuotaSnapshot(tenant_id);
+    if (!before.has_value()) {
+        return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
+    }
+    return master_service_.DeleteTenantQuotaPolicy(tenant_id);
+}
+
+tl::expected<uint64_t, ErrorCode>
+WrappedMasterService::GetDefaultTenantQuotaPolicy() {
+    if (!master_service_.IsTenantQuotaEnabled()) {
+        return tl::make_unexpected(ErrorCode::UNAVAILABLE_IN_CURRENT_MODE);
+    }
+    return master_service_.GetDefaultTenantQuotaPolicy();
+}
+
+tl::expected<void, ErrorCode> WrappedMasterService::SetDefaultTenantQuotaPolicy(
+    uint64_t requested_quota_bytes) {
+    if (!master_service_.IsTenantQuotaEnabled()) {
+        return tl::make_unexpected(ErrorCode::UNAVAILABLE_IN_CURRENT_MODE);
+    }
+    master_service_.SetDefaultTenantQuotaPolicy(requested_quota_bytes);
+    return {};
+}
+
+tl::expected<uint64_t, ErrorCode>
+WrappedMasterService::GetTenantQuotaAllocatableCapacityBytes() {
+    if (!master_service_.IsTenantQuotaEnabled()) {
+        return tl::make_unexpected(ErrorCode::UNAVAILABLE_IN_CURRENT_MODE);
+    }
+    return master_service_.GetTenantQuotaAllocatableCapacityBytes();
+}
+
 tl::expected<std::vector<std::string>, ErrorCode>
 WrappedMasterService::GetAllKeysForAdmin() {
     // Compatibility endpoint: /get_all_keys historically listed only the

--- a/mooncake-store/src/tenant_quota.cpp
+++ b/mooncake-store/src/tenant_quota.cpp
@@ -38,6 +38,92 @@ TenantQuotaResult AccountingMismatch(const char* operation,
 
 }  // namespace
 
+std::vector<TenantQuotaAssignment> BuildEffectiveQuotaAssignments(
+    const std::map<std::string, TenantQuotaState>& tenants,
+    uint64_t default_requested_quota_bytes,
+    uint64_t allocatable_capacity_bytes) {
+    unsigned __int128 explicit_requested_sum = 0;
+    std::vector<std::string> explicit_tenants;
+    std::vector<std::string> default_tenants;
+
+    for (const auto& [tenant_id, state] : tenants) {
+        if (state.has_explicit_policy) {
+            explicit_tenants.push_back(tenant_id);
+            explicit_requested_sum += state.requested_quota_bytes;
+        } else if (!IsLazyEmptyTenant(state)) {
+            default_tenants.push_back(tenant_id);
+        }
+    }
+
+    std::map<std::string, uint64_t> assigned;
+    for (const auto& [tenant_id, _] : tenants) {
+        assigned[tenant_id] = 0;
+    }
+
+    auto distribute = [&](const std::vector<std::string>& tenant_ids,
+                          uint64_t capacity, unsigned __int128 denominator,
+                          bool proportional_to_requested) {
+        if (tenant_ids.empty() || capacity == 0 || denominator == 0) {
+            return;
+        }
+
+        std::vector<RemainderShare> shares;
+        shares.reserve(tenant_ids.size());
+        uint64_t base_assigned = 0;
+        for (const auto& tenant_id : tenant_ids) {
+            const auto& state = tenants.at(tenant_id);
+            unsigned __int128 numerator =
+                proportional_to_requested ? state.requested_quota_bytes : 1;
+            unsigned __int128 product =
+                static_cast<unsigned __int128>(capacity) * numerator;
+            uint64_t base = static_cast<uint64_t>(product / denominator);
+            unsigned __int128 remainder = product % denominator;
+            shares.push_back({tenant_id, base, remainder});
+            base_assigned += base;
+        }
+
+        std::sort(shares.begin(), shares.end(),
+                  [](const RemainderShare& lhs, const RemainderShare& rhs) {
+                      if (lhs.remainder != rhs.remainder) {
+                          return lhs.remainder > rhs.remainder;
+                      }
+                      return lhs.tenant_id < rhs.tenant_id;
+                  });
+
+        uint64_t remaining = capacity - base_assigned;
+        for (auto& share : shares) {
+            if (remaining > 0) {
+                ++share.base;
+                --remaining;
+            }
+            assigned[share.tenant_id] = share.base;
+        }
+    };
+
+    if (explicit_requested_sum <= allocatable_capacity_bytes) {
+        for (const auto& tenant_id : explicit_tenants) {
+            assigned[tenant_id] = tenants.at(tenant_id).requested_quota_bytes;
+        }
+        const uint64_t remaining_capacity =
+            allocatable_capacity_bytes -
+            static_cast<uint64_t>(explicit_requested_sum);
+        distribute(default_tenants, remaining_capacity, default_tenants.size(),
+                   /*proportional_to_requested=*/false);
+    } else {
+        distribute(explicit_tenants, allocatable_capacity_bytes,
+                   explicit_requested_sum,
+                   /*proportional_to_requested=*/true);
+    }
+
+    std::vector<TenantQuotaAssignment> result;
+    result.reserve(assigned.size());
+    for (const auto& [tenant_id, effective_quota_bytes] : assigned) {
+        result.push_back({.tenant_id = tenant_id,
+                          .effective_quota_bytes = effective_quota_bytes});
+    }
+    return result;
+}
+
 void TenantQuotaTable::SetDefaultRequestedQuota(uint64_t bytes) {
     default_requested_quota_bytes_ = bytes;
     for (auto& [_, state] : tenants_) {
@@ -77,80 +163,18 @@ void TenantQuotaTable::EraseTenantPolicy(std::string tenant_id) {
 
 void TenantQuotaTable::RecomputeEffectiveQuotas(
     uint64_t allocatable_capacity_bytes) {
-    unsigned __int128 explicit_requested_sum = 0;
-    std::vector<std::string> explicit_tenants;
-    std::vector<std::string> default_tenants;
-
     for (auto& [tenant_id, state] : tenants_) {
-        if (state.has_explicit_policy) {
-            explicit_tenants.push_back(tenant_id);
-            explicit_requested_sum += state.requested_quota_bytes;
-        } else {
+        if (!state.has_explicit_policy) {
             state.requested_quota_bytes = default_requested_quota_bytes_;
-            if (!IsLazyEmptyTenant(state)) {
-                default_tenants.push_back(tenant_id);
-            }
         }
         state.effective_quota_bytes = 0;
     }
 
-    auto distribute = [&](const std::vector<std::string>& tenant_ids,
-                          uint64_t capacity, bool proportional_to_requested) {
-        if (tenant_ids.empty() || capacity == 0) {
-            return;
-        }
-
-        std::vector<RemainderShare> shares;
-        shares.reserve(tenant_ids.size());
-        uint64_t assigned = 0;
-        unsigned __int128 denominator = proportional_to_requested
-                                            ? explicit_requested_sum
-                                            : tenant_ids.size();
-
-        for (const auto& tenant_id : tenant_ids) {
-            auto& state = tenants_.at(tenant_id);
-            unsigned __int128 numerator =
-                proportional_to_requested ? state.requested_quota_bytes : 1;
-            unsigned __int128 product =
-                static_cast<unsigned __int128>(capacity) * numerator;
-            uint64_t base = static_cast<uint64_t>(product / denominator);
-            unsigned __int128 remainder = product % denominator;
-            shares.push_back({tenant_id, base, remainder});
-            assigned += base;
-        }
-
-        std::sort(shares.begin(), shares.end(),
-                  [](const RemainderShare& lhs, const RemainderShare& rhs) {
-                      if (lhs.remainder != rhs.remainder) {
-                          return lhs.remainder > rhs.remainder;
-                      }
-                      return lhs.tenant_id < rhs.tenant_id;
-                  });
-
-        uint64_t remaining = capacity - assigned;
-        for (auto& share : shares) {
-            if (remaining > 0) {
-                ++share.base;
-                --remaining;
-            }
-            tenants_.at(share.tenant_id).effective_quota_bytes = share.base;
-        }
-    };
-
-    if (explicit_requested_sum <= allocatable_capacity_bytes) {
-        for (const auto& tenant_id : explicit_tenants) {
-            auto& state = tenants_.at(tenant_id);
-            state.effective_quota_bytes = state.requested_quota_bytes;
-        }
-
-        const uint64_t remaining_capacity =
-            allocatable_capacity_bytes -
-            static_cast<uint64_t>(explicit_requested_sum);
-        distribute(default_tenants, remaining_capacity,
-                   /*proportional_to_requested=*/false);
-    } else {
-        distribute(explicit_tenants, allocatable_capacity_bytes,
-                   /*proportional_to_requested=*/true);
+    for (const auto& assignment : BuildEffectiveQuotaAssignments(
+             tenants_, default_requested_quota_bytes_,
+             allocatable_capacity_bytes)) {
+        tenants_.at(assignment.tenant_id).effective_quota_bytes =
+            assignment.effective_quota_bytes;
     }
 
     for (auto& [_, state] : tenants_) {

--- a/mooncake-store/tests/master_admin_server_test.cpp
+++ b/mooncake-store/tests/master_admin_server_test.cpp
@@ -117,6 +117,21 @@ class MasterAdminServerTest : public ::testing::Test {
                                   coro_http::req_content_type::json);
         return {result.status, std::string(result.resp_body)};
     }
+
+    HttpResponse HttpPutJson(int port, const std::string& path,
+                             const std::string& body) {
+        coro_http::coro_http_client client;
+        auto result = async_simple::coro::syncAwait(client.async_put(
+            BaseUrl(port) + path, body, coro_http::req_content_type::json));
+        return {result.status, std::string(result.resp_body)};
+    }
+
+    HttpResponse HttpDelete(int port, const std::string& path) {
+        coro_http::coro_http_client client;
+        auto result = async_simple::coro::syncAwait(client.async_delete(
+            BaseUrl(port) + path, "", coro_http::req_content_type::json));
+        return {result.status, std::string(result.resp_body)};
+    }
 };
 
 // =========================================================================
@@ -440,6 +455,10 @@ TEST_F(MasterAdminServerTest, ServiceEndpointsReturn503WhenServiceUnavailable) {
     EXPECT_EQ(seg_status.http_status, 503);
     EXPECT_NE(seg_status.body.find(unavailable_msg), std::string::npos);
 
+    auto tenant_quotas = HttpGet(port, "/api/v1/tenant_quotas");
+    EXPECT_EQ(tenant_quotas.http_status, 503);
+    EXPECT_NE(tenant_quotas.body.find(unavailable_msg), std::string::npos);
+
     auto drain_create = HttpPostJson(port, "/api/v1/drain_jobs", "{}");
     EXPECT_EQ(drain_create.http_status, 503);
 
@@ -453,6 +472,132 @@ TEST_F(MasterAdminServerTest, ServiceEndpointsReturn503WhenServiceUnavailable) {
     auto drain_cancel = HttpPostJson(
         port, "/api/v1/drain_jobs/cancel?job_id=" + valid_uuid, "");
     EXPECT_EQ(drain_cancel.http_status, 503);
+
+    admin.Stop();
+}
+
+TEST_F(MasterAdminServerTest, TenantQuotaAdminLifecycleEndpoints) {
+    WrappedMasterServiceConfig svc_config;
+    svc_config.default_kv_lease_ttl = 5000;
+    svc_config.enable_metric_reporting = false;
+    svc_config.enable_tenant_quota = true;
+    svc_config.default_tenant_quota_bytes = 1000;
+    svc_config.tenant_quota_pool_capacity_bytes = 2000;
+    auto service = std::make_shared<WrappedMasterService>(svc_config);
+
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = "quota_admin_segment";
+    segment.base = 0x600000000;
+    segment.size = 2000;
+    UUID client_id = generate_uuid();
+    ASSERT_TRUE(service->MountSegment(segment, client_id).has_value());
+
+    int port = getFreeTcpPort();
+    MasterAdminServer admin(static_cast<uint16_t>(port), false);
+    ASSERT_TRUE(admin.Start());
+    admin.SetRuntimeState(ha::MasterRuntimeState::kServing);
+    admin.SetServiceDelegate(service);
+    admin.SetServiceAvailable(true);
+
+    auto default_get = HttpGet(port, "/api/v1/tenant_quotas/default");
+    EXPECT_EQ(default_get.http_status, 200);
+    EXPECT_NE(default_get.body.find("\"requested_quota_bytes\":1000"),
+              std::string::npos);
+
+    auto default_put = HttpPutJson(port, "/api/v1/tenant_quotas/default",
+                                   "{\"requested_quota_bytes\":0}");
+    EXPECT_EQ(default_put.http_status, 200);
+    EXPECT_NE(default_put.body.find("\"requested_quota_bytes\":0"),
+              std::string::npos);
+
+    auto upsert = HttpPutJson(port, "/api/v1/tenant_quotas?tenant_id=tenant-a",
+                              "{\"requested_quota_bytes\":800}");
+    EXPECT_EQ(upsert.http_status, 200);
+    EXPECT_NE(upsert.body.find("\"tenant_id\":\"tenant-a\""),
+              std::string::npos);
+    EXPECT_NE(upsert.body.find("\"requested_quota_bytes\":800"),
+              std::string::npos);
+    EXPECT_NE(upsert.body.find("\"effective_quota_bytes\":800"),
+              std::string::npos);
+    EXPECT_NE(upsert.body.find("\"has_explicit_policy\":true"),
+              std::string::npos);
+
+    auto list = HttpGet(port, "/api/v1/tenant_quotas");
+    EXPECT_EQ(list.http_status, 200);
+    EXPECT_NE(list.body.find("\"tenant_id\":\"tenant-a\""), std::string::npos);
+
+    auto one = HttpGet(port, "/api/v1/tenant_quotas?tenant_id=tenant-a");
+    EXPECT_EQ(one.http_status, 200);
+    EXPECT_NE(one.body.find("\"committed_count\":0"), std::string::npos);
+    EXPECT_NE(one.body.find("\"over_quota\":false"), std::string::npos);
+
+    auto deleted = HttpDelete(port, "/api/v1/tenant_quotas?tenant_id=tenant-a");
+    EXPECT_EQ(deleted.http_status, 200);
+
+    auto missing = HttpGet(port, "/api/v1/tenant_quotas?tenant_id=tenant-a");
+    EXPECT_EQ(missing.http_status, 404);
+
+    admin.Stop();
+}
+
+TEST_F(MasterAdminServerTest, TenantQuotaAdminValidationErrors) {
+    WrappedMasterServiceConfig svc_config;
+    svc_config.default_kv_lease_ttl = 5000;
+    svc_config.enable_metric_reporting = false;
+    svc_config.enable_tenant_quota = true;
+    svc_config.default_tenant_quota_bytes = 1000;
+    svc_config.tenant_quota_pool_capacity_bytes = 1000;
+    auto service = std::make_shared<WrappedMasterService>(svc_config);
+
+    int port = getFreeTcpPort();
+    MasterAdminServer admin(static_cast<uint16_t>(port), false);
+    ASSERT_TRUE(admin.Start());
+    admin.SetRuntimeState(ha::MasterRuntimeState::kServing);
+    admin.SetServiceDelegate(service);
+    admin.SetServiceAvailable(true);
+
+    auto missing_tenant = HttpPutJson(port, "/api/v1/tenant_quotas",
+                                      "{\"requested_quota_bytes\":100}");
+    EXPECT_EQ(missing_tenant.http_status, 400);
+
+    auto empty_tenant = HttpPutJson(port, "/api/v1/tenant_quotas?tenant_id=",
+                                    "{\"requested_quota_bytes\":100}");
+    EXPECT_EQ(empty_tenant.http_status, 400);
+
+    auto zero_explicit =
+        HttpPutJson(port, "/api/v1/tenant_quotas?tenant_id=tenant-a",
+                    "{\"requested_quota_bytes\":0}");
+    EXPECT_EQ(zero_explicit.http_status, 400);
+
+    auto reserved_tenant =
+        HttpGet(port, "/api/v1/tenant_quotas?tenant_id=_system");
+    EXPECT_EQ(reserved_tenant.http_status, 400);
+
+    auto missing_query =
+        HttpGet(port, "/api/v1/tenant_quotas?tenant_id=missing");
+    EXPECT_EQ(missing_query.http_status, 404);
+
+    admin.Stop();
+}
+
+TEST_F(MasterAdminServerTest, TenantQuotaAdminDisabledModeReturns409) {
+    WrappedMasterServiceConfig svc_config;
+    svc_config.default_kv_lease_ttl = 5000;
+    svc_config.enable_metric_reporting = false;
+    svc_config.enable_tenant_quota = false;
+    auto service = std::make_shared<WrappedMasterService>(svc_config);
+
+    int port = getFreeTcpPort();
+    MasterAdminServer admin(static_cast<uint16_t>(port), false);
+    ASSERT_TRUE(admin.Start());
+    admin.SetRuntimeState(ha::MasterRuntimeState::kServing);
+    admin.SetServiceDelegate(service);
+    admin.SetServiceAvailable(true);
+
+    auto list = HttpGet(port, "/api/v1/tenant_quotas");
+    EXPECT_EQ(list.http_status, 409);
+    EXPECT_NE(list.body.find("UNAVAILABLE_IN_CURRENT_MODE"), std::string::npos);
 
     admin.Stop();
 }

--- a/mooncake-store/tests/master_service_tenant_quota_test.cpp
+++ b/mooncake-store/tests/master_service_tenant_quota_test.cpp
@@ -1,8 +1,8 @@
 #include "master_service.h"
 
-#include <limits>
 #include <mutex>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -49,6 +49,12 @@ class MasterServiceTenantQuotaTest : public ::testing::Test {
         return config;
     }
 
+    ReplicateConfig HardPinnedMemoryConfig() {
+        ReplicateConfig config = MemoryConfig();
+        config.with_hard_pin = true;
+        return config;
+    }
+
     MasterServiceConfig MakeOffloadConfig(uint64_t default_quota,
                                           uint64_t pool_capacity) {
         auto config = MakeConfig(default_quota, pool_capacity);
@@ -63,8 +69,13 @@ class MasterServiceTenantQuotaTest : public ::testing::Test {
     void PutComplete(MasterService& service, const UUID& client_id,
                      const std::string& key, const std::string& tenant_id,
                      uint64_t size) {
-        auto start =
-            service.PutStart(client_id, key, tenant_id, size, MemoryConfig());
+        PutComplete(service, client_id, key, tenant_id, size, MemoryConfig());
+    }
+
+    void PutComplete(MasterService& service, const UUID& client_id,
+                     const std::string& key, const std::string& tenant_id,
+                     uint64_t size, const ReplicateConfig& config) {
+        auto start = service.PutStart(client_id, key, tenant_id, size, config);
         ASSERT_TRUE(start.has_value()) << toString(start.error());
         auto end =
             service.PutEnd(client_id, key, tenant_id, ReplicaType::MEMORY);
@@ -74,6 +85,20 @@ class MasterServiceTenantQuotaTest : public ::testing::Test {
     void MountLocalDiskSegment(MasterService& service, const UUID& client_id) {
         auto mount = service.MountLocalDiskSegment(client_id, true);
         ASSERT_TRUE(mount.has_value()) << toString(mount.error());
+    }
+
+    std::unordered_map<std::string, int64_t> DrainOffloadQueue(
+        MasterService& service, const UUID& client_id) {
+        auto result = service.OffloadObjectHeartbeat(client_id, true);
+        EXPECT_TRUE(result.has_value());
+        std::unordered_map<std::string, int64_t> queued;
+        if (!result.has_value()) {
+            return queued;
+        }
+        for (const auto& task : result.value()) {
+            queued[task.key] = task.size;
+        }
+        return queued;
     }
 
     void InjectLocalDiskReplica(MasterService& service, const UUID& client_id,
@@ -124,6 +149,11 @@ class MasterServiceTenantQuotaTest : public ::testing::Test {
     void ReleaseQuotaPartial(MasterService& service,
                              const std::string& tenant_id, uint64_t bytes) {
         service.ReleaseTenantQuotaPartial(tenant_id, bytes);
+    }
+
+    uint64_t ComputeQuotaDeficit(MasterService& service,
+                                 const std::string& tenant_id, uint64_t bytes) {
+        return service.ComputeTenantQuotaDeficit(tenant_id, bytes);
     }
 
     void RecomputeTenantQuotas(MasterService& service) {
@@ -208,7 +238,8 @@ TEST_F(MasterServiceTenantQuotaTest, SameTenantSharesQuotaAcrossKeys) {
                                      /*pool_capacity=*/1000));
     UUID client_id = MountSegment(service);
 
-    PutComplete(service, client_id, "key-a", "tenant-a", 600);
+    PutComplete(service, client_id, "key-a", "tenant-a", 600,
+                HardPinnedMemoryConfig());
     auto over_quota =
         service.PutStart(client_id, "key-b", "tenant-a", 500, MemoryConfig());
 
@@ -244,17 +275,17 @@ TEST_F(MasterServiceTenantQuotaTest, FirstTenantPutStartUsesPoolCapacity) {
 }
 
 TEST_F(MasterServiceTenantQuotaTest,
-       ZeroDefaultQuotaInitializesNewTenantAsUnlimited) {
+       ZeroDefaultQuotaUsesRegisteredCapacityForDefaultTenant) {
     MasterService service(MakeConfig(/*default_quota=*/0,
-                                     /*pool_capacity=*/1));
+                                     /*pool_capacity=*/0));
+    MountSegment(service, /*size=*/4096);
 
     auto reserve = ReserveQuota(service, "tenant-a", 4096);
 
     ASSERT_TRUE(reserve.has_value()) << toString(reserve.error());
     auto snapshot = Snapshot(service, "tenant-a");
     EXPECT_EQ(snapshot.requested_quota_bytes, 0);
-    EXPECT_EQ(snapshot.effective_quota_bytes,
-              std::numeric_limits<uint64_t>::max());
+    EXPECT_EQ(snapshot.effective_quota_bytes, 4096);
     EXPECT_EQ(snapshot.reserved_bytes, 4096);
 }
 
@@ -262,6 +293,7 @@ TEST_F(MasterServiceTenantQuotaTest,
        OverQuotaReserveDoesNotChangeReservedBytes) {
     MasterService service(MakeConfig(/*default_quota=*/100,
                                      /*pool_capacity=*/100));
+    MountSegment(service, /*size=*/100);
     ASSERT_TRUE(ReserveQuota(service, "tenant-a", 80).has_value());
     auto before = Snapshot(service, "tenant-a");
 
@@ -270,6 +302,18 @@ TEST_F(MasterServiceTenantQuotaTest,
     ASSERT_FALSE(reserve.has_value());
     EXPECT_EQ(reserve.error(), ErrorCode::TENANT_QUOTA_EXCEEDED);
     ExpectSameAccounting(before, Snapshot(service, "tenant-a"));
+}
+
+TEST_F(MasterServiceTenantQuotaTest,
+       QuotaDeficitReturnsZeroWhenCurrentDemandFits) {
+    MasterService service(MakeConfig(/*default_quota=*/1000,
+                                     /*pool_capacity=*/1000));
+    MountSegment(service, /*size=*/1000);
+    ASSERT_TRUE(ReserveQuota(service, "tenant-a", 400).has_value());
+    CommitQuota(service, "tenant-a", 400);
+
+    EXPECT_EQ(ComputeQuotaDeficit(service, "tenant-a", 100), 0);
+    EXPECT_EQ(ComputeQuotaDeficit(service, "tenant-a", 700), 100);
 }
 
 TEST_F(MasterServiceTenantQuotaTest,
@@ -306,6 +350,7 @@ TEST_F(MasterServiceTenantQuotaTest,
        AbortPrunesInactiveInheritedTenantAndRecomputesQuotas) {
     MasterService service(MakeConfig(/*default_quota=*/1000,
                                      /*pool_capacity=*/100));
+    MountSegment(service, /*size=*/100);
 
     ASSERT_TRUE(ReserveQuota(service, "tenant-a", 50).has_value());
     ASSERT_TRUE(ReserveQuota(service, "tenant-b", 40).has_value());
@@ -346,6 +391,7 @@ TEST_F(MasterServiceTenantQuotaTest,
 TEST_F(MasterServiceTenantQuotaTest, CommitMismatchDoesNotMutateAccounting) {
     MasterService service(MakeConfig(/*default_quota=*/100,
                                      /*pool_capacity=*/100));
+    MountSegment(service, /*size=*/100);
     ASSERT_TRUE(ReserveQuota(service, "tenant-a", 40).has_value());
     auto before = Snapshot(service, "tenant-a");
 
@@ -357,6 +403,7 @@ TEST_F(MasterServiceTenantQuotaTest, CommitMismatchDoesNotMutateAccounting) {
 TEST_F(MasterServiceTenantQuotaTest, AbortMismatchDoesNotMutateAccounting) {
     MasterService service(MakeConfig(/*default_quota=*/100,
                                      /*pool_capacity=*/100));
+    MountSegment(service, /*size=*/100);
     ASSERT_TRUE(ReserveQuota(service, "tenant-a", 40).has_value());
     auto before = Snapshot(service, "tenant-a");
 
@@ -368,6 +415,7 @@ TEST_F(MasterServiceTenantQuotaTest, AbortMismatchDoesNotMutateAccounting) {
 TEST_F(MasterServiceTenantQuotaTest, ReleaseMismatchDoesNotMutateAccounting) {
     MasterService service(MakeConfig(/*default_quota=*/100,
                                      /*pool_capacity=*/100));
+    MountSegment(service, /*size=*/100);
     ASSERT_TRUE(ReserveQuota(service, "tenant-a", 40).has_value());
     CommitQuota(service, "tenant-a", 40);
     auto before = Snapshot(service, "tenant-a");
@@ -381,6 +429,7 @@ TEST_F(MasterServiceTenantQuotaTest,
        ReleasePartialMismatchDoesNotMutateAccounting) {
     MasterService service(MakeConfig(/*default_quota=*/100,
                                      /*pool_capacity=*/100));
+    MountSegment(service, /*size=*/100);
     ASSERT_TRUE(ReserveQuota(service, "tenant-a", 40).has_value());
     CommitQuota(service, "tenant-a", 40);
     auto before = Snapshot(service, "tenant-a");
@@ -391,7 +440,7 @@ TEST_F(MasterServiceTenantQuotaTest,
 }
 
 TEST_F(MasterServiceTenantQuotaTest,
-       PhysicalAllocationFailureKeepsAllocatorError) {
+       RegisteredCapacityQuotaFailurePrecedesAllocatorFailure) {
     MasterService service(MakeConfig(/*default_quota=*/4096,
                                      /*pool_capacity=*/4096));
     UUID client_id = MountSegment(service, /*size=*/512);
@@ -400,7 +449,7 @@ TEST_F(MasterServiceTenantQuotaTest,
                                    MemoryConfig());
 
     ASSERT_FALSE(result.has_value());
-    EXPECT_EQ(result.error(), ErrorCode::NO_AVAILABLE_HANDLE);
+    EXPECT_EQ(result.error(), ErrorCode::TENANT_QUOTA_EXCEEDED);
     EXPECT_FALSE(
         service.GetTenantQuotaSnapshotForTesting("tenant-a").has_value());
 }
@@ -444,9 +493,45 @@ TEST_F(MasterServiceTenantQuotaTest,
     ASSERT_TRUE(revoke.has_value()) << toString(revoke.error());
 }
 
-TEST_F(MasterServiceTenantQuotaTest, PromotionSuccessCommitsTenantQuota) {
+TEST_F(MasterServiceTenantQuotaTest,
+       TenantQuotaEvictionQueuesOffloadOnEvictBeforeDeletingMemory) {
     MasterService service(MakeOffloadConfig(/*default_quota=*/1000,
                                             /*pool_capacity=*/1000));
+    UUID client_id =
+        MountSegment(service, /*size=*/4096, "quota_offload_segment");
+    MountLocalDiskSegment(service, client_id);
+
+    PutComplete(service, client_id, "old", "tenant-a", 600);
+    EXPECT_TRUE(DrainOffloadQueue(service, client_id).empty())
+        << "offload_on_evict should not queue objects at PutEnd";
+
+    auto start =
+        service.PutStart(client_id, "new", "tenant-a", 600, MemoryConfig());
+    ASSERT_FALSE(start.has_value());
+    EXPECT_EQ(start.error(), ErrorCode::TENANT_QUOTA_EXCEEDED);
+
+    auto queued = DrainOffloadQueue(service, client_id);
+    ASSERT_EQ(queued.size(), 1u);
+    EXPECT_EQ(queued["old"], 600);
+    EXPECT_TRUE(service.GetReplicaList("old", "tenant-a").has_value());
+    EXPECT_EQ(Snapshot(service, "tenant-a").used_bytes, 600);
+
+    InjectLocalDiskReplica(service, client_id, "old", "tenant-a", 600,
+                           "quota_offload_segment");
+    auto retry =
+        service.PutStart(client_id, "new", "tenant-a", 600, MemoryConfig());
+    ASSERT_TRUE(retry.has_value()) << toString(retry.error());
+    EXPECT_TRUE(service.GetReplicaList("old", "tenant-a").has_value());
+    auto revoke =
+        service.PutRevoke(client_id, "new", "tenant-a", ReplicaType::MEMORY);
+    ASSERT_TRUE(revoke.has_value()) << toString(revoke.error());
+}
+
+TEST_F(MasterServiceTenantQuotaTest, PromotionSuccessCommitsTenantQuota) {
+    auto config = MakeOffloadConfig(/*default_quota=*/1000,
+                                    /*pool_capacity=*/1000);
+    config.default_kv_lease_ttl = 5000;
+    MasterService service(config);
     UUID client_id =
         MountSegment(service, /*size=*/4096, "quota_promotion_segment");
     MountLocalDiskSegment(service, client_id);
@@ -466,6 +551,7 @@ TEST_F(MasterServiceTenantQuotaTest, PromotionSuccessCommitsTenantQuota) {
 
     EXPECT_EQ(Snapshot(service, "tenant-a").used_bytes, 400);
     EXPECT_EQ(Snapshot(service, "tenant-a").reserved_bytes, 0);
+    ASSERT_TRUE(service.GetReplicaList("cold", "tenant-a").has_value());
     auto over_quota = service.PutStart(client_id, "too-much", "tenant-a", 700,
                                        MemoryConfig());
     ASSERT_FALSE(over_quota.has_value());


### PR DESCRIPTION
## Description

Part of https://github.com/kvcache-ai/Mooncake/issues/2153

This PR builds on the merged master admission work and completes the next Mooncake Store tenant quota layer:

- Adds explicit tenant quota policy management to `MasterService` and `WrappedMasterService`.
- Adds tenant quota admin HTTP APIs under `/api/v1/tenant_quotas`, including list/query/upsert/delete and default policy get/set.
- Implements tenant-scoped quota eviction and bounded reserve retry for `PutStart` and size-changing `UpsertStart`.
- Preserves `offload_on_evict` semantics during tenant quota eviction by queueing candidates through the offload path before releasing their only memory copy.
- Adds tenant quota Prometheus metrics for per-tenant gauges, reject counters, tenant eviction bytes, and global quota capacity/sum gauges.
- Persists requested tenant quota policy in a separate `tenant_quota_policy` snapshot object and restores effective quota from current capacity.
- Documents tenant quota behavior, admin APIs, metrics, startup flags, and snapshot behavior.

`enable_tenant_quota=false` keeps the existing compatibility behavior. Tenant quota admin endpoints return `UNAVAILABLE_IN_CURRENT_MODE` in that mode.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
./scripts/code_format.sh
cmake --build build --parallel
ctest --test-dir build -R "tenant_quota_test|master_service_tenant_quota_test|master_admin_server_test|offload_on_evict_test" --output-on-failure
build/mooncake-store/tests/master_service_tenant_quota_test --gtest_filter=MasterServiceTenantQuotaTest.TenantQuotaEvictionQueuesOffloadOnEvictBeforeDeletingMemory --gtest_brief=1
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

All listed commands passed locally. Commit-time pre-commit hooks also passed for the committed changes.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue

RFC issue: https://github.com/kvcache-ai/Mooncake/issues/2153

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

OpenAI Codex was used to help implement, review, test, and document this change. I reviewed and edited the generated code before submission.