### PR TITLE
[TE] Route cross-host targets over rdma automatically in rdma+hip multi-protocol segments

### DIFF
--- a/mooncake-transfer-engine/include/multi_transport_locality.h
+++ b/mooncake-transfer-engine/include/multi_transport_locality.h
@@ -15,27 +15,66 @@
 #ifndef MULTI_TRANSPORT_LOCALITY_H
 #define MULTI_TRANSPORT_LOCALITY_H
 
+#include <cctype>
 #include <string>
 
 namespace mooncake {
 
-// Segment names are formatted as "host:port". Return the host portion.
-// If no ':' is present the whole string is treated as the host.
+// Extract the host portion of a segment name. Segment names carry an optional
+// ":port" suffix, and the host may be an IPv4 address, a hostname, or an IPv6
+// literal. IPv6 literals contain multiple colons, so a naive rfind(':') would
+// corrupt them; the following forms are handled explicitly:
+//   "10.0.0.1:8000"      -> "10.0.0.1"      (IPv4 / hostname with port)
+//   "node-a"             -> "node-a"        (no port)
+//   "[2001:db8::1]:8000" -> "2001:db8::1"   (bracketed IPv6 with port)
+//   "[2001:db8::1]"      -> "2001:db8::1"   (bracketed IPv6, no port)
+//   "2001:db8::1"        -> "2001:db8::1"   (bare IPv6, no port)
 inline std::string segmentHost(const std::string& segment_name) {
-    auto pos = segment_name.rfind(':');
-    return pos == std::string::npos ? segment_name
-                                    : segment_name.substr(0, pos);
+    if (!segment_name.empty() && segment_name.front() == '[') {
+        // Bracketed IPv6 literal: strip the brackets and ignore any ":port".
+        auto close = segment_name.find(']');
+        if (close != std::string::npos) {
+            return segment_name.substr(1, close - 1);
+        }
+        return segment_name;  // Malformed; return as-is.
+    }
+    auto first = segment_name.find(':');
+    if (first == std::string::npos) {
+        return segment_name;  // No port and no colon.
+    }
+    if (first != segment_name.rfind(':')) {
+        // More than one colon and not bracketed: a bare IPv6 literal without a
+        // port (an IPv6 host with a port must use brackets). Treat it all as
+        // the host.
+        return segment_name;
+    }
+    return segment_name.substr(0, first);  // "host:port".
+}
+
+// Case-insensitive equality. Hostnames are case-insensitive per DNS, and IPv6
+// hex literals may differ only in letter case, so a plain "==" would spuriously
+// classify the same host as remote and lose the intra-node hip fast path.
+inline bool hostEquals(const std::string& a, const std::string& b) {
+    if (a.size() != b.size()) return false;
+    for (size_t i = 0; i < a.size(); ++i) {
+        if (std::tolower(static_cast<unsigned char>(a[i])) !=
+            std::tolower(static_cast<unsigned char>(b[i]))) {
+            return false;
+        }
+    }
+    return true;
 }
 
 // The device KV pool is registered under both rdma and hip in a "rdma,hip"
 // multi-protocol segment. hip transport uses GPU IPC, which only works between
 // processes on the same physical host, so a hip buffer is a valid transport for
 // a target only when that target lives on the same host as the initiator.
-// A cross-host target must fall back to rdma. Two engines co-located on one host
-// share the host portion of their segment name (they differ only in port).
+// A cross-host target must fall back to rdma. Two engines co-located on one
+// host share the host portion of their segment name (they differ only in port).
 inline bool isHipReachableTarget(const std::string& target_segment_name,
                                  const std::string& local_server_name) {
-    return segmentHost(target_segment_name) == segmentHost(local_server_name);
+    return hostEquals(segmentHost(target_segment_name),
+                      segmentHost(local_server_name));
 }
 
 }  // namespace mooncake

