### PR TITLE
[Store] Batch bucket reads into one io_uring submission (QD32)

### DIFF
--- a/mooncake-store/src/storage_backend.cpp
+++ b/mooncake-store/src/storage_backend.cpp
@@ -1485,16 +1485,23 @@ tl::expected<void, ErrorCode> BucketStorageBackend::BatchLoad(
         }
         auto& file = file_res.value();
 
-        // Read each key's data
-        for (const auto& plan : read_plans) {
-            int64_t actual_offset = plan.offset + plan.key_size;
-            tl::expected<size_t, ErrorCode> read_res;
-
 #ifdef USE_URING
-            // Try to use read_aligned for O_DIRECT I/O if file is UringFile
-            UringFile* uring_file = dynamic_cast<UringFile*>(file.get());
-            if (uring_file != nullptr) {
-                // Calculate aligned read range
+        // Zero-copy O_DIRECT fast path: issue ALL of this bucket's reads as one
+        // io_uring batch (up to QUEUE_DEPTH in flight) instead of a serial
+        // per-key read_aligned loop. This raises the across-value queue depth
+        // from ~1 (drain per value) to QD32, so a single thread can saturate
+        // the device (Little's Law: throughput = in-flight / latency). Falls
+        // back to per-key vector_read for the buffered PosixFile path.
+        UringFile* uring_file = dynamic_cast<UringFile*>(file.get());
+        if (uring_file != nullptr) {
+            // Build one aligned descriptor per key. Each reads a 4096-aligned
+            // SUPERSET of the value into dest_slice.ptr (which is oversized by
+            // AllocateBatch / the bench BufferPool to hold it); the value then
+            // lives at ptr + offset_in_buffer (adjusted below, no memcpy).
+            std::vector<UringFile::ReadDesc> descs;
+            descs.reserve(read_plans.size());
+            for (const auto& plan : read_plans) {
+                int64_t actual_offset = plan.offset + plan.key_size;
                 int64_t aligned_offset =
                     align_down(actual_offset, kDirectIOAlignment);
                 int64_t data_end =
@@ -1503,41 +1510,48 @@ tl::expected<void, ErrorCode> BucketStorageBackend::BatchLoad(
                     static_cast<size_t>(data_end), kDirectIOAlignment));
                 size_t aligned_size =
                     static_cast<size_t>(aligned_end - aligned_offset);
-                int64_t offset_in_buffer = actual_offset - aligned_offset;
-
-                // Zero-copy path: read directly into the slice buffer.
-                // dest_slice.ptr is 4096-aligned and oversized (from
-                // AllocateBatch) to accommodate the full aligned read range.
-                read_res = uring_file->read_aligned(
-                    plan.dest_slice.ptr, aligned_size, aligned_offset);
-
-                if (read_res) {
-                    // Adjust ptr to point to actual data start (no memcpy)
-                    batch_object.at(plan.key).ptr =
-                        static_cast<char*>(plan.dest_slice.ptr) +
-                        offset_in_buffer;
-                    read_res = plan.dest_slice.size;
-                }
-            } else
-#endif
-            {
-                // Fallback to vector_read for non-UringFile
-                iovec iov{plan.dest_slice.ptr, plan.dest_slice.size};
-                read_res = file->vector_read(&iov, 1, actual_offset);
+                descs.push_back(
+                    UringFile::ReadDesc{plan.dest_slice.ptr, aligned_size,
+                                        static_cast<off_t>(aligned_offset)});
             }
 
+            auto read_res = uring_file->batch_read(
+                descs.data(), static_cast<int>(descs.size()));
             if (!read_res) {
-                LOG(ERROR) << "vector_read failed for key: " << plan.key
-                           << ", bucket_id=" << plan.bucket_id
+                LOG(ERROR) << "batch_read failed for bucket_id=" << bucket_id
                            << ", error: " << read_res.error();
                 return tl::make_unexpected(read_res.error());
             }
 
-            if (read_res.value() != plan.dest_slice.size) {
-                LOG(ERROR) << "Read size mismatch for key: " << plan.key
-                           << ", expected: " << plan.dest_slice.size
-                           << ", got: " << read_res.value();
-                return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+            // Point each slice at the actual value start within its buffer.
+            for (const auto& plan : read_plans) {
+                int64_t actual_offset = plan.offset + plan.key_size;
+                int64_t offset_in_buffer =
+                    actual_offset -
+                    align_down(actual_offset, kDirectIOAlignment);
+                batch_object.at(plan.key).ptr =
+                    static_cast<char*>(plan.dest_slice.ptr) + offset_in_buffer;
+            }
+        } else
+#endif
+        {
+            // Buffered fallback: per-key vector_read (PosixFile, page cache).
+            for (const auto& plan : read_plans) {
+                int64_t actual_offset = plan.offset + plan.key_size;
+                iovec iov{plan.dest_slice.ptr, plan.dest_slice.size};
+                auto read_res = file->vector_read(&iov, 1, actual_offset);
+                if (!read_res) {
+                    LOG(ERROR) << "vector_read failed for key: " << plan.key
+                               << ", bucket_id=" << plan.bucket_id
+                               << ", error: " << read_res.error();
+                    return tl::make_unexpected(read_res.error());
+                }
+                if (read_res.value() != plan.dest_slice.size) {
+                    LOG(ERROR) << "Read size mismatch for key: " << plan.key
+                               << ", expected: " << plan.dest_slice.size
+                               << ", got: " << read_res.value();
+                    return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+                }
             }
         }
     }


### PR DESCRIPTION
## Description

`BucketStorageBackend::BatchLoad` issued one blocking `read_aligned` per value, so the io_uring ring drained to empty between values (effective queue depth ≈ 1) and a single reader could not keep the NVMe device(s) busy — ~4.7 GiB/s on a 4× Gen5 NVMe RAID0.

This PR replaces the serial per-key loop with a single `UringFile::batch_read` per bucket: build one aligned descriptor per key, submit up to `QUEUE_DEPTH` reads at once, then shift each slice pointer to the value start (zero-copy, no memcpy). The buffered `PosixFile` path is unchanged.

**Why it works:** throughput is set by how many reads are in flight. `fio` on the same array (one thread, O_DIRECT, 1 MB) scales `QD1 → QD8 → QD32 = 3.9 → 24 → 45 GiB/s`. Batching supplies that depth from a single thread. This matters most for the SSD→memory promotion path, which reads one object at a time and cannot rely on many concurrent readers.

## Performance

Measured on 4× Samsung Gen5 NVMe RAID0 (`md0`, 512K chunk) → btrfs, cold reads, 1 MB values. Device read roofline ≈ 45.3 GiB/s (fio).

| Metric | Before (per-key) | After (`batch_read`) |
|---|---|---|
| Single-thread bucket read | 4.7 GiB/s | **~22 GiB/s (≈4.7×)** |
| Threads to reach ~40 GiB/s | 64 | **16 (4× fewer)** |
| Peak aggregate read | 44.6 GiB/s | 44.6 GiB/s (device-bound, unchanged) |
| Random single-thread (scattered keys, O_DIRECT QD32) | ~3.5 GiB/s | **~41 GiB/s** |

The device ceiling itself does not move (peak is device-bound); the win is **single/low-thread** throughput — precisely the promotion path. On random/scattered access it is especially large, since buffered read-ahead collapses (~2.6 GiB/s) where io_uring at depth stays fast.

## Module

- [x] Mooncake Store (`mooncake-store`)

## Type of Change

- [x] Performance improvement

## How Has This Been Tested?

**Test commands:**
```bash
# formatting (clang-format 20.1.8)
./scripts/code_format.sh --check --base origin/main

# storage-backend unit tests
./build/mooncake-store/tests/storage_backend_test
./build/mooncake-store/tests/file_storage_test

# correctness of the changed (io_uring) read path, across value sizes
./build/mooncake-store/benchmarks/storage_backend_bench \
  --backend=bucket --use_uring=true --test=load \
  --cache_mode=drop_cache_external --verify=true \
  --value_size=1048576 --batch_size=32 --num_operations=200

# throughput (single-thread and thread sweep)
 ./build/mooncake-store/benchmarks/storage_backend_bench \
  --backend=bucket --use_uring=true --test=concurrent_load \
  --cache_mode=drop_cache_external --value_size=1048576 --num_threads=<1..64>
```

**Test results:**
- [x] Unit tests pass — `storage_backend_test` 49/49, `file_storage_test` 20/20
- [ ] Integration tests pass (n/a)
- [x] Manual testing done — `bucket + io_uring` read path verified correct for value sizes **4K–1M** (single-thread and concurrent); throughput as in the table above

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh` (clang-format 20.1.8 → "All files are properly formatted")
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable) — n/a (internal perf; no user-facing API change)
- [ ] I have added tests to prove my changes are effective — the io_uring read path is exercised via `storage_backend_bench --use_uring --verify`; the gtest suite covers the (unchanged) buffered path. Happy to add a `use_uring=true` unit case if preferred.
- [ ] For changes >500 LOC: I have filed an RFC issue — n/a (~50 LOC)

## AI Assistance Disclosure

- [x] AI tools were used — Claude Code assisted with the root-cause analysis, implementation, and benchmarking. All changes have been reviewed and understood by the submitter.

## Notes for reviewers

- Benchmarking through `storage_backend_bench` relies on the `--use_uring` flag added in the companion PR (`[[Store] Fix bucket+uring O_DIRECT corruption in storage_backend_bench #2787`); the code change here is independent.