### PR TITLE
[Store] Skip bucket files with non-numeric names instead of aborting Init

### DIFF
--- a/mooncake-store/src/storage_backend.cpp
+++ b/mooncake-store/src/storage_backend.cpp
@@ -1577,7 +1577,16 @@ tl::expected<void, ErrorCode> BucketStorageBackend::Init() {
             if (entry.is_regular_file() &&
                 entry.path().extension() == BUCKET_METADATA_FILE_SUFFIX) {
                 const auto& bucket_id_str = entry.path().stem();
-                int64_t bucket_id = std::stoll(bucket_id_str);
+                int64_t bucket_id = 0;
+                try {
+                    bucket_id = std::stoll(bucket_id_str);
+                } catch (const std::exception& e) {
+                    LOG(WARNING)
+                        << "Skipping metadata file with a non-numeric "
+                           "bucket id: "
+                        << entry.path().string() << " (" << e.what() << ")";
+                    continue;
+                }
                 auto [metadata_it, success] = buckets_.try_emplace(
                     bucket_id, std::make_shared<BucketMetadata>());
                 if (success) lru_index_.emplace(0LL, bucket_id);
@@ -1688,7 +1697,16 @@ tl::expected<void, ErrorCode> BucketStorageBackend::Init() {
             // Extract bucket ID from filename (e.g., "12345.bucket" ->
             // "12345")
             auto bucket_id_str = entry.path().stem();
-            int64_t bucket_id = std::stoll(bucket_id_str);
+            int64_t bucket_id = 0;
+            try {
+                bucket_id = std::stoll(bucket_id_str);
+            } catch (const std::exception& e) {
+                LOG(WARNING)
+                    << "Skipping orphan-scan file with a non-numeric "
+                       "bucket id: "
+                    << entry.path().string() << " (" << e.what() << ")";
+                continue;
+            }
 
             // Check if this bucket has valid metadata
             if (valid_bucket_ids.find(bucket_id) != valid_bucket_ids.end()) {


### PR DESCRIPTION
## Summary

`BucketStorageBackend::Init()` parses each scanned filename's stem with `std::stoll(bucket_id_str)` at two sites (the `*.meta` load loop and the orphan-`*.bucket` cleanup loop), with no per-file guard. The whole method body is wrapped in a single `try { ... } catch (const std::exception&) { return INTERNAL_ERROR; }`, so one directory entry whose stem isn't a number — a stray temp/backup/renamed file that still carries the bucket extension (e.g. `backup.meta`, or a leftover `67890.tmp.bucket`) — makes `std::stoll` throw and aborts the **entire** store init. The backend then fails to start instead of skipping that single file.

This is the same failure mode fixed for env parsing in #2629 ("don't abort init on a malformed value"). `Init()` already skips buckets with invalid/missing metadata via `continue`; this extends the same tolerance to a non-numeric filename.

## Fix

Guard each `std::stoll` with try/catch; on failure, log a warning and `continue` to the next entry — matching the existing "skip and keep going" handling already used in both loops.

## Verification

The full store can't be built off-target, so I isolated the exact behavior in a standalone repro over a simulated scan set `{12345, 67890, backup, 67890.tmp}`:

```
stock_init (current behavior):
  ABORTED entire init: stoll -> store fails to start
fixed_init (with guard):
  [skip] non-numeric bucket id: backup (stoll)
  loaded 3 buckets (skipped the stray file)
```

`clang-format` applied; the diff is only the two guards. Full build + store unit tests run in CI.