### PR TITLE
[Bug fix][Build] Statically link C++ runtime into binaries and extensions

### DIFF
--- a/mooncake-common/common.cmake
+++ b/mooncake-common/common.cmake
@@ -27,6 +27,19 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=thread-safety")
 endif()
 
+# Link the C++ runtime statically so artifacts depend only on the host glibc,
+# not its libstdc++ version. auditwheel does not vendor libstdc++, so otherwise
+# the build toolchain's GLIBCXX requirement leaks into the wheel and fails to
+# load on hosts with an older libstdc++.
+option(STATIC_CXX_RUNTIME "Statically link libstdc++/libgcc into binaries and extensions" ON)
+if(STATIC_CXX_RUNTIME AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libstdc++ -static-libgcc")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -static-libstdc++ -static-libgcc")
+  # pybind11_add_module builds MODULE libraries (engine.so, store.so), which
+  # take CMAKE_MODULE_LINKER_FLAGS rather than the SHARED ones.
+  set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -static-libstdc++ -static-libgcc")
+endif()
+
 option(ENABLE_ASAN "enable address sanitizer" OFF)
 
 if (ENABLE_ASAN)

--- a/mooncake-common/common.cmake
+++ b/mooncake-common/common.cmake
@@ -28,15 +28,11 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 endif()
 
 # Link the C++ runtime statically so artifacts depend only on the host glibc,
-# not its libstdc++ version. auditwheel does not vendor libstdc++, so otherwise
-# the build toolchain's GLIBCXX requirement leaks into the wheel and fails to
-# load on hosts with an older libstdc++.
+# not its libstdc++ version.
 option(STATIC_CXX_RUNTIME "Statically link libstdc++/libgcc into binaries and extensions" ON)
 if(STATIC_CXX_RUNTIME AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libstdc++ -static-libgcc")
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -static-libstdc++ -static-libgcc")
-  # pybind11_add_module builds MODULE libraries (engine.so, store.so), which
-  # take CMAKE_MODULE_LINKER_FLAGS rather than the SHARED ones.
   set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -static-libstdc++ -static-libgcc")
 endif()
 


### PR DESCRIPTION
## Description

The release wheels are built on an ubuntu-22.04 runner whose libstdc++ (GCC 12) requires GLIBCXX_3.4.30. Because that requirement is dynamic and auditwheel does not graft libstdc++ (it is policy-whitelisted), it leaks into mooncake_master, store.so, engine.so, etc. as a hard dependency on the *host's* libstdc++. Hosts with an older libstdc++ then fail at load:

```
  mooncake_master: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.30' not found
```

This happens even when the wheel's manylinux glibc floor is satisfied, because glibc and libstdc++ are versioned independently.

Link the C++ runtime statically (`-static-libstdc++ -static-libgcc`) so the produced binaries and python extensions depend only on glibc, matching the manylinux contract. Gated behind STATIC_CXX_RUNTIME (default ON) for GNU if you want to disable.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [x] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



**Test commands:**
```bash
# Example: bash scripts/run_ci_test.sh
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [ ] AI tools were used (specify below)