--- a/mooncake-transfer-engine/include/multi_transport_locality.h
+++ b/mooncake-transfer-engine/include/multi_transport_locality.h
@@ -1,0 +1,43 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MULTI_TRANSPORT_LOCALITY_H
+#define MULTI_TRANSPORT_LOCALITY_H
+
+#include <string>
+
+namespace mooncake {
+
+// Segment names are formatted as "host:port". Return the host portion.
+// If no ':' is present the whole string is treated as the host.
+inline std::string segmentHost(const std::string& segment_name) {
+    auto pos = segment_name.rfind(':');
+    return pos == std::string::npos ? segment_name
+                                    : segment_name.substr(0, pos);
+}
+
+// The device KV pool is registered under both rdma and hip in a "rdma,hip"
+// multi-protocol segment. hip transport uses GPU IPC, which only works between
+// processes on the same physical host, so a hip buffer is a valid transport for
+// a target only when that target lives on the same host as the initiator.
+// A cross-host target must fall back to rdma. Two engines co-located on one host
+// share the host portion of their segment name (they differ only in port).
+inline bool isHipReachableTarget(const std::string& target_segment_name,
+                                 const std::string& local_server_name) {
+    return segmentHost(target_segment_name) == segmentHost(local_server_name);
+}
+
+}  // namespace mooncake
+
+#endif  // MULTI_TRANSPORT_LOCALITY_H

--- a/mooncake-transfer-engine/src/multi_transport.cpp
+++ b/mooncake-transfer-engine/src/multi_transport.cpp
@@ -19,6 +19,7 @@
 #include <string>
 
 #include "config.h"
+#include "multi_transport_locality.h"
 #include "transport/rdma_transport/rdma_transport.h"
 #ifdef USE_BAREX
 #include "transport/barex_transport/barex_transport.h"
@@ -475,6 +476,14 @@ Status MultiTransport::selectTransport(const TransferRequest& entry,
             if (p == "tcp") return 1;
             return 0;
         };
