### PR TITLE
[TE] Add metadata versioning

### DIFF
--- a/docs/source/design/transfer-engine/index.md
+++ b/docs/source/design/transfer-engine/index.md
@@ -122,6 +122,13 @@ After successfully compiling Transfer Engine, the test program `transfer_engine_
       go run . --addr=:8080
       ```
 
+    :::{toctree}
+    :maxdepth: 1
+
+    metadata
+    :::
+
+
 2. **Start the target node.**
     ```bash
     ./transfer_engine_bench --mode=target \

--- a/docs/source/design/transfer-engine/index.md
+++ b/docs/source/design/transfer-engine/index.md
@@ -79,6 +79,12 @@ next data transfer attempt.
 
 Evicted and deleted endpoints are moved to an internal `waiting_list_` and reclaimed asynchronously once their outstanding slices drain. Reclaim runs on every new endpoint insertion, and additionally on a ~1 Hz heartbeat from the per-context `monitorWorker`, so the waiting list drains even under failure load where new insertions stall while evictions continue.
 
+### Metadata Versioning
+
+See [Metadata Versioning and Replacement](metadata.md) for how Transfer Engine
+refreshes cached segment descriptors, stages metadata-backed memory
+deregistration, and invalidates RDMA resources when peer metadata changes.
+
 ### Fault Handling
 In a multi-NIC environment, one common failure scenario is the temporary unavailability of a specific NIC, while other routes may still connect two nodes.
 Mooncake Store is designed to adeptly manage such temporary

--- a/docs/source/design/transfer-engine/metadata.md
+++ b/docs/source/design/transfer-engine/metadata.md
@@ -1,0 +1,54 @@
+# Metadata Versioning and Replacement
+
+Transfer Engine caches segment metadata locally. A segment name or id can be
+reused after a remote process is replaced, and memory registration changes can
+also change the buffers, keys, or devices behind the same handle. Cached RDMA
+resources therefore need a small freshness signal.
+
+## Segment Version
+
+Each `SegmentDesc` carries a `metadata_version` field. New local descriptors are
+normalized to version `1`; every published descriptor change advances the value
+to:
+
+```text
+max(now_ns, previous_metadata_version + 1)
+```
+
+Descriptors without the field are treated as legacy metadata with version `0`.
+
+## Cache Refresh
+
+`MC_METADATA_CACHE_TTL_MS` controls when a cached remote descriptor becomes
+eligible for refresh. The default is `1000` ms. Setting it to `0` keeps the
+historical non-expiring behavior unless a caller requests `force_update=true`.
+
+If refresh fails and the caller did not force it, Transfer Engine keeps using
+the previous cached descriptor. This is a best-effort cache refresh, not a
+metadata backend lease or watch protocol.
+
+## Memory Deregistration
+
+When memory is deregistered with metadata update enabled, Transfer Engine first
+publishes the buffer as `DRAINING`. New RDMA path selection skips non-`READY`
+buffers. After `MC_METADATA_DEREG_GRACE_MS` elapses, the buffer is removed from
+the descriptor and the final descriptor is published.
+
+The grace period defaults to `1000` ms and is clamped to at least the metadata
+cache TTL.
+
+## RDMA Resource Invalidation
+
+RDMA workers remember the last observed metadata version and peer NIC paths for
+each target segment. When a refreshed descriptor has a different version, the
+worker deletes endpoints associated with the old peer NIC paths and clears their
+rail state.
+
+This rule is intentionally conservative:
+
+```text
+same segment handle + different metadata_version = invalidate derived RDMA resources
+```
+
+The mechanism is best effort. It does not support concurrent owners of the same
+segment handle or provide strict fencing across metadata backends.

--- a/mooncake-transfer-engine/include/config.h
+++ b/mooncake-transfer-engine/include/config.h
@@ -60,6 +60,8 @@ struct GlobalConfig {
     // which is minutes. Override via MC_HANDSHAKE_CONNECT_TIMEOUT.
     int handshake_connect_timeout = 5;
     bool metacache = true;
+    uint64_t metadata_cache_ttl_ms = 1000;
+    uint64_t metadata_deregister_grace_ms = 1000;
     int log_level = google::INFO;
     bool trace = false;
     int64_t slice_timeout = -1;

--- a/mooncake-transfer-engine/include/transfer_metadata.h
+++ b/mooncake-transfer-engine/include/transfer_metadata.h
@@ -50,9 +50,13 @@ class TransferMetadata {
     };
 
     struct BufferDesc {
+        static constexpr const char* STATE_READY = "READY";
+        static constexpr const char* STATE_DRAINING = "DRAINING";
+
         std::string name;
         uint64_t addr;
         uint64_t length;
+        std::string state;
 #ifdef ENABLE_MULTI_PROTOCOL
         std::string protocol;  // for multi-protocol mode (cxl/tcp/rdma)
 #endif
@@ -107,6 +111,7 @@ class TransferMetadata {
         uint64_t cxl_base_addr;
         // TODO : make these two a union or a std::variant
         std::string timestamp;
+        uint64_t metadata_version = 0;
         // this is for ascend
         RankInfoDesc rank_info;
 
@@ -238,6 +243,12 @@ class TransferMetadata {
                           Json::Value &local_json);
     int receivePeerProbe(const Json::Value &peer_json, Json::Value &local_json);
     std::string getFullMetadataKey(const std::string &segment_name) const;
+    void updateSegmentCacheEntryLocked(
+        SegmentID segment_id, const std::string &segment_name,
+        const std::shared_ptr<SegmentDesc> &desc);
+    bool isSegmentCacheFreshLocked(SegmentID segment_id) const;
+    std::shared_ptr<SegmentDesc> getLocalSegmentDescByName(
+        const std::string &segment_name);
 
     bool p2p_handshake_mode_{false};
     std::string common_key_prefix_;
@@ -247,6 +258,7 @@ class TransferMetadata {
     std::unordered_map<uint64_t, std::shared_ptr<SegmentDesc>>
         segment_id_to_desc_map_;
     std::unordered_map<std::string, uint64_t> segment_name_to_id_map_;
+    std::unordered_map<uint64_t, uint64_t> segment_cache_update_ns_map_;
 
     RWSpinlock notify_lock_;
     std::vector<NotifyDesc> notifys;

--- a/mooncake-transfer-engine/include/transfer_metadata.h
+++ b/mooncake-transfer-engine/include/transfer_metadata.h
@@ -50,8 +50,8 @@ class TransferMetadata {
     };
 
     struct BufferDesc {
-        static constexpr const char* STATE_READY = "READY";
-        static constexpr const char* STATE_DRAINING = "DRAINING";
+        static constexpr const char *STATE_READY = "READY";
+        static constexpr const char *STATE_DRAINING = "DRAINING";
 
         std::string name;
         uint64_t addr;

--- a/mooncake-transfer-engine/include/transport/rdma_transport/worker_pool.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/worker_pool.h
@@ -54,6 +54,11 @@ class WorkerPool {
 
     void markRailFailed(const std::string &peer_nic_path);
     bool isRailAvailable(const std::string &peer_nic_path);
+    void clearRailState(const std::vector<std::string> &peer_nic_paths);
+    std::vector<std::string> buildPeerNicPaths(
+        const Transport::SegmentDesc &desc) const;
+    void recordPeerMetadataVersion(SegmentID segment_id,
+                                   const Transport::SegmentDesc &desc);
 
     // Retry helper: increment retry count and return whether retry is allowed
     static bool shouldRetrySlice(Transport::Slice *slice);
@@ -110,6 +115,14 @@ class WorkerPool {
     // Rail state management: peer_nic_path -> RailState
     std::unordered_map<std::string, RailState> rail_states_;
     std::mutex rail_state_lock_;
+
+    struct TargetMetadataState {
+        bool initialized = false;
+        uint64_t metadata_version = 0;
+        std::vector<std::string> peer_nic_paths;
+    };
+    std::unordered_map<SegmentID, TargetMetadataState> target_metadata_;
+    std::mutex target_metadata_lock_;
 
     // Rail monitor configuration
     const static int kRailErrorThreshold = 5;            // Errors before pause

--- a/mooncake-transfer-engine/src/config.cpp
+++ b/mooncake-transfer-engine/src/config.cpp
@@ -43,6 +43,22 @@ std::vector<std::string> splitConfigString(const std::string& value,
     return result;
 }
 
+void loadUint64Env(const char* name, uint64_t& target, uint64_t max_value) {
+    const char* env = std::getenv(name);
+    if (!env) return;
+    try {
+        uint64_t value = std::stoull(env);
+        if (value <= max_value) {
+            target = value;
+        } else {
+            LOG(WARNING) << "Ignore value from environment variable " << name;
+        }
+    } catch (const std::exception& e) {
+        LOG(WARNING) << "Invalid " << name << " environment value: " << env
+                     << ". Error: " << e.what();
+    }
+}
+
 bool parseBoolConfigEnv(const char* value, const char* env_name, bool& output) {
     if (strcmp(value, "1") == 0 || strcasecmp(value, "true") == 0) {
         output = true;
@@ -315,6 +331,13 @@ void loadGlobalConfig(GlobalConfig& config) {
     const char* disable_metacache = std::getenv("MC_DISABLE_METACACHE");
     if (disable_metacache) {
         config.metacache = false;
+    }
+    loadUint64Env("MC_METADATA_CACHE_TTL_MS", config.metadata_cache_ttl_ms,
+                  3600ULL * 1000ULL);
+    loadUint64Env("MC_METADATA_DEREG_GRACE_MS",
+                  config.metadata_deregister_grace_ms, 3600ULL * 1000ULL);
+    if (config.metadata_deregister_grace_ms < config.metadata_cache_ttl_ms) {
+        config.metadata_deregister_grace_ms = config.metadata_cache_ttl_ms;
     }
 
     const char* handshake_listen_backlog =
@@ -628,6 +651,10 @@ void dumpGlobalConfig() {
     LOG(INFO) << "max_wr = " << config.max_wr;
     LOG(INFO) << "max_inline = " << config.max_inline;
     LOG(INFO) << "mtu_length = " << mtuLengthToString(config.mtu_length);
+    LOG(INFO) << "metadata_cache_ttl_ms = "
+              << config.metadata_cache_ttl_ms;
+    LOG(INFO) << "metadata_deregister_grace_ms = "
+              << config.metadata_deregister_grace_ms;
     LOG(INFO) << "parallel_reg_mr = " << config.parallel_reg_mr;
     LOG(INFO) << "ib_traffic_class = " << config.ib_traffic_class;
     LOG(INFO) << "ib_service_level = " << config.ib_service_level;

--- a/mooncake-transfer-engine/src/config.cpp
+++ b/mooncake-transfer-engine/src/config.cpp
@@ -651,8 +651,7 @@ void dumpGlobalConfig() {
     LOG(INFO) << "max_wr = " << config.max_wr;
     LOG(INFO) << "max_inline = " << config.max_inline;
     LOG(INFO) << "mtu_length = " << mtuLengthToString(config.mtu_length);
-    LOG(INFO) << "metadata_cache_ttl_ms = "
-              << config.metadata_cache_ttl_ms;
+    LOG(INFO) << "metadata_cache_ttl_ms = " << config.metadata_cache_ttl_ms;
     LOG(INFO) << "metadata_deregister_grace_ms = "
               << config.metadata_deregister_grace_ms;
     LOG(INFO) << "parallel_reg_mr = " << config.parallel_reg_mr;

--- a/mooncake-transfer-engine/src/transfer_metadata.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata.cpp
@@ -49,7 +49,8 @@ static inline std::string extractProtocolFromConnString(
     return "etcd";
 }
 
-static void normalizeSegmentDescForPublish(TransferMetadata::SegmentDesc &desc) {
+static void normalizeSegmentDescForPublish(
+    TransferMetadata::SegmentDesc &desc) {
     if (desc.metadata_version == 0) desc.metadata_version = 1;
     for (auto &buffer : desc.buffers) {
         if (buffer.state.empty())
@@ -59,8 +60,7 @@ static void normalizeSegmentDescForPublish(TransferMetadata::SegmentDesc &desc) 
 
 static void bumpSegmentMetadataVersion(TransferMetadata::SegmentDesc &desc) {
     uint64_t now_ns = getCurrentTimeInNano();
-    desc.metadata_version =
-        std::max(now_ns, desc.metadata_version + 1);
+    desc.metadata_version = std::max(now_ns, desc.metadata_version + 1);
 }
 
 static void decodeBufferState(const Json::Value &bufferJSON,
@@ -525,7 +525,8 @@ int TransferMetadata::updateSegmentDesc(const std::string &segment_name,
 
     if (!storage_plugin_->set(getFullMetadataKey(segment_name), segmentJSON)) {
         LOG(ERROR) << "Failed to register segment descriptor, name "
-                   << publish_desc.name << " protocol " << publish_desc.protocol;
+                   << publish_desc.name << " protocol "
+                   << publish_desc.protocol;
         return ERR_METADATA;
     }
 
@@ -1266,9 +1267,8 @@ int TransferMetadata::removeLocalMemoryBuffer(void *addr,
                      iter != segment_desc->buffers.end(); ++iter) {
                     if (iter->addr == (uint64_t)addr
 #ifdef USE_CXL
-                        ||
-                        (iter->offset + segment_desc->cxl_base_addr) ==
-                            (uint64_t)addr
+                        || (iter->offset + segment_desc->cxl_base_addr) ==
+                               (uint64_t)addr
 #endif
                     ) {
                         segment_desc->buffers.erase(iter);

--- a/mooncake-transfer-engine/src/transfer_metadata.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata.cpp
@@ -15,10 +15,11 @@
 #include "transfer_metadata.h"
 
 #include <json/value.h>
+#include <unistd.h>
 
+#include <algorithm>
 #include <cassert>
 #include <set>
-#include <algorithm>
 
 #include "common.h"
 #include "config.h"
@@ -46,6 +47,33 @@ static inline std::string extractProtocolFromConnString(
         return conn_string.substr(0, pos);
     }
     return "etcd";
+}
+
+static void normalizeSegmentDescForPublish(TransferMetadata::SegmentDesc &desc) {
+    if (desc.metadata_version == 0) desc.metadata_version = 1;
+    for (auto &buffer : desc.buffers) {
+        if (buffer.state.empty())
+            buffer.state = TransferMetadata::BufferDesc::STATE_READY;
+    }
+}
+
+static void bumpSegmentMetadataVersion(TransferMetadata::SegmentDesc &desc) {
+    uint64_t now_ns = getCurrentTimeInNano();
+    desc.metadata_version =
+        std::max(now_ns, desc.metadata_version + 1);
+}
+
+static void decodeBufferState(const Json::Value &bufferJSON,
+                              TransferMetadata::BufferDesc &buffer) {
+    if (bufferJSON.isMember("state"))
+        buffer.state = bufferJSON["state"].asString();
+    else
+        buffer.state = TransferMetadata::BufferDesc::STATE_READY;
+}
+
+static void encodeBufferState(const TransferMetadata::BufferDesc &buffer,
+                              Json::Value &bufferJSON) {
+    if (!buffer.state.empty()) bufferJSON["state"] = buffer.state;
 }
 
 struct TransferNotifyUtil {
@@ -229,6 +257,8 @@ static int encodeMultiProtocolSegmentDesc(
     if (!desc.rdma_server_name.empty()) {
         segmentJSON["rdma_server_name"] = desc.rdma_server_name;
     }
+    segmentJSON["metadata_version"] =
+        static_cast<Json::UInt64>(desc.metadata_version);
     Json::Value protocolJSON(Json::arrayValue);
     for (const auto &proto : protocols) {
         if (proto == "rdma") {
@@ -270,6 +300,7 @@ static int encodeMultiProtocolSegmentDesc(
         } else if (buffer.protocol == "tcp") {
             bufferJSON["addr"] = static_cast<Json::UInt64>(buffer.addr);
         }
+        encodeBufferState(buffer, bufferJSON);
         buffersJSON.append(bufferJSON);
     }
     segmentJSON["buffers"] = buffersJSON;
@@ -325,6 +356,8 @@ int TransferMetadata::encodeSegmentDesc(const SegmentDesc &desc,
     segmentJSON["protocol"] = desc.protocol;
     segmentJSON["tcp_data_port"] = desc.tcp_data_port;
     segmentJSON["timestamp"] = getCurrentDateTime();
+    segmentJSON["metadata_version"] =
+        static_cast<Json::UInt64>(desc.metadata_version);
     if (!desc.rdma_server_name.empty()) {
         segmentJSON["rdma_server_name"] = desc.rdma_server_name;
     }
@@ -354,6 +387,7 @@ int TransferMetadata::encodeSegmentDesc(const SegmentDesc &desc,
             Json::Value lkeyJSON(Json::arrayValue);
             for (auto &entry : buffer.lkey) lkeyJSON.append(entry);
             bufferJSON["lkey"] = lkeyJSON;
+            encodeBufferState(buffer, bufferJSON);
             buffersJSON.append(bufferJSON);
         }
         segmentJSON["buffers"] = buffersJSON;
@@ -377,6 +411,7 @@ int TransferMetadata::encodeSegmentDesc(const SegmentDesc &desc,
             Json::Value tsegJSON(Json::arrayValue);
             for (auto &entry : buffer.tseg) tsegJSON.append(entry);
             bufferJSON["tseg"] = tsegJSON;
+            encodeBufferState(buffer, bufferJSON);
             buffersJSON.append(bufferJSON);
         }
         segmentJSON["buffers"] = buffersJSON;
@@ -388,6 +423,7 @@ int TransferMetadata::encodeSegmentDesc(const SegmentDesc &desc,
             bufferJSON["name"] = buffer.name;
             bufferJSON["addr"] = static_cast<Json::UInt64>(buffer.addr);
             bufferJSON["length"] = static_cast<Json::UInt64>(buffer.length);
+            encodeBufferState(buffer, bufferJSON);
             buffersJSON.append(bufferJSON);
         }
         segmentJSON["buffers"] = buffersJSON;
@@ -406,6 +442,7 @@ int TransferMetadata::encodeSegmentDesc(const SegmentDesc &desc,
             bufferJSON["name"] = buffer.name;
             bufferJSON["addr"] = static_cast<Json::UInt64>(buffer.addr);
             bufferJSON["length"] = static_cast<Json::UInt64>(buffer.length);
+            encodeBufferState(buffer, bufferJSON);
             buffersJSON.append(bufferJSON);
         }
         segmentJSON["buffers"] = buffersJSON;
@@ -446,6 +483,7 @@ int TransferMetadata::encodeSegmentDesc(const SegmentDesc &desc,
             bufferJSON["addr"] = static_cast<Json::UInt64>(buffer.addr);
             bufferJSON["length"] = static_cast<Json::UInt64>(buffer.length);
             bufferJSON["shm_name"] = buffer.shm_name;
+            encodeBufferState(buffer, bufferJSON);
             buffersJSON.append(bufferJSON);
         }
         segmentJSON["buffers"] = buffersJSON;
@@ -459,6 +497,7 @@ int TransferMetadata::encodeSegmentDesc(const SegmentDesc &desc,
             bufferJSON["name"] = buffer.name;
             bufferJSON["offset"] = static_cast<Json::UInt64>(buffer.offset);
             bufferJSON["length"] = static_cast<Json::UInt64>(buffer.length);
+            encodeBufferState(buffer, bufferJSON);
             buffersJSON.append(bufferJSON);
         }
         segmentJSON["buffers"] = buffersJSON;
@@ -476,15 +515,17 @@ int TransferMetadata::updateSegmentDesc(const std::string &segment_name,
         return 0;
     }
 
+    SegmentDesc publish_desc = desc;
+    normalizeSegmentDescForPublish(publish_desc);
     Json::Value segmentJSON;
-    int ret = encodeSegmentDesc(desc, segmentJSON);
+    int ret = encodeSegmentDesc(publish_desc, segmentJSON);
     if (ret) {
         return ret;
     }
 
     if (!storage_plugin_->set(getFullMetadataKey(segment_name), segmentJSON)) {
         LOG(ERROR) << "Failed to register segment descriptor, name "
-                   << desc.name << " protocol " << desc.protocol;
+                   << publish_desc.name << " protocol " << publish_desc.protocol;
         return ERR_METADATA;
     }
 
@@ -522,6 +563,8 @@ decodeMultiProtocolSegmentDesc(Json::Value &segmentJSON,
     desc->tcp_data_port = segmentJSON["tcp_data_port"].asInt();
     if (segmentJSON.isMember("timestamp"))
         desc->timestamp = segmentJSON["timestamp"].asString();
+    if (segmentJSON.isMember("metadata_version"))
+        desc->metadata_version = segmentJSON["metadata_version"].asUInt64();
     if (segmentJSON.isMember("rdma_server_name"))
         desc->rdma_server_name = segmentJSON["rdma_server_name"].asString();
 
@@ -563,6 +606,7 @@ decodeMultiProtocolSegmentDesc(Json::Value &segmentJSON,
 
         if (buffer_protocol == "cxl") {
             TransferMetadata::BufferDesc buffer;
+            decodeBufferState(bufferJSON, buffer);
             buffer.name = bufferJSON["name"].asString();
             buffer.offset = bufferJSON["offset"].asUInt64();
             buffer.length = bufferJSON["length"].asUInt64();
@@ -576,6 +620,7 @@ decodeMultiProtocolSegmentDesc(Json::Value &segmentJSON,
             desc->buffers.push_back(buffer);
         } else if (buffer_protocol == "rdma") {
             TransferMetadata::BufferDesc buffer;
+            decodeBufferState(bufferJSON, buffer);
             buffer.name = bufferJSON["name"].asString();
             buffer.addr = bufferJSON["addr"].asUInt64();
             buffer.length = bufferJSON["length"].asUInt64();
@@ -602,6 +647,7 @@ decodeMultiProtocolSegmentDesc(Json::Value &segmentJSON,
             desc->buffers.push_back(buffer);
         } else if (buffer_protocol == "tcp") {
             TransferMetadata::BufferDesc buffer;
+            decodeBufferState(bufferJSON, buffer);
             buffer.name = bufferJSON["name"].asString();
             buffer.addr = bufferJSON["addr"].asUInt64();
             buffer.length = bufferJSON["length"].asUInt64();
@@ -671,6 +717,8 @@ TransferMetadata::decodeSegmentDesc(Json::Value &segmentJSON,
     desc->tcp_data_port = segmentJSON["tcp_data_port"].asInt();
     if (segmentJSON.isMember("timestamp"))
         desc->timestamp = segmentJSON["timestamp"].asString();
+    if (segmentJSON.isMember("metadata_version"))
+        desc->metadata_version = segmentJSON["metadata_version"].asUInt64();
     if (segmentJSON.isMember("rdma_server_name"))
         desc->rdma_server_name = segmentJSON["rdma_server_name"].asString();
 
@@ -691,6 +739,7 @@ TransferMetadata::decodeSegmentDesc(Json::Value &segmentJSON,
 
         for (const auto &bufferJSON : segmentJSON["buffers"]) {
             BufferDesc buffer;
+            decodeBufferState(bufferJSON, buffer);
             buffer.name = bufferJSON["name"].asString();
             buffer.addr = bufferJSON["addr"].asUInt64();
             buffer.length = bufferJSON["length"].asUInt64();
@@ -736,6 +785,7 @@ TransferMetadata::decodeSegmentDesc(Json::Value &segmentJSON,
 
         for (const auto &bufferJSON : segmentJSON["buffers"]) {
             BufferDesc buffer;
+            decodeBufferState(bufferJSON, buffer);
             buffer.name = bufferJSON["name"].asString();
             buffer.addr = bufferJSON["addr"].asUInt64();
             buffer.length = bufferJSON["length"].asUInt64();
@@ -760,6 +810,7 @@ TransferMetadata::decodeSegmentDesc(Json::Value &segmentJSON,
     } else if (desc->protocol == "tcp") {
         for (const auto &bufferJSON : segmentJSON["buffers"]) {
             BufferDesc buffer;
+            decodeBufferState(bufferJSON, buffer);
             buffer.name = bufferJSON["name"].asString();
             buffer.addr = bufferJSON["addr"].asUInt64();
             buffer.length = bufferJSON["length"].asUInt64();
@@ -776,6 +827,7 @@ TransferMetadata::decodeSegmentDesc(Json::Value &segmentJSON,
                desc->protocol == "sunrise_link") {
         for (const auto &bufferJSON : segmentJSON["buffers"]) {
             BufferDesc buffer;
+            decodeBufferState(bufferJSON, buffer);
             buffer.name = bufferJSON["name"].asString();
             buffer.addr = bufferJSON["addr"].asUInt64();
             buffer.length = bufferJSON["length"].asUInt64();
@@ -817,6 +869,7 @@ TransferMetadata::decodeSegmentDesc(Json::Value &segmentJSON,
 
         for (const auto &bufferJSON : segmentJSON["buffers"]) {
             BufferDesc buffer;
+            decodeBufferState(bufferJSON, buffer);
             buffer.name = bufferJSON["name"].asString();
             buffer.addr = bufferJSON["addr"].asUInt64();
             buffer.length = bufferJSON["length"].asUInt64();
@@ -852,6 +905,7 @@ TransferMetadata::decodeSegmentDesc(Json::Value &segmentJSON,
         desc->cxl_base_addr = segmentJSON["cxl_base_addr"].asUInt64();
         for (const auto &bufferJSON : segmentJSON["buffers"]) {
             BufferDesc buffer;
+            decodeBufferState(bufferJSON, buffer);
             buffer.name = bufferJSON["name"].asString();
             buffer.offset = bufferJSON["offset"].asUInt64();
             buffer.length = bufferJSON["length"].asUInt64();
@@ -979,7 +1033,7 @@ int TransferMetadata::syncSegmentCache(const std::string &segment_name) {
     for (const auto &[name, desc] : updates) {
         auto it = segment_name_to_id_map_.find(name);
         if (it != segment_name_to_id_map_.end()) {
-            segment_id_to_desc_map_[it->second] = desc;
+            updateSegmentCacheEntryLocked(it->second, name, desc);
         }
     }
     return 0;
@@ -988,67 +1042,73 @@ int TransferMetadata::syncSegmentCache(const std::string &segment_name) {
 std::shared_ptr<TransferMetadata::SegmentDesc>
 TransferMetadata::getSegmentDescByName(const std::string &segment_name,
                                        bool force_update) {
-    if (globalConfig().metacache && !force_update) {
-        RWSpinlock::ReadGuard guard(segment_lock_);
-        auto iter = segment_name_to_id_map_.find(segment_name);
-        if (iter != segment_name_to_id_map_.end())
-            return segment_id_to_desc_map_[iter->second];
-    }
+    auto local_desc = getLocalSegmentDescByName(segment_name);
+    if (local_desc) return local_desc;
 
-    // Check if it's LOCAL_SEGMENT_ID
+    SegmentID segment_id = 0;
+    std::shared_ptr<SegmentDesc> cached_desc;
     {
         RWSpinlock::ReadGuard guard(segment_lock_);
         auto iter = segment_name_to_id_map_.find(segment_name);
-        if (iter != segment_name_to_id_map_.end() &&
-            iter->second == LOCAL_SEGMENT_ID) {
-            return segment_id_to_desc_map_[iter->second];
+        if (iter != segment_name_to_id_map_.end()) {
+            segment_id = iter->second;
+            auto desc_iter = segment_id_to_desc_map_.find(segment_id);
+            if (desc_iter != segment_id_to_desc_map_.end())
+                cached_desc = desc_iter->second;
+            if (cached_desc && globalConfig().metacache && !force_update &&
+                isSegmentCacheFreshLocked(segment_id)) {
+                return cached_desc;
+            }
         }
     }
 
-    // Fetch segment descriptor without holding lock (may involve network I/O)
     auto segment_desc = this->getSegmentDesc(segment_name);
-    if (!segment_desc) return nullptr;
+    if (!segment_desc)
+        return (!force_update && globalConfig().metacache) ? cached_desc
+                                                           : nullptr;
 
-    // Update cache with write lock
     RWSpinlock::WriteGuard guard(segment_lock_);
     auto iter = segment_name_to_id_map_.find(segment_name);
-    SegmentID segment_id;
     if (iter != segment_name_to_id_map_.end()) {
         segment_id = iter->second;
     } else {
         segment_id = next_segment_id_.fetch_add(1);
     }
-    segment_id_to_desc_map_[segment_id] = segment_desc;
-    segment_name_to_id_map_[segment_name] = segment_id;
+    updateSegmentCacheEntryLocked(segment_id, segment_name, segment_desc);
     return segment_desc;
 }
 
 std::shared_ptr<TransferMetadata::SegmentDesc>
 TransferMetadata::getSegmentDescByID(SegmentID segment_id, bool force_update) {
-    if (segment_id != LOCAL_SEGMENT_ID &&
-        (!globalConfig().metacache || force_update)) {
-        // Get segment name without holding lock during network I/O
-        std::string segment_name;
-        {
-            RWSpinlock::ReadGuard guard(segment_lock_);
-            if (!segment_id_to_desc_map_.count(segment_id)) return nullptr;
-            segment_name = segment_id_to_desc_map_[segment_id]->name;
-        }
-
-        // Fetch segment descriptor without holding lock (may involve network
-        // I/O)
-        auto segment_desc = getSegmentDesc(segment_name);
-        if (!segment_desc) return nullptr;
-
-        // Update cache with write lock
-        RWSpinlock::WriteGuard guard(segment_lock_);
-        segment_id_to_desc_map_[segment_id] = segment_desc;
-        return segment_id_to_desc_map_[segment_id];
-    } else {
+    if (segment_id == LOCAL_SEGMENT_ID) {
         RWSpinlock::ReadGuard guard(segment_lock_);
         if (!segment_id_to_desc_map_.count(segment_id)) return nullptr;
         return segment_id_to_desc_map_[segment_id];
     }
+
+    std::string segment_name;
+    std::shared_ptr<SegmentDesc> cached_desc;
+    {
+        RWSpinlock::ReadGuard guard(segment_lock_);
+        auto iter = segment_id_to_desc_map_.find(segment_id);
+        if (iter == segment_id_to_desc_map_.end()) return nullptr;
+        cached_desc = iter->second;
+        if (!cached_desc) return nullptr;
+        segment_name = cached_desc->name;
+        if (globalConfig().metacache && !force_update &&
+            isSegmentCacheFreshLocked(segment_id)) {
+            return cached_desc;
+        }
+    }
+
+    auto segment_desc = getSegmentDesc(segment_name);
+    if (!segment_desc)
+        return (!force_update && globalConfig().metacache) ? cached_desc
+                                                           : nullptr;
+
+    RWSpinlock::WriteGuard guard(segment_lock_);
+    updateSegmentCacheEntryLocked(segment_id, segment_name, segment_desc);
+    return segment_id_to_desc_map_[segment_id];
 }
 
 TransferMetadata::SegmentID TransferMetadata::getSegmentID(
@@ -1068,21 +1128,51 @@ TransferMetadata::SegmentID TransferMetadata::getSegmentID(
     if (segment_name_to_id_map_.count(segment_name))
         return segment_name_to_id_map_[segment_name];
     SegmentID id = next_segment_id_.fetch_add(1);
-    segment_id_to_desc_map_[id] = segment_desc;
-    segment_name_to_id_map_[segment_name] = id;
+    updateSegmentCacheEntryLocked(id, segment_name, segment_desc);
     return id;
+}
+
+void TransferMetadata::updateSegmentCacheEntryLocked(
+    SegmentID segment_id, const std::string &segment_name,
+    const std::shared_ptr<SegmentDesc> &desc) {
+    segment_id_to_desc_map_[segment_id] = desc;
+    segment_name_to_id_map_[segment_name] = segment_id;
+    segment_cache_update_ns_map_[segment_id] = getCurrentTimeInNano();
+}
+
+bool TransferMetadata::isSegmentCacheFreshLocked(SegmentID segment_id) const {
+    if (segment_id == LOCAL_SEGMENT_ID) return true;
+    if (!globalConfig().metacache) return false;
+    uint64_t ttl_ms = globalConfig().metadata_cache_ttl_ms;
+    if (ttl_ms == 0) return true;
+    auto it = segment_cache_update_ns_map_.find(segment_id);
+    if (it == segment_cache_update_ns_map_.end()) return false;
+    uint64_t now_ns = getCurrentTimeInNano();
+    uint64_t ttl_ns = ttl_ms * 1000ULL * 1000ULL;
+    return now_ns >= it->second && now_ns - it->second <= ttl_ns;
+}
+
+std::shared_ptr<TransferMetadata::SegmentDesc>
+TransferMetadata::getLocalSegmentDescByName(const std::string &segment_name) {
+    RWSpinlock::ReadGuard guard(segment_lock_);
+    auto it = segment_name_to_id_map_.find(segment_name);
+    if (it == segment_name_to_id_map_.end() || it->second != LOCAL_SEGMENT_ID)
+        return nullptr;
+    return segment_id_to_desc_map_[LOCAL_SEGMENT_ID];
 }
 
 int TransferMetadata::updateLocalSegmentDesc(uint64_t segment_id) {
     std::shared_ptr<SegmentDesc> desc;
     {
-        RWSpinlock::ReadGuard guard(segment_lock_);
+        RWSpinlock::WriteGuard guard(segment_lock_);
         auto it = segment_id_to_desc_map_.find(segment_id);
         if (it == segment_id_to_desc_map_.end() || !it->second) {
             LOG(ERROR) << "Segment descriptor " << segment_id << " not found";
             return ERR_METADATA;
         }
-        desc = it->second;
+        desc = std::make_shared<SegmentDesc>(*it->second);
+        bumpSegmentMetadataVersion(*desc);
+        it->second = desc;
     }
     return this->updateSegmentDesc(desc->name, *desc);
 }
@@ -1091,8 +1181,10 @@ int TransferMetadata::addLocalSegment(SegmentID segment_id,
                                       const std::string &segment_name,
                                       std::shared_ptr<SegmentDesc> &&desc) {
     RWSpinlock::WriteGuard guard(segment_lock_);
+    if (desc) normalizeSegmentDescForPublish(*desc);
     segment_id_to_desc_map_[segment_id] = desc;
     segment_name_to_id_map_[segment_name] = segment_id;
+    segment_cache_update_ns_map_[segment_id] = getCurrentTimeInNano();
     return 0;
 }
 
@@ -1102,6 +1194,7 @@ int TransferMetadata::removeLocalSegment(const std::string &segment_name) {
         int segment_id = segment_name_to_id_map_[segment_name];
         segment_name_to_id_map_.erase(segment_name);
         segment_id_to_desc_map_.erase(segment_id);
+        segment_cache_update_ns_map_.erase(segment_id);
     }
     return 0;
 }
@@ -1114,7 +1207,10 @@ int TransferMetadata::addLocalMemoryBuffer(const BufferDesc &buffer_desc,
         auto &segment_desc = segment_id_to_desc_map_[LOCAL_SEGMENT_ID];
         *new_segment_desc = *segment_desc;
         segment_desc = new_segment_desc;
-        segment_desc->buffers.push_back(buffer_desc);
+        BufferDesc updated_buffer = buffer_desc;
+        if (updated_buffer.state.empty())
+            updated_buffer.state = BufferDesc::STATE_READY;
+        segment_desc->buffers.push_back(updated_buffer);
     }
     if (update_metadata) return updateLocalSegmentDesc();
     return 0;
@@ -1123,6 +1219,8 @@ int TransferMetadata::addLocalMemoryBuffer(const BufferDesc &buffer_desc,
 int TransferMetadata::removeLocalMemoryBuffer(void *addr,
                                               bool update_metadata) {
     bool addr_exist = false;
+    std::shared_ptr<SegmentDesc> draining_desc;
+    std::shared_ptr<SegmentDesc> removed_desc;
     {
         RWSpinlock::WriteGuard guard(segment_lock_);
         auto new_segment_desc = std::make_shared<SegmentDesc>();
@@ -1137,14 +1235,53 @@ int TransferMetadata::removeLocalMemoryBuffer(void *addr,
                 (iter->offset + segment_desc->cxl_base_addr) == (uint64_t)addr
 #endif
             ) {
-                segment_desc->buffers.erase(iter);
+                if (update_metadata) {
+                    iter->state = BufferDesc::STATE_DRAINING;
+                    bumpSegmentMetadataVersion(*segment_desc);
+                    draining_desc =
+                        std::make_shared<SegmentDesc>(*segment_desc);
+                } else {
+                    segment_desc->buffers.erase(iter);
+                }
                 addr_exist = true;
                 break;
             }
         }
     }
     if (addr_exist) {
-        if (update_metadata) return updateLocalSegmentDesc();
+        if (update_metadata) {
+            if (!draining_desc) return ERR_ADDRESS_NOT_REGISTERED;
+            int ret = updateSegmentDesc(draining_desc->name, *draining_desc);
+            if (ret) return ret;
+            uint64_t grace_ms = globalConfig().metadata_deregister_grace_ms;
+            if (grace_ms) usleep(grace_ms * 1000);
+
+            {
+                RWSpinlock::WriteGuard guard(segment_lock_);
+                auto new_segment_desc = std::make_shared<SegmentDesc>();
+                auto &segment_desc = segment_id_to_desc_map_[LOCAL_SEGMENT_ID];
+                *new_segment_desc = *segment_desc;
+                segment_desc = new_segment_desc;
+                for (auto iter = segment_desc->buffers.begin();
+                     iter != segment_desc->buffers.end(); ++iter) {
+                    if (iter->addr == (uint64_t)addr
+#ifdef USE_CXL
+                        ||
+                        (iter->offset + segment_desc->cxl_base_addr) ==
+                            (uint64_t)addr
+#endif
+                    ) {
+                        segment_desc->buffers.erase(iter);
+                        bumpSegmentMetadataVersion(*segment_desc);
+                        removed_desc =
+                            std::make_shared<SegmentDesc>(*segment_desc);
+                        break;
+                    }
+                }
+            }
+            if (removed_desc)
+                return updateSegmentDesc(removed_desc->name, *removed_desc);
+        }
         return 0;
     }
     return ERR_ADDRESS_NOT_REGISTERED;

--- a/mooncake-transfer-engine/src/transfer_metadata_dump.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata_dump.cpp
@@ -22,6 +22,7 @@ void TransferMetadata::SegmentDesc::dump() const {
         LOG(INFO) << "  rdma server name: " << rdma_server_name;
     }
     LOG(INFO) << "  protocol: " << protocol;
+    LOG(INFO) << "  metadata version: " << metadata_version;
     LOG(INFO) << "  topology: " << topology.toString();
     LOG(INFO) << "  devices: ";
     for (auto& device : devices) {
@@ -32,7 +33,9 @@ void TransferMetadata::SegmentDesc::dump() const {
     for (auto& buffer : buffers) {
         LOG(INFO) << "    buffer type " << buffer.name << ", address "
                   << (void*)buffer.addr << "--"
-                  << (void*)(buffer.addr + buffer.length);
+                  << (void*)(buffer.addr + buffer.length) << ", state "
+                  << (buffer.state.empty() ? BufferDesc::STATE_READY
+                                           : buffer.state);
     }
     LOG(INFO) << "  nvmeof buffers: " << nvmeof_buffers.size() << " items";
     LOG(INFO) << "  timestamp: " << timestamp;

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
@@ -776,6 +776,10 @@ int RdmaTransport::selectDevice(SegmentDesc *desc, uint64_t offset,
     for (buffer_id = 0; buffer_id < static_cast<int>(buffers.size());
          ++buffer_id) {
         const auto &buffer = buffers[buffer_id];
+        if (!buffer.state.empty() &&
+            buffer.state != TransferMetadata::BufferDesc::STATE_READY) {
+            continue;
+        }
 
         // Check if offset is within buffer range
         if (offset < buffer.addr || length > buffer.length ||

--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -116,6 +116,7 @@ int WorkerPool::submitPostSend(
                            << target_id;
                 return ERR_INVALID_ARGUMENT;
             }
+            recordPeerMetadataVersion(target_id, *segment_desc_map[target_id]);
         }
     }
 #else
@@ -123,9 +124,16 @@ int WorkerPool::submitPostSend(
         segment_desc_map;
     for (auto &slice : slice_list) {
         auto target_id = slice->target_id;
-        if (!segment_desc_map.count(target_id))
+        if (!segment_desc_map.count(target_id)) {
             segment_desc_map[target_id] =
                 context_.engine().meta()->getSegmentDescByID(target_id);
+            if (!segment_desc_map[target_id]) {
+                LOG(ERROR) << "Cannot get target segment description #"
+                           << target_id;
+                return ERR_INVALID_ARGUMENT;
+            }
+            recordPeerMetadataVersion(target_id, *segment_desc_map[target_id]);
+        }
     }
 #endif  // CONFIG_CACHE_SEGMENT_DESC
 
@@ -157,6 +165,7 @@ int WorkerPool::submitPostSend(
                 failed_target_ids[slice->target_id] = getCurrentTimeInNano();
                 continue;
             }
+            recordPeerMetadataVersion(slice->target_id, *peer_segment_desc);
 
             if (selectPeerDevice(peer_segment_desc.get(), slice->rdma.dest_addr,
                                  slice->length, context_.deviceName(),
@@ -185,7 +194,7 @@ int WorkerPool::submitPostSend(
                  alt_dev_id < peer_segment_desc->devices.size(); ++alt_dev_id) {
                 if (alt_dev_id == (size_t)device_id) continue;
                 auto alt_path =
-                    MakeNicPath(peer_segment_desc->name,
+                    MakeNicPath(peer_segment_desc->nicPathServerName(),
                                 peer_segment_desc->devices[alt_dev_id].name);
                 if (isRailAvailable(alt_path)) {
                     device_id = alt_dev_id;
@@ -455,6 +464,10 @@ void WorkerPool::redispatch(std::vector<Transport::Slice *> &slice_list,
         if (!segment_desc_map.count(target_id)) {
             segment_desc_map[target_id] =
                 context_.engine().meta()->getSegmentDescByID(target_id, true);
+            if (segment_desc_map[target_id]) {
+                recordPeerMetadataVersion(target_id,
+                                          *segment_desc_map[target_id]);
+            }
         }
     }
 
@@ -673,6 +686,47 @@ bool WorkerPool::isRailAvailable(const std::string &peer_nic_path) {
         return true;
     }
     return false;
+}
+
+void WorkerPool::clearRailState(
+    const std::vector<std::string> &peer_nic_paths) {
+    std::lock_guard<std::mutex> lock(rail_state_lock_);
+    for (const auto &path : peer_nic_paths) rail_states_.erase(path);
+}
+
+std::vector<std::string> WorkerPool::buildPeerNicPaths(
+    const Transport::SegmentDesc &desc) const {
+    std::vector<std::string> paths;
+    paths.reserve(desc.devices.size());
+    for (const auto &device : desc.devices) {
+        paths.push_back(MakeNicPath(desc.nicPathServerName(), device.name));
+    }
+    return paths;
+}
+
+void WorkerPool::recordPeerMetadataVersion(SegmentID segment_id,
+                                           const Transport::SegmentDesc &desc) {
+    auto new_paths = buildPeerNicPaths(desc);
+    std::vector<std::string> stale_paths;
+    {
+        std::lock_guard<std::mutex> lock(target_metadata_lock_);
+        auto &state = target_metadata_[segment_id];
+        if (!state.initialized) {
+            state.initialized = true;
+            state.metadata_version = desc.metadata_version;
+            state.peer_nic_paths = std::move(new_paths);
+            return;
+        }
+        if (state.metadata_version == desc.metadata_version) {
+            state.peer_nic_paths = std::move(new_paths);
+            return;
+        }
+        stale_paths = state.peer_nic_paths;
+        state.metadata_version = desc.metadata_version;
+        state.peer_nic_paths = std::move(new_paths);
+    }
+    for (const auto &path : stale_paths) context_.deleteEndpoint(path);
+    clearRailState(stale_paths);
 }
 
 // Unified retry logic: increment retry count and return whether retry is

--- a/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
+++ b/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
@@ -166,9 +166,9 @@ TEST(RdmaTransportMetadataTest, SelectDeviceSkipsDrainingBuffers) {
 
     int buffer_id = -1;
     int device_id = -1;
-    EXPECT_EQ(RdmaTransport::selectDevice(&desc, 4096, 128, buffer_id,
-                                          device_id),
-              ERR_ADDRESS_NOT_REGISTERED);
+    EXPECT_EQ(
+        RdmaTransport::selectDevice(&desc, 4096, 128, buffer_id, device_id),
+        ERR_ADDRESS_NOT_REGISTERED);
 }
 
 // add, get and remove RPCMetaEntryMeta

--- a/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
+++ b/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
@@ -21,7 +21,9 @@
 
 #include <cstdlib>
 
+#include "config.h"
 #include "transport/transport.h"
+#include "transport/rdma_transport/rdma_transport.h"
 
 using namespace mooncake;
 
@@ -38,7 +40,7 @@ class TransferMetadataTest : public ::testing::Test {
         if (env)
             metadata_server = env;
         else
-            metadata_server = metadata_server;
+            metadata_server = P2PHANDSHAKE;
         LOG(INFO) << "metadata_server: " << metadata_server;
 
         env = std::getenv("MC_LOCAL_SERVER_NAME");
@@ -49,6 +51,7 @@ class TransferMetadataTest : public ::testing::Test {
         LOG(INFO) << "local_server_name: " << local_server_name;
 
         metadata_client = std::make_unique<TransferMetadata>(metadata_server);
+        globalConfig().metadata_deregister_grace_ms = 0;
     }
     void TearDown() override {
         // clean up glog
@@ -71,6 +74,7 @@ TEST_F(TransferMetadataTest, LocalSegmentTest) {
     ASSERT_EQ(re, 0);
     auto des = metadata_client->getSegmentDescByName(segment_name);
     ASSERT_EQ(des, segment_des);
+    ASSERT_EQ(des->metadata_version, 1);
     des = metadata_client->getSegmentDescByID(segment_id, false);
     ASSERT_EQ(des, segment_des);
     auto id = metadata_client->getSegmentID(segment_name);
@@ -87,6 +91,9 @@ TEST_F(TransferMetadataTest, LocalMemoryBufferTest) {
     int re = metadata_client->addLocalSegment(
         LOCAL_SEGMENT_ID, "test_local_segment", std::move(segment_des));
     ASSERT_EQ(re, 0);
+    auto local_desc = metadata_client->getSegmentDescByID(LOCAL_SEGMENT_ID);
+    ASSERT_TRUE(local_desc);
+    auto metadata_version = local_desc->metadata_version;
     uint64_t addr = 0;
     for (int i = 0; i < 10; ++i) {
         TransferMetadata::BufferDesc buffer_des;
@@ -95,20 +102,80 @@ TEST_F(TransferMetadataTest, LocalMemoryBufferTest) {
         re = metadata_client->addLocalMemoryBuffer(buffer_des, false);
         ASSERT_EQ(re, 0);
     }
+    local_desc = metadata_client->getSegmentDescByID(LOCAL_SEGMENT_ID);
+    ASSERT_TRUE(local_desc);
+    ASSERT_EQ(local_desc->metadata_version, metadata_version);
+    ASSERT_EQ(local_desc->buffers.size(), 10);
+    for (const auto& buffer : local_desc->buffers) {
+        ASSERT_EQ(buffer.state, TransferMetadata::BufferDesc::STATE_READY);
+    }
+    ASSERT_EQ(metadata_client->updateLocalSegmentDesc(), 0);
+    local_desc = metadata_client->getSegmentDescByID(LOCAL_SEGMENT_ID);
+    ASSERT_TRUE(local_desc);
+    ASSERT_GT(local_desc->metadata_version, metadata_version);
     addr = 1000;
     re = metadata_client->removeLocalMemoryBuffer((void*)addr, false);
     ASSERT_EQ(re, ERR_ADDRESS_NOT_REGISTERED);
+    auto before_remove_metadata_version = local_desc->metadata_version;
     for (int i = 9; i > 0; --i) {
         addr = i * 2048;
         re = metadata_client->removeLocalMemoryBuffer((void*)addr, false);
         ASSERT_EQ(re, 0);
     }
+    local_desc = metadata_client->getSegmentDescByID(LOCAL_SEGMENT_ID);
+    ASSERT_TRUE(local_desc);
+    ASSERT_EQ(local_desc->metadata_version, before_remove_metadata_version);
+    ASSERT_EQ(local_desc->buffers.size(), 1);
     re = metadata_client->removeLocalSegment("test_local_segment");
     ASSERT_EQ(re, 0);
 }
 
+TEST_F(TransferMetadataTest, RemoveLocalMemoryBufferWithMetadataBumpsVersion) {
+    auto segment_des = std::make_shared<TransferMetadata::SegmentDesc>();
+    segment_des->name = "test_metadata_deregister";
+    segment_des->protocol = "rdma";
+    ASSERT_EQ(metadata_client->addLocalSegment(LOCAL_SEGMENT_ID,
+                                               "test_metadata_deregister",
+                                               std::move(segment_des)),
+              0);
+
+    TransferMetadata::BufferDesc buffer_des;
+    buffer_des.addr = 4096;
+    buffer_des.length = 1024;
+    ASSERT_EQ(metadata_client->addLocalMemoryBuffer(buffer_des, false), 0);
+
+    auto local_desc = metadata_client->getSegmentDescByID(LOCAL_SEGMENT_ID);
+    ASSERT_TRUE(local_desc);
+    auto metadata_version = local_desc->metadata_version;
+
+    ASSERT_EQ(metadata_client->removeLocalMemoryBuffer((void*)4096, true), 0);
+    local_desc = metadata_client->getSegmentDescByID(LOCAL_SEGMENT_ID);
+    ASSERT_TRUE(local_desc);
+    ASSERT_GT(local_desc->metadata_version, metadata_version);
+    ASSERT_TRUE(local_desc->buffers.empty());
+}
+
+TEST(RdmaTransportMetadataTest, SelectDeviceSkipsDrainingBuffers) {
+    TransferMetadata::SegmentDesc desc;
+    TransferMetadata::BufferDesc buffer;
+    buffer.name = "buffer";
+    buffer.addr = 4096;
+    buffer.length = 1024;
+    buffer.state = TransferMetadata::BufferDesc::STATE_DRAINING;
+    desc.buffers.push_back(buffer);
+
+    int buffer_id = -1;
+    int device_id = -1;
+    EXPECT_EQ(RdmaTransport::selectDevice(&desc, 4096, 128, buffer_id,
+                                          device_id),
+              ERR_ADDRESS_NOT_REGISTERED);
+}
+
 // add, get and remove RPCMetaEntryMeta
 TEST_F(TransferMetadataTest, RpcMetaEntryTest) {
+    if (metadata_server == P2PHANDSHAKE) {
+        GTEST_SKIP() << "P2P RPC metadata requires a local listening socket";
+    }
     auto hostname_port = parseHostNameWithPort(local_server_name);
     TransferMetadata::RpcMetaDesc desc;
     desc.ip_or_host_name = hostname_port.first.c_str();


### PR DESCRIPTION
## Description



This PR strengthens Transfer Engine metadata reliability by introducing a single segment-level metadata_version and using it as the freshness signal for cached metadata and derived RDMA resources.

Segment names and segment IDs can be reused after node replacement, and memory registration changes can also invalidate rkeys, address ranges, and buffer availability. With this change, every published local segment metadata update bumps metadata_version, allowing readers and RDMA workers to detect that cached descriptors or endpoints may be stale.

## Module

- [X] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



**Test commands:**
```bash
# Example: bash scripts/run_ci_test.sh
```

**Test results:**
- [X] Unit tests pass
- [X] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have formatted my code using `./scripts/code_format.sh`
- [X] I have run `pre-commit run --all-files` and all hooks pass
- [X] I have updated the documentation (if applicable)
- [X] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [ ] AI tools were used (specify below)