### PR TITLE
[Store] fix integer overflow in BatchOffload for objects larger than 4 GiB

### DIFF
--- a/mooncake-store/src/storage_backend.cpp
+++ b/mooncake-store/src/storage_backend.cpp
@@ -5,6 +5,7 @@
 #include <sys/stat.h>
 #include <sys/uio.h>
 #include <errno.h>
+#include <cstdint>
 #include <cstring>
 
 #include <regex>
@@ -2858,11 +2859,25 @@ tl::expected<int64_t, ErrorCode> OffsetAllocatorStorageBackend::BatchOffload(
             continue;  // Simulate allocation/write failure
         }
 
-        // Calculate total value size
-        uint32_t value_size = 0;
+        // Calculate total value size. RecordHeader stores value_len as a
+        // uint32_t (RecordHeader::SIZE is 8 bytes), so accumulating directly
+        // into a uint32_t would silently overflow for an object larger than
+        // 4 GiB: the record would be under-allocated and then its full slices
+        // written past the allocation. Sum in 64 bits and reject oversized
+        // objects instead of corrupting the storage arena.
+        uint64_t total_value_size = 0;
         for (const auto& slice : slices) {
-            value_size += static_cast<uint32_t>(slice.size);
+            total_value_size += slice.size;
         }
+        if (total_value_size > UINT32_MAX) {
+            LOG(ERROR)
+                << "Object too large for SSD offload (value_len must fit "
+                   "in 4 GiB) for key: "
+                << key << ", size: " << total_value_size
+                << " - skipping this key";
+            continue;  // partial-success model: keep processing other keys
+        }
+        uint32_t value_size = static_cast<uint32_t>(total_value_size);
 
         // Prepare record header
         RecordHeader header{.key_len = static_cast<uint32_t>(key.size()),


### PR DESCRIPTION
## What

`OffsetAllocatorStorageBackend::BatchOffload` (`mooncake-store/src/storage_backend.cpp`) accumulates a record's slice sizes into a `uint32_t`:

```cpp
uint32_t value_size = 0;
for (const auto& slice : slices) {
    value_size += static_cast<uint32_t>(slice.size);   // slice.size is uint64_t
}
```

For an object whose total size exceeds 4 GiB this **silently overflows**. The record is then allocated from the wrapped (too-small) `value_len`:

```cpp
size_t record_size = RecordHeader::SIZE + header.key_len + header.value_len; // value_len truncated
auto allocation = allocator_->allocate(record_size);
```

…but the write step emits the **full original slices**:

```cpp
for (const auto& slice : slices) iovs.push_back({slice.ptr, slice.size});
data_file_->vector_write(iovs.data(), iovs.size(), offset);
```

so `vector_write` writes past the allocated extent — a heap/arena buffer overflow. The `// Use size_t for record_size to handle large objects` comment does not help, because `value_len` is already truncated before that line. The post-write `written != record_size` check only fires *after* the over-write has happened.

## Why it's reachable

There is no per-object size cap before this path — the only size checks are tenant/bucket quotas (total storage), not a single-object limit. So a value > 4 GiB reaching SSD offload triggers it.

## Fix

`RecordHeader.value_len` is a `uint32_t` (8-byte on-disk header) by design — the header has a `// Currently assumes max object size is 4GB` note. Rather than change the on-disk format, this sums in 64 bits and **skips** any key whose value exceeds 4 GiB (matching the function's existing per-key continue-on-failure model), turning silent memory corruption into a logged skip.

## Verification

The overflow is a deterministic type-width issue, so I verified it by code inspection / type analysis rather than a live run: a `uint64_t` slice-size sum truncated into a `uint32_t` provably wraps at 2^32, and `record_size` is derived from the truncated value. I don't have an RDMA/CUDA build environment locally, so I have **not** built/run the C++ suite — CI will compile and run it.

Happy to add a regression test if you'd like: the new guard returns before any I/O, so a test can pass a `Slice` with `size > UINT32_MAX` and a small dummy buffer and assert the key is skipped, without allocating 4 GiB. Point me at the preferred harness (`mooncake-store/tests/storage_backend_test.cpp`?) and I'll add it.