### PR TITLE
[Store] Make batch_query_keys read-only and return all replica types

### DIFF
--- a/docs/source/http-api-reference/http-service.md
+++ b/docs/source/http-api-reference/http-service.md
@@ -91,7 +91,7 @@ curl "http://localhost:8080/query_key?key=my_object"
 ```
 
 #### `/batch_query_keys`
-Retrieve replica information for multiple keys in a single request, including memory locations and transport endpoints for each key.
+Retrieve replica information for multiple keys in a single request, including memory locations and transport endpoints for each key. The endpoint performs a read-only metadata lookup and does not grant leases, trigger promotion, or update cache-hit metrics.
 
 **Method**: `GET`
 **Parameters**: `keys` (query parameter) - Comma-separated list of object keys to query (format: key1,key2,key3)
@@ -115,6 +115,25 @@ curl "http://localhost:8080/batch_query_keys?keys=key1,key2,key3"
           "transport_endpoint_": "hostname:port",
           "buffer_descriptor": {...}
         }
+      ],
+      "disk_values": [
+        {
+          "file_path": "/path/to/object",
+          "object_size": 4096
+        }
+      ],
+      "local_disk_values": [
+        {
+          "client_id": "12345-67890",
+          "object_size": 4096,
+          "transport_endpoint": "hostname:port"
+        }
+      ],
+      "nof_values": [
+        {
+          "transport_endpoint_": "hostname:port",
+          "buffer_descriptor": {...}
+        }
       ]
     },
     "key2": {
@@ -124,6 +143,8 @@ curl "http://localhost:8080/batch_query_keys?keys=key1,key2,key3"
   }
 }
 ```
