### PR TITLE
HipTransport: restore caller device after async transfer

### DIFF
--- a/mooncake-transfer-engine/include/hip_device_guard.h
+++ b/mooncake-transfer-engine/include/hip_device_guard.h
@@ -1,0 +1,55 @@
+// Copyright 2025 Mooncake Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#if defined(USE_HIP) || defined(USE_HIP_DMABUF)
+
+#include <hip/hip_runtime.h>
+
+namespace mooncake {
+
+// RAII guard that restores the calling thread's active HIP device on scope
+// exit. Functions that switch the device with hipSetDevice() (e.g. to pin a
+// transfer to the source GPU) would otherwise leave the caller pinned to the
+// wrong GPU, breaking its next kernel launch with hipErrorInvalidDevice.
+class HipDeviceGuard {
+   public:
+    // Save the current device; the caller switches devices afterwards.
+    HipDeviceGuard() { saved_ = (hipGetDevice(&prev_device_) == hipSuccess); }
+
+    // Save the current device and switch to target_device.
+    explicit HipDeviceGuard(int target_device) : HipDeviceGuard() {
+        set_ok_ = (hipSetDevice(target_device) == hipSuccess);
+    }
+
+    ~HipDeviceGuard() {
+        if (saved_) (void)hipSetDevice(prev_device_);
+    }
+
+    // Whether the target device passed to the constructor was set successfully.
+    bool set_ok() const { return set_ok_; }
+
+    HipDeviceGuard(const HipDeviceGuard&) = delete;
+    HipDeviceGuard& operator=(const HipDeviceGuard&) = delete;
+
+   private:
+    int prev_device_ = 0;
+    bool saved_ = false;
+    bool set_ok_ = true;
+};
+
+}  // namespace mooncake
+
+#endif  // USE_HIP || USE_HIP_DMABUF

