### PR TITLE
[store] Fix S3 ListObjectsWithPrefix infinite loop on >1000 objects (#2735)

### DIFF
--- a/mooncake-store/src/utils/s3_helper.cpp
+++ b/mooncake-store/src/utils/s3_helper.cpp
@@ -6,7 +6,7 @@
 #include <aws/s3/model/DeleteObjectRequest.h>
 #include <aws/core/auth/AWSCredentials.h>
 #include <aws/core/utils/memory/stl/AWSVector.h>
-#include <aws/s3/model/ListObjectsRequest.h>
+#include <aws/s3/model/ListObjectsV2Request.h>
 #include <aws/s3/model/DeleteObjectsRequest.h>
 #include <aws/s3/model/ObjectIdentifier.h>
 #include <aws/s3/model/Delete.h>
@@ -781,7 +781,7 @@ tl::expected<void, std::string> S3Helper::ListObjectsWithPrefix(
     const std::string &prefix, std::vector<std::string> &object_keys) {
     object_keys.clear();
 
-    Aws::S3::Model::ListObjectsRequest request;
+    Aws::S3::Model::ListObjectsV2Request request;
     request.WithBucket(bucket_);
     request.WithPrefix(prefix);
 
@@ -789,12 +789,18 @@ tl::expected<void, std::string> S3Helper::ListObjectsWithPrefix(
     // objects
     request.WithMaxKeys(1000);
 
+    // Use ListObjectsV2 + continuation token for pagination. The legacy
+    // ListObjects API only populates NextMarker when a delimiter is set; with
+    // no delimiter GetNextMarker() returns empty, so WithMarker("") restarts
+    // from the beginning and loops forever once the listing exceeds MaxKeys
+    // (#2735). ContinuationToken is always populated when the result is
+    // truncated, regardless of delimiter.
     bool done = false;
     while (!done) {
-        auto outcome = s3_client_.ListObjects(request);
+        auto outcome = s3_client_.ListObjectsV2(request);
         if (!outcome.IsSuccess()) {
             return tl::make_unexpected(fmt::format(
-                "ListObjects error: {}", outcome.GetError().GetMessage()));
+                "ListObjectsV2 error: {}", outcome.GetError().GetMessage()));
         }
 
         const auto &result = outcome.GetResult();
@@ -806,8 +812,8 @@ tl::expected<void, std::string> S3Helper::ListObjectsWithPrefix(
 
         // Check if there are more objects to fetch
         if (result.GetIsTruncated()) {
-            // Set marker to get next page
-            request.WithMarker(result.GetNextMarker());
+            // Set continuation token to get next page
+            request.WithContinuationToken(result.GetNextContinuationToken());
         } else {
             done = true;
         }


### PR DESCRIPTION
## Bug

`S3Helper::ListObjectsWithPrefix` uses the legacy `ListObjects` API and paginates
with `NextMarker`:

```cpp
if (result.GetIsTruncated()) {
    request.WithMarker(result.GetNextMarker());
}
```

Per the [AWS S3 `ListObjects` API](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjects.html),
`NextMarker` is **only populated when the request sets a `Delimiter`**. This code
sets none, so `GetNextMarker()` always returns an empty string. Once the listing
is truncated (> `MaxKeys` = 1000 objects), `WithMarker("")` restarts the listing
from the beginning and the loop never terminates.

Reported in #2735: a bucket with ~1300 objects grew `object_keys` to ~1.3M
entries (the same first 1000 keys re-appended ~1299 times) before the process
was killed — it hangs the snapshot-catalog listing path
(`S3SnapshotObjectStore` → `EmbeddedSnapshotCatalogStore`).

## Fix

Switch to `ListObjectsV2` and paginate with `ContinuationToken`. Per the AWS SDK,
`NextContinuationToken` **is sent whenever `IsTruncated` is true**, regardless of
delimiter, so pagination is correct:

```cpp
auto outcome = s3_client_.ListObjectsV2(request);
...
if (result.GetIsTruncated()) {
    request.WithContinuationToken(result.GetNextContinuationToken());
}
```

`ListObjectsV2` is the API AWS recommends for new development.

## Verification

- API surface confirmed against the AWS SDK for C++ docs
  (`ListObjectsV2Result::GetNextContinuationToken()` / `GetIsTruncated()` /
  `GetContents()`, and `ListObjectsV2Request::WithContinuationToken()`).
- clang-format clean.
- Note: I don't have the AWS SDK in my lab environment, so I could not compile
  the S3 code path locally; the change is a mechanical, doc-verified swap of the
  list API + pagination token, confined to this one function. A maintainer with
  the S3 build enabled can confirm the compile.

Fixes #2735.