### PR TITLE
[Bugfix] Reject empty keys in HTTP metadata server

### DIFF
--- a/mooncake-wheel/mooncake/http_metadata_server.py
+++ b/mooncake-wheel/mooncake/http_metadata_server.py
@@ -64,7 +64,7 @@ class KVBootstrapServer:
         key = request.query.get('key', '').strip()
         if not key:
             return web.Response(text='metadata key is required', status=400,
-                              content_type='text/plain')
+                              content_type='application/json')
         
         if request.method == 'GET':
             return await self._handle_get(key)

--- a/mooncake-wheel/mooncake/http_metadata_server.py
+++ b/mooncake-wheel/mooncake/http_metadata_server.py
@@ -61,10 +61,10 @@ class KVBootstrapServer:
 
     async def _handle_metadata(self, request: web.Request):
         """Handle metadata requests."""
-        key = request.query.get('key', '')
-        if not key.strip():
+        key = request.query.get('key', '').strip()
+        if not key:
             return web.Response(text='metadata key is required', status=400,
-                              content_type='application/json')
+                              content_type='text/plain')
         
         if request.method == 'GET':
             return await self._handle_get(key)

--- a/mooncake-wheel/mooncake/http_metadata_server.py
+++ b/mooncake-wheel/mooncake/http_metadata_server.py
@@ -62,6 +62,9 @@ class KVBootstrapServer:
     async def _handle_metadata(self, request: web.Request):
         """Handle metadata requests."""
         key = request.query.get('key', '')
+        if not key.strip():
+            return web.Response(text='metadata key is required', status=400,
+                              content_type='application/json')
         
         if request.method == 'GET':
             return await self._handle_get(key)

--- a/mooncake-wheel/tests/test_http_metadata_server.py
+++ b/mooncake-wheel/tests/test_http_metadata_server.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from mooncake.http_metadata_server import KVBootstrapServer
+
+
+class FakeRequest:
+    def __init__(self, method, key=None, body=b""):
+        self.method = method
+        self.query = {} if key is None else {"key": key}
+        self.body = body
+
+    async def read(self):
+        return self.body
+
+
+class HttpMetadataServerTest(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.server = KVBootstrapServer(port=0)
+
+    async def test_missing_metadata_key_is_rejected_for_all_methods(self):
+        for method in ("GET", "PUT", "DELETE"):
+            with self.subTest(method=method):
+                response = await self.server._handle_metadata(
+                    FakeRequest(method, body=b"value")
+                )
+
+                self.assertEqual(response.status, 400)
+                self.assertNotIn("", self.server.store)
+
+    async def test_empty_metadata_key_is_rejected(self):
+        response = await self.server._handle_metadata(
+            FakeRequest("PUT", key="", body=b"value")
+        )
+
+        self.assertEqual(response.status, 400)
+        self.assertNotIn("", self.server.store)
+
+    async def test_blank_metadata_key_is_rejected(self):
+        response = await self.server._handle_metadata(
+            FakeRequest("PUT", key="   ", body=b"value")
+        )
+
+        self.assertEqual(response.status, 400)
+        self.assertNotIn("   ", self.server.store)
+
+    async def test_valid_metadata_key_still_round_trips(self):
+        put_response = await self.server._handle_metadata(
+            FakeRequest("PUT", key="valid", body=b"value")
+        )
+        get_response = await self.server._handle_metadata(
+            FakeRequest("GET", key="valid")
+        )
+
+        self.assertEqual(put_response.status, 200)
+        self.assertEqual(get_response.status, 200)
+        self.assertEqual(get_response.body, b"value")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mooncake-wheel/tests/test_http_metadata_server.py
+++ b/mooncake-wheel/tests/test_http_metadata_server.py
@@ -30,6 +30,7 @@ class HttpMetadataServerTest(unittest.IsolatedAsyncioTestCase):
                 )
 
                 self.assertEqual(response.status, 400)
+                self.assertEqual(response.content_type, "text/plain")
                 self.assertNotIn("", self.server.store)
 
     async def test_empty_metadata_key_is_rejected(self):
@@ -38,6 +39,7 @@ class HttpMetadataServerTest(unittest.IsolatedAsyncioTestCase):
         )
 
         self.assertEqual(response.status, 400)
+        self.assertEqual(response.content_type, "text/plain")
         self.assertNotIn("", self.server.store)
 
     async def test_blank_metadata_key_is_rejected(self):
