### PR TITLE
fix(rdma): auto-chunk MRs larger than device max_mr_size (#2017)

### DIFF
--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_transport.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_transport.h
@@ -148,6 +148,13 @@ class RdmaTransport : public Transport {
     // local_server_name_ keeps the TCP-reachable address for P2P routing.
     std::string rdma_server_name_;
     std::mutex local_desc_lock_;
+    // Mooncake#2017: buffers larger than the device max_mr_size are split into
+    // multiple sub-max_mr_size MRs (one BufferDesc per chunk) so that
+    // ibv_reg_mr is never silently truncated. unregisterLocalMemory() only
+    // receives the base addr, so remember each base buffer's chunk
+    // start-addresses for cleanup.
+    std::mutex chunk_map_mutex_;
+    std::unordered_map<uint64_t, std::vector<uint64_t>> chunk_map_;
 };
 
 using TransferRequest = Transport::TransferRequest;

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -171,7 +171,9 @@ RdmaContext::RdmaContext(RdmaTransport &engine, const std::string &device_name)
     static std::once_flag g_once_flag;
     auto fork_init = []() {
         int ret = ibv_fork_init();
-        if (ret) LOG(ERROR) << "RDMA context setup failed: fork compatibility: " << strerror(ret);
+        if (ret)
+            LOG(ERROR) << "RDMA context setup failed: fork compatibility: "
+                       << strerror(ret);
     };
     std::call_once(g_once_flag, fork_init);
 }
