### PR TITLE
[Doc] Align docs homepage and sidebar navigation depth

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -85,6 +85,7 @@ html_theme_options = {
     # Prevents the full API being added to the left sidebar of every page.
     # Reduces build time by 2.5x and reduces build size from ~225MB to ~95MB.
     'collapse_navbar': True,
+    'show_navbar_depth': 2,
     # Makes API visible in the right sidebar on API reference pages.
     'show_toc_level': 3,
 }

--- a/docs/source/getting_started/examples/vllm-integration/vllm-integration-v0.2.md
+++ b/docs/source/getting_started/examples/vllm-integration/vllm-integration-v0.2.md
@@ -1,3 +1,7 @@
+---
+orphan: true
+---
+
 # vLLM V0 Disaggregated Serving Demo
 
 ```{admonition} Archived

--- a/docs/source/getting_started/examples/vllm-integration/vllm-integration-v0.3.md
+++ b/docs/source/getting_started/examples/vllm-integration/vllm-integration-v0.3.md
@@ -1,3 +1,7 @@
+---
+orphan: true
+---
+
 # vLLM V0 Disaggregated Serving with MooncakeStore
 
 ```{admonition} Archived

--- a/docs/source/getting_started/examples/vllm-integration/vllm-integration-v1.0.md
+++ b/docs/source/getting_started/examples/vllm-integration/vllm-integration-v1.0.md
@@ -1,3 +1,7 @@
+---
+orphan: true
+---
+
 # vLLM v1 backend Disaggregated Serving with MooncakeConnector
 
 ```{admonition} Archived

--- a/docs/source/getting_started/examples/vllm-integration/vllm-mooncakestoreconnector.md
+++ b/docs/source/getting_started/examples/vllm-integration/vllm-mooncakestoreconnector.md
@@ -1,3 +1,7 @@
+---
+orphan: true
+---
+
 # Guide: vLLM MooncakeStoreConnector
 
 ```{admonition} Archived

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -85,7 +85,7 @@ At the center of Mooncake is a KVCache-centric scheduler that balances effective
 
 :::{toctree}
 :caption: Getting Started
-:maxdepth: 2
+:maxdepth: 1
 
 getting_started/build
 getting_started/quick-start
@@ -96,7 +96,7 @@ getting_started/quick-start
 
 :::{toctree}
 :caption: Deployment
-:maxdepth: 2
+:maxdepth: 1
 
 deployment/mooncake-store-deployment-guide
 getting_started/examples/sglang-integration/index
@@ -121,7 +121,7 @@ performance/mooncake/index
 
 :::{toctree}
 :caption: Design Documents
-:maxdepth: 2
+:maxdepth: 1
 
 design/architecture
 design/mooncake-store
@@ -142,7 +142,7 @@ design/ssd-free-ratio-first-allocation
 
 :::{toctree}
 :caption: API Reference
-:maxdepth: 2
+:maxdepth: 1
 
 api-reference/python/index
 api-reference/cpp/index
@@ -173,12 +173,9 @@ community/governance
 
 % Archived content
 
-:::{toctree}
-:caption: Archived
-:maxdepth: 1
+### Archived
 
-getting_started/examples/vllm-integration/vllm-mooncakestoreconnector
-getting_started/examples/vllm-integration/vllm-integration-v0.2
-getting_started/examples/vllm-integration/vllm-integration-v0.3
-getting_started/examples/vllm-integration/vllm-integration-v1.0
-:::
+- [Guide: vLLM MooncakeStoreConnector](getting_started/examples/vllm-integration/vllm-mooncakestoreconnector)
+- [vLLM V0 Disaggregated Serving Demo](getting_started/examples/vllm-integration/vllm-integration-v0.2)
+- [vLLM V0 Disaggregated Serving with MooncakeStore](getting_started/examples/vllm-integration/vllm-integration-v0.3)
+- [vLLM v1 backend Disaggregated Serving with MooncakeConnector](getting_started/examples/vllm-integration/vllm-integration-v1.0)


### PR DESCRIPTION
## Description

Align the documentation landing page and sidebar navigation depth so the homepage table of contents shows one level while the sidebar is capped at two levels. The archived documentation group remains discoverable from `index.md` as ordinary Markdown links, but is no longer part of the root toctree, so it does not appear in the left sidebar navigation.

The archived pages are marked as `orphan` so Sphinx still builds them without emitting "not included in any toctree" warnings.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Built the Sphinx HTML documentation and verified the generated homepage HTML.

**Test commands:**
```bash
/Users/aione/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m sphinx -b html -E -a source build/html
/Users/aione/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -c "from pathlib import Path; from bs4 import BeautifulSoup; html=Path('docs/build/html/index.html').read_text(); soup=BeautifulSoup(html, 'html.parser'); sidebar=soup.select_one('.bd-sidebar-primary'); article=soup.select_one('article.bd-article'); print('sidebar_has_archived=', 'Archived' in sidebar.get_text(' ') if sidebar else None); print('article_has_archived=', 'Archived' in article.get_text(' ') if article else None)"
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (`sidebar_has_archived=False`, `article_has_archived=True`)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex was used to make the documentation navigation changes, build the Sphinx docs, and verify the generated local HTML.