### PR TITLE
Infer gpu device from request source pointers, set correct device for stream creation.

### DIFF
--- a/mooncake-transfer-engine/tent/src/transport/mnnvl/mnnvl_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/mnnvl/mnnvl_transport.cpp
@@ -145,8 +145,8 @@ Status MnnvlTransport::allocateSubBatch(SubBatchRef &batch, size_t max_size) {
     batch = mnnvl_batch;
     mnnvl_batch->task_list.reserve(max_size);
     mnnvl_batch->max_size = max_size;
-    CHECK_STATUS(platform_->getStreamFromPool(mnnvl_batch->sync_stream));
-    CHECK_STATUS(platform_->getStreamFromPool(mnnvl_batch->async_stream));
+    // Streams are created lazily in submitTransferTasks where the correct
+    // GPU device can be inferred from request source pointers.
     return Status::OK();
 }
 
@@ -162,11 +162,35 @@ Status MnnvlTransport::freeSubBatch(SubBatchRef &batch) {
     return Status::OK();
 }
 
+static int detectDeviceFromPointer(void *ptr) {
+    if (!ptr) return -1;
+    cudaPointerAttributes attrs = {};
+    auto err = cudaPointerGetAttributes(&attrs, ptr);
+    if (err == cudaSuccess && attrs.type == cudaMemoryTypeDevice)
+        return attrs.device;
+    cudaGetLastError();
+    return -1;
+}
+
 Status MnnvlTransport::submitTransferTasks(
     SubBatchRef batch, const std::vector<Request> &request_list) {
     auto mnnvl_batch = dynamic_cast<MnnvlSubBatch *>(batch);
     if (!mnnvl_batch)
         return Status::InvalidArgument("Invalid MNNVL sub-batch" LOC_MARK);
+
+    if (!mnnvl_batch->async_stream.get()) {
+        int device_id = -1;
+        for (auto &req : request_list) {
+            device_id = detectDeviceFromPointer(req.source);
+            if (device_id >= 0) break;
+        }
+        if (device_id < 0) cudaGetDevice(&device_id);
+        CHECK_STATUS(
+            platform_->getStreamFromPool(mnnvl_batch->sync_stream, device_id));
+        CHECK_STATUS(
+            platform_->getStreamFromPool(mnnvl_batch->async_stream, device_id));
+    }
+
     if (request_list.size() + mnnvl_batch->task_list.size() >
         mnnvl_batch->max_size)
         return Status::TooManyRequests("Exceed batch capacity" LOC_MARK);

--- a/mooncake-transfer-engine/tent/src/transport/mnnvl/mnnvl_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/mnnvl/mnnvl_transport.cpp
@@ -162,7 +162,7 @@ Status MnnvlTransport::freeSubBatch(SubBatchRef &batch) {
     return Status::OK();
 }
 
-static int detectDeviceFromPointer(void* ptr) {
+static int detectDeviceFromPointer(void *ptr) {
     if (!ptr) return -1;
     cudaPointerAttributes attrs = {};
     auto err = cudaPointerGetAttributes(&attrs, ptr);

--- a/mooncake-transfer-engine/tent/src/transport/mnnvl/mnnvl_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/mnnvl/mnnvl_transport.cpp
@@ -162,7 +162,7 @@ Status MnnvlTransport::freeSubBatch(SubBatchRef &batch) {
     return Status::OK();
 }
 
-static int detectDeviceFromPointer(void *ptr) {
+static int detectDeviceFromPointer(void* ptr) {
     if (!ptr) return -1;
     cudaPointerAttributes attrs = {};
     auto err = cudaPointerGetAttributes(&attrs, ptr);

--- a/mooncake-transfer-engine/tent/src/transport/nvlink/nvlink_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/nvlink/nvlink_transport.cpp
@@ -54,6 +54,16 @@ Status restoreCudaDeviceForLocation(const LocationParser& location,
     return Status::OK();
 }
 
+int detectDeviceFromPointer(void *ptr) {
+    if (!ptr) return -1;
+    cudaPointerAttributes attrs = {};
+    auto err = cudaPointerGetAttributes(&attrs, ptr);
+    if (err == cudaSuccess && attrs.type == cudaMemoryTypeDevice)
+        return attrs.device;
+    cudaGetLastError();
+    return -1;
+}
+
 }  // namespace
 
 NVLinkTransport::NVLinkTransport() : installed_(false) {}
@@ -106,8 +116,8 @@ Status NVLinkTransport::allocateSubBatch(SubBatchRef& batch, size_t max_size) {
     batch = shm_batch;
     shm_batch->task_list.reserve(max_size);
     shm_batch->max_size = max_size;
-    CHECK_STATUS(platform_->getStreamFromPool(shm_batch->sync_stream));
-    CHECK_STATUS(platform_->getStreamFromPool(shm_batch->async_stream));
+    // Streams are created lazily in submitTransferTasks where the correct
+    // GPU device can be inferred from request source pointers.
     return Status::OK();
 }
 
@@ -128,6 +138,20 @@ Status NVLinkTransport::submitTransferTasks(
     auto shm_batch = dynamic_cast<NVLinkSubBatch*>(batch);
     if (!shm_batch)
         return Status::InvalidArgument("Invalid NVLink sub-batch" LOC_MARK);
+
+    if (!shm_batch->async_stream.get()) {
+        int device_id = -1;
+        for (auto& req : request_list) {
+            device_id = detectDeviceFromPointer(req.source);
+            if (device_id >= 0) break;
+        }
+        if (device_id < 0) cudaGetDevice(&device_id);
+        CHECK_STATUS(
+            platform_->getStreamFromPool(shm_batch->sync_stream, device_id));
+        CHECK_STATUS(
+            platform_->getStreamFromPool(shm_batch->async_stream, device_id));
+    }
+
     if (request_list.size() + shm_batch->task_list.size() > shm_batch->max_size)
         return Status::TooManyRequests("Exceed batch capacity" LOC_MARK);
     std::vector<NVLinkTask*> new_tasks;

--- a/mooncake-transfer-engine/tent/src/transport/nvlink/nvlink_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/nvlink/nvlink_transport.cpp
@@ -54,7 +54,7 @@ Status restoreCudaDeviceForLocation(const LocationParser& location,
     return Status::OK();
 }
 
-int detectDeviceFromPointer(void *ptr) {
+int detectDeviceFromPointer(void* ptr) {
     if (!ptr) return -1;
     cudaPointerAttributes attrs = {};
     auto err = cudaPointerGetAttributes(&attrs, ptr);


### PR DESCRIPTION
Infer gpu device from request source pointers, set correct device for stream creation.

## Description

In a 1P1D Prefill-Decode (PD) separation scenario with long sequences and high concurrency, we observed transmission timeouts in SGLang when using Mooncake Tent’s MNNVL transport for KV cache transfer. The root cause was identified as follows: when creating CUDA streams, Mooncake failed to switch the device context to the GPU corresponding to each TP rank. Consequently, all Mooncake instances across TP ranks initialized their streams on GPU 0. This caused DMA tasks from all ranks to be queued in GPU 0’s KMD (Kernel Mode Driver) queue, preventing the concurrent utilization of the independent copy engines on each GPU. As the number of ranks increased, the queue depth and latency on GPU 0 surged, ultimately triggering the SGLang timeouts.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Performance improvement
- [ ] Other

## How Has This Been Tested?

Prefill-Decode (PD) , 1p1d, input_len 8192, output_len 1024, concurrency 64/128