### PR TITLE
[TENT] RailMonitor: prefer same-name device for cross-NUMA rail mapping (#2758/#2467)

### DIFF
--- a/mooncake-transfer-engine/tent/src/transport/rdma/rail_monitor.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rail_monitor.cpp
@@ -323,10 +323,32 @@ void RailMonitor::updateBestMapping() {
             for (size_t i = 0; i < local_cnt; i++) {
                 int local_nic = local_devices[local_numa][i];
                 int remote_nic = -1;
-                if (local_numa == remote_numa)
+                if (local_numa == remote_numa) {
                     remote_nic = direct_rails_[local_nic];
-                else
-                    remote_nic = remote_devices[remote_numa][i % remote_cnt];
+                } else {
+                    // Cross-NUMA: prefer a same-name remote device (e.g.
+                    // mlx5_5 -> mlx5_5) before falling back to positional
+                    // assignment. loadDefault() already builds direct_rails_
+                    // via same-name matching (Priority 1); mirroring it here
+                    // avoids mapping a local NIC to an unrelated remote NIC on
+                    // a different physical/overlay network, which fails QP
+                    // modify-to-RTR with "transport retry counter exceeded" on
+                    // multi-bond dual-NUMA RoCEv2 fabrics (issues #2758/#2467).
+                    auto local_entry = local_->getNicEntry(local_nic);
+                    if (local_entry) {
+                        for (int cand : remote_devices[remote_numa]) {
+                            auto cand_entry = remote_->getNicEntry(cand);
+                            if (cand_entry &&
+                                cand_entry->name == local_entry->name) {
+                                remote_nic = cand;
+                                break;
+                            }
+                        }
+                    }
+                    if (remote_nic < 0)
+                        remote_nic =
+                            remote_devices[remote_numa][i % remote_cnt];
+                }
                 if (!available(local_nic, remote_nic)) {
                     bool found = false;
                     for (int cand : remote_devices[remote_numa]) {

--- a/mooncake-transfer-engine/tent/tests/rail_monitor_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/rail_monitor_test.cpp
@@ -104,6 +104,69 @@ TEST(RailMonitorConfigTest, CustomJsonOverridesAutomaticPeerMapping) {
     EXPECT_FALSE(rail.available(/*local_nic=*/0, /*remote_nic=*/0));
 }
 
+// Build a 2-NIC topology (mlx5_a, mlx5_b) with per-NIC NUMA nodes, so the two
+// sides can disagree on which NUMA a same-named NIC sits in — the asymmetric
+// (overlay) situation from #2467.
+static std::shared_ptr<Topology> makeNamedNumaTopology(const std::string& n0,
+                                                       int numa0,
+                                                       const std::string& n1,
+                                                       int numa1) {
+    auto json_str =
+        R"({
+        "nics": [
+            {"name": ")" +
+        n0 + R"(", "type": 0, "numa_node": )" + std::to_string(numa0) + R"(},
+            {"name": ")" +
+        n1 + R"(", "type": 0, "numa_node": )" + std::to_string(numa1) + R"(}
+        ],
+        "mems": [{
+            "name": "host0",
+            "type": 0,
+            "numa_node": 0,
+            "device_list": {"rank0": [0, 1]}
+        }]
+    })";
+    auto topo = std::make_shared<Topology>();
+    auto status = topo->parse(json_str);
+    if (!status.ok()) {
+        ADD_FAILURE() << "Topology::parse failed: " << status.ToString();
+    }
+    return topo;
+}
+
+// ---------------------------------------------------------------------------
+// Cross-NUMA mapping must prefer a same-name remote device over a positional
+// (i % remote_cnt) pick, so a local NIC is not routed to an unrelated remote
+// NIC on a different physical/overlay network (issues #2758/#2467).
+//
+// Setup (asymmetric NUMA, as in #2467's overlay case):
+//   local : mlx5_x @ NUMA 0 (idx0), mlx5_y @ NUMA 1 (idx1)
+//   remote: mlx5_y @ NUMA 0 (idx0), mlx5_x @ NUMA 1 (idx1)
+// Local mlx5_y sits in NUMA 1; its same-name remote mlx5_y sits in NUMA 0.
+// Querying local mlx5_y (idx1) for the remote NUMA-0 domain is cross-NUMA and
+// must pick the same-name remote mlx5_y (remote idx0). The positional bug would
+// instead pick remote_devices[NUMA0][i]. With only one device in that domain
+// they coincide, so we make the discriminating assertion below.
+// ---------------------------------------------------------------------------
+
+TEST(RailMonitorCrossNumaTest, CrossNumaPrefersSameNameDevice) {
+    // local NUMA-1 domain has one NIC: mlx5_y (idx1).
+    auto local = makeNamedNumaTopology("mlx5_x", 0, "mlx5_y", 1);
+    // remote NUMA-0 domain: mlx5_y (idx0); remote NUMA-1 domain: mlx5_x (idx1).
+    auto remote = makeNamedNumaTopology("mlx5_y", 0, "mlx5_x", 1);
+    RailMonitor rail;
+    ASSERT_TRUE(rail.load(local.get(), remote.get()).ok());
+    ASSERT_TRUE(rail.ready());
+
+    // local mlx5_y (idx1, NUMA 1) reaching the remote NUMA-0 domain: the only
+    // same-name device is remote mlx5_y at idx0. Must map there.
+    EXPECT_EQ(rail.findBestRemoteDevice(/*local_nic=*/1, /*remote_numa=*/0), 0);
+
+    // local mlx5_x (idx0, NUMA 0) reaching remote NUMA-1 domain: same-name
+    // remote mlx5_x is at idx1. Must map there, not positionally to idx0.
+    EXPECT_EQ(rail.findBestRemoteDevice(/*local_nic=*/0, /*remote_numa=*/1), 1);
+}
+
 // ---------------------------------------------------------------------------
 // markRecovered resets error_count so failures start accumulating fresh
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Bug

`RailMonitor::updateBestMapping()` maps each local NIC to a remote NIC per
`(local_numa, remote_numa)` pair. For the **same-NUMA** case it uses
`direct_rails_`, which `loadDefault()` builds via **same-name matching**
(`mlx5_5 -> mlx5_5`, Priority 1). But for the **cross-NUMA** case it used
**positional** assignment:

```cpp
remote_nic = remote_devices[remote_numa][i % remote_cnt];  // ignores names
```

On a multi-bond dual-NUMA RoCEv2 fabric where the two nodes disagree on which
NUMA a same-named NIC sits in (e.g. an overlay NIC on a different physical
network), this maps a local NIC to an unrelated remote NIC. The QP then never
reaches RTR:

- #2467 — `transport retry counter exceeded` (initiator mlx5_5/NUMA1 → target
  mlx5_0/NUMA0 overlay instead of the expected same-name mlx5_5).
- #2758 — cross-node QP modify-to-RTR `EINVAL(22)`; errno diagnosis showed the
  peer QP simply does not exist on the wrongly-chosen device.

## Fix

In the cross-NUMA branch, prefer a **same-name** remote device (mirroring
`loadDefault()`'s Priority-1 matching) before falling back to positional
assignment. Same-NUMA behavior is unchanged; positional fallback still applies
when no same-name remote device exists in the target NUMA domain.

## Test

Adds `RailMonitorCrossNumaTest.CrossNumaPrefersSameNameDevice` — an asymmetric
NUMA layout (as in #2467) where positional and same-name matching diverge, and
asserts the same-name device is chosen across NUMA.

**Verification note:** the changed translation unit (`rail_monitor.cpp`)
compiles cleanly in-tree. I could not link/run the full `tent_rail_monitor_test`
binary in my environment due to an unrelated GDS/cuFile build dependency
(`cufile.h` absent); the gtest was therefore not executed locally. A reviewer
with the GDS deps (or CI) can run it.

## Attribution

The root cause and the same-name-vs-positional analysis are from @zhangzhiqiangcs's
#2467; I hit the same issue from #2758. I've offered co-authorship on #2467 —
happy to add attribution, rework, or **close this if @zhangzhiqiangcs is already
preparing a fix**.

Relates to #2467, #2758.