### PR TITLE
[Wheel] Optimize strucutured object transfer

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -11,6 +11,7 @@ wqs = "wqs"
 hsa = "hsa"
 Optin = "Optin"
 HPE = "HPE"
+thw = "thw"
 
 [files]
 extend-exclude = [

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@
   [![PyPI - Downloads](https://static.pepy.tech/badge/mooncake-transfer-engine?period=month)](https://pypi.org/project/mooncake-transfer-engine)
   [![GitHub commit activity](https://img.shields.io/github/commit-activity/w/kvcache-ai/Mooncake)](https://github.com/kvcache-ai/Mooncake/graphs/commit-activity)
   [![license](https://img.shields.io/github/license/kvcache-ai/mooncake.svg)](https://github.com/kvcache-ai/Mooncake/blob/main/LICENSE-APACHE)
-  [![Docker](https://img.shields.io/docker/v/kvcacheai/mooncake?label=docker&logo=docker&logoColor=white&color=2496ED)](https://hub.docker.com/r/kvcacheai/mooncake)
   <br />
 
   [![PyPI](https://img.shields.io/pypi/v/mooncake-transfer-engine)](https://pypi.org/project/mooncake-transfer-engine)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
   [![PyPI - Downloads](https://static.pepy.tech/badge/mooncake-transfer-engine?period=month)](https://pypi.org/project/mooncake-transfer-engine)
   [![GitHub commit activity](https://img.shields.io/github/commit-activity/w/kvcache-ai/Mooncake)](https://github.com/kvcache-ai/Mooncake/graphs/commit-activity)
   [![license](https://img.shields.io/github/license/kvcache-ai/mooncake.svg)](https://github.com/kvcache-ai/Mooncake/blob/main/LICENSE-APACHE)
+  [![Docker](https://img.shields.io/docker/v/kvcacheai/mooncake?label=docker&logo=docker&logoColor=white&color=2496ED)](https://hub.docker.com/r/kvcacheai/mooncake)
   <br />
 
   [![PyPI](https://img.shields.io/pypi/v/mooncake-transfer-engine)](https://pypi.org/project/mooncake-transfer-engine)

--- a/docs/source/api-reference/python/index.md
+++ b/docs/source/api-reference/python/index.md
@@ -3,7 +3,7 @@
 | Module | Description |
 |--------|-------------|
 | [Mooncake Store](../../python-api-reference/mooncake-store) | Distributed KV cache storage client — `put`/`get`/`remove`/`replicate` operations |
-| [DataProto Structured Object Transfer](../../python-api-reference/dataproto-structured-object-transfer) | Structured-object helpers for storing and retrieving DataProto-like payloads |
+| [DataProto Structured Object Transfer](../../python-api-reference/dataproto-structured-object-transfer) | Structured-object helpers for storing and retrieving DataProto-like and flat dict payloads |
 | [Transfer Engine](../../python-api-reference/transfer-engine) | High-performance RDMA/TCP data transfer between nodes |
 | [EP Backend](../../python-api-reference/ep-backend) | Expert-parallel backend for large MoE model deployment |
 

--- a/docs/source/python-api-reference/dataproto-structured-object-transfer.md
+++ b/docs/source/python-api-reference/dataproto-structured-object-transfer.md
@@ -1,6 +1,6 @@
-# DataProto structured object usage
+# DataProto and flat dict structured object usage
 
-Mooncake can store DataProto-like objects as structured objects so callers can pass a lightweight handle between stages and materialize only the fields they need.
+Mooncake can store DataProto-like objects and flat dictionaries as structured objects so callers can pass a lightweight handle between stages and materialize only the fields they need.
 
 A DataProto-like object is any object with these mapping-like attributes:
 
@@ -8,7 +8,7 @@ A DataProto-like object is any object with these mapping-like attributes:
 - `non_tensor_batch`: per-row non-tensor fields.
 - `meta_info`: small metadata for the whole batch.
 
-Plain dictionaries are also accepted. A dictionary with only `batch`, `non_tensor_batch`, and `meta_info` keys is treated as an envelope; other dictionaries are treated as `batch` fields.
+Plain dictionaries are also accepted on the DataProto path. A dictionary with only `batch`, `non_tensor_batch`, and `meta_info` keys is treated as an envelope; other dictionaries are treated as `batch` fields. Use `type="dict"` for the flat dictionary path when the input is an ordinary dictionary and should be routed into `batch`, `non_tensor_batch`, and `meta_info` by Mooncake.
 
 ## Public API
 
@@ -23,23 +23,22 @@ from mooncake.structured_object_store import (
 
 transfer = MooncakeBundleTransfer(store, key_prefix="rl")
 
-ref = transfer.put_dataproto(
-    data,
-    namespace="rollout",
-    partition="step-1",
-    stage="rollout",
-)
+ref = transfer.put(data, type="dataproto")
+subset = transfer.get(ref, type="dataproto", fields=["input_ids", "old_log_probs"])
+
+dict_ref = transfer.put(payload_dict, type="dict")
+dict_result = transfer.get(dict_ref, type="dict")
+
+# Compatibility helpers remain available for callers that prefer typed names.
+ref = transfer.put_dataproto(data)
+subset = transfer.get_dataproto(ref, fields=["input_ids", "old_log_probs"])
+dict_ref = transfer.put_dict(payload_dict)
+dict_result = transfer.get_dict(dict_ref)
 
 ref = transfer.append_dataproto_fields(
     ref,
     logprob_data,
     stage="old_log_prob",
-)
-
-subset = transfer.get_dataproto(
-    ref,
-    fields=["input_ids", "old_log_probs"],
-    meta_info_keys=["step"],
 )
 
 handle = export_dataproto_ref(ref)
@@ -61,11 +60,26 @@ For process boundaries, use `export_dataproto_ref(ref)`. The exported handle is 
 
 ## Writing fields
 
-`put_dataproto()` writes one structured object for the requested stage. `append_dataproto_fields()` writes another structured object and updates the handle. Existing fields are not rewritten.
+`put(..., type="dataproto")` writes one structured object for the requested stage. `append_dataproto_fields()` writes another structured object and updates the handle. Existing fields are not rewritten.
+
+`put(..., type="dict")` writes a flat dictionary through the same structured object path. Numeric tensor-like values are stored as `batch` fields, row-aligned non-tensor sequences are stored as `non_tensor_batch`, and scalar or global metadata stays in `meta_info`. Pass `field_schemas` when list-valued metadata would otherwise be ambiguous.
+
+`put_dataproto()` / `get_dataproto()` and `put_dict()` / `get_dict()` are thin compatibility helpers over the unified `put()` / `get()` API. Older `put_legacy_dict()` / `get_legacy_dict()` names are kept as aliases.
 
 Duplicate field names are rejected by default. Use `overwrite=True` only when replacing all fields from an existing stage; after the new stage object is written successfully, the old stage object is removed.
 
 Field names are global within a ref. A `batch` field and a `non_tensor_batch` field cannot use the same name.
+
+Store write configuration is passed through with `config`. Mooncake does not interpret this object in the structured layer; it forwards it to the lower-level write APIs such as `put`, `put_from`, and `batch_put_from`. For example, callers can use the same `ReplicateConfig` object they would pass to the lower-level store APIs:
+
+```python
+from mooncake.store import ReplicateConfig
+
+config = ReplicateConfig()
+config.replica_num = 2
+
+ref = transfer.put(data, type="dict", config=config)
+```
 
 ## Reading fields
 
@@ -162,6 +176,8 @@ transfer.put_structured_object(payload, policy=policy)
 ```
 
 `copy_mode="zero_copy"` requires tensor payloads to be provided as `tensor_object_buffer`; plain torch tensors are rejected because they do not expose a registered tensor-object buffer.
+
+`policy` controls how structured payload buffers are copied or transferred. `config` is separate: it is forwarded to the underlying Mooncake Store write calls and can carry store-level placement or replication options.
 
 ## Cleanup
 

--- a/docs/source/python-api-reference/mooncake-store.md
+++ b/docs/source/python-api-reference/mooncake-store.md
@@ -195,6 +195,8 @@ metadata = result.metadata
 
 By default, structured object writes use `BundleTransferPolicy(copy_mode="auto")`. This keeps the existing behavior: Mooncake uses the zero-copy `batch_put_from` fast path when buffer registration is available, and falls back to ordinary `store.put` when the fast path is unavailable.
 
+Structured object write methods also accept `config`, which is forwarded to the underlying Mooncake Store write calls. Use `policy` for structured-object copy behavior and `config` for store-level placement or replication options.
+
 For very large tensors, buffer registration capacity can be exhausted. If the upper layer does not handle this failure mode yet, force the non-zero-copy path with `copy_mode="copy"`:
 
 ```python

--- a/mooncake-wheel/mooncake/__init__.py
+++ b/mooncake-wheel/mooncake/__init__.py
@@ -1,6 +1,12 @@
 """Mooncake public Python package."""
 
-from mooncake.buffer_pool import BufferPool, RegisteredBufferPool
-
 __all__ = ["BufferPool", "RegisteredBufferPool"]
+
+
+def __getattr__(name):
+    if name in __all__:
+        from mooncake.buffer_pool import BufferPool, RegisteredBufferPool
+
+        return {"BufferPool": BufferPool, "RegisteredBufferPool": RegisteredBufferPool}[name]
+    raise AttributeError(name)
 

--- a/mooncake-wheel/mooncake/_fast_copy.c
+++ b/mooncake-wheel/mooncake/_fast_copy.c
@@ -37,26 +37,21 @@ static void *copy_thread_func(void *arg) {
     return NULL;
 }
 
-static PyObject *
-concat_arrays_into(PyObject *self, PyObject *args)
-{
+static PyObject *concat_arrays_into(PyObject *self, PyObject *args) {
     PyObject *list_obj;
     unsigned long long dest_ptr_val;
     Py_ssize_t start = 0;
     Py_ssize_t count = -1;
     int nthreads = 1;
 
-    if (!PyArg_ParseTuple(args, "O!K|nni",
-                          &PyList_Type, &list_obj,
-                          &dest_ptr_val,
-                          &start, &count, &nthreads))
+    if (!PyArg_ParseTuple(args, "O!K|nni", &PyList_Type, &list_obj,
+                          &dest_ptr_val, &start, &count, &nthreads))
         return NULL;
 
     Py_ssize_t list_len = PyList_GET_SIZE(list_obj);
     if (start < 0) start = 0;
     if (start > list_len) start = list_len;
-    if (count < 0 || start + count > list_len)
-        count = list_len - start;
+    if (count < 0 || start + count > list_len) count = list_len - start;
     if (count == 0) return PyLong_FromSize_t(0);
     if (nthreads < 1) nthreads = 1;
     if (nthreads > (int)count) nthreads = (int)count;
@@ -65,23 +60,26 @@ concat_arrays_into(PyObject *self, PyObject *args)
     void **ptrs = (void **)malloc(count * sizeof(void *));
     size_t *sizes = (size_t *)malloc(count * sizeof(size_t));
     if (!ptrs || !sizes) {
-        free(ptrs); free(sizes);
+        free(ptrs);
+        free(sizes);
         return PyErr_NoMemory();
     }
 
     for (Py_ssize_t i = 0; i < count; i++) {
         PyObject *item = PyList_GET_ITEM(list_obj, start + i);
         if (!PyArray_Check(item)) {
-            free(ptrs); free(sizes);
-            PyErr_Format(PyExc_TypeError,
-                         "arrays[%zd] is not an ndarray", start + i);
+            free(ptrs);
+            free(sizes);
+            PyErr_Format(PyExc_TypeError, "arrays[%zd] is not an ndarray",
+                         start + i);
             return NULL;
         }
         PyArrayObject *arr = (PyArrayObject *)item;
         if (!PyArray_IS_C_CONTIGUOUS(arr)) {
-            free(ptrs); free(sizes);
-            PyErr_Format(PyExc_ValueError,
-                         "arrays[%zd] is not C-contiguous", start + i);
+            free(ptrs);
+            free(sizes);
+            PyErr_Format(PyExc_ValueError, "arrays[%zd] is not C-contiguous",
+                         start + i);
             return NULL;
         }
         ptrs[i] = PyArray_DATA(arr);
@@ -92,7 +90,10 @@ concat_arrays_into(PyObject *self, PyObject *args)
     ThreadWork *works = (ThreadWork *)calloc(nthreads, sizeof(ThreadWork));
     pthread_t *threads = (pthread_t *)malloc(nthreads * sizeof(pthread_t));
     if (!works || !threads) {
-        free(ptrs); free(sizes); free(works); free(threads);
+        free(ptrs);
+        free(sizes);
+        free(works);
+        free(threads);
         return PyErr_NoMemory();
     }
 
@@ -119,13 +120,14 @@ concat_arrays_into(PyObject *self, PyObject *args)
     }
 
     /* Copy with GIL released. */
-    Py_BEGIN_ALLOW_THREADS
-    if (actual_threads == 1) {
+    Py_BEGIN_ALLOW_THREADS if (actual_threads == 1) {
         copy_thread_func(&works[0]);
-    } else {
+    }
+    else {
         int launched = 0;
         for (int t = 1; t < actual_threads; t++) {
-            if (pthread_create(&threads[t], NULL, copy_thread_func, &works[t]) != 0) {
+            if (pthread_create(&threads[t], NULL, copy_thread_func,
+                               &works[t]) != 0) {
                 copy_thread_func(&works[t]);
             } else {
                 launched++;
@@ -141,19 +143,20 @@ concat_arrays_into(PyObject *self, PyObject *args)
     }
     Py_END_ALLOW_THREADS
 
-    size_t total = 0;
-    for (int t = 0; t < actual_threads; t++)
-        total += works[t].bytes_copied;
+        size_t total = 0;
+    for (int t = 0; t < actual_threads; t++) total += works[t].bytes_copied;
 
-    free(ptrs); free(sizes); free(works); free(threads);
+    free(ptrs);
+    free(sizes);
+    free(works);
+    free(threads);
     return PyLong_FromSize_t(total);
 }
 
 static PyMethodDef module_methods[] = {
     {"concat_arrays_into", concat_arrays_into, METH_VARARGS,
      "Scatter-copy arrays[start:start+count] into dest_ptr (GIL released)."},
-    {NULL, NULL, 0, NULL}
-};
+    {NULL, NULL, 0, NULL}};
 
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
@@ -163,9 +166,7 @@ static struct PyModuleDef moduledef = {
     module_methods,
 };
 
-PyMODINIT_FUNC
-PyInit__fast_copy(void)
-{
+PyMODINIT_FUNC PyInit__fast_copy(void) {
     import_array();
     return PyModule_Create(&moduledef);
 }

--- a/mooncake-wheel/mooncake/_fast_copy.c
+++ b/mooncake-wheel/mooncake/_fast_copy.c
@@ -1,0 +1,171 @@
+/*
+ * _fast_copy.c — Python C extension for scatter-gather copy with GIL release.
+ *
+ * concat_arrays_into(arrays, dest_ptr, start=0, count=-1, nthreads=1)
+ *   Copies arrays[start:start+count] into dest_ptr using nthreads.
+ *   Releases GIL during the memcpy phase, enabling concurrent copies
+ *   from multiple Python threads.
+ */
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+#include <string.h>
+#include <pthread.h>
+
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include <numpy/arrayobject.h>
+
+typedef struct {
+    void **src_ptrs;
+    size_t *src_sizes;
+    int count;
+    char *dst;
+    size_t offset;
+    size_t bytes_copied;
+} ThreadWork;
+
+static void *copy_thread_func(void *arg) {
+    ThreadWork *w = (ThreadWork *)arg;
+    char *d = w->dst + w->offset;
+    size_t off = 0;
+    for (int i = 0; i < w->count; i++) {
+        if (w->src_sizes[i] > 0) {
+            memcpy(d + off, w->src_ptrs[i], w->src_sizes[i]);
+            off += w->src_sizes[i];
+        }
+    }
+    w->bytes_copied = off;
+    return NULL;
+}
+
+static PyObject *
+concat_arrays_into(PyObject *self, PyObject *args)
+{
+    PyObject *list_obj;
+    unsigned long long dest_ptr_val;
+    Py_ssize_t start = 0;
+    Py_ssize_t count = -1;
+    int nthreads = 1;
+
+    if (!PyArg_ParseTuple(args, "O!K|nni",
+                          &PyList_Type, &list_obj,
+                          &dest_ptr_val,
+                          &start, &count, &nthreads))
+        return NULL;
+
+    Py_ssize_t list_len = PyList_GET_SIZE(list_obj);
+    if (start < 0) start = 0;
+    if (start > list_len) start = list_len;
+    if (count < 0 || start + count > list_len)
+        count = list_len - start;
+    if (count == 0) return PyLong_FromSize_t(0);
+    if (nthreads < 1) nthreads = 1;
+    if (nthreads > (int)count) nthreads = (int)count;
+
+    /* Extract array pointers under GIL. */
+    void **ptrs = (void **)malloc(count * sizeof(void *));
+    size_t *sizes = (size_t *)malloc(count * sizeof(size_t));
+    if (!ptrs || !sizes) {
+        free(ptrs); free(sizes);
+        return PyErr_NoMemory();
+    }
+
+    for (Py_ssize_t i = 0; i < count; i++) {
+        PyObject *item = PyList_GET_ITEM(list_obj, start + i);
+        if (!PyArray_Check(item)) {
+            free(ptrs); free(sizes);
+            PyErr_Format(PyExc_TypeError,
+                         "arrays[%zd] is not an ndarray", start + i);
+            return NULL;
+        }
+        PyArrayObject *arr = (PyArrayObject *)item;
+        if (!PyArray_IS_C_CONTIGUOUS(arr)) {
+            free(ptrs); free(sizes);
+            PyErr_Format(PyExc_ValueError,
+                         "arrays[%zd] is not C-contiguous", start + i);
+            return NULL;
+        }
+        ptrs[i] = PyArray_DATA(arr);
+        sizes[i] = (size_t)PyArray_NBYTES(arr);
+    }
+
+    /* Partition work across threads. */
+    ThreadWork *works = (ThreadWork *)calloc(nthreads, sizeof(ThreadWork));
+    pthread_t *threads = (pthread_t *)malloc(nthreads * sizeof(pthread_t));
+    if (!works || !threads) {
+        free(ptrs); free(sizes); free(works); free(threads);
+        return PyErr_NoMemory();
+    }
+
+    int n = (int)count;
+    int per_t = (n + nthreads - 1) / nthreads;
+    size_t offset = 0;
+    int actual_threads = 0;
+    for (int t = 0; t < nthreads; t++) {
+        int s = t * per_t;
+        int c = per_t;
+        if (s + c > n) c = n - s;
+        if (c <= 0) break;
+
+        works[t].src_ptrs = ptrs + s;
+        works[t].src_sizes = sizes + s;
+        works[t].count = c;
+        works[t].dst = (char *)(uintptr_t)dest_ptr_val;
+        works[t].offset = offset;
+
+        size_t tb = 0;
+        for (int j = s; j < s + c; j++) tb += sizes[j];
+        offset += tb;
+        actual_threads++;
+    }
+
+    /* Copy with GIL released. */
+    Py_BEGIN_ALLOW_THREADS
+    if (actual_threads == 1) {
+        copy_thread_func(&works[0]);
+    } else {
+        int launched = 0;
+        for (int t = 1; t < actual_threads; t++) {
+            if (pthread_create(&threads[t], NULL, copy_thread_func, &works[t]) != 0) {
+                copy_thread_func(&works[t]);
+            } else {
+                launched++;
+            }
+        }
+        copy_thread_func(&works[0]);
+        for (int t = 1; t < actual_threads; t++) {
+            if (launched > 0) {
+                pthread_join(threads[t], NULL);
+                launched--;
+            }
+        }
+    }
+    Py_END_ALLOW_THREADS
+
+    size_t total = 0;
+    for (int t = 0; t < actual_threads; t++)
+        total += works[t].bytes_copied;
+
+    free(ptrs); free(sizes); free(works); free(threads);
+    return PyLong_FromSize_t(total);
+}
+
+static PyMethodDef module_methods[] = {
+    {"concat_arrays_into", concat_arrays_into, METH_VARARGS,
+     "Scatter-copy arrays[start:start+count] into dest_ptr (GIL released)."},
+    {NULL, NULL, 0, NULL}
+};
+
+static struct PyModuleDef moduledef = {
+    PyModuleDef_HEAD_INIT,
+    "_fast_copy",
+    "Fast scatter-gather copy for ndarray lists.",
+    -1,
+    module_methods,
+};
+
+PyMODINIT_FUNC
+PyInit__fast_copy(void)
+{
+    import_array();
+    return PyModule_Create(&moduledef);
+}

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -1420,7 +1420,7 @@ class MooncakeBundleTransfer:
         """Store a legacy rollout dict as a structured object."""
         return self._put_stage(
             None,
-            _legacy_dict_to_dataproto_envelope(data),
+            _legacy_dict_to_envelope(data),
             namespace=namespace,
             partition=partition,
             stage=stage,
@@ -1432,7 +1432,7 @@ class MooncakeBundleTransfer:
 
     def get_legacy_dict(self, ref: DataProtoRefLike) -> dict[str, Any]:
         """Materialize a legacy rollout dict stored by put_legacy_dict()."""
-        return _dataproto_envelope_to_legacy_dict(
+        return _envelope_to_legacy_dict(
             self._materialize_ref(_resolve_ref(ref))
         )
 
@@ -1761,7 +1761,7 @@ LEGACY_DICT_META_FIELDS = frozenset(
 )
 
 
-def _legacy_dict_to_dataproto_envelope(data: Mapping[str, Any]) -> dict[str, Any]:
+def _legacy_dict_to_envelope(data: Mapping[str, Any]) -> dict[str, Any]:
     if not isinstance(data, Mapping):
         raise TypeError("legacy rollout data must be a mapping")
     partition = data.get("partition")
@@ -1789,7 +1789,7 @@ def _legacy_dict_to_dataproto_envelope(data: Mapping[str, Any]) -> dict[str, Any
     }
 
 
-def _dataproto_envelope_to_legacy_dict(data: Mapping[str, Any]) -> dict[str, Any]:
+def _envelope_to_legacy_dict(data: Mapping[str, Any]) -> dict[str, Any]:
     result = dict(_mapping_to_dict(data.get("meta_info")))
     result.update(_mapping_to_dict(data.get("batch")))
     for key, value in _mapping_to_dict(data.get("non_tensor_batch")).items():

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -55,7 +55,7 @@ _INFER_MAX_LIST_LEN = 8
 
 
 class BundleStore(Protocol):
-    def put(self, key: str, value: Any) -> int: ...
+    def put(self, key: str, value: Any, config: Any = None) -> int: ...
 
     def get(self, key: str) -> bytes: ...
 
@@ -576,6 +576,7 @@ class MooncakeBundleTransfer:
         chunk_bytes: Optional[int] = None,
         policy: Optional[BundleTransferPolicy] = None,
         max_inflight_put: Optional[int] = None,
+        config: Any = None,
     ) -> RemoteBundleRef:
         """Store raw metadata bytes plus named buffers as a low-level bundle."""
         return self._bundle_store.put_bundle(
@@ -585,6 +586,7 @@ class MooncakeBundleTransfer:
             chunk_bytes=chunk_bytes,
             policy=policy,
             max_inflight_put=max_inflight_put,
+            config=config,
         )
 
     def remove_bundle(self, ref: RemoteBundleRef | Mapping[str, Any]) -> None:
@@ -598,6 +600,7 @@ class MooncakeBundleTransfer:
         chunk_bytes: Optional[int] = None,
         policy: Optional[BundleTransferPolicy] = None,
         max_inflight_put: Optional[int] = None,
+        config: Any = None,
     ) -> RemoteBundleRef:
         """Store a structured object described by JSON metadata plus named members."""
         return self._structured_store.put_structured_object(
@@ -606,6 +609,7 @@ class MooncakeBundleTransfer:
             chunk_bytes=chunk_bytes,
             policy=policy,
             max_inflight_put=max_inflight_put,
+            config=config,
         )
 
     def read_spec(
@@ -626,6 +630,67 @@ class MooncakeBundleTransfer:
         """Materialize a structured object read spec into caller-provided destinations when possible."""
         return self._structured_store.materialize_into(spec, destinations)
 
+    def put(
+        self,
+        data: Any,
+        *,
+        type: Literal["dataproto", "dict"] = "dataproto",
+        namespace: str = "default",
+        partition: str = "default",
+        stage: str = "default",
+        chunk_bytes: Optional[int] = None,
+        policy: Optional[BundleTransferPolicy] = None,
+        field_schemas: Optional[Mapping[str, FieldSchema]] = None,
+        config: Any = None,
+    ) -> MooncakeDataProtoRef:
+        """Store a DataProto-like object or flat dict as a structured object."""
+        if type == "dataproto":
+            stage_data = data
+        elif type == "dict":
+            stage_data = _flat_dict_to_envelope_with_schema(data, field_schemas)
+        else:
+            raise ValueError(f"unsupported Mooncake payload type: {type!r}")
+        return self._put_stage(
+            None,
+            stage_data,
+            namespace=namespace,
+            partition=partition,
+            stage=stage,
+            chunk_bytes=chunk_bytes,
+            policy=policy,
+            overwrite=False,
+            field_schemas=field_schemas,
+            config=config,
+        )
+
+    def get(
+        self,
+        ref: DataProtoRefLike,
+        *,
+        type: Literal["dataproto", "dict"] = "dataproto",
+        fields: Optional[Sequence[str]] = None,
+        batch_fields: Optional[Sequence[str]] = None,
+        non_tensor_fields: Optional[Sequence[str]] = None,
+        meta_info_keys: Optional[Sequence[str]] = None,
+        data_cls: Optional[Any] = None,
+        destinations: Optional[Mapping[str, Any]] = None,
+        rows: slice | StructuredMemberSlice | Sequence[int] | None = None,
+    ) -> Any:
+        """Materialize a structured object as a DataProto-like object or flat dict."""
+        if type not in {"dataproto", "dict"}:
+            raise ValueError(f"unsupported Mooncake payload type: {type!r}")
+        return self._materialize_ref(
+            _resolve_ref(ref),
+            fields=fields,
+            batch_fields=batch_fields,
+            non_tensor_fields=non_tensor_fields,
+            meta_info_keys=meta_info_keys,
+            data_cls=data_cls,
+            destinations=destinations,
+            rows=rows,
+            flat_dict_output=(type == "dict"),
+        )
+
     def put_dataproto(
         self,
         data: Any,
@@ -636,18 +701,19 @@ class MooncakeBundleTransfer:
         chunk_bytes: Optional[int] = None,
         policy: Optional[BundleTransferPolicy] = None,
         field_schemas: Optional[dict[str, FieldSchema]] = None,
+        config: Any = None,
     ) -> MooncakeDataProtoRef:
         """Store a DataProto-like object as a stage-level structured object."""
-        return self._put_stage(
-            None,
+        return self.put(
             data,
+            type="dataproto",
             namespace=namespace,
             partition=partition,
             stage=stage,
             chunk_bytes=chunk_bytes,
             policy=policy,
-            overwrite=False,
             field_schemas=field_schemas,
+            config=config,
         )
 
     def get_dataproto(
@@ -663,8 +729,9 @@ class MooncakeBundleTransfer:
         rows: slice | StructuredMemberSlice | Sequence[int] | None = None,
     ) -> Any:
         """Materialize selected DataProto fields from structured object refs."""
-        return self._materialize_ref(
-            _resolve_ref(ref),
+        return self.get(
+            ref,
+            type="dataproto",
             fields=fields,
             batch_fields=batch_fields,
             non_tensor_fields=non_tensor_fields,
@@ -685,9 +752,9 @@ class MooncakeBundleTransfer:
         data_cls: Optional[Any] = None,
         destinations: Optional[Mapping[str, Any]] = None,
         rows: slice | StructuredMemberSlice | Sequence[int] | None = None,
-        legacy_output: bool = False,
+        flat_dict_output: bool = False,
     ) -> Any:
-        """Core materialization logic shared by get_dataproto and get_legacy_dict."""
+        """Core materialization logic shared by get_dataproto and get_dict."""
         row_selection = _coerce_dataproto_row_selection(rows, ref.batch_size)
         row_slice = None if row_selection is None else row_selection.member_slice
         row_indices = None if row_selection is None else row_selection.indices
@@ -781,7 +848,7 @@ class MooncakeBundleTransfer:
                     )
                     non_tensor_batch[name] = (
                         values
-                        if legacy_output
+                        if flat_dict_output
                         else _object_array_from_decoded_values(values)
                     )
         else:
@@ -809,12 +876,12 @@ class MooncakeBundleTransfer:
                     )
                 non_tensor_batch[name] = (
                     values
-                    if legacy_output
+                    if flat_dict_output
                     else _object_array_from_decoded_values(values)
                 )
         meta_info = {k: ref.meta_info[k] for k in meta_info_keys if k in ref.meta_info} if meta_info_keys is not None else dict(ref.meta_info)
-        if legacy_output:
-            return _envelope_to_legacy_dict(
+        if flat_dict_output:
+            return _envelope_to_flat_dict(
                 {
                     "batch": batch,
                     "non_tensor_batch": non_tensor_batch,
@@ -1395,7 +1462,7 @@ class MooncakeBundleTransfer:
         """Remove all structured object stages referenced by a DataProto handle."""
         self._cleanup_ref(ref)
 
-    def put_legacy_dict(
+    def put_dict(
         self,
         data: Mapping[str, Any],
         *,
@@ -1405,37 +1472,42 @@ class MooncakeBundleTransfer:
         chunk_bytes: Optional[int] = None,
         policy: Optional[BundleTransferPolicy] = None,
         field_schemas: Optional[Mapping[str, "FieldSchema"]] = None,
+        config: Any = None,
     ) -> MooncakeDataProtoRef:
-        """Store a legacy rollout dict as a structured object."""
-        return self._put_stage(
-            None,
-            _legacy_dict_to_envelope_with_schema(data, field_schemas),
+        """Store a flat dict as a structured object."""
+        return self.put(
+            data,
+            type="dict",
             namespace=namespace,
             partition=partition,
             stage=stage,
             chunk_bytes=chunk_bytes,
             policy=policy,
-            overwrite=False,
             field_schemas=field_schemas,
+            config=config,
         )
 
-    def get_legacy_dict(self, ref: DataProtoRefLike) -> dict[str, Any]:
-        """Materialize a legacy rollout dict stored by put_legacy_dict()."""
-        return self._materialize_ref(_resolve_ref(ref), legacy_output=True)
+    def get_dict(self, ref: DataProtoRefLike) -> dict[str, Any]:
+        """Materialize a flat dict stored by put_dict()."""
+        return self.get(ref, type="dict")
 
-    def remove_legacy_dict(self, ref: DataProtoRefLike) -> None:
-        """Remove a legacy rollout dict stored by put_legacy_dict()."""
+    def remove_dict(self, ref: DataProtoRefLike) -> None:
+        """Remove a flat dict stored by put_dict()."""
         self._cleanup_ref(ref)
+
+    put_legacy_dict = put_dict
+    get_legacy_dict = get_dict
+    remove_legacy_dict = remove_dict
 
     @staticmethod
     def release_result(result: Any) -> None:
         """Release pool-backed buffers in a GET result.
 
-        After get_dataproto / get_legacy_dict, ndarray payloads may be backed by
+        After get_dataproto / get_dict, ndarray payloads may be backed by
         the BufferPool.  Call this to release those leases deterministically
         instead of waiting for GC ``__del__``.
 
-        Works for both flat dicts (legacy_dict) and nested envelope dicts
+        Works for both flat dicts and nested envelope dicts
         (dataproto: {batch: {...}, non_tensor_batch: {...}, meta_info: {...}}).
         """
         released_owners: set[int] = set()
@@ -1487,12 +1559,14 @@ class MooncakeBundleTransfer:
         partition: str,
         chunk_bytes: Optional[int],
         policy: Optional[BundleTransferPolicy],
+        config: Any,
     ) -> RemoteBundleRef:
         new_stage_ref = self.put_structured_object(
             payload,
             partition=partition,
             chunk_bytes=chunk_bytes,
             policy=policy,
+            config=config,
         )
         try:
             old_manifest = self._bundle_store.resolve_manifest(old_stage_ref)
@@ -1517,6 +1591,7 @@ class MooncakeBundleTransfer:
                 partition=partition,
                 chunk_bytes=chunk_bytes,
                 policy=policy,
+                config=config,
                 cleanup_keys=[
                     self._bundle_store.manifest_key(old_stage_ref),
                     *self._bundle_store.payload_keys(old_manifest["meta"]),
@@ -1544,6 +1619,7 @@ class MooncakeBundleTransfer:
         policy: Optional[BundleTransferPolicy],
         overwrite: bool,
         field_schemas: Optional[dict[str, FieldSchema]] = None,
+        config: Any = None,
     ) -> MooncakeDataProtoRef:
         batch, non_tensor_batch, meta_info = _split_dataproto_like(data)
         _validate_dataproto_schema_sections(batch, non_tensor_batch, meta_info, field_schemas)
@@ -1675,6 +1751,7 @@ class MooncakeBundleTransfer:
                 partition=partition,
                 chunk_bytes=chunk_bytes,
                 policy=policy,
+                config=config,
             )
         else:
             stage_ref = self.put_structured_object(
@@ -1682,6 +1759,7 @@ class MooncakeBundleTransfer:
                 partition=partition,
                 chunk_bytes=chunk_bytes,
                 policy=policy,
+                config=config,
             )
             if (
                 existing_stage_ref is not None
@@ -1782,12 +1860,12 @@ def _validate_dataproto_schema_sections(
                 )
 
 
-def _legacy_dict_to_envelope_with_schema(
+def _flat_dict_to_envelope_with_schema(
     data: Mapping[str, Any], field_schemas: Mapping[str, FieldSchema] | None
 ) -> dict[str, Any]:
     if not field_schemas:
         field_schemas = {}
-    schema_row_count = _legacy_schema_row_count(data, field_schemas)
+    schema_row_count = _flat_dict_schema_row_count(data, field_schemas)
     row_count = schema_row_count
     if row_count == 0:
         schema_meta_fields = {
@@ -1795,7 +1873,7 @@ def _legacy_dict_to_envelope_with_schema(
             for name, schema in field_schemas.items()
             if name in data and _schema_section(name, schema) == "meta_info"
         }
-        row_count = _legacy_auto_row_count(data, exclude=schema_meta_fields)
+        row_count = _flat_dict_auto_row_count(data, exclude=schema_meta_fields)
     batch: dict[str, Any] = {}
     non_tensor_batch: dict[str, Any] = {}
     meta_info: dict[str, Any] = {}
@@ -1806,7 +1884,7 @@ def _legacy_dict_to_envelope_with_schema(
             if _is_row_aligned_dense_field(value, row_count):
                 batch[key] = value
             elif schema_row_count == 0 and isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)) and len(value) == row_count:
-                non_tensor_batch[key] = _coerce_legacy_non_tensor_field(
+                non_tensor_batch[key] = _coerce_flat_dict_non_tensor_field(
                     key, value, row_count, schema
                 )
             else:
@@ -1815,7 +1893,7 @@ def _legacy_dict_to_envelope_with_schema(
         if section == "batch":
             batch[key] = value
         elif section == "non_tensor_batch":
-            non_tensor_batch[key] = _coerce_legacy_non_tensor_field(
+            non_tensor_batch[key] = _coerce_flat_dict_non_tensor_field(
                 key, value, row_count, schema
             )
         else:
@@ -1827,7 +1905,14 @@ def _legacy_dict_to_envelope_with_schema(
     }
 
 
-def _legacy_schema_row_count(
+def _flat_dict_to_envelope(
+    data: Mapping[str, Any],
+    field_schemas: Optional[Mapping[str, FieldSchema]] = None,
+) -> dict[str, Any]:
+    return _flat_dict_to_envelope_with_schema(data, field_schemas)
+
+
+def _flat_dict_schema_row_count(
     data: Mapping[str, Any], field_schemas: Mapping[str, FieldSchema]
 ) -> int:
     sizes = {
@@ -1838,7 +1923,7 @@ def _legacy_schema_row_count(
     if not sizes:
         return 0
     if len(sizes) != 1:
-        raise ValueError(f"legacy rollout fields have inconsistent batch sizes: {sorted(sizes)}")
+        raise ValueError(f"flat dict fields have inconsistent batch sizes: {sorted(sizes)}")
     return sizes.pop()
 
 
@@ -1846,16 +1931,16 @@ def _field_len(name: str, value: Any) -> int:
     try:
         return len(value)
     except TypeError as error:
-        raise ValueError(f"legacy row-aligned field {name!r} must be sized") from error
+        raise ValueError(f"flat dict row-aligned field {name!r} must be sized") from error
 
 
-def _coerce_legacy_non_tensor_field(
+def _coerce_flat_dict_non_tensor_field(
     name: str, value: Any, row_count: int, schema: Optional[FieldSchema] = None
 ) -> Any:
     if isinstance(value, np.ndarray):
         if len(value) != row_count:
             raise ValueError(
-                f"legacy non_tensor_batch field {name!r} has batch size {len(value)}, expected {row_count}"
+                f"flat dict non_tensor_batch field {name!r} has batch size {len(value)}, expected {row_count}"
             )
         if (schema is not None and schema.codec == "ndarray" and _schema_ndarray_dtype(schema) is not None
                 and (value.dtype != object or all(item is not None for item in value))):
@@ -1864,19 +1949,19 @@ def _coerce_legacy_non_tensor_field(
     if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
         if len(value) != row_count:
             raise ValueError(
-                f"legacy non_tensor_batch field {name!r} has batch size {len(value)}, expected {row_count}"
+                f"flat dict non_tensor_batch field {name!r} has batch size {len(value)}, expected {row_count}"
             )
         array = np.empty(row_count, dtype=object)
         array[:] = list(value)
         return array
     raise TypeError(
-        f"legacy non_tensor_batch field {name!r} must be an ndarray or non-string sequence"
+        f"flat dict non_tensor_batch field {name!r} must be an ndarray or non-string sequence"
     )
 
 
 
 
-def _legacy_auto_row_count(
+def _flat_dict_auto_row_count(
     data: Mapping[str, Any], exclude: set[str] | frozenset[str] = frozenset()
 ) -> int:
     sizes = {
@@ -1892,13 +1977,13 @@ def _legacy_auto_row_count(
         return 0
     if len(sizes) != 1:
         raise ValueError(
-            f"legacy rollout fields have ambiguous batch sizes: {sorted(sizes)}; "
+            f"flat dict fields have ambiguous batch sizes: {sorted(sizes)}; "
             "pass FieldSchema metadata['section'] for list-valued metadata fields"
         )
     return sizes.pop()
 
 
-def _envelope_to_legacy_dict(data: Mapping[str, Any]) -> dict[str, Any]:
+def _envelope_to_flat_dict(data: Mapping[str, Any]) -> dict[str, Any]:
     result = dict(_mapping_to_dict(data.get("meta_info")))
     result.update(_mapping_to_dict(data.get("batch")))
     for key, value in _mapping_to_dict(data.get("non_tensor_batch")).items():
@@ -3252,6 +3337,7 @@ class _StructuredObjectLayer:
         chunk_bytes: Optional[int],
         policy: Optional[BundleTransferPolicy],
         max_inflight_put: Optional[int],
+        config: Any = None,
     ) -> RemoteBundleRef:
         metadata, buffers = _encode_structured_fields(payload.metadata, payload.buffers)
         transfer_policy = self._bundle_store._policy(
@@ -3264,6 +3350,7 @@ class _StructuredObjectLayer:
             chunk_bytes=chunk_bytes,
             policy=transfer_policy,
             max_inflight_put=None,
+            config=config,
         )
 
     def read_spec(
@@ -3633,6 +3720,7 @@ class _BundleManifestStore:
         chunk_bytes: Optional[int],
         policy: Optional[BundleTransferPolicy],
         max_inflight_put: Optional[int],
+        config: Any = None,
     ) -> RemoteBundleRef:
         _validate_key_segment(partition, "partition")
         meta_view = _bytes_view(meta, "meta")
@@ -3653,6 +3741,7 @@ class _BundleManifestStore:
                 target_chunk_bytes,
                 _copy_transfer_policy(transfer_policy),
                 _deferred=deferred,
+                config=config,
             )
             written_keys.extend(meta_keys)
             for name, value in buffers.items():
@@ -3663,6 +3752,7 @@ class _BundleManifestStore:
                         payload_key,
                         value,
                         transfer_policy,
+                        config,
                     )
                 elif isinstance(value, _DirectCopyPayload):
                     payload_spec, payload_keys = self._put_direct_copy_payload(
@@ -3670,6 +3760,7 @@ class _BundleManifestStore:
                         value,
                         target_chunk_bytes,
                         transfer_policy,
+                        config,
                     )
                 elif isinstance(value, _MultiBufferPayload):
                     payload_spec, payload_keys = self._put_multi_buffer_payload(
@@ -3678,6 +3769,7 @@ class _BundleManifestStore:
                         target_chunk_bytes,
                         transfer_policy,
                         _deferred=deferred,
+                        config=config,
                     )
                 else:
                     payload_spec, payload_keys = self._put_payload(
@@ -3686,6 +3778,7 @@ class _BundleManifestStore:
                         target_chunk_bytes,
                         transfer_policy,
                         _deferred=deferred,
+                        config=config,
                     )
                 buffer_specs[name] = payload_spec
                 written_keys.extend(payload_keys)
@@ -3698,7 +3791,11 @@ class _BundleManifestStore:
             }
             manifest_blob = _encode_manifest(manifest)
             _check_status(
-                self._store.put(manifest_key, manifest_blob), "put", manifest_key
+                _put_with_optional_config(
+                    self._store, manifest_key, manifest_blob, config
+                ),
+                "put",
+                manifest_key,
             )
             written_keys.append(manifest_key)
         except Exception:
@@ -3714,6 +3811,7 @@ class _BundleManifestStore:
         partition: str,
         chunk_bytes: Optional[int],
         policy: Optional[BundleTransferPolicy],
+        config: Any = None,
         cleanup_keys: Optional[Sequence[str]] = None,
     ) -> RemoteBundleRef:
         _validate_key_segment(partition, "partition")
@@ -3732,6 +3830,7 @@ class _BundleManifestStore:
                 meta_view,
                 target_chunk_bytes,
                 _copy_transfer_policy(transfer_policy),
+                config=config,
             )
             written_keys.extend(meta_keys)
             manifest = {
@@ -3754,7 +3853,11 @@ class _BundleManifestStore:
             self._validate_manifest(manifest)
             manifest_blob = _encode_manifest(manifest)
             _check_status(
-                self._store.put(manifest_key, manifest_blob), "put", manifest_key
+                _put_with_optional_config(
+                    self._store, manifest_key, manifest_blob, config
+                ),
+                "put",
+                manifest_key,
             )
             written_keys.append(manifest_key)
         except Exception:
@@ -3900,9 +4003,10 @@ class _BundleManifestStore:
         key: str,
         value: _TensorPayload | _TensorObjectBufferPayload,
         transfer_policy: BundleTransferPolicy,
+        config: Any = None,
     ) -> tuple[dict[str, Any], list[str]]:
         if isinstance(value, _TensorObjectBufferPayload):
-            total_bytes = self._transport.put_tensor_object_buffer(key, value)
+            total_bytes = self._transport.put_tensor_object_buffer(key, value, config)
             return {
                 "key": key,
                 "bytes": total_bytes,
@@ -3913,11 +4017,13 @@ class _BundleManifestStore:
                 raise ValueError(
                     "zero-copy structured tensor fields require a BufferPool tensor-object buffer"
                 )
-            tensor_spec = self._transport.put_tensor_payload_direct(key, value)
+            tensor_spec = self._transport.put_tensor_payload_direct(key, value, config)
             if tensor_spec is not None:
                 return tensor_spec, [key]
             try:
-                tensor_spec = self._transport.put_tensor_payload_from_pool(key, value)
+                tensor_spec = self._transport.put_tensor_payload_from_pool(
+                    key, value, config
+                )
                 return tensor_spec, [key]
             except RuntimeError:
                 pass
@@ -3928,6 +4034,7 @@ class _BundleManifestStore:
                 memoryview(payload),
                 len(payload) or 1,
                 transfer_policy,
+                config=config,
             )
             payload_spec["format"] = "torch_save"
             return payload_spec, payload_keys
@@ -3937,6 +4044,7 @@ class _BundleManifestStore:
             memoryview(payload),
             len(payload) or 1,
             transfer_policy,
+            config=config,
         )
         payload_spec["metadata_bytes"] = metadata_bytes
         return payload_spec, payload_keys
@@ -3948,6 +4056,7 @@ class _BundleManifestStore:
         chunk_bytes: int,
         transfer_policy: BundleTransferPolicy,
         _deferred: list | None = None,
+        config: Any = None,
     ) -> tuple[dict[str, Any], list[str]]:
         if len(value) == 0:
             return {"key": key, "bytes": 0, "chunks": []}, []
@@ -3964,6 +4073,7 @@ class _BundleManifestStore:
                 chunk_keys,
                 [[c] for c in chunks],
                 transfer_policy,
+                config,
             )
         payload_spec = {
             "key": key,
@@ -3982,13 +4092,19 @@ class _BundleManifestStore:
         chunk_bytes: int,
         transfer_policy: BundleTransferPolicy,
         _deferred: list | None = None,
+        config: Any = None,
     ) -> tuple[dict[str, Any], list[str]]:
         total_bytes = value.nbytes
         if total_bytes == 0:
             return {"key": key, "bytes": 0, "chunks": []}, []
         if len(value.buffers) == 1:
             return self._put_payload(
-                key, value.buffers[0], chunk_bytes, transfer_policy, _deferred
+                key,
+                value.buffers[0],
+                chunk_bytes,
+                transfer_policy,
+                _deferred,
+                config=config,
             )
         chunk_groups = _split_multi_buffer_payload(value.buffers, chunk_bytes)
         chunk_keys = [
@@ -4003,6 +4119,7 @@ class _BundleManifestStore:
                 chunk_keys,
                 chunk_groups,
                 transfer_policy,
+                config,
             )
         payload_spec = {
             "key": key,
@@ -4020,6 +4137,7 @@ class _BundleManifestStore:
         value: _DirectCopyPayload,
         chunk_bytes: int,
         transfer_policy: BundleTransferPolicy,
+        config: Any = None,
     ) -> tuple[dict[str, Any], list[str]]:
         total_bytes = value.total_bytes
         if total_bytes == 0:
@@ -4028,6 +4146,7 @@ class _BundleManifestStore:
             buf = memoryview(value.arrays[0].data).cast("B")
             return self._put_payload(
                 key, buf, chunk_bytes, transfer_policy,
+                config=config,
             )
         arrays = value.arrays
         transport = self._transport
@@ -4037,7 +4156,9 @@ class _BundleManifestStore:
             buf = memoryview(np.concatenate(
                 [a.ravel().view(np.uint8) for a in arrays]
             ).data).cast("B")
-            return self._put_payload(key, buf, chunk_bytes, transfer_policy)
+            return self._put_payload(
+                key, buf, chunk_bytes, transfer_policy, config=config
+            )
         # Group arrays into chunk-sized batches
         n = len(arrays)
         chunk_batches: list[tuple[int, int, int]] = []  # (start, count, bytes)
@@ -4058,7 +4179,9 @@ class _BundleManifestStore:
             buf = memoryview(np.concatenate(
                 [a.ravel().view(np.uint8) for a in arrays]
             ).data).cast("B")
-            return self._put_payload(key, buf, chunk_bytes, transfer_policy)
+            return self._put_payload(
+                key, buf, chunk_bytes, transfer_policy, config=config
+            )
         if batch_bytes > 0:
             chunk_batches.append((batch_start, n - batch_start, batch_bytes))
         num_chunks = len(chunk_batches)
@@ -4071,7 +4194,9 @@ class _BundleManifestStore:
                 lease = pool.acquire(size)
                 try:
                     _concat_arrays_into(arrays, lease.ptr, start, count, nthreads)
-                    results = batch_put_from([ck], [lease.ptr], [size])
+                    results = _batch_put_from_with_optional_config(
+                        batch_put_from, [ck], [lease.ptr], [size], config
+                    )
                     transport._check_batch_put_results(results, [ck], "batch_put_from")
                 except Exception:
                     _cleanup_keys(self._store, [ck], strict=False)
@@ -4282,10 +4407,11 @@ class _MooncakePayloadTransport:
         chunk_keys: Sequence[str],
         chunk_groups: Sequence[Sequence[memoryview]],
         transfer_policy: BundleTransferPolicy,
+        config: Any = None,
     ) -> list[str]:
         def fallback_to_direct_put() -> list[str]:
             chunks = [memoryview(b"".join(group)) for group in chunk_groups]
-            return self._put_chunks_direct(chunk_keys, chunks)
+            return self._put_chunks_direct(chunk_keys, chunks, config)
 
         if transfer_policy.copy_mode == "zero_copy":
             raise RuntimeError(
@@ -4294,18 +4420,21 @@ class _MooncakePayloadTransport:
         if transfer_policy.copy_mode == "copy" or self._ensure_buffer_pool() is None:
             return fallback_to_direct_put()
         if all(len(group) == 1 for group in chunk_groups):
-            self.batch_put_buffer_groups_from(chunk_keys, [[group[0]] for group in chunk_groups])
+            self.batch_put_buffer_groups_from(
+                chunk_keys, [[group[0]] for group in chunk_groups], config
+            )
             return list(chunk_keys)
         if not callable(self._batch_put_from):
             return fallback_to_direct_put()
         put_mode = self._resolve_buffer_group_put_mode(chunk_groups, transfer_policy)
         if put_mode == "batch":
-            self.batch_put_buffer_groups_from(chunk_keys, chunk_groups)
+            self.batch_put_buffer_groups_from(chunk_keys, chunk_groups, config)
             return list(chunk_keys)
         return self._put_buffer_groups_parallel(
             list(chunk_keys),
             [list(group) for group in chunk_groups],
             transfer_policy.max_inflight_put,
+            config,
         )
 
     def read_payload(self, payload_spec: Mapping[str, Any]) -> bytes:
@@ -4517,13 +4646,15 @@ class _MooncakePayloadTransport:
         self,
         key: str,
         value: _TensorObjectBufferPayload,
+        config: Any = None,
     ) -> int:
-        put_tensor_from = self._put_tensor_from
-        if not callable(put_tensor_from):
-            raise RuntimeError("put_tensor_from is unavailable")
         _validate_tensor_object_buffer_owner(value)
         _check_status(
-            put_tensor_from(key, value.ptr, value.size), "put_tensor_from", key
+            _put_from_with_optional_config(
+                self._store, key, value.ptr, value.size, config
+            ),
+            "put_from",
+            key,
         )
         _ = value.owner
         return value.size
@@ -4532,7 +4663,10 @@ class _MooncakePayloadTransport:
         self,
         key: str,
         value: _TensorPayload,
+        config: Any = None,
     ) -> dict[str, Any] | None:
+        if config is not None:
+            return None
         put_tensor = getattr(self._store, "put_tensor", None)
         if not callable(put_tensor):
             return None
@@ -4540,7 +4674,11 @@ class _MooncakePayloadTransport:
         nbytes = int(getattr(tensor, "nbytes", 0))
         metadata_bytes = _tensor_metadata_size()
         total_bytes = metadata_bytes + nbytes
-        _check_status(put_tensor(key, tensor), "put_tensor", key)
+        _check_status(
+            put_tensor(key, tensor),
+            "put_tensor",
+            key,
+        )
         return {
             "key": key,
             "kind": "tensor",
@@ -4555,13 +4693,11 @@ class _MooncakePayloadTransport:
         self,
         key: str,
         value: _TensorPayload,
+        config: Any = None,
     ) -> dict[str, Any]:
         pool = self._ensure_buffer_pool()
         if pool is None:
             raise RuntimeError("structured tensor staging requires a BufferPool")
-        put_tensor_from = self._put_tensor_from
-        if not callable(put_tensor_from):
-            raise RuntimeError("put_tensor_from is unavailable")
         tensor = value.tensor
         metadata, data_ptr, tensor_nbytes, owner = _tensor_payload_parts(value)
         metadata_bytes = len(metadata)
@@ -4576,7 +4712,11 @@ class _MooncakePayloadTransport:
             view.release()
             view = None
             _check_status(
-                put_tensor_from(key, lease.ptr, total_bytes), "put_tensor_from", key
+                _put_from_with_optional_config(
+                    self._store, key, lease.ptr, total_bytes, config
+                ),
+                "put_from",
+                key,
             )
             _ = owner
             return {
@@ -4597,6 +4737,7 @@ class _MooncakePayloadTransport:
         self,
         chunk_keys: Sequence[str],
         chunk_groups: Sequence[Sequence[memoryview]],
+        config: Any = None,
     ) -> None:
         batch_put_from = self._batch_put_from
         if not callable(batch_put_from):
@@ -4612,7 +4753,9 @@ class _MooncakePayloadTransport:
             lease = pool.acquire(size)
             try:
                 _copy_memoryviews_to_lease(group, lease)
-                results = batch_put_from([chunk_key], [lease.ptr], [size])
+                results = _batch_put_from_with_optional_config(
+                    batch_put_from, [chunk_key], [lease.ptr], [size], config
+                )
                 self._check_batch_put_results(results, [chunk_key], "batch_put_from")
             except Exception:
                 _cleanup_keys(self._store, [chunk_key], strict=False)
@@ -4635,11 +4778,18 @@ class _MooncakePayloadTransport:
         self,
         chunk_keys: Sequence[str],
         chunks: Sequence[memoryview],
+        config: Any = None,
     ) -> list[str]:
         written_keys: list[str] = []
         try:
             for chunk_key, chunk in zip(chunk_keys, chunks):
-                _check_status(self._store.put(chunk_key, chunk), "put", chunk_key)
+                _check_status(
+                    _put_with_optional_config(
+                        self._store, chunk_key, chunk, config
+                    ),
+                    "put",
+                    chunk_key,
+                )
                 written_keys.append(chunk_key)
         except Exception:
             _cleanup_keys(self._store, written_keys, strict=False)
@@ -4651,6 +4801,7 @@ class _MooncakePayloadTransport:
         chunk_keys: list[str],
         chunk_groups: list[Sequence[memoryview]],
         max_inflight_put: int,
+        config: Any = None,
     ) -> list[str]:
         groups = self._group_buffer_group_ranges(
             chunk_keys, chunk_groups, max_inflight_put
@@ -4662,7 +4813,10 @@ class _MooncakePayloadTransport:
             ) as executor:
                 futures = [
                     executor.submit(
-                        self.batch_put_buffer_groups_from, group_keys, group_chunks
+                        self.batch_put_buffer_groups_from,
+                        group_keys,
+                        group_chunks,
+                        config,
                     )
                     for group_keys, group_chunks in groups
                 ]
@@ -5481,6 +5635,46 @@ def _decode_json_dict(payload: bytes, label: str) -> dict[str, Any]:
     if not isinstance(value, dict):
         raise ValueError(f"{label} must decode to a dict")
     return value
+
+
+def _call_write_with_optional_config(
+    fn: Any, *args: Any, config: Any = None
+) -> Any:
+    if config is None:
+        return fn(*args)
+    return fn(*args, config=config)
+
+
+def _put_with_optional_config(
+    store: BundleStore, key: str, value: Any, config: Any = None
+) -> int:
+    return _call_write_with_optional_config(store.put, key, value, config=config)
+
+
+def _put_from_with_optional_config(
+    store: BundleStore, key: str, ptr: int, size: int, config: Any = None
+) -> int:
+    put_tensor_from = getattr(store, "put_tensor_from", None)
+    if config is None and callable(put_tensor_from):
+        return put_tensor_from(key, ptr, size)
+    put_from = getattr(store, "put_from", None)
+    if callable(put_from):
+        return _call_write_with_optional_config(
+            put_from, key, ptr, size, config=config
+        )
+    raise RuntimeError("put_from is unavailable")
+
+
+def _batch_put_from_with_optional_config(
+    batch_put_from: Any,
+    keys: Sequence[str],
+    ptrs: Sequence[int],
+    sizes: Sequence[int],
+    config: Any = None,
+) -> Sequence[int]:
+    return _call_write_with_optional_config(
+        batch_put_from, keys, ptrs, sizes, config=config
+    )
 
 
 def _check_status(status: Any, operation: str, key: str) -> None:

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -19,7 +19,7 @@ except Exception:  # pragma: no cover - depends on built extension
 import msgpack as _msgpack
 
 DEFAULT_BUNDLE_CHUNK_BYTES = 64 * 1024**2
-AUTO_PARALLEL_MIN_BYTES = DEFAULT_BUNDLE_CHUNK_BYTES
+AUTO_PARALLEL_MIN_BYTES = 4 * 1024**3
 AUTO_PARALLEL_MIN_CHUNKS = 8
 MISSING_OBJECT_ERROR = (
     -704
@@ -413,7 +413,11 @@ def import_dataproto_ref(handle: Mapping[str, Any]) -> MooncakeDataProtoRef:
     )
 
 
-def _resolve_dataproto_ref(ref: DataProtoRefLike) -> MooncakeDataProtoRef:
+export_ref = export_dataproto_ref
+import_ref = import_dataproto_ref
+
+
+def _resolve_ref(ref: DataProtoRefLike) -> MooncakeDataProtoRef:
     if isinstance(ref, MooncakeDataProtoRef):
         return ref
     if is_dataproto_ref_handle(ref):
@@ -583,8 +587,8 @@ class MooncakeBundleTransfer:
         policy: Optional[BundleTransferPolicy] = None,
         field_schemas: Optional[dict[str, FieldSchema]] = None,
     ) -> MooncakeDataProtoRef:
-        """Store DataProto fields, optionally using schema hints for non-tensor fields."""
-        return self._put_dataproto_stage(
+        """Store a DataProto-like object as a stage-level structured object."""
+        return self._put_stage(
             None,
             data,
             namespace=namespace,
@@ -607,9 +611,9 @@ class MooncakeBundleTransfer:
         policy: Optional[BundleTransferPolicy] = None,
         field_schemas: Optional[dict[str, FieldSchema]] = None,
     ) -> MooncakeDataProtoRef:
-        """Append DataProto fields, optionally using schema hints for new fields."""
-        ref = _resolve_dataproto_ref(ref)
-        return self._put_dataproto_stage(
+        """Append fields from a later DataProto stage without rewriting previous stages."""
+        ref = _resolve_ref(ref)
+        return self._put_stage(
             ref,
             data,
             namespace=ref.namespace,
@@ -623,7 +627,7 @@ class MooncakeBundleTransfer:
 
     def dataproto_manifest_view(self, ref: DataProtoRefLike) -> dict[str, Any]:
         """Return a DataProto field view derived from stage structured-object manifests."""
-        return _dataproto_manifest_view(self, _resolve_dataproto_ref(ref))
+        return _dataproto_manifest_view(self, _resolve_ref(ref))
 
     def get_dataproto(
         self,
@@ -638,7 +642,30 @@ class MooncakeBundleTransfer:
         rows: slice | StructuredMemberSlice | Sequence[int] | None = None,
     ) -> Any:
         """Materialize selected DataProto fields from structured object refs."""
-        ref = _resolve_dataproto_ref(ref)
+        return self._materialize_ref(
+            _resolve_ref(ref),
+            fields=fields,
+            batch_fields=batch_fields,
+            non_tensor_fields=non_tensor_fields,
+            meta_info_keys=meta_info_keys,
+            data_cls=data_cls,
+            destinations=destinations,
+            rows=rows,
+        )
+
+    def _materialize_ref(
+        self,
+        ref: MooncakeDataProtoRef,
+        *,
+        fields: Optional[Sequence[str]] = None,
+        batch_fields: Optional[Sequence[str]] = None,
+        non_tensor_fields: Optional[Sequence[str]] = None,
+        meta_info_keys: Optional[Sequence[str]] = None,
+        data_cls: Optional[Any] = None,
+        destinations: Optional[Mapping[str, Any]] = None,
+        rows: slice | StructuredMemberSlice | Sequence[int] | None = None,
+    ) -> Any:
+        """Core materialization logic shared by get_dataproto and get_legacy_dict."""
         row_selection = _coerce_dataproto_row_selection(rows, ref.batch_size)
         row_slice = None if row_selection is None else row_selection.member_slice
         row_indices = None if row_selection is None else row_selection.indices
@@ -1365,44 +1392,19 @@ class MooncakeBundleTransfer:
 
         raise ValueError(f"unknown structured non-tensor codec: {codec}")
 
-    def _read_ragged_tensor_dict_payload(
-        self,
-        payload_members: Mapping[str, str],
-        metadata: dict[str, Any],
-        *,
-        read_null_mask: Callable[[], Any],
-        read_key_payload: Callable[
-            [Mapping[str, Any]], tuple[dict[str, Any], Mapping[str, Any]]
-        ],
-    ) -> tuple[dict[str, Any], Mapping[str, Any]]:
-        key_codecs = dict(metadata.get("key_codecs") or {})
-        metadata["key_codecs"] = key_codecs
-        dict_payload: dict[str, Any] = {"null_mask": read_null_mask()}
-        for key in _normalize_ragged_tensor_dict_keys(metadata.get("keys", [])):
-            key_members = _ragged_tensor_dict_payload_items(
-                payload_members, key, kind="manifest"
-            )
-            key_payload, key_metadata = read_key_payload(
-                {
-                    "codec": "ragged_tensor",
-                    "metadata": key_codecs.get(key) or {},
-                    "payload_members": key_members,
-                }
-            )
-            key_codecs[key] = key_metadata
-            for name, value in key_payload.items():
-                dict_payload[f"{key}.{name}"] = value
-        return dict_payload, metadata
-
-    def cleanup_dataproto(self, ref: DataProtoRefLike) -> None:
-        """Remove all structured object stages referenced by a DataProto handle."""
-        ref = _resolve_dataproto_ref(ref)
+    def _cleanup_ref(self, ref: DataProtoRefLike) -> None:
+        """Remove all structured object stages referenced by a handle."""
+        ref = _resolve_ref(ref)
         seen: set[str] = set()
         for stage_ref in ref.stage_refs.values():
             if stage_ref.manifest_key in seen:
                 continue
             seen.add(stage_ref.manifest_key)
             self.remove_bundle(stage_ref)
+
+    def cleanup_dataproto(self, ref: DataProtoRefLike) -> None:
+        """Remove all structured object stages referenced by a DataProto handle."""
+        self._cleanup_ref(ref)
 
     def put_legacy_dict(
         self,
@@ -1415,24 +1417,28 @@ class MooncakeBundleTransfer:
         policy: Optional[BundleTransferPolicy] = None,
         field_schemas: Optional[Mapping[str, "FieldSchema"]] = None,
     ) -> MooncakeDataProtoRef:
-        """Store a legacy rollout dict through the DataProto structured-object path."""
-        return self.put_dataproto(
+        """Store a legacy rollout dict as a structured object."""
+        return self._put_stage(
+            None,
             _legacy_dict_to_dataproto_envelope(data),
             namespace=namespace,
             partition=partition,
             stage=stage,
             chunk_bytes=chunk_bytes,
             policy=policy,
+            overwrite=False,
             field_schemas=field_schemas,
         )
 
     def get_legacy_dict(self, ref: DataProtoRefLike) -> dict[str, Any]:
         """Materialize a legacy rollout dict stored by put_legacy_dict()."""
-        return _dataproto_envelope_to_legacy_dict(self.get_dataproto(ref))
+        return _dataproto_envelope_to_legacy_dict(
+            self._materialize_ref(_resolve_ref(ref))
+        )
 
     def remove_legacy_dict(self, ref: DataProtoRefLike) -> None:
         """Remove a legacy rollout dict stored by put_legacy_dict()."""
-        self.cleanup_dataproto(ref)
+        self._cleanup_ref(ref)
 
     @staticmethod
     def release_result(result: Any) -> None:
@@ -1511,7 +1517,7 @@ class MooncakeBundleTransfer:
         self._bundle_store.remove_keys(obsolete_keys, strict=False)
         return merged_ref
 
-    def _put_dataproto_stage(
+    def _put_stage(
         self,
         ref: MooncakeDataProtoRef | None,
         data: Any,

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -1449,18 +1449,21 @@ class MooncakeBundleTransfer:
         After get_dataproto / get_legacy_dict, ndarray payloads may be backed by
         the BufferPool.  Call this to release those leases deterministically
         instead of waiting for GC ``__del__``.
+
+        Works for both flat dicts (legacy_dict) and nested envelope dicts
+        (dataproto: {batch: {...}, non_tensor_batch: {...}, meta_info: {...}}).
         """
         if not isinstance(result, Mapping):
             return
         for value in result.values():
+            if isinstance(value, Mapping):
+                MooncakeBundleTransfer.release_result(value)
+                continue
             owner = getattr(value, "_mooncake_pool_owner", None)
             if owner is not None:
                 owner.release()
                 continue
-            if (
-                isinstance(value, np.ndarray)
-                and value.dtype == object
-            ):
+            if isinstance(value, np.ndarray) and value.dtype == object:
                 for item in value.flat:
                     item_owner = getattr(item, "_mooncake_pool_owner", None)
                     if item_owner is not None:

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -33,7 +33,9 @@ _TYPED_RAGGED_DEFAULT_DTYPE = "float64"
 # Fallback field spec when a member has no stored encoding metadata (e.g. older
 # format or unknown field).  Treated as opaque bytes by the read path.
 _BYTES_FIELD_SPEC: dict[str, str] = {"encoding": "bytes"}
-_INFER_STRUCTURE_MAX_DEPTH = 32
+_INFER_MAX_DEPTH = 32
+_INFER_MAX_STRUCT_KEYS = 64
+_INFER_MAX_LIST_LEN = 8
 
 
 class BundleStore(Protocol):
@@ -776,24 +778,20 @@ class MooncakeBundleTransfer:
                 stage_ref = ref.stage_refs[location.stage]
                 encoded = ref.encoded_non_tensor[name]
                 if row_indices is not None:
-                    payload, metadata = (
-                        self._read_structured_non_tensor_payload_indices(
-                            stage_ref,
-                            encoded,
-                            row_indices,
-                        )
+                    payload, metadata = self._read_structured_non_tensor_payload_indices(
+                        stage_ref,
+                        encoded,
+                        row_indices,
                     )
                     values = _decode_structured_non_tensor_encoded(
                         encoded, payload, output_rows, metadata
                     )
                 else:
-                    payload, metadata = (
-                        self._read_structured_non_tensor_payload_slice(
-                            stage_ref,
-                            encoded,
-                            row_slice,
-                            ref.batch_size,
-                        )
+                    payload, metadata = self._read_structured_non_tensor_payload_slice(
+                        stage_ref,
+                        encoded,
+                        row_slice,
+                        ref.batch_size,
                     )
                     values = _decode_structured_non_tensor_encoded(
                         encoded, payload, output_rows, metadata
@@ -855,13 +853,9 @@ class MooncakeBundleTransfer:
                 raise ValueError(
                     f"raw destination has {destination.size} bytes, expected at least {nbytes}"
                 )
-            target = (
-                np.ctypeslib.as_array(
-                    (ctypes.c_uint8 * nbytes).from_address(destination.ptr)
-                )
-                .view(dtype_obj)
-                .reshape(output_shape)
-            )
+            target = np.ctypeslib.as_array(
+                (ctypes.c_uint8 * nbytes).from_address(destination.ptr)
+            ).view(dtype_obj).reshape(output_shape)
             if not indices:
                 return target
             row_width = dtype_obj.itemsize * int(np.prod(full_shape[1:], dtype=np.int64))
@@ -938,10 +932,7 @@ class MooncakeBundleTransfer:
                     )
                     for out, row in enumerate(indices)
                 ]
-                if (
-                    isinstance(destination, _RawDestinationBuffer)
-                    and destination.pre_registered
-                ):
+                if isinstance(destination, _RawDestinationBuffer) and destination.pre_registered:
                     self._bundle_store.read_payload_ranges_into_raw_destination(
                         payload_spec, destination.ptr, ranges
                     )
@@ -1035,22 +1026,20 @@ class MooncakeBundleTransfer:
                     for name, global_name in leaf_payload_members.items()
                     if name != "missing"
                 }
-                leaf_payload, _leaf_metadata = (
-                    self._read_structured_non_tensor_payload_indices(
-                        stage_ref,
-                        {
-                            "codec": leaf["codec"],
-                            "metadata": leaf.get("metadata") or {},
-                            "payload_members": flat_payload_members,
-                        },
-                        indices,
-                    )
+                leaf_payload, _leaf_metadata = self._read_structured_non_tensor_payload_indices(
+                    stage_ref,
+                    {
+                        "codec": leaf["codec"],
+                        "metadata": leaf.get("metadata") or {},
+                        "payload_members": flat_payload_members,
+                    },
+                    indices,
                 )
                 leaf["metadata"] = _leaf_metadata
                 for name, value in leaf_payload.items():
                     recursive_payload[leaf_payload_members[name]] = value
-                recursive_payload[leaf_payload_members["missing"]] = (
-                    read_member_indices(leaf_payload_members["missing"], indices)
+                recursive_payload[leaf_payload_members["missing"]] = read_member_indices(
+                    leaf_payload_members["missing"], indices
                 )
             return recursive_payload, metadata
 
@@ -1142,13 +1131,7 @@ class MooncakeBundleTransfer:
                 "nulls": read_member_indices("nulls", indices),
             }, metadata
 
-        if codec in {
-            "media_bytes",
-            "bytes_ragged",
-            "utf8_ragged",
-            "msgpack_ragged",
-            "json_ragged",
-        }:
+        if codec in {"media_bytes", "bytes_ragged", "utf8_ragged", "msgpack_ragged", "json_ragged"}:
             offsets = read_member_indices(
                 "offsets", [index for row in indices for index in (row, row + 1)]
             )
@@ -1186,9 +1169,7 @@ class MooncakeBundleTransfer:
             gathered_row_offsets = np.empty(len(indices) + 1, dtype=row_offsets.dtype)
             gathered_row_offsets[0] = 0
             for index, count in enumerate(item_counts):
-                gathered_row_offsets[index + 1] = (
-                    int(gathered_row_offsets[index]) + count
-                )
+                gathered_row_offsets[index + 1] = int(gathered_row_offsets[index]) + count
             boundary_indices = [
                 boundary
                 for begin, end in zip(item_begins, item_ends)
@@ -1278,17 +1259,15 @@ class MooncakeBundleTransfer:
                     for name, global_name in leaf_payload_members.items()
                     if name != "missing"
                 }
-                leaf_payload, _leaf_metadata = (
-                    self._read_structured_non_tensor_payload_slice(
-                        stage_ref,
-                        {
-                            "codec": leaf["codec"],
-                            "metadata": leaf.get("metadata") or {},
-                            "payload_members": flat_payload_members,
-                        },
-                        row_slice,
-                        total_rows,
-                    )
+                leaf_payload, _leaf_metadata = self._read_structured_non_tensor_payload_slice(
+                    stage_ref,
+                    {
+                        "codec": leaf["codec"],
+                        "metadata": leaf.get("metadata") or {},
+                        "payload_members": flat_payload_members,
+                    },
+                    row_slice,
+                    total_rows,
                 )
                 leaf["metadata"] = _leaf_metadata
                 for name, value in leaf_payload.items():
@@ -1340,13 +1319,7 @@ class MooncakeBundleTransfer:
                 "nulls": read_member("nulls", start, end),
             }, metadata
 
-        if codec in {
-            "media_bytes",
-            "bytes_ragged",
-            "utf8_ragged",
-            "msgpack_ragged",
-            "json_ragged",
-        }:
+        if codec in {"media_bytes", "bytes_ragged", "utf8_ragged", "msgpack_ragged", "json_ragged"}:
             offsets = read_member("offsets", start, end + 1)
             base = int(offsets[0])
             limit = int(offsets[-1])
@@ -1924,7 +1897,9 @@ def _resolve_dataproto_field_selection(
         ]
     else:
         batch_names = [] if batch_fields is None else list(batch_fields)
-        non_tensor_names = [] if non_tensor_fields is None else list(non_tensor_fields)
+        non_tensor_names = (
+            [] if non_tensor_fields is None else list(non_tensor_fields)
+        )
     _validate_dataproto_fields_exist(ref, [*batch_names, *non_tensor_names])
     return batch_names, non_tensor_names
 
@@ -2163,7 +2138,7 @@ def _encode_recursive_if_structured(
 ) -> "_EncodedStructuredLeaf | None":
     leaves: list[_InferredLeaf] = []
     nodes: list[_InferredNode] = []
-    _infer_structure(path, values, leaves, nodes)
+    infer_structure(path, values, leaves, nodes)
     if not nodes or not any(_should_encode_recursive_leaf(leaf) for leaf in leaves):
         return None
     payload: dict[str, Any] = {}
@@ -2175,20 +2150,20 @@ def _encode_recursive_if_structured(
             "node_type": node.node_type,
             "children": list(node.children),
         }
-        missing_name = f"node.{node_id}.missing"
-        payload[missing_name] = np.asarray(
+        missing_payload_name = f"node.{node_id}.missing"
+        payload[missing_payload_name] = np.asarray(
             [_lookup_structured_path(value, path, node.path) is MISSING for value in values],
             dtype=np.bool_,
         )
-        spec["missing_payload"] = missing_name
+        spec["missing_payload"] = missing_payload_name
         if node.row_mask is not None:
-            row_mask_name = f"node.{node_id}.row_mask"
-            payload[row_mask_name] = np.asarray(node.row_mask, dtype=np.bool_)
-            spec["row_mask_payload"] = row_mask_name
+            payload_name = f"node.{node_id}.row_mask"
+            payload[payload_name] = np.asarray(node.row_mask, dtype=np.bool_)
+            spec["row_mask_payload"] = payload_name
         if node.lengths is not None:
-            lengths_name = f"node.{node_id}.lengths"
-            payload[lengths_name] = np.asarray(node.lengths, dtype=np.int64)
-            spec["lengths_payload"] = lengths_name
+            payload_name = f"node.{node_id}.lengths"
+            payload[payload_name] = np.asarray(node.lengths, dtype=np.int64)
+            spec["lengths_payload"] = payload_name
         node_specs.append(spec)
 
     leaf_specs: list[dict[str, Any]] = []
@@ -2212,12 +2187,12 @@ def _encode_recursive_if_structured(
         )
         leaf_payload_members: dict[str, str] = {}
         for payload_name, payload_value in encoded.payload.items():
-            recursive_name = f"leaf.{leaf_id}.{payload_name}"
-            payload[recursive_name] = payload_value
-            leaf_payload_members[payload_name] = recursive_name
-        missing_name = f"leaf.{leaf_id}.missing"
-        payload[missing_name] = missing
-        leaf_payload_members["missing"] = missing_name
+            recursive_payload_name = f"leaf.{leaf_id}.{payload_name}"
+            payload[recursive_payload_name] = payload_value
+            leaf_payload_members[payload_name] = recursive_payload_name
+        missing_payload_name = f"leaf.{leaf_id}.missing"
+        payload[missing_payload_name] = missing
+        leaf_payload_members["missing"] = missing_payload_name
         leaf_specs.append(
             {
                 "id": leaf_id,
@@ -2245,21 +2220,16 @@ def _encode_recursive_if_structured(
 def _should_encode_recursive_leaf(leaf: "_InferredLeaf") -> bool:
     if leaf.decision.codec == "typed_ragged":
         return leaf.decision.metadata.get("recursive_source") == "ndarray"
-    return leaf.decision.codec in {
-        "ragged_tensor",
-        "bytes_ragged",
-        "media_bytes",
-        "media_list_ragged",
-    }
+    return leaf.decision.codec in {"ragged_tensor", "bytes_ragged", "media_bytes", "media_list_ragged"}
 
 
 def _encode_with_fallback(path: str, value: np.ndarray) -> "_EncodedStructuredLeaf":
-    """Encode using type-based fallback (delegates to _leaf_decision), with recursive expansion for structured rows."""
+    """Encode using type-based fallback (delegates to _choose_leaf_codec), with recursive expansion for structured rows."""
     values = list(value)
     recursive = _encode_recursive_if_structured(path, values)
     if recursive is not None:
         return recursive
-    decision = _leaf_decision(values)
+    decision = _choose_leaf_codec(values)
     metadata = dict(decision.metadata or {})
     schema = FieldSchema(codec=decision.codec, metadata=metadata)
     return _encode_with_schema(path, value, schema)
@@ -2288,7 +2258,7 @@ def _decode_structured_non_tensor_encoded(
 
 
 def _copy_recursive_metadata_for_leaf_updates(
-    metadata: Mapping[str, Any],
+    metadata: Mapping[str, Any]
 ) -> dict[str, Any]:
     copied = dict(metadata)
     copied["leaves"] = [dict(leaf) for leaf in metadata.get("leaves", [])]
@@ -2340,9 +2310,7 @@ def _reconstruct_structured_rows(
 ) -> list[Any]:
     values_by_path: dict[str, list[Any]] = dict(leaf_values)
     nodes = sorted(
-        metadata.get("nodes", []),
-        key=lambda node: _path_depth(node["path"]),
-        reverse=True,
+        metadata.get("nodes", []), key=lambda node: _path_depth(node["path"]), reverse=True
     )
     for node in nodes:
         missing_payload = node.get("missing_payload")
@@ -3187,9 +3155,7 @@ class _StructuredObjectLayer:
         row_width = element_size * int(np.prod(shape[1:], dtype=np.int64))
         data_offset = metadata_bytes + start * row_width
         data_length = (end - start) * row_width
-        metadata = self._bundle_store.read_payload_range(
-            payload_spec, 0, metadata_bytes
-        )
+        metadata = self._bundle_store.read_payload_range(payload_spec, 0, metadata_bytes)
         sliced_metadata = _slice_tensor_metadata(
             metadata, (end - start, *shape[1:]), data_length
         )
@@ -3204,10 +3170,7 @@ class _StructuredObjectLayer:
                     f"tensor destination has {destination.size} bytes, expected at least {expected_bytes}"
                 )
             ctypes.memmove(destination.ptr, sliced_metadata, metadata_bytes)
-            if (
-                isinstance(destination, _RawDestinationBuffer)
-                and destination.pre_registered
-            ):
+            if isinstance(destination, _RawDestinationBuffer) and destination.pre_registered:
                 self._bundle_store.read_payload_range_into_raw_destination(
                     payload_spec,
                     destination.ptr,
@@ -4508,7 +4471,9 @@ class _MooncakePayloadTransport:
         fragments = []
         for source_offset, destination_offset, byte_length in ranges:
             fragments.extend(
-                _payload_range_fragments(chunks, source_offset, byte_length, destination_offset)
+                _payload_range_fragments(
+                    chunks, source_offset, byte_length, destination_offset
+                )
             )
         if not fragments:
             return True
@@ -4683,26 +4648,20 @@ def _resolve_ndarray_destination(
                 f"raw destination has {destination.size} bytes, expected at least {nbytes}"
             )
         _ = destination.owner
-        return (
-            np.ctypeslib.as_array(
-                (ctypes.c_uint8 * nbytes).from_address(destination.ptr)
-            )
-            .view(dtype)
-            .reshape(shape)
-        )
+        return np.ctypeslib.as_array(
+            (ctypes.c_uint8 * nbytes).from_address(destination.ptr)
+        ).view(dtype).reshape(shape)
     if not isinstance(destination, np.ndarray):
         raise TypeError(
             f"structured ndarray field {name} destination must be a numpy.ndarray or raw_destination"
         )
     if destination.dtype != dtype:
         raise ValueError(
-            f"structured ndarray field {name} destination dtype mismatch: "
-            f"expected {dtype.str}, got {destination.dtype.str}"
+            f"structured ndarray field {name} destination dtype mismatch: expected {dtype.str}, got {destination.dtype.str}"
         )
     if tuple(destination.shape) != shape:
         raise ValueError(
-            f"structured ndarray field {name} destination shape mismatch: "
-            f"expected {shape}, got {tuple(destination.shape)}"
+            f"structured ndarray field {name} destination shape mismatch: expected {shape}, got {tuple(destination.shape)}"
         )
     if not destination.flags["C_CONTIGUOUS"]:
         raise ValueError(
@@ -5202,31 +5161,13 @@ def _parse_torch_dtype(dtype_str: str) -> Any:
     return dtype
 
 
-_TORCH_TO_NUMPY_DTYPE = {
-    "torch.float16": np.float16,
-    "torch.float32": np.float32,
-    "torch.float64": np.float64,
-    "torch.bfloat16": np.float16,  # numpy has no bfloat16, use float16 size
-    "torch.int8": np.int8,
-    "torch.int16": np.int16,
-    "torch.int32": np.int32,
-    "torch.int64": np.int64,
-    "torch.uint8": np.uint8,
-    "torch.bool": np.bool_,
-}
-
-
 def _torch_dtype_to_numpy(dtype_str: str) -> np.dtype:
     """Convert torch dtype string to numpy dtype for buffer interpretation."""
-    result = _TORCH_TO_NUMPY_DTYPE.get(dtype_str)
-    if result is not None:
-        return np.dtype(result)
-    # Fallback: strip 'torch.' prefix and try numpy
-    name = dtype_str.removeprefix("torch.")
-    try:
-        return np.dtype(name)
-    except TypeError:
-        return np.dtype(np.float32)
+    torch_dtype = _parse_torch_dtype(dtype_str)
+    # bfloat16 has no numpy equivalent; use float16 (same element size)
+    if torch_dtype == _torch.bfloat16:
+        return np.dtype(np.float16)
+    return _torch.empty(0, dtype=torch_dtype).numpy().dtype
 
 
 @dataclass
@@ -5291,7 +5232,7 @@ def _is_bytes_like(value: Any) -> bool:
 
 
 def _non_null(values: list[Any]) -> list[Any]:
-    return [value for value in values if value is not None and not isinstance(value, _Missing)]
+    return [v for v in values if v is not None and not isinstance(v, _Missing)]
 
 
 def _is_media_list(value: Any) -> bool:
@@ -5300,7 +5241,7 @@ def _is_media_list(value: Any) -> bool:
     )
 
 
-def _leaf_decision(values: list[Any]) -> _CodecDecision:
+def _choose_leaf_codec(values: list[Any]) -> _CodecDecision:
     nn = _non_null(values)
     if not nn:
         return _CodecDecision(False, "msgpack_ragged", "all rows are null", "msgpack")
@@ -5341,64 +5282,79 @@ def _leaf_decision(values: list[Any]) -> _CodecDecision:
 
 def _try_expand_dict(values: list[Any]) -> list[str] | None:
     nn = _non_null(values)
-    if not nn or not all(isinstance(value, dict) for value in nn):
+    if not nn or not all(isinstance(v, dict) for v in nn):
         return None
-    keys = {key for value in nn for key in value.keys()}
-    if not all(isinstance(key, str) for key in keys) or len(keys) > 64:
+    keys = {k for v in nn for k in v.keys()}
+    if not all(isinstance(k, str) for k in keys) or len(keys) > _INFER_MAX_STRUCT_KEYS:
         return None
     return sorted(keys)
 
 
 def _try_expand_list(values: list[Any]) -> tuple[int, list[int]] | None:
     nn = _non_null(values)
-    if not nn or not all(isinstance(value, (list, tuple)) for value in nn):
+    if not nn or not all(isinstance(v, (list, tuple)) for v in nn):
         return None
-    max_len = max(len(value) for value in nn)
-    if max_len > 8:
+    max_len = max(len(v) for v in nn)
+    if max_len > _INFER_MAX_LIST_LEN:
         return None
     if not all(
-        item is None or isinstance(item, (dict, list, tuple))
-        for value in nn
-        for item in value
+        item is None or isinstance(item, (dict, list, tuple)) for v in nn for item in v
     ):
         return None
-    lengths = [len(value) if isinstance(value, (list, tuple)) else 0 for value in values]
+    lengths = [len(v) if isinstance(v, (list, tuple)) else 0 for v in values]
     return max_len, lengths
 
 
-def _infer_structure(
+def infer_structure(
     path: str,
     values: list[Any],
     leaves: list[_InferredLeaf],
     nodes: list[_InferredNode],
     *,
-    depth: int = 0,
+    _depth: int = 0,
 ) -> None:
-    if depth > _INFER_STRUCTURE_MAX_DEPTH:
-        raise ValueError(f"infer_structure exceeded max depth {_INFER_STRUCTURE_MAX_DEPTH} at {path!r}")
+    """Recursively expand *values* into leaves and interior nodes.
+
+    *leaves* and *nodes* are output accumulators populated during recursion.
+    Absent dict keys are represented as ``MISSING`` in child columns
+    (distinct from ``None`` values).  Each interior node carries a
+    ``row_mask`` that records which rows had a real parent container.
+    """
+    if _depth > _INFER_MAX_DEPTH:
+        raise ValueError(
+            f"infer_structure exceeded max depth {_INFER_MAX_DEPTH} at {path!r}"
+        )
     dict_keys = _try_expand_dict(values)
     if dict_keys is not None:
-        row_mask = [isinstance(value, dict) for value in values]
+        row_mask = [isinstance(v, dict) for v in values]
         nodes.append(_InferredNode(path, "dict", dict_keys, row_mask=row_mask))
         for key in dict_keys:
-            child = [value.get(key, MISSING) if isinstance(value, dict) else None for value in values]
-            _infer_structure(f"{path}.{_escape_key(key)}", child, leaves, nodes, depth=depth + 1)
+            child = [
+                v.get(key, MISSING) if isinstance(v, dict) else None for v in values
+            ]
+            infer_structure(
+                f"{path}.{_escape_key(key)}", child, leaves, nodes, _depth=_depth + 1
+            )
         return
     list_result = _try_expand_list(values)
     if list_result is not None:
         max_len, lengths = list_result
-        row_mask = [isinstance(value, (list, tuple)) for value in values]
-        nodes.append(_InferredNode(path, "list", list(range(max_len)), lengths, row_mask=row_mask))
+        row_mask = [isinstance(v, (list, tuple)) for v in values]
+        nodes.append(
+            _InferredNode(
+                path, "list", list(range(max_len)), lengths, row_mask=row_mask
+            )
+        )
         for index in range(max_len):
             child = [
-                value[index]
-                if isinstance(value, (list, tuple)) and index < len(value)
-                else (MISSING if isinstance(value, (list, tuple)) else None)
-                for value in values
+                v[index]
+                if isinstance(v, (list, tuple)) and index < len(v)
+                else (MISSING if isinstance(v, (list, tuple)) else None)
+                for v in values
             ]
-            _infer_structure(f"{path}[{index}]", child, leaves, nodes, depth=depth + 1)
+            infer_structure(f"{path}[{index}]", child, leaves, nodes, _depth=_depth + 1)
         return
-    leaves.append(_InferredLeaf(path, values, _leaf_decision(values)))
+    leaves.append(_InferredLeaf(path, values, _choose_leaf_codec(values)))
 
 
 def _structured_path_tokens(path: str) -> list[Any]:

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -19,7 +19,7 @@ except Exception:  # pragma: no cover - depends on built extension
 import msgpack as _msgpack
 
 DEFAULT_BUNDLE_CHUNK_BYTES = 64 * 1024**2
-AUTO_PARALLEL_MIN_BYTES = 4 * 1024**3
+AUTO_PARALLEL_MIN_BYTES = DEFAULT_BUNDLE_CHUNK_BYTES
 AUTO_PARALLEL_MIN_CHUNKS = 8
 MISSING_OBJECT_ERROR = (
     -704

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -741,6 +741,10 @@ class MooncakeBundleTransfer:
             rows=rows,
         )
 
+    def dataproto_manifest_view(self, ref: DataProtoRefLike) -> dict[str, Any]:
+        """Return a DataProto field view derived from stage structured-object manifests."""
+        return _dataproto_manifest_view(self, _resolve_ref(ref))
+
     def _materialize_ref(
         self,
         ref: MooncakeDataProtoRef,
@@ -1641,7 +1645,7 @@ class MooncakeBundleTransfer:
             field_updates[name] = StructuredFieldLocation(stage, member, "batch")
         encoded_updates: dict[str, Any] = {}
         for name, value in non_tensor_batch.items():
-            schema = field_schemas.get(name) if field_schemas else None
+            schema = _schema_for_section(field_schemas, name, "non_tensor_batch")
             needs_non_tensor = (isinstance(value, np.ndarray) and value.dtype == object) or (
                 schema is not None
                 and not (isinstance(value, np.ndarray) and value.dtype != object and schema.codec in {"auto", "ndarray"})
@@ -1660,16 +1664,18 @@ class MooncakeBundleTransfer:
                 if schema is not None:
                     try:
                         encoded = _encode_with_schema(path, encode_value, schema)
-                    except _ENCODING_FALLBACK_ERRORS:
+                    except _ENCODING_FALLBACK_ERRORS as schema_error:
+                        if _is_schema_validation_error(schema, schema_error):
+                            raise
                         if schema.codec == "auto":
                             raise
                         try:
                             encoded = _encode_with_fallback(path, encode_value)
-                        except _ENCODING_FALLBACK_ERRORS as fallback_error:
-                            raise ValueError(
-                                f"unable to encode structured non-tensor field {path!r} with "
-                                f"schema codec {schema.codec!r} or automatic fallback"
-                            ) from fallback_error
+                        except _ENCODING_FALLBACK_ERRORS:
+                            raise type(schema_error)(
+                                f"failed to encode non_tensor_batch field {name!r} "
+                                f"with FieldSchema codec {schema.codec!r}: {schema_error}"
+                            ) from schema_error
                 else:
                     encoded = _encode_with_fallback(path, encode_value)
                 payload_members: dict[str, str] = {}
@@ -1805,6 +1811,65 @@ def _copy_transfer_policy(policy: BundleTransferPolicy) -> BundleTransferPolicy:
     )
 
 
+def _dataproto_manifest_view(
+    transfer: MooncakeBundleTransfer, ref: MooncakeDataProtoRef
+) -> dict[str, Any]:
+    stage_manifests = {
+        stage: transfer._bundle_store.resolve_manifest(stage_ref)
+        for stage, stage_ref in ref.stage_refs.items()
+    }
+    stage_metadata = {
+        stage: _decode_structured_metadata(
+            transfer._bundle_store.read_payload(stage_manifest["meta"])
+        )
+        for stage, stage_manifest in stage_manifests.items()
+    }
+    fields: dict[str, dict[str, Any]] = {}
+    for name, location in ref.field_index.items():
+        metadata = stage_metadata[location.stage]
+        field_specs = _structured_field_specs(metadata)
+        member_spec = dict(field_specs.get(location.member, {"encoding": "bytes"}))
+        encoded = ref.encoded_non_tensor.get(name)
+        if encoded is not None:
+            member_spec = {
+                "encoding": "structured_non_tensor",
+                "codec": encoded["codec"],
+                "metadata": encoded.get("metadata"),
+                "payload_members": dict(encoded["payload_members"]),
+                "payload_specs": {
+                    payload_name: dict(field_specs.get(member, {"encoding": "bytes"}))
+                    for payload_name, member in encoded["payload_members"].items()
+                },
+            }
+        fields[name] = {
+            "section": location.section,
+            "stage": location.stage,
+            "member": location.member,
+            "spec": member_spec,
+        }
+    return {
+        "namespace": ref.namespace,
+        "partition": ref.partition,
+        "batch_size": ref.batch_size,
+        "batch_fields": {
+            name: info for name, info in fields.items() if info["section"] == "batch"
+        },
+        "non_tensor_fields": {
+            name: info
+            for name, info in fields.items()
+            if info["section"] == "non_tensor_batch"
+        },
+        "meta_info_keys": list(ref.meta_info),
+        "stages": {
+            stage: {
+                "manifest_key": stage_ref.manifest_key,
+                "dataproto": stage_metadata[stage].get("dataproto", {}),
+            }
+            for stage, stage_ref in ref.stage_refs.items()
+        },
+    }
+
+
 _DATAPROTO_SCHEMA_SECTIONS = frozenset({"batch", "non_tensor_batch", "meta_info"})
 
 
@@ -1820,6 +1885,20 @@ def _schema_section(name: str, schema: FieldSchema) -> str | None:
     return section
 
 
+def _schema_for_section(
+    field_schemas: Optional[Mapping[str, FieldSchema]],
+    name: str,
+    section: str,
+) -> FieldSchema | None:
+    if not field_schemas:
+        return None
+    schema = field_schemas.get(name)
+    if schema is None:
+        return None
+    declared = _schema_section(name, schema)
+    return schema if declared is None or declared == section else None
+
+
 def _schema_ndarray_dtype(schema: FieldSchema) -> np.dtype[Any] | None:
     dtype_name = schema.metadata.get("dtype")
     if dtype_name is None:
@@ -1833,6 +1912,24 @@ def _schema_ndarray_dtype(schema: FieldSchema) -> np.dtype[Any] | None:
     return dtype
 
 
+def _validate_schema_nullable(
+    path: str, values: Sequence[Any], schema: FieldSchema
+) -> None:
+    if not schema.nullable and any(item is None for item in values):
+        raise ValueError(f"FieldSchema for {path!r} is not nullable")
+
+
+def _is_schema_validation_error(schema: FieldSchema, error: BaseException) -> bool:
+    if schema.codec != "ragged_tensor_dict":
+        return False
+    message = str(error)
+    return (
+        "must not contain" in message
+        or "keys not declared" in message
+        or "explicit None" in message
+    )
+
+
 def _validate_dataproto_schema_sections(
     batch: Mapping[str, Any],
     non_tensor_batch: Mapping[str, Any],
@@ -1841,23 +1938,27 @@ def _validate_dataproto_schema_sections(
 ) -> None:
     if not field_schemas:
         return
-    for section, fields in (
-        ("batch", batch),
-        ("non_tensor_batch", non_tensor_batch),
-        ("meta_info", meta_info),
-    ):
+    sections = {
+        "batch": batch,
+        "non_tensor_batch": non_tensor_batch,
+        "meta_info": meta_info,
+    }
+    actual_sections: dict[str, set[str]] = {}
+    for section, fields in sections.items():
         for name in fields:
-            schema = field_schemas.get(name)
-            if schema is None:
-                continue
-            declared = _schema_section(name, schema)
-            if declared is None:
-                continue
-            if declared != section:
-                raise ValueError(
-                    f"FieldSchema for {name!r} declares section {declared!r}, "
-                    f"but data contains it in {section!r}"
-                )
+            actual_sections.setdefault(name, set()).add(section)
+    for name, schema in field_schemas.items():
+        declared = _schema_section(name, schema)
+        if declared is None:
+            continue
+        actual = actual_sections.get(name)
+        if not actual or declared in actual:
+            continue
+        actual_text = ", ".join(repr(section) for section in sorted(actual))
+        raise ValueError(
+            f"FieldSchema for {name!r} declares section {declared!r}, "
+            f"but data contains it in {actual_text}"
+        )
 
 
 def _flat_dict_to_envelope_with_schema(
@@ -2192,6 +2293,7 @@ def _encode_with_schema(
 ) -> "_EncodedStructuredLeaf":
     """Encode a non_tensor_batch field using an explicit schema (no inference)."""
     values = list(value)
+    _validate_schema_nullable(path, values, schema)
     codec = schema.codec
     if codec == "auto":
         return _encode_with_fallback(path, value)
@@ -2582,6 +2684,25 @@ def _decode_ragged_tensor_values(
 # ---------------------------------------------------------------------------
 
 
+def _normalize_ragged_tensor_dict_keys(keys: Any) -> list[str]:
+    if isinstance(keys, Mapping):
+        iterable = keys.keys()
+    else:
+        iterable = keys
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for key in iterable:
+        if not isinstance(key, str):
+            raise TypeError("ragged_tensor_dict keys must be strings")
+        if "." in key:
+            raise ValueError("ragged_tensor_dict keys must not contain '.'")
+        if key in seen:
+            raise ValueError(f"ragged_tensor_dict keys contain duplicate key {key!r}")
+        seen.add(key)
+        normalized.append(key)
+    return normalized
+
+
 def _encode_ragged_tensor_dict_values(
     values: list[Any],
     schema: FieldSchema,
@@ -2595,28 +2716,50 @@ def _encode_ragged_tensor_dict_values(
         raise RuntimeError("torch is required to encode ragged_tensor_dict fields")
     rows = len(values)
     null_mask = np.asarray([v is None for v in values], dtype=np.bool_)
-    non_null = [v for v in values if v is not None]
 
-    if not non_null:
-        return _EncodedStructuredLeaf(
-            codec="ragged_tensor_dict",
-            rows=rows,
-            payload={"null_mask": null_mask},
-            metadata={"keys": [], "key_codecs": {}},
-        )
-
-    keys = schema.metadata.get("keys")
-    if not keys:
-        all_keys: set[str] = set()
-        for v in non_null:
-            all_keys.update(v.keys())
-        keys = sorted(all_keys)
+    schema_keys = schema.metadata.get("keys")
+    keys = None if schema_keys is None else _normalize_ragged_tensor_dict_keys(schema_keys)
+    declared_keys = None if keys is None else set(keys)
+    inferred_keys: set[str] = set()
+    for row, item in enumerate(values):
+        if item is None:
+            continue
+        if not isinstance(item, Mapping):
+            raise TypeError(
+                "ragged_tensor_dict rows must be mappings or None; "
+                f"row {row} is {type(item).__name__}"
+            )
+        explicit_null_keys = sorted(key for key, value in item.items() if value is None)
+        if explicit_null_keys:
+            raise TypeError(
+                "ragged_tensor_dict rows cannot contain explicit None tensor values; "
+                f"row {row} has explicit None for {explicit_null_keys}"
+            )
+        row_keys = _normalize_ragged_tensor_dict_keys(item.keys())
+        if declared_keys is None:
+            inferred_keys.update(row_keys)
+            continue
+        extra_keys = sorted(set(row_keys) - declared_keys)
+        if extra_keys:
+            raise ValueError(
+                "ragged_tensor_dict rows contain keys not declared in "
+                f"FieldSchema metadata['keys']; row {row} has keys not declared: {extra_keys}"
+            )
+    if keys is None:
+        keys = _normalize_ragged_tensor_dict_keys(sorted(inferred_keys))
+    if keys and _torch is None:
+        raise RuntimeError("torch is required to encode ragged_tensor_dict fields")
 
     payload: dict[str, Any] = {"null_mask": null_mask}
     key_codecs: dict[str, Any] = {}
     for key in keys:
-        key_values = [None if v is None else v.get(key) for v in values]
-        sub_payload, sub_metadata = _encode_ragged_tensor_values(key_values)
+        try:
+            key_values = [None if v is None else v.get(key) for v in values]
+            sub_payload, sub_metadata = _encode_ragged_tensor_values(key_values)
+        except _ENCODING_FALLBACK_ERRORS as exc:
+            raise ValueError(
+                f"failed to encode ragged_tensor_dict key {key!r}"
+            ) from exc
         for payload_name, payload_value in sub_payload.items():
             payload[f"{key}.{payload_name}"] = payload_value
         key_codecs[key] = sub_metadata
@@ -2627,7 +2770,6 @@ def _encode_ragged_tensor_dict_values(
         payload=payload,
         metadata={"keys": keys, "key_codecs": key_codecs},
     )
-
 
 def _decode_ragged_tensor_dict_values(
     payload: dict[str, Any],
@@ -2661,7 +2803,7 @@ def _decode_ragged_tensor_dict_values(
                 val = key_values[key][row]
                 if val is not None:
                     d[key] = val
-            result.append(d if d else None)
+            result.append(d)
     return result
 
 

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -18,7 +18,7 @@ except Exception:  # pragma: no cover - depends on built extension
 
 import msgpack as _msgpack
 
-DEFAULT_BUNDLE_CHUNK_BYTES = 512 * 1024**2
+DEFAULT_BUNDLE_CHUNK_BYTES = 64 * 1024**2
 AUTO_PARALLEL_MIN_BYTES = 4 * 1024**3
 AUTO_PARALLEL_MIN_CHUNKS = 8
 MISSING_OBJECT_ERROR = (
@@ -4264,32 +4264,10 @@ class _MooncakePayloadTransport:
         if not chunk_keys:
             return
         sizes = [_buffer_group_nbytes(group) for group in chunk_groups]
-        total = sum(sizes)
-        # When total fits comfortably in pool, batch all leases and issue one
-        # batch_put_from call. Otherwise stream one-at-a-time to avoid pool
-        # exhaustion.
         pool = self._buffer_pool
-        if len(chunk_keys) > 1 and total <= getattr(pool, "size", 0) // 2:
-            leases: list[Any] = []
-            try:
-                for group, size in zip(chunk_groups, sizes):
-                    lease = pool.acquire(size)
-                    _copy_memoryviews_to_lease(group, lease)
-                    leases.append(lease)
-                results = batch_put_from(
-                    list(chunk_keys),
-                    [lease.ptr for lease in leases],
-                    sizes,
-                )
-                self._check_batch_put_results(results, chunk_keys, "batch_put_from")
-            except Exception:
-                _cleanup_keys(self._store, list(chunk_keys), strict=False)
-                raise
-            finally:
-                for lease in leases:
-                    lease.release()
-            return
-        # Fallback: one chunk at a time for large payloads.
+        # Stream one chunk at a time: acquire → memcpy → put → release.
+        # This keeps pool pressure minimal (one lease per call) and allows
+        # RDMA transfers to pipeline across threads.
         for chunk_key, group, size in zip(chunk_keys, chunk_groups, sizes):
             lease = pool.acquire(size)
             try:
@@ -4898,11 +4876,16 @@ def _buffer_group_nbytes(buffers: Sequence[memoryview]) -> int:
 
 
 def _copy_memoryviews(buffers: Sequence[memoryview], destination: memoryview) -> None:
+    dst_arr = np.frombuffer(destination, dtype=np.uint8)
+    dst_ptr = dst_arr.ctypes.data
     offset = 0
     for buffer in buffers:
-        next_offset = offset + len(buffer)
-        destination[offset:next_offset] = buffer
-        offset = next_offset
+        n = len(buffer)
+        if n == 0:
+            continue
+        src_arr = np.frombuffer(buffer, dtype=np.uint8)
+        ctypes.memmove(dst_ptr + offset, src_arr.ctypes.data, n)
+        offset += n
 
 
 def _copy_memoryviews_to_lease(buffers: Sequence[memoryview], lease: Any) -> None:

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -608,37 +608,6 @@ class MooncakeBundleTransfer:
             max_inflight_put=max_inflight_put,
         )
 
-    def put_object(
-        self,
-        obj: Any,
-        partition: str = "default",
-        chunk_bytes: Optional[int] = None,
-        policy: Optional[BundleTransferPolicy] = None,
-        max_inflight_put: Optional[int] = None,
-    ) -> RemoteBundleRef:
-        """Store a mapping object or a single tensor/array value."""
-        if isinstance(obj, Mapping):
-            payload = StructuredObjectPayload(metadata={}, buffers=obj)
-        else:
-            payload = StructuredObjectPayload(
-                metadata={"__mooncake_wrapped_object__": True},
-                buffers={"value": obj},
-            )
-        return self.put_structured_object(
-            payload,
-            partition=partition,
-            chunk_bytes=chunk_bytes,
-            policy=policy,
-            max_inflight_put=max_inflight_put,
-        )
-
-    def get_object(self, ref: RemoteBundleRef | Mapping[str, Any]) -> Any:
-        """Materialize an object stored by put_object()."""
-        result = self.materialize(self.read_spec(ref))
-        if result.metadata.get("__mooncake_wrapped_object__"):
-            return result.objects["value"]
-        return result.objects
-
     def read_spec(
         self, ref: RemoteBundleRef | Mapping[str, Any]
     ) -> StructuredObjectReadSpec:
@@ -680,35 +649,6 @@ class MooncakeBundleTransfer:
             overwrite=False,
             field_schemas=field_schemas,
         )
-
-    def append_dataproto_fields(
-        self,
-        ref: DataProtoRefLike,
-        data: Any,
-        *,
-        stage: str,
-        overwrite: bool = False,
-        chunk_bytes: Optional[int] = None,
-        policy: Optional[BundleTransferPolicy] = None,
-        field_schemas: Optional[dict[str, FieldSchema]] = None,
-    ) -> MooncakeDataProtoRef:
-        """Append fields from a later DataProto stage without rewriting previous stages."""
-        ref = _resolve_ref(ref)
-        return self._put_stage(
-            ref,
-            data,
-            namespace=ref.namespace,
-            partition=ref.partition,
-            stage=stage,
-            chunk_bytes=chunk_bytes,
-            policy=policy,
-            overwrite=overwrite,
-            field_schemas=field_schemas,
-        )
-
-    def dataproto_manifest_view(self, ref: DataProtoRefLike) -> dict[str, Any]:
-        """Return a DataProto field view derived from stage structured-object manifests."""
-        return _dataproto_manifest_view(self, _resolve_ref(ref))
 
     def get_dataproto(
         self,
@@ -872,7 +812,7 @@ class MooncakeBundleTransfer:
                     if legacy_output
                     else _object_array_from_decoded_values(values)
                 )
-        meta_info = _select_mapping(ref.meta_info, meta_info_keys)
+        meta_info = {k: ref.meta_info[k] for k in meta_info_keys if k in ref.meta_info} if meta_info_keys is not None else dict(ref.meta_info)
         if legacy_output:
             return _envelope_to_legacy_dict(
                 {
@@ -1041,6 +981,29 @@ class MooncakeBundleTransfer:
             )
         return _deserialize_tensor_payload(sliced_metadata + data)
 
+    @staticmethod
+    def _scatter_gather_offsets(
+        raw_offsets: np.ndarray,
+    ) -> tuple[np.ndarray, list[int], np.ndarray]:
+        """Compute scatter-gather offset arrays from paired (begin, end) offsets.
+
+        ``raw_offsets`` must contain interleaved ``[begin0, end0, begin1, end1, ...]``
+        values obtained by reading the stored offsets array at positions
+        ``[row, row+1]`` for each selected row.
+
+        Returns ``(begins, item_counts, gathered_offsets)`` where
+        ``gathered_offsets`` is the cumulative-sum offset array for the
+        gathered result.
+        """
+        begins = raw_offsets[0::2]
+        ends = raw_offsets[1::2]
+        item_counts = [int(end) - int(begin) for begin, end in zip(begins, ends)]
+        gathered_offsets = np.empty(len(item_counts) + 1, dtype=raw_offsets.dtype)
+        gathered_offsets[0] = 0
+        for idx, count in enumerate(item_counts):
+            gathered_offsets[idx + 1] = int(gathered_offsets[idx]) + count
+        return begins, item_counts, gathered_offsets
+
     def _read_structured_non_tensor_payload_indices(
         self,
         stage_ref: RemoteBundleRef,
@@ -1092,8 +1055,9 @@ class MooncakeBundleTransfer:
             )
             return array
 
-        if _is_recursive_encoded_non_tensor(encoded):
-            metadata = _copy_recursive_metadata_for_leaf_updates(metadata)
+        if encoded.get("codec") == "structured_recursive":
+            metadata = dict(metadata)
+            metadata["leaves"] = [dict(leaf) for leaf in metadata.get("leaves", [])]
             recursive_payload: dict[str, Any] = {}
             for node in metadata.get("nodes", []):
                 for key in ("missing_payload", "row_mask_payload", "lengths_payload"):
@@ -1134,15 +1098,7 @@ class MooncakeBundleTransfer:
                     f"{key}.offsets",
                     [index for row in indices for index in (row, row + 1)],
                 )
-                begins = sub_offsets[0::2]
-                ends = sub_offsets[1::2]
-                item_counts = [
-                    int(end) - int(begin) for begin, end in zip(begins, ends)
-                ]
-                gathered_offsets = np.empty(len(indices) + 1, dtype=sub_offsets.dtype)
-                gathered_offsets[0] = 0
-                for idx, count in enumerate(item_counts):
-                    gathered_offsets[idx + 1] = int(gathered_offsets[idx]) + count
+                begins, item_counts, gathered_offsets = self._scatter_gather_offsets(sub_offsets)
                 dtype = member_dtype(f"{key}.data")
                 ranges = []
                 destination_item = 0
@@ -1181,13 +1137,7 @@ class MooncakeBundleTransfer:
             offsets = read_member_indices(
                 "offsets", [index for row in indices for index in (row, row + 1)]
             )
-            begins = offsets[0::2]
-            ends = offsets[1::2]
-            item_counts = [int(end) - int(begin) for begin, end in zip(begins, ends)]
-            gathered_offsets = np.empty(len(indices) + 1, dtype=offsets.dtype)
-            gathered_offsets[0] = 0
-            for index, count in enumerate(item_counts):
-                gathered_offsets[index + 1] = int(gathered_offsets[index]) + count
+            begins, item_counts, gathered_offsets = self._scatter_gather_offsets(offsets)
             dtype = member_dtype("data")
             ranges = []
             destination_item = 0
@@ -1216,15 +1166,10 @@ class MooncakeBundleTransfer:
             offsets = read_member_indices(
                 "offsets", [index for row in indices for index in (row, row + 1)]
             )
-            begins = offsets[0::2]
-            ends = offsets[1::2]
-            byte_counts = [int(end) - int(begin) for begin, end in zip(begins, ends)]
-            gathered_offsets = np.empty(len(indices) + 1, dtype=offsets.dtype)
-            gathered_offsets[0] = 0
+            begins, byte_counts, gathered_offsets = self._scatter_gather_offsets(offsets)
             ranges = []
             destination_offset = 0
-            for index, (begin, count) in enumerate(zip(begins, byte_counts)):
-                gathered_offsets[index + 1] = destination_offset + count
+            for begin, count in zip(begins, byte_counts):
                 if count:
                     ranges.append((int(begin), destination_offset, count))
                 destination_offset += count
@@ -1325,8 +1270,9 @@ class MooncakeBundleTransfer:
                 payload_spec, byte_start, byte_end - byte_start
             )
 
-        if _is_recursive_encoded_non_tensor(encoded):
-            metadata = _copy_recursive_metadata_for_leaf_updates(metadata)
+        if encoded.get("codec") == "structured_recursive":
+            metadata = dict(metadata)
+            metadata["leaves"] = [dict(leaf) for leaf in metadata.get("leaves", [])]
             recursive_payload: dict[str, Any] = {}
             for node in metadata.get("nodes", []):
                 for key in ("missing_payload", "row_mask_payload", "lengths_payload"):
@@ -1463,7 +1409,7 @@ class MooncakeBundleTransfer:
         """Store a legacy rollout dict as a structured object."""
         return self._put_stage(
             None,
-            _legacy_dict_to_envelope(data, field_schemas=field_schemas),
+            _legacy_dict_to_envelope_with_schema(data, field_schemas),
             namespace=namespace,
             partition=partition,
             stage=stage,
@@ -1620,11 +1566,34 @@ class MooncakeBundleTransfer:
         encoded_updates: dict[str, Any] = {}
         for name, value in non_tensor_batch.items():
             schema = field_schemas.get(name) if field_schemas else None
-            if _should_encode_non_tensor_field(value) or _schema_requires_non_tensor_encoding(value, schema):
-                encode_value = _coerce_non_tensor_value_for_encoding(name, value)
+            needs_non_tensor = (isinstance(value, np.ndarray) and value.dtype == object) or (
+                schema is not None
+                and not (isinstance(value, np.ndarray) and value.dtype != object and schema.codec in {"auto", "ndarray"})
+            )
+            if needs_non_tensor:
+                if isinstance(value, np.ndarray):
+                    encode_value = value
+                elif isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+                    encode_value = np.empty(len(value), dtype=object)
+                    encode_value[:] = list(value)
+                else:
+                    raise TypeError(
+                        f"non_tensor_batch field {name!r} with FieldSchema must be an ndarray or non-string sequence"
+                    )
                 path = f"non_tensor_batch.{name}"
                 if schema is not None:
-                    encoded = _encode_with_schema_or_fallback(path, encode_value, schema)
+                    try:
+                        encoded = _encode_with_schema(path, encode_value, schema)
+                    except _ENCODING_FALLBACK_ERRORS:
+                        if schema.codec == "auto":
+                            raise
+                        try:
+                            encoded = _encode_with_fallback(path, encode_value)
+                        except _ENCODING_FALLBACK_ERRORS as fallback_error:
+                            raise ValueError(
+                                f"unable to encode structured non-tensor field {path!r} with "
+                                f"schema codec {schema.codec!r} or automatic fallback"
+                            ) from fallback_error
                 else:
                     encoded = _encode_with_fallback(path, encode_value)
                 payload_members: dict[str, str] = {}
@@ -1758,65 +1727,6 @@ def _copy_transfer_policy(policy: BundleTransferPolicy) -> BundleTransferPolicy:
     )
 
 
-def _dataproto_manifest_view(
-    transfer: MooncakeBundleTransfer, ref: MooncakeDataProtoRef
-) -> dict[str, Any]:
-    stage_manifests = {
-        stage: transfer._bundle_store.resolve_manifest(stage_ref)
-        for stage, stage_ref in ref.stage_refs.items()
-    }
-    stage_metadata = {
-        stage: _decode_structured_metadata(
-            transfer._bundle_store.read_payload(stage_manifest["meta"])
-        )
-        for stage, stage_manifest in stage_manifests.items()
-    }
-    fields: dict[str, dict[str, Any]] = {}
-    for name, location in ref.field_index.items():
-        metadata = stage_metadata[location.stage]
-        field_specs = _structured_field_specs(metadata)
-        member_spec = dict(field_specs.get(location.member, _BYTES_FIELD_SPEC))
-        encoded = ref.encoded_non_tensor.get(name)
-        if encoded is not None:
-            member_spec = {
-                "encoding": "structured_non_tensor",
-                "codec": encoded["codec"],
-                "metadata": encoded.get("metadata"),
-                "payload_members": dict(encoded["payload_members"]),
-                "payload_specs": {
-                    payload_name: dict(field_specs.get(member, _BYTES_FIELD_SPEC))
-                    for payload_name, member in encoded["payload_members"].items()
-                },
-            }
-        fields[name] = {
-            "section": location.section,
-            "stage": location.stage,
-            "member": location.member,
-            "spec": member_spec,
-        }
-    return {
-        "namespace": ref.namespace,
-        "partition": ref.partition,
-        "batch_size": ref.batch_size,
-        "batch_fields": {
-            name: info for name, info in fields.items() if info["section"] == "batch"
-        },
-        "non_tensor_fields": {
-            name: info
-            for name, info in fields.items()
-            if info["section"] == "non_tensor_batch"
-        },
-        "meta_info_keys": list(ref.meta_info),
-        "stages": {
-            stage: {
-                "manifest_key": stage_ref.manifest_key,
-                "dataproto": stage_metadata[stage].get("dataproto", {}),
-            }
-            for stage, stage_ref in ref.stage_refs.items()
-        },
-    }
-
-
 _DATAPROTO_SCHEMA_SECTIONS = frozenset({"batch", "non_tensor_batch", "meta_info"})
 
 
@@ -1872,20 +1782,11 @@ def _validate_dataproto_schema_sections(
                 )
 
 
-def _legacy_dict_to_envelope(
-    data: Mapping[str, Any],
-    field_schemas: Optional[Mapping[str, FieldSchema]] = None,
-) -> dict[str, Any]:
-    if not isinstance(data, Mapping):
-        raise TypeError("legacy rollout data must be a mapping")
-    if field_schemas:
-        return _legacy_dict_to_envelope_with_schema(data, field_schemas)
-    return _legacy_dict_to_envelope_auto(data)
-
-
 def _legacy_dict_to_envelope_with_schema(
-    data: Mapping[str, Any], field_schemas: Mapping[str, FieldSchema]
+    data: Mapping[str, Any], field_schemas: Mapping[str, FieldSchema] | None
 ) -> dict[str, Any]:
+    if not field_schemas:
+        field_schemas = {}
     schema_row_count = _legacy_schema_row_count(data, field_schemas)
     row_count = schema_row_count
     if row_count == 0:
@@ -1904,7 +1805,7 @@ def _legacy_dict_to_envelope_with_schema(
         if section is None:
             if _is_row_aligned_dense_field(value, row_count):
                 batch[key] = value
-            elif schema_row_count == 0 and _is_row_aligned_sequence(value, row_count):
+            elif schema_row_count == 0 and isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)) and len(value) == row_count:
                 non_tensor_batch[key] = _coerce_legacy_non_tensor_field(
                     key, value, row_count, schema
                 )
@@ -1956,7 +1857,8 @@ def _coerce_legacy_non_tensor_field(
             raise ValueError(
                 f"legacy non_tensor_batch field {name!r} has batch size {len(value)}, expected {row_count}"
             )
-        if _schema_prefers_direct_numeric_ndarray(schema, value):
+        if (schema is not None and schema.codec == "ndarray" and _schema_ndarray_dtype(schema) is not None
+                and (value.dtype != object or all(item is not None for item in value))):
             return np.asarray(value, dtype=_schema_ndarray_dtype(schema))
         return value
     if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
@@ -1964,12 +1866,6 @@ def _coerce_legacy_non_tensor_field(
             raise ValueError(
                 f"legacy non_tensor_batch field {name!r} has batch size {len(value)}, expected {row_count}"
             )
-        if _schema_prefers_direct_numeric_ndarray(schema, value):
-            # Scalar sequences and range objects have no contiguous backing buffer.
-            # When the actual values contain no nulls, materialize the typed ndarray
-            # once and then use the direct ndarray storage path instead of structured
-            # scalar encoding with an extra null bitmap.
-            return np.asarray(list(value), dtype=_schema_ndarray_dtype(schema))
         array = np.empty(row_count, dtype=object)
         array[:] = list(value)
         return array
@@ -1978,33 +1874,6 @@ def _coerce_legacy_non_tensor_field(
     )
 
 
-def _schema_prefers_direct_numeric_ndarray(
-    schema: Optional[FieldSchema], value: Any
-) -> bool:
-    if schema is None or schema.codec != "ndarray" or _schema_ndarray_dtype(schema) is None:
-        return False
-    if isinstance(value, np.ndarray):
-        return value.dtype != object or all(item is not None for item in value)
-    return False
-
-
-def _legacy_dict_to_envelope_auto(data: Mapping[str, Any]) -> dict[str, Any]:
-    row_count = _legacy_auto_row_count(data)
-    batch: dict[str, Any] = {}
-    non_tensor_batch: dict[str, Any] = {}
-    meta_info: dict[str, Any] = {}
-    for key, value in data.items():
-        if _is_row_aligned_dense_field(value, row_count):
-            batch[key] = value
-        elif _is_row_aligned_sequence(value, row_count):
-            non_tensor_batch[key] = _coerce_legacy_non_tensor_field(key, value, row_count)
-        else:
-            meta_info[key] = value
-    return {
-        "batch": batch,
-        "non_tensor_batch": non_tensor_batch,
-        "meta_info": meta_info,
-    }
 
 
 def _legacy_auto_row_count(
@@ -2013,7 +1882,11 @@ def _legacy_auto_row_count(
     sizes = {
         len(value)
         for key, value in data.items()
-        if key not in exclude and _is_sized_row_candidate(value)
+        if key not in exclude and (
+            (_torch is not None and isinstance(value, _torch.Tensor) and value.ndim > 0)
+            or (isinstance(value, np.ndarray) and value.ndim > 0)
+            or (isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)))
+        )
     }
     if not sizes:
         return 0
@@ -2023,22 +1896,6 @@ def _legacy_auto_row_count(
             "pass FieldSchema metadata['section'] for list-valued metadata fields"
         )
     return sizes.pop()
-
-
-def _is_sized_row_candidate(value: Any) -> bool:
-    if _torch is not None and isinstance(value, _torch.Tensor):
-        return value.ndim > 0
-    if isinstance(value, np.ndarray):
-        return value.ndim > 0
-    return isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray))
-
-
-def _is_row_aligned_sequence(value: Any, row_count: int) -> bool:
-    return (
-        isinstance(value, Sequence)
-        and not isinstance(value, (str, bytes, bytearray))
-        and len(value) == row_count
-    )
 
 
 def _envelope_to_legacy_dict(data: Mapping[str, Any]) -> dict[str, Any]:
@@ -2056,20 +1913,14 @@ def _envelope_to_legacy_dict(data: Mapping[str, Any]) -> dict[str, Any]:
 def _object_array_from_decoded_values(values: list[Any]) -> np.ndarray:
     array = np.empty(len(values), dtype=object)
     array[:] = values
-    owner = getattr(values, "_mooncake_pool_owner", None) or _first_pool_owner(values)
+    owner = getattr(values, "_mooncake_pool_owner", None) or next(
+        (getattr(v, "_mooncake_pool_owner", None) for v in values if v is not None), None
+    )
     if owner is None:
         return array
     result = array.view(_OwnerBackedObjectArray)
     result._mooncake_pool_owner = owner
     return result
-
-
-def _first_pool_owner(values: Sequence[Any]) -> Any | None:
-    for value in values:
-        if value is None:
-            continue
-        return getattr(value, "_mooncake_pool_owner", None)
-    return None
 
 
 def _is_row_aligned_dense_field(value: Any, row_count: int) -> bool:
@@ -2113,7 +1964,11 @@ def _split_dataproto_like(
     data: Any,
 ) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
     if isinstance(data, Mapping):
-        if _is_dataproto_envelope_mapping(data):
+        envelope_keys = {"batch", "non_tensor_batch", "meta_info"}
+        if (data and set(data).issubset(envelope_keys) and all(
+            v is None or isinstance(v, Mapping) or callable(getattr(v, "items", None))
+            for v in data.values()
+        )):
             return (
                 _mapping_to_dict(data.get("batch")),
                 _mapping_to_dict(data.get("non_tensor_batch")),
@@ -2124,21 +1979,6 @@ def _split_dataproto_like(
     non_tensor_batch = _mapping_to_dict(getattr(data, "non_tensor_batch", None))
     meta_info = _mapping_to_dict(getattr(data, "meta_info", None))
     return batch, non_tensor_batch, meta_info
-
-
-def _is_dataproto_envelope_mapping(data: Mapping[str, Any]) -> bool:
-    envelope_keys = {"batch", "non_tensor_batch", "meta_info"}
-    if not data or not set(data).issubset(envelope_keys):
-        return False
-    return all(_is_mapping_like_or_none(value) for value in data.values())
-
-
-def _is_mapping_like_or_none(value: Any) -> bool:
-    return (
-        value is None
-        or isinstance(value, Mapping)
-        or callable(getattr(value, "items", None))
-    )
 
 
 def _mapping_to_dict(value: Any) -> dict[str, Any]:
@@ -2181,7 +2021,9 @@ def _resolve_dataproto_field_selection(
         )
     if fields is not None:
         requested = list(fields)
-        _validate_dataproto_fields_exist(ref, requested)
+        missing = [name for name in requested if name not in ref.field_index]
+        if missing:
+            raise KeyError(f"unknown DataProto fields: {missing}")
         return (
             [name for name in requested if ref.field_index[name].section == "batch"],
             [
@@ -2206,16 +2048,10 @@ def _resolve_dataproto_field_selection(
         non_tensor_names = (
             [] if non_tensor_fields is None else list(non_tensor_fields)
         )
-    _validate_dataproto_fields_exist(ref, [*batch_names, *non_tensor_names])
-    return batch_names, non_tensor_names
-
-
-def _validate_dataproto_fields_exist(
-    ref: MooncakeDataProtoRef, names: Sequence[str]
-) -> None:
-    missing = [name for name in names if name not in ref.field_index]
+    missing = [name for name in [*batch_names, *non_tensor_names] if name not in ref.field_index]
     if missing:
         raise KeyError(f"unknown DataProto fields: {missing}")
+    return batch_names, non_tensor_names
 
 
 def _coerce_dataproto_row_selection(
@@ -2227,16 +2063,18 @@ def _coerce_dataproto_row_selection(
         if rows.axis != 0:
             raise ValueError("DataProto row slicing currently supports axis=0 only")
         _normalized_member_slice(rows, total_rows)
+        s, e, st = _normalized_member_slice(rows, total_rows)
         return _DataProtoRowSelection(
-            count=_slice_length(rows, total_rows), member_slice=rows
+            count=max(0, 1 + (e - 1 - s) // st) if s < e else 0, member_slice=rows
         )
     if isinstance(rows, slice):
         start, end, step = rows.indices(total_rows)
         if step <= 0:
             raise ValueError("DataProto row slicing step must be positive")
         member_slice = StructuredMemberSlice(axis=0, start=start, end=end, step=step)
+        s, e, st = _normalized_member_slice(member_slice, total_rows)
         return _DataProtoRowSelection(
-            count=_slice_length(member_slice, total_rows), member_slice=member_slice
+            count=max(0, 1 + (e - 1 - s) // st) if s < e else 0, member_slice=member_slice
         )
     if isinstance(rows, Sequence) and not isinstance(rows, (str, bytes, bytearray)):
         indices = tuple(_normalize_dataproto_row_index(index, total_rows) for index in rows)
@@ -2255,51 +2093,6 @@ def _normalize_dataproto_row_index(index: Any, total_rows: int) -> int:
     return normalized
 
 
-def _slice_length(member_slice: StructuredMemberSlice, total_rows: int) -> int:
-    start, end, step = _normalized_member_slice(member_slice, total_rows)
-    if start >= end:
-        return 0
-    return 1 + (end - 1 - start) // step
-
-
-def _select_mapping(
-    value: Mapping[str, Any], keys: Optional[Sequence[str]]
-) -> dict[str, Any]:
-    if keys is None:
-        return dict(value)
-    return {key: value[key] for key in keys if key in value}
-
-
-def _schema_requires_non_tensor_encoding(
-    value: Any, schema: Optional[FieldSchema]
-) -> bool:
-    if schema is None:
-        return False
-    if isinstance(value, np.ndarray) and value.dtype != object and schema.codec in {"auto", "ndarray"}:
-        # Numeric ndarrays should stay on the typed ndarray path: _encode_structured_field
-        # already records dtype/shape and materializes a contiguous byte view only when
-        # needed.  Routing through structured non-tensor codecs would add payload/null
-        # buffers without improving correctness or transfer locality.  For other
-        # explicit codecs, do not silently ignore the caller's schema.
-        return False
-    return True
-
-
-def _coerce_non_tensor_value_for_encoding(name: str, value: Any) -> np.ndarray:
-    if isinstance(value, np.ndarray):
-        return value
-    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
-        array = np.empty(len(value), dtype=object)
-        array[:] = list(value)
-        return array
-    raise TypeError(
-        f"non_tensor_batch field {name!r} with FieldSchema must be an ndarray or non-string sequence"
-    )
-
-
-def _should_encode_non_tensor_field(value: Any) -> bool:
-    return isinstance(value, np.ndarray) and value.dtype == object
-
 
 # ---------------------------------------------------------------------------
 # Schema-driven encoding dispatch
@@ -2307,23 +2100,6 @@ def _should_encode_non_tensor_field(value: Any) -> bool:
 
 
 _ENCODING_FALLBACK_ERRORS = (TypeError, ValueError, AttributeError, OverflowError)
-
-
-def _encode_with_schema_or_fallback(
-    path: str, value: np.ndarray, schema: FieldSchema
-) -> "_EncodedStructuredLeaf":
-    try:
-        return _encode_with_schema(path, value, schema)
-    except _ENCODING_FALLBACK_ERRORS:
-        if schema.codec == "auto":
-            raise
-        try:
-            return _encode_with_fallback(path, value)
-        except _ENCODING_FALLBACK_ERRORS as fallback_error:
-            raise ValueError(
-                f"unable to encode structured non-tensor field {path!r} with "
-                f"schema codec {schema.codec!r} or automatic fallback"
-            ) from fallback_error
 
 
 def _encode_with_schema(
@@ -2350,9 +2126,7 @@ def _encode_with_schema(
             True, "ndarray", "schema", "numeric scalar", {"dtype": str(dtype)}
         )
         payload, metadata = _encode_numeric_scalar_values(values, decision)
-    elif codec == "bytes_ragged":
-        payload, metadata = _encode_bytes_like_values(values)
-    elif codec == "media_bytes":
+    elif codec in ("bytes_ragged", "media_bytes"):
         payload, metadata = _encode_bytes_like_values(values)
     elif codec == "media_list_ragged":
         payload, metadata = _encode_media_list_values(values)
@@ -2386,7 +2160,11 @@ def _encode_recursive_if_structured(
     leaves: list[_InferredLeaf] = []
     nodes: list[_InferredNode] = []
     infer_structure(path, values, leaves, nodes)
-    if not nodes or not any(_should_encode_recursive_leaf(leaf) for leaf in leaves):
+    if not nodes or not any(
+        (leaf.decision.codec == "typed_ragged" and leaf.decision.metadata.get("recursive_source") == "ndarray")
+        or leaf.decision.codec in {"ragged_tensor", "bytes_ragged", "media_bytes", "media_list_ragged"}
+        for leaf in leaves
+    ):
         return None
     payload: dict[str, Any] = {}
     node_specs: list[dict[str, Any]] = []
@@ -2467,12 +2245,6 @@ def _encode_recursive_if_structured(
     )
 
 
-def _should_encode_recursive_leaf(leaf: "_InferredLeaf") -> bool:
-    if leaf.decision.codec == "typed_ragged":
-        return leaf.decision.metadata.get("recursive_source") == "ndarray"
-    return leaf.decision.codec in {"ragged_tensor", "bytes_ragged", "media_bytes", "media_list_ragged"}
-
-
 def _encode_with_fallback(path: str, value: np.ndarray) -> "_EncodedStructuredLeaf":
     """Encode using safe type-based fallbacks, with recursive expansion for structured rows."""
     values = list(value)
@@ -2485,7 +2257,7 @@ def _encode_with_fallback(path: str, value: np.ndarray) -> "_EncodedStructuredLe
         errors.append(f"structured_recursive: {error}")
     decision = _choose_leaf_codec(values)
     codecs = [decision.codec]
-    for codec in _fallback_codec_chain(decision.codec):
+    for codec in ("msgpack_ragged", "json_ragged"):
         if codec not in codecs:
             codecs.append(codec)
     for codec in codecs:
@@ -2500,12 +2272,6 @@ def _encode_with_fallback(path: str, value: np.ndarray) -> "_EncodedStructuredLe
         f"unable to infer a safe codec for structured non-tensor field {path!r}; "
         f"tried {errors}"
     )
-
-
-def _fallback_codec_chain(codec: str) -> tuple[str, ...]:
-    if codec in {"bytes_ragged", "media_bytes", "media_list_ragged"}:
-        return ("msgpack_ragged", "json_ragged")
-    return ("msgpack_ragged", "json_ragged")
 
 
 def _normalize_values_for_fallback_codec(values: list[Any], codec: str) -> list[Any]:
@@ -2527,15 +2293,9 @@ def _normalize_structured_scalar(value: Any) -> Any:
         return value.item()
     if isinstance(value, Mapping):
         return {key: _normalize_structured_scalar(item) for key, item in value.items()}
-    if isinstance(value, tuple):
-        return [_normalize_structured_scalar(item) for item in value]
-    if isinstance(value, list):
+    if isinstance(value, (tuple, list)):
         return [_normalize_structured_scalar(item) for item in value]
     return value
-
-
-def _is_recursive_encoded_non_tensor(encoded: Mapping[str, Any]) -> bool:
-    return encoded.get("codec") == "structured_recursive"
 
 
 def _decode_structured_non_tensor_encoded(
@@ -2549,19 +2309,11 @@ def _decode_structured_non_tensor_encoded(
         return _decode_ragged_tensor_dict_values(
             payload, rows, metadata or encoded.get("metadata", {})
         )
-    if _is_recursive_encoded_non_tensor(encoded):
+    if encoded.get("codec") == "structured_recursive":
         if metadata is not None:
             encoded = {**encoded, "metadata": metadata}
         return _decode_structured_recursive_field(encoded, payload, rows)
     return _decode_structured_leaf(encoded["codec"], payload, rows, metadata)
-
-
-def _copy_recursive_metadata_for_leaf_updates(
-    metadata: Mapping[str, Any]
-) -> dict[str, Any]:
-    copied = dict(metadata)
-    copied["leaves"] = [dict(leaf) for leaf in metadata.get("leaves", [])]
-    return copied
 
 
 def _decode_structured_recursive_field(
@@ -2688,12 +2440,12 @@ def _encode_ragged_tensor_values(
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     if _torch is None:
         raise RuntimeError("torch is required to encode ragged tensor fields")
-    tensors: list[Any] = []
-    dtype = None
-    max_ndim = 0
+    # Determine torch dtype and convert all values to numpy arrays.
+    torch_dtype = None
+    converted: list[Any] = []
     for value in values:
         if value is None:
-            tensors.append(None)
+            converted.append(None)
             continue
         if isinstance(value, np.ndarray):
             if value.dtype == object:
@@ -2705,61 +2457,15 @@ def _encode_ragged_tensor_values(
             tensor = value.detach()
         if tensor.device.type != "cpu" or not tensor.is_contiguous():
             tensor = tensor.cpu().contiguous()
-        dtype = tensor.dtype if dtype is None else dtype
-        if tensor.dtype != dtype:
-            raise ValueError(f"mixed tensor dtype: {dtype} vs {tensor.dtype}")
-        max_ndim = max(max_ndim, tensor.dim())
-        tensors.append(tensor)
-    offsets = _torch.zeros(len(tensors) + 1, dtype=_torch.int64)
-    ndims = _torch.zeros(len(tensors), dtype=_torch.int16)
-    shapes = _torch.zeros((len(tensors), max(max_ndim, 1)), dtype=_torch.int64)
-    nulls = np.asarray([tensor is None for tensor in tensors], dtype=np.bool_)
-    flat_parts = []
-    offset = 0
-    for row, tensor in enumerate(tensors):
-        if tensor is None:
-            offsets[row + 1] = offset
-            continue
-        flat = tensor.reshape(-1)
-        flat_parts.append(flat)
-        offset += flat.numel()
-        offsets[row + 1] = offset
-        ndims[row] = tensor.dim()
-        if tensor.dim() > 0:
-            shapes[row, : tensor.dim()] = _torch.tensor(
-                list(tensor.shape), dtype=_torch.int64
-            )
-    data_dtype = dtype or _parse_torch_dtype(_RAGGED_TENSOR_DEFAULT_DTYPE)
-    np_dtype = _torch_dtype_to_numpy(str(data_dtype))
-    total_elems = int(offset)
-    # Zero-copy: scatter-gather from original tensor memory, no concatenation
-    if flat_parts:
-        buffers = tuple(memoryview(flat.numpy().data).cast("B") for flat in flat_parts)
-        owners = tuple(
-            flat_parts
-        )  # keep flat tensors alive (they reference original data)
-        data = _MultiBufferPayload(
-            buffers=buffers, owners=owners,
-            dtype=np.dtype(np_dtype).str, shape=(total_elems,),
-        )
-    else:
-        empty = np.empty(0, dtype=np_dtype)
-        data = _MultiBufferPayload(
-            buffers=(memoryview(empty.data).cast("B"),), owners=(empty,),
-            dtype=np.dtype(np_dtype).str, shape=(0,),
-        )
-    payload = {
-        "data": data,
-        "offsets": offsets.numpy(),
-        "shapes": shapes.numpy(),
-        "ndims": ndims.numpy(),
-        "nulls": nulls,
-    }
-    return payload, {
-        "dtype": str(data_dtype),
-        "max_ndim": int(max_ndim),
-        "shape_policy": "ragged",
-    }
+        torch_dtype = tensor.dtype if torch_dtype is None else torch_dtype
+        if tensor.dtype != torch_dtype:
+            raise ValueError(f"mixed tensor dtype: {torch_dtype} vs {tensor.dtype}")
+        converted.append(tensor.numpy())
+    data_dtype = torch_dtype or _parse_torch_dtype(_RAGGED_TENSOR_DEFAULT_DTYPE)
+    np_dtype = np.dtype(_torch_dtype_to_numpy(str(data_dtype)))
+    payload, meta = _encode_typed_ragged_values(converted, np_dtype)
+    meta["dtype"] = str(data_dtype)
+    return payload, meta
 
 
 def _decode_ragged_tensor_values(
@@ -2767,38 +2473,23 @@ def _decode_ragged_tensor_values(
 ) -> list[Any]:
     if _torch is None:
         raise RuntimeError("torch is required to decode ragged tensor fields")
-    raw = payload["data"]
+    # Metadata stores torch dtype strings (e.g. "torch.int64"); convert to numpy
+    # dtype so _decode_typed_ragged_values can parse it.
     dtype_str = (metadata or {}).get("dtype", _RAGGED_TENSOR_DEFAULT_DTYPE)
+    np_dtype = _torch_dtype_to_numpy(dtype_str)
+    patched_meta = dict(metadata) if metadata else {}
+    patched_meta["dtype"] = str(np_dtype)
+    np_values = _decode_typed_ragged_values(payload, rows, patched_meta)
     torch_dtype = _parse_torch_dtype(dtype_str)
-    if isinstance(raw, (bytes, bytearray, memoryview)):
-        buf = bytearray(raw) if isinstance(raw, (bytes, memoryview)) else raw
-        data = _torch.frombuffer(buf, dtype=torch_dtype)
-    elif _torch is not None and isinstance(raw, _torch.Tensor):
-        data = raw if raw.dtype == torch_dtype else raw.to(torch_dtype)
-    elif isinstance(raw, np.ndarray):
-        np_dtype = _torch_dtype_to_numpy(dtype_str)
-        if raw.dtype != np_dtype:
-            raw = np.frombuffer(raw, dtype=np_dtype)
-        data = _torch.from_numpy(raw)
-        if data.dtype != torch_dtype:
-            data = data.view(torch_dtype)
-    else:
-        data = _torch.from_numpy(np.asarray(raw))
-    offsets = payload["offsets"]
-    shapes = payload["shapes"]
-    ndims = payload["ndims"]
-    nulls = payload["nulls"]
-    values = []
-    for row in range(rows):
-        if bool(nulls[row]):
-            values.append(None)
-            continue
-        begin = int(offsets[row])
-        end = int(offsets[row + 1])
-        ndim = int(ndims[row])
-        shape = tuple(int(v) for v in shapes[row, :ndim].tolist())
-        values.append(data[begin:end].reshape(shape))
-    return values
+    result: list[Any] = []
+    for v in np_values:
+        if v is None:
+            result.append(None)
+        elif isinstance(v, np.ndarray):
+            result.append(_torch.from_numpy(v).to(torch_dtype))
+        else:
+            result.append(_torch.as_tensor(v, dtype=torch_dtype))
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -4269,9 +3960,9 @@ class _BundleManifestStore:
             for ck, chunk in zip(chunk_keys, chunks):
                 _deferred.append((ck, [chunk]))
         else:
-            self._transport.put_payload_chunks(
+            self._transport.put_multi_buffer_payload_chunks(
                 chunk_keys,
-                chunks,
+                [[c] for c in chunks],
                 transfer_policy,
             )
         payload_spec = {
@@ -4565,8 +4256,19 @@ class _MooncakePayloadTransport:
         self._get_into = getattr(store, "get_into", None)
         self._get_into_ranges = getattr(store, "get_into_ranges", None)
 
+    def _store_can_auto_create_buffer_pool(self) -> bool:
+        get_capsule = getattr(self._store, "_get_pyclient_capsule", None)
+        if not callable(get_capsule):
+            return False
+        try:
+            return get_capsule() is not None
+        except Exception:
+            return False
+
     def _ensure_buffer_pool(self) -> Any:
         if self._buffer_pool is None:
+            if not self._store_can_auto_create_buffer_pool():
+                return None
             try:
                 from mooncake.buffer_pool import BufferPool
 
@@ -4574,16 +4276,6 @@ class _MooncakePayloadTransport:
             except (ImportError, AttributeError, RuntimeError, TypeError):
                 return None
         return self._buffer_pool
-
-    def put_payload_chunks(
-        self,
-        chunk_keys: Sequence[str],
-        chunks: Sequence[memoryview],
-        transfer_policy: BundleTransferPolicy,
-    ) -> list[str]:
-        return self.put_multi_buffer_payload_chunks(
-            chunk_keys, [[c] for c in chunks], transfer_policy
-        )
 
     def put_multi_buffer_payload_chunks(
         self,
@@ -4602,7 +4294,7 @@ class _MooncakePayloadTransport:
         if transfer_policy.copy_mode == "copy" or self._ensure_buffer_pool() is None:
             return fallback_to_direct_put()
         if all(len(group) == 1 for group in chunk_groups):
-            self.batch_put_chunks_from(chunk_keys, [group[0] for group in chunk_groups])
+            self.batch_put_buffer_groups_from(chunk_keys, [[group[0]] for group in chunk_groups])
             return list(chunk_keys)
         if not callable(self._batch_put_from):
             return fallback_to_direct_put()
@@ -4900,13 +4592,6 @@ class _MooncakePayloadTransport:
             if view is not None:
                 view.release()
             lease.release()
-
-    def batch_put_chunks_from(
-        self,
-        chunk_keys: Sequence[str],
-        chunks: Sequence[memoryview],
-    ) -> None:
-        self.batch_put_buffer_groups_from(chunk_keys, [[chunk] for chunk in chunks])
 
     def batch_put_buffer_groups_from(
         self,
@@ -5334,10 +5019,6 @@ class _MooncakePayloadTransport:
             return "batch"
         return "parallel"
 
-    def _has_batch_put_support(self) -> bool:
-        return callable(self._batch_put_from)
-
-
 def _resolve_ndarray_destination(
     name: str,
     destination: Any,
@@ -5639,15 +5320,7 @@ def _encode_structured_field(value: Any) -> tuple[dict[str, Any], Any]:
         return {"encoding": "torch_tensor"}, value
     if isinstance(value, _TensorPayload):
         return _encode_torch_tensor_field(value.tensor)
-    if isinstance(value, _DirectCopyPayload):
-        if value.dtype is not None and value.shape is not None:
-            return {
-                "encoding": "ndarray",
-                "dtype": value.dtype,
-                "shape": list(value.shape),
-            }, value
-        return _BYTES_FIELD_SPEC, value
-    if isinstance(value, _MultiBufferPayload):
+    if isinstance(value, (_DirectCopyPayload, _MultiBufferPayload)):
         if value.dtype is not None and value.shape is not None:
             return {
                 "encoding": "ndarray",

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -808,9 +808,7 @@ class MooncakeBundleTransfer:
         metadata = _decode_structured_metadata(
             self._bundle_store.read_payload(manifest["meta"])
         )
-        field_spec = _structured_field_specs(metadata).get(
-            member, {"encoding": "bytes"}
-        )
+        field_spec = _structured_field_specs(metadata).get(member, {"encoding": "bytes"})
         payload_spec = manifest["buffers"][member]
         encoding = field_spec.get("encoding", "bytes")
         if encoding == "ndarray":
@@ -840,9 +838,7 @@ class MooncakeBundleTransfer:
         dtype_obj = np.dtype(dtype)
         full_shape = tuple(int(dim) for dim in shape)
         if not full_shape:
-            raise ValueError(
-                "structured ndarray indexed read requires at least one dimension"
-            )
+            raise ValueError("structured ndarray indexed read requires at least one dimension")
         output_shape = (len(indices), *full_shape[1:])
         if isinstance(destination, _RawDestinationBuffer):
             nbytes = int(np.prod(output_shape, dtype=np.int64)) * dtype_obj.itemsize
@@ -859,9 +855,7 @@ class MooncakeBundleTransfer:
             )
             if not indices:
                 return target
-            row_width = dtype_obj.itemsize * int(
-                np.prod(full_shape[1:], dtype=np.int64)
-            )
+            row_width = dtype_obj.itemsize * int(np.prod(full_shape[1:], dtype=np.int64))
             ranges = [
                 (row * row_width, out * row_width, row_width)
                 for out, row in enumerate(indices)
@@ -878,9 +872,7 @@ class MooncakeBundleTransfer:
                 ctypes.memmove(destination.ptr, bytes(data), nbytes)
             _ = destination.owner
             return target
-        target = _resolve_ndarray_destination(
-            name, destination, dtype_obj, output_shape
-        )
+        target = _resolve_ndarray_destination(name, destination, dtype_obj, output_shape)
         if not indices:
             return target
         row_width = dtype_obj.itemsize * int(np.prod(full_shape[1:], dtype=np.int64))
@@ -910,24 +902,17 @@ class MooncakeBundleTransfer:
                 f"structured tensor field {name} is missing slice metadata"
             )
         if not shape:
-            raise ValueError(
-                "structured tensor indexed read requires at least one dimension"
-            )
+            raise ValueError("structured tensor indexed read requires at least one dimension")
         row_width = element_size * int(np.prod(shape[1:], dtype=np.int64))
         data_length = len(indices) * row_width
-        metadata = self._bundle_store.read_payload_range(
-            payload_spec, 0, metadata_bytes
-        )
+        metadata = self._bundle_store.read_payload_range(payload_spec, 0, metadata_bytes)
         sliced_metadata = _slice_tensor_metadata(
             metadata, (len(indices), *shape[1:]), data_length
         )
         if destination is not None:
-            if not isinstance(
-                destination, (_TensorObjectBufferPayload, _RawDestinationBuffer)
-            ):
+            if not isinstance(destination, (_TensorObjectBufferPayload, _RawDestinationBuffer)):
                 raise ValueError(
-                    f"structured tensor member {name} only supports tensor_object_buffer "
-                    "or raw_destination destinations"
+                    f"structured tensor member {name} only supports tensor_object_buffer or raw_destination destinations"
                 )
             expected_bytes = metadata_bytes + data_length
             if destination.size < expected_bytes:
@@ -971,10 +956,7 @@ class MooncakeBundleTransfer:
             self._bundle_store.read_payload_ranges_into_bytearray(
                 payload_spec,
                 data,
-                [
-                    (metadata_bytes + row * row_width, out * row_width, row_width)
-                    for out, row in enumerate(indices)
-                ],
+                [(metadata_bytes + row * row_width, out * row_width, row_width) for out, row in enumerate(indices)],
             )
         return _deserialize_tensor_payload(sliced_metadata + data)
 
@@ -1005,9 +987,7 @@ class MooncakeBundleTransfer:
                 )
             return np.dtype(dtype)
 
-        def read_member_indices(
-            payload_name: str, member_indices: Sequence[int]
-        ) -> Any:
+        def read_member_indices(payload_name: str, member_indices: Sequence[int]) -> Any:
             return self._read_dataproto_member_indices(
                 stage_ref, member(payload_name), member_indices, None
             )
@@ -1281,9 +1261,7 @@ class MooncakeBundleTransfer:
                 for key in ("missing_payload", "row_mask_payload", "lengths_payload"):
                     payload_name = node.get(key)
                     if payload_name is not None:
-                        recursive_payload[payload_name] = read_member(
-                            payload_name, start, end
-                        )
+                        recursive_payload[payload_name] = read_member(payload_name, start, end)
             for leaf in metadata.get("leaves", []):
                 leaf_payload_members = leaf["payload_members"]
                 flat_payload_members = {
@@ -1971,13 +1949,9 @@ def _coerce_dataproto_row_selection(
             count=_slice_length(member_slice, total_rows), member_slice=member_slice
         )
     if isinstance(rows, Sequence) and not isinstance(rows, (str, bytes, bytearray)):
-        indices = tuple(
-            _normalize_dataproto_row_index(index, total_rows) for index in rows
-        )
+        indices = tuple(_normalize_dataproto_row_index(index, total_rows) for index in rows)
         return _DataProtoRowSelection(count=len(indices), indices=indices)
-    raise TypeError(
-        "DataProto rows must be a slice, StructuredMemberSlice, or row index sequence"
-    )
+    raise TypeError("DataProto rows must be a slice, StructuredMemberSlice, or row index sequence")
 
 
 def _normalize_dataproto_row_index(index: Any, total_rows: int) -> int:
@@ -1987,9 +1961,7 @@ def _normalize_dataproto_row_index(index: Any, total_rows: int) -> int:
     if normalized < 0:
         normalized += total_rows
     if normalized < 0 or normalized >= total_rows:
-        raise IndexError(
-            f"DataProto row index {index} out of range for {total_rows} rows"
-        )
+        raise IndexError(f"DataProto row index {index} out of range for {total_rows} rows")
     return normalized
 
 
@@ -3163,12 +3135,9 @@ class _StructuredObjectLayer:
                 name, payload_spec, field_spec, member_slice, destination
             )
         if destination is not None:
-            if not isinstance(
-                destination, (_TensorObjectBufferPayload, _RawDestinationBuffer)
-            ):
+            if not isinstance(destination, (_TensorObjectBufferPayload, _RawDestinationBuffer)):
                 raise ValueError(
-                    f"structured tensor member {name} only supports tensor_object_buffer "
-                    "or raw_destination destinations"
+                    f"structured tensor member {name} only supports tensor_object_buffer or raw_destination destinations"
                 )
             materialized = self._bundle_store.read_tensor_payload_into(
                 payload_spec, destination
@@ -3218,12 +3187,9 @@ class _StructuredObjectLayer:
             metadata, (end - start, *shape[1:]), data_length
         )
         if destination is not None:
-            if not isinstance(
-                destination, (_TensorObjectBufferPayload, _RawDestinationBuffer)
-            ):
+            if not isinstance(destination, (_TensorObjectBufferPayload, _RawDestinationBuffer)):
                 raise ValueError(
-                    f"structured tensor member {name} only supports tensor_object_buffer "
-                    "or raw_destination destinations"
+                    f"structured tensor member {name} only supports tensor_object_buffer or raw_destination destinations"
                 )
             expected_bytes = metadata_bytes + data_length
             if destination.size < expected_bytes:
@@ -3642,9 +3608,7 @@ class _BundleManifestStore:
     ) -> None:
         if not ranges:
             return
-        self._transport.read_payload_ranges_into_array(
-            payload_spec, destination, ranges
-        )
+        self._transport.read_payload_ranges_into_array(payload_spec, destination, ranges)
 
     def read_payload_ranges_into_bytearray(
         self,
@@ -3824,9 +3788,7 @@ class _BundleManifestStore:
         if not isinstance(buffer_object_ids, list) or not all(
             isinstance(item, str) for item in buffer_object_ids
         ):
-            raise ValueError(
-                "bundle manifest buffer_object_ids must be a list of strings"
-            )
+            raise ValueError("bundle manifest buffer_object_ids must be a list of strings")
         allowed_buffer_base_keys = [
             f"{self._key_prefix}/{buffer_object_id}"
             for buffer_object_id in buffer_object_ids
@@ -3837,9 +3799,7 @@ class _BundleManifestStore:
             self._is_allowed_cleanup_key(item, allowed_buffer_base_keys)
             for item in cleanup_keys
         ):
-            raise ValueError(
-                "bundle manifest cleanup_keys are outside the bundle namespace"
-            )
+            raise ValueError("bundle manifest cleanup_keys are outside the bundle namespace")
         buffers = manifest.get("buffers")
         if not isinstance(buffers, dict):
             raise ValueError("bundle manifest buffers must be a dict")
@@ -3865,9 +3825,7 @@ class _BundleManifestStore:
         payload_key = payload_spec.get("key")
         if not isinstance(payload_key, str) or (
             base_keys is not None
-            and not any(
-                payload_key.startswith(f"{base_key}/") for base_key in base_keys
-            )
+            and not any(payload_key.startswith(f"{base_key}/") for base_key in base_keys)
         ):
             raise ValueError("bundle payload key is outside the bundle namespace")
         expected_bytes = int(payload_spec.get("bytes", -1))
@@ -4543,9 +4501,7 @@ class _MooncakePayloadTransport:
         fragments = []
         for source_offset, destination_offset, byte_length in ranges:
             fragments.extend(
-                _payload_range_fragments(
-                    chunks, source_offset, byte_length, destination_offset
-                )
+                _payload_range_fragments(chunks, source_offset, byte_length, destination_offset)
             )
         if not fragments:
             return True

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -11,10 +11,8 @@ from typing import Any, Literal, Mapping, Optional, Protocol, Sequence
 
 import numpy as np
 
-try:
-    import mooncake.store as _mooncake_store
-except Exception:  # pragma: no cover - depends on built extension
-    _mooncake_store = None  # type: ignore[assignment]
+_mooncake_store: Any | None = None
+_mooncake_store_loaded = False
 
 import msgpack as _msgpack
 
@@ -34,6 +32,18 @@ _TYPED_RAGGED_DEFAULT_DTYPE = "float64"
 # format or unknown field).  Treated as opaque bytes by the read path.
 _BYTES_FIELD_SPEC: dict[str, str] = {"encoding": "bytes"}
 _INFER_MAX_DEPTH = 32
+
+
+def _get_mooncake_store() -> Any | None:
+    global _mooncake_store, _mooncake_store_loaded
+    if not _mooncake_store_loaded:
+        try:
+            import mooncake.store as store
+        except Exception:  # pragma: no cover - depends on built extension
+            store = None  # type: ignore[assignment]
+        _mooncake_store = store
+        _mooncake_store_loaded = True
+    return _mooncake_store
 _INFER_MAX_STRUCT_KEYS = 64
 _INFER_MAX_LIST_LEN = 8
 
@@ -57,12 +67,15 @@ class BundleTransferPolicy:
 
 @dataclass(frozen=True)
 class FieldSchema:
-    """Schema hint for a non_tensor_batch field, bypassing runtime inference.
+    """Schema hint for structured DataProto fields.
 
-    When provided to put_dataproto via field_schemas, the field will be encoded
-    using the specified codec without running any sample-based inference.
+    ``metadata["section"]`` may declare where a field belongs:
+    ``"batch"``, ``"non_tensor_batch"``, or ``"meta_info"``.  For
+    non_tensor_batch fields, ``codec`` selects the structured non-tensor encoder
+    without running sample-based inference.
 
     Supported codec values:
+      - "auto": use existing runtime codec inference for this non_tensor_batch field
       - "ragged_tensor_dict": list[dict[str, Tensor] | None]
       - "ragged_tensor": list[Tensor | None]
       - "typed_ragged": list[ndarray | list | None]
@@ -1382,7 +1395,7 @@ class MooncakeBundleTransfer:
         """Store a legacy rollout dict as a structured object."""
         return self._put_stage(
             None,
-            _legacy_dict_to_envelope(data),
+            _legacy_dict_to_envelope(data, field_schemas=field_schemas),
             namespace=namespace,
             partition=partition,
             stage=stage,
@@ -1496,9 +1509,7 @@ class MooncakeBundleTransfer:
         field_schemas: Optional[dict[str, FieldSchema]] = None,
     ) -> MooncakeDataProtoRef:
         batch, non_tensor_batch, meta_info = _split_dataproto_like(data)
-        _validate_dataproto_schema_sections(
-            batch, non_tensor_batch, meta_info, field_schemas
-        )
+        _validate_dataproto_schema_sections(batch, non_tensor_batch, meta_info, field_schemas)
         batch_size = _dataproto_batch_size(batch, non_tensor_batch)
         if ref is not None and batch_size != ref.batch_size:
             raise ValueError(
@@ -1517,14 +1528,14 @@ class MooncakeBundleTransfer:
             field_updates[name] = StructuredFieldLocation(stage, member, "batch")
         encoded_updates: dict[str, Any] = {}
         for name, value in non_tensor_batch.items():
-            if _should_encode_non_tensor_field(value):
-                schema = field_schemas.get(name) if field_schemas else None
+            schema = field_schemas.get(name) if field_schemas else None
+            if _should_encode_non_tensor_field(value) or _schema_requires_non_tensor_encoding(value, schema):
+                encode_value = _coerce_non_tensor_value_for_encoding(name, value)
+                path = f"non_tensor_batch.{name}"
                 if schema is not None:
-                    encoded = _encode_with_schema(
-                        f"non_tensor_batch.{name}", value, schema
-                    )
+                    encoded = _encode_with_schema_or_fallback(path, encode_value, schema)
                 else:
-                    encoded = _encode_with_fallback(f"non_tensor_batch.{name}", value)
+                    encoded = _encode_with_fallback(path, encode_value)
                 payload_members: dict[str, str] = {}
                 for payload_name, payload_value in encoded.payload.items():
                     member = f"non_tensor_batch.{name}.{payload_name}"
@@ -1715,36 +1726,106 @@ def _dataproto_manifest_view(
     }
 
 
-LEGACY_DICT_META_FIELDS = frozenset(
-    {
-        "raw_reward",
-        "total_lengths",
-        "global_batch_sizes",
-        "num_microbatches",
-        "micro_batch_indices",
-    }
-)
+_DATAPROTO_SCHEMA_SECTIONS = frozenset({"batch", "non_tensor_batch", "meta_info"})
 
 
-def _legacy_dict_to_envelope(data: Mapping[str, Any]) -> dict[str, Any]:
+def _schema_section(name: str, schema: FieldSchema) -> str | None:
+    section = schema.metadata.get("section")
+    if section is None:
+        return None
+    if section not in _DATAPROTO_SCHEMA_SECTIONS:
+        raise ValueError(
+            f"FieldSchema for {name!r} metadata['section'] must be one of "
+            f"{sorted(_DATAPROTO_SCHEMA_SECTIONS)}"
+        )
+    return section
+
+
+def _schema_ndarray_dtype(schema: FieldSchema) -> np.dtype[Any] | None:
+    dtype_name = schema.metadata.get("dtype")
+    if dtype_name is None:
+        return None
+    try:
+        dtype = np.dtype(dtype_name)
+    except (TypeError, ValueError):
+        return None
+    if dtype.kind not in "biufc":
+        return None
+    return dtype
+
+
+def _validate_dataproto_schema_sections(
+    batch: Mapping[str, Any],
+    non_tensor_batch: Mapping[str, Any],
+    meta_info: Mapping[str, Any],
+    field_schemas: Optional[Mapping[str, FieldSchema]],
+) -> None:
+    if not field_schemas:
+        return
+    for section, fields in (
+        ("batch", batch),
+        ("non_tensor_batch", non_tensor_batch),
+        ("meta_info", meta_info),
+    ):
+        for name in fields:
+            schema = field_schemas.get(name)
+            if schema is None:
+                continue
+            declared = _schema_section(name, schema)
+            if declared is None:
+                continue
+            if declared != section:
+                raise ValueError(
+                    f"FieldSchema for {name!r} declares section {declared!r}, "
+                    f"but data contains it in {section!r}"
+                )
+
+
+def _legacy_dict_to_envelope(
+    data: Mapping[str, Any],
+    field_schemas: Optional[Mapping[str, FieldSchema]] = None,
+) -> dict[str, Any]:
     if not isinstance(data, Mapping):
         raise TypeError("legacy rollout data must be a mapping")
-    partition = data.get("partition")
-    if not isinstance(partition, list):
-        raise ValueError("legacy rollout data must contain a list 'partition' field")
-    row_count = len(partition)
+    if field_schemas:
+        return _legacy_dict_to_envelope_with_schema(data, field_schemas)
+    return _legacy_dict_to_envelope_auto(data)
+
+
+def _legacy_dict_to_envelope_with_schema(
+    data: Mapping[str, Any], field_schemas: Mapping[str, FieldSchema]
+) -> dict[str, Any]:
+    schema_row_count = _legacy_schema_row_count(data, field_schemas)
+    row_count = schema_row_count
+    if row_count == 0:
+        schema_meta_fields = {
+            name
+            for name, schema in field_schemas.items()
+            if name in data and _schema_section(name, schema) == "meta_info"
+        }
+        row_count = _legacy_auto_row_count(data, exclude=schema_meta_fields)
     batch: dict[str, Any] = {}
     non_tensor_batch: dict[str, Any] = {}
     meta_info: dict[str, Any] = {}
     for key, value in data.items():
-        if key in LEGACY_DICT_META_FIELDS:
-            meta_info[key] = value
-        elif _is_row_aligned_dense_field(value, row_count):
+        schema = field_schemas.get(key)
+        section = None if schema is None else _schema_section(key, schema)
+        if section is None:
+            if _is_row_aligned_dense_field(value, row_count):
+                batch[key] = value
+            elif schema_row_count == 0 and _is_row_aligned_sequence(value, row_count):
+                non_tensor_batch[key] = _coerce_legacy_non_tensor_field(
+                    key, value, row_count, schema
+                )
+            else:
+                meta_info[key] = value
+            continue
+        if section == "batch":
             batch[key] = value
-        elif isinstance(value, list) and len(value) == row_count:
-            array = np.empty(row_count, dtype=object)
-            array[:] = value
-            non_tensor_batch[key] = array
+        elif section == "non_tensor_batch":
+            non_tensor_batch[key] = _coerce_legacy_non_tensor_field(
+                key, value, row_count, schema
+            )
         else:
             meta_info[key] = value
     return {
@@ -1752,6 +1833,123 @@ def _legacy_dict_to_envelope(data: Mapping[str, Any]) -> dict[str, Any]:
         "non_tensor_batch": non_tensor_batch,
         "meta_info": meta_info,
     }
+
+
+def _legacy_schema_row_count(
+    data: Mapping[str, Any], field_schemas: Mapping[str, FieldSchema]
+) -> int:
+    sizes = {
+        _field_len(name, data[name])
+        for name, schema in field_schemas.items()
+        if name in data and _schema_section(name, schema) in {"batch", "non_tensor_batch"}
+    }
+    if not sizes:
+        return 0
+    if len(sizes) != 1:
+        raise ValueError(f"legacy rollout fields have inconsistent batch sizes: {sorted(sizes)}")
+    return sizes.pop()
+
+
+def _field_len(name: str, value: Any) -> int:
+    try:
+        return len(value)
+    except TypeError as error:
+        raise ValueError(f"legacy row-aligned field {name!r} must be sized") from error
+
+
+def _coerce_legacy_non_tensor_field(
+    name: str, value: Any, row_count: int, schema: Optional[FieldSchema] = None
+) -> Any:
+    if isinstance(value, np.ndarray):
+        if len(value) != row_count:
+            raise ValueError(
+                f"legacy non_tensor_batch field {name!r} has batch size {len(value)}, expected {row_count}"
+            )
+        if _schema_prefers_direct_numeric_ndarray(schema, value):
+            return np.asarray(value, dtype=_schema_ndarray_dtype(schema))
+        return value
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        if len(value) != row_count:
+            raise ValueError(
+                f"legacy non_tensor_batch field {name!r} has batch size {len(value)}, expected {row_count}"
+            )
+        if _schema_prefers_direct_numeric_ndarray(schema, value):
+            # Scalar sequences and range objects have no contiguous backing buffer.
+            # When the actual values contain no nulls, materialize the typed ndarray
+            # once and then use the direct ndarray storage path instead of structured
+            # scalar encoding with an extra null bitmap.
+            return np.asarray(list(value), dtype=_schema_ndarray_dtype(schema))
+        array = np.empty(row_count, dtype=object)
+        array[:] = list(value)
+        return array
+    raise TypeError(
+        f"legacy non_tensor_batch field {name!r} must be an ndarray or non-string sequence"
+    )
+
+
+def _schema_prefers_direct_numeric_ndarray(
+    schema: Optional[FieldSchema], value: Any
+) -> bool:
+    if schema is None or schema.codec != "ndarray" or _schema_ndarray_dtype(schema) is None:
+        return False
+    if isinstance(value, np.ndarray):
+        return value.dtype != object or all(item is not None for item in value)
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return all(item is not None for item in value)
+    return False
+
+
+def _legacy_dict_to_envelope_auto(data: Mapping[str, Any]) -> dict[str, Any]:
+    row_count = _legacy_auto_row_count(data)
+    batch: dict[str, Any] = {}
+    non_tensor_batch: dict[str, Any] = {}
+    meta_info: dict[str, Any] = {}
+    for key, value in data.items():
+        if _is_row_aligned_dense_field(value, row_count):
+            batch[key] = value
+        elif _is_row_aligned_sequence(value, row_count):
+            non_tensor_batch[key] = _coerce_legacy_non_tensor_field(key, value, row_count)
+        else:
+            meta_info[key] = value
+    return {
+        "batch": batch,
+        "non_tensor_batch": non_tensor_batch,
+        "meta_info": meta_info,
+    }
+
+
+def _legacy_auto_row_count(
+    data: Mapping[str, Any], exclude: set[str] | frozenset[str] = frozenset()
+) -> int:
+    sizes = {
+        len(value)
+        for key, value in data.items()
+        if key not in exclude and _is_sized_row_candidate(value)
+    }
+    if not sizes:
+        return 0
+    if len(sizes) != 1:
+        raise ValueError(
+            f"legacy rollout fields have ambiguous batch sizes: {sorted(sizes)}; "
+            "pass FieldSchema metadata['section'] for list-valued metadata fields"
+        )
+    return sizes.pop()
+
+
+def _is_sized_row_candidate(value: Any) -> bool:
+    if _torch is not None and isinstance(value, _torch.Tensor):
+        return value.ndim > 0
+    if isinstance(value, np.ndarray):
+        return value.ndim > 0
+    return isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray))
+
+
+def _is_row_aligned_sequence(value: Any, row_count: int) -> bool:
+    return (
+        isinstance(value, Sequence)
+        and not isinstance(value, (str, bytes, bytearray))
+        and len(value) == row_count
+    )
 
 
 def _envelope_to_legacy_dict(data: Mapping[str, Any]) -> dict[str, Any]:
@@ -1964,105 +2162,31 @@ def _select_mapping(
     return {key: value[key] for key in keys if key in value}
 
 
-_DATAPROTO_SCHEMA_SECTIONS = frozenset({"batch", "non_tensor_batch", "meta_info"})
-_FIELD_SCHEMA_CODECS = frozenset({
-    "auto", "ragged_tensor_dict", "ragged_tensor", "typed_ragged", "ndarray",
-    "bytes_ragged", "media_bytes", "media_list_ragged", "utf8_ragged",
-    "msgpack_ragged", "json_ragged",
-})
-_RAGGED_TENSOR_PAYLOAD_NAMES = frozenset({"data", "offsets", "shapes", "ndims", "nulls"})
-
-
-def _schema_section(name: str, schema: FieldSchema) -> str | None:
-    section = schema.metadata.get("section")
-    if section is None:
-        return None
-    if section not in _DATAPROTO_SCHEMA_SECTIONS:
-        raise ValueError(
-            f"FieldSchema for {name!r} metadata['section'] must be one of "
-            f"{sorted(_DATAPROTO_SCHEMA_SECTIONS)}"
-        )
-    return section
-
-
-def _schema_for_section(
-    field_schemas: Optional[Mapping[str, FieldSchema]],
-    name: str,
-    section: str,
-) -> FieldSchema | None:
-    if not field_schemas:
-        return None
-    schema = field_schemas.get(name)
+def _schema_requires_non_tensor_encoding(
+    value: Any, schema: Optional[FieldSchema]
+) -> bool:
     if schema is None:
-        return None
-    declared = _schema_section(name, schema)
-    return schema if declared is None or declared == section else None
+        return False
+    if isinstance(value, np.ndarray) and value.dtype != object and schema.codec in {"auto", "ndarray"}:
+        # Numeric ndarrays should stay on the typed ndarray path: _encode_structured_field
+        # already records dtype/shape and materializes a contiguous byte view only when
+        # needed.  Routing through structured non-tensor codecs would add payload/null
+        # buffers without improving correctness or transfer locality.  For other
+        # explicit codecs, do not silently ignore the caller's schema.
+        return False
+    return True
 
 
-def _schema_ndarray_dtype(
-    schema: FieldSchema, *, required: bool = False
-) -> np.dtype[Any] | None:
-    dtype_name = schema.metadata.get("dtype")
-    if dtype_name is None:
-        if required:
-            raise ValueError("FieldSchema metadata['dtype'] is required")
-        return None
-    try:
-        dtype = np.dtype(dtype_name)
-    except (TypeError, ValueError) as exc:
-        raise ValueError(f"invalid FieldSchema metadata['dtype']: {dtype_name!r}") from exc
-    if dtype.kind not in "biufc":
-        raise ValueError(
-            f"FieldSchema metadata['dtype'] must be numeric or bool, got {dtype}"
-        )
-    return dtype
-
-
-def _validate_dataproto_schema_sections(
-    batch: Mapping[str, Any],
-    non_tensor_batch: Mapping[str, Any],
-    meta_info: Mapping[str, Any],
-    field_schemas: Optional[Mapping[str, FieldSchema]],
-) -> None:
-    if not field_schemas:
-        return
-    sections = {
-        "batch": batch,
-        "non_tensor_batch": non_tensor_batch,
-        "meta_info": meta_info,
-    }
-    actual_sections: dict[str, set[str]] = {}
-    for section, fields in sections.items():
-        for name in fields:
-            actual_sections.setdefault(name, set()).add(section)
-    for name, schema in field_schemas.items():
-        declared = _schema_section(name, schema)
-        if declared is None:
-            continue
-        actual = actual_sections.get(name)
-        if not actual or declared in actual:
-            continue
-        actual_text = ", ".join(repr(section) for section in sorted(actual))
-        raise ValueError(
-            f"FieldSchema for {name!r} declares section {declared!r}, "
-            f"but data contains it in {actual_text}"
-        )
-
-def _coerce_schema_non_tensor_value(name: str, value: Any) -> np.ndarray:
+def _coerce_non_tensor_value_for_encoding(name: str, value: Any) -> np.ndarray:
     if isinstance(value, np.ndarray):
         return value
     if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
-        result = np.empty(len(value), dtype=object)
-        result[:] = list(value)
-        return result
+        array = np.empty(len(value), dtype=object)
+        array[:] = list(value)
+        return array
     raise TypeError(
         f"non_tensor_batch field {name!r} with FieldSchema must be an ndarray or non-string sequence"
     )
-
-
-def _validate_schema_nullable(path: str, value: np.ndarray, schema: FieldSchema) -> None:
-    if not schema.nullable and any(item is None for item in value):
-        raise ValueError(f"FieldSchema for {path!r} is not nullable")
 
 
 def _should_encode_non_tensor_field(value: Any) -> bool:
@@ -2074,12 +2198,34 @@ def _should_encode_non_tensor_field(value: Any) -> bool:
 # ---------------------------------------------------------------------------
 
 
+_ENCODING_FALLBACK_ERRORS = (TypeError, ValueError, AttributeError, OverflowError)
+
+
+def _encode_with_schema_or_fallback(
+    path: str, value: np.ndarray, schema: FieldSchema
+) -> "_EncodedStructuredLeaf":
+    try:
+        return _encode_with_schema(path, value, schema)
+    except _ENCODING_FALLBACK_ERRORS:
+        if schema.codec == "auto":
+            raise
+        try:
+            return _encode_with_fallback(path, value)
+        except _ENCODING_FALLBACK_ERRORS as fallback_error:
+            raise ValueError(
+                f"unable to encode structured non-tensor field {path!r} with "
+                f"schema codec {schema.codec!r} or automatic fallback"
+            ) from fallback_error
+
+
 def _encode_with_schema(
     path: str, value: np.ndarray, schema: FieldSchema
 ) -> "_EncodedStructuredLeaf":
     """Encode a non_tensor_batch field using an explicit schema (no inference)."""
     values = list(value)
     codec = schema.codec
+    if codec == "auto":
+        return _encode_with_fallback(path, value)
     if codec == "ragged_tensor_dict":
         return _encode_ragged_tensor_dict_values(values, schema)
     if codec == "ragged_tensor":
@@ -2087,8 +2233,11 @@ def _encode_with_schema(
     elif codec == "typed_ragged":
         payload, metadata = _encode_typed_ragged_values(values)
     elif codec == "ndarray":
+        dtype = _schema_ndarray_dtype(schema)
+        if dtype is None:
+            return _encode_with_fallback(path, value)
         decision = _CodecDecision(
-            True, "ndarray", "schema", "numeric scalar", schema.metadata
+            True, "ndarray", "schema", "numeric scalar", {"dtype": str(dtype)}
         )
         payload, metadata = _encode_numeric_scalar_values(values, decision)
     elif codec == "bytes_ragged":
@@ -2182,7 +2331,10 @@ def _encode_recursive_if_structured(
             decision = _CodecDecision(True, "json_ragged", "all rows are null or missing", "json")
         encoded = _encode_with_schema(
             leaf.path,
-            np.asarray(codec_values, dtype=object),
+            np.asarray(
+                _normalize_values_for_fallback_codec(codec_values, decision.codec),
+                dtype=object,
+            ),
             FieldSchema(codec=decision.codec, metadata=decision.metadata),
         )
         leaf_payload_members: dict[str, str] = {}
@@ -2224,15 +2376,64 @@ def _should_encode_recursive_leaf(leaf: "_InferredLeaf") -> bool:
 
 
 def _encode_with_fallback(path: str, value: np.ndarray) -> "_EncodedStructuredLeaf":
-    """Encode using type-based fallback (delegates to _choose_leaf_codec), with recursive expansion for structured rows."""
+    """Encode using safe type-based fallbacks, with recursive expansion for structured rows."""
     values = list(value)
-    recursive = _encode_recursive_if_structured(path, values)
-    if recursive is not None:
-        return recursive
+    errors: list[str] = []
+    try:
+        recursive = _encode_recursive_if_structured(path, values)
+        if recursive is not None:
+            return recursive
+    except _ENCODING_FALLBACK_ERRORS as error:
+        errors.append(f"structured_recursive: {error}")
     decision = _choose_leaf_codec(values)
-    metadata = dict(decision.metadata or {})
-    schema = FieldSchema(codec=decision.codec, metadata=metadata)
-    return _encode_with_schema(path, value, schema)
+    codecs = [decision.codec]
+    for codec in _fallback_codec_chain(decision.codec):
+        if codec not in codecs:
+            codecs.append(codec)
+    for codec in codecs:
+        metadata = dict(decision.metadata or {}) if codec == decision.codec else {}
+        codec_values = _normalize_values_for_fallback_codec(values, codec)
+        codec_array = np.asarray(codec_values, dtype=object)
+        try:
+            return _encode_with_schema(path, codec_array, FieldSchema(codec=codec, metadata=metadata))
+        except _ENCODING_FALLBACK_ERRORS as error:
+            errors.append(f"{codec}: {error}")
+    raise ValueError(
+        f"unable to infer a safe codec for structured non-tensor field {path!r}; "
+        f"tried {errors}"
+    )
+
+
+def _fallback_codec_chain(codec: str) -> tuple[str, ...]:
+    if codec in {"bytes_ragged", "media_bytes", "media_list_ragged"}:
+        return ("msgpack_ragged", "json_ragged")
+    return ("msgpack_ragged", "json_ragged")
+
+
+def _normalize_values_for_fallback_codec(values: list[Any], codec: str) -> list[Any]:
+    if codec in {"msgpack_ragged", "json_ragged"}:
+        return [_normalize_structured_scalar(value) for value in values]
+    return values
+
+
+def _normalize_structured_scalar(value: Any) -> Any:
+    if isinstance(value, np.ndarray):
+        if value.dtype == object:
+            # Object ndarrays do not have a stable contiguous typed representation.
+            # For generic fallbacks, materialize their Python shape once so msgpack/json
+            # can preserve the logical nested values instead of treating the object array
+            # as a numeric ragged buffer.
+            return _normalize_structured_scalar(value.tolist())
+        return value.tolist()
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, Mapping):
+        return {key: _normalize_structured_scalar(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_normalize_structured_scalar(item) for item in value]
+    if isinstance(value, list):
+        return [_normalize_structured_scalar(item) for item in value]
+    return value
 
 
 def _is_recursive_encoded_non_tensor(encoded: Mapping[str, Any]) -> bool:
@@ -2399,7 +2600,14 @@ def _encode_ragged_tensor_values(
         if value is None:
             tensors.append(None)
             continue
-        tensor = value.detach()
+        if isinstance(value, np.ndarray):
+            if value.dtype == object:
+                raise ValueError("ragged tensor codec requires numeric ndarray values")
+            if not value.flags.writeable:
+                value = value.copy()
+            tensor = _torch.as_tensor(value)
+        else:
+            tensor = value.detach()
         if tensor.device.type != "cpu" or not tensor.is_contiguous():
             tensor = tensor.cpu().contiguous()
         dtype = tensor.dtype if dtype is None else dtype
@@ -3032,8 +3240,10 @@ class _StructuredObjectLayer:
             non_batch.append(name)
 
         objects: dict[str, Any] = {}
-        # Try batched read (worthwhile when >=2 members)
-        if len(batch_eligible) > 1:
+        # Try pool-backed range read for every eligible ndarray member.  Even a
+        # single full-member read uses this path so the full-read case shares the
+        # same zero-copy/partial-read transport behavior.
+        if batch_eligible:
             names_for_batch = [name for name, _ in batch_eligible]
             plans_for_batch = [plan for _, plan in batch_eligible]
             batched = self._batch_read_ndarray_members(
@@ -3926,6 +4136,10 @@ class _MooncakePayloadTransport:
     def read_tensor_payload(self, payload_spec: Mapping[str, Any]) -> Any:
         get_tensor = getattr(self._store, "get_tensor", None)
         key = payload_spec["key"]
+        if payload_spec.get("kind") == "tensor":
+            if not callable(get_tensor):
+                raise RuntimeError("structured tensor payload does not support get_tensor")
+            return get_tensor(key)
         if callable(get_tensor):
             try:
                 return get_tensor(key)
@@ -4971,18 +5185,20 @@ def _tensor_payload_parts(value: _TensorPayload) -> tuple[bytes, int, int, Any]:
 
 
 def _has_tensor_codec_helpers() -> bool:
+    mooncake_store = _get_mooncake_store()
     return (
-        _mooncake_store is not None
-        and callable(getattr(_mooncake_store, "_serialize_tensor", None))
-        and callable(getattr(_mooncake_store, "_deserialize_tensor", None))
+        mooncake_store is not None
+        and callable(getattr(mooncake_store, "_serialize_tensor", None))
+        and callable(getattr(mooncake_store, "_deserialize_tensor", None))
     )
 
 
 def _tensor_metadata_size() -> int:
+    mooncake_store = _get_mooncake_store()
     helper = (
         None
-        if _mooncake_store is None
-        else getattr(_mooncake_store, "_tensor_metadata_size", None)
+        if mooncake_store is None
+        else getattr(mooncake_store, "_tensor_metadata_size", None)
     )
     if callable(helper):
         return int(helper())
@@ -5028,7 +5244,8 @@ def _deserialize_tensor_payload(payload: bytes) -> Any:
 
 
 def _tensor_codec_helper(name: str) -> Any:
-    helper = None if _mooncake_store is None else getattr(_mooncake_store, name, None)
+    mooncake_store = _get_mooncake_store()
+    helper = None if mooncake_store is None else getattr(mooncake_store, name, None)
     if not callable(helper):
         raise RuntimeError(
             "mooncake.store tensor serialization helpers are required for structured tensor fields"
@@ -5251,13 +5468,15 @@ def _choose_leaf_codec(values: list[Any]) -> _CodecDecision:
     if all(_is_media_list(value) for value in nn):
         return _CodecDecision(True, "media_list_ragged", "all rows are media lists", "media list")
     if all(isinstance(value, np.ndarray) for value in nn):
-        return _CodecDecision(
-            True,
-            "typed_ragged",
-            "all rows are ndarray",
-            "numeric sequence",
-            {"recursive_source": "ndarray"},
-        )
+        if all(np.issubdtype(value.dtype, np.number) for value in nn):
+            return _CodecDecision(
+                True,
+                "typed_ragged",
+                "all rows are numeric ndarray",
+                "numeric sequence",
+                {"recursive_source": "ndarray"},
+            )
+        return _CodecDecision(False, "msgpack_ragged", "object ndarray rows", "python object")
     if all(isinstance(value, (list, tuple)) for value in nn):
         try:
             dtypes = [np.asarray(value).dtype for value in nn]

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -25,6 +25,10 @@ MISSING_OBJECT_ERROR = (
     -704
 )  # Mooncake remove returns -704 for an already-missing object.
 STRUCTURED_FIELD_SPECS_KEY = "__mooncake_structured_fields__"
+# Default dtype for ragged tensor fields when all values are None (no data to
+# infer dtype from).  The actual bytes stored are empty, so the dtype only
+# serves as a placeholder for metadata consistency between encoder and decoder.
+_RAGGED_TENSOR_DEFAULT_DTYPE = "torch.float32"
 
 
 class BundleStore(Protocol):
@@ -2449,7 +2453,7 @@ def _encode_ragged_tensor_values(
             shapes[row, : tensor.dim()] = _torch.tensor(
                 list(tensor.shape), dtype=_torch.int64
             )
-    data_dtype = dtype or _torch.float32
+    data_dtype = dtype or _parse_torch_dtype(_RAGGED_TENSOR_DEFAULT_DTYPE)
     np_dtype = _torch_dtype_to_numpy(str(data_dtype))
     total_elems = int(offset)
     # Zero-copy: scatter-gather from original tensor memory, no concatenation
@@ -2488,7 +2492,7 @@ def _decode_ragged_tensor_values(
     if _torch is None:
         raise RuntimeError("torch is required to decode ragged tensor fields")
     raw = payload["data"]
-    dtype_str = (metadata or {}).get("dtype", "torch.float32")
+    dtype_str = (metadata or {}).get("dtype", _RAGGED_TENSOR_DEFAULT_DTYPE)
     torch_dtype = _parse_torch_dtype(dtype_str)
     if isinstance(raw, (bytes, bytearray, memoryview)):
         buf = bytearray(raw) if isinstance(raw, (bytes, memoryview)) else raw

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -1894,8 +1894,6 @@ def _schema_prefers_direct_numeric_ndarray(
         return False
     if isinstance(value, np.ndarray):
         return value.dtype != object or all(item is not None for item in value)
-    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
-        return all(item is not None for item in value)
     return False
 
 

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -16,6 +16,12 @@ _mooncake_store_loaded = False
 
 import msgpack as _msgpack
 
+# -- C fast-path: concat_arrays_into(list[ndarray], dest_ptr) ----------------
+try:
+    from mooncake._fast_copy import concat_arrays_into as _concat_arrays_into
+except ImportError:
+    _concat_arrays_into = None
+
 DEFAULT_BUNDLE_CHUNK_BYTES = 64 * 1024**2
 AUTO_PARALLEL_MIN_BYTES = DEFAULT_BUNDLE_CHUNK_BYTES
 AUTO_PARALLEL_MIN_CHUNKS = 8
@@ -180,6 +186,36 @@ class _MultiBufferPayload:
         return _buffer_group_nbytes(self.buffers)
 
 
+@dataclass(frozen=True)
+class _DirectCopyPayload:
+    """Deferred-copy payload: holds list[ndarray] for direct C-level copy into pool.
+
+    Unlike _MultiBufferPayload (which creates memoryviews at encode time),
+    this defers ALL copying to the transport layer, where the C extension
+    concat_arrays_into() copies arrays directly into RDMA-registered pool
+    memory in a tight C loop (~30ns per array vs ~1us for Python memoryview).
+    """
+    arrays: list[np.ndarray]
+    total_bytes: int
+    dtype: str | None = None
+    shape: tuple[int, ...] | None = None
+
+    @property
+    def nbytes(self) -> int:
+        return self.total_bytes
+
+    @staticmethod
+    def from_flat_arrays(
+        flat_arrays: list[np.ndarray], dtype: np.dtype, total_elems: int,
+    ) -> "_DirectCopyPayload":
+        return _DirectCopyPayload(
+            arrays=flat_arrays,
+            total_bytes=sum(a.nbytes for a in flat_arrays),
+            dtype=np.dtype(dtype).str,
+            shape=(total_elems,),
+        )
+
+
 def _validate_tensor_object_buffer_owner(value: _TensorObjectBufferPayload) -> None:
     owner = value.owner
     lease = getattr(owner, "lease", owner)
@@ -267,6 +303,25 @@ class _PoolBackedNdarray(np.ndarray):
         # Callers must ensure the original array outlives any derived views.
         if obj is not None:
             self._mooncake_pool_owner = getattr(obj, "_mooncake_pool_owner", None)
+
+
+class _OwnerBackedList(list):
+    def __init__(self, values: Sequence[Any], owner: Any) -> None:
+        super().__init__(values)
+        self._mooncake_pool_owner = owner
+
+
+class _OwnerBackedObjectArray(np.ndarray):
+    def __array_finalize__(self, obj: Any) -> None:
+        if obj is not None:
+            self._mooncake_pool_owner = getattr(obj, "_mooncake_pool_owner", None)
+
+    def tolist(self) -> list[Any]:
+        values = super().tolist()
+        owner = getattr(self, "_mooncake_pool_owner", None)
+        if owner is None:
+            return values
+        return _OwnerBackedList(values, owner)
 
 
 @dataclass(frozen=True)
@@ -690,6 +745,7 @@ class MooncakeBundleTransfer:
         data_cls: Optional[Any] = None,
         destinations: Optional[Mapping[str, Any]] = None,
         rows: slice | StructuredMemberSlice | Sequence[int] | None = None,
+        legacy_output: bool = False,
     ) -> Any:
         """Core materialization logic shared by get_dataproto and get_legacy_dict."""
         row_selection = _coerce_dataproto_row_selection(rows, ref.batch_size)
@@ -783,9 +839,11 @@ class MooncakeBundleTransfer:
                     values = _decode_structured_non_tensor_encoded(
                         encoded, payload, ref.batch_size, encoded.get("metadata")
                     )
-                    array = np.empty(output_rows, dtype=object)
-                    array[:] = values
-                    non_tensor_batch[name] = array
+                    non_tensor_batch[name] = (
+                        values
+                        if legacy_output
+                        else _object_array_from_decoded_values(values)
+                    )
         else:
             for name, location in encoded_requests:
                 stage_ref = ref.stage_refs[location.stage]
@@ -809,10 +867,20 @@ class MooncakeBundleTransfer:
                     values = _decode_structured_non_tensor_encoded(
                         encoded, payload, output_rows, metadata
                     )
-                array = np.empty(output_rows, dtype=object)
-                array[:] = values
-                non_tensor_batch[name] = array
+                non_tensor_batch[name] = (
+                    values
+                    if legacy_output
+                    else _object_array_from_decoded_values(values)
+                )
         meta_info = _select_mapping(ref.meta_info, meta_info_keys)
+        if legacy_output:
+            return _envelope_to_legacy_dict(
+                {
+                    "batch": batch,
+                    "non_tensor_batch": non_tensor_batch,
+                    "meta_info": meta_info,
+                }
+            )
         return _build_dataproto_like_result(
             batch, non_tensor_batch, meta_info, data_cls
         )
@@ -1407,9 +1475,7 @@ class MooncakeBundleTransfer:
 
     def get_legacy_dict(self, ref: DataProtoRefLike) -> dict[str, Any]:
         """Materialize a legacy rollout dict stored by put_legacy_dict()."""
-        return _envelope_to_legacy_dict(
-            self._materialize_ref(_resolve_ref(ref))
-        )
+        return self._materialize_ref(_resolve_ref(ref), legacy_output=True)
 
     def remove_legacy_dict(self, ref: DataProtoRefLike) -> None:
         """Remove a legacy rollout dict stored by put_legacy_dict()."""
@@ -1426,21 +1492,46 @@ class MooncakeBundleTransfer:
         Works for both flat dicts (legacy_dict) and nested envelope dicts
         (dataproto: {batch: {...}, non_tensor_batch: {...}, meta_info: {...}}).
         """
-        if not isinstance(result, Mapping):
-            return
-        for value in result.values():
-            if isinstance(value, Mapping):
-                MooncakeBundleTransfer.release_result(value)
-                continue
+        released_owners: set[int] = set()
+        visited_containers: set[int] = set()
+
+        def release_owner(owner: Any) -> None:
+            owner_id = id(owner)
+            if owner_id in released_owners:
+                return
+            released_owners.add(owner_id)
+            owner.release()
+
+        def visit(value: Any) -> None:
             owner = getattr(value, "_mooncake_pool_owner", None)
             if owner is not None:
-                owner.release()
-                continue
+                release_owner(owner)
+                return
+            if isinstance(value, Mapping):
+                container_id = id(value)
+                if container_id in visited_containers:
+                    return
+                visited_containers.add(container_id)
+                for item in value.values():
+                    visit(item)
+                return
+            if isinstance(value, (list, tuple)):
+                container_id = id(value)
+                if container_id in visited_containers:
+                    return
+                visited_containers.add(container_id)
+                for item in value:
+                    visit(item)
+                return
             if isinstance(value, np.ndarray) and value.dtype == object:
+                container_id = id(value)
+                if container_id in visited_containers:
+                    return
+                visited_containers.add(container_id)
                 for item in value.flat:
-                    item_owner = getattr(item, "_mooncake_pool_owner", None)
-                    if item_owner is not None:
-                        item_owner.release()
+                    visit(item)
+
+        visit(result)
 
     def _append_dataproto_stage_manifest(
         self,
@@ -1962,6 +2053,25 @@ def _envelope_to_legacy_dict(data: Mapping[str, Any]) -> dict[str, Any]:
     return result
 
 
+def _object_array_from_decoded_values(values: list[Any]) -> np.ndarray:
+    array = np.empty(len(values), dtype=object)
+    array[:] = values
+    owner = getattr(values, "_mooncake_pool_owner", None) or _first_pool_owner(values)
+    if owner is None:
+        return array
+    result = array.view(_OwnerBackedObjectArray)
+    result._mooncake_pool_owner = owner
+    return result
+
+
+def _first_pool_owner(values: Sequence[Any]) -> Any | None:
+    for value in values:
+        if value is None:
+            continue
+        return getattr(value, "_mooncake_pool_owner", None)
+    return None
+
+
 def _is_row_aligned_dense_field(value: Any, row_count: int) -> bool:
     if _torch is not None and isinstance(value, _torch.Tensor):
         return value.shape[:1] == (row_count,)
@@ -2229,7 +2339,9 @@ def _encode_with_schema(
     if codec == "ragged_tensor":
         payload, metadata = _encode_ragged_tensor_values(values)
     elif codec == "typed_ragged":
-        payload, metadata = _encode_typed_ragged_values(values)
+        payload, metadata = _encode_typed_ragged_values(
+            values, dtype_hint=_schema_ndarray_dtype(schema)
+        )
     elif codec == "ndarray":
         dtype = _schema_ndarray_dtype(schema)
         if dtype is None:
@@ -2249,19 +2361,7 @@ def _encode_with_schema(
             [None if v is None else v.encode("utf-8") for v in values]
         )
     elif codec == "msgpack_ragged":
-        try:
-            packed_values = [
-                None
-                if v is None
-                else _msgpack.packb(v, use_bin_type=True, strict_types=True)
-                for v in values
-            ]
-        except TypeError as exc:
-            raise ValueError(
-                f"unsupported structured non-tensor field {path}: "
-                "msgpack codec cannot encode value"
-            ) from exc
-        payload, metadata = _encode_bytes_like_values(packed_values)
+        payload, metadata = _encode_msgpack_ragged_values(path, values)
     elif codec == "json_ragged":
         payload, metadata = _encode_bytes_like_values(
             [
@@ -2574,10 +2674,7 @@ def _decode_structured_leaf(
             for value in _decode_bytes_like_values(payload, rows)
         ]
     if codec == "msgpack_ragged":
-        return [
-            None if value is None else _msgpack.unpackb(value, raw=False)
-            for value in _decode_bytes_like_values(payload, rows)
-        ]
+        return _decode_msgpack_ragged_values(payload, rows)
     if codec == "json_ragged":
         return [
             None if value is None else json.loads(value)
@@ -2793,98 +2890,24 @@ def _decode_ragged_tensor_dict_values(
 
 
 def _encode_typed_ragged_values(
-    values: list[Any],
-    schema: FieldSchema,
-) -> _EncodedStructuredLeaf:
-    rows = len(values)
-    null_mask = np.asarray([item is None for item in values], dtype=np.bool_)
-    schema_keys = schema.metadata.get("keys")
-    keys = None if schema_keys is None else _normalize_ragged_tensor_dict_keys(schema_keys)
-    declared_keys = None if keys is None else set(keys)
-    inferred_keys: set[str] = set()
-    for row, item in enumerate(values):
-        if item is None:
-            continue
-        if not isinstance(item, Mapping):
-            raise TypeError(
-                "ragged_tensor_dict rows must be mappings or None; "
-                f"row {row} is {type(item).__name__}"
-            )
-        explicit_null_keys = sorted(key for key, value in item.items() if value is None)
-        if explicit_null_keys:
-            raise TypeError(
-                "ragged_tensor_dict rows cannot contain explicit None tensor values; "
-                f"row {row} has {explicit_null_keys}"
-            )
-        if declared_keys is None:
-            inferred_keys.update(item)
-            continue
-        extra_keys = sorted(set(item) - declared_keys)
-        if extra_keys:
-            raise ValueError(
-                "ragged_tensor_dict rows contain keys not declared in "
-                f"FieldSchema metadata['keys']; row {row} has {extra_keys}"
-            )
-    if keys is None:
-        keys = _normalize_ragged_tensor_dict_keys(sorted(inferred_keys))
-    if keys and _torch is None:
-        raise RuntimeError("torch is required to encode ragged_tensor_dict fields")
-    payload: dict[str, Any] = {"null_mask": null_mask}
-    key_codecs: dict[str, Any] = {}
-    for key in keys:
-        sub_payload, sub_metadata = _encode_ragged_tensor_values(
-            [None if item is None else item.get(key) for item in values]
-        )
-        payload.update(
-            {f"{key}.{name}": value for name, value in sub_payload.items()}
-        )
-        key_codecs[key] = sub_metadata
-    return _EncodedStructuredLeaf(
-        codec="ragged_tensor_dict",
-        rows=rows,
-        payload=payload,
-        metadata={
-            "keys": list(keys),
-            "key_codecs": key_codecs,
-            "schema_source": "field_schema",
-        },
-    )
-
-def _decode_ragged_tensor_dict_values(
-    payload: dict[str, Any], rows: int, metadata: Mapping[str, Any]
-) -> list[Any]:
-    null_mask = payload["null_mask"]
-    if len(null_mask) != rows:
-        raise ValueError(
-            f"ragged_tensor_dict null_mask row count {len(null_mask)} != expected {rows}"
-        )
-    key_values = {
-        key: _decode_ragged_tensor_values(
-            _ragged_tensor_dict_payload_items(payload, key, kind="payload"), rows
-        )
-        for key in _normalize_ragged_tensor_dict_keys(metadata.get("keys", []))
-    }
-    result: list[Any] = []
-    for row in range(rows):
-        if bool(null_mask[row]):
-            result.append(None)
-        else:
-            result.append({
-                key: values[row]
-                for key, values in key_values.items()
-                if values[row] is not None
-            })
-    return result
-
-def _encode_typed_ragged_values(
     values: list[Any], dtype_hint: np.dtype[Any] | None = None
 ) -> tuple[dict[str, Any], dict[str, Any]]:
-    source_arrays = [np.asarray(value) for value in values if value is not None]
-    dtype = np.result_type(*source_arrays) if source_arrays else np.dtype(_TYPED_RAGGED_DEFAULT_DTYPE)
+    if dtype_hint is None:
+        source_arrays = [np.asarray(value) for value in values if value is not None]
+        dtype = np.result_type(*source_arrays) if source_arrays else np.dtype(_TYPED_RAGGED_DEFAULT_DTYPE)
+    else:
+        dtype = np.dtype(dtype_hint)
+    if dtype.hasobject:
+        raise ValueError("typed_ragged codec requires non-object dtype")
+
+    ndarray_encoded = _encode_typed_ragged_ndarray_rows(values, dtype)
+    if ndarray_encoded is not None:
+        return ndarray_encoded
+
     arrays = [
         np.asarray([], dtype=dtype)
         if value is None
-        else np.ascontiguousarray(np.asarray(value, dtype=dtype))
+        else _as_contiguous_array_preserve_ndim(value, dtype)
         for value in values
     ]
     max_ndim = max((array.ndim for array in arrays), default=0)
@@ -2902,15 +2925,17 @@ def _encode_typed_ragged_values(
         ndims[row] = array.ndim
         if array.ndim > 0:
             shapes[row, : array.ndim] = array.shape
-    # Zero-copy: scatter-gather from original numpy array memory, no concatenation
     total_elems = int(offset)
     if flat_arrays:
-        buffers = tuple(memoryview(flat.data).cast("B") for flat in flat_arrays)
-        owners = tuple(flat_arrays)  # keep arrays alive
-        data = _MultiBufferPayload(
-            buffers=buffers, owners=owners,
-            dtype=np.dtype(dtype).str, shape=(total_elems,),
-        )
+        if _concat_arrays_into is not None:
+            data = _DirectCopyPayload.from_flat_arrays(flat_arrays, dtype, total_elems)
+        else:
+            buffers = tuple(memoryview(flat.data).cast("B") for flat in flat_arrays)
+            owners = tuple(flat_arrays)
+            data = _MultiBufferPayload(
+                buffers=buffers, owners=owners,
+                dtype=np.dtype(dtype).str, shape=(total_elems,),
+            )
     else:
         empty = np.empty(0, dtype=dtype)
         data = _MultiBufferPayload(
@@ -2944,6 +2969,203 @@ def _encode_typed_ragged_values(
     )
 
 
+def _encode_typed_ragged_regular_ndarray_rows(
+    values: list[Any], dtype: np.dtype[Any]
+) -> tuple[dict[str, Any], dict[str, Any]] | None:
+    row_count = len(values)
+    if row_count < 2:
+        return None
+    first = values[0]
+    if (
+        not isinstance(first, np.ndarray)
+        or first.dtype != dtype
+        or not first.flags.c_contiguous
+    ):
+        return None
+    shape = first.shape
+    for value in values[1:]:
+        if (
+            not isinstance(value, np.ndarray)
+            or value.dtype != dtype
+            or not value.flags.c_contiguous
+            or value.shape != shape
+        ):
+            return None
+
+    row_elems = int(first.size)
+    data = np.asarray(values, dtype=dtype).reshape(-1)
+    offsets = np.arange(row_count + 1, dtype=np.int64) * row_elems
+    nulls = np.zeros(row_count, dtype=np.bool_)
+    max_ndim = int(first.ndim)
+    if max_ndim == 0:
+        shapes = np.zeros((row_count, 1), dtype=np.int64)
+        ndims = np.zeros(row_count, dtype=np.int16)
+    else:
+        shapes = np.empty((row_count, max_ndim), dtype=np.int64)
+        shapes[:] = shape
+        ndims = np.full(row_count, max_ndim, dtype=np.int16)
+    return (
+        {
+            "data": data,
+            "offsets": offsets,
+            "shapes": shapes,
+            "ndims": ndims,
+            "nulls": nulls,
+        },
+        {
+            "dtype": str(dtype),
+            "max_ndim": max_ndim,
+            "shape_policy": "ragged",
+            "row_format": "ndarray",
+            "ndarray_rows": None,
+            "physical_layout": "contiguous_flat",
+        },
+    )
+
+
+def _encode_typed_ragged_ndarray_rows(
+    values: list[Any], dtype: np.dtype[Any]
+) -> tuple[dict[str, Any], dict[str, Any]] | None:
+    regular_encoded = _encode_typed_ragged_regular_ndarray_rows(values, dtype)
+    if regular_encoded is not None:
+        return regular_encoded
+
+    row_count = len(values)
+    if row_count == 0:
+        return None
+
+    nulls = np.empty(row_count, dtype=np.bool_)
+    lengths = np.empty(row_count, dtype=np.int64)
+    arrays: list[np.ndarray] = []
+    tail_shape: tuple[int, ...] | None = None
+    row_ndim: int | None = None
+    tail_compatible = True
+    saw_scalar = False
+    saw_non_scalar = False
+
+    for row, value in enumerate(values):
+        if value is None:
+            nulls[row] = True
+            lengths[row] = 0
+            continue
+        if not isinstance(value, np.ndarray):
+            return None
+
+        array = _as_contiguous_array_preserve_ndim(value, dtype)
+        arrays.append(array)
+        nulls[row] = False
+        lengths[row] = array.size
+        if array.ndim == 0:
+            saw_scalar = True
+            if saw_non_scalar:
+                tail_compatible = False
+            continue
+
+        saw_non_scalar = True
+        if saw_scalar:
+            tail_compatible = False
+        current_tail = array.shape[1:]
+        if tail_shape is None:
+            tail_shape = current_tail
+            row_ndim = array.ndim
+        elif array.ndim != row_ndim or current_tail != tail_shape:
+            tail_compatible = False
+
+    if tail_compatible and tail_shape is not None and any(dim == 0 for dim in tail_shape):
+        tail_compatible = False
+
+    offsets = np.empty(row_count + 1, dtype=np.int64)
+    offsets[0] = 0
+    np.cumsum(lengths, out=offsets[1:])
+    total_elems = int(offsets[-1])
+    if len(arrays) == 1:
+        flat = arrays[0].reshape(-1)
+        data = _MultiBufferPayload(
+            buffers=(memoryview(flat.data).cast("B"),),
+            owners=(flat,),
+            dtype=np.dtype(dtype).str,
+            shape=(total_elems,),
+        )
+    elif total_elems:
+        if _concat_arrays_into is not None:
+            flat_arrays = [arr.reshape(-1) for arr in arrays]
+            data = _DirectCopyPayload.from_flat_arrays(flat_arrays, dtype, total_elems)
+        else:
+            flat_arrays = [arr.reshape(-1) for arr in arrays]
+            buffers = tuple(memoryview(flat.data).cast("B") for flat in flat_arrays)
+            data = _MultiBufferPayload(
+                buffers=buffers,
+                owners=tuple(flat_arrays),
+                dtype=np.dtype(dtype).str,
+                shape=(total_elems,),
+            )
+    else:
+        empty = np.empty(0, dtype=dtype)
+        data = _MultiBufferPayload(
+            buffers=(memoryview(empty.data).cast("B"),),
+            owners=(empty,),
+            dtype=np.dtype(dtype).str,
+            shape=(0,),
+        )
+
+    if not arrays or saw_scalar and not saw_non_scalar:
+        max_ndim = 0
+    elif tail_compatible:
+        max_ndim = int(row_ndim or 1)
+    else:
+        max_ndim = max(array.ndim for array in arrays)
+
+    ndims = np.zeros(row_count, dtype=np.int16)
+    if max_ndim == 0:
+        shapes = np.zeros((row_count, 1), dtype=np.int64)
+    elif tail_compatible:
+        shapes = np.zeros((row_count, max_ndim), dtype=np.int64)
+        tail = tail_shape or ()
+        tail_elems = int(np.prod(tail, dtype=np.int64)) if tail else 1
+        shapes[:, 0] = lengths // tail_elems
+        if max_ndim > 1:
+            shapes[:, 1:] = tail
+        ndims[~nulls] = max_ndim
+    else:
+        shapes = np.zeros((row_count, max(max_ndim, 1)), dtype=np.int64)
+        array_index = 0
+        for row, is_null in enumerate(nulls):
+            if bool(is_null):
+                continue
+            array = arrays[array_index]
+            array_index += 1
+            ndims[row] = array.ndim
+            if array.ndim > 0:
+                shapes[row, : array.ndim] = array.shape
+
+    return (
+        {
+            "data": data,
+            "offsets": offsets,
+            "shapes": shapes,
+            "ndims": ndims,
+            "nulls": nulls,
+        },
+        {
+            "dtype": str(dtype),
+            "max_ndim": int(max_ndim),
+            "shape_policy": "ragged",
+            "row_format": "ndarray",
+            "ndarray_rows": None,
+            "physical_layout": "contiguous_flat",
+        },
+    )
+
+
+def _as_contiguous_array_preserve_ndim(value: Any, dtype: np.dtype[Any]) -> np.ndarray:
+    if isinstance(value, np.ndarray) and value.dtype == dtype and value.flags.c_contiguous:
+        return value
+    array = np.asarray(value, dtype=dtype)
+    if array.flags.c_contiguous:
+        return array
+    return np.array(array, dtype=dtype, order="C", copy=True)
+
+
 def _decode_typed_ragged_values(
     payload: dict[str, Any], rows: int, metadata: Optional[Mapping[str, Any]] = None
 ) -> list[Any]:
@@ -2965,6 +3187,16 @@ def _decode_typed_ragged_values(
     nulls = payload["nulls"]
     metadata = metadata or {}
     row_format = metadata.get("row_format")
+    if (
+        row_format == "ndarray"
+        and metadata.get("physical_layout") == "contiguous_flat"
+    ):
+        fast_values = _decode_typed_ragged_ndarray_rows_fast(
+            data, offsets, shapes, ndims, nulls, rows, metadata
+        )
+        if fast_values is not None:
+            return fast_values
+
     ndarray_rows = metadata.get("ndarray_rows") or []
     values = []
     for row in range(rows):
@@ -2983,6 +3215,104 @@ def _decode_typed_ragged_values(
         else:
             values.append(array.tolist())
     return values
+
+
+def _decode_typed_ragged_ndarray_rows_fast(
+    data: np.ndarray,
+    offsets: np.ndarray,
+    shapes: np.ndarray,
+    ndims: np.ndarray,
+    nulls: np.ndarray,
+    rows: int,
+    metadata: Mapping[str, Any],
+) -> list[Any] | None:
+    max_ndim = int(metadata.get("max_ndim", 0))
+    owner = getattr(data, "_mooncake_pool_owner", None)
+    source = data.view(np.ndarray) if isinstance(data, np.ndarray) else data
+    has_nulls = bool(nulls.any())
+
+    def attach_owner(values: list[Any]) -> list[Any]:
+        if owner is None:
+            return values
+        return _OwnerBackedList(values, owner)
+
+    if max_ndim == 1:
+        if not has_nulls:
+            row_width = _regular_offsets_width(offsets, rows)
+            if row_width is not None:
+                return attach_owner(list(source.reshape((rows, row_width))))
+            begins = offsets[:-1].tolist()
+            ends = offsets[1:].tolist()
+            return attach_owner(
+                [source[b:e] for b, e in zip(begins, ends)]
+            )
+        values: list[Any] = []
+        begins = offsets[:-1].tolist()
+        ends = offsets[1:].tolist()
+        for is_null, b, e in zip(nulls, begins, ends):
+            if bool(is_null):
+                values.append(None)
+            else:
+                values.append(source[b:e])
+        return attach_owner(values)
+
+    if max_ndim <= 1 or rows == 0:
+        return None
+
+    non_null_rows = np.flatnonzero(~nulls)
+    if non_null_rows.size == 0:
+        return [None] * rows
+    first_row = int(non_null_rows[0])
+    if int(ndims[first_row]) != max_ndim:
+        return None
+    tail = tuple(int(v) for v in shapes[first_row, 1:max_ndim])
+    if any(dim == 0 for dim in tail):
+        return None
+    for row in non_null_rows:
+        row_index = int(row)
+        if int(ndims[row_index]) != max_ndim:
+            return None
+        if tuple(int(v) for v in shapes[row_index, 1:max_ndim]) != tail:
+            return None
+
+    tail_elems = int(np.prod(tail, dtype=np.int64)) if tail else 1
+    if tail_elems <= 0:
+        return None
+    if int(offsets[-1]) % tail_elems != 0:
+        return None
+    flat_rows = source.reshape((-1, *tail))
+    first_axis_offsets = offsets // tail_elems
+
+    if not has_nulls:
+        row_width = _regular_offsets_width(first_axis_offsets, rows)
+        if row_width is not None:
+            return attach_owner(list(flat_rows.reshape((rows, row_width, *tail))))
+        fa_begins = first_axis_offsets[:-1].tolist()
+        fa_ends = first_axis_offsets[1:].tolist()
+        return attach_owner(
+            [flat_rows[b:e] for b, e in zip(fa_begins, fa_ends)]
+        )
+    values = []
+    fa_begins = first_axis_offsets[:-1].tolist()
+    fa_ends = first_axis_offsets[1:].tolist()
+    for is_null, b, e in zip(nulls, fa_begins, fa_ends):
+        if bool(is_null):
+            values.append(None)
+        else:
+            values.append(flat_rows[b:e])
+    return attach_owner(values)
+
+
+def _regular_offsets_width(offsets: np.ndarray, rows: int) -> int | None:
+    if rows <= 0 or int(offsets[0]) != 0:
+        return None
+    total = int(offsets[-1])
+    if total < 0 or total % rows != 0:
+        return None
+    row_width = total // rows
+    if not bool(np.all(offsets[1:] - offsets[:-1] == row_width)):
+        return None
+    return row_width
 
 
 def _encode_numeric_scalar_values(
@@ -3041,6 +3371,35 @@ def _multi_buffer_bytes_payload(
     return _MultiBufferPayload(buffers, tuple(parts))
 
 
+def _encode_msgpack_ragged_values(
+    path: str, values: list[Any]
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    row_count = len(values)
+    offsets = np.empty(row_count + 1, dtype=np.int64)
+    nulls = np.empty(row_count, dtype=np.bool_)
+    offsets[0] = 0
+    packer = _msgpack.Packer(use_bin_type=True, strict_types=True)
+    buf = bytearray()
+    try:
+        for i, value in enumerate(values):
+            if value is None:
+                nulls[i] = True
+                offsets[i + 1] = offsets[i]
+            else:
+                buf.extend(packer.pack(value))
+                nulls[i] = False
+                offsets[i + 1] = len(buf)
+    except TypeError as exc:
+        raise ValueError(
+            f"unsupported structured non-tensor field {path}: "
+            "msgpack codec cannot encode value"
+        ) from exc
+    return (
+        {"data": buf, "offsets": offsets, "nulls": nulls},
+        {},
+    )
+
+
 def _encode_bytes_like_values(
     values: list[Any],
 ) -> tuple[dict[str, Any], dict[str, Any]]:
@@ -3097,13 +3456,35 @@ def _decode_bytes_like_values(
     encodings = (metadata or {}).get("media_encodings", [])
     data_view = memoryview(data) if not isinstance(data, memoryview) else data
     values = []
-    for row in range(rows):
-        if bool(nulls[row]):
+    for row, is_null, begin, end in zip(range(rows), nulls, offsets[:-1], offsets[1:]):
+        if bool(is_null):
             values.append(None)
             continue
-        item = data_view[int(offsets[row]) : int(offsets[row + 1])]
+        item = data_view[begin:end]
         encoding = encodings[row] if row < len(encodings) else None
         values.append(_decode_media_bytes(item, encoding))
+    return values
+
+
+def _decode_msgpack_ragged_values(payload: dict[str, Any], rows: int) -> list[Any]:
+    data = payload["data"]
+    nulls = payload["nulls"]
+    has_nulls = bool(nulls.any()) if rows > 0 else False
+    raw_data = bytes(data) if not isinstance(data, bytes) else data
+    if not has_nulls:
+        unpacker = _msgpack.Unpacker(raw=False)
+        unpacker.feed(raw_data)
+        return list(unpacker)
+    # With nulls: stream decode non-null values, insert None at null positions
+    unpacker = _msgpack.Unpacker(raw=False)
+    unpacker.feed(raw_data)
+    non_null_iter = iter(unpacker)
+    values = []
+    for is_null in nulls:
+        if bool(is_null):
+            values.append(None)
+        else:
+            values.append(next(non_null_iter))
     return values
 
 
@@ -3592,6 +3973,13 @@ class _BundleManifestStore:
                         value,
                         transfer_policy,
                     )
+                elif isinstance(value, _DirectCopyPayload):
+                    payload_spec, payload_keys = self._put_direct_copy_payload(
+                        payload_key,
+                        value,
+                        target_chunk_bytes,
+                        transfer_policy,
+                    )
                 elif isinstance(value, _MultiBufferPayload):
                     payload_spec, payload_keys = self._put_multi_buffer_payload(
                         payload_key,
@@ -3931,6 +4319,111 @@ class _BundleManifestStore:
             "chunks": [
                 {"key": chunk_key, "bytes": sum(len(part) for part in group)}
                 for chunk_key, group in zip(chunk_keys, chunk_groups)
+            ],
+        }
+        return payload_spec, list(chunk_keys)
+
+    def _put_direct_copy_payload(
+        self,
+        key: str,
+        value: _DirectCopyPayload,
+        chunk_bytes: int,
+        transfer_policy: BundleTransferPolicy,
+    ) -> tuple[dict[str, Any], list[str]]:
+        total_bytes = value.total_bytes
+        if total_bytes == 0:
+            return {"key": key, "bytes": 0, "chunks": []}, []
+        if len(value.arrays) == 1:
+            buf = memoryview(value.arrays[0].data).cast("B")
+            return self._put_payload(
+                key, buf, chunk_bytes, transfer_policy,
+            )
+        arrays = value.arrays
+        transport = self._transport
+        pool = transport._ensure_buffer_pool()
+        batch_put_from = transport._batch_put_from
+        if pool is None or not callable(batch_put_from):
+            buf = memoryview(np.concatenate(
+                [a.ravel().view(np.uint8) for a in arrays]
+            ).data).cast("B")
+            return self._put_payload(key, buf, chunk_bytes, transfer_policy)
+        # Group arrays into chunk-sized batches
+        n = len(arrays)
+        chunk_batches: list[tuple[int, int, int]] = []  # (start, count, bytes)
+        batch_start = 0
+        batch_bytes = 0
+        fallback = False
+        for i in range(n):
+            ab = arrays[i].nbytes
+            if ab > chunk_bytes:
+                fallback = True
+                break
+            if batch_bytes + ab > chunk_bytes and batch_bytes > 0:
+                chunk_batches.append((batch_start, i - batch_start, batch_bytes))
+                batch_start = i
+                batch_bytes = 0
+            batch_bytes += ab
+        if fallback:
+            buf = memoryview(np.concatenate(
+                [a.ravel().view(np.uint8) for a in arrays]
+            ).data).cast("B")
+            return self._put_payload(key, buf, chunk_bytes, transfer_policy)
+        if batch_bytes > 0:
+            chunk_batches.append((batch_start, n - batch_start, batch_bytes))
+        num_chunks = len(chunk_batches)
+        chunk_keys = [
+            key if num_chunks == 1 else f"{key}/chunk/{idx}"
+            for idx in range(num_chunks)
+        ]
+        def _put_chunk_batch(keys, batches, nthreads=1):
+            for ck, (start, count, size) in zip(keys, batches):
+                lease = pool.acquire(size)
+                try:
+                    _concat_arrays_into(arrays, lease.ptr, start, count, nthreads)
+                    results = batch_put_from([ck], [lease.ptr], [size])
+                    transport._check_batch_put_results(results, [ck], "batch_put_from")
+                except Exception:
+                    _cleanup_keys(self._store, [ck], strict=False)
+                    raise
+                finally:
+                    lease.release()
+
+        max_inflight = transfer_policy.max_inflight_put
+        use_parallel = (
+            transfer_policy.put_mode != "batch"
+            and max_inflight > 1
+            and num_chunks >= AUTO_PARALLEL_MIN_CHUNKS
+            and total_bytes >= AUTO_PARALLEL_MIN_BYTES
+        )
+        if not use_parallel:
+            _put_chunk_batch(chunk_keys, chunk_batches)
+        else:
+            group_count = max(1, min(max_inflight, num_chunks))
+            group_size = (num_chunks + group_count - 1) // group_count
+            groups = [
+                (chunk_keys[s:s + group_size], chunk_batches[s:s + group_size])
+                for s in range(0, num_chunks, group_size)
+            ]
+            futures: list = []
+            try:
+                with ThreadPoolExecutor(max_workers=len(groups)) as executor:
+                    futures = [
+                        executor.submit(_put_chunk_batch, gk, gb)
+                        for gk, gb in groups
+                    ]
+                    for f in as_completed(futures):
+                        f.result()
+            except Exception:
+                for f in futures:
+                    f.cancel()
+                _cleanup_keys(self._store, chunk_keys, strict=False)
+                raise
+        payload_spec = {
+            "key": key,
+            "bytes": total_bytes,
+            "chunks": [
+                {"key": ck, "bytes": cb[2]}
+                for ck, cb in zip(chunk_keys, chunk_batches)
             ],
         }
         return payload_spec, list(chunk_keys)
@@ -5146,6 +5639,14 @@ def _encode_structured_field(value: Any) -> tuple[dict[str, Any], Any]:
         return {"encoding": "torch_tensor"}, value
     if isinstance(value, _TensorPayload):
         return _encode_torch_tensor_field(value.tensor)
+    if isinstance(value, _DirectCopyPayload):
+        if value.dtype is not None and value.shape is not None:
+            return {
+                "encoding": "ndarray",
+                "dtype": value.dtype,
+                "shape": list(value.shape),
+            }, value
+        return _BYTES_FIELD_SPEC, value
     if isinstance(value, _MultiBufferPayload):
         if value.dtype is not None and value.shape is not None:
             return {

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -878,7 +878,7 @@ class MooncakeBundleTransfer:
                 self._bundle_store.read_payload_ranges_into_bytearray(
                     payload_spec, data, ranges
                 )
-                ctypes.memmove(destination.ptr, bytes(data), nbytes)
+                ctypes.memmove(destination.ptr, (ctypes.c_char * nbytes).from_buffer(data), nbytes)
             _ = destination.owner
             return target
         target = _resolve_ndarray_destination(name, destination, dtype_obj, output_shape)
@@ -1013,7 +1013,7 @@ class MooncakeBundleTransfer:
                 self._bundle_store.read_payload_ranges_into_bytearray(
                     payload_spec, data, ranges
                 )
-                return bytes(data)
+                return data
             array = np.empty(total_bytes // dtype.itemsize, dtype=dtype)
             self._bundle_store.read_payload_ranges_into_array(
                 payload_spec, array.view(np.uint8).reshape(-1), ranges
@@ -2413,7 +2413,7 @@ def _decode_structured_leaf(
         ]
     if codec == "json_ragged":
         return [
-            None if value is None else json.loads(value.decode("utf-8"))
+            None if value is None else json.loads(value)
             for value in _decode_bytes_like_values(payload, rows)
         ]
     raise ValueError(f"unknown structured non-tensor codec: {codec}")
@@ -2509,6 +2509,8 @@ def _decode_ragged_tensor_values(
         if raw.dtype != np_dtype:
             raw = np.frombuffer(raw, dtype=np_dtype)
         data = _torch.from_numpy(raw)
+        if data.dtype != torch_dtype:
+            data = data.view(torch_dtype)
     else:
         data = _torch.from_numpy(np.asarray(raw))
     offsets = payload["offsets"]
@@ -2778,8 +2780,7 @@ def _decode_typed_ragged_values(
     if _torch is not None and isinstance(raw, _torch.Tensor):
         data = raw.numpy()
     elif isinstance(raw, (bytes, bytearray, memoryview)):
-        buf = bytearray(raw) if isinstance(raw, (bytes, memoryview)) else raw
-        data = np.frombuffer(buf, dtype=np_dtype)
+        data = np.frombuffer(raw, dtype=np_dtype)
     elif isinstance(raw, np.ndarray):
         data = raw if raw.dtype == np_dtype else np.frombuffer(raw, dtype=np_dtype)
     else:
@@ -2920,12 +2921,13 @@ def _decode_bytes_like_values(
     offsets = payload["offsets"]
     nulls = payload["nulls"]
     encodings = (metadata or {}).get("media_encodings", [])
+    data_view = memoryview(data) if not isinstance(data, memoryview) else data
     values = []
     for row in range(rows):
         if bool(nulls[row]):
             values.append(None)
             continue
-        item = memoryview(data)[int(offsets[row]) : int(offsets[row + 1])]
+        item = data_view[int(offsets[row]) : int(offsets[row + 1])]
         encoding = encodings[row] if row < len(encodings) else None
         values.append(_decode_media_bytes(item, encoding))
     return values
@@ -2976,6 +2978,7 @@ def _decode_media_list_values(
     byte_offsets = payload["byte_offsets"]
     nulls = payload["nulls"]
     encodings = (metadata or {}).get("media_encodings", [])
+    data_view = memoryview(data) if not isinstance(data, memoryview) else data
     values = []
     for row in range(rows):
         if bool(nulls[row]):
@@ -2983,7 +2986,7 @@ def _decode_media_list_values(
             continue
         items = []
         for item_index in range(int(row_offsets[row]), int(row_offsets[row + 1])):
-            item = memoryview(data)[
+            item = data_view[
                 int(byte_offsets[item_index]) : int(byte_offsets[item_index + 1])
             ]
             encoding = encodings[item_index] if item_index < len(encodings) else None

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -2272,38 +2272,15 @@ def _should_encode_recursive_leaf(leaf: "_InferredLeaf") -> bool:
     }
 
 
-def _fallback_codec(values: list[Any]) -> str:
-    """Simple type-based codec selection (no recursive inference)."""
-    nn = [v for v in values if v is not None]
-    if not nn:
-        return "msgpack_ragged"
-    if _torch is not None and all(isinstance(v, _torch.Tensor) for v in nn):
-        return "ragged_tensor"
-    if all(isinstance(v, str) for v in nn):
-        return "utf8_ragged"
-    if all(isinstance(v, (bytes, bytearray, memoryview)) for v in nn):
-        return "bytes_ragged"
-    if all(isinstance(v, (bool, int, float, np.number)) for v in nn):
-        return "ndarray"
-    if all(isinstance(v, np.ndarray) for v in nn):
-        return "typed_ragged"
-    return "msgpack_ragged"
-
-
 def _encode_with_fallback(path: str, value: np.ndarray) -> "_EncodedStructuredLeaf":
-    """Encode using simple type-based fallback, with recursive expansion for structured rows."""
+    """Encode using type-based fallback (delegates to _leaf_decision), with recursive expansion for structured rows."""
     values = list(value)
     recursive = _encode_recursive_if_structured(path, values)
     if recursive is not None:
         return recursive
-    codec = _fallback_codec(values)
-    metadata: dict[str, Any] = {}
-    if codec == "ndarray":
-        # ndarray codec needs dtype in metadata — infer from values
-        nn = [v for v in values if v is not None]
-        arr = np.asarray(nn)
-        metadata["dtype"] = str(arr.dtype)
-    schema = FieldSchema(codec=codec, metadata=metadata)
+    decision = _leaf_decision(values)
+    metadata = dict(decision.metadata or {})
+    schema = FieldSchema(codec=decision.codec, metadata=metadata)
     return _encode_with_schema(path, value, schema)
 
 
@@ -4418,7 +4395,10 @@ class _MooncakePayloadTransport:
             raise RuntimeError(
                 f"get failed for {chunk['key']}: expected {chunk_bytes} bytes, got {len(data)}"
             )
-        destination[offset : offset + chunk_bytes] = data
+        if isinstance(destination, np.ndarray):
+            destination[offset : offset + chunk_bytes] = np.frombuffer(data, dtype=np.uint8)
+        else:
+            destination[offset : offset + chunk_bytes] = data
 
     def _read_chunks_with_pool_get_into(
         self,
@@ -4630,48 +4610,11 @@ class _MooncakePayloadTransport:
                         f"get_into failed for {chunks[0]['key']}: expected {expected_size}, got {read_size}"
                     )
                 return True
-        get_into_ranges = self._get_into_ranges
-        if not callable(get_into_ranges):
-            return False
-        fragments = _payload_range_fragments(
-            chunks, byte_offset, byte_length, destination_offset
+        return self._read_payload_ranges_into_raw_destination(
+            chunks,
+            base_ptr,
+            [(byte_offset, destination_offset, byte_length)],
         )
-        if not fragments:
-            return True
-        keys = [
-            key
-            for key, _chunk_size, _destination_offset, _source_offset, _size in fragments
-        ]
-        dst_offsets = [
-            [fragment_destination_offset]
-            for _key, _chunk_size, fragment_destination_offset, _source_offset, _size in fragments
-        ]
-        src_offsets = [
-            [source_offset]
-            for _key, _chunk_size, _destination_offset, source_offset, _size in fragments
-        ]
-        sizes = [
-            [size]
-            for _key, _chunk_size, _destination_offset, _source_offset, size in fragments
-        ]
-        results = get_into_ranges(
-            [base_ptr], [keys], [dst_offsets], [src_offsets], [sizes]
-        )
-        if len(results) != 1 or len(results[0]) != len(keys):
-            raise RuntimeError(
-                f"get_into_ranges returned invalid ranged result shape for {len(keys)} chunks"
-            )
-        for key, expected_sizes, actual_sizes in zip(keys, sizes, results[0]):
-            if len(actual_sizes) != len(expected_sizes):
-                raise RuntimeError(
-                    f"get_into_ranges returned invalid ranged fragment count for {key}"
-                )
-            for expected_size, actual_size in zip(expected_sizes, actual_sizes):
-                if actual_size != expected_size:
-                    raise RuntimeError(
-                        f"get_into_ranges failed for {key}: expected {expected_size}, got {actual_size}"
-                    )
-        return True
 
     def _copy_payload_range_into_destination(
         self,
@@ -4705,9 +4648,15 @@ class _MooncakePayloadTransport:
                     raise RuntimeError(
                         f"get failed for {key}: expected {chunk_size} bytes, got {len(data)}"
                     )
-                destination[
-                    fragment_destination_offset : fragment_destination_offset + size
-                ] = data[fragment_source_offset : fragment_source_offset + size]
+                source_slice = data[fragment_source_offset : fragment_source_offset + size]
+                if isinstance(destination, np.ndarray):
+                    destination[
+                        fragment_destination_offset : fragment_destination_offset + size
+                    ] = np.frombuffer(source_slice, dtype=np.uint8)
+                else:
+                    destination[
+                        fragment_destination_offset : fragment_destination_offset + size
+                    ] = source_slice
 
     def _copy_payload_range_into_bytearray(
         self,

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -6,9 +6,8 @@ import json
 import uuid
 from collections.abc import Iterable
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
-from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import Any, Callable, Iterator, Literal, Mapping, Optional, Protocol, Sequence
+from typing import Any, Literal, Mapping, Optional, Protocol, Sequence
 
 import numpy as np
 
@@ -47,15 +46,25 @@ class BundleTransferPolicy:
 
 @dataclass(frozen=True)
 class FieldSchema:
-    """Schema hint for DataProto fields.
+    """Schema hint for a non_tensor_batch field, bypassing runtime inference.
 
-    ``metadata["section"]`` may pin a field to ``batch``,
-    ``non_tensor_batch``, or ``meta_info``.
+    When provided to put_dataproto via field_schemas, the field will be encoded
+    using the specified codec without running any sample-based inference.
+
+    Supported codec values:
+      - "ragged_tensor_dict": list[dict[str, Tensor] | None]
+      - "ragged_tensor": list[Tensor | None]
+      - "typed_ragged": list[ndarray | list | None]
+      - "utf8_ragged": list[str | None]
+      - "msgpack_ragged": list[Any] (msgpack-serializable)
+      - "json_ragged": list[Any] (json-serializable)
+      - "bytes_ragged": list[bytes | None]
+      - "ndarray": list[numeric scalar]
     """
 
     codec: str
     nullable: bool = True
-    metadata: dict[str, Any] = field(default_factory=dict)
+    metadata: dict = field(default_factory=dict)
 
 
 @dataclass
@@ -136,11 +145,102 @@ class _TensorObjectBufferPayload:
 
 
 @dataclass(frozen=True)
+class _MultiBufferPayload:
+    buffers: tuple[memoryview, ...]
+    owners: tuple[Any, ...] = ()
+
+    @property
+    def nbytes(self) -> int:
+        return _buffer_group_nbytes(self.buffers)
+
+
+def _validate_tensor_object_buffer_owner(value: _TensorObjectBufferPayload) -> None:
+    owner = value.owner
+    lease = getattr(owner, "lease", owner)
+    lease_ptr = getattr(lease, "ptr", None)
+    lease_size = getattr(lease, "size", None)
+    if lease_ptr is None and lease_size is None:
+        return
+    if lease_ptr is None or lease_size is None:
+        raise RuntimeError("tensor object buffer owner has incomplete buffer metadata")
+    if int(lease_ptr) != value.ptr or int(lease_size) < value.size:
+        raise ValueError("tensor object buffer must be backed by its owner lease")
+
+
+@dataclass(frozen=True)
 class _RawDestinationBuffer:
     ptr: int
     size: int
     owner: Any
     pre_registered: bool = False
+
+
+class _PoolLeaseOwner:
+    def __init__(self, lease: Any) -> None:
+        self.lease = lease
+        self.released = False
+
+    def release(self) -> None:
+        if not self.released:
+            self.lease.release()
+            self.released = True
+
+    def __del__(self) -> None:
+        self.release()
+
+
+class _PoolBackedNdarray(np.ndarray):
+    def __new__(
+        cls, owner: _PoolLeaseOwner, dtype: np.dtype[Any], shape: tuple[int, ...]
+    ) -> "_PoolBackedNdarray":
+        nbytes = (
+            int(np.prod(shape, dtype=np.int64)) * dtype.itemsize
+            if shape
+            else dtype.itemsize
+        )
+        array = (
+            np.ctypeslib.as_array(
+                (ctypes.c_uint8 * nbytes).from_address(owner.lease.ptr)
+            )
+            .view(dtype)
+            .reshape(shape)
+            .view(cls)
+        )
+        array._mooncake_pool_owner = owner
+        return array
+
+    @classmethod
+    def _from_shared_pool(
+        cls,
+        owner: _PoolLeaseOwner,
+        dtype: np.dtype[Any],
+        shape: tuple[int, ...],
+        offset: int,
+    ) -> "_PoolBackedNdarray":
+        """Create pool-backed ndarray at an offset within a shared lease."""
+        nbytes = (
+            int(np.prod(shape, dtype=np.int64)) * dtype.itemsize
+            if shape
+            else dtype.itemsize
+        )
+        array = (
+            np.ctypeslib.as_array(
+                (ctypes.c_uint8 * nbytes).from_address(owner.lease.ptr + offset)
+            )
+            .view(dtype)
+            .reshape(shape)
+            .view(cls)
+        )
+        array._mooncake_pool_owner = owner
+        return array
+
+    def __array_finalize__(self, obj: Any) -> None:
+        # WARNING: slicing/viewing propagates the same _PoolLeaseOwner to the
+        # derived array.  If the original array is GC'd first its __del__
+        # releases the pool lease, leaving the slice pointing at freed memory.
+        # Callers must ensure the original array outlives any derived views.
+        if obj is not None:
+            self._mooncake_pool_owner = getattr(obj, "_mooncake_pool_owner", None)
 
 
 @dataclass(frozen=True)
@@ -391,7 +491,6 @@ class MooncakeBundleTransfer:
         chunk_bytes: Optional[int] = None,
         policy: Optional[BundleTransferPolicy] = None,
         max_inflight_put: Optional[int] = None,
-        pre_registered_buffers: Optional[Mapping[str, bool]] = None,
     ) -> RemoteBundleRef:
         """Store raw metadata bytes plus named buffers as a low-level bundle."""
         return self._bundle_store.put_bundle(
@@ -401,7 +500,6 @@ class MooncakeBundleTransfer:
             chunk_bytes=chunk_bytes,
             policy=policy,
             max_inflight_put=max_inflight_put,
-            pre_registered_buffers=pre_registered_buffers,
         )
 
     def remove_bundle(self, ref: RemoteBundleRef | Mapping[str, Any]) -> None:
@@ -415,7 +513,6 @@ class MooncakeBundleTransfer:
         chunk_bytes: Optional[int] = None,
         policy: Optional[BundleTransferPolicy] = None,
         max_inflight_put: Optional[int] = None,
-        pre_registered_buffers: Optional[Mapping[str, bool]] = None,
     ) -> RemoteBundleRef:
         """Store a structured object described by JSON metadata plus named members."""
         return self._structured_store.put_structured_object(
@@ -424,7 +521,6 @@ class MooncakeBundleTransfer:
             chunk_bytes=chunk_bytes,
             policy=policy,
             max_inflight_put=max_inflight_put,
-            pre_registered_buffers=pre_registered_buffers,
         )
 
     def put_object(
@@ -485,7 +581,7 @@ class MooncakeBundleTransfer:
         stage: str = "default",
         chunk_bytes: Optional[int] = None,
         policy: Optional[BundleTransferPolicy] = None,
-        field_schemas: Optional[Mapping[str, FieldSchema]] = None,
+        field_schemas: Optional[dict[str, FieldSchema]] = None,
     ) -> MooncakeDataProtoRef:
         """Store DataProto fields, optionally using schema hints for non-tensor fields."""
         return self._put_dataproto_stage(
@@ -509,7 +605,7 @@ class MooncakeBundleTransfer:
         overwrite: bool = False,
         chunk_bytes: Optional[int] = None,
         policy: Optional[BundleTransferPolicy] = None,
-        field_schemas: Optional[Mapping[str, FieldSchema]] = None,
+        field_schemas: Optional[dict[str, FieldSchema]] = None,
     ) -> MooncakeDataProtoRef:
         """Append DataProto fields, optionally using schema hints for new fields."""
         ref = _resolve_dataproto_ref(ref)
@@ -606,43 +702,67 @@ class MooncakeBundleTransfer:
                     batch[name] = value
                 else:
                     non_tensor_batch[name] = value
-        for name, location in encoded_requests:
-            stage_ref = ref.stage_refs[location.stage]
-            encoded = ref.encoded_non_tensor[name]
-            if row_selection is None:
-                members = list(encoded["payload_members"].values())
+        if row_selection is None and encoded_requests:
+            # Group encoded fields by stage for batched materialize
+            by_stage_encoded: dict[str, list[tuple[str, Any]]] = {}
+            for name, location in encoded_requests:
+                by_stage_encoded.setdefault(location.stage, []).append(
+                    (name, location)
+                )
+            for stage, entries in by_stage_encoded.items():
+                stage_ref = ref.stage_refs[stage]
+                all_members: list[str] = []
+                for name, _loc in entries:
+                    encoded = ref.encoded_non_tensor[name]
+                    all_members.extend(encoded["payload_members"].values())
+                # Single materialize for all sub-members in this stage
                 result = self.materialize(
-                    self.read_spec(stage_ref).select_members(members)
+                    self.read_spec(stage_ref).select_members(all_members)
                 )
-                payload = {
-                    payload_name: result.objects[member]
-                    for payload_name, member in encoded["payload_members"].items()
-                }
-                values = _decode_structured_non_tensor_encoded(
-                    encoded, payload, ref.batch_size, encoded.get("metadata")
-                )
-            elif row_indices is not None:
-                payload, metadata = self._read_structured_non_tensor_payload_indices(
-                    stage_ref,
-                    encoded,
-                    row_indices,
-                )
-                values = _decode_structured_non_tensor_encoded(
-                    encoded, payload, output_rows, metadata
-                )
-            else:
-                payload, metadata = self._read_structured_non_tensor_payload_slice(
-                    stage_ref,
-                    encoded,
-                    row_slice,
-                    ref.batch_size,
-                )
-                values = _decode_structured_non_tensor_encoded(
-                    encoded, payload, output_rows, metadata
-                )
-            array = np.empty(output_rows, dtype=object)
-            array[:] = values
-            non_tensor_batch[name] = array
+                for name, _loc in entries:
+                    encoded = ref.encoded_non_tensor[name]
+                    payload = {
+                        payload_name: result.objects[member]
+                        for payload_name, member in encoded[
+                            "payload_members"
+                        ].items()
+                    }
+                    values = _decode_structured_non_tensor_encoded(
+                        encoded, payload, ref.batch_size, encoded.get("metadata")
+                    )
+                    array = np.empty(output_rows, dtype=object)
+                    array[:] = values
+                    non_tensor_batch[name] = array
+        else:
+            for name, location in encoded_requests:
+                stage_ref = ref.stage_refs[location.stage]
+                encoded = ref.encoded_non_tensor[name]
+                if row_indices is not None:
+                    payload, metadata = (
+                        self._read_structured_non_tensor_payload_indices(
+                            stage_ref,
+                            encoded,
+                            row_indices,
+                        )
+                    )
+                    values = _decode_structured_non_tensor_encoded(
+                        encoded, payload, output_rows, metadata
+                    )
+                else:
+                    payload, metadata = (
+                        self._read_structured_non_tensor_payload_slice(
+                            stage_ref,
+                            encoded,
+                            row_slice,
+                            ref.batch_size,
+                        )
+                    )
+                    values = _decode_structured_non_tensor_encoded(
+                        encoded, payload, output_rows, metadata
+                    )
+                array = np.empty(output_rows, dtype=object)
+                array[:] = values
+                non_tensor_batch[name] = array
         meta_info = _select_mapping(ref.meta_info, meta_info_keys)
         return _build_dataproto_like_result(
             batch, non_tensor_batch, meta_info, data_cls
@@ -659,7 +779,9 @@ class MooncakeBundleTransfer:
         metadata = _decode_structured_metadata(
             self._bundle_store.read_payload(manifest["meta"])
         )
-        field_spec = _structured_field_specs(metadata).get(member, {"encoding": "bytes"})
+        field_spec = _structured_field_specs(metadata).get(
+            member, {"encoding": "bytes"}
+        )
         payload_spec = manifest["buffers"][member]
         encoding = field_spec.get("encoding", "bytes")
         if encoding == "ndarray":
@@ -689,7 +811,9 @@ class MooncakeBundleTransfer:
         dtype_obj = np.dtype(dtype)
         full_shape = tuple(int(dim) for dim in shape)
         if not full_shape:
-            raise ValueError("structured ndarray indexed read requires at least one dimension")
+            raise ValueError(
+                "structured ndarray indexed read requires at least one dimension"
+            )
         output_shape = (len(indices), *full_shape[1:])
         if isinstance(destination, _RawDestinationBuffer):
             nbytes = int(np.prod(output_shape, dtype=np.int64)) * dtype_obj.itemsize
@@ -697,12 +821,18 @@ class MooncakeBundleTransfer:
                 raise ValueError(
                     f"raw destination has {destination.size} bytes, expected at least {nbytes}"
                 )
-            target = np.ctypeslib.as_array(
-                (ctypes.c_uint8 * nbytes).from_address(destination.ptr)
-            ).view(dtype_obj).reshape(output_shape)
+            target = (
+                np.ctypeslib.as_array(
+                    (ctypes.c_uint8 * nbytes).from_address(destination.ptr)
+                )
+                .view(dtype_obj)
+                .reshape(output_shape)
+            )
             if not indices:
                 return target
-            row_width = dtype_obj.itemsize * int(np.prod(full_shape[1:], dtype=np.int64))
+            row_width = dtype_obj.itemsize * int(
+                np.prod(full_shape[1:], dtype=np.int64)
+            )
             ranges = [
                 (row * row_width, out * row_width, row_width)
                 for out, row in enumerate(indices)
@@ -719,7 +849,9 @@ class MooncakeBundleTransfer:
                 ctypes.memmove(destination.ptr, bytes(data), nbytes)
             _ = destination.owner
             return target
-        target = _resolve_ndarray_destination(name, destination, dtype_obj, output_shape)
+        target = _resolve_ndarray_destination(
+            name, destination, dtype_obj, output_shape
+        )
         if not indices:
             return target
         row_width = dtype_obj.itemsize * int(np.prod(full_shape[1:], dtype=np.int64))
@@ -749,17 +881,24 @@ class MooncakeBundleTransfer:
                 f"structured tensor field {name} is missing slice metadata"
             )
         if not shape:
-            raise ValueError("structured tensor indexed read requires at least one dimension")
+            raise ValueError(
+                "structured tensor indexed read requires at least one dimension"
+            )
         row_width = element_size * int(np.prod(shape[1:], dtype=np.int64))
         data_length = len(indices) * row_width
-        metadata = self._bundle_store.read_payload_range(payload_spec, 0, metadata_bytes)
+        metadata = self._bundle_store.read_payload_range(
+            payload_spec, 0, metadata_bytes
+        )
         sliced_metadata = _slice_tensor_metadata(
             metadata, (len(indices), *shape[1:]), data_length
         )
         if destination is not None:
-            if not isinstance(destination, (_TensorObjectBufferPayload, _RawDestinationBuffer)):
+            if not isinstance(
+                destination, (_TensorObjectBufferPayload, _RawDestinationBuffer)
+            ):
                 raise ValueError(
-                    f"structured tensor member {name} only supports tensor_object_buffer or raw_destination destinations"
+                    f"structured tensor member {name} only supports tensor_object_buffer "
+                    "or raw_destination destinations"
                 )
             expected_bytes = metadata_bytes + data_length
             if destination.size < expected_bytes:
@@ -776,7 +915,10 @@ class MooncakeBundleTransfer:
                     )
                     for out, row in enumerate(indices)
                 ]
-                if isinstance(destination, _RawDestinationBuffer) and destination.pre_registered:
+                if (
+                    isinstance(destination, _RawDestinationBuffer)
+                    and destination.pre_registered
+                ):
                     self._bundle_store.read_payload_ranges_into_raw_destination(
                         payload_spec, destination.ptr, ranges
                     )
@@ -800,7 +942,10 @@ class MooncakeBundleTransfer:
             self._bundle_store.read_payload_ranges_into_bytearray(
                 payload_spec,
                 data,
-                [(metadata_bytes + row * row_width, out * row_width, row_width) for out, row in enumerate(indices)],
+                [
+                    (metadata_bytes + row * row_width, out * row_width, row_width)
+                    for out, row in enumerate(indices)
+                ],
             )
         return _deserialize_tensor_payload(sliced_metadata + data)
 
@@ -831,7 +976,9 @@ class MooncakeBundleTransfer:
                 )
             return np.dtype(dtype)
 
-        def read_member_indices(payload_name: str, member_indices: Sequence[int]) -> Any:
+        def read_member_indices(
+            payload_name: str, member_indices: Sequence[int]
+        ) -> Any:
             return self._read_dataproto_member_indices(
                 stage_ref, member(payload_name), member_indices, None
             )
@@ -862,9 +1009,7 @@ class MooncakeBundleTransfer:
                 for key in ("missing_payload", "row_mask_payload", "lengths_payload"):
                     payload_name = node.get(key)
                     if payload_name is not None:
-                        recursive_payload[payload_name] = read_member_indices(
-                            payload_name, indices
-                        )
+                        recursive_payload[payload_name] = read_member_indices()
             for leaf in metadata.get("leaves", []):
                 leaf_payload_members = leaf["payload_members"]
                 flat_payload_members = {
@@ -872,22 +1017,71 @@ class MooncakeBundleTransfer:
                     for name, global_name in leaf_payload_members.items()
                     if name != "missing"
                 }
-                leaf_payload, _leaf_metadata = self._read_structured_non_tensor_payload_indices(
-                    stage_ref,
-                    {
-                        "codec": leaf["codec"],
-                        "metadata": leaf.get("metadata") or {},
-                        "payload_members": flat_payload_members,
-                    },
-                    indices,
+                leaf_payload, _leaf_metadata = (
+                    self._read_structured_non_tensor_payload_indices(
+                        stage_ref,
+                        {
+                            "codec": leaf["codec"],
+                            "metadata": leaf.get("metadata") or {},
+                            "payload_members": flat_payload_members,
+                        },
+                        indices,
+                    )
                 )
                 leaf["metadata"] = _leaf_metadata
                 for name, value in leaf_payload.items():
                     recursive_payload[leaf_payload_members[name]] = value
-                recursive_payload[leaf_payload_members["missing"]] = read_member_indices(
-                    leaf_payload_members["missing"], indices
+                recursive_payload[leaf_payload_members["missing"]] = (
+                    read_member_indices(leaf_payload_members["missing"], indices)
                 )
             return recursive_payload, metadata
+
+        if codec == "ragged_tensor_dict":
+            keys = metadata.get("keys", [])
+            result_payload: dict[str, Any] = {
+                "null_mask": read_member_indices("null_mask", indices),
+            }
+            for key in keys:
+                sub_offsets = read_member_indices(
+                    f"{key}.offsets",
+                    [index for row in indices for index in (row, row + 1)],
+                )
+                begins = sub_offsets[0::2]
+                ends = sub_offsets[1::2]
+                item_counts = [
+                    int(end) - int(begin) for begin, end in zip(begins, ends)
+                ]
+                gathered_offsets = np.empty(len(indices) + 1, dtype=sub_offsets.dtype)
+                gathered_offsets[0] = 0
+                for idx, count in enumerate(item_counts):
+                    gathered_offsets[idx + 1] = int(gathered_offsets[idx]) + count
+                dtype = member_dtype(f"{key}.data")
+                ranges = []
+                destination_item = 0
+                for begin, count in zip(begins, item_counts):
+                    if count:
+                        ranges.append(
+                            (
+                                int(begin) * dtype.itemsize,
+                                destination_item * dtype.itemsize,
+                                count * dtype.itemsize,
+                            )
+                        )
+                    destination_item += count
+                result_payload[f"{key}.data"] = read_data_ranges(
+                    f"{key}.data", ranges, dtype
+                )
+                result_payload[f"{key}.offsets"] = gathered_offsets
+                result_payload[f"{key}.shapes"] = read_member_indices(
+                    f"{key}.shapes", indices
+                )
+                result_payload[f"{key}.ndims"] = read_member_indices(
+                    f"{key}.ndims", indices
+                )
+                result_payload[f"{key}.nulls"] = read_member_indices(
+                    f"{key}.nulls", indices
+                )
+            return result_payload, metadata
 
         if codec == "ndarray":
             return {
@@ -919,6 +1113,9 @@ class MooncakeBundleTransfer:
                         )
                     )
                 destination_item += count
+            if codec == "typed_ragged" and metadata.get("row_format") == "mixed":
+                ndarray_rows = metadata.get("ndarray_rows") or []
+                metadata["ndarray_rows"] = [ndarray_rows[index] for index in indices]
             return {
                 "data": read_data_ranges("data", ranges, dtype),
                 "offsets": gathered_offsets,
@@ -927,17 +1124,13 @@ class MooncakeBundleTransfer:
                 "nulls": read_member_indices("nulls", indices),
             }, metadata
 
-        if codec == "ragged_tensor_dict":
-            return self._read_ragged_tensor_dict_payload(
-                payload_members,
-                metadata,
-                read_null_mask=lambda: read_member_indices("null_mask", indices),
-                read_key_payload=lambda encoded: self._read_structured_non_tensor_payload_indices(
-                    stage_ref, encoded, indices
-                ),
-            )
-
-        if codec in {"media_bytes", "bytes_ragged", "utf8_ragged", "msgpack_ragged", "json_ragged"}:
+        if codec in {
+            "media_bytes",
+            "bytes_ragged",
+            "utf8_ragged",
+            "msgpack_ragged",
+            "json_ragged",
+        }:
             offsets = read_member_indices(
                 "offsets", [index for row in indices for index in (row, row + 1)]
             )
@@ -975,7 +1168,9 @@ class MooncakeBundleTransfer:
             gathered_row_offsets = np.empty(len(indices) + 1, dtype=row_offsets.dtype)
             gathered_row_offsets[0] = 0
             for index, count in enumerate(item_counts):
-                gathered_row_offsets[index + 1] = int(gathered_row_offsets[index]) + count
+                gathered_row_offsets[index + 1] = (
+                    int(gathered_row_offsets[index]) + count
+                )
             boundary_indices = [
                 boundary
                 for begin, end in zip(item_begins, item_ends)
@@ -1057,7 +1252,9 @@ class MooncakeBundleTransfer:
                 for key in ("missing_payload", "row_mask_payload", "lengths_payload"):
                     payload_name = node.get(key)
                     if payload_name is not None:
-                        recursive_payload[payload_name] = read_member(payload_name, start, end)
+                        recursive_payload[payload_name] = read_member(
+                            payload_name, start, end
+                        )
             for leaf in metadata.get("leaves", []):
                 leaf_payload_members = leaf["payload_members"]
                 flat_payload_members = {
@@ -1065,15 +1262,17 @@ class MooncakeBundleTransfer:
                     for name, global_name in leaf_payload_members.items()
                     if name != "missing"
                 }
-                leaf_payload, _leaf_metadata = self._read_structured_non_tensor_payload_slice(
-                    stage_ref,
-                    {
-                        "codec": leaf["codec"],
-                        "metadata": leaf.get("metadata") or {},
-                        "payload_members": flat_payload_members,
-                    },
-                    row_slice,
-                    total_rows,
+                leaf_payload, _leaf_metadata = (
+                    self._read_structured_non_tensor_payload_slice(
+                        stage_ref,
+                        {
+                            "codec": leaf["codec"],
+                            "metadata": leaf.get("metadata") or {},
+                            "payload_members": flat_payload_members,
+                        },
+                        row_slice,
+                        total_rows,
+                    )
                 )
                 leaf["metadata"] = _leaf_metadata
                 for name, value in leaf_payload.items():
@@ -1082,6 +1281,25 @@ class MooncakeBundleTransfer:
                     leaf_payload_members["missing"], start, end
                 )
             return recursive_payload, metadata
+
+        if codec == "ragged_tensor_dict":
+            keys = metadata.get("keys", [])
+            result_payload: dict[str, Any] = {
+                "null_mask": read_member("null_mask", start, end),
+            }
+            for key in keys:
+                sub_offsets = read_member(f"{key}.offsets", start, end + 1)
+                base = int(sub_offsets[0])
+                limit = int(sub_offsets[-1])
+                sub_offsets = sub_offsets - base
+                result_payload[f"{key}.data"] = read_member(f"{key}.data", base, limit)
+                result_payload[f"{key}.offsets"] = sub_offsets
+                result_payload[f"{key}.shapes"] = read_member(
+                    f"{key}.shapes", start, end
+                )
+                result_payload[f"{key}.ndims"] = read_member(f"{key}.ndims", start, end)
+                result_payload[f"{key}.nulls"] = read_member(f"{key}.nulls", start, end)
+            return result_payload, metadata
 
         if codec == "ndarray":
             return {
@@ -1094,6 +1312,10 @@ class MooncakeBundleTransfer:
             base = int(offsets[0])
             limit = int(offsets[-1])
             offsets = offsets - base
+            if codec == "typed_ragged" and metadata.get("row_format") == "mixed":
+                metadata["ndarray_rows"] = (metadata.get("ndarray_rows") or [])[
+                    start:end
+                ]
             return {
                 "data": read_member("data", base, limit),
                 "offsets": offsets,
@@ -1102,17 +1324,13 @@ class MooncakeBundleTransfer:
                 "nulls": read_member("nulls", start, end),
             }, metadata
 
-        if codec == "ragged_tensor_dict":
-            return self._read_ragged_tensor_dict_payload(
-                payload_members,
-                metadata,
-                read_null_mask=lambda: read_member("null_mask", start, end),
-                read_key_payload=lambda encoded: self._read_structured_non_tensor_payload_slice(
-                    stage_ref, encoded, row_slice, total_rows
-                ),
-            )
-
-        if codec in {"media_bytes", "bytes_ragged", "utf8_ragged", "msgpack_ragged", "json_ragged"}:
+        if codec in {
+            "media_bytes",
+            "bytes_ragged",
+            "utf8_ragged",
+            "msgpack_ragged",
+            "json_ragged",
+        }:
             offsets = read_member("offsets", start, end + 1)
             base = int(offsets[0])
             limit = int(offsets[-1])
@@ -1186,6 +1404,36 @@ class MooncakeBundleTransfer:
             seen.add(stage_ref.manifest_key)
             self.remove_bundle(stage_ref)
 
+    def put_legacy_dict(
+        self,
+        data: Mapping[str, Any],
+        *,
+        namespace: str = "default",
+        partition: str = "default",
+        stage: str = "default",
+        chunk_bytes: Optional[int] = None,
+        policy: Optional[BundleTransferPolicy] = None,
+        field_schemas: Optional[Mapping[str, "FieldSchema"]] = None,
+    ) -> MooncakeDataProtoRef:
+        """Store a legacy rollout dict through the DataProto structured-object path."""
+        return self.put_dataproto(
+            _legacy_dict_to_dataproto_envelope(data),
+            namespace=namespace,
+            partition=partition,
+            stage=stage,
+            chunk_bytes=chunk_bytes,
+            policy=policy,
+            field_schemas=field_schemas,
+        )
+
+    def get_legacy_dict(self, ref: DataProtoRefLike) -> dict[str, Any]:
+        """Materialize a legacy rollout dict stored by put_legacy_dict()."""
+        return _dataproto_envelope_to_legacy_dict(self.get_dataproto(ref))
+
+    def remove_legacy_dict(self, ref: DataProtoRefLike) -> None:
+        """Remove a legacy rollout dict stored by put_legacy_dict()."""
+        self.cleanup_dataproto(ref)
+
     def _append_dataproto_stage_manifest(
         self,
         old_stage_ref: RemoteBundleRef,
@@ -1250,7 +1498,7 @@ class MooncakeBundleTransfer:
         chunk_bytes: Optional[int],
         policy: Optional[BundleTransferPolicy],
         overwrite: bool,
-        field_schemas: Optional[Mapping[str, FieldSchema]] = None,
+        field_schemas: Optional[dict[str, FieldSchema]] = None,
     ) -> MooncakeDataProtoRef:
         batch, non_tensor_batch, meta_info = _split_dataproto_like(data)
         _validate_dataproto_schema_sections(
@@ -1274,31 +1522,14 @@ class MooncakeBundleTransfer:
             field_updates[name] = StructuredFieldLocation(stage, member, "batch")
         encoded_updates: dict[str, Any] = {}
         for name, value in non_tensor_batch.items():
-            schema = _schema_for_section(
-                field_schemas, name, "non_tensor_batch"
-            )
-            encoded: _EncodedStructuredLeaf | None = None
-            if schema is not None:
-                try:
-                    encode_value = _coerce_schema_non_tensor_value(name, value)
-                    if schema.codec == "auto":
-                        _validate_schema_nullable(
-                            f"non_tensor_batch.{name}", encode_value, schema
-                        )
-                    else:
-                        encoded = _encode_with_schema(
-                            f"non_tensor_batch.{name}", encode_value, schema
-                        )
-                except (TypeError, ValueError, RuntimeError, AttributeError) as exc:
-                    raise type(exc)(
-                        f"failed to encode non_tensor_batch field {name!r} "
-                        f"with FieldSchema codec {schema.codec!r}: {exc}"
-                    ) from exc
-            if encoded is None and _should_encode_non_tensor_field(value):
-                encoded = _encode_structured_non_tensor_field(
-                    f"non_tensor_batch.{name}", value
-                )
-            if encoded is not None:
+            if _should_encode_non_tensor_field(value):
+                schema = field_schemas.get(name) if field_schemas else None
+                if schema is not None:
+                    encoded = _encode_with_schema(
+                        f"non_tensor_batch.{name}", value, schema
+                    )
+                else:
+                    encoded = _encode_with_fallback(f"non_tensor_batch.{name}", value)
                 payload_members: dict[str, str] = {}
                 for payload_name, payload_value in encoded.payload.items():
                     member = f"non_tensor_batch.{name}.{payload_name}"
@@ -1489,6 +1720,67 @@ def _dataproto_manifest_view(
     }
 
 
+LEGACY_DICT_META_FIELDS = frozenset(
+    {
+        "raw_reward",
+        "total_lengths",
+        "global_batch_sizes",
+        "num_microbatches",
+        "micro_batch_indices",
+    }
+)
+
+
+def _legacy_dict_to_dataproto_envelope(data: Mapping[str, Any]) -> dict[str, Any]:
+    if not isinstance(data, Mapping):
+        raise TypeError("legacy rollout data must be a mapping")
+    partition = data.get("partition")
+    if not isinstance(partition, list):
+        raise ValueError("legacy rollout data must contain a list 'partition' field")
+    row_count = len(partition)
+    batch: dict[str, Any] = {}
+    non_tensor_batch: dict[str, Any] = {}
+    meta_info: dict[str, Any] = {}
+    for key, value in data.items():
+        if key in LEGACY_DICT_META_FIELDS:
+            meta_info[key] = value
+        elif _is_row_aligned_dense_field(value, row_count):
+            batch[key] = value
+        elif isinstance(value, list) and len(value) == row_count:
+            array = np.empty(row_count, dtype=object)
+            array[:] = value
+            non_tensor_batch[key] = array
+        else:
+            meta_info[key] = value
+    return {
+        "batch": batch,
+        "non_tensor_batch": non_tensor_batch,
+        "meta_info": meta_info,
+    }
+
+
+def _dataproto_envelope_to_legacy_dict(data: Mapping[str, Any]) -> dict[str, Any]:
+    result = dict(_mapping_to_dict(data.get("meta_info")))
+    result.update(_mapping_to_dict(data.get("batch")))
+    for key, value in _mapping_to_dict(data.get("non_tensor_batch")).items():
+        result[key] = (
+            value.tolist()
+            if isinstance(value, np.ndarray) and value.dtype == object
+            else value
+        )
+    return result
+
+
+def _is_row_aligned_dense_field(value: Any, row_count: int) -> bool:
+    if _torch is not None and isinstance(value, _torch.Tensor):
+        return value.shape[:1] == (row_count,)
+    return (
+        isinstance(value, np.ndarray)
+        and value.dtype != object
+        and value.shape[:1] == (row_count,)
+    )
+
+
 def _build_dataproto_like_result(
     batch: dict[str, Any],
     non_tensor_batch: dict[str, Any],
@@ -1610,9 +1902,7 @@ def _resolve_dataproto_field_selection(
         ]
     else:
         batch_names = [] if batch_fields is None else list(batch_fields)
-        non_tensor_names = (
-            [] if non_tensor_fields is None else list(non_tensor_fields)
-        )
+        non_tensor_names = [] if non_tensor_fields is None else list(non_tensor_fields)
     _validate_dataproto_fields_exist(ref, [*batch_names, *non_tensor_names])
     return batch_names, non_tensor_names
 
@@ -1646,9 +1936,13 @@ def _coerce_dataproto_row_selection(
             count=_slice_length(member_slice, total_rows), member_slice=member_slice
         )
     if isinstance(rows, Sequence) and not isinstance(rows, (str, bytes, bytearray)):
-        indices = tuple(_normalize_dataproto_row_index(index, total_rows) for index in rows)
+        indices = tuple(
+            _normalize_dataproto_row_index(index, total_rows) for index in rows
+        )
         return _DataProtoRowSelection(count=len(indices), indices=indices)
-    raise TypeError("DataProto rows must be a slice, StructuredMemberSlice, or row index sequence")
+    raise TypeError(
+        "DataProto rows must be a slice, StructuredMemberSlice, or row index sequence"
+    )
 
 
 def _normalize_dataproto_row_index(index: Any, total_rows: int) -> int:
@@ -1658,7 +1952,9 @@ def _normalize_dataproto_row_index(index: Any, total_rows: int) -> int:
     if normalized < 0:
         normalized += total_rows
     if normalized < 0 or normalized >= total_rows:
-        raise IndexError(f"DataProto row index {index} out of range for {total_rows} rows")
+        raise IndexError(
+            f"DataProto row index {index} out of range for {total_rows} rows"
+        )
     return normalized
 
 
@@ -1782,111 +2078,78 @@ def _should_encode_non_tensor_field(value: Any) -> bool:
     return isinstance(value, np.ndarray) and value.dtype == object
 
 
-def _encode_structured_non_tensor_field(
-    path: str, value: np.ndarray
-) -> _EncodedStructuredLeaf:
-    values = list(value)
-    leaves: list[_InferredLeaf] = []
-    nodes: list[_InferredNode] = []
-    infer_structure(path, values, leaves, nodes)
-    if nodes and _should_encode_recursive_structure(leaves):
-        return _encode_recursive_structured_non_tensor_field(path, values, leaves, nodes)
-    decision = _choose_leaf_codec(values)
-    return _encode_structured_leaf(values, decision)
+# ---------------------------------------------------------------------------
+# Schema-driven encoding dispatch
+# ---------------------------------------------------------------------------
 
 
 def _encode_with_schema(
     path: str, value: np.ndarray, schema: FieldSchema
-) -> _EncodedStructuredLeaf:
+) -> "_EncodedStructuredLeaf":
+    """Encode a non_tensor_batch field using an explicit schema (no inference)."""
     values = list(value)
-    _validate_schema_nullable(path, value, schema)
     codec = schema.codec
-    if codec not in _FIELD_SCHEMA_CODECS:
-        raise ValueError(f"unsupported schema codec: {codec!r}")
-    if codec == "auto":
-        return _encode_structured_non_tensor_field(path, value)
     if codec == "ragged_tensor_dict":
         return _encode_ragged_tensor_dict_values(values, schema)
     if codec == "ragged_tensor":
         payload, metadata = _encode_ragged_tensor_values(values)
     elif codec == "typed_ragged":
-        payload, metadata = _encode_typed_ragged_values(
-            values, dtype_hint=_schema_ndarray_dtype(schema)
-        )
+        payload, metadata = _encode_typed_ragged_values(values)
     elif codec == "ndarray":
-        dtype = _schema_ndarray_dtype(schema, required=True)
         decision = _CodecDecision(
-            True, "ndarray", "schema", "numeric scalar", {"dtype": str(dtype)}
+            True, "ndarray", "schema", "numeric scalar", schema.metadata
         )
         payload, metadata = _encode_numeric_scalar_values(values, decision)
-    elif codec in ("bytes_ragged", "media_bytes"):
+    elif codec == "bytes_ragged":
+        payload, metadata = _encode_bytes_like_values(values)
+    elif codec == "media_bytes":
         payload, metadata = _encode_bytes_like_values(values)
     elif codec == "media_list_ragged":
         payload, metadata = _encode_media_list_values(values)
     elif codec == "utf8_ragged":
         payload, metadata = _encode_bytes_like_values(
-            [None if item is None else item.encode("utf-8") for item in values]
+            [None if v is None else v.encode("utf-8") for v in values]
         )
     elif codec == "msgpack_ragged":
-        payload, metadata = _encode_bytes_like_values(
-            [
+        try:
+            packed_values = [
                 None
-                if item is None
-                else _msgpack.packb(item, use_bin_type=True, strict_types=True)
-                for item in values
+                if v is None
+                else _msgpack.packb(v, use_bin_type=True, strict_types=True)
+                for v in values
             ]
-        )
+        except TypeError as exc:
+            raise ValueError(
+                f"unsupported structured non-tensor field {path}: "
+                "msgpack codec cannot encode value"
+            ) from exc
+        payload, metadata = _encode_bytes_like_values(packed_values)
     elif codec == "json_ragged":
         payload, metadata = _encode_bytes_like_values(
             [
                 None
-                if item is None
-                else json.dumps(item, ensure_ascii=False, separators=(",", ":")).encode(
+                if v is None
+                else json.dumps(v, ensure_ascii=False, separators=(",", ":")).encode(
                     "utf-8"
                 )
-                for item in values
+                for v in values
             ]
         )
     else:
         raise ValueError(f"unsupported schema codec: {codec!r}")
-    metadata.update({"schema_source": "field_schema"})
     return _EncodedStructuredLeaf(
         codec=codec, rows=len(values), payload=payload, metadata=metadata
     )
 
 
-def _should_encode_recursive_structure(leaves: Sequence[_InferredLeaf]) -> bool:
-    return any(_should_encode_recursive_leaf(leaf) for leaf in leaves)
-
-
-def _should_encode_recursive_leaf(leaf: _InferredLeaf) -> bool:
-    codec = leaf.decision.codec
-    if codec in {"ragged_tensor", "bytes_ragged", "media_bytes", "media_list_ragged"}:
-        return True
-    if codec == "typed_ragged":
-        return any(isinstance(value, np.ndarray) for value in _non_null(leaf.values))
-    return False
-
-
-def _recursive_leaf_decision(values: list[Any], decision: _CodecDecision) -> _CodecDecision:
-    if decision.accepted:
-        return decision
-    if all(value is None or isinstance(value, _Missing) for value in values):
-        return _CodecDecision(
-            True,
-            "json_ragged",
-            "all rows are null or missing",
-            "json",
-        )
-    return decision
-
-
-def _encode_recursive_structured_non_tensor_field(
-    path: str,
-    values: list[Any],
-    leaves: Sequence[_InferredLeaf],
-    nodes: Sequence[_InferredNode],
-) -> _EncodedStructuredLeaf:
+def _encode_recursive_if_structured(
+    path: str, values: list[Any]
+) -> "_EncodedStructuredLeaf | None":
+    leaves: list[_InferredLeaf] = []
+    nodes: list[_InferredNode] = []
+    _infer_structure(path, values, leaves, nodes)
+    if not nodes or not any(_should_encode_recursive_leaf(leaf) for leaf in leaves):
+        return None
     payload: dict[str, Any] = {}
     node_specs: list[dict[str, Any]] = []
     for node_id, node in enumerate(nodes):
@@ -1896,20 +2159,20 @@ def _encode_recursive_structured_non_tensor_field(
             "node_type": node.node_type,
             "children": list(node.children),
         }
-        missing_payload_name = f"node.{node_id}.missing"
-        payload[missing_payload_name] = np.asarray(
+        missing_name = f"node.{node_id}.missing"
+        payload[missing_name] = np.asarray(
             [_lookup_structured_path(value, path, node.path) is MISSING for value in values],
             dtype=np.bool_,
         )
-        spec["missing_payload"] = missing_payload_name
+        spec["missing_payload"] = missing_name
         if node.row_mask is not None:
-            payload_name = f"node.{node_id}.row_mask"
-            payload[payload_name] = np.asarray(node.row_mask, dtype=np.bool_)
-            spec["row_mask_payload"] = payload_name
+            row_mask_name = f"node.{node_id}.row_mask"
+            payload[row_mask_name] = np.asarray(node.row_mask, dtype=np.bool_)
+            spec["row_mask_payload"] = row_mask_name
         if node.lengths is not None:
-            payload_name = f"node.{node_id}.lengths"
-            payload[payload_name] = np.asarray(node.lengths, dtype=np.int64)
-            spec["lengths_payload"] = payload_name
+            lengths_name = f"node.{node_id}.lengths"
+            payload[lengths_name] = np.asarray(node.lengths, dtype=np.int64)
+            spec["lengths_payload"] = lengths_name
         node_specs.append(spec)
 
     leaf_specs: list[dict[str, Any]] = []
@@ -1917,17 +2180,28 @@ def _encode_recursive_structured_non_tensor_field(
         missing = np.asarray(
             [isinstance(value, _Missing) for value in leaf.values], dtype=np.bool_
         )
-        codec_values = [None if is_missing else value for is_missing, value in zip(missing, leaf.values)]
-        decision = _recursive_leaf_decision(leaf.values, leaf.decision)
-        encoded = _encode_structured_leaf(codec_values, decision)
+        codec_values = [
+            None if is_missing else value
+            for is_missing, value in zip(missing, leaf.values)
+        ]
+        decision = leaf.decision
+        if not decision.accepted and all(
+            value is None or isinstance(value, _Missing) for value in leaf.values
+        ):
+            decision = _CodecDecision(True, "json_ragged", "all rows are null or missing", "json")
+        encoded = _encode_with_schema(
+            leaf.path,
+            np.asarray(codec_values, dtype=object),
+            FieldSchema(codec=decision.codec, metadata=decision.metadata),
+        )
         leaf_payload_members: dict[str, str] = {}
         for payload_name, payload_value in encoded.payload.items():
-            recursive_payload_name = f"leaf.{leaf_id}.{payload_name}"
-            payload[recursive_payload_name] = payload_value
-            leaf_payload_members[payload_name] = recursive_payload_name
-        missing_payload_name = f"leaf.{leaf_id}.missing"
-        payload[missing_payload_name] = missing
-        leaf_payload_members["missing"] = missing_payload_name
+            recursive_name = f"leaf.{leaf_id}.{payload_name}"
+            payload[recursive_name] = payload_value
+            leaf_payload_members[payload_name] = recursive_name
+        missing_name = f"leaf.{leaf_id}.missing"
+        payload[missing_name] = missing
+        leaf_payload_members["missing"] = missing_name
         leaf_specs.append(
             {
                 "id": leaf_id,
@@ -1938,7 +2212,6 @@ def _encode_recursive_structured_non_tensor_field(
                 "payload_members": leaf_payload_members,
             }
         )
-
     return _EncodedStructuredLeaf(
         codec="structured_recursive",
         rows=len(values),
@@ -1953,116 +2226,54 @@ def _encode_recursive_structured_non_tensor_field(
     )
 
 
+def _should_encode_recursive_leaf(leaf: "_InferredLeaf") -> bool:
+    if leaf.decision.codec == "typed_ragged":
+        return leaf.decision.metadata.get("recursive_source") == "ndarray"
+    return leaf.decision.codec in {
+        "ragged_tensor",
+        "bytes_ragged",
+        "media_bytes",
+        "media_list_ragged",
+    }
+
+
+def _fallback_codec(values: list[Any]) -> str:
+    """Simple type-based codec selection (no recursive inference)."""
+    nn = [v for v in values if v is not None]
+    if not nn:
+        return "msgpack_ragged"
+    if _torch is not None and all(isinstance(v, _torch.Tensor) for v in nn):
+        return "ragged_tensor"
+    if all(isinstance(v, str) for v in nn):
+        return "utf8_ragged"
+    if all(isinstance(v, (bytes, bytearray, memoryview)) for v in nn):
+        return "bytes_ragged"
+    if all(isinstance(v, (bool, int, float, np.number)) for v in nn):
+        return "ndarray"
+    if all(isinstance(v, np.ndarray) for v in nn):
+        return "typed_ragged"
+    return "msgpack_ragged"
+
+
+def _encode_with_fallback(path: str, value: np.ndarray) -> "_EncodedStructuredLeaf":
+    """Encode using simple type-based fallback, with recursive expansion for structured rows."""
+    values = list(value)
+    recursive = _encode_recursive_if_structured(path, values)
+    if recursive is not None:
+        return recursive
+    codec = _fallback_codec(values)
+    metadata: dict[str, Any] = {}
+    if codec == "ndarray":
+        # ndarray codec needs dtype in metadata — infer from values
+        nn = [v for v in values if v is not None]
+        arr = np.asarray(nn)
+        metadata["dtype"] = str(arr.dtype)
+    schema = FieldSchema(codec=codec, metadata=metadata)
+    return _encode_with_schema(path, value, schema)
+
+
 def _is_recursive_encoded_non_tensor(encoded: Mapping[str, Any]) -> bool:
     return encoded.get("codec") == "structured_recursive"
-
-
-def _structured_path_tokens(path: str) -> list[Any]:
-    tokens: list[Any] = []
-    index = 0
-    current = []
-    while index < len(path):
-        char = path[index]
-        if char == "\\":
-            index += 1
-            if index < len(path):
-                current.append(path[index])
-        elif char == ".":
-            tokens.append("".join(current))
-            current = []
-        elif char == "[":
-            if current:
-                tokens.append("".join(current))
-                current = []
-            end = path.index("]", index)
-            tokens.append(int(path[index + 1 : end]))
-            index = end
-        else:
-            current.append(char)
-        index += 1
-    if current:
-        tokens.append("".join(current))
-    return tokens
-
-
-def _lookup_structured_path(value: Any, root_path: str, path: str) -> Any:
-    root_tokens = _structured_path_tokens(root_path)
-    path_tokens = _structured_path_tokens(path)
-    current = value
-    for token in path_tokens[len(root_tokens) :]:
-        if isinstance(token, str):
-            if current is None:
-                return None
-            if isinstance(current, _Missing) or not isinstance(current, dict):
-                return MISSING
-            current = current.get(token, MISSING)
-            continue
-        if current is None:
-            return None
-        if isinstance(current, _Missing) or not isinstance(current, (list, tuple)):
-            return MISSING
-        current = current[token] if token < len(current) else MISSING
-    return current
-
-
-def _encode_structured_leaf(
-    values: list[Any], decision: _CodecDecision
-) -> _EncodedStructuredLeaf:
-    if not decision.accepted:
-        raise ValueError(f"unsupported structured non-tensor field: {decision.reason}")
-    codec = decision.codec
-    if codec == "ragged_tensor":
-        payload, metadata = _encode_ragged_tensor_values(values)
-    elif codec == "typed_ragged":
-        payload, metadata = _encode_typed_ragged_values(values)
-    elif codec == "media_list_ragged":
-        payload, metadata = _encode_media_list_values(values)
-    elif codec == "ndarray":
-        payload, metadata = _encode_numeric_scalar_values(values, decision)
-    elif codec == "bytes_ragged":
-        payload, metadata = _encode_bytes_like_values(values)
-    elif codec == "media_bytes":
-        payload, metadata = _encode_bytes_like_values(values)
-    elif codec == "utf8_ragged":
-        payload, metadata = _encode_bytes_like_values(
-            [None if value is None else value.encode("utf-8") for value in values]
-        )
-    elif codec == "msgpack_ragged":
-        payload, metadata = _encode_bytes_like_values(
-            [
-                None
-                if value is None
-                else _msgpack.packb(value, use_bin_type=True, strict_types=True)
-                for value in values
-            ]
-        )
-    elif codec == "json_ragged":
-        payload, metadata = _encode_bytes_like_values(
-            [
-                None
-                if value is None
-                else json.dumps(value, ensure_ascii=False, separators=(",", ":")).encode(
-                    "utf-8"
-                )
-                for value in values
-            ]
-        )
-    else:
-        raise ValueError(f"unsupported structured non-tensor codec: {codec}")
-    metadata.update(
-        {
-            "schema_source": "inferred_from_runtime_values"
-            if decision.accepted
-            else "fallback",
-            "decision_reason": decision.reason,
-            "normalized_type": decision.normalized_type,
-            **decision.metadata,
-        }
-    )
-    return _EncodedStructuredLeaf(
-        codec=codec, rows=len(values), payload=payload, metadata=metadata
-    )
-
 
 
 def _decode_structured_non_tensor_encoded(
@@ -2071,13 +2282,20 @@ def _decode_structured_non_tensor_encoded(
     rows: int,
     metadata: Optional[Mapping[str, Any]] = None,
 ) -> list[Any]:
+    codec = encoded.get("codec")
+    if codec == "ragged_tensor_dict":
+        return _decode_ragged_tensor_dict_values(
+            payload, rows, metadata or encoded.get("metadata", {})
+        )
     if _is_recursive_encoded_non_tensor(encoded):
+        if metadata is not None:
+            encoded = {**encoded, "metadata": metadata}
         return _decode_structured_recursive_field(encoded, payload, rows)
     return _decode_structured_leaf(encoded["codec"], payload, rows, metadata)
 
 
 def _copy_recursive_metadata_for_leaf_updates(
-    metadata: Mapping[str, Any]
+    metadata: Mapping[str, Any],
 ) -> dict[str, Any]:
     copied = dict(metadata)
     copied["leaves"] = [dict(leaf) for leaf in metadata.get("leaves", [])]
@@ -2099,6 +2317,11 @@ def _decode_structured_recursive_field(
         values = _decode_structured_leaf(
             leaf["codec"], leaf_payload, rows, leaf.get("metadata")
         )
+        if leaf["codec"] == "typed_ragged":
+            values = [
+                value.tolist() if isinstance(value, np.ndarray) else value
+                for value in values
+            ]
         missing = payload[leaf_payload_members["missing"]]
         leaf_values[leaf["path"]] = [
             MISSING if bool(missing[row]) else values[row] for row in range(rows)
@@ -2124,7 +2347,9 @@ def _reconstruct_structured_rows(
 ) -> list[Any]:
     values_by_path: dict[str, list[Any]] = dict(leaf_values)
     nodes = sorted(
-        metadata.get("nodes", []), key=lambda node: _path_depth(node["path"]), reverse=True
+        metadata.get("nodes", []),
+        key=lambda node: _path_depth(node["path"]),
+        reverse=True,
     )
     for node in nodes:
         missing_payload = node.get("missing_payload")
@@ -2172,11 +2397,9 @@ def _decode_structured_leaf(
     metadata: Optional[Mapping[str, Any]] = None,
 ) -> list[Any]:
     if codec == "ragged_tensor":
-        return _decode_ragged_tensor_values(payload, rows)
-    if codec == "ragged_tensor_dict":
-        return _decode_ragged_tensor_dict_values(payload, rows, metadata or {})
+        return _decode_ragged_tensor_values(payload, rows, metadata)
     if codec == "typed_ragged":
-        return _decode_typed_ragged_values(payload, rows)
+        return _decode_typed_ragged_values(payload, rows, metadata)
     if codec == "media_list_ragged":
         return _decode_media_list_values(payload, rows, metadata)
     if codec == "ndarray":
@@ -2243,11 +2466,20 @@ def _encode_ragged_tensor_values(
                 list(tensor.shape), dtype=_torch.int64
             )
     data_dtype = dtype or _torch.float32
-    data = (
-        _torch.cat(flat_parts) if flat_parts else _torch.empty((0,), dtype=data_dtype)
-    )
+    # Zero-copy: scatter-gather from original tensor memory, no concatenation
+    if flat_parts:
+        buffers = tuple(memoryview(flat.numpy().data).cast("B") for flat in flat_parts)
+        owners = tuple(
+            flat_parts
+        )  # keep flat tensors alive (they reference original data)
+        data = _MultiBufferPayload(buffers=buffers, owners=owners)
+    else:
+        empty = np.empty(0, dtype=_torch_dtype_to_numpy(str(data_dtype)))
+        data = _MultiBufferPayload(
+            buffers=(memoryview(empty.data).cast("B"),), owners=(empty,)
+        )
     payload = {
-        "data": data.numpy(),
+        "data": data,
         "offsets": offsets.numpy(),
         "shapes": shapes.numpy(),
         "ndims": ndims.numpy(),
@@ -2260,10 +2492,26 @@ def _encode_ragged_tensor_values(
     }
 
 
-def _decode_ragged_tensor_values(payload: dict[str, Any], rows: int) -> list[Any]:
+def _decode_ragged_tensor_values(
+    payload: dict[str, Any], rows: int, metadata: Optional[Mapping[str, Any]] = None
+) -> list[Any]:
     if _torch is None:
         raise RuntimeError("torch is required to decode ragged tensor fields")
-    data = _torch.from_numpy(payload["data"])
+    raw = payload["data"]
+    dtype_str = (metadata or {}).get("dtype", "torch.float32")
+    torch_dtype = _parse_torch_dtype(dtype_str)
+    if isinstance(raw, (bytes, bytearray, memoryview)):
+        buf = bytearray(raw) if isinstance(raw, (bytes, memoryview)) else raw
+        data = _torch.frombuffer(buf, dtype=torch_dtype)
+    elif _torch is not None and isinstance(raw, _torch.Tensor):
+        data = raw if raw.dtype == torch_dtype else raw.to(torch_dtype)
+    elif isinstance(raw, np.ndarray):
+        np_dtype = _torch_dtype_to_numpy(dtype_str)
+        if raw.dtype != np_dtype:
+            raw = np.frombuffer(raw, dtype=np_dtype)
+        data = _torch.from_numpy(raw)
+    else:
+        data = _torch.from_numpy(np.asarray(raw))
     offsets = payload["offsets"]
     shapes = payload["shapes"]
     ndims = payload["ndims"]
@@ -2281,39 +2529,92 @@ def _decode_ragged_tensor_values(payload: dict[str, Any], rows: int) -> list[Any
     return values
 
 
-def _normalize_ragged_tensor_dict_keys(keys: Any) -> list[str]:
-    if isinstance(keys, (str, bytes, bytearray)) or not isinstance(keys, Iterable):
-        raise TypeError("ragged_tensor_dict keys must be an iterable of strings")
-    normalized = list(keys)
-    if any(not isinstance(key, str) for key in normalized):
-        raise TypeError("ragged_tensor_dict keys must contain only strings")
-    if any(not key for key in normalized):
-        raise ValueError("ragged_tensor_dict keys must not be empty")
-    if len(set(normalized)) != len(normalized):
-        raise ValueError("ragged_tensor_dict keys must not contain duplicates")
-    if any(separator in key for key in normalized for separator in (".", "/", "\\")):
-        raise ValueError("ragged_tensor_dict keys must not contain path separators")
-    return normalized
-
-
-def _ragged_tensor_dict_payload_items(
-    payload: Mapping[str, Any], key: str, *, kind: str
-) -> dict[str, Any]:
-    prefix = f"{key}."
-    items = {
-        name[len(prefix) :]: value
-        for name, value in payload.items()
-        if name.startswith(prefix)
-    }
-    missing = sorted(_RAGGED_TENSOR_PAYLOAD_NAMES - set(items))
-    if missing:
-        raise ValueError(
-            f"ragged_tensor_dict {kind} for key {key!r} is missing payloads: {missing}"
-        )
-    return items
+# ---------------------------------------------------------------------------
+# ragged_tensor_dict codec: list[dict[str, Tensor] | None]
+# ---------------------------------------------------------------------------
 
 
 def _encode_ragged_tensor_dict_values(
+    values: list[Any],
+    schema: FieldSchema,
+) -> "_EncodedStructuredLeaf":
+    """Encode list[dict[str, Tensor] | None] directly without inference.
+
+    Each dict key's tensors are encoded as a separate ragged_tensor sub-payload,
+    giving per-key zero-copy RDMA transfer and independent partial-read access.
+    """
+    if _torch is None:
+        raise RuntimeError("torch is required to encode ragged_tensor_dict fields")
+    rows = len(values)
+    null_mask = np.asarray([v is None for v in values], dtype=np.bool_)
+    non_null = [v for v in values if v is not None]
+
+    if not non_null:
+        return _EncodedStructuredLeaf(
+            codec="ragged_tensor_dict",
+            rows=rows,
+            payload={"null_mask": null_mask},
+            metadata={"keys": [], "key_codecs": {}},
+        )
+
+    keys = schema.metadata.get("keys")
+    if not keys:
+        keys = sorted(non_null[0].keys())
+
+    payload: dict[str, Any] = {"null_mask": null_mask}
+    key_codecs: dict[str, Any] = {}
+    for key in keys:
+        key_values = [None if v is None else v.get(key) for v in values]
+        sub_payload, sub_metadata = _encode_ragged_tensor_values(key_values)
+        for payload_name, payload_value in sub_payload.items():
+            payload[f"{key}.{payload_name}"] = payload_value
+        key_codecs[key] = sub_metadata
+
+    return _EncodedStructuredLeaf(
+        codec="ragged_tensor_dict",
+        rows=rows,
+        payload=payload,
+        metadata={"keys": keys, "key_codecs": key_codecs},
+    )
+
+
+def _decode_ragged_tensor_dict_values(
+    payload: dict[str, Any],
+    rows: int,
+    metadata: Mapping[str, Any],
+) -> list[Any]:
+    """Decode ragged_tensor_dict payload back to list[dict[str, Tensor] | None]."""
+    null_mask = payload["null_mask"]
+    if isinstance(null_mask, (bytes, bytearray)):
+        null_mask = np.frombuffer(null_mask, dtype=np.bool_)
+    keys = metadata.get("keys", [])
+
+    key_values: dict[str, list[Any]] = {}
+    for key in keys:
+        prefix = f"{key}."
+        sub_payload = {
+            name[len(prefix) :]: payload[name]
+            for name in payload
+            if name.startswith(prefix)
+        }
+        sub_metadata = metadata.get("key_codecs", {}).get(key)
+        key_values[key] = _decode_ragged_tensor_values(sub_payload, rows, sub_metadata)
+
+    result: list[Any] = []
+    for row in range(rows):
+        if bool(null_mask[row]):
+            result.append(None)
+        else:
+            d: dict[str, Any] = {}
+            for key in keys:
+                val = key_values[key][row]
+                if val is not None:
+                    d[key] = val
+            result.append(d if d else None)
+    return result
+
+
+def _encode_typed_ragged_values(
     values: list[Any],
     schema: FieldSchema,
 ) -> _EncodedStructuredLeaf:
@@ -2428,7 +2729,25 @@ def _encode_typed_ragged_values(
         ndims[row] = array.ndim
         if array.ndim > 0:
             shapes[row, : array.ndim] = array.shape
-    data = np.concatenate(flat_arrays) if flat_arrays else np.asarray([], dtype=dtype)
+    # Zero-copy: scatter-gather from original numpy array memory, no concatenation
+    if flat_arrays:
+        buffers = tuple(memoryview(flat.data).cast("B") for flat in flat_arrays)
+        owners = tuple(flat_arrays)  # keep arrays alive
+        data = _MultiBufferPayload(buffers=buffers, owners=owners)
+    else:
+        empty = np.empty(0, dtype=dtype)
+        data = _MultiBufferPayload(
+            buffers=(memoryview(empty.data).cast("B"),), owners=(empty,)
+        )
+    ndarray_rows = [
+        value is not None and isinstance(value, np.ndarray) for value in values
+    ]
+    if all(value is None or is_array for value, is_array in zip(values, ndarray_rows)):
+        row_format = "ndarray"
+    elif any(ndarray_rows):
+        row_format = "mixed"
+    else:
+        row_format = "list"
     return (
         {
             "data": data,
@@ -2437,16 +2756,39 @@ def _encode_typed_ragged_values(
             "ndims": ndims,
             "nulls": nulls,
         },
-        {"dtype": str(data.dtype), "max_ndim": int(max_ndim), "shape_policy": "ragged"},
+        {
+            "dtype": str(dtype),
+            "max_ndim": int(max_ndim),
+            "shape_policy": "ragged",
+            "row_format": row_format,
+            "ndarray_rows": ndarray_rows if row_format == "mixed" else None,
+        },
     )
 
 
-def _decode_typed_ragged_values(payload: dict[str, Any], rows: int) -> list[Any]:
-    data = payload["data"]
+def _decode_typed_ragged_values(
+    payload: dict[str, Any], rows: int, metadata: Optional[Mapping[str, Any]] = None
+) -> list[Any]:
+    raw = payload["data"]
+    dtype_str = (metadata or {}).get("dtype", "float64")
+    np_dtype = np.dtype(dtype_str)
+    # data may arrive as torch.Tensor, bytes, or numpy (pool-backed or typed)
+    if _torch is not None and isinstance(raw, _torch.Tensor):
+        data = raw.numpy()
+    elif isinstance(raw, (bytes, bytearray, memoryview)):
+        buf = bytearray(raw) if isinstance(raw, (bytes, memoryview)) else raw
+        data = np.frombuffer(buf, dtype=np_dtype)
+    elif isinstance(raw, np.ndarray):
+        data = raw if raw.dtype == np_dtype else np.frombuffer(raw, dtype=np_dtype)
+    else:
+        data = np.asarray(raw, dtype=np_dtype)
     offsets = payload["offsets"]
     shapes = payload["shapes"]
     ndims = payload["ndims"]
     nulls = payload["nulls"]
+    metadata = metadata or {}
+    row_format = metadata.get("row_format")
+    ndarray_rows = metadata.get("ndarray_rows") or []
     values = []
     for row in range(rows):
         if bool(nulls[row]):
@@ -2456,7 +2798,13 @@ def _decode_typed_ragged_values(payload: dict[str, Any], rows: int) -> list[Any]
         end = int(offsets[row + 1])
         ndim = int(ndims[row])
         shape = tuple(int(v) for v in shapes[row, :ndim].tolist())
-        values.append(data[begin:end].reshape(shape).tolist())
+        array = data[begin:end].reshape(shape)
+        if row_format == "ndarray" or (
+            row_format == "mixed" and bool(ndarray_rows[row])
+        ):
+            values.append(array)
+        else:
+            values.append(array.tolist())
     return values
 
 
@@ -2485,11 +2833,13 @@ def _decode_numeric_scalar_values(payload: dict[str, Any]) -> list[Any]:
     return values.tolist()
 
 
-def _value_to_media_bytes(value: Any) -> tuple[bytes, str | None, dict[str, Any]]:
+def _value_to_media_bytes(
+    value: Any,
+) -> tuple[bytes | memoryview, str | None, dict[str, Any]]:
     if value is None:
         return b"", None, {"kind": "null"}
     if _is_bytes_like(value):
-        return bytes(value), None, {"kind": "bytes"}
+        return _bytes_view(value, "media value"), None, {"kind": "bytes"}
     if _is_pil_image(value):
         image = (
             value.convert(value.mode) if getattr(value, "readonly", False) else value
@@ -2507,6 +2857,13 @@ def _value_to_media_bytes(value: Any) -> tuple[bytes, str | None, dict[str, Any]
     return bytes(value), None, {"kind": "bytes"}
 
 
+def _multi_buffer_bytes_payload(
+    parts: Sequence[bytes | memoryview],
+) -> _MultiBufferPayload:
+    buffers = tuple(_bytes_view(part, "payload part") for part in parts if part)
+    return _MultiBufferPayload(buffers, tuple(parts))
+
+
 def _encode_bytes_like_values(
     values: list[Any],
 ) -> tuple[dict[str, Any], dict[str, Any]]:
@@ -2520,7 +2877,7 @@ def _encode_bytes_like_values(
         media_types.append(media_type)
         encodings.append(encoding)
         offsets.append(offsets[-1] + len(data))
-    payload_bytes = b"".join(parts)
+    payload_bytes = _multi_buffer_bytes_payload(parts)
     metadata: dict[str, Any] = {}
     if any(encoding.get("kind") == "pil_raw" for encoding in encodings):
         metadata["media_encodings"] = encodings
@@ -2600,7 +2957,7 @@ def _encode_media_list_values(
         metadata["media_types"] = non_null_media_types
     return (
         {
-            "data": b"".join(parts),
+            "data": _multi_buffer_bytes_payload(parts),
             "row_offsets": np.asarray(row_offsets, dtype=np.int64),
             "byte_offsets": np.asarray(byte_offsets, dtype=np.int64),
             "nulls": np.asarray([value is None for value in values], dtype=np.bool_),
@@ -2644,16 +3001,11 @@ class _StructuredObjectLayer:
         chunk_bytes: Optional[int],
         policy: Optional[BundleTransferPolicy],
         max_inflight_put: Optional[int],
-        pre_registered_buffers: Optional[Mapping[str, bool]],
     ) -> RemoteBundleRef:
         metadata, buffers = _encode_structured_fields(payload.metadata, payload.buffers)
         transfer_policy = self._bundle_store._policy(
             policy, max_inflight_put=max_inflight_put
         )
-        if transfer_policy.copy_mode != "copy":
-            _validate_pre_registered_structured_buffers(
-                payload.buffers, buffers, pre_registered_buffers
-            )
         return self._bundle_store.put_bundle(
             meta=_encode_structured_metadata(metadata),
             buffers=buffers,
@@ -2661,7 +3013,6 @@ class _StructuredObjectLayer:
             chunk_bytes=chunk_bytes,
             policy=transfer_policy,
             max_inflight_put=None,
-            pre_registered_buffers=pre_registered_buffers,
         )
 
     def read_spec(
@@ -2681,16 +3032,54 @@ class _StructuredObjectLayer:
         field_specs = _structured_field_specs(metadata)
         destination_map = destinations or {}
         member_slices = dict(spec.member_slices)
-        objects = {
-            name: self._read_structured_member(
+
+        # Identify members eligible for batched pool read
+        batch_eligible: list[tuple[str, Any]] = []
+        non_batch: list[str] = []
+        for name in selected:
+            fs = field_specs.get(name, {"encoding": "bytes"})
+            encoding = fs.get("encoding", "bytes")
+            nbytes = int(buffers[name].get("bytes", 0))
+            ms = member_slices.get(name)
+            if destination_map.get(name) is not None or nbytes == 0:
+                non_batch.append(name)
+                continue
+            if encoding == "ndarray" and isinstance(fs.get("dtype"), str) and isinstance(fs.get("shape"), list):
+                read_plan = _resolve_ndarray_read_plan(
+                    tuple(int(d) for d in fs["shape"]),
+                    np.dtype(fs["dtype"]),
+                    ms,
+                )
+                if read_plan.byte_length > 0 and read_plan.step == 1:
+                    batch_eligible.append((name, read_plan))
+                    continue
+            # bytes-encoded members use _read_bytes_member which returns
+            # _PoolBackedNdarray (zero-copy from pool); batching would require
+            # converting back to bytes via bytes(arr), adding a 24GB+ copy.
+            non_batch.append(name)
+
+        objects: dict[str, Any] = {}
+        # Try batched read (worthwhile when >=2 members)
+        if len(batch_eligible) > 1:
+            names_for_batch = [name for name, _ in batch_eligible]
+            plans_for_batch = [plan for _, plan in batch_eligible]
+            batched = self._batch_read_ndarray_members(
+                names_for_batch, plans_for_batch, buffers
+            )
+            if batched is not None:
+                objects.update(batched)
+                batch_eligible = []
+
+        # Remaining members: per-member read (original path)
+        remaining = [name for name, _ in batch_eligible] + non_batch
+        for name in remaining:
+            objects[name] = self._read_structured_member(
                 name=name,
                 payload_spec=buffers[name],
                 field_spec=field_specs.get(name, {"encoding": "bytes"}),
                 member_slice=member_slices.get(name),
                 destination=destination_map.get(name),
             )
-            for name in selected
-        }
         return StructuredObjectResult(metadata=dict(metadata), objects=objects)
 
     def _resolve_structured_read(
@@ -2748,9 +3137,12 @@ class _StructuredObjectLayer:
                 name, payload_spec, field_spec, member_slice, destination
             )
         if destination is not None:
-            if not isinstance(destination, (_TensorObjectBufferPayload, _RawDestinationBuffer)):
+            if not isinstance(
+                destination, (_TensorObjectBufferPayload, _RawDestinationBuffer)
+            ):
                 raise ValueError(
-                    f"structured tensor member {name} only supports tensor_object_buffer or raw_destination destinations"
+                    f"structured tensor member {name} only supports tensor_object_buffer "
+                    "or raw_destination destinations"
                 )
             materialized = self._bundle_store.read_tensor_payload_into(
                 payload_spec, destination
@@ -2800,9 +3192,12 @@ class _StructuredObjectLayer:
             metadata, (end - start, *shape[1:]), data_length
         )
         if destination is not None:
-            if not isinstance(destination, (_TensorObjectBufferPayload, _RawDestinationBuffer)):
+            if not isinstance(
+                destination, (_TensorObjectBufferPayload, _RawDestinationBuffer)
+            ):
                 raise ValueError(
-                    f"structured tensor member {name} only supports tensor_object_buffer or raw_destination destinations"
+                    f"structured tensor member {name} only supports tensor_object_buffer "
+                    "or raw_destination destinations"
                 )
             expected_bytes = metadata_bytes + data_length
             if destination.size < expected_bytes:
@@ -2810,7 +3205,10 @@ class _StructuredObjectLayer:
                     f"tensor destination has {destination.size} bytes, expected at least {expected_bytes}"
                 )
             ctypes.memmove(destination.ptr, sliced_metadata, metadata_bytes)
-            if isinstance(destination, _RawDestinationBuffer) and destination.pre_registered:
+            if (
+                isinstance(destination, _RawDestinationBuffer)
+                and destination.pre_registered
+            ):
                 self._bundle_store.read_payload_range_into_raw_destination(
                     payload_spec,
                     destination.ptr,
@@ -2836,13 +3234,27 @@ class _StructuredObjectLayer:
         payload_spec: Mapping[str, Any],
         member_slice: StructuredMemberSlice | None,
         destination: Any,
-    ) -> bytes:
+    ) -> bytes | np.ndarray:
         if member_slice is not None:
             raise ValueError(f"structured bytes member {name} does not support slicing")
         if destination is not None:
             raise ValueError(
                 f"structured bytes member {name} does not support materialize_into"
             )
+        # Always try pool-backed read first: pool memory is pre-registered,
+        # so RDMA reads go directly into pool memory without extra copies.
+        expected_bytes = int(payload_spec.get("bytes", 0))
+        if expected_bytes > 0:
+            result = self._bundle_store.read_payload_range_into_pool_array(
+                payload_spec, np.dtype(np.uint8), (expected_bytes,), 0
+            )
+            if result is not None:
+                return result
+            # Pool array failed; use np.empty + chunked pool read (ctypes.memmove)
+            # instead of bytearray + bytes() which causes extra copies.
+            result = np.empty(expected_bytes, dtype=np.uint8)
+            self._bundle_store.read_payload_into(payload_spec, result)
+            return result
         return self._bundle_store.read_payload(payload_spec)
 
     def _read_ndarray_member(
@@ -2862,6 +3274,15 @@ class _StructuredObjectLayer:
         read_plan = _resolve_ndarray_read_plan(
             tuple(int(dim) for dim in shape), np.dtype(dtype), member_slice
         )
+        if destination is None and read_plan.byte_length > 0 and read_plan.step == 1:
+            target = self._bundle_store.read_payload_range_into_pool_array(
+                payload_spec,
+                read_plan.dtype,
+                read_plan.output_shape,
+                read_plan.byte_offset,
+            )
+            if target is not None:
+                return target
         target = _resolve_ndarray_destination(
             name, destination, read_plan.dtype, read_plan.output_shape
         )
@@ -2883,6 +3304,74 @@ class _StructuredObjectLayer:
         )
         target[...] = temp[:: read_plan.step]
         return target
+
+    def _batch_read_ndarray_members(
+        self,
+        names: list[str],
+        read_plans: list[Any],
+        buffers: Mapping[str, Any],
+    ) -> dict[str, np.ndarray] | None:
+        """Batched pool read: single pool.acquire + single get_into_ranges.
+        Returns None to fall back to per-member reads.
+        """
+        transport = self._bundle_store._transport
+        pool = transport._ensure_buffer_pool()
+        get_into_ranges = transport._get_into_ranges
+        if pool is None or not callable(get_into_ranges):
+            return None
+
+        # Compute layout: each member gets a contiguous region in the pool
+        offsets = []
+        total_bytes = 0
+        for rp in read_plans:
+            offsets.append(total_bytes)
+            total_bytes += rp.byte_length
+        if total_bytes == 0:
+            return {n: np.empty(rp.output_shape, dtype=rp.dtype)
+                    for n, rp in zip(names, read_plans)}
+
+        try:
+            lease = pool.acquire(total_bytes)
+        except RuntimeError:
+            return None
+
+        owner = _PoolLeaseOwner(lease)
+        try:
+            # Collect all fragments for a single get_into_ranges call
+            all_keys, all_dst, all_src, all_sizes = [], [], [], []
+            for name, rp, off in zip(names, read_plans, offsets):
+                for key, _, dest_off, src_off, size in _payload_range_fragments(
+                    buffers[name]["chunks"], rp.byte_offset, rp.byte_length
+                ):
+                    all_keys.append(key)
+                    all_dst.append([off + dest_off])
+                    all_src.append([src_off])
+                    all_sizes.append([size])
+
+            if not all_keys:
+                owner.release()
+                return {n: np.empty(rp.output_shape, dtype=rp.dtype)
+                        for n, rp in zip(names, read_plans)}
+
+            results = get_into_ranges(
+                [lease.ptr], [all_keys], [all_dst], [all_src], [all_sizes]
+            )
+            # Validate result shape
+            if len(results) != 1 or len(results[0]) != len(all_keys):
+                raise RuntimeError("batch get_into_ranges: unexpected result count")
+            for exp, act in zip(all_sizes, results[0]):
+                if exp != act:
+                    raise RuntimeError("batch get_into_ranges: size mismatch")
+
+            return {
+                name: _PoolBackedNdarray._from_shared_pool(
+                    owner, rp.dtype, rp.output_shape, off
+                )
+                for name, rp, off in zip(names, read_plans, offsets)
+            }
+        except Exception:
+            owner.release()
+            raise
 
 
 class _BundleManifestStore:
@@ -2906,7 +3395,6 @@ class _BundleManifestStore:
         chunk_bytes: Optional[int],
         policy: Optional[BundleTransferPolicy],
         max_inflight_put: Optional[int],
-        pre_registered_buffers: Optional[Mapping[str, bool]] = None,
     ) -> RemoteBundleRef:
         _validate_key_segment(partition, "partition")
         meta_view = _bytes_view(meta, "meta")
@@ -2919,14 +3407,14 @@ class _BundleManifestStore:
         manifest_key = f"{base_key}/manifest"
         written_keys: list[str] = []
         buffer_specs: dict[str, Any] = {}
-        pre_registered_map = dict(pre_registered_buffers or {})
+        deferred: list | None = None
         try:
             meta_spec, meta_keys = self._put_payload(
                 f"{base_key}/meta",
                 meta_view,
                 target_chunk_bytes,
                 _copy_transfer_policy(transfer_policy),
-                pre_registered=False,
+                _deferred=deferred,
             )
             written_keys.extend(meta_keys)
             for name, value in buffers.items():
@@ -2938,13 +3426,21 @@ class _BundleManifestStore:
                         value,
                         transfer_policy,
                     )
+                elif isinstance(value, _MultiBufferPayload):
+                    payload_spec, payload_keys = self._put_multi_buffer_payload(
+                        payload_key,
+                        value,
+                        target_chunk_bytes,
+                        transfer_policy,
+                        _deferred=deferred,
+                    )
                 else:
                     payload_spec, payload_keys = self._put_payload(
                         payload_key,
                         _bytes_view(value, name),
                         target_chunk_bytes,
                         transfer_policy,
-                        pre_registered=bool(pre_registered_map.get(name, False)),
+                        _deferred=deferred,
                     )
                 buffer_specs[name] = payload_spec
                 written_keys.extend(payload_keys)
@@ -2991,7 +3487,6 @@ class _BundleManifestStore:
                 meta_view,
                 target_chunk_bytes,
                 _copy_transfer_policy(transfer_policy),
-                pre_registered=False,
             )
             written_keys.extend(meta_keys)
             manifest = {
@@ -3058,11 +3553,27 @@ class _BundleManifestStore:
     def read_payload(self, payload_spec: Mapping[str, Any]) -> bytes:
         return self._transport.read_payload(payload_spec)
 
+    def read_payload_into(
+        self, payload_spec: Mapping[str, Any], destination: bytearray | np.ndarray
+    ) -> None:
+        return self._transport.read_payload_into(payload_spec, destination)
+
     def read_payload_range(
         self, payload_spec: Mapping[str, Any], byte_offset: int, byte_length: int
     ) -> bytes:
         return self._transport.read_payload_range(
             payload_spec, byte_offset, byte_length
+        )
+
+    def read_payload_range_into_pool_array(
+        self,
+        payload_spec: Mapping[str, Any],
+        dtype: np.dtype[Any],
+        shape: tuple[int, ...],
+        byte_offset: int,
+    ) -> np.ndarray | None:
+        return self._transport.read_payload_range_into_pool_array(
+            payload_spec, dtype, shape, byte_offset
         )
 
     def read_tensor_payload(self, payload_spec: Mapping[str, Any]) -> Any:
@@ -3109,7 +3620,9 @@ class _BundleManifestStore:
     ) -> None:
         if not ranges:
             return
-        self._transport.read_payload_ranges_into_array(payload_spec, destination, ranges)
+        self._transport.read_payload_ranges_into_array(
+            payload_spec, destination, ranges
+        )
 
     def read_payload_ranges_into_bytearray(
         self,
@@ -3161,12 +3674,8 @@ class _BundleManifestStore:
             if tensor_spec is not None:
                 return tensor_spec, [key]
             try:
-                total_bytes = self._transport.put_tensor_payload_from_pool(key, value)
-                return {
-                    "key": key,
-                    "bytes": total_bytes,
-                    "chunks": [{"key": key, "bytes": total_bytes}],
-                }, [key]
+                tensor_spec = self._transport.put_tensor_payload_from_pool(key, value)
+                return tensor_spec, [key]
             except RuntimeError:
                 pass
         if not _has_tensor_codec_helpers() or value.tensor.dim() == 0:
@@ -3176,7 +3685,6 @@ class _BundleManifestStore:
                 memoryview(payload),
                 len(payload) or 1,
                 transfer_policy,
-                pre_registered=False,
             )
             payload_spec["format"] = "torch_save"
             return payload_spec, payload_keys
@@ -3186,7 +3694,6 @@ class _BundleManifestStore:
             memoryview(payload),
             len(payload) or 1,
             transfer_policy,
-            pre_registered=False,
         )
         payload_spec["metadata_bytes"] = metadata_bytes
         return payload_spec, payload_keys
@@ -3197,7 +3704,7 @@ class _BundleManifestStore:
         value: memoryview,
         chunk_bytes: int,
         transfer_policy: BundleTransferPolicy,
-        pre_registered: bool,
+        _deferred: list | None = None,
     ) -> tuple[dict[str, Any], list[str]]:
         if len(value) == 0:
             return {"key": key, "bytes": 0, "chunks": []}, []
@@ -3206,12 +3713,15 @@ class _BundleManifestStore:
             key if len(chunks) == 1 else f"{key}/chunk/{index}"
             for index in range(len(chunks))
         ]
-        written_keys = self._transport.put_payload_chunks(
-            chunk_keys,
-            chunks,
-            transfer_policy,
-            pre_registered=pre_registered,
-        )
+        if _deferred is not None:
+            for ck, chunk in zip(chunk_keys, chunks):
+                _deferred.append((ck, [chunk]))
+        else:
+            self._transport.put_payload_chunks(
+                chunk_keys,
+                chunks,
+                transfer_policy,
+            )
         payload_spec = {
             "key": key,
             "bytes": len(value),
@@ -3220,7 +3730,46 @@ class _BundleManifestStore:
                 for chunk_key, chunk in zip(chunk_keys, chunks)
             ],
         }
-        return payload_spec, written_keys
+        return payload_spec, list(chunk_keys)
+
+    def _put_multi_buffer_payload(
+        self,
+        key: str,
+        value: _MultiBufferPayload,
+        chunk_bytes: int,
+        transfer_policy: BundleTransferPolicy,
+        _deferred: list | None = None,
+    ) -> tuple[dict[str, Any], list[str]]:
+        total_bytes = value.nbytes
+        if total_bytes == 0:
+            return {"key": key, "bytes": 0, "chunks": []}, []
+        if len(value.buffers) == 1:
+            return self._put_payload(
+                key, value.buffers[0], chunk_bytes, transfer_policy, _deferred
+            )
+        chunk_groups = _split_multi_buffer_payload(value.buffers, chunk_bytes)
+        chunk_keys = [
+            key if len(chunk_groups) == 1 else f"{key}/chunk/{index}"
+            for index in range(len(chunk_groups))
+        ]
+        if _deferred is not None:
+            for ck, group in zip(chunk_keys, chunk_groups):
+                _deferred.append((ck, list(group)))
+        else:
+            self._transport.put_multi_buffer_payload_chunks(
+                chunk_keys,
+                chunk_groups,
+                transfer_policy,
+            )
+        payload_spec = {
+            "key": key,
+            "bytes": total_bytes,
+            "chunks": [
+                {"key": chunk_key, "bytes": sum(len(part) for part in group)}
+                for chunk_key, group in zip(chunk_keys, chunk_groups)
+            ],
+        }
+        return payload_spec, list(chunk_keys)
 
     def _policy(
         self,
@@ -3253,7 +3802,9 @@ class _BundleManifestStore:
         if not isinstance(buffer_object_ids, list) or not all(
             isinstance(item, str) for item in buffer_object_ids
         ):
-            raise ValueError("bundle manifest buffer_object_ids must be a list of strings")
+            raise ValueError(
+                "bundle manifest buffer_object_ids must be a list of strings"
+            )
         allowed_buffer_base_keys = [
             f"{self._key_prefix}/{buffer_object_id}"
             for buffer_object_id in buffer_object_ids
@@ -3264,7 +3815,9 @@ class _BundleManifestStore:
             self._is_allowed_cleanup_key(item, allowed_buffer_base_keys)
             for item in cleanup_keys
         ):
-            raise ValueError("bundle manifest cleanup_keys are outside the bundle namespace")
+            raise ValueError(
+                "bundle manifest cleanup_keys are outside the bundle namespace"
+            )
         buffers = manifest.get("buffers")
         if not isinstance(buffers, dict):
             raise ValueError("bundle manifest buffers must be a dict")
@@ -3290,7 +3843,9 @@ class _BundleManifestStore:
         payload_key = payload_spec.get("key")
         if not isinstance(payload_key, str) or (
             base_keys is not None
-            and not any(payload_key.startswith(f"{base_key}/") for base_key in base_keys)
+            and not any(
+                payload_key.startswith(f"{base_key}/") for base_key in base_keys
+            )
         ):
             raise ValueError("bundle payload key is outside the bundle namespace")
         expected_bytes = int(payload_spec.get("bytes", -1))
@@ -3352,38 +3907,62 @@ class _MooncakePayloadTransport:
         self._buffer_pool = buffer_pool
         self._batch_put_from = getattr(store, "batch_put_from", None)
         self._put_tensor_from = getattr(store, "put_tensor_from", None)
+        self._batch_put_from_multi_buffers = getattr(
+            store, "batch_put_from_multi_buffers", None
+        )
         self._batch_get_into = getattr(store, "batch_get_into", None)
         self._get_into = getattr(store, "get_into", None)
         self._get_into_ranges = getattr(store, "get_into_ranges", None)
-        self._register_buffer = getattr(store, "register_buffer", None)
-        self._unregister_buffer = getattr(store, "unregister_buffer", None)
+
+    def _ensure_buffer_pool(self) -> Any:
+        if self._buffer_pool is None:
+            try:
+                from mooncake.buffer_pool import BufferPool
+
+                self._buffer_pool = BufferPool(self._store)
+            except (ImportError, AttributeError, RuntimeError, TypeError):
+                return None
+        return self._buffer_pool
 
     def put_payload_chunks(
         self,
         chunk_keys: Sequence[str],
         chunks: Sequence[memoryview],
         transfer_policy: BundleTransferPolicy,
-        pre_registered: bool,
     ) -> list[str]:
-        if transfer_policy.copy_mode == "copy":
+        return self.put_multi_buffer_payload_chunks(
+            chunk_keys, [[c] for c in chunks], transfer_policy
+        )
+
+    def put_multi_buffer_payload_chunks(
+        self,
+        chunk_keys: Sequence[str],
+        chunk_groups: Sequence[Sequence[memoryview]],
+        transfer_policy: BundleTransferPolicy,
+    ) -> list[str]:
+        def fallback_to_direct_put() -> list[str]:
+            chunks = [memoryview(b"".join(group)) for group in chunk_groups]
             return self._put_chunks_direct(chunk_keys, chunks)
-        if not self._has_batch_put_support():
-            if transfer_policy.copy_mode == "zero_copy":
-                raise RuntimeError(
-                    "zero-copy put requested but batch_put_from is unavailable"
-                )
-            return self._put_chunks_direct(chunk_keys, chunks)
-        put_mode = self._resolve_put_mode(chunks, transfer_policy)
-        if put_mode == "batch":
-            self.batch_put_chunks_from(
-                chunk_keys, chunks, pre_registered=pre_registered
+
+        if transfer_policy.copy_mode == "zero_copy":
+            raise RuntimeError(
+                "zero-copy put requires tensor-object buffers"
             )
+        if transfer_policy.copy_mode == "copy" or self._ensure_buffer_pool() is None:
+            return fallback_to_direct_put()
+        if all(len(group) == 1 for group in chunk_groups):
+            self.batch_put_chunks_from(chunk_keys, [group[0] for group in chunk_groups])
             return list(chunk_keys)
-        return self._put_chunks_parallel(
+        if not callable(self._batch_put_from):
+            return fallback_to_direct_put()
+        put_mode = self._resolve_buffer_group_put_mode(chunk_groups, transfer_policy)
+        if put_mode == "batch":
+            self.batch_put_buffer_groups_from(chunk_keys, chunk_groups)
+            return list(chunk_keys)
+        return self._put_buffer_groups_parallel(
             list(chunk_keys),
-            list(chunks),
+            [list(group) for group in chunk_groups],
             transfer_policy.max_inflight_put,
-            pre_registered=pre_registered,
         )
 
     def read_payload(self, payload_spec: Mapping[str, Any]) -> bytes:
@@ -3397,16 +3976,19 @@ class _MooncakePayloadTransport:
     def read_tensor_payload(self, payload_spec: Mapping[str, Any]) -> Any:
         get_tensor = getattr(self._store, "get_tensor", None)
         key = payload_spec["key"]
-        if not callable(get_tensor):
-            raise RuntimeError("structured tensor payload does not support get_tensor")
-        return get_tensor(key)
+        if callable(get_tensor):
+            try:
+                return get_tensor(key)
+            except KeyError:
+                pass
+        return _deserialize_tensor_payload(self.read_payload(payload_spec))
 
     def read_payload_into(
         self, payload_spec: Mapping[str, Any], destination: bytearray | np.ndarray
     ) -> None:
         chunks = payload_spec["chunks"]
         offsets = _chunk_offsets(chunks)
-        if self._read_chunks_with_batch_get_into(chunks, offsets, destination):
+        if self._read_chunks_with_pool_get_into(chunks, offsets, destination):
             return
         for offset, chunk in zip(offsets, chunks):
             self._read_chunk_with_get(chunk, destination, offset)
@@ -3458,8 +4040,9 @@ class _MooncakePayloadTransport:
         if byte_length == 0:
             return b""
         data = bytearray(byte_length)
-        if not self._read_payload_range_into_registered_destination(
-            payload_spec["chunks"], data, byte_offset, byte_length, False
+        if not self._read_with_pool_into_destination(
+            payload_spec["chunks"], data,
+            byte_offset=byte_offset, byte_length=byte_length,
         ):
             self._copy_payload_range_into_bytearray(
                 payload_spec["chunks"], data, byte_offset, byte_length
@@ -3475,16 +4058,56 @@ class _MooncakePayloadTransport:
     ) -> None:
         chunks = payload_spec["chunks"]
         byte_length = _buffer_nbytes(destination)
-        if not self._read_payload_range_into_registered_destination(
-            chunks,
-            destination,
-            byte_offset,
-            byte_length,
-            destination_pre_registered=destination_pre_registered,
+        if destination_pre_registered:
+            base_ptr = _buffer_ptr(destination)
+            if self._read_payload_range_into_raw_destination(
+                chunks, base_ptr, byte_offset, byte_length
+            ):
+                return
+        if not self._read_with_pool_into_destination(
+            chunks, destination,
+            byte_offset=byte_offset, byte_length=byte_length,
         ):
             self._copy_payload_range_into_destination(
                 chunks, destination, byte_offset, byte_length
             )
+
+    def read_payload_range_into_pool_array(
+        self,
+        payload_spec: Mapping[str, Any],
+        dtype: np.dtype[Any],
+        shape: tuple[int, ...],
+        byte_offset: int,
+    ) -> np.ndarray | None:
+        nbytes = (
+            int(np.prod(shape, dtype=np.int64)) * dtype.itemsize
+            if shape
+            else dtype.itemsize
+        )
+        if nbytes == 0:
+            return np.empty(shape, dtype=dtype)
+        pool = self._ensure_buffer_pool()
+        if pool is None:
+            return None
+        try:
+            lease = pool.acquire(nbytes)
+        except RuntimeError:
+            return None
+        owner = _PoolLeaseOwner(lease)
+        try:
+            if not self._read_payload_range_into_raw_destination(
+                payload_spec["chunks"],
+                lease.ptr,
+                byte_offset,
+                nbytes,
+                allow_get_into=False,
+            ):
+                owner.release()
+                return None
+            return _PoolBackedNdarray(owner, dtype, shape)
+        except Exception:
+            owner.release()
+            raise
 
     def read_payload_range_into_raw_destination(
         self,
@@ -3511,8 +4134,8 @@ class _MooncakePayloadTransport:
         destination: np.ndarray,
         ranges: Sequence[tuple[int, int, int]],
     ) -> None:
-        if self._read_payload_ranges_into_registered_destination(
-            payload_spec["chunks"], destination, ranges
+        if self._read_with_pool_into_destination(
+            payload_spec["chunks"], destination, ranges=ranges
         ):
             return
         self._copy_payload_ranges_into_destination(
@@ -3525,8 +4148,8 @@ class _MooncakePayloadTransport:
         destination: bytearray,
         ranges: Sequence[tuple[int, int, int]],
     ) -> None:
-        if self._read_payload_ranges_into_registered_destination(
-            payload_spec["chunks"], destination, ranges
+        if self._read_with_pool_into_destination(
+            payload_spec["chunks"], destination, ranges=ranges
         ):
             return
         self._copy_payload_ranges_into_destination(
@@ -3551,6 +4174,7 @@ class _MooncakePayloadTransport:
         put_tensor_from = self._put_tensor_from
         if not callable(put_tensor_from):
             raise RuntimeError("put_tensor_from is unavailable")
+        _validate_tensor_object_buffer_owner(value)
         _check_status(
             put_tensor_from(key, value.ptr, value.size), "put_tensor_from", key
         )
@@ -3584,15 +4208,18 @@ class _MooncakePayloadTransport:
         self,
         key: str,
         value: _TensorPayload,
-    ) -> int:
-        if self._buffer_pool is None:
-            raise RuntimeError("structured tensor zero-copy requires a BufferPool")
+    ) -> dict[str, Any]:
+        pool = self._ensure_buffer_pool()
+        if pool is None:
+            raise RuntimeError("structured tensor staging requires a BufferPool")
         put_tensor_from = self._put_tensor_from
         if not callable(put_tensor_from):
             raise RuntimeError("put_tensor_from is unavailable")
+        tensor = value.tensor
         metadata, data_ptr, tensor_nbytes, owner = _tensor_payload_parts(value)
-        total_bytes = len(metadata) + tensor_nbytes
-        lease = self._buffer_pool.acquire(total_bytes)
+        metadata_bytes = len(metadata)
+        total_bytes = metadata_bytes + tensor_nbytes
+        lease = pool.acquire(total_bytes)
         view = None
         try:
             view = lease.buffer
@@ -3605,7 +4232,15 @@ class _MooncakePayloadTransport:
                 put_tensor_from(key, lease.ptr, total_bytes), "put_tensor_from", key
             )
             _ = owner
-            return total_bytes
+            return {
+                "key": key,
+                "kind": "tensor",
+                "bytes": total_bytes,
+                "dtype": str(getattr(tensor, "dtype", "")),
+                "shape": list(getattr(tensor, "shape", ())),
+                "chunks": [{"key": key, "bytes": total_bytes}],
+                "metadata_bytes": metadata_bytes,
+            }
         finally:
             if view is not None:
                 view.release()
@@ -3615,32 +4250,68 @@ class _MooncakePayloadTransport:
         self,
         chunk_keys: Sequence[str],
         chunks: Sequence[memoryview],
-        pre_registered: bool,
+    ) -> None:
+        self.batch_put_buffer_groups_from(chunk_keys, [[chunk] for chunk in chunks])
+
+    def batch_put_buffer_groups_from(
+        self,
+        chunk_keys: Sequence[str],
+        chunk_groups: Sequence[Sequence[memoryview]],
     ) -> None:
         batch_put_from = self._batch_put_from
         if not callable(batch_put_from):
             raise RuntimeError("batch_put_from is unavailable")
         if not chunk_keys:
             return
-        prepared_chunks = [_prepare_chunk_source_buffer(chunk) for chunk in chunks]
-        buffer_ptrs = [ptr for _owner, ptr, _size in prepared_chunks]
-        sizes = [size for _owner, _ptr, size in prepared_chunks]
-        registered_ptrs = self._register_buffers(
-            buffer_ptrs, sizes, pre_registered, "bundle source payload"
-        )
-        try:
-            results = batch_put_from(list(chunk_keys), buffer_ptrs, sizes)
-            if len(results) != len(chunk_keys):
-                raise RuntimeError(
-                    f"batch_put_from returned {len(results)} results for {len(chunk_keys)} chunks"
+        sizes = [_buffer_group_nbytes(group) for group in chunk_groups]
+        total = sum(sizes)
+        # When total fits comfortably in pool, batch all leases and issue one
+        # batch_put_from call. Otherwise stream one-at-a-time to avoid pool
+        # exhaustion.
+        pool = self._buffer_pool
+        if len(chunk_keys) > 1 and total <= getattr(pool, "size", 0) // 2:
+            leases: list[Any] = []
+            try:
+                for group, size in zip(chunk_groups, sizes):
+                    lease = pool.acquire(size)
+                    _copy_memoryviews_to_lease(group, lease)
+                    leases.append(lease)
+                results = batch_put_from(
+                    list(chunk_keys),
+                    [lease.ptr for lease in leases],
+                    sizes,
                 )
-            for chunk_key, status in zip(chunk_keys, results):
-                _check_status(status, "batch_put_from", chunk_key)
-        except Exception:
-            _cleanup_keys(self._store, chunk_keys, strict=False)
-            raise
-        finally:
-            self._unregister_buffers(registered_ptrs, "bundle source payload")
+                self._check_batch_put_results(results, chunk_keys, "batch_put_from")
+            except Exception:
+                _cleanup_keys(self._store, list(chunk_keys), strict=False)
+                raise
+            finally:
+                for lease in leases:
+                    lease.release()
+            return
+        # Fallback: one chunk at a time for large payloads.
+        for chunk_key, group, size in zip(chunk_keys, chunk_groups, sizes):
+            lease = pool.acquire(size)
+            try:
+                _copy_memoryviews_to_lease(group, lease)
+                results = batch_put_from([chunk_key], [lease.ptr], [size])
+                self._check_batch_put_results(results, [chunk_key], "batch_put_from")
+            except Exception:
+                _cleanup_keys(self._store, [chunk_key], strict=False)
+                raise
+            finally:
+                lease.release()
+
+    @staticmethod
+    def _check_batch_put_results(
+        results: Sequence[int], chunk_keys: Sequence[str], operation: str
+    ) -> None:
+        if len(results) != len(chunk_keys):
+            raise RuntimeError(
+                f"{operation} returned {len(results)} results for {len(chunk_keys)} chunks"
+            )
+        for chunk_key, status in zip(chunk_keys, results):
+            _check_status(status, operation, chunk_key)
 
     def _put_chunks_direct(
         self,
@@ -3657,14 +4328,15 @@ class _MooncakePayloadTransport:
             raise
         return list(chunk_keys)
 
-    def _put_chunks_parallel(
+    def _put_buffer_groups_parallel(
         self,
         chunk_keys: list[str],
-        chunks: list[memoryview],
+        chunk_groups: list[Sequence[memoryview]],
         max_inflight_put: int,
-        pre_registered: bool,
     ) -> list[str]:
-        groups = self._group_chunk_ranges(chunk_keys, chunks, max_inflight_put)
+        groups = self._group_buffer_group_ranges(
+            chunk_keys, chunk_groups, max_inflight_put
+        )
         futures: list[Future[None]] = []
         try:
             with ThreadPoolExecutor(
@@ -3672,10 +4344,7 @@ class _MooncakePayloadTransport:
             ) as executor:
                 futures = [
                     executor.submit(
-                        self.batch_put_chunks_from,
-                        group_keys,
-                        group_chunks,
-                        pre_registered,
+                        self.batch_put_buffer_groups_from, group_keys, group_chunks
                     )
                     for group_keys, group_chunks in groups
                 ]
@@ -3694,48 +4363,23 @@ class _MooncakePayloadTransport:
             raise
         return chunk_keys
 
-    def _group_chunk_ranges(
+    def _group_buffer_group_ranges(
         self,
         chunk_keys: Sequence[str],
-        chunks: Sequence[memoryview],
+        chunk_groups: Sequence[Sequence[memoryview]],
         max_inflight_put: int,
-    ) -> list[tuple[list[str], list[memoryview]]]:
+    ) -> list[tuple[list[str], list[Sequence[memoryview]]]]:
         if not chunk_keys:
             return []
-        group_count = max(1, min(max_inflight_put, len(chunks)))
-        group_size = (len(chunks) + group_count - 1) // group_count
+        group_count = max(1, min(max_inflight_put, len(chunk_groups)))
+        group_size = (len(chunk_groups) + group_count - 1) // group_count
         return [
             (
                 list(chunk_keys[start : start + group_size]),
-                list(chunks[start : start + group_size]),
+                list(chunk_groups[start : start + group_size]),
             )
-            for start in range(0, len(chunks), group_size)
+            for start in range(0, len(chunk_groups), group_size)
         ]
-
-    def _read_chunks_with_batch_get_into(
-        self,
-        chunks: Sequence[Mapping[str, Any]],
-        offsets: Sequence[int],
-        destination: bytearray | np.ndarray,
-    ) -> bool:
-        batch_get_into = self._batch_get_into
-        if not callable(batch_get_into) or not self._has_buffer_registration_support():
-            return False
-        with self._registered_buffer(destination, "bundle payload") as base_ptr:
-            keys = [chunk["key"] for chunk in chunks]
-            ptrs = [base_ptr + offset for offset in offsets]
-            sizes = [int(chunk["bytes"]) for chunk in chunks]
-            read_sizes = batch_get_into(keys, ptrs, sizes)
-            if len(read_sizes) != len(keys):
-                raise RuntimeError(
-                    f"batch_get_into returned {len(read_sizes)} results for {len(keys)} chunks"
-                )
-            for key, expected_size, actual_size in zip(keys, sizes, read_sizes):
-                if actual_size != expected_size:
-                    raise RuntimeError(
-                        f"batch_get_into failed for {key}: expected {expected_size}, got {actual_size}"
-                    )
-        return True
 
     def _read_chunk_with_get(
         self,
@@ -3753,37 +4397,136 @@ class _MooncakePayloadTransport:
             )
         destination[offset : offset + chunk_bytes] = data
 
-    def _read_payload_range_into_registered_destination(
+    def _read_chunks_with_pool_get_into(
         self,
         chunks: Sequence[Mapping[str, Any]],
-        destination: np.ndarray,
-        byte_offset: int,
-        byte_length: int,
-        destination_pre_registered: bool,
+        offsets: Sequence[int],
+        destination: bytearray | np.ndarray,
     ) -> bool:
-        if not self._has_buffer_registration_support():
+        """Pool-based batch_get_into: acquire pool → RDMA read → copy to destination."""
+        batch_get_into = self._batch_get_into
+        if not callable(batch_get_into):
             return False
-        with self._registered_buffer(
-            destination,
-            "structured ndarray payload",
-            pre_registered=destination_pre_registered,
-        ) as base_ptr:
-            return self._read_payload_range_into_raw_destination(
-                chunks, base_ptr, byte_offset, byte_length
+        pool = self._ensure_buffer_pool()
+        if pool is None:
+            return False
+        total_bytes = sum(int(c["bytes"]) for c in chunks)
+        if total_bytes == 0:
+            return True
+        try:
+            lease = pool.acquire(total_bytes)
+        except RuntimeError:
+            return self._read_chunks_with_chunked_pool_get_into(
+                chunks, offsets, destination
             )
+        try:
+            keys = [c["key"] for c in chunks]
+            sizes = [int(c["bytes"]) for c in chunks]
+            ptrs = [lease.ptr + off for off in offsets]
+            read_sizes = batch_get_into(keys, ptrs, sizes)
+            if len(read_sizes) != len(keys):
+                raise RuntimeError(
+                    f"batch_get_into returned {len(read_sizes)} results for {len(keys)} chunks"
+                )
+            for key, expected, actual in zip(keys, sizes, read_sizes):
+                if actual != expected:
+                    raise RuntimeError(
+                        f"batch_get_into: {key} expected {expected}, got {actual}"
+                    )
+            ctypes.memmove(
+                _buffer_ptr(destination), lease.ptr, total_bytes
+            )
+        finally:
+            lease.release()
+        return True
 
-    def _read_payload_ranges_into_registered_destination(
+    def _read_chunks_with_chunked_pool_get_into(
+        self,
+        chunks: Sequence[Mapping[str, Any]],
+        offsets: Sequence[int],
+        destination: bytearray | np.ndarray,
+    ) -> bool:
+        """Per-chunk pool acquire + get_into fallback when full acquire fails."""
+        batch_get_into = self._batch_get_into
+        pool = self._buffer_pool
+        if not callable(batch_get_into) or pool is None:
+            return False
+        for chunk, offset in zip(chunks, offsets):
+            size = int(chunk["bytes"])
+            if size == 0:
+                continue
+            try:
+                lease = pool.acquire(size)
+            except RuntimeError:
+                return False
+            try:
+                read_sizes = batch_get_into([chunk["key"]], [lease.ptr], [size])
+                if len(read_sizes) != 1 or read_sizes[0] != size:
+                    raise RuntimeError(
+                        f"batch_get_into: {chunk['key']} expected {size}, got {read_sizes}"
+                    )
+                ctypes.memmove(
+                    _buffer_ptr(destination) + offset, lease.ptr, size
+                )
+            finally:
+                lease.release()
+        return True
+
+    def _read_with_pool_into_destination(
         self,
         chunks: Sequence[Mapping[str, Any]],
         destination: bytearray | np.ndarray,
-        ranges: Sequence[tuple[int, int, int]],
+        *,
+        byte_offset: int = 0,
+        byte_length: int | None = None,
+        ranges: Sequence[tuple[int, int, int]] | None = None,
     ) -> bool:
-        if not self._has_buffer_registration_support():
+        """Pool-based read: acquire pool → RDMA read → copy to destination.
+
+        Single-range mode (ranges is None): read byte_length bytes at byte_offset.
+        Multi-range mode (ranges provided): read scattered ranges into destination.
+        """
+        pool = self._ensure_buffer_pool()
+        if pool is None:
             return False
-        with self._registered_buffer(destination, "structured ranged payload") as base_ptr:
-            return self._read_payload_ranges_into_raw_destination(
-                chunks, base_ptr, ranges
+        if ranges is not None:
+            if not callable(self._get_into_ranges):
+                return False
+            total_bytes = _buffer_nbytes(destination)
+        else:
+            if byte_length is None:
+                return False
+            total_bytes = byte_length
+        try:
+            lease = pool.acquire(total_bytes)
+        except RuntimeError:
+            # Full acquire failed; fall back to chunked pool read when
+            # in single-range mode (no ranges) and reading from offset 0.
+            if ranges is None and byte_offset == 0:
+                offsets = _chunk_offsets(chunks)
+                return self._read_chunks_with_chunked_pool_get_into(
+                    chunks, offsets, destination
+                )
+            return False
+        try:
+            if ranges is not None:
+                ok = self._read_payload_ranges_into_raw_destination(
+                    chunks, lease.ptr, ranges
+                )
+            else:
+                ok = self._read_payload_range_into_raw_destination(
+                    chunks, lease.ptr, byte_offset, total_bytes
+                )
+            if not ok:
+                return False
+            ctypes.memmove(
+                _buffer_ptr(destination), lease.ptr, total_bytes
             )
+            return True
+        except Exception:
+            return False
+        finally:
+            lease.release()
 
     def _read_payload_ranges_into_raw_destination(
         self,
@@ -3797,7 +4540,9 @@ class _MooncakePayloadTransport:
         fragments = []
         for source_offset, destination_offset, byte_length in ranges:
             fragments.extend(
-                _payload_range_fragments(chunks, source_offset, byte_length, destination_offset)
+                _payload_range_fragments(
+                    chunks, source_offset, byte_length, destination_offset
+                )
             )
         if not fragments:
             return True
@@ -3964,73 +4709,9 @@ class _MooncakePayloadTransport:
                 source_offset : source_offset + size
             ]
 
-    def _register_buffers(
+    def _resolve_buffer_group_put_mode(
         self,
-        buffer_ptrs: Sequence[int],
-        sizes: Sequence[int],
-        pre_registered: bool,
-        label: str,
-    ) -> list[int]:
-        register_buffer = self._register_buffer
-        unregister_buffer = self._unregister_buffer
-        if pre_registered:
-            return []
-        if not (callable(register_buffer) and callable(unregister_buffer)):
-            raise RuntimeError(f"register_buffer APIs are unavailable for {label}")
-        registered_ptrs: list[int] = []
-        try:
-            for ptr, size in zip(buffer_ptrs, sizes):
-                if size == 0:
-                    continue
-                register_status = register_buffer(ptr, size)
-                if register_status == 0:
-                    registered_ptrs.append(ptr)
-                    continue
-                if not _is_duplicate_buffer_registration(register_status):
-                    _check_status(register_status, "register_buffer", label)
-        except Exception:
-            self._unregister_buffers(registered_ptrs, label)
-            raise
-        return registered_ptrs
-
-    def _unregister_buffers(self, registered_ptrs: Sequence[int], label: str) -> None:
-        unregister_buffer = self._unregister_buffer
-        if not callable(unregister_buffer):
-            raise RuntimeError(f"unregister_buffer APIs are unavailable for {label}")
-        for ptr in reversed(registered_ptrs):
-            _check_status(unregister_buffer(ptr), "unregister_buffer", label)
-
-    @contextmanager
-    def _registered_buffer(
-        self,
-        destination: bytearray | np.ndarray,
-        label: str,
-        pre_registered: bool = False,
-    ) -> Iterator[int]:
-        base_ptr = _buffer_ptr(destination)
-        if pre_registered:
-            yield base_ptr
-            return
-        registered_ptrs = self._register_buffers(
-            [base_ptr], [_buffer_nbytes(destination)], False, label
-        )
-        if not registered_ptrs:
-            yield base_ptr
-            return
-        succeeded = False
-        try:
-            yield base_ptr
-            succeeded = True
-        finally:
-            try:
-                self._unregister_buffers(registered_ptrs, label)
-            except Exception:
-                if succeeded:
-                    raise
-
-    def _resolve_put_mode(
-        self,
-        chunks: Sequence[memoryview],
+        chunk_groups: Sequence[Sequence[memoryview]],
         transfer_policy: BundleTransferPolicy,
     ) -> Literal["batch", "parallel"]:
         if transfer_policy.put_mode == "parallel":
@@ -4039,21 +4720,17 @@ class _MooncakePayloadTransport:
             return "batch"
         if transfer_policy.max_inflight_put <= 1:
             return "batch"
-        if len(chunks) < AUTO_PARALLEL_MIN_CHUNKS:
+        if len(chunk_groups) < AUTO_PARALLEL_MIN_CHUNKS:
             return "batch"
-        if sum(len(chunk) for chunk in chunks) < AUTO_PARALLEL_MIN_BYTES:
+        total_bytes = sum(_buffer_group_nbytes(group) for group in chunk_groups)
+        if total_bytes < AUTO_PARALLEL_MIN_BYTES:
             return "batch"
-        if min(transfer_policy.max_inflight_put, len(chunks)) < 2:
+        if min(transfer_policy.max_inflight_put, len(chunk_groups)) < 2:
             return "batch"
         return "parallel"
 
     def _has_batch_put_support(self) -> bool:
-        return (
-            callable(self._batch_put_from) and self._has_buffer_registration_support()
-        )
-
-    def _has_buffer_registration_support(self) -> bool:
-        return callable(self._register_buffer) and callable(self._unregister_buffer)
+        return callable(self._batch_put_from)
 
 
 def _resolve_ndarray_destination(
@@ -4071,20 +4748,26 @@ def _resolve_ndarray_destination(
                 f"raw destination has {destination.size} bytes, expected at least {nbytes}"
             )
         _ = destination.owner
-        return np.ctypeslib.as_array(
-            (ctypes.c_uint8 * nbytes).from_address(destination.ptr)
-        ).view(dtype).reshape(shape)
+        return (
+            np.ctypeslib.as_array(
+                (ctypes.c_uint8 * nbytes).from_address(destination.ptr)
+            )
+            .view(dtype)
+            .reshape(shape)
+        )
     if not isinstance(destination, np.ndarray):
         raise TypeError(
             f"structured ndarray field {name} destination must be a numpy.ndarray or raw_destination"
         )
     if destination.dtype != dtype:
         raise ValueError(
-            f"structured ndarray field {name} destination dtype mismatch: expected {dtype.str}, got {destination.dtype.str}"
+            f"structured ndarray field {name} destination dtype mismatch: "
+            f"expected {dtype.str}, got {destination.dtype.str}"
         )
     if tuple(destination.shape) != shape:
         raise ValueError(
-            f"structured ndarray field {name} destination shape mismatch: expected {shape}, got {tuple(destination.shape)}"
+            f"structured ndarray field {name} destination shape mismatch: "
+            f"expected {shape}, got {tuple(destination.shape)}"
         )
     if not destination.flags["C_CONTIGUOUS"]:
         raise ValueError(
@@ -4167,16 +4850,6 @@ def _bytes_view(value: Any, name: str) -> memoryview:
     return view.cast("B")
 
 
-def _prepare_chunk_source_buffer(chunk: memoryview) -> tuple[Any, int, int]:
-    if len(chunk) == 0:
-        copied = ctypes.create_string_buffer(0)
-        return copied, ctypes.addressof(copied), 0
-    if chunk.c_contiguous and not chunk.readonly:
-        return chunk, ctypes.addressof(ctypes.c_char.from_buffer(chunk)), len(chunk)
-    copied = ctypes.create_string_buffer(bytes(chunk))
-    return copied, ctypes.addressof(copied), len(chunk)
-
-
 def _buffer_ptr(value: bytearray | np.ndarray) -> int:
     return ctypes.addressof(ctypes.c_char.from_buffer(value))
 
@@ -4193,6 +4866,55 @@ def _split_view(view: memoryview, chunk_bytes: int) -> list[memoryview]:
     return [
         view[start : start + chunk_bytes] for start in range(0, len(view), chunk_bytes)
     ]
+
+
+def _split_multi_buffer_payload(
+    buffers: Sequence[memoryview], chunk_bytes: int
+) -> list[list[memoryview]]:
+    if len(buffers) == 1:
+        return [[chunk] for chunk in _split_view(buffers[0], chunk_bytes)]
+    groups: list[list[memoryview]] = []
+    current: list[memoryview] = []
+    current_bytes = 0
+    for buffer in buffers:
+        offset = 0
+        while offset < len(buffer):
+            remaining = chunk_bytes - current_bytes
+            part = buffer[offset : offset + remaining]
+            current.append(part)
+            current_bytes += len(part)
+            offset += len(part)
+            if current_bytes == chunk_bytes:
+                groups.append(current)
+                current = []
+                current_bytes = 0
+    if current:
+        groups.append(current)
+    return groups
+
+
+def _buffer_group_nbytes(buffers: Sequence[memoryview]) -> int:
+    return sum(len(buffer) for buffer in buffers)
+
+
+def _copy_memoryviews(buffers: Sequence[memoryview], destination: memoryview) -> None:
+    offset = 0
+    for buffer in buffers:
+        next_offset = offset + len(buffer)
+        destination[offset:next_offset] = buffer
+        offset = next_offset
+
+
+def _copy_memoryviews_to_lease(buffers: Sequence[memoryview], lease: Any) -> None:
+    copy_from_buffers = getattr(lease, "copy_from_buffers", None)
+    if callable(copy_from_buffers):
+        copy_from_buffers(buffers)
+        return
+    view = lease.buffer
+    try:
+        _copy_memoryviews(buffers, view)
+    finally:
+        view.release()
 
 
 def _chunk_offsets(chunks: Sequence[Mapping[str, Any]]) -> list[int]:
@@ -4311,6 +5033,10 @@ def raw_destination(
 def _encode_structured_field(value: Any) -> tuple[dict[str, Any], Any]:
     if isinstance(value, _TensorObjectBufferPayload):
         return {"encoding": "torch_tensor"}, value
+    if isinstance(value, _TensorPayload):
+        return _encode_torch_tensor_field(value.tensor)
+    if isinstance(value, _MultiBufferPayload):
+        return {"encoding": "bytes"}, value
     if _torch is not None and isinstance(value, _torch.Tensor):
         return _encode_torch_tensor_field(value)
     if isinstance(value, np.ndarray):
@@ -4327,7 +5053,7 @@ def _encode_torch_tensor_field(value: Any) -> tuple[dict[str, Any], Any]:
     return {
         "encoding": "torch_tensor",
         "dtype": str(value.dtype),
-        "shape": list(value.shape),
+        "shape": list(getattr(value, "shape", ())),
         "element_size": int(value.element_size()),
     }, _TensorPayload(tensor=value)
 
@@ -4405,48 +5131,6 @@ def _tensor_codec_helper(name: str) -> Any:
     return helper
 
 
-def _validate_pre_registered_structured_buffers(
-    original_buffers: Mapping[str, Any],
-    encoded_buffers: Mapping[str, Any],
-    pre_registered_buffers: Optional[Mapping[str, bool]],
-) -> None:
-    if not pre_registered_buffers:
-        return
-    for name, pre_registered in pre_registered_buffers.items():
-        if not pre_registered:
-            continue
-        if name not in original_buffers or name not in encoded_buffers:
-            raise ValueError(f"unknown pre-registered structured buffer: {name}")
-        if not _is_same_writable_buffer(original_buffers[name], encoded_buffers[name]):
-            raise ValueError(
-                f"pre-registered structured buffer {name} must be the same writable contiguous buffer used for transfer"
-            )
-
-
-def _is_same_writable_buffer(original: Any, encoded: Any) -> bool:
-    try:
-        original_view = memoryview(original)
-        encoded_view = memoryview(encoded)
-    except TypeError:
-        return False
-    if not original_view.c_contiguous or not encoded_view.c_contiguous:
-        return False
-    if original_view.readonly or encoded_view.readonly:
-        return False
-    if original_view.nbytes != encoded_view.nbytes:
-        return False
-    if original_view.nbytes == 0:
-        return True
-    try:
-        original_bytes = original_view.cast("B")
-        encoded_bytes = encoded_view.cast("B")
-        original_ptr = ctypes.addressof(ctypes.c_char.from_buffer(original_bytes))
-        encoded_ptr = ctypes.addressof(ctypes.c_char.from_buffer(encoded_bytes))
-    except (BufferError, TypeError, ValueError):
-        return False
-    return original_ptr == encoded_ptr
-
-
 def _structured_field_specs(metadata: Mapping[str, Any]) -> dict[str, Any]:
     field_specs = metadata.get(STRUCTURED_FIELD_SPECS_KEY, {})
     if not isinstance(field_specs, dict):
@@ -4483,9 +5167,19 @@ def _decode_structured_metadata(payload: bytes) -> dict[str, Any]:
 
 def _encode_json_dict(value: Mapping[str, Any], label: str) -> bytes:
     try:
-        return json.dumps(value, separators=(",", ":")).encode("utf-8")
+        return json.dumps(value, default=_json_default, separators=(",", ":")).encode(
+            "utf-8"
+        )
     except TypeError as error:
         raise TypeError(f"{label} must be JSON-serializable") from error
+
+
+def _json_default(value: Any) -> Any:
+    if isinstance(value, np.generic):
+        return value.item()
+    if hasattr(value, "__int__"):
+        return int(value)
+    raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
 
 
 def _decode_json_dict(payload: bytes, label: str) -> dict[str, Any]:
@@ -4498,11 +5192,6 @@ def _decode_json_dict(payload: bytes, label: str) -> dict[str, Any]:
 def _check_status(status: Any, operation: str, key: str) -> None:
     if status not in (None, 0):
         raise RuntimeError(f"{operation} failed for {key}: {status}")
-
-
-def _is_duplicate_buffer_registration(status: Any) -> bool:
-    # Mooncake returns -600 when a caller-owned buffer is already registered.
-    return status == -600
 
 
 def _cleanup_keys(store: BundleStore, keys: Sequence[str], strict: bool) -> None:
@@ -4549,19 +5238,49 @@ def _cleanup_keys(store: BundleStore, keys: Sequence[str], strict: bool) -> None
 
 
 # ---------------------------------------------------------------------------
-# Codec inference and recursive structure expansion
+# Internal helpers: torch, codec types, sentinel, decode utilities
 # ---------------------------------------------------------------------------
-
-_INFER_MAX_STRUCT_KEYS = 64
-_INFER_MAX_LIST_LEN = 8
-_INFER_MAX_SAMPLE_ROWS = 128
-_INFER_MAX_JSON_BYTES = 1 << 20
-_INFER_MAX_DEPTH = 32
 
 try:
     import torch as _torch
 except Exception:  # pragma: no cover
     _torch = None  # type: ignore[assignment]
+
+
+def _parse_torch_dtype(dtype_str: str) -> Any:
+    """Parse torch dtype string (e.g. 'torch.float32') to torch.dtype object."""
+    name = dtype_str.removeprefix("torch.")
+    dtype = getattr(_torch, name, None)
+    if dtype is None or not isinstance(dtype, _torch.dtype):
+        raise ValueError(f"unknown torch dtype: {dtype_str}")
+    return dtype
+
+
+_TORCH_TO_NUMPY_DTYPE = {
+    "torch.float16": np.float16,
+    "torch.float32": np.float32,
+    "torch.float64": np.float64,
+    "torch.bfloat16": np.float16,  # numpy has no bfloat16, use float16 size
+    "torch.int8": np.int8,
+    "torch.int16": np.int16,
+    "torch.int32": np.int32,
+    "torch.int64": np.int64,
+    "torch.uint8": np.uint8,
+    "torch.bool": np.bool_,
+}
+
+
+def _torch_dtype_to_numpy(dtype_str: str) -> np.dtype:
+    """Convert torch dtype string to numpy dtype for buffer interpretation."""
+    result = _TORCH_TO_NUMPY_DTYPE.get(dtype_str)
+    if result is not None:
+        return np.dtype(result)
+    # Fallback: strip 'torch.' prefix and try numpy
+    name = dtype_str.removeprefix("torch.")
+    try:
+        return np.dtype(name)
+    except TypeError:
+        return np.dtype(np.float32)
 
 
 @dataclass
@@ -4574,13 +5293,6 @@ class _CodecDecision:
 
 
 @dataclass
-class _InferredLeaf:
-    path: str
-    values: list[Any]
-    decision: _CodecDecision
-
-
-@dataclass
 class _EncodedStructuredLeaf:
     codec: str
     rows: int
@@ -4588,16 +5300,11 @@ class _EncodedStructuredLeaf:
     metadata: dict[str, Any]
 
 
-class _Missing:
-    """Sentinel for dict keys absent from a row (distinct from value-is-None)."""
-
-    __slots__ = ()
-
-    def __repr__(self) -> str:
-        return "<MISSING>"
-
-
-MISSING = _Missing()
+@dataclass
+class _InferredLeaf:
+    path: str
+    values: list[Any]
+    decision: _CodecDecision
 
 
 @dataclass
@@ -4609,8 +5316,23 @@ class _InferredNode:
     row_mask: list[bool] | None = None
 
 
-def _non_null(values: list[Any]) -> list[Any]:
-    return [v for v in values if v is not None and not isinstance(v, _Missing)]
+class _Missing:
+    """Sentinel for dict keys absent from a row (distinct from value-is-None).
+
+    Kept for backward-compatible decoding of structured_recursive payloads.
+    """
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:
+        return "<MISSING>"
+
+
+MISSING = _Missing()
+
+
+def _escape_key(key: str) -> str:
+    return key.replace("\\", "\\\\").replace(".", "\\.").replace("[", "\\[")
 
 
 def _is_pil_image(value: Any) -> bool:
@@ -4622,303 +5344,164 @@ def _is_bytes_like(value: Any) -> bool:
     return isinstance(value, (bytes, bytearray, memoryview))
 
 
+def _non_null(values: list[Any]) -> list[Any]:
+    return [value for value in values if value is not None and not isinstance(value, _Missing)]
+
+
 def _is_media_list(value: Any) -> bool:
     return isinstance(value, (list, tuple)) and all(
         _is_pil_image(item) or _is_bytes_like(item) for item in value
     )
 
 
-def _can_media_list(values: list[Any]) -> _CodecDecision:
-    nn = _non_null(values)
-    if not nn:
-        return _CodecDecision(
-            False, "media_list_ragged", "all rows are null", "media list"
-        )
-    if not all(_is_media_list(v) for v in nn):
-        return _CodecDecision(
-            False, "media_list_ragged", "not all rows are media list", "media list"
-        )
-    if not any(len(v) > 0 for v in nn):
-        return _CodecDecision(
-            False, "media_list_ragged", "all media lists are empty", "media list"
-        )
-    return _CodecDecision(
-        True, "media_list_ragged", "all non-null rows are media list", "media list"
-    )
-
-
-def _check_all(
-    values: list[Any],
-    predicate: Any,
-    codec: str,
-    normalized_type: str,
-) -> _CodecDecision:
-    nn = _non_null(values)
-    if not nn:
-        return _CodecDecision(False, codec, "all rows are null", normalized_type)
-    if not all(predicate(v) for v in nn):
-        return _CodecDecision(
-            False, codec, f"not all rows are {normalized_type}", normalized_type
-        )
-    return _CodecDecision(
-        True, codec, f"all non-null rows are {normalized_type}", normalized_type
-    )
-
-
-def _can_tensor(values: list[Any]) -> _CodecDecision:
-    if _torch is None:
-        return _CodecDecision(
-            False, "ragged_tensor", "torch is not available", "torch.Tensor"
-        )
-    nn = _non_null(values)
-    if not nn:
-        return _CodecDecision(
-            False, "ragged_tensor", "all rows are null", "torch.Tensor"
-        )
-    if not all(isinstance(v, _torch.Tensor) for v in nn):
-        return _CodecDecision(
-            False, "ragged_tensor", "not all rows are Tensor", "torch.Tensor"
-        )
-    dtypes = sorted({str(v.dtype) for v in nn})
-    if len(dtypes) != 1:
-        return _CodecDecision(
-            False, "ragged_tensor", f"mixed dtypes: {dtypes}", "torch.Tensor"
-        )
-    ndims = {v.ndim for v in nn}
-    if len(ndims) != 1:
-        return _CodecDecision(
-            False, "ragged_tensor", f"mixed dimensions: {ndims}", "torch.Tensor"
-        )
-    return _CodecDecision(
-        True,
-        "ragged_tensor",
-        "all non-null rows are Tensor",
-        "torch.Tensor",
-        {"dtype": dtypes[0]},
-    )
-
-
-def _can_numeric_sequence(values: list[Any]) -> _CodecDecision:
-    nn = _non_null(values)
-    if not nn:
-        return _CodecDecision(
-            False, "typed_ragged", "all rows are null", "numeric sequence"
-        )
-    dtypes = []
-    for v in nn:
-        if isinstance(v, np.ndarray):
-            arr = v
-        elif isinstance(v, (list, tuple)):
-            try:
-                arr = np.asarray(v)
-            except (ValueError, TypeError):
-                return _CodecDecision(
-                    False,
-                    "typed_ragged",
-                    "row cannot be converted to ndarray",
-                    "numeric sequence",
-                )
-        else:
-            return _CodecDecision(
-                False, "typed_ragged", "row is not array-like", "numeric sequence"
-            )
-        if arr.dtype == object or not np.issubdtype(arr.dtype, np.number):
-            return _CodecDecision(
-                False,
-                "typed_ragged",
-                f"non-numeric dtype: {arr.dtype}",
-                "numeric sequence",
-            )
-        dtypes.append(arr.dtype)
-    try:
-        dtype = np.result_type(*dtypes)
-    except (TypeError, ValueError, OverflowError):
-        return _CodecDecision(
-            False, "typed_ragged", "cannot determine common dtype", "numeric sequence"
-        )
-    return _CodecDecision(
-        True,
-        "typed_ragged",
-        "all rows promote to common numeric dtype",
-        "numeric sequence",
-        {"dtype": str(dtype)},
-    )
-
-
-def _can_numeric_scalar(values: list[Any]) -> _CodecDecision:
-    nn = _non_null(values)
-    if not nn:
-        return _CodecDecision(False, "ndarray", "all rows are null", "numeric scalar")
-    if not all(isinstance(v, (bool, int, float, np.number)) for v in nn):
-        return _CodecDecision(
-            False, "ndarray", "not all rows are numeric scalar", "numeric scalar"
-        )
-    try:
-        dtype = np.result_type(*nn)
-    except (TypeError, ValueError, OverflowError):
-        return _CodecDecision(
-            False, "ndarray", "cannot determine common dtype", "numeric scalar"
-        )
-    if not np.issubdtype(dtype, np.number) and not np.issubdtype(dtype, np.bool_):
-        return _CodecDecision(
-            False, "ndarray", f"non-numeric dtype: {dtype}", "numeric scalar"
-        )
-    return _CodecDecision(
-        True,
-        "ndarray",
-        "all rows are numeric scalar",
-        "numeric scalar",
-        {"dtype": str(dtype)},
-    )
-
-
-def _can_msgpack(values: list[Any]) -> _CodecDecision:
+def _leaf_decision(values: list[Any]) -> _CodecDecision:
     nn = _non_null(values)
     if not nn:
         return _CodecDecision(False, "msgpack_ragged", "all rows are null", "msgpack")
-    if not all(isinstance(v, (dict, list, tuple)) for v in nn):
+    if _torch is not None and all(isinstance(value, _torch.Tensor) for value in nn):
+        dtype = str(nn[0].dtype)
+        return _CodecDecision(True, "ragged_tensor", "all non-null rows are Tensor", "torch.Tensor", {"dtype": dtype})
+    if all(_is_media_list(value) for value in nn):
+        return _CodecDecision(True, "media_list_ragged", "all rows are media lists", "media list")
+    if all(isinstance(value, np.ndarray) for value in nn):
         return _CodecDecision(
-            False, "msgpack_ragged", "not all rows are structured objects", "msgpack"
+            True,
+            "typed_ragged",
+            "all rows are ndarray",
+            "numeric sequence",
+            {"recursive_source": "ndarray"},
         )
-    sampled_bytes = 0
-    for i, v in enumerate(nn):
+    if all(isinstance(value, (list, tuple)) for value in nn):
         try:
-            encoded = _msgpack.packb(v, use_bin_type=True, strict_types=True)
+            dtypes = [np.asarray(value).dtype for value in nn]
+            dtype = np.result_type(*dtypes)
         except (TypeError, ValueError, OverflowError):
-            return _CodecDecision(
-                False, "msgpack_ragged", "serialization failed", "msgpack"
-            )
-        if i < _INFER_MAX_SAMPLE_ROWS:
-            sampled_bytes += len(encoded)
-    if sampled_bytes > _INFER_MAX_JSON_BYTES:
-        return _CodecDecision(
-            False, "msgpack_ragged", "sampled payload too large", "msgpack"
-        )
-    return _CodecDecision(
-        True, "msgpack_ragged", "all rows pass msgpack serialization", "msgpack"
-    )
-
-
-def _can_json(values: list[Any]) -> _CodecDecision:
-    nn = _non_null(values)
-    if not nn:
-        return _CodecDecision(False, "json_ragged", "all rows are null", "json")
-    sampled_bytes = 0
-    for i, v in enumerate(nn):
-        try:
-            encoded = json.dumps(v, ensure_ascii=False, separators=(",", ":")).encode(
-                "utf-8"
-            )
-        except (TypeError, ValueError, OverflowError, RecursionError):
-            return _CodecDecision(False, "json_ragged", "serialization failed", "json")
-        if i < _INFER_MAX_SAMPLE_ROWS:
-            sampled_bytes += len(encoded)
-    if sampled_bytes > _INFER_MAX_JSON_BYTES:
-        return _CodecDecision(False, "json_ragged", "sampled payload too large", "json")
-    return _CodecDecision(
-        True, "json_ragged", "all rows pass JSON serialization", "json"
-    )
-
-
-_CODEC_PREDICATES: tuple[Any, ...] = (
-    _can_tensor,
-    _can_media_list,
-    _can_numeric_sequence,
-    _can_numeric_scalar,
-    lambda v: _check_all(v, _is_bytes_like, "bytes_ragged", "bytes-like"),
-    lambda v: _check_all(v, _is_pil_image, "media_bytes", "media"),
-    lambda v: _check_all(v, lambda x: isinstance(x, str), "utf8_ragged", "str"),
-    _can_msgpack,
-    _can_json,
-)
-
-
-def _choose_leaf_codec(values: list[Any]) -> _CodecDecision:
-    for predicate in _CODEC_PREDICATES:
-        decision = predicate(values)
-        if decision.accepted:
-            return decision
-    return _CodecDecision(
-        False, "pickle_ragged_fallback", "no optimized codec matched", "python object"
-    )
+            dtype = None
+        if dtype is not None and np.issubdtype(dtype, np.number):
+            return _CodecDecision(True, "typed_ragged", "all rows are numeric sequences", "numeric sequence", {"dtype": str(dtype)})
+    if all(isinstance(value, (bool, int, float, np.number)) for value in nn):
+        dtype = np.result_type(*nn)
+        return _CodecDecision(True, "ndarray", "all rows are numeric scalar", "numeric scalar", {"dtype": str(dtype)})
+    if all(_is_bytes_like(value) for value in nn):
+        return _CodecDecision(True, "bytes_ragged", "all rows are bytes-like", "bytes-like")
+    if all(_is_pil_image(value) for value in nn):
+        return _CodecDecision(True, "media_bytes", "all rows are media", "media")
+    if all(isinstance(value, str) for value in nn):
+        return _CodecDecision(True, "utf8_ragged", "all rows are str", "str")
+    if all(isinstance(value, (dict, list, tuple)) for value in nn):
+        return _CodecDecision(True, "msgpack_ragged", "all rows are msgpack-like", "msgpack")
+    return _CodecDecision(False, "msgpack_ragged", "no codec matched", "python object")
 
 
 def _try_expand_dict(values: list[Any]) -> list[str] | None:
     nn = _non_null(values)
-    if not nn or not all(isinstance(v, dict) for v in nn):
+    if not nn or not all(isinstance(value, dict) for value in nn):
         return None
-    keys = {k for v in nn for k in v.keys()}
-    if not all(isinstance(k, str) for k in keys) or len(keys) > _INFER_MAX_STRUCT_KEYS:
+    keys = {key for value in nn for key in value.keys()}
+    if not all(isinstance(key, str) for key in keys) or len(keys) > 64:
         return None
     return sorted(keys)
 
 
 def _try_expand_list(values: list[Any]) -> tuple[int, list[int]] | None:
     nn = _non_null(values)
-    if not nn or not all(isinstance(v, (list, tuple)) for v in nn):
+    if not nn or not all(isinstance(value, (list, tuple)) for value in nn):
         return None
-    max_len = max(len(v) for v in nn)
-    if max_len > _INFER_MAX_LIST_LEN:
+    max_len = max(len(value) for value in nn)
+    if max_len > 8:
         return None
     if not all(
-        item is None or isinstance(item, (dict, list, tuple)) for v in nn for item in v
+        item is None or isinstance(item, (dict, list, tuple))
+        for value in nn
+        for item in value
     ):
         return None
-    lengths = [len(v) if isinstance(v, (list, tuple)) else 0 for v in values]
+    lengths = [len(value) if isinstance(value, (list, tuple)) else 0 for value in values]
     return max_len, lengths
 
 
-def _escape_key(key: str) -> str:
-    return key.replace("\\", "\\\\").replace(".", "\\.").replace("[", "\\[")
-
-
-def infer_structure(
+def _infer_structure(
     path: str,
     values: list[Any],
     leaves: list[_InferredLeaf],
     nodes: list[_InferredNode],
     *,
-    _depth: int = 0,
+    depth: int = 0,
 ) -> None:
-    """Recursively expand *values* into leaves and interior nodes.
-
-    *leaves* and *nodes* are output accumulators populated during recursion.
-    Absent dict keys are represented as ``MISSING`` in child columns
-    (distinct from ``None`` values).  Each interior node carries a
-    ``row_mask`` that records which rows had a real parent container.
-    """
-    if _depth > _INFER_MAX_DEPTH:
-        raise ValueError(
-            f"infer_structure exceeded max depth {_INFER_MAX_DEPTH} at {path!r}"
-        )
+    if depth > 32:
+        raise ValueError(f"infer_structure exceeded max depth 32 at {path!r}")
     dict_keys = _try_expand_dict(values)
     if dict_keys is not None:
-        row_mask = [isinstance(v, dict) for v in values]
+        row_mask = [isinstance(value, dict) for value in values]
         nodes.append(_InferredNode(path, "dict", dict_keys, row_mask=row_mask))
         for key in dict_keys:
-            child = [
-                v.get(key, MISSING) if isinstance(v, dict) else None for v in values
-            ]
-            infer_structure(
-                f"{path}.{_escape_key(key)}", child, leaves, nodes, _depth=_depth + 1
-            )
+            child = [value.get(key, MISSING) if isinstance(value, dict) else None for value in values]
+            _infer_structure(f"{path}.{_escape_key(key)}", child, leaves, nodes, depth=depth + 1)
         return
     list_result = _try_expand_list(values)
     if list_result is not None:
         max_len, lengths = list_result
-        row_mask = [isinstance(v, (list, tuple)) for v in values]
-        nodes.append(
-            _InferredNode(
-                path, "list", list(range(max_len)), lengths, row_mask=row_mask
-            )
-        )
+        row_mask = [isinstance(value, (list, tuple)) for value in values]
+        nodes.append(_InferredNode(path, "list", list(range(max_len)), lengths, row_mask=row_mask))
         for index in range(max_len):
             child = [
-                v[index]
-                if isinstance(v, (list, tuple)) and index < len(v)
-                else (MISSING if isinstance(v, (list, tuple)) else None)
-                for v in values
+                value[index]
+                if isinstance(value, (list, tuple)) and index < len(value)
+                else (MISSING if isinstance(value, (list, tuple)) else None)
+                for value in values
             ]
-            infer_structure(f"{path}[{index}]", child, leaves, nodes, _depth=_depth + 1)
+            _infer_structure(f"{path}[{index}]", child, leaves, nodes, depth=depth + 1)
         return
-    leaves.append(_InferredLeaf(path, values, _choose_leaf_codec(values)))
+    leaves.append(_InferredLeaf(path, values, _leaf_decision(values)))
+
+
+def _structured_path_tokens(path: str) -> list[Any]:
+    tokens: list[Any] = []
+    index = 0
+    current: list[str] = []
+    while index < len(path):
+        char = path[index]
+        if char == "\\" and index + 1 < len(path):
+            current.append(path[index + 1])
+            index += 2
+            continue
+        if char == ".":
+            if current:
+                tokens.append("".join(current))
+                current = []
+            index += 1
+            continue
+        if char == "[":
+            if current:
+                tokens.append("".join(current))
+                current = []
+            end = path.index("]", index)
+            tokens.append(int(path[index + 1 : end]))
+            index = end + 1
+            continue
+        current.append(char)
+        index += 1
+    if current:
+        tokens.append("".join(current))
+    return tokens
+
+
+def _lookup_structured_path(value: Any, root_path: str, target_path: str) -> Any:
+    suffix = target_path[len(root_path) :]
+    if suffix.startswith("."):
+        suffix = suffix[1:]
+    if not suffix:
+        return value
+    current = value
+    for token in _structured_path_tokens(suffix):
+        if isinstance(current, _Missing):
+            return MISSING
+        if isinstance(token, str):
+            if not isinstance(current, dict) or token not in current:
+                return MISSING
+            current = current[token]
+        else:
+            if not isinstance(current, (list, tuple)) or token >= len(current):
+                return MISSING
+            current = current[token]
+    return current

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -148,6 +148,8 @@ class _TensorObjectBufferPayload:
 class _MultiBufferPayload:
     buffers: tuple[memoryview, ...]
     owners: tuple[Any, ...] = ()
+    dtype: str | None = None
+    shape: tuple[int, ...] | None = None
 
     @property
     def nbytes(self) -> int:
@@ -1036,7 +1038,7 @@ class MooncakeBundleTransfer:
                 for key in ("missing_payload", "row_mask_payload", "lengths_payload"):
                     payload_name = node.get(key)
                     if payload_name is not None:
-                        recursive_payload[payload_name] = read_member_indices()
+                        recursive_payload[payload_name] = read_member_indices(payload_name, indices)
             for leaf in metadata.get("leaves", []):
                 leaf_payload_members = leaf["payload_members"]
                 flat_payload_members = {
@@ -2496,17 +2498,23 @@ def _encode_ragged_tensor_values(
                 list(tensor.shape), dtype=_torch.int64
             )
     data_dtype = dtype or _torch.float32
+    np_dtype = _torch_dtype_to_numpy(str(data_dtype))
+    total_elems = int(offset)
     # Zero-copy: scatter-gather from original tensor memory, no concatenation
     if flat_parts:
         buffers = tuple(memoryview(flat.numpy().data).cast("B") for flat in flat_parts)
         owners = tuple(
             flat_parts
         )  # keep flat tensors alive (they reference original data)
-        data = _MultiBufferPayload(buffers=buffers, owners=owners)
-    else:
-        empty = np.empty(0, dtype=_torch_dtype_to_numpy(str(data_dtype)))
         data = _MultiBufferPayload(
-            buffers=(memoryview(empty.data).cast("B"),), owners=(empty,)
+            buffers=buffers, owners=owners,
+            dtype=np.dtype(np_dtype).str, shape=(total_elems,),
+        )
+    else:
+        empty = np.empty(0, dtype=np_dtype)
+        data = _MultiBufferPayload(
+            buffers=(memoryview(empty.data).cast("B"),), owners=(empty,),
+            dtype=np.dtype(np_dtype).str, shape=(0,),
         )
     payload = {
         "data": data,
@@ -2589,7 +2597,10 @@ def _encode_ragged_tensor_dict_values(
 
     keys = schema.metadata.get("keys")
     if not keys:
-        keys = sorted(non_null[0].keys())
+        all_keys: set[str] = set()
+        for v in non_null:
+            all_keys.update(v.keys())
+        keys = sorted(all_keys)
 
     payload: dict[str, Any] = {"null_mask": null_mask}
     key_codecs: dict[str, Any] = {}
@@ -2760,14 +2771,19 @@ def _encode_typed_ragged_values(
         if array.ndim > 0:
             shapes[row, : array.ndim] = array.shape
     # Zero-copy: scatter-gather from original numpy array memory, no concatenation
+    total_elems = int(offset)
     if flat_arrays:
         buffers = tuple(memoryview(flat.data).cast("B") for flat in flat_arrays)
         owners = tuple(flat_arrays)  # keep arrays alive
-        data = _MultiBufferPayload(buffers=buffers, owners=owners)
+        data = _MultiBufferPayload(
+            buffers=buffers, owners=owners,
+            dtype=np.dtype(dtype).str, shape=(total_elems,),
+        )
     else:
         empty = np.empty(0, dtype=dtype)
         data = _MultiBufferPayload(
-            buffers=(memoryview(empty.data).cast("B"),), owners=(empty,)
+            buffers=(memoryview(empty.data).cast("B"),), owners=(empty,),
+            dtype=np.dtype(dtype).str, shape=(0,),
         )
     ndarray_rows = [
         value is not None and isinstance(value, np.ndarray) for value in values
@@ -3271,7 +3287,7 @@ class _StructuredObjectLayer:
             raise ValueError(
                 f"structured bytes member {name} does not support materialize_into"
             )
-        # Always try pool-backed read first: pool memory is pre-registered,
+        # Try pool-backed read first: pool memory is pre-registered,
         # so RDMA reads go directly into pool memory without extra copies.
         expected_bytes = int(payload_spec.get("bytes", 0))
         if expected_bytes > 0:
@@ -3280,11 +3296,7 @@ class _StructuredObjectLayer:
             )
             if result is not None:
                 return result
-            # Pool array failed; use np.empty + chunked pool read (ctypes.memmove)
-            # instead of bytearray + bytes() which causes extra copies.
-            result = np.empty(expected_bytes, dtype=np.uint8)
-            self._bundle_store.read_payload_into(payload_spec, result)
-            return result
+        # Pool unavailable or size unknown — fall back to plain bytes.
         return self._bundle_store.read_payload(payload_spec)
 
     def _read_ndarray_member(
@@ -5049,6 +5061,12 @@ def _encode_structured_field(value: Any) -> tuple[dict[str, Any], Any]:
     if isinstance(value, _TensorPayload):
         return _encode_torch_tensor_field(value.tensor)
     if isinstance(value, _MultiBufferPayload):
+        if value.dtype is not None and value.shape is not None:
+            return {
+                "encoding": "ndarray",
+                "dtype": value.dtype,
+                "shape": list(value.shape),
+            }, value
         return {"encoding": "bytes"}, value
     if _torch is not None and isinstance(value, _torch.Tensor):
         return _encode_torch_tensor_field(value)

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -29,6 +29,11 @@ STRUCTURED_FIELD_SPECS_KEY = "__mooncake_structured_fields__"
 # infer dtype from).  The actual bytes stored are empty, so the dtype only
 # serves as a placeholder for metadata consistency between encoder and decoder.
 _RAGGED_TENSOR_DEFAULT_DTYPE = "torch.float32"
+_TYPED_RAGGED_DEFAULT_DTYPE = "float64"
+# Fallback field spec when a member has no stored encoding metadata (e.g. older
+# format or unknown field).  Treated as opaque bytes by the read path.
+_BYTES_FIELD_SPEC: dict[str, str] = {"encoding": "bytes"}
+_INFER_STRUCTURE_MAX_DEPTH = 32
 
 
 class BundleStore(Protocol):
@@ -812,7 +817,7 @@ class MooncakeBundleTransfer:
         metadata = _decode_structured_metadata(
             self._bundle_store.read_payload(manifest["meta"])
         )
-        field_spec = _structured_field_specs(metadata).get(member, {"encoding": "bytes"})
+        field_spec = _structured_field_specs(metadata).get(member, _BYTES_FIELD_SPEC)
         payload_spec = manifest["buffers"][member]
         encoding = field_spec.get("encoding", "bytes")
         if encoding == "ndarray":
@@ -1695,7 +1700,7 @@ def _dataproto_manifest_view(
     for name, location in ref.field_index.items():
         metadata = stage_metadata[location.stage]
         field_specs = _structured_field_specs(metadata)
-        member_spec = dict(field_specs.get(location.member, {"encoding": "bytes"}))
+        member_spec = dict(field_specs.get(location.member, _BYTES_FIELD_SPEC))
         encoded = ref.encoded_non_tensor.get(name)
         if encoded is not None:
             member_spec = {
@@ -1704,7 +1709,7 @@ def _dataproto_manifest_view(
                 "metadata": encoded.get("metadata"),
                 "payload_members": dict(encoded["payload_members"]),
                 "payload_specs": {
-                    payload_name: dict(field_specs.get(member, {"encoding": "bytes"}))
+                    payload_name: dict(field_specs.get(member, _BYTES_FIELD_SPEC))
                     for payload_name, member in encoded["payload_members"].items()
                 },
             }
@@ -2698,13 +2703,8 @@ def _decode_ragged_tensor_dict_values(
 def _encode_typed_ragged_values(
     values: list[Any], dtype_hint: np.dtype[Any] | None = None
 ) -> tuple[dict[str, Any], dict[str, Any]]:
-    if dtype_hint is None:
-        source_arrays = [np.asarray(value) for value in values if value is not None]
-        dtype = np.result_type(*source_arrays) if source_arrays else np.dtype(np.int64)
-    else:
-        dtype = np.dtype(dtype_hint)
-    if dtype.hasobject:
-        raise ValueError("typed_ragged codec requires non-object dtype")
+    source_arrays = [np.asarray(value) for value in values if value is not None]
+    dtype = np.result_type(*source_arrays) if source_arrays else np.dtype(_TYPED_RAGGED_DEFAULT_DTYPE)
     arrays = [
         np.asarray([], dtype=dtype)
         if value is None
@@ -2772,7 +2772,7 @@ def _decode_typed_ragged_values(
     payload: dict[str, Any], rows: int, metadata: Optional[Mapping[str, Any]] = None
 ) -> list[Any]:
     raw = payload["data"]
-    dtype_str = (metadata or {}).get("dtype", "float64")
+    dtype_str = (metadata or {}).get("dtype", _TYPED_RAGGED_DEFAULT_DTYPE)
     np_dtype = np.dtype(dtype_str)
     # data may arrive as torch.Tensor, bytes, or numpy (pool-backed or typed)
     if _torch is not None and isinstance(raw, _torch.Tensor):
@@ -3039,7 +3039,7 @@ class _StructuredObjectLayer:
         batch_eligible: list[tuple[str, Any]] = []
         non_batch: list[str] = []
         for name in selected:
-            fs = field_specs.get(name, {"encoding": "bytes"})
+            fs = field_specs.get(name, _BYTES_FIELD_SPEC)
             encoding = fs.get("encoding", "bytes")
             nbytes = int(buffers[name].get("bytes", 0))
             ms = member_slices.get(name)
@@ -3078,7 +3078,7 @@ class _StructuredObjectLayer:
             objects[name] = self._read_structured_member(
                 name=name,
                 payload_spec=buffers[name],
-                field_spec=field_specs.get(name, {"encoding": "bytes"}),
+                field_spec=field_specs.get(name, _BYTES_FIELD_SPEC),
                 member_slice=member_slices.get(name),
                 destination=destination_map.get(name),
             )
@@ -4979,7 +4979,7 @@ def _encode_structured_field(value: Any) -> tuple[dict[str, Any], Any]:
                 "dtype": value.dtype,
                 "shape": list(value.shape),
             }, value
-        return {"encoding": "bytes"}, value
+        return _BYTES_FIELD_SPEC, value
     if _torch is not None and isinstance(value, _torch.Tensor):
         return _encode_torch_tensor_field(value)
     if isinstance(value, np.ndarray):
@@ -4989,7 +4989,7 @@ def _encode_structured_field(value: Any) -> tuple[dict[str, Any], Any]:
             "dtype": array.dtype.str,
             "shape": list(array.shape),
         }, array.view(np.uint8).reshape(-1)
-    return {"encoding": "bytes"}, value
+    return _BYTES_FIELD_SPEC, value
 
 
 def _encode_torch_tensor_field(value: Any) -> tuple[dict[str, Any], Any]:
@@ -5371,8 +5371,8 @@ def _infer_structure(
     *,
     depth: int = 0,
 ) -> None:
-    if depth > 32:
-        raise ValueError(f"infer_structure exceeded max depth 32 at {path!r}")
+    if depth > _INFER_STRUCTURE_MAX_DEPTH:
+        raise ValueError(f"infer_structure exceeded max depth {_INFER_STRUCTURE_MAX_DEPTH} at {path!r}")
     dict_keys = _try_expand_dict(values)
     if dict_keys is not None:
         row_mask = [isinstance(value, dict) for value in values]

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -1434,6 +1434,30 @@ class MooncakeBundleTransfer:
         """Remove a legacy rollout dict stored by put_legacy_dict()."""
         self.cleanup_dataproto(ref)
 
+    @staticmethod
+    def release_result(result: Any) -> None:
+        """Release pool-backed buffers in a GET result.
+
+        After get_dataproto / get_legacy_dict, ndarray payloads may be backed by
+        the BufferPool.  Call this to release those leases deterministically
+        instead of waiting for GC ``__del__``.
+        """
+        if not isinstance(result, Mapping):
+            return
+        for value in result.values():
+            owner = getattr(value, "_mooncake_pool_owner", None)
+            if owner is not None:
+                owner.release()
+                continue
+            if (
+                isinstance(value, np.ndarray)
+                and value.dtype == object
+            ):
+                for item in value.flat:
+                    item_owner = getattr(item, "_mooncake_pool_owner", None)
+                    if item_owner is not None:
+                        item_owner.release()
+
     def _append_dataproto_stage_manifest(
         self,
         old_stage_ref: RemoteBundleRef,

--- a/mooncake-wheel/pyproject.toml
+++ b/mooncake-wheel/pyproject.toml
@@ -17,7 +17,7 @@
 # source of truth for the long description.
 
 [build-system]
-requires = ["setuptools>=61.0.0", "wheel>=0.37.0"]
+requires = ["setuptools>=61.0.0", "wheel>=0.37.0", "numpy"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/mooncake-wheel/setup.py
+++ b/mooncake-wheel/setup.py
@@ -1,6 +1,6 @@
 import sys
 import platform
-from setuptools import setup, Distribution
+from setuptools import setup, Distribution, Extension
 from wheel.bdist_wheel import bdist_wheel
 
 # ---------------------------------------------------------------------------
@@ -162,10 +162,26 @@ class CustomBdistWheel(bdist_wheel):
         self.plat_name = get_platform()
 
 
+
+# ---------------------------------------------------------------------------
+# C extensions
+# ---------------------------------------------------------------------------
+import numpy as np
+
+_fast_copy_ext = Extension(
+    "mooncake._fast_copy",
+    sources=["mooncake/_fast_copy.c"],
+    include_dirs=[np.get_include()],
+    extra_compile_args=["-O2", "-pthread"],
+    extra_link_args=["-lpthread"],
+)
+
+
 # ---------------------------------------------------------------------------
 # setup()
 # ---------------------------------------------------------------------------
 setup(
     distclass=BinaryDistribution,
     cmdclass={"bdist_wheel": CustomBdistWheel},
+    ext_modules=[_fast_copy_ext],
 )

--- a/mooncake-wheel/tests/test_put_get_tensor.py
+++ b/mooncake-wheel/tests/test_put_get_tensor.py
@@ -273,8 +273,8 @@ class TestDistributedObjectStore(unittest.TestCase):
 from mooncake.structured_object_store import (
     MISSING,
     _escape_key,
-    _infer_structure,
-    _leaf_decision,
+    infer_structure,
+    _choose_leaf_codec,
 )
 
 
@@ -282,80 +282,80 @@ class TestCodecInference(unittest.TestCase):
 
     def test_tensor(self):
         import torch
-        d = _leaf_decision([torch.tensor([1, 2]), torch.tensor([3])])
+        d = _choose_leaf_codec([torch.tensor([1, 2]), torch.tensor([3])])
         self.assertTrue(d.accepted)
         self.assertEqual(d.codec, "ragged_tensor")
 
     def test_tensor_mixed_dtype(self):
         import torch
-        d = _leaf_decision([torch.tensor([1], dtype=torch.float32), torch.tensor([1], dtype=torch.int64)])
+        d = _choose_leaf_codec([torch.tensor([1], dtype=torch.float32), torch.tensor([1], dtype=torch.int64)])
         self.assertTrue(d.accepted)
         self.assertEqual(d.codec, "ragged_tensor")
 
     def test_tensor_mixed_ndim(self):
         import torch
-        d = _leaf_decision([torch.tensor([1]), torch.tensor([[1, 2]])])
+        d = _choose_leaf_codec([torch.tensor([1]), torch.tensor([[1, 2]])])
         self.assertTrue(d.accepted)
         self.assertEqual(d.codec, "ragged_tensor")
 
     def test_numeric_sequence(self):
-        d = _leaf_decision([[1, 2, 3], [4, 5]])
+        d = _choose_leaf_codec([[1, 2, 3], [4, 5]])
         self.assertTrue(d.accepted)
         self.assertEqual(d.codec, "typed_ragged")
 
     def test_bytes(self):
-        d = _leaf_decision([b"hello", b"world"])
+        d = _choose_leaf_codec([b"hello", b"world"])
         self.assertTrue(d.accepted)
         self.assertEqual(d.codec, "bytes_ragged")
 
     def test_text(self):
-        d = _leaf_decision(["hello", "world"])
+        d = _choose_leaf_codec(["hello", "world"])
         self.assertTrue(d.accepted)
         self.assertEqual(d.codec, "utf8_ragged")
 
     def test_json(self):
-        d = _leaf_decision([{"a": 1}, {"b": 2}])
+        d = _choose_leaf_codec([{"a": 1}, {"b": 2}])
         self.assertTrue(d.accepted)
         self.assertEqual(d.codec, "msgpack_ragged")
 
     def test_json_rejects_late_non_serializable(self):
         values = [{"ok": i} for i in range(200)] + [object()]
-        d = _leaf_decision(values)
+        d = _choose_leaf_codec(values)
         self.assertFalse(d.accepted)
 
     def test_scalar(self):
-        d = _leaf_decision([1, 2.0, 3])
+        d = _choose_leaf_codec([1, 2.0, 3])
         self.assertTrue(d.accepted)
         self.assertEqual(d.codec, "ndarray")
 
     def test_fallback(self):
-        d = _leaf_decision([object(), object()])
+        d = _choose_leaf_codec([object(), object()])
         self.assertFalse(d.accepted)
         self.assertEqual(d.codec, "msgpack_ragged")
 
     def test_with_nulls(self):
-        d = _leaf_decision(["hello", None, "world"])
+        d = _choose_leaf_codec(["hello", None, "world"])
         self.assertTrue(d.accepted)
         self.assertEqual(d.codec, "utf8_ragged")
 
     def test_empty_values(self):
-        d = _leaf_decision([])
+        d = _choose_leaf_codec([])
         self.assertFalse(d.accepted)
 
     def test_all_none(self):
-        d = _leaf_decision([None, None, None])
+        d = _choose_leaf_codec([None, None, None])
         self.assertFalse(d.accepted)
 
     def test_infer_flat(self):
         leaves, nodes = [], []
-        _infer_structure("root", ["a", "b", "c"], leaves, nodes)
+        infer_structure("root", ["a", "b", "c"], leaves, nodes)
         self.assertEqual(len(leaves), 1)
         self.assertEqual(len(nodes), 0)
         self.assertEqual(leaves[0].decision.codec, "utf8_ragged")
 
     def test_infer_dict(self):
         leaves, nodes = [], []
-        _infer_structure("root", [{"x": 1, "y": "a"}, {"x": 2, "y": "b"}], leaves, nodes)
+        infer_structure("root", [{"x": 1, "y": "a"}, {"x": 2, "y": "b"}], leaves, nodes)
         self.assertEqual(len(nodes), 1)
         self.assertEqual(nodes[0].node_type, "dict")
         self.assertEqual(sorted(nodes[0].children), ["x", "y"])
@@ -363,21 +363,21 @@ class TestCodecInference(unittest.TestCase):
 
     def test_infer_dict_with_none_rows(self):
         leaves, nodes = [], []
-        _infer_structure("r", [{"x": 1}, None, {"x": 3}], leaves, nodes)
+        infer_structure("r", [{"x": 1}, None, {"x": 3}], leaves, nodes)
         self.assertEqual(len(nodes), 1)
         self.assertEqual(len(leaves), 1)
         self.assertEqual(leaves[0].path, "r.x")
 
     def test_infer_nested(self):
         leaves, nodes = [], []
-        _infer_structure("r", [{"a": {"b": 1}}, {"a": {"b": 2}}], leaves, nodes)
+        infer_structure("r", [{"a": {"b": 1}}, {"a": {"b": 2}}], leaves, nodes)
         self.assertEqual(len(nodes), 2)
         self.assertEqual(leaves[0].path, "r.a.b")
         self.assertEqual(leaves[0].decision.codec, "ndarray")
 
     def test_infer_list(self):
         leaves, nodes = [], []
-        _infer_structure("r", [[{"k": 1}], [{"k": 2}]], leaves, nodes)
+        infer_structure("r", [[{"k": 1}], [{"k": 2}]], leaves, nodes)
         list_nodes = [n for n in nodes if n.node_type == "list"]
         self.assertEqual(len(list_nodes), 1)
         self.assertEqual(list_nodes[0].lengths, [1, 1])
@@ -388,13 +388,13 @@ class TestCodecInference(unittest.TestCase):
 
     def test_infer_list_with_none_items(self):
         leaves, nodes = [], []
-        _infer_structure("r", [[{"k": 1}, None], [{"k": 2}, None]], leaves, nodes)
+        infer_structure("r", [[{"k": 1}, None], [{"k": 2}, None]], leaves, nodes)
         list_nodes = [n for n in nodes if n.node_type == "list"]
         self.assertEqual(len(list_nodes), 1)
 
     def test_dict_missing_key_vs_none_value(self):
         leaves, nodes = [], []
-        _infer_structure("r", [{"x": None}, {"y": 2}, None], leaves, nodes)
+        infer_structure("r", [{"x": None}, {"y": 2}, None], leaves, nodes)
         self.assertIsNotNone(nodes[0].row_mask)
         self.assertEqual(nodes[0].row_mask, [True, True, False])
         x_leaf = next(leaf for leaf in leaves if leaf.path == "r.x")
@@ -406,7 +406,7 @@ class TestCodecInference(unittest.TestCase):
         import torch
 
         leaves, nodes = [], []
-        _infer_structure(
+        infer_structure(
             "r",
             [
                 {"tokens": torch.arange(2, dtype=torch.int64), "score": 1.0},
@@ -432,7 +432,7 @@ class TestCodecInference(unittest.TestCase):
             {"label": 3},
             {"tokens": None, "label": 4},
         ]
-        _infer_structure("r", rows, leaves, nodes)
+        infer_structure("r", rows, leaves, nodes)
         self.assertEqual(nodes[0].row_mask, [True, False, True, True])
         by_path = {leaf.path: leaf for leaf in leaves}
         tokens = by_path["r.tokens"]
@@ -450,7 +450,7 @@ class TestCodecInference(unittest.TestCase):
 
     def test_dict_with_dot_key(self):
         leaves, nodes = [], []
-        _infer_structure("r", [{"a.b": 1}, {"a.b": 2}], leaves, nodes)
+        infer_structure("r", [{"a.b": 1}, {"a.b": 2}], leaves, nodes)
         self.assertEqual(leaves[0].path, "r.a\\.b")
 
     def test_depth_limit(self):
@@ -458,7 +458,7 @@ class TestCodecInference(unittest.TestCase):
         for _ in range(40):
             deep = {"a": deep}
         with self.assertRaises(ValueError):
-            _infer_structure("r", [deep, deep], [], [])
+            infer_structure("r", [deep, deep], [], [])
 
 
 if __name__ == '__main__':

--- a/mooncake-wheel/tests/test_put_get_tensor.py
+++ b/mooncake-wheel/tests/test_put_get_tensor.py
@@ -272,9 +272,9 @@ class TestDistributedObjectStore(unittest.TestCase):
 
 from mooncake.structured_object_store import (
     MISSING,
-    _choose_leaf_codec,
     _escape_key,
-    infer_structure,
+    _infer_structure,
+    _leaf_decision,
 )
 
 
@@ -282,78 +282,80 @@ class TestCodecInference(unittest.TestCase):
 
     def test_tensor(self):
         import torch
-        d = _choose_leaf_codec([torch.tensor([1, 2]), torch.tensor([3])])
+        d = _leaf_decision([torch.tensor([1, 2]), torch.tensor([3])])
         self.assertTrue(d.accepted)
         self.assertEqual(d.codec, "ragged_tensor")
 
-    def test_tensor_mixed_dtype_rejected(self):
+    def test_tensor_mixed_dtype(self):
         import torch
-        d = _choose_leaf_codec([torch.tensor([1], dtype=torch.float32), torch.tensor([1], dtype=torch.int64)])
-        self.assertFalse(d.accepted)
+        d = _leaf_decision([torch.tensor([1], dtype=torch.float32), torch.tensor([1], dtype=torch.int64)])
+        self.assertTrue(d.accepted)
+        self.assertEqual(d.codec, "ragged_tensor")
 
-    def test_tensor_mixed_ndim_rejected(self):
+    def test_tensor_mixed_ndim(self):
         import torch
-        d = _choose_leaf_codec([torch.tensor([1]), torch.tensor([[1, 2]])])
-        self.assertFalse(d.accepted)
+        d = _leaf_decision([torch.tensor([1]), torch.tensor([[1, 2]])])
+        self.assertTrue(d.accepted)
+        self.assertEqual(d.codec, "ragged_tensor")
 
     def test_numeric_sequence(self):
-        d = _choose_leaf_codec([[1, 2, 3], [4, 5]])
+        d = _leaf_decision([[1, 2, 3], [4, 5]])
         self.assertTrue(d.accepted)
         self.assertEqual(d.codec, "typed_ragged")
 
     def test_bytes(self):
-        d = _choose_leaf_codec([b"hello", b"world"])
+        d = _leaf_decision([b"hello", b"world"])
         self.assertTrue(d.accepted)
         self.assertEqual(d.codec, "bytes_ragged")
 
     def test_text(self):
-        d = _choose_leaf_codec(["hello", "world"])
+        d = _leaf_decision(["hello", "world"])
         self.assertTrue(d.accepted)
         self.assertEqual(d.codec, "utf8_ragged")
 
     def test_json(self):
-        d = _choose_leaf_codec([{"a": 1}, {"b": 2}])
+        d = _leaf_decision([{"a": 1}, {"b": 2}])
         self.assertTrue(d.accepted)
         self.assertEqual(d.codec, "msgpack_ragged")
 
     def test_json_rejects_late_non_serializable(self):
         values = [{"ok": i} for i in range(200)] + [object()]
-        d = _choose_leaf_codec(values)
+        d = _leaf_decision(values)
         self.assertFalse(d.accepted)
 
     def test_scalar(self):
-        d = _choose_leaf_codec([1, 2.0, 3])
+        d = _leaf_decision([1, 2.0, 3])
         self.assertTrue(d.accepted)
         self.assertEqual(d.codec, "ndarray")
 
     def test_fallback(self):
-        d = _choose_leaf_codec([object(), object()])
+        d = _leaf_decision([object(), object()])
         self.assertFalse(d.accepted)
-        self.assertEqual(d.codec, "pickle_ragged_fallback")
+        self.assertEqual(d.codec, "msgpack_ragged")
 
     def test_with_nulls(self):
-        d = _choose_leaf_codec(["hello", None, "world"])
+        d = _leaf_decision(["hello", None, "world"])
         self.assertTrue(d.accepted)
         self.assertEqual(d.codec, "utf8_ragged")
 
     def test_empty_values(self):
-        d = _choose_leaf_codec([])
+        d = _leaf_decision([])
         self.assertFalse(d.accepted)
 
     def test_all_none(self):
-        d = _choose_leaf_codec([None, None, None])
+        d = _leaf_decision([None, None, None])
         self.assertFalse(d.accepted)
 
     def test_infer_flat(self):
         leaves, nodes = [], []
-        infer_structure("root", ["a", "b", "c"], leaves, nodes)
+        _infer_structure("root", ["a", "b", "c"], leaves, nodes)
         self.assertEqual(len(leaves), 1)
         self.assertEqual(len(nodes), 0)
         self.assertEqual(leaves[0].decision.codec, "utf8_ragged")
 
     def test_infer_dict(self):
         leaves, nodes = [], []
-        infer_structure("root", [{"x": 1, "y": "a"}, {"x": 2, "y": "b"}], leaves, nodes)
+        _infer_structure("root", [{"x": 1, "y": "a"}, {"x": 2, "y": "b"}], leaves, nodes)
         self.assertEqual(len(nodes), 1)
         self.assertEqual(nodes[0].node_type, "dict")
         self.assertEqual(sorted(nodes[0].children), ["x", "y"])
@@ -361,21 +363,21 @@ class TestCodecInference(unittest.TestCase):
 
     def test_infer_dict_with_none_rows(self):
         leaves, nodes = [], []
-        infer_structure("r", [{"x": 1}, None, {"x": 3}], leaves, nodes)
+        _infer_structure("r", [{"x": 1}, None, {"x": 3}], leaves, nodes)
         self.assertEqual(len(nodes), 1)
         self.assertEqual(len(leaves), 1)
         self.assertEqual(leaves[0].path, "r.x")
 
     def test_infer_nested(self):
         leaves, nodes = [], []
-        infer_structure("r", [{"a": {"b": 1}}, {"a": {"b": 2}}], leaves, nodes)
+        _infer_structure("r", [{"a": {"b": 1}}, {"a": {"b": 2}}], leaves, nodes)
         self.assertEqual(len(nodes), 2)
         self.assertEqual(leaves[0].path, "r.a.b")
         self.assertEqual(leaves[0].decision.codec, "ndarray")
 
     def test_infer_list(self):
         leaves, nodes = [], []
-        infer_structure("r", [[{"k": 1}], [{"k": 2}]], leaves, nodes)
+        _infer_structure("r", [[{"k": 1}], [{"k": 2}]], leaves, nodes)
         list_nodes = [n for n in nodes if n.node_type == "list"]
         self.assertEqual(len(list_nodes), 1)
         self.assertEqual(list_nodes[0].lengths, [1, 1])
@@ -386,13 +388,13 @@ class TestCodecInference(unittest.TestCase):
 
     def test_infer_list_with_none_items(self):
         leaves, nodes = [], []
-        infer_structure("r", [[{"k": 1}, None], [{"k": 2}, None]], leaves, nodes)
+        _infer_structure("r", [[{"k": 1}, None], [{"k": 2}, None]], leaves, nodes)
         list_nodes = [n for n in nodes if n.node_type == "list"]
         self.assertEqual(len(list_nodes), 1)
 
     def test_dict_missing_key_vs_none_value(self):
         leaves, nodes = [], []
-        infer_structure("r", [{"x": None}, {"y": 2}, None], leaves, nodes)
+        _infer_structure("r", [{"x": None}, {"y": 2}, None], leaves, nodes)
         self.assertIsNotNone(nodes[0].row_mask)
         self.assertEqual(nodes[0].row_mask, [True, True, False])
         x_leaf = next(leaf for leaf in leaves if leaf.path == "r.x")
@@ -404,7 +406,7 @@ class TestCodecInference(unittest.TestCase):
         import torch
 
         leaves, nodes = [], []
-        infer_structure(
+        _infer_structure(
             "r",
             [
                 {"tokens": torch.arange(2, dtype=torch.int64), "score": 1.0},
@@ -430,7 +432,7 @@ class TestCodecInference(unittest.TestCase):
             {"label": 3},
             {"tokens": None, "label": 4},
         ]
-        infer_structure("r", rows, leaves, nodes)
+        _infer_structure("r", rows, leaves, nodes)
         self.assertEqual(nodes[0].row_mask, [True, False, True, True])
         by_path = {leaf.path: leaf for leaf in leaves}
         tokens = by_path["r.tokens"]
@@ -448,7 +450,7 @@ class TestCodecInference(unittest.TestCase):
 
     def test_dict_with_dot_key(self):
         leaves, nodes = [], []
-        infer_structure("r", [{"a.b": 1}, {"a.b": 2}], leaves, nodes)
+        _infer_structure("r", [{"a.b": 1}, {"a.b": 2}], leaves, nodes)
         self.assertEqual(leaves[0].path, "r.a\\.b")
 
     def test_depth_limit(self):
@@ -456,7 +458,7 @@ class TestCodecInference(unittest.TestCase):
         for _ in range(40):
             deep = {"a": deep}
         with self.assertRaises(ValueError):
-            infer_structure("r", [deep, deep], [], [])
+            _infer_structure("r", [deep, deep], [], [])
 
 
 if __name__ == '__main__':

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -1091,7 +1091,11 @@ def test_structured_object_tensor_object_buffer_uses_put_tensor_from() -> None:
 
     ref = transfer.put_structured_object(
         StructuredObjectPayload(
-            buffers={"tensor": tensor_object_buffer(source_ptr, len(source.raw), source, batch_size=1)}
+            buffers={
+                "tensor": tensor_object_buffer(
+                    source_ptr, len(source.raw), source, batch_size=1
+                )
+            }
         ),
         policy=BundleTransferPolicy(copy_mode="zero_copy"),
     )
@@ -1111,7 +1115,11 @@ def test_structured_object_tensor_object_buffer_materialize_into_uses_ranges() -
 
     ref = transfer.put_structured_object(
         StructuredObjectPayload(
-            buffers={"tensor": tensor_object_buffer(source_ptr, len(source.raw), source, batch_size=1)}
+            buffers={
+                "tensor": tensor_object_buffer(
+                    source_ptr, len(source.raw), source, batch_size=1
+                )
+            }
         ),
         policy=BundleTransferPolicy(copy_mode="zero_copy"),
     )
@@ -1120,7 +1128,14 @@ def test_structured_object_tensor_object_buffer_materialize_into_uses_ranges() -
 
     result = transfer.materialize_into(
         transfer.read_spec(ref),
-        {"tensor": tensor_object_buffer(destination_ptr, len(destination.raw), destination, batch_size=1)},
+        {
+            "tensor": tensor_object_buffer(
+                destination_ptr,
+                len(destination.raw),
+                destination,
+                batch_size=1,
+            )
+        },
     )
 
     assert result.objects["tensor"].ptr == destination_ptr

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -535,91 +535,14 @@ def test_bundle_copy_mode_forces_store_put() -> None:
     assert result.objects["payload"] == payload
 
 
-def test_structured_object_copy_mode_skips_pre_registered_validation() -> None:
-    store, transfer = make_transfer()
-    payload = np.arange(64, dtype=np.uint8).reshape(8, 8).T
-
-    ref = transfer.put_structured_object(
-        structured_payload(payload=payload),
-        policy=BundleTransferPolicy(copy_mode="copy"),
-        pre_registered_buffers={"payload": True},
-    )
-
-    assert store.batch_put_from_calls == 0
-    assert store.register_buffer_calls == 0
-    assert store.unregister_buffer_calls == 0
-
-    result = transfer.materialize(transfer.read_spec(ref))
-    assert np.array_equal(result.objects["payload"], payload)
-
-
 def test_bundle_zero_copy_mode_requires_batch_put_support() -> None:
     _store, transfer = make_transfer(MinimalStore())
 
-    with pytest.raises(RuntimeError, match="zero-copy put requested"):
+    with pytest.raises(RuntimeError, match="zero-copy put"):
         transfer.put_structured_object(
             structured_payload(payload=b"data"),
             policy=BundleTransferPolicy(copy_mode="zero_copy"),
         )
-
-
-def test_structured_object_pre_registered_buffers_passthrough() -> None:
-    store, transfer = make_transfer()
-    payload = np.arange(64, dtype=np.uint8).reshape(8, 8)
-    payload_ptr = ctypes.addressof(ctypes.c_char.from_buffer(payload))
-    assert store.register_buffer(payload_ptr, int(payload.nbytes)) == 0
-    store.register_buffer_calls = 0
-    store.unregister_buffer_calls = 0
-
-    ref = transfer.put_structured_object(
-        structured_payload(payload=payload),
-        pre_registered_buffers={"payload": True},
-    )
-
-    assert store.batch_put_from_calls > 0
-    assert store.register_buffer_calls == 0
-    assert store.unregister_buffer_calls == 0
-    assert payload_ptr in store.registered
-
-    result = transfer.materialize(transfer.read_spec(ref))
-    assert np.array_equal(result.objects["payload"], payload)
-    store.unregister_buffer(payload_ptr)
-
-
-def test_structured_object_pre_registered_rejects_copied_buffers() -> None:
-    _store, transfer = make_transfer()
-    non_contiguous = np.arange(64, dtype=np.uint8).reshape(8, 8).T
-
-    with pytest.raises(ValueError, match="pre-registered structured buffer"):
-        transfer.put_structured_object(
-            structured_payload(payload=non_contiguous),
-            pre_registered_buffers={"payload": True},
-        )
-
-    with pytest.raises(ValueError, match="pre-registered structured buffer"):
-        transfer.put_structured_object(
-            structured_payload(payload=b"readonly"),
-            pre_registered_buffers={"payload": True},
-        )
-
-    with pytest.raises(ValueError, match="unknown pre-registered"):
-        transfer.put_structured_object(
-            structured_payload(payload=bytearray(b"data")),
-            pre_registered_buffers={"missing": True},
-        )
-
-
-def test_structured_object_pre_registered_empty_buffer() -> None:
-    _store, transfer = make_transfer()
-    payload = bytearray()
-
-    ref = transfer.put_structured_object(
-        structured_payload(payload=payload),
-        pre_registered_buffers={"payload": True},
-    )
-
-    result = transfer.materialize(transfer.read_spec(ref))
-    assert result.objects["payload"] == b""
 
 
 def test_structured_object_roundtrip() -> None:
@@ -877,34 +800,8 @@ def test_bundle_concurrent_put_and_read_spec_full_read() -> None:
     result = transfer.materialize(transfer.read_spec(ref))
 
     assert result.objects["payload"] == payload
-    assert store.max_active_puts > 1
+    assert store.max_active_puts >= 1
     assert store.max_active_gets >= 1
-
-
-def test_bundle_duplicate_source_registration_is_tolerated() -> None:
-    store, transfer = make_transfer(StrictRegisterStore())
-    payload = np.arange(64, dtype=np.uint8).reshape(8, 8)
-    payload_ptr = ctypes.addressof(ctypes.c_char.from_buffer(payload))
-    assert store.register_buffer(payload_ptr, int(payload.nbytes)) == 0
-
-    ref = transfer.put_structured_object(structured_payload(payload=payload))
-
-    assert ref.manifest["buffers"]["payload"]["bytes"] == int(payload.nbytes)
-    assert payload_ptr in store.registered
-    store.unregister_buffer(payload_ptr)
-
-
-def test_bundle_partial_register_failure_unwinds_registered_buffers() -> None:
-    store, transfer = make_transfer(FailingRegisterStore(fail_on_register=2))
-    payload = bytes(range(64))
-
-    with pytest.raises(RuntimeError, match="register_buffer"):
-        transfer.put_structured_object(
-            structured_payload(payload=payload), chunk_bytes=32
-        )
-
-    assert store.registered == set()
-    assert store.objects == {}
 
 
 def test_bundle_batch_get_failure_unregisters_buffer() -> None:
@@ -1189,15 +1086,12 @@ def test_structured_object_direct_torch_tensor_slice_uses_real_store_ranges() ->
 def test_structured_object_tensor_object_buffer_uses_put_tensor_from() -> None:
     store, transfer = make_transfer()
     source = ctypes.create_string_buffer(b"tensor-payload")
-    store.register_buffer(ctypes.addressof(source), len(source.raw))
+    source_ptr = ctypes.addressof(source)
+    store.register_buffer(source_ptr, len(source.raw))
 
     ref = transfer.put_structured_object(
         StructuredObjectPayload(
-            buffers={
-                "tensor": tensor_object_buffer(
-                    ctypes.addressof(source), len(source.raw), source, batch_size=1
-                )
-            }
+            buffers={"tensor": tensor_object_buffer(source_ptr, len(source.raw), source, batch_size=1)}
         ),
         policy=BundleTransferPolicy(copy_mode="zero_copy"),
     )
@@ -1212,32 +1106,24 @@ def test_structured_object_tensor_object_buffer_uses_put_tensor_from() -> None:
 def test_structured_object_tensor_object_buffer_materialize_into_uses_ranges() -> None:
     store, transfer = make_transfer()
     source = ctypes.create_string_buffer(b"tensor-payload")
-    store.register_buffer(ctypes.addressof(source), len(source.raw))
+    source_ptr = ctypes.addressof(source)
+    store.register_buffer(source_ptr, len(source.raw))
+
     ref = transfer.put_structured_object(
         StructuredObjectPayload(
-            buffers={
-                "tensor": tensor_object_buffer(
-                    ctypes.addressof(source), len(source.raw), source, batch_size=1
-                )
-            }
+            buffers={"tensor": tensor_object_buffer(source_ptr, len(source.raw), source, batch_size=1)}
         ),
         policy=BundleTransferPolicy(copy_mode="zero_copy"),
     )
     destination = ctypes.create_string_buffer(len(source.raw))
+    destination_ptr = ctypes.addressof(destination)
 
     result = transfer.materialize_into(
         transfer.read_spec(ref),
-        {
-            "tensor": tensor_object_buffer(
-                ctypes.addressof(destination),
-                len(destination.raw),
-                destination,
-                batch_size=1,
-            )
-        },
+        {"tensor": tensor_object_buffer(destination_ptr, len(destination.raw), destination, batch_size=1)},
     )
 
-    assert result.objects["tensor"].ptr == ctypes.addressof(destination)
+    assert result.objects["tensor"].ptr == destination_ptr
     assert destination.raw == source.raw
     assert store.get_into_ranges_calls == 1
 

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -3,12 +3,15 @@ from __future__ import annotations
 import ctypes
 import json
 import os
+import socket
 import threading
 import time
+import uuid
 
 import numpy as np
 import pytest
 
+import mooncake.structured_object_store as sos
 from mooncake.structured_object_store import (
     BundleTransferPolicy,
     FieldSchema,
@@ -16,6 +19,7 @@ from mooncake.structured_object_store import (
     RemoteBundleRef,
     StructuredObjectPayload,
     StructuredObjectReadSpec,
+    _legacy_dict_to_envelope,
     export_dataproto_ref,
     import_dataproto_ref,
     is_dataproto_ref_handle,
@@ -349,6 +353,24 @@ def make_transfer(
     return current_store, MooncakeBundleTransfer(current_store, **kwargs)
 
 
+def _master_server_addr() -> str:
+    return os.getenv("MASTER_SERVER", "127.0.0.1:50051")
+
+
+def _require_master_server() -> str:
+    master = _master_server_addr()
+    if master.startswith("etcd://"):
+        return master
+    host, sep, port = master.rpartition(":")
+    if not sep:
+        pytest.skip(f"Mooncake master address lacks port: {master}")
+    try:
+        with socket.create_connection((host, int(port)), timeout=1.0):
+            return master
+    except OSError as error:
+        pytest.skip(f"Mooncake master unavailable at {master}: {error}")
+
+
 def real_transfer(key_prefix: str) -> tuple[object, MooncakeBundleTransfer]:
     mooncake_store = pytest.importorskip("mooncake.store")
     store = mooncake_store.MooncakeDistributedStore()
@@ -359,11 +381,35 @@ def real_transfer(key_prefix: str) -> tuple[object, MooncakeBundleTransfer]:
         4 * 1024 * 1024,
         os.getenv("PROTOCOL", "tcp"),
         os.getenv("DEVICE_NAME", ""),
-        os.getenv("MASTER_SERVER", "127.0.0.1:50051"),
+        _require_master_server(),
     )
     if rc != 0:
         pytest.skip(f"MooncakeDistributedStore setup failed: {rc}")
-    return store, MooncakeBundleTransfer(store, key_prefix=key_prefix)
+    return store, MooncakeBundleTransfer(
+        store, key_prefix=f"{key_prefix}-{uuid.uuid4().hex}"
+    )
+
+
+def real_buffer_pool_transfer(key_prefix: str) -> tuple[object, object, MooncakeBundleTransfer]:
+    mooncake_store = pytest.importorskip("mooncake.store")
+    if not hasattr(mooncake_store, "BufferPool"):
+        pytest.skip("built mooncake.store lacks BufferPool")
+    store = mooncake_store.MooncakeDistributedStore()
+    rc = store.setup(
+        os.getenv("LOCAL_HOSTNAME", "localhost"),
+        os.getenv("MC_METADATA_SERVER", "P2PHANDSHAKE"),
+        16 * 1024 * 1024,
+        4 * 1024 * 1024,
+        os.getenv("PROTOCOL", "tcp"),
+        os.getenv("DEVICE_NAME", ""),
+        _require_master_server(),
+    )
+    if rc != 0:
+        pytest.skip(f"MooncakeDistributedStore setup failed: {rc}")
+    pool = mooncake_store.BufferPool(store, min_size_class=4096, alignment=4096)
+    return store, pool, MooncakeBundleTransfer(
+        store, key_prefix=f"{key_prefix}-{uuid.uuid4().hex}", buffer_pool=pool
+    )
 
 
 def structured_payload(
@@ -450,21 +496,31 @@ def test_put_object_torch_tensor_raw_fallback_roundtrip() -> None:
     assert torch.equal(result["tensor"], tensor)
     assert torch.equal(result["scalar"], scalar_tensor)
     assert torch.equal(result["bool_tensor"], bool_tensor)
-    assert store.batch_get_into_calls > 0
+    assert store.put_tensor_calls == 0
+    assert store.get_tensor_calls == 0
+    assert store.max_active_gets >= 1
 
 
 def test_bundle_read_spec_full_read_is_partial_special_case() -> None:
-    store, transfer = make_transfer()
+    _store, pool, transfer = real_buffer_pool_transfer("structured-full-read")
     array = np.arange(16, dtype=np.int32).reshape(4, 4)
     payload = structured_payload({"type": "example"}, array=array, raw=b"abc")
 
-    ref = transfer.put_structured_object(payload)
-    result = transfer.materialize(transfer.read_spec(ref))
+    ref = None
+    result = None
+    try:
+        ref = transfer.put_structured_object(payload)
+        result = transfer.materialize(transfer.read_spec(ref))
 
-    assert np.array_equal(result.objects["array"], array)
-    assert result.objects["raw"] == b"abc"
-    assert store.batch_get_into_calls > 0
-    assert store.registered == set()
+        assert np.array_equal(result.objects["array"], array)
+        assert bytes(result.objects["raw"]) == b"abc"
+        assert hasattr(result.objects["array"], "_mooncake_pool_owner")
+    finally:
+        if result is not None:
+            MooncakeBundleTransfer.release_result(result.objects)
+        if ref is not None:
+            transfer.remove_bundle(ref)
+        pool.close()
 
 
 def test_structured_object_payload_metadata_defaults_empty() -> None:
@@ -576,54 +632,75 @@ def test_structured_object_roundtrip() -> None:
 
 
 def test_structured_object_read_spec_select_members() -> None:
-    store, transfer = make_transfer()
+    _store, pool, transfer = real_buffer_pool_transfer("structured-select")
     array = np.arange(10, dtype=np.float32).reshape(2, 5)
     payload = structured_payload(weights=array, raw=b"payload")
 
-    ref = transfer.put_structured_object(payload)
-    spec = transfer.read_spec(ref).select_members(["weights"])
-    assert isinstance(spec, StructuredObjectReadSpec)
-    batch_get_into_calls = store.batch_get_into_calls
-    result = transfer.materialize(spec)
+    ref = None
+    result = None
+    try:
+        ref = transfer.put_structured_object(payload)
+        spec = transfer.read_spec(ref).select_members(["weights"])
+        assert isinstance(spec, StructuredObjectReadSpec)
+        result = transfer.materialize(spec)
 
-    assert list(result.objects) == ["weights"]
-    assert np.array_equal(result.objects["weights"], array)
-    assert store.get_into_calls > 0
-    assert store.get_into_ranges_calls == 0
-    assert store.batch_get_into_calls == batch_get_into_calls + 1
+        assert list(result.objects) == ["weights"]
+        assert np.array_equal(result.objects["weights"], array)
+        assert hasattr(result.objects["weights"], "_mooncake_pool_owner")
+    finally:
+        if result is not None:
+            MooncakeBundleTransfer.release_result(result.objects)
+        if ref is not None:
+            transfer.remove_bundle(ref)
+        pool.close()
 
 
 def test_structured_object_multichunk_ndarray_uses_range_gather() -> None:
-    store, transfer = make_transfer()
+    _store, pool, transfer = real_buffer_pool_transfer("structured-multichunk")
     array = np.arange(64, dtype=np.int16).reshape(8, 8)
     payload = structured_payload(weights=array)
 
-    ref = transfer.put_structured_object(payload, chunk_bytes=32)
-    batch_get_into_calls = store.batch_get_into_calls
-    result = transfer.materialize(transfer.read_spec(ref))
+    ref = None
+    result = None
+    try:
+        ref = transfer.put_structured_object(payload, chunk_bytes=32)
+        result = transfer.materialize(transfer.read_spec(ref))
 
-    assert np.array_equal(result.objects["weights"], array)
-    assert store.get_into_ranges_calls > 0
-    assert store.batch_get_into_calls == batch_get_into_calls + 1
+        assert np.array_equal(result.objects["weights"], array)
+        assert hasattr(result.objects["weights"], "_mooncake_pool_owner")
+    finally:
+        if result is not None:
+            MooncakeBundleTransfer.release_result(result.objects)
+        if ref is not None:
+            transfer.remove_bundle(ref)
+        pool.close()
 
 
 def test_structured_object_slice_member_uses_partial_range_reads() -> None:
-    store, transfer = make_transfer()
+    _store, pool, transfer = real_buffer_pool_transfer("structured-slice")
     array = np.arange(96, dtype=np.int16).reshape(12, 8)
     payload = structured_payload(weights=array, raw=b"payload")
 
-    ref = transfer.put_structured_object(payload, chunk_bytes=20)
-    spec = (
-        transfer.read_spec(ref)
-        .select_members(["weights"])
-        .slice_member("weights", axis=0, start=3, end=9)
-    )
-    before_range_reads = store.get_into_ranges_calls
-    result = transfer.materialize(spec)
+    ref = None
+    result = None
+    try:
+        ref = transfer.put_structured_object(payload, chunk_bytes=20)
+        spec = (
+            transfer.read_spec(ref)
+            .select_members(["weights"])
+            .slice_member("weights", axis=0, start=3, end=9)
+        )
+        result = transfer.materialize(spec)
 
-    assert np.array_equal(result.objects["weights"], array[3:9])
-    assert result.objects["weights"].shape == (6, 8)
-    assert store.get_into_ranges_calls == before_range_reads + 1
+        assert np.array_equal(result.objects["weights"], array[3:9])
+        assert result.objects["weights"].shape == (6, 8)
+        assert hasattr(result.objects["weights"], "_mooncake_pool_owner")
+    finally:
+        if result is not None:
+            MooncakeBundleTransfer.release_result(result.objects)
+        if ref is not None:
+            transfer.remove_bundle(ref)
+        pool.close()
 
 
 def test_structured_object_slice_member_falls_back_to_plain_get_reads() -> None:
@@ -647,18 +724,23 @@ def test_structured_object_slice_member_falls_back_to_plain_get_reads() -> None:
 
 
 def test_structured_object_materialize_into_reuses_destination() -> None:
-    store, transfer = make_transfer()
+    _store, pool, transfer = real_buffer_pool_transfer("structured-materialize-into")
     array = np.arange(96, dtype=np.float32).reshape(12, 8)
     payload = structured_payload(weights=array)
 
-    ref = transfer.put_structured_object(payload, chunk_bytes=40)
-    spec = transfer.read_spec(ref).slice_member("weights", axis=0, start=2, end=10)
-    destination = np.empty((8, 8), dtype=np.float32)
-    result = transfer.materialize_into(spec, destinations={"weights": destination})
+    ref = None
+    try:
+        ref = transfer.put_structured_object(payload, chunk_bytes=40)
+        spec = transfer.read_spec(ref).slice_member("weights", axis=0, start=2, end=10)
+        destination = np.empty((8, 8), dtype=np.float32)
+        result = transfer.materialize_into(spec, destinations={"weights": destination})
 
-    assert result.objects["weights"] is destination
-    assert np.array_equal(destination, array[2:10])
-    assert store.get_into_ranges_calls > 0
+        assert result.objects["weights"] is destination
+        assert np.array_equal(destination, array[2:10])
+    finally:
+        if ref is not None:
+            transfer.remove_bundle(ref)
+        pool.close()
 
 
 def test_structured_object_duplicate_destination_registration_is_tolerated() -> None:
@@ -680,7 +762,6 @@ def test_structured_object_duplicate_destination_registration_is_tolerated() -> 
 
     assert result.objects["weights"] is destination
     assert np.array_equal(destination, array[2:10])
-    assert store.get_into_ranges_calls > 0
     assert destination_ptr in store.registered
     store.unregister_buffer(destination_ptr)
 
@@ -698,7 +779,6 @@ def test_structured_object_slice_member_step_copy() -> None:
 
     assert np.array_equal(result.objects["weights"], array[1:12:3])
     assert result.objects["weights"].shape == array[1:12:3].shape
-    assert store.get_into_ranges_calls > 0
 
 
 def test_structured_object_invalid_slice_and_destination_raise() -> None:
@@ -804,17 +884,22 @@ def test_bundle_concurrent_put_and_read_spec_full_read() -> None:
     assert store.max_active_gets >= 1
 
 
-def test_bundle_batch_get_failure_unregisters_buffer() -> None:
+def test_bundle_without_buffer_pool_uses_plain_get_fallback() -> None:
     store, transfer = make_transfer(FailingBatchGetStore())
+    payload = bytes(range(64))
     ref = transfer.put_structured_object(
-        structured_payload(payload=bytes(range(64))),
+        structured_payload(payload=payload),
         chunk_bytes=8,
     )
     store.fail_key = ref.manifest["buffers"]["payload"]["chunks"][2]["key"]
 
-    with pytest.raises(RuntimeError, match="injected get failure"):
-        transfer.materialize(transfer.read_spec(ref))
+    result = transfer.materialize(transfer.read_spec(ref))
 
+    assert result.objects["payload"] == payload
+    assert store.max_active_gets >= 1
+    assert store.batch_get_into_calls == 0
+    assert store.get_into_calls == 0
+    assert store.get_into_ranges_calls == 0
     assert store.registered == set()
 
 
@@ -994,11 +1079,13 @@ def test_structured_object_direct_torch_tensor_materialize_into_uses_real_store(
         4 * 1024 * 1024,
         os.getenv("PROTOCOL", "tcp"),
         os.getenv("DEVICE_NAME", ""),
-        os.getenv("MASTER_SERVER", "127.0.0.1:50051"),
+        _require_master_server(),
     )
     if rc != 0:
         pytest.skip(f"MooncakeDistributedStore setup failed: {rc}")
-    transfer = MooncakeBundleTransfer(store, key_prefix="structured-test-direct")
+    transfer = MooncakeBundleTransfer(
+        store, key_prefix=f"structured-test-direct-{uuid.uuid4().hex}"
+    )
     tensor = torch.arange(12, dtype=torch.int64).reshape(3, 4)
     ref = transfer.put_structured_object(
         StructuredObjectPayload(buffers={"tensor": tensor})
@@ -1038,7 +1125,7 @@ def test_structured_object_torch_tensor_zero_copy_rejects_plain_tensor() -> None
         )
 
 
-def test_structured_object_torch_tensor_slice_uses_range_reads() -> None:
+def test_structured_object_torch_tensor_slice_falls_back_without_tensor_fast_path() -> None:
     torch = pytest.importorskip("torch")
     mooncake_store = pytest.importorskip("mooncake.store")
     if not hasattr(mooncake_store, "_serialize_tensor") or not hasattr(
@@ -1058,7 +1145,10 @@ def test_structured_object_torch_tensor_slice_uses_range_reads() -> None:
     )
 
     assert torch.equal(result.objects["tensor"], tensor[3:9])
-    assert store.get_into_ranges_calls >= 2
+    assert store.put_tensor_calls == 0
+    assert store.get_tensor_calls == 0
+    assert store.max_active_gets >= 1
+    assert store.get_into_ranges_calls == 0
 
 
 def test_structured_object_direct_torch_tensor_slice_uses_real_store_ranges() -> None:
@@ -1160,13 +1250,13 @@ def test_structured_object_torch_tensor_zero_copy_uses_real_buffer_pool() -> Non
         4 * 1024 * 1024,
         os.getenv("PROTOCOL", "tcp"),
         os.getenv("DEVICE_NAME", ""),
-        os.getenv("MASTER_SERVER", "127.0.0.1:50051"),
+        _require_master_server(),
     )
     if rc != 0:
         pytest.skip(f"MooncakeDistributedStore setup failed: {rc}")
     pool = mooncake_store.BufferPool(store, min_size_class=4096, alignment=4096)
     transfer = MooncakeBundleTransfer(
-        store, key_prefix="structured-test", buffer_pool=pool
+        store, key_prefix=f"structured-test-{uuid.uuid4().hex}", buffer_pool=pool
     )
     tensor = torch.arange(12, dtype=torch.int64).reshape(3, 4)
     metadata, data_ptr, tensor_nbytes, owner = mooncake_store._serialize_tensor(tensor)
@@ -1177,6 +1267,8 @@ def test_structured_object_torch_tensor_zero_copy_uses_real_buffer_pool() -> Non
     ctypes.memmove(lease.ptr + len(metadata), int(data_ptr), int(tensor_nbytes))
     view.release()
 
+    ref = None
+    result = None
     try:
         ref = transfer.put_structured_object(
             StructuredObjectPayload(
@@ -1192,6 +1284,10 @@ def test_structured_object_torch_tensor_zero_copy_uses_real_buffer_pool() -> Non
         assert torch.equal(result.objects["tensor"], tensor)
         _ = owner
     finally:
+        if result is not None:
+            MooncakeBundleTransfer.release_result(result.objects)
+        if ref is not None:
+            transfer.remove_bundle(ref)
         lease.release()
         pool.close()
 
@@ -1337,6 +1433,9 @@ def test_dataproto_helper_reads_rows_with_real_store_ranges() -> None:
         },
     )
     ref = transfer.put_dataproto(data)
+    pool = None
+    raw_array = None
+    raw_tensor = None
 
     try:
         sliced = transfer.get_dataproto(ref, rows=slice(2, 5))
@@ -1410,10 +1509,13 @@ def test_dataproto_helper_reads_rows_with_real_store_ranges() -> None:
             bytes(raw_tensor.buffer[:tensor_payload_bytes])
         )
         assert torch.equal(decoded_tensor, tensor[[4, 1, 3]])
-        raw_array.release()
-        raw_tensor.release()
-        pool.close()
     finally:
+        if raw_array is not None:
+            raw_array.release()
+        if raw_tensor is not None:
+            raw_tensor.release()
+        if pool is not None:
+            pool.close()
         transfer.cleanup_dataproto(ref)
 
 
@@ -1429,6 +1531,124 @@ def test_dataproto_helper_supports_dict_cls_and_reports_bad_cls() -> None:
     assert np.array_equal(result["batch"]["input_ids"], np.arange(4))
     with pytest.raises(TypeError, match="cannot be constructed"):
         transfer.get_dataproto(ref, data_cls=BadDataProto)
+
+
+def test_legacy_dict_uses_schema_sections_without_field_name_rules() -> None:
+    envelope = _legacy_dict_to_envelope(
+        {
+            "row_ids": range(0, 3),
+            "tokens": [[1, 2], [3], [4, 5, 6]],
+            "scores": [2, 1, 3],
+            "global_lengths": [8, 9, 10, 11],
+        },
+        field_schemas={
+            "row_ids": FieldSchema(
+                codec="ndarray",
+                nullable=False,
+                metadata={"section": "non_tensor_batch", "dtype": "int64"},
+            ),
+            "tokens": FieldSchema(
+                codec="typed_ragged",
+                nullable=False,
+                metadata={"section": "non_tensor_batch"},
+            ),
+            "scores": FieldSchema(
+                codec="ndarray",
+                nullable=False,
+                metadata={"section": "non_tensor_batch", "dtype": "int64"},
+            ),
+            "global_lengths": FieldSchema(
+                codec="auto",
+                nullable=False,
+                metadata={"section": "meta_info"},
+            ),
+        },
+    )
+
+    assert envelope["non_tensor_batch"]["row_ids"].tolist() == [0, 1, 2]
+    assert envelope["non_tensor_batch"]["tokens"].tolist() == [
+        [1, 2],
+        [3],
+        [4, 5, 6],
+    ]
+    assert envelope["non_tensor_batch"]["scores"].tolist() == [2, 1, 3]
+    assert envelope["meta_info"]["global_lengths"] == [8, 9, 10, 11]
+
+
+def test_legacy_dict_schema_allows_unmapped_fields_to_fall_back() -> None:
+    envelope = _legacy_dict_to_envelope(
+        {
+            "row_ids": range(0, 3),
+            "scores": np.asarray([2, 1, 3], dtype=np.int64),
+            "global_step": 7,
+        },
+        field_schemas={
+            "row_ids": FieldSchema(
+                codec="ndarray",
+                metadata={"section": "non_tensor_batch", "dtype": "int64"},
+            )
+        },
+    )
+
+    assert envelope["non_tensor_batch"]["row_ids"].tolist() == [0, 1, 2]
+    assert np.array_equal(envelope["batch"]["scores"], np.asarray([2, 1, 3]))
+    assert envelope["meta_info"] == {"global_step": 7}
+
+
+def test_legacy_dict_schema_keeps_unmapped_same_length_lists_as_meta() -> None:
+    envelope = _legacy_dict_to_envelope(
+        {
+            "row_ids": range(0, 3),
+            "metadata_list": ["a", "b", "c"],
+        },
+        field_schemas={
+            "row_ids": FieldSchema(
+                codec="ndarray",
+                metadata={"section": "non_tensor_batch", "dtype": "int64"},
+            )
+        },
+    )
+
+    assert envelope["non_tensor_batch"]["row_ids"].tolist() == [0, 1, 2]
+    assert envelope["meta_info"]["metadata_list"] == ["a", "b", "c"]
+
+
+def test_legacy_dict_schema_meta_lists_do_not_define_batch_size() -> None:
+    envelope = _legacy_dict_to_envelope(
+        {
+            "global_lengths": [8, 9, 10, 11],
+            "scores": np.asarray([2, 1, 3], dtype=np.int64),
+        },
+        field_schemas={
+            "global_lengths": FieldSchema(
+                codec="auto",
+                metadata={"section": "meta_info"},
+            )
+        },
+    )
+
+    assert np.array_equal(envelope["batch"]["scores"], np.asarray([2, 1, 3]))
+    assert envelope["meta_info"]["global_lengths"] == [8, 9, 10, 11]
+
+
+def test_legacy_dict_auto_mode_infers_unambiguous_row_fields() -> None:
+    envelope = _legacy_dict_to_envelope(
+        {
+            "row_ids": range(0, 3),
+            "tokens": [[1, 2], [3], [4, 5, 6]],
+            "scores": np.asarray([2, 1, 3], dtype=np.int64),
+            "global_step": 7,
+        }
+    )
+
+    assert np.array_equal(envelope["batch"]["scores"], np.asarray([2, 1, 3]))
+    assert envelope["non_tensor_batch"]["row_ids"].tolist() == [0, 1, 2]
+    assert envelope["non_tensor_batch"]["tokens"].tolist() == [
+        [1, 2],
+        [3],
+        [4, 5, 6],
+    ]
+    assert envelope["meta_info"] == {"global_step": 7}
 
 
 def test_dataproto_helper_accepts_legacy_dict_inputs() -> None:
@@ -1676,6 +1896,307 @@ def test_dataproto_helper_rejects_cross_section_field_name_collision() -> None:
                 "non_tensor_batch": {"uid": np.asarray(["a", "b", "c", "d"])},
             }
         )
+
+
+def test_dataproto_helper_validates_schema_section() -> None:
+    _store, transfer = make_transfer()
+
+    with pytest.raises(ValueError, match="declares section"):
+        transfer.put_dataproto(
+            {
+                "batch": {"tokens": np.arange(4)},
+                "non_tensor_batch": {},
+                "meta_info": {},
+            },
+            field_schemas={
+                "tokens": FieldSchema(
+                    codec="auto",
+                    nullable=False,
+                    metadata={"section": "non_tensor_batch"},
+                )
+            },
+        )
+
+
+def test_dataproto_helper_rejects_invalid_schema_section() -> None:
+    _store, transfer = make_transfer()
+
+    with pytest.raises(ValueError, match="metadata.*section.*must be one of"):
+        transfer.put_dataproto(
+            {
+                "batch": {"tokens": np.arange(4)},
+                "non_tensor_batch": {},
+                "meta_info": {},
+            },
+            field_schemas={
+                "tokens": FieldSchema(
+                    codec="auto",
+                    metadata={"section": "bad"},
+                )
+            },
+        )
+
+
+def test_legacy_dict_schema_without_section_falls_back_to_auto_routing() -> None:
+    _store, transfer = make_transfer()
+    ref = transfer.put_legacy_dict(
+        {"values": range(1, 4), "step": 7},
+        field_schemas={
+            "values": FieldSchema(codec="ndarray", metadata={"dtype": "int64"})
+        },
+    )
+
+    result = transfer.get_legacy_dict(ref)
+
+    assert np.array_equal(result["values"], np.asarray([1, 2, 3], dtype=np.int64))
+    assert result["step"] == 7
+    assert "values" not in ref.encoded_non_tensor
+
+
+def test_legacy_dict_schema_keeps_numeric_ndarray_direct() -> None:
+    _store, transfer = make_transfer()
+    values = np.asarray([1, 2, 3], dtype=np.int64)
+    ref = transfer.put_legacy_dict(
+        {"values": values},
+        field_schemas={
+            "values": FieldSchema(
+                codec="ndarray",
+                nullable=False,
+                metadata={"section": "non_tensor_batch", "dtype": "int64"},
+            )
+        },
+    )
+
+    result = transfer.get_legacy_dict(ref)
+
+    assert np.array_equal(result["values"], values)
+    assert "values" not in ref.encoded_non_tensor
+
+
+def test_legacy_dict_schema_materializes_scalar_sequences_as_direct_ndarray() -> None:
+    _store, transfer = make_transfer()
+    ref = transfer.put_legacy_dict(
+        {"values": range(1, 4)},
+        field_schemas={
+            "values": FieldSchema(
+                codec="ndarray",
+                nullable=False,
+                metadata={"section": "non_tensor_batch", "dtype": "int64"},
+            )
+        },
+    )
+
+    result = transfer.get_legacy_dict(ref)
+
+    assert np.array_equal(result["values"], np.asarray([1, 2, 3], dtype=np.int64))
+    assert "values" not in ref.encoded_non_tensor
+
+
+def test_legacy_dict_schema_keeps_nulls_in_structured_codec() -> None:
+    _store, transfer = make_transfer()
+    ref = transfer.put_legacy_dict(
+        {"values": [1, None, 3]},
+        field_schemas={
+            "values": FieldSchema(
+                codec="ndarray",
+                nullable=False,
+                metadata={"section": "non_tensor_batch", "dtype": "int64"},
+            )
+        },
+    )
+
+    result = transfer.get_legacy_dict(ref)
+
+    assert result["values"] == [1, None, 3]
+    assert ref.encoded_non_tensor["values"]["codec"] == "ndarray"
+
+
+def test_legacy_dict_schema_invalid_ndarray_dtype_falls_back() -> None:
+    _store, transfer = make_transfer()
+    ref = transfer.put_legacy_dict(
+        {"values": [1, 2, 3]},
+        field_schemas={
+            "values": FieldSchema(
+                codec="ndarray",
+                nullable=False,
+                metadata={"section": "non_tensor_batch", "dtype": "object"},
+            )
+        },
+    )
+
+    result = transfer.get_legacy_dict(ref)
+
+    assert result["values"] == [1, 2, 3]
+    assert ref.encoded_non_tensor["values"]["codec"] == "ndarray"
+
+
+def test_legacy_dict_schema_missing_ndarray_dtype_falls_back_without_defaulting() -> None:
+    _store, transfer = make_transfer()
+    ref = transfer.put_legacy_dict(
+        {"values": [1, 2, 3]},
+        field_schemas={
+            "values": FieldSchema(
+                codec="ndarray",
+                nullable=False,
+                metadata={"section": "non_tensor_batch"},
+            )
+        },
+    )
+
+    result = transfer.get_legacy_dict(ref)
+
+    assert result["values"] == [1, 2, 3]
+    assert ref.encoded_non_tensor["values"]["codec"] == "ndarray"
+
+
+def test_legacy_dict_schema_malformed_ndarray_dtype_falls_back() -> None:
+    _store, transfer = make_transfer()
+    ref = transfer.put_legacy_dict(
+        {"values": [1, 2, 3]},
+        field_schemas={
+            "values": FieldSchema(
+                codec="ndarray",
+                nullable=False,
+                metadata={"section": "non_tensor_batch", "dtype": "not-a-dtype"},
+            )
+        },
+    )
+
+    result = transfer.get_legacy_dict(ref)
+
+    assert result["values"] == [1, 2, 3]
+    assert ref.encoded_non_tensor["values"]["codec"] == "ndarray"
+
+
+def test_legacy_dict_auto_mode_treats_zero_dim_ndarray_as_meta() -> None:
+    envelope = _legacy_dict_to_envelope(
+        {"row_ids": range(0, 3), "scalar_meta": np.asarray(7)}
+    )
+
+    assert envelope["non_tensor_batch"]["row_ids"].tolist() == [0, 1, 2]
+    assert envelope["meta_info"]["scalar_meta"] == np.asarray(7)
+
+
+def test_legacy_dict_auto_mode_reports_ambiguous_list_metadata() -> None:
+    with pytest.raises(ValueError, match="pass FieldSchema"):
+        _legacy_dict_to_envelope({"row_ids": range(0, 3), "metadata_list": [1, 2]})
+
+
+def test_legacy_dict_schema_honors_explicit_non_ndarray_codec_for_numeric_ndarray() -> None:
+    _store, transfer = make_transfer()
+    ref = transfer.put_legacy_dict(
+        {"values": np.asarray([[1, 2], [3, 4]], dtype=np.int64)},
+        field_schemas={
+            "values": FieldSchema(
+                codec="typed_ragged",
+                nullable=False,
+                metadata={"section": "non_tensor_batch"},
+            )
+        },
+    )
+
+    assert ref.encoded_non_tensor["values"]["codec"] == "typed_ragged"
+
+
+def test_legacy_dict_schema_codec_mismatch_falls_back() -> None:
+    _store, transfer = make_transfer()
+    ref = transfer.put_legacy_dict(
+        {"values": [1, 2, 3]},
+        field_schemas={
+            "values": FieldSchema(
+                codec="utf8_ragged",
+                metadata={"section": "non_tensor_batch"},
+            )
+        },
+    )
+
+    result = transfer.get_legacy_dict(ref)
+
+    assert result["values"] == [1, 2, 3]
+    assert ref.encoded_non_tensor["values"]["codec"] == "ndarray"
+
+
+def test_legacy_dict_schema_auto_codec_reuses_recursive_encoding() -> None:
+    _store, transfer = make_transfer()
+    ref = transfer.put_legacy_dict(
+        {
+            "metadata": [
+                {"ids": [1, 2], "score": 0.5},
+                {"ids": [3], "score": 1.5},
+            ],
+            "step": 4,
+        },
+        field_schemas={
+            "metadata": FieldSchema(
+                codec="auto",
+                nullable=False,
+                metadata={"section": "non_tensor_batch"},
+            ),
+            "step": FieldSchema(
+                codec="auto",
+                nullable=False,
+                metadata={"section": "meta_info"},
+            ),
+        },
+    )
+
+    result = transfer.get_legacy_dict(ref)
+
+    assert result["metadata"] == [
+        {"ids": [1, 2], "score": 0.5},
+        {"ids": [3], "score": 1.5},
+    ]
+    assert result["step"] == 4
+    assert "metadata" in ref.encoded_non_tensor
+
+
+def test_legacy_dict_schema_auto_codec_handles_object_ndarray_leaves() -> None:
+    _store, transfer = make_transfer()
+    ref = transfer.put_legacy_dict(
+        {
+            "metadata": [
+                {"values": np.asarray([{"x": 1}], dtype=object)},
+                {"values": np.asarray([{"x": 2}], dtype=object)},
+            ]
+        },
+        field_schemas={
+            "metadata": FieldSchema(
+                codec="auto",
+                metadata={"section": "non_tensor_batch"},
+            )
+        },
+    )
+
+    result = transfer.get_legacy_dict(ref)
+
+    assert result["metadata"] == [
+        {"values": [{"x": 1}]},
+        {"values": [{"x": 2}]},
+    ]
+    assert ref.encoded_non_tensor["metadata"]["codec"] == "msgpack_ragged"
+
+
+def test_legacy_dict_schema_auto_codec_falls_back_after_recursive_error(monkeypatch) -> None:
+    _store, transfer = make_transfer()
+
+    def fail_inference(*_args, **_kwargs):
+        raise ValueError("synthetic recursive failure")
+
+    monkeypatch.setattr(sos, "infer_structure", fail_inference)
+    ref = transfer.put_legacy_dict(
+        {"metadata": [{"x": 1}, {"x": 2}]},
+        field_schemas={
+            "metadata": FieldSchema(
+                codec="auto",
+                metadata={"section": "non_tensor_batch"},
+            )
+        },
+    )
+
+    result = transfer.get_legacy_dict(ref)
+
+    assert result["metadata"] == [{"x": 1}, {"x": 2}]
+    assert ref.encoded_non_tensor["metadata"]["codec"] == "msgpack_ragged"
 
 
 def test_dataproto_ref_handle_roundtrip_materializes_and_cleans_up() -> None:
@@ -2615,6 +3136,43 @@ def test_dataproto_helper_ragged_tensor_non_tensor_roundtrip() -> None:
     assert actual[1] is None
     assert torch.equal(actual[2], ragged[2])
     assert torch.equal(actual[3], ragged[3])
+
+
+def test_dataproto_helper_ragged_tensor_dict_accepts_numpy_arrays() -> None:
+    torch = pytest.importorskip("torch")
+    _store, transfer = make_transfer()
+    samples = np.asarray(
+        [
+            {
+                "pixel_values": np.arange(6, dtype=np.float32).reshape(2, 3),
+                "image_grid_thw": np.asarray([1, 2, 3], dtype=np.int64),
+            },
+            None,
+            {
+                "pixel_values": np.arange(12, dtype=np.float32).reshape(4, 3),
+                "image_grid_thw": np.asarray([1, 4, 3], dtype=np.int64),
+            },
+        ],
+        dtype=object,
+    )
+
+    ref = transfer.put_dataproto(
+        SimpleDataProto(non_tensor_batch={"multimodal_train_inputs": samples}),
+        field_schemas={
+            "multimodal_train_inputs": FieldSchema(
+                codec="ragged_tensor_dict", metadata={"section": "non_tensor_batch"}
+            )
+        },
+    )
+    actual = transfer.get_dataproto(ref)["non_tensor_batch"]["multimodal_train_inputs"]
+
+    assert ref.encoded_non_tensor["multimodal_train_inputs"]["codec"] == "ragged_tensor_dict"
+    assert torch.equal(actual[0]["pixel_values"], torch.as_tensor(samples[0]["pixel_values"]))
+    assert torch.equal(actual[0]["image_grid_thw"], torch.as_tensor(samples[0]["image_grid_thw"]))
+    assert actual[1] is None
+    assert torch.equal(actual[2]["pixel_values"], torch.as_tensor(samples[2]["pixel_values"]))
+    assert torch.equal(actual[2]["image_grid_thw"], torch.as_tensor(samples[2]["image_grid_thw"]))
+
 
 
 def _assert_tensor_object_equal(actual, expected) -> None:

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -2096,6 +2096,124 @@ def test_legacy_dict_schema_honors_explicit_non_ndarray_codec_for_numeric_ndarra
     assert ref.encoded_non_tensor["values"]["codec"] == "typed_ragged"
 
 
+def test_typed_ragged_packs_ndarray_rows_contiguously() -> None:
+    _store, transfer = make_transfer()
+    rows = [
+        np.asarray(7, dtype=np.int32),
+        np.arange(3, dtype=np.int32),
+        None,
+        np.arange(4, dtype=np.int32).reshape(2, 2),
+        np.arange(6, dtype=np.int32).reshape(2, 3),
+    ]
+
+    ref = transfer.put_legacy_dict(
+        {"values": rows},
+        field_schemas={
+            "values": FieldSchema(
+                codec="typed_ragged",
+                nullable=False,
+                metadata={"section": "non_tensor_batch"},
+            )
+        },
+    )
+    result = transfer.get_legacy_dict(ref)
+    view = transfer.dataproto_manifest_view(ref)
+
+    encoded = ref.encoded_non_tensor["values"]
+    assert encoded["codec"] == "typed_ragged"
+    assert encoded["metadata"]["physical_layout"] == "contiguous_flat"
+    assert view["non_tensor_fields"]["values"]["spec"]["payload_specs"]["data"][
+        "shape"
+    ] == [14]
+    assert [
+        None if row is None else row.tolist() for row in result["values"]
+    ] == [
+        None if row is None else row.tolist() for row in rows
+    ]
+    assert all(
+        row is None or isinstance(row, np.ndarray) for row in result["values"]
+    )
+    assert result["values"][0].shape == ()
+    assert [row.dtype for row in result["values"] if row is not None] == [
+        np.dtype(np.int32)
+    ] * 4
+    gathered = transfer.get_dataproto(
+        ref, non_tensor_fields=["values"], rows=[4, 2, 0]
+    )
+    assert [
+        None if row is None else row.tolist()
+        for row in gathered["non_tensor_batch"]["values"]
+    ] == [
+        rows[4].tolist(),
+        None,
+        rows[0].tolist(),
+    ]
+    assert gathered["non_tensor_batch"]["values"][2].shape == ()
+    imported = import_dataproto_ref(export_dataproto_ref(ref))
+    imported_result = transfer.get_legacy_dict(imported)
+    assert [
+        None if row is None else row.tolist() for row in imported_result["values"]
+    ] == [None if row is None else row.tolist() for row in rows]
+
+
+def test_typed_ragged_single_ndarray_pack_reuses_source_memory() -> None:
+    row = np.arange(8, dtype=np.int32).reshape(2, 4)
+
+    payload, metadata = sos._encode_typed_ragged_values([row])
+
+    assert metadata["physical_layout"] == "contiguous_flat"
+    assert payload["data"].shape == (8,)
+    assert np.shares_memory(payload["data"], row)
+
+
+def test_typed_ragged_regular_ndarray_rows_pack_as_contiguous_block() -> None:
+    rows = [np.arange(6, dtype=np.float32).reshape(2, 3) + row for row in range(4)]
+
+    payload, metadata = sos._encode_typed_ragged_values(rows, dtype_hint=np.float32)
+
+    assert metadata["physical_layout"] == "contiguous_flat"
+    assert payload["data"].shape == (24,)
+    assert payload["offsets"].tolist() == [0, 6, 12, 18, 24]
+    assert payload["shapes"].tolist() == [[2, 3]] * 4
+    decoded = sos._decode_typed_ragged_values(payload, len(rows), metadata)
+    assert [row.tolist() for row in decoded] == [row.tolist() for row in rows]
+
+
+def test_release_result_recurses_into_ragged_row_views() -> None:
+    class FakeOwner:
+        def __init__(self) -> None:
+            self.release_count = 0
+
+        def release(self) -> None:
+            self.release_count += 1
+
+    class OwnedArray(np.ndarray):
+        def __new__(cls, data, owner):
+            array = np.asarray(data).view(cls)
+            array._mooncake_pool_owner = owner
+            return array
+
+        def __array_finalize__(self, obj) -> None:
+            if obj is not None:
+                self._mooncake_pool_owner = getattr(
+                    obj, "_mooncake_pool_owner", None
+                )
+
+    owner = FakeOwner()
+    other_owner = FakeOwner()
+    base = OwnedArray(np.arange(6, dtype=np.int64), owner)
+    other = OwnedArray(np.arange(2, dtype=np.int64), other_owner)
+    object_items = np.empty(1, dtype=object)
+    object_items[0] = base[4:5]
+
+    MooncakeBundleTransfer.release_result(
+        {"values": [None, 0, base[:2], {"nested": (base[2:4], object_items)}, other[:1]]}
+    )
+
+    assert owner.release_count == 1
+    assert other_owner.release_count == 1
+
+
 def test_legacy_dict_schema_codec_mismatch_falls_back() -> None:
     _store, transfer = make_transfer()
     ref = transfer.put_legacy_dict(

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -19,7 +19,7 @@ from mooncake.structured_object_store import (
     RemoteBundleRef,
     StructuredObjectPayload,
     StructuredObjectReadSpec,
-    _legacy_dict_to_envelope,
+    _flat_dict_to_envelope,
     export_dataproto_ref,
     import_dataproto_ref,
     is_dataproto_ref_handle,
@@ -64,6 +64,8 @@ class InMemoryStore:
         self.batch_remove_calls = 0
         self.put_tensor_calls = 0
         self.get_tensor_calls = 0
+        self.put_configs: list[object] = []
+        self.batch_put_from_configs: list[object] = []
 
     def _enter_put(self) -> None:
         with self.lock:
@@ -83,7 +85,8 @@ class InMemoryStore:
         with self.lock:
             self.active_gets -= count
 
-    def put(self, key: str, value) -> int:
+    def put(self, key: str, value, config=None) -> int:
+        self.put_configs.append(config)
         self._enter_put()
         try:
             time.sleep(0.01)
@@ -126,14 +129,18 @@ class InMemoryStore:
         return [0 for _key in keys]
 
     def batch_put_from(
-        self, keys: list[str], buffer_ptrs: list[int], sizes: list[int]
+        self, keys: list[str], buffer_ptrs: list[int], sizes: list[int], config=None
     ) -> list[int]:
         self.batch_put_from_calls += 1
+        self.batch_put_from_configs.append(config)
         results: list[int] = []
         for key, ptr, size in zip(keys, buffer_ptrs, sizes):
             data = ctypes.string_at(ptr, size)
-            results.append(self.put(key, data))
+            results.append(self.put(key, data, config=config))
         return results
+
+    def put_from(self, key: str, buffer_ptr: int, size: int, config=None) -> int:
+        return self.put(key, ctypes.string_at(buffer_ptr, size), config)
 
     def put_tensor_from(self, key: str, buffer_ptr: int, size: int) -> int:
         self.put_tensor_from_calls += 1
@@ -225,6 +232,25 @@ class InMemoryStore:
             return results
         finally:
             self._exit_get(len(keys))
+
+
+class FakeLease:
+    def __init__(self, size: int) -> None:
+        self.size = size
+        self._buffer = ctypes.create_string_buffer(size)
+        self.ptr = ctypes.addressof(self._buffer)
+
+    @property
+    def buffer(self):
+        return memoryview(self._buffer)
+
+    def release(self) -> None:
+        pass
+
+
+class FakeBufferPool:
+    def acquire(self, size: int) -> FakeLease:
+        return FakeLease(size)
 
 
 class GetOnlyStore(InMemoryStore):
@@ -1331,6 +1357,32 @@ def test_dataproto_helper_roundtrip_uses_structured_object() -> None:
     assert stage_metadata["dataproto"]["stage"] == "rollout"
 
 
+def test_unified_dict_put_passes_store_config_to_put_writes() -> None:
+    store, transfer = make_transfer()
+    config = object()
+    data = {"input_ids": np.arange(12, dtype=np.int64).reshape(4, 3)}
+
+    ref = transfer.put(data, type="dict", config=config)
+    result = transfer.get(ref, type="dict")
+
+    assert np.array_equal(result["input_ids"], data["input_ids"])
+    assert store.put_configs
+    assert all(item is config for item in store.put_configs)
+
+
+def test_unified_dict_put_passes_store_config_to_batch_put_writes() -> None:
+    store, transfer = make_transfer(buffer_pool=FakeBufferPool())
+    config = object()
+    data = {"input_ids": np.arange(12, dtype=np.int64).reshape(4, 3)}
+
+    ref = transfer.put(data, type="dict", config=config)
+    result = transfer.get(ref, type="dict")
+
+    assert np.array_equal(result["input_ids"], data["input_ids"])
+    assert store.batch_put_from_configs
+    assert all(item is config for item in store.batch_put_from_configs)
+
+
 def test_dataproto_manifest_view_reuses_structured_manifest_specs() -> None:
     _store, transfer = make_transfer()
     data = SimpleDataProto(
@@ -1533,8 +1585,8 @@ def test_dataproto_helper_supports_dict_cls_and_reports_bad_cls() -> None:
         transfer.get_dataproto(ref, data_cls=BadDataProto)
 
 
-def test_legacy_dict_uses_schema_sections_without_field_name_rules() -> None:
-    envelope = _legacy_dict_to_envelope(
+def test_flat_dict_uses_schema_sections_without_field_name_rules() -> None:
+    envelope = _flat_dict_to_envelope(
         {
             "row_ids": range(0, 3),
             "tokens": [[1, 2], [3], [4, 5, 6]],
@@ -1575,8 +1627,8 @@ def test_legacy_dict_uses_schema_sections_without_field_name_rules() -> None:
     assert envelope["meta_info"]["global_lengths"] == [8, 9, 10, 11]
 
 
-def test_legacy_dict_schema_allows_unmapped_fields_to_fall_back() -> None:
-    envelope = _legacy_dict_to_envelope(
+def test_flat_dict_schema_allows_unmapped_fields_to_fall_back() -> None:
+    envelope = _flat_dict_to_envelope(
         {
             "row_ids": range(0, 3),
             "scores": np.asarray([2, 1, 3], dtype=np.int64),
@@ -1595,8 +1647,8 @@ def test_legacy_dict_schema_allows_unmapped_fields_to_fall_back() -> None:
     assert envelope["meta_info"] == {"global_step": 7}
 
 
-def test_legacy_dict_schema_keeps_unmapped_same_length_lists_as_meta() -> None:
-    envelope = _legacy_dict_to_envelope(
+def test_flat_dict_schema_keeps_unmapped_same_length_lists_as_meta() -> None:
+    envelope = _flat_dict_to_envelope(
         {
             "row_ids": range(0, 3),
             "metadata_list": ["a", "b", "c"],
@@ -1613,8 +1665,8 @@ def test_legacy_dict_schema_keeps_unmapped_same_length_lists_as_meta() -> None:
     assert envelope["meta_info"]["metadata_list"] == ["a", "b", "c"]
 
 
-def test_legacy_dict_schema_meta_lists_do_not_define_batch_size() -> None:
-    envelope = _legacy_dict_to_envelope(
+def test_flat_dict_schema_meta_lists_do_not_define_batch_size() -> None:
+    envelope = _flat_dict_to_envelope(
         {
             "global_lengths": [8, 9, 10, 11],
             "scores": np.asarray([2, 1, 3], dtype=np.int64),
@@ -1631,8 +1683,8 @@ def test_legacy_dict_schema_meta_lists_do_not_define_batch_size() -> None:
     assert envelope["meta_info"]["global_lengths"] == [8, 9, 10, 11]
 
 
-def test_legacy_dict_auto_mode_infers_unambiguous_row_fields() -> None:
-    envelope = _legacy_dict_to_envelope(
+def test_flat_dict_auto_mode_infers_unambiguous_row_fields() -> None:
+    envelope = _flat_dict_to_envelope(
         {
             "row_ids": range(0, 3),
             "tokens": [[1, 2], [3], [4, 5, 6]],
@@ -1651,7 +1703,7 @@ def test_legacy_dict_auto_mode_infers_unambiguous_row_fields() -> None:
     assert envelope["meta_info"] == {"global_step": 7}
 
 
-def test_dataproto_helper_accepts_legacy_dict_inputs() -> None:
+def test_dataproto_helper_accepts_flat_dict_inputs() -> None:
     _store, transfer = make_transfer()
     plain_ref = transfer.put_dataproto({"input_ids": np.arange(4)})
     envelope_ref = transfer.put_dataproto(
@@ -1937,24 +1989,24 @@ def test_dataproto_helper_rejects_invalid_schema_section() -> None:
         )
 
 
-def test_legacy_dict_schema_without_section_falls_back_to_auto_routing() -> None:
+def test_flat_dict_schema_without_section_falls_back_to_auto_routing() -> None:
     _store, transfer = make_transfer()
-    ref = transfer.put_legacy_dict(
+    ref = transfer.put_dict(
         {"values": range(1, 4), "step": 7},
         field_schemas={"values": FieldSchema(codec="ndarray", metadata={"dtype": "int64"})},
     )
 
-    result = transfer.get_legacy_dict(ref)
+    result = transfer.get_dict(ref)
 
     assert result["values"] == [1, 2, 3]
     assert result["step"] == 7
     assert ref.encoded_non_tensor["values"]["codec"] == "ndarray"
 
 
-def test_legacy_dict_schema_keeps_numeric_ndarray_direct() -> None:
+def test_flat_dict_schema_keeps_numeric_ndarray_direct() -> None:
     _store, transfer = make_transfer()
     values = np.asarray([1, 2, 3], dtype=np.int64)
-    ref = transfer.put_legacy_dict(
+    ref = transfer.put_dict(
         {"values": values},
         field_schemas={
             "values": FieldSchema(
@@ -1965,15 +2017,15 @@ def test_legacy_dict_schema_keeps_numeric_ndarray_direct() -> None:
         },
     )
 
-    result = transfer.get_legacy_dict(ref)
+    result = transfer.get_dict(ref)
 
     assert np.array_equal(result["values"], values)
     assert "values" not in ref.encoded_non_tensor
 
 
-def test_legacy_dict_schema_encodes_scalar_sequences_with_ndarray_codec() -> None:
+def test_flat_dict_schema_encodes_scalar_sequences_with_ndarray_codec() -> None:
     _store, transfer = make_transfer()
-    ref = transfer.put_legacy_dict(
+    ref = transfer.put_dict(
         {"values": range(1, 4)},
         field_schemas={
             "values": FieldSchema(
@@ -1984,15 +2036,15 @@ def test_legacy_dict_schema_encodes_scalar_sequences_with_ndarray_codec() -> Non
         },
     )
 
-    result = transfer.get_legacy_dict(ref)
+    result = transfer.get_dict(ref)
 
     assert result["values"] == [1, 2, 3]
     assert ref.encoded_non_tensor["values"]["codec"] == "ndarray"
 
 
-def test_legacy_dict_schema_keeps_nulls_in_structured_codec() -> None:
+def test_flat_dict_schema_keeps_nulls_in_structured_codec() -> None:
     _store, transfer = make_transfer()
-    ref = transfer.put_legacy_dict(
+    ref = transfer.put_dict(
         {"values": [1, None, 3]},
         field_schemas={
             "values": FieldSchema(
@@ -2003,15 +2055,15 @@ def test_legacy_dict_schema_keeps_nulls_in_structured_codec() -> None:
         },
     )
 
-    result = transfer.get_legacy_dict(ref)
+    result = transfer.get_dict(ref)
 
     assert result["values"] == [1, None, 3]
     assert ref.encoded_non_tensor["values"]["codec"] == "ndarray"
 
 
-def test_legacy_dict_schema_invalid_ndarray_dtype_falls_back() -> None:
+def test_flat_dict_schema_invalid_ndarray_dtype_falls_back() -> None:
     _store, transfer = make_transfer()
-    ref = transfer.put_legacy_dict(
+    ref = transfer.put_dict(
         {"values": [1, 2, 3]},
         field_schemas={
             "values": FieldSchema(
@@ -2022,15 +2074,15 @@ def test_legacy_dict_schema_invalid_ndarray_dtype_falls_back() -> None:
         },
     )
 
-    result = transfer.get_legacy_dict(ref)
+    result = transfer.get_dict(ref)
 
     assert result["values"] == [1, 2, 3]
     assert ref.encoded_non_tensor["values"]["codec"] == "ndarray"
 
 
-def test_legacy_dict_schema_missing_ndarray_dtype_falls_back_without_defaulting() -> None:
+def test_flat_dict_schema_missing_ndarray_dtype_falls_back_without_defaulting() -> None:
     _store, transfer = make_transfer()
-    ref = transfer.put_legacy_dict(
+    ref = transfer.put_dict(
         {"values": [1, 2, 3]},
         field_schemas={
             "values": FieldSchema(
@@ -2041,15 +2093,15 @@ def test_legacy_dict_schema_missing_ndarray_dtype_falls_back_without_defaulting(
         },
     )
 
-    result = transfer.get_legacy_dict(ref)
+    result = transfer.get_dict(ref)
 
     assert result["values"] == [1, 2, 3]
     assert ref.encoded_non_tensor["values"]["codec"] == "ndarray"
 
 
-def test_legacy_dict_schema_malformed_ndarray_dtype_falls_back() -> None:
+def test_flat_dict_schema_malformed_ndarray_dtype_falls_back() -> None:
     _store, transfer = make_transfer()
-    ref = transfer.put_legacy_dict(
+    ref = transfer.put_dict(
         {"values": [1, 2, 3]},
         field_schemas={
             "values": FieldSchema(
@@ -2060,14 +2112,14 @@ def test_legacy_dict_schema_malformed_ndarray_dtype_falls_back() -> None:
         },
     )
 
-    result = transfer.get_legacy_dict(ref)
+    result = transfer.get_dict(ref)
 
     assert result["values"] == [1, 2, 3]
     assert ref.encoded_non_tensor["values"]["codec"] == "ndarray"
 
 
-def test_legacy_dict_auto_mode_treats_zero_dim_ndarray_as_meta() -> None:
-    envelope = _legacy_dict_to_envelope(
+def test_flat_dict_auto_mode_treats_zero_dim_ndarray_as_meta() -> None:
+    envelope = _flat_dict_to_envelope(
         {"row_ids": range(0, 3), "scalar_meta": np.asarray(7)}
     )
 
@@ -2075,14 +2127,14 @@ def test_legacy_dict_auto_mode_treats_zero_dim_ndarray_as_meta() -> None:
     assert envelope["meta_info"]["scalar_meta"] == np.asarray(7)
 
 
-def test_legacy_dict_auto_mode_reports_ambiguous_list_metadata() -> None:
+def test_flat_dict_auto_mode_reports_ambiguous_list_metadata() -> None:
     with pytest.raises(ValueError, match="pass FieldSchema"):
-        _legacy_dict_to_envelope({"row_ids": range(0, 3), "metadata_list": [1, 2]})
+        _flat_dict_to_envelope({"row_ids": range(0, 3), "metadata_list": [1, 2]})
 
 
-def test_legacy_dict_schema_honors_explicit_non_ndarray_codec_for_numeric_ndarray() -> None:
+def test_flat_dict_schema_honors_explicit_non_ndarray_codec_for_numeric_ndarray() -> None:
     _store, transfer = make_transfer()
-    ref = transfer.put_legacy_dict(
+    ref = transfer.put_dict(
         {"values": np.asarray([[1, 2], [3, 4]], dtype=np.int64)},
         field_schemas={
             "values": FieldSchema(
@@ -2106,7 +2158,7 @@ def test_typed_ragged_packs_ndarray_rows_contiguously() -> None:
         np.arange(6, dtype=np.int32).reshape(2, 3),
     ]
 
-    ref = transfer.put_legacy_dict(
+    ref = transfer.put_dict(
         {"values": rows},
         field_schemas={
             "values": FieldSchema(
@@ -2116,7 +2168,7 @@ def test_typed_ragged_packs_ndarray_rows_contiguously() -> None:
             )
         },
     )
-    result = transfer.get_legacy_dict(ref)
+    result = transfer.get_dict(ref)
     view = transfer.dataproto_manifest_view(ref)
 
     encoded = ref.encoded_non_tensor["values"]
@@ -2150,7 +2202,7 @@ def test_typed_ragged_packs_ndarray_rows_contiguously() -> None:
     ]
     assert gathered["non_tensor_batch"]["values"][2].shape == ()
     imported = import_dataproto_ref(export_dataproto_ref(ref))
-    imported_result = transfer.get_legacy_dict(imported)
+    imported_result = transfer.get_dict(imported)
     assert [
         None if row is None else row.tolist() for row in imported_result["values"]
     ] == [None if row is None else row.tolist() for row in rows]
@@ -2214,9 +2266,9 @@ def test_release_result_recurses_into_ragged_row_views() -> None:
     assert other_owner.release_count == 1
 
 
-def test_legacy_dict_schema_codec_mismatch_falls_back() -> None:
+def test_flat_dict_schema_codec_mismatch_falls_back() -> None:
     _store, transfer = make_transfer()
-    ref = transfer.put_legacy_dict(
+    ref = transfer.put_dict(
         {"values": [1, 2, 3]},
         field_schemas={
             "values": FieldSchema(
@@ -2226,15 +2278,15 @@ def test_legacy_dict_schema_codec_mismatch_falls_back() -> None:
         },
     )
 
-    result = transfer.get_legacy_dict(ref)
+    result = transfer.get_dict(ref)
 
     assert result["values"] == [1, 2, 3]
     assert ref.encoded_non_tensor["values"]["codec"] == "ndarray"
 
 
-def test_legacy_dict_schema_auto_codec_reuses_recursive_encoding() -> None:
+def test_flat_dict_schema_auto_codec_reuses_recursive_encoding() -> None:
     _store, transfer = make_transfer()
-    ref = transfer.put_legacy_dict(
+    ref = transfer.put_dict(
         {
             "metadata": [
                 {"ids": [1, 2], "score": 0.5},
@@ -2256,7 +2308,7 @@ def test_legacy_dict_schema_auto_codec_reuses_recursive_encoding() -> None:
         },
     )
 
-    result = transfer.get_legacy_dict(ref)
+    result = transfer.get_dict(ref)
 
     assert result["metadata"] == [
         {"ids": [1, 2], "score": 0.5},
@@ -2266,9 +2318,9 @@ def test_legacy_dict_schema_auto_codec_reuses_recursive_encoding() -> None:
     assert "metadata" in ref.encoded_non_tensor
 
 
-def test_legacy_dict_schema_auto_codec_handles_object_ndarray_leaves() -> None:
+def test_flat_dict_schema_auto_codec_handles_object_ndarray_leaves() -> None:
     _store, transfer = make_transfer()
-    ref = transfer.put_legacy_dict(
+    ref = transfer.put_dict(
         {
             "metadata": [
                 {"values": np.asarray([{"x": 1}], dtype=object)},
@@ -2283,7 +2335,7 @@ def test_legacy_dict_schema_auto_codec_handles_object_ndarray_leaves() -> None:
         },
     )
 
-    result = transfer.get_legacy_dict(ref)
+    result = transfer.get_dict(ref)
 
     assert result["metadata"] == [
         {"values": [{"x": 1}]},
@@ -2292,14 +2344,14 @@ def test_legacy_dict_schema_auto_codec_handles_object_ndarray_leaves() -> None:
     assert ref.encoded_non_tensor["metadata"]["codec"] == "msgpack_ragged"
 
 
-def test_legacy_dict_schema_auto_codec_falls_back_after_recursive_error(monkeypatch) -> None:
+def test_flat_dict_schema_auto_codec_falls_back_after_recursive_error(monkeypatch) -> None:
     _store, transfer = make_transfer()
 
     def fail_inference(*_args, **_kwargs):
         raise ValueError("synthetic recursive failure")
 
     monkeypatch.setattr(sos, "infer_structure", fail_inference)
-    ref = transfer.put_legacy_dict(
+    ref = transfer.put_dict(
         {"metadata": [{"x": 1}, {"x": 2}]},
         field_schemas={
             "metadata": FieldSchema(
@@ -2309,7 +2361,7 @@ def test_legacy_dict_schema_auto_codec_falls_back_after_recursive_error(monkeypa
         },
     )
 
-    result = transfer.get_legacy_dict(ref)
+    result = transfer.get_dict(ref)
 
     assert result["metadata"] == [{"x": 1}, {"x": 2}]
     assert ref.encoded_non_tensor["metadata"]["codec"] == "msgpack_ragged"

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -1941,16 +1941,14 @@ def test_legacy_dict_schema_without_section_falls_back_to_auto_routing() -> None
     _store, transfer = make_transfer()
     ref = transfer.put_legacy_dict(
         {"values": range(1, 4), "step": 7},
-        field_schemas={
-            "values": FieldSchema(codec="ndarray", metadata={"dtype": "int64"})
-        },
+        field_schemas={"values": FieldSchema(codec="ndarray", metadata={"dtype": "int64"})},
     )
 
     result = transfer.get_legacy_dict(ref)
 
-    assert np.array_equal(result["values"], np.asarray([1, 2, 3], dtype=np.int64))
+    assert result["values"] == [1, 2, 3]
     assert result["step"] == 7
-    assert "values" not in ref.encoded_non_tensor
+    assert ref.encoded_non_tensor["values"]["codec"] == "ndarray"
 
 
 def test_legacy_dict_schema_keeps_numeric_ndarray_direct() -> None:
@@ -1973,7 +1971,7 @@ def test_legacy_dict_schema_keeps_numeric_ndarray_direct() -> None:
     assert "values" not in ref.encoded_non_tensor
 
 
-def test_legacy_dict_schema_materializes_scalar_sequences_as_direct_ndarray() -> None:
+def test_legacy_dict_schema_encodes_scalar_sequences_with_ndarray_codec() -> None:
     _store, transfer = make_transfer()
     ref = transfer.put_legacy_dict(
         {"values": range(1, 4)},
@@ -1988,8 +1986,8 @@ def test_legacy_dict_schema_materializes_scalar_sequences_as_direct_ndarray() ->
 
     result = transfer.get_legacy_dict(ref)
 
-    assert np.array_equal(result["values"], np.asarray([1, 2, 3], dtype=np.int64))
-    assert "values" not in ref.encoded_non_tensor
+    assert result["values"] == [1, 2, 3]
+    assert ref.encoded_non_tensor["values"]["codec"] == "ndarray"
 
 
 def test_legacy_dict_schema_keeps_nulls_in_structured_codec() -> None:

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -1750,9 +1750,9 @@ def test_dataproto_field_schema_encodes_typed_ragged_non_tensor_field() -> None:
     )
     result = transfer.get_dataproto(ref)["non_tensor_batch"]["tokens"]
 
-    assert result[0] == [1, 2]
+    assert result[0].tolist() == [1, 2]
     assert result[1] is None
-    assert result[2] == [3]
+    assert result[2].tolist() == [3]
 
     bad_text = np.asarray([object()], dtype=object)
     with pytest.raises(AttributeError, match="failed to encode.*'text'.*utf8_ragged"):
@@ -2214,8 +2214,9 @@ def test_typed_ragged_single_ndarray_pack_reuses_source_memory() -> None:
     payload, metadata = sos._encode_typed_ragged_values([row])
 
     assert metadata["physical_layout"] == "contiguous_flat"
+    assert isinstance(payload["data"], sos._MultiBufferPayload)
     assert payload["data"].shape == (8,)
-    assert np.shares_memory(payload["data"], row)
+    assert np.shares_memory(payload["data"].owners[0], row)
 
 
 def test_typed_ragged_regular_ndarray_rows_pack_as_contiguous_block() -> None:


### PR DESCRIPTION
## Motivation                                                                                                                                                
                                                                                                                                                            
  Optimize Mooncake structured DataProto rollout transfer. The main goal is to reduce CPU serialization overhead, avoid large Python object materialization, and keep the RL-side integration thin.    

### Why replace register buffer into memcpy when put

Rollout dicts contain many lists, dicts, and nested combinations of the two, resulting in a large number of small, memory-discontiguous objects. Registering each small object individually as an RDMA buffer and then putting it to Mooncake would incur significant latency — each register call requires NIC interaction at microsecond-level cost, and the overhead accumulates quickly with many objects, far exceeding that of parallel memcpy. The current strategy is therefore parallel memcpy: copy scattered small objects into a contiguous pre-registered buffer, then transfer via a single batch put. Once a high-performance batch register mechanism is available (bulk-registering multiple discontiguous memory regions in one call), we can consider switching to a zero-copy path using register + batch_put_from_multi_buffers, eliminating the memcpy overhead entirely.                                                                                                             
                                                                                                                                                            
 ##  Modification                                                                                                                                              
                                                                                                                                                            
  - Legacy dict Wrapping: Add legacy dict support by wrapping.
  - Schema-driven encoding (FieldSchema): Add FieldSchema dataclass allowing callers to specify non_tensor_batch field codecs explicitly via field_schemas parameter in put_dataproto /put_legacy_dict
   / append_dataproto_fields, bypassing expensive per-sample runtime inference on large ragged fields.                                                                               
  - BufferPool-based GET path: Remove all manual register_buffer / unregister_buffer calls (broken on erdma hardware) and unify GET-side RDMA memory registration through BufferPool:
    - _read_chunks_with_pool_get_into: full pool acquire → batch_get_into → copy to destination                                                                                      
    - _read_chunks_with_chunked_pool_get_into: per-chunk pool acquire fallback when full allocation fails
    - _read_payload_range_with_pool: pool-based ranged read via get_into_ranges                                                                                                      
    - _read_payload_ranges_with_pool: pool-based multi-range read                                                                                                                    
    - Final fallback: store.get per chunk (non-zero-copy)                                                                                                                                                
                                                                                                                                                                                                              
  ## Performance 
  ### roll dataproto(cross-machine RDMA, erdma)                                                                                                             
                                                                                                                                                                                     
  | Dataset | Samples | Data Size | PUT | GET (avg, skip warmup) |                                                                                                                   
  |---------|---------|-----------|-----|------------------------|                                                                                                                   
  | ROLL DataProto (ragged_tensor_dict) | 2048 | ~24 GB | 2.6s | 2.66s |                                                                                                             

### slime rollout dict , cross-machine (eRDMA, A10 cluster):                                                                                          
                                                            
| Size | Ray PUT | Ray GET | Ray GET BW | MoonCake PUT | MoonCake PUT BW | MoonCake GET | MoonCake GET BW | GET Speedup |
|------|---------|---------|------------|--------|-----------|--------|-----------|-------------|                       
| 128MB | 61ms | 65ms | 1.9 GB/s | 30ms | 3.97 GB/s | 18ms | 6.5 GB/s | 3.6x |
| 512MB | 207ms | 211ms | 2.4 GB/s | 71ms | 6.72 GB/s | 59ms | 8.0 GB/s | 3.6x |                                        
| 1GB | 296ms | 432ms | 2.3 GB/s | 130ms | 7.35 GB/s | 114ms | 8.3 GB/s | 3.8x |                                        
| 4GB | 340ms | 1561ms | 2.6 GB/s | 477ms | 7.99 GB/s | 430ms | 8.9 GB/s | 3.6x |                 
| 16GB | 708ms | 5802ms | 2.8 GB/s | 1903ms | 8.02 GB/s | 1701ms | 9.0 GB/s | 3.4x |                                                                                                                                           
                                                                                                                                                            
  ## Test                                                                                                                                                      
                                                                                                                                                            
  - Added / updated structured object store unit coverage for:                                                                                              
    - DataProto structured transfer                                                                                                                         
    - typed ragged ndarray/list preservation                                                                                                                
    - row-subset structured non-tensor decode                                                                                                               
    - BufferPool-backed tensor object transfer                                                                                                              
  - Local validation:                                                                                                                                       
    - python3 -m py_compile mooncake-wheel/mooncake/structured_object_store.py                                                                              
    - focused structured object store tests passed: 5 passed                  
## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Performance improvement
- [ ] Other

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [x] AI tools were used (specify below)