### PR TITLE
[Store] Add P2POpLogApplier dispatch

### DIFF
--- a/mooncake-store/include/ha/oplog/p2p_oplog_applier.h
+++ b/mooncake-store/include/ha/oplog/p2p_oplog_applier.h
@@ -1,0 +1,59 @@
+// mooncake-store/include/ha/oplog/p2p_oplog_applier.h
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include "ha/oplog/oplog_applier.h"
+#include "ha/oplog/p2p_oplog_types.h"
+#include "ha/oplog/p2p_standby_metadata_store.h"
+
+namespace mooncake {
+
+/// P2P-specific OpLog applier.
+///
+/// Extends the main branch's OpLogApplier base class to handle currently
+/// defined P2P-specific OpType values (ADD_REPLICA, REMOVE_REPLICA,
+/// MOUNT_SEGMENT, UNMOUNT_SEGMENT, REMOVE_ALL, REGISTER_CLIENT,
+/// UNREGISTER_CLIENT). The base class handles PUT_END, PUT_REVOKE, and REMOVE
+/// using the generic MetadataStore interface.
+///
+/// P2POpLogApplier delegates P2P OpTypes to P2PStandbyMetadataStore which
+/// maintains both object metadata (via MetadataStore) and P2P-specific state
+/// (client registrations, segment mappings).
+///
+/// Note: primary-side recording for UNREGISTER_CLIENT is intentionally deferred
+/// to the follow-up change that wires lifecycle events into RecordOplog().
+class P2POpLogApplier : public OpLogApplier {
+   public:
+    /// Constructor.
+    /// @param p2p_store       The P2PStandbyMetadataStore to apply ops to.
+    ///                        Must outlive this applier.
+    /// @param cluster_id      Cluster ID for validation.
+    /// @param oplog_store     Optional OpLogStore for gap resolution.
+    explicit P2POpLogApplier(P2PStandbyMetadataStore* p2p_store,
+                             const std::string& cluster_id = std::string(),
+                             OpLogStore* oplog_store = nullptr);
+
+    /// Override to handle P2P-specific OpTypes.
+    /// Falls back to OpLogApplier::ApplyOpLogEntry for PUT_END, PUT_REVOKE,
+    /// and REMOVE.
+    bool ApplyOpLogEntry(const OpLogEntry& entry) override;
+
+    /// Get the underlying P2P metadata store.
+    P2PStandbyMetadataStore* GetP2PMetadataStore() const { return p2p_store_; }
+
+   private:
+    // Apply individual P2P OpTypes. Return true on success.
+    bool ApplyAddReplica(const OpLogEntry& entry);
+    bool ApplyRemoveReplica(const OpLogEntry& entry);
+    bool ApplyMountSegment(const OpLogEntry& entry);
+    bool ApplyUnmountSegment(const OpLogEntry& entry);
+    bool ApplyRemoveAll(const OpLogEntry& entry);
+    bool ApplyRegisterClient(const OpLogEntry& entry);
+    bool ApplyUnregisterClient(const OpLogEntry& entry);
+
+    P2PStandbyMetadataStore* p2p_store_;
+};
+
+}  // namespace mooncake

--- a/mooncake-store/include/ha/oplog/p2p_oplog_types.h
+++ b/mooncake-store/include/ha/oplog/p2p_oplog_types.h
@@ -24,6 +24,7 @@ constexpr OpType OpType_MOUNT_SEGMENT = static_cast<OpType>(12);
 constexpr OpType OpType_UNMOUNT_SEGMENT = static_cast<OpType>(13);
 constexpr OpType OpType_REMOVE_ALL = static_cast<OpType>(14);
 constexpr OpType OpType_REGISTER_CLIENT = static_cast<OpType>(15);
+constexpr OpType OpType_UNREGISTER_CLIENT = static_cast<OpType>(16);
 
 // ============================================================================
 // P2P Payload structures for OpLog entries
@@ -47,6 +48,14 @@ struct RegisterClientPayload {
     YLT_REFL(RegisterClientPayload, client_id, ip_address, rpc_port, segments);
 };
 
