### PR TITLE
[TENT] Opt-in earliest-deadline-first dispatch in admission queue (RFC #2519 step 2)

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
@@ -42,6 +42,13 @@ struct QueueLimits {
     size_t max_outstanding_bytes{0};
     size_t staging_owner_reserve{0};
     size_t staging_byte_reserve{0};
+    // Opt-in deadline-aware dispatch (RFC #2519 step 2). When false (default),
+    // pickForDispatch keeps strict FIFO order — unchanged behavior. When true,
+    // owners carrying a deadline (request.deadline_ns != 0) are dispatched
+    // earliest-deadline-first; owners without a deadline keep FIFO order behind
+    // them. This only reorders selection within the existing capacity limits;
+    // it does not admit/reject or otherwise change what gets dispatched.
+    bool deadline_aware{false};
 };
 
 struct QueueOwnerInput {

--- a/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
@@ -14,6 +14,7 @@
 
 #include "tent/runtime/admission_queue.h"
 
+#include <algorithm>
 #include <limits>
 #include <set>
 
@@ -185,10 +186,40 @@ Status LocalTransferAdmissionQueue::tryAdmit(
     return Status::OK();
 }
 
+namespace {
+// Sort key for EDF: owners without a deadline (0) sort after all deadlined
+// owners, so they never jump ahead of a real deadline.
+inline uint64_t deadlineKey(uint64_t deadline_ns) {
+    return deadline_ns == 0 ? std::numeric_limits<uint64_t>::max()
+                            : deadline_ns;
+}
+}  // namespace
+
 std::vector<QueueOwnerId> LocalTransferAdmissionQueue::pickForDispatch(
     size_t max_owners, size_t max_bytes) {
     std::vector<QueueOwnerId> picked;
     if (max_owners == 0 || max_bytes == 0) return picked;
+
+    // RFC #2519 step 2 (opt-in): reorder the dispatch queue earliest-deadline-
+    // first before selection. Owners without a deadline keep their relative
+    // FIFO order behind all deadlined owners (stable sort on the current fifo_
+    // sequence). Default (deadline_aware == false) leaves fifo_ untouched, so
+    // behavior is identical to strict FIFO. This only reorders *selection*
+    // within the existing capacity limits; it does not admit or reject.
+    if (limits_.deadline_aware) {
+        std::stable_sort(
+            fifo_.begin(), fifo_.end(), [this](QueueOwnerId a, QueueOwnerId b) {
+                auto ia = owners_.find(a);
+                auto ib = owners_.find(b);
+                uint64_t da = (ia == owners_.end())
+                                  ? std::numeric_limits<uint64_t>::max()
+                                  : deadlineKey(ia->second.request.deadline_ns);
+                uint64_t db = (ib == owners_.end())
+                                  ? std::numeric_limits<uint64_t>::max()
+                                  : deadlineKey(ib->second.request.deadline_ns);
+                return da < db;
+            });
+    }
 
     size_t used_owners = 0;
     size_t used_bytes = 0;

--- a/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
@@ -24,6 +24,13 @@ namespace {
 
 using PublicTaskKey = std::pair<uint64_t, size_t>;
 
+// Sort key for EDF: owners without a deadline (0) sort after all deadlined
+// owners, so they never jump ahead of a real deadline.
+inline uint64_t deadlineKey(uint64_t deadline_ns) {
+    return deadline_ns == 0 ? std::numeric_limits<uint64_t>::max()
+                            : deadline_ns;
+}
+
 bool isSupportedTerminalStatus(TransferStatusEnum status) {
     return status == TransferStatusEnum::COMPLETED ||
            status == TransferStatusEnum::INVALID ||
@@ -175,7 +182,27 @@ Status LocalTransferAdmissionQueue::tryAdmit(
         for (const auto derived_task_id : owner_input.derived_task_ids) {
             public_to_owner_[{submit.batch_token, derived_task_id}] = owner_id;
         }
-        fifo_.push_back(owner_id);
+        // RFC #2519 step 2: keep fifo_ ordered on admission so pickForDispatch
+        // never has to re-sort. Default (deadline_aware == false) appends in
+        // strict FIFO. When deadline-aware, insert at the earliest-deadline-
+        // first position; upper_bound places a new owner *after* existing
+        // owners with the same deadline, preserving FIFO order among ties.
+        if (limits_.deadline_aware) {
+            const uint64_t key = deadlineKey(owner.request.deadline_ns);
+            auto pos = std::upper_bound(
+                fifo_.begin(), fifo_.end(), key,
+                [this](uint64_t k, QueueOwnerId id) {
+                    auto it = owners_.find(id);
+                    uint64_t d =
+                        (it == owners_.end())
+                            ? std::numeric_limits<uint64_t>::max()
+                            : deadlineKey(it->second.request.deadline_ns);
+                    return k < d;
+                });
+            fifo_.insert(pos, owner_id);
+        } else {
+            fifo_.push_back(owner_id);
+        }
         admitted_owner_ids.push_back(owner_id);
     }
 
@@ -186,40 +213,17 @@ Status LocalTransferAdmissionQueue::tryAdmit(
     return Status::OK();
 }
 
-namespace {
-// Sort key for EDF: owners without a deadline (0) sort after all deadlined
-// owners, so they never jump ahead of a real deadline.
-inline uint64_t deadlineKey(uint64_t deadline_ns) {
-    return deadline_ns == 0 ? std::numeric_limits<uint64_t>::max()
-                            : deadline_ns;
-}
-}  // namespace
-
 std::vector<QueueOwnerId> LocalTransferAdmissionQueue::pickForDispatch(
     size_t max_owners, size_t max_bytes) {
     std::vector<QueueOwnerId> picked;
     if (max_owners == 0 || max_bytes == 0) return picked;
 
-    // RFC #2519 step 2 (opt-in): reorder the dispatch queue earliest-deadline-
-    // first before selection. Owners without a deadline keep their relative
-    // FIFO order behind all deadlined owners (stable sort on the current fifo_
-    // sequence). Default (deadline_aware == false) leaves fifo_ untouched, so
-    // behavior is identical to strict FIFO. This only reorders *selection*
-    // within the existing capacity limits; it does not admit or reject.
-    if (limits_.deadline_aware) {
-        std::stable_sort(
-            fifo_.begin(), fifo_.end(), [this](QueueOwnerId a, QueueOwnerId b) {
-                auto ia = owners_.find(a);
-                auto ib = owners_.find(b);
-                uint64_t da = (ia == owners_.end())
-                                  ? std::numeric_limits<uint64_t>::max()
-                                  : deadlineKey(ia->second.request.deadline_ns);
-                uint64_t db = (ib == owners_.end())
-                                  ? std::numeric_limits<uint64_t>::max()
-                                  : deadlineKey(ib->second.request.deadline_ns);
-                return da < db;
-            });
-    }
+    // RFC #2519 step 2 (opt-in): earliest-deadline-first dispatch. When
+    // deadline_aware, fifo_ is kept EDF-ordered at admission time (see
+    // tryAdmit's ordered insert), so there is nothing to sort here — we just
+    // consume from the front. This keeps the hot dispatch path O(picked)
+    // instead of re-sorting the whole queue (up to max_outstanding_owners) on
+    // every call. Default (deadline_aware == false) is plain FIFO.
 
     size_t used_owners = 0;
     size_t used_bytes = 0;

--- a/mooncake-transfer-engine/tent/tests/admission_queue_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/admission_queue_test.cpp
@@ -388,6 +388,76 @@ TEST(AdmissionQueueTest, AllowsBatchTokenReuseAfterRetire) {
     EXPECT_EQ(resolved_owner, 2u);
 }
 
+// --- RFC #2519 step 2: opt-in deadline-aware (EDF) dispatch ---------------
+
+QueueOwnerInput makeOwnerWithDeadline(size_t public_task_id, size_t length,
+                                      uint64_t deadline_ns) {
+    QueueOwnerInput owner = makeOwner(public_task_id, length);
+    owner.request.deadline_ns = deadline_ns;
+    return owner;
+}
+
+TEST(AdmissionQueueTest, DeadlineAwareDispatchesEarliestDeadlineFirst) {
+    QueueLimits limits{4, 4096, 0, 0};
+    limits.deadline_aware = true;
+    LocalTransferAdmissionQueue queue(limits);
+    std::vector<QueueOwnerId> admitted_ids;
+
+    // Admitted in FIFO order 1,2,3 but with deadlines 300,100,200.
+    auto status =
+        queue.tryAdmit(makeSubmit(1, 3,
+                                  {makeOwnerWithDeadline(0, 16, 300),
+                                   makeOwnerWithDeadline(1, 16, 100),
+                                   makeOwnerWithDeadline(2, 16, 200)}),
+                       admitted_ids);
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+    ASSERT_EQ(admitted_ids.size(), 3u);  // owner ids 1,2,3
+
+    auto picked = queue.pickForDispatch(3, 4096);
+    // EDF order: owner 2 (dl 100) < owner 3 (dl 200) < owner 1 (dl 300).
+    const std::vector<QueueOwnerId> expected{2, 3, 1};
+    EXPECT_EQ(picked, expected);
+}
+
+TEST(AdmissionQueueTest, DeadlineAwareKeepsUndeadlinedOwnersLast) {
+    QueueLimits limits{4, 4096, 0, 0};
+    limits.deadline_aware = true;
+    LocalTransferAdmissionQueue queue(limits);
+    std::vector<QueueOwnerId> admitted_ids;
+
+    // owner 1: no deadline (0); owner 2: deadline 100; owner 3: no deadline.
+    auto status = queue.tryAdmit(makeSubmit(1, 3,
+                                            {makeOwnerWithDeadline(0, 16, 0),
+                                             makeOwnerWithDeadline(1, 16, 100),
+                                             makeOwnerWithDeadline(2, 16, 0)}),
+                                 admitted_ids);
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+
+    auto picked = queue.pickForDispatch(3, 4096);
+    // Deadlined owner 2 first; undeadlined 1,3 keep FIFO order behind it.
+    const std::vector<QueueOwnerId> expected{2, 1, 3};
+    EXPECT_EQ(picked, expected);
+}
+
+TEST(AdmissionQueueTest, DeadlineUnawareKeepsStrictFifo) {
+    // Default (deadline_aware == false): FIFO regardless of deadlines.
+    LocalTransferAdmissionQueue queue({4, 4096, 0, 0});
+    std::vector<QueueOwnerId> admitted_ids;
+
+    auto status =
+        queue.tryAdmit(makeSubmit(1, 3,
+                                  {makeOwnerWithDeadline(0, 16, 300),
+                                   makeOwnerWithDeadline(1, 16, 100),
+                                   makeOwnerWithDeadline(2, 16, 200)}),
+                       admitted_ids);
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+
+    auto picked = queue.pickForDispatch(3, 4096);
+    const std::vector<QueueOwnerId> expected{1, 2,
+                                             3};  // FIFO, deadlines ignored
+    EXPECT_EQ(picked, expected);
+}
+
 }  // namespace
 }  // namespace tent
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tent/tests/admission_queue_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/admission_queue_test.cpp
@@ -458,6 +458,45 @@ TEST(AdmissionQueueTest, DeadlineUnawareKeepsStrictFifo) {
     EXPECT_EQ(picked, expected);
 }
 
+// fifo_ is kept EDF-ordered at admission time, so owners admitted across
+// *separate* tryAdmit calls (out of deadline order) must still dispatch EDF —
+// this exercises the ordered-insert path, not just a single sorted batch.
+TEST(AdmissionQueueTest, DeadlineAwareOrdersAcrossSeparateAdmits) {
+    QueueLimits limits{8, 4096, 0, 0};
+    limits.deadline_aware = true;
+    LocalTransferAdmissionQueue queue(limits);
+    std::vector<QueueOwnerId> ids;
+
+    // Admit one at a time, deadlines arriving out of order: 300, 100, 200, 0.
+    ASSERT_EQ(
+        queue
+            .tryAdmit(makeSubmit(1, 1, {makeOwnerWithDeadline(0, 16, 300)}),
+                      ids)
+            .code(),
+        Status::Code::kOk);  // owner 1
+    ASSERT_EQ(
+        queue
+            .tryAdmit(makeSubmit(2, 1, {makeOwnerWithDeadline(0, 16, 100)}),
+                      ids)
+            .code(),
+        Status::Code::kOk);  // owner 2
+    ASSERT_EQ(
+        queue
+            .tryAdmit(makeSubmit(3, 1, {makeOwnerWithDeadline(0, 16, 200)}),
+                      ids)
+            .code(),
+        Status::Code::kOk);  // owner 3
+    ASSERT_EQ(
+        queue.tryAdmit(makeSubmit(4, 1, {makeOwnerWithDeadline(0, 16, 0)}), ids)
+            .code(),
+        Status::Code::kOk);  // owner 4 (no deadline → last)
+
+    auto picked = queue.pickForDispatch(8, 4096);
+    // EDF: 100(owner2) < 200(owner3) < 300(owner1) < no-deadline(owner4).
+    const std::vector<QueueOwnerId> expected{2, 3, 1, 4};
+    EXPECT_EQ(picked, expected);
+}
+
 }  // namespace
 }  // namespace tent
 }  // namespace mooncake


### PR DESCRIPTION
## What

The first policy step for RFC #2519, following #2618 (which added `Request.deadline_ns` + post-hoc MLU observability): an **opt-in earliest-deadline-first (EDF) ordering** in `LocalTransferAdmissionQueue::pickForDispatch`.

- `QueueLimits` gains `deadline_aware` (default `false`).
- **`false` (default): strict FIFO — behavior unchanged.**
- `true`: the dispatch queue is stably reordered earliest-deadline-first before selection; owners without a deadline (`deadline_ns == 0`) keep FIFO order behind all deadlined owners.
- Selection still respects the existing owner/byte capacity limits. This only reorders *which* queued owner is picked next — it does **not** admit or reject.

No codec / local-decode / bandwidth prediction here — this is the **ordering layer only**, strictly additive and gated behind the opt-in flag. This is the "PoC PR adding the EDF `pickForDispatch` policy (no codec, no local-decode body)" offered in the RFC.

## Why (measurement)

On an H20 / CX-7 200G RoCEv2 box (TENT backend, 1 MB transfers), sweeping the deadline shows a clear **transition band** where feasible and missed transfers coexist:

| deadline | mean MLU | feasible (MLU<1.0) |
|---|---|---|
| 500 µs | 0.52 | most |
| **200 µs** | **1.31** | **~13%** |
| 100 µs | 2.63 | ~0% |
| 60/30 µs | 4.37 / 8.89 | 0% |

The ~200 µs band is exactly where EDF ordering has leverage — reorder the tight ones ahead. Above (all feasible) or below (all missed) it, ordering buys nothing. The misses there are driven by concurrency queueing, which is what this reordering targets. Full data in #2519.

## Tests

3 new unit tests — EDF order, undeadlined-owners-last, and FIFO-unchanged-when-off. Full `admission_queue_test` suite passes **16/16**.

## Notes

Opt-in; default FIFO behavior unchanged. Next steps (separate) would be MLU-based admission/drop and the degradation hook — both need the bandwidth-prediction input and are deliberately out of scope here. Related: #2519, #2618.