### PR TITLE
[Store] add structured object flat mvp

### DIFF
--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -83,7 +83,7 @@ class StructuredMemberSlice:
 @dataclass(frozen=True)
 class _TensorPayload:
     tensor: Any
-    array: np.ndarray
+    nbytes: int
 
 
 @dataclass(frozen=True)
@@ -563,7 +563,7 @@ class _BundleManifestStore:
             tensor_spec = self._put_tensor_payload(key, value)
             if tensor_spec is not None:
                 return tensor_spec, [key]
-            value = value.array.view(np.uint8).reshape(-1).data
+            value = _tensor_payload_bytes_view(value)
         chunks = _split_view(value, chunk_bytes)
         chunk_keys = [
             key if len(chunks) == 1 else f"{key}/chunk/{index}"
@@ -595,10 +595,10 @@ class _BundleManifestStore:
         return {
             "key": key,
             "kind": "tensor",
-            "bytes": int(value.array.nbytes),
+            "bytes": value.nbytes,
             "dtype": str(value.tensor.dtype),
             "shape": list(value.tensor.shape),
-            "chunks": [{"key": key, "bytes": int(value.array.nbytes)}],
+            "chunks": [{"key": key, "bytes": value.nbytes}],
         }
 
     def _policy(
@@ -1344,13 +1344,16 @@ def _encode_structured_field(value: Any) -> tuple[dict[str, Any], Any]:
 
 
 def _encode_torch_tensor_field(value: Any) -> tuple[dict[str, Any], Any]:
-    tensor = value.detach().cpu().contiguous()
-    array = tensor.numpy()
     return {
         "encoding": "torch_tensor",
-        "dtype": str(tensor.dtype),
-        "shape": list(tensor.shape),
-    }, _TensorPayload(tensor=tensor, array=array)
+        "dtype": str(value.dtype),
+        "shape": list(value.shape),
+    }, _TensorPayload(tensor=value, nbytes=int(value.numel() * value.element_size()))
+
+
+def _tensor_payload_bytes_view(value: _TensorPayload) -> memoryview:
+    tensor = value.tensor.detach().cpu().contiguous()
+    return tensor.numpy().view(np.uint8).reshape(-1).data
 
 
 def _torch_dtype_to_numpy(dtype: Any) -> np.dtype[Any]:

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -81,6 +81,12 @@ class StructuredMemberSlice:
 
 
 @dataclass(frozen=True)
+class _TensorPayload:
+    tensor: Any
+    array: np.ndarray
+
+
+@dataclass(frozen=True)
 class StructuredObjectReadSpec:
     """Lazy read plan for structured object materialization."""
 
@@ -198,6 +204,37 @@ class MooncakeBundleTransfer:
             pre_registered_buffers=pre_registered_buffers,
         )
 
+    def put_object(
+        self,
+        obj: Any,
+        partition: str = "default",
+        chunk_bytes: Optional[int] = None,
+        policy: Optional[BundleTransferPolicy] = None,
+        max_inflight_put: Optional[int] = None,
+    ) -> RemoteBundleRef:
+        """Store a mapping object or a single tensor/array value."""
+        if isinstance(obj, Mapping):
+            payload = StructuredObjectPayload(metadata={}, buffers=obj)
+        else:
+            payload = StructuredObjectPayload(
+                metadata={"__mooncake_wrapped_object__": True},
+                buffers={"value": obj},
+            )
+        return self.put_structured_object(
+            payload,
+            partition=partition,
+            chunk_bytes=chunk_bytes,
+            policy=policy,
+            max_inflight_put=max_inflight_put,
+        )
+
+    def get_object(self, ref: RemoteBundleRef | Mapping[str, Any]) -> Any:
+        """Materialize an object stored by put_object()."""
+        result = self.materialize(self.read_spec(ref))
+        if result.metadata.get("__mooncake_wrapped_object__"):
+            return result.objects["value"]
+        return result.objects
+
     def read_spec(
         self, ref: RemoteBundleRef | Mapping[str, Any]
     ) -> StructuredObjectReadSpec:
