### PR TITLE
fix(rdma): restore task.request association in submitTransfer

### DIFF
--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
@@ -506,7 +506,17 @@ Status RdmaTransport::submitTransfer(
     size_t task_id = batch_desc.task_list.size();
     batch_desc.task_list.resize(task_id + entries.size());
     std::vector<TransferTask *> task_list;
-    for (auto &task : batch_desc.task_list) task_list.push_back(&task);
+    for (auto &request : entries) {
+        auto &task = batch_desc.task_list[task_id];
+        ++task_id;
+        task.batch_id = batch_id;
+#ifdef USE_ASCEND_HETEROGENEOUS
+        task.request = const_cast<TransferRequest *>(&request);
+#else
+        task.request = &request;
+#endif
+        task_list.push_back(&task);
+    }
     return submitTransferTask(task_list);
 }
 


### PR DESCRIPTION
## Description

`RdmaTransport::submitTransfer(BatchID, entries)` stopped associating each task with its originating request, so the tasks it hands to `submitTransferTask()` carry a null `request` pointer.

In #772 this overload was simplified to delegate slice construction to `submitTransferTask()` instead of building slices inline. The inline loop used to read each `entries[i]` directly; the rewrite removed that loop but did not add the `task.request = &entries[i]` assignment that `submitTransferTask()` now depends on:

```cpp
// submitTransferTask(), per task:
assert(task.request);
auto &request = *task.request;   // null deref when request was never set
```

The leftover `task_id` variable in the current code (computed, then only used by `resize`) is what remains of that deleted per-entry loop.

This overload is not on the normal engine path — `MultiTransport::submitTransfer` sets `task.request` itself and calls `submitTransferTask` directly. It is reached through `HeterogeneousRdmaTransport::submitTransfer`, which forwards both the CPU-source fast path and the staged-host path to `transport_->submitTransfer(batch_id, entries)` (where `transport_` is a `std::unique_ptr<RdmaTransport>`). On that path every submitted task has `request == nullptr`: an assertion failure in debug builds, and a null-pointer dereference (`request.length`, `request.source`, …) in release builds.

The fix repopulates `batch_id` and `request` for each newly created task before delegating, mirroring what `MultiTransport::submitTransfer` does (including the `USE_ASCEND_HETEROGENEOUS` const handling, since `TransferTask::request` is non-const in that build) and what `TcpTransport::submitTransfer` does inline. As a side effect it also stops re-submitting pre-existing tasks in the batch, since it now iterates the new entries rather than the whole `task_list`.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

I have not been able to exercise this path at runtime: the only caller is `HeterogeneousRdmaTransport`, which is built under `USE_ASCEND_HETEROGENEOUS` and needs Ascend NPU hardware, and `RdmaTransport` itself needs an RDMA-capable NIC to instantiate. There is no hardware-free unit harness for it in the tree.

So this is verified by code inspection rather than execution:

- the regression is visible in the #772 diff (the per-entry `request` consumption was removed without a replacement assignment);
- `submitTransferTask()` unconditionally requires `task.request`;
- the corrected loop matches the proven `MultiTransport::submitTransfer` / `TcpTransport::submitTransfer` siblings;
- the change compiles in the standard (non-Ascend) build that CI covers.

I'd appreciate a check from someone with the Ascend heterogeneous setup to confirm the runtime path end to end.

**Test results:**
- [ ] Unit tests pass