+
+The `values` field is always present (empty array when no memory replica exists). The `disk_values`, `local_disk_values`, and `nof_values` fields are optional and only appear when the corresponding replica type is present for the key.
 
 #### `/get_all_keys`
 List all keys currently stored in the distributed system.

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -318,11 +318,29 @@ class MasterService {
         -> tl::expected<GetReplicaListResponse, ErrorCode>;
 
     /**
+     * @brief Read-only single-key replica list query for admin use.
+     * Unlike GetReplicaList, this does not grant leases, trigger
+     * promotion, or update cache-hit metrics.
+     */
+    auto GetReplicaListForAdmin(const std::string& key,
+                                const std::string& tenant_id)
+        -> tl::expected<GetReplicaListResponse, ErrorCode>;
+
+    /**
      * @brief Get replica lists for a batch of objects.
      */
     std::vector<tl::expected<GetReplicaListResponse, ErrorCode>>
     BatchGetReplicaList(const std::vector<std::string>& keys,
                         const std::string& tenant_id);
+
+    /**
+     * @brief Read-only batch replica list query for admin use.
+     * Unlike BatchGetReplicaList, this does not grant leases, trigger
+     * promotion, or update cache-hit metrics.
+     */
+    std::vector<tl::expected<GetReplicaListResponse, ErrorCode>>
+    BatchGetReplicaListForAdmin(const std::vector<std::string>& keys,
+                                const std::string& tenant_id);
 
     /**
      * @brief Start a put operation for an object

--- a/mooncake-store/include/rpc_service.h
+++ b/mooncake-store/include/rpc_service.h
@@ -65,6 +65,15 @@ class WrappedMasterService {
     BatchGetReplicaList(const std::vector<std::string>& keys,
                         const std::string& tenant_id = "default");
 
+    // Read-only admin variants: no lease grants, no promotion, no metric
+    // updates.
+    std::vector<tl::expected<GetReplicaListResponse, ErrorCode>>
+    BatchGetReplicaListForAdmin(const std::vector<std::string>& keys,
+                                const std::string& tenant_id = "default");
+
+    tl::expected<GetReplicaListResponse, ErrorCode> GetReplicaListForAdmin(
+        const std::string& key, const std::string& tenant_id = "default");
+
     tl::expected<std::vector<Replica::Descriptor>, ErrorCode> PutStart(
         const UUID& client_id, const std::string& key,
         const uint64_t slice_length, const ReplicateConfig& config,

--- a/mooncake-store/src/master_admin_service.cpp
+++ b/mooncake-store/src/master_admin_service.cpp
@@ -916,12 +916,30 @@ void MasterAdminServer::HandleSegmentStatus(
     });
 }
 
+struct HttpDiskReplicaInfo {
+    std::string file_path;
+    uint64_t object_size = 0;
+    YLT_REFL(HttpDiskReplicaInfo, file_path, object_size);
+};
+
+struct HttpLocalDiskReplicaInfo {
+    std::string client_id;
+    uint64_t object_size = 0;
+    std::string transport_endpoint;
+    YLT_REFL(HttpLocalDiskReplicaInfo, client_id, object_size,
+             transport_endpoint);
+};
+
 struct HttpBatchQueryKeyResult {
     bool ok{false};
     std::optional<std::string> error;
     std::optional<std::vector<AllocatedBuffer::Descriptor>> values;
+    std::optional<std::vector<HttpDiskReplicaInfo>> disk_values;
+    std::optional<std::vector<HttpLocalDiskReplicaInfo>> local_disk_values;
+    std::optional<std::vector<AllocatedBuffer::Descriptor>> nof_values;
 };
-YLT_REFL(HttpBatchQueryKeyResult, ok, error, values);
+YLT_REFL(HttpBatchQueryKeyResult, ok, error, values, disk_values,
+         local_disk_values, nof_values);
 
 struct HttpBatchQueryKeysResponse {
     bool success{false};
@@ -931,63 +949,81 @@ YLT_REFL(HttpBatchQueryKeysResponse, success, data);
 
 void MasterAdminServer::HandleBatchQueryKeys(
     coro_http::coro_http_request& req, coro_http::coro_http_response& resp) {
-    auto service = GetActiveService();
-    if (!service) {
-        WriteSimpleErrorResponse(resp,
-                                 coro_http::status_type::service_unavailable,
-                                 "service plane is not active");
-        return;
-    }
-
-    auto keys_str = req.get_query_value("keys");
-    std::vector<std::string> keys;
-    if (!keys_str.empty()) {
-        std::string_view sv(keys_str);
-        size_t pos = 0;
-        while ((pos = sv.find(',')) != std::string_view::npos) {
-            keys.emplace_back(sv.substr(0, pos));
-            sv.remove_prefix(pos + 1);
-        }
-        keys.emplace_back(sv);
-    }
-
-    if (keys.empty()) {
-        WriteSimpleErrorResponse(resp, coro_http::status_type::bad_request,
-                                 "No keys provided. Use ?keys=key1,key2,...");
-        return;
-    }
-
-    auto results = service->BatchGetReplicaList(keys, "default");
-    const size_t n = std::min(keys.size(), results.size());
-    HttpBatchQueryKeysResponse payload;
-    payload.success = true;
-
-    for (size_t i = 0; i < n; ++i) {
-        const auto& result = results[i];
-        HttpBatchQueryKeyResult item;
-        if (!result.has_value()) {
-            item.error = toString(result.error());
-            payload.data.emplace(keys[i], std::move(item));
-            continue;
+    WithActiveService(resp, [&](auto service) {
+        auto keys_str = req.get_decode_query_value("keys");
+        std::vector<std::string> keys;
+        if (!keys_str.empty()) {
+            std::string_view sv(keys_str);
+            size_t pos = 0;
+            while ((pos = sv.find(',')) != std::string_view::npos) {
+                keys.emplace_back(sv.substr(0, pos));
+                sv.remove_prefix(pos + 1);
+            }
+            keys.emplace_back(sv);
         }
 
-        item.ok = true;
-        item.values = std::vector<AllocatedBuffer::Descriptor>{};
-        for (const auto& replica : result.value().replicas) {
-            if (!replica.is_memory_replica()) {
+        if (keys.empty()) {
+            WriteSimpleErrorResponse(
+                resp, coro_http::status_type::bad_request,
+                "No keys provided. Use ?keys=key1,key2,...");
+            return;
+        }
+
+        auto results = service->BatchGetReplicaListForAdmin(keys, "default");
+        const size_t n = std::min(keys.size(), results.size());
+        HttpBatchQueryKeysResponse payload;
+        payload.success = true;
+
+        for (size_t i = 0; i < n; ++i) {
+            const auto& result = results[i];
+            HttpBatchQueryKeyResult item;
+            if (!result.has_value()) {
+                item.error = toString(result.error());
+                payload.data.emplace(keys[i], std::move(item));
                 continue;
             }
-            item.values->emplace_back(
-                replica.get_memory_descriptor().buffer_descriptor);
-        }
-        payload.data.emplace(keys[i], std::move(item));
-    }
 
-    if (results.size() != keys.size()) {
-        LOG(WARNING) << "BatchGetReplicaList size mismatch: keys="
-                     << keys.size() << " results=" << results.size();
-    }
-    WriteJsonResponse(resp, coro_http::status_type::ok, payload);
+            item.ok = true;
+            item.values = std::vector<AllocatedBuffer::Descriptor>{};
+            for (const auto& replica : result.value().replicas) {
+                if (replica.is_memory_replica()) {
+                    item.values->emplace_back(
+                        replica.get_memory_descriptor().buffer_descriptor);
+                } else if (replica.is_disk_replica()) {
+                    if (!item.disk_values.has_value()) {
+                        item.disk_values = std::vector<HttpDiskReplicaInfo>{};
+                    }
+                    auto& d = replica.get_disk_descriptor();
+                    item.disk_values->emplace_back(
+                        HttpDiskReplicaInfo{d.file_path, d.object_size});
+                } else if (replica.is_local_disk_replica()) {
+                    if (!item.local_disk_values.has_value()) {
+                        item.local_disk_values =
+                            std::vector<HttpLocalDiskReplicaInfo>{};
+                    }
+                    auto& d = replica.get_local_disk_descriptor();
+                    item.local_disk_values->emplace_back(
+                        HttpLocalDiskReplicaInfo{UuidToString(d.client_id),
+                                                 d.object_size,
+                                                 d.transport_endpoint});
+                } else if (replica.is_nof_replica()) {
+                    if (!item.nof_values.has_value()) {
+                        item.nof_values =
+                            std::vector<AllocatedBuffer::Descriptor>{};
+                    }
+                    item.nof_values->emplace_back(
+                        replica.get_nof_descriptor().buffer_descriptor);
+                }
+            }
+            payload.data.emplace(keys[i], std::move(item));
+        }
+
+        if (results.size() != keys.size()) {
+            LOG(WARNING) << "BatchGetReplicaListForAdmin size mismatch: keys="
+                         << keys.size() << " results=" << results.size();
+        }
+        WriteJsonResponse(resp, coro_http::status_type::ok, payload);
+    });
 }
 
 void MasterAdminServer::HandleGetTenantQuotas(

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -2228,6 +2228,35 @@ auto MasterService::GetReplicaList(const std::string& key,
     return resp;
 }
 
+auto MasterService::GetReplicaListForAdmin(const std::string& key,
+                                           const std::string& tenant_id)
+    -> tl::expected<GetReplicaListResponse, ErrorCode> {
+    const auto object_id = MakeObjectIdentity(key, tenant_id);
+
+    std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+    MetadataAccessorRO accessor(this, object_id);
+
+    if (!accessor.Exists()) {
+        VLOG(1) << "key=" << key << ", info=object_not_found";
+        return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
+    }
+    const auto& metadata = accessor.Get();
+
+    std::vector<Replica::Descriptor> replica_list;
+    metadata.VisitReplicas(
+        &Replica::fn_is_completed, [&replica_list](const Replica& replica) {
+            replica_list.emplace_back(replica.get_descriptor());
+        });
+
+    if (replica_list.empty()) {
+        LOG(WARNING) << "key=" << key << ", error=replica_not_ready";
+        return tl::make_unexpected(ErrorCode::REPLICA_IS_NOT_READY);
+    }
+
+    return GetReplicaListResponse(std::move(replica_list),
+                                  default_kv_lease_ttl_);
+}
+
 std::vector<tl::expected<GetReplicaListResponse, ErrorCode>>
 MasterService::BatchGetReplicaList(const std::vector<std::string>& keys,
                                    const std::string& tenant_id) {
@@ -2338,6 +2367,93 @@ MasterService::BatchGetReplicaList(const std::vector<std::string>& keys,
 
         for (const auto& object_id : promotion_candidates) {
             TryPushPromotionQueue(object_id);
+        }
+    }
+
+    return results;
+}
+
+std::vector<tl::expected<GetReplicaListResponse, ErrorCode>>
+MasterService::BatchGetReplicaListForAdmin(const std::vector<std::string>& keys,
+                                           const std::string& tenant_id) {
+    using GetResult = tl::expected<GetReplicaListResponse, ErrorCode>;
+
+    std::vector<GetResult> results(
+        keys.size(), tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND));
+    if (keys.empty()) {
+        return results;
+    }
+
+    const auto normalized_tenant = NormalizeTenantId(tenant_id);
+    constexpr size_t kInvalidKeyIndex = std::numeric_limits<size_t>::max();
+    std::array<size_t, kNumShards> key_list_heads;
+    key_list_heads.fill(kInvalidKeyIndex);
+    std::vector<size_t> next_key_indexes(keys.size(), kInvalidKeyIndex);
+    {
+        std::shared_lock<std::shared_mutex> lock(group_routing_mutex_);
+        for (size_t i = keys.size(); i > 0; --i) {
+            const size_t original_idx = i - 1;
+            const auto scoped_key =
+                MakeTenantScopedKey(normalized_tenant, keys[original_idx]);
+            const auto route_it = object_group_ids_.find(scoped_key);
+            const size_t shard_idx =
+                route_it == object_group_ids_.end()
+                    ? getShardIndex(normalized_tenant, keys[original_idx])
+                    : getShardIndex(route_it->second);
+            next_key_indexes[original_idx] = key_list_heads[shard_idx];
+            key_list_heads[shard_idx] = original_idx;
+        }
+    }
+
+    const size_t start_shard = RandomIndex(kNumShards);
+    for (size_t scanned = 0; scanned < kNumShards; ++scanned) {
+        const size_t shard_idx =
+            (start_shard + kNumShards - scanned) % kNumShards;
+        if (key_list_heads[shard_idx] == kInvalidKeyIndex) {
+            continue;
+        }
+
+        std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+        {
+            MetadataShardAccessorRO shard(this, shard_idx);
+            const auto tenant_it = shard->tenants.find(normalized_tenant);
+            for (size_t original_idx = key_list_heads[shard_idx];
+                 original_idx != kInvalidKeyIndex;
+                 original_idx = next_key_indexes[original_idx]) {
+                const std::string& key = keys[original_idx];
+
+                if (tenant_it == shard->tenants.end()) {
+                    results[original_idx] =
+                        tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
+                    continue;
+                }
+
+                const auto& tenant_state = tenant_it->second;
+                const auto metadata_it = tenant_state.metadata.find(key);
+                if (metadata_it == tenant_state.metadata.end() ||
+                    !metadata_it->second.IsValid()) {
+                    results[original_idx] =
+                        tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
+                    continue;
+                }
+
+                const auto& metadata = metadata_it->second;
+                std::vector<Replica::Descriptor> replica_list;
+                metadata.VisitReplicas(
+                    &Replica::fn_is_completed,
+                    [&replica_list](const Replica& replica) {
+                        replica_list.emplace_back(replica.get_descriptor());
+                    });
+
+                if (replica_list.empty()) {
+                    results[original_idx] =
+                        tl::make_unexpected(ErrorCode::REPLICA_IS_NOT_READY);
+                    continue;
+                }
+
+                results[original_idx] = GetReplicaListResponse(
+                    std::move(replica_list), default_kv_lease_ttl_);
+            }
         }
     }
 

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -230,6 +230,21 @@ WrappedMasterService::BatchGetReplicaList(const std::vector<std::string>& keys,
     return results;
 }
 
+std::vector<tl::expected<GetReplicaListResponse, ErrorCode>>
+WrappedMasterService::BatchGetReplicaListForAdmin(
+    const std::vector<std::string>& keys, const std::string& tenant_id) {
+    return master_service_.BatchGetReplicaListForAdmin(keys, tenant_id);
+}
+
+tl::expected<GetReplicaListResponse, ErrorCode>
+WrappedMasterService::GetReplicaListForAdmin(const std::string& key,
+                                             const std::string& tenant_id) {
+    return execute_rpc(
+        "GetReplicaListForAdmin",
+        [&] { return master_service_.GetReplicaListForAdmin(key, tenant_id); },
+        [&](auto& timer) { timer.LogRequest("key=", key); }, [] {}, [] {});
+}
+
 tl::expected<std::vector<Replica::Descriptor>, ErrorCode>
 WrappedMasterService::PutStart(const UUID& client_id, const std::string& key,
                                const uint64_t slice_length,

--- a/mooncake-store/tests/master_admin_server_test.cpp
+++ b/mooncake-store/tests/master_admin_server_test.cpp
@@ -1178,6 +1178,55 @@ TEST_F(MasterAdminServerTest, MultipleSegmentsAndKeys) {
     admin.Stop();
 }
 
+// /batch_query_keys returns replica metadata for disk-based keys via the
+// optional disk_values/local_disk_values/nof_values fields, while the existing
+// values field stays present (empty array) for backward compatibility.
+TEST_F(MasterAdminServerTest, BatchQueryKeysReturnsLocalDiskReplicaInfo) {
+    WrappedMasterServiceConfig svc_config;
+    svc_config.default_kv_lease_ttl = 5000;
+    svc_config.enable_metric_reporting = false;
+    svc_config.enable_offload = true;  // required to mount local-disk segments
+    auto service = std::make_shared<WrappedMasterService>(svc_config);
+
+    UUID client_id = generate_uuid();
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = "ld_segment";
+    segment.base = 0x600000000;
+    segment.size = 8 * 1024 * 1024;
+    ASSERT_TRUE(service->MountSegment(segment, client_id).has_value());
+    ASSERT_TRUE(service->MountLocalDiskSegment(client_id, true).has_value());
+
+    const std::string key = "ld_only_key";
+    const std::string endpoint = "127.0.0.1:9999";
+    StorageObjectMetadata sm;
+    sm.bucket_id = 0;
+    sm.offset = 0;
+    sm.key_size = static_cast<int64_t>(key.size());
+    sm.data_size = 2048;
+    sm.transport_endpoint = endpoint;
+    OffloadTaskItem task{.tenant_id = "default", .key = key, .size = 2048};
+    ASSERT_TRUE(
+        service->NotifyOffloadSuccess(client_id, {task}, {sm}).has_value());
+
+    int port = getFreeTcpPort();
+    MasterAdminServer admin(static_cast<uint16_t>(port), false);
+    ASSERT_TRUE(admin.Start());
+    admin.SetRuntimeState(ha::MasterRuntimeState::kServing);
+    admin.SetServiceDelegate(service);
+    admin.SetServiceAvailable(true);
+
+    auto resp = HttpGet(port, "/batch_query_keys?keys=" + key);
+    EXPECT_EQ(resp.http_status, 200);
+    EXPECT_NE(resp.body.find("\"success\":true"), std::string::npos);
+    EXPECT_NE(resp.body.find("local_disk_values"), std::string::npos);
+    EXPECT_NE(resp.body.find(endpoint), std::string::npos);
+    // Backward compat: a disk-only key still reports an (empty) values array.
+    EXPECT_NE(resp.body.find("\"values\":[]"), std::string::npos);
+
+    admin.Stop();
+}
+
 }  // namespace test
 }  // namespace mooncake
 

--- a/mooncake-store/tests/promotion_on_hit_test.cpp
+++ b/mooncake-store/tests/promotion_on_hit_test.cpp
@@ -253,6 +253,91 @@ TEST_F(PromotionOnHitTest, BatchGetReplicaListPromotesLocalDiskOnlyObject) {
     service->RemoveAll();
 }
 
+// The read-only admin batch query must NOT trigger promotion-on-hit, even for a
+// LOCAL_DISK-only key. Contrast with BatchGetReplicaListPromotesLocalDiskOnly
+// Object above, where the client-facing BatchGetReplicaList admits the key for
+// promotion.
+TEST_F(PromotionOnHitTest,
+       BatchGetReplicaListForAdminDoesNotPromoteLocalDiskOnlyObject) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;
+    config.promotion_max_per_heartbeat = 2;
+    config.default_kv_lease_ttl = 2000;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto ctx = PrepareSegment(*service, "test_segment_admin",
+                              kDefaultSegmentBase, seg_size);
+
+    const std::string key = "k_batch_admin_no_promote";
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, ctx.client_id, key, 1024,
+                                       ctx.segment_name));
+
+    auto& mm = MasterMetricManager::instance();
+    const int64_t admitted_pre = mm.get_promotion_admitted();
+    const int64_t in_flight_pre = mm.get_promotion_in_flight();
+
+    auto result = service->BatchGetReplicaListForAdmin(
+        std::vector<std::string>{key}, "default");
+    ASSERT_EQ(result.size(), 1u);
+    ASSERT_TRUE(result[0].has_value());
+    ASSERT_EQ(result[0]->replicas.size(), 1u);
+    EXPECT_TRUE(result[0]->replicas[0].is_local_disk_replica());
+
+    // No promotion admitted or enqueued by the read-only admin path.
+    EXPECT_EQ(mm.get_promotion_admitted() - admitted_pre, 0);
+    EXPECT_EQ(mm.get_promotion_in_flight() - in_flight_pre, 0);
+    auto pending = service->PromotionObjectHeartbeat(ctx.client_id);
+    ASSERT_TRUE(pending.has_value());
+    EXPECT_EQ(pending->size(), 0u);
+    EXPECT_EQ(CountPromotionTask(*pending, key), 0u);
+
+    service->RemoveAll();
+}
+
+// The read-only admin batch query must NOT update the store-observed cache-hit
+// counters. Contrast with the client-facing BatchGetReplicaList, which bumps
+// the memory-cache-hit counter for a MEMORY replica.
+TEST_F(PromotionOnHitTest,
+       BatchGetReplicaListForAdminDoesNotUpdateCacheHitMetrics) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.default_kv_lease_ttl = 2000;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto ctx = PrepareSegment(*service, "metrics_segment", kDefaultSegmentBase,
+                              seg_size);
+
+    const std::string key = "k_admin_no_metric";
+    PutObject(*service, ctx.client_id, key, 1024);
+
+    using CacheHitStat = MasterMetricManager::CacheHitStat;
+    auto mem_hits = []() {
+        auto stats = MasterMetricManager::instance().calculate_cache_stats();
+        return stats[CacheHitStat::MEMORY_HITS];
+    };
+
+    const double before_admin = mem_hits();
+
+    // Read-only admin query must leave the memory-cache-hit counter untouched.
+    auto admin_result = service->BatchGetReplicaListForAdmin(
+        std::vector<std::string>{key}, "default");
+    ASSERT_EQ(admin_result.size(), 1u);
+    ASSERT_TRUE(admin_result[0].has_value());
+    EXPECT_EQ(mem_hits(), before_admin);
+
+    // The client-facing path does bump it, proving the assertion above is
+    // meaningful rather than a counter that never moves.
+    (void)service->BatchGetReplicaList(std::vector<std::string>{key},
+                                       "default");
+    EXPECT_GT(mem_hits(), before_admin);
+
+    service->RemoveAll();
+}
+
 // PromotionObjectHeartbeat returns an empty task list when called against a
 // client that has no LocalDiskSegment registered.
 TEST_F(PromotionOnHitTest, HeartbeatReturnsErrorForUnknownClient) {


### PR DESCRIPTION
## Description

The `/batch_query_keys` HTTP admin endpoint had two problems:

1. **Side effects from reusing a client-facing API.** `HandleBatchQueryKeys` called `BatchGetReplicaList`, which is designed for client reads and performs `GrantLeaseForGroup()`, `promotion_on_hit_`, and cache-hit metric updates. Admin queries therefore prevented keys from being evicted, spuriously promoted disk-only keys to memory, and polluted cache-hit metrics. By contrast `/get_all_keys` uses the side-effect-free `GetAllKeysForAdmin()` path — the two endpoints were inconsistent.

2. **Missing replica info for disk-based keys.** The HTTP handler skipped non-memory replicas (`if (!replica.is_memory_replica()) continue;`), so disk / local_disk / nof keys returned an empty `values` vector and the caller could not inspect their replica locations, even though the metadata was available in the master.

This change adds `BatchGetReplicaListForAdmin` and `GetReplicaListForAdmin` to `MasterService` and `WrappedMasterService`: pure metadata reads that skip lease grants, promotion, and cache-hit counters. `HandleBatchQueryKeys` now uses the admin variant and additionally serializes `disk_values`, `local_disk_values`, and `nof_values` alongside the existing `values` field. `values` remains always-present (empty array for disk-only keys) so existing clients that check for the field or treat it as an array are unaffected; the new fields are optional and only appear when the corresponding replica type is present.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
# Code format check
./scripts/code_format.sh --check

# Compile the changed files
cd build
cmake --build . --target mooncake_master -j1

# End-to-end manual test against a running mooncake_master
# (write a local_disk key via the store client first)
curl -s "http://<master_host>:<http_port>/batch_query_keys?keys=<local_disk_key>"
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

**Code format:** `./scripts/code_format.sh --check` reports all 5 changed files properly formatted.

**Compile verification:** `master_admin_service.cpp` and `rpc_service.cpp` compiled individually with the project's exact CMake flags — no errors from the changed code (only pre-existing third-party warnings from async_simple / yalantinglibs).

**End-to-end manual test:** Wrote a `LOCAL_DISK` replica to the store, then queried it via `/batch_query_keys`:

```bash
$ curl -s "http://127.0.0.1:9003/batch_query_keys?keys=b909bf28318272fd6ce0dc7ceae4c1ee6477878cd662defd8363ff49b5c24bd0_0_k"
```

Response:
```json
{
  "success": true,
  "data": {
    "b909bf28318272fd6ce0dc7ceae4c1ee6477878cd662defd8363ff49b5c24bd0_0_k": {
      "ok": true,
      "error": null,
      "values": [],
      "disk_values": null,
      "local_disk_values": [
        {
          "client_id": "9531234657444698320-2435329600209450907",
          "object_size": 32768,
          "transport_endpoint": "127.0.0.1:44641"
        }
      ],
      "nof_values": null
    }
  }
}
```

The response confirms the expected behavior:
- `values` is `[]` (no memory replica) — unchanged from prior behavior, preserving backward compatibility
- `local_disk_values` is populated with the replica's `client_id`, `object_size`, and `transport_endpoint`
- `disk_values` and `nof_values` are `null` (no replicas of those types)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [x] No AI tools were used
- [ ] AI tools were used (specify below)