### PR TITLE
fix(store): chunk oversized io_uring vector I/O

### DIFF
--- a/mooncake-store/src/uring_file.cpp
+++ b/mooncake-store/src/uring_file.cpp
@@ -244,10 +244,13 @@ class SharedUringRing {
     }
 
     static size_t max_rw_count() {
-        long page_size = sysconf(_SC_PAGESIZE);
-        if (page_size <= 0) page_size = 4096;
-        return static_cast<size_t>(INT_MAX) &
-               ~(static_cast<size_t>(page_size) - 1);
+        static const size_t value = [] {
+            long page_size = sysconf(_SC_PAGESIZE);
+            if (page_size <= 0) page_size = 4096;
+            return static_cast<size_t>(INT_MAX) &
+                   ~(static_cast<size_t>(page_size) - 1);
+        }();
+        return value;
     }
 
     // Drain exactly @expected CQEs and accumulate bytes.

--- a/mooncake-store/src/uring_file.cpp
+++ b/mooncake-store/src/uring_file.cpp
@@ -4,6 +4,7 @@
 #include <atomic>
 #include <cerrno>
 #include <chrono>
+#include <climits>
 #include <cstring>
 #include <string>
 #include <sys/mman.h>
@@ -242,6 +243,13 @@ class SharedUringRing {
         return std::max(s, MIN_CHUNK);
     }
 
