### PR TITLE
[Store] Fix bucket+uring O_DIRECT corruption in storage_backend_bench

### DIFF
--- a/mooncake-store/benchmarks/storage_backend_bench.cpp
+++ b/mooncake-store/benchmarks/storage_backend_bench.cpp
@@ -153,6 +153,12 @@ DEFINE_double(zipf_skew, 1.0,
 DEFINE_uint64(report_interval, 100,
               "Report stats every N operations in time-series mode");
 DEFINE_bool(time_series, false, "Enable periodic stats reporting during test");
+// The benchmark previously hardcoded use_uring=false (always buffered
+// PosixFile). This flag exposes the io_uring + O_DIRECT read transport so it
+// can be benchmarked per backend.
+DEFINE_bool(use_uring, false,
+            "Use io_uring+O_DIRECT for backend file I/O (reads). Requires "
+            "USE_URING build. Default false = buffered PosixFile.");
 
 // ============================================================================
 // Constants
@@ -563,9 +569,11 @@ class BufferPool {
 
     // Pre-allocate N buffers of given size (aligned to 4KB)
     void Init(size_t num_buffers, size_t buffer_size) {
-        // Round up to alignment (potential future O_DIRECT / avoid false
-        // sharing)
-        buffer_size_ = AlignUp(buffer_size, kAlignment);
+        // Round up to alignment. O_DIRECT readers (bucket BatchLoad) read a
+        // 4096-aligned SUPERSET of the value into this buffer (value_size + up
+        // to 2 pages of front/back slop), so over-allocate by 2 pages to avoid
+        // a heap overflow on the read.
+        buffer_size_ = AlignUp(buffer_size, kAlignment) + 2 * kAlignment;
         buffers_.resize(num_buffers);
         for (auto& buf : buffers_) {
             void* ptr = nullptr;
@@ -806,6 +814,7 @@ std::shared_ptr<mooncake::StorageBackendInterface> CreateBackend(
     config.storage_filepath = storage_path;
     config.total_size_limit = capacity_bytes;
     config.total_keys_limit = 10'000'000;
+    config.use_uring = FLAGS_use_uring;  // enable io_uring + O_DIRECT read path
 
     switch (type) {
         case BackendType::OFFSET_ALLOCATOR: {
@@ -1182,8 +1191,10 @@ void BenchBatchOffload(BackendType type, const std::string& storage_path,
             auto result = backend->BatchLoad(load_batch);
             if (result) {
                 for (size_t i = 0; i < batch_size; ++i) {
-                    if (!gen.VerifyBuffer(verify_buffers.Get(i), value_size,
-                                          base_key + i)) {
+                    if (!gen.VerifyBuffer(
+                            static_cast<const char*>(
+                                load_batch.at(keys.Get(base_key + i)).ptr),
+                            value_size, base_key + i)) {
                         verification_failures++;
                         if (FLAGS_fail_fast) {
                             LOG(FATAL)
@@ -1368,8 +1379,12 @@ void BenchBatchLoad(BackendType type, const std::string& storage_path,
                 size_t measured_op = op - warmup_operations;
                 if (ShouldVerify(measured_op, is_warmup)) {
                     for (size_t i = 0; i < batch_size; ++i) {
-                        if (!gen.VerifyBuffer(read_buffers.Get(i), value_size,
-                                              batch.key_indices[i])) {
+                        if (!gen.VerifyBuffer(
+                                static_cast<const char*>(
+                                    batch.load_batch
+                                        .at(keys.Get(batch.key_indices[i]))
+                                        .ptr),
+                                value_size, batch.key_indices[i])) {
                             thread_stats.RecordChecksumFailure();
                             LOG(ERROR) << "Checksum mismatch for key "
                                        << batch.key_indices[i];
@@ -1386,8 +1401,12 @@ void BenchBatchLoad(BackendType type, const std::string& storage_path,
             // Verify all warmup ops
             if (result) {
                 for (size_t i = 0; i < batch_size; ++i) {
-                    if (!gen.VerifyBuffer(read_buffers.Get(i), value_size,
-                                          batch.key_indices[i])) {
+                    if (!gen.VerifyBuffer(
+                            static_cast<const char*>(
+                                batch.load_batch
+                                    .at(keys.Get(batch.key_indices[i]))
+                                    .ptr),
+                            value_size, batch.key_indices[i])) {
                         LOG(ERROR) << "Warmup verification failed for key "
                                    << batch.key_indices[i];
                         if (FLAGS_fail_fast) {
@@ -1549,9 +1568,12 @@ void BenchConcurrentLoad(BackendType type, const std::string& storage_path,
 
                     // Verify data integrity
                     for (size_t i = 0; i < batch_size; ++i) {
-                        if (!local_gen.VerifyBuffer(local_buffers.Get(i),
-                                                    value_size,
-                                                    batch_key_indices[i])) {
+                        if (!local_gen.VerifyBuffer(
+                                static_cast<const char*>(
+                                    load_slices
+                                        .at(keys.Get(batch_key_indices[i]))
+                                        .ptr),
+                                value_size, batch_key_indices[i])) {
                             my_stats.RecordChecksumFailure();
                         }
                     }
@@ -2241,7 +2263,9 @@ void BenchRestart(BackendType type, const std::string& storage_path,
 
         // Verify data
         if (result && FLAGS_verify) {
-            if (!gen.VerifyBuffer(buffers.Get(0), value_size, i)) {
+            if (!gen.VerifyBuffer(
+                    static_cast<const char*>(load_batch.at(keys.Get(i)).ptr),
+                    value_size, i)) {
                 LOG(ERROR) << "Post-restart verification failed for key " << i;
             }
         }


### PR DESCRIPTION
## Description

  `storage_backend_bench` hardcoded `use_uring=false`, so every backend ran on buffered `PosixFile` regardless of
  `--cache_mode`, and there was no way to benchmark the io_uring + O_DIRECT read path. When that path *was* exercised,
  the `bucket` backend corrupted data and aborted (`exit 134`).

  The root cause is in the **benchmark**, not the backend. `BucketStorageBackend::BatchLoad` reads a 4096-aligned
  **superset** of each value (O_DIRECT alignment) and returns the value at `slice.ptr + offset_in_buffer`. The benchmark
  (1) allocated read buffers of exactly `value_size` → heap overflow on the aligned read, and (2) verified from its
  original pool pointer instead of the `BatchLoad`-updated slice pointer.

  This PR (benchmark-only, no production code changes):
  - Adds a `--use_uring` flag wired into `FileStorageConfig::use_uring`, so the io_uring + O_DIRECT read transport can
  be benchmarked per backend.
  - Over-allocates `BufferPool` buffers by two alignment pages so the aligned-superset read fits.
  - Verifies from the `BatchLoad`-updated slice pointer (`map.at(key).ptr`) at all readback sites (`load`,
  `concurrent_load`, offload readback, `restart`). Correct for all backends — `offset_allocator`/`file_per_key` leave
  the pointer at offset 0; only `bucket` shifts it.

  ## Module

  - [x] Mooncake Store (`mooncake-store`)

  ## Type of Change

  - [x] Bug fix

  ## How Has This Been Tested?

  **Test commands:**
  ```bash
  # formatting (clang-format 20.1.8)
  ./scripts/code_format.sh --check --base origin/main

  # bucket + io_uring now verifies across value sizes (previously exit 134)
  sudo -E ./build/mooncake-store/benchmarks/storage_backend_bench \
    --backend=bucket --use_uring=true --test=load \
    --cache_mode=drop_cache_external --verify=true \
    --value_size=1048576 --batch_size=32 --num_operations=200

  # store unit tests (benchmark-only change; run to confirm nothing regressed)
  ./build/mooncake-store/tests/storage_backend_test
  ./build/mooncake-store/tests/file_storage_test
  ```

  **Test results:**
  - [x] Unit tests pass — `storage_backend_test` 49/49, `file_storage_test` 20/20
  - [ ] Integration tests pass (n/a)
  - [x] Manual testing done — `bucket --use_uring=true --verify=true` passes for value sizes **4K–1M**, single-threaded
  and concurrent (previously aborted with `exit 134`)

  ## Checklist

  - [x] I have performed a self-review of my own code
  - [x] I have formatted my code using `./scripts/code_format.sh` (clang-format 20.1.8 → "All files are properly
  formatted")
  - [ ] I have run `pre-commit run --all-files` and all hooks pass
  - [ ] I have updated the documentation (if applicable) — n/a
  - [ ] I have added tests to prove my changes are effective — this PR fixes/enables the benchmark's own `bucket +
  io_uring` verification rather than adding a unit test
  - [ ] For changes >500 LOC: I have filed an RFC issue — n/a (~37 LOC)

  ## AI Assistance Disclosure

  - [x] AI tools were used — Claude Code assisted with root-cause diagnosis, the fix, and testing. All changes have been
  reviewed and understood by the submitter.