### PR TITLE
[Store] Add StandbyP2PMetadataStore for P2P HA standby

### DIFF
--- a/mooncake-store/include/ha/oplog/p2p_standby_metadata_store.h
+++ b/mooncake-store/include/ha/oplog/p2p_standby_metadata_store.h
@@ -1,0 +1,141 @@
+// mooncake-store/include/ha/oplog/p2p_standby_metadata_store.h
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <boost/functional/hash.hpp>
+
+#include "ha/oplog/oplog_manager.h"
+#include "metadata_store.h"
+#include "replica.h"
+#include "types.h"
+
+namespace mooncake {
+
+/// Client registration info stored in P2PStandbyMetadataStore.
+struct P2PStandbyClientInfo {
+    UUID client_id{0, 0};
+    std::string ip_address;
+    uint16_t rpc_port = 0;
+    // Segments owned by this client.
+    std::vector<Segment> segments;
+};
+
+/// P2P-specific standby metadata store.
+///
+/// Unlike main branch's MetadataStore which only stores object-level
+/// StandbyObjectMetadata, P2P must also store client registration info
+/// and segment mappings because:
+///   1. P2P has no Snapshot fallback (main uses Snapshot + client reconnect)
+///   2. Segment info directly affects GetWriteRoute routing
+///   3. MOUNT_SEGMENT replay requires client_id → client record lookup
+///
+/// This class holds:
+///   - objects_: key → replica list (mirrors Primary's object metadata)
+///   - clients_: client_id → client info (ip, port, segments)
+///
+/// Thread safety: this class is NOT thread-safe. It is accessed by a single
+/// thread — the OpLogReplicator callback thread writes via P2POpLogApplier,
+/// and ExportMetadata() is called only after Replicator::Stop() has joined
+/// the callback thread during promotion.
+class P2PStandbyMetadataStore : public MetadataStore {
+   public:
+    P2PStandbyMetadataStore() = default;
+    ~P2PStandbyMetadataStore() override = default;
+
+    // ========================================================================
+    // MetadataStore interface (object-level operations)
+    // ========================================================================
+    bool PutMetadata(const std::string& key,
+                     const StandbyObjectMetadata& metadata) override;
+    bool Put(const std::string& key,
+             const std::string& payload = std::string()) override;
+    std::optional<StandbyObjectMetadata> GetMetadata(
+        const std::string& key) const override;
+    bool Remove(const std::string& key) override;
+    bool Exists(const std::string& key) const override;
+    size_t GetKeyCount() const override;
+
+    // ========================================================================
+    // P2P-specific operations (called by P2POpLogApplier)
+    // ========================================================================
+
+    /// Add a replica to an object. Creates the object if it doesn't exist.
+    void AddReplica(const std::string& object_key, const UUID& client_id,
+                    const UUID& segment_id, size_t size, int priority,
+                    const std::vector<std::string>& tags,
+                    MemoryType memory_type);
+
+    /// Remove a replica from an object. Removes the object if no replicas left.
+    void RemoveReplica(const std::string& object_key, const UUID& client_id,
+                       const UUID& segment_id);
+
+    /// Register or update a client.
+    void RegisterClient(const UUID& client_id, const std::string& ip_address,
+                        uint16_t rpc_port,
+                        const std::vector<Segment>& segments);
+
+    /// Add (mount) a segment to a client.
+    void AddSegment(const UUID& client_id, const Segment& segment);
+
+    /// Remove (unmount) a segment from a client.
+    /// Also removes all replicas on this segment from their objects (cascade
+    /// delete).
+    void RemoveSegment(const UUID& segment_id, const UUID& client_id);
+
+    /// Remove all replicas on a segment from their objects (cascade helper).
+    void RemoveReplicasBySegment(const UUID& segment_id);
+
+    /// Remove all objects and client data. Used for REMOVE_ALL oplog entry.
+    void RemoveAllMetadata();
+
+    // ========================================================================
+    // Export for Promotion
+    // ========================================================================
+
+    /// Export all metadata for promotion to Primary.
+    /// This is used when Standby is promoted to Primary — the exported
+    /// data is used to initialize a new P2PMasterService.
+    struct ExportedMetadata {
+        std::unordered_map<std::string, StandbyObjectMetadata> objects;
+        std::unordered_map<UUID, P2PStandbyClientInfo, boost::hash<UUID>>
+            clients;
+    };
+
+    ExportedMetadata ExportMetadata() const;
+
+    // ========================================================================
+    // Query helpers
+    // ========================================================================
+
+    /// Get client info by client_id. Returns nullptr if not found.
+    const P2PStandbyClientInfo* GetClient(const UUID& client_id) const;
+
+    /// Get all objects. For testing/diagnostics only.
+    const std::unordered_map<std::string, StandbyObjectMetadata>& GetObjects()
+        const {
+        return objects_;
+    }
+
+    /// Get all clients. For testing/diagnostics only.
+    const std::unordered_map<UUID, P2PStandbyClientInfo, boost::hash<UUID>>&
+    GetClients() const {
+        return clients_;
+    }
+
+   private:
+    // Remove all replicas referencing a segment.
+    void RemoveReplicasBySegmentInternal(const UUID& segment_id);
+
+    // Object key → metadata (replicas, size, etc.)
+    std::unordered_map<std::string, StandbyObjectMetadata> objects_;
+
+    // Client UUID → client info (ip, port, segments)
+    std::unordered_map<UUID, P2PStandbyClientInfo, boost::hash<UUID>> clients_;
+};
+
+}  // namespace mooncake

--- a/mooncake-store/include/ha/oplog/p2p_standby_metadata_store.h
+++ b/mooncake-store/include/ha/oplog/p2p_standby_metadata_store.h
@@ -79,6 +79,11 @@ class P2PStandbyMetadataStore : public MetadataStore {
                         uint16_t rpc_port,
                         const std::vector<Segment>& segments);
 
+    /// Unregister a client.
+    /// Also removes all replicas owned by this client from their objects
+    /// (cascade delete).
+    void UnRegisterClient(const UUID& client_id);
+
     /// Add (mount) a segment to a client.
     void AddSegment(const UUID& client_id, const Segment& segment);
 

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -75,6 +75,7 @@ set(MOONCAKE_STORE_SOURCES
     ha/oplog/oplog_replicator.cpp
     # P2P HA OpLog components
     ha/oplog/p2p_oplog_types.cpp
+    ha/oplog/p2p_standby_metadata_store.cpp
     standby_state_machine.cpp
     ha_metric_manager.cpp
 )

--- a/mooncake-store/src/ha/oplog/p2p_standby_metadata_store.cpp
+++ b/mooncake-store/src/ha/oplog/p2p_standby_metadata_store.cpp
@@ -1,6 +1,7 @@
 #include "ha/oplog/p2p_standby_metadata_store.h"
 
 #include <glog/logging.h>
