### PR TITLE
[TE] Fix cross-node RDMA KV transfer under rdma+hip multi-protocol on AMD

### DIFF
--- a/mooncake-transfer-engine/src/CMakeLists.txt
+++ b/mooncake-transfer-engine/src/CMakeLists.txt
@@ -107,7 +107,16 @@ if(USE_HIP)
   if(USE_HIP_DMABUF)
     find_package(hsa-runtime64 CONFIG)
     if(hsa-runtime64_FOUND)
-      target_compile_definitions(transfer_engine PRIVATE USE_HIP_DMABUF)
+      # The dmabuf MR-registration code lives in rdma_context.cpp, which is
+      # compiled in the rdma_transport OBJECT library and pulled into
+      # transfer_engine via $<TARGET_OBJECTS:transport>. A PRIVATE define on
+      # transfer_engine never reaches that object compilation, so the dmabuf
+      # path is silently compiled out and GPU MRs fall back to plain
+      # ibv_reg_mr (EINVAL on device memory). Put the define (and the hsa
+      # include/link usage requirements) on the target that actually compiles
+      # rdma_context.cpp.
+      target_compile_definitions(rdma_transport PRIVATE USE_HIP_DMABUF)
+      target_link_libraries(rdma_transport PUBLIC hsa-runtime64::hsa-runtime64)
       target_link_libraries(transfer_engine PUBLIC hsa-runtime64::hsa-runtime64)
       message(STATUS "HIP dmabuf MR registration enabled (hsa-runtime64 found)")
     else()

--- a/mooncake-transfer-engine/src/multi_transport.cpp
+++ b/mooncake-transfer-engine/src/multi_transport.cpp
@@ -14,6 +14,7 @@
 
 #include "multi_transport.h"
 #include <algorithm>
+#include <cstdlib>
 #include <sstream>
 #include <string>
 
