### PR TITLE
[TENT] add strict-priority runtime queue dispatch and staging backpressure

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
@@ -95,8 +95,6 @@ class LocalTransferAdmissionQueue {
     std::vector<QueueOwnerId> pickForDispatch(size_t max_owners,
                                               size_t max_bytes, TimePoint now);
 
-    Status requeueForDispatch(QueueOwnerId owner_id);
-
     Status complete(QueueOwnerId owner_id, TransferStatusEnum terminal_status);
 
     Status retireBatch(uint64_t batch_token);
@@ -122,7 +120,7 @@ class LocalTransferAdmissionQueue {
         uint64_t batch_token{0};
         Request request{};
         QueueOwnerKind kind{QueueOwnerKind::User};
-        TimePoint enqueue_time{};
+        TimePoint queue_enter_time{};
         QueueState state{QueueState::Queued};
         TransferStatusEnum terminal_status{TransferStatusEnum::PENDING};
     };

--- a/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
@@ -31,8 +31,8 @@ namespace tent {
 
 using QueueOwnerId = uint64_t;
 
-// Owner kind is used only for admission accounting. It is not a dispatch
-// priority.
+// Owner kind separates user work from staging-internal work. Request priority
+// remains the primary dispatch ordering key.
 enum class QueueOwnerKind {
     User,
     StagingInternal,
@@ -110,17 +110,29 @@ class LocalTransferAdmissionQueue {
 
     class DispatchScheduler {
        public:
-        void enqueue(QueueOwnerId owner_id, int priority);
+        void enqueue(QueueOwnerId owner_id, int priority, QueueOwnerKind kind);
 
         std::vector<QueueOwnerId> pick(
             size_t max_owners, size_t max_bytes,
             const std::map<QueueOwnerId, QueueOwner>& owners);
 
        private:
+        enum class KindLane : size_t {
+            StagingInternal = 0,
+            User = 1,
+            Count = 2,
+        };
+
         static constexpr size_t kPriorityCount =
             static_cast<size_t>(PRIO_LOW) + 1;
 
-        std::array<std::deque<QueueOwnerId>, kPriorityCount> queues_;
+        using KindQueues = std::array<std::deque<QueueOwnerId>,
+                                      static_cast<size_t>(KindLane::Count)>;
+
+        static size_t kindLane(QueueOwnerKind kind);
+
+        std::array<KindQueues, kPriorityCount> queues_;
+        std::array<size_t, kPriorityCount> next_kind_lane_{};
     };
 
     QueueLimits limits_;

--- a/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
@@ -147,10 +147,41 @@ class LocalTransferAdmissionQueue {
         static constexpr size_t kPriorityCount =
             static_cast<size_t>(PRIO_LOW) + 1;
 
-        using KindQueues = std::array<std::deque<QueueOwnerId>,
-                                      static_cast<size_t>(KindLane::Count)>;
+        struct PickResult {
+            QueueOwnerId owner_id{0};
+            size_t byte_charge{0};
+            bool has_owner{false};
+            bool blocked_by_credit{false};
+            bool blocked_by_window{false};
+        };
+
+        struct LaneState {
+            std::deque<QueueOwnerId> queue;
+            size_t deficit_bytes{0};
+        };
+
+        using KindLanes =
+            std::array<LaneState, static_cast<size_t>(KindLane::Count)>;
+
+        struct PriorityClass {
+            KindLanes lanes;
+            size_t next_kind_lane{0};
+        };
 
         static size_t kindLane(QueueOwnerKind kind);
+
+        static size_t priorityWeight(size_t priority);
+
+        size_t quantumForPriority(size_t priority, size_t max_bytes) const;
+
+        void addDeficit(size_t priority, size_t lane, size_t max_bytes);
+
+        bool hasQueuedOwner(size_t priority,
+                            const std::map<QueueOwnerId, QueueOwner>& owners);
+
+        PickResult pickFromPriority(
+            size_t priority, size_t remaining_bytes,
+            const std::map<QueueOwnerId, QueueOwner>& owners);
 
         void promoteAgedOwners(
             TimePoint now, const std::map<QueueOwnerId, QueueOwner>& owners);
@@ -160,8 +191,8 @@ class LocalTransferAdmissionQueue {
             std::chrono::microseconds threshold, TimePoint now,
             const std::map<QueueOwnerId, QueueOwner>& owners);
 
-        std::array<KindQueues, kPriorityCount> queues_;
-        std::array<size_t, kPriorityCount> next_kind_lane_{};
+        std::array<PriorityClass, kPriorityCount> classes_;
+        size_t next_priority_{0};
         QueueAgingConfig aging_;
     };
 

--- a/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
@@ -16,6 +16,7 @@
 #define ADMISSION_QUEUE_H_
 
 #include <array>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <deque>
@@ -45,6 +46,12 @@ struct QueueLimits {
     size_t staging_byte_reserve{0};
 };
 
+struct QueueAgingConfig {
+    // Zero disables aging for the corresponding priority class.
+    std::chrono::microseconds medium_to_high{0};
+    std::chrono::microseconds low_to_high{0};
+};
+
 struct QueueOwnerInput {
     // Absolute task id within the caller's Batch, not relative to this submit.
     size_t owner_task_id{0};
@@ -64,7 +71,11 @@ struct QueueSubmit {
 // eventual TransferEngineImpl integration owns synchronization.
 class LocalTransferAdmissionQueue {
    public:
+    using Clock = std::chrono::steady_clock;
+    using TimePoint = Clock::time_point;
+
     explicit LocalTransferAdmissionQueue(QueueLimits limits);
+    LocalTransferAdmissionQueue(QueueLimits limits, QueueAgingConfig aging);
 
     LocalTransferAdmissionQueue(const LocalTransferAdmissionQueue&) = delete;
     LocalTransferAdmissionQueue& operator=(const LocalTransferAdmissionQueue&) =
@@ -75,9 +86,14 @@ class LocalTransferAdmissionQueue {
 
     Status tryAdmit(const QueueSubmit& submit,
                     std::vector<QueueOwnerId>& admitted_owner_ids);
+    Status tryAdmit(const QueueSubmit& submit,
+                    std::vector<QueueOwnerId>& admitted_owner_ids,
+                    TimePoint now);
 
     std::vector<QueueOwnerId> pickForDispatch(size_t max_owners,
                                               size_t max_bytes);
+    std::vector<QueueOwnerId> pickForDispatch(size_t max_owners,
+                                              size_t max_bytes, TimePoint now);
 
     Status complete(QueueOwnerId owner_id, TransferStatusEnum terminal_status);
 
@@ -104,17 +120,20 @@ class LocalTransferAdmissionQueue {
         uint64_t batch_token{0};
         Request request{};
         QueueOwnerKind kind{QueueOwnerKind::User};
+        TimePoint enqueue_time{};
         QueueState state{QueueState::Queued};
         TransferStatusEnum terminal_status{TransferStatusEnum::PENDING};
     };
 
     class DispatchScheduler {
        public:
-        void enqueue(QueueOwnerId owner_id, int priority, QueueOwnerKind kind);
+        explicit DispatchScheduler(QueueAgingConfig aging = {});
 
         std::vector<QueueOwnerId> pick(
             size_t max_owners, size_t max_bytes,
-            const std::map<QueueOwnerId, QueueOwner>& owners);
+            const std::map<QueueOwnerId, QueueOwner>& owners, TimePoint now);
+
+        void enqueue(QueueOwnerId owner_id, int priority, QueueOwnerKind kind);
 
        private:
         enum class KindLane : size_t {
@@ -131,8 +150,17 @@ class LocalTransferAdmissionQueue {
 
         static size_t kindLane(QueueOwnerKind kind);
 
+        void promoteAgedOwners(
+            TimePoint now, const std::map<QueueOwnerId, QueueOwner>& owners);
+
+        void promoteAgedPriority(
+            size_t from_priority, size_t to_priority,
+            std::chrono::microseconds threshold, TimePoint now,
+            const std::map<QueueOwnerId, QueueOwner>& owners);
+
         std::array<KindQueues, kPriorityCount> queues_;
         std::array<size_t, kPriorityCount> next_kind_lane_{};
+        QueueAgingConfig aging_;
     };
 
     QueueLimits limits_;

--- a/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
@@ -20,7 +20,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <deque>
-#include <map>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -127,13 +127,26 @@ class LocalTransferAdmissionQueue {
         TransferStatusEnum terminal_status{TransferStatusEnum::PENDING};
     };
 
+    using OwnerMap = std::unordered_map<QueueOwnerId, QueueOwner>;
+
+    struct PublicTaskOwner {
+        size_t task_id{0};
+        QueueOwnerId owner_id{0};
+    };
+
+    struct BatchIndex {
+        std::vector<QueueOwnerId> owner_ids;
+        std::vector<PublicTaskOwner> public_tasks;
+    };
+
+    static bool hasPublicTask(const BatchIndex& batch_index, size_t task_id);
+
     class DispatchScheduler {
        public:
         explicit DispatchScheduler(QueueAgingConfig aging = {});
 
-        std::vector<QueueOwnerId> pick(
-            size_t max_owners, size_t max_bytes,
-            const std::map<QueueOwnerId, QueueOwner>& owners, TimePoint now);
+        std::vector<QueueOwnerId> pick(size_t max_owners, size_t max_bytes,
+                                       const OwnerMap& owners, TimePoint now);
 
         void enqueue(QueueOwnerId owner_id, int priority, QueueOwnerKind kind);
 
@@ -176,20 +189,16 @@ class LocalTransferAdmissionQueue {
 
         void addDeficit(size_t priority, size_t lane, size_t max_bytes);
 
-        bool hasQueuedOwner(size_t priority,
-                            const std::map<QueueOwnerId, QueueOwner>& owners);
+        bool hasQueuedOwner(size_t priority, const OwnerMap& owners);
 
-        PickResult pickFromPriority(
-            size_t priority, size_t remaining_bytes,
-            const std::map<QueueOwnerId, QueueOwner>& owners);
+        PickResult pickFromPriority(size_t priority, size_t remaining_bytes,
+                                    const OwnerMap& owners);
 
-        void promoteAgedOwners(
-            TimePoint now, const std::map<QueueOwnerId, QueueOwner>& owners);
+        void promoteAgedOwners(TimePoint now, const OwnerMap& owners);
 
-        void promoteAgedPriority(
-            size_t from_priority, size_t to_priority,
-            std::chrono::microseconds threshold, TimePoint now,
-            const std::map<QueueOwnerId, QueueOwner>& owners);
+        void promoteAgedPriority(size_t from_priority, size_t to_priority,
+                                 std::chrono::microseconds threshold,
+                                 TimePoint now, const OwnerMap& owners);
 
         std::array<PriorityClass, kPriorityCount> classes_;
         size_t next_priority_{0};
@@ -200,8 +209,8 @@ class LocalTransferAdmissionQueue {
     Status limits_status_;
     DispatchScheduler scheduler_;
     QueueOwnerId next_owner_id_{1};
-    std::map<QueueOwnerId, QueueOwner> owners_;
-    std::map<std::pair<uint64_t, size_t>, QueueOwnerId> public_to_owner_;
+    OwnerMap owners_;
+    std::unordered_map<uint64_t, BatchIndex> batch_index_;
     size_t outstanding_owners_{0};
     size_t outstanding_bytes_{0};
     size_t outstanding_user_owners_{0};

--- a/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
@@ -95,6 +95,8 @@ class LocalTransferAdmissionQueue {
     std::vector<QueueOwnerId> pickForDispatch(size_t max_owners,
                                               size_t max_bytes, TimePoint now);
 
+    Status requeueForDispatch(QueueOwnerId owner_id);
+
     Status complete(QueueOwnerId owner_id, TransferStatusEnum terminal_status);
 
     Status retireBatch(uint64_t batch_token);

--- a/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
@@ -141,6 +141,9 @@ class LocalTransferAdmissionQueue {
 
     static bool hasPublicTask(const BatchIndex& batch_index, size_t task_id);
 
+    // Weighted byte-deficit scheduler over request priorities and owner-kind
+    // lanes. It can skip a blocked head in another lane to use the dispatch
+    // byte window, while preserving FIFO order inside one priority/kind lane.
     class DispatchScheduler {
        public:
         explicit DispatchScheduler(QueueAgingConfig aging = {});
@@ -163,7 +166,7 @@ class LocalTransferAdmissionQueue {
         struct PickResult {
             QueueOwnerId owner_id{0};
             size_t byte_charge{0};
-            bool has_owner{false};
+            bool found{false};
             bool blocked_by_credit{false};
             bool blocked_by_window{false};
         };
@@ -181,7 +184,7 @@ class LocalTransferAdmissionQueue {
             size_t next_kind_lane{0};
         };
 
-        static size_t kindLane(QueueOwnerKind kind);
+        static size_t laneForKind(QueueOwnerKind kind);
 
         static size_t priorityWeight(size_t priority);
 

--- a/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
@@ -15,6 +15,7 @@
 #ifndef ADMISSION_QUEUE_H_
 #define ADMISSION_QUEUE_H_
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <deque>
@@ -109,14 +110,17 @@ class LocalTransferAdmissionQueue {
 
     class DispatchScheduler {
        public:
-        void enqueue(QueueOwnerId owner_id);
+        void enqueue(QueueOwnerId owner_id, int priority);
 
         std::vector<QueueOwnerId> pick(
             size_t max_owners, size_t max_bytes,
             const std::map<QueueOwnerId, QueueOwner>& owners);
 
        private:
-        std::deque<QueueOwnerId> fifo_;
+        static constexpr size_t kPriorityCount =
+            static_cast<size_t>(PRIO_LOW) + 1;
+
+        std::array<std::deque<QueueOwnerId>, kPriorityCount> queues_;
     };
 
     QueueLimits limits_;

--- a/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
@@ -107,12 +107,24 @@ class LocalTransferAdmissionQueue {
         TransferStatusEnum terminal_status{TransferStatusEnum::PENDING};
     };
 
+    class DispatchScheduler {
+       public:
+        void enqueue(QueueOwnerId owner_id);
+
+        std::vector<QueueOwnerId> pick(
+            size_t max_owners, size_t max_bytes,
+            const std::map<QueueOwnerId, QueueOwner>& owners);
+
+       private:
+        std::deque<QueueOwnerId> fifo_;
+    };
+
     QueueLimits limits_;
     Status limits_status_;
+    DispatchScheduler scheduler_;
     QueueOwnerId next_owner_id_{1};
     std::map<QueueOwnerId, QueueOwner> owners_;
     std::map<std::pair<uint64_t, size_t>, QueueOwnerId> public_to_owner_;
-    std::deque<QueueOwnerId> fifo_;
     size_t outstanding_owners_{0};
     size_t outstanding_bytes_{0};
     size_t outstanding_user_owners_{0};

--- a/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
@@ -32,8 +32,8 @@ namespace tent {
 
 using QueueOwnerId = uint64_t;
 
-// Owner kind is used only for admission accounting. It is not a dispatch
-// priority.
+// Owner kind separates user work from staging-internal work. Request priority
+// remains the primary dispatch ordering key.
 enum class QueueOwnerKind {
     User,
     StagingInternal,
@@ -196,14 +196,14 @@ class LocalTransferAdmissionQueue {
         void consume(const Candidate& candidate);
 
        private:
-        static constexpr size_t kPriorityCount =
-            static_cast<size_t>(PRIO_LOW) + 1;
-
-        enum class KindLane {
+        enum class KindLane : size_t {
             StagingInternal = 0,
             User = 1,
             Count = 2,
         };
+
+        static constexpr size_t kPriorityCount =
+            static_cast<size_t>(PRIO_LOW) + 1;
 
         struct LaneState {
             std::deque<QueueOwnerId> queue;

--- a/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
@@ -15,6 +15,7 @@
 #ifndef ADMISSION_QUEUE_H_
 #define ADMISSION_QUEUE_H_
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <deque>
@@ -44,11 +45,11 @@ struct QueueLimits {
     size_t staging_owner_reserve{0};
     size_t staging_byte_reserve{0};
     // Opt-in deadline-aware dispatch (RFC #2519 step 2). When false (default),
-    // pickForDispatch keeps strict FIFO order — unchanged behavior. When true,
-    // owners carrying a deadline (request.deadline_ns != 0) are dispatched
-    // earliest-deadline-first; owners without a deadline keep FIFO order behind
-    // them. This only reorders selection within the existing capacity limits;
-    // it does not admit/reject or otherwise change what gets dispatched.
+    // pickForDispatch keeps strict FIFO order within each priority/kind lane.
+    // When true, owners carrying a deadline (request.deadline_ns != 0) are
+    // dispatched earliest-deadline-first within that lane; owners without a
+    // deadline keep FIFO order behind them. Request priority still determines
+    // dispatch order across lanes.
     bool deadline_aware{false};
     // Opt-in deadline-infeasible drop (RFC #2519 step 3). Local-decode MLU
     // threshold θ_local. 0 (default) disables drop entirely — behavior is the
@@ -172,12 +173,60 @@ class LocalTransferAdmissionQueue {
         TransferStatusEnum terminal_status{TransferStatusEnum::PENDING};
     };
 
+    using OwnerMap = std::map<QueueOwnerId, QueueOwner>;
+
+    class DispatchScheduler {
+       public:
+        struct Candidate {
+            QueueOwnerId owner_id{0};
+            size_t priority{0};
+            size_t lane{0};
+            bool found{false};
+        };
+
+        void enqueue(QueueOwnerId owner_id, int priority, QueueOwnerKind kind,
+                     bool deadline_aware, const OwnerMap& owners);
+
+        void promoteDeadlineUrgentOwners(uint64_t now_ns,
+                                         uint64_t promotion_slack_ns,
+                                         const OwnerMap& owners);
+
+        Candidate next(const OwnerMap& owners);
+
+        void consume(const Candidate& candidate);
+
+       private:
+        static constexpr size_t kPriorityCount =
+            static_cast<size_t>(PRIO_LOW) + 1;
+
+        enum class KindLane {
+            StagingInternal = 0,
+            User = 1,
+            Count = 2,
+        };
+
+        struct LaneState {
+            std::deque<QueueOwnerId> queue;
+        };
+
+        using KindLanes =
+            std::array<LaneState, static_cast<size_t>(KindLane::Count)>;
+
+        struct PriorityClass {
+            KindLanes lanes;
+            size_t next_kind_lane{0};
+        };
+
+        static size_t laneForKind(QueueOwnerKind kind);
+
+        std::array<PriorityClass, kPriorityCount> classes_;
+    };
     QueueLimits limits_;
     Status limits_status_;
+    DispatchScheduler scheduler_;
     QueueOwnerId next_owner_id_{1};
-    std::map<QueueOwnerId, QueueOwner> owners_;
+    OwnerMap owners_;
     std::map<std::pair<uint64_t, size_t>, QueueOwnerId> public_to_owner_;
-    std::deque<QueueOwnerId> fifo_;
     size_t outstanding_owners_{0};
     size_t outstanding_bytes_{0};
     size_t outstanding_user_owners_{0};

--- a/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
@@ -20,7 +20,7 @@
 #include <cstdint>
 #include <deque>
 #include <functional>
-#include <map>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -173,7 +173,19 @@ class LocalTransferAdmissionQueue {
         TransferStatusEnum terminal_status{TransferStatusEnum::PENDING};
     };
 
-    using OwnerMap = std::map<QueueOwnerId, QueueOwner>;
+    using OwnerMap = std::unordered_map<QueueOwnerId, QueueOwner>;
+
+    struct PublicTaskOwner {
+        size_t task_id{0};
+        QueueOwnerId owner_id{0};
+    };
+
+    struct BatchIndex {
+        std::vector<QueueOwnerId> owner_ids;
+        std::vector<PublicTaskOwner> public_tasks;
+    };
+
+    static bool hasPublicTask(const BatchIndex& batch_index, size_t task_id);
 
     class DispatchScheduler {
        public:
@@ -226,7 +238,7 @@ class LocalTransferAdmissionQueue {
     DispatchScheduler scheduler_;
     QueueOwnerId next_owner_id_{1};
     OwnerMap owners_;
-    std::map<std::pair<uint64_t, size_t>, QueueOwnerId> public_to_owner_;
+    std::unordered_map<uint64_t, BatchIndex> batch_index_;
     size_t outstanding_owners_{0};
     size_t outstanding_bytes_{0};
     size_t outstanding_user_owners_{0};

--- a/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
@@ -86,6 +86,9 @@ struct QueueSubmit {
     uint64_t batch_token{0};
     // Caller-computed remaining public task slots for this submit.
     size_t batch_slots_left{0};
+    // Public task ids in one submit form a contiguous range in
+    // Batch::task_list, although owner/derived ids need not be presented in
+    // that order.
     std::vector<QueueOwnerInput> owners;
 };
 
@@ -175,17 +178,13 @@ class LocalTransferAdmissionQueue {
 
     using OwnerMap = std::unordered_map<QueueOwnerId, QueueOwner>;
 
-    struct PublicTaskOwner {
-        size_t task_id{0};
-        QueueOwnerId owner_id{0};
-    };
-
     struct BatchIndex {
         std::vector<QueueOwnerId> owner_ids;
-        std::vector<PublicTaskOwner> public_tasks;
+        // Indexed by the absolute task id in Batch::task_list. Zero means the
+        // task is not managed by this runtime queue (for example, a direct
+        // submission made earlier in the same batch).
+        std::vector<QueueOwnerId> public_task_owners;
     };
-
-    static bool hasPublicTask(const BatchIndex& batch_index, size_t task_id);
 
     class DispatchScheduler {
        public:

--- a/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
@@ -84,8 +84,6 @@ struct QueueOwnerInput {
 
 struct QueueSubmit {
     uint64_t batch_token{0};
-    // Caller-computed remaining public task slots for this submit.
-    size_t batch_slots_left{0};
     // Public task ids in one submit form a contiguous range in
     // Batch::task_list, although owner/derived ids need not be presented in
     // that order.
@@ -202,7 +200,10 @@ class LocalTransferAdmissionQueue {
                                          uint64_t promotion_slack_ns,
                                          const OwnerMap& owners);
 
-        Candidate next(const OwnerMap& owners);
+        // Returns a fitting owner from the highest non-empty priority. When
+        // that priority has queued work but no lane head fits, found is true
+        // and owner_id is zero so callers do not fall through to lower work.
+        Candidate next(size_t remaining_bytes, const OwnerMap& owners);
 
         void consume(const Candidate& candidate);
 

--- a/mooncake-transfer-engine/tent/include/tent/runtime/proxy_manager.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/proxy_manager.h
@@ -16,6 +16,7 @@
 #define PROXY_MANAGER_H_
 
 #include <memory>
+#include <mutex>
 
 #include "tent/common/types.h"
 #include "tent/common/status.h"
@@ -96,7 +97,7 @@ class ProxyManager {
 
     Status transferSync(StagingTask& task, StageBufferCache* cache);
 
-    Status allocateStageBuffers(const std::string& location);
+    Status allocateStageBuffersLocked(const std::string& location);
 
     Status freeStageBuffers(const std::string& location);
 
@@ -129,6 +130,7 @@ class ProxyManager {
     static constexpr size_t kChunkCount = 64;
     const size_t max_queued_tasks_per_shard_;
     TransferEngineImpl* impl_;
+    std::mutex stage_buffers_mu_;
     std::unordered_map<std::string, StageBuffers> stage_buffers_;
     std::atomic<bool> running_;
     struct WorkerShard {

--- a/mooncake-transfer-engine/tent/include/tent/runtime/proxy_manager.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/proxy_manager.h
@@ -39,7 +39,7 @@ struct StagingTask {
 
 class ProxyManager {
    public:
-    static constexpr size_t kDefaultMaxQueuedTasksPerShard = 1024;
+    static constexpr size_t kDefaultMaxQueuedTasksPerShard = 0;
 
    private:
     struct StageBuffers {
@@ -54,7 +54,7 @@ class ProxyManager {
         TransferEngineImpl* impl,
         size_t max_queued_tasks_per_shard = kDefaultMaxQueuedTasksPerShard);
 
-    static std::unique_ptr<ProxyManager> createWithoutWorkersForTest(
+    static std::unique_ptr<ProxyManager> createForTest(
         TransferEngineImpl* impl,
         size_t max_queued_tasks_per_shard = kDefaultMaxQueuedTasksPerShard);
 

--- a/mooncake-transfer-engine/tent/include/tent/runtime/proxy_manager.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/proxy_manager.h
@@ -61,6 +61,21 @@ class ProxyManager {
 
     Status unpinStageBuffer(uint64_t addr);
 
+    static Request makeCrossStageRequest(const Request& request,
+                                         uint64_t local_stage_buffer,
+                                         uint64_t remote_stage_buffer,
+                                         uint64_t chunk_length);
+
+    static Request makeLocalStageRequest(const Request& request,
+                                         uint64_t local_stage_buffer,
+                                         uint64_t chunk_length,
+                                         uint64_t offset);
+
+    static Request makeRemoteStageRequest(const Request& request,
+                                          uint64_t remote_stage_buffer,
+                                          uint64_t chunk_length,
+                                          uint64_t offset);
+
    private:
     void runner(size_t id);
 

--- a/mooncake-transfer-engine/tent/include/tent/runtime/proxy_manager.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/proxy_manager.h
@@ -15,6 +15,8 @@
 #ifndef PROXY_MANAGER_H_
 #define PROXY_MANAGER_H_
 
+#include <memory>
+
 #include "tent/common/types.h"
 #include "tent/common/status.h"
 #include "tent/common/concurrent/thread_pool.h"
@@ -36,6 +38,10 @@ struct StagingTask {
 };
 
 class ProxyManager {
+   public:
+    static constexpr size_t kDefaultMaxQueuedTasksPerShard = 1024;
+
+   private:
     struct StageBuffers {
         void* chunks;
         std::atomic_flag* bitmap;
@@ -44,9 +50,13 @@ class ProxyManager {
     };
 
    public:
-    explicit ProxyManager(TransferEngineImpl* impl,
-                          size_t chunk_size = 4 * 1024 * 1024,
-                          size_t chunk_count = 64);
+    explicit ProxyManager(
+        TransferEngineImpl* impl,
+        size_t max_queued_tasks_per_shard = kDefaultMaxQueuedTasksPerShard);
+
+    static std::unique_ptr<ProxyManager> createWithoutWorkersForTest(
+        TransferEngineImpl* impl,
+        size_t max_queued_tasks_per_shard = kDefaultMaxQueuedTasksPerShard);
 
     ~ProxyManager();
 
@@ -77,6 +87,9 @@ class ProxyManager {
                                           uint64_t offset);
 
    private:
+    ProxyManager(TransferEngineImpl* impl, size_t max_queued_tasks_per_shard,
+                 bool start_workers);
+
     void runner(size_t id);
 
     Status transferEventLoop(StagingTask& task, StageBufferCache* cache);
@@ -112,8 +125,9 @@ class ProxyManager {
                            std::future<Status>& handle);
 
    private:
-    const size_t chunk_size_;
-    const size_t chunk_count_;
+    static constexpr size_t kChunkSize = 4 * 1024 * 1024;
+    static constexpr size_t kChunkCount = 64;
+    const size_t max_queued_tasks_per_shard_;
     TransferEngineImpl* impl_;
     std::unordered_map<std::string, StageBuffers> stage_buffers_;
     std::atomic<bool> running_;
@@ -122,6 +136,7 @@ class ProxyManager {
         std::mutex mu;
         std::condition_variable cv;
         std::queue<StagingTask> queue;
+        size_t queued_tasks{0};
     };
     const static size_t kShards = 8;
     WorkerShard shards_[kShards];

--- a/mooncake-transfer-engine/tent/include/tent/runtime/proxy_manager.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/proxy_manager.h
@@ -42,6 +42,12 @@ struct StagingTask {
 };
 
 class ProxyManager {
+   public:
+    static constexpr size_t kDefaultChunkSize = 4 * 1024 * 1024;
+    static constexpr size_t kDefaultChunkCount = 64;
+    static constexpr size_t kDefaultMaxQueuedTasksPerShard = 1024;
+
+   private:
     struct StageBuffers {
         void* chunks;
         std::atomic_flag* bitmap;
@@ -50,9 +56,14 @@ class ProxyManager {
     };
 
    public:
-    explicit ProxyManager(TransferEngineImpl* impl,
-                          size_t chunk_size = 4 * 1024 * 1024,
-                          size_t chunk_count = 64);
+    explicit ProxyManager(
+        TransferEngineImpl* impl, size_t chunk_size = kDefaultChunkSize,
+        size_t chunk_count = kDefaultChunkCount,
+        size_t max_queued_tasks_per_shard = kDefaultMaxQueuedTasksPerShard);
+
+    static std::unique_ptr<ProxyManager> createWithoutWorkersForTest(
+        TransferEngineImpl* impl,
+        size_t max_queued_tasks_per_shard = kDefaultMaxQueuedTasksPerShard);
 
     ~ProxyManager();
 
@@ -83,6 +94,10 @@ class ProxyManager {
                                           uint64_t offset);
 
    private:
+    ProxyManager(TransferEngineImpl* impl, size_t chunk_size,
+                 size_t chunk_count, size_t max_queued_tasks_per_shard,
+                 bool start_workers);
+
     void runner(size_t id);
 
     Status transferEventLoop(
@@ -134,6 +149,7 @@ class ProxyManager {
 
     const size_t chunk_size_;
     const size_t chunk_count_;
+    const size_t max_queued_tasks_per_shard_;
     TransferEngineImpl* impl_;
     // How long deconstruct() waits for in-flight staging batches to reach a
     // terminal state before handing the survivors to the engine for deferred
@@ -156,6 +172,7 @@ class ProxyManager {
         std::mutex mu;
         std::condition_variable cv;
         std::queue<StagingTask> queue;
+        size_t queued_tasks{0};
     };
     const static size_t kShards = 8;
     WorkerShard shards_[kShards];

--- a/mooncake-transfer-engine/tent/include/tent/runtime/proxy_manager.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/proxy_manager.h
@@ -67,6 +67,21 @@ class ProxyManager {
 
     Status unpinStageBuffer(uint64_t addr);
 
+    static Request makeCrossStageRequest(const Request& request,
+                                         uint64_t local_stage_buffer,
+                                         uint64_t remote_stage_buffer,
+                                         uint64_t chunk_length);
+
+    static Request makeLocalStageRequest(const Request& request,
+                                         uint64_t local_stage_buffer,
+                                         uint64_t chunk_length,
+                                         uint64_t offset);
+
+    static Request makeRemoteStageRequest(const Request& request,
+                                          uint64_t remote_stage_buffer,
+                                          uint64_t chunk_length,
+                                          uint64_t offset);
+
    private:
     void runner(size_t id);
 

--- a/mooncake-transfer-engine/tent/include/tent/runtime/proxy_manager.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/proxy_manager.h
@@ -45,7 +45,9 @@ class ProxyManager {
    public:
     static constexpr size_t kDefaultChunkSize = 4 * 1024 * 1024;
     static constexpr size_t kDefaultChunkCount = 64;
-    static constexpr size_t kDefaultMaxQueuedTasksPerShard = 1024;
+    // Zero preserves the legacy unbounded shard queue. Production callers may
+    // opt into backpressure through staging/max_queued_tasks_per_shard.
+    static constexpr size_t kDefaultMaxQueuedTasksPerShard = 0;
 
    private:
     struct StageBuffers {
@@ -61,7 +63,7 @@ class ProxyManager {
         size_t chunk_count = kDefaultChunkCount,
         size_t max_queued_tasks_per_shard = kDefaultMaxQueuedTasksPerShard);
 
-    static std::unique_ptr<ProxyManager> createWithoutWorkersForTest(
+    static std::unique_ptr<ProxyManager> createForTest(
         TransferEngineImpl* impl,
         size_t max_queued_tasks_per_shard = kDefaultMaxQueuedTasksPerShard);
 

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -337,6 +337,8 @@ class TransferEngineImpl {
     bool enable_auto_failover_on_poll_{true};
     bool enable_progress_worker_{false};
     RuntimeQueueConfig runtime_queue_config_;
+    // Zero leaves the legacy unbounded accept behavior enabled.
+    size_t staging_max_queued_tasks_per_shard_{1024};
     std::unique_ptr<LocalTransferAdmissionQueue> runtime_queue_;
     std::unordered_map<QueueOwnerId, QueuedOwnerState> queued_owners_;
     size_t dispatch_inflight_owners_{0};

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -161,6 +161,8 @@ class TransferEngineImpl {
 
     uint64_t lockStageBuffer(const std::string& location);
 
+    Status pinStageBuffer(const std::string& location, uint64_t& addr);
+
     Status unlockStageBuffer(uint64_t addr);
 
     // Test-only hook: replace the transport in a given slot after construct().

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -294,6 +294,7 @@ class TransferEngineImpl {
     struct RuntimeQueueConfig {
         bool enabled{false};
         QueueLimits limits{};
+        QueueAgingConfig aging{};
         size_t max_dispatch_owners{0};
         size_t max_dispatch_bytes{0};
         std::chrono::microseconds progress_fallback_interval{50000};

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -338,7 +338,7 @@ class TransferEngineImpl {
     bool enable_progress_worker_{false};
     RuntimeQueueConfig runtime_queue_config_;
     // Zero leaves the legacy unbounded accept behavior enabled.
-    size_t staging_max_queued_tasks_per_shard_{1024};
+    size_t staging_max_queued_tasks_per_shard_{0};
     std::unique_ptr<LocalTransferAdmissionQueue> runtime_queue_;
     std::unordered_map<QueueOwnerId, QueuedOwnerState> queued_owners_;
     size_t dispatch_inflight_owners_{0};

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -503,7 +503,7 @@ class TransferEngineImpl {
         QueueLimits limits{};
         size_t max_dispatch_owners{0};
         size_t max_dispatch_bytes{0};
-        std::chrono::microseconds progress_fallback_interval{50000};
+        std::chrono::microseconds progress_fallback_interval{5000};
     };
 
     struct QueuedOwnerState {

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -309,6 +309,8 @@ class TransferEngineImpl {
 
     uint64_t lockStageBuffer(const std::string& location);
 
+    Status pinStageBuffer(const std::string& location, uint64_t& addr);
+
     Status unlockStageBuffer(uint64_t addr);
 
     // Test-only hook: replace the transport in a given slot after construct().

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -541,7 +541,7 @@ class TransferEngineImpl {
     bool enable_progress_worker_{false};
     RuntimeQueueConfig runtime_queue_config_;
     // Zero leaves the legacy unbounded accept behavior enabled.
-    size_t staging_max_queued_tasks_per_shard_{1024};
+    size_t staging_max_queued_tasks_per_shard_{0};
     std::unique_ptr<LocalTransferAdmissionQueue> runtime_queue_;
     std::unordered_map<QueueOwnerId, QueuedOwnerState> queued_owners_;
     size_t dispatch_inflight_owners_{0};

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -540,6 +540,8 @@ class TransferEngineImpl {
     bool enable_auto_failover_on_poll_{true};
     bool enable_progress_worker_{false};
     RuntimeQueueConfig runtime_queue_config_;
+    // Zero leaves the legacy unbounded accept behavior enabled.
+    size_t staging_max_queued_tasks_per_shard_{1024};
     std::unique_ptr<LocalTransferAdmissionQueue> runtime_queue_;
     std::unordered_map<QueueOwnerId, QueuedOwnerState> queued_owners_;
     size_t dispatch_inflight_owners_{0};

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/slice.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/slice.h
@@ -18,6 +18,7 @@
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <iostream>
 #include <list>
 #include <memory>
@@ -64,6 +65,8 @@ struct RdmaTask {
     std::atomic<int> success_slices{0};
     std::atomic<int> resolved_slices{0};
     volatile TransferStatusEnum first_error = PENDING;
+    BatchID progress_batch_id{0};
+    std::function<void(BatchID)> notify_progress;
 
     // Set by the control thread. Workers observe this flag before posting or
     // retrying a slice. Already-posted WRs are allowed to drain normally.
@@ -71,6 +74,10 @@ struct RdmaTask {
 
     // Reference counting for UAF protection
     std::atomic<int> ref_count{0};
+
+    void notifyProgress() {
+        if (notify_progress) notify_progress(progress_batch_id);
+    }
 
     void ref() { ref_count.fetch_add(1, std::memory_order_relaxed); }
     void deref() {
@@ -161,7 +168,10 @@ static inline void updateSliceStatus(RdmaSlice* slice,
                 ? COMPLETED
                 : task->first_error;
         if (final_st == PENDING) final_st = FAILED;
-        __sync_bool_compare_and_swap(&task->status_word, PENDING, final_st);
+        if (__sync_bool_compare_and_swap(&task->status_word, PENDING,
+                                         final_st)) {
+            task->notifyProgress();
+        }
     }
     task->deref();
 }

--- a/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
@@ -14,6 +14,7 @@
 
 #include "tent/runtime/admission_queue.h"
 
+#include <algorithm>
 #include <limits>
 #include <set>
 
@@ -90,7 +91,113 @@ size_t LocalTransferAdmissionQueue::DispatchScheduler::kindLane(
 
 void LocalTransferAdmissionQueue::DispatchScheduler::enqueue(
     QueueOwnerId owner_id, int priority, QueueOwnerKind kind) {
-    queues_[static_cast<size_t>(priority)][kindLane(kind)].push_back(owner_id);
+    classes_[static_cast<size_t>(priority)]
+        .lanes[kindLane(kind)]
+        .queue.push_back(owner_id);
+}
+
+size_t LocalTransferAdmissionQueue::DispatchScheduler::priorityWeight(
+    size_t priority) {
+    switch (priority) {
+        case PRIO_HIGH:
+            return 4;
+        case PRIO_MEDIUM:
+            return 2;
+        case PRIO_LOW:
+            return 1;
+        default:
+            return 1;
+    }
+}
+
+size_t LocalTransferAdmissionQueue::DispatchScheduler::quantumForPriority(
+    size_t priority, size_t max_bytes) const {
+    const size_t base_quantum =
+        std::max<size_t>(max_bytes / 8 + (max_bytes % 8 != 0), 1);
+    const size_t weight = priorityWeight(priority);
+    if (base_quantum > std::numeric_limits<size_t>::max() / weight) {
+        return std::numeric_limits<size_t>::max();
+    }
+    return base_quantum * weight;
+}
+
+void LocalTransferAdmissionQueue::DispatchScheduler::addDeficit(
+    size_t priority, size_t lane, size_t max_bytes) {
+    auto& lane_state = classes_[priority].lanes[lane];
+    const size_t quantum = quantumForPriority(priority, max_bytes);
+    if (lane_state.deficit_bytes >= max_bytes ||
+        quantum > max_bytes - lane_state.deficit_bytes) {
+        lane_state.deficit_bytes = max_bytes;
+        return;
+    }
+    lane_state.deficit_bytes += quantum;
+}
+
+bool LocalTransferAdmissionQueue::DispatchScheduler::hasQueuedOwner(
+    size_t priority, const std::map<QueueOwnerId, QueueOwner>& owners) {
+    auto& priority_class = classes_[priority];
+    bool has_owner = false;
+    for (auto& lane : priority_class.lanes) {
+        while (!lane.queue.empty()) {
+            const auto owner_id = lane.queue.front();
+            auto owner_it = owners.find(owner_id);
+            if (owner_it != owners.end() &&
+                owner_it->second.state == QueueState::Queued) {
+                has_owner = true;
+                break;
+            }
+            lane.queue.pop_front();
+        }
+        if (lane.queue.empty()) {
+            lane.deficit_bytes = 0;
+        }
+    }
+    return has_owner;
+}
+
+LocalTransferAdmissionQueue::DispatchScheduler::PickResult
+LocalTransferAdmissionQueue::DispatchScheduler::pickFromPriority(
+    size_t priority, size_t remaining_bytes,
+    const std::map<QueueOwnerId, QueueOwner>& owners) {
+    auto& priority_class = classes_[priority];
+    PickResult blocked;
+    for (size_t offset = 0; offset < priority_class.lanes.size(); ++offset) {
+        const size_t lane = (priority_class.next_kind_lane + offset) %
+                            priority_class.lanes.size();
+        auto& lane_state = priority_class.lanes[lane];
+
+        while (!lane_state.queue.empty()) {
+            const auto owner_id = lane_state.queue.front();
+            auto owner_it = owners.find(owner_id);
+            if (owner_it == owners.end() ||
+                owner_it->second.state != QueueState::Queued) {
+                lane_state.queue.pop_front();
+                continue;
+            }
+
+            const size_t byte_charge = owner_it->second.request.length;
+            blocked.has_owner = true;
+            if (byte_charge > remaining_bytes) {
+                blocked.blocked_by_window = true;
+                break;
+            }
+            if (byte_charge > lane_state.deficit_bytes) {
+                blocked.blocked_by_credit = true;
+                break;
+            }
+
+            lane_state.queue.pop_front();
+            priority_class.next_kind_lane =
+                (lane + 1) % priority_class.lanes.size();
+            lane_state.deficit_bytes -= byte_charge;
+            if (lane_state.queue.empty()) {
+                lane_state.deficit_bytes = 0;
+            }
+            return PickResult{owner_id, byte_charge, true, false, false};
+        }
+    }
+
+    return blocked;
 }
 
 void LocalTransferAdmissionQueue::DispatchScheduler::promoteAgedOwners(
@@ -105,14 +212,16 @@ void LocalTransferAdmissionQueue::DispatchScheduler::promoteAgedPriority(
     std::chrono::microseconds threshold, TimePoint now,
     const std::map<QueueOwnerId, QueueOwner>& owners) {
     if (threshold <= std::chrono::microseconds::zero()) return;
-    if (from_priority == PRIO_HIGH || from_priority >= queues_.size() ||
-        to_priority >= queues_.size()) {
+    if (from_priority == PRIO_HIGH || from_priority >= classes_.size() ||
+        to_priority >= classes_.size()) {
         return;
     }
 
-    for (size_t lane = 0; lane < queues_[from_priority].size(); ++lane) {
-        auto& queue = queues_[from_priority][lane];
-        auto& promoted_queue = queues_[to_priority][lane];
+    for (size_t lane = 0; lane < classes_[from_priority].lanes.size(); ++lane) {
+        auto& source_lane = classes_[from_priority].lanes[lane];
+        auto& target_lane = classes_[to_priority].lanes[lane];
+        auto& queue = source_lane.queue;
+        auto& promoted_queue = target_lane.queue;
         while (!queue.empty()) {
             const auto owner_id = queue.front();
             auto owner_it = owners.find(owner_id);
@@ -139,7 +248,13 @@ void LocalTransferAdmissionQueue::DispatchScheduler::promoteAgedPriority(
                 }
             }
             queue.pop_front();
+            if (promoted_queue.empty()) {
+                target_lane.deficit_bytes = 0;
+            }
             promoted_queue.insert(insert_it, owner_id);
+        }
+        if (queue.empty()) {
+            source_lane.deficit_bytes = 0;
         }
     }
 }
@@ -154,41 +269,41 @@ std::vector<QueueOwnerId> LocalTransferAdmissionQueue::DispatchScheduler::pick(
 
     size_t used_owners = 0;
     size_t used_bytes = 0;
-    for (size_t priority = 0; priority < queues_.size(); ++priority) {
-        auto& priority_queues = queues_[priority];
-        while (used_owners < max_owners && used_bytes < max_bytes) {
-            bool made_progress = false;
-            for (size_t offset = 0; offset < priority_queues.size(); ++offset) {
-                const size_t lane = (next_kind_lane_[priority] + offset) %
-                                    priority_queues.size();
-                auto& queue = priority_queues[lane];
+    while (used_owners < max_owners && used_bytes < max_bytes) {
+        bool made_progress = false;
+        bool blocked_by_credit = false;
+        bool blocked_by_window = false;
+        const size_t start_priority = next_priority_;
+        for (size_t offset = 0; offset < classes_.size(); ++offset) {
+            const size_t priority = (start_priority + offset) % classes_.size();
+            if (!hasQueuedOwner(priority, owners)) continue;
 
-                while (!queue.empty()) {
-                    const auto owner_id = queue.front();
-                    auto owner_it = owners.find(owner_id);
-                    if (owner_it == owners.end() ||
-                        owner_it->second.state != QueueState::Queued) {
-                        queue.pop_front();
-                        continue;
-                    }
-
-                    const size_t remaining_bytes = max_bytes - used_bytes;
-                    if (owner_it->second.request.length > remaining_bytes)
-                        break;
-
-                    queue.pop_front();
-                    picked.push_back(owner_id);
-                    ++used_owners;
-                    used_bytes += owner_it->second.request.length;
-                    next_kind_lane_[priority] =
-                        (lane + 1) % priority_queues.size();
-                    made_progress = true;
-                    break;
+            auto& priority_class = classes_[priority];
+            for (size_t lane = 0; lane < priority_class.lanes.size(); ++lane) {
+                if (!priority_class.lanes[lane].queue.empty()) {
+                    addDeficit(priority, lane, max_bytes);
                 }
-                if (made_progress || used_owners >= max_owners) break;
             }
-            if (!made_progress) break;
+            while (used_owners < max_owners && used_bytes < max_bytes) {
+                auto result =
+                    pickFromPriority(priority, max_bytes - used_bytes, owners);
+                if (!result.has_owner) break;
+                blocked_by_credit =
+                    blocked_by_credit || result.blocked_by_credit;
+                blocked_by_window =
+                    blocked_by_window || result.blocked_by_window;
+                if (result.owner_id == 0) break;
+
+                picked.push_back(result.owner_id);
+                ++used_owners;
+                used_bytes += result.byte_charge;
+                next_priority_ = (priority + 1) % classes_.size();
+                made_progress = true;
+            }
+            if (used_owners >= max_owners || used_bytes >= max_bytes) break;
         }
+        if (!made_progress && !blocked_by_credit) break;
+        if (!made_progress && blocked_by_window && !blocked_by_credit) break;
     }
     return picked;
 }

--- a/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
@@ -73,9 +73,20 @@ Status validateLimits(const QueueLimits& limits) {
 
 }  // namespace
 
+size_t LocalTransferAdmissionQueue::DispatchScheduler::kindLane(
+    QueueOwnerKind kind) {
+    switch (kind) {
+        case QueueOwnerKind::StagingInternal:
+            return static_cast<size_t>(KindLane::StagingInternal);
+        case QueueOwnerKind::User:
+            return static_cast<size_t>(KindLane::User);
+    }
+    return static_cast<size_t>(KindLane::User);
+}
+
 void LocalTransferAdmissionQueue::DispatchScheduler::enqueue(
-    QueueOwnerId owner_id, int priority) {
-    queues_[priority].push_back(owner_id);
+    QueueOwnerId owner_id, int priority, QueueOwnerKind kind) {
+    queues_[static_cast<size_t>(priority)][kindLane(kind)].push_back(owner_id);
 }
 
 std::vector<QueueOwnerId> LocalTransferAdmissionQueue::DispatchScheduler::pick(
@@ -86,24 +97,40 @@ std::vector<QueueOwnerId> LocalTransferAdmissionQueue::DispatchScheduler::pick(
 
     size_t used_owners = 0;
     size_t used_bytes = 0;
-    for (auto& queue : queues_) {
-        while (!queue.empty() && used_owners < max_owners) {
-            const auto owner_id = queue.front();
-            auto owner_it = owners.find(owner_id);
-            if (owner_it == owners.end() ||
-                owner_it->second.state != QueueState::Queued) {
-                queue.pop_front();
-                continue;
+    for (size_t priority = 0; priority < queues_.size(); ++priority) {
+        auto& priority_queues = queues_[priority];
+        while (used_owners < max_owners) {
+            bool made_progress = false;
+            for (size_t offset = 0; offset < priority_queues.size(); ++offset) {
+                const size_t lane = (next_kind_lane_[priority] + offset) %
+                                    priority_queues.size();
+                auto& queue = priority_queues[lane];
+
+                while (!queue.empty()) {
+                    const auto owner_id = queue.front();
+                    auto owner_it = owners.find(owner_id);
+                    if (owner_it == owners.end() ||
+                        owner_it->second.state != QueueState::Queued) {
+                        queue.pop_front();
+                        continue;
+                    }
+
+                    const size_t remaining_bytes = max_bytes - used_bytes;
+                    if (owner_it->second.request.length > remaining_bytes)
+                        return picked;
+
+                    queue.pop_front();
+                    picked.push_back(owner_id);
+                    ++used_owners;
+                    used_bytes += owner_it->second.request.length;
+                    next_kind_lane_[priority] =
+                        (lane + 1) % priority_queues.size();
+                    made_progress = true;
+                    break;
+                }
+                if (made_progress || used_owners >= max_owners) break;
             }
-
-            const size_t remaining_bytes = max_bytes - used_bytes;
-            if (owner_it->second.request.length > remaining_bytes)
-                return picked;
-
-            queue.pop_front();
-            picked.push_back(owner_id);
-            ++used_owners;
-            used_bytes += owner_it->second.request.length;
+            if (!made_progress) break;
         }
     }
     return picked;
@@ -224,7 +251,8 @@ Status LocalTransferAdmissionQueue::tryAdmit(
         for (const auto derived_task_id : owner_input.derived_task_ids) {
             public_to_owner_[{submit.batch_token, derived_task_id}] = owner_id;
         }
-        scheduler_.enqueue(owner_id, owner_input.request.priority);
+        scheduler_.enqueue(owner_id, owner_input.request.priority,
+                           owner_input.kind);
         admitted_owner_ids.push_back(owner_id);
     }
 

--- a/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
@@ -94,7 +94,7 @@ LocalTransferAdmissionQueue::DispatchScheduler::DispatchScheduler(
     QueueAgingConfig aging)
     : aging_(aging) {}
 
-size_t LocalTransferAdmissionQueue::DispatchScheduler::kindLane(
+size_t LocalTransferAdmissionQueue::DispatchScheduler::laneForKind(
     QueueOwnerKind kind) {
     switch (kind) {
         case QueueOwnerKind::StagingInternal:
@@ -108,7 +108,7 @@ size_t LocalTransferAdmissionQueue::DispatchScheduler::kindLane(
 void LocalTransferAdmissionQueue::DispatchScheduler::enqueue(
     QueueOwnerId owner_id, int priority, QueueOwnerKind kind) {
     classes_[static_cast<size_t>(priority)]
-        .lanes[kindLane(kind)]
+        .lanes[laneForKind(kind)]
         .queue.push_back(owner_id);
 }
 
@@ -191,7 +191,7 @@ LocalTransferAdmissionQueue::DispatchScheduler::pickFromPriority(
             }
 
             const size_t byte_charge = owner_it->second.request.length;
-            blocked.has_owner = true;
+            blocked.found = true;
             if (byte_charge > remaining_bytes) {
                 blocked.blocked_by_window = true;
                 break;
@@ -302,7 +302,7 @@ std::vector<QueueOwnerId> LocalTransferAdmissionQueue::DispatchScheduler::pick(
             while (used_owners < max_owners && used_bytes < max_bytes) {
                 auto result =
                     pickFromPriority(priority, max_bytes - used_bytes, owners);
-                if (!result.has_owner) break;
+                if (!result.found) break;
                 blocked_by_credit =
                     blocked_by_credit || result.blocked_by_credit;
                 blocked_by_window =
@@ -523,6 +523,7 @@ Status LocalTransferAdmissionQueue::requeueForDispatch(QueueOwnerId owner_id) {
     }
 
     owner.state = QueueState::Queued;
+    owner.enqueue_time = Clock::now();
     scheduler_.enqueue(owner_id, owner.request.priority, owner.kind);
     return Status::OK();
 }

--- a/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
@@ -246,7 +246,7 @@ void LocalTransferAdmissionQueue::DispatchScheduler::promoteAgedPriority(
                 continue;
             }
 
-            if (now - owner_it->second.enqueue_time < threshold) break;
+            if (now - owner_it->second.queue_enter_time < threshold) break;
 
             auto insert_it = promoted_queue.end();
             for (auto it = promoted_queue.begin(); it != promoted_queue.end();
@@ -256,8 +256,8 @@ void LocalTransferAdmissionQueue::DispatchScheduler::promoteAgedPriority(
                     promoted_it->second.state != QueueState::Queued) {
                     continue;
                 }
-                if (owner_it->second.enqueue_time <
-                    promoted_it->second.enqueue_time) {
+                if (owner_it->second.queue_enter_time <
+                    promoted_it->second.queue_enter_time) {
                     insert_it = it;
                     break;
                 }
@@ -468,7 +468,7 @@ Status LocalTransferAdmissionQueue::tryAdmit(
         owner.batch_token = submit.batch_token;
         owner.request = owner_input.request;
         owner.kind = owner_input.kind;
-        owner.enqueue_time = now;
+        owner.queue_enter_time = now;
         owners_.emplace(owner_id, owner);
         batch_index.owner_ids.push_back(owner_id);
         owner_ids.push_back(owner_id);
@@ -507,25 +507,6 @@ std::vector<QueueOwnerId> LocalTransferAdmissionQueue::pickForDispatch(
         owners_.find(owner_id)->second.state = QueueState::Dispatching;
     }
     return picked;
-}
-
-Status LocalTransferAdmissionQueue::requeueForDispatch(QueueOwnerId owner_id) {
-    if (owner_id == 0) {
-        return Status::InvalidArgument("invalid queue owner id" LOC_MARK);
-    }
-    auto owner_it = owners_.find(owner_id);
-    if (owner_it == owners_.end()) {
-        return Status::InvalidEntry("queue owner not found" LOC_MARK);
-    }
-    auto& owner = owner_it->second;
-    if (owner.state != QueueState::Dispatching) {
-        return Status::InvalidEntry("queue owner is not dispatching" LOC_MARK);
-    }
-
-    owner.state = QueueState::Queued;
-    owner.enqueue_time = Clock::now();
-    scheduler_.enqueue(owner_id, owner.request.priority, owner.kind);
-    return Status::OK();
 }
 
 Status LocalTransferAdmissionQueue::complete(

--- a/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
@@ -73,6 +73,10 @@ Status validateLimits(const QueueLimits& limits) {
 
 }  // namespace
 
+LocalTransferAdmissionQueue::DispatchScheduler::DispatchScheduler(
+    QueueAgingConfig aging)
+    : aging_(aging) {}
+
 size_t LocalTransferAdmissionQueue::DispatchScheduler::kindLane(
     QueueOwnerKind kind) {
     switch (kind) {
@@ -89,17 +93,70 @@ void LocalTransferAdmissionQueue::DispatchScheduler::enqueue(
     queues_[static_cast<size_t>(priority)][kindLane(kind)].push_back(owner_id);
 }
 
+void LocalTransferAdmissionQueue::DispatchScheduler::promoteAgedOwners(
+    TimePoint now, const std::map<QueueOwnerId, QueueOwner>& owners) {
+    promoteAgedPriority(PRIO_MEDIUM, PRIO_HIGH, aging_.medium_to_high, now,
+                        owners);
+    promoteAgedPriority(PRIO_LOW, PRIO_HIGH, aging_.low_to_high, now, owners);
+}
+
+void LocalTransferAdmissionQueue::DispatchScheduler::promoteAgedPriority(
+    size_t from_priority, size_t to_priority,
+    std::chrono::microseconds threshold, TimePoint now,
+    const std::map<QueueOwnerId, QueueOwner>& owners) {
+    if (threshold <= std::chrono::microseconds::zero()) return;
+    if (from_priority == PRIO_HIGH || from_priority >= queues_.size() ||
+        to_priority >= queues_.size()) {
+        return;
+    }
+
+    for (size_t lane = 0; lane < queues_[from_priority].size(); ++lane) {
+        auto& queue = queues_[from_priority][lane];
+        auto& promoted_queue = queues_[to_priority][lane];
+        while (!queue.empty()) {
+            const auto owner_id = queue.front();
+            auto owner_it = owners.find(owner_id);
+            if (owner_it == owners.end() ||
+                owner_it->second.state != QueueState::Queued) {
+                queue.pop_front();
+                continue;
+            }
+
+            if (now - owner_it->second.enqueue_time < threshold) break;
+
+            auto insert_it = promoted_queue.end();
+            for (auto it = promoted_queue.begin(); it != promoted_queue.end();
+                 ++it) {
+                auto promoted_it = owners.find(*it);
+                if (promoted_it == owners.end() ||
+                    promoted_it->second.state != QueueState::Queued) {
+                    continue;
+                }
+                if (owner_it->second.enqueue_time <
+                    promoted_it->second.enqueue_time) {
+                    insert_it = it;
+                    break;
+                }
+            }
+            queue.pop_front();
+            promoted_queue.insert(insert_it, owner_id);
+        }
+    }
+}
+
 std::vector<QueueOwnerId> LocalTransferAdmissionQueue::DispatchScheduler::pick(
     size_t max_owners, size_t max_bytes,
-    const std::map<QueueOwnerId, QueueOwner>& owners) {
+    const std::map<QueueOwnerId, QueueOwner>& owners, TimePoint now) {
     std::vector<QueueOwnerId> picked;
     if (max_owners == 0 || max_bytes == 0) return picked;
+
+    promoteAgedOwners(now, owners);
 
     size_t used_owners = 0;
     size_t used_bytes = 0;
     for (size_t priority = 0; priority < queues_.size(); ++priority) {
         auto& priority_queues = queues_[priority];
-        while (used_owners < max_owners) {
+        while (used_owners < max_owners && used_bytes < max_bytes) {
             bool made_progress = false;
             for (size_t offset = 0; offset < priority_queues.size(); ++offset) {
                 const size_t lane = (next_kind_lane_[priority] + offset) %
@@ -117,7 +174,7 @@ std::vector<QueueOwnerId> LocalTransferAdmissionQueue::DispatchScheduler::pick(
 
                     const size_t remaining_bytes = max_bytes - used_bytes;
                     if (owner_it->second.request.length > remaining_bytes)
-                        return picked;
+                        break;
 
                     queue.pop_front();
                     picked.push_back(owner_id);
@@ -139,8 +196,20 @@ std::vector<QueueOwnerId> LocalTransferAdmissionQueue::DispatchScheduler::pick(
 LocalTransferAdmissionQueue::LocalTransferAdmissionQueue(QueueLimits limits)
     : limits_(limits), limits_status_(validateLimits(limits)) {}
 
+LocalTransferAdmissionQueue::LocalTransferAdmissionQueue(QueueLimits limits,
+                                                         QueueAgingConfig aging)
+    : limits_(limits),
+      limits_status_(validateLimits(limits)),
+      scheduler_(aging) {}
+
 Status LocalTransferAdmissionQueue::tryAdmit(
     const QueueSubmit& submit, std::vector<QueueOwnerId>& admitted_owner_ids) {
+    return tryAdmit(submit, admitted_owner_ids, Clock::now());
+}
+
+Status LocalTransferAdmissionQueue::tryAdmit(
+    const QueueSubmit& submit, std::vector<QueueOwnerId>& admitted_owner_ids,
+    TimePoint now) {
     admitted_owner_ids.clear();
     CHECK_STATUS(limits_status_);
     if (submit.batch_token == 0) {
@@ -244,6 +313,7 @@ Status LocalTransferAdmissionQueue::tryAdmit(
         owner.batch_token = submit.batch_token;
         owner.request = owner_input.request;
         owner.kind = owner_input.kind;
+        owner.enqueue_time = now;
         owners_.emplace(owner_id, owner);
 
         public_to_owner_[{submit.batch_token, owner_input.owner_task_id}] =
@@ -265,7 +335,12 @@ Status LocalTransferAdmissionQueue::tryAdmit(
 
 std::vector<QueueOwnerId> LocalTransferAdmissionQueue::pickForDispatch(
     size_t max_owners, size_t max_bytes) {
-    auto picked = scheduler_.pick(max_owners, max_bytes, owners_);
+    return pickForDispatch(max_owners, max_bytes, Clock::now());
+}
+
+std::vector<QueueOwnerId> LocalTransferAdmissionQueue::pickForDispatch(
+    size_t max_owners, size_t max_bytes, TimePoint now) {
+    auto picked = scheduler_.pick(max_owners, max_bytes, owners_, now);
     for (const auto owner_id : picked) {
         owners_.find(owner_id)->second.state = QueueState::Dispatching;
     }

--- a/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
@@ -16,13 +16,19 @@
 
 #include <algorithm>
 #include <limits>
-#include <set>
 
 namespace mooncake {
 namespace tent {
 namespace {
 
-using PublicTaskKey = std::pair<uint64_t, size_t>;
+struct PendingPublicTask {
+    size_t task_id{0};
+    size_t owner_index{0};
+
+    bool operator<(const PendingPublicTask& other) const {
+        return task_id < other.task_id;
+    }
+};
 
 bool isSupportedTerminalStatus(TransferStatusEnum status) {
     return status == TransferStatusEnum::COMPLETED ||
@@ -73,6 +79,16 @@ Status validateLimits(const QueueLimits& limits) {
 }
 
 }  // namespace
+
+bool LocalTransferAdmissionQueue::hasPublicTask(const BatchIndex& batch_index,
+                                                size_t task_id) {
+    auto it = std::lower_bound(batch_index.public_tasks.begin(),
+                               batch_index.public_tasks.end(), task_id,
+                               [](const auto& public_task, size_t key) {
+                                   return public_task.task_id < key;
+                               });
+    return it != batch_index.public_tasks.end() && it->task_id == task_id;
+}
 
 LocalTransferAdmissionQueue::DispatchScheduler::DispatchScheduler(
     QueueAgingConfig aging)
@@ -134,7 +150,7 @@ void LocalTransferAdmissionQueue::DispatchScheduler::addDeficit(
 }
 
 bool LocalTransferAdmissionQueue::DispatchScheduler::hasQueuedOwner(
-    size_t priority, const std::map<QueueOwnerId, QueueOwner>& owners) {
+    size_t priority, const OwnerMap& owners) {
     auto& priority_class = classes_[priority];
     bool has_owner = false;
     for (auto& lane : priority_class.lanes) {
@@ -157,8 +173,7 @@ bool LocalTransferAdmissionQueue::DispatchScheduler::hasQueuedOwner(
 
 LocalTransferAdmissionQueue::DispatchScheduler::PickResult
 LocalTransferAdmissionQueue::DispatchScheduler::pickFromPriority(
-    size_t priority, size_t remaining_bytes,
-    const std::map<QueueOwnerId, QueueOwner>& owners) {
+    size_t priority, size_t remaining_bytes, const OwnerMap& owners) {
     auto& priority_class = classes_[priority];
     PickResult blocked;
     for (size_t offset = 0; offset < priority_class.lanes.size(); ++offset) {
@@ -201,7 +216,7 @@ LocalTransferAdmissionQueue::DispatchScheduler::pickFromPriority(
 }
 
 void LocalTransferAdmissionQueue::DispatchScheduler::promoteAgedOwners(
-    TimePoint now, const std::map<QueueOwnerId, QueueOwner>& owners) {
+    TimePoint now, const OwnerMap& owners) {
     promoteAgedPriority(PRIO_MEDIUM, PRIO_HIGH, aging_.medium_to_high, now,
                         owners);
     promoteAgedPriority(PRIO_LOW, PRIO_HIGH, aging_.low_to_high, now, owners);
@@ -210,7 +225,7 @@ void LocalTransferAdmissionQueue::DispatchScheduler::promoteAgedOwners(
 void LocalTransferAdmissionQueue::DispatchScheduler::promoteAgedPriority(
     size_t from_priority, size_t to_priority,
     std::chrono::microseconds threshold, TimePoint now,
-    const std::map<QueueOwnerId, QueueOwner>& owners) {
+    const OwnerMap& owners) {
     if (threshold <= std::chrono::microseconds::zero()) return;
     if (from_priority == PRIO_HIGH || from_priority >= classes_.size() ||
         to_priority >= classes_.size()) {
@@ -260,8 +275,8 @@ void LocalTransferAdmissionQueue::DispatchScheduler::promoteAgedPriority(
 }
 
 std::vector<QueueOwnerId> LocalTransferAdmissionQueue::DispatchScheduler::pick(
-    size_t max_owners, size_t max_bytes,
-    const std::map<QueueOwnerId, QueueOwner>& owners, TimePoint now) {
+    size_t max_owners, size_t max_bytes, const OwnerMap& owners,
+    TimePoint now) {
     std::vector<QueueOwnerId> picked;
     if (max_owners == 0 || max_bytes == 0) return picked;
 
@@ -332,12 +347,22 @@ Status LocalTransferAdmissionQueue::tryAdmit(
     }
     if (submit.owners.empty()) return Status::OK();
 
-    std::set<PublicTaskKey> public_keys;
+    std::vector<PendingPublicTask> public_tasks;
+    size_t public_task_count = 0;
+    for (const auto& owner : submit.owners) {
+        CHECK_STATUS(checkedAdd(public_task_count, 1, public_task_count));
+        CHECK_STATUS(checkedAdd(public_task_count,
+                                owner.derived_task_ids.size(),
+                                public_task_count));
+    }
+    public_tasks.reserve(public_task_count);
     size_t byte_charge = 0;
     size_t user_owner_charge = 0;
     size_t user_byte_charge = 0;
 
-    for (const auto& owner : submit.owners) {
+    for (size_t owner_index = 0; owner_index < submit.owners.size();
+         ++owner_index) {
+        const auto& owner = submit.owners[owner_index];
         if (!isSupportedOwnerKind(owner.kind)) {
             return Status::InvalidArgument(
                 "unsupported queue owner kind" LOC_MARK);
@@ -350,21 +375,13 @@ Status LocalTransferAdmissionQueue::tryAdmit(
             return Status::InvalidArgument("empty transfer request" LOC_MARK);
         }
 
-        const PublicTaskKey owner_key{submit.batch_token, owner.owner_task_id};
-        if (!public_keys.insert(owner_key).second) {
-            return Status::InvalidArgument("duplicate public task id" LOC_MARK);
-        }
+        public_tasks.push_back({owner.owner_task_id, owner_index});
         for (const auto derived_task_id : owner.derived_task_ids) {
             if (derived_task_id == owner.owner_task_id) {
                 return Status::InvalidArgument(
                     "owner task id appears in derived task ids" LOC_MARK);
             }
-            const PublicTaskKey derived_key{submit.batch_token,
-                                            derived_task_id};
-            if (!public_keys.insert(derived_key).second) {
-                return Status::InvalidArgument(
-                    "duplicate public task id" LOC_MARK);
-            }
+            public_tasks.push_back({derived_task_id, owner_index});
         }
 
         CHECK_STATUS(
@@ -376,15 +393,28 @@ Status LocalTransferAdmissionQueue::tryAdmit(
         }
     }
 
-    if (public_keys.size() > submit.batch_slots_left) {
+    std::sort(public_tasks.begin(), public_tasks.end());
+    auto duplicate_public_task =
+        std::adjacent_find(public_tasks.begin(), public_tasks.end(),
+                           [](const auto& lhs, const auto& rhs) {
+                               return lhs.task_id == rhs.task_id;
+                           });
+    if (duplicate_public_task != public_tasks.end()) {
+        return Status::InvalidArgument("duplicate public task id" LOC_MARK);
+    }
+
+    if (public_tasks.size() > submit.batch_slots_left) {
         return Status::TooManyRequests(
             "batch public task capacity exceeded" LOC_MARK);
     }
 
-    for (const auto& key : public_keys) {
-        if (public_to_owner_.count(key)) {
-            return Status::InvalidEntry(
-                "public task id already admitted" LOC_MARK);
+    auto batch_it = batch_index_.find(submit.batch_token);
+    if (batch_it != batch_index_.end()) {
+        for (const auto& public_task : public_tasks) {
+            if (hasPublicTask(batch_it->second, public_task.task_id)) {
+                return Status::InvalidEntry(
+                    "public task id already admitted" LOC_MARK);
+            }
         }
     }
 
@@ -422,6 +452,16 @@ Status LocalTransferAdmissionQueue::tryAdmit(
     }
 
     admitted_owner_ids.reserve(submit.owners.size());
+    owners_.reserve(owners_.size() + submit.owners.size());
+    auto& batch_index =
+        batch_index_.try_emplace(submit.batch_token).first->second;
+    batch_index.owner_ids.reserve(batch_index.owner_ids.size() +
+                                  submit.owners.size());
+    batch_index.public_tasks.reserve(batch_index.public_tasks.size() +
+                                     public_tasks.size());
+
+    std::vector<QueueOwnerId> owner_ids;
+    owner_ids.reserve(submit.owners.size());
     for (const auto& owner_input : submit.owners) {
         const QueueOwnerId owner_id = next_owner_id_++;
         QueueOwner owner;
@@ -430,16 +470,23 @@ Status LocalTransferAdmissionQueue::tryAdmit(
         owner.kind = owner_input.kind;
         owner.enqueue_time = now;
         owners_.emplace(owner_id, owner);
-
-        public_to_owner_[{submit.batch_token, owner_input.owner_task_id}] =
-            owner_id;
-        for (const auto derived_task_id : owner_input.derived_task_ids) {
-            public_to_owner_[{submit.batch_token, derived_task_id}] = owner_id;
-        }
+        batch_index.owner_ids.push_back(owner_id);
+        owner_ids.push_back(owner_id);
         scheduler_.enqueue(owner_id, owner_input.request.priority,
                            owner_input.kind);
         admitted_owner_ids.push_back(owner_id);
     }
+    const auto public_task_begin = batch_index.public_tasks.size();
+    for (const auto& public_task : public_tasks) {
+        batch_index.public_tasks.push_back(
+            {public_task.task_id, owner_ids[public_task.owner_index]});
+    }
+    std::inplace_merge(batch_index.public_tasks.begin(),
+                       batch_index.public_tasks.begin() + public_task_begin,
+                       batch_index.public_tasks.end(),
+                       [](const auto& lhs, const auto& rhs) {
+                           return lhs.task_id < rhs.task_id;
+                       });
 
     outstanding_owners_ = next_outstanding_owners;
     outstanding_bytes_ = next_outstanding_bytes;
@@ -514,17 +561,10 @@ Status LocalTransferAdmissionQueue::retireBatch(uint64_t batch_token) {
         return Status::InvalidArgument("invalid batch token" LOC_MARK);
     }
 
-    const PublicTaskKey batch_begin{batch_token, 0};
-    auto public_begin = public_to_owner_.lower_bound(batch_begin);
-    auto public_end = public_to_owner_.upper_bound(
-        {batch_token, std::numeric_limits<size_t>::max()});
+    auto batch_it = batch_index_.find(batch_token);
+    if (batch_it == batch_index_.end()) return Status::OK();
 
-    std::set<QueueOwnerId> owner_ids;
-    for (auto it = public_begin; it != public_end; ++it) {
-        owner_ids.insert(it->second);
-    }
-
-    for (const auto owner_id : owner_ids) {
+    for (const auto owner_id : batch_it->second.owner_ids) {
         auto owner_it = owners_.find(owner_id);
         if (owner_it == owners_.end()) {
             return Status::InternalError(
@@ -542,10 +582,10 @@ Status LocalTransferAdmissionQueue::retireBatch(uint64_t batch_token) {
         }
     }
 
-    for (const auto owner_id : owner_ids) {
+    for (const auto owner_id : batch_it->second.owner_ids) {
         owners_.erase(owner_id);
     }
-    public_to_owner_.erase(public_begin, public_end);
+    batch_index_.erase(batch_it);
     return Status::OK();
 }
 
@@ -555,11 +595,21 @@ Status LocalTransferAdmissionQueue::resolveOwner(uint64_t batch_token,
     if (batch_token == 0) {
         return Status::InvalidArgument("invalid batch token" LOC_MARK);
     }
-    auto it = public_to_owner_.find({batch_token, public_task_id});
-    if (it == public_to_owner_.end()) {
+    auto batch_it = batch_index_.find(batch_token);
+    if (batch_it == batch_index_.end()) {
         return Status::InvalidEntry("public task id not found" LOC_MARK);
     }
-    owner_id = it->second;
+    auto public_it =
+        std::lower_bound(batch_it->second.public_tasks.begin(),
+                         batch_it->second.public_tasks.end(), public_task_id,
+                         [](const auto& public_task, size_t task_id) {
+                             return public_task.task_id < task_id;
+                         });
+    if (public_it == batch_it->second.public_tasks.end() ||
+        public_it->task_id != public_task_id) {
+        return Status::InvalidEntry("public task id not found" LOC_MARK);
+    }
+    owner_id = public_it->owner_id;
     return Status::OK();
 }
 

--- a/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
@@ -347,6 +347,24 @@ std::vector<QueueOwnerId> LocalTransferAdmissionQueue::pickForDispatch(
     return picked;
 }
 
+Status LocalTransferAdmissionQueue::requeueForDispatch(QueueOwnerId owner_id) {
+    if (owner_id == 0) {
+        return Status::InvalidArgument("invalid queue owner id" LOC_MARK);
+    }
+    auto owner_it = owners_.find(owner_id);
+    if (owner_it == owners_.end()) {
+        return Status::InvalidEntry("queue owner not found" LOC_MARK);
+    }
+    auto& owner = owner_it->second;
+    if (owner.state != QueueState::Dispatching) {
+        return Status::InvalidEntry("queue owner is not dispatching" LOC_MARK);
+    }
+
+    owner.state = QueueState::Queued;
+    scheduler_.enqueue(owner_id, owner.request.priority, owner.kind);
+    return Status::OK();
+}
+
 Status LocalTransferAdmissionQueue::complete(
     QueueOwnerId owner_id, TransferStatusEnum terminal_status) {
     if (owner_id == 0) {

--- a/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
@@ -63,6 +63,39 @@ Status validateLimits(const QueueLimits& limits) {
 
 }  // namespace
 
+void LocalTransferAdmissionQueue::DispatchScheduler::enqueue(
+    QueueOwnerId owner_id) {
+    fifo_.push_back(owner_id);
+}
+
+std::vector<QueueOwnerId> LocalTransferAdmissionQueue::DispatchScheduler::pick(
+    size_t max_owners, size_t max_bytes,
+    const std::map<QueueOwnerId, QueueOwner>& owners) {
+    std::vector<QueueOwnerId> picked;
+    if (max_owners == 0 || max_bytes == 0) return picked;
+
+    size_t used_owners = 0;
+    size_t used_bytes = 0;
+    while (!fifo_.empty() && used_owners < max_owners) {
+        const auto owner_id = fifo_.front();
+        auto owner_it = owners.find(owner_id);
+        if (owner_it == owners.end() ||
+            owner_it->second.state != QueueState::Queued) {
+            fifo_.pop_front();
+            continue;
+        }
+
+        const size_t remaining_bytes = max_bytes - used_bytes;
+        if (owner_it->second.request.length > remaining_bytes) break;
+
+        fifo_.pop_front();
+        picked.push_back(owner_id);
+        ++used_owners;
+        used_bytes += owner_it->second.request.length;
+    }
+    return picked;
+}
+
 LocalTransferAdmissionQueue::LocalTransferAdmissionQueue(QueueLimits limits)
     : limits_(limits), limits_status_(validateLimits(limits)) {}
 
@@ -174,7 +207,7 @@ Status LocalTransferAdmissionQueue::tryAdmit(
         for (const auto derived_task_id : owner_input.derived_task_ids) {
             public_to_owner_[{submit.batch_token, derived_task_id}] = owner_id;
         }
-        fifo_.push_back(owner_id);
+        scheduler_.enqueue(owner_id);
         admitted_owner_ids.push_back(owner_id);
     }
 
@@ -187,32 +220,9 @@ Status LocalTransferAdmissionQueue::tryAdmit(
 
 std::vector<QueueOwnerId> LocalTransferAdmissionQueue::pickForDispatch(
     size_t max_owners, size_t max_bytes) {
-    std::vector<QueueOwnerId> picked;
-    if (max_owners == 0 || max_bytes == 0) return picked;
-
-    size_t used_owners = 0;
-    size_t used_bytes = 0;
-    while (!fifo_.empty() && used_owners < max_owners) {
-        auto owner_id = fifo_.front();
-        auto owner_it = owners_.find(owner_id);
-        // Non-queued entries should not normally remain in fifo_, but stale
-        // entries are skipped defensively so retireBatch() does not need to
-        // scan the dispatch queue.
-        if (owner_it == owners_.end() ||
-            owner_it->second.state != QueueState::Queued) {
-            fifo_.pop_front();
-            continue;
-        }
-
-        const auto& owner = owner_it->second;
-        const size_t remaining_bytes = max_bytes - used_bytes;
-        if (owner.request.length > remaining_bytes) break;
-
-        fifo_.pop_front();
-        owner_it->second.state = QueueState::Dispatching;
-        picked.push_back(owner_id);
-        ++used_owners;
-        used_bytes += owner.request.length;
+    auto picked = scheduler_.pick(max_owners, max_bytes, owners_);
+    for (const auto owner_id : picked) {
+        owners_.find(owner_id)->second.state = QueueState::Dispatching;
     }
     return picked;
 }

--- a/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
@@ -40,6 +40,16 @@ bool isSupportedOwnerKind(QueueOwnerKind kind) {
     return false;
 }
 
+bool isSupportedRequestPriority(int priority) {
+    switch (priority) {
+        case PRIO_HIGH:
+        case PRIO_MEDIUM:
+        case PRIO_LOW:
+            return true;
+    }
+    return false;
+}
+
 Status checkedAdd(size_t lhs, size_t rhs, size_t& out) {
     if (rhs > std::numeric_limits<size_t>::max() - lhs) {
         return Status::InvalidArgument(
@@ -64,8 +74,8 @@ Status validateLimits(const QueueLimits& limits) {
 }  // namespace
 
 void LocalTransferAdmissionQueue::DispatchScheduler::enqueue(
-    QueueOwnerId owner_id) {
-    fifo_.push_back(owner_id);
+    QueueOwnerId owner_id, int priority) {
+    queues_[priority].push_back(owner_id);
 }
 
 std::vector<QueueOwnerId> LocalTransferAdmissionQueue::DispatchScheduler::pick(
@@ -76,22 +86,25 @@ std::vector<QueueOwnerId> LocalTransferAdmissionQueue::DispatchScheduler::pick(
 
     size_t used_owners = 0;
     size_t used_bytes = 0;
-    while (!fifo_.empty() && used_owners < max_owners) {
-        const auto owner_id = fifo_.front();
-        auto owner_it = owners.find(owner_id);
-        if (owner_it == owners.end() ||
-            owner_it->second.state != QueueState::Queued) {
-            fifo_.pop_front();
-            continue;
+    for (auto& queue : queues_) {
+        while (!queue.empty() && used_owners < max_owners) {
+            const auto owner_id = queue.front();
+            auto owner_it = owners.find(owner_id);
+            if (owner_it == owners.end() ||
+                owner_it->second.state != QueueState::Queued) {
+                queue.pop_front();
+                continue;
+            }
+
+            const size_t remaining_bytes = max_bytes - used_bytes;
+            if (owner_it->second.request.length > remaining_bytes)
+                return picked;
+
+            queue.pop_front();
+            picked.push_back(owner_id);
+            ++used_owners;
+            used_bytes += owner_it->second.request.length;
         }
-
-        const size_t remaining_bytes = max_bytes - used_bytes;
-        if (owner_it->second.request.length > remaining_bytes) break;
-
-        fifo_.pop_front();
-        picked.push_back(owner_id);
-        ++used_owners;
-        used_bytes += owner_it->second.request.length;
     }
     return picked;
 }
@@ -117,6 +130,10 @@ Status LocalTransferAdmissionQueue::tryAdmit(
         if (!isSupportedOwnerKind(owner.kind)) {
             return Status::InvalidArgument(
                 "unsupported queue owner kind" LOC_MARK);
+        }
+        if (!isSupportedRequestPriority(owner.request.priority)) {
+            return Status::InvalidArgument(
+                "unsupported queue request priority" LOC_MARK);
         }
         if (owner.request.length == 0) {
             return Status::InvalidArgument("empty transfer request" LOC_MARK);
@@ -207,7 +224,7 @@ Status LocalTransferAdmissionQueue::tryAdmit(
         for (const auto derived_task_id : owner_input.derived_task_ids) {
             public_to_owner_[{submit.batch_token, derived_task_id}] = owner_id;
         }
-        scheduler_.enqueue(owner_id);
+        scheduler_.enqueue(owner_id, owner_input.request.priority);
         admitted_owner_ids.push_back(owner_id);
     }
 

--- a/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
@@ -142,9 +142,11 @@ void LocalTransferAdmissionQueue::DispatchScheduler::promoteDeadlineUrgentOwners
 }
 
 LocalTransferAdmissionQueue::DispatchScheduler::Candidate
-LocalTransferAdmissionQueue::DispatchScheduler::next(const OwnerMap& owners) {
+LocalTransferAdmissionQueue::DispatchScheduler::next(
+    size_t remaining_bytes, const OwnerMap& owners) {
     for (size_t priority = PRIO_HIGH; priority < classes_.size(); ++priority) {
         auto& priority_class = classes_[priority];
+        bool has_queued_owner = false;
         for (size_t offset = 0; offset < priority_class.lanes.size(); ++offset) {
             const size_t lane =
                 (priority_class.next_kind_lane + offset) %
@@ -154,11 +156,16 @@ LocalTransferAdmissionQueue::DispatchScheduler::next(const OwnerMap& owners) {
                 const auto owner_it = owners.find(queue.front());
                 if (owner_it != owners.end() &&
                     owner_it->second.state == QueueState::Queued) {
-                    return Candidate{queue.front(), priority, lane, true};
+                    has_queued_owner = true;
+                    if (owner_it->second.request.length <= remaining_bytes) {
+                        return Candidate{queue.front(), priority, lane, true};
+                    }
+                    break;
                 }
                 queue.pop_front();
             }
         }
+        if (has_queued_owner) return Candidate{0, priority, 0, true};
     }
     return {};
 }
@@ -189,17 +196,9 @@ Status LocalTransferAdmissionQueue::tryAdmit(
     if (submit.batch_token == 0) {
         return Status::InvalidArgument("invalid batch token" LOC_MARK);
     }
-    if (submit.owners.empty()) return Status::OK();
 
     std::vector<PendingPublicTask> public_tasks;
-    size_t public_task_count = 0;
-    for (const auto& owner : submit.owners) {
-        CHECK_STATUS(checkedAdd(public_task_count, 1, public_task_count));
-        CHECK_STATUS(checkedAdd(public_task_count,
-                                owner.derived_task_ids.size(),
-                                public_task_count));
-    }
-    public_tasks.reserve(public_task_count);
+    size_t public_task_extent = 0;
     size_t byte_charge = 0;
     size_t user_owner_charge = 0;
     size_t user_byte_charge = 0;
@@ -219,12 +218,13 @@ Status LocalTransferAdmissionQueue::tryAdmit(
             return Status::InvalidArgument("empty transfer request" LOC_MARK);
         }
 
+        size_t task_extent = 0;
+        CHECK_STATUS(checkedAdd(owner.owner_task_id, 1, task_extent));
+        public_task_extent = std::max(public_task_extent, task_extent);
         public_tasks.push_back({owner.owner_task_id, owner_index});
         for (const auto derived_task_id : owner.derived_task_ids) {
-            if (derived_task_id == owner.owner_task_id) {
-                return Status::InvalidArgument(
-                    "owner task id appears in derived task ids" LOC_MARK);
-            }
+            CHECK_STATUS(checkedAdd(derived_task_id, 1, task_extent));
+            public_task_extent = std::max(public_task_extent, task_extent);
             public_tasks.push_back({derived_task_id, owner_index});
         }
 
@@ -235,36 +235,6 @@ Status LocalTransferAdmissionQueue::tryAdmit(
             CHECK_STATUS(checkedAdd(user_byte_charge, owner.request.length,
                                     user_byte_charge));
         }
-    }
-
-    size_t first_public_task_id = std::numeric_limits<size_t>::max();
-    size_t public_task_extent = 0;
-    for (const auto& public_task : public_tasks) {
-        size_t task_extent = 0;
-        CHECK_STATUS(checkedAdd(public_task.task_id, 1, task_extent));
-        first_public_task_id =
-            std::min(first_public_task_id, public_task.task_id);
-        public_task_extent = std::max(public_task_extent, task_extent);
-    }
-
-    if (public_task_extent - first_public_task_id != public_tasks.size()) {
-        return Status::InvalidArgument(
-            "public task ids must form a contiguous range" LOC_MARK);
-    }
-    std::vector<size_t> pending_owner_indices(public_tasks.size(),
-                                              submit.owners.size());
-    for (const auto& public_task : public_tasks) {
-        auto& owner_index =
-            pending_owner_indices[public_task.task_id - first_public_task_id];
-        if (owner_index != submit.owners.size()) {
-            return Status::InvalidArgument("duplicate public task id" LOC_MARK);
-        }
-        owner_index = public_task.owner_index;
-    }
-
-    if (public_tasks.size() > submit.batch_slots_left) {
-        return Status::TooManyRequests(
-            "batch public task capacity exceeded" LOC_MARK);
     }
 
     auto batch_it = batch_index_.find(submit.batch_token);
@@ -316,8 +286,6 @@ Status LocalTransferAdmissionQueue::tryAdmit(
     auto& batch_index =
         batch_index_.try_emplace(submit.batch_token).first->second;
 
-    std::vector<QueueOwnerId> owner_ids;
-    owner_ids.reserve(submit.owners.size());
     for (const auto& owner_input : submit.owners) {
         const QueueOwnerId owner_id = next_owner_id_++;
         QueueOwner owner;
@@ -327,7 +295,6 @@ Status LocalTransferAdmissionQueue::tryAdmit(
         owner.degradation_eligible = owner_input.degradation_eligible;
         owners_.emplace(owner_id, owner);
         batch_index.owner_ids.push_back(owner_id);
-        owner_ids.push_back(owner_id);
         scheduler_.enqueue(owner_id, owner_input.request.priority,
                            owner_input.kind, limits_.deadline_aware, owners_);
         admitted_owner_ids.push_back(owner_id);
@@ -335,10 +302,9 @@ Status LocalTransferAdmissionQueue::tryAdmit(
     if (batch_index.public_task_owners.size() < public_task_extent) {
         batch_index.public_task_owners.resize(public_task_extent, 0);
     }
-    for (size_t offset = 0; offset < pending_owner_indices.size(); ++offset) {
-        const auto task_id = first_public_task_id + offset;
-        const auto owner_index = pending_owner_indices[offset];
-        batch_index.public_task_owners[task_id] = owner_ids[owner_index];
+    for (const auto& public_task : public_tasks) {
+        batch_index.public_task_owners[public_task.task_id] =
+            admitted_owner_ids[public_task.owner_index];
     }
 
     outstanding_owners_ = next_outstanding_owners;
@@ -426,8 +392,9 @@ std::vector<QueueOwnerId> LocalTransferAdmissionQueue::pickForDispatch(
     size_t used_owners = 0;
     size_t used_bytes = 0;
     while (used_owners < max_owners && used_bytes < max_bytes) {
-        const auto candidate = scheduler_.next(owners_);
-        if (!candidate.found) break;
+        const auto candidate =
+            scheduler_.next(max_bytes - used_bytes, owners_);
+        if (!candidate.found || candidate.owner_id == 0) break;
 
         auto owner_it = owners_.find(candidate.owner_id);
         if (owner_it == owners_.end()) continue;
@@ -440,15 +407,11 @@ std::vector<QueueOwnerId> LocalTransferAdmissionQueue::pickForDispatch(
             continue;
         }
 
-        const auto& owner = owner_it->second;
-        const size_t remaining_bytes = max_bytes - used_bytes;
-        if (owner.request.length > remaining_bytes) break;
-
         scheduler_.consume(candidate);
         owner_it->second.state = QueueState::Dispatching;
         picked.push_back(candidate.owner_id);
         ++used_owners;
-        used_bytes += owner.request.length;
+        used_bytes += owner_it->second.request.length;
     }
     return picked;
 }

--- a/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
@@ -17,14 +17,20 @@
 #include <algorithm>
 #include <chrono>
 #include <limits>
-#include <set>
 #include <utility>
 
 namespace mooncake {
 namespace tent {
 namespace {
 
-using PublicTaskKey = std::pair<uint64_t, size_t>;
+struct PendingPublicTask {
+    size_t task_id{0};
+    size_t owner_index{0};
+
+    bool operator<(const PendingPublicTask& other) const {
+        return task_id < other.task_id;
+    }
+};
 
 // Sort key for EDF: owners without a deadline (0) sort after all deadlined
 // owners, so they never jump ahead of a real deadline.
@@ -82,6 +88,16 @@ Status validateLimits(const QueueLimits& limits) {
 }
 
 }  // namespace
+
+bool LocalTransferAdmissionQueue::hasPublicTask(const BatchIndex& batch_index,
+                                                size_t task_id) {
+    auto it = std::lower_bound(batch_index.public_tasks.begin(),
+                               batch_index.public_tasks.end(), task_id,
+                               [](const auto& public_task, size_t key) {
+                                   return public_task.task_id < key;
+                               });
+    return it != batch_index.public_tasks.end() && it->task_id == task_id;
+}
 
 size_t LocalTransferAdmissionQueue::DispatchScheduler::laneForKind(
     QueueOwnerKind kind) {
@@ -189,12 +205,22 @@ Status LocalTransferAdmissionQueue::tryAdmit(
     }
     if (submit.owners.empty()) return Status::OK();
 
-    std::set<PublicTaskKey> public_keys;
+    std::vector<PendingPublicTask> public_tasks;
+    size_t public_task_count = 0;
+    for (const auto& owner : submit.owners) {
+        CHECK_STATUS(checkedAdd(public_task_count, 1, public_task_count));
+        CHECK_STATUS(checkedAdd(public_task_count,
+                                owner.derived_task_ids.size(),
+                                public_task_count));
+    }
+    public_tasks.reserve(public_task_count);
     size_t byte_charge = 0;
     size_t user_owner_charge = 0;
     size_t user_byte_charge = 0;
 
-    for (const auto& owner : submit.owners) {
+    for (size_t owner_index = 0; owner_index < submit.owners.size();
+         ++owner_index) {
+        const auto& owner = submit.owners[owner_index];
         if (!isSupportedOwnerKind(owner.kind)) {
             return Status::InvalidArgument(
                 "unsupported queue owner kind" LOC_MARK);
@@ -207,21 +233,13 @@ Status LocalTransferAdmissionQueue::tryAdmit(
             return Status::InvalidArgument("empty transfer request" LOC_MARK);
         }
 
-        const PublicTaskKey owner_key{submit.batch_token, owner.owner_task_id};
-        if (!public_keys.insert(owner_key).second) {
-            return Status::InvalidArgument("duplicate public task id" LOC_MARK);
-        }
+        public_tasks.push_back({owner.owner_task_id, owner_index});
         for (const auto derived_task_id : owner.derived_task_ids) {
             if (derived_task_id == owner.owner_task_id) {
                 return Status::InvalidArgument(
                     "owner task id appears in derived task ids" LOC_MARK);
             }
-            const PublicTaskKey derived_key{submit.batch_token,
-                                            derived_task_id};
-            if (!public_keys.insert(derived_key).second) {
-                return Status::InvalidArgument(
-                    "duplicate public task id" LOC_MARK);
-            }
+            public_tasks.push_back({derived_task_id, owner_index});
         }
 
         CHECK_STATUS(
@@ -233,15 +251,28 @@ Status LocalTransferAdmissionQueue::tryAdmit(
         }
     }
 
-    if (public_keys.size() > submit.batch_slots_left) {
+    std::sort(public_tasks.begin(), public_tasks.end());
+    const auto duplicate_public_task =
+        std::adjacent_find(public_tasks.begin(), public_tasks.end(),
+                           [](const auto& lhs, const auto& rhs) {
+                               return lhs.task_id == rhs.task_id;
+                           });
+    if (duplicate_public_task != public_tasks.end()) {
+        return Status::InvalidArgument("duplicate public task id" LOC_MARK);
+    }
+
+    if (public_tasks.size() > submit.batch_slots_left) {
         return Status::TooManyRequests(
             "batch public task capacity exceeded" LOC_MARK);
     }
 
-    for (const auto& key : public_keys) {
-        if (public_to_owner_.count(key)) {
-            return Status::InvalidEntry(
-                "public task id already admitted" LOC_MARK);
+    auto batch_it = batch_index_.find(submit.batch_token);
+    if (batch_it != batch_index_.end()) {
+        for (const auto& public_task : public_tasks) {
+            if (hasPublicTask(batch_it->second, public_task.task_id)) {
+                return Status::InvalidEntry(
+                    "public task id already admitted" LOC_MARK);
+            }
         }
     }
 
@@ -279,6 +310,16 @@ Status LocalTransferAdmissionQueue::tryAdmit(
     }
 
     admitted_owner_ids.reserve(submit.owners.size());
+    owners_.reserve(owners_.size() + submit.owners.size());
+    auto& batch_index =
+        batch_index_.try_emplace(submit.batch_token).first->second;
+    batch_index.owner_ids.reserve(batch_index.owner_ids.size() +
+                                  submit.owners.size());
+    batch_index.public_tasks.reserve(batch_index.public_tasks.size() +
+                                     public_tasks.size());
+
+    std::vector<QueueOwnerId> owner_ids;
+    owner_ids.reserve(submit.owners.size());
     for (const auto& owner_input : submit.owners) {
         const QueueOwnerId owner_id = next_owner_id_++;
         QueueOwner owner;
@@ -287,16 +328,23 @@ Status LocalTransferAdmissionQueue::tryAdmit(
         owner.kind = owner_input.kind;
         owner.degradation_eligible = owner_input.degradation_eligible;
         owners_.emplace(owner_id, owner);
-
-        public_to_owner_[{submit.batch_token, owner_input.owner_task_id}] =
-            owner_id;
-        for (const auto derived_task_id : owner_input.derived_task_ids) {
-            public_to_owner_[{submit.batch_token, derived_task_id}] = owner_id;
-        }
+        batch_index.owner_ids.push_back(owner_id);
+        owner_ids.push_back(owner_id);
         scheduler_.enqueue(owner_id, owner_input.request.priority,
                            owner_input.kind, limits_.deadline_aware, owners_);
         admitted_owner_ids.push_back(owner_id);
     }
+    const auto public_task_begin = batch_index.public_tasks.size();
+    for (const auto& public_task : public_tasks) {
+        batch_index.public_tasks.push_back(
+            {public_task.task_id, owner_ids[public_task.owner_index]});
+    }
+    std::inplace_merge(batch_index.public_tasks.begin(),
+                       batch_index.public_tasks.begin() + public_task_begin,
+                       batch_index.public_tasks.end(),
+                       [](const auto& lhs, const auto& rhs) {
+                           return lhs.task_id < rhs.task_id;
+                       });
 
     outstanding_owners_ = next_outstanding_owners;
     outstanding_bytes_ = next_outstanding_bytes;
@@ -475,17 +523,10 @@ Status LocalTransferAdmissionQueue::retireBatch(uint64_t batch_token) {
         return Status::InvalidArgument("invalid batch token" LOC_MARK);
     }
 
-    const PublicTaskKey batch_begin{batch_token, 0};
-    auto public_begin = public_to_owner_.lower_bound(batch_begin);
-    auto public_end = public_to_owner_.upper_bound(
-        {batch_token, std::numeric_limits<size_t>::max()});
+    auto batch_it = batch_index_.find(batch_token);
+    if (batch_it == batch_index_.end()) return Status::OK();
 
-    std::set<QueueOwnerId> owner_ids;
-    for (auto it = public_begin; it != public_end; ++it) {
-        owner_ids.insert(it->second);
-    }
-
-    for (const auto owner_id : owner_ids) {
+    for (const auto owner_id : batch_it->second.owner_ids) {
         auto owner_it = owners_.find(owner_id);
         if (owner_it == owners_.end()) {
             return Status::InternalError(
@@ -503,10 +544,10 @@ Status LocalTransferAdmissionQueue::retireBatch(uint64_t batch_token) {
         }
     }
 
-    for (const auto owner_id : owner_ids) {
+    for (const auto owner_id : batch_it->second.owner_ids) {
         owners_.erase(owner_id);
     }
-    public_to_owner_.erase(public_begin, public_end);
+    batch_index_.erase(batch_it);
     return Status::OK();
 }
 
@@ -516,11 +557,21 @@ Status LocalTransferAdmissionQueue::resolveOwner(uint64_t batch_token,
     if (batch_token == 0) {
         return Status::InvalidArgument("invalid batch token" LOC_MARK);
     }
-    auto it = public_to_owner_.find({batch_token, public_task_id});
-    if (it == public_to_owner_.end()) {
+    auto batch_it = batch_index_.find(batch_token);
+    if (batch_it == batch_index_.end()) {
         return Status::InvalidEntry("public task id not found" LOC_MARK);
     }
-    owner_id = it->second;
+    auto public_it =
+        std::lower_bound(batch_it->second.public_tasks.begin(),
+                         batch_it->second.public_tasks.end(), public_task_id,
+                         [](const auto& public_task, size_t task_id) {
+                             return public_task.task_id < task_id;
+                         });
+    if (public_it == batch_it->second.public_tasks.end() ||
+        public_it->task_id != public_task_id) {
+        return Status::InvalidEntry("public task id not found" LOC_MARK);
+    }
+    owner_id = public_it->owner_id;
     return Status::OK();
 }
 

--- a/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
@@ -26,10 +26,6 @@ namespace {
 struct PendingPublicTask {
     size_t task_id{0};
     size_t owner_index{0};
-
-    bool operator<(const PendingPublicTask& other) const {
-        return task_id < other.task_id;
-    }
 };
 
 // Sort key for EDF: owners without a deadline (0) sort after all deadlined
@@ -88,16 +84,6 @@ Status validateLimits(const QueueLimits& limits) {
 }
 
 }  // namespace
-
-bool LocalTransferAdmissionQueue::hasPublicTask(const BatchIndex& batch_index,
-                                                size_t task_id) {
-    auto it = std::lower_bound(batch_index.public_tasks.begin(),
-                               batch_index.public_tasks.end(), task_id,
-                               [](const auto& public_task, size_t key) {
-                                   return public_task.task_id < key;
-                               });
-    return it != batch_index.public_tasks.end() && it->task_id == task_id;
-}
 
 size_t LocalTransferAdmissionQueue::DispatchScheduler::laneForKind(
     QueueOwnerKind kind) {
@@ -251,14 +237,29 @@ Status LocalTransferAdmissionQueue::tryAdmit(
         }
     }
 
-    std::sort(public_tasks.begin(), public_tasks.end());
-    const auto duplicate_public_task =
-        std::adjacent_find(public_tasks.begin(), public_tasks.end(),
-                           [](const auto& lhs, const auto& rhs) {
-                               return lhs.task_id == rhs.task_id;
-                           });
-    if (duplicate_public_task != public_tasks.end()) {
-        return Status::InvalidArgument("duplicate public task id" LOC_MARK);
+    size_t first_public_task_id = std::numeric_limits<size_t>::max();
+    size_t public_task_extent = 0;
+    for (const auto& public_task : public_tasks) {
+        size_t task_extent = 0;
+        CHECK_STATUS(checkedAdd(public_task.task_id, 1, task_extent));
+        first_public_task_id =
+            std::min(first_public_task_id, public_task.task_id);
+        public_task_extent = std::max(public_task_extent, task_extent);
+    }
+
+    if (public_task_extent - first_public_task_id != public_tasks.size()) {
+        return Status::InvalidArgument(
+            "public task ids must form a contiguous range" LOC_MARK);
+    }
+    std::vector<size_t> pending_owner_indices(public_tasks.size(),
+                                              submit.owners.size());
+    for (const auto& public_task : public_tasks) {
+        auto& owner_index =
+            pending_owner_indices[public_task.task_id - first_public_task_id];
+        if (owner_index != submit.owners.size()) {
+            return Status::InvalidArgument("duplicate public task id" LOC_MARK);
+        }
+        owner_index = public_task.owner_index;
     }
 
     if (public_tasks.size() > submit.batch_slots_left) {
@@ -269,7 +270,9 @@ Status LocalTransferAdmissionQueue::tryAdmit(
     auto batch_it = batch_index_.find(submit.batch_token);
     if (batch_it != batch_index_.end()) {
         for (const auto& public_task : public_tasks) {
-            if (hasPublicTask(batch_it->second, public_task.task_id)) {
+            if (public_task.task_id <
+                    batch_it->second.public_task_owners.size() &&
+                batch_it->second.public_task_owners[public_task.task_id] != 0) {
                 return Status::InvalidEntry(
                     "public task id already admitted" LOC_MARK);
             }
@@ -310,13 +313,8 @@ Status LocalTransferAdmissionQueue::tryAdmit(
     }
 
     admitted_owner_ids.reserve(submit.owners.size());
-    owners_.reserve(owners_.size() + submit.owners.size());
     auto& batch_index =
         batch_index_.try_emplace(submit.batch_token).first->second;
-    batch_index.owner_ids.reserve(batch_index.owner_ids.size() +
-                                  submit.owners.size());
-    batch_index.public_tasks.reserve(batch_index.public_tasks.size() +
-                                     public_tasks.size());
 
     std::vector<QueueOwnerId> owner_ids;
     owner_ids.reserve(submit.owners.size());
@@ -334,17 +332,14 @@ Status LocalTransferAdmissionQueue::tryAdmit(
                            owner_input.kind, limits_.deadline_aware, owners_);
         admitted_owner_ids.push_back(owner_id);
     }
-    const auto public_task_begin = batch_index.public_tasks.size();
-    for (const auto& public_task : public_tasks) {
-        batch_index.public_tasks.push_back(
-            {public_task.task_id, owner_ids[public_task.owner_index]});
+    if (batch_index.public_task_owners.size() < public_task_extent) {
+        batch_index.public_task_owners.resize(public_task_extent, 0);
     }
-    std::inplace_merge(batch_index.public_tasks.begin(),
-                       batch_index.public_tasks.begin() + public_task_begin,
-                       batch_index.public_tasks.end(),
-                       [](const auto& lhs, const auto& rhs) {
-                           return lhs.task_id < rhs.task_id;
-                       });
+    for (size_t offset = 0; offset < pending_owner_indices.size(); ++offset) {
+        const auto task_id = first_public_task_id + offset;
+        const auto owner_index = pending_owner_indices[offset];
+        batch_index.public_task_owners[task_id] = owner_ids[owner_index];
+    }
 
     outstanding_owners_ = next_outstanding_owners;
     outstanding_bytes_ = next_outstanding_bytes;
@@ -561,17 +556,11 @@ Status LocalTransferAdmissionQueue::resolveOwner(uint64_t batch_token,
     if (batch_it == batch_index_.end()) {
         return Status::InvalidEntry("public task id not found" LOC_MARK);
     }
-    auto public_it =
-        std::lower_bound(batch_it->second.public_tasks.begin(),
-                         batch_it->second.public_tasks.end(), public_task_id,
-                         [](const auto& public_task, size_t task_id) {
-                             return public_task.task_id < task_id;
-                         });
-    if (public_it == batch_it->second.public_tasks.end() ||
-        public_it->task_id != public_task_id) {
+    if (public_task_id >= batch_it->second.public_task_owners.size() ||
+        batch_it->second.public_task_owners[public_task_id] == 0) {
         return Status::InvalidEntry("public task id not found" LOC_MARK);
     }
-    owner_id = public_it->owner_id;
+    owner_id = batch_it->second.public_task_owners[public_task_id];
     return Status::OK();
 }
 

--- a/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
@@ -50,6 +50,16 @@ bool isSupportedOwnerKind(QueueOwnerKind kind) {
     return false;
 }
 
+bool isSupportedRequestPriority(int priority) {
+    switch (priority) {
+        case PRIO_HIGH:
+        case PRIO_MEDIUM:
+        case PRIO_LOW:
+            return true;
+    }
+    return false;
+}
+
 Status checkedAdd(size_t lhs, size_t rhs, size_t& out) {
     if (rhs > std::numeric_limits<size_t>::max() - lhs) {
         return Status::InvalidArgument(
@@ -73,6 +83,100 @@ Status validateLimits(const QueueLimits& limits) {
 
 }  // namespace
 
+size_t LocalTransferAdmissionQueue::DispatchScheduler::laneForKind(
+    QueueOwnerKind kind) {
+    return kind == QueueOwnerKind::StagingInternal
+               ? static_cast<size_t>(KindLane::StagingInternal)
+               : static_cast<size_t>(KindLane::User);
+}
+
+void LocalTransferAdmissionQueue::DispatchScheduler::enqueue(
+    QueueOwnerId owner_id, int priority, QueueOwnerKind kind,
+    bool deadline_aware, const OwnerMap& owners) {
+    auto& queue = classes_[priority].lanes[laneForKind(kind)].queue;
+    if (!deadline_aware) {
+        queue.push_back(owner_id);
+        return;
+    }
+
+    const auto owner_it = owners.find(owner_id);
+    const uint64_t key =
+        owner_it == owners.end()
+            ? std::numeric_limits<uint64_t>::max()
+            : deadlineKey(owner_it->second.request.deadline_ns);
+    const auto pos = std::upper_bound(
+        queue.begin(), queue.end(), key, [&owners](uint64_t deadline,
+                                                   QueueOwnerId queued_id) {
+            const auto queued_it = owners.find(queued_id);
+            const uint64_t queued_deadline =
+                queued_it == owners.end()
+                    ? std::numeric_limits<uint64_t>::max()
+                    : deadlineKey(queued_it->second.request.deadline_ns);
+            return deadline < queued_deadline;
+        });
+    queue.insert(pos, owner_id);
+}
+
+void LocalTransferAdmissionQueue::DispatchScheduler::promoteDeadlineUrgentOwners(
+    uint64_t now_ns, uint64_t promotion_slack_ns, const OwnerMap& owners) {
+    if (promotion_slack_ns == 0) return;
+
+    for (auto& priority_class : classes_) {
+        for (auto& lane : priority_class.lanes) {
+            std::stable_partition(
+                lane.queue.begin(), lane.queue.end(), [&](QueueOwnerId id) {
+                    const auto owner_it = owners.find(id);
+                    if (owner_it == owners.end() ||
+                        owner_it->second.state != QueueState::Queued) {
+                        return false;
+                    }
+                    const uint64_t deadline =
+                        owner_it->second.request.deadline_ns;
+                    return deadline > now_ns &&
+                           deadline - now_ns < promotion_slack_ns;
+                });
+        }
+    }
+}
+
+LocalTransferAdmissionQueue::DispatchScheduler::Candidate
+LocalTransferAdmissionQueue::DispatchScheduler::next(const OwnerMap& owners) {
+    for (size_t priority = PRIO_HIGH; priority < classes_.size(); ++priority) {
+        auto& priority_class = classes_[priority];
+        for (size_t offset = 0; offset < priority_class.lanes.size(); ++offset) {
+            const size_t lane =
+                (priority_class.next_kind_lane + offset) %
+                priority_class.lanes.size();
+            auto& queue = priority_class.lanes[lane].queue;
+            while (!queue.empty()) {
+                const auto owner_it = owners.find(queue.front());
+                if (owner_it != owners.end() &&
+                    owner_it->second.state == QueueState::Queued) {
+                    return Candidate{queue.front(), priority, lane, true};
+                }
+                queue.pop_front();
+            }
+        }
+    }
+    return {};
+}
+
+void LocalTransferAdmissionQueue::DispatchScheduler::consume(
+    const Candidate& candidate) {
+    if (!candidate.found || candidate.priority >= classes_.size() ||
+        candidate.lane >= classes_[candidate.priority].lanes.size()) {
+        return;
+    }
+
+    auto& priority_class = classes_[candidate.priority];
+    auto& queue = priority_class.lanes[candidate.lane].queue;
+    if (!queue.empty() && queue.front() == candidate.owner_id) {
+        queue.pop_front();
+        priority_class.next_kind_lane =
+            (candidate.lane + 1) % priority_class.lanes.size();
+    }
+}
+
 LocalTransferAdmissionQueue::LocalTransferAdmissionQueue(QueueLimits limits)
     : limits_(limits), limits_status_(validateLimits(limits)) {}
 
@@ -94,6 +198,10 @@ Status LocalTransferAdmissionQueue::tryAdmit(
         if (!isSupportedOwnerKind(owner.kind)) {
             return Status::InvalidArgument(
                 "unsupported queue owner kind" LOC_MARK);
+        }
+        if (!isSupportedRequestPriority(owner.request.priority)) {
+            return Status::InvalidArgument(
+                "unsupported queue request priority" LOC_MARK);
         }
         if (owner.request.length == 0) {
             return Status::InvalidArgument("empty transfer request" LOC_MARK);
@@ -185,27 +293,8 @@ Status LocalTransferAdmissionQueue::tryAdmit(
         for (const auto derived_task_id : owner_input.derived_task_ids) {
             public_to_owner_[{submit.batch_token, derived_task_id}] = owner_id;
         }
-        // RFC #2519 step 2: keep fifo_ ordered on admission so pickForDispatch
-        // never has to re-sort. Default (deadline_aware == false) appends in
-        // strict FIFO. When deadline-aware, insert at the earliest-deadline-
-        // first position; upper_bound places a new owner *after* existing
-        // owners with the same deadline, preserving FIFO order among ties.
-        if (limits_.deadline_aware) {
-            const uint64_t key = deadlineKey(owner.request.deadline_ns);
-            auto pos = std::upper_bound(
-                fifo_.begin(), fifo_.end(), key,
-                [this](uint64_t k, QueueOwnerId id) {
-                    auto it = owners_.find(id);
-                    uint64_t d =
-                        (it == owners_.end())
-                            ? std::numeric_limits<uint64_t>::max()
-                            : deadlineKey(it->second.request.deadline_ns);
-                    return k < d;
-                });
-            fifo_.insert(pos, owner_id);
-        } else {
-            fifo_.push_back(owner_id);
-        }
+        scheduler_.enqueue(owner_id, owner_input.request.priority,
+                           owner_input.kind, limits_.deadline_aware, owners_);
         admitted_owner_ids.push_back(owner_id);
     }
 
@@ -231,12 +320,9 @@ std::vector<QueueOwnerId> LocalTransferAdmissionQueue::pickForDispatch(
     std::vector<QueueOwnerId> picked;
     if (max_owners == 0 || max_bytes == 0) return picked;
 
-    // RFC #2519 step 2 (opt-in): earliest-deadline-first dispatch. When
-    // deadline_aware, fifo_ is kept EDF-ordered at admission time (see
-    // tryAdmit's ordered insert), so there is nothing to sort here — we just
-    // consume from the front. This keeps the hot dispatch path O(picked)
-    // instead of re-sorting the whole queue on every call. Default
-    // (deadline_aware == false) is plain FIFO.
+    // RFC #2519 step 2 (opt-in): each priority/kind lane is kept EDF-ordered
+    // at admission time, so the scheduler only consumes lane fronts here.
+    // Request priority remains the outer ordering rule.
     //
     // RFC #2519 step 3 (opt-in): drop is active only when a positive threshold,
     // deadline awareness, and a bandwidth provider are all present.
@@ -258,20 +344,11 @@ std::vector<QueueOwnerId> LocalTransferAdmissionQueue::pickForDispatch(
                              .count()))
             : 0;
 
-    // Deadline proximity promotion: partition fifo_ so owners with critical
-    // slack (deadline approaching within promotion_slack_ns) appear before
-    // owners with comfortable slack or no deadline. stable_partition preserves
-    // relative EDF order within each group.
+    // Deadline proximity promotion runs within each priority/kind lane.
     if (promotion_enabled) {
-        std::stable_partition(fifo_.begin(), fifo_.end(), [&](QueueOwnerId id) {
-            auto it = owners_.find(id);
-            if (it == owners_.end() || it->second.state != QueueState::Queued) {
-                return false;
-            }
-            const uint64_t dl = it->second.request.deadline_ns;
-            if (dl == 0 || dl <= now_ns) return false;
-            return (dl - now_ns) < limits_.promotion_slack_ns;
-        });
+        scheduler_.promoteDeadlineUrgentOwners(now_ns,
+                                               limits_.promotion_slack_ns,
+                                               owners_);
     }
 
     // Predicted MLU = predicted_transfer_time / remaining_window. Returns true
@@ -305,25 +382,18 @@ std::vector<QueueOwnerId> LocalTransferAdmissionQueue::pickForDispatch(
 
     size_t used_owners = 0;
     size_t used_bytes = 0;
-    while (!fifo_.empty() && used_owners < max_owners) {
-        auto owner_id = fifo_.front();
-        auto owner_it = owners_.find(owner_id);
-        // Non-queued entries should not normally remain in fifo_, but stale
-        // entries are skipped defensively so retireBatch() does not need to
-        // scan the dispatch queue.
-        if (owner_it == owners_.end() ||
-            owner_it->second.state != QueueState::Queued) {
-            fifo_.pop_front();
-            continue;
-        }
+    while (used_owners < max_owners && used_bytes < max_bytes) {
+        const auto candidate = scheduler_.next(owners_);
+        if (!candidate.found) break;
 
-        // Step 3: an owner predicted to miss its deadline is dropped (not
-        // dispatched) and does not consume the dispatch budget. Because the
-        // queue is EDF-ordered, later owners have looser deadlines, so we keep
-        // scanning rather than stopping.
+        auto owner_it = owners_.find(candidate.owner_id);
+        if (owner_it == owners_.end()) continue;
+
+        // Step 3: a dropped owner does not consume dispatch budget. Continue
+        // at the same priority so an infeasible head cannot block its lane.
         if (shouldDrop(owner_it->second)) {
-            fifo_.pop_front();
-            dropOwner(owner_id, owner_it->second);
+            scheduler_.consume(candidate);
+            dropOwner(candidate.owner_id, owner_it->second);
             continue;
         }
 
@@ -331,9 +401,9 @@ std::vector<QueueOwnerId> LocalTransferAdmissionQueue::pickForDispatch(
         const size_t remaining_bytes = max_bytes - used_bytes;
         if (owner.request.length > remaining_bytes) break;
 
-        fifo_.pop_front();
+        scheduler_.consume(candidate);
         owner_it->second.state = QueueState::Dispatching;
-        picked.push_back(owner_id);
+        picked.push_back(candidate.owner_id);
         ++used_owners;
         used_bytes += owner.request.length;
     }

--- a/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
@@ -141,7 +141,16 @@ Status ControlClient::pinStageBuffer(const std::string& server_addr,
     request_raw = j.dump();
     CHECK_STATUS(
         tl_rpc_agent.call(server_addr, Pin, request_raw, response_raw));
-    addr = json::parse(response_raw).get<uint64_t>();
+    if (response_raw.empty()) {
+        return Status::RpcServiceError(
+            "pin stage buffer returned empty response" LOC_MARK);
+    }
+    json response = json::parse(response_raw);
+    if (response.is_object() && response.contains("error")) {
+        return Status::RpcServiceError(response["error"].get<std::string>() +
+                                       LOC_MARK);
+    }
+    addr = response.get<uint64_t>();
     return Status::OK();
 }
 
@@ -317,9 +326,14 @@ void ControlService::onDelegate(const std::string_view& request,
 void ControlService::onPinStageBuffer(const std::string_view& request,
                                       std::string& response) {
     std::string location = json::parse(request).get<std::string>();
-    uint64_t addr = impl_->lockStageBuffer(location);
-    json j = addr;
-    response = j.dump();
+    uint64_t addr = 0;
+    auto status = impl_->pinStageBuffer(location, addr);
+    if (!status.ok()) {
+        json j = {{"error", status.ToString()}};
+        response = j.dump();
+        return;
+    }
+    response = json(addr).dump();
 }
 
 void ControlService::onUnpinStageBuffer(const std::string_view& request,

--- a/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
@@ -145,7 +145,11 @@ Status ControlClient::pinStageBuffer(const std::string& server_addr,
         return Status::RpcServiceError(
             "pin stage buffer returned empty response" LOC_MARK);
     }
-    json response = json::parse(response_raw);
+    json response = json::parse(response_raw, nullptr, false);
+    if (response.is_discarded()) {
+        return Status::RpcServiceError(
+            "failed to parse pin stage buffer response" LOC_MARK);
+    }
     if (response.is_object() && response.contains("error")) {
         return Status::RpcServiceError(response["error"].get<std::string>() +
                                        LOC_MARK);

--- a/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
@@ -102,7 +102,8 @@ inline void to_json(json& j, const Request& r) {
              {"source", reinterpret_cast<uintptr_t>(r.source)},
              {"target_id", r.target_id},
              {"target_offset", r.target_offset},
-             {"length", r.length}};
+             {"length", r.length},
+             {"priority", r.priority}};
 }
 
 inline void from_json(const json& j, Request& r) {
@@ -118,6 +119,7 @@ inline void from_json(const json& j, Request& r) {
     r.target_id = j.at("target_id").get<int>();
     r.target_offset = j.at("target_offset").get<uint64_t>();
     r.length = j.at("length").get<size_t>();
+    r.priority = j.value("priority", static_cast<int>(PRIO_HIGH));
 }
 
 Status ControlClient::delegate(const std::string& server_addr,
@@ -226,7 +228,7 @@ Status ControlService::start(uint16_t& port, bool ipv6_) {
 
 void ControlService::onGetSegmentDesc(const std::string_view& request,
                                       std::string& response) {
-    // Re-use the cached dump shared across concurrent peer fetches.
+    // Reuse the cached dump shared across concurrent peer fetches.
     auto cached = manager_->getLocalDumpedJson();
     response = *cached;
 }

--- a/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
@@ -238,7 +238,11 @@ Status ControlClient::pinStageBuffer(const std::string& server_addr,
         return Status::RpcServiceError(
             "pin stage buffer returned empty response" LOC_MARK);
     }
-    json response = json::parse(response_raw);
+    json response = json::parse(response_raw, nullptr, false);
+    if (response.is_discarded()) {
+        return Status::RpcServiceError(
+            "failed to parse pin stage buffer response" LOC_MARK);
+    }
     if (response.is_object() && response.contains("error")) {
         return Status::RpcServiceError(response["error"].get<std::string>() +
                                        LOC_MARK);

--- a/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
@@ -234,7 +234,16 @@ Status ControlClient::pinStageBuffer(const std::string& server_addr,
     request_raw = j.dump();
     CHECK_STATUS(
         tl_rpc_agent.call(server_addr, Pin, request_raw, response_raw));
-    addr = json::parse(response_raw).get<uint64_t>();
+    if (response_raw.empty()) {
+        return Status::RpcServiceError(
+            "pin stage buffer returned empty response" LOC_MARK);
+    }
+    json response = json::parse(response_raw);
+    if (response.is_object() && response.contains("error")) {
+        return Status::RpcServiceError(response["error"].get<std::string>() +
+                                       LOC_MARK);
+    }
+    addr = response.get<uint64_t>();
     return Status::OK();
 }
 
@@ -617,9 +626,14 @@ void ControlService::onDelegate(const std::string_view& request,
 void ControlService::onPinStageBuffer(const std::string_view& request,
                                       std::string& response) {
     std::string location = json::parse(request).get<std::string>();
-    uint64_t addr = impl_->lockStageBuffer(location);
-    json j = addr;
-    response = j.dump();
+    uint64_t addr = 0;
+    auto status = impl_->pinStageBuffer(location, addr);
+    if (!status.ok()) {
+        json j = {{"error", status.ToString()}};
+        response = j.dump();
+        return;
+    }
+    response = json(addr).dump();
 }
 
 void ControlService::onUnpinStageBuffer(const std::string_view& request,

--- a/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
@@ -175,7 +175,8 @@ inline void to_json(json& j, const Request& r) {
              {"source", reinterpret_cast<uintptr_t>(r.source)},
              {"target_id", r.target_id},
              {"target_offset", r.target_offset},
-             {"length", r.length}};
+             {"length", r.length},
+             {"priority", r.priority}};
 }
 
 inline void from_json(const json& j, Request& r) {
@@ -191,6 +192,7 @@ inline void from_json(const json& j, Request& r) {
     r.target_id = j.at("target_id").get<int>();
     r.target_offset = j.at("target_offset").get<uint64_t>();
     r.length = j.at("length").get<size_t>();
+    r.priority = j.value("priority", static_cast<int>(PRIO_HIGH));
 }
 
 Status ControlClient::delegate(const std::string& server_addr,

--- a/mooncake-transfer-engine/tent/src/runtime/progress_worker.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/progress_worker.cpp
@@ -62,7 +62,7 @@ void ProgressWorker::notifyRuntimeQueueReady() {
     if (!running_.load(std::memory_order_acquire)) return;
     {
         std::lock_guard<std::mutex> lk(mu_);
-        if (queue_ready_ || !order_.empty()) return;
+        if (queue_ready_) return;
         queue_ready_ = true;
     }
     cv_.notify_one();

--- a/mooncake-transfer-engine/tent/src/runtime/progress_worker.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/progress_worker.cpp
@@ -62,6 +62,7 @@ void ProgressWorker::notifyRuntimeQueueReady() {
     if (!running_.load(std::memory_order_acquire)) return;
     {
         std::lock_guard<std::mutex> lk(mu_);
+        if (queue_ready_ || !order_.empty()) return;
         queue_ready_ = true;
     }
     cv_.notify_one();
@@ -69,7 +70,7 @@ void ProgressWorker::notifyRuntimeQueueReady() {
 
 void ProgressWorker::runner() {
     while (true) {
-        BatchID batch_id = 0;
+        std::deque<BatchID> batch_ids;
         bool queue_ready = false;
         bool fallback_due = false;
         bool queue_active = impl_->hasActiveRuntimeQueue();
@@ -90,31 +91,30 @@ void ProgressWorker::runner() {
             if (!running_.load(std::memory_order_acquire)) return;
             queue_ready = queue_ready_;
             queue_ready_ = false;
-            if (!order_.empty()) {
-                batch_id = order_.front();
-                order_.pop_front();
-                queued_.erase(batch_id);
-            }
+            batch_ids.swap(order_);
+            queued_.clear();
         }
+        bool did_work = false;
         if (queue_ready) {
             (void)impl_->progressRuntimeQueue();
-            (void)impl_->lazyFreeBatch();
+            did_work = true;
         }
         // progressBatch acquires the engine's progress_mutex_ and silently
         // returns InvalidArgument if the batch was freed before we got here.
         // PENDING means "kick again later"; the next notify wakes us up.
         // Terminal states are observed here; lazyFreeBatch reclaims a batch
         // only if freeBatch has already marked it free_requested.
-        if (batch_id) {
+        for (const auto batch_id : batch_ids) {
+            if (!batch_id) continue;
             TransferStatus s;
             (void)impl_->progressBatch(batch_id, s);
-            (void)impl_->progressRuntimeQueue();
-            (void)impl_->lazyFreeBatch();
+            did_work = true;
         }
-        if (fallback_due && !queue_ready && !batch_id && queue_active) {
+        if (fallback_due && !queue_ready && batch_ids.empty() && queue_active) {
             (void)impl_->progressRuntimeQueue();
-            (void)impl_->lazyFreeBatch();
+            did_work = true;
         }
+        if (did_work) (void)impl_->lazyFreeBatch();
     }
 }
 

--- a/mooncake-transfer-engine/tent/src/runtime/progress_worker.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/progress_worker.cpp
@@ -62,6 +62,7 @@ void ProgressWorker::notifyRuntimeQueueReady() {
     if (!running_.load(std::memory_order_acquire)) return;
     {
         std::lock_guard<std::mutex> lk(mu_);
+        if (queue_ready_ || !order_.empty()) return;
         queue_ready_ = true;
     }
     cv_.notify_one();
@@ -69,7 +70,7 @@ void ProgressWorker::notifyRuntimeQueueReady() {
 
 void ProgressWorker::runner() {
     while (true) {
-        BatchID batch_id = 0;
+        std::deque<BatchID> batch_ids;
         bool queue_ready = false;
         bool fallback_due = false;
         bool queue_active = impl_->hasActiveRuntimeQueue();
@@ -90,34 +91,33 @@ void ProgressWorker::runner() {
             if (!running_.load(std::memory_order_acquire)) return;
             queue_ready = queue_ready_;
             queue_ready_ = false;
-            if (!order_.empty()) {
-                batch_id = order_.front();
-                order_.pop_front();
-                queued_.erase(batch_id);
-            }
+            batch_ids.swap(order_);
+            queued_.clear();
         }
         // lazyFreeBatch reports the first batch it could not reclaim and logs
         // the skip itself (rate-limited); the worker only sweeps, so the
         // status is intentionally dropped at these call sites.
+        bool did_work = false;
         if (queue_ready) {
             (void)impl_->progressRuntimeQueue();
-            (void)impl_->lazyFreeBatch();
+            did_work = true;
         }
         // progressBatch acquires the engine's progress_mutex_ and silently
         // returns InvalidArgument if the batch was freed before we got here.
         // PENDING means "kick again later"; the next notify wakes us up.
         // Terminal states are observed here; lazyFreeBatch reclaims a batch
         // only if freeBatch has already marked it free_requested.
-        if (batch_id) {
+        for (const auto batch_id : batch_ids) {
+            if (!batch_id) continue;
             TransferStatus s;
             (void)impl_->progressBatch(batch_id, s);
-            (void)impl_->progressRuntimeQueue();
-            (void)impl_->lazyFreeBatch();
+            did_work = true;
         }
-        if (fallback_due && !queue_ready && !batch_id && queue_active) {
+        if (fallback_due && !queue_ready && batch_ids.empty() && queue_active) {
             (void)impl_->progressRuntimeQueue();
-            (void)impl_->lazyFreeBatch();
+            did_work = true;
         }
+        if (did_work) (void)impl_->lazyFreeBatch();
     }
 }
 

--- a/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
@@ -190,7 +190,8 @@ Status ProxyManager::submit(TaskInfo* task, BatchID batch,
     staging_task.batch = batch;
     staging_task.params = params;
     static std::atomic<size_t> next_queue_index(0);
-    thread_local size_t id = next_queue_index.fetch_add(1) % kShards;
+    const size_t id =
+        next_queue_index.fetch_add(1, std::memory_order_relaxed) % kShards;
     {
         std::lock_guard<std::mutex> lk(shards_[id].mu);
         if (max_queued_tasks_per_shard_ > 0 &&

--- a/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
@@ -51,12 +51,17 @@ Status ProxyManager::deconstruct() {
         shards_[i].cv.notify_all();
         if (shards_[i].thread.joinable()) shards_[i].thread.join();
     }
-    for (auto entry : stage_buffers_) {
+
+    std::unordered_map<std::string, StageBuffers> stage_buffers;
+    {
+        std::lock_guard<std::mutex> lk(stage_buffers_mu_);
+        stage_buffers = std::move(stage_buffers_);
+    }
+    for (auto& entry : stage_buffers) {
         impl_->unregisterLocalMemory(entry.second.chunks);
         impl_->freeLocalMemory(entry.second.chunks);
         delete[] entry.second.bitmap;
     }
-    stage_buffers_.clear();
     return Status::OK();
 }
 
@@ -609,7 +614,7 @@ Status ProxyManager::transferSync(StagingTask& task, StageBufferCache* cache) {
     return Status::OK();
 }
 
-Status ProxyManager::allocateStageBuffers(const std::string& location) {
+Status ProxyManager::allocateStageBuffersLocked(const std::string& location) {
     if (stage_buffers_.count(location)) return Status::OK();
     StageBuffers buf;
     auto total_size = kChunkSize * kChunkCount;
@@ -624,6 +629,7 @@ Status ProxyManager::allocateStageBuffers(const std::string& location) {
 }
 
 Status ProxyManager::freeStageBuffers(const std::string& location) {
+    std::lock_guard<std::mutex> lk(stage_buffers_mu_);
     auto it = stage_buffers_.find(location);
     if (it == stage_buffers_.end())
         return Status::InvalidArgument("Stage buffer not allocated" LOC_MARK);
@@ -636,9 +642,10 @@ Status ProxyManager::freeStageBuffers(const std::string& location) {
 
 Status ProxyManager::pinStageBuffer(const std::string& location,
                                     uint64_t& addr) {
+    std::lock_guard<std::mutex> lk(stage_buffers_mu_);
     auto it = stage_buffers_.find(location);
     if (it == stage_buffers_.end()) {
-        CHECK_STATUS(allocateStageBuffers(location));
+        CHECK_STATUS(allocateStageBuffersLocked(location));
         it = stage_buffers_.find(location);
     }
 
@@ -654,6 +661,7 @@ Status ProxyManager::pinStageBuffer(const std::string& location,
 }
 
 Status ProxyManager::unpinStageBuffer(uint64_t addr) {
+    std::lock_guard<std::mutex> lk(stage_buffers_mu_);
     for (auto& [location, buf] : stage_buffers_) {
         auto base = reinterpret_cast<uint64_t>(buf.chunks);
         auto end = base + kChunkSize * kChunkCount;

--- a/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
@@ -25,7 +25,7 @@ ProxyManager::ProxyManager(TransferEngineImpl* impl,
                            size_t max_queued_tasks_per_shard)
     : ProxyManager(impl, max_queued_tasks_per_shard, true) {}
 
-std::unique_ptr<ProxyManager> ProxyManager::createWithoutWorkersForTest(
+std::unique_ptr<ProxyManager> ProxyManager::createForTest(
     TransferEngineImpl* impl, size_t max_queued_tasks_per_shard) {
     return std::unique_ptr<ProxyManager>(
         new ProxyManager(impl, max_queued_tasks_per_shard, false));

--- a/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
@@ -21,12 +21,25 @@
 
 namespace mooncake {
 namespace tent {
-ProxyManager::ProxyManager(TransferEngineImpl* impl, size_t chunk_size,
-                           size_t chunk_count)
-    : chunk_size_(chunk_size), chunk_count_(chunk_count), impl_(impl) {
+ProxyManager::ProxyManager(TransferEngineImpl* impl,
+                           size_t max_queued_tasks_per_shard)
+    : ProxyManager(impl, max_queued_tasks_per_shard, true) {}
+
+std::unique_ptr<ProxyManager> ProxyManager::createWithoutWorkersForTest(
+    TransferEngineImpl* impl, size_t max_queued_tasks_per_shard) {
+    return std::unique_ptr<ProxyManager>(
+        new ProxyManager(impl, max_queued_tasks_per_shard, false));
+}
+
+ProxyManager::ProxyManager(TransferEngineImpl* impl,
+                           size_t max_queued_tasks_per_shard,
+                           bool start_workers)
+    : max_queued_tasks_per_shard_(max_queued_tasks_per_shard), impl_(impl) {
     running_ = true;
-    for (size_t i = 0; i < kShards; ++i) {
-        shards_[i].thread = std::thread(&ProxyManager::runner, this, i);
+    if (start_workers) {
+        for (size_t i = 0; i < kShards; ++i) {
+            shards_[i].thread = std::thread(&ProxyManager::runner, this, i);
+        }
     }
 }
 
@@ -36,7 +49,7 @@ Status ProxyManager::deconstruct() {
     running_ = false;
     for (size_t i = 0; i < kShards; ++i) {
         shards_[i].cv.notify_all();
-        shards_[i].thread.join();
+        if (shards_[i].thread.joinable()) shards_[i].thread.join();
     }
     for (auto entry : stage_buffers_) {
         impl_->unregisterLocalMemory(entry.second.chunks);
@@ -164,16 +177,25 @@ Status ProxyManager::waitCrossStage(const Request& request,
 
 Status ProxyManager::submit(TaskInfo* task, BatchID batch,
                             const std::vector<std::string>& params) {
+    if (!task || batch == 0) {
+        return Status::InvalidArgument("invalid staging task" LOC_MARK);
+    }
     StagingTask staging_task;
     staging_task.native = task;
     staging_task.batch = batch;
     staging_task.params = params;
-    task->staging_status = PENDING;
     static std::atomic<size_t> next_queue_index(0);
     thread_local size_t id = next_queue_index.fetch_add(1) % kShards;
     {
         std::lock_guard<std::mutex> lk(shards_[id].mu);
+        if (max_queued_tasks_per_shard_ > 0 &&
+            shards_[id].queued_tasks >= max_queued_tasks_per_shard_) {
+            return Status::TooManyRequests(
+                "staging proxy shard queue is full" LOC_MARK);
+        }
         shards_[id].queue.push(staging_task);
+        ++shards_[id].queued_tasks;
+        task->staging_status = PENDING;
     }
     shards_[id].cv.notify_one();
     return Status::OK();
@@ -262,6 +284,7 @@ void ProxyManager::runner(size_t id) {
 
             task = shard.queue.front();
             shard.queue.pop();
+            --shard.queued_tasks;
         }
 
         if (!task.native) continue;
@@ -280,8 +303,7 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
     auto server_addr = task.params[0];
     bool local_staging = !task.params[1].empty();
     bool remote_staging = !task.params[2].empty();
-    const size_t kStageBuffers =
-        std::min(chunk_count_, static_cast<size_t>(16));
+    const size_t kStageBuffers = std::min(kChunkCount, static_cast<size_t>(16));
     uint64_t local_stage_buffer[kStageBuffers],
         remote_stage_buffer[kStageBuffers];
     if (local_staging) {
@@ -329,10 +351,10 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
     std::unordered_set<uint64_t> local_locked;
     std::unordered_set<uint64_t> remote_locked;
 
-    for (size_t offset = 0; offset < request.length; offset += chunk_size_) {
+    for (size_t offset = 0; offset < request.length; offset += kChunkSize) {
         size_t id = chunks.size();
         Chunk chunk{offset,
-                    std::min(chunk_size_, request.length - offset),
+                    std::min(kChunkSize, request.length - offset),
                     local_staging ? local_stage_buffer[id % kStageBuffers]
                                   : (uint64_t)request.source + offset,
                     remote_staging ? remote_stage_buffer[id % kStageBuffers]
@@ -544,8 +566,8 @@ Status ProxyManager::transferSync(StagingTask& task, StageBufferCache* cache) {
             return Status::InternalError("Failed to pin remote stage buffer");
     }
 
-    for (size_t offset = 0; offset < request.length; offset += chunk_size_) {
-        size_t chunk_length = std::min(chunk_size_, request.length - offset);
+    for (size_t offset = 0; offset < request.length; offset += kChunkSize) {
+        size_t chunk_length = std::min(kChunkSize, request.length - offset);
 
         if (!local_staging)
             local_stage_buffer = (uint64_t)request.source + offset;
@@ -590,12 +612,12 @@ Status ProxyManager::transferSync(StagingTask& task, StageBufferCache* cache) {
 Status ProxyManager::allocateStageBuffers(const std::string& location) {
     if (stage_buffers_.count(location)) return Status::OK();
     StageBuffers buf;
-    auto total_size = chunk_size_ * chunk_count_;
+    auto total_size = kChunkSize * kChunkCount;
     CHECK_STATUS(
         impl_->allocateLocalMemory(&buf.chunks, total_size, location, true));
     CHECK_STATUS(impl_->registerLocalMemory(buf.chunks, total_size));
-    buf.bitmap = new std::atomic_flag[chunk_count_];
-    for (size_t i = 0; i < chunk_count_; ++i)
+    buf.bitmap = new std::atomic_flag[kChunkCount];
+    for (size_t i = 0; i < kChunkCount; ++i)
         buf.bitmap[i].clear(std::memory_order_relaxed);
     stage_buffers_[location] = std::move(buf);
     return Status::OK();
@@ -621,10 +643,10 @@ Status ProxyManager::pinStageBuffer(const std::string& location,
     }
 
     auto& buf = it->second;
-    for (size_t i = 0; i < chunk_count_; ++i) {
+    for (size_t i = 0; i < kChunkCount; ++i) {
         if (!buf.bitmap[i].test_and_set(std::memory_order_acquire)) {
             addr = reinterpret_cast<uint64_t>(static_cast<char*>(buf.chunks) +
-                                              i * chunk_size_);
+                                              i * kChunkSize);
             return Status::OK();
         }
     }
@@ -634,10 +656,10 @@ Status ProxyManager::pinStageBuffer(const std::string& location,
 Status ProxyManager::unpinStageBuffer(uint64_t addr) {
     for (auto& [location, buf] : stage_buffers_) {
         auto base = reinterpret_cast<uint64_t>(buf.chunks);
-        auto end = base + chunk_size_ * chunk_count_;
+        auto end = base + kChunkSize * kChunkCount;
         if (addr >= base && addr < end) {
-            size_t index = (addr - base) / chunk_size_;
-            if (index >= chunk_count_)
+            size_t index = (addr - base) / kChunkSize;
+            if (index >= kChunkCount)
                 return Status::InvalidArgument("Invalid buffer index");
             buf.bitmap[index].clear(std::memory_order_release);
             return Status::OK();

--- a/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
@@ -47,16 +47,54 @@ Status ProxyManager::deconstruct() {
     return Status::OK();
 }
 
-BatchID ProxyManager::submitCrossStage(const Request& request,
-                                       uint64_t local_stage_buffer,
-                                       uint64_t remote_stage_buffer,
-                                       uint64_t chunk_length) {
+Request ProxyManager::makeCrossStageRequest(const Request& request,
+                                            uint64_t local_stage_buffer,
+                                            uint64_t remote_stage_buffer,
+                                            uint64_t chunk_length) {
     Request inter_stage;
     inter_stage.opcode = request.opcode;
     inter_stage.source = (void*)local_stage_buffer;
     inter_stage.length = chunk_length;
     inter_stage.target_id = request.target_id;
     inter_stage.target_offset = remote_stage_buffer;
+    inter_stage.priority = request.priority;
+    return inter_stage;
+}
+
+Request ProxyManager::makeLocalStageRequest(const Request& request,
+                                            uint64_t local_stage_buffer,
+                                            uint64_t chunk_length,
+                                            uint64_t offset) {
+    Request local_stage;
+    local_stage.opcode = request.opcode;
+    local_stage.source = (uint8_t*)request.source + offset;
+    local_stage.length = chunk_length;
+    local_stage.target_id = LOCAL_SEGMENT_ID;
+    local_stage.target_offset = local_stage_buffer;
+    local_stage.priority = request.priority;
+    return local_stage;
+}
+
+Request ProxyManager::makeRemoteStageRequest(const Request& request,
+                                             uint64_t remote_stage_buffer,
+                                             uint64_t chunk_length,
+                                             uint64_t offset) {
+    Request remote_stage;
+    remote_stage.opcode = request.opcode;
+    remote_stage.source = (void*)remote_stage_buffer;
+    remote_stage.length = chunk_length;
+    remote_stage.target_id = LOCAL_SEGMENT_ID;
+    remote_stage.target_offset = request.target_offset + offset;
+    remote_stage.priority = request.priority;
+    return remote_stage;
+}
+
+BatchID ProxyManager::submitCrossStage(const Request& request,
+                                       uint64_t local_stage_buffer,
+                                       uint64_t remote_stage_buffer,
+                                       uint64_t chunk_length) {
+    auto inter_stage = makeCrossStageRequest(request, local_stage_buffer,
+                                             remote_stage_buffer, chunk_length);
     auto batch = impl_->allocateBatch(1);
     auto status = impl_->submitStagingTransfer(batch, {inter_stage});
     if (!status.ok()) {
@@ -71,12 +109,8 @@ BatchID ProxyManager::submitCrossStage(const Request& request,
 BatchID ProxyManager::submitLocalStage(const Request& request,
                                        uint64_t local_stage_buffer,
                                        uint64_t chunk_length, uint64_t offset) {
-    Request local_stage;
-    local_stage.opcode = request.opcode;
-    local_stage.source = (uint8_t*)request.source + offset;
-    local_stage.length = chunk_length;
-    local_stage.target_id = LOCAL_SEGMENT_ID;
-    local_stage.target_offset = local_stage_buffer;
+    auto local_stage = makeLocalStageRequest(request, local_stage_buffer,
+                                             chunk_length, offset);
     auto batch = impl_->allocateBatch(1);
     auto status = impl_->submitStagingTransfer(batch, {local_stage});
     if (!status.ok()) {
@@ -101,12 +135,8 @@ Status ProxyManager::waitRemoteStage(const std::string& server_addr,
                                      const Request& request,
                                      uint64_t remote_stage_buffer,
                                      uint64_t chunk_length, uint64_t offset) {
-    Request remote_stage;
-    remote_stage.opcode = request.opcode;
-    remote_stage.source = (void*)remote_stage_buffer;
-    remote_stage.length = chunk_length;
-    remote_stage.target_id = LOCAL_SEGMENT_ID;
-    remote_stage.target_offset = request.target_offset + offset;
+    auto remote_stage = makeRemoteStageRequest(request, remote_stage_buffer,
+                                               chunk_length, offset);
     return ControlClient::delegate(server_addr, remote_stage);
 }
 
@@ -115,12 +145,8 @@ void ProxyManager::submitRemoteStage(const std::string& server_addr,
                                      uint64_t remote_stage_buffer,
                                      uint64_t chunk_length, uint64_t offset,
                                      std::future<Status>& handle) {
-    Request remote_stage;
-    remote_stage.opcode = request.opcode;
-    remote_stage.source = (void*)remote_stage_buffer;
-    remote_stage.length = chunk_length;
-    remote_stage.target_id = LOCAL_SEGMENT_ID;
-    remote_stage.target_offset = request.target_offset + offset;
+    auto remote_stage = makeRemoteStageRequest(request, remote_stage_buffer,
+                                               chunk_length, offset);
     handle = delegate_pool_.enqueue([server_addr, remote_stage]() {
         return ControlClient::delegate(server_addr, remote_stage);
     });

--- a/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
@@ -191,38 +191,38 @@ Status ProxyManager::getStatus(TaskInfo* task, TransferStatus& task_status) {
 struct StageBufferCache {
     StageBufferCache(ProxyManager& mgr) : mgr(mgr) {}
 
-    uint64_t allocateLocal(const std::string& location, int idx = 0) {
+    Status allocateLocal(const std::string& location, uint64_t& addr,
+                         int idx = 0) {
         auto key = location + "-" + std::to_string(idx);
         if (local_stage_buffers.count(key)) {
-            return local_stage_buffers[key];
+            addr = local_stage_buffers[key];
+            return Status::OK();
         }
-        uint64_t addr = 0;
         auto status = mgr.pinStageBuffer(location, addr);
         if (!status.ok()) {
-            LOG(FATAL) << "Failed to pin local stage buffer: " << status
-                       << ", location " << location;
-            return 0;
+            addr = 0;
+            return status;
         }
         local_stage_buffers[key] = addr;
-        return addr;
+        return Status::OK();
     }
 
-    uint64_t allocateRemote(const std::string& server_addr,
-                            const std::string& location, int idx = 0) {
+    Status allocateRemote(const std::string& server_addr,
+                          const std::string& location, uint64_t& addr,
+                          int idx = 0) {
         auto key = location + "-" + std::to_string(idx);
         if (remote_stage_buffers[server_addr].count(key)) {
-            return remote_stage_buffers[server_addr][key];
+            addr = remote_stage_buffers[server_addr][key];
+            return Status::OK();
         }
-        uint64_t addr = 0;
         auto status =
             ControlClient::pinStageBuffer(server_addr, location, addr);
         if (!status.ok()) {
-            LOG(FATAL) << "Failed to pin remote stage buffer: " << status
-                       << ", location " << location;
-            return 0;
+            addr = 0;
+            return status;
         }
         remote_stage_buffers[server_addr][key] = addr;
-        return addr;
+        return Status::OK();
     }
 
     void reset() {
@@ -286,8 +286,8 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
         remote_stage_buffer[kStageBuffers];
     if (local_staging) {
         for (size_t i = 0; i < kStageBuffers; ++i) {
-            local_stage_buffer[i] =
-                cache->allocateLocal(task.params[1], static_cast<int>(i));
+            CHECK_STATUS(cache->allocateLocal(
+                task.params[1], local_stage_buffer[i], static_cast<int>(i)));
             if (local_stage_buffer[i] == 0)
                 return Status::InternalError(
                     "Failed to pin local stage buffer");
@@ -295,8 +295,9 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
     }
     if (remote_staging) {
         for (size_t i = 0; i < kStageBuffers; ++i) {
-            remote_stage_buffer[i] = cache->allocateRemote(
-                server_addr, task.params[2], static_cast<int>(i));
+            CHECK_STATUS(cache->allocateRemote(server_addr, task.params[2],
+                                               remote_stage_buffer[i],
+                                               static_cast<int>(i)));
             if (remote_stage_buffer[i] == 0)
                 return Status::InternalError(
                     "Failed to pin remote stage buffer");
@@ -532,13 +533,13 @@ Status ProxyManager::transferSync(StagingTask& task, StageBufferCache* cache) {
     bool remote_staging = !task.params[2].empty();
 
     if (local_staging) {
-        local_stage_buffer = cache->allocateLocal(task.params[1]);
+        CHECK_STATUS(cache->allocateLocal(task.params[1], local_stage_buffer));
         if (local_stage_buffer == 0)
             return Status::InternalError("Failed to pin local stage buffer");
     }
     if (remote_staging) {
-        remote_stage_buffer =
-            cache->allocateRemote(server_addr, task.params[2]);
+        CHECK_STATUS(cache->allocateRemote(server_addr, task.params[2],
+                                           remote_stage_buffer));
         if (remote_stage_buffer == 0)
             return Status::InternalError("Failed to pin remote stage buffer");
     }

--- a/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
@@ -223,16 +223,54 @@ Status ProxyManager::deconstruct() {
     return Status::OK();
 }
 
-BatchID ProxyManager::submitCrossStage(const Request& request,
-                                       uint64_t local_stage_buffer,
-                                       uint64_t remote_stage_buffer,
-                                       uint64_t chunk_length) {
+Request ProxyManager::makeCrossStageRequest(const Request& request,
+                                            uint64_t local_stage_buffer,
+                                            uint64_t remote_stage_buffer,
+                                            uint64_t chunk_length) {
     Request inter_stage;
     inter_stage.opcode = request.opcode;
     inter_stage.source = (void*)local_stage_buffer;
     inter_stage.length = chunk_length;
     inter_stage.target_id = request.target_id;
     inter_stage.target_offset = remote_stage_buffer;
+    inter_stage.priority = request.priority;
+    return inter_stage;
+}
+
+Request ProxyManager::makeLocalStageRequest(const Request& request,
+                                            uint64_t local_stage_buffer,
+                                            uint64_t chunk_length,
+                                            uint64_t offset) {
+    Request local_stage;
+    local_stage.opcode = request.opcode;
+    local_stage.source = (uint8_t*)request.source + offset;
+    local_stage.length = chunk_length;
+    local_stage.target_id = LOCAL_SEGMENT_ID;
+    local_stage.target_offset = local_stage_buffer;
+    local_stage.priority = request.priority;
+    return local_stage;
+}
+
+Request ProxyManager::makeRemoteStageRequest(const Request& request,
+                                             uint64_t remote_stage_buffer,
+                                             uint64_t chunk_length,
+                                             uint64_t offset) {
+    Request remote_stage;
+    remote_stage.opcode = request.opcode;
+    remote_stage.source = (void*)remote_stage_buffer;
+    remote_stage.length = chunk_length;
+    remote_stage.target_id = LOCAL_SEGMENT_ID;
+    remote_stage.target_offset = request.target_offset + offset;
+    remote_stage.priority = request.priority;
+    return remote_stage;
+}
+
+BatchID ProxyManager::submitCrossStage(const Request& request,
+                                       uint64_t local_stage_buffer,
+                                       uint64_t remote_stage_buffer,
+                                       uint64_t chunk_length) {
+    auto inter_stage = makeCrossStageRequest(request, local_stage_buffer,
+                                             remote_stage_buffer, chunk_length);
     auto batch = impl_->allocateBatch(1);
     auto status = impl_->submitStagingTransfer(batch, {inter_stage});
     if (!status.ok()) {
@@ -247,12 +285,8 @@ BatchID ProxyManager::submitCrossStage(const Request& request,
 BatchID ProxyManager::submitLocalStage(const Request& request,
                                        uint64_t local_stage_buffer,
                                        uint64_t chunk_length, uint64_t offset) {
-    Request local_stage;
-    local_stage.opcode = request.opcode;
-    local_stage.source = (uint8_t*)request.source + offset;
-    local_stage.length = chunk_length;
-    local_stage.target_id = LOCAL_SEGMENT_ID;
-    local_stage.target_offset = local_stage_buffer;
+    auto local_stage = makeLocalStageRequest(request, local_stage_buffer,
+                                             chunk_length, offset);
     auto batch = impl_->allocateBatch(1);
     auto status = impl_->submitStagingTransfer(batch, {local_stage});
     if (!status.ok()) {
@@ -277,12 +311,8 @@ Status ProxyManager::waitRemoteStage(const std::string& server_addr,
                                      const Request& request,
                                      uint64_t remote_stage_buffer,
                                      uint64_t chunk_length, uint64_t offset) {
-    Request remote_stage;
-    remote_stage.opcode = request.opcode;
-    remote_stage.source = (void*)remote_stage_buffer;
-    remote_stage.length = chunk_length;
-    remote_stage.target_id = LOCAL_SEGMENT_ID;
-    remote_stage.target_offset = request.target_offset + offset;
+    auto remote_stage = makeRemoteStageRequest(request, remote_stage_buffer,
+                                               chunk_length, offset);
     return ControlClient::delegate(server_addr, remote_stage);
 }
 
@@ -290,12 +320,8 @@ void ProxyManager::submitRemoteStage(
     const std::string& server_addr, const Request& request,
     uint64_t remote_stage_buffer, uint64_t chunk_length, uint64_t offset,
     std::shared_ptr<internal::RemoteStageOperation>& operation) {
-    Request remote_stage;
-    remote_stage.opcode = request.opcode;
-    remote_stage.source = (void*)remote_stage_buffer;
-    remote_stage.length = chunk_length;
-    remote_stage.target_id = LOCAL_SEGMENT_ID;
-    remote_stage.target_offset = request.target_offset + offset;
+    auto remote_stage = makeRemoteStageRequest(request, remote_stage_buffer,
+                                               chunk_length, offset);
     operation = std::make_shared<internal::RemoteStageOperation>(
         server_addr, remote_stage_buffer, [server_addr, remote_stage_buffer] {
             ControlClient::unpinStageBufferAsync(

--- a/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
@@ -380,38 +380,42 @@ Status ProxyManager::getStatus(TaskInfo* task, TransferStatus& task_status) {
 struct StageBufferCache {
     StageBufferCache(ProxyManager& mgr) : mgr(mgr) {}
 
-    uint64_t allocateLocal(const std::string& location, int idx = 0) {
+    Status allocateLocal(const std::string& location, uint64_t& addr,
+                         int idx = 0) {
         auto key = location + "-" + std::to_string(idx);
         if (local_stage_buffers.count(key)) {
-            return local_stage_buffers[key];
+            addr = local_stage_buffers[key];
+            return Status::OK();
         }
-        uint64_t addr = 0;
         auto status = mgr.pinStageBuffer(location, addr);
         if (!status.ok()) {
             LOG(ERROR) << "Failed to pin local stage buffer: " << status
                        << ", location " << location;
-            return 0;
+            addr = 0;
+            return status;
         }
         local_stage_buffers[key] = addr;
-        return addr;
+        return Status::OK();
     }
 
-    uint64_t allocateRemote(const std::string& server_addr,
-                            const std::string& location, int idx = 0) {
+    Status allocateRemote(const std::string& server_addr,
+                          const std::string& location, uint64_t& addr,
+                          int idx = 0) {
         auto key = location + "-" + std::to_string(idx);
         if (remote_stage_buffers[server_addr].count(key)) {
-            return remote_stage_buffers[server_addr][key];
+            addr = remote_stage_buffers[server_addr][key];
+            return Status::OK();
         }
-        uint64_t addr = 0;
         auto status =
             ControlClient::pinStageBuffer(server_addr, location, addr);
         if (!status.ok()) {
             LOG(ERROR) << "Failed to pin remote stage buffer: " << status
                        << ", location " << location;
-            return 0;
+            addr = 0;
+            return status;
         }
         remote_stage_buffers[server_addr][key] = addr;
-        return addr;
+        return Status::OK();
     }
 
     void reset() {
@@ -507,8 +511,8 @@ Status ProxyManager::transferEventLoop(
         remote_stage_buffer[kStageBuffers];
     if (local_staging) {
         for (size_t i = 0; i < kStageBuffers; ++i) {
-            local_stage_buffer[i] =
-                cache->allocateLocal(task.params[1], static_cast<int>(i));
+            CHECK_STATUS(cache->allocateLocal(
+                task.params[1], local_stage_buffer[i], static_cast<int>(i)));
             if (local_stage_buffer[i] == 0)
                 return Status::InternalError(
                     "Failed to pin local stage buffer");
@@ -516,8 +520,9 @@ Status ProxyManager::transferEventLoop(
     }
     if (remote_staging) {
         for (size_t i = 0; i < kStageBuffers; ++i) {
-            remote_stage_buffer[i] = cache->allocateRemote(
-                server_addr, task.params[2], static_cast<int>(i));
+            CHECK_STATUS(cache->allocateRemote(server_addr, task.params[2],
+                                               remote_stage_buffer[i],
+                                               static_cast<int>(i)));
             if (remote_stage_buffer[i] == 0)
                 return Status::InternalError(
                     "Failed to pin remote stage buffer");
@@ -846,13 +851,13 @@ Status ProxyManager::transferSync(StagingTask& task, StageBufferCache* cache) {
     bool remote_staging = !task.params[2].empty();
 
     if (local_staging) {
-        local_stage_buffer = cache->allocateLocal(task.params[1]);
+        CHECK_STATUS(cache->allocateLocal(task.params[1], local_stage_buffer));
         if (local_stage_buffer == 0)
             return Status::InternalError("Failed to pin local stage buffer");
     }
     if (remote_staging) {
-        remote_stage_buffer =
-            cache->allocateRemote(server_addr, task.params[2]);
+        CHECK_STATUS(cache->allocateRemote(server_addr, task.params[2],
+                                           remote_stage_buffer));
         if (remote_stage_buffer == 0)
             return Status::InternalError("Failed to pin remote stage buffer");
     }

--- a/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
@@ -372,7 +372,7 @@ Status ProxyManager::waitCrossStage(const Request& request,
 
 Status ProxyManager::submit(TaskInfo* task, BatchID batch,
                             const std::vector<std::string>& params) {
-    if (!task || batch == 0) {
+    if (!task) {
         return Status::InvalidArgument("invalid staging task" LOC_MARK);
     }
     StagingTask staging_task;

--- a/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
@@ -380,7 +380,8 @@ Status ProxyManager::submit(TaskInfo* task, BatchID batch,
     staging_task.batch = batch;
     staging_task.params = params;
     static std::atomic<size_t> next_queue_index(0);
-    thread_local size_t id = next_queue_index.fetch_add(1) % kShards;
+    const size_t id =
+        next_queue_index.fetch_add(1, std::memory_order_relaxed) % kShards;
     {
         std::lock_guard<std::mutex> lk(shards_[id].mu);
         if (max_queued_tasks_per_shard_ > 0 &&

--- a/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
@@ -28,7 +28,7 @@ ProxyManager::ProxyManager(TransferEngineImpl* impl, size_t chunk_size,
     : ProxyManager(impl, chunk_size, chunk_count,
                    max_queued_tasks_per_shard, true) {}
 
-std::unique_ptr<ProxyManager> ProxyManager::createWithoutWorkersForTest(
+std::unique_ptr<ProxyManager> ProxyManager::createForTest(
     TransferEngineImpl* impl, size_t max_queued_tasks_per_shard) {
     return std::unique_ptr<ProxyManager>(new ProxyManager(
         impl, kDefaultChunkSize, kDefaultChunkCount,

--- a/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
@@ -23,15 +23,34 @@
 namespace mooncake {
 namespace tent {
 ProxyManager::ProxyManager(TransferEngineImpl* impl, size_t chunk_size,
-                           size_t chunk_count)
+                           size_t chunk_count,
+                           size_t max_queued_tasks_per_shard)
+    : ProxyManager(impl, chunk_size, chunk_count,
+                   max_queued_tasks_per_shard, true) {}
+
+std::unique_ptr<ProxyManager> ProxyManager::createWithoutWorkersForTest(
+    TransferEngineImpl* impl, size_t max_queued_tasks_per_shard) {
+    return std::unique_ptr<ProxyManager>(new ProxyManager(
+        impl, kDefaultChunkSize, kDefaultChunkCount,
+        max_queued_tasks_per_shard, false));
+}
+
+ProxyManager::ProxyManager(TransferEngineImpl* impl, size_t chunk_size,
+                           size_t chunk_count,
+                           size_t max_queued_tasks_per_shard,
+                           bool start_workers)
     : chunk_size_(chunk_size),
       chunk_count_(chunk_count),
+      max_queued_tasks_per_shard_(max_queued_tasks_per_shard),
       impl_(impl),
       shutdown_drain_timeout_(std::chrono::milliseconds(
-          impl->conf_->get("staging/shutdown_drain_timeout_ms", 30000L))) {
+          impl ? impl->conf_->get("staging/shutdown_drain_timeout_ms", 30000L)
+               : 30000L)) {
     running_ = true;
-    for (size_t i = 0; i < kShards; ++i) {
-        shards_[i].thread = std::thread(&ProxyManager::runner, this, i);
+    if (start_workers) {
+        for (size_t i = 0; i < kShards; ++i) {
+            shards_[i].thread = std::thread(&ProxyManager::runner, this, i);
+        }
     }
 }
 
@@ -353,16 +372,25 @@ Status ProxyManager::waitCrossStage(const Request& request,
 
 Status ProxyManager::submit(TaskInfo* task, BatchID batch,
                             const std::vector<std::string>& params) {
+    if (!task || batch == 0) {
+        return Status::InvalidArgument("invalid staging task" LOC_MARK);
+    }
     StagingTask staging_task;
     staging_task.native = task;
     staging_task.batch = batch;
     staging_task.params = params;
-    task->staging_status.store(PENDING, std::memory_order_relaxed);
     static std::atomic<size_t> next_queue_index(0);
     thread_local size_t id = next_queue_index.fetch_add(1) % kShards;
     {
         std::lock_guard<std::mutex> lk(shards_[id].mu);
+        if (max_queued_tasks_per_shard_ > 0 &&
+            shards_[id].queued_tasks >= max_queued_tasks_per_shard_) {
+            return Status::TooManyRequests(
+                "staging proxy shard queue is full" LOC_MARK);
+        }
         shards_[id].queue.push(staging_task);
+        ++shards_[id].queued_tasks;
+        task->staging_status.store(PENDING, std::memory_order_relaxed);
     }
     shards_[id].cv.notify_one();
     return Status::OK();
@@ -454,6 +482,7 @@ void ProxyManager::runner(size_t id) {
 
             task = shard.queue.front();
             shard.queue.pop();
+            --shard.queued_tasks;
         }
 
         if (!task.native) continue;

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -299,6 +299,10 @@ Status TransferEngineImpl::construct() {
         conf_->get("runtime_queue/staging_owner_reserve", 0UL);
     runtime_queue_config_.limits.staging_byte_reserve =
         conf_->get("runtime_queue/staging_byte_reserve", 0UL);
+    runtime_queue_config_.aging.medium_to_high = std::chrono::microseconds(
+        conf_->get("runtime_queue/medium_to_high_aging_us", 0UL));
+    runtime_queue_config_.aging.low_to_high = std::chrono::microseconds(
+        conf_->get("runtime_queue/low_to_high_aging_us", 0UL));
     runtime_queue_config_.max_dispatch_owners =
         conf_->get("runtime_queue/max_dispatch_owners", 64UL);
     runtime_queue_config_.max_dispatch_bytes =
@@ -313,7 +317,7 @@ Status TransferEngineImpl::construct() {
             "runtime queue dispatch window must be non-zero" LOC_MARK);
     }
     runtime_queue_ = std::make_unique<LocalTransferAdmissionQueue>(
-        runtime_queue_config_.limits);
+        runtime_queue_config_.limits, runtime_queue_config_.aging);
     if (!hostname_.empty())
         CHECK_STATUS(checkLocalIpAddress(hostname_, ipv6_));
     else

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -289,6 +289,9 @@ Status TransferEngineImpl::construct() {
     enable_auto_failover_on_poll_ =
         conf_->get("enable_auto_failover_on_poll", true);
     enable_progress_worker_ = conf_->get("enable_progress_worker", false);
+    staging_max_queued_tasks_per_shard_ =
+        conf_->get("staging/max_queued_tasks_per_shard",
+                   ProxyManager::kDefaultMaxQueuedTasksPerShard);
     runtime_queue_config_.enabled = conf_->get("enable_runtime_queue", false);
     if (runtime_queue_config_.enabled) enable_progress_worker_ = true;
     runtime_queue_config_.limits.max_outstanding_owners =
@@ -368,7 +371,8 @@ Status TransferEngineImpl::construct() {
         }
     }
 
-    staging_proxy_ = std::make_unique<ProxyManager>(this);
+    staging_proxy_ = std::make_unique<ProxyManager>(
+        this, staging_max_queued_tasks_per_shard_);
 
     if (enable_progress_worker_) {
         progress_worker_ = std::make_unique<ProgressWorker>(
@@ -1447,7 +1451,15 @@ Status TransferEngineImpl::commitPreparedSubmit(
 
         if (owner.staging) {
             task.staging = true;
-            staging_proxy_->submit(&task, (BatchID)batch, owner.staging_params);
+            auto status = staging_proxy_->submit(&task, (BatchID)batch,
+                                                 owner.staging_params);
+            if (!status.ok()) {
+                task.staging = false;
+                task.type = UNSPEC;
+                task.status = FAILED;
+                LOG(WARNING) << "Failed to submit staged transfer: "
+                             << status.ToString();
+            }
             continue;
         }
 
@@ -1638,7 +1650,15 @@ Status TransferEngineImpl::dispatchQueuedOwner(QueueOwnerId owner_id) {
             task.staging = true;
             auto status =
                 staging_proxy_->submit(&task, (BatchID)batch, staging_params);
-            if (!status.ok()) return finishQueuedOwner(owner_id, FAILED);
+            if (!status.ok()) {
+                task.staging = false;
+                task.type = UNSPEC;
+                if (status.IsTooManyRequests()) {
+                    CHECK_STATUS(runtime_queue_->requeueForDispatch(owner_id));
+                    return Status::OK();
+                }
+                return finishQueuedOwner(owner_id, FAILED);
+            }
             return markQueuedOwnerSubmitted(owner_id);
         }
     }

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -2192,9 +2192,18 @@ Status TransferEngineImpl::transferSync(
 
 uint64_t TransferEngineImpl::lockStageBuffer(const std::string& location) {
     uint64_t addr = 0;
-    auto status = staging_proxy_->pinStageBuffer(location, addr);
+    auto status = pinStageBuffer(location, addr);
     if (!status.ok()) LOG(ERROR) << status.ToString();
     return addr;
+}
+
+Status TransferEngineImpl::pinStageBuffer(const std::string& location,
+                                          uint64_t& addr) {
+    addr = 0;
+    if (!staging_proxy_) {
+        return Status::InvalidEntry("staging proxy is not available" LOC_MARK);
+    }
+    return staging_proxy_->pinStageBuffer(location, addr);
 }
 
 Status TransferEngineImpl::unlockStageBuffer(uint64_t addr) {

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -1642,26 +1642,6 @@ Status TransferEngineImpl::dispatchQueuedOwner(QueueOwnerId owner_id) {
         return finishQueuedOwner(owner_id, FAILED);
     }
 
-    if (task.type == TCP) {
-        std::vector<std::string> staging_params;
-        findStagingPolicy(task.request, staging_params);
-        if (!staging_params.empty() && staging_proxy_) {
-            task.staging = true;
-            auto status =
-                staging_proxy_->submit(&task, (BatchID)batch, staging_params);
-            if (!status.ok()) {
-                task.staging = false;
-                task.type = UNSPEC;
-                if (status.IsTooManyRequests()) {
-                    CHECK_STATUS(runtime_queue_->requeueForDispatch(owner_id));
-                    return Status::OK();
-                }
-                return finishQueuedOwner(owner_id, FAILED);
-            }
-            return markQueuedOwnerSubmitted(owner_id);
-        }
-    }
-
     if (!batch->sub_batch[task.type]) {
         auto& transport = transport_list_[task.type];
         if (!transport) return finishQueuedOwner(owner_id, FAILED);

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -290,8 +290,7 @@ Status TransferEngineImpl::construct() {
         conf_->get("enable_auto_failover_on_poll", true);
     enable_progress_worker_ = conf_->get("enable_progress_worker", false);
     staging_max_queued_tasks_per_shard_ =
-        conf_->get("staging/max_queued_tasks_per_shard",
-                   ProxyManager::kDefaultMaxQueuedTasksPerShard);
+        conf_->get("staging/max_queued_tasks_per_shard", 0UL);
     runtime_queue_config_.enabled = conf_->get("enable_runtime_queue", false);
     if (runtime_queue_config_.enabled) enable_progress_worker_ = true;
     runtime_queue_config_.limits.max_outstanding_owners =

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -2077,7 +2077,6 @@ Status TransferEngineImpl::enqueuePreparedSubmit(Batch* batch,
         batch->queue_token != 0 ? batch->queue_token : nextBatchToken();
     QueueSubmit submit;
     submit.batch_token = batch_token;
-    submit.batch_slots_left = batch->max_size - batch->task_list.size();
     submit.owners.reserve(prepared.owners.size());
     for (const auto& owner : prepared.owners) {
         if (owner.request.length > runtime_queue_config_.max_dispatch_bytes) {

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -386,7 +386,7 @@ Status TransferEngineImpl::construct() {
         conf_->get("runtime_queue/max_dispatch_bytes", 64UL << 20);
     runtime_queue_config_.progress_fallback_interval =
         std::chrono::microseconds(
-            conf_->get("runtime_queue/progress_fallback_interval_us", 50000UL));
+            conf_->get("runtime_queue/progress_fallback_interval_us", 5000UL));
     if (runtime_queue_config_.enabled &&
         (runtime_queue_config_.max_dispatch_owners == 0 ||
          runtime_queue_config_.max_dispatch_bytes == 0)) {

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -363,8 +363,7 @@ Status TransferEngineImpl::construct() {
         conf_->get("enable_auto_failover_on_poll", true);
     enable_progress_worker_ = conf_->get("enable_progress_worker", false);
     staging_max_queued_tasks_per_shard_ =
-        conf_->get("staging/max_queued_tasks_per_shard",
-                   ProxyManager::kDefaultMaxQueuedTasksPerShard);
+        conf_->get("staging/max_queued_tasks_per_shard", 0UL);
     runtime_queue_config_.enabled = conf_->get("enable_runtime_queue", false);
     if (runtime_queue_config_.enabled) enable_progress_worker_ = true;
     runtime_queue_config_.limits.max_outstanding_owners =

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -2216,26 +2216,6 @@ Status TransferEngineImpl::dispatchQueuedOwner(QueueOwnerId owner_id) {
         return finishQueuedOwner(owner_id, FAILED);
     }
 
-    if (task.type == TCP || task.type == HP_TCP) {
-        std::vector<std::string> staging_params;
-        findStagingPolicy(task.request, staging_params);
-        if (!staging_params.empty() && staging_proxy_) {
-            task.staging = true;
-            // Orchestration only; the real transport submissions issued by
-            // ProxyManager are counted where they recurse through the
-            // non-staging path below.
-            auto status =
-                staging_proxy_->submit(&task, (BatchID)batch, staging_params);
-            if (!status.ok()) {
-                task.staging = false;
-                task.type = UNSPEC;
-                return finishQueuedOwner(owner_id, FAILED);
-            }
-            task.post_time = std::chrono::steady_clock::now();
-            return markQueuedOwnerSubmitted(owner_id);
-        }
-    }
-
     if (!batch->sub_batch[task.type]) {
         auto& transport = transport_list_[task.type];
         if (!transport) return finishQueuedOwner(owner_id, FAILED);

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -3030,9 +3030,18 @@ Status TransferEngineImpl::transferSync(
 
 uint64_t TransferEngineImpl::lockStageBuffer(const std::string& location) {
     uint64_t addr = 0;
-    auto status = staging_proxy_->pinStageBuffer(location, addr);
+    auto status = pinStageBuffer(location, addr);
     if (!status.ok()) LOG(ERROR) << status.ToString();
     return addr;
+}
+
+Status TransferEngineImpl::pinStageBuffer(const std::string& location,
+                                          uint64_t& addr) {
+    addr = 0;
+    if (!staging_proxy_) {
+        return Status::InvalidEntry("staging proxy is not available" LOC_MARK);
+    }
+    return staging_proxy_->pinStageBuffer(location, addr);
 }
 
 Status TransferEngineImpl::unlockStageBuffer(uint64_t addr) {

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -362,6 +362,9 @@ Status TransferEngineImpl::construct() {
     enable_auto_failover_on_poll_ =
         conf_->get("enable_auto_failover_on_poll", true);
     enable_progress_worker_ = conf_->get("enable_progress_worker", false);
+    staging_max_queued_tasks_per_shard_ =
+        conf_->get("staging/max_queued_tasks_per_shard",
+                   ProxyManager::kDefaultMaxQueuedTasksPerShard);
     runtime_queue_config_.enabled = conf_->get("enable_runtime_queue", false);
     if (runtime_queue_config_.enabled) enable_progress_worker_ = true;
     runtime_queue_config_.limits.max_outstanding_owners =
@@ -462,7 +465,10 @@ Status TransferEngineImpl::construct() {
         }
     }
 
-    staging_proxy_ = std::make_unique<ProxyManager>(this);
+    staging_proxy_ = std::make_unique<ProxyManager>(
+        this, ProxyManager::kDefaultChunkSize,
+        ProxyManager::kDefaultChunkCount,
+        staging_max_queued_tasks_per_shard_);
 
     if (runtime_queue_config_.limits.deadline_aware &&
         runtime_queue_config_.limits.mlu_local_threshold > 0.0) {
@@ -1921,6 +1927,9 @@ Status TransferEngineImpl::commitPreparedSubmit(
             if (!status.ok()) {
                 task.staging = false;
                 task.type = UNSPEC;
+                task.status = FAILED;
+                LOG(WARNING) << "Failed to submit staged transfer: "
+                             << status.ToString();
             } else {
                 task.post_time = std::chrono::steady_clock::now();
             }
@@ -2218,7 +2227,11 @@ Status TransferEngineImpl::dispatchQueuedOwner(QueueOwnerId owner_id) {
             // non-staging path below.
             auto status =
                 staging_proxy_->submit(&task, (BatchID)batch, staging_params);
-            if (!status.ok()) return finishQueuedOwner(owner_id, FAILED);
+            if (!status.ok()) {
+                task.staging = false;
+                task.type = UNSPEC;
+                return finishQueuedOwner(owner_id, FAILED);
+            }
             task.post_time = std::chrono::steady_clock::now();
             return markQueuedOwnerSubmitted(owner_id);
         }

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
@@ -473,6 +473,8 @@ Status RdmaTransport::submitTransferTasks(
         task->resolved_slices.store(0, std::memory_order_relaxed);
         task->first_error = PENDING;
         task->cancel_requested.store(false, std::memory_order_relaxed);
+        task->progress_batch_id = rdma_batch->progress_batch_id;
+        task->notify_progress = rdma_batch->notify_progress;
         task->ref();  // Batch holds a reference to the task
 
         const double merge_ratio = 0.25;

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -81,9 +81,8 @@ add_test(NAME tent_endpoint_lifecycle_test COMMAND tent_endpoint_lifecycle_test)
 if(USE_HIP)
   find_package(HIP REQUIRED)
   add_executable(tent_rocm_platform_test rocm_platform_test.cpp)
-  target_link_libraries(tent_rocm_platform_test PRIVATE gtest gtest_main
-                                                        tent_link_group
-                                                        hip::host)
+  target_link_libraries(tent_rocm_platform_test
+                        PRIVATE gtest gtest_main tent_link_group hip::host)
   target_include_directories(tent_rocm_platform_test
                              PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
   add_test(NAME tent_rocm_platform_test COMMAND tent_rocm_platform_test)
@@ -92,9 +91,8 @@ endif()
 if(USE_SUNRISE)
   add_executable(tent_sunrise_link_transport_test
                  sunrise_link_transport_test.cpp)
-  target_link_libraries(tent_sunrise_link_transport_test PRIVATE gtest
-                                                                 gtest_main
-                                                                 tent_link_group)
+  target_link_libraries(tent_sunrise_link_transport_test
+                        PRIVATE gtest gtest_main tent_link_group)
   target_include_directories(
     tent_sunrise_link_transport_test
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include
@@ -104,14 +102,24 @@ if(USE_SUNRISE)
 endif()
 add_executable(tent_fault_proxy_test fault_proxy_test.cpp)
 target_link_libraries(tent_fault_proxy_test PRIVATE gtest gtest_main
-                                                     tent_link_group)
+                                                    tent_link_group)
 target_include_directories(tent_fault_proxy_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME tent_fault_proxy_test COMMAND tent_fault_proxy_test)
 
+add_executable(tent_proxy_manager_test proxy_manager_test.cpp)
+target_link_libraries(tent_proxy_manager_test PRIVATE gtest gtest_main
+                                                      tent_link_group)
+if(TARGET asio_shared)
+  target_link_libraries(tent_proxy_manager_test PRIVATE asio_shared)
+endif()
+target_include_directories(tent_proxy_manager_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+add_test(NAME tent_proxy_manager_test COMMAND tent_proxy_manager_test)
+
 add_executable(tent_rail_monitor_test rail_monitor_test.cpp)
 target_link_libraries(tent_rail_monitor_test PRIVATE gtest gtest_main
-                                                      tent_link_group)
+                                                     tent_link_group)
 target_include_directories(tent_rail_monitor_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME tent_rail_monitor_test COMMAND tent_rail_monitor_test)
@@ -119,7 +127,7 @@ add_test(NAME tent_rail_monitor_test COMMAND tent_rail_monitor_test)
 # Transport Selector Unit Test
 add_executable(tent_transport_selector_test transport_selector_test.cpp)
 target_link_libraries(tent_transport_selector_test PRIVATE gtest gtest_main
-                                                            tent_link_group)
+                                                           tent_link_group)
 target_include_directories(tent_transport_selector_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME tent_transport_selector_test COMMAND tent_transport_selector_test)
@@ -127,8 +135,8 @@ add_test(NAME tent_transport_selector_test COMMAND tent_transport_selector_test)
 # End-to-end failover test: drives real TransferEngineImpl with
 # FaultProxyTransport-wrapped fakes to exercise resubmitTransferTask.
 add_executable(tent_engine_failover_e2e_test engine_failover_e2e_test.cpp)
-target_link_libraries(tent_engine_failover_e2e_test
-                      PRIVATE gtest gtest_main tent_link_group)
+target_link_libraries(tent_engine_failover_e2e_test PRIVATE gtest gtest_main
+                                                            tent_link_group)
 if(TARGET asio_shared)
   target_link_libraries(tent_engine_failover_e2e_test PRIVATE asio_shared)
 endif()
@@ -140,8 +148,8 @@ add_test(NAME tent_engine_failover_e2e_test
 # Per-request transport_hint: validates submitTransfer parameter, routing,
 # disabled-transport rejection, out-of-range rejection, mixed-hint batches.
 add_executable(tent_transport_hint_test transport_hint_test.cpp)
-target_link_libraries(tent_transport_hint_test
-                      PRIVATE gtest gtest_main tent_link_group)
+target_link_libraries(tent_transport_hint_test PRIVATE gtest gtest_main
+                                                       tent_link_group)
 if(TARGET asio_shared)
   target_link_libraries(tent_transport_hint_test PRIVATE asio_shared)
 endif()
@@ -152,20 +160,18 @@ add_test(NAME tent_transport_hint_test COMMAND tent_transport_hint_test)
 # ProgressWorker skeleton test: covers default-off behavior, event-driven
 # progress without poll-failover, and freeBatch races (issue #2116).
 add_executable(tent_progress_worker_test progress_worker_test.cpp)
-target_link_libraries(tent_progress_worker_test
-                      PRIVATE gtest gtest_main tent_link_group)
+target_link_libraries(tent_progress_worker_test PRIVATE gtest gtest_main
+                                                        tent_link_group)
 if(TARGET asio_shared)
   target_link_libraries(tent_progress_worker_test PRIVATE asio_shared)
 endif()
 target_include_directories(tent_progress_worker_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
-add_test(NAME tent_progress_worker_test
-         COMMAND tent_progress_worker_test)
+add_test(NAME tent_progress_worker_test COMMAND tent_progress_worker_test)
 
-add_executable(tent_runtime_queue_dispatch_test
-               runtime_queue_dispatch_test.cpp)
-target_link_libraries(tent_runtime_queue_dispatch_test
-                      PRIVATE gtest gtest_main tent_link_group)
+add_executable(tent_runtime_queue_dispatch_test runtime_queue_dispatch_test.cpp)
+target_link_libraries(tent_runtime_queue_dispatch_test PRIVATE gtest gtest_main
+                                                               tent_link_group)
 if(TARGET asio_shared)
   target_link_libraries(tent_runtime_queue_dispatch_test PRIVATE asio_shared)
 endif()

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -425,6 +425,16 @@ target_include_directories(tent_fault_proxy_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME tent_fault_proxy_test COMMAND tent_fault_proxy_test)
 
+add_executable(tent_proxy_manager_test proxy_manager_test.cpp)
+target_link_libraries(tent_proxy_manager_test PRIVATE gtest gtest_main
+                                                      tent_link_group)
+if(TARGET asio_shared)
+  target_link_libraries(tent_proxy_manager_test PRIVATE asio_shared)
+endif()
+target_include_directories(tent_proxy_manager_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+add_test(NAME tent_proxy_manager_test COMMAND tent_proxy_manager_test)
+
 add_executable(tent_rail_monitor_test rail_monitor_test.cpp)
 target_link_libraries(tent_rail_monitor_test PRIVATE gtest gtest_main
                                                      tent_link_group)

--- a/mooncake-transfer-engine/tent/tests/admission_queue_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/admission_queue_test.cpp
@@ -14,6 +14,7 @@
 
 #include "tent/runtime/admission_queue.h"
 
+#include <chrono>
 #include <utility>
 #include <vector>
 
@@ -271,6 +272,46 @@ TEST(AdmissionQueueTest, BlocksOnSameLaneHeadWhenByteWindowIsTooSmall) {
     EXPECT_EQ(picked, expected_ids);
 }
 
+TEST(AdmissionQueueTest, UsesByteWindowBehindBlockedOwnerInOtherLane) {
+    LocalTransferAdmissionQueue queue({4, 128, 0, 0});
+    std::vector<QueueOwnerId> admitted_ids;
+
+    auto status = queue.tryAdmit(
+        makeSubmit(
+            1, 3,
+            {makeOwner(0, 60, QueueOwnerKind::StagingInternal, {}, PRIO_HIGH),
+             makeOwner(1, 10, QueueOwnerKind::User, {}, PRIO_HIGH),
+             makeOwner(2, 10, QueueOwnerKind::StagingInternal, {}, PRIO_HIGH)}),
+        admitted_ids);
+
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+    ASSERT_EQ(admitted_ids.size(), 3u);
+
+    auto picked = queue.pickForDispatch(2, 50);
+
+    const std::vector<QueueOwnerId> expected_ids{admitted_ids[1]};
+    EXPECT_EQ(picked, expected_ids);
+}
+
+TEST(AdmissionQueueTest, UsesByteWindowBehindBlockedHigherPriorityLane) {
+    LocalTransferAdmissionQueue queue({4, 128, 0, 0});
+    std::vector<QueueOwnerId> admitted_ids;
+
+    auto status = queue.tryAdmit(
+        makeSubmit(1, 2,
+                   {makeOwner(0, 60, QueueOwnerKind::User, {}, PRIO_HIGH),
+                    makeOwner(1, 10, QueueOwnerKind::User, {}, PRIO_MEDIUM)}),
+        admitted_ids);
+
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+    ASSERT_EQ(admitted_ids.size(), 2u);
+
+    auto picked = queue.pickForDispatch(2, 50);
+
+    const std::vector<QueueOwnerId> expected_ids{admitted_ids[1]};
+    EXPECT_EQ(picked, expected_ids);
+}
+
 TEST(AdmissionQueueTest, DispatchesHigherPriorityBeforeEarlierLowerPriority) {
     LocalTransferAdmissionQueue queue({4, 128, 0, 0});
     std::vector<QueueOwnerId> admitted_ids;
@@ -355,6 +396,96 @@ TEST(AdmissionQueueTest, AlternatesOwnerKindWithinSamePriority) {
     const std::vector<QueueOwnerId> expected_ids{
         admitted_ids[1], admitted_ids[0], admitted_ids[2], admitted_ids[3]};
     EXPECT_EQ(picked, expected_ids);
+}
+
+TEST(AdmissionQueueTest, AgesMediumPriorityToHigh) {
+    QueueAgingConfig aging;
+    aging.medium_to_high = std::chrono::microseconds(10);
+    LocalTransferAdmissionQueue queue({4, 128, 0, 0}, aging);
+    std::vector<QueueOwnerId> admitted_ids;
+
+    const auto base = LocalTransferAdmissionQueue::TimePoint{};
+    auto status = queue.tryAdmit(
+        makeSubmit(1, 1,
+                   {makeOwner(0, 10, QueueOwnerKind::User, {}, PRIO_MEDIUM)}),
+        admitted_ids, base);
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+    ASSERT_EQ(admitted_ids.size(), 1u);
+    const auto medium_id = admitted_ids[0];
+
+    status = queue.tryAdmit(
+        makeSubmit(2, 1,
+                   {makeOwner(0, 10, QueueOwnerKind::User, {}, PRIO_HIGH)}),
+        admitted_ids, base + std::chrono::microseconds(20));
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+    ASSERT_EQ(admitted_ids.size(), 1u);
+    const auto high_id = admitted_ids[0];
+
+    auto picked =
+        queue.pickForDispatch(2, 128, base + std::chrono::microseconds(20));
+
+    const std::vector<QueueOwnerId> expected_ids{medium_id, high_id};
+    EXPECT_EQ(picked, expected_ids);
+}
+
+TEST(AdmissionQueueTest, AgesLowPriorityToHigh) {
+    QueueAgingConfig aging;
+    aging.medium_to_high = std::chrono::microseconds(10);
+    aging.low_to_high = std::chrono::microseconds(10);
+    LocalTransferAdmissionQueue queue({4, 128, 0, 0}, aging);
+    std::vector<QueueOwnerId> admitted_ids;
+
+    const auto base = LocalTransferAdmissionQueue::TimePoint{};
+    auto status = queue.tryAdmit(
+        makeSubmit(1, 1,
+                   {makeOwner(0, 10, QueueOwnerKind::User, {}, PRIO_LOW)}),
+        admitted_ids, base);
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+    ASSERT_EQ(admitted_ids.size(), 1u);
+    const auto low_id = admitted_ids[0];
+
+    status = queue.tryAdmit(
+        makeSubmit(2, 1,
+                   {makeOwner(0, 10, QueueOwnerKind::User, {}, PRIO_MEDIUM)}),
+        admitted_ids, base + std::chrono::microseconds(20));
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+    ASSERT_EQ(admitted_ids.size(), 1u);
+    const auto medium_id = admitted_ids[0];
+
+    status = queue.tryAdmit(
+        makeSubmit(3, 1,
+                   {makeOwner(0, 10, QueueOwnerKind::User, {}, PRIO_HIGH)}),
+        admitted_ids, base + std::chrono::microseconds(20));
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+    ASSERT_EQ(admitted_ids.size(), 1u);
+    const auto high_id = admitted_ids[0];
+
+    auto picked =
+        queue.pickForDispatch(3, 128, base + std::chrono::microseconds(20));
+
+    const std::vector<QueueOwnerId> expected_ids{low_id, high_id, medium_id};
+    EXPECT_EQ(picked, expected_ids);
+}
+
+TEST(AdmissionQueueTest, AgingPreservesFifoWithinPromotedLane) {
+    QueueAgingConfig aging;
+    aging.medium_to_high = std::chrono::microseconds(10);
+    LocalTransferAdmissionQueue queue({4, 128, 0, 0}, aging);
+    std::vector<QueueOwnerId> admitted_ids;
+
+    const auto base = LocalTransferAdmissionQueue::TimePoint{};
+    auto status = queue.tryAdmit(
+        makeSubmit(1, 2,
+                   {makeOwner(0, 10, QueueOwnerKind::User, {}, PRIO_MEDIUM),
+                    makeOwner(1, 10, QueueOwnerKind::User, {}, PRIO_MEDIUM)}),
+        admitted_ids, base);
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+    ASSERT_EQ(admitted_ids.size(), 2u);
+
+    auto picked =
+        queue.pickForDispatch(2, 128, base + std::chrono::microseconds(20));
+
+    EXPECT_EQ(picked, admitted_ids);
 }
 
 TEST(AdmissionQueueTest, RequiresDispatchBeforeTerminalCompletion) {

--- a/mooncake-transfer-engine/tent/tests/admission_queue_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/admission_queue_test.cpp
@@ -194,6 +194,44 @@ TEST(AdmissionQueueTest, RejectsExistingPublicTaskConflictWithoutMutation) {
     EXPECT_EQ(admitted_ids[0], 2u);
 }
 
+TEST(AdmissionQueueTest, AllowsAdditionalOwnersInSameBatch) {
+    LocalTransferAdmissionQueue queue({4, 128, 0, 0});
+    std::vector<QueueOwnerId> admitted_ids;
+
+    auto status =
+        queue.tryAdmit(makeSubmit(1, 3, {makeOwner(0, 16)}), admitted_ids);
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+    ASSERT_EQ(admitted_ids.size(), 1u);
+    const auto first_owner = admitted_ids[0];
+
+    status = queue.tryAdmit(
+        makeSubmit(1, 2, {makeOwner(1, 16, QueueOwnerKind::User, {2})}),
+        admitted_ids);
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+    ASSERT_EQ(admitted_ids.size(), 1u);
+    const auto second_owner = admitted_ids[0];
+
+    QueueOwnerId resolved_owner = 0;
+    status = queue.resolveOwner(1, 0, resolved_owner);
+    EXPECT_EQ(status.code(), Status::Code::kOk);
+    EXPECT_EQ(resolved_owner, first_owner);
+    status = queue.resolveOwner(1, 1, resolved_owner);
+    EXPECT_EQ(status.code(), Status::Code::kOk);
+    EXPECT_EQ(resolved_owner, second_owner);
+    status = queue.resolveOwner(1, 2, resolved_owner);
+    EXPECT_EQ(status.code(), Status::Code::kOk);
+    EXPECT_EQ(resolved_owner, second_owner);
+
+    auto picked = queue.pickForDispatch(2, 32);
+    ASSERT_EQ(picked.size(), 2u);
+    for (const auto owner_id : picked) {
+        status = queue.complete(owner_id, TransferStatusEnum::COMPLETED);
+        ASSERT_EQ(status.code(), Status::Code::kOk);
+    }
+    status = queue.retireBatch(1);
+    EXPECT_EQ(status.code(), Status::Code::kOk);
+}
+
 TEST(AdmissionQueueTest, AccountsPublicSlotsSeparatelyFromQueueOwners) {
     LocalTransferAdmissionQueue queue({2, 128, 0, 0});
     std::vector<QueueOwnerId> admitted_ids;

--- a/mooncake-transfer-engine/tent/tests/admission_queue_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/admission_queue_test.cpp
@@ -516,6 +516,29 @@ TEST(AdmissionQueueTest, RequiresDispatchBeforeTerminalCompletion) {
     EXPECT_EQ(status.code(), Status::Code::kInvalidEntry);
 }
 
+TEST(AdmissionQueueTest, RequeuesDispatchingOwnerWithoutRechargingAdmission) {
+    LocalTransferAdmissionQueue queue({2, 128, 0, 0});
+    std::vector<QueueOwnerId> admitted_ids;
+
+    auto status =
+        queue.tryAdmit(makeSubmit(1, 1, {makeOwner(0, 16)}), admitted_ids);
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+    ASSERT_EQ(admitted_ids.size(), 1u);
+    EXPECT_EQ(queue.outstandingOwners(), 1u);
+    EXPECT_EQ(queue.outstandingBytes(), 16u);
+
+    auto picked = queue.pickForDispatch(1, 16);
+    ASSERT_EQ(picked.size(), 1u);
+    status = queue.requeueForDispatch(picked[0]);
+    EXPECT_EQ(status.code(), Status::Code::kOk);
+    EXPECT_EQ(queue.outstandingOwners(), 1u);
+    EXPECT_EQ(queue.outstandingBytes(), 16u);
+
+    picked = queue.pickForDispatch(1, 16);
+    ASSERT_EQ(picked.size(), 1u);
+    EXPECT_EQ(picked[0], admitted_ids[0]);
+}
+
 TEST(AdmissionQueueTest, RetainsTerminalStatusUntilBatchRetire) {
     LocalTransferAdmissionQueue queue({2, 128, 0, 0});
     std::vector<QueueOwnerId> admitted_ids;

--- a/mooncake-transfer-engine/tent/tests/admission_queue_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/admission_queue_test.cpp
@@ -333,6 +333,84 @@ TEST(AdmissionQueueTest, DispatchesHigherPriorityBeforeEarlierLowerPriority) {
     EXPECT_EQ(picked, expected_ids);
 }
 
+TEST(AdmissionQueueTest, DispatchPriorityPaysByBytes) {
+    LocalTransferAdmissionQueue queue({32, 1024, 0, 0});
+    std::vector<QueueOwnerId> admitted_ids;
+    std::vector<QueueOwnerInput> owners;
+
+    for (size_t i = 0; i < 10; ++i) {
+        owners.push_back(makeOwner(i, 16, QueueOwnerKind::User, {}, PRIO_HIGH));
+    }
+    for (size_t i = 0; i < 10; ++i) {
+        owners.push_back(
+            makeOwner(10 + i, 16, QueueOwnerKind::User, {}, PRIO_LOW));
+    }
+
+    const size_t slot_count = owners.size();
+    auto status = queue.tryAdmit(makeSubmit(1, slot_count, std::move(owners)),
+                                 admitted_ids);
+
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+    ASSERT_EQ(admitted_ids.size(), 20u);
+
+    auto picked = queue.pickForDispatch(10, 160);
+
+    const std::vector<QueueOwnerId> expected_ids{
+        admitted_ids[0], admitted_ids[1],  admitted_ids[2], admitted_ids[3],
+        admitted_ids[4], admitted_ids[10], admitted_ids[5], admitted_ids[6],
+        admitted_ids[7], admitted_ids[8]};
+    EXPECT_EQ(picked, expected_ids);
+}
+
+TEST(AdmissionQueueTest, UsesByteCreditsBehindHigherPriorityOwner) {
+    LocalTransferAdmissionQueue queue({4, 256, 0, 0});
+    std::vector<QueueOwnerId> admitted_ids;
+
+    auto status = queue.tryAdmit(
+        makeSubmit(1, 2,
+                   {makeOwner(0, 80, QueueOwnerKind::User, {}, PRIO_HIGH),
+                    makeOwner(1, 16, QueueOwnerKind::User, {}, PRIO_LOW)}),
+        admitted_ids);
+
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+    ASSERT_EQ(admitted_ids.size(), 2u);
+
+    auto picked = queue.pickForDispatch(2, 128);
+
+    const std::vector<QueueOwnerId> expected_ids{admitted_ids[1],
+                                                 admitted_ids[0]};
+    EXPECT_EQ(picked, expected_ids);
+}
+
+TEST(AdmissionQueueTest, KeepsByteCreditsSeparateAcrossOwnerKinds) {
+    LocalTransferAdmissionQueue queue({16, 512, 0, 0});
+    std::vector<QueueOwnerId> admitted_ids;
+    std::vector<QueueOwnerInput> owners;
+
+    owners.push_back(
+        makeOwner(0, 80, QueueOwnerKind::StagingInternal, {}, PRIO_HIGH));
+    for (size_t i = 1; i <= 8; ++i) {
+        owners.push_back(makeOwner(i, 16, QueueOwnerKind::User, {}, PRIO_HIGH));
+    }
+
+    const size_t slot_count = owners.size();
+    auto status = queue.tryAdmit(makeSubmit(1, slot_count, std::move(owners)),
+                                 admitted_ids);
+
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+    ASSERT_EQ(admitted_ids.size(), 9u);
+
+    auto picked = queue.pickForDispatch(4, 128);
+    const std::vector<QueueOwnerId> first_expected{
+        admitted_ids[1], admitted_ids[2], admitted_ids[3], admitted_ids[4]};
+    EXPECT_EQ(picked, first_expected);
+
+    picked = queue.pickForDispatch(4, 128);
+    const std::vector<QueueOwnerId> second_expected{
+        admitted_ids[0], admitted_ids[5], admitted_ids[6], admitted_ids[7]};
+    EXPECT_EQ(picked, second_expected);
+}
+
 TEST(AdmissionQueueTest, PreservesFifoWithinSamePriorityLane) {
     LocalTransferAdmissionQueue queue({4, 128, 0, 0});
     std::vector<QueueOwnerId> admitted_ids;

--- a/mooncake-transfer-engine/tent/tests/admission_queue_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/admission_queue_test.cpp
@@ -632,29 +632,6 @@ TEST(AdmissionQueueTest, RequiresDispatchBeforeTerminalCompletion) {
     EXPECT_EQ(status.code(), Status::Code::kInvalidEntry);
 }
 
-TEST(AdmissionQueueTest, RequeuesDispatchingOwnerWithoutRechargingAdmission) {
-    LocalTransferAdmissionQueue queue({2, 128, 0, 0});
-    std::vector<QueueOwnerId> admitted_ids;
-
-    auto status =
-        queue.tryAdmit(makeSubmit(1, 1, {makeOwner(0, 16)}), admitted_ids);
-    ASSERT_EQ(status.code(), Status::Code::kOk);
-    ASSERT_EQ(admitted_ids.size(), 1u);
-    EXPECT_EQ(queue.outstandingOwners(), 1u);
-    EXPECT_EQ(queue.outstandingBytes(), 16u);
-
-    auto picked = queue.pickForDispatch(1, 16);
-    ASSERT_EQ(picked.size(), 1u);
-    status = queue.requeueForDispatch(picked[0]);
-    EXPECT_EQ(status.code(), Status::Code::kOk);
-    EXPECT_EQ(queue.outstandingOwners(), 1u);
-    EXPECT_EQ(queue.outstandingBytes(), 16u);
-
-    picked = queue.pickForDispatch(1, 16);
-    ASSERT_EQ(picked.size(), 1u);
-    EXPECT_EQ(picked[0], admitted_ids[0]);
-}
-
 TEST(AdmissionQueueTest, RetainsTerminalStatusUntilBatchRetire) {
     LocalTransferAdmissionQueue queue({2, 128, 0, 0});
     std::vector<QueueOwnerId> admitted_ids;

--- a/mooncake-transfer-engine/tent/tests/admission_queue_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/admission_queue_test.cpp
@@ -26,7 +26,8 @@ namespace {
 QueueOwnerInput makeOwner(
     size_t public_task_id, size_t length,
     QueueOwnerKind kind = QueueOwnerKind::User,
-    std::vector<size_t> derived_task_ids = std::vector<size_t>()) {
+    std::vector<size_t> derived_task_ids = std::vector<size_t>(),
+    int priority = PRIO_HIGH) {
     QueueOwnerInput owner;
     owner.owner_task_id = public_task_id;
     owner.derived_task_ids = std::move(derived_task_ids);
@@ -35,6 +36,7 @@ QueueOwnerInput makeOwner(
     owner.request.target_id = 1;
     owner.request.target_offset = public_task_id * 4096;
     owner.request.length = length;
+    owner.request.priority = priority;
     owner.kind = kind;
     return owner;
 }
@@ -101,6 +103,27 @@ TEST(AdmissionQueueTest, RejectsUnsupportedOwnerKindWithoutPartialAdmission) {
 
     auto invalid_owner = makeOwner(0, 16, static_cast<QueueOwnerKind>(99), {1});
     auto status = queue.tryAdmit(makeSubmit(1, 2, {std::move(invalid_owner)}),
+                                 admitted_ids);
+
+    EXPECT_EQ(status.code(), Status::Code::kInvalidArgument);
+    EXPECT_TRUE(admitted_ids.empty());
+    EXPECT_EQ(queue.outstandingOwners(), 0u);
+    EXPECT_EQ(queue.outstandingBytes(), 0u);
+
+    status = queue.tryAdmit(makeSubmit(1, 1, {makeOwner(2, 16)}), admitted_ids);
+
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+    ASSERT_EQ(admitted_ids.size(), 1u);
+    EXPECT_EQ(admitted_ids[0], 1u);
+}
+
+TEST(AdmissionQueueTest, RejectsUnsupportedPriorityWithoutPartialAdmission) {
+    LocalTransferAdmissionQueue queue({4, 128, 0, 0});
+    std::vector<QueueOwnerId> admitted_ids{99};
+
+    auto invalid_owner = makeOwner(0, 16);
+    invalid_owner.request.priority = 99;
+    auto status = queue.tryAdmit(makeSubmit(1, 1, {std::move(invalid_owner)}),
                                  admitted_ids);
 
     EXPECT_EQ(status.code(), Status::Code::kInvalidArgument);
@@ -248,6 +271,69 @@ TEST(AdmissionQueueTest, KeepsAdmissionOrderForDispatch) {
 
     auto picked = queue.pickForDispatch(2, 70);
 
+    EXPECT_EQ(picked, expected_ids);
+}
+
+TEST(AdmissionQueueTest, DispatchesHigherPriorityBeforeEarlierLowerPriority) {
+    LocalTransferAdmissionQueue queue({4, 128, 0, 0});
+    std::vector<QueueOwnerId> admitted_ids;
+
+    auto status = queue.tryAdmit(
+        makeSubmit(1, 3,
+                   {makeOwner(0, 10, QueueOwnerKind::User, {}, PRIO_LOW),
+                    makeOwner(1, 10, QueueOwnerKind::User, {}, PRIO_HIGH),
+                    makeOwner(2, 10, QueueOwnerKind::User, {}, PRIO_MEDIUM)}),
+        admitted_ids);
+
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+    ASSERT_EQ(admitted_ids.size(), 3u);
+
+    auto picked = queue.pickForDispatch(3, 128);
+
+    const std::vector<QueueOwnerId> expected_ids{
+        admitted_ids[1], admitted_ids[2], admitted_ids[0]};
+    EXPECT_EQ(picked, expected_ids);
+}
+
+TEST(AdmissionQueueTest, PreservesFifoWithinSamePriority) {
+    LocalTransferAdmissionQueue queue({4, 128, 0, 0});
+    std::vector<QueueOwnerId> admitted_ids;
+
+    auto status = queue.tryAdmit(
+        makeSubmit(1, 3,
+                   {makeOwner(0, 10, QueueOwnerKind::User, {}, PRIO_MEDIUM),
+                    makeOwner(1, 10, QueueOwnerKind::User, {}, PRIO_MEDIUM),
+                    makeOwner(2, 10, QueueOwnerKind::User, {}, PRIO_HIGH)}),
+        admitted_ids);
+
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+    ASSERT_EQ(admitted_ids.size(), 3u);
+
+    auto picked = queue.pickForDispatch(3, 128);
+
+    const std::vector<QueueOwnerId> expected_ids{
+        admitted_ids[2], admitted_ids[0], admitted_ids[1]};
+    EXPECT_EQ(picked, expected_ids);
+}
+
+TEST(AdmissionQueueTest, OwnerKindDoesNotOverrideRequestPriority) {
+    LocalTransferAdmissionQueue queue({4, 128, 0, 0});
+    std::vector<QueueOwnerId> admitted_ids;
+
+    auto status = queue.tryAdmit(
+        makeSubmit(
+            1, 2,
+            {makeOwner(0, 10, QueueOwnerKind::StagingInternal, {}, PRIO_LOW),
+             makeOwner(1, 10, QueueOwnerKind::User, {}, PRIO_HIGH)}),
+        admitted_ids);
+
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+    ASSERT_EQ(admitted_ids.size(), 2u);
+
+    auto picked = queue.pickForDispatch(2, 128);
+
+    const std::vector<QueueOwnerId> expected_ids{admitted_ids[1],
+                                                 admitted_ids[0]};
     EXPECT_EQ(picked, expected_ids);
 }
 

--- a/mooncake-transfer-engine/tent/tests/admission_queue_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/admission_queue_test.cpp
@@ -252,15 +252,12 @@ TEST(AdmissionQueueTest, PreservesStagingReserveForStagingInternalOwners) {
     EXPECT_EQ(queue.outstandingBytes(), 100u);
 }
 
-TEST(AdmissionQueueTest, KeepsAdmissionOrderForDispatch) {
+TEST(AdmissionQueueTest, BlocksOnSameLaneHeadWhenByteWindowIsTooSmall) {
     LocalTransferAdmissionQueue queue({4, 128, 0, 0});
     std::vector<QueueOwnerId> admitted_ids;
 
     auto status = queue.tryAdmit(
-        makeSubmit(1, 2,
-                   {makeOwner(0, 60),
-                    makeOwner(1, 10, QueueOwnerKind::StagingInternal)}),
-        admitted_ids);
+        makeSubmit(1, 2, {makeOwner(0, 60), makeOwner(1, 10)}), admitted_ids);
 
     ASSERT_EQ(status.code(), Status::Code::kOk);
     ASSERT_EQ(admitted_ids.size(), 2u);
@@ -295,7 +292,7 @@ TEST(AdmissionQueueTest, DispatchesHigherPriorityBeforeEarlierLowerPriority) {
     EXPECT_EQ(picked, expected_ids);
 }
 
-TEST(AdmissionQueueTest, PreservesFifoWithinSamePriority) {
+TEST(AdmissionQueueTest, PreservesFifoWithinSamePriorityLane) {
     LocalTransferAdmissionQueue queue({4, 128, 0, 0});
     std::vector<QueueOwnerId> admitted_ids;
 
@@ -334,6 +331,29 @@ TEST(AdmissionQueueTest, OwnerKindDoesNotOverrideRequestPriority) {
 
     const std::vector<QueueOwnerId> expected_ids{admitted_ids[1],
                                                  admitted_ids[0]};
+    EXPECT_EQ(picked, expected_ids);
+}
+
+TEST(AdmissionQueueTest, AlternatesOwnerKindWithinSamePriority) {
+    LocalTransferAdmissionQueue queue({4, 128, 0, 0});
+    std::vector<QueueOwnerId> admitted_ids;
+
+    auto status = queue.tryAdmit(
+        makeSubmit(
+            1, 4,
+            {makeOwner(0, 10, QueueOwnerKind::User, {}, PRIO_MEDIUM),
+             makeOwner(1, 10, QueueOwnerKind::StagingInternal, {}, PRIO_MEDIUM),
+             makeOwner(2, 10, QueueOwnerKind::StagingInternal, {}, PRIO_MEDIUM),
+             makeOwner(3, 10, QueueOwnerKind::User, {}, PRIO_MEDIUM)}),
+        admitted_ids);
+
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+    ASSERT_EQ(admitted_ids.size(), 4u);
+
+    auto picked = queue.pickForDispatch(4, 128);
+
+    const std::vector<QueueOwnerId> expected_ids{
+        admitted_ids[1], admitted_ids[0], admitted_ids[2], admitted_ids[3]};
     EXPECT_EQ(picked, expected_ids);
 }
 

--- a/mooncake-transfer-engine/tent/tests/admission_queue_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/admission_queue_test.cpp
@@ -42,11 +42,10 @@ QueueOwnerInput makeOwner(
     return owner;
 }
 
-QueueSubmit makeSubmit(uint64_t batch_token, size_t batch_slots_left,
+QueueSubmit makeSubmit(uint64_t batch_token,
                        std::vector<QueueOwnerInput> owners) {
     QueueSubmit submit;
     submit.batch_token = batch_token;
-    submit.batch_slots_left = batch_slots_left;
     submit.owners = std::move(owners);
     return submit;
 }
@@ -55,7 +54,7 @@ TEST(AdmissionQueueTest, AllowsEmptySubmitAsNoOp) {
     LocalTransferAdmissionQueue queue({2, 128, 0, 0});
     std::vector<QueueOwnerId> admitted_ids{99};
 
-    auto status = queue.tryAdmit(makeSubmit(1, 0, {}), admitted_ids);
+    auto status = queue.tryAdmit(makeSubmit(1, {}), admitted_ids);
 
     EXPECT_EQ(status.code(), Status::Code::kOk);
     EXPECT_TRUE(admitted_ids.empty());
@@ -68,34 +67,12 @@ TEST(AdmissionQueueTest, RejectsSubmitWhenQueueLimitsAreInvalid) {
     std::vector<QueueOwnerId> admitted_ids{99};
 
     auto status =
-        queue.tryAdmit(makeSubmit(1, 1, {makeOwner(0, 16)}), admitted_ids);
+        queue.tryAdmit(makeSubmit(1, {makeOwner(0, 16)}), admitted_ids);
 
     EXPECT_EQ(status.code(), Status::Code::kInvalidArgument);
     EXPECT_TRUE(admitted_ids.empty());
     EXPECT_EQ(queue.outstandingOwners(), 0u);
     EXPECT_EQ(queue.outstandingBytes(), 0u);
-}
-
-TEST(AdmissionQueueTest, RejectsInvalidInputsWithoutPartialAdmission) {
-    LocalTransferAdmissionQueue queue({4, 128, 0, 0});
-    std::vector<QueueOwnerId> admitted_ids{99};
-
-    auto status = queue.tryAdmit(
-        makeSubmit(
-            1, 2,
-            {makeOwner(0, 16, QueueOwnerKind::User, {1}), makeOwner(1, 16)}),
-        admitted_ids);
-
-    EXPECT_EQ(status.code(), Status::Code::kInvalidArgument);
-    EXPECT_TRUE(admitted_ids.empty());
-    EXPECT_EQ(queue.outstandingOwners(), 0u);
-    EXPECT_EQ(queue.outstandingBytes(), 0u);
-
-    status = queue.tryAdmit(makeSubmit(1, 1, {makeOwner(2, 16)}), admitted_ids);
-
-    ASSERT_EQ(status.code(), Status::Code::kOk);
-    ASSERT_EQ(admitted_ids.size(), 1u);
-    EXPECT_EQ(admitted_ids[0], 1u);
 }
 
 TEST(AdmissionQueueTest, RejectsUnsupportedOwnerKindWithoutPartialAdmission) {
@@ -103,7 +80,7 @@ TEST(AdmissionQueueTest, RejectsUnsupportedOwnerKindWithoutPartialAdmission) {
     std::vector<QueueOwnerId> admitted_ids{99};
 
     auto invalid_owner = makeOwner(0, 16, static_cast<QueueOwnerKind>(99), {1});
-    auto status = queue.tryAdmit(makeSubmit(1, 2, {std::move(invalid_owner)}),
+    auto status = queue.tryAdmit(makeSubmit(1, {std::move(invalid_owner)}),
                                  admitted_ids);
 
     EXPECT_EQ(status.code(), Status::Code::kInvalidArgument);
@@ -111,7 +88,7 @@ TEST(AdmissionQueueTest, RejectsUnsupportedOwnerKindWithoutPartialAdmission) {
     EXPECT_EQ(queue.outstandingOwners(), 0u);
     EXPECT_EQ(queue.outstandingBytes(), 0u);
 
-    status = queue.tryAdmit(makeSubmit(1, 1, {makeOwner(2, 16)}), admitted_ids);
+    status = queue.tryAdmit(makeSubmit(1, {makeOwner(2, 16)}), admitted_ids);
 
     ASSERT_EQ(status.code(), Status::Code::kOk);
     ASSERT_EQ(admitted_ids.size(), 1u);
@@ -124,7 +101,7 @@ TEST(AdmissionQueueTest, RejectsUnsupportedPriorityWithoutPartialAdmission) {
 
     auto invalid_owner = makeOwner(0, 16);
     invalid_owner.request.priority = 99;
-    auto status = queue.tryAdmit(makeSubmit(1, 1, {std::move(invalid_owner)}),
+    auto status = queue.tryAdmit(makeSubmit(1, {std::move(invalid_owner)}),
                                  admitted_ids);
 
     EXPECT_EQ(status.code(), Status::Code::kInvalidArgument);
@@ -132,7 +109,7 @@ TEST(AdmissionQueueTest, RejectsUnsupportedPriorityWithoutPartialAdmission) {
     EXPECT_EQ(queue.outstandingOwners(), 0u);
     EXPECT_EQ(queue.outstandingBytes(), 0u);
 
-    status = queue.tryAdmit(makeSubmit(1, 1, {makeOwner(2, 16)}), admitted_ids);
+    status = queue.tryAdmit(makeSubmit(1, {makeOwner(2, 16)}), admitted_ids);
 
     ASSERT_EQ(status.code(), Status::Code::kOk);
     ASSERT_EQ(admitted_ids.size(), 1u);
@@ -144,14 +121,14 @@ TEST(AdmissionQueueTest, RejectsCapacityExceededWithoutPartialAdmission) {
     std::vector<QueueOwnerId> admitted_ids;
 
     auto status = queue.tryAdmit(
-        makeSubmit(1, 2, {makeOwner(0, 16), makeOwner(1, 16)}), admitted_ids);
+        makeSubmit(1, {makeOwner(0, 16), makeOwner(1, 16)}), admitted_ids);
 
     EXPECT_EQ(status.code(), Status::Code::kTooManyRequests);
     EXPECT_TRUE(admitted_ids.empty());
     EXPECT_EQ(queue.outstandingOwners(), 0u);
     EXPECT_EQ(queue.outstandingBytes(), 0u);
 
-    status = queue.tryAdmit(makeSubmit(1, 1, {makeOwner(0, 16)}), admitted_ids);
+    status = queue.tryAdmit(makeSubmit(1, {makeOwner(0, 16)}), admitted_ids);
 
     ASSERT_EQ(status.code(), Status::Code::kOk);
     ASSERT_EQ(admitted_ids.size(), 1u);
@@ -163,13 +140,13 @@ TEST(AdmissionQueueTest, RejectsExistingPublicTaskConflictWithoutMutation) {
     std::vector<QueueOwnerId> admitted_ids;
 
     auto status =
-        queue.tryAdmit(makeSubmit(1, 1, {makeOwner(0, 16)}), admitted_ids);
+        queue.tryAdmit(makeSubmit(1, {makeOwner(0, 16)}), admitted_ids);
     ASSERT_EQ(status.code(), Status::Code::kOk);
     ASSERT_EQ(admitted_ids.size(), 1u);
     EXPECT_EQ(admitted_ids[0], 1u);
 
     status = queue.tryAdmit(
-        makeSubmit(1, 2, {makeOwner(1, 16), makeOwner(0, 16)}), admitted_ids);
+        makeSubmit(1, {makeOwner(1, 16), makeOwner(0, 16)}), admitted_ids);
 
     EXPECT_EQ(status.code(), Status::Code::kInvalidEntry);
     EXPECT_TRUE(admitted_ids.empty());
@@ -187,7 +164,7 @@ TEST(AdmissionQueueTest, RejectsExistingPublicTaskConflictWithoutMutation) {
     status = queue.retireBatch(1);
     ASSERT_EQ(status.code(), Status::Code::kOk);
 
-    status = queue.tryAdmit(makeSubmit(2, 1, {makeOwner(0, 16)}), admitted_ids);
+    status = queue.tryAdmit(makeSubmit(2, {makeOwner(0, 16)}), admitted_ids);
 
     ASSERT_EQ(status.code(), Status::Code::kOk);
     ASSERT_EQ(admitted_ids.size(), 1u);
@@ -199,13 +176,13 @@ TEST(AdmissionQueueTest, AllowsAdditionalOwnersInSameBatch) {
     std::vector<QueueOwnerId> admitted_ids;
 
     auto status =
-        queue.tryAdmit(makeSubmit(1, 3, {makeOwner(0, 16)}), admitted_ids);
+        queue.tryAdmit(makeSubmit(1, {makeOwner(0, 16)}), admitted_ids);
     ASSERT_EQ(status.code(), Status::Code::kOk);
     ASSERT_EQ(admitted_ids.size(), 1u);
     const auto first_owner = admitted_ids[0];
 
     status = queue.tryAdmit(
-        makeSubmit(1, 2, {makeOwner(1, 16, QueueOwnerKind::User, {2})}),
+        makeSubmit(1, {makeOwner(1, 16, QueueOwnerKind::User, {2})}),
         admitted_ids);
     ASSERT_EQ(status.code(), Status::Code::kOk);
     ASSERT_EQ(admitted_ids.size(), 1u);
@@ -232,20 +209,12 @@ TEST(AdmissionQueueTest, AllowsAdditionalOwnersInSameBatch) {
     EXPECT_EQ(status.code(), Status::Code::kOk);
 }
 
-TEST(AdmissionQueueTest, AccountsPublicSlotsSeparatelyFromQueueOwners) {
+TEST(AdmissionQueueTest, MapsDerivedPublicTasksToOwner) {
     LocalTransferAdmissionQueue queue({2, 128, 0, 0});
     std::vector<QueueOwnerId> admitted_ids;
 
     auto status = queue.tryAdmit(
-        makeSubmit(1, 2, {makeOwner(7, 32, QueueOwnerKind::User, {8, 9})}),
-        admitted_ids);
-
-    EXPECT_EQ(status.code(), Status::Code::kTooManyRequests);
-    EXPECT_TRUE(admitted_ids.empty());
-    EXPECT_EQ(queue.outstandingOwners(), 0u);
-
-    status = queue.tryAdmit(
-        makeSubmit(1, 3, {makeOwner(7, 32, QueueOwnerKind::User, {8, 9})}),
+        makeSubmit(1, {makeOwner(7, 32, QueueOwnerKind::User, {8, 9})}),
         admitted_ids);
 
     ASSERT_EQ(status.code(), Status::Code::kOk);
@@ -272,17 +241,17 @@ TEST(AdmissionQueueTest, PreservesStagingReserveForStagingInternalOwners) {
     std::vector<QueueOwnerId> admitted_ids;
 
     auto status =
-        queue.tryAdmit(makeSubmit(1, 1, {makeOwner(0, 60)}), admitted_ids);
+        queue.tryAdmit(makeSubmit(1, {makeOwner(0, 60)}), admitted_ids);
     ASSERT_EQ(status.code(), Status::Code::kOk);
 
-    status = queue.tryAdmit(makeSubmit(2, 1, {makeOwner(0, 1)}), admitted_ids);
+    status = queue.tryAdmit(makeSubmit(2, {makeOwner(0, 1)}), admitted_ids);
     EXPECT_EQ(status.code(), Status::Code::kTooManyRequests);
     EXPECT_TRUE(admitted_ids.empty());
     EXPECT_EQ(queue.outstandingOwners(), 1u);
     EXPECT_EQ(queue.outstandingBytes(), 60u);
 
     status = queue.tryAdmit(
-        makeSubmit(3, 1, {makeOwner(0, 40, QueueOwnerKind::StagingInternal)}),
+        makeSubmit(3, {makeOwner(0, 40, QueueOwnerKind::StagingInternal)}),
         admitted_ids);
     ASSERT_EQ(status.code(), Status::Code::kOk);
     ASSERT_EQ(admitted_ids.size(), 1u);
@@ -296,7 +265,7 @@ TEST(AdmissionQueueTest, BlocksOnSameLaneHeadWhenByteWindowIsTooSmall) {
     std::vector<QueueOwnerId> admitted_ids;
 
     auto status = queue.tryAdmit(
-        makeSubmit(1, 2, {makeOwner(0, 60), makeOwner(1, 10)}), admitted_ids);
+        makeSubmit(1, {makeOwner(0, 60), makeOwner(1, 10)}), admitted_ids);
 
     ASSERT_EQ(status.code(), Status::Code::kOk);
     ASSERT_EQ(admitted_ids.size(), 2u);
@@ -316,7 +285,7 @@ TEST(AdmissionQueueTest, DispatchesHigherPriorityBeforeEarlierLowerPriority) {
     std::vector<QueueOwnerId> admitted_ids;
 
     auto status = queue.tryAdmit(
-        makeSubmit(1, 3,
+        makeSubmit(1,
                    {makeOwner(0, 10, QueueOwnerKind::User, {}, PRIO_LOW),
                     makeOwner(1, 10, QueueOwnerKind::User, {}, PRIO_HIGH),
                     makeOwner(2, 10, QueueOwnerKind::User, {}, PRIO_MEDIUM)}),
@@ -337,7 +306,7 @@ TEST(AdmissionQueueTest, PreservesFifoWithinSamePriorityLane) {
     std::vector<QueueOwnerId> admitted_ids;
 
     auto status = queue.tryAdmit(
-        makeSubmit(1, 3,
+        makeSubmit(1,
                    {makeOwner(0, 10, QueueOwnerKind::User, {}, PRIO_MEDIUM),
                     makeOwner(1, 10, QueueOwnerKind::User, {}, PRIO_MEDIUM),
                     makeOwner(2, 10, QueueOwnerKind::User, {}, PRIO_HIGH)}),
@@ -359,7 +328,7 @@ TEST(AdmissionQueueTest, OwnerKindDoesNotOverrideRequestPriority) {
 
     auto status = queue.tryAdmit(
         makeSubmit(
-            1, 2,
+            1,
             {makeOwner(0, 10, QueueOwnerKind::StagingInternal, {}, PRIO_LOW),
              makeOwner(1, 10, QueueOwnerKind::User, {}, PRIO_HIGH)}),
         admitted_ids);
@@ -380,7 +349,7 @@ TEST(AdmissionQueueTest, AlternatesOwnerKindWithinSamePriority) {
 
     auto status = queue.tryAdmit(
         makeSubmit(
-            1, 4,
+            1,
             {makeOwner(0, 10, QueueOwnerKind::User, {}, PRIO_MEDIUM),
              makeOwner(1, 10, QueueOwnerKind::StagingInternal, {}, PRIO_MEDIUM),
              makeOwner(2, 10, QueueOwnerKind::StagingInternal, {}, PRIO_MEDIUM),
@@ -402,7 +371,7 @@ TEST(AdmissionQueueTest, RequiresDispatchBeforeTerminalCompletion) {
     std::vector<QueueOwnerId> admitted_ids;
 
     auto status =
-        queue.tryAdmit(makeSubmit(1, 1, {makeOwner(0, 16)}), admitted_ids);
+        queue.tryAdmit(makeSubmit(1, {makeOwner(0, 16)}), admitted_ids);
     ASSERT_EQ(status.code(), Status::Code::kOk);
     ASSERT_EQ(admitted_ids.size(), 1u);
 
@@ -429,7 +398,7 @@ TEST(AdmissionQueueTest, CancelsQueuedOwnerAndReleasesAccounting) {
     LocalTransferAdmissionQueue queue({2, 128, 0, 0});
     std::vector<QueueOwnerId> admitted_ids;
     ASSERT_TRUE(
-        queue.tryAdmit(makeSubmit(1, 1, {makeOwner(0, 16)}), admitted_ids)
+        queue.tryAdmit(makeSubmit(1, {makeOwner(0, 16)}), admitted_ids)
             .ok());
     ASSERT_EQ(admitted_ids.size(), 1u);
 
@@ -449,7 +418,7 @@ TEST(AdmissionQueueTest, RejectsQueueCancelAfterDispatchStarts) {
     LocalTransferAdmissionQueue queue({2, 128, 0, 0});
     std::vector<QueueOwnerId> admitted_ids;
     ASSERT_TRUE(
-        queue.tryAdmit(makeSubmit(1, 1, {makeOwner(0, 16)}), admitted_ids)
+        queue.tryAdmit(makeSubmit(1, {makeOwner(0, 16)}), admitted_ids)
             .ok());
     auto picked = queue.pickForDispatch(1, 16);
     ASSERT_EQ(picked.size(), 1u);
@@ -464,7 +433,7 @@ TEST(AdmissionQueueTest, RetainsTerminalStatusUntilBatchRetire) {
     std::vector<QueueOwnerId> admitted_ids;
 
     auto status = queue.tryAdmit(
-        makeSubmit(1, 2, {makeOwner(0, 16, QueueOwnerKind::User, {1})}),
+        makeSubmit(1, {makeOwner(0, 16, QueueOwnerKind::User, {1})}),
         admitted_ids);
     ASSERT_EQ(status.code(), Status::Code::kOk);
 
@@ -500,7 +469,7 @@ TEST(AdmissionQueueTest, RetainsSpecificTerminalStatus) {
     std::vector<QueueOwnerId> admitted_ids;
 
     auto status =
-        queue.tryAdmit(makeSubmit(1, 1, {makeOwner(0, 16)}), admitted_ids);
+        queue.tryAdmit(makeSubmit(1, {makeOwner(0, 16)}), admitted_ids);
     ASSERT_EQ(status.code(), Status::Code::kOk);
 
     auto picked = queue.pickForDispatch(1, 16);
@@ -519,7 +488,7 @@ TEST(AdmissionQueueTest, RejectsRetireWithNonTerminalOwners) {
     std::vector<QueueOwnerId> admitted_ids;
 
     auto status = queue.tryAdmit(
-        makeSubmit(1, 2, {makeOwner(0, 16), makeOwner(1, 16)}), admitted_ids);
+        makeSubmit(1, {makeOwner(0, 16), makeOwner(1, 16)}), admitted_ids);
     ASSERT_EQ(status.code(), Status::Code::kOk);
 
     auto picked = queue.pickForDispatch(1, 16);
@@ -544,7 +513,7 @@ TEST(AdmissionQueueTest, AllowsBatchTokenReuseAfterRetire) {
     std::vector<QueueOwnerId> admitted_ids;
 
     auto status =
-        queue.tryAdmit(makeSubmit(1, 1, {makeOwner(0, 16)}), admitted_ids);
+        queue.tryAdmit(makeSubmit(1, {makeOwner(0, 16)}), admitted_ids);
     ASSERT_EQ(status.code(), Status::Code::kOk);
     ASSERT_EQ(admitted_ids.size(), 1u);
     EXPECT_EQ(admitted_ids[0], 1u);
@@ -556,7 +525,7 @@ TEST(AdmissionQueueTest, AllowsBatchTokenReuseAfterRetire) {
     status = queue.retireBatch(1);
     ASSERT_EQ(status.code(), Status::Code::kOk);
 
-    status = queue.tryAdmit(makeSubmit(1, 1, {makeOwner(0, 16)}), admitted_ids);
+    status = queue.tryAdmit(makeSubmit(1, {makeOwner(0, 16)}), admitted_ids);
 
     ASSERT_EQ(status.code(), Status::Code::kOk);
     ASSERT_EQ(admitted_ids.size(), 1u);
@@ -594,7 +563,7 @@ TEST(AdmissionQueueTest, DeadlineAwareDispatchesEarliestDeadlineFirst) {
 
     // Admitted in FIFO order 1,2,3 but with deadlines 300,100,200.
     auto status =
-        queue.tryAdmit(makeSubmit(1, 3,
+        queue.tryAdmit(makeSubmit(1,
                                   {makeOwnerWithDeadline(0, 16, 300),
                                    makeOwnerWithDeadline(1, 16, 100),
                                    makeOwnerWithDeadline(2, 16, 200)}),
@@ -615,7 +584,7 @@ TEST(AdmissionQueueTest, DeadlineAwareKeepsUndeadlinedOwnersLast) {
     std::vector<QueueOwnerId> admitted_ids;
 
     // owner 1: no deadline (0); owner 2: deadline 100; owner 3: no deadline.
-    auto status = queue.tryAdmit(makeSubmit(1, 3,
+    auto status = queue.tryAdmit(makeSubmit(1,
                                             {makeOwnerWithDeadline(0, 16, 0),
                                              makeOwnerWithDeadline(1, 16, 100),
                                              makeOwnerWithDeadline(2, 16, 0)}),
@@ -634,7 +603,7 @@ TEST(AdmissionQueueTest, DeadlineUnawareKeepsStrictFifo) {
     std::vector<QueueOwnerId> admitted_ids;
 
     auto status =
-        queue.tryAdmit(makeSubmit(1, 3,
+        queue.tryAdmit(makeSubmit(1,
                                   {makeOwnerWithDeadline(0, 16, 300),
                                    makeOwnerWithDeadline(1, 16, 100),
                                    makeOwnerWithDeadline(2, 16, 200)}),
@@ -659,24 +628,24 @@ TEST(AdmissionQueueTest, DeadlineAwareOrdersAcrossSeparateAdmits) {
     // Admit one at a time, deadlines arriving out of order: 300, 100, 200, 0.
     ASSERT_EQ(
         queue
-            .tryAdmit(makeSubmit(1, 1, {makeOwnerWithDeadline(0, 16, 300)}),
+            .tryAdmit(makeSubmit(1, {makeOwnerWithDeadline(0, 16, 300)}),
                       ids)
             .code(),
         Status::Code::kOk);  // owner 1
     ASSERT_EQ(
         queue
-            .tryAdmit(makeSubmit(2, 1, {makeOwnerWithDeadline(0, 16, 100)}),
+            .tryAdmit(makeSubmit(2, {makeOwnerWithDeadline(0, 16, 100)}),
                       ids)
             .code(),
         Status::Code::kOk);  // owner 2
     ASSERT_EQ(
         queue
-            .tryAdmit(makeSubmit(3, 1, {makeOwnerWithDeadline(0, 16, 200)}),
+            .tryAdmit(makeSubmit(3, {makeOwnerWithDeadline(0, 16, 200)}),
                       ids)
             .code(),
         Status::Code::kOk);  // owner 3
     ASSERT_EQ(
-        queue.tryAdmit(makeSubmit(4, 1, {makeOwnerWithDeadline(0, 16, 0)}), ids)
+        queue.tryAdmit(makeSubmit(4, {makeOwnerWithDeadline(0, 16, 0)}), ids)
             .code(),
         Status::Code::kOk);  // owner 4 (no deadline → last)
 
@@ -711,7 +680,7 @@ TEST(AdmissionQueueTest, Step3DropsInfeasibleAndKeepsFeasible) {
     // owner 2: window = 1e6 ns → MLU ~1.6e-5 → feasible → dispatch.
     auto status = queue.tryAdmit(
         makeSubmit(
-            1, 2,
+            1,
             {makeDegradationEligibleOwnerWithDeadline(0, 16, 1'000'000'010),
              makeDegradationEligibleOwnerWithDeadline(1, 16, 2'000'000'000)}),
         admitted_ids);
@@ -740,7 +709,7 @@ TEST(AdmissionQueueTest, Step3DropsAlreadyExpiredDeadline) {
     // deadline 1e9 < now 2e9 → already past → dropped.
     auto status = queue.tryAdmit(
         makeSubmit(
-            1, 1,
+            1,
             {makeDegradationEligibleOwnerWithDeadline(0, 16, 1'000'000'000)}),
         admitted_ids);
     ASSERT_EQ(status.code(), Status::Code::kOk);
@@ -762,7 +731,7 @@ TEST(AdmissionQueueTest, Step3DisabledWhenThresholdZero) {
     std::vector<QueueOwnerId> admitted_ids;
     auto status = queue.tryAdmit(
         makeSubmit(
-            1, 1,
+            1,
             {makeDegradationEligibleOwnerWithDeadline(0, 16, 1'000'000'001)}),
         admitted_ids);
     ASSERT_EQ(status.code(), Status::Code::kOk);
@@ -779,7 +748,7 @@ TEST(AdmissionQueueTest, Step3NoDropWithoutBandwidthProvider) {
     LocalTransferAdmissionQueue queue(step3Limits(1.5));
     std::vector<QueueOwnerId> admitted_ids;
     auto status = queue.tryAdmit(
-        makeSubmit(1, 1, {makeOwnerWithDeadline(0, 16, 1'000'000'001)}),
+        makeSubmit(1, {makeOwnerWithDeadline(0, 16, 1'000'000'001)}),
         admitted_ids);
     ASSERT_EQ(status.code(), Status::Code::kOk);
 
@@ -802,7 +771,7 @@ TEST(AdmissionQueueTest, Step3DynamicBandwidthProvider) {
     // At 1e9 B/s: time=16ns, window=10ns, MLU=1.6 >= 1.5 -> DROP.
     auto status = queue.tryAdmit(
         makeSubmit(
-            1, 1,
+            1,
             {makeDegradationEligibleOwnerWithDeadline(0, 16, 1'000'000'010)}),
         admitted_ids);
     ASSERT_EQ(status.code(), Status::Code::kOk);
@@ -817,7 +786,7 @@ TEST(AdmissionQueueTest, Step3DynamicBandwidthProvider) {
     live_bw.store(1e10);
     status = queue.tryAdmit(
         makeSubmit(
-            2, 1,
+            2,
             {makeDegradationEligibleOwnerWithDeadline(0, 16, 1'000'000'010)}),
         admitted_ids);
     ASSERT_EQ(status.code(), Status::Code::kOk);
@@ -841,7 +810,7 @@ TEST(AdmissionQueueTest, Step3SkipsNonRdmaOwner) {
     auto owner = makeOwnerWithDeadline(0, 16, 1'000'000'010);
     owner.degradation_eligible = false;
     std::vector<QueueOwnerId> admitted_ids;
-    auto status = queue.tryAdmit(makeSubmit(1, 1, {owner}), admitted_ids);
+    auto status = queue.tryAdmit(makeSubmit(1, {owner}), admitted_ids);
     ASSERT_EQ(status.code(), Status::Code::kOk);
 
     std::vector<QueueOwnerId> dropped;
@@ -861,7 +830,7 @@ TEST(AdmissionQueueTest, Step3RequiresExplicitDegradationEligibility) {
 
     std::vector<QueueOwnerId> admitted_ids;
     auto status = queue.tryAdmit(
-        makeSubmit(1, 1, {makeOwnerWithDeadline(0, 16, 1'000'000'010)}),
+        makeSubmit(1, {makeOwnerWithDeadline(0, 16, 1'000'000'010)}),
         admitted_ids);
     ASSERT_EQ(status.code(), Status::Code::kOk);
 
@@ -890,7 +859,7 @@ TEST(AdmissionQueueTest, PromotionDisabledKeepsEdfOrder) {
 
     std::vector<QueueOwnerId> ids;
     auto status =
-        queue.tryAdmit(makeSubmit(1, 3,
+        queue.tryAdmit(makeSubmit(1,
                                   {makeOwnerWithDeadline(0, 16, 2000),
                                    makeOwnerWithDeadline(1, 16, 1500),
                                    makeOwnerWithDeadline(2, 16, 1800)}),
@@ -909,7 +878,7 @@ TEST(AdmissionQueueTest, PromotionMovesUrgentOwnersToFront) {
 
     std::vector<QueueOwnerId> ids;
     auto status =
-        queue.tryAdmit(makeSubmit(1, 3,
+        queue.tryAdmit(makeSubmit(1,
                                   {makeOwnerWithDeadline(0, 16, 2000),
                                    makeOwnerWithDeadline(1, 16, 1400),
                                    makeOwnerWithDeadline(2, 16, 1300)}),
@@ -928,13 +897,13 @@ TEST(AdmissionQueueTest, PromotionReordersAcrossSeparateAdmits) {
 
     std::vector<QueueOwnerId> ids;
     auto s1 = queue.tryAdmit(
-        makeSubmit(1, 1, {makeOwnerWithDeadline(0, 16, 10000)}), ids);
+        makeSubmit(1, {makeOwnerWithDeadline(0, 16, 10000)}), ids);
     ASSERT_EQ(s1.code(), Status::Code::kOk);
     auto s2 = queue.tryAdmit(
-        makeSubmit(2, 1, {makeOwnerWithDeadline(0, 16, 6500)}), ids);
+        makeSubmit(2, {makeOwnerWithDeadline(0, 16, 6500)}), ids);
     ASSERT_EQ(s2.code(), Status::Code::kOk);
     auto s3 = queue.tryAdmit(
-        makeSubmit(3, 1, {makeOwnerWithDeadline(0, 16, 6000)}), ids);
+        makeSubmit(3, {makeOwnerWithDeadline(0, 16, 6000)}), ids);
     ASSERT_EQ(s3.code(), Status::Code::kOk);
 
     auto picked = queue.pickForDispatch(4, 1 << 20);
@@ -949,7 +918,7 @@ TEST(AdmissionQueueTest, PromotionSkipsNoDeadlineOwners) {
 
     std::vector<QueueOwnerId> ids;
     auto status =
-        queue.tryAdmit(makeSubmit(1, 2,
+        queue.tryAdmit(makeSubmit(1,
                                   {makeOwnerWithDeadline(0, 16, 0),
                                    makeOwnerWithDeadline(1, 16, 2000)}),
                        ids);
@@ -967,7 +936,7 @@ TEST(AdmissionQueueTest, PromotionPreservesEdfWithinPromotedGroup) {
 
     std::vector<QueueOwnerId> ids;
     auto status =
-        queue.tryAdmit(makeSubmit(1, 3,
+        queue.tryAdmit(makeSubmit(1,
                                   {makeOwnerWithDeadline(0, 16, 2500),
                                    makeOwnerWithDeadline(1, 16, 2200),
                                    makeOwnerWithDeadline(2, 16, 2800)}),
@@ -991,7 +960,7 @@ TEST(AdmissionQueueTest, PromotionCoexistsWithStep3Drop) {
 
     std::vector<QueueOwnerId> ids;
     auto status = queue.tryAdmit(
-        makeSubmit(1, 3,
+        makeSubmit(1,
                    {makeDegradationEligibleOwnerWithDeadline(0, 16, 1010),
                     makeDegradationEligibleOwnerWithDeadline(1, 16, 1400),
                     makeDegradationEligibleOwnerWithDeadline(2, 16, 5000)}),
@@ -1018,13 +987,13 @@ TEST(AdmissionQueueTest, PromotionWithAdvancingTime) {
 
     std::vector<QueueOwnerId> ids;
     auto s1 = queue.tryAdmit(
-        makeSubmit(1, 1, {makeOwnerWithDeadline(0, 16, 1800)}), ids);
+        makeSubmit(1, {makeOwnerWithDeadline(0, 16, 1800)}), ids);
     ASSERT_EQ(s1.code(), Status::Code::kOk);
     auto s2 = queue.tryAdmit(
-        makeSubmit(2, 1, {makeOwnerWithDeadline(0, 16, 1400)}), ids);
+        makeSubmit(2, {makeOwnerWithDeadline(0, 16, 1400)}), ids);
     ASSERT_EQ(s2.code(), Status::Code::kOk);
     auto s3 = queue.tryAdmit(
-        makeSubmit(3, 1, {makeOwnerWithDeadline(0, 16, 3000)}), ids);
+        makeSubmit(3, {makeOwnerWithDeadline(0, 16, 3000)}), ids);
     ASSERT_EQ(s3.code(), Status::Code::kOk);
 
     auto picked1 = queue.pickForDispatch(1, 1 << 20);
@@ -1050,7 +1019,7 @@ TEST(AdmissionQueueTest, PromotionDisabledWithoutDeadlineAware) {
 
     std::vector<QueueOwnerId> ids;
     auto status =
-        queue.tryAdmit(makeSubmit(1, 3,
+        queue.tryAdmit(makeSubmit(1,
                                   {makeOwnerWithDeadline(0, 16, 1200),
                                    makeOwnerWithDeadline(1, 16, 5000),
                                    makeOwnerWithDeadline(2, 16, 1100)}),

--- a/mooncake-transfer-engine/tent/tests/admission_queue_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/admission_queue_test.cpp
@@ -253,15 +253,12 @@ TEST(AdmissionQueueTest, PreservesStagingReserveForStagingInternalOwners) {
     EXPECT_EQ(queue.outstandingBytes(), 100u);
 }
 
-TEST(AdmissionQueueTest, AlternatesOwnerKindLanesWithinPriority) {
+TEST(AdmissionQueueTest, BlocksOnSameLaneHeadWhenByteWindowIsTooSmall) {
     LocalTransferAdmissionQueue queue({4, 128, 0, 0});
     std::vector<QueueOwnerId> admitted_ids;
 
     auto status = queue.tryAdmit(
-        makeSubmit(1, 2,
-                   {makeOwner(0, 60),
-                    makeOwner(1, 10, QueueOwnerKind::StagingInternal)}),
-        admitted_ids);
+        makeSubmit(1, 2, {makeOwner(0, 60), makeOwner(1, 10)}), admitted_ids);
 
     ASSERT_EQ(status.code(), Status::Code::kOk);
     ASSERT_EQ(admitted_ids.size(), 2u);
@@ -269,11 +266,11 @@ TEST(AdmissionQueueTest, AlternatesOwnerKindLanesWithinPriority) {
     EXPECT_EQ(admitted_ids, expected_ids);
 
     auto picked = queue.pickForDispatch(2, 50);
-    EXPECT_EQ(picked, std::vector<QueueOwnerId>{admitted_ids[1]});
+    EXPECT_TRUE(picked.empty());
 
     picked = queue.pickForDispatch(2, 70);
 
-    EXPECT_EQ(picked, std::vector<QueueOwnerId>{admitted_ids[0]});
+    EXPECT_EQ(picked, expected_ids);
 }
 
 TEST(AdmissionQueueTest, DispatchesHigherPriorityBeforeEarlierLowerPriority) {
@@ -297,7 +294,7 @@ TEST(AdmissionQueueTest, DispatchesHigherPriorityBeforeEarlierLowerPriority) {
     EXPECT_EQ(picked, expected_ids);
 }
 
-TEST(AdmissionQueueTest, PreservesFifoWithinSamePriority) {
+TEST(AdmissionQueueTest, PreservesFifoWithinSamePriorityLane) {
     LocalTransferAdmissionQueue queue({4, 128, 0, 0});
     std::vector<QueueOwnerId> admitted_ids;
 
@@ -336,6 +333,29 @@ TEST(AdmissionQueueTest, OwnerKindDoesNotOverrideRequestPriority) {
 
     const std::vector<QueueOwnerId> expected_ids{admitted_ids[1],
                                                  admitted_ids[0]};
+    EXPECT_EQ(picked, expected_ids);
+}
+
+TEST(AdmissionQueueTest, AlternatesOwnerKindWithinSamePriority) {
+    LocalTransferAdmissionQueue queue({4, 128, 0, 0});
+    std::vector<QueueOwnerId> admitted_ids;
+
+    auto status = queue.tryAdmit(
+        makeSubmit(
+            1, 4,
+            {makeOwner(0, 10, QueueOwnerKind::User, {}, PRIO_MEDIUM),
+             makeOwner(1, 10, QueueOwnerKind::StagingInternal, {}, PRIO_MEDIUM),
+             makeOwner(2, 10, QueueOwnerKind::StagingInternal, {}, PRIO_MEDIUM),
+             makeOwner(3, 10, QueueOwnerKind::User, {}, PRIO_MEDIUM)}),
+        admitted_ids);
+
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+    ASSERT_EQ(admitted_ids.size(), 4u);
+
+    auto picked = queue.pickForDispatch(4, 128);
+
+    const std::vector<QueueOwnerId> expected_ids{
+        admitted_ids[1], admitted_ids[0], admitted_ids[2], admitted_ids[3]};
     EXPECT_EQ(picked, expected_ids);
 }
 

--- a/mooncake-transfer-engine/tent/tests/admission_queue_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/admission_queue_test.cpp
@@ -27,7 +27,8 @@ namespace {
 QueueOwnerInput makeOwner(
     size_t public_task_id, size_t length,
     QueueOwnerKind kind = QueueOwnerKind::User,
-    std::vector<size_t> derived_task_ids = std::vector<size_t>()) {
+    std::vector<size_t> derived_task_ids = std::vector<size_t>(),
+    int priority = PRIO_HIGH) {
     QueueOwnerInput owner;
     owner.owner_task_id = public_task_id;
     owner.derived_task_ids = std::move(derived_task_ids);
@@ -36,6 +37,7 @@ QueueOwnerInput makeOwner(
     owner.request.target_id = 1;
     owner.request.target_offset = public_task_id * 4096;
     owner.request.length = length;
+    owner.request.priority = priority;
     owner.kind = kind;
     return owner;
 }
@@ -102,6 +104,27 @@ TEST(AdmissionQueueTest, RejectsUnsupportedOwnerKindWithoutPartialAdmission) {
 
     auto invalid_owner = makeOwner(0, 16, static_cast<QueueOwnerKind>(99), {1});
     auto status = queue.tryAdmit(makeSubmit(1, 2, {std::move(invalid_owner)}),
+                                 admitted_ids);
+
+    EXPECT_EQ(status.code(), Status::Code::kInvalidArgument);
+    EXPECT_TRUE(admitted_ids.empty());
+    EXPECT_EQ(queue.outstandingOwners(), 0u);
+    EXPECT_EQ(queue.outstandingBytes(), 0u);
+
+    status = queue.tryAdmit(makeSubmit(1, 1, {makeOwner(2, 16)}), admitted_ids);
+
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+    ASSERT_EQ(admitted_ids.size(), 1u);
+    EXPECT_EQ(admitted_ids[0], 1u);
+}
+
+TEST(AdmissionQueueTest, RejectsUnsupportedPriorityWithoutPartialAdmission) {
+    LocalTransferAdmissionQueue queue({4, 128, 0, 0});
+    std::vector<QueueOwnerId> admitted_ids{99};
+
+    auto invalid_owner = makeOwner(0, 16);
+    invalid_owner.request.priority = 99;
+    auto status = queue.tryAdmit(makeSubmit(1, 1, {std::move(invalid_owner)}),
                                  admitted_ids);
 
     EXPECT_EQ(status.code(), Status::Code::kInvalidArgument);
@@ -230,7 +253,7 @@ TEST(AdmissionQueueTest, PreservesStagingReserveForStagingInternalOwners) {
     EXPECT_EQ(queue.outstandingBytes(), 100u);
 }
 
-TEST(AdmissionQueueTest, KeepsAdmissionOrderForDispatch) {
+TEST(AdmissionQueueTest, AlternatesOwnerKindLanesWithinPriority) {
     LocalTransferAdmissionQueue queue({4, 128, 0, 0});
     std::vector<QueueOwnerId> admitted_ids;
 
@@ -245,10 +268,74 @@ TEST(AdmissionQueueTest, KeepsAdmissionOrderForDispatch) {
     const std::vector<QueueOwnerId> expected_ids{1, 2};
     EXPECT_EQ(admitted_ids, expected_ids);
 
-    EXPECT_TRUE(queue.pickForDispatch(2, 50).empty());
+    auto picked = queue.pickForDispatch(2, 50);
+    EXPECT_EQ(picked, std::vector<QueueOwnerId>{admitted_ids[1]});
 
-    auto picked = queue.pickForDispatch(2, 70);
+    picked = queue.pickForDispatch(2, 70);
 
+    EXPECT_EQ(picked, std::vector<QueueOwnerId>{admitted_ids[0]});
+}
+
+TEST(AdmissionQueueTest, DispatchesHigherPriorityBeforeEarlierLowerPriority) {
+    LocalTransferAdmissionQueue queue({4, 128, 0, 0});
+    std::vector<QueueOwnerId> admitted_ids;
+
+    auto status = queue.tryAdmit(
+        makeSubmit(1, 3,
+                   {makeOwner(0, 10, QueueOwnerKind::User, {}, PRIO_LOW),
+                    makeOwner(1, 10, QueueOwnerKind::User, {}, PRIO_HIGH),
+                    makeOwner(2, 10, QueueOwnerKind::User, {}, PRIO_MEDIUM)}),
+        admitted_ids);
+
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+    ASSERT_EQ(admitted_ids.size(), 3u);
+
+    auto picked = queue.pickForDispatch(3, 128);
+
+    const std::vector<QueueOwnerId> expected_ids{
+        admitted_ids[1], admitted_ids[2], admitted_ids[0]};
+    EXPECT_EQ(picked, expected_ids);
+}
+
+TEST(AdmissionQueueTest, PreservesFifoWithinSamePriority) {
+    LocalTransferAdmissionQueue queue({4, 128, 0, 0});
+    std::vector<QueueOwnerId> admitted_ids;
+
+    auto status = queue.tryAdmit(
+        makeSubmit(1, 3,
+                   {makeOwner(0, 10, QueueOwnerKind::User, {}, PRIO_MEDIUM),
+                    makeOwner(1, 10, QueueOwnerKind::User, {}, PRIO_MEDIUM),
+                    makeOwner(2, 10, QueueOwnerKind::User, {}, PRIO_HIGH)}),
+        admitted_ids);
+
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+    ASSERT_EQ(admitted_ids.size(), 3u);
+
+    auto picked = queue.pickForDispatch(3, 128);
+
+    const std::vector<QueueOwnerId> expected_ids{
+        admitted_ids[2], admitted_ids[0], admitted_ids[1]};
+    EXPECT_EQ(picked, expected_ids);
+}
+
+TEST(AdmissionQueueTest, OwnerKindDoesNotOverrideRequestPriority) {
+    LocalTransferAdmissionQueue queue({4, 128, 0, 0});
+    std::vector<QueueOwnerId> admitted_ids;
+
+    auto status = queue.tryAdmit(
+        makeSubmit(
+            1, 2,
+            {makeOwner(0, 10, QueueOwnerKind::StagingInternal, {}, PRIO_LOW),
+             makeOwner(1, 10, QueueOwnerKind::User, {}, PRIO_HIGH)}),
+        admitted_ids);
+
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+    ASSERT_EQ(admitted_ids.size(), 2u);
+
+    auto picked = queue.pickForDispatch(2, 128);
+
+    const std::vector<QueueOwnerId> expected_ids{admitted_ids[1],
+                                                 admitted_ids[0]};
     EXPECT_EQ(picked, expected_ids);
 }
 

--- a/mooncake-transfer-engine/tent/tests/deadline_promotion_bench.cpp
+++ b/mooncake-transfer-engine/tent/tests/deadline_promotion_bench.cpp
@@ -60,7 +60,6 @@ void runDepth(size_t depth) {
 
         QueueSubmit submit;
         submit.batch_token = repeat + 1;
-        submit.batch_slots_left = depth;
         submit.owners.reserve(depth);
         for (size_t i = 0; i < depth; ++i) {
             // Interleave urgent and comfortable requests so every dispatch

--- a/mooncake-transfer-engine/tent/tests/proxy_manager_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/proxy_manager_test.cpp
@@ -39,15 +39,17 @@ Request makeRequest(int priority) {
 TEST(ProxyManagerTest, SubmitReturnsTooManyRequestsWhenShardQueueIsFull) {
     auto proxy = ProxyManager::createForTest(nullptr, 1);
 
-    TaskInfo first;
-    TaskInfo second;
+    constexpr size_t kProxyShards = 8;
+    std::vector<TaskInfo> tasks(kProxyShards + 1);
     std::vector<std::string> params{"server", "local", "remote"};
 
-    auto status = proxy->submit(&first, 1, params);
-    ASSERT_TRUE(status.ok()) << status.ToString();
-    EXPECT_EQ(first.staging_status, TransferStatusEnum::PENDING);
+    for (size_t i = 0; i < kProxyShards; ++i) {
+        auto status = proxy->submit(&tasks[i], i + 1, params);
+        ASSERT_TRUE(status.ok()) << status.ToString();
+        EXPECT_EQ(tasks[i].staging_status, TransferStatusEnum::PENDING);
+    }
 
-    status = proxy->submit(&second, 2, params);
+    auto status = proxy->submit(&tasks.back(), kProxyShards + 1, params);
     EXPECT_TRUE(status.IsTooManyRequests()) << status.ToString();
 }
 

--- a/mooncake-transfer-engine/tent/tests/proxy_manager_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/proxy_manager_test.cpp
@@ -1,0 +1,98 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "tent/runtime/proxy_manager.h"
+#include "tent/runtime/transfer_engine_impl.h"
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+Request makeRequest(int priority) {
+    Request request;
+    request.opcode = Request::WRITE;
+    request.source = reinterpret_cast<void*>(0x1000);
+    request.target_id = 7;
+    request.target_offset = 0x2000;
+    request.length = 4096;
+    request.priority = priority;
+    return request;
+}
+
+TEST(ProxyManagerTest, SubmitReturnsTooManyRequestsWhenShardQueueIsFull) {
+    auto proxy = ProxyManager::createWithoutWorkersForTest(nullptr, 1);
+
+    TaskInfo first;
+    TaskInfo second;
+    std::vector<std::string> params{"server", "local", "remote"};
+
+    auto status = proxy->submit(&first, 1, params);
+    ASSERT_TRUE(status.ok()) << status.ToString();
+    EXPECT_EQ(first.staging_status, TransferStatusEnum::PENDING);
+
+    status = proxy->submit(&second, 2, params);
+    EXPECT_TRUE(status.IsTooManyRequests()) << status.ToString();
+}
+
+TEST(ProxyManagerTest, InternalStageRequestsInheritPriority) {
+    auto request = makeRequest(PRIO_LOW);
+
+    auto local_stage =
+        ProxyManager::makeLocalStageRequest(request, 0x3000, 512, 128);
+    EXPECT_EQ(local_stage.opcode, request.opcode);
+    EXPECT_EQ(local_stage.source,
+              reinterpret_cast<uint8_t*>(request.source) + 128);
+    EXPECT_EQ(local_stage.target_id, LOCAL_SEGMENT_ID);
+    EXPECT_EQ(local_stage.target_offset, 0x3000);
+    EXPECT_EQ(local_stage.length, 512);
+    EXPECT_EQ(local_stage.priority, PRIO_LOW);
+
+    auto cross_stage =
+        ProxyManager::makeCrossStageRequest(request, 0x3000, 0x4000, 512);
+    EXPECT_EQ(cross_stage.opcode, request.opcode);
+    EXPECT_EQ(cross_stage.source, reinterpret_cast<void*>(0x3000));
+    EXPECT_EQ(cross_stage.target_id, request.target_id);
+    EXPECT_EQ(cross_stage.target_offset, 0x4000);
+    EXPECT_EQ(cross_stage.length, 512);
+    EXPECT_EQ(cross_stage.priority, PRIO_LOW);
+
+    auto remote_stage =
+        ProxyManager::makeRemoteStageRequest(request, 0x4000, 512, 128);
+    EXPECT_EQ(remote_stage.opcode, request.opcode);
+    EXPECT_EQ(remote_stage.source, reinterpret_cast<void*>(0x4000));
+    EXPECT_EQ(remote_stage.target_id, LOCAL_SEGMENT_ID);
+    EXPECT_EQ(remote_stage.target_offset, request.target_offset + 128);
+    EXPECT_EQ(remote_stage.length, 512);
+    EXPECT_EQ(remote_stage.priority, PRIO_LOW);
+}
+
+TEST(ProxyManagerTest, UnboundedShardQueueKeepsLegacyAcceptBehavior) {
+    auto proxy = ProxyManager::createWithoutWorkersForTest(nullptr, 0);
+    std::vector<std::string> params{"server", "local", "remote"};
+
+    TaskInfo first;
+    TaskInfo second;
+    EXPECT_TRUE(proxy->submit(&first, 1, params).ok());
+    EXPECT_TRUE(proxy->submit(&second, 2, params).ok());
+}
+
+}  // namespace
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/tests/proxy_manager_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/proxy_manager_test.cpp
@@ -37,7 +37,7 @@ Request makeRequest(int priority) {
 }
 
 TEST(ProxyManagerTest, SubmitReturnsTooManyRequestsWhenShardQueueIsFull) {
-    auto proxy = ProxyManager::createWithoutWorkersForTest(nullptr, 1);
+    auto proxy = ProxyManager::createForTest(nullptr, 1);
 
     TaskInfo first;
     TaskInfo second;
@@ -84,7 +84,7 @@ TEST(ProxyManagerTest, InternalStageRequestsInheritPriority) {
 }
 
 TEST(ProxyManagerTest, UnboundedShardQueueKeepsLegacyAcceptBehavior) {
-    auto proxy = ProxyManager::createWithoutWorkersForTest(nullptr, 0);
+    auto proxy = ProxyManager::createForTest(nullptr, 0);
     std::vector<std::string> params{"server", "local", "remote"};
 
     TaskInfo first;

--- a/mooncake-transfer-engine/tent/tests/runtime_queue_dispatch_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/runtime_queue_dispatch_test.cpp
@@ -403,6 +403,7 @@ TEST(RuntimeQueueDispatch, ProgressWorkerRefillsWindowFromTransportNotify) {
 
 TEST(RuntimeQueueDispatch, RuntimeQueueDrainsWithoutUserPolling) {
     auto cfg = makeRuntimeQueueConfig(1, 1UL << 20);
+    cfg->set("enable_progress_worker", true);
     cfg->set("runtime_queue/progress_fallback_interval_us", 1000UL);
     TransferEngineImpl engine(cfg);
     ASSERT_TRUE(engine.available());
@@ -453,6 +454,7 @@ TEST(RuntimeQueueDispatch, RuntimeQueueDrainsWithoutUserPolling) {
 
 TEST(RuntimeQueueDispatch, EarlyFreeReclaimsAfterQueuedCompletion) {
     auto cfg = makeRuntimeQueueConfig(1, 1UL << 20);
+    cfg->set("enable_progress_worker", true);
     TransferEngineImpl engine(cfg);
     ASSERT_TRUE(engine.available());
 

--- a/mooncake-transfer-engine/tent/tests/runtime_queue_dispatch_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/runtime_queue_dispatch_test.cpp
@@ -403,7 +403,6 @@ TEST(RuntimeQueueDispatch, ProgressWorkerRefillsWindowFromTransportNotify) {
 
 TEST(RuntimeQueueDispatch, RuntimeQueueDrainsWithoutUserPolling) {
     auto cfg = makeRuntimeQueueConfig(1, 1UL << 20);
-    cfg->set("enable_progress_worker", true);
     cfg->set("runtime_queue/progress_fallback_interval_us", 1000UL);
     TransferEngineImpl engine(cfg);
     ASSERT_TRUE(engine.available());
@@ -454,7 +453,6 @@ TEST(RuntimeQueueDispatch, RuntimeQueueDrainsWithoutUserPolling) {
 
 TEST(RuntimeQueueDispatch, EarlyFreeReclaimsAfterQueuedCompletion) {
     auto cfg = makeRuntimeQueueConfig(1, 1UL << 20);
-    cfg->set("enable_progress_worker", true);
     TransferEngineImpl engine(cfg);
     ASSERT_TRUE(engine.available());
 

--- a/mooncake-transfer-engine/tent/tests/runtime_queue_dispatch_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/runtime_queue_dispatch_test.cpp
@@ -544,6 +544,7 @@ TEST(RuntimeQueueDispatch, ProgressWorkerRefillsWindowFromTransportNotify) {
 
 TEST(RuntimeQueueDispatch, RuntimeQueueDrainsWithoutUserPolling) {
     auto cfg = makeRuntimeQueueConfig(1, 1UL << 20);
+    cfg->set("enable_progress_worker", true);
     cfg->set("runtime_queue/progress_fallback_interval_us", 1000UL);
     TransferEngineImpl engine(cfg);
     ASSERT_TRUE(engine.available());
@@ -594,6 +595,7 @@ TEST(RuntimeQueueDispatch, RuntimeQueueDrainsWithoutUserPolling) {
 
 TEST(RuntimeQueueDispatch, EarlyFreeReclaimsAfterQueuedCompletion) {
     auto cfg = makeRuntimeQueueConfig(1, 1UL << 20);
+    cfg->set("enable_progress_worker", true);
     TransferEngineImpl engine(cfg);
     ASSERT_TRUE(engine.available());
 

--- a/mooncake-transfer-engine/tent/tests/runtime_queue_dispatch_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/runtime_queue_dispatch_test.cpp
@@ -544,7 +544,6 @@ TEST(RuntimeQueueDispatch, ProgressWorkerRefillsWindowFromTransportNotify) {
 
 TEST(RuntimeQueueDispatch, RuntimeQueueDrainsWithoutUserPolling) {
     auto cfg = makeRuntimeQueueConfig(1, 1UL << 20);
-    cfg->set("enable_progress_worker", true);
     cfg->set("runtime_queue/progress_fallback_interval_us", 1000UL);
     TransferEngineImpl engine(cfg);
     ASSERT_TRUE(engine.available());
@@ -595,7 +594,6 @@ TEST(RuntimeQueueDispatch, RuntimeQueueDrainsWithoutUserPolling) {
 
 TEST(RuntimeQueueDispatch, EarlyFreeReclaimsAfterQueuedCompletion) {
     auto cfg = makeRuntimeQueueConfig(1, 1UL << 20);
-    cfg->set("enable_progress_worker", true);
     TransferEngineImpl engine(cfg);
     ASSERT_TRUE(engine.available());
 


### PR DESCRIPTION
## Description

 #2132 
This PR changes the TENT runtime queue from FIFO to strict-priority dispatch and improves the staging path under queue pressure.

  Queued owners are dispatched in `PRIO_HIGH`, `PRIO_MEDIUM`, and `PRIO_LOW` order. Lower-priority work is dispatched only when all higher-priority queues are empty. The runtime queue does not promote requests based on wait time, so accumulated low-priority work cannot gain priority over newly submitted high-priority work.

  User work and staging-internal work use separate lanes within each priority.  The scheduler alternates between these lanes while preserving FIFO order inside each lane. Internal staging transfers inherit the priority of the original request.

  Dispatch is bounded by both the number of in-flight owners and their total bytes. A request must fit in the remaining dispatch byte window. If the  highest non-empty priority cannot fit, lower-priority work is not dispatched
  just to fill the remaining window. This limits how much work can be submitted to a non-preemptive transport ahead of future high-priority requests.

  The staging path now propagates pressure back to the runtime queue.  `ProxyManager::submit()` supports a configurable per-shard queue limit through `staging/max_queued_tasks_per_shard` and returns `TooManyRequests` when the limit is reached. Runtime-queued staging transfers are requeued on temporary   proxy pressure, while non-retryable failures complete as failures.  Stage-buffer pin errors are returned as status errors instead of aborting the  process.

  The PR also reduces runtime queue overhead by using batch-local public-task indexes and draining progress-worker notifications in batches.

  Main changes:

  - dispatch queued owners using strict `HIGH > MEDIUM > LOW` priority
  - preserve FIFO order within each priority and owner-kind lane
  - alternate user and staging-internal work at the same priority
  - bound in-flight dispatch by owner count and bytes
  - preserve staging admission reserves without treating owner kind as priority
  - make staging-internal transfers inherit the original request priority
  - support bounded staging proxy shard queues
  - requeue staged transfers on temporary proxy pressure
  - return stage-buffer pin failures as status errors
  - reduce public-task lookup and progress-worker wakeup overhead


## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## How Has This Been Tested?
### Tests

```bash
cmake --build build --target \
    admission_queue_test \
    tent_runtime_queue_dispatch_test \
    tent_progress_worker_test \
    tent_metrics_recording_test \
    tebench_qos_metrics_test \
    tebench
./build/mooncake-transfer-engine/tent/tests/admission_queue_test
./build/mooncake-transfer-engine/tent/tests/tent_runtime_queue_dispatch_test
./build/mooncake-transfer-engine/tent/tests/tent_progress_worker_test
./build/mooncake-transfer-engine/tent/tests/tent_metrics_recording_test
./build/mooncake-transfer-engine/benchmark/tebench_qos_metrics_test
```

All tests passed.

### Two-node eRDMA benchmark

**Environment:**
- Two Aliyun instances, each with 16 vCPUs and 64 GiB RAM
- TENT + DRAM + eRDMA only
- Normal RDMA worker path; no TCP, SHM, staging, proxy, or direct fast path
- Request merging disabled
- HIGH/LOW selected only through `Request.priority`
- `intent = UNSPEC`, `deadline = 0`
- 5-second warmup, 30-second measurement, 5 repetitions
- Independent `ib_read_bw`: 25.92 Gbit/s

**Mixed overload workload:**
- HIGH: 2 threads, 4 KiB, batch 16
- LOW: 4 threads, 4 MiB, batch 32
- Approximately 160 maximum outstanding owners

Latency uses the existing causal timestamps:
- `queue_wait = t1 - t0`
- `dispatch = t2 - t1`
- `transport = t3 - t2`
- `E2E = t3 - t0`

#### Queue OFF vs Queue ON

Queue ON uses a 32-owner dispatch window.

| Metric                      | Queue OFF   | Queue ON    | Delta                     |
| --------------------------- | ----------- | ----------- | ------------------------- |
| FG average E2E              | 40.849 ms   | 27.368 ms   | -33.0%                    |
| FG P99 E2E                  | 195.097 ms  | 49.634 ms   | -74.6%                    |
| FG P999 E2E                 | 199.510 ms  | 49.972 ms   | -75.0%                    |
| BG average E2E              | 145.496 ms  | 145.396 ms  | -0.07%                    |
| Aggregate throughput        | 3.239905 GB/s | 3.244270 GB/s | +0.13%                  |
| Link utilization            | 100.00%     | 100.13%     | approximately unchanged  |
| Initiator CPU               | 66.24%      | 56.10%      | -10.14 pp                 |

#### Average causal breakdown

| FG stage  | Queue OFF   | Queue ON    |
| --------- | ----------- | ----------- |
| Queue wait| 0           | 14.337 ms   |
| Dispatch  | 15.795 µs   | 0.309 µs    |
| Transport | 40.832 ms   | 13.030 ms   |
| E2E       | 40.849 ms   | 27.368 ms   |

The queue added 14.337 ms of controlled waiting but reduced downstream transport time by 27.802 ms.

#### Backlog verification

| Metric                          | Queue OFF | Queue ON |
| ------------------------------- | --------- | -------- |
| Merge count                     | 0         | 0        |
| Average queued owners           | N/A       | 108.16   |
| P99 queued owners               | N/A       | 128      |
| Samples with backlog            | N/A       | 100%     |
| Average inflight owners         | 122.78    | 31.99    |
| Maximum dispatch inflight owners| 160       | 32       |
| Admission rejects               | N/A       | 0        |

This confirms that the queue maintained a real backlog and bounded the logical owners admitted to RDMA. It does not directly limit RDMA slices, WQEs, or SQ entries.

#### Dispatch-window sweep

| Window | FG P99     | Aggregate throughput | Average queued owners |
| ------ | ---------- | -------------------- | --------------------- |
| 32     | 49.634 ms  | 3.244270 GB/s        | 108.16                |
| 64     | 97.644 ms  | 3.242127 GB/s        | 69.21                 |
| 128    | 196.656 ms | 3.239736 GB/s        | 9.15                  |

Window 32 produced the best foreground P99 while keeping the eRDMA link saturated.

#### Load sweep

| Load           | Queue OFF FG P99 | Queue ON FG P99 | Throughput delta |
| -------------- | ---------------- | --------------- | ---------------- |
| Light          | 0.199 ms         | 0.713 ms        | -13.50%          |
| Near saturation| 49.127 ms        | 49.633 ms       | +0.04%           |
| Overload       | 195.097 ms       | 49.634 ms       | +0.13%           |

The runtime queue adds overhead at light load and provides its main benefit under sustained overload. These results compare Queue OFF with Queue ON plus priority scheduling; they do not isolate priority arbitration from FIFO scheduling.


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [x] AI tools were used (specify below)
Claude Code was used to assist with implementation and review. The final changes were reviewed and validated by myself.