### PR TITLE
[TE] Guard against null endpoint_store_ in UrmaContext destructor

### DIFF
--- a/mooncake-transfer-engine/src/transport/kunpeng_transport/urma/urma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/kunpeng_transport/urma/urma_endpoint.cpp
@@ -38,7 +38,9 @@ UrmaContext::~UrmaContext() {
     auto thisString = toString();
     worker_pool_.reset();
     LOG(INFO) << "destroy worker pool done.";
-    endpoint_store_->destroy();
+    if (endpoint_store_) {
+        endpoint_store_->destroy();
+    }
     LOG(INFO) << "destroy endpoint store done.";
     if (urma_context_) deconstruct();
     LOG(WARNING) << "finished destroy context : " << thisString;


### PR DESCRIPTION
### Problem

`UbContext::doConstruct()` only assigns `endpoint_store_` after the virtual `construct()` succeeds:

```cpp
int doConstruct(GlobalConfig& config) {
    ...
    if (construct(config)) {
        LOG(INFO) << "failed construct context " << toString();
        return 1;                       // early return, endpoint_store_ still null
    }
    endpoint_store_ =
        std::make_shared<UbSIEVEEndpointStore>(max_endpoints_);
    ...
}
```

`UrmaContext::construct()` returns `ERR_CONTEXT` on any of the normal device-init failures (`openDevice`, `urma_create_jfce`, `urma_create_jfc`, `urma_create_jfr`). When that happens the context object is fully constructed but `endpoint_store_` is left as a default (null) `std::shared_ptr`.

The destructor then dereferences it unconditionally:

```cpp
UrmaContext::~UrmaContext() {
    ...
    worker_pool_.reset();                 // null-safe
    LOG(INFO) << "destroy worker pool done.";
    endpoint_store_->destroy();           // null deref when construct() failed
    LOG(INFO) << "destroy endpoint store done.";
    if (urma_context_) deconstruct();     // null-checked
    ...
}
```

So a Kunpeng/URMA device that fails to initialize crashes on cleanup instead of failing gracefully.

### Fix

Guard the call the same way the two neighbouring members in the same destructor are already guarded (`worker_pool_.reset()` is null-safe and `urma_context_` is explicitly checked):

```cpp
if (endpoint_store_) {
    endpoint_store_->destroy();
}
```

### Verification

I don't have Kunpeng/URMA hardware to drive the device-init failure path locally, so this relies on CI for compilation. The change is a minimal null guard that mirrors the existing null-safe handling of the sibling members in the same destructor; behaviour on the success path is unchanged.