### PR TITLE
[codex] docs: sync store metadata guidance

### DIFF
--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -472,7 +472,7 @@ Arguments of `MooncakeDistributedStore.setup(...)`:
 | `global_segment_size` | int (bytes) | required | DRAM contributed to the cluster (the sample uses 3.2 GB) |
 | `local_buffer_size` | int (bytes) | required | Transfer Engine buffer |
 | `protocol` | str | required | `tcp` / `rdma` / `cxl` / `ascend` |
-| `rdma_devices` | str | required | RDMA NIC(s), comma-separated (pass `""` for non-RDMA). **Keyword is `rdma_devices`, not `device_name`** |
+| `rdma_devices` | str | required | RDMA/EFA NIC(s), comma-separated. Leave `""` to auto-discover for RDMA/EFA unless `MC_MS_AUTO_DISC=0`; always use `""` for TCP. **Keyword is `rdma_devices`, not `device_name`** |
 | `master_server_addr` | str | required | Master `host:port`. **Keyword is `master_server_addr`, not `master_server_address`** |
 | `engine` | TransferEngine | `None` | *(advanced)* Reuse an existing Transfer Engine instance instead of creating one |
 | `enable_ssd_offload` | bool | `false` | *(advanced)* Enable client-side SSD offload |
@@ -500,7 +500,7 @@ The store service CLI only accepts `--config`, `-D/--define`, `--port`, and `--m
 | `MOONCAKE_MASTER` | `master_server_addr` | — (required unless `MOONCAKE_CONFIG_PATH`) | Master `host:port` |
 | `MOONCAKE_TE_META_DATA_SERVER` | `metadata_server` | `P2PHANDSHAKE` | `P2PHANDSHAKE` / `http://…:8080/metadata` / etcd address |
 | `MOONCAKE_PROTOCOL` | `protocol` | `tcp` | `tcp` / `rdma` / `cxl` / `ascend` |
-| `MOONCAKE_DEVICE` | `rdma_devices` | empty | RDMA device(s), comma-separated; `auto-discovery` supported |
+| `MOONCAKE_DEVICE` | `rdma_devices` | empty | RDMA/EFA device(s), comma-separated. Leave empty for auto-discovery unless `MC_MS_AUTO_DISC=0` |
 | `MOONCAKE_GLOBAL_SEGMENT_SIZE` | `global_segment_size` | `3355443200` (3.125 GiB) | DRAM contributed; accepts byte integer **or** suffixed form like `500gb` |
 | `MOONCAKE_LOCAL_BUFFER_SIZE` | `local_buffer_size` | `1073741824` (1 GiB) | Transfer Engine buffer; same parsing as above |
 | `MOONCAKE_LOCAL_HOSTNAME` | `local_hostname` | `localhost` | |

--- a/docs/source/getting_started/supported-protocols.md
+++ b/docs/source/getting_started/supported-protocols.md
@@ -90,14 +90,14 @@ engine.initialize(
     hostname="node1",
     metadata_server="P2PHANDSHAKE",
     protocol="rdma",
-    device_name="auto-discovery"  # Automatically detect optimal device
+    device_name=""  # Empty string enables auto-discovery
 )
 ```
 
 ```bash
 # Environment variables
 export MOONCAKE_PROTOCOL="rdma"
-export MOONCAKE_DEVICE="mlx5_0"  # or "auto-discovery"
+export MOONCAKE_DEVICE="mlx5_0"  # or leave empty for auto-discovery
 ```
 
 **Device Discovery:**
@@ -306,7 +306,7 @@ export MOONCAKE_DEVICE="mlx5_0"
 
 # RDMA with auto-discovery
 export MOONCAKE_PROTOCOL="rdma"
-export MOONCAKE_DEVICE="auto-discovery"
+export MOONCAKE_DEVICE=""
 
 # Other configuration
 export MOONCAKE_MASTER="10.0.0.1:50051"

--- a/docs/source/python-api-reference/mooncake-store.md
+++ b/docs/source/python-api-reference/mooncake-store.md
@@ -12,9 +12,13 @@ pip install mooncake-transfer-engine
 📦 **Package Details**: [https://pypi.org/project/mooncake-transfer-engine/](https://pypi.org/project/mooncake-transfer-engine/)
 
 ### Required Service
-Only one service is required now:
+The only always-required service is:
 
-- `mooncake_master` — Master service which now embeds the HTTP metadata server
+- `mooncake_master` — Master service for cluster membership and object placement
+
+For Transfer Engine metadata, use the `P2PHANDSHAKE` connection string for
+decentralized peer discovery, enable the master's embedded HTTP metadata
+server, or provide an external metadata service.
 
 ## Quick Start
 
@@ -60,13 +64,17 @@ print(data.decode())  # Output: Hello, Mooncake Store!
 store.close()
 ```
 
