### PR TITLE
[TENT] Expose Request.deadline_ns and policy_name to Python bindings

### DIFF
--- a/mooncake-transfer-engine/tent/src/python/pybind.cpp
+++ b/mooncake-transfer-engine/tent/src/python/pybind.cpp
@@ -18,6 +18,7 @@
 #include <cstdint>
 #include <exception>
 #include <memory>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <utility>

--- a/mooncake-transfer-engine/tent/src/python/pybind.cpp
+++ b/mooncake-transfer-engine/tent/src/python/pybind.cpp
@@ -321,7 +321,9 @@ PYBIND11_MODULE(tent, m) {
         .def(py::init([](Request::OpCode opcode, uint64_t source,
                          uint64_t target_id, uint64_t target_offset,
                          size_t length, int priority,
-                         TransportType transport_hint) {
+                         TransportType transport_hint,
+                         std::optional<std::string> policy_name,
+                         uint64_t deadline_ns) {
                  Request r;
                  r.opcode = opcode;
                  r.source = U64ToPtr(source);
@@ -330,12 +332,15 @@ PYBIND11_MODULE(tent, m) {
                  r.length = length;
                  r.priority = priority;
                  r.transport_hint = transport_hint;
+                 r.policy_name = std::move(policy_name);
+                 r.deadline_ns = deadline_ns;
                  return r;
              }),
              py::arg("opcode"), py::arg("source"), py::arg("target_id"),
              py::arg("target_offset"), py::arg("length"),
              py::arg("priority") = PRIO_HIGH,
-             py::arg("transport_hint") = TransportType::UNSPEC)
+             py::arg("transport_hint") = TransportType::UNSPEC,
+             py::arg("policy_name") = std::nullopt, py::arg("deadline_ns") = 0)
         .def_property(
             "opcode", [](const Request& r) { return r.opcode; },
             [](Request& r, Request::OpCode op) { r.opcode = op; })
@@ -346,7 +351,9 @@ PYBIND11_MODULE(tent, m) {
         .def_readwrite("target_offset", &Request::target_offset)
         .def_readwrite("length", &Request::length)
         .def_readwrite("priority", &Request::priority)
-        .def_readwrite("transport_hint", &Request::transport_hint);
+        .def_readwrite("transport_hint", &Request::transport_hint)
+        .def_readwrite("policy_name", &Request::policy_name)
+        .def_readwrite("deadline_ns", &Request::deadline_ns);
 
     py::class_<TransferStatus>(m, "TransferStatus")
         .def(py::init<>())


### PR DESCRIPTION
## Summary

- Expose the `deadline_ns` and `policy_name` fields (added in #2618 / #2640) to the Python `tent.Request` constructor and as read/write attributes.
- Both are opt-in with backward-compatible defaults (`deadline_ns=0`, `policy_name=None`), so existing callers are unaffected.

This lets upper-layer Python code (e.g. SGLang/vLLM KV connectors) set per-request deadline and traffic-class intent without dropping to C++.

## Changes

`pybind.cpp` (+10/−3):
1. Add `policy_name` (`std::optional<std::string>`) and `deadline_ns` (`uint64_t`) to the `Request.__init__` constructor with default values.
2. Expose both as `def_readwrite` properties.

## Test plan

- [x] In-tree compile (`cmake --build` target `tentpy`) — passes
- [x] Imported real `tent` module, verified `Request` accepts and round-trips `deadline_ns` / `policy_name` (12/12 assertions)
- [ ] CI (clang-format pre-checked locally with v20.1.8)

Relates to: #2519 (deadline-aware admission), #2568 (traffic-class hint API)