### PR TITLE
[Store] object type eviction policy

### DIFF
--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -1784,6 +1784,7 @@ PYBIND11_MODULE(store, m) {
         .value("OPTIMIZER_STATE", ObjectDataType::OPTIMIZER_STATE)
         .value("METADATA", ObjectDataType::METADATA)
         .value("GENERAL", ObjectDataType::GENERAL)
+        .value("HIDDEN_STATE", ObjectDataType::HIDDEN_STATE)
         .export_values();
 
     // Define the ReplicateConfig class

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -19,6 +19,7 @@ class HttpMetadataServer;
 struct ObjectTypeEvictionScorePolicy {
     double reuse_scale{1.0};
     double soft_pin_weight{1.0};
+    int64_t eviction_grace{0};
 };
 
 inline void ValidateObjectTypeEvictionScorePolicy(

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -22,6 +22,10 @@ struct ObjectTypeEvictionScorePolicy {
     int64_t eviction_grace{0};
 };
 
+struct ObjectTypeEvictionPolicy {
+    double budget_ratio{1.0};
+};
+
 inline void ValidateObjectTypeEvictionScorePolicy(
     const ObjectTypeEvictionScorePolicy& policy) {
     if (!std::isfinite(policy.reuse_scale) || policy.reuse_scale <= 0.0) {
@@ -640,6 +644,8 @@ class MasterServiceConfigBuilder {
     uint64_t default_kv_soft_pin_ttl_ = DEFAULT_KV_SOFT_PIN_TTL_MS;
     std::unordered_map<ObjectDataType, ObjectTypeEvictionScorePolicy>
         object_type_eviction_score_policies_;
+    std::unordered_map<ObjectDataType, ObjectTypeEvictionPolicy>
+        object_type_eviction_policies_;
     bool allow_evict_soft_pinned_objects_ =
         DEFAULT_ALLOW_EVICT_SOFT_PINNED_OBJECTS;
     double eviction_ratio_ = DEFAULT_EVICTION_RATIO;
@@ -710,6 +716,15 @@ class MasterServiceConfigBuilder {
         ObjectDataType data_type, ObjectTypeEvictionScorePolicy policy) {
         ValidateObjectTypeEvictionScorePolicy(policy);
         object_type_eviction_score_policies_[data_type] = policy;
+        return *this;
+    }
+
+    MasterServiceConfigBuilder& set_object_type_eviction_policy(
+        ObjectDataType data_type, ObjectTypeEvictionPolicy policy) {
+        if (policy.budget_ratio < 0.0) {
+            throw std::invalid_argument("budget_ratio must be non-negative");
+        }
+        object_type_eviction_policies_[data_type] = policy;
         return *this;
     }
 
@@ -987,6 +1002,8 @@ class MasterServiceConfig {
     uint64_t default_kv_soft_pin_ttl = DEFAULT_KV_SOFT_PIN_TTL_MS;
     std::unordered_map<ObjectDataType, ObjectTypeEvictionScorePolicy>
         object_type_eviction_score_policies;
+    std::unordered_map<ObjectDataType, ObjectTypeEvictionPolicy>
+        object_type_eviction_policies;
     bool allow_evict_soft_pinned_objects =
         DEFAULT_ALLOW_EVICT_SOFT_PINNED_OBJECTS;
     double eviction_ratio = DEFAULT_EVICTION_RATIO;
@@ -1135,6 +1152,7 @@ inline MasterServiceConfig MasterServiceConfigBuilder::build() const {
     config.default_kv_soft_pin_ttl = default_kv_soft_pin_ttl_;
     config.object_type_eviction_score_policies =
         object_type_eviction_score_policies_;
+    config.object_type_eviction_policies = object_type_eviction_policies_;
     config.allow_evict_soft_pinned_objects = allow_evict_soft_pinned_objects_;
     config.eviction_ratio = eviction_ratio_;
     config.eviction_high_watermark_ratio = eviction_high_watermark_ratio_;

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -3,6 +3,7 @@
 #include <optional>
 #include <stdexcept>
 #include <string_view>
+#include <unordered_map>
 
 #include <glog/logging.h>
 
@@ -13,6 +14,11 @@ namespace mooncake {
 
 // Forwarded to the HA serve phase via MasterServiceSupervisorConfig.
 class HttpMetadataServer;
+
+struct ObjectTypeEvictionScorePolicy {
+    double reuse_scale{1.0};
+    double soft_pin_weight{1.0};
+};
 
 inline std::string ResolveConfiguredHABackendConnstring(
     std::string_view ha_backend_type, std::string_view ha_backend_connstring,
@@ -617,6 +623,8 @@ class MasterServiceConfigBuilder {
    private:
     uint64_t default_kv_lease_ttl_ = DEFAULT_DEFAULT_KV_LEASE_TTL;
     uint64_t default_kv_soft_pin_ttl_ = DEFAULT_KV_SOFT_PIN_TTL_MS;
+    std::unordered_map<ObjectDataType, ObjectTypeEvictionScorePolicy>
+        object_type_eviction_score_policies_;
     bool allow_evict_soft_pinned_objects_ =
         DEFAULT_ALLOW_EVICT_SOFT_PINNED_OBJECTS;
     double eviction_ratio_ = DEFAULT_EVICTION_RATIO;
@@ -680,6 +688,15 @@ class MasterServiceConfigBuilder {
 
     MasterServiceConfigBuilder& set_default_kv_soft_pin_ttl(uint64_t ttl) {
         default_kv_soft_pin_ttl_ = ttl;
+        return *this;
+    }
+
+    MasterServiceConfigBuilder& set_object_type_eviction_score_policy(
+        ObjectDataType data_type, ObjectTypeEvictionScorePolicy policy) {
+        if (policy.reuse_scale <= 0.0) {
+            throw std::invalid_argument("reuse_scale must be greater than 0");
+        }
+        object_type_eviction_score_policies_[data_type] = policy;
         return *this;
     }
 
@@ -955,6 +972,8 @@ class MasterServiceConfig {
    public:
     uint64_t default_kv_lease_ttl = DEFAULT_DEFAULT_KV_LEASE_TTL;
     uint64_t default_kv_soft_pin_ttl = DEFAULT_KV_SOFT_PIN_TTL_MS;
+    std::unordered_map<ObjectDataType, ObjectTypeEvictionScorePolicy>
+        object_type_eviction_score_policies;
     bool allow_evict_soft_pinned_objects =
         DEFAULT_ALLOW_EVICT_SOFT_PINNED_OBJECTS;
     double eviction_ratio = DEFAULT_EVICTION_RATIO;
@@ -1101,6 +1120,8 @@ inline MasterServiceConfig MasterServiceConfigBuilder::build() const {
     MasterServiceConfig config;
     config.default_kv_lease_ttl = default_kv_lease_ttl_;
     config.default_kv_soft_pin_ttl = default_kv_soft_pin_ttl_;
+    config.object_type_eviction_score_policies =
+        object_type_eviction_score_policies_;
     config.allow_evict_soft_pinned_objects = allow_evict_soft_pinned_objects_;
     config.eviction_ratio = eviction_ratio_;
     config.eviction_high_watermark_ratio = eviction_high_watermark_ratio_;

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cmath>
 #include <optional>
 #include <stdexcept>
 #include <string_view>
@@ -19,6 +20,19 @@ struct ObjectTypeEvictionScorePolicy {
     double reuse_scale{1.0};
     double soft_pin_weight{1.0};
 };
+
+inline void ValidateObjectTypeEvictionScorePolicy(
+    const ObjectTypeEvictionScorePolicy& policy) {
+    if (!std::isfinite(policy.reuse_scale) || policy.reuse_scale <= 0.0) {
+        throw std::invalid_argument(
+            "reuse_scale must be finite and greater than 0");
+    }
+    if (!std::isfinite(policy.soft_pin_weight) ||
+        policy.soft_pin_weight < 0.0) {
+        throw std::invalid_argument(
+            "soft_pin_weight must be finite and non-negative");
+    }
+}
 
 inline std::string ResolveConfiguredHABackendConnstring(
     std::string_view ha_backend_type, std::string_view ha_backend_connstring,
@@ -693,9 +707,7 @@ class MasterServiceConfigBuilder {
 
     MasterServiceConfigBuilder& set_object_type_eviction_score_policy(
         ObjectDataType data_type, ObjectTypeEvictionScorePolicy policy) {
-        if (policy.reuse_scale <= 0.0) {
-            throw std::invalid_argument("reuse_scale must be greater than 0");
-        }
+        ValidateObjectTypeEvictionScorePolicy(policy);
         object_type_eviction_score_policies_[data_type] = policy;
         return *this;
     }

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -64,6 +64,10 @@ struct MasterConfig {
 
     uint64_t default_kv_lease_ttl;
     uint64_t default_kv_soft_pin_ttl;
+    std::unordered_map<ObjectDataType, ObjectTypeEvictionScorePolicy>
+        object_type_eviction_score_policies;
+    std::unordered_map<ObjectDataType, ObjectTypeEvictionPolicy>
+        object_type_eviction_policies;
     bool allow_evict_soft_pinned_objects;
     double eviction_ratio;
     double eviction_high_watermark_ratio;
@@ -166,6 +170,10 @@ class MasterServiceSupervisorConfig {
     RequiredParam<int> metrics_port{"metrics_port"};
     RequiredParam<int64_t> default_kv_lease_ttl{"default_kv_lease_ttl"};
     RequiredParam<int64_t> default_kv_soft_pin_ttl{"default_kv_soft_pin_ttl"};
+    std::unordered_map<ObjectDataType, ObjectTypeEvictionScorePolicy>
+        object_type_eviction_score_policies;
+    std::unordered_map<ObjectDataType, ObjectTypeEvictionPolicy>
+        object_type_eviction_policies;
     RequiredParam<bool> allow_evict_soft_pinned_objects{
         "allow_evict_soft_pinned_objects"};
     RequiredParam<double> eviction_ratio{"eviction_ratio"};
@@ -257,6 +265,9 @@ class MasterServiceSupervisorConfig {
         metrics_port = static_cast<int>(config.metrics_port);
         default_kv_lease_ttl = config.default_kv_lease_ttl;
         default_kv_soft_pin_ttl = config.default_kv_soft_pin_ttl;
+        object_type_eviction_score_policies =
+            config.object_type_eviction_score_policies;
+        object_type_eviction_policies = config.object_type_eviction_policies;
         allow_evict_soft_pinned_objects =
             config.allow_evict_soft_pinned_objects;
         eviction_ratio = config.eviction_ratio;
@@ -401,6 +412,10 @@ class WrappedMasterServiceConfig {
 
     // Optional parameters (with default values)
     uint64_t default_kv_soft_pin_ttl = DEFAULT_KV_SOFT_PIN_TTL_MS;
+    std::unordered_map<ObjectDataType, ObjectTypeEvictionScorePolicy>
+        object_type_eviction_score_policies;
+    std::unordered_map<ObjectDataType, ObjectTypeEvictionPolicy>
+        object_type_eviction_policies;
     bool allow_evict_soft_pinned_objects =
         DEFAULT_ALLOW_EVICT_SOFT_PINNED_OBJECTS;
     bool enable_metric_reporting = true;
@@ -476,6 +491,9 @@ class WrappedMasterServiceConfig {
 
         // Set optional parameters (these have default values)
         default_kv_soft_pin_ttl = config.default_kv_soft_pin_ttl;
+        object_type_eviction_score_policies =
+            config.object_type_eviction_score_policies;
+        object_type_eviction_policies = config.object_type_eviction_policies;
         allow_evict_soft_pinned_objects =
             config.allow_evict_soft_pinned_objects;
         enable_metric_reporting = config.enable_metric_reporting;
@@ -573,6 +591,9 @@ class WrappedMasterServiceConfig {
 
         // Set optional parameters (these have default values)
         default_kv_soft_pin_ttl = config.default_kv_soft_pin_ttl;
+        object_type_eviction_score_policies =
+            config.object_type_eviction_score_policies;
+        object_type_eviction_policies = config.object_type_eviction_policies;
         allow_evict_soft_pinned_objects =
             config.allow_evict_soft_pinned_objects;
         enable_metric_reporting = config.enable_metric_reporting;
@@ -1075,6 +1096,9 @@ class MasterServiceConfig {
 
         default_kv_lease_ttl = config.default_kv_lease_ttl;
         default_kv_soft_pin_ttl = config.default_kv_soft_pin_ttl;
+        object_type_eviction_score_policies =
+            config.object_type_eviction_score_policies;
+        object_type_eviction_policies = config.object_type_eviction_policies;
         allow_evict_soft_pinned_objects =
             config.allow_evict_soft_pinned_objects;
         eviction_ratio = config.eviction_ratio;

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -26,6 +26,14 @@ struct ObjectTypeEvictionPolicy {
     double budget_ratio{1.0};
 };
 
+inline void ValidateObjectTypeEvictionPolicy(
+    const ObjectTypeEvictionPolicy& policy) {
+    if (!std::isfinite(policy.budget_ratio) || policy.budget_ratio < 0.0) {
+        throw std::invalid_argument(
+            "budget_ratio must be finite and non-negative");
+    }
+}
+
 inline void ValidateObjectTypeEvictionScorePolicy(
     const ObjectTypeEvictionScorePolicy& policy) {
     if (!std::isfinite(policy.reuse_scale) || policy.reuse_scale <= 0.0) {
@@ -742,9 +750,7 @@ class MasterServiceConfigBuilder {
 
     MasterServiceConfigBuilder& set_object_type_eviction_policy(
         ObjectDataType data_type, ObjectTypeEvictionPolicy policy) {
-        if (policy.budget_ratio < 0.0) {
-            throw std::invalid_argument("budget_ratio must be non-negative");
-        }
+        ValidateObjectTypeEvictionPolicy(policy);
         object_type_eviction_policies_[data_type] = policy;
         return *this;
     }

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -28,9 +28,10 @@ struct ObjectTypeEvictionPolicy {
 
 inline void ValidateObjectTypeEvictionPolicy(
     const ObjectTypeEvictionPolicy& policy) {
-    if (!std::isfinite(policy.budget_ratio) || policy.budget_ratio < 0.0) {
+    if (!std::isfinite(policy.budget_ratio) || policy.budget_ratio < 0.0 ||
+        policy.budget_ratio > 1.0) {
         throw std::invalid_argument(
-            "budget_ratio must be finite and non-negative");
+            "budget_ratio must be finite and between 0.0 and 1.0");
     }
 }
 

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1536,6 +1536,7 @@ class MasterService {
     const bool allow_evict_soft_pinned_objects_;
     std::array<double, UINT8_MAX + 1> object_type_reuse_scales_;
     std::array<double, UINT8_MAX + 1> object_type_soft_pin_weights_;
+    std::array<int64_t, UINT8_MAX + 1> object_type_eviction_graces_;
 
     // Eviction related members
     std::atomic<bool> need_mem_eviction_{

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1534,6 +1534,8 @@ class MasterService {
     const uint64_t default_kv_lease_ttl_;     // in milliseconds
     const uint64_t default_kv_soft_pin_ttl_;  // in milliseconds
     const bool allow_evict_soft_pinned_objects_;
+    std::array<double, 256> object_type_reuse_scales_;
+    std::array<double, 256> object_type_soft_pin_weights_;
 
     // Eviction related members
     std::atomic<bool> need_mem_eviction_{

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1537,6 +1537,7 @@ class MasterService {
     std::array<double, UINT8_MAX + 1> object_type_reuse_scales_;
     std::array<double, UINT8_MAX + 1> object_type_soft_pin_weights_;
     std::array<int64_t, UINT8_MAX + 1> object_type_eviction_graces_;
+    std::array<double, UINT8_MAX + 1> object_type_budget_ratios_;
 
     // Eviction related members
     std::atomic<bool> need_mem_eviction_{

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1534,8 +1534,8 @@ class MasterService {
     const uint64_t default_kv_lease_ttl_;     // in milliseconds
     const uint64_t default_kv_soft_pin_ttl_;  // in milliseconds
     const bool allow_evict_soft_pinned_objects_;
-    std::array<double, 256> object_type_reuse_scales_;
-    std::array<double, 256> object_type_soft_pin_weights_;
+    std::array<double, UINT8_MAX + 1> object_type_reuse_scales_;
+    std::array<double, UINT8_MAX + 1> object_type_soft_pin_weights_;
 
     // Eviction related members
     std::atomic<bool> need_mem_eviction_{

--- a/mooncake-store/include/types.h
+++ b/mooncake-store/include/types.h
@@ -147,7 +147,8 @@ enum class ObjectDataType : uint8_t {
     OPTIMIZER_STATE = 7,
     METADATA = 8,
     GENERAL = 9,
-    // 10-255 reserved for future types
+    HIDDEN_STATE = 10,
+    // 11-255 reserved for future types
 };
 
 inline std::ostream& operator<<(std::ostream& os,
@@ -162,7 +163,8 @@ inline std::ostream& operator<<(std::ostream& os,
                      {ObjectDataType::GRADIENT, "GRADIENT"},
                      {ObjectDataType::OPTIMIZER_STATE, "OPTIMIZER_STATE"},
                      {ObjectDataType::METADATA, "METADATA"},
-                     {ObjectDataType::GENERAL, "GENERAL"}};
+                     {ObjectDataType::GENERAL, "GENERAL"},
+                     {ObjectDataType::HIDDEN_STATE, "HIDDEN_STATE"}};
 
     auto it = type_strings.find(type);
     os << (it != type_strings.end() ? it->second : "UNKNOWN");

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -3,9 +3,12 @@
 
 #include <atomic>  // For std::atomic
 #include <chrono>  // For std::chrono
+#include <cmath>
+#include <cstdint>
 #include <csignal>
 #include <cstdlib>  // For std::getenv
 #include <fstream>  // For std::ifstream
+#include <limits>
 #include <memory>   // For std::unique_ptr
 #include <string>
 #include <thread>  // For std::thread
@@ -62,6 +65,13 @@ uint64_t ParseDurationFlagOrDie(const char* flag_name,
                    << ". " << error;
     }
     return parsed_value;
+}
+
+bool TryGetDoubleConfig(const mooncake::DefaultConfig& default_config,
+                        const std::string& key, double* value) {
+    const double missing = std::numeric_limits<double>::quiet_NaN();
+    default_config.GetDouble(key, value, missing);
+    return !std::isnan(*value);
 }
 
 // Derive the metadata server address for cleanup when it is deployed
@@ -427,6 +437,47 @@ void InitMasterConf(const mooncake::DefaultConfig& default_config,
     default_config.GetBool("allow_evict_soft_pinned_objects",
                            &master_config.allow_evict_soft_pinned_objects,
                            FLAGS_allow_evict_soft_pinned_objects);
+    for (uint16_t type_id = 0; type_id <= UINT8_MAX; ++type_id) {
+        const auto data_type =
+            static_cast<mooncake::ObjectDataType>(static_cast<uint8_t>(type_id));
+        const std::string type_key = std::to_string(type_id);
+
+        double reuse_scale = 0.0;
+        if (TryGetDoubleConfig(default_config,
+                               "object_type_eviction_score_policies." +
+                                   type_key + ".reuse_scale",
+                               &reuse_scale)) {
+            if (reuse_scale <= 0.0) {
+                LOG(FATAL)
+                    << "object_type_eviction_score_policies." << type_key
+                    << ".reuse_scale must be greater than 0";
+            }
+            master_config.object_type_eviction_score_policies[data_type]
+                .reuse_scale = reuse_scale;
+        }
+
+        double soft_pin_weight = 0.0;
+        if (TryGetDoubleConfig(default_config,
+                               "object_type_eviction_score_policies." +
+                                   type_key + ".soft_pin_weight",
+                               &soft_pin_weight)) {
+            master_config.object_type_eviction_score_policies[data_type]
+                .soft_pin_weight = soft_pin_weight;
+        }
+
+        double budget_ratio = 0.0;
+        if (TryGetDoubleConfig(default_config,
+                               "object_type_eviction_policies." + type_key +
+                                   ".budget_ratio",
+                               &budget_ratio)) {
+            if (budget_ratio < 0.0) {
+                LOG(FATAL) << "object_type_eviction_policies." << type_key
+                           << ".budget_ratio must be non-negative";
+            }
+            master_config.object_type_eviction_policies[data_type]
+                .budget_ratio = budget_ratio;
+        }
+    }
     default_config.GetDouble("eviction_ratio", &master_config.eviction_ratio,
                              FLAGS_eviction_ratio);
     default_config.GetDouble("eviction_high_watermark_ratio",

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -69,9 +69,9 @@ uint64_t ParseDurationFlagOrDie(const char* flag_name,
 
 bool TryGetDoubleConfig(const mooncake::DefaultConfig& default_config,
                         const std::string& key, double* value) {
-    const double missing = std::numeric_limits<double>::quiet_NaN();
+    const double missing = std::numeric_limits<double>::lowest();
     default_config.GetDouble(key, value, missing);
-    return !std::isnan(*value);
+    return *value != missing;
 }
 
 // Derive the metadata server address for cleanup when it is deployed
@@ -442,17 +442,15 @@ void InitMasterConf(const mooncake::DefaultConfig& default_config,
             static_cast<uint8_t>(type_id));
         const std::string type_key = std::to_string(type_id);
 
+        bool has_score_policy = false;
+        mooncake::ObjectTypeEvictionScorePolicy score_policy;
         double reuse_scale = 0.0;
         if (TryGetDoubleConfig(default_config,
                                "object_type_eviction_score_policies." +
                                    type_key + ".reuse_scale",
                                &reuse_scale)) {
-            if (reuse_scale <= 0.0) {
-                LOG(FATAL) << "object_type_eviction_score_policies." << type_key
-                           << ".reuse_scale must be greater than 0";
-            }
-            master_config.object_type_eviction_score_policies[data_type]
-                .reuse_scale = reuse_scale;
+            score_policy.reuse_scale = reuse_scale;
+            has_score_policy = true;
         }
 
         double soft_pin_weight = 0.0;
@@ -460,8 +458,25 @@ void InitMasterConf(const mooncake::DefaultConfig& default_config,
                                "object_type_eviction_score_policies." +
                                    type_key + ".soft_pin_weight",
                                &soft_pin_weight)) {
-            master_config.object_type_eviction_score_policies[data_type]
-                .soft_pin_weight = soft_pin_weight;
+            score_policy.soft_pin_weight = soft_pin_weight;
+            has_score_policy = true;
+        }
+
+        const int64_t missing_eviction_grace =
+            std::numeric_limits<int64_t>::min();
+        int64_t eviction_grace = missing_eviction_grace;
+        default_config.GetInt64("object_type_eviction_score_policies." +
+                                    type_key + ".eviction_grace",
+                                &eviction_grace, missing_eviction_grace);
+        if (eviction_grace != missing_eviction_grace) {
+            score_policy.eviction_grace = eviction_grace;
+            has_score_policy = true;
+        }
+
+        if (has_score_policy) {
+            mooncake::ValidateObjectTypeEvictionScorePolicy(score_policy);
+            master_config.object_type_eviction_score_policies[data_type] =
+                score_policy;
         }
 
         double budget_ratio = 0.0;

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -469,9 +469,9 @@ void InitMasterConf(const mooncake::DefaultConfig& default_config,
                 default_config,
                 "object_type_eviction_policies." + type_key + ".budget_ratio",
                 &budget_ratio)) {
-            if (budget_ratio < 0.0) {
+            if (!std::isfinite(budget_ratio) || budget_ratio < 0.0) {
                 LOG(FATAL) << "object_type_eviction_policies." << type_key
-                           << ".budget_ratio must be non-negative";
+                           << ".budget_ratio must be finite and non-negative";
             }
             master_config.object_type_eviction_policies[data_type]
                 .budget_ratio = budget_ratio;

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -9,7 +9,7 @@
 #include <cstdlib>  // For std::getenv
 #include <fstream>  // For std::ifstream
 #include <limits>
-#include <memory>   // For std::unique_ptr
+#include <memory>  // For std::unique_ptr
 #include <string>
 #include <thread>  // For std::thread
 #include <json/json.h>
@@ -438,8 +438,8 @@ void InitMasterConf(const mooncake::DefaultConfig& default_config,
                            &master_config.allow_evict_soft_pinned_objects,
                            FLAGS_allow_evict_soft_pinned_objects);
     for (uint16_t type_id = 0; type_id <= UINT8_MAX; ++type_id) {
-        const auto data_type =
-            static_cast<mooncake::ObjectDataType>(static_cast<uint8_t>(type_id));
+        const auto data_type = static_cast<mooncake::ObjectDataType>(
+            static_cast<uint8_t>(type_id));
         const std::string type_key = std::to_string(type_id);
 
         double reuse_scale = 0.0;
@@ -448,9 +448,8 @@ void InitMasterConf(const mooncake::DefaultConfig& default_config,
                                    type_key + ".reuse_scale",
                                &reuse_scale)) {
             if (reuse_scale <= 0.0) {
-                LOG(FATAL)
-                    << "object_type_eviction_score_policies." << type_key
-                    << ".reuse_scale must be greater than 0";
+                LOG(FATAL) << "object_type_eviction_score_policies." << type_key
+                           << ".reuse_scale must be greater than 0";
             }
             master_config.object_type_eviction_score_policies[data_type]
                 .reuse_scale = reuse_scale;
@@ -466,10 +465,10 @@ void InitMasterConf(const mooncake::DefaultConfig& default_config,
         }
 
         double budget_ratio = 0.0;
-        if (TryGetDoubleConfig(default_config,
-                               "object_type_eviction_policies." + type_key +
-                                   ".budget_ratio",
-                               &budget_ratio)) {
+        if (TryGetDoubleConfig(
+                default_config,
+                "object_type_eviction_policies." + type_key + ".budget_ratio",
+                &budget_ratio)) {
             if (budget_ratio < 0.0) {
                 LOG(FATAL) << "object_type_eviction_policies." << type_key
                            << ".budget_ratio must be non-negative";

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -469,9 +469,11 @@ void InitMasterConf(const mooncake::DefaultConfig& default_config,
                 default_config,
                 "object_type_eviction_policies." + type_key + ".budget_ratio",
                 &budget_ratio)) {
-            if (!std::isfinite(budget_ratio) || budget_ratio < 0.0) {
+            if (!std::isfinite(budget_ratio) || budget_ratio < 0.0 ||
+                budget_ratio > 1.0) {
                 LOG(FATAL) << "object_type_eviction_policies." << type_key
-                           << ".budget_ratio must be finite and non-negative";
+                           << ".budget_ratio must be finite and between 0.0 "
+                              "and 1.0";
             }
             master_config.object_type_eviction_policies[data_type]
                 .budget_ratio = budget_ratio;

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -7198,10 +7198,10 @@ void MasterService::BatchEvict(double evict_ratio_target,
     std::vector<std::vector<Candidate>> local_candidates(num_threads);
     std::vector<long> local_eviction_base(num_threads, 0);
     std::vector<long> local_object_count(num_threads, 0);
-    std::vector<std::array<long, UINT8_MAX + 1>>
-        local_per_type_eviction_base(num_threads);
-    std::vector<std::array<uint64_t, UINT8_MAX + 1>>
-        local_per_type_used_bytes(num_threads);
+    std::vector<std::array<long, UINT8_MAX + 1>> local_per_type_eviction_base(
+        num_threads);
+    std::vector<std::array<uint64_t, UINT8_MAX + 1>> local_per_type_used_bytes(
+        num_threads);
     for (auto& counts : local_per_type_eviction_base) counts.fill(0);
     for (auto& used_bytes : local_per_type_used_bytes) used_bytes.fill(0);
     std::vector<std::vector<int64_t>> local_soft_pin(num_threads);
@@ -7282,8 +7282,7 @@ void MasterService::BatchEvict(double evict_ratio_target,
     }
 
     std::vector<Candidate> candidates;
-    std::array<std::vector<size_t>, UINT8_MAX + 1>
-        per_type_candidate_indices;
+    std::array<std::vector<size_t>, UINT8_MAX + 1> per_type_candidate_indices;
     {
         size_t total = 0;
         for (auto& v : local_candidates) total += v.size();
@@ -7292,8 +7291,7 @@ void MasterService::BatchEvict(double evict_ratio_target,
     for (auto& v : local_candidates) {
         for (auto& candidate : v) {
             const size_t candidate_idx = candidates.size();
-            const auto data_type_idx =
-                static_cast<size_t>(candidate.data_type);
+            const auto data_type_idx = static_cast<size_t>(candidate.data_type);
             per_type_candidate_indices[data_type_idx].push_back(candidate_idx);
             candidates.push_back(std::move(candidate));
         }
@@ -7413,55 +7411,61 @@ void MasterService::BatchEvict(double evict_ratio_target,
             std::ceil(total_eviction_base * evict_ratio_target) - evicted_count;
         long evict_num = std::min(ideal_evict_num, (long)candidates.size());
 
-        if (evict_num > 0) {
-            std::nth_element(
-                candidates.begin(), candidates.begin() + (evict_num - 1),
-                candidates.end(), [](const Candidate& a, const Candidate& b) {
-                    return a.adjusted_age > b.adjusted_age;
-                });
-            auto target_adjusted_age = candidates[evict_num - 1].adjusted_age;
+        if (evict_num <= 0) {
+            evict_num = 0;
+        } else {
+            std::nth_element(candidates.begin(),
+                             candidates.begin() + (evict_num - 1),
+                             candidates.end(),
+                             [](const Candidate& a, const Candidate& b) {
+                                 return a.adjusted_age > b.adjusted_age;
+                             });
+        }
+        auto target_adjusted_age =
+            evict_num > 0 ? candidates[evict_num - 1].adjusted_age
+                          : std::numeric_limits<int64_t>::max();
 
-            // Treat evict_num as a minimum: if re-validation skips a candidate,
-            // continue trying the next one so actual evicted count reaches
-            // evict_num. This matches the old per-shard over-eviction behavior.
-            long evicted_this_pass = 0;
-            for (auto& c : candidates) {
-                if (evicted_this_pass >= evict_num &&
-                    c.adjusted_age < target_adjusted_age) {
+        // Treat evict_num as a minimum: if re-validation skips a candidate,
+        // continue trying the next one so actual evicted count reaches
+        // evict_num. This matches the old per-shard over-eviction behavior.
+        long evicted_this_pass = 0;
+        for (auto& c : candidates) {
+            if (evict_num <= 0 ||
+                (evicted_this_pass >= evict_num &&
+                 c.adjusted_age < target_adjusted_age)) {
+                no_pin_objects.push_back(c.adjusted_age);
+                continue;
+            }
+            {
+                MetadataShardAccessorRW shard(this, c.shard_idx);
+                auto tenant_it = shard->tenants.find(c.tenant_id);
+                if (tenant_it == shard->tenants.end()) continue;
+                auto& tenant_state = tenant_it->second;
+                auto it = tenant_state.metadata.find(c.key);
+                if (it == tenant_state.metadata.end()) continue;
+                // Re-validate: state may have changed since Phase 1
+                if (!it->second.IsLeaseExpired(now) ||
+                    it->second.IsSoftPinned(now) ||
+                    !can_evict_replicas(it->second)) {
                     no_pin_objects.push_back(c.adjusted_age);
                     continue;
                 }
-                {
-                    MetadataShardAccessorRW shard(this, c.shard_idx);
-                    auto tenant_it = shard->tenants.find(c.tenant_id);
-                    if (tenant_it == shard->tenants.end()) continue;
-                    auto& tenant_state = tenant_it->second;
-                    auto it = tenant_state.metadata.find(c.key);
-                    if (it == tenant_state.metadata.end()) continue;
-                    // Re-validate: state may have changed since Phase 1
-                    if (!it->second.IsLeaseExpired(now) ||
-                        it->second.IsSoftPinned(now) ||
-                        !can_evict_replicas(it->second)) {
-                        no_pin_objects.push_back(c.adjusted_age);
-                        continue;
-                    }
-                    auto evict_result = try_evict_group_or_object(
-                        c.tenant_id, c.key, it->second, shard, tenant_state,
-                        deferred_replicas,
-                        /*allow_soft_pinned=*/false);
-                    total_freed_size += evict_result.freed_bytes;
-                    if (!it->second.IsValid()) {
-                        EraseMetadata(tenant_state, it, c.tenant_id,
-                                      QuotaEraseMode::kFull, &shard);
-                    }
-                    if (tenant_state.Empty()) {
-                        shard->tenants.erase(tenant_it);
-                    }
-                    evicted_count += evict_result.evicted_objects;
-                    evicted_this_pass += evict_result.evicted_objects;
+                auto evict_result = try_evict_group_or_object(
+                    c.tenant_id, c.key, it->second, shard, tenant_state,
+                    deferred_replicas,
+                    /*allow_soft_pinned=*/false);
+                total_freed_size += evict_result.freed_bytes;
+                if (!it->second.IsValid()) {
+                    EraseMetadata(tenant_state, it, c.tenant_id,
+                                  QuotaEraseMode::kFull, &shard);
                 }
-                deferred_replicas.clear();
+                if (tenant_state.Empty()) {
+                    shard->tenants.erase(tenant_it);
+                }
+                evicted_count += evict_result.evicted_objects;
+                evicted_this_pass += evict_result.evicted_objects;
             }
+            deferred_replicas.clear();
         }
     }
 

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -7198,13 +7198,14 @@ void MasterService::BatchEvict(double evict_ratio_target,
     std::vector<std::vector<Candidate>> local_candidates(num_threads);
     std::vector<long> local_eviction_base(num_threads, 0);
     std::vector<long> local_object_count(num_threads, 0);
+    std::vector<std::vector<int64_t>> local_soft_pin(num_threads);
+
     std::vector<std::array<long, UINT8_MAX + 1>> local_per_type_eviction_base(
         num_threads);
     std::vector<std::array<uint64_t, UINT8_MAX + 1>> local_per_type_used_bytes(
         num_threads);
     for (auto& counts : local_per_type_eviction_base) counts.fill(0);
     for (auto& used_bytes : local_per_type_used_bytes) used_bytes.fill(0);
-    std::vector<std::vector<int64_t>> local_soft_pin(num_threads);
 
     std::vector<std::thread> threads;
     for (int t = 0; t < num_threads; t++) {

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -7323,6 +7323,7 @@ void MasterService::BatchEvict(double evict_ratio_target,
     std::vector<int64_t> no_pin_objects;
     std::vector<std::vector<Replica>> deferred_replicas;
 
+    // First pass: evict candidates with no soft pin
     if (!candidates.empty()) {
         const int64_t total_mem_capacity =
             MasterMetricManager::instance().get_total_mem_capacity();
@@ -7408,7 +7409,6 @@ void MasterService::BatchEvict(double evict_ratio_target,
 
     const long remaining_evict_num =
         std::ceil(total_eviction_base * evict_ratio_target) - evicted_count;
-    // First pass: evict candidates with no soft pin
     if (!candidates.empty() && remaining_evict_num > 0) {
         long evict_num =
             std::min(remaining_evict_num, (long)candidates.size());

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -239,12 +239,14 @@ MasterService::MasterService(const MasterServiceConfig& config)
       offload_cap_ratio_(config.offload_cap_ratio) {
     object_type_reuse_scales_.fill(1.0);
     object_type_soft_pin_weights_.fill(1.0);
+    object_type_eviction_graces_.fill(0);
     for (const auto& [data_type, policy] :
          config.object_type_eviction_score_policies) {
         ValidateObjectTypeEvictionScorePolicy(policy);
         const auto idx = static_cast<uint8_t>(data_type);
         object_type_reuse_scales_[idx] = policy.reuse_scale;
         object_type_soft_pin_weights_[idx] = policy.soft_pin_weight;
+        object_type_eviction_graces_[idx] = policy.eviction_grace;
     }
 
     // Initialize HTTP metadata key prefix (read env var once at startup)
@@ -7160,11 +7162,12 @@ void MasterService::BatchEvict(double evict_ratio_target,
         const double reuse_scale = object_type_reuse_scales_[idx];
         const double weight =
             is_soft_pinned ? object_type_soft_pin_weights_[idx] : 1.0;
+        const int64_t eviction_grace = object_type_eviction_graces_[idx];
         auto expired_age =
             std::chrono::duration_cast<std::chrono::milliseconds>(
                 rank_reference_time - metadata.lease_timeout)
                 .count();
-        expired_age = std::max<int64_t>(expired_age, 0);
+        expired_age = std::max<int64_t>(expired_age - eviction_grace, 0);
         const double score = expired_age * weight / reuse_scale;
         if (!std::isfinite(score) ||
             score >= static_cast<double>(std::numeric_limits<int64_t>::max())) {

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -7406,34 +7406,28 @@ void MasterService::BatchEvict(double evict_ratio_target,
         }
     }
 
+    const long remaining_evict_num =
+        std::ceil(total_eviction_base * evict_ratio_target) - evicted_count;
     // First pass: evict candidates with no soft pin
-    if (!candidates.empty()) {
-        long ideal_evict_num =
-            std::ceil(total_eviction_base * evict_ratio_target) - evicted_count;
-        long evict_num = std::min(ideal_evict_num, (long)candidates.size());
+    if (!candidates.empty() && remaining_evict_num > 0) {
+        long evict_num =
+            std::min(remaining_evict_num, (long)candidates.size());
 
-        if (evict_num <= 0) {
-            evict_num = 0;
-        } else {
-            std::nth_element(candidates.begin(),
-                             candidates.begin() + (evict_num - 1),
-                             candidates.end(),
-                             [](const Candidate& a, const Candidate& b) {
-                                 return a.adjusted_age > b.adjusted_age;
-                             });
-        }
-        auto target_adjusted_age =
-            evict_num > 0 ? candidates[evict_num - 1].adjusted_age
-                          : std::numeric_limits<int64_t>::max();
+        std::nth_element(candidates.begin(),
+                         candidates.begin() + (evict_num - 1),
+                         candidates.end(),
+                         [](const Candidate& a, const Candidate& b) {
+                             return a.adjusted_age > b.adjusted_age;
+                         });
+        auto target_adjusted_age = candidates[evict_num - 1].adjusted_age;
 
         // Treat evict_num as a minimum: if re-validation skips a candidate,
         // continue trying the next one so actual evicted count reaches
         // evict_num. This matches the old per-shard over-eviction behavior.
         long evicted_this_pass = 0;
         for (auto& c : candidates) {
-            if (evict_num <= 0 ||
-                (evicted_this_pass >= evict_num &&
-                 c.adjusted_age < target_adjusted_age)) {
+            if (evicted_this_pass >= evict_num &&
+                c.adjusted_age < target_adjusted_age) {
                 no_pin_objects.push_back(c.adjusted_age);
                 continue;
             }

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -240,6 +240,7 @@ MasterService::MasterService(const MasterServiceConfig& config)
     object_type_reuse_scales_.fill(1.0);
     object_type_soft_pin_weights_.fill(1.0);
     object_type_eviction_graces_.fill(0);
+    object_type_budget_ratios_.fill(1.0);
     for (const auto& [data_type, policy] :
          config.object_type_eviction_score_policies) {
         ValidateObjectTypeEvictionScorePolicy(policy);
@@ -247,6 +248,11 @@ MasterService::MasterService(const MasterServiceConfig& config)
         object_type_reuse_scales_[idx] = policy.reuse_scale;
         object_type_soft_pin_weights_[idx] = policy.soft_pin_weight;
         object_type_eviction_graces_[idx] = policy.eviction_grace;
+    }
+    for (const auto& [data_type, policy] :
+         config.object_type_eviction_policies) {
+        const auto idx = static_cast<uint8_t>(data_type);
+        object_type_budget_ratios_[idx] = policy.budget_ratio;
     }
 
     // Initialize HTTP metadata key prefix (read env var once at startup)

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -7150,6 +7150,7 @@ void MasterService::BatchEvict(double evict_ratio_target,
         size_t shard_idx;
         std::string tenant_id;
         std::string key;
+        ObjectDataType data_type;
         std::chrono::system_clock::time_point lease_timeout;
         int64_t adjusted_age;
     };
@@ -7190,6 +7191,12 @@ void MasterService::BatchEvict(double evict_ratio_target,
     std::vector<std::vector<Candidate>> local_candidates(num_threads);
     std::vector<long> local_eviction_base(num_threads, 0);
     std::vector<long> local_object_count(num_threads, 0);
+    std::vector<std::array<long, UINT8_MAX + 1>>
+        local_per_type_eviction_base(num_threads);
+    std::vector<std::array<uint64_t, UINT8_MAX + 1>>
+        local_per_type_used_bytes(num_threads);
+    for (auto& counts : local_per_type_eviction_base) counts.fill(0);
+    for (auto& used_bytes : local_per_type_used_bytes) used_bytes.fill(0);
     std::vector<std::vector<int64_t>> local_soft_pin(num_threads);
 
     std::vector<std::thread> threads;
@@ -7207,14 +7214,27 @@ void MasterService::BatchEvict(double evict_ratio_target,
                     shard_metadata_count += tenant_state.metadata.size();
                     for (auto it = tenant_state.metadata.begin();
                          it != tenant_state.metadata.end(); ++it) {
+                        const ObjectDataType data_type = it->second.data_type;
+                        const auto data_type_idx =
+                            static_cast<size_t>(data_type);
+                        const uint64_t charge =
+                            CompletedMemoryQuotaCharge(it->second);
+                        if (charge > 0) {
+                            auto& used_bytes =
+                                local_per_type_used_bytes[t][data_type_idx];
+                            used_bytes = SaturatingAdd(used_bytes, charge);
+                        }
                         if (it->second.IsHardPinned()) continue;
                         bool has_evictable = can_evict_replicas(it->second);
-                        if (has_evictable) shard_evictable_count++;
+                        if (has_evictable) {
+                            shard_evictable_count++;
+                            local_per_type_eviction_base[t][data_type_idx]++;
+                        }
                         if (!it->second.IsLeaseExpired(now) || !has_evictable)
                             continue;
                         if (!it->second.IsSoftPinned(now)) {
                             local_candidates[t].push_back(
-                                {s, tenant_id, it->first,
+                                {s, tenant_id, it->first, data_type,
                                  it->second.lease_timeout,
                                  adjusted_age(it->second,
                                               /*is_soft_pinned=*/false)});
@@ -7236,18 +7256,40 @@ void MasterService::BatchEvict(double evict_ratio_target,
     long total_eviction_base = 0;
     for (auto v : local_eviction_base) total_eviction_base += v;
 
+    std::array<long, UINT8_MAX + 1> per_type_eviction_base{};
+    for (const auto& local_counts : local_per_type_eviction_base) {
+        for (size_t i = 0; i < per_type_eviction_base.size(); ++i) {
+            per_type_eviction_base[i] += local_counts[i];
+        }
+    }
+
     long object_count = 0;
     for (auto v : local_object_count) object_count += v;
 
+    std::array<uint64_t, UINT8_MAX + 1> per_type_used_bytes{};
+    for (const auto& local_used_bytes : local_per_type_used_bytes) {
+        for (size_t i = 0; i < per_type_used_bytes.size(); ++i) {
+            per_type_used_bytes[i] =
+                SaturatingAdd(per_type_used_bytes[i], local_used_bytes[i]);
+        }
+    }
+
     std::vector<Candidate> candidates;
+    std::array<std::vector<size_t>, UINT8_MAX + 1>
+        per_type_candidate_indices;
     {
         size_t total = 0;
         for (auto& v : local_candidates) total += v.size();
         candidates.reserve(total);
     }
     for (auto& v : local_candidates) {
-        candidates.insert(candidates.end(), std::make_move_iterator(v.begin()),
-                          std::make_move_iterator(v.end()));
+        for (auto& candidate : v) {
+            const size_t candidate_idx = candidates.size();
+            const auto data_type_idx =
+                static_cast<size_t>(candidate.data_type);
+            per_type_candidate_indices[data_type_idx].push_back(candidate_idx);
+            candidates.push_back(std::move(candidate));
+        }
     }
 
     std::vector<int64_t> soft_pin_objects;

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -7323,59 +7323,146 @@ void MasterService::BatchEvict(double evict_ratio_target,
     std::vector<int64_t> no_pin_objects;
     std::vector<std::vector<Replica>> deferred_replicas;
 
+    if (!candidates.empty()) {
+        const int64_t total_mem_capacity =
+            MasterMetricManager::instance().get_total_mem_capacity();
+        for (size_t data_type_idx = 0;
+             data_type_idx < per_type_used_bytes.size(); ++data_type_idx) {
+            const uint64_t type_used_bytes =
+                per_type_used_bytes[data_type_idx];
+            const double budget_ratio =
+                object_type_budget_ratios_[data_type_idx];
+            const double type_budget_bytes =
+                budget_ratio * static_cast<double>(total_mem_capacity);
+            if (static_cast<double>(type_used_bytes) <= type_budget_bytes) {
+                continue;
+            }
+
+            auto& type_candidate_indices =
+                per_type_candidate_indices[data_type_idx];
+            const double over_budget_ratio =
+                static_cast<double>(type_used_bytes) /
+                    static_cast<double>(total_mem_capacity) -
+                budget_ratio;
+            const double type_evict_ratio =
+                std::min(evict_ratio_target, over_budget_ratio);
+            long type_evict_num =
+                std::ceil(per_type_eviction_base[data_type_idx] *
+                          type_evict_ratio);
+            type_evict_num =
+                std::min(type_evict_num, (long)type_candidate_indices.size());
+            if (type_evict_num <= 0) {
+                continue;
+            }
+
+            std::nth_element(type_candidate_indices.begin(),
+                             type_candidate_indices.begin() +
+                                 (type_evict_num - 1),
+                             type_candidate_indices.end(),
+                             [&](size_t a, size_t b) {
+                                 return candidates[a].adjusted_age >
+                                        candidates[b].adjusted_age;
+                             });
+            auto target_adjusted_age =
+                candidates[type_candidate_indices[type_evict_num - 1]]
+                    .adjusted_age;
+
+            long evicted_this_type = 0;
+            for (const auto candidate_idx : type_candidate_indices) {
+                const auto& c = candidates[candidate_idx];
+                if (evicted_this_type >= type_evict_num &&
+                    c.adjusted_age < target_adjusted_age) {
+                    continue;
+                }
+                {
+                    MetadataShardAccessorRW shard(this, c.shard_idx);
+                    auto tenant_it = shard->tenants.find(c.tenant_id);
+                    if (tenant_it == shard->tenants.end()) continue;
+                    auto& tenant_state = tenant_it->second;
+                    auto it = tenant_state.metadata.find(c.key);
+                    if (it == tenant_state.metadata.end()) continue;
+                    if (!it->second.IsLeaseExpired(now) ||
+                        it->second.IsSoftPinned(now) ||
+                        !can_evict_replicas(it->second)) {
+                        continue;
+                    }
+                    auto evict_result = try_evict_group_or_object(
+                        c.tenant_id, c.key, it->second, shard, tenant_state,
+                        deferred_replicas,
+                        /*allow_soft_pinned=*/false);
+                    total_freed_size += evict_result.freed_bytes;
+                    if (!it->second.IsValid()) {
+                        EraseMetadata(tenant_state, it, c.tenant_id,
+                                      QuotaEraseMode::kFull, &shard);
+                    }
+                    if (tenant_state.Empty()) {
+                        shard->tenants.erase(tenant_it);
+                    }
+                    evicted_count += evict_result.evicted_objects;
+                    evicted_this_type += evict_result.evicted_objects;
+                }
+                deferred_replicas.clear();
+            }
+        }
+    }
+
     // First pass: evict candidates with no soft pin
     if (!candidates.empty()) {
         long ideal_evict_num =
-            std::ceil(total_eviction_base * evict_ratio_target);
+            std::ceil(total_eviction_base * evict_ratio_target) -
+            evicted_count;
         long evict_num = std::min(ideal_evict_num, (long)candidates.size());
 
-        std::nth_element(candidates.begin(),
-                         candidates.begin() + (evict_num - 1), candidates.end(),
-                         [](const Candidate& a, const Candidate& b) {
-                             return a.adjusted_age > b.adjusted_age;
-                         });
-        auto target_adjusted_age = candidates[evict_num - 1].adjusted_age;
+        if (evict_num > 0) {
+            std::nth_element(candidates.begin(),
+                             candidates.begin() + (evict_num - 1),
+                             candidates.end(),
+                             [](const Candidate& a, const Candidate& b) {
+                                 return a.adjusted_age > b.adjusted_age;
+                             });
+            auto target_adjusted_age = candidates[evict_num - 1].adjusted_age;
 
-        // Treat evict_num as a minimum: if re-validation skips a candidate,
-        // continue trying the next one so actual evicted count reaches
-        // evict_num. This matches the old per-shard over-eviction behavior.
-        long evicted_this_pass = 0;
-        for (auto& c : candidates) {
-            if (evicted_this_pass >= evict_num &&
-                c.adjusted_age < target_adjusted_age) {
-                no_pin_objects.push_back(c.adjusted_age);
-                continue;
-            }
-            {
-                MetadataShardAccessorRW shard(this, c.shard_idx);
-                auto tenant_it = shard->tenants.find(c.tenant_id);
-                if (tenant_it == shard->tenants.end()) continue;
-                auto& tenant_state = tenant_it->second;
-                auto it = tenant_state.metadata.find(c.key);
-                if (it == tenant_state.metadata.end()) continue;
-                // Re-validate: state may have changed since Phase 1
-                if (!it->second.IsLeaseExpired(now) ||
-                    it->second.IsSoftPinned(now) ||
-                    !can_evict_replicas(it->second)) {
+            // Treat evict_num as a minimum: if re-validation skips a candidate,
+            // continue trying the next one so actual evicted count reaches
+            // evict_num. This matches the old per-shard over-eviction behavior.
+            long evicted_this_pass = 0;
+            for (auto& c : candidates) {
+                if (evicted_this_pass >= evict_num &&
+                    c.adjusted_age < target_adjusted_age) {
                     no_pin_objects.push_back(c.adjusted_age);
                     continue;
                 }
-                auto evict_result = try_evict_group_or_object(
-                    c.tenant_id, c.key, it->second, shard, tenant_state,
-                    deferred_replicas,
-                    /*allow_soft_pinned=*/false);
-                total_freed_size += evict_result.freed_bytes;
-                if (!it->second.IsValid()) {
-                    EraseMetadata(tenant_state, it, c.tenant_id,
-                                  QuotaEraseMode::kFull, &shard);
+                {
+                    MetadataShardAccessorRW shard(this, c.shard_idx);
+                    auto tenant_it = shard->tenants.find(c.tenant_id);
+                    if (tenant_it == shard->tenants.end()) continue;
+                    auto& tenant_state = tenant_it->second;
+                    auto it = tenant_state.metadata.find(c.key);
+                    if (it == tenant_state.metadata.end()) continue;
+                    // Re-validate: state may have changed since Phase 1
+                    if (!it->second.IsLeaseExpired(now) ||
+                        it->second.IsSoftPinned(now) ||
+                        !can_evict_replicas(it->second)) {
+                        no_pin_objects.push_back(c.adjusted_age);
+                        continue;
+                    }
+                    auto evict_result = try_evict_group_or_object(
+                        c.tenant_id, c.key, it->second, shard, tenant_state,
+                        deferred_replicas,
+                        /*allow_soft_pinned=*/false);
+                    total_freed_size += evict_result.freed_bytes;
+                    if (!it->second.IsValid()) {
+                        EraseMetadata(tenant_state, it, c.tenant_id,
+                                      QuotaEraseMode::kFull, &shard);
+                    }
+                    if (tenant_state.Empty()) {
+                        shard->tenants.erase(tenant_it);
+                    }
+                    evicted_count += evict_result.evicted_objects;
+                    evicted_this_pass += evict_result.evicted_objects;
                 }
-                if (tenant_state.Empty()) {
-                    shard->tenants.erase(tenant_it);
-                }
-                evicted_count += evict_result.evicted_objects;
-                evicted_this_pass += evict_result.evicted_objects;
+                deferred_replicas.clear();
             }
-            deferred_replicas.clear();
         }
     }
 

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -251,6 +251,7 @@ MasterService::MasterService(const MasterServiceConfig& config)
     }
     for (const auto& [data_type, policy] :
          config.object_type_eviction_policies) {
+        ValidateObjectTypeEvictionPolicy(policy);
         const auto idx = static_cast<uint8_t>(data_type);
         object_type_budget_ratios_[idx] = policy.budget_ratio;
     }
@@ -7326,79 +7327,82 @@ void MasterService::BatchEvict(double evict_ratio_target,
     if (!candidates.empty()) {
         const int64_t total_mem_capacity =
             MasterMetricManager::instance().get_total_mem_capacity();
-        for (size_t data_type_idx = 0;
-             data_type_idx < per_type_used_bytes.size(); ++data_type_idx) {
-            const uint64_t type_used_bytes = per_type_used_bytes[data_type_idx];
-            const double budget_ratio =
-                object_type_budget_ratios_[data_type_idx];
-            const double type_budget_bytes =
-                budget_ratio * static_cast<double>(total_mem_capacity);
-            if (static_cast<double>(type_used_bytes) <= type_budget_bytes) {
-                continue;
-            }
-
-            auto& type_candidate_indices =
-                per_type_candidate_indices[data_type_idx];
-            const double over_budget_ratio =
-                static_cast<double>(type_used_bytes) /
-                    static_cast<double>(total_mem_capacity) -
-                budget_ratio;
-            const double type_evict_ratio =
-                std::min(evict_ratio_target, over_budget_ratio);
-            long type_evict_num = std::ceil(
-                per_type_eviction_base[data_type_idx] * type_evict_ratio);
-            type_evict_num =
-                std::min(type_evict_num, (long)type_candidate_indices.size());
-            if (type_evict_num <= 0) {
-                continue;
-            }
-
-            std::nth_element(
-                type_candidate_indices.begin(),
-                type_candidate_indices.begin() + (type_evict_num - 1),
-                type_candidate_indices.end(), [&](size_t a, size_t b) {
-                    return candidates[a].adjusted_age >
-                           candidates[b].adjusted_age;
-                });
-            auto target_adjusted_age =
-                candidates[type_candidate_indices[type_evict_num - 1]]
-                    .adjusted_age;
-
-            long evicted_this_type = 0;
-            for (const auto candidate_idx : type_candidate_indices) {
-                const auto& c = candidates[candidate_idx];
-                if (evicted_this_type >= type_evict_num &&
-                    c.adjusted_age < target_adjusted_age) {
+        if (total_mem_capacity > 0) {
+            for (size_t data_type_idx = 0;
+                 data_type_idx < per_type_used_bytes.size(); ++data_type_idx) {
+                const uint64_t type_used_bytes =
+                    per_type_used_bytes[data_type_idx];
+                const double budget_ratio =
+                    object_type_budget_ratios_[data_type_idx];
+                const double type_budget_bytes =
+                    budget_ratio * static_cast<double>(total_mem_capacity);
+                if (static_cast<double>(type_used_bytes) <= type_budget_bytes) {
                     continue;
                 }
-                {
-                    MetadataShardAccessorRW shard(this, c.shard_idx);
-                    auto tenant_it = shard->tenants.find(c.tenant_id);
-                    if (tenant_it == shard->tenants.end()) continue;
-                    auto& tenant_state = tenant_it->second;
-                    auto it = tenant_state.metadata.find(c.key);
-                    if (it == tenant_state.metadata.end()) continue;
-                    if (!it->second.IsLeaseExpired(now) ||
-                        it->second.IsSoftPinned(now) ||
-                        !can_evict_replicas(it->second)) {
+
+                auto& type_candidate_indices =
+                    per_type_candidate_indices[data_type_idx];
+                const double over_budget_ratio =
+                    static_cast<double>(type_used_bytes) /
+                        static_cast<double>(total_mem_capacity) -
+                    budget_ratio;
+                const double type_evict_ratio =
+                    std::min(evict_ratio_target, over_budget_ratio);
+                long type_evict_num = std::ceil(
+                    per_type_eviction_base[data_type_idx] * type_evict_ratio);
+                type_evict_num = std::min(type_evict_num,
+                                          (long)type_candidate_indices.size());
+                if (type_evict_num <= 0) {
+                    continue;
+                }
+
+                std::nth_element(
+                    type_candidate_indices.begin(),
+                    type_candidate_indices.begin() + (type_evict_num - 1),
+                    type_candidate_indices.end(), [&](size_t a, size_t b) {
+                        return candidates[a].adjusted_age >
+                               candidates[b].adjusted_age;
+                    });
+                auto target_adjusted_age =
+                    candidates[type_candidate_indices[type_evict_num - 1]]
+                        .adjusted_age;
+
+                long evicted_this_type = 0;
+                for (const auto candidate_idx : type_candidate_indices) {
+                    const auto& c = candidates[candidate_idx];
+                    if (evicted_this_type >= type_evict_num &&
+                        c.adjusted_age < target_adjusted_age) {
                         continue;
                     }
-                    auto evict_result = try_evict_group_or_object(
-                        c.tenant_id, c.key, it->second, shard, tenant_state,
-                        deferred_replicas,
-                        /*allow_soft_pinned=*/false);
-                    total_freed_size += evict_result.freed_bytes;
-                    if (!it->second.IsValid()) {
-                        EraseMetadata(tenant_state, it, c.tenant_id,
-                                      QuotaEraseMode::kFull, &shard);
+                    {
+                        MetadataShardAccessorRW shard(this, c.shard_idx);
+                        auto tenant_it = shard->tenants.find(c.tenant_id);
+                        if (tenant_it == shard->tenants.end()) continue;
+                        auto& tenant_state = tenant_it->second;
+                        auto it = tenant_state.metadata.find(c.key);
+                        if (it == tenant_state.metadata.end()) continue;
+                        if (!it->second.IsLeaseExpired(now) ||
+                            it->second.IsSoftPinned(now) ||
+                            !can_evict_replicas(it->second)) {
+                            continue;
+                        }
+                        auto evict_result = try_evict_group_or_object(
+                            c.tenant_id, c.key, it->second, shard, tenant_state,
+                            deferred_replicas,
+                            /*allow_soft_pinned=*/false);
+                        total_freed_size += evict_result.freed_bytes;
+                        if (!it->second.IsValid()) {
+                            EraseMetadata(tenant_state, it, c.tenant_id,
+                                          QuotaEraseMode::kFull, &shard);
+                        }
+                        if (tenant_state.Empty()) {
+                            shard->tenants.erase(tenant_it);
+                        }
+                        evicted_count += evict_result.evicted_objects;
+                        evicted_this_type += evict_result.evicted_objects;
                     }
-                    if (tenant_state.Empty()) {
-                        shard->tenants.erase(tenant_it);
-                    }
-                    evicted_count += evict_result.evicted_objects;
-                    evicted_this_type += evict_result.evicted_objects;
+                    deferred_replicas.clear();
                 }
-                deferred_replicas.clear();
             }
         }
     }

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -237,6 +237,15 @@ MasterService::MasterService(const MasterServiceConfig& config)
       enable_cxl_(config.enable_cxl),
       offloading_queue_limit_(config.offloading_queue_limit),
       offload_cap_ratio_(config.offload_cap_ratio) {
+    object_type_reuse_scales_.fill(1.0);
+    object_type_soft_pin_weights_.fill(1.0);
+    for (const auto& [data_type, policy] :
+         config.object_type_eviction_score_policies) {
+        const auto idx = static_cast<uint8_t>(data_type);
+        object_type_reuse_scales_[idx] = policy.reuse_scale;
+        object_type_soft_pin_weights_[idx] = policy.soft_pin_weight;
+    }
+
     // Initialize HTTP metadata key prefix (read env var once at startup)
     const char* custom_prefix = std::getenv("MC_METADATA_CLUSTER_ID");
     if (custom_prefix && std::strlen(custom_prefix) > 0) {
@@ -7139,6 +7148,23 @@ void MasterService::BatchEvict(double evict_ratio_target,
         std::string tenant_id;
         std::string key;
         std::chrono::system_clock::time_point lease_timeout;
+        int64_t adjusted_age;
+    };
+
+    const auto rank_reference_time = now;
+    auto adjusted_age = [this, rank_reference_time](
+                            const ObjectMetadata& metadata,
+                            bool is_soft_pinned) {
+        const auto idx = static_cast<uint8_t>(metadata.data_type);
+        const double reuse_scale = object_type_reuse_scales_[idx];
+        const double weight =
+            is_soft_pinned ? object_type_soft_pin_weights_[idx] : 1.0;
+        auto expired_age =
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+                rank_reference_time - metadata.lease_timeout)
+                .count();
+        expired_age = std::max<int64_t>(expired_age, 0);
+        return static_cast<int64_t>(expired_age * weight / reuse_scale);
     };
 
     // Randomly select a starting shard to avoid imbalance eviction between
@@ -7155,8 +7181,7 @@ void MasterService::BatchEvict(double evict_ratio_target,
     std::vector<std::vector<Candidate>> local_candidates(num_threads);
     std::vector<long> local_eviction_base(num_threads, 0);
     std::vector<long> local_object_count(num_threads, 0);
-    std::vector<std::vector<std::chrono::system_clock::time_point>>
-        local_soft_pin(num_threads);
+    std::vector<std::vector<int64_t>> local_soft_pin(num_threads);
 
     std::vector<std::thread> threads;
     for (int t = 0; t < num_threads; t++) {
@@ -7181,10 +7206,13 @@ void MasterService::BatchEvict(double evict_ratio_target,
                         if (!it->second.IsSoftPinned(now)) {
                             local_candidates[t].push_back(
                                 {s, tenant_id, it->first,
-                                 it->second.lease_timeout});
+                                 it->second.lease_timeout,
+                                 adjusted_age(it->second,
+                                              /*is_soft_pinned=*/false)});
                         } else if (allow_evict_soft_pinned_objects_) {
                             local_soft_pin[t].push_back(
-                                it->second.lease_timeout);
+                                adjusted_age(it->second,
+                                             /*is_soft_pinned=*/true));
                         }
                     }
                 }
@@ -7213,7 +7241,7 @@ void MasterService::BatchEvict(double evict_ratio_target,
                           std::make_move_iterator(v.end()));
     }
 
-    std::vector<std::chrono::system_clock::time_point> soft_pin_objects;
+    std::vector<int64_t> soft_pin_objects;
     {
         size_t total = 0;
         for (auto& v : local_soft_pin) total += v.size();
@@ -7235,7 +7263,7 @@ void MasterService::BatchEvict(double evict_ratio_target,
     // ===== Phase 2: Serial eviction via key lookup =====
     long evicted_count = 0;
     uint64_t total_freed_size = 0;
-    std::vector<std::chrono::system_clock::time_point> no_pin_objects;
+    std::vector<int64_t> no_pin_objects;
     std::vector<std::vector<Replica>> deferred_replicas;
 
     // First pass: evict candidates with no soft pin
@@ -7247,9 +7275,9 @@ void MasterService::BatchEvict(double evict_ratio_target,
         std::nth_element(candidates.begin(),
                          candidates.begin() + (evict_num - 1), candidates.end(),
                          [](const Candidate& a, const Candidate& b) {
-                             return a.lease_timeout < b.lease_timeout;
+                             return a.adjusted_age > b.adjusted_age;
                          });
-        auto target_timeout = candidates[evict_num - 1].lease_timeout;
+        auto target_adjusted_age = candidates[evict_num - 1].adjusted_age;
 
         // Treat evict_num as a minimum: if re-validation skips a candidate,
         // continue trying the next one so actual evicted count reaches
@@ -7257,8 +7285,8 @@ void MasterService::BatchEvict(double evict_ratio_target,
         long evicted_this_pass = 0;
         for (auto& c : candidates) {
             if (evicted_this_pass >= evict_num &&
-                c.lease_timeout > target_timeout) {
-                no_pin_objects.push_back(c.lease_timeout);
+                c.adjusted_age < target_adjusted_age) {
+                no_pin_objects.push_back(c.adjusted_age);
                 continue;
             }
             {
@@ -7272,7 +7300,7 @@ void MasterService::BatchEvict(double evict_ratio_target,
                 if (!it->second.IsLeaseExpired(now) ||
                     it->second.IsSoftPinned(now) ||
                     !can_evict_replicas(it->second)) {
-                    no_pin_objects.push_back(c.lease_timeout);
+                    no_pin_objects.push_back(c.adjusted_age);
                     continue;
                 }
                 auto evict_result = try_evict_group_or_object(
@@ -7315,8 +7343,9 @@ void MasterService::BatchEvict(double evict_ratio_target,
             // Second pass A: only evict objects without soft pin.
             std::nth_element(no_pin_objects.begin(),
                              no_pin_objects.begin() + (target_evict_num - 1),
-                             no_pin_objects.end());
-            auto target_timeout = no_pin_objects[target_evict_num - 1];
+                             no_pin_objects.end(),
+                             [](int64_t a, int64_t b) { return a > b; });
+            auto target_adjusted_age = no_pin_objects[target_evict_num - 1];
 
             // Evict via key lookup — avoid full metadata traversal
             for (size_t i = 0; i < kNumShards && target_evict_num > 0; i++) {
@@ -7332,7 +7361,9 @@ void MasterService::BatchEvict(double evict_ratio_target,
                                target_evict_num > 0) {
                             if (!it->second.IsHardPinned() &&
                                 it->second.IsLeaseExpired(now) &&
-                                it->second.lease_timeout <= target_timeout &&
+                                adjusted_age(it->second,
+                                             /*is_soft_pinned=*/false) >=
+                                    target_adjusted_age &&
                                 !it->second.IsSoftPinned(now) &&
                                 can_evict_replicas(it->second)) {
                                 auto evict_result = try_evict_group_or_object(
@@ -7371,8 +7402,10 @@ void MasterService::BatchEvict(double evict_ratio_target,
             std::nth_element(
                 soft_pin_objects.begin(),
                 soft_pin_objects.begin() + (soft_pin_evict_num - 1),
-                soft_pin_objects.end());
-            auto soft_target_timeout = soft_pin_objects[soft_pin_evict_num - 1];
+                soft_pin_objects.end(),
+                [](int64_t a, int64_t b) { return a > b; });
+            auto soft_target_adjusted_age =
+                soft_pin_objects[soft_pin_evict_num - 1];
 
             for (size_t i = 0; i < kNumShards && target_evict_num > 0; i++) {
                 {
@@ -7393,8 +7426,9 @@ void MasterService::BatchEvict(double evict_ratio_target,
                                 continue;
                             }
                             if (!it->second.IsSoftPinned(now) ||
-                                it->second.lease_timeout <=
-                                    soft_target_timeout) {
+                                adjusted_age(it->second,
+                                             /*is_soft_pinned=*/true) >=
+                                    soft_target_adjusted_age) {
                                 auto evict_result = try_evict_group_or_object(
                                     tenant_it->first, it->first, it->second,
                                     shard, tenant_state, deferred_replicas,

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -241,6 +241,7 @@ MasterService::MasterService(const MasterServiceConfig& config)
     object_type_soft_pin_weights_.fill(1.0);
     for (const auto& [data_type, policy] :
          config.object_type_eviction_score_policies) {
+        ValidateObjectTypeEvictionScorePolicy(policy);
         const auto idx = static_cast<uint8_t>(data_type);
         object_type_reuse_scales_[idx] = policy.reuse_scale;
         object_type_soft_pin_weights_[idx] = policy.soft_pin_weight;
@@ -7164,7 +7165,12 @@ void MasterService::BatchEvict(double evict_ratio_target,
                 rank_reference_time - metadata.lease_timeout)
                 .count();
         expired_age = std::max<int64_t>(expired_age, 0);
-        return static_cast<int64_t>(expired_age * weight / reuse_scale);
+        const double score = expired_age * weight / reuse_scale;
+        if (!std::isfinite(score) ||
+            score >= static_cast<double>(std::numeric_limits<int64_t>::max())) {
+            return std::numeric_limits<int64_t>::max();
+        }
+        return static_cast<int64_t>(score);
     };
 
     // Randomly select a starting shard to avoid imbalance eviction between

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -7191,10 +7191,10 @@ void MasterService::BatchEvict(double evict_ratio_target,
     std::vector<std::vector<Candidate>> local_candidates(num_threads);
     std::vector<long> local_eviction_base(num_threads, 0);
     std::vector<long> local_object_count(num_threads, 0);
-    std::vector<std::array<long, UINT8_MAX + 1>>
-        local_per_type_eviction_base(num_threads);
-    std::vector<std::array<uint64_t, UINT8_MAX + 1>>
-        local_per_type_used_bytes(num_threads);
+    std::vector<std::array<long, UINT8_MAX + 1>> local_per_type_eviction_base(
+        num_threads);
+    std::vector<std::array<uint64_t, UINT8_MAX + 1>> local_per_type_used_bytes(
+        num_threads);
     for (auto& counts : local_per_type_eviction_base) counts.fill(0);
     for (auto& used_bytes : local_per_type_used_bytes) used_bytes.fill(0);
     std::vector<std::vector<int64_t>> local_soft_pin(num_threads);
@@ -7275,8 +7275,7 @@ void MasterService::BatchEvict(double evict_ratio_target,
     }
 
     std::vector<Candidate> candidates;
-    std::array<std::vector<size_t>, UINT8_MAX + 1>
-        per_type_candidate_indices;
+    std::array<std::vector<size_t>, UINT8_MAX + 1> per_type_candidate_indices;
     {
         size_t total = 0;
         for (auto& v : local_candidates) total += v.size();
@@ -7285,8 +7284,7 @@ void MasterService::BatchEvict(double evict_ratio_target,
     for (auto& v : local_candidates) {
         for (auto& candidate : v) {
             const size_t candidate_idx = candidates.size();
-            const auto data_type_idx =
-                static_cast<size_t>(candidate.data_type);
+            const auto data_type_idx = static_cast<size_t>(candidate.data_type);
             per_type_candidate_indices[data_type_idx].push_back(candidate_idx);
             candidates.push_back(std::move(candidate));
         }

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -7171,11 +7171,12 @@ void MasterService::BatchEvict(double evict_ratio_target,
         const double weight =
             is_soft_pinned ? object_type_soft_pin_weights_[idx] : 1.0;
         const int64_t eviction_grace = object_type_eviction_graces_[idx];
-        auto expired_age =
+        const auto expired_age = std::max<int64_t>(
             std::chrono::duration_cast<std::chrono::milliseconds>(
                 rank_reference_time - metadata.lease_timeout)
-                .count();
-        expired_age = std::max<int64_t>(expired_age - eviction_grace, 0);
+                    .count() -
+                eviction_grace,
+            0);
         const double score = expired_age * weight / reuse_scale;
         if (!std::isfinite(score) ||
             score >= static_cast<double>(std::numeric_limits<int64_t>::max())) {
@@ -7198,14 +7199,13 @@ void MasterService::BatchEvict(double evict_ratio_target,
     std::vector<std::vector<Candidate>> local_candidates(num_threads);
     std::vector<long> local_eviction_base(num_threads, 0);
     std::vector<long> local_object_count(num_threads, 0);
-    std::vector<std::vector<int64_t>> local_soft_pin(num_threads);
-
     std::vector<std::array<long, UINT8_MAX + 1>> local_per_type_eviction_base(
         num_threads);
     std::vector<std::array<uint64_t, UINT8_MAX + 1>> local_per_type_used_bytes(
         num_threads);
     for (auto& counts : local_per_type_eviction_base) counts.fill(0);
     for (auto& used_bytes : local_per_type_used_bytes) used_bytes.fill(0);
+    std::vector<std::vector<int64_t>> local_soft_pin(num_threads);
 
     std::vector<std::thread> threads;
     for (int t = 0; t < num_threads; t++) {
@@ -7410,12 +7410,10 @@ void MasterService::BatchEvict(double evict_ratio_target,
     const long remaining_evict_num =
         std::ceil(total_eviction_base * evict_ratio_target) - evicted_count;
     if (!candidates.empty() && remaining_evict_num > 0) {
-        long evict_num =
-            std::min(remaining_evict_num, (long)candidates.size());
+        long evict_num = std::min(remaining_evict_num, (long)candidates.size());
 
         std::nth_element(candidates.begin(),
-                         candidates.begin() + (evict_num - 1),
-                         candidates.end(),
+                         candidates.begin() + (evict_num - 1), candidates.end(),
                          [](const Candidate& a, const Candidate& b) {
                              return a.adjusted_age > b.adjusted_age;
                          });

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -7328,8 +7328,7 @@ void MasterService::BatchEvict(double evict_ratio_target,
             MasterMetricManager::instance().get_total_mem_capacity();
         for (size_t data_type_idx = 0;
              data_type_idx < per_type_used_bytes.size(); ++data_type_idx) {
-            const uint64_t type_used_bytes =
-                per_type_used_bytes[data_type_idx];
+            const uint64_t type_used_bytes = per_type_used_bytes[data_type_idx];
             const double budget_ratio =
                 object_type_budget_ratios_[data_type_idx];
             const double type_budget_bytes =
@@ -7346,23 +7345,21 @@ void MasterService::BatchEvict(double evict_ratio_target,
                 budget_ratio;
             const double type_evict_ratio =
                 std::min(evict_ratio_target, over_budget_ratio);
-            long type_evict_num =
-                std::ceil(per_type_eviction_base[data_type_idx] *
-                          type_evict_ratio);
+            long type_evict_num = std::ceil(
+                per_type_eviction_base[data_type_idx] * type_evict_ratio);
             type_evict_num =
                 std::min(type_evict_num, (long)type_candidate_indices.size());
             if (type_evict_num <= 0) {
                 continue;
             }
 
-            std::nth_element(type_candidate_indices.begin(),
-                             type_candidate_indices.begin() +
-                                 (type_evict_num - 1),
-                             type_candidate_indices.end(),
-                             [&](size_t a, size_t b) {
-                                 return candidates[a].adjusted_age >
-                                        candidates[b].adjusted_age;
-                             });
+            std::nth_element(
+                type_candidate_indices.begin(),
+                type_candidate_indices.begin() + (type_evict_num - 1),
+                type_candidate_indices.end(), [&](size_t a, size_t b) {
+                    return candidates[a].adjusted_age >
+                           candidates[b].adjusted_age;
+                });
             auto target_adjusted_age =
                 candidates[type_candidate_indices[type_evict_num - 1]]
                     .adjusted_age;
@@ -7409,17 +7406,15 @@ void MasterService::BatchEvict(double evict_ratio_target,
     // First pass: evict candidates with no soft pin
     if (!candidates.empty()) {
         long ideal_evict_num =
-            std::ceil(total_eviction_base * evict_ratio_target) -
-            evicted_count;
+            std::ceil(total_eviction_base * evict_ratio_target) - evicted_count;
         long evict_num = std::min(ideal_evict_num, (long)candidates.size());
 
         if (evict_num > 0) {
-            std::nth_element(candidates.begin(),
-                             candidates.begin() + (evict_num - 1),
-                             candidates.end(),
-                             [](const Candidate& a, const Candidate& b) {
-                                 return a.adjusted_age > b.adjusted_age;
-                             });
+            std::nth_element(
+                candidates.begin(), candidates.begin() + (evict_num - 1),
+                candidates.end(), [](const Candidate& a, const Candidate& b) {
+                    return a.adjusted_age > b.adjusted_age;
+                });
             auto target_adjusted_age = candidates[evict_num - 1].adjusted_age;
 
             // Treat evict_num as a minimum: if re-validation skips a candidate,

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -7197,10 +7197,10 @@ void MasterService::BatchEvict(double evict_ratio_target,
     std::vector<std::vector<Candidate>> local_candidates(num_threads);
     std::vector<long> local_eviction_base(num_threads, 0);
     std::vector<long> local_object_count(num_threads, 0);
-    std::vector<std::array<long, UINT8_MAX + 1>> local_per_type_eviction_base(
-        num_threads);
-    std::vector<std::array<uint64_t, UINT8_MAX + 1>> local_per_type_used_bytes(
-        num_threads);
+    std::vector<std::array<long, UINT8_MAX + 1>>
+        local_per_type_eviction_base(num_threads);
+    std::vector<std::array<uint64_t, UINT8_MAX + 1>>
+        local_per_type_used_bytes(num_threads);
     for (auto& counts : local_per_type_eviction_base) counts.fill(0);
     for (auto& used_bytes : local_per_type_used_bytes) used_bytes.fill(0);
     std::vector<std::vector<int64_t>> local_soft_pin(num_threads);
@@ -7281,7 +7281,8 @@ void MasterService::BatchEvict(double evict_ratio_target,
     }
 
     std::vector<Candidate> candidates;
-    std::array<std::vector<size_t>, UINT8_MAX + 1> per_type_candidate_indices;
+    std::array<std::vector<size_t>, UINT8_MAX + 1>
+        per_type_candidate_indices;
     {
         size_t total = 0;
         for (auto& v : local_candidates) total += v.size();
@@ -7290,7 +7291,8 @@ void MasterService::BatchEvict(double evict_ratio_target,
     for (auto& v : local_candidates) {
         for (auto& candidate : v) {
             const size_t candidate_idx = candidates.size();
-            const auto data_type_idx = static_cast<size_t>(candidate.data_type);
+            const auto data_type_idx =
+                static_cast<size_t>(candidate.data_type);
             per_type_candidate_indices[data_type_idx].push_back(candidate_idx);
             candidates.push_back(std::move(candidate));
         }

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -6911,19 +6911,20 @@ TEST_F(MasterServiceTest,
     auto builder = MasterServiceConfig::builder();
     EXPECT_THROW(
         builder.set_object_type_eviction_score_policy(
-            ObjectDataType::KVCACHE, ObjectTypeEvictionScorePolicy{1.0, -1.0}),
+            ObjectDataType::KVCACHE,
+            ObjectTypeEvictionScorePolicy{1.0, -1.0, 0}),
         std::invalid_argument);
 
     EXPECT_THROW(builder.set_object_type_eviction_score_policy(
                      ObjectDataType::KVCACHE,
                      ObjectTypeEvictionScorePolicy{
-                         std::numeric_limits<double>::quiet_NaN(), 1.0}),
+                         std::numeric_limits<double>::quiet_NaN(), 1.0, 0}),
                  std::invalid_argument);
 
     EXPECT_THROW(builder.set_object_type_eviction_score_policy(
                      ObjectDataType::KVCACHE,
                      ObjectTypeEvictionScorePolicy{
-                         1.0, std::numeric_limits<double>::infinity()}),
+                         1.0, std::numeric_limits<double>::infinity(), 0}),
                  std::invalid_argument);
 }
 
@@ -6931,16 +6932,16 @@ TEST_F(MasterServiceTest,
        ObjectTypeEvictionScorePolicyRejectsInvalidDirectConfigInput) {
     auto config = MasterServiceConfig::builder().build();
     config.object_type_eviction_score_policies[ObjectDataType::KVCACHE] =
-        ObjectTypeEvictionScorePolicy{0.0, 1.0};
+        ObjectTypeEvictionScorePolicy{0.0, 1.0, 0};
     EXPECT_THROW({ MasterService service(config); }, std::invalid_argument);
 
     config.object_type_eviction_score_policies[ObjectDataType::KVCACHE] =
-        ObjectTypeEvictionScorePolicy{1.0, -1.0};
+        ObjectTypeEvictionScorePolicy{1.0, -1.0, 0};
     EXPECT_THROW({ MasterService service(config); }, std::invalid_argument);
 
     config.object_type_eviction_score_policies[ObjectDataType::KVCACHE] =
         ObjectTypeEvictionScorePolicy{std::numeric_limits<double>::infinity(),
-                                      1.0};
+                                      1.0, 0};
     EXPECT_THROW({ MasterService service(config); }, std::invalid_argument);
 }
 

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -11,6 +11,7 @@
 #include <filesystem>
 #include <fstream>
 #include <functional>
+#include <limits>
 #include <map>
 #include <memory>
 #include <random>
@@ -6903,6 +6904,44 @@ TEST_F(MasterServiceTest, HardPinWithSoftPinEvictionOrder) {
 
     std::this_thread::sleep_for(std::chrono::milliseconds(kv_lease_ttl));
     service_->RemoveAll();
+}
+
+TEST_F(MasterServiceTest,
+       ObjectTypeEvictionScorePolicyRejectsInvalidBuilderInput) {
+    auto builder = MasterServiceConfig::builder();
+    EXPECT_THROW(
+        builder.set_object_type_eviction_score_policy(
+            ObjectDataType::KVCACHE, ObjectTypeEvictionScorePolicy{1.0, -1.0}),
+        std::invalid_argument);
+
+    EXPECT_THROW(builder.set_object_type_eviction_score_policy(
+                     ObjectDataType::KVCACHE,
+                     ObjectTypeEvictionScorePolicy{
+                         std::numeric_limits<double>::quiet_NaN(), 1.0}),
+                 std::invalid_argument);
+
+    EXPECT_THROW(builder.set_object_type_eviction_score_policy(
+                     ObjectDataType::KVCACHE,
+                     ObjectTypeEvictionScorePolicy{
+                         1.0, std::numeric_limits<double>::infinity()}),
+                 std::invalid_argument);
+}
+
+TEST_F(MasterServiceTest,
+       ObjectTypeEvictionScorePolicyRejectsInvalidDirectConfigInput) {
+    auto config = MasterServiceConfig::builder().build();
+    config.object_type_eviction_score_policies[ObjectDataType::KVCACHE] =
+        ObjectTypeEvictionScorePolicy{0.0, 1.0};
+    EXPECT_THROW({ MasterService service(config); }, std::invalid_argument);
+
+    config.object_type_eviction_score_policies[ObjectDataType::KVCACHE] =
+        ObjectTypeEvictionScorePolicy{1.0, -1.0};
+    EXPECT_THROW({ MasterService service(config); }, std::invalid_argument);
+
+    config.object_type_eviction_score_policies[ObjectDataType::KVCACHE] =
+        ObjectTypeEvictionScorePolicy{std::numeric_limits<double>::infinity(),
+                                      1.0};
+    EXPECT_THROW({ MasterService service(config); }, std::invalid_argument);
 }
 
 TEST_F(MasterServiceTest, HardPinDefaultIsFalse) {

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -6909,11 +6909,10 @@ TEST_F(MasterServiceTest, HardPinWithSoftPinEvictionOrder) {
 TEST_F(MasterServiceTest,
        ObjectTypeEvictionScorePolicyRejectsInvalidBuilderInput) {
     auto builder = MasterServiceConfig::builder();
-    EXPECT_THROW(
-        builder.set_object_type_eviction_score_policy(
-            ObjectDataType::KVCACHE,
-            ObjectTypeEvictionScorePolicy{1.0, -1.0, 0}),
-        std::invalid_argument);
+    EXPECT_THROW(builder.set_object_type_eviction_score_policy(
+                     ObjectDataType::KVCACHE,
+                     ObjectTypeEvictionScorePolicy{1.0, -1.0, 0}),
+                 std::invalid_argument);
 
     EXPECT_THROW(builder.set_object_type_eviction_score_policy(
                      ObjectDataType::KVCACHE,
@@ -6940,8 +6939,8 @@ TEST_F(MasterServiceTest,
     EXPECT_THROW({ MasterService service(config); }, std::invalid_argument);
 
     config.object_type_eviction_score_policies[ObjectDataType::KVCACHE] =
-        ObjectTypeEvictionScorePolicy{std::numeric_limits<double>::infinity(),
-                                      1.0, 0};
+        ObjectTypeEvictionScorePolicy{
+            std::numeric_limits<double>::infinity(), 1.0, 0};
     EXPECT_THROW({ MasterService service(config); }, std::invalid_argument);
 }
 

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -6944,6 +6944,41 @@ TEST_F(MasterServiceTest,
     EXPECT_THROW({ MasterService service(config); }, std::invalid_argument);
 }
 
+TEST_F(MasterServiceTest, ObjectTypeEvictionPolicyRejectsInvalidBuilderInput) {
+    auto builder = MasterServiceConfig::builder();
+    EXPECT_THROW(builder.set_object_type_eviction_policy(
+                     ObjectDataType::KVCACHE, ObjectTypeEvictionPolicy{-1.0}),
+                 std::invalid_argument);
+
+    EXPECT_THROW(
+        builder.set_object_type_eviction_policy(
+            ObjectDataType::KVCACHE,
+            ObjectTypeEvictionPolicy{std::numeric_limits<double>::quiet_NaN()}),
+        std::invalid_argument);
+
+    EXPECT_THROW(
+        builder.set_object_type_eviction_policy(
+            ObjectDataType::KVCACHE,
+            ObjectTypeEvictionPolicy{std::numeric_limits<double>::infinity()}),
+        std::invalid_argument);
+}
+
+TEST_F(MasterServiceTest,
+       ObjectTypeEvictionPolicyRejectsInvalidDirectConfigInput) {
+    auto config = MasterServiceConfig::builder().build();
+    config.object_type_eviction_policies[ObjectDataType::KVCACHE] =
+        ObjectTypeEvictionPolicy{-1.0};
+    EXPECT_THROW({ MasterService service(config); }, std::invalid_argument);
+
+    config.object_type_eviction_policies[ObjectDataType::KVCACHE] =
+        ObjectTypeEvictionPolicy{std::numeric_limits<double>::quiet_NaN()};
+    EXPECT_THROW({ MasterService service(config); }, std::invalid_argument);
+
+    config.object_type_eviction_policies[ObjectDataType::KVCACHE] =
+        ObjectTypeEvictionPolicy{std::numeric_limits<double>::infinity()};
+    EXPECT_THROW({ MasterService service(config); }, std::invalid_argument);
+}
+
 TEST_F(MasterServiceTest, HardPinDefaultIsFalse) {
     // Objects created without with_hard_pin should not be hard-pinned
     auto service_config =

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -6939,8 +6939,8 @@ TEST_F(MasterServiceTest,
     EXPECT_THROW({ MasterService service(config); }, std::invalid_argument);
 
     config.object_type_eviction_score_policies[ObjectDataType::KVCACHE] =
-        ObjectTypeEvictionScorePolicy{
-            std::numeric_limits<double>::infinity(), 1.0, 0};
+        ObjectTypeEvictionScorePolicy{std::numeric_limits<double>::infinity(),
+                                      1.0, 0};
     EXPECT_THROW({ MasterService service(config); }, std::invalid_argument);
 }
 

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -6961,6 +6961,10 @@ TEST_F(MasterServiceTest, ObjectTypeEvictionPolicyRejectsInvalidBuilderInput) {
             ObjectDataType::KVCACHE,
             ObjectTypeEvictionPolicy{std::numeric_limits<double>::infinity()}),
         std::invalid_argument);
+
+    EXPECT_THROW(builder.set_object_type_eviction_policy(
+                     ObjectDataType::KVCACHE, ObjectTypeEvictionPolicy{1.1}),
+                 std::invalid_argument);
 }
 
 TEST_F(MasterServiceTest,
@@ -6976,6 +6980,10 @@ TEST_F(MasterServiceTest,
 
     config.object_type_eviction_policies[ObjectDataType::KVCACHE] =
         ObjectTypeEvictionPolicy{std::numeric_limits<double>::infinity()};
+    EXPECT_THROW({ MasterService service(config); }, std::invalid_argument);
+
+    config.object_type_eviction_policies[ObjectDataType::KVCACHE] =
+        ObjectTypeEvictionPolicy{1.1};
     EXPECT_THROW({ MasterService service(config); }, std::invalid_argument);
 }
 

--- a/mooncake-store/tests/object_data_type_test.cpp
+++ b/mooncake-store/tests/object_data_type_test.cpp
@@ -47,6 +47,7 @@ TEST_F(ObjectDataTypeTest, EnumValues) {
     EXPECT_EQ(static_cast<uint8_t>(ObjectDataType::OPTIMIZER_STATE), 7);
     EXPECT_EQ(static_cast<uint8_t>(ObjectDataType::METADATA), 8);
     EXPECT_EQ(static_cast<uint8_t>(ObjectDataType::GENERAL), 9);
+    EXPECT_EQ(static_cast<uint8_t>(ObjectDataType::HIDDEN_STATE), 10);
 }
 
 // Verify stream operator produces readable output
@@ -66,6 +67,10 @@ TEST_F(ObjectDataTypeTest, StreamOperator) {
     oss.str("");
     oss << ObjectDataType::GENERAL;
     EXPECT_EQ(oss.str(), "GENERAL");
+
+    oss.str("");
+    oss << ObjectDataType::HIDDEN_STATE;
+    EXPECT_EQ(oss.str(), "HIDDEN_STATE");
 
     // Out-of-range value should print "UNKNOWN"
     oss.str("");
@@ -147,6 +152,7 @@ TEST_F(ObjectDataTypeTest, EnumRoundtrip) {
         ObjectDataType::SAMPLE,   ObjectDataType::ACTIVATION,
         ObjectDataType::GRADIENT, ObjectDataType::OPTIMIZER_STATE,
         ObjectDataType::METADATA, ObjectDataType::GENERAL,
+        ObjectDataType::HIDDEN_STATE,
     };
 
     for (auto type : all_types) {

--- a/mooncake-store/tests/object_data_type_test.cpp
+++ b/mooncake-store/tests/object_data_type_test.cpp
@@ -147,11 +147,11 @@ TEST_F(ObjectDataTypeTest, PutStartDefaultDataType) {
 // Verify all enum values can roundtrip through uint8_t cast
 TEST_F(ObjectDataTypeTest, EnumRoundtrip) {
     std::vector<ObjectDataType> all_types = {
-        ObjectDataType::UNKNOWN,  ObjectDataType::KVCACHE,
-        ObjectDataType::TENSOR,   ObjectDataType::WEIGHT,
-        ObjectDataType::SAMPLE,   ObjectDataType::ACTIVATION,
-        ObjectDataType::GRADIENT, ObjectDataType::OPTIMIZER_STATE,
-        ObjectDataType::METADATA, ObjectDataType::GENERAL,
+        ObjectDataType::UNKNOWN,      ObjectDataType::KVCACHE,
+        ObjectDataType::TENSOR,       ObjectDataType::WEIGHT,
+        ObjectDataType::SAMPLE,       ObjectDataType::ACTIVATION,
+        ObjectDataType::GRADIENT,     ObjectDataType::OPTIMIZER_STATE,
+        ObjectDataType::METADATA,     ObjectDataType::GENERAL,
         ObjectDataType::HIDDEN_STATE,
     };
 


### PR DESCRIPTION
## Description

This is split optimization version 4/4 of the original PR: https://github.com/kvcache-ai/Mooncake/pull/2689.

This PR builds on the object type metadata, type-aware eviction scoring, and per-type eviction statistics introduced by the previous three PRs. It adds the ability to configure memory eviction budgets by `ObjectDataType`. The new `ObjectTypeEvictionPolicy` allows each object type to specify a `budget_ratio`; during `BatchEvict`, Mooncake first selects candidates from object types that exceed their configured budget, then passes the remaining eviction target to the existing global adjusted-age eviction flow.

This is the fourth step split out from the original Hidden State type-aware eviction PR. This PR description focuses only on the object-type budget policy added on top of PR1, PR2, and PR3. The `HIDDEN_STATE` type, `ObjectTypeEvictionScorePolicy`, `adjusted_age`, and per-type eviction statistics included in this combined branch are covered by the previous PRs.

Design rationale:

- With only global LRU or global adjusted-age ranking, high-reuse-value object types can be disadvantaged by other types in some workloads, while a single object type can also consume too much memory and hurt the others.
- PR3 already collects per-`ObjectDataType` memory usage and candidate sets during eviction scanning. PR4 uses that information to add a per-type budget pass before falling back to global eviction.
- `budget_ratio` is expressed as a fraction of total memory capacity, making the same policy easier to reuse across different deployment sizes. The default value is `1.0`; when no explicit policy is configured, no object type is actively limited by budget.

Main changes:

- Add `ObjectTypeEvictionPolicy`, containing:
  - `budget_ratio`: the fraction of total memory capacity an object type is allowed to use. Default: `1.0`.
- Add `object_type_eviction_policies` config propagation through `MasterConfig`, `MasterServiceSupervisorConfig`, `WrappedMasterServiceConfig`, `MasterServiceConfig`, and `MasterServiceConfigBuilder`.
- Validate `budget_ratio >= 0.0` in the builder to reject meaningless negative budget policies.
- Expand object type budget policies into `UINT8_MAX + 1` indexed slots during `MasterService` initialization. Unconfigured object types keep the default `1.0` budget ratio.
- Add an object-type budget check before the regular global eviction stage in `BatchEvict`:

```text
type_budget_bytes = budget_ratio * total_mem_capacity
over_budget_ratio = type_used_bytes / total_mem_capacity - budget_ratio
type_evict_ratio = min(evict_ratio_target, over_budget_ratio)
type_evict_num = ceil(per_type_eviction_base[type] * type_evict_ratio)
```

- When an object type's `type_used_bytes` exceeds `type_budget_bytes`, candidates from that type's non-soft-pinned set are evicted first, prioritizing larger `adjusted_age`.
- After the type budget pass finishes, the regular first global eviction stage subtracts the number of objects already evicted from its target count. This avoids expanding a single eviction cycle by independently applying both the budget pass and the global pass.

Compatibility notes:

- The full branch contains the previous three PRs for correctness, but the new runtime behavior added by this PR is limited to the memory eviction policy inside `BatchEvict`: if an object type exceeds its configured budget, Mooncake first performs a type-aware pass over non-soft-pinned candidates from that type.
- This PR does not change the external meaning of `evict_ratio_target` or `evict_ratio_lowerbound` in `BatchEvict`. The function still tries to evict the target number of objects and at least attempts to satisfy the lower bound; this PR only changes internal candidate selection.
- This PR does not change the basic eligibility conditions for entering the eviction candidate set. Objects still need to satisfy the existing lease-expired, non-hard-pinned, and evictable memory replica conditions.
- The type budget pass only uses the non-soft-pinned candidates collected by PR3. Soft-pinned objects are still considered only in the later global second stage, and only when `allow_evict_soft_pinned_objects` is enabled.
- This PR does not change the existing fallback scan semantics of the tenant quota eviction path `EvictTenantMemoryForQuota`. That path is not based on an in-tenant LRU queue; it picks a random starting shard with `RandomIndex(kNumShards)` for the specified tenant and scans existing shard / metadata state to release eligible objects.
- The default `budget_ratio = 1.0` falls back to the original behavior.
- This PR does not change offload, promotion, or NoF eviction paths.
- The type budget selection reuses existing candidate sets and `std::nth_element` threshold selection. It does not introduce a full sort. The extra traversal is limited to `uint8_t` object type slots and candidate indices, so candidate selection/scanning remains in the same complexity class as the existing implementation.

Full eviction policy overview:

- The original LRU ranking value based on `lease_timeout` is adjusted by value-aware scoring:

```text
adjusted_age =
    max(0, rank_reference_time - lease_timeout - eviction_grace)
    * soft_pin_weight / reuse_scale
```

- `BatchEvict` first follows the existing parallel shard scan. It collects candidates that satisfy the basic eviction conditions, while also recording memory usage, evictable object counts, and candidate indices for each `ObjectDataType`.
- For object types exceeding `budget_ratio * total_mem_capacity`, the budget pass first evicts from that type's non-soft-pinned, expired candidates, prioritizing larger `adjusted_age`. The number of objects evicted is bounded by both `evict_ratio_target` and the type's over-budget ratio.
- After the type budget pass, the regular first global stage continues over all non-soft-pinned candidates by `adjusted_age` to fill the remaining target count, preserving the `BatchEvict` best-effort target semantics.
- If the first stage still does not satisfy `evict_ratio_lowerbound`, the existing second-stage behavior is preserved: it first supplements with non-soft-pinned candidates, and then considers soft-pinned candidates only when `allow_evict_soft_pinned_objects` is enabled.
- Offload-on-evict, force-evict, discarded replica release, metadata erase, and NoF eviction paths keep their existing flow. This PR only changes the internal selection order for memory eviction candidates.

Benchmark and experiment results:

The benchmark is designed to approximate realistic multimodal session behavior where KV Cache and Hidden State have different characteristics. It uses a continuous session timeline rather than separate warm / pressure / probe phases. The workload models different average reuse intervals for KV and Hidden State, different object sizes, different session round counts, image counts, image sizes, video ratios, public/private visual reuse, and session rebuilds. Since real cache-hit latency savings are difficult to measure exactly in a store-level benchmark, the report uses a simple modeled saving metric based on recomputation cost and size-based transfer cost.

Full benchmark code, run instructions, and the detailed experiment report are available at:

https://github.com/kanceler/mooncake-object-type-eviction-policy-benchmark

This run aggregates 3 repetitions, each covering 9 representative configurations.

| Case | Policy configuration | Hidden hit | vs baseline | KV hit | vs baseline | Saving Time Rate | Put Fail | Avg Evict |
|---|---|---:|---:|---:|---:|---:|---:|---:|
| baseline default | Default policy, no object-type reuse scale / budget | 111/327=33.94% | +0.00 pp | 495577/512742=96.65% | +0.00 pp | 87.80% | 0 | 5.11% |
| budget only kv80 h100 | `KVCACHE budget_ratio=0.80`, `HIDDEN_STATE budget_ratio=1.0` | 159/327=48.62% | +14.68 pp | 492260/512742=96.01% | -0.64 pp | 88.42% | 0 | 5.09% |
| grace only h20 | `HIDDEN_STATE eviction_grace=20000`, no reuse scale / budget | 222/327=67.89% | +33.95 pp | 491422/512742=95.84% | -0.81 pp | 92.42% | 0 | 5.08% |
| reuse scale only h8 | `HIDDEN_STATE reuse_scale=8.0` | 277/327=84.71% | +50.77 pp | 486987/512742=94.98% | -1.67 pp | 94.38% | 0 | 5.12% |
| reuse scale h8 g10 | `HIDDEN_STATE reuse_scale=8.0`, `HIDDEN_STATE eviction_grace=10000` | 298/327=91.13% | +57.19 pp | 477489/512742=93.12% | -3.52 pp | 93.33% | 0 | 5.09% |
| h8 + kv80 + h100 | `HIDDEN_STATE reuse_scale=8.0`, `KVCACHE budget_ratio=0.80`, `HIDDEN_STATE budget_ratio=1.0` | 281/327=85.93% | +51.99 pp | 483605/512742=94.32% | -2.33 pp | 93.47% | 0 | 5.12% |
| h8 + kv80 + h12 | `HIDDEN_STATE reuse_scale=8.0`, `KVCACHE budget_ratio=0.80`, `HIDDEN_STATE budget_ratio=0.12` | 248/327=75.84% | +41.90 pp | 490691/512742=95.70% | -0.95 pp | 93.47% | 0 | 5.10% |
| h8 + g10 + kv80 + h12 | `HIDDEN_STATE reuse_scale=8.0`, `HIDDEN_STATE eviction_grace=10000`, `KVCACHE budget_ratio=0.80`, `HIDDEN_STATE budget_ratio=0.12` | 247/327=75.54% | +41.60 pp | 490905/512742=95.74% | -0.91 pp | 94.26% | 0 | 5.07% |
| h8 + kv80 + h08 | `HIDDEN_STATE reuse_scale=8.0`, `KVCACHE budget_ratio=0.80`, `HIDDEN_STATE budget_ratio=0.08` | 195/327=59.63% | +25.69 pp | 491814/512742=95.92% | -0.73 pp | 90.94% | 1 | 5.10% |

Experiment summary:

- Type-aware reuse scale, `eviction_grace`, and per-type budget control different dimensions of the eviction policy: reuse scale normalizes adjusted age across object types, `eviction_grace` adds a type-level time bias, and per-type budget provides a capacity-side guardrail so one protected type does not grow without bounds at the expense of others.
- Looking only at Hidden object hit rate can overstate the gain, because Hidden State has a small unique-byte share in this workload. Global byte hit rate is also dominated by KV Cache. Therefore the table includes `Saving Time Rate` to provide an additional view based on modeled recomputation and transfer cost.
- More aggressive Hidden protection can further improve Hidden hit rate, but it also causes a larger KV hit-rate drop. With a budget guardrail, the policy moves closer to a stable tradeoff region where both KV reusable hit and Saving Time Rate remain high.
- Without a budget constraint, `eviction_grace` behaves like a stronger protection knob, which can be useful for highly valuable systematic data types. With `HIDDEN_STATE budget_ratio=0.12`, it does not significantly change object hit rate, but it slightly improves the cost-weighted saving metric. This makes it a fine-grained tuning knob on top of reuse scale and budget, rather than a replacement for either.
- From the perspective of `Saving Time Rate`, the goal is not to favor one cache type unconditionally or maximize one relative hit rate. The policy should give different object types a fair chance to compete under LRU-style pressure, while still allowing type-specific corrections based on data value and reuse characteristics.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [X] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Changes

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

This PR mainly adds the object-type budget stage in `BatchEvict` while preserving the default behavior when no budget policy is configured. Recommended coverage includes existing master service tests and object-type policy scenarios:

- With the default `budget_ratio = 1.0`, eviction without explicit object-type budget configuration should preserve the default behavior of the first three PRs.
- For an object type configured with a smaller `budget_ratio`, when that type exceeds its budget, the budget pass should first evict from that type's non-soft-pinned, expired candidates by larger `adjusted_age`.
- Objects evicted by the type budget stage should be subtracted from the target count of the following global first stage.
- Soft-pinned objects should still participate only in the global second stage when `allow_evict_soft_pinned_objects` is enabled.
- Invalid `budget_ratio < 0.0` should be rejected by the builder.

Commands:

```bash
ninja -C build-docker mooncake-store/tests/master_service_test
./build-docker/mooncake-store/tests/master_service_test
ninja -C build-docker mooncake-store/tests/object_data_type_test
./build-docker/mooncake-store/tests/object_data_type_test
```

Additional static check:

```bash
git diff --check origin/main..origin/pr4-object-type-eviction-policy-combined
```

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [X] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [X] AI tools were used
