### PR TITLE
[Store] Don't abort client init on a malformed MC_MS_AUTO_DISC value

### DIFF
--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -393,18 +393,23 @@ Client::~Client() {
 static std::optional<bool> get_auto_discover() {
     const char* ev_ad = std::getenv("MC_MS_AUTO_DISC");
     if (ev_ad) {
-        int iv = std::stoi(ev_ad);
-        if (iv == 1) {
-            LOG(INFO) << "auto discovery set by env MC_MS_AUTO_DISC";
-            return true;
-        } else if (iv == 0) {
-            LOG(INFO) << "auto discovery not set by env MC_MS_AUTO_DISC";
-            return false;
-        } else {
-            LOG(WARNING)
-                << "invalid MC_MS_AUTO_DISC value: " << ev_ad
-                << ", should be 0 or 1, using default: auto discovery not set";
+        try {
+            int iv = std::stoi(ev_ad);
+            if (iv == 1) {
+                LOG(INFO) << "auto discovery set by env MC_MS_AUTO_DISC";
+                return true;
+            } else if (iv == 0) {
+                LOG(INFO) << "auto discovery not set by env MC_MS_AUTO_DISC";
+                return false;
+            }
+        } catch (const std::exception&) {
+            // A non-numeric or out-of-range value makes std::stoi throw; fall
+            // through to the warning below and use the default instead of
+            // letting the exception abort client initialization.
         }
+        LOG(WARNING)
+            << "invalid MC_MS_AUTO_DISC value: " << ev_ad
+            << ", should be 0 or 1, using default: auto discovery not set";
     }
     return std::nullopt;
 }


### PR DESCRIPTION
## Description

`get_auto_discover()` (mooncake-store/src/client_service.cpp) reads the `MC_MS_AUTO_DISC` env var and parses it with `std::stoi`:

```cpp
int iv = std::stoi(ev_ad);
if (iv == 1) { ... return true; }
else if (iv == 0) { ... return false; }
else { LOG(WARNING) << "invalid MC_MS_AUTO_DISC value: " << ev_ad
                    << ", should be 0 or 1, using default: ..."; }
```

The `else` branch shows the intent is to tolerate a bad value: warn and fall back to the default. But it only covers the case where `std::stoi` *succeeds* and returns something other than 0 or 1. A value `std::stoi` cannot parse — a non-numeric string (`MC_MS_AUTO_DISC=true`), an empty-but-set var (`MC_MS_AUTO_DISC=`), or an out-of-range number (`MC_MS_AUTO_DISC=99999999999999`) — makes `std::stoi` throw `std::invalid_argument` / `std::out_of_range`.

Neither `get_auto_discover()` nor its caller `Client::InitTransferEngine()` catches it, so a simple typo in the env var aborts client initialization with an uncaught exception instead of warning and continuing with the default.

This is the same "be lenient about config/env input" class as #2506 (string-boolean parsing for `enable_ssd_offload`); this is the C++ side of the same idea.

## Fix

Wrap the parse in `try`/`catch` and route the throwing cases through the same warning-and-default path the numeric out-of-range case already uses. Valid `0` / `1` values keep their existing behavior; every invalid value now degrades gracefully whether `std::stoi` rejects it or returns it.

```diff
-        int iv = std::stoi(ev_ad);
-        if (iv == 1) { ... return true; }
-        else if (iv == 0) { ... return false; }
-        else { LOG(WARNING) << "invalid MC_MS_AUTO_DISC value: " ... }
+        try {
+            int iv = std::stoi(ev_ad);
+            if (iv == 1) { ... return true; }
+            else if (iv == 0) { ... return false; }
+        } catch (const std::exception&) {
+            // fall through to the warning below instead of aborting init
+        }
+        LOG(WARNING) << "invalid MC_MS_AUTO_DISC value: " ...
```

`std::exception` is already caught elsewhere in this translation unit, so no new include is needed. Out of scope: values like `1.5` are still accepted as `1` (existing `std::stoi` leniency); this change only stops the throw.

## Module

- [x] Mooncake Store (`mooncake-store`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

The target function is `static` (file-local), so it cannot be unit-tested directly, and a full Mooncake build isn't available in my environment. I verified the behavior by extracting a faithful, isolated mirror of both the buggy and fixed parse and compiling it with g++ (`-std=c++17`):

| `MC_MS_AUTO_DISC` | before | after |
| --- | --- | --- |
| `1` / `0` | returns true / false | unchanged |
| `5` | warns, default | unchanged |
| `abc` | **throws `std::invalid_argument`** | warns, default |
| `` (empty) | **throws `std::invalid_argument`** | warns, default |
| `99999999999999` | **throws `std::out_of_range`** | warns, default |

The "before" column reproduces the uncaught throw; the "after" column shows it routed to the existing warning-and-default path. Worth a maintainer running the repo's normal store test suite to confirm nothing else changes.