### PR TITLE
Add fragmentation-aware allocation strategy for Mooncake Store

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,15 @@ jobs:
         kill $MASTER_PID 2>/dev/null || true
       shell: bash
 
+    - name: Reclaim disk before Go store binding integration tests
+      run: |
+        df -h
+        rm -rf mooncake-store/rust/target
+        rm -rf ~/.cargo/registry ~/.cargo/git
+        rm -rf ~/.cache/sccache || true
+        df -h
+      shell: bash
+
     - name: Run Go store binding integration tests
       run: |
         $GITHUB_WORKSPACE/build/mooncake-store/src/mooncake_master \

--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -461,7 +461,7 @@ mooncake_master \
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--allocation_strategy` | `random` | Allocation strategy: `random` (pure random, fastest), `free_ratio_first` (best memory load balance), `ssd_free_ratio_first` (SSD-aware free-ratio-first), `cxl` (prefer CXL memory), or `local_first` (prefer local host memory segments before ordered remote fallback) |
+| `--allocation_strategy` | `random` | Allocation strategy: `random` (pure random, fastest), `free_ratio_first` (best memory load balance), `fragmentation_aware` (prefer sampled segments with a fit-capable contiguous free region), `ssd_free_ratio_first` (SSD-aware free-ratio-first), `cxl` (prefer CXL memory), or `local_first` (prefer local host memory segments before ordered remote fallback) |
 
 ### PutStart Timeouts
 

--- a/docs/source/design/mooncake-store.md
+++ b/docs/source/design/mooncake-store.md
@@ -564,7 +564,7 @@ Mooncake Store provides multiple built-in allocation strategies to control how s
 ./build/mooncake-store/src/mooncake_master --allocation_strategy=free_ratio_first
 ```
 
-Valid values are: `random` (default), `free_ratio_first`, `ssd_free_ratio_first`, `cxl`, `local_first` (case-sensitive).
+Valid values are: `random` (default), `free_ratio_first`, `fragmentation_aware`, `ssd_free_ratio_first`, `cxl`, `local_first` (case-sensitive).
 
 #### How to Choose
 
@@ -572,6 +572,7 @@ Valid values are: `random` (default), `free_ratio_first`, `ssd_free_ratio_first`
 |---|---|---|
 | `random` | Maximum throughput, stable clusters | Limited load balancing; slow convergence when new segments join |
 | `free_ratio_first` | Balanced utilization, dynamic scaling | Slightly lower throughput due to sampling and sorting overhead |
+| `fragmentation_aware` | Mixed-size KV cache workloads and long-running clusters with allocator fragmentation | Slightly higher metadata-read overhead than `free_ratio_first` |
 | `ssd_free_ratio_first` | SSD-aware memory allocation when SSD offloading is enabled | Depends on SSD usage metrics; falls back to random allocation when needed |
 | `cxl` | CXL memory hardware | CXL-specific; single-replica only |
 | `local_first` | Colocated inference workers and memory store segments | Requires stable host identity in `local_hostname`; single memory replica only |
@@ -581,6 +582,8 @@ Valid values are: `random` (default), `free_ratio_first`, `ssd_free_ratio_first`
 **Use `free_ratio_first`** when you need better load balancing across segments, especially in scenarios where:
 - Segments have different capacities and you want even utilization ratios.
 - New segments are dynamically added at runtime and you need them to absorb load quickly. With `random`, convergence to a well-balanced state can be slow on large or dynamic clusters; `free_ratio_first` accelerates this by preferentially filling emptier segments, substantially increasing the likelihood that newly joined segments are selected for allocations (see details below).
+
+**Use `fragmentation_aware`** when request sizes vary and long-running allocators may have high aggregate free bytes split into small holes. It prefers sampled segments whose largest contiguous free region can satisfy the current request, reducing failed allocation attempts for larger KV cache objects.
 
 **Use `ssd_free_ratio_first`** when SSD offloading is enabled and you want memory allocation to prefer segments whose backing SSD still has more free capacity.
 
