### PR TITLE
store: reattach local disk replicas after restart

### DIFF
--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -411,7 +411,9 @@ class Client {
      * @brief Mounts a local disk segment into the master.
      * @param enable_offloading If true, enables offloading (write-to-file).
      */
-    tl::expected<void, ErrorCode> MountLocalDiskSegment(bool enable_offloading);
+    tl::expected<void, ErrorCode> MountLocalDiskSegment(
+        bool enable_offloading, const std::string& local_disk_segment_id = {},
+        const std::string& transport_endpoint = {});
 
     /**
      * @brief Heartbeat call to collect object-level statistics and retrieve the

--- a/mooncake-store/include/master_client.h
+++ b/mooncake-store/include/master_client.h
@@ -420,7 +420,9 @@ class MasterClient {
      * @param enable_offloading If true, enables offloading (write-to-file).
      */
     [[nodiscard]] tl::expected<void, ErrorCode> MountLocalDiskSegment(
-        const UUID& client_id, bool enable_offloading);
+        const UUID& client_id, bool enable_offloading,
+        const std::string& local_disk_segment_id = {},
+        const std::string& transport_endpoint = {});
 
     /**
      * @brief Heartbeat call to collect object-level statistics and retrieve the

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -45,6 +45,7 @@ struct MasterConfig {
     double nof_eviction_ratio;
     double nof_eviction_high_watermark_ratio;
     int64_t client_live_ttl_sec;
+    int64_t local_disk_rejoin_grace_sec;
     int64_t nof_heartbeat_interval_sec;
     uint32_t nof_heartbeat_probe_timeout_ms;
     uint32_t nof_heartbeat_failures_threshold;
@@ -164,6 +165,7 @@ class MasterServiceSupervisorConfig {
     RequiredParam<double> nof_eviction_high_watermark_ratio{
         "nof_eviction_high_watermark_ratio"};
     RequiredParam<int64_t> client_live_ttl_sec{"client_live_ttl_sec"};
+    int64_t local_disk_rejoin_grace_sec = 600;
     RequiredParam<int64_t> nof_heartbeat_interval_sec{
         "nof_heartbeat_interval_sec"};
     RequiredParam<uint32_t> nof_heartbeat_probe_timeout_ms{
@@ -266,6 +268,7 @@ class MasterServiceSupervisorConfig {
         nof_eviction_high_watermark_ratio =
             config.nof_eviction_high_watermark_ratio;
         client_live_ttl_sec = config.client_live_ttl_sec;
+        local_disk_rejoin_grace_sec = config.local_disk_rejoin_grace_sec;
         nof_heartbeat_interval_sec = config.nof_heartbeat_interval_sec;
         nof_heartbeat_probe_timeout_ms = config.nof_heartbeat_probe_timeout_ms;
         nof_heartbeat_failures_threshold =
@@ -426,6 +429,7 @@ class WrappedMasterServiceConfig {
         DEFAULT_NOF_EVICTION_HIGH_WATERMARK_RATIO;
     ViewVersionId view_version = 0;
     int64_t client_live_ttl_sec = DEFAULT_CLIENT_LIVE_TTL_SEC;
+    int64_t local_disk_rejoin_grace_sec = 600;
     int64_t nof_heartbeat_interval_sec = DEFAULT_NOF_HEARTBEAT_INTERVAL_SEC;
     uint32_t nof_heartbeat_probe_timeout_ms =
         DEFAULT_NOF_HEARTBEAT_PROBE_TIMEOUT_MS;
@@ -512,6 +516,7 @@ class WrappedMasterServiceConfig {
             config.nof_eviction_high_watermark_ratio;
         view_version = view_version_param;
         client_live_ttl_sec = config.client_live_ttl_sec;
+        local_disk_rejoin_grace_sec = config.local_disk_rejoin_grace_sec;
         nof_heartbeat_interval_sec = config.nof_heartbeat_interval_sec;
         nof_heartbeat_probe_timeout_ms = config.nof_heartbeat_probe_timeout_ms;
         nof_heartbeat_failures_threshold =
@@ -624,6 +629,7 @@ class WrappedMasterServiceConfig {
             config.nof_eviction_high_watermark_ratio;
         view_version = view_version_param;
         client_live_ttl_sec = config.client_live_ttl_sec;
+        local_disk_rejoin_grace_sec = config.local_disk_rejoin_grace_sec;
         enable_ha =
             true;  // This is used in HA mode, so enable_ha should be true
         enable_offload = config.enable_offload;
@@ -704,6 +710,7 @@ class MasterServiceConfigBuilder {
         DEFAULT_NOF_EVICTION_HIGH_WATERMARK_RATIO;
     ViewVersionId view_version_ = 0;
     int64_t client_live_ttl_sec_ = DEFAULT_CLIENT_LIVE_TTL_SEC;
+    int64_t local_disk_rejoin_grace_sec_ = 600;
     int64_t nof_heartbeat_interval_sec_ = DEFAULT_NOF_HEARTBEAT_INTERVAL_SEC;
     uint32_t nof_heartbeat_probe_timeout_ms_ =
         DEFAULT_NOF_HEARTBEAT_PROBE_TIMEOUT_MS;
@@ -795,6 +802,11 @@ class MasterServiceConfigBuilder {
 
     MasterServiceConfigBuilder& set_client_live_ttl_sec(int64_t ttl) {
         client_live_ttl_sec_ = ttl;
+        return *this;
+    }
+
+    MasterServiceConfigBuilder& set_local_disk_rejoin_grace_sec(int64_t ttl) {
+        local_disk_rejoin_grace_sec_ = ttl;
         return *this;
     }
 
@@ -1042,6 +1054,7 @@ class MasterServiceConfig {
         DEFAULT_NOF_EVICTION_HIGH_WATERMARK_RATIO;
     ViewVersionId view_version = 0;
     int64_t client_live_ttl_sec = DEFAULT_CLIENT_LIVE_TTL_SEC;
+    int64_t local_disk_rejoin_grace_sec = 600;
     int64_t nof_heartbeat_interval_sec = DEFAULT_NOF_HEARTBEAT_INTERVAL_SEC;
     uint32_t nof_heartbeat_probe_timeout_ms =
         DEFAULT_NOF_HEARTBEAT_PROBE_TIMEOUT_MS;
@@ -1124,6 +1137,7 @@ class MasterServiceConfig {
             config.nof_eviction_high_watermark_ratio;
         view_version = config.view_version;
         client_live_ttl_sec = config.client_live_ttl_sec;
+        local_disk_rejoin_grace_sec = config.local_disk_rejoin_grace_sec;
         nof_heartbeat_interval_sec = config.nof_heartbeat_interval_sec;
         nof_heartbeat_probe_timeout_ms = config.nof_heartbeat_probe_timeout_ms;
         nof_heartbeat_failures_threshold =
@@ -1210,6 +1224,7 @@ inline MasterServiceConfig MasterServiceConfigBuilder::build() const {
         nof_eviction_high_watermark_ratio_;
     config.view_version = view_version_;
     config.client_live_ttl_sec = client_live_ttl_sec_;
+    config.local_disk_rejoin_grace_sec = local_disk_rejoin_grace_sec_;
     config.nof_heartbeat_interval_sec = nof_heartbeat_interval_sec_;
     config.nof_heartbeat_probe_timeout_ms = nof_heartbeat_probe_timeout_ms_;
     config.nof_heartbeat_failures_threshold = nof_heartbeat_failures_threshold_;

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -632,7 +632,9 @@ class MasterService {
      * @brief Mounts a file storage segment into the master.
      * @param enable_offloading If true, enables offloading (write-to-file).
      */
-    auto MountLocalDiskSegment(const UUID& client_id, bool enable_offloading)
+    auto MountLocalDiskSegment(const UUID& client_id, bool enable_offloading,
+                               const std::string& local_disk_segment_id = {},
+                               const std::string& transport_endpoint = {})
         -> tl::expected<void, ErrorCode>;
 
     /**
@@ -1244,6 +1246,7 @@ class MasterService {
 
     static bool HasCompletedMemoryCacheReplica(const ObjectMetadata& metadata);
     static bool HasCompletedDiskCacheReplica(const ObjectMetadata& metadata);
+    static bool HasCompletedLocalDiskReplica(const ObjectMetadata& metadata);
     static void SyncCacheTotalAccounting(ObjectMetadata& metadata);
     void RebuildCacheTotalAccounting();
     static void AccountCacheTotalRemoval(ObjectMetadata& metadata);
@@ -1255,6 +1258,7 @@ class MasterService {
     size_t EraseReplicasWithCacheTotalAccounting(
         ObjectMetadata& metadata,
         const std::function<bool(const Replica&)>& pred_fn);
+    size_t EraseDisconnectedLocalDiskReplicas(ObjectMetadata& metadata);
 
     static constexpr size_t kNumTenantQuotaShards = 1024;
     struct TenantQuotaShard {
@@ -1407,6 +1411,7 @@ class MasterService {
         std::unordered_map<std::string, ObjectMetadata>::iterator it,
         const std::string& tenant_id);
     void ReleaseLocalDiskUsage(const std::vector<Replica>& replicas);
+    void AddLocalDiskUsage(const UUID& client_id, int64_t bytes);
     enum class QuotaEraseMode {
         kFull,
         kPreserveOld,
@@ -1459,6 +1464,10 @@ class MasterService {
         ObjectMetadata& metadata,
         const std::unordered_set<UUID, boost::hash<UUID>>& alive_clients,
         MetadataShardAccessorRW* shard = nullptr);
+
+    size_t ReattachDisconnectedLocalDiskReplicas(
+        const std::string& local_disk_segment_id, const UUID& new_client_id,
+        const std::string& transport_endpoint);
 
     // Helper: allocate replicas, create ObjectMetadata, insert into shard,
     // and return descriptor list.  Shared by PutStart and UpsertStart.
@@ -1884,6 +1893,8 @@ class MasterService {
         128 * 1024;  // Size of the client ping queue
     boost::lockfree::queue<PodUUID> client_ping_queue_{kClientPingQueueSize};
     const int64_t client_live_ttl_sec_;
+    const std::chrono::seconds local_disk_rejoin_grace_period_;
+    std::atomic<size_t> disconnected_local_disk_replica_count_{0};
     const std::chrono::seconds nof_heartbeat_interval_sec_;
     const std::chrono::milliseconds nof_heartbeat_probe_timeout_ms_;
     const uint32_t nof_heartbeat_failures_threshold_;

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1463,7 +1463,9 @@ class MasterService {
     bool CleanupStaleHandles(
         ObjectMetadata& metadata,
         const std::unordered_set<UUID, boost::hash<UUID>>& alive_clients,
-        MetadataShardAccessorRW* shard = nullptr);
+        MetadataShardAccessorRW* shard, TenantState& tenant_state,
+        const std::string& key, const std::string& tenant_id,
+        bool* local_disk_disconnected = nullptr);
 
     size_t ReattachDisconnectedLocalDiskReplicas(
         const std::string& local_disk_segment_id, const UUID& new_client_id,
@@ -1532,22 +1534,13 @@ class MasterService {
      */
     void TryPushPromotionQueue(const ObjectIdentity& object_id);
 
-    // Erase any in-flight PromotionTask for `key`, abort any staged promotion
-    // quota reservation, and decrement the cluster-wide in-flight counter. Safe
-    // no-op if no task exists.
+    // Erase any in-flight PromotionTask for `key`, release pinned replicas,
+    // abort any staged promotion quota reservation, and decrement the
+    // cluster-wide in-flight counter. Safe no-op if no task exists.
     void ErasePromotionTaskIfPresent(
         TenantState& tenant_state, const std::string& key,
-        const std::string& tenant_id) NO_THREAD_SAFETY_ANALYSIS {
-        auto task_it = tenant_state.promotion_tasks.find(key);
-        if (task_it != tenant_state.promotion_tasks.end()) {
-            AbortTenantQuota(tenant_id,
-                             task_it->second.reserved_quota_charge_bytes);
-            tenant_state.promotion_tasks.erase(task_it);
-            promotion_in_flight_.fetch_sub(1, std::memory_order_relaxed);
-            MasterMetricManager::instance().dec_promotion_in_flight();
-            MasterMetricManager::instance().inc_promotion_cancelled();
-        }
-    }
+        const std::string& tenant_id,
+        ObjectMetadata* metadata = nullptr) NO_THREAD_SAFETY_ANALYSIS;
 
     // Lease related members
     const uint64_t default_kv_lease_ttl_;     // in milliseconds

--- a/mooncake-store/include/replica.h
+++ b/mooncake-store/include/replica.h
@@ -5,6 +5,7 @@
 #include <boost/functional/hash.hpp>
 
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -53,6 +54,7 @@ enum class ReplicaStatus {
     INITIALIZED,    // Space allocated, waiting for write
     PROCESSING,     // Write in progress
     COMPLETE,       // Write complete, replica is available
+    DISCONNECTED,   // Local disk replica retained but owner client is offline
     REMOVED,        // Replica has been removed
     FAILED,         // Failed state (can be used for reassignment)
 };
