### PR TITLE
[CI] publish master image to Docker Hub via manual workflow

### DIFF
--- a/.github/workflows/publish-master-image.yaml
+++ b/.github/workflows/publish-master-image.yaml
@@ -1,0 +1,89 @@
+name: Publish Master Image
+
+# Manual trigger only: this installs an already-published PyPI wheel, so it must be
+# run after that version's wheel is published — avoids racing release.yaml, which builds
+# and publishes the wheel in the same v* tag event.
+on:
+  workflow_dispatch:
+    inputs:
+      mooncake_version:
+        description: "Published mooncake-transfer-engine version (also the image tag), e.g. 0.3.11.post1"
+        required: true
+        type: string
+      pip_index_url:
+        description: "pip index URL"
+        required: false
+        default: "https://pypi.org/simple"
+        type: string
+      tag_latest:
+        description: "Also tag :latest"
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  publish-master:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Free up disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /usr/local/lib/android
+          df -h
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          # For an org access token (OAT), the login username is the org name
+          # (Docker: docker login --username <ORG_NAME>) — not a secret.
+          username: kvcacheai
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: tags
+        run: |
+          REPO="docker.io/kvcacheai/mooncake"
+          TAGS="${REPO}:${{ inputs.mooncake_version }}"
+          if [ "${{ inputs.tag_latest }}" = "true" ]; then
+            TAGS="${TAGS}"$'\n'"${REPO}:latest"
+          fi
+          {
+            echo "tags<<EOF"
+            echo "${TAGS}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build and push (multi-arch)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/master.Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            MOONCAKE_VERSION=${{ inputs.mooncake_version }}
+            PIP_INDEX_URL=${{ inputs.pip_index_url }}
+          tags: ${{ steps.tags.outputs.tags }}
+
+      - name: Smoke test (amd64 import)
+        run: |
+          docker run --rm --platform linux/amd64 \
+            "docker.io/kvcacheai/mooncake:${{ inputs.mooncake_version }}" \
+            python3 -c "import mooncake.engine, mooncake.store; print('ok')"

--- a/.github/workflows/publish-master-image.yaml
+++ b/.github/workflows/publish-master-image.yaml
@@ -3,6 +3,12 @@ name: Publish Master Image
 # Manual trigger only: this installs an already-published PyPI wheel, so it must be
 # run after that version's wheel is published — avoids racing release.yaml, which builds
 # and publishes the wheel in the same v* tag event.
+#
+# Publish flow: validate input -> confirm amd64+arm64 wheels exist -> build multi-arch
+# and push the :<version> tag -> smoke-test amd64 AND arm64 -> only then promote :latest
+# (when requested). :latest is copied from the smoked :<version> digest, so the default
+# pull tag can never point at an image that failed smoke. A failed smoke still leaves the
+# :<version> tag public; since this is manual, delete it from Docker Hub by hand.
 on:
   workflow_dispatch:
     inputs:
@@ -10,28 +16,71 @@ on:
         description: "Published mooncake-transfer-engine version (also the image tag), e.g. 0.3.11.post1"
         required: true
         type: string
-      pip_index_url:
-        description: "pip index URL"
-        required: false
-        default: "https://pypi.org/simple"
-        type: string
       tag_latest:
-        description: "Also tag :latest"
+        description: "Also move :latest to this build. Only enable when publishing the newest release (a backfill/retry of an older wheel must NOT move :latest)."
         required: false
-        default: true
+        default: false
         type: boolean
 
 permissions:
   contents: read
 
+# Serialize publishes so two concurrent runs can't interleave and move :latest backwards.
+concurrency:
+  group: publish-master-image
+  cancel-in-progress: false
+
 jobs:
   publish-master:
     runs-on: ubuntu-22.04
+    env:
+      REPO: docker.io/kvcacheai/mooncake
+      # inputs.* placed in env (not interpolated into shell source) — injection-safe.
+      MOONCAKE_VERSION: ${{ inputs.mooncake_version }}
+      # Pinned for the official image: provenance must always be the public PyPI index.
+      # Debug builds against another index belong in a separate workflow that does NOT
+      # push official kvcacheai/mooncake tags.
+      PIP_INDEX_URL: https://pypi.org/simple
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+
+      - name: Validate mooncake_version
+        run: |
+          if ! printf '%s' "$MOONCAKE_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(\.post[0-9]+)?$'; then
+            echo "Invalid mooncake_version '$MOONCAKE_VERSION': expected e.g. 0.3.11 or 0.3.11.post1" >&2
+            exit 1
+          fi
+
+      # This image is intentionally the CPython 3.12 flavor: master.Dockerfile pins
+      # python:3.12-slim-trixie, so only cp312 wheels are ABI-compatible. If that base
+      # Python is ever bumped (e.g. to 3.13), update the "cp312" match below to match —
+      # otherwise this preflight would green-light wheels the image cannot import.
+      - name: Confirm cp312 amd64+arm64 wheels are published on PyPI
+        run: |
+          python3 - <<'PY'
+          import json, os, sys, urllib.request
+          v = os.environ["MOONCAKE_VERSION"]
+          url = f"https://pypi.org/pypi/mooncake-transfer-engine/{v}/json"
+          try:
+              data = json.load(urllib.request.urlopen(url, timeout=30))
+          except Exception as e:
+              sys.exit(f"Cannot fetch PyPI metadata for {v}: {e}")
+          arch_ok = {"x86_64": False, "aarch64": False}
+          for f in data.get("urls", []):
+              fn = f.get("filename", "")
+              if fn.endswith(".whl") and "cp312" in fn:
+                  for arch in arch_ok:
+                      if arch in fn:
+                          arch_ok[arch] = True
+          missing = [a for a, ok in arch_ok.items() if not ok]
+          if missing:
+              sys.exit(f"Missing cp312 wheel(s) for {v}: {missing}. "
+                       "Both amd64 (x86_64) and arm64 (aarch64) must be published first.")
+          print(f"cp312 amd64+arm64 wheels present for {v}")
+          PY
 
       - name: Free up disk space
         run: |
@@ -56,34 +105,62 @@ jobs:
           username: kvcacheai
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Compute image tags
-        id: tags
-        run: |
-          REPO="docker.io/kvcacheai/mooncake"
-          TAGS="${REPO}:${{ inputs.mooncake_version }}"
-          if [ "${{ inputs.tag_latest }}" = "true" ]; then
-            TAGS="${TAGS}"$'\n'"${REPO}:latest"
-          fi
-          {
-            echo "tags<<EOF"
-            echo "${TAGS}"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Build and push (multi-arch)
+      # Build multi-arch and push ONLY the immutable :<version> tag. :latest is promoted
+      # in a later step, after smoke passes. provenance/sbom disabled to keep the index
+      # free of unknown/unknown attestation entries (they would otherwise show up in
+      # `imagetools inspect`).
+      - name: Build and push :<version> (multi-arch)
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
           file: docker/master.Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: true
+          provenance: false
+          sbom: false
           build-args: |
             MOONCAKE_VERSION=${{ inputs.mooncake_version }}
-            PIP_INDEX_URL=${{ inputs.pip_index_url }}
-          tags: ${{ steps.tags.outputs.tags }}
+            PIP_INDEX_URL=${{ env.PIP_INDEX_URL }}
+          tags: ${{ env.REPO }}:${{ inputs.mooncake_version }}
+          push: true
 
-      - name: Smoke test (amd64 import)
+      # Smoke tests run AFTER the :<version> push (a failed smoke leaves :<version> public
+      # — delete it from Docker Hub by hand; this manual workflow wires no auto-cleanup).
+      # :latest is NOT pushed yet, so a bad build can never poison the default pull tag.
+      # We exercise real entrypoints, not just imports: `mooncake_master --version` runs the
+      # compiled binary through the console-script/cli.py path and exits 0 (gflags
+      # SetVersionString) — note `--help` would exit 1 under gflags, so --version is used.
+      # `mooncake_http_metadata_server --help` (argparse) exits 0 and proves that entrypoint.
+      - name: Smoke test amd64 (entrypoints)
         run: |
           docker run --rm --platform linux/amd64 \
-            "docker.io/kvcacheai/mooncake:${{ inputs.mooncake_version }}" \
-            python3 -c "import mooncake.engine, mooncake.store; print('ok')"
+            "${REPO}:${MOONCAKE_VERSION}" bash -c '
+              set -euo pipefail
+              python3 -c "import mooncake.engine, mooncake.store"
+              mooncake_master --version
+              mooncake_http_metadata_server --help >/dev/null
+              echo "amd64 ok"
+            '
+
+      # arm64 is the riskier arch here: the aarch64 wheel is manylinux_2_39 (glibc >= 2.39),
+      # which is the whole reason master.Dockerfile pins a trixie base. Smoke it under QEMU.
+      - name: Smoke test arm64 (entrypoints, QEMU)
+        run: |
+          docker run --rm --platform linux/arm64 \
+            "${REPO}:${MOONCAKE_VERSION}" bash -c '
+              set -euo pipefail
+              python3 -c "import mooncake.engine, mooncake.store"
+              mooncake_master --version
+              mooncake_http_metadata_server --help >/dev/null
+              echo "arm64 ok"
+            '
+
+      # Promote :latest ONLY after both arches pass smoke, and only when explicitly
+      # requested. imagetools create copies the tested :<version> manifest by digest
+      # (no rebuild), so :latest can never point at an image that didn't pass smoke.
+      - name: Promote :latest (post-smoke)
+        if: ${{ inputs.tag_latest }}
+        run: |
+          docker buildx imagetools create \
+            --tag "${REPO}:latest" \
+            "${REPO}:${MOONCAKE_VERSION}"

--- a/docker/master.Dockerfile
+++ b/docker/master.Dockerfile
@@ -1,0 +1,40 @@
+# syntax=docker/dockerfile:1
+
+# Stage cudalibs: take stub libcuda and libcudart from the CUDA devel image
+FROM nvidia/cuda:12.8.1-devel-ubuntu22.04@sha256:a99a1860ba8e2916e5c3e73b72ec4c4301653a84586e05bfc9a2aa2d58027e97 AS cudalibs
+
+# Final image. Must be trixie (glibc 2.41): the aarch64 wheel is manylinux_2_39
+# (needs glibc >= 2.39), which bookworm (2.36) cannot satisfy.
+FROM python:3.12-slim-trixie@sha256:d764629ce0ddd8c71fd371e9901efb324a95789d2315a47db7e4d27e78f1b0e9
+
+# Build args: mooncake version, pip index URL
+ARG MOONCAKE_VERSION
+ARG PIP_INDEX_URL=https://pypi.org/simple
+
+# Install runtime system libraries and tini
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates libibverbs1 libnuma1 libcurl4t64 libstdc++6 tini \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy stub libcuda and libcudart into the loader's default path, refresh the link cache
+COPY --from=cudalibs /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/lib/libcuda.so.1
+COPY --from=cudalibs /usr/local/cuda/lib64/libcudart.so.12  /usr/local/lib/libcudart.so.12
+RUN ldconfig
+
+# Install mooncake, remove torch EP/PG extensions (ep_*/pg_*), chown the package dir to uid 65532 (all in one layer)
+RUN pip install --no-cache-dir --index-url "${PIP_INDEX_URL}" \
+        mooncake-transfer-engine==${MOONCAKE_VERSION} \
+    && PKG="$(python3 -c 'import mooncake,os;print(os.path.dirname(mooncake.__file__))')" \
+    && rm -f "$PKG"/ep_*.so "$PKG"/pg_*.so \
+    && chown -R 65532:65532 "$PKG"
+
+# Create a HOME owned by uid 65532 and set it as WORKDIR
+ENV HOME=/home/nonroot
+RUN mkdir -p /home/nonroot && chown 65532:65532 /home/nonroot
+WORKDIR /home/nonroot
+
+USER 65532:65532
+
+# tini as PID 1 to forward signals; default into bash
+ENTRYPOINT ["tini", "-g", "--"]
+CMD ["bash"]


### PR DESCRIPTION
## Description

Adds a manually-triggered (`workflow_dispatch`) GitHub Actions workflow that builds a
multi-architecture (`linux/amd64,linux/arm64`) image from an **already-published**
`mooncake-transfer-engine` wheel and pushes it to `docker.io/kvcacheai/mooncake`,
tagged with the wheel version (and optionally `:latest`).

Two files:
- **`docker/master.Dockerfile`** — a no-GPU image: a stub `libcuda.so.1` satisfies dynamic
  linking, it installs the published wheel, drops the torch EP/PG extensions (`ep_*/pg_*`),
  and runs as uid 65532 under `tini`. Usable to run `mooncake_master` / the HTTP metadata
  server / import checks on nodes without a GPU or driver.
- **`.github/workflows/publish-master-image.yaml`** — `setup-qemu` + `buildx` + Docker Hub
  login + `build-push-action` + an amd64 `import` smoke test.

Inputs: `mooncake_version` (required; also the image tag), `pip_index_url`
(default `https://pypi.org/simple`), `tag_latest` (default `true`).

**Manual-only trigger** is intentional: the image installs a published wheel, so it must run
*after* that version's wheel is on the index. Listening on `v*` tags would race the
release workflow that publishes the wheel in the same tag event.

> Note: this `docker/master.Dockerfile` installs a published wheel and is distinct from a
> source-built master image — same role, different build method.

**Prerequisites for running the workflow:**
- The target `mooncake_version` wheel is already published to `pip_index_url`.
- Repo secret `DOCKERHUB_TOKEN` is set to an organization access token (Read & Write) for
  `kvcacheai/mooncake`. Login username is the org name `kvcacheai` (hardcoded, not a secret).

## Module

- [x] CI/CD
- [x] Other — container image / deployment

## Type of Change

- [x] New feature

## How Has This Been Tested?

Static validation has been done locally; the end-to-end run (multi-arch build, push, smoke)
requires the `DOCKERHUB_TOKEN` secret and is exercised by running the workflow after merge
(a `workflow_dispatch` workflow only appears on the default branch).

**Test commands (static, run locally):**
```bash
# Workflow YAML parses
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/publish-master-image.yaml'))"

# Dockerfile has no host-path COPY (build context-independent; only --from=<stage>)
grep -nE '^\s*COPY\s' docker/master.Dockerfile
```

**Post-merge acceptance (to run via `workflow_dispatch`):**
```bash
gh workflow run publish-master-image.yaml -f mooncake_version=<published-version> -f tag_latest=true
docker buildx imagetools inspect docker.io/kvcacheai/mooncake:<published-version>   # expect amd64 + arm64
# workflow's smoke step prints: ok
```

**Test results:**
- [ ] Unit tests pass — N/A (no unit-testable code; CI workflow + Dockerfile only)
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done — workflow YAML parses; Dockerfile build-args match the workflow,
      `file:` path resolves, no context `COPY`. Full build/push/smoke pending the first
      `workflow_dispatch` run (needs the secret).

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh` — N/A (Dockerfile + YAML)
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective — verification is the workflow's
      own amd64 import smoke step
- [x] For changes >500 LOC: I have filed an RFC issue — N/A (126 LOC)

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

Claude Code assisted with the design, the workflow/Dockerfile authoring, and review. The
submitter is responsible for understanding and defending all changes.