### PR TITLE
[Store] adjusted lease timeout policy

### DIFF
--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -19,6 +19,7 @@ class HttpMetadataServer;
 struct ObjectTypeEvictionScorePolicy {
     double reuse_scale{1.0};
     double soft_pin_weight{1.0};
+    int64_t eviction_grace{0};
 };
 
 inline void ValidateObjectTypeEvictionScorePolicy(

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -3,6 +3,7 @@
 #include <optional>
 #include <stdexcept>
 #include <string_view>
+#include <unordered_map>
 
 #include <glog/logging.h>
 
@@ -13,6 +14,11 @@ namespace mooncake {
 
 // Forwarded to the HA serve phase via MasterServiceSupervisorConfig.
 class HttpMetadataServer;
+
+struct ObjectTypeEvictionScorePolicy {
+    double reuse_scale{1.0};
+    double soft_pin_weight{1.0};
+};
 
 inline std::string ResolveConfiguredHABackendConnstring(
     std::string_view ha_backend_type, std::string_view ha_backend_connstring,
@@ -617,6 +623,8 @@ class MasterServiceConfigBuilder {
    private:
     uint64_t default_kv_lease_ttl_ = DEFAULT_DEFAULT_KV_LEASE_TTL;
     uint64_t default_kv_soft_pin_ttl_ = DEFAULT_KV_SOFT_PIN_TTL_MS;
+    std::unordered_map<ObjectDataType, ObjectTypeEvictionScorePolicy>
+        object_type_eviction_score_policies_;
     bool allow_evict_soft_pinned_objects_ =
         DEFAULT_ALLOW_EVICT_SOFT_PINNED_OBJECTS;
     double eviction_ratio_ = DEFAULT_EVICTION_RATIO;
@@ -680,6 +688,15 @@ class MasterServiceConfigBuilder {
 
     MasterServiceConfigBuilder& set_default_kv_soft_pin_ttl(uint64_t ttl) {
         default_kv_soft_pin_ttl_ = ttl;
+        return *this;
+    }
+
+    MasterServiceConfigBuilder& set_object_type_eviction_score_policy(
+        ObjectDataType data_type, ObjectTypeEvictionScorePolicy policy) {
+        if (policy.reuse_scale <= 0.0) {
+            throw std::invalid_argument("reuse_scale must be greater than 0");
+        }
+        object_type_eviction_score_policies_[data_type] = policy;
         return *this;
     }
 
@@ -955,6 +972,8 @@ class MasterServiceConfig {
    public:
     uint64_t default_kv_lease_ttl = DEFAULT_DEFAULT_KV_LEASE_TTL;
     uint64_t default_kv_soft_pin_ttl = DEFAULT_KV_SOFT_PIN_TTL_MS;
+    std::unordered_map<ObjectDataType, ObjectTypeEvictionScorePolicy>
+        object_type_eviction_score_policies;
     bool allow_evict_soft_pinned_objects =
         DEFAULT_ALLOW_EVICT_SOFT_PINNED_OBJECTS;
     double eviction_ratio = DEFAULT_EVICTION_RATIO;
@@ -1101,6 +1120,8 @@ inline MasterServiceConfig MasterServiceConfigBuilder::build() const {
     MasterServiceConfig config;
     config.default_kv_lease_ttl = default_kv_lease_ttl_;
     config.default_kv_soft_pin_ttl = default_kv_soft_pin_ttl_;
+    config.object_type_eviction_score_policies =
+        object_type_eviction_score_policies_;
     config.allow_evict_soft_pinned_objects = allow_evict_soft_pinned_objects_;
     config.eviction_ratio = eviction_ratio_;
     config.eviction_high_watermark_ratio = eviction_high_watermark_ratio_;

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cmath>
 #include <optional>
 #include <stdexcept>
 #include <string_view>
@@ -19,6 +20,19 @@ struct ObjectTypeEvictionScorePolicy {
     double reuse_scale{1.0};
     double soft_pin_weight{1.0};
 };
+
+inline void ValidateObjectTypeEvictionScorePolicy(
+    const ObjectTypeEvictionScorePolicy& policy) {
+    if (!std::isfinite(policy.reuse_scale) || policy.reuse_scale <= 0.0) {
+        throw std::invalid_argument(
+            "reuse_scale must be finite and greater than 0");
+    }
+    if (!std::isfinite(policy.soft_pin_weight) ||
+        policy.soft_pin_weight < 0.0) {
+        throw std::invalid_argument(
+            "soft_pin_weight must be finite and non-negative");
+    }
+}
 
 inline std::string ResolveConfiguredHABackendConnstring(
     std::string_view ha_backend_type, std::string_view ha_backend_connstring,
@@ -693,9 +707,7 @@ class MasterServiceConfigBuilder {
 
     MasterServiceConfigBuilder& set_object_type_eviction_score_policy(
         ObjectDataType data_type, ObjectTypeEvictionScorePolicy policy) {
-        if (policy.reuse_scale <= 0.0) {
-            throw std::invalid_argument("reuse_scale must be greater than 0");
-        }
+        ValidateObjectTypeEvictionScorePolicy(policy);
         object_type_eviction_score_policies_[data_type] = policy;
         return *this;
     }

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1536,6 +1536,7 @@ class MasterService {
     const bool allow_evict_soft_pinned_objects_;
     std::array<double, UINT8_MAX + 1> object_type_reuse_scales_;
     std::array<double, UINT8_MAX + 1> object_type_soft_pin_weights_;
+    std::array<int64_t, UINT8_MAX + 1> object_type_eviction_graces_;
 
     // Eviction related members
     std::atomic<bool> need_mem_eviction_{

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1534,6 +1534,8 @@ class MasterService {
     const uint64_t default_kv_lease_ttl_;     // in milliseconds
     const uint64_t default_kv_soft_pin_ttl_;  // in milliseconds
     const bool allow_evict_soft_pinned_objects_;
+    std::array<double, 256> object_type_reuse_scales_;
+    std::array<double, 256> object_type_soft_pin_weights_;
 
     // Eviction related members
     std::atomic<bool> need_mem_eviction_{

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1534,8 +1534,8 @@ class MasterService {
     const uint64_t default_kv_lease_ttl_;     // in milliseconds
     const uint64_t default_kv_soft_pin_ttl_;  // in milliseconds
     const bool allow_evict_soft_pinned_objects_;
-    std::array<double, 256> object_type_reuse_scales_;
-    std::array<double, 256> object_type_soft_pin_weights_;
+    std::array<double, UINT8_MAX + 1> object_type_reuse_scales_;
+    std::array<double, UINT8_MAX + 1> object_type_soft_pin_weights_;
 
     // Eviction related members
     std::atomic<bool> need_mem_eviction_{

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -239,12 +239,14 @@ MasterService::MasterService(const MasterServiceConfig& config)
       offload_cap_ratio_(config.offload_cap_ratio) {
     object_type_reuse_scales_.fill(1.0);
     object_type_soft_pin_weights_.fill(1.0);
+    object_type_eviction_graces_.fill(0);
     for (const auto& [data_type, policy] :
          config.object_type_eviction_score_policies) {
         ValidateObjectTypeEvictionScorePolicy(policy);
         const auto idx = static_cast<uint8_t>(data_type);
         object_type_reuse_scales_[idx] = policy.reuse_scale;
         object_type_soft_pin_weights_[idx] = policy.soft_pin_weight;
+        object_type_eviction_graces_[idx] = policy.eviction_grace;
     }
 
     // Initialize HTTP metadata key prefix (read env var once at startup)
@@ -7160,11 +7162,12 @@ void MasterService::BatchEvict(double evict_ratio_target,
         const double reuse_scale = object_type_reuse_scales_[idx];
         const double weight =
             is_soft_pinned ? object_type_soft_pin_weights_[idx] : 1.0;
+        const int64_t eviction_grace = object_type_eviction_graces_[idx];
         auto expired_age =
             std::chrono::duration_cast<std::chrono::milliseconds>(
                 rank_reference_time - metadata.lease_timeout)
                 .count();
-        expired_age = std::max<int64_t>(expired_age, 0);
+        expired_age = std::max<int64_t>(expired_age - eviction_grace, 0);
         const double score = expired_age * weight / reuse_scale;
         if (!std::isfinite(score) ||
             score >= static_cast<double>(std::numeric_limits<int64_t>::max())) {

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -237,6 +237,15 @@ MasterService::MasterService(const MasterServiceConfig& config)
       enable_cxl_(config.enable_cxl),
       offloading_queue_limit_(config.offloading_queue_limit),
       offload_cap_ratio_(config.offload_cap_ratio) {
+    object_type_reuse_scales_.fill(1.0);
+    object_type_soft_pin_weights_.fill(1.0);
+    for (const auto& [data_type, policy] :
+         config.object_type_eviction_score_policies) {
+        const auto idx = static_cast<uint8_t>(data_type);
+        object_type_reuse_scales_[idx] = policy.reuse_scale;
+        object_type_soft_pin_weights_[idx] = policy.soft_pin_weight;
+    }
+
     // Initialize HTTP metadata key prefix (read env var once at startup)
     const char* custom_prefix = std::getenv("MC_METADATA_CLUSTER_ID");
     if (custom_prefix && std::strlen(custom_prefix) > 0) {
@@ -7139,6 +7148,23 @@ void MasterService::BatchEvict(double evict_ratio_target,
         std::string tenant_id;
         std::string key;
         std::chrono::system_clock::time_point lease_timeout;
+        int64_t adjusted_age;
+    };
+
+    const auto rank_reference_time = now;
+    auto adjusted_age = [this, rank_reference_time](
+                            const ObjectMetadata& metadata,
+                            bool is_soft_pinned) {
+        const auto idx = static_cast<uint8_t>(metadata.data_type);
+        const double reuse_scale = object_type_reuse_scales_[idx];
+        const double weight =
+            is_soft_pinned ? object_type_soft_pin_weights_[idx] : 1.0;
+        auto expired_age =
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+                rank_reference_time - metadata.lease_timeout)
+                .count();
+        expired_age = std::max<int64_t>(expired_age, 0);
+        return static_cast<int64_t>(expired_age * weight / reuse_scale);
     };
 
     // Randomly select a starting shard to avoid imbalance eviction between
@@ -7155,8 +7181,7 @@ void MasterService::BatchEvict(double evict_ratio_target,
     std::vector<std::vector<Candidate>> local_candidates(num_threads);
     std::vector<long> local_eviction_base(num_threads, 0);
     std::vector<long> local_object_count(num_threads, 0);
-    std::vector<std::vector<std::chrono::system_clock::time_point>>
-        local_soft_pin(num_threads);
+    std::vector<std::vector<int64_t>> local_soft_pin(num_threads);
 
     std::vector<std::thread> threads;
     for (int t = 0; t < num_threads; t++) {
@@ -7181,10 +7206,13 @@ void MasterService::BatchEvict(double evict_ratio_target,
                         if (!it->second.IsSoftPinned(now)) {
                             local_candidates[t].push_back(
                                 {s, tenant_id, it->first,
-                                 it->second.lease_timeout});
+                                 it->second.lease_timeout,
+                                 adjusted_age(it->second,
+                                              /*is_soft_pinned=*/false)});
                         } else if (allow_evict_soft_pinned_objects_) {
                             local_soft_pin[t].push_back(
-                                it->second.lease_timeout);
+                                adjusted_age(it->second,
+                                             /*is_soft_pinned=*/true));
                         }
                     }
                 }
@@ -7213,7 +7241,7 @@ void MasterService::BatchEvict(double evict_ratio_target,
                           std::make_move_iterator(v.end()));
     }
 
-    std::vector<std::chrono::system_clock::time_point> soft_pin_objects;
+    std::vector<int64_t> soft_pin_objects;
     {
         size_t total = 0;
         for (auto& v : local_soft_pin) total += v.size();
@@ -7235,7 +7263,7 @@ void MasterService::BatchEvict(double evict_ratio_target,
     // ===== Phase 2: Serial eviction via key lookup =====
     long evicted_count = 0;
     uint64_t total_freed_size = 0;
-    std::vector<std::chrono::system_clock::time_point> no_pin_objects;
+    std::vector<int64_t> no_pin_objects;
     std::vector<std::vector<Replica>> deferred_replicas;
 
     // First pass: evict candidates with no soft pin
@@ -7247,9 +7275,9 @@ void MasterService::BatchEvict(double evict_ratio_target,
         std::nth_element(candidates.begin(),
                          candidates.begin() + (evict_num - 1), candidates.end(),
                          [](const Candidate& a, const Candidate& b) {
-                             return a.lease_timeout < b.lease_timeout;
+                             return a.adjusted_age > b.adjusted_age;
                          });
-        auto target_timeout = candidates[evict_num - 1].lease_timeout;
+        auto target_adjusted_age = candidates[evict_num - 1].adjusted_age;
 
         // Treat evict_num as a minimum: if re-validation skips a candidate,
         // continue trying the next one so actual evicted count reaches
@@ -7257,8 +7285,8 @@ void MasterService::BatchEvict(double evict_ratio_target,
         long evicted_this_pass = 0;
         for (auto& c : candidates) {
             if (evicted_this_pass >= evict_num &&
-                c.lease_timeout > target_timeout) {
-                no_pin_objects.push_back(c.lease_timeout);
+                c.adjusted_age < target_adjusted_age) {
+                no_pin_objects.push_back(c.adjusted_age);
                 continue;
             }
             {
@@ -7272,7 +7300,7 @@ void MasterService::BatchEvict(double evict_ratio_target,
                 if (!it->second.IsLeaseExpired(now) ||
                     it->second.IsSoftPinned(now) ||
                     !can_evict_replicas(it->second)) {
-                    no_pin_objects.push_back(c.lease_timeout);
+                    no_pin_objects.push_back(c.adjusted_age);
                     continue;
                 }
                 auto evict_result = try_evict_group_or_object(
@@ -7315,8 +7343,9 @@ void MasterService::BatchEvict(double evict_ratio_target,
             // Second pass A: only evict objects without soft pin.
             std::nth_element(no_pin_objects.begin(),
                              no_pin_objects.begin() + (target_evict_num - 1),
-                             no_pin_objects.end());
-            auto target_timeout = no_pin_objects[target_evict_num - 1];
+                             no_pin_objects.end(),
+                             [](int64_t a, int64_t b) { return a > b; });
+            auto target_adjusted_age = no_pin_objects[target_evict_num - 1];
 
             // Evict via key lookup — avoid full metadata traversal
             for (size_t i = 0; i < kNumShards && target_evict_num > 0; i++) {
@@ -7332,7 +7361,9 @@ void MasterService::BatchEvict(double evict_ratio_target,
                                target_evict_num > 0) {
                             if (!it->second.IsHardPinned() &&
                                 it->second.IsLeaseExpired(now) &&
-                                it->second.lease_timeout <= target_timeout &&
+                                adjusted_age(it->second,
+                                             /*is_soft_pinned=*/false) >=
+                                    target_adjusted_age &&
                                 !it->second.IsSoftPinned(now) &&
                                 can_evict_replicas(it->second)) {
                                 auto evict_result = try_evict_group_or_object(
@@ -7371,8 +7402,10 @@ void MasterService::BatchEvict(double evict_ratio_target,
             std::nth_element(
                 soft_pin_objects.begin(),
                 soft_pin_objects.begin() + (soft_pin_evict_num - 1),
-                soft_pin_objects.end());
-            auto soft_target_timeout = soft_pin_objects[soft_pin_evict_num - 1];
+                soft_pin_objects.end(),
+                [](int64_t a, int64_t b) { return a > b; });
+            auto soft_target_adjusted_age =
+                soft_pin_objects[soft_pin_evict_num - 1];
 
             for (size_t i = 0; i < kNumShards && target_evict_num > 0; i++) {
                 {
@@ -7393,8 +7426,9 @@ void MasterService::BatchEvict(double evict_ratio_target,
                                 continue;
                             }
                             if (!it->second.IsSoftPinned(now) ||
-                                it->second.lease_timeout <=
-                                    soft_target_timeout) {
+                                adjusted_age(it->second,
+                                             /*is_soft_pinned=*/true) >=
+                                    soft_target_adjusted_age) {
                                 auto evict_result = try_evict_group_or_object(
                                     tenant_it->first, it->first, it->second,
                                     shard, tenant_state, deferred_replicas,

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -241,6 +241,7 @@ MasterService::MasterService(const MasterServiceConfig& config)
     object_type_soft_pin_weights_.fill(1.0);
     for (const auto& [data_type, policy] :
          config.object_type_eviction_score_policies) {
+        ValidateObjectTypeEvictionScorePolicy(policy);
         const auto idx = static_cast<uint8_t>(data_type);
         object_type_reuse_scales_[idx] = policy.reuse_scale;
         object_type_soft_pin_weights_[idx] = policy.soft_pin_weight;
@@ -7164,7 +7165,12 @@ void MasterService::BatchEvict(double evict_ratio_target,
                 rank_reference_time - metadata.lease_timeout)
                 .count();
         expired_age = std::max<int64_t>(expired_age, 0);
-        return static_cast<int64_t>(expired_age * weight / reuse_scale);
+        const double score = expired_age * weight / reuse_scale;
+        if (!std::isfinite(score) ||
+            score >= static_cast<double>(std::numeric_limits<int64_t>::max())) {
+            return std::numeric_limits<int64_t>::max();
+        }
+        return static_cast<int64_t>(score);
     };
 
     // Randomly select a starting shard to avoid imbalance eviction between

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -7163,11 +7163,12 @@ void MasterService::BatchEvict(double evict_ratio_target,
         const double weight =
             is_soft_pinned ? object_type_soft_pin_weights_[idx] : 1.0;
         const int64_t eviction_grace = object_type_eviction_graces_[idx];
-        auto expired_age =
+        const auto expired_age = std::max<int64_t>(
             std::chrono::duration_cast<std::chrono::milliseconds>(
                 rank_reference_time - metadata.lease_timeout)
-                .count();
-        expired_age = std::max<int64_t>(expired_age - eviction_grace, 0);
+                    .count() -
+                eviction_grace,
+            0);
         const double score = expired_age * weight / reuse_scale;
         if (!std::isfinite(score) ||
             score >= static_cast<double>(std::numeric_limits<int64_t>::max())) {

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -6911,19 +6911,20 @@ TEST_F(MasterServiceTest,
     auto builder = MasterServiceConfig::builder();
     EXPECT_THROW(
         builder.set_object_type_eviction_score_policy(
-            ObjectDataType::KVCACHE, ObjectTypeEvictionScorePolicy{1.0, -1.0}),
+            ObjectDataType::KVCACHE,
+            ObjectTypeEvictionScorePolicy{1.0, -1.0, 0}),
         std::invalid_argument);
 
     EXPECT_THROW(builder.set_object_type_eviction_score_policy(
                      ObjectDataType::KVCACHE,
                      ObjectTypeEvictionScorePolicy{
-                         std::numeric_limits<double>::quiet_NaN(), 1.0}),
+                         std::numeric_limits<double>::quiet_NaN(), 1.0, 0}),
                  std::invalid_argument);
 
     EXPECT_THROW(builder.set_object_type_eviction_score_policy(
                      ObjectDataType::KVCACHE,
                      ObjectTypeEvictionScorePolicy{
-                         1.0, std::numeric_limits<double>::infinity()}),
+                         1.0, std::numeric_limits<double>::infinity(), 0}),
                  std::invalid_argument);
 }
 
@@ -6931,16 +6932,16 @@ TEST_F(MasterServiceTest,
        ObjectTypeEvictionScorePolicyRejectsInvalidDirectConfigInput) {
     auto config = MasterServiceConfig::builder().build();
     config.object_type_eviction_score_policies[ObjectDataType::KVCACHE] =
-        ObjectTypeEvictionScorePolicy{0.0, 1.0};
+        ObjectTypeEvictionScorePolicy{0.0, 1.0, 0};
     EXPECT_THROW({ MasterService service(config); }, std::invalid_argument);
 
     config.object_type_eviction_score_policies[ObjectDataType::KVCACHE] =
-        ObjectTypeEvictionScorePolicy{1.0, -1.0};
+        ObjectTypeEvictionScorePolicy{1.0, -1.0, 0};
     EXPECT_THROW({ MasterService service(config); }, std::invalid_argument);
 
     config.object_type_eviction_score_policies[ObjectDataType::KVCACHE] =
         ObjectTypeEvictionScorePolicy{std::numeric_limits<double>::infinity(),
-                                      1.0};
+                                      1.0, 0};
     EXPECT_THROW({ MasterService service(config); }, std::invalid_argument);
 }
 

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -11,6 +11,7 @@
 #include <filesystem>
 #include <fstream>
 #include <functional>
+#include <limits>
 #include <map>
 #include <memory>
 #include <random>
@@ -6903,6 +6904,44 @@ TEST_F(MasterServiceTest, HardPinWithSoftPinEvictionOrder) {
 
     std::this_thread::sleep_for(std::chrono::milliseconds(kv_lease_ttl));
     service_->RemoveAll();
+}
+
+TEST_F(MasterServiceTest,
+       ObjectTypeEvictionScorePolicyRejectsInvalidBuilderInput) {
+    auto builder = MasterServiceConfig::builder();
+    EXPECT_THROW(
+        builder.set_object_type_eviction_score_policy(
+            ObjectDataType::KVCACHE, ObjectTypeEvictionScorePolicy{1.0, -1.0}),
+        std::invalid_argument);
+
+    EXPECT_THROW(builder.set_object_type_eviction_score_policy(
+                     ObjectDataType::KVCACHE,
+                     ObjectTypeEvictionScorePolicy{
+                         std::numeric_limits<double>::quiet_NaN(), 1.0}),
+                 std::invalid_argument);
+
+    EXPECT_THROW(builder.set_object_type_eviction_score_policy(
+                     ObjectDataType::KVCACHE,
+                     ObjectTypeEvictionScorePolicy{
+                         1.0, std::numeric_limits<double>::infinity()}),
+                 std::invalid_argument);
+}
+
+TEST_F(MasterServiceTest,
+       ObjectTypeEvictionScorePolicyRejectsInvalidDirectConfigInput) {
+    auto config = MasterServiceConfig::builder().build();
+    config.object_type_eviction_score_policies[ObjectDataType::KVCACHE] =
+        ObjectTypeEvictionScorePolicy{0.0, 1.0};
+    EXPECT_THROW({ MasterService service(config); }, std::invalid_argument);
+
+    config.object_type_eviction_score_policies[ObjectDataType::KVCACHE] =
+        ObjectTypeEvictionScorePolicy{1.0, -1.0};
+    EXPECT_THROW({ MasterService service(config); }, std::invalid_argument);
+
+    config.object_type_eviction_score_policies[ObjectDataType::KVCACHE] =
+        ObjectTypeEvictionScorePolicy{std::numeric_limits<double>::infinity(),
+                                      1.0};
+    EXPECT_THROW({ MasterService service(config); }, std::invalid_argument);
 }
 
 TEST_F(MasterServiceTest, HardPinDefaultIsFalse) {

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -6909,11 +6909,10 @@ TEST_F(MasterServiceTest, HardPinWithSoftPinEvictionOrder) {
 TEST_F(MasterServiceTest,
        ObjectTypeEvictionScorePolicyRejectsInvalidBuilderInput) {
     auto builder = MasterServiceConfig::builder();
-    EXPECT_THROW(
-        builder.set_object_type_eviction_score_policy(
-            ObjectDataType::KVCACHE,
-            ObjectTypeEvictionScorePolicy{1.0, -1.0, 0}),
-        std::invalid_argument);
+    EXPECT_THROW(builder.set_object_type_eviction_score_policy(
+                     ObjectDataType::KVCACHE,
+                     ObjectTypeEvictionScorePolicy{1.0, -1.0, 0}),
+                 std::invalid_argument);
 
     EXPECT_THROW(builder.set_object_type_eviction_score_policy(
                      ObjectDataType::KVCACHE,
@@ -6940,8 +6939,8 @@ TEST_F(MasterServiceTest,
     EXPECT_THROW({ MasterService service(config); }, std::invalid_argument);
 
     config.object_type_eviction_score_policies[ObjectDataType::KVCACHE] =
-        ObjectTypeEvictionScorePolicy{std::numeric_limits<double>::infinity(),
-                                      1.0, 0};
+        ObjectTypeEvictionScorePolicy{
+            std::numeric_limits<double>::infinity(), 1.0, 0};
     EXPECT_THROW({ MasterService service(config); }, std::invalid_argument);
 }
 

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -6939,8 +6939,8 @@ TEST_F(MasterServiceTest,
     EXPECT_THROW({ MasterService service(config); }, std::invalid_argument);
 
     config.object_type_eviction_score_policies[ObjectDataType::KVCACHE] =
-        ObjectTypeEvictionScorePolicy{
-            std::numeric_limits<double>::infinity(), 1.0, 0};
+        ObjectTypeEvictionScorePolicy{std::numeric_limits<double>::infinity(),
+                                      1.0, 0};
     EXPECT_THROW({ MasterService service(config); }, std::invalid_argument);
 }
 


### PR DESCRIPTION
## Description

This is split optimization version 2/4 of the original PR: https://github.com/kvcache-ai/Mooncake/pull/2689.

This PR adds the master-side foundation for comparing memory eviction pressure across object types in Mooncake Store. It introduces `ObjectTypeEvictionScorePolicy`, which provides `reuse_scale`, `soft_pin_weight`, and `eviction_grace` scoring parameters for different `ObjectDataType` values, and changes memory eviction ranking from comparing raw `lease_timeout` to comparing normalized `adjusted_age`.

This is the second step split out from the original Hidden State type-aware eviction PR. This PR only introduces the object-type-aware eviction ranking foundation. It does not add new object types, change object metadata format, change the default lease TTL, or change quota/offload/NoF eviction behavior. Under the default policy, all object types use `reuse_scale = 1.0`, `soft_pin_weight = 1.0`, and `eviction_grace = 0`, so eviction ordering remains equivalent to the old lease-timeout logic when no policy is explicitly configured.

Design rationale:

- Hidden State, KV Cache, and other object types can have different reuse intervals and reuse value. If eviction uses only a unified `lease_timeout`, some object types can be unfairly disadvantaged in LRU-style eviction competition.
- The scoring policy should stay generic and not be hard-coded to `HIDDEN_STATE` or any specific upper-layer integration. Follow-up PRs can reuse the same `ObjectDataType` metadata to configure policies for Hidden State, KV Cache, model weights, or other object types.
- `eviction_grace` adjusts eviction ranking only. It does not extend or shorten the actual lease timeout used for transfer protection or remove protection.
- Defaults must preserve old behavior to avoid behavior changes for existing deployments that do not configure object-type policies.

Main changes:

- Add `ObjectTypeEvictionScorePolicy`, containing:
  - `reuse_scale`: lowers eviction priority for objects with higher reuse value. Default: `1.0`.
  - `soft_pin_weight`: adjusts scoring for soft-pinned objects when they are allowed to be evicted. Default: `1.0`.
  - `eviction_grace`: shifts the eviction ranking age for an object type without changing the real lease timeout. Positive values delay eviction ranking; negative values accelerate eviction ranking. Default: `0`.
- Add the `object_type_eviction_score_policies` configuration entry to `MasterServiceConfig` and `MasterServiceConfigBuilder`.
- Validate `reuse_scale > 0.0` in the builder to avoid invalid division or meaningless scoring policies.
- Expand object type policies into `UINT8_MAX + 1` index slots during `MasterService` initialization. Unconfigured object types keep the default values.
- Change `BatchEvict` candidate ranking from raw `lease_timeout` to:

```text
adjusted_age =
    max(0, rank_reference_time - lease_timeout - eviction_grace)
    * soft_pin_weight / reuse_scale
```

- `rank_reference_time` is the baseline time captured at the beginning of ranking. `eviction_grace` adjusts the ranking age only; it does not change the actual lease timeout. `reuse_scale` normalizes reuse intervals across object types, and `soft_pin_weight` adjusts the value of soft-pinned objects.
- Non-soft-pinned objects use `soft_pin_weight = 1.0`. Soft-pinned objects only enter the second-stage candidates when `allow_evict_soft_pinned_objects` is enabled, and then use the configured `soft_pin_weight` for their object type.
- The first pass without soft pin, the second pass without soft pin, and the second pass with soft pin now all prioritize objects with larger `adjusted_age`.

Compatibility notes:

- This PR does not change the conditions for whether an object is expired or eligible for eviction. Objects still need to satisfy the existing lease-expired, non-hard-pinned, and evictable-replica conditions before entering the candidate set.
- This PR does not change the actual lease duration or lease protection semantics. `eviction_grace` only affects eviction ranking after the existing lease-expired eligibility check.
- This PR does not change `eviction_ratio`, `eviction_high_watermark_ratio`, quota, offload, promotion, or NoF eviction policy.
- When all object types use `reuse_scale = 1.0`, `soft_pin_weight = 1.0`, and `eviction_grace = 0`, `adjusted_age` is equivalent to the old `lease_timeout` ordering and still prioritizes objects whose lease expired earlier.
- The implementation stays within the existing eviction flow. It only computes `adjusted_age` during candidate collection and comparison, continues to use the existing linear scan and `std::nth_element` threshold selection, and does not introduce a full sort. Candidate selection/scanning remains the same complexity class as the old implementation, `O(N)`.
- This PR only provides the master-side internal configuration and ranking foundation. CLI, config-file, or upper-layer integration policy wiring can be added by follow-up PRs.

## Module

- [ ]  Transfer Engine (`mooncake-transfer-engine`)
- [X]  Mooncake Store (`mooncake-store`)
- [ ]  Mooncake EP (`mooncake-ep`)
- [ ]  Mooncake PG (`mooncake-pg`)
- [ ]  Integration (`mooncake-integration`)
- [ ]  P2P Store (`mooncake-p2p-store`)
- [ ]  Python Wheel (`mooncake-wheel`)
- [ ]  Common (`mooncake-common`)
- [ ]  Mooncake RL (`mooncake-rl`)
- [ ]  CI/CD
- [ ]  Docs
- [ ]  Other

## Type of Changes

- [ ]  Bug fix
- [X]  New feature
- [ ]  Refactor
- [ ]  Breaking change
- [ ]  Documentation update
- [ ]  Performance improvement
- [ ]  Other

## How Has This Been Tested?

This PR mainly changes candidate ranking in `BatchEvict` while keeping the default policy equivalent to the old lease-timeout ordering. Recommended coverage includes existing master service and object type related tests:

- Under the default policy, existing memory eviction paths should keep their old behavior when no object-type score policy is configured.
- For an object type configured with `reuse_scale > 1.0`, the same ranking age produces a smaller `adjusted_age`, lowering its eviction priority.
- For an object type configured with positive `eviction_grace`, the same lease timeout produces a smaller ranking age, lowering its eviction priority.
- For an object type configured with negative `eviction_grace`, the same lease timeout produces a larger ranking age, raising its eviction priority.
- Configuring an invalid `reuse_scale <= 0.0` should be rejected by the builder.
- Soft-pinned objects should still participate in the second eviction stage only when `allow_evict_soft_pinned_objects` is enabled.

Commands:

```bash
ninja -C build-docker mooncake-store/tests/master_service_test
./build-docker/mooncake-store/tests/master_service_test
ninja -C build-docker mooncake-store/tests/object_data_type_test
./build-docker/mooncake-store/tests/object_data_type_test
```

Additional static check:

```bash
git diff --check origin/main..origin/pr2-step-adjusted-lease-timeout-policy
```

## Checklist

- [X]  I have performed a self-review of my own code
- [X]  I have formatted my code using `./scripts/code_format.sh`
- [ ]  I have run `pre-commit run --all-files` and all hooks pass
- [ ]  I have updated the documentation (if applicable)
- [X]  I have added tests to prove my changes are effective
- [ ]  For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ]  No AI tools were used
- [X]  AI tools were used
