### PR TITLE
[Store] Fix source refcnt leak in CopyEnd/MoveEnd on invalid source

### DIFF
--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -3497,6 +3497,12 @@ tl::expected<void, ErrorCode> MasterService::CopyEnd(
         LOG(ERROR) << "key=" << key << ", source_id=" << source_id
                    << ", status=" << (source == nullptr ? "nullptr" : "invalid")
                    << ", copy source becomes invalid during data transfer";
+        // Release the refcnt taken in CopyStart. The success path below does
+        // this once the copy completes; this error path must do it too, or the
+        // source replica stays pinned and can never be evicted.
+        if (source != nullptr) {
+            source->dec_refcnt();
+        }
         // Discard target replicas and clear the replication task.
         EraseReplicasWithCacheTotalAccounting(
             metadata, [&task](const Replica& replica) {
@@ -3724,6 +3730,12 @@ tl::expected<void, ErrorCode> MasterService::MoveEnd(
         LOG(ERROR) << "key=" << key << ", source_id=" << source_id
                    << ", status=" << (source == nullptr ? "nullptr" : "invalid")
                    << ", move source becomes invalid during data transfer";
+        // Release the refcnt taken in MoveStart. The success path below does
+        // this once the move completes; this error path must do it too, or the
+        // source replica stays pinned and can never be evicted.
+        if (source != nullptr) {
+            source->dec_refcnt();
+        }
         // Discard target replica and clear the replication task.
         EraseReplicasWithCacheTotalAccounting(
             metadata, [&task](const Replica& replica) {


### PR DESCRIPTION
### Problem

`CopyStart` increments the source replica's refcnt to protect it from eviction while the copy is in flight:

```cpp
// CopyStart
source->inc_refcnt();
```

`CopyEnd` is expected to release it. The success path does, at the end:

```cpp
// CopyEnd, success path
source->dec_refcnt();
```

But the error path that fires when the source becomes invalid mid-transfer returns early **without** decrementing:

```cpp
auto source = metadata.GetReplicaByID(source_id);
if (source == nullptr || !source->is_completed() ||
    source->has_invalid_mem_handle()) {
    LOG(ERROR) << ... << ", copy source becomes invalid during data transfer";
    EraseReplicasWithCacheTotalAccounting(metadata, ...);  // erases the *targets*
    accessor.EraseReplicationTask();
    if (!metadata.IsValid()) {
        accessor.Erase();
    }
    return tl::make_unexpected(ErrorCode::REPLICA_IS_GONE);  // source refcnt never released
}
```

When `source` is non-null but `has_invalid_mem_handle()` is true (its segment was unmounted during the transfer) or `!is_completed()`, the `inc_refcnt()` from `CopyStart` is never balanced. The cleanup in this branch erases the copy *targets* (`task.replica_ids`), not the source, so the source replica stays in metadata with an elevated refcnt and can never be evicted.

`MoveEnd` has the identical pattern against `MoveStart`'s `inc_refcnt()`.

### Fix

Release the refcnt on the error path for a non-null source, mirroring what `CopyRevoke` / `MoveRevoke` already do:

```cpp
// CopyRevoke (existing)
if (source == nullptr) {
    LOG(WARNING) << ... << ", copy source not found during revoke";
} else {
    source->dec_refcnt();
}
```

The added guard only decrements when `source != nullptr`, so the genuine `source == nullptr` case (nothing to release) is unaffected, and the success path is unchanged.

### Verification

The replica refcnt isn't observable through the public `MasterService` API (the leak only surfaces later as a source replica that can't be evicted), so I haven't added a focused unit test that would be reliable without reaching into internals. The change is a two-line symmetry fix that makes the error path balance the `inc_refcnt()` exactly like the success path and the existing `*Revoke` paths; it relies on CI for the build and the existing master-service tests for regression coverage.