### PR TITLE
[CI/Build] Add dedicated tent-ci job with CUDA/CPU matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -729,26 +729,6 @@ jobs:
         sudo cmake --install .
       shell: bash
 
-    - name: Configure project with TENT
-      run: |
-        mkdir build-tent
-        cd build-tent
-        cmake -G Ninja .. -DUSE_TENT=ON -DUSE_HTTP=ON -DENABLE_SCCACHE=ON -DBUILD_UNIT_TESTS=ON -DBUILD_EXAMPLES=ON -DENABLE_DEBUG_SYMBOLS=OFF
-      shell: bash
-
-    - name: Build project with TENT
-      run: |
-        cd build-tent
-        cmake --build .
-        sudo cmake --install .
-      shell: bash
-
-    - name: Test (TENT)
-      run: |
-        cd build-tent
-        ctest --test-dir mooncake-transfer-engine/tent/tests -j --output-on-failure
-      shell: bash
-
     - name: Build nvlink_allocator.so
       run: |
         mkdir -p build/mooncake-transfer-engine/nvlink-allocator
@@ -925,12 +905,15 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       should-run-downstream: ${{ steps.dispatch-override.outputs.src || steps.filter.outputs.src }}
+      should-run-tent: ${{ steps.dispatch-override.outputs.tent || steps.filter.outputs.tent }}
     steps:
       # workflow_dispatch has no PR/push diff context — skip paths-filter and default to true
       - name: Default to true for workflow_dispatch
         id: dispatch-override
         if: github.event_name == 'workflow_dispatch'
-        run: echo "src=true" >> $GITHUB_OUTPUT
+        run: |
+          echo "src=true" >> $GITHUB_OUTPUT
+          echo "tent=true" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v4
         if: github.event_name != 'workflow_dispatch'
         with:
@@ -948,6 +931,12 @@ jobs:
               - 'dependencies.sh'
               - 'scripts/**'
               - '.github/workflows/**'
+            tent:
+              - 'mooncake-transfer-engine/**'
+              - 'mooncake-common/**'
+              - 'CMakeLists.txt'
+              - 'dependencies.sh'
+              - '.github/workflows/ci.yml'
 
   build-wheel-cu13:
     needs: [spell-check, clang-format, check-paths]
@@ -985,6 +974,109 @@ jobs:
     uses: ./.github/workflows/integration-test.yml
     secrets: inherit
 
+  tent-ci:
+    needs: [spell-check, clang-format, check-paths]
+    if: >-
+      (needs.check-paths.outputs.should-run-tent == 'true' ||
+       github.event_name == 'workflow_dispatch') &&
+      (github.event_name == 'push' ||
+       github.event_name == 'workflow_dispatch' ||
+       github.event.action == 'opened' ||
+       contains(github.event.pull_request.labels.*.name, 'run-ci'))
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: cuda-on
+            cmake_flags: '-DUSE_CUDA=ON -DCMAKE_EXE_LINKER_FLAGS=-L/usr/local/cuda/lib64/stubs'
+            need_cuda: true
+          - name: cuda-off
+            cmake_flags: '-DUSE_CUDA=OFF'
+            need_cuda: false
+    name: tent-ci (${{ matrix.name }})
+    env:
+      CI: "true"
+      SCCACHE_GHA_ENABLED: "true"
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+
+    - name: Free up disk space
+      if: matrix.need_cuda
+      run: |
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /opt/ghc
+        sudo rm -rf /opt/hostedtoolcache/CodeQL
+        sudo rm -rf /usr/local/lib/android
+        df -h
+
+    - name: Install CUDA Toolkit
+      if: matrix.need_cuda
+      uses: Jimver/cuda-toolkit@v0.2.24
+      with:
+        cuda: '12.8.1'
+        linux-local-args: '["--toolkit"]'
+        method: 'network'
+        sub-packages: '["nvcc", "nvrtc-dev"]'
+
+    - name: Run sccache-cache
+      uses: mozilla-actions/sccache-action@v0.0.9
+
+    - name: Configure sccache
+      uses: actions/github-script@v7
+      with:
+        script: |
+          core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
+          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+
+    - name: Install dependencies
+      run: |
+        sudo apt update -y
+        sudo apt install -y ninja-build
+        sudo bash -x dependencies.sh -y
+        df -h
+      shell: bash
+
+    - name: Configure project with TENT
+      run: |
+        mkdir build-tent
+        cd build-tent
+        cmake -G Ninja .. -DUSE_TENT=ON -DUSE_HTTP=ON -DENABLE_SCCACHE=ON -DBUILD_UNIT_TESTS=ON -DBUILD_EXAMPLES=ON -DENABLE_DEBUG_SYMBOLS=OFF ${{ matrix.cmake_flags }}
+      shell: bash
+
+    - name: Build project with TENT
+      run: |
+        if [ "${{ matrix.need_cuda }}" = "true" ]; then
+          export LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH
+          export LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LIBRARY_PATH
+        fi
+        cd build-tent
+        cmake --build .
+        sudo cmake --install .
+      shell: bash
+
+    - name: Test (TENT)
+      run: |
+        if [ "${{ matrix.need_cuda }}" = "true" ]; then
+          # libcuda.so.1 (SONAME of the CUDA stub) must be findable at runtime.
+          if [ -f /usr/local/cuda/lib64/stubs/libcuda.so ] && \
+             [ ! -e /usr/local/cuda/lib64/stubs/libcuda.so.1 ]; then
+            sudo ln -s libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1
+          fi
+          export LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH
+        fi
+        cd build-tent
+        ctest --test-dir mooncake-transfer-engine/tent/tests -j --output-on-failure
+      shell: bash
+
+    - name: Run sccache stat for check
+      if: ${{ env.SCCACHE_PATH != '' }}
+      shell: bash
+      run: ${SCCACHE_PATH} --show-stats
+
   ci-gate:
     name: CI Gate
     if: always()