@@ -616,6 +619,18 @@ An improved strategy built on top of `RandomAllocationStrategy`. Instead of pick
 The overhead is minimal: sampling is `O(K)` and sorting is `O(K log K)`, where K is the candidate count (at most `6*N`) — both small since `replica_num` is typically 1–3. The strategy is thread-safe, using `thread_local` random state with no shared mutable data.
 
 The key insight behind Best-of-N is that if a new/empty segment is sampled, it will almost certainly be ranked first due to having the highest free ratio, which naturally accelerates convergence when new segments join the cluster.
+
+**`fragmentation_aware` - FragmentationAwareAllocationStrategy**
+
+A fragmentation-aware variant for mixed-size KV cache workloads. It uses the same bounded candidate sampling shape as `free_ratio_first`, but adds a contiguous-fit signal before ranking by score:
+
+1. **Preferred segment phase**: Same as `random` and `free_ratio_first`; explicit preferred segments are tried before sampled candidates.
+2. **Sampling phase**: Randomly picks a starting index and takes `min(6*remaining_replicas, total_segments)` consecutive segments as candidates.
+3. **Fragmentation scoring phase**: For each candidate, reads aggregate free bytes and `getLargestFreeRegion()` from its allocators. Offset allocators expose the actual largest free region; allocators without precise fragmentation metadata are treated conservatively by using available free bytes.
+4. **Ranking phase**: Fit-capable candidates are ranked ahead of candidates whose largest free region cannot fit the current slice. Candidates with the same fit status are sorted by `0.70 * contiguity_ratio + 0.30 * free_ratio`, then by largest free region.
+5. **Fallback phase**: If sampled candidates cannot satisfy all requested replicas, allocation falls back to the normal random path for the remaining replicas.
+
+This prevents a segment with high total free space but no sufficiently large contiguous block from being tried before a segment that can actually satisfy the allocation. The default `random` strategy remains unchanged; users opt in with `--allocation_strategy=fragmentation_aware`.
 
 **`ssd_free_ratio_first` — SsdFreeRatioFirstAllocationStrategy**
 

--- a/mooncake-store/benchmarks/allocation_strategy_bench.cpp
+++ b/mooncake-store/benchmarks/allocation_strategy_bench.cpp
@@ -627,6 +627,8 @@ static std::string strategyName(AllocationStrategyType type) {
             return "Random";
         case AllocationStrategyType::FREE_RATIO_FIRST:
             return "FreeRatioFirst";
+        case AllocationStrategyType::FRAGMENTATION_AWARE:
+            return "FragmentationAware";
         default:
             return "Unknown";
     }