@@ -335,7 +337,8 @@ int RdmaContext::deconstruct() {
     for (auto &[_, entry] : memory_region_map_) {
         int ret = ibv_dereg_mr(entry.mr);
         if (ret) {
-            LOG(ERROR) << "Failed to unregister memory region: " << strerror(ret);
+            LOG(ERROR) << "Failed to unregister memory region: "
+                       << strerror(ret);
         }
     }
     memory_region_map_.clear();
@@ -345,7 +348,8 @@ int RdmaContext::deconstruct() {
 
         int ret = ibv_destroy_cq(cq_list_[i].native);
         if (ret) {
-            LOG(ERROR) << "Failed to destroy completion queue: " << strerror(ret);
+            LOG(ERROR) << "Failed to destroy completion queue: "
+                       << strerror(ret);
         }
     }
     cq_list_.clear();
@@ -360,7 +364,8 @@ int RdmaContext::deconstruct() {
             if (comp_channel_[i]) {
                 int ret = ibv_destroy_comp_channel(comp_channel_[i]);
                 if (ret)
-                    LOG(ERROR) << "Failed to destroy completion channel: " << strerror(ret);
+                    LOG(ERROR) << "Failed to destroy completion channel: "
+                               << strerror(ret);
             }
         delete[] comp_channel_;
         comp_channel_ = nullptr;
@@ -369,7 +374,8 @@ int RdmaContext::deconstruct() {
     if (pd_) {
         int ret = ibv_dealloc_pd(pd_);
         if (ret)
-            LOG(ERROR) << "Failed to deallocate protection domain: " << strerror(ret);
+            LOG(ERROR) << "Failed to deallocate protection domain: "
+                       << strerror(ret);
         pd_ = nullptr;
     }
 
@@ -563,9 +569,16 @@ int RdmaContext::registerMemoryRegionInternal(void *addr, size_t length,
                                               const DmabufExport &exp,
                                               MemoryRegionMeta &mrMeta) {
     if (length > (size_t)globalConfig().max_mr_size) {
-        PLOG(WARNING) << "The buffer length exceeds device max_mr_size, "
-                      << "shrink it to " << globalConfig().max_mr_size;
-        length = (size_t)globalConfig().max_mr_size;
+        // #2017: registerLocalMemory auto-chunks buffers to <= max_mr_size, so
+        // no larger buffer should reach here. Fail loudly instead of silently
+        // truncating the MR — a truncated MR advertises bytes past the
+        // registered region and causes IBV_WC_REM_ACCESS_ERR on RDMA ops whose
+        // target lands past the boundary.
+        LOG(ERROR) << "Buffer length " << length
+                   << " exceeds device max_mr_size "
+                   << globalConfig().max_mr_size
+                   << " (should have been chunked before registration, #2017)";
+        return ERR_INVALID_ARGUMENT;
     }
     mrMeta.addr = addr;
 #if defined(USE_MLU) || defined(USE_MACA) || defined(USE_CUDA) || \
@@ -960,7 +973,8 @@ bool RdmaContext::reprobeAutoGid(
     int ret = ibv_query_port(current_context, current_port, &port_attr);
     if (ret) {
         LOG(WARNING) << "Failed to reprobe port attributes on " << device_name_
-                     << "/" << static_cast<int>(current_port) << ": " << strerror(ret);
+                     << "/" << static_cast<int>(current_port) << ": "
+                     << strerror(ret);
         return false;
     }
 
@@ -1076,7 +1090,8 @@ GidRefreshResult RdmaContext::refreshCurrentGid(std::string *previous_gid,
         if (ret) {
             LOG(WARNING) << "Failed to refresh port attributes on "
                          << device_name_ << "/"
-                         << static_cast<int>(current_port) << ": " << strerror(ret);
+                         << static_cast<int>(current_port) << ": "
+                         << strerror(ret);
             return GidRefreshResult::FAILED;
         }
 
@@ -1194,7 +1209,8 @@ int RdmaContext::openRdmaDevice(const std::string &device_name, uint8_t port,
                        << device_name << ": " << strerror(ret);
             int close_ret = ibv_close_device(context);
             if (close_ret) {
-                LOG(ERROR) << "ibv_close_device(" << device_name << ") failed: " << strerror(close_ret);
+                LOG(ERROR) << "ibv_close_device(" << device_name
+                           << ") failed: " << strerror(close_ret);
             }
             ibv_free_device_list(devices);
             return ERR_CONTEXT;
@@ -1204,7 +1220,8 @@ int RdmaContext::openRdmaDevice(const std::string &device_name, uint8_t port,
             LOG(WARNING) << "Device " << device_name << " port not active";
             int close_ret = ibv_close_device(context);
             if (close_ret) {
-                LOG(ERROR) << "ibv_close_device(" << device_name << ") failed: " << strerror(close_ret);
+                LOG(ERROR) << "ibv_close_device(" << device_name
+                           << ") failed: " << strerror(close_ret);
             }
             ibv_free_device_list(devices);
             return ERR_CONTEXT;
@@ -1213,10 +1230,12 @@ int RdmaContext::openRdmaDevice(const std::string &device_name, uint8_t port,
         ibv_device_attr device_attr;
         ret = ibv_query_device(context, &device_attr);
         if (ret) {
-            LOG(WARNING) << "Failed to query attributes on " << device_name << ": " << strerror(ret);
+            LOG(WARNING) << "Failed to query attributes on " << device_name
+                         << ": " << strerror(ret);
             int close_ret = ibv_close_device(context);
             if (close_ret) {
-                LOG(ERROR) << "ibv_close_device(" << device_name << ") failed: " << strerror(close_ret);
+                LOG(ERROR) << "ibv_close_device(" << device_name
+                           << ") failed: " << strerror(close_ret);
             }
             ibv_free_device_list(devices);
             return ERR_CONTEXT;
@@ -1313,11 +1332,12 @@ int RdmaContext::openRdmaDevice(const std::string &device_name, uint8_t port,
         ibv_port_attr port_attr;
         ret = ibv_query_port(context, port, &port_attr);
         if (ret) {
-            LOG(WARNING) << "Failed to query port attributes on "
-                         << device_name << "/" << port << ": " << strerror(ret);
+            LOG(WARNING) << "Failed to query port attributes on " << device_name
+                         << "/" << port << ": " << strerror(ret);
             int close_ret = ibv_close_device(context);
             if (close_ret) {
-                LOG(ERROR) << "ibv_close_device(" << device_name << ") failed: " << strerror(close_ret);
+                LOG(ERROR) << "ibv_close_device(" << device_name
+                           << ") failed: " << strerror(close_ret);
             }
             ibv_free_device_list(devices);
             return ERR_CONTEXT;
@@ -1386,13 +1406,13 @@ int RdmaContext::openRdmaDevice(const std::string &device_name, uint8_t port,
         ibv_free_device_list(devices);
         return 0;
 
-    cleanup_context_and_devices:
-        {
-            int close_ret = ibv_close_device(context);
-            if (close_ret) {
-                LOG(ERROR) << "ibv_close_device(" << device_name << ") failed: " << strerror(close_ret);
-            }
+    cleanup_context_and_devices: {
+        int close_ret = ibv_close_device(context);
+        if (close_ret) {
+            LOG(ERROR) << "ibv_close_device(" << device_name
+                       << ") failed: " << strerror(close_ret);
         }
+    }
         ibv_free_device_list(devices);
         return ERR_CONTEXT;
     }

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
@@ -18,6 +18,7 @@
 #include <sys/mman.h>
 #include <sys/time.h>
 
+#include <algorithm>
 #include <cassert>
 #include <chrono>
 #include <cstddef>
@@ -25,6 +26,7 @@
 #include <future>
 #include <set>
 #include <thread>
+#include <utility>
 
 #include <dlfcn.h>
 
@@ -213,7 +215,6 @@ int RdmaTransport::registerLocalMemoryInternal(void *addr, size_t length,
                                                bool update_metadata,
                                                bool force_sequential) {
     (void)remote_accessible;
-    BufferDesc buffer_desc;
     const int kBaseAccessRights = IBV_ACCESS_LOCAL_WRITE |
                                   IBV_ACCESS_REMOTE_WRITE |
                                   IBV_ACCESS_REMOTE_READ;
@@ -222,40 +223,49 @@ int RdmaTransport::registerLocalMemoryInternal(void *addr, size_t length,
     if (MCIbRelaxedOrderingEnabled) {
         access_rights |= IBV_ACCESS_RELAXED_ORDERING;
     }
-    bool do_pre_touch = context_list_.size() > 0 &&
-                        std::thread::hardware_concurrency() >= 4 &&
-                        length >= (size_t)4 * 1024 * 1024 * 1024;
-    if (do_pre_touch) {
-        // Parallel Pre-touch the memory to speedup the registration process.
-        int ret = preTouchMemory(addr, length);
-        if (ret != 0) {
-            return ret;
+
+    // Mooncake#2017: ibv_reg_mr silently truncates a registration to the device
+    // max_mr_size, but the metadata would still advertise the full BufferDesc
+    // length, so any remote RDMA op past the boundary fails with
+    // IBV_WC_REM_ACCESS_ERR (ionic CQE error 10). Split buffers larger than
+    // max_mr_size into chunks of <= max_mr_size, register each as its own MR,
+    // and publish one BufferDesc per chunk (the per-context rkey/lkey lookups
+    // are address-range based, so each chunk gets the correct key).
+    size_t chunk_limit = (size_t)globalConfig().max_mr_size;
+    std::vector<std::pair<void *, size_t>> chunks;
+    if (chunk_limit > 0 && length > chunk_limit) {
+        for (size_t offset = 0; offset < length;) {
+            size_t chunk_len = std::min(chunk_limit, length - offset);
+            chunks.emplace_back(static_cast<char *>(addr) + offset, chunk_len);
+            offset += chunk_len;
         }
+        LOG(WARNING) << "Auto-splitting buffer " << addr << " (" << length
+                     << " bytes) into " << chunks.size()
+                     << " chunks of <= " << chunk_limit
+                     << " bytes each (device max_mr_size; Mooncake#2017)";
+    } else {
+        chunks.emplace_back(addr, length);
     }
 
-    /* Parallel register when:
-    1. parallel_reg_mr is enabled via MC_ENABLE_PARALLEL_REG_MR;
-    2. parallel_reg_mr not set and multiple contexts exist and memory has been
-    pre-touched
-    Note: If memory hasn't been touched, parallel register can be
-    slower. Details in: https://github.com/kvcache-ai/Mooncake/issues/848
-    Note: force_sequential is used by batch operations to avoid nested
-    parallelism.
-    */
-    int use_parallel_reg = 0;
-    if (!force_sequential) {
-        use_parallel_reg = globalConfig().parallel_reg_mr;
-        if (use_parallel_reg == -1) {
-            use_parallel_reg = context_list_.size() > 1 && do_pre_touch;
-        }
+    // Resolve the location name once, from the original buffer.
+    std::string resolved_name;
+    if (name == kWildcardLocation) {
+        bool only_first_page = true;
+        const std::vector<MemoryLocationEntry> entries =
+            getMemoryLocation(addr, length, only_first_page);
+        if (entries.empty()) return -1;
+        resolved_name = entries[0].location;
+    } else {
+        resolved_name = name;
     }
 
-    // Export a single dma_buf fd for the buffer and import it into every NIC's
-    // PD below, closing it once after all registrations. One dma_buf object
-    // shared across NICs lets the GPU driver reserve a single BAR1 window for
-    // the buffer instead of one per NIC. Host memory yields an empty export and
-    // takes the plain ibv_reg_mr path. The fd must stay open across all
-    // registrations (each MR takes its own reference); see exportDmabuf().
+    // Export a single dma_buf fd for the whole buffer and import it into every
+    // NIC's PD during each chunk's registration below (one dma_buf object
+    // shared across NICs keeps a single BAR1 window for the buffer instead of
+    // one per NIC). Host memory yields an empty export (plain ibv_reg_mr). The
+    // fd must stay open across every registration that consumes it (each MR
+    // takes its own reference), so it is closed once, on any return path, by
+    // the RAII guard below.
     DmabufExport dmabuf_exp;
     if (!context_list_.empty()) {
         int eret = RdmaContext::exportDmabuf(addr, dmabuf_exp);
@@ -264,97 +274,189 @@ int RdmaTransport::registerLocalMemoryInternal(void *addr, size_t length,
             return eret;
         }
     }
+    struct DmabufCloser {
+        DmabufExport &exp;
+        ~DmabufCloser() { RdmaContext::closeDmabufExport(exp); }
+    } dmabuf_closer{dmabuf_exp};
 
-    auto reg_start = std::chrono::steady_clock::now();
+    // Best-effort unregister of ONE chunk's MRs across all contexts. Used to
+    // clean up a chunk whose registration failed part-way (some contexts
+    // succeeded, one failed) BEFORE its metadata was committed — that chunk is
+    // not a "committed" chunk, so rollbackChunks() below must not touch its
+    // (never-added) metadata, but its partial MRs still need releasing.
+    auto unregisterChunkMRs = [&](void *chunk_addr) {
+        for (auto &context : context_list_) {
+            int ret = context->unregisterMemoryRegion(chunk_addr);
+            if (ret)
+                LOG(WARNING) << "Rollback: failed to unregister chunk MR at "
+                             << chunk_addr << " (ret=" << ret << ")";
+        }
+    };
 
-    int reg_error = 0;
-    if (use_parallel_reg) {
-        std::vector<std::thread> reg_threads;
-        reg_threads.reserve(context_list_.size());
-        std::vector<int> ret_codes(context_list_.size(), 0);
-        const int ar = access_rights;  // Local copy for lambda capture
+    // Best-effort rollback of the first `committed` FULLY-committed chunks
+    // (metadata added to the local segment desc AND MRs registered), i.e.
+    // chunks [0, committed). Pass the count of chunks whose
+    // addLocalMemoryBuffer has succeeded — `committed == 0` is a no-op (nothing
+    // to undo). Metadata is removed WITHOUT a per-chunk publish; one
+    // updateLocalSegmentDesc() at the end republishes the cleaned desc.
+    auto rollbackChunks = [&](size_t committed) {
+        size_t n = std::min(committed, chunks.size());
+        for (size_t ri = 0; ri < n; ++ri) {
+            int rc = metadata_->removeLocalMemoryBuffer(
+                chunks[ri].first, /*update_metadata=*/false);
+            if (rc)
+                LOG(WARNING) << "Rollback: failed to remove metadata for chunk "
+                                "at "
+                             << chunks[ri].first << " (ret=" << rc << ")";
+            unregisterChunkMRs(chunks[ri].first);
+        }
+        if (n > 0 && update_metadata) metadata_->updateLocalSegmentDesc();
+    };
 
-        for (size_t i = 0; i < context_list_.size(); ++i) {
-            reg_threads.emplace_back(
-                [this, &ret_codes, &dmabuf_exp, i, addr, length, ar]() {
+    // Pre-touch decision is loop-invariant: it depends only on context_list_,
+    // hardware_concurrency(), and the ORIGINAL buffer length (never chunk_len,
+    // which is capped at max_mr_size and would silently disable pre-touch for a
+    // >=4GiB buffer). Compute once above the loop to avoid repeated
+    // hardware_concurrency() OS queries per chunk.
+    const bool do_pre_touch = context_list_.size() > 0 &&
+                              std::thread::hardware_concurrency() >= 4 &&
+                              length >= (size_t)4 * 1024 * 1024 * 1024;
+
+    for (size_t ci = 0; ci < chunks.size(); ++ci) {
+        void *chunk_addr = chunks[ci].first;
+        size_t chunk_len = chunks[ci].second;
+
+        if (do_pre_touch) {
+            // Parallel pre-touch the memory to speed up registration.
+            int ret = preTouchMemory(chunk_addr, chunk_len);
+            if (ret != 0) {
+                // pre-touch is before MR registration for chunk ci, so ci has
+                // no MR/metadata yet: roll back only committed chunks [0, ci).
+                rollbackChunks(ci);
+                return ret;
+            }
+        }
+
+        /* Parallel register when:
+        1. parallel_reg_mr is enabled via MC_ENABLE_PARALLEL_REG_MR;
+        2. parallel_reg_mr not set, multiple contexts exist, memory pre-touched.
+        force_sequential is used by batch operations to avoid nested
+        parallelism.
+        */
+        int use_parallel_reg = 0;
+        if (!force_sequential) {
+            use_parallel_reg = globalConfig().parallel_reg_mr;
+            if (use_parallel_reg == -1) {
+                use_parallel_reg = context_list_.size() > 1 && do_pre_touch;
+            }
+        }
+
+        auto reg_start = std::chrono::steady_clock::now();
+
+        if (use_parallel_reg) {
+            std::vector<std::thread> reg_threads;
+            reg_threads.reserve(context_list_.size());
+            std::vector<int> ret_codes(context_list_.size(), 0);
+            const int ar = access_rights;  // Local copy for lambda capture
+
+            for (size_t i = 0; i < context_list_.size(); ++i) {
+                reg_threads.emplace_back([this, &ret_codes, &dmabuf_exp, i,
+                                          chunk_addr, chunk_len, ar]() {
                     ret_codes[i] = context_list_[i]->registerMemoryRegion(
-                        addr, length, ar, dmabuf_exp);
+                        chunk_addr, chunk_len, ar, dmabuf_exp);
                 });
-        }
+            }
 
-        for (auto &thread : reg_threads) {
-            thread.join();
-        }
+            for (auto &thread : reg_threads) thread.join();
 
-        for (size_t i = 0; i < ret_codes.size(); ++i) {
-            if (ret_codes[i] != 0) {
-                LOG(ERROR) << "Failed to register memory region with context "
-                           << i;
-                reg_error = ret_codes[i];
-                break;
+            for (size_t i = 0; i < ret_codes.size(); ++i) {
+                if (ret_codes[i] != 0) {
+                    LOG(ERROR) << "Failed to register memory region (chunk "
+                               << ci << ") with context " << i;
+                    // chunk ci's MRs are partially registered but its metadata
+                    // was never added; release ci's MRs, then roll back the
+                    // committed chunks [0, ci).
+                    unregisterChunkMRs(chunk_addr);
+                    rollbackChunks(ci);
+                    return ret_codes[i];
+                }
+            }
+        } else {
+            for (size_t i = 0; i < context_list_.size(); ++i) {
+                int ret = context_list_[i]->registerMemoryRegion(
+                    chunk_addr, chunk_len, access_rights, dmabuf_exp);
+                if (ret) {
+                    LOG(ERROR) << "Failed to register memory region (chunk "
+                               << ci << ") with context " << i;
+                    // chunk ci's MRs are partially registered but its metadata
+                    // was never added; release ci's MRs, then roll back [0,
+                    // ci).
+                    unregisterChunkMRs(chunk_addr);
+                    rollbackChunks(ci);
+                    return ret;
+                }
             }
         }
-    } else {
-        for (size_t i = 0; i < context_list_.size(); ++i) {
-            int ret = context_list_[i]->registerMemoryRegion(
-                addr, length, access_rights, dmabuf_exp);
-            if (ret) {
-                LOG(ERROR) << "Failed to register memory region with context "
-                           << i;
-                reg_error = ret;
-                break;
-            }
+
+        auto reg_end = std::chrono::steady_clock::now();
+        auto reg_duration_ms =
+            std::chrono::duration_cast<std::chrono::milliseconds>(reg_end -
+                                                                  reg_start)
+                .count();
+        if (globalConfig().trace) {
+            LOG(INFO) << "registerMemoryRegion: chunk " << ci << "/"
+                      << chunks.size() << ", addr=" << chunk_addr
+                      << ", length=" << chunk_len
+                      << ", contexts=" << context_list_.size()
+                      << ", parallel=" << (use_parallel_reg ? "true" : "false")
+                      << ", duration=" << reg_duration_ms << "ms";
         }
-    }
 
-    // Close the single dma_buf fd now that all NIC registrations are done.
-    // Each successful MR holds its own reference, so the underlying dma_buf
-    // (and its BAR1 window) stays alive until those MRs are deregistered.
-    RdmaContext::closeDmabufExport(dmabuf_exp);
-
-    if (reg_error != 0) {
-        return reg_error;
-    }
-
-    auto reg_end = std::chrono::steady_clock::now();
-    auto reg_duration_ms =
-        std::chrono::duration_cast<std::chrono::milliseconds>(reg_end -
-                                                              reg_start)
-            .count();
-
-    if (globalConfig().trace) {
-        LOG(INFO) << "registerMemoryRegion: addr=" << addr
-                  << ", length=" << length
-                  << ", contexts=" << context_list_.size()
-                  << ", parallel=" << (use_parallel_reg ? "true" : "false")
-                  << ", duration=" << reg_duration_ms << "ms";
-    }
-
-    // Collect keys from all contexts
-    for (auto &context : context_list_) {
-        buffer_desc.lkey.push_back(context->lkey(addr));
-        buffer_desc.rkey.push_back(context->rkey(addr));
-    }
-
-    // Get the memory location automatically after registered MR(pinned),
-    // when the name is kWildcardLocation("*").
-    if (name == kWildcardLocation) {
-        bool only_first_page = true;
-        const std::vector<MemoryLocationEntry> entries =
-            getMemoryLocation(addr, length, only_first_page);
-        if (entries.empty()) return -1;
-        buffer_desc.name = entries[0].location;
-    } else {
-        buffer_desc.name = name;
-    }
-
-    buffer_desc.addr = (uint64_t)addr;
-    buffer_desc.length = length;
+        // Collect per-context keys for THIS chunk (address-range lookup).
+        BufferDesc buffer_desc;
+        for (auto &context : context_list_) {
+            buffer_desc.lkey.push_back(context->lkey(chunk_addr));
+            buffer_desc.rkey.push_back(context->rkey(chunk_addr));
+        }
+        buffer_desc.name = resolved_name;
+        buffer_desc.addr = (uint64_t)chunk_addr;
+        buffer_desc.length = chunk_len;
 #ifdef ENABLE_MULTI_PROTOCOL
-    buffer_desc.protocol = "rdma";
+        buffer_desc.protocol = "rdma";
 #endif
-    int rc = metadata_->addLocalMemoryBuffer(buffer_desc, update_metadata);
-    if (rc) return rc;
+        // Add to the LOCAL segment desc only (update_metadata=false); a chunked
+        // buffer otherwise publishes to the metadata server once PER CHUNK. We
+        // publish once, below, after every chunk has been added.
+        int rc = metadata_->addLocalMemoryBuffer(buffer_desc,
+                                                 /*update_metadata=*/false);
+        if (rc) {
+            // ci's MRs are registered but its metadata add failed; release ci's
+            // MRs, then roll back the committed chunks [0, ci).
+            unregisterChunkMRs(chunk_addr);
+            rollbackChunks(ci);
+            return rc;
+        }
+    }
+
+    // Publish the accumulated per-chunk BufferDescs in a SINGLE metadata update
+    // (a chunked buffer otherwise publishes once per chunk).
+    if (update_metadata) {
+        int rc = metadata_->updateLocalSegmentDesc();
+        if (rc) {
+            rollbackChunks(chunks.size());
+            return rc;
+        }
+    }
+
+    // Remember chunk start-addresses so unregisterLocalMemory(addr) (which only
+    // gets the base addr) can clean up every chunk.
+    if (chunks.size() > 1) {
+        std::lock_guard<std::mutex> lock(chunk_map_mutex_);
+        std::vector<uint64_t> chunk_addrs;
+        chunk_addrs.reserve(chunks.size());
+        for (auto &c : chunks) chunk_addrs.push_back((uint64_t)c.first);
+        chunk_map_[(uint64_t)addr] = std::move(chunk_addrs);
+    }
     return 0;
 }
 
@@ -365,6 +467,80 @@ int RdmaTransport::unregisterLocalMemory(void *addr, bool update_metadata) {
 int RdmaTransport::unregisterLocalMemoryInternal(void *addr,
                                                  bool update_metadata,
                                                  bool force_sequential) {
+    // Mooncake#2017: if this base buffer was split into chunks at registration,
+    // unregister each chunk's MR + metadata entry (unregisterLocalMemory only
+    // receives the base addr).
+    std::vector<uint64_t> chunk_addrs;
+    {
+        std::lock_guard<std::mutex> lock(chunk_map_mutex_);
+        auto it = chunk_map_.find((uint64_t)addr);
+        if (it != chunk_map_.end()) {
+            chunk_addrs = std::move(it->second);
+            chunk_map_.erase(it);
+        }
+    }
+    if (!chunk_addrs.empty()) {
+        // Unregister EVERY chunk even if one fails; chunk_map_ was already
+        // erased, so an early return would leak the remaining chunks' MRs +
+        // metadata. Remember the first error and report it at the end.
+        int first_err = 0;
+
+        // Metadata: remove each chunk from the local desc WITHOUT publishing (a
+        // chunked buffer otherwise publishes to the metadata server once per
+        // chunk); publish once after all removals, below.
+        for (uint64_t ca : chunk_addrs) {
+            int rc = metadata_->removeLocalMemoryBuffer(
+                reinterpret_cast<void *>(ca), /*update_metadata=*/false);
+            if (rc && !first_err) first_err = rc;
+        }
+
+        // MRs: unregister across contexts in PARALLEL (one thread per context,
+        // each releasing all chunks) — the previous code did chunks × contexts
+        // fully sequentially (e.g. 4 chunks × 8 NICs = 32 sequential
+        // ibv_dereg_mr). Mirrors the parallel path used for single buffers.
+        int use_parallel_unreg = 0;
+        if (!force_sequential) {
+            use_parallel_unreg = globalConfig().parallel_reg_mr;
+            if (use_parallel_unreg == -1)
+                use_parallel_unreg = context_list_.size() > 1;
+        }
+        if (use_parallel_unreg) {
+            std::vector<std::thread> threads;
+            threads.reserve(context_list_.size());
+            std::vector<int> ret_codes(context_list_.size(), 0);
+            for (size_t i = 0; i < context_list_.size(); ++i) {
+                threads.emplace_back([this, &ret_codes, i, &chunk_addrs]() {
+                    for (uint64_t ca : chunk_addrs) {
+                        int ret = context_list_[i]->unregisterMemoryRegion(
+                            reinterpret_cast<void *>(ca));
+                        if (ret && !ret_codes[i]) ret_codes[i] = ret;
+                    }
+                });
+            }
+            for (auto &t : threads) t.join();
+            for (int rc : ret_codes)
+                if (rc && !first_err) first_err = rc;
+        } else {
+            for (uint64_t ca : chunk_addrs)
+                for (auto &context : context_list_) {
+                    int ret = context->unregisterMemoryRegion(
+                        reinterpret_cast<void *>(ca));
+                    if (ret) {
+                        LOG(ERROR) << "Failed to unregister chunk MR at "
+                                   << reinterpret_cast<void *>(ca);
+                        if (!first_err) first_err = ret;
+                    }
+                }
+        }
+
+        // Single metadata publish covering all removed chunks.
+        if (update_metadata) {
+            int rc = metadata_->updateLocalSegmentDesc();
+            if (rc && !first_err) first_err = rc;
+        }
+        return first_err;
+    }
+
     int rc = metadata_->removeLocalMemoryBuffer(addr, update_metadata);
     if (rc) return rc;
 

--- a/mooncake-transfer-engine/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tests/CMakeLists.txt
@@ -50,6 +50,12 @@ target_link_libraries(rdma_loopback_test PUBLIC transfer_engine gtest
                                                 gtest_main)
 # add_test(NAME rdma_loopback_test COMMAND rdma_loopback_test)
 
+# Regression test for #2017 (registerLocalMemory must auto-chunk buffers larger
+# than the device max_mr_size; loopback WRITE past the boundary must succeed).
+add_executable(rdma_large_mr_test ${WORKSPACE}/rdma_large_mr_test.cpp)
+target_link_libraries(rdma_large_mr_test PUBLIC transfer_engine gtest gtest_main )
+# add_test(NAME rdma_large_mr_test COMMAND rdma_large_mr_test)  # needs an RDMA dev + metadata server
+
 # This test verifies endpoint re-establishment in RDMATransport.
 add_executable(rdma_endpoint_reestablish_test
                ${WORKSPACE}/rdma_endpoint_reestablish_test.cpp)

--- a/mooncake-transfer-engine/tests/rdma_large_mr_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_large_mr_test.cpp
@@ -1,0 +1,190 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Regression test for issue #2017: RdmaTransport::registerLocalMemory must NOT
+// silently truncate a buffer larger than the device max_mr_size.
+//
+// Bug: registerMemoryRegionInternal shrank `length` to max_mr_size and
+// registered a single MR of that size, but registerLocalMemory still published
+// BufferDesc.length = full length with that one (truncated) rkey. A remote RDMA
+// op whose target address fell past max_mr_size then failed with
+// IBV_WC_REM_ACCESS_ERR (e.g. ionic CQE error 10). It is ADDRESS-driven: ops to
+// low addresses succeed, ops past the boundary fail -> PD KV transfer ran for a
+// while then a worker died mid-run (seen on MI355x/ionic, per-layer KV ~3.25
+// GiB > the ionic 2 GiB max_mr_size).
+//
+// Fix: split buffers > max_mr_size into <= max_mr_size chunks, register each as
+// its own MR, and publish one BufferDesc per chunk.
+//
+// This test forces the condition at a small, HW-independent size by setting
+// MC_MAX_MR_SIZE, then does a LOOPBACK RDMA WRITE whose target lands PAST that
+// boundary. Pre-fix: the transfer FAILS (REM_ACCESS_ERR). Post-fix: it
+// COMPLETES and the bytes match. Runs on any RDMA device (incl. rdma_rxe /
+// loopback).
+
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+
+#include "transfer_engine.h"
+#include "transport/transport.h"
+
+using namespace mooncake;
+
+namespace mooncake {
+
+DEFINE_string(metadata_server, "127.0.0.1:2379",
+              "central metadata server for transfer engine");
+
+// Small max_mr_size so the >max_mr_size path is exercised without needing a
+// multi-GB allocation. Must be set before TransferEngine init (config reads
+// env).
+static constexpr size_t kMaxMrSize = 64ull << 20;    // 64 MiB
+static constexpr size_t kBufferSize = 256ull << 20;  // 256 MiB -> 4 chunks
+
+class RDMALargeMrTest : public ::testing::Test {
+   public:
+    void *addr = nullptr;
+    std::unique_ptr<mooncake::TransferEngine> engine;
+
+   protected:
+    void SetUp() override {
+        // Force a small device max_mr_size cap (config caps to min(env,
+        // device)).
+        setenv("MC_MAX_MR_SIZE", std::to_string(kMaxMrSize).c_str(), 1);
+        engine = std::make_unique<TransferEngine>(true);
+        engine->init(FLAGS_metadata_server, "test_node_large_mr");
+        addr = numa_alloc_onnode(kBufferSize, 0);
+        ASSERT_NE(addr, nullptr);
+        // Register a buffer LARGER than max_mr_size. Pre-fix this silently
+        // truncates the MR to kMaxMrSize; post-fix it splits into 4 chunks.
+        int rc = engine->registerLocalMemory(addr, kBufferSize, "cpu:0");
+        ASSERT_EQ(rc, 0);
+    }
+
+    void TearDown() override {
+        if (engine && addr) engine->unregisterLocalMemory(addr);
+        if (addr) numa_free(addr, kBufferSize);
+    }
+};
+
+// Loopback RDMA WRITE whose TARGET lands past max_mr_size. The source stays in
+// the first MR; only the destination address exercises the truncation boundary.
+TEST_F(RDMALargeMrTest, WritePastMaxMrSizeBoundary) {
+    const size_t kDataLength = 1ull << 20;  // 1 MiB
+    // Target offset is well past kMaxMrSize (in the 4th chunk). Pre-fix: the
+    // single 64 MiB MR does not cover this address -> IBV_WC_REM_ACCESS_ERR.
+    const size_t kTargetOffset = kBufferSize - kDataLength;  // ~255 MiB
+    ASSERT_GT(kTargetOffset, kMaxMrSize);
+
+    for (size_t i = 0; i < kDataLength; ++i)
+        *((char *)addr + i) = (char)('a' + (lrand48() % 26));
+
+    auto batch_id = engine->allocateBatchID(1);
+    TransferRequest entry;
+    entry.opcode = TransferRequest::WRITE;
+    entry.length = kDataLength;
+    entry.source = (uint8_t *)addr;  // src in chunk 0
+    entry.target_id = LOCAL_SEGMENT_ID;
+    entry.target_offset = (uint64_t)addr + kTargetOffset;  // dst past 64 MiB
+
+    Status s = engine->submitTransfer(batch_id, {entry});
+    ASSERT_TRUE(s.ok());
+
+    TransferStatus status;
+    bool completed = false;
+    while (!completed) {
+        Status gs = engine->getTransferStatus(batch_id, 0, status);
+        ASSERT_EQ(gs, Status::OK());
+        if (status.s == TransferStatusEnum::COMPLETED)
+            completed = true;
+        else if (status.s == TransferStatusEnum::FAILED)
+            break;
+    }
+    ASSERT_EQ(engine->freeBatchID(batch_id), Status::OK());
+
+    // The regression assertion: pre-fix this is FAILED (remote access error);
+    // post-fix it COMPLETES and the bytes match.
+    ASSERT_EQ(status.s, TransferStatusEnum::COMPLETED)
+        << "RDMA WRITE to an address past max_mr_size failed -- buffer MR was "
+           "truncated and not auto-chunked (issue #2017).";
+    ASSERT_EQ(0, memcmp(addr, (char *)addr + kTargetOffset, kDataLength));
+}
+
+// Loopback RDMA WRITE whose TARGET range STRADDLES a chunk boundary (the seam
+// between chunk 0 and chunk 1 at kMaxMrSize). The single logical transfer spans
+// two MRs, so it must be split across the two chunks' rkeys -- otherwise the
+// same IBV_WC_REM_ACCESS_ERR class re-surfaces at chunk seams (the concern this
+// test guards, complementing WritePastMaxMrSizeBoundary which stays within one
+// chunk).
+TEST_F(RDMALargeMrTest, WriteStraddlesChunkBoundary) {
+    const size_t kDataLength = 1ull << 20;  // 1 MiB
+    // Center the target on the first chunk boundary: half in chunk 0, half in
+    // chunk 1.
+    const size_t kTargetOffset = kMaxMrSize - kDataLength / 2;
+    ASSERT_LT(kTargetOffset, kMaxMrSize);                // starts in chunk 0
+    ASSERT_GT(kTargetOffset + kDataLength, kMaxMrSize);  // ends in chunk 1
+
+    // Distinct source bytes, and poison the destination so a dropped/partial
+    // write past the seam is caught by the memcmp below.
+    for (size_t i = 0; i < kDataLength; ++i)
+        *((char *)addr + i) = (char)('A' + (lrand48() % 26));
+    memset((char *)addr + kTargetOffset, 0, kDataLength);
+
+    auto batch_id = engine->allocateBatchID(1);
+    TransferRequest entry;
+    entry.opcode = TransferRequest::WRITE;
+    entry.length = kDataLength;
+    entry.source = (uint8_t *)addr;  // src in chunk 0
+    entry.target_id = LOCAL_SEGMENT_ID;
+    entry.target_offset = (uint64_t)addr + kTargetOffset;  // straddles the seam
+
+    Status s = engine->submitTransfer(batch_id, {entry});
+    ASSERT_TRUE(s.ok());
+
+    TransferStatus status;
+    bool completed = false;
+    while (!completed) {
+        Status gs = engine->getTransferStatus(batch_id, 0, status);
+        ASSERT_EQ(gs, Status::OK());
+        if (status.s == TransferStatusEnum::COMPLETED)
+            completed = true;
+        else if (status.s == TransferStatusEnum::FAILED)
+            break;
+    }
+    ASSERT_EQ(engine->freeBatchID(batch_id), Status::OK());
+
+    ASSERT_EQ(status.s, TransferStatusEnum::COMPLETED)
+        << "RDMA WRITE straddling a chunk boundary failed -- a cross-chunk "
+           "transfer was not split across the two chunks' MRs (issue #2017).";
+    ASSERT_EQ(0, memcmp(addr, (char *)addr + kTargetOffset, kDataLength));
+}
+
+}  // namespace mooncake
+
+int main(int argc, char **argv) {
+    gflags::ParseCommandLineFlags(&argc, &argv, false);
+    // Initialize logging once for the whole binary — calling
+    // InitGoogleLogging() per-test in SetUp() aborts on the 2nd TEST_F.
+    google::InitGoogleLogging(argv[0]);
+    FLAGS_logtostderr = 1;
+    ::testing::InitGoogleTest(&argc, argv);
+    int rc = RUN_ALL_TESTS();
+    google::ShutdownGoogleLogging();
+    return rc;
+}


### PR DESCRIPTION
Closes #2017.

## Problem

`RdmaTransport::registerLocalMemory()` registers a single MR for the whole buffer and publishes `BufferDesc.length = full length`, but `RdmaContext::registerMemoryRegionInternal()` **silently shrinks `length` to the device `max_mr_size`** (some RoCE NICs cap this at 2 GiB) and registers an MR of only that size. The metadata then advertises bytes past the registered region, so any remote RDMA op whose **target address falls past `max_mr_size`** completes with **`IBV_WC_REM_ACCESS_ERR`**.

It is **address-driven, not size-driven**: ops to low addresses succeed; ops past the boundary fail (even small ones). Any registered buffer larger than `max_mr_size` is affected (e.g. large disaggregated-PD KV pools) — it works for a while, then fails once an op targets a high address.

## Fix

Mirror what the EFA transport already does: split a buffer larger than `max_mr_size` into `<= max_mr_size` chunks, register each as its **own MR**, and publish **one `BufferDesc` per chunk**. The per-context `rkey()/lkey()` lookups are address-range based (`findMemoryRegionContaining`), so each chunk resolves to the correct key. Chunk start-addresses are tracked (`chunk_map_`) so `unregisterLocalMemory(base_addr)` tears down every chunk; unregister continues past a per-chunk failure (reporting the first error) to avoid leaks; best-effort rollback on partial registration. Pre-touch is decided from the original buffer length, not the capped chunk length. No metadata schema change.

## Test

`tests/rdma_large_mr_test.cpp` (`RDMALargeMrTest.WritePastMaxMrSizeBoundary`): sets a small `MC_MAX_MR_SIZE` (64 MiB), registers a larger buffer (256 MiB -> 4 chunks), then issues a loopback RDMA WRITE whose target lands past the boundary. **Before:** the transfer FAILS with a remote access error. **After:** it COMPLETES and the bytes match. Runs on any RDMA device (incl. soft-RoCE / loopback) plus a metadata server; built but left out of auto-ctest (needs a device), like the sibling `rdma_loopback_test`.

## Verification (real workload)

A disaggregated prefill/decode KV transfer at high tensor-parallel degree (per-layer KV ~3.2 GiB > a 2 GiB `max_mr_size`): the patched build logged ~488 `Auto-splitting buffer (3213176832 bytes) into 2 chunks` and ran the full window with **0** remote-access-errors across a concurrency sweep; unpatched it failed mid-run with remote access errors.