### PR TITLE
[Bugfix] Return HTTP 500 when is_exist reports an error in handle_exist

### DIFF
--- a/mooncake-wheel/mooncake/mooncake_store_service.py
+++ b/mooncake-wheel/mooncake/mooncake_store_service.py
@@ -550,9 +550,16 @@ class MooncakeStoreService:
             key = request.match_info['key']
             exists = self.store.is_exist(key)
 
+            if exists < 0:
+                return web.Response(
+                    status=500,
+                    text=json.dumps({'error': 'Exist check failed'}),
+                    content_type='application/json'
+                )
+
             return web.Response(
                 status=200,
-                text=json.dumps({'exists': bool(exists)}),
+                text=json.dumps({'exists': exists > 0}),
                 content_type='application/json'
             )
         except Exception as e:

--- a/mooncake-wheel/tests/test_mooncake_store_service_api.py
+++ b/mooncake-wheel/tests/test_mooncake_store_service_api.py
@@ -410,6 +410,17 @@ class StoreServiceApiTest(unittest.IsolatedAsyncioTestCase):
         body = json.loads(resp.text)
         self.assertIn("exist check crashed", body["error"])
 
+    async def test_handle_exist_store_error(self):
+        # is_exist returns -1 when the store is unhealthy; this should surface
+        # as HTTP 500, not as HTTP 200 {"exists": true} (bool(-1) == True).
+        self.fake_store.is_exist = lambda key: -1
+        request = FakeRequest({})
+        request.match_info = {"key": "some_key"}
+        resp = await self.service.handle_exist(request)
+        self.assertEqual(resp.status, 500)
+        body = json.loads(resp.text)
+        self.assertIn("error", body)
+
     # ==================== /api/remove/{key} tests ====================
 
     async def test_handle_remove_success(self):

--- a/mooncake-wheel/tests/test_mooncake_store_service_api.py
+++ b/mooncake-wheel/tests/test_mooncake_store_service_api.py
@@ -419,7 +419,9 @@ class StoreServiceApiTest(unittest.IsolatedAsyncioTestCase):
         resp = await self.service.handle_exist(request)
         self.assertEqual(resp.status, 500)
         body = json.loads(resp.text)
-        self.assertIn("error", body)
+        # Assert the specific message so this pins the exists < 0 branch rather
+        # than any 500 (the except path returns {"error": str(e)} too).
+        self.assertEqual(body["error"], "Exist check failed")
 
     # ==================== /api/remove/{key} tests ====================
 


### PR DESCRIPTION
## Problem

`handle_exist` used `bool(is_exist(key))` to populate the response body.

`is_exist()` returns three distinct values:

| Return | Meaning |
|--------|---------|
| `0` | key does not exist |
| positive integer | key exists |
| negative integer | store error |

`bool(-1)` evaluates to `True` in Python, so a store error was silently reported as HTTP 200 `{"exists": true}` instead of HTTP 500.  Callers have no way to distinguish "key found" from "store is unhealthy".

## Fix

Mirror the pattern introduced for `handle_get` in #2587: check `exists < 0` first and return HTTP 500 `{"error": "Exist check failed"}`.  Also replace `bool(exists)` with `exists > 0` to make the positive-vs-zero distinction explicit.

## Test plan

New test `test_handle_exist_store_error` sets `is_exist = lambda key: -1` and asserts the response is HTTP 500 with an `"error"` key.

To verify:

```bash
cd mooncake-wheel
python -m pytest tests/test_mooncake_store_service_api.py -k exist -v
```

All exist-related tests pass.  Four unrelated tests (`test_handle_put_missing_value`, `test_reconfigure_*`, `test_unmount_shm_string_segment_id_coercion`) fail on upstream `main` as existing failures before this change and are unaffected.

## Relation to #2587

#2587 fixed the same class of bug in `handle_get` (which also calls `is_exist` and previously used `if not value` as a truthiness check).  This PR applies the same correction to the `handle_exist` endpoint.