+    static size_t max_rw_count() {
+        long page_size = sysconf(_SC_PAGESIZE);
+        if (page_size <= 0) page_size = 4096;
+        return static_cast<size_t>(INT_MAX) &
+               ~(static_cast<size_t>(page_size) - 1);
+    }
+
     // Drain exactly @expected CQEs and accumulate bytes.
     tl::expected<size_t, ErrorCode> collect(int expected) {
         int ret = io_uring_submit_and_wait(&ring_, expected);
@@ -288,7 +296,7 @@ class SharedUringRing {
                 static_cast<unsigned>((remaining + cs - 1) / cs), QUEUE_DEPTH);
 
             for (unsigned i = 0; i < n; ++i) {
-                size_t chunk = std::min(cs, remaining);
+                size_t chunk = std::min({cs, remaining, max_rw_count()});
 
                 struct io_uring_sqe* sqe = io_uring_get_sqe(&ring_);
                 if (!sqe) {
@@ -332,6 +340,7 @@ class SharedUringRing {
                                                   off_t off) {
         const ErrorCode err_code =
             is_write ? ErrorCode::FILE_WRITE_FAIL : ErrorCode::FILE_READ_FAIL;
+        const size_t max_io = max_rw_count();
 
         size_t total = 0;
         off_t cur = off;
@@ -339,7 +348,23 @@ class SharedUringRing {
         int idx = 0;
 
         while (remaining > 0) {
-            int batch = std::min(remaining, static_cast<int>(QUEUE_DEPTH));
+            if (iovs[idx].iov_len > max_io) {
+                auto res = submit_rw(is_write, fd, iovs[idx].iov_base,
+                                     iovs[idx].iov_len, cur,
+                                     /*use_fixed_buf=*/false);
+                if (!res) return res;
+                total += res.value();
+                cur += static_cast<off_t>(iovs[idx].iov_len);
+                ++idx;
+                --remaining;
+                continue;
+            }
+
+            int batch = 0;
+            while (batch < remaining && batch < static_cast<int>(QUEUE_DEPTH) &&
+                   iovs[idx + batch].iov_len <= max_io) {
+                ++batch;
+            }
 
             for (int i = 0; i < batch; ++i) {
                 struct io_uring_sqe* sqe = io_uring_get_sqe(&ring_);


### PR DESCRIPTION
## Description                                                                                                                                                                     
                                                                                                                                                                                     
  Fix io_uring vector I/O truncation for oversized Mooncake Store offload reads/writes.                                                                                              
                                                                                                                                                                                     
  When `UringFile::vector_read()` or `UringFile::vector_write()` submits an iovec larger than Linux's single-I/O limit (`MAX_RW_COUNT`), the kernel can complete the SQE with a short result instead of failing. This can cause large object I/O through `OffsetAllocatorStorageBackend` to return only the first ~2 GiB and then fail with a size mismatch.            

  In RL scenario, mooncake is used for store model weights, which may be much larger than 2GB, and this problem occurs.

  This patch keeps the normal batched vector I/O path unchanged for regular iovecs, and only redirects oversized iovec entries to the existing contiguous `submit_rw()` chunking logic.                                                                                                                                                                             
                                                                                                                                                                                     
  ## Analysis                                                                                                                                                                        
                                                                                                                                                                                     
  Linux caps a single read/write request to:                                                                                                                                         
                                                                                                                                                                                     
  ```cpp                                                                                                                                                                             
  INT_MAX & ~(page_size - 1)                                                                                                                                                         
  ```                                                                                                                                                                                  
  On the test host this is:                                                                                                                                                          
                                                                                                                                                                                     
  2147479552 = 0x7ffff000                                                                                                                                                            
                                                                                                                                                                                     
  Before this fix, SharedUringRing::submit_vector() submitted one SQE per iovec without checking iov_len. If a single iovec exceeded the kernel limit, io_uring returned a short completion:                                                                                                                                                                        
                                                                                                                                                                                     
  requested=2147483648                                                                                                                                                               
  single_sqe_read=2147479552                                                                                                                                                         
  single_sqe_write=2147479552                                                                                                                                                        
                                                                                                                                                                                     
  The existing submit_rw() path already chunks contiguous I/O safely. The fix reuses that path for only the oversized vector entries:                                                
                                                                                                                                                                                     
  - normal iovecs: keep existing batched vector SQE behavior                                                                                                                         
  - oversized iovecs: call submit_rw(is_write, ...) to chunk below the kernel limit                                                                                                  
                                                                                                                                                                                     
  This avoids duplicating chunking logic and covers both read and write paths.                                                                                                                                 
                                                                                                                                                                                     
  ## Module                                                                                                                                                                             
                                                                                                                                                                                     
  [ ] Transfer Engine (mooncake-transfer-engine)                                                                                                                                       
  [x] Mooncake Store (mooncake-store)                                                                                                                                                  
  [ ] Mooncake EP (mooncake-ep)                                                                                                                                                        
  [ ] Mooncake PG (mooncake-pg)                                                                                                                                                        
  [ ] Integration (mooncake-integration)                                                                                                                                               
  [ ] P2P Store (mooncake-p2p-store)                                                                                                                                                   
  [ ] Python Wheel (mooncake-wheel)                                                                                                                                                    
  [ ] Common (mooncake-common)                                                                                                                                                         
  [ ] Mooncake RL (mooncake-rl)                                                                                                                                                        
  [ ] CI/CD                                                                                                                                                                            
  [ ] Docs                                                                                                                                                                             
  [ ] Other                                                                                                                                                                            
                                                                                                                                                                                     
  ## Type of Change                                                                                                                                                                     
                                                                                                                                                                                     
  [x] Bug fix                                                                                                                                                                          
  [ ] New feature                                                                                                                                                                      
  [ ] Refactor                                                                                                                                                                         
  [ ] Breaking change                                                                                                                                                                  
  [ ] Documentation update                                                                                                                                                             
  [ ] Performance improvement                                                                                                                                                          
  [ ] Other                                                                                                                                                                            
                                                                                                                                                                                     
  ## How Has This Been Tested?                                                                                                                                                          
                                                                                                                                                                                     
  Test commands:                                                                                                                                                                     
  Write and read a tensor with size 2147483648, which is larger than 2147479552.                                                                                                                                                                                                                                                          
                                                                                                                                                                                     
  Test results:                                                                                                                                                                      
                                                                                                                                                                                     
  Repro script:                                                                                                                                                                      
                                                                                                                                                                                     
  max_rw_count=2147479552                                                                                                                                                            
  requested=2147483648                                                                                                                                                               
  single_sqe_read=2147479552                                                                                                                                                         
  chunked_read=2147483648                                                                                                                                                            
  single_sqe_write=2147479552                                                                                                                                                        
  chunked_write=2147483648                                                                                                                                                           
  PASS: single SQE truncates, chunked I/O completes same request                                                                                                                     
                                                                                                                                                                                     
  Build:                                                                                                                                                                             
                                                                                                                                                                                     
  [100%] Built target mooncake_store                                                                                                                                                 
                                                                                                                                                                                     
  Offset allocator tests:                                                                                                                                                            
                                                                                                                                                                                     
  [==========] 18 tests from 1 test suite ran.                                                                                                                                       
  [  PASSED  ] 18 tests.                                                                                                                                                             
                                                                                                                                                                                     
  [x] Unit tests pass                                                                                                                                                                  
  [x] Integration tests pass (if applicable)                                                                                                                                           
  [x] Manual testing done (standalone io_uring repro validates read/write truncation and chunked completion)                                                                           
                                                                                                                                                                                     
  Checklist                                                                                                                                                                          
                                                                                                                                                                                     
  [x] I have performed a self-review of my own code                                                                                                                                    
  [x] I have formatted my code using clang-format-20                                                                                                                                   
  [x] I have run pre-commit run --all-files and all hooks pass                                                                                                                         
  [x] I have updated the documentation (if applicable)                                                                                                                                 
  [x] I have added tests to prove my changes are effective                                                                                                                             
  - For changes >500 LOC: not applicable                                                                                                                                             
                                                                                                                                                                                     
  AI Assistance Disclosure                                                                                                                                                           
                                                                                                                                                                                     
  - No AI tools were used                                                                                                                                                            
  [x] AI tools were used (Claude Code helped investigate, implement, and validate the fix)