### PR TITLE
[TE] Skip redundant Disconnect on AutoConnect transfer failures

### DIFF
--- a/mooncake-transfer-engine/include/transport/ascend_transport/ascend_direct_transport/async_transfer_executor.h
+++ b/mooncake-transfer-engine/include/transport/ascend_transport/ascend_direct_transport/async_transfer_executor.h
@@ -58,6 +58,9 @@ class AsyncTransferExecutor : public TransferExecutorBase {
         // pending_batches for this route. Batches enqueued after disconnect
         // are not affected.
         bool fail_entire_route = false;
+        // When true with auto_connect, ADXL DisconnectOnError already ran;
+        // only forgetConnectedSegment is needed (if the route was recorded).
+        bool adxl_already_disconnected = false;
         std::string fail_reason;
     };
 
@@ -66,7 +69,8 @@ class AsyncTransferExecutor : public TransferExecutorBase {
     void processOneBatch(QueryBatch& batch, BatchPollResult& result);
     void failAllPendingOnRoute(size_t engine_idx, const std::string& target,
                                std::vector<QueryBatch>& pending,
-                               const std::string& reason);
+                               const std::string& reason,
+                               bool adxl_already_disconnected);
     void markBatchFailed(QueryBatch& batch, const std::string& reason,
                          bool log_error = true);
     void handleTaskFinished();

--- a/mooncake-transfer-engine/include/transport/ascend_transport/ascend_direct_transport/transfer_executor_base.h
+++ b/mooncake-transfer-engine/include/transport/ascend_transport/ascend_direct_transport/transfer_executor_base.h
@@ -95,6 +95,7 @@ class TransferExecutorBase {
     void finalizeEngines();
     void disconnectAllForEngine(size_t engine_idx);
     void recordConnectedSegment(size_t engine_idx, const std::string& remote);
+    void forgetConnectedSegment(size_t engine_idx, const std::string& remote);
 
     int checkAndConnect(size_t engine_idx,
                         const std::string& target_adxl_engine_name);

--- a/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/async_transfer_executor.cpp
+++ b/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/async_transfer_executor.cpp
@@ -139,8 +139,10 @@ TransferExecutorBase::ExecuteResult AsyncTransferExecutor::execute(
         }
         async_task_cv_.notify_one();
     }
-    disconnect(local_engine_idx, target_adxl_engine_name,
-               kDefaultDisconnectTime);
+    if (!params_.auto_connect) {
+        disconnect(local_engine_idx, target_adxl_engine_name,
+                   kDefaultDisconnectTime);
+    }
     return {.ret = -1, .status = status, .retryable = true};
 }
 
@@ -172,7 +174,8 @@ void AsyncTransferExecutor::queryThreadLoop() {
                         : poll_result.fail_reason;
                 failAllPendingOnRoute(batch.engine_idx,
                                       batch.target_adxl_engine_name,
-                                      pending_batches, reason);
+                                      pending_batches, reason,
+                                      poll_result.adxl_already_disconnected);
                 // failAllPendingOnRoute swap-pops may move unvisited batches to
                 // indices < i; restart the scan so none are skipped this cycle.
                 i = 0;
