### PR TITLE
Apply per Device stream to avoid GPU 0 kmd traffic

### DIFF
--- a/mooncake-transfer-engine/src/transport/intranode_nvlink_transport/intranode_nvlink_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/intranode_nvlink_transport/intranode_nvlink_transport.cpp
@@ -66,8 +66,8 @@ class PerDeviceStreamPool {
         }
         CudaStreamEntry entry;
         entry.device_id = device_id;
-        cudaError_t err = cudaStreamCreateWithFlags(&entry.stream,
-                                                    cudaStreamNonBlocking);
+        cudaError_t err =
+            cudaStreamCreateWithFlags(&entry.stream, cudaStreamNonBlocking);
         if (err != cudaSuccess)
             LOG(FATAL) << "Failed to create NVLink CUDA stream on device "
                        << device_id << ": " << cudaGetErrorString(err);
@@ -79,12 +79,11 @@ class PerDeviceStreamPool {
                   std::to_string(prop.pciBusID) + ":" +
                   std::to_string(prop.pciDeviceID);
         }
-        const char* visible = getenv("CUDA_VISIBLE_DEVICES");
+        const char *visible = getenv("CUDA_VISIBLE_DEVICES");
         LOG(INFO) << "IntraNodeNvlinkTransport: NVLink CUDA stream created on "
                   << "device " << device_id << " [physical: " << pci
                   << "] CUDA_VISIBLE_DEVICES="
-                  << (visible ? visible : "(not set)")
-                  << " pid=" << getpid();
+                  << (visible ? visible : "(not set)") << " pid=" << getpid();
         pool_[device_id] = entry;
         return entry;
     }
@@ -97,6 +96,7 @@ class PerDeviceStreamPool {
         }
         cudaSetDevice(saved_device);
     }
+
    private:
     std::unordered_map<int, CudaStreamEntry> pool_;
 };
