### PR TITLE
[TENT] add local runtime queue dispatch

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
@@ -96,8 +96,7 @@ class LocalTransferAdmissionQueue {
     enum class QueueState {
         Queued,
         Dispatching,
-        Completed,
-        Failed,
+        Terminal,
     };
 
     struct QueueOwner {
@@ -105,6 +104,7 @@ class LocalTransferAdmissionQueue {
         Request request{};
         QueueOwnerKind kind{QueueOwnerKind::User};
         QueueState state{QueueState::Queued};
+        TransferStatusEnum terminal_status{TransferStatusEnum::PENDING};
     };
 
     QueueLimits limits_;

--- a/mooncake-transfer-engine/tent/include/tent/runtime/progress_worker.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/progress_worker.h
@@ -55,6 +55,10 @@ class ProgressWorker {
     // started.
     void notifyBatchMaybeReady(BatchID batch_id);
 
+    // Safe from any thread. Coalesces multiple runtime queue wakes into one
+    // bounded refill step.
+    void notifyRuntimeQueueReady();
+
    private:
     void runner();
 
@@ -66,6 +70,7 @@ class ProgressWorker {
     std::condition_variable cv_;
     std::unordered_set<BatchID> queued_;
     std::deque<BatchID> order_;
+    bool queue_ready_{false};
 };
 
 }  // namespace tent

--- a/mooncake-transfer-engine/tent/include/tent/runtime/progress_worker.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/progress_worker.h
@@ -33,9 +33,9 @@ class TransferEngineImpl;
 // Event-driven progress worker for issue #2116. When the engine is configured
 // with enable_progress_worker=true, transports call
 // notifyBatchMaybeReady to wake this worker, which then drives one
-// progressBatch step per notification. Runtime queue users also get a bounded
-// fallback tick while queue work is active, so older transports without a
-// completion wake still make progress.
+// progressBatch step per notification. When the runtime queue has active work,
+// the worker also uses a low-frequency fallback tick so transports that do not
+// yet emit completion wakes can still drain the queue.
 class ProgressWorker {
    public:
     explicit ProgressWorker(TransferEngineImpl* impl,

--- a/mooncake-transfer-engine/tent/include/tent/runtime/progress_worker.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/progress_worker.h
@@ -16,6 +16,7 @@
 #define PROGRESS_WORKER_H_
 
 #include <atomic>
+#include <chrono>
 #include <condition_variable>
 #include <deque>
 #include <mutex>
@@ -30,15 +31,16 @@ namespace tent {
 class TransferEngineImpl;
 
 // Event-driven progress worker for issue #2116. When the engine is configured
-// with enable_progress_worker=true, transports (or test hooks) call
+// with enable_progress_worker=true, transports call
 // notifyBatchMaybeReady to wake this worker, which then drives one
-// progressBatch step per notification. This decouples failover/resubmit from
-// the caller polling loop, so integrators that turn off
-// enable_auto_failover_on_poll do not need to spin a polling thread of their
-// own to keep failover progressing.
+// progressBatch step per notification. Runtime queue users also get a bounded
+// fallback tick while queue work is active, so older transports without a
+// completion wake still make progress.
 class ProgressWorker {
    public:
-    explicit ProgressWorker(TransferEngineImpl* impl);
+    explicit ProgressWorker(TransferEngineImpl* impl,
+                            std::chrono::microseconds fallback_interval =
+                                std::chrono::microseconds(0));
     ~ProgressWorker();
 
     ProgressWorker(const ProgressWorker&) = delete;
@@ -63,6 +65,7 @@ class ProgressWorker {
     void runner();
 
     TransferEngineImpl* impl_;
+    std::chrono::microseconds fallback_interval_;
     std::atomic<bool> running_{false};
     std::thread thread_;
 

--- a/mooncake-transfer-engine/tent/include/tent/runtime/proxy_manager.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/proxy_manager.h
@@ -31,6 +31,7 @@ struct StageBufferCache;
 
 struct StagingTask {
     TaskInfo* native{nullptr};
+    BatchID batch{0};
     std::vector<std::string> params;
 };
 
@@ -51,7 +52,8 @@ class ProxyManager {
 
     Status deconstruct();
 
-    Status submit(TaskInfo* task, const std::vector<std::string>& params);
+    Status submit(TaskInfo* task, BatchID batch,
+                  const std::vector<std::string>& params);
 
     Status getStatus(TaskInfo* task, TransferStatus& task_status);
 

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -231,6 +231,10 @@ class TransferEngineImpl {
 
     Status refillDispatchWindow();
 
+    Status progressRuntimeQueue();
+
+    bool hasActiveRuntimeQueue();
+
     void notifyRuntimeQueueReady();
 
     Status dispatchQueuedOwner(QueueOwnerId owner_id);

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -182,6 +182,8 @@ class TransferEngineImpl {
     void notifyBatchMaybeReady(BatchID batch_id);
 
    private:
+    friend class ProgressWorker;
+
     Status construct();
 
     Status deconstruct();
@@ -228,6 +230,8 @@ class TransferEngineImpl {
     uint64_t nextBatchToken();
 
     Status refillDispatchWindow();
+
+    void notifyRuntimeQueueReady();
 
     Status dispatchQueuedOwner(QueueOwnerId owner_id);
 

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -197,6 +197,10 @@ class TransferEngineImpl {
 
     Status resubmitTransferTask(Batch* batch, size_t task_id);
 
+    Status retainBatch(BatchID batch_id, Batch*& batch);
+
+    Status releaseBatch(Batch* batch);
+
     struct SubmitPlan;
 
     Status submitTransferToBatch(Batch* batch,

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -201,6 +201,8 @@ class TransferEngineImpl {
 
     Status releaseBatch(Batch* batch);
 
+    class BatchRef;
+
     struct PreparedSubmit;
 
     Status submitTransferToBatch(Batch* batch,

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -201,16 +201,15 @@ class TransferEngineImpl {
 
     Status releaseBatch(Batch* batch);
 
-    struct SubmitPlan;
+    struct PreparedSubmit;
 
     Status submitTransferToBatch(Batch* batch,
                                  const std::vector<Request>& request_list);
 
-    Status buildSubmitPlan(Batch* batch,
-                           const std::vector<Request>& request_list,
-                           SubmitPlan& plan);
+    Status prepareSubmit(Batch* batch, const std::vector<Request>& request_list,
+                         PreparedSubmit& prepared);
 
-    Status commitSubmitPlan(Batch* batch, const SubmitPlan& plan);
+    Status commitPreparedSubmit(Batch* batch, const PreparedSubmit& prepared);
 
     Status pollTaskStatus(Batch* batch, size_t task_id,
                           TransferStatus& task_status);

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -197,6 +197,17 @@ class TransferEngineImpl {
 
     Status resubmitTransferTask(Batch* batch, size_t task_id);
 
+    struct SubmitPlan;
+
+    Status submitTransferToBatch(Batch* batch,
+                                 const std::vector<Request>& request_list);
+
+    Status buildSubmitPlan(Batch* batch,
+                           const std::vector<Request>& request_list,
+                           SubmitPlan& plan);
+
+    Status commitSubmitPlan(Batch* batch, const SubmitPlan& plan);
+
     Status pollTaskStatus(Batch* batch, size_t task_id,
                           TransferStatus& task_status);
 

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -211,6 +211,9 @@ class TransferEngineImpl {
                           const Notification* notifi,
                           QueueOwnerKind owner_kind);
 
+    Status submitStagingTransfer(BatchID batch_id,
+                                 const std::vector<Request>& request_list);
+
     Status enqueuePreparedSubmit(Batch* batch, const PreparedSubmit& prepared,
                                  QueueOwnerKind owner_kind);
 

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -31,6 +31,7 @@
 #include "tent/common/status.h"
 #include "tent/common/types.h"
 #include "tent/common/concurrent/thread_local_storage.h"
+#include "tent/runtime/admission_queue.h"
 #include "tent/runtime/transport_selector.h"
 
 namespace mooncake {
@@ -213,6 +214,8 @@ class TransferEngineImpl {
 
     Status commitPreparedSubmit(Batch* batch, const PreparedSubmit& prepared);
 
+    uint64_t nextBatchToken();
+
     Status pollTaskStatus(Batch* batch, size_t task_id,
                           TransferStatus& task_status);
 
@@ -253,6 +256,13 @@ class TransferEngineImpl {
         std::vector<Batch*> freelist;
     };
 
+    struct RuntimeQueueConfig {
+        bool enabled{false};
+        QueueLimits limits{};
+        size_t max_dispatch_owners{0};
+        size_t max_dispatch_bytes{0};
+    };
+
    private:
     std::shared_ptr<Config> conf_;
     std::shared_ptr<ControlService> metadata_;
@@ -279,6 +289,9 @@ class TransferEngineImpl {
     int max_failover_attempts_{3};
     bool enable_auto_failover_on_poll_{true};
     bool enable_progress_worker_{false};
+    RuntimeQueueConfig runtime_queue_config_;
+    std::unique_ptr<LocalTransferAdmissionQueue> runtime_queue_;
+    uint64_t next_batch_token_{1};
 
     // Guards alive_batches_ and serializes pollTaskStatus /
     // updateTaskStatusAfterPoll / lazyFreeBatch against the optional

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -32,6 +32,7 @@
 #include "tent/common/types.h"
 #include "tent/common/concurrent/thread_local_storage.h"
 #include "tent/runtime/admission_queue.h"
+#include "tent/runtime/transport.h"
 #include "tent/runtime/transport_selector.h"
 
 namespace mooncake {
@@ -177,8 +178,8 @@ class TransferEngineImpl {
     }
 
     // Wake the optional event-driven progress worker for `batch_id`. No-op if
-    // enable_progress_worker is false. Currently used by test/integration
-    // hooks; transports will be migrated to call this in a follow-up PR.
+    // enable_progress_worker is false. Transport completion paths use this as
+    // an idempotent "maybe ready" signal.
     void notifyBatchMaybeReady(BatchID batch_id);
 
    private:
@@ -226,6 +227,8 @@ class TransferEngineImpl {
                          PreparedSubmit& prepared);
 
     Status commitPreparedSubmit(Batch* batch, const PreparedSubmit& prepared);
+
+    void attachProgressNotifier(Batch* batch, Transport::SubBatchRef sub_batch);
 
     uint64_t nextBatchToken();
 
@@ -295,6 +298,7 @@ class TransferEngineImpl {
         QueueLimits limits{};
         size_t max_dispatch_owners{0};
         size_t max_dispatch_bytes{0};
+        std::chrono::microseconds progress_fallback_interval{50000};
     };
 
     struct QueuedOwnerState {

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -30,7 +30,6 @@
 #include "tent/common/config.h"
 #include "tent/common/status.h"
 #include "tent/common/types.h"
-#include "tent/common/concurrent/thread_local_storage.h"
 #include "tent/runtime/admission_queue.h"
 #include "tent/runtime/transport.h"
 #include "tent/runtime/transport_selector.h"
@@ -39,7 +38,6 @@ namespace mooncake {
 namespace tent {
 
 class Batch;
-class BatchSet;
 class Topology;
 class Transport;
 class SegmentDesc;
@@ -320,7 +318,7 @@ class TransferEngineImpl {
         transport_list_;
     std::unique_ptr<SegmentTracker> local_segment_tracker_;
 
-    ThreadLocalStorage<BatchSet> batch_set_;
+    BatchSet batch_set_;
 
     std::vector<AllocatedMemory> allocated_memory_;
     std::mutex mutex_;

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -206,8 +206,16 @@ class TransferEngineImpl {
 
     struct PreparedSubmit;
 
-    Status submitTransferToBatch(Batch* batch,
-                                 const std::vector<Request>& request_list);
+    Status submitTransfer(BatchID batch_id,
+                          const std::vector<Request>& request_list,
+                          const Notification* notifi,
+                          QueueOwnerKind owner_kind);
+
+    Status enqueuePreparedSubmit(Batch* batch, const PreparedSubmit& prepared,
+                                 QueueOwnerKind owner_kind);
+
+    bool shouldQueueSubmit(const PreparedSubmit& prepared,
+                           QueueOwnerKind owner_kind) const;
 
     Status prepareSubmit(Batch* batch, const std::vector<Request>& request_list,
                          PreparedSubmit& prepared);
@@ -215,6 +223,15 @@ class TransferEngineImpl {
     Status commitPreparedSubmit(Batch* batch, const PreparedSubmit& prepared);
 
     uint64_t nextBatchToken();
+
+    Status dispatchQueuedTransfers();
+
+    Status dispatchQueuedOwner(QueueOwnerId owner_id);
+
+    Status finishQueuedOwner(QueueOwnerId owner_id,
+                             TransferStatusEnum terminal_status);
+
+    Status retireQueueForBatch(Batch* batch);
 
     Status pollTaskStatus(Batch* batch, size_t task_id,
                           TransferStatus& task_status);
@@ -239,6 +256,10 @@ class TransferEngineImpl {
 
     Status maybeFireSubmitHooks(Batch* batch, bool check = true);
 
+    void addSubmitHook(Batch* batch, size_t start_task_id,
+                       const std::vector<Request>& request_list,
+                       const Notification& notifi);
+
     void recordTaskCompletionMetrics(TaskInfo& task,
                                      TransferStatusEnum prev_status,
                                      TransferStatusEnum new_status);
@@ -261,6 +282,13 @@ class TransferEngineImpl {
         QueueLimits limits{};
         size_t max_dispatch_owners{0};
         size_t max_dispatch_bytes{0};
+    };
+
+    struct QueuedOwnerState {
+        Batch* batch{nullptr};
+        size_t owner_task_id{0};
+        std::vector<size_t> public_task_ids;
+        bool submitted{false};
     };
 
    private:
@@ -291,6 +319,7 @@ class TransferEngineImpl {
     bool enable_progress_worker_{false};
     RuntimeQueueConfig runtime_queue_config_;
     std::unique_ptr<LocalTransferAdmissionQueue> runtime_queue_;
+    std::unordered_map<QueueOwnerId, QueuedOwnerState> queued_owners_;
     uint64_t next_batch_token_{1};
 
     // Guards alive_batches_ and serializes pollTaskStatus /

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -227,9 +227,11 @@ class TransferEngineImpl {
 
     uint64_t nextBatchToken();
 
-    Status dispatchQueuedTransfers();
+    Status refillDispatchWindow();
 
     Status dispatchQueuedOwner(QueueOwnerId owner_id);
+
+    Status markQueuedOwnerSubmitted(QueueOwnerId owner_id);
 
     Status finishQueuedOwner(QueueOwnerId owner_id,
                              TransferStatusEnum terminal_status);
@@ -291,7 +293,8 @@ class TransferEngineImpl {
         Batch* batch{nullptr};
         size_t owner_task_id{0};
         std::vector<size_t> public_task_ids;
-        bool submitted{false};
+        size_t byte_charge{0};
+        bool in_dispatch_window{false};
     };
 
    private:
@@ -323,6 +326,8 @@ class TransferEngineImpl {
     RuntimeQueueConfig runtime_queue_config_;
     std::unique_ptr<LocalTransferAdmissionQueue> runtime_queue_;
     std::unordered_map<QueueOwnerId, QueuedOwnerState> queued_owners_;
+    size_t dispatch_inflight_owners_{0};
+    size_t dispatch_inflight_bytes_{0};
     uint64_t next_batch_token_{1};
 
     // Guards alive_batches_ and serializes pollTaskStatus /

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transport.h
@@ -22,12 +22,14 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <iostream>
 #include <memory>
 #include <queue>
 #include <string>
 
 #include "tent/common/status.h"
+#include "tent/common/types.h"
 #include "tent/runtime/platform.h"
 #include "tent/runtime/control_plane.h"
 
@@ -48,7 +50,13 @@ class Transport {
         SubBatch() : device_mask(~0ULL) {}
         virtual ~SubBatch() {}
         virtual size_t size() const = 0;
+        void notifyProgress() {
+            if (notify_progress) notify_progress(progress_batch_id);
+        }
+
         uint64_t device_mask;  // Device mask for transport selection
+        BatchID progress_batch_id{0};
+        std::function<void(BatchID)> notify_progress;
     };
 
     using SubBatchRef = SubBatch *;

--- a/mooncake-transfer-engine/tent/include/tent/transport/tcp/tcp_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/tcp/tcp_transport.h
@@ -38,6 +38,8 @@ struct TcpParams {
 
 struct TcpTask {
     Request request;
+    BatchID progress_batch_id{0};
+    std::function<void(BatchID)> notify_progress;
     std::atomic<TransferStatusEnum> status_word{TransferStatusEnum::PENDING};
     std::atomic<size_t> transferred_bytes{0};
     uint64_t target_addr = 0;
@@ -45,6 +47,8 @@ struct TcpTask {
     TcpTask() = default;
     TcpTask(TcpTask &&other) noexcept
         : request(std::move(other.request)),
+          progress_batch_id(other.progress_batch_id),
+          notify_progress(std::move(other.notify_progress)),
           status_word(other.status_word.load(std::memory_order_relaxed)),
           transferred_bytes(
               other.transferred_bytes.load(std::memory_order_relaxed)),

--- a/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
@@ -25,6 +25,9 @@ using PublicTaskKey = std::pair<uint64_t, size_t>;
 
 bool isSupportedTerminalStatus(TransferStatusEnum status) {
     return status == TransferStatusEnum::COMPLETED ||
+           status == TransferStatusEnum::INVALID ||
+           status == TransferStatusEnum::CANCELED ||
+           status == TransferStatusEnum::TIMEOUT ||
            status == TransferStatusEnum::FAILED;
 }
 
@@ -232,9 +235,8 @@ Status LocalTransferAdmissionQueue::complete(
         return Status::InvalidEntry("queue owner is not dispatching" LOC_MARK);
     }
 
-    owner.state = terminal_status == TransferStatusEnum::COMPLETED
-                      ? QueueState::Completed
-                      : QueueState::Failed;
+    owner.state = QueueState::Terminal;
+    owner.terminal_status = terminal_status;
     --outstanding_owners_;
     outstanding_bytes_ -= owner.request.length;
     if (owner.kind == QueueOwnerKind::User) {
@@ -271,9 +273,7 @@ Status LocalTransferAdmissionQueue::retireBatch(uint64_t batch_token) {
             return Status::InternalError(
                 "queue owner batch token mismatch" LOC_MARK);
         }
-        const bool terminal = owner.state == QueueState::Completed ||
-                              owner.state == QueueState::Failed;
-        if (!terminal) {
+        if (owner.state != QueueState::Terminal) {
             return Status::InvalidEntry(
                 "batch has non-terminal queue owners" LOC_MARK);
         }
@@ -314,11 +314,8 @@ Status LocalTransferAdmissionQueue::getPublicStatus(
         case QueueState::Dispatching:
             status = TransferStatusEnum::PENDING;
             break;
-        case QueueState::Completed:
-            status = TransferStatusEnum::COMPLETED;
-            break;
-        case QueueState::Failed:
-            status = TransferStatusEnum::FAILED;
+        case QueueState::Terminal:
+            status = owner_it->second.terminal_status;
             break;
     }
     return Status::OK();

--- a/mooncake-transfer-engine/tent/src/runtime/progress_worker.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/progress_worker.cpp
@@ -14,11 +14,16 @@
 
 #include "tent/runtime/progress_worker.h"
 
+#include <chrono>
+
 #include "tent/common/status.h"
 #include "tent/runtime/transfer_engine_impl.h"
 
 namespace mooncake {
 namespace tent {
+namespace {
+constexpr auto kRuntimeQueueTick = std::chrono::milliseconds(2);
+}  // namespace
 
 ProgressWorker::ProgressWorker(TransferEngineImpl* impl) : impl_(impl) {}
 
@@ -67,12 +72,20 @@ void ProgressWorker::runner() {
     while (true) {
         BatchID batch_id = 0;
         bool queue_ready = false;
+        bool queue_active = impl_->hasActiveRuntimeQueue();
         {
             std::unique_lock<std::mutex> lk(mu_);
-            cv_.wait(lk, [&] {
-                return !running_.load(std::memory_order_acquire) ||
-                       queue_ready_ || !order_.empty();
-            });
+            if (queue_active) {
+                cv_.wait_for(lk, kRuntimeQueueTick, [&] {
+                    return !running_.load(std::memory_order_acquire) ||
+                           queue_ready_ || !order_.empty();
+                });
+            } else {
+                cv_.wait(lk, [&] {
+                    return !running_.load(std::memory_order_acquire) ||
+                           queue_ready_ || !order_.empty();
+                });
+            }
             if (!running_.load(std::memory_order_acquire)) return;
             queue_ready = queue_ready_;
             queue_ready_ = false;
@@ -83,7 +96,7 @@ void ProgressWorker::runner() {
             }
         }
         if (queue_ready) {
-            (void)impl_->refillDispatchWindow();
+            (void)impl_->progressRuntimeQueue();
         }
         // progressBatch acquires the engine's progress_mutex_ and silently
         // returns InvalidArgument if the batch was freed before we got here.
@@ -94,6 +107,9 @@ void ProgressWorker::runner() {
             TransferStatus s;
             (void)impl_->progressBatch(batch_id, s);
             (void)impl_->refillDispatchWindow();
+        }
+        if (!queue_ready && !batch_id && queue_active) {
+            (void)impl_->progressRuntimeQueue();
         }
     }
 }

--- a/mooncake-transfer-engine/tent/src/runtime/progress_worker.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/progress_worker.cpp
@@ -98,19 +98,22 @@ void ProgressWorker::runner() {
         }
         if (queue_ready) {
             (void)impl_->progressRuntimeQueue();
+            (void)impl_->lazyFreeBatch();
         }
         // progressBatch acquires the engine's progress_mutex_ and silently
         // returns InvalidArgument if the batch was freed before we got here.
         // PENDING means "kick again later"; the next notify wakes us up.
-        // Terminal states leave the batch alone — freeBatch on the user
-        // thread is responsible for reclamation.
+        // Terminal states are observed here; lazyFreeBatch reclaims a batch
+        // only if freeBatch has already marked it free_requested.
         if (batch_id) {
             TransferStatus s;
             (void)impl_->progressBatch(batch_id, s);
             (void)impl_->progressRuntimeQueue();
+            (void)impl_->lazyFreeBatch();
         }
         if (fallback_due && !queue_ready && !batch_id && queue_active) {
             (void)impl_->progressRuntimeQueue();
+            (void)impl_->lazyFreeBatch();
         }
     }
 }

--- a/mooncake-transfer-engine/tent/src/runtime/progress_worker.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/progress_worker.cpp
@@ -21,11 +21,10 @@
 
 namespace mooncake {
 namespace tent {
-namespace {
-constexpr auto kRuntimeQueueTick = std::chrono::milliseconds(2);
-}  // namespace
 
-ProgressWorker::ProgressWorker(TransferEngineImpl* impl) : impl_(impl) {}
+ProgressWorker::ProgressWorker(TransferEngineImpl* impl,
+                               std::chrono::microseconds fallback_interval)
+    : impl_(impl), fallback_interval_(fallback_interval) {}
 
 ProgressWorker::~ProgressWorker() { stop(); }
 
@@ -72,14 +71,16 @@ void ProgressWorker::runner() {
     while (true) {
         BatchID batch_id = 0;
         bool queue_ready = false;
+        bool fallback_due = false;
         bool queue_active = impl_->hasActiveRuntimeQueue();
         {
             std::unique_lock<std::mutex> lk(mu_);
-            if (queue_active) {
-                cv_.wait_for(lk, kRuntimeQueueTick, [&] {
+            if (queue_active && fallback_interval_.count() > 0) {
+                const bool woke = cv_.wait_for(lk, fallback_interval_, [&] {
                     return !running_.load(std::memory_order_acquire) ||
                            queue_ready_ || !order_.empty();
                 });
+                fallback_due = !woke;
             } else {
                 cv_.wait(lk, [&] {
                     return !running_.load(std::memory_order_acquire) ||
@@ -106,9 +107,9 @@ void ProgressWorker::runner() {
         if (batch_id) {
             TransferStatus s;
             (void)impl_->progressBatch(batch_id, s);
-            (void)impl_->refillDispatchWindow();
+            (void)impl_->progressRuntimeQueue();
         }
-        if (!queue_ready && !batch_id && queue_active) {
+        if (fallback_due && !queue_ready && !batch_id && queue_active) {
             (void)impl_->progressRuntimeQueue();
         }
     }

--- a/mooncake-transfer-engine/tent/src/runtime/progress_worker.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/progress_worker.cpp
@@ -37,6 +37,7 @@ void ProgressWorker::stop() {
         // user thread's freeBatch path.
         order_.clear();
         queued_.clear();
+        queue_ready_ = false;
     }
     cv_.notify_all();
     if (thread_.joinable()) thread_.join();
@@ -53,27 +54,47 @@ void ProgressWorker::notifyBatchMaybeReady(BatchID batch_id) {
     cv_.notify_one();
 }
 
+void ProgressWorker::notifyRuntimeQueueReady() {
+    if (!running_.load(std::memory_order_acquire)) return;
+    {
+        std::lock_guard<std::mutex> lk(mu_);
+        queue_ready_ = true;
+    }
+    cv_.notify_one();
+}
+
 void ProgressWorker::runner() {
     while (true) {
         BatchID batch_id = 0;
+        bool queue_ready = false;
         {
             std::unique_lock<std::mutex> lk(mu_);
             cv_.wait(lk, [&] {
                 return !running_.load(std::memory_order_acquire) ||
-                       !order_.empty();
+                       queue_ready_ || !order_.empty();
             });
             if (!running_.load(std::memory_order_acquire)) return;
-            batch_id = order_.front();
-            order_.pop_front();
-            queued_.erase(batch_id);
+            queue_ready = queue_ready_;
+            queue_ready_ = false;
+            if (!order_.empty()) {
+                batch_id = order_.front();
+                order_.pop_front();
+                queued_.erase(batch_id);
+            }
+        }
+        if (queue_ready) {
+            (void)impl_->refillDispatchWindow();
         }
         // progressBatch acquires the engine's progress_mutex_ and silently
         // returns InvalidArgument if the batch was freed before we got here.
         // PENDING means "kick again later"; the next notify wakes us up.
         // Terminal states leave the batch alone — freeBatch on the user
         // thread is responsible for reclamation.
-        TransferStatus s;
-        (void)impl_->progressBatch(batch_id, s);
+        if (batch_id) {
+            TransferStatus s;
+            (void)impl_->progressBatch(batch_id, s);
+            (void)impl_->refillDispatchWindow();
+        }
     }
 }
 

--- a/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
@@ -136,10 +136,11 @@ Status ProxyManager::waitCrossStage(const Request& request,
     return impl_->waitTransferCompletion(batch);
 }
 
-Status ProxyManager::submit(TaskInfo* task,
+Status ProxyManager::submit(TaskInfo* task, BatchID batch,
                             const std::vector<std::string>& params) {
     StagingTask staging_task;
     staging_task.native = task;
+    staging_task.batch = batch;
     staging_task.params = params;
     task->staging_status = PENDING;
     static std::atomic<size_t> next_queue_index(0);
@@ -242,6 +243,7 @@ void ProxyManager::runner(size_t id) {
         auto staging_status = status.ok() ? COMPLETED : FAILED;
         __atomic_store(&task.native->staging_status, &staging_status,
                        __ATOMIC_RELEASE);
+        impl_->notifyBatchMaybeReady(task.batch);
     }
     cache.reset();
 }

--- a/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
@@ -58,7 +58,13 @@ BatchID ProxyManager::submitCrossStage(const Request& request,
     inter_stage.target_id = request.target_id;
     inter_stage.target_offset = remote_stage_buffer;
     auto batch = impl_->allocateBatch(1);
-    impl_->submitTransfer(batch, {inter_stage});
+    auto status = impl_->submitStagingTransfer(batch, {inter_stage});
+    if (!status.ok()) {
+        LOG(WARNING) << "failed to submit cross-stage transfer: "
+                     << status.ToString();
+        if (batch) impl_->freeBatch(batch);
+        return 0;
+    }
     return batch;
 }
 
@@ -72,7 +78,13 @@ BatchID ProxyManager::submitLocalStage(const Request& request,
     local_stage.target_id = LOCAL_SEGMENT_ID;
     local_stage.target_offset = local_stage_buffer;
     auto batch = impl_->allocateBatch(1);
-    impl_->submitTransfer(batch, {local_stage});
+    auto status = impl_->submitStagingTransfer(batch, {local_stage});
+    if (!status.ok()) {
+        LOG(WARNING) << "failed to submit local-stage transfer: "
+                     << status.ToString();
+        if (batch) impl_->freeBatch(batch);
+        return 0;
+    }
     return batch;
 }
 
@@ -81,6 +93,7 @@ Status ProxyManager::waitLocalStage(const Request& request,
                                     uint64_t chunk_length, uint64_t offset) {
     auto batch =
         submitLocalStage(request, local_stage_buffer, chunk_length, offset);
+    if (!batch) return Status::TooManyRequests("submit local stage failed");
     return impl_->waitTransferCompletion(batch);
 }
 
@@ -119,6 +132,7 @@ Status ProxyManager::waitCrossStage(const Request& request,
                                     uint64_t chunk_length) {
     auto batch = submitCrossStage(request, local_stage_buffer,
                                   remote_stage_buffer, chunk_length);
+    if (!batch) return Status::TooManyRequests("submit cross stage failed");
     return impl_->waitTransferCompletion(batch);
 }
 
@@ -317,6 +331,11 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
                     local_locked.insert(chunk.local_buf);
                     chunk.batch = submitLocalStage(request, chunk.local_buf,
                                                    chunk.length, chunk.offset);
+                    if (!chunk.batch) {
+                        chunk.state = StageState::FAILED;
+                        event_queue.push(id);
+                        break;
+                    }
                     chunk.prev_state = chunk.state;
                     chunk.state = StageState::INFLIGHT;
                     event_queue.push(id);
@@ -356,6 +375,11 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
                 }
                 chunk.batch = submitCrossStage(request, chunk.local_buf,
                                                chunk.remote_buf, chunk.length);
+                if (!chunk.batch) {
+                    chunk.state = StageState::FAILED;
+                    event_queue.push(id);
+                    break;
+                }
                 chunk.prev_state = chunk.state;
                 chunk.state = StageState::INFLIGHT;
                 event_queue.push(id);
@@ -373,6 +397,11 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
                 } else if (request.opcode == Request::READ && local_staging) {
                     chunk.batch = submitLocalStage(request, chunk.local_buf,
                                                    chunk.length, chunk.offset);
+                    if (!chunk.batch) {
+                        chunk.state = StageState::FAILED;
+                        event_queue.push(id);
+                        break;
+                    }
                     chunk.prev_state = chunk.state;
                     chunk.state = StageState::INFLIGHT;
                     event_queue.push(id);

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -58,6 +58,7 @@ struct Batch {
     size_t max_size;
     size_t runtime_refs{0};
     bool free_requested{false};
+    uint64_t queue_token{0};
 
     struct SubmitHook {
         size_t start_task_id{0};
@@ -756,6 +757,12 @@ Status TransferEngineImpl::freeBatch(BatchID batch_id) {
     std::lock_guard<std::recursive_mutex> lk(progress_mutex_);
     if (!alive_batches_.count(batch_id))
         return Status::InvalidArgument("Batch is not alive" LOC_MARK);
+    if (runtime_queue_config_.enabled && batch->queue_token != 0) {
+        auto retire_status = retireQueueForBatch(batch);
+        if (!retire_status.ok() && !retire_status.IsInvalidEntry()) {
+            return retire_status;
+        }
+    }
     if (batch->free_requested) {
         CHECK_STATUS(lazyFreeBatch());
         return Status::OK();
@@ -781,6 +788,9 @@ Status TransferEngineImpl::lazyFreeBatch() {
         if (overall_status.s == PENDING) {
             it++;
             continue;
+        }
+        if (runtime_queue_config_.enabled && batch->queue_token != 0) {
+            CHECK_STATUS(retireQueueForBatch(batch));
         }
         for (size_t type = 0; type < kSupportedTransportTypes; ++type) {
             auto& transport = transport_list_[type];
@@ -1335,15 +1345,15 @@ Status TransferEngineImpl::prepareSubmit(
     for (const auto& kv : merged.task_lookup) {
         const size_t public_task_index = kv.first;
         const size_t merged_task_index = kv.second;
+        const size_t task_id = start_task_id + public_task_index;
         auto& owner = prepared.owners[merged_task_index];
         if (!owner.has_owner_task_id) {
-            owner.owner_task_id = public_task_index;
+            owner.owner_task_id = task_id;
             owner.has_owner_task_id = true;
         } else {
-            owner.derived_task_ids.push_back(public_task_index);
+            owner.derived_task_ids.push_back(task_id);
         }
-        prepared.tasks.push_back(
-            {merged_task_index, start_task_id + public_task_index});
+        prepared.tasks.push_back({merged_task_index, task_id});
     }
     return Status::OK();
 }
@@ -1447,21 +1457,202 @@ Status TransferEngineImpl::commitPreparedSubmit(
     return Status::OK();
 }
 
-Status TransferEngineImpl::submitTransferToBatch(
-    Batch* batch, const std::vector<Request>& request_list) {
-    PreparedSubmit prepared;
-    CHECK_STATUS(prepareSubmit(batch, request_list, prepared));
-    CHECK_STATUS(commitPreparedSubmit(batch, prepared));
+Status TransferEngineImpl::enqueuePreparedSubmit(Batch* batch,
+                                                 const PreparedSubmit& prepared,
+                                                 QueueOwnerKind owner_kind) {
+    std::lock_guard<std::recursive_mutex> lk(progress_mutex_);
+    if (prepared.tasks.empty()) return Status::OK();
+    if (prepared.tasks.size() > batch->max_size - batch->task_list.size()) {
+        return Status::TooManyRequests(
+            "batch public task capacity exceeded" LOC_MARK);
+    }
+
+    const uint64_t batch_token =
+        batch->queue_token != 0 ? batch->queue_token : nextBatchToken();
+    QueueSubmit submit;
+    submit.batch_token = batch_token;
+    submit.batch_slots_left = batch->max_size - batch->task_list.size();
+    submit.owners.reserve(prepared.owners.size());
+    for (const auto& owner : prepared.owners) {
+        QueueOwnerInput input;
+        input.owner_task_id = owner.owner_task_id;
+        input.derived_task_ids = owner.derived_task_ids;
+        input.request = owner.request;
+        input.kind = owner_kind;
+        submit.owners.push_back(std::move(input));
+    }
+
+    std::vector<QueueOwnerId> admitted_owner_ids;
+    CHECK_STATUS(runtime_queue_->tryAdmit(submit, admitted_owner_ids));
+    batch->queue_token = batch_token;
+
+    batch->task_list.insert(batch->task_list.end(), prepared.tasks.size(),
+                            TaskInfo{});
+    for (const auto& task_plan : prepared.tasks) {
+        auto& task = batch->task_list[task_plan.task_id];
+        const auto& owner = prepared.owners[task_plan.merged_task_index];
+        task.failover_count = 0;
+        task.xport_priority = 0;
+        task.status = PENDING;
+        task.request = owner.request;
+        task.staging = false;
+        task.start_time = prepared.submit_time;
+        task.type = UNSPEC;
+        task.sub_task_id = -1;
+        task.device_mask = owner.route.device_mask;
+        task.derived = task_plan.task_id != owner.owner_task_id;
+    }
+
+    for (size_t i = 0; i < admitted_owner_ids.size(); ++i) {
+        QueuedOwnerState queued;
+        queued.batch = batch;
+        queued.owner_task_id = prepared.owners[i].owner_task_id;
+        queued.public_task_ids.push_back(prepared.owners[i].owner_task_id);
+        queued.public_task_ids.insert(
+            queued.public_task_ids.end(),
+            prepared.owners[i].derived_task_ids.begin(),
+            prepared.owners[i].derived_task_ids.end());
+        queued_owners_.emplace(admitted_owner_ids[i], queued);
+    }
     return Status::OK();
+}
+
+Status TransferEngineImpl::finishQueuedOwner(
+    QueueOwnerId owner_id, TransferStatusEnum terminal_status) {
+    auto queued_it = queued_owners_.find(owner_id);
+    if (queued_it == queued_owners_.end()) {
+        return Status::InvalidEntry("queued owner not found" LOC_MARK);
+    }
+    auto& queued = queued_it->second;
+    CHECK_STATUS(runtime_queue_->complete(owner_id, terminal_status));
+    for (const auto task_id : queued.public_task_ids) {
+        queued.batch->task_list[task_id].status = terminal_status;
+    }
+    queued_owners_.erase(queued_it);
+    return Status::OK();
+}
+
+Status TransferEngineImpl::retireQueueForBatch(Batch* batch) {
+    if (!batch || batch->queue_token == 0) return Status::OK();
+    auto status = runtime_queue_->retireBatch(batch->queue_token);
+    if (!status.ok()) return status;
+    batch->queue_token = 0;
+    return Status::OK();
+}
+
+Status TransferEngineImpl::dispatchQueuedOwner(QueueOwnerId owner_id) {
+    auto queued_it = queued_owners_.find(owner_id);
+    if (queued_it == queued_owners_.end()) {
+        return Status::InternalError("queued owner metadata missing" LOC_MARK);
+    }
+    const auto queued = queued_it->second;
+    auto* batch = queued.batch;
+    auto& task = batch->task_list[queued.owner_task_id];
+    auto route = resolveTransport(task.request, 0);
+    task.type = route.transport;
+    task.device_mask = route.device_mask;
+    if (task.type == UNSPEC) {
+        return finishQueuedOwner(owner_id, FAILED);
+    }
+
+    if (task.type == TCP) {
+        std::vector<std::string> staging_params;
+        findStagingPolicy(task.request, staging_params);
+        if (!staging_params.empty() && staging_proxy_) {
+            task.staging = true;
+            auto status = staging_proxy_->submit(&task, staging_params);
+            if (!status.ok()) return finishQueuedOwner(owner_id, FAILED);
+            queued_it->second.submitted = true;
+            return Status::OK();
+        }
+    }
+
+    if (!batch->sub_batch[task.type]) {
+        auto& transport = transport_list_[task.type];
+        if (!transport) return finishQueuedOwner(owner_id, FAILED);
+        auto status = transport->allocateSubBatch(batch->sub_batch[task.type],
+                                                  batch->max_size);
+        if (!status.ok()) return finishQueuedOwner(owner_id, FAILED);
+    }
+
+    auto& transport = transport_list_[task.type];
+    if (!transport) return finishQueuedOwner(owner_id, FAILED);
+    auto& sub_batch = batch->sub_batch[task.type];
+    task.sub_task_id = sub_batch->size();
+    auto status = transport->submitTransferTasks(sub_batch, {task.request});
+    if (!status.ok()) {
+        task.type = UNSPEC;
+        return finishQueuedOwner(owner_id, FAILED);
+    }
+    queued_it->second.submitted = true;
+    return Status::OK();
+}
+
+Status TransferEngineImpl::dispatchQueuedTransfers() {
+    if (!runtime_queue_config_.enabled) return Status::OK();
+    auto picked = runtime_queue_->pickForDispatch(
+        runtime_queue_config_.max_dispatch_owners,
+        runtime_queue_config_.max_dispatch_bytes);
+    for (const auto owner_id : picked) {
+        CHECK_STATUS(dispatchQueuedOwner(owner_id));
+    }
+    return Status::OK();
+}
+
+bool TransferEngineImpl::shouldQueueSubmit(const PreparedSubmit& prepared,
+                                           QueueOwnerKind owner_kind) const {
+    if (!runtime_queue_config_.enabled) return false;
+    if (owner_kind == QueueOwnerKind::StagingInternal) return true;
+    return std::none_of(
+        prepared.owners.begin(), prepared.owners.end(),
+        [](const PreparedSubmit::Owner& owner) { return owner.staging; });
+}
+
+Status TransferEngineImpl::submitTransfer(
+    BatchID batch_id, const std::vector<Request>& request_list,
+    const Notification* notifi, QueueOwnerKind owner_kind) {
+    Batch* batch = nullptr;
+    CHECK_STATUS(retainBatch(batch_id, batch));
+    BatchRef batch_ref(*this, batch);
+    const size_t start_task_id = batch_ref.get()->task_list.size();
+    PreparedSubmit prepared;
+    CHECK_STATUS(prepareSubmit(batch_ref.get(), request_list, prepared));
+
+    if (shouldQueueSubmit(prepared, owner_kind)) {
+        CHECK_STATUS(
+            enqueuePreparedSubmit(batch_ref.get(), prepared, owner_kind));
+        auto dispatch_status = dispatchQueuedTransfers();
+        if (!dispatch_status.ok()) {
+            LOG(WARNING) << "runtime queue dispatch failed after admission: "
+                         << dispatch_status.ToString();
+        }
+    } else {
+        CHECK_STATUS(commitPreparedSubmit(batch_ref.get(), prepared));
+    }
+
+    if (notifi) {
+        addSubmitHook(batch_ref.get(), start_task_id, request_list, *notifi);
+    }
+    return batch_ref.release();
 }
 
 Status TransferEngineImpl::submitTransfer(
     BatchID batch_id, const std::vector<Request>& request_list) {
-    Batch* batch = nullptr;
-    CHECK_STATUS(retainBatch(batch_id, batch));
-    BatchRef batch_ref(*this, batch);
-    CHECK_STATUS(submitTransferToBatch(batch_ref.get(), request_list));
-    return batch_ref.release();
+    return submitTransfer(batch_id, request_list, nullptr,
+                          QueueOwnerKind::User);
+}
+
+void TransferEngineImpl::addSubmitHook(Batch* batch, size_t start_task_id,
+                                       const std::vector<Request>& request_list,
+                                       const Notification& notifi) {
+    Batch::SubmitHook hook;
+    hook.start_task_id = start_task_id;
+    hook.end_task_id = start_task_id + request_list.size();
+    hook.notifi = notifi;
+    hook.fired = false;
+    for (const auto& request : request_list)
+        hook.targets.insert(request.target_id);
+    batch->submit_hooks.emplace_back(std::move(hook));
 }
 
 Status TransferEngineImpl::maybeFireSubmitHooks(Batch* batch, bool check) {
@@ -1499,21 +1690,8 @@ Status TransferEngineImpl::maybeFireSubmitHooks(Batch* batch, bool check) {
 Status TransferEngineImpl::submitTransfer(
     BatchID batch_id, const std::vector<Request>& request_list,
     const Notification& notifi) {
-    Batch* batch = nullptr;
-    CHECK_STATUS(retainBatch(batch_id, batch));
-    BatchRef batch_ref(*this, batch);
-    const size_t start_task_id = batch_ref.get()->task_list.size();
-    CHECK_STATUS(submitTransferToBatch(batch_ref.get(), request_list));
-
-    Batch::SubmitHook hook;
-    hook.start_task_id = start_task_id;
-    hook.end_task_id = start_task_id + request_list.size();
-    hook.notifi = notifi;
-    hook.fired = false;
-    for (const auto& request : request_list)
-        hook.targets.insert(request.target_id);
-    batch_ref.get()->submit_hooks.emplace_back(std::move(hook));
-    return batch_ref.release();
+    return submitTransfer(batch_id, request_list, &notifi,
+                          QueueOwnerKind::User);
 }
 
 Status TransferEngineImpl::resubmitTransferTask(Batch* batch, size_t task_id) {
@@ -1640,11 +1818,42 @@ Status TransferEngineImpl::getTransferStatus(BatchID batch_id, size_t task_id,
     Batch* batch = (Batch*)(batch_id);
     if (task_id >= batch->task_list.size())
         return Status::InvalidArgument("Invalid task ID" LOC_MARK);
+    CHECK_STATUS(dispatchQueuedTransfers());
+    if (runtime_queue_config_.enabled && batch->queue_token != 0) {
+        QueueOwnerId owner_id = 0;
+        auto resolve_status =
+            runtime_queue_->resolveOwner(batch->queue_token, task_id, owner_id);
+        if (resolve_status.ok()) {
+            TransferStatusEnum public_status = PENDING;
+            CHECK_STATUS(runtime_queue_->getPublicStatus(
+                batch->queue_token, task_id, public_status));
+            auto queued_it = queued_owners_.find(owner_id);
+            if (public_status != PENDING || batch->task_list[task_id].derived ||
+                (queued_it != queued_owners_.end() &&
+                 !queued_it->second.submitted)) {
+                task_status.s = public_status;
+                task_status.transferred_bytes =
+                    public_status == COMPLETED
+                        ? batch->task_list[task_id].request.length
+                        : 0;
+                return Status::OK();
+            }
+        }
+    }
     auto& task = batch->task_list[task_id];
     auto prev_status = task.status;
     CHECK_STATUS(pollTaskStatus(batch, task_id, task_status));
     updateTaskStatusAfterPoll(batch, task_id, task_status,
                               enable_auto_failover_on_poll_);
+    if (runtime_queue_config_.enabled && batch->queue_token != 0 &&
+        task_status.s != PENDING) {
+        QueueOwnerId owner_id = 0;
+        auto resolve_status =
+            runtime_queue_->resolveOwner(batch->queue_token, task_id, owner_id);
+        if (resolve_status.ok()) {
+            CHECK_STATUS(finishQueuedOwner(owner_id, task_status.s));
+        }
+    }
 
     // Record metrics when task transitions to terminal state
     recordTaskCompletionMetrics(batch->task_list[task_id], prev_status,
@@ -1677,6 +1886,7 @@ Status TransferEngineImpl::getBatchStatus(BatchID batch_id,
     std::lock_guard<std::recursive_mutex> lk(progress_mutex_);
     if (!alive_batches_.count(batch_id))
         return Status::InvalidArgument("Batch is not alive" LOC_MARK);
+    CHECK_STATUS(dispatchQueuedTransfers());
     Batch* batch = (Batch*)(batch_id);
     overall_status.s = PENDING;
     overall_status.transferred_bytes = 0;
@@ -1695,6 +1905,34 @@ Status TransferEngineImpl::getBatchStatus(BatchID batch_id,
         auto& task = batch->task_list[task_id];
         if (task.derived) continue;  // This task is performed by other tasks
         total_tasks++;
+        if (runtime_queue_config_.enabled && batch->queue_token != 0) {
+            QueueOwnerId owner_id = 0;
+            auto resolve_status = runtime_queue_->resolveOwner(
+                batch->queue_token, task_id, owner_id);
+            if (resolve_status.ok()) {
+                TransferStatusEnum public_status = PENDING;
+                CHECK_STATUS(runtime_queue_->getPublicStatus(
+                    batch->queue_token, task_id, public_status));
+                auto queued_it = queued_owners_.find(owner_id);
+                if (public_status == PENDING) {
+                    if (queued_it != queued_owners_.end() &&
+                        !queued_it->second.submitted) {
+                        continue;
+                    }
+                }
+                if (public_status == COMPLETED) {
+                    success_tasks++;
+                    overall_status.transferred_bytes += task.request.length;
+                    continue;
+                }
+                if (public_status != PENDING) {
+                    failed_tasks++;
+                    if (isWorse(public_status, worst_failure))
+                        worst_failure = public_status;
+                    continue;
+                }
+            }
+        }
         TransferStatus task_status;
         if (task.status != PENDING) {
             if (task.status == COMPLETED) {
@@ -1710,6 +1948,15 @@ Status TransferEngineImpl::getBatchStatus(BatchID batch_id,
         auto prev_status = task.status;
         CHECK_STATUS(pollTaskStatus(batch, task_id, task_status));
         updateTaskStatusAfterPoll(batch, task_id, task_status, allow_failover);
+        if (runtime_queue_config_.enabled && batch->queue_token != 0 &&
+            task_status.s != PENDING) {
+            QueueOwnerId owner_id = 0;
+            auto resolve_status = runtime_queue_->resolveOwner(
+                batch->queue_token, task_id, owner_id);
+            if (resolve_status.ok()) {
+                CHECK_STATUS(finishQueuedOwner(owner_id, task_status.s));
+            }
+        }
 
         if (task_status.s == COMPLETED) {
             success_tasks++;

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -1642,6 +1642,12 @@ Status TransferEngineImpl::submitTransfer(
                           QueueOwnerKind::User);
 }
 
+Status TransferEngineImpl::submitStagingTransfer(
+    BatchID batch_id, const std::vector<Request>& request_list) {
+    return submitTransfer(batch_id, request_list, nullptr,
+                          QueueOwnerKind::StagingInternal);
+}
+
 void TransferEngineImpl::addSubmitHook(Batch* batch, size_t start_task_id,
                                        const std::vector<Request>& request_list,
                                        const Notification& notifi) {

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -1442,20 +1442,19 @@ Status TransferEngineImpl::submitTransfer(
     CHECK_STATUS(retainBatch(batch_id, batch));
     const size_t start_task_id = batch->task_list.size();
     auto status = submitTransferToBatch(batch, request_list);
-    if (!status.ok()) {
-        auto release_status = releaseBatch(batch);
-        return release_status.ok() ? status : release_status;
+    if (status.ok()) {
+        Batch::SubmitHook hook;
+        hook.start_task_id = start_task_id;
+        hook.end_task_id = start_task_id + request_list.size();
+        hook.notifi = notifi;
+        hook.fired = false;
+        for (const auto& request : request_list)
+            hook.targets.insert(request.target_id);
+        batch->submit_hooks.emplace_back(std::move(hook));
     }
-    const size_t end_task_id = start_task_id + request_list.size();
-    Batch::SubmitHook hook;
-    hook.start_task_id = start_task_id;
-    hook.end_task_id = end_task_id;
-    hook.notifi = notifi;
-    hook.fired = false;
-    for (const auto& request : request_list)
-        hook.targets.insert(request.target_id);
-    batch->submit_hooks.emplace_back(std::move(hook));
-    return releaseBatch(batch);
+
+    auto release_status = releaseBatch(batch);
+    return status.ok() ? release_status : status;
 }
 
 Status TransferEngineImpl::resubmitTransferTask(Batch* batch, size_t task_id) {

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -56,6 +56,8 @@ struct Batch {
     std::array<Transport::SubBatchRef, kSupportedTransportTypes> sub_batch;
     std::vector<TaskInfo> task_list;
     size_t max_size;
+    size_t runtime_refs{0};
+    bool free_requested{false};
 
     struct SubmitHook {
         size_t start_task_id{0};
@@ -416,7 +418,9 @@ Status TransferEngineImpl::deconstruct() {
     // Callers must ensure no transfers are in-flight before calling
     // deconstruct().
     batch_set_.forEach([&](BatchSet& entry) {
-        for (auto& batch : entry.active) {
+        std::unordered_set<Batch*> released_batches;
+        auto release_batch = [&](Batch* batch) {
+            if (!released_batches.insert(batch).second) return;
             for (size_t type = 0; type < kSupportedTransportTypes; ++type) {
                 auto& transport = transport_list_[type];
                 auto& sub_batch = batch->sub_batch[type];
@@ -424,16 +428,9 @@ Status TransferEngineImpl::deconstruct() {
                 transport->freeSubBatch(sub_batch);
             }
             Slab<Batch>::Get().deallocate(batch);
-        }
-        for (auto& batch : entry.freelist) {
-            for (size_t type = 0; type < kSupportedTransportTypes; ++type) {
-                auto& transport = transport_list_[type];
-                auto& sub_batch = batch->sub_batch[type];
-                if (!transport || !sub_batch) continue;
-                transport->freeSubBatch(sub_batch);
-            }
-            Slab<Batch>::Get().deallocate(batch);
-        }
+        };
+        for (auto& batch : entry.active) release_batch(batch);
+        for (auto& batch : entry.freelist) release_batch(batch);
         entry.active.clear();
         entry.freelist.clear();
     });
@@ -742,6 +739,10 @@ Status TransferEngineImpl::freeBatch(BatchID batch_id) {
     if (!batch_id) return Status::InvalidArgument("Invalid batch ID" LOC_MARK);
     Batch* batch = (Batch*)(batch_id);
     std::lock_guard<std::recursive_mutex> lk(progress_mutex_);
+    if (!alive_batches_.count(batch_id))
+        return Status::InvalidArgument("Batch is not alive" LOC_MARK);
+    if (batch->free_requested) return Status::OK();
+    batch->free_requested = true;
     batch_set_.get().freelist.push_back(batch);
     lazyFreeBatch();
     return Status::OK();
@@ -753,6 +754,10 @@ Status TransferEngineImpl::lazyFreeBatch() {
     for (auto it = batch_set.freelist.begin();
          it != batch_set.freelist.end();) {
         auto& batch = *it;
+        if (batch->runtime_refs > 0) {
+            it++;
+            continue;
+        }
         TransferStatus overall_status;
         CHECK_STATUS(getTransferStatus((BatchID)batch, overall_status));
         if (overall_status.s == PENDING) {
@@ -768,6 +773,33 @@ Status TransferEngineImpl::lazyFreeBatch() {
         alive_batches_.erase((BatchID)batch);
         Slab<Batch>::Get().deallocate(batch);
         it = batch_set.freelist.erase(it);
+    }
+    return Status::OK();
+}
+
+Status TransferEngineImpl::retainBatch(BatchID batch_id, Batch*& batch) {
+    if (!batch_id) return Status::InvalidArgument("Invalid batch ID" LOC_MARK);
+    std::lock_guard<std::recursive_mutex> lk(progress_mutex_);
+    if (!alive_batches_.count(batch_id)) {
+        return Status::InvalidArgument("Batch is not alive" LOC_MARK);
+    }
+    batch = (Batch*)batch_id;
+    if (batch->free_requested) {
+        return Status::InvalidArgument("Batch is being freed" LOC_MARK);
+    }
+    ++batch->runtime_refs;
+    return Status::OK();
+}
+
+Status TransferEngineImpl::releaseBatch(Batch* batch) {
+    if (!batch) return Status::InvalidArgument("Invalid batch" LOC_MARK);
+    std::lock_guard<std::recursive_mutex> lk(progress_mutex_);
+    if (batch->runtime_refs == 0) {
+        return Status::InternalError("Batch runtime ref underflow" LOC_MARK);
+    }
+    --batch->runtime_refs;
+    if (batch->runtime_refs == 0 && batch->free_requested) {
+        CHECK_STATUS(lazyFreeBatch());
     }
     return Status::OK();
 }
@@ -1363,8 +1395,11 @@ Status TransferEngineImpl::submitTransferToBatch(
 
 Status TransferEngineImpl::submitTransfer(
     BatchID batch_id, const std::vector<Request>& request_list) {
-    if (!batch_id) return Status::InvalidArgument("Invalid batch ID" LOC_MARK);
-    return submitTransferToBatch((Batch*)batch_id, request_list);
+    Batch* batch = nullptr;
+    CHECK_STATUS(retainBatch(batch_id, batch));
+    auto status = submitTransferToBatch(batch, request_list);
+    auto release_status = releaseBatch(batch);
+    return status.ok() ? release_status : status;
 }
 
 Status TransferEngineImpl::maybeFireSubmitHooks(Batch* batch, bool check) {
@@ -1402,10 +1437,14 @@ Status TransferEngineImpl::maybeFireSubmitHooks(Batch* batch, bool check) {
 Status TransferEngineImpl::submitTransfer(
     BatchID batch_id, const std::vector<Request>& request_list,
     const Notification& notifi) {
-    if (!batch_id) return Status::InvalidArgument("Invalid batch ID" LOC_MARK);
-    Batch* batch = (Batch*)(batch_id);
+    Batch* batch = nullptr;
+    CHECK_STATUS(retainBatch(batch_id, batch));
     const size_t start_task_id = batch->task_list.size();
-    CHECK_STATUS(submitTransfer(batch_id, request_list));
+    auto status = submitTransferToBatch(batch, request_list);
+    if (!status.ok()) {
+        auto release_status = releaseBatch(batch);
+        return release_status.ok() ? status : release_status;
+    }
     const size_t end_task_id = start_task_id + request_list.size();
     Batch::SubmitHook hook;
     hook.start_task_id = start_task_id;
@@ -1415,7 +1454,7 @@ Status TransferEngineImpl::submitTransfer(
     for (const auto& request : request_list)
         hook.targets.insert(request.target_id);
     batch->submit_hooks.emplace_back(std::move(hook));
-    return Status::OK();
+    return releaseBatch(batch);
 }
 
 Status TransferEngineImpl::resubmitTransferTask(Batch* batch, size_t task_id) {

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -288,6 +288,21 @@ Status TransferEngineImpl::construct() {
     enable_auto_failover_on_poll_ =
         conf_->get("enable_auto_failover_on_poll", true);
     enable_progress_worker_ = conf_->get("enable_progress_worker", false);
+    runtime_queue_config_.enabled = conf_->get("enable_runtime_queue", false);
+    runtime_queue_config_.limits.max_outstanding_owners =
+        conf_->get("runtime_queue/max_outstanding_owners", 1024UL);
+    runtime_queue_config_.limits.max_outstanding_bytes =
+        conf_->get("runtime_queue/max_outstanding_bytes", 1UL << 30);
+    runtime_queue_config_.limits.staging_owner_reserve =
+        conf_->get("runtime_queue/staging_owner_reserve", 0UL);
+    runtime_queue_config_.limits.staging_byte_reserve =
+        conf_->get("runtime_queue/staging_byte_reserve", 0UL);
+    runtime_queue_config_.max_dispatch_owners =
+        conf_->get("runtime_queue/max_dispatch_owners", 64UL);
+    runtime_queue_config_.max_dispatch_bytes =
+        conf_->get("runtime_queue/max_dispatch_bytes", 64UL << 20);
+    runtime_queue_ = std::make_unique<LocalTransferAdmissionQueue>(
+        runtime_queue_config_.limits);
     if (!hostname_.empty())
         CHECK_STATUS(checkLocalIpAddress(hostname_, ipv6_));
     else
@@ -1041,6 +1056,9 @@ struct TransferEngineImpl::PreparedSubmit {
     };
 
     struct Owner {
+        size_t owner_task_id{0};
+        bool has_owner_task_id{false};
+        std::vector<size_t> derived_task_ids;
         Request request{};
         SelectionResult route{};
         bool staging{false};
@@ -1317,11 +1335,20 @@ Status TransferEngineImpl::prepareSubmit(
     for (const auto& kv : merged.task_lookup) {
         const size_t public_task_index = kv.first;
         const size_t merged_task_index = kv.second;
+        auto& owner = prepared.owners[merged_task_index];
+        if (!owner.has_owner_task_id) {
+            owner.owner_task_id = public_task_index;
+            owner.has_owner_task_id = true;
+        } else {
+            owner.derived_task_ids.push_back(public_task_index);
+        }
         prepared.tasks.push_back(
             {merged_task_index, start_task_id + public_task_index});
     }
     return Status::OK();
 }
+
+uint64_t TransferEngineImpl::nextBatchToken() { return next_batch_token_++; }
 
 Status TransferEngineImpl::commitPreparedSubmit(
     Batch* batch, const PreparedSubmit& prepared) {

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -302,6 +302,12 @@ Status TransferEngineImpl::construct() {
         conf_->get("runtime_queue/max_dispatch_owners", 64UL);
     runtime_queue_config_.max_dispatch_bytes =
         conf_->get("runtime_queue/max_dispatch_bytes", 64UL << 20);
+    if (runtime_queue_config_.enabled &&
+        (runtime_queue_config_.max_dispatch_owners == 0 ||
+         runtime_queue_config_.max_dispatch_bytes == 0)) {
+        return Status::InvalidArgument(
+            "runtime queue dispatch window must be non-zero" LOC_MARK);
+    }
     runtime_queue_ = std::make_unique<LocalTransferAdmissionQueue>(
         runtime_queue_config_.limits);
     if (!hostname_.empty())
@@ -1474,6 +1480,10 @@ Status TransferEngineImpl::enqueuePreparedSubmit(Batch* batch,
     submit.batch_slots_left = batch->max_size - batch->task_list.size();
     submit.owners.reserve(prepared.owners.size());
     for (const auto& owner : prepared.owners) {
+        if (owner.request.length > runtime_queue_config_.max_dispatch_bytes) {
+            return Status::TooManyRequests(
+                "request exceeds runtime queue dispatch byte window" LOC_MARK);
+        }
         QueueOwnerInput input;
         input.owner_task_id = owner.owner_task_id;
         input.derived_task_ids = owner.derived_task_ids;

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -1604,6 +1604,7 @@ Status TransferEngineImpl::dispatchQueuedOwner(QueueOwnerId owner_id) {
     auto& transport = transport_list_[task.type];
     if (!transport) return finishQueuedOwner(owner_id, FAILED);
     auto& sub_batch = batch->sub_batch[task.type];
+    if (task.type == RDMA) sub_batch->device_mask = task.device_mask;
     task.sub_task_id = sub_batch->size();
     auto status = transport->submitTransferTasks(sub_batch, {task.request});
     if (!status.ok()) {

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -1507,6 +1507,7 @@ Status TransferEngineImpl::enqueuePreparedSubmit(Batch* batch,
         QueuedOwnerState queued;
         queued.batch = batch;
         queued.owner_task_id = prepared.owners[i].owner_task_id;
+        queued.byte_charge = prepared.owners[i].request.length;
         queued.public_task_ids.push_back(prepared.owners[i].owner_task_id);
         queued.public_task_ids.insert(
             queued.public_task_ids.end(),
@@ -1524,6 +1525,16 @@ Status TransferEngineImpl::finishQueuedOwner(
         return Status::InvalidEntry("queued owner not found" LOC_MARK);
     }
     auto& queued = queued_it->second;
+    if (queued.in_dispatch_window) {
+        if (dispatch_inflight_owners_ == 0 ||
+            dispatch_inflight_bytes_ < queued.byte_charge) {
+            return Status::InternalError(
+                "runtime dispatch window accounting underflow" LOC_MARK);
+        }
+        --dispatch_inflight_owners_;
+        dispatch_inflight_bytes_ -= queued.byte_charge;
+        queued.in_dispatch_window = false;
+    }
     CHECK_STATUS(runtime_queue_->complete(owner_id, terminal_status));
     for (const auto task_id : queued.public_task_ids) {
         queued.batch->task_list[task_id].status = terminal_status;
@@ -1537,6 +1548,20 @@ Status TransferEngineImpl::retireQueueForBatch(Batch* batch) {
     auto status = runtime_queue_->retireBatch(batch->queue_token);
     if (!status.ok()) return status;
     batch->queue_token = 0;
+    return Status::OK();
+}
+
+Status TransferEngineImpl::markQueuedOwnerSubmitted(QueueOwnerId owner_id) {
+    auto queued_it = queued_owners_.find(owner_id);
+    if (queued_it == queued_owners_.end()) {
+        return Status::InternalError("queued owner metadata missing" LOC_MARK);
+    }
+    auto& queued = queued_it->second;
+    if (!queued.in_dispatch_window) {
+        queued.in_dispatch_window = true;
+        ++dispatch_inflight_owners_;
+        dispatch_inflight_bytes_ += queued.byte_charge;
+    }
     return Status::OK();
 }
 
@@ -1562,8 +1587,7 @@ Status TransferEngineImpl::dispatchQueuedOwner(QueueOwnerId owner_id) {
             task.staging = true;
             auto status = staging_proxy_->submit(&task, staging_params);
             if (!status.ok()) return finishQueuedOwner(owner_id, FAILED);
-            queued_it->second.submitted = true;
-            return Status::OK();
+            return markQueuedOwnerSubmitted(owner_id);
         }
     }
 
@@ -1584,15 +1608,23 @@ Status TransferEngineImpl::dispatchQueuedOwner(QueueOwnerId owner_id) {
         task.type = UNSPEC;
         return finishQueuedOwner(owner_id, FAILED);
     }
-    queued_it->second.submitted = true;
-    return Status::OK();
+    return markQueuedOwnerSubmitted(owner_id);
 }
 
-Status TransferEngineImpl::dispatchQueuedTransfers() {
+Status TransferEngineImpl::refillDispatchWindow() {
+    std::lock_guard<std::recursive_mutex> lk(progress_mutex_);
     if (!runtime_queue_config_.enabled) return Status::OK();
-    auto picked = runtime_queue_->pickForDispatch(
-        runtime_queue_config_.max_dispatch_owners,
-        runtime_queue_config_.max_dispatch_bytes);
+    if (dispatch_inflight_owners_ >=
+            runtime_queue_config_.max_dispatch_owners ||
+        dispatch_inflight_bytes_ >= runtime_queue_config_.max_dispatch_bytes) {
+        return Status::OK();
+    }
+
+    const size_t owner_budget =
+        runtime_queue_config_.max_dispatch_owners - dispatch_inflight_owners_;
+    const size_t byte_budget =
+        runtime_queue_config_.max_dispatch_bytes - dispatch_inflight_bytes_;
+    auto picked = runtime_queue_->pickForDispatch(owner_budget, byte_budget);
     for (const auto owner_id : picked) {
         CHECK_STATUS(dispatchQueuedOwner(owner_id));
     }
@@ -1621,7 +1653,7 @@ Status TransferEngineImpl::submitTransfer(
     if (shouldQueueSubmit(prepared, owner_kind)) {
         CHECK_STATUS(
             enqueuePreparedSubmit(batch_ref.get(), prepared, owner_kind));
-        auto dispatch_status = dispatchQueuedTransfers();
+        auto dispatch_status = refillDispatchWindow();
         if (!dispatch_status.ok()) {
             LOG(WARNING) << "runtime queue dispatch failed after admission: "
                          << dispatch_status.ToString();
@@ -1826,7 +1858,7 @@ Status TransferEngineImpl::getTransferStatus(BatchID batch_id, size_t task_id,
         return Status::InvalidArgument("Invalid task ID" LOC_MARK);
     const size_t public_task_id = task_id;
     size_t poll_task_id = task_id;
-    CHECK_STATUS(dispatchQueuedTransfers());
+    CHECK_STATUS(refillDispatchWindow());
     if (runtime_queue_config_.enabled && batch->queue_token != 0) {
         QueueOwnerId owner_id = 0;
         auto resolve_status = runtime_queue_->resolveOwner(
@@ -1838,7 +1870,7 @@ Status TransferEngineImpl::getTransferStatus(BatchID batch_id, size_t task_id,
             auto queued_it = queued_owners_.find(owner_id);
             if (public_status != PENDING ||
                 (queued_it != queued_owners_.end() &&
-                 !queued_it->second.submitted)) {
+                 !queued_it->second.in_dispatch_window)) {
                 task_status.s = public_status;
                 task_status.transferred_bytes =
                     public_status == COMPLETED
@@ -1864,6 +1896,7 @@ Status TransferEngineImpl::getTransferStatus(BatchID batch_id, size_t task_id,
             batch->queue_token, public_task_id, owner_id);
         if (resolve_status.ok()) {
             CHECK_STATUS(finishQueuedOwner(owner_id, task_status.s));
+            CHECK_STATUS(refillDispatchWindow());
         }
     }
 
@@ -1898,7 +1931,7 @@ Status TransferEngineImpl::getBatchStatus(BatchID batch_id,
     std::lock_guard<std::recursive_mutex> lk(progress_mutex_);
     if (!alive_batches_.count(batch_id))
         return Status::InvalidArgument("Batch is not alive" LOC_MARK);
-    CHECK_STATUS(dispatchQueuedTransfers());
+    CHECK_STATUS(refillDispatchWindow());
     Batch* batch = (Batch*)(batch_id);
     overall_status.s = PENDING;
     overall_status.transferred_bytes = 0;
@@ -1928,7 +1961,7 @@ Status TransferEngineImpl::getBatchStatus(BatchID batch_id,
                 auto queued_it = queued_owners_.find(owner_id);
                 if (public_status == PENDING) {
                     if (queued_it != queued_owners_.end() &&
-                        !queued_it->second.submitted) {
+                        !queued_it->second.in_dispatch_window) {
                         continue;
                     }
                 }
@@ -1967,6 +2000,7 @@ Status TransferEngineImpl::getBatchStatus(BatchID batch_id,
                 batch->queue_token, task_id, owner_id);
             if (resolve_status.ok()) {
                 CHECK_STATUS(finishQueuedOwner(owner_id, task_status.s));
+                CHECK_STATUS(refillDispatchWindow());
             }
         }
 

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -1000,7 +1000,7 @@ struct MergeResult {
     std::map<size_t, size_t> task_lookup;
 };
 
-struct TransferEngineImpl::SubmitPlan {
+struct TransferEngineImpl::PreparedSubmit {
     struct Task {
         size_t merged_task_index{0};
         size_t task_id{0};
@@ -1248,17 +1248,18 @@ SelectionResult TransferEngineImpl::resolveTransport(const Request& req,
     return result;
 }
 
-Status TransferEngineImpl::buildSubmitPlan(
-    Batch* batch, const std::vector<Request>& request_list, SubmitPlan& plan) {
+Status TransferEngineImpl::prepareSubmit(
+    Batch* batch, const std::vector<Request>& request_list,
+    PreparedSubmit& prepared) {
     if (!batch) return Status::InvalidArgument("Invalid batch" LOC_MARK);
     for (size_t i = 0; i < request_list.size(); ++i) {
         auto st = validateTransportHint(request_list[i], i);
         if (!st.ok()) return st;
     }
 
-    plan = SubmitPlan{};
+    prepared = PreparedSubmit{};
     const size_t start_task_id = batch->task_list.size();
-    plan.submit_time = std::chrono::steady_clock::now();
+    prepared.submit_time = std::chrono::steady_clock::now();
     auto merge_boundaries =
         merge_requests_
             ? resolveRequestBoundaries(metadata_.get(), request_list)
@@ -1266,46 +1267,46 @@ Status TransferEngineImpl::buildSubmitPlan(
     auto merged =
         mergeRequests(request_list, merge_boundaries, merge_requests_);
 
-    plan.owners.reserve(merged.request_list.size());
+    prepared.owners.reserve(merged.request_list.size());
     for (const auto& request : merged.request_list) {
-        SubmitPlan::Owner owner;
+        PreparedSubmit::Owner owner;
         owner.request = request;
         owner.route = resolveTransport(owner.request, 0);
         if (owner.route.transport == TCP) {
             findStagingPolicy(owner.request, owner.staging_params);
             owner.staging = !owner.staging_params.empty() && staging_proxy_;
         }
-        plan.owners.push_back(std::move(owner));
+        prepared.owners.push_back(std::move(owner));
     }
 
-    plan.tasks.reserve(merged.task_lookup.size());
+    prepared.tasks.reserve(merged.task_lookup.size());
     for (const auto& kv : merged.task_lookup) {
         const size_t public_task_index = kv.first;
         const size_t merged_task_index = kv.second;
-        plan.tasks.push_back(
+        prepared.tasks.push_back(
             {merged_task_index, start_task_id + public_task_index});
     }
     return Status::OK();
 }
 
-Status TransferEngineImpl::commitSubmitPlan(Batch* batch,
-                                            const SubmitPlan& plan) {
+Status TransferEngineImpl::commitPreparedSubmit(
+    Batch* batch, const PreparedSubmit& prepared) {
     if (!batch) return Status::InvalidArgument("Invalid batch" LOC_MARK);
 
     std::vector<Request> classified_request_list[kSupportedTransportTypes];
     std::vector<size_t> task_id_list[kSupportedTransportTypes];
     std::unordered_map<size_t, TaskInfo> merged_task_id_map;
 
-    batch->task_list.insert(batch->task_list.end(), plan.tasks.size(),
+    batch->task_list.insert(batch->task_list.end(), prepared.tasks.size(),
                             TaskInfo{});
 
     std::unordered_map<TransportType, size_t> next_sub_task_id;
-    for (const auto& task_plan : plan.tasks) {
+    for (const auto& task_plan : prepared.tasks) {
         size_t task_id = task_plan.task_id;
         size_t merged_task_id = task_plan.merged_task_index;
         auto& task = batch->task_list[task_id];
-        const auto& owner_plan = plan.owners[merged_task_id];
-        auto& merged_request = owner_plan.request;
+        const auto& owner = prepared.owners[merged_task_id];
+        auto& merged_request = owner.request;
         if (merged_task_id_map.count(merged_task_id)) {
             task = merged_task_id_map[merged_task_id];
             task.derived = true;
@@ -1319,9 +1320,9 @@ Status TransferEngineImpl::commitSubmitPlan(Batch* batch,
         task.request = merged_request;
         task.staging = false;
         task.start_time =
-            plan.submit_time;  // Record start time for latency tracking
-        task.type = owner_plan.route.transport;
-        task.device_mask = owner_plan.route.device_mask;
+            prepared.submit_time;  // Record start time for latency tracking
+        task.type = owner.route.transport;
+        task.device_mask = owner.route.device_mask;
         if (task.type == UNSPEC) {
             LOG(WARNING) << "Unable to find registered buffer for request: "
                          << printRequest(merged_request);
@@ -1329,9 +1330,9 @@ Status TransferEngineImpl::commitSubmitPlan(Batch* batch,
             continue;
         }
 
-        if (owner_plan.staging) {
+        if (owner.staging) {
             task.staging = true;
-            staging_proxy_->submit(&task, owner_plan.staging_params);
+            staging_proxy_->submit(&task, owner.staging_params);
             continue;
         }
 
@@ -1387,9 +1388,9 @@ Status TransferEngineImpl::commitSubmitPlan(Batch* batch,
 
 Status TransferEngineImpl::submitTransferToBatch(
     Batch* batch, const std::vector<Request>& request_list) {
-    SubmitPlan plan;
-    CHECK_STATUS(buildSubmitPlan(batch, request_list, plan));
-    CHECK_STATUS(commitSubmitPlan(batch, plan));
+    PreparedSubmit prepared;
+    CHECK_STATUS(prepareSubmit(batch, request_list, prepared));
+    CHECK_STATUS(commitPreparedSubmit(batch, prepared));
     return Status::OK();
 }
 

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -1531,11 +1531,13 @@ Status TransferEngineImpl::finishQueuedOwner(
             return Status::InternalError(
                 "runtime dispatch window accounting underflow" LOC_MARK);
         }
+    }
+    CHECK_STATUS(runtime_queue_->complete(owner_id, terminal_status));
+    if (queued.in_dispatch_window) {
         --dispatch_inflight_owners_;
         dispatch_inflight_bytes_ -= queued.byte_charge;
         queued.in_dispatch_window = false;
     }
-    CHECK_STATUS(runtime_queue_->complete(owner_id, terminal_status));
     for (const auto task_id : queued.public_task_ids) {
         queued.batch->task_list[task_id].status = terminal_status;
     }

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -968,6 +968,24 @@ struct MergeResult {
     std::map<size_t, size_t> task_lookup;
 };
 
+struct TransferEngineImpl::SubmitPlan {
+    struct Task {
+        size_t merged_task_index{0};
+        size_t task_id{0};
+    };
+
+    struct Owner {
+        Request request{};
+        SelectionResult route{};
+        bool staging{false};
+        std::vector<std::string> staging_params;
+    };
+
+    std::chrono::steady_clock::time_point submit_time{};
+    std::vector<Task> tasks;
+    std::vector<Owner> owners;
+};
+
 namespace {
 
 bool tryAddUint64(uint64_t lhs, uint64_t rhs, uint64_t& out) {
@@ -1198,39 +1216,64 @@ SelectionResult TransferEngineImpl::resolveTransport(const Request& req,
     return result;
 }
 
-Status TransferEngineImpl::submitTransfer(
-    BatchID batch_id, const std::vector<Request>& request_list) {
-    if (!batch_id) return Status::InvalidArgument("Invalid batch ID" LOC_MARK);
-    Batch* batch = (Batch*)(batch_id);
-
+Status TransferEngineImpl::buildSubmitPlan(
+    Batch* batch, const std::vector<Request>& request_list, SubmitPlan& plan) {
+    if (!batch) return Status::InvalidArgument("Invalid batch" LOC_MARK);
     for (size_t i = 0; i < request_list.size(); ++i) {
         auto st = validateTransportHint(request_list[i], i);
         if (!st.ok()) return st;
     }
 
-    std::vector<Request> classified_request_list[kSupportedTransportTypes];
-    std::vector<size_t> task_id_list[kSupportedTransportTypes];
-    std::unordered_map<size_t, TaskInfo> merged_task_id_map;
-
-    size_t start_task_id = batch->task_list.size();
-    batch->task_list.insert(batch->task_list.end(), request_list.size(),
-                            TaskInfo{});
-
-    // Record start time for metrics tracking
-    auto submit_time = std::chrono::steady_clock::now();
-
+    plan = SubmitPlan{};
+    const size_t start_task_id = batch->task_list.size();
+    plan.submit_time = std::chrono::steady_clock::now();
     auto merge_boundaries =
         merge_requests_
             ? resolveRequestBoundaries(metadata_.get(), request_list)
             : std::vector<RequestBoundaryInfo>{};
     auto merged =
         mergeRequests(request_list, merge_boundaries, merge_requests_);
+
+    plan.owners.reserve(merged.request_list.size());
+    for (const auto& request : merged.request_list) {
+        SubmitPlan::Owner owner;
+        owner.request = request;
+        owner.route = resolveTransport(owner.request, 0);
+        if (owner.route.transport == TCP) {
+            findStagingPolicy(owner.request, owner.staging_params);
+            owner.staging = !owner.staging_params.empty() && staging_proxy_;
+        }
+        plan.owners.push_back(std::move(owner));
+    }
+
+    plan.tasks.reserve(merged.task_lookup.size());
+    for (const auto& kv : merged.task_lookup) {
+        const size_t public_task_index = kv.first;
+        const size_t merged_task_index = kv.second;
+        plan.tasks.push_back(
+            {merged_task_index, start_task_id + public_task_index});
+    }
+    return Status::OK();
+}
+
+Status TransferEngineImpl::commitSubmitPlan(Batch* batch,
+                                            const SubmitPlan& plan) {
+    if (!batch) return Status::InvalidArgument("Invalid batch" LOC_MARK);
+
+    std::vector<Request> classified_request_list[kSupportedTransportTypes];
+    std::vector<size_t> task_id_list[kSupportedTransportTypes];
+    std::unordered_map<size_t, TaskInfo> merged_task_id_map;
+
+    batch->task_list.insert(batch->task_list.end(), plan.tasks.size(),
+                            TaskInfo{});
+
     std::unordered_map<TransportType, size_t> next_sub_task_id;
-    for (auto& kv : merged.task_lookup) {
-        size_t task_id = start_task_id + kv.first;
-        size_t merged_task_id = kv.second;
+    for (const auto& task_plan : plan.tasks) {
+        size_t task_id = task_plan.task_id;
+        size_t merged_task_id = task_plan.merged_task_index;
         auto& task = batch->task_list[task_id];
-        auto& merged_request = merged.request_list[merged_task_id];
+        const auto& owner_plan = plan.owners[merged_task_id];
+        auto& merged_request = owner_plan.request;
         if (merged_task_id_map.count(merged_task_id)) {
             task = merged_task_id_map[merged_task_id];
             task.derived = true;
@@ -1244,10 +1287,9 @@ Status TransferEngineImpl::submitTransfer(
         task.request = merged_request;
         task.staging = false;
         task.start_time =
-            submit_time;  // Record start time for latency tracking
-        auto select_result = resolveTransport(merged_request, 0);
-        task.type = select_result.transport;
-        task.device_mask = select_result.device_mask;
+            plan.submit_time;  // Record start time for latency tracking
+        task.type = owner_plan.route.transport;
+        task.device_mask = owner_plan.route.device_mask;
         if (task.type == UNSPEC) {
             LOG(WARNING) << "Unable to find registered buffer for request: "
                          << printRequest(merged_request);
@@ -1255,14 +1297,10 @@ Status TransferEngineImpl::submitTransfer(
             continue;
         }
 
-        if (task.type == TCP) {
-            std::vector<std::string> staging_params;
-            findStagingPolicy(merged_request, staging_params);
-            if (!staging_params.empty() && staging_proxy_) {
-                task.staging = true;
-                staging_proxy_->submit(&task, staging_params);
-                continue;
-            }
+        if (owner_plan.staging) {
+            task.staging = true;
+            staging_proxy_->submit(&task, owner_plan.staging_params);
+            continue;
         }
 
         if (!batch->sub_batch[task.type]) {
@@ -1313,6 +1351,20 @@ Status TransferEngineImpl::submitTransfer(
     }
 
     return Status::OK();
+}
+
+Status TransferEngineImpl::submitTransferToBatch(
+    Batch* batch, const std::vector<Request>& request_list) {
+    SubmitPlan plan;
+    CHECK_STATUS(buildSubmitPlan(batch, request_list, plan));
+    CHECK_STATUS(commitSubmitPlan(batch, plan));
+    return Status::OK();
+}
+
+Status TransferEngineImpl::submitTransfer(
+    BatchID batch_id, const std::vector<Request>& request_list) {
+    if (!batch_id) return Status::InvalidArgument("Invalid batch ID" LOC_MARK);
+    return submitTransferToBatch((Batch*)batch_id, request_list);
 }
 
 Status TransferEngineImpl::maybeFireSubmitHooks(Batch* batch, bool check) {

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -1658,6 +1658,7 @@ Status TransferEngineImpl::submitTransfer(
             LOG(WARNING) << "runtime queue dispatch failed after admission: "
                          << dispatch_status.ToString();
         }
+        notifyRuntimeQueueReady();
     } else {
         CHECK_STATUS(commitPreparedSubmit(batch_ref.get(), prepared));
     }
@@ -2043,6 +2044,10 @@ Status TransferEngineImpl::progressBatch(BatchID batch_id,
 
 void TransferEngineImpl::notifyBatchMaybeReady(BatchID batch_id) {
     if (progress_worker_) progress_worker_->notifyBatchMaybeReady(batch_id);
+}
+
+void TransferEngineImpl::notifyRuntimeQueueReady() {
+    if (progress_worker_) progress_worker_->notifyRuntimeQueueReady();
 }
 
 Status TransferEngineImpl::waitTransferCompletion(BatchID batch_id) {

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -741,7 +741,10 @@ Status TransferEngineImpl::freeBatch(BatchID batch_id) {
     std::lock_guard<std::recursive_mutex> lk(progress_mutex_);
     if (!alive_batches_.count(batch_id))
         return Status::InvalidArgument("Batch is not alive" LOC_MARK);
-    if (batch->free_requested) return Status::OK();
+    if (batch->free_requested) {
+        CHECK_STATUS(lazyFreeBatch());
+        return Status::OK();
+    }
     batch->free_requested = true;
     batch_set_.get().freelist.push_back(batch);
     lazyFreeBatch();
@@ -803,6 +806,37 @@ Status TransferEngineImpl::releaseBatch(Batch* batch) {
     }
     return Status::OK();
 }
+
+class TransferEngineImpl::BatchRef {
+   public:
+    BatchRef(TransferEngineImpl& engine, Batch* batch)
+        : engine_(engine), batch_(batch) {}
+
+    ~BatchRef() {
+        if (!batch_) return;
+        auto status = engine_.releaseBatch(batch_);
+        if (!status.ok()) {
+            LOG(WARNING) << "failed to release batch ref: "
+                         << status.ToString();
+        }
+    }
+
+    BatchRef(const BatchRef&) = delete;
+    BatchRef& operator=(const BatchRef&) = delete;
+
+    Batch* get() const { return batch_; }
+
+    Status release() {
+        if (!batch_) return Status::OK();
+        auto status = engine_.releaseBatch(batch_);
+        batch_ = nullptr;
+        return status;
+    }
+
+   private:
+    TransferEngineImpl& engine_;
+    Batch* batch_{nullptr};
+};
 
 static bool isGpuType(MemoryType t) {
     return t == MTYPE_CUDA || t == MTYPE_ROCM;
@@ -1398,9 +1432,9 @@ Status TransferEngineImpl::submitTransfer(
     BatchID batch_id, const std::vector<Request>& request_list) {
     Batch* batch = nullptr;
     CHECK_STATUS(retainBatch(batch_id, batch));
-    auto status = submitTransferToBatch(batch, request_list);
-    auto release_status = releaseBatch(batch);
-    return status.ok() ? release_status : status;
+    BatchRef batch_ref(*this, batch);
+    CHECK_STATUS(submitTransferToBatch(batch_ref.get(), request_list));
+    return batch_ref.release();
 }
 
 Status TransferEngineImpl::maybeFireSubmitHooks(Batch* batch, bool check) {
@@ -1440,21 +1474,19 @@ Status TransferEngineImpl::submitTransfer(
     const Notification& notifi) {
     Batch* batch = nullptr;
     CHECK_STATUS(retainBatch(batch_id, batch));
-    const size_t start_task_id = batch->task_list.size();
-    auto status = submitTransferToBatch(batch, request_list);
-    if (status.ok()) {
-        Batch::SubmitHook hook;
-        hook.start_task_id = start_task_id;
-        hook.end_task_id = start_task_id + request_list.size();
-        hook.notifi = notifi;
-        hook.fired = false;
-        for (const auto& request : request_list)
-            hook.targets.insert(request.target_id);
-        batch->submit_hooks.emplace_back(std::move(hook));
-    }
+    BatchRef batch_ref(*this, batch);
+    const size_t start_task_id = batch_ref.get()->task_list.size();
+    CHECK_STATUS(submitTransferToBatch(batch_ref.get(), request_list));
 
-    auto release_status = releaseBatch(batch);
-    return status.ok() ? release_status : status;
+    Batch::SubmitHook hook;
+    hook.start_task_id = start_task_id;
+    hook.end_task_id = start_task_id + request_list.size();
+    hook.notifi = notifi;
+    hook.fired = false;
+    for (const auto& request : request_list)
+        hook.targets.insert(request.target_id);
+    batch_ref.get()->submit_hooks.emplace_back(std::move(hook));
+    return batch_ref.release();
 }
 
 Status TransferEngineImpl::resubmitTransferTask(Batch* batch, size_t task_id) {

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -1824,45 +1824,51 @@ Status TransferEngineImpl::getTransferStatus(BatchID batch_id, size_t task_id,
     Batch* batch = (Batch*)(batch_id);
     if (task_id >= batch->task_list.size())
         return Status::InvalidArgument("Invalid task ID" LOC_MARK);
+    const size_t public_task_id = task_id;
+    size_t poll_task_id = task_id;
     CHECK_STATUS(dispatchQueuedTransfers());
     if (runtime_queue_config_.enabled && batch->queue_token != 0) {
         QueueOwnerId owner_id = 0;
-        auto resolve_status =
-            runtime_queue_->resolveOwner(batch->queue_token, task_id, owner_id);
+        auto resolve_status = runtime_queue_->resolveOwner(
+            batch->queue_token, public_task_id, owner_id);
         if (resolve_status.ok()) {
             TransferStatusEnum public_status = PENDING;
             CHECK_STATUS(runtime_queue_->getPublicStatus(
-                batch->queue_token, task_id, public_status));
+                batch->queue_token, public_task_id, public_status));
             auto queued_it = queued_owners_.find(owner_id);
-            if (public_status != PENDING || batch->task_list[task_id].derived ||
+            if (public_status != PENDING ||
                 (queued_it != queued_owners_.end() &&
                  !queued_it->second.submitted)) {
                 task_status.s = public_status;
                 task_status.transferred_bytes =
                     public_status == COMPLETED
-                        ? batch->task_list[task_id].request.length
+                        ? batch->task_list[public_task_id].request.length
                         : 0;
                 return Status::OK();
             }
+            if (batch->task_list[public_task_id].derived &&
+                queued_it != queued_owners_.end()) {
+                poll_task_id = queued_it->second.owner_task_id;
+            }
         }
     }
-    auto& task = batch->task_list[task_id];
+    auto& task = batch->task_list[poll_task_id];
     auto prev_status = task.status;
-    CHECK_STATUS(pollTaskStatus(batch, task_id, task_status));
-    updateTaskStatusAfterPoll(batch, task_id, task_status,
+    CHECK_STATUS(pollTaskStatus(batch, poll_task_id, task_status));
+    updateTaskStatusAfterPoll(batch, poll_task_id, task_status,
                               enable_auto_failover_on_poll_);
     if (runtime_queue_config_.enabled && batch->queue_token != 0 &&
         task_status.s != PENDING) {
         QueueOwnerId owner_id = 0;
-        auto resolve_status =
-            runtime_queue_->resolveOwner(batch->queue_token, task_id, owner_id);
+        auto resolve_status = runtime_queue_->resolveOwner(
+            batch->queue_token, public_task_id, owner_id);
         if (resolve_status.ok()) {
             CHECK_STATUS(finishQueuedOwner(owner_id, task_status.s));
         }
     }
 
     // Record metrics when task transitions to terminal state
-    recordTaskCompletionMetrics(batch->task_list[task_id], prev_status,
+    recordTaskCompletionMetrics(batch->task_list[poll_task_id], prev_status,
                                 task_status.s);
 
     if (task_status.s == COMPLETED) CHECK_STATUS(maybeFireSubmitHooks(batch));

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -290,6 +290,7 @@ Status TransferEngineImpl::construct() {
         conf_->get("enable_auto_failover_on_poll", true);
     enable_progress_worker_ = conf_->get("enable_progress_worker", false);
     runtime_queue_config_.enabled = conf_->get("enable_runtime_queue", false);
+    if (runtime_queue_config_.enabled) enable_progress_worker_ = true;
     runtime_queue_config_.limits.max_outstanding_owners =
         conf_->get("runtime_queue/max_outstanding_owners", 1024UL);
     runtime_queue_config_.limits.max_outstanding_bytes =
@@ -1642,6 +1643,57 @@ Status TransferEngineImpl::refillDispatchWindow() {
         CHECK_STATUS(dispatchQueuedOwner(owner_id));
     }
     return Status::OK();
+}
+
+Status TransferEngineImpl::progressRuntimeQueue() {
+    std::lock_guard<std::recursive_mutex> lk(progress_mutex_);
+    if (!runtime_queue_config_.enabled) return Status::OK();
+
+    CHECK_STATUS(refillDispatchWindow());
+
+    std::vector<QueueOwnerId> owner_ids;
+    owner_ids.reserve(queued_owners_.size());
+    for (const auto& entry : queued_owners_) {
+        if (entry.second.in_dispatch_window) owner_ids.push_back(entry.first);
+    }
+
+    bool released_window = false;
+    for (const auto owner_id : owner_ids) {
+        auto queued_it = queued_owners_.find(owner_id);
+        if (queued_it == queued_owners_.end()) continue;
+
+        auto& queued = queued_it->second;
+        if (!queued.in_dispatch_window) continue;
+        auto* batch = queued.batch;
+        if (!batch || !alive_batches_.count((BatchID)batch)) continue;
+        if (queued.owner_task_id >= batch->task_list.size()) {
+            return Status::InternalError(
+                "queued owner task id out of range" LOC_MARK);
+        }
+
+        auto& task = batch->task_list[queued.owner_task_id];
+        auto prev_status = task.status;
+        TransferStatus task_status;
+        CHECK_STATUS(pollTaskStatus(batch, queued.owner_task_id, task_status));
+        updateTaskStatusAfterPoll(batch, queued.owner_task_id, task_status,
+                                  true);
+        recordTaskCompletionMetrics(task, prev_status, task_status.s);
+
+        if (task_status.s == PENDING) continue;
+
+        CHECK_STATUS(finishQueuedOwner(owner_id, task_status.s));
+        if (task_status.s == COMPLETED)
+            CHECK_STATUS(maybeFireSubmitHooks(batch));
+        released_window = true;
+    }
+
+    if (released_window) CHECK_STATUS(refillDispatchWindow());
+    return Status::OK();
+}
+
+bool TransferEngineImpl::hasActiveRuntimeQueue() {
+    std::lock_guard<std::recursive_mutex> lk(progress_mutex_);
+    return runtime_queue_config_.enabled && !queued_owners_.empty();
 }
 
 bool TransferEngineImpl::shouldQueueSubmit(const PreparedSubmit& prepared,

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -447,7 +447,8 @@ Status TransferEngineImpl::deconstruct() {
     // does not access transport-internal state (workers, connections).
     // Callers must ensure no transfers are in-flight before calling
     // deconstruct().
-    batch_set_.forEach([&](BatchSet& entry) {
+    {
+        std::lock_guard<std::recursive_mutex> lk(progress_mutex_);
         std::unordered_set<Batch*> released_batches;
         auto release_batch = [&](Batch* batch) {
             if (!released_batches.insert(batch).second) return;
@@ -459,11 +460,12 @@ Status TransferEngineImpl::deconstruct() {
             }
             Slab<Batch>::Get().deallocate(batch);
         };
-        for (auto& batch : entry.active) release_batch(batch);
-        for (auto& batch : entry.freelist) release_batch(batch);
-        entry.active.clear();
-        entry.freelist.clear();
-    });
+        for (auto& batch : batch_set_.active) release_batch(batch);
+        for (auto& batch : batch_set_.freelist) release_batch(batch);
+        batch_set_.active.clear();
+        batch_set_.freelist.clear();
+        alive_batches_.clear();
+    }
 
     // Now safe to destroy transports (workers join here)
     for (auto& transport : transport_list_) transport.reset();
@@ -757,12 +759,10 @@ BatchID TransferEngineImpl::allocateBatch(size_t batch_size) {
     Batch* batch = Slab<Batch>::Get().allocate();
     if (!batch) return (BatchID)0;
     batch->max_size = batch_size;
-    batch_set_.get().active.insert(batch);
     BatchID batch_id = (BatchID)batch;
-    {
-        std::lock_guard<std::recursive_mutex> lk(progress_mutex_);
-        alive_batches_.insert(batch_id);
-    }
+    std::lock_guard<std::recursive_mutex> lk(progress_mutex_);
+    batch_set_.active.insert(batch);
+    alive_batches_.insert(batch_id);
     return batch_id;
 }
 
@@ -783,16 +783,15 @@ Status TransferEngineImpl::freeBatch(BatchID batch_id) {
         return Status::OK();
     }
     batch->free_requested = true;
-    batch_set_.get().freelist.push_back(batch);
+    batch_set_.freelist.push_back(batch);
     lazyFreeBatch();
     return Status::OK();
 }
 
 Status TransferEngineImpl::lazyFreeBatch() {
-    // Caller must hold progress_mutex_.
-    auto& batch_set = batch_set_.get();
-    for (auto it = batch_set.freelist.begin();
-         it != batch_set.freelist.end();) {
+    std::lock_guard<std::recursive_mutex> lk(progress_mutex_);
+    for (auto it = batch_set_.freelist.begin();
+         it != batch_set_.freelist.end();) {
         auto& batch = *it;
         if (batch->runtime_refs > 0) {
             it++;
@@ -812,10 +811,10 @@ Status TransferEngineImpl::lazyFreeBatch() {
             auto& sub_batch = batch->sub_batch[type];
             if (transport && sub_batch) transport->freeSubBatch(sub_batch);
         }
-        batch_set.active.erase(batch);
+        batch_set_.active.erase(batch);
         alive_batches_.erase((BatchID)batch);
         Slab<Batch>::Get().deallocate(batch);
-        it = batch_set.freelist.erase(it);
+        it = batch_set_.freelist.erase(it);
     }
     return Status::OK();
 }

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -303,6 +303,9 @@ Status TransferEngineImpl::construct() {
         conf_->get("runtime_queue/max_dispatch_owners", 64UL);
     runtime_queue_config_.max_dispatch_bytes =
         conf_->get("runtime_queue/max_dispatch_bytes", 64UL << 20);
+    runtime_queue_config_.progress_fallback_interval =
+        std::chrono::microseconds(
+            conf_->get("runtime_queue/progress_fallback_interval_us", 50000UL));
     if (runtime_queue_config_.enabled &&
         (runtime_queue_config_.max_dispatch_owners == 0 ||
          runtime_queue_config_.max_dispatch_bytes == 0)) {
@@ -364,7 +367,10 @@ Status TransferEngineImpl::construct() {
     staging_proxy_ = std::make_unique<ProxyManager>(this);
 
     if (enable_progress_worker_) {
-        progress_worker_ = std::make_unique<ProgressWorker>(this);
+        progress_worker_ = std::make_unique<ProgressWorker>(
+            this, runtime_queue_config_.enabled
+                      ? runtime_queue_config_.progress_fallback_interval
+                      : std::chrono::microseconds(0));
         progress_worker_->start();
     }
 
@@ -411,10 +417,11 @@ Status TransferEngineImpl::deconstruct() {
     // Metrics cleanup is handled automatically by TentMetrics destructor
 
     // Stop the progress worker first so it cannot race with batch teardown
-    // below (it dereferences BatchID into Batch* via progressBatch).
+    // below (it dereferences BatchID into Batch* via progressBatch). Keep the
+    // object alive until transports are destroyed: completion paths may still
+    // issue a final no-op wake while their workers are joining.
     if (progress_worker_) {
         progress_worker_->stop();
-        progress_worker_.reset();
     }
 
     // Destroy staging_proxy_ first: its destructor calls back into
@@ -460,6 +467,7 @@ Status TransferEngineImpl::deconstruct() {
 
     // Now safe to destroy transports (workers join here)
     for (auto& transport : transport_list_) transport.reset();
+    progress_worker_.reset();
     local_segment_tracker_.reset();
     if (metadata_) {
         metadata_->segmentManager().deleteLocal();
@@ -1367,6 +1375,15 @@ Status TransferEngineImpl::prepareSubmit(
 
 uint64_t TransferEngineImpl::nextBatchToken() { return next_batch_token_++; }
 
+void TransferEngineImpl::attachProgressNotifier(
+    Batch* batch, Transport::SubBatchRef sub_batch) {
+    if (!batch || !sub_batch) return;
+    sub_batch->progress_batch_id = (BatchID)batch;
+    sub_batch->notify_progress = [this](BatchID batch_id) {
+        notifyBatchMaybeReady(batch_id);
+    };
+}
+
 Status TransferEngineImpl::commitPreparedSubmit(
     Batch* batch, const PreparedSubmit& prepared) {
     if (!batch) return Status::InvalidArgument("Invalid batch" LOC_MARK);
@@ -1410,7 +1427,7 @@ Status TransferEngineImpl::commitPreparedSubmit(
 
         if (owner.staging) {
             task.staging = true;
-            staging_proxy_->submit(&task, owner.staging_params);
+            staging_proxy_->submit(&task, (BatchID)batch, owner.staging_params);
             continue;
         }
 
@@ -1424,6 +1441,7 @@ Status TransferEngineImpl::commitPreparedSubmit(
                 merged_task_id_map[merged_task_id] = task;
                 continue;
             }
+            attachProgressNotifier(batch, batch->sub_batch[task.type]);
         }
 
         if (!next_sub_task_id.count(task.type))
@@ -1598,7 +1616,8 @@ Status TransferEngineImpl::dispatchQueuedOwner(QueueOwnerId owner_id) {
         findStagingPolicy(task.request, staging_params);
         if (!staging_params.empty() && staging_proxy_) {
             task.staging = true;
-            auto status = staging_proxy_->submit(&task, staging_params);
+            auto status =
+                staging_proxy_->submit(&task, (BatchID)batch, staging_params);
             if (!status.ok()) return finishQueuedOwner(owner_id, FAILED);
             return markQueuedOwnerSubmitted(owner_id);
         }
@@ -1610,6 +1629,7 @@ Status TransferEngineImpl::dispatchQueuedOwner(QueueOwnerId owner_id) {
         auto status = transport->allocateSubBatch(batch->sub_batch[task.type],
                                                   batch->max_size);
         if (!status.ok()) return finishQueuedOwner(owner_id, FAILED);
+        attachProgressNotifier(batch, batch->sub_batch[task.type]);
     }
 
     auto& transport = transport_list_[task.type];
@@ -1829,9 +1849,11 @@ Status TransferEngineImpl::resubmitTransferTask(Batch* batch, size_t task_id) {
     TENT_RECORD_TRANSPORT_FAILOVER();
 
     auto& transport = transport_list_[type];
-    if (!batch->sub_batch[type])
+    if (!batch->sub_batch[type]) {
         CHECK_STATUS(transport->allocateSubBatch(batch->sub_batch[type],
                                                  batch->max_size));
+        attachProgressNotifier(batch, batch->sub_batch[type]);
+    }
     auto& sub_batch = batch->sub_batch[type];
     task.sub_task_id = sub_batch->size();
     task.type = type;

--- a/mooncake-transfer-engine/tent/src/transport/io_uring/io_uring_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/io_uring/io_uring_transport.cpp
@@ -267,6 +267,7 @@ Status IOUringTransport::getTransferStatus(SubBatchRef batch, int task_id,
             }
         }
         io_uring_cqe_seen(&io_uring_batch->ring, cqe);
+        batch->notifyProgress();
     }
     return Status::OK();
 }

--- a/mooncake-transfer-engine/tent/src/transport/shm/shm_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/shm/shm_transport.cpp
@@ -132,6 +132,7 @@ void ShmTransport::startTransfer(ShmTask *task, ShmSubBatch *batch) {
     } else {
         task->status_word = TransferStatusEnum::FAILED;
     }
+    batch->notifyProgress();
 }
 
 Status ShmTransport::getTransferStatus(SubBatchRef batch, int task_id,

--- a/mooncake-transfer-engine/tent/src/transport/tcp/tcp_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/tcp/tcp_transport.cpp
@@ -152,6 +152,8 @@ Status TcpTransport::submitTransferTasks(
         tcp_batch->task_list.emplace_back();
         auto &task = tcp_batch->task_list.back();
         task.request = request;
+        task.progress_batch_id = batch->progress_batch_id;
+        task.notify_progress = batch->notify_progress;
         task.status_word.store(TransferStatusEnum::PENDING,
                                std::memory_order_release);
     }
@@ -211,6 +213,7 @@ void TcpTransport::startTransfer(TcpTask *task) {
         task->status_word.store(TransferStatusEnum::FAILED,
                                 std::memory_order_release);
     }
+    if (task->notify_progress) task->notify_progress(task->progress_batch_id);
 }
 
 Status TcpTransport::doTransferWithRetry(TcpTask *task) {

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -154,3 +154,15 @@ target_include_directories(tent_progress_worker_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME tent_progress_worker_test
          COMMAND tent_progress_worker_test)
+
+add_executable(tent_runtime_queue_dispatch_test
+               runtime_queue_dispatch_test.cpp)
+target_link_libraries(tent_runtime_queue_dispatch_test
+                      PRIVATE gtest gtest_main tent_link_group)
+if(TARGET asio_shared)
+  target_link_libraries(tent_runtime_queue_dispatch_test PRIVATE asio_shared)
+endif()
+target_include_directories(tent_runtime_queue_dispatch_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+add_test(NAME tent_runtime_queue_dispatch_test
+         COMMAND tent_runtime_queue_dispatch_test)

--- a/mooncake-transfer-engine/tent/tests/admission_queue_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/admission_queue_test.cpp
@@ -315,6 +315,25 @@ TEST(AdmissionQueueTest, RetainsTerminalStatusUntilBatchRetire) {
     EXPECT_EQ(status.code(), Status::Code::kInvalidEntry);
 }
 
+TEST(AdmissionQueueTest, RetainsSpecificTerminalStatus) {
+    LocalTransferAdmissionQueue queue({1, 128, 0, 0});
+    std::vector<QueueOwnerId> admitted_ids;
+
+    auto status =
+        queue.tryAdmit(makeSubmit(1, 1, {makeOwner(0, 16)}), admitted_ids);
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+
+    auto picked = queue.pickForDispatch(1, 16);
+    ASSERT_EQ(picked.size(), 1u);
+    status = queue.complete(picked[0], TransferStatusEnum::TIMEOUT);
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+
+    TransferStatusEnum public_status = TransferStatusEnum::PENDING;
+    status = queue.getPublicStatus(1, 0, public_status);
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+    EXPECT_EQ(public_status, TransferStatusEnum::TIMEOUT);
+}
+
 TEST(AdmissionQueueTest, RejectsRetireWithNonTerminalOwners) {
     LocalTransferAdmissionQueue queue({2, 128, 0, 0});
     std::vector<QueueOwnerId> admitted_ids;

--- a/mooncake-transfer-engine/tent/tests/progress_worker_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/progress_worker_test.cpp
@@ -20,7 +20,7 @@
 //     progressBatch / waitTransferCompletion) still sees its batch
 //     progress through failover;
 //   * one notify advances the engine by exactly one progress step;
-//   * freeBatch racing the worker is safe (no UAF, no crash);
+//   * freeBatch racing the worker, including cross-thread free, is safe;
 //   * worker shuts down cleanly on engine destruction.
 
 #include <gtest/gtest.h>
@@ -447,6 +447,46 @@ TEST(ProgressWorker, FreeBatchRacesWithWorker) {
 
     stop.store(true, std::memory_order_release);
     spammer.join();
+
+    EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), kBufLen).ok());
+}
+
+TEST(ProgressWorker, BatchMayBeFreedFromDifferentThread) {
+    auto cfg = makeMinimalP2PConfig();
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake_rdma = std::make_shared<FakeTransport>(RDMA);
+    std::string seg = engine.getSegmentName();
+    ASSERT_TRUE(fake_rdma->install(seg, nullptr, nullptr).ok());
+    engine.swapTransportForTest(RDMA, fake_rdma);
+
+    constexpr size_t kBufLen = 4096;
+    std::vector<uint8_t> buf(kBufLen, 0xC4);
+    ASSERT_TRUE(engine.registerLocalMemory(buf.data(), kBufLen).ok());
+
+    BatchID batch_id = 0;
+    std::thread allocator([&] { batch_id = engine.allocateBatch(1); });
+    allocator.join();
+    ASSERT_NE(batch_id, (BatchID)0);
+
+    Request req;
+    req.opcode = Request::WRITE;
+    req.source = buf.data();
+    req.target_id = LOCAL_SEGMENT_ID;
+    req.target_offset = reinterpret_cast<uint64_t>(buf.data());
+    req.length = kBufLen;
+    ASSERT_TRUE(engine.submitTransfer(batch_id, {req}).ok());
+
+    TransferStatus status{};
+    ASSERT_TRUE(engine.getTransferStatus(batch_id, status).ok());
+    ASSERT_EQ(status.s, TransferStatusEnum::COMPLETED);
+
+    std::atomic<bool> free_ok{false};
+    std::thread freer([&] { free_ok.store(engine.freeBatch(batch_id).ok()); });
+    freer.join();
+    EXPECT_TRUE(free_ok.load());
+    EXPECT_TRUE(engine.getTransferStatus(batch_id, status).IsInvalidArgument());
 
     EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), kBufLen).ok());
 }

--- a/mooncake-transfer-engine/tent/tests/runtime_queue_dispatch_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/runtime_queue_dispatch_test.cpp
@@ -304,9 +304,10 @@ TEST(RuntimeQueueDispatch, KeepsDispatchWindowUntilOwnerIsTerminal) {
     TransferEngineImpl engine(cfg);
     ASSERT_TRUE(engine.available());
 
+    std::atomic<bool> complete_first{false};
     auto fake_rdma = std::make_shared<FakeTransport>(
-        RDMA, [](const Request& request, int poll_count) {
-            if (poll_count == 1) {
+        RDMA, [&complete_first](const Request& request, int) {
+            if (!complete_first.load()) {
                 return TransferStatus{TransferStatusEnum::PENDING, 0};
             }
             return TransferStatus{TransferStatusEnum::COMPLETED,
@@ -339,12 +340,11 @@ TEST(RuntimeQueueDispatch, KeepsDispatchWindowUntilOwnerIsTerminal) {
     EXPECT_EQ(second.s, TransferStatusEnum::PENDING);
     EXPECT_EQ(fake_rdma->submit_calls.load(), 1);
 
+    complete_first.store(true);
     ASSERT_TRUE(engine.getTransferStatus(batch, 0, first).ok());
     EXPECT_EQ(first.s, TransferStatusEnum::COMPLETED);
     EXPECT_EQ(fake_rdma->submit_calls.load(), 2);
 
-    ASSERT_TRUE(engine.getTransferStatus(batch, 1, second).ok());
-    EXPECT_EQ(second.s, TransferStatusEnum::PENDING);
     ASSERT_TRUE(engine.getTransferStatus(batch, 1, second).ok());
     EXPECT_EQ(second.s, TransferStatusEnum::COMPLETED);
 
@@ -395,6 +395,56 @@ TEST(RuntimeQueueDispatch, ProgressWorkerRefillsWindowAfterProgress) {
         engine.unregisterLocalMemory(buffer.data(), buffer.size()).ok());
 }
 
+TEST(RuntimeQueueDispatch, RuntimeQueueDrainsWithoutUserPolling) {
+    auto cfg = makeRuntimeQueueConfig(1, 1UL << 20);
+    cfg->set("enable_progress_worker", false);
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake_rdma = std::make_shared<FakeTransport>(
+        RDMA, [](const Request& request, int poll_count) {
+            if (poll_count == 1) {
+                return TransferStatus{TransferStatusEnum::PENDING, 0};
+            }
+            return TransferStatus{TransferStatusEnum::COMPLETED,
+                                  request.length};
+        });
+    installFakeRdma(engine, fake_rdma);
+
+    constexpr size_t kReqLen = 4096;
+    std::vector<uint8_t> buffer(kReqLen * 2, 0x88);
+    ASSERT_TRUE(engine.registerLocalMemory(buffer.data(), buffer.size()).ok());
+
+    BatchID batch = engine.allocateBatch(2);
+    ASSERT_NE(batch, (BatchID)0);
+
+    ASSERT_TRUE(
+        engine
+            .submitTransfer(batch,
+                            {makeLocalWrite(buffer.data(), kReqLen),
+                             makeLocalWrite(buffer.data() + kReqLen, kReqLen)})
+            .ok());
+    EXPECT_EQ(fake_rdma->submit_calls.load(), 1);
+
+    const auto deadline =
+        std::chrono::steady_clock::now() + std::chrono::milliseconds(1000);
+    while (std::chrono::steady_clock::now() < deadline &&
+           (fake_rdma->submit_calls.load() < 2 ||
+            fake_rdma->status_calls.load() < 4)) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+    EXPECT_EQ(fake_rdma->submit_calls.load(), 2);
+    EXPECT_GE(fake_rdma->status_calls.load(), 4);
+
+    TransferStatus status{};
+    ASSERT_TRUE(engine.getTransferStatus(batch, status).ok());
+    EXPECT_EQ(status.s, TransferStatusEnum::COMPLETED);
+
+    EXPECT_TRUE(engine.freeBatch(batch).ok());
+    EXPECT_TRUE(
+        engine.unregisterLocalMemory(buffer.data(), buffer.size()).ok());
+}
+
 TEST(RuntimeQueueDispatch, EarlyFreeWaitsForQueuedCompletion) {
     auto cfg = makeRuntimeQueueConfig(1, 1UL << 20);
     TransferEngineImpl engine(cfg);
@@ -421,6 +471,15 @@ TEST(RuntimeQueueDispatch, EarlyFreeWaitsForQueuedCompletion) {
             .ok());
 
     ASSERT_TRUE(engine.freeBatch(batch).ok());
+
+    const auto deadline =
+        std::chrono::steady_clock::now() + std::chrono::milliseconds(1000);
+    while (std::chrono::steady_clock::now() < deadline &&
+           fake_rdma->status_calls.load() < 2) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+    EXPECT_GE(fake_rdma->status_calls.load(), 2);
+
     TransferStatus status{};
     ASSERT_TRUE(engine.getTransferStatus(batch, 0, status).ok());
     EXPECT_EQ(status.s, TransferStatusEnum::COMPLETED);

--- a/mooncake-transfer-engine/tent/tests/runtime_queue_dispatch_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/runtime_queue_dispatch_test.cpp
@@ -451,7 +451,7 @@ TEST(RuntimeQueueDispatch, RuntimeQueueDrainsWithoutUserPolling) {
         engine.unregisterLocalMemory(buffer.data(), buffer.size()).ok());
 }
 
-TEST(RuntimeQueueDispatch, EarlyFreeWaitsForQueuedCompletion) {
+TEST(RuntimeQueueDispatch, EarlyFreeReclaimsAfterQueuedCompletion) {
     auto cfg = makeRuntimeQueueConfig(1, 1UL << 20);
     TransferEngineImpl engine(cfg);
     ASSERT_TRUE(engine.available());
@@ -487,10 +487,6 @@ TEST(RuntimeQueueDispatch, EarlyFreeWaitsForQueuedCompletion) {
     EXPECT_GE(fake_rdma->status_calls.load(), 2);
 
     TransferStatus status{};
-    ASSERT_TRUE(engine.getTransferStatus(batch, 0, status).ok());
-    EXPECT_EQ(status.s, TransferStatusEnum::COMPLETED);
-
-    EXPECT_TRUE(engine.freeBatch(batch).ok());
     EXPECT_TRUE(engine.getTransferStatus(batch, 0, status).IsInvalidArgument());
     EXPECT_TRUE(
         engine.unregisterLocalMemory(buffer.data(), buffer.size()).ok());

--- a/mooncake-transfer-engine/tent/tests/runtime_queue_dispatch_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/runtime_queue_dispatch_test.cpp
@@ -15,10 +15,12 @@
 #include <gtest/gtest.h>
 
 #include <atomic>
+#include <chrono>
 #include <cstdlib>
 #include <functional>
 #include <memory>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -304,6 +306,48 @@ TEST(RuntimeQueueDispatch, KeepsDispatchWindowUntilOwnerIsTerminal) {
     EXPECT_EQ(second.s, TransferStatusEnum::PENDING);
     ASSERT_TRUE(engine.getTransferStatus(batch, 1, second).ok());
     EXPECT_EQ(second.s, TransferStatusEnum::COMPLETED);
+
+    EXPECT_TRUE(engine.freeBatch(batch).ok());
+    EXPECT_TRUE(
+        engine.unregisterLocalMemory(buffer.data(), buffer.size()).ok());
+}
+
+TEST(RuntimeQueueDispatch, ProgressWorkerRefillsWindowAfterProgress) {
+    auto cfg = makeRuntimeQueueConfig(1, 1UL << 20);
+    cfg->set("enable_progress_worker", true);
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake_rdma = std::make_shared<FakeTransport>(RDMA);
+    installFakeRdma(engine, fake_rdma);
+
+    constexpr size_t kReqLen = 4096;
+    std::vector<uint8_t> buffer(kReqLen * 2, 0x66);
+    ASSERT_TRUE(engine.registerLocalMemory(buffer.data(), buffer.size()).ok());
+
+    BatchID batch = engine.allocateBatch(2);
+    ASSERT_NE(batch, (BatchID)0);
+
+    ASSERT_TRUE(
+        engine
+            .submitTransfer(batch,
+                            {makeLocalWrite(buffer.data(), kReqLen),
+                             makeLocalWrite(buffer.data() + kReqLen, kReqLen)})
+            .ok());
+    EXPECT_EQ(fake_rdma->submit_calls.load(), 1);
+
+    engine.notifyBatchMaybeReady(batch);
+    const auto deadline =
+        std::chrono::steady_clock::now() + std::chrono::milliseconds(1000);
+    while (std::chrono::steady_clock::now() < deadline &&
+           fake_rdma->submit_calls.load() < 2) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+    EXPECT_EQ(fake_rdma->submit_calls.load(), 2);
+
+    TransferStatus status{};
+    ASSERT_TRUE(engine.getTransferStatus(batch, status).ok());
+    EXPECT_EQ(status.s, TransferStatusEnum::COMPLETED);
 
     EXPECT_TRUE(engine.freeBatch(batch).ok());
     EXPECT_TRUE(

--- a/mooncake-transfer-engine/tent/tests/runtime_queue_dispatch_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/runtime_queue_dispatch_test.cpp
@@ -50,9 +50,11 @@ class FakeTransport : public Transport {
         std::function<TransferStatus(const Request&, int)>;
 
     explicit FakeTransport(TransportType self_type,
-                           PollStatusFactory poll_status_factory = {})
+                           PollStatusFactory poll_status_factory = {},
+                           bool notify_on_submit = false)
         : self_type_(self_type),
-          poll_status_factory_(std::move(poll_status_factory)) {
+          poll_status_factory_(std::move(poll_status_factory)),
+          notify_on_submit_(notify_on_submit) {
         caps.dram_to_dram = true;
     }
 
@@ -87,6 +89,7 @@ class FakeTransport : public Transport {
             fake->poll_counts.push_back(0);
             ++fake->task_count;
         }
+        if (notify_on_submit_) batch->notifyProgress();
         return Status::OK();
     }
 
@@ -142,6 +145,7 @@ class FakeTransport : public Transport {
    private:
     TransportType self_type_;
     PollStatusFactory poll_status_factory_;
+    bool notify_on_submit_;
 };
 
 std::shared_ptr<Config> makeRuntimeQueueConfig(size_t max_dispatch_owners,
@@ -161,6 +165,7 @@ std::shared_ptr<Config> makeRuntimeQueueConfig(size_t max_dispatch_owners,
     cfg->set("runtime_queue/max_dispatch_bytes", max_dispatch_bytes);
     cfg->set("runtime_queue/staging_owner_reserve", 0UL);
     cfg->set("runtime_queue/staging_byte_reserve", 0UL);
+    cfg->set("runtime_queue/progress_fallback_interval_us", 50000UL);
 
     cfg->set("transports/tcp/enable", false);
     cfg->set("transports/shm/enable", false);
@@ -353,13 +358,15 @@ TEST(RuntimeQueueDispatch, KeepsDispatchWindowUntilOwnerIsTerminal) {
         engine.unregisterLocalMemory(buffer.data(), buffer.size()).ok());
 }
 
-TEST(RuntimeQueueDispatch, ProgressWorkerRefillsWindowAfterProgress) {
+TEST(RuntimeQueueDispatch, ProgressWorkerRefillsWindowFromTransportNotify) {
     auto cfg = makeRuntimeQueueConfig(1, 1UL << 20);
     cfg->set("enable_progress_worker", true);
+    cfg->set("runtime_queue/progress_fallback_interval_us", 0UL);
     TransferEngineImpl engine(cfg);
     ASSERT_TRUE(engine.available());
 
-    auto fake_rdma = std::make_shared<FakeTransport>(RDMA);
+    auto fake_rdma = std::make_shared<FakeTransport>(
+        RDMA, FakeTransport::PollStatusFactory{}, true);
     installFakeRdma(engine, fake_rdma);
 
     constexpr size_t kReqLen = 4096;
@@ -377,7 +384,6 @@ TEST(RuntimeQueueDispatch, ProgressWorkerRefillsWindowAfterProgress) {
             .ok());
     EXPECT_EQ(fake_rdma->submit_calls.load(), 1);
 
-    engine.notifyBatchMaybeReady(batch);
     const auto deadline =
         std::chrono::steady_clock::now() + std::chrono::milliseconds(1000);
     while (std::chrono::steady_clock::now() < deadline &&
@@ -397,7 +403,7 @@ TEST(RuntimeQueueDispatch, ProgressWorkerRefillsWindowAfterProgress) {
 
 TEST(RuntimeQueueDispatch, RuntimeQueueDrainsWithoutUserPolling) {
     auto cfg = makeRuntimeQueueConfig(1, 1UL << 20);
-    cfg->set("enable_progress_worker", false);
+    cfg->set("runtime_queue/progress_fallback_interval_us", 1000UL);
     TransferEngineImpl engine(cfg);
     ASSERT_TRUE(engine.available());
 

--- a/mooncake-transfer-engine/tent/tests/runtime_queue_dispatch_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/runtime_queue_dispatch_test.cpp
@@ -221,6 +221,47 @@ TEST(RuntimeQueueDispatch, RejectsOverfullBatchBeforePublishingTasks) {
         engine.unregisterLocalMemory(buffer.data(), buffer.size()).ok());
 }
 
+TEST(RuntimeQueueDispatch, RejectsOwnerLargerThanDispatchByteWindow) {
+    constexpr size_t kReqLen = 4096;
+    auto cfg = makeRuntimeQueueConfig(1, kReqLen - 1);
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake_rdma = std::make_shared<FakeTransport>(RDMA);
+    installFakeRdma(engine, fake_rdma);
+
+    std::vector<uint8_t> buffer(kReqLen, 0x77);
+    ASSERT_TRUE(engine.registerLocalMemory(buffer.data(), buffer.size()).ok());
+
+    BatchID batch = engine.allocateBatch(1);
+    ASSERT_NE(batch, (BatchID)0);
+
+    auto status =
+        engine.submitTransfer(batch, {makeLocalWrite(buffer.data(), kReqLen)});
+    EXPECT_TRUE(status.IsTooManyRequests()) << status.ToString();
+    EXPECT_EQ(fake_rdma->submit_calls.load(), 0);
+
+    TransferStatus task_status{};
+    EXPECT_TRUE(
+        engine.getTransferStatus(batch, 0, task_status).IsInvalidArgument());
+
+    EXPECT_TRUE(engine.freeBatch(batch).ok());
+    EXPECT_TRUE(
+        engine.unregisterLocalMemory(buffer.data(), buffer.size()).ok());
+}
+
+TEST(RuntimeQueueDispatch, RejectsEmptyDispatchWindowConfig) {
+    auto cfg = makeRuntimeQueueConfig(0, 1UL << 20);
+    TransferEngineImpl engine(cfg);
+
+    EXPECT_FALSE(engine.available());
+
+    cfg = makeRuntimeQueueConfig(1, 0);
+    TransferEngineImpl byte_window_engine(cfg);
+
+    EXPECT_FALSE(byte_window_engine.available());
+}
+
 TEST(RuntimeQueueDispatch, DispatchesOnlyOneWindowOnSubmit) {
     auto cfg = makeRuntimeQueueConfig(1, 1UL << 20);
     TransferEngineImpl engine(cfg);

--- a/mooncake-transfer-engine/tent/tests/runtime_queue_dispatch_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/runtime_queue_dispatch_test.cpp
@@ -1,0 +1,296 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cstdlib>
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "tent/common/config.h"
+#include "tent/common/types.h"
+#include "tent/runtime/segment.h"
+#include "tent/runtime/transfer_engine_impl.h"
+#include "tent/runtime/transport.h"
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+class FakeSubBatch : public Transport::SubBatch {
+   public:
+    size_t size() const override { return task_count; }
+
+    size_t task_count = 0;
+    std::vector<Request> requests;
+    std::vector<TransferStatus> statuses;
+    std::vector<int> poll_counts;
+};
+
+class FakeTransport : public Transport {
+   public:
+    using PollStatusFactory =
+        std::function<TransferStatus(const Request&, int)>;
+
+    explicit FakeTransport(TransportType self_type,
+                           PollStatusFactory poll_status_factory = {})
+        : self_type_(self_type),
+          poll_status_factory_(std::move(poll_status_factory)) {
+        caps.dram_to_dram = true;
+    }
+
+    std::atomic<int> submit_calls{0};
+    std::atomic<int> status_calls{0};
+
+    Status install(std::string&, std::shared_ptr<ControlService>,
+                   std::shared_ptr<Topology>,
+                   std::shared_ptr<Config> = nullptr) override {
+        return Status::OK();
+    }
+
+    Status allocateSubBatch(SubBatchRef& batch, size_t) override {
+        batch = new FakeSubBatch();
+        return Status::OK();
+    }
+
+    Status freeSubBatch(SubBatchRef& batch) override {
+        delete static_cast<FakeSubBatch*>(batch);
+        batch = nullptr;
+        return Status::OK();
+    }
+
+    Status submitTransferTasks(SubBatchRef batch,
+                               const std::vector<Request>& requests) override {
+        ++submit_calls;
+        auto* fake = static_cast<FakeSubBatch*>(batch);
+        for (const auto& request : requests) {
+            fake->requests.push_back(request);
+            fake->statuses.push_back(
+                {TransferStatusEnum::COMPLETED, request.length});
+            fake->poll_counts.push_back(0);
+            ++fake->task_count;
+        }
+        return Status::OK();
+    }
+
+    Status getTransferStatus(SubBatchRef batch, int task_id,
+                             TransferStatus& status) override {
+        ++status_calls;
+        auto* fake = static_cast<FakeSubBatch*>(batch);
+        if (task_id < 0 || task_id >= (int)fake->statuses.size()) {
+            return Status::InvalidArgument("bad task_id" LOC_MARK);
+        }
+        ++fake->poll_counts[task_id];
+        if (poll_status_factory_) {
+            status = poll_status_factory_(fake->requests[task_id],
+                                          fake->poll_counts[task_id]);
+        } else {
+            status = fake->statuses[task_id];
+        }
+        return Status::OK();
+    }
+
+    Status addMemoryBuffer(BufferDesc& desc, const MemoryOptions&) override {
+        desc.transports.push_back(self_type_);
+        return Status::OK();
+    }
+
+    Status addMemoryBuffer(std::vector<BufferDesc>& desc_list,
+                           const MemoryOptions& options) override {
+        for (auto& desc : desc_list) {
+            auto status = addMemoryBuffer(desc, options);
+            if (!status.ok()) return status;
+        }
+        return Status::OK();
+    }
+
+    Status removeMemoryBuffer(BufferDesc&) override { return Status::OK(); }
+
+    Status allocateLocalMemory(void** addr, size_t size,
+                               MemoryOptions&) override {
+        *addr = std::malloc(size);
+        return *addr ? Status::OK()
+                     : Status::InternalError("malloc failed" LOC_MARK);
+    }
+
+    Status freeLocalMemory(void* addr, size_t) override {
+        std::free(addr);
+        return Status::OK();
+    }
+
+    bool warmupMemory(void*, size_t) override { return false; }
+
+    const char* getName() const override { return "<fake-rdma>"; }
+
+   private:
+    TransportType self_type_;
+    PollStatusFactory poll_status_factory_;
+};
+
+std::shared_ptr<Config> makeRuntimeQueueConfig(size_t max_dispatch_owners,
+                                               size_t max_dispatch_bytes) {
+    auto cfg = std::make_shared<Config>();
+    cfg->set("metadata_type", "p2p");
+    cfg->set("metadata_servers", "");
+    cfg->set("rpc_server_hostname", "127.0.0.1");
+    cfg->set("rpc_server_port", "0");
+    cfg->set("log_level", "warning");
+    cfg->set("merge_requests", false);
+    cfg->set("enable_runtime_queue", true);
+    cfg->set("runtime_queue/max_outstanding_owners", 16UL);
+    cfg->set("runtime_queue/max_outstanding_bytes", 1UL << 20);
+    cfg->set("runtime_queue/max_dispatch_owners", max_dispatch_owners);
+    cfg->set("runtime_queue/max_dispatch_bytes", max_dispatch_bytes);
+    cfg->set("runtime_queue/staging_owner_reserve", 0UL);
+    cfg->set("runtime_queue/staging_byte_reserve", 0UL);
+
+    cfg->set("transports/tcp/enable", false);
+    cfg->set("transports/shm/enable", false);
+    cfg->set("transports/rdma/enable", false);
+    cfg->set("transports/io_uring/enable", false);
+    cfg->set("transports/nvlink/enable", false);
+    cfg->set("transports/mnnvl/enable", false);
+    cfg->set("transports/gds/enable", false);
+    cfg->set("transports/ascend_direct/enable", false);
+    return cfg;
+}
+
+void installFakeRdma(TransferEngineImpl& engine,
+                     const std::shared_ptr<FakeTransport>& fake_rdma) {
+    std::string seg_name = engine.getSegmentName();
+    ASSERT_TRUE(fake_rdma->install(seg_name, nullptr, nullptr).ok());
+    engine.swapTransportForTest(RDMA, fake_rdma);
+}
+
+Request makeLocalWrite(uint8_t* ptr, size_t length) {
+    Request request;
+    request.opcode = Request::WRITE;
+    request.source = ptr;
+    request.target_id = LOCAL_SEGMENT_ID;
+    request.target_offset = reinterpret_cast<uint64_t>(ptr);
+    request.length = length;
+    request.transport_hint = RDMA;
+    return request;
+}
+
+TEST(RuntimeQueueDispatch, RejectsOverfullBatchBeforePublishingTasks) {
+    auto cfg = makeRuntimeQueueConfig(1, 1UL << 20);
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake_rdma = std::make_shared<FakeTransport>(RDMA);
+    installFakeRdma(engine, fake_rdma);
+
+    constexpr size_t kReqLen = 4096;
+    std::vector<uint8_t> buffer(kReqLen * 2, 0x11);
+    ASSERT_TRUE(engine.registerLocalMemory(buffer.data(), buffer.size()).ok());
+
+    BatchID batch = engine.allocateBatch(1);
+    ASSERT_NE(batch, (BatchID)0);
+
+    auto status = engine.submitTransfer(
+        batch, {makeLocalWrite(buffer.data(), kReqLen),
+                makeLocalWrite(buffer.data() + kReqLen, kReqLen)});
+    EXPECT_TRUE(status.IsTooManyRequests()) << status.ToString();
+    EXPECT_EQ(fake_rdma->submit_calls.load(), 0);
+
+    TransferStatus task_status{};
+    EXPECT_TRUE(
+        engine.getTransferStatus(batch, 0, task_status).IsInvalidArgument());
+
+    EXPECT_TRUE(engine.freeBatch(batch).ok());
+    EXPECT_TRUE(
+        engine.unregisterLocalMemory(buffer.data(), buffer.size()).ok());
+}
+
+TEST(RuntimeQueueDispatch, DispatchesOnlyOneWindowOnSubmit) {
+    auto cfg = makeRuntimeQueueConfig(1, 1UL << 20);
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake_rdma = std::make_shared<FakeTransport>(RDMA);
+    installFakeRdma(engine, fake_rdma);
+
+    constexpr size_t kReqLen = 4096;
+    std::vector<uint8_t> buffer(kReqLen * 2, 0x22);
+    ASSERT_TRUE(engine.registerLocalMemory(buffer.data(), buffer.size()).ok());
+
+    BatchID batch = engine.allocateBatch(2);
+    ASSERT_NE(batch, (BatchID)0);
+
+    ASSERT_TRUE(
+        engine
+            .submitTransfer(batch,
+                            {makeLocalWrite(buffer.data(), kReqLen),
+                             makeLocalWrite(buffer.data() + kReqLen, kReqLen)})
+            .ok());
+    EXPECT_EQ(fake_rdma->submit_calls.load(), 1);
+
+    TransferStatus first{};
+    ASSERT_TRUE(engine.getTransferStatus(batch, 0, first).ok());
+    EXPECT_EQ(first.s, TransferStatusEnum::COMPLETED);
+    EXPECT_EQ(fake_rdma->submit_calls.load(), 2);
+
+    TransferStatus second{};
+    ASSERT_TRUE(engine.getTransferStatus(batch, 1, second).ok());
+    EXPECT_EQ(second.s, TransferStatusEnum::COMPLETED);
+
+    EXPECT_TRUE(engine.freeBatch(batch).ok());
+    EXPECT_TRUE(
+        engine.unregisterLocalMemory(buffer.data(), buffer.size()).ok());
+}
+
+TEST(RuntimeQueueDispatch, EarlyFreeWaitsForQueuedCompletion) {
+    auto cfg = makeRuntimeQueueConfig(1, 1UL << 20);
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake_rdma = std::make_shared<FakeTransport>(
+        RDMA, [](const Request& request, int poll_count) {
+            if (poll_count == 1) {
+                return TransferStatus{TransferStatusEnum::PENDING, 0};
+            }
+            return TransferStatus{TransferStatusEnum::COMPLETED,
+                                  request.length};
+        });
+    installFakeRdma(engine, fake_rdma);
+
+    constexpr size_t kReqLen = 4096;
+    std::vector<uint8_t> buffer(kReqLen, 0x33);
+    ASSERT_TRUE(engine.registerLocalMemory(buffer.data(), buffer.size()).ok());
+
+    BatchID batch = engine.allocateBatch(1);
+    ASSERT_NE(batch, (BatchID)0);
+    ASSERT_TRUE(
+        engine.submitTransfer(batch, {makeLocalWrite(buffer.data(), kReqLen)})
+            .ok());
+
+    ASSERT_TRUE(engine.freeBatch(batch).ok());
+    TransferStatus status{};
+    ASSERT_TRUE(engine.getTransferStatus(batch, 0, status).ok());
+    EXPECT_EQ(status.s, TransferStatusEnum::COMPLETED);
+
+    EXPECT_TRUE(engine.freeBatch(batch).ok());
+    EXPECT_TRUE(engine.getTransferStatus(batch, 0, status).IsInvalidArgument());
+    EXPECT_TRUE(
+        engine.unregisterLocalMemory(buffer.data(), buffer.size()).ok());
+}
+
+}  // namespace
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/tests/runtime_queue_dispatch_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/runtime_queue_dispatch_test.cpp
@@ -256,6 +256,60 @@ TEST(RuntimeQueueDispatch, DispatchesOnlyOneWindowOnSubmit) {
         engine.unregisterLocalMemory(buffer.data(), buffer.size()).ok());
 }
 
+TEST(RuntimeQueueDispatch, KeepsDispatchWindowUntilOwnerIsTerminal) {
+    auto cfg = makeRuntimeQueueConfig(1, 1UL << 20);
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake_rdma = std::make_shared<FakeTransport>(
+        RDMA, [](const Request& request, int poll_count) {
+            if (poll_count == 1) {
+                return TransferStatus{TransferStatusEnum::PENDING, 0};
+            }
+            return TransferStatus{TransferStatusEnum::COMPLETED,
+                                  request.length};
+        });
+    installFakeRdma(engine, fake_rdma);
+
+    constexpr size_t kReqLen = 4096;
+    std::vector<uint8_t> buffer(kReqLen * 2, 0x55);
+    ASSERT_TRUE(engine.registerLocalMemory(buffer.data(), buffer.size()).ok());
+
+    BatchID batch = engine.allocateBatch(2);
+    ASSERT_NE(batch, (BatchID)0);
+
+    ASSERT_TRUE(
+        engine
+            .submitTransfer(batch,
+                            {makeLocalWrite(buffer.data(), kReqLen),
+                             makeLocalWrite(buffer.data() + kReqLen, kReqLen)})
+            .ok());
+    EXPECT_EQ(fake_rdma->submit_calls.load(), 1);
+
+    TransferStatus first{};
+    ASSERT_TRUE(engine.getTransferStatus(batch, 0, first).ok());
+    EXPECT_EQ(first.s, TransferStatusEnum::PENDING);
+    EXPECT_EQ(fake_rdma->submit_calls.load(), 1);
+
+    TransferStatus second{};
+    ASSERT_TRUE(engine.getTransferStatus(batch, 1, second).ok());
+    EXPECT_EQ(second.s, TransferStatusEnum::PENDING);
+    EXPECT_EQ(fake_rdma->submit_calls.load(), 1);
+
+    ASSERT_TRUE(engine.getTransferStatus(batch, 0, first).ok());
+    EXPECT_EQ(first.s, TransferStatusEnum::COMPLETED);
+    EXPECT_EQ(fake_rdma->submit_calls.load(), 2);
+
+    ASSERT_TRUE(engine.getTransferStatus(batch, 1, second).ok());
+    EXPECT_EQ(second.s, TransferStatusEnum::PENDING);
+    ASSERT_TRUE(engine.getTransferStatus(batch, 1, second).ok());
+    EXPECT_EQ(second.s, TransferStatusEnum::COMPLETED);
+
+    EXPECT_TRUE(engine.freeBatch(batch).ok());
+    EXPECT_TRUE(
+        engine.unregisterLocalMemory(buffer.data(), buffer.size()).ok());
+}
+
 TEST(RuntimeQueueDispatch, EarlyFreeWaitsForQueuedCompletion) {
     auto cfg = makeRuntimeQueueConfig(1, 1UL << 20);
     TransferEngineImpl engine(cfg);

--- a/mooncake-transfer-engine/tent/tests/runtime_queue_dispatch_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/runtime_queue_dispatch_test.cpp
@@ -143,14 +143,15 @@ class FakeTransport : public Transport {
 };
 
 std::shared_ptr<Config> makeRuntimeQueueConfig(size_t max_dispatch_owners,
-                                               size_t max_dispatch_bytes) {
+                                               size_t max_dispatch_bytes,
+                                               bool merge_requests = false) {
     auto cfg = std::make_shared<Config>();
     cfg->set("metadata_type", "p2p");
     cfg->set("metadata_servers", "");
     cfg->set("rpc_server_hostname", "127.0.0.1");
     cfg->set("rpc_server_port", "0");
     cfg->set("log_level", "warning");
-    cfg->set("merge_requests", false);
+    cfg->set("merge_requests", merge_requests);
     cfg->set("enable_runtime_queue", true);
     cfg->set("runtime_queue/max_outstanding_owners", 16UL);
     cfg->set("runtime_queue/max_outstanding_bytes", 1UL << 20);
@@ -287,6 +288,42 @@ TEST(RuntimeQueueDispatch, EarlyFreeWaitsForQueuedCompletion) {
 
     EXPECT_TRUE(engine.freeBatch(batch).ok());
     EXPECT_TRUE(engine.getTransferStatus(batch, 0, status).IsInvalidArgument());
+    EXPECT_TRUE(
+        engine.unregisterLocalMemory(buffer.data(), buffer.size()).ok());
+}
+
+TEST(RuntimeQueueDispatch, PollingDerivedTaskCompletesMergedOwner) {
+    auto cfg = makeRuntimeQueueConfig(1, 1UL << 20, true);
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake_rdma = std::make_shared<FakeTransport>(RDMA);
+    installFakeRdma(engine, fake_rdma);
+
+    constexpr size_t kReqLen = 4096;
+    std::vector<uint8_t> buffer(kReqLen * 2, 0x44);
+    ASSERT_TRUE(engine.registerLocalMemory(buffer.data(), buffer.size()).ok());
+
+    BatchID batch = engine.allocateBatch(2);
+    ASSERT_NE(batch, (BatchID)0);
+
+    ASSERT_TRUE(
+        engine
+            .submitTransfer(batch,
+                            {makeLocalWrite(buffer.data(), kReqLen),
+                             makeLocalWrite(buffer.data() + kReqLen, kReqLen)})
+            .ok());
+    EXPECT_EQ(fake_rdma->submit_calls.load(), 1);
+
+    TransferStatus derived{};
+    ASSERT_TRUE(engine.getTransferStatus(batch, 1, derived).ok());
+    EXPECT_EQ(derived.s, TransferStatusEnum::COMPLETED);
+
+    TransferStatus owner{};
+    ASSERT_TRUE(engine.getTransferStatus(batch, 0, owner).ok());
+    EXPECT_EQ(owner.s, TransferStatusEnum::COMPLETED);
+
+    EXPECT_TRUE(engine.freeBatch(batch).ok());
     EXPECT_TRUE(
         engine.unregisterLocalMemory(buffer.data(), buffer.size()).ok());
 }


### PR DESCRIPTION
## Description

part of #2132 
  This PR wires the local admission queue into the transfer engine. When the runtime queue is enabled, prepared owners are admitted into `LocalTransferAdmissionQueue`, published into the batch only after admission succeeds, and dispatched through the existing transport or staging path under a bounded owner/byte window.

  Queue progress is driven by the engine's existing progress path. Transport and staging completion paths send a "maybe ready" wakeup to `ProgressWorker`; the worker then calls back into the engine to observe terminal status, release the dispatch window, and pick more queued owners. A low-frequency fallback tick remains for transports that do not yet provide completion wakeups.

  The queue is still disabled by default. When `enable_runtime_queue` is false, `submitTransfer()` keeps the existing direct-submit behavior.

  ```text
 submitTransfer()
    -> prepareSubmit()
    -> shouldQueueSubmit()

  queued path:
    -> enqueuePreparedSubmit()
         -> LocalTransferAdmissionQueue::tryAdmit()
         -> publish TaskInfo after admission succeeds
    -> refillDispatchWindow()
         -> pickForDispatch()
         -> dispatchQueuedOwner()
              -> Transport::submitTransferTasks()
              -> ProxyManager::submit() for staged transfers

  progress path:
    transport / ProxyManager maybe-ready wakeup
      -> ProgressWorker
      -> progressBatch() / progressRuntimeQueue()
      -> finishQueuedOwner() on terminal status
      -> refillDispatchWindow()
```
  This keeps the queue's existing all-or-nothing admission contract: failed admission does not publish TaskInfo,  terminal status is retained until batch retirement, and freeBatch() waits for queued work to become terminal before reclaiming the batch.

  This PR uses the queue's current FIFO pick order and bounded dispatch window. It does not add a new scheduling   policy.that can be built later on top of the pick step.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
  cmake --build build --target tent_runtime_queue_dispatch_test tent_progress_worker_test admission_queue_test
  ./build/mooncake-transfer-engine/tent/tests/tent_runtime_queue_dispatch_test
  ./build/mooncake-transfer-engine/tent/tests/tent_progress_worker_test
  ./build/mooncake-transfer-engine/tent/tests/admission_queue_test
```

**Test results:**
  - [x] Unit tests pass
  - [x] Queue dispatch tests pass
  - [x] Progress worker tests pass

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Claude Code was used to assist with implementation and review. The final changes were reviewed and validated by myself.