### PR TITLE
fix(transport): associate task.request in EFA/Kunpeng submitTransfer

### DIFF
--- a/mooncake-transfer-engine/src/transport/efa_transport/efa_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/efa_transport/efa_transport.cpp
@@ -775,7 +775,17 @@ Status EfaTransport::submitTransfer(
     size_t task_id = batch_desc.task_list.size();
     batch_desc.task_list.resize(task_id + entries.size());
     std::vector<TransferTask*> task_list;
-    for (auto& task : batch_desc.task_list) task_list.push_back(&task);
+    for (auto& request : entries) {
+        auto& task = batch_desc.task_list[task_id];
+        ++task_id;
+        task.batch_id = batch_id;
+#ifdef USE_ASCEND_HETEROGENEOUS
+        task.request = const_cast<TransferRequest*>(&request);
+#else
+        task.request = &request;
+#endif
+        task_list.push_back(&task);
+    }
     return submitTransferTask(task_list);
 }
 

--- a/mooncake-transfer-engine/src/transport/kunpeng_transport/ub_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/kunpeng_transport/ub_transport.cpp
@@ -186,8 +186,18 @@ Status UbTransport::submitTransfer(
     size_t task_id = batch_desc.task_list.size();
     batch_desc.task_list.resize(task_id + entries.size());
     std::vector<TransferTask*> task_list;
-    task_list.reserve(batch_desc.task_list.size());
-    for (auto& task : batch_desc.task_list) task_list.push_back(&task);
+    task_list.reserve(entries.size());
+    for (auto& request : entries) {
+        auto& task = batch_desc.task_list[task_id];
+        ++task_id;
+        task.batch_id = batch_id;
+#ifdef USE_ASCEND_HETEROGENEOUS
+        task.request = const_cast<TransferRequest*>(&request);
+#else
+        task.request = &request;
+#endif
+        task_list.push_back(&task);
+    }
     return submitTransferTask(task_list);
 }
 


### PR DESCRIPTION
## Description

Follow-up parity fix to #2610. That PR restored the `task.request` association in `RdmaTransport::submitTransfer(BatchID, entries)`. `EfaTransport` and Kunpeng `UbTransport` carry the exact same defect and are the only two transports whose `submitTransfer` override still has it.

Both overrides resize `batch_desc.task_list` to make room for the new entries and then push every slot into `submitTransferTask()`, but they never set `task.request` on the freshly created tasks. `submitTransferTask()` immediately does:

```cpp
assert(task.request);
auto &request = *task.request;
```

so each task entering through this path carries a null `request` pointer — assert failure in debug builds, undefined behavior / segfault in release.

The fix mirrors #2610: for each new entry, set `task.batch_id` and `task.request` (with the same `USE_ASCEND_HETEROGENEOUS` `const_cast` the other transports use) before delegating, and submit only the newly added tasks instead of re-pushing the whole list.

After this, `MultiTransport`, `TcpTransport`, `RdmaTransport`, `EfaTransport` and `UbTransport` all populate the association consistently.

A note on reachability, to be upfront: in the default engine path `MultiTransport::submitTransfer` sets `task.request` itself before calling `submitTransferTask`, so it never hits these overrides. `RdmaTransport`'s override is exercised through the `HeterogeneousRdmaTransport` wrapper; EFA and Kunpeng UB have no equivalent wrapper today, so their overrides are currently only reachable via the `Transport`-level API and the bug is latent there. This closes that contract gap so the override is correct for any caller, same as #2610.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

Verified by code inspection against the merged #2610 fix and the `MultiTransport`/`TcpTransport` implementations of the same association. Exercising the EFA / Kunpeng paths at runtime needs the corresponding hardware, which I don't have, so like #2610 there is no added unit test and I'm relying on CI for the build.

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

Reviewed the diff against #2610 and the sibling transports; confirmed `clang-format` is clean on both files.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `clang-format` (matches `./scripts/code_format.sh` style)
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue (N/A, ~20 LOC)

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

Used Claude Code to help cross-check the fix against the #2610 pattern and the other transports. I reviewed and understand the change and am responsible for it.