+        // hip transport uses GPU IPC, which cannot reach a GPU on another host.
+        // The device KV pool is registered under both rdma and hip, so a
+        // cross-host target must skip its hip buffers and fall back to rdma.
+        // This makes the intra-node fast path (hip) and the cross-node path
+        // (rdma) work automatically from a single multi-protocol segment,
+        // without requiring the operator to set MC_DISABLE_HIP.
+        const bool hip_reachable = isHipReachableTarget(
+            target_segment_desc->name, local_server_name_);
         std::string chosen;
         int chosen_priority = -1;
         for (const auto& buffer : target_segment_desc->buffers) {
@@ -486,6 +495,7 @@ Status MultiTransport::selectTransport(const TransferRequest& entry,
                     : buffer.addr;
             if (entry.target_offset >= start &&
                 entry.target_offset < start + buffer.length) {
+                if (buffer.protocol == "hip" && !hip_reachable) continue;
                 int priority = protocol_priority(buffer.protocol);
                 if (priority > chosen_priority) {
                     chosen = buffer.protocol;
@@ -502,6 +512,12 @@ Status MultiTransport::selectTransport(const TransferRequest& entry,
         if (!transport_map_.count(chosen)) {
             return Status::NotSupportedTransport("Transport " + chosen +
                                                  " not installed");
+        }
+        if (globalConfig().trace) {
+            LOG(INFO) << "MultiTransport::selectTransport route: target_id="
+                      << entry.target_id << " segment_protocol=\"" << proto
+                      << "\" hip_reachable=" << hip_reachable
+                      << " chosen=" << chosen;
         }
         transport = transport_map_[chosen].get();
         return Status::OK();
@@ -538,6 +554,15 @@ Status MultiTransport::mp_selectTransport(const TransferRequest& entry,
     std::string item;
     while (std::getline(ss, item, ',')) {
         if (!item.empty()) protos.push_back(item);
+    }
+
+    // hip GPU IPC cannot reach a remote host; downgrade an explicit hip
+    // preference to rdma for a cross-host target (mirrors the locality gate in
+    // selectTransport).
+    if (preferred_proto == "hip" &&
+        !isHipReachableTarget(target_segment_desc->name, local_server_name_) &&
+        std::find(protos.begin(), protos.end(), "rdma") != protos.end()) {
+        preferred_proto = "rdma";
     }
 
 #ifdef USE_ASCEND_HETEROGENEOUS

--- a/mooncake-transfer-engine/src/multi_transport.cpp
+++ b/mooncake-transfer-engine/src/multi_transport.cpp
@@ -482,8 +482,8 @@ Status MultiTransport::selectTransport(const TransferRequest& entry,
         // This makes the intra-node fast path (hip) and the cross-node path
         // (rdma) work automatically from a single multi-protocol segment,
         // without requiring the operator to set MC_DISABLE_HIP.
-        const bool hip_reachable = isHipReachableTarget(
-            target_segment_desc->name, local_server_name_);
+        const bool hip_reachable =
+            isHipReachableTarget(target_segment_desc->name, local_server_name_);
         std::string chosen;
         int chosen_priority = -1;
         for (const auto& buffer : target_segment_desc->buffers) {
@@ -557,12 +557,25 @@ Status MultiTransport::mp_selectTransport(const TransferRequest& entry,
     }
 
     // hip GPU IPC cannot reach a remote host; downgrade an explicit hip
-    // preference to rdma for a cross-host target (mirrors the locality gate in
-    // selectTransport).
+    // preference to a cross-host-capable transport for a cross-host target
+    // (mirrors the locality gate in selectTransport). Prefer rdma, then tcp.
     if (preferred_proto == "hip" &&
-        !isHipReachableTarget(target_segment_desc->name, local_server_name_) &&
-        std::find(protos.begin(), protos.end(), "rdma") != protos.end()) {
-        preferred_proto = "rdma";
+        !isHipReachableTarget(target_segment_desc->name, local_server_name_)) {
+        std::string fallback;
+        for (const char* candidate : {"rdma", "tcp"}) {
+            if (std::find(protos.begin(), protos.end(), candidate) !=
+                protos.end()) {
+                fallback = candidate;
+                break;
+            }
+        }
+        if (fallback.empty()) {
+            return Status::NotSupportedTransport(
+                "hip target is cross-host but segment " +
+                std::to_string(entry.target_id) +
+                " offers no cross-host transport (rdma/tcp)");
+        }
+        preferred_proto = fallback;
     }
 
 #ifdef USE_ASCEND_HETEROGENEOUS

--- a/mooncake-transfer-engine/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tests/CMakeLists.txt
@@ -244,6 +244,13 @@ target_link_libraries(rdma_gid_probe_test PUBLIC transfer_engine gtest
                                                  gtest_main)
 add_test(NAME rdma_gid_probe_test COMMAND rdma_gid_probe_test)
 
+add_executable(multi_transport_locality_test
+               ${WORKSPACE}/multi_transport_locality_test.cpp)
+target_link_libraries(multi_transport_locality_test PUBLIC transfer_engine gtest
+                                                           gtest_main)
+add_test(NAME multi_transport_locality_test
+         COMMAND multi_transport_locality_test)
+
 add_executable(rdma_context_reprobe_test
                ${WORKSPACE}/rdma_context_reprobe_test.cpp)
 target_link_libraries(rdma_context_reprobe_test PUBLIC transfer_engine gtest

--- a/mooncake-transfer-engine/tests/multi_transport_locality_test.cpp
+++ b/mooncake-transfer-engine/tests/multi_transport_locality_test.cpp
@@ -1,0 +1,56 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "multi_transport_locality.h"
+
+using namespace mooncake;
+
+TEST(MultiTransportLocalityTest, SegmentHostStripsPort) {
+    EXPECT_EQ(segmentHost("10.0.0.1:12345"), "10.0.0.1");
+    EXPECT_EQ(segmentHost("node-a:8000"), "node-a");
+    // No port: whole string is the host.
+    EXPECT_EQ(segmentHost("node-a"), "node-a");
+    EXPECT_EQ(segmentHost(""), "");
+}
+
+TEST(MultiTransportLocalityTest, HipReachableForSameHostDifferentPort) {
+    // Two engines co-located on one host share the host, differ only in port.
+    EXPECT_TRUE(isHipReachableTarget("10.0.0.1:20000", "10.0.0.1:20001"));
+    EXPECT_TRUE(isHipReachableTarget("node-a:8000", "node-a:9000"));
+}
+
+TEST(MultiTransportLocalityTest, HipReachableForIdenticalName) {
+    EXPECT_TRUE(isHipReachableTarget("node-a:8000", "node-a:8000"));
+}
+
+TEST(MultiTransportLocalityTest, HipNotReachableForRemoteHost) {
+    // Cross-host target: hip (GPU IPC) is not usable, must fall back to rdma.
+    EXPECT_FALSE(isHipReachableTarget("10.0.0.2:20000", "10.0.0.1:20000"));
+    EXPECT_FALSE(isHipReachableTarget("node-b:8000", "node-a:8000"));
+}
+
+TEST(MultiTransportLocalityTest, HandlesMissingPort) {
+    // Locality decision still works when one side has no explicit port.
+    EXPECT_TRUE(isHipReachableTarget("node-a", "node-a:8000"));
+    EXPECT_FALSE(isHipReachableTarget("node-b", "node-a:8000"));
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/mooncake-transfer-engine/tests/multi_transport_locality_test.cpp
+++ b/mooncake-transfer-engine/tests/multi_transport_locality_test.cpp
@@ -50,6 +50,34 @@ TEST(MultiTransportLocalityTest, HandlesMissingPort) {
     EXPECT_FALSE(isHipReachableTarget("node-b", "node-a:8000"));
 }
 
+TEST(MultiTransportLocalityTest, SegmentHostParsesIPv6) {
+    // Bracketed IPv6 with and without a port.
+    EXPECT_EQ(segmentHost("[2001:db8::1]:8000"), "2001:db8::1");
+    EXPECT_EQ(segmentHost("[2001:db8::1]"), "2001:db8::1");
+    EXPECT_EQ(segmentHost("[::1]:20000"), "::1");
+    // Bare IPv6 literal without a port: the whole string is the host.
+    EXPECT_EQ(segmentHost("2001:db8::1"), "2001:db8::1");
+    EXPECT_EQ(segmentHost("::1"), "::1");
+}
+
+TEST(MultiTransportLocalityTest, HipReachableForIPv6) {
+    // Same IPv6 host, different ports (bracketed) -> intra-node hip.
+    EXPECT_TRUE(
+        isHipReachableTarget("[2001:db8::1]:20000", "[2001:db8::1]:20001"));
+    // Bracketed-with-port vs bare literal for the same host must still match.
+    EXPECT_TRUE(isHipReachableTarget("[2001:db8::1]:20000", "2001:db8::1"));
+    // Different IPv6 hosts -> cross-node, fall back to rdma.
+    EXPECT_FALSE(
+        isHipReachableTarget("[2001:db8::1]:20000", "[2001:db8::2]:20000"));
+}
+
+TEST(MultiTransportLocalityTest, HostMatchIsCaseInsensitive) {
+    // Hostnames and IPv6 hex literals are case-insensitive.
+    EXPECT_TRUE(isHipReachableTarget("Node-A:8000", "node-a:9000"));
+    EXPECT_TRUE(
+        isHipReachableTarget("[2001:DB8::1]:8000", "[2001:db8::1]:9000"));
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();


### PR DESCRIPTION
## Summary
A `"rdma,hip"` multi-protocol segment registers the device KV pool under **both** rdma and hip. hip transport uses GPU IPC (`hipIpcOpenMemHandle`), which only works between processes on the **same physical host**. Today `MultiTransport::selectTransport` picks hip by fixed priority (`hip > cxl > rdma > tcp`) with no locality check, so a **cross-node** target selects hip and fails:

```
E hip_transport.cpp HipTransport: hipIpcOpenMemHandle failed (Error code: 17 - invalid device pointer)
```

The only existing mitigation is the `MC_DISABLE_HIP` env — a global switch that also kills the **intra-node** hip fast path.

## What this PR does
Adds an automatic same-host **locality gate**:
- compare the host portion (`host` of `host:port`) of the target segment name vs `local_server_name_`;
- in `selectTransport`, **skip hip buffers for cross-host targets** so they fall back to rdma; intra-node targets still use hip;
- `mp_selectTransport` mirrors the downgrade (`hip → rdma`) for an explicit hip preference.

Result: single multi-protocol segment → **hip intra-node, rdma cross-node, no env needed**. `MC_DISABLE_HIP` is kept as a manual override for backward compatibility.

The locality helpers are factored into `multi_transport_locality.h` with a unit test (`multi_transport_locality_test`), matching the `rdma_gid_probe` pattern.

## Testing
- New `multi_transport_locality_test` (same-host different-port → hip; cross-host → rdma; missing-port handling).
- HW-verified on MI355X (both ionic and bnxt RoCEv2, TP1 and TP4, Qwen + DeepSeek-V4 MLA), **no `MC_DISABLE_HIP`**:
  - single-node → `hip_reachable=1 chosen=hip`, intra-node GPU P2P, no crash;
  - cross-node → `hip_reachable=0 chosen=rdma`, **zero err17**, KV transferred over rdma.

## Context
Fixes the cross-node half of the AMD/ROCm multi-protocol flakiness described in #2752.