### PR TITLE
[TE] Enforce one-shot lifecycle for connected RDMA endpoints

### DIFF
--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_endpoint.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_endpoint.h
@@ -59,6 +59,7 @@ class RdmaEndPoint {
     int reconstruct();
     int deconstruct();
     int deconstructLocked();
+    void beginDestroyLocked();
 
    public:
     void setPeerNicPath(const std::string &peer_nic_path);
@@ -113,25 +114,8 @@ class RdmaEndPoint {
    private:
     int disconnectUnlocked();
 
-    // Resets the connection.
-    //
-    // The main difference between this function and `disconnectUnlocked`
-    // is that it will reconstruct QPs when `CONFIG_ERDMA` is defined.
-    // Without `CONFIG_ERDMA`, it is essentially the same as
-    // `disconnectUnlocked` but with additional logging.
-    //
-    // This serves as a workaround for Aliyun eRDMA devices (i.e., once a QP is
-    // transitioned to the RTS state, it cannot be reset to RTS again directly).
-    // For more details:
-    // https://github.com/kvcache-ai/Mooncake/pull/1733#discussion_r2992088663
-    //
-    // In practice:
-    // - Call `resetConnection` if the QPs' state may have transitioned to RTS.
-    // - Call `disconnectUnlocked` otherwise.
-    //
-    // This is mainly used in `setupConnectionsByActive` or
-    // `setupConnectionsByPassive`. It is NOT invoked in the normal execution
-    // flow, so a `reason` argument is passed for internal logging purposes.
+    // Resets only pre-connected handshake attempts. Once an endpoint has ever
+    // reached CONNECTED, it is retired instead of being reused.
     int resetConnection(const std::string &reason);
 
    public:
@@ -199,6 +183,7 @@ class RdmaEndPoint {
 
     std::string peer_nic_path_;
     std::vector<uint32_t> peer_qp_num_list_;
+    bool has_connected_;
 
     volatile int *wr_depth_list_;
     int max_wr_depth_;

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_endpoint.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_endpoint.h
@@ -93,6 +93,11 @@ class RdmaEndPoint {
         return status_.load(std::memory_order_relaxed) == CONNECTED;
     }
 
+    bool retired() const {
+        auto status = status_.load(std::memory_order_relaxed);
+        return status == DESTROYING || status == DESTROYED;
+    }
+
     // Interrupts the connection, which can be triggered by user or by internal
     // error. Use setupConnectionsByActive or setupConnectionsByPassive to
     // reconnect

--- a/mooncake-transfer-engine/include/transport/rdma_transport/worker_pool.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/worker_pool.h
@@ -40,6 +40,8 @@ class WorkerPool {
 
     void transferWorker(int thread_id);
 
+    bool hasOutstandingCq();
+
     void monitorWorker();
 
     int doProcessContextEvents();
@@ -86,7 +88,6 @@ class WorkerPool {
 
     std::vector<std::thread> worker_thread_;
     std::atomic<bool> workers_running_;
-    std::atomic<int> suspended_flag_;
 
     std::atomic<int> redispatch_counter_;
 

--- a/mooncake-transfer-engine/include/transport/rdma_transport/worker_pool.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/worker_pool.h
@@ -89,6 +89,7 @@ class WorkerPool {
     std::vector<std::thread> worker_thread_;
     std::atomic<bool> workers_running_;
 
+    std::atomic<int> parked_worker_count_;
     std::atomic<int> redispatch_counter_;
 
     std::mutex cond_mutex_;

--- a/mooncake-transfer-engine/include/transport/rdma_transport/worker_pool.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/worker_pool.h
@@ -40,7 +40,7 @@ class WorkerPool {
 
     void transferWorker(int thread_id);
 
-    bool hasOutstandingCq();
+    bool hasOutstandingCq(int thread_id);
 
     void monitorWorker();
 

--- a/mooncake-transfer-engine/src/transport/rdma_transport/endpoint_store.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/endpoint_store.cpp
@@ -149,9 +149,15 @@ int FIFOEndpointStore::destroyQPs() {
 }
 
 int FIFOEndpointStore::disconnectQPs() {
+    RWSpinlock::WriteGuard guard(endpoint_map_lock_);
     for (auto &kv : endpoint_map_) {
-        kv.second->disconnect();
+        kv.second->beginDestroy();
+        waiting_list_.insert(kv.second);
     }
+    waiting_list_len_ += endpoint_map_.size();
+    endpoint_map_.clear();
+    fifo_list_.clear();
+    fifo_map_.clear();
     return 0;
 }
 
@@ -318,8 +324,16 @@ int SIEVEEndpointStore::destroyQPs() {
 }
 
 int SIEVEEndpointStore::disconnectQPs() {
-    for (auto &endpoint : waiting_list_) endpoint->disconnect();
-    for (auto &kv : endpoint_map_) kv.second.first->disconnect();
+    RWSpinlock::WriteGuard guard(endpoint_map_lock_);
+    for (auto &kv : endpoint_map_) {
+        kv.second.first->beginDestroy();
+        waiting_list_.insert(kv.second.first);
+    }
+    waiting_list_len_ += endpoint_map_.size();
+    endpoint_map_.clear();
+    fifo_list_.clear();
+    fifo_map_.clear();
+    hand_ = std::nullopt;
     return 0;
 }
 

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -67,6 +67,7 @@ static void rememberAutoGidSelection(
 RdmaEndPoint::RdmaEndPoint(RdmaContext &context)
     : context_(context),
       status_(INITIALIZING),
+      has_connected_(false),
       wr_depth_list_(nullptr),
       active_(true),
       cq_outstanding_(nullptr) {}
@@ -202,6 +203,10 @@ int RdmaEndPoint::destroyQP() { return deconstruct(); }
 
 void RdmaEndPoint::beginDestroy() {
     RWSpinlock::WriteGuard guard(lock_);
+    beginDestroyLocked();
+}
+
+void RdmaEndPoint::beginDestroyLocked() {
     auto current_status = status_.load(std::memory_order_relaxed);
     if (current_status == DESTROYING || current_status == DESTROYED) return;
 
@@ -285,9 +290,12 @@ bool RdmaEndPoint::finishDestroy() {
 
 void RdmaEndPoint::setPeerNicPath(const std::string &peer_nic_path) {
     RWSpinlock::WriteGuard guard(lock_);
-    if (connected()) {
-        LOG(WARNING) << "Previous connection will be discarded";
-        disconnectUnlocked();
+    auto curr_status = status_.load(std::memory_order_relaxed);
+    if (curr_status != INITIALIZING && curr_status != UNCONNECTED) {
+        LOG(ERROR) << "Cannot change peer NIC path after endpoint lifecycle "
+                      "has started: "
+                   << toString();
+        return;
     }
     peer_nic_path_ = peer_nic_path;
 }
@@ -655,51 +663,56 @@ int RdmaEndPoint::disconnectUnlocked() {
     auto curr_status = status_.load(std::memory_order_acquire);
     if (curr_status != CONNECTED && curr_status != CONNECTING) return 0;
 
-    ibv_qp_attr attr;
-    memset(&attr, 0, sizeof(attr));
-    attr.qp_state = IBV_QPS_RESET;
-    int ret = 0;
-    for (size_t i = 0; i < qp_list_.size(); ++i) {
-        int curr_ret = ibv_modify_qp(qp_list_[i], &attr, IBV_QP_STATE);
-        if (curr_ret) {
-            PLOG(ERROR) << "Failed to modify QP to RESET";
-            ret = ERR_ENDPOINT;
-        }
-        // After resetting QP, the wr_depth_list_ won't change
-        bool displayed = false;
-        if (wr_depth_list_[i] != 0) {
-            if (!displayed) {
-                LOG(WARNING) << "Outstanding work requests found, CQ will not "
-                                "be generated";
-                displayed = true;
+    if (!has_connected_) {
+        // Pre-connected handshake retries are allowed to reuse this endpoint:
+        // no user WR has been posted yet. eRDMA still needs fresh QPs because
+        // a QP that reached RTS cannot be reliably reset back to RTS.
+#ifdef CONFIG_ERDMA
+        return reconstruct();
+#else
+        ibv_qp_attr attr;
+        memset(&attr, 0, sizeof(attr));
+        attr.qp_state = IBV_QPS_RESET;
+        int ret = 0;
+        for (size_t i = 0; i < qp_list_.size(); ++i) {
+            int curr_ret = ibv_modify_qp(qp_list_[i], &attr, IBV_QP_STATE);
+            if (curr_ret) {
+                PLOG(ERROR) << "Failed to modify pre-connected QP to RESET";
+                ret = ERR_ENDPOINT;
             }
-            __sync_fetch_and_sub(cq_outstanding_, wr_depth_list_[i]);
-            wr_depth_list_[i] = 0;
+            CHECK_EQ(wr_depth_list_[i], 0)
+                << "Pre-connected endpoint must not have outstanding WRs";
         }
+        peer_qp_num_list_.clear();
+        status_.store(UNCONNECTED, std::memory_order_release);
+        return ret;
+#endif
     }
-    peer_qp_num_list_.clear();
-    status_.store(UNCONNECTED, std::memory_order_release);
-    return ret;
+
+    beginDestroyLocked();
+    return 0;
 }
 
 int RdmaEndPoint::resetConnection(const std::string &reason) {
     auto curr_status = status_.load(std::memory_order_acquire);
     if (curr_status != CONNECTING && curr_status != CONNECTED) return 0;
 
-#ifdef CONFIG_ERDMA
-    int ret = reconstruct();
-#else
-    int ret = disconnectUnlocked();
-#endif
-
-    if (ret) {
-        LOG(ERROR) << "Failed to reset the endpoint (triggered by: " << reason
-                   << "): error=" << ret;
-    } else {
-        LOG(INFO) << "Successfully reset the endpoint (triggered by: " << reason
-                  << ").";
+    if (!has_connected_) {
+        int ret = disconnectUnlocked();
+        if (ret) {
+            LOG(ERROR) << "Failed to reset pre-connected endpoint "
+                       << "(triggered by: " << reason << "): error=" << ret;
+        } else {
+            LOG(INFO) << "Successfully reset pre-connected endpoint "
+                      << "(triggered by: " << reason << ").";
+        }
+        return ret;
     }
-    return ret;
+
+    LOG(WARNING) << "Retiring endpoint instead of resetting it (triggered by: "
+                 << reason << "): " << toString();
+    beginDestroyLocked();
+    return ERR_ENDPOINT;
 }
 
 const std::string RdmaEndPoint::toString() const {
@@ -896,6 +909,7 @@ int RdmaEndPoint::doSetupConnection(const std::string &peer_gid,
     }
 
     peer_qp_num_list_ = std::move(peer_qp_num_list);
+    has_connected_ = true;
     status_.store(CONNECTED, std::memory_order_relaxed);
     return 0;
 }

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -668,6 +668,10 @@ int RdmaEndPoint::disconnectUnlocked() {
         // no user WR has been posted yet. eRDMA still needs fresh QPs because
         // a QP that reached RTS cannot be reliably reset back to RTS.
 #ifdef CONFIG_ERDMA
+        for (size_t i = 0; i < qp_list_.size(); ++i) {
+            CHECK_EQ(wr_depth_list_[i], 0)
+                << "Pre-connected endpoint must not have outstanding WRs";
+        }
         return reconstruct();
 #else
         ibv_qp_attr attr;

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
@@ -702,7 +702,9 @@ int RdmaTransport::onSetupRdmaConnections(const HandShakeDesc &peer_desc,
     // Use existing endpoint or create new one.
     auto endpoint = context->endpoint(peer_desc.local_nic_path);
     if (!endpoint) return ERR_ENDPOINT;
-    return endpoint->setupConnectionsByPassive(peer_desc, local_desc);
+    int ret = endpoint->setupConnectionsByPassive(peer_desc, local_desc);
+    if (ret == ERR_ENDPOINT) context->deleteEndpointByPtr(endpoint.get());
+    return ret;
 }
 
 int RdmaTransport::initializeRdmaResources() {

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
@@ -703,7 +703,7 @@ int RdmaTransport::onSetupRdmaConnections(const HandShakeDesc &peer_desc,
     auto endpoint = context->endpoint(peer_desc.local_nic_path);
     if (!endpoint) return ERR_ENDPOINT;
     int ret = endpoint->setupConnectionsByPassive(peer_desc, local_desc);
-    if (ret == ERR_ENDPOINT) context->deleteEndpointByPtr(endpoint.get());
+    if (endpoint->retired()) context->deleteEndpointByPtr(endpoint.get());
     return ret;
 }
 

--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -35,7 +35,6 @@ WorkerPool::WorkerPool(RdmaContext &context, int numa_socket_id)
     : context_(context),
       numa_socket_id_(numa_socket_id),
       workers_running_(true),
-      suspended_flag_(0),
       redispatch_counter_(0),
       submitted_slice_count_(0),
       processed_slice_count_(0) {
@@ -189,7 +188,7 @@ int WorkerPool::submitPostSend(
     }
 
     submitted_slice_count_.fetch_add(submitted_slice_count);
-    if (suspended_flag_.load()) {
+    if (submitted_slice_count) {
         std::lock_guard<std::mutex> lock(cond_mutex_);
         cond_var_.notify_all();
     }
@@ -440,6 +439,13 @@ void WorkerPool::redispatch(std::vector<Transport::Slice *> &slice_list,
     }
 }
 
+bool WorkerPool::hasOutstandingCq() {
+    for (int cq_index = 0; cq_index < context_.cqCount(); ++cq_index) {
+        if (*context_.cqOutstandingCount(cq_index) > 0) return true;
+    }
+    return false;
+}
+
 void WorkerPool::transferWorker(int thread_id) {
     bindToSocket(numa_socket_id_);
     const static uint64_t kWaitPeriodInNano = 100000000;  // 100ms
@@ -449,18 +455,18 @@ void WorkerPool::transferWorker(int thread_id) {
             processed_slice_count_.load(std::memory_order_relaxed);
         auto submitted_slice_count =
             submitted_slice_count_.load(std::memory_order_relaxed);
-        if (processed_slice_count == submitted_slice_count) {
+        if (processed_slice_count == submitted_slice_count &&
+            !hasOutstandingCq()) {
             uint64_t curr_wait_ts = getCurrentTimeInNano();
             if (curr_wait_ts - last_wait_ts > kWaitPeriodInNano) {
                 std::unique_lock<std::mutex> lock(cond_mutex_);
-                suspended_flag_.fetch_add(1);
                 // Double-check condition after acquiring lock to avoid lost
                 // wakeup
                 if (processed_slice_count_.load(std::memory_order_relaxed) ==
-                    submitted_slice_count_.load()) {
+                        submitted_slice_count_.load() &&
+                    !hasOutstandingCq()) {
                     cond_var_.wait_for(lock, std::chrono::seconds(1));
                 }
-                suspended_flag_.fetch_sub(1);
                 last_wait_ts = curr_wait_ts;
             }
             continue;

--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -440,8 +440,9 @@ void WorkerPool::redispatch(std::vector<Transport::Slice *> &slice_list,
     }
 }
 
-bool WorkerPool::hasOutstandingCq() {
-    for (int cq_index = 0; cq_index < context_.cqCount(); ++cq_index) {
+bool WorkerPool::hasOutstandingCq(int thread_id) {
+    for (int cq_index = thread_id; cq_index < context_.cqCount();
+         cq_index += kTransferWorkerCount) {
         if (*context_.cqOutstandingCount(cq_index) > 0) return true;
     }
     return false;
@@ -457,7 +458,7 @@ void WorkerPool::transferWorker(int thread_id) {
         auto submitted_slice_count =
             submitted_slice_count_.load(std::memory_order_relaxed);
         if (processed_slice_count == submitted_slice_count &&
-            !hasOutstandingCq()) {
+            !hasOutstandingCq(thread_id)) {
             uint64_t curr_wait_ts = getCurrentTimeInNano();
             if (curr_wait_ts - last_wait_ts > kWaitPeriodInNano) {
                 std::unique_lock<std::mutex> lock(cond_mutex_);
@@ -467,7 +468,7 @@ void WorkerPool::transferWorker(int thread_id) {
                 // producers that submit after it will notify this worker.
                 if (processed_slice_count_.load(std::memory_order_relaxed) ==
                         submitted_slice_count_.load() &&
-                    !hasOutstandingCq()) {
+                    !hasOutstandingCq(thread_id)) {
                     cond_var_.wait_for(lock, std::chrono::seconds(1));
                 }
                 parked_worker_count_.fetch_sub(1, std::memory_order_acq_rel);

--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -35,6 +35,7 @@ WorkerPool::WorkerPool(RdmaContext &context, int numa_socket_id)
     : context_(context),
       numa_socket_id_(numa_socket_id),
       workers_running_(true),
+      parked_worker_count_(0),
       redispatch_counter_(0),
       submitted_slice_count_(0),
       processed_slice_count_(0) {
@@ -188,7 +189,8 @@ int WorkerPool::submitPostSend(
     }
 
     submitted_slice_count_.fetch_add(submitted_slice_count);
-    if (submitted_slice_count) {
+    if (submitted_slice_count &&
+        parked_worker_count_.load(std::memory_order_acquire) > 0) {
         std::lock_guard<std::mutex> lock(cond_mutex_);
         cond_var_.notify_all();
     }
@@ -207,7 +209,6 @@ int WorkerPool::submitPostSend(
 void WorkerPool::performPostSend(int thread_id) {
     // Fast-fail if context is unhealthy due to catastrophic hardware failure
     if (!contextHealthy()) {
-        auto &local_slice_queue = collective_slice_queue_[thread_id];
         for (int shard_id = thread_id; shard_id < kShardCount;
              shard_id += kTransferWorkerCount) {
             if (slice_queue_count_[shard_id].load(std::memory_order_relaxed) ==
@@ -460,13 +461,16 @@ void WorkerPool::transferWorker(int thread_id) {
             uint64_t curr_wait_ts = getCurrentTimeInNano();
             if (curr_wait_ts - last_wait_ts > kWaitPeriodInNano) {
                 std::unique_lock<std::mutex> lock(cond_mutex_);
+                parked_worker_count_.fetch_add(1, std::memory_order_acq_rel);
                 // Double-check condition after acquiring lock to avoid lost
-                // wakeup
+                // wakeup. parked_worker_count_ is set before this check so
+                // producers that submit after it will notify this worker.
                 if (processed_slice_count_.load(std::memory_order_relaxed) ==
                         submitted_slice_count_.load() &&
                     !hasOutstandingCq()) {
                     cond_var_.wait_for(lock, std::chrono::seconds(1));
                 }
+                parked_worker_count_.fetch_sub(1, std::memory_order_acq_rel);
                 last_wait_ts = curr_wait_ts;
             }
             continue;


### PR DESCRIPTION
## Description

This PR tightens RDMA endpoint lifecycle handling to prevent connected endpoints from being reset and reused after they may have carried in-flight work requests.

The core issue is that resetting or reconstructing a QP after an endpoint has already reached CONNECTED can drop outstanding WR completions. Those slices may never receive CQEs, leaving transfer tasks stuck in WAITING until the upper-layer timeout is hit. The fix is to make endpoint reuse legal only before the first successful connection, preserving GID retry behavior, while retiring any endpoint that has ever been connected.

- Enforce one-shot lifecycle for connected RdmaEndPoints.
Added has_connected_ to distinguish pre-connected handshake retries from endpoints that have successfully reached CONNECTED.
Once doSetupConnection() succeeds, the endpoint is marked as having connected.
Later reset attempts on such endpoints retire them instead of resetting/reusing QPs.

- Preserve pre-connected GID retry behavior.
Before an endpoint has ever connected, handshake retry can still reset/reconstruct QPs.
CONFIG_ERDMA continues to reconstruct fresh QPs for pre-connected retries, because eRDMA QPs that reached RTS cannot be reliably reset back to RTS.
Added comments documenting this distinction.

- Prevent silent counter repair in impossible pre-connected states.
Pre-connected retry now asserts wr_depth_list_[i] == 0.
If a pre-connected endpoint has outstanding WRs, that is treated as an invariant violation rather than silently decrementing cq_outstanding_.

- Retire endpoints on disconnect-all paths.
Endpoint stores now move active endpoints to the waiting list via beginDestroy() instead of leaving reset endpoints in the active map for reuse.

- Keep CQ polling alive while completions may still be outstanding.
Worker idle logic now checks cqOutstandingCount().
Workers continue polling CQ while any CQ has outstanding WRs, even if submitted/processed counters appear balanced.

- Handle passive handshake retirement carefully.
onSetupRdmaConnections() does not create a fresh endpoint and retry inside the same RPC.
If passive setup returns ERR_ENDPOINT, the old endpoint is removed from the store and the error is returned to the active side, preserving handshake/QP correspondence.

## Module

- [X] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



**Test commands:**
```bash
# Example: bash scripts/run_ci_test.sh
```

**Test results:**
- [X] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have formatted my code using `./scripts/code_format.sh`
- [X] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [X] AI tools were used (specify below)



Use with CodeX.