### PR TITLE
[Doc] Sync transfer docs with implementation

### DIFF
--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -669,7 +669,7 @@ The store service CLI only accepts `--config`, `-D/--define`, `--port`, and `--m
 | `MOONCAKE_MASTER` | `master_server_addr` | — (required unless `MOONCAKE_CONFIG_PATH`) | Master `host:port` |
 | `MOONCAKE_TE_META_DATA_SERVER` | `metadata_server` | `P2PHANDSHAKE` | `P2PHANDSHAKE` / `http://…:8080/metadata` / etcd address |
 | `MOONCAKE_PROTOCOL` | `protocol` | `tcp` | `tcp` / `rdma` / `efa` / `cxl` / `ascend` |
-| `MOONCAKE_DEVICE` | `rdma_devices` | empty | RDMA/EFA device(s), comma-separated; `auto-discovery` supported |
+| `MOONCAKE_DEVICE` | `rdma_devices` | empty | RDMA/EFA device(s), comma-separated; leave empty for default auto-discovery |
 | `MOONCAKE_GLOBAL_SEGMENT_SIZE` | `global_segment_size` | `3355443200` (3.125 GiB) | DRAM contributed; accepts byte integer **or** suffixed form like `500gb` |
 | `MOONCAKE_LOCAL_BUFFER_SIZE` | `local_buffer_size` | `1073741824` (1 GiB) | Transfer Engine buffer; same parsing as above |
 | `MOONCAKE_LOCAL_HOSTNAME` | `local_hostname` | `localhost` | |

--- a/docs/source/design/tent/transport-selector.md
+++ b/docs/source/design/tent/transport-selector.md
@@ -27,6 +27,8 @@ Transport selection is driven by configuration with pattern-based rules.
       "segment_type": "memory",
       "priority": "high",
       "devices": ["mlx5_0", "mlx5_1", "mlx5_2"],
