### PR TITLE
[TransferEngine] Guard MC_TCP_SLICE_SIZE parsing against std::stoull throwing

### DIFF
--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
@@ -45,15 +45,17 @@ static size_t getChunkSize() {
             try {
                 size_t v = std::stoull(env);
                 if (v > 0) return v;
-                LOG(WARNING) << "Ignore non-positive MC_TCP_SLICE_SIZE value: "
-                             << env << ", using default 65536";
+                LOG(WARNING)
+                    << "Ignore non-positive MC_TCP_SLICE_SIZE value: " << env
+                    << ", using default 65536";
             } catch (const std::exception& e) {
                 // A non-numeric or out-of-range value makes std::stoull throw;
                 // fall through to the default instead of letting the exception
                 // propagate out of this static initializer and abort the
                 // transfer that first reads the chunk size.
-                LOG(WARNING) << "Invalid MC_TCP_SLICE_SIZE value: " << env
-                             << ". Error: " << e.what() << ", using default 65536";
+                LOG(WARNING)
+                    << "Invalid MC_TCP_SLICE_SIZE value: " << env
+                    << ". Error: " << e.what() << ", using default 65536";
             }
         }
         return size_t(65536);  // 64KB default

--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
@@ -42,8 +42,19 @@ static size_t getChunkSize() {
     static const size_t val = [] {
         const char* env = std::getenv("MC_TCP_SLICE_SIZE");
         if (env) {
-            size_t v = std::stoull(env);
-            if (v > 0) return v;
+            try {
+                size_t v = std::stoull(env);
+                if (v > 0) return v;
+                LOG(WARNING) << "Ignore non-positive MC_TCP_SLICE_SIZE value: "
+                             << env << ", using default 65536";
+            } catch (const std::exception& e) {
+                // A non-numeric or out-of-range value makes std::stoull throw;
+                // fall through to the default instead of letting the exception
+                // propagate out of this static initializer and abort the
+                // transfer that first reads the chunk size.
+                LOG(WARNING) << "Invalid MC_TCP_SLICE_SIZE value: " << env
+                             << ". Error: " << e.what() << ", using default 65536";
+            }
         }
         return size_t(65536);  // 64KB default
     }();


### PR DESCRIPTION
## Problem

`getChunkSize()` in `tcp_transport.cpp` reads the `MC_TCP_SLICE_SIZE` env var and parses it with `std::stoull`:

```cpp
static size_t getChunkSize() {
    static const size_t val = [] {
        const char* env = std::getenv("MC_TCP_SLICE_SIZE");
        if (env) {
            size_t v = std::stoull(env);   // throws on bad input
            if (v > 0) return v;
        }
        return size_t(65536);  // 64KB default
    }();
    return val;
}
```

The lambda only handles the success path (a positive value; otherwise it falls back to the 64KB default). But a value that `std::stoull` cannot parse makes it throw:

- non-numeric string (e.g. a typo like `64K`/`true`) -> `std::invalid_argument`
- empty string (`export MC_TCP_SLICE_SIZE=`, where `getenv` returns a non-null empty string) -> `std::invalid_argument`
- out-of-range number -> `std::out_of_range`

The parse runs inside the static-local initializer, and neither `getChunkSize()` nor its callers (the `TcpTransport` read/write paths at the `std::min(getChunkSize(), ...)` call sites) catch the exception. So a misconfigured env var aborts the first TCP transfer instead of warning and using the default, which is what the existing `if (v > 0)` branch already intends for bad input.

## Fix

Wrap the parse in try/catch and route both the throwing case and a non-positive value through a warning-and-default path, so any invalid `MC_TCP_SLICE_SIZE` value degrades gracefully.

This mirrors the env-var parsing that already exists in this codebase:
- `get_auto_discover()` guarding `MC_MS_AUTO_DISC` against `std::stoi` throwing (#2629)
- `config.cpp` guarding `MC_PKEY_INDEX` / `MC_IB_TC` / `MC_IB_SL` / `MC_MLX5_QP_UDP_SPORTS` with the same try/catch + warning + default shape

## Verification

13 lines, single file. I did not build locally (the transfer engine needs an RDMA/CUDA toolchain I don't have set up); the change is verified by the C++ standard semantics of `std::stoull` (throws `std::invalid_argument` / `std::out_of_range` on the inputs above) and by matching the established sibling guards listed above, and relies on the existing build/CI jobs to compile-check it. The default-path behavior (64KB) is unchanged for valid and absent values.