-**RDMA device selection**: Leave `rdma_devices` as `""` to auto-select RDMA NICs. Provide a comma-separated list (e.g. `"mlx5_0,mlx5_1"`) to pin to specific hardware.
+**RDMA device selection**: For `protocol="rdma"` or `protocol="efa"`, leave
+`rdma_devices` as `""` to auto-discover NICs. Set `MC_MS_AUTO_DISC=0` when you
+want auto-discovery disabled, then provide a comma-separated list such as
+`"mlx5_0,mlx5_1"` to pin specific hardware.
 
 Mooncake selects available ports internally at `setup() `, so you do not need to fix specific port numbers in these examples. Internally, ports are chosen from a dynamic range (currently 12300–14300).
 
-#### P2P Hello World (preview)
+#### P2P Hello World
 
-The following setup uses the new P2P handshake and does not require an HTTP metadata server. This feature is not released yet; use only if you’re testing the latest code.
+The following setup uses P2P handshake and does not require an HTTP metadata
+server. Pass the literal `P2PHANDSHAKE` value as the metadata server.
 
 ```python
 from mooncake.store import MooncakeDistributedStore
@@ -937,11 +945,14 @@ print("Retrieved all keys successfully:", retrieved == values)
 
 ## Topology & Devices
 
-- Auto-discovery: Disabled by default. For `protocol="rdma"`, you must specify RDMA devices.
-- Enable auto-discovery (optional):
-  - `MC_MS_AUTO_DISC=1` enables auto-discovery; then `rdma_devices` is not required.
-  - Optionally restrict candidates with `MC_MS_FILTERS`, a comma-separated whitelist of NIC names, e.g. `MC_MS_FILTERS=mlx5_0,mlx5_2`.
-  - If `MC_MS_AUTO_DISC` is not set or set to `0`, auto-discovery remains disabled and `rdma_devices` is required for RDMA.
+- Auto-discovery: Enabled by default for `protocol="rdma"` or `protocol="efa"`
+  when `rdma_devices` is empty.
+- Discovery controls:
+  - `MC_MS_AUTO_DISC=1` forces auto-discovery; then `rdma_devices` is ignored.
+  - `MC_MS_AUTO_DISC=0` disables auto-discovery; then `rdma_devices` is required
+    for RDMA/EFA.
+  - `MC_MS_FILTERS` restricts auto-discovery to a comma-separated whitelist of
+    NIC names, e.g. `MC_MS_FILTERS=mlx5_0,mlx5_2`.
 
 Examples:
 
@@ -1022,22 +1033,30 @@ def setup(
     self,
     local_hostname: str,
     metadata_server: str,
-    global_segment_size: int = 16777216,
-    local_buffer_size: int = 1073741824,
-    protocol: str = "tcp",
-    rdma_devices: str = "",
+    global_segment_size: int,
+    local_buffer_size: int,
+    protocol: str,
+    rdma_devices: str,
     master_server_addr: str,
+    engine: Optional[TransferEngine] = None,
+    enable_ssd_offload: bool = False,
+    ssd_offload_path: str = "",
+    tenant_id: str = "default",
 ) -> int
 ```
 
 **Parameters:**
 - `local_hostname` (str): **Required**. Local hostname and port (e.g., "localhost" or "localhost:12345")
-- `metadata_server` (str): **Required**. Metadata server address (e.g., "http://localhost:8080/metadata")
-- `global_segment_size` (int): Memory segment size in bytes for mounting (default: 16MB = 16777216)
-- `local_buffer_size` (int): Local buffer size in bytes (default: 1GB = 1073741824)
-- `protocol` (str): Network protocol - "tcp" or "rdma" (default: "tcp")
-- `rdma_devices` (str): RDMA device name(s), e.g. `"mlx5_0"` or `"mlx5_0,mlx5_1"`. Leave empty to auto-select NICs. Provide device names to pin the NICs. Always empty for TCP.
+- `metadata_server` (str): **Required**. Metadata connection string, e.g. `"P2PHANDSHAKE"` or `"http://localhost:8080/metadata"`.
+- `global_segment_size` (int): Memory segment size in bytes for mounting.
+- `local_buffer_size` (int): Local buffer size in bytes.
+- `protocol` (str): Network protocol, usually `"tcp"` or `"rdma"`.
+- `rdma_devices` (str): RDMA/EFA device name(s), e.g. `"mlx5_0"` or `"mlx5_0,mlx5_1"`. Leave empty to auto-discover NICs unless `MC_MS_AUTO_DISC=0`; always empty for TCP.
 - `master_server_addr` (str): **Required**. Master server address (e.g., "localhost:50051")
