### PR TITLE
[CI] Disable pip cache in build-flags to avoid disk exhaustion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -500,6 +500,7 @@ jobs:
       BUILD_WITH_EP: "1"
       TORCH_CUDA_ARCH_LIST: "8.0;9.0"
       SCCACHE_GHA_ENABLED: "true"
+      PIP_NO_CACHE_DIR: "1"
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
The `build-flags` job builds many configs back-to-back on one `ubuntu-22.04` runner, including the EP step that pip-installs all 5 torch versions (`2.9.1`→`2.12.1`). Their wheel cache (several GB, plus the `nvidia-cu12` deps) is never reclaimed, so the later `Build project with TENT` step hits `No space left on device` (e.g. https://github.com/kvcache-ai/Mooncake/actions/runs/28183041682).

The root `build/` dir cant be cleaned mid-job (the wheel step reads from it) and the existing "Free up disk space" step is already present, so the safe lever is to stop pip from retaining the cached wheels. `PIP_NO_CACHE_DIR=1` is behavior-neutral (cache is only an optimization) and frees the largest reclaimable chunk.

Minimal, scoped to the `build-flags` job.