### PR TITLE
[Store] Externalize S3 client config via environment variables

### DIFF
--- a/mooncake-common/include/environ.h
+++ b/mooncake-common/include/environ.h
@@ -52,8 +52,30 @@ class Environ {
     bool GetWithNvidiaPeermem() const { return with_nvidia_peermem_; }
     int GetEfaCqThreads() const { return efa_cq_threads_; }
 
+    // AWS / S3 client configuration
+    std::string GetAwsRegion() const { return aws_region_; }
+    std::string GetAwsS3Endpoint() const { return aws_s3_endpoint_; }
+    std::string GetAwsBucketName() const { return aws_bucket_name_; }
+    std::string GetAwsAccessKeyId() const { return aws_access_key_id_; }
+    std::string GetAwsSecretAccessKey() const { return aws_secret_access_key_; }
+    bool GetAwsUseVirtualAddressing() const {
+        return aws_use_virtual_addressing_;
+    }
+    bool GetAwsUseHttps() const { return aws_use_https_; }
+    // Empty string means "unset" — s3_helper keeps the AWS SDK default in
+    // that case. Parsing to AWS enums is done by the consumer.
+    std::string GetAwsRequestChecksumCalculation() const {
+        return aws_request_checksum_calculation_;
+    }
+    std::string GetAwsResponseChecksumValidation() const {
+        return aws_response_checksum_validation_;
+    }
+    int64_t GetAwsConnectTimeoutMs() const { return aws_connect_timeout_ms_; }
+    int64_t GetAwsRequestTimeoutMs() const { return aws_request_timeout_ms_; }
+
     // Helper method to get int from env
     static int GetInt(const char* name, int default_value);
+    static int64_t GetInt64(const char* name, int64_t default_value);
     // Helper method to get size_t from env
     static size_t GetSizeT(const char* name, size_t default_value);
     // Helper method to get bool from env (checks for "1", "true", "TRUE")
@@ -103,6 +125,19 @@ class Environ {
     bool path_roundrobin_;
     bool with_nvidia_peermem_;
     int efa_cq_threads_;
+
+    // AWS / S3 client configuration
+    std::string aws_region_;
+    std::string aws_s3_endpoint_;
+    std::string aws_bucket_name_;
+    std::string aws_access_key_id_;
+    std::string aws_secret_access_key_;
+    bool aws_use_virtual_addressing_;
+    bool aws_use_https_;
+    std::string aws_request_checksum_calculation_;
+    std::string aws_response_checksum_validation_;
+    int64_t aws_connect_timeout_ms_;
+    int64_t aws_request_timeout_ms_;
 };
 
 }  // namespace mooncake

--- a/mooncake-common/src/environ.cpp
+++ b/mooncake-common/src/environ.cpp
@@ -31,6 +31,23 @@ int Environ::GetInt(const char* name, int default_value) {
     return default_value;
 }
 
