### PR TITLE
[Bugfix] Skip os.chmod when binary is already readable and executable

### DIFF
--- a/mooncake-wheel/mooncake/cli.py
+++ b/mooncake-wheel/mooncake/cli.py
@@ -4,6 +4,7 @@ Minimal CLI module for mooncake_master.
 """
 
 import os
+import stat
 import sys
 import subprocess
 
@@ -18,8 +19,9 @@ def main():
     bin_path = os.path.join(package_dir, "mooncake_master")
 
     # Make sure the binary is executable
-    if not os.access(bin_path, os.R_OK | os.X_OK):
-        os.chmod(bin_path, 0o755)
+    if not os.access(bin_path, os.X_OK):
+        st = os.stat(bin_path)
+        os.chmod(bin_path, st.st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
     # Run the binary with all arguments passed through
     return subprocess.call([bin_path] + sys.argv[1:])

--- a/mooncake-wheel/mooncake/cli.py
+++ b/mooncake-wheel/mooncake/cli.py
@@ -16,10 +16,11 @@ def main():
     # Get the path to the mooncake_master binary
     package_dir = os.path.dirname(os.path.abspath(__file__))
     bin_path = os.path.join(package_dir, "mooncake_master")
-    
+
     # Make sure the binary is executable
-    os.chmod(bin_path, 0o755)
-    
+    if not os.access(bin_path, os.R_OK | os.X_OK):
+        os.chmod(bin_path, 0o755)
+
     # Run the binary with all arguments passed through
     return subprocess.call([bin_path] + sys.argv[1:])
 

--- a/mooncake-wheel/mooncake/cli_bench.py
+++ b/mooncake-wheel/mooncake/cli_bench.py
@@ -4,6 +4,7 @@ Minimal CLI module for transfer_engine_bench.
 """
 
 import os
+import stat
 import sys
 import subprocess
 
@@ -18,8 +19,9 @@ def main():
     bin_path = os.path.join(package_dir, "transfer_engine_bench")
 
     # Make sure the binary is executable
-    if not os.access(bin_path, os.R_OK | os.X_OK):
-        os.chmod(bin_path, 0o755)
+    if not os.access(bin_path, os.X_OK):
+        st = os.stat(bin_path)
+        os.chmod(bin_path, st.st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
     # Run the binary with all arguments passed through
     return subprocess.call([bin_path] + sys.argv[1:])

--- a/mooncake-wheel/mooncake/cli_bench.py
+++ b/mooncake-wheel/mooncake/cli_bench.py
@@ -16,10 +16,11 @@ def main():
     # Get the path to the transfer_engine_bench binary
     package_dir = os.path.dirname(os.path.abspath(__file__))
     bin_path = os.path.join(package_dir, "transfer_engine_bench")
-    
+
     # Make sure the binary is executable
-    os.chmod(bin_path, 0o755)
-    
+    if not os.access(bin_path, os.R_OK | os.X_OK):
+        os.chmod(bin_path, 0o755)
+
     # Run the binary with all arguments passed through
     return subprocess.call([bin_path] + sys.argv[1:])
 

--- a/mooncake-wheel/mooncake/cli_client.py
+++ b/mooncake-wheel/mooncake/cli_client.py
@@ -4,6 +4,7 @@ Minimal CLI module for mooncake_client.
 """
 
 import os
+import stat
 import sys
 import subprocess
 
@@ -18,8 +19,9 @@ def main():
     bin_path = os.path.join(package_dir, "mooncake_client")
 
     # Make sure the binary is executable
-    if not os.access(bin_path, os.R_OK | os.X_OK):
-        os.chmod(bin_path, 0o755)
+    if not os.access(bin_path, os.X_OK):
+        st = os.stat(bin_path)
+        os.chmod(bin_path, st.st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
     # Run the binary with all arguments passed through
     return subprocess.call([bin_path] + sys.argv[1:])

--- a/mooncake-wheel/mooncake/cli_client.py
+++ b/mooncake-wheel/mooncake/cli_client.py
@@ -18,7 +18,8 @@ def main():
     bin_path = os.path.join(package_dir, "mooncake_client")
 
     # Make sure the binary is executable
-    os.chmod(bin_path, 0o755)
+    if not os.access(bin_path, os.R_OK | os.X_OK):
+        os.chmod(bin_path, 0o755)
 
     # Run the binary with all arguments passed through
     return subprocess.call([bin_path] + sys.argv[1:])


### PR DESCRIPTION
## Description

Fix #2802. Fix a PermissionError when running mooncake_master as a non-root user on a wheel installed as root. cli.py unconditionally calls os.chmod(bin_path, 0o755) on every invocation. This fails when:

1. The wheel was installed as root (so the binary is owned by root), but a non-root user runs it.  `os.chmod` requires owner or root privilege. The result is a PermissionError that crashes the CLI before the actual binary is even reached.
2. The file already has full read+execute permissions (-rwxrwxrwx), so the chmod is entirely unnecessary.


This PR adds an os.access pre-check and only runs chmod when the file is missing either read or execute permission.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

manual testing

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [x] No AI tools were used
- [ ] AI tools were used (specify below)