### PR TITLE
[Store] Add RedisHelper for standalone Redis leader election

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,15 @@ jobs:
         etcdctl --endpoints=http://127.0.0.1:2379 endpoint health
       shell: bash
 
+    - name: Install and start Redis
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install -y redis-server
+        redis-server --port 6379 --daemonize yes
+        sleep 2
+        redis-cli ping
+      shell: bash
+
     - name: Free up disk space
       run: |
         sudo rm -rf /usr/share/dotnet
@@ -87,7 +96,7 @@ jobs:
         sudo bash -x dependencies.sh -y
         mkdir build
         cd build
-        cmake -G Ninja .. -DUSE_HTTP=ON -DUSE_CXL=ON -DUSE_ETCD=ON -DSTORE_USE_ETCD=ON -DENABLE_ASAN=ON -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Debug
+        cmake -G Ninja .. -DUSE_HTTP=ON -DUSE_CXL=ON -DUSE_ETCD=ON -DSTORE_USE_ETCD=ON -DSTORE_USE_REDIS=ON -DENABLE_ASAN=ON -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Debug
       shell: bash
 
     - name: Build project

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,11 @@ if (STORE_USE_ETCD)
   add_compile_definitions(STORE_USE_ETCD)
 endif()
 
+option(STORE_USE_REDIS "build mooncake store with redis" OFF)
+if (STORE_USE_REDIS)
+  add_compile_definitions(STORE_USE_REDIS)
+endif()
+
 option(STORE_USE_JEMALLOC "Use jemalloc in mooncake store master" OFF)
 option(USE_ASCEND_CACHE_TIER "Enable Ascend NPU cache tier support" OFF)
 option(USE_ASCEND_DRAM_TIER "Enable Ascend ACL Host memory for DRAM tier (aclrtMallocHost)" OFF)

