### PR TITLE
[TENT] Fix data race on local SegmentDesc via copy-on-write snapshots

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/runtime/segment_manager.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/segment_manager.h
@@ -23,6 +23,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <shared_mutex>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -58,6 +59,11 @@ class SegmentManager {
     // cache invalidation and retry on stale segment cache.
     Status getRemoteCached(SegmentDesc *&desc, SegmentID handle);
 
+    // Owning-reference variant: the returned SegmentDescRef keeps the desc
+    // (and raw pointers into it) alive independently of the thread-local
+    // cache's lifetime.
+    Status getRemoteCached(SegmentDescRef &desc, SegmentID handle);
+
     Status getRemote(SegmentDescRef &desc, const std::string &segment_name);
 
     // Invalidates the thread-local cache.
@@ -77,18 +83,33 @@ class SegmentManager {
     //    invalidated, the segment is refetched and the operation is retried.
     template <typename Func>
     Status withCachedSegment(SegmentID segment_id, Func operation) {
+        SegmentDescRef pin;
+        return withCachedSegment(segment_id, pin, operation);
+    }
+
+    // Same as above, but additionally hands the caller an owning reference
+    // to the segment snapshot in `pin`. Use this variant whenever a raw
+    // pointer obtained inside `operation` (e.g. a BufferDesc* from
+    // findBuffer()) must remain valid after `operation` returns: the pointer
+    // is guaranteed valid only for as long as `pin` is held.
+    template <typename Func>
+    Status withCachedSegment(SegmentID segment_id, SegmentDescRef &pin,
+                             Func operation) {
         static_assert(
             std::is_same_v<std::invoke_result_t<Func &, SegmentDesc *>, Status>,
             "operation must return Status");
 
-        // Local segment: no cache lookup or retry required.
+        // Local segment: no cache lookup or retry required. Pin the current
+        // snapshot so pointers into it survive concurrent updateLocal().
         if (segment_id == LOCAL_SEGMENT_ID) {
-            return operation(getLocal().get());
+            pin = getLocal();
+            return operation(pin.get());
         }
 
         // First get a cached version.
         SegmentDesc *desc = nullptr;
-        CHECK_STATUS(getRemoteCached(desc, segment_id));
+        CHECK_STATUS(getRemoteCached(pin, segment_id));
+        desc = pin.get();
 
         // Do operation under the cached segment.
         Status res = operation(desc);
@@ -98,7 +119,8 @@ class SegmentManager {
 
         // If result status is IsNeedsRefreshCache, invalidate cache and retry
         invalidateRemote(segment_id);
-        CHECK_STATUS(getRemoteCached(desc, segment_id));
+        CHECK_STATUS(getRemoteCached(pin, segment_id));
+        desc = pin.get();
 
         // Do operation again
         res = operation(desc);
@@ -114,14 +136,60 @@ class SegmentManager {
     }
 
    public:
-    SegmentDescRef getLocal() { return local_desc_; }
+    // Returns the current immutable snapshot of the local SegmentDesc.
+    //
+    // Snapshots are copy-on-write: once published they are never mutated, so
+    // the returned SegmentDescRef (and raw pointers into it, e.g. from
+    // findBuffer()) stays valid and self-consistent for as long as the caller
+    // holds the reference. A reader may observe a snapshot that is stale with
+    // respect to a concurrent register/unregister, never a torn one —
+    // staleness is already a designed-in property of segment metadata (remote
+    // peers cache descs with a TTL plus best-effort invalidation pushes).
+    //
+    // Do NOT write through the returned pointer; all mutations must go
+    // through updateLocal().
+    SegmentDescRef getLocal() {
+        // Per-thread snapshot cache with version-based invalidation — the
+        // same pattern getRemoteCached() uses for remote descs. The fast
+        // path is one relaxed-acquire load; the shared_mutex is only taken
+        // after a publication. Keyed by a monotonic manager id (not `this`)
+        // so a recycled allocation can never satisfy a stale cache entry.
+        struct Cache {
+            uint64_t manager_id = UINT64_MAX;
+            uint64_t version = 0;
+            SegmentDescRef ref;
+        };
+        thread_local Cache cache;
+        auto version = local_desc_version_.load(std::memory_order_acquire);
+        if (cache.manager_id != manager_id_ || cache.version != version ||
+            !cache.ref) {
+            std::shared_lock<std::shared_mutex> guard(local_desc_lock_);
+            cache.ref = local_desc_;
+            cache.manager_id = manager_id_;
+            // Tag with the pre-lock version: if a publication raced in
+            // between, the tag mismatches on the next call and we simply
+            // refresh again — the cache can serve a fresher snapshot than
+            // its tag, never a staler one.
+            cache.version = version;
+        }
+        return cache.ref;
+    }
+
+    // Applies `mutator` to a private clone of the local SegmentDesc and
+    // atomically publishes the result as the new snapshot. Mutations are
+    // serialized by an internal writer mutex. If `mutator` returns a non-OK
+    // status, nothing is published.
+    //
+    // This is the only way to modify the local SegmentDesc; see getLocal()
+    // for the snapshot semantics it guarantees.
+    Status updateLocal(const std::function<Status(SegmentDesc &)> &mutator);
 
     // Returns a serialized JSON snapshot of local_desc_. The result is cached
     // and shared across concurrent GetSegmentDesc RPC handlers; the cache is
-    // invalidated by synchronizeLocal() (which is called on every register /
-    // unregisterLocalMemory). This avoids re-dumping the full segment desc on
-    // every peer fetch — the previous behavior multiplied dump cost by the
-    // number of concurrent peer RPCs and dominated remote getRemote latency.
+    // invalidated by updateLocal() on every publication. This avoids
+    // re-dumping the full segment desc on every peer fetch — the previous
+    // behavior multiplied dump cost by the number of concurrent peer RPCs and
+    // dominated remote getRemote latency.
     std::shared_ptr<const std::string> getLocalDumpedJson();
 
     Status synchronizeLocal();
@@ -153,7 +221,25 @@ class SegmentManager {
 
     std::atomic<uint64_t> version_;
 
+    // Current published snapshot of the local SegmentDesc. Replaced wholesale
+    // by updateLocal(); never mutated in place. local_desc_lock_ only guards
+    // the pointer swap, not the pointee. std::shared_mutex (rather than the
+    // in-tree RWSpinlock) keeps the synchronization visible to
+    // ThreadSanitizer.
+    std::shared_mutex local_desc_lock_;
     SegmentDescRef local_desc_;
+    // Serializes clone-mutate-publish cycles in updateLocal().
+    std::mutex local_update_mu_;
+    // Serializes {snapshot, putSegmentDesc} pairs in synchronizeLocal() so a
+    // stale in-flight put cannot overwrite a newer snapshot in the registry.
+    std::mutex local_sync_mu_;
+    // Publication counter; invalidates the per-thread snapshot caches in
+    // getLocal() and tags local_json_cache_ so that a slow JSON dump of an
+    // old snapshot can never overwrite the cache entry of a newer one.
+    std::atomic<uint64_t> local_desc_version_{0};
+    // Process-unique id for the thread-local cache key in getLocal().
+    const uint64_t manager_id_;
+
     ThreadLocalStorage<RemoteSegmentCache> tl_remote_cache_;
 
     std::unique_ptr<SegmentRegistry> registry_;
@@ -164,9 +250,12 @@ class SegmentManager {
     std::shared_ptr<RWSpinlock> subscribers_lock_;
     std::shared_ptr<std::unordered_set<std::string>> subscribers_;
 
-    // Cache for the serialized JSON of local_desc_. Reset by synchronizeLocal.
+    // Cache for the serialized JSON of local_desc_. Invalidated by
+    // updateLocal(); local_json_cache_version_ records which publication the
+    // cached string was computed from.
     std::mutex local_json_cache_mu_;
     std::shared_ptr<const std::string> local_json_cache_;
+    uint64_t local_json_cache_version_{0};
 };
 }  // namespace tent
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tent/include/tent/runtime/segment_tracker.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/segment_tracker.h
@@ -29,13 +29,18 @@
 #include <vector>
 
 #include "tent/runtime/segment.h"
+#include "tent/runtime/segment_manager.h"
 
 namespace mooncake {
 namespace tent {
+// Maintains the buffer list of the local SegmentDesc (ref-counted
+// registration / deregistration). All mutations are applied through
+// SegmentManager::updateLocal(), so concurrent readers of getLocal() always
+// observe consistent snapshots; SegmentTracker itself holds no state besides
+// the manager reference.
 class SegmentTracker {
    public:
-    SegmentTracker(const SegmentDescRef& local_desc)
-        : local_desc_(local_desc) {}
+    explicit SegmentTracker(SegmentManager& manager) : manager_(manager) {}
 
     ~SegmentTracker() {}
 
@@ -43,9 +48,6 @@ class SegmentTracker {
     SegmentTracker& operator==(const SegmentTracker&) = delete;
 
    public:
-    Status query(uint64_t base, size_t length,
-                 std::vector<BufferDesc*>& result);
-
     Status addInBatch(std::vector<BufferDesc>& desc_list,
                       std::function<Status(std::vector<BufferDesc>&)> callback);
 
@@ -55,11 +57,13 @@ class SegmentTracker {
     Status remove(uint64_t base, size_t length,
                   std::function<Status(BufferDesc&)> callback);
 
-    Status forEach(std::function<Status(BufferDesc&)> callback);
+    // Iterates over the current snapshot; entries are immutable. Callers
+    // needing a mutable copy (e.g. transports scrubbing keys during
+    // deregistration) must copy explicitly.
+    Status forEach(std::function<Status(const BufferDesc&)> callback);
 
    private:
-    SegmentDescRef local_desc_;
-    std::mutex mutex_;
+    SegmentManager& manager_;
 };
 }  // namespace tent
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/workers.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/workers.h
@@ -76,6 +76,9 @@ class Workers {
 
    private:
     struct RouteHint {
+        // Owning reference to the segment snapshot; keeps all raw pointers
+        // below valid for the lifetime of this hint.
+        SegmentDescRef pin;
         SegmentDesc *segment;
         BufferDesc *buffer;
         const Topology::MemEntry *topo_entry;

--- a/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
@@ -249,7 +249,7 @@ void ControlService::onSendData(const std::string_view& request,
         return;
     }
     XferDataDesc* desc = (XferDataDesc*)request.data();
-    auto local_desc = manager_->getLocal().get();
+    auto local_desc = manager_->getLocal();
     auto peer_mem_addr = le64toh(desc->peer_mem_addr);
     auto length = le64toh(desc->length);
 
@@ -273,7 +273,7 @@ void ControlService::onRecvData(const std::string_view& request,
         return;
     }
     XferDataDesc* desc = (XferDataDesc*)request.data();
-    auto local_desc = manager_->getLocal().get();
+    auto local_desc = manager_->getLocal();
     auto peer_mem_addr = le64toh(desc->peer_mem_addr);
     auto length = le64toh(desc->length);
 

--- a/mooncake-transfer-engine/tent/src/runtime/segment_manager.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/segment_manager.cpp
@@ -25,8 +25,18 @@
 
 namespace mooncake {
 namespace tent {
+namespace {
+uint64_t nextManagerId() {
+    static std::atomic<uint64_t> counter{0};
+    return counter.fetch_add(1, std::memory_order_relaxed);
+}
+}  // namespace
+
 SegmentManager::SegmentManager(std::unique_ptr<SegmentRegistry> agent)
-    : next_id_(1), version_(0), registry_(std::move(agent)) {
+    : next_id_(1),
+      version_(0),
+      manager_id_(nextManagerId()),
+      registry_(std::move(agent)) {
     local_desc_ = std::make_shared<SegmentDesc>();
     subscribers_lock_ = std::make_shared<RWSpinlock>();
     subscribers_ = std::make_shared<std::unordered_set<std::string>>();
@@ -60,7 +70,33 @@ Status SegmentManager::closeRemote(SegmentID handle) {
     return Status::OK();
 }
 
+Status SegmentManager::updateLocal(
+    const std::function<Status(SegmentDesc &)> &mutator) {
+    std::lock_guard<std::mutex> g(local_update_mu_);
+    // No concurrent writer exists (serialized by local_update_mu_), so
+    // reading local_desc_ without local_desc_lock_ is safe here.
+    auto next = std::make_shared<SegmentDesc>(*local_desc_);
+    CHECK_STATUS(mutator(*next));
+    {
+        std::unique_lock<std::shared_mutex> guard(local_desc_lock_);
+        local_desc_ = std::move(next);
+    }
+    local_desc_version_.fetch_add(1, std::memory_order_relaxed);
+    {
+        std::lock_guard<std::mutex> jg(local_json_cache_mu_);
+        local_json_cache_.reset();
+    }
+    return Status::OK();
+}
+
 Status SegmentManager::getRemoteCached(SegmentDesc *&desc, SegmentID handle) {
+    SegmentDescRef ref;
+    CHECK_STATUS(getRemoteCached(ref, handle));
+    desc = ref.get();
+    return Status::OK();
+}
+
+Status SegmentManager::getRemoteCached(SegmentDescRef &desc, SegmentID handle) {
     auto &cache = tl_remote_cache_.get();
     auto current_ts = getCurrentTimeInNano();
     auto current_version = version_.load(std::memory_order_relaxed);
@@ -78,7 +114,7 @@ Status SegmentManager::getRemoteCached(SegmentDesc *&desc, SegmentID handle) {
         cache.id_to_desc_map[handle] = desc_ref;
 
         std::string peer_rpc_addr = desc_ref->rpc_server_addr;
-        std::string local_rpc_addr = local_desc_->rpc_server_addr;
+        std::string local_rpc_addr = getLocal()->rpc_server_addr;
         if (!peer_rpc_addr.empty() && !local_rpc_addr.empty()) {
             // Send a subscription request to enable proactive cache
             // invalidation. This is a best-effort mechanism to reduce stale
@@ -92,7 +128,7 @@ Status SegmentManager::getRemoteCached(SegmentDesc *&desc, SegmentID handle) {
                        << "'.";
         }
     }
-    desc = cache.id_to_desc_map[handle].get();
+    desc = cache.id_to_desc_map[handle];
     assert(desc);
     return Status::OK();
 }
@@ -164,7 +200,7 @@ Status SegmentManager::makeFileRemote(SegmentDescRef &desc,
     desc = std::make_shared<SegmentDesc>();
     desc->name = segment_name;
     desc->type = SegmentType::File;
-    desc->machine_id = local_desc_->machine_id;
+    desc->machine_id = getLocal()->machine_id;
     FileSegmentDesc detail;
     FileBufferDesc buffer;
     buffer.path = path;
@@ -176,26 +212,41 @@ Status SegmentManager::makeFileRemote(SegmentDescRef &desc,
 }
 
 std::shared_ptr<const std::string> SegmentManager::getLocalDumpedJson() {
+    // Capture the snapshot together with its publication version so a slow
+    // dump of an older snapshot can never overwrite the cache entry computed
+    // from a newer one.
+    auto version = local_desc_version_.load(std::memory_order_relaxed);
+    auto snapshot = getLocal();
     {
         std::lock_guard<std::mutex> g(local_json_cache_mu_);
-        if (local_json_cache_) return local_json_cache_;
+        if (local_json_cache_ && local_json_cache_version_ == version)
+            return local_json_cache_;
     }
-    json j = *local_desc_;
+    json j = *snapshot;
     auto computed = std::make_shared<const std::string>(j.dump());
 
     std::lock_guard<std::mutex> g(local_json_cache_mu_);
-    if (!local_json_cache_) {
+    // Store only if no publication happened since we sampled `version`;
+    // otherwise this dump is already outdated and must not evict a cache
+    // entry computed from a newer snapshot.
+    if (local_desc_version_.load(std::memory_order_relaxed) == version &&
+        !local_json_cache_) {
         local_json_cache_ = computed;
+        local_json_cache_version_ = version;
     }
-    return local_json_cache_;
+    return computed;
 }
 
 Status SegmentManager::synchronizeLocal() {
     {
-        std::lock_guard<std::mutex> g(local_json_cache_mu_);
-        local_json_cache_.reset();
+        // Serialize {snapshot, put} pairs: without this, a put carrying an
+        // older snapshot could complete after (and overwrite) one carrying a
+        // newer snapshot in the registry, hiding a completed registration
+        // from peers until the next synchronizeLocal call.
+        std::lock_guard<std::mutex> g(local_sync_mu_);
+        auto snapshot = getLocal();
+        CHECK_STATUS(registry_->putSegmentDesc(snapshot));
     }
-    CHECK_STATUS(registry_->putSegmentDesc(local_desc_));
 
     std::vector<std::string> subscribers_snapshot;
     {
@@ -214,7 +265,7 @@ Status SegmentManager::synchronizeLocal() {
         // Remove subscribers that have failed (e.g., peer might shutdown)
         // to avoid repeated RPC failures.
         ControlClient::notifySegmentUpdatedAsync(
-            subscriber, local_desc_->name,
+            subscriber, getLocal()->name,
             /* on_failure */
             [subscribers = subscribers_, lock = subscribers_lock_, subscriber] {
                 RWSpinlock::WriteGuard guard(*lock);
@@ -225,7 +276,7 @@ Status SegmentManager::synchronizeLocal() {
 }
 
 Status SegmentManager::deleteLocal() {
-    return registry_->deleteSegmentDesc(local_desc_->name);
+    return registry_->deleteSegmentDesc(getLocal()->name);
 }
 
 }  // namespace tent

--- a/mooncake-transfer-engine/tent/src/runtime/segment_manager.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/segment_manager.cpp
@@ -81,7 +81,13 @@ Status SegmentManager::updateLocal(
         std::unique_lock<std::shared_mutex> guard(local_desc_lock_);
         local_desc_ = std::move(next);
     }
-    local_desc_version_.fetch_add(1, std::memory_order_relaxed);
+    // Release pairs with the acquire load in getLocal(): a reader that
+    // observes the new version must also observe the pointer swap above.
+    // With a relaxed bump, on weakly-ordered architectures the version
+    // store may become visible before the swap, letting a reader tag the
+    // OLD snapshot with the NEW version — which its thread-local cache
+    // would then serve until the next publication.
+    local_desc_version_.fetch_add(1, std::memory_order_release);
     {
         std::lock_guard<std::mutex> jg(local_json_cache_mu_);
         local_json_cache_.reset();
@@ -214,8 +220,9 @@ Status SegmentManager::makeFileRemote(SegmentDescRef &desc,
 std::shared_ptr<const std::string> SegmentManager::getLocalDumpedJson() {
     // Capture the snapshot together with its publication version so a slow
     // dump of an older snapshot can never overwrite the cache entry computed
-    // from a newer one.
-    auto version = local_desc_version_.load(std::memory_order_relaxed);
+    // from a newer one. Acquire keeps the tag conservative: the snapshot
+    // read below is then guaranteed to be at least as new as the tag.
+    auto version = local_desc_version_.load(std::memory_order_acquire);
     auto snapshot = getLocal();
     {
         std::lock_guard<std::mutex> g(local_json_cache_mu_);

--- a/mooncake-transfer-engine/tent/src/runtime/segment_tracker.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/segment_tracker.cpp
@@ -25,39 +25,47 @@
 
 namespace mooncake {
 namespace tent {
-Status SegmentTracker::query(uint64_t base, size_t length,
-                             std::vector<BufferDesc*>& result) {
-    assert(local_desc_->type == SegmentType::Memory);
-    auto& detail = std::get<MemorySegmentDesc>(local_desc_->detail);
-    assert(length);
-    for (auto& buf : detail.buffers) {
-        if (buf.addr > base) continue;
-        if (buf.addr + buf.length <= base) break;
-        result.push_back(&buf);
-        if (buf.addr + buf.length >= base + length) {
-            return Status::OK();
-        } else {
-            auto new_base = buf.addr + buf.length;
-            auto new_length = base + length - new_base;
-            return query(new_base, new_length, result);
-        }
-    }
-    return Status::InvalidArgument("Some buffers are not registered");
+namespace {
+void sortBuffers(std::vector<BufferDesc>& buffers) {
+    std::sort(buffers.begin(), buffers.end(),
+              [](const BufferDesc& lhs, const BufferDesc& rhs) -> bool {
+                  if (lhs.addr < rhs.addr) return true;
+                  if (lhs.addr > rhs.addr) return false;
+                  return lhs.length > rhs.length;  // prefer large interval
+              });
 }
+
+bool containsBuffer(const SegmentDesc& desc, uint64_t base, size_t length) {
+    auto& detail = std::get<MemorySegmentDesc>(desc.detail);
+    for (auto& buf : detail.buffers) {
+        if (buf.addr == base && buf.length == length) return true;
+    }
+    return false;
+}
+}  // namespace
 
 Status SegmentTracker::add(uint64_t base, size_t length,
                            std::function<Status(BufferDesc&)> callback) {
-    assert(local_desc_->type == SegmentType::Memory);
-    auto& detail = std::get<MemorySegmentDesc>(local_desc_->detail);
-    mutex_.lock();
-    for (auto& buf : detail.buffers) {
-        if (buf.addr == base && buf.length == length) {
-            buf.ref_count++;
-            mutex_.unlock();
+    // Read-only pre-scan on the current snapshot: the common miss path pays
+    // no clone/publication. A hit is re-verified under the writer mutex; a
+    // racing insert of the same range degenerates to today's benign
+    // duplicate-registration behavior.
+    if (containsBuffer(*manager_.getLocal(), base, length)) {
+        bool found = false;
+        CHECK_STATUS(manager_.updateLocal([&](SegmentDesc& desc) -> Status {
+            assert(desc.type == SegmentType::Memory);
+            auto& detail = std::get<MemorySegmentDesc>(desc.detail);
+            for (auto& buf : detail.buffers) {
+                if (buf.addr == base && buf.length == length) {
+                    buf.ref_count++;
+                    found = true;
+                    break;
+                }
+            }
             return Status::OK();
-        }
+        }));
+        if (found) return Status::OK();
     }
-    mutex_.unlock();
     BufferDesc new_desc;
     new_desc.addr = base;
     new_desc.length = length;
@@ -71,86 +79,95 @@ Status SegmentTracker::add(uint64_t base, size_t length,
     new_desc.ref_count = 1;
     auto status = callback(new_desc);
     if (!status.ok()) return status;
-    mutex_.lock();
-    detail.buffers.push_back(new_desc);
-    std::sort(detail.buffers.begin(), detail.buffers.end(),
-              [](const BufferDesc& lhs, BufferDesc& rhs) -> bool {
-                  if (lhs.addr < rhs.addr) return true;
-                  if (lhs.addr > rhs.addr) return false;
-                  return lhs.length > rhs.length;  // prefer large interval
-              });
-    mutex_.unlock();
-    return Status::OK();
+    return manager_.updateLocal([&](SegmentDesc& desc) -> Status {
+        assert(desc.type == SegmentType::Memory);
+        auto& detail = std::get<MemorySegmentDesc>(desc.detail);
+        detail.buffers.push_back(std::move(new_desc));
+        sortBuffers(detail.buffers);
+        return Status::OK();
+    });
 }
 
 Status SegmentTracker::addInBatch(
     std::vector<BufferDesc>& desc_list,
     std::function<Status(std::vector<BufferDesc>&)> callback) {
     std::vector<BufferDesc> new_desc_list;
-    for (auto& desc : desc_list) {
-        bool found = false;
-        {
-            std::lock_guard<std::mutex> lock(mutex_);
-            assert(local_desc_->type == SegmentType::Memory);
-            auto& detail = std::get<MemorySegmentDesc>(local_desc_->detail);
-            for (auto& buf : detail.buffers) {
-                if (buf.addr == desc.addr && buf.length == desc.length) {
-                    buf.ref_count++;
-                    found = true;
-                    break;
-                }
+    // Read-only pre-scan (see add()): skip the ref-count publication when no
+    // entry duplicates an already-registered range.
+    bool any_dup = false;
+    {
+        auto snapshot = manager_.getLocal();
+        for (auto& entry : desc_list) {
+            if (containsBuffer(*snapshot, entry.addr, entry.length)) {
+                any_dup = true;
+                break;
             }
         }
-        if (!found) new_desc_list.push_back(std::move(desc));
+    }
+    if (any_dup) {
+        CHECK_STATUS(manager_.updateLocal([&](SegmentDesc& desc) -> Status {
+            assert(desc.type == SegmentType::Memory);
+            auto& detail = std::get<MemorySegmentDesc>(desc.detail);
+            for (auto& entry : desc_list) {
+                bool found = false;
+                for (auto& buf : detail.buffers) {
+                    if (buf.addr == entry.addr && buf.length == entry.length) {
+                        buf.ref_count++;
+                        found = true;
+                        break;
+                    }
+                }
+                if (!found) new_desc_list.push_back(std::move(entry));
+            }
+            return Status::OK();
+        }));
+    } else {
+        new_desc_list = std::move(desc_list);
     }
     auto status = callback(new_desc_list);
     if (!status.ok()) return status;
-    {
-        std::lock_guard<std::mutex> lock(mutex_);
-        assert(local_desc_->type == SegmentType::Memory);
-        auto& detail = std::get<MemorySegmentDesc>(local_desc_->detail);
+    return manager_.updateLocal([&](SegmentDesc& desc) -> Status {
+        assert(desc.type == SegmentType::Memory);
+        auto& detail = std::get<MemorySegmentDesc>(desc.detail);
         for (auto& new_desc : new_desc_list) {
             detail.buffers.push_back(new_desc);
         }
-        std::sort(detail.buffers.begin(), detail.buffers.end(),
-                  [](const BufferDesc& lhs, BufferDesc& rhs) -> bool {
-                      if (lhs.addr < rhs.addr) return true;
-                      if (lhs.addr > rhs.addr) return false;
-                      return lhs.length > rhs.length;  // prefer large interval
-                  });
-    }
-    return Status::OK();
+        sortBuffers(detail.buffers);
+        return Status::OK();
+    });
 }
 
 Status SegmentTracker::remove(uint64_t base, size_t length,
                               std::function<Status(BufferDesc&)> callback) {
-    assert(local_desc_->type == SegmentType::Memory);
-    auto& detail = std::get<MemorySegmentDesc>(local_desc_->detail);
-    mutex_.lock();
-    for (auto it = detail.buffers.begin(); it != detail.buffers.end(); ++it) {
-        if (it->addr == base && (!length || it->length == length)) {
-            it->ref_count--;
-            Status status = Status::OK();
-            if (it->ref_count == 0) {
-                BufferDesc clone = *it;
-                detail.buffers.erase(it);
-                mutex_.unlock();
-                status = callback(clone);
-            } else {
-                mutex_.unlock();
+    bool removed = false;
+    BufferDesc removed_desc;
+    CHECK_STATUS(manager_.updateLocal([&](SegmentDesc& desc) -> Status {
+        assert(desc.type == SegmentType::Memory);
+        auto& detail = std::get<MemorySegmentDesc>(desc.detail);
+        for (auto it = detail.buffers.begin(); it != detail.buffers.end();
+             ++it) {
+            if (it->addr == base && (!length || it->length == length)) {
+                it->ref_count--;
+                if (it->ref_count == 0) {
+                    removed_desc = *it;
+                    detail.buffers.erase(it);
+                    removed = true;
+                }
+                break;
             }
-            return status;
         }
-    }
-    mutex_.unlock();
+        return Status::OK();
+    }));
+    if (removed) return callback(removed_desc);
     return Status::OK();
 }
 
-Status SegmentTracker::forEach(std::function<Status(BufferDesc&)> callback) {
-    std::lock_guard<std::mutex> lock(mutex_);
-    assert(local_desc_->type == SegmentType::Memory);
-    auto& detail = std::get<MemorySegmentDesc>(local_desc_->detail);
-    for (auto& buf : detail.buffers) {
+Status SegmentTracker::forEach(
+    std::function<Status(const BufferDesc&)> callback) {
+    auto snapshot = manager_.getLocal();
+    assert(snapshot->type == SegmentType::Memory);
+    for (const auto& buf :
+         std::get<MemorySegmentDesc>(snapshot->detail).buffers) {
         auto status = callback(buf);
         if (!status.ok()) return status;
     }

--- a/mooncake-transfer-engine/tent/src/runtime/segment_tracker.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/segment_tracker.cpp
@@ -104,6 +104,12 @@ Status SegmentTracker::addInBatch(
             }
         }
     }
+    // Ranges whose ref_count we bumped; used to roll back if the callback
+    // fails. The bump must happen under the writer mutex *before* the
+    // callback: it is what pins the duplicate entry (ref_count >= 2) so a
+    // concurrent unregister cannot erase it out from under this
+    // registration.
+    std::vector<std::pair<uint64_t, uint64_t>> bumped;
     if (any_dup) {
         CHECK_STATUS(manager_.updateLocal([&](SegmentDesc& desc) -> Status {
             assert(desc.type == SegmentType::Memory);
@@ -117,7 +123,11 @@ Status SegmentTracker::addInBatch(
                         break;
                     }
                 }
-                if (!found) new_desc_list.push_back(std::move(entry));
+                if (found) {
+                    bumped.emplace_back(entry.addr, entry.length);
+                } else {
+                    new_desc_list.push_back(std::move(entry));
+                }
             }
             return Status::OK();
         }));
@@ -125,7 +135,31 @@ Status SegmentTracker::addInBatch(
         new_desc_list = std::move(desc_list);
     }
     auto status = callback(new_desc_list);
-    if (!status.ok()) return status;
+    if (!status.ok()) {
+        // Roll back the duplicate ref-counts so a failed registration does
+        // not leave buffers pinned forever.
+        if (!bumped.empty()) {
+            manager_.updateLocal([&](SegmentDesc& desc) -> Status {
+                auto& detail = std::get<MemorySegmentDesc>(desc.detail);
+                for (auto& range : bumped) {
+                    for (auto it = detail.buffers.begin();
+                         it != detail.buffers.end(); ++it) {
+                        if (it->addr == range.first &&
+                            it->length == range.second) {
+                            it->ref_count--;
+                            // The original owner unregistered while we held
+                            // the extra reference; drop the entry so it is
+                            // no longer advertised.
+                            if (it->ref_count == 0) detail.buffers.erase(it);
+                            break;
+                        }
+                    }
+                }
+                return Status::OK();
+            });
+        }
+        return status;
+    }
     return manager_.updateLocal([&](SegmentDesc& desc) -> Status {
         assert(desc.type == SegmentType::Memory);
         auto& detail = std::get<MemorySegmentDesc>(desc.detail);

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -265,14 +265,16 @@ std::string getMachineID() {
 
 Status TransferEngineImpl::setupLocalSegment() {
     auto& manager = metadata_->segmentManager();
-    auto segment = manager.getLocal();
-    segment->name = local_segment_name_;
-    segment->type = SegmentType::Memory;
-    segment->machine_id = getMachineID();
-    segment->rpc_server_addr = buildIpAddrWithPort(hostname_, port_, ipv6_);
-    auto& detail = std::get<MemorySegmentDesc>(segment->detail);
-    detail.topology = *(topology_.get());
-    local_segment_tracker_ = std::make_unique<SegmentTracker>(segment);
+    CHECK_STATUS(manager.updateLocal([&](SegmentDesc& segment) -> Status {
+        segment.name = local_segment_name_;
+        segment.type = SegmentType::Memory;
+        segment.machine_id = getMachineID();
+        segment.rpc_server_addr = buildIpAddrWithPort(hostname_, port_, ipv6_);
+        auto& detail = std::get<MemorySegmentDesc>(segment.detail);
+        detail.topology = *(topology_.get());
+        return Status::OK();
+    }));
+    local_segment_tracker_ = std::make_unique<SegmentTracker>(manager);
     return manager.synchronizeLocal();
 }
 
@@ -430,10 +432,13 @@ Status TransferEngineImpl::deconstruct() {
     staging_proxy_.reset();
 
     if (local_segment_tracker_) {
-        local_segment_tracker_->forEach([&](BufferDesc& desc) -> Status {
+        local_segment_tracker_->forEach([&](const BufferDesc& desc) -> Status {
+            // Snapshot entries are immutable; transports may scrub fields of
+            // their deregistration argument, so hand them a copy.
+            BufferDesc copy = desc;
             for (size_t type = 0; type < kSupportedTransportTypes; ++type) {
                 if (transport_list_[type])
-                    transport_list_[type]->removeMemoryBuffer(desc);
+                    transport_list_[type]->removeMemoryBuffer(copy);
             }
             return Status::OK();
         });
@@ -514,9 +519,10 @@ Status TransferEngineImpl::closeSegment(SegmentID handle) {
 }
 
 Status TransferEngineImpl::getSegmentInfo(SegmentID handle, SegmentInfo& info) {
-    SegmentDesc* desc = nullptr;
+    // Owning reference: keeps the snapshot alive while we read through it.
+    SegmentDescRef desc;
     if (handle == LOCAL_SEGMENT_ID) {
-        desc = metadata_->segmentManager().getLocal().get();
+        desc = metadata_->segmentManager().getLocal();
     } else {
         CHECK_STATUS(metadata_->segmentManager().getRemoteCached(desc, handle));
     }
@@ -929,9 +935,10 @@ Status TransferEngineImpl::validateTransportHint(const Request& req,
 
 SelectionResult TransferEngineImpl::getTransportType(const Request& request,
                                                      int transport_index) {
-    SegmentDesc* desc;
+    // Owning reference: keeps the snapshot alive while we read through it.
+    SegmentDescRef desc;
     if (request.target_id == LOCAL_SEGMENT_ID) {
-        desc = metadata_->segmentManager().getLocal().get();
+        desc = metadata_->segmentManager().getLocal();
     } else {
         auto status = metadata_->segmentManager().getRemoteCached(
             desc, request.target_id);
@@ -1212,7 +1219,8 @@ std::vector<RequestBoundaryInfo> resolveRequestBoundaries(
     // Group requests by target_id so withCachedSegment fires at most once per
     // peer.
     std::vector<RequestBoundaryInfo> boundaries(requests.size());
-    auto* local_desc = metadata->segmentManager().getLocal().get();
+    // Owning reference: keeps the snapshot alive while we read through it.
+    auto local_desc = metadata->segmentManager().getLocal();
 
     if (local_desc) {
         for (size_t i = 0; i < requests.size(); ++i) {
@@ -1272,8 +1280,10 @@ void TransferEngineImpl::findStagingPolicy(const Request& request,
 
     SegmentDesc* desc = nullptr;
     BufferDesc* entry = nullptr;
+    // Owning reference: `entry` is used after the lambda returns.
+    SegmentDescRef pin;
     auto status = metadata_->segmentManager().withCachedSegment(
-        request.target_id, [&](SegmentDesc* segment) {
+        request.target_id, pin, [&](SegmentDesc* segment) {
             desc = segment;
             entry = desc->findBuffer(request.target_offset, request.length);
             if (!entry)

--- a/mooncake-transfer-engine/tent/src/transport/ascend/ascend_direct_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/ascend/ascend_direct_transport.cpp
@@ -160,9 +160,12 @@ Status AscendDirectTransport::initHixl(const std::shared_ptr<Config> &conf) {
     auto hixl_name = host_ip + ":" + std::to_string(port);
     local_hixl_name_ = hixl_name;
 
-    auto segment = metadata_->segmentManager().getLocal();
-    auto &detail = std::get<MemorySegmentDesc>(segment->detail);
-    detail.device_attrs["hixl_name"] = hixl_name;
+    CHECK_STATUS(metadata_->segmentManager().updateLocal(
+        [&](SegmentDesc &segment) -> Status {
+            auto &detail = std::get<MemorySegmentDesc>(segment.detail);
+            detail.device_attrs["hixl_name"] = hixl_name;
+            return Status::OK();
+        }));
 
     hixl_ = std::make_unique<hixl::Hixl>();
     if (!hixl_) return Status::InternalError("Create hixl failed.");

--- a/mooncake-transfer-engine/tent/src/transport/mnnvl/mnnvl_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/mnnvl/mnnvl_transport.cpp
@@ -174,7 +174,8 @@ Status MnnvlTransport::submitTransferTasks(
 
     // Get local segment for buffer lookup
     auto &segment_manager = metadata_->segmentManager();
-    SegmentDesc *local_segment = segment_manager.getLocal().get();
+    // Owning reference: keeps the snapshot alive while we read through it.
+    SegmentDescRef local_segment = segment_manager.getLocal();
     if (!local_segment)
         return Status::InternalError("Local segment not found" LOC_MARK);
 

--- a/mooncake-transfer-engine/tent/src/transport/mnnvl/mnnvl_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/mnnvl/mnnvl_transport.cpp
@@ -553,9 +553,11 @@ Status MnnvlTransport::relocateSharedMemoryAddress(uint64_t &dest_addr,
     RWSpinlock::WriteGuard guard(relocate_lock_);
 
     BufferDesc *buffer;
+    // Owning reference: `buffer` is used after the lambda returns.
+    SegmentDescRef pin;
     auto &segment_manager = metadata_->segmentManager();
-    CHECK_STATUS(
-        segment_manager.withCachedSegment(target_id, [&](SegmentDesc *segment) {
+    CHECK_STATUS(segment_manager.withCachedSegment(
+        target_id, pin, [&](SegmentDesc *segment) {
             buffer = segment->findBuffer(dest_addr, length);
             if (!buffer || buffer->mnnvl_handle.empty())
                 return Status::NeedsRefreshCache(

--- a/mooncake-transfer-engine/tent/src/transport/nvlink/nvlink_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/nvlink/nvlink_transport.cpp
@@ -459,9 +459,11 @@ Status NVLinkTransport::relocateSharedMemoryAddress(uint64_t& dest_addr,
     RWSpinlock::WriteGuard guard(relocate_lock_);
 
     BufferDesc* buffer;
+    // Owning reference: `buffer` is used after the lambda returns.
+    SegmentDescRef pin;
     auto& segment_manager = metadata_->segmentManager();
-    CHECK_STATUS(
-        segment_manager.withCachedSegment(target_id, [&](SegmentDesc* segment) {
+    CHECK_STATUS(segment_manager.withCachedSegment(
+        target_id, pin, [&](SegmentDesc* segment) {
             buffer = segment->findBuffer(dest_addr, length);
             if (!buffer || buffer->shm_path.empty())
                 return Status::NeedsRefreshCache(

--- a/mooncake-transfer-engine/tent/src/transport/nvlink/nvlink_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/nvlink/nvlink_transport.cpp
@@ -134,7 +134,8 @@ Status NVLinkTransport::submitTransferTasks(
 
     // Get local segment for buffer lookup
     auto& segment_manager = metadata_->segmentManager();
-    SegmentDesc* local_segment = segment_manager.getLocal().get();
+    // Owning reference: keeps the snapshot alive while we read through it.
+    SegmentDescRef local_segment = segment_manager.getLocal();
     if (!local_segment)
         return Status::InternalError("Local segment not found" LOC_MARK);
 

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
@@ -543,22 +543,23 @@ Status RdmaTransport::removeMemoryBuffer(BufferDesc& desc) {
 
 Status RdmaTransport::setupLocalSegment() {
     auto& manager = metadata_->segmentManager();
-    auto segment = manager.getLocal();
-    assert(segment);
-    // Store RDMA server name for dual-NIC setups; when it differs from
-    // local_segment_name_ the peer will use it for NIC path construction.
-    if (rdma_server_name_ != local_segment_name_) {
-        segment->rdma_server_name = rdma_server_name_;
-    }
-    auto& detail = std::get<MemorySegmentDesc>(segment->detail);
-    for (auto& context : context_set_) {
-        if (context->status() != RdmaContext::DEVICE_ENABLED) continue;
-        DeviceDesc device_desc;
-        device_desc.name = context->name();
-        device_desc.lid = context->lid();
-        device_desc.gid = context->gid();
-        detail.devices.push_back(device_desc);
-    }
+    CHECK_STATUS(manager.updateLocal([&](SegmentDesc& segment) -> Status {
+        // Store RDMA server name for dual-NIC setups; when it differs from
+        // local_segment_name_ the peer will use it for NIC path construction.
+        if (rdma_server_name_ != local_segment_name_) {
+            segment.rdma_server_name = rdma_server_name_;
+        }
+        auto& detail = std::get<MemorySegmentDesc>(segment.detail);
+        for (auto& context : context_set_) {
+            if (context->status() != RdmaContext::DEVICE_ENABLED) continue;
+            DeviceDesc device_desc;
+            device_desc.name = context->name();
+            device_desc.lid = context->lid();
+            device_desc.gid = context->gid();
+            detail.devices.push_back(device_desc);
+        }
+        return Status::OK();
+    }));
     return manager.synchronizeLocal();
 }
 
@@ -606,13 +607,11 @@ int RdmaTransport::onSetupRdmaConnections(const BootstrapDesc& peer_desc,
 
 std::shared_ptr<RdmaEndPoint> RdmaTransport::getEndpoint(SegmentID target_id,
                                                          int device_id) {
-    SegmentDesc* segment_desc = nullptr;
-    std::string rpc_server_addr, target_seg_name, target_dev_name;
+    std::string rpc_server_addr, target_seg_name, target_dev_name,
+        target_nic_path_name;
 
     auto status = metadata_->segmentManager().withCachedSegment(
         target_id, [&](SegmentDesc* segment) {
-            segment_desc = segment;
-
             if (segment->type != SegmentType::Memory) {
                 return Status::NeedsRefreshCache(
                     "Segment type is not Memory" LOC_MARK);
@@ -624,6 +623,7 @@ std::shared_ptr<RdmaEndPoint> RdmaTransport::getEndpoint(SegmentID target_id,
 
             auto topo = &std::get<MemorySegmentDesc>(segment->detail).topology;
             target_seg_name = segment->name;
+            target_nic_path_name = segment->nicPathServerName();
             target_dev_name = topo->getNicName(device_id);
             if (target_seg_name.empty() || target_dev_name.empty()) {
                 return Status::NeedsRefreshCache(
@@ -642,8 +642,7 @@ std::shared_ptr<RdmaEndPoint> RdmaTransport::getEndpoint(SegmentID target_id,
         return nullptr;
     }
     std::shared_ptr<RdmaEndPoint> endpoint;
-    std::string peer_name =
-        MakeNicPath(segment_desc->nicPathServerName(), target_dev_name);
+    std::string peer_name = MakeNicPath(target_nic_path_name, target_dev_name);
     endpoint = context->endpointStore()->getOrInsert(peer_name);
     if (!endpoint) {
         LOG(ERROR) << "Cannot allocate endpoint " << peer_name;

--- a/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
@@ -260,8 +260,8 @@ std::shared_ptr<RdmaEndPoint> Workers::getEndpoint(Workers::PostPath path) {
     auto target_id = path.remote_segment_id;
     auto device_id = path.remote_device_id;
 
-    auto status =
-        segment_manager.withCachedSegment(target_id, [&](SegmentDesc* segment) {
+    auto status = segment_manager.withCachedSegment(
+        target_id, hint.pin, [&](SegmentDesc* segment) {
             hint.segment = segment;
             if (segment->type != SegmentType::Memory) {
                 return Status::NeedsRefreshCache(
@@ -670,7 +670,7 @@ Status Workers::getRouteHint(RouteHint& hint, SegmentID segment_id,
                              uint64_t addr, uint64_t length) {
     auto& segment_manager = transport_->metadata_->segmentManager();
     CHECK_STATUS(segment_manager.withCachedSegment(
-        segment_id, [&](SegmentDesc* segment) {
+        segment_id, hint.pin, [&](SegmentDesc* segment) {
             hint.segment = segment;
             hint.buffer = segment->findBuffer(addr, length);
             if (!hint.buffer)

--- a/mooncake-transfer-engine/tent/src/transport/shm/shm_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/shm/shm_transport.cpp
@@ -263,9 +263,11 @@ Status ShmTransport::relocateSharedMemoryAddress(uint64_t &dest_addr,
     RWSpinlock::WriteGuard guard(relocate_lock_);
 
     BufferDesc *buffer;
+    // Owning reference: `buffer` is used after the lambda returns.
+    SegmentDescRef pin;
     auto &segment_manager = metadata_->segmentManager();
-    CHECK_STATUS(
-        segment_manager.withCachedSegment(target_id, [&](SegmentDesc *segment) {
+    CHECK_STATUS(segment_manager.withCachedSegment(
+        target_id, pin, [&](SegmentDesc *segment) {
             buffer = segment->findBuffer(dest_addr, length);
             if (!buffer || buffer->shm_path.empty())
                 return Status::NeedsRefreshCache(

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -40,6 +40,16 @@ target_include_directories(tent_coalesce_regions_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME tent_coalesce_regions_test COMMAND tent_coalesce_regions_test)
 
+add_executable(segment_manager_test segment_manager_test.cpp)
+target_link_libraries(segment_manager_test PRIVATE gtest gtest_main
+                                                   tent_link_group)
+if(TARGET asio_shared)
+  target_link_libraries(segment_manager_test PRIVATE asio_shared)
+endif()
+target_include_directories(segment_manager_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+add_test(NAME segment_manager_test COMMAND segment_manager_test)
+
 add_executable(request_merge_test request_merge_test.cpp)
 target_link_libraries(request_merge_test PRIVATE gtest gtest_main
                                                  tent_link_group)

--- a/mooncake-transfer-engine/tent/tests/segment_manager_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/segment_manager_test.cpp
@@ -1,0 +1,280 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Regression tests for issue #2477: concurrent registerLocalMemory /
+// unregisterLocalMemory racing with lock-free readers of the local
+// SegmentDesc. The local desc is published as immutable copy-on-write
+// snapshots; these tests assert the snapshot semantics (readers never
+// observe torn or unsorted buffer lists) and, when built with
+// -fsanitize=thread, additionally prove the absence of data races between
+// SegmentTracker writers and getLocal() / getLocalDumpedJson() readers.
+// A port of ConcurrentWritersVsSnapshotReaders to the pre-fix in-place
+// mutation API fails its invariants on stock builds and reports data races
+// under TSAN.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cstdlib>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "tent/runtime/segment_manager.h"
+#include "tent/runtime/segment_registry.h"
+#include "tent/runtime/segment_tracker.h"
+
+namespace mooncake {
+namespace tent {
+
+namespace {
+
+std::unique_ptr<SegmentManager> makeManager() {
+    // No registry: these tests never touch remote segments or
+    // synchronizeLocal().
+    auto manager = std::make_unique<SegmentManager>(nullptr);
+    EXPECT_TRUE(manager
+                    ->updateLocal([](SegmentDesc& desc) -> Status {
+                        desc.name = "local_test_segment";
+                        desc.type = SegmentType::Memory;
+                        desc.machine_id = "test_machine";
+                        return Status::OK();
+                    })
+                    .ok());
+    return manager;
+}
+
+// Location derived from the buffer address; readers use it to detect
+// partially-constructed or torn BufferDesc entries.
+std::string locationFor(uint64_t addr) {
+    return "cpu:" + std::to_string(addr % 4096);
+}
+
+BufferDesc makeBuffer(uint64_t addr, uint64_t length) {
+    BufferDesc desc;
+    desc.addr = addr;
+    desc.length = length;
+    desc.location = locationFor(addr);
+    desc.ref_count = 1;
+    return desc;
+}
+
+const std::vector<BufferDesc>& buffersOf(const SegmentDescRef& snapshot) {
+    return std::get<MemorySegmentDesc>(snapshot->detail).buffers;
+}
+
+}  // namespace
+
+TEST(SegmentManagerTest, UpdateLocalPublishesImmutableSnapshots) {
+    auto manager = makeManager();
+    auto before = manager->getLocal();
+    ASSERT_EQ(before->name, "local_test_segment");
+    ASSERT_TRUE(buffersOf(before).empty());
+
+    ASSERT_TRUE(manager
+                    ->updateLocal([](SegmentDesc& desc) -> Status {
+                        auto& detail = std::get<MemorySegmentDesc>(desc.detail);
+                        detail.buffers.push_back(makeBuffer(0x1000, 0x1000));
+                        return Status::OK();
+                    })
+                    .ok());
+
+    // The old snapshot is untouched; the new snapshot sees the mutation.
+    EXPECT_TRUE(buffersOf(before).empty());
+    auto after = manager->getLocal();
+    ASSERT_EQ(buffersOf(after).size(), 1u);
+    EXPECT_EQ(buffersOf(after)[0].addr, 0x1000u);
+    EXPECT_NE(before.get(), after.get());
+}
+
+TEST(SegmentManagerTest, UpdateLocalFailureDoesNotPublish) {
+    auto manager = makeManager();
+    auto before = manager->getLocal();
+    auto status = manager->updateLocal([](SegmentDesc& desc) -> Status {
+        desc.name = "must_not_be_published";
+        return Status::InvalidArgument("injected failure");
+    });
+    EXPECT_FALSE(status.ok());
+    EXPECT_EQ(manager->getLocal().get(), before.get());
+    EXPECT_EQ(manager->getLocal()->name, "local_test_segment");
+}
+
+TEST(SegmentManagerTest, JsonCacheInvalidatedOnPublication) {
+    auto manager = makeManager();
+    auto dump1 = manager->getLocalDumpedJson();
+    auto dump2 = manager->getLocalDumpedJson();
+    EXPECT_EQ(dump1.get(), dump2.get());  // served from cache
+
+    ASSERT_TRUE(manager
+                    ->updateLocal([](SegmentDesc& desc) -> Status {
+                        auto& detail = std::get<MemorySegmentDesc>(desc.detail);
+                        detail.buffers.push_back(makeBuffer(0x2000, 0x1000));
+                        return Status::OK();
+                    })
+                    .ok());
+
+    auto dump3 = manager->getLocalDumpedJson();
+    EXPECT_NE(*dump1, *dump3);
+    EXPECT_NE(dump3->find("8192"), std::string::npos);  // 0x2000 serialized
+}
+
+TEST(SegmentTrackerTest, RefCountedAddRemove) {
+    auto manager = makeManager();
+    SegmentTracker tracker(*manager);
+
+    auto noop = [](std::vector<BufferDesc>&) -> Status { return Status::OK(); };
+    std::vector<BufferDesc> first{makeBuffer(0x10000, 0x1000)};
+    ASSERT_TRUE(tracker.addInBatch(first, noop).ok());
+    std::vector<BufferDesc> second{makeBuffer(0x10000, 0x1000)};
+    ASSERT_TRUE(tracker.addInBatch(second, noop).ok());
+
+    auto snapshot = manager->getLocal();
+    ASSERT_EQ(buffersOf(snapshot).size(), 1u);
+    EXPECT_EQ(buffersOf(snapshot)[0].ref_count, 2);
+
+    int remove_callbacks = 0;
+    auto on_remove = [&](BufferDesc&) -> Status {
+        remove_callbacks++;
+        return Status::OK();
+    };
+    ASSERT_TRUE(tracker.remove(0x10000, 0x1000, on_remove).ok());
+    EXPECT_EQ(remove_callbacks, 0);  // still referenced
+    ASSERT_EQ(buffersOf(manager->getLocal()).size(), 1u);
+
+    ASSERT_TRUE(tracker.remove(0x10000, 0x1000, on_remove).ok());
+    EXPECT_EQ(remove_callbacks, 1);
+    EXPECT_TRUE(buffersOf(manager->getLocal()).empty());
+}
+
+TEST(SegmentTrackerTest, AddProbesRealMemoryAndRefCounts) {
+    auto manager = makeManager();
+    SegmentTracker tracker(*manager);
+
+    constexpr size_t kSize = 1 << 20;
+    void* mem = malloc(kSize);
+    ASSERT_NE(mem, nullptr);
+    auto base = reinterpret_cast<uint64_t>(mem);
+
+    int add_callbacks = 0;
+    auto on_add = [&](BufferDesc& desc) -> Status {
+        add_callbacks++;
+        EXPECT_EQ(desc.addr, base);
+        EXPECT_FALSE(desc.location.empty());  // NUMA probe ran
+        return Status::OK();
+    };
+    ASSERT_TRUE(tracker.add(base, kSize, on_add).ok());
+    EXPECT_EQ(add_callbacks, 1);
+    // Re-adding the same range takes the ref-count fast path: no new probe.
+    ASSERT_TRUE(tracker.add(base, kSize, on_add).ok());
+    EXPECT_EQ(add_callbacks, 1);
+    ASSERT_EQ(buffersOf(manager->getLocal()).size(), 1u);
+    EXPECT_EQ(buffersOf(manager->getLocal())[0].ref_count, 2);
+
+    auto noop = [](BufferDesc&) -> Status { return Status::OK(); };
+    ASSERT_TRUE(tracker.remove(base, kSize, noop).ok());
+    ASSERT_TRUE(tracker.remove(base, kSize, noop).ok());
+    EXPECT_TRUE(buffersOf(manager->getLocal()).empty());
+    free(mem);
+}
+
+// The actual #2477 regression: register/unregister churn concurrent with
+// lock-free snapshot readers. With in-place mutation this is a data race on
+// MemorySegmentDesc::buffers (vector push_back/erase/sort vs. iteration):
+// ThreadSanitizer reports it and the location invariant below can observe
+// partially-constructed entries. With copy-on-write snapshots every reader
+// observes a fully-consistent (possibly stale) buffer list.
+TEST(SegmentTrackerTest, ConcurrentWritersVsSnapshotReaders) {
+    auto manager = makeManager();
+    SegmentTracker tracker(*manager);
+
+    constexpr int kWriters = 4;
+    constexpr int kReaders = 4;
+    constexpr int kIterations = 300;
+    constexpr int kBuffersPerBatch = 8;
+    constexpr uint64_t kLength = 0x1000;
+
+    std::atomic<bool> done{false};
+    std::atomic<int> failures{0};
+
+    auto noop = [](std::vector<BufferDesc>&) -> Status { return Status::OK(); };
+
+    std::vector<std::thread> writers;
+    writers.reserve(kWriters);
+    for (int w = 0; w < kWriters; ++w) {
+        writers.emplace_back([&, w] {
+            // Writers 0 and 1 share an address range so ref-count bumps,
+            // duplicate-registration races and erase-vs-bump interleavings
+            // are exercised concurrently, not just disjoint inserts.
+            const uint64_t base = (w < 2 ? 1 : w + 1) * 0x100000000ULL;
+            for (int iter = 0; iter < kIterations; ++iter) {
+                std::vector<BufferDesc> batch;
+                batch.reserve(kBuffersPerBatch);
+                for (int i = 0; i < kBuffersPerBatch; ++i) {
+                    batch.push_back(
+                        makeBuffer(base + i * kLength * 2, kLength));
+                }
+                if (!tracker.addInBatch(batch, noop).ok()) failures++;
+                for (int i = 0; i < kBuffersPerBatch; ++i) {
+                    auto on_remove = [](BufferDesc&) -> Status {
+                        return Status::OK();
+                    };
+                    if (!tracker
+                             .remove(base + i * kLength * 2, kLength, on_remove)
+                             .ok())
+                        failures++;
+                }
+            }
+        });
+    }
+
+    std::vector<std::thread> readers;
+    readers.reserve(kReaders);
+    for (int r = 0; r < kReaders; ++r) {
+        readers.emplace_back([&, r] {
+            uint64_t rounds = 0;
+            while (!done.load(std::memory_order_acquire)) {
+                auto snapshot = manager->getLocal();
+                const auto& buffers = buffersOf(snapshot);
+                uint64_t prev_addr = 0;
+                for (const auto& buf : buffers) {
+                    // Entries must be fully constructed and sorted; a torn
+                    // read of an in-place mutated vector violates these.
+                    if (buf.length != kLength ||
+                        buf.location != locationFor(buf.addr) ||
+                        buf.addr < prev_addr) {
+                        failures++;
+                    }
+                    prev_addr = buf.addr;
+                }
+                // Exercise findBuffer() through the snapshot as transports
+                // do, and the JSON dump path peers hit via GetSegmentDesc.
+                snapshot->findBuffer(0x100000000ULL, kLength);
+                if (rounds++ % 64 == 0) {
+                    auto dump = manager->getLocalDumpedJson();
+                    if (!dump || dump->empty()) failures++;
+                }
+            }
+        });
+    }
+
+    for (auto& t : writers) t.join();
+    done.store(true, std::memory_order_release);
+    for (auto& t : readers) t.join();
+
+    EXPECT_EQ(failures.load(), 0);
+    EXPECT_TRUE(buffersOf(manager->getLocal()).empty());
+}
+
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/tests/segment_manager_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/segment_manager_test.cpp
@@ -157,6 +157,35 @@ TEST(SegmentTrackerTest, RefCountedAddRemove) {
     EXPECT_TRUE(buffersOf(manager->getLocal()).empty());
 }
 
+TEST(SegmentTrackerTest, AddInBatchCallbackFailureRollsBackRefCounts) {
+    auto manager = makeManager();
+    SegmentTracker tracker(*manager);
+
+    auto ok = [](std::vector<BufferDesc>&) -> Status { return Status::OK(); };
+    std::vector<BufferDesc> first{makeBuffer(0x20000, 0x1000)};
+    ASSERT_TRUE(tracker.addInBatch(first, ok).ok());
+    ASSERT_EQ(buffersOf(manager->getLocal())[0].ref_count, 1);
+
+    // A duplicate registration whose transport callback fails must not leave
+    // the ref-count bumped, or the buffer could never be deregistered.
+    auto fail = [](std::vector<BufferDesc>&) -> Status {
+        return Status::InternalError("injected transport failure");
+    };
+    std::vector<BufferDesc> dup{makeBuffer(0x20000, 0x1000)};
+    EXPECT_FALSE(tracker.addInBatch(dup, fail).ok());
+    ASSERT_EQ(buffersOf(manager->getLocal()).size(), 1u);
+    EXPECT_EQ(buffersOf(manager->getLocal())[0].ref_count, 1);
+
+    int remove_callbacks = 0;
+    auto on_remove = [&](BufferDesc&) -> Status {
+        remove_callbacks++;
+        return Status::OK();
+    };
+    ASSERT_TRUE(tracker.remove(0x20000, 0x1000, on_remove).ok());
+    EXPECT_EQ(remove_callbacks, 1);
+    EXPECT_TRUE(buffersOf(manager->getLocal()).empty());
+}
+
 TEST(SegmentTrackerTest, AddProbesRealMemoryAndRefCounts) {
     auto manager = makeManager();
     SegmentTracker tracker(*manager);


### PR DESCRIPTION
Fixes #2477.

The local `SegmentDesc` was mutated in place by `SegmentTracker` (and the transport install paths) while every reader — `GetSegmentDesc` JSON dumps, `findBuffer()` in transports and route resolution — accessed it with no locking. Under concurrent `register/unregisterLocalMemory` this is UB: on current main, a 4-writer/4-reader gtest observes **183,033 torn buffer entries in a single run** (stock `-O3`, no sanitizer) and **197 distinct ThreadSanitizer data-race reports**. This PR makes the local desc a sequence of immutable copy-on-write snapshots; the same test now runs TSAN-clean, and end-to-end RDMA benchmarks are flat within noise.

## Design

**Publication model: immutable snapshots, single writer path.**
- `SegmentManager::updateLocal(mutator)` is now the only way to modify the local desc: it serializes writers behind a mutex, applies the mutator to a private clone, and publishes the clone with a pointer swap. If the mutator fails, nothing is published.
- `getLocal()` returns an owning `SegmentDescRef` to the current snapshot. Readers may observe a snapshot that is *stale* with respect to a racing registration — which is already the designed-in semantics of segment metadata (remote peers cache descs with a TTL plus best-effort invalidation pushes) — but never a torn one. Raw pointers into a snapshot (`findBuffer()` results) are valid exactly as long as the `SegmentDescRef` is held.
- Sites that retain a `BufferDesc*` past the lookup scope now pin the snapshot: `RouteHint::pin` in the RDMA workers, a `withCachedSegment(id, pin, op)` overload for the SHM/NVLink/MNNVL relocate paths and `findStagingPolicy`.
- The implicit init-time writers the issue calls out (`TransferEngineImpl::setupLocalSegment`, `RdmaTransport::setupLocalSegment`, `AscendDirectTransport`'s `hixl_name`) go through `updateLocal()` as well, so their ordering is now enforced rather than assumed.

**Hot-path cost is bought back with the existing thread-local-cache pattern.** A naive `getLocal()` behind a `shared_mutex` costs 23.9 ns single-threaded / ~300 ns at 8 threads. `getLocal()` therefore keeps a per-thread snapshot cache invalidated by a publication counter — the same scheme `getRemoteCached()` already uses for remote descs — restoring parity with main (see numbers below). The cache key is a process-monotonic manager id, not `this`, so a recycled allocation can never satisfy a stale entry.

**Deliberate non-abstractions:**
- `ref_count` bookkeeping stays inside `BufferDesc` (it is not serialized); splitting it into a separate tracker-owned index would avoid some clones but adds a second source of truth for no measured benefit.
- Remote descs keep their existing thread-local cache semantics untouched.
- `SegmentTracker::query()` — unused, and returned raw pointers into the mutable vector — is removed rather than fixed.
- The publication lock is `std::shared_mutex` rather than the in-tree `RWSpinlock`: the critical section is a pointer copy, the cost is equivalent, and unlike `RWSpinlock` (plain loads + compiler fences) it is visible to ThreadSanitizer, which is what lets the regression test assert race-freedom.
- Two preexisting benign behaviors are preserved, not fixed: concurrent `add()` of the same range can still produce a duplicate entry (exactly as on main), and a `remove()` of a still-referenced buffer only decrements the refcount.

Found while auditing the publication path (two adjacent preexisting races, fixed here because they undermine the same guarantee):
1. `synchronizeLocal()` could let a put carrying an older snapshot land in the registry *after* one carrying a newer snapshot (serialization time vs. RPC completion were unordered), hiding a completed registration from registry-resolving peers until the next sync. `{snapshot, put}` pairs are now serialized.
2. The `getLocalDumpedJson()` cache (#2482) had a secondary race — a dump computed from an old snapshot could repopulate the cache *after* the invalidation, pinning a stale JSON until the next registration; the cache entry is now version-tagged so a dump that lost the race cannot overwrite a newer entry.

## Correctness argument

- Writers are serialized by `local_update_mu_`; the published pointer is swapped under `local_desc_lock_` (readers take it shared). A snapshot is immutable after publication, so any reader-held pointer stays valid and internally consistent for the life of its `SegmentDescRef`.
- The thread-local cache can serve a snapshot *newer* than its version tag (tag is sampled before the locked copy), never older: version mismatch always forces a refresh, and the counter is monotonic.
- Tracker semantics are preserved: dedup/refcount fast path re-verifies under the writer mutex after a read-only pre-scan (a lost race degenerates to main's duplicate-registration behavior); `remove()` still fires the deregistration callback only when the refcount hits zero, outside the lock, with a copy of the removed desc — as on main.

## Validation (multi-GPU CUDA-enabled Linux host with real mlx5 hardware)

New regression test `segment_manager_test.cpp` (runs in the existing CPU-only TENT CI job):

| build | `ConcurrentWritersVsSnapshotReaders` | result |
|---|---|---|
| main + this test, `-O3` | torn-entry invariant | **fails 3/3 runs, 183,033 violations** in one run |
| main + this test, TSAN | data races | **197 reports** (vector iteration vs `push_back`/`erase`/`sort`) |
| this PR, `-O3` | same invariant | passes 3/3 |
| this PR, TSAN | same | **0 reports**, whole test binary clean |

Full TENT suite: 19/19 pass, including `tent_rdma_transport_test` cross-process write/read on real mlx5 HCAs.

Microbenchmarks (1024 registered buffers):

| metric | main | this PR |
|---|---|---|
| `getLocal()` 1 thread | 1.9 ns | 2.7–7.3 ns |
| `getLocal()` 8 threads | 75 ns | 79 ns |
| register+unregister pair | 68 µs | 175 µs |

The register-pair delta is two whole-desc clones per cycle; the real path spends milliseconds in MR registration and the metadata RPC per call, so this is noise in practice (and registration is not a steady-state operation).

End-to-end `tebench` (TENT backend, RDMA loopback, DRAM segments, read, batch 16, 4 threads, best of 3):

| block | main GB/s | this PR GB/s |
|---|---|---|
| 4 KB | 8.26 | 8.17 |
| 16 KB | 26.3 | 26.6 |
| 64 KB | 59.5 | 58.5 |

Flat within run-to-run noise (≤2%).

Commands:
```bash
cmake .. -DUSE_TENT=ON -DUSE_HTTP=ON -DBUILD_UNIT_TESTS=ON
ctest --test-dir mooncake-transfer-engine/tent/tests -j --output-on-failure
# TSAN
cmake .. -DUSE_TENT=ON -DUSE_HTTP=ON -DBUILD_UNIT_TESTS=ON -DWITH_STORE=OFF \
  -DCMAKE_CXX_FLAGS="-fsanitize=thread -O1 -g" -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=thread"
make segment_manager_test && ./mooncake-transfer-engine/tent/tests/segment_manager_test
```

## Notes for review

- The `AscendDirectTransport` change is mechanical (`updateLocal` around the `hixl_name` write) but compile-verified only for the CUDA/RDMA/TCP/SHM/MNNVL set — I don't have the Ascend toolchain.
- `forEach()` now takes `const BufferDesc&` (snapshot entries are immutable); its only caller (destructor cleanup in `TransferEngineImpl::deconstruct`) copies explicitly before handing descs to `removeMemoryBuffer`, so transports that scrub fields during deregistration keep working. The scrubbing no longer reaches the published desc — during the teardown window a peer may see a desc for already-deregistered memory, which fails on use exactly as the pre-scrub window always did.
- `RdmaTransport::getEndpoint` also leaked a raw `SegmentDesc*` out of its lookup lambda (same shape as `Workers::getEndpoint`); it now copies `nicPathServerName()` out inside the lambda.
- If a follow-up is welcome: `getLocal()` could return `shared_ptr<const SegmentDesc>` to enforce immutability in the type system, but that ripples into every transport lambda signature, so I kept this PR at the minimal correct surface.