### PR TITLE
[TransferEngine] Prefer private-range IPv4 GIDs over link-local IPv6 in auto-selection

### DIFF
--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_gid_probe.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_gid_probe.h
@@ -29,9 +29,18 @@ namespace mooncake {
 enum class AutoGidCandidateClass {
     kNetworkRoutable = 0,
     kNoNetworkRoutable = 1,
-    kNetworkDegraded = 2,
-    kNoNetworkDegraded = 3,
-    kFallbackNonzero = 4,
+    // Private-range (RFC 1918 / CGNAT) IPv4-mapped GIDs. Split out of the
+    // degraded tier (#2729): datacenter RoCE fabrics routinely address NICs
+    // from 10/8, and such a GID is at worst same-subnet-usable — unlike a
+    // link-local fe80:: GID, which can never work across subnets. The
+    // relative order of all pre-existing tiers is unchanged; only the former
+    // tie between private-range IPv4 and link-local/overlay entries within
+    // "degraded" is split.
+    kNetworkPrivateV4 = 2,
+    kNetworkDegraded = 3,
+    kNoNetworkPrivateV4 = 4,
+    kNoNetworkDegraded = 5,
+    kFallbackNonzero = 6,
 };
 
 enum class AutoGidRetryAction {
@@ -72,8 +81,12 @@ inline const char* autoGidCandidateClassToString(
             return "network-routable";
         case AutoGidCandidateClass::kNoNetworkRoutable:
             return "no-network-routable";
+        case AutoGidCandidateClass::kNetworkPrivateV4:
+            return "network-private-v4";
         case AutoGidCandidateClass::kNetworkDegraded:
             return "network-degraded";
+        case AutoGidCandidateClass::kNoNetworkPrivateV4:
+            return "no-network-private-v4";
         case AutoGidCandidateClass::kNoNetworkDegraded:
             return "no-network-degraded";
         case AutoGidCandidateClass::kFallbackNonzero:
@@ -95,20 +108,26 @@ inline std::optional<AutoGidCandidateClass> classifyAutoGidCandidate(
     }
 
     const bool is_roce_v2 = candidate.gid_type == IBV_GID_TYPE_ROCE_V2;
-    const bool is_overlay =
-        is_roce_v2 && (candidate.is_overlay_network ||
-                       (candidate.is_ipv4_mapped && candidate.is_overlay_ipv4));
+    // Interface-name-based overlay detection (docker*/cni*/...) is the
+    // reliable demotion signal; a private address range alone is not — DC
+    // RoCE fabrics commonly use 10/8 (#2729).
+    const bool is_overlay_iface = is_roce_v2 && candidate.is_overlay_network;
+    const bool is_private_v4 = is_roce_v2 && !is_overlay_iface &&
+                               candidate.is_ipv4_mapped &&
+                               candidate.is_overlay_ipv4;
     const bool is_link_local =
         is_roce_v2 && !candidate.is_ipv4_mapped && candidate.is_link_local_ipv6;
-    const bool is_degraded = is_overlay || is_link_local;
+    const bool is_degraded = is_overlay_iface || is_link_local;
 
     if (candidate.has_network_device) {
-        return is_degraded ? AutoGidCandidateClass::kNetworkDegraded
-                           : AutoGidCandidateClass::kNetworkRoutable;
+        if (is_degraded) return AutoGidCandidateClass::kNetworkDegraded;
+        if (is_private_v4) return AutoGidCandidateClass::kNetworkPrivateV4;
+        return AutoGidCandidateClass::kNetworkRoutable;
     }
 
-    return is_degraded ? AutoGidCandidateClass::kNoNetworkDegraded
-                       : AutoGidCandidateClass::kNoNetworkRoutable;
+    if (is_degraded) return AutoGidCandidateClass::kNoNetworkDegraded;
+    if (is_private_v4) return AutoGidCandidateClass::kNoNetworkPrivateV4;
+    return AutoGidCandidateClass::kNoNetworkRoutable;
 }
 
 inline int autoGidCandidateClassPriority(
@@ -118,14 +137,18 @@ inline int autoGidCandidateClassPriority(
             return 0;
         case AutoGidCandidateClass::kNoNetworkRoutable:
             return 1;
-        case AutoGidCandidateClass::kNetworkDegraded:
+        case AutoGidCandidateClass::kNetworkPrivateV4:
             return 2;
-        case AutoGidCandidateClass::kNoNetworkDegraded:
+        case AutoGidCandidateClass::kNetworkDegraded:
             return 3;
-        case AutoGidCandidateClass::kFallbackNonzero:
+        case AutoGidCandidateClass::kNoNetworkPrivateV4:
             return 4;
+        case AutoGidCandidateClass::kNoNetworkDegraded:
+            return 5;
+        case AutoGidCandidateClass::kFallbackNonzero:
+            return 6;
     }
-    return 5;
+    return 7;
 }
 
 inline std::vector<AutoGidSelection> rankAutoGidCandidates(

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -745,9 +745,11 @@ static GidNetworkState autoGidStateFromSelection(
     const AutoGidSelection &selection) {
     switch (selection.candidate_class) {
         case AutoGidCandidateClass::kNetworkRoutable:
+        case AutoGidCandidateClass::kNetworkPrivateV4:
         case AutoGidCandidateClass::kNetworkDegraded:
             return GidNetworkState::GID_WITH_NETWORK;
         case AutoGidCandidateClass::kNoNetworkRoutable:
+        case AutoGidCandidateClass::kNoNetworkPrivateV4:
         case AutoGidCandidateClass::kNoNetworkDegraded:
         case AutoGidCandidateClass::kFallbackNonzero:
             return GidNetworkState::GID_WITHOUT_NETWORK;

--- a/mooncake-transfer-engine/tests/rdma_gid_probe_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_gid_probe_test.cpp
@@ -14,6 +14,8 @@
 
 #include <gtest/gtest.h>
 
+#include <set>
+#include <string>
 #include <vector>
 
 #include "transport/rdma_transport/rdma_gid_probe.h"
@@ -509,6 +511,30 @@ TEST(RdmaGidProbeTest, NetworkLinkLocalStillOutranksNoNetworkPrivateV4) {
     EXPECT_EQ(selection->gid_index, 1);
     EXPECT_EQ(selection->candidate_class,
               AutoGidCandidateClass::kNetworkDegraded);
+}
+
+// Completeness pin for the tier tables: every class has a distinct
+// priority consistent with its enum order and a unique display name, so a
+// future class insertion cannot silently create a tie or reuse a label.
+TEST(RdmaGidProbeTest, ClassPriorityAndNameTablesAreComplete) {
+    const AutoGidCandidateClass all[] = {
+        AutoGidCandidateClass::kNetworkRoutable,
+        AutoGidCandidateClass::kNoNetworkRoutable,
+        AutoGidCandidateClass::kNetworkPrivateV4,
+        AutoGidCandidateClass::kNetworkDegraded,
+        AutoGidCandidateClass::kNoNetworkPrivateV4,
+        AutoGidCandidateClass::kNoNetworkDegraded,
+        AutoGidCandidateClass::kFallbackNonzero,
+    };
+    int expected_priority = 0;
+    std::set<std::string> names;
+    for (auto cls : all) {
+        EXPECT_EQ(autoGidCandidateClassPriority(cls), expected_priority++);
+        std::string name = autoGidCandidateClassToString(cls);
+        EXPECT_NE(name, "unknown");
+        EXPECT_TRUE(names.insert(name).second)
+            << "duplicate class name: " << name;
+    }
 }
 
 // When only link-local candidates exist, behavior is unchanged: lowest

--- a/mooncake-transfer-engine/tests/rdma_gid_probe_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_gid_probe_test.cpp
@@ -399,4 +399,137 @@ TEST(RdmaGidProbeTest, RetryActionRequiresObservedOrReprobedChange) {
               AutoGidRetryAction::kRetryWithObservedChange);
 }
 
+// Regression tests for #2729: a routable-fabric private-range IPv4 GID must
+// outrank a link-local IPv6 GID instead of tying with it in the degraded
+// tier (where the lowest-index tie-break used to pick fe80::).
+
+// Exactly the GID table from the #2729 report: fe80 v1/v2 at indices 0/1,
+// 10.14.x-mapped v1/v2 at indices 2/3, all on the same netdev. RoCE v1
+// entries are filtered by type; index 3 (private v4, RoCE v2) must win over
+// index 1 (link-local, RoCE v2).
+TEST(RdmaGidProbeTest, PrefersPrivateRangeV4OverLinkLocal) {
+    std::vector<AutoGidCandidate> candidates = {
+        makeCandidate(/*gid_index=*/0, IBV_GID_TYPE_ROCE_V1,
+                      /*has_network_device=*/true,
+                      /*is_ipv4_mapped=*/false,
+                      /*is_link_local_ipv6=*/true),
+        makeCandidate(/*gid_index=*/1, IBV_GID_TYPE_ROCE_V2,
+                      /*has_network_device=*/true,
+                      /*is_ipv4_mapped=*/false,
+                      /*is_link_local_ipv6=*/true),
+        makeCandidate(/*gid_index=*/2, IBV_GID_TYPE_ROCE_V1,
+                      /*has_network_device=*/true,
+                      /*is_ipv4_mapped=*/true,
+                      /*is_link_local_ipv6=*/false,
+                      /*is_overlay_network=*/false,
+                      /*is_overlay_ipv4=*/true),
+        makeCandidate(/*gid_index=*/3, IBV_GID_TYPE_ROCE_V2,
+                      /*has_network_device=*/true,
+                      /*is_ipv4_mapped=*/true,
+                      /*is_link_local_ipv6=*/false,
+                      /*is_overlay_network=*/false,
+                      /*is_overlay_ipv4=*/true),
+    };
+
+    auto selection = selectBestAutoGidCandidate(candidates);
+    ASSERT_TRUE(selection.has_value());
+    EXPECT_EQ(selection->gid_index, 3);
+    EXPECT_EQ(selection->candidate_class,
+              AutoGidCandidateClass::kNetworkPrivateV4);
+}
+
+// A genuinely routable (non-private) v4 GID still outranks a private-range
+// one: the new tier sits strictly between routable and degraded.
+TEST(RdmaGidProbeTest, RoutableV4StillOutranksPrivateRangeV4) {
+    std::vector<AutoGidCandidate> candidates = {
+        makeCandidate(/*gid_index=*/1, IBV_GID_TYPE_ROCE_V2,
+                      /*has_network_device=*/true,
+                      /*is_ipv4_mapped=*/true,
+                      /*is_link_local_ipv6=*/false,
+                      /*is_overlay_network=*/false,
+                      /*is_overlay_ipv4=*/true),
+        makeCandidate(/*gid_index=*/5, IBV_GID_TYPE_ROCE_V2,
+                      /*has_network_device=*/true,
+                      /*is_ipv4_mapped=*/true,
+                      /*is_link_local_ipv6=*/false),
+    };
+
+    auto selection = selectBestAutoGidCandidate(candidates);
+    ASSERT_TRUE(selection.has_value());
+    EXPECT_EQ(selection->gid_index, 5);
+    EXPECT_EQ(selection->candidate_class,
+              AutoGidCandidateClass::kNetworkRoutable);
+}
+
+// An overlay-NAMED interface (docker0/cni/...) stays demoted below
+// private-range v4 even when its address is v4-mapped: the interface-name
+// heuristic remains the strongest demotion signal.
+TEST(RdmaGidProbeTest, OverlayInterfaceStaysDemotedBelowPrivateRangeV4) {
+    std::vector<AutoGidCandidate> candidates = {
+        makeCandidate(/*gid_index=*/1, IBV_GID_TYPE_ROCE_V2,
+                      /*has_network_device=*/true,
+                      /*is_ipv4_mapped=*/true,
+                      /*is_link_local_ipv6=*/false,
+                      /*is_overlay_network=*/true,
+                      /*is_overlay_ipv4=*/true),
+        makeCandidate(/*gid_index=*/4, IBV_GID_TYPE_ROCE_V2,
+                      /*has_network_device=*/true,
+                      /*is_ipv4_mapped=*/true,
+                      /*is_link_local_ipv6=*/false,
+                      /*is_overlay_network=*/false,
+                      /*is_overlay_ipv4=*/true),
+    };
+
+    auto selection = selectBestAutoGidCandidate(candidates);
+    ASSERT_TRUE(selection.has_value());
+    EXPECT_EQ(selection->gid_index, 4);
+    EXPECT_EQ(selection->candidate_class,
+              AutoGidCandidateClass::kNetworkPrivateV4);
+}
+
+// Cross-tier order is preserved from before the split: a link-local GID
+// with a netdev still outranks a private-range v4 GID without one, exactly
+// as network-degraded outranked no-network-degraded before.
+TEST(RdmaGidProbeTest, NetworkLinkLocalStillOutranksNoNetworkPrivateV4) {
+    std::vector<AutoGidCandidate> candidates = {
+        makeCandidate(/*gid_index=*/1, IBV_GID_TYPE_ROCE_V2,
+                      /*has_network_device=*/true,
+                      /*is_ipv4_mapped=*/false,
+                      /*is_link_local_ipv6=*/true),
+        makeCandidate(/*gid_index=*/3, IBV_GID_TYPE_ROCE_V2,
+                      /*has_network_device=*/false,
+                      /*is_ipv4_mapped=*/true,
+                      /*is_link_local_ipv6=*/false,
+                      /*is_overlay_network=*/false,
+                      /*is_overlay_ipv4=*/true),
+    };
+
+    auto selection = selectBestAutoGidCandidate(candidates);
+    ASSERT_TRUE(selection.has_value());
+    EXPECT_EQ(selection->gid_index, 1);
+    EXPECT_EQ(selection->candidate_class,
+              AutoGidCandidateClass::kNetworkDegraded);
+}
+
+// When only link-local candidates exist, behavior is unchanged: lowest
+// index wins within the tier.
+TEST(RdmaGidProbeTest, LinkLocalOnlyKeepsLowestIndexTieBreak) {
+    std::vector<AutoGidCandidate> candidates = {
+        makeCandidate(/*gid_index=*/1, IBV_GID_TYPE_ROCE_V2,
+                      /*has_network_device=*/true,
+                      /*is_ipv4_mapped=*/false,
+                      /*is_link_local_ipv6=*/true),
+        makeCandidate(/*gid_index=*/2, IBV_GID_TYPE_ROCE_V2,
+                      /*has_network_device=*/true,
+                      /*is_ipv4_mapped=*/false,
+                      /*is_link_local_ipv6=*/true),
+    };
+
+    auto selection = selectBestAutoGidCandidate(candidates);
+    ASSERT_TRUE(selection.has_value());
+    EXPECT_EQ(selection->gid_index, 1);
+    EXPECT_EQ(selection->candidate_class,
+              AutoGidCandidateClass::kNetworkDegraded);
+}
+
 }  // namespace


### PR DESCRIPTION
Fixes #2729.

`isOverlayIPv4()` classifies every RFC 1918 / CGNAT address as "overlay", which drops routable 10.x datacenter-fabric GIDs into the same degraded tier as link-local `fe80::` GIDs; the lowest-gid-index tie-break then deterministically picks the link-local entry (they occupy indices 0/1 on mlx5), which can only ever work same-L2. Every RoCEv2 deployment addressed from 10/8 — like the reporter's, and like SGLang's default docker setups — gets a broken auto-selection.

## Design

Split the degraded tier rather than reorder anything else, shaped around the compatibility concern raised in the issue:

- New tier `k{Network,NoNetwork}PrivateV4`: private-range IPv4-mapped GIDs (10/8, 172.16/12, 100.64/10) rank **strictly below** genuinely routable GIDs (public v4, global v6 — unchanged) and **strictly above** link-local / overlay-named-interface GIDs.
- The interface-name overlay heuristic (`docker*`/`cni*`/`flannel*`/…) remains the strongest demotion signal: a v4-mapped GID on `docker0` still ranks below a private-range GID on a physical NIC.
- **Every pre-existing cross-tier ordering is preserved** — the change is exactly "the former two-way tie inside degraded is now ordered". All 17 existing `rdma_gid_probe_test` cases pass unmodified; deployments pinning `MC_GID_INDEX` are unaffected. For the reported topology this restores the effective pre-4d7c1a19 selection (which the reporter confirmed worked, e.g. 0.3.11.post1).

The policy lives entirely in `rdma_gid_probe.h` (pure functions), so the fix is fully covered by table-driven unit tests — including one that reproduces the exact GID table from the report.

## Validation (multi-GPU Linux host with real mlx5 RoCEv2 hardware on a private RFC1918 fabric, with the same link-local and IPv4-mapped GID-table shape as the report)

Unit: `rdma_gid_probe_test` 22/22 (17 pre-existing unmodified + 5 new).

Live A/B with `transfer_engine_bench` (P2PHANDSHAKE, RDMA):

| build | auto-selected GID on mlx5_0 |
|---|---|
| main (b5ad133) | selects a link-local GID |
| this PR | selects the routable IPv4-mapped private-fabric GID |

End-to-end with the fixed selection across two mlx5 interfaces (read, 64 KB × 128 batch × 4 threads, 5 s): **24.10 GB/s**, no handshake retries.

@pzcyyj would you mind verifying this build on your cross-subnet fabric? On the validation host the mis-selection reproduces on main exactly as you described and this branch selects the private-fabric GID, but yours is the topology where the link-local choice actually breaks connections.