### PR TITLE
[CI] Extract reusable wheel build/publish workflows

### DIFF
--- a/.github/workflows/_build-wheel.yaml
+++ b/.github/workflows/_build-wheel.yaml
@@ -1,0 +1,184 @@
+name: _build-wheel
+
+# Shared build for one wheel variant (matrixed over Python version), used by the
+# Release and Pre-Release workflows so both build identically.
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        type: string
+        required: true
+      container:
+        # x86 builds run in manylinux2_28 so the wheel's libstdc++/glibc floor
+        # stays low enough to import on RHEL/Rocky/Alma 8+. '' = bare runner.
+        type: string
+        default: ''
+      python-versions:
+        type: string
+        default: '["3.10", "3.11", "3.12", "3.13"]'
+      cuda:
+        # none | container | sbsa-12.8 | sbsa-13.0
+        type: string
+        default: none
+      cmake-args:
+        # Space-separated -D flags. No semicolons; use ep-torch-versions for those.
+        type: string
+        required: true
+      cmake-generator:
+        type: string
+        default: ''
+      ep-torch-versions:
+        type: string
+        default: ''
+      build-with-ep:
+        type: string
+        default: '0'
+      variant-flag:
+        # build_wheel.sh variant set to 1, e.g. CU13_BUILD, NON_CUDA_BUILD
+        type: string
+        default: ''
+      torch-cuda-arch-list:
+        type: string
+        default: ''
+      build-nvlink-allocator:
+        type: boolean
+        default: false
+      artifact-prefix:
+        type: string
+        required: true
+
+env:
+  SCCACHE_GHA_ENABLED: "true"
+
+jobs:
+  build:
+    runs-on: ${{ inputs.runner }}
+    container: ${{ inputs.container }}
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        python-version: ${{ fromJSON(inputs.python-versions) }}
+    env:
+      BUILD_WITH_EP: ${{ inputs.build-with-ep }}
+      TORCH_CUDA_ARCH_LIST: ${{ inputs.torch-cuda-arch-list }}
+      CMAKE_ARGS: ${{ inputs.cmake-args }}
+      CMAKE_GEN: ${{ inputs.cmake-generator }}
+      EP_TORCH_VERSIONS_INPUT: ${{ inputs.ep-torch-versions }}
+      VARIANT_FLAG: ${{ inputs.variant-flag }}
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Mark workspace safe for git (container runs as root)
+        if: ${{ inputs.container != '' }}
+        run: git config --global --add safe.directory '*'
+
+      - name: Set version from tag
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+
+      - name: Select Python ${{ matrix.python-version }} from manylinux image
+        if: ${{ inputs.container != '' }}
+        run: |
+          PYV_NODOT=$(echo "${{ matrix.python-version }}" | tr -d '.')
+          PYBIN="/opt/python/cp${PYV_NODOT}-cp${PYV_NODOT}/bin"
+          echo "$PYBIN" >> "$GITHUB_PATH"
+          "$PYBIN/pip" install --quiet "cmake<4" setuptools wheel
+
+      - name: Set up Python ${{ matrix.python-version }}
+        if: ${{ inputs.container == '' }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Free up disk space
+        if: ${{ inputs.container == '' }}
+        run: |
+          sudo rm -rf /usr/share/dotnet /opt/ghc /opt/hostedtoolcache/CodeQL /usr/local/lib/android
+          df -h
+
+      - name: Install CUDA Toolkit (arm64 SBSA)
+        if: ${{ startsWith(inputs.cuda, 'sbsa-') }}
+        run: |
+          ver="${{ inputs.cuda }}"; ver="${ver#sbsa-}"
+          wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/sbsa/cuda-keyring_1.1-1_all.deb
+          sudo dpkg -i cuda-keyring_1.1-1_all.deb
+          sudo apt-get update
+          sudo apt-get install -y "cuda-toolkit-${ver/./-}"
+          echo "/usr/local/cuda/bin" >> "$GITHUB_PATH"
+          /usr/local/cuda/bin/nvcc --version
+
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Configure sccache
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+
+      - name: Configure project
+        run: |
+          SUDO=""; [ "$(id -u)" -ne 0 ] && SUDO="sudo"
+          if [ -n "$SUDO" ] && command -v apt-get >/dev/null 2>&1; then
+            $SUDO apt-get update -y || true
+          fi
+          $SUDO bash -x dependencies.sh -y
+          echo "/usr/local/go/bin" >> "$GITHUB_PATH"
+          gen=(); [ -n "$CMAKE_GEN" ] && gen=(-G "$CMAKE_GEN")
+          ep=(); [ -n "$EP_TORCH_VERSIONS_INPUT" ] && ep=(-DEP_TORCH_VERSIONS="$EP_TORCH_VERSIONS_INPUT")
+          mkdir -p build && cd build
+          # shellcheck disable=SC2086
+          cmake "${gen[@]}" .. $CMAKE_ARGS "${ep[@]}" -DPython3_EXECUTABLE="$(which python3)"
+
+      - name: Build project
+        run: |
+          for dir in /usr/local/cuda/lib64/stubs /usr/local/cuda/targets/*/lib/stubs; do
+            [ -d "$dir" ] && export LIBRARY_PATH="$dir:${LIBRARY_PATH:-}"
+          done
+          [ -d /usr/local/cuda ] && export CUDA_HOME=/usr/local/cuda
+          SUDO=""; [ "$(id -u)" -ne 0 ] && SUDO="sudo -E"
+          cd build
+          cmake --build . -j"$(nproc)"
+          $SUDO cmake --install .
+
+      - name: Build nvlink_allocator.so
+        if: ${{ inputs.build-nvlink-allocator }}
+        run: |
+          export PATH=/usr/local/nvidia/bin:/usr/local/nvidia/lib64:$PATH
+          if [ -d /usr/local/cuda/lib64/stubs ]; then
+            export LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:${LD_LIBRARY_PATH:-}
+            export LIBRARY_PATH=/usr/local/cuda/lib64/stubs:${LIBRARY_PATH:-}
+          fi
+          mkdir -p build/mooncake-transfer-engine/nvlink-allocator
+          cd mooncake-transfer-engine/nvlink-allocator
+          bash build.sh ../../build/mooncake-transfer-engine/nvlink-allocator/
+
+      - name: Run sccache stat for check
+        if: ${{ env.SCCACHE_PATH != '' }}
+        run: ${SCCACHE_PATH} --show-stats
+
+      - name: Generate Python version tag
+        id: pytag
+        run: echo "tag=$(echo ${{ matrix.python-version }} | tr -d '.')" >> "$GITHUB_OUTPUT"
+
+      - name: Build Python wheel
+        run: |
+          [ -d /usr/local/cuda ] && export CUDA_HOME=/usr/local/cuda
+          export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}:/usr/local/lib"
+          variant=()
+          [ -n "$VARIANT_FLAG" ] && variant=("$VARIANT_FLAG=1")
+          env "${variant[@]}" \
+            PYTHON_VERSION="${{ matrix.python-version }}" \
+            OUTPUT_DIR="dist-py${{ steps.pytag.outputs.tag }}" \
+            ./scripts/build_wheel.sh
+        env:
+          VERSION: ${{ env.VERSION }}
+
+      - name: Upload Python wheel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact-prefix }}-py${{ steps.pytag.outputs.tag }}
+          path: mooncake-wheel/dist-py${{ steps.pytag.outputs.tag }}/*.whl

--- a/.github/workflows/_publish-wheel.yaml
+++ b/.github/workflows/_publish-wheel.yaml
@@ -1,0 +1,49 @@
+name: _publish-wheel
+
+# Shared publish tail: collect this run's wheels, attach to the GitHub Release,
+# and upload to PyPI. Used by the Release workflows.
+
+on:
+  workflow_call:
+    inputs:
+      artifact-pattern:
+        type: string
+        required: true
+    secrets:
+      pypi-token:
+        required: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Download all wheel artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: mooncake-wheel/dist-all
+          pattern: ${{ inputs.artifact-pattern }}
+
+      - name: Prepare wheels for release
+        run: |
+          mkdir -p mooncake-wheel/dist-release
+          find mooncake-wheel/dist-all -name "*.whl" -exec cp {} mooncake-wheel/dist-release/ \;
+          echo "Collected wheels for release:"
+          ls -la mooncake-wheel/dist-release/
+
+      - name: Upload wheels to GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: mooncake-wheel/dist-release/*.whl
+
+      - name: Publish package to PyPI
+        if: ${{ github.repository == 'kvcache-ai/Mooncake' }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: mooncake-wheel/dist-release/
+          password: ${{ secrets.pypi-token }}

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -1,7 +1,8 @@
 name: Pre-Release
 
-# Dry-run of the release pipelines: build wheels like Release / Release Non-CUDA /
-# Release CUDA 13, validate artifacts, but do not create a GitHub Release or publish to PyPI.
+# Dry run of the release pipelines: build wheels through the same _build-wheel.yaml
+# the Release / Release Non-CUDA / Release CUDA 13 workflows use, validate the
+# artifacts, but do not create a GitHub Release or publish to PyPI.
 #
 # Trigger by pushing a pre-release tag, for example:
 #   git tag v1.0.0-rc1 && git push origin v1.0.0-rc1
@@ -13,484 +14,75 @@ on:
       - 'v*-beta*'
       - 'v*-pre*'
 
-env:
-  SCCACHE_GHA_ENABLED: "true"
-
 jobs:
   build-cuda:
-    name: Build (CUDA 12)
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: read
-    strategy:
-      matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
-    env:
-      BUILD_WITH_EP: "1"
-      TORCH_CUDA_ARCH_LIST: "8.0;9.0"
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
-
-      - name: Set version from tag
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Free up disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo rm -rf /usr/local/lib/android
-          df -h
-
-      - name: Install CUDA Toolkit
-        uses: Jimver/cuda-toolkit@v0.2.24
-        with:
-          cuda: '12.8.1'
-          linux-local-args: '["--toolkit"]'
-          method: 'network'
-          sub-packages: '["nvcc", "nvrtc-dev"]'
-          non-cuda-sub-packages: '["libcusparse-dev", "libcublas-dev", "libcusolver-dev"]'
-
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
-
-      - name: Configure sccache
-        uses: actions/github-script@v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-
-      - name: Configure project
-        run: |
-          sudo apt update -y
-          sudo bash -x dependencies.sh -y
-          mkdir build
-          cd build
-          cmake .. -DBUILD_UNIT_TESTS=OFF -DUSE_HTTP=ON -DUSE_ETCD=ON -DUSE_CUDA=ON -DWITH_EP=ON -DEP_TORCH_VERSIONS="2.11.0;2.12.0;2.12.1" -DSTORE_USE_ETCD=ON -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Release
-        shell: bash
-
-      - name: Build project
-        run: |
-          export LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LIBRARY_PATH
-          cd build
-          make -j
-          sudo -E make install
-        shell: bash
-
-      - name: Build nvlink_allocator.so
-        run: |
-          export PATH=/usr/local/nvidia/bin:/usr/local/nvidia/lib64:$PATH
-          export LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH
-          export LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LIBRARY_PATH
-          mkdir -p build/mooncake-transfer-engine/nvlink-allocator
-          cd mooncake-transfer-engine/nvlink-allocator
-          bash build.sh ../../build/mooncake-transfer-engine/nvlink-allocator/
-        shell: bash
-
-      - name: Run sccache stat for check
-        if: ${{ env.SCCACHE_PATH != '' }}
-        shell: bash
-        run: ${SCCACHE_PATH} --show-stats
-
-      - name: Generate Python version tag
-        id: generate_tag_release
-        run: |
-          echo "python_version_tag=$(echo ${{ matrix.python-version }} | tr -d '.')" >> $GITHUB_OUTPUT
-        shell: bash
-
-      - name: Build Python wheel
-        run: |
-          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
-          PYTHON_VERSION=${{ matrix.python-version }} OUTPUT_DIR=dist-py${{ steps.generate_tag_release.outputs.python_version_tag }} ./scripts/build_wheel.sh
-        env:
-          VERSION: ${{ env.VERSION }}
-
-      - name: Upload Python wheel artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: pre-release-cuda-py${{ steps.generate_tag_release.outputs.python_version_tag }}
-          path: mooncake-wheel/dist-py${{ steps.generate_tag_release.outputs.python_version_tag }}/*.whl
+    uses: ./.github/workflows/_build-wheel.yaml
+    with:
+      runner: ubuntu-22.04
+      container: pytorch/manylinux2_28-builder:cuda12.8
+      cuda: container
+      build-with-ep: '1'
+      torch-cuda-arch-list: '8.0;9.0'
+      ep-torch-versions: '2.11.0;2.12.0;2.12.1'
+      build-nvlink-allocator: true
+      cmake-args: >-
+        -DBUILD_UNIT_TESTS=OFF -DUSE_HTTP=ON -DUSE_ETCD=ON -DUSE_CUDA=ON
+        -DWITH_EP=ON -DSTORE_USE_ETCD=ON -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Release
+      artifact-prefix: pre-release-cuda
 
   build-non-cuda:
-    name: Build (Non-CUDA)
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: read
-    strategy:
-      matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
-    env:
-      BUILD_WITH_EP: "0"
-      NON_CUDA_BUILD: "1"
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
-
-      - name: Set version from tag
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Free up disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
-
-      - name: Configure sccache
-        uses: actions/github-script@v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-
-      - name: Configure project
-        run: |
-          sudo apt update -y
-          sudo bash -x dependencies.sh -y
-          mkdir build
-          cd build
-          cmake .. -DUSE_HTTP=ON -DUSE_ETCD=ON -DUSE_CUDA=OFF -DWITH_EP=OFF -DSTORE_USE_ETCD=ON -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Release
-        shell: bash
-
-      - name: Build project
-        run: |
-          cd build
-          make -j
-          sudo -E make install
-        shell: bash
-
-      - name: Run sccache stat for check
-        if: ${{ env.SCCACHE_PATH != '' }}
-        shell: bash
-        run: ${SCCACHE_PATH} --show-stats
-
-      - name: Generate Python version tag
-        id: generate_tag_release
-        run: |
-          echo "python_version_tag=$(echo ${{ matrix.python-version }} | tr -d '.')" >> $GITHUB_OUTPUT
-        shell: bash
-
-      - name: Build Python wheel
-        run: |
-          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
-          PYTHON_VERSION=${{ matrix.python-version }} OUTPUT_DIR=dist-py${{ steps.generate_tag_release.outputs.python_version_tag }} ./scripts/build_wheel.sh
-        env:
-          VERSION: ${{ env.VERSION }}
-
-      - name: Upload Python wheel artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: pre-release-non-cuda-py${{ steps.generate_tag_release.outputs.python_version_tag }}
-          path: mooncake-wheel/dist-py${{ steps.generate_tag_release.outputs.python_version_tag }}/*.whl
+    uses: ./.github/workflows/_build-wheel.yaml
+    with:
+      runner: ubuntu-22.04
+      container: pytorch/manylinux2_28-builder:cuda12.8
+      cuda: container
+      build-with-ep: '0'
+      variant-flag: NON_CUDA_BUILD
+      cmake-args: >-
+        -DUSE_HTTP=ON -DUSE_ETCD=ON -DUSE_CUDA=OFF -DWITH_EP=OFF
+        -DSTORE_USE_ETCD=ON -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Release
+      artifact-prefix: pre-release-non-cuda
 
   build-cuda13:
-    name: Build (CUDA 13)
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: read
-    strategy:
-      matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
-    env:
-      BUILD_WITH_EP: "1"
-      CU13_BUILD: "1"
-      TORCH_CUDA_ARCH_LIST: "8.0;9.0"
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
-
-      - name: Set version from tag
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Free up disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo rm -rf /usr/local/lib/android
-          df -h
-
-      - name: Install CUDA Toolkit 13
-        uses: Jimver/cuda-toolkit@v0.2.29
-        with:
-          cuda: '13.0.2'
-          linux-local-args: '["--toolkit"]'
-          method: 'network'
-          sub-packages: '["nvcc", "nvrtc-dev"]'
-          non-cuda-sub-packages: '["libcusparse-dev", "libcublas-dev", "libcusolver-dev"]'
-
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
-
-      - name: Configure sccache
-        uses: actions/github-script@v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-
-      - name: Configure project
-        run: |
-          sudo apt update -y
-          sudo bash -x dependencies.sh -y
-          mkdir build
-          cd build
-          cmake .. -DBUILD_UNIT_TESTS=OFF -DUSE_HTTP=ON -DUSE_ETCD=ON -DUSE_CUDA=ON -DWITH_EP=ON -DEP_TORCH_VERSIONS="2.11.0;2.12.0;2.12.1" -DSTORE_USE_ETCD=ON -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Release
-        shell: bash
-
-      - name: Build project
-        run: |
-          export LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LIBRARY_PATH
-          cd build
-          make -j
-          sudo make install
-        shell: bash
-
-      - name: Build nvlink_allocator.so
-        run: |
-          export PATH=/usr/local/nvidia/bin:/usr/local/nvidia/lib64:$PATH
-          export LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH
-          export LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LIBRARY_PATH
-          mkdir -p build/mooncake-transfer-engine/nvlink-allocator
-          cd mooncake-transfer-engine/nvlink-allocator
-          bash build.sh ../../build/mooncake-transfer-engine/nvlink-allocator/
-        shell: bash
-
-      - name: Run sccache stat for check
-        if: ${{ env.SCCACHE_PATH != '' }}
-        shell: bash
-        run: ${SCCACHE_PATH} --show-stats
-
-      - name: Generate Python version tag
-        id: generate_tag_release
-        run: |
-          echo "python_version_tag=$(echo ${{ matrix.python-version }} | tr -d '.')" >> $GITHUB_OUTPUT
-        shell: bash
-
-      - name: Build Python wheel
-        run: |
-          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
-          PYTHON_VERSION=${{ matrix.python-version }} OUTPUT_DIR=dist-py${{ steps.generate_tag_release.outputs.python_version_tag }} ./scripts/build_wheel.sh
-        env:
-          VERSION: ${{ env.VERSION }}
-
-      - name: Upload Python wheel artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: pre-release-cuda13-py${{ steps.generate_tag_release.outputs.python_version_tag }}
-          path: mooncake-wheel/dist-py${{ steps.generate_tag_release.outputs.python_version_tag }}/*.whl
+    uses: ./.github/workflows/_build-wheel.yaml
+    with:
+      runner: ubuntu-22.04
+      container: pytorch/manylinux2_28-builder:cuda13.0
+      cuda: container
+      build-with-ep: '1'
+      variant-flag: CU13_BUILD
+      torch-cuda-arch-list: '8.0;9.0'
+      ep-torch-versions: '2.11.0;2.12.0;2.12.1'
+      build-nvlink-allocator: true
+      cmake-args: >-
+        -DBUILD_UNIT_TESTS=OFF -DUSE_HTTP=ON -DUSE_ETCD=ON -DUSE_CUDA=ON
+        -DWITH_EP=ON -DSTORE_USE_ETCD=ON -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Release
+      artifact-prefix: pre-release-cuda13
 
   build-cuda-arm64:
-    name: Build (CUDA 12, arm64)
-    runs-on: ubuntu-22.04-arm
-    permissions:
-      contents: read
-    strategy:
-      matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
-    env:
-      TORCH_CUDA_ARCH_LIST: "9.0"
-      CUDA_HOME: "/usr/local/cuda"
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
-
-      - name: Set version from tag
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Free up disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-
-      - name: Install CUDA Toolkit 12.8 (arm64 SBSA)
-        run: |
-          wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/sbsa/cuda-keyring_1.1-1_all.deb
-          sudo dpkg -i cuda-keyring_1.1-1_all.deb
-          sudo apt-get update
-          sudo apt-get install -y cuda-toolkit-12-8
-          echo "/usr/local/cuda/bin" >> $GITHUB_PATH
-          /usr/local/cuda/bin/nvcc --version
-        shell: bash
-
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
-
-      - name: Configure sccache
-        uses: actions/github-script@v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-
-      - name: Configure project
-        run: |
-          sudo apt update -y
-          sudo bash -x dependencies.sh -y
-          mkdir build
-          cd build
-          cmake -G Ninja .. -DUSE_HTTP=ON -DUSE_CUDA=ON -DUSE_MNNVL=ON -DWITH_EP=OFF -DWITH_STORE_RUST=OFF -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Release
-        shell: bash
-
-      - name: Build project
-        run: |
-          export CUDA_HOME=/usr/local/cuda
-          for dir in /usr/local/cuda/lib64/stubs /usr/local/cuda/targets/*/lib/stubs; do
-            if [ -d "$dir" ]; then
-              export LIBRARY_PATH="$dir:${LIBRARY_PATH:-}"
-            fi
-          done
-          cd build
-          cmake --build .
-          sudo cmake --install .
-        shell: bash
-
-      - name: Run sccache stat for check
-        if: ${{ env.SCCACHE_PATH != '' }}
-        shell: bash
-        run: ${SCCACHE_PATH} --show-stats
-
-      - name: Generate Python version tag
-        id: generate_tag_arm64
-        run: |
-          echo "python_version_tag=$(echo ${{ matrix.python-version }} | tr -d '.')" >> $GITHUB_OUTPUT
-        shell: bash
-
-      - name: Build Python wheel
-        run: |
-          export CUDA_HOME=/usr/local/cuda
-          PYTHON_VERSION=${{ matrix.python-version }} OUTPUT_DIR=dist-py${{ steps.generate_tag_arm64.outputs.python_version_tag }} ./scripts/build_wheel.sh
-        env:
-          VERSION: ${{ env.VERSION }}
-        shell: bash
-
-      - name: Upload Python wheel artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: pre-release-cuda-arm64-py${{ steps.generate_tag_arm64.outputs.python_version_tag }}
-          path: mooncake-wheel/dist-py${{ steps.generate_tag_arm64.outputs.python_version_tag }}/*.whl
+    uses: ./.github/workflows/_build-wheel.yaml
+    with:
+      runner: ubuntu-22.04-arm
+      cuda: sbsa-12.8
+      cmake-generator: Ninja
+      torch-cuda-arch-list: '9.0'
+      cmake-args: >-
+        -DUSE_HTTP=ON -DUSE_CUDA=ON -DUSE_MNNVL=ON -DWITH_EP=OFF
+        -DWITH_STORE_RUST=OFF -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Release
+      artifact-prefix: pre-release-cuda-arm64
 
   build-cuda13-arm64:
-    name: Build (CUDA 13, arm64)
-    runs-on: ubuntu-22.04-arm
-    permissions:
-      contents: read
-    strategy:
-      matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
-    env:
-      CU13_BUILD: "1"
-      TORCH_CUDA_ARCH_LIST: "9.0"
-      CUDA_HOME: "/usr/local/cuda"
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
-
-      - name: Set version from tag
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Free up disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-
-      - name: Install CUDA Toolkit 13.0 (arm64 SBSA)
-        run: |
-          wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/sbsa/cuda-keyring_1.1-1_all.deb
-          sudo dpkg -i cuda-keyring_1.1-1_all.deb
-          sudo apt-get update
-          sudo apt-get install -y cuda-toolkit-13-0
-          echo "/usr/local/cuda/bin" >> $GITHUB_PATH
-          /usr/local/cuda/bin/nvcc --version
-        shell: bash
-
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
-
-      - name: Configure sccache
-        uses: actions/github-script@v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-
-      - name: Configure project
-        run: |
-          sudo apt update -y
-          sudo bash -x dependencies.sh -y
-          mkdir build
-          cd build
-          cmake -G Ninja .. -DUSE_HTTP=ON -DUSE_CUDA=ON -DUSE_MNNVL=ON -DWITH_EP=OFF -DWITH_STORE_RUST=OFF -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Release
-        shell: bash
-
-      - name: Build project
-        run: |
-          export CUDA_HOME=/usr/local/cuda
-          for dir in /usr/local/cuda/lib64/stubs /usr/local/cuda/targets/*/lib/stubs; do
-            if [ -d "$dir" ]; then
-              export LIBRARY_PATH="$dir:${LIBRARY_PATH:-}"
-            fi
-          done
-          cd build
-          cmake --build .
-          sudo cmake --install .
-        shell: bash
-
-      - name: Run sccache stat for check
-        if: ${{ env.SCCACHE_PATH != '' }}
-        shell: bash
-        run: ${SCCACHE_PATH} --show-stats
-
-      - name: Generate Python version tag
-        id: generate_tag_arm64
-        run: |
-          echo "python_version_tag=$(echo ${{ matrix.python-version }} | tr -d '.')" >> $GITHUB_OUTPUT
-        shell: bash
-
-      - name: Build Python wheel
-        run: |
-          export CUDA_HOME=/usr/local/cuda
-          PYTHON_VERSION=${{ matrix.python-version }} OUTPUT_DIR=dist-py${{ steps.generate_tag_arm64.outputs.python_version_tag }} ./scripts/build_wheel.sh
-        env:
-          VERSION: ${{ env.VERSION }}
-        shell: bash
-
-      - name: Upload Python wheel artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: pre-release-cuda13-arm64-py${{ steps.generate_tag_arm64.outputs.python_version_tag }}
-          path: mooncake-wheel/dist-py${{ steps.generate_tag_arm64.outputs.python_version_tag }}/*.whl
+    uses: ./.github/workflows/_build-wheel.yaml
+    with:
+      runner: ubuntu-22.04-arm
+      cuda: sbsa-13.0
+      cmake-generator: Ninja
+      variant-flag: CU13_BUILD
+      torch-cuda-arch-list: '9.0'
+      cmake-args: >-
+        -DUSE_HTTP=ON -DUSE_CUDA=ON -DUSE_MNNVL=ON -DWITH_EP=OFF
+        -DWITH_STORE_RUST=OFF -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Release
+      artifact-prefix: pre-release-cuda13-arm64
 
   validate-release:
     name: Validate release artifacts

--- a/.github/workflows/release-cuda13.yaml
+++ b/.github/workflows/release-cuda13.yaml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   build:
-    if: ${{ !contains(github.ref_name, '-') }}
     uses: ./.github/workflows/_build-wheel.yaml
     with:
       runner: ubuntu-22.04
@@ -40,6 +39,9 @@ jobs:
   publish-release:
     if: ${{ !contains(github.ref_name, '-') }}
     needs: [build, build-arm64]
+    permissions:
+      contents: write
+      id-token: write
     uses: ./.github/workflows/_publish-wheel.yaml
     with:
       artifact-pattern: 'mooncake-wheel-cuda13*'

--- a/.github/workflows/release-cuda13.yaml
+++ b/.github/workflows/release-cuda13.yaml
@@ -5,225 +5,43 @@ on:
     tags:
       - 'v*'
 
-env:
-  SCCACHE_GHA_ENABLED: "true"
 jobs:
   build:
-    runs-on: ubuntu-22.04
-    container: pytorch/manylinux2_28-builder:cuda13.0
-    permissions:
-      contents: write
-    strategy:
-      matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
-    env:
-      BUILD_WITH_EP: "1"
-      CU13_BUILD: "1"
-      TORCH_CUDA_ARCH_LIST: "8.0;9.0"
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
-
-      - name: Mark workspace safe for git (container runs as root)
-        run: git config --global --add safe.directory '*'
-
-      - name: Select Python ${{ matrix.python-version }} from manylinux image
-        run: |
-          PYV_NODOT=$(echo "${{ matrix.python-version }}" | tr -d '.')
-          PYBIN="/opt/python/cp${PYV_NODOT}-cp${PYV_NODOT}/bin"
-          echo "$PYBIN" >> "$GITHUB_PATH"
-          "$PYBIN/pip" install --quiet "cmake<4" setuptools wheel
-
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
-
-      - name: Configure sccache
-        uses: actions/github-script@v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-
-      - name: Configure project
-        run: |
-          bash -x dependencies.sh -y
-          echo "/usr/local/go/bin" >> "$GITHUB_PATH"
-          mkdir build
-          cd build
-          cmake .. -DBUILD_UNIT_TESTS=OFF -DUSE_HTTP=ON -DUSE_ETCD=ON -DUSE_CUDA=ON -DWITH_EP=ON -DEP_TORCH_VERSIONS="2.11.0;2.12.0;2.12.1" -DSTORE_USE_ETCD=ON -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Release -DPython3_EXECUTABLE="$(which python3)"
-        shell: bash
-
-      - name: Build project
-        run: |
-          export LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LIBRARY_PATH
-          cd build
-          make -j
-          make install
-        shell: bash
-
-      - name: Build nvlink_allocator.so
-        run: |
-          export PATH=/usr/local/nvidia/bin:/usr/local/nvidia/lib64:$PATH
-          export LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH
-          export LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LIBRARY_PATH
-          mkdir -p build/mooncake-transfer-engine/nvlink-allocator
-          cd mooncake-transfer-engine/nvlink-allocator
-          bash build.sh ../../build/mooncake-transfer-engine/nvlink-allocator/
-        shell: bash
-
-      - name: Run sccache stat for check
-        if: ${{ env.SCCACHE_PATH != '' }}
-        shell: bash
-        run: ${SCCACHE_PATH} --show-stats
-
-      - name: Generate Python version tag
-        id: generate_tag_release
-        run: |
-          echo "python_version_tag=$(echo ${{ matrix.python-version }} | tr -d '.')" >> $GITHUB_OUTPUT
-        shell: bash
-
-      - name: Build Python wheel
-        run: |
-          # Set LD_LIBRARY_PATH for wheel building
-          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
-          PYTHON_VERSION=${{ matrix.python-version }} OUTPUT_DIR=dist-py${{ steps.generate_tag_release.outputs.python_version_tag }} ./scripts/build_wheel.sh
-        env:
-          VERSION: ${{ env.VERSION }}
-
-      - name: Upload Python wheel artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: mooncake-wheel-cuda13-py${{ steps.generate_tag_release.outputs.python_version_tag }}
-          path: mooncake-wheel/dist-py${{ steps.generate_tag_release.outputs.python_version_tag }}/*.whl
+    if: ${{ !contains(github.ref_name, '-') }}
+    uses: ./.github/workflows/_build-wheel.yaml
+    with:
+      runner: ubuntu-22.04
+      container: pytorch/manylinux2_28-builder:cuda13.0
+      cuda: container
+      build-with-ep: '1'
+      variant-flag: CU13_BUILD
+      torch-cuda-arch-list: '8.0;9.0'
+      ep-torch-versions: '2.11.0;2.12.0;2.12.1'
+      build-nvlink-allocator: true
+      cmake-args: >-
+        -DBUILD_UNIT_TESTS=OFF -DUSE_HTTP=ON -DUSE_ETCD=ON -DUSE_CUDA=ON
+        -DWITH_EP=ON -DSTORE_USE_ETCD=ON -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Release
+      artifact-prefix: mooncake-wheel-cuda13
 
   build-arm64:
     if: ${{ !contains(github.ref_name, '-') }}
-    runs-on: ubuntu-22.04-arm
-    permissions:
-      contents: write
-    strategy:
-      matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
-    env:
-      CU13_BUILD: "1"
-      TORCH_CUDA_ARCH_LIST: "9.0"
-      CUDA_HOME: "/usr/local/cuda"
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Free up disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-
-      - name: Install CUDA Toolkit 13.0 (arm64 SBSA)
-        run: |
-          wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/sbsa/cuda-keyring_1.1-1_all.deb
-          sudo dpkg -i cuda-keyring_1.1-1_all.deb
-          sudo apt-get update
-          sudo apt-get install -y cuda-toolkit-13-0
-          echo "/usr/local/cuda/bin" >> $GITHUB_PATH
-          /usr/local/cuda/bin/nvcc --version
-        shell: bash
-
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
-
-      - name: Configure sccache
-        uses: actions/github-script@v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-
-      - name: Configure project
-        run: |
-          sudo apt update -y
-          sudo bash -x dependencies.sh -y
-          mkdir build
-          cd build
-          cmake -G Ninja .. -DUSE_HTTP=ON -DUSE_CUDA=ON -DUSE_MNNVL=ON -DWITH_EP=OFF -DWITH_STORE_RUST=OFF -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Release
-        shell: bash
-
-      - name: Build project
-        run: |
-          export CUDA_HOME=/usr/local/cuda
-          for dir in /usr/local/cuda/lib64/stubs /usr/local/cuda/targets/*/lib/stubs; do
-            if [ -d "$dir" ]; then
-              export LIBRARY_PATH="$dir:${LIBRARY_PATH:-}"
-            fi
-          done
-          cd build
-          cmake --build .
-          sudo cmake --install .
-        shell: bash
-
-      - name: Run sccache stat for check
-        if: ${{ env.SCCACHE_PATH != '' }}
-        shell: bash
-        run: ${SCCACHE_PATH} --show-stats
-
-      - name: Generate Python version tag
-        id: generate_tag_release
-        run: |
-          echo "python_version_tag=$(echo ${{ matrix.python-version }} | tr -d '.')" >> $GITHUB_OUTPUT
-        shell: bash
-
-      - name: Build Python wheel
-        run: |
-          export CUDA_HOME=/usr/local/cuda
-          export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}:/usr/local/lib"
-          PYTHON_VERSION=${{ matrix.python-version }} OUTPUT_DIR=dist-py${{ steps.generate_tag_release.outputs.python_version_tag }} ./scripts/build_wheel.sh
-        shell: bash
-
-      - name: Upload Python wheel artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: mooncake-wheel-cuda13-arm64-py${{ steps.generate_tag_release.outputs.python_version_tag }}
-          path: mooncake-wheel/dist-py${{ steps.generate_tag_release.outputs.python_version_tag }}/*.whl
+    uses: ./.github/workflows/_build-wheel.yaml
+    with:
+      runner: ubuntu-22.04-arm
+      cuda: sbsa-13.0
+      cmake-generator: Ninja
+      variant-flag: CU13_BUILD
+      torch-cuda-arch-list: '9.0'
+      cmake-args: >-
+        -DUSE_HTTP=ON -DUSE_CUDA=ON -DUSE_MNNVL=ON -DWITH_EP=OFF
+        -DWITH_STORE_RUST=OFF -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Release
+      artifact-prefix: mooncake-wheel-cuda13-arm64
 
   publish-release:
     if: ${{ !contains(github.ref_name, '-') }}
     needs: [build, build-arm64]
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: write
-      id-token: write
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
-
-      - name: Download all wheel artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: mooncake-wheel/dist-all
-          pattern: mooncake-wheel-cuda13*
-
-      - name: Prepare wheels for release
-        run: |
-          # Move all wheels to a single directory
-          mkdir -p mooncake-wheel/dist-release
-          find mooncake-wheel/dist-all -name "*.whl" -exec cp {} mooncake-wheel/dist-release/ \;
-          ls -la mooncake-wheel/dist-release/
-          # List all collected wheels
-          echo "Collected wheels for release:"
-          ls -la mooncake-wheel/dist-release/
-
-      - name: Upload wheels to GitHub Release
-        uses: softprops/action-gh-release@v1
-        with:
-          files: mooncake-wheel/dist-release/*.whl
-
-      - name: Publish package to PyPI
-        if: github.repository == 'kvcache-ai/Mooncake'
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: mooncake-wheel/dist-release/
-          password: ${{ secrets.PYPI_CU13_API_TOKEN }}
+    uses: ./.github/workflows/_publish-wheel.yaml
+    with:
+      artifact-pattern: 'mooncake-wheel-cuda13*'
+    secrets:
+      pypi-token: ${{ secrets.PYPI_CU13_API_TOKEN }}

--- a/.github/workflows/release-non-cuda.yaml
+++ b/.github/workflows/release-non-cuda.yaml
@@ -9,7 +9,6 @@ jobs:
   # manylinux2_28 for the toolchain only (USE_CUDA=OFF); keeps the glibc floor
   # aligned with the CUDA wheels.
   build:
-    if: ${{ !contains(github.ref_name, '-') }}
     uses: ./.github/workflows/_build-wheel.yaml
     with:
       runner: ubuntu-22.04
@@ -25,6 +24,9 @@ jobs:
   publish-release:
     if: ${{ !contains(github.ref_name, '-') }}
     needs: build
+    permissions:
+      contents: write
+      id-token: write
     uses: ./.github/workflows/_publish-wheel.yaml
     with:
       artifact-pattern: 'mooncake-wheel-non-cuda*'

--- a/.github/workflows/release-non-cuda.yaml
+++ b/.github/workflows/release-non-cuda.yaml
@@ -5,120 +5,28 @@ on:
     tags:
       - 'v*'
 
-env:
-  SCCACHE_GHA_ENABLED: "true"
 jobs:
+  # manylinux2_28 for the toolchain only (USE_CUDA=OFF); keeps the glibc floor
+  # aligned with the CUDA wheels.
   build:
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: write
-    strategy:
-      matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
-    env:
-      BUILD_WITH_EP: "0"
-      NON_CUDA_BUILD: "1"
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Free up disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
-
-      - name: Configure sccache
-        uses: actions/github-script@v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-
-      - name: Configure project
-        run: |
-          sudo apt update -y
-          sudo bash -x dependencies.sh -y
-          mkdir build
-          cd build
-          cmake .. -DUSE_HTTP=ON -DUSE_ETCD=ON -DUSE_CUDA=OFF -DWITH_EP=OFF -DSTORE_USE_ETCD=ON -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Release
-        shell: bash
-
-      - name: Build project
-        run: |
-          cd build
-          make -j
-          sudo make install
-        shell: bash
-
-      - name: Run sccache stat for check
-        if: ${{ env.SCCACHE_PATH != '' }}
-        shell: bash
-        run: ${SCCACHE_PATH} --show-stats
-
-      - name: Generate Python version tag
-        id: generate_tag_release
-        run: |
-          echo "python_version_tag=$(echo ${{ matrix.python-version }} | tr -d '.')" >> $GITHUB_OUTPUT
-        shell: bash
-
-      - name: Build Python wheel
-        run: |
-          # Set LD_LIBRARY_PATH for wheel building
-          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
-          PYTHON_VERSION=${{ matrix.python-version }} OUTPUT_DIR=dist-py${{ steps.generate_tag_release.outputs.python_version_tag }} ./scripts/build_wheel.sh
-        env:
-          VERSION: ${{ env.VERSION }}
-
-      - name: Upload Python wheel artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: mooncake-wheel-non-cuda-py${{ steps.generate_tag_release.outputs.python_version_tag }}
-          path: mooncake-wheel/dist-py${{ steps.generate_tag_release.outputs.python_version_tag }}/*.whl
+    if: ${{ !contains(github.ref_name, '-') }}
+    uses: ./.github/workflows/_build-wheel.yaml
+    with:
+      runner: ubuntu-22.04
+      container: pytorch/manylinux2_28-builder:cuda12.8
+      cuda: container
+      build-with-ep: '0'
+      variant-flag: NON_CUDA_BUILD
+      cmake-args: >-
+        -DUSE_HTTP=ON -DUSE_ETCD=ON -DUSE_CUDA=OFF -DWITH_EP=OFF
+        -DSTORE_USE_ETCD=ON -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Release
+      artifact-prefix: mooncake-wheel-non-cuda
 
   publish-release:
     if: ${{ !contains(github.ref_name, '-') }}
     needs: build
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: write
-      id-token: write
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
-
-      - name: Download all wheel artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: mooncake-wheel/dist-all
-          pattern: mooncake-wheel-non-cuda-py*
-
-      - name: Prepare wheels for release
-        run: |
-          # Move all wheels to a single directory
-          mkdir -p mooncake-wheel/dist-release
-          find mooncake-wheel/dist-all -name "*.whl" -exec cp {} mooncake-wheel/dist-release/ \;
-          ls -la mooncake-wheel/dist-release/
-          # List all collected wheels
-          echo "Collected wheels for release:"
-          ls -la mooncake-wheel/dist-release/
-
-      - name: Upload wheels to GitHub Release
-        uses: softprops/action-gh-release@v1
-        with:
-          files: mooncake-wheel/dist-release/*.whl
-
-      - name: Publish package to PyPI
-        if: github.repository == 'kvcache-ai/Mooncake'
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: mooncake-wheel/dist-release/
-          password: ${{ secrets.PYPI_API_TOKEN }}
+    uses: ./.github/workflows/_publish-wheel.yaml
+    with:
+      artifact-pattern: 'mooncake-wheel-non-cuda*'
+    secrets:
+      pypi-token: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,8 +37,10 @@ jobs:
       artifact-prefix: mooncake-wheel-arm64
 
   publish-release:
-    if: ${{ !contains(github.ref_name, '-') }}
     needs: [build, build-arm64]
+    permissions:
+      contents: write
+      id-token: write
     uses: ./.github/workflows/_publish-wheel.yaml
     with:
       artifact-pattern: 'mooncake-wheel*'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,223 +5,42 @@ on:
     tags:
       - 'v*'
 
-env:
-  SCCACHE_GHA_ENABLED: "true"
 jobs:
+  # Skip semver pre-release tags (e.g. v1.0.0-rc1); those are handled by pre-release.yaml.
   build:
-    # Skip semver pre-release tags (e.g. v1.0.0-rc1); those are handled by pre-release.yaml.
     if: ${{ !contains(github.ref_name, '-') }}
-    runs-on: ubuntu-22.04
-    container: pytorch/manylinux2_28-builder:cuda12.8
-    permissions:
-      contents: write
-    strategy:
-      matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
-    env:
-      BUILD_WITH_EP: "1"
-      TORCH_CUDA_ARCH_LIST: "8.0;9.0"
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
-
-      - name: Mark workspace safe for git (container runs as root)
-        run: git config --global --add safe.directory '*'
-
-      - name: Select Python ${{ matrix.python-version }} from manylinux image
-        run: |
-          PYV_NODOT=$(echo "${{ matrix.python-version }}" | tr -d '.')
-          PYBIN="/opt/python/cp${PYV_NODOT}-cp${PYV_NODOT}/bin"
-          echo "$PYBIN" >> "$GITHUB_PATH"
-          "$PYBIN/pip" install --quiet "cmake<4" setuptools wheel
-
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
-
-      - name: Configure sccache
-        uses: actions/github-script@v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-
-      - name: Configure project
-        run: |
-          bash -x dependencies.sh -y
-          echo "/usr/local/go/bin" >> "$GITHUB_PATH"
-          mkdir build
-          cd build
-          cmake .. -DBUILD_UNIT_TESTS=OFF -DUSE_HTTP=ON -DUSE_ETCD=ON -DUSE_CUDA=ON -DWITH_EP=ON -DEP_TORCH_VERSIONS="2.11.0;2.12.0;2.12.1" -DSTORE_USE_ETCD=ON -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Release -DPython3_EXECUTABLE="$(which python3)"
-        shell: bash
-
-      - name: Build project
-        run: |
-          export LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LIBRARY_PATH
-          cd build
-          make -j
-          make install
-        shell: bash
-
-      - name: Build nvlink_allocator.so
-        run: |
-          export PATH=/usr/local/nvidia/bin:/usr/local/nvidia/lib64:$PATH
-          export LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH
-          export LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LIBRARY_PATH
-          mkdir -p build/mooncake-transfer-engine/nvlink-allocator
-          cd mooncake-transfer-engine/nvlink-allocator
-          bash build.sh ../../build/mooncake-transfer-engine/nvlink-allocator/
-        shell: bash
-
-      - name: Run sccache stat for check
-        if: ${{ env.SCCACHE_PATH != '' }}
-        shell: bash
-        run: ${SCCACHE_PATH} --show-stats
-
-      - name: Generate Python version tag
-        id: generate_tag_release
-        run: |
-          echo "python_version_tag=$(echo ${{ matrix.python-version }} | tr -d '.')" >> $GITHUB_OUTPUT
-        shell: bash
-
-      - name: Build Python wheel
-        run: |
-          # Set LD_LIBRARY_PATH for wheel building
-          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
-          PYTHON_VERSION=${{ matrix.python-version }} OUTPUT_DIR=dist-py${{ steps.generate_tag_release.outputs.python_version_tag }} ./scripts/build_wheel.sh
-        env:
-          VERSION: ${{ env.VERSION }}
-
-      - name: Upload Python wheel artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: mooncake-wheel-py${{ steps.generate_tag_release.outputs.python_version_tag }}
-          path: mooncake-wheel/dist-py${{ steps.generate_tag_release.outputs.python_version_tag }}/*.whl
+    uses: ./.github/workflows/_build-wheel.yaml
+    with:
+      runner: ubuntu-22.04
+      container: pytorch/manylinux2_28-builder:cuda12.8
+      cuda: container
+      build-with-ep: '1'
+      torch-cuda-arch-list: '8.0;9.0'
+      ep-torch-versions: '2.11.0;2.12.0;2.12.1'
+      build-nvlink-allocator: true
+      cmake-args: >-
+        -DBUILD_UNIT_TESTS=OFF -DUSE_HTTP=ON -DUSE_ETCD=ON -DUSE_CUDA=ON
+        -DWITH_EP=ON -DSTORE_USE_ETCD=ON -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Release
+      artifact-prefix: mooncake-wheel
 
   build-arm64:
     if: ${{ !contains(github.ref_name, '-') }}
-    runs-on: ubuntu-22.04-arm
-    permissions:
-      contents: write
-    strategy:
-      matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
-    env:
-      TORCH_CUDA_ARCH_LIST: "9.0"
-      CUDA_HOME: "/usr/local/cuda"
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Free up disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-
-      - name: Install CUDA Toolkit 12.8 (arm64 SBSA)
-        run: |
-          wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/sbsa/cuda-keyring_1.1-1_all.deb
-          sudo dpkg -i cuda-keyring_1.1-1_all.deb
-          sudo apt-get update
-          sudo apt-get install -y cuda-toolkit-12-8
-          echo "/usr/local/cuda/bin" >> $GITHUB_PATH
-          /usr/local/cuda/bin/nvcc --version
-        shell: bash
-
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
-
-      - name: Configure sccache
-        uses: actions/github-script@v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-
-      - name: Configure project
-        run: |
-          sudo apt update -y
-          sudo bash -x dependencies.sh -y
-          mkdir build
-          cd build
-          cmake -G Ninja .. -DUSE_HTTP=ON -DUSE_CUDA=ON -DUSE_MNNVL=ON -DWITH_EP=OFF -DWITH_STORE_RUST=OFF -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Release
-        shell: bash
-
-      - name: Build project
-        run: |
-          export CUDA_HOME=/usr/local/cuda
-          for dir in /usr/local/cuda/lib64/stubs /usr/local/cuda/targets/*/lib/stubs; do
-            if [ -d "$dir" ]; then
-              export LIBRARY_PATH="$dir:${LIBRARY_PATH:-}"
-            fi
-          done
-          cd build
-          cmake --build .
-          sudo cmake --install .
-        shell: bash
-
-      - name: Run sccache stat for check
-        if: ${{ env.SCCACHE_PATH != '' }}
-        shell: bash
-        run: ${SCCACHE_PATH} --show-stats
-
-      - name: Generate Python version tag
-        id: generate_tag_release
-        run: |
-          echo "python_version_tag=$(echo ${{ matrix.python-version }} | tr -d '.')" >> $GITHUB_OUTPUT
-        shell: bash
-
-      - name: Build Python wheel
-        run: |
-          export CUDA_HOME=/usr/local/cuda
-          export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}:/usr/local/lib"
-          PYTHON_VERSION=${{ matrix.python-version }} OUTPUT_DIR=dist-py${{ steps.generate_tag_release.outputs.python_version_tag }} ./scripts/build_wheel.sh
-        shell: bash
-
-      - name: Upload Python wheel artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: mooncake-wheel-arm64-py${{ steps.generate_tag_release.outputs.python_version_tag }}
-          path: mooncake-wheel/dist-py${{ steps.generate_tag_release.outputs.python_version_tag }}/*.whl
+    uses: ./.github/workflows/_build-wheel.yaml
+    with:
+      runner: ubuntu-22.04-arm
+      cuda: sbsa-12.8
+      cmake-generator: Ninja
+      torch-cuda-arch-list: '9.0'
+      cmake-args: >-
+        -DUSE_HTTP=ON -DUSE_CUDA=ON -DUSE_MNNVL=ON -DWITH_EP=OFF
+        -DWITH_STORE_RUST=OFF -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Release
+      artifact-prefix: mooncake-wheel-arm64
 
   publish-release:
+    if: ${{ !contains(github.ref_name, '-') }}
     needs: [build, build-arm64]
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: write
-      id-token: write
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
-
-      - name: Download all wheel artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: mooncake-wheel/dist-all
-
-      - name: Prepare wheels for release
-        run: |
-          # Move all wheels to a single directory
-          mkdir -p mooncake-wheel/dist-release
-          find mooncake-wheel/dist-all -name "*.whl" -exec cp {} mooncake-wheel/dist-release/ \;
-          ls -la mooncake-wheel/dist-release/
-          # List all collected wheels
-          echo "Collected wheels for release:"
-          ls -la mooncake-wheel/dist-release/
-
-      - name: Upload wheels to GitHub Release
-        uses: softprops/action-gh-release@v1
-        with:
-          files: mooncake-wheel/dist-release/*.whl
-
-      - name: Publish package to PyPI
-        if: github.repository == 'kvcache-ai/Mooncake'
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: mooncake-wheel/dist-release/
-          password: ${{ secrets.PYPI_API_TOKEN }}
+    uses: ./.github/workflows/_publish-wheel.yaml
+    with:
+      artifact-pattern: 'mooncake-wheel*'
+    secrets:
+      pypi-token: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Factors the duplicated wheel build steps out of `release.yaml`, `release-cuda13.yaml`, `release-non-cuda.yaml`, and `pre-release.yaml` into a shared `_build-wheel.yaml` (and `_publish-wheel.yaml` for the release tail). Release and Pre-Release now call the same build, so a pre-release tag is a faithful dry run with no build-environment drift. Net −630 lines.

As part of this, the Non-CUDA and all Pre-Release x86 builds move into `manylinux2_28` like the CUDA wheels, so their wheels stop requiring `GLIBCXX_3.4.30` and install on RHEL/Rocky/Alma 8+. EFA/MUSA/NPU are left unchanged.

Validated with `actionlint` + `shellcheck` (no new findings); end-to-end verification is a `vX.Y.Z-rc` tag, which triggers the Pre-Release dry run. AI assistance (Claude) was used.