### PR TITLE
fix(transfer-engine): stop URL-encoding key in HTTP metadata plugin

### DIFF
--- a/mooncake-transfer-engine/src/transfer_metadata_plugin.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata_plugin.cpp
@@ -252,12 +252,7 @@ struct HTTPStoragePlugin : public MetadataStoragePlugin {
     }
 
     std::string encodeUrl(const std::string &key) const {
-        CURL *h = tl_easy();
-        char *esc =
-            curl_easy_escape(h, key.c_str(), static_cast<int>(key.size()));
-        std::string url = metadata_uri_ + "?key=" + (esc ? esc : "");
-        if (esc) curl_free(esc);
-        return url;
+        return metadata_uri_ + "?key=" + key;
     }
 
     static inline bool is_200(long code) { return code == 200; }


### PR DESCRIPTION
## Summary

The HTTP metadata server (`coro_http_server` from yalantinglibs) does not URL-decode query parameters. However, `MetadataStoragePlugin::encodeUrl()` applies `curl_easy_escape()` to the key value, turning `mooncake/ram/127.0.0.1:14291` into `mooncake%2Fram%2F127.0.0.1%3A14291`.

This means GET/PUT/DELETE issued through the plugin target a different key than what the Transfer Engine client (which uses httplib without encoding) originally published. The mismatch breaks metadata cleanup on client timeout in the separately-deployed metadata server topology (#2498).

## Fix

Remove the `curl_easy_escape()` call in `encodeUrl()` and pass the key directly, matching what other metadata clients already do.

## Test plan

- [ ] Verify metadata GET/PUT/DELETE work correctly through the plugin with keys containing `/` and `:`
- [ ] E2E: client crash → TTL expiry → metadata keys removed (separately-deployed mode)