### PR TITLE
[TENT] Port TE RDMA lifecycle and tests to TENT

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint.h
@@ -222,7 +222,7 @@ class RdmaEndPoint : public std::enable_shared_from_this<RdmaEndPoint> {
     std::mutex notify_send_mutex_;
     std::condition_variable notify_send_cv_;
     size_t notify_pending_count_ = 0;  // Number of pending sends
-    uint64_t notify_send_wr_id_ = 0;  // Circular counter for wr_id
+    uint64_t notify_send_wr_id_ = 0;   // Circular counter for wr_id
     std::atomic<bool> notify_connected_{false};
 
     // Two-phase destruction constants (matching TE)

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint.h
@@ -106,7 +106,6 @@ class RdmaEndPoint : public std::enable_shared_from_this<RdmaEndPoint> {
     // WRs have been drained, actually destroys QPs and frees resources.
     // Returns true if destruction is complete, false if outstanding WRs remain.
     void beginDestroy();
-    void beginDestroyNoLock();  // Internal version without locking
     bool finishDestroy();
 
     Status connect(const std::string& peer_server_name,
@@ -179,6 +178,7 @@ class RdmaEndPoint : public std::enable_shared_from_this<RdmaEndPoint> {
 
    private:
     // Caller must hold lock_ in write mode.
+    void beginDestroyNoLock();
     int deconstructUnlocked();
 
     void resetInflightSlices();
@@ -227,8 +227,8 @@ class RdmaEndPoint : public std::enable_shared_from_this<RdmaEndPoint> {
 
     // Two-phase destruction constants (matching TE)
     static constexpr double kFinishDestroyTimeoutSec = 30.0;
-    static constexpr int kFinishDestroyMaxRetries = 3;
-    int finish_destroy_retries_ = 0;  // Retry counter for finishDestroy
+    static constexpr int kMaxDestroyErrorLogs = 3;
+    int destroy_error_count_ = 0;
 };
 }  // namespace tent
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint.h
@@ -93,8 +93,7 @@ class RdmaEndPoint : public std::enable_shared_from_this<RdmaEndPoint> {
     };
 
     int construct(RdmaContext* context, EndPointParams* params,
-                  const std::string& endpoint_name,
-                  std::atomic<int>* endpoints_count = nullptr);
+                  const std::string& endpoint_name);
 
     int deconstruct();
 
@@ -208,8 +207,6 @@ class RdmaEndPoint : public std::enable_shared_from_this<RdmaEndPoint> {
     std::string peer_server_name_;
     std::string peer_nic_name_;
     std::vector<uint32_t> peer_qp_num_list_;
-    std::atomic<int>* endpoints_count_;
-
     // Notification QP (one per endpoint for control plane operations)
     ibv_qp* notify_qp_ = nullptr;
 
@@ -220,11 +217,13 @@ class RdmaEndPoint : public std::enable_shared_from_this<RdmaEndPoint> {
     std::vector<ibv_mr*> notify_recv_mrs_;  // Memory regions for recv buffers
     std::vector<char> notify_send_buffer_;  // Single contiguous send buffer
     ibv_mr* notify_send_mr_ = nullptr;      // Single MR for all send slots
+    // Serializes notification buffer/QP access against deconstruction.
+    std::mutex notify_resource_mutex_;
     std::mutex notify_send_mutex_;
     std::condition_variable notify_send_cv_;
-    int notify_pending_count_ = 0;    // Number of pending sends
+    size_t notify_pending_count_ = 0;  // Number of pending sends
     uint64_t notify_send_wr_id_ = 0;  // Circular counter for wr_id
-    bool notify_connected_ = false;
+    std::atomic<bool> notify_connected_{false};
 
     // Two-phase destruction constants (matching TE)
     static constexpr double kFinishDestroyTimeoutSec = 30.0;

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint_store.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint_store.h
@@ -37,6 +37,10 @@ class EndpointStore {
 
     virtual int remove(RdmaEndPoint *ep) = 0;
 
+    // Terminal context-shutdown operation. Unlike remove()/reclaim(), clear()
+    // synchronously releases every endpoint's verbs resources because workers
+    // have stopped and can no longer drain CQ flush completions. Callers must
+    // not use the store again after clear() returns.
     virtual void clear() = 0;
 
     virtual size_t size() = 0;
@@ -111,7 +115,6 @@ class SIEVEEndpointStore : public EndpointStore {
     std::atomic<int> waiting_list_len_;
 
     size_t max_size_;
-    std::atomic<int> endpoints_count_{0};
 };
 }  // namespace tent
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint_store.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint_store.h
@@ -28,6 +28,8 @@ using namespace mooncake;
 
 namespace mooncake {
 namespace tent {
+class EndpointStoreTestAccess;
+
 class EndpointStore {
    public:
     virtual std::shared_ptr<RdmaEndPoint> get(const std::string &key) = 0;
@@ -41,7 +43,7 @@ class EndpointStore {
     // synchronously releases every endpoint's verbs resources because workers
     // have stopped and can no longer drain CQ flush completions. Callers must
     // not use the store again after clear() returns.
-    virtual void clear() = 0;
+    virtual int clear() = 0;
 
     virtual size_t size() = 0;
 
@@ -61,17 +63,16 @@ class FIFOEndpointStore : public EndpointStore {
 
     int remove(RdmaEndPoint *ep) override;
 
-    void clear();
+    int clear() override;
 
     size_t size() override;
 
     void evictOne() override;
     void reclaim() override;
 
-    void testOnlyInsertWaiting(std::shared_ptr<RdmaEndPoint> endpoint);
-    size_t testOnlyWaitingListSize();
-
    private:
+    friend class EndpointStoreTestAccess;
+
     RdmaContext &context_;
     RWSpinlock endpoint_map_lock_;
     std::unordered_map<std::string, std::shared_ptr<RdmaEndPoint>>
@@ -94,7 +95,7 @@ class SIEVEEndpointStore : public EndpointStore {
 
     std::shared_ptr<RdmaEndPoint> getOrInsert(const std::string &key) override;
 
-    void clear();
+    int clear() override;
 
     size_t size() override;
 
@@ -102,10 +103,9 @@ class SIEVEEndpointStore : public EndpointStore {
     void evictOne() override;
     void reclaim() override;
 
-    void testOnlyInsertWaiting(std::shared_ptr<RdmaEndPoint> endpoint);
-    size_t testOnlyWaitingListSize();
-
    private:
+    friend class EndpointStoreTestAccess;
+
     RdmaContext &context_;
     RWSpinlock endpoint_map_lock_;
     // The bool represents visited

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint_store.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint_store.h
@@ -68,6 +68,9 @@ class FIFOEndpointStore : public EndpointStore {
     void evictOne() override;
     void reclaim() override;
 
+    void testOnlyInsertWaiting(std::shared_ptr<RdmaEndPoint> endpoint);
+    size_t testOnlyWaitingListSize();
+
    private:
     RdmaContext &context_;
     RWSpinlock endpoint_map_lock_;
@@ -98,6 +101,9 @@ class SIEVEEndpointStore : public EndpointStore {
     int remove(RdmaEndPoint *ep) override;
     void evictOne() override;
     void reclaim() override;
+
+    void testOnlyInsertWaiting(std::shared_ptr<RdmaEndPoint> endpoint);
+    size_t testOnlyWaitingListSize();
 
    private:
     RdmaContext &context_;

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/params.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/params.h
@@ -72,7 +72,8 @@ struct RdmaParams {
     DeviceParams device;
     EndPointParams endpoint;
     WorkerParams workers;
-    bool verbose;
+    bool verbose = false;
+    bool log_slice_affinity = false;
 };
 }  // namespace tent
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/rdma_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/rdma_transport.h
@@ -140,10 +140,12 @@ class RdmaTransport : public Transport {
 
     // Map QP number to Endpoint for notification processing
     RWSpinlock notify_endpoint_map_lock_;
-    std::unordered_map<uint32_t, RdmaEndPoint*> notify_qp_to_endpoint_;
+    std::unordered_map<uint32_t, std::weak_ptr<RdmaEndPoint>>
+        notify_qp_to_endpoint_;
 
     // Register/unregister notification QP (called by Endpoint)
-    void registerNotifyQp(uint32_t qp_num, RdmaEndPoint* endpoint);
+    void registerNotifyQp(uint32_t qp_num,
+                          const std::shared_ptr<RdmaEndPoint>& endpoint);
     void unregisterNotifyQp(uint32_t qp_num);
     std::shared_ptr<RdmaEndPoint> getEndpoint(SegmentID target_id,
                                               int device_id);

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/workers.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/workers.h
@@ -80,6 +80,7 @@ class Workers {
         BufferDesc *buffer;
         const Topology::MemEntry *topo_entry;
         const Topology *topo;
+        std::string location;
     };
 
     Status getRouteHint(RouteHint &hint, SegmentID segment_id, uint64_t addr,
@@ -213,6 +214,9 @@ class Workers {
     uint64_t priority_promotion_timeout_ns_;  // Timeout for priority promotion
 
     std::unique_ptr<DeviceSelector> device_selector_;
+    // File contents loaded once from workers.rail_topo_path and shared by all
+    // per-worker/per-peer RailMonitor instances.
+    std::string rail_topo_json_;
     bool always_tier1_ = false;
 };
 }  // namespace tent

--- a/mooncake-transfer-engine/tent/src/common/config.cpp
+++ b/mooncake-transfer-engine/tent/src/common/config.cpp
@@ -117,6 +117,8 @@ Status ConfigHelper::loadFromEnv(Config& config) {
               "transports/rdma/workers/max_retry_count");
     setConfig(config, "MC_DISABLE_GPU_DIRECT_RDMA",
               "transports/rdma/disable_gpu_direct_rdma");
+    setConfig(config, "MC_LOG_RDMA_SLICE_AFFINITY",
+              "transports/rdma/log_slice_affinity");
     return status;
 }
 

--- a/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
@@ -443,7 +443,11 @@ int RdmaContext::disable() {
         LOG(WARNING) << "RDMA context " << name() << " has been deconstructed";
         return 0;
     }
-    endpoint_store_->clear();
+    if (endpoint_store_->clear()) {
+        LOG(ERROR) << "Failed to destroy all endpoints for context " << name()
+                   << "; preserving CQ, PD and device resources for retry";
+        return -1;
+    }
 
     for (auto& entry : mr_set_) {
         int ret = verbs_.ibv_dereg_mr(entry);

--- a/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
@@ -210,8 +210,7 @@ int RdmaEndPoint::deconstructUnlocked() {
         for (auto& mr : notify_recv_mrs_) {
             if (mr) {
                 if (context_->verbs_.ibv_dereg_mr(mr))
-                    PLOG(ERROR)
-                        << "Failed to deregister notification recv MR";
+                    PLOG(ERROR) << "Failed to deregister notification recv MR";
                 mr = nullptr;
             }
         }
@@ -437,9 +436,8 @@ Status RdmaEndPoint::connect(const std::string& peer_server_name,
             // establishment failed. Reuse only the exact endpoint generation
             // that issued this RPC; EP_READY alone is not sufficient.
             RWSpinlock::WriteGuard guard(lock_);
-            const bool same_peer =
-                peer_server_name_ == peer_server_name &&
-                peer_nic_name_ == peer_nic_name;
+            const bool same_peer = peer_server_name_ == peer_server_name &&
+                                   peer_nic_name_ == peer_nic_name;
             const bool same_local_qps = qpNum() == local_desc.qp_num;
             if (status_.load(std::memory_order_relaxed) == EP_READY &&
                 same_peer && same_local_qps) {

--- a/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
@@ -58,24 +58,26 @@ static int setupNotifyQpConnection(ibv_qp* qp, RdmaContext* ctx,
                                    uint8_t service_level = 0,
                                    uint8_t traffic_class = 0);
 
-RdmaEndPoint::RdmaEndPoint() : status_(EP_UNINIT) {}
+RdmaEndPoint::RdmaEndPoint()
+    : status_(EP_UNINIT),
+      context_(nullptr),
+      params_(nullptr),
+      wr_depth_list_(nullptr),
+      inflight_slices_(0),
+      destroy_start_time_(0) {}
 
-RdmaEndPoint::~RdmaEndPoint() {
-    if (status_.load(std::memory_order_relaxed) != EP_UNINIT) deconstruct();
-    if (endpoints_count_)
-        endpoints_count_->fetch_sub(1, std::memory_order_relaxed);
-}
+RdmaEndPoint::~RdmaEndPoint() { deconstruct(); }
 
 int RdmaEndPoint::construct(RdmaContext* context, EndPointParams* params,
-                            const std::string& endpoint_name,
-                            std::atomic<int>* endpoints_count) {
+                            const std::string& endpoint_name) {
     context_ = context;
     params_ = params;
     endpoint_name_ = endpoint_name;
     inflight_slices_ = 0;
-    endpoints_count_ = endpoints_count;
     qp_list_.resize(params_->qp_mul_factor);
-    wr_depth_list_ = new WrDepthBlock[params_->qp_mul_factor];
+    // Value-initialize the full array because cleanup may run after only a
+    // prefix of QPs has been created.
+    wr_depth_list_ = new WrDepthBlock[params_->qp_mul_factor]();
 
     for (int i = 0; i < params_->qp_mul_factor; ++i) {
         wr_depth_list_[i].value = 0;
@@ -172,49 +174,63 @@ int RdmaEndPoint::construct(RdmaContext* context, EndPointParams* params,
 
 int RdmaEndPoint::deconstruct() {
     RWSpinlock::WriteGuard guard(lock_);
+    if (status_.load(std::memory_order_relaxed) == EP_DESTROYED) return 0;
+    // Synchronous terminal destruction includes the retirement transition so
+    // callers cannot tear down live QPs without first blocking submissions,
+    // unpublishing notification state and waking notification senders.
+    beginDestroyNoLock();
     return deconstructUnlocked();
 }
 
 int RdmaEndPoint::deconstructUnlocked() {
     auto current_status = status_.load(std::memory_order_relaxed);
-    // Idempotent: if already destroyed or never initialized, skip cleanup
-    if (current_status == EP_DESTROYED || current_status == EP_UNINIT) return 0;
+    // Idempotent, including delayed destruction through an external shared_ptr.
+    if (current_status == EP_DESTROYED) return 0;
     status_.store(EP_DESTROYED, std::memory_order_relaxed);
     resetInflightSlices();
     peer_qp_num_list_.clear();
 
-    // Destroy notification QP
-    if (notify_qp_) {
-        // Unregister from transport before destroying
-        context_->transport_.unregisterNotifyQp(notify_qp_->qp_num);
-        if (context_->verbs_.ibv_destroy_qp(notify_qp_))
-            PLOG(ERROR) << "Failed to destroy notification QP";
-        notify_qp_ = nullptr;
-        notify_connected_ = false;
-    }
+    // A default-constructed endpoint owns no verbs resources. A partially
+    // constructed endpoint has context_ set and must be cleaned below even
+    // though it never reached EP_HANDSHAKING.
+    if (!context_) return 0;
 
-    // Deregister and free notification memory
-    for (auto& mr : notify_recv_mrs_) {
-        if (mr) {
-            if (context_->verbs_.ibv_dereg_mr(mr))
-                PLOG(ERROR) << "Failed to deregister notification recv MR";
-            mr = nullptr;
+    {
+        std::lock_guard<std::mutex> notify_guard(notify_resource_mutex_);
+        // Destroy notification QP
+        if (notify_qp_) {
+            // Unregister from transport before destroying
+            context_->transport_.unregisterNotifyQp(notify_qp_->qp_num);
+            if (context_->verbs_.ibv_destroy_qp(notify_qp_))
+                PLOG(ERROR) << "Failed to destroy notification QP";
+            notify_qp_ = nullptr;
         }
-    }
-    notify_recv_mrs_.clear();
-    if (notify_send_mr_) {
-        if (context_->verbs_.ibv_dereg_mr(notify_send_mr_))
-            PLOG(ERROR) << "Failed to deregister notification send MR";
-        notify_send_mr_ = nullptr;
-    }
 
-    notify_recv_buffers_.clear();
-    notify_send_buffer_.clear();
+        // Deregister and free notification memory
+        for (auto& mr : notify_recv_mrs_) {
+            if (mr) {
+                if (context_->verbs_.ibv_dereg_mr(mr))
+                    PLOG(ERROR)
+                        << "Failed to deregister notification recv MR";
+                mr = nullptr;
+            }
+        }
+        notify_recv_mrs_.clear();
+        if (notify_send_mr_) {
+            if (context_->verbs_.ibv_dereg_mr(notify_send_mr_))
+                PLOG(ERROR) << "Failed to deregister notification send MR";
+            notify_send_mr_ = nullptr;
+        }
+
+        notify_recv_buffers_.clear();
+        notify_send_buffer_.clear();
+    }
 
     for (size_t i = 0; i < qp_list_.size(); ++i) {
-        if (context_->verbs_.ibv_destroy_qp(qp_list_[i]))
+        if (qp_list_[i] && context_->verbs_.ibv_destroy_qp(qp_list_[i]))
             PLOG(ERROR) << "ibv_destroy_qp";
-        cancelQuota(i, wr_depth_list_[i].value);
+        if (wr_depth_list_ && wr_depth_list_[i].value != 0)
+            cancelQuota(i, wr_depth_list_[i].value);
     }
     qp_list_.clear();
     slice_queue_.clear();
@@ -239,17 +255,41 @@ void RdmaEndPoint::beginDestroyNoLock() {
     destroy_start_time_ = getCurrentTimeInNano();
     status_.store(EP_DESTROYING, std::memory_order_release);
 
+    // EP_UNINIT also covers construction failure. Such QPs were never
+    // published and may still be in RESET/INIT, so forcing an ERR transition
+    // is unnecessary (and invalid on some providers); deconstructUnlocked()
+    // will destroy whichever resources were created successfully.
+    if (current_status == EP_UNINIT || !context_) return;
+
+    // Stop publishing the endpoint before QPs start flushing. A notification
+    // completion that already locked the weak_ptr may finish safely, while no
+    // later completion can acquire a retiring endpoint.
+    if (notify_qp_) {
+        context_->transport_.unregisterNotifyQp(notify_qp_->qp_num);
+    }
+    {
+        std::lock_guard<std::mutex> notify_guard(notify_send_mutex_);
+        notify_connected_ = false;
+        notify_send_cv_.notify_all();
+    }
+
     // Transition QPs to ERR state so hardware flushes inflight WRs to CQ
     ibv_qp_attr attr;
     memset(&attr, 0, sizeof(attr));
     attr.qp_state = IBV_QPS_ERR;
 
     for (size_t i = 0; i < qp_list_.size(); ++i) {
+        if (!qp_list_[i]) continue;
         int ret =
             context_->verbs_.ibv_modify_qp(qp_list_[i], &attr, IBV_QP_STATE);
         if (ret) {
             PLOG(ERROR) << "Failed to modify QP to ERR in beginDestroy";
         }
+    }
+    if (notify_qp_ &&
+        context_->verbs_.ibv_modify_qp(notify_qp_, &attr, IBV_QP_STATE)) {
+        PLOG(ERROR) << "Failed to modify notification QP to ERR in "
+                       "beginDestroy";
     }
 }
 
@@ -278,7 +318,7 @@ bool RdmaEndPoint::finishDestroy() {
         // polling. If ibv_modify_qp-to-ERR failed in beginDestroy, WRs may
         // never be flushed; enforce a timeout to avoid leaking forever.
         bool has_outstanding = false;
-        for (size_t i = 0; i < qp_list_.size(); ++i) {
+        for (size_t i = 0; wr_depth_list_ && i < qp_list_.size(); ++i) {
             if (wr_depth_list_[i].value != 0) {
                 has_outstanding = true;
                 break;
@@ -390,7 +430,27 @@ Status RdmaEndPoint::connect(const std::string& peer_server_name,
         }
         auto bootstrap_status =
             ControlClient::bootstrap(rpc_server_addr, local_desc, peer_desc);
-        if (!bootstrap_status.ok()) return bootstrap_status;
+        if (!bootstrap_status.ok()) {
+            // With simultaneous open, the peer's bootstrap request may finish
+            // our passive setup while this outbound RPC is still in flight.
+            // A timeout therefore does not necessarily mean that connection
+            // establishment failed. Reuse only the exact endpoint generation
+            // that issued this RPC; EP_READY alone is not sufficient.
+            RWSpinlock::WriteGuard guard(lock_);
+            const bool same_peer =
+                peer_server_name_ == peer_server_name &&
+                peer_nic_name_ == peer_nic_name;
+            const bool same_local_qps = qpNum() == local_desc.qp_num;
+            if (status_.load(std::memory_order_relaxed) == EP_READY &&
+                same_peer && same_local_qps) {
+                LOG(WARNING)
+                    << "Bootstrap RPC failed after simultaneous-open passive "
+                       "setup completed; reusing the established endpoint "
+                    << endpoint_name_ << ": " << bootstrap_status.ToString();
+                return mooncake::tent::Status::OK();
+            }
+            return bootstrap_status;
+        }
         qp_num = peer_desc.qp_num;
         peer_gid = peer_desc.local_gid;
         peer_lid = peer_desc.local_lid;
@@ -419,6 +479,7 @@ Status RdmaEndPoint::connect(const std::string& peer_server_name,
         peer_nic_name_ = peer_nic_name;
         int rc = setupAllQPs(peer_gid, peer_lid, qp_num);
         if (rc) {
+            beginDestroyNoLock();
             return mooncake::tent::Status::InternalError(
                 "Failed to configure RDMA endpoint" LOC_MARK);
         }
@@ -437,7 +498,8 @@ Status RdmaEndPoint::connect(const std::string& peer_server_name,
             } else {
                 notify_connected_ = true;
                 repostAllNotifyRecvs();
-                context_->transport_.registerNotifyQp(notify_qp_->qp_num, this);
+                context_->transport_.registerNotifyQp(notify_qp_->qp_num,
+                                                      shared_from_this());
             }
         }
     }
@@ -514,6 +576,7 @@ Status RdmaEndPoint::accept(const BootstrapDesc& peer_desc,
     int rc =
         setupAllQPs(peer_desc.local_gid, peer_desc.local_lid, peer_desc.qp_num);
     if (rc) {
+        beginDestroyNoLock();
         return mooncake::tent::Status::InternalError(
             "Failed to configure RDMA endpoint" LOC_MARK);
     }
@@ -530,7 +593,8 @@ Status RdmaEndPoint::accept(const BootstrapDesc& peer_desc,
         } else {
             notify_connected_ = true;
             repostAllNotifyRecvs();
-            context_->transport_.registerNotifyQp(notify_qp_->qp_num, this);
+            context_->transport_.registerNotifyQp(notify_qp_->qp_num,
+                                                  shared_from_this());
         }
     }
 
@@ -551,14 +615,13 @@ int RdmaEndPoint::resetConnection(const std::string& reason) {
             return 0;
         if (curr_status != EP_HANDSHAKING && curr_status != EP_READY) return 0;
 
-        destroy_start_time_ = getCurrentTimeInNano();
-        status_.store(EP_DESTROYING, std::memory_order_release);
+        beginDestroyNoLock();
         LOG(INFO) << "Endpoint marked for destruction: " << reason;
     }
 
     // Delete from endpoint store so endpoint() won't return this endpoint.
-    // remove() calls beginDestroyNoLock() to avoid deadlocking when
-    // caller already holds lock_.
+    // Store removal happens after releasing lock_ so remove() can safely take
+    // the endpoint lock and remains valid for async-event callers too.
     context_->endpointStore()->remove(endpoint_ptr);
     return 0;
 }
@@ -567,7 +630,6 @@ int RdmaEndPoint::setupAllQPs(const std::string& peer_gid, uint16_t peer_lid,
                               std::vector<uint32_t> peer_qp_num_list,
                               std::string* reply_msg) {
     if (status_.load(std::memory_order_relaxed) == EP_READY) {
-        status_.store(EP_DESTROYING, std::memory_order_relaxed);
         return -1;
     }
 
@@ -578,7 +640,6 @@ int RdmaEndPoint::setupAllQPs(const std::string& peer_gid, uint16_t peer_lid,
            << peer_nic_name_ << " of " << peer_server_name_;
         LOG(ERROR) << ss.str();
         if (reply_msg) *reply_msg = ss.str();
-        status_.store(EP_DESTROYING, std::memory_order_relaxed);
         return -1;
     }
 
@@ -586,7 +647,6 @@ int RdmaEndPoint::setupAllQPs(const std::string& peer_gid, uint16_t peer_lid,
         int ret = setupOneQP(qp_index, peer_gid, peer_lid,
                              peer_qp_num_list[qp_index], reply_msg);
         if (ret) {
-            status_.store(EP_DESTROYING, std::memory_order_relaxed);
             return ret;
         }
     }
@@ -698,7 +758,10 @@ int RdmaEndPoint::submitRecvImmDataRequest(int qp_index, uint64_t id) {
 }
 
 void RdmaEndPoint::resetInflightSlices() {
-    for (int qp_index = 0; qp_index < (int)qp_list_.size(); ++qp_index) {
+    // qp_list_ is sized up front, while slice_queue_ grows after each
+    // successful QP creation. Use the latter during partial-construction
+    // cleanup to avoid indexing queues that were never created.
+    for (int qp_index = 0; qp_index < (int)slice_queue_.size(); ++qp_index) {
         auto& queue = slice_queue_[qp_index];
         while (!queue.empty()) {
             auto current = queue.pop();
@@ -728,7 +791,7 @@ size_t RdmaEndPoint::acknowledge(RdmaSlice* slice, TransferStatusEnum status) {
 std::vector<uint32_t> RdmaEndPoint::qpNum() {
     std::vector<uint32_t> ret;
     for (int qp_index = 0; qp_index < (int)qp_list_.size(); ++qp_index)
-        ret.push_back(qp_list_[qp_index]->qp_num);
+        if (qp_list_[qp_index]) ret.push_back(qp_list_[qp_index]->qp_num);
     return ret;
 }
 
@@ -970,16 +1033,18 @@ static int setupNotifyQpConnection(ibv_qp* qp, RdmaContext* ctx,
 
 bool RdmaEndPoint::sendNotification(const std::string& name,
                                     const std::string& msg) {
-    if (!notify_qp_ || !notify_connected_) {
-        LOG(ERROR) << "Notification QP not connected";
-        return false;
-    }
-
     // Flow control: wait for pending sends to complete
     std::unique_lock<std::mutex> lock(notify_send_mutex_);
     notify_send_cv_.wait(lock, [this] {
-        return notify_pending_count_ < kNotifyMaxPendingSends;
+        return !notify_connected_ ||
+               notify_pending_count_ < kNotifyMaxPendingSends;
     });
+    if (!notify_connected_) {
+        LOG(ERROR) << "Notification QP not connected";
+        return false;
+    }
+    std::lock_guard<std::mutex> resource_guard(notify_resource_mutex_);
+    if (!notify_qp_ || !notify_send_mr_) return false;
 
     // Pick the next send slot — flow control guarantees this slot's previous
     // DMA has completed (at most kNotifyMaxPendingSends-1 in-flight).
@@ -1037,6 +1102,7 @@ bool RdmaEndPoint::sendNotification(const std::string& name,
 }
 
 bool RdmaEndPoint::handleNotifyRecv(size_t buffer_idx, size_t byte_len) {
+    std::lock_guard<std::mutex> resource_guard(notify_resource_mutex_);
     if (buffer_idx >= notify_recv_buffers_.size()) {
         LOG(ERROR) << "Invalid recv buffer index: " << buffer_idx;
         return false;

--- a/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
@@ -16,6 +16,7 @@
 
 #include <glog/logging.h>
 
+#include <algorithm>
 #include <cassert>
 #include <cstddef>
 #include <sstream>
@@ -70,6 +71,14 @@ RdmaEndPoint::~RdmaEndPoint() { deconstruct(); }
 
 int RdmaEndPoint::construct(RdmaContext* context, EndPointParams* params,
                             const std::string& endpoint_name) {
+    EndPointStatus expected = EP_UNINIT;
+    if (!status_.compare_exchange_strong(expected, EP_HANDSHAKING,
+                                         std::memory_order_acq_rel)) {
+        LOG(ERROR) << "Endpoint can only be constructed from EP_UNINIT, got "
+                   << statusToString(expected);
+        return -1;
+    }
+
     context_ = context;
     params_ = params;
     endpoint_name_ = endpoint_name;
@@ -168,7 +177,6 @@ int RdmaEndPoint::construct(RdmaContext* context, EndPointParams* params,
         }
     }
 
-    status_.store(EP_HANDSHAKING, std::memory_order_relaxed);
     return 0;
 }
 
@@ -186,14 +194,18 @@ int RdmaEndPoint::deconstructUnlocked() {
     auto current_status = status_.load(std::memory_order_relaxed);
     // Idempotent, including delayed destruction through an external shared_ptr.
     if (current_status == EP_DESTROYED) return 0;
-    status_.store(EP_DESTROYED, std::memory_order_relaxed);
     resetInflightSlices();
     peer_qp_num_list_.clear();
 
     // A default-constructed endpoint owns no verbs resources. A partially
     // constructed endpoint has context_ set and must be cleaned below even
     // though it never reached EP_HANDSHAKING.
-    if (!context_) return 0;
+    if (!context_) {
+        status_.store(EP_DESTROYED, std::memory_order_release);
+        return 0;
+    }
+
+    int result = 0;
 
     {
         std::lock_guard<std::mutex> notify_guard(notify_resource_mutex_);
@@ -201,44 +213,76 @@ int RdmaEndPoint::deconstructUnlocked() {
         if (notify_qp_) {
             // Unregister from transport before destroying
             context_->transport_.unregisterNotifyQp(notify_qp_->qp_num);
-            if (context_->verbs_.ibv_destroy_qp(notify_qp_))
+            if (context_->verbs_.ibv_destroy_qp(notify_qp_)) {
                 PLOG(ERROR) << "Failed to destroy notification QP";
-            notify_qp_ = nullptr;
-        }
-
-        // Deregister and free notification memory
-        for (auto& mr : notify_recv_mrs_) {
-            if (mr) {
-                if (context_->verbs_.ibv_dereg_mr(mr))
-                    PLOG(ERROR) << "Failed to deregister notification recv MR";
-                mr = nullptr;
+                result = -1;
+            } else {
+                notify_qp_ = nullptr;
             }
         }
-        notify_recv_mrs_.clear();
-        if (notify_send_mr_) {
-            if (context_->verbs_.ibv_dereg_mr(notify_send_mr_))
-                PLOG(ERROR) << "Failed to deregister notification send MR";
-            notify_send_mr_ = nullptr;
+
+        // A live QP may still reference the notification MRs. Keep both MRs
+        // and backing buffers intact until QP destruction succeeds.
+        if (!notify_qp_) {
+            for (auto& mr : notify_recv_mrs_) {
+                if (!mr) continue;
+                if (context_->verbs_.ibv_dereg_mr(mr)) {
+                    PLOG(ERROR) << "Failed to deregister notification recv MR";
+                    result = -1;
+                } else {
+                    mr = nullptr;
+                }
+            }
+            if (std::all_of(notify_recv_mrs_.begin(), notify_recv_mrs_.end(),
+                            [](ibv_mr* mr) { return mr == nullptr; })) {
+                notify_recv_mrs_.clear();
+                notify_recv_buffers_.clear();
+            }
+
+            if (notify_send_mr_) {
+                if (context_->verbs_.ibv_dereg_mr(notify_send_mr_)) {
+                    PLOG(ERROR) << "Failed to deregister notification send MR";
+                    result = -1;
+                } else {
+                    notify_send_mr_ = nullptr;
+                }
+            }
+            if (!notify_send_mr_) notify_send_buffer_.clear();
+        } else {
+            result = -1;
         }
-
-        notify_recv_buffers_.clear();
-        notify_send_buffer_.clear();
     }
 
+    bool all_qps_destroyed = true;
     for (size_t i = 0; i < qp_list_.size(); ++i) {
-        if (qp_list_[i] && context_->verbs_.ibv_destroy_qp(qp_list_[i]))
-            PLOG(ERROR) << "ibv_destroy_qp";
-        if (wr_depth_list_ && wr_depth_list_[i].value != 0)
-            cancelQuota(i, wr_depth_list_[i].value);
+        if (wr_depth_list_ && wr_depth_list_[i].value != 0) {
+            const int outstanding = wr_depth_list_[i].value;
+            cancelQuota(i, outstanding);
+        }
+        if (!qp_list_[i]) continue;
+        if (context_->verbs_.ibv_destroy_qp(qp_list_[i])) {
+            PLOG(ERROR) << "Failed to destroy data QP[" << i << "]";
+            result = -1;
+            all_qps_destroyed = false;
+        } else {
+            qp_list_[i] = nullptr;
+        }
     }
-    qp_list_.clear();
-    slice_queue_.clear();
-    delete[] wr_depth_list_;
-    wr_depth_list_ = nullptr;
-    peer_server_name_.clear();
-    peer_nic_name_.clear();
-    // Status remains EP_DESTROYED (unidirectional lifecycle)
-    return 0;
+    if (all_qps_destroyed) {
+        qp_list_.clear();
+        slice_queue_.clear();
+        delete[] wr_depth_list_;
+        wr_depth_list_ = nullptr;
+    }
+
+    if (result == 0 && !notify_qp_ && notify_recv_mrs_.empty() &&
+        !notify_send_mr_ && qp_list_.empty()) {
+        peer_server_name_.clear();
+        peer_nic_name_.clear();
+        status_.store(EP_DESTROYED, std::memory_order_release);
+        return 0;
+    }
+    return -1;
 }
 
 void RdmaEndPoint::beginDestroy() {
@@ -254,12 +298,6 @@ void RdmaEndPoint::beginDestroyNoLock() {
     destroy_start_time_ = getCurrentTimeInNano();
     status_.store(EP_DESTROYING, std::memory_order_release);
 
-    // EP_UNINIT also covers construction failure. Such QPs were never
-    // published and may still be in RESET/INIT, so forcing an ERR transition
-    // is unnecessary (and invalid on some providers); deconstructUnlocked()
-    // will destroy whichever resources were created successfully.
-    if (current_status == EP_UNINIT || !context_) return;
-
     // Stop publishing the endpoint before QPs start flushing. A notification
     // completion that already locked the weak_ptr may finish safely, while no
     // later completion can acquire a retiring endpoint.
@@ -271,6 +309,10 @@ void RdmaEndPoint::beginDestroyNoLock() {
         notify_connected_ = false;
         notify_send_cv_.notify_all();
     }
+
+    // Only EP_READY can own submitted WRs. QPs in EP_UNINIT/EP_HANDSHAKING may
+    // still be RESET/INIT, where a transition to ERR is invalid on providers.
+    if (current_status != EP_READY) return;
 
     // Transition QPs to ERR state so hardware flushes inflight WRs to CQ
     ibv_qp_attr attr;
@@ -299,57 +341,39 @@ bool RdmaEndPoint::finishDestroy() {
     // Gate 1: already done
     if (current_status == EP_DESTROYED) return true;
 
-    // Gate 2: non-two-phase path. Endpoint reached waiting_list_ without
-    // going through beginDestroy(). This handles edge cases and serves as
-    // a safety net. Endpoints that never reached construct() own no RDMA
-    // resources; drop them directly.
     if (current_status != EP_DESTROYING) {
-        if (qp_list_.empty()) {
-            status_.store(EP_DESTROYED, std::memory_order_relaxed);
-            return true;
-        }
-        LOG(WARNING) << "finishDestroy called in unexpected state: "
-                     << statusToString(current_status)
-                     << ", forcing destruction to avoid waiting_list_ leak";
-        // Fall through to the unified destroy path
-    } else {
-        // Gate 3: two-phase path. Wait for inflight WRs to drain via CQ
-        // polling. If ibv_modify_qp-to-ERR failed in beginDestroy, WRs may
-        // never be flushed; enforce a timeout to avoid leaking forever.
-        bool has_outstanding = false;
-        for (size_t i = 0; wr_depth_list_ && i < qp_list_.size(); ++i) {
-            if (wr_depth_list_[i].value != 0) {
-                has_outstanding = true;
-                break;
-            }
-        }
-        if (has_outstanding) {
-            double elapsed =
-                (getCurrentTimeInNano() - destroy_start_time_) / 1e9;
-            if (elapsed < kFinishDestroyTimeoutSec) {
-                return false;  // Still waiting for WRs to drain
-            }
-            LOG(WARNING) << "finishDestroy timed out after " << elapsed
-                         << "s with outstanding WRs, forcing destruction";
-        }
+        LOG(ERROR) << "finishDestroy requires EP_DESTROYING, got "
+                   << statusToString(current_status);
+        return false;
     }
 
-    // Unified destroy: tear down QPs and bound retries to avoid
-    // log flooding when ibv_destroy_qp fails permanently.
+    // Wait for inflight WRs to drain via CQ polling. If the transition to ERR
+    // failed, enforce a timeout so cleanup can still make progress.
+    bool has_outstanding = false;
+    for (size_t i = 0; wr_depth_list_ && i < qp_list_.size(); ++i) {
+        if (wr_depth_list_[i].value != 0) {
+            has_outstanding = true;
+            break;
+        }
+    }
+    if (has_outstanding) {
+        double elapsed = (getCurrentTimeInNano() - destroy_start_time_) / 1e9;
+        if (elapsed < kFinishDestroyTimeoutSec) {
+            return false;
+        }
+        LOG(WARNING) << "finishDestroy timed out after " << elapsed
+                     << "s with outstanding WRs, forcing destruction";
+    }
+
     int ret = deconstructUnlocked();
     if (ret) {
-        finish_destroy_retries_++;
-        LOG(ERROR) << "Failed to finish destroying endpoint (attempt "
-                   << finish_destroy_retries_ << "/" << kFinishDestroyMaxRetries
-                   << "): " << ret;
-        if (finish_destroy_retries_ < kFinishDestroyMaxRetries) {
-            return false;  // Retry later
+        destroy_error_count_++;
+        if (destroy_error_count_ <= kMaxDestroyErrorLogs) {
+            LOG(ERROR) << "Failed to finish destroying endpoint (attempt "
+                       << destroy_error_count_ << "): " << ret;
         }
-        LOG(ERROR) << "Giving up after " << finish_destroy_retries_
-                   << " retries (possible resource leak)";
+        return false;
     }
-
-    status_.store(EP_DESTROYED, std::memory_order_relaxed);
     return true;
 }
 

--- a/mooncake-transfer-engine/tent/src/transport/rdma/endpoint_store.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/endpoint_store.cpp
@@ -89,7 +89,7 @@ int FIFOEndpointStore::remove(RdmaEndPoint* ep) {
          ++iter) {
         if (iter->second.get() == ep) {
             waiting_list_.insert(iter->second);
-            iter->second->beginDestroyNoLock();
+            iter->second->beginDestroy();
             auto fifo_iter = fifo_map_[iter->first];
             fifo_list_.erase(fifo_iter);
             fifo_map_.erase(iter->first);
@@ -131,14 +131,35 @@ void FIFOEndpointStore::reclaim() {
 size_t FIFOEndpointStore::size() { return endpoint_map_.size(); }
 
 void FIFOEndpointStore::clear() {
-    RWSpinlock::WriteGuard guard(endpoint_map_lock_);
-    std::vector<std::string> to_delete;
-    for (auto& entry : endpoint_map_) to_delete.push_back(entry.first);
-    for (auto& key : to_delete) {
-        endpoint_map_.erase(key);
-        auto fifo_iter = fifo_map_[key];
-        fifo_list_.erase(fifo_iter);
-        fifo_map_.erase(key);
+    // clear() is used by RdmaContext::disable() immediately before CQs, PD and
+    // the verbs context are destroyed. Merely erasing endpoint_map_ is unsafe:
+    // an endpoint retained by an external shared_ptr could otherwise run its
+    // destructor later and access an already-destroyed RdmaContext.
+    std::vector<std::shared_ptr<RdmaEndPoint>> endpoints;
+    {
+        RWSpinlock::WriteGuard guard(endpoint_map_lock_);
+        // Detach both published and already-retiring endpoints atomically.
+        // After this point no lookup can acquire one of these endpoints.
+        endpoints.reserve(endpoint_map_.size() + waiting_list_.size());
+        for (auto& entry : endpoint_map_) endpoints.push_back(entry.second);
+        for (auto& endpoint : waiting_list_) endpoints.push_back(endpoint);
+        endpoint_map_.clear();
+        waiting_list_.clear();
+        fifo_list_.clear();
+        fifo_map_.clear();
+    }
+    // Do not call endpoint methods while holding endpoint_map_lock_: endpoint
+    // destruction also unregisters its notification QP and takes endpoint
+    // locks. Keeping verbs teardown outside the Store lock both shortens the
+    // critical section and avoids introducing a Store/Endpoint lock cycle.
+    //
+    // Context shutdown has already stopped workers, so the normal two-phase
+    // waiting-list path cannot drain CQ flush completions. Force synchronous
+    // deconstruction here, before RdmaContext destroys its CQs and PD.
+    // deconstruct() is idempotent, so external shared_ptr owners may release
+    // the already-deconstructed endpoint later without touching verbs again.
+    for (auto& endpoint : endpoints) {
+        endpoint->deconstruct();
     }
 }
 
@@ -191,13 +212,11 @@ std::shared_ptr<RdmaEndPoint> SIEVEEndpointStore::getOrInsert(
         }
     }
     endpoint = std::make_shared<RdmaEndPoint>();
-    int ret = endpoint->construct(&context_, &context_.params().endpoint, key,
-                                  &endpoints_count_);
+    int ret = endpoint->construct(&context_, &context_.params().endpoint, key);
     if (ret) {
         LOG(ERROR) << "Failed to construct endpoint for key " << key;
         return nullptr;
     }
-    endpoints_count_.fetch_add(1, std::memory_order_relaxed);
     while (this->size() >= max_size_) evictOne();
     endpoint_map_[key] = std::make_pair(endpoint, false);
     fifo_list_.push_front(key);
@@ -213,7 +232,7 @@ int SIEVEEndpointStore::remove(RdmaEndPoint* ep) {
         if (iter->second.first.get() == ep) {
             waiting_list_len_++;
             waiting_list_.insert(iter->second.first);
-            iter->second.first->beginDestroyNoLock();
+            iter->second.first->beginDestroy();
             auto fifo_iter = fifo_map_[iter->first];
             if (hand_.has_value() && hand_.value() == fifo_iter) {
                 fifo_iter == fifo_list_.begin() ? hand_ = std::nullopt
@@ -277,28 +296,34 @@ void SIEVEEndpointStore::reclaim() {
 size_t SIEVEEndpointStore::size() { return endpoint_map_.size(); }
 
 void SIEVEEndpointStore::clear() {
-    RWSpinlock::WriteGuard guard(endpoint_map_lock_);
-    std::vector<std::string> to_delete;
-    for (auto& entry : endpoint_map_) to_delete.push_back(entry.first);
-    for (auto& key : to_delete) {
-        endpoint_map_.erase(key);
-        auto fifo_iter = fifo_map_[key];
-        if (hand_.has_value() && hand_.value() == fifo_iter) {
-            fifo_iter == fifo_list_.begin() ? hand_ = std::nullopt
-                                            : hand_ = std::prev(fifo_iter);
-        }
-        fifo_list_.erase(fifo_iter);
-        fifo_map_.erase(key);
+    // Terminal shutdown semantics are intentionally different from normal
+    // SIEVE eviction: remove()/evictOne() retire endpoints asynchronously,
+    // while clear() must release all verbs objects before their parent
+    // RdmaContext tears down CQs, PD and the device context.
+    std::vector<std::shared_ptr<RdmaEndPoint>> endpoints;
+    {
+        RWSpinlock::WriteGuard guard(endpoint_map_lock_);
+        // Take a strong-reference snapshot and make the Store empty in one
+        // critical section. This prevents concurrent lookup from observing a
+        // partially-cleared cache or returning an endpoint being destroyed.
+        endpoints.reserve(endpoint_map_.size() + waiting_list_.size());
+        for (auto& entry : endpoint_map_)
+            endpoints.push_back(entry.second.first);
+        for (auto& endpoint : waiting_list_) endpoints.push_back(endpoint);
+        endpoint_map_.clear();
+        waiting_list_.clear();
+        waiting_list_len_.store(0, std::memory_order_relaxed);
+        fifo_list_.clear();
+        fifo_map_.clear();
+        hand_ = std::nullopt;
     }
-
-    const int max_retries = 5000;
-    int retries = 0;
-    while (endpoints_count_.load(std::memory_order_relaxed) > 0) {
-        if (++retries > max_retries) {
-            LOG(ERROR) << "Some endpoints not cleared after 5 seconds";
-            break;
-        }
-        usleep(1000);
+    // Run verbs operations outside endpoint_map_lock_. Workers are already
+    // stopped, so waiting for asynchronous CQ-driven reclaim is impossible;
+    // synchronously deconstruct each endpoint instead. The operation is
+    // idempotent, allowing outstanding external shared_ptr references to die
+    // safely after the Store and Context have gone away.
+    for (auto& endpoint : endpoints) {
+        endpoint->deconstruct();
     }
 }
 }  // namespace tent

--- a/mooncake-transfer-engine/tent/src/transport/rdma/endpoint_store.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/endpoint_store.cpp
@@ -128,6 +128,17 @@ void FIFOEndpointStore::reclaim() {
     for (auto& endpoint : to_delete) waiting_list_.erase(endpoint);
 }
 
+void FIFOEndpointStore::testOnlyInsertWaiting(
+    std::shared_ptr<RdmaEndPoint> endpoint) {
+    RWSpinlock::WriteGuard guard(endpoint_map_lock_);
+    waiting_list_.insert(std::move(endpoint));
+}
+
+size_t FIFOEndpointStore::testOnlyWaitingListSize() {
+    RWSpinlock::ReadGuard guard(endpoint_map_lock_);
+    return waiting_list_.size();
+}
+
 size_t FIFOEndpointStore::size() { return endpoint_map_.size(); }
 
 void FIFOEndpointStore::clear() {
@@ -291,6 +302,19 @@ void SIEVEEndpointStore::reclaim() {
     }
     for (auto& endpoint : to_delete) waiting_list_.erase(endpoint);
     waiting_list_len_ -= to_delete.size();
+}
+
+void SIEVEEndpointStore::testOnlyInsertWaiting(
+    std::shared_ptr<RdmaEndPoint> endpoint) {
+    RWSpinlock::WriteGuard guard(endpoint_map_lock_);
+    if (waiting_list_.insert(std::move(endpoint)).second) {
+        waiting_list_len_.fetch_add(1, std::memory_order_relaxed);
+    }
+}
+
+size_t SIEVEEndpointStore::testOnlyWaitingListSize() {
+    RWSpinlock::ReadGuard guard(endpoint_map_lock_);
+    return waiting_list_.size();
 }
 
 size_t SIEVEEndpointStore::size() { return endpoint_map_.size(); }

--- a/mooncake-transfer-engine/tent/src/transport/rdma/endpoint_store.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/endpoint_store.cpp
@@ -128,20 +128,9 @@ void FIFOEndpointStore::reclaim() {
     for (auto& endpoint : to_delete) waiting_list_.erase(endpoint);
 }
 
-void FIFOEndpointStore::testOnlyInsertWaiting(
-    std::shared_ptr<RdmaEndPoint> endpoint) {
-    RWSpinlock::WriteGuard guard(endpoint_map_lock_);
-    waiting_list_.insert(std::move(endpoint));
-}
-
-size_t FIFOEndpointStore::testOnlyWaitingListSize() {
-    RWSpinlock::ReadGuard guard(endpoint_map_lock_);
-    return waiting_list_.size();
-}
-
 size_t FIFOEndpointStore::size() { return endpoint_map_.size(); }
 
-void FIFOEndpointStore::clear() {
+int FIFOEndpointStore::clear() {
     // clear() is used by RdmaContext::disable() immediately before CQs, PD and
     // the verbs context are destroyed. Merely erasing endpoint_map_ is unsafe:
     // an endpoint retained by an external shared_ptr could otherwise run its
@@ -169,9 +158,15 @@ void FIFOEndpointStore::clear() {
     // deconstruction here, before RdmaContext destroys its CQs and PD.
     // deconstruct() is idempotent, so external shared_ptr owners may release
     // the already-deconstructed endpoint later without touching verbs again.
+    std::vector<std::shared_ptr<RdmaEndPoint>> failed;
     for (auto& endpoint : endpoints) {
-        endpoint->deconstruct();
+        if (endpoint->deconstruct()) failed.push_back(endpoint);
     }
+    if (failed.empty()) return 0;
+
+    RWSpinlock::WriteGuard guard(endpoint_map_lock_);
+    waiting_list_.insert(failed.begin(), failed.end());
+    return -1;
 }
 
 std::shared_ptr<RdmaEndPoint> SIEVEEndpointStore::get(const std::string& key) {
@@ -304,22 +299,9 @@ void SIEVEEndpointStore::reclaim() {
     waiting_list_len_ -= to_delete.size();
 }
 
-void SIEVEEndpointStore::testOnlyInsertWaiting(
-    std::shared_ptr<RdmaEndPoint> endpoint) {
-    RWSpinlock::WriteGuard guard(endpoint_map_lock_);
-    if (waiting_list_.insert(std::move(endpoint)).second) {
-        waiting_list_len_.fetch_add(1, std::memory_order_relaxed);
-    }
-}
-
-size_t SIEVEEndpointStore::testOnlyWaitingListSize() {
-    RWSpinlock::ReadGuard guard(endpoint_map_lock_);
-    return waiting_list_.size();
-}
-
 size_t SIEVEEndpointStore::size() { return endpoint_map_.size(); }
 
-void SIEVEEndpointStore::clear() {
+int SIEVEEndpointStore::clear() {
     // Terminal shutdown semantics are intentionally different from normal
     // SIEVE eviction: remove()/evictOne() retire endpoints asynchronously,
     // while clear() must release all verbs objects before their parent
@@ -346,9 +328,16 @@ void SIEVEEndpointStore::clear() {
     // synchronously deconstruct each endpoint instead. The operation is
     // idempotent, allowing outstanding external shared_ptr references to die
     // safely after the Store and Context have gone away.
+    std::vector<std::shared_ptr<RdmaEndPoint>> failed;
     for (auto& endpoint : endpoints) {
-        endpoint->deconstruct();
+        if (endpoint->deconstruct()) failed.push_back(endpoint);
     }
+    if (failed.empty()) return 0;
+
+    RWSpinlock::WriteGuard guard(endpoint_map_lock_);
+    waiting_list_.insert(failed.begin(), failed.end());
+    waiting_list_len_.store(waiting_list_.size(), std::memory_order_relaxed);
+    return -1;
 }
 }  // namespace tent
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
@@ -716,13 +716,9 @@ int RdmaTransport::processNotifyCompletions() {
 
         // Process each completion
         for (int i = 0; i < completed; ++i) {
-            if (wc[i].status != IBV_WC_SUCCESS) {
-                LOG(ERROR) << "Notification completion failed: " << wc[i].status
-                           << ", qp_num=" << wc[i].qp_num;
-                continue;
-            }
-
-            // Find endpoint by QP number
+            // Find endpoint by QP number before interpreting errors. A flush
+            // completion after endpoint unpublication is expected during
+            // retirement and should not flood logs.
             std::shared_ptr<RdmaEndPoint> endpoint;
             {
                 RWSpinlock::ReadGuard guard(notify_endpoint_map_lock_);
@@ -730,6 +726,17 @@ int RdmaTransport::processNotifyCompletions() {
                 if (it != notify_qp_to_endpoint_.end()) {
                     endpoint = it->second.lock();
                 }
+            }
+
+            if (wc[i].status != IBV_WC_SUCCESS) {
+                if (wc[i].status == IBV_WC_WR_FLUSH_ERR &&
+                    (!endpoint ||
+                     endpoint->status() != RdmaEndPoint::EP_READY)) {
+                    continue;
+                }
+                LOG(ERROR) << "Notification completion failed: " << wc[i].status
+                           << ", qp_num=" << wc[i].qp_num;
+                continue;
             }
 
             if (!endpoint) {

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
@@ -198,6 +198,8 @@ static Status convertConfToRdmaParams(std::shared_ptr<Config> conf,
     SET_WORKERS(rail_topo_path, params->workers.rail_topo_path);
 
     params->verbose = conf->get("verbose", false);
+    params->log_slice_affinity =
+        conf->get("transports/rdma/log_slice_affinity", false);
     return Status::OK();
 }
 
@@ -590,6 +592,10 @@ int RdmaTransport::onSetupRdmaConnections(const BootstrapDesc& peer_desc,
     }
     auto status = endpoint->accept(peer_desc, local_desc);
     if (!status.ok()) {
+        if (endpoint->status() == RdmaEndPoint::EP_DESTROYING ||
+            endpoint->status() == RdmaEndPoint::EP_DESTROYED) {
+            context->endpointStore()->remove(endpoint.get());
+        }
         LOG(ERROR) << status.ToString();
         local_desc.reply_msg = status.ToString();
         return -1;
@@ -717,12 +723,12 @@ int RdmaTransport::processNotifyCompletions() {
             }
 
             // Find endpoint by QP number
-            RdmaEndPoint* endpoint = nullptr;
+            std::shared_ptr<RdmaEndPoint> endpoint;
             {
                 RWSpinlock::ReadGuard guard(notify_endpoint_map_lock_);
                 auto it = notify_qp_to_endpoint_.find(wc[i].qp_num);
                 if (it != notify_qp_to_endpoint_.end()) {
-                    endpoint = it->second;
+                    endpoint = it->second.lock();
                 }
             }
 
@@ -745,7 +751,8 @@ int RdmaTransport::processNotifyCompletions() {
     return total_completions;
 }
 
-void RdmaTransport::registerNotifyQp(uint32_t qp_num, RdmaEndPoint* endpoint) {
+void RdmaTransport::registerNotifyQp(
+    uint32_t qp_num, const std::shared_ptr<RdmaEndPoint>& endpoint) {
     RWSpinlock::WriteGuard guard(notify_endpoint_map_lock_);
     notify_qp_to_endpoint_[qp_num] = endpoint;
 }

--- a/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
@@ -17,6 +17,8 @@
 #include <sys/epoll.h>
 
 #include <cassert>
+#include <fstream>
+#include <sstream>
 
 #include "tent/transport/rdma/endpoint_store.h"
 #include "tent/transport/rdma/shared_quota.h"
@@ -48,6 +50,27 @@ Workers::Workers(RdmaTransport* transport)
     device_selector_ = std::make_unique<DeviceSelector>();
     device_selector_->loadTopology(transport_->local_topology_);
     auto& conf = transport_->conf_;
+
+    // RailMonitor consumes JSON text, while the public configuration is a file
+    // path. Load it once here instead of reopening the file for every worker
+    // and every remote machine. Invalid/missing files fall back to automatic
+    // topology matching in RailMonitor::load().
+    const auto& rail_topo_path = transport_->params_->workers.rail_topo_path;
+    if (!rail_topo_path.empty()) {
+        std::ifstream input(rail_topo_path);
+        if (!input.is_open()) {
+            LOG(WARNING) << "Unable to open RDMA rail topology file "
+                         << rail_topo_path << "; using automatic rail mapping";
+        } else {
+            std::ostringstream contents;
+            contents << input.rdbuf();
+            rail_topo_json_ = contents.str();
+            if (rail_topo_json_.empty()) {
+                LOG(WARNING) << "RDMA rail topology file " << rail_topo_path
+                             << " is empty; using automatic rail mapping";
+            }
+        }
+    }
 
     // ============================================================
     // Core Scheduling Configuration
@@ -685,6 +708,7 @@ Status Workers::getRouteHint(RouteHint& hint, SegmentID segment_id,
     auto mem_id = hint.topo->getMemId(location);
     if (mem_id < 0) mem_id = hint.topo->getMemId(kWildcardLocation);
     hint.topo_entry = hint.topo->getMemEntry(mem_id);
+    hint.location = std::move(location);
     return Status::OK();
 }
 
@@ -711,7 +735,7 @@ Status Workers::selectOptimalDevice(RouteHint& source, RouteHint& target,
 
     auto& rail = getOrCreateRail(worker.rails, target.segment->machine_id);
     if (!rail.ready() || target.topo != rail.remote())
-        rail.load(source.topo, target.topo, /*rail_topo_json=*/"",
+        rail.load(source.topo, target.topo, rail_topo_json_,
                   transport_->conf_.get());
     if (slice->target_dev_id < 0) {
         int mapped_dev_id = rail.findBestRemoteDevice(
@@ -847,6 +871,25 @@ Status Workers::generatePostPath(RdmaSlice* slice) {
     // lookup on the hot path.
     slice->rail_monitor = &getOrCreateRail(worker_context_[tl_wid].rails,
                                            target.segment->machine_id);
+    if (transport_->params_->log_slice_affinity) {
+        const auto* local_nic =
+            source.topo->getNicEntry(slice->source_dev_id);
+        const auto* remote_nic =
+            target.topo->getNicEntry(slice->target_dev_id);
+        VLOG(1) << "RDMA slice affinity: source_location=" << source.location
+                << ", target_location=" << target.location
+                << ", local_device_name="
+                << (local_nic ? local_nic->name : "<unknown>")
+                << ", peer_device_name="
+                << (remote_nic ? remote_nic->name : "<unknown>")
+                << ", target_id=" << slice->task->request.target_id
+                << ", source_addr="
+                << static_cast<void*>(slice->source_addr)
+                << ", dest_addr="
+                << reinterpret_cast<void*>(slice->target_addr)
+                << ", length=" << slice->length
+                << ", retry_count=" << slice->retry_count;
+    }
     return Status::OK();
 }
 }  // namespace tent

--- a/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
@@ -872,10 +872,8 @@ Status Workers::generatePostPath(RdmaSlice* slice) {
     slice->rail_monitor = &getOrCreateRail(worker_context_[tl_wid].rails,
                                            target.segment->machine_id);
     if (transport_->params_->log_slice_affinity) {
-        const auto* local_nic =
-            source.topo->getNicEntry(slice->source_dev_id);
-        const auto* remote_nic =
-            target.topo->getNicEntry(slice->target_dev_id);
+        const auto* local_nic = source.topo->getNicEntry(slice->source_dev_id);
+        const auto* remote_nic = target.topo->getNicEntry(slice->target_dev_id);
         VLOG(1) << "RDMA slice affinity: source_location=" << source.location
                 << ", target_location=" << target.location
                 << ", local_device_name="
@@ -883,10 +881,8 @@ Status Workers::generatePostPath(RdmaSlice* slice) {
                 << ", peer_device_name="
                 << (remote_nic ? remote_nic->name : "<unknown>")
                 << ", target_id=" << slice->task->request.target_id
-                << ", source_addr="
-                << static_cast<void*>(slice->source_addr)
-                << ", dest_addr="
-                << reinterpret_cast<void*>(slice->target_addr)
+                << ", source_addr=" << static_cast<void*>(slice->source_addr)
+                << ", dest_addr=" << reinterpret_cast<void*>(slice->target_addr)
                 << ", length=" << slice->length
                 << ", retry_count=" << slice->retry_count;
     }

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -75,8 +75,25 @@ target_include_directories(tent_failover_test
 add_test(NAME tent_failover_test COMMAND tent_failover_test)
 
 add_executable(tent_endpoint_lifecycle_test endpoint_lifecycle_test.cpp)
-target_link_libraries(tent_endpoint_lifecycle_test PRIVATE gtest gtest_main)
+target_link_libraries(tent_endpoint_lifecycle_test
+                      PRIVATE gtest gtest_main tent_link_group)
+target_include_directories(tent_endpoint_lifecycle_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME tent_endpoint_lifecycle_test COMMAND tent_endpoint_lifecycle_test)
+
+add_executable(tent_endpoint_store_test endpoint_store_test.cpp)
+target_link_libraries(tent_endpoint_store_test
+                      PRIVATE gtest gtest_main tent_link_group)
+target_include_directories(tent_endpoint_store_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+add_test(NAME tent_endpoint_store_test COMMAND tent_endpoint_store_test)
+
+add_executable(tent_rdma_transport_test rdma_transport_test.cpp)
+target_link_libraries(tent_rdma_transport_test
+                      PRIVATE gtest gtest_main tent_link_group ibverbs)
+target_include_directories(tent_rdma_transport_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+add_test(NAME tent_rdma_transport_test COMMAND tent_rdma_transport_test)
 
 if(USE_HIP)
   find_package(HIP REQUIRED)

--- a/mooncake-transfer-engine/tent/tests/endpoint_lifecycle_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/endpoint_lifecycle_test.cpp
@@ -47,6 +47,14 @@ TEST(EndpointLifecycleTest, DeconstructIsIdempotent) {
     EXPECT_EQ(endpoint.status(), RdmaEndPoint::EP_DESTROYED);
 }
 
+TEST(EndpointLifecycleTest, DestroyedEndpointCannotBeConstructedAgain) {
+    RdmaEndPoint endpoint;
+
+    ASSERT_EQ(endpoint.deconstruct(), 0);
+    EXPECT_NE(endpoint.construct(nullptr, nullptr, "reused"), 0);
+    EXPECT_EQ(endpoint.status(), RdmaEndPoint::EP_DESTROYED);
+}
+
 TEST(EndpointLifecycleTest, TwoPhaseDestroyHandlesUninitializedEndpoint) {
     RdmaEndPoint endpoint;
 
@@ -54,6 +62,13 @@ TEST(EndpointLifecycleTest, TwoPhaseDestroyHandlesUninitializedEndpoint) {
     EXPECT_EQ(endpoint.status(), RdmaEndPoint::EP_DESTROYING);
     EXPECT_TRUE(endpoint.finishDestroy());
     EXPECT_EQ(endpoint.status(), RdmaEndPoint::EP_DESTROYED);
+}
+
+TEST(EndpointLifecycleTest, FinishDestroyRejectsNonRetiringEndpoint) {
+    RdmaEndPoint endpoint;
+
+    EXPECT_FALSE(endpoint.finishDestroy());
+    EXPECT_EQ(endpoint.status(), RdmaEndPoint::EP_UNINIT);
 }
 
 TEST(EndpointLifecycleTest, FinishDestroyIsIdempotent) {

--- a/mooncake-transfer-engine/tent/tests/endpoint_lifecycle_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/endpoint_lifecycle_test.cpp
@@ -16,130 +16,83 @@
 
 #include <memory>
 
+#include "tent/transport/rdma/endpoint.h"
+
 namespace mooncake {
 namespace tent {
 namespace {
 
-// ---------------------------------------------------------------------------
-// Minimal stub to validate weak_ptr lifecycle without RDMA dependencies.
-// The real RdmaEndPoint inherits enable_shared_from_this; we mirror that
-// pattern here so the test proves the ownership model works.
-// ---------------------------------------------------------------------------
+TEST(EndpointLifecycleTest, DefaultConstructedEndpointOwnsNoResources) {
+    RdmaEndPoint endpoint;
 
-class FakeEndPoint : public std::enable_shared_from_this<FakeEndPoint> {
-   public:
-    int acknowledge_calls = 0;
-    int reset_calls = 0;
+    EXPECT_EQ(endpoint.status(), RdmaEndPoint::EP_UNINIT);
+    EXPECT_TRUE(endpoint.qpNum().empty());
+    EXPECT_EQ(endpoint.getInflightSlices(), 0);
+    EXPECT_EQ(endpoint.notifyQpNum(), 0);
+}
 
-    void acknowledge() { ++acknowledge_calls; }
-    void reset() { ++reset_calls; }
-};
+TEST(EndpointLifecycleTest, DefaultConstructedEndpointCanBeDestroyed) {
+    RdmaEndPoint endpoint;
 
-// ---------------------------------------------------------------------------
-// weak_ptr basic lifecycle
-// ---------------------------------------------------------------------------
+    EXPECT_EQ(endpoint.deconstruct(), 0);
+    EXPECT_EQ(endpoint.status(), RdmaEndPoint::EP_DESTROYED);
+    EXPECT_TRUE(endpoint.qpNum().empty());
+}
 
-TEST(EndpointLifecycleTest, WeakPtrLocksWhileAlive) {
-    auto ep = std::make_shared<FakeEndPoint>();
-    std::weak_ptr<FakeEndPoint> weak = ep;
+TEST(EndpointLifecycleTest, DeconstructIsIdempotent) {
+    RdmaEndPoint endpoint;
+
+    ASSERT_EQ(endpoint.deconstruct(), 0);
+    EXPECT_EQ(endpoint.deconstruct(), 0);
+    EXPECT_EQ(endpoint.status(), RdmaEndPoint::EP_DESTROYED);
+}
+
+TEST(EndpointLifecycleTest, TwoPhaseDestroyHandlesUninitializedEndpoint) {
+    RdmaEndPoint endpoint;
+
+    endpoint.beginDestroy();
+    EXPECT_EQ(endpoint.status(), RdmaEndPoint::EP_DESTROYING);
+    EXPECT_TRUE(endpoint.finishDestroy());
+    EXPECT_EQ(endpoint.status(), RdmaEndPoint::EP_DESTROYED);
+}
+
+TEST(EndpointLifecycleTest, FinishDestroyIsIdempotent) {
+    RdmaEndPoint endpoint;
+
+    endpoint.beginDestroy();
+    ASSERT_TRUE(endpoint.finishDestroy());
+    EXPECT_TRUE(endpoint.finishDestroy());
+    EXPECT_EQ(endpoint.status(), RdmaEndPoint::EP_DESTROYED);
+}
+
+TEST(EndpointLifecycleTest, NotificationFailsWhenEndpointIsNotConnected) {
+    RdmaEndPoint endpoint;
+
+    EXPECT_FALSE(endpoint.sendNotification("name", "message"));
+}
+
+TEST(EndpointLifecycleTest, SharedFromThisUsesRealEndpointOwnership) {
+    auto endpoint = std::make_shared<RdmaEndPoint>();
+    std::weak_ptr<RdmaEndPoint> weak = endpoint->shared_from_this();
 
     auto locked = weak.lock();
     ASSERT_NE(locked, nullptr);
-    locked->acknowledge();
-    EXPECT_EQ(ep->acknowledge_calls, 1);
-}
+    EXPECT_EQ(locked.get(), endpoint.get());
 
-TEST(EndpointLifecycleTest, WeakPtrExpiresAfterRelease) {
-    std::weak_ptr<FakeEndPoint> weak;
-    {
-        auto ep = std::make_shared<FakeEndPoint>();
-        weak = ep;
-        EXPECT_FALSE(weak.expired());
-    }  // ep destroyed here
+    locked.reset();
+    endpoint.reset();
     EXPECT_TRUE(weak.expired());
-    EXPECT_EQ(weak.lock(), nullptr);
 }
 
-TEST(EndpointLifecycleTest, SharedFromThisProducesValidWeakPtr) {
-    auto ep = std::make_shared<FakeEndPoint>();
-    // Simulate what submitSlices() does: shared_from_this() assigned to
-    // weak_ptr
-    std::weak_ptr<FakeEndPoint> weak = ep->shared_from_this();
+TEST(EndpointLifecycleTest, ExternalOwnerCanReleaseAfterExplicitDeconstruct) {
+    auto endpoint = std::make_shared<RdmaEndPoint>();
+    std::weak_ptr<RdmaEndPoint> weak = endpoint;
 
-    auto locked = weak.lock();
-    ASSERT_NE(locked, nullptr);
-    EXPECT_EQ(locked.get(), ep.get());
-}
+    ASSERT_EQ(endpoint->deconstruct(), 0);
+    EXPECT_EQ(endpoint->status(), RdmaEndPoint::EP_DESTROYED);
 
-// ---------------------------------------------------------------------------
-// Simulate the slice → endpoint dereference pattern used in workers.cpp
-// ---------------------------------------------------------------------------
-
-struct FakeSlice {
-    std::weak_ptr<FakeEndPoint> ep_weak_ptr;
-};
-
-TEST(EndpointLifecycleTest, SliceAccessWhileEndpointAlive) {
-    auto ep = std::make_shared<FakeEndPoint>();
-    FakeSlice slice;
-    slice.ep_weak_ptr = ep;
-
-    // Simulate workers.cpp completion path
-    if (auto locked = slice.ep_weak_ptr.lock()) {
-        locked->acknowledge();
-        locked->reset();
-    }
-    EXPECT_EQ(ep->acknowledge_calls, 1);
-    EXPECT_EQ(ep->reset_calls, 1);
-}
-
-TEST(EndpointLifecycleTest, SliceAccessAfterEndpointEvicted) {
-    FakeSlice slice;
-    {
-        auto ep = std::make_shared<FakeEndPoint>();
-        slice.ep_weak_ptr = ep;
-    }  // endpoint evicted — shared_ptr destroyed
-
-    // Simulate workers.cpp: lock() returns nullptr, gracefully skip
-    auto locked = slice.ep_weak_ptr.lock();
-    EXPECT_EQ(locked, nullptr);
-    // No crash — the slice safely detected endpoint destruction
-}
-
-TEST(EndpointLifecycleTest, MultipleSlicesSameEndpoint) {
-    auto ep = std::make_shared<FakeEndPoint>();
-    FakeSlice slices[3];
-    for (auto& s : slices) s.ep_weak_ptr = ep;
-
-    // All slices can lock while endpoint alive
-    for (auto& s : slices) {
-        auto locked = s.ep_weak_ptr.lock();
-        ASSERT_NE(locked, nullptr);
-        locked->acknowledge();
-    }
-    EXPECT_EQ(ep->acknowledge_calls, 3);
-
-    // Simulate eviction: drop the owning shared_ptr
-    ep.reset();
-
-    // All slices now get nullptr
-    for (auto& s : slices) {
-        EXPECT_EQ(s.ep_weak_ptr.lock(), nullptr);
-    }
-}
-
-TEST(EndpointLifecycleTest, WeakPtrResetClearsReference) {
-    auto ep = std::make_shared<FakeEndPoint>();
-    FakeSlice slice;
-    slice.ep_weak_ptr = ep;
-
-    // Simulate rdma_transport.cpp slice initialization: reset()
-    slice.ep_weak_ptr.reset();
-    EXPECT_TRUE(slice.ep_weak_ptr.expired());
-    EXPECT_EQ(slice.ep_weak_ptr.lock(), nullptr);
-
-    // Original endpoint still alive
-    EXPECT_NE(ep, nullptr);
+    endpoint.reset();
+    EXPECT_TRUE(weak.expired());
 }
 
 }  // namespace

--- a/mooncake-transfer-engine/tent/tests/endpoint_lifecycle_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/endpoint_lifecycle_test.cpp
@@ -17,6 +17,7 @@
 #include <memory>
 
 #include "tent/transport/rdma/endpoint.h"
+#include "tent/transport/rdma/slice.h"
 
 namespace mooncake {
 namespace tent {
@@ -97,6 +98,58 @@ TEST(EndpointLifecycleTest, SharedFromThisUsesRealEndpointOwnership) {
     locked.reset();
     endpoint.reset();
     EXPECT_TRUE(weak.expired());
+}
+
+TEST(EndpointLifecycleTest, SliceAccessWhileEndpointAlive) {
+    auto endpoint = std::make_shared<RdmaEndPoint>();
+    RdmaSlice slice;
+    slice.ep_weak_ptr = endpoint;
+
+    auto locked = slice.ep_weak_ptr.lock();
+    ASSERT_NE(locked, nullptr);
+    EXPECT_EQ(locked.get(), endpoint.get());
+}
+
+TEST(EndpointLifecycleTest, SliceAccessAfterEndpointEvicted) {
+    RdmaSlice slice;
+    {
+        auto endpoint = std::make_shared<RdmaEndPoint>();
+        slice.ep_weak_ptr = endpoint;
+        ASSERT_FALSE(slice.ep_weak_ptr.expired());
+    }
+
+    EXPECT_TRUE(slice.ep_weak_ptr.expired());
+    EXPECT_EQ(slice.ep_weak_ptr.lock(), nullptr);
+}
+
+TEST(EndpointLifecycleTest, MultipleSlicesShareEndpointLifetime) {
+    auto endpoint = std::make_shared<RdmaEndPoint>();
+    RdmaSlice slices[3];
+    for (auto& slice : slices) slice.ep_weak_ptr = endpoint;
+
+    for (auto& slice : slices) {
+        auto locked = slice.ep_weak_ptr.lock();
+        ASSERT_NE(locked, nullptr);
+        EXPECT_EQ(locked.get(), endpoint.get());
+    }
+
+    endpoint.reset();
+    for (auto& slice : slices) {
+        EXPECT_TRUE(slice.ep_weak_ptr.expired());
+        EXPECT_EQ(slice.ep_weak_ptr.lock(), nullptr);
+    }
+}
+
+TEST(EndpointLifecycleTest, SliceWeakPtrResetClearsReference) {
+    auto endpoint = std::make_shared<RdmaEndPoint>();
+    RdmaSlice slice;
+    slice.ep_weak_ptr = endpoint;
+
+    slice.ep_weak_ptr.reset();
+
+    EXPECT_TRUE(slice.ep_weak_ptr.expired());
+    EXPECT_EQ(slice.ep_weak_ptr.lock(), nullptr);
+    EXPECT_NE(endpoint, nullptr);
 }
 
 TEST(EndpointLifecycleTest, ExternalOwnerCanReleaseAfterExplicitDeconstruct) {

--- a/mooncake-transfer-engine/tent/tests/endpoint_store_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/endpoint_store_test.cpp
@@ -1,0 +1,125 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "tent/transport/rdma/context.h"
+#include "tent/transport/rdma/endpoint.h"
+#include "tent/transport/rdma/endpoint_store.h"
+#include "tent/transport/rdma/rdma_transport.h"
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+enum class StoreType { FIFO, SIEVE };
+
+class EndpointStoreTest : public testing::TestWithParam<StoreType> {
+   protected:
+    EndpointStoreTest() : context_(transport_) {}
+
+    std::unique_ptr<EndpointStore> makeStore() {
+        if (GetParam() == StoreType::FIFO) {
+            return std::make_unique<FIFOEndpointStore>(context_, 4);
+        }
+        return std::make_unique<SIEVEEndpointStore>(context_, 4);
+    }
+
+    void insertWaiting(EndpointStore& store,
+                       std::shared_ptr<RdmaEndPoint> endpoint) {
+        if (GetParam() == StoreType::FIFO) {
+            static_cast<FIFOEndpointStore&>(store).testOnlyInsertWaiting(
+                std::move(endpoint));
+        } else {
+            static_cast<SIEVEEndpointStore&>(store).testOnlyInsertWaiting(
+                std::move(endpoint));
+        }
+    }
+
+    size_t waitingListSize(EndpointStore& store) {
+        if (GetParam() == StoreType::FIFO) {
+            return static_cast<FIFOEndpointStore&>(store)
+                .testOnlyWaitingListSize();
+        }
+        return static_cast<SIEVEEndpointStore&>(store)
+            .testOnlyWaitingListSize();
+    }
+
+    RdmaTransport transport_;
+    RdmaContext context_;
+};
+
+TEST_P(EndpointStoreTest, ReclaimDrainsQuiescentEntries) {
+    auto store = makeStore();
+
+    constexpr size_t kEndpointCount = 10;
+    for (size_t i = 0; i < kEndpointCount; ++i) {
+        insertWaiting(*store, std::make_shared<RdmaEndPoint>());
+    }
+    ASSERT_EQ(waitingListSize(*store), kEndpointCount);
+
+    store->reclaim();
+    EXPECT_EQ(waitingListSize(*store), 0);
+}
+
+TEST_P(EndpointStoreTest, ReclaimIsIdempotentWhenEmpty) {
+    auto store = makeStore();
+
+    store->reclaim();
+    EXPECT_EQ(waitingListSize(*store), 0);
+
+    insertWaiting(*store, std::make_shared<RdmaEndPoint>());
+    store->reclaim();
+    ASSERT_EQ(waitingListSize(*store), 0);
+
+    store->reclaim();
+    EXPECT_EQ(waitingListSize(*store), 0);
+}
+
+TEST_P(EndpointStoreTest, ReclaimDrainsBacklogWithoutActiveMapEntries) {
+    auto store = makeStore();
+
+    constexpr size_t kEndpointCount = 1000;
+    for (size_t i = 0; i < kEndpointCount; ++i) {
+        insertWaiting(*store, std::make_shared<RdmaEndPoint>());
+    }
+    ASSERT_EQ(store->size(), 0);
+    ASSERT_EQ(waitingListSize(*store), kEndpointCount);
+
+    store->reclaim();
+    EXPECT_EQ(waitingListSize(*store), 0);
+}
+
+TEST_P(EndpointStoreTest, ClearDeconstructsExternallyOwnedWaitingEndpoint) {
+    auto store = makeStore();
+    auto endpoint = std::make_shared<RdmaEndPoint>();
+    std::weak_ptr<RdmaEndPoint> weak = endpoint;
+    insertWaiting(*store, endpoint);
+
+    store->clear();
+
+    EXPECT_EQ(waitingListSize(*store), 0);
+    EXPECT_EQ(endpoint->status(), RdmaEndPoint::EP_DESTROYED);
+    endpoint.reset();
+    EXPECT_TRUE(weak.expired());
+}
+
+INSTANTIATE_TEST_SUITE_P(AllStoreTypes, EndpointStoreTest,
+                         testing::Values(StoreType::FIFO, StoreType::SIEVE));
+
+}  // namespace
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/tests/endpoint_store_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/endpoint_store_test.cpp
@@ -23,6 +23,36 @@
 
 namespace mooncake {
 namespace tent {
+
+class EndpointStoreTestAccess {
+   public:
+    static void insertWaiting(FIFOEndpointStore& store,
+                              std::shared_ptr<RdmaEndPoint> endpoint) {
+        endpoint->beginDestroy();
+        RWSpinlock::WriteGuard guard(store.endpoint_map_lock_);
+        store.waiting_list_.insert(std::move(endpoint));
+    }
+
+    static void insertWaiting(SIEVEEndpointStore& store,
+                              std::shared_ptr<RdmaEndPoint> endpoint) {
+        endpoint->beginDestroy();
+        RWSpinlock::WriteGuard guard(store.endpoint_map_lock_);
+        if (store.waiting_list_.insert(std::move(endpoint)).second) {
+            store.waiting_list_len_.fetch_add(1, std::memory_order_relaxed);
+        }
+    }
+
+    static size_t waitingListSize(FIFOEndpointStore& store) {
+        RWSpinlock::ReadGuard guard(store.endpoint_map_lock_);
+        return store.waiting_list_.size();
+    }
+
+    static size_t waitingListSize(SIEVEEndpointStore& store) {
+        RWSpinlock::ReadGuard guard(store.endpoint_map_lock_);
+        return store.waiting_list_.size();
+    }
+};
+
 namespace {
 
 enum class StoreType { FIFO, SIEVE };
@@ -41,21 +71,21 @@ class EndpointStoreTest : public testing::TestWithParam<StoreType> {
     void insertWaiting(EndpointStore& store,
                        std::shared_ptr<RdmaEndPoint> endpoint) {
         if (GetParam() == StoreType::FIFO) {
-            static_cast<FIFOEndpointStore&>(store).testOnlyInsertWaiting(
-                std::move(endpoint));
+            EndpointStoreTestAccess::insertWaiting(
+                static_cast<FIFOEndpointStore&>(store), std::move(endpoint));
         } else {
-            static_cast<SIEVEEndpointStore&>(store).testOnlyInsertWaiting(
-                std::move(endpoint));
+            EndpointStoreTestAccess::insertWaiting(
+                static_cast<SIEVEEndpointStore&>(store), std::move(endpoint));
         }
     }
 
     size_t waitingListSize(EndpointStore& store) {
         if (GetParam() == StoreType::FIFO) {
-            return static_cast<FIFOEndpointStore&>(store)
-                .testOnlyWaitingListSize();
+            return EndpointStoreTestAccess::waitingListSize(
+                static_cast<FIFOEndpointStore&>(store));
         }
-        return static_cast<SIEVEEndpointStore&>(store)
-            .testOnlyWaitingListSize();
+        return EndpointStoreTestAccess::waitingListSize(
+            static_cast<SIEVEEndpointStore&>(store));
     }
 
     RdmaTransport transport_;
@@ -109,7 +139,7 @@ TEST_P(EndpointStoreTest, ClearDeconstructsExternallyOwnedWaitingEndpoint) {
     std::weak_ptr<RdmaEndPoint> weak = endpoint;
     insertWaiting(*store, endpoint);
 
-    store->clear();
+    ASSERT_EQ(store->clear(), 0);
 
     EXPECT_EQ(waitingListSize(*store), 0);
     EXPECT_EQ(endpoint->status(), RdmaEndPoint::EP_DESTROYED);

--- a/mooncake-transfer-engine/tent/tests/rail_monitor_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/rail_monitor_test.cpp
@@ -58,6 +58,53 @@ static std::shared_ptr<Topology> makeSingleNicTopology(const std::string& nic,
     return topo;
 }
 
+static std::shared_ptr<Topology> makeTwoNicTopology(
+    const std::string& first, const std::string& second) {
+    auto json_str = R"({
+        "nics": [
+            {"name": ")" +
+                    first + R"(", "type": 0, "numa_node": 0},
+            {"name": ")" +
+                    second + R"(", "type": 0, "numa_node": 0}
+        ],
+        "mems": [{
+            "name": "host0",
+            "type": 0,
+            "numa_node": 0,
+            "device_list": {"rank0": [0, 1]}
+        }]
+    })";
+    auto topo = std::make_shared<Topology>();
+    auto status = topo->parse(json_str);
+    if (!status.ok()) {
+        ADD_FAILURE() << "Topology::parse failed: " << status.ToString();
+    }
+    return topo;
+}
+
+TEST(RailMonitorConfigTest, CustomJsonOverridesAutomaticPeerMapping) {
+    auto local = makeTwoNicTopology("local0", "local1");
+    auto remote = makeTwoNicTopology("remote0", "remote1");
+    const std::string rail_json = R"({
+        "all": [
+            {"local": "local0", "remote": "remote1"},
+            {"local": "local1", "remote": "remote0"}
+        ],
+        "direct": [
+            {"local": "local0", "remote": "remote1"},
+            {"local": "local1", "remote": "remote0"}
+        ]
+    })";
+
+    RailMonitor rail;
+    ASSERT_TRUE(
+        rail.load(local.get(), remote.get(), rail_json, nullptr).ok());
+    EXPECT_EQ(rail.findBestRemoteDevice(/*local_nic=*/0, /*remote_numa=*/0), 1);
+    EXPECT_EQ(rail.findBestRemoteDevice(/*local_nic=*/1, /*remote_numa=*/0), 0);
+    EXPECT_TRUE(rail.available(/*local_nic=*/0, /*remote_nic=*/1));
+    EXPECT_FALSE(rail.available(/*local_nic=*/0, /*remote_nic=*/0));
+}
+
 // ---------------------------------------------------------------------------
 // markRecovered resets error_count so failures start accumulating fresh
 // ---------------------------------------------------------------------------

--- a/mooncake-transfer-engine/tent/tests/rail_monitor_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/rail_monitor_test.cpp
@@ -58,8 +58,8 @@ static std::shared_ptr<Topology> makeSingleNicTopology(const std::string& nic,
     return topo;
 }
 
-static std::shared_ptr<Topology> makeTwoNicTopology(
-    const std::string& first, const std::string& second) {
+static std::shared_ptr<Topology> makeTwoNicTopology(const std::string& first,
+                                                    const std::string& second) {
     auto json_str = R"({
         "nics": [
             {"name": ")" +
@@ -97,8 +97,7 @@ TEST(RailMonitorConfigTest, CustomJsonOverridesAutomaticPeerMapping) {
     })";
 
     RailMonitor rail;
-    ASSERT_TRUE(
-        rail.load(local.get(), remote.get(), rail_json, nullptr).ok());
+    ASSERT_TRUE(rail.load(local.get(), remote.get(), rail_json, nullptr).ok());
     EXPECT_EQ(rail.findBestRemoteDevice(/*local_nic=*/0, /*remote_numa=*/0), 1);
     EXPECT_EQ(rail.findBestRemoteDevice(/*local_nic=*/1, /*remote_numa=*/0), 0);
     EXPECT_TRUE(rail.available(/*local_nic=*/0, /*remote_nic=*/1));

--- a/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
@@ -1,0 +1,226 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <infiniband/verbs.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "tent/common/config.h"
+#include "tent/common/types.h"
+#include "tent/transfer_engine.h"
+#include "tent/transport/rdma/params.h"
+#include "tent/transport/rdma/rdma_transport.h"
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+bool hasRdmaDevice() {
+    int count = 0;
+    ibv_device** devices = ibv_get_device_list(&count);
+    const bool available = devices != nullptr && count > 0;
+    if (devices) ibv_free_device_list(devices);
+    return available;
+}
+
+class ChildProcessGuard {
+   public:
+    ChildProcessGuard(pid_t pid, int stop_fd) : pid_(pid), stop_fd_(stop_fd) {}
+
+    ~ChildProcessGuard() {
+        if (pid_ <= 0) return;
+        close(stop_fd_);
+        (void)waitpid(pid_, nullptr, 0);
+    }
+
+    int finish() {
+        close(stop_fd_);
+        int status = 0;
+        (void)waitpid(pid_, &status, 0);
+        pid_ = -1;
+        stop_fd_ = -1;
+        return status;
+    }
+
+    int reap() {
+        int status = 0;
+        (void)waitpid(pid_, &status, 0);
+        close(stop_fd_);
+        pid_ = -1;
+        stop_fd_ = -1;
+        return status;
+    }
+
+   private:
+    pid_t pid_;
+    int stop_fd_;
+};
+
+std::shared_ptr<Config> makeRdmaConfig() {
+    auto config = std::make_shared<Config>();
+    config->set("metadata_type", "p2p");
+    config->set("metadata_servers", "P2PHANDSHAKE");
+    config->set("transports/rdma/enable", true);
+    config->set("transports/tcp/enable", false);
+    config->set("transports/shm/enable", false);
+    return config;
+}
+
+bool waitBatchDone(TransferEngine& engine, BatchID batch) {
+    TransferStatus status;
+    for (int i = 0; i < 10000; ++i) {
+        auto result = engine.getTransferStatus(batch, status);
+        if (!result.ok() || status.s == TransferStatusEnum::FAILED) return false;
+        if (status.s == TransferStatusEnum::COMPLETED) return true;
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    return false;
+}
+
+TEST(RdmaParamsTest, DefaultsKeepLaneCountsAligned) {
+    RdmaParams params;
+
+    EXPECT_EQ(params.num_lanes, 6);
+    EXPECT_EQ(params.device.num_cq_list, params.num_lanes);
+    EXPECT_EQ(params.endpoint.qp_mul_factor, params.num_lanes);
+    EXPECT_EQ(params.workers.num_workers, params.num_lanes);
+    EXPECT_EQ(params.endpoint.path_mtu, IBV_MTU_4096);
+}
+
+TEST(RdmaSubBatchTest, ReportsTaskCount) {
+    RdmaSubBatch batch;
+    batch.max_size = 8;
+
+    EXPECT_EQ(batch.size(), 0);
+    batch.task_list.push_back(nullptr);
+    batch.task_list.push_back(nullptr);
+    EXPECT_EQ(batch.size(), 2);
+}
+
+TEST(RdmaTransportIntegrationTest, WriteThenReadAcrossProcesses) {
+    if (!hasRdmaDevice()) GTEST_SKIP() << "no RDMA device detected";
+
+    constexpr size_t kDataLength = 4 * 1024 * 1024;
+    int ready_pipe[2];
+    int stop_pipe[2];
+    ASSERT_EQ(pipe(ready_pipe), 0);
+    ASSERT_EQ(pipe(stop_pipe), 0);
+
+    pid_t child = fork();
+    ASSERT_GE(child, 0);
+    if (child == 0) {
+        close(ready_pipe[0]);
+        close(stop_pipe[1]);
+
+        TransferEngine server(makeRdmaConfig());
+        if (!server.available()) _exit(2);
+        std::vector<uint8_t> buffer(kDataLength);
+        if (!server.registerLocalMemory(buffer.data(), buffer.size()).ok())
+            _exit(3);
+
+        const std::string segment = server.getSegmentName();
+        uint32_t length = static_cast<uint32_t>(segment.size());
+        if (write(ready_pipe[1], &length, sizeof(length)) != sizeof(length))
+            _exit(4);
+        if (write(ready_pipe[1], segment.data(), length) !=
+            static_cast<ssize_t>(length))
+            _exit(5);
+
+        char stop = 0;
+        const ssize_t stop_result = read(stop_pipe[0], &stop, 1);
+        (void)stop_result;
+        (void)server.unregisterLocalMemory(buffer.data(), buffer.size());
+        _exit(0);
+    }
+
+    close(ready_pipe[1]);
+    close(stop_pipe[0]);
+    ChildProcessGuard child_guard(child, stop_pipe[1]);
+
+    uint32_t segment_length = 0;
+    ssize_t received =
+        read(ready_pipe[0], &segment_length, sizeof(segment_length));
+    if (received != static_cast<ssize_t>(sizeof(segment_length))) {
+        const int status = child_guard.reap();
+        GTEST_SKIP() << "RDMA server initialization failed, child status "
+                     << status;
+    }
+    std::string server_segment(segment_length, '\0');
+    ASSERT_EQ(read(ready_pipe[0], server_segment.data(), segment_length),
+              static_cast<ssize_t>(segment_length));
+
+    TransferEngine client(makeRdmaConfig());
+    ASSERT_TRUE(client.available());
+    std::vector<uint8_t> buffer(kDataLength * 2);
+    for (size_t i = 0; i < kDataLength; ++i) {
+        buffer[i] = static_cast<uint8_t>((i * 31) & 0xff);
+    }
+    ASSERT_TRUE(client.registerLocalMemory(buffer.data(), buffer.size()).ok());
+
+    SegmentID segment = 0;
+    Status result;
+    for (int i = 0; i < 100; ++i) {
+        result = client.openSegment(segment, server_segment);
+        if (result.ok()) break;
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+    ASSERT_TRUE(result.ok()) << result.ToString();
+
+    SegmentInfo info;
+    ASSERT_TRUE(client.getSegmentInfo(segment, info).ok());
+    ASSERT_FALSE(info.buffers.empty());
+
+    Request request{};
+    request.opcode = Request::WRITE;
+    request.source = buffer.data();
+    request.target_id = segment;
+    request.target_offset = info.buffers[0].base;
+    request.length = kDataLength;
+    request.transport_hint = RDMA;
+
+    BatchID batch = client.allocateBatch(1);
+    ASSERT_TRUE(client.submitTransfer(batch, {request}).ok());
+    ASSERT_TRUE(waitBatchDone(client, batch));
+    ASSERT_TRUE(client.freeBatch(batch).ok());
+
+    request.opcode = Request::READ;
+    request.source = buffer.data() + kDataLength;
+    batch = client.allocateBatch(1);
+    ASSERT_TRUE(client.submitTransfer(batch, {request}).ok());
+    ASSERT_TRUE(waitBatchDone(client, batch));
+    ASSERT_TRUE(client.freeBatch(batch).ok());
+    EXPECT_EQ(std::memcmp(buffer.data(), buffer.data() + kDataLength,
+                          kDataLength),
+              0);
+
+    EXPECT_TRUE(client.closeSegment(segment).ok());
+    EXPECT_TRUE(client.unregisterLocalMemory(buffer.data(), buffer.size()).ok());
+
+    const int status = child_guard.finish();
+    ASSERT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(WEXITSTATUS(status), 0);
+}
+
+}  // namespace
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
@@ -90,7 +90,8 @@ bool waitBatchDone(TransferEngine& engine, BatchID batch) {
     TransferStatus status;
     for (int i = 0; i < 10000; ++i) {
         auto result = engine.getTransferStatus(batch, status);
-        if (!result.ok() || status.s == TransferStatusEnum::FAILED) return false;
+        if (!result.ok() || status.s == TransferStatusEnum::FAILED)
+            return false;
         if (status.s == TransferStatusEnum::COMPLETED) return true;
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
@@ -209,12 +210,13 @@ TEST(RdmaTransportIntegrationTest, WriteThenReadAcrossProcesses) {
     ASSERT_TRUE(client.submitTransfer(batch, {request}).ok());
     ASSERT_TRUE(waitBatchDone(client, batch));
     ASSERT_TRUE(client.freeBatch(batch).ok());
-    EXPECT_EQ(std::memcmp(buffer.data(), buffer.data() + kDataLength,
-                          kDataLength),
-              0);
+    EXPECT_EQ(
+        std::memcmp(buffer.data(), buffer.data() + kDataLength, kDataLength),
+        0);
 
     EXPECT_TRUE(client.closeSegment(segment).ok());
-    EXPECT_TRUE(client.unregisterLocalMemory(buffer.data(), buffer.size()).ok());
+    EXPECT_TRUE(
+        client.unregisterLocalMemory(buffer.data(), buffer.size()).ok());
 
     const int status = child_guard.finish();
     ASSERT_TRUE(WIFEXITED(status));

--- a/mooncake-transfer-engine/tent/tests/transfer_engine_config_override_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/transfer_engine_config_override_test.cpp
@@ -290,8 +290,7 @@ TEST(TransferEngineConfigOverrideTest,
     Config config;
     ASSERT_TRUE(ConfigHelper().loadFromEnv(config).ok());
 
-    EXPECT_TRUE(
-        config.get("transports/rdma/log_slice_affinity", false));
+    EXPECT_TRUE(config.get("transports/rdma/log_slice_affinity", false));
 }
 
 TEST(TransferEngineConfigOverrideTest,

--- a/mooncake-transfer-engine/tent/tests/transfer_engine_config_override_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/transfer_engine_config_override_test.cpp
@@ -284,6 +284,17 @@ TEST(TransferEngineConfigOverrideTest,
 }
 
 TEST(TransferEngineConfigOverrideTest,
+     LegacyRdmaSliceAffinityLogEnvLoadsIntoTentConfig) {
+    EnvVarGuard guard("MC_LOG_RDMA_SLICE_AFFINITY", "true");
+
+    Config config;
+    ASSERT_TRUE(ConfigHelper().loadFromEnv(config).ok());
+
+    EXPECT_TRUE(
+        config.get("transports/rdma/log_slice_affinity", false));
+}
+
+TEST(TransferEngineConfigOverrideTest,
      ExplicitMetadataOverridesDriveSuccessfulHttpInitialization) {
 #ifdef _WIN32
     GTEST_SKIP() << "Requires local HTTP metadata server support";


### PR DESCRIPTION
## Summary

This PR ports the current Transfer Engine (TE) RDMA lifecycle semantics and test coverage to TENT. #2588

Rather than introducing a separate TENT-specific design, it aligns TENT with the behavior already established and validated in TE while preserving TENT's worker, rail-selection, and transport architecture.

## TE to TENT Porting Scope

### RDMA endpoint lifecycle

- port TE's unidirectional endpoint lifecycle to TENT:
  `UNINIT -> HANDSHAKING -> READY -> DESTROYING -> DESTROYED`
- make endpoint destruction idempotent and safe for default-constructed or partially constructed endpoints
- move live QPs to `ERR` before asynchronous reclamation so outstanding WRs can be flushed
- prevent destroyed or retiring endpoint generations from being reused
- safely handle delayed destruction through externally retained `shared_ptr`s
- reuse the matching endpoint generation after simultaneous-open bootstrap timeouts

### Endpoint store and shutdown

- align FIFO and SIEVE removal and reclamation behavior with TE
- unpublish endpoints before reclamation
- synchronously deconstruct endpoints during context shutdown before CQ, PD, and device teardown
- drain both active and waiting-list endpoints during `clear()`
- avoid Store/Endpoint lock-order inversions by destroying verbs resources outside the store lock

### Notification ownership

- replace raw notification endpoint ownership with `weak_ptr`/`shared_ptr` semantics
- unregister notification QPs when endpoint retirement begins
- wake blocked notification senders during teardown
- serialize notification resource access against endpoint deconstruction

### Rail affinity

- apply configured `rail_topo_path` mappings to TENT path selection
- support optional RDMA slice-affinity logging through `MC_LOG_RDMA_SLICE_AFFINITY`
- retain TENT's rail monitoring and fallback behavior

## Tests Ported from TE

The TE RDMA tests were adapted to the TENT API and lifecycle model instead of testing equivalent behavior through local stubs.

- real `RdmaEndPoint` construction and ownership tests
- idempotent synchronous and two-phase destruction tests
- FIFO and SIEVE waiting-list reclamation tests
- large endpoint backlog reclamation without active map entries
- endpoint-store `clear()` with externally retained endpoint ownership
- RDMA parameter and sub-batch tests
- cross-process RDMA WRITE followed by RDMA READ with full payload verification
- explicit `transport_hint = RDMA` to ensure integration tests cannot silently fall back to TCP or SHM
- automatic skip on hosts without an RDMA device

## Why

TE already contains the mature RDMA lifecycle contract. TENT had independently implemented similar behavior, but several transitions and ownership boundaries were incomplete:

- failed endpoints could enter `DESTROYING` without transitioning QPs to `ERR`
- store removal could call endpoint no-lock helpers without holding the endpoint lock
- context shutdown could leave verbs resources owned by delayed `shared_ptr`s
- notification completion lookup used raw pointers
- partial endpoint construction was not uniformly safe to clean up
- configured rail topology mappings were not consumed by the active TENT path

Porting the TE behavior and tests gives both implementations the same lifecycle invariants and regression coverage.


## Module

- [X] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



**Test commands:**
```bash
# Example: bash scripts/run_ci_test.sh
```

**Test results:**
- [X] Unit tests pass
- [X] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have formatted my code using `./scripts/code_format.sh`
- [X] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [X] AI tools were used (specify below)