### PR TITLE
[Store] Integrate Redis election backend into Master HA framework

### DIFF
--- a/mooncake-store/include/ha_helper.h
+++ b/mooncake-store/include/ha_helper.h
@@ -4,6 +4,7 @@
 #include <csignal>
 #include <glog/logging.h>
 
+#include <memory>
 #include <string>
 #include <thread>
 #include <ylt/coro_rpc/coro_rpc_server.hpp>
@@ -19,16 +20,20 @@ namespace mooncake {
  *        one master can be elected as leader to serve client requests.
  *        Each master view is associated with a unique version id, which
  *        is incremented monotonically each time the master view is changed.
+ *
+ *        This base class implements the etcd-based election. Redis-based
+ *        election is provided by the RedisMasterViewHelper subclass.
  */
 class MasterViewHelper {
    public:
     MasterViewHelper(const MasterViewHelper&) = delete;
     MasterViewHelper& operator=(const MasterViewHelper&) = delete;
     MasterViewHelper();
+    virtual ~MasterViewHelper();
 
     /*
-     * @brief Connect to the etcd cluster. This function should be called at
-     * first
+     * @brief Connect to the etcd cluster. This function should be called first
+     *        when using the etcd election backend.
      * @param etcd_endpoints: The endpoints of the etcd store client.
      *        Multiple endpoints are separated by semicolons.
      * @return: Error code.
@@ -41,15 +46,21 @@ class MasterViewHelper {
      * @param version: Output param, the version of the new master view.
      * @param lease_id: Output param, the lease id of the leader.
      */
-    void ElectLeader(const std::string& master_address, ViewVersionId& version,
-                     EtcdLeaseId& lease_id);
+    virtual void ElectLeader(const std::string& master_address,
+                             ViewVersionId& version, EtcdLeaseId& lease_id);
 
     /*
      * @brief Keep the master to be the leader. This function blocks until the
      * master is no longer the leader.
      * @param lease_id: The lease id of the leader.
      */
-    void KeepLeader(EtcdLeaseId lease_id);
+    virtual void KeepLeader(EtcdLeaseId lease_id);
+
+    /*
+     * @brief Cancel the keep-alive loop (for graceful shutdown).
+     * @param lease_id: The lease id of the leader.
+     */
+    virtual void CancelKeepAlive(EtcdLeaseId lease_id);
 
     /*
      * @brief Get the current master view.
@@ -57,12 +68,22 @@ class MasterViewHelper {
      * @param version: Output param, the version of the master view.
      * @return: Error code.
      */
-    ErrorCode GetMasterView(std::string& master_address,
-                            ViewVersionId& version);
+    virtual ErrorCode GetMasterView(std::string& master_address,
+                                    ViewVersionId& version);
 
    private:
     std::string master_view_key_;
 };
+
+/*
+ * @brief Create the appropriate MasterViewHelper based on election backend
+ *        configuration. Returns an etcd-based helper by default, or a
+ *        Redis-based helper when election_backend is REDIS.
+ * @param config: The supervisor configuration.
+ * @return: A unique_ptr to the created helper, or nullptr on error.
+ */
+std::unique_ptr<MasterViewHelper> CreateMasterViewHelper(
+    const MasterServiceSupervisorConfig& config);
 
 /*
  * @brief A supervisor class for the master service, only used in HA mode.

--- a/mooncake-store/include/ha_helper.h
+++ b/mooncake-store/include/ha_helper.h
@@ -63,6 +63,12 @@ class MasterViewHelper {
     virtual void CancelKeepAlive(EtcdLeaseId lease_id);
 
     /*
+     * @brief Get the leader lease TTL in seconds for the current election
+     *        backend.
+     */
+    virtual int GetLeaderLeaseTTLSeconds() const;
+
+    /*
      * @brief Get the current master view.
      * @param master: Output param, the ip:port address of the master.
      * @param version: Output param, the version of the master view.

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -59,6 +59,16 @@ struct MasterConfig {
     uint64_t max_replicas_per_key;
 
     std::string deployment_mode;
+
+    // Redis election backend configuration (used when election_backend ==
+    // "redis")
+    std::string election_backend = "etcd";  // "etcd" (default) or "redis"
+    std::string redis_endpoint;         // Redis endpoint, e.g. "10.0.0.1:6379"
+    std::string redis_password;         // Redis AUTH password (empty = no auth)
+    int redis_db_index = 0;             // Redis DB index
+    int redis_master_view_ttl_sec = 5;  // Leader key TTL in seconds
+    int redis_heartbeat_interval_sec =
+        2;  // KeepLeader renewal interval (TTL/3)
 };
 
 class MasterServiceSupervisorConfig {
@@ -107,6 +117,15 @@ class MasterServiceSupervisorConfig {
     std::string cxl_path = DEFAULT_CXL_PATH;
     size_t cxl_size = DEFAULT_CXL_SIZE;
     bool enable_cxl = false;
+
+    // Redis election backend configuration
+    ElectionBackend election_backend = ElectionBackend::ETCD;
+    std::string redis_endpoint;            // Redis endpoint for election
+    std::string redis_password;            // Redis AUTH password
+    int redis_db_index = 0;                // Redis DB index
+    int redis_master_view_ttl_sec = 5;     // Leader key TTL in seconds
+    int redis_heartbeat_interval_sec = 2;  // KeepLeader renewal interval
+
     MasterServiceSupervisorConfig() = default;
 
     // From MasterConfig
@@ -164,6 +183,23 @@ class MasterServiceSupervisorConfig {
         cxl_path = config.cxl_path;
         cxl_size = config.cxl_size;
         enable_cxl = config.enable_cxl;
+
+        // Election backend configuration
+        if (config.election_backend == "redis") {
+            election_backend = ElectionBackend::REDIS;
+        } else if (config.election_backend == "etcd") {
+            election_backend = ElectionBackend::ETCD;
+        } else {
+            throw std::runtime_error(
+                "Unknown election_backend: " + config.election_backend +
+                ". Must be 'etcd' or 'redis'");
+        }
+        redis_endpoint = config.redis_endpoint;
+        redis_password = config.redis_password;
+        redis_db_index = config.redis_db_index;
+        redis_master_view_ttl_sec = config.redis_master_view_ttl_sec;
+        redis_heartbeat_interval_sec = config.redis_heartbeat_interval_sec;
+
         validate();
     }
 
@@ -206,6 +242,20 @@ class MasterServiceSupervisorConfig {
         }
         if (!rpc_thread_num.IsSet()) {
             throw std::runtime_error("rpc_thread_num is not set");
+        }
+        // Validate Redis election backend configuration
+        if (election_backend == ElectionBackend::REDIS &&
+            redis_endpoint.empty()) {
+            throw std::runtime_error(
+                "redis_endpoint is required when election_backend is redis");
+        }
+        if (election_backend == ElectionBackend::REDIS &&
+            redis_heartbeat_interval_sec >= redis_master_view_ttl_sec) {
+            throw std::runtime_error(
+                "redis_heartbeat_interval_sec (" +
+                std::to_string(redis_heartbeat_interval_sec) +
+                ") must be less than redis_master_view_ttl_sec (" +
+                std::to_string(redis_master_view_ttl_sec) + ")");
         }
     }
 };

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -249,13 +249,22 @@ class MasterServiceSupervisorConfig {
             throw std::runtime_error(
                 "redis_endpoint is required when election_backend is redis");
         }
-        if (election_backend == ElectionBackend::REDIS &&
-            redis_heartbeat_interval_sec >= redis_master_view_ttl_sec) {
-            throw std::runtime_error(
-                "redis_heartbeat_interval_sec (" +
-                std::to_string(redis_heartbeat_interval_sec) +
-                ") must be less than redis_master_view_ttl_sec (" +
-                std::to_string(redis_master_view_ttl_sec) + ")");
+        if (election_backend == ElectionBackend::REDIS) {
+            if (redis_master_view_ttl_sec <= 0) {
+                throw std::runtime_error(
+                    "redis_master_view_ttl_sec must be greater than 0");
+            }
+            if (redis_heartbeat_interval_sec <= 0) {
+                throw std::runtime_error(
+                    "redis_heartbeat_interval_sec must be greater than 0");
+            }
+            if (redis_heartbeat_interval_sec >= redis_master_view_ttl_sec) {
+                throw std::runtime_error(
+                    "redis_heartbeat_interval_sec (" +
+                    std::to_string(redis_heartbeat_interval_sec) +
+                    ") must be less than redis_master_view_ttl_sec (" +
+                    std::to_string(redis_master_view_ttl_sec) + ")");
+            }
         }
     }
 };

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -67,8 +67,7 @@ struct MasterConfig {
     std::string redis_password;         // Redis AUTH password (empty = no auth)
     int redis_db_index = 0;             // Redis DB index
     int redis_master_view_ttl_sec = 5;  // Leader key TTL in seconds
-    int redis_heartbeat_interval_sec =
-        2;  // KeepLeader renewal interval (TTL/3)
+    int redis_heartbeat_interval_sec = 2;  // KeepLeader renewal interval
 };
 
 class MasterServiceSupervisorConfig {

--- a/mooncake-store/include/redis_helper.h
+++ b/mooncake-store/include/redis_helper.h
@@ -79,6 +79,11 @@ class RedisHelper {
     void CancelKeepAlive();
 
     /**
+     * @brief Cancel any in-progress ElectLeader/WatchLeader call.
+     */
+    void CancelElection();
+
+    /**
      * @brief Get current leader's address and version from Redis.
      * @param master_address Output: leader address.
      * @param version Output: leader epoch.

--- a/mooncake-store/include/redis_master_view_helper.h
+++ b/mooncake-store/include/redis_master_view_helper.h
@@ -1,0 +1,48 @@
+#ifndef MOONCAKE_REDIS_MASTER_VIEW_HELPER_H_
+#define MOONCAKE_REDIS_MASTER_VIEW_HELPER_H_
+
+#include "ha_helper.h"
+
+#ifdef STORE_USE_REDIS
+#include "redis_helper.h"
+#endif
+
+namespace mooncake {
+
+/*
+ * @brief Redis-based leader election backend for MasterViewHelper.
+ *        Overrides the etcd-based virtual methods to use Redis
+ *        for leader election, leader keep-alive, and master view queries.
+ *
+ * NOTE: This class is introduced temporarily to minimize divergence
+ * from the community mainline. It may be refactored or removed once
+ * a unified election abstraction is upstreamed.
+ */
+#ifdef STORE_USE_REDIS
+class RedisMasterViewHelper : public MasterViewHelper {
+   public:
+    RedisMasterViewHelper(const std::string& cluster_id,
+                          const std::string& redis_endpoint,
+                          const std::string& password, int db_index,
+                          int ttl_sec, int heartbeat_interval_sec);
+
+    ErrorCode Connect();
+
+    void ElectLeader(const std::string& master_address, ViewVersionId& version,
+                     EtcdLeaseId& lease_id) override;
+
+    void KeepLeader(EtcdLeaseId lease_id) override;
+
+    void CancelKeepAlive(EtcdLeaseId lease_id) override;
+
+    ErrorCode GetMasterView(std::string& master_address,
+                            ViewVersionId& version) override;
+
+   private:
+    RedisHelper redis_helper_;
+};
+#endif  // STORE_USE_REDIS
+
+}  // namespace mooncake
+
+#endif  // MOONCAKE_REDIS_MASTER_VIEW_HELPER_H_

