### PR TITLE
[Store] Replace OffsetAllocator Mutex with SharedMutex for concurrent reads

### DIFF
--- a/mooncake-store/include/mutex.h
+++ b/mooncake-store/include/mutex.h
@@ -39,6 +39,9 @@
 #define REQUIRES(...) \
     THREAD_ANNOTATION_ATTRIBUTE__(requires_capability(__VA_ARGS__))
 
+#define REQUIRES_SHARED(...) \
+    THREAD_ANNOTATION_ATTRIBUTE__(requires_shared_capability(__VA_ARGS__))
+
 #define ACQUIRE(...) \
     THREAD_ANNOTATION_ATTRIBUTE__(acquire_capability(__VA_ARGS__))
 

--- a/mooncake-store/include/offset_allocator/offset_allocator.h
+++ b/mooncake-store/include/offset_allocator/offset_allocator.h
@@ -182,7 +182,8 @@ class OffsetAllocator : public std::enable_shared_from_this<OffsetAllocator> {
     // Internal method for Handle to free allocation (thread-safe)
     void freeAllocation(const OffsetAllocation& allocation, uint64_t size);
 
-    // Internal method to get metrics without locking (caller must hold m_mutex)
+    // Internal method to get metrics without locking.
+    // Caller must hold m_mutex (shared or exclusive lock).
     [[nodiscard]]
     OffsetAllocatorMetrics get_metrics_internal() const REQUIRES(m_mutex);
 
@@ -192,7 +193,7 @@ class OffsetAllocator : public std::enable_shared_from_this<OffsetAllocator> {
     // m_multiplier
     uint64_t m_multiplier_bits;
     uint64_t m_capacity;
-    mutable Mutex m_mutex;
+    mutable SharedMutex m_mutex;
 
     // Lightweight metrics maintained during allocation/deallocation
     uint64_t m_allocated_size GUARDED_BY(m_mutex) = 0;
@@ -271,7 +272,7 @@ class __Allocator {
 // Template method implementations
 template <typename T>
 void OffsetAllocator::serialize_to(T& serializer) const {
-    MutexLocker guard(&m_mutex);
+    SharedMutexLocker guard(&m_mutex, shared_lock);
 
     if (!m_allocator) {
         serializer.set_error("Allocator is not initialized");

--- a/mooncake-store/include/offset_allocator/offset_allocator.h
+++ b/mooncake-store/include/offset_allocator/offset_allocator.h
@@ -185,7 +185,8 @@ class OffsetAllocator : public std::enable_shared_from_this<OffsetAllocator> {
     // Internal method to get metrics without locking.
     // Caller must hold m_mutex (shared or exclusive lock).
     [[nodiscard]]
-    OffsetAllocatorMetrics get_metrics_internal() const REQUIRES(m_mutex);
+    OffsetAllocatorMetrics get_metrics_internal() const
+        REQUIRES_SHARED(m_mutex);
 
     std::unique_ptr<__Allocator> m_allocator GUARDED_BY(m_mutex);
     uint64_t m_base;

--- a/mooncake-store/src/offset_allocator.cpp
+++ b/mooncake-store/src/offset_allocator.cpp
@@ -570,7 +570,7 @@ std::optional<OffsetAllocationHandle> OffsetAllocator::allocate(size_t size) {
         return std::nullopt;
     }
 
-    MutexLocker guard(&m_mutex);
+    SharedMutexLocker guard(&m_mutex);
     if (!m_allocator) {
         return std::nullopt;
     }
@@ -606,7 +606,7 @@ std::optional<OffsetAllocationHandle> OffsetAllocator::allocate(size_t size) {
 }
 
 OffsetAllocStorageReport OffsetAllocator::storageReport() const {
-    MutexLocker guard(&m_mutex);
+    SharedMutexLocker guard(&m_mutex, shared_lock);
     if (!m_allocator) {
         return {0, 0};
     }
@@ -616,7 +616,7 @@ OffsetAllocStorageReport OffsetAllocator::storageReport() const {
 }
 
 OffsetAllocStorageReportFull OffsetAllocator::storageReportFull() const {
-    MutexLocker lock(&m_mutex);
+    SharedMutexLocker lock(&m_mutex, shared_lock);
     if (!m_allocator) {
         OffsetAllocStorageReportFull report{};
         return report;
@@ -648,13 +648,13 @@ OffsetAllocatorMetrics OffsetAllocator::get_metrics_internal() const {
 }
 
 OffsetAllocatorMetrics OffsetAllocator::get_metrics() const {
-    MutexLocker guard(&m_mutex);
+    SharedMutexLocker guard(&m_mutex, shared_lock);
     return get_metrics_internal();
 }
 
 void OffsetAllocator::freeAllocation(const OffsetAllocation& allocation,
                                      uint64_t size) {
-    MutexLocker lock(&m_mutex);
+    SharedMutexLocker lock(&m_mutex);
     if (m_allocator) {
         m_allocator->free(allocation);
         // Update lightweight metrics

--- a/mooncake-store/tests/offset_allocator_test.cpp
+++ b/mooncake-store/tests/offset_allocator_test.cpp
@@ -298,8 +298,8 @@ class OffsetAllocatorTest : public ::testing::Test {
 
     void assertAllocatorEQ(const std::shared_ptr<OffsetAllocator>& a,
                            const std::shared_ptr<OffsetAllocator>& b) {
-        MutexLocker lock_a(&a->m_mutex);
-        MutexLocker lock_b(&b->m_mutex);
+        SharedMutexLocker lock_a(&a->m_mutex);
+        SharedMutexLocker lock_b(&b->m_mutex);
         // Compare basic member variables
         ASSERT_EQ(a->m_base, b->m_base);
         ASSERT_EQ(a->m_multiplier_bits, b->m_multiplier_bits);
@@ -356,8 +356,8 @@ class OffsetAllocatorTest : public ::testing::Test {
     // Compare two allocators bytes by bytes to detect one bit difference.
     bool isAllocatorEqual(const std::shared_ptr<OffsetAllocator>& a,
                           const std::shared_ptr<OffsetAllocator>& b) {
-        MutexLocker lock_a(&a->m_mutex);
-        MutexLocker lock_b(&b->m_mutex);
+        SharedMutexLocker lock_a(&a->m_mutex);
+        SharedMutexLocker lock_b(&b->m_mutex);
         // Compare basic member variables
         if (memcmp(&a->m_base, &b->m_base, sizeof(a->m_base)) != 0)
             return false;


### PR DESCRIPTION
## Description

Replace the single `Mutex` in `OffsetAllocator` with a `SharedMutex` (reader-writer lock). Allocations (`allocate`, `freeAllocation`) take an exclusive lock while metric queries (`storageReport`, `getMetrics`, `serialize_to`) take a shared lock.

Under concurrent GET workloads, the original mutex serialized all read-only metric queries against allocations, creating head-of-line blocking. With SharedMutex, multiple concurrent metric queries can proceed simultaneously.

**E2E benchmark (16 threads):** CONC_GET 45,667 → 59,931 ops/s (**+31.2%**)

## Module

- [x] Mooncake Store (`mooncake-store`)

## Type of Change

- [x] Performance improvement

## How Has This Been Tested?

**Test commands:**
```bash
# Build with the full Mooncake Store build
cmake .. -DCMAKE_BUILD_TYPE=Release && make -j$(nproc)
```

**Test results:**
- [x] Manual testing done — E2E benchmark shows +31.2% CONC_GET throughput
- [ ] Unit tests pass — CI will verify
- [ ] Integration tests pass — CI will verify

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using clang-format v20.1.0 (Google style, 4-space indent)
- [x] I have run `pre-commit run --all-files` — all hooks pass
- [ ] I have updated the documentation — N/A
- [ ] I have added tests to prove my changes are effective — E2E benchmark scripts in separate PR
- [ ] For changes >500 LOC: N/A (19 lines)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Claude Code was used for: code review and pre-commit verification.