### PR TITLE
[CI/Build] Isolate wheel test service ports

### DIFF
--- a/mooncake-wheel/tests/test_cli.py
+++ b/mooncake-wheel/tests/test_cli.py
@@ -14,9 +14,7 @@ def test_entry_point_installed():
     try:
         # Check if mooncake_master is in PATH
         result = subprocess.run(
-            ["which", "mooncake_master"],
-            capture_output=True,
-            text=True
+            ["which", "mooncake_master"], capture_output=True, text=True
         )
 
         if result.returncode != 0:
@@ -25,9 +23,7 @@ def test_entry_point_installed():
 
         print(f"✅ mooncake_master entry point found at: {result.stdout.strip()}")
         result = subprocess.run(
-            ["which", "mooncake_client"],
-            capture_output=True,
-            text=True
+            ["which", "mooncake_client"], capture_output=True, text=True
         )
 
         if result.returncode != 0:
@@ -36,9 +32,7 @@ def test_entry_point_installed():
 
         print(f"✅ mooncake_client entry point found at: {result.stdout.strip()}")
         result = subprocess.run(
-            ["which", "transfer_engine_bench"],
-            capture_output=True,
-            text=True
+            ["which", "transfer_engine_bench"], capture_output=True, text=True
         )
 
         if result.returncode != 0:
@@ -54,12 +48,24 @@ def test_entry_point_installed():
 
 def test_run_master_and_client():
     """Test running the master service through the entry point."""
+    master_port = int(os.getenv("MOONCAKE_CLI_MASTER_PORT", "61351"))
+    client_port = int(os.getenv("MOONCAKE_CLI_CLIENT_PORT", "61352"))
+    http_metadata_port = int(os.getenv("MOONCAKE_CLI_HTTP_METADATA_PORT", "61353"))
+    metrics_port = int(os.getenv("MOONCAKE_CLI_METRICS_PORT", "61354"))
+
     try:
-        # Run mooncake_master with a non-default port to avoid conflicts
+        # Run mooncake_master with non-default ports to avoid conflicts
         process = subprocess.Popen(
-            ["mooncake_master", "--port=61351", "--max_threads=2", "--enable_http_metadata_server=true"],
+            [
+                "mooncake_master",
+                f"--port={master_port}",
+                f"--metrics_port={metrics_port}",
+                "--max_threads=2",
+                "--enable_http_metadata_server=true",
+                f"--http_metadata_server_port={http_metadata_port}",
+            ],
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE
+            stderr=subprocess.PIPE,
         )
 
         # Give it a moment to start
@@ -69,9 +75,14 @@ def test_run_master_and_client():
         if process.poll() is None:
             print("✅ mooncake_master process started successfully")
             client_process = subprocess.Popen(
-                ["mooncake_client", "--master_server_address=127.0.0.1:61351", "--port=61352"],
+                [
+                    "mooncake_client",
+                    f"--master_server_address=127.0.0.1:{master_port}",
+                    f"--metadata_server=http://127.0.0.1:{http_metadata_port}/metadata",
+                    f"--port={client_port}",
+                ],
                 stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE
+                stderr=subprocess.PIPE,
             )
 
             # Give the client some time to connect
@@ -84,7 +95,7 @@ def test_run_master_and_client():
                 print("✅ mooncake_client process terminated successfully")
             else:
                 stdout, stderr = client_process.communicate()
-                print(f"❌ mooncake_client failed to start")
+                print("❌ mooncake_client failed to start")
                 print(f"stdout: {stdout.decode()}")
                 print(f"stderr: {stderr.decode()}")
             # Terminate the process
@@ -94,7 +105,7 @@ def test_run_master_and_client():
             return True
         else:
             stdout, stderr = process.communicate()
-            print(f"❌ mooncake_master process failed to start")
+            print("❌ mooncake_master process failed to start")
             print(f"stdout: {stdout.decode()}")
             print(f"stderr: {stderr.decode()}")
             return False

--- a/mooncake-wheel/tests/test_dummy_client.py
+++ b/mooncake-wheel/tests/test_dummy_client.py
@@ -1,34 +1,34 @@
 import unittest
 import os
 import time
-import threading
 import random
 from mooncake.store import MooncakeDistributedStore
 
 # The lease time of the kv object, should be set equal to
 # the master's value.
-DEFAULT_DEFAULT_KV_LEASE_TTL = 5000 # 5000 milliseconds
+DEFAULT_DEFAULT_KV_LEASE_TTL = 5000  # 5000 milliseconds
 # Use environment variable if set, otherwise use default
-default_kv_lease_ttl = int(os.getenv("DEFAULT_KV_LEASE_TTL", DEFAULT_DEFAULT_KV_LEASE_TTL))
+default_kv_lease_ttl = int(
+    os.getenv("DEFAULT_KV_LEASE_TTL", DEFAULT_DEFAULT_KV_LEASE_TTL)
+)
+real_client_port = int(os.getenv("MOONCAKE_CLIENT_PORT", "50052"))
 
 
 def get_client(store, local_buffer_size_param=None):
     """Initialize and setup the distributed store client."""
     mem_pool_size = 3200 * 1024 * 1024  # 3200 MB
     local_buffer_size = (
-        local_buffer_size_param if local_buffer_size_param is not None
+        local_buffer_size_param
+        if local_buffer_size_param is not None
         else 512 * 1024 * 1024  # 512 MB
     )
