### PR TITLE
[TE] Support rdma+hip multi-protocol segments for single-node disaggregation

### DIFF
--- a/mooncake-transfer-engine/src/multi_transport.cpp
+++ b/mooncake-transfer-engine/src/multi_transport.cpp
@@ -464,7 +464,7 @@ Status MultiTransport::selectTransport(const TransferRequest& entry,
     // by both rdma and hip), pick the highest-performance transport by a fixed
     // priority instead of relying on buffer registration order.
     if (proto.find(',') != std::string::npos) {
-        auto protocol_priority = [](const std::string &p) {
+        auto protocol_priority = [](const std::string& p) {
             if (p == "hip") return 4;
             if (p == "cxl") return 3;
             if (p == "rdma") return 2;
@@ -473,12 +473,13 @@ Status MultiTransport::selectTransport(const TransferRequest& entry,
         };
         std::string chosen;
         int chosen_priority = -1;
-        for (const auto &buffer : target_segment_desc->buffers) {
+        for (const auto& buffer : target_segment_desc->buffers) {
             // CXL buffers locate via offset + cxl_base_addr; all other
             // protocols use the absolute virtual address in buffer.addr.
-            uint64_t start = (buffer.protocol == "cxl")
-                                 ? buffer.offset + target_segment_desc->cxl_base_addr
-                                 : buffer.addr;
+            uint64_t start =
+                (buffer.protocol == "cxl")
+                    ? buffer.offset + target_segment_desc->cxl_base_addr
+                    : buffer.addr;
             if (entry.target_offset >= start &&
                 entry.target_offset < start + buffer.length) {
                 int priority = protocol_priority(buffer.protocol);

--- a/mooncake-transfer-engine/src/multi_transport.cpp
+++ b/mooncake-transfer-engine/src/multi_transport.cpp
@@ -455,6 +455,39 @@ Status MultiTransport::selectTransport(const TransferRequest& entry,
                                        std::to_string(entry.target_id));
     }
     auto proto = target_segment_desc->protocol;
+#ifdef ENABLE_MULTI_PROTOCOL
+    // Multi-protocol segment (e.g. "rdma,hip"): a single batch may target
+    // buffers owned by different transports (the device KV pool via hip, the
+    // host aux/metadata buffers via rdma). Route each request to the transport
+    // that owns the buffer covering the target address. When a buffer is
+    // registered under more than one protocol (the device KV pool is registered
+    // by both rdma and hip), prefer hip for intra-node XGMI throughput.
+    if (proto.find(',') != std::string::npos) {
+        std::string chosen;
+        for (const auto &buffer : target_segment_desc->buffers) {
+            if (entry.target_offset >= buffer.addr &&
+                entry.target_offset < buffer.addr + buffer.length) {
+                if (buffer.protocol == "hip") {
+                    chosen = "hip";
+                    break;
+                }
+                if (chosen.empty()) chosen = buffer.protocol;
+            }
+        }
+        if (chosen.empty()) {
+            return Status::InvalidArgument(
+                "No matching buffer for target offset in multi-protocol "
+                "segment " +
+                std::to_string(entry.target_id));
+        }
+        if (!transport_map_.count(chosen)) {
+            return Status::NotSupportedTransport("Transport " + chosen +
+                                                 " not installed");
+        }
+        transport = transport_map_[chosen].get();
+        return Status::OK();
+    }
+#endif
 #ifdef USE_ASCEND_HETEROGENEOUS
     // When USE_ASCEND_HETEROGENEOUS is enabled:
     // - Target side directly reuses RDMA Transport

--- a/mooncake-transfer-engine/src/multi_transport.cpp
+++ b/mooncake-transfer-engine/src/multi_transport.cpp
@@ -461,17 +461,31 @@ Status MultiTransport::selectTransport(const TransferRequest& entry,
     // host aux/metadata buffers via rdma). Route each request to the transport
     // that owns the buffer covering the target address. When a buffer is
     // registered under more than one protocol (the device KV pool is registered
-    // by both rdma and hip), prefer hip for intra-node XGMI throughput.
+    // by both rdma and hip), pick the highest-performance transport by a fixed
+    // priority instead of relying on buffer registration order.
     if (proto.find(',') != std::string::npos) {
+        auto protocol_priority = [](const std::string &p) {
+            if (p == "hip") return 4;
+            if (p == "cxl") return 3;
+            if (p == "rdma") return 2;
+            if (p == "tcp") return 1;
+            return 0;
+        };
         std::string chosen;
+        int chosen_priority = -1;
         for (const auto &buffer : target_segment_desc->buffers) {
-            if (entry.target_offset >= buffer.addr &&
-                entry.target_offset < buffer.addr + buffer.length) {
-                if (buffer.protocol == "hip") {
-                    chosen = "hip";
-                    break;
+            // CXL buffers locate via offset + cxl_base_addr; all other
+            // protocols use the absolute virtual address in buffer.addr.
+            uint64_t start = (buffer.protocol == "cxl")
+                                 ? buffer.offset + target_segment_desc->cxl_base_addr
+                                 : buffer.addr;
+            if (entry.target_offset >= start &&
+                entry.target_offset < start + buffer.length) {
+                int priority = protocol_priority(buffer.protocol);
+                if (priority > chosen_priority) {
+                    chosen = buffer.protocol;
+                    chosen_priority = priority;
                 }
-                if (chosen.empty()) chosen = buffer.protocol;
             }
         }
         if (chosen.empty()) {

--- a/mooncake-transfer-engine/src/transfer_metadata.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata.cpp
@@ -269,6 +269,9 @@ static int encodeMultiProtocolSegmentDesc(
             bufferJSON["lkey"] = lkeyJSON;
         } else if (buffer.protocol == "tcp") {
             bufferJSON["addr"] = static_cast<Json::UInt64>(buffer.addr);
+        } else if (buffer.protocol == "hip") {
+            bufferJSON["addr"] = static_cast<Json::UInt64>(buffer.addr);
+            bufferJSON["shm_name"] = buffer.shm_name;
         }
         buffersJSON.append(bufferJSON);
     }
@@ -284,35 +287,27 @@ static int encodeMultiProtocolSegmentDesc(
 int TransferMetadata::encodeSegmentDesc(const SegmentDesc &desc,
                                         Json::Value &segmentJSON) {
 #ifdef ENABLE_MULTI_PROTOCOL
-    // Check if this is a multi-protocol scenario (CXL+TCP or CXL+RDMA)
+    // A segment is multi-protocol when more than one transport registered
+    // buffers on it (e.g. tcp+hip or rdma+hip for intra-node disagg). Every
+    // protocol must have a per-buffer emitter below; otherwise its buffers
+    // would be silently dropped.
     std::vector<std::string> protocols = splitProtocols(desc.protocol);
     bool is_multi_protocol = false;
-    if (protocols.size() == 2) {
-        // Only support CXL+TCP or CXL+RDMA combinations
-        bool has_cxl = false, has_tcp = false, has_rdma = false;
+    if (protocols.size() >= 2) {
+        is_multi_protocol = true;
         for (const auto &proto : protocols) {
-            if (proto == "cxl")
-                has_cxl = true;
-            else if (proto == "tcp")
-                has_tcp = true;
-            else if (proto == "rdma")
-                has_rdma = true;
+            if (proto != "cxl" && proto != "tcp" && proto != "rdma" &&
+                proto != "hip") {
+                is_multi_protocol = false;
+                break;
+            }
         }
-        // Multi-protocol only supported for CXL+TCP or CXL+RDMA
-        if (has_cxl && (has_tcp || has_rdma)) {
-            is_multi_protocol = true;
-        }
-        // If not valid multi-protocol combination, return error
         if (!is_multi_protocol) {
             LOG(ERROR) << "Unsupported multi-protocol combination: "
                        << desc.protocol
-                       << ". Only CXL+TCP or CXL+RDMA are supported.";
+                       << ". Only cxl, tcp, rdma and hip may be combined.";
             return ERR_INVALID_ARGUMENT;
         }
-    } else if (protocols.size() > 2) {
-        LOG(ERROR) << "Unsupported multi-protocol combination: "
-                   << desc.protocol << ". Maximum 2 protocols allowed.";
-        return ERR_INVALID_ARGUMENT;
     }
 
     // If multi-protocol scenario, use multi-protocol encoding
@@ -613,6 +608,21 @@ decodeMultiProtocolSegmentDesc(Json::Value &segmentJSON,
                 return nullptr;
             }
             desc->buffers.push_back(buffer);
+        } else if (buffer_protocol == "hip") {
+            TransferMetadata::BufferDesc buffer;
+            buffer.name = bufferJSON["name"].asString();
+            buffer.addr = bufferJSON["addr"].asUInt64();
+            buffer.length = bufferJSON["length"].asUInt64();
+            buffer.shm_name = bufferJSON["shm_name"].asString();
+            buffer.protocol = buffer_protocol;
+            if (buffer.name.empty() || !buffer.addr || !buffer.length ||
+                buffer.shm_name.empty()) {
+                LOG(WARNING)
+                    << "Corrupted segment descriptor, name " << segment_name
+                    << " buffer_protocol " << buffer_protocol;
+                return nullptr;
+            }
+            desc->buffers.push_back(buffer);
         }
     }
 
@@ -628,34 +638,25 @@ TransferMetadata::decodeSegmentDesc(Json::Value &segmentJSON,
     bool is_multi_protocol = false;
     if (segmentJSON["protocol"].isArray()) {
         size_t proto_count = segmentJSON["protocol"].size();
-        if (proto_count == 2) {
-            // Only support CXL+TCP or CXL+RDMA combinations
-            bool has_cxl = false, has_tcp = false, has_rdma = false;
+        if (proto_count >= 2) {
+            // Every protocol must have a per-buffer parser in
+            // decodeMultiProtocolSegmentDesc below.
+            is_multi_protocol = true;
             for (const auto &protocolStr : segmentJSON["protocol"]) {
                 std::string proto = protocolStr.asString();
-                if (proto == "cxl")
-                    has_cxl = true;
-                else if (proto == "tcp")
-                    has_tcp = true;
-                else if (proto == "rdma")
-                    has_rdma = true;
+                if (proto != "cxl" && proto != "tcp" && proto != "rdma" &&
+                    proto != "hip") {
+                    is_multi_protocol = false;
+                    break;
+                }
             }
-            // Multi-protocol only supported for CXL+TCP or CXL+RDMA
-            if (has_cxl && (has_tcp || has_rdma)) {
-                is_multi_protocol = true;
-            }
-            // If not valid multi-protocol combination, return error
             if (!is_multi_protocol) {
                 LOG(ERROR)
                     << "Unsupported multi-protocol combination in segment: "
                     << segment_name
-                    << ". Only CXL+TCP or CXL+RDMA are supported.";
+                    << ". Only cxl, tcp, rdma and hip may be combined.";
                 return nullptr;
             }
-        } else if (proto_count > 2) {
-            LOG(ERROR) << "Unsupported multi-protocol combination in segment: "
-                       << segment_name << ". Maximum 2 protocols allowed.";
-            return nullptr;
         }
     }
 
@@ -780,8 +781,15 @@ TransferMetadata::decodeSegmentDesc(Json::Value &segmentJSON,
             buffer.addr = bufferJSON["addr"].asUInt64();
             buffer.length = bufferJSON["length"].asUInt64();
             buffer.shm_name = bufferJSON["shm_name"].asString();
-            if (buffer.name.empty() || !buffer.addr || !buffer.length ||
-                buffer.shm_name.empty()) {
+            if (buffer.shm_name.empty()) {
+                // In a multi-protocol build every transport registers each
+                // buffer into this node's single shared segment. Buffers owned
+                // by another transport (e.g. RDMA) carry no HIP IPC handle and
+                // are not reachable via this transport. Skip them instead of
+                // rejecting the whole segment, which would tear down sessions.
+                continue;
+            }
+            if (buffer.name.empty() || !buffer.addr || !buffer.length) {
                 LOG(WARNING) << "Corrupted segment descriptor, name "
                              << segment_name << " protocol " << desc->protocol
                              << "buffer name " << buffer.name << "buffer addr "

--- a/mooncake-transfer-engine/src/transport/hip_transport/hip_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/hip_transport/hip_transport.cpp
@@ -427,11 +427,21 @@ int HipTransport::install(std::string& local_server_name,
     metadata_ = metadata;
     local_server_name_ = local_server_name;
 
-    auto desc = std::make_shared<SegmentDesc>();
+    // Compose with any local segment another transport (e.g. RDMA) already
+    // installed instead of overwriting it, so a single-node segment can
+    // advertise both protocols (e.g. "rdma,hip"). Mirrors
+    // RdmaTransport::allocateLocalSegmentID.
+    auto desc = metadata_->getSegmentDescByID(LOCAL_SEGMENT_ID);
+    if (!desc) desc = std::make_shared<SegmentDesc>();
     if (!desc) return ERR_MEMORY;
 
     desc->name = local_server_name_;
+#ifdef ENABLE_MULTI_PROTOCOL
+    if (!desc->protocol.empty()) desc->protocol += ",";
+    desc->protocol += "hip";
+#else
     desc->protocol = "hip";
+#endif
 
     metadata_->addLocalSegment(LOCAL_SEGMENT_ID, local_server_name_,
                                std::move(desc));
@@ -649,17 +659,23 @@ int HipTransport::registerLocalMemory(void* addr, size_t length,
 
     // IPC-based memory registration
     if (!use_fabric_mem_) {
-        // Validate memory type
+        // Only device memory can be exported via HIP IPC. Callers that register
+        // a batch across all transports (e.g. SGLang's PD metadata/aux buffers,
+        // which live in host memory) also hand those host buffers to this
+        // transport. Skip non-device memory gracefully and let RDMA/TCP register
+        // it; returning an error would roll back the entire multi-protocol batch
+        // and tear down every session.
         hipPointerAttribute_t attr;
-        if (!checkHip(hipPointerGetAttributes(&attr, addr),
-                      "HipTransport: hipPointerGetAttributes failed")) {
-            return -1;
-        }
-
-        if (attr.type != hipMemoryTypeDevice) {
-            LOG(ERROR) << "Unsupported memory type, " << addr << " "
-                       << attr.type;
-            return -1;
+        hipError_t attr_err = hipPointerGetAttributes(&attr, addr);
+        if (attr_err != hipSuccess || attr.type != hipMemoryTypeDevice) {
+            // Clear any sticky error the failed query latched so it does not
+            // poison subsequent HIP calls made by the caller.
+            (void)hipGetLastError();
+            if (globalConfig().trace) {
+                LOG(INFO) << "HipTransport: skipping non-device memory " << addr
+                          << ", leaving it to other transports";
+            }
+            return 0;
         }
 
         // Get IPC handle
@@ -676,6 +692,9 @@ int HipTransport::registerLocalMemory(void* addr, size_t length,
         desc.length = length;
         desc.name = location;
         desc.shm_name = serializeBinaryData(&handle, sizeof(hipIpcMemHandle_t));
+#ifdef ENABLE_MULTI_PROTOCOL
+        desc.protocol = "hip";
+#endif
         return metadata_->addLocalMemoryBuffer(desc, true);
     }
 

--- a/mooncake-transfer-engine/src/transport/hip_transport/hip_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/hip_transport/hip_transport.cpp
@@ -667,9 +667,9 @@ int HipTransport::registerLocalMemory(void* addr, size_t length,
         // Only device memory can be exported via HIP IPC. Callers that register
         // a batch across all transports (e.g. SGLang's PD metadata/aux buffers,
         // which live in host memory) also hand those host buffers to this
-        // transport. Skip non-device memory gracefully and let RDMA/TCP register
-        // it; returning an error would roll back the entire multi-protocol batch
-        // and tear down every session.
+        // transport. Skip non-device memory gracefully and let RDMA/TCP
+        // register it; returning an error would roll back the entire
+        // multi-protocol batch and tear down every session.
         hipPointerAttribute_t attr;
         hipError_t attr_err = hipPointerGetAttributes(&attr, addr);
         if (attr_err != hipSuccess || attr.type != hipMemoryTypeDevice) {

--- a/mooncake-transfer-engine/src/transport/hip_transport/hip_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/hip_transport/hip_transport.cpp
@@ -429,16 +429,21 @@ int HipTransport::install(std::string& local_server_name,
 
     // Compose with any local segment another transport (e.g. RDMA) already
     // installed instead of overwriting it, so a single-node segment can
-    // advertise both protocols (e.g. "rdma,hip"). Mirrors
-    // RdmaTransport::allocateLocalSegmentID.
-    auto desc = metadata_->getSegmentDescByID(LOCAL_SEGMENT_ID);
-    if (!desc) desc = std::make_shared<SegmentDesc>();
+    // advertise both protocols (e.g. "rdma,hip"). Work on a copy (the map may
+    // hand back a descriptor other threads are reading) and publish the new
+    // one atomically via addLocalSegment.
+    auto old_desc = metadata_->getSegmentDescByID(LOCAL_SEGMENT_ID);
+    auto desc = std::make_shared<SegmentDesc>();
     if (!desc) return ERR_MEMORY;
+    if (old_desc) *desc = *old_desc;
 
     desc->name = local_server_name_;
 #ifdef ENABLE_MULTI_PROTOCOL
-    if (!desc->protocol.empty()) desc->protocol += ",";
-    desc->protocol += "hip";
+    if (desc->protocol.empty()) {
+        desc->protocol = "hip";
+    } else if (desc->protocol.find("hip") == std::string::npos) {
+        desc->protocol += ",hip";
+    }
 #else
     desc->protocol = "hip";
 #endif


### PR DESCRIPTION
Addresses #2684.

## Summary
This change lets a single node advertise and use **both** `rdma` and `hip` on one local segment, which is the combination AMD prefill/decode (PD) disaggregation needs: the device KV pool moves over the intra-node HIP transport (XGMI) while the host-resident metadata/aux buffers move over RDMA. Previously the transfer engine registered every buffer into all installed transports but published them under a single protocol, so an `rdma+hip` node collapsed to `hip`, the RDMA-registered KV buffers (no `shm_name`) tripped `Corrupted segment descriptor`, and KV transfer died.

It does not change client-facing RPCs, the heartbeat protocol, or the existing single-protocol fast path. Scope is intentionally bounded to `rdma+hip`, mirroring the existing `cxl+tcp` / `cxl+rdma` multi-protocol pattern.

## Design
- `HipTransport::registerLocalMemory`: skip non-device memory gracefully (`return 0`) instead of returning `-1`, so host buffers handed to every transport fall through to RDMA/TCP rather than rolling back the whole batch and tearing down sessions. Clear the sticky HIP error left by the failed pointer query so it cannot poison the caller's subsequent HIP calls.
- `HipTransport::install`: compose with any local segment another transport already published instead of overwriting it, so the node advertises `"rdma,hip"`. Mirrors `RdmaTransport::allocateLocalSegmentID`.
- Tag each HIP-registered `BufferDesc.protocol = "hip"` (RDMA already tags `"rdma"`) so a mixed segment round-trips with per-buffer ownership.
- Generalize the multi-protocol encode/decode allow-list (`encodeSegmentDesc` / `decodeSegmentDesc`) to accept any combination of protocols that have a per-buffer emit/parse branch (`cxl`/`tcp`/`rdma`/`hip`); remove the hardcoded 2-protocol cap and the CXL-must-be-present requirement.
- Add a `hip` per-buffer emit/parse branch (`addr` + `shm_name`).
- `MultiTransport::selectTransport`: for a comma-protocol segment, route each request to the transport owning the buffer that covers the target address; prefer `hip` when an address is registered under multiple protocols (device KV over XGMI). Single-protocol segments keep the existing path unchanged.
- Single-protocol `hip` decode: skip buffers with an empty `shm_name` defensively instead of rejecting the whole segment.

## Tests
Single-node 1P1D (prefill GPU0 / decode GPU1, Qwen2.5-0.5B) on MI355X over the real `rdma+hip` path. Topology discovery finds the bnxt HCA, then installs both transports:
```
Topology discovery complete. Found 1 HCAs.
installTransport, type=rdma
HIP transport installed for intra-node GPU P2P
```
A/B with the patch stashed vs. applied, same servers, same request:
```
curl http://0.0.0.0:8000/v1/chat/completions \
  -d '{"model":"qwen","messages":[{"role":"user","content":"What is the capital of France? Answer in one word."}],"max_tokens":16,"temperature":0}'
```
Results:
- **Without this change:** `hip_transport.cpp Unsupported memory type`, `transfer_metadata.cpp Corrupted segment descriptor ... protocol hip ... shm_name `(empty), then `Failed to get kvcache from prefill instance`.
- **With this change:** completion returns `Paris`; logs show 0 Corrupted-segment, 0 Unsupported-memory, 0 session-not-alive, 0 address-not-found.