+      "service_level": 3,
+      "traffic_class": 96,
       "transports": ["nvlink", "rdma", "shm"]
     },
     {
@@ -54,6 +56,15 @@ Transport selection is driven by configuration with pattern-based rules.
 | `priority` | string or int | No | Match only requests with this priority: `"high"` (0), `"medium"` (1), `"low"` (2) |
 | `devices` | array[string] | No | List of allowed device names (empty = all devices) |
 | `transports` | array[string] | No | Transport preference list (evaluated in order) |
+| `service_level` | int | No | InfiniBand service level for the matched policy; values outside 0-15 are ignored |
+| `traffic_class` | int | No | Traffic class / DSCP value for the matched policy; values outside 0-255 are ignored |
+| `qp_pool` | string | No | Reserved forward-compatible QP pool name. Parsed and returned by the selector, but not applied to QP setup yet |
+
+`service_level`, `traffic_class`, and `qp_pool` are parsed and carried in the
+selection result for follow-on RDMA handling. This is the schema-plumbing step:
+current QP setup still uses existing endpoint defaults until per-policy QP
+application is wired. If either QoS value is omitted or out of range, the
+selector leaves it unset.
 
 ### Memory Type Filters
 
@@ -173,6 +184,8 @@ If no `policy` is configured, TENT falls back to original behavior:
       "local_memory": "cuda",
       "remote_memory": "cuda",
       "devices": ["mlx5_0", "mlx5_1", "mlx5_2"],
+      "service_level": 3,
+      "traffic_class": 96,
       "transports": ["rdma"]
     },
     {
@@ -237,6 +250,7 @@ Build device_mask from policy.devices
 Select transport from policy.transports[transport_index]
     ↓
 Return SelectionResult { transport, device_mask }
+    + optional service_level, traffic_class, qp_pool
     ↓
 RdmaTransport.submitTransferTasks(batch, requests)
     ↓

--- a/docs/source/design/transfer-engine/index.md
+++ b/docs/source/design/transfer-engine/index.md
@@ -121,7 +121,7 @@ After successfully compiling Transfer Engine, the test program `transfer_engine_
     ./transfer_engine_bench --mode=target \
                             --metadata_server=etcd://10.0.0.1:2379 \
                             [--local_server_name=TARGET_NAME] \
-                            [--device_name=erdma_0 | --auto-discovery]
+                            [--device_name=erdma_0 | --auto_discovery]
     ```
    The meanings of the various parameters are as follows:
    - `--mode=target` indicates the start of the target node. The target node does not initiate read/write requests; it passively supplies or writes data as required by the initiator node.
@@ -140,7 +140,7 @@ After successfully compiling Transfer Engine, the test program `transfer_engine_
     ./transfer_engine_bench --metadata_server=etcd://10.0.0.1:2379 \
                             --segment_id=TARGET_NAME \
                             [--local_server_name=INITIATOR_NAME] \
-                            [--device_name=erdma_1 | --auto-discovery]
+                            [--device_name=erdma_1 | --auto_discovery]
     ```
    The meanings of the various parameters are as follows (the rest are the same as before):
    - `--segment_id` is the segment name of target node. It needs to be consistent with the value passed to `--local_server_name` when starting the target node (if any).
@@ -485,7 +485,7 @@ For advanced users, TransferEngine provides the following advanced runtime optio
 - `MC_ENABLE_PARALLEL_REG_MR` Control parallel memory region registration across multiple RDMA NICs. Valid values: -1 (auto, default), 0 (disabled), 1 (enabled). When set to -1, parallel registration is automatically enabled when multiple RNICs exist and memory has been pre-touched. Note: If memory hasn't been touched before registration, parallel registration can be slower than sequential registration
 - `MC_FORCE_HCA` Force to use RDMA as the active transport, return error if no HCA has been found.
 - `MC_FORCE_MNNVL` Force to use Multi-Node NVLink as the active transport regardless whether RDMA devices are installed.
-- `MC_INTRA_NVLINK` Enable intra-node NVLINK transport, and cannot be used together with MC_FORCE_MNNVL.
+- `MC_INTRANODE_NVLINK` Enable intra-node NVLINK transport, and cannot be used together with MC_FORCE_MNNVL.
 - `MC_FORCE_TCP` Force to use TCP as the active transport regardless whether RDMA devices are installed.
 - `MC_MIN_RPC_PORT` Specifies the minimum port number for RPC service. The default value is 15000.
 - `MC_MAX_RPC_PORT` Specifies the maximum port number for RPC service. The default value is 17000.

--- a/docs/source/getting_started/supported-protocols.md
+++ b/docs/source/getting_started/supported-protocols.md
@@ -91,14 +91,14 @@ engine.initialize(
     hostname="node1",
     metadata_server="P2PHANDSHAKE",
     protocol="rdma",
-    device_name="auto-discovery"  # Automatically detect optimal device
+    device_name=""  # Empty string enables default RDMA auto-discovery
 )
 ```
 
 ```bash
 # Environment variables
 export MOONCAKE_PROTOCOL="rdma"
-export MOONCAKE_DEVICE="mlx5_0"  # or "auto-discovery"
+export MOONCAKE_DEVICE="mlx5_0"  # leave unset or set "" for auto-discovery
 ```
 
 **Device Discovery:**
@@ -340,7 +340,7 @@ export MOONCAKE_DEVICE="mlx5_0"
 
 # RDMA with auto-discovery
 export MOONCAKE_PROTOCOL="rdma"
-export MOONCAKE_DEVICE="auto-discovery"
+export MOONCAKE_DEVICE=""
 
 # Other configuration
 export MOONCAKE_MASTER="10.0.0.1:50051"

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -58,9 +58,7 @@ To be monitored by Prometheus, the `mooncake_master` must be started with metric
     Run the `mooncake_master` executable with the following flags to enable the metrics endpoint. For a complete list of flags, see the [Mooncake Store Deployment Guide](../docs/source/deployment/mooncake-store-deployment-guide.md).
 
     ```bash
-    # Make sure you are in the root directory of the project
-    # The path to mooncake_master might vary depending on your build output directory
-    ./build/mooncake_master \
+    mooncake_master \
       --metrics_port=9003 \
       --enable_metric_reporting=true
     ```
@@ -78,4 +76,3 @@ To be monitored by Prometheus, the `mooncake_master` must be started with metric
     This should return a list of Prometheus-style metrics.
 
 Once both Prometheus and `mooncake_master` are running, you can go to the Prometheus UI (`http://localhost:9090`), navigate to **Status -> Targets**, and you should see the `mooncake-master` job with a state of "UP". You can then explore the pre-built dashboard in Grafana.
-

--- a/mooncake-wheel/mooncake/mooncake_config.py
+++ b/mooncake-wheel/mooncake/mooncake_config.py
@@ -29,8 +29,8 @@ In addition to tcp and rdma, the C++ Transfer Engine also supports:
 - ascend: Huawei Ascend NPU communication (HCCL and direct transport)
 
 For most use cases, 'tcp' or 'rdma' is recommended. The default is 'tcp'.
-For RDMA, you also need to specify the device_name (e.g., 'mlx5_0', 'erdma_0')
-or use auto-discovery.
+For RDMA, set device_name to pin specific NICs (e.g., 'mlx5_0', 'erdma_0')
+or leave it empty for default auto-discovery.
 
 Examples:
 ---------
@@ -43,8 +43,9 @@ export MOONCAKE_DEVICE="mlx5_0"
 
 # Using RDMA with auto-discovery
 export MOONCAKE_PROTOCOL="rdma"
-export MOONCAKE_DEVICE="auto-discovery"
+export MOONCAKE_DEVICE=""
 """
+
 import json
 import os
 from dataclasses import dataclass
@@ -55,13 +56,13 @@ DEFAULT_LOCAL_BUFFER_SIZE = 1073741824  # 1.0 GiB
 
 _SIZE_SUFFIXES = [
     ("kb", 1024),
-    ("mb", 1024 ** 2),
-    ("gb", 1024 ** 3),
-    ("tb", 1024 ** 4),
+    ("mb", 1024**2),
+    ("gb", 1024**3),
+    ("tb", 1024**4),
     ("k", 1024),
-    ("m", 1024 ** 2),
-    ("g", 1024 ** 3),
-    ("t", 1024 ** 4),
+    ("m", 1024**2),
+    ("g", 1024**3),
+    ("t", 1024**4),
     ("b", 1),
 ]
 
@@ -124,8 +125,10 @@ class MooncakeConfig:
             - "rdma": RDMA protocol (requires RDMA-capable NICs and device_name)
             See module docstring for full list of supported protocols.
         device_name (Optional[str]): The name of the RDMA device to use
-            (e.g., "mlx5_0", "erdma_0", or "auto-discovery").
-            Required when protocol is "rdma", optional for other protocols.
+            (e.g., "mlx5_0" or "erdma_0"); use an empty string for
+            auto-discovery.
+            For "rdma", provide a value to pin specific NICs, or keep the
+            empty default for auto-discovery. Optional for other protocols.
         master_server_address (str): The address of the master server.
         enable_ssd_offload (bool): Enable SSD offload. Default is False.
         ssd_offload_path (str): The path to the SSD directory for offloading.
@@ -144,7 +147,7 @@ class MooncakeConfig:
             "ssd_offload_path": "/nvme/mooncake_offload",
             "tenant_id": "default"
         }
-        
+
         For RDMA:
         {
             "local_hostname": "node1",
@@ -159,6 +162,7 @@ class MooncakeConfig:
             "tenant_id": "default"
         }
     """
+
     local_hostname: str
     metadata_server: str
     global_segment_size: int
@@ -171,7 +175,7 @@ class MooncakeConfig:
     tenant_id: str = "default"
 
     @staticmethod
-    def from_file(file_path: str) -> 'MooncakeConfig':
+    def from_file(file_path: str) -> "MooncakeConfig":
         """Load the config from a JSON file."""
         with open(file_path) as fin:
             config = json.load(fin)
@@ -198,27 +202,35 @@ class MooncakeConfig:
             device_name=config.get("device_name", ""),
             master_server_address=config.get("master_server_address"),
             enable_ssd_offload=_parse_bool(config.get("enable_ssd_offload", False)),
-            ssd_offload_path=str(ssd_offload_path) if ssd_offload_path is not None else "",
+            ssd_offload_path=str(ssd_offload_path)
+            if ssd_offload_path is not None
+            else "",
             tenant_id=str(tenant_id) if tenant_id is not None else "default",
         )
 
     @staticmethod