@@ -220,9 +223,10 @@ void AsyncTransferExecutor::markBatchFailed(QueryBatch& batch,
 
 void AsyncTransferExecutor::failAllPendingOnRoute(
     size_t engine_idx, const std::string& target,
-    std::vector<QueryBatch>& pending, const std::string& reason) {
+    std::vector<QueryBatch>& pending, const std::string& reason,
+    bool adxl_already_disconnected) {
     LOG(ERROR) << reason;
-    bool disconnected = false;
+    bool cleaned_up = false;
     for (size_t j = 0; j < pending.size();) {
         auto& batch = pending[j];
         if (batch.engine_idx != engine_idx ||
@@ -232,10 +236,14 @@ void AsyncTransferExecutor::failAllPendingOnRoute(
         }
 
         markBatchFailed(batch, reason, false);
-        if (!disconnected && engine_idx < adxl_engines_.size() &&
+        if (!cleaned_up && engine_idx < adxl_engines_.size() &&
             !target.empty()) {
-            disconnect(engine_idx, target, params_.connect_timeout);
-            disconnected = true;
+            if (params_.auto_connect && adxl_already_disconnected) {
+                forgetConnectedSegment(engine_idx, target);
+            } else {
+                disconnect(engine_idx, target, params_.connect_timeout);
+            }
+            cleaned_up = true;
         }
 
         std::swap(pending[j], pending.back());
@@ -284,6 +292,7 @@ void AsyncTransferExecutor::processOneBatch(QueryBatch& batch,
     if (ret != adxl::SUCCESS || task_status == adxl::TransferStatus::FAILED) {
         result.done = true;
         result.fail_entire_route = true;
+        result.adxl_already_disconnected = true;
         result.fail_reason = "Get transfer status failed, ret: " +
                              std::to_string(static_cast<int>(ret)) +
                              ", errmsg: " + aclGetRecentErrMsg();

--- a/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/sync_transfer_executor.cpp
+++ b/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/sync_transfer_executor.cpp
@@ -76,8 +76,10 @@ TransferExecutorBase::ExecuteResult SyncTransferExecutor::execute(
                              op_descs, params_.transfer_timeout);
 
     if (status != adxl::SUCCESS) {
-        disconnect(local_engine_idx, target_adxl_engine_name,
-                   kDefaultDisconnectTime);
+        if (!params_.auto_connect) {
+            disconnect(local_engine_idx, target_adxl_engine_name,
+                       kDefaultDisconnectTime);
+        }
         return {.ret = -1, .status = status, .retryable = true};
     }
 

--- a/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/transfer_executor_base.cpp
+++ b/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/transfer_executor_base.cpp
@@ -290,6 +290,19 @@ void TransferExecutorBase::recordConnectedSegment(size_t engine_idx,
     connected_segments_[engine_idx].insert(remote);
 }
 
+void TransferExecutorBase::forgetConnectedSegment(size_t engine_idx,
+                                                  const std::string& remote) {
+    std::lock_guard<std::mutex> lock(connection_mutex_);
+    auto it = connected_segments_.find(engine_idx);
+    if (it == connected_segments_.end()) {
+        return;
+    }
+    it->second.erase(remote);
+    if (it->second.empty()) {
+        connected_segments_.erase(it);
+    }
+}
+
 int TransferExecutorBase::disconnect(size_t engine_idx,
                                      const std::string& target_adxl_engine_name,
                                      int32_t timeout_in_millis) {

--- a/mooncake-transfer-engine/tests/ascend_direct_transport_test.cpp
+++ b/mooncake-transfer-engine/tests/ascend_direct_transport_test.cpp
@@ -1753,6 +1753,94 @@ TEST_F(AscendDirectTransportTest, RemoteTransfer_Async_TransferTimeout) {
                                   "(GetTransferStatus stays WAITING)";
 }
 
+TEST_F(AscendDirectTransportTest,
+       RemoteTransfer_Sync_FailureWithAutoConnect_SkipsDisconnect) {
+    setenv("ASCEND_AUTO_CONNECT", "1", 1);
+    adxl_mock::set_transfer_result(adxl::FAILED);
+
+    auto transport = createTransport();
+    ASSERT_NE(transport, nullptr);
+    ASSERT_EQ(transport->registerLocalMemory(test_buffer_src_, kRegisterMemSize,
+                                             "cpu:0", true, true),
+              0);
+    addRemoteSegment(transport->meta(),
+                     {1, "remote_server", "192.168.1.100", 30000});
+
+    initTestData(kTransferBufSize);
+    auto result = runRemoteTransfer(transport.get(), test_buffer_src_, 1,
+                                    0x10000, kTransferBufSize);
+    ASSERT_TRUE(result.finished);
+    EXPECT_TRUE(result.failed);
+    EXPECT_EQ(adxl_mock::get_disconnect_count(), 0);
+}
+
+TEST_F(AscendDirectTransportTest,
+       RemoteTransfer_Async_SubmitFailureWithAutoConnect_SkipsDisconnect) {
+    setenv("ASCEND_AUTO_CONNECT", "1", 1);
+    adxl_mock::set_transfer_async_result(adxl::FAILED);
+
+    auto transport = createTransport(true);
+    ASSERT_NE(transport, nullptr);
+    ASSERT_EQ(transport->registerLocalMemory(test_buffer_src_, kRegisterMemSize,
+                                             "cpu:0", true, true),
+              0);
+    addRemoteSegment(transport->meta(),
+                     {1, "remote_server", "192.168.1.100", 30000});
+
+    initTestData(kTransferBufSize);
+    auto result = runRemoteTransfer(transport.get(), test_buffer_src_, 1,
+                                    0x10000, kTransferBufSize);
+    ASSERT_TRUE(result.finished);
+    EXPECT_TRUE(result.failed);
+    EXPECT_EQ(adxl_mock::get_disconnect_count(), 0);
+}
+
+TEST_F(AscendDirectTransportTest,
+       RemoteTransfer_Async_GetStatusFailureWithAutoConnect_SkipsDisconnect) {
+    setenv("ASCEND_AUTO_CONNECT", "1", 1);
+    adxl_mock::set_transfer_async_result(adxl::SUCCESS);
+    adxl_mock::set_get_transfer_status_result(adxl::FAILED);
+
+    auto transport = createTransport(true);
+    ASSERT_NE(transport, nullptr);
+    ASSERT_EQ(transport->registerLocalMemory(test_buffer_src_, kRegisterMemSize,
+                                             "cpu:0", true, true),
+              0);
+    addRemoteSegment(transport->meta(),
+                     {1, "remote_server", "192.168.1.100", 30000});
+
+    initTestData(kTransferBufSize);
+    auto result = runRemoteTransfer(transport.get(), test_buffer_src_, 1,
+                                    0x10000, kTransferBufSize);
+    ASSERT_TRUE(result.finished);
+    EXPECT_TRUE(result.failed);
+    EXPECT_EQ(adxl_mock::get_disconnect_count(), 0);
+}
+
+TEST_F(AscendDirectTransportTest,
+       RemoteTransfer_Async_TimeoutWithAutoConnect_StillDisconnects) {
+    setenv("ASCEND_AUTO_CONNECT", "1", 1);
+    setenv("ASCEND_TRANSFER_TIMEOUT", "100", 1);
+    adxl_mock::set_transfer_async_result(adxl::SUCCESS);
+    adxl_mock::set_get_transfer_status_result(adxl::SUCCESS);
+    adxl_mock::set_transfer_status_enum(adxl::TransferStatus::WAITING);
+
+    auto transport = createTransport(true);
+    ASSERT_NE(transport, nullptr);
+    ASSERT_EQ(transport->registerLocalMemory(test_buffer_src_, kRegisterMemSize,
+                                             "cpu:0", true, true),
+              0);
+    addRemoteSegment(transport->meta(),
+                     {1, "remote_server", "192.168.1.100", 30000});
+
+    initTestData(kTransferBufSize);
+    auto result = runRemoteTransfer(transport.get(), test_buffer_src_, 1,
+                                    0x10000, kTransferBufSize);
+    ASSERT_TRUE(result.finished);
+    EXPECT_TRUE(result.failed);
+    EXPECT_EQ(adxl_mock::get_disconnect_count(), 1);
+}
+
 // -----------------------------------------------------------------------------
 // Standalone mode tests (non-dummy-real, non-fabric-mem)
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Description

When `ASCEND_AUTO_CONNECT=1`, ADXL already disconnects failed routes via `DisconnectOnError`. Mooncake was calling `Disconnect` again on the same failure paths, causing redundant teardown.

This change:
- Skips Mooncake `disconnect()` on sync/async submit failures when auto-connect is enabled (peer was never recorded in `connected_segments_`).
- On async `GetTransferStatus` failures (peer was recorded), clears local tracking via `forgetConnectedSegment()` instead of calling ADXL `Disconnect` again.
- Keeps Mooncake `disconnect()` for application-level async timeouts, short-connection mode, and deregister/cleanup paths where ADXL does not auto-disconnect.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

- `./scripts/code_format.sh -b upstream/main` — passed
- `./mooncake-transfer-engine/tests/ascend_direct_transport_test --gtest_filter='*AutoConnect*:*RetryAfterMetadataRefresh*'` — passed

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.