### PR TITLE
[Store] Retry transient promotion candidates

### DIFF
--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1203,6 +1203,34 @@ class MasterService {
         UUID holder_id;  // owner of source LOCAL_DISK; only Notifier allowed
     };
 
+    enum class PromotionQueueResult {
+        kQueued,
+        kDisabled,
+        kFrequencyRejected,
+        kWatermarkRejected,
+        kNotFound,
+        kAlreadyInFlight,
+        kMemoryReplicaPresent,
+        kQueueCapRejected,
+        kNoLocalDiskSource,
+        kPushFailed,
+    };
+
+    enum class PromotionCandidateReason {
+        kWatermark,
+        kQueueCap,
+        kPushFailed,
+    };
+
+    struct PromotionCandidate {
+        std::chrono::system_clock::time_point first_seen;
+        std::chrono::system_clock::time_point next_retry_time;
+        uint32_t retry_attempts{0};
+        PromotionCandidateReason last_reason{
+            PromotionCandidateReason::kQueueCap};
+        ErrorCode last_error{ErrorCode::OK};
+    };
+
     static constexpr size_t kNumShards = 1024;  // Number of metadata shards
 
     struct TenantState {
@@ -1212,6 +1240,8 @@ class MasterService {
             replication_tasks;
         std::unordered_map<std::string, const OffloadingTask> offloading_tasks;
         std::unordered_map<std::string, PromotionTask> promotion_tasks;
+        std::unordered_map<std::string, PromotionCandidate>
+            promotion_candidates;
 
         std::unordered_map<std::string, std::unordered_set<std::string>>
             group_members;  // group_id → set of keys
@@ -1219,7 +1249,8 @@ class MasterService {
         bool Empty() const {
             return metadata.empty() && processing_keys.empty() &&
                    replication_tasks.empty() && offloading_tasks.empty() &&
-                   promotion_tasks.empty() && group_members.empty();
+                   promotion_tasks.empty() && promotion_candidates.empty() &&
+                   group_members.empty();
         }
     };
 
@@ -1513,7 +1544,26 @@ class MasterService {
      * map. Acquires its own RW shard accessor; safe to call after
      * GetReplicaList's RO accessor has been released.
      */
-    void TryPushPromotionQueue(const ObjectIdentity& object_id);
+    PromotionQueueResult TryPushPromotionQueue(const ObjectIdentity& object_id,
+                                               bool record_candidate = true);
+    void RecordPromotionCandidate(TenantState& tenant_state,
+                                  const std::string& key,
+                                  PromotionCandidateReason reason,
+                                  ErrorCode last_error);
+    void DecrementPromotionCandidateCount();
+    void ErasePromotionCandidate(TenantState& tenant_state,
+                                 const std::string& key);
+    void ErasePromotionCandidate(const ObjectIdentity& object_id);
+    void ClearPromotionTransientStateForMetadataReload();
+    bool IsTransientPromotionQueueResult(PromotionQueueResult result) const;
+    std::chrono::milliseconds PromotionCandidateBackoff(
+        uint32_t retry_attempts) const;
+    void BackoffPromotionCandidate(const ObjectIdentity& object_id,
+                                   PromotionQueueResult result);
+    size_t RunPromotionCandidateRetry(size_t max_shards_to_scan);
+    size_t RunPromotionCandidateRetry();
+    size_t RunPromotionCandidateRetryForTesting();
+    size_t CountPromotionCandidatesForTesting(const std::string& tenant_id);
 
     // Erase any in-flight PromotionTask for `key`, abort any staged promotion
     // quota reservation, and decrement the cluster-wide in-flight counter. Safe
@@ -1926,6 +1976,21 @@ class MasterService {
     // promotion task reaper after the task entry is erased. Relaxed memory
     // order is safe — the value is an advisory soft cap, not a barrier.
     std::atomic<uint64_t> promotion_in_flight_{0};
+    std::atomic<uint64_t> promotion_candidate_count_{0};
+    std::atomic<uint64_t> promotion_candidate_recorded_{0};
+    std::atomic<uint64_t> promotion_candidate_retry_attempted_{0};
+    std::atomic<uint64_t> promotion_candidate_retry_queued_{0};
+    std::atomic<uint64_t> promotion_candidate_gave_up_{0};
+    std::atomic<size_t> promotion_retry_cursor_shard_{0};
+    static constexpr size_t kPromotionCandidateLimit = 50000;
+    static constexpr uint32_t kPromotionCandidateMaxAttempts = 8;
+    static constexpr size_t kPromotionRetryScanBatch = 128;
+    static constexpr size_t kPromotionRetryShardScanBatch = 64;
+    static constexpr std::chrono::milliseconds kPromotionCandidateTtl{60000};
+    static constexpr std::chrono::milliseconds
+        kPromotionCandidateInitialBackoff{10};
+    static constexpr std::chrono::milliseconds kPromotionCandidateMaxBackoff{
+        1000};
     // Master-side frequency sketch. Constructed only when promotion_on_hit_ is
     // true. CountMinSketch is mutex-protected internally so we can call into it
     // from any GetReplicaList caller without additional locking.

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -1763,6 +1763,7 @@ MasterService::EraseMetadata(
             AbortTenantQuota(tenant_id, metadata.reserved_quota_charge_bytes);
             break;
     }
+    ErasePromotionCandidate(tenant_state, key);
     auto next = tenant_state.metadata.erase(it);
     DecrementTenantMetadataObjectCount(tenant_id);
     if (had_completed_disk && shard) {
@@ -5095,9 +5096,303 @@ tl::expected<void, ErrorCode> MasterService::PushPromotionQueue(
     return {};
 }
 
-void MasterService::TryPushPromotionQueue(const ObjectIdentity& object_id) {
-    if (!promotion_on_hit_ || !promotion_sketch_) {
+void MasterService::ErasePromotionCandidate(TenantState& tenant_state,
+                                            const std::string& key) {
+    if (tenant_state.promotion_candidates.erase(key) > 0) {
+        DecrementPromotionCandidateCount();
+    }
+}
+
+void MasterService::DecrementPromotionCandidateCount() {
+    // The counter is advisory; keep it from wrapping if a metadata reload reset
+    // races with a stale candidate cleanup path.
+    uint64_t count = promotion_candidate_count_.load(std::memory_order_relaxed);
+    while (count > 0) {
+        if (promotion_candidate_count_.compare_exchange_weak(
+                count, count - 1, std::memory_order_relaxed)) {
+            return;
+        }
+    }
+}
+
+void MasterService::ErasePromotionCandidate(const ObjectIdentity& object_id) {
+    MetadataShardAccessorRW shard(
+        this, getMetadataShardIndex(object_id.tenant_id, object_id.user_key));
+    auto tenant_it = shard->tenants.find(object_id.tenant_id);
+    if (tenant_it == shard->tenants.end()) {
         return;
+    }
+    ErasePromotionCandidate(tenant_it->second, object_id.user_key);
+    if (tenant_it->second.Empty()) {
+        shard->tenants.erase(tenant_it);
+    }
+}
+
+void MasterService::ClearPromotionTransientStateForMetadataReload() {
+    for (auto& shard : metadata_shards_) {
+        for (auto& [tenant_id, tenant_state] : shard.tenants) {
+            (void)tenant_id;
+            tenant_state.promotion_candidates.clear();
+        }
+    }
+    const uint64_t in_flight =
+        promotion_in_flight_.exchange(0, std::memory_order_relaxed);
+    if (in_flight > 0) {
+        MasterMetricManager::instance().dec_promotion_in_flight(
+            static_cast<int64_t>(in_flight));
+    }
+    promotion_candidate_count_.store(0, std::memory_order_relaxed);
+    promotion_retry_cursor_shard_.store(0, std::memory_order_relaxed);
+}
+
+void MasterService::RecordPromotionCandidate(TenantState& tenant_state,
+                                             const std::string& key,
+                                             PromotionCandidateReason reason,
+                                             ErrorCode last_error) {
+    const auto now = std::chrono::system_clock::now();
+    auto candidate_it = tenant_state.promotion_candidates.find(key);
+    if (candidate_it == tenant_state.promotion_candidates.end()) {
+        bool reserved_candidate_slot = false;
+        uint64_t candidate_count =
+            promotion_candidate_count_.load(std::memory_order_relaxed);
+        while (candidate_count < kPromotionCandidateLimit) {
+            if (promotion_candidate_count_.compare_exchange_weak(
+                    candidate_count, candidate_count + 1,
+                    std::memory_order_relaxed)) {
+                reserved_candidate_slot = true;
+                break;
+            }
+        }
+        if (!reserved_candidate_slot) {
+            VLOG(1) << "promotion_candidate_dropped key=" << key
+                    << " reason=global_candidate_limit";
+            promotion_candidate_gave_up_.fetch_add(1,
+                                                   std::memory_order_relaxed);
+            return;
+        }
+
+        auto emplace_result = tenant_state.promotion_candidates.emplace(
+            key, PromotionCandidate{.first_seen = now,
+                                    .next_retry_time = now,
+                                    .retry_attempts = 0,
+                                    .last_reason = reason,
+                                    .last_error = last_error});
+        if (emplace_result.second) {
+            promotion_candidate_recorded_.fetch_add(1,
+                                                    std::memory_order_relaxed);
+            VLOG(1) << "promotion_candidate_recorded key=" << key;
+        } else {
+            DecrementPromotionCandidateCount();
+        }
+        return;
+    }
+
+    candidate_it->second.last_reason = reason;
+    candidate_it->second.last_error = last_error;
+    if (candidate_it->second.next_retry_time < now) {
+        candidate_it->second.next_retry_time = now;
+    }
+}
+
+bool MasterService::IsTransientPromotionQueueResult(
+    PromotionQueueResult result) const {
+    return result == PromotionQueueResult::kWatermarkRejected ||
+           result == PromotionQueueResult::kQueueCapRejected ||
+           result == PromotionQueueResult::kPushFailed;
+}
+
+std::chrono::milliseconds MasterService::PromotionCandidateBackoff(
+    uint32_t retry_attempts) const {
+    uint64_t backoff_ms =
+        static_cast<uint64_t>(kPromotionCandidateInitialBackoff.count());
+    for (uint32_t i = 1; i < retry_attempts; ++i) {
+        backoff_ms = std::min<uint64_t>(
+            backoff_ms * 2,
+            static_cast<uint64_t>(kPromotionCandidateMaxBackoff.count()));
+    }
+    return std::chrono::milliseconds(backoff_ms);
+}
+
+void MasterService::BackoffPromotionCandidate(const ObjectIdentity& object_id,
+                                              PromotionQueueResult result) {
+    const auto now = std::chrono::system_clock::now();
+    MetadataShardAccessorRW shard(
+        this, getMetadataShardIndex(object_id.tenant_id, object_id.user_key));
+    auto tenant_it = shard->tenants.find(object_id.tenant_id);
+    if (tenant_it == shard->tenants.end()) {
+        return;
+    }
+    auto& tenant_state = tenant_it->second;
+    auto candidate_it =
+        tenant_state.promotion_candidates.find(object_id.user_key);
+    if (candidate_it == tenant_state.promotion_candidates.end()) {
+        return;
+    }
+
+    auto& candidate = candidate_it->second;
+    candidate.retry_attempts++;
+    if (result == PromotionQueueResult::kWatermarkRejected) {
+        candidate.last_reason = PromotionCandidateReason::kWatermark;
+        candidate.last_error = ErrorCode::OK;
+    } else if (result == PromotionQueueResult::kQueueCapRejected) {
+        candidate.last_reason = PromotionCandidateReason::kQueueCap;
+        candidate.last_error = ErrorCode::OK;
+    } else {
+        candidate.last_reason = PromotionCandidateReason::kPushFailed;
+    }
+
+    const bool expired = now - candidate.first_seen >= kPromotionCandidateTtl;
+    if (expired || candidate.retry_attempts >= kPromotionCandidateMaxAttempts) {
+        VLOG(1) << "promotion_candidate_gave_up key=" << object_id.user_key
+                << " attempts=" << candidate.retry_attempts;
+        ErasePromotionCandidate(tenant_state, object_id.user_key);
+        promotion_candidate_gave_up_.fetch_add(1, std::memory_order_relaxed);
+    } else {
+        candidate.next_retry_time =
+            now + PromotionCandidateBackoff(candidate.retry_attempts);
+    }
+
+    if (tenant_state.Empty()) {
+        shard->tenants.erase(tenant_it);
+    }
+}
+
+size_t MasterService::RunPromotionCandidateRetry() {
+    return RunPromotionCandidateRetry(kPromotionRetryShardScanBatch);
+}
+
+size_t MasterService::RunPromotionCandidateRetryForTesting() {
+    return RunPromotionCandidateRetry(kNumShards);
+}
+
+size_t MasterService::RunPromotionCandidateRetry(size_t max_shards_to_scan) {
+    if (!promotion_on_hit_ ||
+        promotion_candidate_count_.load(std::memory_order_relaxed) == 0) {
+        return 0;
+    }
+
+    const auto now = std::chrono::system_clock::now();
+    std::vector<ObjectIdentity> due_candidates;
+    due_candidates.reserve(kPromotionRetryScanBatch);
+    const size_t shards_to_scan = std::min(max_shards_to_scan, kNumShards);
+    if (shards_to_scan == 0) {
+        return 0;
+    }
+    const size_t start_shard = promotion_retry_cursor_shard_.fetch_add(
+                                   shards_to_scan, std::memory_order_relaxed) %
+                               kNumShards;
+
+    {
+        std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+        for (size_t scanned = 0;
+             scanned < shards_to_scan &&
+             due_candidates.size() < kPromotionRetryScanBatch;
+             scanned++) {
+            const size_t i = (start_shard + scanned) % kNumShards;
+            MetadataShardAccessorRW shard(this, i);
+            for (auto tenant_it = shard->tenants.begin();
+                 tenant_it != shard->tenants.end() &&
+                 due_candidates.size() < kPromotionRetryScanBatch;) {
+                auto& tenant_state = tenant_it->second;
+                for (auto candidate_it =
+                         tenant_state.promotion_candidates.begin();
+                     candidate_it != tenant_state.promotion_candidates.end() &&
+                     due_candidates.size() < kPromotionRetryScanBatch;) {
+                    const auto& key = candidate_it->first;
+                    auto& candidate = candidate_it->second;
+                    const bool expired =
+                        now - candidate.first_seen >= kPromotionCandidateTtl;
+                    if (expired || candidate.retry_attempts >=
+                                       kPromotionCandidateMaxAttempts) {
+                        VLOG(1) << "promotion_candidate_gave_up key=" << key
+                                << " attempts=" << candidate.retry_attempts;
+                        candidate_it = tenant_state.promotion_candidates.erase(
+                            candidate_it);
+                        DecrementPromotionCandidateCount();
+                        promotion_candidate_gave_up_.fetch_add(
+                            1, std::memory_order_relaxed);
+                        continue;
+                    }
+                    if (candidate.next_retry_time > now) {
+                        ++candidate_it;
+                        continue;
+                    }
+
+                    auto metadata_it = tenant_state.metadata.find(key);
+                    if (metadata_it == tenant_state.metadata.end() ||
+                        !metadata_it->second.IsValid() ||
+                        tenant_state.promotion_tasks.count(key) > 0 ||
+                        metadata_it->second.HasReplica(
+                            &Replica::fn_is_memory_replica) ||
+                        !metadata_it->second.HasReplica(
+                            &Replica::fn_is_local_disk_replica)) {
+                        candidate_it = tenant_state.promotion_candidates.erase(
+                            candidate_it);
+                        DecrementPromotionCandidateCount();
+                        continue;
+                    }
+
+                    due_candidates.push_back(ObjectIdentity{
+                        .tenant_id = tenant_it->first, .user_key = key});
+                    ++candidate_it;
+                }
+
+                if (tenant_state.Empty()) {
+                    tenant_it = shard->tenants.erase(tenant_it);
+                } else {
+                    ++tenant_it;
+                }
+            }
+        }
+    }
+
+    size_t queued = 0;
+    {
+        // Match foreground Get/BatchGet: the retry path re-enters metadata
+        // admission only while holding snapshot_mutex_. Shard locks were
+        // released above, so this does not create lock recursion.
+        std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+        for (const auto& object_id : due_candidates) {
+            promotion_candidate_retry_attempted_.fetch_add(
+                1, std::memory_order_relaxed);
+            const auto result =
+                TryPushPromotionQueue(object_id, /*record_candidate=*/false);
+            if (result == PromotionQueueResult::kQueued) {
+                queued++;
+                promotion_candidate_retry_queued_.fetch_add(
+                    1, std::memory_order_relaxed);
+                continue;
+            }
+            if (IsTransientPromotionQueueResult(result)) {
+                BackoffPromotionCandidate(object_id, result);
+            } else {
+                ErasePromotionCandidate(object_id);
+            }
+        }
+    }
+
+    return queued;
+}
+
+size_t MasterService::CountPromotionCandidatesForTesting(
+    const std::string& tenant_id) {
+    const auto normalized_tenant = NormalizeTenantId(tenant_id);
+    size_t count = 0;
+    std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+    for (size_t i = 0; i < kNumShards; i++) {
+        MetadataShardAccessorRO shard(this, i);
+        auto tenant_it = shard->tenants.find(normalized_tenant);
+        if (tenant_it != shard->tenants.end()) {
+            count += tenant_it->second.promotion_candidates.size();
+        }
+    }
+    return count;
+}
+
+MasterService::PromotionQueueResult MasterService::TryPushPromotionQueue(
+    const ObjectIdentity& object_id, bool record_candidate) {
+    if (!promotion_on_hit_ || !promotion_sketch_) {
+        return PromotionQueueResult::kDisabled;
     }
     const auto& key = object_id.user_key;
     const auto admission_key =
@@ -5111,7 +5406,39 @@ void MasterService::TryPushPromotionQueue(const ObjectIdentity& object_id) {
     const uint8_t freq = promotion_sketch_->increment(admission_key);
     if (freq < promotion_admission_threshold_) {
         MasterMetricManager::instance().inc_promotion_rejected_frequency();
-        return;
+        return PromotionQueueResult::kFrequencyRejected;
+    }
+
+    // Acquire a fresh RW shard accessor for dedup, refcnt-pin, and task
+    // record. Safe to call here because GetReplicaList has already released
+    // its RO accessor.
+    MetadataAccessorRW accessor(this, object_id);
+    if (!accessor.Exists()) {
+        return PromotionQueueResult::kNotFound;
+    }
+    auto& metadata = accessor.Get();
+    auto& tenant_state = accessor.GetTenantState();
+
+    // Dedup: don't queue twice if a promotion is already in flight or if a
+    // MEMORY replica has appeared since GetReplicaList observed only-disk.
+    if (tenant_state.promotion_tasks.count(key) > 0) {
+        ErasePromotionCandidate(tenant_state, key);
+        return PromotionQueueResult::kAlreadyInFlight;
+    }
+    if (metadata.HasReplica(&Replica::fn_is_memory_replica)) {
+        ErasePromotionCandidate(tenant_state, key);
+        return PromotionQueueResult::kMemoryReplicaPresent;
+    }
+
+    // Find the LOCAL_DISK source replica.
+    Replica* source = nullptr;
+    metadata.VisitReplicas(&Replica::fn_is_local_disk_replica,
+                           [&source](Replica& r) {
+                               if (source == nullptr) source = &r;
+                           });
+    if (source == nullptr) {
+        ErasePromotionCandidate(tenant_state, key);
+        return PromotionQueueResult::kNoLocalDiskSource;
     }
 
     // Watermark gate: don't promote if DRAM is already under eviction
@@ -5121,26 +5448,12 @@ void MasterService::TryPushPromotionQueue(const ObjectIdentity& object_id) {
         MasterMetricManager::instance().get_global_mem_used_ratio();
     if (used_ratio >= eviction_high_watermark_ratio_) {
         MasterMetricManager::instance().inc_promotion_rejected_watermark();
-        return;
-    }
-
-    // Acquire a fresh RW shard accessor for dedup, refcnt-pin, and task
-    // record. Safe to call here because GetReplicaList has already released
-    // its RO accessor.
-    MetadataAccessorRW accessor(this, object_id);
-    if (!accessor.Exists()) {
-        return;
-    }
-    auto& metadata = accessor.Get();
-    auto& tenant_state = accessor.GetTenantState();
-
-    // Dedup: don't queue twice if a promotion is already in flight or if a
-    // MEMORY replica has appeared since GetReplicaList observed only-disk.
-    if (tenant_state.promotion_tasks.count(key) > 0) {
-        return;
-    }
-    if (metadata.HasReplica(&Replica::fn_is_memory_replica)) {
-        return;
+        if (record_candidate) {
+            RecordPromotionCandidate(tenant_state, key,
+                                     PromotionCandidateReason::kWatermark,
+                                     ErrorCode::OK);
+        }
+        return PromotionQueueResult::kWatermarkRejected;
     }
 
     // Cap gate: read the cluster-wide in-flight count. Soft cap — a
@@ -5153,17 +5466,12 @@ void MasterService::TryPushPromotionQueue(const ObjectIdentity& object_id) {
     if (promotion_in_flight_.load(std::memory_order_relaxed) >=
         promotion_queue_limit_) {
         MasterMetricManager::instance().inc_promotion_rejected_cap();
-        return;
-    }
-
-    // Find the LOCAL_DISK source replica.
-    Replica* source = nullptr;
-    metadata.VisitReplicas(&Replica::fn_is_local_disk_replica,
-                           [&source](Replica& r) {
-                               if (source == nullptr) source = &r;
-                           });
-    if (source == nullptr) {
-        return;
+        if (record_candidate) {
+            RecordPromotionCandidate(tenant_state, key,
+                                     PromotionCandidateReason::kQueueCap,
+                                     ErrorCode::OK);
+        }
+        return PromotionQueueResult::kQueueCapRejected;
     }
 
     // Pin the source replica.
@@ -5177,7 +5485,21 @@ void MasterService::TryPushPromotionQueue(const ObjectIdentity& object_id) {
         source->dec_refcnt();
         VLOG(1) << "promotion_push_failed key=" << key
                 << " error=" << push_result.error();
-        return;
+        if (push_result.error() == ErrorCode::OBJECT_ALREADY_EXISTS) {
+            ErasePromotionCandidate(tenant_state, key);
+            return PromotionQueueResult::kAlreadyInFlight;
+        }
+        if (push_result.error() == ErrorCode::SEGMENT_NOT_FOUND ||
+            push_result.error() == ErrorCode::INVALID_PARAMS) {
+            ErasePromotionCandidate(tenant_state, key);
+            return PromotionQueueResult::kNoLocalDiskSource;
+        }
+        if (record_candidate) {
+            RecordPromotionCandidate(tenant_state, key,
+                                     PromotionCandidateReason::kPushFailed,
+                                     push_result.error());
+        }
+        return PromotionQueueResult::kPushFailed;
     }
 
     // Capture the holder client_id so NotifyPromotionSuccess can reject
@@ -5193,10 +5515,12 @@ void MasterService::TryPushPromotionQueue(const ObjectIdentity& object_id) {
                            .object_size = object_size,
                            .start_time = std::chrono::system_clock::now(),
                            .holder_id = holder_id});
+    ErasePromotionCandidate(tenant_state, key);
     promotion_in_flight_.fetch_add(1, std::memory_order_relaxed);
     MasterMetricManager::instance().inc_promotion_in_flight();
     MasterMetricManager::instance().inc_promotion_admitted();
     VLOG(1) << "promotion_queued key=" << key << " size=" << object_size;
+    return PromotionQueueResult::kQueued;
 }
 
 auto MasterService::PromotionObjectHeartbeat(const UUID& client_id)
@@ -5511,6 +5835,8 @@ void MasterService::EvictionThreadFunc() {
     VLOG(1) << "action=eviction_thread_started";
 
     auto last_discard_time = std::chrono::system_clock::now();
+    auto last_promotion_retry_time =
+        std::chrono::system_clock::now() - kPromotionCandidateInitialBackoff;
     while (eviction_running_) {
         const auto now = std::chrono::system_clock::now();
         double used_ratio =
@@ -5560,6 +5886,13 @@ void MasterService::EvictionThreadFunc() {
             NoFBatchEvict(nof_evict_ratio_target, nof_evict_ratio_lowerbound);
         }
 #endif
+
+        if (promotion_candidate_count_.load(std::memory_order_relaxed) > 0 &&
+            now - last_promotion_retry_time >=
+                kPromotionCandidateInitialBackoff) {
+            RunPromotionCandidateRetry();
+            last_promotion_retry_time = now;
+        }
 
         std::this_thread::sleep_for(
             std::chrono::milliseconds(kEvictionThreadSleepMs));
@@ -8266,6 +8599,7 @@ MasterService::MetadataSerializer::Deserialize(
     Replica::next_id_.store(next_id);
     LOG(INFO) << "Restored Replica::next_id_ to " << next_id;
     service_->RebuildGroupRoutingIndex();
+    service_->ClearPromotionTransientStateForMetadataReload();
     return {};
 }
 
@@ -8273,6 +8607,7 @@ void MasterService::MetadataSerializer::Reset() {
     for (auto& shard : service_->metadata_shards_) {
         shard.tenants.clear();
     }
+    service_->ClearPromotionTransientStateForMetadataReload();
     {
         std::unique_lock<std::shared_mutex> lock(
             service_->group_routing_mutex_);

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -45,6 +45,8 @@ add_store_test(batch_remove_test batch_remove_test.cpp)
 add_store_test(master_service_ssd_test master_service_ssd_test.cpp)
 add_store_test(offload_on_evict_test offload_on_evict_test.cpp)
 add_store_test(promotion_on_hit_test promotion_on_hit_test.cpp)
+add_store_test(promotion_retry_benchmark_test
+               promotion_retry_benchmark_test.cpp)
 add_store_test(file_storage_promotion_test file_storage_promotion_test.cpp)
 add_store_test(master_service_ssd_test_for_snapshot
                ha/snapshot/master_service_ssd_test_for_snapshot.cpp)

--- a/mooncake-store/tests/promotion_on_hit_test.cpp
+++ b/mooncake-store/tests/promotion_on_hit_test.cpp
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <filesystem>
 #include <fstream>
@@ -52,6 +53,48 @@ class PromotionOnHitTest : public ::testing::Test {
     static uint32_t GetPromotionAdmissionThresholdForTesting(
         MasterService* service) {
         return service->promotion_admission_threshold_;
+    }
+
+    static size_t CountPromotionCandidatesForTesting(
+        MasterService* service, const std::string& tenant = "default") {
+        return service->CountPromotionCandidatesForTesting(tenant);
+    }
+
+    static uint64_t GetPromotionCandidateCountForTesting(
+        MasterService* service) {
+        return service->promotion_candidate_count_.load(
+            std::memory_order_relaxed);
+    }
+
+    static void DecrementPromotionCandidateCountForTesting(
+        MasterService* service) {
+        service->DecrementPromotionCandidateCount();
+    }
+
+    static void BackoffQueueCapCandidateForTesting(
+        MasterService* service, const std::string& key,
+        const std::string& tenant = "default") {
+        service->BackoffPromotionCandidate(
+            MasterService::MakeObjectIdentity(key, tenant),
+            MasterService::PromotionQueueResult::kQueueCapRejected);
+    }
+
+    static uint64_t GetPromotionInFlightForTesting(MasterService* service) {
+        return service->promotion_in_flight_.load(std::memory_order_relaxed);
+    }
+
+    static size_t RunPromotionCandidateRetryForTesting(MasterService* service) {
+        return service->RunPromotionCandidateRetryForTesting();
+    }
+
+    static size_t RunPromotionCandidateRetryForTesting(MasterService* service,
+                                                       size_t max_shards) {
+        return service->RunPromotionCandidateRetry(max_shards);
+    }
+
+    static void ResetMetadataForTesting(MasterService* service) {
+        MasterService::MetadataSerializer serializer(service);
+        serializer.Reset();
     }
 
     static constexpr size_t kDefaultSegmentBase = 0x300000000;
@@ -624,7 +667,7 @@ TEST_F(PromotionOnHitTest, QueueLimitRejectsBeyondCap) {
     config.enable_offload = true;
     config.promotion_on_hit = true;
     config.promotion_admission_threshold = 1;
-    config.promotion_queue_limit = 1;  // any 1 task saturates a shard
+    config.promotion_queue_limit = 1;  // any 1 task saturates the global cap
     config.default_kv_lease_ttl = 2000;
     auto service = std::make_unique<MasterService>(config);
 
@@ -634,7 +677,7 @@ TEST_F(PromotionOnHitTest, QueueLimitRejectsBeyondCap) {
     // Find two keys that hash to the same shard. MasterService::
     // getShardIndex is private but the formula is deterministic
     // (std::hash<std::string>{}(key) % kNumShards), so we can mirror
-    // it here. kNumShards=1024 (master_service.h:889).
+    // it here.
     constexpr size_t kNumShardsLocal = 1024;
     auto shard_of = [](const std::string& k) {
         return std::hash<std::string>{}(k) % kNumShardsLocal;
@@ -683,6 +726,194 @@ TEST_F(PromotionOnHitTest, QueueLimitRejectsBeyondCap) {
         << "k2's rejection must increment promotion_rejected_cap";
 
     service->RemoveAll();
+}
+
+TEST_F(PromotionOnHitTest, QueueLimitRejectedCandidateRetriesAfterSlotFreed) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;
+    config.promotion_queue_limit = 1;
+    config.default_kv_lease_ttl = 2000;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto seg = PrepareSegment(*service, "seg_a", kDefaultSegmentBase, seg_size);
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, seg.client_id, "k_first", 1024,
+                                       seg.segment_name));
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, seg.client_id, "k_retry", 1024,
+                                       seg.segment_name));
+
+    auto first = service->GetReplicaList("k_first", "default");
+    ASSERT_TRUE(first.has_value());
+    auto retry = service->GetReplicaList("k_retry", "default");
+    ASSERT_TRUE(retry.has_value());
+
+    auto initial = service->PromotionObjectHeartbeat(seg.client_id);
+    ASSERT_TRUE(initial.has_value());
+    EXPECT_EQ(CountPromotionTask(*initial, "k_first"), 1u);
+    EXPECT_EQ(CountPromotionTask(*initial, "k_retry"), 0u);
+    EXPECT_EQ(CountPromotionCandidatesForTesting(service.get()), 1u);
+
+    auto failure =
+        service->NotifyPromotionFailure(seg.client_id, "k_first", "default");
+    ASSERT_TRUE(failure.has_value());
+
+    EXPECT_EQ(RunPromotionCandidateRetryForTesting(service.get(), 0), 0u);
+    EXPECT_EQ(CountPromotionCandidatesForTesting(service.get()), 1u)
+        << "zero-shard retry scans are no-ops and must not drop candidates";
+    EXPECT_EQ(GetPromotionCandidateCountForTesting(service.get()), 1u);
+
+    EXPECT_EQ(RunPromotionCandidateRetryForTesting(service.get()), 1u);
+    auto after_retry = service->PromotionObjectHeartbeat(seg.client_id);
+    ASSERT_TRUE(after_retry.has_value());
+    EXPECT_EQ(CountPromotionTask(*after_retry, "k_retry"), 1u)
+        << "cap-rejected hot LOCAL_DISK-only key should be re-enqueued "
+        << "after the transient in-flight cap clears, without requiring "
+        << "another foreground Get";
+    EXPECT_EQ(CountPromotionCandidatesForTesting(service.get()), 0u);
+
+    service->RemoveAll();
+}
+
+TEST_F(PromotionOnHitTest, RetryDropsCandidateWhenObjectRemoved) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;
+    config.promotion_queue_limit = 1;
+    config.default_kv_lease_ttl = 2000;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto seg = PrepareSegment(*service, "seg_a", kDefaultSegmentBase, seg_size);
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, seg.client_id, "k_first", 1024,
+                                       seg.segment_name));
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, seg.client_id, "k_drop", 1024,
+                                       seg.segment_name));
+
+    auto first = service->GetReplicaList("k_first", "default");
+    ASSERT_TRUE(first.has_value());
+    auto dropped = service->GetReplicaList("k_drop", "default");
+    ASSERT_TRUE(dropped.has_value());
+    EXPECT_EQ(CountPromotionCandidatesForTesting(service.get()), 1u);
+
+    auto rm = service->Remove("k_drop", "default", /*force=*/true);
+    ASSERT_TRUE(rm.has_value());
+    auto failure =
+        service->NotifyPromotionFailure(seg.client_id, "k_first", "default");
+    ASSERT_TRUE(failure.has_value());
+
+    EXPECT_EQ(RunPromotionCandidateRetryForTesting(service.get()), 0u);
+    EXPECT_EQ(CountPromotionCandidatesForTesting(service.get()), 0u);
+    auto heartbeat = service->PromotionObjectHeartbeat(seg.client_id);
+    ASSERT_TRUE(heartbeat.has_value());
+    EXPECT_EQ(CountPromotionTask(*heartbeat, "k_drop"), 0u)
+        << "removed objects are permanent failures for promotion retry";
+
+    service->RemoveAll();
+}
+
+TEST_F(PromotionOnHitTest, QueueLimitRejectedCandidateGivesUpAfterMaxBackoff) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;
+    config.promotion_queue_limit = 1;
+    config.default_kv_lease_ttl = 2000;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto seg = PrepareSegment(*service, "seg_a", kDefaultSegmentBase, seg_size);
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, seg.client_id, "k_first", 1024,
+                                       seg.segment_name));
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, seg.client_id, "k_retry", 1024,
+                                       seg.segment_name));
+
+    auto first = service->GetReplicaList("k_first", "default");
+    ASSERT_TRUE(first.has_value());
+    auto retry = service->GetReplicaList("k_retry", "default");
+    ASSERT_TRUE(retry.has_value());
+    ASSERT_EQ(CountPromotionCandidatesForTesting(service.get()), 1u);
+    ASSERT_EQ(GetPromotionCandidateCountForTesting(service.get()), 1u);
+
+    for (uint32_t attempt = 1; attempt < 8; ++attempt) {
+        BackoffQueueCapCandidateForTesting(service.get(), "k_retry");
+        EXPECT_EQ(CountPromotionCandidatesForTesting(service.get()), 1u)
+            << "candidate should remain retryable before max attempt "
+            << attempt;
+        EXPECT_EQ(GetPromotionCandidateCountForTesting(service.get()), 1u);
+    }
+
+    BackoffQueueCapCandidateForTesting(service.get(), "k_retry");
+    EXPECT_EQ(CountPromotionCandidatesForTesting(service.get()), 0u)
+        << "bounded retry must give up once max attempts is reached";
+    EXPECT_EQ(GetPromotionCandidateCountForTesting(service.get()), 0u);
+
+    auto failure =
+        service->NotifyPromotionFailure(seg.client_id, "k_first", "default");
+    ASSERT_TRUE(failure.has_value());
+    EXPECT_EQ(RunPromotionCandidateRetryForTesting(service.get()), 0u);
+    auto heartbeat = service->PromotionObjectHeartbeat(seg.client_id);
+    ASSERT_TRUE(heartbeat.has_value());
+    EXPECT_EQ(CountPromotionTask(*heartbeat, "k_retry"), 0u)
+        << "gave-up candidates must not be resurrected after the cap clears";
+
+    service->RemoveAll();
+}
+
+TEST_F(PromotionOnHitTest, MetadataResetClearsTransientRetryCandidates) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;
+    config.promotion_queue_limit = 1;
+    config.default_kv_lease_ttl = 2000;
+    auto service = std::make_unique<MasterService>(config);
+    auto& mm = MasterMetricManager::instance();
+    const int64_t in_flight_pre = mm.get_promotion_in_flight();
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto seg = PrepareSegment(*service, "seg_a", kDefaultSegmentBase, seg_size);
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, seg.client_id, "k_first", 1024,
+                                       seg.segment_name));
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, seg.client_id, "k_retry", 1024,
+                                       seg.segment_name));
+
+    auto first = service->GetReplicaList("k_first", "default");
+    ASSERT_TRUE(first.has_value());
+    auto retry = service->GetReplicaList("k_retry", "default");
+    ASSERT_TRUE(retry.has_value());
+    EXPECT_EQ(CountPromotionCandidatesForTesting(service.get()), 1u);
+    EXPECT_EQ(GetPromotionCandidateCountForTesting(service.get()), 1u);
+    EXPECT_EQ(GetPromotionInFlightForTesting(service.get()), 1u);
+    EXPECT_EQ(mm.get_promotion_in_flight() - in_flight_pre, 1);
+
+    ResetMetadataForTesting(service.get());
+
+    EXPECT_EQ(CountPromotionCandidatesForTesting(service.get()), 0u);
+    EXPECT_EQ(GetPromotionCandidateCountForTesting(service.get()), 0u)
+        << "metadata reload/reset clears transient candidate maps directly, "
+        << "so the global candidate counter must be reset too";
+    EXPECT_EQ(GetPromotionInFlightForTesting(service.get()), 0u)
+        << "metadata reload/reset also clears promotion_tasks, so the soft "
+        << "in-flight cap must be reset with the transient metadata";
+    EXPECT_EQ(mm.get_promotion_in_flight() - in_flight_pre, 0);
+    EXPECT_EQ(RunPromotionCandidateRetryForTesting(service.get()), 0u);
+}
+
+TEST_F(PromotionOnHitTest,
+       CandidateCounterSaturatingDecrementDoesNotUnderflow) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    auto service = std::make_unique<MasterService>(config);
+
+    ASSERT_EQ(GetPromotionCandidateCountForTesting(service.get()), 0u);
+    DecrementPromotionCandidateCountForTesting(service.get());
+    EXPECT_EQ(GetPromotionCandidateCountForTesting(service.get()), 0u)
+        << "candidate counter cleanup is advisory and must not underflow if "
+        << "a metadata reload/reset already cleared it";
 }
 
 // PromotionObjectHeartbeat caps the per-call response at kMaxPerHeartbeat

