### PR TITLE
[Store] Support local_buffer_size in mooncake_client

### DIFF
--- a/mooncake-store/src/real_client_main.cpp
+++ b/mooncake-store/src/real_client_main.cpp
@@ -17,6 +17,7 @@ DEFINE_string(master_server_address, "127.0.0.1:50051",
 DEFINE_string(protocol, "tcp", "Protocol");
 DEFINE_int32(port, 50052, "Real Client service port");
 DEFINE_string(global_segment_size, "4 GB", "Size of global segment");
+DEFINE_string(local_buffer_size, "0", "Size of local buffer (e.g., 16MB, 1GB)");
 DEFINE_int32(threads, 1, "Number of threads for client service");
 DEFINE_string(tenant_id, "default", "Tenant identifier");
 DEFINE_bool(enable_offload, false, "Enable offload availability");
@@ -103,6 +104,7 @@ int main(int argc, char *argv[]) {
     }
 
     size_t global_segment_size = string_to_byte_size(FLAGS_global_segment_size);
+    size_t local_buffer_size = string_to_byte_size(FLAGS_local_buffer_size);
 #ifdef USE_ASCEND_DIRECT
     // just set to true, does not affect GPU process.
     globalConfig().ascend_agent_mode = true;
@@ -110,10 +112,11 @@ int main(int argc, char *argv[]) {
 
     auto client_inst = RealClient::create();
     auto res = client_inst->setup_internal(
-        FLAGS_host, FLAGS_metadata_server, global_segment_size, 0,
-        FLAGS_protocol, FLAGS_device_names, FLAGS_master_server_address,
-        nullptr, "@mooncake_client_" + std::to_string(FLAGS_port) + ".sock",
-        FLAGS_port, FLAGS_enable_offload, FLAGS_start_offload_rpc_server, "",
+        FLAGS_host, FLAGS_metadata_server, global_segment_size,
+        local_buffer_size, FLAGS_protocol, FLAGS_device_names,
+        FLAGS_master_server_address, nullptr,
+        "@mooncake_client_" + std::to_string(FLAGS_port) + ".sock", FLAGS_port,
+        FLAGS_enable_offload, FLAGS_start_offload_rpc_server, "",
         FLAGS_tenant_id);
     if (!res) {
         LOG(FATAL) << "Failed to setup client: " << toString(res.error());


### PR DESCRIPTION
fix: https://github.com/kvcache-ai/Mooncake/issues/2740
Previously hardcoded to 0, now configurable with default "0" to preserve existing behavior.

## Description



## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



**Test commands:**
```bash
# Example: bash scripts/run_ci_test.sh
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [ ] AI tools were used (specify below)