+#include <xxhash.h>
 
 namespace mooncake {
 
@@ -58,10 +59,9 @@ void P2PStandbyMetadataStore::AddReplica(const std::string& object_key,
     // Build a Replica::Descriptor for this replica.
     // P2PProxyDescriptor is the P2P-specific descriptor type.
     Replica::Descriptor desc;
-    ReplicaID replica_id =
-        static_cast<ReplicaID>(std::hash<std::string>{}(object_key) ^
-                               std::hash<uint64_t>{}(client_id.first) ^
-                               std::hash<uint64_t>{}(segment_id.first));
+    ReplicaID replica_id = static_cast<ReplicaID>(XXH64(
+        object_key.data(), object_key.size(),
+        XXH64(&client_id, sizeof(UUID), XXH64(&segment_id, sizeof(UUID), 0))));
     desc.id = replica_id;
 
     // Look up client info for IP/port
@@ -137,28 +137,26 @@ void P2PStandbyMetadataStore::RegisterClient(
     info.client_id = client_id;
     info.ip_address = ip_address;
     info.rpc_port = rpc_port;
-    info.segments = segments;
+    // Merge segments instead of overwriting to preserve segments added by
+    // out-of-order AddSegment (MOUNT_SEGMENT) calls that arrived before
+    // REGISTER_CLIENT.
+    for (const auto& seg : segments) {
+        if (std::find_if(info.segments.begin(), info.segments.end(),
+                         [&](const Segment& existing) {
+                             return existing.id == seg.id;
+                         }) == info.segments.end()) {
+            info.segments.push_back(seg);
+        }
+    }
 
     VLOG(1) << "P2PStandbyMetadataStore::RegisterClient "
             << "client=" << client_id.first << ":" << client_id.second
             << " ip=" << ip_address << ":" << rpc_port
             << " segments=" << segments.size();
 
-    // Update existing replica entries with this client's IP/port if they
-    // were added before REGISTER_CLIENT arrived.
-    for (auto& [key, metadata] : objects_) {
-        for (auto& desc : metadata.replicas) {
-            if (!std::holds_alternative<P2PProxyDescriptor>(
-                    desc.descriptor_variant)) {
-                continue;
-            }
-            auto& p2p = std::get<P2PProxyDescriptor>(desc.descriptor_variant);
-            if (p2p.client_id == client_id) {
-                p2p.ip_address = ip_address;
-                p2p.rpc_port = rpc_port;
-            }
-        }
-    }
+    // IP/port backfilling is deferred to ExportMetadata() to avoid O(N*M)
+    // overhead on the OpLog replication thread. IP/port is only needed after
+    // promotion, so a one-time scan during ExportMetadata() is acceptable.
 }
 
 void P2PStandbyMetadataStore::AddSegment(const UUID& client_id,
@@ -222,6 +220,28 @@ P2PStandbyMetadataStore::ExportMetadata() const {
     ExportedMetadata result;
     result.objects = objects_;
     result.clients = clients_;
+
+    // Backfill IP/port for replicas whose clients were registered out-of-order.
+    // This is deferred from RegisterClient to avoid O(N*M) overhead on the
+    // replication thread. ExportMetadata() is a one-time call during promotion,
+    // where this cost is acceptable.
+    for (auto& [key, metadata] : result.objects) {
+        for (auto& desc : metadata.replicas) {
+            if (!std::holds_alternative<P2PProxyDescriptor>(
+                    desc.descriptor_variant)) {
+                continue;
+            }
+            auto& p2p = std::get<P2PProxyDescriptor>(desc.descriptor_variant);
+            if (p2p.ip_address.empty()) {
+                auto client_it = result.clients.find(p2p.client_id);
+                if (client_it != result.clients.end()) {
+                    p2p.ip_address = client_it->second.ip_address;
+                    p2p.rpc_port = client_it->second.rpc_port;
+                }
+            }
+        }
+    }
+
     return result;
 }
 

--- a/mooncake-store/src/ha/oplog/p2p_standby_metadata_store.cpp
+++ b/mooncake-store/src/ha/oplog/p2p_standby_metadata_store.cpp
@@ -1,0 +1,268 @@
+#include "ha/oplog/p2p_standby_metadata_store.h"
+
+#include <glog/logging.h>
+
+namespace mooncake {
+
+// ============================================================================
+// MetadataStore interface
+// ============================================================================
+
+bool P2PStandbyMetadataStore::PutMetadata(
+    const std::string& key, const StandbyObjectMetadata& metadata) {
+    objects_[key] = metadata;
+    return true;
+}
+
+bool P2PStandbyMetadataStore::Put(const std::string& key,
+                                  const std::string& /*payload*/) {
+    // Legacy Put — create empty metadata. Called by OpLogApplier base class
+    // for PUT_END without payload (legacy compatibility).
+    objects_[key] = StandbyObjectMetadata{};
+    return true;
+}
+
+std::optional<StandbyObjectMetadata> P2PStandbyMetadataStore::GetMetadata(
+    const std::string& key) const {
+    auto it = objects_.find(key);
+    if (it == objects_.end()) {
+        return std::nullopt;
+    }
+    return it->second;
+}
+
+bool P2PStandbyMetadataStore::Remove(const std::string& key) {
+    return objects_.erase(key) > 0;
+}
+
+bool P2PStandbyMetadataStore::Exists(const std::string& key) const {
+    return objects_.find(key) != objects_.end();
+}
+
+size_t P2PStandbyMetadataStore::GetKeyCount() const { return objects_.size(); }
+
+// ============================================================================
+// P2P-specific operations
+// ============================================================================
+
+void P2PStandbyMetadataStore::AddReplica(const std::string& object_key,
+                                         const UUID& client_id,
+                                         const UUID& segment_id, size_t size,
+                                         int priority,
+                                         const std::vector<std::string>& tags,
+                                         MemoryType memory_type) {
+    auto& metadata = objects_[object_key];
+    metadata.size = size;
+    metadata.last_sequence_id = 0;  // Will be set by Applier
+
+    // Build a Replica::Descriptor for this replica.
+    // P2PProxyDescriptor is the P2P-specific descriptor type.
+    Replica::Descriptor desc;
+    ReplicaID replica_id =
+        static_cast<ReplicaID>(std::hash<std::string>{}(object_key) ^
+                               std::hash<uint64_t>{}(client_id.first) ^
+                               std::hash<uint64_t>{}(segment_id.first));
+    desc.id = replica_id;
+
+    // Look up client info for IP/port
+    auto client_it = clients_.find(client_id);
+    if (client_it != clients_.end()) {
+        P2PProxyDescriptor p2p_desc;
+        p2p_desc.client_id = client_id;
+        p2p_desc.segment_id = segment_id;
+        p2p_desc.ip_address = client_it->second.ip_address;
+        p2p_desc.rpc_port = client_it->second.rpc_port;
+        p2p_desc.object_size = size;
+        desc.descriptor_variant = p2p_desc;
+    } else {
+        // Client not registered yet — create a P2PProxyDescriptor with
+        // empty IP/port. This can happen if ADD_REPLICA arrives before
+        // REGISTER_CLIENT. The entry will be updated when REGISTER_CLIENT
+        // arrives later.
+        P2PProxyDescriptor p2p_desc;
+        p2p_desc.client_id = client_id;
+        p2p_desc.segment_id = segment_id;
+        p2p_desc.object_size = size;
+        desc.descriptor_variant = p2p_desc;
+    }
+    desc.status = ReplicaStatus::COMPLETE;
+
+    metadata.replicas.push_back(std::move(desc));
+    VLOG(1) << "P2PStandbyMetadataStore::AddReplica key=" << object_key
+            << " client=" << client_id.first << ":" << client_id.second
+            << " seg=" << segment_id.first << ":" << segment_id.second
+            << " total_replicas=" << metadata.replicas.size();
+}
+
+void P2PStandbyMetadataStore::RemoveReplica(const std::string& object_key,
+                                            const UUID& client_id,
+                                            const UUID& segment_id) {
+    auto it = objects_.find(object_key);
+    if (it == objects_.end()) {
+        VLOG(1) << "P2PStandbyMetadataStore::RemoveReplica key=" << object_key
+                << " not found, ignoring";
+        return;
+    }
+
+    auto& replicas = it->second.replicas;
+    replicas.erase(
+        std::remove_if(replicas.begin(), replicas.end(),
+                       [&](const Replica::Descriptor& desc) {
+                           if (!std::holds_alternative<P2PProxyDescriptor>(
+                                   desc.descriptor_variant)) {
+                               return false;
+                           }
+                           const auto& p2p = std::get<P2PProxyDescriptor>(
+                               desc.descriptor_variant);
+                           return p2p.client_id == client_id &&
+                                  p2p.segment_id == segment_id;
+                       }),
+        replicas.end());
+
+    // Remove object if no replicas left
+    if (replicas.empty()) {
+        objects_.erase(it);
+        VLOG(1) << "P2PStandbyMetadataStore::RemoveReplica key=" << object_key
+                << " removed (no replicas left)";
+    } else {
+        VLOG(1) << "P2PStandbyMetadataStore::RemoveReplica key=" << object_key
+                << " remaining_replicas=" << replicas.size();
+    }
+}
+
+void P2PStandbyMetadataStore::RegisterClient(
+    const UUID& client_id, const std::string& ip_address, uint16_t rpc_port,
+    const std::vector<Segment>& segments) {
+    auto& info = clients_[client_id];
+    info.client_id = client_id;
+    info.ip_address = ip_address;
+    info.rpc_port = rpc_port;
+    info.segments = segments;
+
+    VLOG(1) << "P2PStandbyMetadataStore::RegisterClient "
+            << "client=" << client_id.first << ":" << client_id.second
+            << " ip=" << ip_address << ":" << rpc_port
+            << " segments=" << segments.size();
+
+    // Update existing replica entries with this client's IP/port if they
+    // were added before REGISTER_CLIENT arrived.
+    for (auto& [key, metadata] : objects_) {
+        for (auto& desc : metadata.replicas) {
+            if (!std::holds_alternative<P2PProxyDescriptor>(
+                    desc.descriptor_variant)) {
+                continue;
+            }
+            auto& p2p = std::get<P2PProxyDescriptor>(desc.descriptor_variant);
+            if (p2p.client_id == client_id) {
+                p2p.ip_address = ip_address;
+                p2p.rpc_port = rpc_port;
+            }
+        }
+    }
+}
+
+void P2PStandbyMetadataStore::AddSegment(const UUID& client_id,
+                                         const Segment& segment) {
+    auto& info = clients_[client_id];
+    info.client_id = client_id;  // In case client wasn't registered yet
+
+    // Check if segment already exists
+    for (const auto& seg : info.segments) {
+        if (seg.id == segment.id) {
+            VLOG(1) << "P2PStandbyMetadataStore::AddSegment "
+                    << "segment already exists, ignoring";
+            return;
+        }
+    }
+
+    info.segments.push_back(segment);
+    VLOG(1) << "P2PStandbyMetadataStore::AddSegment "
+            << "client=" << client_id.first << ":" << client_id.second
+            << " segment=" << segment.id.first << ":" << segment.id.second
+            << " total_segments=" << info.segments.size();
+}
+
+void P2PStandbyMetadataStore::RemoveSegment(const UUID& segment_id,
+                                            const UUID& client_id) {
+    // Remove segment from client
+    auto client_it = clients_.find(client_id);
+    if (client_it != clients_.end()) {
+        auto& segments = client_it->second.segments;
+        segments.erase(std::remove_if(segments.begin(), segments.end(),
+                                      [&](const Segment& seg) {
+                                          return seg.id == segment_id;
+                                      }),
+                       segments.end());
+    }
+
+    // Cascade delete: remove all replicas on this segment
+    RemoveReplicasBySegmentInternal(segment_id);
+
+    VLOG(1) << "P2PStandbyMetadataStore::RemoveSegment "
+            << "segment=" << segment_id.first << ":" << segment_id.second
+            << " client=" << client_id.first << ":" << client_id.second;
+}
+
+void P2PStandbyMetadataStore::RemoveReplicasBySegment(const UUID& segment_id) {
+    RemoveReplicasBySegmentInternal(segment_id);
+}
+
+void P2PStandbyMetadataStore::RemoveAllMetadata() {
+    objects_.clear();
+    clients_.clear();
+    VLOG(1) << "P2PStandbyMetadataStore::RemoveAllMetadata";
+}
+
+// ============================================================================
+// Export for Promotion
+// ============================================================================
+
+P2PStandbyMetadataStore::ExportedMetadata
+P2PStandbyMetadataStore::ExportMetadata() const {
+    ExportedMetadata result;
+    result.objects = objects_;
+    result.clients = clients_;
+    return result;
+}
+
+// ============================================================================
+// Query helpers
+// ============================================================================
+
+const P2PStandbyClientInfo* P2PStandbyMetadataStore::GetClient(
+    const UUID& client_id) const {
+    auto it = clients_.find(client_id);
+    return it != clients_.end() ? &it->second : nullptr;
+}
+
+// ============================================================================
+// Internal helpers
+// ============================================================================
+
+void P2PStandbyMetadataStore::RemoveReplicasBySegmentInternal(
+    const UUID& segment_id) {
+    // Iterate all objects, remove replicas referencing this segment
+    for (auto it = objects_.begin(); it != objects_.end();) {
+        auto& replicas = it->second.replicas;
+        replicas.erase(
+            std::remove_if(replicas.begin(), replicas.end(),
+                           [&](const Replica::Descriptor& desc) {
+                               if (!std::holds_alternative<P2PProxyDescriptor>(
+                                       desc.descriptor_variant)) {
+                                   return false;
+                               }
+                               const auto& p2p = std::get<P2PProxyDescriptor>(
+                                   desc.descriptor_variant);
+                               return p2p.segment_id == segment_id;
+                           }),
+            replicas.end());
+
+        if (replicas.empty()) {
+            it = objects_.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/ha/oplog/p2p_standby_metadata_store.cpp
+++ b/mooncake-store/src/ha/oplog/p2p_standby_metadata_store.cpp
@@ -10,16 +10,16 @@ namespace mooncake {
 // ============================================================================
 
 bool P2PStandbyMetadataStore::PutMetadata(
-    const std::string& key, const StandbyObjectMetadata& metadata) {
-    objects_[key] = metadata;
+    const std::string& /*key*/, const StandbyObjectMetadata& /*metadata*/) {
+    // Compatibility no-op. P2P standby metadata is reconstructed from
+    // P2P-specific oplog operations.
     return true;
 }
 
-bool P2PStandbyMetadataStore::Put(const std::string& key,
+bool P2PStandbyMetadataStore::Put(const std::string& /*key*/,
                                   const std::string& /*payload*/) {
-    // Legacy Put — create empty metadata. Called by OpLogApplier base class
-    // for PUT_END without payload (legacy compatibility).
-    objects_[key] = StandbyObjectMetadata{};
+    // Compatibility no-op. P2P standby metadata is reconstructed from
+    // P2P-specific oplog operations.
     return true;
 }
 
@@ -56,6 +56,35 @@ void P2PStandbyMetadataStore::AddReplica(const std::string& object_key,
     metadata.size = size;
     metadata.last_sequence_id = 0;  // Will be set by Applier
 
+    auto client_it = clients_.find(client_id);
+    if (client_it != clients_.end()) {
+        for (auto& segment : client_it->second.segments) {
+            if (segment.id != segment_id) {
+                continue;
+            }
+            auto& extra = segment.GetP2PExtra();
+            extra.priority = priority;
+            extra.tags = tags;
+            extra.memory_type = memory_type;
+            break;
+        }
+    }
+
+    for (const auto& desc : metadata.replicas) {
+        if (!std::holds_alternative<P2PProxyDescriptor>(
+                desc.descriptor_variant)) {
+            continue;
+        }
+        const auto& p2p = std::get<P2PProxyDescriptor>(desc.descriptor_variant);
+        if (p2p.client_id == client_id && p2p.segment_id == segment_id) {
+            VLOG(1) << "P2PStandbyMetadataStore::AddReplica key=" << object_key
+                    << " client=" << client_id.first << ":" << client_id.second
+                    << " seg=" << segment_id.first << ":" << segment_id.second
+                    << " already exists, ignoring duplicate";
+            return;
+        }
+    }
+
     // Build a Replica::Descriptor for this replica.
     // P2PProxyDescriptor is the P2P-specific descriptor type.
     Replica::Descriptor desc;
@@ -65,7 +94,6 @@ void P2PStandbyMetadataStore::AddReplica(const std::string& object_key,
     desc.id = replica_id;
 
     // Look up client info for IP/port
-    auto client_it = clients_.find(client_id);
     if (client_it != clients_.end()) {
         P2PProxyDescriptor p2p_desc;
         p2p_desc.client_id = client_id;
@@ -157,6 +185,36 @@ void P2PStandbyMetadataStore::RegisterClient(
     // IP/port backfilling is deferred to ExportMetadata() to avoid O(N*M)
     // overhead on the OpLog replication thread. IP/port is only needed after
     // promotion, so a one-time scan during ExportMetadata() is acceptable.
+}
+
+void P2PStandbyMetadataStore::UnRegisterClient(const UUID& client_id) {
+    clients_.erase(client_id);
+
+    // Cascade delete: remove all replicas owned by this client.
+    for (auto it = objects_.begin(); it != objects_.end();) {
+        auto& replicas = it->second.replicas;
+        replicas.erase(
+            std::remove_if(replicas.begin(), replicas.end(),
+                           [&](const Replica::Descriptor& desc) {
+                               if (!std::holds_alternative<P2PProxyDescriptor>(
+                                       desc.descriptor_variant)) {
+                                   return false;
+                               }
+                               const auto& p2p = std::get<P2PProxyDescriptor>(
+                                   desc.descriptor_variant);
+                               return p2p.client_id == client_id;
+                           }),
+            replicas.end());
+
+        if (replicas.empty()) {
+            it = objects_.erase(it);
+        } else {
+            ++it;
+        }
+    }
+
+    VLOG(1) << "P2PStandbyMetadataStore::UnRegisterClient "
+            << "client=" << client_id.first << ":" << client_id.second;
 }
 
 void P2PStandbyMetadataStore::AddSegment(const UUID& client_id,

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -79,6 +79,7 @@ add_store_test(ha_metric_manager_test ha/oplog/ha_metric_manager_test.cpp)
 add_store_test(oplog_applier_test ha/oplog/oplog_applier_test.cpp)
 add_store_test(oplog_replicator_test ha/oplog/oplog_replicator_test.cpp)
 add_store_test(p2p_oplog_test ha/oplog/p2p_oplog_test.cpp)
+add_store_test(p2p_standby_metadata_store_test ha/oplog/p2p_standby_metadata_store_test.cpp)
 add_subdirectory(e2e)
 
 add_executable(high_availability_test high_availability_test.cpp)

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -78,8 +78,10 @@ add_store_test(standby_state_machine_test ha/oplog/standby_state_machine_test.cp
 add_store_test(ha_metric_manager_test ha/oplog/ha_metric_manager_test.cpp)
 add_store_test(oplog_applier_test ha/oplog/oplog_applier_test.cpp)
 add_store_test(oplog_replicator_test ha/oplog/oplog_replicator_test.cpp)
-add_store_test(p2p_oplog_test ha/oplog/p2p_oplog_test.cpp)
-add_store_test(p2p_standby_metadata_store_test ha/oplog/p2p_standby_metadata_store_test.cpp)
+add_store_test(p2p_oplog_test
+    ha/oplog/p2p_oplog_test.cpp
+    ha/oplog/p2p_standby_metadata_store_test.cpp
+)
 add_subdirectory(e2e)
 
 add_executable(high_availability_test high_availability_test.cpp)

--- a/mooncake-store/tests/ha/oplog/p2p_oplog_test.cpp
+++ b/mooncake-store/tests/ha/oplog/p2p_oplog_test.cpp
@@ -292,8 +292,3 @@ TEST(P2POpLogTypesTest, Deserialize_WrongType_ReturnsFalse) {
 }
 
 }  // namespace mooncake::test
-
-int main(int argc, char** argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-}

--- a/mooncake-store/tests/ha/oplog/p2p_record_oplog_test.cpp
+++ b/mooncake-store/tests/ha/oplog/p2p_record_oplog_test.cpp
@@ -1,0 +1,125 @@
+#include "p2p_master_service.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+#include "ha/oplog/oplog_manager.h"
+#include "ha/oplog/oplog_store_factory.h"
+#include "ha/oplog/p2p_oplog_types.h"
+#include "mock_oplog_store.h"
+
+namespace mooncake::test {
+
+namespace {
+
+// Helper to create a minimal MasterServiceConfig for P2P mode with oplog
+// enabled.
+MasterServiceConfig MakeP2PConfig(bool enable_oplog = true) {
+    MasterServiceConfig config;
+    config.enable_metric_reporting = false;
+    config.metrics_port = 0;
+    config.rpc_port = 0;
+    config.rpc_thread_num = 1;
+    config.default_kv_lease_ttl = 30000;
+    config.default_kv_soft_pin_ttl = 30000;
+    config.allow_evict_soft_pinned_objects = false;
+    config.eviction_ratio = 0.8;
+    config.eviction_high_watermark_ratio = 0.9;
+    config.client_live_ttl_sec = 30;
+    config.client_crashed_ttl_sec = 90;
+    config.enable_ha = enable_oplog;
+    config.enable_offload = false;
+    config.cluster_id = "test-cluster";
+    config.max_replicas_per_key = 0;
+    config.enable_oplog = enable_oplog;
+    config.oplog_store_type = "localfs";
+    config.oplog_data_dir = "/tmp/mooncake_oplog_test";
+    return config;
+}
+
+// Verify that RecordOplog writes entries to the OpLogManager.
+TEST(P2PRecordOplogTest, RecordOplogWritesToManager) {
+    MasterServiceConfig config = MakeP2PConfig(/*enable_oplog=*/true);
+    P2PMasterService service(config);
+
+    // With oplog enabled, oplog_manager_ should be initialized.
+    auto* manager = service.GetOpLogManager();
+    ASSERT_NE(manager, nullptr);
+
+    // Write an ADD_REPLICA entry via RecordOplog.
+    AddReplicaPayload payload;
+    payload.object_key = "test-key";
+    payload.client_id = {1, 0};
+    payload.segment_id = {10, 0};
+    payload.size = 1024;
+    service.RecordOplog(OpType_ADD_REPLICA, "test-key",
+                        SerializeP2PPayload(payload));
+
+    // Verify the entry was written.
+    uint64_t latest = 0;
+    EXPECT_EQ(manager->GetLastSequenceId(), 1u);
+}
+
+// Verify that RecordOplog with sync=true calls AppendAndPersist.
+TEST(P2PRecordOplogTest, RecordOplogSyncWritesToManager) {
+    MasterServiceConfig config = MakeP2PConfig(/*enable_oplog=*/true);
+    P2PMasterService service(config);
+
+    auto* manager = service.GetOpLogManager();
+    ASSERT_NE(manager, nullptr);
+
+    RemoveReplicaPayload payload;
+    payload.object_key = "test-key";
+    payload.client_id = {1, 0};
+    payload.segment_id = {10, 0};
+    service.RecordOplog(OpType_REMOVE_REPLICA, "test-key",
+                        SerializeP2PPayload(payload), /*sync=*/true);
+
+    EXPECT_EQ(manager->GetLastSequenceId(), 1u);
+}
+
+// Verify that RecordOplog is no-op when HA is disabled.
+TEST(P2PRecordOplogTest, RecordOplogNoopWhenDisabled) {
+    MasterServiceConfig config = MakeP2PConfig(/*enable_oplog=*/false);
+    P2PMasterService service(config);
+
+    auto* manager = service.GetOpLogManager();
+    EXPECT_EQ(manager, nullptr);
+
+    // Should not crash — just a no-op.
+    AddReplicaPayload payload;
+    payload.object_key = "test-key";
+    service.RecordOplog(OpType_ADD_REPLICA, "test-key",
+                        SerializeP2PPayload(payload));
+}
+
+// Verify that multiple RecordOplog calls result in sequential sequence IDs.
+TEST(P2PRecordOplogTest, MultipleRecordsGetSequentialIds) {
+    MasterServiceConfig config = MakeP2PConfig(/*enable_oplog=*/true);
+    P2PMasterService service(config);
+
+    auto* manager = service.GetOpLogManager();
+    ASSERT_NE(manager, nullptr);
+
+    AddReplicaPayload add_payload;
+    add_payload.object_key = "key1";
+    add_payload.client_id = {1, 0};
+    add_payload.segment_id = {10, 0};
+    add_payload.size = 1024;
+    service.RecordOplog(OpType_ADD_REPLICA, "key1",
+                        SerializeP2PPayload(add_payload));
+
+    RemoveReplicaPayload rm_payload;
+    rm_payload.object_key = "key1";
+    rm_payload.client_id = {1, 0};
+    rm_payload.segment_id = {10, 0};
+    service.RecordOplog(OpType_REMOVE_REPLICA, "key1",
+                        SerializeP2PPayload(rm_payload));
+
+    uint64_t latest = 0;
+    EXPECT_EQ(manager->GetLastSequenceId(), 2u);
+}
+
+}  // namespace mooncake::test

--- a/mooncake-store/tests/ha/oplog/p2p_standby_metadata_store_test.cpp
+++ b/mooncake-store/tests/ha/oplog/p2p_standby_metadata_store_test.cpp
@@ -83,6 +83,33 @@ TEST(P2PStandbyMetadataStoreTest, GetKeyCount) {
 // AddReplica / RemoveReplica
 // ============================================================================
 
+TEST(P2PStandbyMetadataStoreTest, LegacyPut) {
+    P2PStandbyMetadataStore store;
+    EXPECT_TRUE(store.Put("key1"));
+    auto result = store.GetMetadata("key1");
+    EXPECT_TRUE(result.has_value());
+    EXPECT_EQ(result->size, 0u);
+}
+
+TEST(P2PStandbyMetadataStoreTest, AddReplicaAfterClientRegistered) {
+    P2PStandbyMetadataStore store;
+    auto client_id = MakeUUID(1, 0);
+    auto seg_id = MakeUUID(10, 0);
+
+    // Register client first, then add replica
+    store.RegisterClient(client_id, "10.0.0.1", 50051, {});
+    store.AddReplica("key1", client_id, seg_id, 1024, 0, {}, MemoryType::DRAM);
+
+    auto it = store.GetObjects().find("key1");
+    ASSERT_NE(it, store.GetObjects().end());
+    ASSERT_EQ(it->second.replicas.size(), 1u);
+    auto& p2p =
+        std::get<P2PProxyDescriptor>(it->second.replicas[0].descriptor_variant);
+    // IP/port should be populated since client was registered first
+    EXPECT_EQ(p2p.ip_address, "10.0.0.1");
+    EXPECT_EQ(p2p.rpc_port, 50051u);
+}
+
 TEST(P2PStandbyMetadataStoreTest, AddReplicaCreatesObject) {
     P2PStandbyMetadataStore store;
     auto client_id = MakeUUID(1, 0);
@@ -188,6 +215,44 @@ TEST(P2PStandbyMetadataStoreTest, RegisterClientUpdatesExisting) {
     EXPECT_EQ(info->segments.size(), 1u);
 }
 
+TEST(P2PStandbyMetadataStoreTest, RegisterClientPreservesEarlyMountSegment) {
+    P2PStandbyMetadataStore store;
+    auto client_id = MakeUUID(1, 0);
+    auto early_seg_id = MakeUUID(50, 0);
+
+    // MOUNT_SEGMENT arrives before REGISTER_CLIENT
+    Segment early_seg;
+    early_seg.id = early_seg_id;
+    early_seg.size = 2048;
+    store.AddSegment(client_id, early_seg);
+
+    // REGISTER_CLIENT with a different segment
+    auto reg_seg = MakeSegment(MakeUUID(100, 0));
+    store.RegisterClient(client_id, "192.168.1.1", 50051, {reg_seg});
+
+    // Both segments should be preserved (merge, not overwrite)
+    auto* info = store.GetClient(client_id);
+    ASSERT_NE(info, nullptr);
+    EXPECT_EQ(info->segments.size(), 2u);
+}
+
+TEST(P2PStandbyMetadataStoreTest, RegisterClientDuplicateSegmentIgnored) {
+    P2PStandbyMetadataStore store;
+    auto client_id = MakeUUID(1, 0);
+    auto seg_id = MakeUUID(100, 0);
+
+    // MOUNT_SEGMENT first
+    Segment seg = MakeSegment(seg_id, 4096);
+    store.AddSegment(client_id, seg);
+
+    // REGISTER_CLIENT with same segment — should not duplicate
+    store.RegisterClient(client_id, "10.0.0.1", 50051, {seg});
+
+    auto* info = store.GetClient(client_id);
+    ASSERT_NE(info, nullptr);
+    EXPECT_EQ(info->segments.size(), 1u);
+}
+
 TEST(P2PStandbyMetadataStoreTest, RegisterClientUpdatesReplicaIPs) {
     P2PStandbyMetadataStore store;
     auto client_id = MakeUUID(1, 0);
@@ -196,7 +261,7 @@ TEST(P2PStandbyMetadataStoreTest, RegisterClientUpdatesReplicaIPs) {
     // Add replica BEFORE client is registered (ip/port unknown)
     store.AddReplica("key1", client_id, seg_id, 1024, 0, {}, MemoryType::DRAM);
 
-    // Verify replica has empty ip/port
+    // Verify replica has empty ip/port (backfilling deferred to ExportMetadata)
     auto it = store.GetObjects().find("key1");
     ASSERT_NE(it, store.GetObjects().end());
     ASSERT_EQ(it->second.replicas.size(), 1u);
@@ -205,22 +270,55 @@ TEST(P2PStandbyMetadataStoreTest, RegisterClientUpdatesReplicaIPs) {
     EXPECT_TRUE(p2p.ip_address.empty());
     EXPECT_EQ(p2p.rpc_port, 0u);
 
-    // Register client — should update existing replicas
+    // Register client — does NOT update replicas in-place (deferred)
     store.RegisterClient(client_id, "192.168.1.1", 50051, {});
 
-    // Verify replica now has ip/port
+    // In-place replicas still have empty ip/port
     it = store.GetObjects().find("key1");
     ASSERT_NE(it, store.GetObjects().end());
-    auto& updated_desc = it->second.replicas[0];
-    auto& updated_p2p =
-        std::get<P2PProxyDescriptor>(updated_desc.descriptor_variant);
-    EXPECT_EQ(updated_p2p.ip_address, "192.168.1.1");
-    EXPECT_EQ(updated_p2p.rpc_port, 50051u);
+    auto& in_place_p2p =
+        std::get<P2PProxyDescriptor>(it->second.replicas[0].descriptor_variant);
+    EXPECT_TRUE(in_place_p2p.ip_address.empty());
+    EXPECT_EQ(in_place_p2p.rpc_port, 0u);
+
+    // Verify IP/port is backfilled in exported metadata (during promotion)
+    auto exported = store.ExportMetadata();
+    auto obj_it = exported.objects.find("key1");
+    ASSERT_NE(obj_it, exported.objects.end());
+    ASSERT_EQ(obj_it->second.replicas.size(), 1u);
+    auto& exported_p2p = std::get<P2PProxyDescriptor>(
+        obj_it->second.replicas[0].descriptor_variant);
+    EXPECT_EQ(exported_p2p.ip_address, "192.168.1.1");
+    EXPECT_EQ(exported_p2p.rpc_port, 50051u);
 }
 
 // ============================================================================
 // AddSegment / RemoveSegment
 // ============================================================================
+
+TEST(P2PStandbyMetadataStoreTest, AddSegmentDuplicateIgnored) {
+    P2PStandbyMetadataStore store;
+    auto client_id = MakeUUID(1, 0);
+    auto seg_id = MakeUUID(100, 0);
+    Segment seg = MakeSegment(seg_id, 4096);
+
+    store.AddSegment(client_id, seg);
+    store.AddSegment(client_id, seg);  // duplicate — should be ignored
+
+    auto* info = store.GetClient(client_id);
+    ASSERT_NE(info, nullptr);
+    EXPECT_EQ(info->segments.size(), 1u);
+}
+
+TEST(P2PStandbyMetadataStoreTest, RemoveSegmentUnknownClient) {
+    P2PStandbyMetadataStore store;
+    auto seg_id = MakeUUID(100, 0);
+    auto client_id = MakeUUID(1, 0);
+
+    // RemoveSegment with unregistered client — should not crash
+    store.RemoveSegment(seg_id, client_id);
+    EXPECT_EQ(store.GetKeyCount(), 0u);
+}
 
 TEST(P2PStandbyMetadataStoreTest, AddAndRemoveSegment) {
     P2PStandbyMetadataStore store;
@@ -319,6 +417,25 @@ TEST(P2PStandbyMetadataStoreTest, ExportMetadata) {
     EXPECT_EQ(exported.clients.size(), 1u);
     EXPECT_NE(exported.clients.find(client), exported.clients.end());
     EXPECT_EQ(exported.clients.at(client).ip_address, "1.2.3.4");
+}
+
+TEST(P2PStandbyMetadataStoreTest, ExportMetadataNoBackfillForUnknownClient) {
+    P2PStandbyMetadataStore store;
+    auto client_id = MakeUUID(1, 0);
+    auto seg_id = MakeUUID(10, 0);
+
+    // Add replica but never register the client
+    store.AddReplica("key1", client_id, seg_id, 1024, 0, {}, MemoryType::DRAM);
+
+    auto exported = store.ExportMetadata();
+    auto obj_it = exported.objects.find("key1");
+    ASSERT_NE(obj_it, exported.objects.end());
+    ASSERT_EQ(obj_it->second.replicas.size(), 1u);
+    auto& p2p = std::get<P2PProxyDescriptor>(
+        obj_it->second.replicas[0].descriptor_variant);
+    // Client not registered — ip/port stays empty
+    EXPECT_TRUE(p2p.ip_address.empty());
+    EXPECT_EQ(p2p.rpc_port, 0u);
 }
 
 }  // namespace mooncake::test

--- a/mooncake-store/tests/ha/oplog/p2p_standby_metadata_store_test.cpp
+++ b/mooncake-store/tests/ha/oplog/p2p_standby_metadata_store_test.cpp
@@ -1,0 +1,324 @@
+#include "ha/oplog/p2p_standby_metadata_store.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "replica.h"
+#include "types.h"
+
+namespace mooncake::test {
+
+namespace {
+// Helper to create a UUID from two uint64_t values.
+UUID MakeUUID(uint64_t hi, uint64_t lo) { return UUID{hi, lo}; }
+
+// Helper to create a basic Segment.
+Segment MakeSegment(const UUID& id, size_t size = 1024) {
+    Segment seg;
+    seg.id = id;
+    seg.size = size;
+    return seg;
+}
+}  // namespace
+
+// ============================================================================
+// P2PStandbyMetadataStore - Basic MetadataStore interface
+// ============================================================================
+
+TEST(P2PStandbyMetadataStoreTest, PutAndGetMetadata) {
+    P2PStandbyMetadataStore store;
+    StandbyObjectMetadata meta;
+    meta.size = 4096;
+    meta.last_sequence_id = 42;
+
+    EXPECT_TRUE(store.PutMetadata("key1", meta));
+
+    auto result = store.GetMetadata("key1");
+    EXPECT_TRUE(result.has_value());
+    EXPECT_EQ(result->size, 4096u);
+    EXPECT_EQ(result->last_sequence_id, 42u);
+}
+
+TEST(P2PStandbyMetadataStoreTest, GetMetadataNotFound) {
+    P2PStandbyMetadataStore store;
+    auto result = store.GetMetadata("nonexistent");
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(P2PStandbyMetadataStoreTest, Remove) {
+    P2PStandbyMetadataStore store;
+    StandbyObjectMetadata meta;
+    meta.size = 100;
+    store.PutMetadata("key1", meta);
+
+    EXPECT_TRUE(store.Remove("key1"));
+    EXPECT_FALSE(store.GetMetadata("key1").has_value());
+    EXPECT_FALSE(store.Remove("key1"));  // Already removed
+}
+
+TEST(P2PStandbyMetadataStoreTest, Exists) {
+    P2PStandbyMetadataStore store;
+    EXPECT_FALSE(store.Exists("key1"));
+    StandbyObjectMetadata meta;
+    store.PutMetadata("key1", meta);
+    EXPECT_TRUE(store.Exists("key1"));
+}
+
+TEST(P2PStandbyMetadataStoreTest, GetKeyCount) {
+    P2PStandbyMetadataStore store;
+    EXPECT_EQ(store.GetKeyCount(), 0u);
+
+    StandbyObjectMetadata meta;
+    store.PutMetadata("key1", meta);
+    EXPECT_EQ(store.GetKeyCount(), 1u);
+    store.PutMetadata("key2", meta);
+    EXPECT_EQ(store.GetKeyCount(), 2u);
+    store.Remove("key1");
+    EXPECT_EQ(store.GetKeyCount(), 1u);
+}
+
+// ============================================================================
+// AddReplica / RemoveReplica
+// ============================================================================
+
+TEST(P2PStandbyMetadataStoreTest, AddReplicaCreatesObject) {
+    P2PStandbyMetadataStore store;
+    auto client_id = MakeUUID(1, 0);
+    auto seg_id = MakeUUID(10, 0);
+
+    store.AddReplica("model-weights", client_id, seg_id, 4096, 0, {},
+                     MemoryType::DRAM);
+
+    const auto& objects = store.GetObjects();
+    ASSERT_EQ(objects.size(), 1u);
+    auto it = objects.find("model-weights");
+    ASSERT_NE(it, objects.end());
+    EXPECT_EQ(it->second.replicas.size(), 1u);
+}
+
+TEST(P2PStandbyMetadataStoreTest, AddReplicaMultiple) {
+    P2PStandbyMetadataStore store;
+    auto client1 = MakeUUID(1, 0);
+    auto client2 = MakeUUID(2, 0);
+    auto seg1 = MakeUUID(10, 0);
+    auto seg2 = MakeUUID(11, 0);
+
+    store.AddReplica("key1", client1, seg1, 1024, 0, {}, MemoryType::DRAM);
+    store.AddReplica("key1", client2, seg2, 2048, 0, {}, MemoryType::DRAM);
+
+    auto it = store.GetObjects().find("key1");
+    ASSERT_NE(it, store.GetObjects().end());
+    EXPECT_EQ(it->second.replicas.size(), 2u);
+}
+
+TEST(P2PStandbyMetadataStoreTest, RemoveReplica) {
+    P2PStandbyMetadataStore store;
+    auto client1 = MakeUUID(1, 0);
+    auto client2 = MakeUUID(2, 0);
+    auto seg1 = MakeUUID(10, 0);
+    auto seg2 = MakeUUID(11, 0);
+
+    store.AddReplica("key1", client1, seg1, 1024, 0, {}, MemoryType::DRAM);
+    store.AddReplica("key1", client2, seg2, 2048, 0, {}, MemoryType::DRAM);
+
+    // Remove one replica
+    store.RemoveReplica("key1", client1, seg1);
+
+    auto it = store.GetObjects().find("key1");
+    ASSERT_NE(it, store.GetObjects().end());
+    EXPECT_EQ(it->second.replicas.size(), 1u);
+}
+
+TEST(P2PStandbyMetadataStoreTest, RemoveReplicaRemovesEmptyObject) {
+    P2PStandbyMetadataStore store;
+    auto client = MakeUUID(1, 0);
+    auto seg = MakeUUID(10, 0);
+
+    store.AddReplica("key1", client, seg, 1024, 0, {}, MemoryType::DRAM);
+    store.RemoveReplica("key1", client, seg);
+
+    // Object with no replicas should be removed
+    EXPECT_FALSE(store.GetMetadata("key1").has_value());
+    EXPECT_EQ(store.GetKeyCount(), 0u);
+}
+
+TEST(P2PStandbyMetadataStoreTest, RemoveReplicaNonexistentKey) {
+    P2PStandbyMetadataStore store;
+    auto client = MakeUUID(1, 0);
+    auto seg = MakeUUID(10, 0);
+
+    // Should not crash
+    store.RemoveReplica("nonexistent", client, seg);
+    EXPECT_EQ(store.GetKeyCount(), 0u);
+}
+
+// ============================================================================
+// RegisterClient
+// ============================================================================
+
+TEST(P2PStandbyMetadataStoreTest, RegisterClientBasic) {
+    P2PStandbyMetadataStore store;
+    auto client_id = MakeUUID(1, 0);
+    std::vector<Segment> segments;
+    segments.push_back(MakeSegment(MakeUUID(100, 0)));
+
+    store.RegisterClient(client_id, "192.168.1.1", 50051, segments);
+
+    auto* info = store.GetClient(client_id);
+    ASSERT_NE(info, nullptr);
+    EXPECT_EQ(info->ip_address, "192.168.1.1");
+    EXPECT_EQ(info->rpc_port, 50051u);
+    EXPECT_EQ(info->segments.size(), 1u);
+}
+
+TEST(P2PStandbyMetadataStoreTest, RegisterClientUpdatesExisting) {
+    P2PStandbyMetadataStore store;
+    auto client_id = MakeUUID(1, 0);
+
+    store.RegisterClient(client_id, "192.168.1.1", 50051, {});
+    store.RegisterClient(client_id, "10.0.0.1", 50052,
+                         {MakeSegment(MakeUUID(100, 0))});
+
+    auto* info = store.GetClient(client_id);
+    ASSERT_NE(info, nullptr);
+    EXPECT_EQ(info->ip_address, "10.0.0.1");
+    EXPECT_EQ(info->rpc_port, 50052u);
+    EXPECT_EQ(info->segments.size(), 1u);
+}
+
+TEST(P2PStandbyMetadataStoreTest, RegisterClientUpdatesReplicaIPs) {
+    P2PStandbyMetadataStore store;
+    auto client_id = MakeUUID(1, 0);
+    auto seg_id = MakeUUID(10, 0);
+
+    // Add replica BEFORE client is registered (ip/port unknown)
+    store.AddReplica("key1", client_id, seg_id, 1024, 0, {}, MemoryType::DRAM);
+
+    // Verify replica has empty ip/port
+    auto it = store.GetObjects().find("key1");
+    ASSERT_NE(it, store.GetObjects().end());
+    ASSERT_EQ(it->second.replicas.size(), 1u);
+    auto& desc = it->second.replicas[0];
+    auto& p2p = std::get<P2PProxyDescriptor>(desc.descriptor_variant);
+    EXPECT_TRUE(p2p.ip_address.empty());
+    EXPECT_EQ(p2p.rpc_port, 0u);
+
+    // Register client — should update existing replicas
+    store.RegisterClient(client_id, "192.168.1.1", 50051, {});
+
+    // Verify replica now has ip/port
+    it = store.GetObjects().find("key1");
+    ASSERT_NE(it, store.GetObjects().end());
+    auto& updated_desc = it->second.replicas[0];
+    auto& updated_p2p =
+        std::get<P2PProxyDescriptor>(updated_desc.descriptor_variant);
+    EXPECT_EQ(updated_p2p.ip_address, "192.168.1.1");
+    EXPECT_EQ(updated_p2p.rpc_port, 50051u);
+}
+
+// ============================================================================
+// AddSegment / RemoveSegment
+// ============================================================================
+
+TEST(P2PStandbyMetadataStoreTest, AddAndRemoveSegment) {
+    P2PStandbyMetadataStore store;
+    auto client_id = MakeUUID(1, 0);
+    auto seg_id = MakeUUID(100, 0);
+    Segment seg = MakeSegment(seg_id, 4096);
+
+    store.AddSegment(client_id, seg);
+
+    auto* info = store.GetClient(client_id);
+    ASSERT_NE(info, nullptr);
+    EXPECT_EQ(info->segments.size(), 1u);
+    EXPECT_EQ(info->segments[0].id, seg_id);
+
+    store.RemoveSegment(seg_id, client_id);
+
+    info = store.GetClient(client_id);
+    ASSERT_NE(info, nullptr);
+    EXPECT_EQ(info->segments.size(), 0u);
+}
+
+TEST(P2PStandbyMetadataStoreTest, RemoveSegmentCascadeDeletesReplicas) {
+    P2PStandbyMetadataStore store;
+    auto client_id = MakeUUID(1, 0);
+    auto seg_id = MakeUUID(100, 0);
+
+    // Add replica on this segment
+    store.AddReplica("key1", client_id, seg_id, 1024, 0, {}, MemoryType::DRAM);
+    ASSERT_EQ(store.GetObjects().size(), 1u);
+
+    // Unmount the segment — should cascade delete replicas
+    store.RemoveSegment(seg_id, client_id);
+
+    // Object should be gone (no replicas left)
+    EXPECT_EQ(store.GetObjects().size(), 0u);
+}
+
+TEST(P2PStandbyMetadataStoreTest, RemoveSegmentDoesNotAffectOtherSegments) {
+    P2PStandbyMetadataStore store;
+    auto client_id = MakeUUID(1, 0);
+    auto seg1 = MakeUUID(100, 0);
+    auto seg2 = MakeUUID(200, 0);
+
+    // Add replicas on two different segments
+    store.AddReplica("key1", client_id, seg1, 1024, 0, {}, MemoryType::DRAM);
+    store.AddReplica("key1", client_id, seg2, 2048, 0, {}, MemoryType::DRAM);
+
+    ASSERT_EQ(store.GetObjects().find("key1")->second.replicas.size(), 2u);
+
+    // Remove seg1 — should only remove replica on seg1
+    store.RemoveSegment(seg1, client_id);
+
+    auto it = store.GetObjects().find("key1");
+    ASSERT_NE(it, store.GetObjects().end());
+    EXPECT_EQ(it->second.replicas.size(), 1u);
+}
+
+// ============================================================================
+// RemoveAllMetadata
+// ============================================================================
+
+TEST(P2PStandbyMetadataStoreTest, RemoveAllMetadata) {
+    P2PStandbyMetadataStore store;
+    auto client = MakeUUID(1, 0);
+    auto seg = MakeUUID(10, 0);
+
+    store.AddReplica("key1", client, seg, 1024, 0, {}, MemoryType::DRAM);
+    store.AddReplica("key2", client, seg, 2048, 0, {}, MemoryType::DRAM);
+    store.RegisterClient(client, "1.2.3.4", 50051, {MakeSegment(seg, 1024)});
+
+    EXPECT_EQ(store.GetKeyCount(), 2u);
+    EXPECT_NE(store.GetClient(client), nullptr);
+
+    store.RemoveAllMetadata();
+
+    EXPECT_EQ(store.GetKeyCount(), 0u);
+    EXPECT_EQ(store.GetClient(client), nullptr);
+}
+
+// ============================================================================
+// ExportMetadata
+// ============================================================================
+
+TEST(P2PStandbyMetadataStoreTest, ExportMetadata) {
+    P2PStandbyMetadataStore store;
+    auto client = MakeUUID(1, 0);
+    auto seg = MakeUUID(10, 0);
+
+    store.AddReplica("key1", client, seg, 1024, 0, {}, MemoryType::DRAM);
+    store.RegisterClient(client, "1.2.3.4", 50051, {MakeSegment(seg, 1024)});
+
+    auto exported = store.ExportMetadata();
+
+    EXPECT_EQ(exported.objects.size(), 1u);
+    EXPECT_NE(exported.objects.find("key1"), exported.objects.end());
+    EXPECT_EQ(exported.clients.size(), 1u);
+    EXPECT_NE(exported.clients.find(client), exported.clients.end());
+    EXPECT_EQ(exported.clients.at(client).ip_address, "1.2.3.4");
+}
+
+}  // namespace mooncake::test

--- a/mooncake-store/tests/ha/oplog/p2p_standby_metadata_store_test.cpp
+++ b/mooncake-store/tests/ha/oplog/p2p_standby_metadata_store_test.cpp
@@ -27,18 +27,15 @@ Segment MakeSegment(const UUID& id, size_t size = 1024) {
 // P2PStandbyMetadataStore - Basic MetadataStore interface
 // ============================================================================
 
-TEST(P2PStandbyMetadataStoreTest, PutAndGetMetadata) {
+TEST(P2PStandbyMetadataStoreTest, PutMetadataIsCompatibilityNoop) {
     P2PStandbyMetadataStore store;
     StandbyObjectMetadata meta;
     meta.size = 4096;
     meta.last_sequence_id = 42;
 
     EXPECT_TRUE(store.PutMetadata("key1", meta));
-
-    auto result = store.GetMetadata("key1");
-    EXPECT_TRUE(result.has_value());
-    EXPECT_EQ(result->size, 4096u);
-    EXPECT_EQ(result->last_sequence_id, 42u);
+    EXPECT_FALSE(store.GetMetadata("key1").has_value());
+    EXPECT_EQ(store.GetKeyCount(), 0u);
 }
 
 TEST(P2PStandbyMetadataStoreTest, GetMetadataNotFound) {
@@ -51,7 +48,8 @@ TEST(P2PStandbyMetadataStoreTest, Remove) {
     P2PStandbyMetadataStore store;
     StandbyObjectMetadata meta;
     meta.size = 100;
-    store.PutMetadata("key1", meta);
+    store.AddReplica("key1", MakeUUID(1, 0), MakeUUID(10, 0), 100, 0, {},
+                     MemoryType::DRAM);
 
     EXPECT_TRUE(store.Remove("key1"));
     EXPECT_FALSE(store.GetMetadata("key1").has_value());
@@ -61,8 +59,8 @@ TEST(P2PStandbyMetadataStoreTest, Remove) {
 TEST(P2PStandbyMetadataStoreTest, Exists) {
     P2PStandbyMetadataStore store;
     EXPECT_FALSE(store.Exists("key1"));
-    StandbyObjectMetadata meta;
-    store.PutMetadata("key1", meta);
+    store.AddReplica("key1", MakeUUID(1, 0), MakeUUID(10, 0), 100, 0, {},
+                     MemoryType::DRAM);
     EXPECT_TRUE(store.Exists("key1"));
 }
 
@@ -70,10 +68,11 @@ TEST(P2PStandbyMetadataStoreTest, GetKeyCount) {
     P2PStandbyMetadataStore store;
     EXPECT_EQ(store.GetKeyCount(), 0u);
 
-    StandbyObjectMetadata meta;
-    store.PutMetadata("key1", meta);
+    store.AddReplica("key1", MakeUUID(1, 0), MakeUUID(10, 0), 100, 0, {},
+                     MemoryType::DRAM);
     EXPECT_EQ(store.GetKeyCount(), 1u);
-    store.PutMetadata("key2", meta);
+    store.AddReplica("key2", MakeUUID(1, 0), MakeUUID(11, 0), 200, 0, {},
+                     MemoryType::DRAM);
     EXPECT_EQ(store.GetKeyCount(), 2u);
     store.Remove("key1");
     EXPECT_EQ(store.GetKeyCount(), 1u);
@@ -83,12 +82,11 @@ TEST(P2PStandbyMetadataStoreTest, GetKeyCount) {
 // AddReplica / RemoveReplica
 // ============================================================================
 
-TEST(P2PStandbyMetadataStoreTest, LegacyPut) {
+TEST(P2PStandbyMetadataStoreTest, PutIsCompatibilityNoop) {
     P2PStandbyMetadataStore store;
     EXPECT_TRUE(store.Put("key1"));
-    auto result = store.GetMetadata("key1");
-    EXPECT_TRUE(result.has_value());
-    EXPECT_EQ(result->size, 0u);
+    EXPECT_FALSE(store.GetMetadata("key1").has_value());
+    EXPECT_EQ(store.GetKeyCount(), 0u);
 }
 
 TEST(P2PStandbyMetadataStoreTest, AddReplicaAfterClientRegistered) {
@@ -108,6 +106,28 @@ TEST(P2PStandbyMetadataStoreTest, AddReplicaAfterClientRegistered) {
     // IP/port should be populated since client was registered first
     EXPECT_EQ(p2p.ip_address, "10.0.0.1");
     EXPECT_EQ(p2p.rpc_port, 50051u);
+}
+
+TEST(P2PStandbyMetadataStoreTest, AddReplicaUpdatesSegmentExtra) {
+    P2PStandbyMetadataStore store;
+    auto client_id = MakeUUID(1, 0);
+    auto seg_id = MakeUUID(10, 0);
+    auto seg = MakeSegment(seg_id, 4096);
+    seg.GetP2PExtra().usage = 256;
+    store.RegisterClient(client_id, "10.0.0.1", 50051, {seg});
+
+    store.AddReplica("key1", client_id, seg_id, 1024, 7, {"hot", "ssd"},
+                     MemoryType::NVME);
+
+    auto* info = store.GetClient(client_id);
+    ASSERT_NE(info, nullptr);
+    ASSERT_EQ(info->segments.size(), 1u);
+    ASSERT_TRUE(info->segments[0].IsP2PSegment());
+    const auto& extra = info->segments[0].GetP2PExtra();
+    EXPECT_EQ(extra.priority, 7);
+    EXPECT_EQ(extra.tags, std::vector<std::string>({"hot", "ssd"}));
+    EXPECT_EQ(extra.memory_type, MemoryType::NVME);
+    EXPECT_EQ(extra.usage, 256u);
 }
 
 TEST(P2PStandbyMetadataStoreTest, AddReplicaCreatesObject) {
@@ -138,6 +158,19 @@ TEST(P2PStandbyMetadataStoreTest, AddReplicaMultiple) {
     auto it = store.GetObjects().find("key1");
     ASSERT_NE(it, store.GetObjects().end());
     EXPECT_EQ(it->second.replicas.size(), 2u);
+}
+
+TEST(P2PStandbyMetadataStoreTest, AddReplicaDuplicateIgnored) {
+    P2PStandbyMetadataStore store;
+    auto client = MakeUUID(1, 0);
+    auto seg = MakeUUID(10, 0);
+
+    store.AddReplica("key1", client, seg, 1024, 0, {}, MemoryType::DRAM);
+    store.AddReplica("key1", client, seg, 1024, 0, {}, MemoryType::DRAM);
+
+    auto it = store.GetObjects().find("key1");
+    ASSERT_NE(it, store.GetObjects().end());
+    EXPECT_EQ(it->second.replicas.size(), 1u);
 }
 
 TEST(P2PStandbyMetadataStoreTest, RemoveReplica) {
@@ -290,6 +323,86 @@ TEST(P2PStandbyMetadataStoreTest, RegisterClientUpdatesReplicaIPs) {
         obj_it->second.replicas[0].descriptor_variant);
     EXPECT_EQ(exported_p2p.ip_address, "192.168.1.1");
     EXPECT_EQ(exported_p2p.rpc_port, 50051u);
+}
+
+// ============================================================================
+// UnRegisterClient
+// ============================================================================
+
+TEST(P2PStandbyMetadataStoreTest, UnRegisterClientUnknownClient) {
+    P2PStandbyMetadataStore store;
+    auto client_id = MakeUUID(1, 0);
+
+    // UnRegisterClient with unregistered client — should not crash
+    store.UnRegisterClient(client_id);
+
+    EXPECT_EQ(store.GetClient(client_id), nullptr);
+    EXPECT_EQ(store.GetKeyCount(), 0u);
+}
+
+TEST(P2PStandbyMetadataStoreTest, UnRegisterClientRemovesClientInfo) {
+    P2PStandbyMetadataStore store;
+    auto client_id = MakeUUID(1, 0);
+    auto seg_id = MakeUUID(10, 0);
+
+    store.RegisterClient(client_id, "10.0.0.1", 50051,
+                         {MakeSegment(seg_id, 1024)});
+    ASSERT_NE(store.GetClient(client_id), nullptr);
+
+    store.UnRegisterClient(client_id);
+
+    EXPECT_EQ(store.GetClient(client_id), nullptr);
+    EXPECT_TRUE(store.GetClients().empty());
+}
+
+TEST(P2PStandbyMetadataStoreTest, UnRegisterClientCascadeDeletesReplicas) {
+    P2PStandbyMetadataStore store;
+    auto client_id = MakeUUID(1, 0);
+    auto seg1 = MakeUUID(10, 0);
+    auto seg2 = MakeUUID(11, 0);
+
+    store.RegisterClient(client_id, "10.0.0.1", 50051,
+                         {MakeSegment(seg1, 1024), MakeSegment(seg2, 2048)});
+    store.AddReplica("key1", client_id, seg1, 1024, 0, {}, MemoryType::DRAM);
+    store.AddReplica("key2", client_id, seg2, 2048, 0, {}, MemoryType::DRAM);
+    ASSERT_EQ(store.GetKeyCount(), 2u);
+
+    store.UnRegisterClient(client_id);
+
+    EXPECT_EQ(store.GetClient(client_id), nullptr);
+    EXPECT_EQ(store.GetKeyCount(), 0u);
+}
+
+TEST(P2PStandbyMetadataStoreTest, UnRegisterClientPreservesOtherClients) {
+    P2PStandbyMetadataStore store;
+    auto client1 = MakeUUID(1, 0);
+    auto client2 = MakeUUID(2, 0);
+    auto seg1 = MakeUUID(10, 0);
+    auto seg2 = MakeUUID(20, 0);
+
+    store.RegisterClient(client1, "10.0.0.1", 50051, {MakeSegment(seg1, 1024)});
+    store.RegisterClient(client2, "10.0.0.2", 50052, {MakeSegment(seg2, 2048)});
+    store.AddReplica("shared-key", client1, seg1, 1024, 0, {},
+                     MemoryType::DRAM);
+    store.AddReplica("shared-key", client2, seg2, 2048, 0, {},
+                     MemoryType::DRAM);
+    store.AddReplica("client1-only", client1, seg1, 512, 0, {},
+                     MemoryType::DRAM);
+
+    store.UnRegisterClient(client1);
+
+    EXPECT_EQ(store.GetClient(client1), nullptr);
+    ASSERT_NE(store.GetClient(client2), nullptr);
+    EXPECT_EQ(store.GetKeyCount(), 1u);
+
+    auto shared_it = store.GetObjects().find("shared-key");
+    ASSERT_NE(shared_it, store.GetObjects().end());
+    ASSERT_EQ(shared_it->second.replicas.size(), 1u);
+    const auto& p2p = std::get<P2PProxyDescriptor>(
+        shared_it->second.replicas[0].descriptor_variant);
+    EXPECT_EQ(p2p.client_id, client2);
+    EXPECT_EQ(store.GetObjects().find("client1-only"),
+              store.GetObjects().end());
 }
 
 // ============================================================================


### PR DESCRIPTION
Description

  Add P2PStandbyMetadataStore — the metadata storage layer for P2P HA
  standby mode.

  In P2P HA standby, the standby node must replay the Primary's OpLog
  to maintain a metadata mirror for fast failover promotion. The main
  branch's MetadataStore only stores object-level
  StandbyObjectMetadata, but P2P mode additionally needs:

  1. Client registration info — P2P has no Snapshot fallback (main uses
  Snapshot + client reconnect)
  2. Segment mappings — segment info directly affects GetWriteRoute
  routing
  3. Client lookup for MOUNT_SEGMENT replay — requires client_id →
  client record mapping

  Key design decisions:

  - Inherits MetadataStore interface for object-level CRUD (used by
  OpLogApplier base class)
  - Extends with P2P-specific operations: AddReplica, RemoveReplica,
  RegisterClient, AddSegment, RemoveSegment, RemoveAllMetadata
  - Out-of-order tolerance: If ADD_REPLICA arrives before
  REGISTER_CLIENT, replica IP/port stays empty; RegisterClient
  backfills all matching replicas on arrival
  - Cascade delete: RemoveSegment removes the segment from client and
  deletes all replicas on that segment; objects with no remaining
  replicas are automatically removed
  - ExportMetadata(): exports all objects + clients for initializing
  P2PMasterService during standby → primary promotion
  - Thread safety: single-threaded by design — OpLogReplicator callback
  thread writes, and ExportMetadata() is called only after
  Replicator::Stop() joins the callback thread during promotion

  Module

  - [ ] Transfer Engine (mooncake-transfer-engine)
  - [ ] Mooncake Store (mooncake-store)
  - [ ] Mooncake EP (mooncake-ep)
  - [ ] Mooncake PG (mooncake-pg)
  - [ ] Integration (mooncake-integration)
  - [x] P2P Store (mooncake-p2p-store)
  - [ ] Python Wheel (mooncake-wheel)
  - [ ] Common (mooncake-common)
  - [ ] Mooncake RL (mooncake-rl)
  - [ ] CI/CD
  - [ ] Docs
  - [ ] Other

  Type of Change

  - [ ] Bug fix
  - [x] New feature
  - [ ] Refactor
  - [ ] Breaking change
  - [ ] Documentation update
  - [ ] Performance improvement
  - [ ] Other

  How Has This Been Tested?

  Test commands:
  # Build
  docker exec mooncake-dev bash -c "cd /workspace && rm -rf build &&
  mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Debug && make
  -j3"

  # Run unit tests
  docker exec mooncake-dev bash -c "cd /workspace/build && ctest -R
  p2p_standby_metadata_store_test -V"

  # Code format
  docker exec mooncake-dev bash -c "cd /workspace &&
  ./scripts/code_format.sh"

  Test results:
  - [x] Unit tests pass — 18 tests from P2PStandbyMetadataStoreTest all
  passed
  - [ ] Integration tests pass (not applicable for this component)
  - [x] Manual testing done — clean build succeeded, code format check
  passed

  Checklist

  - [x] I have performed a self-review of my own code
  - [x] I have formatted my code using ./scripts/code_format.sh
  - [ ] I have run pre-commit run --all-files and all hooks pass
  - [ ] I have updated the documentation (not applicable)
  - [x] I have added tests to prove my changes are effective
  - [ ] For changes >500 LOC: I have filed an RFC issue (860 LOC added,
  but this is part of the existing P2P OpLog HA design)

  AI Assistance Disclosure

  - [ ] No AI tools were used
  - [x] AI tools were used — Claude Code assisted with code review,
  renaming, and formatting