### PR TITLE
[Bugfix] Preserve empty values in Mooncake Store REST GET

### DIFF
--- a/mooncake-wheel/mooncake/mooncake_store_service.py
+++ b/mooncake-wheel/mooncake/mooncake_store_service.py
@@ -497,7 +497,7 @@ class MooncakeStoreService:
             key = request.match_info['key']
             value = self.store.get(key)
 
-            if not value:
+            if value is None:
                 return web.Response(
                     status=404,
                     text=json.dumps({'error': 'Key not found'}),

--- a/mooncake-wheel/mooncake/mooncake_store_service.py
+++ b/mooncake-wheel/mooncake/mooncake_store_service.py
@@ -495,14 +495,42 @@ class MooncakeStoreService:
     async def handle_get(self, request):
         try:
             key = request.match_info['key']
-            value = self.store.get(key)
+            exists = self.store.is_exist(key)
 
-            if value is None:
+            if exists == 0:
                 return web.Response(
                     status=404,
                     text=json.dumps({'error': 'Key not found'}),
                     content_type='application/json'
                 )
+            if exists < 0:
+                return web.Response(
+                    status=500,
+                    text=json.dumps({'error': 'Exist check failed'}),
+                    content_type='application/json'
+                )
+
+            value = self.store.get(key)
+            if value is None:
+                return web.Response(
+                    status=500,
+                    text=json.dumps({'error': 'GET operation failed'}),
+                    content_type='application/json'
+                )
+            if value == b"":
+                exists = self.store.is_exist(key)
+                if exists == 0:
+                    return web.Response(
+                        status=404,
+                        text=json.dumps({'error': 'Key not found'}),
+                        content_type='application/json'
+                    )
+                if exists < 0:
+                    return web.Response(
+                        status=500,
+                        text=json.dumps({'error': 'Exist check failed'}),
+                        content_type='application/json'
+                    )
 
             return web.Response(
                 status=200,

--- a/mooncake-wheel/tests/test_mooncake_store_service_api.py
+++ b/mooncake-wheel/tests/test_mooncake_store_service_api.py
@@ -16,9 +16,10 @@ except ModuleNotFoundError:
     web_module = types.ModuleType("aiohttp.web")
 
     class Response:
-        def __init__(self, status=200, text="", content_type=None):
+        def __init__(self, status=200, text="", body=None, content_type=None):
             self.status = status
             self.text = text
+            self.body = body
             self.content_type = content_type
 
     web_module.Response = Response
@@ -327,9 +328,8 @@ class StoreServiceApiTest(unittest.IsolatedAsyncioTestCase):
         request = FakeRequest({})
         request.match_info = {"key": "empty_value_key"}
         resp = await self.service.handle_get(request)
-        self.assertEqual(resp.status, 404)
-        body = json.loads(resp.text)
-        self.assertIn("Key not found", body["error"])
+        self.assertEqual(resp.status, 200)
+        self.assertEqual(resp.body, b"")
 
     async def test_handle_get_store_exception(self):
         def raise_error(key):

--- a/mooncake-wheel/tests/test_mooncake_store_service_api.py
+++ b/mooncake-wheel/tests/test_mooncake_store_service_api.py
@@ -307,6 +307,7 @@ class StoreServiceApiTest(unittest.IsolatedAsyncioTestCase):
     # ==================== /api/get/{key} tests ====================
 
     async def test_handle_get_success(self):
+        self.fake_store.is_exist = lambda key: True
         self.fake_store.get = lambda key: b"payload_bytes"
         request = FakeRequest({})
         request.match_info = {"key": "my_key"}
@@ -315,7 +316,8 @@ class StoreServiceApiTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(resp.body, b"payload_bytes")
 
     async def test_handle_get_not_found(self):
-        self.fake_store.get = lambda key: None
+        self.fake_store.is_exist = lambda key: 0
+        self.fake_store.get = lambda key: b""
         request = FakeRequest({})
         request.match_info = {"key": "missing_key"}
         resp = await self.service.handle_get(request)
@@ -323,7 +325,18 @@ class StoreServiceApiTest(unittest.IsolatedAsyncioTestCase):
         body = json.loads(resp.text)
         self.assertIn("Key not found", body["error"])
 
+    async def test_handle_get_exist_check_failure(self):
+        self.fake_store.is_exist = lambda key: -1
+        self.fake_store.get = lambda key: b""
+        request = FakeRequest({})
+        request.match_info = {"key": "error_key"}
+        resp = await self.service.handle_get(request)
+        self.assertEqual(resp.status, 500)
+        body = json.loads(resp.text)
+        self.assertIn("Exist check failed", body["error"])
+
     async def test_handle_get_empty_bytes(self):
+        self.fake_store.is_exist = lambda key: True
         self.fake_store.get = lambda key: b""
         request = FakeRequest({})
         request.match_info = {"key": "empty_value_key"}
@@ -331,10 +344,32 @@ class StoreServiceApiTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(resp.status, 200)
         self.assertEqual(resp.body, b"")
 
+    async def test_handle_get_empty_bytes_rechecks_existence(self):
+        existence_results = iter([1, 0])
+        self.fake_store.is_exist = lambda key: next(existence_results)
+        self.fake_store.get = lambda key: b""
+        request = FakeRequest({})
+        request.match_info = {"key": "empty_value_key"}
+        resp = await self.service.handle_get(request)
+        self.assertEqual(resp.status, 404)
+        body = json.loads(resp.text)
+        self.assertIn("Key not found", body["error"])
+
+    async def test_handle_get_none_value_is_store_failure(self):
+        self.fake_store.is_exist = lambda key: True
+        self.fake_store.get = lambda key: None
+        request = FakeRequest({})
+        request.match_info = {"key": "empty_value_key"}
+        resp = await self.service.handle_get(request)
+        self.assertEqual(resp.status, 500)
+        body = json.loads(resp.text)
+        self.assertIn("GET operation failed", body["error"])
+
     async def test_handle_get_store_exception(self):
         def raise_error(key):
             raise RuntimeError("store crashed")
 
+        self.fake_store.is_exist = lambda key: True
         self.fake_store.get = raise_error
         request = FakeRequest({})
         request.match_info = {"key": "crash_key"}


### PR DESCRIPTION
## Description

This PR fixes a value-preservation bug in the Mooncake Store REST API `GET /api/get/{key}` path. The handler previously treated an empty byte payload as a missing key, so a value that could be stored through the REST API could not be read back reliably.

The original REST read path used the value returned by `self.store.get(key)` to decide whether the key existed:

```python
value = self.store.get(key)
if not value:
    return 404
```

That check conflates two different states: an existing empty byte payload (`b""`) and an absent object. Reviewer feedback also pointed out that the real `MooncakeDistributedStore.get()` binding may return zero-length bytes when the underlying `get_buffer(key)` result is null, so `get()` alone is not a reliable existence signal.

The updated handler now uses the store's explicit existence API before reading the value:

```python
exists = self.store.is_exist(key)
if exists == 0:
    return 404
if exists < 0:
    return 500
value = self.store.get(key)
```

For empty byte values, the handler re-checks existence after `get()` returns `b""`. This keeps valid stored empty payloads readable while avoiding a false `200` response when the binding surfaces a missing/null buffer as zero-length bytes.

### Changes Made

- Switched REST GET missing-key detection from value truthiness/`None` checks to `self.store.is_exist(key)`.
- Preserved `b""` as a valid `200` response body for existing keys.
- Returned `500` when `is_exist()` reports a negative error or when `get()` unexpectedly returns `None` after a successful existence check.
- Updated tests so missing keys match the real binding behavior: `is_exist(key) == 0` while `get(key)` may still be `b""`.
- Added coverage for empty byte payloads, existence-check failure, unexpected `None` from `get()`, and the empty-byte ambiguity after `get()`.

### Evidence

The original bug can be reproduced with an isolated handler-style case where the store returns an existing empty byte payload:

```python
self.fake_store.is_exist = lambda key: True
self.fake_store.get = lambda key: b""
request.match_info = {"key": "empty_value_key"}
resp = await self.service.handle_get(request)
```

Before this fix, the handler evaluated `b""` as false and returned the missing-key branch:

```text
status: 404
body: {"error": "Key not found"}
```

After this fix, the key existence check distinguishes an existing empty payload from a missing key:

```text
status: 200
body: b""
```

A real missing key is represented by `is_exist(key) == 0` and still returns `404 Key not found` even if `get(key)` would produce `b""`.

![REST GET empty byte value reproduction](https://img.vectorpeak.cn/obsidian/2026/05-06/20260624112709944.png?imageSlim)

### Possible Call Chain / Impact

The affected path is the Mooncake Store REST API read flow:

```text
mooncake-wheel/mooncake/mooncake_store_service.py
  -> MooncakeStoreService.start_http_service(...)
  -> web.get('/api/get/{key}', self.handle_get)
  -> MooncakeStoreService.handle_get(...)
  -> self.store.is_exist(key)
  -> self.store.get(key)
  -> web.Response(body=value, content_type='application/octet-stream')
```

This PR only changes the REST GET response decision for values returned through the REST shim. It does not change writes, deletion, mounting, store setup, or the underlying Mooncake distributed store APIs.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
python -m unittest mooncake-wheel.tests.test_mooncake_store_service_api.StoreServiceApiTest.test_handle_get_success mooncake-wheel.tests.test_mooncake_store_service_api.StoreServiceApiTest.test_handle_get_empty_bytes mooncake-wheel.tests.test_mooncake_store_service_api.StoreServiceApiTest.test_handle_get_empty_bytes_rechecks_existence mooncake-wheel.tests.test_mooncake_store_service_api.StoreServiceApiTest.test_handle_get_not_found mooncake-wheel.tests.test_mooncake_store_service_api.StoreServiceApiTest.test_handle_get_none_value_is_store_failure mooncake-wheel.tests.test_mooncake_store_service_api.StoreServiceApiTest.test_handle_get_exist_check_failure mooncake-wheel.tests.test_mooncake_store_service_api.StoreServiceApiTest.test_handle_get_store_exception
git diff --check
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

Targeted GET handler tests passed:

```text
Ran 7 tests in 0.017s

OK
```

`git diff --check` passed with no patch errors. It emitted Windows line-ending warnings only.

I also ran the full `mooncake-wheel.tests.test_mooncake_store_service_api` file locally before this update. It had unrelated existing failures around `handle_put_missing_value` and unmount call expectations, so I did not include that as a passing validation claim.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue (not applicable; this PR changes fewer than 100 lines)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

AI assistance was used to identify the edge case, make the handler/test updates, respond to review feedback, and draft this PR description. The submitter is responsible for reviewing and validating the final changes.