### PR TITLE
[CI/Build] Fix build-musa: add missing MUSA mappings for nvlink_transport APIs (#2578)

### DIFF
--- a/mooncake-transfer-engine/include/gpu_vendor/musa.h
+++ b/mooncake-transfer-engine/include/gpu_vendor/musa.h
@@ -111,6 +111,9 @@ const static std::string GPU_PREFIX = "musa:";
 #define cudaEventDisableTiming musaEventDisableTiming
 #define cudaEventDestroy musaEventDestroy
 #define cudaEventRecord musaEventRecord
+#define cudaEventSynchronize musaEventSynchronize
+#define cudaDeviceProp musaDeviceProp
+#define cudaGetDeviceProperties musaGetDeviceProperties
 #define cudaMemcpyDeviceToDevice musaMemcpyDeviceToDevice
 #define cudaDevAttrClockRate musaDevAttrClockRate
 #define cudaLaunchConfig_t musaLaunchConfig_t


### PR DESCRIPTION
## Description

PR #2578 introduced `cudaEventSynchronize`, `cudaDeviceProp`, and `cudaGetDeviceProperties` in `nvlink_transport.cpp` / `intranode_nvlink_transport.cpp` (for the new `PerDeviceStreamPool` and per-device event synchronization), but `gpu_vendor/musa.h` was not updated with the corresponding MUSA mappings, causing build-musa CI to fail:

```
nvlink_transport.cpp:80: 'cudaDeviceProp' was not declared in this scope; did you mean 'musaDeviceProp'?
nvlink_transport.cpp:82: 'cudaGetDeviceProperties' was not declared in this scope; did you mean 'musaGetDeviceProperties'?
nvlink_transport.cpp:485: 'cudaEventSynchronize' was not declared in this scope; did you mean 'musaEventSynchronize'?
```

Failing run: https://github.com/kvcache-ai/Mooncake/actions/runs/28561956953/job/84682279230

This is the same failure mode previously fixed in #2575 (for #2384). The vendor header must be kept in sync whenever new CUDA symbols are used in transport source files.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

The failing errors are compile-time and reported directly by the build-musa CI job. Once this PR merges, the same job on `main` should pass. No local MUSA toolchain is available to verify offline, but the added `#define` lines are one-to-one with the three symbols the CI logs list as undeclared, and mirror the existing pattern used for the other 20+ CUDA→MUSA mappings in the same file.

**Test commands:**
```bash
# CI-side verification
# GitHub Actions build-musa job compiles nvlink_transport.cpp / intranode_nvlink_transport.cpp against MUSA SDK
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

CI-side compile of MUSA build after applying this patch is the manual test.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Claude Code was used to (1) locate the failing build-musa CI run for PR #2578, (2) diff the CUDA symbols added by the PR against `gpu_vendor/musa.h`, and (3) draft the three-line patch and this PR description. All resulting code was reviewed by me.