### PR TITLE
fix(rdma): rank link-local GID below any network-backed IPv4 in auto-GID

### DIFF
--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_gid_probe.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_gid_probe.h
@@ -30,8 +30,13 @@ enum class AutoGidCandidateClass {
     kNetworkRoutable = 0,
     kNoNetworkRoutable = 1,
     kNetworkDegraded = 2,
-    kNoNetworkDegraded = 3,
-    kFallbackNonzero = 4,
+    // A network-backed link-local GID is not routable across subnets, so it
+    // must rank strictly below any network-backed IPv4 GID (even a degraded /
+    // RFC1918 one). On routed RoCEv2 fabrics the only usable cross-node GID is
+    // the IPv4 one; picking link-local here breaks the RTR handshake.
+    kNetworkLinkLocal = 3,
+    kNoNetworkDegraded = 4,
+    kFallbackNonzero = 5,
 };
 
 enum class AutoGidRetryAction {
@@ -74,6 +79,8 @@ inline const char* autoGidCandidateClassToString(
             return "no-network-routable";
         case AutoGidCandidateClass::kNetworkDegraded:
             return "network-degraded";
+        case AutoGidCandidateClass::kNetworkLinkLocal:
+            return "network-link-local";
         case AutoGidCandidateClass::kNoNetworkDegraded:
             return "no-network-degraded";
         case AutoGidCandidateClass::kFallbackNonzero:
@@ -103,8 +110,14 @@ inline std::optional<AutoGidCandidateClass> classifyAutoGidCandidate(
     const bool is_degraded = is_overlay || is_link_local;
 
     if (candidate.has_network_device) {
-        return is_degraded ? AutoGidCandidateClass::kNetworkDegraded
-                           : AutoGidCandidateClass::kNetworkRoutable;
+        // A non-routable link-local GID must never outrank a network-backed
+        // IPv4 GID, even one flagged as degraded/overlay (e.g. an RFC1918
+        // 10.0.0.0/8 address that a routed RoCEv2 fabric legitimately uses).
+        if (is_link_local) {
+            return AutoGidCandidateClass::kNetworkLinkLocal;
+        }
+        return is_overlay ? AutoGidCandidateClass::kNetworkDegraded
+                          : AutoGidCandidateClass::kNetworkRoutable;
     }
 
     return is_degraded ? AutoGidCandidateClass::kNoNetworkDegraded
@@ -120,12 +133,14 @@ inline int autoGidCandidateClassPriority(
             return 1;
         case AutoGidCandidateClass::kNetworkDegraded:
             return 2;
-        case AutoGidCandidateClass::kNoNetworkDegraded:
+        case AutoGidCandidateClass::kNetworkLinkLocal:
             return 3;
-        case AutoGidCandidateClass::kFallbackNonzero:
+        case AutoGidCandidateClass::kNoNetworkDegraded:
             return 4;
+        case AutoGidCandidateClass::kFallbackNonzero:
+            return 5;
     }
-    return 5;
+    return 6;
 }
 
 inline std::vector<AutoGidSelection> rankAutoGidCandidates(

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -746,6 +746,7 @@ static GidNetworkState autoGidStateFromSelection(
     switch (selection.candidate_class) {
         case AutoGidCandidateClass::kNetworkRoutable:
         case AutoGidCandidateClass::kNetworkDegraded:
+        case AutoGidCandidateClass::kNetworkLinkLocal:
             return GidNetworkState::GID_WITH_NETWORK;
         case AutoGidCandidateClass::kNoNetworkRoutable:
         case AutoGidCandidateClass::kNoNetworkDegraded:

--- a/mooncake-transfer-engine/tests/rdma_gid_probe_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_gid_probe_test.cpp
@@ -101,6 +101,56 @@ TEST(RdmaGidProbeTest, DemotesOverlayCandidateBehindNormalNetworkCandidate) {
     EXPECT_EQ(selection->gid_index, 1);
 }
 
+// Regression for routed RoCEv2 fabrics: index 0 is a network-backed link-local
+// GID and index 1 is a network-backed IPv4 GID whose address falls in RFC1918
+// space (e.g. 10.0.0.0/8), so it is flagged as an overlay. Before the fix both
+// landed in the same "network-degraded" class and the tie-break on gid_index
+// picked the non-routable link-local GID, which breaks the cross-node RTR
+// handshake. The routable IPv4 GID must win.
+TEST(RdmaGidProbeTest, PrefersOverlayIpv4OverLinkLocalOnNetworkBackedDevice) {
+    std::vector<AutoGidCandidate> candidates = {
+        makeCandidate(/*gid_index=*/0, IBV_GID_TYPE_ROCE_V2,
+                      /*has_network_device=*/true,
+                      /*is_ipv4_mapped=*/false,
+                      /*is_link_local_ipv6=*/true),
+        makeCandidate(/*gid_index=*/1, IBV_GID_TYPE_ROCE_V2,
+                      /*has_network_device=*/true,
+                      /*is_ipv4_mapped=*/true,
+                      /*is_link_local_ipv6=*/false,
+                      /*is_overlay_network=*/false,
+                      /*is_overlay_ipv4=*/true),
+    };
+
+    auto selection = selectBestAutoGidCandidate(candidates);
+    ASSERT_TRUE(selection.has_value());
+    EXPECT_EQ(selection->gid_index, 1);
+    EXPECT_EQ(selection->candidate_class,
+              AutoGidCandidateClass::kNetworkDegraded);
+}
+
+// Same scenario as above but with the candidate order reversed, to prove the
+// outcome comes from the class ranking rather than input ordering.
+TEST(RdmaGidProbeTest, PrefersOverlayIpv4OverLinkLocalRegardlessOfOrder) {
+    std::vector<AutoGidCandidate> candidates = {
+        makeCandidate(/*gid_index=*/0, IBV_GID_TYPE_ROCE_V2,
+                      /*has_network_device=*/true,
+                      /*is_ipv4_mapped=*/true,
+                      /*is_link_local_ipv6=*/false,
+                      /*is_overlay_network=*/false,
+                      /*is_overlay_ipv4=*/true),
+        makeCandidate(/*gid_index=*/1, IBV_GID_TYPE_ROCE_V2,
+                      /*has_network_device=*/true,
+                      /*is_ipv4_mapped=*/false,
+                      /*is_link_local_ipv6=*/true),
+    };
+
+    auto selection = selectBestAutoGidCandidate(candidates);
+    ASSERT_TRUE(selection.has_value());
+    EXPECT_EQ(selection->gid_index, 0);
+    EXPECT_EQ(selection->candidate_class,
+              AutoGidCandidateClass::kNetworkDegraded);
+}
+
 TEST(RdmaGidProbeTest,
      PrefersNoNetworkRoutableOverDegradedNetworkBackedCandidate) {
     std::vector<AutoGidCandidate> candidates = {


### PR DESCRIPTION
## Problem
Fixes #2747. On routed RoCEv2 fabrics using RFC1918 addressing (e.g.
10.0.0.0/8), auto-GID selection picks a non-routable link-local GID over the
routable IPv4 GID, so cross-node QPs never reach RTR and transfers fail.

The routable IPv4 GID is flagged as an overlay by `isOverlayIPv4` (10/8,
172.16/12, 100.64/10) and lands in `kNetworkDegraded`; a network-backed
link-local GID also landed in `kNetworkDegraded`, so the stable tie-break on
ascending `gid_index` chose the link-local GID.

## Fix
Introduce a dedicated `kNetworkLinkLocal` class ranked strictly below every
network-backed IPv4 class, so a link-local GID is chosen only when no
network-backed IPv4 GID exists. Wired into the priority table, the string
helper, and `autoGidStateFromSelection` (still `GID_WITH_NETWORK`).

Only the auto-GID path (`gid_index < 0`) is affected; explicit-index
deployments are unchanged.

## Testing
- Unit: existing `rdma_gid_probe_test.cpp` cases still pass; added an ionic
  regression (network-backed link-local vs network-backed overlay-IPv4 → IPv4
  wins) plus a reversed-order variant.
- HW `transfer_engine_bench`, auto-GID (no explicit index), two fabrics:
  - routed RoCEv2 (10.102.x.x): **before** → selects link-local GID[0], transfer
    fails at RTR; **after** → selects routable GID[1] (10.102.x.x), completes
    (~48 GB/s).
  - flat-L2 (exposes a normal routable IPv4 GID): selection unchanged, no
    regression (~41 GB/s before and after).