+- `engine` (Optional[TransferEngine]): Existing Transfer Engine instance to reuse. Defaults to `None`.
+- `enable_ssd_offload` (bool): Enable client-side SSD offload support. Defaults to `False`.
+- `ssd_offload_path` (str): SSD offload directory. When provided, overrides the storage path environment configuration.
+- `tenant_id` (str): Tenant namespace for object keys. Defaults to `"default"`.
 
 **Returns:**
 - `int`: Status code (0 = success, non-zero = error code)


### PR DESCRIPTION
## Description

This PR fixes a docs-only mismatch between the current Mooncake Store setup documentation and the behavior implemented in the Store / Transfer Engine code.

### `P2PHANDSHAKE` Is A Supported Metadata Mode

The Python Store API docs currently describe `P2PHANDSHAKE` as a preview or latest-code-only feature.

Code evidence:
- `mooncake-transfer-engine/include/transfer_metadata.h` defines `P2PHANDSHAKE`.
- `mooncake-transfer-engine/src/transfer_engine.cpp` routes `P2PHANDSHAKE` to P2P metadata mode.
- `mooncake-transfer-engine/src/transfer_engine_impl.cpp` contains the P2P handshake binding path.

Why this docs change is needed:
Users should not be told that a supported metadata path is unreleased. The updated docs present `P2PHANDSHAKE` as a normal option for simple deployments that do not need HTTP, etcd, or Redis metadata services.

### RDMA/EFA Auto-Discovery Is The Default When Devices Are Empty

The docs currently imply that RDMA devices must be specified unless auto-discovery is explicitly enabled.

Code evidence:
- `mooncake-store/src/client_service.cpp::get_auto_discover()` reads `MC_MS_AUTO_DISC`.
- `Client::InitTransferEngine()` enables auto-discovery for `rdma` and `efa` when no device names are provided.
- The same code only requires explicit device names when auto-discovery is disabled.

Why this docs change is needed:
The old wording makes users overconfigure NIC names and hides the intended default behavior. The docs now explain that empty `rdma_devices` enables discovery, while `MC_MS_AUTO_DISC=0` is the opt-out.

### `auto-discovery` Is Not A Device-Name Sentinel

The docs currently show `auto-discovery` as a value for `device_name` / `MOONCAKE_DEVICE`.

Code evidence:
- `mooncake-store/src/real_client.cpp::setup_internal()` converts an empty `rdma_devices` string to `std::nullopt`.
- Any non-empty string is treated as explicit device input.
- `MooncakeConfig.load_from_env()` forwards `MOONCAKE_DEVICE` into that same field.

Why this docs change is needed:
Passing `auto-discovery` does not trigger a special mode in this path; it can be interpreted as a literal device name. The examples now use an empty value to trigger discovery.

### `MooncakeDistributedStore.setup()` Docs Lag Behind The Binding

The Python API reference omits supported setup parameters.

Code evidence:
- `mooncake-integration/store/store_py.cpp` exposes `engine`, `enable_ssd_offload`, `ssd_offload_path`, and `tenant_id` in the pybind `MooncakeDistributedStore.setup()` definition.
- The binding forwards those values to `setup_real()`.

Why this docs change is needed:
Users need the API reference to expose supported setup paths for reusing an existing Transfer Engine, enabling client-side SSD offload, selecting an offload directory, and setting tenant isolation.

This pull request was generated entirely by AI using OpenAI Codex and requires human review before merge.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
git diff --check
rg -n 'device_name="auto-discovery"|MOONCAKE_DEVICE="auto-discovery"|`auto-discovery` supported|or "auto-discovery"' docs/source/python-api-reference/mooncake-store.md docs/source/deployment/mooncake-store-deployment-guide.md docs/source/getting_started/supported-protocols.md
pre-commit run --files docs/source/python-api-reference/mooncake-store.md docs/source/deployment/mooncake-store-deployment-guide.md docs/source/getting_started/supported-protocols.md
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

Manual validation: checked the documented behavior against `Client::InitTransferEngine`, `RealClient::setup_internal`, `MooncakeDistributedStore.setup`, and `MooncakeConfig.load_from_env`. File-scoped pre-commit hooks passed for the changed Markdown files, including trailing whitespace, EOF fixer, merge-conflict, large-file, Mooncake code format, and codespell. Sphinx docs build was not run because Sphinx is not installed in the available Python runtimes.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Generated entirely by OpenAI Codex. No human-authored changes are included in this pull request. Human review is required before merge.
