### PR TITLE
[TE] Fix cross-GPU NVLink/MNNVL event-stream device mismatch (#2722)

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/transport/mnnvl/mnnvl_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/mnnvl/mnnvl_transport.h
@@ -46,6 +46,7 @@ struct MnnvlSubBatch : public Transport::SubBatch {
     size_t max_size;
     CUDAStreamHandle sync_stream;
     CUDAStreamHandle async_stream;
+    int stream_device_id = -1;
     // Completion events created in startTransfer (one per submit). Destroyed by
     // the destructor (RAII); Slab<T>::deallocate() invokes ~MnnvlSubBatch()
     // before reusing the storage, so this runs on every free.

--- a/mooncake-transfer-engine/tent/include/tent/transport/nvlink/nvlink_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/nvlink/nvlink_transport.h
@@ -48,6 +48,7 @@ struct NVLinkSubBatch : public Transport::SubBatch {
     size_t max_size;
     CUDAStreamHandle sync_stream;
     CUDAStreamHandle async_stream;
+    int stream_device_id = -1;
     // Completion events created in startTransfer (one per submit). Destroyed by
     // the destructor (RAII); Slab<T>::deallocate() invokes ~NVLinkSubBatch()
     // before reusing the storage, so this runs on every free.

--- a/mooncake-transfer-engine/tent/src/transport/mnnvl/mnnvl_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/mnnvl/mnnvl_transport.cpp
@@ -319,15 +319,19 @@ void MnnvlTransport::startTransfer(std::vector<MnnvlTask *> &tasks,
     if (batch->stream_device_id >= 0) {
         auto err = cudaGetDevice(&saved_device);
         if (err != cudaSuccess) {
-            LOG(ERROR) << "MnnvlTransport: cudaGetDevice failed: " << cudaGetErrorString(err);
-            for (auto *task : tasks) task->status_word = TransferStatusEnum::FAILED;
+            LOG(ERROR) << "MnnvlTransport: cudaGetDevice failed: "
+                       << cudaGetErrorString(err);
+            for (auto *task : tasks)
+                task->status_word = TransferStatusEnum::FAILED;
             return;
         }
         if (saved_device != batch->stream_device_id) {
             err = cudaSetDevice(batch->stream_device_id);
             if (err != cudaSuccess) {
-                LOG(ERROR) << "MnnvlTransport: cudaSetDevice failed: " << cudaGetErrorString(err);
-                for (auto *task : tasks) task->status_word = TransferStatusEnum::FAILED;
+                LOG(ERROR) << "MnnvlTransport: cudaSetDevice failed: "
+                           << cudaGetErrorString(err);
+                for (auto *task : tasks)
+                    task->status_word = TransferStatusEnum::FAILED;
                 return;
             }
         }

--- a/mooncake-transfer-engine/tent/src/transport/mnnvl/mnnvl_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/mnnvl/mnnvl_transport.cpp
@@ -238,6 +238,7 @@ Status MnnvlTransport::submitTransferTasks(
                                                   stream_device));
         CHECK_STATUS(platform_->getStreamFromPool(mnnvl_batch->async_stream,
                                                   stream_device));
+        mnnvl_batch->stream_device_id = stream_device;
     }
 
     startTransfer(new_tasks, mnnvl_batch);
@@ -312,11 +313,25 @@ void MnnvlTransport::startTransfer(std::vector<MnnvlTask *> &tasks,
         return;
     }
 
+    // Save and set device to match the stream's device to ensure event
+    // creation and recording happen on the correct device (fix for #2722).
+    int saved_device = -1;
+    if (batch->stream_device_id >= 0) {
+        CHECK_CUDA(cudaGetDevice(&saved_device));
+        if (saved_device != batch->stream_device_id) {
+            CHECK_CUDA(cudaSetDevice(batch->stream_device_id));
+        }
+    }
+
     cudaEvent_t event;
     auto event_err = cudaEventCreateWithFlags(&event, cudaEventDisableTiming);
     if (event_err != cudaSuccess) {
         LOG(ERROR) << "MnnvlTransport: cudaEventCreateWithFlags failed: "
                    << cudaGetErrorString(event_err);
+        // Restore device before returning
+        if (saved_device >= 0 && saved_device != batch->stream_device_id) {
+            cudaSetDevice(saved_device);
+        }
         for (auto *task : tasks) task->status_word = TransferStatusEnum::FAILED;
         return;
     }
@@ -325,9 +340,19 @@ void MnnvlTransport::startTransfer(std::vector<MnnvlTask *> &tasks,
         LOG(ERROR) << "MnnvlTransport: cudaEventRecord failed: "
                    << cudaGetErrorString(record_err);
         cudaEventDestroy(event);
+        // Restore device before returning
+        if (saved_device >= 0 && saved_device != batch->stream_device_id) {
+            cudaSetDevice(saved_device);
+        }
         for (auto *task : tasks) task->status_word = TransferStatusEnum::FAILED;
         return;
     }
+
+    // Restore original device
+    if (saved_device >= 0 && saved_device != batch->stream_device_id) {
+        CHECK_CUDA(cudaSetDevice(saved_device));
+    }
+
     batch->completion_events.push_back(event);
     for (auto *task : tasks) task->completion_event = event;
 }

--- a/mooncake-transfer-engine/tent/src/transport/mnnvl/mnnvl_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/mnnvl/mnnvl_transport.cpp
@@ -317,9 +317,19 @@ void MnnvlTransport::startTransfer(std::vector<MnnvlTask *> &tasks,
     // creation and recording happen on the correct device (fix for #2722).
     int saved_device = -1;
     if (batch->stream_device_id >= 0) {
-        CHECK_CUDA(cudaGetDevice(&saved_device));
+        auto err = cudaGetDevice(&saved_device);
+        if (err != cudaSuccess) {
+            LOG(ERROR) << "MnnvlTransport: cudaGetDevice failed: " << cudaGetErrorString(err);
+            for (auto *task : tasks) task->status_word = TransferStatusEnum::FAILED;
+            return;
+        }
         if (saved_device != batch->stream_device_id) {
-            CHECK_CUDA(cudaSetDevice(batch->stream_device_id));
+            err = cudaSetDevice(batch->stream_device_id);
+            if (err != cudaSuccess) {
+                LOG(ERROR) << "MnnvlTransport: cudaSetDevice failed: " << cudaGetErrorString(err);
+                for (auto *task : tasks) task->status_word = TransferStatusEnum::FAILED;
+                return;
+            }
         }
     }
 
@@ -350,7 +360,7 @@ void MnnvlTransport::startTransfer(std::vector<MnnvlTask *> &tasks,
 
     // Restore original device
     if (saved_device >= 0 && saved_device != batch->stream_device_id) {
-        CHECK_CUDA(cudaSetDevice(saved_device));
+        cudaSetDevice(saved_device);
     }
 
     batch->completion_events.push_back(event);

--- a/mooncake-transfer-engine/tent/src/transport/nvlink/nvlink_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/nvlink/nvlink_transport.cpp
@@ -278,9 +278,19 @@ void NVLinkTransport::startTransfer(std::vector<NVLinkTask*>& tasks,
     // creation and recording happen on the correct device (fix for #2722).
     int saved_device = -1;
     if (batch->stream_device_id >= 0) {
-        CHECK_CUDA(cudaGetDevice(&saved_device));
+        auto err = cudaGetDevice(&saved_device);
+        if (err != cudaSuccess) {
+            LOG(ERROR) << "NVLinkTransport: cudaGetDevice failed: " << cudaGetErrorString(err);
+            for (auto* task : tasks) task->status_word = TransferStatusEnum::FAILED;
+            return;
+        }
         if (saved_device != batch->stream_device_id) {
-            CHECK_CUDA(cudaSetDevice(batch->stream_device_id));
+            err = cudaSetDevice(batch->stream_device_id);
+            if (err != cudaSuccess) {
+                LOG(ERROR) << "NVLinkTransport: cudaSetDevice failed: " << cudaGetErrorString(err);
+                for (auto* task : tasks) task->status_word = TransferStatusEnum::FAILED;
+                return;
+            }
         }
     }
 
@@ -311,7 +321,7 @@ void NVLinkTransport::startTransfer(std::vector<NVLinkTask*>& tasks,
 
     // Restore original device
     if (saved_device >= 0 && saved_device != batch->stream_device_id) {
-        CHECK_CUDA(cudaSetDevice(saved_device));
+        cudaSetDevice(saved_device);
     }
 
     batch->completion_events.push_back(event);

--- a/mooncake-transfer-engine/tent/src/transport/nvlink/nvlink_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/nvlink/nvlink_transport.cpp
@@ -194,6 +194,7 @@ Status NVLinkTransport::submitTransferTasks(
                                                   stream_device));
         CHECK_STATUS(platform_->getStreamFromPool(shm_batch->async_stream,
                                                   stream_device));
+        shm_batch->stream_device_id = stream_device;
     }
 
     startTransfer(new_tasks, shm_batch);
@@ -273,11 +274,25 @@ void NVLinkTransport::startTransfer(std::vector<NVLinkTask*>& tasks,
         }
     }
 
+    // Save and set device to match the stream's device to ensure event
+    // creation and recording happen on the correct device (fix for #2722).
+    int saved_device = -1;
+    if (batch->stream_device_id >= 0) {
+        CHECK_CUDA(cudaGetDevice(&saved_device));
+        if (saved_device != batch->stream_device_id) {
+            CHECK_CUDA(cudaSetDevice(batch->stream_device_id));
+        }
+    }
+
     cudaEvent_t event;
     auto event_err = cudaEventCreateWithFlags(&event, cudaEventDisableTiming);
     if (event_err != cudaSuccess) {
         LOG(ERROR) << "NVLinkTransport: cudaEventCreateWithFlags failed: "
                    << cudaGetErrorString(event_err);
+        // Restore device before returning
+        if (saved_device >= 0 && saved_device != batch->stream_device_id) {
+            cudaSetDevice(saved_device);
+        }
         for (auto* task : tasks) task->status_word = TransferStatusEnum::FAILED;
         return;
     }
@@ -286,9 +301,19 @@ void NVLinkTransport::startTransfer(std::vector<NVLinkTask*>& tasks,
         LOG(ERROR) << "NVLinkTransport: cudaEventRecord failed: "
                    << cudaGetErrorString(record_err);
         cudaEventDestroy(event);
+        // Restore device before returning
+        if (saved_device >= 0 && saved_device != batch->stream_device_id) {
+            cudaSetDevice(saved_device);
+        }
         for (auto* task : tasks) task->status_word = TransferStatusEnum::FAILED;
         return;
     }
+
+    // Restore original device
+    if (saved_device >= 0 && saved_device != batch->stream_device_id) {
+        CHECK_CUDA(cudaSetDevice(saved_device));
+    }
+
     batch->completion_events.push_back(event);
     for (auto* task : tasks) task->completion_event = event;
 }

--- a/mooncake-transfer-engine/tent/src/transport/nvlink/nvlink_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/nvlink/nvlink_transport.cpp
@@ -280,15 +280,19 @@ void NVLinkTransport::startTransfer(std::vector<NVLinkTask*>& tasks,
     if (batch->stream_device_id >= 0) {
         auto err = cudaGetDevice(&saved_device);
         if (err != cudaSuccess) {
-            LOG(ERROR) << "NVLinkTransport: cudaGetDevice failed: " << cudaGetErrorString(err);
-            for (auto* task : tasks) task->status_word = TransferStatusEnum::FAILED;
+            LOG(ERROR) << "NVLinkTransport: cudaGetDevice failed: "
+                       << cudaGetErrorString(err);
+            for (auto* task : tasks)
+                task->status_word = TransferStatusEnum::FAILED;
             return;
         }
         if (saved_device != batch->stream_device_id) {
             err = cudaSetDevice(batch->stream_device_id);
             if (err != cudaSuccess) {
-                LOG(ERROR) << "NVLinkTransport: cudaSetDevice failed: " << cudaGetErrorString(err);
-                for (auto* task : tasks) task->status_word = TransferStatusEnum::FAILED;
+                LOG(ERROR) << "NVLinkTransport: cudaSetDevice failed: "
+                           << cudaGetErrorString(err);
+                for (auto* task : tasks)
+                    task->status_word = TransferStatusEnum::FAILED;
                 return;
             }
         }


### PR DESCRIPTION
## Description

Fixes #2722 - Cross-GPU NVLink/MNNVL transfers fail with "cudaEventRecord: invalid resource handle" error.

### Problem
When transferring data between different GPUs via NVLink or MNNVL, the transfer fails with: cudaEventRecord: invalid resource handle

Same-GPU transfers work correctly (~1.3 TB/s).

### Root Cause
CUDA events and streams have a device mismatch:
  1. `CUDAStreamPool::acquire()` creates a stream on the target device (e.g., device 1)
  2. The pool restores the caller's original device after stream creation (e.g., device 0)
  3. `cudaEventCreateWithFlags()` creates an event on the **current device** (device 0)
  4. `cudaEventRecord()` tries to record the device-0 event into the device-1 stream → **error**

### Solution
  - Store the stream's device ID in `NVLinkSubBatch` and `MnnvlSubBatch` structures
  - Wrap event creation and recording in a device guard that switches to the stream's device
  - Restore the original device on all code paths (including error paths)

  This ensures events and streams are always created on the same device.

### Changes
  - `tent/include/tent/transport/nvlink/nvlink_transport.h`: Add `stream_device_id` field
  - `tent/include/tent/transport/mnnvl/mnnvl_transport.h`: Add `stream_device_id` field
  - `tent/src/transport/nvlink/nvlink_transport.cpp`: Store device ID and add device guard in `startTransfer()`
  - `tent/src/transport/mnnvl/mnnvl_transport.cpp`: Store device ID and add device guard in `startTransfer()`

  ### Testing
  - ✅ Code compiles successfully with CUDA 12.6
  - ✅ Device switching pattern matches existing code (`setCudaDeviceForLocation()`)
  - ✅ All error paths correctly restore device state
  - 🔄 Requires multi-GPU testing to verify cross-GPU transfers work correctly

  ### Checklist
  - [ ] Code follows project style guidelines
  - [ ] Changes are minimal and focused on the issue
  - [ ] Error handling is complete
  - [ ] Comments explain the fix (references #2722)
  - [ ] Tested on multi-GPU hardware (requires hardware access)

  ### AI Assistance Disclosure
  This fix was developed with AI assistance (Claude Opus 4.8). All code changes have been reviewed and verified by the human submitter.