@@ -309,11 +346,41 @@ class _StructuredObjectLayer:
             return self._read_bytes_member(
                 name, payload_spec, member_slice, destination
             )
+        if encoding == "torch_tensor":
+            return self._read_torch_tensor_member(
+                name, payload_spec, field_spec, member_slice, destination
+            )
         if encoding != "ndarray":
             raise ValueError(f"unsupported structured field encoding: {encoding}")
         return self._read_ndarray_member(
             name, payload_spec, field_spec, member_slice, destination
         )
+
+    def _read_torch_tensor_member(
+        self,
+        name: str,
+        payload_spec: Mapping[str, Any],
+        field_spec: Mapping[str, Any],
+        member_slice: StructuredMemberSlice | None,
+        destination: Any,
+    ) -> Any:
+        if _torch is None:
+            raise RuntimeError("torch is required to materialize structured tensor fields")
+        if member_slice is not None:
+            raise ValueError(f"structured tensor member {name} does not support slicing")
+        if destination is not None:
+            raise ValueError(
+                f"structured tensor member {name} does not support materialize_into"
+            )
+        if payload_spec.get("kind") == "tensor":
+            get_tensor = getattr(self._bundle_store._store, "get_tensor", None)
+            if callable(get_tensor):
+                return get_tensor(payload_spec["key"])
+        dtype = _torch_dtype_to_numpy(field_spec["dtype"])
+        shape = tuple(int(dim) for dim in field_spec["shape"])
+        data = self._bundle_store.read_payload(payload_spec)
+        array = np.frombuffer(data, dtype=dtype).reshape(shape)
+        return _torch.from_numpy(array.copy())
 
     def _read_bytes_member(
         self,
@@ -416,10 +483,10 @@ class _BundleManifestStore:
             written_keys.extend(meta_keys)
             for name, value in buffers.items():
                 _validate_key_segment(name, "buffer name")
-                payload_view = _bytes_view(value, name)
+                payload_value = value if isinstance(value, _TensorPayload) else _bytes_view(value, name)
                 payload_spec, payload_keys = self._put_payload(
                     f"{base_key}/buffer/{name}",
-                    payload_view,
+                    payload_value,
                     target_chunk_bytes,
                     transfer_policy,
                     pre_registered=bool(pre_registered_map.get(name, False)),
@@ -484,11 +551,16 @@ class _BundleManifestStore:
     def _put_payload(
         self,
         key: str,
-        value: memoryview,
+        value: memoryview | _TensorPayload,
         chunk_bytes: int,
         transfer_policy: BundleTransferPolicy,
         pre_registered: bool,
     ) -> tuple[dict[str, Any], list[str]]:
+        if isinstance(value, _TensorPayload):
+            tensor_spec = self._put_tensor_payload(key, value)
+            if tensor_spec is not None:
+                return tensor_spec, [key]
+            value = value.array.view(np.uint8).reshape(-1).data
         chunks = _split_view(value, chunk_bytes)
         chunk_keys = [
             key if len(chunks) == 1 else f"{key}/chunk/{index}"
@@ -509,6 +581,22 @@ class _BundleManifestStore:
             ],
         }
         return payload_spec, written_keys
+
+    def _put_tensor_payload(
+        self, key: str, value: _TensorPayload
+    ) -> dict[str, Any] | None:
+        put_tensor = getattr(self._store, "put_tensor", None)
+        if not callable(put_tensor):
+            return None
+        _check_status(put_tensor(key, value.tensor), "put_tensor", key)
+        return {
+            "key": key,
+            "kind": "tensor",
+            "bytes": int(value.array.nbytes),
+            "dtype": str(value.tensor.dtype),
+            "shape": list(value.tensor.shape),
+            "chunks": [{"key": key, "bytes": int(value.array.nbytes)}],
+        }
 
     def _policy(
         self,
@@ -1240,6 +1328,8 @@ def _encode_structured_fields(
 
 
 def _encode_structured_field(value: Any) -> tuple[dict[str, Any], Any]:
+    if _torch is not None and isinstance(value, _torch.Tensor):
+        return _encode_torch_tensor_field(value)
     if isinstance(value, np.ndarray):
         array = np.ascontiguousarray(value)
         return {
@@ -1248,6 +1338,34 @@ def _encode_structured_field(value: Any) -> tuple[dict[str, Any], Any]:
             "shape": list(array.shape),
         }, array.view(np.uint8).reshape(-1)
     return {"encoding": "bytes"}, value
+
+
+def _encode_torch_tensor_field(value: Any) -> tuple[dict[str, Any], Any]:
+    tensor = value.detach().cpu().contiguous()
+    array = tensor.numpy()
+    return {
+        "encoding": "torch_tensor",
+        "dtype": str(tensor.dtype),
+        "shape": list(tensor.shape),
+    }, _TensorPayload(tensor=tensor, array=array)
+
+
+def _torch_dtype_to_numpy(dtype: Any) -> np.dtype[Any]:
+    dtype_name = str(dtype).removeprefix("torch.")
+    mapping = {
+        "bool": np.bool_,
+        "uint8": np.uint8,
+        "int8": np.int8,
+        "int16": np.int16,
+        "int32": np.int32,
+        "int64": np.int64,
+        "float16": np.float16,
+        "float32": np.float32,
+        "float64": np.float64,
+    }
+    if dtype_name not in mapping:
+        raise ValueError(f"unsupported tensor dtype for raw field codec: {dtype}")
+    return np.dtype(mapping[dtype_name])
 
 
 def _validate_pre_registered_structured_buffers(

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -374,8 +374,12 @@ class _StructuredObjectLayer:
             )
         if payload_spec.get("kind") == "tensor":
             get_tensor = getattr(self._bundle_store._store, "get_tensor", None)
-            if callable(get_tensor):
-                return get_tensor(payload_spec["key"])
+            if not callable(get_tensor):
+                raise RuntimeError(
+                    f"structured tensor member {name} was stored using put_tensor, "
+                    "but the current store does not support get_tensor"
+                )
+            return get_tensor(payload_spec["key"])
         dtype = _torch_dtype_to_numpy(field_spec["dtype"])
         shape = tuple(int(dim) for dim in field_spec["shape"])
         data = self._bundle_store.read_payload(payload_spec)

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -483,7 +483,10 @@ class _BundleManifestStore:
             written_keys.extend(meta_keys)
             for name, value in buffers.items():
                 _validate_key_segment(name, "buffer name")
-                payload_value = value if isinstance(value, _TensorPayload) else _bytes_view(value, name)
+                if isinstance(value, _TensorPayload):
+                    payload_value = value
+                else:
+                    payload_value = _bytes_view(value, name)
                 payload_spec, payload_keys = self._put_payload(
                     f"{base_key}/buffer/{name}",
                     payload_value,

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -385,7 +385,7 @@ class _StructuredObjectLayer:
         array = np.empty(shape, dtype=dtype)
         self._bundle_store.read_payload_range_into_destination(
             payload_spec,
-            array.view(np.uint8).reshape(-1),
+            array.reshape(-1).view(np.uint8),
             0,
         )
         return _torch.from_numpy(array)
@@ -1361,7 +1361,7 @@ def _encode_torch_tensor_field(value: Any) -> tuple[dict[str, Any], Any]:
 
 def _tensor_payload_bytes_view(value: _TensorPayload) -> memoryview:
     tensor = value.tensor.detach().cpu().contiguous()
-    return memoryview(tensor.numpy()).cast("B")
+    return memoryview(tensor.numpy().reshape(-1).view(np.uint8)).cast("B")
 
 
 def _torch_dtype_to_numpy(dtype: Any) -> np.dtype[Any]:

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -382,9 +382,13 @@ class _StructuredObjectLayer:
             return get_tensor(payload_spec["key"])
         dtype = _torch_dtype_to_numpy(field_spec["dtype"])
         shape = tuple(int(dim) for dim in field_spec["shape"])
-        data = self._bundle_store.read_payload(payload_spec)
-        array = np.frombuffer(data, dtype=dtype).reshape(shape)
-        return _torch.from_numpy(array.copy())
+        array = np.empty(shape, dtype=dtype)
+        self._bundle_store.read_payload_range_into_destination(
+            payload_spec,
+            array.view(np.uint8).reshape(-1),
+            0,
+        )
+        return _torch.from_numpy(array)
 
     def _read_bytes_member(
         self,
@@ -1357,7 +1361,7 @@ def _encode_torch_tensor_field(value: Any) -> tuple[dict[str, Any], Any]:
 
 def _tensor_payload_bytes_view(value: _TensorPayload) -> memoryview:
     tensor = value.tensor.detach().cpu().contiguous()
-    return tensor.numpy().view(np.uint8).reshape(-1).data
+    return memoryview(tensor.numpy()).cast("B")
 
 
 def _torch_dtype_to_numpy(dtype: Any) -> np.dtype[Any]:

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -337,13 +337,26 @@ def test_put_object_roundtrips_numpy_and_torch_tensor_fields() -> None:
     store, transfer = make_transfer()
     array = np.arange(6, dtype=np.float32).reshape(2, 3)
     tensor = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+    scalar_tensor = torch.tensor(1.5, dtype=torch.float32)
+    bool_tensor = torch.tensor([True, False], dtype=torch.bool)
 
-    result = transfer.get_object(transfer.put_object({"array": array, "tensor": tensor}))
+    result = transfer.get_object(
+        transfer.put_object(
+            {
+                "array": array,
+                "tensor": tensor,
+                "scalar": scalar_tensor,
+                "bool_tensor": bool_tensor,
+            }
+        )
+    )
 
     assert np.array_equal(result["array"], array)
     assert torch.equal(result["tensor"], tensor)
-    assert store.put_tensor_calls == 1
-    assert store.get_tensor_calls == 1
+    assert torch.equal(result["scalar"], scalar_tensor)
+    assert torch.equal(result["bool_tensor"], bool_tensor)
+    assert store.put_tensor_calls == 3
+    assert store.get_tensor_calls == 3
 
 
 def test_put_object_roundtrips_wrapped_numpy_and_torch_values() -> None:
@@ -373,10 +386,22 @@ def test_put_object_torch_tensor_raw_fallback_roundtrip() -> None:
     torch = pytest.importorskip("torch")
     store, transfer = make_transfer(NoTensorFastPathStore())
     tensor = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+    scalar_tensor = torch.tensor(1.5, dtype=torch.float32)
+    bool_tensor = torch.tensor([True, False], dtype=torch.bool)
 
-    result = transfer.get_object(transfer.put_object({"tensor": tensor}))
+    result = transfer.get_object(
+        transfer.put_object(
+            {
+                "tensor": tensor,
+                "scalar": scalar_tensor,
+                "bool_tensor": bool_tensor,
+            }
+        )
+    )
 
     assert torch.equal(result["tensor"], tensor)
+    assert torch.equal(result["scalar"], scalar_tensor)
+    assert torch.equal(result["bool_tensor"], bool_tensor)
     assert store.batch_get_into_calls > 0
 
 

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -214,6 +214,10 @@ class PlainStore(MinimalStore):
     get_into_ranges = None
 
 
+class PutTensorOnlyStore(InMemoryStore):
+    get_tensor = None
+
+
 class FailingPutStore(InMemoryStore):
     def __init__(self, fail_on_put: int) -> None:
         super().__init__()
@@ -347,6 +351,17 @@ def test_put_object_roundtrips_wrapped_numpy_and_torch_values() -> None:
     assert torch.equal(transfer.get_object(transfer.put_object(tensor)), tensor)
     assert store.put_tensor_calls == 1
     assert store.get_tensor_calls == 1
+
+
+def test_get_object_requires_get_tensor_for_tensor_payload() -> None:
+    torch = pytest.importorskip("torch")
+    store, transfer = make_transfer(PutTensorOnlyStore())
+    tensor = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+
+    ref = transfer.put_object({"tensor": tensor})
+
+    with pytest.raises(RuntimeError, match="does not support get_tensor"):
+        transfer.get_object(ref)
 
 
 def test_bundle_read_spec_full_read_is_partial_special_case() -> None:

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -20,6 +20,7 @@ from mooncake.structured_object_store import (
 class InMemoryStore:
     def __init__(self) -> None:
         self.objects: dict[str, bytes] = {}
+        self.tensor_objects: dict[str, object] = {}
         self.lock = threading.Lock()
         self.registered: set[int] = set()
         self.register_buffer_calls = 0
@@ -33,6 +34,8 @@ class InMemoryStore:
         self.batch_get_into_calls = 0
         self.batch_put_from_calls = 0
         self.batch_remove_calls = 0
+        self.put_tensor_calls = 0
+        self.get_tensor_calls = 0
 
     def _enter_put(self) -> None:
         with self.lock:
@@ -74,7 +77,19 @@ class InMemoryStore:
     def remove(self, key: str, force: bool = False) -> int:
         with self.lock:
             self.objects.pop(key, None)
+            self.tensor_objects.pop(key, None)
         return 0
+
+    def put_tensor(self, key: str, value) -> int:
+        self.put_tensor_calls += 1
+        with self.lock:
+            self.tensor_objects[key] = value.detach().clone()
+        return 0
+
+    def get_tensor(self, key: str):
+        self.get_tensor_calls += 1
+        with self.lock:
+            return self.tensor_objects[key].clone()
 
     def batch_remove(self, keys: list[str], force: bool = False) -> list[int]:
         self.batch_remove_calls += 1
@@ -306,6 +321,32 @@ def write_manifest(
     store.objects[manifest_key] = json.dumps(manifest, separators=(",", ":")).encode(
         "utf-8"
     )
+
+
+def test_put_object_roundtrips_numpy_and_torch_tensor_fields() -> None:
+    torch = pytest.importorskip("torch")
+    store, transfer = make_transfer()
+    array = np.arange(6, dtype=np.float32).reshape(2, 3)
+    tensor = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+
+    result = transfer.get_object(transfer.put_object({"array": array, "tensor": tensor}))
+
+    assert np.array_equal(result["array"], array)
+    assert torch.equal(result["tensor"], tensor)
+    assert store.put_tensor_calls == 1
+    assert store.get_tensor_calls == 1
+
+
+def test_put_object_roundtrips_wrapped_numpy_and_torch_values() -> None:
+    torch = pytest.importorskip("torch")
+    store, transfer = make_transfer()
+    array = np.arange(6, dtype=np.float32).reshape(2, 3)
+    tensor = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+
+    assert np.array_equal(transfer.get_object(transfer.put_object(array)), array)
+    assert torch.equal(transfer.get_object(transfer.put_object(tensor)), tensor)
+    assert store.put_tensor_calls == 1
+    assert store.get_tensor_calls == 1
 
 
 def test_bundle_read_spec_full_read_is_partial_special_case() -> None:

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -218,6 +218,11 @@ class PutTensorOnlyStore(InMemoryStore):
     get_tensor = None
 
 
+class NoTensorFastPathStore(InMemoryStore):
+    put_tensor = None
+    get_tensor = None
+
+
 class FailingPutStore(InMemoryStore):
     def __init__(self, fail_on_put: int) -> None:
         super().__init__()
@@ -362,6 +367,17 @@ def test_get_object_requires_get_tensor_for_tensor_payload() -> None:
 
     with pytest.raises(RuntimeError, match="does not support get_tensor"):
         transfer.get_object(ref)
+
+
+def test_put_object_torch_tensor_raw_fallback_roundtrip() -> None:
+    torch = pytest.importorskip("torch")
+    store, transfer = make_transfer(NoTensorFastPathStore())
+    tensor = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+
+    result = transfer.get_object(transfer.put_object({"tensor": tensor}))
+
+    assert torch.equal(result["tensor"], tensor)
+    assert store.batch_get_into_calls > 0
 
 
 def test_bundle_read_spec_full_read_is_partial_special_case() -> None:


### PR DESCRIPTION
## Motivation                                                                                                                                                                      
                                                                                                                                                                                     
  PR2050 added a broad DataProto-oriented transfer stack for RL batch exchange. That PR is now being split into smaller, reviewable pieces so reviewers can validate the structured-object foundation before lazy batch, planner, sharding, and DataProto compatibility layers are added.                                                                   
                                                                                                                                                                                     
  This PR adds the minimal flat structured-object object API and tensor fast path on top of the existing `structured_object_store.py` bundle/manifest infrastructure that has already landed on main.                                                                                                                    
                                                                                                                                                                                     
  ## Scenario                                                                                                                                                                        
                                                                                                                                                                                     
  This targets the first step of remote structured-object transfer in RL pipelines:                                                                                                  
                                                                                                                                                                                     
  1. A producer stores a flat mapping or a single wrapped object through `MooncakeBundleTransfer`.                                                                                   
  2. NumPy arrays are stored as structured ndarray members with dtype/shape metadata.                                                                                                
  3. Torch tensors are stored through the Mooncake Store tensor path when `put_tensor/get_tensor` are available.                                                                     
  4. A consumer materializes the object back with `get_object()` or the existing `read_spec()` / `materialize()` path.                                                               
                                                                                                                                                                                     
  Later split PRs will layer nested mappings, TensorDict support, row/list codecs, partial materialization, lazy remote batch, planner, and DataProto compatibility on this foundation.                                                                                                                                                                        
                                                                                                                                                                                     
  ## Description                                                                                                                                                                     
                                                                                                                                                                                     
  This PR adds the flat structured-object MVP split from PR2050.                                                                                                                     
                                                                                                                                                                                     
  ### Structured object convenience API                                                                                                                                              
                                                                                                                                                                                     
  - `MooncakeBundleTransfer.put_object(obj, ...)`                                                                                                                                    
    - stores a flat mapping directly as structured object members;                                                                                                                   
    - wraps a single non-mapping object under an internal `value` member.                                                                                                            
  - `MooncakeBundleTransfer.get_object(ref)`                                                                                                                                         
    - materializes objects written by `put_object()`;                                                                                                                                
    - unwraps single-object payloads automatically.                                                                                                                                  
                                                                                                                                                                                     
  ### Torch tensor fast path                                                                                                                                                         
                                                                                                                                                                                     
  - Adds an internal `_TensorPayload` marker for structured tensor fields.                                                                                                           
  - Encodes torch tensors as `torch_tensor` structured members with dtype/shape metadata.                                                                                            
  - Uses Store `put_tensor()` when available.                                                                                                                                        
  - Uses Store `get_tensor()` when materializing tensor payloads.                                                                                                                    
  - Falls back to raw bytes payload storage/read when the tensor APIs are unavailable.                                                                                               
                                                                                                                                                                                     
  ### Tests                                                                                                                                                                          
                                                                                                                                                                                     
  - Extends the in-memory test store with `put_tensor()` / `get_tensor()` hooks.                                                                                                     
  - Verifies flat NumPy + torch tensor object roundtrip.                                                                                                                             
  - Verifies wrapped NumPy + torch tensor value roundtrip.                                                                                                                           
  - Asserts tensor fields use the direct tensor fast path.                                                                                                                           
                                                                                                                                                                                     
  ## Basic Usage                                                                                                                                                                     
                                                                                                                                                                                     
  ```python                                                                                                                                                                          
  transfer = MooncakeBundleTransfer(store, key_prefix="rl/structured")                                                                                                               
                                                                                                                                                                                     
  ref = transfer.put_object(                                                                                                                                                         
      {                                                                                                                                                                              
          "tokens": torch.arange(8, dtype=torch.int64).reshape(2, 4),                                                                                                                
          "scores": np.arange(2, dtype=np.float32),                                                                                                                                  
      }                                                                                                                                                                              
  )                                                                                                                                                                                  
                                                                                                                                                                                     
  obj = transfer.get_object(ref)                                                                                                                                                     
                                                                                                                                                                                     
  assert torch.equal(obj["tokens"], torch.arange(8, dtype=torch.int64).reshape(2, 4))                                                                                                
  assert np.array_equal(obj["scores"], np.arange(2, dtype=np.float32))                                                                                                               
                                                                                                                                                                                     
  Single wrapped value:                                                                                                                                                              
                                                                                                                                                                                     
  ref = transfer.put_object(torch.arange(4))                                                                                                                                         
  tensor = transfer.get_object(ref)     
  ```                                                                                                                                             
                                                                                                                                                                                     
  ## Architecture                                                                                                                                                                       
                                                                                                                                                                                     
  This PR keeps the abstraction generic and framework-neutral.                                                                                                                       
                                                                                                                                                                                     
  caller object / flat mapping                                                                                                                                                       
          │                                                                                                                                                                          
          ▼                                                                                                                                                                          
  MooncakeBundleTransfer.put_object()                                                                                                                                                
          │                                                                                                                                                                          
          ├── numpy fields ─────► structured ndarray payload + dtype/shape metadata                                                                                                  
          ├── torch fields ─────► Mooncake Store put_tensor/get_tensor fast path                                                                                                     
          └── bytes fields ─────► existing bundle payload path                                                                                                                       
          │                                                                                                                                                                          
          ▼                                                                                                                                                                          
  existing structured_object_store bundle manifest                                                                                                                                   
                                                                                                                                                                                     
  This is intentionally only the first layer from PR2050. It does not introduce DataProto-specific APIs or a parallel manifest format.                                               
                                                                                                                                                                                     
  ## Robustness and Safety                                                                                                                                                              
                                                                                                                                                                                     
  - Keeps structured metadata JSON-serializable.                                                                                                                                     
  - Rejects user-provided reserved structured metadata keys.                                                                                                                         
  - Keeps tensor payload cleanup under the existing bundle removal path.                                                                                                             
  - Avoids pickle or general Python object deserialization.                                                                                                                          
  - Preserves the existing bytes/ndarray structured-object behavior.                                                                                                                 
                                                                                                                                                                                     
  ## Performance                                                                                                                                                                        
                                                                                                                                                                                     
  The main performance improvement in this split is avoiding raw byte serialization for torch tensor fields when Store tensor APIs are available:                                    
                                                                                                                                                                                     
  - tensor writes use put_tensor();                                                                                                                                                  
  - tensor reads use get_tensor();                                                                                                                                                   
  - non-tensor flat members continue using the existing bundle payload path.                                                                                                         
                                                                                                                                                                                     
  Planner, lazy selection, range reads, sharding, and DataProto adaptive policy are intentionally left to later split PRs.                                                                                                                                                                                                                             
                                                                                                                                                                                     
  ## How Has This Been Tested?                                                                                                                                                          
                                                                                                                                                                                     
  - python -m py_compile mooncake-wheel/mooncake/structured_object_store.py mooncake-wheel/tests/test_structured_object_store.py                                                     
  - PYTHONPATH=/tmp/mooncake-pr2050-rebase-20260624/mooncake-wheel pytest -q mooncake-wheel/tests/test_structured_object_store.py                                                    
    - 38 passed                                                                                                                                                                      
  - PYTHONPATH=/tmp/mooncake-pr2050-rebase-20260624/mooncake-wheel pytest -q mooncake-wheel/tests/test_structured_object_store.py -k 'put_object or structured_object_roundtrip or metadata_defaults or invalid_metadata'                                                                                                                                             
    - 5 passed, 33 deselected                                                                                                                                                        
  - ./scripts/code_format.sh --check                                                                                                                                                 
    - no C/C++ files changed                                                                                                                                                         
                                                                                                                                                                                    
## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Claude Opus 4.6 assisted with code generation, code review, benchmark analysis, and PR description drafting. All changes were reviewed and validated by me。