### PR TITLE
[Store] Add hidden state object data type

### DIFF
--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -1784,6 +1784,7 @@ PYBIND11_MODULE(store, m) {
         .value("OPTIMIZER_STATE", ObjectDataType::OPTIMIZER_STATE)
         .value("METADATA", ObjectDataType::METADATA)
         .value("GENERAL", ObjectDataType::GENERAL)
+        .value("HIDDEN_STATE", ObjectDataType::HIDDEN_STATE)
         .export_values();
 
     // Define the ReplicateConfig class

--- a/mooncake-store/include/types.h
+++ b/mooncake-store/include/types.h
@@ -147,7 +147,8 @@ enum class ObjectDataType : uint8_t {
     OPTIMIZER_STATE = 7,
     METADATA = 8,
     GENERAL = 9,
-    // 10-255 reserved for future types
+    HIDDEN_STATE = 10,
+    // 11-255 reserved for future types
 };
 
 inline std::ostream& operator<<(std::ostream& os,
@@ -162,7 +163,8 @@ inline std::ostream& operator<<(std::ostream& os,
                      {ObjectDataType::GRADIENT, "GRADIENT"},
                      {ObjectDataType::OPTIMIZER_STATE, "OPTIMIZER_STATE"},
                      {ObjectDataType::METADATA, "METADATA"},
-                     {ObjectDataType::GENERAL, "GENERAL"}};
+                     {ObjectDataType::GENERAL, "GENERAL"},
+                     {ObjectDataType::HIDDEN_STATE, "HIDDEN_STATE"}};
 
     auto it = type_strings.find(type);
     os << (it != type_strings.end() ? it->second : "UNKNOWN");

--- a/mooncake-store/tests/object_data_type_test.cpp
+++ b/mooncake-store/tests/object_data_type_test.cpp
@@ -47,6 +47,7 @@ TEST_F(ObjectDataTypeTest, EnumValues) {
     EXPECT_EQ(static_cast<uint8_t>(ObjectDataType::OPTIMIZER_STATE), 7);
     EXPECT_EQ(static_cast<uint8_t>(ObjectDataType::METADATA), 8);
     EXPECT_EQ(static_cast<uint8_t>(ObjectDataType::GENERAL), 9);
+    EXPECT_EQ(static_cast<uint8_t>(ObjectDataType::HIDDEN_STATE), 10);
 }
 
 // Verify stream operator produces readable output
@@ -66,6 +67,10 @@ TEST_F(ObjectDataTypeTest, StreamOperator) {
     oss.str("");
     oss << ObjectDataType::GENERAL;
     EXPECT_EQ(oss.str(), "GENERAL");
+
+    oss.str("");
+    oss << ObjectDataType::HIDDEN_STATE;
+    EXPECT_EQ(oss.str(), "HIDDEN_STATE");
 
     // Out-of-range value should print "UNKNOWN"
     oss.str("");
@@ -147,6 +152,7 @@ TEST_F(ObjectDataTypeTest, EnumRoundtrip) {
         ObjectDataType::SAMPLE,   ObjectDataType::ACTIVATION,
         ObjectDataType::GRADIENT, ObjectDataType::OPTIMIZER_STATE,
         ObjectDataType::METADATA, ObjectDataType::GENERAL,
+        ObjectDataType::HIDDEN_STATE,
     };
 
     for (auto type : all_types) {

--- a/mooncake-store/tests/object_data_type_test.cpp
+++ b/mooncake-store/tests/object_data_type_test.cpp
@@ -147,11 +147,11 @@ TEST_F(ObjectDataTypeTest, PutStartDefaultDataType) {
 // Verify all enum values can roundtrip through uint8_t cast
 TEST_F(ObjectDataTypeTest, EnumRoundtrip) {
     std::vector<ObjectDataType> all_types = {
-        ObjectDataType::UNKNOWN,  ObjectDataType::KVCACHE,
-        ObjectDataType::TENSOR,   ObjectDataType::WEIGHT,
-        ObjectDataType::SAMPLE,   ObjectDataType::ACTIVATION,
-        ObjectDataType::GRADIENT, ObjectDataType::OPTIMIZER_STATE,
-        ObjectDataType::METADATA, ObjectDataType::GENERAL,
+        ObjectDataType::UNKNOWN,      ObjectDataType::KVCACHE,
+        ObjectDataType::TENSOR,       ObjectDataType::WEIGHT,
+        ObjectDataType::SAMPLE,       ObjectDataType::ACTIVATION,
+        ObjectDataType::GRADIENT,     ObjectDataType::OPTIMIZER_STATE,
+        ObjectDataType::METADATA,     ObjectDataType::GENERAL,
         ObjectDataType::HIDDEN_STATE,
     };
 


### PR DESCRIPTION
## Description

This is split optimization version 1/4 of the original PR: https://github.com/kvcache-ai/Mooncake/pull/2689.

This PR adds `HIDDEN_STATE` as an object data type metadata value in Mooncake Store. It provides the type semantic needed by follow-up PRs for object-type-aware lease policy, memory accounting, quota, and eviction behavior.

This is the first step split out from the original Hidden State type-aware eviction PR. This PR only introduces the object type semantic. It does not change Store runtime behavior, lease behavior, quota behavior, or eviction behavior.

Design rationale:

- Hidden State and KV Cache have different reuse granularity, lifetime, and recomputation cost, so Store needs a way to preserve object type information for follow-up policies.

Main changes:

- Add `ObjectDataType::HIDDEN_STATE = 10`.
- Expose `HIDDEN_STATE` in the Python binding.
- Extend object data type tests to cover enum value stability, stream output, and `uint8_t` roundtrip conversion.

Compatibility notes:

- This PR does not change the `ObjectMetadata` snapshot wire format. The current snapshot path already serializes `data_type` as `uint8_t` and converts it back to `ObjectDataType` during deserialization, so adding a new enum value does not change the serialized layout.
- This PR does not change the default value of `ReplicateConfig::data_type`.
- `HIDDEN_STATE` only adds a Store-level object type semantic and does not change the physical storage format. The payload layout of Hidden State objects can still be the same as ordinary `TENSOR` objects. For example, in the vLLM MooncakeStoreECConnector integration https://github.com/vllm-project/vllm/pull/47302, the EC connector first tries to transfer encoder hidden states with the `HIDDEN_STATE` type; if the current Mooncake Store binding does not expose that type, it can fall back to `TENSOR` for the same tensor payload.
- This PR does not introduce Hidden-specific lease, quota, metrics, or eviction branches.

## Module

- [ ]  Transfer Engine (`mooncake-transfer-engine`)
- [X]  Mooncake Store (`mooncake-store`)
- [ ]  Mooncake EP (`mooncake-ep`)
- [ ]  Mooncake PG (`mooncake-pg`)
- [X]  Integration (`mooncake-integration`)
- [ ]  P2P Store (`mooncake-p2p-store`)
- [ ]  Python Wheel (`mooncake-wheel`)
- [ ]  Common (`mooncake-common`)
- [ ]  Mooncake RL (`mooncake-rl`)
- [ ]  CI/CD
- [ ]  Docs
- [ ]  Other

## Type of Changes

- [ ]  Bug fix
- [X]  New feature
- [ ]  Refactor
- [ ]  Breaking change
- [ ]  Documentation update
- [ ]  Performance improvement
- [ ]  Other

## How Has This Been Tested?

This PR adds coverage in `object_data_type_test` for:

- Stability of the `HIDDEN_STATE` enum value.
- Human-readable stream output for `HIDDEN_STATE`.
- Roundtrip conversion through `uint8_t` casts.
- Existing default behavior where `ReplicateConfig::data_type == UNKNOWN`.

Commands:

```bash
ninja -C build-docker mooncake-store/tests/object_data_type_test
./build-docker/mooncake-store/tests/object_data_type_test
```

## Checklist

- [X]  I have performed a self-review of my own code
- [X]  I have formatted my code using `./scripts/code_format.sh`
- [ ]  I have run `pre-commit run --all-files` and all hooks pass
- [ ]  I have updated the documentation (if applicable)
- [X]  I have added tests to prove my changes are effective
- [ ]  For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ]  No AI tools were used
- [X]  AI tools were used