@@ -1577,6 +1579,7 @@ static void runFillupBenchmarks() {
     std::vector<AllocationStrategyType> strategies = {
         AllocationStrategyType::RANDOM,
         AllocationStrategyType::FREE_RATIO_FIRST,
+        AllocationStrategyType::FRAGMENTATION_AWARE,
     };
 
     std::cout
@@ -1640,7 +1643,8 @@ static void runScaleOutMatrix() {
     std::vector<int> replica_nums = {1, 2, 3};
     std::vector<AllocationStrategyType> strategies = {
         AllocationStrategyType::RANDOM,
-        AllocationStrategyType::FREE_RATIO_FIRST};
+        AllocationStrategyType::FREE_RATIO_FIRST,
+        AllocationStrategyType::FRAGMENTATION_AWARE};
 
     std::cout
         << "\n=== Scale-Out Workload Benchmark (Matrix) ===\n"
@@ -1706,6 +1710,7 @@ static void runDsaMatrix() {
     std::vector<AllocationStrategyType> strategies = {
         AllocationStrategyType::RANDOM,
         AllocationStrategyType::FREE_RATIO_FIRST,
+        AllocationStrategyType::FRAGMENTATION_AWARE,
     };
 
     size_t seg_cap_mb = static_cast<size_t>(FLAGS_dsa_segment_capacity);
@@ -1804,6 +1809,7 @@ static void runSizeClassChurnMatrix() {
     std::vector<AllocationStrategyType> strategies = {
         AllocationStrategyType::RANDOM,
         AllocationStrategyType::FREE_RATIO_FIRST,
+        AllocationStrategyType::FRAGMENTATION_AWARE,
     };
 
     std::vector<std::string> patterns;

--- a/mooncake-store/include/allocation_strategy.h
+++ b/mooncake-store/include/allocation_strategy.h
@@ -558,6 +558,215 @@ class FreeRatioFirstAllocationStrategy : public RandomAllocationStrategy {
     }
 };
 
+/**
+ * @brief Fragmentation-aware allocation strategy.
+ *
+ * This strategy keeps the bounded sampling shape of FreeRatioFirst, but ranks
+ * each sampled segment by whether its largest contiguous free region can fit
+ * the current request. This avoids selecting a segment that has enough total
+ * free bytes but only in small fragmented holes.
+ */
+class FragmentationAwareAllocationStrategy : public RandomAllocationStrategy {
+   public:
+    FragmentationAwareAllocationStrategy() = default;
+
+    tl::expected<std::vector<Replica>, ErrorCode> Allocate(
+        const AllocatorManager& allocator_manager, const size_t slice_length,
+        const size_t replica_num = 1,
+        const std::vector<std::string>& preferred_segments =
+            std::vector<std::string>(),
+        const std::set<std::string>& excluded_segments =
+            std::set<std::string>(),
+        const ReplicaType replica_type = ReplicaType::MEMORY) override {
+        if (slice_length == 0 || replica_num == 0) {
+            return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+        }
+
+        const auto& names = allocator_manager.getNames();
+        if (names.empty()) {
+            return tl::make_unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
+        }
+
+        static thread_local std::mt19937 generator(std::random_device{}());
+
+        std::vector<Replica> replicas;
+        replicas.reserve(replica_num);
+        std::set<std::string> used_segments;
+
+        for (const auto& preferred_segment : preferred_segments) {
+            if (excluded_segments.contains(preferred_segment) ||
+                used_segments.contains(preferred_segment)) {
+                continue;
+            }
+
+            auto buffer = allocateSingle(allocator_manager, preferred_segment,
+                                         slice_length, generator);
+            if (buffer) {
+                replicas.emplace_back(std::move(buffer),
+                                      ReplicaStatus::PROCESSING, replica_type);
+                used_segments.insert(preferred_segment);
+                if (replicas.size() == replica_num) {
+                    return replicas;
+                }
+            }
+        }
+
+        const size_t remaining = replica_num - replicas.size();
+        const size_t sample_count =
+            std::min(kCandidateMultiplier * remaining, names.size());
+
+        std::uniform_int_distribution<size_t> start_dist(0, names.size() - 1);
+        size_t start_idx = start_dist(generator);
+
+        std::vector<Candidate> candidates;
+        candidates.reserve(sample_count);
+
+        for (size_t i = 0; i < sample_count; ++i) {
+            size_t idx = (start_idx + i) % names.size();
+            const auto& name = names[idx];
+            if (excluded_segments.contains(name) ||
+                used_segments.contains(name)) {
+                continue;
+            }
+            candidates.push_back(getSegmentCandidate(allocator_manager, idx,
+                                                     name, slice_length));
+        }
+
+        std::sort(candidates.begin(), candidates.end(),
+                  [](const Candidate& a, const Candidate& b) {
+                      if (a.can_fit != b.can_fit) {
+                          return a.can_fit > b.can_fit;
+                      }
+                      if (a.score != b.score) {
+                          return a.score > b.score;
+                      }
+                      if (a.largest_free_region != b.largest_free_region) {
+                          return a.largest_free_region >
+                                 b.largest_free_region;
+                      }
+                      if (a.free_ratio != b.free_ratio) {
+                          return a.free_ratio > b.free_ratio;
+                      }
+                      return a.name_idx < b.name_idx;
+                  });
+
+        for (const auto& candidate : candidates) {
+            if (replicas.size() >= replica_num) {
+                break;
+            }
+
+            const auto& name = names[candidate.name_idx];
+            if (excluded_segments.contains(name) ||
+                used_segments.contains(name)) {
+                continue;
+            }
+
+            auto buffer = allocateSingle(allocator_manager, name, slice_length,
+                                         generator);
+            if (buffer) {
+                replicas.emplace_back(std::move(buffer),
+                                      ReplicaStatus::PROCESSING, replica_type);
+                used_segments.insert(name);
+            }
+        }
+
+        if (replicas.size() >= replica_num) {
+            return replicas;
+        }
+
+        std::uniform_int_distribution<size_t> distribution(0, names.size() - 1);
+        size_t fallback_idx = distribution(generator);
+        const size_t max_retry = std::min(kMaxRetryLimit, names.size());
+        size_t try_count = 0;
+
+        while (replicas.size() < replica_num && try_count < max_retry) {
+            auto index = fallback_idx % names.size();
+            fallback_idx++;
+            try_count++;
+
+            if (excluded_segments.contains(names[index]) ||
+                used_segments.contains(names[index])) {
+                continue;
+            }
+
+            auto buffer = allocateSingle(allocator_manager, names[index],
+                                         slice_length, generator);
+            if (buffer) {
+                replicas.emplace_back(std::move(buffer),
+                                      ReplicaStatus::PROCESSING, replica_type);
+                used_segments.insert(names[index]);
+            }
+        }
+
+        if (replicas.empty()) {
+            return tl::make_unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
+        }
+        return replicas;
+    }
+
+   private:
+    static constexpr size_t kMaxRetryLimit = 100;
+    static constexpr size_t kCandidateMultiplier = 6;
+
+    struct Candidate {
+        size_t name_idx;
+        bool can_fit;
+        double free_ratio;
+        double score;
+        uint64_t largest_free_region;
+    };
+
+    Candidate getSegmentCandidate(const AllocatorManager& allocator_manager,
+                                  size_t name_idx, const std::string& name,
+                                  size_t slice_length) const {
+        auto allocators = allocator_manager.getAllocators(name);
+        if (!allocators || allocators->empty()) {
+            return {name_idx, false, 0.0, 0.0, 0};
+        }
+
+        uint64_t total_capacity = 0;
+        uint64_t total_free = 0;
+        uint64_t largest_free_region = 0;
+
+        for (const auto& alloc : *allocators) {
+            if (!alloc) {
+                continue;
+            }
+
+            const uint64_t capacity = static_cast<uint64_t>(alloc->capacity());
+            const uint64_t used =
+                std::min<uint64_t>(static_cast<uint64_t>(alloc->size()),
+                                   capacity);
+            const uint64_t free = capacity - used;
+            const uint64_t reported_largest =
+                static_cast<uint64_t>(alloc->getLargestFreeRegion());
+            const uint64_t allocator_largest =
+                reported_largest == kAllocatorUnknownFreeSpace
+                    ? free
+                    : std::min<uint64_t>(reported_largest, free);
+
+            total_capacity += capacity;
+            total_free += free;
+            largest_free_region =
+                std::max(largest_free_region, allocator_largest);
+        }
+
+        if (total_capacity == 0 || total_free == 0) {
+            return {name_idx, false, 0.0, 0.0, largest_free_region};
+        }
+
+        const double free_ratio = static_cast<double>(total_free) /
+                                  static_cast<double>(total_capacity);
+        const double contiguity_ratio =
+            std::min(1.0, static_cast<double>(largest_free_region) /
+                              static_cast<double>(total_free));
+        const bool can_fit = largest_free_region >= slice_length;
+        const double score = 0.70 * contiguity_ratio + 0.30 * free_ratio;
+
+        return {name_idx, can_fit, free_ratio, score, largest_free_region};
+    }
+};
+
 class SsdFreeRatioFirstAllocationStrategy : public RandomAllocationStrategy {
    public:
     SsdFreeRatioFirstAllocationStrategy() = default;
@@ -778,6 +987,8 @@ inline std::shared_ptr<AllocationStrategy> CreateAllocationStrategy(
             return std::make_shared<RandomAllocationStrategy>();
         case AllocationStrategyType::FREE_RATIO_FIRST:
             return std::make_shared<FreeRatioFirstAllocationStrategy>();
+        case AllocationStrategyType::FRAGMENTATION_AWARE:
+            return std::make_shared<FragmentationAwareAllocationStrategy>();
         case AllocationStrategyType::CXL:
             return std::make_shared<CxlAllocationStrategy>();
         case AllocationStrategyType::SSD_FREE_RATIO_FIRST:

--- a/mooncake-store/include/allocation_strategy.h
+++ b/mooncake-store/include/allocation_strategy.h
@@ -641,8 +641,7 @@ class FragmentationAwareAllocationStrategy : public RandomAllocationStrategy {
                           return a.score > b.score;
                       }
                       if (a.largest_free_region != b.largest_free_region) {
-                          return a.largest_free_region >
-                                 b.largest_free_region;
+                          return a.largest_free_region > b.largest_free_region;
                       }
                       if (a.free_ratio != b.free_ratio) {
                           return a.free_ratio > b.free_ratio;
@@ -734,9 +733,8 @@ class FragmentationAwareAllocationStrategy : public RandomAllocationStrategy {
             }
 
             const uint64_t capacity = static_cast<uint64_t>(alloc->capacity());
-            const uint64_t used =
-                std::min<uint64_t>(static_cast<uint64_t>(alloc->size()),
-                                   capacity);
+            const uint64_t used = std::min<uint64_t>(
+                static_cast<uint64_t>(alloc->size()), capacity);
             const uint64_t free = capacity - used;
             const uint64_t reported_largest =
                 static_cast<uint64_t>(alloc->getLargestFreeRegion());

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -499,6 +499,9 @@ class WrappedMasterServiceConfig {
         // Convert string allocation_strategy to AllocationStrategyType enum
         if (config.allocation_strategy == "free_ratio_first") {
             allocation_strategy_type = AllocationStrategyType::FREE_RATIO_FIRST;
+        } else if (config.allocation_strategy == "fragmentation_aware") {
+            allocation_strategy_type =
+                AllocationStrategyType::FRAGMENTATION_AWARE;
         } else if (config.allocation_strategy == "cxl") {
             allocation_strategy_type = AllocationStrategyType::CXL;
         } else if (config.allocation_strategy == "random") {
@@ -513,7 +516,8 @@ class WrappedMasterServiceConfig {
                          << config.allocation_strategy
                          << "'. Defaulting to 'random'. "
                          << "Valid options are: random, free_ratio_first, cxl, "
-                            "ssd_free_ratio_first, local_first "
+                            "ssd_free_ratio_first, local_first, "
+                            "fragmentation_aware "
                             "(case-sensitive)";
             allocation_strategy_type = AllocationStrategyType::RANDOM;
         }

--- a/mooncake-store/include/types.h
+++ b/mooncake-store/include/types.h
@@ -499,7 +499,8 @@ enum class AllocationStrategyType {
     FREE_RATIO_FIRST,      // Free-ratio-first allocation
     CXL,                   // CXL-specific allocation
     SSD_FREE_RATIO_FIRST,  // SSD free-ratio-first allocation
-    LOCAL_FIRST            // Prefer local host before ordered remote fallback
+    LOCAL_FIRST,           // Prefer local host before ordered remote fallback
+    FRAGMENTATION_AWARE    // Fragmentation-aware allocation
 };
 
 /**

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -264,7 +264,7 @@ DEFINE_string(memory_allocator, "offset",
 DEFINE_string(
     allocation_strategy, "random",
     "Allocation strategy for segments, random | free_ratio_first | cxl | "
-    "ssd_free_ratio_first | local_first");
+    "ssd_free_ratio_first | local_first | fragmentation_aware");
 DEFINE_bool(enable_http_metadata_server, false,
             "Enable HTTP metadata server instead of etcd");
 DEFINE_int32(http_metadata_server_port, 8080,

--- a/mooncake-store/tests/allocation_strategy_test.cpp
+++ b/mooncake-store/tests/allocation_strategy_test.cpp
@@ -665,7 +665,7 @@ TEST_F(AllocationStrategyTest,
         "contiguous", kSegmentBase + 0x10000000ULL, kSegmentSize, "contiguous");
 
     std::vector<std::unique_ptr<AllocatedBuffer>> fragmented_buffers;
-    for (int i = 0; i < 4; ++i) {
+    for (int i = 0; i < 5; ++i) {
         auto buffer = fragmented->allocate(8 * MiB);
         ASSERT_NE(buffer, nullptr);
         fragmented_buffers.emplace_back(std::move(buffer));

--- a/mooncake-store/tests/allocation_strategy_test.cpp
+++ b/mooncake-store/tests/allocation_strategy_test.cpp
@@ -662,8 +662,7 @@ TEST_F(AllocationStrategyTest,
     auto fragmented = std::make_shared<OffsetBufferAllocator>(
         "fragmented", kSegmentBase, kSegmentSize, "fragmented");
     auto contiguous = std::make_shared<OffsetBufferAllocator>(
-        "contiguous", kSegmentBase + 0x10000000ULL, kSegmentSize,
-        "contiguous");
+        "contiguous", kSegmentBase + 0x10000000ULL, kSegmentSize, "contiguous");
 
     std::vector<std::unique_ptr<AllocatedBuffer>> fragmented_buffers;
     for (int i = 0; i < 4; ++i) {
@@ -692,8 +691,9 @@ TEST_F(AllocationStrategyTest,
 
     const auto desc = result->front().get_descriptor();
     ASSERT_TRUE(desc.is_memory_replica());
-    EXPECT_EQ(desc.get_memory_descriptor().buffer_descriptor.transport_endpoint_,
-              "contiguous");
+    EXPECT_EQ(
+        desc.get_memory_descriptor().buffer_descriptor.transport_endpoint_,
+        "contiguous");
 }
 
 TEST_F(AllocationStrategyTest, FragmentationAwarePreservesPreferredSegment) {
@@ -717,8 +717,9 @@ TEST_F(AllocationStrategyTest, FragmentationAwarePreservesPreferredSegment) {
 
     const auto desc = result->front().get_descriptor();
     ASSERT_TRUE(desc.is_memory_replica());
-    EXPECT_EQ(desc.get_memory_descriptor().buffer_descriptor.transport_endpoint_,
-              "preferred");
+    EXPECT_EQ(
+        desc.get_memory_descriptor().buffer_descriptor.transport_endpoint_,
+        "preferred");
 }
 
 // Test the performance comparison between strategies

--- a/mooncake-store/tests/allocation_strategy_test.cpp
+++ b/mooncake-store/tests/allocation_strategy_test.cpp
@@ -25,7 +25,8 @@ static constexpr size_t MiB = 1024 * 1024;
 
 // Strategy types for parameterized tests
 const auto kStrategyTypes = ::testing::Values(
-    AllocationStrategyType::RANDOM, AllocationStrategyType::FREE_RATIO_FIRST);
+    AllocationStrategyType::RANDOM, AllocationStrategyType::FREE_RATIO_FIRST,
+    AllocationStrategyType::FRAGMENTATION_AWARE);
 
 const auto kAllocatorTypes = ::testing::Values(BufferAllocatorType::CACHELIB,
                                                BufferAllocatorType::OFFSET);
@@ -88,6 +89,9 @@ INSTANTIATE_TEST_SUITE_P(
                 break;
             case AllocationStrategyType::FREE_RATIO_FIRST:
                 strategy_str = "FreeRatioFirst";
+                break;
+            case AllocationStrategyType::FRAGMENTATION_AWARE:
+                strategy_str = "FragmentationAware";
                 break;
             case AllocationStrategyType::SSD_FREE_RATIO_FIRST:
                 strategy_str = "SsdFreeRatioFirst";
@@ -647,6 +651,74 @@ TEST_P(AllocationStrategyParameterizedTest,
     // Verify that utilization ratios are balanced (within 15%)
     EXPECT_LT(util_diff, 15.0)
         << "FreeRatioFirst should balance utilization ratios";
+}
+
+TEST_F(AllocationStrategyTest,
+       FragmentationAwarePrefersContiguousSpaceOverTotalFreeSpace) {
+    const auto kSegmentBase = 0x100000000ULL;
+    const auto kSegmentSize = 40 * MiB;
+    const auto kRequestSize = 10 * MiB;
+
+    auto fragmented = std::make_shared<OffsetBufferAllocator>(
+        "fragmented", kSegmentBase, kSegmentSize, "fragmented");
+    auto contiguous = std::make_shared<OffsetBufferAllocator>(
+        "contiguous", kSegmentBase + 0x10000000ULL, kSegmentSize,
+        "contiguous");
+
+    std::vector<std::unique_ptr<AllocatedBuffer>> fragmented_buffers;
+    for (int i = 0; i < 4; ++i) {
+        auto buffer = fragmented->allocate(8 * MiB);
+        ASSERT_NE(buffer, nullptr);
+        fragmented_buffers.emplace_back(std::move(buffer));
+    }
+
+    fragmented_buffers[1].reset();
+    fragmented_buffers[3].reset();
+
+    auto contiguous_used = contiguous->allocate(28 * MiB);
+    ASSERT_NE(contiguous_used, nullptr);
+
+    ASSERT_LT(fragmented->getLargestFreeRegion(), kRequestSize);
+    ASSERT_GE(contiguous->getLargestFreeRegion(), kRequestSize);
+
+    AllocatorManager allocator_manager;
+    allocator_manager.addAllocator("fragmented", fragmented);
+    allocator_manager.addAllocator("contiguous", contiguous);
+
+    FragmentationAwareAllocationStrategy strategy;
+    auto result = strategy.Allocate(allocator_manager, kRequestSize);
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(result->size(), 1);
+
+    const auto desc = result->front().get_descriptor();
+    ASSERT_TRUE(desc.is_memory_replica());
+    EXPECT_EQ(desc.get_memory_descriptor().buffer_descriptor.transport_endpoint_,
+              "contiguous");
+}
+
+TEST_F(AllocationStrategyTest, FragmentationAwarePreservesPreferredSegment) {
+    const auto kSegmentBase = 0x100000000ULL;
+    const auto kSegmentSize = 32 * MiB;
+
+    auto preferred = std::make_shared<OffsetBufferAllocator>(
+        "preferred", kSegmentBase, kSegmentSize, "preferred");
+    auto other = std::make_shared<OffsetBufferAllocator>(
+        "other", kSegmentBase + 0x10000000ULL, kSegmentSize, "other");
+
+    AllocatorManager allocator_manager;
+    allocator_manager.addAllocator("preferred", preferred);
+    allocator_manager.addAllocator("other", other);
+
+    FragmentationAwareAllocationStrategy strategy;
+    auto result =
+        strategy.Allocate(allocator_manager, 4 * MiB, 1, {"preferred"}, {});
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(result->size(), 1);
+
+    const auto desc = result->front().get_descriptor();
+    ASSERT_TRUE(desc.is_memory_replica());
+    EXPECT_EQ(desc.get_memory_descriptor().buffer_descriptor.transport_endpoint_,
+              "preferred");
 }
 
 // Test the performance comparison between strategies


### PR DESCRIPTION
## Summary

This PR adds an opt-in Mooncake Store allocation strategy named `fragmentation_aware` for mixed-size KVCache workloads. The strategy keeps bounded candidate sampling, but ranks sampled segments by whether their largest contiguous free region can satisfy the current request before considering aggregate free ratio.

## Why

In long-running Store pools, aggregate free space can be split into fragmented holes. A segment may report a higher total free ratio while failing a large allocation because no contiguous region is large enough. This creates avoidable allocation attempts and fallback pressure.

## Changes

- Add `AllocationStrategyType::FRAGMENTATION_AWARE`.
- Add `FragmentationAwareAllocationStrategy`.
- Wire `--allocation_strategy=fragmentation_aware`.
- Add deterministic fragmentation and preferred-segment tests.
- Add the strategy to `allocation_strategy_bench`.
- Document design and deployment usage.

## Validation

- `git diff --check`
- `git apply --check` against current upstream
- deterministic fragmentation simulation
- extended ranking and boundary simulation
- topic-aligned Store scalability simulation

## Boundaries

The default allocation strategy remains unchanged. This PR does not redesign SGLang HiCache, RDMA transport, or Mooncake HA. Full upstream CI, RDMA validation, and real SGLang HiCache benchmark should still be run in a production-like environment before claiming end-to-end throughput gains.