### PR TITLE
[Store] Cover Redis HA failover paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,12 +121,20 @@ jobs:
         python ./bootstrap_server.py &
       shell: bash
 
+    - name: Test Redis HA failover
+      run: |
+        cd build
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+        redis-cli ping
+        ctest -R '^redis_chaos_test$' --output-on-failure
+      shell: bash
+
     - name: Test (in build env) with coverage
       run: |
         cd build
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
         ldconfig -v || echo "always continue"
-        MC_METADATA_SERVER=http://127.0.0.1:8080/metadata DEFAULT_KV_LEASE_TTL=500 ctest -j --output-on-failure
+        MC_METADATA_SERVER=http://127.0.0.1:8080/metadata DEFAULT_KV_LEASE_TTL=500 ctest -j -LE redis_ha --output-on-failure
       shell: bash
 
     - name: Generate coverage report

--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -28,10 +28,16 @@ This page summarizes useful flags, environment variables, and HTTP endpoints to 
   - `--eviction_high_watermark_ratio` (double, default `0.95`): Usage ratio to trigger eviction.
 
 - High Availability (optional)
-  - `--enable_ha` (bool, default `false`): Enable HA (requires etcd).
+  - `--enable_ha` (bool, default `false`): Enable HA.
+  - `--election_backend` (str, default `etcd`): Election backend, either `etcd` or `redis`.
   - `--etcd_endpoints` (str, default empty unless HA config): etcd endpoints, semicolon separated.
+  - `--redis_endpoint` (str, default empty): Redis endpoint for Redis-based HA, such as `10.0.0.10:6379`.
+  - `--redis_password` (str, default empty): Redis AUTH password for Redis-based HA.
+  - `--redis_db_index` (int, default `0`): Redis DB index for Redis-based HA.
+  - `--redis_master_view_ttl_sec` (int, default `5`): TTL for the Redis master view key.
+  - `--redis_heartbeat_interval_sec` (int, default `2`): Redis leader renewal interval. It must be smaller than `--redis_master_view_ttl_sec`.
   - `--client_ttl` (int64, default `10` s): Client alive TTL after last ping (HA mode).
-  - `--cluster_id` (str, default `mooncake_cluster`): Cluster ID for persistence in HA mode.
+  - `--cluster_id` (str, default `mooncake_cluster`): Cluster ID for persistence and HA metadata isolation.
 
 - DFS Storage (optional)
   - `--root_fs_dir` (str, default empty): DFS mount directory for storage backend, used in Multi-layer Storage Support.
@@ -48,6 +54,46 @@ mooncake_master \
   --metrics_port=9003 \
   --enable_metric_reporting=true
 ```
+
+## Redis-based Master HA
+
+Redis-based HA uses Redis as the coordination backend for master election. It is independent from the Transfer Engine metadata backend: the Store master election backend can use Redis even if the Transfer Engine metadata service uses etcd, Redis, or HTTP.
+
+Build with Redis HA support before deployment:
+
+```bash
+cmake -S . -B build -DSTORE_USE_REDIS=ON
+cmake --build build --target mooncake_master
+```
+
+Start multiple master processes with the same Redis endpoint and cluster ID. Each master must advertise an RPC address that clients can reach; do not use `0.0.0.0` as the advertised address in a multi-node deployment.
+
+```bash
+mooncake_master \
+  --enable_ha=true \
+  --election_backend=redis \
+  --redis_endpoint=10.0.0.10:6379 \
+  --cluster_id=mooncake_cluster \
+  --rpc_address=10.0.0.1
+```
+
+Repeat the command on the other master nodes with their own reachable `--rpc_address` values, for example `10.0.0.2` and `10.0.0.3`, while keeping `--redis_endpoint` and `--cluster_id` identical.
+
+Clients should use the matching Redis endpoint for HA master discovery:
+
+```text
+master_server_entry = "redis://10.0.0.10:6379"
+```
+
+The client Redis cluster ID must match the masters' `--cluster_id`. If the client does not set a cluster ID explicitly, it uses the default `mooncake_cluster`.
+
+Operational notes:
+
+- Keep `--redis_heartbeat_interval_sec` smaller than `--redis_master_view_ttl_sec`. The default pair is `2` seconds and `5` seconds.
+- A smaller TTL reduces failover latency but is more sensitive to transient Redis or scheduling delays. Increase the TTL if CI or production logs show unexpected leader churn.
+- The active leader renews the Redis master view key periodically. If the leader process exits or loses renewal, the key expires and another master can be elected.
+- Clients using `redis://` resolve the current leader from Redis and reconnect after heartbeat failures. Existing requests may fail during the failover window and should be retried by the caller.
+- Redis HA metadata is isolated by `--cluster_id`, so different Mooncake Store clusters can share one Redis instance when they use different cluster IDs.
 
 **Tips:**
 

