### PR TITLE
[CI] Migrate tone_tests to CUDA 13: pull cu130 wheel, adapt sglang/vllm paths, add NCCL env & offline model cache

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -37,7 +37,7 @@ jobs:
             if curl -L -fs -o artifact.json -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/${{ github.repository }}/actions/artifacts?per_page=100; then
               artifact_id=""
               if jq empty artifact.json >/dev/null 2>&1; then
-                artifact_id=$(jq -r ".artifacts[] | select(.name | contains(\"py312\") ) | select(.name | contains(\"mooncake\") ) | select(.name | contains(\"cu130\") | not) | select(.workflow_run.head_sha == \"$SHA\" ) | .id" artifact.json | head -n 1)
+                artifact_id=$(jq -r ".artifacts[] | select(.name | contains(\"py312\") ) | select(.name | contains(\"mooncake\") ) | select(.name | contains(\"cu130\") ) | select(.workflow_run.head_sha == \"$SHA\" ) | .id" artifact.json | head -n 1)
               else
                 echo "Failed to download artifact list. Retrying..."
               fi

--- a/scripts/tone_tests/scripts/common.sh
+++ b/scripts/tone_tests/scripts/common.sh
@@ -231,7 +231,7 @@ get_whl(){
 
     echo "get whl file from github action"
     rm -f "$whls_path/mooncake.zip"
-    rm -f "$whls_path/*.whl"
+    rm -f "$whls_path"/*.whl
 
     local max_retries=5
     local base_delay=5 # seconds

--- a/scripts/tone_tests/scripts/common.sh
+++ b/scripts/tone_tests/scripts/common.sh
@@ -401,6 +401,57 @@ cleanup_test_env() {
     echo "Cleanup completed"
 }
 
+# Wait until GPU memory on the local host drains below a threshold.
+# Used between test cases in run-all so a previous test's leftover GPU
+# memory does not cause the next test's server to OOM / get SIGKILLed.
+wait_gpu_idle() {
+    local max_seconds=${1:-120}
+    local threshold_mb=${2:-1024}
+
+    if ! command -v nvidia-smi >/dev/null 2>&1; then
+        echo "nvidia-smi not available, skipping GPU drain wait"
+        return 0
+    fi
+
+    echo "Waiting for GPU memory to drain (threshold ${threshold_mb}MB, timeout ${max_seconds}s)..."
+    local elapsed=0
+    local max_used=0
+    while [ $elapsed -lt $max_seconds ]; do
+        max_used=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits 2>/dev/null | sort -n | tail -n 1)
+        [ -z "$max_used" ] && { echo "nvidia-smi query failed, skipping GPU drain wait"; return 0; }
+        if [ "$max_used" -le "$threshold_mb" ]; then
+            echo "GPU memory drained (max used ${max_used}MB)"
+            return 0
+        fi
+        sleep 3
+        elapsed=$((elapsed + 3))
+    done
+    echo "WARNING: GPU memory did not fully drain within ${max_seconds}s (max used ${max_used}MB)"
+    return 0
+}
+
+# Between test cases in run-all the container is reused; kill any leftover
+# inference processes and wait for GPU memory to be released, on both the
+# local and (for double-machine runs) remote nodes. No container restart,
+# so wheel / ERDMA drivers are not reinstalled.
+drain_gpu_between_tests() {
+    local max_seconds=${1:-120}
+    echo "===== Draining GPU between test cases ====="
+
+    ${docker_exec} "pkill -9 -f 'sglang|vllm' 2>/dev/null; true" >/dev/null 2>&1 || true
+    wait_gpu_idle "$max_seconds"
+
+    if [ -n "$REMOTE_IP" ]; then
+        echo "Draining GPU on remote node $REMOTE_IP..."
+        ${SSH_CMD} "$REMOTE_IP" "
+            source ${REMOTE_TEST_DIR}/run/.shrc && \
+            source ${REMOTE_TEST_DIR}/scripts/common.sh && \
+            ${docker_exec} \"pkill -9 -f 'sglang|vllm' 2>/dev/null; true\" >/dev/null 2>&1; \
+            wait_gpu_idle $max_seconds
+        " 2>/dev/null || true
+    fi
+}
+
 setup_node_env() {
     local registry_addr=$1
     echo "===== Setting up docker environment ====="

--- a/scripts/tone_tests/scripts/common.sh
+++ b/scripts/tone_tests/scripts/common.sh
@@ -892,6 +892,19 @@ collect_and_validate_model_results() {
     fi
 }
 
+# Echo an offline env prefix when the given model already exists in the
+# container's HuggingFace cache, so servers use the local snapshot instead of
+# querying the hub (skips downloads and avoids hf-mirror 429 rate limiting).
+# Models are pre-cached under MODEL_CACHE (mounted at /root/.cache) on both nodes.
+hf_offline_prefix() {
+    local model_name=$1
+    [ -z "$model_name" ] && return 0
+    local cache_dir="models--$(echo "$model_name" | sed 's#/#--#g')"
+    if ${docker_exec} "ls /root/.cache/huggingface/hub/${cache_dir}/snapshots/*/config.json >/dev/null 2>&1"; then
+        echo "HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 "
+    fi
+}
+
 launch_sglang_server() {
     local model_path=$1
     local host=$2
@@ -907,7 +920,8 @@ launch_sglang_server() {
         return 1
     fi
     
-    local sglang_cmd="${docker_exec} \"python -m sglang.launch_server --model-path ${model_path} --host ${host} --port ${port}"
+    local offline_prefix=$(hf_offline_prefix "$model_path")
+    local sglang_cmd="${docker_exec} \"${offline_prefix}python -m sglang.launch_server --model-path ${model_path} --host ${host} --port ${port}"
     if [ -n "$extra_args" ]; then
         sglang_cmd="${sglang_cmd} ${extra_args}"
     fi
@@ -957,6 +971,7 @@ launch_vllm_server() {
     if [ -n "$env_vars" ]; then
         env_prefix="${env_vars} "
     fi
+    env_prefix="${env_prefix}$(hf_offline_prefix "$model_path")"
     
     local vllm_cmd="${docker_exec} \"${env_prefix}python3 -m vllm.entrypoints.openai.api_server --model '${model_path}' --host '${host}' --port ${port}"
     

--- a/scripts/tone_tests/scripts/common.sh
+++ b/scripts/tone_tests/scripts/common.sh
@@ -416,6 +416,7 @@ setup_node_env() {
     fi
 
     local extra_args=""
+    extra_args="$extra_args -e NCCL_GIN_TYPE=0 "
     extra_args="$extra_args --device=/dev/infiniband/uverbs0 --device=/dev/infiniband/uverbs1 --device=/dev/infiniband/rdma_cm "
     if [ "${USE_HUGGINGFACE_MIRROR}" = "true" ]; then
         extra_args="$extra_args -e HF_ENDPOINT=${HUGGINGFACE_MIRROR} -e HF_HUB_ENABLE_HF_TRANSFER=1"

--- a/scripts/tone_tests/scripts/common.sh
+++ b/scripts/tone_tests/scripts/common.sh
@@ -402,10 +402,9 @@ cleanup_test_env() {
 }
 
 # Wait until GPU memory on the local host drains below a threshold.
-# Used between test cases in run-all so a previous test's leftover GPU
-# memory does not cause the next test's server to OOM / get SIGKILLed.
+# Returns 0 once drained, 1 if it times out.
 wait_gpu_idle() {
-    local max_seconds=${1:-120}
+    local max_seconds=${1:-90}
     local threshold_mb=${2:-1024}
 
     if ! command -v nvidia-smi >/dev/null 2>&1; then
@@ -426,28 +425,48 @@ wait_gpu_idle() {
         sleep 3
         elapsed=$((elapsed + 3))
     done
-    echo "WARNING: GPU memory did not fully drain within ${max_seconds}s (max used ${max_used}MB)"
-    return 0
+    echo "GPU memory not drained within ${max_seconds}s (max used ${max_used}MB)"
+    return 1
 }
 
-# Between test cases in run-all the container is reused; kill any leftover
-# inference processes and wait for GPU memory to be released, on both the
-# local and (for double-machine runs) remote nodes. No container restart,
-# so wheel / ERDMA drivers are not reinstalled.
-drain_gpu_between_tests() {
-    local max_seconds=${1:-120}
-    echo "===== Draining GPU between test cases ====="
+# Force-kill every host process still holding GPU memory. This catches leftovers
+# that an in-container pkill cannot reach: processes reparented to the host
+# (orphans) or in a different PID namespace. Only GPU-holding PIDs are targeted.
+force_kill_gpu_procs() {
+    command -v nvidia-smi >/dev/null 2>&1 || return 0
+    local pids
+    pids=$(nvidia-smi --query-compute-apps=pid --format=csv,noheader 2>/dev/null | tr -cd '0-9\n' | grep -E '^[0-9]+$' | sort -u)
+    [ -z "$pids" ] && return 0
+    echo "Force-killing GPU-holding PIDs: $(echo $pids | tr '\n' ' ')"
+    for pid in $pids; do
+        kill -9 "$pid" 2>/dev/null || true
+    done
+    sleep 3
+}
 
+# Fully clear GPU memory on the current node: graceful in-container kill first,
+# then host-level force-kill of any process still holding GPU memory.
+drain_gpu_local() {
     ${docker_exec} "pkill -9 -f 'sglang|vllm' 2>/dev/null; true" >/dev/null 2>&1 || true
-    wait_gpu_idle "$max_seconds"
+    if ! wait_gpu_idle 60; then
+        force_kill_gpu_procs
+        wait_gpu_idle 45 || echo "WARNING: GPU still occupied after force-kill (possible stuck/zombie process or GPU fault)"
+    fi
+}
+
+# Between test cases in run-all the container is reused; fully clear GPU memory
+# on both the local and (for double-machine runs) remote nodes. No container
+# restart, so wheel / ERDMA drivers are not reinstalled.
+drain_gpu_between_tests() {
+    echo "===== Draining GPU between test cases ====="
+    drain_gpu_local
 
     if [ -n "$REMOTE_IP" ]; then
         echo "Draining GPU on remote node $REMOTE_IP..."
         ${SSH_CMD} "$REMOTE_IP" "
             source ${REMOTE_TEST_DIR}/run/.shrc && \
             source ${REMOTE_TEST_DIR}/scripts/common.sh && \
-            ${docker_exec} \"pkill -9 -f 'sglang|vllm' 2>/dev/null; true\" >/dev/null 2>&1; \
-            wait_gpu_idle $max_seconds
+            drain_gpu_local
         " 2>/dev/null || true
     fi
 }

--- a/scripts/tone_tests/scripts/common.sh
+++ b/scripts/tone_tests/scripts/common.sh
@@ -446,23 +446,28 @@ force_kill_gpu_procs() {
 
 # Fully clear GPU memory on the current node: graceful in-container kill first,
 # then host-level force-kill of any process still holding GPU memory.
+# Restart the reused container to reset all in-container state (processes, GPU
+# memory, ERDMA queue-pairs / RDMA contexts). 'docker restart' keeps the
+# writable layer, so the mooncake wheel and ERDMA drivers are NOT reinstalled.
+# force_kill_gpu_procs stays as a fallback for leftovers restart cannot reclaim.
 drain_gpu_local() {
-    ${docker_exec} "pkill -9 -f 'sglang|vllm' 2>/dev/null; true" >/dev/null 2>&1 || true
+    echo "Restarting container ${CONTAINER_NAME} to reset GPU/ERDMA state..."
+    docker restart ${CONTAINER_NAME} >/dev/null 2>&1 || true
     if ! wait_gpu_idle 60; then
         force_kill_gpu_procs
-        wait_gpu_idle 45 || echo "WARNING: GPU still occupied after force-kill (possible stuck/zombie process or GPU fault)"
+        wait_gpu_idle 45 || echo "WARNING: GPU still occupied after restart+force-kill (possible stuck/zombie process or GPU fault)"
     fi
 }
 
-# Between test cases in run-all the container is reused; fully clear GPU memory
-# on both the local and (for double-machine runs) remote nodes. No container
-# restart, so wheel / ERDMA drivers are not reinstalled.
+# Between test cases in run-all the container is reused; reset in-container
+# state on both the local and (for double-machine runs) remote nodes via a
+# lightweight container restart (no wheel / ERDMA driver reinstall).
 drain_gpu_between_tests() {
-    echo "===== Draining GPU between test cases ====="
+    echo "===== Resetting environment between test cases ====="
     drain_gpu_local
 
     if [ -n "$REMOTE_IP" ]; then
-        echo "Draining GPU on remote node $REMOTE_IP..."
+        echo "Resetting environment on remote node $REMOTE_IP..."
         ${SSH_CMD} "$REMOTE_IP" "
             source ${REMOTE_TEST_DIR}/run/.shrc && \
             source ${REMOTE_TEST_DIR}/scripts/common.sh && \

--- a/scripts/tone_tests/scripts/run_test.sh
+++ b/scripts/tone_tests/scripts/run_test.sh
@@ -232,7 +232,10 @@ run_single_test(){
     source "$RUN_DIR/.shrc"
     cd "$TONE_TESTS_DIR/scripts"
     source "./$test_name"
-    
+
+    local log_dir="${BASE_DIR}/run/logs/$(basename "$test_name" .sh)"
+    setup_log_directory "$log_dir"
+
     local exit_code=0
     run_test "$@" || exit_code=1
     

--- a/scripts/tone_tests/scripts/run_test.sh
+++ b/scripts/tone_tests/scripts/run_test.sh
@@ -285,6 +285,10 @@ run_all_tests(){
         fi
         
         [ $exit_code -ne 0 ] && all_passed=false
+
+        # Container is shared across cases in run-all; drain leftover GPU
+        # memory before the next case so it does not OOM / get SIGKILLed.
+        drain_gpu_between_tests
     done
     
     cleanup_test_env "double"

--- a/scripts/tone_tests/scripts/test_disaggregation_different_tp.sh
+++ b/scripts/tone_tests/scripts/test_disaggregation_different_tp.sh
@@ -16,11 +16,20 @@ run_test()
     local log_file="${BASE_DIR}/${TEST_CASE_RESULT_PATH}/${test_case_name}.log"
 
     echo "Running tests in container and saving output to: $log_file"
+
+    # Use local HF cache (offline) only when both models are already downloaded.
+    local off_mla=$(hf_offline_prefix "deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct")
+    local off_llama=$(hf_offline_prefix "meta-llama/Llama-3.2-3B-Instruct")
+    local offline_prefix=""
+    if [ -n "$off_mla" ] && [ -n "$off_llama" ]; then
+        offline_prefix="$off_mla"
+    fi
+
     ${docker_exec} "\
         cd /sgl-workspace/sglang/test/registered/disaggregation && \
         sed -i '0,/^class /s|^class |DEFAULT_MODEL_NAME_FOR_TEST_MLA = \"deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct\"\nDEFAULT_MODEL_NAME_FOR_TEST = \"meta-llama/Llama-3.2-3B-Instruct\"\n&|' test_disaggregation_different_tp.py && \
         echo 'Model override applied successfully' && \
-        python3 -m pytest test_disaggregation_different_tp.py -v -s --tb=long" | tee "$log_file"
+        ${offline_prefix}python3 -m pytest test_disaggregation_different_tp.py -v -s --tb=long" | tee "$log_file"
     
     return ${PIPESTATUS[0]}
 }

--- a/scripts/tone_tests/scripts/test_disaggregation_different_tp.sh
+++ b/scripts/tone_tests/scripts/test_disaggregation_different_tp.sh
@@ -17,7 +17,7 @@ run_test()
 
     echo "Running tests in container and saving output to: $log_file"
     ${docker_exec} "\
-        cd /sgl-workspace/sglang/test/registered/distributed && \
+        cd /sgl-workspace/sglang/test/registered/disaggregation && \
         sed -i '0,/^class /s|^class |DEFAULT_MODEL_NAME_FOR_TEST_MLA = \"deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct\"\nDEFAULT_MODEL_NAME_FOR_TEST = \"meta-llama/Llama-3.2-3B-Instruct\"\n&|' test_disaggregation_different_tp.py && \
         echo 'Model override applied successfully' && \
         python3 -m pytest test_disaggregation_different_tp.py -v -s --tb=long" | tee "$log_file"

--- a/scripts/tone_tests/scripts/test_moe_mooncake.sh
+++ b/scripts/tone_tests/scripts/test_moe_mooncake.sh
@@ -13,11 +13,14 @@ run_test()
     local log_file="${BASE_DIR}/${TEST_CASE_RESULT_PATH}/${test_case_name}.log"
 
     echo "Running tests in container and saving output to: $log_file"
-    
+
+    # Use local HF cache (offline) when the model is already downloaded.
+    local offline_prefix=$(hf_offline_prefix "deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct")
+
     ${docker_exec} "\
         export PYTHONPATH=/sgl-workspace/sglang:\$PYTHONPATH && \
         cd /test_run/python && \
-        python3 -m pytest test_moe_mooncake.py -v -s --tb=long" | tee "$log_file"
+        ${offline_prefix}python3 -m pytest test_moe_mooncake.py -v -s --tb=long" | tee "$log_file"
 
     return ${PIPESTATUS[0]}
 }

--- a/scripts/tone_tests/scripts/test_vllm_1p1d_erdma.sh
+++ b/scripts/tone_tests/scripts/test_vllm_1p1d_erdma.sh
@@ -34,7 +34,7 @@ start_server()
 
     local kv_config_json="{\\\"kv_connector\\\":\\\"MooncakeConnector\\\",\\\"kv_role\\\":\\\"$kv_role\\\"}"
 
-    local extra_args="--tensor-parallel-size 2 --max-model-len 32768 --no-enable-prefix-caching --kv-transfer-config '$kv_config_json'"
+    local extra_args="--tensor-parallel-size 2 --max-model-len 32768 --gpu-memory-utilization 0.85 --no-enable-prefix-caching --kv-transfer-config '$kv_config_json'"
     
     local env_vars="CUDA_VISIBLE_DEVICES=0,1"
     
@@ -62,7 +62,7 @@ run_proxy()
     local use_health_check=0
     if python3 -c "from packaging import version; import sys; sys.exit(0 if version.parse('$vllm_version') >= version.parse('0.16.0') else 1)" 2>/dev/null; then
         echo "Using Mooncake Connector Proxy (vLLM >= 0.16.0)"
-        proxy_script="python3 -u /vllm-workspace/examples/online_serving/disaggregated_serving/mooncake_connector/mooncake_connector_proxy.py --prefill http://$REMOTE_IP:8010 --decode http://$LOCAL_IP:8020 --host 0.0.0.0 --port 8000"
+        proxy_script="python3 -u /vllm-workspace/examples/disaggregated/mooncake_connector/mooncake_connector_proxy.py --prefill http://$REMOTE_IP:8010 --decode http://$LOCAL_IP:8020 --host 0.0.0.0 --port 8000"
         ready_pattern="All prefiller instances are ready."
     else
         echo "Using NIXL Proxy (vLLM < 0.16.0)"

--- a/scripts/tone_tests/scripts/test_vllm_1p1d_erdma.sh
+++ b/scripts/tone_tests/scripts/test_vllm_1p1d_erdma.sh
@@ -36,7 +36,7 @@ start_server()
 
     local extra_args="--tensor-parallel-size 2 --max-model-len 32768 --gpu-memory-utilization 0.85 --no-enable-prefix-caching --kv-transfer-config '$kv_config_json'"
     
-    local env_vars="CUDA_VISIBLE_DEVICES=0,1"
+    local env_vars="CUDA_VISIBLE_DEVICES=6,7"
     
     if ! launch_vllm_server "$model_name" "$host" "$port" "$vllm_server_log_path" "$kv_role" "$extra_args" "$env_vars"; then
         return 1


### PR DESCRIPTION
## Description


### Summary
Migrate the scripts/tone_tests integration test suite to the CUDA 13 runtime and fix a series of issues surfaced by the sglang/vllm image upgrade, so run-all runs reliably on CUDA 13. All changes are confined to scripts/tone_tests/ and .github/workflows/integration-test.yml.

### What & Why
**1. Inject NCCL_GIN_TYPE=0 into the test container**
The test container requires NCCL_GIN_TYPE=0. Injected it via -e NCCL_GIN_TYPE=0 in setup_node_env when assembling the container run args (applies to both local and remote nodes).

**2. CI must pull the CUDA 13 (cu130) wheel after the sglang/vllm upgrade**
The runtime image was upgraded to CUDA 13, but the integration test picked the CUDA 12 wheel, causing ImportError: libcudart.so.12 at runtime.
integration-test.yml: changed the artifact filter from contains("cu130") | not to contains("cu130") so it selects the CUDA 13 build.
common.sh (get_whl): fixed a quoted-glob bug (rm -f "$whls_path/*.whl" → rm -f "$whls_path"/*.whl) that left stale wheels behind. With both cu12 and cu13 wheels present, the head -n 1 selection alphabetically picked the wrong (cu12) wheel; proper cleanup ensures only the intended wheel is installed.

**3. Adapt to path changes introduced by the sglang/vllm upgrade**
sglang test path: .../test/registered/distributed was renamed to .../test/registered/disaggregation in the new image — updated test_disaggregation_different_tp.sh.
vLLM proxy path: in vLLM 0.24.0 the mooncake proxy moved from examples/online_serving/disaggregated_serving/mooncake_connector/... to examples/disaggregated/mooncake_connector/mooncake_connector_proxy.py — updated test_vllm_1p1d_erdma.sh.
Also fixed run_single_test to create the log directory (previously only run_all_tests did), avoiding tee: No such file or directory.

**4. Model cache offline detection (avoid hf-mirror.com 429 startup failures)**
Models are already cached on both nodes, but vllm/sglang still queried the hub at startup and got throttled by hf-mirror.com (HTTP 429), causing server launch failures. Added a hf_offline_prefix helper in common.sh that detects whether a model already exists in the local HF cache (/root/.cache/huggingface/hub/models--*/snapshots/*/config.json) and, if so, injects HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1. Wired into launch_sglang_server, launch_vllm_server, and the moe / disaggregation pytest commands.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



https://tone.openanolis.cn/ws/gclfnh19/test_result/229741

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [x] AI tools were used (specify below)