@@ -46,7 +48,22 @@ class HttpMetadataServerTest(unittest.IsolatedAsyncioTestCase):
         )
 
         self.assertEqual(response.status, 400)
+        self.assertEqual(response.content_type, "text/plain")
         self.assertNotIn("   ", self.server.store)
+
+    async def test_metadata_key_is_stripped_before_operations(self):
+        put_response = await self.server._handle_metadata(
+            FakeRequest("PUT", key="  valid  ", body=b"value")
+        )
+        get_response = await self.server._handle_metadata(
+            FakeRequest("GET", key="  valid  ")
+        )
+
+        self.assertEqual(put_response.status, 200)
+        self.assertEqual(get_response.status, 200)
+        self.assertEqual(get_response.body, b"value")
+        self.assertIn("valid", self.server.store)
+        self.assertNotIn("  valid  ", self.server.store)
 
     async def test_valid_metadata_key_still_round_trips(self):
         put_response = await self.server._handle_metadata(

--- a/mooncake-wheel/tests/test_http_metadata_server.py
+++ b/mooncake-wheel/tests/test_http_metadata_server.py
@@ -30,7 +30,7 @@ class HttpMetadataServerTest(unittest.IsolatedAsyncioTestCase):
                 )
 
                 self.assertEqual(response.status, 400)
-                self.assertEqual(response.content_type, "text/plain")
+                self.assertEqual(response.content_type, "application/json")
                 self.assertNotIn("", self.server.store)
 
     async def test_empty_metadata_key_is_rejected(self):
@@ -39,7 +39,7 @@ class HttpMetadataServerTest(unittest.IsolatedAsyncioTestCase):
         )
 
         self.assertEqual(response.status, 400)
-        self.assertEqual(response.content_type, "text/plain")
+        self.assertEqual(response.content_type, "application/json")
         self.assertNotIn("", self.server.store)
 
     async def test_blank_metadata_key_is_rejected(self):
@@ -48,7 +48,7 @@ class HttpMetadataServerTest(unittest.IsolatedAsyncioTestCase):
         )
 
         self.assertEqual(response.status, 400)
-        self.assertEqual(response.content_type, "text/plain")
+        self.assertEqual(response.content_type, "application/json")
         self.assertNotIn("   ", self.server.store)
 
     async def test_metadata_key_is_stripped_before_operations(self):


### PR DESCRIPTION
## Description

### What Problem This Solves

The Python HTTP metadata server currently treats a missing `key` query parameter as an empty string. As a result, requests such as `PUT /metadata` or `PUT /metadata?key=` can operate on `self.store[""]` instead of being rejected.

This can create accidental empty-string metadata entries when callers omit the query parameter, and later empty-key requests can then appear valid instead of surfacing the original bad request.

### Changes

- Adds metadata key validation in `KVBootstrapServer._handle_metadata()` before dispatching GET, PUT, or DELETE handling.
- Rejects missing, empty, and whitespace-only metadata keys with HTTP 400.
- Strips valid non-empty metadata keys before they are passed to the existing handler path.

### Evidence

- Adds focused handler-level unit coverage for missing keys across GET, PUT, and DELETE.
- Adds coverage for empty and whitespace-only keys.
- Adds coverage for stripping leading and trailing whitespace before metadata operations, plus a valid-key PUT/GET round-trip test to confirm normal metadata storage and retrieval still works.

### Possible call chain / impact

External metadata requests enter through `/metadata`, then `KVBootstrapServer._handle_metadata()` dispatches to `_handle_get()`, `_handle_put()`, or `_handle_delete()`.

This change affects only the Python HTTP metadata server key handling path: missing, empty, and whitespace-only `key` query parameters are rejected, while valid non-empty keys are stripped before continuing through the existing handler path.
## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Focused unit coverage validates the metadata handler directly:

- missing `key` is rejected for GET, PUT, and DELETE
- empty `key` is rejected
- whitespace-only `key` is rejected
- valid keys with leading/trailing whitespace are stripped before PUT/GET operations
- valid non-empty keys still round-trip through PUT and GET

**Test commands:**
```bash
python -m pytest mooncake-wheel/tests/test_http_metadata_server.py -q
python -m py_compile mooncake-wheel/mooncake/http_metadata_server.py mooncake-wheel/tests/test_http_metadata_server.py
git diff --check
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

AI assistance was used to identify the empty-key API contract issue, inspect the affected handler path, and draft focused validation coverage. The human submitter is responsible for reviewing and validating the final changes.