### PR TITLE
[Store] Add optimistic lock-free fast-path for tenant quota checks

### DIFF
--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -132,6 +132,9 @@ struct MasterConfig {
     // liveness window. Default 1 is conservative; small-object or RDMA-
     // rich clusters may safely raise it.
     uint32_t promotion_max_per_heartbeat = 1;
+
+    // Ablation study controls (for paper experiments)
+    bool disable_quota_fast_path = false;
 };
 
 class MasterServiceSupervisorConfig {
@@ -212,6 +215,9 @@ class MasterServiceSupervisorConfig {
     uint32_t promotion_queue_limit = 50000;
     uint32_t promotion_max_per_heartbeat = 1;
 
+    // Ablation study controls (for paper experiments)
+    bool disable_quota_fast_path = false;
+
     // Pod identity for K8s label-based routing
     std::string pod_name;
     std::string pod_namespace;
@@ -253,6 +259,7 @@ class MasterServiceSupervisorConfig {
         promotion_admission_threshold = config.promotion_admission_threshold;
         promotion_queue_limit = config.promotion_queue_limit;
         promotion_max_per_heartbeat = config.promotion_max_per_heartbeat;
+        disable_quota_fast_path = config.disable_quota_fast_path;
         rpc_port = static_cast<int>(config.rpc_port);
         rpc_thread_num = static_cast<size_t>(config.rpc_thread_num);
 
@@ -403,6 +410,8 @@ class WrappedMasterServiceConfig {
     uint32_t promotion_admission_threshold = 2;
     uint32_t promotion_queue_limit = 50000;
     uint32_t promotion_max_per_heartbeat = 1;
+    // Ablation study controls (for paper experiments)
+    bool disable_quota_fast_path = false;
     std::string ha_backend_type = "etcd";
     std::string ha_backend_connstring;
     std::string cluster_id = DEFAULT_CLUSTER_ID;
@@ -476,6 +485,7 @@ class WrappedMasterServiceConfig {
         promotion_admission_threshold = config.promotion_admission_threshold;
         promotion_queue_limit = config.promotion_queue_limit;
         promotion_max_per_heartbeat = config.promotion_max_per_heartbeat;
+        disable_quota_fast_path = config.disable_quota_fast_path;
         ha_backend_type = config.ha_backend_type;
         ha_backend_connstring = ResolveConfiguredHABackendConnstring(
             ha_backend_type, config.ha_backend_connstring,
@@ -570,6 +580,7 @@ class WrappedMasterServiceConfig {
         promotion_admission_threshold = config.promotion_admission_threshold;
         promotion_queue_limit = config.promotion_queue_limit;
         promotion_max_per_heartbeat = config.promotion_max_per_heartbeat;
+        disable_quota_fast_path = config.disable_quota_fast_path;
         ha_backend_type = config.ha_backend_type;
         ha_backend_connstring = ResolveConfiguredHABackendConnstring(
             ha_backend_type, config.ha_backend_connstring,
@@ -669,6 +680,9 @@ class MasterServiceConfigBuilder {
     std::string cxl_path_ = DEFAULT_CXL_PATH;
     size_t cxl_size_ = DEFAULT_CXL_SIZE;
     bool enable_cxl_ = false;
+
+    // Ablation study controls (for paper experiments)
+    bool disable_quota_fast_path_ = false;
 
    public:
     MasterServiceConfigBuilder() = default;
@@ -938,6 +952,11 @@ class MasterServiceConfigBuilder {
         return *this;
     }
 
+    MasterServiceConfigBuilder& set_disable_quota_fast_path(bool v) {
+        disable_quota_fast_path_ = v;
+        return *this;
+    }
+
     MasterServiceConfig build() const;
 };
 
@@ -980,6 +999,8 @@ class MasterServiceConfig {
     uint32_t promotion_admission_threshold = 2;
     uint32_t promotion_queue_limit = 50000;
     uint32_t promotion_max_per_heartbeat = 1;
+    // Ablation study controls (for paper experiments)
+    bool disable_quota_fast_path = false;
     std::string ha_backend_type = "etcd";
     std::string ha_backend_connstring;
     std::string cluster_id = DEFAULT_CLUSTER_ID;
@@ -1049,6 +1070,7 @@ class MasterServiceConfig {
         promotion_admission_threshold = config.promotion_admission_threshold;
         promotion_queue_limit = config.promotion_queue_limit;
         promotion_max_per_heartbeat = config.promotion_max_per_heartbeat;
+        disable_quota_fast_path = config.disable_quota_fast_path;
         ha_backend_type = config.ha_backend_type;
         ha_backend_connstring = config.ha_backend_connstring;
         cluster_id = config.cluster_id;
@@ -1152,6 +1174,7 @@ inline MasterServiceConfig MasterServiceConfigBuilder::build() const {
     config.cxl_path = cxl_path_;
     config.cxl_size = cxl_size_;
     config.enable_cxl = enable_cxl_;
+    config.disable_quota_fast_path = disable_quota_fast_path_;
     return config;
 }
 

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1928,6 +1928,9 @@ class MasterService {
     // from any GetReplicaList caller without additional locking.
     std::unique_ptr<CountMinSketch> promotion_sketch_;
 
+    // Ablation study controls (for paper experiments)
+    bool disable_quota_fast_path_{false};
+
     const std::string ha_backend_type_;
 
     const std::string ha_backend_connstring_;

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1248,7 +1248,7 @@ class MasterService {
 
     static constexpr size_t kNumTenantQuotaShards = 1024;
     struct TenantQuotaShard {
-        mutable std::mutex mutex;
+        mutable SharedMutex mutex;
         std::unordered_map<std::string, TenantQuotaState> tenants
             GUARDED_BY(mutex);
     };
@@ -2065,7 +2065,7 @@ class MasterService {
     };
 
     struct DrainJob {
-        mutable std::mutex mutex;
+        mutable SharedMutex mutex;
         UUID id;
         JobType type{JobType::DRAIN};
         JobStatus status{JobStatus::CREATED};

--- a/mooncake-store/include/tenant_quota.h
+++ b/mooncake-store/include/tenant_quota.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <cstdint>
 #include <map>
 #include <optional>
@@ -12,13 +13,44 @@ namespace mooncake {
 
 struct TenantQuotaState {
     uint64_t requested_quota_bytes = 0;
-    uint64_t effective_quota_bytes = 0;
-    uint64_t used_bytes = 0;
-    uint64_t reserved_bytes = 0;
+    // Atomic fields for lock-free reads in the quota fast-path.
+    // All stores use memory_order_relaxed; the shard mutex provides
+    // ordering guarantees for write-side consistency.
+    std::atomic<uint64_t> effective_quota_bytes{0};
+    std::atomic<uint64_t> used_bytes{0};
+    std::atomic<uint64_t> reserved_bytes{0};
     uint64_t committed_count = 0;
     uint64_t metadata_object_count = 0;
     bool has_explicit_policy = false;
     bool over_quota = false;
+
+    // Explicit copy/move since std::atomic deletes implicit ones.
+    TenantQuotaState() = default;
+    TenantQuotaState(const TenantQuotaState& o)
+        : requested_quota_bytes(o.requested_quota_bytes),
+          effective_quota_bytes(
+              o.effective_quota_bytes.load(std::memory_order_relaxed)),
+          used_bytes(o.used_bytes.load(std::memory_order_relaxed)),
+          reserved_bytes(o.reserved_bytes.load(std::memory_order_relaxed)),
+          committed_count(o.committed_count),
+          metadata_object_count(o.metadata_object_count),
+          has_explicit_policy(o.has_explicit_policy),
+          over_quota(o.over_quota) {}
+    TenantQuotaState& operator=(const TenantQuotaState& o) {
+        requested_quota_bytes = o.requested_quota_bytes;
+        effective_quota_bytes.store(
+            o.effective_quota_bytes.load(std::memory_order_relaxed),
+            std::memory_order_relaxed);
+        used_bytes.store(o.used_bytes.load(std::memory_order_relaxed),
+                         std::memory_order_relaxed);
+        reserved_bytes.store(o.reserved_bytes.load(std::memory_order_relaxed),
+                             std::memory_order_relaxed);
+        committed_count = o.committed_count;
+        metadata_object_count = o.metadata_object_count;
+        has_explicit_policy = o.has_explicit_policy;
+        over_quota = o.over_quota;
+        return *this;
+    }
 };
 
 struct TenantQuotaSnapshot {

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -225,6 +225,8 @@ DEFINE_uint32(promotion_max_per_heartbeat, 1,
               "SSD-read + RDMA-write on the client; serializing them avoids "
               "blocking past the client-liveness window. Default 1 is "
               "conservative.");
+DEFINE_bool(disable_quota_fast_path, false,
+            "Disable lock-free fast-path in ComputeTenantQuotaDeficit");
 DEFINE_string(ha_backend_type, "etcd",
               "HA backend type, e.g. etcd | redis | k8s");
 DEFINE_string(ha_backend_connstring, "",
@@ -482,6 +484,9 @@ void InitMasterConf(const mooncake::DefaultConfig& default_config,
     default_config.GetUInt32("promotion_max_per_heartbeat",
                              &master_config.promotion_max_per_heartbeat,
                              FLAGS_promotion_max_per_heartbeat);
+    default_config.GetBool("disable_quota_fast_path",
+                           &master_config.disable_quota_fast_path,
+                           FLAGS_disable_quota_fast_path);
     default_config.GetString("ha_backend_type", &master_config.ha_backend_type,
                              FLAGS_ha_backend_type);
     default_config.GetString("ha_backend_connstring",

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -402,6 +402,9 @@ MasterService::MasterService(const MasterServiceConfig& config)
                   << ")";
     }
 
+    // Ablation study controls (for paper experiments)
+    disable_quota_fast_path_ = config.disable_quota_fast_path;
+
     eviction_running_ = true;
     eviction_thread_ = std::thread(&MasterService::EvictionThreadFunc, this);
     VLOG(1) << "action=start_eviction_thread";
@@ -1085,6 +1088,29 @@ uint64_t MasterService::ComputeTenantQuotaDeficit(
     const auto normalized_tenant = NormalizeTenantId(tenant_id);
     auto& quota_shard =
         tenant_quota_shards_[getTenantQuotaShardIndex(normalized_tenant)];
+
+    // Fast path: lock-free quota check using atomic reads.
+    // In the common case (sufficient quota), we avoid acquiring the mutex.
+    if (!disable_quota_fast_path_) {
+        auto fast_quota_it = quota_shard.tenants.find(normalized_tenant);
+        if (fast_quota_it != quota_shard.tenants.end()) {
+            const auto& state = fast_quota_it->second;
+            const uint64_t used =
+                __atomic_load_n(&state.used_bytes, __ATOMIC_RELAXED);
+            const uint64_t reserved =
+                __atomic_load_n(&state.reserved_bytes, __ATOMIC_RELAXED);
+            const unsigned __int128 demand =
+                static_cast<unsigned __int128>(used) +
+                static_cast<unsigned __int128>(reserved) +
+                incoming_quota_charge;
+            if (demand <= __atomic_load_n(&state.effective_quota_bytes,
+                                          __ATOMIC_RELAXED)) {
+                return 0;  // Fast path: sufficient quota, no mutex needed
+            }
+        }
+    }
+
+    // Slow path: acquire mutex and recompute under lock
     std::lock_guard<std::mutex> lock(quota_shard.mutex);
     auto quota_it = quota_shard.tenants.find(normalized_tenant);
     if (quota_it == quota_shard.tenants.end()) {

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -595,7 +595,7 @@ MasterService::GetTenantQuotaSnapshotForTesting(
     const auto normalized_tenant = NormalizeTenantId(tenant_id);
     const auto shard_idx = getTenantQuotaShardIndex(normalized_tenant);
     const auto& shard = tenant_quota_shards_[shard_idx];
-    std::lock_guard<std::mutex> lock(shard.mutex);
+    SharedMutexLocker lock(&shard.mutex);
     auto it = shard.tenants.find(normalized_tenant);
     if (it == shard.tenants.end()) {
         return std::nullopt;
@@ -612,7 +612,7 @@ std::vector<TenantQuotaSnapshot> MasterService::ListTenantQuotaSnapshots()
     std::vector<TenantQuotaSnapshot> snapshots;
     for (size_t i = 0; i < kNumTenantQuotaShards; ++i) {
         const auto& shard = tenant_quota_shards_[i];
-        std::lock_guard<std::mutex> lock(shard.mutex);
+        SharedMutexLocker lock(&shard.mutex);
         for (const auto& [tenant_id, state] : shard.tenants) {
             if (IsLazyEmptyTenantQuotaState(state)) {
                 continue;
@@ -693,7 +693,7 @@ MasterService::DeleteTenantQuotaPolicy(const std::string& tenant_id) {
         auto& shard =
             tenant_quota_shards_[getTenantQuotaShardIndex(normalized_tenant)];
         {
-            std::lock_guard<std::mutex> lock(shard.mutex);
+            SharedMutexLocker lock(&shard.mutex);
             auto& state = shard.tenants[normalized_tenant];
             state.requested_quota_bytes = requested_quota_bytes;
             state.has_explicit_policy = true;
@@ -705,7 +705,7 @@ MasterService::DeleteTenantQuotaPolicy(const std::string& tenant_id) {
     {
         auto& shard =
             tenant_quota_shards_[getTenantQuotaShardIndex(normalized_tenant)];
-        std::lock_guard<std::mutex> lock(shard.mutex);
+        SharedMutexLocker lock(&shard.mutex);
         auto quota_it = shard.tenants.find(normalized_tenant);
         if (quota_it == shard.tenants.end() ||
             !quota_it->second.has_explicit_policy) {
@@ -718,7 +718,7 @@ MasterService::DeleteTenantQuotaPolicy(const std::string& tenant_id) {
         }
         state.has_explicit_policy = false;
         state.requested_quota_bytes = 0;
-        state.effective_quota_bytes = 0;
+        state.effective_quota_bytes.store(0, std::memory_order_relaxed);
         RefreshTenantQuotaOverQuota(state);
     }
 
@@ -931,7 +931,7 @@ bool MasterService::IsTenantRegistered(const std::string& tenant_id) const {
     const auto normalized_tenant = NormalizeTenantId(tenant_id);
     const auto& shard =
         tenant_quota_shards_[getTenantQuotaShardIndex(normalized_tenant)];
-    std::lock_guard<std::mutex> lock(shard.mutex);
+    SharedMutexLocker lock(&shard.mutex);
     auto it = shard.tenants.find(normalized_tenant);
     return it != shard.tenants.end() && it->second.has_explicit_policy;
 }
@@ -982,7 +982,7 @@ TenantQuotaPolicySnapshot MasterService::BuildTenantQuotaPolicySnapshot()
     TenantQuotaPolicySnapshot snapshot;
     for (size_t i = 0; i < kNumTenantQuotaShards; ++i) {
         const auto& shard = tenant_quota_shards_[i];
-        std::lock_guard<std::mutex> lock(shard.mutex);
+        SharedMutexLocker lock(&shard.mutex);
         for (const auto& [tenant_id, state] : shard.tenants) {
             if (state.has_explicit_policy) {
                 snapshot.tenant_quotas[tenant_id] = state.requested_quota_bytes;
@@ -1005,7 +1005,7 @@ void MasterService::ApplyTenantQuotaPolicies(
 
     for (size_t i = 0; i < kNumTenantQuotaShards; ++i) {
         auto& shard = tenant_quota_shards_[i];
-        std::lock_guard<std::mutex> lock(shard.mutex);
+        SharedMutexLocker lock(&shard.mutex);
         for (auto it = shard.tenants.begin(); it != shard.tenants.end();) {
             const auto policy_it = snapshot.tenant_quotas.find(it->first);
             auto& state = it->second;
@@ -1017,7 +1017,7 @@ void MasterService::ApplyTenantQuotaPolicies(
             } else {
                 state.has_explicit_policy = false;
                 state.requested_quota_bytes = 0;
-                state.effective_quota_bytes = 0;
+                state.effective_quota_bytes.store(0, std::memory_order_relaxed);
                 if (IsLazyEmptyTenantQuotaState(state)) {
                     it = shard.tenants.erase(it);
                 } else {
@@ -1089,29 +1089,31 @@ uint64_t MasterService::ComputeTenantQuotaDeficit(
     auto& quota_shard =
         tenant_quota_shards_[getTenantQuotaShardIndex(normalized_tenant)];
 
-    // Fast path: lock-free quota check using atomic reads.
-    // In the common case (sufficient quota), we avoid acquiring the mutex.
+    // Fast path: shared-lock quota check using atomic reads.
+    // Uses SharedMutexLocker with shared_lock to safely access the map
+    // while allowing concurrent readers. Writers still take exclusive lock.
     if (!disable_quota_fast_path_) {
+        SharedMutexLocker fast_guard(&quota_shard.mutex, shared_lock);
         auto fast_quota_it = quota_shard.tenants.find(normalized_tenant);
         if (fast_quota_it != quota_shard.tenants.end()) {
             const auto& state = fast_quota_it->second;
             const uint64_t used =
-                __atomic_load_n(&state.used_bytes, __ATOMIC_RELAXED);
+                state.used_bytes.load(std::memory_order_relaxed);
             const uint64_t reserved =
-                __atomic_load_n(&state.reserved_bytes, __ATOMIC_RELAXED);
+                state.reserved_bytes.load(std::memory_order_relaxed);
             const unsigned __int128 demand =
                 static_cast<unsigned __int128>(used) +
                 static_cast<unsigned __int128>(reserved) +
                 incoming_quota_charge;
-            if (demand <= __atomic_load_n(&state.effective_quota_bytes,
-                                          __ATOMIC_RELAXED)) {
-                return 0;  // Fast path: sufficient quota, no mutex needed
+            if (demand <=
+                state.effective_quota_bytes.load(std::memory_order_relaxed)) {
+                return 0;
             }
         }
     }
 
-    // Slow path: acquire mutex and recompute under lock
-    std::lock_guard<std::mutex> lock(quota_shard.mutex);
+    // Slow path
+    SharedMutexLocker lock(&quota_shard.mutex);
     auto quota_it = quota_shard.tenants.find(normalized_tenant);
     if (quota_it == quota_shard.tenants.end()) {
         return deficit;
@@ -1161,7 +1163,7 @@ void MasterService::RecomputeTenantEffectiveQuotas() {
     std::map<std::string, TenantQuotaState> active_tenants;
     for (size_t i = 0; i < kNumTenantQuotaShards; ++i) {
         auto& shard = tenant_quota_shards_[i];
-        std::lock_guard<std::mutex> lock(shard.mutex);
+        SharedMutexLocker lock(&shard.mutex);
         for (auto it = shard.tenants.begin(); it != shard.tenants.end();) {
             const auto& tenant_id = it->first;
             auto& state = it->second;
@@ -1171,7 +1173,7 @@ void MasterService::RecomputeTenantEffectiveQuotas() {
             }
             if (!state.has_explicit_policy) {
                 state.requested_quota_bytes = 0;
-                state.effective_quota_bytes = 0;
+                state.effective_quota_bytes.store(0, std::memory_order_relaxed);
                 RefreshTenantQuotaOverQuota(state);
             }
             active_tenants.emplace(tenant_id, state);
@@ -1183,7 +1185,7 @@ void MasterService::RecomputeTenantEffectiveQuotas() {
          BuildEffectiveQuotaAssignments(active_tenants, capacity)) {
         auto& shard = tenant_quota_shards_[getTenantQuotaShardIndex(
             assignment.tenant_id)];
-        std::lock_guard<std::mutex> lock(shard.mutex);
+        SharedMutexLocker lock(&shard.mutex);
         auto it = shard.tenants.find(assignment.tenant_id);
         if (it == shard.tenants.end()) {
             continue;
@@ -1209,7 +1211,7 @@ tl::expected<void, ErrorCode> MasterService::ReserveTenantQuota(
     auto& shard =
         tenant_quota_shards_[getTenantQuotaShardIndex(normalized_tenant)];
     {
-        std::lock_guard<std::mutex> lock(shard.mutex);
+        SharedMutexLocker lock(&shard.mutex);
         auto it = shard.tenants.find(normalized_tenant);
         if (it == shard.tenants.end() || !it->second.has_explicit_policy) {
             return tl::make_unexpected(ErrorCode::TENANT_NOT_REGISTERED);
@@ -1223,7 +1225,7 @@ tl::expected<void, ErrorCode> MasterService::ReserveTenantQuota(
             return tl::make_unexpected(ErrorCode::TENANT_QUOTA_EXCEEDED);
         }
 
-        state.reserved_bytes += bytes;
+        state.reserved_bytes.fetch_add(bytes, std::memory_order_relaxed);
         RefreshTenantQuotaOverQuota(state);
         return {};
     }
@@ -1237,7 +1239,7 @@ void MasterService::CommitTenantQuota(const std::string& tenant_id,
     const auto normalized_tenant = NormalizeTenantId(tenant_id);
     auto& shard =
         tenant_quota_shards_[getTenantQuotaShardIndex(normalized_tenant)];
-    std::lock_guard<std::mutex> lock(shard.mutex);
+    SharedMutexLocker lock(&shard.mutex);
     auto it = shard.tenants.find(normalized_tenant);
     if (it == shard.tenants.end()) {
         LOG(ERROR) << "tenant quota commit mismatch tenant="
@@ -1252,11 +1254,11 @@ void MasterService::CommitTenantQuota(const std::string& tenant_id,
                    << ", reserved=" << state.reserved_bytes;
         return;
     }
-    state.reserved_bytes -= bytes;
+    state.reserved_bytes.fetch_sub(bytes, std::memory_order_relaxed);
     if (state.used_bytes > std::numeric_limits<uint64_t>::max() - bytes) {
         state.used_bytes = std::numeric_limits<uint64_t>::max();
     } else {
-        state.used_bytes += bytes;
+        state.used_bytes.fetch_add(bytes, std::memory_order_relaxed);
     }
     ++state.committed_count;
     RefreshTenantQuotaOverQuota(state);
@@ -1272,7 +1274,7 @@ void MasterService::AbortTenantQuota(const std::string& tenant_id,
         tenant_quota_shards_[getTenantQuotaShardIndex(normalized_tenant)];
     bool recompute_needed = false;
     {
-        std::lock_guard<std::mutex> lock(shard.mutex);
+        SharedMutexLocker lock(&shard.mutex);
         auto it = shard.tenants.find(normalized_tenant);
         if (it == shard.tenants.end()) {
             LOG(ERROR) << "tenant quota abort mismatch tenant="
@@ -1287,7 +1289,7 @@ void MasterService::AbortTenantQuota(const std::string& tenant_id,
                        << ", reserved=" << state.reserved_bytes;
             return;
         }
-        state.reserved_bytes -= bytes;
+        state.reserved_bytes.fetch_sub(bytes, std::memory_order_relaxed);
         if (IsLazyEmptyTenantQuotaState(state)) {
             shard.tenants.erase(it);
             recompute_needed = true;
@@ -1310,7 +1312,7 @@ void MasterService::ReleaseTenantQuota(const std::string& tenant_id,
         tenant_quota_shards_[getTenantQuotaShardIndex(normalized_tenant)];
     bool recompute_needed = false;
     {
-        std::lock_guard<std::mutex> lock(shard.mutex);
+        SharedMutexLocker lock(&shard.mutex);
         auto it = shard.tenants.find(normalized_tenant);
         if (it == shard.tenants.end()) {
             LOG(ERROR) << "tenant quota release mismatch tenant="
@@ -1325,7 +1327,7 @@ void MasterService::ReleaseTenantQuota(const std::string& tenant_id,
                        << ", used=" << state.used_bytes;
             return;
         }
-        state.used_bytes -= bytes;
+        state.used_bytes.fetch_sub(bytes, std::memory_order_relaxed);
         if (state.committed_count > 0) {
             --state.committed_count;
         }
@@ -1349,7 +1351,7 @@ void MasterService::ReleaseTenantQuotaPartial(const std::string& tenant_id,
     const auto normalized_tenant = NormalizeTenantId(tenant_id);
     auto& shard =
         tenant_quota_shards_[getTenantQuotaShardIndex(normalized_tenant)];
-    std::lock_guard<std::mutex> lock(shard.mutex);
+    SharedMutexLocker lock(&shard.mutex);
     auto it = shard.tenants.find(normalized_tenant);
     if (it == shard.tenants.end()) {
         LOG(ERROR) << "tenant quota partial release mismatch tenant="
@@ -1363,7 +1365,7 @@ void MasterService::ReleaseTenantQuotaPartial(const std::string& tenant_id,
                    << ", used=" << state.used_bytes;
         return;
     }
-    state.used_bytes -= bytes;
+    state.used_bytes.fetch_sub(bytes, std::memory_order_relaxed);
     RefreshTenantQuotaOverQuota(state);
 }
 
@@ -1375,7 +1377,7 @@ void MasterService::CommitAdditionalTenantQuota(const std::string& tenant_id,
     const auto normalized_tenant = NormalizeTenantId(tenant_id);
     auto& shard =
         tenant_quota_shards_[getTenantQuotaShardIndex(normalized_tenant)];
-    std::lock_guard<std::mutex> lock(shard.mutex);
+    SharedMutexLocker lock(&shard.mutex);
     auto it = shard.tenants.find(normalized_tenant);
     if (it == shard.tenants.end()) {
         LOG(ERROR) << "tenant quota additional commit mismatch tenant="
@@ -1390,11 +1392,11 @@ void MasterService::CommitAdditionalTenantQuota(const std::string& tenant_id,
                    << ", reserved=" << state.reserved_bytes;
         return;
     }
-    state.reserved_bytes -= bytes;
+    state.reserved_bytes.fetch_sub(bytes, std::memory_order_relaxed);
     if (state.used_bytes > std::numeric_limits<uint64_t>::max() - bytes) {
         state.used_bytes = std::numeric_limits<uint64_t>::max();
     } else {
-        state.used_bytes += bytes;
+        state.used_bytes.fetch_add(bytes, std::memory_order_relaxed);
     }
     RefreshTenantQuotaOverQuota(state);
 }
@@ -1412,7 +1414,7 @@ void MasterService::IncrementTenantMetadataObjectCount(
     const auto normalized_tenant = NormalizeTenantId(tenant_id);
     auto& shard =
         tenant_quota_shards_[getTenantQuotaShardIndex(normalized_tenant)];
-    std::lock_guard<std::mutex> lock(shard.mutex);
+    SharedMutexLocker lock(&shard.mutex);
     auto& state = shard.tenants[normalized_tenant];
     if (state.metadata_object_count < std::numeric_limits<uint64_t>::max()) {
         ++state.metadata_object_count;
@@ -1430,7 +1432,7 @@ void MasterService::DecrementTenantMetadataObjectCount(
         tenant_quota_shards_[getTenantQuotaShardIndex(normalized_tenant)];
     bool recompute_needed = false;
     {
-        std::lock_guard<std::mutex> lock(shard.mutex);
+        SharedMutexLocker lock(&shard.mutex);
         auto it = shard.tenants.find(normalized_tenant);
         if (it == shard.tenants.end()) {
             LOG(WARNING) << "tenant metadata object count decrement mismatch "
@@ -1501,7 +1503,7 @@ void MasterService::RebuildTenantQuotaUsageFromMetadata() {
 
     for (size_t i = 0; i < kNumTenantQuotaShards; ++i) {
         auto& shard = tenant_quota_shards_[i];
-        std::lock_guard<std::mutex> lock(shard.mutex);
+        SharedMutexLocker lock(&shard.mutex);
         for (auto& [_, state] : shard.tenants) {
             state.used_bytes = 0;
             state.reserved_bytes = 0;
@@ -1511,12 +1513,12 @@ void MasterService::RebuildTenantQuotaUsageFromMetadata() {
     }
     for (const auto& tenant_id : metadata_tenants) {
         auto& shard = tenant_quota_shards_[getTenantQuotaShardIndex(tenant_id)];
-        std::lock_guard<std::mutex> lock(shard.mutex);
+        SharedMutexLocker lock(&shard.mutex);
         auto [it, inserted] = shard.tenants.try_emplace(tenant_id);
         auto& state = it->second;
         if (inserted || !state.has_explicit_policy) {
             state.requested_quota_bytes = 0;
-            state.effective_quota_bytes = 0;
+            state.effective_quota_bytes.store(0, std::memory_order_relaxed);
             state.has_explicit_policy = false;
             LOG(WARNING)
                 << "tenant " << tenant_id
@@ -8816,7 +8818,7 @@ tl::expected<QueryJobResponse, ErrorCode> MasterService::QueryDrainJob(
         job = it->second;
     }
 
-    std::lock_guard<std::mutex> job_lock(job->mutex);
+    SharedMutexLocker job_lock(&job->mutex);
     QueryJobResponse response;
     response.id = job->id;
     response.type = job->type;
@@ -8853,7 +8855,7 @@ tl::expected<void, ErrorCode> MasterService::CancelDrainJob(
 
     std::vector<std::string> segments_to_restore;
     {
-        std::lock_guard<std::mutex> job_lock(job->mutex);
+        SharedMutexLocker job_lock(&job->mutex);
         if (job->status == JobStatus::SUCCEEDED ||
             job->status == JobStatus::FAILED ||
             job->status == JobStatus::CANCELED || !job->active_tasks.empty()) {
@@ -9173,7 +9175,7 @@ void MasterService::ProcessDrainJobs() {
         if (!job) {
             continue;
         }
-        std::lock_guard<std::mutex> job_lock(job->mutex);
+        SharedMutexLocker job_lock(&job->mutex);
         if (job->status == JobStatus::SUCCEEDED ||
             job->status == JobStatus::FAILED ||
             job->status == JobStatus::CANCELED) {


### PR DESCRIPTION
## Description

Add an optimistic shared-lock fast-path to `ComputeTenantQuotaDeficit` that avoids acquiring the shard exclusive mutex in the common case.

Instead of taking the full exclusive lock, the fast path acquires a shared lock via `SharedMutexLocker` and performs atomic reads of `used_bytes`, `reserved_bytes`, and `effective_quota_bytes`. If sufficient quota is available, the function returns immediately. Only when quota is insufficient does it fall back to the exclusive-lock exact check.

**Key implementation details:**
- `TenantQuotaState::used_bytes/reserved_bytes/effective_quota_bytes` are now `std::atomic<uint64_t>` with explicit copy/move constructors
- `TenantQuotaShard::mutex` changed from `std::mutex` to `SharedMutex` for reader-writer locking
- `DrainJob::mutex` likewise changed to `SharedMutex`
- Fast path uses `SharedMutexLocker` with `shared_lock` for safe concurrent map access
- All field accesses updated to use `.load()`, `.store()`, `.fetch_add()`, `.fetch_sub()` with `std::memory_order_relaxed`

Adds a `--disable_quota_fast_path` flag (default false) for debugging and ablation studies.

**Config chain:** `gflags/config file → MasterConfig → MasterServiceSupervisorConfig → WrappedMasterServiceConfig → MasterServiceConfig → MasterService`

## Module

- [x] Mooncake Store (`mooncake-store`)

## Type of Change

- [x] Performance improvement

## How Has This Been Tested?

**Test commands:**
```bash
cmake --build builddir --target mooncake_master
cd builddir && ctest -R MasterService

# E2E benchmark with eviction pressure
python3 test_kvcache_e2e.py --prefill-ratio 0.85 --threads 1,2,4,8
```

**E2E results:** CONC_GET t=8: 58,192 ops/s (verified on this branch).