### PR TITLE
fix(maca): map cudaStreamQuery for the intra-node NVLink build

### DIFF
--- a/mooncake-transfer-engine/include/gpu_vendor/maca.h
+++ b/mooncake-transfer-engine/include/gpu_vendor/maca.h
@@ -133,6 +133,7 @@ static inline CUresult cuGetErrorString(CUresult error, const char **err_str) {
 #define cudaStreamDestroy mcStreamDestroy
 #define cudaStreamNonBlocking mcStreamNonBlocking
 #define cudaStreamPerThread mcStreamPerThread
+#define cudaStreamQuery mcStreamQuery
 #define cudaStreamSynchronize mcStreamSynchronize
 #define cudaStream_t mcStream_t
 #define cudaStreamWaitEvent mcStreamWaitEvent


### PR DESCRIPTION
## What

`gpu_vendor/maca.h` maps every CUDA stream/event symbol the intra-node NVLink transport touches except `cudaStreamQuery`. As a result a `USE_MACA` + `USE_INTRA_NVLINK` build fails to compile the async-completion polling loop in `intranode_nvlink_transport.cpp`.

The polling path added in #2012 calls:

```cpp
// intranode_nvlink_transport.cpp:411
cudaError_t cuda_err = cudaStreamQuery(stream);
if (cuda_err == cudaSuccess) {
    slice->markSuccess();
} else if (cuda_err != cudaErrorNotReady) {
    slice->markFailed();
}
```

`cuda_alike.h` selects `maca.h` for `USE_MACA`, and `transport/CMakeLists.txt` compiles `intranode_nvlink_transport` whenever `USE_INTRA_NVLINK` is set (orthogonal to the GPU vendor). `maca.h` already aliases `cudaErrorNotReady` (used on the very next line) and the rest of the stream/event surface for this file — `cudaStreamCreateWithFlags`, `cudaStreamPerThread`, `cudaStreamWaitEvent`, `cudaEventCreateWithFlags`, `cudaEventRecord`, etc. — but `cudaStreamQuery` was missed, so the MACA build sees an undeclared identifier.

This is the MACA counterpart of #2575, which added the same missing aliases to `musa.h` for this exact NVLink path.

## Fix

One line, following the existing `cudaStream* -> mcStream*` convention (and `cudaEventQuery -> mcEventQuery`, already present):

```c
#define cudaStreamQuery mcStreamQuery
```

## Verification

I don't have the MetaX SDK to run a full `USE_MACA` build locally, so I reproduced the failure at compile level with a small stub standing in for the MACA runtime, using maca.h's current alias set and the exact polling snippet:

```
repro.cpp: In function 'bool poll(void*)':
repro.cpp:5:28: error: 'cudaStreamQuery' was not declared in this scope; did you mean 'mcStreamQuery'?
    5 |     cudaError_t cuda_err = cudaStreamQuery(stream);
      |                            ^~~~~~~~~~~~~~~
      |                            mcStreamQuery
```

The compiler itself suggests `mcStreamQuery`. Adding the `#define` above makes the same translation unit compile cleanly. No behavior change for CUDA/MUSA/other vendors — this only fills a missing alias in the MACA shim.