### PR TITLE
docs: clarify local SSD offload configuration

### DIFF
--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -203,7 +203,7 @@ mooncake_master \
   --http_metadata_server_port=8080
 ```
 
-Do not set `--root_fs_dir` for local SSD offload. Local SSD offload stores data through the real client's `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH` and reports `LOCAL_DISK` replicas to the master. `--root_fs_dir` enables the legacy DFS-backed `DISK` replica path and must only point to a filesystem path that is valid on every client host.
+Do not set `--root_fs_dir` for the local filesystem-backed offload path. That path stores data through the real client's `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH`, and the master tracks those objects as `LOCAL_DISK` replicas. `--root_fs_dir` enables the distributed filesystem-backed `DISK` replica path and must only point to a filesystem path that is valid on every client host.
 
 ---
 
@@ -545,7 +545,7 @@ Flags for controlling data movement between DRAM and SSD.
 
 Start with `--enable_offload=true` for eager asynchronous SSD persistence after `Put` completion. Add `--offload_on_evict=true` when you want SSD writes to happen only when memory pressure selects an object for eviction. Add `--promotion_on_hit=true` to allow hot SSD-only data to be promoted back to DRAM, and tune `--promotion_admission_threshold` to control how many observed reads are required before promotion is queued.
 
-For local SSD offload, configure the disk path on each real client with `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH`; the master tracks these objects as `LOCAL_DISK` replicas. Do not use `--root_fs_dir` for a node-local SSD directory.
+For the local filesystem-backed offload path, configure the disk path on each real client with `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH`; the master tracks these objects as `LOCAL_DISK` replicas. Do not use `--root_fs_dir` for a per-node filesystem path.
 
 When `--offload_on_evict=true` is active, each `BatchEvict` cycle can queue at most `offloading_queue_limit * offload_cap_ratio` objects for SSD offload (default: `50000 * 0.5 = 25000`); objects exceeding this cap fall back to force-evict (discard) if `--offload_force_evict=true`, otherwise they remain in memory. For SSD-heavy workloads where NVMe bandwidth is underutilized while the KV-cache hit rate suffers, raise both `--offloading_queue_limit` and `--offload_cap_ratio` so more objects per cycle are actually persisted to SSD instead of discarded. Example: `--offloading_queue_limit=500000 --offload_cap_ratio=0.8` yields a per-cycle cap of `400000` (vs the default `25000`).
 
@@ -566,7 +566,7 @@ When `--allocation_strategy=cxl` is set alongside `--enable_cxl=true`, the maste
 | `--root_fs_dir` | empty | DFS mount directory for multi-layer storage backend |
 | `--global_file_segment_size` | `INT64_MAX` (unlimited) | Max available space for DFS segments; default does not cap DFS usage |
 
-`--root_fs_dir` is for the legacy DFS-backed `DISK` replica path. The configured path must be mounted consistently on every client host. It is separate from local SSD offload, which uses `LOCAL_DISK` replicas and client-side `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH`.
+`--root_fs_dir` is for the distributed filesystem-backed `DISK` replica path. The configured path must be mounted consistently on every client host. It is separate from the local filesystem-backed offload path, which uses `LOCAL_DISK` replicas and client-side `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH`.
 
 ### NoF (NVMe-oF SSD Pool)
 

--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -203,7 +203,7 @@ mooncake_master \
   --http_metadata_server_port=8080
 ```
 
-Do not set `--root_fs_dir` for the local filesystem-backed offload path. That path stores data through the real client's `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH`, and the master tracks those objects as `LOCAL_DISK` replicas. `--root_fs_dir` enables the distributed filesystem-backed `DISK` replica path and must only point to a filesystem path that is valid on every client host.
+Do not set `--root_fs_dir` with `--enable_offload=true`. `--root_fs_dir` is a legacy parameter from an older persistence path and may cause issues on the SSD offload path. Configure each real client's offload directory with `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH` instead.
 
 ---
 
@@ -545,7 +545,7 @@ Flags for controlling data movement between DRAM and SSD.
 
 Start with `--enable_offload=true` for eager asynchronous SSD persistence after `Put` completion. Add `--offload_on_evict=true` when you want SSD writes to happen only when memory pressure selects an object for eviction. Add `--promotion_on_hit=true` to allow hot SSD-only data to be promoted back to DRAM, and tune `--promotion_admission_threshold` to control how many observed reads are required before promotion is queued.
 