+int64_t Environ::GetInt64(const char* name, int64_t default_value) {
+    const char* val = std::getenv(name);
+    if (val) {
+        char* endptr = nullptr;
+        errno = 0;
+        long long result = std::strtoll(val, &endptr, 10);
+        if (endptr == val || *endptr != '\0' || errno == ERANGE) {
+            std::cerr << "[Mooncake] Warning: invalid value '" << val
+                      << "' for env " << name << ", using default "
+                      << default_value << std::endl;
+            return default_value;
+        }
+        return static_cast<int64_t>(result);
+    }
+    return default_value;
+}
+
 size_t Environ::GetSizeT(const char* name, size_t default_value) {
     const char* val = std::getenv(name);
     if (val) {
@@ -108,6 +125,26 @@ Environ::Environ() {
     path_roundrobin_ = GetBool("MC_PATH_ROUNDROBIN", false);
     with_nvidia_peermem_ = GetBool("WITH_NVIDIA_PEERMEM", true);
     efa_cq_threads_ = GetInt("MC_EFA_CQ_THREADS", 1);
+
+    // AWS / S3 client configuration (consumed by s3_helper.cpp)
+    aws_region_ = GetString("MOONCAKE_AWS_REGION", "");
+    aws_s3_endpoint_ = GetString("MOONCAKE_AWS_S3_ENDPOINT", "");
+    aws_bucket_name_ = GetString("MOONCAKE_AWS_BUCKET_NAME", "");
+    aws_access_key_id_ = GetString("MOONCAKE_AWS_ACCESS_KEY_ID", "");
+    aws_secret_access_key_ = GetString("MOONCAKE_AWS_SECRET_ACCESS_KEY", "");
+    aws_use_virtual_addressing_ =
+        GetBool("MOONCAKE_AWS_USE_VIRTUAL_ADDRESSING", true);
+    aws_use_https_ = GetBool("MOONCAKE_AWS_USE_HTTPS", true);
+    // Empty string preserves "unset" semantics — s3_helper keeps the AWS SDK
+    // default in that case rather than forcing a value.
+    aws_request_checksum_calculation_ =
+        GetString("MOONCAKE_AWS_REQUEST_CHECKSUM_CALCULATION", "");
+    aws_response_checksum_validation_ =
+        GetString("MOONCAKE_AWS_RESPONSE_CHECKSUM_VALIDATION", "");
+    aws_connect_timeout_ms_ =
+        GetInt64("MOONCAKE_AWS_CONNECT_TIMEOUT_MS", 10000);
+    aws_request_timeout_ms_ =
+        GetInt64("MOONCAKE_AWS_REQUEST_TIMEOUT_MS", 30000);
 }
 
 }  // namespace mooncake

--- a/mooncake-common/tests/environ_test.cpp
+++ b/mooncake-common/tests/environ_test.cpp
@@ -28,9 +28,22 @@ class EnvironTest : public ::testing::Test {
 
     void clearTestEnvVars() {
         unsetenv("MC_TEST_INT");
+        unsetenv("MC_TEST_INT64");
         unsetenv("MC_TEST_SIZET");
         unsetenv("MC_TEST_BOOL");
         unsetenv("MC_TEST_STRING");
+        // Make sure AWS vars don't leak in from the test runner's env.
+        unsetenv("MOONCAKE_AWS_REGION");
+        unsetenv("MOONCAKE_AWS_S3_ENDPOINT");
+        unsetenv("MOONCAKE_AWS_BUCKET_NAME");
+        unsetenv("MOONCAKE_AWS_ACCESS_KEY_ID");
+        unsetenv("MOONCAKE_AWS_SECRET_ACCESS_KEY");
+        unsetenv("MOONCAKE_AWS_USE_VIRTUAL_ADDRESSING");
+        unsetenv("MOONCAKE_AWS_USE_HTTPS");
+        unsetenv("MOONCAKE_AWS_REQUEST_CHECKSUM_CALCULATION");
+        unsetenv("MOONCAKE_AWS_RESPONSE_CHECKSUM_VALIDATION");
+        unsetenv("MOONCAKE_AWS_CONNECT_TIMEOUT_MS");
+        unsetenv("MOONCAKE_AWS_REQUEST_TIMEOUT_MS");
     }
 };
 
@@ -83,6 +96,70 @@ TEST_F(EnvironTest, GetIntMaxValue) {
 TEST_F(EnvironTest, GetIntMinValue) {
     setenv("MC_TEST_INT", std::to_string(INT_MIN).c_str(), 1);
     EXPECT_EQ(Environ::GetInt("MC_TEST_INT", 0), INT_MIN);
+}
+
+// --- GetInt64 ---
+
+TEST_F(EnvironTest, GetInt64ValidValue) {
+    setenv("MC_TEST_INT64", "123456789012", 1);
+    EXPECT_EQ(Environ::GetInt64("MC_TEST_INT64", 0), 123456789012LL);
+}
+
+TEST_F(EnvironTest, GetInt64Missing) {
+    EXPECT_EQ(Environ::GetInt64("MC_TEST_INT64", 9999), 9999);
+}
+
+TEST_F(EnvironTest, GetInt64Empty) {
+    setenv("MC_TEST_INT64", "", 1);
+    EXPECT_EQ(Environ::GetInt64("MC_TEST_INT64", 555), 555);
+}
+
+TEST_F(EnvironTest, GetInt64NonNumeric) {
+    setenv("MC_TEST_INT64", "abc", 1);
+    EXPECT_EQ(Environ::GetInt64("MC_TEST_INT64", 555), 555);
+}
+
+TEST_F(EnvironTest, GetInt64Overflow) {
+    setenv("MC_TEST_INT64", "99999999999999999999999999", 1);
+    EXPECT_EQ(Environ::GetInt64("MC_TEST_INT64", 555), 555);
+}
+
+// --- AWS / S3 fields ---
+//
+// NOTE: Environ is a singleton whose constructor caches every value the
+// first time Get() is called. So all AWS env vars must be set BEFORE the
+// first Environ::Get() in this process. We therefore cover the populate
+// path in a single test that takes the singleton's "first call" for
+// itself; the default-path behavior is implicitly covered by Environ's
+// constructor defaults (any earlier test would lock the cache to defaults
+// and prevent us from observing populated values here).
+
+TEST_F(EnvironTest, AwsFieldsPopulateFromEnv) {
+    setenv("MOONCAKE_AWS_REGION", "us-east-1", 1);
+    setenv("MOONCAKE_AWS_S3_ENDPOINT", "https://s3.example.com", 1);
+    setenv("MOONCAKE_AWS_BUCKET_NAME", "my-bucket", 1);
+    setenv("MOONCAKE_AWS_ACCESS_KEY_ID", "AKIA-test", 1);
+    setenv("MOONCAKE_AWS_SECRET_ACCESS_KEY", "secret", 1);
+    setenv("MOONCAKE_AWS_USE_VIRTUAL_ADDRESSING", "0", 1);
+    setenv("MOONCAKE_AWS_USE_HTTPS", "0", 1);
+    setenv("MOONCAKE_AWS_REQUEST_CHECKSUM_CALCULATION", "when_required", 1);
+    setenv("MOONCAKE_AWS_RESPONSE_CHECKSUM_VALIDATION", "when_supported", 1);
+    setenv("MOONCAKE_AWS_CONNECT_TIMEOUT_MS", "5000", 1);
+    // Bogus request timeout should fall back to the registered default.
+    setenv("MOONCAKE_AWS_REQUEST_TIMEOUT_MS", "bogus", 1);
+
+    const auto& e = Environ::Get();
+    EXPECT_EQ(e.GetAwsRegion(), "us-east-1");
+    EXPECT_EQ(e.GetAwsS3Endpoint(), "https://s3.example.com");
+    EXPECT_EQ(e.GetAwsBucketName(), "my-bucket");
+    EXPECT_EQ(e.GetAwsAccessKeyId(), "AKIA-test");
+    EXPECT_EQ(e.GetAwsSecretAccessKey(), "secret");
+    EXPECT_FALSE(e.GetAwsUseVirtualAddressing());
+    EXPECT_FALSE(e.GetAwsUseHttps());
+    EXPECT_EQ(e.GetAwsRequestChecksumCalculation(), "when_required");
+    EXPECT_EQ(e.GetAwsResponseChecksumValidation(), "when_supported");
+    EXPECT_EQ(e.GetAwsConnectTimeoutMs(), 5000);
+    EXPECT_EQ(e.GetAwsRequestTimeoutMs(), 30000);
 }
 
 // --- GetSizeT ---

--- a/mooncake-store/src/utils/s3_helper.cpp
+++ b/mooncake-store/src/utils/s3_helper.cpp
@@ -10,11 +10,11 @@
 #include <aws/s3/model/DeleteObjectsRequest.h>
 #include <aws/s3/model/ObjectIdentifier.h>
 #include <aws/s3/model/Delete.h>
+#include <algorithm>
 #include <optional>
 #include <fstream>
 #include <iostream>
 #include <cstdint>
-#include <cstdlib>
 #include <cstring>
 #include <cctype>
 #include <glog/logging.h>
@@ -27,69 +27,30 @@
 #include <aws/s3/model/CompleteMultipartUploadRequest.h>
 #include <aws/s3/model/AbortMultipartUploadRequest.h>
 #include <aws/s3/model/UploadPartRequest.h>
-#include "utils/type_util.h"
+#include <aws/core/client/ClientConfiguration.h>
+#include "environ.h"
 #include "fmt/format.h"
 
 namespace mooncake {
 
 namespace {
 
-constexpr int64_t kDefaultS3ConnectTimeoutMs = 10000;
-constexpr int64_t kDefaultS3RequestTimeoutMs = 30000;
-
-struct S3Env {
-    std::string region;
-
-    std::string endpoint;
-
-    std::string bucket;
-
-    std::string access_key;
-
-    std::string secret_key;
-
-    bool use_virtual_addressing = true;
-
-    int64_t connect_timeout_ms = kDefaultS3ConnectTimeoutMs;
-
-    int64_t request_timeout_ms = kDefaultS3RequestTimeoutMs;
-};
-
-S3Env s3_env;
-
-void AssignStringFromEnv(const char *env_name, std::string &target) {
-    const char *env_value = std::getenv(env_name);
-    if (env_value && *env_value) {
-        target = env_value;
-    } else {
-        target.clear();
-    }
-}
-
-void AssignBoolFromEnv(const char *env_name, bool &target) {
-    const char *env_value = std::getenv(env_name);
-    if (env_value && *env_value) {
-        bool parsed = true;
-        if (TypeUtil::ParseBool(env_value, parsed)) {
-            target = parsed;
-            return;
-        }
-        LOG(WARNING) << "Invalid " << env_name << " value: " << env_value;
-    }
-}
-
-void AssignTimeoutFromEnv(const char *env_name, int64_t default_value,
-                          int64_t &target) {
-    const char *env_value = std::getenv(env_name);
-    if (env_value && *env_value) {
-        int64_t parsed;
-        if (TypeUtil::ParseInt64(env_value, parsed)) {
-            target = parsed;
-            return;
-        }
-        LOG(WARNING) << "Invalid " << env_name << " value: " << env_value;
-    }
-    target = default_value;
+// Parse a checksum-mode string ("when_supported" | "when_required") into the
+// AWS SDK enum. Returns std::nullopt when the value is unset or invalid — the
+// caller should then leave the AWS SDK's default in place. This is purely
+// string-to-enum logic (not getenv), so it lives next to the AWS types it
+// produces.
+template <typename T>
+std::optional<T> ParseChecksumMode(const std::string &value) {
+    if (value.empty()) return std::nullopt;
+    std::string lower = value;
+    std::transform(lower.begin(), lower.end(), lower.begin(),
+                   [](unsigned char ch) { return std::tolower(ch); });
+    if (lower == "when_required") return T::WHEN_REQUIRED;
+    if (lower == "when_supported") return T::WHEN_SUPPORTED;
+    LOG(WARNING) << "Invalid value: " << value
+                 << ", ignoring (keeping AWS SDK default)";
+    return std::nullopt;
 }
 
 }  // namespace
@@ -102,21 +63,10 @@ void S3Helper::InitAPI() {
     Aws::InitAPI(options_);
     aws_initialized = true;
 
-    // Read environment variables once during initialization (fallback as needed
-    // if not set)
-    AssignStringFromEnv("MOONCAKE_AWS_REGION", s3_env.region);
-    AssignStringFromEnv("MOONCAKE_AWS_S3_ENDPOINT", s3_env.endpoint);
-    AssignStringFromEnv("MOONCAKE_AWS_BUCKET_NAME", s3_env.bucket);
-    AssignStringFromEnv("MOONCAKE_AWS_ACCESS_KEY_ID", s3_env.access_key);
-    AssignStringFromEnv("MOONCAKE_AWS_SECRET_ACCESS_KEY", s3_env.secret_key);
-
-    AssignBoolFromEnv("MOONCAKE_AWS_USE_VIRTUAL_ADDRESSING",
-                      s3_env.use_virtual_addressing);
-
-    AssignTimeoutFromEnv("MOONCAKE_AWS_CONNECT_TIMEOUT_MS",
-                         kDefaultS3ConnectTimeoutMs, s3_env.connect_timeout_ms);
-    AssignTimeoutFromEnv("MOONCAKE_AWS_REQUEST_TIMEOUT_MS",
-                         kDefaultS3RequestTimeoutMs, s3_env.request_timeout_ms);
+    // Force Environ initialization so all MOONCAKE_AWS_* env vars are read
+    // once during startup, matching the previous "read once at InitAPI"
+    // behavior.
+    (void)Environ::Get();
 }
 
 void S3Helper::ShutdownAPI() {
@@ -128,30 +78,43 @@ void S3Helper::ShutdownAPI() {
 
 S3Helper::S3Helper(const std::string &endpoint, const std::string &bucket,
                    const std::string &region) {
+    const auto &env = Environ::Get();
     Aws::Client::ClientConfiguration config(true);
 
-    config.connectTimeoutMs = s3_env.connect_timeout_ms;
-    config.requestTimeoutMs = s3_env.request_timeout_ms;
-    config.scheme = Aws::Http::Scheme::HTTPS;
+    config.connectTimeoutMs = env.GetAwsConnectTimeoutMs();
+    config.requestTimeoutMs = env.GetAwsRequestTimeoutMs();
+    config.scheme = env.GetAwsUseHttps() ? Aws::Http::Scheme::HTTPS
+                                         : Aws::Http::Scheme::HTTP;
+    if (auto request_checksum =
+            ParseChecksumMode<Aws::Client::RequestChecksumCalculation>(
+                env.GetAwsRequestChecksumCalculation())) {
+        config.checksumConfig.requestChecksumCalculation = *request_checksum;
+    }
+    if (auto response_checksum =
+            ParseChecksumMode<Aws::Client::ResponseChecksumValidation>(
+                env.GetAwsResponseChecksumValidation())) {
+        config.checksumConfig.responseChecksumValidation = *response_checksum;
+    }
 
     if (!region.empty()) {
         config.region = region;
     } else {
-        config.region = s3_env.region;
+        config.region = env.GetAwsRegion();
     }
 
     if (!endpoint.empty()) {
         config.endpointOverride = endpoint;
     } else {
-        config.endpointOverride = s3_env.endpoint;
+        config.endpointOverride = env.GetAwsS3Endpoint();
     }
 
-    bucket_ = s3_env.bucket;
+    bucket_ = env.GetAwsBucketName();
     if (!bucket.empty()) {
         bucket_ = bucket;
     }
 
-    Aws::Auth::AWSCredentials credentials(s3_env.access_key, s3_env.secret_key);
+    Aws::Auth::AWSCredentials credentials(env.GetAwsAccessKeyId(),
+                                          env.GetAwsSecretAccessKey());
 
     // Concatenate log information into member variable connection_info_
     connection_info_ = fmt::format(
@@ -169,14 +132,14 @@ S3Helper::S3Helper(const std::string &endpoint, const std::string &bucket,
         bucket_.empty() ? "unset" : bucket_, config.connectTimeoutMs,
         config.requestTimeoutMs,
         config.scheme == Aws::Http::Scheme::HTTPS ? "HTTPS" : "HTTP",
-        !s3_env.access_key.empty() ? "set" : "unset",
-        !s3_env.secret_key.empty() ? "set" : "unset",
-        s3_env.use_virtual_addressing ? "true" : "false");
+        !env.GetAwsAccessKeyId().empty() ? "set" : "unset",
+        !env.GetAwsSecretAccessKey().empty() ? "set" : "unset",
+        env.GetAwsUseVirtualAddressing() ? "true" : "false");
 
     s3_client_ = Aws::S3::S3Client(
         credentials, config,
         Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never,
-        s3_env.use_virtual_addressing);
+        env.GetAwsUseVirtualAddressing());
 }
 
 S3Helper::~S3Helper() = default;


### PR DESCRIPTION
## Description

Externalize three S3 client knobs as environment variables so they can be tuned at runtime without rebuilding. Defaults preserve current behavior — existing users see
  no change.

  ## New environment variables
  
  | Env var | Values | Default | Purpose |
  |---|---|---|---|
  | `MOONCAKE_AWS_USE_HTTPS` | `true` / `false` | `true` | Switch between HTTPS and HTTP scheme |
  | `MOONCAKE_AWS_REQUEST_CHECKSUM_CALCULATION` | `when_supported` / `when_required` | `when_supported` | PUT request checksum behavior |
  | `MOONCAKE_AWS_RESPONSE_CHECKSUM_VALIDATION` | `when_supported` / `when_required` | `when_supported` | GET response checksum validation |
  
  ## Why
  
  - `MOONCAKE_AWS_USE_HTTPS` — the original code hardcoded HTTPS, breaking deployments to plaintext MinIO/Ceph.
  - The two checksum vars — AWS SDK 1.11+ added flexible checksum trailers that fail PUT against MinIO and other S3-compatible backends. Setting `when_required` restores
  pre-1.11 behavior.
  
  ## Backward compatibility
  
  All three defaults match the previous behavior:
  - scheme: HTTPS (was hardcoded)
  - checksums: `WHEN_SUPPORTED` (AWS SDK default, was implicit)

  Users on AWS-proper S3 see no change. Users on MinIO/Ceph can now opt into compatible behavior by setting the two checksum vars to `when_required`.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [x] Other

## How Has This Been Tested?



**Test commands:**
```bash
# Example: bash scripts/run_ci_test.sh
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [x] AI tools were used (specify below)