-    real_client_address = "127.0.0.1:50052"
+    real_client_address = f"127.0.0.1:{real_client_port}"
 
-    retcode = store.setup_dummy(
-        mem_pool_size,
-        local_buffer_size,
-        real_client_address
-    )
+    retcode = store.setup_dummy(mem_pool_size, local_buffer_size, real_client_address)
 
     if retcode:
         raise RuntimeError(f"Failed to setup store client. Return code: {retcode}")
+
 
 class TestDistributedObjectStoreSingleStore(unittest.TestCase):
     """Test class for single store operations (no replication)."""
@@ -68,7 +68,7 @@ class TestDistributedObjectStoreSingleStore(unittest.TestCase):
         keys = [f"test_batch_exist_key_{i}" for i in range(batch_size)]
 
         # Put only the first half of the keys
-        existing_keys = keys[:batch_size // 2]
+        existing_keys = keys[: batch_size // 2]
         for key in existing_keys:
             self.assertEqual(self.store.put(key, test_data), 0)
 
@@ -80,11 +80,15 @@ class TestDistributedObjectStoreSingleStore(unittest.TestCase):
 
         # First half should exist (result = 1)
         for i in range(batch_size // 2):
-            self.assertEqual(results[i], 1, f"Key {keys[i]} should exist but got {results[i]}")
+            self.assertEqual(
+                results[i], 1, f"Key {keys[i]} should exist but got {results[i]}"
+            )
 
         # Second half should not exist (result = 0)
         for i in range(batch_size // 2, batch_size):
-            self.assertEqual(results[i], 0, f"Key {keys[i]} should not exist but got {results[i]}")
+            self.assertEqual(
+                results[i], 0, f"Key {keys[i]} should not exist but got {results[i]}"
+            )
 
         # Test with empty keys list
         empty_results = self.store.batch_is_exist([])
@@ -162,7 +166,11 @@ class TestDistributedObjectStoreSingleStore(unittest.TestCase):
         self.assertLess(destination_overflow_results[0][0][0], 0)
 
         missing_key_results = self.store.get_into_ranges(
-            [buffer_ptr0], [["missing-key", key1]], [[[0], [8]]], [[[0], [0]]], [[[4], [4]]]
+            [buffer_ptr0],
+            [["missing-key", key1]],
+            [[[0], [8]]],
+            [[[0], [0]]],
+            [[[4], [4]]],
         )
         self.assertLess(missing_key_results[0][0][0], 0)
         self.assertEqual(missing_key_results[0][1][0], 4)
@@ -197,7 +205,9 @@ class TestDistributedObjectStoreSingleStore(unittest.TestCase):
         # Allocate one large buffer with significant spacing
         total_buffer_size = buffer_spacing * batch_size
         large_buffer_ptr = self.store.alloc_from_mem_pool(total_buffer_size)
-        large_buffer = (ctypes.c_char * total_buffer_size).from_address(large_buffer_ptr)
+        large_buffer = (ctypes.c_char * total_buffer_size).from_address(
+            large_buffer_ptr
+        )
 
         # Register the entire large buffer once
         result = self.store.register_buffer(large_buffer_ptr, total_buffer_size)
@@ -224,28 +234,46 @@ class TestDistributedObjectStoreSingleStore(unittest.TestCase):
         self.assertEqual(len(results), batch_size, "Should return result for each key")
 
         for i, (expected_data, result) in enumerate(zip(test_data, results)):
-            self.assertGreater(result, 0, f"batch_get_into should succeed for key {keys[i]}")
-            self.assertEqual(result, len(expected_data), f"Should read correct number of bytes for key {keys[i]}")
+            self.assertGreater(
+                result, 0, f"batch_get_into should succeed for key {keys[i]}"
+            )
+            self.assertEqual(
+                result,
+                len(expected_data),
+                f"Should read correct number of bytes for key {keys[i]}",
+            )
 
             # Verify data integrity - read from the correct offset in the large buffer
             offset = i * buffer_spacing
-            read_data = bytes(large_buffer[offset:offset + result])
-            self.assertEqual(read_data, expected_data, f"Data should match for key {keys[i]}")
+            read_data = bytes(large_buffer[offset : offset + result])
+            self.assertEqual(
+                read_data, expected_data, f"Data should match for key {keys[i]}"
+            )
 
         # Test error cases
         # Test with mismatched array sizes
-        mismatched_results = self.store.batch_get_into(keys[:2], buffer_ptrs[:3], buffer_sizes[:3])
-        self.assertEqual(len(mismatched_results), 2, "Should return results for provided keys")
+        mismatched_results = self.store.batch_get_into(
+            keys[:2], buffer_ptrs[:3], buffer_sizes[:3]
+        )
+        self.assertEqual(
+            len(mismatched_results), 2, "Should return results for provided keys"
+        )
         for result in mismatched_results:
             self.assertLess(result, 0, "Should fail with mismatched array sizes")
 
         # Test with empty arrays
         empty_results = self.store.batch_get_into([], [], [])
-        self.assertEqual(len(empty_results), 0, "Should return empty results for empty input")
+        self.assertEqual(
+            len(empty_results), 0, "Should return empty results for empty input"
+        )
 
         # Cleanup
         time.sleep(default_kv_lease_ttl / 1000)
-        self.assertEqual(self.store.unregister_buffer(large_buffer_ptr), 0, "Buffer unregistration should succeed")
+        self.assertEqual(
+            self.store.unregister_buffer(large_buffer_ptr),
+            0,
+            "Buffer unregistration should succeed",
+        )
         for key in keys:
             self.assertEqual(self.store.remove(key), 0)
 
@@ -268,7 +296,9 @@ class TestDistributedObjectStoreSingleStore(unittest.TestCase):
         # Allocate one large buffer with significant spacing
         total_buffer_size = buffer_spacing * batch_size
         large_buffer_ptr = self.store.alloc_from_mem_pool(total_buffer_size)
-        large_buffer = (ctypes.c_char * total_buffer_size).from_address(large_buffer_ptr)
+        large_buffer = (ctypes.c_char * total_buffer_size).from_address(
+            large_buffer_ptr
+        )
 
         # Register the entire large buffer once
         result = self.store.register_buffer(large_buffer_ptr, total_buffer_size)
@@ -298,93 +328,110 @@ class TestDistributedObjectStoreSingleStore(unittest.TestCase):
         self.assertEqual(len(results), batch_size, "Should return result for each key")
 
         for i, result in enumerate(results):
-            self.assertEqual(result, 0, f"batch_put_from should succeed for key {keys[i]}")
+            self.assertEqual(
+                result, 0, f"batch_put_from should succeed for key {keys[i]}"
+            )
 
         # Verify data was stored correctly using regular get
         for i, (key, expected_data) in enumerate(zip(keys, test_data)):
             retrieved_data = self.store.get(key)
-            self.assertEqual(retrieved_data, expected_data, f"Data should match after batch_put_from for key {key}")
+            self.assertEqual(
+                retrieved_data,
+                expected_data,
+                f"Data should match after batch_put_from for key {key}",
+            )
 
         # Test error cases
         # Test with mismatched array sizes
-        mismatched_results = self.store.batch_put_from(keys[:2], buffer_ptrs[:3], buffer_sizes[:3])
-        self.assertEqual(len(mismatched_results), 2, "Should return results for provided keys")
+        mismatched_results = self.store.batch_put_from(
+            keys[:2], buffer_ptrs[:3], buffer_sizes[:3]
+        )
+        self.assertEqual(
+            len(mismatched_results), 2, "Should return results for provided keys"
+        )
         for result in mismatched_results:
             self.assertLess(result, 0, "Should fail with mismatched array sizes")
 
         # Test with empty arrays
         empty_results = self.store.batch_put_from([], [], [])
-        self.assertEqual(len(empty_results), 0, "Should return empty results for empty input")
+        self.assertEqual(
+            len(empty_results), 0, "Should return empty results for empty input"
+        )
 
         # Cleanup
         time.sleep(default_kv_lease_ttl / 1000)
-        self.assertEqual(self.store.unregister_buffer(large_buffer_ptr), 0, "Buffer unregistration should succeed")
+        self.assertEqual(
+            self.store.unregister_buffer(large_buffer_ptr),
+            0,
+            "Buffer unregistration should succeed",
+        )
         for key in keys:
             self.assertEqual(self.store.remove(key), 0)
 
     # Mark this test as zzz_ so that it is the last test to run
     def zzz_test_dict_fuzz_e2e(self):
-         """End-to-end fuzz test comparing distributed store behavior with dict.
-         Performs ~1000 random operations (put, get, remove) with random value sizes between 1KB and 64MB.
-         After testing, all keys are removed.
-         """
-         import random
-         # Local reference dict to simulate expected dict behavior
-         reference = {}
-         operations = 1000
-         # Use a pool of keys to limit memory consumption
-         keys_pool = [f"key_{i}" for i in range(100)]
-         # Track which keys have values assigned to ensure consistency
-         key_values = {}
-         # Fuzz record for debugging in case of errors
-         fuzz_record = []
-         try:
-             for i in range(operations):
-                 op = random.choice(["put", "get", "remove"])
-                 key = random.choice(keys_pool)
-                 if op == "put":
-                     # If key already exists, use the same value to ensure consistency
-                     if key in key_values:
-                         value = key_values[key]
-                         size = len(value)
-                     else:
-                         size = random.randint(1, 64 * 1024 * 1024)
-                         value = os.urandom(size)
-                         key_values[key] = value
+        """End-to-end fuzz test comparing distributed store behavior with dict.
+        Performs ~1000 random operations (put, get, remove) with random value sizes between 1KB and 64MB.
+        After testing, all keys are removed.
+        """
+        # Local reference dict to simulate expected dict behavior
+        reference = {}
+        operations = 1000
+        # Use a pool of keys to limit memory consumption
+        keys_pool = [f"key_{i}" for i in range(100)]
+        # Track which keys have values assigned to ensure consistency
+        key_values = {}
+        # Fuzz record for debugging in case of errors
+        fuzz_record = []
+        try:
+            for i in range(operations):
+                op = random.choice(["put", "get", "remove"])
+                key = random.choice(keys_pool)
+                if op == "put":
+                    # If key already exists, use the same value to ensure consistency
+                    if key in key_values:
+                        value = key_values[key]
+                        size = len(value)
+                    else:
+                        size = random.randint(1, 64 * 1024 * 1024)
+                        value = os.urandom(size)
+                        key_values[key] = value
 
-                     fuzz_record.append(f"{i}: put {key} [size: {size}]")
-                     error_code = self.store.put(key, value)
-                     if error_code == -200:
-                         # The space is not enough, continue to next operation
-                         continue
-                     elif error_code == 0:
-                         reference[key] = value
-                     else:
-                         raise RuntimeError(f"Put operation failed for key {key}. Error code: {error_code}")
-                 elif op == "get":
-                     fuzz_record.append(f"{i}: get {key}")
-                     retrieved = self.store.get(key)
-                     if retrieved != b"": # Otherwise the key may have been evicted
+                    fuzz_record.append(f"{i}: put {key} [size: {size}]")
+                    error_code = self.store.put(key, value)
+                    if error_code == -200:
+                        # The space is not enough, continue to next operation
+                        continue
+                    elif error_code == 0:
+                        reference[key] = value
+                    else:
+                        raise RuntimeError(
+                            f"Put operation failed for key {key}. Error code: {error_code}"
+                        )
+                elif op == "get":
+                    fuzz_record.append(f"{i}: get {key}")
+                    retrieved = self.store.get(key)
+                    if retrieved != b"":  # Otherwise the key may have been evicted
                         expected = reference.get(key, b"")
                         self.assertEqual(retrieved, expected)
-                 elif op == "remove":
-                     fuzz_record.append(f"{i}: remove {key}")
-                     error_code = self.store.remove(key)
-                     # if remove did not fail due to the key has a lease
-                     if error_code != -706:
+                elif op == "remove":
+                    fuzz_record.append(f"{i}: remove {key}")
+                    error_code = self.store.remove(key)
+                    # if remove did not fail due to the key has a lease
+                    if error_code != -706:
                         reference.pop(key, None)
                         # Also remove from key_values to allow new value if key is reused
                         key_values.pop(key, None)
-         except Exception as e:
-             print(f"Error: {e}")
-             print('\nFuzz record (operations so far):')
-             for record in fuzz_record:
-                 print(record)
-             raise e
-         # Cleanup: ensure all remaining keys are removed
-         time.sleep(default_kv_lease_ttl / 1000)
-         for key in list(reference.keys()):
-             self.store.remove(key)
+        except Exception as e:
+            print(f"Error: {e}")
+            print("\nFuzz record (operations so far):")
+            for record in fuzz_record:
+                print(record)
+            raise e
+        # Cleanup: ensure all remaining keys are removed
+        time.sleep(default_kv_lease_ttl / 1000)
+        for key in list(reference.keys()):
+            self.store.remove(key)
 
     def test_replicate_config_creation_and_properties(self):
         """Test ReplicateConfig class creation and property access."""
@@ -410,6 +457,7 @@ class TestDistributedObjectStoreSingleStore(unittest.TestCase):
         self.assertIsInstance(config_str, str)
         self.assertIn("3", config_str)  # Should contain replica_num
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     # Show which test is running; stop on first failure
     unittest.main(verbosity=2, failfast=True)

--- a/mooncake-wheel/tests/test_multi_dummy_clients.py
+++ b/mooncake-wheel/tests/test_multi_dummy_clients.py
@@ -7,13 +7,18 @@ from mooncake.store import MooncakeDistributedStore
 
 # The lease time of the kv object, should be set equal to
 # the master's value.
-DEFAULT_DEFAULT_KV_LEASE_TTL = 5000 # 5000 milliseconds
+DEFAULT_DEFAULT_KV_LEASE_TTL = 5000  # 5000 milliseconds
 # Use environment variable if set, otherwise use default
-default_kv_lease_ttl = int(os.getenv("DEFAULT_KV_LEASE_TTL", DEFAULT_DEFAULT_KV_LEASE_TTL))
+default_kv_lease_ttl = int(
+    os.getenv("DEFAULT_KV_LEASE_TTL", DEFAULT_DEFAULT_KV_LEASE_TTL)
+)
+real_client_port = int(os.getenv("MOONCAKE_CLIENT_PORT", "50052"))
 
 # Parse command line arguments for client ID
 parser = argparse.ArgumentParser()
-parser.add_argument('--client-id', type=str, default='default', help='Client ID for this instance')
+parser.add_argument(
+    "--client-id", type=str, default="default", help="Client ID for this instance"
+)
 args, unknown = parser.parse_known_args()
 CLIENT_ID = args.client_id
 
@@ -22,19 +27,17 @@ def get_client(store, local_buffer_size_param=None):
     """Initialize and setup the distributed store client."""
     mem_pool_size = 3200 * 1024 * 1024  # 3200 MB
     local_buffer_size = (
-        local_buffer_size_param if local_buffer_size_param is not None
+        local_buffer_size_param
+        if local_buffer_size_param is not None
         else 512 * 1024 * 1024  # 512 MB
     )
-    real_client_address = "127.0.0.1:50052"
+    real_client_address = f"127.0.0.1:{real_client_port}"
 
-    retcode = store.setup_dummy(
-        mem_pool_size,
-        local_buffer_size,
-        real_client_address
-    )
+    retcode = store.setup_dummy(mem_pool_size, local_buffer_size, real_client_address)
 
     if retcode:
         raise RuntimeError(f"Failed to setup store client. Return code: {retcode}")
+
 
 class TestMultiDummyClients(unittest.TestCase):
     """Test class for multi dummy clients operations."""
@@ -49,11 +52,11 @@ class TestMultiDummyClients(unittest.TestCase):
     def test_client_interaction(self):
         """Test basic Put/Get/Exist operations between multi dummy clients."""
         test_data = b"Hello, World!"
-        key1 = f"test_multi_dummy_client_interaction_client1"
-        key2 = f"test_multi_dummy_client_interaction_client2"
+        key1 = "test_multi_dummy_client_interaction_client1"
+        key2 = "test_multi_dummy_client_interaction_client2"
 
         # Test Put/Get/Remove interaction
-        if self.client_id == 'client1':
+        if self.client_id == "client1":
             self.assertEqual(self.store.put(key1, test_data), 0)
             start_time = time.time()
             timeout = 10  # 10 seconds timeout
@@ -91,7 +94,8 @@ class TestMultiDummyClients(unittest.TestCase):
                 if time.time() - start_time > timeout:
                     raise RuntimeError("timeout waiting for key1 to appear")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     # Show which test is running; stop on first failure
-    sys.argv = ['test_multi_dummy_clients.py'] + unknown
+    sys.argv = ["test_multi_dummy_clients.py"] + unknown
     unittest.main(verbosity=2, failfast=True)

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -7,11 +7,122 @@ set -e  # Exit immediately if a command exits with a non-zero status
 # Ensure LD_LIBRARY_PATH includes /usr/local/lib
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
 
+
+DEFAULT_TEST_PORT_BASE=${MOONCAKE_DEFAULT_TEST_PORT_BASE:-61000}
+TEST_PORTS_PER_RUN=${MOONCAKE_TEST_PORTS_PER_RUN:-100}
+
+allocate_port_block() {
+    if [ -n "${MOONCAKE_TEST_PORT_BASE:-}" ]; then
+        TEST_PORT_BASE=$MOONCAKE_TEST_PORT_BASE
+        return
+    fi
+
+    local state_file=${MOONCAKE_TEST_PORT_STATE_FILE:-/tmp/mooncake_run_tests_next_port}
+    local lock_file=${MOONCAKE_TEST_PORT_LOCK_FILE:-/tmp/mooncake_run_tests_port.lock}
+    local next_base
+
+    exec 9>"$lock_file"
+    flock 9
+
+    if [ -f "$state_file" ]; then
+        next_base=$(cat "$state_file")
+    else
+        next_base=$DEFAULT_TEST_PORT_BASE
+    fi
+
+    if ! [[ "$next_base" =~ ^[0-9]+$ ]] || [ "$next_base" -lt "$DEFAULT_TEST_PORT_BASE" ] || [ $((next_base + TEST_PORTS_PER_RUN)) -gt 65535 ]; then
+        next_base=$DEFAULT_TEST_PORT_BASE
+    fi
+
+    TEST_PORT_BASE=$next_base
+    echo $((TEST_PORT_BASE + TEST_PORTS_PER_RUN)) > "$state_file"
+
+    flock -u 9
+}
+
+allocate_test_ports() {
+    allocate_port_block
+    NEXT_TEST_PORT=$TEST_PORT_BASE
+
+    allocate_named_port METADATA_PORT
+    allocate_named_port MAIN_MASTER_PORT
+    allocate_named_port MAIN_MASTER_METRICS_PORT
+    allocate_named_port DUMMY_CLIENT_PORT
+    allocate_named_port MULTI_DUMMY_CLIENT_PORT
+    allocate_named_port SSD_MASTER_PORT
+    allocate_named_port SSD_MASTER_METRICS_PORT
+    allocate_named_port PROMOTION_MASTER_PORT
+    allocate_named_port PROMOTION_MASTER_METRICS_PORT
+    allocate_named_port CXL_MASTER_PORT
+    allocate_named_port CXL_MASTER_METRICS_PORT
+    allocate_named_port CLI_MASTER_PORT
+    allocate_named_port CLI_CLIENT_PORT
+    allocate_named_port CLI_HTTP_METADATA_PORT
+    allocate_named_port CLI_METRICS_PORT
+    allocate_named_port EMBEDDED_HTTP_METADATA_PORT
+    allocate_named_port EMBEDDED_MASTER_PORT
+    allocate_named_port EMBEDDED_MASTER_METRICS_PORT
+}
+
+allocate_port() {
+    ALLOCATED_PORT=$NEXT_TEST_PORT
+    NEXT_TEST_PORT=$((NEXT_TEST_PORT + 1))
+}
+
+allocate_named_port() {
+    allocate_port
+    printf -v "$1" '%s' "$ALLOCATED_PORT"
+}
+
+start_metadata() {
+    METADATA_SERVER_URL="http://127.0.0.1:${METADATA_PORT}/metadata"
+    mooncake_http_metadata_server --port ${METADATA_PORT} &
+    METADATA_PID=$!
+    sleep 1
+}
+
+stop_metadata() {
+    kill $METADATA_PID || true
+    wait $METADATA_PID 2>/dev/null || true
+}
+
+start_master() {
+    MASTER_PORT=$1
+    MASTER_METRICS_PORT=$2
+    shift 2
+    mooncake_master --port=${MASTER_PORT} --metrics_port=${MASTER_METRICS_PORT} "$@" &
+    MASTER_PID=$!
+    MASTER_SERVER_ADDR="127.0.0.1:${MASTER_PORT}"
+    sleep 1
+}
+
+stop_master() {
+    kill $MASTER_PID || true
+    wait $MASTER_PID 2>/dev/null || true
+}
+
+start_client() {
+    CLIENT_PORT=$1
+    shift
+    mooncake_client --master_server_address=${MASTER_SERVER_ADDR} --metadata_server=${METADATA_SERVER_URL} --port=${CLIENT_PORT} "$@" &
+    CLIENT_PID=$!
+    sleep 1
+}
+
+stop_client() {
+    kill $CLIENT_PID || true
+    wait $CLIENT_PID 2>/dev/null || true
+}
+
+allocate_test_ports
+echo "Using Mooncake test port block ${TEST_PORT_BASE}-$((TEST_PORT_BASE + TEST_PORTS_PER_RUN - 1))"
+
 echo "Running transfer_engine tests..."
 cd mooncake-wheel/tests
-MC_METADATA_SERVER=http://127.0.0.1:8080/metadata MC_FORCE_TCP=true python transfer_engine_target.py &
+start_metadata
+MC_METADATA_SERVER=${METADATA_SERVER_URL} MC_FORCE_TCP=true python transfer_engine_target.py &
 TARGET_PID=$!
-MC_METADATA_SERVER=http://127.0.0.1:8080/metadata MC_FORCE_TCP=true python transfer_engine_initiator_test.py
+MC_METADATA_SERVER=${METADATA_SERVER_URL} MC_FORCE_TCP=true python transfer_engine_initiator_test.py
 kill $TARGET_PID || true
 
 echo "Running master tests..."
@@ -23,32 +134,30 @@ which mooncake_master 2>/dev/null | grep -q '/usr/local/bin/mooncake_master' && 
 echo "mooncake_master found, running tests..."
 # Set a small kv lease ttl to make the test faster.
 # Must be consistent with the client test parameters.
-mooncake_master --default_kv_lease_ttl=500 &
-MASTER_PID=$!
-sleep 1
-MC_METADATA_SERVER=http://127.0.0.1:8080/metadata DEFAULT_KV_LEASE_TTL=500 python test_distributed_object_store.py
-MC_METADATA_SERVER=http://127.0.0.1:8080/metadata DEFAULT_KV_LEASE_TTL=500 python test_replicated_distributed_object_store.py
-sleep 1
-mooncake_client &
-CLIENT_PID=$!
-sleep 1
-MC_METADATA_SERVER=http://127.0.0.1:8080/metadata DEFAULT_KV_LEASE_TTL=500 python test_dummy_client.py
-MC_METADATA_SERVER=http://127.0.0.1:8080/metadata DEFAULT_KV_LEASE_TTL=500 python test_multi_dummy_clients.py --client-id client1 &
+start_master ${MAIN_MASTER_PORT} ${MAIN_MASTER_METRICS_PORT} --default_kv_lease_ttl=500
+MC_METADATA_SERVER=${METADATA_SERVER_URL} MASTER_SERVER=${MASTER_SERVER_ADDR} DEFAULT_KV_LEASE_TTL=500 python test_distributed_object_store.py
+MC_METADATA_SERVER=${METADATA_SERVER_URL} MASTER_SERVER=${MASTER_SERVER_ADDR} DEFAULT_KV_LEASE_TTL=500 python test_replicated_distributed_object_store.py
+
+start_client ${DUMMY_CLIENT_PORT}
+MC_METADATA_SERVER=${METADATA_SERVER_URL} MASTER_SERVER=${MASTER_SERVER_ADDR} DEFAULT_KV_LEASE_TTL=500 MOONCAKE_CLIENT_PORT=${DUMMY_CLIENT_PORT} python test_dummy_client.py
+stop_client
+
+start_client ${MULTI_DUMMY_CLIENT_PORT}
+MC_METADATA_SERVER=${METADATA_SERVER_URL} MASTER_SERVER=${MASTER_SERVER_ADDR} DEFAULT_KV_LEASE_TTL=500 MOONCAKE_CLIENT_PORT=${MULTI_DUMMY_CLIENT_PORT} python test_multi_dummy_clients.py --client-id client1 &
 DUMMY_TEST_PID_1=$!
-MC_METADATA_SERVER=http://127.0.0.1:8080/metadata DEFAULT_KV_LEASE_TTL=500 python test_multi_dummy_clients.py --client-id client2 &
+MC_METADATA_SERVER=${METADATA_SERVER_URL} MASTER_SERVER=${MASTER_SERVER_ADDR} DEFAULT_KV_LEASE_TTL=500 MOONCAKE_CLIENT_PORT=${MULTI_DUMMY_CLIENT_PORT} python test_multi_dummy_clients.py --client-id client2 &
 DUMMY_TEST_PID_2=$!
 wait $DUMMY_TEST_PID_1 $DUMMY_TEST_PID_2
-kill $CLIENT_PID || true
+stop_client
 
 pip install numpy safetensors packaging
 # Keep the test torch aligned with the EP/PG variants packaged into the CI wheel.
 pip install "${MOONCAKE_TEST_TORCH_SPEC:-torch==2.11.0+cu128}" \
     --index-url "${MOONCAKE_TEST_TORCH_INDEX_URL:-https://download.pytorch.org/whl/cu128}" \
     --extra-index-url https://pypi.org/simple
-MC_METADATA_SERVER=http://127.0.0.1:8080/metadata DEFAULT_KV_LEASE_TTL=500 python test_put_get_tensor.py
-MC_METADATA_SERVER=http://127.0.0.1:8080/metadata DEFAULT_KV_LEASE_TTL=500 python test_safetensor_functions.py
-kill $MASTER_PID || true
-wait $MASTER_PID 2>/dev/null || true
+MC_METADATA_SERVER=${METADATA_SERVER_URL} MASTER_SERVER=${MASTER_SERVER_ADDR} DEFAULT_KV_LEASE_TTL=500 python test_put_get_tensor.py
+MC_METADATA_SERVER=${METADATA_SERVER_URL} MASTER_SERVER=${MASTER_SERVER_ADDR} DEFAULT_KV_LEASE_TTL=500 python test_safetensor_functions.py
+stop_master
 
 
 # Check if MOONCAKE_STORAGE_ROOT_DIR is set and not empty
@@ -59,12 +168,9 @@ if [ -n "$TEST_SSD_OFFLOAD_IN_EVICT" ]; then
     echo "Running with ssd offload in evict tests..."
     # Set a small kv lease ttl to make the test faster.
     # Must be consistent with the client test parameters.
-    mooncake_master --default_kv_lease_ttl=500 --root_fs_dir=$TEST_ROOT_DIR &
-    MASTER_PID=$!
-    sleep 1
-    MC_METADATA_SERVER=http://127.0.0.1:8080/metadata DEFAULT_KV_LEASE_TTL=500 python test_ssd_offload_in_evict.py
-    kill $MASTER_PID || true
-    wait $MASTER_PID 2>/dev/null || true
+    start_master ${SSD_MASTER_PORT} ${SSD_MASTER_METRICS_PORT} --default_kv_lease_ttl=500 --root_fs_dir=$TEST_ROOT_DIR
+    MC_METADATA_SERVER=${METADATA_SERVER_URL} MASTER_SERVER=${MASTER_SERVER_ADDR} DEFAULT_KV_LEASE_TTL=500 python test_ssd_offload_in_evict.py
+    stop_master
     rm -rf $TEST_ROOT_DIR
 else
     echo "Skipping test: MOONCAKE_STORAGE_ROOT_DIR environment variable is not set"
@@ -79,26 +185,24 @@ if [ -n "$TEST_PROMOTION_ON_HIT" ]; then
     # deterministic. --root_fs_dir is required so the master returns a non-
     # empty fsdir from GetStorageConfig, which is the trigger that initializes
     # the client's FileStorage (and therefore the offload heartbeat).
-    mooncake_master \
+    start_master ${PROMOTION_MASTER_PORT} ${PROMOTION_MASTER_METRICS_PORT} \
         --default_kv_lease_ttl=500 \
         --root_fs_dir=$TEST_ROOT_DIR \
         --enable_offload=true \
         --offload_on_evict=true \
         --promotion_on_hit=true \
-        --promotion_admission_threshold=1 &
-    MASTER_PID=$!
-    sleep 1
+        --promotion_admission_threshold=1
     # Lower bucket-flush thresholds so the test workload (~64 MB) actually
     # writes to disk rather than sitting in the bucket backend's ungrouped
     # pool until the default 500-key / 256-MB bucket fills.
-    MC_METADATA_SERVER=http://127.0.0.1:8080/metadata \
+    MC_METADATA_SERVER=${METADATA_SERVER_URL} \
+        MASTER_SERVER=${MASTER_SERVER_ADDR} \
         DEFAULT_KV_LEASE_TTL=500 \
         MOONCAKE_OFFLOAD_FILE_STORAGE_PATH=$TEST_ROOT_DIR \
         MOONCAKE_OFFLOAD_BUCKET_KEYS_LIMIT=10 \
         MOONCAKE_OFFLOAD_BUCKET_SIZE_LIMIT_BYTES=10485760 \
         python test_promotion_on_hit.py
-    kill $MASTER_PID || true
-    wait $MASTER_PID 2>/dev/null || true
+    stop_master
     rm -rf $TEST_ROOT_DIR
 else
     echo "Skipping test: TEST_PROMOTION_ON_HIT environment variable is not set"
@@ -109,31 +213,32 @@ killall mooncake_master || true
 sleep 2
 
 echo "Starting Mooncake Master with CXL enabled (--enable_cxl=true)..."
-mooncake_master \
+start_master ${CXL_MASTER_PORT} ${CXL_MASTER_METRICS_PORT} \
   --default_kv_lease_ttl=500 \
-  --enable_cxl=true \
-  &
-CXL_MASTER_PID=$!
-sleep 3
-MC_METADATA_SERVER=http://127.0.0.1:8080/metadata DEFAULT_KV_LEASE_TTL=500 python test_distributed_object_store_cxl.py
-kill $CXL_MASTER_PID || true
-wait $CXL_MASTER_PID 2>/dev/null || true
+  --enable_cxl=true
+sleep 2
+MC_METADATA_SERVER=${METADATA_SERVER_URL} MASTER_SERVER=${MASTER_SERVER_ADDR} DEFAULT_KV_LEASE_TTL=500 python test_distributed_object_store_cxl.py
+stop_master
 sleep 2
 echo "CXL protocol test completed successfully!"
+stop_metadata
 
 echo "Running CLI entry point tests..."
-python test_cli.py
+MOONCAKE_CLI_MASTER_PORT=${CLI_MASTER_PORT} \
+    MOONCAKE_CLI_CLIENT_PORT=${CLI_CLIENT_PORT} \
+    MOONCAKE_CLI_HTTP_METADATA_PORT=${CLI_HTTP_METADATA_PORT} \
+    MOONCAKE_CLI_METRICS_PORT=${CLI_METRICS_PORT} \
+    python test_cli.py
 
 killall mooncake_http_metadata_server || true
 killall mooncake_master || true
 killall mooncake_client || true
-mooncake_master --default_kv_lease_ttl=500 --enable_http_metadata_server=true &
-MASTER_PID=$!
+start_master ${EMBEDDED_MASTER_PORT} ${EMBEDDED_MASTER_METRICS_PORT} --default_kv_lease_ttl=500 \
+    --enable_http_metadata_server=true \
+    --http_metadata_server_port=${EMBEDDED_HTTP_METADATA_PORT}
+MC_METADATA_SERVER=http://127.0.0.1:${EMBEDDED_HTTP_METADATA_PORT}/metadata MASTER_SERVER=${MASTER_SERVER_ADDR} DEFAULT_KV_LEASE_TTL=500 python test_distributed_object_store.py
 sleep 1
-MC_METADATA_SERVER=http://127.0.0.1:8080/metadata DEFAULT_KV_LEASE_TTL=500 python test_distributed_object_store.py
-sleep 1
-kill $MASTER_PID || true
-wait $MASTER_PID 2>/dev/null || true
+stop_master
 
 
 echo "All tests completed successfully!"


### PR DESCRIPTION
## Description

Fixes wheel-test port collisions by giving each service instance its own preallocated port instead of reusing fixed ports across `scripts/run_tests.sh`.

`run_tests.sh` now allocates a per-run port block at startup, then assigns named ports from that block for metadata, master RPC, master metrics, real-client RPC, CLI master/client/metadata/metrics, and the final embedded metadata server. By default, concurrent `run_tests.sh` processes coordinate through a small `/tmp` state file guarded by `flock`, so each process receives a different 100-port block. `MOONCAKE_TEST_PORT_BASE` can still be set to force an explicit block.

The dummy client tests and CLI entrypoint test read their ports from environment variables so each test can consume its assigned port without relying on fixed defaults.

This addresses the fd/TIME_WAIT resource contention seen in CI where a service bind could fail after another test had recently used the same port.

## Module

- Python Wheel
- CI/Build

## Type of Change

- Bug fix

## Testing

- `bash -n scripts/run_tests.sh`
- `git diff --check -- scripts/run_tests.sh`
- `command -v flock`
- Dynamic metadata + dummy client smoke test with non-default ports: passed before the preallocation refactor (`Ran 6 tests ... OK`)
- Dynamic CLI entrypoint test with non-default master/client/http-metadata/metrics ports: passed before the preallocation refactor
- Commit hook passed: trim trailing whitespace, EOF fixer, merge-conflict check, large-file check, Mooncake format script, codespell

Full `scripts/run_tests.sh` was not run end-to-end because the torch install portion is heavy.

## Checklist

- [x] I have performed a self-review of the changed files.
- [x] Existing tests were updated to support isolated service ports.
- [x] Relevant local checks were run as listed above.
- [ ] Full test suite was run end-to-end.
- [x] Documentation changes are not needed.
- [x] RFC is not needed for this CI/test isolation fix.

## AI Assistance Disclosure

OpenAI Codex helped inspect the CI failure mode, implement the port isolation changes, and run local verification. Human review is required before merge.