-For the local filesystem-backed offload path, configure the disk path on each real client with `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH`; the master tracks these objects as `LOCAL_DISK` replicas. Do not use `--root_fs_dir` for a per-node filesystem path.
+For SSD offload, configure the disk path on each real client with `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH`; the master tracks these objects as `LOCAL_DISK` replicas. Do not use the legacy `--root_fs_dir` parameter with `--enable_offload=true`.
 
 When `--offload_on_evict=true` is active, each `BatchEvict` cycle can queue at most `offloading_queue_limit * offload_cap_ratio` objects for SSD offload (default: `50000 * 0.5 = 25000`); objects exceeding this cap fall back to force-evict (discard) if `--offload_force_evict=true`, otherwise they remain in memory. For SSD-heavy workloads where NVMe bandwidth is underutilized while the KV-cache hit rate suffers, raise both `--offloading_queue_limit` and `--offload_cap_ratio` so more objects per cycle are actually persisted to SSD instead of discarded. Example: `--offloading_queue_limit=500000 --offload_cap_ratio=0.8` yields a per-cycle cap of `400000` (vs the default `25000`).
 
@@ -563,10 +563,10 @@ When `--allocation_strategy=cxl` is set alongside `--enable_cxl=true`, the maste
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--root_fs_dir` | empty | DFS mount directory for multi-layer storage backend |
+| `--root_fs_dir` | empty | Legacy DFS persistence directory; do not use with SSD offload |
 | `--global_file_segment_size` | `INT64_MAX` (unlimited) | Max available space for DFS segments; default does not cap DFS usage |
 
-`--root_fs_dir` is for the distributed filesystem-backed `DISK` replica path. The configured path must be mounted consistently on every client host. It is separate from the local filesystem-backed offload path, which uses `LOCAL_DISK` replicas and client-side `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH`.
+`--root_fs_dir` is a legacy persistence parameter and is expected to be replaced as the distributed filesystem path is refactored. For SSD offload, configure `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH` on each real client instead.
 
 ### NoF (NVMe-oF SSD Pool)
 

--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -199,10 +199,11 @@ mooncake_master \
   --offload_on_evict=true \
   --promotion_on_hit=true \
   --promotion_admission_threshold=2 \
-  --root_fs_dir=/mnt/ssd_cache \
   --enable_http_metadata_server=true \
   --http_metadata_server_port=8080
 ```
+
+Do not set `--root_fs_dir` for local SSD offload. Local SSD offload stores data through the real client's `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH` and reports `LOCAL_DISK` replicas to the master. `--root_fs_dir` enables the legacy DFS-backed `DISK` replica path and must only point to a filesystem path that is valid on every client host.
 
 ---
 
@@ -544,6 +545,8 @@ Flags for controlling data movement between DRAM and SSD.
 
 Start with `--enable_offload=true` for eager asynchronous SSD persistence after `Put` completion. Add `--offload_on_evict=true` when you want SSD writes to happen only when memory pressure selects an object for eviction. Add `--promotion_on_hit=true` to allow hot SSD-only data to be promoted back to DRAM, and tune `--promotion_admission_threshold` to control how many observed reads are required before promotion is queued.
 
+For local SSD offload, configure the disk path on each real client with `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH`; the master tracks these objects as `LOCAL_DISK` replicas. Do not use `--root_fs_dir` for a node-local SSD directory.
+
 When `--offload_on_evict=true` is active, each `BatchEvict` cycle can queue at most `offloading_queue_limit * offload_cap_ratio` objects for SSD offload (default: `50000 * 0.5 = 25000`); objects exceeding this cap fall back to force-evict (discard) if `--offload_force_evict=true`, otherwise they remain in memory. For SSD-heavy workloads where NVMe bandwidth is underutilized while the KV-cache hit rate suffers, raise both `--offloading_queue_limit` and `--offload_cap_ratio` so more objects per cycle are actually persisted to SSD instead of discarded. Example: `--offloading_queue_limit=500000 --offload_cap_ratio=0.8` yields a per-cycle cap of `400000` (vs the default `25000`).
 
 ### CXL Memory
@@ -562,6 +565,8 @@ When `--allocation_strategy=cxl` is set alongside `--enable_cxl=true`, the maste
 |------|---------|-------------|
 | `--root_fs_dir` | empty | DFS mount directory for multi-layer storage backend |
 | `--global_file_segment_size` | `INT64_MAX` (unlimited) | Max available space for DFS segments; default does not cap DFS usage |
