### PR TITLE
[Wheel] Enrich PyPI metadata for Mooncake wheel variants

### DIFF
--- a/mooncake-wheel/pyproject.toml
+++ b/mooncake-wheel/pyproject.toml
@@ -27,7 +27,7 @@ description = "Mooncake is the serving platform for Kimi, a leading LLM service 
 authors = [
     { name = "Mooncake Authors" }
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 readme = "README.md"   # local copy of ../README.md, materialized at build time by scripts/build_wheel.sh
 dependencies = ["aiohttp", "requests", "msgpack"]
 # Single-line arrays: sed-substituted by scripts/build_wheel.sh for each variant.

--- a/mooncake-wheel/pyproject.toml
+++ b/mooncake-wheel/pyproject.toml
@@ -1,3 +1,21 @@
+# mooncake-wheel/pyproject.toml
+#
+# This file is built from this directory; scripts/build_wheel.sh `cd`s
+# here before invoking setuptools. Do not move this file or its parent
+# build script out of sync.
+#
+# NOTE: the `keywords` and `classifiers` arrays below MUST stay on a
+# single line. They are sed-substituted by scripts/build_wheel.sh for
+# each build variant (non-cuda, cuda13, npu, efa, efa-non-cuda, musa);
+# reordering or wrapping will silently break the variant build matrix.
+#
+# `readme = "README.md"` points at a per-build copy of the repo-root
+# README.md, materialized by scripts/build_wheel.sh (which `cp`s
+# ../README.md into this directory before invoking the build backend, and
+# `rm`s it after). This avoids modern setuptools' path-sandbox check
+# (rejects `../`-traversal) while keeping the root README.md the single
+# source of truth for the long description.
+
 [build-system]
 requires = ["setuptools>=61.0.0", "wheel>=0.37.0"]
 build-backend = "setuptools.build_meta"
@@ -5,25 +23,25 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "mooncake-transfer-engine"
 version = "0.3.11.post1"
-description = "Python binding of a Mooncake library using pybind11"
+description = "Mooncake is the serving platform for Kimi, a leading LLM service provided by Moonshot AI."
 authors = [
     { name = "Mooncake Authors" }
 ]
 requires-python = ">=3.8"
+readme = "README.md"   # local copy of ../README.md, materialized at build time by scripts/build_wheel.sh
 dependencies = ["aiohttp", "requests", "msgpack"]
-keywords = ["mooncake", "data transfer", "kv cache", "llm inference"]
-classifiers = [
-    "Programming Language :: Python :: 3",
-    "Programming Language :: C++",
-    "Operating System :: POSIX :: Linux",
-]
-readme = ""
+# Single-line arrays: sed-substituted by scripts/build_wheel.sh for each variant.
+keywords = ["mooncake", "transfer-engine", "mooncake-store", "kv-cache", "llm-inference", "disaggregated-inference", "prefill-decode-disaggregation", "kimi", "moonshot-ai", "p2p-transfer", "rdma"]
+classifiers = ["Development Status :: 5 - Production/Stable", "Environment :: GPU :: NVIDIA CUDA", "Intended Audience :: Developers", "Intended Audience :: Science/Research", "License :: OSI Approved :: Apache Software License", "Operating System :: POSIX :: Linux", "Programming Language :: C++", "Programming Language :: Python :: 3", "Programming Language :: Python :: 3 :: Only", "Programming Language :: Python :: 3.10", "Programming Language :: Python :: 3.11", "Programming Language :: Python :: 3.12", "Programming Language :: Python :: 3.13", "Programming Language :: Python :: Implementation :: CPython", "Topic :: Scientific/Engineering :: Artificial Intelligence", "Topic :: System :: Distributed Computing"]
 
 [project.urls]
 Homepage = "https://github.com/kvcache-ai/Mooncake"
 Documentation = "https://kvcache-ai.github.io/Mooncake"
 Source = "https://github.com/kvcache-ai/Mooncake"
 Issues = "https://github.com/kvcache-ai/Mooncake/issues"
+Blog = "https://kvcache.ai/"
+Changelog = "https://github.com/kvcache-ai/Mooncake/releases"
+Slack = "https://join.slack.com/t/mooncake-project/shared_invite/zt-3qx4x35ea-zSSTqTHItHJs9SCoXLOSPA"
 
 [project.scripts]
 mooncake_master = "mooncake.cli:main"

--- a/mooncake-wheel/pyproject.toml
+++ b/mooncake-wheel/pyproject.toml
@@ -23,7 +23,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "mooncake-transfer-engine"
 version = "0.3.11.post1"
-description = "Mooncake is the serving platform for Kimi, a leading LLM service provided by Moonshot AI."
+description = "A KVCache-centric Disaggregated Architecture for large-scale LLM inference and training."
 authors = [
     { name = "Mooncake Authors" }
 ]
@@ -31,7 +31,7 @@ requires-python = ">=3.10"
 readme = "README.md"   # local copy of ../README.md, materialized at build time by scripts/build_wheel.sh
 dependencies = ["aiohttp", "requests", "msgpack"]
 # Single-line arrays: sed-substituted by scripts/build_wheel.sh for each variant.
-keywords = ["mooncake", "transfer-engine", "mooncake-store", "kv-cache", "llm-inference", "disaggregated-inference", "prefill-decode-disaggregation", "kimi", "moonshot-ai", "p2p-transfer", "rdma"]
+keywords = ["mooncake", "transfer engine", "kv cache", "llm inference", "rdma"]
 classifiers = ["Development Status :: 5 - Production/Stable", "Environment :: GPU :: NVIDIA CUDA", "Intended Audience :: Developers", "Intended Audience :: Science/Research", "License :: OSI Approved :: Apache Software License", "Operating System :: POSIX :: Linux", "Programming Language :: C++", "Programming Language :: Python :: 3", "Programming Language :: Python :: 3 :: Only", "Programming Language :: Python :: 3.10", "Programming Language :: Python :: 3.11", "Programming Language :: Python :: 3.12", "Programming Language :: Python :: 3.13", "Programming Language :: Python :: Implementation :: CPython", "Topic :: Scientific/Engineering :: Artificial Intelligence", "Topic :: System :: Distributed Computing"]
 
 [project.urls]
@@ -39,7 +39,7 @@ Homepage = "https://github.com/kvcache-ai/Mooncake"
 Documentation = "https://kvcache-ai.github.io/Mooncake"
 Source = "https://github.com/kvcache-ai/Mooncake"
 Issues = "https://github.com/kvcache-ai/Mooncake/issues"
-Blog = "https://kvcache.ai/"
+Blog = "https://kvcache.ai/blog"
 Changelog = "https://github.com/kvcache-ai/Mooncake/releases"
 Slack = "https://join.slack.com/t/mooncake-project/shared_invite/zt-3qx4x35ea-zSSTqTHItHJs9SCoXLOSPA"
 

--- a/scripts/build_wheel.sh
+++ b/scripts/build_wheel.sh
@@ -160,6 +160,19 @@ echo "Building wheel package..."
 # Build the wheel package
 cd mooncake-wheel
 
+# Materialize a local copy of the root README.md so that
+# `readme = "README.md"` resolves inside this directory. Modern
+# setuptools rejects `../`-traversal in the readme path. The file is
+# removed at the end of the script (the explicit `rm` after `cd ..`).
+cp ../README.md README.md
+
+WHEEL_DIR="$(pwd)"
+cleanup_wheel_metadata_state() {
+    [[ -f "${WHEEL_DIR}/pyproject.toml.backup" ]] && mv "${WHEEL_DIR}/pyproject.toml.backup" "${WHEEL_DIR}/pyproject.toml"
+    rm -f "${WHEEL_DIR}/README.md"
+}
+trap cleanup_wheel_metadata_state EXIT
+
 BUILD_VARIANTS="NON_CUDA_BUILD CU13_BUILD NPU_BUILD EFA_BUILD EFA_NON_CUDA_BUILD MUSA_BUILD"
 BUILD_VARIANT_COUNT=0
 for build_variant in $BUILD_VARIANTS; do
@@ -188,8 +201,9 @@ if [ "$NON_CUDA_BUILD" = "1" ]; then
     cp pyproject.toml pyproject.toml.backup
     # Replace package name and description
     sed -i 's/name = "mooncake-transfer-engine"/name = "mooncake-transfer-engine-non-cuda"/' pyproject.toml
-    sed -i 's/description = "Python binding of a Mooncake library using pybind11"/description = "Python binding of a Mooncake library using pybind11 (Non-CUDA version)"/' pyproject.toml
-    sed -i 's/keywords = \["mooncake", "data transfer", "kv cache", "llm inference"\]/keywords = ["mooncake", "data transfer", "kv cache", "llm inference", "non-cuda"]/' pyproject.toml
+    sed -i 's/description = "Mooncake is the serving platform for Kimi, a leading LLM service provided by Moonshot AI."/description = "Mooncake is the serving platform for Kimi, a leading LLM service provided by Moonshot AI. (Non-CUDA version)"/' pyproject.toml
+    sed -i 's/keywords = \["mooncake", "transfer-engine", "mooncake-store", "kv-cache", "llm-inference", "disaggregated-inference", "prefill-decode-disaggregation", "kimi", "moonshot-ai", "p2p-transfer", "rdma"\]/keywords = ["mooncake", "transfer-engine", "mooncake-store", "kv-cache", "llm-inference", "disaggregated-inference", "prefill-decode-disaggregation", "kimi", "moonshot-ai", "p2p-transfer", "rdma", "non-cuda"]/' pyproject.toml
+    sed -i 's|"Environment :: GPU :: NVIDIA CUDA", ||' pyproject.toml
     echo "Package name modified to: mooncake-transfer-engine-non-cuda"
 elif [ "$CU13_BUILD" = "1" ]; then
     echo "Modifying package name for CU13 build"
@@ -197,8 +211,8 @@ elif [ "$CU13_BUILD" = "1" ]; then
     cp pyproject.toml pyproject.toml.backup
     # Replace package name and description
     sed -i 's/name = "mooncake-transfer-engine"/name = "mooncake-transfer-engine-cuda13"/' pyproject.toml
-    sed -i 's/description = "Python binding of a Mooncake library using pybind11"/description = "Python binding of a Mooncake library using pybind11 (CUDA 13 version)"/' pyproject.toml
-    sed -i 's/keywords = \["mooncake", "data transfer", "kv cache", "llm inference"\]/keywords = ["mooncake", "data transfer", "kv cache", "llm inference", "cuda13"]/' pyproject.toml
+    sed -i 's/description = "Mooncake is the serving platform for Kimi, a leading LLM service provided by Moonshot AI."/description = "Mooncake is the serving platform for Kimi, a leading LLM service provided by Moonshot AI. (CUDA 13 version)"/' pyproject.toml
+    sed -i 's/keywords = \["mooncake", "transfer-engine", "mooncake-store", "kv-cache", "llm-inference", "disaggregated-inference", "prefill-decode-disaggregation", "kimi", "moonshot-ai", "p2p-transfer", "rdma"\]/keywords = ["mooncake", "transfer-engine", "mooncake-store", "kv-cache", "llm-inference", "disaggregated-inference", "prefill-decode-disaggregation", "kimi", "moonshot-ai", "p2p-transfer", "rdma", "cuda13"]/' pyproject.toml
     echo "Package name modified to: mooncake-transfer-engine-cuda13"
 elif [ "$NPU_BUILD" = "1" ]; then
     echo "Modifying package name for Ascend NPU build"
@@ -206,8 +220,10 @@ elif [ "$NPU_BUILD" = "1" ]; then
     cp pyproject.toml pyproject.toml.backup
     # Replace package name and description
     sed -i 's/name = "mooncake-transfer-engine"/name = "mooncake-transfer-engine-npu"/' pyproject.toml
-    sed -i 's/description = "Python binding of a Mooncake library using pybind11"/description = "Python binding of a Mooncake library using pybind11 (Ascend NPU version)"/' pyproject.toml
-    sed -i 's/keywords = \["mooncake", "data transfer", "kv cache", "llm inference"\]/keywords = ["mooncake", "data transfer", "kv cache", "llm inference", "ascend", "npu"]/' pyproject.toml
+    sed -i 's/description = "Mooncake is the serving platform for Kimi, a leading LLM service provided by Moonshot AI."/description = "Mooncake is the serving platform for Kimi, a leading LLM service provided by Moonshot AI. (Ascend NPU version)"/' pyproject.toml
+    sed -i 's/keywords = \["mooncake", "transfer-engine", "mooncake-store", "kv-cache", "llm-inference", "disaggregated-inference", "prefill-decode-disaggregation", "kimi", "moonshot-ai", "p2p-transfer", "rdma"\]/keywords = ["mooncake", "transfer-engine", "mooncake-store", "kv-cache", "llm-inference", "disaggregated-inference", "prefill-decode-disaggregation", "kimi", "moonshot-ai", "p2p-transfer", "rdma", "ascend", "npu"]/' pyproject.toml
+    sed -i 's|"Environment :: GPU :: NVIDIA CUDA"|"Environment :: GPU"|' pyproject.toml
+    sed -i 's|"Programming Language :: Python :: 3.10"|"Programming Language :: Python :: 3.9", "Programming Language :: Python :: 3.10"|' pyproject.toml
     echo "Package name modified to: mooncake-transfer-engine-npu"
 elif [ "$EFA_BUILD" = "1" ]; then
     echo "Modifying package name for AWS EFA build (CUDA)"
@@ -215,8 +231,8 @@ elif [ "$EFA_BUILD" = "1" ]; then
     cp pyproject.toml pyproject.toml.backup
     # Replace package name and description
     sed -i 's/name = "mooncake-transfer-engine"/name = "mooncake-transfer-engine-efa"/' pyproject.toml
-    sed -i 's/description = "Python binding of a Mooncake library using pybind11"/description = "Python binding of a Mooncake library using pybind11 (AWS EFA, CUDA version)"/' pyproject.toml
-    sed -i 's/keywords = \["mooncake", "data transfer", "kv cache", "llm inference"\]/keywords = ["mooncake", "data transfer", "kv cache", "llm inference", "aws", "efa", "libfabric", "cuda"]/' pyproject.toml
+    sed -i 's/description = "Mooncake is the serving platform for Kimi, a leading LLM service provided by Moonshot AI."/description = "Mooncake is the serving platform for Kimi, a leading LLM service provided by Moonshot AI. (AWS EFA, CUDA version)"/' pyproject.toml
+    sed -i 's/keywords = \["mooncake", "transfer-engine", "mooncake-store", "kv-cache", "llm-inference", "disaggregated-inference", "prefill-decode-disaggregation", "kimi", "moonshot-ai", "p2p-transfer", "rdma"\]/keywords = ["mooncake", "transfer-engine", "mooncake-store", "kv-cache", "llm-inference", "disaggregated-inference", "prefill-decode-disaggregation", "kimi", "moonshot-ai", "p2p-transfer", "rdma", "aws", "efa", "libfabric", "cuda"]/' pyproject.toml
     echo "Package name modified to: mooncake-transfer-engine-efa"
 elif [ "$EFA_NON_CUDA_BUILD" = "1" ]; then
     echo "Modifying package name for AWS EFA build (non-CUDA)"
@@ -224,8 +240,9 @@ elif [ "$EFA_NON_CUDA_BUILD" = "1" ]; then
     cp pyproject.toml pyproject.toml.backup
     # Replace package name and description
     sed -i 's/name = "mooncake-transfer-engine"/name = "mooncake-transfer-engine-efa-non-cuda"/' pyproject.toml
-    sed -i 's/description = "Python binding of a Mooncake library using pybind11"/description = "Python binding of a Mooncake library using pybind11 (AWS EFA, Non-CUDA version)"/' pyproject.toml
-    sed -i 's/keywords = \["mooncake", "data transfer", "kv cache", "llm inference"\]/keywords = ["mooncake", "data transfer", "kv cache", "llm inference", "aws", "efa", "libfabric", "non-cuda"]/' pyproject.toml
+    sed -i 's/description = "Mooncake is the serving platform for Kimi, a leading LLM service provided by Moonshot AI."/description = "Mooncake is the serving platform for Kimi, a leading LLM service provided by Moonshot AI. (AWS EFA, Non-CUDA version)"/' pyproject.toml
+    sed -i 's/keywords = \["mooncake", "transfer-engine", "mooncake-store", "kv-cache", "llm-inference", "disaggregated-inference", "prefill-decode-disaggregation", "kimi", "moonshot-ai", "p2p-transfer", "rdma"\]/keywords = ["mooncake", "transfer-engine", "mooncake-store", "kv-cache", "llm-inference", "disaggregated-inference", "prefill-decode-disaggregation", "kimi", "moonshot-ai", "p2p-transfer", "rdma", "aws", "efa", "libfabric", "non-cuda"]/' pyproject.toml
+    sed -i 's|"Environment :: GPU :: NVIDIA CUDA", ||' pyproject.toml
     echo "Package name modified to: mooncake-transfer-engine-efa-non-cuda"
 elif [ "$MUSA_BUILD" = "1" ]; then
     echo "Modifying package name for MUSA build"
@@ -233,8 +250,10 @@ elif [ "$MUSA_BUILD" = "1" ]; then
     cp pyproject.toml pyproject.toml.backup
     # Replace package name and description
     sed -i 's/name = "mooncake-transfer-engine"/name = "mooncake-transfer-engine-musa"/' pyproject.toml
-    sed -i 's/description = "Python binding of a Mooncake library using pybind11"/description = "Python binding of a Mooncake library using pybind11 (MUSA version)"/' pyproject.toml
-    sed -i 's/keywords = \["mooncake", "data transfer", "kv cache", "llm inference"\]/keywords = ["mooncake", "data transfer", "kv cache", "llm inference", "musa", "moore-threads"]/' pyproject.toml
+    sed -i 's/description = "Mooncake is the serving platform for Kimi, a leading LLM service provided by Moonshot AI."/description = "Mooncake is the serving platform for Kimi, a leading LLM service provided by Moonshot AI. (MUSA version)"/' pyproject.toml
+    sed -i 's/keywords = \["mooncake", "transfer-engine", "mooncake-store", "kv-cache", "llm-inference", "disaggregated-inference", "prefill-decode-disaggregation", "kimi", "moonshot-ai", "p2p-transfer", "rdma"\]/keywords = ["mooncake", "transfer-engine", "mooncake-store", "kv-cache", "llm-inference", "disaggregated-inference", "prefill-decode-disaggregation", "kimi", "moonshot-ai", "p2p-transfer", "rdma", "musa", "moore-threads"]/' pyproject.toml
+    sed -i 's|"Environment :: GPU :: NVIDIA CUDA"|"Environment :: GPU"|' pyproject.toml
+    sed -i 's|"Programming Language :: Python :: 3.10"|"Programming Language :: Python :: 3.9", "Programming Language :: Python :: 3.10"|' pyproject.toml
     echo "Package name modified to: mooncake-transfer-engine-musa"
 else
     echo "Using standard package name: mooncake-transfer-engine"
@@ -505,5 +524,8 @@ mv ${REPAIRED_DIR}/*.whl ${OUTPUT_DIR}/
 cd ..
 
 [[ -f mooncake-wheel/pyproject.toml.backup ]] && mv mooncake-wheel/pyproject.toml.backup mooncake-wheel/pyproject.toml
+
+# Remove the staged README.md copy materialized earlier so the working tree stays clean.
+rm -f mooncake-wheel/README.md
 
 echo "Wheel package built and repaired successfully!"

--- a/scripts/build_wheel.sh
+++ b/scripts/build_wheel.sh
@@ -222,6 +222,7 @@ elif [ "$NPU_BUILD" = "1" ]; then
     sed -i 's/name = "mooncake-transfer-engine"/name = "mooncake-transfer-engine-npu"/' pyproject.toml
     sed -i 's/^description = "\(.*\)"$/description = "\1 (Ascend NPU version)"/' pyproject.toml
     sed -i 's/^keywords = \[\(.*\)\]$/keywords = [\1, "ascend", "npu"]/' pyproject.toml
+    sed -i 's/^requires-python = ">=3.10"$/requires-python = ">=3.9"/' pyproject.toml
     sed -i 's|"Environment :: GPU :: NVIDIA CUDA"|"Environment :: GPU"|' pyproject.toml
     sed -i 's|"Programming Language :: Python :: 3.10"|"Programming Language :: Python :: 3.9", "Programming Language :: Python :: 3.10"|' pyproject.toml
     echo "Package name modified to: mooncake-transfer-engine-npu"
@@ -252,6 +253,7 @@ elif [ "$MUSA_BUILD" = "1" ]; then
     sed -i 's/name = "mooncake-transfer-engine"/name = "mooncake-transfer-engine-musa"/' pyproject.toml
     sed -i 's/^description = "\(.*\)"$/description = "\1 (MUSA version)"/' pyproject.toml
     sed -i 's/^keywords = \[\(.*\)\]$/keywords = [\1, "musa", "moore-threads"]/' pyproject.toml
+    sed -i 's/^requires-python = ">=3.10"$/requires-python = ">=3.9"/' pyproject.toml
     sed -i 's|"Environment :: GPU :: NVIDIA CUDA"|"Environment :: GPU"|' pyproject.toml
     sed -i 's|"Programming Language :: Python :: 3.10"|"Programming Language :: Python :: 3.9", "Programming Language :: Python :: 3.10"|' pyproject.toml
     echo "Package name modified to: mooncake-transfer-engine-musa"

--- a/scripts/build_wheel.sh
+++ b/scripts/build_wheel.sh
@@ -163,7 +163,7 @@ cd mooncake-wheel
 # Materialize a local copy of the root README.md so that
 # `readme = "README.md"` resolves inside this directory. Modern
 # setuptools rejects `../`-traversal in the readme path. The file is
-# removed at the end of the script (the explicit `rm` after `cd ..`).
+# removed by the EXIT trap below.
 cp ../README.md README.md
 
 WHEEL_DIR="$(pwd)"
@@ -201,8 +201,8 @@ if [ "$NON_CUDA_BUILD" = "1" ]; then
     cp pyproject.toml pyproject.toml.backup
     # Replace package name and description
     sed -i 's/name = "mooncake-transfer-engine"/name = "mooncake-transfer-engine-non-cuda"/' pyproject.toml
-    sed -i 's/description = "Mooncake is the serving platform for Kimi, a leading LLM service provided by Moonshot AI."/description = "Mooncake is the serving platform for Kimi, a leading LLM service provided by Moonshot AI. (Non-CUDA version)"/' pyproject.toml
-    sed -i 's/keywords = \["mooncake", "transfer-engine", "mooncake-store", "kv-cache", "llm-inference", "disaggregated-inference", "prefill-decode-disaggregation", "kimi", "moonshot-ai", "p2p-transfer", "rdma"\]/keywords = ["mooncake", "transfer-engine", "mooncake-store", "kv-cache", "llm-inference", "disaggregated-inference", "prefill-decode-disaggregation", "kimi", "moonshot-ai", "p2p-transfer", "rdma", "non-cuda"]/' pyproject.toml
+    sed -i 's/^description = "\(.*\)"$/description = "\1 (Non-CUDA version)"/' pyproject.toml
+    sed -i 's/^keywords = \[\(.*\)\]$/keywords = [\1, "non-cuda"]/' pyproject.toml
     sed -i 's|"Environment :: GPU :: NVIDIA CUDA", ||' pyproject.toml
     echo "Package name modified to: mooncake-transfer-engine-non-cuda"
 elif [ "$CU13_BUILD" = "1" ]; then
@@ -211,8 +211,8 @@ elif [ "$CU13_BUILD" = "1" ]; then
     cp pyproject.toml pyproject.toml.backup
     # Replace package name and description
     sed -i 's/name = "mooncake-transfer-engine"/name = "mooncake-transfer-engine-cuda13"/' pyproject.toml
-    sed -i 's/description = "Mooncake is the serving platform for Kimi, a leading LLM service provided by Moonshot AI."/description = "Mooncake is the serving platform for Kimi, a leading LLM service provided by Moonshot AI. (CUDA 13 version)"/' pyproject.toml
-    sed -i 's/keywords = \["mooncake", "transfer-engine", "mooncake-store", "kv-cache", "llm-inference", "disaggregated-inference", "prefill-decode-disaggregation", "kimi", "moonshot-ai", "p2p-transfer", "rdma"\]/keywords = ["mooncake", "transfer-engine", "mooncake-store", "kv-cache", "llm-inference", "disaggregated-inference", "prefill-decode-disaggregation", "kimi", "moonshot-ai", "p2p-transfer", "rdma", "cuda13"]/' pyproject.toml
+    sed -i 's/^description = "\(.*\)"$/description = "\1 (CUDA 13 version)"/' pyproject.toml
+    sed -i 's/^keywords = \[\(.*\)\]$/keywords = [\1, "cuda13"]/' pyproject.toml
     echo "Package name modified to: mooncake-transfer-engine-cuda13"
 elif [ "$NPU_BUILD" = "1" ]; then
     echo "Modifying package name for Ascend NPU build"
@@ -220,8 +220,8 @@ elif [ "$NPU_BUILD" = "1" ]; then
     cp pyproject.toml pyproject.toml.backup
     # Replace package name and description
     sed -i 's/name = "mooncake-transfer-engine"/name = "mooncake-transfer-engine-npu"/' pyproject.toml
-    sed -i 's/description = "Mooncake is the serving platform for Kimi, a leading LLM service provided by Moonshot AI."/description = "Mooncake is the serving platform for Kimi, a leading LLM service provided by Moonshot AI. (Ascend NPU version)"/' pyproject.toml
-    sed -i 's/keywords = \["mooncake", "transfer-engine", "mooncake-store", "kv-cache", "llm-inference", "disaggregated-inference", "prefill-decode-disaggregation", "kimi", "moonshot-ai", "p2p-transfer", "rdma"\]/keywords = ["mooncake", "transfer-engine", "mooncake-store", "kv-cache", "llm-inference", "disaggregated-inference", "prefill-decode-disaggregation", "kimi", "moonshot-ai", "p2p-transfer", "rdma", "ascend", "npu"]/' pyproject.toml
+    sed -i 's/^description = "\(.*\)"$/description = "\1 (Ascend NPU version)"/' pyproject.toml
+    sed -i 's/^keywords = \[\(.*\)\]$/keywords = [\1, "ascend", "npu"]/' pyproject.toml
     sed -i 's|"Environment :: GPU :: NVIDIA CUDA"|"Environment :: GPU"|' pyproject.toml
     sed -i 's|"Programming Language :: Python :: 3.10"|"Programming Language :: Python :: 3.9", "Programming Language :: Python :: 3.10"|' pyproject.toml
     echo "Package name modified to: mooncake-transfer-engine-npu"
@@ -231,8 +231,8 @@ elif [ "$EFA_BUILD" = "1" ]; then
     cp pyproject.toml pyproject.toml.backup
     # Replace package name and description
     sed -i 's/name = "mooncake-transfer-engine"/name = "mooncake-transfer-engine-efa"/' pyproject.toml
-    sed -i 's/description = "Mooncake is the serving platform for Kimi, a leading LLM service provided by Moonshot AI."/description = "Mooncake is the serving platform for Kimi, a leading LLM service provided by Moonshot AI. (AWS EFA, CUDA version)"/' pyproject.toml
-    sed -i 's/keywords = \["mooncake", "transfer-engine", "mooncake-store", "kv-cache", "llm-inference", "disaggregated-inference", "prefill-decode-disaggregation", "kimi", "moonshot-ai", "p2p-transfer", "rdma"\]/keywords = ["mooncake", "transfer-engine", "mooncake-store", "kv-cache", "llm-inference", "disaggregated-inference", "prefill-decode-disaggregation", "kimi", "moonshot-ai", "p2p-transfer", "rdma", "aws", "efa", "libfabric", "cuda"]/' pyproject.toml
+    sed -i 's/^description = "\(.*\)"$/description = "\1 (AWS EFA, CUDA version)"/' pyproject.toml
+    sed -i 's/^keywords = \[\(.*\)\]$/keywords = [\1, "aws", "efa", "libfabric", "cuda"]/' pyproject.toml
     echo "Package name modified to: mooncake-transfer-engine-efa"
 elif [ "$EFA_NON_CUDA_BUILD" = "1" ]; then
     echo "Modifying package name for AWS EFA build (non-CUDA)"
@@ -240,8 +240,8 @@ elif [ "$EFA_NON_CUDA_BUILD" = "1" ]; then
     cp pyproject.toml pyproject.toml.backup
     # Replace package name and description
     sed -i 's/name = "mooncake-transfer-engine"/name = "mooncake-transfer-engine-efa-non-cuda"/' pyproject.toml
-    sed -i 's/description = "Mooncake is the serving platform for Kimi, a leading LLM service provided by Moonshot AI."/description = "Mooncake is the serving platform for Kimi, a leading LLM service provided by Moonshot AI. (AWS EFA, Non-CUDA version)"/' pyproject.toml
-    sed -i 's/keywords = \["mooncake", "transfer-engine", "mooncake-store", "kv-cache", "llm-inference", "disaggregated-inference", "prefill-decode-disaggregation", "kimi", "moonshot-ai", "p2p-transfer", "rdma"\]/keywords = ["mooncake", "transfer-engine", "mooncake-store", "kv-cache", "llm-inference", "disaggregated-inference", "prefill-decode-disaggregation", "kimi", "moonshot-ai", "p2p-transfer", "rdma", "aws", "efa", "libfabric", "non-cuda"]/' pyproject.toml
+    sed -i 's/^description = "\(.*\)"$/description = "\1 (AWS EFA, Non-CUDA version)"/' pyproject.toml
+    sed -i 's/^keywords = \[\(.*\)\]$/keywords = [\1, "aws", "efa", "libfabric", "non-cuda"]/' pyproject.toml
     sed -i 's|"Environment :: GPU :: NVIDIA CUDA", ||' pyproject.toml
     echo "Package name modified to: mooncake-transfer-engine-efa-non-cuda"
 elif [ "$MUSA_BUILD" = "1" ]; then
@@ -250,8 +250,8 @@ elif [ "$MUSA_BUILD" = "1" ]; then
     cp pyproject.toml pyproject.toml.backup
     # Replace package name and description
     sed -i 's/name = "mooncake-transfer-engine"/name = "mooncake-transfer-engine-musa"/' pyproject.toml
-    sed -i 's/description = "Mooncake is the serving platform for Kimi, a leading LLM service provided by Moonshot AI."/description = "Mooncake is the serving platform for Kimi, a leading LLM service provided by Moonshot AI. (MUSA version)"/' pyproject.toml
-    sed -i 's/keywords = \["mooncake", "transfer-engine", "mooncake-store", "kv-cache", "llm-inference", "disaggregated-inference", "prefill-decode-disaggregation", "kimi", "moonshot-ai", "p2p-transfer", "rdma"\]/keywords = ["mooncake", "transfer-engine", "mooncake-store", "kv-cache", "llm-inference", "disaggregated-inference", "prefill-decode-disaggregation", "kimi", "moonshot-ai", "p2p-transfer", "rdma", "musa", "moore-threads"]/' pyproject.toml
+    sed -i 's/^description = "\(.*\)"$/description = "\1 (MUSA version)"/' pyproject.toml
+    sed -i 's/^keywords = \[\(.*\)\]$/keywords = [\1, "musa", "moore-threads"]/' pyproject.toml
     sed -i 's|"Environment :: GPU :: NVIDIA CUDA"|"Environment :: GPU"|' pyproject.toml
     sed -i 's|"Programming Language :: Python :: 3.10"|"Programming Language :: Python :: 3.9", "Programming Language :: Python :: 3.10"|' pyproject.toml
     echo "Package name modified to: mooncake-transfer-engine-musa"
@@ -522,10 +522,5 @@ rm -f ${OUTPUT_DIR}/*.whl
 mv ${REPAIRED_DIR}/*.whl ${OUTPUT_DIR}/
 
 cd ..
-
-[[ -f mooncake-wheel/pyproject.toml.backup ]] && mv mooncake-wheel/pyproject.toml.backup mooncake-wheel/pyproject.toml
-
-# Remove the staged README.md copy materialized earlier so the working tree stays clean.
-rm -f mooncake-wheel/README.md
 
 echo "Wheel package built and repaired successfully!"


### PR DESCRIPTION
## Description

Enriches the PyPI metadata for `mooncake-transfer-engine` and its wheel variants.

Changes include:
- Adds a clearer package summary, root README long description, expanded keywords, classifiers, and project URLs.
- Uses a temporary build-time copy of the root `README.md` so setuptools can include it as the PyPI long description.
- Keeps `requires-python` unchanged at `>=3.8`.
- Updates variant metadata so:
  - non-CUDA and EFA non-CUDA wheels do not advertise NVIDIA CUDA.
  - NPU and MUSA wheels use the generic GPU classifier and include Python 3.9.
  - CUDA, CUDA 13, and EFA CUDA wheels keep the NVIDIA CUDA classifier.

No related issue.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [x] Other

## How Has This Been Tested?

- Validated shell syntax:
  ```bash
  bash -n scripts/build_wheel.sh
  ```

- Built the wheel and verified with Twine:
  ```bash
  python3 -m twine check mooncake-wheel/dist-test/*.whl
  ```

- Verified failure-path cleanup for temporary wheel metadata files; confirmed `mooncake-wheel/README.md` and `mooncake-wheel/pyproject.toml.backup` are not left behind after the build script exits.

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [ ] AI tools were used (specify below)