### PR TITLE
[Store] Fix 32-bit host-pointer offset overflow in SPDK NoF transfers over 4 GiB

### DIFF
--- a/mooncake-store/src/transfer_task.cpp
+++ b/mooncake-store/src/transfer_task.cpp
@@ -485,7 +485,13 @@ void SpdkNofWorkerPool::workerThread(int work_idx) {
                         uint32_t submit_lba_count = std::min(
                             avail_blocks, std::min(task->remaining_lba,
                                                    nof_qos->blocks_per_chunk));
-                        int lba_off = task->lba_count - task->remaining_lba;
+                        // 64-bit: a NoF transfer can exceed 4 GiB, and once
+                        // lba_off * block_size crosses 2^32 the host-pointer
+                        // offset would wrap when computed in 32 bits (int *
+                        // uint32_t), making submit_ptr address the wrong part
+                        // of the buffer. submit_lba below is already widened.
+                        uint64_t lba_off =
+                            task->lba_count - task->remaining_lba;
                         uint64_t submit_lba = task->lba + lba_off;
                         void* submit_ptr = reinterpret_cast<void*>(
                             reinterpret_cast<char*>(task->ptr) +


### PR DESCRIPTION
## Description

In the SPDK NoF worker (`mooncake-store/src/transfer_task.cpp`, `SpdkNofWorkerPool::workerThread`), the host buffer offset for each sub-I/O was computed as:

```cpp
int lba_off = task->lba_count - task->remaining_lba;   // int
...
void* submit_ptr = reinterpret_cast<char*>(task->ptr) + lba_off * block_size;
```

`block_size` is a `uint32_t`, so `lba_off * block_size` is evaluated in 32-bit unsigned arithmetic. Once the running offset reaches 4 GiB (`lba_off * block_size >= 2^32`) the product wraps around and `submit_ptr` points to the wrong part of the buffer. The DMA for the tail of a >4 GiB transfer then reads from / writes to the *start* of the user buffer instead of the intended region, silently corrupting data.

The device-side address one line below — `uint64_t submit_lba = task->lba + lba_off;` — is already 64-bit, so only the host pointer offset was left narrow.

This is reachable for any sufficiently large transfer: a single `SpdkNofTask` is created with `lba_count = size / block_size` for the whole request and there is no size cap at the submit site (`submitNofTransfer` only checks block alignment), so `lba_off` walks from 0 up to `lba_count` as the task drains. It is the same >4 GiB scenario that was fixed for SSD offload in #2570.

The fix widens `lba_off` to `uint64_t` so the offset arithmetic stays 64-bit, matching the already-widened `submit_lba`.

## Module

- [x] Mooncake Store (`mooncake-store`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

The SPDK NoF path is behind `USE_NOF` and needs SPDK + NVMe-oF hardware, so I could not build or exercise it locally (no native SPDK toolchain on this machine). It is verified three ways:

1. **Standalone reproduction of the arithmetic.** Mirroring the exact types (`int lba_off`, `uint32_t block_size`) and picking the first `lba_off` whose byte offset crosses 4 GiB for a 5 GiB transfer with 4096-byte blocks:

   ```
   lba_count=1310720 lba_off=1048576 block_size=4096
   expected byte offset      = 4294967296
   buggy (32-bit) offset     = 0
   fixed (64-bit) offset     = 4294967296
   buggy pointer wrong by    = -4294967296 bytes
   RESULT: OVERFLOW CONFIRMED (buggy != fixed)
   ```

   The 32-bit expression wraps to 0 (off by exactly 4 GiB); the 64-bit expression is correct.

2. **Parity with #2570**, which fixed the same 32-bit-overflow-on-a->4 GiB-size class in the SSD offload path and was accepted as a code-only change.

3. `clang-format` clean on the file.

- [x] Manual testing done (standalone arithmetic repro above; SPDK NoF integration build exercised by CI)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh` (clang-format)

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

Used Claude Code to help sweep the store/transfer-engine code for the remaining 32-bit size/offset arithmetic siblings of #2570 and to draft the change. I reviewed and verified the fix (including the standalone overflow reproduction above) and am responsible for it.