+
+`--root_fs_dir` is for the legacy DFS-backed `DISK` replica path. The configured path must be mounted consistently on every client host. It is separate from local SSD offload, which uses `LOCAL_DISK` replicas and client-side `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH`.
 
 ### NoF (NVMe-oF SSD Pool)
 

--- a/docs/source/deployment/ssd-offload.md
+++ b/docs/source/deployment/ssd-offload.md
@@ -13,6 +13,8 @@ SSD offload requires the **Real Client** and supports two deployment modes:
 
 In both modes, all SSD reads and writes happen within the Real Client (embedded or standalone).
 
+Local SSD offload does not use the master's `--root_fs_dir` option. Configure the local disk path on each Real Client with `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH`; the master tracks offloaded objects as `LOCAL_DISK` replicas. `--root_fs_dir` belongs to the legacy DFS-backed `DISK` replica path and requires the same mounted path on every client host.
+
 ## Startup Steps
 
 ### Step 1: Create the SSD storage directory

--- a/docs/source/deployment/ssd-offload.md
+++ b/docs/source/deployment/ssd-offload.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Mooncake Store supports offloading KV cache objects from distributed memory to local SSD. When memory pressure is high, the master instructs clients to persist selected objects to disk. On a cache miss, the client automatically falls back to reading from SSD.
+Mooncake Store supports offloading KV cache objects from distributed memory to a local filesystem path, typically backed by local SSDs. When memory pressure is high, the master instructs clients to persist selected objects to disk. On a cache miss, the client automatically falls back to reading from the local filesystem-backed offload path.
 
 For measured TTFT and throughput impact in multi-turn workloads, see [Mooncake SSD Offload Benchmark](../performance/ssd-offload-benchmark-results.md).
 
@@ -13,7 +13,7 @@ SSD offload requires the **Real Client** and supports two deployment modes:
 
 In both modes, all SSD reads and writes happen within the Real Client (embedded or standalone).
 
-Local SSD offload does not use the master's `--root_fs_dir` option. Configure the local disk path on each Real Client with `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH`; the master tracks offloaded objects as `LOCAL_DISK` replicas. `--root_fs_dir` belongs to the legacy DFS-backed `DISK` replica path and requires the same mounted path on every client host.
+The local filesystem-backed offload path does not use the master's `--root_fs_dir` option. Configure the local disk path on each Real Client with `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH`; the master tracks offloaded objects as `LOCAL_DISK` replicas. `--root_fs_dir` belongs to the distributed filesystem-backed `DISK` replica path and requires the same mounted path on every client host.
 
 ## Startup Steps
 

--- a/docs/source/deployment/ssd-offload.md
+++ b/docs/source/deployment/ssd-offload.md
@@ -13,7 +13,7 @@ SSD offload requires the **Real Client** and supports two deployment modes:
 
 In both modes, all SSD reads and writes happen within the Real Client (embedded or standalone).
 
-The local filesystem-backed offload path does not use the master's `--root_fs_dir` option. Configure the local disk path on each Real Client with `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH`; the master tracks offloaded objects as `LOCAL_DISK` replicas. `--root_fs_dir` belongs to the distributed filesystem-backed `DISK` replica path and requires the same mounted path on every client host.
+SSD offload does not use the master's `--root_fs_dir` option. Configure the local disk path on each Real Client with `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH`; the master tracks offloaded objects as `LOCAL_DISK` replicas. `--root_fs_dir` is a legacy parameter from an older persistence path and may cause issues when used with `--enable_offload=true`.
 
 ## Startup Steps
 

--- a/docs/source/design/mooncake-store.md
+++ b/docs/source/design/mooncake-store.md
@@ -731,6 +731,8 @@ When the user specifies `--root_fs_dir=/path/to/dir` when starting the master, a
 
 ​Note​​: When enabling this feature, the user must ensure that the DFS-mounted directory (`root_fs_dir=/path/to/dir`) is valid and consistent across all client hosts. If some clients have invalid or incorrect mount paths, it may cause abnormal behavior in Mooncake Store.
 
+This DFS-backed path is separate from local SSD offload. Local SSD offload uses `--enable_offload=true` on the master and real client, stores data under the real client's `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH`, and records `LOCAL_DISK` replicas. Do not point `--root_fs_dir` at a node-local SSD directory for local SSD offload.
+
 ### Persistent Storage Space Configuration​
 Mooncake provides configurable DFS available space. Users can specify `--global_file_segment_size=1048576` when starting the master, indicating a maximum usable space of 1MB on DFS.
 The current default setting is the maximum value of int64 (as we generally do not restrict DFS storage usage), which is displayed as `infinite` in `mooncake_maseter`'s console logs.

