### PR TITLE
[Bugfix] Validate LocalFs OpLog sequence file parsing

### DIFF
--- a/mooncake-store/src/ha/oplog/localfs_oplog_store.cpp
+++ b/mooncake-store/src/ha/oplog/localfs_oplog_store.cpp
@@ -233,9 +233,8 @@ ErrorCode LocalFsOpLogStore::ReadUint64FromFile(const std::string& filepath,
         LOG(ERROR) << "ReadUint64FromFile: extra content in " << filepath;
         return ErrorCode::INTERNAL_ERROR;
     }
-    if (!std::all_of(content.begin(), content.end(), [](unsigned char c) {
-            return std::isdigit(c);
-        })) {
+    if (!std::all_of(content.begin(), content.end(),
+                     [](unsigned char c) { return std::isdigit(c); })) {
         LOG(ERROR) << "ReadUint64FromFile: invalid content in " << filepath
                    << ": " << content;
         return ErrorCode::INTERNAL_ERROR;

--- a/mooncake-store/src/ha/oplog/localfs_oplog_store.cpp
+++ b/mooncake-store/src/ha/oplog/localfs_oplog_store.cpp
@@ -3,6 +3,7 @@
 #include <glog/logging.h>
 
 #include <algorithm>
+#include <cctype>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
@@ -222,17 +223,27 @@ ErrorCode LocalFsOpLogStore::ReadUint64FromFile(const std::string& filepath,
         return ErrorCode::INTERNAL_ERROR;
     }
     std::string content;
-    f >> content;
-    try {
-        size_t parsed_len = 0;
-        value = std::stoull(content, &parsed_len);
-        if (parsed_len != content.size()) {
-            LOG(ERROR) << "ReadUint64FromFile: trailing characters in "
-                       << filepath << ": " << content;
-            return ErrorCode::INTERNAL_ERROR;
-        }
-    } catch (...) {
+    if (!(f >> content)) {
+        LOG(ERROR) << "ReadUint64FromFile: empty or unreadable file "
+                   << filepath;
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    std::string extra;
+    if (f >> extra) {
+        LOG(ERROR) << "ReadUint64FromFile: extra content in " << filepath;
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    if (!std::all_of(content.begin(), content.end(), [](unsigned char c) {
+            return std::isdigit(c);
+        })) {
         LOG(ERROR) << "ReadUint64FromFile: invalid content in " << filepath
+                   << ": " << content;
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    try {
+        value = std::stoull(content);
+    } catch (...) {
+        LOG(ERROR) << "ReadUint64FromFile: value out of range in " << filepath
                    << ": " << content;
         return ErrorCode::INTERNAL_ERROR;
     }

--- a/mooncake-store/src/ha/oplog/localfs_oplog_store.cpp
+++ b/mooncake-store/src/ha/oplog/localfs_oplog_store.cpp
@@ -6,6 +6,7 @@
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <system_error>
 
 #include <fcntl.h>
 #include <unistd.h>
@@ -223,7 +224,13 @@ ErrorCode LocalFsOpLogStore::ReadUint64FromFile(const std::string& filepath,
     std::string content;
     f >> content;
     try {
-        value = std::stoull(content);
+        size_t parsed_len = 0;
+        value = std::stoull(content, &parsed_len);
+        if (parsed_len != content.size()) {
+            LOG(ERROR) << "ReadUint64FromFile: trailing characters in "
+                       << filepath << ": " << content;
+            return ErrorCode::INTERNAL_ERROR;
+        }
     } catch (...) {
         LOG(ERROR) << "ReadUint64FromFile: invalid content in " << filepath
                    << ": " << content;
@@ -696,11 +703,22 @@ ErrorCode LocalFsOpLogStore::ReadOpLogSince(uint64_t start_sequence_id,
 
 ErrorCode LocalFsOpLogStore::GetLatestSequenceId(uint64_t& sequence_id) {
     std::string latest_path = LatestFilePath();
-    auto err = ReadUint64FromFile(latest_path, sequence_id);
-    if (err != ErrorCode::OK) {
-        // File doesn't exist yet — default to 0
+    std::error_code exists_error;
+    bool latest_exists = fs::exists(latest_path, exists_error);
+    if (exists_error) {
+        LOG(ERROR) << "GetLatestSequenceId: failed to stat " << latest_path
+                   << ": " << exists_error.message();
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    if (!latest_exists) {
+        // File does not exist yet; default to 0
         sequence_id = 0;
         return ErrorCode::OK;
+    }
+
+    auto err = ReadUint64FromFile(latest_path, sequence_id);
+    if (err != ErrorCode::OK) {
+        return err;
     }
     return ErrorCode::OK;
 }

--- a/mooncake-store/tests/ha/oplog/localfs_oplog_store_test.cpp
+++ b/mooncake-store/tests/ha/oplog/localfs_oplog_store_test.cpp
@@ -291,8 +291,8 @@ TEST_F(LocalFsOpLogStoreTest, GetLatestSequenceIdReturnsErrorOnStatFailure) {
     const std::string cluster_path = test_dir_ + "/" + cluster_id_;
     fs::create_directories(cluster_path);
     std::error_code permission_error;
-    fs::permissions(cluster_path, fs::perms::none,
-                    fs::perm_options::replace, permission_error);
+    fs::permissions(cluster_path, fs::perms::none, fs::perm_options::replace,
+                    permission_error);
     ASSERT_FALSE(permission_error) << permission_error.message();
 
     uint64_t seq = 999;

--- a/mooncake-store/tests/ha/oplog/localfs_oplog_store_test.cpp
+++ b/mooncake-store/tests/ha/oplog/localfs_oplog_store_test.cpp
@@ -303,6 +303,24 @@ TEST_F(LocalFsOpLogStoreTest, GetLatestSequenceIdRejectsInvalidContent) {
     EXPECT_EQ(ErrorCode::INTERNAL_ERROR, store->GetLatestSequenceId(seq));
 }
 
+TEST_F(LocalFsOpLogStoreTest, GetLatestSequenceIdRejectsNegativeNumber) {
+    auto store = CreateWriter();
+    const std::string latest_path = test_dir_ + "/" + cluster_id_ + "/latest";
+    std::ofstream(latest_path, std::ios::trunc) << "-42";
+
+    uint64_t seq = 999;
+    EXPECT_EQ(ErrorCode::INTERNAL_ERROR, store->GetLatestSequenceId(seq));
+}
+
+TEST_F(LocalFsOpLogStoreTest, GetLatestSequenceIdRejectsMultipleTokens) {
+    auto store = CreateWriter();
+    const std::string latest_path = test_dir_ + "/" + cluster_id_ + "/latest";
+    std::ofstream(latest_path, std::ios::trunc) << "42 43";
+
+    uint64_t seq = 999;
+    EXPECT_EQ(ErrorCode::INTERNAL_ERROR, store->GetLatestSequenceId(seq));
+}
+
 TEST_F(LocalFsOpLogStoreTest, GetMaxSequenceIdEmpty) {
     auto store = CreateWriter();
     uint64_t seq = 0;

--- a/mooncake-store/tests/ha/oplog/localfs_oplog_store_test.cpp
+++ b/mooncake-store/tests/ha/oplog/localfs_oplog_store_test.cpp
@@ -2,6 +2,7 @@
 #include <glog/logging.h>
 #include <filesystem>
 #include <fstream>
+#include <system_error>
 
 #include "ha/oplog/localfs_oplog_store.h"
 #include "ha/oplog/oplog_store_factory.h"
@@ -288,11 +289,18 @@ TEST_F(LocalFsOpLogStoreTest, GetLatestSequenceIdMissingFileDefaultsToZero) {
 TEST_F(LocalFsOpLogStoreTest, GetLatestSequenceIdReturnsErrorOnStatFailure) {
     auto store = CreateReader();
     const std::string cluster_path = test_dir_ + "/" + cluster_id_;
-    fs::remove_all(cluster_path);
-    std::ofstream(cluster_path) << "not a directory";
+    fs::create_directories(cluster_path);
+    std::error_code permission_error;
+    fs::permissions(cluster_path, fs::perms::none,
+                    fs::perm_options::replace, permission_error);
+    ASSERT_FALSE(permission_error) << permission_error.message();
 
     uint64_t seq = 999;
-    EXPECT_EQ(ErrorCode::INTERNAL_ERROR, store->GetLatestSequenceId(seq));
+    auto err = store->GetLatestSequenceId(seq);
+
+    fs::permissions(cluster_path, fs::perms::owner_all,
+                    fs::perm_options::replace, permission_error);
+    EXPECT_EQ(ErrorCode::INTERNAL_ERROR, err);
 }
 
 TEST_F(LocalFsOpLogStoreTest, GetLatestSequenceIdRejectsTrailingGarbage) {

--- a/mooncake-store/tests/ha/oplog/localfs_oplog_store_test.cpp
+++ b/mooncake-store/tests/ha/oplog/localfs_oplog_store_test.cpp
@@ -285,6 +285,16 @@ TEST_F(LocalFsOpLogStoreTest, GetLatestSequenceIdMissingFileDefaultsToZero) {
     EXPECT_EQ(0, seq);
 }
 
+TEST_F(LocalFsOpLogStoreTest, GetLatestSequenceIdReturnsErrorOnStatFailure) {
+    auto store = CreateReader();
+    const std::string cluster_path = test_dir_ + "/" + cluster_id_;
+    fs::remove_all(cluster_path);
+    std::ofstream(cluster_path) << "not a directory";
+
+    uint64_t seq = 999;
+    EXPECT_EQ(ErrorCode::INTERNAL_ERROR, store->GetLatestSequenceId(seq));
+}
+
 TEST_F(LocalFsOpLogStoreTest, GetLatestSequenceIdRejectsTrailingGarbage) {
     auto store = CreateWriter();
     const std::string latest_path = test_dir_ + "/" + cluster_id_ + "/latest";

--- a/mooncake-store/tests/ha/oplog/localfs_oplog_store_test.cpp
+++ b/mooncake-store/tests/ha/oplog/localfs_oplog_store_test.cpp
@@ -303,6 +303,15 @@ TEST_F(LocalFsOpLogStoreTest, GetLatestSequenceIdRejectsInvalidContent) {
     EXPECT_EQ(ErrorCode::INTERNAL_ERROR, store->GetLatestSequenceId(seq));
 }
 
+TEST_F(LocalFsOpLogStoreTest, GetLatestSequenceIdRejectsEmptyFile) {
+    auto store = CreateWriter();
+    const std::string latest_path = test_dir_ + "/" + cluster_id_ + "/latest";
+    std::ofstream(latest_path, std::ios::trunc);
+
+    uint64_t seq = 999;
+    EXPECT_EQ(ErrorCode::INTERNAL_ERROR, store->GetLatestSequenceId(seq));
+}
+
 TEST_F(LocalFsOpLogStoreTest, GetLatestSequenceIdRejectsNegativeNumber) {
     auto store = CreateWriter();
     const std::string latest_path = test_dir_ + "/" + cluster_id_ + "/latest";
@@ -316,6 +325,15 @@ TEST_F(LocalFsOpLogStoreTest, GetLatestSequenceIdRejectsMultipleTokens) {
     auto store = CreateWriter();
     const std::string latest_path = test_dir_ + "/" + cluster_id_ + "/latest";
     std::ofstream(latest_path, std::ios::trunc) << "42 43";
+
+    uint64_t seq = 999;
+    EXPECT_EQ(ErrorCode::INTERNAL_ERROR, store->GetLatestSequenceId(seq));
+}
+
+TEST_F(LocalFsOpLogStoreTest, GetLatestSequenceIdRejectsOutOfRangeValue) {
+    auto store = CreateWriter();
+    const std::string latest_path = test_dir_ + "/" + cluster_id_ + "/latest";
+    std::ofstream(latest_path, std::ios::trunc) << "18446744073709551616";
 
     uint64_t seq = 999;
     EXPECT_EQ(ErrorCode::INTERNAL_ERROR, store->GetLatestSequenceId(seq));

--- a/mooncake-store/tests/ha/oplog/localfs_oplog_store_test.cpp
+++ b/mooncake-store/tests/ha/oplog/localfs_oplog_store_test.cpp
@@ -275,6 +275,34 @@ TEST_F(LocalFsOpLogStoreTest, GetLatestSequenceIdFirstBoot) {
     EXPECT_EQ(0, seq);
 }
 
+TEST_F(LocalFsOpLogStoreTest, GetLatestSequenceIdMissingFileDefaultsToZero) {
+    auto store = CreateReader();
+    const std::string latest_path = test_dir_ + "/" + cluster_id_ + "/latest";
+    ASSERT_FALSE(fs::exists(latest_path));
+
+    uint64_t seq = 999;
+    EXPECT_EQ(ErrorCode::OK, store->GetLatestSequenceId(seq));
+    EXPECT_EQ(0, seq);
+}
+
+TEST_F(LocalFsOpLogStoreTest, GetLatestSequenceIdRejectsTrailingGarbage) {
+    auto store = CreateWriter();
+    const std::string latest_path = test_dir_ + "/" + cluster_id_ + "/latest";
+    std::ofstream(latest_path, std::ios::trunc) << "42junk";
+
+    uint64_t seq = 999;
+    EXPECT_EQ(ErrorCode::INTERNAL_ERROR, store->GetLatestSequenceId(seq));
+}
+
+TEST_F(LocalFsOpLogStoreTest, GetLatestSequenceIdRejectsInvalidContent) {
+    auto store = CreateWriter();
+    const std::string latest_path = test_dir_ + "/" + cluster_id_ + "/latest";
+    std::ofstream(latest_path, std::ios::trunc) << "not-a-number";
+
+    uint64_t seq = 999;
+    EXPECT_EQ(ErrorCode::INTERNAL_ERROR, store->GetLatestSequenceId(seq));
+}
+
 TEST_F(LocalFsOpLogStoreTest, GetMaxSequenceIdEmpty) {
     auto store = CreateWriter();
     uint64_t seq = 0;
@@ -361,6 +389,17 @@ TEST_F(LocalFsOpLogStoreTest, SnapshotRecordAndGet) {
     uint64_t seq = 0;
     EXPECT_EQ(ErrorCode::OK, store->GetSnapshotSequenceId("snap1", seq));
     EXPECT_EQ(42, seq);
+}
+
+TEST_F(LocalFsOpLogStoreTest, SnapshotSequenceRejectsTrailingGarbage) {
+    auto store = CreateWriter();
+    ASSERT_EQ(ErrorCode::OK, store->RecordSnapshotSequenceId("snap1", 42));
+    const std::string snapshot_path =
+        test_dir_ + "/" + cluster_id_ + "/snapshots/snap1";
+    std::ofstream(snapshot_path, std::ios::trunc) << "42junk";
+
+    uint64_t seq = 999;
+    EXPECT_NE(ErrorCode::OK, store->GetSnapshotSequenceId("snap1", seq));
 }
 
 TEST_F(LocalFsOpLogStoreTest, SnapshotNotFound) {


### PR DESCRIPTION
﻿﻿## Description

This PR tightens LocalFs OpLog sequence-file parsing so malformed persisted sequence values are reported as read/parse failures instead of being accepted as valid sequence IDs or silently treated as first boot.

### What Problem This Solves

`LocalFsOpLogStore::ReadUint64FromFile()` currently reads one token from a persisted sequence file and parses it with:

```cpp
value = std::stoull(content);
```

That leaves several malformed sequence-file cases too permissive:

- `42junk` can be parsed as `42` unless the full token is validated
- `-42` can be accepted by `std::stoull()` as an unsigned value
- `42 43` can be treated as `42` if only the first token is read
- an empty or unreadable sequence file can be hidden behind a generic parse path
- an out-of-range decimal token can throw after the file has otherwise looked syntactically numeric
- `not-a-number` fails parsing, but the old `GetLatestSequenceId()` path converted that failure into `OK, 0`

The `OK, 0` fallback is correct for a missing `latest` file on first boot, but a present malformed `latest` file should not look like an empty store. Otherwise corrupted LocalFs OpLog metadata can be hidden from callers.

### Change

The fix makes LocalFs sequence-file parsing strict:

- require the file to contain exactly one token
- require every character in that token to be a decimal digit
- parse the validated token with `std::stoull()` and report out-of-range values as errors
- keep the first-boot fallback only when the `latest` file is actually missing
- return an error when statting the `latest` path fails
- return an error for present-but-malformed LocalFs sequence files

This keeps normal valid sequence values unchanged, while making corrupted metadata visible instead of silently accepting or masking it.

### Evidence

Focused tests cover these LocalFs metadata cases:

```text
latest = "42junk"
GetLatestSequenceId(seq) -> INTERNAL_ERROR

latest = "not-a-number"
GetLatestSequenceId(seq) -> INTERNAL_ERROR

latest = ""
GetLatestSequenceId(seq) -> INTERNAL_ERROR

latest = "-42"
GetLatestSequenceId(seq) -> INTERNAL_ERROR

latest = "42 43"
GetLatestSequenceId(seq) -> INTERNAL_ERROR

latest = "18446744073709551616"
GetLatestSequenceId(seq) -> INTERNAL_ERROR

latest path stat failure
GetLatestSequenceId(seq) -> INTERNAL_ERROR

latest file missing
GetLatestSequenceId(seq) -> OK
seq == 0

snapshot "snap1" = "42junk"
GetSnapshotSequenceId("snap1", seq) -> non-OK
```

### Possible call chain / impact

```text
LocalFsOpLogStore::GetLatestSequenceId()
  -> stat latest path
  -> missing latest file keeps first-boot OK, 0 behavior
  -> present latest file is parsed by LocalFsOpLogStore::ReadUint64FromFile()
  -> malformed latest-file content is rejected instead of accepted or treated as first boot

LocalFsOpLogStore::GetSnapshotSequenceId()
  -> LocalFsOpLogStore::ReadUint64FromFile()
  -> strict one-token decimal parsing
  -> malformed snapshot sequence content is rejected instead of accepted as valid
```

This PR only changes LocalFs OpLog sequence-file parsing. It does not change segment file serialization, OpLog entry parsing, snapshot ID validation, or the first-boot behavior for a missing `latest` file.

The analogous etcd latest/snapshot parsing path is separate and intentionally out of scope for this LocalFs-focused fix.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
git diff --check
cmake -S . -B /tmp/mooncake-localfs-build -DUSE_ETCD=OFF -DUSE_HTTP=ON -DUSE_CUDA=OFF -DUSE_MNNVL=OFF -DUSE_UB=OFF -DBUILD_UNIT_TESTS=ON -DBUILD_EXAMPLES=OFF -DWITH_STORE_RUST=OFF -DCMAKE_BUILD_TYPE=Debug
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

`git diff --check` passes.

Focused LocalFs OpLog tests were added for malformed sequence-file payloads and error branches, including trailing garbage, invalid text, empty files, negative numbers, multiple tokens, out-of-range values, `latest` stat failures, missing `latest`, and corrupted snapshot sequence content.

Local WSL CMake configure is currently blocked before build/test by a missing `yaml-cpp` CMake package:

```text
Could not find a package configuration file provided by "yaml-cpp"
with any of the following names:

  yaml-cppConfig.cmake
  yaml-cpp-config.cmake
```

Because configure does not complete in this local environment, I could not run `localfs_oplog_store_test` locally. The intended focused validation command after dependencies are available is:

```bash
cmake --build build --target localfs_oplog_store_test -j
ctest --test-dir build -R '^localfs_oplog_store_test$' --output-on-failure
```

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex was used to inspect the relevant LocalFs OpLog parsing path, identify focused reproduction cases, implement the narrow fix and tests, address reviewer feedback, and draft/update this PR description. The human submitter reviewed the change and is responsible for the final implementation and validation.

