### PR TITLE
[Bugfix] Report SSD capacity to Master after local disk segment remount

### DIFF
--- a/mooncake-store/src/file_storage.cpp
+++ b/mooncake-store/src/file_storage.cpp
@@ -664,6 +664,14 @@ tl::expected<void, ErrorCode> FileStorage::Heartbeat() {
                 auto remount_result =
                     client_->MountLocalDiskSegment(enable_offloading_);
                 if (remount_result) {
+                    if (config_.total_size_limit > 0) {
+                        auto cap_result = client_->ReportSsdCapacity(
+                            config_.total_size_limit);
+                        if (!cap_result) {
+                            LOG(WARNING) << "ReportSsdCapacity failed: "
+                                         << cap_result.error();
+                        }
+                    }
                     heartbeat_result = client_->OffloadObjectHeartbeat(
                         enable_offloading_, offloading_objects);
                     if (!heartbeat_result) {


### PR DESCRIPTION
## Description

When the Mooncake Master restarts, its in-memory states are lost. The client's periodic `Heartbeat()` will detect the `SEGMENT_NOT_FOUND` error and attempt to re-register the local disk segment by calling `MountLocalDiskSegment`.

Prior to this change, the client did not re-report the SSD capacity to the Master after a successful remount (as `ReportSsdCapacity` was only called once during `FileStorage::Init`). As a result, the Master lost the client's configured SSD capacity (e.g., `file_total_capacity_`), causing incorrect capacity statistics and affecting the scheduling policies.

**Changes:**
- In `FileStorage::Heartbeat()`, when handling `SEGMENT_NOT_FOUND` and after `MountLocalDiskSegment` successfully completes, check if `config_.total_size_limit > 0` is set.
- If so, call `client_->ReportSsdCapacity(config_.total_size_limit)` to ensure that the SSD capacity configuration is synchronized back to the Master.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

**Manual testing description:**
Manually verified that the SSD capacity is successfully reported and updated on the Master side after the local disk segment is remounted.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [x] No AI tools were used
- [ ] AI tools were used