--- a/mooncake-store/tests/promotion_retry_benchmark_test.cpp
+++ b/mooncake-store/tests/promotion_retry_benchmark_test.cpp
@@ -1,0 +1,148 @@
+// Deterministic public-API benchmark for promotion retry admission.
+//
+// The scenario keeps promotion_queue_limit=1, rejects a second hot
+// LOCAL_DISK-only key on the cap gate, then releases the first task slot.
+// A retry-capable master should re-enqueue the second key without another
+// foreground Get.
+
+#include "master_service.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <chrono>
+#include <iostream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "types.h"
+
+namespace mooncake::test {
+namespace {
+
+size_t CountPromotionTask(const std::vector<PromotionTaskItem>& tasks,
+                          const std::string& key) {
+    return std::count_if(
+        tasks.begin(), tasks.end(),
+        [&key](const PromotionTaskItem& task) { return task.key == key; });
+}
+
+Segment MakeSegment(std::string name, size_t base, size_t size) {
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = std::move(name);
+    segment.base = base;
+    segment.size = size;
+    segment.te_endpoint = segment.name;
+    return segment;
+}
+
+struct MountedSegmentContext {
+    UUID segment_id;
+    UUID client_id;
+    std::string segment_name;
+};
+
+MountedSegmentContext PrepareSegment(MasterService& service, std::string name,
+                                     size_t base, size_t size) {
+    Segment segment = MakeSegment(std::move(name), base, size);
+    UUID client_id = generate_uuid();
+    auto mount_result = service.MountSegment(segment, client_id);
+    EXPECT_TRUE(mount_result.has_value());
+    auto mount_ld = service.MountLocalDiskSegment(client_id, true);
+    EXPECT_TRUE(mount_ld.has_value());
+    return {.segment_id = segment.id,
+            .client_id = client_id,
+            .segment_name = segment.name};
+}
+
+bool InjectLocalDiskReplica(MasterService& service, const UUID& client_id,
+                            const std::string& key, int64_t size,
+                            const std::string& transport_endpoint) {
+    std::vector<OffloadTaskItem> tasks{
+        OffloadTaskItem{.tenant_id = "default", .key = key, .size = size}};
+    StorageObjectMetadata sm;
+    sm.bucket_id = 0;
+    sm.offset = 0;
+    sm.key_size = static_cast<int64_t>(key.size());
+    sm.data_size = size;
+    sm.transport_endpoint = transport_endpoint;
+    std::vector<StorageObjectMetadata> metas{sm};
+    auto res = service.NotifyOffloadSuccess(client_id, tasks, metas);
+    return res.has_value();
+}
+
+}  // namespace
+
+TEST(PromotionRetryBenchmark, QueueLimitRetryPublicPath) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;
+    config.promotion_queue_limit = 1;
+    config.default_kv_lease_ttl = 2000;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t kSegmentBase = 0x330000000;
+    constexpr size_t kSegmentSize = 1024 * 1024 * 16;
+    auto seg =
+        PrepareSegment(*service, "bench_seg", kSegmentBase, kSegmentSize);
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, seg.client_id, "bench_first",
+                                       1024, seg.segment_name));
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, seg.client_id, "bench_retry",
+                                       1024, seg.segment_name));
+
+    auto first = service->GetReplicaList("bench_first", "default");
+    ASSERT_TRUE(first.has_value());
+    auto retry = service->GetReplicaList("bench_retry", "default");
+    ASSERT_TRUE(retry.has_value());
+
+    auto initial = service->PromotionObjectHeartbeat(seg.client_id);
+    ASSERT_TRUE(initial.has_value());
+    ASSERT_EQ(CountPromotionTask(*initial, "bench_first"), 1u);
+    ASSERT_EQ(CountPromotionTask(*initial, "bench_retry"), 0u);
+
+    auto failure = service->NotifyPromotionFailure(seg.client_id, "bench_first",
+                                                   "default");
+    ASSERT_TRUE(failure.has_value());
+
+    bool retry_visible = false;
+    int retry_poll_ms = -1;
+    const auto start = std::chrono::steady_clock::now();
+    for (int i = 0; i < 100; ++i) {
+        auto heartbeat = service->PromotionObjectHeartbeat(seg.client_id);
+        ASSERT_TRUE(heartbeat.has_value());
+        if (CountPromotionTask(*heartbeat, "bench_retry") == 1u) {
+            retry_visible = true;
+            retry_poll_ms = static_cast<int>(
+                std::chrono::duration_cast<std::chrono::milliseconds>(
+                    std::chrono::steady_clock::now() - start)
+                    .count());
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+
+    int fallback_reads_needed = 0;
+    if (!retry_visible) {
+        fallback_reads_needed = 1;
+        auto fallback = service->GetReplicaList("bench_retry", "default");
+        ASSERT_TRUE(fallback.has_value());
+        auto heartbeat = service->PromotionObjectHeartbeat(seg.client_id);
+        ASSERT_TRUE(heartbeat.has_value());
+        retry_visible = CountPromotionTask(*heartbeat, "bench_retry") == 1u;
+    }
+
+    std::cout << "PROMOTION_RETRY_BENCHMARK_JSON={"
+              << "\"retry_visible\":" << (retry_visible ? "true" : "false")
+              << ",\"fallback_reads_needed\":" << fallback_reads_needed
+              << ",\"retry_poll_ms\":" << retry_poll_ms << ",\"queue_limit\":1"
+              << ",\"workload\":\"two_hot_local_disk_only_keys\""
+              << "}" << std::endl;
+
+    EXPECT_TRUE(retry_visible);
+    service->RemoveAll();
+}
+
+}  // namespace mooncake::test