--- a/mooncake-store/include/redis_master_view_helper.h
+++ b/mooncake-store/include/redis_master_view_helper.h
@@ -35,6 +35,8 @@ class RedisMasterViewHelper : public MasterViewHelper {
 
     void CancelKeepAlive(EtcdLeaseId lease_id) override;
 
+    int GetLeaderLeaseTTLSeconds() const override;
+
     void CancelElection();
 
     ErrorCode GetMasterView(std::string& master_address,
@@ -42,6 +44,7 @@ class RedisMasterViewHelper : public MasterViewHelper {
 
    private:
     RedisHelper redis_helper_;
+    int ttl_sec_;
 };
 #endif  // STORE_USE_REDIS
 

--- a/mooncake-store/include/redis_master_view_helper.h
+++ b/mooncake-store/include/redis_master_view_helper.h
@@ -35,6 +35,8 @@ class RedisMasterViewHelper : public MasterViewHelper {
 
     void CancelKeepAlive(EtcdLeaseId lease_id) override;
 
+    void CancelElection();
+
     ErrorCode GetMasterView(std::string& master_address,
                             ViewVersionId& version) override;
 

--- a/mooncake-store/include/types.h
+++ b/mooncake-store/include/types.h
@@ -84,6 +84,11 @@ using ViewVersionId = int64_t;
 using EtcdLeaseId = int64_t;
 #endif
 
+/**
+ * @brief Election backend type for leader election in HA mode.
+ */
+enum class ElectionBackend { ETCD, REDIS };
+
 using UUID = std::pair<uint64_t, uint64_t>;
 
 using SerializedByte = uint8_t;  // Used as basic unit of serialized data

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -87,6 +87,7 @@ if(STORE_USE_REDIS)
     find_library(HIREDIS_LIB NAMES hiredis REQUIRED)
     message(STATUS "Found hiredis: include=${HIREDIS_INCLUDE_DIR} lib=${HIREDIS_LIB}")
     list(APPEND MOONCAKE_STORE_SOURCES redis_helper.cpp)
+    list(APPEND MOONCAKE_STORE_SOURCES redis_master_view_helper.cpp)
     list(APPEND EXTRA_LIBS ${HIREDIS_LIB})
 endif()
 

--- a/mooncake-store/src/ha_helper.cpp
+++ b/mooncake-store/src/ha_helper.cpp
@@ -97,7 +97,15 @@ void MasterViewHelper::KeepLeader(EtcdLeaseId lease_id) {
 }
 
 void MasterViewHelper::CancelKeepAlive(EtcdLeaseId lease_id) {
-    EtcdHelper::CancelKeepAlive(lease_id);
+    auto ret = EtcdHelper::CancelKeepAlive(lease_id);
+    if (ret != ErrorCode::OK) {
+        LOG(ERROR) << "Failed to cancel etcd keep-alive, lease_id=" << lease_id
+                   << ", error=" << ret;
+    }
+}
+
+int MasterViewHelper::GetLeaderLeaseTTLSeconds() const {
+    return static_cast<int>(ETCD_MASTER_VIEW_LEASE_TTL);
 }
 
 ErrorCode MasterViewHelper::GetMasterView(std::string& master_address,
@@ -142,6 +150,10 @@ int MasterServiceSupervisor::Start() {
 
         auto mv_helper = CreateMasterViewHelper(config_);
         if (!mv_helper) {
+            LOG(ERROR) << "Failed to create leader election helper, backend="
+                       << (config_.election_backend == ElectionBackend::REDIS
+                               ? "redis"
+                               : "etcd");
             return -1;
         }
 
@@ -162,11 +174,8 @@ int MasterServiceSupervisor::Start() {
 
         // To prevent potential split-brain, wait long enough for the old leader
         // to retire.
-        const int waiting_time =
-            config_.election_backend == ElectionBackend::REDIS
-                ? config_.redis_master_view_ttl_sec
-                : static_cast<int>(ETCD_MASTER_VIEW_LEASE_TTL);
-        std::this_thread::sleep_for(std::chrono::seconds(waiting_time));
+        std::this_thread::sleep_for(
+            std::chrono::seconds(mv_helper->GetLeaderLeaseTTLSeconds()));
 
         LOG(INFO) << "Starting master service...";
         if (config_.deployment_mode == DeploymentMode::CENTRALIZATION) {

--- a/mooncake-store/src/ha_helper.cpp
+++ b/mooncake-store/src/ha_helper.cpp
@@ -154,7 +154,7 @@ int MasterServiceSupervisor::Start() {
 
         // Start a thread to keep the leader alive
         auto keep_leader_thread =
-            std::thread([&server, &mv_helper, lease_id]() {
+            std::thread([&server, mv_helper = mv_helper.get(), lease_id]() {
                 mv_helper->KeepLeader(lease_id);
                 LOG(INFO) << "Trying to stop server...";
                 server.stop();

--- a/mooncake-store/src/ha_helper.cpp
+++ b/mooncake-store/src/ha_helper.cpp
@@ -2,6 +2,9 @@
 #include "etcd_helper.h"
 #include "centralized_rpc_service.h"
 #include "p2p_rpc_service.h"
+#ifdef STORE_USE_REDIS
+#include "redis_master_view_helper.h"
+#endif
 
 namespace mooncake {
 
@@ -20,6 +23,8 @@ MasterViewHelper::MasterViewHelper() {
     master_view_key_ = "mooncake-store/" + cluster_id + "master_view";
     LOG(INFO) << "Master view key: " << master_view_key_;
 }
+
+MasterViewHelper::~MasterViewHelper() = default;
 
 ErrorCode MasterViewHelper::ConnectToEtcd(const std::string& etcd_endpoints) {
     return EtcdHelper::ConnectToEtcdStoreClient(etcd_endpoints);
@@ -91,6 +96,10 @@ void MasterViewHelper::KeepLeader(EtcdLeaseId lease_id) {
     EtcdHelper::KeepAlive(lease_id);
 }
 
+void MasterViewHelper::CancelKeepAlive(EtcdLeaseId lease_id) {
+    EtcdHelper::CancelKeepAlive(lease_id);
+}
+
 ErrorCode MasterViewHelper::GetMasterView(std::string& master_address,
                                           ViewVersionId& version) {
     auto err_code =
@@ -125,31 +134,38 @@ int MasterServiceSupervisor::Start() {
             server.init_ibv();
         }
 
-        LOG(INFO) << "Init leader election helper...";
-        MasterViewHelper mv_helper;
-        if (mv_helper.ConnectToEtcd(config_.etcd_endpoints) != ErrorCode::OK) {
-            LOG(ERROR) << "Failed to connect to etcd endpoints: "
-                       << config_.etcd_endpoints;
+        LOG(INFO) << "Init leader election helper (backend="
+                  << (config_.election_backend == ElectionBackend::REDIS
+                          ? "redis"
+                          : "etcd")
+                  << ")...";
+
+        auto mv_helper = CreateMasterViewHelper(config_);
+        if (!mv_helper) {
             return -1;
         }
+
         LOG(INFO) << "Trying to elect self as leader...";
         EtcdLeaseId lease_id = 0;
         // view_version will be updated by ElectLeader and then used in
         // WrappedMasterService
         ViewVersionId view_version = 0;
-        mv_helper.ElectLeader(config_.local_hostname, view_version, lease_id);
+        mv_helper->ElectLeader(config_.local_hostname, view_version, lease_id);
 
         // Start a thread to keep the leader alive
         auto keep_leader_thread =
             std::thread([&server, &mv_helper, lease_id]() {
-                mv_helper.KeepLeader(lease_id);
+                mv_helper->KeepLeader(lease_id);
                 LOG(INFO) << "Trying to stop server...";
                 server.stop();
             });
 
         // To prevent potential split-brain, wait long enough for the old leader
         // to retire.
-        const int waiting_time = ETCD_MASTER_VIEW_LEASE_TTL;
+        const int waiting_time =
+            config_.election_backend == ElectionBackend::REDIS
+                ? config_.redis_master_view_ttl_sec
+                : static_cast<int>(ETCD_MASTER_VIEW_LEASE_TTL);
         std::this_thread::sleep_for(std::chrono::seconds(waiting_time));
 
         LOG(INFO) << "Starting master service...";
@@ -170,13 +186,7 @@ int MasterServiceSupervisor::Start() {
         if (ec.hasResult()) {
             LOG(ERROR) << "Failed to start master service: "
                        << ec.result().value();
-            auto etcd_err = EtcdHelper::CancelKeepAlive(lease_id);
-            if (etcd_err != ErrorCode::OK) {
-                LOG(ERROR) << "Failed to cancel keep leader alive: "
-                           << etcd_err;
-            }
-            // Even if CancelKeepAlive fails, the keep alive context are closed.
-            // We can safely join the keep leader thread.
+            mv_helper->CancelKeepAlive(lease_id);
             keep_leader_thread.join();
             return -1;
         }
@@ -186,9 +196,8 @@ int MasterServiceSupervisor::Start() {
 
         // If the server is closed due to internal errors, we need to manually
         // stop keep leader alive.
-        auto etcd_err = EtcdHelper::CancelKeepAlive(lease_id);
-        // The error here is predicatable, no need to log it as ERROR.
-        LOG(INFO) << "Cancel keep leader alive: " << etcd_err;
+        mv_helper->CancelKeepAlive(lease_id);
+        LOG(INFO) << "Cancel keep leader alive requested";
         keep_leader_thread.join();
     }
     return 0;
@@ -198,6 +207,38 @@ MasterServiceSupervisor::~MasterServiceSupervisor() {
     if (server_thread_.joinable()) {
         server_thread_.join();
     }
+}
+
+std::unique_ptr<MasterViewHelper> CreateMasterViewHelper(
+    const MasterServiceSupervisorConfig& config) {
+    if (config.election_backend == ElectionBackend::REDIS) {
+#ifdef STORE_USE_REDIS
+        auto helper = std::make_unique<RedisMasterViewHelper>(
+            config.cluster_id, config.redis_endpoint, config.redis_password,
+            config.redis_db_index, config.redis_master_view_ttl_sec,
+            config.redis_heartbeat_interval_sec);
+        auto rc = helper->Connect();
+        if (rc != ErrorCode::OK) {
+            LOG(ERROR) << "Failed to connect to Redis at: "
+                       << config.redis_endpoint;
+            return nullptr;
+        }
+        return helper;
+#else
+        LOG(ERROR) << "Redis election backend requested but STORE_USE_REDIS "
+                      "is not enabled at compile time";
+        return nullptr;
+#endif
+    }
+
+    // Default: etcd backend
+    auto helper = std::make_unique<MasterViewHelper>();
+    if (helper->ConnectToEtcd(config.etcd_endpoints) != ErrorCode::OK) {
+        LOG(ERROR) << "Failed to connect to etcd endpoints: "
+                   << config.etcd_endpoints;
+        return nullptr;
+    }
+    return helper;
 }
 
 }  // namespace mooncake

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -126,6 +126,22 @@ DEFINE_string(cxl_path, mooncake::DEFAULT_CXL_PATH,
               "DAX device path for CXL memory");
 DEFINE_uint64(cxl_size, mooncake::DEFAULT_CXL_SIZE, "CXL memory size in bytes");
 DEFINE_bool(enable_cxl, false, "Whether to enable CXL memory support");
+
+// Redis election backend configuration
+DEFINE_string(election_backend, "etcd",
+              "Election backend for HA leader election: 'etcd' (default) or "
+              "'redis' (P2P HA)");
+DEFINE_string(redis_endpoint, "",
+              "Redis endpoint for election (required when "
+              "election_backend=redis), e.g. '10.0.0.1:6379'");
+DEFINE_string(redis_password, "", "Redis AUTH password (empty = no auth)");
+DEFINE_int32(redis_db_index, 0, "Redis database index (default: 0)");
+DEFINE_int32(
+    redis_master_view_ttl_sec, 5,
+    "TTL in seconds for the leader key in Redis election (default: 5)");
+DEFINE_int32(redis_heartbeat_interval_sec, 2,
+             "KeepLeader heartbeat interval in seconds for Redis election "
+             "(default: 2, should be < ttl)");
 void InitMasterConf(const mooncake::DefaultConfig& default_config,
                     mooncake::MasterConfig& master_config) {
     // Initialize the master service configuration from the default config
@@ -228,6 +244,23 @@ void InitMasterConf(const mooncake::DefaultConfig& default_config,
                              FLAGS_max_replicas_per_key);
     default_config.GetString("deployment_mode", &master_config.deployment_mode,
                              FLAGS_deployment_mode);
+
+    // Redis election backend configuration
+    default_config.GetString("election_backend",
+                             &master_config.election_backend,
+                             FLAGS_election_backend);
+    default_config.GetString("redis_endpoint", &master_config.redis_endpoint,
+                             FLAGS_redis_endpoint);
+    default_config.GetString("redis_password", &master_config.redis_password,
+                             FLAGS_redis_password);
+    default_config.GetInt32("redis_db_index", &master_config.redis_db_index,
+                            FLAGS_redis_db_index);
+    default_config.GetInt32("redis_master_view_ttl_sec",
+                            &master_config.redis_master_view_ttl_sec,
+                            FLAGS_redis_master_view_ttl_sec);
+    default_config.GetInt32("redis_heartbeat_interval_sec",
+                            &master_config.redis_heartbeat_interval_sec,
+                            FLAGS_redis_heartbeat_interval_sec);
 }
 
 void LoadConfigFromCmdline(mooncake::MasterConfig& master_config,
@@ -469,6 +502,41 @@ void LoadConfigFromCmdline(mooncake::MasterConfig& master_config,
         !conf_set) {
         master_config.max_replicas_per_key = FLAGS_max_replicas_per_key;
     }
+
+    // Redis election backend configuration
+    if ((google::GetCommandLineFlagInfo("election_backend", &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.election_backend = FLAGS_election_backend;
+    }
+    if ((google::GetCommandLineFlagInfo("redis_endpoint", &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.redis_endpoint = FLAGS_redis_endpoint;
+    }
+    if ((google::GetCommandLineFlagInfo("redis_password", &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.redis_password = FLAGS_redis_password;
+    }
+    if ((google::GetCommandLineFlagInfo("redis_db_index", &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.redis_db_index = FLAGS_redis_db_index;
+    }
+    if ((google::GetCommandLineFlagInfo("redis_master_view_ttl_sec", &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.redis_master_view_ttl_sec =
+            FLAGS_redis_master_view_ttl_sec;
+    }
+    if ((google::GetCommandLineFlagInfo("redis_heartbeat_interval_sec",
+                                        &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.redis_heartbeat_interval_sec =
+            FLAGS_redis_heartbeat_interval_sec;
+    }
 }
 
 // Function to start HTTP metadata server
@@ -520,8 +588,34 @@ int main(int argc, char* argv[]) {
     }
     LoadConfigFromCmdline(master_config, !conf_path.empty());
 
-    if (master_config.enable_ha && master_config.etcd_endpoints.empty()) {
-        LOG(FATAL) << "Etcd endpoints must be set when enable_ha is true";
+    // Validate election_backend value
+    if (master_config.election_backend != "etcd" &&
+        master_config.election_backend != "redis") {
+        LOG(FATAL) << "Invalid election_backend: "
+                   << master_config.election_backend
+                   << ". Must be 'etcd' or 'redis'";
+        return 1;
+    }
+    if (master_config.enable_ha && master_config.etcd_endpoints.empty() &&
+        master_config.election_backend != "redis") {
+        LOG(FATAL) << "Etcd endpoints must be set when enable_ha is true and "
+                      "election_backend is etcd";
+        return 1;
+    }
+    if (master_config.enable_ha && master_config.election_backend == "redis" &&
+        master_config.redis_endpoint.empty()) {
+        LOG(FATAL)
+            << "redis_endpoint must be set when election_backend is redis "
+               "and enable_ha is true";
+        return 1;
+    }
+    if (master_config.election_backend == "redis" &&
+        master_config.redis_heartbeat_interval_sec >=
+            master_config.redis_master_view_ttl_sec) {
+        LOG(FATAL) << "redis_heartbeat_interval_sec ("
+                   << master_config.redis_heartbeat_interval_sec
+                   << ") must be less than redis_master_view_ttl_sec ("
+                   << master_config.redis_master_view_ttl_sec << ")";
         return 1;
     }
     if (!master_config.enable_ha && !master_config.etcd_endpoints.empty()) {

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -596,6 +596,13 @@ int main(int argc, char* argv[]) {
                    << ". Must be 'etcd' or 'redis'";
         return 1;
     }
+#ifndef STORE_USE_REDIS
+    if (master_config.enable_ha && master_config.election_backend == "redis") {
+        LOG(FATAL) << "Redis election backend requested but STORE_USE_REDIS "
+                      "is not enabled at compile time";
+        return 1;
+    }
+#endif
     if (master_config.enable_ha && master_config.etcd_endpoints.empty() &&
         master_config.election_backend != "redis") {
         LOG(FATAL) << "Etcd endpoints must be set when enable_ha is true and "
@@ -609,14 +616,23 @@ int main(int argc, char* argv[]) {
                "and enable_ha is true";
         return 1;
     }
-    if (master_config.election_backend == "redis" &&
-        master_config.redis_heartbeat_interval_sec >=
+    if (master_config.election_backend == "redis") {
+        if (master_config.redis_master_view_ttl_sec <= 0) {
+            LOG(FATAL) << "redis_master_view_ttl_sec must be greater than 0";
+            return 1;
+        }
+        if (master_config.redis_heartbeat_interval_sec <= 0) {
+            LOG(FATAL) << "redis_heartbeat_interval_sec must be greater than 0";
+            return 1;
+        }
+        if (master_config.redis_heartbeat_interval_sec >=
             master_config.redis_master_view_ttl_sec) {
-        LOG(FATAL) << "redis_heartbeat_interval_sec ("
-                   << master_config.redis_heartbeat_interval_sec
-                   << ") must be less than redis_master_view_ttl_sec ("
-                   << master_config.redis_master_view_ttl_sec << ")";
-        return 1;
+            LOG(FATAL) << "redis_heartbeat_interval_sec ("
+                       << master_config.redis_heartbeat_interval_sec
+                       << ") must be less than redis_master_view_ttl_sec ("
+                       << master_config.redis_master_view_ttl_sec << ")";
+            return 1;
+        }
     }
     if (!master_config.enable_ha && !master_config.etcd_endpoints.empty()) {
         LOG(WARNING)

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -588,50 +588,52 @@ int main(int argc, char* argv[]) {
     }
     LoadConfigFromCmdline(master_config, !conf_path.empty());
 
-    // Validate election_backend value
-    if (master_config.election_backend != "etcd" &&
-        master_config.election_backend != "redis") {
-        LOG(FATAL) << "Invalid election_backend: "
-                   << master_config.election_backend
-                   << ". Must be 'etcd' or 'redis'";
-        return 1;
-    }
+    if (master_config.enable_ha) {
+        if (master_config.election_backend != "etcd" &&
+            master_config.election_backend != "redis") {
+            LOG(FATAL) << "Invalid election_backend: "
+                       << master_config.election_backend
+                       << ". Must be 'etcd' or 'redis'";
+            return 1;
+        }
+
+        if (master_config.election_backend == "etcd") {
+            if (master_config.etcd_endpoints.empty()) {
+                LOG(FATAL)
+                    << "Etcd endpoints must be set when enable_ha is true and "
+                       "election_backend is etcd";
+                return 1;
+            }
+        } else {
 #ifndef STORE_USE_REDIS
-    if (master_config.enable_ha && master_config.election_backend == "redis") {
-        LOG(FATAL) << "Redis election backend requested but STORE_USE_REDIS "
-                      "is not enabled at compile time";
-        return 1;
-    }
+            LOG(FATAL) << "Redis election backend requested but "
+                          "STORE_USE_REDIS is not enabled at compile time";
+            return 1;
 #endif
-    if (master_config.enable_ha && master_config.etcd_endpoints.empty() &&
-        master_config.election_backend != "redis") {
-        LOG(FATAL) << "Etcd endpoints must be set when enable_ha is true and "
-                      "election_backend is etcd";
-        return 1;
-    }
-    if (master_config.enable_ha && master_config.election_backend == "redis" &&
-        master_config.redis_endpoint.empty()) {
-        LOG(FATAL)
-            << "redis_endpoint must be set when election_backend is redis "
-               "and enable_ha is true";
-        return 1;
-    }
-    if (master_config.election_backend == "redis") {
-        if (master_config.redis_master_view_ttl_sec <= 0) {
-            LOG(FATAL) << "redis_master_view_ttl_sec must be greater than 0";
-            return 1;
-        }
-        if (master_config.redis_heartbeat_interval_sec <= 0) {
-            LOG(FATAL) << "redis_heartbeat_interval_sec must be greater than 0";
-            return 1;
-        }
-        if (master_config.redis_heartbeat_interval_sec >=
-            master_config.redis_master_view_ttl_sec) {
-            LOG(FATAL) << "redis_heartbeat_interval_sec ("
-                       << master_config.redis_heartbeat_interval_sec
-                       << ") must be less than redis_master_view_ttl_sec ("
-                       << master_config.redis_master_view_ttl_sec << ")";
-            return 1;
+            if (master_config.redis_endpoint.empty()) {
+                LOG(FATAL)
+                    << "redis_endpoint must be set when election_backend is "
+                       "redis and enable_ha is true";
+                return 1;
+            }
+            if (master_config.redis_master_view_ttl_sec <= 0) {
+                LOG(FATAL)
+                    << "redis_master_view_ttl_sec must be greater than 0";
+                return 1;
+            }
+            if (master_config.redis_heartbeat_interval_sec <= 0) {
+                LOG(FATAL)
+                    << "redis_heartbeat_interval_sec must be greater than 0";
+                return 1;
+            }
+            if (master_config.redis_heartbeat_interval_sec >=
+                master_config.redis_master_view_ttl_sec) {
+                LOG(FATAL) << "redis_heartbeat_interval_sec ("
+                           << master_config.redis_heartbeat_interval_sec
+                           << ") must be less than redis_master_view_ttl_sec ("
+                           << master_config.redis_master_view_ttl_sec << ")";
+                return 1;
+            }
         }
     }
     if (!master_config.enable_ha && !master_config.etcd_endpoints.empty()) {

--- a/mooncake-store/src/redis_helper.cpp
+++ b/mooncake-store/src/redis_helper.cpp
@@ -40,7 +40,7 @@ RedisHelper::RedisHelper(const std::string& cluster_id,
 }
 
 RedisHelper::~RedisHelper() {
-    cancel_election_ = true;
+    CancelElection();
     CancelKeepAlive();
     if (subscribe_ctx_) {
         redisFree(subscribe_ctx_);
@@ -338,7 +338,12 @@ bool RedisHelper::WatchLeaderSubscribe() {
     redisContext* polling_ctx = CreateConnection();
     if (!polling_ctx) {
         LOG(WARNING) << "WatchLeaderSubscribe: failed to create polling "
-                        "connection; relying on subscribe loop only";
+                        "connection; falling back to pure polling";
+        RedisReplyPtr unsub((redisReply*)redisCommand(
+            subscribe_ctx_, "UNSUBSCRIBE %b", leader_event_channel_.data(),
+            leader_event_channel_.size()));
+        DrainSubscribeContext();
+        return false;
     }
 
     // Polling thread: check if key still exists periodically.
@@ -574,6 +579,8 @@ void RedisHelper::CancelKeepAlive() {
     cancel_keep_alive_ = true;
     keep_alive_running_ = false;
 }
+
+void RedisHelper::CancelElection() { cancel_election_ = true; }
 
 // ============================================================
 // GetMasterView

--- a/mooncake-store/src/redis_helper.cpp
+++ b/mooncake-store/src/redis_helper.cpp
@@ -351,30 +351,25 @@ bool RedisHelper::WatchLeaderSubscribe() {
     // so redisGetReply returns at least once per second regardless
     // of whether a Pub/Sub message arrives, allowing the subscribe
     // loop to check leader_lost/cancel_election_ flags.
-    // Only create the polling thread if we have a valid connection.
-    std::thread polling_thread;
-    if (polling_ctx) {
-        polling_thread = std::thread([this, &leader_lost, polling_ctx]() {
-            auto interval = std::chrono::seconds(ttl_sec_);
-            while (!leader_lost && !cancel_election_) {
-                std::this_thread::sleep_for(interval);
-                if (leader_lost || cancel_election_) break;
+    std::thread polling_thread([this, &leader_lost, polling_ctx]() {
+        auto interval = std::chrono::seconds(ttl_sec_);
+        while (!leader_lost && !cancel_election_) {
+            std::this_thread::sleep_for(interval);
+            if (leader_lost || cancel_election_) break;
 
-                RedisReplyPtr r((redisReply*)redisCommand(
-                    polling_ctx, "GET %b", master_view_key_.data(),
-                    master_view_key_.size()));
-                if (!r) {
-                    LOG(WARNING)
-                        << "WatchLeaderSubscribe: polling GET failed "
-                           "(connection error), exiting polling thread";
-                    break;
-                }
-                if (r->type == REDIS_REPLY_NIL) {
-                    leader_lost = true;
-                }
+            RedisReplyPtr r((redisReply*)redisCommand(polling_ctx, "GET %b",
+                                                      master_view_key_.data(),
+                                                      master_view_key_.size()));
+            if (!r) {
+                LOG(WARNING) << "WatchLeaderSubscribe: polling GET failed "
+                                "(connection error), exiting polling thread";
+                break;
             }
-        });
-    }
+            if (r->type == REDIS_REPLY_NIL) {
+                leader_lost = true;
+            }
+        }
+    });
 
     // Subscribe loop: read messages until leader vacancy is detected.
     // redisGetReply returns at least every 1s (subscribe_ctx_ timeout)

--- a/mooncake-store/src/redis_master_view_helper.cpp
+++ b/mooncake-store/src/redis_master_view_helper.cpp
@@ -10,7 +10,8 @@ RedisMasterViewHelper::RedisMasterViewHelper(const std::string& cluster_id,
                                              int db_index, int ttl_sec,
                                              int heartbeat_interval_sec)
     : redis_helper_(cluster_id, redis_endpoint, password, db_index, ttl_sec,
-                    heartbeat_interval_sec) {}
+                    heartbeat_interval_sec),
+      ttl_sec_(ttl_sec) {}
 
 ErrorCode RedisMasterViewHelper::Connect() { return redis_helper_.Connect(); }
 
@@ -30,6 +31,8 @@ void RedisMasterViewHelper::CancelKeepAlive(EtcdLeaseId lease_id) {
     (void)lease_id;
     redis_helper_.CancelKeepAlive();
 }
+
+int RedisMasterViewHelper::GetLeaderLeaseTTLSeconds() const { return ttl_sec_; }
 
 void RedisMasterViewHelper::CancelElection() { redis_helper_.CancelElection(); }
 

--- a/mooncake-store/src/redis_master_view_helper.cpp
+++ b/mooncake-store/src/redis_master_view_helper.cpp
@@ -31,6 +31,8 @@ void RedisMasterViewHelper::CancelKeepAlive(EtcdLeaseId lease_id) {
     redis_helper_.CancelKeepAlive();
 }
 
+void RedisMasterViewHelper::CancelElection() { redis_helper_.CancelElection(); }
+
 ErrorCode RedisMasterViewHelper::GetMasterView(std::string& master_address,
                                                ViewVersionId& version) {
     return redis_helper_.GetMasterView(master_address, version);

--- a/mooncake-store/src/redis_master_view_helper.cpp
+++ b/mooncake-store/src/redis_master_view_helper.cpp
@@ -1,0 +1,41 @@
+#ifdef STORE_USE_REDIS
+
+#include "redis_master_view_helper.h"
+
+namespace mooncake {
+
+RedisMasterViewHelper::RedisMasterViewHelper(const std::string& cluster_id,
+                                             const std::string& redis_endpoint,
+                                             const std::string& password,
+                                             int db_index, int ttl_sec,
+                                             int heartbeat_interval_sec)
+    : redis_helper_(cluster_id, redis_endpoint, password, db_index, ttl_sec,
+                    heartbeat_interval_sec) {}
+
+ErrorCode RedisMasterViewHelper::Connect() { return redis_helper_.Connect(); }
+
+void RedisMasterViewHelper::ElectLeader(const std::string& master_address,
+                                        ViewVersionId& version,
+                                        EtcdLeaseId& lease_id) {
+    int redis_lease_id = 0;
+    redis_helper_.ElectLeader(master_address, version, redis_lease_id);
+    lease_id = static_cast<EtcdLeaseId>(redis_lease_id);
+}
+
+void RedisMasterViewHelper::KeepLeader(EtcdLeaseId lease_id) {
+    redis_helper_.KeepLeader(static_cast<int>(lease_id));
+}
+
+void RedisMasterViewHelper::CancelKeepAlive(EtcdLeaseId lease_id) {
+    (void)lease_id;
+    redis_helper_.CancelKeepAlive();
+}
+
+ErrorCode RedisMasterViewHelper::GetMasterView(std::string& master_address,
+                                               ViewVersionId& version) {
+    return redis_helper_.GetMasterView(master_address, version);
+}
+
+}  // namespace mooncake
+
+#endif  // STORE_USE_REDIS

--- a/mooncake-store/tests/redis_helper_test.cpp
+++ b/mooncake-store/tests/redis_helper_test.cpp
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <future>
 #include <string>
 #include <thread>
 
@@ -10,15 +11,48 @@
 
 #ifdef STORE_USE_REDIS
 #include "redis_helper.h"
+#include "redis_master_view_helper.h"
 #include <hiredis/hiredis.h>
 
 namespace mooncake {
 namespace testing {
 
 DEFINE_string(redis_endpoint, "127.0.0.1:6379",
-              "Redis endpoint for helper test");
+              "Redis endpoint for Redis test");
 DEFINE_int32(redis_ttl_sec, 2, "Short TTL for testing fast key expiration");
-DEFINE_string(cluster_id, "test_helper", "Cluster ID for Redis helper test");
+DEFINE_string(cluster_id, "test_helper", "Cluster ID for Redis test");
+
+// ============================================================
+// Helper: clean up Redis keys between tests
+// ============================================================
+
+static void CleanupRedisKeys() {
+    std::string host = "127.0.0.1";
+    int port = 6379;
+    auto colon_pos = FLAGS_redis_endpoint.rfind(':');
+    if (colon_pos != std::string::npos) {
+        host = FLAGS_redis_endpoint.substr(0, colon_pos);
+        port = std::stoi(FLAGS_redis_endpoint.substr(colon_pos + 1));
+    }
+    redisContext* ctx = redisConnect(host.c_str(), port);
+    if (ctx && !ctx->err) {
+        std::string master_view_key =
+            "mooncake:{" + FLAGS_cluster_id + "/}master_view";
+        std::string master_epoch_key =
+            "mooncake:{" + FLAGS_cluster_id + "/}master_epoch";
+        redisReply* r = (redisReply*)redisCommand(
+            ctx, "DEL %b %b", master_view_key.data(), master_view_key.size(),
+            master_epoch_key.data(), master_epoch_key.size());
+        if (r) freeReplyObject(r);
+        redisFree(ctx);
+    } else {
+        if (ctx) redisFree(ctx);
+    }
+}
+
+// ============================================================
+// RedisHelperTest — direct RedisHelper API tests
+// ============================================================
 
 class RedisHelperTest : public ::testing::Test {
    protected:
@@ -31,41 +65,8 @@ class RedisHelperTest : public ::testing::Test {
     static void TearDownTestSuite() { google::ShutdownGoogleLogging(); }
 
     void SetUp() override { CleanupRedisKeys(); }
-
     void TearDown() override { CleanupRedisKeys(); }
-
-   private:
-    // Delete both master_view and master_epoch keys directly.
-    // master_epoch has no TTL (INCR key), so it persists across tests
-    // and would block subsequent ElectLeader calls if not cleaned up.
-    // Both SetUp and TearDown call this to ensure isolation even if a
-    // test's KeepLeader thread is still renewing the key at exit.
-    static void CleanupRedisKeys() {
-        std::string host = "127.0.0.1";
-        int port = 6379;
-        auto colon_pos = FLAGS_redis_endpoint.rfind(':');
-        if (colon_pos != std::string::npos) {
-            host = FLAGS_redis_endpoint.substr(0, colon_pos);
-            port = std::stoi(FLAGS_redis_endpoint.substr(colon_pos + 1));
-        }
-        redisContext* ctx = redisConnect(host.c_str(), port);
-        if (ctx && !ctx->err) {
-            std::string master_view_key =
-                "mooncake:{" + FLAGS_cluster_id + "/}master_view";
-            std::string master_epoch_key =
-                "mooncake:{" + FLAGS_cluster_id + "/}master_epoch";
-            RedisReplyPtr r((redisReply*)redisCommand(
-                ctx, "DEL %b %b", master_view_key.data(),
-                master_view_key.size(), master_epoch_key.data(),
-                master_epoch_key.size()));
-            redisFree(ctx);
-        } else {
-            if (ctx) redisFree(ctx);
-        }
-    }
 };
-
-// === Test 1: Connect ===
 
 TEST_F(RedisHelperTest, Connect) {
     RedisHelper helper(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0,
@@ -176,11 +177,22 @@ TEST_F(RedisHelperTest, ElectLeaderWaitsForKeyExpiry) {
     ViewVersionId second_version = 0;
     int second_lease = 0;
 
+    // Use a future with timeout to prevent blocking forever if the
+    // Redis key does not expire as expected.
+    std::promise<void> done;
+    auto future = done.get_future();
     std::thread elect_thread([&]() {
         second.ElectLeader("10.0.0.5:50051", second_version, second_lease);
+        done.set_value();
     });
 
-    // Should complete within short_ttl * 3 seconds
+    // short_ttl=1, key should expire in ~2s; allow 10s safety margin
+    if (future.wait_for(std::chrono::seconds(10)) !=
+        std::future_status::ready) {
+        second.CancelKeepAlive();
+        elect_thread.join();
+        FAIL() << "Timed out waiting for Redis leader election";
+    }
     elect_thread.join();
     ASSERT_GT(second_version, 0);
     // Epoch should be strictly increasing
@@ -615,6 +627,149 @@ TEST_F(RedisHelperTest, SubscribeReceivesVacantMessage) {
     ASSERT_GT(second_version, first_version);
 }
 
+// ============================================================
+// RedisElectionTest — MasterViewHelper integration tests
+// ============================================================
+
+#ifdef STORE_USE_REDIS
+
+class RedisElectionTest : public ::testing::Test {
+   protected:
+    void SetUp() override { CleanupRedisKeys(); }
+    void TearDown() override { CleanupRedisKeys(); }
+};
+
+// === Test 8: MasterViewHelper ElectLeader + GetMasterView ===
+
+TEST_F(RedisElectionTest, ElectAndGetMasterView) {
+    RedisMasterViewHelper mv_helper(FLAGS_cluster_id, FLAGS_redis_endpoint, "",
+                                    0, FLAGS_redis_ttl_sec, 1);
+    ASSERT_EQ(ErrorCode::OK, mv_helper.Connect());
+
+    std::string master_address = "10.0.0.10:50051";
+    ViewVersionId version = 0;
+    EtcdLeaseId lease_id = 0;
+
+    mv_helper.ElectLeader(master_address, version, lease_id);
+    ASSERT_GT(version, 0);
+    ASSERT_GT(lease_id, 0);
+
+    std::string got_address;
+    ViewVersionId got_version = 0;
+    ASSERT_EQ(ErrorCode::OK, mv_helper.GetMasterView(got_address, got_version));
+    ASSERT_EQ(got_address, master_address);
+    ASSERT_EQ(got_version, version);
+}
+
+// === Test 9: MasterViewHelper KeepLeader ===
+
+TEST_F(RedisElectionTest, KeepLeaderRenewsTTL) {
+    RedisMasterViewHelper mv_helper(FLAGS_cluster_id, FLAGS_redis_endpoint, "",
+                                    0, FLAGS_redis_ttl_sec, 1);
+    ASSERT_EQ(ErrorCode::OK, mv_helper.Connect());
+
+    std::string master_address = "10.0.0.11:50051";
+    ViewVersionId version = 0;
+    EtcdLeaseId lease_id = 0;
+
+    mv_helper.ElectLeader(master_address, version, lease_id);
+
+    std::thread keep_alive_thread([&]() { mv_helper.KeepLeader(lease_id); });
+    std::this_thread::sleep_for(std::chrono::seconds(FLAGS_redis_ttl_sec * 3));
+
+    std::string got_address;
+    ViewVersionId got_version = 0;
+    EXPECT_EQ(ErrorCode::OK, mv_helper.GetMasterView(got_address, got_version));
+    EXPECT_EQ(got_address, master_address);
+
+    mv_helper.CancelKeepAlive(lease_id);
+    keep_alive_thread.join();
+}
+
+// === Test 10: MasterViewHelper key expiry ===
+
+TEST_F(RedisElectionTest, KeyExpiresAfterKeepLeaderStops) {
+    const int short_ttl = 1;
+    RedisMasterViewHelper mv_helper(FLAGS_cluster_id, FLAGS_redis_endpoint, "",
+                                    0, short_ttl, 1);
+    ASSERT_EQ(ErrorCode::OK, mv_helper.Connect());
+
+    std::string master_address = "10.0.0.12:50051";
+    ViewVersionId version = 0;
+    EtcdLeaseId lease_id = 0;
+
+    mv_helper.ElectLeader(master_address, version, lease_id);
+
+    // Don't start KeepLeader — let the key expire naturally
+    std::this_thread::sleep_for(std::chrono::seconds(short_ttl * 3));
+
+    RedisMasterViewHelper reader(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0,
+                                 short_ttl, 1);
+    ASSERT_EQ(ErrorCode::OK, reader.Connect());
+    std::string got_address;
+    ViewVersionId got_version = 0;
+    EXPECT_NE(ErrorCode::OK, reader.GetMasterView(got_address, got_version));
+}
+
+// === Test 11: MasterViewHelper ElectLeader waits for key expiry ===
+
+TEST_F(RedisElectionTest, ElectLeaderWaitsForKeyExpiry) {
+    const int short_ttl = 1;
+
+    RedisMasterViewHelper first(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0,
+                                short_ttl, 1);
+    ASSERT_EQ(ErrorCode::OK, first.Connect());
+    ViewVersionId first_version = 0;
+    EtcdLeaseId first_lease = 0;
+    first.ElectLeader("10.0.0.13:50051", first_version, first_lease);
+
+    RedisMasterViewHelper second(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0,
+                                 short_ttl, 1);
+    ASSERT_EQ(ErrorCode::OK, second.Connect());
+    ViewVersionId second_version = 0;
+    EtcdLeaseId second_lease = 0;
+
+    // Use a future with timeout to prevent blocking forever if the
+    // Redis key does not expire as expected.
+    std::promise<void> done;
+    auto future = done.get_future();
+    std::thread elect_thread([&]() {
+        second.ElectLeader("10.0.0.14:50051", second_version, second_lease);
+        done.set_value();
+    });
+
+    // short_ttl=1, key should expire in ~2s; allow 10s safety margin
+    if (future.wait_for(std::chrono::seconds(10)) !=
+        std::future_status::ready) {
+        second.CancelKeepAlive(second_lease);
+        elect_thread.join();
+        FAIL() << "Timed out waiting for Redis master view election";
+    }
+    elect_thread.join();
+    ASSERT_GT(second_version, 0);
+    ASSERT_GT(second_version, first_version);
+}
+
+// === Test 12: MasterViewHelper epoch monotonicity ===
+
+TEST_F(RedisElectionTest, EpochMonotonicallyIncreases) {
+    const int short_ttl = 1;
+    RedisMasterViewHelper helper(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0,
+                                 short_ttl, 1);
+    ASSERT_EQ(ErrorCode::OK, helper.Connect());
+
+    ViewVersionId prev_epoch = 0;
+    for (int i = 0; i < 3; i++) {
+        ViewVersionId version = 0;
+        EtcdLeaseId lease_id = 0;
+        helper.ElectLeader("10.0.0.15:50051", version, lease_id);
+        ASSERT_GT(version, prev_epoch);
+        prev_epoch = version;
+        std::this_thread::sleep_for(std::chrono::seconds(short_ttl * 3));
+    }
+}
+
+#endif  // STORE_USE_REDIS
 }  // namespace testing
 }  // namespace mooncake
 

--- a/mooncake-store/tests/redis_helper_test.cpp
+++ b/mooncake-store/tests/redis_helper_test.cpp
@@ -189,7 +189,7 @@ TEST_F(RedisHelperTest, ElectLeaderWaitsForKeyExpiry) {
     // short_ttl=1, key should expire in ~2s; allow 10s safety margin
     if (future.wait_for(std::chrono::seconds(10)) !=
         std::future_status::ready) {
-        second.CancelKeepAlive();
+        second.CancelElection();
         elect_thread.join();
         FAIL() << "Timed out waiting for Redis leader election";
     }
@@ -545,10 +545,7 @@ TEST_F(RedisHelperTest, ReconnectAfterConnectionLoss) {
 
 // === Test 19: ElectLeader detects cancel via WatchLeader ===
 // Covers: redis_helper.cpp:171-179 (election_ctx_ null → retry)
-// ElectLeader's while(true) loop doesn't check cancel_requested_ directly,
-// but WatchLeader does. We create a scenario where ElectLeader enters
-// WatchLeader (which can be cancelled), covering the connect-retry path
-// at lines 171-179 along the way.
+// ElectLeader can be cancelled while waiting in WatchLeader.
 
 TEST_F(RedisHelperTest, ElectLeaderCancelledViaWatchLeader) {
     const int short_ttl = 2;
@@ -576,14 +573,14 @@ TEST_F(RedisHelperTest, ElectLeaderCancelledViaWatchLeader) {
 
     // Wait for second to enter WatchLeader
     std::this_thread::sleep_for(std::chrono::seconds(1));
-    second.CancelKeepAlive();
-
-    // Cancel first so key expires, allowing second to win
-    first.CancelKeepAlive();
-    first_keep.join();
+    second.CancelElection();
     elect_thread.join();
 
-    ASSERT_GT(second_version, first_version);
+    // Clean up the first leader.
+    first.CancelKeepAlive();
+    first_keep.join();
+
+    ASSERT_EQ(0, second_version);
 }
 
 // === Test 20: Subscribe loop processes message ===
@@ -741,7 +738,7 @@ TEST_F(RedisElectionTest, ElectLeaderWaitsForKeyExpiry) {
     // short_ttl=1, key should expire in ~2s; allow 10s safety margin
     if (future.wait_for(std::chrono::seconds(10)) !=
         std::future_status::ready) {
-        second.CancelKeepAlive(second_lease);
+        second.CancelElection();
         elect_thread.join();
         FAIL() << "Timed out waiting for Redis master view election";
     }


### PR DESCRIPTION
## Description

  Integrate Redis as an alternative election backend for the Master HA framework, enabling P2P Store deployments to use Redis
  instead of etcd for leader election.

  Key changes:
  - Make `MasterViewHelper` methods virtual and add `RedisMasterViewHelper` subclass that implements leader election via
  `RedisHelper`
  - Add `CreateMasterViewHelper()` factory to select etcd or redis backend at runtime
  - Add `election_backend` config field (`"etcd"` default, `"redis"` for P2P HA) with Redis-specific flags (`redis_endpoint`,
  `redis_password`, `redis_db_index`, `redis_master_view_ttl_sec`, `redis_heartbeat_interval_sec`)
  - Wire Redis election config through `MasterConfig` → `MasterServiceSupervisorConfig` → gflags in `master.cpp`, with
  validation
  - Merge election test cases into `redis_helper_test`

  ## Module

  - [ ] Transfer Engine (`mooncake-transfer-engine`)
  - [ ] Mooncake Store (`mooncake-store`)
  - [ ] Mooncake EP (`mooncake-ep`)
  - [ ] Mooncake PG (`mooncake-pg`)
  - [ ] Integration (`mooncake-integration`)
  - [x] P2P Store (`mooncake-p2p-store`)
  - [ ] Python Wheel (`mooncake-wheel`)
  - [ ] Common (`mooncake-common`)
  - [ ] Mooncake RL (`mooncake-rl`)
  - [ ] CI/CD
  - [ ] Docs
  - [ ] Other

  ## Type of Change

  - [ ] Bug fix
  - [x] New feature
  - [ ] Refactor
  - [ ] Breaking change
  - [ ] Documentation update
  - [ ] Performance improvement
  - [ ] Other

  ## How Has This Been Tested?

  **Test commands:**
  ```bash
  # Build with Redis support
  docker exec mooncake-dev bash -c "cd /workspace && rm -rf build && mkdir build && cd build && cmake ..
  -DCMAKE_BUILD_TYPE=Debug && make -j\$(nproc)"

  # Run Redis helper tests (includes election tests)
  docker exec mooncake-dev bash -c "cd /workspace/build && ctest -R redis_helper_test -V"
```

  Test results:
  - [ ] Unit tests pass
  - [ ] Integration tests pass (if applicable)
  - [ ] Manual testing done (describe below)

  Checklist

  - [x] I have performed a self-review of my own code
  - [x] I have formatted my code using ./scripts/code_format.sh
  - [ ] I have run pre-commit run --all-files and all hooks pass
  - [ ] I have updated the documentation (if applicable)
  - [x] I have added tests to prove my changes are effective
  - [ ] For changes >500 LOC: I have filed an RFC issue

  AI Assistance Disclosure

  - [ ] No AI tools were used
  - [x] AI tools were used (specify below)

  Claude Code was used for code formatting and PR description drafting. Human author is responsible for all design decisions
  and code changes.