### PR TITLE
[EP] Make RoCE active-QP cap runtime-configurable via env

### DIFF
--- a/mooncake-ep/include/mooncake_ep_buffer.h
+++ b/mooncake-ep/include/mooncake_ep_buffer.h
@@ -89,6 +89,10 @@ struct MooncakeEpBuffer {
     bool ibgda_disabled_ = false;
 
     int USE_QP_COUNT = MAX_QP_COUNT;
+    // Cap on active RoCE QPs per peer: spreading small EP messages across too many
+    // QP/doorbell/progress streams hurts when GPUs share an HCA. Default 8;
+    // override at runtime with MOONCAKE_EP_ACTIVE_QPS_PER_RANK (>= per-rank QP count disables).
+    int active_qps_cap_ = 8;
 
     // Stream for communication
     at::cuda::CUDAStream comm_stream;

--- a/mooncake-ep/include/mooncake_ep_configs.cuh
+++ b/mooncake-ep/include/mooncake_ep_configs.cuh
@@ -3,9 +3,6 @@
 #define NUM_MAX_NVL_PEERS 8
 #define NUM_MAX_RDMA_PEERS 20
 #define MAX_QP_COUNT 256
-// Limit active RoCE QPs per peer to avoid spreading small EP messages across
-// too many QP/doorbell/progress streams when multiple GPUs share one HCA.
-constexpr int kEpActiveQpsPerRank = 8;
 #define NUM_MAX_FIFO_SLOTS 32768
 #define NUM_WORKSPACE_BYTES (32 * 1024 * 1024)
 #define NUM_MAX_LOCAL_EXPERTS 1024

--- a/mooncake-ep/src/mooncake_ep_buffer.cpp
+++ b/mooncake-ep/src/mooncake_ep_buffer.cpp
@@ -9,9 +9,9 @@ namespace mooncake {
 
 namespace {
 
-int active_qps_per_rank_for_ep(int qps_per_rank, bool is_roce) {
+int active_qps_per_rank_for_ep(int qps_per_rank, bool is_roce, int cap) {
     if (!is_roce) return qps_per_rank;
-    return std::min(qps_per_rank, kEpActiveQpsPerRank);
+    return std::min(qps_per_rank, cap);
 }
 
 }  // namespace
@@ -50,6 +50,23 @@ MooncakeEpBuffer::MooncakeEpBuffer(int rank, int num_ranks,
       num_ep_buffer_bytes(num_ep_buffer_bytes),
       comm_stream(at::cuda::getStreamFromPool(true)) {
     USE_QP_COUNT = MAX_QP_COUNT / num_ranks * num_ranks;
+
+    // Optional runtime override for the RoCE active-QP cap (default 8).
+    // Set MOONCAKE_EP_ACTIVE_QPS_PER_RANK to a value >= the per-rank QP count
+    // (e.g. 256) to effectively disable the cap.
+    if (const char* env = std::getenv("MOONCAKE_EP_ACTIVE_QPS_PER_RANK")) {
+        char* end = nullptr;
+        long v = std::strtol(env, &end, 10);
+        if (end != env && *end == '\0' && v > 0) {
+            active_qps_cap_ = static_cast<int>(v);
+        } else {
+            LOG(WARNING) << "[EP] ignoring invalid "
+                            "MOONCAKE_EP_ACTIVE_QPS_PER_RANK='"
+                         << env << "'";
+        }
+    }
+    LOG(INFO) << "[EP] RoCE active QPs/rank cap = " << active_qps_cap_;
+
     // Get ranks
     CUDA_CHECK(cudaGetDevice(&device_id));
     CUDA_CHECK(cudaDeviceGetAttribute(&clock_rate_khz, cudaDevAttrClockRate,
@@ -220,7 +237,8 @@ MooncakeEpBuffer::dispatch(const torch::Tensor& x,
     int32_t* nvlink_avail = p2p_transport_->availableTablePtr();
     void** ipc_ptrs = p2p_transport_->peerPtrsTablePtr();
     int active_qps_per_rank = active_qps_per_rank_for_ep(
-        USE_QP_COUNT / num_ranks, rdma_transport_ && rdma_transport_->isRoce());
+        USE_QP_COUNT / num_ranks, rdma_transport_ && rdma_transport_->isRoce(),
+        active_qps_cap_);
 
     auto mark_send_done = [=]() {
 #ifdef MOONCAKE_EP_SPLIT_SEND_RECV
@@ -380,7 +398,8 @@ MooncakeEpBuffer::combine(const torch::Tensor& x, const torch::Tensor& topk_idx,
     int32_t* nvlink_avail = p2p_transport_->availableTablePtr();
     void** ipc_ptrs = p2p_transport_->peerPtrsTablePtr();
     int active_qps_per_rank = active_qps_per_rank_for_ep(
-        USE_QP_COUNT / num_ranks, rdma_transport_ && rdma_transport_->isRoce());
+        USE_QP_COUNT / num_ranks, rdma_transport_ && rdma_transport_->isRoce(),
+        active_qps_cap_);
 
     auto mark_send_done = [=]() {
 #ifdef MOONCAKE_EP_SPLIT_SEND_RECV


### PR DESCRIPTION
Authored by: @KMSorSMS 

PR #2544 caps active RoCE QPs per peer at a compile-time kEpActiveQpsPerRank = 8, which is topology-dependent (tuned for 8 GPU / 4 HCA) yet hardcoded.

Since active_qps_per_rank is already plumbed to the kernels as a runtime argument, expose the cap via the MOONCAKE_EP_ACTIVE_QPS_PER_RANK env var (default 8, byte-identical behavior when unset). Setting it >= the per-rank QP count effectively disables the cap. Host-only change; kernels and API signatures untouched.

## Description



## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



**Test commands:**
```bash
# Example: bash scripts/run_ci_test.sh
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [ ] AI tools were used (specify below)