@@ -1000,6 +1092,7 @@ jobs:
       - test-wheel-ubuntu
       - build-wheel-cu13
       - build-wheel-efa
+      - tent-ci
       - ascend-test
       - integration-test
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1058,16 +1058,14 @@ jobs:
         sudo cmake --install .
       shell: bash
 
+    # Only run tests on the cuda-off leg. GitHub runners have no real GPU;
+    # with USE_CUDA=ON tent's cuda_probe hits the CUDA stub library at
+    # runtime and drives some dispatch paths past the fake objects the
+    # unit tests rely on, causing false failures. cuda-on still validates
+    # that every #ifdef USE_CUDA branch compiles.
     - name: Test (TENT)
+      if: '!matrix.need_cuda'
       run: |
-        if [ "${{ matrix.need_cuda }}" = "true" ]; then
-          # libcuda.so.1 (SONAME of the CUDA stub) must be findable at runtime.
-          if [ -f /usr/local/cuda/lib64/stubs/libcuda.so ] && \
-             [ ! -e /usr/local/cuda/lib64/stubs/libcuda.so.1 ]; then
-            sudo ln -s libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1
-          fi
-          export LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH
-        fi
         cd build-tent
         ctest --test-dir mooncake-transfer-engine/tent/tests -j --output-on-failure
       shell: bash


### PR DESCRIPTION
## Description

Extract TENT build/test out of the `build-flags` job into a dedicated
`tent-ci` job, cover both `USE_CUDA=ON` and `USE_CUDA=OFF` via a matrix,
and gate it on TENT-relevant path changes so unrelated PRs don't pay
the cost.

Motivation: while reviewing #2691 we found the `build-flags` "TENT"
step never enabled `USE_CUDA`, so every `#ifdef USE_CUDA` branch inside
TENT (`context.cpp`, `platform.cpp`, `transport_loader.cpp`,
`plugins/CMakeLists.txt`) was silently missing from CI compile
coverage. A dedicated job also gives TENT a first-class CI slot
instead of hiding as steps under an unrelated job.

Notes:
- The `cuda-on` leg is build-only. GitHub runners have no real GPU, and
  tent's `cuda_probe` cannot run correctly against the CUDA stub library
  at test time. `cuda-off` continues to run `ctest`, so tests are still
  covered — the matrix specifically closes the compile-coverage gap.
- `check-paths` gains a `tent`-scoped filter so TENT CI is skipped when
  a PR does not touch `mooncake-transfer-engine/**`, `mooncake-common/**`,
  top-level `CMakeLists.txt`, `dependencies.sh`, or `ci.yml` itself.
- `tent-ci` is wired into `ci-gate` as a required check.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Validated on the fork PR staryxchen/Mooncake#5.

**Test commands:**
```bash
# CI run: https://github.com/staryxchen/Mooncake/actions/runs/28585448879
gh pr checks 5 --repo staryxchen/Mooncake
```

**Test results:**
- [x] Unit tests pass — `tent-ci (cuda-off)`: build + `ctest` ✅ (7m19s)
- [x] Integration tests pass (if applicable) — `tent-ci (cuda-on)`: build ✅, test skipped as designed (8m16s)
- [x] Manual testing done (describe below) — verified `build-flags (3.12)` still passes after removing the TENT steps (21m45s). The unrelated `build-musa` failure on the fork is pre-existing and out of scope.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Claude Code Internal (Opus 4.7) helped scope the CI gap, draft the
`tent-ci` job structure and path filter, and iterate on the
`cuda-on` test-skip after fork validation surfaced a `cuda_probe`
runtime issue against the CUDA stub library. All final changes were
reviewed by me before submission.