### PR TITLE
[Store] Externalize S3 client config via environment variables

### DIFF
--- a/mooncake-store/src/utils/s3_helper.cpp
+++ b/mooncake-store/src/utils/s3_helper.cpp
@@ -27,6 +27,8 @@
 #include <aws/s3/model/CompleteMultipartUploadRequest.h>
 #include <aws/s3/model/AbortMultipartUploadRequest.h>
 #include <aws/s3/model/UploadPartRequest.h>
+#include <aws/core/client/ClientConfiguration.h>
+#include <aws/core/utils/logging/LogLevel.h>
 #include "utils/type_util.h"
 #include "fmt/format.h"
 
@@ -49,6 +51,14 @@ struct S3Env {
     std::string secret_key;
 
     bool use_virtual_addressing = true;
+
+    bool use_https = true;
+
+    Aws::Client::RequestChecksumCalculation request_checksum =
+        Aws::Client::RequestChecksumCalculation::WHEN_SUPPORTED;
+
+    Aws::Client::ResponseChecksumValidation response_checksum =
+        Aws::Client::ResponseChecksumValidation::WHEN_SUPPORTED;
 
     int64_t connect_timeout_ms = kDefaultS3ConnectTimeoutMs;
 
@@ -92,6 +102,46 @@ void AssignTimeoutFromEnv(const char *env_name, int64_t default_value,
     target = default_value;
 }
 
+Aws::Utils::Logging::LogLevel ParseLogLevel(const std::string &value) {
+    if (value == "off") return Aws::Utils::Logging::LogLevel::Off;
+    if (value == "fatal") return Aws::Utils::Logging::LogLevel::Fatal;
+    if (value == "warn") return Aws::Utils::Logging::LogLevel::Warn;
+    if (value == "info") return Aws::Utils::Logging::LogLevel::Info;
+    if (value == "debug") return Aws::Utils::Logging::LogLevel::Debug;
+    if (value == "trace") return Aws::Utils::Logging::LogLevel::Trace;
+    if (!value.empty()) {
+        LOG(WARNING) << "Invalid MOONCAKE_AWS_LOG_LEVEL value: " << value
+                     << ", falling back to Error";
+    }
+    return Aws::Utils::Logging::LogLevel::Error;
+}
+
+Aws::Client::RequestChecksumCalculation ParseRequestChecksum(
+    const std::string &value) {
+    if (value == "when_required") {
+        return Aws::Client::RequestChecksumCalculation::WHEN_REQUIRED;
+    }
+    if (!value.empty()) {
+        LOG(WARNING)
+            << "Invalid MOONCAKE_AWS_S3_REQUEST_CHECKSUM value: " << value
+            << ", falling back to when_supported";
+    }
+    return Aws::Client::RequestChecksumCalculation::WHEN_SUPPORTED;
+}
+
+Aws::Client::ResponseChecksumValidation ParseResponseChecksum(
+    const std::string &value) {
+    if (value == "when_required") {
+        return Aws::Client::ResponseChecksumValidation::WHEN_REQUIRED;
+    }
+    if (!value.empty()) {
+        LOG(WARNING)
+            << "Invalid MOONCAKE_AWS_S3_RESPONSE_CHECKSUM value: " << value
+            << ", falling back to when_supported";
+    }
+    return Aws::Client::ResponseChecksumValidation::WHEN_SUPPORTED;
+}
+
 }  // namespace
 
 bool S3Helper::aws_initialized = false;
