### PR TITLE
Hca peer affinity

### DIFF
--- a/mooncake-transfer-engine/include/config.h
+++ b/mooncake-transfer-engine/include/config.h
@@ -22,6 +22,7 @@
 #include <cstdint>
 #include <mutex>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -60,6 +61,8 @@ struct GlobalConfig {
     bool use_ipv6 = false;
     size_t fragment_limit = 16384;
     bool enable_dest_device_affinity = false;
+    bool enable_hca_peer_affinity = false;
+    std::unordered_map<std::string, std::vector<std::string>> nic_peer_affinity;
     int parallel_reg_mr = -1;
     size_t eic_max_block_size = 64UL * 1024 * 1024;
     EndpointStoreType endpoint_store_type = EndpointStoreType::SIEVE;

--- a/mooncake-transfer-engine/include/config.h
+++ b/mooncake-transfer-engine/include/config.h
@@ -63,6 +63,7 @@ struct GlobalConfig {
     bool enable_dest_device_affinity = false;
     bool enable_hca_peer_affinity = false;
     std::unordered_map<std::string, std::vector<std::string>> nic_peer_affinity;
+    bool log_rdma_slice_affinity = false;
     int parallel_reg_mr = -1;
     size_t eic_max_block_size = 64UL * 1024 * 1024;
     EndpointStoreType endpoint_store_type = EndpointStoreType::SIEVE;

--- a/mooncake-transfer-engine/include/topology.h
+++ b/mooncake-transfer-engine/include/topology.h
@@ -30,6 +30,7 @@
 #include <string>
 #include <thread>
 #include <unordered_map>
+#include <vector>
 
 #include "common.h"
 
@@ -86,6 +87,9 @@ class Topology {
     int selectDevice(const std::string storage_type, int retry_count = 0);
     int selectDevice(const std::string storage_type, std::string_view hint,
                      int retry_count = 0);
+    int selectDeviceByLocalHca(const std::string storage_type,
+                               std::string_view local_hca,
+                               int retry_count = 0);
 
     TopologyMatrix getMatrix() const { return matrix_; }
 
@@ -121,6 +125,11 @@ class Topology {
     };
     std::unordered_map<std::string /* storage type */, ResolvedTopologyEntry>
         resolved_matrix_;
+    std::unordered_map<
+        std::string /* local HCA */,
+        std::unordered_map<std::string /* storage type */,
+                           std::vector<int> /* peer HCA ids */>>
+        resolved_hca_peer_affinity_by_local_;
 };
 
 }  // namespace mooncake

--- a/mooncake-transfer-engine/include/topology.h
+++ b/mooncake-transfer-engine/include/topology.h
@@ -88,8 +88,7 @@ class Topology {
     int selectDevice(const std::string storage_type, std::string_view hint,
                      int retry_count = 0);
     int selectDeviceByLocalHca(const std::string storage_type,
-                               std::string_view local_hca,
-                               int retry_count = 0);
+                               std::string_view local_hca, int retry_count = 0);
 
     TopologyMatrix getMatrix() const { return matrix_; }
 
@@ -125,10 +124,9 @@ class Topology {
     };
     std::unordered_map<std::string /* storage type */, ResolvedTopologyEntry>
         resolved_matrix_;