@@ -67,6 +69,7 @@ inline std::ostream& operator<<(std::ostream& os,
                        {ReplicaStatus::INITIALIZED, "INITIALIZED"},
                        {ReplicaStatus::PROCESSING, "PROCESSING"},
                        {ReplicaStatus::COMPLETE, "COMPLETE"},
+                       {ReplicaStatus::DISCONNECTED, "DISCONNECTED"},
                        {ReplicaStatus::REMOVED, "REMOVED"},
                        {ReplicaStatus::FAILED, "FAILED"}};
 
@@ -181,6 +184,8 @@ struct LocalDiskReplicaData {
     UUID client_id;
     uint64_t object_size = 0;
     std::string transport_endpoint;
+    std::string local_disk_segment_id;
+    std::chrono::steady_clock::time_point disconnected_at{};
 };
 
 struct MemoryDescriptor {
@@ -203,7 +208,9 @@ struct LocalDiskDescriptor {
     UUID client_id;
     uint64_t object_size = 0;
     std::string transport_endpoint;
-    YLT_REFL(LocalDiskDescriptor, client_id, object_size, transport_endpoint);
+    std::string local_disk_segment_id;
+    YLT_REFL(LocalDiskDescriptor, client_id, object_size, transport_endpoint,
+             local_disk_segment_id);
 };
 
 class Replica {
@@ -242,10 +249,14 @@ class Replica {
 
     // local disk replica constructor
     Replica(UUID client_id, uint64_t object_size,
-            std::string transport_endpoint, ReplicaStatus status)
+            std::string transport_endpoint, ReplicaStatus status,
+            std::string local_disk_segment_id = {})
         : id_(next_id_.fetch_add(1)),
-          data_(LocalDiskReplicaData{client_id, object_size,
-                                     std::move(transport_endpoint)}),
+          data_(LocalDiskReplicaData{client_id,
+                                     object_size,
+                                     std::move(transport_endpoint),
+                                     std::move(local_disk_segment_id),
+                                     {}}),
           status_(status),
           refcnt_(0) {
         MasterMetricManager::instance().inc_allocated_file_size(object_size);
@@ -428,13 +439,72 @@ class Replica {
         const;
 
     void mark_complete() {
-        if (status_ == ReplicaStatus::PROCESSING) {
+        if (status_ == ReplicaStatus::PROCESSING ||
+            status_ == ReplicaStatus::DISCONNECTED) {
             status_ = ReplicaStatus::COMPLETE;
         } else if (status_ == ReplicaStatus::COMPLETE) {
             LOG(WARNING) << "Replica already marked as complete";
         } else {
             LOG(ERROR) << "Invalid replica status: " << status_;
         }
+    }
+
+    void mark_disconnected() {
+        if (status_ == ReplicaStatus::COMPLETE && is_local_disk_replica()) {
+            status_ = ReplicaStatus::DISCONNECTED;
+            std::get<LocalDiskReplicaData>(data_).disconnected_at =
+                std::chrono::steady_clock::now();
+        } else if (status_ != ReplicaStatus::DISCONNECTED) {
+            LOG(ERROR) << "Cannot mark_disconnected from status: " << status_;
+        }
+    }
+
+    void update_local_disk_owner(const UUID& client_id,
+                                 std::string transport_endpoint) {
+        if (!is_local_disk_replica()) {
+            LOG(ERROR) << "Cannot update local disk owner on type: " << type();
+            return;
+        }
+        auto& disk_data = std::get<LocalDiskReplicaData>(data_);
+        disk_data.client_id = client_id;
+        disk_data.transport_endpoint = std::move(transport_endpoint);
+        disk_data.disconnected_at = {};
+    }
+
+    void update_local_disk_metadata(uint64_t object_size,
+                                    std::string transport_endpoint,
+                                    std::string local_disk_segment_id) {
+        if (!is_local_disk_replica()) {
+            LOG(ERROR) << "Cannot update local disk metadata on type: "
+                       << type();
+            return;
+        }
+        auto& disk_data = std::get<LocalDiskReplicaData>(data_);
+        disk_data.object_size = object_size;
+        disk_data.transport_endpoint = std::move(transport_endpoint);
+        disk_data.local_disk_segment_id = std::move(local_disk_segment_id);
+    }
+
+    [[nodiscard]] std::string get_local_disk_segment_id() const {
+        if (!is_local_disk_replica()) {
+            return {};
+        }
+        return std::get<LocalDiskReplicaData>(data_).local_disk_segment_id;
+    }
+
+    [[nodiscard]] bool local_disk_disconnected_for_at_least(
+        std::chrono::seconds grace_period) const {
+        if (!is_local_disk_replica() ||
+            status_ != ReplicaStatus::DISCONNECTED) {
+            return false;
+        }
+        const auto disconnected_at =
+            std::get<LocalDiskReplicaData>(data_).disconnected_at;
+        if (disconnected_at == std::chrono::steady_clock::time_point{}) {
+            return false;
+        }
+        return std::chrono::steady_clock::now() - disconnected_at >=
+               grace_period;
     }
 
     void mark_processing() {
@@ -627,6 +697,7 @@ inline Replica::Descriptor Replica::get_descriptor() const {
         local_disk_desc.client_id = disk_data.client_id;
         local_disk_desc.object_size = disk_data.object_size;
         local_disk_desc.transport_endpoint = disk_data.transport_endpoint;
+        local_disk_desc.local_disk_segment_id = disk_data.local_disk_segment_id;
         desc.descriptor_variant = std::move(local_disk_desc);
     }
 

--- a/mooncake-store/include/rpc_service.h
+++ b/mooncake-store/include/rpc_service.h
@@ -207,8 +207,10 @@ class WrappedMasterService {
     tl::expected<std::pair<uint64_t, uint64_t>, ErrorCode> QuerySegmentForAdmin(
         const std::string& segment);
 
-    tl::expected<void, ErrorCode> MountLocalDiskSegment(const UUID& client_id,
-                                                        bool enable_offloading);
+    tl::expected<void, ErrorCode> MountLocalDiskSegment(
+        const UUID& client_id, bool enable_offloading,
+        const std::string& local_disk_segment_id = {},
+        const std::string& transport_endpoint = {});
 
     tl::expected<std::vector<OffloadTaskItem>, ErrorCode>
     OffloadObjectHeartbeat(const UUID& client_id, bool enable_offloading);

--- a/mooncake-store/include/segment.h
+++ b/mooncake-store/include/segment.h
@@ -90,6 +90,8 @@ inline std::ostream& operator<<(
 struct LocalDiskSegment {
     mutable Mutex offloading_mutex_;
     bool enable_offloading;
+    std::string local_disk_segment_id;
+    std::string transport_endpoint;
     int64_t ssd_total_capacity_bytes = 0;  // last reported by client heartbeat
     std::atomic<int64_t> ssd_used_bytes{0};
     std::unordered_map<std::string, OffloadTaskItem> GUARDED_BY(
@@ -100,8 +102,12 @@ struct LocalDiskSegment {
     // offloading_objects (offloading_mutex_).
     std::unordered_map<std::string, PromotionTaskItem> GUARDED_BY(
         offloading_mutex_) promotion_objects;
-    explicit LocalDiskSegment(bool enable_offloading)
-        : enable_offloading(enable_offloading) {}
+    explicit LocalDiskSegment(bool enable_offloading,
+                              std::string local_disk_segment_id = {},
+                              std::string transport_endpoint = {})
+        : enable_offloading(enable_offloading),
+          local_disk_segment_id(std::move(local_disk_segment_id)),
+          transport_endpoint(std::move(transport_endpoint)) {}
 
     LocalDiskSegment(const LocalDiskSegment&) = delete;
     LocalDiskSegment& operator=(const LocalDiskSegment&) = delete;
@@ -131,8 +137,10 @@ class ScopedSegmentAccess {
      */
     ErrorCode MountSegment(const Segment& segment, const UUID& client_id);
 
-    ErrorCode MountLocalDiskSegment(const UUID& client_id,
-                                    bool enable_offloading);
+    ErrorCode MountLocalDiskSegment(
+        const UUID& client_id, bool enable_offloading,
+        const std::string& local_disk_segment_id = {},
+        const std::string& transport_endpoint = {});
 
     /**
      * @brief Re-mount a segment. To avoid infinite remount trying, only the

--- a/mooncake-store/include/storage_backend.h
+++ b/mooncake-store/include/storage_backend.h
@@ -256,6 +256,7 @@ struct FileStorageConfig {
     int64_t total_keys_limit = 10'000'000;  // Maximum total number of keys
     int64_t total_size_limit =
         2ULL * 1024 * 1024 * 1024 * 1024;  // Maximum total storage size (2 TB)
+    std::string local_disk_segment_id;
 
     // Interval between heartbeats sent to the control plane (in seconds)
     uint32_t heartbeat_interval_seconds = 10;

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -3016,9 +3016,11 @@ std::vector<tl::expected<bool, ErrorCode>> Client::BatchIsExist(
 void* Client::GetBaseAddr() { return transfer_engine_->getBaseAddr(); }
 
 tl::expected<void, ErrorCode> Client::MountLocalDiskSegment(
-    bool enable_offloading) {
-    auto response =
-        master_client_.MountLocalDiskSegment(client_id_, enable_offloading);
+    bool enable_offloading, const std::string& local_disk_segment_id,
+    const std::string& transport_endpoint) {
+    auto response = master_client_.MountLocalDiskSegment(
+        client_id_, enable_offloading, local_disk_segment_id,
+        transport_endpoint);
 
     if (!response) {
         LOG(ERROR) << "MountLocalDiskSegment failed, error code is "

--- a/mooncake-store/src/file_storage.cpp
+++ b/mooncake-store/src/file_storage.cpp
@@ -1,6 +1,17 @@
 #include "file_storage.h"
 
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <chrono>
+#include <cstring>
+#include <fstream>
 #include <memory>
+#include <mutex>
+#include <random>
+#include <sstream>
+#include <stdexcept>
 #include <utility>
 #include <vector>
 
@@ -16,6 +27,127 @@
 namespace mooncake {
 
 namespace {
+
+constexpr const char* kLocalDiskSegmentIdMarker =
+    ".mooncake_local_disk_segment_id";
+
+std::string TrimMarker(std::string marker) {
+    const auto first = marker.find_first_not_of(" \t\r\n");
+    if (first == std::string::npos) {
+        return {};
+    }
+    const auto last = marker.find_last_not_of(" \t\r\n");
+    return marker.substr(first, last - first + 1);
+}
+
+std::string ReadExistingLocalDiskSegmentId(
+    const std::filesystem::path& marker_path) {
+    std::ifstream input(marker_path);
+    if (!input) {
+        return {};
+    }
+
+    std::string existing;
+    if (!std::getline(input, existing)) {
+        throw std::runtime_error("Invalid empty LOCAL_DISK marker: " +
+                                 marker_path.string());
+    }
+    existing = TrimMarker(existing);
+    if (existing.empty()) {
+        throw std::runtime_error("Invalid empty LOCAL_DISK marker: " +
+                                 marker_path.string());
+    }
+    return existing;
+}
+
+bool HasUnmarkedLocalDiskData(const std::filesystem::path& storage_path) {
+    namespace fs = std::filesystem;
+    std::error_code ec;
+    for (const auto& entry : fs::directory_iterator(storage_path, ec)) {
+        if (entry.path().filename() == kLocalDiskSegmentIdMarker) {
+            continue;
+        }
+        return true;
+    }
+    if (ec) {
+        throw std::runtime_error("Failed to scan LOCAL_DISK storage path " +
+                                 storage_path.string() + ": " + ec.message());
+    }
+    return false;
+}
+
+bool RejectUnmarkedLocalDiskData() {
+    const char* value = std::getenv("MC_STORE_REJECT_UNMARKED_DATA");
+    return value != nullptr &&
+           (std::strcmp(value, "1") == 0 || std::strcmp(value, "true") == 0 ||
+            std::strcmp(value, "TRUE") == 0);
+}
+
+std::string GenerateLocalDiskSegmentId(const std::string& storage_path) {
+    std::random_device rd;
+    std::mt19937_64 gen(rd());
+    const auto now =
+        std::chrono::steady_clock::now().time_since_epoch().count();
+    std::ostringstream oss;
+    oss << "local-disk-" << std::hex << std::hash<std::string>{}(storage_path)
+        << "-" << now << "-" << gen();
+    return oss.str();
+}
+
+std::string LoadOrCreateLocalDiskSegmentId(const std::string& storage_path) {
+    static std::mutex local_disk_segment_id_mutex;
+    std::lock_guard<std::mutex> lock(local_disk_segment_id_mutex);
+    namespace fs = std::filesystem;
+    std::error_code ec;
+    if (!fs::create_directories(storage_path, ec) && ec) {
+        throw std::runtime_error("Failed to create LOCAL_DISK storage path " +
+                                 storage_path + ": " + ec.message());
+    }
+    const auto marker_path = fs::path(storage_path) / kLocalDiskSegmentIdMarker;
+    if (fs::exists(marker_path, ec)) {
+        return ReadExistingLocalDiskSegmentId(marker_path);
+    }
+    if (ec) {
+        throw std::runtime_error("Failed to stat LOCAL_DISK marker " +
+                                 marker_path.string() + ": " + ec.message());
+    }
+
+    const bool has_unmarked_data = HasUnmarkedLocalDiskData(storage_path);
+    if (has_unmarked_data) {
+        const std::string message =
+            "LOCAL_DISK storage path contains data but no marker: " +
+            storage_path;
+        if (RejectUnmarkedLocalDiskData()) {
+            throw std::runtime_error(message);
+        }
+        LOG(WARNING) << message << "; auto-generating marker for migration";
+    }
+
+    const auto generated = GenerateLocalDiskSegmentId(storage_path);
+    const std::string contents = generated + "\n";
+    const int fd = ::open(marker_path.c_str(), O_WRONLY | O_CREAT | O_EXCL,
+                          S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+    if (fd < 0) {
+        if (errno == EEXIST) {
+            return ReadExistingLocalDiskSegmentId(marker_path);
+        }
+        throw std::runtime_error("Failed to create LOCAL_DISK marker " +
+                                 marker_path.string() + ": " +
+                                 std::strerror(errno));
+    }
+    const ssize_t written =
+        ::write(fd, contents.data(), static_cast<size_t>(contents.size()));
+    const int write_errno = errno;
+    const int close_result = ::close(fd);
+    if (written != static_cast<ssize_t>(contents.size()) || close_result != 0) {
+        std::error_code unlink_ec;
+        fs::remove(marker_path, unlink_ec);
+        throw std::runtime_error("Failed to write LOCAL_DISK marker " +
+                                 marker_path.string() + ": " +
+                                 std::strerror(write_errno));
+    }
+    return generated;
+}
 
 std::vector<OffloadTaskItem> BuildOffloadTasksFromStorageKeys(
     const std::vector<std::string>& storage_keys,
@@ -185,6 +317,12 @@ FileStorage::FileStorage(const FileStorageConfig& config,
     if (!config.Validate()) {
         throw std::invalid_argument("Invalid FileStorage configuration");
     }
+    if (config_.local_disk_segment_id.empty()) {
+        config_.local_disk_segment_id =
+            LoadOrCreateLocalDiskSegmentId(config_.storage_filepath);
+    }
+    LOG(INFO) << "FileStorage local_disk_segment_id="
+              << config_.local_disk_segment_id;
 
     auto create_storage_backend_result = CreateStorageBackend(config_);
     if (!create_storage_backend_result) {
@@ -257,8 +395,8 @@ tl::expected<void, ErrorCode> FileStorage::Init() {
     {
         MutexLocker locker(&offloading_mutex_);
         enable_offloading_ = enable_offloading_result.value();
-        auto mount_file_storage_result =
-            client_->MountLocalDiskSegment(enable_offloading_);
+        auto mount_file_storage_result = client_->MountLocalDiskSegment(
+            enable_offloading_, config_.local_disk_segment_id, local_rpc_addr_);
         if (!mount_file_storage_result) {
             LOG(ERROR) << "Failed to mount file storage: "
                        << mount_file_storage_result.error();
@@ -661,8 +799,9 @@ tl::expected<void, ErrorCode> FileStorage::Heartbeat() {
                              << "SEGMENT_NOT_FOUND, attempting to "
                              << "re-register local disk segment and "
                              << "re-register object metadata";
-                auto remount_result =
-                    client_->MountLocalDiskSegment(enable_offloading_);
+                auto remount_result = client_->MountLocalDiskSegment(
+                    enable_offloading_, config_.local_disk_segment_id,
+                    local_rpc_addr_);
                 if (remount_result) {
                     heartbeat_result = client_->OffloadObjectHeartbeat(
                         enable_offloading_, offloading_objects);

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -262,6 +262,9 @@ DEFINE_int64(
     "Seconds a client stays considered alive after the last heartbeat. "
     "If this TTL elapses without a refresh, the master treats the "
     "client as disconnected and may unmount its segments");
+DEFINE_int64(local_disk_rejoin_grace_sec, 600,
+             "Seconds to retain DISCONNECTED LOCAL_DISK metadata for warm "
+             "client rejoin before cleanup");
 DEFINE_int64(nof_heartbeat_interval_sec,
              mooncake::DEFAULT_NOF_HEARTBEAT_INTERVAL_SEC,
              "How often master probes each mounted NoF segment");
@@ -465,6 +468,9 @@ void InitMasterConf(const mooncake::DefaultConfig& default_config,
     default_config.GetInt64("client_live_ttl_sec",
                             &master_config.client_live_ttl_sec,
                             FLAGS_client_ttl);
+    default_config.GetInt64("local_disk_rejoin_grace_sec",
+                            &master_config.local_disk_rejoin_grace_sec,
+                            FLAGS_local_disk_rejoin_grace_sec);
     default_config.GetInt64("nof_heartbeat_interval_sec",
                             &master_config.nof_heartbeat_interval_sec,
                             FLAGS_nof_heartbeat_interval_sec);
@@ -951,6 +957,12 @@ void LoadConfigFromCmdline(mooncake::MasterConfig& master_config,
         !conf_set) {
         master_config.client_live_ttl_sec = FLAGS_client_ttl;
     }
+    if ((google::GetCommandLineFlagInfo("local_disk_rejoin_grace_sec", &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.local_disk_rejoin_grace_sec =
+            FLAGS_local_disk_rejoin_grace_sec;
+    }
     if ((google::GetCommandLineFlagInfo("nof_heartbeat_interval_sec", &info) &&
          !info.is_default) ||
         !conf_set) {
@@ -1388,6 +1400,8 @@ int main(int argc, char* argv[]) {
         << ", ha_backend_connstring=" << ha_backend_connstring
         << ", etcd_endpoints=" << master_config.etcd_endpoints
         << ", client_ttl=" << master_config.client_live_ttl_sec
+        << ", local_disk_rejoin_grace_sec="
+        << master_config.local_disk_rejoin_grace_sec
         << ", rpc_thread_num=" << master_config.rpc_thread_num
         << ", rpc_port=" << master_config.rpc_port
         << ", rpc_address=" << master_config.rpc_address

--- a/mooncake-store/src/master_client.cpp
+++ b/mooncake-store/src/master_client.cpp
@@ -926,14 +926,19 @@ MasterClient::GetStorageConfig() {
 }
 
 tl::expected<void, ErrorCode> MasterClient::MountLocalDiskSegment(
-    const UUID& client_id, bool enable_offloading) {
+    const UUID& client_id, bool enable_offloading,
+    const std::string& local_disk_segment_id,
+    const std::string& transport_endpoint) {
     ScopedVLogTimer timer(1, "MasterClient::MountLocalDiskSegment");
     timer.LogRequest("client_id=", client_id,
-                     ", enable_offloading=", enable_offloading);
+                     ", enable_offloading=", enable_offloading,
+                     ", local_disk_segment_id=", local_disk_segment_id,
+                     ", transport_endpoint=", transport_endpoint);
 
     auto result =
         invoke_rpc<&WrappedMasterService::MountLocalDiskSegment, void>(
-            client_id, enable_offloading);
+            client_id, enable_offloading, local_disk_segment_id,
+            transport_endpoint);
     timer.LogResponseExpected(result);
     return result;
 }

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -1777,6 +1777,49 @@ size_t MasterService::EraseDisconnectedLocalDiskReplicas(
     return erased;
 }
 
+void MasterService::ErasePromotionTaskIfPresent(TenantState& tenant_state,
+                                                const std::string& key,
+                                                const std::string& tenant_id,
+                                                ObjectMetadata* metadata) {
+    auto task_it = tenant_state.promotion_tasks.find(key);
+    if (task_it == tenant_state.promotion_tasks.end()) {
+        return;
+    }
+
+    const auto task = task_it->second;
+    if (metadata != nullptr) {
+        auto* source = metadata->GetReplicaByID(task.source_id);
+        if (source != nullptr) {
+            source->dec_refcnt();
+        }
+        if (task.alloc_id != 0) {
+            EraseReplicasWithCacheTotalAccounting(
+                *metadata, [alloc_id = task.alloc_id](const Replica& replica) {
+                    return replica.id() == alloc_id;
+                });
+        }
+    }
+
+    {
+        ScopedLocalDiskSegmentAccess local_disk_segment_access =
+            segment_manager_.getLocalDiskSegmentAccess();
+        auto& client_local_disk_segment =
+            local_disk_segment_access.getClientLocalDiskSegment();
+        auto segment_it = client_local_disk_segment.find(task.holder_id);
+        if (segment_it != client_local_disk_segment.end()) {
+            MutexLocker locker(&segment_it->second->offloading_mutex_);
+            segment_it->second->promotion_objects.erase(
+                MakeTenantScopedStorageKey(tenant_id, key));
+        }
+    }
+
+    AbortTenantQuota(tenant_id, task.reserved_quota_charge_bytes);
+    tenant_state.promotion_tasks.erase(task_it);
+    promotion_in_flight_.fetch_sub(1, std::memory_order_relaxed);
+    MasterMetricManager::instance().dec_promotion_in_flight();
+    MasterMetricManager::instance().inc_promotion_cancelled();
+}
+
 std::unordered_map<std::string, MasterService::ObjectMetadata>::iterator
 MasterService::EraseMetadata(
     TenantState& tenant_state,
@@ -1824,7 +1867,7 @@ MasterService::EraseMetadata(
     }
     tenant_state.processing_keys.erase(key);
     tenant_state.replication_tasks.erase(key);
-    ErasePromotionTaskIfPresent(tenant_state, key, tenant_id);
+    ErasePromotionTaskIfPresent(tenant_state, key, tenant_id, &metadata);
 
     ReleaseLocalDiskUsage(metadata.GetAllReplicas());
     AccountCacheTotalRemoval(metadata);
@@ -1983,7 +2026,9 @@ void MasterService::ClearInvalidHandles(
             auto& tenant_state = tenant_it->second;
             auto it = tenant_state.metadata.begin();
             while (it != tenant_state.metadata.end()) {
-                if (CleanupStaleHandles(it->second, alive_clients, &shard)) {
+                if (CleanupStaleHandles(it->second, alive_clients, &shard,
+                                        tenant_state, it->first,
+                                        tenant_it->first)) {
                     // EraseMetadata handles processing_keys,
                     // replication_tasks, offloading_tasks (with
                     // dec_refcnt), and promotion task cleanup.
@@ -3211,7 +3256,9 @@ auto MasterService::PutStart(const UUID& client_id, const std::string& key,
 
             auto it = tenant_state.metadata.find(key);
             if (it != tenant_state.metadata.end()) {
-                if (CleanupStaleHandles(it->second, alive_clients, &shard)) {
+                if (CleanupStaleHandles(it->second, alive_clients, &shard,
+                                        tenant_state, key,
+                                        object_id.tenant_id)) {
                     // EraseMetadata handles processing_keys,
                     // replication_tasks, offloading_tasks (with
                     // dec_refcnt), and promotion task cleanup.
@@ -3462,13 +3509,14 @@ auto MasterService::AddReplica(const UUID& client_id, const std::string& key,
             updated_existing++;
         });
     if (updated_existing == 0) {
+        if (had_completed_disk) {
+            return false;
+        }
         std::vector<Replica> replicas;
         replicas.emplace_back(std::move(replica));
         metadata.AddReplicas(std::move(replicas));
         auto& shard = accessor.GetShard();
-        if (!had_completed_disk) {
-            shard.OnDiskReplicaAdded(metadata);
-        }
+        shard.OnDiskReplicaAdded(metadata);
         SyncCacheTotalAccounting(metadata);
         return true;
     }
@@ -3675,7 +3723,8 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
 
             // --- Step 0: stale handle cleanup ---
             if (it != tenant_state.metadata.end() &&
-                CleanupStaleHandles(it->second, alive_clients, &shard)) {
+                CleanupStaleHandles(it->second, alive_clients, &shard,
+                                    tenant_state, key, object_id.tenant_id)) {
                 // EraseMetadata handles processing_keys, replication_tasks,
                 // offloading_tasks (with dec_refcnt), and promotion task
                 // cleanup.
@@ -4857,12 +4906,8 @@ auto MasterService::BatchRemove(const std::vector<std::string>& keys,
             auto tenant_it = shard->tenants.find(normalized_tenant);
             if (tenant_it == shard->tenants.end()) {
                 VLOG(1) << "key=" << key << ", error=object_not_found";
-                if (force) {
-                    results[original_idx] = {};
-                } else {
-                    results[original_idx] =
-                        tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
-                }
+                results[original_idx] =
+                    tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
                 continue;
             }
             auto& tenant_state = tenant_it->second;
@@ -4876,7 +4921,10 @@ auto MasterService::BatchRemove(const std::vector<std::string>& keys,
             }
 
             // Clean up stale replica handles (consistent with single Remove)
-            if (CleanupStaleHandles(it->second, alive_clients, &shard)) {
+            bool disconnected_now = false;
+            if (CleanupStaleHandles(it->second, alive_clients, &shard,
+                                    tenant_state, key, normalized_tenant,
+                                    &disconnected_now)) {
                 // EraseMetadata handles processing_keys,
                 // replication_tasks, offloading_tasks (with
                 // dec_refcnt), and promotion task cleanup.
@@ -4903,7 +4951,12 @@ auto MasterService::BatchRemove(const std::vector<std::string>& keys,
                     if (tenant_state.Empty()) {
                         shard->tenants.erase(tenant_it);
                     }
-                    results[original_idx] = {};
+                    if (disconnected_now) {
+                        results[original_idx] =
+                            tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
+                    } else {
+                        results[original_idx] = {};
+                    }
                     continue;
                 }
             }
@@ -4946,7 +4999,9 @@ auto MasterService::BatchRemove(const std::vector<std::string>& keys,
 bool MasterService::CleanupStaleHandles(
     ObjectMetadata& metadata,
     const std::unordered_set<UUID, boost::hash<UUID>>& alive_clients,
-    MetadataShardAccessorRW* shard) {
+    MetadataShardAccessorRW* shard, TenantState& tenant_state,
+    const std::string& key, const std::string& tenant_id,
+    bool* local_disk_disconnected) {
     bool had_completed_disk = metadata.HasReplica([](const Replica& r) {
         return r.is_local_disk_replica() && r.is_completed();
     });
@@ -4962,10 +5017,14 @@ bool MasterService::CleanupStaleHandles(
         });
 
     if (disconnected_local_disk > 0) {
+        if (local_disk_disconnected != nullptr) {
+            *local_disk_disconnected = true;
+        }
         disconnected_local_disk_replica_count_.fetch_add(
             disconnected_local_disk, std::memory_order_relaxed);
         LOG(INFO) << "action=local_disk_replica_disconnected"
                   << ", count=" << disconnected_local_disk;
+        ErasePromotionTaskIfPresent(tenant_state, key, tenant_id, &metadata);
     }
 
     // Remove those with invalid allocators (memory replicas on unmounted
@@ -5392,13 +5451,15 @@ auto MasterService::NotifyOffloadSuccess(
                                 updated_existing++;
                             });
                         if (updated_existing == 0) {
+                            if (had_completed_disk) {
+                                handled_existing_object = true;
+                                continue;
+                            }
                             std::vector<Replica> replicas;
                             replicas.emplace_back(std::move(replica));
                             obj_metadata.AddReplicas(std::move(replicas));
                             auto& shard = accessor.GetShard();
-                            if (!had_completed_disk) {
-                                shard.OnDiskReplicaAdded(obj_metadata);
-                            }
+                            shard.OnDiskReplicaAdded(obj_metadata);
                             SyncCacheTotalAccounting(obj_metadata);
                             added_new_local_disk_replica = true;
                         } else if (disconnected_completed > 0) {

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -55,12 +55,41 @@ static const std::string SNAPSHOT_SEGMENTS_FILE = "segments";
 static const std::string SNAPSHOT_TASK_MANAGER_FILE = "task_manager";
 static const std::string SNAPSHOT_MANIFEST_FILE = "manifest.txt";
 static const std::string SNAPSHOT_LATEST_FILE = "latest.txt";
+std::string PercentEncodeMetadataKey(const std::string& key) {
+    std::ostringstream oss;
+    static constexpr char kHex[] = "0123456789ABCDEF";
+    for (unsigned char ch : key) {
+        if ((ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') ||
+            (ch >= '0' && ch <= '9') || ch == '-' || ch == '_' || ch == '.' ||
+            ch == '~') {
+            oss << ch;
+        } else {
+            oss << '%' << kHex[ch >> 4] << kHex[ch & 0x0F];
+        }
+    }
+    return oss.str();
+}
 static const std::string SNAPSHOT_BACKUP_SAVE_DIR =
     "mooncake_snapshot_save_backup";
 static const std::string SNAPSHOT_BACKUP_RESTORE_DIR =
     "mooncake_snapshot_restore_backup";
 static const std::string SNAPSHOT_SERIALIZER_VERSION = "1.0.0";
 static const std::string SNAPSHOT_SERIALIZER_TYPE = "messagepack";
+
+void AtomicSaturatingSub(std::atomic<size_t>& value, size_t delta) {
+    if (delta == 0) {
+        return;
+    }
+    size_t current = value.load(std::memory_order_relaxed);
+    while (current > 0) {
+        const size_t next = current > delta ? current - delta : 0;
+        if (value.compare_exchange_weak(current, next,
+                                        std::memory_order_relaxed,
+                                        std::memory_order_relaxed)) {
+            return;
+        }
+    }
+}
 
 namespace {
 
@@ -200,6 +229,8 @@ MasterService::MasterService(const MasterServiceConfig& config)
           config.nof_eviction_high_watermark_ratio),
       view_version_(config.view_version),
       client_live_ttl_sec_(config.client_live_ttl_sec),
+      local_disk_rejoin_grace_period_(
+          std::chrono::seconds(config.local_disk_rejoin_grace_sec)),
       nof_heartbeat_interval_sec_(
           std::chrono::seconds(config.nof_heartbeat_interval_sec)),
       nof_heartbeat_probe_timeout_ms_(
@@ -1657,6 +1688,13 @@ bool MasterService::HasCompletedDiskCacheReplica(
     });
 }
 
+bool MasterService::HasCompletedLocalDiskReplica(
+    const ObjectMetadata& metadata) {
+    return metadata.HasReplica([](const Replica& replica) {
+        return replica.is_local_disk_replica() && replica.is_completed();
+    });
+}
+
 void MasterService::SyncCacheTotalAccounting(ObjectMetadata& metadata) {
     const bool has_memory_cache_replica =
         HasCompletedMemoryCacheReplica(metadata);
@@ -1726,6 +1764,17 @@ size_t MasterService::EraseReplicasWithCacheTotalAccounting(
     // No-op for memory/noF replicas, so it is safe to call unconditionally.
     ReleaseLocalDiskUsage(erased_replicas);
     return erased_replicas.size();
+}
+
+size_t MasterService::EraseDisconnectedLocalDiskReplicas(
+    ObjectMetadata& metadata) {
+    const size_t erased = EraseReplicasWithCacheTotalAccounting(
+        metadata, [](const Replica& replica) {
+            return replica.is_local_disk_replica() &&
+                   replica.status() == ReplicaStatus::DISCONNECTED;
+        });
+    AtomicSaturatingSub(disconnected_local_disk_replica_count_, erased);
+    return erased;
 }
 
 std::unordered_map<std::string, MasterService::ObjectMetadata>::iterator
@@ -1828,6 +1877,26 @@ void MasterService::ReleaseLocalDiskUsage(
         if (disk_it != client_segments.end()) {
             disk_it->second->ssd_used_bytes.fetch_sub(
                 bytes, std::memory_order_relaxed);
+        }
+    }
+}
+
+void MasterService::AddLocalDiskUsage(const UUID& client_id, int64_t bytes) {
+    if (bytes == 0) {
+        return;
+    }
+
+    ScopedLocalDiskSegmentAccess ssd_access =
+        segment_manager_.getLocalDiskSegmentAccess();
+    auto& client_segments = ssd_access.getClientLocalDiskSegment();
+    auto disk_it = client_segments.find(client_id);
+    if (disk_it != client_segments.end()) {
+        if (bytes > 0) {
+            disk_it->second->ssd_used_bytes.fetch_add(
+                bytes, std::memory_order_relaxed);
+        } else {
+            disk_it->second->ssd_used_bytes.fetch_sub(
+                -bytes, std::memory_order_relaxed);
         }
     }
 }
@@ -1951,9 +2020,15 @@ void MasterService::TaskCleanupThreadFunc() {
         }
 
         std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-        auto write_access = task_manager_.get_write_access();
-        write_access.prune_expired_tasks();
-        write_access.prune_finished_tasks();
+        {
+            auto write_access = task_manager_.get_write_access();
+            write_access.prune_expired_tasks();
+            write_access.prune_finished_tasks();
+        }
+        if (disconnected_local_disk_replica_count_.load(
+                std::memory_order_relaxed) > 0) {
+            ClearInvalidHandles();
+        }
     }
     LOG(INFO) << "Task cleanup thread stopped";
 }
@@ -3363,23 +3438,50 @@ auto MasterService::AddReplica(const UUID& client_id, const std::string& key,
         return true;
     }
 
+    size_t updated_existing = 0;
+    size_t disconnected_completed = 0;
+    const bool had_completed_disk = HasCompletedLocalDiskReplica(metadata);
     metadata.VisitReplicas(
         [client_id](const Replica& rep) {
             return rep.type() == ReplicaType::LOCAL_DISK &&
                    rep.get_descriptor().get_local_disk_descriptor().client_id ==
                        client_id;
         },
-        [&replica](Replica& rep) {
-            rep.get_descriptor()
-                .get_local_disk_descriptor()
-                .transport_endpoint = replica.get_descriptor()
-                                          .get_local_disk_descriptor()
-                                          .transport_endpoint;
-            rep.get_descriptor().get_local_disk_descriptor().object_size =
-                replica.get_descriptor()
-                    .get_local_disk_descriptor()
-                    .object_size;
+        [&replica, &updated_existing, &disconnected_completed](Replica& rep) {
+            const auto desc =
+                replica.get_descriptor().get_local_disk_descriptor();
+            const bool was_disconnected =
+                rep.status() == ReplicaStatus::DISCONNECTED;
+            rep.update_local_disk_metadata(desc.object_size,
+                                           desc.transport_endpoint,
+                                           desc.local_disk_segment_id);
+            if (was_disconnected) {
+                rep.mark_complete();
+                disconnected_completed++;
+            }
+            updated_existing++;
         });
+    if (updated_existing == 0) {
+        std::vector<Replica> replicas;
+        replicas.emplace_back(std::move(replica));
+        metadata.AddReplicas(std::move(replicas));
+        auto& shard = accessor.GetShard();
+        if (!had_completed_disk) {
+            shard.OnDiskReplicaAdded(metadata);
+        }
+        SyncCacheTotalAccounting(metadata);
+        return true;
+    }
+    if (disconnected_completed > 0) {
+        AtomicSaturatingSub(disconnected_local_disk_replica_count_,
+                            disconnected_completed);
+        if (!had_completed_disk) {
+            auto& shard = accessor.GetShard();
+            shard.OnDiskReplicaAdded(metadata);
+        }
+        SyncCacheTotalAccounting(metadata);
+        return true;
+    }
     return false;
 }
 
@@ -3613,13 +3715,30 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
                         ErrorCode::OBJECT_HAS_REPLICATION_TASK);
                 }
 
+                {
+                    const bool had_completed_disk =
+                        HasCompletedLocalDiskReplica(metadata);
+                    const size_t removed_disconnected =
+                        EraseDisconnectedLocalDiskReplicas(metadata);
+                    if (removed_disconnected > 0) {
+                        shard.OnDiskReplicaRemoved(had_completed_disk,
+                                                   metadata);
+                        if (!metadata.HasReplica(&Replica::fn_is_completed)) {
+                            EraseMetadata(tenant_state, it, object_id.tenant_id,
+                                          QuotaEraseMode::kFull, &shard);
+                            it = tenant_state.metadata.end();
+                        }
+                    }
+                }
+
                 // Preempt an in-progress Put/Upsert on the same key.  The
                 // previous writer's PROCESSING replicas are moved to
                 // discarded_replicas_ with a TTL so they are not freed while
                 // the old writer may still be doing RDMA writes.  Unlike
                 // PutStart (which only preempts after a timeout), UpsertStart
                 // preempts immediately.
-                if (tenant_state.processing_keys.count(key) > 0) {
+                if (it != tenant_state.metadata.end() &&
+                    tenant_state.processing_keys.count(key) > 0) {
                     auto processing_replicas =
                         metadata.PopReplicas(&Replica::fn_is_processing);
                     if (!processing_replicas.empty()) {
@@ -3747,6 +3866,15 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
                         : CompletedMemoryQuotaCharge(metadata);
                 auto old_replicas =
                     PopReplicasWithCacheTotalAccounting(metadata);
+                ReleaseLocalDiskUsage(old_replicas);
+                AtomicSaturatingSub(
+                    disconnected_local_disk_replica_count_,
+                    std::count_if(old_replicas.begin(), old_replicas.end(),
+                                  [](const Replica& replica) {
+                                      return replica.is_local_disk_replica() &&
+                                             replica.status() ==
+                                                 ReplicaStatus::DISCONNECTED;
+                                  }));
                 if (!old_replicas.empty()) {
                     std::lock_guard lock(discarded_replicas_mutex_);
                     discarded_replicas_.emplace_back(
@@ -4505,6 +4633,12 @@ auto MasterService::Remove(const std::string& key, const std::string& tenant_id,
     }
 
     auto& metadata = accessor.Get();
+    if (force && EraseDisconnectedLocalDiskReplicas(metadata) > 0) {
+        if (!metadata.IsValid()) {
+            accessor.Erase();
+            return {};
+        }
+    }
 
     if (!force && !metadata.IsLeaseExpired()) {
         VLOG(1) << "key=" << key << ", error=object_has_lease";
@@ -4723,8 +4857,12 @@ auto MasterService::BatchRemove(const std::vector<std::string>& keys,
             auto tenant_it = shard->tenants.find(normalized_tenant);
             if (tenant_it == shard->tenants.end()) {
                 VLOG(1) << "key=" << key << ", error=object_not_found";
-                results[original_idx] =
-                    tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
+                if (force) {
+                    results[original_idx] = {};
+                } else {
+                    results[original_idx] =
+                        tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
+                }
                 continue;
             }
             auto& tenant_state = tenant_it->second;
@@ -4758,6 +4896,17 @@ auto MasterService::BatchRemove(const std::vector<std::string>& keys,
             }
 
             auto& metadata = it->second;
+            if (force && EraseDisconnectedLocalDiskReplicas(metadata) > 0) {
+                if (!metadata.IsValid()) {
+                    EraseMetadata(tenant_state, it, normalized_tenant,
+                                  QuotaEraseMode::kFull, &shard);
+                    if (tenant_state.Empty()) {
+                        shard->tenants.erase(tenant_it);
+                    }
+                    results[original_idx] = {};
+                    continue;
+                }
+            }
 
             if (!force && !metadata.IsLeaseExpired(now)) {
                 VLOG(1) << "key=" << key << ", error=object_has_lease";
@@ -4801,16 +4950,45 @@ bool MasterService::CleanupStaleHandles(
     bool had_completed_disk = metadata.HasReplica([](const Replica& r) {
         return r.is_local_disk_replica() && r.is_completed();
     });
-    // Remove those with invalid allocators (memory replicas on unmounted
-    // segments) and local_disk replicas whose owner client is no longer alive.
-    const uint64_t before_charge = CompletedMemoryQuotaCharge(metadata);
-    EraseReplicasWithCacheTotalAccounting(
-        metadata, [&alive_clients](const Replica& replica) {
-            return (replica.has_invalid_mem_handle() ||
-                    replica.has_invalid_nof_handle() ||
-                    replica.has_stale_local_disk_client(alive_clients)) &&
-                   replica.is_completed();
+    size_t disconnected_local_disk = 0;
+    metadata.VisitReplicas(
+        [&alive_clients](const Replica& replica) {
+            return replica.is_local_disk_replica() && replica.is_completed() &&
+                   replica.has_stale_local_disk_client(alive_clients);
+        },
+        [&disconnected_local_disk](Replica& replica) {
+            replica.mark_disconnected();
+            disconnected_local_disk++;
         });
+
+    if (disconnected_local_disk > 0) {
+        disconnected_local_disk_replica_count_.fetch_add(
+            disconnected_local_disk, std::memory_order_relaxed);
+        LOG(INFO) << "action=local_disk_replica_disconnected"
+                  << ", count=" << disconnected_local_disk;
+    }
+
+    // Remove those with invalid allocators (memory replicas on unmounted
+    // segments). LOCAL_DISK replicas are retained as DISCONNECTED so a
+    // returning client can re-adopt them by local_disk_segment_id.
+    const uint64_t before_charge = CompletedMemoryQuotaCharge(metadata);
+    size_t expired_disconnected_local_disk = 0;
+    EraseReplicasWithCacheTotalAccounting(
+        metadata,
+        [this, &expired_disconnected_local_disk](const Replica& replica) {
+            const bool expired_disconnected =
+                replica.local_disk_disconnected_for_at_least(
+                    local_disk_rejoin_grace_period_);
+            if (expired_disconnected) {
+                expired_disconnected_local_disk++;
+            }
+            return (replica.has_invalid_mem_handle() ||
+                    replica.has_invalid_nof_handle() || expired_disconnected) &&
+                   (replica.is_completed() ||
+                    replica.status() == ReplicaStatus::DISCONNECTED);
+        });
+    AtomicSaturatingSub(disconnected_local_disk_replica_count_,
+                        expired_disconnected_local_disk);
     const uint64_t after_charge = CompletedMemoryQuotaCharge(metadata);
     if (before_charge > after_charge) {
         ReleaseCommittedQuotaCharge(metadata, before_charge - after_charge);
@@ -4824,6 +5002,81 @@ bool MasterService::CleanupStaleHandles(
 
     // Return true if no valid replicas remain after cleanup
     return !metadata.IsValid();
+}
+
+size_t MasterService::ReattachDisconnectedLocalDiskReplicas(
+    const std::string& local_disk_segment_id, const UUID& new_client_id,
+    const std::string& transport_endpoint) {
+    if (local_disk_segment_id.empty()) {
+        return 0;
+    }
+
+    size_t reattached = 0;
+    size_t disconnected_reattached = 0;
+    std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+    for (size_t i = 0; i < kNumShards; i++) {
+        MetadataShardAccessorRW shard(this, i);
+        for (auto& tenant_pair : shard->tenants) {
+            for (auto& metadata_pair : tenant_pair.second.metadata) {
+                auto& metadata = metadata_pair.second;
+                const bool had_completed_disk =
+                    HasCompletedLocalDiskReplica(metadata);
+                size_t local_count = 0;
+                int64_t local_bytes = 0;
+                metadata.VisitReplicas(
+                    [&local_disk_segment_id,
+                     &new_client_id](const Replica& replica) {
+                        if (!replica.is_local_disk_replica() ||
+                            replica.get_local_disk_segment_id() !=
+                                local_disk_segment_id) {
+                            return false;
+                        }
+                        if (replica.status() == ReplicaStatus::DISCONNECTED) {
+                            return true;
+                        }
+                        const auto owner = replica.get_local_disk_client_id();
+                        return replica.is_completed() && owner.has_value() &&
+                               owner.value() != new_client_id;
+                    },
+                    [this, &new_client_id, &transport_endpoint,
+                     &disconnected_reattached, &local_count,
+                     &local_bytes](Replica& replica) {
+                        const auto desc = replica.get_descriptor()
+                                              .get_local_disk_descriptor();
+                        if (desc.client_id != new_client_id) {
+                            AddLocalDiskUsage(
+                                desc.client_id,
+                                -static_cast<int64_t>(desc.object_size));
+                        }
+                        local_bytes += static_cast<int64_t>(desc.object_size);
+                        if (replica.status() == ReplicaStatus::DISCONNECTED) {
+                            disconnected_reattached++;
+                        }
+                        replica.update_local_disk_owner(new_client_id,
+                                                        transport_endpoint);
+                        replica.mark_complete();
+                        local_count++;
+                    });
+                if (local_count > 0) {
+                    if (!had_completed_disk) {
+                        shard.OnDiskReplicaAdded(metadata);
+                    }
+                    AddLocalDiskUsage(new_client_id, local_bytes);
+                    reattached += local_count;
+                }
+            }
+        }
+    }
+
+    if (reattached > 0) {
+        AtomicSaturatingSub(disconnected_local_disk_replica_count_,
+                            disconnected_reattached);
+        LOG(INFO) << "action=reattach_local_disk_replicas"
+                  << ", local_disk_segment_id=" << local_disk_segment_id
+                  << ", client_id=" << new_client_id
+                  << ", count=" << reattached;
+    }
+    return reattached;
 }
 
 size_t MasterService::GetKeyCount() const {
@@ -4882,36 +5135,42 @@ MasterService::GetStorageConfig() const {
     return GetStorageConfigResponse(fsdir, enable_disk_eviction_, quota_bytes_);
 }
 
-auto MasterService::MountLocalDiskSegment(const UUID& client_id,
-                                          bool enable_offloading)
-    -> tl::expected<void, ErrorCode> {
+auto MasterService::MountLocalDiskSegment(
+    const UUID& client_id, bool enable_offloading,
+    const std::string& local_disk_segment_id,
+    const std::string& transport_endpoint) -> tl::expected<void, ErrorCode> {
     if (!enable_offload_) {
         LOG(ERROR) << "	The offload functionality is not enabled";
         return tl::make_unexpected(ErrorCode::UNABLE_OFFLOAD);
     }
-    std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-    ScopedSegmentAccess segment_access = segment_manager_.getSegmentAccess();
+    {
+        std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+        ScopedSegmentAccess segment_access =
+            segment_manager_.getSegmentAccess();
 
-    auto err =
-        segment_access.MountLocalDiskSegment(client_id, enable_offloading);
-    if (err == ErrorCode::SEGMENT_ALREADY_EXISTS) {
-        // Return OK because this is an idempotent operation
-        return {};
-    } else if (err != ErrorCode::OK) {
-        return tl::make_unexpected(err);
+        PodUUID pod_client_id;
+        pod_client_id.first = client_id.first;
+        pod_client_id.second = client_id.second;
+        if (!client_ping_queue_.push(pod_client_id)) {
+            LOG(ERROR) << "client_id=" << client_id
+                       << ", error=client_ping_queue_full";
+            return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+        }
+
+        auto err = segment_access.MountLocalDiskSegment(
+            client_id, enable_offloading, local_disk_segment_id,
+            transport_endpoint);
+        if (err != ErrorCode::OK) {
+            return tl::make_unexpected(err);
+        }
     }
 
-    // Notify the client monitor thread to start tracking this client's TTL.
-    // Without this, a client that only mounts a LOCAL_DISK segment (and
-    // doesn't ping) would be considered expired by ClientMonitorFunc, which
-    // would then clear all its LOCAL_DISK replicas.
-    PodUUID pod_client_id;
-    pod_client_id.first = client_id.first;
-    pod_client_id.second = client_id.second;
-    if (!client_ping_queue_.push(pod_client_id)) {
-        LOG(ERROR) << "client_id=" << client_id
-                   << ", error=client_ping_queue_full";
-        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    const size_t reattached = ReattachDisconnectedLocalDiskReplicas(
+        local_disk_segment_id, client_id, transport_endpoint);
+    if (reattached > 0) {
+        LOG(INFO) << "action=mount_local_disk_segment_reattached"
+                  << ", local_disk_segment_id=" << local_disk_segment_id
+                  << ", count=" << reattached;
     }
 
     return {};
@@ -5059,8 +5318,14 @@ auto MasterService::NotifyOffloadSuccess(
             continue;
         }
 
+        std::string local_disk_segment_id;
+        if (local_disk_segment) {
+            MutexLocker locker(&local_disk_segment->offloading_mutex_);
+            local_disk_segment_id = local_disk_segment->local_disk_segment_id;
+        }
         Replica replica(client_id, metadata.data_size,
-                        metadata.transport_endpoint, ReplicaStatus::COMPLETE);
+                        metadata.transport_endpoint, ReplicaStatus::COMPLETE,
+                        local_disk_segment_id);
         bool handled_existing_object = false;
         bool added_new_local_disk_replica = false;
         {
@@ -5089,6 +5354,8 @@ auto MasterService::NotifyOffloadSuccess(
                     }
                     tenant_state.offloading_tasks.erase(task_it);
 
+                    const bool had_completed_disk =
+                        HasCompletedLocalDiskReplica(obj_metadata);
                     if (!obj_metadata.HasReplica(
                             &Replica::fn_is_local_disk_replica)) {
                         std::vector<Replica> replicas;
@@ -5099,6 +5366,8 @@ auto MasterService::NotifyOffloadSuccess(
                         SyncCacheTotalAccounting(obj_metadata);
                         added_new_local_disk_replica = true;
                     } else {
+                        size_t updated_existing = 0;
+                        size_t disconnected_completed = 0;
                         obj_metadata.VisitReplicas(
                             [client_id](const Replica& rep) {
                                 return rep.type() == ReplicaType::LOCAL_DISK &&
@@ -5106,20 +5375,43 @@ auto MasterService::NotifyOffloadSuccess(
                                                .get_local_disk_descriptor()
                                                .client_id == client_id;
                             },
-                            [&replica](Replica& rep) {
-                                rep.get_descriptor()
-                                    .get_local_disk_descriptor()
-                                    .transport_endpoint =
-                                    replica.get_descriptor()
-                                        .get_local_disk_descriptor()
-                                        .transport_endpoint;
-                                rep.get_descriptor()
-                                    .get_local_disk_descriptor()
-                                    .object_size =
-                                    replica.get_descriptor()
-                                        .get_local_disk_descriptor()
-                                        .object_size;
+                            [&replica, &local_disk_segment_id,
+                             &updated_existing,
+                             &disconnected_completed](Replica& rep) {
+                                auto desc = replica.get_descriptor()
+                                                .get_local_disk_descriptor();
+                                const bool was_disconnected =
+                                    rep.status() == ReplicaStatus::DISCONNECTED;
+                                rep.update_local_disk_metadata(
+                                    desc.object_size, desc.transport_endpoint,
+                                    local_disk_segment_id);
+                                if (was_disconnected) {
+                                    rep.mark_complete();
+                                    disconnected_completed++;
+                                }
+                                updated_existing++;
                             });
+                        if (updated_existing == 0) {
+                            std::vector<Replica> replicas;
+                            replicas.emplace_back(std::move(replica));
+                            obj_metadata.AddReplicas(std::move(replicas));
+                            auto& shard = accessor.GetShard();
+                            if (!had_completed_disk) {
+                                shard.OnDiskReplicaAdded(obj_metadata);
+                            }
+                            SyncCacheTotalAccounting(obj_metadata);
+                            added_new_local_disk_replica = true;
+                        } else if (disconnected_completed > 0) {
+                            AtomicSaturatingSub(
+                                disconnected_local_disk_replica_count_,
+                                disconnected_completed);
+                            if (!had_completed_disk) {
+                                auto& shard = accessor.GetShard();
+                                shard.OnDiskReplicaAdded(obj_metadata);
+                            }
+                            SyncCacheTotalAccounting(obj_metadata);
+                            added_new_local_disk_replica = true;
+                        }
                     }
                     handled_existing_object = true;
                 }
@@ -6257,6 +6549,22 @@ bool MasterService::TryRestoreStateFromSnapshot(
             }
         }
 
+        {
+            std::vector<UUID> local_disk_clients;
+            {
+                ScopedLocalDiskSegmentAccess local_disk_access =
+                    segment_manager_.getLocalDiskSegmentAccess();
+                for (const auto& [client_id, segment] :
+                     local_disk_access.getClientLocalDiskSegment()) {
+                    (void)segment;
+                    local_disk_clients.push_back(client_id);
+                }
+            }
+            for (const auto& client_id : local_disk_clients) {
+                Ping(client_id);
+            }
+        }
+
         LOG(INFO) << "[Restore] Successfully restored state from snapshot: "
                   << state_id;
         return true;
@@ -6314,7 +6622,7 @@ MasterService::EvictTenantMemoryForQuota(const std::string& tenant_id,
         return metadata.HasReplica(is_evictable_memory_replica);
     };
     auto has_local_disk_replica = [](const ObjectMetadata& metadata) {
-        return metadata.HasReplica(&Replica::fn_is_local_disk_replica);
+        return HasCompletedLocalDiskReplica(metadata);
     };
     auto evict_replicas =
         [&, this](ObjectMetadata& metadata,
@@ -6575,7 +6883,7 @@ void MasterService::BatchEvict(double evict_ratio_target,
             : 0;
 
     auto has_local_disk_replica = [](const ObjectMetadata& metadata) {
-        return metadata.HasReplica(&Replica::fn_is_local_disk_replica);
+        return HasCompletedLocalDiskReplica(metadata);
     };
 
     // Returns freed bytes. Returns 0 if offload-queued and no additional
@@ -7909,9 +8217,7 @@ MasterService::MetadataSerializer::DeserializeShard(const msgpack::object& obj,
         it->second.soft_pin_timeout = metadata_ptr->soft_pin_timeout;
 
         // Recompute disk_object_count for restored metadata
-        if (it->second.HasReplica([](const Replica& r) {
-                return r.is_local_disk_replica() && r.is_completed();
-            })) {
+        if (HasCompletedLocalDiskReplica(it->second)) {
             shard.disk_object_count++;
         }
     }
@@ -9024,6 +9330,14 @@ void MasterService::cleanupHttpMetadata(const std::string& segment_name) {
             http_metadata_prefix_ + "rpc_meta/" + segment_name;
         bool ram_removed = http_metadata_server_->removeKey(ram_key);
         bool rpc_removed = http_metadata_server_->removeKey(rpc_key);
+        if (!ram_removed) {
+            ram_removed = http_metadata_server_->removeKey(
+                PercentEncodeMetadataKey(ram_key));
+        }
+        if (!rpc_removed) {
+            rpc_removed = http_metadata_server_->removeKey(
+                PercentEncodeMetadataKey(rpc_key));
+        }
         LOG(INFO) << "Cleaned up HTTP metadata for segment: " << segment_name
                   << ", ram_key_removed=" << ram_removed
                   << ", rpc_key_removed=" << rpc_removed;

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -1149,13 +1149,18 @@ WrappedMasterService::QuerySegmentForAdmin(const std::string& segment) {
 }
 
 tl::expected<void, ErrorCode> WrappedMasterService::MountLocalDiskSegment(
-    const UUID& client_id, bool enable_offloading) {
+    const UUID& client_id, bool enable_offloading,
+    const std::string& local_disk_segment_id,
+    const std::string& transport_endpoint) {
     ScopedVLogTimer timer(1, "MountLocalDiskSegment");
     timer.LogRequest("action=mount_local_disk_segment");
     LOG(INFO) << "Mount local disk segment with client id is : " << client_id
-              << ", enable offloading is: " << enable_offloading;
-    auto result =
-        master_service_.MountLocalDiskSegment(client_id, enable_offloading);
+              << ", enable offloading is: " << enable_offloading
+              << ", local_disk_segment_id=" << local_disk_segment_id
+              << ", transport_endpoint=" << transport_endpoint;
+    auto result = master_service_.MountLocalDiskSegment(
+        client_id, enable_offloading, local_disk_segment_id,
+        transport_endpoint);
 
     timer.LogResponseExpected(result);
     return result;

--- a/mooncake-store/src/segment.cpp
+++ b/mooncake-store/src/segment.cpp
@@ -219,18 +219,27 @@ ErrorCode ScopedSegmentAccess::MountSegment(const Segment& segment,
     return ErrorCode::OK;
 }
 
-ErrorCode ScopedSegmentAccess::MountLocalDiskSegment(const UUID& client_id,
-                                                     bool enable_offloading) {
+ErrorCode ScopedSegmentAccess::MountLocalDiskSegment(
+    const UUID& client_id, bool enable_offloading,
+    const std::string& local_disk_segment_id,
+    const std::string& transport_endpoint) {
     auto exist_segment_it =
         segment_manager_->client_local_disk_segment_.find(client_id);
     if (exist_segment_it !=
         segment_manager_->client_local_disk_segment_.end()) {
-        LOG(WARNING) << "client_id=" << client_id
-                     << ", warn=local_disk_segment_already_exists";
-        return ErrorCode::SEGMENT_ALREADY_EXISTS;
+        MutexLocker locker(&exist_segment_it->second->offloading_mutex_);
+        exist_segment_it->second->enable_offloading = enable_offloading;
+        exist_segment_it->second->local_disk_segment_id = local_disk_segment_id;
+        exist_segment_it->second->transport_endpoint = transport_endpoint;
+        LOG(INFO) << "client_id=" << client_id
+                  << ", action=local_disk_segment_already_mounted_update"
+                  << ", local_disk_segment_id=" << local_disk_segment_id;
+        return ErrorCode::OK;
     }
     segment_manager_->client_local_disk_segment_.emplace(
-        client_id, std::make_shared<LocalDiskSegment>(enable_offloading));
+        client_id,
+        std::make_shared<LocalDiskSegment>(
+            enable_offloading, local_disk_segment_id, transport_endpoint));
     return ErrorCode::OK;
 }
 

--- a/mooncake-store/src/serialize/serializer.cpp
+++ b/mooncake-store/src/serialize/serializer.cpp
@@ -658,11 +658,21 @@ tl::expected<void, SerializationError> Serializer<Replica>::serialize(
     // 1. Serialize id_ member variable
     packer.pack(static_cast<uint64_t>(replica.id_));
 
+    auto replica_type = replica.type();
+
+    // DISCONNECTED is a runtime-only LOCAL_DISK owner-liveness state. Restore
+    // it as COMPLETE and let the client monitor re-evaluate liveness after a
+    // leader restart, without changing the snapshot wire format.
+    auto serialized_status = replica.status_;
+    if (replica_type == ReplicaType::LOCAL_DISK &&
+        serialized_status == ReplicaStatus::DISCONNECTED) {
+        serialized_status = ReplicaStatus::COMPLETE;
+    }
+
     // 2. Serialize status_ member variable
-    packer.pack(static_cast<int16_t>(replica.status_));
+    packer.pack(static_cast<int16_t>(serialized_status));
 
     // 3. Serialize replica type
-    auto replica_type = replica.type();
     packer.pack(static_cast<int8_t>(replica_type));
 
     // 4. Serialize specific data by type

--- a/mooncake-store/tests/file_storage_test.cpp
+++ b/mooncake-store/tests/file_storage_test.cpp
@@ -2,6 +2,7 @@
 #include <gtest/gtest.h>
 
 #include <filesystem>
+#include <fstream>
 #include <thread>
 
 #include "allocator.h"
@@ -33,6 +34,7 @@ class FileStorageTest : public ::testing::Test {
         UnsetEnv("MOONCAKE_OFFLOAD_TOTAL_KEYS_LIMIT");
         UnsetEnv("MOONCAKE_OFFLOAD_TOTAL_SIZE_LIMIT_BYTES");
         UnsetEnv("MOONCAKE_OFFLOAD_HEARTBEAT_INTERVAL_SECONDS");
+        UnsetEnv("MC_STORE_REJECT_UNMARKED_DATA");
         data_path = std::filesystem::current_path().string() + "/data";
         fs::create_directories(data_path);
         for (const auto& entry : fs::directory_iterator(data_path)) {
@@ -92,6 +94,7 @@ class FileStorageTest : public ::testing::Test {
     }
 
     void TearDown() override {
+        UnsetEnv("MC_STORE_REJECT_UNMARKED_DATA");
         google::ShutdownGoogleLogging();
         LOG(INFO) << "Clear test data...";
         for (const auto& entry : fs::directory_iterator(data_path)) {
@@ -101,6 +104,101 @@ class FileStorageTest : public ::testing::Test {
         }
     }
 };
+
+TEST_F(FileStorageTest, LocalDiskSegmentMarkerCreatedAndReused) {
+    auto file_storage_config = FileStorageConfig::FromEnvironment();
+    file_storage_config.storage_filepath = data_path;
+
+    {
+        FileStorage fileStorage(file_storage_config, nullptr, "localhost:9003");
+    }
+
+    const auto marker_path =
+        std::filesystem::path(data_path) / ".mooncake_local_disk_segment_id";
+    std::ifstream first_marker(marker_path);
+    std::string first_id;
+    ASSERT_TRUE(std::getline(first_marker, first_id));
+    ASSERT_FALSE(first_id.empty());
+
+    {
+        FileStorage fileStorage(file_storage_config, nullptr, "localhost:9003");
+    }
+
+    std::ifstream second_marker(marker_path);
+    std::string second_id;
+    ASSERT_TRUE(std::getline(second_marker, second_id));
+    EXPECT_EQ(second_id, first_id);
+}
+
+TEST_F(FileStorageTest, LocalDiskSegmentMarkerConcurrentCreateIsIdempotent) {
+    auto file_storage_config = FileStorageConfig::FromEnvironment();
+    file_storage_config.storage_filepath = data_path;
+
+    std::vector<std::thread> threads;
+    std::vector<std::string> errors(8);
+    for (size_t i = 0; i < errors.size(); ++i) {
+        threads.emplace_back([&, i] {
+            try {
+                FileStorage fileStorage(file_storage_config, nullptr,
+                                        "localhost:9003");
+            } catch (const std::exception& e) {
+                errors[i] = e.what();
+            }
+        });
+    }
+    for (auto& thread : threads) {
+        thread.join();
+    }
+    for (const auto& error : errors) {
+        EXPECT_TRUE(error.empty()) << error;
+    }
+
+    const auto marker_path =
+        std::filesystem::path(data_path) / ".mooncake_local_disk_segment_id";
+    std::ifstream marker(marker_path);
+    std::string id;
+    ASSERT_TRUE(std::getline(marker, id));
+    EXPECT_FALSE(id.empty());
+}
+
+TEST_F(FileStorageTest,
+       LocalDiskSegmentMarkerMissingWithDataMigratesByDefault) {
+    std::filesystem::create_directory(std::filesystem::path(data_path) /
+                                      "existing_payload");
+    auto file_storage_config = FileStorageConfig::FromEnvironment();
+    file_storage_config.storage_filepath = data_path;
+
+    FileStorage fileStorage(file_storage_config, nullptr, "localhost:9003");
+
+    const auto marker_path =
+        std::filesystem::path(data_path) / ".mooncake_local_disk_segment_id";
+    std::ifstream marker(marker_path);
+    std::string id;
+    ASSERT_TRUE(std::getline(marker, id));
+    EXPECT_FALSE(id.empty());
+}
+
+TEST_F(FileStorageTest, LocalDiskSegmentMarkerMissingWithDataStrictRejects) {
+    std::filesystem::create_directory(std::filesystem::path(data_path) /
+                                      "existing_payload");
+    SetEnv("MC_STORE_REJECT_UNMARKED_DATA", "1");
+    auto file_storage_config = FileStorageConfig::FromEnvironment();
+    file_storage_config.storage_filepath = data_path;
+
+    EXPECT_THROW(FileStorage(file_storage_config, nullptr, "localhost:9003"),
+                 std::runtime_error);
+}
+
+TEST_F(FileStorageTest, LocalDiskSegmentMarkerEmptyRejects) {
+    const auto marker_path =
+        std::filesystem::path(data_path) / ".mooncake_local_disk_segment_id";
+    std::ofstream(marker_path) << "\n";
+    auto file_storage_config = FileStorageConfig::FromEnvironment();
+    file_storage_config.storage_filepath = data_path;
+
+    EXPECT_THROW(FileStorage(file_storage_config, nullptr, "localhost:9003"),
+                 std::runtime_error);
+}
 
 TEST_F(FileStorageTest, IsEnableOffloading) {
     std::unordered_map<std::string, std::string> all_object;

--- a/mooncake-store/tests/master_service_ssd_test.cpp
+++ b/mooncake-store/tests/master_service_ssd_test.cpp
@@ -120,6 +120,22 @@ void WaitForReplicaNotReady(MasterService& service, const std::string& key,
     EXPECT_EQ(result.error(), ErrorCode::REPLICA_IS_NOT_READY);
 }
 
+void WaitForObjectNotFound(MasterService& service, const std::string& key,
+                           std::chrono::seconds timeout) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+        auto result = service.GetReplicaList(key, "default");
+        if (!result.has_value() &&
+            result.error() == ErrorCode::OBJECT_NOT_FOUND) {
+            return;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    auto result = service.GetReplicaList(key, "default");
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), ErrorCode::OBJECT_NOT_FOUND);
+}
+
 void ExpectNextAllocationOnSegment(MasterService& service,
                                    const UUID& client_id,
                                    const std::string& key,
@@ -890,10 +906,7 @@ TEST_F(MasterServiceSSDTest,
     ASSERT_FALSE(mismatch_result.has_value());
     EXPECT_EQ(mismatch_result.error(), ErrorCode::REPLICA_IS_NOT_READY);
 
-    std::this_thread::sleep_for(std::chrono::seconds(2));
-    auto expired_result = service->GetReplicaList(key, "default");
-    ASSERT_FALSE(expired_result.has_value());
-    EXPECT_EQ(expired_result.error(), ErrorCode::OBJECT_NOT_FOUND);
+    WaitForObjectNotFound(*service, key, std::chrono::seconds(4));
 
     MountMemoryAndLocalDisk(*service, same_marker_late_client,
                             "ssd_expire_same_marker_late", 0x1300000000ULL,

--- a/mooncake-store/tests/master_service_ssd_test.cpp
+++ b/mooncake-store/tests/master_service_ssd_test.cpp
@@ -37,6 +37,18 @@ std::unique_ptr<MasterService> CreateSsdAwareOffloadService() {
     return std::make_unique<MasterService>(config);
 }
 
+std::unique_ptr<MasterService> CreateSsdRejoinService(
+    int64_t client_live_ttl_sec, int64_t local_disk_rejoin_grace_sec) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.default_kv_lease_ttl = 0;
+    config.client_live_ttl_sec = client_live_ttl_sec;
+    config.local_disk_rejoin_grace_sec = local_disk_rejoin_grace_sec;
+    config.allocation_strategy_type =
+        AllocationStrategyType::SSD_FREE_RATIO_FIRST;
+    return std::make_unique<MasterService>(config);
+}
+
 void MountMemoryAndLocalDisk(MasterService& service, const UUID& client_id,
                              const std::string& segment_name,
                              size_t base_addr) {
@@ -49,6 +61,26 @@ void MountMemoryAndLocalDisk(MasterService& service, const UUID& client_id,
 
     ASSERT_TRUE(service.MountSegment(segment, client_id).has_value());
     ASSERT_TRUE(service.MountLocalDiskSegment(client_id, true).has_value());
+    ASSERT_TRUE(service.ReportSsdCapacity(client_id, 1000).has_value());
+}
+
+void MountMemoryAndLocalDisk(MasterService& service, const UUID& client_id,
+                             const std::string& segment_name, size_t base_addr,
+                             const std::string& local_disk_segment_id,
+                             const std::string& transport_endpoint) {
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = segment_name;
+    segment.base = base_addr;
+    segment.size = 64 * 1024 * 1024;
+    segment.te_endpoint = segment.name;
+
+    ASSERT_TRUE(service.MountSegment(segment, client_id).has_value());
+    ASSERT_TRUE(service
+                    .MountLocalDiskSegment(client_id, true,
+                                           local_disk_segment_id,
+                                           transport_endpoint)
+                    .has_value());
     ASSERT_TRUE(service.ReportSsdCapacity(client_id, 1000).has_value());
 }
 
@@ -70,6 +102,22 @@ void PutAndOffload(MasterService& service, const UUID& client_id,
         .tenant_id = "default", .key = key, .size = object_size};
     ASSERT_TRUE(service.NotifyOffloadSuccess(client_id, {task}, {metadata})
                     .has_value());
+}
+
+void WaitForReplicaNotReady(MasterService& service, const std::string& key,
+                            std::chrono::seconds timeout) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+        auto result = service.GetReplicaList(key, "default");
+        if (!result.has_value() &&
+            result.error() == ErrorCode::REPLICA_IS_NOT_READY) {
+            return;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    auto result = service.GetReplicaList(key, "default");
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), ErrorCode::REPLICA_IS_NOT_READY);
 }
 
 void ExpectNextAllocationOnSegment(MasterService& service,
@@ -774,6 +822,380 @@ TEST_F(MasterServiceSSDTest, EvictDiskReplicaDecrementsFileCacheNums) {
     // mem_cache_nums_ unchanged (MEMORY replica still present).
     EXPECT_EQ(metrics.get_file_cache_nums(), baseline);
     EXPECT_EQ(metrics.get_mem_cache_nums(), baseline_mem + 1);
+}
+
+TEST_F(MasterServiceSSDTest,
+       LocalDiskReplicaDisconnectInvisibleThenReattachesBySegmentId) {
+    auto service = CreateSsdRejoinService(/*client_live_ttl_sec=*/1,
+                                          /*local_disk_rejoin_grace_sec=*/10);
+    const UUID old_client = generate_uuid();
+    const UUID new_client = generate_uuid();
+    const std::string marker = "local-disk-segment-rejoin-ok";
+    const std::string key = "ssd_rejoin_invisible_then_ok";
+
+    const std::string old_segment = "ssd_rejoin_old";
+    MountMemoryAndLocalDisk(*service, old_client, old_segment, 0xf00000000ULL,
+                            marker, "old_endpoint");
+    PutAndOffload(*service, old_client, key, 256, "old_endpoint");
+
+    auto clear_result =
+        service->BatchReplicaClear({key}, old_client, old_segment);
+    ASSERT_TRUE(clear_result.has_value());
+    ASSERT_EQ(clear_result->size(), 1u);
+    EXPECT_EQ((*clear_result)[0], key);
+    auto before_expiry = service->GetReplicaList(key, "default");
+    ASSERT_TRUE(before_expiry.has_value());
+    ASSERT_EQ(before_expiry->replicas.size(), 1u);
+    ASSERT_TRUE(before_expiry->replicas[0].is_local_disk_replica());
+
+    WaitForReplicaNotReady(*service, key, std::chrono::seconds(4));
+
+    MountMemoryAndLocalDisk(*service, new_client, "ssd_rejoin_new",
+                            0x1000000000ULL, marker, "new_endpoint");
+    auto reattached = service->GetReplicaList(key, "default");
+    ASSERT_TRUE(reattached.has_value());
+    ASSERT_EQ(reattached->replicas.size(), 1u);
+    const auto descriptor = reattached->replicas[0].get_local_disk_descriptor();
+    EXPECT_EQ(descriptor.client_id, new_client);
+    EXPECT_EQ(descriptor.transport_endpoint, "new_endpoint");
+    EXPECT_EQ(descriptor.local_disk_segment_id, marker);
+}
+
+TEST_F(MasterServiceSSDTest,
+       LocalDiskReplicaGraceExpiryRemovesAndMarkerMismatchCannotReattach) {
+    auto service = CreateSsdRejoinService(/*client_live_ttl_sec=*/1,
+                                          /*local_disk_rejoin_grace_sec=*/1);
+    const UUID old_client = generate_uuid();
+    const UUID mismatch_client = generate_uuid();
+    const UUID same_marker_late_client = generate_uuid();
+    const std::string marker = "local-disk-segment-expire";
+    const std::string key = "ssd_rejoin_expire_no_reattach";
+
+    const std::string old_segment = "ssd_expire_old";
+    MountMemoryAndLocalDisk(*service, old_client, old_segment, 0x1100000000ULL,
+                            marker, "old_endpoint");
+    PutAndOffload(*service, old_client, key, 256, "old_endpoint");
+    auto clear_result =
+        service->BatchReplicaClear({key}, old_client, old_segment);
+    ASSERT_TRUE(clear_result.has_value());
+    ASSERT_EQ(clear_result->size(), 1u);
+    EXPECT_EQ((*clear_result)[0], key);
+
+    WaitForReplicaNotReady(*service, key, std::chrono::seconds(4));
+
+    MountMemoryAndLocalDisk(*service, mismatch_client, "ssd_expire_mismatch",
+                            0x1200000000ULL, "different-marker",
+                            "mismatch_endpoint");
+    auto mismatch_result = service->GetReplicaList(key, "default");
+    ASSERT_FALSE(mismatch_result.has_value());
+    EXPECT_EQ(mismatch_result.error(), ErrorCode::REPLICA_IS_NOT_READY);
+
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+    auto expired_result = service->GetReplicaList(key, "default");
+    ASSERT_FALSE(expired_result.has_value());
+    EXPECT_EQ(expired_result.error(), ErrorCode::OBJECT_NOT_FOUND);
+
+    MountMemoryAndLocalDisk(*service, same_marker_late_client,
+                            "ssd_expire_same_marker_late", 0x1300000000ULL,
+                            marker, "late_endpoint");
+    auto late_result = service->GetReplicaList(key, "default");
+    ASSERT_FALSE(late_result.has_value());
+    EXPECT_EQ(late_result.error(), ErrorCode::OBJECT_NOT_FOUND);
+}
+
+TEST_F(MasterServiceSSDTest,
+       LocalDiskReplicaReattachesReplacementBeforeOldClientExpires) {
+    auto service = CreateSsdRejoinService(/*client_live_ttl_sec=*/5,
+                                          /*local_disk_rejoin_grace_sec=*/10);
+    const UUID old_client = generate_uuid();
+    const UUID new_client = generate_uuid();
+    const std::string marker = "local-disk-segment-before-ttl";
+    const std::string key = "ssd_rejoin_before_ttl";
+
+    MountMemoryAndLocalDisk(*service, old_client, "ssd_before_ttl_old",
+                            0x1900000000ULL, marker, "old_endpoint");
+    PutAndOffload(*service, old_client, key, 256, "old_endpoint");
+    auto clear_result =
+        service->BatchReplicaClear({key}, old_client, "ssd_before_ttl_old");
+    ASSERT_TRUE(clear_result.has_value());
+    ASSERT_EQ(clear_result->size(), 1u);
+
+    auto before_replacement = service->GetReplicaList(key, "default");
+    ASSERT_TRUE(before_replacement.has_value());
+    ASSERT_EQ(before_replacement->replicas.size(), 1u);
+    EXPECT_EQ(
+        before_replacement->replicas[0].get_local_disk_descriptor().client_id,
+        old_client);
+
+    MountMemoryAndLocalDisk(*service, new_client, "ssd_before_ttl_new",
+                            0x1a00000000ULL, marker, "new_endpoint");
+    auto reattached = service->GetReplicaList(key, "default");
+    ASSERT_TRUE(reattached.has_value());
+    ASSERT_EQ(reattached->replicas.size(), 1u);
+    const auto descriptor = reattached->replicas[0].get_local_disk_descriptor();
+    EXPECT_EQ(descriptor.client_id, new_client);
+    EXPECT_EQ(descriptor.transport_endpoint, "new_endpoint");
+    EXPECT_EQ(descriptor.local_disk_segment_id, marker);
+}
+
+TEST_F(MasterServiceSSDTest, ReattachRestoresLocalDiskUsageTracking) {
+    auto service = CreateSsdRejoinService(/*client_live_ttl_sec=*/1,
+                                          /*local_disk_rejoin_grace_sec=*/10);
+    const UUID old_client = generate_uuid();
+    const UUID new_client = generate_uuid();
+    const UUID other_client = generate_uuid();
+    const std::string marker = "local-disk-segment-usage-restore";
+    const std::string old_segment = "ssd_usage_old";
+    const std::string new_segment = "ssd_usage_new";
+    const std::string other_segment = "ssd_usage_other";
+    const std::string key = "ssd_rejoin_usage_restore";
+
+    MountMemoryAndLocalDisk(*service, old_client, old_segment, 0x1b00000000ULL,
+                            marker, "old_endpoint");
+    PutAndOffload(*service, old_client, key, 800, "old_endpoint");
+
+    auto clear_result =
+        service->BatchReplicaClear({key}, old_client, old_segment);
+    ASSERT_TRUE(clear_result.has_value());
+    ASSERT_EQ(clear_result->size(), 1u);
+    WaitForReplicaNotReady(*service, key, std::chrono::seconds(4));
+
+    MountMemoryAndLocalDisk(*service, other_client, other_segment,
+                            0x1c00000000ULL, "other-marker", "other_endpoint");
+    PutAndOffload(*service, other_client, "ssd_usage_other_baseline", 100,
+                  "other_endpoint");
+
+    MountMemoryAndLocalDisk(*service, new_client, new_segment, 0x1d00000000ULL,
+                            marker, "new_endpoint");
+    auto reattached = service->GetReplicaList(key, "default");
+    ASSERT_TRUE(reattached.has_value());
+
+    ExpectNextAllocationOnSegment(*service, other_client,
+                                  "ssd_usage_restore_probe", other_segment);
+}
+
+TEST_F(MasterServiceSSDTest, UpsertRemovesDisconnectedLocalDiskReplica) {
+    auto service = CreateSsdRejoinService(/*client_live_ttl_sec=*/1,
+                                          /*local_disk_rejoin_grace_sec=*/10);
+    const UUID old_client = generate_uuid();
+    const UUID writer_client = generate_uuid();
+    const UUID rejoin_client = generate_uuid();
+    const std::string marker = "local-disk-segment-upsert-stale";
+    const std::string key = "ssd_rejoin_upsert_stale";
+
+    MountMemoryAndLocalDisk(*service, old_client, "ssd_upsert_old",
+                            0x1e00000000ULL, marker, "old_endpoint");
+    PutAndOffload(*service, old_client, key, 256, "old_endpoint");
+    auto clear_result =
+        service->BatchReplicaClear({key}, old_client, "ssd_upsert_old");
+    ASSERT_TRUE(clear_result.has_value());
+    ASSERT_EQ(clear_result->size(), 1u);
+    WaitForReplicaNotReady(*service, key, std::chrono::seconds(4));
+
+    Segment writer_segment;
+    writer_segment.id = generate_uuid();
+    writer_segment.name = "ssd_upsert_writer";
+    writer_segment.base = 0x1f00000000ULL;
+    writer_segment.size = 64 * 1024 * 1024;
+    writer_segment.te_endpoint = writer_segment.name;
+    ASSERT_TRUE(
+        service->MountSegment(writer_segment, writer_client).has_value());
+
+    ReplicateConfig config;
+    config.replica_num = 1;
+    auto upsert_result =
+        service->UpsertStart(writer_client, key, "default", 256, config);
+    ASSERT_TRUE(upsert_result.has_value());
+    ASSERT_TRUE(
+        service->UpsertEnd(writer_client, key, "default", ReplicaType::MEMORY)
+            .has_value());
+
+    MountMemoryAndLocalDisk(*service, rejoin_client, "ssd_upsert_rejoin",
+                            0x2000000000ULL, marker, "rejoin_endpoint");
+    auto result = service->GetReplicaList(key, "default");
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(result->replicas.size(), 1u);
+    EXPECT_TRUE(result->replicas[0].is_memory_replica());
+}
+
+TEST_F(MasterServiceSSDTest,
+       ForceBatchRemoveDropsDisconnectedLocalDiskReplica) {
+    auto service = CreateSsdRejoinService(/*client_live_ttl_sec=*/1,
+                                          /*local_disk_rejoin_grace_sec=*/10);
+    const UUID old_client = generate_uuid();
+    const std::string marker = "local-disk-segment-force-remove";
+    const std::string key = "ssd_rejoin_force_remove";
+
+    MountMemoryAndLocalDisk(*service, old_client, "ssd_force_remove_old",
+                            0x2100000000ULL, marker, "old_endpoint");
+    PutAndOffload(*service, old_client, key, 256, "old_endpoint");
+    auto clear_result =
+        service->BatchReplicaClear({key}, old_client, "ssd_force_remove_old");
+    ASSERT_TRUE(clear_result.has_value());
+    ASSERT_EQ(clear_result->size(), 1u);
+    WaitForReplicaNotReady(*service, key, std::chrono::seconds(4));
+
+    auto remove_result = service->BatchRemove({key}, "default", /*force=*/true);
+    ASSERT_EQ(remove_result.size(), 1u);
+    ASSERT_TRUE(remove_result[0].has_value());
+
+    auto get_result = service->GetReplicaList(key, "default");
+    ASSERT_FALSE(get_result.has_value());
+    EXPECT_EQ(get_result.error(), ErrorCode::OBJECT_NOT_FOUND);
+}
+
+TEST_F(MasterServiceSSDTest,
+       OffloadSuccessAddsDiskReplicaWhenOnlyStaleDiskOwnerExists) {
+    auto service = CreateSsdRejoinService(/*client_live_ttl_sec=*/1,
+                                          /*local_disk_rejoin_grace_sec=*/10);
+    const UUID writer_client = generate_uuid();
+    const UUID old_disk_client = generate_uuid();
+    const UUID new_disk_client = generate_uuid();
+    const std::string key = "ssd_rejoin_offload_after_stale";
+
+    Segment writer_segment;
+    writer_segment.id = generate_uuid();
+    writer_segment.name = "ssd_stale_writer";
+    writer_segment.base = 0x2200000000ULL;
+    writer_segment.size = 64 * 1024 * 1024;
+    writer_segment.te_endpoint = writer_segment.name;
+    ASSERT_TRUE(
+        service->MountSegment(writer_segment, writer_client).has_value());
+
+    MountMemoryAndLocalDisk(*service, old_disk_client, "ssd_stale_old_disk",
+                            0x2300000000ULL, "old-stale-marker",
+                            "old_endpoint");
+
+    ReplicateConfig config;
+    config.replica_num = 1;
+    ASSERT_TRUE(service->PutStart(writer_client, key, "default", 256, config)
+                    .has_value());
+    ASSERT_TRUE(
+        service->PutEnd(writer_client, key, "default", ReplicaType::MEMORY)
+            .has_value());
+
+    StorageObjectMetadata old_metadata;
+    old_metadata.data_size = 256;
+    old_metadata.transport_endpoint = "old_endpoint";
+    OffloadTaskItem task{.tenant_id = "default", .key = key, .size = 256};
+    ASSERT_TRUE(
+        service->NotifyOffloadSuccess(old_disk_client, {task}, {old_metadata})
+            .has_value());
+
+    for (int i = 0; i < 5; ++i) {
+        ASSERT_TRUE(service->Ping(writer_client).has_value());
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    }
+    MountMemoryAndLocalDisk(*service, new_disk_client, "ssd_stale_new_disk",
+                            0x2400000000ULL, "new-stale-marker",
+                            "new_endpoint");
+
+    StorageObjectMetadata new_metadata;
+    new_metadata.data_size = 256;
+    new_metadata.transport_endpoint = "new_endpoint";
+    ASSERT_TRUE(
+        service->NotifyOffloadSuccess(new_disk_client, {task}, {new_metadata})
+            .has_value());
+
+    auto after_new_offload = service->GetReplicaList(key, "default");
+    ASSERT_TRUE(after_new_offload.has_value());
+    bool found_new_disk = false;
+    for (const auto& replica : after_new_offload->replicas) {
+        if (!replica.is_local_disk_replica()) {
+            continue;
+        }
+        const auto desc = replica.get_local_disk_descriptor();
+        if (desc.client_id == new_disk_client &&
+            desc.transport_endpoint == "new_endpoint") {
+            found_new_disk = true;
+        }
+    }
+    EXPECT_TRUE(found_new_disk);
+}
+
+TEST_F(MasterServiceSSDTest, EmptyLocalDiskSegmentIdDoesNotReattach) {
+    auto service = CreateSsdRejoinService(/*client_live_ttl_sec=*/1,
+                                          /*local_disk_rejoin_grace_sec=*/10);
+    const UUID old_client = generate_uuid();
+    const UUID old_style_client = generate_uuid();
+    const UUID new_client = generate_uuid();
+    const std::string marker = "local-disk-segment-empty-old-style";
+    const std::string key = "ssd_rejoin_empty_marker_no_adopt";
+
+    MountMemoryAndLocalDisk(*service, old_client, "ssd_empty_old",
+                            0x1400000000ULL, marker, "old_endpoint");
+    PutAndOffload(*service, old_client, key, 256, "old_endpoint");
+    auto clear_result =
+        service->BatchReplicaClear({key}, old_client, "ssd_empty_old");
+    ASSERT_TRUE(clear_result.has_value());
+    ASSERT_EQ(clear_result->size(), 1u);
+    EXPECT_EQ((*clear_result)[0], key);
+
+    WaitForReplicaNotReady(*service, key, std::chrono::seconds(4));
+
+    MountMemoryAndLocalDisk(*service, old_style_client, "ssd_empty_old_style",
+                            0x1500000000ULL, "", "old_style_endpoint");
+    auto old_style_result = service->GetReplicaList(key, "default");
+    ASSERT_FALSE(old_style_result.has_value());
+    EXPECT_EQ(old_style_result.error(), ErrorCode::REPLICA_IS_NOT_READY);
+
+    MountMemoryAndLocalDisk(*service, new_client, "ssd_empty_new",
+                            0x1600000000ULL, marker, "new_endpoint");
+    auto reattached = service->GetReplicaList(key, "default");
+    ASSERT_TRUE(reattached.has_value());
+    ASSERT_EQ(reattached->replicas.size(), 1u);
+    const auto descriptor = reattached->replicas[0].get_local_disk_descriptor();
+    EXPECT_EQ(descriptor.client_id, new_client);
+    EXPECT_EQ(descriptor.transport_endpoint, "new_endpoint");
+    EXPECT_EQ(descriptor.local_disk_segment_id, marker);
+}
+
+TEST_F(MasterServiceSSDTest, ReattachFiveThousandLocalDiskReplicasQuickly) {
+    auto service = CreateSsdRejoinService(/*client_live_ttl_sec=*/1,
+                                          /*local_disk_rejoin_grace_sec=*/10);
+    const UUID old_client = generate_uuid();
+    const UUID new_client = generate_uuid();
+    const std::string marker = "local-disk-segment-scale-5k";
+    const std::string old_segment = "ssd_scale_5k_old";
+    constexpr size_t kKeyCount = 5000;
+
+    MountMemoryAndLocalDisk(*service, old_client, old_segment, 0x1700000000ULL,
+                            marker, "old_endpoint");
+
+    std::vector<std::string> keys;
+    keys.reserve(kKeyCount);
+    for (size_t i = 0; i < kKeyCount; ++i) {
+        auto key = "ssd_rejoin_scale_5k_" + std::to_string(i);
+        PutAndOffload(*service, old_client, key, 256, "old_endpoint");
+        keys.emplace_back(std::move(key));
+    }
+
+    auto clear_result =
+        service->BatchReplicaClear(keys, old_client, old_segment);
+    ASSERT_TRUE(clear_result.has_value());
+    ASSERT_EQ(clear_result->size(), kKeyCount);
+
+    WaitForReplicaNotReady(*service, keys.front(), std::chrono::seconds(4));
+
+    const auto start = std::chrono::steady_clock::now();
+    MountMemoryAndLocalDisk(*service, new_client, "ssd_scale_5k_new",
+                            0x1800000000ULL, marker, "new_endpoint");
+    const auto elapsed_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - start)
+            .count();
+    EXPECT_LT(elapsed_ms, 1000);
+
+    for (const auto& key : {keys.front(), keys[kKeyCount / 2], keys.back()}) {
+        auto reattached = service->GetReplicaList(key, "default");
+        ASSERT_TRUE(reattached.has_value());
+        ASSERT_EQ(reattached->replicas.size(), 1u);
+        const auto descriptor =
+            reattached->replicas[0].get_local_disk_descriptor();
+        EXPECT_EQ(descriptor.client_id, new_client);
+        EXPECT_EQ(descriptor.transport_endpoint, "new_endpoint");
+        EXPECT_EQ(descriptor.local_disk_segment_id, marker);
+    }
 }
 
 // Real-path performance comparison: MasterService PutStart throughput for

--- a/mooncake-store/tests/master_service_ssd_test.cpp
+++ b/mooncake-store/tests/master_service_ssd_test.cpp
@@ -502,7 +502,7 @@ TEST_F(MasterServiceSSDTest, PutStartExpires) {
     ASSERT_TRUE(mount_result.has_value());
 
     std::string key = "test_key";
-    uint64_t value_length = 16 * 1024 * 1024;  // 16MB
+    uint64_t value_length = 8 * 1024 * 1024;  // 8MB
     uint64_t slice_length = value_length;
     ReplicateConfig config;
 

--- a/mooncake-store/tests/segment_test.cpp
+++ b/mooncake-store/tests/segment_test.cpp
@@ -747,8 +747,8 @@ TEST_F(SegmentTest, MountLocalDiskSegmentSuccess) {
 }
 
 // MountLocalDiskSegmentDuplicate Tests:
-// 1. MountLocalDiskSegment with the same segment id. The second mount operation
-// return SEGMENT_ALREADY_EXISTS.
+// 1. MountLocalDiskSegment with the same client id is idempotent and updates
+// the existing local disk segment metadata.
 // 2. MountLocalDiskSegment with different segment id and the same segment name
 // should be considered as different segments. Validate the status of
 // SegmentManager use ValidateMountedLocalDiskSegments function.
@@ -766,9 +766,9 @@ TEST_F(SegmentTest, MountLocalDiskSegmentDuplicate) {
     // Verify first mount
     ValidateMountedLocalDiskSegments(segment_manager, segment, client_id);
 
-    // Test duplicate mount - mount the same segment again
+    // Test duplicate mount - the same client can update its local disk segment
     ASSERT_EQ(segment_access.MountLocalDiskSegment(client_id, true),
-              ErrorCode::SEGMENT_ALREADY_EXISTS);
+              ErrorCode::OK);
 
     // Verify state remains the same after duplicate mount
     ValidateMountedLocalDiskSegments(segment_manager, segment, client_id);


### PR DESCRIPTION
## Summary

Reattaches LOCAL_DISK replicas when a client restarts with the same on-disk segment marker.

## Changes

- Keep expired LOCAL_DISK replicas hidden during a configurable grace period.
- Persist a storage-bound marker and pass it through `MountLocalDiskSegment`.
- Reattach matching replicas with the restarted client's endpoint and restore SSD accounting.
- Remove stale disconnected copies on overwrite and keep eviction/offload decisions limited to completed disk replicas.
- Keep disconnect state runtime-only; no snapshot schema change or promotion-on-hit changes.

## Validation

- Release build and clang-format check passed.
- `master_service_ssd_test`: 27/27 passed.
- `file_storage_test`, `segment_test`, `serializer_test`, and `master_service_ssd_test_for_snapshot` passed.
- Process repro: 4/4 LOCAL_DISK-only reads recovered after one mount reattachment; first successful read was 5 ms after restart, with no `ScanMeta` recovery in the logs.

Refs #2306