### PR TITLE
[TE] Name AscendDirectTransport worker threads

### DIFF
--- a/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/utils.cpp
+++ b/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/utils.cpp
@@ -18,6 +18,11 @@
 #include <cstring>
 #include <memory>
 #include <random>
+#include <string>
+
+#if defined(__linux__)
+#include <pthread.h>
+#endif
 
 #include <glog/logging.h>
 #if __has_include(<jsoncpp/json/json.h>)
@@ -73,6 +78,13 @@ const Json::Value* FindProtocolDescValue(const Json::Value& root) {
         return &root["comm_resource_config"]["protocol_desc"];
     }
     return nullptr;
+}
+
+void SetAscendThreadName(const char* name) {
+#if defined(__linux__)
+    pthread_setname_np(pthread_self(), name);
+#endif
+    (void)name;
 }
 }  // namespace
 
@@ -163,7 +175,8 @@ bool IsRoceModeEnabled() {
 // AscendThreadPool implementation
 AscendThreadPool::AscendThreadPool(size_t num_threads) : running_(true) {
     for (size_t i = 0; i < num_threads; ++i) {
-        workers_.emplace_back([this] {
+        workers_.emplace_back([this, i] {
+            SetAscendThreadName(("ascend-wk-" + std::to_string(i)).c_str());
             while (true) {
                 std::function<void()> task;
                 {

--- a/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/utils.cpp
+++ b/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/utils.cpp
@@ -17,12 +17,9 @@
 
 #include <cstring>
 #include <memory>
+#include <pthread.h>
 #include <random>
 #include <string>
-
-#if defined(__linux__)
-#include <pthread.h>
-#endif
 
 #include <glog/logging.h>
 #if __has_include(<jsoncpp/json/json.h>)
@@ -78,13 +75,6 @@ const Json::Value* FindProtocolDescValue(const Json::Value& root) {
         return &root["comm_resource_config"]["protocol_desc"];
     }
     return nullptr;
-}
-
-void SetAscendThreadName(const char* name) {
-#if defined(__linux__)
-    pthread_setname_np(pthread_self(), name);
-#endif
-    (void)name;
 }
 }  // namespace
 
@@ -176,7 +166,8 @@ bool IsRoceModeEnabled() {
 AscendThreadPool::AscendThreadPool(size_t num_threads) : running_(true) {
     for (size_t i = 0; i < num_threads; ++i) {
         workers_.emplace_back([this, i] {
-            SetAscendThreadName(("ascend-wk-" + std::to_string(i)).c_str());
+            auto thread_name = "ascend-wk-" + std::to_string(i);
+            pthread_setname_np(pthread_self(), thread_name.c_str());
             while (true) {
                 std::function<void()> task;
                 {


### PR DESCRIPTION
## Description

Name each `AscendThreadPool` worker thread in the Ascend direct transport
(`ascend-wk-<i>`) via `pthread_setname_np`. Previously these worker threads
inherited the process name, making them indistinguishable in `top -H`, `ps -L`,
`perf`, and `/proc/<tid>/comm`.

Thread names are bounded by the pool size (<= 16), so the longest name
`ascend-wk-15` fits within the 15-byte `pthread_setname_np` limit on Linux.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Pytorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

- `./scripts/code_format.sh -b upstream/main` — passed
- Ascend Mooncake Store real workload — passed

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