--- a/mooncake-store/include/redis_helper.h
+++ b/mooncake-store/include/redis_helper.h
@@ -75,6 +75,21 @@ class RedisHelper {
     ErrorCode GetMasterView(std::string& master_address,
                             ViewVersionId& version);
 
+    // === Serialization (public for testability) ===
+
+    /**
+     * @brief Serialize leader value as JSON.
+     */
+    static std::string SerializeLeaderValue(const std::string& address,
+                                            ViewVersionId epoch, int ttl_sec);
+
+    /**
+     * @brief Parse leader value from JSON. Returns false on parse failure.
+     */
+    static bool ParseLeaderValue(const std::string& json,
+                                 std::string& out_address,
+                                 ViewVersionId& out_epoch);
+
    private:
     // === Internal helpers ===
 
@@ -109,19 +124,6 @@ class RedisHelper {
      *        Used internally by Connect and for the polling connection.
      */
     redisContext* CreateConnection();
-
-    /**
-     * @brief Serialize leader value as JSON.
-     */
-    static std::string SerializeLeaderValue(const std::string& address,
-                                            ViewVersionId epoch, int ttl_sec);
-
-    /**
-     * @brief Parse leader value from JSON. Returns false on parse failure.
-     */
-    static bool ParseLeaderValue(const std::string& json,
-                                 std::string& out_address,
-                                 ViewVersionId& out_epoch);
 
     // === Redis key naming ===
 

--- a/mooncake-store/include/redis_helper.h
+++ b/mooncake-store/include/redis_helper.h
@@ -108,6 +108,20 @@ class RedisHelper {
     void WatchLeader();
 
     /**
+     * @brief Fast-path watch: SUBSCRIBE to leader event channel, with a
+     *        polling thread as backup. Returns true if subscribe succeeded
+     *        and the watch completed, false if subscribe failed (caller
+     *        should fall back to pure polling).
+     */
+    bool WatchLeaderSubscribe();
+
+    /**
+     * @brief Slow-path watch: pure polling via a separate connection.
+     *        Blocks until the leader key expires or cancel is requested.
+     */
+    void WatchLeaderPolling();
+
+    /**
      * @brief Publish a leader event on the notification channel.
      *        Caller must hold election_mutex_.
      */
@@ -124,6 +138,14 @@ class RedisHelper {
      *        Used internally by Connect and for the polling connection.
      */
     redisContext* CreateConnection();
+
+    /**
+     * @brief Drain any pending replies from a subscribe context.
+     *        After UNSUBSCRIBE, buffered message frames may remain in the
+     *        socket. This function reads and discards them so that the next
+     *        SUBSCRIBE command receives a clean reply.
+     */
+    void DrainSubscribeContext();
 
     // === Redis key naming ===
 
@@ -154,7 +176,9 @@ class RedisHelper {
     std::string our_value_;  // JSON value we wrote, for Lua lease renewal
     std::string cluster_id_;
     std::atomic<bool> keep_alive_running_{false};
-    std::atomic<bool> cancel_requested_{false};
+    std::atomic<bool> cancel_keep_alive_{false};  // Cancel KeepLeader only
+    std::atomic<bool> cancel_election_{
+        false};  // Cancel ElectLeader/WatchLeader
     std::atomic<int> next_lease_id_{
         1};  // Local monotonic counter for lease IDs
 };

--- a/mooncake-store/include/redis_helper.h
+++ b/mooncake-store/include/redis_helper.h
@@ -1,0 +1,162 @@
+#pragma once
+
+#ifdef STORE_USE_REDIS
+
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <thread>
+
+#include <hiredis/hiredis.h>
+#include "types.h"
+
+namespace mooncake {
+
+/**
+ * @brief Redis helper for leader election, mirroring EtcdHelper's role.
+ *
+ * Uses SET NX EX for atomic election, Lua scripts for lease renewal,
+ * and Pub/Sub + fallback polling for watching leader key expiration.
+ *
+ * Only uses standard Redis commands + Lua scripts.
+ *
+ * Thread safety: election_ctx_ is shared between KeepLeader (background
+ * thread) and GetMasterView (called from any thread). All accesses to
+ * election_ctx_ are serialized via election_mutex_. The subscribe and
+ * polling connections are used only from single threads and do not need
+ * mutual exclusion.
+ */
+class RedisHelper {
+   public:
+    RedisHelper(const std::string& cluster_id,
+                const std::string& redis_endpoint,
+                const std::string& password = "", int db_index = 0,
+                int ttl_sec = 5, int heartbeat_interval_sec = 2);
+    ~RedisHelper();
+
+    RedisHelper(const RedisHelper&) = delete;
+    RedisHelper& operator=(const RedisHelper&) = delete;
+
+    /**
+     * @brief Connect to Redis. Must be called before ElectLeader.
+     * @return ErrorCode::OK on success.
+     */
+    ErrorCode Connect();
+
+    /**
+     * @brief Elect self as leader. Blocks until this node wins election.
+     *        Same semantics as MasterViewHelper::ElectLeader.
+     * @param master_address The address to register as leader.
+     * @param version Output: epoch (monotonic version) from INCR.
+     * @param lease_id Output: opaque lease identifier (local counter).
+     */
+    void ElectLeader(const std::string& master_address, ViewVersionId& version,
+                     int& lease_id);
+
+    /**
+     * @brief Keep leadership by periodically renewing TTL. Blocks until
+     *        leadership is lost (key no longer ours, or connection error).
+     * @param lease_id The lease ID returned by ElectLeader.
+     */
+    void KeepLeader(int lease_id);
+
+    /**
+     * @brief Cancel the keep-alive loop. For graceful shutdown.
+     */
+    void CancelKeepAlive();
+
+    /**
+     * @brief Get current leader's address and version from Redis.
+     * @param master_address Output: leader address.
+     * @param version Output: leader epoch.
+     * @return ErrorCode::OK on success, error if key not found or Redis error.
+     */
+    ErrorCode GetMasterView(std::string& master_address,
+                            ViewVersionId& version);
+
+   private:
+    // === Internal helpers ===
+
+    /**
+     * @brief Try to elect self once. Returns true if we won.
+     *        Caller must hold election_mutex_.
+     */
+    bool TryElectOnce(const std::string& master_address,
+                      ViewVersionId& out_epoch);
+
+    /**
+     * @brief Watch leader key until it expires (replaces etcd
+     * WatchUntilDeleted). Uses SUBSCRIBE for fast notification + fallback
+     * polling.
+     */
+    void WatchLeader();
+
+    /**
+     * @brief Publish a leader event on the notification channel.
+     *        Caller must hold election_mutex_.
+     */
+    void PublishLeaderEvent(const std::string& event);
+
+    /**
+     * @brief Reconnect a broken redisContext.
+     *        Caller must hold election_mutex_ if reconnecting election_ctx_.
+     */
+    bool Reconnect(redisContext*& ctx);
+
+    /**
+     * @brief Create a new authenticated connection to Redis.
+     *        Used internally by Connect and for the polling connection.
+     */
+    redisContext* CreateConnection();
+
+    /**
+     * @brief Serialize leader value as JSON.
+     */
+    static std::string SerializeLeaderValue(const std::string& address,
+                                            ViewVersionId epoch, int ttl_sec);
+
+    /**
+     * @brief Parse leader value from JSON. Returns false on parse failure.
+     */
+    static bool ParseLeaderValue(const std::string& json,
+                                 std::string& out_address,
+                                 ViewVersionId& out_epoch);
+
+    // === Redis key naming ===
+
+    std::string master_view_key_;       // mooncake:{cid}:master_view
+    std::string master_epoch_key_;      // mooncake:{cid}:master_epoch
+    std::string leader_event_channel_;  // mooncake:{cid}:leader_event
+
+    // === Connection state ===
+
+    std::string redis_endpoint_;
+    std::string password_;
+    int db_index_;
+    redisContext* election_ctx_ =
+        nullptr;  // For election + keepalive + GetMasterView
+    redisContext* subscribe_ctx_ =
+        nullptr;  // Dedicated connection for SUBSCRIBE (single-threaded)
+    mutable std::mutex election_mutex_;  // Protects election_ctx_ access
+
+    // === Configuration ===
+
+    int ttl_sec_ = 5;                 // redis_master_view_ttl_sec
+    int heartbeat_interval_sec_ = 2;  // TTL/3, rounded up
+    int connect_timeout_ms_ = 5000;
+    int command_timeout_ms_ = 3000;
+
+    // === Runtime state ===
+
+    std::string our_value_;  // JSON value we wrote, for Lua lease renewal
+    std::string cluster_id_;
+    std::atomic<bool> keep_alive_running_{false};
+    std::atomic<bool> cancel_requested_{false};
+    std::atomic<int> next_lease_id_{
+        1};  // Local monotonic counter for lease IDs
+};
+
+}  // namespace mooncake
+
+#endif  // STORE_USE_REDIS

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -81,6 +81,15 @@ set(MOONCAKE_STORE_SOURCES
 
 set(EXTRA_LIBS "")
 
+# Find hiredis for Redis election backend
+if(STORE_USE_REDIS)
+    find_path(HIREDIS_INCLUDE_DIR NAMES hiredis/hiredis.h REQUIRED)
+    find_library(HIREDIS_LIB NAMES hiredis REQUIRED)
+    message(STATUS "Found hiredis: include=${HIREDIS_INCLUDE_DIR} lib=${HIREDIS_LIB}")
+    list(APPEND MOONCAKE_STORE_SOURCES redis_helper.cpp)
+    list(APPEND EXTRA_LIBS ${HIREDIS_LIB})
+endif()
+
 # Find xxHash (required for ComputeChecksum)
 find_path(
   XXHASH_INCLUDE_DIR
@@ -129,6 +138,10 @@ add_library(mooncake_store ${MOONCAKE_STORE_SOURCES})
 # to targets that don't need it (e.g., mooncake_master).
 # Targets that need transfer_engine should link it explicitly.
 target_include_directories(mooncake_store PUBLIC ${XXHASH_INCLUDE_DIR})
+if(STORE_USE_REDIS)
+    target_include_directories(mooncake_store PUBLIC ${HIREDIS_INCLUDE_DIR})
+    target_compile_definitions(mooncake_store PUBLIC STORE_USE_REDIS)
+endif()
 target_link_libraries(mooncake_store
     PUBLIC
         cachelib_memory_allocator

--- a/mooncake-store/src/redis_helper.cpp
+++ b/mooncake-store/src/redis_helper.cpp
@@ -1,0 +1,616 @@
+#ifdef STORE_USE_REDIS
+
+#include "redis_helper.h"
+
+#include <glog/logging.h>
+
+#include <chrono>
+#include <cstring>
+#include <json/json.h>
+
+namespace mooncake {
+
+// ============================================================
+// Construction / Destruction
+// ============================================================
+
+RedisHelper::RedisHelper(const std::string& cluster_id,
+                         const std::string& redis_endpoint,
+                         const std::string& password, int db_index, int ttl_sec,
+                         int heartbeat_interval_sec)
+    : redis_endpoint_(redis_endpoint),
+      password_(password),
+      db_index_(db_index),
+      ttl_sec_(ttl_sec),
+      heartbeat_interval_sec_(heartbeat_interval_sec),
+      cluster_id_(cluster_id) {
+    std::string cid = cluster_id;
+    if (!cid.empty() && cid.back() != '/') {
+        cid += '/';
+    }
+    // Use {cid} with braces as hash tag for Redis cluster slot affinity
+    master_view_key_ = "mooncake:{" + cid + "}master_view";
+    master_epoch_key_ = "mooncake:{" + cid + "}master_epoch";
+    leader_event_channel_ = "mooncake:" + cid + "leader_event";
+    LOG(INFO) << "RedisHelper created, master_view_key=" << master_view_key_
+              << " epoch_key=" << master_epoch_key_
+              << " channel=" << leader_event_channel_ << " ttl=" << ttl_sec_
+              << "s"
+              << " heartbeat=" << heartbeat_interval_sec_ << "s";
+}
+
+RedisHelper::~RedisHelper() {
+    CancelKeepAlive();
+    if (subscribe_ctx_) {
+        redisFree(subscribe_ctx_);
+        subscribe_ctx_ = nullptr;
+    }
+    {
+        std::lock_guard<std::mutex> lock(election_mutex_);
+        if (election_ctx_) {
+            redisFree(election_ctx_);
+            election_ctx_ = nullptr;
+        }
+    }
+}
+
+// ============================================================
+// CreateConnection — common logic for Connect / polling
+// ============================================================
+
+redisContext* RedisHelper::CreateConnection() {
+    std::string host = "127.0.0.1";
+    int port = 6379;
+    auto colon_pos = redis_endpoint_.rfind(':');
+    if (colon_pos != std::string::npos) {
+        host = redis_endpoint_.substr(0, colon_pos);
+        try {
+            port = std::stoi(redis_endpoint_.substr(colon_pos + 1));
+        } catch (const std::exception& e) {
+            LOG(ERROR) << "Invalid Redis endpoint port: " << redis_endpoint_;
+            return nullptr;
+        }
+    } else if (!redis_endpoint_.empty()) {
+        host = redis_endpoint_;
+    }
+
+    struct timeval tv;
+    tv.tv_sec = connect_timeout_ms_ / 1000;
+    tv.tv_usec = (connect_timeout_ms_ % 1000) * 1000;
+
+    redisContext* ctx = redisConnectWithTimeout(host.c_str(), port, tv);
+    if (!ctx || ctx->err) {
+        LOG(ERROR) << "Failed to connect to Redis at " << host << ":" << port
+                   << " err=" << (ctx ? ctx->errstr : "null");
+        if (ctx) {
+            redisFree(ctx);
+        }
+        return nullptr;
+    }
+    redisSetTimeout(ctx, tv);
+
+    // Authenticate if password provided
+    if (!password_.empty()) {
+        redisReply* reply = (redisReply*)redisCommand(
+            ctx, "AUTH %b", password_.data(), password_.size());
+        if (!reply || reply->type == REDIS_REPLY_ERROR) {
+            LOG(ERROR) << "Redis AUTH failed";
+            if (reply) freeReplyObject(reply);
+            redisFree(ctx);
+            return nullptr;
+        }
+        freeReplyObject(reply);
+    }
+
+    // Select DB if not default
+    if (db_index_ != 0) {
+        redisReply* reply =
+            (redisReply*)redisCommand(ctx, "SELECT %d", db_index_);
+        if (!reply || reply->type == REDIS_REPLY_ERROR) {
+            LOG(ERROR) << "Redis SELECT " << db_index_ << " failed";
+            if (reply) freeReplyObject(reply);
+            redisFree(ctx);
+            return nullptr;
+        }
+        freeReplyObject(reply);
+    }
+
+    return ctx;
+}
+
+// ============================================================
+// Connect
+// ============================================================
+
+ErrorCode RedisHelper::Connect() {
+    // Election connection
+    {
+        std::lock_guard<std::mutex> lock(election_mutex_);
+        if (election_ctx_) {
+            redisFree(election_ctx_);
+            election_ctx_ = nullptr;
+        }
+        election_ctx_ = CreateConnection();
+        if (!election_ctx_) {
+            return ErrorCode::INTERNAL_ERROR;
+        }
+    }
+
+    // Subscribe connection (separate, as SUBSCRIBE blocks).
+    // Set a 1-second read timeout so that redisGetReply in WatchLeader's
+    // subscribe loop returns periodically, allowing the loop to check
+    // notified / cancel_requested_ flags even when no Pub/Sub message
+    // arrives (e.g. leader key expired without graceful handoff).
+    if (subscribe_ctx_) {
+        redisFree(subscribe_ctx_);
+        subscribe_ctx_ = nullptr;
+    }
+    subscribe_ctx_ = CreateConnection();
+    if (subscribe_ctx_) {
+        struct timeval sub_timeout = {1, 0};  // 1 second
+        redisSetTimeout(subscribe_ctx_, sub_timeout);
+    } else {
+        // Non-fatal: WatchLeader will fall back to polling
+        LOG(ERROR) << "Failed to create subscribe connection to Redis";
+    }
+
+    LOG(INFO) << "Connected to Redis";
+    return ErrorCode::OK;
+}
+
+// ============================================================
+// ElectLeader — blocks until this node wins election
+// ============================================================
+
+void RedisHelper::ElectLeader(const std::string& master_address,
+                              ViewVersionId& version, int& lease_id) {
+    while (true) {
+        {
+            std::lock_guard<std::mutex> lock(election_mutex_);
+            if (!election_ctx_) {
+                election_ctx_ = CreateConnection();
+                if (!election_ctx_) {
+                    LOG(ERROR) << "ElectLeader: connect failed, retry in 1s";
+                }
+            }
+        }
+        if (!election_ctx_) {
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+            continue;
+        }
+
+        // Step 1: Check if a leader already exists
+        redisReply* reply = nullptr;
+        {
+            std::lock_guard<std::mutex> lock(election_mutex_);
+            reply = (redisReply*)redisCommand(election_ctx_, "GET %b",
+                                              master_view_key_.data(),
+                                              master_view_key_.size());
+        }
+
+        if (!reply) {
+            LOG(ERROR)
+                << "ElectLeader: GET failed (connection error), retry in 1s";
+            {
+                std::lock_guard<std::mutex> lock(election_mutex_);
+                Reconnect(election_ctx_);
+            }
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+            continue;
+        }
+
+        if (reply->type == REDIS_REPLY_NIL) {
+            // No leader exists — try to elect ourselves
+            freeReplyObject(reply);
+
+            bool elected = false;
+            {
+                std::lock_guard<std::mutex> lock(election_mutex_);
+                elected = TryElectOnce(master_address, version);
+            }
+            if (elected) {
+                lease_id = next_lease_id_++;
+                LOG(INFO) << "ElectLeader: elected as leader, epoch=" << version
+                          << " lease_id=" << lease_id;
+                return;
+            }
+            // TryElectOnce failed (someone else won) — loop back and wait
+            continue;
+        }
+
+        if (reply->type == REDIS_REPLY_STRING) {
+            // A leader exists — watch until the key expires
+            std::string current_value(reply->str, reply->len);
+            freeReplyObject(reply);
+
+            std::string current_addr;
+            ViewVersionId current_epoch = 0;
+            if (ParseLeaderValue(current_value, current_addr, current_epoch)) {
+                LOG(INFO) << "ElectLeader: current leader=" << current_addr
+                          << " epoch=" << current_epoch << ", waiting...";
+            } else {
+                LOG(INFO) << "ElectLeader: leader key exists but unparsable, "
+                             "waiting...";
+            }
+
+            WatchLeader();  // Blocks until key expires or "vacant" received
+            continue;
+        }
+
+        // Unexpected reply type
+        freeReplyObject(reply);
+        LOG(ERROR) << "ElectLeader: unexpected reply type=" << reply->type;
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+}
+
+bool RedisHelper::TryElectOnce(const std::string& master_address,
+                               ViewVersionId& out_epoch) {
+    // Caller must hold election_mutex_
+    // Step 2: INCR epoch counter
+    redisReply* reply = (redisReply*)redisCommand(election_ctx_, "INCR %b",
+                                                  master_epoch_key_.data(),
+                                                  master_epoch_key_.size());
+
+    if (!reply || reply->type != REDIS_REPLY_INTEGER) {
+        LOG(ERROR) << "TryElectOnce: INCR failed";
+        if (reply) freeReplyObject(reply);
+        return false;
+    }
+    out_epoch = reply->integer;
+    freeReplyObject(reply);
+
+    // Step 3: SET NX EX — atomically create leader key only if it doesn't exist
+    std::string value =
+        SerializeLeaderValue(master_address, out_epoch, ttl_sec_);
+    our_value_ = value;
+
+    reply = (redisReply*)redisCommand(
+        election_ctx_, "SET %b %b EX %d NX", master_view_key_.data(),
+        master_view_key_.size(), value.data(), value.size(), ttl_sec_);
+
+    if (!reply) {
+        LOG(ERROR) << "TryElectOnce: SET NX EX failed (connection error)";
+        our_value_.clear();
+        return false;
+    }
+
+    if (reply->type == REDIS_REPLY_STATUS &&
+        strncmp(reply->str, "OK", 2) == 0) {
+        // We won the election!
+        freeReplyObject(reply);
+
+        // Publish election event
+        std::string event =
+            "elected:" + master_address + ":" + std::to_string(out_epoch);
+        PublishLeaderEvent(event);
+
+        return true;
+    }
+
+    // Key already exists — someone else won
+    freeReplyObject(reply);
+    our_value_.clear();
+    LOG(INFO) << "TryElectOnce: someone else won the election, retrying";
+    return false;
+}
+
+// ============================================================
+// WatchLeader — wait until leader key expires
+// ============================================================
+
+void RedisHelper::WatchLeader() {
+    // Fast path: SUBSCRIBE for leader event notification
+    if (subscribe_ctx_) {
+        redisReply* reply = (redisReply*)redisCommand(
+            subscribe_ctx_, "SUBSCRIBE %b", leader_event_channel_.data(),
+            leader_event_channel_.size());
+
+        if (reply && reply->type == REDIS_REPLY_ARRAY && reply->elements >= 3 &&
+            reply->element[0]->type == REDIS_REPLY_STRING &&
+            strncmp(reply->element[0]->str, "subscribe", 9) == 0) {
+            freeReplyObject(reply);
+
+            std::atomic<bool> notified{false};
+            redisContext* polling_ctx = CreateConnection();
+
+            // Polling thread: check if key still exists periodically.
+            // The subscribe_ctx_ has a 1-second timeout set in Connect(),
+            // so redisGetReply returns at least once per second regardless
+            // of whether a Pub/Sub message arrives, allowing the subscribe
+            // loop to check notified/cancel_requested_ flags.
+            std::thread polling_thread([this, &notified, polling_ctx]() {
+                auto interval = std::chrono::seconds(ttl_sec_);
+                while (!notified && !cancel_requested_) {
+                    std::this_thread::sleep_for(interval);
+                    if (notified || cancel_requested_) break;
+
+                    if (polling_ctx) {
+                        redisReply* r = (redisReply*)redisCommand(
+                            polling_ctx, "GET %b", master_view_key_.data(),
+                            master_view_key_.size());
+                        if (r) {
+                            if (r->type == REDIS_REPLY_NIL) {
+                                notified = true;
+                            }
+                            freeReplyObject(r);
+                        }
+                    }
+                }
+            });
+
+            // Subscribe loop: read messages until "vacant" or key gone.
+            // redisGetReply returns at least every 1s (subscribe_ctx_ timeout)
+            // so the loop can check notified/cancel_requested_ promptly.
+            while (!notified && !cancel_requested_) {
+                redisReply* msg = nullptr;
+                if (redisGetReply(subscribe_ctx_, (void**)&msg) != REDIS_OK) {
+                    // Timeout or connection error — re-check flags and retry
+                    continue;
+                }
+
+                if (msg) {
+                    if (msg->type == REDIS_REPLY_ARRAY && msg->elements >= 3) {
+                        if (msg->element[0]->type == REDIS_REPLY_STRING &&
+                            strncmp(msg->element[0]->str, "message", 7) == 0) {
+                            notified = true;
+                        }
+                    }
+                    freeReplyObject(msg);
+                }
+            }
+
+            notified = true;  // Signal polling thread to stop
+            polling_thread.join();
+
+            // Clean up polling connection
+            if (polling_ctx) {
+                redisFree(polling_ctx);
+            }
+
+            // Unsubscribe to restore connection state
+            redisReply* unsub = (redisReply*)redisCommand(
+                subscribe_ctx_, "UNSUBSCRIBE %b", leader_event_channel_.data(),
+                leader_event_channel_.size());
+            if (unsub) freeReplyObject(unsub);
+
+            return;
+        }
+        if (reply) freeReplyObject(reply);
+        // Subscribe failed — fall through to pure polling
+    }
+
+    // Slow path (fallback): pure polling — use a separate connection
+    LOG(INFO) << "WatchLeader: using polling fallback (interval=" << ttl_sec_
+              << "s)";
+    redisContext* polling_ctx = CreateConnection();
+    auto interval = std::chrono::seconds(ttl_sec_);
+    while (!cancel_requested_) {
+        std::this_thread::sleep_for(interval);
+
+        if (!polling_ctx) {
+            // Connection was never established or previously lost — retry
+            polling_ctx = CreateConnection();
+            continue;
+        }
+
+        redisReply* reply = (redisReply*)redisCommand(polling_ctx, "GET %b",
+                                                      master_view_key_.data(),
+                                                      master_view_key_.size());
+        if (reply) {
+            if (reply->type == REDIS_REPLY_NIL) {
+                freeReplyObject(reply);
+                redisFree(polling_ctx);
+                return;  // Key expired
+            }
+            freeReplyObject(reply);
+        } else {
+            // Connection error — reconnect
+            redisFree(polling_ctx);
+            polling_ctx = nullptr;  // Will retry CreateConnection next loop
+        }
+    }
+    if (polling_ctx) redisFree(polling_ctx);
+}
+
+// ============================================================
+// KeepLeader — renew TTL via Lua script, block until lost
+// ============================================================
+
+void RedisHelper::KeepLeader(int lease_id) {
+    keep_alive_running_ = true;
+    cancel_requested_ = false;
+
+    // Lua script: atomically check ownership and renew TTL
+    // KEYS[1] = master_view_key
+    // ARGV[1] = TTL seconds
+    // ARGV[2] = our value (the JSON we wrote)
+    const char* renewal_script =
+        "local val = redis.call('GET', KEYS[1]) "
+        "if val == ARGV[2] then "
+        "  redis.call('EXPIRE', KEYS[1], ARGV[1]) "
+        "  return 1 "
+        "else "
+        "  return 0 "
+        "end";
+
+    LOG(INFO) << "KeepLeader: starting renewal loop (interval="
+              << heartbeat_interval_sec_ << "s)";
+
+    while (keep_alive_running_ && !cancel_requested_) {
+        bool renewed = false;
+        {
+            std::lock_guard<std::mutex> lock(election_mutex_);
+            // Execute Lua renewal script
+            redisReply* reply = (redisReply*)redisCommand(
+                election_ctx_, "EVAL %s 1 %b %d %b", renewal_script,
+                master_view_key_.data(), master_view_key_.size(), ttl_sec_,
+                our_value_.data(), our_value_.size());
+
+            if (!reply) {
+                LOG(ERROR)
+                    << "KeepLeader: Lua renewal failed (connection error)";
+                if (Reconnect(election_ctx_)) {
+                    // Reconnected — check if we still own the key
+                    redisReply* check = (redisReply*)redisCommand(
+                        election_ctx_, "GET %b", master_view_key_.data(),
+                        master_view_key_.size());
+                    if (check && check->type == REDIS_REPLY_STRING &&
+                        check->len == our_value_.size() &&
+                        memcmp(check->str, our_value_.data(),
+                               our_value_.size()) == 0) {
+                        // Still ours — continue renewing
+                        freeReplyObject(check);
+                        renewed = true;
+                    } else {
+                        // Not ours anymore
+                        if (check) freeReplyObject(check);
+                    }
+                }
+            } else if (reply->type == REDIS_REPLY_INTEGER &&
+                       reply->integer == 1) {
+                // Renewal succeeded
+                freeReplyObject(reply);
+                renewed = true;
+            } else {
+                // Key no longer ours
+                freeReplyObject(reply);
+                LOG(WARNING)
+                    << "KeepLeader: lost leadership (key no longer ours)";
+            }
+        }
+
+        if (!renewed) {
+            break;  // Lost leadership
+        }
+
+        std::this_thread::sleep_for(
+            std::chrono::seconds(heartbeat_interval_sec_));
+    }
+
+    keep_alive_running_ = false;
+    LOG(INFO) << "KeepLeader: exited renewal loop";
+}
+
+void RedisHelper::CancelKeepAlive() {
+    cancel_requested_ = true;
+    keep_alive_running_ = false;
+    // subscribe_ctx_ has a 1-second timeout, so WatchLeader's subscribe
+    // loop will check cancel_requested_ within 1 second.
+}
+
+// ============================================================
+// GetMasterView
+// ============================================================
+
+ErrorCode RedisHelper::GetMasterView(std::string& master_address,
+                                     ViewVersionId& version) {
+    std::lock_guard<std::mutex> lock(election_mutex_);
+    if (!election_ctx_) {
+        return ErrorCode::INTERNAL_ERROR;
+    }
+
+    redisReply* reply = (redisReply*)redisCommand(election_ctx_, "GET %b",
+                                                  master_view_key_.data(),
+                                                  master_view_key_.size());
+
+    if (!reply) {
+        return ErrorCode::INTERNAL_ERROR;
+    }
+
+    if (reply->type == REDIS_REPLY_NIL) {
+        freeReplyObject(reply);
+        return ErrorCode::INTERNAL_ERROR;  // No leader
+    }
+
+    if (reply->type == REDIS_REPLY_STRING) {
+        std::string value(reply->str, reply->len);
+        freeReplyObject(reply);
+        if (ParseLeaderValue(value, master_address, version)) {
+            return ErrorCode::OK;
+        }
+        return ErrorCode::INTERNAL_ERROR;
+    }
+
+    freeReplyObject(reply);
+    return ErrorCode::INTERNAL_ERROR;
+}
+
+// ============================================================
+// Internal helpers
+// ============================================================
+
+void RedisHelper::PublishLeaderEvent(const std::string& event) {
+    // Caller must hold election_mutex_
+    if (!election_ctx_) return;
+    redisReply* reply = (redisReply*)redisCommand(
+        election_ctx_, "PUBLISH %b %b", leader_event_channel_.data(),
+        leader_event_channel_.size(), event.data(), event.size());
+    if (reply) freeReplyObject(reply);
+}
+
+bool RedisHelper::Reconnect(redisContext*& ctx) {
+    // Caller must hold election_mutex_ if reconnecting election_ctx_
+    if (ctx) {
+        redisFree(ctx);
+        ctx = nullptr;
+    }
+
+    ctx = CreateConnection();
+    if (!ctx) {
+        LOG(ERROR) << "Reconnect: failed to connect to Redis";
+        return false;
+    }
+
+    LOG(INFO) << "Reconnect: successfully reconnected to Redis";
+    return true;
+}
+
+// ============================================================
+// Serialization
+// ============================================================
+
+std::string RedisHelper::SerializeLeaderValue(const std::string& address,
+                                              ViewVersionId epoch,
+                                              int ttl_sec) {
+    Json::Value root;
+    root["address"] = address;
+    root["epoch"] = static_cast<Json::Int64>(epoch);
+    auto now = std::chrono::system_clock::now();
+    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                  now.time_since_epoch())
+                  .count();
+    root["ts"] = static_cast<Json::Int64>(ms);
+    root["ttl"] = ttl_sec;
+
+    Json::StreamWriterBuilder builder;
+    builder["commentStyle"] = "None";
+    builder["indentation"] = "";
+    return Json::writeString(builder, root);
+}
+
+bool RedisHelper::ParseLeaderValue(const std::string& json,
+                                   std::string& out_address,
+                                   ViewVersionId& out_epoch) {
+    Json::Value root;
+    Json::CharReaderBuilder builder;
+    std::istringstream stream(json);
+    std::string errors;
+    if (!Json::parseFromStream(builder, stream, &root, &errors)) {
+        LOG(ERROR) << "ParseLeaderValue: JSON parse failed: " << errors;
+        return false;
+    }
+
+    if (!root.isMember("address") || !root["address"].isString() ||
+        !root.isMember("epoch") || !root["epoch"].isInt64()) {
+        return false;
+    }
+
+    out_address = root["address"].asString();
+    out_epoch = root["epoch"].asInt64();
+    return true;
+}
+
+}  // namespace mooncake
+
+#endif  // STORE_USE_REDIS

--- a/mooncake-store/src/redis_helper.cpp
+++ b/mooncake-store/src/redis_helper.cpp
@@ -40,6 +40,7 @@ RedisHelper::RedisHelper(const std::string& cluster_id,
 }
 
 RedisHelper::~RedisHelper() {
+    cancel_election_ = true;
     CancelKeepAlive();
     if (subscribe_ctx_) {
         redisFree(subscribe_ctx_);
@@ -132,6 +133,9 @@ ErrorCode RedisHelper::Connect() {
         }
         election_ctx_ = CreateConnection();
         if (!election_ctx_) {
+            LOG(ERROR)
+                << "Connect: failed to create election connection to Redis at "
+                << redis_endpoint_;
             return ErrorCode::INTERNAL_ERROR;
         }
     }
@@ -139,8 +143,8 @@ ErrorCode RedisHelper::Connect() {
     // Subscribe connection (separate, as SUBSCRIBE blocks).
     // Set a 1-second read timeout so that redisGetReply in WatchLeader's
     // subscribe loop returns periodically, allowing the loop to check
-    // notified / cancel_requested_ flags even when no Pub/Sub message
-    // arrives (e.g. leader key expired without graceful handoff).
+    // cancel flags even when no Pub/Sub message arrives
+    // (e.g. leader key expired without graceful handoff).
     if (subscribe_ctx_) {
         redisFree(subscribe_ctx_);
         subscribe_ctx_ = nullptr;
@@ -150,8 +154,14 @@ ErrorCode RedisHelper::Connect() {
         struct timeval sub_timeout = {1, 0};  // 1 second
         redisSetTimeout(subscribe_ctx_, sub_timeout);
     } else {
-        // Non-fatal: WatchLeader will fall back to polling
-        LOG(ERROR) << "Failed to create subscribe connection to Redis";
+        // Non-fatal: WatchLeader will fall back to polling when
+        // subscribe_ctx_ is null. We intentionally do NOT retry
+        // here — reconnect is deferred to the next Connect() call
+        // (e.g. during a leadership re-election cycle), which is
+        // sufficient because the polling path provides a correct
+        // (if slower) fallback.
+        LOG(ERROR) << "Failed to create subscribe connection to Redis at "
+                   << redis_endpoint_;
     }
 
     LOG(INFO) << "Connected to Redis";
@@ -164,7 +174,8 @@ ErrorCode RedisHelper::Connect() {
 
 void RedisHelper::ElectLeader(const std::string& master_address,
                               ViewVersionId& version, int& lease_id) {
-    while (true) {
+    while (!cancel_election_) {
+        bool connected = false;
         {
             std::lock_guard<std::mutex> lock(election_mutex_);
             if (!election_ctx_) {
@@ -173,8 +184,9 @@ void RedisHelper::ElectLeader(const std::string& master_address,
                     LOG(ERROR) << "ElectLeader: connect failed, retry in 1s";
                 }
             }
+            connected = (election_ctx_ != nullptr);
         }
-        if (!election_ctx_) {
+        if (!connected) {
             std::this_thread::sleep_for(std::chrono::seconds(1));
             continue;
         }
@@ -229,8 +241,9 @@ void RedisHelper::ElectLeader(const std::string& master_address,
                 LOG(INFO) << "ElectLeader: current leader=" << current_addr
                           << " epoch=" << current_epoch << ", waiting...";
             } else {
-                LOG(INFO) << "ElectLeader: leader key exists but unparsable, "
-                             "waiting...";
+                LOG(WARNING)
+                    << "ElectLeader: leader key exists but unparsable: "
+                    << current_value << ", waiting...";
             }
 
             WatchLeader();  // Blocks until key expires or "vacant" received
@@ -238,8 +251,9 @@ void RedisHelper::ElectLeader(const std::string& master_address,
         }
 
         // Unexpected reply type
+        int reply_type = reply->type;
         freeReplyObject(reply);
-        LOG(ERROR) << "ElectLeader: unexpected reply type=" << reply->type;
+        LOG(ERROR) << "ElectLeader: unexpected reply type=" << reply_type;
         std::this_thread::sleep_for(std::chrono::seconds(1));
     }
 }
@@ -301,91 +315,156 @@ bool RedisHelper::TryElectOnce(const std::string& master_address,
 
 void RedisHelper::WatchLeader() {
     // Fast path: SUBSCRIBE for leader event notification
-    if (subscribe_ctx_) {
-        redisReply* reply = (redisReply*)redisCommand(
-            subscribe_ctx_, "SUBSCRIBE %b", leader_event_channel_.data(),
-            leader_event_channel_.size());
-
-        if (reply && reply->type == REDIS_REPLY_ARRAY && reply->elements >= 3 &&
-            reply->element[0]->type == REDIS_REPLY_STRING &&
-            strncmp(reply->element[0]->str, "subscribe", 9) == 0) {
-            freeReplyObject(reply);
-
-            std::atomic<bool> notified{false};
-            redisContext* polling_ctx = CreateConnection();
-
-            // Polling thread: check if key still exists periodically.
-            // The subscribe_ctx_ has a 1-second timeout set in Connect(),
-            // so redisGetReply returns at least once per second regardless
-            // of whether a Pub/Sub message arrives, allowing the subscribe
-            // loop to check notified/cancel_requested_ flags.
-            std::thread polling_thread([this, &notified, polling_ctx]() {
-                auto interval = std::chrono::seconds(ttl_sec_);
-                while (!notified && !cancel_requested_) {
-                    std::this_thread::sleep_for(interval);
-                    if (notified || cancel_requested_) break;
-
-                    if (polling_ctx) {
-                        redisReply* r = (redisReply*)redisCommand(
-                            polling_ctx, "GET %b", master_view_key_.data(),
-                            master_view_key_.size());
-                        if (r) {
-                            if (r->type == REDIS_REPLY_NIL) {
-                                notified = true;
-                            }
-                            freeReplyObject(r);
-                        }
-                    }
-                }
-            });
-
-            // Subscribe loop: read messages until "vacant" or key gone.
-            // redisGetReply returns at least every 1s (subscribe_ctx_ timeout)
-            // so the loop can check notified/cancel_requested_ promptly.
-            while (!notified && !cancel_requested_) {
-                redisReply* msg = nullptr;
-                if (redisGetReply(subscribe_ctx_, (void**)&msg) != REDIS_OK) {
-                    // Timeout or connection error — re-check flags and retry
-                    continue;
-                }
-
-                if (msg) {
-                    if (msg->type == REDIS_REPLY_ARRAY && msg->elements >= 3) {
-                        if (msg->element[0]->type == REDIS_REPLY_STRING &&
-                            strncmp(msg->element[0]->str, "message", 7) == 0) {
-                            notified = true;
-                        }
-                    }
-                    freeReplyObject(msg);
-                }
-            }
-
-            notified = true;  // Signal polling thread to stop
-            polling_thread.join();
-
-            // Clean up polling connection
-            if (polling_ctx) {
-                redisFree(polling_ctx);
-            }
-
-            // Unsubscribe to restore connection state
-            redisReply* unsub = (redisReply*)redisCommand(
-                subscribe_ctx_, "UNSUBSCRIBE %b", leader_event_channel_.data(),
-                leader_event_channel_.size());
-            if (unsub) freeReplyObject(unsub);
-
-            return;
-        }
-        if (reply) freeReplyObject(reply);
-        // Subscribe failed — fall through to pure polling
+    if (subscribe_ctx_ && WatchLeaderSubscribe()) {
+        return;
     }
 
     // Slow path (fallback): pure polling — use a separate connection
+    WatchLeaderPolling();
+}
+
+bool RedisHelper::WatchLeaderSubscribe() {
+    // Attempt SUBSCRIBE; return true if successful, false to fall back to
+    // polling.
+    if (!subscribe_ctx_) return false;
+
+    redisReply* reply = (redisReply*)redisCommand(
+        subscribe_ctx_, "SUBSCRIBE %b", leader_event_channel_.data(),
+        leader_event_channel_.size());
+
+    if (!reply || reply->type != REDIS_REPLY_ARRAY || reply->elements < 3 ||
+        reply->element[0]->type != REDIS_REPLY_STRING ||
+        strncmp(reply->element[0]->str, "subscribe", 9) != 0) {
+        if (reply) freeReplyObject(reply);
+        return false;  // Fall back to polling
+    }
+    freeReplyObject(reply);
+
+    std::atomic<bool> leader_lost{false};
+    redisContext* polling_ctx = CreateConnection();
+    if (!polling_ctx) {
+        LOG(WARNING) << "WatchLeaderSubscribe: failed to create polling "
+                        "connection; relying on subscribe loop only";
+    }
+
+    // Polling thread: check if key still exists periodically.
+    // The subscribe_ctx_ has a 1-second timeout set in Connect(),
+    // so redisGetReply returns at least once per second regardless
+    // of whether a Pub/Sub message arrives, allowing the subscribe
+    // loop to check leader_lost/cancel_election_ flags.
+    // Only create the polling thread if we have a valid connection.
+    std::thread polling_thread;
+    if (polling_ctx) {
+        polling_thread = std::thread([this, &leader_lost, polling_ctx]() {
+            auto interval = std::chrono::seconds(ttl_sec_);
+            while (!leader_lost && !cancel_election_) {
+                std::this_thread::sleep_for(interval);
+                if (leader_lost || cancel_election_) break;
+
+                redisReply* r = (redisReply*)redisCommand(
+                    polling_ctx, "GET %b", master_view_key_.data(),
+                    master_view_key_.size());
+                if (!r) {
+                    LOG(WARNING)
+                        << "WatchLeaderSubscribe: polling GET failed "
+                           "(connection error), exiting polling thread";
+                    break;
+                }
+                if (r->type == REDIS_REPLY_NIL) {
+                    leader_lost = true;
+                }
+                freeReplyObject(r);
+            }
+        });
+    }
+
+    // Subscribe loop: read messages until leader vacancy is detected.
+    // redisGetReply returns at least every 1s (subscribe_ctx_ timeout)
+    // so the loop can check leader_lost/cancel_election_ promptly.
+    int subscribe_errors = 0;
+    while (!leader_lost && !cancel_election_) {
+        redisReply* msg = nullptr;
+        if (redisGetReply(subscribe_ctx_, (void**)&msg) != REDIS_OK) {
+            // redisGetReply returns REDIS_ERR for both read timeouts
+            // (benign — the 1s timeout we set on subscribe_ctx_) and
+            // real connection errors. We cannot reliably distinguish
+            // them purely from subscribe_ctx_->err because Hiredis sets
+            // err=REDIS_ERR_IO even on timeout. Instead, clear the
+            // error state on the context and only treat persistent
+            // failures (3 consecutive errors without a successful read
+            // between them) as a broken connection.
+            if (subscribe_ctx_ && subscribe_ctx_->err != 0) {
+                subscribe_errors++;
+                LOG(WARNING) << "WatchLeaderSubscribe: subscribe connection "
+                             << "error (" << subscribe_errors
+                             << "): err=" << subscribe_ctx_->errstr;
+                // Clear error state so the next redisGetReply can retry.
+                // For timeouts, this allows normal operation to resume.
+                // For real connection errors, the next call will fail
+                // again and increment subscribe_errors.
+                subscribe_ctx_->err = 0;
+                subscribe_ctx_->errstr[0] = '\0';
+                if (subscribe_errors >= 3) {
+                    LOG(ERROR) << "WatchLeaderSubscribe: subscribe connection "
+                               << "unhealthy after 3 consecutive errors, "
+                               << "giving up";
+                    break;
+                }
+            }
+            // Timeout or cleared transient error — re-check flags
+            continue;
+        }
+        subscribe_errors = 0;  // Reset on successful read
+
+        if (msg) {
+            if (msg->type == REDIS_REPLY_ARRAY && msg->elements >= 3) {
+                if (msg->element[0]->type == REDIS_REPLY_STRING &&
+                    strncmp(msg->element[0]->str, "message", 7) == 0) {
+                    leader_lost = true;
+                }
+            }
+            freeReplyObject(msg);
+        }
+    }
+
+    // If the loop exited without leader_lost or cancel_election_, the
+    // subscribe connection is broken — fall back to pure polling.
+    const bool subscribe_failed = !leader_lost && !cancel_election_;
+    leader_lost = true;  // Signal polling thread to stop
+    if (polling_thread.joinable()) {
+        polling_thread.join();
+    }
+
+    // Clean up polling connection
+    if (polling_ctx) {
+        redisFree(polling_ctx);
+    }
+
+    if (subscribe_failed) {
+        // Subscribe connection is broken — skip UNSUBSCRIBE (it would fail
+        // anyway) and let WatchLeader fall back to pure polling.
+        return false;
+    }
+
+    // Unsubscribe to restore connection state
+    redisReply* unsub = (redisReply*)redisCommand(
+        subscribe_ctx_, "UNSUBSCRIBE %b", leader_event_channel_.data(),
+        leader_event_channel_.size());
+    if (unsub) freeReplyObject(unsub);
+
+    // Drain any buffered message frames remaining in the socket
+    // so the next SUBSCRIBE gets a clean reply.
+    DrainSubscribeContext();
+
+    return true;
+}
+
+void RedisHelper::WatchLeaderPolling() {
     LOG(INFO) << "WatchLeader: using polling fallback (interval=" << ttl_sec_
               << "s)";
     redisContext* polling_ctx = CreateConnection();
     auto interval = std::chrono::seconds(ttl_sec_);
-    while (!cancel_requested_) {
+    while (!cancel_election_) {
         std::this_thread::sleep_for(interval);
 
         if (!polling_ctx) {
@@ -418,8 +497,9 @@ void RedisHelper::WatchLeader() {
 // ============================================================
 
 void RedisHelper::KeepLeader(int lease_id) {
+    (void)lease_id;  // Reserved for future lease validation
     keep_alive_running_ = true;
-    cancel_requested_ = false;
+    cancel_keep_alive_ = false;
 
     // Lua script: atomically check ownership and renew TTL
     // KEYS[1] = master_view_key
@@ -437,7 +517,7 @@ void RedisHelper::KeepLeader(int lease_id) {
     LOG(INFO) << "KeepLeader: starting renewal loop (interval="
               << heartbeat_interval_sec_ << "s)";
 
-    while (keep_alive_running_ && !cancel_requested_) {
+    while (keep_alive_running_ && !cancel_keep_alive_) {
         bool renewed = false;
         {
             std::lock_guard<std::mutex> lock(election_mutex_);
@@ -459,9 +539,21 @@ void RedisHelper::KeepLeader(int lease_id) {
                         check->len == our_value_.size() &&
                         memcmp(check->str, our_value_.data(),
                                our_value_.size()) == 0) {
-                        // Still ours — continue renewing
+                        // Still ours — renew TTL after reconnection
                         freeReplyObject(check);
-                        renewed = true;
+                        redisReply* expire_reply = (redisReply*)redisCommand(
+                            election_ctx_, "EXPIRE %b %d",
+                            master_view_key_.data(), master_view_key_.size(),
+                            ttl_sec_);
+                        if (expire_reply &&
+                            expire_reply->type == REDIS_REPLY_INTEGER &&
+                            expire_reply->integer == 1) {
+                            renewed = true;
+                        } else {
+                            LOG(WARNING) << "KeepLeader: EXPIRE failed after "
+                                            "reconnect, key may have changed";
+                        }
+                        if (expire_reply) freeReplyObject(expire_reply);
                     } else {
                         // Not ours anymore
                         if (check) freeReplyObject(check);
@@ -493,10 +585,8 @@ void RedisHelper::KeepLeader(int lease_id) {
 }
 
 void RedisHelper::CancelKeepAlive() {
-    cancel_requested_ = true;
+    cancel_keep_alive_ = true;
     keep_alive_running_ = false;
-    // subscribe_ctx_ has a 1-second timeout, so WatchLeader's subscribe
-    // loop will check cancel_requested_ within 1 second.
 }
 
 // ============================================================
@@ -507,6 +597,8 @@ ErrorCode RedisHelper::GetMasterView(std::string& master_address,
                                      ViewVersionId& version) {
     std::lock_guard<std::mutex> lock(election_mutex_);
     if (!election_ctx_) {
+        LOG(ERROR) << "GetMasterView: not connected to Redis at "
+                   << redis_endpoint_;
         return ErrorCode::INTERNAL_ERROR;
     }
 
@@ -515,12 +607,15 @@ ErrorCode RedisHelper::GetMasterView(std::string& master_address,
                                                   master_view_key_.size());
 
     if (!reply) {
+        LOG(ERROR) << "GetMasterView: GET failed (connection error) at "
+                   << redis_endpoint_;
         return ErrorCode::INTERNAL_ERROR;
     }
 
     if (reply->type == REDIS_REPLY_NIL) {
         freeReplyObject(reply);
-        return ErrorCode::INTERNAL_ERROR;  // No leader
+        LOG(WARNING) << "GetMasterView: no leader currently elected";
+        return ErrorCode::INTERNAL_ERROR;
     }
 
     if (reply->type == REDIS_REPLY_STRING) {
@@ -529,10 +624,13 @@ ErrorCode RedisHelper::GetMasterView(std::string& master_address,
         if (ParseLeaderValue(value, master_address, version)) {
             return ErrorCode::OK;
         }
+        LOG(ERROR) << "GetMasterView: failed to parse leader value: " << value;
         return ErrorCode::INTERNAL_ERROR;
     }
 
+    int reply_type = reply->type;
     freeReplyObject(reply);
+    LOG(ERROR) << "GetMasterView: unexpected reply type=" << reply_type;
     return ErrorCode::INTERNAL_ERROR;
 }
 
@@ -564,6 +662,29 @@ bool RedisHelper::Reconnect(redisContext*& ctx) {
 
     LOG(INFO) << "Reconnect: successfully reconnected to Redis";
     return true;
+}
+
+void RedisHelper::DrainSubscribeContext() {
+    if (!subscribe_ctx_) return;
+    // After UNSUBSCRIBE, buffered message frames may still be in the
+    // read buffer. Drain them so the next SUBSCRIBE gets a clean reply.
+    while (true) {
+        redisReply* reply = nullptr;
+        if (redisGetReply(subscribe_ctx_, (void**)&reply) != REDIS_OK ||
+            !reply) {
+            break;  // No more data or connection error
+        }
+        bool is_unsub_ack =
+            (reply->type == REDIS_REPLY_ARRAY && reply->elements >= 3 &&
+             reply->element[0]->type == REDIS_REPLY_STRING &&
+             strncmp(reply->element[0]->str, "unsubscribe", 11) == 0);
+        freeReplyObject(reply);
+        if (is_unsub_ack) {
+            // We've consumed the UNSUBSCRIBE acknowledgment — anything
+            // after this would be from a future SUBSCRIBE cycle.
+            break;
+        }
+    }
 }
 
 // ============================================================

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -87,6 +87,12 @@ if (STORE_USE_ETCD)
     add_test(NAME high_availability_test COMMAND high_availability_test)
 endif()
 
+add_executable(redis_helper_test redis_helper_test.cpp)
+target_link_libraries(redis_helper_test PUBLIC mooncake_store transfer_engine cachelib_memory_allocator ${ETCD_WRAPPER_LIB} glog gtest gtest_main pthread)
+if(STORE_USE_REDIS)
+    add_test(NAME redis_helper_test COMMAND redis_helper_test)
+endif()
+
 add_executable(stress_workload_test stress_workload_test.cpp)
 target_link_libraries(stress_workload_test PUBLIC
     mooncake_store

--- a/mooncake-store/tests/redis_helper_test.cpp
+++ b/mooncake-store/tests/redis_helper_test.cpp
@@ -236,6 +236,390 @@ TEST_F(RedisHelperTest, CancelKeepAliveStopsPromptly) {
     EXPECT_LT(elapsed, 5000);
 }
 
+// === Test 8: CreateConnection with invalid port ===
+// Covers: redis_helper.cpp:69-74 (port parse exception, host-only endpoint)
+
+TEST_F(RedisHelperTest, CreateConnectionInvalidPort) {
+    RedisHelper helper(FLAGS_cluster_id, "127.0.0.1:notaport", "", 0,
+                       FLAGS_redis_ttl_sec, 1);
+    // Connect should fail because port is not a number (stoi throws)
+    EXPECT_NE(ErrorCode::OK, helper.Connect());
+}
+
+TEST_F(RedisHelperTest, CreateConnectionHostOnlyEndpoint) {
+    // Endpoint without colon → host-only, port defaults to 6379
+    RedisHelper helper(FLAGS_cluster_id, "127.0.0.1", "", 0,
+                       FLAGS_redis_ttl_sec, 1);
+    EXPECT_EQ(ErrorCode::OK, helper.Connect());
+}
+
+TEST_F(RedisHelperTest, CreateConnectionUnreachable) {
+    // Use a port that nobody listens on — connect should fail
+    RedisHelper helper(FLAGS_cluster_id, "127.0.0.1:16379", "", 0,
+                       FLAGS_redis_ttl_sec, 1);
+    EXPECT_NE(ErrorCode::OK, helper.Connect());
+}
+
+// === Test 9: Connect called twice (replaces existing connections) ===
+// Covers: redis_helper.cpp:130-131, 145-146
+
+TEST_F(RedisHelperTest, ConnectTwice) {
+    RedisHelper helper(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0,
+                       FLAGS_redis_ttl_sec, 1);
+    ASSERT_EQ(ErrorCode::OK, helper.Connect());
+    // Second Connect should free old contexts and create new ones
+    EXPECT_EQ(ErrorCode::OK, helper.Connect());
+}
+
+// === Test 10: GetMasterView without Connect ===
+// Covers: redis_helper.cpp:510
+
+TEST_F(RedisHelperTest, GetMasterViewWithoutConnect) {
+    RedisHelper helper(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0,
+                       FLAGS_redis_ttl_sec, 1);
+    // Don't call Connect — election_ctx_ is null
+    std::string addr;
+    ViewVersionId ver = 0;
+    EXPECT_EQ(ErrorCode::INTERNAL_ERROR, helper.GetMasterView(addr, ver));
+}
+
+// === Test 11: ElectLeader with existing invalid (unparsable) value ===
+// Covers: redis_helper.cpp:232-233
+
+TEST_F(RedisHelperTest, ElectLeaderUnparsableExistingValue) {
+    const int short_ttl = 2;
+    // Write garbage into the master_view key directly
+    std::string master_view_key =
+        "mooncake:{" + FLAGS_cluster_id + "/}master_view";
+    redisContext* ctx = redisConnect(
+        FLAGS_redis_endpoint.substr(0, FLAGS_redis_endpoint.rfind(':')).c_str(),
+        std::stoi(
+            FLAGS_redis_endpoint.substr(FLAGS_redis_endpoint.rfind(':') + 1)));
+    ASSERT_TRUE(ctx && !ctx->err);
+    redisReply* r = (redisReply*)redisCommand(
+        ctx, "SET %b %b EX %d", master_view_key.data(), master_view_key.size(),
+        "garbage", 7, short_ttl);
+    ASSERT_TRUE(r != nullptr);
+    freeReplyObject(r);
+
+    // ElectLeader should still work — it sees an unparsable leader value
+    // and waits for it to expire, then wins election
+    RedisHelper helper(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0, short_ttl,
+                       1);
+    ASSERT_EQ(ErrorCode::OK, helper.Connect());
+
+    ViewVersionId version = 0;
+    int lease_id = 0;
+    helper.ElectLeader("10.0.0.8:50051", version, lease_id);
+    ASSERT_GT(version, 0);
+
+    redisFree(ctx);
+}
+
+// === Test 12: ElectLeader sees existing leader, waits, then wins ===
+// Covers: redis_helper.cpp:218 (TryElectOnce failed → loop back)
+
+TEST_F(RedisHelperTest, ElectLeaderContendedThenWin) {
+    const int short_ttl = 1;
+
+    // First helper: elect as leader
+    RedisHelper first(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0, short_ttl,
+                      1);
+    ASSERT_EQ(ErrorCode::OK, first.Connect());
+    ViewVersionId first_version = 0;
+    int first_lease = 0;
+    first.ElectLeader("10.0.0.9:50051", first_version, first_lease);
+
+    // Second helper: try to elect while key exists — will watch until expiry
+    // Then TryElectOnce may race and lose once before winning
+    RedisHelper second(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0, short_ttl,
+                       1);
+    ASSERT_EQ(ErrorCode::OK, second.Connect());
+
+    ViewVersionId second_version = 0;
+    int second_lease = 0;
+    // This blocks until first's key expires and second wins
+    second.ElectLeader("10.0.0.10:50051", second_version, second_lease);
+    ASSERT_GT(second_version, first_version);
+}
+
+// === Test 13: GetMasterView with no leader key ===
+// Covers: redis_helper.cpp:532-536
+
+TEST_F(RedisHelperTest, GetMasterViewNoLeader) {
+    RedisHelper helper(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0,
+                       FLAGS_redis_ttl_sec, 1);
+    ASSERT_EQ(ErrorCode::OK, helper.Connect());
+
+    // No election has happened, so master_view key should not exist
+    std::string addr;
+    ViewVersionId ver = 0;
+    EXPECT_EQ(ErrorCode::INTERNAL_ERROR, helper.GetMasterView(addr, ver));
+}
+
+// === Test 14: GetMasterView with corrupted value in Redis ===
+// Covers: redis_helper.cpp:532-536 (ParseLeaderValue failure path)
+
+TEST_F(RedisHelperTest, GetMasterViewCorruptedValue) {
+    RedisHelper helper(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0,
+                       FLAGS_redis_ttl_sec, 1);
+    ASSERT_EQ(ErrorCode::OK, helper.Connect());
+
+    // Write corrupt value directly
+    std::string master_view_key =
+        "mooncake:{" + FLAGS_cluster_id + "/}master_view";
+    std::string host =
+        FLAGS_redis_endpoint.substr(0, FLAGS_redis_endpoint.rfind(':'));
+    int port = std::stoi(
+        FLAGS_redis_endpoint.substr(FLAGS_redis_endpoint.rfind(':') + 1));
+    redisContext* ctx = redisConnect(host.c_str(), port);
+    ASSERT_TRUE(ctx && !ctx->err);
+    redisReply* r = (redisReply*)redisCommand(
+        ctx, "SET %b %b EX %d", master_view_key.data(), master_view_key.size(),
+        "not-json", 8, FLAGS_redis_ttl_sec);
+    ASSERT_TRUE(r != nullptr);
+    freeReplyObject(r);
+    redisFree(ctx);
+
+    std::string addr;
+    ViewVersionId ver = 0;
+    EXPECT_EQ(ErrorCode::INTERNAL_ERROR, helper.GetMasterView(addr, ver));
+}
+
+// === Test 15: ParseLeaderValue unit tests (no Redis needed) ===
+// Covers: redis_helper.cpp:600-601, 606
+
+TEST_F(RedisHelperTest, ParseLeaderValueInvalidJson) {
+    std::string addr;
+    ViewVersionId epoch = 0;
+    EXPECT_FALSE(RedisHelper::ParseLeaderValue("not-json", addr, epoch));
+}
+
+TEST_F(RedisHelperTest, ParseLeaderValueMissingFields) {
+    std::string addr;
+    ViewVersionId epoch = 0;
+    // Valid JSON but missing "address" field
+    EXPECT_FALSE(RedisHelper::ParseLeaderValue(R"({"epoch":1})", addr, epoch));
+    // Has address but missing "epoch"
+    EXPECT_FALSE(RedisHelper::ParseLeaderValue(
+        R"({"address":"10.0.0.1:50051"})", addr, epoch));
+    // Has both but epoch is not integer
+    EXPECT_FALSE(RedisHelper::ParseLeaderValue(
+        R"({"address":"10.0.0.1:50051","epoch":"not_int"})", addr, epoch));
+}
+
+// === Test 16: KeepLeader loses leadership when key is overwritten ===
+// Covers: redis_helper.cpp:477-479, 484
+
+TEST_F(RedisHelperTest, KeepLeaderLosesLeadership) {
+    const int short_ttl = 2;
+    RedisHelper helper(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0, short_ttl,
+                       1);
+    ASSERT_EQ(ErrorCode::OK, helper.Connect());
+
+    std::string master_address = "10.0.0.11:50051";
+    ViewVersionId version = 0;
+    int lease_id = 0;
+    helper.ElectLeader(master_address, version, lease_id);
+
+    // Overwrite the leader key with a different value (simulate another node
+    // taking over)
+    std::string master_view_key =
+        "mooncake:{" + FLAGS_cluster_id + "/}master_view";
+    std::string host =
+        FLAGS_redis_endpoint.substr(0, FLAGS_redis_endpoint.rfind(':'));
+    int port = std::stoi(
+        FLAGS_redis_endpoint.substr(FLAGS_redis_endpoint.rfind(':') + 1));
+    redisContext* ctx = redisConnect(host.c_str(), port);
+    ASSERT_TRUE(ctx && !ctx->err);
+    redisReply* r = (redisReply*)redisCommand(
+        ctx, "SET %b %b EX %d", master_view_key.data(), master_view_key.size(),
+        R"({"address":"10.0.0.99:50051","epoch":999,"ts":0,"ttl":2})", 57,
+        short_ttl);
+    ASSERT_TRUE(r != nullptr);
+    freeReplyObject(r);
+    redisFree(ctx);
+
+    // KeepLeader should detect the key no longer matches and exit
+    auto start = std::chrono::steady_clock::now();
+    helper.KeepLeader(lease_id);
+    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                       std::chrono::steady_clock::now() - start)
+                       .count();
+    // Should exit promptly (within heartbeat interval + margin), not hang
+    EXPECT_LT(elapsed, (short_ttl + 5) * 1000);
+}
+
+// === Test 17: WatchLeader polling fallback ===
+// Covers: redis_helper.cpp:379-413 (polling path when SUBSCRIBE fails)
+// We use CLIENT KILL to break subscribe_ctx_ so SUBSCRIBE command fails,
+// forcing WatchLeader to fall through to the pure polling path.
+
+TEST_F(RedisHelperTest, WatchLeaderPollingFallback) {
+    const int short_ttl = 3;
+
+    // First helper: elect as leader (key lives for short_ttl seconds)
+    RedisHelper first(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0, short_ttl,
+                      1);
+    ASSERT_EQ(ErrorCode::OK, first.Connect());
+    ViewVersionId first_version = 0;
+    int first_lease = 0;
+    first.ElectLeader("10.0.0.12:50051", first_version, first_lease);
+
+    // Second helper: Connect, then break its subscribe connection
+    RedisHelper second(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0, short_ttl,
+                       1);
+    ASSERT_EQ(ErrorCode::OK, second.Connect());
+
+    // Kill all normal client connections to break subscribe_ctx_
+    std::string host =
+        FLAGS_redis_endpoint.substr(0, FLAGS_redis_endpoint.rfind(':'));
+    int port = std::stoi(
+        FLAGS_redis_endpoint.substr(FLAGS_redis_endpoint.rfind(':') + 1));
+    redisContext* admin = redisConnect(host.c_str(), port);
+    ASSERT_TRUE(admin && !admin->err);
+    redisReply* kr =
+        (redisReply*)redisCommand(admin, "CLIENT KILL TYPE normal");
+    if (kr) freeReplyObject(kr);
+    redisFree(admin);
+
+    // ElectLeader will reconnect election_ctx_, then find the leader key,
+    // then WatchLeader will try SUBSCRIBE on broken subscribe_ctx_ → fail
+    // → fall back to pure polling → first's key expires → polling detects
+    // → second wins election
+    ViewVersionId second_version = 0;
+    int second_lease = 0;
+    second.ElectLeader("10.0.0.13:50051", second_version, second_lease);
+    ASSERT_GT(second_version, first_version);
+}
+
+// === Test 18: Reconnect after connection loss ===
+// Covers: redis_helper.cpp:552-566, 192-199, 171-179
+// We use CLIENT KILL to sever the election connection, then trigger an
+// operation that retries.
+
+TEST_F(RedisHelperTest, ReconnectAfterConnectionLoss) {
+    const int short_ttl = 2;
+    RedisHelper helper(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0, short_ttl,
+                       1);
+    ASSERT_EQ(ErrorCode::OK, helper.Connect());
+
+    std::string master_address = "10.0.0.14:50051";
+    ViewVersionId version = 0;
+    int lease_id = 0;
+    helper.ElectLeader(master_address, version, lease_id);
+    ASSERT_GT(version, 0);
+
+    // Start KeepLeader to test reconnection
+    std::thread keep_alive_thread([&]() { helper.KeepLeader(lease_id); });
+
+    // Let keep-alive run at least one cycle
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    // Kill the redis client connections to force a reconnect
+    std::string host =
+        FLAGS_redis_endpoint.substr(0, FLAGS_redis_endpoint.rfind(':'));
+    int port = std::stoi(
+        FLAGS_redis_endpoint.substr(FLAGS_redis_endpoint.rfind(':') + 1));
+    redisContext* admin = redisConnect(host.c_str(), port);
+    ASSERT_TRUE(admin && !admin->err);
+
+    // CLIENT KILL to drop all normal clients except our admin connection
+    redisReply* r = (redisReply*)redisCommand(admin, "CLIENT KILL TYPE normal");
+    if (r) freeReplyObject(r);
+    redisFree(admin);
+
+    // KeepLeader should attempt reconnection and continue or exit gracefully
+    std::this_thread::sleep_for(std::chrono::seconds(short_ttl + 2));
+
+    helper.CancelKeepAlive();
+    keep_alive_thread.join();
+}
+
+// === Test 19: ElectLeader detects cancel via WatchLeader ===
+// Covers: redis_helper.cpp:171-179 (election_ctx_ null → retry)
+// ElectLeader's while(true) loop doesn't check cancel_requested_ directly,
+// but WatchLeader does. We create a scenario where ElectLeader enters
+// WatchLeader (which can be cancelled), covering the connect-retry path
+// at lines 171-179 along the way.
+
+TEST_F(RedisHelperTest, ElectLeaderCancelledViaWatchLeader) {
+    const int short_ttl = 2;
+
+    // First helper: elect as leader and keep it alive
+    RedisHelper first(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0, short_ttl,
+                      1);
+    ASSERT_EQ(ErrorCode::OK, first.Connect());
+    ViewVersionId first_version = 0;
+    int first_lease = 0;
+    first.ElectLeader("10.0.0.15:50051", first_version, first_lease);
+
+    std::thread first_keep([&]() { first.KeepLeader(first_lease); });
+
+    // Second helper: will block in ElectLeader → WatchLeader
+    RedisHelper second(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0, short_ttl,
+                       1);
+    ASSERT_EQ(ErrorCode::OK, second.Connect());
+    ViewVersionId second_version = 0;
+    int second_lease = 0;
+
+    std::thread elect_thread([&]() {
+        second.ElectLeader("10.0.0.16:50051", second_version, second_lease);
+    });
+
+    // Wait for second to enter WatchLeader
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    second.CancelKeepAlive();
+
+    // Cancel first so key expires, allowing second to win
+    first.CancelKeepAlive();
+    first_keep.join();
+    elect_thread.join();
+
+    ASSERT_GT(second_version, first_version);
+}
+
+// === Test 20: Subscribe loop processes message ===
+// Covers: redis_helper.cpp:352-359 (message parsing in subscribe loop)
+
+TEST_F(RedisHelperTest, SubscribeReceivesVacantMessage) {
+    const int short_ttl = 2;
+
+    // First helper: elect as leader with a short TTL
+    RedisHelper first(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0, short_ttl,
+                      1);
+    ASSERT_EQ(ErrorCode::OK, first.Connect());
+    ViewVersionId first_version = 0;
+    int first_lease = 0;
+    first.ElectLeader("10.0.0.16:50051", first_version, first_lease);
+
+    // Start KeepLeader so the key stays alive
+    std::thread first_keep([&]() { first.KeepLeader(first_lease); });
+
+    // Second helper: elect — will block in WatchLeader subscribing
+    RedisHelper second(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0, short_ttl,
+                       1);
+    ASSERT_EQ(ErrorCode::OK, second.Connect());
+    ViewVersionId second_version = 0;
+    int second_lease = 0;
+
+    std::thread elect_thread([&]() {
+        second.ElectLeader("10.0.0.17:50051", second_version, second_lease);
+    });
+
+    // Wait a moment for second to enter WatchLeader subscribe loop
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+    // Cancel first's keep-alive → first's key will expire →
+    // second's subscribe loop should detect "vacant" message
+    first.CancelKeepAlive();
+    first_keep.join();
+
+    // Second should win election
+    elect_thread.join();
+    ASSERT_GT(second_version, first_version);
+}
+
 }  // namespace testing
 }  // namespace mooncake
 

--- a/mooncake-store/tests/redis_helper_test.cpp
+++ b/mooncake-store/tests/redis_helper_test.cpp
@@ -1,0 +1,253 @@
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <string>
+#include <thread>
+
+#include "types.h"
+
+#ifdef STORE_USE_REDIS
+#include "redis_helper.h"
+#include <hiredis/hiredis.h>
+
+namespace mooncake {
+namespace testing {
+
+DEFINE_string(redis_endpoint, "127.0.0.1:6379",
+              "Redis endpoint for helper test");
+DEFINE_int32(redis_ttl_sec, 2, "Short TTL for testing fast key expiration");
+DEFINE_string(cluster_id, "test_helper", "Cluster ID for Redis helper test");
+
+class RedisHelperTest : public ::testing::Test {
+   protected:
+    static void SetUpTestSuite() {
+        google::InitGoogleLogging("RedisHelperTest");
+        google::SetVLOGLevel("*", 1);
+        FLAGS_logtostderr = 1;
+    }
+
+    static void TearDownTestSuite() { google::ShutdownGoogleLogging(); }
+
+    void SetUp() override { CleanupRedisKeys(); }
+
+    void TearDown() override { CleanupRedisKeys(); }
+
+   private:
+    // Delete both master_view and master_epoch keys directly.
+    // master_epoch has no TTL (INCR key), so it persists across tests
+    // and would block subsequent ElectLeader calls if not cleaned up.
+    // Both SetUp and TearDown call this to ensure isolation even if a
+    // test's KeepLeader thread is still renewing the key at exit.
+    static void CleanupRedisKeys() {
+        std::string host = "127.0.0.1";
+        int port = 6379;
+        auto colon_pos = FLAGS_redis_endpoint.rfind(':');
+        if (colon_pos != std::string::npos) {
+            host = FLAGS_redis_endpoint.substr(0, colon_pos);
+            port = std::stoi(FLAGS_redis_endpoint.substr(colon_pos + 1));
+        }
+        redisContext* ctx = redisConnect(host.c_str(), port);
+        if (ctx && !ctx->err) {
+            std::string master_view_key =
+                "mooncake:{" + FLAGS_cluster_id + "/}master_view";
+            std::string master_epoch_key =
+                "mooncake:{" + FLAGS_cluster_id + "/}master_epoch";
+            redisReply* r = (redisReply*)redisCommand(
+                ctx, "DEL %b %b", master_view_key.data(),
+                master_view_key.size(), master_epoch_key.data(),
+                master_epoch_key.size());
+            if (r) freeReplyObject(r);
+            redisFree(ctx);
+        } else {
+            if (ctx) redisFree(ctx);
+        }
+    }
+};
+
+// === Test 1: Connect ===
+
+TEST_F(RedisHelperTest, Connect) {
+    RedisHelper helper(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0,
+                       FLAGS_redis_ttl_sec, 1);
+    ASSERT_EQ(ErrorCode::OK, helper.Connect());
+
+    // Second connection (empty password = no auth) should also work
+    RedisHelper helper2(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0,
+                        FLAGS_redis_ttl_sec, 1);
+    ASSERT_EQ(ErrorCode::OK, helper2.Connect());
+}
+
+// === Test 2: ElectLeader + GetMasterView ===
+
+TEST_F(RedisHelperTest, ElectLeaderAndGetMasterView) {
+    RedisHelper helper(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0,
+                       FLAGS_redis_ttl_sec, 1);
+    ASSERT_EQ(ErrorCode::OK, helper.Connect());
+
+    std::string master_address = "10.0.0.1:50051";
+    ViewVersionId version = 0;
+    int lease_id = 0;
+
+    helper.ElectLeader(master_address, version, lease_id);
+    ASSERT_GT(version, 0);
+    ASSERT_GT(lease_id, 0);
+
+    // Read back via a separate helper
+    RedisHelper reader(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0,
+                       FLAGS_redis_ttl_sec, 1);
+    ASSERT_EQ(ErrorCode::OK, reader.Connect());
+
+    std::string got_address;
+    ViewVersionId got_version = 0;
+    ASSERT_EQ(ErrorCode::OK, reader.GetMasterView(got_address, got_version));
+    ASSERT_EQ(got_address, master_address);
+    ASSERT_EQ(got_version, version);
+}
+
+// === Test 3: KeepLeader keeps key alive past TTL ===
+
+TEST_F(RedisHelperTest, KeepLeaderRenewsTTL) {
+    RedisHelper helper(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0,
+                       FLAGS_redis_ttl_sec, 1);
+    ASSERT_EQ(ErrorCode::OK, helper.Connect());
+
+    std::string master_address = "10.0.0.2:50051";
+    ViewVersionId version = 0;
+    int lease_id = 0;
+    helper.ElectLeader(master_address, version, lease_id);
+
+    // Start keep-alive in background
+    std::thread keep_alive_thread([&]() { helper.KeepLeader(lease_id); });
+
+    // Wait longer than TTL — if KeepLeader works, the key should still exist
+    std::this_thread::sleep_for(std::chrono::seconds(FLAGS_redis_ttl_sec * 3));
+
+    std::string got_address;
+    ViewVersionId got_version = 0;
+    EXPECT_EQ(ErrorCode::OK, helper.GetMasterView(got_address, got_version));
+    EXPECT_EQ(got_address, master_address);
+
+    // Cancel keep-alive and join
+    helper.CancelKeepAlive();
+    keep_alive_thread.join();
+}
+
+// === Test 4: Key expires after KeepLeader stops ===
+
+TEST_F(RedisHelperTest, KeyExpiresAfterKeepLeaderStops) {
+    const int short_ttl = 1;
+    RedisHelper helper(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0, short_ttl,
+                       1);
+    ASSERT_EQ(ErrorCode::OK, helper.Connect());
+
+    std::string master_address = "10.0.0.3:50051";
+    ViewVersionId version = 0;
+    int lease_id = 0;
+    helper.ElectLeader(master_address, version, lease_id);
+
+    // Don't start KeepLeader — let the key expire naturally
+    std::this_thread::sleep_for(std::chrono::seconds(short_ttl * 3));
+
+    // Key should have expired
+    std::string got_address;
+    ViewVersionId got_version = 0;
+    EXPECT_NE(ErrorCode::OK, helper.GetMasterView(got_address, got_version));
+}
+
+// === Test 5: ElectLeader waits for key expiry, then wins ===
+
+TEST_F(RedisHelperTest, ElectLeaderWaitsForKeyExpiry) {
+    const int short_ttl = 1;
+
+    // First helper: elect and let key expire (no KeepLeader)
+    RedisHelper first(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0, short_ttl,
+                      1);
+    ASSERT_EQ(ErrorCode::OK, first.Connect());
+    std::string first_addr = "10.0.0.4:50051";
+    ViewVersionId first_version = 0;
+    int first_lease = 0;
+    first.ElectLeader(first_addr, first_version, first_lease);
+
+    // Second helper: try to elect — should block until key expires
+    RedisHelper second(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0, short_ttl,
+                       1);
+    ASSERT_EQ(ErrorCode::OK, second.Connect());
+    ViewVersionId second_version = 0;
+    int second_lease = 0;
+
+    std::thread elect_thread([&]() {
+        second.ElectLeader("10.0.0.5:50051", second_version, second_lease);
+    });
+
+    // Should complete within short_ttl * 3 seconds
+    elect_thread.join();
+    ASSERT_GT(second_version, 0);
+    // Epoch should be strictly increasing
+    ASSERT_GT(second_version, first_version);
+}
+
+// === Test 6: Epoch monotonicity ===
+
+TEST_F(RedisHelperTest, EpochMonotonicallyIncreases) {
+    const int short_ttl = 1;
+    RedisHelper helper(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0, short_ttl,
+                       1);
+    ASSERT_EQ(ErrorCode::OK, helper.Connect());
+
+    ViewVersionId prev_epoch = 0;
+    for (int i = 0; i < 3; i++) {
+        ViewVersionId version = 0;
+        int lease_id = 0;
+        helper.ElectLeader("10.0.0.6:50051", version, lease_id);
+        ASSERT_GT(version, prev_epoch);
+        prev_epoch = version;
+        // Let key expire for next iteration
+        std::this_thread::sleep_for(std::chrono::seconds(short_ttl * 3));
+    }
+}
+
+// === Test 7: CancelKeepAlive stops KeepLeader promptly ===
+
+TEST_F(RedisHelperTest, CancelKeepAliveStopsPromptly) {
+    RedisHelper helper(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0,
+                       FLAGS_redis_ttl_sec, 1);
+    ASSERT_EQ(ErrorCode::OK, helper.Connect());
+
+    std::string master_address = "10.0.0.7:50051";
+    ViewVersionId version = 0;
+    int lease_id = 0;
+    helper.ElectLeader(master_address, version, lease_id);
+
+    std::thread keep_alive_thread([&]() { helper.KeepLeader(lease_id); });
+
+    // Give keep-alive a moment to start
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+    auto start = std::chrono::steady_clock::now();
+    helper.CancelKeepAlive();
+    keep_alive_thread.join();
+    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                       std::chrono::steady_clock::now() - start)
+                       .count();
+
+    // Should complete within a few seconds, not hang
+    EXPECT_LT(elapsed, 5000);
+}
+
+}  // namespace testing
+}  // namespace mooncake
+
+int main(int argc, char** argv) {
+    gflags::ParseCommandLineFlags(&argc, &argv, true);
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}
+
+#else  // STORE_USE_REDIS
+
+// Stub main when STORE_USE_REDIS is not defined
+int main() { return 0; }
+
+#endif  // STORE_USE_REDIS


### PR DESCRIPTION
Description

  Add RedisHelper as a standalone Redis-based leader election backend, mirroring EtcdHelper's role for P2P HA mode. This
  eliminates the etcd dependency when OpLog already uses Redis/TBase.

  This is the first of two PRs split from the original monolithic Redis election commit:
  - PR1 (this): RedisHelper component + CMake + unit tests
  - PR2 (follow-up): Integration into MasterViewHelper, MasterServiceSupervisor, config/gflags, and integration tests

  Key design:
  - SET NX EX for atomic leader election
  - INCR on epoch key for monotonic versioning
  - Lua script for atomic lease renewal (check-then-EXPIRE)
  - Pub/Sub + fallback polling for watching leader key expiration
  - Conditional compilation via USE_REDIS (auto-detected by CMake find_library(hiredis))
  - Only uses standard Redis commands + Lua scripts — compatible with any Redis-compatible server

  Module

  - [ ] Transfer Engine (mooncake-transfer-engine)
  - [ ] Mooncake Store (mooncake-store)
  - [ ] Mooncake EP (mooncake-ep)
  - [ ] Mooncake PG (mooncake-pg)
  - [ ] Integration (mooncake-integration)
  - [x] P2P Store (mooncake-p2p-store)
  - [ ] Python Wheel (mooncake-wheel)
  - [ ] Common (mooncake-common)
  - [ ] Mooncake RL (mooncake-rl)
  - [ ] CI/CD
  - [ ] Docs
  - [ ] Other

  Type of Change

  - [ ] Bug fix
  - [x] New feature
  - [ ] Refactor
  - [ ] Breaking change
  - [ ] Documentation update
  - [ ] Performance improvement
  - [ ] Other

  How Has This Been Tested?

  Test commands:
  # Build with Redis support
  cmake .. -DCMAKE_BUILD_TYPE=Debug
  make -j$(nproc) redis_helper_test

  # Run tests (requires local Redis on 127.0.0.1:6379)
  ./mooncake-store/tests/redis_helper_test \
    --redis_endpoint=127.0.0.1:6379 \
    --redis_ttl_sec=2 \
    --cluster_id=test_helper

  Test results:
  - [x] Unit tests pass (7/7: Connect, ElectLeader+GetMasterView, KeepLeaderRenewsTTL, KeyExpiresAfterKeepLeaderStops,
  ElectLeaderWaitsForKeyExpiry, EpochMonotonicallyIncreases, CancelKeepAliveStopsPromptly)
  - [ ] Integration tests pass (covered in PR2)
  - [x] Manual testing done — Ran full build + test suite in dev container with redis-server, all 7 tests passed

  Checklist

  - [x] I have performed a self-review of my own code
  - [x] I have formatted my code using ./scripts/code_format.sh
  - [ ] I have run pre-commit run --all-files and all hooks pass
  - [ ] I have updated the documentation (if applicable)
  - [x] I have added tests to prove my changes are effective
  - [ ] For changes >500 LOC: I have filed an RFC issue

  AI Assistance Disclosure

  - [ ] No AI tools were used
  - [x] AI tools were used (specify below)

  Claude Code (Claude Fable 5) assisted with code implementation, unit test writing, code review, and CI integration.