### PR TITLE
[TE] Make TransferEngine movable

### DIFF
--- a/mooncake-transfer-engine/include/transfer_engine.h
+++ b/mooncake-transfer-engine/include/transfer_engine.h
@@ -71,6 +71,10 @@ class TransferEngine {
 
     TransferEngine(bool auto_discover, const std::vector<std::string>& filter);
 
+    TransferEngine(TransferEngine&&) = default;
+
+    TransferEngine& operator=(TransferEngine&&) = default;
+
     ~TransferEngine();
 
     int init(const std::string& metadata_conn_string,


### PR DESCRIPTION
## Description

Make TransferEngine movable to prevent freeEngine() from being called multiple times when there are multiple copies of a TransferEngine object.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

This is a simple change and guarented to be correct according to C++ syntax, and the test has been performed on our private project.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [x] No AI tools were used