### PR TITLE
[Store] Fix S3 list objects pagination

### DIFF
--- a/mooncake-store/src/utils/s3_helper.cpp
+++ b/mooncake-store/src/utils/s3_helper.cpp
@@ -6,7 +6,7 @@
 #include <aws/s3/model/DeleteObjectRequest.h>
 #include <aws/core/auth/AWSCredentials.h>
 #include <aws/core/utils/memory/stl/AWSVector.h>
-#include <aws/s3/model/ListObjectsRequest.h>
+#include <aws/s3/model/ListObjectsV2Request.h>
 #include <aws/s3/model/DeleteObjectsRequest.h>
 #include <aws/s3/model/ObjectIdentifier.h>
 #include <aws/s3/model/Delete.h>
@@ -781,7 +781,7 @@ tl::expected<void, std::string> S3Helper::ListObjectsWithPrefix(
     const std::string &prefix, std::vector<std::string> &object_keys) {
     object_keys.clear();
 
-    Aws::S3::Model::ListObjectsRequest request;
+    Aws::S3::Model::ListObjectsV2Request request;
     request.WithBucket(bucket_);
     request.WithPrefix(prefix);
 
@@ -791,10 +791,10 @@ tl::expected<void, std::string> S3Helper::ListObjectsWithPrefix(
 
     bool done = false;
     while (!done) {
-        auto outcome = s3_client_.ListObjects(request);
+        auto outcome = s3_client_.ListObjectsV2(request);
         if (!outcome.IsSuccess()) {
             return tl::make_unexpected(fmt::format(
-                "ListObjects error: {}", outcome.GetError().GetMessage()));
+                "ListObjectsV2 error: {}", outcome.GetError().GetMessage()));
         }
 
         const auto &result = outcome.GetResult();
@@ -806,8 +806,13 @@ tl::expected<void, std::string> S3Helper::ListObjectsWithPrefix(
 
         // Check if there are more objects to fetch
         if (result.GetIsTruncated()) {
-            // Set marker to get next page
-            request.WithMarker(result.GetNextMarker());
+            const auto &next_token = result.GetNextContinuationToken();
+            if (next_token.empty()) {
+                return tl::make_unexpected(
+                    "ListObjectsV2 error: truncated response missing next "
+                    "continuation token");
+            }
+            request.SetContinuationToken(next_token);
         } else {
             done = true;
         }


### PR DESCRIPTION
## Description

Fixes #2735.

This PR fixes S3 prefix listing pagination in `S3Helper::ListObjectsWithPrefix()`:

- Uses `ListObjectsV2` instead of the legacy `ListObjects` API.
- Advances pages with `NextContinuationToken` instead of `NextMarker`.
- Returns an error if S3 reports a truncated response without a continuation token, avoiding an infinite loop.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
git diff --check
SKIP=mooncake-code-format pre-commit run --files mooncake-store/src/utils/s3_helper.cpp
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh` (blocked locally by missing `clang-format-20`)
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable; not applicable for this bug fix)
- [ ] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue (not applicable; this PR changes one source file)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used: Codex assisted with issue triage, implementation, and PR description.