### PR TITLE
[Store][Bugfix]:Fix SGLang fails to start with MC_USE_TENT=1 when built without USE_TENT

### DIFF
--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -648,9 +648,10 @@ ErrorCode Client::InitTransferEngine(
     }
 
     // Check if using TENT mode - TENT handles transport configuration
-    // internally
-    bool use_tent = (std::getenv("MC_USE_TENT") != nullptr) ||
-                    (std::getenv("MC_USE_TEV1") != nullptr);
+    // internally. Use the engine's own check rather than the raw env var:
+    // if Mooncake was built without USE_TENT, the env var has no effect on
+    // the TransferEngine, so the store must still install transports.
+    bool use_tent = transfer_engine_->isUsingTent();
 
     bool auto_discover = false;
     if (!use_tent) {

--- a/mooncake-transfer-engine/include/transfer_engine.h
+++ b/mooncake-transfer-engine/include/transfer_engine.h
@@ -88,6 +88,8 @@ class TransferEngine {
 
     int getRpcPort();
 
+    bool isUsingTent() const { return use_tent_; }
+
     SegmentHandle openSegment(const std::string& segment_name);
 
     Status CheckSegmentStatus(SegmentID sid);


### PR DESCRIPTION
## Description
Fix https://github.com/kvcache-ai/Mooncake/issues/2554

**Root cause:**
getenv("MC_USE_TENT") ignores compile-time availability: without USE_TENT, the env var is set but TENT code doesn't exist. The store skips installTransport(), which means addLocalSegment() is never called, so openSegment() queries the metadata server, gets 404, and returns -800

**Fix:**
Replace the raw getenv check with transfer_engine_->isUsingTent(), which returns true only when TENT is actually compiled in and active.


## Test
| Scenario | Before | Fixed|
|----------|--------|-------|
| USE_TENT=OFF, no env | ✅ | ✅ |
| USE_TENT=OFF, MC_USE_TENT=1 | ❌ -800 | ✅ |
| USE_TENT=ON, MC_USE_TENT=1 | ✅ | ✅ |

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



**Test commands:**
```bash
# Example: bash scripts/run_ci_test.sh
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [ ] AI tools were used (specify below)

@alogfans @ykwd 