### PR TITLE
[TE] Fix signed-char isxdigit UB in EFA smaps page-size parsing (follow-up to #2504)

### DIFF
--- a/mooncake-transfer-engine/src/transport/efa_transport/efa_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/efa_transport/efa_transport.cpp
@@ -59,8 +59,12 @@ static size_t detectBufferPageSize(void* addr) {
     bool in_range = false;
 
     while (std::getline(smaps, line)) {
-        // VMA header: "start-end perms offset dev inode [pathname]"
-        if (!line.empty() && std::isxdigit(line[0])) {
+        // VMA header: "start-end perms offset dev inode [pathname]".
+        // Cast to unsigned char before std::isxdigit: passing a (possibly
+        // signed) char whose value is > 0x7F is UB, since the argument must be
+        // representable as unsigned char or equal EOF.
+        if (!line.empty() &&
+            std::isxdigit(static_cast<unsigned char>(line[0]))) {
             unsigned long start = 0, end = 0;
             if (sscanf(line.c_str(), "%lx-%lx", &start, &end) == 2) {
                 in_range = (target >= start && target < end);


### PR DESCRIPTION
## Description

`detectBufferPageSize()` in the EFA transport scans `/proc/self/smaps` and uses `std::isxdigit(line[0])` to recognize VMA header lines. `line[0]` is a plain `char` from `std::getline`; where `char` is signed, a byte `> 0x7F` becomes a negative `int`. Passing that to `std::isxdigit` is undefined behavior — the argument must be representable as `unsigned char` or equal `EOF`. The fix casts to `unsigned char` first.

This is the same class of bug fixed for the PCI BDF lowercasing loops in #2367 / #2488 / #2504 (which added `char_util.h::to_lower`). That sweep didn't reach `efa_transport.cpp` — this was the last remaining un-cast ctype call across `mooncake-transfer-engine` and `mooncake-store`. I kept it inline rather than routing through a helper, since it's a single classification site (`isxdigit`), unlike the multi-site case conversion that justified `to_lower()`. Happy to switch to a shared helper if you'd prefer consistency.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

No unit test: `detectBufferPageSize()` is a file-static helper that reads `/proc/self/smaps` directly, so there's no seam to inject a crafted line without refactoring the function — the same reason #2504 shipped the `char_util.h` helper without a dedicated test. The change is verified by the C++ ctype contract (the `static_cast<unsigned char>` is the documented precondition) and is parity with the existing sweep. No behavior change for realistic input: smaps header lines start with an ASCII hex address and attribute lines with ASCII keywords, so the predicate's result is unchanged — this only removes the UB on the value passed in.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh` (clang-format)

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

Used Claude Code to help locate the remaining un-cast ctype site and draft the change. I reviewed and verified the fix and am responsible for it.