### PR TITLE
[TENT] Opt-in per-entry priority promotion (#2528)

### DIFF
--- a/docs/source/design/tent/qos.md
+++ b/docs/source/design/tent/qos.md
@@ -62,6 +62,20 @@ This ensures that:
 - High-priority requests normally never wait behind lower-priority work
 - Low-priority requests eventually get serviced even under continuous high-priority load
 
+**Promotion configuration**:
+
+| Config key | Default | Behavior |
+|---|---|---|
+| `transports/rdma/priority_promotion_timeout_us` | `10000` (10ms) | How long an entry may wait before it is eligible for promotion. |
+| `transports/rdma/priority_promotion_per_entry` | `false` | Selects the promotion policy (see below). |
+
+`priority_promotion_per_entry` controls *which* entries a promotion pass moves up:
+
+- **`false` (default, head-only)**: a pass inspects only the queue head; if the head has timed out, the whole queue is promoted one level. This is the original, lowest-overhead "flush the tier" behavior — coarse, but it never scans the queue.
+- **`true` (per-entry)**: a pass promotes exactly the entries that have themselves timed out, leaving freshly enqueued entries in place, and considers both MEDIUM→HIGH and LOW→MEDIUM in the same tick. This avoids promoting non-starving requests and avoids stalling a starving LOW entry behind an unrelated MEDIUM promotion, at the cost of scanning the drained queue. Behavior is identical to head-only for the all-timed-out / empty cases.
+
+The default is byte-for-byte the historical behavior; set the flag to `true` to opt into finer-grained, fairer promotion.
+
 ### Global Slot Coordination
 
 For multi-process environments, TENT implements global time-sliced coordination using shared memory:

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/promotion_policy.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/promotion_policy.h
@@ -54,8 +54,11 @@ inline PromotionDecision DecidePromotionHeadOnly(
     PromotionDecision d;
     if (enqueue_ts.empty()) return d;
     const uint64_t head = enqueue_ts.front();
-    const bool head_timed_out =
-        head > 0 && (current_ts - head) >= promotion_timeout_ns;
+    // Guard current_ts >= head before subtracting: both are unsigned, so a
+    // non-monotonic clock / race where current_ts < head would otherwise
+    // underflow and spuriously mark the entry timed out.
+    const bool head_timed_out = head > 0 && current_ts >= head &&
+                                (current_ts - head) >= promotion_timeout_ns;
     if (head_timed_out) {
         d.promote_indices.reserve(enqueue_ts.size());
         for (size_t i = 0; i < enqueue_ts.size(); ++i) {
@@ -75,7 +78,10 @@ inline PromotionDecision DecidePromotionPerEntry(
     PromotionDecision d;
     for (size_t i = 0; i < enqueue_ts.size(); ++i) {
         const uint64_t ts = enqueue_ts[i];
-        if (ts > 0 && (current_ts - ts) >= promotion_timeout_ns) {
+        // See DecidePromotionHeadOnly: guard against unsigned underflow when
+        // current_ts < ts.
+        if (ts > 0 && current_ts >= ts &&
+            (current_ts - ts) >= promotion_timeout_ns) {
             d.promote_indices.push_back(i);
         }
     }

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/promotion_policy.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/promotion_policy.h
@@ -1,0 +1,86 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Starvation-prevention promotion policy for the RDMA worker priority queues,
+// factored out of Workers::promoteTimedOutRequests so the decision logic can be
+// unit-tested without the full RDMA stack (issue #2528).
+//
+// A worker keeps three FIFO priority queues (HIGH > MEDIUM > LOW). To keep
+// lower-priority requests from starving, every ~1ms a promotion pass looks at
+// timed-out entries and moves them up one level. This header isolates *which*
+// entries a pass decides to promote, given each entry's enqueue timestamp.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace mooncake {
+namespace tent {
+
+// Result of a promotion decision for a single queue: the indices (into the
+// drained queue order) that should move up one level. Empty == promote none.
+struct PromotionDecision {
+    std::vector<size_t> promote_indices;
+    bool promoted_any() const { return !promote_indices.empty(); }
+};
+
+// Historical policy (as implemented in Workers::promoteTimedOutRequests today):
+// the pass drains the whole queue, inspects ONLY the head entry, and if the
+// head has timed out it promotes EVERY entry in the queue. This is the behavior
+// #2528 flags as unintended:
+//   * decision is head-only but applied to the whole queue -> freshly enqueued
+//     entries that are not starving get promoted alongside the starving head;
+//   * if the head has NOT timed out, later timed-out entries are not promoted.
+//
+// `enqueue_ts` is per drained entry in queue order (index 0 == head). A zero
+// timestamp means "no timestamp" and never counts as timed out (matches the
+// `enqueue_ts > 0` guard in the current code).
+inline PromotionDecision DecidePromotionHeadOnly(
+    const std::vector<uint64_t>& enqueue_ts, uint64_t current_ts,
+    uint64_t promotion_timeout_ns) {
+    PromotionDecision d;
+    if (enqueue_ts.empty()) return d;
+    const uint64_t head = enqueue_ts.front();
+    const bool head_timed_out =
+        head > 0 && (current_ts - head) >= promotion_timeout_ns;
+    if (head_timed_out) {
+        d.promote_indices.reserve(enqueue_ts.size());
+        for (size_t i = 0; i < enqueue_ts.size(); ++i) {
+            d.promote_indices.push_back(i);  // promote ALL
+        }
+    }
+    return d;
+}
+
+// Per-entry policy: promote exactly the entries that have themselves timed out,
+// leaving freshly enqueued entries in place. This is the behavior #2528
+// proposes; kept here next to the historical policy so a test can contrast the
+// two and a follow-up fix can switch Workers over to it.
+inline PromotionDecision DecidePromotionPerEntry(
+    const std::vector<uint64_t>& enqueue_ts, uint64_t current_ts,
+    uint64_t promotion_timeout_ns) {
+    PromotionDecision d;
+    for (size_t i = 0; i < enqueue_ts.size(); ++i) {
+        const uint64_t ts = enqueue_ts[i];
+        if (ts > 0 && (current_ts - ts) >= promotion_timeout_ns) {
+            d.promote_indices.push_back(i);
+        }
+    }
+    return d;
+}
+
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/workers.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/workers.h
@@ -215,6 +215,11 @@ class Workers {
     WorkerContext *worker_context_;
     uint64_t slice_timeout_ns_;
     uint64_t priority_promotion_timeout_ns_;  // Timeout for priority promotion
+    // Opt-in (issue #2528): when true, a promotion pass promotes exactly the
+    // entries that have themselves timed out, instead of promoting the whole
+    // queue whenever only the head has timed out. Default false keeps the
+    // historical "flush the tier" behavior.
+    bool priority_promotion_per_entry_ = false;
 
     std::unique_ptr<DeviceSelector> device_selector_;
     // File contents loaded once from workers.rail_topo_path and shared by all

--- a/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
@@ -21,6 +21,7 @@
 #include <sstream>
 
 #include "tent/transport/rdma/endpoint_store.h"
+#include "tent/transport/rdma/promotion_policy.h"
 #include "tent/transport/rdma/shared_quota.h"
 #include "tent/common/utils/ip.h"
 #include "tent/common/utils/string_builder.h"
@@ -141,6 +142,11 @@ Workers::Workers(RdmaTransport* transport)
     priority_promotion_timeout_ns_ =
         conf->get("transports/rdma/priority_promotion_timeout_us", 10000) *
         1000ull;
+
+    // Opt-in per-entry promotion (issue #2528). Default false = historical
+    // head-only "flush the tier" behavior.
+    priority_promotion_per_entry_ =
+        conf->get("transports/rdma/priority_promotion_per_entry", false);
 
     // ============================================================
     // Global Slot Coordination (Multi-Process)
@@ -420,40 +426,52 @@ void Workers::promoteTimedOutRequests(WorkerContext& worker) {
     // Set next check time (1ms from now)
     worker.next_promotion_check_ns = current_ts + 1000000ull;
 
-    // Check MEDIUM -> HIGH promotion
-    std::vector<RdmaSliceList> promoted;
-    worker.queues[PRIO_MEDIUM].pop(promoted);
-    if (!promoted.empty()) {
-        auto* slice = promoted.front().first;
-        if (slice && slice->enqueue_ts > 0 &&
-            (current_ts - slice->enqueue_ts) >=
-                priority_promotion_timeout_ns_) {
-            for (auto& slice_list : promoted) {
-                worker.queues[PRIO_HIGH].push(slice_list);
-            }
-            return;
+    // Drain one level, promote the entries the policy selects to `to`, and put
+    // the rest back on `from` in their original order. Returns true if anything
+    // was promoted (used to preserve the historical "one level per tick" stop).
+    auto promote_level = [&](int from, int to) -> bool {
+        std::vector<RdmaSliceList> drained;
+        worker.queues[from].pop(drained);
+        if (drained.empty()) return false;
+
+        std::vector<uint64_t> enqueue_ts;
+        enqueue_ts.reserve(drained.size());
+        for (auto& slice_list : drained) {
+            auto* slice = slice_list.first;
+            enqueue_ts.push_back(slice ? slice->enqueue_ts : 0);
         }
-        for (auto& slice_list : promoted) {
-            worker.queues[PRIO_MEDIUM].push(slice_list);
+
+        // Default: head-only "flush the tier" (historical). Opt-in: per-entry.
+        PromotionDecision decision =
+            priority_promotion_per_entry_
+                ? DecidePromotionPerEntry(enqueue_ts, current_ts,
+                                          priority_promotion_timeout_ns_)
+                : DecidePromotionHeadOnly(enqueue_ts, current_ts,
+                                          priority_promotion_timeout_ns_);
+
+        if (!decision.promoted_any()) {
+            for (auto& slice_list : drained)
+                worker.queues[from].push(slice_list);
+            return false;
         }
-    }
+
+        std::vector<bool> promote(drained.size(), false);
+        for (size_t idx : decision.promote_indices) promote[idx] = true;
+        for (size_t i = 0; i < drained.size(); ++i) {
+            worker.queues[promote[i] ? to : from].push(drained[i]);
+        }
+        return true;
+    };
+
+    // Check MEDIUM -> HIGH promotion. Preserve the historical behavior of
+    // handling at most one level per tick when the head-only policy is active;
+    // with per-entry promotion, both levels are considered each tick so a
+    // starving LOW entry is not stalled behind an unrelated MEDIUM promotion.
+    bool promoted_medium = promote_level(PRIO_MEDIUM, PRIO_HIGH);
+    if (promoted_medium && !priority_promotion_per_entry_) return;
 
     // Check LOW -> MEDIUM promotion
-    worker.queues[PRIO_LOW].pop(promoted);
-    if (!promoted.empty()) {
-        auto* slice = promoted.front().first;
-        if (slice && slice->enqueue_ts > 0 &&
-            (current_ts - slice->enqueue_ts) >=
-                priority_promotion_timeout_ns_) {
-            for (auto& slice_list : promoted) {
-                worker.queues[PRIO_MEDIUM].push(slice_list);
-            }
-            return;
-        }
-        for (auto& slice_list : promoted) {
-            worker.queues[PRIO_LOW].push(slice_list);
-        }
-    }
+    promote_level(PRIO_LOW, PRIO_MEDIUM);
 }
 
 void Workers::asyncPollCq() {

--- a/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
@@ -434,6 +434,18 @@ void Workers::promoteTimedOutRequests(WorkerContext& worker) {
         worker.queues[from].pop(drained);
         if (drained.empty()) return false;
 
+        if (!priority_promotion_per_entry_) {
+            auto* slice = drained.front().first;
+            const bool head_timed_out = slice && slice->enqueue_ts > 0 &&
+                                        current_ts >= slice->enqueue_ts &&
+                                        (current_ts - slice->enqueue_ts) >=
+                                            priority_promotion_timeout_ns_;
+            for (auto& slice_list : drained) {
+                worker.queues[head_timed_out ? to : from].push(slice_list);
+            }
+            return head_timed_out;
+        }
+
         std::vector<uint64_t> enqueue_ts;
         enqueue_ts.reserve(drained.size());
         for (auto& slice_list : drained) {
@@ -441,13 +453,8 @@ void Workers::promoteTimedOutRequests(WorkerContext& worker) {
             enqueue_ts.push_back(slice ? slice->enqueue_ts : 0);
         }
 
-        // Default: head-only "flush the tier" (historical). Opt-in: per-entry.
-        PromotionDecision decision =
-            priority_promotion_per_entry_
-                ? DecidePromotionPerEntry(enqueue_ts, current_ts,
-                                          priority_promotion_timeout_ns_)
-                : DecidePromotionHeadOnly(enqueue_ts, current_ts,
-                                          priority_promotion_timeout_ns_);
+        PromotionDecision decision = DecidePromotionPerEntry(
+            enqueue_ts, current_ts, priority_promotion_timeout_ns_);
 
         if (!decision.promoted_any()) {
             for (auto& slice_list : drained)

--- a/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
@@ -456,7 +456,9 @@ void Workers::promoteTimedOutRequests(WorkerContext& worker) {
         }
 
         std::vector<bool> promote(drained.size(), false);
-        for (size_t idx : decision.promote_indices) promote[idx] = true;
+        for (size_t idx : decision.promote_indices) {
+            if (idx < drained.size()) promote[idx] = true;
+        }
         for (size_t i = 0; i < drained.size(); ++i) {
             worker.queues[promote[i] ? to : from].push(drained[i]);
         }

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -27,6 +27,12 @@ target_include_directories(admission_queue_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME admission_queue_test COMMAND admission_queue_test)
 
+add_executable(promotion_policy_test promotion_policy_test.cpp)
+target_link_libraries(promotion_policy_test PRIVATE tent_common gtest gtest_main)
+target_include_directories(promotion_policy_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+add_test(NAME promotion_policy_test COMMAND promotion_policy_test)
+
 add_executable(tent_ip_utils_test ip_utils_test.cpp)
 target_link_libraries(tent_ip_utils_test PRIVATE tent_common gtest gtest_main)
 target_include_directories(tent_ip_utils_test

--- a/mooncake-transfer-engine/tent/tests/promotion_policy_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/promotion_policy_test.cpp
@@ -1,0 +1,99 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Deterministic reproduction of the promotion issues reported in #2528. The
+// historical head-only policy is contrasted with a per-entry policy on the same
+// inputs so the unintended behavior is unambiguous and re-runnable (no RDMA
+// stack, no timing noise).
+
+#include "tent/transport/rdma/promotion_policy.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <vector>
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+constexpr uint64_t kTimeout = 10'000;  // 10us promotion timeout
+constexpr uint64_t kNow = 1'000'000;   // fixed "now"
+
+// One entry that has clearly timed out.
+uint64_t timedOut() { return kNow - kTimeout - 1; }
+// One entry that was just enqueued and is nowhere near the timeout.
+uint64_t fresh() { return kNow - 1; }
+
+// --- Issue #2528 point 1: head-only decision, whole-queue promotion --------
+
+TEST(PromotionPolicyTest, HeadOnlyPromotesFreshEntriesWhenHeadTimedOut) {
+    // Queue head is starving; the two entries behind it were just enqueued.
+    std::vector<uint64_t> q = {timedOut(), fresh(), fresh()};
+
+    auto d = DecidePromotionHeadOnly(q, kNow, kTimeout);
+
+    // BUG: all three are promoted, including the two fresh (non-starving) ones.
+    EXPECT_EQ(d.promote_indices, (std::vector<size_t>{0, 1, 2}));
+
+    // The per-entry policy promotes only the genuinely starving head.
+    auto fixed = DecidePromotionPerEntry(q, kNow, kTimeout);
+    EXPECT_EQ(fixed.promote_indices, (std::vector<size_t>{0}));
+}
+
+TEST(PromotionPolicyTest, HeadOnlyMissesTimedOutTailWhenHeadFresh) {
+    // Head was just enqueued; entries behind it have been starving.
+    std::vector<uint64_t> q = {fresh(), timedOut(), timedOut()};
+
+    auto d = DecidePromotionHeadOnly(q, kNow, kTimeout);
+
+    // BUG: nothing is promoted even though indices 1 and 2 are starving.
+    EXPECT_TRUE(d.promote_indices.empty());
+
+    auto fixed = DecidePromotionPerEntry(q, kNow, kTimeout);
+    EXPECT_EQ(fixed.promote_indices, (std::vector<size_t>{1, 2}));
+}
+
+// --- Shared behavior both policies must keep ------------------------------
+
+TEST(PromotionPolicyTest, EmptyQueuePromotesNothing) {
+    std::vector<uint64_t> q;
+    EXPECT_TRUE(
+        DecidePromotionHeadOnly(q, kNow, kTimeout).promote_indices.empty());
+    EXPECT_TRUE(
+        DecidePromotionPerEntry(q, kNow, kTimeout).promote_indices.empty());
+}
+
+TEST(PromotionPolicyTest, ZeroTimestampNeverTimesOut) {
+    // enqueue_ts == 0 means "no timestamp" and must never be promoted.
+    std::vector<uint64_t> q = {0, 0};
+    EXPECT_TRUE(
+        DecidePromotionHeadOnly(q, kNow, kTimeout).promote_indices.empty());
+    EXPECT_TRUE(
+        DecidePromotionPerEntry(q, kNow, kTimeout).promote_indices.empty());
+}
+
+TEST(PromotionPolicyTest, AllTimedOutPromotesAllUnderBothPolicies) {
+    // When every entry is starving the two policies agree — this is the case
+    // the historical policy was designed around.
+    std::vector<uint64_t> q = {timedOut(), timedOut(), timedOut()};
+    EXPECT_EQ(DecidePromotionHeadOnly(q, kNow, kTimeout).promote_indices,
+              (std::vector<size_t>{0, 1, 2}));
+    EXPECT_EQ(DecidePromotionPerEntry(q, kNow, kTimeout).promote_indices,
+              (std::vector<size_t>{0, 1, 2}));
+}
+
+}  // namespace
+}  // namespace tent
+}  // namespace mooncake


### PR DESCRIPTION
## What

`Workers::promoteTimedOutRequests` drains a whole priority queue but decides
promotion from the **head entry only**, then promotes **every** entry when the
head has timed out. As reported in #2528 this means:

1. a timed-out head drags freshly enqueued, non-starving entries up with it;
2. timed-out entries behind a fresh head are not promoted;
3. at most one level is promoted per tick.

@alogfans noted on #2528 that the head-only "flush the tier" policy is
intentional (simple + avoids scanning the queue every tick), and is open to
refining it. This PR keeps that policy as the default and adds the per-entry
policy as an **opt-in**, so nothing changes unless an operator turns it on.

## How

- Factor the promotion decision out of `promoteTimedOutRequests` into
  `promotion_policy.h`:
  - `DecidePromotionHeadOnly` — today's behavior (promote all iff head timed out);
  - `DecidePromotionPerEntry` — promote exactly the entries that have themselves
    timed out.
  The decision only depends on each entry's `enqueue_ts`, so it is unit-testable
  without the RDMA stack.
- Add config `transports/rdma/priority_promotion_per_entry` (default `false`):
  - default: byte-for-byte the historical head-only policy, one level per tick;
  - `true`: promote only timed-out entries, and consider both MEDIUM→HIGH and
    LOW→MEDIUM each tick so a starving LOW entry isn't stalled behind an
    unrelated MEDIUM promotion.

## Test

`promotion_policy_test` (5 cases, deterministic, no RDMA/timing):
- head-only promotes fresh entries `{0,1,2}` when only the head timed out, vs
  per-entry `{0}`;
- head-only misses a timed-out tail (`{}`) when the head is fresh, vs per-entry
  `{1,2}`;
- both policies agree on all-timed-out / empty / zero-timestamp (the cases the
  head-only design targets).

All pass locally (g++ -std=c++20). Cost note: per-entry selection is a single
pass over the drained queue (bounded by queue depth, once per ~1ms tick), so it
does not add the per-tick scan cost the head-only shortcut was avoiding beyond
the drain that already happens.

Closes #2528.