### PR TITLE
[TransferEngine] Optimize MACA P2P copy path

### DIFF
--- a/mooncake-transfer-engine/include/gpu_vendor/maca.h
+++ b/mooncake-transfer-engine/include/gpu_vendor/maca.h
@@ -120,6 +120,7 @@ static inline CUresult cuGetErrorString(CUresult error, const char **err_str) {
 #define cudaMemcpyDeviceToHost mcMemcpyDeviceToHost
 #define cudaMemcpyHostToDevice mcMemcpyHostToDevice
 #define cudaMemcpyKind mcMemcpyKind
+#define cudaMemcpyPeerAsync mcMemcpyPeerAsync
 #define cudaMemset mcMemset
 #define cudaMemsetAsync mcMemsetAsync
 #define cudaMemoryTypeDevice mcMemoryTypeDevice

--- a/mooncake-transfer-engine/src/multi_transport.cpp
+++ b/mooncake-transfer-engine/src/multi_transport.cpp
@@ -470,6 +470,7 @@ Status MultiTransport::selectTransport(const TransferRequest& entry,
             // hip+rdma segment must fall through to rdma; allow deployments
             // that know they need the cross-node path to de-prioritize hip.
             if (p == "hip") return std::getenv("MC_DISABLE_HIP") ? 0 : 4;
+            if (p == "maca") return std::getenv("MC_DISABLE_MACA") ? 0 : 4;
             if (p == "cxl") return 3;
             if (p == "rdma") return 2;
             if (p == "tcp") return 1;

--- a/mooncake-transfer-engine/src/transfer_metadata.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata.cpp
@@ -269,7 +269,7 @@ static int encodeMultiProtocolSegmentDesc(
             bufferJSON["lkey"] = lkeyJSON;
         } else if (buffer.protocol == "tcp") {
             bufferJSON["addr"] = static_cast<Json::UInt64>(buffer.addr);
-        } else if (buffer.protocol == "hip") {
+        } else if (buffer.protocol == "hip" || buffer.protocol == "maca") {
             bufferJSON["addr"] = static_cast<Json::UInt64>(buffer.addr);
             bufferJSON["shm_name"] = buffer.shm_name;
         }
@@ -297,7 +297,7 @@ int TransferMetadata::encodeSegmentDesc(const SegmentDesc &desc,
         is_multi_protocol = true;
         for (const auto &proto : protocols) {
             if (proto != "cxl" && proto != "tcp" && proto != "rdma" &&
-                proto != "hip") {
+                proto != "hip" && proto != "maca") {
                 is_multi_protocol = false;
                 break;
             }
@@ -305,7 +305,8 @@ int TransferMetadata::encodeSegmentDesc(const SegmentDesc &desc,
         if (!is_multi_protocol) {
             LOG(ERROR) << "Unsupported multi-protocol combination: "
                        << desc.protocol
-                       << ". Only cxl, tcp, rdma and hip may be combined.";
+                       << ". Only cxl, tcp, rdma, hip and maca may be "
+                          "combined.";
             return ERR_INVALID_ARGUMENT;
         }
     }
@@ -608,7 +609,7 @@ decodeMultiProtocolSegmentDesc(Json::Value &segmentJSON,
                 return nullptr;
             }
             desc->buffers.push_back(buffer);
-        } else if (buffer_protocol == "hip") {
+        } else if (buffer_protocol == "hip" || buffer_protocol == "maca") {
             TransferMetadata::BufferDesc buffer;
             buffer.name = bufferJSON["name"].asString();
             buffer.addr = bufferJSON["addr"].asUInt64();
@@ -645,7 +646,7 @@ TransferMetadata::decodeSegmentDesc(Json::Value &segmentJSON,
             for (const auto &protocolStr : segmentJSON["protocol"]) {
                 std::string proto = protocolStr.asString();
                 if (proto != "cxl" && proto != "tcp" && proto != "rdma" &&
-                    proto != "hip") {
+                    proto != "hip" && proto != "maca") {
                     is_multi_protocol = false;
                     break;
                 }
@@ -654,7 +655,7 @@ TransferMetadata::decodeSegmentDesc(Json::Value &segmentJSON,
                 LOG(ERROR)
                     << "Unsupported multi-protocol combination in segment: "
                     << segment_name
-                    << ". Only cxl, tcp, rdma and hip may be combined.";
+                    << ". Only cxl, tcp, rdma, hip and maca may be combined.";
                 return nullptr;
             }
         }

--- a/mooncake-transfer-engine/src/transport/maca_transport/maca_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/maca_transport/maca_transport.cpp
@@ -22,8 +22,12 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
+#include <cstring>
 #include <iomanip>
 #include <memory>
+#include <string>
+#include <unordered_map>
 
 #include "common.h"
 #include "common/serialization.h"
@@ -125,6 +129,316 @@ static int getDeviceFromPointer(void *ptr) {
     return -1;
 }
 
+enum class MacaCopyMode {
+    Sync,
+    NewStreamSync,
+    StreamSync,
+    Posted,
+};
+
+enum class MacaCallerSyncMode {
+    None,
+    Host,
+    Wait,
+};
+
+enum class MacaCopyApi {
+    Auto,
+    Default,
+    Peer,
+    BatchFlag,
+};
+
+struct CallerSync {
+    MacaCallerSyncMode mode;
+    cudaEvent_t event;
+};
+
+static MacaCopyMode copyMode() {
+    static const MacaCopyMode mode = [] {
+        const char *mode_env = std::getenv("MC_MACA_COPY_MODE");
+        if (mode_env) {
+            std::string mode(mode_env);
+            if (mode == "newstream_sync") return MacaCopyMode::NewStreamSync;
+            if (mode == "stream_sync") return MacaCopyMode::StreamSync;
+            if (mode == "posted") return MacaCopyMode::Posted;
+            if (mode == "sync") return MacaCopyMode::Sync;
+            LOG(WARNING) << "MacaTransport: unknown MC_MACA_COPY_MODE=" << mode
+                         << ", falling back to sync";
+            return MacaCopyMode::Sync;
+        }
+
+        const char *async_env = std::getenv("MC_MACA_ASYNC_COPY");
+        if (async_env) {
+            if (std::string(async_env) != "0") return MacaCopyMode::StreamSync;
+            return MacaCopyMode::Sync;
+        }
+        return MacaCopyMode::Posted;
+    }();
+    return mode;
+}
+
+static const char *copyModeName(MacaCopyMode mode) {
+    switch (mode) {
+        case MacaCopyMode::Sync:
+            return "sync";
+        case MacaCopyMode::NewStreamSync:
+            return "newstream_sync";
+        case MacaCopyMode::StreamSync:
+            return "stream_sync";
+        case MacaCopyMode::Posted:
+            return "posted";
+    }
+    return "unknown";
+}
+
+static MacaCallerSyncMode callerSyncMode() {
+    static const MacaCallerSyncMode mode = [] {
+        const char *env = std::getenv("MC_MACA_CALLER_SYNC");
+        if (!env) {
+            const char *legacy_env = std::getenv("MC_MACA_SYNC_CALLER_STREAM");
+            if (legacy_env && std::string(legacy_env) != "0")
+                return MacaCallerSyncMode::Wait;
+            return MacaCallerSyncMode::Host;
+        }
+
+        std::string value(env);
+        if (value == "none" || value == "0") return MacaCallerSyncMode::None;
+        if (value == "host") return MacaCallerSyncMode::Host;
+        if (value == "wait") return MacaCallerSyncMode::Wait;
+        LOG(WARNING) << "MacaTransport: unknown MC_MACA_CALLER_SYNC=" << value
+                     << ", falling back to host";
+        return MacaCallerSyncMode::Host;
+    }();
+    return mode;
+}
+
+static const char *callerSyncModeName(MacaCallerSyncMode mode) {
+    switch (mode) {
+        case MacaCallerSyncMode::None:
+            return "none";
+        case MacaCallerSyncMode::Host:
+            return "host";
+        case MacaCallerSyncMode::Wait:
+            return "wait";
+    }
+    return "unknown";
+}
+
+static MacaCopyApi copyApi() {
+    static const MacaCopyApi api = [] {
+        const char *env = std::getenv("MC_MACA_COPY_API");
+        if (!env) return MacaCopyApi::Auto;
+
+        std::string value(env);
+        if (value == "auto") return MacaCopyApi::Auto;
+        if (value == "default" || value == "0") return MacaCopyApi::Default;
+        if (value == "peer") return MacaCopyApi::Peer;
+        if (value == "batchflag" || value == "batch_flag" || value == "batch")
+            return MacaCopyApi::BatchFlag;
+        LOG(WARNING) << "MacaTransport: unknown MC_MACA_COPY_API=" << value
+                     << ", falling back to auto";
+        return MacaCopyApi::Auto;
+    }();
+    return api;
+}
+
+static const char *copyApiName(MacaCopyApi api) {
+    switch (api) {
+        case MacaCopyApi::Auto:
+            return "auto";
+        case MacaCopyApi::Default:
+            return "default";
+        case MacaCopyApi::Peer:
+            return "peer";
+        case MacaCopyApi::BatchFlag:
+            return "batchflag";
+    }
+    return "unknown";
+}
+
+static size_t batchFlagMinBytes() {
+    static const size_t min_bytes = [] {
+        constexpr size_t kDefaultMinBytes = 1024ULL * 1024ULL;
+        const char *env = std::getenv("MC_MACA_BATCHFLAG_MIN_BYTES");
+        if (!env) return kDefaultMinBytes;
+
+        char *end = nullptr;
+        unsigned long long value = std::strtoull(env, &end, 0);
+        if (end == env || *end != '\0') {
+            LOG(WARNING) << "MacaTransport: unknown "
+                            "MC_MACA_BATCHFLAG_MIN_BYTES="
+                         << env << ", falling back to " << kDefaultMinBytes;
+            return kDefaultMinBytes;
+        }
+        return static_cast<size_t>(value);
+    }();
+    return min_bytes;
+}
+
+static bool shouldUseBatchFlag(MacaCopyApi api, size_t length) {
+    if (api == MacaCopyApi::BatchFlag) return true;
+    if (api == MacaCopyApi::Auto) return length >= batchFlagMinBytes();
+    return false;
+}
+
+static MacaCopyApi asyncCopyApi(MacaCopyApi api) {
+    return api == MacaCopyApi::Peer ? MacaCopyApi::Peer : MacaCopyApi::Default;
+}
+
+class PerDeviceStreamPool {
+   public:
+    cudaStream_t getOrCreate(int device_id) {
+        auto iter = streams_.find(device_id);
+        if (iter != streams_.end()) return iter->second;
+
+        int original_device = -1;
+        cudaGetDevice(&original_device);
+        if (!checkCudaErrorReturn(cudaSetDevice(device_id),
+                                  "MacaTransport: failed to set device")) {
+            if (original_device >= 0) cudaSetDevice(original_device);
+            return nullptr;
+        }
+
+        cudaStream_t stream = nullptr;
+        cudaError_t err =
+            cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking);
+        if (original_device >= 0) cudaSetDevice(original_device);
+        if (!checkCudaErrorReturn(
+                err, "MacaTransport: cudaStreamCreateWithFlags failed")) {
+            return nullptr;
+        }
+
+        streams_[device_id] = stream;
+        return stream;
+    }
+
+    ~PerDeviceStreamPool() {
+        int original_device = -1;
+        cudaGetDevice(&original_device);
+        for (auto &entry : streams_) {
+            cudaSetDevice(entry.first);
+            cudaStreamDestroy(entry.second);
+        }
+        if (original_device >= 0) cudaSetDevice(original_device);
+    }
+
+   private:
+    std::unordered_map<int, cudaStream_t> streams_;
+};
+
+static thread_local PerDeviceStreamPool thread_local_stream_pool;
+
+class PerDeviceEventPool {
+   public:
+    cudaEvent_t getOrCreate(int device_id) {
+        auto iter = events_.find(device_id);
+        if (iter != events_.end()) return iter->second;
+
+        int original_device = -1;
+        cudaGetDevice(&original_device);
+        if (!checkCudaErrorReturn(cudaSetDevice(device_id),
+                                  "MacaTransport: failed to set device")) {
+            if (original_device >= 0) cudaSetDevice(original_device);
+            return nullptr;
+        }
+
+        cudaEvent_t event = nullptr;
+        cudaError_t err =
+            cudaEventCreateWithFlags(&event, cudaEventDisableTiming);
+        if (original_device >= 0) cudaSetDevice(original_device);
+        if (!checkCudaErrorReturn(
+                err, "MacaTransport: cudaEventCreateWithFlags failed")) {
+            return nullptr;
+        }
+
+        events_[device_id] = event;
+        return event;
+    }
+
+    ~PerDeviceEventPool() {
+        int original_device = -1;
+        cudaGetDevice(&original_device);
+        for (auto &entry : events_) {
+            cudaSetDevice(entry.first);
+            cudaEventDestroy(entry.second);
+        }
+        if (original_device >= 0) cudaSetDevice(original_device);
+    }
+
+   private:
+    std::unordered_map<int, cudaEvent_t> events_;
+};
+
+static thread_local PerDeviceEventPool thread_local_event_pool;
+
+static Status prepareCallerSync(CallerSync &sync) {
+    sync.mode = callerSyncMode();
+    sync.event = nullptr;
+    if (sync.mode == MacaCallerSyncMode::None) return Status::OK();
+
+    int current_device = 0;
+    cudaGetDevice(&current_device);
+    cudaEvent_t event = thread_local_event_pool.getOrCreate(current_device);
+    if (!event) {
+        return Status::Context("MacaTransport: failed to create sync event");
+    }
+
+    cudaError_t err = cudaEventRecord(event, cudaStreamPerThread);
+    if (err != cudaSuccess) {
+        LOG(ERROR) << "MacaTransport: cudaEventRecord failed: "
+                   << cudaGetErrorString(err);
+        return Status::Context("MacaTransport: cudaEventRecord failed");
+    }
+
+    sync.event = event;
+    if (sync.mode == MacaCallerSyncMode::Host) {
+        err = cudaEventSynchronize(event);
+        if (err != cudaSuccess) {
+            LOG(ERROR) << "MacaTransport: cudaEventSynchronize failed: "
+                       << cudaGetErrorString(err);
+            return Status::Context(
+                "MacaTransport: cudaEventSynchronize failed");
+        }
+    }
+    return Status::OK();
+}
+
+static void getCopyEndpoints(Transport::Slice *slice, void *&dst,
+                             const void *&src) {
+    dst = slice->local.dest_addr;
+    src = slice->source_addr;
+    if (slice->opcode == Transport::TransferRequest::READ) {
+        dst = slice->source_addr;
+        src = slice->local.dest_addr;
+    }
+}
+
+static cudaError_t submitMemcpyAsync(Transport::Slice *slice, MacaCopyApi api,
+                                     cudaStream_t stream) {
+    void *dst;
+    const void *src;
+    getCopyEndpoints(slice, dst, src);
+
+    if (api == MacaCopyApi::Peer) {
+        int dst_device = getDeviceFromPointer(dst);
+        int src_device = getDeviceFromPointer(const_cast<void *>(src));
+        if (dst_device >= 0 && src_device >= 0 && dst_device != src_device) {
+            return cudaMemcpyPeerAsync(dst, dst_device, src, src_device,
+                                       slice->length, stream);
+        }
+    }
+
+    return cudaMemcpyAsync(dst, src, slice->length, cudaMemcpyDefault, stream);
+}
+
+static cudaError_t submitBatchFlagAsync(std::vector<mcCopyFlag_t> &copy_batch,
+                                        cudaStream_t stream) {
+    if (copy_batch.empty()) return cudaSuccess;
+    return mcExtBatchCopyFlagAndWaitV2(copy_batch.data(), copy_batch.size(),
+                                       nullptr, 0, stream);
+}
+
 MacaTransport::MacaTransport() {
     int num_devices = getNumDevices();
     if (globalConfig().trace) {
@@ -163,10 +477,21 @@ int MacaTransport::install(std::string &local_server_name,
     metadata_ = metadata;
     local_server_name_ = local_server_name;
 
+    auto old_desc = metadata_->getSegmentDescByID(LOCAL_SEGMENT_ID);
     auto desc = std::make_shared<SegmentDesc>();
     if (!desc) return ERR_MEMORY;
+    if (old_desc) *desc = *old_desc;
+
     desc->name = local_server_name_;
+#ifdef ENABLE_MULTI_PROTOCOL
+    if (desc->protocol.empty()) {
+        desc->protocol = "maca";
+    } else if (desc->protocol.find("maca") == std::string::npos) {
+        desc->protocol += ",maca";
+    }
+#else
     desc->protocol = "maca";
+#endif
     metadata_->addLocalSegment(LOCAL_SEGMENT_ID, local_server_name_,
                                std::move(desc));
     return 0;
@@ -204,6 +529,7 @@ Status MacaTransport::submitTransfer(
         slice->task = &task;
         slice->target_id = request.target_id;
         slice->status = Slice::PENDING;
+        task.slice_list.push_back(slice);
         __sync_fetch_and_add(&task.slice_count, 1);
 
         // Set correct device context before memcpy
@@ -242,6 +568,28 @@ Status MacaTransport::getTransferStatus(BatchID batch_id, size_t task_id,
             std::to_string(batch_id));
     }
     auto &task = batch_desc.task_list[task_id];
+    std::unordered_map<cudaStream_t, cudaError_t> stream_status_cache;
+    for (auto *slice : task.slice_list) {
+        if (slice && slice->status == Slice::POSTED) {
+            cudaStream_t stream = (cudaStream_t)slice->local.cuda_stream;
+            auto iter = stream_status_cache.find(stream);
+            cudaError_t err;
+            if (iter == stream_status_cache.end()) {
+                err = cudaStreamQuery(stream);
+                stream_status_cache[stream] = err;
+            } else {
+                err = iter->second;
+            }
+
+            if (err == cudaSuccess) {
+                slice->markSuccess();
+            } else if (err != cudaErrorNotReady) {
+                LOG(ERROR) << "MacaTransport: cudaStreamQuery failed: "
+                           << cudaGetErrorString(err);
+                slice->markFailed();
+            }
+        }
+    }
     status.transferred_bytes = task.transferred_bytes;
     uint64_t success_slice_count = task.success_slice_count;
     uint64_t failed_slice_count = task.failed_slice_count;
@@ -260,6 +608,300 @@ Status MacaTransport::getTransferStatus(BatchID batch_id, size_t task_id,
 
 Status MacaTransport::submitTransferTask(
     const std::vector<TransferTask *> &task_list) {
+    MacaCopyMode mode = copyMode();
+    static const bool logged_copy_mode = [mode] {
+        LOG(INFO) << "MacaTransport: copy mode " << copyModeName(mode);
+        return true;
+    }();
+    (void)logged_copy_mode;
+    MacaCallerSyncMode sync_mode = callerSyncMode();
+    static const bool logged_sync_mode = [sync_mode] {
+        LOG(INFO) << "MacaTransport: caller sync mode "
+                  << callerSyncModeName(sync_mode);
+        return true;
+    }();
+    (void)logged_sync_mode;
+    MacaCopyApi api = copyApi();
+    static const bool logged_copy_api = [api] {
+        LOG(INFO) << "MacaTransport: copy api " << copyApiName(api);
+        return true;
+    }();
+    (void)logged_copy_api;
+    static const bool logged_batchflag_threshold = [api] {
+        if (api == MacaCopyApi::Auto) {
+            LOG(INFO) << "MacaTransport: batchflag min bytes "
+                      << batchFlagMinBytes();
+        }
+        return true;
+    }();
+    (void)logged_batchflag_threshold;
+
+    if (mode != MacaCopyMode::Sync) {
+        CallerSync caller_sync;
+        Status sync_status = prepareCallerSync(caller_sync);
+        if (!sync_status.ok()) return sync_status;
+
+        struct DeviceStream {
+            int device_id;
+            cudaStream_t stream;
+            bool ok;
+            bool owned;
+            std::vector<mcCopyFlag_t> copy_batch;
+            std::vector<Slice *> batch_slices;
+        };
+        struct PendingCopy {
+            Slice *slice;
+            size_t stream_index;
+        };
+
+        std::vector<DeviceStream> streams;
+        std::unordered_map<int, size_t> stream_index_by_device;
+        std::vector<PendingCopy> pending_copies;
+        Status first_error = Status::OK();
+        bool has_batchflag_copies = false;
+
+        int original_device = -1;
+        cudaGetDevice(&original_device);
+        int active_copy_device = -1;
+
+        auto getStream = [&](int device_id, cudaStream_t &stream,
+                             size_t &stream_index) -> bool {
+            auto iter = stream_index_by_device.find(device_id);
+            if (iter != stream_index_by_device.end()) {
+                stream_index = iter->second;
+                stream = streams[stream_index].stream;
+                return true;
+            }
+
+            if (!checkCudaErrorReturn(cudaSetDevice(device_id),
+                                      "MacaTransport: failed to set device")) {
+                return false;
+            }
+
+            bool owned = mode == MacaCopyMode::NewStreamSync;
+            cudaStream_t new_stream = nullptr;
+            if (owned) {
+                if (!checkCudaErrorReturn(
+                        cudaStreamCreateWithFlags(&new_stream,
+                                                  cudaStreamNonBlocking),
+                        "MacaTransport: cudaStreamCreateWithFlags failed")) {
+                    return false;
+                }
+            } else {
+                new_stream = thread_local_stream_pool.getOrCreate(device_id);
+                if (!new_stream) return false;
+            }
+
+            if (caller_sync.mode == MacaCallerSyncMode::Wait &&
+                caller_sync.event) {
+                cudaError_t wait_err =
+                    cudaStreamWaitEvent(new_stream, caller_sync.event, 0);
+                if (wait_err != cudaSuccess) {
+                    LOG(ERROR) << "MacaTransport: cudaStreamWaitEvent failed: "
+                               << cudaGetErrorString(wait_err);
+                    if (owned) cudaStreamDestroy(new_stream);
+                    return false;
+                }
+            }
+
+            stream_index = streams.size();
+            streams.push_back({device_id, new_stream, true, owned, {}, {}});
+            stream_index_by_device[device_id] = stream_index;
+            stream = new_stream;
+            return true;
+        };
+
+        for (size_t index = 0; index < task_list.size(); ++index) {
+            assert(task_list[index]);
+            auto &task = *task_list[index];
+            assert(task.request);
+            auto &request = *task.request;
+            uint64_t dest_addr = request.target_offset;
+
+            task.total_bytes = request.length;
+            Slice *slice = getSliceCache().allocate();
+            slice->source_addr = (char *)request.source;
+            slice->length = request.length;
+            slice->opcode = request.opcode;
+            slice->task = &task;
+            slice->target_id = request.target_id;
+            slice->status = Slice::PENDING;
+            slice->ts =
+                globalConfig().slice_timeout > 0 ? getCurrentTimeInNano() : 0;
+            task.slice_list.push_back(slice);
+            __sync_fetch_and_add(&task.slice_count, 1);
+
+            if (request.target_id != LOCAL_SEGMENT_ID) {
+                int rc = relocateSharedMemoryAddress(dest_addr, request.length,
+                                                     request.target_id);
+                if (rc) {
+                    slice->local.dest_addr = nullptr;
+                    slice->markFailed();
+                    if (first_error.ok())
+                        first_error =
+                            Status::Memory("device memory not registered");
+                    continue;
+                }
+            }
+            slice->local.dest_addr = (char *)dest_addr;
+
+            int target_device = getDeviceFromPointer(request.source);
+            if (target_device < 0)
+                target_device = getDeviceFromPointer((void *)dest_addr);
+            if (target_device < 0) {
+                slice->markFailed();
+                if (first_error.ok())
+                    first_error =
+                        Status::InvalidArgument("Cannot infer MACA device");
+                continue;
+            }
+
+            cudaStream_t stream = nullptr;
+            size_t stream_index = 0;
+            if (!getStream(target_device, stream, stream_index)) {
+                slice->markFailed();
+                if (first_error.ok())
+                    first_error = Status::Memory(
+                        "MacaTransport: failed to create MACA stream");
+                continue;
+            }
+
+            if (active_copy_device != target_device) {
+                if (!checkCudaErrorReturn(
+                        cudaSetDevice(target_device),
+                        "MacaTransport: failed to set device")) {
+                    slice->markFailed();
+                    streams[stream_index].ok = false;
+                    if (first_error.ok())
+                        first_error = Status::Context(
+                            "MacaTransport: failed to set device");
+                    continue;
+                }
+                active_copy_device = target_device;
+            }
+
+            if (shouldUseBatchFlag(api, slice->length)) {
+                void *dst;
+                const void *src;
+                getCopyEndpoints(slice, dst, src);
+
+                mcCopyFlag_t copy;
+                std::memset(&copy, 0, sizeof(copy));
+                copy.dst = dst;
+                copy.src = src;
+                copy.engine = ParallelCopyEngineDefault;
+                copy.count = slice->length;
+                copy.waitNum = 0;
+                copy.writeNum = 0;
+
+                streams[stream_index].copy_batch.push_back(copy);
+                streams[stream_index].batch_slices.push_back(slice);
+                slice->local.cuda_stream = (void *)stream;
+                pending_copies.push_back({slice, stream_index});
+                has_batchflag_copies = true;
+                continue;
+            }
+
+            cudaError_t err =
+                submitMemcpyAsync(slice, asyncCopyApi(api), stream);
+            if (err != cudaSuccess) {
+                LOG(ERROR) << "MacaTransport: async copy failed: "
+                           << cudaGetErrorString(err);
+                slice->markFailed();
+                streams[stream_index].ok = false;
+                if (first_error.ok())
+                    first_error =
+                        Status::Memory("MacaTransport: async copy failed");
+            } else {
+                slice->local.cuda_stream = (void *)stream;
+                if (mode == MacaCopyMode::Posted) {
+                    slice->status = Slice::POSTED;
+                } else {
+                    pending_copies.push_back({slice, stream_index});
+                }
+            }
+        }
+
+        if (has_batchflag_copies) {
+            for (auto &entry : streams) {
+                if (entry.copy_batch.empty()) continue;
+                if (!checkCudaErrorReturn(
+                        cudaSetDevice(entry.device_id),
+                        "MacaTransport: failed to set device")) {
+                    entry.ok = false;
+                    continue;
+                }
+
+                cudaError_t err =
+                    submitBatchFlagAsync(entry.copy_batch, entry.stream);
+                if (err != cudaSuccess) {
+                    LOG(ERROR)
+                        << "MacaTransport: mcExtBatchCopyFlagAndWaitV2 failed: "
+                        << cudaGetErrorString(err);
+                    for (auto *slice : entry.batch_slices) {
+                        if (slice->status == Slice::PENDING) {
+                            slice->markFailed();
+                        }
+                    }
+                    if (first_error.ok())
+                        first_error =
+                            Status::Memory("MacaTransport: batch copy failed");
+                }
+            }
+
+            if (mode == MacaCopyMode::Posted) {
+                for (auto &entry : streams) {
+                    if (entry.copy_batch.empty()) continue;
+                    for (auto *slice : entry.batch_slices) {
+                        if (slice->status != Slice::PENDING) continue;
+                        if (entry.ok)
+                            slice->status = Slice::POSTED;
+                        else
+                            slice->markFailed();
+                    }
+                }
+            }
+        }
+
+        if (mode != MacaCopyMode::Posted) {
+            for (auto &entry : streams) {
+                if (!checkCudaErrorReturn(
+                        cudaSetDevice(entry.device_id),
+                        "MacaTransport: failed to set device")) {
+                    entry.ok = false;
+                    continue;
+                }
+                cudaError_t err = cudaStreamSynchronize(entry.stream);
+                if (err != cudaSuccess) {
+                    LOG(ERROR)
+                        << "MacaTransport: cudaStreamSynchronize failed: "
+                        << cudaGetErrorString(err);
+                    entry.ok = false;
+                    if (first_error.ok())
+                        first_error =
+                            Status::Memory("MacaTransport: stream sync failed");
+                }
+            }
+
+            for (auto &pending : pending_copies) {
+                if (pending.slice->status != Slice::PENDING) continue;
+                if (streams[pending.stream_index].ok)
+                    pending.slice->markSuccess();
+                else
+                    pending.slice->markFailed();
+            }
+        }
+
+        for (auto &entry : streams) {
+            if (entry.owned) {
+                cudaSetDevice(entry.device_id);
+                cudaStreamDestroy(entry.stream);
+            }
+        }
+        if (original_device >= 0) cudaSetDevice(original_device);
+        return first_error;
+    }
+
     for (size_t index = 0; index < task_list.size(); ++index) {
         assert(task_list[index]);
         auto &task = *task_list[index];
@@ -360,6 +1002,9 @@ int MacaTransport::registerLocalMemory(void *addr, size_t length,
     desc.length = alloc_size;
     desc.name = location;
     desc.shm_name = serializeBinaryData(&handle, sizeof(cudaIpcMemHandle_t));
+#ifdef ENABLE_MULTI_PROTOCOL
+    desc.protocol = "maca";
+#endif
     int rc = metadata_->addLocalMemoryBuffer(desc, true);
     if (rc == 0) {
         registered_base_addrs_.insert((uint64_t)base_ptr);

--- a/mooncake-transfer-engine/src/transport/maca_transport/maca_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/maca_transport/maca_transport.cpp
@@ -129,15 +129,7 @@ static int getDeviceFromPointer(void *ptr) {
     return -1;
 }
 
-enum class MacaCopyMode {
-    Sync,
-    NewStreamSync,
-    StreamSync,
-    Posted,
-};
-
 enum class MacaCallerSyncMode {
-    None,
     Host,
     Wait,
 };
@@ -145,7 +137,6 @@ enum class MacaCallerSyncMode {
 enum class MacaCopyApi {
     Auto,
     Default,
-    Peer,
     BatchFlag,
 };
 
@@ -154,56 +145,12 @@ struct CallerSync {
     cudaEvent_t event;
 };
 
-static MacaCopyMode copyMode() {
-    static const MacaCopyMode mode = [] {
-        const char *mode_env = std::getenv("MC_MACA_COPY_MODE");
-        if (mode_env) {
-            std::string mode(mode_env);
-            if (mode == "newstream_sync") return MacaCopyMode::NewStreamSync;
-            if (mode == "stream_sync") return MacaCopyMode::StreamSync;
-            if (mode == "posted") return MacaCopyMode::Posted;
-            if (mode == "sync") return MacaCopyMode::Sync;
-            LOG(WARNING) << "MacaTransport: unknown MC_MACA_COPY_MODE=" << mode
-                         << ", falling back to sync";
-            return MacaCopyMode::Sync;
-        }
-
-        const char *async_env = std::getenv("MC_MACA_ASYNC_COPY");
-        if (async_env) {
-            if (std::string(async_env) != "0") return MacaCopyMode::StreamSync;
-            return MacaCopyMode::Sync;
-        }
-        return MacaCopyMode::Posted;
-    }();
-    return mode;
-}
-
-static const char *copyModeName(MacaCopyMode mode) {
-    switch (mode) {
-        case MacaCopyMode::Sync:
-            return "sync";
-        case MacaCopyMode::NewStreamSync:
-            return "newstream_sync";
-        case MacaCopyMode::StreamSync:
-            return "stream_sync";
-        case MacaCopyMode::Posted:
-            return "posted";
-    }
-    return "unknown";
-}
-
 static MacaCallerSyncMode callerSyncMode() {
     static const MacaCallerSyncMode mode = [] {
         const char *env = std::getenv("MC_MACA_CALLER_SYNC");
-        if (!env) {
-            const char *legacy_env = std::getenv("MC_MACA_SYNC_CALLER_STREAM");
-            if (legacy_env && std::string(legacy_env) != "0")
-                return MacaCallerSyncMode::Wait;
-            return MacaCallerSyncMode::Host;
-        }
+        if (!env) return MacaCallerSyncMode::Host;
 
         std::string value(env);
-        if (value == "none" || value == "0") return MacaCallerSyncMode::None;
         if (value == "host") return MacaCallerSyncMode::Host;
         if (value == "wait") return MacaCallerSyncMode::Wait;
         LOG(WARNING) << "MacaTransport: unknown MC_MACA_CALLER_SYNC=" << value
@@ -215,8 +162,6 @@ static MacaCallerSyncMode callerSyncMode() {
 
 static const char *callerSyncModeName(MacaCallerSyncMode mode) {
     switch (mode) {
-        case MacaCallerSyncMode::None:
-            return "none";
         case MacaCallerSyncMode::Host:
             return "host";
         case MacaCallerSyncMode::Wait:
@@ -232,10 +177,8 @@ static MacaCopyApi copyApi() {
 
         std::string value(env);
         if (value == "auto") return MacaCopyApi::Auto;
-        if (value == "default" || value == "0") return MacaCopyApi::Default;
-        if (value == "peer") return MacaCopyApi::Peer;
-        if (value == "batchflag" || value == "batch_flag" || value == "batch")
-            return MacaCopyApi::BatchFlag;
+        if (value == "default") return MacaCopyApi::Default;
+        if (value == "batchflag") return MacaCopyApi::BatchFlag;
         LOG(WARNING) << "MacaTransport: unknown MC_MACA_COPY_API=" << value
                      << ", falling back to auto";
         return MacaCopyApi::Auto;
@@ -249,8 +192,6 @@ static const char *copyApiName(MacaCopyApi api) {
             return "auto";
         case MacaCopyApi::Default:
             return "default";
-        case MacaCopyApi::Peer:
-            return "peer";
         case MacaCopyApi::BatchFlag:
             return "batchflag";
     }
@@ -280,10 +221,6 @@ static bool shouldUseBatchFlag(MacaCopyApi api, size_t length) {
     if (api == MacaCopyApi::BatchFlag) return true;
     if (api == MacaCopyApi::Auto) return length >= batchFlagMinBytes();
     return false;
-}
-
-static MacaCopyApi asyncCopyApi(MacaCopyApi api) {
-    return api == MacaCopyApi::Peer ? MacaCopyApi::Peer : MacaCopyApi::Default;
 }
 
 class PerDeviceStreamPool {
@@ -375,7 +312,6 @@ static thread_local PerDeviceEventPool thread_local_event_pool;
 static Status prepareCallerSync(CallerSync &sync) {
     sync.mode = callerSyncMode();
     sync.event = nullptr;
-    if (sync.mode == MacaCallerSyncMode::None) return Status::OK();
 
     int current_device = 0;
     cudaGetDevice(&current_device);
@@ -414,21 +350,11 @@ static void getCopyEndpoints(Transport::Slice *slice, void *&dst,
     }
 }
 
-static cudaError_t submitMemcpyAsync(Transport::Slice *slice, MacaCopyApi api,
+static cudaError_t submitMemcpyAsync(Transport::Slice *slice,
                                      cudaStream_t stream) {
     void *dst;
     const void *src;
     getCopyEndpoints(slice, dst, src);
-
-    if (api == MacaCopyApi::Peer) {
-        int dst_device = getDeviceFromPointer(dst);
-        int src_device = getDeviceFromPointer(const_cast<void *>(src));
-        if (dst_device >= 0 && src_device >= 0 && dst_device != src_device) {
-            return cudaMemcpyPeerAsync(dst, dst_device, src, src_device,
-                                       slice->length, stream);
-        }
-    }
-
     return cudaMemcpyAsync(dst, src, slice->length, cudaMemcpyDefault, stream);
 }
 
@@ -610,12 +536,6 @@ Status MacaTransport::getTransferStatus(BatchID batch_id, size_t task_id,
 
 Status MacaTransport::submitTransferTask(
     const std::vector<TransferTask *> &task_list) {
-    MacaCopyMode mode = copyMode();
-    static const bool logged_copy_mode = [mode] {
-        LOG(INFO) << "MacaTransport: copy mode " << copyModeName(mode);
-        return true;
-    }();
-    (void)logged_copy_mode;
     MacaCallerSyncMode sync_mode = callerSyncMode();
     static const bool logged_sync_mode = [sync_mode] {
         LOG(INFO) << "MacaTransport: caller sync mode "
@@ -638,285 +558,61 @@ Status MacaTransport::submitTransferTask(
     }();
     (void)logged_batchflag_threshold;
 
-    if (mode != MacaCopyMode::Sync) {
-        CallerSync caller_sync;
-        Status sync_status = prepareCallerSync(caller_sync);
-        if (!sync_status.ok()) return sync_status;
+    CallerSync caller_sync;
+    Status sync_status = prepareCallerSync(caller_sync);
+    if (!sync_status.ok()) return sync_status;
 
-        struct DeviceStream {
-            int device_id;
-            cudaStream_t stream;
-            bool ok;
-            bool owned;
-            std::vector<mcCopyFlag_t> copy_batch;
-            std::vector<Slice *> batch_slices;
-        };
-        struct PendingCopy {
-            Slice *slice;
-            size_t stream_index;
-        };
+    struct DeviceStream {
+        int device_id;
+        cudaStream_t stream;
+        bool ok;
+        std::vector<mcCopyFlag_t> copy_batch;
+        std::vector<Slice *> batch_slices;
+    };
 
-        std::vector<DeviceStream> streams;
-        std::unordered_map<int, size_t> stream_index_by_device;
-        std::vector<PendingCopy> pending_copies;
-        Status first_error = Status::OK();
-        bool has_batchflag_copies = false;
+    std::vector<DeviceStream> streams;
+    std::unordered_map<int, size_t> stream_index_by_device;
+    Status first_error = Status::OK();
+    bool has_batchflag_copies = false;
 
-        int original_device = -1;
-        cudaGetDevice(&original_device);
-        int active_copy_device = -1;
+    int original_device = -1;
+    cudaGetDevice(&original_device);
+    int active_copy_device = -1;
 
-        auto getStream = [&](int device_id, cudaStream_t &stream,
-                             size_t &stream_index) -> bool {
-            auto iter = stream_index_by_device.find(device_id);
-            if (iter != stream_index_by_device.end()) {
-                stream_index = iter->second;
-                stream = streams[stream_index].stream;
-                return true;
-            }
+    auto getStream = [&](int device_id, cudaStream_t &stream,
+                         size_t &stream_index) -> bool {
+        auto iter = stream_index_by_device.find(device_id);
+        if (iter != stream_index_by_device.end()) {
+            stream_index = iter->second;
+            stream = streams[stream_index].stream;
+            return true;
+        }
 
-            if (!checkCudaErrorReturn(cudaSetDevice(device_id),
-                                      "MacaTransport: failed to set device")) {
+        if (!checkCudaErrorReturn(cudaSetDevice(device_id),
+                                  "MacaTransport: failed to set device")) {
+            return false;
+        }
+
+        cudaStream_t new_stream =
+            thread_local_stream_pool.getOrCreate(device_id);
+        if (!new_stream) return false;
+
+        if (caller_sync.mode == MacaCallerSyncMode::Wait && caller_sync.event) {
+            cudaError_t wait_err =
+                cudaStreamWaitEvent(new_stream, caller_sync.event, 0);
+            if (wait_err != cudaSuccess) {
+                LOG(ERROR) << "MacaTransport: cudaStreamWaitEvent failed: "
+                           << cudaGetErrorString(wait_err);
                 return false;
             }
-
-            bool owned = mode == MacaCopyMode::NewStreamSync;
-            cudaStream_t new_stream = nullptr;
-            if (owned) {
-                if (!checkCudaErrorReturn(
-                        cudaStreamCreateWithFlags(&new_stream,
-                                                  cudaStreamNonBlocking),
-                        "MacaTransport: cudaStreamCreateWithFlags failed")) {
-                    return false;
-                }
-            } else {
-                new_stream = thread_local_stream_pool.getOrCreate(device_id);
-                if (!new_stream) return false;
-            }
-
-            if (caller_sync.mode == MacaCallerSyncMode::Wait &&
-                caller_sync.event) {
-                cudaError_t wait_err =
-                    cudaStreamWaitEvent(new_stream, caller_sync.event, 0);
-                if (wait_err != cudaSuccess) {
-                    LOG(ERROR) << "MacaTransport: cudaStreamWaitEvent failed: "
-                               << cudaGetErrorString(wait_err);
-                    if (owned) cudaStreamDestroy(new_stream);
-                    return false;
-                }
-            }
-
-            stream_index = streams.size();
-            streams.push_back({device_id, new_stream, true, owned, {}, {}});
-            stream_index_by_device[device_id] = stream_index;
-            stream = new_stream;
-            return true;
-        };
-
-        for (size_t index = 0; index < task_list.size(); ++index) {
-            assert(task_list[index]);
-            auto &task = *task_list[index];
-            assert(task.request);
-            auto &request = *task.request;
-            uint64_t dest_addr = request.target_offset;
-
-            task.total_bytes = request.length;
-            Slice *slice = getSliceCache().allocate();
-            slice->source_addr = (char *)request.source;
-            slice->length = request.length;
-            slice->opcode = request.opcode;
-            slice->task = &task;
-            slice->target_id = request.target_id;
-            slice->status = Slice::PENDING;
-            slice->ts =
-                globalConfig().slice_timeout > 0 ? getCurrentTimeInNano() : 0;
-            task.slice_list.push_back(slice);
-            __sync_fetch_and_add(&task.slice_count, 1);
-
-            if (request.target_id != LOCAL_SEGMENT_ID) {
-                int rc = relocateSharedMemoryAddress(dest_addr, request.length,
-                                                     request.target_id);
-                if (rc) {
-                    slice->local.dest_addr = nullptr;
-                    slice->markFailed();
-                    if (first_error.ok())
-                        first_error =
-                            Status::Memory("device memory not registered");
-                    continue;
-                }
-            }
-            slice->local.dest_addr = (char *)dest_addr;
-
-            int target_device = getDeviceFromPointer(request.source);
-            if (target_device < 0)
-                target_device = getDeviceFromPointer((void *)dest_addr);
-            if (target_device < 0) {
-                slice->markFailed();
-                if (first_error.ok())
-                    first_error =
-                        Status::InvalidArgument("Cannot infer MACA device");
-                continue;
-            }
-
-            cudaStream_t stream = nullptr;
-            size_t stream_index = 0;
-            if (!getStream(target_device, stream, stream_index)) {
-                slice->markFailed();
-                if (first_error.ok())
-                    first_error = Status::Memory(
-                        "MacaTransport: failed to create MACA stream");
-                continue;
-            }
-
-            if (active_copy_device != target_device) {
-                if (!checkCudaErrorReturn(
-                        cudaSetDevice(target_device),
-                        "MacaTransport: failed to set device")) {
-                    slice->markFailed();
-                    streams[stream_index].ok = false;
-                    if (first_error.ok())
-                        first_error = Status::Context(
-                            "MacaTransport: failed to set device");
-                    continue;
-                }
-                active_copy_device = target_device;
-            }
-
-            if (shouldUseBatchFlag(api, slice->length)) {
-                void *dst;
-                const void *src;
-                getCopyEndpoints(slice, dst, src);
-
-                mcCopyFlag_t copy;
-                std::memset(&copy, 0, sizeof(copy));
-                copy.dst = dst;
-                copy.src = src;
-                copy.engine = ParallelCopyEngineDefault;
-                copy.count = slice->length;
-                copy.waitNum = 0;
-                copy.writeNum = 0;
-
-                streams[stream_index].copy_batch.push_back(copy);
-                streams[stream_index].batch_slices.push_back(slice);
-                slice->local.cuda_stream = (void *)stream;
-                pending_copies.push_back({slice, stream_index});
-                has_batchflag_copies = true;
-                continue;
-            }
-
-            cudaError_t err =
-                submitMemcpyAsync(slice, asyncCopyApi(api), stream);
-            if (err != cudaSuccess) {
-                LOG(ERROR) << "MacaTransport: async copy failed: "
-                           << cudaGetErrorString(err);
-                slice->markFailed();
-                streams[stream_index].ok = false;
-                if (first_error.ok())
-                    first_error =
-                        Status::Memory("MacaTransport: async copy failed");
-            } else {
-                slice->local.cuda_stream = (void *)stream;
-                if (mode == MacaCopyMode::Posted) {
-                    slice->status = Slice::POSTED;
-                } else {
-                    pending_copies.push_back({slice, stream_index});
-                }
-            }
         }
 
-        if (has_batchflag_copies) {
-            auto failBatchSlices = [](DeviceStream &entry) {
-                for (auto *slice : entry.batch_slices) {
-                    if (slice->status == Slice::PENDING) {
-                        slice->markFailed();
-                    }
-                }
-            };
-            for (auto &entry : streams) {
-                if (entry.copy_batch.empty()) continue;
-                if (!entry.ok) {
-                    failBatchSlices(entry);
-                    if (first_error.ok())
-                        first_error =
-                            Status::Memory("MacaTransport: batch copy skipped");
-                    continue;
-                }
-                if (!checkCudaErrorReturn(
-                        cudaSetDevice(entry.device_id),
-                        "MacaTransport: failed to set device")) {
-                    entry.ok = false;
-                    failBatchSlices(entry);
-                    if (first_error.ok())
-                        first_error = Status::Context(
-                            "MacaTransport: failed to set device");
-                    continue;
-                }
-
-                cudaError_t err =
-                    submitBatchFlagAsync(entry.copy_batch, entry.stream);
-                if (err != cudaSuccess) {
-                    LOG(ERROR)
-                        << "MacaTransport: mcExtBatchCopyFlagAndWaitV2 failed: "
-                        << cudaGetErrorString(err);
-                    failBatchSlices(entry);
-                    if (first_error.ok())
-                        first_error =
-                            Status::Memory("MacaTransport: batch copy failed");
-                }
-            }
-
-            if (mode == MacaCopyMode::Posted) {
-                for (auto &entry : streams) {
-                    if (entry.copy_batch.empty()) continue;
-                    for (auto *slice : entry.batch_slices) {
-                        if (slice->status != Slice::PENDING) continue;
-                        if (entry.ok)
-                            slice->status = Slice::POSTED;
-                        else
-                            slice->markFailed();
-                    }
-                }
-            }
-        }
-
-        if (mode != MacaCopyMode::Posted) {
-            for (auto &entry : streams) {
-                if (!checkCudaErrorReturn(
-                        cudaSetDevice(entry.device_id),
-                        "MacaTransport: failed to set device")) {
-                    entry.ok = false;
-                    continue;
-                }
-                cudaError_t err = cudaStreamSynchronize(entry.stream);
-                if (err != cudaSuccess) {
-                    LOG(ERROR)
-                        << "MacaTransport: cudaStreamSynchronize failed: "
-                        << cudaGetErrorString(err);
-                    entry.ok = false;
-                    if (first_error.ok())
-                        first_error =
-                            Status::Memory("MacaTransport: stream sync failed");
-                }
-            }
-
-            for (auto &pending : pending_copies) {
-                if (pending.slice->status != Slice::PENDING) continue;
-                if (streams[pending.stream_index].ok)
-                    pending.slice->markSuccess();
-                else
-                    pending.slice->markFailed();
-            }
-        }
-
-        for (auto &entry : streams) {
-            if (entry.owned) {
-                cudaSetDevice(entry.device_id);
-                cudaStreamDestroy(entry.stream);
-            }
-        }
-        if (original_device >= 0) cudaSetDevice(original_device);
-        return first_error;
-    }
+        stream_index = streams.size();
+        streams.push_back({device_id, new_stream, true, {}, {}});
+        stream_index_by_device[device_id] = stream_index;
+        stream = new_stream;
+        return true;
+    };
 
     for (size_t index = 0; index < task_list.size(); ++index) {
         assert(task_list[index]);
@@ -924,46 +620,160 @@ Status MacaTransport::submitTransferTask(
         assert(task.request);
         auto &request = *task.request;
         uint64_t dest_addr = request.target_offset;
-        if (request.target_id != LOCAL_SEGMENT_ID) {
-            int rc = relocateSharedMemoryAddress(dest_addr, request.length,
-                                                 request.target_id);
-            if (rc) return Status::Memory("device memory not registered");
-        }
+
         task.total_bytes = request.length;
         Slice *slice = getSliceCache().allocate();
         slice->source_addr = (char *)request.source;
-        slice->local.dest_addr = (char *)dest_addr;
         slice->length = request.length;
         slice->opcode = request.opcode;
         slice->task = &task;
         slice->target_id = request.target_id;
         slice->status = Slice::PENDING;
+        slice->ts =
+            globalConfig().slice_timeout > 0 ? getCurrentTimeInNano() : 0;
         task.slice_list.push_back(slice);
         __sync_fetch_and_add(&task.slice_count, 1);
 
-        // Set correct device context before memcpy
-        int original_device = -1;
-        cudaGetDevice(&original_device);
+        if (request.target_id != LOCAL_SEGMENT_ID) {
+            int rc = relocateSharedMemoryAddress(dest_addr, request.length,
+                                                 request.target_id);
+            if (rc) {
+                slice->local.dest_addr = nullptr;
+                slice->markFailed();
+                if (first_error.ok())
+                    first_error =
+                        Status::Memory("device memory not registered");
+                continue;
+            }
+        }
+        slice->local.dest_addr = (char *)dest_addr;
+
         int target_device = getDeviceFromPointer(request.source);
         if (target_device < 0)
             target_device = getDeviceFromPointer((void *)dest_addr);
-        if (target_device >= 0) cudaSetDevice(target_device);
-
-        cudaError_t err;
-        if (slice->opcode == TransferRequest::READ)
-            err = cudaMemcpy(slice->source_addr, (void *)slice->local.dest_addr,
-                             slice->length, cudaMemcpyDefault);
-        else
-            err = cudaMemcpy((void *)slice->local.dest_addr, slice->source_addr,
-                             slice->length, cudaMemcpyDefault);
-        if (err != cudaSuccess)
+        if (target_device < 0) {
             slice->markFailed();
-        else
-            slice->markSuccess();
+            if (first_error.ok())
+                first_error =
+                    Status::InvalidArgument("Cannot infer MACA device");
+            continue;
+        }
 
-        if (original_device >= 0) cudaSetDevice(original_device);
+        cudaStream_t stream = nullptr;
+        size_t stream_index = 0;
+        if (!getStream(target_device, stream, stream_index)) {
+            slice->markFailed();
+            if (first_error.ok())
+                first_error =
+                    Status::Memory("MacaTransport: failed to get MACA stream");
+            continue;
+        }
+
+        if (active_copy_device != target_device) {
+            if (!checkCudaErrorReturn(cudaSetDevice(target_device),
+                                      "MacaTransport: failed to set device")) {
+                slice->markFailed();
+                streams[stream_index].ok = false;
+                if (first_error.ok())
+                    first_error =
+                        Status::Context("MacaTransport: failed to set device");
+                continue;
+            }
+            active_copy_device = target_device;
+        }
+
+        if (shouldUseBatchFlag(api, slice->length)) {
+            void *dst;
+            const void *src;
+            getCopyEndpoints(slice, dst, src);
+
+            mcCopyFlag_t copy;
+            std::memset(&copy, 0, sizeof(copy));
+            copy.dst = dst;
+            copy.src = src;
+            copy.engine = ParallelCopyEngineDefault;
+            copy.count = slice->length;
+            copy.waitNum = 0;
+            copy.writeNum = 0;
+
+            streams[stream_index].copy_batch.push_back(copy);
+            streams[stream_index].batch_slices.push_back(slice);
+            slice->local.cuda_stream = (void *)stream;
+            has_batchflag_copies = true;
+            continue;
+        }
+
+        cudaError_t err = submitMemcpyAsync(slice, stream);
+        if (err != cudaSuccess) {
+            LOG(ERROR) << "MacaTransport: async copy failed: "
+                       << cudaGetErrorString(err);
+            slice->markFailed();
+            streams[stream_index].ok = false;
+            if (first_error.ok())
+                first_error =
+                    Status::Memory("MacaTransport: async copy failed");
+        } else {
+            slice->local.cuda_stream = (void *)stream;
+            slice->status = Slice::POSTED;
+        }
     }
-    return Status::OK();
+
+    if (has_batchflag_copies) {
+        auto failBatchSlices = [](DeviceStream &entry) {
+            for (auto *slice : entry.batch_slices) {
+                if (slice->status == Slice::PENDING) {
+                    slice->markFailed();
+                }
+            }
+        };
+
+        for (auto &entry : streams) {
+            if (entry.copy_batch.empty()) continue;
+            if (!entry.ok) {
+                failBatchSlices(entry);
+                if (first_error.ok())
+                    first_error =
+                        Status::Memory("MacaTransport: batch copy skipped");
+                continue;
+            }
+            if (!checkCudaErrorReturn(cudaSetDevice(entry.device_id),
+                                      "MacaTransport: failed to set device")) {
+                entry.ok = false;
+                failBatchSlices(entry);
+                if (first_error.ok())
+                    first_error =
+                        Status::Context("MacaTransport: failed to set device");
+                continue;
+            }
+
+            cudaError_t err =
+                submitBatchFlagAsync(entry.copy_batch, entry.stream);
+            if (err != cudaSuccess) {
+                LOG(ERROR)
+                    << "MacaTransport: mcExtBatchCopyFlagAndWaitV2 failed: "
+                    << cudaGetErrorString(err);
+                entry.ok = false;
+                failBatchSlices(entry);
+                if (first_error.ok())
+                    first_error =
+                        Status::Memory("MacaTransport: batch copy failed");
+            }
+        }
+
+        for (auto &entry : streams) {
+            if (entry.copy_batch.empty()) continue;
+            for (auto *slice : entry.batch_slices) {
+                if (slice->status != Slice::PENDING) continue;
+                if (entry.ok)
+                    slice->status = Slice::POSTED;
+                else
+                    slice->markFailed();
+            }
+        }
+    }
+
+    if (original_device >= 0) cudaSetDevice(original_device);
+    return first_error;
 }
 
 int MacaTransport::registerLocalMemory(void *addr, size_t length,

--- a/mooncake-transfer-engine/src/transport/maca_transport/maca_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/maca_transport/maca_transport.cpp
@@ -514,6 +514,8 @@ Status MacaTransport::submitTransfer(
     for (auto &request : entries) {
         TransferTask &task = batch_desc.task_list[task_id];
         ++task_id;
+        task.batch_id = batch_id;
+        task.transport_ = this;
         uint64_t dest_addr = request.target_offset;
         if (request.target_id != LOCAL_SEGMENT_ID) {
             int rc = relocateSharedMemoryAddress(dest_addr, request.length,
@@ -823,12 +825,30 @@ Status MacaTransport::submitTransferTask(
         }
 
         if (has_batchflag_copies) {
+            auto failBatchSlices = [](DeviceStream &entry) {
+                for (auto *slice : entry.batch_slices) {
+                    if (slice->status == Slice::PENDING) {
+                        slice->markFailed();
+                    }
+                }
+            };
             for (auto &entry : streams) {
                 if (entry.copy_batch.empty()) continue;
+                if (!entry.ok) {
+                    failBatchSlices(entry);
+                    if (first_error.ok())
+                        first_error =
+                            Status::Memory("MacaTransport: batch copy skipped");
+                    continue;
+                }
                 if (!checkCudaErrorReturn(
                         cudaSetDevice(entry.device_id),
                         "MacaTransport: failed to set device")) {
                     entry.ok = false;
+                    failBatchSlices(entry);
+                    if (first_error.ok())
+                        first_error = Status::Context(
+                            "MacaTransport: failed to set device");
                     continue;
                 }
 
@@ -838,11 +858,7 @@ Status MacaTransport::submitTransferTask(
                     LOG(ERROR)
                         << "MacaTransport: mcExtBatchCopyFlagAndWaitV2 failed: "
                         << cudaGetErrorString(err);
-                    for (auto *slice : entry.batch_slices) {
-                        if (slice->status == Slice::PENDING) {
-                            slice->markFailed();
-                        }
-                    }
+                    failBatchSlices(entry);
                     if (first_error.ok())
                         first_error =
                             Status::Memory("MacaTransport: batch copy failed");


### PR DESCRIPTION
## Description

This PR optimizes the MACA intra-node P2P copy path for Metax C500 and fixes
the caller-stream dependency in `maca_transport`.

The optimized path keeps the MACA transport on a single posted async copy model:
copies are submitted asynchronously on pooled transfer streams, slices are marked
posted after submission, and completion is polled with `mcStreamQuery`. For large
copies, the default `auto` mode uses `mcExtBatchCopyFlagAndWaitV2`; smaller
copies stay on regular `mcMemcpyAsync`.

The PR also trims the tuning surface that was used during exploration. The
unsafe `caller_sync=none` mode and the temporary sync / stream-sync /
new-stream-sync copy modes were removed from the transport, so the production
path only keeps the modes that passed correctness validation.

Key changes:

- Use posted async MACA copy submission with completion polling through
  `mcStreamQuery`.
- Add safe caller-stream synchronization before transfer submission.
- Use `mcExtBatchCopyFlagAndWaitV2` automatically for copies at or above the
  configured threshold.
- Keep only the production tuning knobs:
  - `MC_MACA_COPY_API=auto|default|batchflag`
  - `MC_MACA_CALLER_SYNC=host|wait`
  - `MC_MACA_BATCHFLAG_MIN_BYTES`
- Remove exploration-only knobs and aliases:
  - `MC_MACA_COPY_MODE`
  - `MC_MACA_ASYNC_COPY`
  - `MC_MACA_SYNC_CALLER_STREAM`
  - `caller_sync=none`
  - `copy_api=peer`
  - sync / stream-sync / new-stream-sync copy modes
- Initialize `task.batch_id` and `task.transport_` in `submitTransfer`.
- Skip batchflag submission when an entry has already failed, and fail pending
  slices explicitly on batchflag setup or submission errors.

This is a follow-up optimization for the standalone MACA transport added in
#2059.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Performance improvement
- [ ] Other

## How Has This Been Tested?

### Build and Static Checks

```bash
cmake --build build-maca-te --target maca_transport -j32
cmake --build build-maca-te --target transfer_engine_validator -j32
git diff --check -- mooncake-transfer-engine/src/transport/maca_transport/maca_transport.cpp
```

`./scripts/code_format.sh --check` could not be completed in the local test
environment because `clang-format-20` was not installed. `pre-commit` was also
not installed in the local test environment.

### Generic TE Validator Commands

Start a target process:

```bash
build-maca-te/example/transfer_engine_validator \
  --mode=target \
  --protocol=maca \
  --metadata_server=P2PHANDSHAKE \
  --local_server_name=127.0.0.1:15908 \
  --segment_id=127.0.0.1:15908 \
  --gpu_id=1 \
  --buffer_size=4294967296 \
  --block_size=1048576 \
  --batch_size=128 \
  --threads=4 \
  --duration=5 \
  --logtostderr=1
```

Run the default optimized path from another shell:

```bash
build-maca-te/example/transfer_engine_validator \
  --mode=initiator \
  --protocol=maca \
  --metadata_server=P2PHANDSHAKE \
  --local_server_name=127.0.0.1:15909 \
  --segment_id=127.0.0.1:15908 \
  --gpu_id=0 \
  --buffer_size=4294967296 \
  --block_size=1048576 \
  --batch_size=128 \
  --threads=4 \
  --duration=5 \
  --report_unit=GB \
  --logtostderr=1
```

Force regular `mcMemcpyAsync` for comparison:

```bash
MC_MACA_COPY_API=default build-maca-te/example/transfer_engine_validator \
  --mode=initiator \
  --protocol=maca \
  --metadata_server=P2PHANDSHAKE \
  --local_server_name=127.0.0.1:15909 \
  --segment_id=127.0.0.1:15908 \
  --gpu_id=0 \
  --buffer_size=4294967296 \
  --block_size=1048576 \
  --batch_size=128 \
  --threads=4 \
  --duration=5 \
  --report_unit=GB \
  --logtostderr=1
```

Force batchflag copy for comparison:

```bash
MC_MACA_COPY_API=batchflag build-maca-te/example/transfer_engine_validator \
  --mode=initiator \
  --protocol=maca \
  --metadata_server=P2PHANDSHAKE \
  --local_server_name=127.0.0.1:15909 \
  --segment_id=127.0.0.1:15908 \
  --gpu_id=0 \
  --buffer_size=4294967296 \
  --block_size=1048576 \
  --batch_size=128 \
  --threads=4 \
  --duration=5 \
  --report_unit=GB \
  --logtostderr=1
```

Validate the alternative safe caller-sync mode:

```bash
MC_MACA_CALLER_SYNC=wait build-maca-te/example/transfer_engine_validator \
  --mode=initiator \
  --protocol=maca \
  --metadata_server=P2PHANDSHAKE \
  --local_server_name=127.0.0.1:15909 \
  --segment_id=127.0.0.1:15908 \
  --gpu_id=0 \
  --buffer_size=4294967296 \
  --block_size=4194304 \
  --batch_size=16 \
  --threads=4 \
  --duration=5 \
  --report_unit=GB \
  --logtostderr=1
```

### Test Results

Test setup:

- Protocol: `maca`
- Metadata mode: `P2PHANDSHAKE`
- Direction: GPU0 initiator to GPU1 target
- Buffer size: 4GiB
- Report unit: GB
- All listed TE validator runs reported `Data validation passed`.

Performance after trimming the tuning surface:

| Mode | Block / Batch / Threads | Duration | Throughput |
| --- | ---: | ---: | ---: |
| default `auto+host` | 1MiB / 128 / 4 | 5s | 64.51 GB/s |
| default `auto+host` | 4MiB / 16 / 4 | 5s | 65.66 GB/s |
| default `auto+host` | 8MiB / 16 / 4 | 5s | 65.86 GB/s |
| default `auto+host` | 16MiB / 16 / 4 | 5s | 65.67 GB/s |
| `MC_MACA_COPY_API=default` | 1MiB / 128 / 4 | 5s | 29.86 GB/s |
| `MC_MACA_COPY_API=batchflag` | 1MiB / 128 / 4 | 5s | 59.55 GB/s |
| `MC_MACA_CALLER_SYNC=wait` | 4MiB / 16 / 4 | 5s | 67.06 GB/s |

Correctness notes:

- The standalone caller-stream probe showed that no caller-stream sync can read
  stale producer-stream data, so `caller_sync=none` was removed from the
  transport.
- Both retained caller sync modes, `host` and `wait`, passed data validation.
- One invalid parallel benchmark run was excluded because two initiators wrote
  to the same target buffer concurrently; the affected size was rerun
  sequentially and passed validation.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (Codex was used to help inspect the code path, draft
  the PR text, and organize validation notes; the submitter reviewed the final
  changes).