### PR TITLE
[TENT] Deadline-infeasible drop + degradation hook (RFC #2519 step 3)

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
@@ -18,6 +18,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <deque>
+#include <functional>
 #include <map>
 #include <utility>
 #include <vector>
@@ -49,6 +50,14 @@ struct QueueLimits {
     // them. This only reorders selection within the existing capacity limits;
     // it does not admit/reject or otherwise change what gets dispatched.
     bool deadline_aware{false};
+    // Opt-in deadline-infeasible drop (RFC #2519 step 3). Local-decode MLU
+    // threshold θ_local. 0 (default) disables drop entirely — behavior is the
+    // step-2 EDF ordering (or FIFO). When > 0 (e.g. 1.5) and a bandwidth
+    // provider is set, an owner whose predicted MLU
+    // (= predicted_transfer_time / remaining_window) reaches this threshold is
+    // dropped instead of dispatched, and on_local_decode_suggested is raised so
+    // the caller can recompute locally. Requires deadline_aware = true.
+    double mlu_local_threshold{0.0};
 };
 
 struct QueueOwnerInput {
@@ -66,6 +75,23 @@ struct QueueSubmit {
     std::vector<QueueOwnerInput> owners;
 };
 
+// RFC #2519 step 3: degradation signal raised when a transfer is predicted to
+// miss its deadline and is dropped from dispatch. The bodies (compression /
+// local recompute) live in the upper layer (vLLM/SGLang); TENT only raises the
+// signal. No hook registered ⇒ the drop still happens but nothing is notified.
+struct DegradationHooks {
+    std::function<void(const Request&)> on_local_decode_suggested;
+};
+
+// Returns the predicted transfer bandwidth in bytes/second, or <= 0 if unknown
+// (in which case the drop decision is skipped). Injected by the owner so the
+// admission queue does not depend on the device-selection layer directly.
+using BandwidthProvider = std::function<double()>;
+
+// Returns "now" as a steady-clock timestamp in nanoseconds, matching the units
+// of Request.deadline_ns. Injectable so tests are deterministic.
+using NowProvider = std::function<uint64_t()>;
+
 // Runtime-private admission model. It is intentionally single-threaded; the
 // eventual TransferEngineImpl integration owns synchronization.
 class LocalTransferAdmissionQueue {
@@ -82,8 +108,21 @@ class LocalTransferAdmissionQueue {
     Status tryAdmit(const QueueSubmit& submit,
                     std::vector<QueueOwnerId>& admitted_owner_ids);
 
-    std::vector<QueueOwnerId> pickForDispatch(size_t max_owners,
-                                              size_t max_bytes);
+    // Returns the owners to dispatch. When step-3 drop is enabled
+    // (mlu_local_threshold > 0, deadline_aware, and a bandwidth provider set),
+    // owners predicted to miss their deadline are dropped: charged out of the
+    // outstanding accounting, marked terminal (CANCELED), appended to
+    // `dropped_owner_ids` (if non-null), and on_local_decode_suggested is
+    // raised. `dropped_owner_ids` is cleared on entry.
+    std::vector<QueueOwnerId> pickForDispatch(
+        size_t max_owners, size_t max_bytes,
+        std::vector<QueueOwnerId>* dropped_owner_ids = nullptr);
+
+    // Install the step-3 degradation policy inputs. Optional; without it the
+    // queue never drops (default behavior). now defaults to steady_clock.
+    void setDegradationPolicy(BandwidthProvider bandwidth_provider,
+                              DegradationHooks hooks,
+                              NowProvider now_provider = nullptr);
 
     Status complete(QueueOwnerId owner_id, TransferStatusEnum terminal_status);
 
@@ -124,6 +163,11 @@ class LocalTransferAdmissionQueue {
     size_t outstanding_bytes_{0};
     size_t outstanding_user_owners_{0};
     size_t outstanding_user_bytes_{0};
+
+    // RFC #2519 step 3 degradation policy (all optional / opt-in).
+    BandwidthProvider bandwidth_provider_;
+    DegradationHooks degradation_hooks_;
+    NowProvider now_provider_;
 };
 
 }  // namespace tent

--- a/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
@@ -15,8 +15,10 @@
 #include "tent/runtime/admission_queue.h"
 
 #include <algorithm>
+#include <chrono>
 #include <limits>
 #include <set>
+#include <utility>
 
 namespace mooncake {
 namespace tent {
@@ -213,8 +215,18 @@ Status LocalTransferAdmissionQueue::tryAdmit(
     return Status::OK();
 }
 
+void LocalTransferAdmissionQueue::setDegradationPolicy(
+    BandwidthProvider bandwidth_provider, DegradationHooks hooks,
+    NowProvider now_provider) {
+    bandwidth_provider_ = std::move(bandwidth_provider);
+    degradation_hooks_ = std::move(hooks);
+    now_provider_ = std::move(now_provider);
+}
+
 std::vector<QueueOwnerId> LocalTransferAdmissionQueue::pickForDispatch(
-    size_t max_owners, size_t max_bytes) {
+    size_t max_owners, size_t max_bytes,
+    std::vector<QueueOwnerId>* dropped_owner_ids) {
+    if (dropped_owner_ids) dropped_owner_ids->clear();
     std::vector<QueueOwnerId> picked;
     if (max_owners == 0 || max_bytes == 0) return picked;
 
@@ -222,8 +234,53 @@ std::vector<QueueOwnerId> LocalTransferAdmissionQueue::pickForDispatch(
     // deadline_aware, fifo_ is kept EDF-ordered at admission time (see
     // tryAdmit's ordered insert), so there is nothing to sort here — we just
     // consume from the front. This keeps the hot dispatch path O(picked)
-    // instead of re-sorting the whole queue (up to max_outstanding_owners) on
-    // every call. Default (deadline_aware == false) is plain FIFO.
+    // instead of re-sorting the whole queue on every call. Default
+    // (deadline_aware == false) is plain FIFO.
+    //
+    // RFC #2519 step 3 (opt-in): drop is active only when a positive threshold,
+    // deadline awareness, and a bandwidth provider are all present.
+    const bool drop_enabled = limits_.deadline_aware &&
+                              limits_.mlu_local_threshold > 0.0 &&
+                              static_cast<bool>(bandwidth_provider_);
+    const double bw_bps = drop_enabled ? bandwidth_provider_() : 0.0;
+    const uint64_t now_ns =
+        drop_enabled
+            ? (now_provider_
+                   ? now_provider_()
+                   : static_cast<uint64_t>(
+                         std::chrono::duration_cast<std::chrono::nanoseconds>(
+                             std::chrono::steady_clock::now()
+                                 .time_since_epoch())
+                             .count()))
+            : 0;
+
+    // Predicted MLU = predicted_transfer_time / remaining_window. Returns true
+    // if the owner is predicted to miss its deadline hard enough to drop.
+    auto shouldDrop = [&](const QueueOwner& owner) -> bool {
+        if (!drop_enabled || bw_bps <= 0.0) return false;
+        const uint64_t deadline_ns = owner.request.deadline_ns;
+        if (deadline_ns == 0) return false;      // no deadline → never dropped
+        if (deadline_ns <= now_ns) return true;  // already past → infeasible
+        const double window_s = (deadline_ns - now_ns) / 1e9;
+        const double predicted_time_s = owner.request.length / bw_bps;
+        const double mlu = predicted_time_s / window_s;
+        return mlu >= limits_.mlu_local_threshold;
+    };
+
+    auto dropOwner = [&](QueueOwnerId owner_id, QueueOwner& owner) {
+        owner.state = QueueState::Terminal;
+        owner.terminal_status = TransferStatusEnum::CANCELED;
+        --outstanding_owners_;
+        outstanding_bytes_ -= owner.request.length;
+        if (owner.kind == QueueOwnerKind::User) {
+            --outstanding_user_owners_;
+            outstanding_user_bytes_ -= owner.request.length;
+        }
+        if (dropped_owner_ids) dropped_owner_ids->push_back(owner_id);
+        if (degradation_hooks_.on_local_decode_suggested) {
+            degradation_hooks_.on_local_decode_suggested(owner.request);
+        }
+    };
 
     size_t used_owners = 0;
     size_t used_bytes = 0;
@@ -236,6 +293,16 @@ std::vector<QueueOwnerId> LocalTransferAdmissionQueue::pickForDispatch(
         if (owner_it == owners_.end() ||
             owner_it->second.state != QueueState::Queued) {
             fifo_.pop_front();
+            continue;
+        }
+
+        // Step 3: an owner predicted to miss its deadline is dropped (not
+        // dispatched) and does not consume the dispatch budget. Because the
+        // queue is EDF-ordered, later owners have looser deadlines, so we keep
+        // scanning rather than stopping.
+        if (shouldDrop(owner_it->second)) {
+            fifo_.pop_front();
+            dropOwner(owner_id, owner_it->second);
             continue;
         }
 

--- a/mooncake-transfer-engine/tent/tests/admission_queue_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/admission_queue_test.cpp
@@ -497,6 +497,104 @@ TEST(AdmissionQueueTest, DeadlineAwareOrdersAcrossSeparateAdmits) {
     EXPECT_EQ(picked, expected);
 }
 
+// --- RFC #2519 step 3: deadline-infeasible drop + degradation hook --------
+
+// Helper: build a queue with deadline_aware + a θ_local, a fixed bandwidth,
+// and a fixed "now" clock so MLU is deterministic.
+QueueLimits step3Limits(double theta_local) {
+    QueueLimits limits{4, 1 << 20, 0, 0};
+    limits.deadline_aware = true;
+    limits.mlu_local_threshold = theta_local;
+    return limits;
+}
+
+TEST(AdmissionQueueTest, Step3DropsInfeasibleAndKeepsFeasible) {
+    LocalTransferAdmissionQueue queue(step3Limits(1.5));
+    // Fixed now = 1e9 ns; bandwidth = 1e9 B/s (so 16 B takes 16 ns).
+    int hook_calls = 0;
+    DegradationHooks hooks;
+    hooks.on_local_decode_suggested = [&](const Request&) { ++hook_calls; };
+    queue.setDegradationPolicy([] { return 1e9; }, hooks,
+                               [] { return uint64_t{1'000'000'000}; });
+
+    std::vector<QueueOwnerId> admitted_ids;
+    // owner 1: window = 10 ns → 16 B / 1e9 = 16 ns → MLU 1.6 ≥ 1.5 → DROP.
+    // owner 2: window = 1e6 ns → MLU ~1.6e-5 → feasible → dispatch.
+    auto status = queue.tryAdmit(
+        makeSubmit(1, 2,
+                   {makeOwnerWithDeadline(0, 16, 1'000'000'010),
+                    makeOwnerWithDeadline(1, 16, 2'000'000'000)}),
+        admitted_ids);
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+    ASSERT_EQ(admitted_ids.size(), 2u);
+
+    std::vector<QueueOwnerId> dropped;
+    auto picked = queue.pickForDispatch(4, 1 << 20, &dropped);
+
+    const std::vector<QueueOwnerId> exp_pick{2};
+    const std::vector<QueueOwnerId> exp_drop{1};
+    EXPECT_EQ(picked, exp_pick);
+    EXPECT_EQ(dropped, exp_drop);
+    EXPECT_EQ(hook_calls, 1);
+    // Dropped owner is charged out of the outstanding accounting.
+    EXPECT_EQ(queue.outstandingOwners(), 1u);
+    EXPECT_EQ(queue.outstandingBytes(), 16u);
+}
+
+TEST(AdmissionQueueTest, Step3DropsAlreadyExpiredDeadline) {
+    LocalTransferAdmissionQueue queue(step3Limits(1.5));
+    queue.setDegradationPolicy([] { return 1e9; }, DegradationHooks{},
+                               [] { return uint64_t{2'000'000'000}; });
+
+    std::vector<QueueOwnerId> admitted_ids;
+    // deadline 1e9 < now 2e9 → already past → dropped.
+    auto status = queue.tryAdmit(
+        makeSubmit(1, 1, {makeOwnerWithDeadline(0, 16, 1'000'000'000)}),
+        admitted_ids);
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+
+    std::vector<QueueOwnerId> dropped;
+    auto picked = queue.pickForDispatch(4, 1 << 20, &dropped);
+    EXPECT_TRUE(picked.empty());
+    ASSERT_EQ(dropped.size(), 1u);
+    EXPECT_EQ(dropped[0], 1u);
+}
+
+TEST(AdmissionQueueTest, Step3DisabledWhenThresholdZero) {
+    // θ_local = 0 (default off): even a hopeless deadline is dispatched, and
+    // the dropped vector stays empty — behavior is pure step-2 EDF.
+    LocalTransferAdmissionQueue queue(step3Limits(0.0));
+    queue.setDegradationPolicy([] { return 1e9; }, DegradationHooks{},
+                               [] { return uint64_t{1'000'000'000}; });
+
+    std::vector<QueueOwnerId> admitted_ids;
+    auto status = queue.tryAdmit(
+        makeSubmit(1, 1, {makeOwnerWithDeadline(0, 16, 1'000'000'001)}),
+        admitted_ids);
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+
+    std::vector<QueueOwnerId> dropped;
+    auto picked = queue.pickForDispatch(4, 1 << 20, &dropped);
+    ASSERT_EQ(picked.size(), 1u);
+    EXPECT_EQ(picked[0], 1u);
+    EXPECT_TRUE(dropped.empty());
+}
+
+TEST(AdmissionQueueTest, Step3NoDropWithoutBandwidthProvider) {
+    // Threshold set but no bandwidth provider → cannot predict → never drops.
+    LocalTransferAdmissionQueue queue(step3Limits(1.5));
+    std::vector<QueueOwnerId> admitted_ids;
+    auto status = queue.tryAdmit(
+        makeSubmit(1, 1, {makeOwnerWithDeadline(0, 16, 1'000'000'001)}),
+        admitted_ids);
+    ASSERT_EQ(status.code(), Status::Code::kOk);
+
+    std::vector<QueueOwnerId> dropped;
+    auto picked = queue.pickForDispatch(4, 1 << 20, &dropped);
+    ASSERT_EQ(picked.size(), 1u);
+    EXPECT_TRUE(dropped.empty());
+}
+
 }  // namespace
 }  // namespace tent
 }  // namespace mooncake


### PR DESCRIPTION
## What

RFC #2519 **step 3** (degradation layer), on top of step 2 (#2763, EDF ordering) and step 1 (#2618, `deadline_ns` + MLU observability). Owners predicted to miss their deadline are **dropped** from dispatch instead of sent, and a **local-decode signal** is raised so the caller can recompute locally rather than waste bandwidth.

> Depends on #2763 — this branch is stacked on it. Please review #2763 first; the diff here is step-3-only.

## How

- `QueueLimits.mlu_local_threshold` (θ_local, **default 0 = disabled**).
- `setDegradationPolicy(bandwidth_provider, hooks, now_provider)` — dependency-injected, so the admission queue stays decoupled from the device-selection layer and remains unit-testable. `now_provider` defaults to `steady_clock`.
- `pickForDispatch` gains an optional `dropped_owner_ids` out-param. When drop is enabled (θ_local > 0, `deadline_aware`, bandwidth provider set), an owner whose predicted MLU (`= length/bw / (deadline − now)`) reaches θ_local — or whose deadline is already past — is charged out of the outstanding accounting, marked terminal (`CANCELED`), reported in `dropped_owner_ids`, and triggers `on_local_decode_suggested`. Everything else dispatches as before.

**Interface only**: no codec / local-decode body (those live in vLLM/SGLang; TENT only raises the signal), as scoped in the RFC. Strictly additive and fully opt-in — θ_local = 0 (default) is zero behavior change from step 2.

## Tests

5 new unit tests: drop-infeasible / keep-feasible / expired-deadline drop / disabled-when-threshold-zero / no-drop-without-bandwidth-provider — including hook invocation and outstanding-accounting checks. Full `admission_queue_test` suite passes **21/21**.

## Why (measurement)

The MLU sweep in #2519 (H20 / CX-7 RoCEv2, TENT backend) shows the 100 µs deadline tier at **mean MLU 2.63** — well past a θ_local of ~1.5. Under contention those transfers are provably infeasible; step 3 drops them to local-decode instead of spending bandwidth on a transfer that will miss anyway.

## Not in scope

Caller wiring in `TransferEngineImpl` (bridging the real EWMA bandwidth into the provider, and acting on `dropped_owner_ids`) is deliberately separate — this PR is the self-contained, unit-tested policy core. Honest caveat: the drop decision is only as good as the injected bandwidth estimate, and the codec/local-decode implementations are upper-layer concerns.