### PR TITLE
[TENT] Route slices to their QP pool (RFC #2568 step 3)

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -55,6 +55,7 @@ struct TaskInfo {
     int xport_priority{0};        // transport priority (for fallback)
     int failover_count{0};        // number of failover attempts
     uint64_t device_mask{~0ULL};  // Device mask for quota allocation
+    std::string qp_pool;          // Named QP pool (RFC #2568 step 3), "" = none
     Request request;
     bool staging{false};
     TransferStatusEnum status{TransferStatusEnum::PENDING};

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transport.h
@@ -55,6 +55,10 @@ class Transport {
         }
 
         uint64_t device_mask;  // Device mask for transport selection
+        // Named QP pool for this batch's transfers (RFC #2568 step 3). Empty =
+        // no pool (default spray). Carried like device_mask, from the matched
+        // SelectionPolicy down to each RdmaTask.
+        std::string qp_pool;
         BatchID progress_batch_id{0};
         std::function<void(BatchID)> notify_progress;
     };

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint.h
@@ -172,6 +172,10 @@ class RdmaEndPoint : public std::enable_shared_from_this<RdmaEndPoint> {
     int setupOneQP(int qp_index, const std::string& peer_gid, uint16_t peer_lid,
                    uint32_t peer_qp_num, std::string* reply_msg = nullptr);
 
+    // Returns the pool segment owning qp_index, or nullptr when no pools are
+    // configured (the default single-pool case). Read-only after construct().
+    const QpPoolSegment* poolForQp(int qp_index) const;
+
     bool reserveQuota(int qp_index, int num_entries);
 
     void cancelQuota(int qp_index, int num_entries);
@@ -193,6 +197,10 @@ class RdmaEndPoint : public std::enable_shared_from_this<RdmaEndPoint> {
     std::string endpoint_name_;
 
     std::vector<ibv_qp*> qp_list_;
+    // Per-pool QP layout, resolved once in construct() from params_->qp_pools.
+    // Empty = default single pool spanning all of qp_list_. Each segment's
+    // [begin, begin+num_qp) indexes into qp_list_. Read-only after construct().
+    std::vector<QpPoolSegment> qp_pool_segments_;
     // Each data QP queue is owned by exactly one worker lane; reset/deconstruct
     // are synchronized by the endpoint lifecycle lock.
     std::vector<BoundedSliceQueue> slice_queue_;

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/params.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/params.h
@@ -15,8 +15,12 @@
 #ifndef TENT_PARAMS_H
 #define TENT_PARAMS_H
 
+#include <infiniband/verbs.h>
+
 #include <cstddef>
 #include <cstdint>
+#include <string>
+#include <vector>
 
 namespace mooncake {
 namespace tent {
@@ -29,6 +33,24 @@ struct DeviceParams {
     int max_cqe = 4096;
 };
 
+// One named QP pool. When SelectionPolicy entries declare a `qp_pool`, each
+// distinct pool gets its own contiguous run of data QPs inside every endpoint,
+// handshaked with that pool's SL/TC. Transfers routed to a pool only use its
+// QPs, giving link-layer isolation between traffic classes (RFC #2568 step 2).
+//
+// Layering note: the wire handshake is unchanged. Both peers derive the same
+// pool layout from the same SelectionPolicy config, so the flat qp_num list is
+// still paired positionally — pool P's i-th QP on one side lines up with pool
+// P's i-th QP on the other. This keeps BootstrapDesc byte-compatible with peers
+// that don't know about pools (they simply run a single default pool).
+struct QpPoolSegment {
+    std::string name;
+    int num_qp = 0;          // Number of data QPs dedicated to this pool.
+    int begin = 0;           // Index into qp_list_ where this pool's QPs start.
+    int service_level = -1;  // -1 = fall back to EndPointParams::service_level.
+    int traffic_class = -1;  // -1 = fall back to EndPointParams::traffic_class.
+};
+
 struct EndPointParams {
     int endpoint_store_cap = 65536;
     int qp_mul_factor = 6;  // Derived from RdmaParams::num_lanes.
@@ -36,6 +58,12 @@ struct EndPointParams {
     int max_qp_wr = 256;
     int max_inline_bytes = 64;
     ibv_mtu path_mtu = IBV_MTU_4096;
+
+    // Named QP pools. Empty (default) = today's behavior: a single homogeneous
+    // run of qp_mul_factor data QPs, all handshaked with the global SL/TC. When
+    // non-empty, the segments partition the data QPs by pool; total QP count is
+    // the sum of per-pool num_qp. Both peers must derive the same layout.
+    std::vector<QpPoolSegment> qp_pools;
 
     // Advanced parameters, do not change unless you understand them
     // INIT State
@@ -57,6 +85,36 @@ struct EndPointParams {
     uint8_t send_rnr_count = 7;
     uint8_t max_rd_atomic = 16;
 };
+
+// Result of resolving the QP-pool layout: the concrete per-pool segments (each
+// with its [begin, begin+num_qp) span filled in) and the total data-QP count.
+struct QpPoolLayout {
+    std::vector<QpPoolSegment> segments;
+    int total_qp = 0;
+    bool valid = false;  // false = invalid config (non-positive total).
+};
+
+// Pure resolver used by RdmaEndPoint::construct(). Kept free-standing (no RDMA
+// handles) so the layout math can be unit-tested. Empty `pools` reproduces the
+// historical single homogeneous run of `qp_mul_factor` data QPs (segments left
+// empty, meaning "one default pool"); a non-empty config lays out one
+// contiguous segment per pool and the total is the sum of per-pool num_qp.
+inline QpPoolLayout computeQpPoolSegments(
+    const std::vector<QpPoolSegment>& pools, int qp_mul_factor) {
+    QpPoolLayout layout;
+    if (pools.empty()) {
+        layout.total_qp = qp_mul_factor;
+    } else {
+        for (const auto& pool : pools) {
+            QpPoolSegment seg = pool;
+            seg.begin = layout.total_qp;
+            layout.segments.push_back(seg);
+            layout.total_qp += pool.num_qp;
+        }
+    }
+    layout.valid = layout.total_qp > 0;
+    return layout;
+}
 
 struct WorkerParams {
     int num_workers = 6;  // Derived from RdmaParams::num_lanes.

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/params.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/params.h
@@ -116,6 +116,27 @@ inline QpPoolLayout computeQpPoolSegments(
     return layout;
 }
 
+// Pure QP router used by RdmaEndPoint::submitSlices (RFC #2568 step 3). Given
+// the resolved segments, the pool a transfer asked for, and a caller-provided
+// candidate index (the worker lane), return the QP index the transfer should
+// use. When the pool is named and found, the candidate is folded into that
+// pool's [begin, begin+num_qp) span so the transfer only ever touches its
+// pool's QPs. When no pool is named, or the name is unknown, or no pools are
+// configured, the candidate passes through unchanged (default spray behavior).
+// total_qp must be > 0; the result is always in [0, total_qp).
+inline int selectQpInPool(const std::vector<QpPoolSegment>& segments,
+                          const std::string& pool_name, int candidate,
+                          int total_qp) {
+    if (candidate < 0) candidate = 0;
+    if (!pool_name.empty()) {
+        for (const auto& seg : segments) {
+            if (seg.name == pool_name && seg.num_qp > 0)
+                return seg.begin + (candidate % seg.num_qp);
+        }
+    }
+    return candidate % total_qp;
+}
+
 struct WorkerParams {
     int num_workers = 6;  // Derived from RdmaParams::num_lanes.
     int max_retry_count = 8;

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/slice.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/slice.h
@@ -23,6 +23,7 @@
 #include <memory>
 #include <mutex>
 #include <new>
+#include <string>
 #include <thread>
 #include <type_traits>
 #include <vector>
@@ -50,6 +51,10 @@ using RdmaTaskStorage = Slab<RdmaTask>;
 struct RdmaTask {
     int num_slices;
     Request request;
+    // Named QP pool this task's slices should use (RFC #2568 step 3). Empty =
+    // no pool selected: slices spray across all data QPs as before. Resolved
+    // from SelectionResult.qp_pool at task creation.
+    std::string qp_pool;
     volatile TransferStatusEnum status_word;
     volatile size_t transferred_bytes;
     volatile int success_slices;

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -1485,6 +1485,7 @@ Status TransferEngineImpl::commitPreparedSubmit(
             prepared.submit_time;  // Record start time for latency tracking
         task.type = owner.route.transport;
         task.device_mask = owner.route.device_mask;
+        if (owner.route.qp_pool) task.qp_pool = *owner.route.qp_pool;
         if (task.type == UNSPEC) {
             LOG(WARNING) << "Unable to find registered buffer for request: "
                          << printRequest(merged_request);
@@ -1534,6 +1535,8 @@ Status TransferEngineImpl::commitPreparedSubmit(
             // this batch should have the same policy)
             sub_batch->device_mask =
                 batch->task_list[task_id_list[type][0]].device_mask;
+            sub_batch->qp_pool =
+                batch->task_list[task_id_list[type][0]].qp_pool;
         }
 
         auto status = transport->submitTransferTasks(
@@ -1596,6 +1599,7 @@ Status TransferEngineImpl::enqueuePreparedSubmit(Batch* batch,
         task.type = UNSPEC;
         task.sub_task_id = -1;
         task.device_mask = owner.route.device_mask;
+        if (owner.route.qp_pool) task.qp_pool = *owner.route.qp_pool;
         task.derived = task_plan.task_id != owner.owner_task_id;
     }
 
@@ -1674,6 +1678,7 @@ Status TransferEngineImpl::dispatchQueuedOwner(QueueOwnerId owner_id) {
     auto route = resolveTransport(task.request, 0);
     task.type = route.transport;
     task.device_mask = route.device_mask;
+    if (route.qp_pool) task.qp_pool = *route.qp_pool;
     if (task.type == UNSPEC) {
         return finishQueuedOwner(owner_id, FAILED);
     }
@@ -1702,7 +1707,10 @@ Status TransferEngineImpl::dispatchQueuedOwner(QueueOwnerId owner_id) {
     auto& transport = transport_list_[task.type];
     if (!transport) return finishQueuedOwner(owner_id, FAILED);
     auto& sub_batch = batch->sub_batch[task.type];
-    if (task.type == RDMA) sub_batch->device_mask = task.device_mask;
+    if (task.type == RDMA) {
+        sub_batch->device_mask = task.device_mask;
+        sub_batch->qp_pool = task.qp_pool;
+    }
     task.sub_task_id = sub_batch->size();
     auto status = transport->submitTransferTasks(sub_batch, {task.request});
     if (!status.ok()) {

--- a/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
@@ -718,7 +718,17 @@ int RdmaEndPoint::submitSlices(std::vector<RdmaSlice*>& slice_list,
     RWSpinlock::ReadGuard guard(lock_);
     if (qp_list_.empty()) return 0;
     if (qp_index < 0) qp_index = 0;
-    qp_index %= qp_list_.size();
+    // Route to the QP pool this transfer asked for (RFC #2568 step 3). All
+    // slices in a list belong to one task, hence one pool; fold the worker-lane
+    // candidate into that pool's QP segment. Empty/unknown pool or no pools
+    // configured => unchanged global spray.
+    static const std::string kNoPool;
+    const std::string& pool_name =
+        (!slice_list.empty() && slice_list.front()->task)
+            ? slice_list.front()->task->qp_pool
+            : kNoPool;
+    qp_index = selectQpInPool(qp_pool_segments_, pool_name, qp_index,
+                              (int)qp_list_.size());
     // Check endpoint status before submitting
     if (status_.load(std::memory_order_relaxed) != EP_READY) return 0;
     auto cq = context_->cq(qp_index % context_->cqCount());

--- a/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
@@ -83,12 +83,28 @@ int RdmaEndPoint::construct(RdmaContext* context, EndPointParams* params,
     params_ = params;
     endpoint_name_ = endpoint_name;
     inflight_slices_ = 0;
-    qp_list_.resize(params_->qp_mul_factor);
+
+    // Resolve the per-pool QP layout (see computeQpPoolSegments). Empty
+    // qp_pools (the default) keeps the historical single homogeneous run of
+    // qp_mul_factor data QPs; a non-empty config lays out one contiguous
+    // segment per pool. qp_pool_segments_ is read-only after construct().
+    QpPoolLayout layout =
+        computeQpPoolSegments(params_->qp_pools, params_->qp_mul_factor);
+    if (!layout.valid) {
+        LOG(ERROR) << "Invalid QP count " << layout.total_qp
+                   << " (qp_mul_factor=" << params_->qp_mul_factor
+                   << ", pools=" << params_->qp_pools.size() << ")";
+        return -1;
+    }
+    qp_pool_segments_ = std::move(layout.segments);
+    const int total_qp = layout.total_qp;
+
+    qp_list_.resize(total_qp);
     // Value-initialize the full array because cleanup may run after only a
     // prefix of QPs has been created.
-    wr_depth_list_ = new WrDepthBlock[params_->qp_mul_factor]();
+    wr_depth_list_ = new WrDepthBlock[total_qp]();
 
-    for (int i = 0; i < params_->qp_mul_factor; ++i) {
+    for (int i = 0; i < total_qp; ++i) {
         wr_depth_list_[i].value = 0;
         ibv_qp_init_attr attr;
         memset(&attr, 0, sizeof(attr));
@@ -648,6 +664,14 @@ int RdmaEndPoint::resetConnection(const std::string& reason) {
     return 0;
 }
 
+const QpPoolSegment* RdmaEndPoint::poolForQp(int qp_index) const {
+    for (const auto& seg : qp_pool_segments_) {
+        if (qp_index >= seg.begin && qp_index < seg.begin + seg.num_qp)
+            return &seg;
+    }
+    return nullptr;
+}
+
 int RdmaEndPoint::setupAllQPs(const std::string& peer_gid, uint16_t peer_lid,
                               std::vector<uint32_t> peer_qp_num_list,
                               std::string* reply_msg) {
@@ -847,6 +871,19 @@ int RdmaEndPoint::setupOneQP(int qp_index, const std::string& peer_gid,
     assert(qp_index >= 0 && qp_index < (int)qp_list_.size());
     auto& qp = qp_list_[qp_index];
 
+    // Resolve link-layer QoS for this QP. When it belongs to a pool that
+    // overrides SL/TC, use the pool's values; otherwise fall back to the global
+    // endpoint SL/TC (unchanged default behavior).
+    const QpPoolSegment* pool = poolForQp(qp_index);
+    const uint8_t qp_service_level =
+        (pool && pool->service_level >= 0)
+            ? static_cast<uint8_t>(pool->service_level)
+            : params_->service_level;
+    const uint8_t qp_traffic_class =
+        (pool && pool->traffic_class >= 0)
+            ? static_cast<uint8_t>(pool->traffic_class)
+            : params_->traffic_class;
+
     // RESET -> INIT
     ibv_qp_attr attr;
     memset(&attr, 0, sizeof(attr));
@@ -886,9 +923,9 @@ int RdmaEndPoint::setupOneQP(int qp_index, const std::string& peer_gid,
     attr.ah_attr.grh.sgid_index = context().gidIndex();
     attr.ah_attr.grh.hop_limit = params_->hop_limit;
     attr.ah_attr.grh.flow_label = params_->flow_label;
-    attr.ah_attr.grh.traffic_class = params_->traffic_class;
+    attr.ah_attr.grh.traffic_class = qp_traffic_class;
     attr.ah_attr.dlid = peer_lid;
-    attr.ah_attr.sl = params_->service_level;
+    attr.ah_attr.sl = qp_service_level;
     attr.ah_attr.src_path_bits = params_->src_path_bits;
     attr.ah_attr.static_rate = params_->static_rate;
     attr.ah_attr.is_global = 1;

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
@@ -437,6 +437,7 @@ Status RdmaTransport::submitTransferTasks(
         auto* task = RdmaTaskStorage::Get().allocate();
         rdma_batch->task_list.push_back(task);
         task->request = request;
+        task->qp_pool = rdma_batch->qp_pool;  // RFC #2568 step 3
         task->num_slices = 0;
         task->status_word = PENDING;
         task->transferred_bytes = 0;

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
@@ -37,6 +37,7 @@
 #include "tent/common/utils/string_builder.h"
 #include "tent/runtime/topology.h"
 #include "tent/common/utils/random.h"
+#include "tent/thirdparty/nlohmann/json.h"
 
 #define SET_DEVICE(key, param) \
     param = conf->get("transports/rdma/device/" #key, param)
@@ -191,6 +192,41 @@ static Status convertConfToRdmaParams(std::shared_ptr<Config> conf,
         params->endpoint.path_mtu = IBV_MTU_1024;
     else
         params->endpoint.path_mtu = IBV_MTU_512;
+
+    // Optional per-pool QP layout (RFC #2568 step 2). Each entry defines a
+    // named pool with its own QP count and link-layer SL/TC;
+    // SelectionPolicy.qp_pool references these by name. Absent/empty => single
+    // default pool (unchanged). The pool SL/TC live here in the RDMA config,
+    // not in SelectionPolicy, to keep the link-layer QoS definition in the
+    // transport layer; policies only reference a pool by name.
+    params->endpoint.qp_pools.clear();
+    auto qp_pools_json =
+        conf->getArray<nlohmann::json>("transports/rdma/endpoint/qp_pools");
+    for (const auto& pool_json : qp_pools_json) {
+        if (!pool_json.is_object()) {
+            LOG(WARNING) << "Ignore non-object entry in qp_pools";
+            continue;
+        }
+        if (!pool_json.contains("name") || !pool_json["name"].is_string()) {
+            LOG(WARNING) << "Ignore qp_pool entry without a string 'name'";
+            continue;
+        }
+        QpPoolSegment seg;
+        seg.name = pool_json["name"].get<std::string>();
+        seg.num_qp = pool_json.value("num_qp", 0);
+        if (seg.num_qp <= 0) {
+            LOG(WARNING) << "Ignore qp_pool '" << seg.name
+                         << "' with non-positive num_qp " << seg.num_qp;
+            continue;
+        }
+        seg.service_level = pool_json.value("service_level", -1);
+        seg.traffic_class = pool_json.value("traffic_class", -1);
+        params->endpoint.qp_pools.push_back(std::move(seg));
+    }
+    if (!params->endpoint.qp_pools.empty()) {
+        LOG(INFO) << "Configured " << params->endpoint.qp_pools.size()
+                  << " QP pool(s) for per-class link-layer isolation";
+    }
 
     SET_WORKERS(max_retry_count, params->workers.max_retry_count);
     SET_WORKERS(block_size, params->workers.block_size);

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -33,6 +33,13 @@ target_include_directories(tent_ip_utils_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME tent_ip_utils_test COMMAND tent_ip_utils_test)
 
+add_executable(tent_qp_pool_layout_test qp_pool_layout_test.cpp)
+target_link_libraries(tent_qp_pool_layout_test PRIVATE tent_common gtest
+                                                       gtest_main)
+target_include_directories(tent_qp_pool_layout_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+add_test(NAME tent_qp_pool_layout_test COMMAND tent_qp_pool_layout_test)
+
 add_executable(tent_coalesce_regions_test coalesce_regions_test.cpp)
 target_link_libraries(tent_coalesce_regions_test PRIVATE tent_common gtest
                                                          gtest_main)

--- a/mooncake-transfer-engine/tent/tests/qp_pool_layout_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/qp_pool_layout_test.cpp
@@ -1,0 +1,114 @@
+// Copyright 2025 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Unit tests for computeQpPoolSegments — the pure QP-pool layout resolver used
+// by RdmaEndPoint::construct() (RFC #2568 step 2). Kept free of RDMA handles so
+// the layout math is testable without a device.
+
+#include <gtest/gtest.h>
+
+#include "tent/transport/rdma/params.h"
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+// Default path: no pools configured => a single homogeneous run of
+// qp_mul_factor QPs, no explicit segments (poolForQp will return nullptr and
+// callers fall back to the global SL/TC — byte-for-byte the prior behavior).
+TEST(QpPoolLayoutTest, EmptyPoolsKeepsFlatQpMulFactor) {
+    auto layout = computeQpPoolSegments({}, 6);
+    EXPECT_TRUE(layout.valid);
+    EXPECT_EQ(layout.total_qp, 6);
+    EXPECT_TRUE(layout.segments.empty());
+}
+
+// A non-positive total (e.g. qp_mul_factor <= 0 with no pools) is rejected so
+// construct() can fail cleanly instead of allocating a zero-length QP array.
+TEST(QpPoolLayoutTest, EmptyPoolsWithNonPositiveFactorIsInvalid) {
+    auto layout = computeQpPoolSegments({}, 0);
+    EXPECT_FALSE(layout.valid);
+    EXPECT_EQ(layout.total_qp, 0);
+}
+
+// Multiple pools lay out contiguous, non-overlapping segments; total is the
+// sum of per-pool num_qp; qp_mul_factor is ignored once pools are set.
+TEST(QpPoolLayoutTest, MultiplePoolsLayoutContiguousSegments) {
+    std::vector<QpPoolSegment> pools;
+    QpPoolSegment kv;
+    kv.name = "kv";
+    kv.num_qp = 4;
+    kv.service_level = 5;
+    kv.traffic_class = 96;
+    pools.push_back(kv);
+    QpPoolSegment ctrl;
+    ctrl.name = "ctrl";
+    ctrl.num_qp = 2;
+    pools.push_back(ctrl);
+
+    auto layout = computeQpPoolSegments(pools, /*qp_mul_factor=*/6);
+    ASSERT_TRUE(layout.valid);
+    EXPECT_EQ(layout.total_qp, 6);  // 4 + 2, not qp_mul_factor
+    ASSERT_EQ(layout.segments.size(), 2u);
+
+    EXPECT_EQ(layout.segments[0].name, "kv");
+    EXPECT_EQ(layout.segments[0].begin, 0);
+    EXPECT_EQ(layout.segments[0].num_qp, 4);
+    EXPECT_EQ(layout.segments[0].service_level, 5);
+    EXPECT_EQ(layout.segments[0].traffic_class, 96);
+
+    EXPECT_EQ(layout.segments[1].name, "ctrl");
+    EXPECT_EQ(layout.segments[1].begin, 4);  // starts after kv's 4 QPs
+    EXPECT_EQ(layout.segments[1].num_qp, 2);
+    // ctrl left SL/TC unset -> sentinel -1 (setupOneQP falls back to global).
+    EXPECT_EQ(layout.segments[1].service_level, -1);
+    EXPECT_EQ(layout.segments[1].traffic_class, -1);
+}
+
+// Segments partition [0, total_qp): every QP index maps to exactly one pool,
+// mirroring RdmaEndPoint::poolForQp's linear scan.
+TEST(QpPoolLayoutTest, SegmentsPartitionAllQpIndices) {
+    std::vector<QpPoolSegment> pools;
+    QpPoolSegment a;
+    a.name = "a";
+    a.num_qp = 3;
+    pools.push_back(a);
+    QpPoolSegment b;
+    b.name = "b";
+    b.num_qp = 1;
+    pools.push_back(b);
+
+    auto layout = computeQpPoolSegments(pools, 6);
+    ASSERT_TRUE(layout.valid);
+    ASSERT_EQ(layout.total_qp, 4);
+
+    auto pool_of = [&](int qp_index) -> const QpPoolSegment* {
+        for (const auto& seg : layout.segments) {
+            if (qp_index >= seg.begin && qp_index < seg.begin + seg.num_qp)
+                return &seg;
+        }
+        return nullptr;
+    };
+    ASSERT_NE(pool_of(0), nullptr);
+    EXPECT_EQ(pool_of(0)->name, "a");
+    EXPECT_EQ(pool_of(2)->name, "a");
+    ASSERT_NE(pool_of(3), nullptr);
+    EXPECT_EQ(pool_of(3)->name, "b");
+    // Out of range => no pool (default single-pool fallback in poolForQp).
+    EXPECT_EQ(pool_of(4), nullptr);
+}
+
+}  // namespace
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/tests/qp_pool_layout_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/qp_pool_layout_test.cpp
@@ -109,6 +109,72 @@ TEST(QpPoolLayoutTest, SegmentsPartitionAllQpIndices) {
     EXPECT_EQ(pool_of(4), nullptr);
 }
 
+// --- selectQpInPool: the step-3 router (slice pool -> QP index)
+// ---------------
+
+// Helper: a two-pool layout kv=[0,4), ctrl=[4,6).
+static std::vector<QpPoolSegment> twoPools() {
+    auto layout = computeQpPoolSegments(
+        {{"kv", 4, 0, -1, -1}, {"ctrl", 2, 0, -1, -1}}, 6);
+    return layout.segments;
+}
+
+// Empty pool name => pass through, folded into the whole QP range. This is the
+// default (no pool selected) behavior — identical to the pre-step-3 spray.
+TEST(SelectQpInPoolTest, EmptyPoolNameSpraysAcrossAllQps) {
+    auto segs = twoPools();
+    EXPECT_EQ(selectQpInPool(segs, "", 0, 6), 0);
+    EXPECT_EQ(selectQpInPool(segs, "", 5, 6), 5);
+    EXPECT_EQ(selectQpInPool(segs, "", 7, 6), 1);  // 7 % 6
+}
+
+// No pools configured at all => also pass through (single default pool).
+TEST(SelectQpInPoolTest, NoSegmentsSpraysAcrossAllQps) {
+    std::vector<QpPoolSegment> none;
+    EXPECT_EQ(selectQpInPool(none, "kv", 3, 6), 3);
+    EXPECT_EQ(selectQpInPool(none, "", 8, 6), 2);  // 8 % 6
+}
+
+// A named pool folds the candidate into that pool's segment only.
+TEST(SelectQpInPoolTest, NamedPoolFoldsIntoItsSegment) {
+    auto segs = twoPools();  // kv=[0,4), ctrl=[4,6)
+    // kv: begin 0, num 4 -> indices 0..3
+    EXPECT_EQ(selectQpInPool(segs, "kv", 0, 6), 0);
+    EXPECT_EQ(selectQpInPool(segs, "kv", 3, 6), 3);
+    EXPECT_EQ(selectQpInPool(segs, "kv", 4, 6), 0);  // 4 % 4 -> begin+0
+    EXPECT_EQ(selectQpInPool(segs, "kv", 6, 6), 2);  // 6 % 4 -> begin+2
+    // ctrl: begin 4, num 2 -> indices 4..5
+    EXPECT_EQ(selectQpInPool(segs, "ctrl", 0, 6), 4);
+    EXPECT_EQ(selectQpInPool(segs, "ctrl", 1, 6), 5);
+    EXPECT_EQ(selectQpInPool(segs, "ctrl", 3, 6), 5);  // 3 % 2 -> begin+1
+}
+
+// Unknown pool name => fall back to the whole range (don't drop the transfer).
+TEST(SelectQpInPoolTest, UnknownPoolFallsBackToWholeRange) {
+    auto segs = twoPools();
+    EXPECT_EQ(selectQpInPool(segs, "nope", 5, 6), 5);
+    EXPECT_EQ(selectQpInPool(segs, "nope", 9, 6), 3);  // 9 % 6
+}
+
+// Negative candidate is clamped to 0 before folding.
+TEST(SelectQpInPoolTest, NegativeCandidateClampsToZero) {
+    auto segs = twoPools();
+    EXPECT_EQ(selectQpInPool(segs, "ctrl", -1, 6), 4);  // begin+0
+    EXPECT_EQ(selectQpInPool(segs, "", -1, 6), 0);
+}
+
+// Every result stays in [0, total_qp) regardless of pool/candidate.
+TEST(SelectQpInPoolTest, ResultAlwaysInRange) {
+    auto segs = twoPools();
+    for (int c = 0; c < 20; ++c) {
+        for (const char* name : {"", "kv", "ctrl", "nope"}) {
+            int idx = selectQpInPool(segs, name, c, 6);
+            EXPECT_GE(idx, 0);
+            EXPECT_LT(idx, 6);
+        }
+    }
+}
+
 }  // namespace
 }  // namespace tent
 }  // namespace mooncake


### PR DESCRIPTION
> **Stacked on #2759** (RFC #2568 step 2). This PR's own change is the last commit, `[TENT] Route slices to their QP pool`. The diff will show step 2's changes too until #2759 merges, after which it narrows to just the routing commit. Please review the final commit here; the pool *allocation* it builds on is #2759.

### What

Step 1 (#2640) added the `SelectionPolicy.qp_pool` schema. Step 2 (#2759) builds a per-pool QP segment inside each endpoint, handshaked with that pool's SL/TC. **This step makes the routing real**: a transfer tagged with a `qp_pool` actually sends on that pool's QPs, giving link-layer isolation between traffic classes end to end.

### How — carry `qp_pool` like `device_mask`, then fold into the pool's segment

The pool name rides the exact same plumbing the existing `device_mask` already uses, so the data flow mirrors code reviewers know:

```
SelectionResult.qp_pool  ->  TaskInfo.qp_pool  ->  SubBatch.qp_pool
   ->  RdmaTask.qp_pool  ->  submitSlices() -> selectQpInPool()
```

- **`selectQpInPool()`** (pure, in `params.h` next to `computeQpPoolSegments`): given the segments, the requested pool, and a worker-lane candidate index, returns the QP index to use. A named, known pool folds the candidate into that pool's `[begin, begin+num_qp)` span; empty / unknown pool / no pools configured => the candidate passes through as `candidate % qp_count` (unchanged spray). Result is always in `[0, qp_count)`.
- **`submitSlices()`**: all slices in a list belong to one task, hence one pool, so it reads `slice->task->qp_pool` once and routes the whole list.

### Default path unchanged

With no `qp_pool` on the matched policy, the name is empty and `selectQpInPool` returns `candidate % qp_count` — byte-for-byte the prior round-robin. No pools configured ⇒ same.

### Tests

`SelectQpInPoolTest` (6 cases): empty pool name sprays across all QPs; no segments configured also sprays; a named pool folds only into its segment; unknown pool falls back to the whole range (never drops a transfer); negative candidate clamps to 0; and the result is always in range for any pool/candidate. Built and all 10 cases (with step 2's 4) pass on an H20 / CX-7 box; the `tent` library compiles clean.

### The line this completes

#2640 (schema) → #2759 (per-pool QPs + SL/TC) → this (routing). Together: a policy can name a `qp_pool`, that pool gets its own QPs with its own Service Level / Traffic Class, and its traffic is isolated onto those QPs — the end-to-end mechanism @alogfans outlined on the RFC.