### PR TITLE
[Store] feat: allow configuring client tenant id

### DIFF
--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -675,6 +675,7 @@ The store service CLI only accepts `--config`, `-D/--define`, `--port`, and `--m
 | `MOONCAKE_LOCAL_HOSTNAME` | `local_hostname` | `localhost` | |
 | `MOONCAKE_OFFLOAD_ENABLED` | `enable_ssd_offload` | `false` | Client-side SSD offload |
 | `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH` | `ssd_offload_path` | empty | Offload directory |
+| `MOONCAKE_TENANT_ID` | `tenant_id` | `default` | Tenant identifier |
 | `MOONCAKE_CONFIG_PATH` | — | unset | Path to a JSON config file (takes precedence over the variables above) |
 
 ```{note}
@@ -705,12 +706,14 @@ Or via a JSON config file. The service also exposes a lightweight HTTP API (on `
   "local_buffer_size": 268435456,
   "protocol": "tcp",
   "device_name": "",
-  "master_server_address": "127.0.0.1:50051"
+  "master_server_address": "127.0.0.1:50051",
+  "tenant_id": "default"
 }
 ```
 
 ```bash
 python -m mooncake.mooncake_store_service --config=<config_path> --port=8081
+python -m mooncake.mooncake_store_service --config=<config_path> -Dtenant_id=tenant-a
 ```
 
 ### Method C — Resource-owning Real Client (`mooncake_client`)
@@ -721,7 +724,8 @@ Run the `mooncake_client` binary as a standalone RPC process that owns storage r
 mooncake_client \
   --global_segment_size="4GB" \
   --master_server_address="127.0.0.1:50051" \
-  --metadata_server="http://127.0.0.1:8080/metadata"
+  --metadata_server="http://127.0.0.1:8080/metadata" \
+  --tenant_id="default"
 ```
 
 | Flag | Default | Description |
@@ -734,6 +738,7 @@ mooncake_client \
 | `--protocol` | `tcp` | Transfer protocol |
 | `--device_names` | empty | Transfer device name(s), comma-separated |
 | `--threads` | `1` | Client worker thread count |
+| `--tenant_id` | `default` | Tenant identifier |
 | `--enable_offload` | `false` | Enable client-side SSD offload |
 | `--start_offload_rpc_server` | `true` | Start the offload RPC server for dummy clients |
 

--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -2167,7 +2167,8 @@ PYBIND11_MODULE(store, m) {
             "  ipc_socket_path: IPC socket path.\n"
             "  enable_ssd_offload: Enable SSD offload (default false).\n"
             "  ssd_offload_path: SSD storage directory path (overrides env "
-            "var).")
+            "var).\n"
+            "  tenant_id: Tenant identifier (default 'default').")
         .def(
             "setup_dummy",
             [](MooncakeStorePyWrapper &self, size_t mem_pool_size,

--- a/mooncake-store/src/real_client_main.cpp
+++ b/mooncake-store/src/real_client_main.cpp
@@ -18,6 +18,7 @@ DEFINE_string(protocol, "tcp", "Protocol");
 DEFINE_int32(port, 50052, "Real Client service port");
 DEFINE_string(global_segment_size, "4 GB", "Size of global segment");
 DEFINE_int32(threads, 1, "Number of threads for client service");
+DEFINE_string(tenant_id, "default", "Tenant identifier");
 DEFINE_bool(enable_offload, false, "Enable offload availability");
 DEFINE_bool(start_offload_rpc_server, true,
             "Expose TCP RPC for disk-tier reads "
@@ -112,7 +113,8 @@ int main(int argc, char *argv[]) {
         FLAGS_host, FLAGS_metadata_server, global_segment_size, 0,
         FLAGS_protocol, FLAGS_device_names, FLAGS_master_server_address,
         nullptr, "@mooncake_client_" + std::to_string(FLAGS_port) + ".sock",
-        FLAGS_port, FLAGS_enable_offload, FLAGS_start_offload_rpc_server);
+        FLAGS_port, FLAGS_enable_offload, FLAGS_start_offload_rpc_server, "",
+        FLAGS_tenant_id);
     if (!res) {
         LOG(FATAL) << "Failed to setup client: " << toString(res.error());
         return -1;

--- a/mooncake-wheel/mooncake/mooncake_config.py
+++ b/mooncake-wheel/mooncake/mooncake_config.py
@@ -185,6 +185,7 @@ class MooncakeConfig:
         for field in required_fields:
             if field not in config:
                 raise ValueError(f"Missing required config field: {field}")
+        tenant_id = config.get("tenant_id")
         return MooncakeConfig(
             local_hostname=config.get("local_hostname"),
             metadata_server=config.get("metadata_server"),
@@ -199,7 +200,7 @@ class MooncakeConfig:
             master_server_address=config.get("master_server_address"),
             enable_ssd_offload=_parse_bool(config.get("enable_ssd_offload", False)),
             ssd_offload_path=str(config.get("ssd_offload_path", "")),
-            tenant_id=str(config.get("tenant_id", "default")),
+            tenant_id=str(tenant_id) if tenant_id is not None else "default",
         )
 
     @staticmethod

--- a/mooncake-wheel/mooncake/mooncake_config.py
+++ b/mooncake-wheel/mooncake/mooncake_config.py
@@ -45,6 +45,7 @@ export MOONCAKE_DEVICE="mlx5_0"
 export MOONCAKE_PROTOCOL="rdma"
 export MOONCAKE_DEVICE="auto-discovery"
 """
+
 import json
 import os
 from dataclasses import dataclass
@@ -55,13 +56,13 @@ DEFAULT_LOCAL_BUFFER_SIZE = 1073741824  # 1.0 GiB
 
 _SIZE_SUFFIXES = [
     ("kb", 1024),
-    ("mb", 1024 ** 2),
-    ("gb", 1024 ** 3),
-    ("tb", 1024 ** 4),
+    ("mb", 1024**2),
+    ("gb", 1024**3),
+    ("tb", 1024**4),
     ("k", 1024),
-    ("m", 1024 ** 2),
-    ("g", 1024 ** 3),
-    ("t", 1024 ** 4),
+    ("m", 1024**2),
+    ("g", 1024**3),
+    ("t", 1024**4),
     ("b", 1),
 ]
 
@@ -129,6 +130,7 @@ class MooncakeConfig:
         master_server_address (str): The address of the master server.
         enable_ssd_offload (bool): Enable SSD offload. Default is False.
         ssd_offload_path (str): The path to the SSD directory for offloading.
+        tenant_id (str): Tenant identifier. Default is "default".
 
     Example of configuration file:
         {
@@ -140,9 +142,10 @@ class MooncakeConfig:
             "device_name": "",
             "master_server_address": "localhost:8081",
             "enable_ssd_offload": true,
-            "ssd_offload_path": "/nvme/mooncake_offload"
+            "ssd_offload_path": "/nvme/mooncake_offload",
+            "tenant_id": "default"
         }
-        
+
         For RDMA:
         {
             "local_hostname": "node1",
@@ -153,9 +156,11 @@ class MooncakeConfig:
             "device_name": "mlx5_0",
             "master_server_address": "master:8081",
             "enable_ssd_offload": true,
-            "ssd_offload_path": "/nvme/mooncake_offload"
+            "ssd_offload_path": "/nvme/mooncake_offload",
+            "tenant_id": "default"
         }
     """
+
     local_hostname: str
     metadata_server: str
     global_segment_size: int
@@ -165,9 +170,10 @@ class MooncakeConfig:
     master_server_address: str
     enable_ssd_offload: bool = False
     ssd_offload_path: str = ""
+    tenant_id: str = "default"
 
     @staticmethod
-    def from_file(file_path: str) -> 'MooncakeConfig':
+    def from_file(file_path: str) -> "MooncakeConfig":
         """Load the config from a JSON file."""
         with open(file_path) as fin:
             config = json.load(fin)
@@ -193,25 +199,32 @@ class MooncakeConfig:
             master_server_address=config.get("master_server_address"),
             enable_ssd_offload=_parse_bool(config.get("enable_ssd_offload", False)),
             ssd_offload_path=str(config.get("ssd_offload_path", "")),
+            tenant_id=str(config.get("tenant_id", "default")),
         )
 
     @staticmethod
-    def load_from_env() -> 'MooncakeConfig':
+    def load_from_env() -> "MooncakeConfig":
         """Load config from a file specified in the environment variable.
         export MOONCAKE_MASTER=10.13.3.232:50051
         export MOONCAKE_PROTOCOL="rdma"
         export MOONCAKE_DEVICE=""
         export MOONCAKE_TE_META_DATA_SERVER="P2PHANDSHAKE"
         """
-        config_file_path = os.getenv('MOONCAKE_CONFIG_PATH')
+        config_file_path = os.getenv("MOONCAKE_CONFIG_PATH")
         if config_file_path is None:
             if not os.getenv("MOONCAKE_MASTER"):
-                raise ValueError("Neither the environment variable 'MOONCAKE_CONFIG_PATH' nor 'MOONCAKE_MASTER' is set.")
+                raise ValueError(
+                    "Neither the environment variable 'MOONCAKE_CONFIG_PATH' nor 'MOONCAKE_MASTER' is set."
+                )
             return MooncakeConfig(
                 local_hostname=os.getenv("MOONCAKE_LOCAL_HOSTNAME", "localhost"),
-                metadata_server=os.getenv("MOONCAKE_TE_META_DATA_SERVER", "P2PHANDSHAKE"),
+                metadata_server=os.getenv(
+                    "MOONCAKE_TE_META_DATA_SERVER", "P2PHANDSHAKE"
+                ),
                 global_segment_size=_parse_segment_size(
-                    os.getenv("MOONCAKE_GLOBAL_SEGMENT_SIZE", DEFAULT_GLOBAL_SEGMENT_SIZE)
+                    os.getenv(
+                        "MOONCAKE_GLOBAL_SEGMENT_SIZE", DEFAULT_GLOBAL_SEGMENT_SIZE
+                    )
                 ),
                 local_buffer_size=_parse_segment_size(
                     os.getenv("MOONCAKE_LOCAL_BUFFER_SIZE", DEFAULT_LOCAL_BUFFER_SIZE)
@@ -219,7 +232,10 @@ class MooncakeConfig:
                 protocol=os.getenv("MOONCAKE_PROTOCOL", "tcp"),
                 device_name=os.getenv("MOONCAKE_DEVICE", ""),
                 master_server_address=os.getenv("MOONCAKE_MASTER"),
-                enable_ssd_offload=_parse_bool(os.getenv("MOONCAKE_OFFLOAD_ENABLED", "false")),
+                enable_ssd_offload=_parse_bool(
+                    os.getenv("MOONCAKE_OFFLOAD_ENABLED", "false")
+                ),
                 ssd_offload_path=os.getenv("MOONCAKE_OFFLOAD_FILE_STORAGE_PATH", ""),
+                tenant_id=os.getenv("MOONCAKE_TENANT_ID", "default"),
             )
         return MooncakeConfig.from_file(config_file_path)

--- a/mooncake-wheel/mooncake/mooncake_config.py
+++ b/mooncake-wheel/mooncake/mooncake_config.py
@@ -45,7 +45,6 @@ export MOONCAKE_DEVICE="mlx5_0"
 export MOONCAKE_PROTOCOL="rdma"
 export MOONCAKE_DEVICE="auto-discovery"
 """
-
 import json
 import os
 from dataclasses import dataclass
@@ -56,13 +55,13 @@ DEFAULT_LOCAL_BUFFER_SIZE = 1073741824  # 1.0 GiB
 
 _SIZE_SUFFIXES = [
     ("kb", 1024),
-    ("mb", 1024**2),
-    ("gb", 1024**3),
-    ("tb", 1024**4),
+    ("mb", 1024 ** 2),
+    ("gb", 1024 ** 3),
+    ("tb", 1024 ** 4),
     ("k", 1024),
-    ("m", 1024**2),
-    ("g", 1024**3),
-    ("t", 1024**4),
+    ("m", 1024 ** 2),
+    ("g", 1024 ** 3),
+    ("t", 1024 ** 4),
     ("b", 1),
 ]
 
@@ -145,7 +144,7 @@ class MooncakeConfig:
             "ssd_offload_path": "/nvme/mooncake_offload",
             "tenant_id": "default"
         }
-
+        
         For RDMA:
         {
             "local_hostname": "node1",
@@ -160,7 +159,6 @@ class MooncakeConfig:
             "tenant_id": "default"
         }
     """
-
     local_hostname: str
     metadata_server: str
     global_segment_size: int
@@ -173,7 +171,7 @@ class MooncakeConfig:
     tenant_id: str = "default"
 
     @staticmethod
-    def from_file(file_path: str) -> "MooncakeConfig":
+    def from_file(file_path: str) -> 'MooncakeConfig':
         """Load the config from a JSON file."""
         with open(file_path) as fin:
             config = json.load(fin)
@@ -185,6 +183,7 @@ class MooncakeConfig:
         for field in required_fields:
             if field not in config:
                 raise ValueError(f"Missing required config field: {field}")
+        ssd_offload_path = config.get("ssd_offload_path")
         tenant_id = config.get("tenant_id")
         return MooncakeConfig(
             local_hostname=config.get("local_hostname"),
@@ -199,33 +198,27 @@ class MooncakeConfig:
             device_name=config.get("device_name", ""),
             master_server_address=config.get("master_server_address"),
             enable_ssd_offload=_parse_bool(config.get("enable_ssd_offload", False)),
-            ssd_offload_path=str(config.get("ssd_offload_path", "")),
+            ssd_offload_path=str(ssd_offload_path) if ssd_offload_path is not None else "",
             tenant_id=str(tenant_id) if tenant_id is not None else "default",
         )
 
     @staticmethod
-    def load_from_env() -> "MooncakeConfig":
+    def load_from_env() -> 'MooncakeConfig':
         """Load config from a file specified in the environment variable.
         export MOONCAKE_MASTER=10.13.3.232:50051
         export MOONCAKE_PROTOCOL="rdma"
         export MOONCAKE_DEVICE=""
         export MOONCAKE_TE_META_DATA_SERVER="P2PHANDSHAKE"
         """
-        config_file_path = os.getenv("MOONCAKE_CONFIG_PATH")
+        config_file_path = os.getenv('MOONCAKE_CONFIG_PATH')
         if config_file_path is None:
             if not os.getenv("MOONCAKE_MASTER"):
-                raise ValueError(
-                    "Neither the environment variable 'MOONCAKE_CONFIG_PATH' nor 'MOONCAKE_MASTER' is set."
-                )
+                raise ValueError("Neither the environment variable 'MOONCAKE_CONFIG_PATH' nor 'MOONCAKE_MASTER' is set.")
             return MooncakeConfig(
                 local_hostname=os.getenv("MOONCAKE_LOCAL_HOSTNAME", "localhost"),
-                metadata_server=os.getenv(
-                    "MOONCAKE_TE_META_DATA_SERVER", "P2PHANDSHAKE"
-                ),
+                metadata_server=os.getenv("MOONCAKE_TE_META_DATA_SERVER", "P2PHANDSHAKE"),
                 global_segment_size=_parse_segment_size(
-                    os.getenv(
-                        "MOONCAKE_GLOBAL_SEGMENT_SIZE", DEFAULT_GLOBAL_SEGMENT_SIZE
-                    )
+                    os.getenv("MOONCAKE_GLOBAL_SEGMENT_SIZE", DEFAULT_GLOBAL_SEGMENT_SIZE)
                 ),
                 local_buffer_size=_parse_segment_size(
                     os.getenv("MOONCAKE_LOCAL_BUFFER_SIZE", DEFAULT_LOCAL_BUFFER_SIZE)
@@ -233,9 +226,7 @@ class MooncakeConfig:
                 protocol=os.getenv("MOONCAKE_PROTOCOL", "tcp"),
                 device_name=os.getenv("MOONCAKE_DEVICE", ""),
                 master_server_address=os.getenv("MOONCAKE_MASTER"),
-                enable_ssd_offload=_parse_bool(
-                    os.getenv("MOONCAKE_OFFLOAD_ENABLED", "false")
-                ),
+                enable_ssd_offload=_parse_bool(os.getenv("MOONCAKE_OFFLOAD_ENABLED", "false")),
                 ssd_offload_path=os.getenv("MOONCAKE_OFFLOAD_FILE_STORAGE_PATH", ""),
                 tenant_id=os.getenv("MOONCAKE_TENANT_ID", "default"),
             )

--- a/mooncake-wheel/mooncake/mooncake_store_service.py
+++ b/mooncake-wheel/mooncake/mooncake_store_service.py
@@ -20,7 +20,6 @@ def _timed_handler(operation_name, handler):
         finally:
             elapsed_ms = (time.perf_counter() - start_time) * 1000
             logging.info(f"{operation_name} operation completed in {elapsed_ms:.2f} ms")
-
     return wrapper
 
 
@@ -64,12 +63,10 @@ class MooncakeStoreService:
         self._setup_logging()
 
         # State for /api/reconfigure (Prefill/Decode mode switch)
-        self.current_mode = "prefill"  # "prefill" or "decode"
-        self.mounted_segment_ids = []  # persisted segment_ids from last decode mount
-        self.last_mount_info = {}  # last mount parameters for debugging
-        self._state_lock = (
-            asyncio.Lock()
-        )  # serialize reconfigure/mount/unmount state changes
+        self.current_mode = "prefill"          # "prefill" or "decode"
+        self.mounted_segment_ids = []          # persisted segment_ids from last decode mount
+        self.last_mount_info = {}              # last mount parameters for debugging
+        self._state_lock = asyncio.Lock()      # serialize reconfigure/mount/unmount state changes
 
         try:
             if config_path:
@@ -91,7 +88,7 @@ class MooncakeStoreService:
     def _setup_logging(self):
         logging.basicConfig(
             level=logging.INFO,
-            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+            format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
         )
 
     async def start_store_service(self, max_wait_time: float = 60):
@@ -135,15 +132,13 @@ class MooncakeStoreService:
                     None,
                     self.config.enable_ssd_offload,
                     self.config.ssd_offload_path,
-                    self.config.tenant_id,
+                    self.config.tenant_id
                 )
 
                 if ret != 0:
                     raise RuntimeError("Store initialization failed")
 
-                logging.info(
-                    f"Store service started successfully on {self.config.local_hostname}"
-                )
+                logging.info(f"Store service started successfully on {self.config.local_hostname}")
                 return True
 
             except Exception as e:
@@ -152,9 +147,7 @@ class MooncakeStoreService:
                 remaining_time = max_wait_time - elapsed_after_attempt
 
                 # Calculate actual sleep duration
-                actual_sleep_time = (
-                    min(retry_interval, remaining_time) if remaining_time > 0 else 0
-                )
+                actual_sleep_time = min(retry_interval, remaining_time) if remaining_time > 0 else 0
 
                 logging.warning(
                     f"Store startup failed (attempt {retry_count}): {e}. "
@@ -165,40 +158,24 @@ class MooncakeStoreService:
                 if actual_sleep_time > 0:
                     await asyncio.sleep(actual_sleep_time)
 
+
     async def start_http_service(self, port: int = 8080):
         app = web.Application(client_max_size=1024 * 1024 * 100)  # 100MB limit
-        app.add_routes(
-            [
-                web.post(
-                    "/api/reconfigure",
-                    _timed_handler("RECONFIGURE", self.handle_reconfigure),
-                ),
-                web.post(
-                    "/api/mount_shm", _timed_handler("MOUNT_SHM", self.handle_mount_shm)
-                ),
-                web.post(
-                    "/api/unmount_shm",
-                    _timed_handler("UNMOUNT_SHM", self.handle_unmount_shm),
-                ),
-                web.post("/api/mount", _timed_handler("MOUNT", self.handle_mount)),
-                web.post(
-                    "/api/unmount", _timed_handler("UNMOUNT", self.handle_unmount)
-                ),
-                web.put("/api/put", _timed_handler("PUT", self.handle_put)),
-                web.get("/api/get/{key}", _timed_handler("GET", self.handle_get)),
-                web.get("/api/exist/{key}", _timed_handler("EXIST", self.handle_exist)),
-                web.delete(
-                    "/api/remove/{key}", _timed_handler("REMOVE", self.handle_remove)
-                ),
-                web.delete(
-                    "/api/remove_all",
-                    _timed_handler("REMOVE_ALL", self.handle_remove_all),
-                ),
-            ]
-        )
+        app.add_routes([
+            web.post('/api/reconfigure', _timed_handler("RECONFIGURE", self.handle_reconfigure)),
+            web.post('/api/mount_shm', _timed_handler("MOUNT_SHM", self.handle_mount_shm)),
+            web.post('/api/unmount_shm', _timed_handler("UNMOUNT_SHM", self.handle_unmount_shm)),
+            web.post('/api/mount', _timed_handler("MOUNT", self.handle_mount)),
+            web.post('/api/unmount', _timed_handler("UNMOUNT", self.handle_unmount)),
+            web.put('/api/put', _timed_handler("PUT", self.handle_put)),
+            web.get('/api/get/{key}', _timed_handler("GET", self.handle_get)),
+            web.get('/api/exist/{key}', _timed_handler("EXIST", self.handle_exist)),
+            web.delete('/api/remove/{key}', _timed_handler("REMOVE", self.handle_remove)),
+            web.delete('/api/remove_all', _timed_handler("REMOVE_ALL", self.handle_remove_all))
+        ])
         runner = web.AppRunner(app)
         await runner.setup()
-        site = web.TCPSite(runner, "0.0.0.0", port)
+        site = web.TCPSite(runner, '0.0.0.0', port)
         await site.start()
         logging.info(f"REST API started on port {port}")
         return True
@@ -219,34 +196,24 @@ class MooncakeStoreService:
                 if not path or size is None:
                     return web.Response(
                         status=400,
-                        text=json.dumps(
-                            {"error": "Missing path or size for decode mode"}
-                        ),
-                        content_type="application/json",
+                        text=json.dumps({"error": "Missing path or size for decode mode"}),
+                        content_type="application/json"
                     )
 
                 async with self._state_lock:
                     # If already in decode mode with mounted segments, unmount them first
                     if self.mounted_segment_ids:
-                        logging.info(
-                            "Reconfigure decode: unmounting previous segments before remount"
-                        )
+                        logging.info("Reconfigure decode: unmounting previous segments before remount")
                         ret = self.store.unmount_segment(self.mounted_segment_ids)
                         if ret != 0:
                             return web.Response(
                                 status=500,
-                                text=json.dumps(
-                                    {
-                                        "error": f"Unmount of previous segments failed, ret={ret}"
-                                    }
-                                ),
-                                content_type="application/json",
+                                text=json.dumps({"error": f"Unmount of previous segments failed, ret={ret}"}),
+                                content_type="application/json"
                             )
                         self.mounted_segment_ids.clear()
 
-                    result = self.store.mount_segment(
-                        path, size, offset, protocol, location
-                    )
+                    result = self.store.mount_segment(path, size, offset, protocol, location)
                     if result["ret"] != 0:
                         self.current_mode = "prefill"
                         self.mounted_segment_ids.clear()
@@ -262,29 +229,24 @@ class MooncakeStoreService:
                                     "mode": self.current_mode,
                                 }
                             ),
-                            content_type="application/json",
+                            content_type="application/json"
                         )
 
                     self.mounted_segment_ids = list(result["segment_ids"])
                     self.current_mode = "decode"
                     self.last_mount_info = {
-                        "path": path,
-                        "offset": offset,
-                        "size": size,
-                        "protocol": protocol,
-                        "location": location,
+                        "path": path, "offset": offset, "size": size,
+                        "protocol": protocol, "location": location
                     }
 
                 return web.Response(
                     status=200,
-                    text=json.dumps(
-                        {
-                            "status": "success",
-                            "mode": self.current_mode,
-                            "segment_ids": self.mounted_segment_ids,
-                        }
-                    ),
-                    content_type="application/json",
+                    text=json.dumps({
+                        "status": "success",
+                        "mode": self.current_mode,
+                        "segment_ids": self.mounted_segment_ids,
+                    }),
+                    content_type="application/json"
                 )
 
             elif mode == "prefill":
@@ -294,10 +256,8 @@ class MooncakeStoreService:
                         if ret != 0:
                             return web.Response(
                                 status=500,
-                                text=json.dumps(
-                                    {"error": f"Unmount failed, ret={ret}"}
-                                ),
-                                content_type="application/json",
+                                text=json.dumps({"error": f"Unmount failed, ret={ret}"}),
+                                content_type="application/json"
                             )
                         self.mounted_segment_ids.clear()
 
@@ -307,23 +267,21 @@ class MooncakeStoreService:
                 return web.Response(
                     status=200,
                     text=json.dumps({"status": "success", "mode": self.current_mode}),
-                    content_type="application/json",
+                    content_type="application/json"
                 )
 
             else:
                 return web.Response(
                     status=400,
-                    text=json.dumps(
-                        {"error": "Invalid mode. Use 'decode' or 'prefill'"}
-                    ),
-                    content_type="application/json",
+                    text=json.dumps({"error": "Invalid mode. Use 'decode' or 'prefill'"}),
+                    content_type="application/json"
                 )
         except Exception as e:
             logging.error("RECONFIGURE error: %s", e)
             return web.Response(
                 status=500,
                 text=json.dumps({"error": str(e)}),
-                content_type="application/json",
+                content_type="application/json"
             )
 
     async def handle_mount_shm(self, request):
@@ -340,7 +298,7 @@ class MooncakeStoreService:
                 return web.Response(
                     status=400,
                     text=json.dumps({"error": "Missing or invalid name or size"}),
-                    content_type="application/json",
+                    content_type="application/json"
                 )
 
             result = self.store.mount_segment(path, size, offset, protocol, location)
@@ -348,7 +306,7 @@ class MooncakeStoreService:
                 return web.Response(
                     status=500,
                     text=json.dumps({"error": f"Mount failed, ret={result['ret']}"}),
-                    content_type="application/json",
+                    content_type="application/json"
                 )
 
             return web.Response(
@@ -366,7 +324,7 @@ class MooncakeStoreService:
             return web.Response(
                 status=500,
                 text=json.dumps({"error": str(e)}),
-                content_type="application/json",
+                content_type="application/json"
             )
 
     async def handle_unmount_shm(self, request):
@@ -417,7 +375,7 @@ class MooncakeStoreService:
             return web.Response(
                 status=500,
                 text=json.dumps({"error": str(e)}),
-                content_type="application/json",
+                content_type="application/json"
             )
 
     async def handle_mount(self, request):
@@ -430,20 +388,16 @@ class MooncakeStoreService:
             if type(size) is not int or size <= 0:
                 return web.Response(
                     status=400,
-                    text=json.dumps(
-                        {"error": "Invalid size, must be a positive integer"}
-                    ),
-                    content_type="application/json",
+                    text=json.dumps({"error": "Invalid size, must be a positive integer"}),
+                    content_type="application/json"
                 )
 
             result = self.store.allocate_and_mount_segment(size, protocol, location)
             if result["ret"] != 0:
                 return web.Response(
                     status=500,
-                    text=json.dumps(
-                        {"error": f"Allocate and mount failed, ret={result['ret']}"}
-                    ),
-                    content_type="application/json",
+                    text=json.dumps({"error": f"Allocate and mount failed, ret={result['ret']}"}),
+                    content_type="application/json"
                 )
 
             return web.Response(
@@ -462,7 +416,7 @@ class MooncakeStoreService:
             return web.Response(
                 status=500,
                 text=json.dumps({"error": str(e)}),
-                content_type="application/json",
+                content_type="application/json"
             )
 
     async def handle_unmount(self, request):
@@ -479,11 +433,15 @@ class MooncakeStoreService:
                 )
 
             grace_period_seconds = data.get("grace_period_seconds", 0)
-            ret = self.store.unmount_and_free_segment(segment_ids, grace_period_seconds)
+            ret = self.store.unmount_and_free_segment(
+                segment_ids, grace_period_seconds
+            )
             if ret != 0:
                 return web.Response(
                     status=500,
-                    text=json.dumps({"error": f"Unmount and free failed, ret={ret}"}),
+                    text=json.dumps(
+                        {"error": f"Unmount and free failed, ret={ret}"}
+                    ),
                     content_type="application/json",
                 )
 
@@ -497,20 +455,20 @@ class MooncakeStoreService:
             return web.Response(
                 status=500,
                 text=json.dumps({"error": str(e)}),
-                content_type="application/json",
+                content_type="application/json"
             )
 
     async def handle_put(self, request):
         try:
             data = await request.json()
-            key = data.get("key")
-            raw_value = data.get("value")
+            key = data.get('key')
+            raw_value = data.get('value')
 
             if not key or raw_value is None:
                 return web.Response(
                     status=400,
-                    text=json.dumps({"error": "Missing key or value"}),
-                    content_type="application/json",
+                    text=json.dumps({'error': 'Missing key or value'}),
+                    content_type='application/json'
                 )
 
             value = raw_value.encode()
@@ -518,122 +476,124 @@ class MooncakeStoreService:
             if ret != 0:
                 return web.Response(
                     status=500,
-                    text=json.dumps({"error": "PUT operation failed"}),
-                    content_type="application/json",
+                    text=json.dumps({'error': 'PUT operation failed'}),
+                    content_type='application/json'
                 )
 
             return web.Response(
                 status=200,
-                text=json.dumps({"status": "success"}),
-                content_type="application/json",
+                text=json.dumps({'status': 'success'}),
+                content_type='application/json'
             )
         except Exception as e:
             logging.error("PUT error: %s", e)
             return web.Response(
                 status=500,
-                text=json.dumps({"error": str(e)}),
-                content_type="application/json",
+                text=json.dumps({'error': str(e)}),
+                content_type='application/json'
             )
 
     async def handle_get(self, request):
         try:
-            key = request.match_info["key"]
+            key = request.match_info['key']
             exists = self.store.is_exist(key)
 
             if exists == 0:
                 return web.Response(
                     status=404,
-                    text=json.dumps({"error": "Key not found"}),
-                    content_type="application/json",
+                    text=json.dumps({'error': 'Key not found'}),
+                    content_type='application/json'
                 )
             if exists < 0:
                 return web.Response(
                     status=500,
-                    text=json.dumps({"error": "Exist check failed"}),
-                    content_type="application/json",
+                    text=json.dumps({'error': 'Exist check failed'}),
+                    content_type='application/json'
                 )
 
             value = self.store.get(key)
             if value is None:
                 return web.Response(
                     status=500,
-                    text=json.dumps({"error": "GET operation failed"}),
-                    content_type="application/json",
+                    text=json.dumps({'error': 'GET operation failed'}),
+                    content_type='application/json'
                 )
             if value == b"":
                 exists = self.store.is_exist(key)
                 if exists == 0:
                     return web.Response(
                         status=404,
-                        text=json.dumps({"error": "Key not found"}),
-                        content_type="application/json",
+                        text=json.dumps({'error': 'Key not found'}),
+                        content_type='application/json'
                     )
                 if exists < 0:
                     return web.Response(
                         status=500,
-                        text=json.dumps({"error": "Exist check failed"}),
-                        content_type="application/json",
+                        text=json.dumps({'error': 'Exist check failed'}),
+                        content_type='application/json'
                     )
 
             return web.Response(
-                status=200, body=value, content_type="application/octet-stream"
+                status=200,
+                body=value,
+                content_type='application/octet-stream'
             )
         except Exception as e:
             logging.error("GET error: %s", e)
             return web.Response(
                 status=500,
-                text=json.dumps({"error": str(e)}),
-                content_type="application/json",
+                text=json.dumps({'error': str(e)}),
+                content_type='application/json'
             )
 
     async def handle_exist(self, request):
         try:
-            key = request.match_info["key"]
+            key = request.match_info['key']
             exists = self.store.is_exist(key)
 
             if exists < 0:
                 return web.Response(
                     status=500,
-                    text=json.dumps({"error": "Exist check failed"}),
-                    content_type="application/json",
+                    text=json.dumps({'error': 'Exist check failed'}),
+                    content_type='application/json'
                 )
 
             return web.Response(
                 status=200,
-                text=json.dumps({"exists": exists > 0}),
-                content_type="application/json",
+                text=json.dumps({'exists': exists > 0}),
+                content_type='application/json'
             )
         except Exception as e:
             logging.error("EXIST error: %s", e)
             return web.Response(
                 status=500,
-                text=json.dumps({"error": str(e)}),
-                content_type="application/json",
+                text=json.dumps({'error': str(e)}),
+                content_type='application/json'
             )
 
     async def handle_remove(self, request):
         try:
-            key = request.match_info["key"]
+            key = request.match_info['key']
             ret = self.store.remove(key)
 
             if ret != 0:
                 return web.Response(
                     status=500,
-                    text=json.dumps({"error": "Remove operation failed"}),
-                    content_type="application/json",
+                    text=json.dumps({'error': 'Remove operation failed'}),
+                    content_type='application/json'
                 )
 
             return web.Response(
                 status=200,
-                text=json.dumps({"status": "success"}),
-                content_type="application/json",
+                text=json.dumps({'status': 'success'}),
+                content_type='application/json'
             )
         except Exception as e:
             logging.error("REMOVE error: %s", e)
             return web.Response(
                 status=500,
-                text=json.dumps({"error": str(e)}),
-                content_type="application/json",
+                text=json.dumps({'error': str(e)}),
+                content_type='application/json'
             )
 
     async def handle_remove_all(self, request):
@@ -643,21 +603,21 @@ class MooncakeStoreService:
             if ret < 0:
                 return web.Response(
                     status=500,
-                    text=json.dumps({"error": "RemoveAll operation failed"}),
-                    content_type="application/json",
+                    text=json.dumps({'error': 'RemoveAll operation failed'}),
+                    content_type='application/json'
                 )
 
             return web.Response(
                 status=200,
-                text=json.dumps({"status": "success removed " + str(ret) + " keys"}),
-                content_type="application/json",
+                text=json.dumps({'status': 'success removed ' + str(ret) + ' keys'}),
+                content_type='application/json'
             )
         except Exception as e:
             logging.error("REMOVE_ALL error: %s", e)
             return web.Response(
                 status=500,
-                text=json.dumps({"error": str(e)}),
-                content_type="application/json",
+                text=json.dumps({'error': str(e)}),
+                content_type='application/json'
             )
 
     async def stop(self):
@@ -665,35 +625,23 @@ class MooncakeStoreService:
             self.store.close()
             logging.info("Mooncake service stopped")
 
-
 def parse_arguments():
-    parser = argparse.ArgumentParser(description="Mooncake Store Service with REST API")
-    parser.add_argument(
-        "--config", type=str, help="Path to Mooncake config file", required=False
-    )
-    parser.add_argument(
-        "-D",
-        "--define",
-        action="append",
-        help="Override configuration with key=value pairs (e.g., -Dlocal_hostname=example.com)",
-        default=[],
-    )
-    parser.add_argument(
-        "--port",
-        type=int,
-        help="HTTP API port (default: 8080)",
-        default=8080,
-        required=False,
-    )
-    parser.add_argument(
-        "--max-wait-time",
-        type=float,
-        help="Maximum total wait time in seconds (default: 60)",
-        default=60,
-        required=False,
-    )
+    parser = argparse.ArgumentParser(description='Mooncake Store Service with REST API')
+    parser.add_argument('--config', type=str,
+                        help='Path to Mooncake config file',
+                        required=False)
+    parser.add_argument('-D', '--define', action='append',
+                        help='Override configuration with key=value pairs (e.g., -Dlocal_hostname=example.com)',
+                        default=[])
+    parser.add_argument('--port', type=int,
+                        help='HTTP API port (default: 8080)',
+                        default=8080,
+                        required=False)
+    parser.add_argument('--max-wait-time', type=float,
+                        help='Maximum total wait time in seconds (default: 60)',
+                        default=60,
+                        required=False)
     return parser.parse_args()
-
 
 async def main():
     args = parse_arguments()
@@ -701,8 +649,8 @@ async def main():
     # Parse -D key=value pairs into a dictionary
     cli_config = {}
     for item in args.define:
-        if "=" in item:
-            key, value = item.split("=", 1)
+        if '=' in item:
+            key, value = item.split('=', 1)
             cli_config[key] = value
         else:
             logging.warning(f"Ignoring invalid CLI config: {item}")

--- a/mooncake-wheel/mooncake/mooncake_store_service.py
+++ b/mooncake-wheel/mooncake/mooncake_store_service.py
@@ -20,6 +20,7 @@ def _timed_handler(operation_name, handler):
         finally:
             elapsed_ms = (time.perf_counter() - start_time) * 1000
             logging.info(f"{operation_name} operation completed in {elapsed_ms:.2f} ms")
+
     return wrapper
 
 
@@ -63,10 +64,12 @@ class MooncakeStoreService:
         self._setup_logging()
 
         # State for /api/reconfigure (Prefill/Decode mode switch)
-        self.current_mode = "prefill"          # "prefill" or "decode"
-        self.mounted_segment_ids = []          # persisted segment_ids from last decode mount
-        self.last_mount_info = {}              # last mount parameters for debugging
-        self._state_lock = asyncio.Lock()      # serialize reconfigure/mount/unmount state changes
+        self.current_mode = "prefill"  # "prefill" or "decode"
+        self.mounted_segment_ids = []  # persisted segment_ids from last decode mount
+        self.last_mount_info = {}  # last mount parameters for debugging
+        self._state_lock = (
+            asyncio.Lock()
+        )  # serialize reconfigure/mount/unmount state changes
 
         try:
             if config_path:
@@ -88,7 +91,7 @@ class MooncakeStoreService:
     def _setup_logging(self):
         logging.basicConfig(
             level=logging.INFO,
-            format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
         )
 
     async def start_store_service(self, max_wait_time: float = 60):
@@ -131,13 +134,16 @@ class MooncakeStoreService:
                     self.config.master_server_address,
                     None,
                     self.config.enable_ssd_offload,
-                    self.config.ssd_offload_path
+                    self.config.ssd_offload_path,
+                    self.config.tenant_id,
                 )
 
                 if ret != 0:
                     raise RuntimeError("Store initialization failed")
 
-                logging.info(f"Store service started successfully on {self.config.local_hostname}")
+                logging.info(
+                    f"Store service started successfully on {self.config.local_hostname}"
+                )
                 return True
 
             except Exception as e:
@@ -146,7 +152,9 @@ class MooncakeStoreService:
                 remaining_time = max_wait_time - elapsed_after_attempt
 
                 # Calculate actual sleep duration
-                actual_sleep_time = min(retry_interval, remaining_time) if remaining_time > 0 else 0
+                actual_sleep_time = (
+                    min(retry_interval, remaining_time) if remaining_time > 0 else 0
+                )
 
                 logging.warning(
                     f"Store startup failed (attempt {retry_count}): {e}. "
@@ -157,24 +165,40 @@ class MooncakeStoreService:
                 if actual_sleep_time > 0:
                     await asyncio.sleep(actual_sleep_time)
 
-
     async def start_http_service(self, port: int = 8080):
         app = web.Application(client_max_size=1024 * 1024 * 100)  # 100MB limit
-        app.add_routes([
-            web.post('/api/reconfigure', _timed_handler("RECONFIGURE", self.handle_reconfigure)),
-            web.post('/api/mount_shm', _timed_handler("MOUNT_SHM", self.handle_mount_shm)),
-            web.post('/api/unmount_shm', _timed_handler("UNMOUNT_SHM", self.handle_unmount_shm)),
-            web.post('/api/mount', _timed_handler("MOUNT", self.handle_mount)),
-            web.post('/api/unmount', _timed_handler("UNMOUNT", self.handle_unmount)),
-            web.put('/api/put', _timed_handler("PUT", self.handle_put)),
-            web.get('/api/get/{key}', _timed_handler("GET", self.handle_get)),
-            web.get('/api/exist/{key}', _timed_handler("EXIST", self.handle_exist)),
-            web.delete('/api/remove/{key}', _timed_handler("REMOVE", self.handle_remove)),
-            web.delete('/api/remove_all', _timed_handler("REMOVE_ALL", self.handle_remove_all))
-        ])
+        app.add_routes(
+            [
+                web.post(
+                    "/api/reconfigure",
+                    _timed_handler("RECONFIGURE", self.handle_reconfigure),
+                ),
+                web.post(
+                    "/api/mount_shm", _timed_handler("MOUNT_SHM", self.handle_mount_shm)
+                ),
+                web.post(
+                    "/api/unmount_shm",
+                    _timed_handler("UNMOUNT_SHM", self.handle_unmount_shm),
+                ),
+                web.post("/api/mount", _timed_handler("MOUNT", self.handle_mount)),
+                web.post(
+                    "/api/unmount", _timed_handler("UNMOUNT", self.handle_unmount)
+                ),
+                web.put("/api/put", _timed_handler("PUT", self.handle_put)),
+                web.get("/api/get/{key}", _timed_handler("GET", self.handle_get)),
+                web.get("/api/exist/{key}", _timed_handler("EXIST", self.handle_exist)),
+                web.delete(
+                    "/api/remove/{key}", _timed_handler("REMOVE", self.handle_remove)
+                ),
+                web.delete(
+                    "/api/remove_all",
+                    _timed_handler("REMOVE_ALL", self.handle_remove_all),
+                ),
+            ]
+        )
         runner = web.AppRunner(app)
         await runner.setup()
-        site = web.TCPSite(runner, '0.0.0.0', port)
+        site = web.TCPSite(runner, "0.0.0.0", port)
         await site.start()
         logging.info(f"REST API started on port {port}")
         return True
@@ -195,24 +219,34 @@ class MooncakeStoreService:
                 if not path or size is None:
                     return web.Response(
                         status=400,
-                        text=json.dumps({"error": "Missing path or size for decode mode"}),
-                        content_type="application/json"
+                        text=json.dumps(
+                            {"error": "Missing path or size for decode mode"}
+                        ),
+                        content_type="application/json",
                     )
 
                 async with self._state_lock:
                     # If already in decode mode with mounted segments, unmount them first
                     if self.mounted_segment_ids:
-                        logging.info("Reconfigure decode: unmounting previous segments before remount")
+                        logging.info(
+                            "Reconfigure decode: unmounting previous segments before remount"
+                        )
                         ret = self.store.unmount_segment(self.mounted_segment_ids)
                         if ret != 0:
                             return web.Response(
                                 status=500,
-                                text=json.dumps({"error": f"Unmount of previous segments failed, ret={ret}"}),
-                                content_type="application/json"
+                                text=json.dumps(
+                                    {
+                                        "error": f"Unmount of previous segments failed, ret={ret}"
+                                    }
+                                ),
+                                content_type="application/json",
                             )
                         self.mounted_segment_ids.clear()
 
-                    result = self.store.mount_segment(path, size, offset, protocol, location)
+                    result = self.store.mount_segment(
+                        path, size, offset, protocol, location
+                    )
                     if result["ret"] != 0:
                         self.current_mode = "prefill"
                         self.mounted_segment_ids.clear()
@@ -228,24 +262,29 @@ class MooncakeStoreService:
                                     "mode": self.current_mode,
                                 }
                             ),
-                            content_type="application/json"
+                            content_type="application/json",
                         )
 
                     self.mounted_segment_ids = list(result["segment_ids"])
                     self.current_mode = "decode"
                     self.last_mount_info = {
-                        "path": path, "offset": offset, "size": size,
-                        "protocol": protocol, "location": location
+                        "path": path,
+                        "offset": offset,
+                        "size": size,
+                        "protocol": protocol,
+                        "location": location,
                     }
 
                 return web.Response(
                     status=200,
-                    text=json.dumps({
-                        "status": "success",
-                        "mode": self.current_mode,
-                        "segment_ids": self.mounted_segment_ids,
-                    }),
-                    content_type="application/json"
+                    text=json.dumps(
+                        {
+                            "status": "success",
+                            "mode": self.current_mode,
+                            "segment_ids": self.mounted_segment_ids,
+                        }
+                    ),
+                    content_type="application/json",
                 )
 
             elif mode == "prefill":
@@ -255,8 +294,10 @@ class MooncakeStoreService:
                         if ret != 0:
                             return web.Response(
                                 status=500,
-                                text=json.dumps({"error": f"Unmount failed, ret={ret}"}),
-                                content_type="application/json"
+                                text=json.dumps(
+                                    {"error": f"Unmount failed, ret={ret}"}
+                                ),
+                                content_type="application/json",
                             )
                         self.mounted_segment_ids.clear()
 
@@ -266,21 +307,23 @@ class MooncakeStoreService:
                 return web.Response(
                     status=200,
                     text=json.dumps({"status": "success", "mode": self.current_mode}),
-                    content_type="application/json"
+                    content_type="application/json",
                 )
 
             else:
                 return web.Response(
                     status=400,
-                    text=json.dumps({"error": "Invalid mode. Use 'decode' or 'prefill'"}),
-                    content_type="application/json"
+                    text=json.dumps(
+                        {"error": "Invalid mode. Use 'decode' or 'prefill'"}
+                    ),
+                    content_type="application/json",
                 )
         except Exception as e:
             logging.error("RECONFIGURE error: %s", e)
             return web.Response(
                 status=500,
                 text=json.dumps({"error": str(e)}),
-                content_type="application/json"
+                content_type="application/json",
             )
 
     async def handle_mount_shm(self, request):
@@ -297,7 +340,7 @@ class MooncakeStoreService:
                 return web.Response(
                     status=400,
                     text=json.dumps({"error": "Missing or invalid name or size"}),
-                    content_type="application/json"
+                    content_type="application/json",
                 )
 
             result = self.store.mount_segment(path, size, offset, protocol, location)
@@ -305,7 +348,7 @@ class MooncakeStoreService:
                 return web.Response(
                     status=500,
                     text=json.dumps({"error": f"Mount failed, ret={result['ret']}"}),
-                    content_type="application/json"
+                    content_type="application/json",
                 )
 
             return web.Response(
@@ -323,7 +366,7 @@ class MooncakeStoreService:
             return web.Response(
                 status=500,
                 text=json.dumps({"error": str(e)}),
-                content_type="application/json"
+                content_type="application/json",
             )
 
     async def handle_unmount_shm(self, request):
@@ -374,7 +417,7 @@ class MooncakeStoreService:
             return web.Response(
                 status=500,
                 text=json.dumps({"error": str(e)}),
-                content_type="application/json"
+                content_type="application/json",
             )
 
     async def handle_mount(self, request):
@@ -387,16 +430,20 @@ class MooncakeStoreService:
             if type(size) is not int or size <= 0:
                 return web.Response(
                     status=400,
-                    text=json.dumps({"error": "Invalid size, must be a positive integer"}),
-                    content_type="application/json"
+                    text=json.dumps(
+                        {"error": "Invalid size, must be a positive integer"}
+                    ),
+                    content_type="application/json",
                 )
 
             result = self.store.allocate_and_mount_segment(size, protocol, location)
             if result["ret"] != 0:
                 return web.Response(
                     status=500,
-                    text=json.dumps({"error": f"Allocate and mount failed, ret={result['ret']}"}),
-                    content_type="application/json"
+                    text=json.dumps(
+                        {"error": f"Allocate and mount failed, ret={result['ret']}"}
+                    ),
+                    content_type="application/json",
                 )
 
             return web.Response(
@@ -415,7 +462,7 @@ class MooncakeStoreService:
             return web.Response(
                 status=500,
                 text=json.dumps({"error": str(e)}),
-                content_type="application/json"
+                content_type="application/json",
             )
 
     async def handle_unmount(self, request):
@@ -432,15 +479,11 @@ class MooncakeStoreService:
                 )
 
             grace_period_seconds = data.get("grace_period_seconds", 0)
-            ret = self.store.unmount_and_free_segment(
-                segment_ids, grace_period_seconds
-            )
+            ret = self.store.unmount_and_free_segment(segment_ids, grace_period_seconds)
             if ret != 0:
                 return web.Response(
                     status=500,
-                    text=json.dumps(
-                        {"error": f"Unmount and free failed, ret={ret}"}
-                    ),
+                    text=json.dumps({"error": f"Unmount and free failed, ret={ret}"}),
                     content_type="application/json",
                 )
 
@@ -454,20 +497,20 @@ class MooncakeStoreService:
             return web.Response(
                 status=500,
                 text=json.dumps({"error": str(e)}),
-                content_type="application/json"
+                content_type="application/json",
             )
 
     async def handle_put(self, request):
         try:
             data = await request.json()
-            key = data.get('key')
-            raw_value = data.get('value')
+            key = data.get("key")
+            raw_value = data.get("value")
 
             if not key or raw_value is None:
                 return web.Response(
                     status=400,
-                    text=json.dumps({'error': 'Missing key or value'}),
-                    content_type='application/json'
+                    text=json.dumps({"error": "Missing key or value"}),
+                    content_type="application/json",
                 )
 
             value = raw_value.encode()
@@ -475,124 +518,122 @@ class MooncakeStoreService:
             if ret != 0:
                 return web.Response(
                     status=500,
-                    text=json.dumps({'error': 'PUT operation failed'}),
-                    content_type='application/json'
+                    text=json.dumps({"error": "PUT operation failed"}),
+                    content_type="application/json",
                 )
 
             return web.Response(
                 status=200,
-                text=json.dumps({'status': 'success'}),
-                content_type='application/json'
+                text=json.dumps({"status": "success"}),
+                content_type="application/json",
             )
         except Exception as e:
             logging.error("PUT error: %s", e)
             return web.Response(
                 status=500,
-                text=json.dumps({'error': str(e)}),
-                content_type='application/json'
+                text=json.dumps({"error": str(e)}),
+                content_type="application/json",
             )
 
     async def handle_get(self, request):
         try:
-            key = request.match_info['key']
+            key = request.match_info["key"]
             exists = self.store.is_exist(key)
 
             if exists == 0:
                 return web.Response(
                     status=404,
-                    text=json.dumps({'error': 'Key not found'}),
-                    content_type='application/json'
+                    text=json.dumps({"error": "Key not found"}),
+                    content_type="application/json",
                 )
             if exists < 0:
                 return web.Response(
                     status=500,
-                    text=json.dumps({'error': 'Exist check failed'}),
-                    content_type='application/json'
+                    text=json.dumps({"error": "Exist check failed"}),
+                    content_type="application/json",
                 )
 
             value = self.store.get(key)
             if value is None:
                 return web.Response(
                     status=500,
-                    text=json.dumps({'error': 'GET operation failed'}),
-                    content_type='application/json'
+                    text=json.dumps({"error": "GET operation failed"}),
+                    content_type="application/json",
                 )
             if value == b"":
                 exists = self.store.is_exist(key)
                 if exists == 0:
                     return web.Response(
                         status=404,
-                        text=json.dumps({'error': 'Key not found'}),
-                        content_type='application/json'
+                        text=json.dumps({"error": "Key not found"}),
+                        content_type="application/json",
                     )
                 if exists < 0:
                     return web.Response(
                         status=500,
-                        text=json.dumps({'error': 'Exist check failed'}),
-                        content_type='application/json'
+                        text=json.dumps({"error": "Exist check failed"}),
+                        content_type="application/json",
                     )
 
             return web.Response(
-                status=200,
-                body=value,
-                content_type='application/octet-stream'
+                status=200, body=value, content_type="application/octet-stream"
             )
         except Exception as e:
             logging.error("GET error: %s", e)
             return web.Response(
                 status=500,
-                text=json.dumps({'error': str(e)}),
-                content_type='application/json'
+                text=json.dumps({"error": str(e)}),
+                content_type="application/json",
             )
 
     async def handle_exist(self, request):
         try:
-            key = request.match_info['key']
+            key = request.match_info["key"]
             exists = self.store.is_exist(key)
 
             if exists < 0:
                 return web.Response(
                     status=500,
-                    text=json.dumps({'error': 'Exist check failed'}),
-                    content_type='application/json'
+                    text=json.dumps({"error": "Exist check failed"}),
+                    content_type="application/json",
                 )
 
             return web.Response(
                 status=200,
-                text=json.dumps({'exists': exists > 0}),
-                content_type='application/json'
+                text=json.dumps({"exists": exists > 0}),
+                content_type="application/json",
             )
         except Exception as e:
             logging.error("EXIST error: %s", e)
             return web.Response(
                 status=500,
-                text=json.dumps({'error': str(e)}),
-                content_type='application/json'
+                text=json.dumps({"error": str(e)}),
+                content_type="application/json",
             )
 
     async def handle_remove(self, request):
         try:
-            key = request.match_info['key']
+            key = request.match_info["key"]
             ret = self.store.remove(key)
 
             if ret != 0:
                 return web.Response(
                     status=500,
-                    text=json.dumps({'error': 'Remove operation failed'}),
-                    content_type='application/json'
+                    text=json.dumps({"error": "Remove operation failed"}),
+                    content_type="application/json",
                 )
 
             return web.Response(
                 status=200,
-                text=json.dumps({'status': 'success'}),
-                content_type='application/json'
+                text=json.dumps({"status": "success"}),
+                content_type="application/json",
             )
         except Exception as e:
             logging.error("REMOVE error: %s", e)
             return web.Response(
                 status=500,
-                text=json.dumps({'error': str(e)}),
-                content_type='application/json'
+                text=json.dumps({"error": str(e)}),
+                content_type="application/json",
             )
 
     async def handle_remove_all(self, request):
@@ -602,21 +643,21 @@ class MooncakeStoreService:
             if ret < 0:
                 return web.Response(
                     status=500,
-                    text=json.dumps({'error': 'RemoveAll operation failed'}),
-                    content_type='application/json'
+                    text=json.dumps({"error": "RemoveAll operation failed"}),
+                    content_type="application/json",
                 )
 
             return web.Response(
                 status=200,
-                text=json.dumps({'status': 'success removed ' + str(ret) + ' keys'}),
-                content_type='application/json'
+                text=json.dumps({"status": "success removed " + str(ret) + " keys"}),
+                content_type="application/json",
             )
         except Exception as e:
             logging.error("REMOVE_ALL error: %s", e)
             return web.Response(
                 status=500,
-                text=json.dumps({'error': str(e)}),
-                content_type='application/json'
+                text=json.dumps({"error": str(e)}),
+                content_type="application/json",
             )
 
     async def stop(self):
@@ -624,23 +665,35 @@ class MooncakeStoreService:
             self.store.close()
             logging.info("Mooncake service stopped")
 
+
 def parse_arguments():
-    parser = argparse.ArgumentParser(description='Mooncake Store Service with REST API')
-    parser.add_argument('--config', type=str,
-                        help='Path to Mooncake config file',
-                        required=False)
-    parser.add_argument('-D', '--define', action='append',
-                        help='Override configuration with key=value pairs (e.g., -Dlocal_hostname=example.com)',
-                        default=[])
-    parser.add_argument('--port', type=int,
-                        help='HTTP API port (default: 8080)',
-                        default=8080,
-                        required=False)
-    parser.add_argument('--max-wait-time', type=float,
-                        help='Maximum total wait time in seconds (default: 60)',
-                        default=60,
-                        required=False)
+    parser = argparse.ArgumentParser(description="Mooncake Store Service with REST API")
+    parser.add_argument(
+        "--config", type=str, help="Path to Mooncake config file", required=False
+    )
+    parser.add_argument(
+        "-D",
+        "--define",
+        action="append",
+        help="Override configuration with key=value pairs (e.g., -Dlocal_hostname=example.com)",
+        default=[],
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        help="HTTP API port (default: 8080)",
+        default=8080,
+        required=False,
+    )
+    parser.add_argument(
+        "--max-wait-time",
+        type=float,
+        help="Maximum total wait time in seconds (default: 60)",
+        default=60,
+        required=False,
+    )
     return parser.parse_args()
+
 
 async def main():
     args = parse_arguments()
@@ -648,8 +701,8 @@ async def main():
     # Parse -D key=value pairs into a dictionary
     cli_config = {}
     for item in args.define:
-        if '=' in item:
-            key, value = item.split('=', 1)
+        if "=" in item:
+            key, value = item.split("=", 1)
             cli_config[key] = value
         else:
             logging.warning(f"Ignoring invalid CLI config: {item}")

--- a/mooncake-wheel/tests/test_mooncake_config.py
+++ b/mooncake-wheel/tests/test_mooncake_config.py
@@ -27,7 +27,8 @@ class TestMooncakeConfig(unittest.TestCase):
             "protocol": "tcp",
             "device_name": "eth0",
             "enable_ssd_offload": True,
-            "ssd_offload_path": "/nvme/mooncake_offload"
+            "ssd_offload_path": "/nvme/mooncake_offload",
+            "tenant_id": "tenant-a",
         }
 
     def tearDown(self):
@@ -35,7 +36,7 @@ class TestMooncakeConfig(unittest.TestCase):
 
     def write_config(self, config_data):
         """Write configuration to file"""
-        with open(self.config_file, 'w') as f:
+        with open(self.config_file, "w") as f:
             json.dump(config_data, f)
 
     def test_load_valid_config(self):
@@ -52,13 +53,14 @@ class TestMooncakeConfig(unittest.TestCase):
         self.assertEqual(config.device_name, "eth0")
         self.assertEqual(config.enable_ssd_offload, True)
         self.assertEqual(config.ssd_offload_path, "/nvme/mooncake_offload")
+        self.assertEqual(config.tenant_id, "tenant-a")
 
     def test_load_with_default_values(self):
         """Test loading configuration with default values"""
         minimal_config = {
             "local_hostname": "localhost",
             "metadata_server": "localhost:8080",
-            "master_server_address": "localhost:8081"
+            "master_server_address": "localhost:8081",
         }
         self.write_config(minimal_config)
         config = MooncakeConfig.from_file(self.config_file)
@@ -69,6 +71,26 @@ class TestMooncakeConfig(unittest.TestCase):
         self.assertEqual(config.device_name, "")
         self.assertEqual(config.enable_ssd_offload, False)
         self.assertEqual(config.ssd_offload_path, "")
+        self.assertEqual(config.tenant_id, "default")
+
+    def test_load_tenant_id_from_file(self):
+        """Test loading tenant_id from configuration file"""
+        self.write_config({**self.valid_config, "tenant_id": "tenant-from-file"})
+        config = MooncakeConfig.from_file(self.config_file)
+
+        self.assertEqual(config.tenant_id, "tenant-from-file")
+
+    def test_tenant_id_defaults(self):
+        """Test tenant_id defaults to default when omitted"""
+        minimal_config = {
+            "local_hostname": "localhost",
+            "metadata_server": "localhost:8080",
+            "master_server_address": "localhost:8081",
+        }
+        self.write_config(minimal_config)
+        config = MooncakeConfig.from_file(self.config_file)
+
+        self.assertEqual(config.tenant_id, "default")
 
     def test_enable_ssd_offload_string_values(self):
         """from_file must parse string booleans like load_from_env, and reject typos.
@@ -117,61 +139,112 @@ class TestMooncakeConfig(unittest.TestCase):
 
                 with self.assertRaises(ValueError) as cm:
                     MooncakeConfig.from_file(self.config_file)
-                self.assertIn(f"Missing required config field: {field}", str(cm.exception))
+                self.assertIn(
+                    f"Missing required config field: {field}", str(cm.exception)
+                )
 
     def test_load_from_config_path_env(self):
         """Test loading configuration from environment variable MOONCAKE_CONFIG_PATH"""
         self.write_config(self.valid_config)
 
         # Set environment variable
-        os.environ['MOONCAKE_CONFIG_PATH'] = self.config_file
+        os.environ["MOONCAKE_CONFIG_PATH"] = self.config_file
 
         try:
             config = MooncakeConfig.load_from_env()
             self.assertEqual(config.local_hostname, "localhost")
         finally:
             # Clean up environment variable
-            del os.environ['MOONCAKE_CONFIG_PATH']
+            del os.environ["MOONCAKE_CONFIG_PATH"]
 
     def test_load_from_config_env(self):
         """Test loading configuration from environment variable MOONCAKE_MASTER"""
         # Set environment variable
-        os.environ['MOONCAKE_MASTER'] = self.valid_config["master_server_address"]
-        os.environ['LOCAL_HOSTNAME'] = self.valid_config["local_hostname"]
-        os.environ['MOONCAKE_TE_META_DATA_SERVER'] = self.valid_config["metadata_server"]
-        os.environ['MOONCAKE_GLOBAL_SEGMENT_SIZE'] = str(self.valid_config["global_segment_size"])
-        os.environ['MOONCAKE_PROTOCOL'] = self.valid_config["protocol"]
-        os.environ['MOONCAKE_DEVICE'] = self.valid_config["device_name"]
-        os.environ['MOONCAKE_OFFLOAD_ENABLED'] = str(self.valid_config["enable_ssd_offload"])
-        os.environ['MOONCAKE_OFFLOAD_FILE_STORAGE_PATH'] = self.valid_config["ssd_offload_path"]
+        os.environ["MOONCAKE_MASTER"] = self.valid_config["master_server_address"]
+        os.environ["LOCAL_HOSTNAME"] = self.valid_config["local_hostname"]
+        os.environ["MOONCAKE_TE_META_DATA_SERVER"] = self.valid_config[
+            "metadata_server"
+        ]
+        os.environ["MOONCAKE_GLOBAL_SEGMENT_SIZE"] = str(
+            self.valid_config["global_segment_size"]
+        )
+        os.environ["MOONCAKE_PROTOCOL"] = self.valid_config["protocol"]
+        os.environ["MOONCAKE_DEVICE"] = self.valid_config["device_name"]
+        os.environ["MOONCAKE_OFFLOAD_ENABLED"] = str(
+            self.valid_config["enable_ssd_offload"]
+        )
+        os.environ["MOONCAKE_OFFLOAD_FILE_STORAGE_PATH"] = self.valid_config[
+            "ssd_offload_path"
+        ]
+        os.environ["MOONCAKE_TENANT_ID"] = self.valid_config["tenant_id"]
 
         try:
             config = MooncakeConfig.load_from_env()
-            self.assertEqual(config.master_server_address, self.valid_config["master_server_address"])
-            self.assertEqual(config.metadata_server, self.valid_config["metadata_server"])
+            self.assertEqual(
+                config.master_server_address, self.valid_config["master_server_address"]
+            )
+            self.assertEqual(
+                config.metadata_server, self.valid_config["metadata_server"]
+            )
             self.assertEqual(config.local_hostname, self.valid_config["local_hostname"])
-            self.assertEqual(config.global_segment_size, self.valid_config["global_segment_size"])
+            self.assertEqual(
+                config.global_segment_size, self.valid_config["global_segment_size"]
+            )
             self.assertEqual(config.protocol, self.valid_config["protocol"])
             self.assertEqual(config.device_name, self.valid_config["device_name"])
-            self.assertEqual(config.enable_ssd_offload, self.valid_config["enable_ssd_offload"])
-            self.assertEqual(config.ssd_offload_path, self.valid_config["ssd_offload_path"])
+            self.assertEqual(
+                config.enable_ssd_offload, self.valid_config["enable_ssd_offload"]
+            )
+            self.assertEqual(
+                config.ssd_offload_path, self.valid_config["ssd_offload_path"]
+            )
+            self.assertEqual(config.tenant_id, self.valid_config["tenant_id"])
 
         finally:
             # Clean up environment variable
-            del os.environ['MOONCAKE_MASTER']
-            del os.environ['LOCAL_HOSTNAME']
-            del os.environ['MOONCAKE_TE_META_DATA_SERVER']
-            del os.environ['MOONCAKE_GLOBAL_SEGMENT_SIZE']
-            del os.environ['MOONCAKE_PROTOCOL']
-            del os.environ['MOONCAKE_DEVICE']
-            del os.environ['MOONCAKE_OFFLOAD_ENABLED']
-            del os.environ['MOONCAKE_OFFLOAD_FILE_STORAGE_PATH']
+            del os.environ["MOONCAKE_MASTER"]
+            del os.environ["LOCAL_HOSTNAME"]
+            del os.environ["MOONCAKE_TE_META_DATA_SERVER"]
+            del os.environ["MOONCAKE_GLOBAL_SEGMENT_SIZE"]
+            del os.environ["MOONCAKE_PROTOCOL"]
+            del os.environ["MOONCAKE_DEVICE"]
+            del os.environ["MOONCAKE_OFFLOAD_ENABLED"]
+            del os.environ["MOONCAKE_OFFLOAD_FILE_STORAGE_PATH"]
+            del os.environ["MOONCAKE_TENANT_ID"]
+
+    def test_tenant_id_from_env(self):
+        """Test loading tenant_id from MOONCAKE_TENANT_ID"""
+        os.environ["MOONCAKE_MASTER"] = self.valid_config["master_server_address"]
+        os.environ["MOONCAKE_TENANT_ID"] = "tenant-from-env"
+
+        try:
+            config = MooncakeConfig.load_from_env()
+            self.assertEqual(config.tenant_id, "tenant-from-env")
+        finally:
+            del os.environ["MOONCAKE_MASTER"]
+            del os.environ["MOONCAKE_TENANT_ID"]
+
+    def test_tenant_id_env_defaults(self):
+        """Test tenant_id defaults to default when MOONCAKE_TENANT_ID is omitted"""
+        previous_tenant_id = os.environ.pop("MOONCAKE_TENANT_ID", None)
+        os.environ["MOONCAKE_MASTER"] = self.valid_config["master_server_address"]
+
+        try:
+            config = MooncakeConfig.load_from_env()
+            self.assertEqual(config.tenant_id, "default")
+        finally:
+            del os.environ["MOONCAKE_MASTER"]
+            if previous_tenant_id is not None:
+                os.environ["MOONCAKE_TENANT_ID"] = previous_tenant_id
 
     def test_load_from_env_missing(self):
         """Test loading configuration from environment variable when not set"""
         with self.assertRaises(ValueError) as cm:
             MooncakeConfig.load_from_env()
-        self.assertIn("Neither the environment variable 'MOONCAKE_CONFIG_PATH' nor 'MOONCAKE_MASTER' is set.", str(cm.exception))
+        self.assertIn(
+            "Neither the environment variable 'MOONCAKE_CONFIG_PATH' nor 'MOONCAKE_MASTER' is set.",
+            str(cm.exception),
+        )
 
 
 class TestParseSegmentSize(unittest.TestCase):
@@ -193,20 +266,20 @@ class TestParseSegmentSize(unittest.TestCase):
         self.assertEqual(_parse_segment_size("1.5kb"), int(1.5 * 1024))
 
     def test_mb_suffix(self):
-        self.assertEqual(_parse_segment_size("1mb"), 1024 ** 2)
-        self.assertEqual(_parse_segment_size("512MB"), 512 * 1024 ** 2)
-        self.assertEqual(_parse_segment_size("1m"), 1024 ** 2)
+        self.assertEqual(_parse_segment_size("1mb"), 1024**2)
+        self.assertEqual(_parse_segment_size("512MB"), 512 * 1024**2)
+        self.assertEqual(_parse_segment_size("1m"), 1024**2)
 
     def test_gb_suffix(self):
-        self.assertEqual(_parse_segment_size("1gb"), 1024 ** 3)
-        self.assertEqual(_parse_segment_size("3GB"), 3 * 1024 ** 3)
-        self.assertEqual(_parse_segment_size("1g"), 1024 ** 3)
-        self.assertEqual(_parse_segment_size("1.5gb"), int(1.5 * 1024 ** 3))
+        self.assertEqual(_parse_segment_size("1gb"), 1024**3)
+        self.assertEqual(_parse_segment_size("3GB"), 3 * 1024**3)
+        self.assertEqual(_parse_segment_size("1g"), 1024**3)
+        self.assertEqual(_parse_segment_size("1.5gb"), int(1.5 * 1024**3))
 
     def test_tb_suffix(self):
-        self.assertEqual(_parse_segment_size("1tb"), 1024 ** 4)
-        self.assertEqual(_parse_segment_size("1TB"), 1024 ** 4)
-        self.assertEqual(_parse_segment_size("1t"), 1024 ** 4)
+        self.assertEqual(_parse_segment_size("1tb"), 1024**4)
+        self.assertEqual(_parse_segment_size("1TB"), 1024**4)
+        self.assertEqual(_parse_segment_size("1t"), 1024**4)
 
     def test_b_suffix(self):
         self.assertEqual(_parse_segment_size("4096b"), 4096)
@@ -233,8 +306,8 @@ class TestParseSegmentSize(unittest.TestCase):
             _parse_segment_size("abc")
 
     def test_whitespace_handling(self):
-        self.assertEqual(_parse_segment_size("  3 gb  "), 3 * 1024 ** 3)
+        self.assertEqual(_parse_segment_size("  3 gb  "), 3 * 1024**3)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/mooncake-wheel/tests/test_mooncake_config.py
+++ b/mooncake-wheel/tests/test_mooncake_config.py
@@ -92,6 +92,13 @@ class TestMooncakeConfig(unittest.TestCase):
 
         self.assertEqual(config.tenant_id, "default")
 
+    def test_tenant_id_null_defaults(self):
+        """Test tenant_id defaults to default when explicitly null"""
+        self.write_config({**self.valid_config, "tenant_id": None})
+        config = MooncakeConfig.from_file(self.config_file)
+
+        self.assertEqual(config.tenant_id, "default")
+
     def test_enable_ssd_offload_string_values(self):
         """from_file must parse string booleans like load_from_env, and reject typos.
 
@@ -214,6 +221,10 @@ class TestMooncakeConfig(unittest.TestCase):
 
     def test_tenant_id_from_env(self):
         """Test loading tenant_id from MOONCAKE_TENANT_ID"""
+        previous_config_path = os.environ.pop("MOONCAKE_CONFIG_PATH", None)
+        previous_master = os.environ.pop("MOONCAKE_MASTER", None)
+        previous_tenant_id = os.environ.pop("MOONCAKE_TENANT_ID", None)
+
         os.environ["MOONCAKE_MASTER"] = self.valid_config["master_server_address"]
         os.environ["MOONCAKE_TENANT_ID"] = "tenant-from-env"
 
@@ -221,19 +232,33 @@ class TestMooncakeConfig(unittest.TestCase):
             config = MooncakeConfig.load_from_env()
             self.assertEqual(config.tenant_id, "tenant-from-env")
         finally:
-            del os.environ["MOONCAKE_MASTER"]
-            del os.environ["MOONCAKE_TENANT_ID"]
+            os.environ.pop("MOONCAKE_MASTER", None)
+            os.environ.pop("MOONCAKE_TENANT_ID", None)
+            if previous_config_path is not None:
+                os.environ["MOONCAKE_CONFIG_PATH"] = previous_config_path
+            if previous_master is not None:
+                os.environ["MOONCAKE_MASTER"] = previous_master
+            if previous_tenant_id is not None:
+                os.environ["MOONCAKE_TENANT_ID"] = previous_tenant_id
 
     def test_tenant_id_env_defaults(self):
         """Test tenant_id defaults to default when MOONCAKE_TENANT_ID is omitted"""
+        previous_config_path = os.environ.pop("MOONCAKE_CONFIG_PATH", None)
+        previous_master = os.environ.pop("MOONCAKE_MASTER", None)
         previous_tenant_id = os.environ.pop("MOONCAKE_TENANT_ID", None)
+
         os.environ["MOONCAKE_MASTER"] = self.valid_config["master_server_address"]
 
         try:
             config = MooncakeConfig.load_from_env()
             self.assertEqual(config.tenant_id, "default")
         finally:
-            del os.environ["MOONCAKE_MASTER"]
+            os.environ.pop("MOONCAKE_MASTER", None)
+            os.environ.pop("MOONCAKE_TENANT_ID", None)
+            if previous_config_path is not None:
+                os.environ["MOONCAKE_CONFIG_PATH"] = previous_config_path
+            if previous_master is not None:
+                os.environ["MOONCAKE_MASTER"] = previous_master
             if previous_tenant_id is not None:
                 os.environ["MOONCAKE_TENANT_ID"] = previous_tenant_id
 

--- a/mooncake-wheel/tests/test_mooncake_config.py
+++ b/mooncake-wheel/tests/test_mooncake_config.py
@@ -28,7 +28,7 @@ class TestMooncakeConfig(unittest.TestCase):
             "device_name": "eth0",
             "enable_ssd_offload": True,
             "ssd_offload_path": "/nvme/mooncake_offload",
-            "tenant_id": "tenant-a",
+            "tenant_id": "tenant-a"
         }
 
     def tearDown(self):
@@ -36,7 +36,7 @@ class TestMooncakeConfig(unittest.TestCase):
 
     def write_config(self, config_data):
         """Write configuration to file"""
-        with open(self.config_file, "w") as f:
+        with open(self.config_file, 'w') as f:
             json.dump(config_data, f)
 
     def test_load_valid_config(self):
@@ -60,7 +60,7 @@ class TestMooncakeConfig(unittest.TestCase):
         minimal_config = {
             "local_hostname": "localhost",
             "metadata_server": "localhost:8080",
-            "master_server_address": "localhost:8081",
+            "master_server_address": "localhost:8081"
         }
         self.write_config(minimal_config)
         config = MooncakeConfig.from_file(self.config_file)
@@ -85,7 +85,7 @@ class TestMooncakeConfig(unittest.TestCase):
         minimal_config = {
             "local_hostname": "localhost",
             "metadata_server": "localhost:8080",
-            "master_server_address": "localhost:8081",
+            "master_server_address": "localhost:8081"
         }
         self.write_config(minimal_config)
         config = MooncakeConfig.from_file(self.config_file)
@@ -98,6 +98,13 @@ class TestMooncakeConfig(unittest.TestCase):
         config = MooncakeConfig.from_file(self.config_file)
 
         self.assertEqual(config.tenant_id, "default")
+
+    def test_ssd_offload_path_null_defaults(self):
+        """Test ssd_offload_path defaults to empty when explicitly null"""
+        self.write_config({**self.valid_config, "ssd_offload_path": None})
+        config = MooncakeConfig.from_file(self.config_file)
+
+        self.assertEqual(config.ssd_offload_path, "")
 
     def test_enable_ssd_offload_string_values(self):
         """from_file must parse string booleans like load_from_env, and reject typos.
@@ -146,78 +153,58 @@ class TestMooncakeConfig(unittest.TestCase):
 
                 with self.assertRaises(ValueError) as cm:
                     MooncakeConfig.from_file(self.config_file)
-                self.assertIn(
-                    f"Missing required config field: {field}", str(cm.exception)
-                )
+                self.assertIn(f"Missing required config field: {field}", str(cm.exception))
 
     def test_load_from_config_path_env(self):
         """Test loading configuration from environment variable MOONCAKE_CONFIG_PATH"""
         self.write_config(self.valid_config)
 
         # Set environment variable
-        os.environ["MOONCAKE_CONFIG_PATH"] = self.config_file
+        os.environ['MOONCAKE_CONFIG_PATH'] = self.config_file
 
         try:
             config = MooncakeConfig.load_from_env()
             self.assertEqual(config.local_hostname, "localhost")
         finally:
             # Clean up environment variable
-            del os.environ["MOONCAKE_CONFIG_PATH"]
+            del os.environ['MOONCAKE_CONFIG_PATH']
 
     def test_load_from_config_env(self):
         """Test loading configuration from environment variable MOONCAKE_MASTER"""
         # Set environment variable
-        os.environ["MOONCAKE_MASTER"] = self.valid_config["master_server_address"]
-        os.environ["LOCAL_HOSTNAME"] = self.valid_config["local_hostname"]
-        os.environ["MOONCAKE_TE_META_DATA_SERVER"] = self.valid_config[
-            "metadata_server"
-        ]
-        os.environ["MOONCAKE_GLOBAL_SEGMENT_SIZE"] = str(
-            self.valid_config["global_segment_size"]
-        )
-        os.environ["MOONCAKE_PROTOCOL"] = self.valid_config["protocol"]
-        os.environ["MOONCAKE_DEVICE"] = self.valid_config["device_name"]
-        os.environ["MOONCAKE_OFFLOAD_ENABLED"] = str(
-            self.valid_config["enable_ssd_offload"]
-        )
-        os.environ["MOONCAKE_OFFLOAD_FILE_STORAGE_PATH"] = self.valid_config[
-            "ssd_offload_path"
-        ]
-        os.environ["MOONCAKE_TENANT_ID"] = self.valid_config["tenant_id"]
+        os.environ['MOONCAKE_MASTER'] = self.valid_config["master_server_address"]
+        os.environ['LOCAL_HOSTNAME'] = self.valid_config["local_hostname"]
+        os.environ['MOONCAKE_TE_META_DATA_SERVER'] = self.valid_config["metadata_server"]
+        os.environ['MOONCAKE_GLOBAL_SEGMENT_SIZE'] = str(self.valid_config["global_segment_size"])
+        os.environ['MOONCAKE_PROTOCOL'] = self.valid_config["protocol"]
+        os.environ['MOONCAKE_DEVICE'] = self.valid_config["device_name"]
+        os.environ['MOONCAKE_OFFLOAD_ENABLED'] = str(self.valid_config["enable_ssd_offload"])
+        os.environ['MOONCAKE_OFFLOAD_FILE_STORAGE_PATH'] = self.valid_config["ssd_offload_path"]
+        os.environ['MOONCAKE_TENANT_ID'] = self.valid_config["tenant_id"]
 
         try:
             config = MooncakeConfig.load_from_env()
-            self.assertEqual(
-                config.master_server_address, self.valid_config["master_server_address"]
-            )
-            self.assertEqual(
-                config.metadata_server, self.valid_config["metadata_server"]
-            )
+            self.assertEqual(config.master_server_address, self.valid_config["master_server_address"])
+            self.assertEqual(config.metadata_server, self.valid_config["metadata_server"])
             self.assertEqual(config.local_hostname, self.valid_config["local_hostname"])
-            self.assertEqual(
-                config.global_segment_size, self.valid_config["global_segment_size"]
-            )
+            self.assertEqual(config.global_segment_size, self.valid_config["global_segment_size"])
             self.assertEqual(config.protocol, self.valid_config["protocol"])
             self.assertEqual(config.device_name, self.valid_config["device_name"])
-            self.assertEqual(
-                config.enable_ssd_offload, self.valid_config["enable_ssd_offload"]
-            )
-            self.assertEqual(
-                config.ssd_offload_path, self.valid_config["ssd_offload_path"]
-            )
+            self.assertEqual(config.enable_ssd_offload, self.valid_config["enable_ssd_offload"])
+            self.assertEqual(config.ssd_offload_path, self.valid_config["ssd_offload_path"])
             self.assertEqual(config.tenant_id, self.valid_config["tenant_id"])
 
         finally:
             # Clean up environment variable
-            del os.environ["MOONCAKE_MASTER"]
-            del os.environ["LOCAL_HOSTNAME"]
-            del os.environ["MOONCAKE_TE_META_DATA_SERVER"]
-            del os.environ["MOONCAKE_GLOBAL_SEGMENT_SIZE"]
-            del os.environ["MOONCAKE_PROTOCOL"]
-            del os.environ["MOONCAKE_DEVICE"]
-            del os.environ["MOONCAKE_OFFLOAD_ENABLED"]
-            del os.environ["MOONCAKE_OFFLOAD_FILE_STORAGE_PATH"]
-            del os.environ["MOONCAKE_TENANT_ID"]
+            del os.environ['MOONCAKE_MASTER']
+            del os.environ['LOCAL_HOSTNAME']
+            del os.environ['MOONCAKE_TE_META_DATA_SERVER']
+            del os.environ['MOONCAKE_GLOBAL_SEGMENT_SIZE']
+            del os.environ['MOONCAKE_PROTOCOL']
+            del os.environ['MOONCAKE_DEVICE']
+            del os.environ['MOONCAKE_OFFLOAD_ENABLED']
+            del os.environ['MOONCAKE_OFFLOAD_FILE_STORAGE_PATH']
+            del os.environ['MOONCAKE_TENANT_ID']
 
     def test_tenant_id_from_env(self):
         """Test loading tenant_id from MOONCAKE_TENANT_ID"""
@@ -266,10 +253,7 @@ class TestMooncakeConfig(unittest.TestCase):
         """Test loading configuration from environment variable when not set"""
         with self.assertRaises(ValueError) as cm:
             MooncakeConfig.load_from_env()
-        self.assertIn(
-            "Neither the environment variable 'MOONCAKE_CONFIG_PATH' nor 'MOONCAKE_MASTER' is set.",
-            str(cm.exception),
-        )
+        self.assertIn("Neither the environment variable 'MOONCAKE_CONFIG_PATH' nor 'MOONCAKE_MASTER' is set.", str(cm.exception))
 
 
 class TestParseSegmentSize(unittest.TestCase):
@@ -291,20 +275,20 @@ class TestParseSegmentSize(unittest.TestCase):
         self.assertEqual(_parse_segment_size("1.5kb"), int(1.5 * 1024))
 
     def test_mb_suffix(self):
-        self.assertEqual(_parse_segment_size("1mb"), 1024**2)
-        self.assertEqual(_parse_segment_size("512MB"), 512 * 1024**2)
-        self.assertEqual(_parse_segment_size("1m"), 1024**2)
+        self.assertEqual(_parse_segment_size("1mb"), 1024 ** 2)
+        self.assertEqual(_parse_segment_size("512MB"), 512 * 1024 ** 2)
+        self.assertEqual(_parse_segment_size("1m"), 1024 ** 2)
 
     def test_gb_suffix(self):
-        self.assertEqual(_parse_segment_size("1gb"), 1024**3)
-        self.assertEqual(_parse_segment_size("3GB"), 3 * 1024**3)
-        self.assertEqual(_parse_segment_size("1g"), 1024**3)
-        self.assertEqual(_parse_segment_size("1.5gb"), int(1.5 * 1024**3))
+        self.assertEqual(_parse_segment_size("1gb"), 1024 ** 3)
+        self.assertEqual(_parse_segment_size("3GB"), 3 * 1024 ** 3)
+        self.assertEqual(_parse_segment_size("1g"), 1024 ** 3)
+        self.assertEqual(_parse_segment_size("1.5gb"), int(1.5 * 1024 ** 3))
 
     def test_tb_suffix(self):
-        self.assertEqual(_parse_segment_size("1tb"), 1024**4)
-        self.assertEqual(_parse_segment_size("1TB"), 1024**4)
-        self.assertEqual(_parse_segment_size("1t"), 1024**4)
+        self.assertEqual(_parse_segment_size("1tb"), 1024 ** 4)
+        self.assertEqual(_parse_segment_size("1TB"), 1024 ** 4)
+        self.assertEqual(_parse_segment_size("1t"), 1024 ** 4)
 
     def test_b_suffix(self):
         self.assertEqual(_parse_segment_size("4096b"), 4096)
@@ -331,8 +315,8 @@ class TestParseSegmentSize(unittest.TestCase):
             _parse_segment_size("abc")
 
     def test_whitespace_handling(self):
-        self.assertEqual(_parse_segment_size("  3 gb  "), 3 * 1024**3)
+        self.assertEqual(_parse_segment_size("  3 gb  "), 3 * 1024 ** 3)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     unittest.main()

--- a/mooncake-wheel/tests/test_mooncake_store_service_api.py
+++ b/mooncake-wheel/tests/test_mooncake_store_service_api.py
@@ -2,10 +2,12 @@
 import asyncio
 import json
 import sys
+import tempfile
 import types
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -50,6 +52,11 @@ class FakeStore:
         self.unmount_failures = set()
         self.allocated_mount_calls = []
         self.free_unmount_calls = []
+        self.setup_calls = []
+
+    def setup(self, *args):
+        self.setup_calls.append(args)
+        return 0
 
     def mount_segment(self, path, size, offset, protocol, location):
         self.mount_calls.append((path, size, offset, protocol, location))
@@ -106,6 +113,64 @@ class StoreServiceApiTest(unittest.IsolatedAsyncioTestCase):
         self.service.mounted_segment_ids = []
         self.service.last_mount_info = {}
         self.service._state_lock = asyncio.Lock()
+
+    async def test_start_store_service_passes_tenant_id_to_setup(self):
+        fake_store = FakeStore()
+        self.service.config = SimpleNamespace(
+            local_hostname="localhost",
+            metadata_server="P2PHANDSHAKE",
+            global_segment_size=1024,
+            local_buffer_size=2048,
+            protocol="tcp",
+            device_name="",
+            master_server_address="127.0.0.1:50051",
+            enable_ssd_offload=False,
+            ssd_offload_path="",
+            tenant_id="tenant-a",
+        )
+
+        with patch(
+            "mooncake.mooncake_store_service.MooncakeDistributedStore",
+            return_value=fake_store,
+        ):
+            result = await self.service.start_store_service(max_wait_time=1)
+
+        self.assertTrue(result)
+        self.assertEqual(
+            fake_store.setup_calls,
+            [
+                (
+                    "localhost",
+                    "P2PHANDSHAKE",
+                    1024,
+                    2048,
+                    "tcp",
+                    "",
+                    "127.0.0.1:50051",
+                    None,
+                    False,
+                    "",
+                    "tenant-a",
+                )
+            ],
+        )
+
+    async def test_cli_config_can_override_tenant_id(self):
+        config = {
+            "local_hostname": "localhost",
+            "metadata_server": "P2PHANDSHAKE",
+            "master_server_address": "127.0.0.1:50051",
+            "tenant_id": "tenant-from-file",
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.json"
+            config_path.write_text(json.dumps(config))
+            service = MooncakeStoreService(
+                str(config_path), {"tenant_id": "tenant-from-cli"}
+            )
+
+        self.assertEqual(service.config.tenant_id, "tenant-from-cli")
 
     async def test_mount_shm_then_unmount_shm_api(self):
         mount_resp = await self.service.handle_mount_shm(


### PR DESCRIPTION
## Description

Add tenant ID configuration support for Mooncake Store clients.

This change wires `tenant_id` through the external client initialization paths that already accept it internally:

- Adds `--tenant_id` to `mooncake_client` and passes it to `RealClient::setup_internal`.
- Adds `tenant_id` to `MooncakeConfig`, including JSON config and `MOONCAKE_TENANT_ID` environment loading.
- Passes `tenant_id` from `MooncakeStoreService` into `MooncakeDistributedStore.setup`.
- Updates pybind dictionary setup documentation to include the existing `tenant_id` key.
- Documents tenant configuration in the deployment guide.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [x] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Validated Python configuration/service behavior, built the affected C++/pybind targets, and verified the CLI flag is exposed.

**Test commands:**
```bash
git diff --check

python3 -m unittest \
  mooncake-wheel/tests/test_mooncake_config.py \
  mooncake-wheel.tests.test_mooncake_store_service_api.StoreServiceApiTest.test_start_store_service_passes_tenant_id_to_setup \
  mooncake-wheel.tests.test_mooncake_store_service_api.StoreServiceApiTest.test_cli_config_can_override_tenant_id

cmake --build build --target mooncake_client -j2
cmake --build build --target store -j2

build/mooncake-store/src/mooncake_client --help
./scripts/code_format.sh
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done: confirmed `mooncake_client --help` lists `--tenant_id`

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex was used to inspect the code paths and implement the tenant ID configuration plumbing. I reviewed and edited the generated code before submission.