### PR DESCRIPTION
# [Store] Retry transient promotion candidates

Addresses #2233.

## Summary

This change adds a master-side bounded retry candidate set for promotion-on-hit. When a hot LOCAL_DISK-only key passes the frequency gate but is rejected by a transient admission gate, the master records it as a candidate and a background scheduler re-evaluates it later through the existing promotion queue path.

It does not change client-facing RPCs or heartbeat protocol.

## Design

- Add `PromotionCandidate` state under `TenantState`.
- Convert `TryPushPromotionQueue` from `void` to an internal `PromotionQueueResult` so the background retry loop can classify outcomes.
- Record candidates for transient admission failures:
  - DRAM watermark gate
  - global `promotion_queue_limit` cap
  - recoverable promotion queue push failure
- Stop retry for permanent or already-resolved states:
  - object removed
  - MEMORY replica already present
  - no LOCAL_DISK source
  - task already in flight
- Bound retry by candidate count, TTL, max attempts, and exponential backoff.
- Enforce the candidate limit with an atomic global reservation and saturating decrement so reset/cleanup paths cannot underflow the advisory counter.
- Scan retry candidates in bounded metadata-shard batches instead of sweeping all 1024 shards every retry tick.
- Re-enter promotion admission under the snapshot shared lock after releasing shard locks, matching foreground metadata access without shard-lock recursion.
- Clear transient promotion retry state on metadata snapshot reload/reset, including the candidate counter and in-flight soft cap.
- Reuse the existing enqueue path so refcount pinning, holder queue insertion, and `PromotionTask` bookkeeping stay centralized.

## Tests

```bash
cmake --build build-ccf-ninja --target promotion_on_hit_test promotion_retry_benchmark_test -j2
./build-ccf-ninja/mooncake-store/tests/promotion_on_hit_test --gtest_brief=1
./build-ccf-ninja/mooncake-store/tests/promotion_retry_benchmark_test --gtest_brief=1
```

Results:

```text
promotion_on_hit_test: 43/43 PASS
promotion_retry_benchmark_test: PASS
```

Benchmark output:

```json
{"retry_visible":true,"fallback_reads_needed":0,"retry_poll_ms":171,"queue_limit":1,"workload":"two_hot_local_disk_only_keys"}
```

`retry_poll_ms` is the observed local public-heartbeat visibility time for this run; it can vary slightly with shard placement and scheduler timing. The semantic regression target is `fallback_reads_needed=0` after the in-flight slot is released.