-    std::unordered_map<
-        std::string /* local HCA */,
-        std::unordered_map<std::string /* storage type */,
-                           std::vector<int> /* peer HCA ids */>>
+    std::unordered_map<std::string /* local HCA */,
+                       std::unordered_map<std::string /* storage type */,
+                                          std::vector<int> /* peer HCA ids */>>
         resolved_hca_peer_affinity_by_local_;
 };
 

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_transport.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_transport.h
@@ -126,8 +126,7 @@ class RdmaTransport : public Transport {
                             std::string_view hint, int &buffer_id,
                             int &device_id, int retry_cnt = 0);
     static int selectDeviceByLocalHca(SegmentDesc *desc, uint64_t offset,
-                                      size_t length,
-                                      std::string_view local_hca,
+                                      size_t length, std::string_view local_hca,
                                       int &buffer_id, int &device_id,
                                       int retry_cnt = 0);
 

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_transport.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_transport.h
@@ -125,6 +125,11 @@ class RdmaTransport : public Transport {
     static int selectDevice(SegmentDesc *desc, uint64_t offset, size_t length,
                             std::string_view hint, int &buffer_id,
                             int &device_id, int retry_cnt = 0);
+    static int selectDeviceByLocalHca(SegmentDesc *desc, uint64_t offset,
+                                      size_t length,
+                                      std::string_view local_hca,
+                                      int &buffer_id, int &device_id,
+                                      int retry_cnt = 0);
 
    private:
     std::vector<std::shared_ptr<RdmaContext>> context_list_;

--- a/mooncake-transfer-engine/include/transport/transport.h
+++ b/mooncake-transfer-engine/include/transport/transport.h
@@ -109,6 +109,7 @@ class Transport {
         TransferRequest::OpCode opcode;
         SegmentID target_id;
         std::string peer_nic_path;
+        std::string source_location;
         SliceStatus status;
         TransferTask *task;
         std::vector<uint32_t> dest_rkeys;

--- a/mooncake-transfer-engine/src/config.cpp
+++ b/mooncake-transfer-engine/src/config.cpp
@@ -43,8 +43,7 @@ std::vector<std::string> splitConfigString(const std::string& value,
     return result;
 }
 
-bool parseBoolConfigEnv(const char* value, const char* env_name,
-                        bool& output) {
+bool parseBoolConfigEnv(const char* value, const char* env_name, bool& output) {
     if (strcmp(value, "1") == 0 || strcasecmp(value, "true") == 0) {
         output = true;
         return true;
@@ -408,8 +407,7 @@ void loadGlobalConfig(GlobalConfig& config) {
     parseNicPeerAffinity(std::getenv("MC_NIC_PEER_AFFINITY"),
                          config.nic_peer_affinity);
 
-    if (config.enable_hca_peer_affinity &&
-        config.enable_dest_device_affinity) {
+    if (config.enable_hca_peer_affinity && config.enable_dest_device_affinity) {
         LOG(ERROR) << "MC_ENABLE_HCA_PEER_AFFINITY and "
                       "MC_ENABLE_DEST_DEVICE_AFFINITY cannot be enabled at "
                       "the same time; falling back to default peer device "

--- a/mooncake-transfer-engine/src/config.cpp
+++ b/mooncake-transfer-engine/src/config.cpp
@@ -418,6 +418,14 @@ void loadGlobalConfig(GlobalConfig& config) {
         config.enable_dest_device_affinity = false;
     }
 
+    const char* log_rdma_slice_affinity_env =
+        std::getenv("MC_LOG_RDMA_SLICE_AFFINITY");
+    if (log_rdma_slice_affinity_env) {
+        parseBoolConfigEnv(log_rdma_slice_affinity_env,
+                           "MC_LOG_RDMA_SLICE_AFFINITY",
+                           config.log_rdma_slice_affinity);
+    }
+
     const char* enable_parallel_reg_mr =
         std::getenv("MC_ENABLE_PARALLEL_REG_MR");
     if (enable_parallel_reg_mr) {
@@ -577,6 +585,8 @@ void dumpGlobalConfig() {
     LOG(INFO) << "mtu_length = " << mtuLengthToString(config.mtu_length);
     LOG(INFO) << "parallel_reg_mr = " << config.parallel_reg_mr;
     LOG(INFO) << "ib_traffic_class = " << config.ib_traffic_class;
+    LOG(INFO) << "log_rdma_slice_affinity = "
+              << (config.log_rdma_slice_affinity ? "true" : "false");
     {
         std::ostringstream oss;
         for (size_t i = 0; i < config.mlx5_qp_udp_sports.size(); ++i) {

--- a/mooncake-transfer-engine/src/config.cpp
+++ b/mooncake-transfer-engine/src/config.cpp
@@ -583,8 +583,6 @@ void dumpGlobalConfig() {
     LOG(INFO) << "mtu_length = " << mtuLengthToString(config.mtu_length);
     LOG(INFO) << "parallel_reg_mr = " << config.parallel_reg_mr;
     LOG(INFO) << "ib_traffic_class = " << config.ib_traffic_class;
-    LOG(INFO) << "log_rdma_slice_affinity = "
-              << (config.log_rdma_slice_affinity ? "true" : "false");
     {
         std::ostringstream oss;
         for (size_t i = 0; i < config.mlx5_qp_udp_sports.size(); ++i) {
@@ -597,6 +595,8 @@ void dumpGlobalConfig() {
     }
     LOG(INFO) << "mlx5_qp_lag_port_balance = "
               << (config.mlx5_qp_lag_port_balance ? "true" : "false");
+    LOG(INFO) << "log_rdma_slice_affinity = "
+              << (config.log_rdma_slice_affinity ? "true" : "false");
 }
 
 GlobalConfig& globalConfig() {

--- a/mooncake-transfer-engine/src/config.cpp
+++ b/mooncake-transfer-engine/src/config.cpp
@@ -19,9 +19,87 @@
 #include <cstdlib>
 #include <dirent.h>
 #include <sstream>
+#include <strings.h>
 #include <unistd.h>
 
 namespace mooncake {
+namespace {
+
+std::string trimConfigToken(const std::string& value) {
+    const auto begin = value.find_first_not_of(" \t\n\r");
+    if (begin == std::string::npos) return "";
+    const auto end = value.find_last_not_of(" \t\n\r");
+    return value.substr(begin, end - begin + 1);
+}
+
+std::vector<std::string> splitConfigString(const std::string& value,
+                                           char delim) {
+    std::vector<std::string> result;
+    std::stringstream stream(value);
+    std::string item;
+    while (std::getline(stream, item, delim)) {
+        result.push_back(trimConfigToken(item));
+    }
+    return result;
+}
+
+bool parseBoolConfigEnv(const char* value, const char* env_name,
+                        bool& output) {
+    if (strcmp(value, "1") == 0 || strcasecmp(value, "true") == 0) {
+        output = true;
+        return true;
+    }
+    if (strcmp(value, "0") == 0 || strcasecmp(value, "false") == 0) {
+        output = false;
+        return true;
+    }
+    LOG(WARNING) << "Ignore value from environment variable " << env_name
+                 << ", it should be 0|1|true|false";
+    return false;
+}
+
+void parseNicPeerAffinity(
+    const char* env,
+    std::unordered_map<std::string, std::vector<std::string>>& affinity) {
+    affinity.clear();
+    if (!env || env[0] == '\0') return;
+
+    for (const auto& raw_rule : splitConfigString(env, ';')) {
+        const auto rule = trimConfigToken(raw_rule);
+        if (rule.empty()) continue;
+
+        auto delim = rule.find('=');
+        if (delim == std::string::npos) {
+            LOG(WARNING) << "Invalid MC_NIC_PEER_AFFINITY rule '" << rule
+                         << "'. Expected local_hca=peer_hca[,peer_hca].";
+            continue;
+        }
+
+        auto local_hca = trimConfigToken(rule.substr(0, delim));
+        if (local_hca.empty()) {
+            LOG(WARNING) << "Invalid MC_NIC_PEER_AFFINITY rule '" << rule
+                         << "': local HCA is empty.";
+            continue;
+        }
+
+        std::vector<std::string> peer_hcas;
+        for (const auto& peer_hca :
+             splitConfigString(rule.substr(delim + 1), ',')) {
+            if (!peer_hca.empty()) peer_hcas.push_back(peer_hca);
+        }
+
+        if (peer_hcas.empty()) {
+            LOG(WARNING) << "Invalid MC_NIC_PEER_AFFINITY rule '" << rule
+                         << "': peer HCA list is empty.";
+            continue;
+        }
+
+        affinity[local_hca] = std::move(peer_hcas);
+    }
+}
+
+}  // namespace
+
 void loadGlobalConfig(GlobalConfig& config) {
     const char* num_cq_per_ctx_env = std::getenv("MC_NUM_CQ_PER_CTX");
     if (num_cq_per_ctx_env) {
@@ -317,6 +395,27 @@ void loadGlobalConfig(GlobalConfig& config) {
 
     if (std::getenv("MC_ENABLE_DEST_DEVICE_AFFINITY")) {
         config.enable_dest_device_affinity = true;
+    }
+
+    const char* enable_hca_peer_affinity_env =
+        std::getenv("MC_ENABLE_HCA_PEER_AFFINITY");
+    if (enable_hca_peer_affinity_env) {
+        parseBoolConfigEnv(enable_hca_peer_affinity_env,
+                           "MC_ENABLE_HCA_PEER_AFFINITY",
+                           config.enable_hca_peer_affinity);
+    }
+
+    parseNicPeerAffinity(std::getenv("MC_NIC_PEER_AFFINITY"),
+                         config.nic_peer_affinity);
+
+    if (config.enable_hca_peer_affinity &&
+        config.enable_dest_device_affinity) {
+        LOG(ERROR) << "MC_ENABLE_HCA_PEER_AFFINITY and "
+                      "MC_ENABLE_DEST_DEVICE_AFFINITY cannot be enabled at "
+                      "the same time; falling back to default peer device "
+                      "selection.";
+        config.enable_hca_peer_affinity = false;
+        config.enable_dest_device_affinity = false;
     }
 
     const char* enable_parallel_reg_mr =

--- a/mooncake-transfer-engine/src/topology.cpp
+++ b/mooncake-transfer-engine/src/topology.cpp
@@ -19,9 +19,7 @@
 #include <iostream>
 #include <map>
 #include <set>
-#include <sstream>
 #include <string>
-#include <strings.h>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -147,168 +145,6 @@ struct InfinibandDevice {
     int numa_node;
 };
 
-static std::string trim(const std::string &value) {
-    const auto begin = value.find_first_not_of(" \t\n\r");
-    if (begin == std::string::npos) return "";
-    const auto end = value.find_last_not_of(" \t\n\r");
-    return value.substr(begin, end - begin + 1);
-}
-
-static std::vector<std::string> splitString(const std::string &value,
-                                            char delim) {
-    std::vector<std::string> result;
-    std::stringstream stream(value);
-    std::string item;
-    while (std::getline(stream, item, delim)) {
-        result.push_back(trim(item));
-    }
-    return result;
-}
-
-static bool parseTrailingHcaIndex(const std::string &hca_name, int &index) {
-    if (hca_name.empty() || !isdigit(hca_name.back())) return false;
-
-    size_t begin = hca_name.size() - 1;
-    while (begin > 0 && isdigit(hca_name[begin - 1])) begin--;
-
-    index = atoi(hca_name.c_str() + begin);
-    return true;
-}
-
-static bool isDigits(const std::string &value) {
-    return !value.empty() &&
-           std::all_of(value.begin(), value.end(),
-                       [](unsigned char ch) { return isdigit(ch); });
-}
-
-static std::string normalizeGpuLocation(const std::string &gpu_token) {
-    auto token = trim(gpu_token);
-    if (token.rfind(GPU_PREFIX, 0) == 0) return token;
-
-    const std::string gpu_prefix = "gpu";
-    if (token.size() > gpu_prefix.size() &&
-        strncasecmp(token.c_str(), gpu_prefix.c_str(), gpu_prefix.size()) ==
-            0) {
-        token = token.substr(gpu_prefix.size());
-    }
-
-    if (!isDigits(token)) return "";
-    return GPU_PREFIX + token;
-}
-
-static std::string resolveHcaName(const std::string &hca_token,
-                                  const std::vector<InfinibandDevice> &all_hca,
-                                  const std::unordered_set<std::string> &hcas) {
-    auto token = trim(hca_token);
-    if (token.empty()) return "";
-    if (hcas.count(token)) return token;
-
-    std::string numeric_token = token;
-    const std::string nic_prefix = "nic";
-    if (numeric_token.size() > nic_prefix.size() &&
-        strncasecmp(numeric_token.c_str(), nic_prefix.c_str(),
-                    nic_prefix.size()) == 0) {
-        numeric_token = numeric_token.substr(nic_prefix.size());
-    }
-    if (!isDigits(numeric_token)) return "";
-
-    auto mlx5_name = "mlx5_" + numeric_token;
-    if (hcas.count(mlx5_name)) return mlx5_name;
-
-    std::string matched_name;
-    int target_index = atoi(numeric_token.c_str());
-    for (const auto &hca : all_hca) {
-        int hca_index;
-        if (!parseTrailingHcaIndex(hca.name, hca_index) ||
-            hca_index != target_index) {
-            continue;
-        }
-        if (!matched_name.empty()) {
-            LOG(WARNING) << "Ambiguous HCA token '" << hca_token
-                         << "' in MC_GPU_HCA_AFFINITY; use exact HCA name.";
-            return "";
-        }
-        matched_name = hca.name;
-    }
-    return matched_name;
-}
-
-static void applyGpuHcaAffinityOverride(
-    TopologyMatrix &matrix, const std::vector<InfinibandDevice> &all_hca) {
-    const char *env = getenv("MC_GPU_HCA_AFFINITY");
-    if (!env || env[0] == '\0') return;
-
-    std::vector<std::string> all_hca_names;
-    std::unordered_set<std::string> all_hca_name_set;
-    for (const auto &hca : all_hca) {
-        all_hca_names.push_back(hca.name);
-        all_hca_name_set.insert(hca.name);
-    }
-
-    if (all_hca_names.empty()) {
-        LOG(WARNING) << "MC_GPU_HCA_AFFINITY is set, but no HCA was found.";
-        return;
-    }
-
-    for (const auto &raw_rule : splitString(env, ';')) {
-        const auto rule = trim(raw_rule);
-        if (rule.empty()) continue;
-
-        auto delim = rule.find('=');
-        if (delim == std::string::npos) delim = rule.find(':');
-        if (delim == std::string::npos) {
-            LOG(WARNING) << "Invalid MC_GPU_HCA_AFFINITY rule '" << rule
-                         << "'. Expected gpu:hca[,hca] or cuda:N=hca[,hca].";
-            continue;
-        }
-
-        auto gpu_location = normalizeGpuLocation(rule.substr(0, delim));
-        if (gpu_location.empty()) {
-            LOG(WARNING) << "Invalid GPU token in MC_GPU_HCA_AFFINITY rule '"
-                         << rule << "'.";
-            continue;
-        }
-
-        auto entry_it = matrix.find(gpu_location);
-        if (entry_it == matrix.end()) {
-            LOG(WARNING) << "MC_GPU_HCA_AFFINITY rule '" << rule
-                         << "' ignored because topology has no " << gpu_location
-                         << " entry.";
-            continue;
-        }
-
-        std::vector<std::string> preferred_hca;
-        std::unordered_set<std::string> preferred_set;
-        for (const auto &hca_token : splitString(rule.substr(delim + 1), ',')) {
-            auto hca_name =
-                resolveHcaName(hca_token, all_hca, all_hca_name_set);
-            if (hca_name.empty()) {
-                LOG(WARNING)
-                    << "Unknown HCA token '" << hca_token
-                    << "' in MC_GPU_HCA_AFFINITY rule '" << rule << "'.";
-                continue;
-            }
-            if (preferred_set.insert(hca_name).second) {
-                preferred_hca.push_back(hca_name);
-            }
-        }
-
-        if (preferred_hca.empty()) {
-            LOG(WARNING) << "MC_GPU_HCA_AFFINITY rule '" << rule
-                         << "' has no valid HCA and is ignored.";
-            continue;
-        }
-
-        std::vector<std::string> avail_hca;
-        for (const auto &hca_name : all_hca_names) {
-            if (!preferred_set.count(hca_name)) avail_hca.push_back(hca_name);
-        }
-
-        entry_it->second.preferred_hca = std::move(preferred_hca);
-        entry_it->second.avail_hca = std::move(avail_hca);
-    }
-}
-
 static void precomputeResolvedHcaPeerAffinity(
     const TopologyMatrix &matrix, const std::map<std::string, int> &hca_id_map,
     std::unordered_map<std::string,
@@ -324,7 +160,7 @@ static void precomputeResolvedHcaPeerAffinity(
     }
 
     for (const auto &entry : matrix) {
-        if (entry.first.rfind(GPU_PREFIX, 0) != 0) continue;
+        if (entry.first.rfind("cuda:", 0) != 0) continue;
 
         std::unordered_set<std::string> preferred_set(
             entry.second.preferred_hca.begin(),
@@ -696,7 +532,6 @@ int Topology::discover(const std::vector<std::string> &filter) {
         matrix_[ent.name] = ent;
     }
 #endif
-    applyGpuHcaAffinityOverride(matrix_, all_hca);
 #ifdef USE_UB
     auto ub_all_hca = listUBDevices(filter);
     for (auto &ent : discoverCpuTopology(ub_all_hca)) {

--- a/mooncake-transfer-engine/src/topology.cpp
+++ b/mooncake-transfer-engine/src/topology.cpp
@@ -311,9 +311,9 @@ static void applyGpuHcaAffinityOverride(
 
 static void precomputeResolvedHcaPeerAffinity(
     const TopologyMatrix &matrix, const std::map<std::string, int> &hca_id_map,
-    std::unordered_map<
-        std::string,
-        std::unordered_map<std::string, std::vector<int>>> &affinity_by_local) {
+    std::unordered_map<std::string,
+                       std::unordered_map<std::string, std::vector<int>>>
+        &affinity_by_local) {
     affinity_by_local.clear();
     const auto &config = globalConfig();
     if (!config.enable_hca_peer_affinity) return;
@@ -881,8 +881,8 @@ int Topology::resolve() {
                 hca_id_map[hca];
         }
     }
-    precomputeResolvedHcaPeerAffinity(
-        matrix_, hca_id_map, resolved_hca_peer_affinity_by_local_);
+    precomputeResolvedHcaPeerAffinity(matrix_, hca_id_map,
+                                      resolved_hca_peer_affinity_by_local_);
     return 0;
 }
 

--- a/mooncake-transfer-engine/src/topology.cpp
+++ b/mooncake-transfer-engine/src/topology.cpp
@@ -309,7 +309,12 @@ static void applyGpuHcaAffinityOverride(
     }
 }
 
-static void applyHcaPeerAffinity(TopologyMatrix &matrix) {
+static void precomputeResolvedHcaPeerAffinity(
+    const TopologyMatrix &matrix, const std::map<std::string, int> &hca_id_map,
+    std::unordered_map<
+        std::string,
+        std::unordered_map<std::string, std::vector<int>>> &affinity_by_local) {
+    affinity_by_local.clear();
     const auto &config = globalConfig();
     if (!config.enable_hca_peer_affinity) return;
     if (config.nic_peer_affinity.empty()) {
@@ -318,46 +323,32 @@ static void applyHcaPeerAffinity(TopologyMatrix &matrix) {
         return;
     }
 
-    for (auto &entry : matrix) {
+    for (const auto &entry : matrix) {
         if (entry.first.rfind(GPU_PREFIX, 0) != 0) continue;
-
-        std::vector<std::string> all_hca = entry.second.preferred_hca;
-        all_hca.insert(all_hca.end(), entry.second.avail_hca.begin(),
-                       entry.second.avail_hca.end());
 
         std::unordered_set<std::string> preferred_set(
             entry.second.preferred_hca.begin(),
             entry.second.preferred_hca.end());
-        std::vector<std::string> peer_preferred_hca;
-        std::unordered_set<std::string> peer_preferred_set;
 
-        for (const auto &local_hca : entry.second.preferred_hca) {
-            const auto mapping_it = config.nic_peer_affinity.find(local_hca);
-            if (mapping_it == config.nic_peer_affinity.end()) continue;
+        for (const auto &mapping : config.nic_peer_affinity) {
+            const auto &local_hca = mapping.first;
+            const auto &peer_hcas = mapping.second;
 
-            for (const auto &peer_hca : mapping_it->second) {
+            std::vector<int> peer_preferred_hca;
+            std::unordered_set<std::string> peer_preferred_set;
+            for (const auto &peer_hca : peer_hcas) {
                 if (!preferred_set.count(peer_hca)) continue;
+                auto hca_id_it = hca_id_map.find(peer_hca);
+                if (hca_id_it == hca_id_map.end()) continue;
                 if (peer_preferred_set.insert(peer_hca).second) {
-                    peer_preferred_hca.push_back(peer_hca);
+                    peer_preferred_hca.push_back(hca_id_it->second);
                 }
             }
-        }
 
-        if (peer_preferred_hca.empty()) {
-            LOG(WARNING) << "No MC_NIC_PEER_AFFINITY intersection for "
-                         << entry.first << "; keep existing preferred HCAs.";
-            continue;
+            if (peer_preferred_hca.empty()) continue;
+            affinity_by_local[local_hca][entry.first] =
+                std::move(peer_preferred_hca);
         }
-
-        std::vector<std::string> avail_hca;
-        std::unordered_set<std::string> seen_hca;
-        for (const auto &hca : all_hca) {
-            if (!seen_hca.insert(hca).second) continue;
-            if (!peer_preferred_set.count(hca)) avail_hca.push_back(hca);
-        }
-
-        entry.second.preferred_hca = std::move(peer_preferred_hca);
-        entry.second.avail_hca = std::move(avail_hca);
     }
 }
 
@@ -688,10 +679,12 @@ void Topology::clear() {
     matrix_.clear();
     hca_list_.clear();
     resolved_matrix_.clear();
+    resolved_hca_peer_affinity_by_local_.clear();
 }
 
 int Topology::discover(const std::vector<std::string> &filter) {
     matrix_.clear();
+    resolved_hca_peer_affinity_by_local_.clear();
     auto all_hca = listInfiniBandDevices(filter);
     for (auto &ent : discoverCpuTopology(all_hca)) {
         matrix_[ent.name] = ent;
@@ -734,6 +727,7 @@ int Topology::parse(const std::string &topology_json) {
     }
 
     matrix_.clear();
+    resolved_hca_peer_affinity_by_local_.clear();
     for (const auto &key : root.getMemberNames()) {
         const Json::Value &value = root[key];
         if (value.isArray() && value.size() == 2) {
@@ -753,7 +747,6 @@ int Topology::parse(const std::string &topology_json) {
         }
     }
 
-    applyHcaPeerAffinity(matrix_);
     return resolve();
 }
 
@@ -792,6 +785,36 @@ int Topology::selectDevice(const std::string storage_type,
     return selectDevice(storage_type, retry_count);
 }
 
+int Topology::selectDeviceByLocalHca(const std::string storage_type,
+                                     std::string_view local_hca,
+                                     int retry_count) {
+    if (!local_hca.empty()) {
+        auto local_it =
+            resolved_hca_peer_affinity_by_local_.find(std::string(local_hca));
+        if (local_it != resolved_hca_peer_affinity_by_local_.end()) {
+            auto hints_it = local_it->second.find(std::string(storage_type));
+            if (hints_it != local_it->second.end() &&
+                !hints_it->second.empty()) {
+                const auto &candidates = hints_it->second;
+                if (retry_count == 0) {
+                    int rand_value;
+                    if (use_round_robin_) {
+                        thread_local int tl_counter = 0;
+                        rand_value = tl_counter;
+                        tl_counter = (tl_counter + 1) % 10000;
+                    } else {
+                        rand_value = SimpleRandom::Get().next();
+                    }
+                    return candidates[rand_value % candidates.size()];
+                }
+                return candidates[(retry_count - 1) % candidates.size()];
+            }
+        }
+    }
+
+    return selectDevice(storage_type, retry_count);
+}
+
 int Topology::selectDevice(const std::string storage_type, int retry_count) {
     if (resolved_matrix_.count(storage_type) == 0) return ERR_DEVICE_NOT_FOUND;
 
@@ -823,6 +846,7 @@ int Topology::selectDevice(const std::string storage_type, int retry_count) {
 
 int Topology::resolve() {
     resolved_matrix_.clear();
+    resolved_hca_peer_affinity_by_local_.clear();
     hca_list_.clear();
     std::map<std::string, int> hca_id_map;
     int next_hca_map_index = 0;
@@ -857,6 +881,8 @@ int Topology::resolve() {
                 hca_id_map[hca];
         }
     }
+    precomputeResolvedHcaPeerAffinity(
+        matrix_, hca_id_map, resolved_hca_peer_affinity_by_local_);
     return 0;
 }
 

--- a/mooncake-transfer-engine/src/topology.cpp
+++ b/mooncake-transfer-engine/src/topology.cpp
@@ -14,11 +14,15 @@
 
 #include <glog/logging.h>
 
+#include <algorithm>
 #include <fstream>
 #include <iostream>
 #include <map>
 #include <set>
+#include <sstream>
 #include <string>
+#include <strings.h>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 #include <ctype.h>
@@ -31,6 +35,7 @@
 #include <sys/stat.h>
 
 #include "cuda_alike.h"
+#include "config.h"
 #include "memory_location.h"
 #include "topology.h"
 #ifdef USE_UB
@@ -141,6 +146,220 @@ struct InfinibandDevice {
     std::string pci_bus_id;
     int numa_node;
 };
+
+static std::string trim(const std::string &value) {
+    const auto begin = value.find_first_not_of(" \t\n\r");
+    if (begin == std::string::npos) return "";
+    const auto end = value.find_last_not_of(" \t\n\r");
+    return value.substr(begin, end - begin + 1);
+}
+
+static std::vector<std::string> splitString(const std::string &value,
+                                            char delim) {
+    std::vector<std::string> result;
+    std::stringstream stream(value);
+    std::string item;
+    while (std::getline(stream, item, delim)) {
+        result.push_back(trim(item));
+    }
+    return result;
+}
+
+static bool parseTrailingHcaIndex(const std::string &hca_name, int &index) {
+    if (hca_name.empty() || !isdigit(hca_name.back())) return false;
+
+    size_t begin = hca_name.size() - 1;
+    while (begin > 0 && isdigit(hca_name[begin - 1])) begin--;
+
+    index = atoi(hca_name.c_str() + begin);
+    return true;
+}
+
+static bool isDigits(const std::string &value) {
+    return !value.empty() &&
+           std::all_of(value.begin(), value.end(),
+                       [](unsigned char ch) { return isdigit(ch); });
+}
+
+static std::string normalizeGpuLocation(const std::string &gpu_token) {
+    auto token = trim(gpu_token);
+    if (token.rfind(GPU_PREFIX, 0) == 0) return token;
+
+    const std::string gpu_prefix = "gpu";
+    if (token.size() > gpu_prefix.size() &&
+        strncasecmp(token.c_str(), gpu_prefix.c_str(), gpu_prefix.size()) ==
+            0) {
+        token = token.substr(gpu_prefix.size());
+    }
+
+    if (!isDigits(token)) return "";
+    return GPU_PREFIX + token;
+}
+
+static std::string resolveHcaName(const std::string &hca_token,
+                                  const std::vector<InfinibandDevice> &all_hca,
+                                  const std::unordered_set<std::string> &hcas) {
+    auto token = trim(hca_token);
+    if (token.empty()) return "";
+    if (hcas.count(token)) return token;
+
+    std::string numeric_token = token;
+    const std::string nic_prefix = "nic";
+    if (numeric_token.size() > nic_prefix.size() &&
+        strncasecmp(numeric_token.c_str(), nic_prefix.c_str(),
+                    nic_prefix.size()) == 0) {
+        numeric_token = numeric_token.substr(nic_prefix.size());
+    }
+    if (!isDigits(numeric_token)) return "";
+
+    auto mlx5_name = "mlx5_" + numeric_token;
+    if (hcas.count(mlx5_name)) return mlx5_name;
+
+    std::string matched_name;
+    int target_index = atoi(numeric_token.c_str());
+    for (const auto &hca : all_hca) {
+        int hca_index;
+        if (!parseTrailingHcaIndex(hca.name, hca_index) ||
+            hca_index != target_index) {
+            continue;
+        }
+        if (!matched_name.empty()) {
+            LOG(WARNING) << "Ambiguous HCA token '" << hca_token
+                         << "' in MC_GPU_HCA_AFFINITY; use exact HCA name.";
+            return "";
+        }
+        matched_name = hca.name;
+    }
+    return matched_name;
+}
+
+static void applyGpuHcaAffinityOverride(
+    TopologyMatrix &matrix, const std::vector<InfinibandDevice> &all_hca) {
+    const char *env = getenv("MC_GPU_HCA_AFFINITY");
+    if (!env || env[0] == '\0') return;
+
+    std::vector<std::string> all_hca_names;
+    std::unordered_set<std::string> all_hca_name_set;
+    for (const auto &hca : all_hca) {
+        all_hca_names.push_back(hca.name);
+        all_hca_name_set.insert(hca.name);
+    }
+
+    if (all_hca_names.empty()) {
+        LOG(WARNING) << "MC_GPU_HCA_AFFINITY is set, but no HCA was found.";
+        return;
+    }
+
+    for (const auto &raw_rule : splitString(env, ';')) {
+        const auto rule = trim(raw_rule);
+        if (rule.empty()) continue;
+
+        auto delim = rule.find('=');
+        if (delim == std::string::npos) delim = rule.find(':');
+        if (delim == std::string::npos) {
+            LOG(WARNING) << "Invalid MC_GPU_HCA_AFFINITY rule '" << rule
+                         << "'. Expected gpu:hca[,hca] or cuda:N=hca[,hca].";
+            continue;
+        }
+
+        auto gpu_location = normalizeGpuLocation(rule.substr(0, delim));
+        if (gpu_location.empty()) {
+            LOG(WARNING) << "Invalid GPU token in MC_GPU_HCA_AFFINITY rule '"
+                         << rule << "'.";
+            continue;
+        }
+
+        auto entry_it = matrix.find(gpu_location);
+        if (entry_it == matrix.end()) {
+            LOG(WARNING) << "MC_GPU_HCA_AFFINITY rule '" << rule
+                         << "' ignored because topology has no " << gpu_location
+                         << " entry.";
+            continue;
+        }
+
+        std::vector<std::string> preferred_hca;
+        std::unordered_set<std::string> preferred_set;
+        for (const auto &hca_token : splitString(rule.substr(delim + 1), ',')) {
+            auto hca_name =
+                resolveHcaName(hca_token, all_hca, all_hca_name_set);
+            if (hca_name.empty()) {
+                LOG(WARNING)
+                    << "Unknown HCA token '" << hca_token
+                    << "' in MC_GPU_HCA_AFFINITY rule '" << rule << "'.";
+                continue;
+            }
+            if (preferred_set.insert(hca_name).second) {
+                preferred_hca.push_back(hca_name);
+            }
+        }
+
+        if (preferred_hca.empty()) {
+            LOG(WARNING) << "MC_GPU_HCA_AFFINITY rule '" << rule
+                         << "' has no valid HCA and is ignored.";
+            continue;
+        }
+
+        std::vector<std::string> avail_hca;
+        for (const auto &hca_name : all_hca_names) {
+            if (!preferred_set.count(hca_name)) avail_hca.push_back(hca_name);
+        }
+
+        entry_it->second.preferred_hca = std::move(preferred_hca);
+        entry_it->second.avail_hca = std::move(avail_hca);
+    }
+}
+
+static void applyHcaPeerAffinity(TopologyMatrix &matrix) {
+    const auto &config = globalConfig();
+    if (!config.enable_hca_peer_affinity) return;
+    if (config.nic_peer_affinity.empty()) {
+        LOG(WARNING) << "MC_ENABLE_HCA_PEER_AFFINITY is set, but "
+                        "MC_NIC_PEER_AFFINITY has no valid mappings.";
+        return;
+    }
+
+    for (auto &entry : matrix) {
+        if (entry.first.rfind(GPU_PREFIX, 0) != 0) continue;
+
+        std::vector<std::string> all_hca = entry.second.preferred_hca;
+        all_hca.insert(all_hca.end(), entry.second.avail_hca.begin(),
+                       entry.second.avail_hca.end());
+
+        std::unordered_set<std::string> preferred_set(
+            entry.second.preferred_hca.begin(),
+            entry.second.preferred_hca.end());
+        std::vector<std::string> peer_preferred_hca;
+        std::unordered_set<std::string> peer_preferred_set;
+
+        for (const auto &local_hca : entry.second.preferred_hca) {
+            const auto mapping_it = config.nic_peer_affinity.find(local_hca);
+            if (mapping_it == config.nic_peer_affinity.end()) continue;
+
+            for (const auto &peer_hca : mapping_it->second) {
+                if (!preferred_set.count(peer_hca)) continue;
+                if (peer_preferred_set.insert(peer_hca).second) {
+                    peer_preferred_hca.push_back(peer_hca);
+                }
+            }
+        }
+
+        if (peer_preferred_hca.empty()) {
+            LOG(WARNING) << "No MC_NIC_PEER_AFFINITY intersection for "
+                         << entry.first << "; keep existing preferred HCAs.";
+            continue;
+        }
+
+        std::vector<std::string> avail_hca;
+        std::unordered_set<std::string> seen_hca;
+        for (const auto &hca : all_hca) {
+            if (!seen_hca.insert(hca).second) continue;
+            if (!peer_preferred_set.count(hca)) avail_hca.push_back(hca);
+        }
+
+        entry.second.preferred_hca = std::move(peer_preferred_hca);
+        entry.second.avail_hca = std::move(avail_hca);
+    }
+}
 
 static std::vector<InfinibandDevice> listInfiniBandDevices(
     const std::vector<std::string> &filter) {
@@ -484,6 +703,7 @@ int Topology::discover(const std::vector<std::string> &filter) {
         matrix_[ent.name] = ent;
     }
 #endif
+    applyGpuHcaAffinityOverride(matrix_, all_hca);
 #ifdef USE_UB
     auto ub_all_hca = listUBDevices(filter);
     for (auto &ent : discoverCpuTopology(ub_all_hca)) {
@@ -533,6 +753,7 @@ int Topology::parse(const std::string &topology_json) {
         }
     }
 
+    applyHcaPeerAffinity(matrix_);
     return resolve();
 }
 

--- a/mooncake-transfer-engine/src/topology.cpp
+++ b/mooncake-transfer-engine/src/topology.cpp
@@ -145,6 +145,111 @@ struct InfinibandDevice {
     int numa_node;
 };
 
+static inline void ltrim(std::string &s) {
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](unsigned char ch) {
+                return !std::isspace(ch);
+            }));
+}
+
+static inline void rtrim(std::string &s) {
+    s.erase(std::find_if(s.rbegin(), s.rend(),
+                         [](unsigned char ch) { return !std::isspace(ch); })
+                .base(),
+            s.end());
+}
+
+static std::set<std::string> getIbvDeviceWhitelist() {
+    std::set<std::string> whitelist;
+    const char *env = std::getenv("MC_TE_FILTERS");
+    if (!env || !*env) {
+        return whitelist;
+    }
+
+    LOG(INFO) << "IB device whitelist: " << env;
+    std::string env_str(env);
+    size_t start = 0;
+    size_t pos = 0;
+    while ((pos = env_str.find(',', start)) != std::string::npos) {
+        std::string token = env_str.substr(start, pos - start);
+        ltrim(token);
+        rtrim(token);
+        if (!token.empty()) {
+            whitelist.insert(std::move(token));
+        }
+        start = pos + 1;
+    }
+    if (start < env_str.length()) {
+        std::string token = env_str.substr(start);
+        ltrim(token);
+        rtrim(token);
+        if (!token.empty()) {
+            whitelist.insert(std::move(token));
+        }
+    }
+    return whitelist;
+}
+
+static std::vector<InfinibandDevice> listInfiniBandDevices(
+    const std::vector<std::string> &filter) {
+    int num_devices = 0;
+    std::vector<InfinibandDevice> devices;
+    const auto whitelist = getIbvDeviceWhitelist();
+
+    struct ibv_device **device_list = ibv_get_device_list(&num_devices);
+    if (!device_list) {
+        LOG(WARNING) << "No RDMA devices found, check your device installation";
+        return {};
+    }
+    if (device_list && num_devices <= 0) {
+        LOG(WARNING) << "No RDMA devices found, check your device installation";
+        ibv_free_device_list(device_list);
+        return {};
+    }
+
+    for (int i = 0; i < num_devices; ++i) {
+        std::string device_name = ibv_get_device_name(device_list[i]);
+        if (!filter.empty() && std::find(filter.begin(), filter.end(),
+                                         device_name) == filter.end())
+            continue;
+
+        if (!whitelist.empty() &&
+            whitelist.find(device_name) == whitelist.end()) {
+            LOG(INFO) << "Skipping device: " << device_name;
+            continue;
+        }
+
+        // Check device availability before adding to the list
+        if (!isIbDeviceAvailable(device_list[i])) {
+            LOG(WARNING) << "Skipping unavailable device: " << device_name;
+            continue;
+        }
+
+        char path[PATH_MAX + 32];
+        char resolved_path[PATH_MAX];
+        // Get the PCI bus id for the infiniband device. Note that
+        // "/sys/class/infiniband/mlx5_X/" is a symlink to
+        // "/sys/devices/pciXXXX:XX/XXXX:XX:XX.X/infiniband/mlx5_X/".
+        snprintf(path, sizeof(path), "/sys/class/infiniband/%s/../..",
+                 device_name.c_str());
+        if (realpath(path, resolved_path) == NULL) {
+            PLOG(ERROR) << "listInfiniBandDevices: realpath " << path
+                        << " failed";
+            continue;
+        }
+        std::string pci_bus_id = basename(resolved_path);
+
+        int numa_node = -1;
+        snprintf(path, sizeof(path), "%s/numa_node", resolved_path);
+        std::ifstream(path) >> numa_node;
+
+        devices.push_back(InfinibandDevice{.name = std::move(device_name),
+                                           .pci_bus_id = std::move(pci_bus_id),
+                                           .numa_node = numa_node});
+    }
+    ibv_free_device_list(device_list);
+    return devices;
+}
+
 static void precomputeResolvedHcaPeerAffinity(
     const TopologyMatrix &matrix, const std::map<std::string, int> &hca_id_map,
     std::unordered_map<std::string,
@@ -186,60 +291,6 @@ static void precomputeResolvedHcaPeerAffinity(
                 std::move(peer_preferred_hca);
         }
     }
-}
-
-static std::vector<InfinibandDevice> listInfiniBandDevices(
-    const std::vector<std::string> &filter) {
-    int num_devices = 0;
-    std::vector<InfinibandDevice> devices;
-
-    struct ibv_device **device_list = ibv_get_device_list(&num_devices);
-    if (!device_list) {
-        LOG(WARNING) << "No RDMA devices found, check your device installation";
-        return {};
-    }
-    if (device_list && num_devices <= 0) {
-        LOG(WARNING) << "No RDMA devices found, check your device installation";
-        ibv_free_device_list(device_list);
-        return {};
-    }
-
-    for (int i = 0; i < num_devices; ++i) {
-        std::string device_name = ibv_get_device_name(device_list[i]);
-        if (!filter.empty() && std::find(filter.begin(), filter.end(),
-                                         device_name) == filter.end())
-            continue;
-
-        // Check device availability before adding to the list
-        if (!isIbDeviceAvailable(device_list[i])) {
-            LOG(WARNING) << "Skipping unavailable device: " << device_name;
-            continue;
-        }
-
-        char path[PATH_MAX + 32];
-        char resolved_path[PATH_MAX];
-        // Get the PCI bus id for the infiniband device. Note that
-        // "/sys/class/infiniband/mlx5_X/" is a symlink to
-        // "/sys/devices/pciXXXX:XX/XXXX:XX:XX.X/infiniband/mlx5_X/".
-        snprintf(path, sizeof(path), "/sys/class/infiniband/%s/../..",
-                 device_name.c_str());
-        if (realpath(path, resolved_path) == NULL) {
-            PLOG(ERROR) << "listInfiniBandDevices: realpath " << path
-                        << " failed";
-            continue;
-        }
-        std::string pci_bus_id = basename(resolved_path);
-
-        int numa_node = -1;
-        snprintf(path, sizeof(path), "%s/numa_node", resolved_path);
-        std::ifstream(path) >> numa_node;
-
-        devices.push_back(InfinibandDevice{.name = std::move(device_name),
-                                           .pci_bus_id = std::move(pci_bus_id),
-                                           .numa_node = numa_node});
-    }
-    ibv_free_device_list(device_list);
-    return devices;
 }
 
 #ifdef USE_UB

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
@@ -744,6 +744,33 @@ int RdmaTransport::selectDevice(SegmentDesc *desc, uint64_t offset,
     return ERR_ADDRESS_NOT_REGISTERED;
 }
 
+int RdmaTransport::selectDeviceByLocalHca(SegmentDesc *desc, uint64_t offset,
+                                          size_t length,
+                                          std::string_view local_hca,
+                                          int &buffer_id, int &device_id,
+                                          int retry_count) {
+    if (desc == nullptr) return ERR_ADDRESS_NOT_REGISTERED;
+    const auto &buffers = desc->buffers;
+    for (buffer_id = 0; buffer_id < static_cast<int>(buffers.size());
+         ++buffer_id) {
+        const auto &buffer = buffers[buffer_id];
+
+        if (offset < buffer.addr || length > buffer.length ||
+            offset - buffer.addr > buffer.length - length) {
+            continue;
+        }
+
+        const auto location = resolveBufferLocation(buffer, offset);
+        device_id = desc->topology.selectDeviceByLocalHca(
+            location, local_hca, retry_count);
+        if (device_id >= 0) return 0;
+        device_id = desc->topology.selectDeviceByLocalHca(
+            kWildcardLocation, local_hca, retry_count);
+        if (device_id >= 0) return 0;
+    }
+    return ERR_ADDRESS_NOT_REGISTERED;
+}
+
 int RdmaTransport::selectDevice(SegmentDesc *desc, uint64_t offset,
                                 size_t length, int &buffer_id, int &device_id,
                                 int retry_count) {

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
@@ -40,6 +40,17 @@ namespace mooncake {
 static bool MCIbRelaxedOrderingEnabled = false;
 static int MCIbRelaxedOrderingMode = 2;
 
+static std::string resolveBufferLocation(
+    const TransferMetadata::BufferDesc &buffer, uint64_t offset) {
+    std::string location = buffer.name;
+    SegmentsLocationInfo seg_info;
+    if (parseSegmentsLocation(buffer.name, seg_info)) {
+        location = resolveSegmentsLocation(seg_info, buffer.length,
+                                           offset - buffer.addr);
+    }
+    return location;
+}
+
 // Mode definition for MC_IB_PCI_RELAXED_ORDERING env.
 // 0 - disabled, 1 - enabled if supported, 2 - auto (default, same as 1 today).
 static int getIbRelaxedOrderingMode() {
@@ -502,6 +513,7 @@ Status RdmaTransport::submitTransferTask(
             slice->source_addr = (char *)request.source + offset;
             slice->length =
                 merge_final_slice ? request.length - offset : kBlockSize;
+            slice->source_location.clear();
             slice->opcode = request.opcode;
             slice->rdma.dest_addr = request.target_offset + offset;
             slice->rdma.retry_cnt = request.advise_retry_cnt;
@@ -558,6 +570,11 @@ Status RdmaTransport::submitTransferTask(
                 }
                 slice->rdma.source_lkey =
                     local_segment_desc->buffers[buffer_id].lkey[device_id];
+                if (globalConfig().log_rdma_slice_affinity) {
+                    slice->source_location = resolveBufferLocation(
+                        local_segment_desc->buffers[buffer_id],
+                        reinterpret_cast<uint64_t>(slice->source_addr));
+                }
                 slices_to_post[context].push_back(slice);
                 task.total_bytes += slice->length;
                 __sync_fetch_and_add(&task.slice_count, 1);

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
@@ -761,8 +761,8 @@ int RdmaTransport::selectDeviceByLocalHca(SegmentDesc *desc, uint64_t offset,
         }
 
         const auto location = resolveBufferLocation(buffer, offset);
-        device_id = desc->topology.selectDeviceByLocalHca(
-            location, local_hca, retry_count);
+        device_id = desc->topology.selectDeviceByLocalHca(location, local_hca,
+                                                          retry_count);
         if (device_id >= 0) return 0;
         device_id = desc->topology.selectDeviceByLocalHca(
             kWildcardLocation, local_hca, retry_count);

--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -19,6 +19,7 @@
 #include <cassert>
 
 #include "config.h"
+#include "memory_location.h"
 #include "transport/rdma_transport/rdma_context.h"
 #include "transport/rdma_transport/rdma_endpoint.h"
 #include "transport/rdma_transport/rdma_transport.h"
@@ -30,6 +31,22 @@
 namespace mooncake {
 
 const static int kTransferWorkerCount = globalConfig().workers_per_ctx;
+
+static std::string resolveBufferLocation(
+    const TransferMetadata::BufferDesc &buffer, uint64_t offset) {
+    std::string location = buffer.name;
+    SegmentsLocationInfo seg_info;
+    if (parseSegmentsLocation(buffer.name, seg_info)) {
+        location = resolveSegmentsLocation(seg_info, buffer.length,
+                                           offset - buffer.addr);
+    }
+    return location;
+}
+
+static const std::string &sourceLocationOrUnknown(Transport::Slice *slice) {
+    static const std::string kUnknown = "<unknown>";
+    return slice->source_location.empty() ? kUnknown : slice->source_location;
+}
 
 WorkerPool::WorkerPool(RdmaContext &context, int numa_socket_id)
     : context_(context),
@@ -146,6 +163,22 @@ int WorkerPool::submitPostSend(
             MakeNicPath(peer_segment_desc->name,
                         peer_segment_desc->devices[device_id].name);
         slice->peer_nic_path = peer_nic_path;
+        if (globalConfig().log_rdma_slice_affinity) {
+            LOG(INFO) << "RDMA slice affinity: source_location="
+                      << sourceLocationOrUnknown(slice)
+                      << ", target_location="
+                      << resolveBufferLocation(peer_segment_desc
+                                                   ->buffers[buffer_id],
+                                               slice->rdma.dest_addr)
+                      << ", local_device_name=" << context_.deviceName()
+                      << ", peer_device_name="
+                      << peer_segment_desc->devices[device_id].name
+                      << ", target_id=" << slice->target_id
+                      << ", source_addr=" << slice->source_addr
+                      << ", dest_addr="
+                      << reinterpret_cast<void *>(slice->rdma.dest_addr)
+                      << ", length=" << slice->length;
+        }
         int shard_id = (slice->target_id * 10007 + device_id) % kShardCount;
         slice_list_map[shard_id].push_back(slice);
         submitted_slice_count++;
@@ -383,6 +416,23 @@ void WorkerPool::redispatch(std::vector<Transport::Slice *> &slice_list,
                 MakeNicPath(peer_segment_desc->name,
                             peer_segment_desc->devices[device_id].name);
             slice->peer_nic_path = peer_nic_path;
+            if (globalConfig().log_rdma_slice_affinity) {
+                LOG(INFO) << "RDMA slice affinity: source_location="
+                          << sourceLocationOrUnknown(slice)
+                          << ", target_location="
+                          << resolveBufferLocation(peer_segment_desc
+                                                       ->buffers[buffer_id],
+                                                   slice->rdma.dest_addr)
+                          << ", local_device_name=" << context_.deviceName()
+                          << ", peer_device_name="
+                          << peer_segment_desc->devices[device_id].name
+                          << ", target_id=" << slice->target_id
+                          << ", source_addr=" << slice->source_addr
+                          << ", dest_addr="
+                          << reinterpret_cast<void *>(slice->rdma.dest_addr)
+                          << ", length=" << slice->length
+                          << ", retry_cnt=" << slice->rdma.retry_cnt;
+            }
             collective_slice_queue_[thread_id][peer_nic_path].push_back(slice);
         }
     }

--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -59,9 +59,8 @@ static int selectPeerDevice(RdmaTransport::SegmentDesc *peer_segment_desc,
             retry_count);
     }
 
-    auto hint = config.enable_dest_device_affinity
-                    ? std::string_view(local_hca)
-                    : std::string_view();
+    auto hint = config.enable_dest_device_affinity ? std::string_view(local_hca)
+                                                   : std::string_view();
     return RdmaTransport::selectDevice(peer_segment_desc, offset, length, hint,
                                        buffer_id, device_id, retry_count);
 }
@@ -158,10 +157,9 @@ int WorkerPool::submitPostSend(
                 continue;
             }
 
-            if (selectPeerDevice(peer_segment_desc.get(),
-                                 slice->rdma.dest_addr, slice->length,
-                                 context_.deviceName(), buffer_id,
-                                 device_id)) {
+            if (selectPeerDevice(peer_segment_desc.get(), slice->rdma.dest_addr,
+                                 slice->length, context_.deviceName(),
+                                 buffer_id, device_id)) {
                 slice->markFailed();
                 context_.engine().meta()->dumpMetadataContent(
                     peer_segment_desc->name, slice->rdma.dest_addr,
@@ -181,11 +179,10 @@ int WorkerPool::submitPostSend(
         slice->peer_nic_path = peer_nic_path;
         if (globalConfig().log_rdma_slice_affinity) {
             LOG(INFO) << "RDMA slice affinity: source_location="
-                      << sourceLocationOrUnknown(slice)
-                      << ", target_location="
-                      << resolveBufferLocation(peer_segment_desc
-                                                   ->buffers[buffer_id],
-                                               slice->rdma.dest_addr)
+                      << sourceLocationOrUnknown(slice) << ", target_location="
+                      << resolveBufferLocation(
+                             peer_segment_desc->buffers[buffer_id],
+                             slice->rdma.dest_addr)
                       << ", local_device_name=" << context_.deviceName()
                       << ", peer_device_name="
                       << peer_segment_desc->devices[device_id].name
@@ -420,8 +417,7 @@ void WorkerPool::redispatch(std::vector<Transport::Slice *> &slice_list,
             if (!peer_segment_desc ||
                 selectPeerDevice(peer_segment_desc.get(), slice->rdma.dest_addr,
                                  slice->length, context_.deviceName(),
-                                 buffer_id, device_id,
-                                 slice->rdma.retry_cnt)) {
+                                 buffer_id, device_id, slice->rdma.retry_cnt)) {
                 slice->markFailed();
                 processed_slice_count_++;
                 continue;
@@ -436,9 +432,9 @@ void WorkerPool::redispatch(std::vector<Transport::Slice *> &slice_list,
                 LOG(INFO) << "RDMA slice affinity: source_location="
                           << sourceLocationOrUnknown(slice)
                           << ", target_location="
-                          << resolveBufferLocation(peer_segment_desc
-                                                       ->buffers[buffer_id],
-                                                   slice->rdma.dest_addr)
+                          << resolveBufferLocation(
+                                 peer_segment_desc->buffers[buffer_id],
+                                 slice->rdma.dest_addr)
                           << ", local_device_name=" << context_.deviceName()
                           << ", peer_device_name="
                           << peer_segment_desc->devices[device_id].name

--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -178,19 +178,18 @@ int WorkerPool::submitPostSend(
                         peer_segment_desc->devices[device_id].name);
         slice->peer_nic_path = peer_nic_path;
         if (globalConfig().log_rdma_slice_affinity) {
-            LOG(INFO) << "RDMA slice affinity: source_location="
-                      << sourceLocationOrUnknown(slice) << ", target_location="
-                      << resolveBufferLocation(
-                             peer_segment_desc->buffers[buffer_id],
-                             slice->rdma.dest_addr)
-                      << ", local_device_name=" << context_.deviceName()
-                      << ", peer_device_name="
-                      << peer_segment_desc->devices[device_id].name
-                      << ", target_id=" << slice->target_id
-                      << ", source_addr=" << slice->source_addr
-                      << ", dest_addr="
-                      << reinterpret_cast<void *>(slice->rdma.dest_addr)
-                      << ", length=" << slice->length;
+            VLOG(1) << "RDMA slice affinity: source_location="
+                    << sourceLocationOrUnknown(slice) << ", target_location="
+                    << resolveBufferLocation(
+                           peer_segment_desc->buffers[buffer_id],
+                           slice->rdma.dest_addr)
+                    << ", local_device_name=" << context_.deviceName()
+                    << ", peer_device_name="
+                    << peer_segment_desc->devices[device_id].name
+                    << ", target_id=" << slice->target_id
+                    << ", source_addr=" << slice->source_addr << ", dest_addr="
+                    << reinterpret_cast<void *>(slice->rdma.dest_addr)
+                    << ", length=" << slice->length;
         }
         int shard_id = (slice->target_id * 10007 + device_id) % kShardCount;
         slice_list_map[shard_id].push_back(slice);
@@ -429,21 +428,21 @@ void WorkerPool::redispatch(std::vector<Transport::Slice *> &slice_list,
                             peer_segment_desc->devices[device_id].name);
             slice->peer_nic_path = peer_nic_path;
             if (globalConfig().log_rdma_slice_affinity) {
-                LOG(INFO) << "RDMA slice affinity: source_location="
-                          << sourceLocationOrUnknown(slice)
-                          << ", target_location="
-                          << resolveBufferLocation(
-                                 peer_segment_desc->buffers[buffer_id],
-                                 slice->rdma.dest_addr)
-                          << ", local_device_name=" << context_.deviceName()
-                          << ", peer_device_name="
-                          << peer_segment_desc->devices[device_id].name
-                          << ", target_id=" << slice->target_id
-                          << ", source_addr=" << slice->source_addr
-                          << ", dest_addr="
-                          << reinterpret_cast<void *>(slice->rdma.dest_addr)
-                          << ", length=" << slice->length
-                          << ", retry_cnt=" << slice->rdma.retry_cnt;
+                VLOG(1) << "RDMA slice affinity: source_location="
+                        << sourceLocationOrUnknown(slice)
+                        << ", target_location="
+                        << resolveBufferLocation(
+                               peer_segment_desc->buffers[buffer_id],
+                               slice->rdma.dest_addr)
+                        << ", local_device_name=" << context_.deviceName()
+                        << ", peer_device_name="
+                        << peer_segment_desc->devices[device_id].name
+                        << ", target_id=" << slice->target_id
+                        << ", source_addr=" << slice->source_addr
+                        << ", dest_addr="
+                        << reinterpret_cast<void *>(slice->rdma.dest_addr)
+                        << ", length=" << slice->length
+                        << ", retry_cnt=" << slice->rdma.retry_cnt;
             }
             collective_slice_queue_[thread_id][peer_nic_path].push_back(slice);
         }

--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -48,6 +48,24 @@ static const std::string &sourceLocationOrUnknown(Transport::Slice *slice) {
     return slice->source_location.empty() ? kUnknown : slice->source_location;
 }
 
+static int selectPeerDevice(RdmaTransport::SegmentDesc *peer_segment_desc,
+                            uint64_t offset, size_t length,
+                            const std::string &local_hca, int &buffer_id,
+                            int &device_id, int retry_count = 0) {
+    const auto &config = globalConfig();
+    if (config.enable_hca_peer_affinity) {
+        return RdmaTransport::selectDeviceByLocalHca(
+            peer_segment_desc, offset, length, local_hca, buffer_id, device_id,
+            retry_count);
+    }
+
+    auto hint = config.enable_dest_device_affinity
+                    ? std::string_view(local_hca)
+                    : std::string_view();
+    return RdmaTransport::selectDevice(peer_segment_desc, offset, length, hint,
+                                       buffer_id, device_id, retry_count);
+}
+
 WorkerPool::WorkerPool(RdmaContext &context, int numa_socket_id)
     : context_(context),
       numa_socket_id_(numa_socket_id),
@@ -127,12 +145,9 @@ int WorkerPool::submitPostSend(
         }
         auto &peer_segment_desc = segment_desc_map[slice->target_id];
         int buffer_id, device_id;
-        auto hint = globalConfig().enable_dest_device_affinity
-                        ? context_.deviceName()
-                        : "";
-        if (RdmaTransport::selectDevice(peer_segment_desc.get(),
-                                        slice->rdma.dest_addr, slice->length,
-                                        hint, buffer_id, device_id)) {
+        if (selectPeerDevice(peer_segment_desc.get(), slice->rdma.dest_addr,
+                             slice->length, context_.deviceName(), buffer_id,
+                             device_id)) {
             peer_segment_desc = context_.engine().meta()->getSegmentDescByID(
                 slice->target_id, true);
             if (!peer_segment_desc) {
@@ -143,9 +158,10 @@ int WorkerPool::submitPostSend(
                 continue;
             }
 
-            if (RdmaTransport::selectDevice(
-                    peer_segment_desc.get(), slice->rdma.dest_addr,
-                    slice->length, hint, buffer_id, device_id)) {
+            if (selectPeerDevice(peer_segment_desc.get(),
+                                 slice->rdma.dest_addr, slice->length,
+                                 context_.deviceName(), buffer_id,
+                                 device_id)) {
                 slice->markFailed();
                 context_.engine().meta()->dumpMetadataContent(
                     peer_segment_desc->name, slice->rdma.dest_addr,
@@ -402,10 +418,10 @@ void WorkerPool::redispatch(std::vector<Transport::Slice *> &slice_list,
             auto &peer_segment_desc = segment_desc_map[slice->target_id];
             int buffer_id, device_id;
             if (!peer_segment_desc ||
-                RdmaTransport::selectDevice(peer_segment_desc.get(),
-                                            slice->rdma.dest_addr,
-                                            slice->length, buffer_id, device_id,
-                                            slice->rdma.retry_cnt)) {
+                selectPeerDevice(peer_segment_desc.get(), slice->rdma.dest_addr,
+                                 slice->length, context_.deviceName(),
+                                 buffer_id, device_id,
+                                 slice->rdma.retry_cnt)) {
                 slice->markFailed();
                 processed_slice_count_++;
                 continue;


### PR DESCRIPTION
## Description

This change adds an opt-in HCA peer affinity path for RDMA transfers in multi-NIC, multi-GPU deployments. It lets operators configure an explicit local-HCA to peer-HCA mapping, so RDMA slice dispatch can select a peer HCA that matches both the sender's local NIC and the target buffer's topology.

Default behavior is unchanged unless `MC_ENABLE_HCA_PEER_AFFINITY` is enabled.

## Usage

### Assumptions

This feature is intended for homogeneous RDMA clusters. It assumes:

- all servers expose the same RDMA HCA names, such as `mlx5_0`, `mlx5_1`, and so on;
- all servers have the same intra-node topology, including GPU-to-HCA and NUMA-to-HCA relationships.

With these assumptions, the same `MC_GPU_HCA_AFFINITY` and `MC_NIC_PEER_AFFINITY` rules can be reused across servers.

### Configuration

#### `MC_GPU_HCA_AFFINITY`

Overrides the preferred HCA list for GPU topology entries discovered by Transfer Engine.

#### `MC_NIC_PEER_AFFINITY`

Describes which peer HCAs should be preferred for each local HCA.

For each RDMA slice, the sender uses its local HCA name and the target buffer location to select a peer device:

1. Find peer HCA candidates configured for the local HCA.
2. Intersect those candidates with the target location's preferred HCA list.
3. Choose among the remaining candidates using the existing random or round-robin policy.
4. Fall back to normal topology selection if no valid peer-affinity candidate is available.

#### `MC_ENABLE_HCA_PEER_AFFINITY`

Enables local-HCA based peer HCA selection.

This mode is mutually exclusive with `MC_ENABLE_DEST_DEVICE_AFFINITY`. If both are enabled, both affinity modes are disabled and Transfer Engine falls back to default peer device selection.

#### `MC_LOG_RDMA_SLICE_AFFINITY`

Enables optional per-slice RDMA affinity logs for validation. Each log line includes the source location, target location, local HCA, and selected peer HCA.

### Example

Assume a two-node setup where each node has four GPUs and eight RDMA HCAs. The desired fabric mapping is:

- local `mlx5_0` should target peer `mlx5_4` or `mlx5_5`;
- local `mlx5_1` should target peer `mlx5_6` or `mlx5_7`;
- peer GPU 0 should prefer `mlx5_4` and `mlx5_6`;
- peer GPU 1 should prefer `mlx5_5` and `mlx5_7`.

Configure the peer process topology:

```bash
export MC_GPU_HCA_AFFINITY="cuda:0=mlx5_4,mlx5_6;cuda:1=mlx5_5,mlx5_7"
```

Configure the sender process peer mapping:

```bash
export MC_ENABLE_HCA_PEER_AFFINITY=1
export MC_NIC_PEER_AFFINITY="mlx5_0=mlx5_4,mlx5_5;mlx5_1=mlx5_6,mlx5_7"
```

If a slice is sent through local `mlx5_0` to a target buffer resolved as `cuda:0`, the peer candidates are:

- mapping for local `mlx5_0`: `mlx5_4`, `mlx5_5`;
- preferred HCAs for target `cuda:0`: `mlx5_4`, `mlx5_6`;
- final candidate set: `mlx5_4`.

The slice is posted to peer `mlx5_4`. If the intersection is empty, the code falls back to the existing topology-aware selector.

### Performance Experiments

We also validated the change with `transfer_engine_bench` on two H200 servers. The results below compare the existing destination-device affinity path with the new HCA peer affinity modes.

Common benchmark settings:

- setup: two H200 servers, one initiator and one target;
- protocol: `rdma` with `P2PHANDSHAKE`;
- HCA list: 8 RDMA HCAs with consistent device names across both servers;
- VRAM transfer: `--use_vram=true`;
- buffer size: `268435456`;
- block size: `65536`;
- batch size: `16`;
- duration: `10` seconds;
- path policy: `MC_PATH_ROUNDROBIN=1`.

Test cases:

- existing destination-device affinity baseline;
- new HCA peer affinity with one-to-one local-to-peer HCA mapping;
- new HCA peer affinity with cross-rail local-to-peer HCA mapping.

#### Single GPU

Single-GPU runs use `GPU_ID=0` and `THREADS=1`.

| Case | Read throughput | Write throughput |
|------|-----------------|------------------|
| Existing destination-device affinity baseline | 18.24 GB/s | 18.35 GB/s |
| HCA peer affinity with one-to-one mapping | 18.40 GB/s | 18.45 GB/s |
| HCA peer affinity with cross-rail mapping | 16.55 GB/s | 16.77 GB/s |

#### 8 GPUs Concurrently

Eight-GPU runs use `GPU_ID=-1` and `THREADS=8`.

| Case | Read throughput | Write throughput |
|------|-----------------|------------------|
| Existing destination-device affinity baseline | 118.47 GB/s | 113.32 GB/s |
| HCA peer affinity with one-to-one mapping | 118.27 GB/s | 112.83 GB/s |
| HCA peer affinity with cross-rail mapping | 102.98 GB/s | 111.03 GB/s |

The one-to-one HCA peer affinity case is on par with the existing destination-device affinity baseline in both single-GPU and 8-GPU runs. The cross-rail case confirms that explicit local-to-peer HCA mapping is functional, with throughput depending on the selected fabric path.


## Module

- [✅] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [✅] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



**Test commands:**
```bash
# Example: bash scripts/run_ci_test.sh
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [ ] AI tools were used (specify below)