@@ -465,7 +466,10 @@ Status MultiTransport::selectTransport(const TransferRequest& entry,
     // priority instead of relying on buffer registration order.
     if (proto.find(',') != std::string::npos) {
         auto protocol_priority = [](const std::string& p) {
-            if (p == "hip") return 4;
+            // hip is intra-node GPU-IPC only. On a cross-node request a
+            // hip+rdma segment must fall through to rdma; allow deployments
+            // that know they need the cross-node path to de-prioritize hip.
+            if (p == "hip") return std::getenv("MC_DISABLE_HIP") ? 0 : 4;
             if (p == "cxl") return 3;
             if (p == "rdma") return 2;
             if (p == "tcp") return 1;

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
@@ -777,6 +777,17 @@ int RdmaTransport::selectDevice(SegmentDesc *desc, uint64_t offset,
          ++buffer_id) {
         const auto &buffer = buffers[buffer_id];
 
+#ifdef ENABLE_MULTI_PROTOCOL
+        // The RDMA transport must only bind buffers registered under the rdma
+        // protocol. Device (hip) buffers alias the same GPU addresses but carry
+        // no lkey/rkey, so picking one yields an empty-lkey out-of-bounds read
+        // in the submit path. The !empty() guard leaves legacy single-protocol
+        // descriptors (empty protocol field) unaffected.
+        if (!buffer.protocol.empty() && buffer.protocol != "rdma") {
+            continue;
+        }
+#endif
+
         // Check if offset is within buffer range
         if (offset < buffer.addr || length > buffer.length ||
             offset - buffer.addr > buffer.length - length) {
@@ -815,6 +826,12 @@ int RdmaTransport::selectDeviceByLocalHca(SegmentDesc *desc, uint64_t offset,
     for (buffer_id = 0; buffer_id < static_cast<int>(buffers.size());
          ++buffer_id) {
         const auto &buffer = buffers[buffer_id];
+
+#ifdef ENABLE_MULTI_PROTOCOL
+        if (!buffer.protocol.empty() && buffer.protocol != "rdma") {
+            continue;
+        }
+#endif
 
         if (offset < buffer.addr || length > buffer.length ||
             offset - buffer.addr > buffer.length - length) {


### PR DESCRIPTION
Fixes #2724

## Summary

After #2682 enabled `rdma`+`hip` multi-protocol segments, **cross-node RDMA
transfer of GPU memory crashes (SIGSEGV) on AMD** whenever the same GPU buffer
is registered under both the `hip` and `rdma` protocols (the normal
disaggregated-inference case: `hip` for intra-node GPU-IPC, `rdma` for
cross-node).

This PR fixes three independent issues that together block that path. None of
them affect the single-protocol RDMA path (which is why plain rdma-only
deployments were unaffected and this went unnoticed).

## Background: why this only bites multi-protocol AMD

With multi-protocol registration, a single GPU address ends up with **two**
buffer descriptors at the same address range:

* a `hip` twin — uses IPC handles / `shm_name`, carries **no** `lkey`/`rkey`
  (the `hip` metadata (de)serialization intentionally omits them);
* an `rdma` twin — the valid RDMA registration, with a populated `lkey`.

Single-protocol rdma-only deployments only ever have the second one, so every
lookup is correct. Multi-protocol puts both in the segment's buffer list, and
the RDMA data path then has to disambiguate — which is where it goes wrong.

## Fix 1 — `selectDevice()` / `selectDeviceByLocalHca()` are protocol-blind (root cause of the crash)

`RdmaTransport::selectDevice` and `selectDeviceByLocalHca`
(`rdma_transport.cpp`) scan the segment's buffers **by address range only** and
return the first match. Because the `hip` twin aliases the same address, they
return the `hip` buffer, whose `lkey` vector is empty. The RDMA submit path then
does:

```cpp
slice->rdma.source_lkey = local_segment_desc->buffers[buffer_id].lkey[device_id];
```

i.e. an out-of-bounds read on an empty `lkey` vector → SIGSEGV. (The
`assert(lkey.size() == context_list_.size())` that would have caught this is
compiled out in Release builds.)

**Fix:** in both loops, when compiled with `ENABLE_MULTI_PROTOCOL`, skip any
buffer whose protocol is set and is not `rdma`, so the RDMA transport only ever
binds an rdma-registered buffer:

```cpp
#ifdef ENABLE_MULTI_PROTOCOL
    // RDMA transport must only bind buffers registered under the rdma
    // protocol. Device (hip) buffers alias the same GPU addresses but
    // carry no lkey/rkey, so picking one yields an empty-lkey OOB.
    if (!buffer.protocol.empty() && buffer.protocol != "rdma") {
        continue;
    }
#endif
```

The `!buffer.protocol.empty()` guard keeps legacy single-protocol descriptors
(empty protocol field) fully unaffected.

## Fix 2 — `selectTransport()` hardcodes `hip` priority above `rdma`

For a comma-joined multi-protocol segment, `MultiTransport::selectTransport`
(`multi_transport.cpp`) picks the transport by a hardcoded priority where
`hip` (4) outranks `rdma` (2). On a cross-node request this selects the `hip`
transport, which is intra-node GPU-IPC only, and fails with
`hipIpcOpenMemHandle failed`.

**Fix:** allow `hip` to be de-prioritized via an env var so a deployment that
knows it needs the cross-node RDMA path can opt out of `hip` selection:

```cpp
if (p == "hip") return std::getenv("MC_DISABLE_HIP") ? 0 : 4;
```

Default behavior is unchanged (env unset → returns 4 as before).

## Fix 3 — `USE_HIP_DMABUF` define never reaches `rdma_context.cpp`

`mooncake-transfer-engine/src/CMakeLists.txt` applies the define with:

```cmake
target_compile_definitions(transfer_engine PRIVATE USE_HIP_DMABUF)
```

But `transfer_engine` links the transports as object libraries
(`$<TARGET_OBJECTS:transport>` etc.), and the dmabuf registration code lives in
`rdma_context.cpp`, which is part of the separate `rdma_transport` object
target. A `PRIVATE` define on `transfer_engine` therefore never reaches
`rdma_context.cpp`, so the dmabuf MR-registration path is silently compiled out
— GPU MRs fall back to plain `ibv_reg_mr`, which returns `EINVAL` on device
memory.

**Fix:** apply `USE_HIP_DMABUF` (and link `hsa-runtime64`) to the target that
actually compiles `rdma_context.cpp`, so the define reaches the dmabuf code.
Verify with `strings engine*.so | grep -c "retrieve dmabuf"` > 0.

## Validation

* **Repro (before):** SGLang 1P1D disaggregation, prefill and decode on separate
  AMD nodes, mooncake backend, GPU KV over RDMA → prefill SIGSEGV during KV
  transfer; `[DIAG]` dump confirms the RDMA path was handed the `hip` twin with
  an empty `lkey`.
* **After all three fixes:** cross-node `/generate` returns correct output, and
  a concurrency sweep (1/8/32/64) completes with 100% success, zero
  QP/transfer failures, zero SIGSEGV. Validated on two independent AMD RoCE
  fabrics.
* **rdma-only unaffected:** a build with `ENABLE_MULTI_PROTOCOL=OFF` runs the
  same cross-node workload with none of these changes, confirming the bug is
  specific to multi-protocol dual registration and the fixes don't alter the
  single-protocol path.

## Notes

* On routed (L3) RoCE fabrics, the deployment must also select a routable GID
  (e.g. `MC_GID_INDEX` pointing at the RoCEv2 IPv4 GID) — that is a deployment
  config, not part of this PR, but worth documenting for AMD multi-node users.