### PR TITLE
[TENT] Add optional Request.deadline_ns and MLU observability metric (RFC #2519 step 1)

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/common/types.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/types.h
@@ -79,6 +79,12 @@ struct Request {
     TransportType transport_hint =
         UNSPEC;  // UNSPEC = follow policy; otherwise pin this request to the
                  // name transport.
+    // Optional SLO deadline as an absolute steady_clock timestamp in
+    // nanoseconds. 0 = no deadline (default), behaves exactly as today.
+    // When set, the engine emits an observability-only feasibility metric
+    // (MLU = actual transfer time / available window) on completion; it does
+    // not yet drive any admission or scheduling decision. See RFC #2519.
+    uint64_t deadline_ns = 0;
 };
 
 enum TransferStatusEnum {

--- a/mooncake-transfer-engine/tent/include/tent/metrics/tent_metrics.h
+++ b/mooncake-transfer-engine/tent/include/tent/metrics/tent_metrics.h
@@ -81,6 +81,12 @@ class TentMetrics {
     void recordWriteFailed(size_t bytes);
     void recordTransportFailover();
 
+    // Record the deadline feasibility ratio (MLU) for a completed transfer
+    // that carried a deadline. mlu = actual_transfer_seconds / window_seconds,
+    // where window_seconds is (deadline - submit_time). mlu < 1 means the
+    // transfer met its deadline; mlu >= 1 means it missed. Observability only.
+    void recordDeadlineMLU(double mlu);
+
     // Get metrics for HTTP server
     std::string getPrometheusMetrics();
     std::string getJsonMetrics();
@@ -160,6 +166,17 @@ class TentMetrics {
     ylt::metric::histogram_t write_size_{
         "tent_write_size_bytes", "Write request size distribution in bytes",
         kSizeBuckets};
+
+    // Deadline feasibility ratio (MLU) distribution for transfers that carried
+    // a deadline. Stored in per-mille (MLU x 1000) so the histogram can use
+    // integer observe() like the others; the 1000 boundary is MLU == 1.0, the
+    // feasible/infeasible line (< 1000 met the deadline, >= 1000 missed it).
+    static inline const std::vector<double> kMluPerMilleBuckets{
+        100, 250, 500, 750, 900, 1000, 1250, 1500, 2000, 5000};
+    ylt::metric::histogram_t deadline_mlu_{
+        "tent_deadline_mlu_permille",
+        "Deadline feasibility ratio (MLU x 1000) distribution",
+        kMluPerMilleBuckets};
 
     // Helper to register all metrics to the vectors
     void registerMetrics();

--- a/mooncake-transfer-engine/tent/src/metrics/tent_metrics.cpp
+++ b/mooncake-transfer-engine/tent/src/metrics/tent_metrics.cpp
@@ -173,8 +173,8 @@ void TentMetrics::shutdown() {
 void TentMetrics::registerMetrics() {
     // Pre-allocate vectors to avoid reallocation
     counters_.reserve(7);
-    histograms_.reserve(4);
-    histogram_boundaries_.reserve(4);
+    histograms_.reserve(5);
+    histogram_boundaries_.reserve(5);
 
     // Register all counters - add new counters here
     counters_ = {
@@ -186,16 +186,12 @@ void TentMetrics::registerMetrics() {
     // Register all histograms - add new histograms here
     // Note: histogram_boundaries_ must match the order of histograms_
     histograms_ = {
-        &read_latency_,
-        &write_latency_,
-        &read_size_,
-        &write_size_,
+        &read_latency_, &write_latency_, &read_size_,
+        &write_size_,   &deadline_mlu_,
     };
     histogram_boundaries_ = {
-        kLatencyBuckets,
-        kLatencyBuckets,
-        kSizeBuckets,
-        kSizeBuckets,
+        kLatencyBuckets, kLatencyBuckets,     kSizeBuckets,
+        kSizeBuckets,    kMluPerMilleBuckets,
     };
 }
 
@@ -227,6 +223,15 @@ void TentMetrics::recordWriteCompleted(size_t bytes, double latency_seconds) {
         int64_t latency_us = static_cast<int64_t>(latency_seconds * 1000000.0);
         write_latency_.observe(latency_us);
     }
+}
+
+void TentMetrics::recordDeadlineMLU(double mlu) {
+    // Fast path: check runtime switch first
+    if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
+        return;
+    if (mlu < 0.0) return;  // defensive: ignore invalid (e.g. window <= 0)
+    // Store in per-mille so the integer histogram can bucket fractional ratios.
+    deadline_mlu_.observe(static_cast<int64_t>(mlu * 1000.0));
 }
 
 void TentMetrics::recordReadFailed(size_t bytes) {
@@ -384,6 +389,7 @@ void TentMetrics::recordWriteCompleted(size_t, double) {}
 void TentMetrics::recordReadFailed(size_t) {}
 void TentMetrics::recordWriteFailed(size_t) {}
 void TentMetrics::recordTransportFailover() {}
+void TentMetrics::recordDeadlineMLU(double) {}
 
 std::string TentMetrics::getPrometheusMetrics() {
     return "# TENT metrics disabled at compile time\n";

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -1680,6 +1680,26 @@ void TransferEngineImpl::recordTaskCompletionMetrics(
                     TentMetrics::instance().recordWriteCompleted(
                         task.request.length, latency_seconds);
                 }
+                // Observability only (RFC #2519): if this transfer carried a
+                // deadline, emit the post-hoc feasibility ratio MLU =
+                // actual_transfer_time / available_window, where the window is
+                // (deadline - submit_time). MLU < 1 met the deadline; >= 1
+                // missed it. This does not drive any admission/scheduling yet.
+                if (task.request.deadline_ns != 0) {
+                    uint64_t start_ns = static_cast<uint64_t>(
+                        std::chrono::duration_cast<std::chrono::nanoseconds>(
+                            start_time.time_since_epoch())
+                            .count());
+                    if (task.request.deadline_ns > start_ns) {
+                        double window_seconds =
+                            (task.request.deadline_ns - start_ns) / 1e9;
+                        TentMetrics::instance().recordDeadlineMLU(
+                            latency_seconds / window_seconds);
+                    } else {
+                        // Deadline already in the past at submit: infeasible.
+                        TentMetrics::instance().recordDeadlineMLU(5.0);
+                    }
+                }
             } else if (new_status == FAILED) {
                 if (task.request.opcode == Request::READ) {
                     TentMetrics::instance().recordReadFailed(


### PR DESCRIPTION
## Description

Minimal first step of RFC #2519 (deadline-aware admission), scoped to what
@alogfans approved:

> "LGTM for the minimal first step (deadline_ns field + MLU observability
> only). Let's see the MLU metrics on real workloads before adding policy
> logic."

This adds the deadline plumbing + an **observability-only** feasibility
metric. There is **no admission, scheduling, or degradation logic** — the
deadline does not affect any transfer decision yet.

### Changes
- **`types.h`**: add optional `uint64_t deadline_ns = 0` to `Request`. `0`
  (default) is bit-for-bit today's behavior; nothing reads it unless the
  caller sets it. It is an absolute `steady_clock` timestamp in ns.
- **`tent_metrics`**: add `recordDeadlineMLU(double)` and a `deadline_mlu`
  histogram. MLU (laxity feasibility ratio) is stored in **per-mille**
  (MLU × 1000) so it uses the same integer `observe()` as the other
  histograms; the `1000` boundary is `MLU == 1.0` (< 1000 met the deadline,
  ≥ 1000 missed). Both the enabled and the compile-time-disabled
  (`TENT_METRICS_ENABLED=0`) stubs are provided.
- **`transfer_engine_impl`**: at task completion, when the request carried a
  deadline, emit the post-hoc `MLU = actual_transfer_time / window`, where
  `window = deadline − submit_time`. Reuses the `start_time` /
  `latency_seconds` already computed at the completion point — no new
  measurement subsystem.

### Why post-hoc MLU (and not the predictive submit-time MLU from RFC §2)
Device pinning happens *after* submit, so a per-device EWMA-bandwidth
predictive MLU isn't available at submit time (this is open question #2 in
the RFC). The post-hoc ratio validates whether MLU is a useful signal on
real workloads first — exactly the "see the metrics before adding policy"
step requested. The predictive/admission layers are deliberate follow-ups.

## Module
- [x] Transfer Engine (`mooncake-transfer-engine`) — TENT runtime

## Type of Change
- [x] New feature (observability)

## How Has This Been Tested?
Additive and behavior-preserving when `deadline_ns == 0` (the default), which
is every existing caller. The MLU path only runs when a caller opts in by
setting a deadline, and only emits a histogram observation.

- [ ] Unit tests pass — N/A yet (observability-only; see note)
- [ ] Integration tests pass
- [ ] Manual testing done

> Notes:
> - Not built locally (no TENT toolchain on my dev machine); relying on CI.
> - Real-workload MLU numbers (what @alogfans asked to see) are still TODO —
>   they require building with `-DTENT_METRICS_ENABLED=ON` and a caller that
>   sets `deadline_ns`. Happy to follow up with measurements; opening the PR
>   now so the integration point can be reviewed in parallel.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have formatted my code using clang-format (v20.1.8)
- [ ] I have run `pre-commit run --all-files`
- [x] For changes >500 LOC: I have filed an RFC issue — RFC #2519

## AI Assistance Disclosure
- [x] AI tools were used (Claude Code) for code navigation and drafting.