### PR TITLE
[Bugfix] Fix RDMA active handshake timeout race with simultaneous passive connection

### DIFF
--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -64,6 +64,17 @@ static void rememberAutoGidSelection(
     }
 }
 
+static std::string qpListToString(const std::vector<uint32_t> &qp_num) {
+    std::ostringstream oss;
+    oss << "[";
+    for (size_t i = 0; i < qp_num.size(); ++i) {
+        if (i) oss << ",";
+        oss << qp_num[i];
+    }
+    oss << "]";
+    return oss.str();
+}
+
 RdmaEndPoint::RdmaEndPoint(RdmaContext &context)
     : context_(context),
       status_(INITIALIZING),
@@ -391,13 +402,32 @@ int RdmaEndPoint::setupConnectionsByActive() {
         // `peer_qp_num_list_` with `peer_desc.qp_num`, since a failed RPC may
         // result in an invalid `peer_desc.qp_num`.
         //
-        // If the RPC is failed, even if the state is CONNECTED, (which means
-        // it is handled by setupConnectionsByPassive in another thread during
-        // the RPC, or "simultaneous open"), we should resetConnection to be
-        // safe. Because we're not sure whether the peer needs a connection
-        // re-establishment. (We don't know `peer_desc.qp_num`)
+        // If the RPC failed but simultaneous-open passive setup has already
+        // made this endpoint CONNECTED with the same local QPs used by this
+        // RPC, reuse that connection. Otherwise reset because
+        // `peer_desc.qp_num` is invalid and we cannot safely infer the peer
+        // state.
         if (rc) {
             RWSpinlock::WriteGuard write_guard(lock_);
+            if (connected()) {
+                auto current_qp_num = qpNum();
+                if (current_qp_num == local_desc.qp_num) {
+                    LOG(WARNING)
+                        << "Active handshake RPC failed, but simultaneous-open "
+                           "passive setup already connected this endpoint. "
+                           "Reusing existing connection. rc="
+                        << rc << ", local_desc.qp_num="
+                        << qpListToString(local_desc.qp_num)
+                        << ", current_qp_num=" << qpListToString(current_qp_num)
+                        << ", endpoint=" << toString();
+                    return 0;
+                }
+            }
+
+            LOG(ERROR) << "Active handshake RPC failed; resetting endpoint. rc="
+                       << rc << ", local_desc.qp_num="
+                       << qpListToString(local_desc.qp_num)
+                       << ", endpoint=" << toString();
             resetConnection("handshake RPC failure");
             return rc;
         }


### PR DESCRIPTION
## Description

During simultaneous RDMA connection setup, both peers may initiate active handshakes at nearly the same time. While one active handshake RPC is still waiting, the same endpoint may already be connected by an incoming passive handshake from the peer.

If the active RPC later times out, the old code treats the RPC failure as a connection failure without checking whether the endpoint has already become CONNECTED. It then calls resetConnection("handshake RPC failure"), which can reset or retire an endpoint that is already usable.

This may invalidate the local QPs while the peer still considers the old connection valid, leaving both sides with inconsistent QP state and causing later RDMA transfers to fail.

This patch re-checks the endpoint state under lock when the active handshake RPC fails. If the endpoint is already CONNECTED and its current local QP numbers match the QPs advertised by this active handshake request, the connection is treated as a successful simultaneous-open passive connection and reused. Otherwise, the original reset behavior is preserved.

```mermaid
sequenceDiagram
    autonumber
    participant AW as "A worker"
    participant AE as "A endpoint(B)"
    participant RPC as "Handshake RPC"
    participant BE as "B endpoint(A)"
    participant BW as "B worker"

    Note over AW,BW: Both sides need RDMA connection at nearly the same time

    par A actively connects to B
        AW->>AE: setupConnectionsByActive()
        AE->>RPC: sendHandshake(A local QPNs)
    and B actively connects to A
        BW->>BE: setupConnectionsByActive()
        BE->>RPC: sendHandshake(B local QPNs)
    end

    RPC-->>AE: B->A passive handshake arrives first
    AE->>AE: setupConnectionsByPassive()
    AE->>AE: QPs move to RTR/RTS
    AE->>AE: status = CONNECTED

    Note over AE: A endpoint(B) is already usable<br/>via simultaneous passive setup

    RPC--x AE: A active handshake RPC times out

    rect rgb(255, 235, 235)
        Note over AE: Old behavior
        AE->>AE: does not re-check connected state
        AE->>AE: resetConnection("handshake RPC failure")
        AE->>AE: reset/retire an already connected endpoint
    end

    Note over AE,BE: Peer may still use the old QPs,<br/>but local endpoint has been reset/retired
```