-    def load_from_env() -> 'MooncakeConfig':
+    def load_from_env() -> "MooncakeConfig":
         """Load config from a file specified in the environment variable.
         export MOONCAKE_MASTER=10.13.3.232:50051
         export MOONCAKE_PROTOCOL="rdma"
         export MOONCAKE_DEVICE=""
         export MOONCAKE_TE_META_DATA_SERVER="P2PHANDSHAKE"
         """
-        config_file_path = os.getenv('MOONCAKE_CONFIG_PATH')
+        config_file_path = os.getenv("MOONCAKE_CONFIG_PATH")
         if config_file_path is None:
             if not os.getenv("MOONCAKE_MASTER"):
-                raise ValueError("Neither the environment variable 'MOONCAKE_CONFIG_PATH' nor 'MOONCAKE_MASTER' is set.")
+                raise ValueError(
+                    "Neither the environment variable 'MOONCAKE_CONFIG_PATH' nor 'MOONCAKE_MASTER' is set."
+                )
             return MooncakeConfig(
                 local_hostname=os.getenv("MOONCAKE_LOCAL_HOSTNAME", "localhost"),
-                metadata_server=os.getenv("MOONCAKE_TE_META_DATA_SERVER", "P2PHANDSHAKE"),
+                metadata_server=os.getenv(
+                    "MOONCAKE_TE_META_DATA_SERVER", "P2PHANDSHAKE"
+                ),
                 global_segment_size=_parse_segment_size(
-                    os.getenv("MOONCAKE_GLOBAL_SEGMENT_SIZE", DEFAULT_GLOBAL_SEGMENT_SIZE)
+                    os.getenv(
+                        "MOONCAKE_GLOBAL_SEGMENT_SIZE", DEFAULT_GLOBAL_SEGMENT_SIZE
+                    )
                 ),
                 local_buffer_size=_parse_segment_size(
                     os.getenv("MOONCAKE_LOCAL_BUFFER_SIZE", DEFAULT_LOCAL_BUFFER_SIZE)
@@ -226,7 +238,9 @@ class MooncakeConfig:
                 protocol=os.getenv("MOONCAKE_PROTOCOL", "tcp"),
                 device_name=os.getenv("MOONCAKE_DEVICE", ""),
                 master_server_address=os.getenv("MOONCAKE_MASTER"),
-                enable_ssd_offload=_parse_bool(os.getenv("MOONCAKE_OFFLOAD_ENABLED", "false")),
+                enable_ssd_offload=_parse_bool(
+                    os.getenv("MOONCAKE_OFFLOAD_ENABLED", "false")
+                ),
                 ssd_offload_path=os.getenv("MOONCAKE_OFFLOAD_FILE_STORAGE_PATH", ""),
                 tenant_id=os.getenv("MOONCAKE_TENANT_ID", "default"),
             )


### PR DESCRIPTION
## Description

This PR is the weekly docs/code drift sync. It updates active user-facing documentation and Python-facing docstrings where current implementation behavior did not match the documented commands, configuration values, or policy schema.

No high-severity drift was found in this pass.

### Medium: RDMA auto-discovery was documented as a device-name sentinel

**Location:** `docs/source/getting_started/supported-protocols.md`, `docs/source/deployment/mooncake-store-deployment-guide.md`, `mooncake-wheel/mooncake/mooncake_config.py`

**Evidence:** `MooncakeConfig.from_file()` reads `device_name` literally from JSON and defaults it to `""`; `MooncakeConfig.load_from_env()` reads `MOONCAKE_DEVICE` literally and defaults it to `""`. The Store service passes that value through to setup. The docs still showed `"auto-discovery"` as a valid `device_name` / `MOONCAKE_DEVICE` value, which would be treated as a real device filter rather than the empty auto-discovery default.

**Suggested fix:** Replace the sentinel examples with `device_name=""`, `MOONCAKE_DEVICE=""`, or unset-variable guidance.

### Medium: Transfer Engine guide had stale flag and env-var names

**Location:** `docs/source/design/transfer-engine/index.md`

**Evidence:** `transfer_engine_bench.cpp` defines `DEFINE_bool(auto_discovery, ...)`, so the valid flag is `--auto_discovery`. `TransferEngineImpl` reads `MC_INTRANODE_NVLINK` for the intra-node NVLink override, while the active guide still referenced `MC_INTRA_NVLINK`.

**Suggested fix:** Update command examples to `--auto_discovery` and the runtime option to `MC_INTRANODE_NVLINK`.

### Medium: Monitoring README used a broken master executable path

**Location:** `monitoring/README.md`

**Evidence:** `mooncake-store/src/CMakeLists.txt` builds and installs `mooncake_master` to `bin`; the deployment guide uses `mooncake_master` directly. The monitoring README still used `./build/mooncake_master`, which does not match the current build tree layout.

**Suggested fix:** Use the installed `mooncake_master` executable in the monitoring startup example.

### Low: TENT selector docs omitted implemented per-policy QoS schema fields

**Location:** `docs/source/design/tent/transport-selector.md`

**Evidence:** `TransportSelector::loadPolicies()` parses `service_level`, `traffic_class`, and `qp_pool`; `TransportSelector::select()` carries those fields in `SelectionResult`; `transport_selector_test.cpp` covers valid, invalid, and empty values. The selector guide still documented only `name`, `segment_type`, `priority`, `devices`, and `transports`.

**Suggested fix:** Document the three fields, their ranges, and the current schema-plumbing status before per-policy QP setup applies them.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
git diff --check
env PYTHONPYCACHEPREFIX=/tmp/mooncake-pycache python3 -m py_compile mooncake-wheel/mooncake/mooncake_config.py
rg -n --glob '!docs/source/zh_archive/**' -- 'device_name="auto-discovery"|MOONCAKE_DEVICE="auto-discovery"|--auto-discovery|MC_INTRA_NVLINK|\./build/mooncake_master' README.md docs/source mooncake-wheel monitoring/README.md
cd docs && uv venv
cd docs && uv pip install -r requirements-docs.txt
cd docs && make clean SPHINXBUILD=.venv/bin/sphinx-build
cd docs && make html SPHINXBUILD=.venv/bin/sphinx-build
pre-commit run --files docs/source/deployment/mooncake-store-deployment-guide.md docs/source/design/tent/transport-selector.md docs/source/design/transfer-engine/index.md docs/source/getting_started/supported-protocols.md monitoring/README.md mooncake-wheel/mooncake/mooncake_config.py
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

Manual validation: active stale-string scan returned no matches outside `docs/source/zh_archive`; Sphinx HTML build succeeded with one unrelated intersphinx warning for the `psutil` inventory; touched-file pre-commit passed. The first docs dependency install attempt hit a transient GitHub SSL fetch error for `sphinx-autodoc2`; retry succeeded.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

`pre-commit run --files ...` was run on the files touched by this PR. `pre-commit run --all-files` was not run to avoid rewriting unrelated files.

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Fully AI-generated by Codex. No human was involved in authoring, reviewing, or validating the changed lines before opening this PR.