### PR TITLE
[TE] Downgrade unrecognized mem addr log from ERROR to INFO

### DIFF
--- a/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/ascend_direct_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/ascend_direct_transport.cpp
@@ -343,8 +343,8 @@ int AscendDirectTransport::registerLocalMemory(void *addr, size_t length,
         } else if (attributes.location.type == ACL_MEM_LOCATION_TYPE_DEVICE) {
             mem_type = adxl::MEM_DEVICE;
         } else {
-            LOG(ERROR) << "mem addr:" << addr
-                       << " can not be recognized, try set to host mem.";
+            LOG(INFO) << "mem addr:" << addr
+                      << " can not be recognized, try set to host mem.";
             mem_type = adxl::MEM_HOST;
         }
     } else {


### PR DESCRIPTION
## Description

Downgrade the log level when `aclrtPointerGetAttributes` returns an unrecognized memory location type from `LOG(ERROR)` to `LOG(INFO)`. The transport already falls back to host memory in this case, so ERROR was unnecessarily noisy.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How Has This Been Tested?

- `./scripts/code_format.sh -b upstream/main --check` — passed

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.