--- a/mooncake-transfer-engine/include/hip_device_guard.h
+++ b/mooncake-transfer-engine/include/hip_device_guard.h
@@ -20,16 +20,14 @@
 
 namespace mooncake {
 
-// RAII guard that restores the calling thread's active HIP device on scope
-// exit. Functions that switch the device with hipSetDevice() (e.g. to pin a
-// transfer to the source GPU) would otherwise leave the caller pinned to the
-// wrong GPU, breaking its next kernel launch with hipErrorInvalidDevice.
+// RAII: saves the active HIP device and restores it on scope exit, so a
+// function that calls hipSetDevice() doesn't leave the caller on the wrong GPU
+// (which would fail its next kernel launch with hipErrorInvalidDevice).
 class HipDeviceGuard {
    public:
-    // Save the current device; the caller switches devices afterwards.
     HipDeviceGuard() { saved_ = (hipGetDevice(&prev_device_) == hipSuccess); }
 
-    // Save the current device and switch to target_device.
+    // Also switch to target_device; set_ok() reports whether that succeeded.
     explicit HipDeviceGuard(int target_device) : HipDeviceGuard() {
         set_ok_ = (hipSetDevice(target_device) == hipSuccess);
     }
@@ -38,7 +36,6 @@ class HipDeviceGuard {
         if (saved_) (void)hipSetDevice(prev_device_);
     }
 
-    // Whether the target device passed to the constructor was set successfully.
     bool set_ok() const { return set_ok_; }
 
     HipDeviceGuard(const HipDeviceGuard&) = delete;

--- a/mooncake-transfer-engine/src/transport/hip_transport/hip_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/hip_transport/hip_transport.cpp
@@ -27,6 +27,7 @@
 #include "common.h"
 #include "common/serialization.h"
 #include "config.h"
+#include "hip_device_guard.h"
 #include "transfer_metadata.h"
 #include "transport/transport.h"
 
@@ -251,16 +252,9 @@ static int setDeviceContext(void* source_ptr, int& device_id) {
 }
 
 static void setupP2PAccess(int num_devices) {
-    // Save the active device. The loop below calls hipSetDevice once per
-    // iteration; without restoring it before returning, the calling thread is
-    // left with its active device pinned to num_devices-1, causing downstream
-    // HIP calls on the same thread (e.g. PyTorch allocations in TP workers) to
-    // target the wrong GPU.
-    int original_device = -1;
-    if (!checkHip(hipGetDevice(&original_device),
-                  "HipTransport: failed to get current device")) {
-        return;
-    }
+    // The loop below switches the active device per iteration; the guard
+    // restores the caller's device on return so this is transparent to it.
+    HipDeviceGuard device_guard;
 
     auto clearStickyPeerAccessError = [](int src_device, int dst_device) {
         // hipDeviceEnablePeerAccess may leave hipErrorPeerAccessAlreadyEnabled
@@ -310,12 +304,6 @@ static void setupP2PAccess(int num_devices) {
                     << i << " and device " << j;
             }
         }
-    }
-
-    // Restore the active device so this function is transparent to the caller.
-    if (original_device >= 0) {
-        (void)checkHip(hipSetDevice(original_device),
-                       "HipTransport: failed to restore device");
     }
 }
 
@@ -457,16 +445,7 @@ Status HipTransport::startAsyncTransfer(const TransferRequest& request,
     hipError_t err;
     int device_id;
 
-    // setDeviceContext() below switches the active device to the source GPU.
-    // Restore the caller's device on every exit (RAII) so its next kernel launch
-    // doesn't hit hipErrorInvalidDevice; the guard also keeps device_id active
-    // through hipEventRecord, which needs the event/stream's device current.
-    int prev_device = 0;
-    (void)hipGetDevice(&prev_device);
-    struct DeviceGuard {
-        int prev;
-        ~DeviceGuard() { (void)hipSetDevice(prev); }
-    } device_guard{prev_device};
+    HipDeviceGuard device_guard;
 
     if (setDeviceContext(request.source, device_id) != 0) {
         return Status::InvalidArgument("Failed to set device context");

--- a/mooncake-transfer-engine/src/transport/hip_transport/hip_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/hip_transport/hip_transport.cpp
@@ -459,15 +459,20 @@ Status HipTransport::startAsyncTransfer(const TransferRequest& request,
 
     // setDeviceContext() switches the active device to the source GPU and the
     // async copy below is enqueued on a stream bound to that device. Without
-    // restoring the caller's device before returning, the host thread is left
-    // pinned to device_id, so the engine's next kernel launch on the same
-    // thread (e.g. a PyTorch op in a TP worker) targets the wrong GPU and
-    // fails with hipErrorInvalidDevice. Save it here and restore on every exit.
+    // restoring the caller's device the host thread is left pinned to the
+    // source GPU, so the engine's next kernel launch on the same thread (e.g. a
+    // PyTorch op in a TP worker) targets the wrong GPU and fails with
+    // hipErrorInvalidDevice. An RAII guard restores the device on every exit
+    // path and keeps device_id active through hipEventRecord below (which must
+    // run with the event/stream's device current).
     int prev_device = 0;
     (void)hipGetDevice(&prev_device);
+    struct DeviceGuard {
+        int prev;
+        ~DeviceGuard() { (void)hipSetDevice(prev); }
+    } device_guard{prev_device};
 
     if (setDeviceContext(request.source, device_id) != 0) {
-        (void)hipSetDevice(prev_device);
         return Status::InvalidArgument("Failed to set device context");
     }
 
@@ -504,7 +509,6 @@ Status HipTransport::startAsyncTransfer(const TransferRequest& request,
         if (event != nullptr) {
             event_pool_.putEvent(event, device_id);
         }
-        (void)hipSetDevice(prev_device);
         return Status::Memory("Failed to get event or stream from pool");
     }
 
@@ -520,12 +524,8 @@ Status HipTransport::startAsyncTransfer(const TransferRequest& request,
     if (!checkHip(err, "HipTransport: hipMemcpyAsync failed")) {
         slice->markFailed();
         event_pool_.putEvent(event, device_id);
-        (void)hipSetDevice(prev_device);
         return Status::Memory("HipTransport: Async memory copy failed");
     }
-    // The copy is queued on its device-bound stream; restore the caller's
-    // device so the engine's subsequent kernels run where they expect.
-    (void)hipSetDevice(prev_device);
 
     // Record event on the stream
     err = hipEventRecord(event, stream);

--- a/mooncake-transfer-engine/src/transport/hip_transport/hip_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/hip_transport/hip_transport.cpp
@@ -252,8 +252,7 @@ static int setDeviceContext(void* source_ptr, int& device_id) {
 }
 
 static void setupP2PAccess(int num_devices) {
-    // The loop below switches the active device per iteration; the guard
-    // restores the caller's device on return so this is transparent to it.
+    // The loop switches devices; the guard restores the caller's on return.
     HipDeviceGuard device_guard;
 
     auto clearStickyPeerAccessError = [](int src_device, int dst_device) {

--- a/mooncake-transfer-engine/src/transport/hip_transport/hip_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/hip_transport/hip_transport.cpp
@@ -457,7 +457,17 @@ Status HipTransport::startAsyncTransfer(const TransferRequest& request,
     hipError_t err;
     int device_id;
 
+    // setDeviceContext() switches the active device to the source GPU and the
+    // async copy below is enqueued on a stream bound to that device. Without
+    // restoring the caller's device before returning, the host thread is left
+    // pinned to device_id, so the engine's next kernel launch on the same
+    // thread (e.g. a PyTorch op in a TP worker) targets the wrong GPU and
+    // fails with hipErrorInvalidDevice. Save it here and restore on every exit.
+    int prev_device = 0;
+    (void)hipGetDevice(&prev_device);
+
     if (setDeviceContext(request.source, device_id) != 0) {
+        (void)hipSetDevice(prev_device);
         return Status::InvalidArgument("Failed to set device context");
     }
 
@@ -494,6 +504,7 @@ Status HipTransport::startAsyncTransfer(const TransferRequest& request,
         if (event != nullptr) {
             event_pool_.putEvent(event, device_id);
         }
+        (void)hipSetDevice(prev_device);
         return Status::Memory("Failed to get event or stream from pool");
     }
 
@@ -509,8 +520,12 @@ Status HipTransport::startAsyncTransfer(const TransferRequest& request,
     if (!checkHip(err, "HipTransport: hipMemcpyAsync failed")) {
         slice->markFailed();
         event_pool_.putEvent(event, device_id);
+        (void)hipSetDevice(prev_device);
         return Status::Memory("HipTransport: Async memory copy failed");
     }
+    // The copy is queued on its device-bound stream; restore the caller's
+    // device so the engine's subsequent kernels run where they expect.
+    (void)hipSetDevice(prev_device);
 
     // Record event on the stream
     err = hipEventRecord(event, stream);

--- a/mooncake-transfer-engine/src/transport/hip_transport/hip_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/hip_transport/hip_transport.cpp
@@ -457,14 +457,10 @@ Status HipTransport::startAsyncTransfer(const TransferRequest& request,
     hipError_t err;
     int device_id;
 
-    // setDeviceContext() switches the active device to the source GPU and the
-    // async copy below is enqueued on a stream bound to that device. Without
-    // restoring the caller's device the host thread is left pinned to the
-    // source GPU, so the engine's next kernel launch on the same thread (e.g. a
-    // PyTorch op in a TP worker) targets the wrong GPU and fails with
-    // hipErrorInvalidDevice. An RAII guard restores the device on every exit
-    // path and keeps device_id active through hipEventRecord below (which must
-    // run with the event/stream's device current).
+    // setDeviceContext() below switches the active device to the source GPU.
+    // Restore the caller's device on every exit (RAII) so its next kernel launch
+    // doesn't hit hipErrorInvalidDevice; the guard also keeps device_id active
+    // through hipEventRecord, which needs the event/stream's device current.
     int prev_device = 0;
     (void)hipGetDevice(&prev_device);
     struct DeviceGuard {

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -32,6 +32,7 @@
 #include "config.h"
 #include "cuda_alike.h"
 #include "environ.h"
+#include "hip_device_guard.h"
 #if defined(USE_HIP_DMABUF)
 #include <sys/utsname.h>
 
@@ -464,23 +465,8 @@ int RdmaContext::registerMemoryRegionInternal(void *addr, size_t length,
     } else if (hipAttr.type == hipMemoryTypeDevice) {
         // Device memory + kernel support — export dmabuf fd and register.
         // Pin to the owning device for the duration of the export calls.
-        struct HipDeviceGuard {
-            int prev_device = 0;
-            bool need_restore = false;
-            bool set_ok = false;
-            explicit HipDeviceGuard(int target_device) {
-                if (hipGetDevice(&prev_device) == hipSuccess) {
-                    need_restore = (prev_device != target_device);
-                }
-                set_ok = (hipSetDevice(target_device) == hipSuccess);
-            }
-            ~HipDeviceGuard() {
-                if (need_restore) {
-                    (void)hipSetDevice(prev_device);
-                }
-            }
-        } dev_guard(hipAttr.device);
-        if (!dev_guard.set_ok) {
+        HipDeviceGuard dev_guard(hipAttr.device);
+        if (!dev_guard.set_ok()) {
             LOG(ERROR) << "Failed to set HIP device to " << hipAttr.device
                        << " for dmabuf export of " << (uintptr_t)addr;
             return ERR_CONTEXT;

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -463,8 +463,7 @@ int RdmaContext::registerMemoryRegionInternal(void *addr, size_t length,
         mrMeta.addr = addr;
         mrMeta.mr = ibv_reg_mr(pd_, addr, length, access);
     } else if (hipAttr.type == hipMemoryTypeDevice) {
-        // Device memory + kernel support — export dmabuf fd and register.
-        // Pin to the owning device for the duration of the export calls.
+        // Pin to the owning device while exporting the dmabuf fd.
         HipDeviceGuard dev_guard(hipAttr.device);
         if (!dev_guard.set_ok()) {
             LOG(ERROR) << "Failed to set HIP device to " << hipAttr.device

--- a/mooncake-transfer-engine/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tests/CMakeLists.txt
@@ -75,6 +75,12 @@ if (USE_MNNVL)
     add_test(NAME nvlink_transport_test COMMAND nvlink_transport_test)
 endif()
 
+if (USE_HIP)
+    add_executable(hip_transport_test ${WORKSPACE}/hip_transport_test.cpp)
+    target_link_libraries(hip_transport_test PUBLIC transfer_engine gtest gtest_main )
+    add_test(NAME hip_transport_test COMMAND hip_transport_test)
+endif()
+
 if (USE_UBSHMEM)
     add_executable(ubshmem_transport_test ${WORKSPACE}/ubshmem_transport_test.cpp)
     target_link_libraries(ubshmem_transport_test PUBLIC transfer_engine gtest gtest_main ascendcl)

--- a/mooncake-transfer-engine/tests/hip_transport_test.cpp
+++ b/mooncake-transfer-engine/tests/hip_transport_test.cpp
@@ -26,23 +26,11 @@
 
 using namespace mooncake;
 
-// This test documents *why* HipTransport must restore the caller's active HIP
-// device after a transfer.
-//
-// HipTransport::startAsyncTransfer() calls setDeviceContext(request.source),
-// which switches the active device to the GPU that owns the source buffer, and
-// enqueues the copy on a stream bound to that device. The engine thread that
-// drives transfers is the SAME thread that subsequently launches compute
-// kernels — for example, a PyTorch op in a tensor-parallel worker that is also
-// pulling KV cache for intra-node prefill/decode disaggregation. If the
-// transport returns with the thread still pinned to the source GPU, the next
-// kernel launch on that thread targets the wrong device and fails with
-// hipErrorInvalidDevice (which surfaces asynchronously, often far from here).
-//
-// The test pins the calling thread to one GPU, runs a transfer whose source
-// buffer lives on a DIFFERENT GPU, and asserts the active device is unchanged
-// afterwards. Without the device-restore fix in startAsyncTransfer(), the
-// active device is left as the source GPU and the EXPECT_EQ below fails.
+// startAsyncTransfer() switches the active device to the source GPU; if it does
+// not restore it, the calling thread (which also launches the engine's compute
+// kernels) is left on the wrong GPU and the next kernel fails with
+// hipErrorInvalidDevice. This pins the caller to one GPU, transfers from a
+// buffer on a different GPU, and asserts the active device is unchanged.
 
 namespace {
 constexpr size_t kLen = 64 * 1024;
@@ -66,8 +54,7 @@ TEST(HipTransportTest, RestoresActiveDeviceAfterTransfer) {
     const int kCallerDevice = 0;  // device the engine thread runs on
     const int kSourceDevice = 1;  // KV source lives on a different GPU
 
-    // P2PHANDSHAKE keeps the test self-contained (no external etcd/http
-    // metadata server). The engine talks only to itself (loopback segment).
+    // P2PHANDSHAKE: self-contained loopback, no external metadata server.
     auto engine = std::make_unique<TransferEngine>(false);
     const std::string server_name = "127.0.0.1:17813";
     if (engine->init(P2PHANDSHAKE, server_name, "127.0.0.1", 17813) != 0) {
@@ -79,8 +66,7 @@ TEST(HipTransportTest, RestoresActiveDeviceAfterTransfer) {
         GTEST_SKIP() << "HIP transport unavailable (built without -DUSE_HIP=ON?).";
     }
 
-    // Source and destination buffers both live on kSourceDevice, so the
-    // transfer's source GPU differs from the calling thread's device.
+    // Both buffers on kSourceDevice so the source GPU differs from the caller.
     void* src = allocOnDevice(kLen, kSourceDevice);
     void* dst = allocOnDevice(kLen, kSourceDevice);
     ASSERT_EQ(engine->registerLocalMemory(src, kLen,
@@ -97,8 +83,7 @@ TEST(HipTransportTest, RestoresActiveDeviceAfterTransfer) {
     ASSERT_EQ(cudaMemset(src, 0xAB, kLen), cudaSuccess);
     ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
 
-    // Pin the calling thread to a device DIFFERENT from the source, mimicking
-    // the engine thread that will launch the next compute kernel.
+    // Pin the caller to a different device than the source, as the engine does.
     ASSERT_EQ(cudaSetDevice(kCallerDevice), cudaSuccess);
 
     auto batch_id = engine->allocateBatchID(1);
@@ -111,8 +96,7 @@ TEST(HipTransportTest, RestoresActiveDeviceAfterTransfer) {
     Status s = engine->submitTransfer(batch_id, {entry});
     ASSERT_TRUE(s.ok());
 
-    // The invariant under test: submitTransfer() must not leave the calling
-    // thread pinned to the source GPU. Before the fix this is kSourceDevice.
+    // Invariant: the caller's device is unchanged (== kSourceDevice before fix).
     int active_after_submit = -1;
     ASSERT_EQ(cudaGetDevice(&active_after_submit), cudaSuccess);
     EXPECT_EQ(active_after_submit, kCallerDevice)
@@ -120,15 +104,14 @@ TEST(HipTransportTest, RestoresActiveDeviceAfterTransfer) {
            "Leaving it on the source GPU corrupts the engine thread's HIP "
            "context, so its next kernel launch fails with hipErrorInvalidDevice.";
 
-    // Drain the transfer; also serves as a basic functional check that the
-    // copy still works with the device-restore in place.
+    // Drain the transfer (also a basic functional check).
     TransferStatus status;
     do {
         ASSERT_TRUE(engine->getTransferStatus(batch_id, 0, status).ok());
     } while (status.s == TransferStatusEnum::WAITING);
     EXPECT_EQ(status.s, TransferStatusEnum::COMPLETED);
 
-    // The active device must remain restored after completion as well.
+    // Still restored after completion polling.
     int active_after_wait = -1;
     ASSERT_EQ(cudaGetDevice(&active_after_wait), cudaSuccess);
     EXPECT_EQ(active_after_wait, kCallerDevice);

--- a/mooncake-transfer-engine/tests/hip_transport_test.cpp
+++ b/mooncake-transfer-engine/tests/hip_transport_test.cpp
@@ -63,17 +63,18 @@ TEST(HipTransportTest, RestoresActiveDeviceAfterTransfer) {
 
     Transport* transport = engine->installTransport("hip", nullptr);
     if (transport == nullptr) {
-        GTEST_SKIP() << "HIP transport unavailable (built without -DUSE_HIP=ON?).";
+        GTEST_SKIP()
+            << "HIP transport unavailable (built without -DUSE_HIP=ON?).";
     }
 
     // Both buffers on kSourceDevice so the source GPU differs from the caller.
     void* src = allocOnDevice(kLen, kSourceDevice);
     void* dst = allocOnDevice(kLen, kSourceDevice);
-    ASSERT_EQ(engine->registerLocalMemory(src, kLen,
-                                          "cuda:" + std::to_string(kSourceDevice)),
+    ASSERT_EQ(engine->registerLocalMemory(
+                  src, kLen, "cuda:" + std::to_string(kSourceDevice)),
               0);
-    ASSERT_EQ(engine->registerLocalMemory(dst, kLen,
-                                          "cuda:" + std::to_string(kSourceDevice)),
+    ASSERT_EQ(engine->registerLocalMemory(
+                  dst, kLen, "cuda:" + std::to_string(kSourceDevice)),
               0);
 
     auto segment_id = engine->openSegment(server_name);
@@ -96,13 +97,15 @@ TEST(HipTransportTest, RestoresActiveDeviceAfterTransfer) {
     Status s = engine->submitTransfer(batch_id, {entry});
     ASSERT_TRUE(s.ok());
 
-    // Invariant: the caller's device is unchanged (== kSourceDevice before fix).
+    // Invariant: the caller's device is unchanged (== kSourceDevice before
+    // fix).
     int active_after_submit = -1;
     ASSERT_EQ(cudaGetDevice(&active_after_submit), cudaSuccess);
     EXPECT_EQ(active_after_submit, kCallerDevice)
         << "startAsyncTransfer() must restore the caller's active device. "
            "Leaving it on the source GPU corrupts the engine thread's HIP "
-           "context, so its next kernel launch fails with hipErrorInvalidDevice.";
+           "context, so its next kernel launch fails with "
+           "hipErrorInvalidDevice.";
 
     // Drain the transfer (also a basic functional check).
     TransferStatus status;

--- a/mooncake-transfer-engine/tests/hip_transport_test.cpp
+++ b/mooncake-transfer-engine/tests/hip_transport_test.cpp
@@ -1,0 +1,148 @@
+// Copyright 2025 Mooncake Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+#include "cuda_alike.h"
+#include "transfer_engine.h"
+#include "transfer_metadata.h"  // P2PHANDSHAKE
+#include "transport/transport.h"
+
+using namespace mooncake;
+
+// This test documents *why* HipTransport must restore the caller's active HIP
+// device after a transfer.
+//
+// HipTransport::startAsyncTransfer() calls setDeviceContext(request.source),
+// which switches the active device to the GPU that owns the source buffer, and
+// enqueues the copy on a stream bound to that device. The engine thread that
+// drives transfers is the SAME thread that subsequently launches compute
+// kernels — for example, a PyTorch op in a tensor-parallel worker that is also
+// pulling KV cache for intra-node prefill/decode disaggregation. If the
+// transport returns with the thread still pinned to the source GPU, the next
+// kernel launch on that thread targets the wrong device and fails with
+// hipErrorInvalidDevice (which surfaces asynchronously, often far from here).
+//
+// The test pins the calling thread to one GPU, runs a transfer whose source
+// buffer lives on a DIFFERENT GPU, and asserts the active device is unchanged
+// afterwards. Without the device-restore fix in startAsyncTransfer(), the
+// active device is left as the source GPU and the EXPECT_EQ below fails.
+
+namespace {
+constexpr size_t kLen = 64 * 1024;
+
+void* allocOnDevice(size_t size, int device) {
+    EXPECT_EQ(cudaSetDevice(device), cudaSuccess);
+    void* ptr = nullptr;
+    EXPECT_EQ(cudaMalloc(&ptr, size), cudaSuccess);
+    return ptr;
+}
+}  // namespace
+
+TEST(HipTransportTest, RestoresActiveDeviceAfterTransfer) {
+    int device_count = 0;
+    ASSERT_EQ(cudaGetDeviceCount(&device_count), cudaSuccess);
+    if (device_count < 2) {
+        GTEST_SKIP() << "Needs >= 2 GPUs: the transfer source must live on a "
+                        "different device than the calling thread's device.";
+    }
+
+    const int kCallerDevice = 0;  // device the engine thread runs on
+    const int kSourceDevice = 1;  // KV source lives on a different GPU
+
+    // P2PHANDSHAKE keeps the test self-contained (no external etcd/http
+    // metadata server). The engine talks only to itself (loopback segment).
+    auto engine = std::make_unique<TransferEngine>(false);
+    const std::string server_name = "127.0.0.1:17813";
+    if (engine->init(P2PHANDSHAKE, server_name, "127.0.0.1", 17813) != 0) {
+        GTEST_SKIP() << "TransferEngine init failed in this environment.";
+    }
+
+    Transport* transport = engine->installTransport("hip", nullptr);
+    if (transport == nullptr) {
+        GTEST_SKIP() << "HIP transport unavailable (built without -DUSE_HIP=ON?).";
+    }
+
+    // Source and destination buffers both live on kSourceDevice, so the
+    // transfer's source GPU differs from the calling thread's device.
+    void* src = allocOnDevice(kLen, kSourceDevice);
+    void* dst = allocOnDevice(kLen, kSourceDevice);
+    ASSERT_EQ(engine->registerLocalMemory(src, kLen,
+                                          "cuda:" + std::to_string(kSourceDevice)),
+              0);
+    ASSERT_EQ(engine->registerLocalMemory(dst, kLen,
+                                          "cuda:" + std::to_string(kSourceDevice)),
+              0);
+
+    auto segment_id = engine->openSegment(server_name);
+    ASSERT_GE(segment_id, 0);
+
+    ASSERT_EQ(cudaSetDevice(kSourceDevice), cudaSuccess);
+    ASSERT_EQ(cudaMemset(src, 0xAB, kLen), cudaSuccess);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+    // Pin the calling thread to a device DIFFERENT from the source, mimicking
+    // the engine thread that will launch the next compute kernel.
+    ASSERT_EQ(cudaSetDevice(kCallerDevice), cudaSuccess);
+
+    auto batch_id = engine->allocateBatchID(1);
+    TransferRequest entry;
+    entry.opcode = TransferRequest::WRITE;
+    entry.length = kLen;
+    entry.source = src;  // on kSourceDevice
+    entry.target_id = segment_id;
+    entry.target_offset = reinterpret_cast<uint64_t>(dst);
+    Status s = engine->submitTransfer(batch_id, {entry});
+    ASSERT_TRUE(s.ok());
+
+    // The invariant under test: submitTransfer() must not leave the calling
+    // thread pinned to the source GPU. Before the fix this is kSourceDevice.
+    int active_after_submit = -1;
+    ASSERT_EQ(cudaGetDevice(&active_after_submit), cudaSuccess);
+    EXPECT_EQ(active_after_submit, kCallerDevice)
+        << "startAsyncTransfer() must restore the caller's active device. "
+           "Leaving it on the source GPU corrupts the engine thread's HIP "
+           "context, so its next kernel launch fails with hipErrorInvalidDevice.";
+
+    // Drain the transfer; also serves as a basic functional check that the
+    // copy still works with the device-restore in place.
+    TransferStatus status;
+    do {
+        ASSERT_TRUE(engine->getTransferStatus(batch_id, 0, status).ok());
+    } while (status.s == TransferStatusEnum::WAITING);
+    EXPECT_EQ(status.s, TransferStatusEnum::COMPLETED);
+
+    // The active device must remain restored after completion as well.
+    int active_after_wait = -1;
+    ASSERT_EQ(cudaGetDevice(&active_after_wait), cudaSuccess);
+    EXPECT_EQ(active_after_wait, kCallerDevice);
+
+    engine->freeBatchID(batch_id);
+    engine->unregisterLocalMemory(src);
+    engine->unregisterLocalMemory(dst);
+    (void)cudaSetDevice(kSourceDevice);
+    (void)cudaFree(src);
+    (void)cudaFree(dst);
+}
+
+int main(int argc, char** argv) {
+    gflags::ParseCommandLineFlags(&argc, &argv, false);
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/mooncake-transfer-engine/tests/hip_transport_test.cpp
+++ b/mooncake-transfer-engine/tests/hip_transport_test.cpp
@@ -90,7 +90,7 @@ TEST(HipTransportTest, RestoresActiveDeviceAfterTransfer) {
     TransferRequest entry;
     entry.opcode = TransferRequest::WRITE;
     entry.length = kLen;
-    entry.source = src;  // on kSourceDevice
+    entry.source = src;
     entry.target_id = segment_id;
     entry.target_offset = reinterpret_cast<uint64_t>(dst);
     Status s = engine->submitTransfer(batch_id, {entry});
@@ -111,7 +111,6 @@ TEST(HipTransportTest, RestoresActiveDeviceAfterTransfer) {
     } while (status.s == TransferStatusEnum::WAITING);
     EXPECT_EQ(status.s, TransferStatusEnum::COMPLETED);
 
-    // Still restored after completion polling.
     int active_after_wait = -1;
     ASSERT_EQ(cudaGetDevice(&active_after_wait), cudaSuccess);
     EXPECT_EQ(active_after_wait, kCallerDevice);


### PR DESCRIPTION
## Description

`HipTransport::startAsyncTransfer()` switches the active device to the source GPU (via `setDeviceContext()`) and enqueues the async copy on a stream bound to that device, but it never restores the caller's device before returning. The host thread is therefore left pinned to the source GPU.

In an intra-node prefill/decode KV-transfer setup, the transfer is driven from the same host thread that later launches the engine's compute kernels (e.g. a PyTorch op in a TP worker). With the device left switched, the next kernel runs on the wrong GPU and fails with `hipErrorInvalidDevice` (surfacing asynchronously, often in the sampler).

`setupP2PAccess()` already saves and restores the active device for exactly this reason; this PR applies the same discipline to `startAsyncTransfer()` via an RAII `DeviceGuard` (matching the `HipDeviceGuard` pattern in `rdma_context.cpp`). The guard restores the caller's device on every exit path and keeps `device_id` active for the whole function, including `hipEventRecord` (which must run with the event/stream's device current).

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

**Unit test (added in this PR):** `mooncake-transfer-engine/tests/hip_transport_test.cpp` (`HipTransportTest.RestoresActiveDeviceAfterTransfer`) documents and guards the exact case: it pins the calling thread to one GPU, runs a transfer whose source buffer lives on a *different* GPU, and asserts the active device is unchanged after `submitTransfer()`. Before the fix this returns the source GPU and the test fails; after it, it stays on the caller's device. The test uses a single-engine loopback over `P2PHANDSHAKE` (no external metadata server) and self-skips when fewer than 2 GPUs are visible. Gated behind `USE_HIP`.

**End-to-end:** built with `-DUSE_HIP=ON -DUSE_MNNVL=ON` on ROCm 7.2 / 8×MI355X (gfx950) and ran intra-node prefill/decode disaggregation over `protocol=hip` (XGMI), driving KV transfers from TP workers.

- **Before:** the first remote-prefill transfer leaves the worker thread on the source GPU; the subsequent forward/sampler kernel aborts with `hipErrorInvalidDevice`.
- **After:** the active device is preserved across `startAsyncTransfer()`; transfers complete and the engine produces correct output with no invalid-device errors across repeated requests.

No functional change on the transfer itself — the copy is still enqueued on the source device's stream; only the host thread's active device is restored.
