### PR TITLE
[TENT] Make RDMA NIC allow/deny list configurable via MC_FILTER_NIC(_EXCLUDE)

### DIFF
--- a/docs/source/design/transfer-engine/index.md
+++ b/docs/source/design/transfer-engine/index.md
@@ -471,6 +471,8 @@ For advanced users, TransferEngine provides the following advanced runtime optio
 - `MC_WORKERS_PER_CTX` The number of asynchronous worker threads corresponding to each device instance
 - `MC_SLICE_SIZE` The segmentation granularity of user requests in Transfer Engine
 - `MC_RETRY_CNT` The maximum number of retries in Transfer Engine
+- `MC_TE_FILTERS` Restrict which RDMA NICs the engine discovers and uses, as a comma-separated allow-list of device names (e.g. `mlx5_bond_0,mlx5_bond_1`). Only the listed NICs are kept; all others are ignored. Unset (default) discovers all NICs. This is the **same env var and semantics as the legacy Transfer Engine's device whitelist** (see below), so a single variable scopes NICs across both engines. Useful on multi-NIC / multi-NUMA hosts to keep the engine (and its rail selection) off NICs that are not routable to the peer.
+- `MC_TE_FILTERS_EXCLUDE` The deny-list counterpart of `MC_TE_FILTERS`: a comma-separated list of device names to exclude from discovery. Ignored if `MC_TE_FILTERS` is set (allow-list takes precedence). Unset (default) excludes nothing. (New; the legacy engine has an allow-list only.)
 - `MC_AUTO_GID_MAX_RETRIES` The maximum number of automatic local GID reprobe retries during classic RDMA handshake recovery. Default value 2. Set to 0 to disable automatic GID retry.
 - `MC_LOG_LEVEL` This option can be set as `TRACE`/`INFO`/`WARNING`/`ERROR` (see [glog doc](https://github.com/google/glog/blob/master/docs/logging.md)), and more detailed logs will be output during runtime
 - `MC_DISABLE_METACACHE` Disable local meta cache to prevent transfer failure due to dynamic memory registrations, which may downgrades the performance

--- a/mooncake-transfer-engine/tent/src/common/config.cpp
+++ b/mooncake-transfer-engine/tent/src/common/config.cpp
@@ -55,6 +55,24 @@ static inline void setConfig(Config& config, const std::string& env_key,
     if (val) config.setFromString(config_key, std::string(val));
 }
 
+// Like setConfig, but parses the env value as a comma-separated list and
+// stores it as a string array. Empty/whitespace-only items are dropped so a
+// trailing comma or spaces around names are tolerated (e.g. "mlx5_0, mlx5_1").
+static inline void setArrayConfig(Config& config, const std::string& env_key,
+                                  const std::string& config_key) {
+    const char* val = std::getenv(env_key.c_str());
+    if (!val) return;
+    std::vector<std::string> items;
+    std::stringstream ss(val);
+    std::string item;
+    while (std::getline(ss, item, ',')) {
+        item.erase(0, item.find_first_not_of(" \t"));
+        item.erase(item.find_last_not_of(" \t") + 1);
+        if (!item.empty()) items.push_back(item);
+    }
+    if (!items.empty()) config.set(config_key, items);
+}
+
 Status ConfigHelper::loadFromEnv(Config& config) {
     const char* conf_str = std::getenv("MC_TENT_CONF");
     Status status = Status::OK();
@@ -119,6 +137,14 @@ Status ConfigHelper::loadFromEnv(Config& config) {
               "transports/rdma/disable_gpu_direct_rdma");
     setConfig(config, "MC_LOG_RDMA_SLICE_AFFINITY",
               "transports/rdma/log_slice_affinity");
+    // Restrict which RDMA NICs the engine discovers/uses (comma-separated
+    // device names). MC_TE_FILTERS is an allow-list — same name and semantics
+    // as the legacy Transfer Engine's device whitelist, so a single env works
+    // across both engines. MC_TE_FILTERS_EXCLUDE is a deny-list (new; the
+    // legacy engine has no deny-list). Unset = discover all (default).
+    // Consumed by filterInfiniBandDevices() in the platform probes.
+    setArrayConfig(config, "MC_TE_FILTERS", "topology/rdma_whitelist");
+    setArrayConfig(config, "MC_TE_FILTERS_EXCLUDE", "topology/rdma_blacklist");
     return status;
 }
 

--- a/mooncake-transfer-engine/tent/tests/transfer_engine_config_override_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/transfer_engine_config_override_test.cpp
@@ -293,6 +293,49 @@ TEST(TransferEngineConfigOverrideTest,
     EXPECT_TRUE(config.get("transports/rdma/log_slice_affinity", false));
 }
 
+TEST(TransferEngineConfigOverrideTest, FilterNicEnvLoadsRdmaWhitelist) {
+    EnvVarGuard guard("MC_TE_FILTERS", "mlx5_0,mlx5_1");
+
+    Config config;
+    ASSERT_TRUE(ConfigHelper().loadFromEnv(config).ok());
+
+    std::vector<std::string> expected{"mlx5_0", "mlx5_1"};
+    EXPECT_EQ(config.getArray<std::string>("topology/rdma_whitelist"),
+              expected);
+}
+
+TEST(TransferEngineConfigOverrideTest, FilterNicExcludeEnvLoadsRdmaBlacklist) {
+    EnvVarGuard guard("MC_TE_FILTERS_EXCLUDE", "mlx5_2,mlx5_3");
+
+    Config config;
+    ASSERT_TRUE(ConfigHelper().loadFromEnv(config).ok());
+
+    std::vector<std::string> expected{"mlx5_2", "mlx5_3"};
+    EXPECT_EQ(config.getArray<std::string>("topology/rdma_blacklist"),
+              expected);
+}
+
+TEST(TransferEngineConfigOverrideTest, FilterNicEnvTrimsWhitespaceAndEmpties) {
+    // Spaces around names and a trailing comma must be tolerated.
+    EnvVarGuard guard("MC_TE_FILTERS", " mlx5_0 , mlx5_1 ,");
+
+    Config config;
+    ASSERT_TRUE(ConfigHelper().loadFromEnv(config).ok());
+
+    std::vector<std::string> expected{"mlx5_0", "mlx5_1"};
+    EXPECT_EQ(config.getArray<std::string>("topology/rdma_whitelist"),
+              expected);
+}
+
+TEST(TransferEngineConfigOverrideTest, FilterNicUnsetLeavesWhitelistEmpty) {
+    // Not setting the env var must leave the default (discover all NICs).
+    Config config;
+    ASSERT_TRUE(ConfigHelper().loadFromEnv(config).ok());
+
+    EXPECT_TRUE(
+        config.getArray<std::string>("topology/rdma_whitelist").empty());
+}
+
 TEST(TransferEngineConfigOverrideTest,
      ExplicitMetadataOverridesDriveSuccessfulHttpInitialization) {
 #ifdef _WIN32


### PR DESCRIPTION
## What

Add environment variables to configure the RDMA NIC allow/deny list:

- `MC_FILTER_NIC` → `topology/rdma_whitelist` (allow-list; only these NICs are used, takes precedence)
- `MC_FILTER_NIC_EXCLUDE` → `topology/rdma_blacklist` (deny-list)

Values are comma-separated device names, e.g. `MC_FILTER_NIC=mlx5_bond_0,mlx5_bond_1`. Unset = discover all NICs (unchanged default).

## Why

The platform probes already support NIC allow/deny lists via the config keys `topology/rdma_whitelist` / `topology/rdma_blacklist` (see `filterInfiniBandDevices`), but **there was no env var wired to them**, so users had no way to restrict which RDMA NICs the engine discovers and uses.

On multi-NIC / multi-NUMA hosts this matters. The rail selection enumerates every discovered remote device and will attempt QPs to devices that are not reachable from the peer; those fail at `modify QP to RTR` and drag aggregate throughput down. See #2758 (and the related cross-NUMA mapping issue #2467). Giving operators a way to scope the engine to the reachable NICs is a simple, opt-in mitigation that works today, independent of the deeper rail-mapping fix.

## Changes

- `setArrayConfig()`: parse a comma-separated env value into a string array (trims whitespace, drops empty items), mirroring `parseDoubleArray`.
- Wire `MC_FILTER_NIC` / `MC_FILTER_NIC_EXCLUDE` in `loadFromEnv`.
- Unit tests: both mappings, whitespace trimming, and the unset default.
- Env var docs.

## Measured effect

8× H20 / CX-7 200G RoCEv2, 4-bond dual-NUMA, 2 nodes, TENT backend:

| | without filter | `MC_FILTER_NIC=mlx5_bond_0` |
|---|---|---|
| discovered topology | 5 devices (incl. unreachable NUMA1 bonds) | 1 device (mlx5_bond_0) |
| `modify QP to RTR error 22` | repeated on bond_2/3 | none |
| cross-node throughput | 0.14 GB/s | 48 GB/s |

## Notes

Opt-in; default behavior unchanged. Sits on the same TENT device-selection line as #2516 / #2568.