@@ -113,6 +163,24 @@ void S3Helper::InitAPI() {
     AssignBoolFromEnv("MOONCAKE_AWS_USE_VIRTUAL_ADDRESSING",
                       s3_env.use_virtual_addressing);
 
+    AssignBoolFromEnv("MOONCAKE_AWS_S3_USE_HTTPS", s3_env.use_https);
+
+    {
+        std::string tmp;
+        AssignStringFromEnv("MOONCAKE_AWS_LOG_LEVEL", tmp);
+        options_.loggingOptions.logLevel = ParseLogLevel(tmp);
+    }
+    {
+        std::string tmp;
+        AssignStringFromEnv("MOONCAKE_AWS_S3_REQUEST_CHECKSUM", tmp);
+        s3_env.request_checksum = ParseRequestChecksum(tmp);
+    }
+    {
+        std::string tmp;
+        AssignStringFromEnv("MOONCAKE_AWS_S3_RESPONSE_CHECKSUM", tmp);
+        s3_env.response_checksum = ParseResponseChecksum(tmp);
+    }
+
     AssignTimeoutFromEnv("MOONCAKE_AWS_CONNECT_TIMEOUT_MS",
                          kDefaultS3ConnectTimeoutMs, s3_env.connect_timeout_ms);
     AssignTimeoutFromEnv("MOONCAKE_AWS_REQUEST_TIMEOUT_MS",
@@ -132,7 +200,10 @@ S3Helper::S3Helper(const std::string &endpoint, const std::string &bucket,
 
     config.connectTimeoutMs = s3_env.connect_timeout_ms;
     config.requestTimeoutMs = s3_env.request_timeout_ms;
-    config.scheme = Aws::Http::Scheme::HTTPS;
+    config.scheme = s3_env.use_https ? Aws::Http::Scheme::HTTPS
+                                      : Aws::Http::Scheme::HTTP;
+    config.checksumConfig.requestChecksumCalculation = s3_env.request_checksum;
+    config.checksumConfig.responseChecksumValidation = s3_env.response_checksum;
 
     if (!region.empty()) {
         config.region = region;
@@ -163,7 +234,10 @@ S3Helper::S3Helper(const std::string &endpoint, const std::string &bucket,
         "requestTimeoutMs={} "
         "scheme={} "
         "credentials={}/{} "
-        "useVirtualAddressing={}",
+        "useVirtualAddressing={} "
+        "logLevel={} "
+        "requestChecksum={} "
+        "responseChecksum={}",
         config.region.empty() ? "unset" : config.region,
         config.endpointOverride.empty() ? "unset" : config.endpointOverride,
         bucket_.empty() ? "unset" : bucket_, config.connectTimeoutMs,
@@ -171,7 +245,16 @@ S3Helper::S3Helper(const std::string &endpoint, const std::string &bucket,
         config.scheme == Aws::Http::Scheme::HTTPS ? "HTTPS" : "HTTP",
         !s3_env.access_key.empty() ? "set" : "unset",
         !s3_env.secret_key.empty() ? "set" : "unset",
-        s3_env.use_virtual_addressing ? "true" : "false");
+        s3_env.use_virtual_addressing ? "true" : "false",
+        Aws::Utils::Logging::GetLogLevelName(options_.loggingOptions.logLevel),
+        s3_env.request_checksum ==
+                Aws::Client::RequestChecksumCalculation::WHEN_SUPPORTED
+            ? "when_supported"
+            : "when_required",
+        s3_env.response_checksum ==
+                Aws::Client::ResponseChecksumValidation::WHEN_SUPPORTED
+            ? "when_supported"
+            : "when_required");
 
     s3_client_ = Aws::S3::S3Client(
         credentials, config,

--- a/mooncake-wheel/mooncake/mooncake_store_service.py
+++ b/mooncake-wheel/mooncake/mooncake_store_service.py
@@ -640,5 +640,11 @@ async def main():
         await service.stop()
         raise
 
+
+def sync_main():
+    """Synchronous entry point for ``mc_store_rest_server`` CLI."""
+    return asyncio.run(main())
+
+
 if __name__ == "__main__":
-    asyncio.run(main())
+    sync_main()

--- a/mooncake-wheel/pyproject.toml
+++ b/mooncake-wheel/pyproject.toml
@@ -30,7 +30,7 @@ mooncake_master = "mooncake.cli:main"
 mooncake_client = "mooncake.cli_client:main"
 transfer_engine_bench = "mooncake.cli_bench:main"
 mooncake_http_metadata_server = "mooncake.http_metadata_server:main"
-mc_store_rest_server = "mooncake.mooncake_store_service:main"
+mc_store_rest_server = "mooncake.mooncake_store_service:sync_main"
 transfer_engine_topology_dump = "mooncake.transfer_engine_topology_dump:main"
 
 [tool.setuptools]


### PR DESCRIPTION
## Description

Externalize four S3 client knobs as environment variables so they can be tuned at runtime without rebuilding. Defaults preserve current behavior — existing users see no
  change.

  ## New environment variables

  | Env var | Values | Default | Purpose |
  |---|---|---|---|
  | `MOONCAKE_AWS_S3_USE_HTTPS` | `true` / `false` | `true` | Switch between HTTPS and HTTP scheme |
  | `MOONCAKE_AWS_LOG_LEVEL` | `off` / `fatal` / `error` / `warn` / `info` / `debug` / `trace` | `error` | AWS SDK log verbosity |
  | `MOONCAKE_AWS_S3_REQUEST_CHECKSUM` | `when_supported` / `when_required` | `when_supported` | PUT request checksum behavior |
  | `MOONCAKE_AWS_S3_RESPONSE_CHECKSUM` | `when_supported` / `when_required` | `when_supported` | GET response checksum validation |

  ## Why
  
  - `MOONCAKE_AWS_S3_USE_HTTPS` — the original code hardcoded HTTPS, breaking deployments to plaintext MinIO/Ceph.
  - `MOONCAKE_AWS_LOG_LEVEL` — production debugging currently requires rebuilding with a different log level.
  - The two checksum vars — AWS SDK 1.11+ added flexible checksum trailers that fail PUT against MinIO and other S3-compatible backends. Setting `when_required` restores
  pre-1.11 behavior.
  
  ## Backward compatibility
  
  All four defaults match the previous behavior:
  - scheme: HTTPS (was hardcoded)
  - log level: `Error` (was hardcoded)
  - checksums: `WHEN_SUPPORTED` (AWS SDK default, was implicit)
  
  Users on AWS-proper S3 see no change. Users on MinIO/Ceph can now opt into compatible behavior by setting the two checksum vars to `when_required`.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [x] Other

## How Has This Been Tested?



**Test commands:**
```bash
# Example: bash scripts/run_ci_test.sh
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [ ] AI tools were used (specify below)