### PR TITLE
[Bugfix] Set Ascend context in batch get worker

### DIFF
--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -4152,15 +4152,6 @@ RealClient::batch_get_into_dummy_helper(
     const std::vector<uint64_t> &dummy_buffers,
     const std::vector<size_t> &sizes, int32_t device_id,
     const UUID &client_id) {
-#ifdef USE_ASCEND_DIRECT
-    if (!ContextManager::getInstance().setCurrentContextByPhysicalId(
-            device_id)) {
-        LOG(ERROR) << "Failed to set context for physical device " << device_id;
-        co_return std::vector<tl::expected<int64_t, ErrorCode>>(
-            keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
-    }
-#endif
-
     // Hold shared_lock for the entire operation to prevent SHM from being
     // unmapped while batch_get_into_internal is using the translated buffers.
     auto lock = std::make_shared<std::shared_lock<std::shared_mutex>>(
@@ -4205,12 +4196,11 @@ RealClient::batch_get_into_dummy_helper(
     auto *s = state.get();
     auto try_result = co_await coro_io::post([this, s]() {
 #ifdef USE_ASCEND_DIRECT
-        if (!ContextManager::getInstance().setCurrentContextByPhysicalId(
-                s->device_id)) {
-            LOG(ERROR) << "Failed to set context for physical device "
-                       << s->device_id << " in batch_get worker";
+        auto context_result =
+            set_context_if_needed(protocol, s->device_id, "batch_get worker");
+        if (!context_result) {
             return std::vector<tl::expected<int64_t, ErrorCode>>(
-                s->keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
+                s->keys.size(), tl::unexpected(context_result.error()));
         }
 #endif
         return batch_get_into_internal(s->keys, s->buffers, s->sizes);

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -4193,15 +4193,26 @@ RealClient::batch_get_into_dummy_helper(
         std::vector<size_t> sizes;
         std::vector<void *> buffers;
         std::shared_ptr<std::shared_lock<std::shared_mutex>> lock;
+        int32_t device_id;
     };
     auto state = std::make_unique<CallState>();
     state->keys = keys;
     state->sizes = sizes;
     state->buffers = std::move(buffers_result.value());
     state->lock = std::move(lock);
+    state->device_id = device_id;
 
     auto *s = state.get();
     auto try_result = co_await coro_io::post([this, s]() {
+#ifdef USE_ASCEND_DIRECT
+        if (!ContextManager::getInstance().setCurrentContextByPhysicalId(
+                s->device_id)) {
+            LOG(ERROR) << "Failed to set context for physical device "
+                       << s->device_id << " in batch_get worker";
+            return std::vector<tl::expected<int64_t, ErrorCode>>(
+                s->keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
+        }
+#endif
         return batch_get_into_internal(s->keys, s->buffers, s->sizes);
     });
     co_return try_result.value();


### PR DESCRIPTION
## Description

This PR fixes an Ascend Direct context issue in the Mooncake Store batch get
path.

`batch_get_into_dummy_helper()` posts the actual `batch_get_into_internal()`
work to a worker thread. For `USE_ASCEND_DIRECT` builds, the worker thread also
needs to set the current Ascend context using the physical `device_id` before
touching device-related buffers.

This change carries `device_id` into the async call state and sets the current
context inside the posted worker task. If the context cannot be set, the batch
get request fails early with `ErrorCode::INVALID_PARAMS` instead of continuing
with an invalid or missing device context.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

This patch has been checked for whitespace issues and target-built in an
internal ARM64 Ascend K8s test container.

The targeted build was configured with `USE_ASCEND_DIRECT=ON`.
The changed C++ file was also checked with `./scripts/code_format.sh`.

`pre-commit run --all-files` was attempted in the same test container, but it
could not initialize hook environments because fetching
`https://github.com/astral-sh/ruff-pre-commit/` timed out before any hooks ran.

Runtime `ctest` was attempted for `dummy_client_get_buffer_test`, but the test
process failed during stack setup before reaching the batch get path because
Ascend transport initialization reported a missing runtime context
(`ctx is NULL`). The executable itself built successfully in the same
configuration.

**Test commands:**

```bash
git diff --check HEAD~1..HEAD

./scripts/code_format.sh --base HEAD~1
./scripts/code_format.sh --check --base HEAD~1

cmake .. \
  -DUSE_ASCEND_DIRECT=ON \
  -DUSE_HTTP=OFF \
  -DUSE_ETCD=ON \
  -DSTORE_USE_ETCD=ON \
  -DBUILD_UNIT_TESTS=ON \
  -DWITH_STORE_RUST=OFF \
  -DCMAKE_BUILD_TYPE=Debug

cmake --build . --target dummy_client_get_buffer_test -j16
ctest -R dummy_client_get_buffer_test --output-on-failure
```

**Test results:**

- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

Manual testing result: `dummy_client_get_buffer_test` target builds
successfully in the ARM64 Ascend K8s container. The runtime test is currently
blocked by test-environment Ascend context initialization before the changed
batch get code path is exercised.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

OpenAI Codex was used to help prepare the patch branch and draft this PR
description. The human submitter reviewed the change and is responsible for the
final submission.