--- a/docs/source/design/mooncake-store.md
+++ b/docs/source/design/mooncake-store.md
@@ -731,7 +731,7 @@ When the user specifies `--root_fs_dir=/path/to/dir` when starting the master, a
 
 ​Note​​: When enabling this feature, the user must ensure that the DFS-mounted directory (`root_fs_dir=/path/to/dir`) is valid and consistent across all client hosts. If some clients have invalid or incorrect mount paths, it may cause abnormal behavior in Mooncake Store.
 
-This DFS-backed path is separate from local SSD offload. Local SSD offload uses `--enable_offload=true` on the master and real client, stores data under the real client's `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH`, and records `LOCAL_DISK` replicas. Do not point `--root_fs_dir` at a node-local SSD directory for local SSD offload.
+This distributed filesystem-backed path is separate from the local filesystem-backed offload path. The local filesystem-backed path uses `--enable_offload=true` on the master and real client, stores data under the real client's `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH`, and records `LOCAL_DISK` replicas. Do not point `--root_fs_dir` at a per-node filesystem path for local offload.
 
 ### Persistent Storage Space Configuration​
 Mooncake provides configurable DFS available space. Users can specify `--global_file_segment_size=1048576` when starting the master, indicating a maximum usable space of 1MB on DFS.

--- a/docs/source/design/mooncake-store.md
+++ b/docs/source/design/mooncake-store.md
@@ -731,7 +731,7 @@ When the user specifies `--root_fs_dir=/path/to/dir` when starting the master, a
 
 ​Note​​: When enabling this feature, the user must ensure that the DFS-mounted directory (`root_fs_dir=/path/to/dir`) is valid and consistent across all client hosts. If some clients have invalid or incorrect mount paths, it may cause abnormal behavior in Mooncake Store.
 
-This distributed filesystem-backed path is separate from the local filesystem-backed offload path. The local filesystem-backed path uses `--enable_offload=true` on the master and real client, stores data under the real client's `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH`, and records `LOCAL_DISK` replicas. Do not point `--root_fs_dir` at a per-node filesystem path for local offload.
+This `root_fs_dir` path is a legacy persistence path. SSD offload uses `--enable_offload=true` on the master and real client, stores data under the real client's `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH`, and records `LOCAL_DISK` replicas. Do not use `--root_fs_dir` with `--enable_offload=true`.
 
 ### Persistent Storage Space Configuration​
 Mooncake provides configurable DFS available space. Users can specify `--global_file_segment_size=1048576` when starting the master, indicating a maximum usable space of 1MB on DFS.


### PR DESCRIPTION
## Description

Addresses #2715. Related to #1195.

This PR clarifies the difference between local SSD offload and the legacy DFS-backed path:

- local SSD offload uses `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH` on each Real Client and reports `LOCAL_DISK` replicas
- `--root_fs_dir` belongs to the legacy DFS-backed `DISK` replica path and must point to a path mounted consistently on every client host
- removes `--root_fs_dir` from the SSD offload quick-start example

## Module

- [x] Mooncake Store (`mooncake-store`)
- [x] Docs

## Type of Change

- [x] Documentation update

## How Has This Been Tested?

**Test commands:**
```bash
git diff --check
PATH="/opt/homebrew/opt/llvm@20/bin:$PATH" scripts/code_format.sh --check
PATH="/opt/homebrew/opt/llvm@20/bin:$PATH" pre-commit run --files docs/source/deployment/mooncake-store-deployment-guide.md docs/source/deployment/ssd-offload.md docs/source/design/mooncake-store.md
```

**Test results:**
- [ ] Unit tests pass (not applicable; docs-only)
- [ ] Integration tests pass (not applicable; docs-only)
- [x] Manual testing done (reviewed the updated SSD offload and DFS configuration text)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass (ran touched-file hooks for this docs-only change)
- [x] I have updated the documentation
- [ ] I have added tests to prove my changes are effective (not applicable; docs-only)
- [x] For changes >500 LOC: I have filed an RFC issue (not applicable; 10 insertions / 1 deletion)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used: Codex assisted with docs update and PR preparation.