### PR TITLE
[Bugfix] Remove duplicate replica erase in PutRevoke

### DIFF
--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -3187,14 +3187,6 @@ auto MasterService::PutRevoke(const UUID& client_id, const std::string& key,
         metadata.reserved_quota_charge_bytes = 0;
     }
 
-    EraseReplicasWithCacheTotalAccounting(
-        metadata, [replica_type](const Replica& replica) {
-            if (replica_type == ReplicaType::ALL) {
-                return replica.is_memory_replica() || replica.is_nof_replica();
-            }
-            return replica.type() == replica_type;
-        });
-
     // If the object is completed, remove it from the processing set.
     if (metadata.AllReplicas(&Replica::fn_is_completed) &&
         accessor.InProcessing()) {


### PR DESCRIPTION
## Description

Remove a duplicate `EraseReplicasWithCacheTotalAccounting` call in `PutRevoke`.

The first call already removes the matching replicas and performs cache-total accounting, local disk usage cleanup, and quota adjustment bookkeeping. The second call uses the same predicate immediately afterward, so it cannot remove additional replicas and only repeats the accounting sync path unnecessarily.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other