--- a/docs/source/design/mooncake-store.md
+++ b/docs/source/design/mooncake-store.md
@@ -673,7 +673,7 @@ make
 sudo make install # Install Python interface support package
 ```
 
-**Note:** To use high availability mode, only `-DSTORE_USE_ETCD` is required. `-DUSE_ETCD` is a compilation option for the **Transfer Engine** and is **not related** to the high availability mode.
+**Note:** To use etcd-based high availability mode, only `-DSTORE_USE_ETCD` is required. `-DUSE_ETCD` is a compilation option for the **Transfer Engine** and is **not related** to the high availability mode. To use Redis-based master election, build with `-DSTORE_USE_REDIS=ON` and install `hiredis`.
 
 ### Starting the Transfer Engine's Metadata Service
 Mooncake Store uses the Transfer Engine as its core transfer engine, so it is necessary to start the metadata service (etcd/redis/http). The startup and configuration of the `metadata` service can be referred to in the relevant sections of [Transfer Engine](./transfer-engine/index.md). **Special Note**: For the etcd service, by default, it only provides services for local processes. You need to modify the listening options (IP to 0.0.0.0 instead of the default 127.0.0.1). You can use commands like curl to verify correctness.
@@ -689,20 +689,34 @@ Master service listening on 0.0.0.0:50051
 
 **High availability mode**:
 
-HA mode relies on an etcd service for coordination. If Transfer Engine also uses etcd as its metadata service, the etcd cluster used by Mooncake Store can either be shared with or separate from the one used by Transfer Engine.
+HA mode relies on an external coordination backend for master election. Mooncake Store supports etcd and Redis election backends. If Transfer Engine also uses etcd or Redis as its metadata service, the backend used by Mooncake Store can either be shared with or separate from the one used by Transfer Engine.
 
 HA mode allows deployment of multiple master instances to eliminate the single point of failure. Each master instance must be started with the following parameters:
 ```
 --enable-ha: enables high availability mode
+--election-backend: election backend, "etcd" by default or "redis"
 --etcd-endpoints: specifies endpoints for etcd service, separated by ';'
+--redis-endpoint: specifies the Redis endpoint when election_backend is redis
+--cluster-id: cluster ID used to isolate HA metadata in the election backend
 --rpc-address: the RPC address of this instance. Note that the address specified here should be accessible to the client.
 ```
 
-For example:
+For etcd-based HA:
 ```
 ./build/mooncake-store/src/mooncake_master \
     --enable-ha=true \
+    --election-backend=etcd \
     --etcd-endpoints="0.0.0.0:2379;0.0.0.0:2479;0.0.0.0:2579" \
