### PR TITLE
fix: restore SSD total capacity after snapshot restore

### DIFF
--- a/mooncake-store/include/master_metric_manager.h
+++ b/mooncake-store/include/master_metric_manager.h
@@ -109,6 +109,7 @@ class MasterMetricManager {
     void dec_allocated_file_size(int64_t val = 1);
     void inc_total_file_capacity(int64_t val = 1);
     void dec_total_file_capacity(int64_t val = 1);
+    void reset_total_file_capacity();
     int64_t get_allocated_file_size();
     int64_t get_total_file_capacity();
     double get_global_file_used_ratio(void);

--- a/mooncake-store/src/master_metric_manager.cpp
+++ b/mooncake-store/src/master_metric_manager.cpp
@@ -767,6 +767,10 @@ void MasterMetricManager::dec_total_file_capacity(int64_t val) {
     file_total_capacity_.dec(val);
 }
 
+void MasterMetricManager::reset_total_file_capacity() {
+    file_total_capacity_.reset();
+}
+
 void MasterMetricManager::set_dfs_capacity_unlimited(bool unlimited) {
     dfs_capacity_unlimited_ = unlimited;
 }

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -6904,6 +6904,26 @@ bool MasterService::TryRestoreStateFromSnapshot(
             }
         }
 
+        {
+            // Rebuild file (SSD) total capacity from restored LocalDiskSegment
+            // instances, so that the SSD Storage denominator is correct after
+            // restore (matching the mem capacity rebuild above).
+            ScopedLocalDiskSegmentAccess local_disk_access =
+                segment_manager_.getLocalDiskSegmentAccess();
+            auto& client_local_disk =
+                local_disk_access.getClientLocalDiskSegment();
+            int64_t total_file_cap = 0;
+            for (const auto& [client_id, segment] : client_local_disk) {
+                if (segment->ssd_total_capacity_bytes > 0) {
+                    MasterMetricManager::instance().inc_total_file_capacity(
+                        segment->ssd_total_capacity_bytes);
+                    total_file_cap += segment->ssd_total_capacity_bytes;
+                }
+            }
+            LOG(INFO) << "[Restore] Total file capacity after restore: "
+                      << total_file_cap;
+        }
+
         LOG(INFO) << "[Restore] Successfully restored state from snapshot: "
                   << state_id;
         return true;

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -6905,9 +6905,10 @@ bool MasterService::TryRestoreStateFromSnapshot(
         }
 
         {
-            // Rebuild file (SSD) total capacity from restored LocalDiskSegment
-            // instances, so that the SSD Storage denominator is correct after
-            // restore (matching the mem capacity rebuild above).
+            // Rebuild file (SSD) total capacity from restored
+            // LocalDiskSegment instances, so that the SSD Storage
+            // denominator is correct after restore (matching the mem
+            // capacity rebuild above).
             ScopedLocalDiskSegmentAccess local_disk_access =
                 segment_manager_.getLocalDiskSegmentAccess();
             auto& client_local_disk =

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -6914,7 +6914,7 @@ bool MasterService::TryRestoreStateFromSnapshot(
                 local_disk_access.getClientLocalDiskSegment();
             int64_t total_file_cap = 0;
             for (const auto& [client_id, segment] : client_local_disk) {
-                if (segment->ssd_total_capacity_bytes > 0) {
+                if (segment && segment->ssd_total_capacity_bytes > 0) {
                     MasterMetricManager::instance().inc_total_file_capacity(
                         segment->ssd_total_capacity_bytes);
                     total_file_cap += segment->ssd_total_capacity_bytes;
@@ -6954,6 +6954,7 @@ void MasterService::ResetStateAfterFailedRestoreAttempt() {
 
     MasterMetricManager::instance().reset_allocated_mem_size();
     MasterMetricManager::instance().reset_total_mem_capacity();
+    MasterMetricManager::instance().reset_total_file_capacity();
     MasterMetricManager::instance().reset_cache_total_nums();
 }
 

--- a/mooncake-store/src/segment.cpp
+++ b/mooncake-store/src/segment.cpp
@@ -673,14 +673,15 @@ SegmentSerializer::Serialize() {
         packer.pack(UuidToString(client_uuid));
 
         // Serialize LocalDiskSegment: [enable_offloading, count, storage_key1,
-        // task1, storage_key2, task2, ...] Sort keys to ensure determinism.
+        // task1, storage_key2, task2, ..., ssd_total_capacity_bytes]
+        // Sort keys to ensure determinism.
         std::vector<std::string> sorted_keys;
         for (const auto& [key, _] : segment->offloading_objects) {
             sorted_keys.push_back(key);
         }
         std::sort(sorted_keys.begin(), sorted_keys.end());
 
-        packer.pack_array(2 + sorted_keys.size() * 2);
+        packer.pack_array(3 + sorted_keys.size() * 2);
         packer.pack(segment->enable_offloading);
         packer.pack(static_cast<uint64_t>(sorted_keys.size()));
 
@@ -692,6 +693,8 @@ SegmentSerializer::Serialize() {
             packer.pack(task.key);
             packer.pack(task.size);
         }
+
+        packer.pack(segment->ssd_total_capacity_bytes);
     }
 
     // Compress entire data
@@ -1013,7 +1016,7 @@ tl::expected<void, SerializationError> SegmentSerializer::Deserialize(
             }
 
             // Parse LocalDiskSegment array: [enable_offloading, count,
-            // storage_key1, task1, ...]
+            // storage_key1, task1, ..., ssd_total_capacity_bytes]
             if (client_value.type != msgpack::type::ARRAY ||
                 client_value.via.array.size < 2) {
                 return tl::unexpected(
@@ -1027,6 +1030,17 @@ tl::expected<void, SerializationError> SegmentSerializer::Deserialize(
 
             auto segment =
                 std::make_shared<LocalDiskSegment>(enable_offloading);
+
+            // Backward compatibility: the last element (ssd_total_capacity_bytes)
+            // was added later. For old snapshots without this field, the
+            // capacity defaults to 0.
+            if (client_value.via.array.size > 2 + count * 2) {
+                size_t cap_idx = client_value.via.array.size - 1;
+                if (IsMsgpackInteger(client_value.via.array.ptr[cap_idx])) {
+                    segment->ssd_total_capacity_bytes =
+                        client_value.via.array.ptr[cap_idx].as<int64_t>();
+                }
+            }
 
             // Parse offloading_objects
             for (uint64_t k = 0; k < count; ++k) {

--- a/mooncake-store/src/segment.cpp
+++ b/mooncake-store/src/segment.cpp
@@ -672,8 +672,8 @@ SegmentSerializer::Serialize() {
             segment_manager_->client_local_disk_segment_.at(client_uuid);
         packer.pack(UuidToString(client_uuid));
 
-        // Serialize LocalDiskSegment: [enable_offloading, count, storage_key1,
-        // task1, storage_key2, task2, ..., ssd_total_capacity_bytes]
+        // Serialize LocalDiskSegment: [enable_offloading, count,
+        // storage_key1, task1, ..., ssd_total_capacity_bytes]
         // Sort keys to ensure determinism.
         std::vector<std::string> sorted_keys;
         for (const auto& [key, _] : segment->offloading_objects) {
@@ -1031,9 +1031,9 @@ tl::expected<void, SerializationError> SegmentSerializer::Deserialize(
             auto segment =
                 std::make_shared<LocalDiskSegment>(enable_offloading);
 
-            // Backward compatibility: the last element (ssd_total_capacity_bytes)
-            // was added later. For old snapshots without this field, the
-            // capacity defaults to 0.
+            // Backward compatibility: the last element
+            // (ssd_total_capacity_bytes) was added later. For old
+            // snapshots without this field, capacity defaults to 0.
             if (client_value.via.array.size > 2 + count * 2) {
                 size_t cap_idx = client_value.via.array.size - 1;
                 if (IsMsgpackInteger(client_value.via.array.ptr[cap_idx])) {


### PR DESCRIPTION
When master restarts with snapshot enabled and SSD offload configured, the
SSD total capacity (denominator) in metrics displays as 0 after restore:

    Before restart: SSD Storage: 400MB / 2TB
    After restart:  SSD Storage: 400MB / 0 B

Root cause:
1. SegmentSerializer.Serialize() did not include ssd_total_capacity_bytes
   in the serialized LocalDiskSegment fields.
2. TryRestoreStateFromSnapshot() did not rebuild the file_total_capacity_
   gauge after deserializing segments (mem capacity has equivalent logic).

Fix:
- segment.cpp: Append ssd_total_capacity_bytes to the serialized array
  with backward-compatible deserialization for old snapshots.
- master_service.cpp: Rebuild file_total_capacity_ gauge from restored
  LocalDiskSegment instances after snapshot restore.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Manual testing:
1. Started master with enable_snapshot=true, enable_offloading=true
2. Started 1 client with 2TB SSD offload, wrote 100 KV pairs
3. Verified metrics show "SSD Storage: X / 2TB" (correct)
4. Restarted master, verified snapshot restored successfully
5. Confirmed metrics show "SSD Storage: X / 2TB" instead of "X / 0 B"
   (denominator restored correctly)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

CodeBuddy assisted with root cause analysis and code navigation.
All changes were manually reviewed and verified through testing.