+/// Payload for UNREGISTER_CLIENT (OpType=16, sync).
+/// Records that a client was proactively unregistered.
+struct UnregisterClientPayload {
+    UUID client_id{0, 0};
+
+    YLT_REFL(UnregisterClientPayload, client_id);
+};
+
 /// Payload for ADD_REPLICA (OpType=10, async).
 /// Records that a replica was added to an object.
 struct AddReplicaPayload {
@@ -54,12 +63,8 @@ struct AddReplicaPayload {
     UUID client_id{0, 0};
     UUID segment_id{0, 0};
     size_t size = 0;
-    int priority = 0;
-    std::vector<std::string> tags;
-    MemoryType memory_type = MemoryType::DRAM;
 
-    YLT_REFL(AddReplicaPayload, object_key, client_id, segment_id, size,
-             priority, tags, memory_type);
+    YLT_REFL(AddReplicaPayload, object_key, client_id, segment_id, size);
 };
 
 /// Payload for REMOVE_REPLICA (OpType=11, async).
@@ -100,6 +105,7 @@ struct UnmountSegmentPayload {
 
 /// Serialize a P2P payload to binary (struct_pack format).
 std::string SerializeP2PPayload(const RegisterClientPayload& payload);
+std::string SerializeP2PPayload(const UnregisterClientPayload& payload);
 std::string SerializeP2PPayload(const AddReplicaPayload& payload);
 std::string SerializeP2PPayload(const RemoveReplicaPayload& payload);
 std::string SerializeP2PPayload(const MountSegmentPayload& payload);
@@ -109,6 +115,8 @@ std::string SerializeP2PPayload(const UnmountSegmentPayload& payload);
 /// Returns true on success, false on deserialization error.
 bool DeserializeP2PPayload(const std::string& data,
                            RegisterClientPayload& payload);
+bool DeserializeP2PPayload(const std::string& data,
+                           UnregisterClientPayload& payload);
 bool DeserializeP2PPayload(const std::string& data, AddReplicaPayload& payload);
 bool DeserializeP2PPayload(const std::string& data,
                            RemoveReplicaPayload& payload);

--- a/mooncake-store/include/ha/oplog/p2p_standby_metadata_store.h
+++ b/mooncake-store/include/ha/oplog/p2p_standby_metadata_store.h
@@ -66,7 +66,7 @@ class P2PStandbyMetadataStore : public MetadataStore {
 
     /// Add a replica to an object. Creates the object if it doesn't exist.
     void AddReplica(const std::string& object_key, const UUID& client_id,
-                    const UUID& segment_id, size_t size);
+                    const UUID& segment_id, size_t size, uint64_t sequence_id);
 
     /// Remove a replica from an object. Removes the object if no replicas left.
     void RemoveReplica(const std::string& object_key, const UUID& client_id,

--- a/mooncake-store/include/ha/oplog/p2p_standby_metadata_store.h
+++ b/mooncake-store/include/ha/oplog/p2p_standby_metadata_store.h
@@ -66,9 +66,7 @@ class P2PStandbyMetadataStore : public MetadataStore {
 
     /// Add a replica to an object. Creates the object if it doesn't exist.
     void AddReplica(const std::string& object_key, const UUID& client_id,
-                    const UUID& segment_id, size_t size, int priority,
-                    const std::vector<std::string>& tags,
-                    MemoryType memory_type);
+                    const UUID& segment_id, size_t size);
 
     /// Remove a replica from an object. Removes the object if no replicas left.
     void RemoveReplica(const std::string& object_key, const UUID& client_id,

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -75,6 +75,7 @@ set(MOONCAKE_STORE_SOURCES
     ha/oplog/oplog_replicator.cpp
     # P2P HA OpLog components
     ha/oplog/p2p_oplog_types.cpp
+    ha/oplog/p2p_oplog_applier.cpp
     ha/oplog/p2p_standby_metadata_store.cpp
     standby_state_machine.cpp
     ha_metric_manager.cpp

--- a/mooncake-store/src/ha/oplog/p2p_oplog_applier.cpp
+++ b/mooncake-store/src/ha/oplog/p2p_oplog_applier.cpp
@@ -1,0 +1,210 @@
+#include "ha/oplog/p2p_oplog_applier.h"
+
+#include <glog/logging.h>
+
+#include "ha/oplog/oplog_manager.h"
+#include "ha_metric_manager.h"
+#include "types.h"
+
+namespace mooncake {
+
+P2POpLogApplier::P2POpLogApplier(P2PStandbyMetadataStore* p2p_store,
+                                 const std::string& cluster_id,
+                                 OpLogStore* oplog_store)
+    : OpLogApplier(p2p_store, cluster_id, oplog_store), p2p_store_(p2p_store) {
+    if (p2p_store_ == nullptr) {
+        LOG(FATAL) << "P2POpLogApplier: p2p_store cannot be null";
+    }
+}
+
+bool P2POpLogApplier::ApplyOpLogEntry(const OpLogEntry& entry) {
+    // Main branch OpTypes — delegate entirely to base class (which handles
+    // validate, checksum, sequence ordering, and dispatch).
+    if (entry.op_type == OpType::PUT_END ||
+        entry.op_type == OpType::PUT_REVOKE ||
+        entry.op_type == OpType::REMOVE ||
+        entry.op_type == OpType::LEASE_RENEW) {
+        return OpLogApplier::ApplyOpLogEntry(entry);
+    }
+
+    // For P2P OpTypes, perform the same validate + checksum + sequence checks
+    // as the base class, then dispatch to P2P-specific apply methods.
+    const bool is_p2p_op = entry.op_type == OpType_ADD_REPLICA ||
+                           entry.op_type == OpType_REMOVE_REPLICA ||
+                           entry.op_type == OpType_MOUNT_SEGMENT ||
+                           entry.op_type == OpType_UNMOUNT_SEGMENT ||
+                           entry.op_type == OpType_REMOVE_ALL ||
+                           entry.op_type == OpType_REGISTER_CLIENT ||
+                           entry.op_type == OpType_UNREGISTER_CLIENT;
+    if (!is_p2p_op) {
+        LOG(ERROR) << "P2POpLogApplier: unknown op_type="
+                   << static_cast<int>(entry.op_type)
+                   << ", sequence_id=" << entry.sequence_id
+                   << ", key=" << entry.object_key;
+        return false;
+    }
+
+    // Validate entry size (DoS protection).
+    std::string size_reason;
+    if (!OpLogManager::ValidateEntrySize(entry, &size_reason)) {
+        LOG(ERROR) << "P2POpLogApplier: entry size rejected, sequence_id="
+                   << entry.sequence_id << ", key=" << entry.object_key
+                   << ", reason=" << size_reason;
+        return false;
+    }
+
+    // Verify checksum.
+    if (!OpLogManager::VerifyChecksum(entry)) {
+        LOG(ERROR) << "P2POpLogApplier: checksum mismatch, sequence_id="
+                   << entry.sequence_id << ", key=" << entry.object_key;
+        HAMetricManager::instance().inc_oplog_checksum_failures();
+        return false;
+    }
+
+    // Sequence ordering check (mirrors base class logic).
+    const uint64_t expected = GetExpectedSequenceId();
+    if (IsSequenceOlder(entry.sequence_id, expected)) {
+        VLOG(2) << "P2POpLogApplier: skip already-applied entry, sequence_id="
+                << entry.sequence_id << ", expected=" << expected
+                << ", key=" << entry.object_key;
+        return true;  // consumed (no-op for duplicates)
+    }
+    if (IsSequenceNewer(entry.sequence_id, expected)) {
+        // Future entry — reject it for later re-delivery.
+        // NOTE: P2POpLogApplier does not manage pending_entries_ itself.
+        // The OpLogReplicator or caller should re-deliver out-of-order
+        // entries after the gap is filled. This matches the simplified
+        // ordering model for P2P's initial HA implementation.
+        LOG(WARNING) << "P2POpLogApplier: out-of-order entry, sequence_id="
+                     << entry.sequence_id << ", expected=" << expected
+                     << ", key=" << entry.object_key;
+        return false;
+    }
+
+    // Dispatch to P2P-specific apply methods.
+    bool ok = false;
+    if (entry.op_type == OpType_ADD_REPLICA) {
+        ok = ApplyAddReplica(entry);
+    } else if (entry.op_type == OpType_REMOVE_REPLICA) {
+        ok = ApplyRemoveReplica(entry);
+    } else if (entry.op_type == OpType_MOUNT_SEGMENT) {
+        ok = ApplyMountSegment(entry);
+    } else if (entry.op_type == OpType_UNMOUNT_SEGMENT) {
+        ok = ApplyUnmountSegment(entry);
+    } else if (entry.op_type == OpType_REMOVE_ALL) {
+        ok = ApplyRemoveAll(entry);
+    } else if (entry.op_type == OpType_REGISTER_CLIENT) {
+        ok = ApplyRegisterClient(entry);
+    } else if (entry.op_type == OpType_UNREGISTER_CLIENT) {
+        ok = ApplyUnregisterClient(entry);
+    }
+
+    if (ok) {
+        // Advance expected sequence ID (mirrors base class).
+        // Note: we access the base class atomic directly via Recover(),
+        // which sets expected = last_applied + 1.
+        Recover(entry.sequence_id);
+
+        // Update metrics.
+        HAMetricManager::instance().inc_oplog_applied_entries();
+        HAMetricManager::instance().set_oplog_applied_sequence_id(
+            static_cast<int64_t>(entry.sequence_id));
+    }
+
+    return ok;
+}
+
+bool P2POpLogApplier::ApplyAddReplica(const OpLogEntry& entry) {
+    AddReplicaPayload payload;
+    if (!DeserializeP2PPayload(entry.payload, payload)) {
+        LOG(ERROR) << "P2POpLogApplier: failed to deserialize AddReplicaPayload"
+                   << ", sequence_id=" << entry.sequence_id
+                   << ", key=" << entry.object_key;
+        return false;
+    }
+
+    p2p_store_->AddReplica(payload.object_key, payload.client_id,
+                           payload.segment_id, payload.size);
+    return true;
+}
+
+bool P2POpLogApplier::ApplyRemoveReplica(const OpLogEntry& entry) {
+    RemoveReplicaPayload payload;
+    if (!DeserializeP2PPayload(entry.payload, payload)) {
+        LOG(ERROR)
+            << "P2POpLogApplier: failed to deserialize RemoveReplicaPayload"
+            << ", sequence_id=" << entry.sequence_id
+            << ", key=" << entry.object_key;
+        return false;
+    }
+
+    p2p_store_->RemoveReplica(payload.object_key, payload.client_id,
+                              payload.segment_id);
+    return true;
+}
+
+bool P2POpLogApplier::ApplyMountSegment(const OpLogEntry& entry) {
+    MountSegmentPayload payload;
+    if (!DeserializeP2PPayload(entry.payload, payload)) {
+        LOG(ERROR)
+            << "P2POpLogApplier: failed to deserialize MountSegmentPayload"
+            << ", sequence_id=" << entry.sequence_id
+            << ", key=" << entry.object_key;
+        return false;
+    }
+
+    p2p_store_->AddSegment(payload.client_id, payload.segment);
+    return true;
+}
+
+bool P2POpLogApplier::ApplyUnmountSegment(const OpLogEntry& entry) {
+    UnmountSegmentPayload payload;
+    if (!DeserializeP2PPayload(entry.payload, payload)) {
+        LOG(ERROR)
+            << "P2POpLogApplier: failed to deserialize UnmountSegmentPayload"
+            << ", sequence_id=" << entry.sequence_id
+            << ", key=" << entry.object_key;
+        return false;
+    }
+
+    p2p_store_->RemoveSegment(payload.segment_id, payload.client_id);
+    return true;
+}
+
+bool P2POpLogApplier::ApplyRemoveAll(const OpLogEntry& entry) {
+    VLOG(1) << "P2POpLogApplier::ApplyRemoveAll, sequence_id="
+            << entry.sequence_id;
+    p2p_store_->RemoveAllMetadata();
+    return true;
+}
+
+bool P2POpLogApplier::ApplyRegisterClient(const OpLogEntry& entry) {
+    RegisterClientPayload payload;
+    if (!DeserializeP2PPayload(entry.payload, payload)) {
+        LOG(ERROR)
+            << "P2POpLogApplier: failed to deserialize RegisterClientPayload"
+            << ", sequence_id=" << entry.sequence_id
+            << ", key=" << entry.object_key;
+        return false;
+    }
+
+    p2p_store_->RegisterClient(payload.client_id, payload.ip_address,
+                               payload.rpc_port, payload.segments);
+    return true;
+}
+
+bool P2POpLogApplier::ApplyUnregisterClient(const OpLogEntry& entry) {
+    UnregisterClientPayload payload;
+    if (!DeserializeP2PPayload(entry.payload, payload)) {
+        LOG(ERROR)
+            << "P2POpLogApplier: failed to deserialize UnregisterClientPayload"
+            << ", sequence_id=" << entry.sequence_id
+            << ", key=" << entry.object_key;
+        return false;
+    }
+
+    p2p_store_->UnRegisterClient(payload.client_id);
+    return true;
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/ha/oplog/p2p_oplog_applier.cpp
+++ b/mooncake-store/src/ha/oplog/p2p_oplog_applier.cpp
@@ -124,7 +124,7 @@ bool P2POpLogApplier::ApplyAddReplica(const OpLogEntry& entry) {
     }
 
     p2p_store_->AddReplica(payload.object_key, payload.client_id,
-                           payload.segment_id, payload.size);
+                           payload.segment_id, payload.size, entry.sequence_id);
     return true;
 }
 

--- a/mooncake-store/src/ha/oplog/p2p_oplog_types.cpp
+++ b/mooncake-store/src/ha/oplog/p2p_oplog_types.cpp
@@ -10,6 +10,10 @@ std::string SerializeP2PPayload(const RegisterClientPayload& payload) {
     return struct_pack::serialize<std::string>(payload);
 }
 
+std::string SerializeP2PPayload(const UnregisterClientPayload& payload) {
+    return struct_pack::serialize<std::string>(payload);
+}
+
 std::string SerializeP2PPayload(const AddReplicaPayload& payload) {
     return struct_pack::serialize<std::string>(payload);
 }
@@ -32,6 +36,13 @@ std::string SerializeP2PPayload(const UnmountSegmentPayload& payload) {
 
 bool DeserializeP2PPayload(const std::string& data,
                            RegisterClientPayload& payload) {
+    auto result =
+        struct_pack::deserialize_to(payload, data.data(), data.size());
+    return result == struct_pack::errc::ok;
+}
+
+bool DeserializeP2PPayload(const std::string& data,
+                           UnregisterClientPayload& payload) {
     auto result =
         struct_pack::deserialize_to(payload, data.data(), data.size());
     return result == struct_pack::errc::ok;

--- a/mooncake-store/src/ha/oplog/p2p_standby_metadata_store.cpp
+++ b/mooncake-store/src/ha/oplog/p2p_standby_metadata_store.cpp
@@ -48,10 +48,11 @@ size_t P2PStandbyMetadataStore::GetKeyCount() const { return objects_.size(); }
 
 void P2PStandbyMetadataStore::AddReplica(const std::string& object_key,
                                          const UUID& client_id,
-                                         const UUID& segment_id, size_t size) {
+                                         const UUID& segment_id, size_t size,
+                                         uint64_t sequence_id) {
     auto& metadata = objects_[object_key];
     metadata.size = size;
-    metadata.last_sequence_id = 0;  // Will be set by Applier
+    metadata.last_sequence_id = sequence_id;
 
     auto client_it = clients_.find(client_id);
     for (const auto& desc : metadata.replicas) {

--- a/mooncake-store/src/ha/oplog/p2p_standby_metadata_store.cpp
+++ b/mooncake-store/src/ha/oplog/p2p_standby_metadata_store.cpp
@@ -48,28 +48,12 @@ size_t P2PStandbyMetadataStore::GetKeyCount() const { return objects_.size(); }
 
 void P2PStandbyMetadataStore::AddReplica(const std::string& object_key,
                                          const UUID& client_id,
-                                         const UUID& segment_id, size_t size,
-                                         int priority,
-                                         const std::vector<std::string>& tags,
-                                         MemoryType memory_type) {
+                                         const UUID& segment_id, size_t size) {
     auto& metadata = objects_[object_key];
     metadata.size = size;
     metadata.last_sequence_id = 0;  // Will be set by Applier
 
     auto client_it = clients_.find(client_id);
-    if (client_it != clients_.end()) {
-        for (auto& segment : client_it->second.segments) {
-            if (segment.id != segment_id) {
-                continue;
-            }
-            auto& extra = segment.GetP2PExtra();
-            extra.priority = priority;
-            extra.tags = tags;
-            extra.memory_type = memory_type;
-            break;
-        }
-    }
-
     for (const auto& desc : metadata.replicas) {
         if (!std::holds_alternative<P2PProxyDescriptor>(
                 desc.descriptor_variant)) {

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -82,6 +82,7 @@ add_store_test(oplog_applier_test ha/oplog/oplog_applier_test.cpp)
 add_store_test(oplog_replicator_test ha/oplog/oplog_replicator_test.cpp)
 add_store_test(p2p_oplog_test
     ha/oplog/p2p_oplog_test.cpp
+    ha/oplog/p2p_oplog_applier_test.cpp
     ha/oplog/p2p_standby_metadata_store_test.cpp
 )
 add_subdirectory(e2e)

--- a/mooncake-store/tests/ha/oplog/p2p_oplog_applier_test.cpp
+++ b/mooncake-store/tests/ha/oplog/p2p_oplog_applier_test.cpp
@@ -113,6 +113,7 @@ TEST(P2POpLogApplierTest, ApplyAddReplica) {
     ASSERT_EQ(objects.size(), 1u);
     EXPECT_NE(objects.find("model-weights"), objects.end());
     EXPECT_EQ(objects.at("model-weights").replicas.size(), 1u);
+    EXPECT_EQ(objects.at("model-weights").last_sequence_id, 1u);
 }
 
 TEST(P2POpLogApplierTest, ApplyRemoveReplica) {
@@ -148,7 +149,7 @@ TEST(P2POpLogApplierTest, ApplyRemove_DelegatesToBaseClass) {
 
     // Add P2P metadata first. PutMetadata is a compatibility no-op for
     // P2PStandbyMetadataStore.
-    store.AddReplica("key1", MakeUUID(1, 0), MakeUUID(10, 0), 100);
+    store.AddReplica("key1", MakeUUID(1, 0), MakeUUID(10, 0), 100, 1);
     ASSERT_TRUE(store.GetMetadata("key1").has_value());
 
     // REMOVE should delegate to base class

--- a/mooncake-store/tests/ha/oplog/p2p_oplog_applier_test.cpp
+++ b/mooncake-store/tests/ha/oplog/p2p_oplog_applier_test.cpp
@@ -1,0 +1,442 @@
+#include "ha/oplog/p2p_oplog_applier.h"
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+#include <xxhash.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "ha/oplog/oplog_manager.h"
+#include "ha/oplog/p2p_oplog_types.h"
+#include "ha/oplog/p2p_standby_metadata_store.h"
+#include "mock_oplog_store.h"
+#include "types.h"
+
+using mooncake::test::MockOpLogStore;
+
+namespace mooncake::test {
+
+namespace {
+// Helper to create a valid OpLogEntry with checksum.
+OpLogEntry MakeEntry(uint64_t seq, OpType type, const std::string& key,
+                     const std::string& payload) {
+    OpLogEntry e;
+    e.sequence_id = seq;
+    e.op_type = type;
+    e.object_key = key;
+    e.payload = payload;
+    e.timestamp_ms = 1000 + seq;
+    e.checksum = XXH32(payload.data(), payload.size(), 0);
+    e.prefix_hash = XXH32(key.data(), key.size(), 0);
+    return e;
+}
+
+// Helper to create a valid ADD_REPLICA entry.
+OpLogEntry MakeAddReplicaEntry(uint64_t seq, const std::string& object_key,
+                               const AddReplicaPayload& payload) {
+    std::string data = SerializeP2PPayload(payload);
+    return MakeEntry(seq, OpType_ADD_REPLICA, object_key, data);
+}
+
+// Helper to create a valid REMOVE_REPLICA entry.
+OpLogEntry MakeRemoveReplicaEntry(uint64_t seq, const std::string& object_key,
+                                  const RemoveReplicaPayload& payload) {
+    std::string data = SerializeP2PPayload(payload);
+    return MakeEntry(seq, OpType_REMOVE_REPLICA, object_key, data);
+}
+
+// Helper to create a valid MOUNT_SEGMENT entry.
+OpLogEntry MakeMountSegmentEntry(uint64_t seq,
+                                 const MountSegmentPayload& payload) {
+    std::string data = SerializeP2PPayload(payload);
+    return MakeEntry(seq, OpType_MOUNT_SEGMENT, "", data);
+}
+
+// Helper to create a valid UNMOUNT_SEGMENT entry.
+OpLogEntry MakeUnmountSegmentEntry(uint64_t seq,
+                                   const UnmountSegmentPayload& payload) {
+    std::string data = SerializeP2PPayload(payload);
+    return MakeEntry(seq, OpType_UNMOUNT_SEGMENT, "", data);
+}
+
+// Helper to create a valid REGISTER_CLIENT entry.
+OpLogEntry MakeRegisterClientEntry(uint64_t seq,
+                                   const RegisterClientPayload& payload) {
+    std::string data = SerializeP2PPayload(payload);
+    return MakeEntry(seq, OpType_REGISTER_CLIENT, "", data);
+}
+
+// Helper to create a valid UNREGISTER_CLIENT entry.
+OpLogEntry MakeUnregisterClientEntry(uint64_t seq,
+                                     const UnregisterClientPayload& payload) {
+    std::string data = SerializeP2PPayload(payload);
+    return MakeEntry(seq, OpType_UNREGISTER_CLIENT, "", data);
+}
+
+// Helper to create REMOVE entry (main branch OpType).
+OpLogEntry MakeRemoveEntry(uint64_t seq, const std::string& key) {
+    return MakeEntry(seq, OpType::REMOVE, key, "");
+}
+
+UUID MakeUUID(uint64_t hi, uint64_t lo) { return UUID{hi, lo}; }
+
+Segment MakeSegment(const UUID& id, size_t size) {
+    Segment segment;
+    segment.id = id;
+    segment.size = size;
+    return segment;
+}
+}  // namespace
+
+// ============================================================================
+// P2POpLogApplier - Basic Apply
+// ============================================================================
+
+TEST(P2POpLogApplierTest, ApplyAddReplica) {
+    P2PStandbyMetadataStore store;
+    P2POpLogApplier applier(&store, "test-cluster");
+
+    auto client = MakeUUID(1, 0);
+    auto seg = MakeUUID(10, 0);
+    AddReplicaPayload payload;
+    payload.object_key = "model-weights";
+    payload.client_id = client;
+    payload.segment_id = seg;
+    payload.size = 4096;
+
+    auto entry = MakeAddReplicaEntry(1, "model-weights", payload);
+    EXPECT_TRUE(applier.ApplyOpLogEntry(entry));
+
+    auto& objects = store.GetObjects();
+    ASSERT_EQ(objects.size(), 1u);
+    EXPECT_NE(objects.find("model-weights"), objects.end());
+    EXPECT_EQ(objects.at("model-weights").replicas.size(), 1u);
+}
+
+TEST(P2POpLogApplierTest, ApplyRemoveReplica) {
+    P2PStandbyMetadataStore store;
+    P2POpLogApplier applier(&store, "test-cluster");
+
+    auto client = MakeUUID(1, 0);
+    auto seg = MakeUUID(10, 0);
+
+    // First add, then remove
+    AddReplicaPayload add_payload;
+    add_payload.object_key = "key1";
+    add_payload.client_id = client;
+    add_payload.segment_id = seg;
+    add_payload.size = 1024;
+    EXPECT_TRUE(
+        applier.ApplyOpLogEntry(MakeAddReplicaEntry(1, "key1", add_payload)));
+
+    RemoveReplicaPayload rm_payload;
+    rm_payload.object_key = "key1";
+    rm_payload.client_id = client;
+    rm_payload.segment_id = seg;
+    EXPECT_TRUE(
+        applier.ApplyOpLogEntry(MakeRemoveReplicaEntry(2, "key1", rm_payload)));
+
+    // Object should be removed (no replicas left)
+    EXPECT_EQ(store.GetKeyCount(), 0u);
+}
+
+TEST(P2POpLogApplierTest, ApplyRemove_DelegatesToBaseClass) {
+    P2PStandbyMetadataStore store;
+    P2POpLogApplier applier(&store, "test-cluster");
+
+    // Add P2P metadata first. PutMetadata is a compatibility no-op for
+    // P2PStandbyMetadataStore.
+    store.AddReplica("key1", MakeUUID(1, 0), MakeUUID(10, 0), 100);
+    ASSERT_TRUE(store.GetMetadata("key1").has_value());
+
+    // REMOVE should delegate to base class
+    auto entry = MakeRemoveEntry(1, "key1");
+    EXPECT_TRUE(applier.ApplyOpLogEntry(entry));
+    EXPECT_FALSE(store.GetMetadata("key1").has_value());
+}
+
+TEST(P2POpLogApplierTest, ApplyRemoveAll) {
+    P2PStandbyMetadataStore store;
+    P2POpLogApplier applier(&store, "test-cluster");
+
+    auto client = MakeUUID(1, 0);
+    auto seg = MakeUUID(10, 0);
+
+    AddReplicaPayload payload;
+    payload.object_key = "key1";
+    payload.client_id = client;
+    payload.segment_id = seg;
+    payload.size = 1024;
+    applier.ApplyOpLogEntry(MakeAddReplicaEntry(1, "key1", payload));
+
+    AddReplicaPayload payload2;
+    payload2.object_key = "key2";
+    payload2.client_id = client;
+    payload2.segment_id = seg;
+    payload2.size = 2048;
+    applier.ApplyOpLogEntry(MakeAddReplicaEntry(2, "key2", payload2));
+
+    EXPECT_EQ(store.GetKeyCount(), 2u);
+
+    // REMOVE_ALL
+    auto entry = MakeEntry(3, OpType_REMOVE_ALL, "", "");
+    EXPECT_TRUE(applier.ApplyOpLogEntry(entry));
+
+    EXPECT_EQ(store.GetKeyCount(), 0u);
+    EXPECT_EQ(store.GetClients().size(), 0u);
+}
+
+TEST(P2POpLogApplierTest, ApplyMountSegment) {
+    P2PStandbyMetadataStore store;
+    P2POpLogApplier applier(&store, "test-cluster");
+
+    auto client = MakeUUID(1, 0);
+    auto seg_id = MakeUUID(100, 0);
+
+    Segment segment;
+    segment.id = seg_id;
+    segment.size = 4096;
+
+    MountSegmentPayload payload;
+    payload.client_id = client;
+    payload.segment = segment;
+
+    auto entry = MakeMountSegmentEntry(1, payload);
+    EXPECT_TRUE(applier.ApplyOpLogEntry(entry));
+
+    auto* info = store.GetClient(client);
+    ASSERT_NE(info, nullptr);
+    ASSERT_EQ(info->segments.size(), 1u);
+    EXPECT_EQ(info->segments[0].id, seg_id);
+}
+
+TEST(P2POpLogApplierTest, ApplyUnmountSegment) {
+    P2PStandbyMetadataStore store;
+    P2POpLogApplier applier(&store, "test-cluster");
+
+    auto client = MakeUUID(1, 0);
+    auto seg_id = MakeUUID(100, 0);
+
+    // First register client and mount
+    store.RegisterClient(client, "1.2.3.4", 50051, {});
+
+    Segment segment;
+    segment.id = seg_id;
+    segment.size = 4096;
+
+    MountSegmentPayload mount_payload;
+    mount_payload.client_id = client;
+    mount_payload.segment = segment;
+    applier.ApplyOpLogEntry(MakeMountSegmentEntry(1, mount_payload));
+
+    // Add a replica on this segment
+    AddReplicaPayload add_payload;
+    add_payload.object_key = "key1";
+    add_payload.client_id = client;
+    add_payload.segment_id = seg_id;
+    add_payload.size = 1024;
+    applier.ApplyOpLogEntry(MakeAddReplicaEntry(2, "key1", add_payload));
+
+    ASSERT_EQ(store.GetKeyCount(), 1u);
+
+    // Unmount — should cascade delete replica
+    UnmountSegmentPayload umount_payload;
+    umount_payload.segment_id = seg_id;
+    umount_payload.client_id = client;
+    applier.ApplyOpLogEntry(MakeUnmountSegmentEntry(3, umount_payload));
+
+    EXPECT_EQ(store.GetKeyCount(), 0u);  // Object removed (no replicas)
+    auto* info = store.GetClient(client);
+    ASSERT_NE(info, nullptr);
+    EXPECT_EQ(info->segments.size(), 0u);  // Segment removed
+}
+
+TEST(P2POpLogApplierTest, ApplyRegisterClient) {
+    P2PStandbyMetadataStore store;
+    P2POpLogApplier applier(&store, "test-cluster");
+
+    auto client = MakeUUID(1, 0);
+    auto seg_id = MakeUUID(100, 0);
+
+    Segment segment;
+    segment.id = seg_id;
+    segment.size = 2048;
+
+    RegisterClientPayload payload;
+    payload.client_id = client;
+    payload.ip_address = "192.168.1.100";
+    payload.rpc_port = 50051;
+    payload.segments = {segment};
+
+    auto entry = MakeRegisterClientEntry(1, payload);
+    EXPECT_TRUE(applier.ApplyOpLogEntry(entry));
+
+    auto* info = store.GetClient(client);
+    ASSERT_NE(info, nullptr);
+    EXPECT_EQ(info->ip_address, "192.168.1.100");
+    EXPECT_EQ(info->rpc_port, 50051u);
+    ASSERT_EQ(info->segments.size(), 1u);
+    EXPECT_EQ(info->segments[0].id, seg_id);
+}
+
+TEST(P2POpLogApplierTest, ApplyUnregisterClient) {
+    P2PStandbyMetadataStore store;
+    P2POpLogApplier applier(&store, "test-cluster");
+
+    auto client = MakeUUID(1, 0);
+    auto other_client = MakeUUID(2, 0);
+    auto seg = MakeUUID(100, 0);
+    auto other_seg = MakeUUID(200, 0);
+
+    RegisterClientPayload register_payload;
+    register_payload.client_id = client;
+    register_payload.ip_address = "192.168.1.100";
+    register_payload.rpc_port = 50051;
+    register_payload.segments = {MakeSegment(seg, 2048)};
+    EXPECT_TRUE(
+        applier.ApplyOpLogEntry(MakeRegisterClientEntry(1, register_payload)));
+
+    RegisterClientPayload other_register_payload;
+    other_register_payload.client_id = other_client;
+    other_register_payload.ip_address = "192.168.1.101";
+    other_register_payload.rpc_port = 50052;
+    other_register_payload.segments = {MakeSegment(other_seg, 4096)};
+    EXPECT_TRUE(applier.ApplyOpLogEntry(
+        MakeRegisterClientEntry(2, other_register_payload)));
+
+    AddReplicaPayload replica_payload;
+    replica_payload.object_key = "shared-key";
+    replica_payload.client_id = client;
+    replica_payload.segment_id = seg;
+    replica_payload.size = 1024;
+    EXPECT_TRUE(applier.ApplyOpLogEntry(
+        MakeAddReplicaEntry(3, "shared-key", replica_payload)));
+
+    AddReplicaPayload other_replica_payload;
+    other_replica_payload.object_key = "shared-key";
+    other_replica_payload.client_id = other_client;
+    other_replica_payload.segment_id = other_seg;
+    other_replica_payload.size = 1024;
+    EXPECT_TRUE(applier.ApplyOpLogEntry(
+        MakeAddReplicaEntry(4, "shared-key", other_replica_payload)));
+
+    UnregisterClientPayload unregister_payload;
+    unregister_payload.client_id = client;
+    EXPECT_TRUE(applier.ApplyOpLogEntry(
+        MakeUnregisterClientEntry(5, unregister_payload)));
+
+    EXPECT_EQ(store.GetClient(client), nullptr);
+    ASSERT_NE(store.GetClient(other_client), nullptr);
+    auto object_it = store.GetObjects().find("shared-key");
+    ASSERT_NE(object_it, store.GetObjects().end());
+    ASSERT_EQ(object_it->second.replicas.size(), 1u);
+    const auto& p2p = std::get<P2PProxyDescriptor>(
+        object_it->second.replicas[0].descriptor_variant);
+    EXPECT_EQ(p2p.client_id, other_client);
+}
+
+// ============================================================================
+// P2POpLogApplier - Ordering and gap detection
+// ============================================================================
+
+TEST(P2POpLogApplierTest, EntriesAppliedInOrder) {
+    P2PStandbyMetadataStore store;
+    P2POpLogApplier applier(&store, "test-cluster");
+
+    auto client = MakeUUID(1, 0);
+    auto seg = MakeUUID(10, 0);
+
+    // Apply entries in order
+    AddReplicaPayload p1;
+    p1.object_key = "key1";
+    p1.client_id = client;
+    p1.segment_id = seg;
+    p1.size = 1024;
+
+    AddReplicaPayload p2;
+    p2.object_key = "key2";
+    p2.client_id = client;
+    p2.segment_id = seg;
+    p2.size = 2048;
+
+    EXPECT_TRUE(applier.ApplyOpLogEntry(MakeAddReplicaEntry(1, "key1", p1)));
+    EXPECT_TRUE(applier.ApplyOpLogEntry(MakeAddReplicaEntry(2, "key2", p2)));
+
+    EXPECT_EQ(store.GetKeyCount(), 2u);
+    EXPECT_EQ(applier.GetExpectedSequenceId(), 3u);
+}
+
+TEST(P2POpLogApplierTest, OutOfOrderEntryRejected) {
+    P2PStandbyMetadataStore store;
+    P2POpLogApplier applier(&store, "test-cluster");
+
+    auto client = MakeUUID(1, 0);
+    auto seg = MakeUUID(10, 0);
+
+    AddReplicaPayload p2;
+    p2.object_key = "key2";
+    p2.client_id = client;
+    p2.segment_id = seg;
+    p2.size = 2048;
+
+    // Entry seq=2 arrives before seq=1 — should be rejected, not applied
+    EXPECT_FALSE(applier.ApplyOpLogEntry(MakeAddReplicaEntry(2, "key2", p2)));
+
+    EXPECT_EQ(store.GetKeyCount(), 0u);  // Not applied yet
+    EXPECT_EQ(applier.GetExpectedSequenceId(), 1u);
+}
+
+TEST(P2POpLogApplierTest, OutOfOrderEntryRejectedThenReplaySucceeds) {
+    // P2POpLogApplier does not buffer out-of-order entries (unlike base class
+    // which uses pending_entries_). Out-of-order entries are rejected, and
+    // the caller (OpLogReplicator) is responsible for re-delivering them
+    // after the gap is filled.
+    P2PStandbyMetadataStore store;
+    P2POpLogApplier applier(&store, "test-cluster");
+
+    auto client = MakeUUID(1, 0);
+    auto seg = MakeUUID(10, 0);
+
+    AddReplicaPayload p1;
+    p1.object_key = "key1";
+    p1.client_id = client;
+    p1.segment_id = seg;
+    p1.size = 1024;
+
+    AddReplicaPayload p2;
+    p2.object_key = "key2";
+    p2.client_id = client;
+    p2.segment_id = seg;
+    p2.size = 2048;
+
+    // seq=2 first — rejected (out-of-order)
+    EXPECT_FALSE(applier.ApplyOpLogEntry(MakeAddReplicaEntry(2, "key2", p2)));
+    EXPECT_EQ(store.GetKeyCount(), 0u);
+
+    // seq=1 fills the gap — only key1 applied
+    EXPECT_TRUE(applier.ApplyOpLogEntry(MakeAddReplicaEntry(1, "key1", p1)));
+    EXPECT_EQ(store.GetKeyCount(), 1u);
+    EXPECT_EQ(applier.GetExpectedSequenceId(), 2u);
+
+    // Caller re-delivers seq=2 — now it succeeds
+    EXPECT_TRUE(applier.ApplyOpLogEntry(MakeAddReplicaEntry(2, "key2", p2)));
+    EXPECT_EQ(store.GetKeyCount(), 2u);
+    EXPECT_EQ(applier.GetExpectedSequenceId(), 3u);
+}
+
+// ============================================================================
+// P2POpLogApplier - Unknown OpType
+// ============================================================================
+
+TEST(P2POpLogApplierTest, UnknownOpTypeReturnsFalse) {
+    P2PStandbyMetadataStore store;
+    P2POpLogApplier applier(&store, "test-cluster");
+
+    // Use an OpType value that doesn't exist
+    auto entry = MakeEntry(1, static_cast<OpType>(99), "key1", "");
+    EXPECT_FALSE(applier.ApplyOpLogEntry(entry));
+}
+
+}  // namespace mooncake::test

--- a/mooncake-store/tests/ha/oplog/p2p_oplog_test.cpp
+++ b/mooncake-store/tests/ha/oplog/p2p_oplog_test.cpp
@@ -21,6 +21,7 @@ TEST(P2POpLogTypesTest, OpTypeValuesDoNotConflictWithMain) {
     EXPECT_EQ(static_cast<int>(OpType_UNMOUNT_SEGMENT), 13);
     EXPECT_EQ(static_cast<int>(OpType_REMOVE_ALL), 14);
     EXPECT_EQ(static_cast<int>(OpType_REGISTER_CLIENT), 15);
+    EXPECT_EQ(static_cast<int>(OpType_UNREGISTER_CLIENT), 16);
 }
 
 TEST(P2POpLogTypesTest, OpTypeValuesAreDistinct) {
@@ -31,6 +32,7 @@ TEST(P2POpLogTypesTest, OpTypeValuesAreDistinct) {
         static_cast<int>(OpType_UNMOUNT_SEGMENT),
         static_cast<int>(OpType_REMOVE_ALL),
         static_cast<int>(OpType_REGISTER_CLIENT),
+        static_cast<int>(OpType_UNREGISTER_CLIENT),
     };
     std::sort(values.begin(), values.end());
     for (size_t i = 1; i < values.size(); ++i) {
@@ -123,6 +125,18 @@ TEST(P2POpLogTypesTest, RoundTrip_RegisterClientPayload_MultipleSegments) {
     EXPECT_EQ(decoded.segments[1].size, 8192u);
 }
 
+TEST(P2POpLogTypesTest, RoundTrip_UnregisterClientPayload) {
+    UnregisterClientPayload original;
+    original.client_id = {100, 200};
+
+    std::string data = SerializeP2PPayload(original);
+    UnregisterClientPayload decoded;
+    ASSERT_TRUE(DeserializeP2PPayload(data, decoded));
+
+    EXPECT_EQ(decoded.client_id.first, 100u);
+    EXPECT_EQ(decoded.client_id.second, 200u);
+}
+
 // ============================================================================
 // AddReplicaPayload round-trip
 // ============================================================================
@@ -133,9 +147,6 @@ TEST(P2POpLogTypesTest, RoundTrip_AddReplicaPayload) {
     original.client_id = {10, 20};
     original.segment_id = {30, 40};
     original.size = 4096;
-    original.priority = 1;
-    original.tags = {"tag1", "tag2"};
-    original.memory_type = MemoryType::DRAM;
 
     std::string data = SerializeP2PPayload(original);
     AddReplicaPayload decoded;
@@ -147,28 +158,25 @@ TEST(P2POpLogTypesTest, RoundTrip_AddReplicaPayload) {
     EXPECT_EQ(decoded.segment_id.first, 30u);
     EXPECT_EQ(decoded.segment_id.second, 40u);
     EXPECT_EQ(decoded.size, 4096u);
-    EXPECT_EQ(decoded.priority, 1);
-    ASSERT_EQ(decoded.tags.size(), 2u);
-    EXPECT_EQ(decoded.tags[0], "tag1");
-    EXPECT_EQ(decoded.tags[1], "tag2");
-    EXPECT_EQ(decoded.memory_type, MemoryType::DRAM);
 }
 
-TEST(P2POpLogTypesTest, RoundTrip_AddReplicaPayload_EmptyTags) {
+TEST(P2POpLogTypesTest, RoundTrip_AddReplicaPayload_MinimalFields) {
     AddReplicaPayload original;
-    original.object_key = "obj_empty_tags";
+    original.object_key = "obj_minimal_fields";
     original.client_id = {1, 2};
     original.segment_id = {3, 4};
     original.size = 1024;
-    original.priority = 0;
-    // tags intentionally left empty
-    original.memory_type = MemoryType::DRAM;
 
     std::string data = SerializeP2PPayload(original);
     AddReplicaPayload decoded;
     ASSERT_TRUE(DeserializeP2PPayload(data, decoded));
 
-    EXPECT_EQ(decoded.tags.size(), 0u);
+    EXPECT_EQ(decoded.object_key, "obj_minimal_fields");
+    EXPECT_EQ(decoded.client_id.first, 1u);
+    EXPECT_EQ(decoded.client_id.second, 2u);
+    EXPECT_EQ(decoded.segment_id.first, 3u);
+    EXPECT_EQ(decoded.segment_id.second, 4u);
+    EXPECT_EQ(decoded.size, 1024u);
 }
 
 // ============================================================================

--- a/mooncake-store/tests/ha/oplog/p2p_standby_metadata_store_test.cpp
+++ b/mooncake-store/tests/ha/oplog/p2p_standby_metadata_store_test.cpp
@@ -48,7 +48,7 @@ TEST(P2PStandbyMetadataStoreTest, Remove) {
     P2PStandbyMetadataStore store;
     StandbyObjectMetadata meta;
     meta.size = 100;
-    store.AddReplica("key1", MakeUUID(1, 0), MakeUUID(10, 0), 100);
+    store.AddReplica("key1", MakeUUID(1, 0), MakeUUID(10, 0), 100, 1);
 
     EXPECT_TRUE(store.Remove("key1"));
     EXPECT_FALSE(store.GetMetadata("key1").has_value());
@@ -58,7 +58,7 @@ TEST(P2PStandbyMetadataStoreTest, Remove) {
 TEST(P2PStandbyMetadataStoreTest, Exists) {
     P2PStandbyMetadataStore store;
     EXPECT_FALSE(store.Exists("key1"));
-    store.AddReplica("key1", MakeUUID(1, 0), MakeUUID(10, 0), 100);
+    store.AddReplica("key1", MakeUUID(1, 0), MakeUUID(10, 0), 100, 1);
     EXPECT_TRUE(store.Exists("key1"));
 }
 
@@ -66,9 +66,9 @@ TEST(P2PStandbyMetadataStoreTest, GetKeyCount) {
     P2PStandbyMetadataStore store;
     EXPECT_EQ(store.GetKeyCount(), 0u);
 
-    store.AddReplica("key1", MakeUUID(1, 0), MakeUUID(10, 0), 100);
+    store.AddReplica("key1", MakeUUID(1, 0), MakeUUID(10, 0), 100, 1);
     EXPECT_EQ(store.GetKeyCount(), 1u);
-    store.AddReplica("key2", MakeUUID(1, 0), MakeUUID(11, 0), 200);
+    store.AddReplica("key2", MakeUUID(1, 0), MakeUUID(11, 0), 200, 1);
     EXPECT_EQ(store.GetKeyCount(), 2u);
     store.Remove("key1");
     EXPECT_EQ(store.GetKeyCount(), 1u);
@@ -92,7 +92,7 @@ TEST(P2PStandbyMetadataStoreTest, AddReplicaAfterClientRegistered) {
 
     // Register client first, then add replica
     store.RegisterClient(client_id, "10.0.0.1", 50051, {});
-    store.AddReplica("key1", client_id, seg_id, 1024);
+    store.AddReplica("key1", client_id, seg_id, 1024, 1);
 
     auto it = store.GetObjects().find("key1");
     ASSERT_NE(it, store.GetObjects().end());
@@ -116,7 +116,7 @@ TEST(P2PStandbyMetadataStoreTest, AddReplicaPreservesSegmentExtra) {
     registered_extra.usage = 256;
     store.RegisterClient(client_id, "10.0.0.1", 50051, {seg});
 
-    store.AddReplica("key1", client_id, seg_id, 1024);
+    store.AddReplica("key1", client_id, seg_id, 1024, 1);
 
     auto* info = store.GetClient(client_id);
     ASSERT_NE(info, nullptr);
@@ -134,12 +134,13 @@ TEST(P2PStandbyMetadataStoreTest, AddReplicaCreatesObject) {
     auto client_id = MakeUUID(1, 0);
     auto seg_id = MakeUUID(10, 0);
 
-    store.AddReplica("model-weights", client_id, seg_id, 4096);
+    store.AddReplica("model-weights", client_id, seg_id, 4096, 123);
 
     const auto& objects = store.GetObjects();
     ASSERT_EQ(objects.size(), 1u);
     auto it = objects.find("model-weights");
     ASSERT_NE(it, objects.end());
+    EXPECT_EQ(it->second.last_sequence_id, 123u);
     EXPECT_EQ(it->second.replicas.size(), 1u);
 }
 
@@ -150,11 +151,12 @@ TEST(P2PStandbyMetadataStoreTest, AddReplicaMultiple) {
     auto seg1 = MakeUUID(10, 0);
     auto seg2 = MakeUUID(11, 0);
 
-    store.AddReplica("key1", client1, seg1, 1024);
-    store.AddReplica("key1", client2, seg2, 2048);
+    store.AddReplica("key1", client1, seg1, 1024, 1);
+    store.AddReplica("key1", client2, seg2, 2048, 2);
 
     auto it = store.GetObjects().find("key1");
     ASSERT_NE(it, store.GetObjects().end());
+    EXPECT_EQ(it->second.last_sequence_id, 2u);
     EXPECT_EQ(it->second.replicas.size(), 2u);
 }
 
@@ -163,11 +165,12 @@ TEST(P2PStandbyMetadataStoreTest, AddReplicaDuplicateIgnored) {
     auto client = MakeUUID(1, 0);
     auto seg = MakeUUID(10, 0);
 
-    store.AddReplica("key1", client, seg, 1024);
-    store.AddReplica("key1", client, seg, 1024);
+    store.AddReplica("key1", client, seg, 1024, 1);
+    store.AddReplica("key1", client, seg, 1024, 2);
 
     auto it = store.GetObjects().find("key1");
     ASSERT_NE(it, store.GetObjects().end());
+    EXPECT_EQ(it->second.last_sequence_id, 2u);
     EXPECT_EQ(it->second.replicas.size(), 1u);
 }
 
@@ -178,8 +181,8 @@ TEST(P2PStandbyMetadataStoreTest, RemoveReplica) {
     auto seg1 = MakeUUID(10, 0);
     auto seg2 = MakeUUID(11, 0);
 
-    store.AddReplica("key1", client1, seg1, 1024);
-    store.AddReplica("key1", client2, seg2, 2048);
+    store.AddReplica("key1", client1, seg1, 1024, 1);
+    store.AddReplica("key1", client2, seg2, 2048, 1);
 
     // Remove one replica
     store.RemoveReplica("key1", client1, seg1);
@@ -194,7 +197,7 @@ TEST(P2PStandbyMetadataStoreTest, RemoveReplicaRemovesEmptyObject) {
     auto client = MakeUUID(1, 0);
     auto seg = MakeUUID(10, 0);
 
-    store.AddReplica("key1", client, seg, 1024);
+    store.AddReplica("key1", client, seg, 1024, 1);
     store.RemoveReplica("key1", client, seg);
 
     // Object with no replicas should be removed
@@ -290,7 +293,7 @@ TEST(P2PStandbyMetadataStoreTest, RegisterClientUpdatesReplicaIPs) {
     auto seg_id = MakeUUID(10, 0);
 
     // Add replica BEFORE client is registered (ip/port unknown)
-    store.AddReplica("key1", client_id, seg_id, 1024);
+    store.AddReplica("key1", client_id, seg_id, 1024, 1);
 
     // Verify replica has empty ip/port (backfilling deferred to ExportMetadata)
     auto it = store.GetObjects().find("key1");
@@ -361,8 +364,8 @@ TEST(P2PStandbyMetadataStoreTest, UnRegisterClientCascadeDeletesReplicas) {
 
     store.RegisterClient(client_id, "10.0.0.1", 50051,
                          {MakeSegment(seg1, 1024), MakeSegment(seg2, 2048)});
-    store.AddReplica("key1", client_id, seg1, 1024);
-    store.AddReplica("key2", client_id, seg2, 2048);
+    store.AddReplica("key1", client_id, seg1, 1024, 1);
+    store.AddReplica("key2", client_id, seg2, 2048, 1);
     ASSERT_EQ(store.GetKeyCount(), 2u);
 
     store.UnRegisterClient(client_id);
@@ -380,9 +383,9 @@ TEST(P2PStandbyMetadataStoreTest, UnRegisterClientPreservesOtherClients) {
 
     store.RegisterClient(client1, "10.0.0.1", 50051, {MakeSegment(seg1, 1024)});
     store.RegisterClient(client2, "10.0.0.2", 50052, {MakeSegment(seg2, 2048)});
-    store.AddReplica("shared-key", client1, seg1, 1024);
-    store.AddReplica("shared-key", client2, seg2, 2048);
-    store.AddReplica("client1-only", client1, seg1, 512);
+    store.AddReplica("shared-key", client1, seg1, 1024, 1);
+    store.AddReplica("shared-key", client2, seg2, 2048, 1);
+    store.AddReplica("client1-only", client1, seg1, 512, 1);
 
     store.UnRegisterClient(client1);
 
@@ -454,7 +457,7 @@ TEST(P2PStandbyMetadataStoreTest, RemoveSegmentCascadeDeletesReplicas) {
     auto seg_id = MakeUUID(100, 0);
 
     // Add replica on this segment
-    store.AddReplica("key1", client_id, seg_id, 1024);
+    store.AddReplica("key1", client_id, seg_id, 1024, 1);
     ASSERT_EQ(store.GetObjects().size(), 1u);
 
     // Unmount the segment — should cascade delete replicas
@@ -471,8 +474,8 @@ TEST(P2PStandbyMetadataStoreTest, RemoveSegmentDoesNotAffectOtherSegments) {
     auto seg2 = MakeUUID(200, 0);
 
     // Add replicas on two different segments
-    store.AddReplica("key1", client_id, seg1, 1024);
-    store.AddReplica("key1", client_id, seg2, 2048);
+    store.AddReplica("key1", client_id, seg1, 1024, 1);
+    store.AddReplica("key1", client_id, seg2, 2048, 1);
 
     ASSERT_EQ(store.GetObjects().find("key1")->second.replicas.size(), 2u);
 
@@ -493,8 +496,8 @@ TEST(P2PStandbyMetadataStoreTest, RemoveAllMetadata) {
     auto client = MakeUUID(1, 0);
     auto seg = MakeUUID(10, 0);
 
-    store.AddReplica("key1", client, seg, 1024);
-    store.AddReplica("key2", client, seg, 2048);
+    store.AddReplica("key1", client, seg, 1024, 1);
+    store.AddReplica("key2", client, seg, 2048, 1);
     store.RegisterClient(client, "1.2.3.4", 50051, {MakeSegment(seg, 1024)});
 
     EXPECT_EQ(store.GetKeyCount(), 2u);
@@ -515,7 +518,7 @@ TEST(P2PStandbyMetadataStoreTest, ExportMetadata) {
     auto client = MakeUUID(1, 0);
     auto seg = MakeUUID(10, 0);
 
-    store.AddReplica("key1", client, seg, 1024);
+    store.AddReplica("key1", client, seg, 1024, 1);
     store.RegisterClient(client, "1.2.3.4", 50051, {MakeSegment(seg, 1024)});
 
     auto exported = store.ExportMetadata();
@@ -533,7 +536,7 @@ TEST(P2PStandbyMetadataStoreTest, ExportMetadataNoBackfillForUnknownClient) {
     auto seg_id = MakeUUID(10, 0);
 
     // Add replica but never register the client
-    store.AddReplica("key1", client_id, seg_id, 1024);
+    store.AddReplica("key1", client_id, seg_id, 1024, 1);
 
     auto exported = store.ExportMetadata();
     auto obj_it = exported.objects.find("key1");

--- a/mooncake-store/tests/ha/oplog/p2p_standby_metadata_store_test.cpp
+++ b/mooncake-store/tests/ha/oplog/p2p_standby_metadata_store_test.cpp
@@ -48,8 +48,7 @@ TEST(P2PStandbyMetadataStoreTest, Remove) {
     P2PStandbyMetadataStore store;
     StandbyObjectMetadata meta;
     meta.size = 100;
-    store.AddReplica("key1", MakeUUID(1, 0), MakeUUID(10, 0), 100, 0, {},
-                     MemoryType::DRAM);
+    store.AddReplica("key1", MakeUUID(1, 0), MakeUUID(10, 0), 100);
 
     EXPECT_TRUE(store.Remove("key1"));
     EXPECT_FALSE(store.GetMetadata("key1").has_value());
@@ -59,8 +58,7 @@ TEST(P2PStandbyMetadataStoreTest, Remove) {
 TEST(P2PStandbyMetadataStoreTest, Exists) {
     P2PStandbyMetadataStore store;
     EXPECT_FALSE(store.Exists("key1"));
-    store.AddReplica("key1", MakeUUID(1, 0), MakeUUID(10, 0), 100, 0, {},
-                     MemoryType::DRAM);
+    store.AddReplica("key1", MakeUUID(1, 0), MakeUUID(10, 0), 100);
     EXPECT_TRUE(store.Exists("key1"));
 }
 
@@ -68,11 +66,9 @@ TEST(P2PStandbyMetadataStoreTest, GetKeyCount) {
     P2PStandbyMetadataStore store;
     EXPECT_EQ(store.GetKeyCount(), 0u);
 
-    store.AddReplica("key1", MakeUUID(1, 0), MakeUUID(10, 0), 100, 0, {},
-                     MemoryType::DRAM);
+    store.AddReplica("key1", MakeUUID(1, 0), MakeUUID(10, 0), 100);
     EXPECT_EQ(store.GetKeyCount(), 1u);
-    store.AddReplica("key2", MakeUUID(1, 0), MakeUUID(11, 0), 200, 0, {},
-                     MemoryType::DRAM);
+    store.AddReplica("key2", MakeUUID(1, 0), MakeUUID(11, 0), 200);
     EXPECT_EQ(store.GetKeyCount(), 2u);
     store.Remove("key1");
     EXPECT_EQ(store.GetKeyCount(), 1u);
@@ -96,7 +92,7 @@ TEST(P2PStandbyMetadataStoreTest, AddReplicaAfterClientRegistered) {
 
     // Register client first, then add replica
     store.RegisterClient(client_id, "10.0.0.1", 50051, {});
-    store.AddReplica("key1", client_id, seg_id, 1024, 0, {}, MemoryType::DRAM);
+    store.AddReplica("key1", client_id, seg_id, 1024);
 
     auto it = store.GetObjects().find("key1");
     ASSERT_NE(it, store.GetObjects().end());
@@ -108,16 +104,19 @@ TEST(P2PStandbyMetadataStoreTest, AddReplicaAfterClientRegistered) {
     EXPECT_EQ(p2p.rpc_port, 50051u);
 }
 
-TEST(P2PStandbyMetadataStoreTest, AddReplicaUpdatesSegmentExtra) {
+TEST(P2PStandbyMetadataStoreTest, AddReplicaPreservesSegmentExtra) {
     P2PStandbyMetadataStore store;
     auto client_id = MakeUUID(1, 0);
     auto seg_id = MakeUUID(10, 0);
     auto seg = MakeSegment(seg_id, 4096);
-    seg.GetP2PExtra().usage = 256;
+    auto& registered_extra = seg.GetP2PExtra();
+    registered_extra.priority = 7;
+    registered_extra.tags = {"hot", "ssd"};
+    registered_extra.memory_type = MemoryType::NVME;
+    registered_extra.usage = 256;
     store.RegisterClient(client_id, "10.0.0.1", 50051, {seg});
 
-    store.AddReplica("key1", client_id, seg_id, 1024, 7, {"hot", "ssd"},
-                     MemoryType::NVME);
+    store.AddReplica("key1", client_id, seg_id, 1024);
 
     auto* info = store.GetClient(client_id);
     ASSERT_NE(info, nullptr);
@@ -135,8 +134,7 @@ TEST(P2PStandbyMetadataStoreTest, AddReplicaCreatesObject) {
     auto client_id = MakeUUID(1, 0);
     auto seg_id = MakeUUID(10, 0);
 
-    store.AddReplica("model-weights", client_id, seg_id, 4096, 0, {},
-                     MemoryType::DRAM);
+    store.AddReplica("model-weights", client_id, seg_id, 4096);
 
     const auto& objects = store.GetObjects();
     ASSERT_EQ(objects.size(), 1u);
@@ -152,8 +150,8 @@ TEST(P2PStandbyMetadataStoreTest, AddReplicaMultiple) {
     auto seg1 = MakeUUID(10, 0);
     auto seg2 = MakeUUID(11, 0);
 
-    store.AddReplica("key1", client1, seg1, 1024, 0, {}, MemoryType::DRAM);
-    store.AddReplica("key1", client2, seg2, 2048, 0, {}, MemoryType::DRAM);
+    store.AddReplica("key1", client1, seg1, 1024);
+    store.AddReplica("key1", client2, seg2, 2048);
 
     auto it = store.GetObjects().find("key1");
     ASSERT_NE(it, store.GetObjects().end());
@@ -165,8 +163,8 @@ TEST(P2PStandbyMetadataStoreTest, AddReplicaDuplicateIgnored) {
     auto client = MakeUUID(1, 0);
     auto seg = MakeUUID(10, 0);
 
-    store.AddReplica("key1", client, seg, 1024, 0, {}, MemoryType::DRAM);
-    store.AddReplica("key1", client, seg, 1024, 0, {}, MemoryType::DRAM);
+    store.AddReplica("key1", client, seg, 1024);
+    store.AddReplica("key1", client, seg, 1024);
 
     auto it = store.GetObjects().find("key1");
     ASSERT_NE(it, store.GetObjects().end());
@@ -180,8 +178,8 @@ TEST(P2PStandbyMetadataStoreTest, RemoveReplica) {
     auto seg1 = MakeUUID(10, 0);
     auto seg2 = MakeUUID(11, 0);
 
-    store.AddReplica("key1", client1, seg1, 1024, 0, {}, MemoryType::DRAM);
-    store.AddReplica("key1", client2, seg2, 2048, 0, {}, MemoryType::DRAM);
+    store.AddReplica("key1", client1, seg1, 1024);
+    store.AddReplica("key1", client2, seg2, 2048);
 
     // Remove one replica
     store.RemoveReplica("key1", client1, seg1);
@@ -196,7 +194,7 @@ TEST(P2PStandbyMetadataStoreTest, RemoveReplicaRemovesEmptyObject) {
     auto client = MakeUUID(1, 0);
     auto seg = MakeUUID(10, 0);
 
-    store.AddReplica("key1", client, seg, 1024, 0, {}, MemoryType::DRAM);
+    store.AddReplica("key1", client, seg, 1024);
     store.RemoveReplica("key1", client, seg);
 
     // Object with no replicas should be removed
@@ -292,7 +290,7 @@ TEST(P2PStandbyMetadataStoreTest, RegisterClientUpdatesReplicaIPs) {
     auto seg_id = MakeUUID(10, 0);
 
     // Add replica BEFORE client is registered (ip/port unknown)
-    store.AddReplica("key1", client_id, seg_id, 1024, 0, {}, MemoryType::DRAM);
+    store.AddReplica("key1", client_id, seg_id, 1024);
 
     // Verify replica has empty ip/port (backfilling deferred to ExportMetadata)
     auto it = store.GetObjects().find("key1");
@@ -363,8 +361,8 @@ TEST(P2PStandbyMetadataStoreTest, UnRegisterClientCascadeDeletesReplicas) {
 
     store.RegisterClient(client_id, "10.0.0.1", 50051,
                          {MakeSegment(seg1, 1024), MakeSegment(seg2, 2048)});
-    store.AddReplica("key1", client_id, seg1, 1024, 0, {}, MemoryType::DRAM);
-    store.AddReplica("key2", client_id, seg2, 2048, 0, {}, MemoryType::DRAM);
+    store.AddReplica("key1", client_id, seg1, 1024);
+    store.AddReplica("key2", client_id, seg2, 2048);
     ASSERT_EQ(store.GetKeyCount(), 2u);
 
     store.UnRegisterClient(client_id);
@@ -382,12 +380,9 @@ TEST(P2PStandbyMetadataStoreTest, UnRegisterClientPreservesOtherClients) {
 
     store.RegisterClient(client1, "10.0.0.1", 50051, {MakeSegment(seg1, 1024)});
     store.RegisterClient(client2, "10.0.0.2", 50052, {MakeSegment(seg2, 2048)});
-    store.AddReplica("shared-key", client1, seg1, 1024, 0, {},
-                     MemoryType::DRAM);
-    store.AddReplica("shared-key", client2, seg2, 2048, 0, {},
-                     MemoryType::DRAM);
-    store.AddReplica("client1-only", client1, seg1, 512, 0, {},
-                     MemoryType::DRAM);
+    store.AddReplica("shared-key", client1, seg1, 1024);
+    store.AddReplica("shared-key", client2, seg2, 2048);
+    store.AddReplica("client1-only", client1, seg1, 512);
 
     store.UnRegisterClient(client1);
 
@@ -459,7 +454,7 @@ TEST(P2PStandbyMetadataStoreTest, RemoveSegmentCascadeDeletesReplicas) {
     auto seg_id = MakeUUID(100, 0);
 
     // Add replica on this segment
-    store.AddReplica("key1", client_id, seg_id, 1024, 0, {}, MemoryType::DRAM);
+    store.AddReplica("key1", client_id, seg_id, 1024);
     ASSERT_EQ(store.GetObjects().size(), 1u);
 
     // Unmount the segment — should cascade delete replicas
@@ -476,8 +471,8 @@ TEST(P2PStandbyMetadataStoreTest, RemoveSegmentDoesNotAffectOtherSegments) {
     auto seg2 = MakeUUID(200, 0);
 
     // Add replicas on two different segments
-    store.AddReplica("key1", client_id, seg1, 1024, 0, {}, MemoryType::DRAM);
-    store.AddReplica("key1", client_id, seg2, 2048, 0, {}, MemoryType::DRAM);
+    store.AddReplica("key1", client_id, seg1, 1024);
+    store.AddReplica("key1", client_id, seg2, 2048);
 
     ASSERT_EQ(store.GetObjects().find("key1")->second.replicas.size(), 2u);
 
@@ -498,8 +493,8 @@ TEST(P2PStandbyMetadataStoreTest, RemoveAllMetadata) {
     auto client = MakeUUID(1, 0);
     auto seg = MakeUUID(10, 0);
 
-    store.AddReplica("key1", client, seg, 1024, 0, {}, MemoryType::DRAM);
-    store.AddReplica("key2", client, seg, 2048, 0, {}, MemoryType::DRAM);
+    store.AddReplica("key1", client, seg, 1024);
+    store.AddReplica("key2", client, seg, 2048);
     store.RegisterClient(client, "1.2.3.4", 50051, {MakeSegment(seg, 1024)});
 
     EXPECT_EQ(store.GetKeyCount(), 2u);
@@ -520,7 +515,7 @@ TEST(P2PStandbyMetadataStoreTest, ExportMetadata) {
     auto client = MakeUUID(1, 0);
     auto seg = MakeUUID(10, 0);
 
-    store.AddReplica("key1", client, seg, 1024, 0, {}, MemoryType::DRAM);
+    store.AddReplica("key1", client, seg, 1024);
     store.RegisterClient(client, "1.2.3.4", 50051, {MakeSegment(seg, 1024)});
 
     auto exported = store.ExportMetadata();
@@ -538,7 +533,7 @@ TEST(P2PStandbyMetadataStoreTest, ExportMetadataNoBackfillForUnknownClient) {
     auto seg_id = MakeUUID(10, 0);
 
     // Add replica but never register the client
-    store.AddReplica("key1", client_id, seg_id, 1024, 0, {}, MemoryType::DRAM);
+    store.AddReplica("key1", client_id, seg_id, 1024);
 
     auto exported = store.ExportMetadata();
     auto obj_it = exported.objects.find("key1");


### PR DESCRIPTION
 ## Description

  Add `P2POpLogApplier` for P2P OpLog replay dispatch.

  This PR extends the standby-side P2P OpLog path by:
  - Adding `P2POpLogApplier` to handle P2P-specific OpTypes through `P2PStandbyMetadataStore`
  - Delegating existing main OpTypes to `OpLogApplier`
  - Adding `UNREGISTER_CLIENT` payload serialization/deserialization and apply support
  - Updating P2P OpLog and standby metadata store tests

  ## Module

  - [ ] Transfer Engine (`mooncake-transfer-engine`)
  - [ ] Mooncake Store (`mooncake-store`)
  - [ ] Mooncake EP (`mooncake-ep`)
  - [ ] Mooncake PG (`mooncake-pg`)
  - [ ] Integration (`mooncake-integration`)
  - [x] P2P Store (`mooncake-p2p-store`)
  - [ ] Python Wheel (`mooncake-wheel`)
  - [ ] Common (`mooncake-common`)
  - [ ] Mooncake RL (`mooncake-rl`)
  - [ ] CI/CD
  - [ ] Docs
  - [ ] Other

  ## Type of Change

  - [ ] Bug fix
  - [x] New feature
  - [ ] Refactor
  - [ ] Breaking change
  - [ ] Documentation update
  - [ ] Performance improvement
  - [ ] Other

  ## How Has This Been Tested?

  Added unit coverage for P2P payload dispatch and standby metadata mutations.

  **Test commands:**
  ```bash
  ./mooncake-store/tests/p2p_oplog_test
  ```

  Test results:

  - [x] Unit tests pass
  - [ ] Integration tests pass (if applicable)
  - [ ] Manual testing done (describe below)

  ## Checklist

  - [x] I have performed a self-review of my own code
  - [ ] I have formatted my code using ./scripts/code_format.sh
  - [ ] I have run pre-commit run --all-files and all hooks pass
  - [ ] I have updated the documentation (if applicable)
  - [x] I have added tests to prove my changes are effective
  - [x] For changes >500 LOC: I have filed an RFC issue

  ## AI Assistance Disclosure

  - [ ] No AI tools were used
  - [x] AI tools were used (specify below)

  AI tools were used for code review and PR message drafting. The submitter reviewed the final changes.