+    --rpc-address=10.0.0.1
+```
+
+For Redis-based HA:
+```
+./build/mooncake-store/src/mooncake_master \
+    --enable-ha=true \
+    --election-backend=redis \
+    --redis-endpoint="10.0.0.10:6379" \
+    --cluster-id=mooncake_cluster \
     --rpc-address=10.0.0.1
 ```
 
@@ -713,7 +727,7 @@ Mooncake Store provides various sample programs, including interface forms based
 `local_hostname`: the IP address of the local machine
 `metadata_server`: the address of the Transfer Engine metadata service
 `master_server_address`: the address of the Master Service
-**Note**: The format of `master_server_address` depends on the deployment mode. In default mode, use the format `IP:Port`, specifying the address of a single master node. In HA mode, use the format `etcd://IP:Port;IP:Port;...;IP:Port`, specifying the addresses of the etcd cluster endpoints.
+**Note**: The format of `master_server_address` depends on the deployment mode. In default mode, use the format `IP:Port`, specifying the address of a single master node. In etcd-based HA mode, use the format `etcd://IP:Port;IP:Port;...;IP:Port`, specifying the addresses of the etcd cluster endpoints. In Redis-based HA mode, use the format `redis://IP:Port`, specifying the Redis endpoint. The client's Redis cluster ID must match the masters' `--cluster-id`.
 For example: 
 ```python
 import os

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -687,7 +687,8 @@ tl::expected<void, ErrorCode> ClientService::unregisterLocalMemory(
 void ClientService::HeartbeatThreadMain(
     bool is_ha_mode, std::string current_master_address,
     const std::string& master_server_entry) {
-    // How many failed heartbeats before getting latest master view from etcd
+    // How many failed heartbeats before getting latest master view from HA
+    // backend
     const int max_heartbeat_fail_count = 10;
     // How long to wait for next heartbeat after success
     const int success_heartbeat_interval_ms = 1000;

--- a/mooncake-store/src/ha_helper.cpp
+++ b/mooncake-store/src/ha_helper.cpp
@@ -178,15 +178,19 @@ int MasterServiceSupervisor::Start() {
             std::chrono::seconds(mv_helper->GetLeaderLeaseTTLSeconds()));
 
         LOG(INFO) << "Starting master service...";
+        std::unique_ptr<WrappedMasterService> wrapped_master_service;
         if (config_.deployment_mode == DeploymentMode::CENTRALIZATION) {
-            WrappedCentralizedMasterService wrapped_master_service(
-                WrappedMasterServiceConfig(config_, view_version));
-            RegisterCentralizedRpcService(server, wrapped_master_service);
+            wrapped_master_service =
+                std::make_unique<WrappedCentralizedMasterService>(
+                    WrappedMasterServiceConfig(config_, view_version));
+            RegisterCentralizedRpcService(
+                server, static_cast<WrappedCentralizedMasterService&>(
+                            *wrapped_master_service));
         } else {
-            WrappedP2PMasterService wrapped_master_service(
+            wrapped_master_service = std::make_unique<WrappedP2PMasterService>(
                 WrappedMasterServiceConfig(config_, view_version));
-
-            RegisterP2PRpcService(server, wrapped_master_service);
+            RegisterP2PRpcService(server, static_cast<WrappedP2PMasterService&>(
+                                              *wrapped_master_service));
         }
         // Metric reporting is now handled by WrappedMasterService.
 

--- a/mooncake-store/tests/e2e/CMakeLists.txt
+++ b/mooncake-store/tests/e2e/CMakeLists.txt
@@ -83,4 +83,9 @@ if(STORE_USE_REDIS)
             --master_path=${CMAKE_BINARY_DIR}/mooncake-store/src/mooncake_master
             --out_dir=${CMAKE_BINARY_DIR}/redis_chaos_output
     )
+    set_tests_properties(redis_chaos_test PROPERTIES
+        LABELS "redis_ha"
+        RUN_SERIAL TRUE
+        TIMEOUT 180
+    )
 endif()

--- a/mooncake-store/tests/e2e/client_wrapper.cpp
+++ b/mooncake-store/tests/e2e/client_wrapper.cpp
@@ -19,15 +19,18 @@ ClientTestWrapper::~ClientTestWrapper() {
 }
 
 std::optional<std::shared_ptr<ClientTestWrapper>>
-ClientTestWrapper::CreateClientWrapper(const std::string& hostname,
-                                       const std::string& metadata_connstring,
-                                       const std::string& protocol,
-                                       const std::string& device_name,
-                                       const std::string& master_server_entry,
-                                       size_t local_buffer_size) {
+ClientTestWrapper::CreateClientWrapper(
+    const std::string& hostname, const std::string& metadata_connstring,
+    const std::string& protocol, const std::string& device_name,
+    const std::string& master_server_entry, size_t local_buffer_size,
+    const std::string& redis_cluster_id, bool enable_http_server) {
     auto config = ClientConfigBuilder::build_centralized_real_client(
         hostname, metadata_connstring, protocol, device_name,
-        master_server_entry, 0, local_buffer_size);
+        master_server_entry, 0, local_buffer_size, nullptr, "", false, 9003,
+        enable_http_server);
+    if (!redis_cluster_id.empty()) {
+        config.redis_cluster_id = redis_cluster_id;
+    }
     auto client_opt = ClientService::Create(config);
 
     if (!client_opt.has_value()) {

--- a/mooncake-store/tests/e2e/client_wrapper.h
+++ b/mooncake-store/tests/e2e/client_wrapper.h
@@ -50,6 +50,10 @@ class ClientTestWrapper {
      * @param master_server_entry The master server entry.
      * @param local_buffer_size The local buffer size that will be used for get
      * and put operations.
+     * @param redis_cluster_id Optional Redis HA cluster ID for tests using
+     * redis:// master discovery.
+     * @param enable_http_server Whether to start the client's HTTP metrics
+     * server.
      * @return The client wrapper.
      */
     static std::optional<std::shared_ptr<ClientTestWrapper>>
@@ -58,7 +62,9 @@ class ClientTestWrapper {
                         const std::string& protocol,
                         const std::string& device_name,
                         const std::string& master_server_entry,
-                        size_t local_buffer_size = 1024 * 1024 * 128);
+                        size_t local_buffer_size = 1024 * 1024 * 128,
+                        const std::string& redis_cluster_id = "",
+                        bool enable_http_server = true);
 
     // Mount a segment. The buffer will be used to unmount the segment.
     ErrorCode Mount(const size_t size, void*& buffer);

--- a/mooncake-store/tests/e2e/process_handler.cpp
+++ b/mooncake-store/tests/e2e/process_handler.cpp
@@ -120,7 +120,7 @@ bool MasterProcessHandler::start() {
         close(stderr_fd);
 
         // Execute the master
-        std::string rpc_address_arg = "--rpc-address=0.0.0.0";
+        std::string rpc_address_arg = "--rpc-address=" + config_.rpc_address;
         std::string rpc_port_arg = "--rpc-port=" + std::to_string(port_);
         std::vector<std::string> args = {master_path_, "--enable-ha=true",
                                          rpc_address_arg, rpc_port_arg};

--- a/mooncake-store/tests/e2e/process_handler.h
+++ b/mooncake-store/tests/e2e/process_handler.h
@@ -35,6 +35,7 @@ struct MasterRunnerConfig {
     int redis_master_view_ttl_sec = 5;
     int redis_heartbeat_interval_sec = 2;
     std::string cluster_id;
+    std::string rpc_address = "0.0.0.0";
 };
 
 class MasterProcessHandler {

--- a/mooncake-store/tests/e2e/redis_chaos_test.cpp
+++ b/mooncake-store/tests/e2e/redis_chaos_test.cpp
@@ -9,6 +9,7 @@
 #include <thread>
 #include <vector>
 
+#include "client_wrapper.h"
 #include "e2e_utils.h"
 #include "process_handler.h"
 #include "redis_master_view_helper.h"
@@ -22,20 +23,21 @@ DEFINE_string(redis_endpoint, "127.0.0.1:6379",
               "Redis endpoint for Redis master failover test");
 DEFINE_string(redis_cluster_id, "redis_chaos_test",
               "Redis cluster ID for Redis master failover test");
-DEFINE_int32(redis_master_view_ttl_sec, 2,
+DEFINE_int32(redis_master_view_ttl_sec, 5,
              "Redis master view TTL for Redis master failover test");
-DEFINE_int32(redis_heartbeat_interval_sec, 1,
+DEFINE_int32(redis_heartbeat_interval_sec, 2,
              "Redis heartbeat interval for Redis master failover test");
 
 constexpr int kMasterPortBase = 51051;
 constexpr int kMasterNum = 3;
+constexpr int kClientPortBase = 52051;
 
 namespace mooncake {
 namespace testing {
 
 namespace {
 
-void CleanupRedisKeys() {
+std::pair<std::string, int> ParseRedisEndpoint() {
     std::string host = "127.0.0.1";
     int port = 6379;
     auto colon_pos = FLAGS_redis_endpoint.rfind(':');
@@ -43,20 +45,52 @@ void CleanupRedisKeys() {
         host = FLAGS_redis_endpoint.substr(0, colon_pos);
         port = std::stoi(FLAGS_redis_endpoint.substr(colon_pos + 1));
     }
+    return {host, port};
+}
 
+std::string RedisClusterIdWithSlash() {
+    std::string cluster_id = FLAGS_redis_cluster_id;
+    if (!cluster_id.empty() && cluster_id.back() != '/') {
+        cluster_id += '/';
+    }
+    return cluster_id;
+}
+
+std::string MasterViewKey() {
+    return "mooncake:{" + RedisClusterIdWithSlash() + "}master_view";
+}
+
+std::string MasterEpochKey() {
+    return "mooncake:{" + RedisClusterIdWithSlash() + "}master_epoch";
+}
+
+bool DeleteRedisKey(const std::string& key) {
+    auto [host, port] = ParseRedisEndpoint();
+    redisContext* ctx = redisConnect(host.c_str(), port);
+    if (!ctx || ctx->err) {
+        if (ctx) redisFree(ctx);
+        return false;
+    }
+
+    redisReply* reply = static_cast<redisReply*>(
+        redisCommand(ctx, "DEL %b", key.data(), key.size()));
+    bool deleted =
+        reply && reply->type == REDIS_REPLY_INTEGER && reply->integer == 1;
+    if (reply) freeReplyObject(reply);
+    redisFree(ctx);
+    return deleted;
+}
+
+void CleanupRedisKeys() {
+    auto [host, port] = ParseRedisEndpoint();
     redisContext* ctx = redisConnect(host.c_str(), port);
     if (!ctx || ctx->err) {
         if (ctx) redisFree(ctx);
         return;
     }
 
-    std::string cluster_id = FLAGS_redis_cluster_id;
-    if (!cluster_id.empty() && cluster_id.back() != '/') {
-        cluster_id += '/';
-    }
-    std::string master_view_key = "mooncake:{" + cluster_id + "}master_view";
-    std::string master_epoch_key = "mooncake:{" + cluster_id + "}master_epoch";
-
+    std::string master_view_key = MasterViewKey();
+    std::string master_epoch_key = MasterEpochKey();
     redisReply* reply = static_cast<redisReply*>(redisCommand(
         ctx, "DEL %b %b", master_view_key.data(), master_view_key.size(),
         master_epoch_key.data(), master_epoch_key.size()));
@@ -99,6 +133,7 @@ class RedisChaosTest : public ::testing::Test {
         config.redis_heartbeat_interval_sec =
             FLAGS_redis_heartbeat_interval_sec;
         config.cluster_id = FLAGS_redis_cluster_id;
+        config.rpc_address = "127.0.0.1";
 
         for (int i = 0; i < kMasterNum; ++i) {
             masters_.emplace_back(std::make_unique<MasterProcessHandler>(
@@ -151,6 +186,61 @@ class RedisChaosTest : public ::testing::Test {
         return false;
     }
 
+    bool WaitForNewerView(ViewVersionId old_version, int& leader_index,
+                          ViewVersionId& version) {
+        auto timeout =
+            std::chrono::seconds(FLAGS_redis_master_view_ttl_sec * 8);
+        auto deadline = std::chrono::steady_clock::now() + timeout;
+        while (std::chrono::steady_clock::now() < deadline) {
+            if (WaitForLeader(leader_index, version, std::chrono::seconds(1)) &&
+                version > old_version) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    void WaitForLeaderServiceReady() {
+        std::this_thread::sleep_for(
+            std::chrono::seconds(FLAGS_redis_master_view_ttl_sec + 1));
+    }
+
+    std::shared_ptr<ClientTestWrapper> CreateRedisClient(
+        int index, std::chrono::seconds timeout) {
+        auto deadline = std::chrono::steady_clock::now() + timeout;
+        while (std::chrono::steady_clock::now() < deadline) {
+            auto client = ClientTestWrapper::CreateClientWrapper(
+                "0.0.0.0:" + std::to_string(kClientPortBase + index),
+                "P2PHANDSHAKE", "tcp", "", "redis://" + FLAGS_redis_endpoint,
+                /*local_buffer_size=*/1024 * 1024 * 128, FLAGS_redis_cluster_id,
+                /*enable_http_server=*/false);
+            if (client.has_value()) {
+                return client.value();
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        }
+        return nullptr;
+    }
+
+    bool WaitForClientPutGet(ClientTestWrapper& client,
+                             const std::string& key_prefix,
+                             const std::string& value,
+                             std::chrono::seconds timeout) {
+        auto deadline = std::chrono::steady_clock::now() + timeout;
+        int attempt = 0;
+        while (std::chrono::steady_clock::now() < deadline) {
+            std::string key = key_prefix + "_" + std::to_string(attempt++);
+            if (client.Put(key, value) == ErrorCode::OK) {
+                std::string got;
+                if (client.Get(key, got) == ErrorCode::OK && got == value) {
+                    return true;
+                }
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        }
+        return false;
+    }
+
     std::vector<std::unique_ptr<MasterProcessHandler>> masters_;
     std::unique_ptr<RedisMasterViewHelper> master_view_helper_;
 };
@@ -170,6 +260,49 @@ TEST_F(RedisChaosTest, LeaderKilledFailover) {
         WaitForNewLeader(leader_index, version, new_leader_index, new_version));
     EXPECT_NE(new_leader_index, leader_index);
     EXPECT_GT(new_version, version);
+}
+
+TEST_F(RedisChaosTest, LeaderKeyDeletedTriggersReElection) {
+    int leader_index = -1;
+    ViewVersionId version = 0;
+    ASSERT_TRUE(WaitForLeader(leader_index, version, std::chrono::seconds(10)));
+    ASSERT_GE(leader_index, 0);
+    ASSERT_LT(leader_index, kMasterNum);
+
+    ASSERT_TRUE(DeleteRedisKey(MasterViewKey()));
+
+    int next_leader_index = -1;
+    ViewVersionId next_version = 0;
+    ASSERT_TRUE(WaitForNewerView(version, next_leader_index, next_version));
+    EXPECT_GE(next_leader_index, 0);
+    EXPECT_LT(next_leader_index, kMasterNum);
+    EXPECT_GT(next_version, version);
+}
+
+TEST_F(RedisChaosTest, ClientRedisDiscoverySurvivesLeaderFailover) {
+    int leader_index = -1;
+    ViewVersionId version = 0;
+    ASSERT_TRUE(WaitForLeader(leader_index, version, std::chrono::seconds(10)));
+    WaitForLeaderServiceReady();
+
+    auto client = CreateRedisClient(/*index=*/0, std::chrono::seconds(30));
+    ASSERT_NE(client, nullptr);
+
+    void* buffer = nullptr;
+    ASSERT_EQ(client->Mount(1024 * 1024 * 16, buffer), ErrorCode::OK);
+    ASSERT_TRUE(WaitForClientPutGet(*client, "redis_failover_before", "value",
+                                    std::chrono::seconds(5)));
+
+    ASSERT_TRUE(masters_[leader_index]->kill());
+
+    int new_leader_index = -1;
+    ViewVersionId new_version = 0;
+    ASSERT_TRUE(
+        WaitForNewLeader(leader_index, version, new_leader_index, new_version));
+    WaitForLeaderServiceReady();
+
+    ASSERT_TRUE(WaitForClientPutGet(*client, "redis_failover_after", "value2",
+                                    std::chrono::seconds(60)));
 }
 
 }  // namespace testing

--- a/mooncake-store/tests/e2e/redis_chaos_test.cpp
+++ b/mooncake-store/tests/e2e/redis_chaos_test.cpp
@@ -210,7 +210,7 @@ class RedisChaosTest : public ::testing::Test {
         auto deadline = std::chrono::steady_clock::now() + timeout;
         while (std::chrono::steady_clock::now() < deadline) {
             auto client = ClientTestWrapper::CreateClientWrapper(
-                "0.0.0.0:" + std::to_string(kClientPortBase + index),
+                "127.0.0.1:" + std::to_string(kClientPortBase + index),
                 "P2PHANDSHAKE", "tcp", "", "redis://" + FLAGS_redis_endpoint,
                 /*local_buffer_size=*/1024 * 1024 * 128, FLAGS_redis_cluster_id,
                 /*enable_http_server=*/false);


### PR DESCRIPTION
## Description

  Cover Redis-based Mooncake Store HA failover paths.

  This PR adds Redis HA e2e coverage for:
  - leader process failover
  - Redis master view key deletion and re-election
  - client `redis://` master discovery surviving leader failover with subsequent `Put/Get`

  It also keeps HA wrapped master services alive for the RPC server lifetime, updates Redis HA deployment docs, and runs Redis
  HA chaos coverage separately in CI.

  ## Module

  - [ ] Transfer Engine (`mooncake-transfer-engine`)
  - [ ] Mooncake Store (`mooncake-store`)
  - [ ] Mooncake EP (`mooncake-ep`)
  - [ ] Mooncake PG (`mooncake-pg`)
  - [ ] Integration (`mooncake-integration`)
  - [x] P2P Store (`mooncake-p2p-store`)
  - [ ] Python Wheel (`mooncake-wheel`)
  - [ ] Common (`mooncake-common`)
  - [ ] Mooncake RL (`mooncake-rl`)
  - [x] CI/CD
  - [x] Docs
  - [ ] Other

  ## Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor
  - [ ] Breaking change
  - [x] Documentation update
  - [ ] Performance improvement
  - [ ] Other

  ## How Has This Been Tested?

  **Test commands:**
  ```bash
  ./scripts/code_format.sh

  cmake --build build

  redis-cli ping
  ctest -R '^redis_chaos_test$' --output-on-failure

  Test results:

  - [ ] Unit tests pass
  - [x] Integration tests pass (if applicable)
  - [x] Manual testing done (describe below)

  Manual testing:

  - Verified Redis HA chaos coverage locally in the container workflow.
  - Note: creating a fresh verification container hit an apt.llvm.org timeout while installing clang-format-20; existing
    formatted state was checked before push.

  ## Checklist

  - [x] I have performed a self-review of my own code
  - [x] I have formatted my code using ./scripts/code_format.sh
  - [ ] I have run pre-commit run --all-files and all hooks pass
  - [x] I have updated the documentation (if applicable)
  - [x] I have added tests to prove my changes are effective
  - [ ] For changes >500 LOC: I have filed an RFC issue

  ## AI Assistance Disclosure

  - [ ] No AI tools were used
  - [x] AI tools were used (specify below)

  AI tools were used to help inspect the code paths, implement test coverage, and draft this PR message. The submitter
  reviewed the changes.