### PR TITLE
[TE] Fix MNNVL staging path reading capabilities from RDMA transport

### DIFF
--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -1313,7 +1313,7 @@ void TransferEngineImpl::findStagingPolicy(const Request& request,
     }
     // case 2: pure mnnvl
     if (transport_list_[MNNVL] && transport_list_[NVLINK]) {
-        auto& xport = transport_list_[RDMA];
+        auto& xport = transport_list_[MNNVL];
         auto& caps = xport->capabilities();
         if (local_mtype == MTYPE_CPU && remote_mtype == MTYPE_CPU &&
             !caps.dram_to_dram) {


### PR DESCRIPTION
## Description

Fix a bug in `TransferEngineImpl::findStagingPolicy` (tent runtime) where
the "pure mnnvl" branch (`transfer_engine_impl.cpp:1315-1329`) is guarded
by `transport_list_[MNNVL] && transport_list_[NVLINK]` but reads
`capabilities()` from `transport_list_[RDMA]`.

Two problems:

1. **Null deref risk.** The scenario this branch is designed for is
   MNNVL + NVLINK *without* RDMA (that is what "pure mnnvl" means; the
   RDMA-present path is already handled by case 1 above). In that scenario
   `transport_list_[RDMA]` is a null `shared_ptr`, and
   `xport->capabilities()` on the next line dereferences null.

2. **Semantically wrong even when RDMA is present.** The guard only checks
   MNNVL and NVLINK, so this block also runs when RDMA happens to be
   loaded alongside them. Using RDMA's caps to drive MNNVL staging
   decisions doesn't match the branch's stated intent.

Fix: read caps from `transport_list_[MNNVL]`, matching the guard. This
also aligns with case 1 (guard `RDMA && NVLINK` → caps from RDMA) and
case 3 (guard `TPU && (RDMA || TCP)` → caps from the guarded transport)
in the same function — all three branches are now consistent.

Diff: single line, `transport_list_[RDMA]` → `transport_list_[MNNVL]`.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

- [x] Manual testing done

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh` (verified via `--check`, no formatting delta)

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

Claude Code helped identify the mismatch between the guard condition and
the transport being read for capabilities, and drafted this description.
The submitter reviewed and confirmed the diagnosis and the one-line fix.