@@ -112,7 +112,7 @@ static cudaEvent_t getCallerSyncEvent() {
     if (tl_caller_sync_event_device != current_device) {
         if (tl_caller_sync_event) cudaEventDestroy(tl_caller_sync_event);
         cudaError_t err = cudaEventCreateWithFlags(&tl_caller_sync_event,
-                                                    cudaEventDisableTiming);
+                                                   cudaEventDisableTiming);
         if (err != cudaSuccess)
             LOG(FATAL) << "Failed to create NVLink sync event on device "
                        << current_device << ": " << cudaGetErrorString(err);
@@ -407,13 +407,12 @@ Status IntraNodeNvlinkTransport::submitTransfer(
     CudaStreamEntry stream_entry =
         getStreamForRequest(entries.empty() ? nullptr : entries[0].source);
     cudaStream_t stream = stream_entry.stream;
-    if (!stream)
-        return Status::Context("Failed to create NVLink CUDA stream");
-    // Synchronize with caller's GPU work via cudaEventSynchronize (CPU-blocking)
-    // to avoid expensive cross-device cudaStreamWaitEvent on non-NVIDIA GPUs.
+    if (!stream) return Status::Context("Failed to create NVLink CUDA stream");
+    // Synchronize with caller's GPU work via cudaEventSynchronize
+    // (CPU-blocking) to avoid expensive cross-device cudaStreamWaitEvent on
+    // non-NVIDIA GPUs.
     cudaEvent_t sync_event = getCallerSyncEvent();
-    cudaError_t sync_err =
-        cudaEventRecord(sync_event, cudaStreamPerThread);
+    cudaError_t sync_err = cudaEventRecord(sync_event, cudaStreamPerThread);
     if (sync_err != cudaSuccess) {
         LOG(ERROR) << "IntraNodeNvlinkTransport: cudaEventRecord failed: "
                    << cudaGetErrorString(sync_err);
@@ -527,11 +526,9 @@ Status IntraNodeNvlinkTransport::submitTransferTask(
     CudaStreamEntry stream_entry = getStreamForRequest(
         task_list.empty() ? nullptr : task_list[0]->request->source);
     cudaStream_t stream = stream_entry.stream;
-    if (!stream)
-        return Status::Context("Failed to create NVLink CUDA stream");
+    if (!stream) return Status::Context("Failed to create NVLink CUDA stream");
     cudaEvent_t sync_event = getCallerSyncEvent();
-    cudaError_t sync_err =
-        cudaEventRecord(sync_event, cudaStreamPerThread);
+    cudaError_t sync_err = cudaEventRecord(sync_event, cudaStreamPerThread);
     if (sync_err != cudaSuccess) {
         LOG(ERROR) << "IntraNodeNvlinkTransport: cudaEventRecord failed: "
                    << cudaGetErrorString(sync_err);

--- a/mooncake-transfer-engine/src/transport/intranode_nvlink_transport/intranode_nvlink_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/intranode_nvlink_transport/intranode_nvlink_transport.cpp
@@ -46,50 +46,32 @@ namespace mooncake {
 
 namespace {
 
-/// Per-device CUDA stream + event pool (thread-local).
-/// Each thread maintains a map of device_id → (stream, event).
-/// When submitTransfer is called, the source buffer's device is queried via
-/// cudaPointerGetAttributes, and the stream for THAT device is used.
-/// This ensures that DMA copies are submitted to the correct GPU's KMD
-/// queue, avoiding the problem where all copies pile up on GPU 0.
-struct CudaStreamEventPair {
+/// Per-device CUDA stream pool (thread-local).
+struct CudaStreamEntry {
     cudaStream_t stream;
-    cudaEvent_t event;
     int device_id;
 };
 
 class PerDeviceStreamPool {
    public:
-    CudaStreamEventPair getOrCreate(int device_id) {
+    CudaStreamEntry getOrCreate(int device_id) {
         auto it = pool_.find(device_id);
-        if (it != pool_.end()) {
-            return it->second;
-        }
-
+        if (it != pool_.end()) return it->second;
         int saved_device = 0;
         cudaGetDevice(&saved_device);
         if (cudaSetDevice(device_id) != cudaSuccess) {
             LOG(ERROR) << "IntraNodeNvlinkTransport: cudaSetDevice("
-                       << device_id << ") failed when creating stream";
-            return {nullptr, nullptr, -1};
+                       << device_id << ") failed";
+            return {nullptr, -1};
         }
-
-        CudaStreamEventPair pair;
-        pair.device_id = device_id;
-        cudaError_t err = cudaStreamCreateWithFlags(&pair.stream,
+        CudaStreamEntry entry;
+        entry.device_id = device_id;
+        cudaError_t err = cudaStreamCreateWithFlags(&entry.stream,
                                                     cudaStreamNonBlocking);
-        if (err != cudaSuccess) {
+        if (err != cudaSuccess)
             LOG(FATAL) << "Failed to create NVLink CUDA stream on device "
                        << device_id << ": " << cudaGetErrorString(err);
-        }
-        err = cudaEventCreateWithFlags(&pair.event, cudaEventDisableTiming);
-        if (err != cudaSuccess) {
-            LOG(FATAL) << "Failed to create NVLink CUDA event on device "
-                       << device_id << ": " << cudaGetErrorString(err);
-        }
-
         cudaSetDevice(saved_device);
-
         cudaDeviceProp prop;
         std::string pci = "unknown";
         if (cudaGetDeviceProperties(&prop, device_id) == cudaSuccess) {
@@ -103,42 +85,52 @@ class PerDeviceStreamPool {
                   << "] CUDA_VISIBLE_DEVICES="
                   << (visible ? visible : "(not set)")
                   << " pid=" << getpid();
-
-        pool_[device_id] = pair;
-        return pair;
+        pool_[device_id] = entry;
+        return entry;
     }
-
     ~PerDeviceStreamPool() {
         int saved_device = 0;
         cudaGetDevice(&saved_device);
         for (auto &kv : pool_) {
             cudaSetDevice(kv.first);
             if (kv.second.stream) cudaStreamDestroy(kv.second.stream);
-            if (kv.second.event) cudaEventDestroy(kv.second.event);
         }
         cudaSetDevice(saved_device);
     }
-
    private:
-    std::unordered_map<int, CudaStreamEventPair> pool_;
+    std::unordered_map<int, CudaStreamEntry> pool_;
 };
 
 static thread_local PerDeviceStreamPool tl_device_stream_pool;
 
+static thread_local cudaEvent_t tl_caller_sync_event = nullptr;
+static thread_local int tl_caller_sync_event_device = -1;
+
+static cudaEvent_t getCallerSyncEvent() {
+    int current_device = 0;
+    cudaGetDevice(&current_device);
+    if (tl_caller_sync_event_device != current_device) {
+        if (tl_caller_sync_event) cudaEventDestroy(tl_caller_sync_event);
+        cudaError_t err = cudaEventCreateWithFlags(&tl_caller_sync_event,
+                                                    cudaEventDisableTiming);
+        if (err != cudaSuccess)
+            LOG(FATAL) << "Failed to create NVLink sync event on device "
+                       << current_device << ": " << cudaGetErrorString(err);
+        tl_caller_sync_event_device = current_device;
+    }
+    return tl_caller_sync_event;
+}
+
 static int getDeviceForPointer(const void *ptr) {
     cudaPointerAttributes attr;
-    cudaError_t err = cudaPointerGetAttributes(&attr, ptr);
-    if (err != cudaSuccess) {
+    if (cudaPointerGetAttributes(&attr, ptr) != cudaSuccess) {
         cudaGetLastError();
         return -1;
     }
-    if (attr.type == cudaMemoryTypeDevice) {
-        return attr.device;
-    }
-    return -1;
+    return (attr.type == cudaMemoryTypeDevice) ? attr.device : -1;
 }
 
-static CudaStreamEventPair getStreamForRequest(const void *source) {
+static CudaStreamEntry getStreamForRequest(const void *source) {
     int device_id = getDeviceForPointer(source);
     if (device_id < 0) {
         cudaGetDevice(&device_id);
@@ -411,42 +403,29 @@ Status IntraNodeNvlinkTransport::submitTransfer(
     size_t task_id = batch_desc.task_list.size();
     batch_desc.task_list.resize(task_id + entries.size());
 
-    // Determine the source buffer's device and get the per-device stream.
-    // This ensures DMA copies are submitted to the correct GPU's KMD queue,
-    // not all piled up on GPU 0.
-    CudaStreamEventPair stream_event =
+    // Get per-device transfer stream for the source buffer's device.
+    CudaStreamEntry stream_entry =
         getStreamForRequest(entries.empty() ? nullptr : entries[0].source);
-    cudaStream_t stream = stream_event.stream;
-    cudaEvent_t sync_event = stream_event.event;
-    if (!stream || !sync_event) {
-        return Status::Context("Failed to create NVLink CUDA stream/event");
-    }
-    // Switch to the stream's device before recording the event.
-    int saved_device = 0;
-    cudaGetDevice(&saved_device);
-    if (stream_event.device_id != saved_device) {
-        cudaSetDevice(stream_event.device_id);
-    }
+    cudaStream_t stream = stream_entry.stream;
+    if (!stream)
+        return Status::Context("Failed to create NVLink CUDA stream");
+    // Synchronize with caller's GPU work via cudaEventSynchronize (CPU-blocking)
+    // to avoid expensive cross-device cudaStreamWaitEvent on non-NVIDIA GPUs.
+    cudaEvent_t sync_event = getCallerSyncEvent();
     cudaError_t sync_err =
         cudaEventRecord(sync_event, cudaStreamPerThread);
     if (sync_err != cudaSuccess) {
-        LOG(ERROR) << "IntraNodeNvlinkTransport: cudaEventRecord on "
-                      "cudaStreamPerThread failed: "
+        LOG(ERROR) << "IntraNodeNvlinkTransport: cudaEventRecord failed: "
                    << cudaGetErrorString(sync_err);
-        cudaSetDevice(saved_device);
         return Status::Context("cudaEventRecord failed: " +
                                std::string(cudaGetErrorString(sync_err)));
     }
-    sync_err = cudaStreamWaitEvent(stream, sync_event, 0);
+    sync_err = cudaEventSynchronize(sync_event);
     if (sync_err != cudaSuccess) {
-        LOG(ERROR) << "IntraNodeNvlinkTransport: cudaStreamWaitEvent failed: "
+        LOG(ERROR) << "IntraNodeNvlinkTransport: cudaEventSynchronize failed: "
                    << cudaGetErrorString(sync_err);
-        cudaSetDevice(saved_device);
-        return Status::Context("cudaStreamWaitEvent failed: " +
+        return Status::Context("cudaEventSynchronize failed: " +
                                std::string(cudaGetErrorString(sync_err)));
-    }
-    if (stream_event.device_id != saved_device) {
-        cudaSetDevice(saved_device);
     }
 
     // Phase 1: Prepare slices and collect memcpy parameters
@@ -507,51 +486,25 @@ Status IntraNodeNvlinkTransport::getTransferStatus(BatchID batch_id,
     }
     auto &task = batch_desc.task_list[task_id];
     // Poll POSTED slices for async completion via cudaStreamQuery.
-    // Cache the query result per stream to avoid redundant driver calls,
-    // since multiple slices typically share the same CUDA stream.
-    //
-    // IMPORTANT: cudaStreamQuery must be called from the correct device
-    // context. On non-NVIDIA GPUs, querying a stream created on device N
-    // while the active device is 0 may return an error instead of
-    // cudaErrorNotReady, causing false failures.
-    struct StreamQueryResult {
-        cudaError_t err;
-        int device_id;
-    };
-    std::unordered_map<cudaStream_t, StreamQueryResult> stream_status_cache;
-    int saved_device = 0;
-    cudaGetDevice(&saved_device);
+    std::unordered_map<cudaStream_t, cudaError_t> stream_status_cache;
     for (auto *slice : task.slice_list) {
         if (slice && slice->status == Slice::POSTED) {
             cudaStream_t stream = (cudaStream_t)slice->local.cuda_stream;
             auto it = stream_status_cache.find(stream);
             cudaError_t cuda_err;
-            int stream_device = -1;
             if (it == stream_status_cache.end()) {
-#if CUDART_VERSION >= 12000
-                cudaStreamGetDevice(stream, &stream_device);
-#else
-                cudaGetDevice(&stream_device);
-#endif
-                if (stream_device >= 0 && stream_device != saved_device) {
-                    cudaSetDevice(stream_device);
-                }
                 cuda_err = cudaStreamQuery(stream);
-                stream_status_cache[stream] = {cuda_err, stream_device};
+                stream_status_cache[stream] = cuda_err;
             } else {
-                cuda_err = it->second.err;
-                stream_device = it->second.device_id;
+                cuda_err = it->second;
             }
             if (cuda_err == cudaSuccess) {
                 slice->markSuccess();
             } else if (cuda_err != cudaErrorNotReady) {
                 slice->markFailed();
             }
-            // cudaErrorNotReady means still in progress, keep POSTED
         }
     }
-    // Restore the caller's device.
-    cudaSetDevice(saved_device);
     status.transferred_bytes = task.transferred_bytes;
     uint64_t success_slice_count = task.success_slice_count;
     uint64_t failed_slice_count = task.failed_slice_count;
@@ -570,41 +523,27 @@ Status IntraNodeNvlinkTransport::getTransferStatus(BatchID batch_id,
 
 Status IntraNodeNvlinkTransport::submitTransferTask(
     const std::vector<TransferTask *> &task_list) {
-    // Determine the source buffer's device and get the per-device stream.
-    // See submitTransfer() for detailed rationale.
-    CudaStreamEventPair stream_event = getStreamForRequest(
+    // Get per-device transfer stream. See submitTransfer() for rationale.
+    CudaStreamEntry stream_entry = getStreamForRequest(
         task_list.empty() ? nullptr : task_list[0]->request->source);
-    cudaStream_t stream = stream_event.stream;
-    cudaEvent_t sync_event = stream_event.event;
-    if (!stream || !sync_event) {
-        return Status::Context("Failed to create NVLink CUDA stream/event");
-    }
-    // Switch to the stream's device before recording the event.
-    int saved_device = 0;
-    cudaGetDevice(&saved_device);
-    if (stream_event.device_id != saved_device) {
-        cudaSetDevice(stream_event.device_id);
-    }
+    cudaStream_t stream = stream_entry.stream;
+    if (!stream)
+        return Status::Context("Failed to create NVLink CUDA stream");
+    cudaEvent_t sync_event = getCallerSyncEvent();
     cudaError_t sync_err =
         cudaEventRecord(sync_event, cudaStreamPerThread);
     if (sync_err != cudaSuccess) {
-        LOG(ERROR) << "IntraNodeNvlinkTransport: cudaEventRecord on "
-                      "cudaStreamPerThread failed: "
+        LOG(ERROR) << "IntraNodeNvlinkTransport: cudaEventRecord failed: "
                    << cudaGetErrorString(sync_err);
-        cudaSetDevice(saved_device);
         return Status::Context("cudaEventRecord failed: " +
                                std::string(cudaGetErrorString(sync_err)));
     }
-    sync_err = cudaStreamWaitEvent(stream, sync_event, 0);
+    sync_err = cudaEventSynchronize(sync_event);
     if (sync_err != cudaSuccess) {
-        LOG(ERROR) << "IntraNodeNvlinkTransport: cudaStreamWaitEvent failed: "
+        LOG(ERROR) << "IntraNodeNvlinkTransport: cudaEventSynchronize failed: "
                    << cudaGetErrorString(sync_err);
-        cudaSetDevice(saved_device);
-        return Status::Context("cudaStreamWaitEvent failed: " +
+        return Status::Context("cudaEventSynchronize failed: " +
                                std::string(cudaGetErrorString(sync_err)));
-    }
-    if (stream_event.device_id != saved_device) {
-        cudaSetDevice(saved_device);
     }
 
     // Phase 1: Prepare slices and collect memcpy parameters

--- a/mooncake-transfer-engine/src/transport/intranode_nvlink_transport/intranode_nvlink_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/intranode_nvlink_transport/intranode_nvlink_transport.cpp
@@ -45,37 +45,108 @@ static bool checkCudaErrorReturn(cudaError_t result, const char *message) {
 namespace mooncake {
 
 namespace {
-struct CudaStreamNVLinkRAII {
-    cudaStream_t stream_;
-    CudaStreamNVLinkRAII() : stream_(nullptr) {
-        auto err = cudaStreamCreateWithFlags(&stream_, cudaStreamNonBlocking);
-        if (err != cudaSuccess) {
-            LOG(FATAL) << "Failed to create NVLink CUDA stream: " << err
-                       << " - " << cudaGetErrorString(err);
-        }
-    }
-    ~CudaStreamNVLinkRAII() { cudaStreamDestroy(stream_); }
+
+/// Per-device CUDA stream + event pool (thread-local).
+/// Each thread maintains a map of device_id → (stream, event).
+/// When submitTransfer is called, the source buffer's device is queried via
+/// cudaPointerGetAttributes, and the stream for THAT device is used.
+/// This ensures that DMA copies are submitted to the correct GPU's KMD
+/// queue, avoiding the problem where all copies pile up on GPU 0.
+struct CudaStreamEventPair {
+    cudaStream_t stream;
+    cudaEvent_t event;
+    int device_id;
 };
 
-static thread_local CudaStreamNVLinkRAII tl_nvlink_stream;
-
-/// Thread-local CUDA event for GPU-level stream synchronization.
-/// Used to establish a GPU-visible dependency between cudaStreamPerThread
-/// and nvlink_stream, which is required by cudaMemcpyBatchAsync's
-/// srcAccessOrderStream attribute for cross-stream P2P copies.
-struct CudaEventNVLinkRAII {
-    cudaEvent_t event_;
-    CudaEventNVLinkRAII() {
-        auto err = cudaEventCreateWithFlags(&event_, cudaEventDisableTiming);
-        if (err != cudaSuccess) {
-            LOG(FATAL) << "Failed to create NVLink CUDA sync event: " << err
-                       << " - " << cudaGetErrorString(err);
+class PerDeviceStreamPool {
+   public:
+    CudaStreamEventPair getOrCreate(int device_id) {
+        auto it = pool_.find(device_id);
+        if (it != pool_.end()) {
+            return it->second;
         }
+
+        int saved_device = 0;
+        cudaGetDevice(&saved_device);
+        if (cudaSetDevice(device_id) != cudaSuccess) {
+            LOG(ERROR) << "IntraNodeNvlinkTransport: cudaSetDevice("
+                       << device_id << ") failed when creating stream";
+            return {nullptr, nullptr, -1};
+        }
+
+        CudaStreamEventPair pair;
+        pair.device_id = device_id;
+        cudaError_t err = cudaStreamCreateWithFlags(&pair.stream,
+                                                    cudaStreamNonBlocking);
+        if (err != cudaSuccess) {
+            LOG(FATAL) << "Failed to create NVLink CUDA stream on device "
+                       << device_id << ": " << cudaGetErrorString(err);
+        }
+        err = cudaEventCreateWithFlags(&pair.event, cudaEventDisableTiming);
+        if (err != cudaSuccess) {
+            LOG(FATAL) << "Failed to create NVLink CUDA event on device "
+                       << device_id << ": " << cudaGetErrorString(err);
+        }
+
+        cudaSetDevice(saved_device);
+
+        cudaDeviceProp prop;
+        std::string pci = "unknown";
+        if (cudaGetDeviceProperties(&prop, device_id) == cudaSuccess) {
+            pci = std::string(prop.name) + " PCI " +
+                  std::to_string(prop.pciBusID) + ":" +
+                  std::to_string(prop.pciDeviceID);
+        }
+        const char* visible = getenv("CUDA_VISIBLE_DEVICES");
+        LOG(INFO) << "IntraNodeNvlinkTransport: NVLink CUDA stream created on "
+                  << "device " << device_id << " [physical: " << pci
+                  << "] CUDA_VISIBLE_DEVICES="
+                  << (visible ? visible : "(not set)")
+                  << " pid=" << getpid();
+
+        pool_[device_id] = pair;
+        return pair;
     }
-    ~CudaEventNVLinkRAII() { cudaEventDestroy(event_); }
+
+    ~PerDeviceStreamPool() {
+        int saved_device = 0;
+        cudaGetDevice(&saved_device);
+        for (auto &kv : pool_) {
+            cudaSetDevice(kv.first);
+            if (kv.second.stream) cudaStreamDestroy(kv.second.stream);
+            if (kv.second.event) cudaEventDestroy(kv.second.event);
+        }
+        cudaSetDevice(saved_device);
+    }
+
+   private:
+    std::unordered_map<int, CudaStreamEventPair> pool_;
 };
 
-static thread_local CudaEventNVLinkRAII tl_nvlink_sync_event;
+static thread_local PerDeviceStreamPool tl_device_stream_pool;
+
+static int getDeviceForPointer(const void *ptr) {
+    cudaPointerAttributes attr;
+    cudaError_t err = cudaPointerGetAttributes(&attr, ptr);
+    if (err != cudaSuccess) {
+        cudaGetLastError();
+        return -1;
+    }
+    if (attr.type == cudaMemoryTypeDevice) {
+        return attr.device;
+    }
+    return -1;
+}
+
+static CudaStreamEventPair getStreamForRequest(const void *source) {
+    int device_id = getDeviceForPointer(source);
+    if (device_id < 0) {
+        cudaGetDevice(&device_id);
+        if (device_id < 0) device_id = 0;
+    }
+    return tl_device_stream_pool.getOrCreate(device_id);
+}
+
 }  // anonymous namespace
 
 using Slice = Transport::Slice;
@@ -340,34 +411,42 @@ Status IntraNodeNvlinkTransport::submitTransfer(
     size_t task_id = batch_desc.task_list.size();
     batch_desc.task_list.resize(task_id + entries.size());
 
-    // Synchronize with the caller's CUDA stream before issuing any memcpy.
-    // PyTorch uses cudaStreamPerThread (per-thread default stream), NOT the
-    // legacy default stream (nullptr). Recording an event on
-    // cudaStreamPerThread and making nvlink_stream wait for it ensures that all
-    // PyTorch GPU operations on source/dest buffers complete before the NVLink
-    // memcpy starts. This GPU-level dependency is also required by
-    // cudaMemcpyBatchAsync's srcAccessOrderStream attribute, which needs
-    // the source data to be visible through the nvlink_stream's access order.
-    //
-    // Do NOT use the legacy default stream (nullptr) for cudaEventRecord,
-    // as it would trigger implicit synchronization with blocking streams and
-    // could cause deadlocks.
-    cudaStream_t stream = tl_nvlink_stream.stream_;
+    // Determine the source buffer's device and get the per-device stream.
+    // This ensures DMA copies are submitted to the correct GPU's KMD queue,
+    // not all piled up on GPU 0.
+    CudaStreamEventPair stream_event =
+        getStreamForRequest(entries.empty() ? nullptr : entries[0].source);
+    cudaStream_t stream = stream_event.stream;
+    cudaEvent_t sync_event = stream_event.event;
+    if (!stream || !sync_event) {
+        return Status::Context("Failed to create NVLink CUDA stream/event");
+    }
+    // Switch to the stream's device before recording the event.
+    int saved_device = 0;
+    cudaGetDevice(&saved_device);
+    if (stream_event.device_id != saved_device) {
+        cudaSetDevice(stream_event.device_id);
+    }
     cudaError_t sync_err =
-        cudaEventRecord(tl_nvlink_sync_event.event_, cudaStreamPerThread);
+        cudaEventRecord(sync_event, cudaStreamPerThread);
     if (sync_err != cudaSuccess) {
         LOG(ERROR) << "IntraNodeNvlinkTransport: cudaEventRecord on "
                       "cudaStreamPerThread failed: "
                    << cudaGetErrorString(sync_err);
+        cudaSetDevice(saved_device);
         return Status::Context("cudaEventRecord failed: " +
                                std::string(cudaGetErrorString(sync_err)));
     }
-    sync_err = cudaStreamWaitEvent(stream, tl_nvlink_sync_event.event_, 0);
+    sync_err = cudaStreamWaitEvent(stream, sync_event, 0);
     if (sync_err != cudaSuccess) {
         LOG(ERROR) << "IntraNodeNvlinkTransport: cudaStreamWaitEvent failed: "
                    << cudaGetErrorString(sync_err);
+        cudaSetDevice(saved_device);
         return Status::Context("cudaStreamWaitEvent failed: " +
                                std::string(cudaGetErrorString(sync_err)));
+    }
+    if (stream_event.device_id != saved_device) {
+        cudaSetDevice(saved_device);
     }
 
     // Phase 1: Prepare slices and collect memcpy parameters
@@ -430,17 +509,38 @@ Status IntraNodeNvlinkTransport::getTransferStatus(BatchID batch_id,
     // Poll POSTED slices for async completion via cudaStreamQuery.
     // Cache the query result per stream to avoid redundant driver calls,
     // since multiple slices typically share the same CUDA stream.
-    std::unordered_map<cudaStream_t, cudaError_t> stream_status_cache;
+    //
+    // IMPORTANT: cudaStreamQuery must be called from the correct device
+    // context. On non-NVIDIA GPUs, querying a stream created on device N
+    // while the active device is 0 may return an error instead of
+    // cudaErrorNotReady, causing false failures.
+    struct StreamQueryResult {
+        cudaError_t err;
+        int device_id;
+    };
+    std::unordered_map<cudaStream_t, StreamQueryResult> stream_status_cache;
+    int saved_device = 0;
+    cudaGetDevice(&saved_device);
     for (auto *slice : task.slice_list) {
         if (slice && slice->status == Slice::POSTED) {
             cudaStream_t stream = (cudaStream_t)slice->local.cuda_stream;
             auto it = stream_status_cache.find(stream);
             cudaError_t cuda_err;
+            int stream_device = -1;
             if (it == stream_status_cache.end()) {
+#if CUDART_VERSION >= 12000
+                cudaStreamGetDevice(stream, &stream_device);
+#else
+                cudaGetDevice(&stream_device);
+#endif
+                if (stream_device >= 0 && stream_device != saved_device) {
+                    cudaSetDevice(stream_device);
+                }
                 cuda_err = cudaStreamQuery(stream);
-                stream_status_cache[stream] = cuda_err;
+                stream_status_cache[stream] = {cuda_err, stream_device};
             } else {
-                cuda_err = it->second;
+                cuda_err = it->second.err;
+                stream_device = it->second.device_id;
             }
             if (cuda_err == cudaSuccess) {
                 slice->markSuccess();
@@ -450,6 +550,8 @@ Status IntraNodeNvlinkTransport::getTransferStatus(BatchID batch_id,
             // cudaErrorNotReady means still in progress, keep POSTED
         }
     }
+    // Restore the caller's device.
+    cudaSetDevice(saved_device);
     status.transferred_bytes = task.transferred_bytes;
     uint64_t success_slice_count = task.success_slice_count;
     uint64_t failed_slice_count = task.failed_slice_count;
@@ -468,24 +570,41 @@ Status IntraNodeNvlinkTransport::getTransferStatus(BatchID batch_id,
 
 Status IntraNodeNvlinkTransport::submitTransferTask(
     const std::vector<TransferTask *> &task_list) {
-    // Synchronize with the caller's CUDA stream before issuing any memcpy.
+    // Determine the source buffer's device and get the per-device stream.
     // See submitTransfer() for detailed rationale.
-    cudaStream_t stream = tl_nvlink_stream.stream_;
+    CudaStreamEventPair stream_event = getStreamForRequest(
+        task_list.empty() ? nullptr : task_list[0]->request->source);
+    cudaStream_t stream = stream_event.stream;
+    cudaEvent_t sync_event = stream_event.event;
+    if (!stream || !sync_event) {
+        return Status::Context("Failed to create NVLink CUDA stream/event");
+    }
+    // Switch to the stream's device before recording the event.
+    int saved_device = 0;
+    cudaGetDevice(&saved_device);
+    if (stream_event.device_id != saved_device) {
+        cudaSetDevice(stream_event.device_id);
+    }
     cudaError_t sync_err =
-        cudaEventRecord(tl_nvlink_sync_event.event_, cudaStreamPerThread);
+        cudaEventRecord(sync_event, cudaStreamPerThread);
     if (sync_err != cudaSuccess) {
         LOG(ERROR) << "IntraNodeNvlinkTransport: cudaEventRecord on "
                       "cudaStreamPerThread failed: "
                    << cudaGetErrorString(sync_err);
+        cudaSetDevice(saved_device);
         return Status::Context("cudaEventRecord failed: " +
                                std::string(cudaGetErrorString(sync_err)));
     }
-    sync_err = cudaStreamWaitEvent(stream, tl_nvlink_sync_event.event_, 0);
+    sync_err = cudaStreamWaitEvent(stream, sync_event, 0);
     if (sync_err != cudaSuccess) {
         LOG(ERROR) << "IntraNodeNvlinkTransport: cudaStreamWaitEvent failed: "
                    << cudaGetErrorString(sync_err);
+        cudaSetDevice(saved_device);
         return Status::Context("cudaStreamWaitEvent failed: " +
                                std::string(cudaGetErrorString(sync_err)));
+    }
+    if (stream_event.device_id != saved_device) {
+        cudaSetDevice(saved_device);
     }
 
     // Phase 1: Prepare slices and collect memcpy parameters

--- a/mooncake-transfer-engine/src/transport/intranode_nvlink_transport/intranode_nvlink_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/intranode_nvlink_transport/intranode_nvlink_transport.cpp
@@ -103,22 +103,51 @@ class PerDeviceStreamPool {
 
 static thread_local PerDeviceStreamPool tl_device_stream_pool;
 
-static thread_local cudaEvent_t tl_caller_sync_event = nullptr;
-static thread_local int tl_caller_sync_event_device = -1;
+/// Per-device event pool (thread-local). Caches one event per device to
+/// avoid repeated create/destroy on device switches, and ensures proper
+/// cleanup when the thread exits.
+class PerDeviceEventPool {
+   public:
+    cudaEvent_t getOrCreate(int device_id) {
+        auto it = pool_.find(device_id);
+        if (it != pool_.end()) return it->second;
+        int saved_device = 0;
+        cudaGetDevice(&saved_device);
+        if (cudaSetDevice(device_id) != cudaSuccess) {
+            LOG(ERROR) << "IntraNodeNvlinkTransport: cudaSetDevice("
+                       << device_id << ") failed when creating event";
+            return nullptr;
+        }
+        cudaEvent_t event = nullptr;
+        cudaError_t err =
+            cudaEventCreateWithFlags(&event, cudaEventDisableTiming);
+        if (err != cudaSuccess)
+            LOG(FATAL) << "Failed to create NVLink sync event on device "
+                       << device_id << ": " << cudaGetErrorString(err);
+        cudaSetDevice(saved_device);
+        pool_[device_id] = event;
+        return event;
+    }
+    ~PerDeviceEventPool() {
+        int saved_device = 0;
+        cudaGetDevice(&saved_device);
+        for (auto &kv : pool_) {
+            cudaSetDevice(kv.first);
+            if (kv.second) cudaEventDestroy(kv.second);
+        }
+        cudaSetDevice(saved_device);
+    }
+
+   private:
+    std::unordered_map<int, cudaEvent_t> pool_;
+};
+
+static thread_local PerDeviceEventPool tl_device_event_pool;
 
 static cudaEvent_t getCallerSyncEvent() {
     int current_device = 0;
     cudaGetDevice(&current_device);
-    if (tl_caller_sync_event_device != current_device) {
-        if (tl_caller_sync_event) cudaEventDestroy(tl_caller_sync_event);
-        cudaError_t err = cudaEventCreateWithFlags(&tl_caller_sync_event,
-                                                   cudaEventDisableTiming);
-        if (err != cudaSuccess)
-            LOG(FATAL) << "Failed to create NVLink sync event on device "
-                       << current_device << ": " << cudaGetErrorString(err);
-        tl_caller_sync_event_device = current_device;
-    }
-    return tl_caller_sync_event;
+    return tl_device_event_pool.getOrCreate(current_device);
 }
 
 static int getDeviceForPointer(const void *ptr) {

--- a/mooncake-transfer-engine/src/transport/nvlink_transport/nvlink_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/nvlink_transport/nvlink_transport.cpp
@@ -46,54 +46,37 @@ namespace mooncake {
 
 namespace {
 
-/// Per-device CUDA stream + event pool (thread-local).
-/// Each thread maintains a map of device_id → (stream, event).
-/// When submitTransfer is called, the source buffer's device is queried via
-/// cudaPointerGetAttributes, and the stream for THAT device is used.
-/// This ensures that DMA copies are submitted to the correct GPU's KMD
-/// queue, avoiding the problem where all copies pile up on GPU 0.
-struct CudaStreamEventPair {
+/// Per-device CUDA stream pool (thread-local).
+/// Each thread maintains a map of device_id → stream.
+/// The source buffer's device is queried via cudaPointerGetAttributes,
+/// and the stream for THAT device is used for DMA copy submission.
+struct CudaStreamEntry {
     cudaStream_t stream;
-    cudaEvent_t event;
-    int device_id;  // device on which stream and event were created
+    int device_id;
 };
 
 class PerDeviceStreamPool {
    public:
-    /// Get or create a stream+event for the given device.
-    /// Creates on first access, caches for subsequent calls.
-    CudaStreamEventPair getOrCreate(int device_id) {
+    CudaStreamEntry getOrCreate(int device_id) {
         auto it = pool_.find(device_id);
-        if (it != pool_.end()) {
-            return it->second;
-        }
+        if (it != pool_.end()) return it->second;
 
-        // Save current device, switch to target, create stream+event, switch back.
         int saved_device = 0;
         cudaGetDevice(&saved_device);
         if (cudaSetDevice(device_id) != cudaSuccess) {
             LOG(ERROR) << "NvlinkTransport: cudaSetDevice(" << device_id
                        << ") failed when creating stream";
-            return {nullptr, nullptr, -1};
+            return {nullptr, -1};
         }
-
-        CudaStreamEventPair pair;
-        pair.device_id = device_id;
-        cudaError_t err = cudaStreamCreateWithFlags(&pair.stream,
+        CudaStreamEntry entry;
+        entry.device_id = device_id;
+        cudaError_t err = cudaStreamCreateWithFlags(&entry.stream,
                                                     cudaStreamNonBlocking);
-        if (err != cudaSuccess) {
+        if (err != cudaSuccess)
             LOG(FATAL) << "Failed to create NVLink CUDA stream on device "
                        << device_id << ": " << cudaGetErrorString(err);
-        }
-        err = cudaEventCreateWithFlags(&pair.event, cudaEventDisableTiming);
-        if (err != cudaSuccess) {
-            LOG(FATAL) << "Failed to create NVLink CUDA event on device "
-                       << device_id << ": " << cudaGetErrorString(err);
-        }
+        cudaSetDevice(saved_device);
 
-        cudaSetDevice(saved_device);  // restore
-
-        // Log physical GPU identity for verification.
         cudaDeviceProp prop;
         std::string pci = "unknown";
         if (cudaGetDeviceProperties(&prop, device_id) == cudaSuccess) {
@@ -107,50 +90,58 @@ class PerDeviceStreamPool {
                   << "] CUDA_VISIBLE_DEVICES="
                   << (visible ? visible : "(not set)")
                   << " pid=" << getpid();
-
-        pool_[device_id] = pair;
-        return pair;
+        pool_[device_id] = entry;
+        return entry;
     }
-
     ~PerDeviceStreamPool() {
         int saved_device = 0;
         cudaGetDevice(&saved_device);
         for (auto &kv : pool_) {
             cudaSetDevice(kv.first);
             if (kv.second.stream) cudaStreamDestroy(kv.second.stream);
-            if (kv.second.event) cudaEventDestroy(kv.second.event);
         }
         cudaSetDevice(saved_device);
     }
-
    private:
-    std::unordered_map<int, CudaStreamEventPair> pool_;
+    std::unordered_map<int, CudaStreamEntry> pool_;
 };
 
 static thread_local PerDeviceStreamPool tl_device_stream_pool;
 
-/// Query the CUDA device that owns the given pointer.
-/// Returns -1 if the pointer is not device memory or query fails.
-static int getDeviceForPointer(const void *ptr) {
-    cudaPointerAttributes attr;
-    cudaError_t err = cudaPointerGetAttributes(&attr, ptr);
-    if (err != cudaSuccess) {
-        cudaGetLastError();  // clear the error
-        return -1;
+/// Thread-local sync event, created on the caller's active device.
+/// Used to capture the caller's GPU work completion via cudaEventSynchronize
+/// (CPU-blocking), avoiding expensive cross-device cudaStreamWaitEvent on
+/// non-NVIDIA GPUs.
+static thread_local cudaEvent_t tl_caller_sync_event = nullptr;
+static thread_local int tl_caller_sync_event_device = -1;
+
+static cudaEvent_t getCallerSyncEvent() {
+    int current_device = 0;
+    cudaGetDevice(&current_device);
+    if (tl_caller_sync_event_device != current_device) {
+        if (tl_caller_sync_event) cudaEventDestroy(tl_caller_sync_event);
+        cudaError_t err = cudaEventCreateWithFlags(&tl_caller_sync_event,
+                                                    cudaEventDisableTiming);
+        if (err != cudaSuccess)
+            LOG(FATAL) << "Failed to create NVLink sync event on device "
+                       << current_device << ": " << cudaGetErrorString(err);
+        tl_caller_sync_event_device = current_device;
     }
-    if (attr.type == cudaMemoryTypeDevice) {
-        return attr.device;
-    }
-    return -1;
+    return tl_caller_sync_event;
 }
 
-/// Get the appropriate stream+event for a transfer request.
-/// Determines the source buffer's device and returns the stream for that GPU.
-/// Falls back to the current device if the pointer query fails.
-static CudaStreamEventPair getStreamForRequest(const void *source) {
+static int getDeviceForPointer(const void *ptr) {
+    cudaPointerAttributes attr;
+    if (cudaPointerGetAttributes(&attr, ptr) != cudaSuccess) {
+        cudaGetLastError();
+        return -1;
+    }
+    return (attr.type == cudaMemoryTypeDevice) ? attr.device : -1;
+}
+
+static CudaStreamEntry getStreamForRequest(const void *source) {
     int device_id = getDeviceForPointer(source);
     if (device_id < 0) {
-        // Not device memory (e.g., pinned host memory); use current device.
         cudaGetDevice(&device_id);
         if (device_id < 0) device_id = 0;
     }
@@ -447,48 +438,33 @@ Status NvlinkTransport::submitTransfer(
     size_t task_id = batch_desc.task_list.size();
     batch_desc.task_list.resize(task_id + entries.size());
 
-    // Determine the source buffer's device and get the per-device stream.
-    // This ensures DMA copies are submitted to the correct GPU's KMD queue,
-    // not all piled up on GPU 0.
-    // Use the first entry's source to determine the device; all entries in
-    // a batch typically share the same source device.
-    CudaStreamEventPair stream_event =
+    // Get per-device transfer stream for the source buffer's device.
+    CudaStreamEntry stream_entry =
         getStreamForRequest(entries.empty() ? nullptr : entries[0].source);
-    cudaStream_t stream = stream_event.stream;
-    cudaEvent_t sync_event = stream_event.event;
-    if (!stream || !sync_event) {
-        return Status::Context("Failed to create NVLink CUDA stream/event");
-    }
-    // Switch to the stream's device before recording the event.
-    // cudaStreamPerThread is per-device: recording on device 0's stream
-    // with a device N event may fail on non-NVIDIA GPUs. We must ensure
-    // the event is recorded on the SAME device's per-thread stream.
-    int saved_device = 0;
-    cudaGetDevice(&saved_device);
-    if (stream_event.device_id != saved_device) {
-        cudaSetDevice(stream_event.device_id);
-    }
+    cudaStream_t stream = stream_entry.stream;
+    if (!stream)
+        return Status::Context("Failed to create NVLink CUDA stream");
+
+    // Synchronize with the caller's GPU work (e.g., PyTorch gather operations)
+    // that produced the source data. We use cudaEventSynchronize (CPU-blocking)
+    // instead of cudaStreamWaitEvent to avoid expensive cross-device event
+    // operations on non-NVIDIA GPUs. The CPU blocking is acceptable because
+    // the transfer depends on the caller's work anyway — they cannot overlap.
+    cudaEvent_t sync_event = getCallerSyncEvent();
     cudaError_t sync_err =
         cudaEventRecord(sync_event, cudaStreamPerThread);
     if (sync_err != cudaSuccess) {
-        LOG(ERROR) << "NvlinkTransport: cudaEventRecord on "
-                      "cudaStreamPerThread failed: "
+        LOG(ERROR) << "NvlinkTransport: cudaEventRecord failed: "
                    << cudaGetErrorString(sync_err);
-        cudaSetDevice(saved_device);
         return Status::Context("cudaEventRecord failed: " +
                                std::string(cudaGetErrorString(sync_err)));
     }
-    sync_err = cudaStreamWaitEvent(stream, sync_event, 0);
+    sync_err = cudaEventSynchronize(sync_event);
     if (sync_err != cudaSuccess) {
-        LOG(ERROR) << "NvlinkTransport: cudaStreamWaitEvent failed: "
+        LOG(ERROR) << "NvlinkTransport: cudaEventSynchronize failed: "
                    << cudaGetErrorString(sync_err);
-        cudaSetDevice(saved_device);
-        return Status::Context("cudaStreamWaitEvent failed: " +
+        return Status::Context("cudaEventSynchronize failed: " +
                                std::string(cudaGetErrorString(sync_err)));
-    }
-    // Restore the caller's device after event sync is established.
-    if (stream_event.device_id != saved_device) {
-        cudaSetDevice(saved_device);
     }
 
     // Phase 1: Prepare slices and collect memcpy parameters
@@ -547,54 +523,29 @@ Status NvlinkTransport::getTransferStatus(BatchID batch_id, size_t task_id,
     }
     auto &task = batch_desc.task_list[task_id];
     // Poll POSTED slices for async completion via cudaStreamQuery.
-    // Cache the query result per stream to avoid redundant driver calls,
-    // since multiple slices typically share the same CUDA stream.
-    //
-    // IMPORTANT: cudaStreamQuery must be called from the correct device
-    // context. On non-NVIDIA GPUs (e.g. ZW-M890P), querying a stream
-    // created on device N while the active device is 0 may return an
-    // error instead of cudaErrorNotReady, causing false failures.
-    // We track the device_id alongside the stream in the cache.
-    struct StreamQueryResult {
-        cudaError_t err;
-        int device_id;
-    };
-    std::unordered_map<cudaStream_t, StreamQueryResult> stream_status_cache;
-    int saved_device = 0;
-    cudaGetDevice(&saved_device);
+    // Cache the query result per stream to avoid redundant driver calls.
+    // With SGLang-side torch.cuda.device(gpu_id), the calling thread's
+    // active device matches the stream's device, so no device switching
+    // is needed.
+    std::unordered_map<cudaStream_t, cudaError_t> stream_status_cache;
     for (auto *slice : task.slice_list) {
         if (slice && slice->status == Slice::POSTED) {
             cudaStream_t stream = (cudaStream_t)slice->local.cuda_stream;
             auto it = stream_status_cache.find(stream);
             cudaError_t cuda_err;
-            int stream_device = -1;
             if (it == stream_status_cache.end()) {
-                // Query which device this stream belongs to, switch to it,
-                // then query. cudaStreamGetDevice is available in CUDA 12.0+.
-#if CUDART_VERSION >= 12000
-                cudaStreamGetDevice(stream, &stream_device);
-#else
-                cudaGetDevice(&stream_device);
-#endif
-                if (stream_device >= 0 && stream_device != saved_device) {
-                    cudaSetDevice(stream_device);
-                }
                 cuda_err = cudaStreamQuery(stream);
-                stream_status_cache[stream] = {cuda_err, stream_device};
+                stream_status_cache[stream] = cuda_err;
             } else {
-                cuda_err = it->second.err;
-                stream_device = it->second.device_id;
+                cuda_err = it->second;
             }
             if (cuda_err == cudaSuccess) {
                 slice->markSuccess();
             } else if (cuda_err != cudaErrorNotReady) {
                 slice->markFailed();
             }
-            // cudaErrorNotReady means still in progress, keep POSTED
         }
     }
-    // Restore the caller's device.
-    cudaSetDevice(saved_device);
     status.transferred_bytes = task.transferred_bytes;
     uint64_t success_slice_count = task.success_slice_count;
     uint64_t failed_slice_count = task.failed_slice_count;
@@ -613,41 +564,28 @@ Status NvlinkTransport::getTransferStatus(BatchID batch_id, size_t task_id,
 
 Status NvlinkTransport::submitTransferTask(
     const std::vector<TransferTask *> &task_list) {
-    // Determine the source buffer's device and get the per-device stream.
-    // See submitTransfer() for detailed rationale.
-    CudaStreamEventPair stream_event = getStreamForRequest(
+    // Get per-device transfer stream. See submitTransfer() for rationale.
+    CudaStreamEntry stream_entry = getStreamForRequest(
         task_list.empty() ? nullptr : task_list[0]->request->source);
-    cudaStream_t stream = stream_event.stream;
-    cudaEvent_t sync_event = stream_event.event;
-    if (!stream || !sync_event) {
-        return Status::Context("Failed to create NVLink CUDA stream/event");
-    }
-    // Switch to the stream's device before recording the event.
-    int saved_device = 0;
-    cudaGetDevice(&saved_device);
-    if (stream_event.device_id != saved_device) {
-        cudaSetDevice(stream_event.device_id);
-    }
+    cudaStream_t stream = stream_entry.stream;
+    if (!stream)
+        return Status::Context("Failed to create NVLink CUDA stream");
+    // Synchronize with caller's GPU work via cudaEventSynchronize.
+    cudaEvent_t sync_event = getCallerSyncEvent();
     cudaError_t sync_err =
         cudaEventRecord(sync_event, cudaStreamPerThread);
     if (sync_err != cudaSuccess) {
-        LOG(ERROR) << "NvlinkTransport: cudaEventRecord on "
-                      "cudaStreamPerThread failed: "
+        LOG(ERROR) << "NvlinkTransport: cudaEventRecord failed: "
                    << cudaGetErrorString(sync_err);
-        cudaSetDevice(saved_device);
         return Status::Context("cudaEventRecord failed: " +
                                std::string(cudaGetErrorString(sync_err)));
     }
-    sync_err = cudaStreamWaitEvent(stream, sync_event, 0);
+    sync_err = cudaEventSynchronize(sync_event);
     if (sync_err != cudaSuccess) {
-        LOG(ERROR) << "NvlinkTransport: cudaStreamWaitEvent failed: "
+        LOG(ERROR) << "NvlinkTransport: cudaEventSynchronize failed: "
                    << cudaGetErrorString(sync_err);
-        cudaSetDevice(saved_device);
-        return Status::Context("cudaStreamWaitEvent failed: " +
+        return Status::Context("cudaEventSynchronize failed: " +
                                std::string(cudaGetErrorString(sync_err)));
-    }
-    if (stream_event.device_id != saved_device) {
-        cudaSetDevice(saved_device);
     }
 
     // Phase 1: Prepare slices and collect memcpy parameters

--- a/mooncake-transfer-engine/src/transport/nvlink_transport/nvlink_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/nvlink_transport/nvlink_transport.cpp
@@ -45,37 +45,118 @@ static bool checkCudaErrorReturn(cudaError_t result, const char *message) {
 namespace mooncake {
 
 namespace {
-struct CudaStreamNVLinkRAII {
-    cudaStream_t stream_;
-    CudaStreamNVLinkRAII() : stream_(nullptr) {
-        auto err = cudaStreamCreateWithFlags(&stream_, cudaStreamNonBlocking);
-        if (err != cudaSuccess) {
-            LOG(FATAL) << "Failed to create NVLink CUDA stream: " << err
-                       << " - " << cudaGetErrorString(err);
-        }
-    }
-    ~CudaStreamNVLinkRAII() { cudaStreamDestroy(stream_); }
+
+/// Per-device CUDA stream + event pool (thread-local).
+/// Each thread maintains a map of device_id → (stream, event).
+/// When submitTransfer is called, the source buffer's device is queried via
+/// cudaPointerGetAttributes, and the stream for THAT device is used.
+/// This ensures that DMA copies are submitted to the correct GPU's KMD
+/// queue, avoiding the problem where all copies pile up on GPU 0.
+struct CudaStreamEventPair {
+    cudaStream_t stream;
+    cudaEvent_t event;
+    int device_id;  // device on which stream and event were created
 };
 
-static thread_local CudaStreamNVLinkRAII tl_nvlink_stream;
-
-/// Thread-local CUDA event for GPU-level stream synchronization.
-/// Used to establish a GPU-visible dependency between cudaStreamPerThread
-/// and nvlink_stream, which is required by cudaMemcpyBatchAsync's
-/// srcAccessOrderStream attribute for cross-stream P2P copies.
-struct CudaEventNVLinkRAII {
-    cudaEvent_t event_;
-    CudaEventNVLinkRAII() {
-        auto err = cudaEventCreateWithFlags(&event_, cudaEventDisableTiming);
-        if (err != cudaSuccess) {
-            LOG(FATAL) << "Failed to create NVLink CUDA sync event: " << err
-                       << " - " << cudaGetErrorString(err);
+class PerDeviceStreamPool {
+   public:
+    /// Get or create a stream+event for the given device.
+    /// Creates on first access, caches for subsequent calls.
+    CudaStreamEventPair getOrCreate(int device_id) {
+        auto it = pool_.find(device_id);
+        if (it != pool_.end()) {
+            return it->second;
         }
+
+        // Save current device, switch to target, create stream+event, switch back.
+        int saved_device = 0;
+        cudaGetDevice(&saved_device);
+        if (cudaSetDevice(device_id) != cudaSuccess) {
+            LOG(ERROR) << "NvlinkTransport: cudaSetDevice(" << device_id
+                       << ") failed when creating stream";
+            return {nullptr, nullptr, -1};
+        }
+
+        CudaStreamEventPair pair;
+        pair.device_id = device_id;
+        cudaError_t err = cudaStreamCreateWithFlags(&pair.stream,
+                                                    cudaStreamNonBlocking);
+        if (err != cudaSuccess) {
+            LOG(FATAL) << "Failed to create NVLink CUDA stream on device "
+                       << device_id << ": " << cudaGetErrorString(err);
+        }
+        err = cudaEventCreateWithFlags(&pair.event, cudaEventDisableTiming);
+        if (err != cudaSuccess) {
+            LOG(FATAL) << "Failed to create NVLink CUDA event on device "
+                       << device_id << ": " << cudaGetErrorString(err);
+        }
+
+        cudaSetDevice(saved_device);  // restore
+
+        // Log physical GPU identity for verification.
+        cudaDeviceProp prop;
+        std::string pci = "unknown";
+        if (cudaGetDeviceProperties(&prop, device_id) == cudaSuccess) {
+            pci = std::string(prop.name) + " PCI " +
+                  std::to_string(prop.pciBusID) + ":" +
+                  std::to_string(prop.pciDeviceID);
+        }
+        const char* visible = getenv("CUDA_VISIBLE_DEVICES");
+        LOG(INFO) << "NvlinkTransport: NVLink CUDA stream created on device "
+                  << device_id << " [physical: " << pci
+                  << "] CUDA_VISIBLE_DEVICES="
+                  << (visible ? visible : "(not set)")
+                  << " pid=" << getpid();
+
+        pool_[device_id] = pair;
+        return pair;
     }
-    ~CudaEventNVLinkRAII() { cudaEventDestroy(event_); }
+
+    ~PerDeviceStreamPool() {
+        int saved_device = 0;
+        cudaGetDevice(&saved_device);
+        for (auto &kv : pool_) {
+            cudaSetDevice(kv.first);
+            if (kv.second.stream) cudaStreamDestroy(kv.second.stream);
+            if (kv.second.event) cudaEventDestroy(kv.second.event);
+        }
+        cudaSetDevice(saved_device);
+    }
+
+   private:
+    std::unordered_map<int, CudaStreamEventPair> pool_;
 };
 
-static thread_local CudaEventNVLinkRAII tl_nvlink_sync_event;
+static thread_local PerDeviceStreamPool tl_device_stream_pool;
+
+/// Query the CUDA device that owns the given pointer.
+/// Returns -1 if the pointer is not device memory or query fails.
+static int getDeviceForPointer(const void *ptr) {
+    cudaPointerAttributes attr;
+    cudaError_t err = cudaPointerGetAttributes(&attr, ptr);
+    if (err != cudaSuccess) {
+        cudaGetLastError();  // clear the error
+        return -1;
+    }
+    if (attr.type == cudaMemoryTypeDevice) {
+        return attr.device;
+    }
+    return -1;
+}
+
+/// Get the appropriate stream+event for a transfer request.
+/// Determines the source buffer's device and returns the stream for that GPU.
+/// Falls back to the current device if the pointer query fails.
+static CudaStreamEventPair getStreamForRequest(const void *source) {
+    int device_id = getDeviceForPointer(source);
+    if (device_id < 0) {
+        // Not device memory (e.g., pinned host memory); use current device.
+        cudaGetDevice(&device_id);
+        if (device_id < 0) device_id = 0;
+    }
+    return tl_device_stream_pool.getOrCreate(device_id);
+}
+
 }  // anonymous namespace
 
 using Slice = Transport::Slice;
@@ -366,34 +447,48 @@ Status NvlinkTransport::submitTransfer(
     size_t task_id = batch_desc.task_list.size();
     batch_desc.task_list.resize(task_id + entries.size());
 
-    // Synchronize with the caller's CUDA stream before issuing any memcpy.
-    // PyTorch uses cudaStreamPerThread (per-thread default stream), NOT the
-    // legacy default stream (nullptr). Recording an event on
-    // cudaStreamPerThread and making nvlink_stream wait for it ensures that all
-    // PyTorch GPU operations on source/dest buffers complete before the NVLink
-    // memcpy starts. This GPU-level dependency is also required by
-    // cudaMemcpyBatchAsync's srcAccessOrderStream attribute, which needs
-    // the source data to be visible through the nvlink_stream's access order.
-    //
-    // Do NOT use the legacy default stream (nullptr) for cudaEventRecord,
-    // as it would trigger implicit synchronization with blocking streams and
-    // could cause deadlocks.
-    cudaStream_t stream = tl_nvlink_stream.stream_;
+    // Determine the source buffer's device and get the per-device stream.
+    // This ensures DMA copies are submitted to the correct GPU's KMD queue,
+    // not all piled up on GPU 0.
+    // Use the first entry's source to determine the device; all entries in
+    // a batch typically share the same source device.
+    CudaStreamEventPair stream_event =
+        getStreamForRequest(entries.empty() ? nullptr : entries[0].source);
+    cudaStream_t stream = stream_event.stream;
+    cudaEvent_t sync_event = stream_event.event;
+    if (!stream || !sync_event) {
+        return Status::Context("Failed to create NVLink CUDA stream/event");
+    }
+    // Switch to the stream's device before recording the event.
+    // cudaStreamPerThread is per-device: recording on device 0's stream
+    // with a device N event may fail on non-NVIDIA GPUs. We must ensure
+    // the event is recorded on the SAME device's per-thread stream.
+    int saved_device = 0;
+    cudaGetDevice(&saved_device);
+    if (stream_event.device_id != saved_device) {
+        cudaSetDevice(stream_event.device_id);
+    }
     cudaError_t sync_err =
-        cudaEventRecord(tl_nvlink_sync_event.event_, cudaStreamPerThread);
+        cudaEventRecord(sync_event, cudaStreamPerThread);
     if (sync_err != cudaSuccess) {
         LOG(ERROR) << "NvlinkTransport: cudaEventRecord on "
                       "cudaStreamPerThread failed: "
                    << cudaGetErrorString(sync_err);
+        cudaSetDevice(saved_device);
         return Status::Context("cudaEventRecord failed: " +
                                std::string(cudaGetErrorString(sync_err)));
     }
-    sync_err = cudaStreamWaitEvent(stream, tl_nvlink_sync_event.event_, 0);
+    sync_err = cudaStreamWaitEvent(stream, sync_event, 0);
     if (sync_err != cudaSuccess) {
         LOG(ERROR) << "NvlinkTransport: cudaStreamWaitEvent failed: "
                    << cudaGetErrorString(sync_err);
+        cudaSetDevice(saved_device);
         return Status::Context("cudaStreamWaitEvent failed: " +
                                std::string(cudaGetErrorString(sync_err)));
+    }
+    // Restore the caller's device after event sync is established.
+    if (stream_event.device_id != saved_device) {
+        cudaSetDevice(saved_device);
     }
 
     // Phase 1: Prepare slices and collect memcpy parameters
@@ -454,17 +549,41 @@ Status NvlinkTransport::getTransferStatus(BatchID batch_id, size_t task_id,
     // Poll POSTED slices for async completion via cudaStreamQuery.
     // Cache the query result per stream to avoid redundant driver calls,
     // since multiple slices typically share the same CUDA stream.
-    std::unordered_map<cudaStream_t, cudaError_t> stream_status_cache;
+    //
+    // IMPORTANT: cudaStreamQuery must be called from the correct device
+    // context. On non-NVIDIA GPUs (e.g. ZW-M890P), querying a stream
+    // created on device N while the active device is 0 may return an
+    // error instead of cudaErrorNotReady, causing false failures.
+    // We track the device_id alongside the stream in the cache.
+    struct StreamQueryResult {
+        cudaError_t err;
+        int device_id;
+    };
+    std::unordered_map<cudaStream_t, StreamQueryResult> stream_status_cache;
+    int saved_device = 0;
+    cudaGetDevice(&saved_device);
     for (auto *slice : task.slice_list) {
         if (slice && slice->status == Slice::POSTED) {
             cudaStream_t stream = (cudaStream_t)slice->local.cuda_stream;
             auto it = stream_status_cache.find(stream);
             cudaError_t cuda_err;
+            int stream_device = -1;
             if (it == stream_status_cache.end()) {
+                // Query which device this stream belongs to, switch to it,
+                // then query. cudaStreamGetDevice is available in CUDA 12.0+.
+#if CUDART_VERSION >= 12000
+                cudaStreamGetDevice(stream, &stream_device);
+#else
+                cudaGetDevice(&stream_device);
+#endif
+                if (stream_device >= 0 && stream_device != saved_device) {
+                    cudaSetDevice(stream_device);
+                }
                 cuda_err = cudaStreamQuery(stream);
-                stream_status_cache[stream] = cuda_err;
+                stream_status_cache[stream] = {cuda_err, stream_device};
             } else {
-                cuda_err = it->second;
+                cuda_err = it->second.err;
+                stream_device = it->second.device_id;
             }
             if (cuda_err == cudaSuccess) {
                 slice->markSuccess();
@@ -474,6 +593,8 @@ Status NvlinkTransport::getTransferStatus(BatchID batch_id, size_t task_id,
             // cudaErrorNotReady means still in progress, keep POSTED
         }
     }
+    // Restore the caller's device.
+    cudaSetDevice(saved_device);
     status.transferred_bytes = task.transferred_bytes;
     uint64_t success_slice_count = task.success_slice_count;
     uint64_t failed_slice_count = task.failed_slice_count;
@@ -492,24 +613,41 @@ Status NvlinkTransport::getTransferStatus(BatchID batch_id, size_t task_id,
 
 Status NvlinkTransport::submitTransferTask(
     const std::vector<TransferTask *> &task_list) {
-    // Synchronize with the caller's CUDA stream before issuing any memcpy.
+    // Determine the source buffer's device and get the per-device stream.
     // See submitTransfer() for detailed rationale.
-    cudaStream_t stream = tl_nvlink_stream.stream_;
+    CudaStreamEventPair stream_event = getStreamForRequest(
+        task_list.empty() ? nullptr : task_list[0]->request->source);
+    cudaStream_t stream = stream_event.stream;
+    cudaEvent_t sync_event = stream_event.event;
+    if (!stream || !sync_event) {
+        return Status::Context("Failed to create NVLink CUDA stream/event");
+    }
+    // Switch to the stream's device before recording the event.
+    int saved_device = 0;
+    cudaGetDevice(&saved_device);
+    if (stream_event.device_id != saved_device) {
+        cudaSetDevice(stream_event.device_id);
+    }
     cudaError_t sync_err =
-        cudaEventRecord(tl_nvlink_sync_event.event_, cudaStreamPerThread);
+        cudaEventRecord(sync_event, cudaStreamPerThread);
     if (sync_err != cudaSuccess) {
         LOG(ERROR) << "NvlinkTransport: cudaEventRecord on "
                       "cudaStreamPerThread failed: "
                    << cudaGetErrorString(sync_err);
+        cudaSetDevice(saved_device);
         return Status::Context("cudaEventRecord failed: " +
                                std::string(cudaGetErrorString(sync_err)));
     }
-    sync_err = cudaStreamWaitEvent(stream, tl_nvlink_sync_event.event_, 0);
+    sync_err = cudaStreamWaitEvent(stream, sync_event, 0);
     if (sync_err != cudaSuccess) {
         LOG(ERROR) << "NvlinkTransport: cudaStreamWaitEvent failed: "
                    << cudaGetErrorString(sync_err);
+        cudaSetDevice(saved_device);
         return Status::Context("cudaStreamWaitEvent failed: " +
                                std::string(cudaGetErrorString(sync_err)));
+    }
+    if (stream_event.device_id != saved_device) {
+        cudaSetDevice(saved_device);
     }
 
     // Phase 1: Prepare slices and collect memcpy parameters

--- a/mooncake-transfer-engine/src/transport/nvlink_transport/nvlink_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/nvlink_transport/nvlink_transport.cpp
@@ -70,8 +70,8 @@ class PerDeviceStreamPool {
         }
         CudaStreamEntry entry;
         entry.device_id = device_id;
-        cudaError_t err = cudaStreamCreateWithFlags(&entry.stream,
-                                                    cudaStreamNonBlocking);
+        cudaError_t err =
+            cudaStreamCreateWithFlags(&entry.stream, cudaStreamNonBlocking);
         if (err != cudaSuccess)
             LOG(FATAL) << "Failed to create NVLink CUDA stream on device "
                        << device_id << ": " << cudaGetErrorString(err);
@@ -84,12 +84,11 @@ class PerDeviceStreamPool {
                   std::to_string(prop.pciBusID) + ":" +
                   std::to_string(prop.pciDeviceID);
         }
-        const char* visible = getenv("CUDA_VISIBLE_DEVICES");
+        const char *visible = getenv("CUDA_VISIBLE_DEVICES");
         LOG(INFO) << "NvlinkTransport: NVLink CUDA stream created on device "
                   << device_id << " [physical: " << pci
                   << "] CUDA_VISIBLE_DEVICES="
-                  << (visible ? visible : "(not set)")
-                  << " pid=" << getpid();
+                  << (visible ? visible : "(not set)") << " pid=" << getpid();
         pool_[device_id] = entry;
         return entry;
     }
@@ -102,6 +101,7 @@ class PerDeviceStreamPool {
         }
         cudaSetDevice(saved_device);
     }
+
    private:
     std::unordered_map<int, CudaStreamEntry> pool_;
 };
@@ -121,7 +121,7 @@ static cudaEvent_t getCallerSyncEvent() {
     if (tl_caller_sync_event_device != current_device) {
         if (tl_caller_sync_event) cudaEventDestroy(tl_caller_sync_event);
         cudaError_t err = cudaEventCreateWithFlags(&tl_caller_sync_event,
-                                                    cudaEventDisableTiming);
+                                                   cudaEventDisableTiming);
         if (err != cudaSuccess)
             LOG(FATAL) << "Failed to create NVLink sync event on device "
                        << current_device << ": " << cudaGetErrorString(err);
@@ -442,8 +442,7 @@ Status NvlinkTransport::submitTransfer(
     CudaStreamEntry stream_entry =
         getStreamForRequest(entries.empty() ? nullptr : entries[0].source);
     cudaStream_t stream = stream_entry.stream;
-    if (!stream)
-        return Status::Context("Failed to create NVLink CUDA stream");
+    if (!stream) return Status::Context("Failed to create NVLink CUDA stream");
 
     // Synchronize with the caller's GPU work (e.g., PyTorch gather operations)
     // that produced the source data. We use cudaEventSynchronize (CPU-blocking)
@@ -451,8 +450,7 @@ Status NvlinkTransport::submitTransfer(
     // operations on non-NVIDIA GPUs. The CPU blocking is acceptable because
     // the transfer depends on the caller's work anyway — they cannot overlap.
     cudaEvent_t sync_event = getCallerSyncEvent();
-    cudaError_t sync_err =
-        cudaEventRecord(sync_event, cudaStreamPerThread);
+    cudaError_t sync_err = cudaEventRecord(sync_event, cudaStreamPerThread);
     if (sync_err != cudaSuccess) {
         LOG(ERROR) << "NvlinkTransport: cudaEventRecord failed: "
                    << cudaGetErrorString(sync_err);
@@ -568,12 +566,10 @@ Status NvlinkTransport::submitTransferTask(
     CudaStreamEntry stream_entry = getStreamForRequest(
         task_list.empty() ? nullptr : task_list[0]->request->source);
     cudaStream_t stream = stream_entry.stream;
-    if (!stream)
-        return Status::Context("Failed to create NVLink CUDA stream");
+    if (!stream) return Status::Context("Failed to create NVLink CUDA stream");
     // Synchronize with caller's GPU work via cudaEventSynchronize.
     cudaEvent_t sync_event = getCallerSyncEvent();
-    cudaError_t sync_err =
-        cudaEventRecord(sync_event, cudaStreamPerThread);
+    cudaError_t sync_err = cudaEventRecord(sync_event, cudaStreamPerThread);
     if (sync_err != cudaSuccess) {
         LOG(ERROR) << "NvlinkTransport: cudaEventRecord failed: "
                    << cudaGetErrorString(sync_err);

--- a/mooncake-transfer-engine/src/transport/nvlink_transport/nvlink_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/nvlink_transport/nvlink_transport.cpp
@@ -108,26 +108,51 @@ class PerDeviceStreamPool {
 
 static thread_local PerDeviceStreamPool tl_device_stream_pool;
 
-/// Thread-local sync event, created on the caller's active device.
-/// Used to capture the caller's GPU work completion via cudaEventSynchronize
-/// (CPU-blocking), avoiding expensive cross-device cudaStreamWaitEvent on
-/// non-NVIDIA GPUs.
-static thread_local cudaEvent_t tl_caller_sync_event = nullptr;
-static thread_local int tl_caller_sync_event_device = -1;
+/// Per-device event pool (thread-local). Caches one event per device to
+/// avoid repeated create/destroy on device switches, and ensures proper
+/// cleanup when the thread exits.
+class PerDeviceEventPool {
+   public:
+    cudaEvent_t getOrCreate(int device_id) {
+        auto it = pool_.find(device_id);
+        if (it != pool_.end()) return it->second;
+        int saved_device = 0;
+        cudaGetDevice(&saved_device);
+        if (cudaSetDevice(device_id) != cudaSuccess) {
+            LOG(ERROR) << "NvlinkTransport: cudaSetDevice(" << device_id
+                       << ") failed when creating event";
+            return nullptr;
+        }
+        cudaEvent_t event = nullptr;
+        cudaError_t err =
+            cudaEventCreateWithFlags(&event, cudaEventDisableTiming);
+        if (err != cudaSuccess)
+            LOG(FATAL) << "Failed to create NVLink sync event on device "
+                       << device_id << ": " << cudaGetErrorString(err);
+        cudaSetDevice(saved_device);
+        pool_[device_id] = event;
+        return event;
+    }
+    ~PerDeviceEventPool() {
+        int saved_device = 0;
+        cudaGetDevice(&saved_device);
+        for (auto &kv : pool_) {
+            cudaSetDevice(kv.first);
+            if (kv.second) cudaEventDestroy(kv.second);
+        }
+        cudaSetDevice(saved_device);
+    }
+
+   private:
+    std::unordered_map<int, cudaEvent_t> pool_;
+};
+
+static thread_local PerDeviceEventPool tl_device_event_pool;
 
 static cudaEvent_t getCallerSyncEvent() {
     int current_device = 0;
     cudaGetDevice(&current_device);
-    if (tl_caller_sync_event_device != current_device) {
-        if (tl_caller_sync_event) cudaEventDestroy(tl_caller_sync_event);
-        cudaError_t err = cudaEventCreateWithFlags(&tl_caller_sync_event,
-                                                   cudaEventDisableTiming);
-        if (err != cudaSuccess)
-            LOG(FATAL) << "Failed to create NVLink sync event on device "
-                       << current_device << ": " << cudaGetErrorString(err);
-        tl_caller_sync_event_device = current_device;
-    }
-    return tl_caller_sync_event;
+    return tl_device_event_pool.getOrCreate(current_device);
 }
 
 static int getDeviceForPointer(const void *ptr) {


### PR DESCRIPTION
## Description

In MMNVL & IntraNode NVLINK transport, we update Async API before introducing another problem.  In SGlang PD disaggregation scenario, worker threads never called cudaSetDevice() to set their active GPU and CUDA_VISIBLE_DEVICES was not set per process. As a result, all thread_local streams were created on the default device 0, regardless of which GPU the source data actually resided on.

This caused several severe performance issues:
1. All DMA commands queued on GPU 0's KMD (Kernel Mode Driver) queue — Transfers from all TP ranks were serialized through a single GPU's command queue, creating a bottleneck.
2. DMA degradation to kernel copy — Since the source memory addresses were not on GPU 0, the DMA copy engine could not directly access them. The copy fell back to a GPU kernel (compute-based copy), which: (a) occupied SM compute units, (b) required staging through GPU 0 as an intermediate, doubling the data movement, and (c) competed with inference workloads on GPU 0.

Solution:
Replaced the single thread_local stream with a PerDeviceStreamPool — a thread_local map of device_id → (stream, event). Before each submitTransfer, the source buffer's device is queried via cudaPointerGetAttributes, and the stream for that specific device is used.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

This update has been tested via SGlang 1P1D disaggregation, using 8192 as input and 1024 as output with 64 max concurrency 
<img width="746" height="1084" alt="image" src="https://github.com/user-attachments/assets/535303e5-e854-4d08-853a-75aeafc1f7b6" />


**Test commands:**
```bash
# Example: bash scripts/run_ci_test.sh
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [ ] AI tools were used (specify below)