### PR TITLE
[Bugfix][TENT] Fix silent TPU data corruption for transfers larger than one staging chunk

### DIFF
--- a/mooncake-common/common.cmake
+++ b/mooncake-common/common.cmake
@@ -207,6 +207,15 @@ if(USE_CUDA)
 endif()
 
 if(USE_TPU)
+  # Every TPU source file lives under mooncake-transfer-engine/tent, which is
+  # only added when USE_TENT is ON. Without this guard -DUSE_TPU=ON configures
+  # and builds cleanly while compiling no TPU code at all.
+  if(NOT USE_TENT)
+    message(
+      FATAL_ERROR
+        "USE_TPU=ON requires USE_TENT=ON: all TPU support lives in TENT. Re-run cmake with -DUSE_TENT=ON."
+    )
+  endif()
   add_compile_definitions(USE_TPU)
   message(STATUS "TPU (PJRT) staging support is enabled")
 endif()

--- a/mooncake-transfer-engine/tent/include/tent/platform/tpu_pjrt_abi.h
+++ b/mooncake-transfer-engine/tent/include/tent/platform/tpu_pjrt_abi.h
@@ -24,6 +24,21 @@
 // the mapping from that token to the underlying PJRT buffer; mc_tpu_pjrt_* copy
 // and classification calls resolve the token through the adapter's own
 // registry.
+//
+// INTERIOR POINTERS (load-bearing): TENT stages transfers through host DRAM in
+// chunks (see ProxyManager, chunk_size defaults to 4 MiB), and hands the
+// adapter `token + chunk_offset` for every chunk after the first. Every
+// entrypoint below therefore takes an address that may point into the MIDDLE of
+// a registered buffer, not only at its base. An adapter whose registry only
+// matches base addresses will report `is_device_ptr(token + off) == 0`, TENT
+// will classify TPU HBM as host memory, and the staging copy silently degrades
+// into a memcpy from a non-data address -- corrupting every transfer larger
+// than one chunk without raising an error. Adapters MUST resolve an address to
+// the registered buffer whose range [base, base + size) contains it.
+//
+// The token is NOT required to be host-dereferenceable, and on real PJRT/TPU it
+// is not: PJRT_Buffer_UnsafePointer returns an internal handle that reads as
+// garbage rather than buffer contents. Never dereference it.
 
 #ifndef TENT_PLATFORM_TPU_PJRT_ABI_H_
 #define TENT_PLATFORM_TPU_PJRT_ABI_H_
@@ -38,17 +53,24 @@ extern "C" {
 // success, non-zero on failure. Idempotent; safe to call more than once.
 int mc_tpu_pjrt_init(void);
 
-// Returns 1 if `addr` is a TPU device buffer known to the adapter, else 0.
+// Returns 1 if `addr` falls inside any TPU device buffer known to the adapter
+// (base address or interior), else 0.
 int mc_tpu_pjrt_is_device_ptr(const void *addr);
 
-// Returns the device ordinal backing `addr`, or -1 if `addr` is not a known TPU
-// device buffer.
+// Returns the device ordinal of the buffer containing `addr` (base address or
+// interior), or -1 if `addr` is not inside a known TPU device buffer.
 int mc_tpu_pjrt_device_index(const void *addr);
 
-// Synchronous device->host copy. Returns 0 on success, non-zero on failure.
+// Synchronous device->host copy. `device_src` may be an interior address; the
+// whole range [device_src, device_src + len) must lie within a single
+// registered buffer, otherwise the adapter must fail rather than copy short.
+// Returns 0 on success, non-zero on failure.
 int mc_tpu_pjrt_copy_d2h(void *host_dst, const void *device_src, size_t len);
 
-// Synchronous host->device copy. Returns 0 on success, non-zero on failure.
+// Synchronous host->device copy. `device_dst` may be an interior address; the
+// whole range [device_dst, device_dst + len) must lie within a single
+// registered buffer, otherwise the adapter must fail rather than copy short.
+// Returns 0 on success, non-zero on failure.
 int mc_tpu_pjrt_copy_h2d(void *device_dst, const void *host_src, size_t len);
 
 // Number of visible TPU devices.

--- a/mooncake-transfer-engine/tent/include/tent/platform/tpu_pjrt_shim.h
+++ b/mooncake-transfer-engine/tent/include/tent/platform/tpu_pjrt_shim.h
@@ -46,18 +46,22 @@ class TpuPjrtShim {
     // True when the adapter library was loaded and initialized successfully.
     bool available() const { return available_; }
 
-    // Returns true if `addr` refers to memory owned by the TPU runtime (HBM).
-    // Returns false when the adapter is unavailable or the pointer is host
-    // memory, so a caller can safely treat "not TPU" as host memory.
+    // Returns true if `addr` refers to memory owned by the TPU runtime (HBM),
+    // including addresses interior to a registered buffer. Returns false when
+    // the adapter is unavailable or the pointer is host memory, so a caller can
+    // safely treat "not TPU" as host memory.
     bool isDevicePtr(const void *addr) const;
 
-    // Device ordinal backing `addr`, or -1 if `addr` is not TPU device memory.
+    // Device ordinal of the buffer containing `addr` (base or interior), or -1
+    // if `addr` is not TPU device memory.
     int deviceIndex(const void *addr) const;
 
-    // Synchronous HBM -> host DMA copy of `length` bytes.
+    // Synchronous HBM -> host DMA copy of `length` bytes. `device_src` may be
+    // interior to a registered buffer; the range must not run past its end.
     Status copyD2H(void *host_dst, const void *device_src, size_t length) const;
 
-    // Synchronous host -> HBM DMA copy of `length` bytes.
+    // Synchronous host -> HBM DMA copy of `length` bytes. `device_dst` may be
+    // interior to a registered buffer; the range must not run past its end.
     Status copyH2D(void *device_dst, const void *host_src, size_t length) const;
 
     // Number of visible TPU devices (0 when the adapter is unavailable).

--- a/mooncake-transfer-engine/tent/src/platform/tpu/README.md
+++ b/mooncake-transfer-engine/tent/src/platform/tpu/README.md
@@ -59,10 +59,22 @@ int mc_tpu_pjrt_device_numa(int index);
 - **Pointer tokens:** the `const void *` "device pointer" is the stable token the
   serving-engine integration registers with TENT for a TPU buffer (via a
   `tpu:N` location). The adapter owns the mapping from that token to the
-  underlying PJRT buffer.
+  underlying PJRT buffer. The token is **not** the buffer's data and must never
+  be dereferenced — on real PJRT it is an internal handle that is
+  host-readable but reads as unrelated bytes.
+- **Interior pointers:** `ProxyManager` stages a transfer in `chunk_size`
+  (4 MiB) pieces and passes `token + chunk_offset` for every chunk after the
+  first. Classification and copy entrypoints must therefore resolve an address
+  to the registered buffer whose range contains it. An adapter that only matches
+  base addresses makes TENT classify HBM as host memory, and — because the token
+  *is* readable — the staging copy degrades into a `memcpy` of unrelated bytes
+  that reports success. `TpuTransport` defends against this by requiring exactly
+  one TPU-device side per staging hop and failing loudly otherwise.
 
-A mock adapter and a unit test that exercise this ABI on any Linux host live in
-[`../../../tests/tpu/`](../../../tests/tpu/).
+A mock adapter and unit tests that exercise this ABI on any Linux host live in
+[`../../../tests/tpu/`](../../../tests/tpu/). The mock hands out poisoned tokens
+backed by shadow storage, so a copy that bypasses the adapter yields `0xDD`
+rather than accidentally producing the right answer.
 
 ## Not yet included (follow-ups)
 

--- a/mooncake-transfer-engine/tent/src/transport/tpu/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/src/transport/tpu/CMakeLists.txt
@@ -1,5 +1,8 @@
 if(USE_TPU)
     file(GLOB XPORT_SOURCES "*.cpp")
     add_library(tent_xport_tpu STATIC ${XPORT_SOURCES})
-    target_link_libraries(tent_xport_tpu PUBLIC tent_rpc tent_common)
+    # platform_tpu provides TpuPjrtShim, which the transport consults to
+    # verify that a staging copy really has a TPU-device side.
+    target_link_libraries(tent_xport_tpu PUBLIC tent_rpc tent_common
+                                                platform_tpu)
 endif()

--- a/mooncake-transfer-engine/tent/src/transport/tpu/tpu_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/tpu/tpu_transport.cpp
@@ -17,6 +17,7 @@
 #include <glog/logging.h>
 
 #include "tent/common/status.h"
+#include "tent/platform/tpu_pjrt_shim.h"
 #include "tent/runtime/platform.h"
 #include "tent/runtime/slab.h"
 
@@ -59,7 +60,8 @@ Status TpuTransport::uninstall() {
 Status TpuTransport::allocateSubBatch(SubBatchRef &batch, size_t max_size) {
     auto tpu_batch = Slab<TpuSubBatch>::Get().allocate();
     if (!tpu_batch)
-        return Status::InternalError("Unable to allocate TPU sub-batch");
+        return Status::InternalError(
+            "Unable to allocate TPU sub-batch" LOC_MARK);
     batch = tpu_batch;
     tpu_batch->task_list.reserve(max_size);
     tpu_batch->max_size = max_size;
@@ -108,6 +110,32 @@ void TpuTransport::startTransfer(TpuTask *task, TpuSubBatch *batch) {
     }
 
     void *staging = reinterpret_cast<void *>(task->request.target_offset);
+
+    // Exactly one side of a staging hop is TPU HBM: the local stage copies
+    // HBM<->host staging buffer, and a delegated remote stage copies the peer's
+    // host staging buffer<->its HBM (so `staging` is the device side there).
+    // Verify that here instead of relying on Platform::copy to classify: if the
+    // adapter fails to recognise a device pointer -- e.g. it only matches base
+    // addresses and ProxyManager handed us `base + chunk_offset` -- then
+    // Platform::copy sees two host pointers and silently memcpy()s from a token
+    // that is not the buffer's data, corrupting the transfer. Fail loudly.
+    auto &shim = TpuPjrtShim::instance();
+    const bool source_is_device = shim.isDevicePtr(task->request.source);
+    const bool staging_is_device = shim.isDevicePtr(staging);
+    if (source_is_device == staging_is_device) {
+        LOG(ERROR)
+            << "TpuTransport: a staging copy must have exactly one TPU "
+               "device side, but source="
+            << task->request.source << " (device=" << source_is_device
+            << ") and target=" << staging << " (device=" << staging_is_device
+            << "). Either the PJRT adapter is unavailable, or it does not "
+               "resolve interior pointers (see tpu_pjrt_abi.h).";
+        task->status_word = TransferStatusEnum::FAILED;
+        task->transferred_bytes = 0;
+        batch->notifyProgress();
+        return;
+    }
+
     Status status;
     if (task->request.opcode == Request::READ)
         // host staging buffer -> device (H2D)

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -229,4 +229,18 @@ if(USE_TPU)
     tent_tpu_pjrt_shim_test
     PRIVATE MOCK_TPU_PJRT_LIB="$<TARGET_FILE:mock_tpu_pjrt>")
   add_test(NAME tent_tpu_pjrt_shim_test COMMAND tent_tpu_pjrt_shim_test)
+
+  # Drives TpuTransport's staging hop (interior-offset chunks, and the
+  # exactly-one-device-side guard) against the same mock adapter.
+  add_executable(tent_tpu_transport_test tpu/tpu_transport_test.cpp)
+  add_dependencies(tent_tpu_transport_test mock_tpu_pjrt)
+  target_link_libraries(tent_tpu_transport_test
+                        PRIVATE gtest gtest_main tent_link_group
+                                ${CMAKE_DL_LIBS})
+  target_include_directories(tent_tpu_transport_test
+                             PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+  target_compile_definitions(
+    tent_tpu_transport_test
+    PRIVATE MOCK_TPU_PJRT_LIB="$<TARGET_FILE:mock_tpu_pjrt>")
+  add_test(NAME tent_tpu_transport_test COMMAND tent_tpu_transport_test)
 endif()

--- a/mooncake-transfer-engine/tent/tests/tpu/mock_tpu_pjrt_adapter.cpp
+++ b/mooncake-transfer-engine/tent/tests/tpu/mock_tpu_pjrt_adapter.cpp
@@ -12,24 +12,67 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Mock TPU/PJRT adapter for unit testing TpuPjrtShim and TpuPlatform without
-// TPU hardware or a PJRT runtime. It implements the C ABI declared in
-// tpu_pjrt_abi.h using ordinary host memory: "device" buffers are plain
-// allocations the test registers via the mock_* test helpers below, and D2H/H2D
-// copies are memcpy. This lets the routing and shim logic be exercised on any
-// Linux host (see tpu_pjrt_shim_test.cpp).
+// Mock TPU/PJRT adapter for unit testing TpuPjrtShim, TpuPlatform and
+// TpuTransport without TPU hardware or a PJRT runtime. It implements the C ABI
+// declared in tpu_pjrt_abi.h, so the routing, classification and staging logic
+// can be exercised on any Linux host (see tpu_pjrt_shim_test.cpp and
+// tpu_transport_test.cpp).
+//
+// Two properties of real PJRT/TPU are modelled deliberately, because both are
+// load-bearing for TENT's correctness and neither is obvious:
+//
+//  1. The device "pointer" is an opaque TOKEN, not the buffer's data. On real
+//     hardware PJRT_Buffer_UnsafePointer returns an internal handle that is
+//     host-dereferenceable but reads as unrelated bytes. So the token here is a
+//     separate read-only mapping poisoned with kPoison, and the buffer contents
+//     live in a shadow allocation reachable only through the copy entrypoints.
+//     Any code path that "helpfully" memcpy()s from a device token therefore
+//     reads poison instead of silently producing the right answer -- which is
+//     what a plain-host-memory mock would have done, and why an
+//     interior-pointer bug could pass a green test suite.
+//
+//  2. Addresses may be INTERIOR to a registered buffer. TENT stages transfers
+//  in
+//     chunks and passes `token + chunk_offset` for every chunk after the first,
+//     so classification and copies resolve ranges, and a copy that would run
+//     past a buffer's end is rejected rather than truncated.
 
+#include <sys/mman.h>
+
+#include <cstdint>
 #include <cstring>
 #include <mutex>
-#include <unordered_map>
+#include <vector>
 
 #include "tent/platform/tpu_pjrt_abi.h"
 
 namespace {
+// Byte filling the token mapping. Nothing should ever read it; if a test sees
+// 0xDD it means something dereferenced a device token directly.
+constexpr unsigned char kPoison = 0xDD;
+
+struct Buffer {
+    uintptr_t token;        // opaque handle handed out to TENT
+    unsigned char *shadow;  // where the bytes actually live
+    size_t size;
+    int device;
+};
+
 std::mutex g_mutex;
-// Registered fake device buffers: pointer -> device ordinal.
-std::unordered_map<const void *, int> g_device_registry;
+std::vector<Buffer> g_device_registry;
 int g_device_count = 4;
+
+// Returns the buffer containing [addr, addr + len), or nullptr. len == 0 only
+// checks that `addr` itself is inside a buffer.
+Buffer *findLocked(const void *addr, size_t len) {
+    auto a = reinterpret_cast<uintptr_t>(addr);
+    for (auto &b : g_device_registry) {
+        if (a < b.token || a >= b.token + b.size) continue;
+        if (len > b.token + b.size - a) return nullptr;  // runs past the end
+        return &b;
+    }
+    return nullptr;
+}
 }  // namespace
 
 extern "C" {
@@ -40,24 +83,32 @@ int mc_tpu_pjrt_init(void) { return 0; }
 
 int mc_tpu_pjrt_is_device_ptr(const void *addr) {
     std::lock_guard<std::mutex> lock(g_mutex);
-    return g_device_registry.count(addr) ? 1 : 0;
+    return findLocked(addr, 0) ? 1 : 0;
 }
 
 int mc_tpu_pjrt_device_index(const void *addr) {
     std::lock_guard<std::mutex> lock(g_mutex);
-    auto it = g_device_registry.find(addr);
-    return it == g_device_registry.end() ? -1 : it->second;
+    const Buffer *b = findLocked(addr, 0);
+    return b ? b->device : -1;
 }
 
 int mc_tpu_pjrt_copy_d2h(void *host_dst, const void *device_src, size_t len) {
     if (!host_dst || !device_src) return 1;
-    std::memcpy(host_dst, device_src, len);
+    std::lock_guard<std::mutex> lock(g_mutex);
+    const Buffer *b = findLocked(device_src, len);
+    if (!b) return 1;
+    size_t offset = reinterpret_cast<uintptr_t>(device_src) - b->token;
+    std::memcpy(host_dst, b->shadow + offset, len);
     return 0;
 }
 
 int mc_tpu_pjrt_copy_h2d(void *device_dst, const void *host_src, size_t len) {
     if (!device_dst || !host_src) return 1;
-    std::memcpy(device_dst, host_src, len);
+    std::lock_guard<std::mutex> lock(g_mutex);
+    const Buffer *b = findLocked(device_dst, len);
+    if (!b) return 1;
+    size_t offset = reinterpret_cast<uintptr_t>(device_dst) - b->token;
+    std::memcpy(b->shadow + offset, host_src, len);
     return 0;
 }
 
@@ -71,13 +122,39 @@ int mc_tpu_pjrt_device_numa(int index) {
 
 // --- Test-only helpers (not part of the shim ABI) --------------------------
 
-void mock_tpu_pjrt_register_device(const void *addr, int index) {
+// Creates a fake device buffer of `size` bytes on device `index` and returns
+// its token. The token is readable (like PJRT's unsafe pointer) but holds
+// poison, never the buffer's data.
+void *mock_tpu_pjrt_register_device(size_t size, int index) {
+    void *token = mmap(nullptr, size, PROT_READ | PROT_WRITE,
+                       MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (token == MAP_FAILED) return nullptr;
+    std::memset(token, kPoison, size);
+    mprotect(token, size, PROT_READ);
+
     std::lock_guard<std::mutex> lock(g_mutex);
-    g_device_registry[addr] = index;
+    g_device_registry.push_back(Buffer{reinterpret_cast<uintptr_t>(token),
+                                       new unsigned char[size](), size, index});
+    return token;
 }
+
+// Direct access to a buffer's bytes, for seeding inputs and asserting outputs.
+// Accepts an interior token address and returns the matching shadow address.
+void *mock_tpu_pjrt_device_data(const void *token) {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    Buffer *b = findLocked(token, 0);
+    if (!b) return nullptr;
+    return b->shadow + (reinterpret_cast<uintptr_t>(token) - b->token);
+}
+
+unsigned char mock_tpu_pjrt_poison_byte(void) { return kPoison; }
 
 void mock_tpu_pjrt_reset(void) {
     std::lock_guard<std::mutex> lock(g_mutex);
+    for (auto &b : g_device_registry) {
+        munmap(reinterpret_cast<void *>(b.token), b.size);
+        delete[] b.shadow;
+    }
     g_device_registry.clear();
     g_device_count = 4;
 }

--- a/mooncake-transfer-engine/tent/tests/tpu/tpu_pjrt_shim_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/tpu/tpu_pjrt_shim_test.cpp
@@ -24,6 +24,7 @@
 #include <gtest/gtest.h>
 
 #include <cstdlib>
+#include <cstring>
 #include <vector>
 
 #ifndef MOCK_TPU_PJRT_LIB
@@ -34,7 +35,8 @@ namespace mooncake {
 namespace tent {
 namespace {
 
-using RegisterFn = void (*)(const void *, int);
+using RegisterFn = void *(*)(size_t, int);
+using DeviceDataFn = void *(*)(const void *);
 using ResetFn = void (*)();
 using SetCountFn = void (*)(int);
 
@@ -53,10 +55,13 @@ class TpuShimTest : public ::testing::Test {
         ASSERT_NE(mock_, nullptr) << dlerror();
         register_ = reinterpret_cast<RegisterFn>(
             dlsym(mock_, "mock_tpu_pjrt_register_device"));
+        device_data_ = reinterpret_cast<DeviceDataFn>(
+            dlsym(mock_, "mock_tpu_pjrt_device_data"));
         reset_ = reinterpret_cast<ResetFn>(dlsym(mock_, "mock_tpu_pjrt_reset"));
         set_count_ = reinterpret_cast<SetCountFn>(
             dlsym(mock_, "mock_tpu_pjrt_set_device_count"));
         ASSERT_NE(register_, nullptr);
+        ASSERT_NE(device_data_, nullptr);
         ASSERT_NE(reset_, nullptr);
         ASSERT_NE(set_count_, nullptr);
         reset_();
@@ -67,8 +72,16 @@ class TpuShimTest : public ::testing::Test {
         if (mock_) dlclose(mock_);
     }
 
+    // Fills a fake device buffer with a repeatable pattern.
+    void seedDevice(void *token, size_t size, uint8_t modulus) {
+        auto *data = static_cast<uint8_t *>(device_data_(token));
+        ASSERT_NE(data, nullptr);
+        for (size_t i = 0; i < size; ++i) data[i] = (uint8_t)(i % modulus);
+    }
+
     void *mock_ = nullptr;
     RegisterFn register_ = nullptr;
+    DeviceDataFn device_data_ = nullptr;
     ResetFn reset_ = nullptr;
     SetCountFn set_count_ = nullptr;
 };
@@ -84,12 +97,12 @@ TEST_F(TpuShimTest, AdapterLoadsAndReportsDevices) {
 
 TEST_F(TpuShimTest, ClassifiesRegisteredDevicePointers) {
     int host_value = 0;
-    std::vector<uint8_t> fake_device(64);
-    register_(fake_device.data(), /*index=*/2);
+    void *token = register_(64, /*index=*/2);
+    ASSERT_NE(token, nullptr);
 
     auto &shim = TpuPjrtShim::instance();
-    EXPECT_TRUE(shim.isDevicePtr(fake_device.data()));
-    EXPECT_EQ(shim.deviceIndex(fake_device.data()), 2);
+    EXPECT_TRUE(shim.isDevicePtr(token));
+    EXPECT_EQ(shim.deviceIndex(token), 2);
 
     // Unregistered host memory is not device memory.
     EXPECT_FALSE(shim.isDevicePtr(&host_value));
@@ -97,19 +110,77 @@ TEST_F(TpuShimTest, ClassifiesRegisteredDevicePointers) {
     EXPECT_FALSE(shim.isDevicePtr(nullptr));
 }
 
+// Regression: ProxyManager stages a transfer in chunk_size (4 MiB) pieces and
+// hands the platform `token + chunk_offset` for every chunk after the first. An
+// adapter that only recognises base addresses makes TENT classify TPU HBM as
+// host memory, and the staging copy degrades into a memcpy from a token that on
+// real PJRT is not the buffer's data -- silently corrupting every transfer
+// larger than one chunk. Interior addresses must classify as device memory.
+TEST_F(TpuShimTest, ClassifiesInteriorDevicePointers) {
+    const size_t kSize = 8192;
+    auto *token = static_cast<uint8_t *>(register_(kSize, /*index=*/3));
+    ASSERT_NE(token, nullptr);
+
+    auto &shim = TpuPjrtShim::instance();
+    EXPECT_TRUE(shim.isDevicePtr(token + 1));
+    EXPECT_TRUE(shim.isDevicePtr(token + 4096));
+    EXPECT_TRUE(shim.isDevicePtr(token + kSize - 1));
+    EXPECT_EQ(shim.deviceIndex(token + 4096), 3);
+
+    // One past the end belongs to no buffer.
+    EXPECT_FALSE(shim.isDevicePtr(token + kSize));
+    EXPECT_EQ(shim.deviceIndex(token + kSize), -1);
+}
+
 TEST_F(TpuShimTest, CopyRoundTripMovesBytes) {
     auto &shim = TpuPjrtShim::instance();
     const std::vector<uint8_t> src = {1, 2, 3, 4, 5, 6, 7, 8};
-    std::vector<uint8_t> device(src.size(), 0);
+    void *token = register_(src.size(), /*index=*/0);
+    ASSERT_NE(token, nullptr);
     std::vector<uint8_t> dst(src.size(), 0);
 
     // host -> "device"
-    ASSERT_TRUE(shim.copyH2D(device.data(), src.data(), src.size()).ok());
-    EXPECT_EQ(device, src);
+    ASSERT_TRUE(shim.copyH2D(token, src.data(), src.size()).ok());
+    EXPECT_EQ(0, std::memcmp(device_data_(token), src.data(), src.size()));
 
     // "device" -> host
-    ASSERT_TRUE(shim.copyD2H(dst.data(), device.data(), device.size()).ok());
+    ASSERT_TRUE(shim.copyD2H(dst.data(), token, src.size()).ok());
     EXPECT_EQ(dst, src);
+}
+
+// The chunked staging pattern end to end: copy each 4 KiB slice of a "device"
+// buffer out through an interior pointer, exactly as ProxyManager would.
+TEST_F(TpuShimTest, CopyFromInteriorOffsetMovesTheRightBytes) {
+    auto &shim = TpuPjrtShim::instance();
+    const size_t kChunk = 4096, kChunks = 4, kSize = kChunk * kChunks;
+    auto *token = static_cast<uint8_t *>(register_(kSize, /*index=*/1));
+    ASSERT_NE(token, nullptr);
+    seedDevice(token, kSize, 251);
+
+    std::vector<uint8_t> host(kSize, 0);
+    for (size_t c = 0; c < kChunks; ++c) {
+        ASSERT_TRUE(
+            shim.copyD2H(host.data() + c * kChunk, token + c * kChunk, kChunk)
+                .ok())
+            << "chunk " << c;
+    }
+    EXPECT_EQ(0, std::memcmp(host.data(), device_data_(token), kSize));
+    // And the bytes are the seeded pattern, not the token's poison.
+    EXPECT_EQ(host[0], 0);
+    EXPECT_EQ(host[kChunk + 1], (uint8_t)((kChunk + 1) % 251));
+}
+
+// A copy must never run past the end of the buffer it started in.
+TEST_F(TpuShimTest, RejectsCopyRunningPastBufferEnd) {
+    auto &shim = TpuPjrtShim::instance();
+    auto *token = static_cast<uint8_t *>(register_(1024, /*index=*/0));
+    ASSERT_NE(token, nullptr);
+    std::vector<uint8_t> host(2048, 0);
+
+    EXPECT_FALSE(shim.copyD2H(host.data(), token + 512, 1024).ok());
+    EXPECT_FALSE(shim.copyH2D(token + 512, host.data(), 1024).ok());
+    // Unregistered addresses are not device memory and cannot be copied.
+    EXPECT_FALSE(shim.copyD2H(host.data(), host.data() + 1024, 16).ok());
 }
 
 }  // namespace

--- a/mooncake-transfer-engine/tent/tests/tpu/tpu_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/tpu/tpu_transport_test.cpp
@@ -1,0 +1,204 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Drives TpuTransport's staging hop against the mock PJRT adapter. No TPU
+// hardware or PJRT runtime required.
+//
+// The cases here mirror the requests ProxyManager actually issues: a local
+// stage whose `source` is `device_token + chunk_offset` and whose
+// `target_offset` is the host staging buffer, and the delegated remote stage
+// where the device side is `target_offset` instead.
+//
+// The mock's device tokens are poisoned (see mock_tpu_pjrt_adapter.cpp), so a
+// staging copy that bypasses the adapter and memcpy()s straight from a token
+// yields 0xDD rather than the buffer's data. That makes the data assertions
+// below real detectors of the "device pointer misclassified as host memory"
+// failure mode, instead of accidentally passing.
+
+#include "tent/transport/tpu/tpu_transport.h"
+
+#include <dlfcn.h>
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+#ifndef MOCK_TPU_PJRT_LIB
+#error "MOCK_TPU_PJRT_LIB must be defined by the build (path to mock adapter)"
+#endif
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+using RegisterFn = void *(*)(size_t, int);
+using DeviceDataFn = void *(*)(const void *);
+using PoisonFn = unsigned char (*)();
+using ResetFn = void (*)();
+
+constexpr size_t kChunk = 4ul << 20;  // ProxyManager's default chunk_size
+constexpr size_t kBufSize = 3 * kChunk;
+
+class TpuTransportTest : public ::testing::Test {
+   protected:
+    static void SetUpTestSuite() {
+        ::setenv("MC_TPU_PJRT_LIB", MOCK_TPU_PJRT_LIB, /*overwrite=*/1);
+    }
+
+    void SetUp() override {
+        mock_ = dlopen(MOCK_TPU_PJRT_LIB, RTLD_NOW | RTLD_GLOBAL);
+        ASSERT_NE(mock_, nullptr) << dlerror();
+        register_ = reinterpret_cast<RegisterFn>(
+            dlsym(mock_, "mock_tpu_pjrt_register_device"));
+        device_data_ = reinterpret_cast<DeviceDataFn>(
+            dlsym(mock_, "mock_tpu_pjrt_device_data"));
+        poison_ = reinterpret_cast<PoisonFn>(
+            dlsym(mock_, "mock_tpu_pjrt_poison_byte"));
+        reset_ = reinterpret_cast<ResetFn>(dlsym(mock_, "mock_tpu_pjrt_reset"));
+        ASSERT_NE(register_, nullptr);
+        ASSERT_NE(device_data_, nullptr);
+        ASSERT_NE(poison_, nullptr);
+        ASSERT_NE(reset_, nullptr);
+        reset_();
+
+        std::string segment = "local";
+        ASSERT_TRUE(
+            transport_.install(segment, nullptr, nullptr, nullptr).ok());
+    }
+
+    void TearDown() override {
+        transport_.uninstall();
+        if (reset_) reset_();
+        if (mock_) dlclose(mock_);
+    }
+
+    // Runs one request through the transport and returns its final status.
+    TransferStatus run(const Request &request) {
+        Transport::SubBatchRef batch = nullptr;
+        EXPECT_TRUE(transport_.allocateSubBatch(batch, 1).ok());
+        EXPECT_TRUE(transport_.submitTransferTasks(batch, {request}).ok());
+        TransferStatus status{};
+        EXPECT_TRUE(transport_.getTransferStatus(batch, 0, status).ok());
+        EXPECT_TRUE(transport_.freeSubBatch(batch).ok());
+        return status;
+    }
+
+    static Request makeRequest(Request::OpCode op, void *source,
+                               uint64_t target, size_t length) {
+        Request r;
+        r.opcode = op;
+        r.source = source;
+        r.length = length;
+        r.target_id = LOCAL_SEGMENT_ID;
+        r.target_offset = target;
+        return r;
+    }
+
+    void *mock_ = nullptr;
+    RegisterFn register_ = nullptr;
+    DeviceDataFn device_data_ = nullptr;
+    PoisonFn poison_ = nullptr;
+    ResetFn reset_ = nullptr;
+    TpuTransport transport_;
+};
+
+// The local WRITE stage of chunk #1: source is an interior device address.
+// Before interior pointers were part of the adapter contract this silently
+// memcpy()d from a non-data token and still reported COMPLETED.
+TEST_F(TpuTransportTest, LocalStageCopiesFromInteriorDeviceOffset) {
+    auto *token = static_cast<uint8_t *>(register_(kBufSize, /*index=*/0));
+    ASSERT_NE(token, nullptr);
+    auto *data = static_cast<uint8_t *>(device_data_(token));
+    for (size_t i = 0; i < kBufSize; ++i) data[i] = (uint8_t)(i % 251);
+    std::vector<uint8_t> staging(kChunk, 0);
+
+    // Chunk #1: device_token + 4 MiB -> host staging buffer.
+    auto status = run(makeRequest(Request::WRITE, token + kChunk,
+                                  (uint64_t)staging.data(), kChunk));
+    ASSERT_EQ(status.s, TransferStatusEnum::COMPLETED);
+    EXPECT_EQ(status.transferred_bytes, kChunk);
+    EXPECT_EQ(0, std::memcmp(staging.data(), data + kChunk, kChunk));
+    // Not the token's poison: the adapter really did the copy.
+    EXPECT_NE(staging[0], poison_());
+}
+
+// The mirrored remote stage: the device side is `target_offset`, at an offset.
+TEST_F(TpuTransportTest, RemoteStageCopiesToInteriorDeviceOffset) {
+    auto *token = static_cast<uint8_t *>(register_(kBufSize, /*index=*/0));
+    ASSERT_NE(token, nullptr);
+    std::vector<uint8_t> staging(kChunk);
+    for (size_t i = 0; i < kChunk; ++i) staging[i] = (uint8_t)(i % 197);
+
+    // WRITE with a device target: host staging -> device_token + 4 MiB.
+    auto status = run(makeRequest(Request::WRITE, staging.data(),
+                                  (uint64_t)(token + kChunk), kChunk));
+    ASSERT_EQ(status.s, TransferStatusEnum::COMPLETED);
+    auto *data = static_cast<uint8_t *>(device_data_(token));
+    EXPECT_EQ(0, std::memcmp(data + kChunk, staging.data(), kChunk));
+}
+
+// A READ stage moves host staging -> device.
+TEST_F(TpuTransportTest, ReadStageCopiesHostToDevice) {
+    auto *token = static_cast<uint8_t *>(register_(kBufSize, /*index=*/0));
+    ASSERT_NE(token, nullptr);
+    std::vector<uint8_t> staging(kChunk, 0xAB);
+
+    auto status = run(makeRequest(Request::READ, token + 2 * kChunk,
+                                  (uint64_t)staging.data(), kChunk));
+    ASSERT_EQ(status.s, TransferStatusEnum::COMPLETED);
+    auto *data = static_cast<uint8_t *>(device_data_(token));
+    EXPECT_EQ(0, std::memcmp(data + 2 * kChunk, staging.data(), kChunk));
+}
+
+// Neither side is device memory: the adapter is missing, or it failed to
+// classify an interior pointer. Either way the transport must fail rather than
+// let Platform::copy memcpy from a token that is not the buffer's data.
+TEST_F(TpuTransportTest, FailsWhenNeitherSideIsDeviceMemory) {
+    std::vector<uint8_t> host_a(4096, 1), host_b(4096, 2);
+    auto status = run(makeRequest(Request::WRITE, host_a.data(),
+                                  (uint64_t)host_b.data(), host_a.size()));
+    EXPECT_EQ(status.s, TransferStatusEnum::FAILED);
+    EXPECT_EQ(status.transferred_bytes, 0u);
+    // The destination is untouched -- no silent partial copy.
+    EXPECT_EQ(host_b[0], 2);
+}
+
+// Both sides device: HBM<->HBM is not a staging hop and must be rejected.
+TEST_F(TpuTransportTest, FailsWhenBothSidesAreDeviceMemory) {
+    auto *a = static_cast<uint8_t *>(register_(kBufSize, /*index=*/0));
+    auto *b = static_cast<uint8_t *>(register_(kBufSize, /*index=*/1));
+    ASSERT_NE(a, nullptr);
+    ASSERT_NE(b, nullptr);
+
+    auto status = run(makeRequest(Request::WRITE, a, (uint64_t)b, kChunk));
+    EXPECT_EQ(status.s, TransferStatusEnum::FAILED);
+}
+
+// TPU HBM can never be a remote peer; a non-local target is a routing bug.
+TEST_F(TpuTransportTest, FailsOnNonLocalTarget) {
+    auto *token = static_cast<uint8_t *>(register_(kBufSize, /*index=*/0));
+    ASSERT_NE(token, nullptr);
+    std::vector<uint8_t> staging(kChunk, 0);
+
+    auto request =
+        makeRequest(Request::WRITE, token, (uint64_t)staging.data(), kChunk);
+    request.target_id = LOCAL_SEGMENT_ID + 1;
+    auto status = run(request);
+    EXPECT_EQ(status.s, TransferStatusEnum::FAILED);
+}
+
+}  // namespace
+}  // namespace tent
+}  // namespace mooncake


### PR DESCRIPTION
## Description

Fixes a silent data-corruption bug in the TENT TPU staging path added by #2733 (RFC #2662).

**Found by running the TPU path on a real TPU VM for the first time** (`v5p-8`, `libtpu 0.0.32`, PJRT C API 0.83). Everything before this had only ever run against the mock adapter.

### The bug

`ProxyManager` stages a transfer in `chunk_size` (4 MiB) pieces and passes `token + chunk_offset` to the platform for every chunk after the first:

```cpp
// mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp:76
local_stage.source = (uint8_t*)request.source + offset;
```

The adapter ABI only ever specified *base-address* classification. So for `offset > 0`:

1. `mc_tpu_pjrt_is_device_ptr(token + offset)` returns 0,
2. `TpuPlatform::copy` concludes neither side is device memory,
3. it falls through to `CpuPlatform::copy` — a plain `memcpy` of the device token.

On real PJRT that `memcpy` **does not crash**. `PJRT_Buffer_UnsafePointer` returns an address that is host-readable but does not hold the buffer's data. The staging copy produced garbage and reported `COMPLETED`.

Net effect: chunk 0 is correct, every later chunk is silently wrong. **Any TPU transfer larger than 4 MiB was corrupted, with no error raised anywhere** — which is essentially every real KV-cache transfer.

### Why CI never caught it

Two independent reasons, both fixed here:

- `-DUSE_TPU=ON` compiled **zero** TPU code. All TPU sources live under `tent/`, which is gated on `USE_TENT`. The build configured and succeeded while building nothing.
- The mock adapter's "device" pointers were ordinary host memory, so the accidental `memcpy` produced the *right* bytes. The mock structurally could not reproduce the failure.

### Changes

- **`tpu_pjrt_abi.h` / `tpu_pjrt_shim.h`** — specify that classification and copy entrypoints must resolve an interior address to the registered buffer whose range contains it; that a copy may not run past a buffer's end; and that the token must never be dereferenced.
- **`tpu_transport.cpp`** — require exactly one TPU-device side per staging hop, and fail loudly otherwise. Defense in depth: a non-conforming *or absent* adapter can no longer degrade into a silent `memcpy`.
- **`mock_tpu_pjrt_adapter.cpp`** — model the two properties that actually matter on hardware: tokens are opaque (a poisoned read-only mapping; data lives in shadow storage) and addresses may be interior. A copy that bypasses the adapter now yields `0xDD` instead of accidentally passing.
- **`common.cmake`** — `USE_TPU=ON` without `USE_TENT=ON` is now a hard error instead of a silent no-op.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [x] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

Note: the `common.cmake` guard is technically build-breaking for anyone passing `-DUSE_TPU=ON` alone — but such a build produced no TPU code, so nothing can regress.

## How Has This Been Tested?

**Test commands:**
```bash
cmake -S . -B build -G Ninja -DUSE_TENT=ON -DUSE_TPU=ON \
  -DWITH_STORE=OFF -DWITH_STORE_RUST=OFF -DBUILD_BENCHMARK=OFF -DUSE_RDMA=ON
cmake --build build -j
ctest --test-dir build/mooncake-transfer-engine/tent
```

**Test results:**

- `100% tests passed, 0 tests failed out of 22`
- New: `tent_tpu_transport_test` (6 cases) drives `TpuTransport`'s staging hop exactly as `ProxyManager` issues it — local stage at an interior device offset, the mirrored remote stage, the READ direction, and the three failure modes (no device side, two device sides, non-local target).
- New: `ClassifiesInteriorDevicePointers` and `CopyFromInteriorOffsetMovesTheRightBytes` in `tent_tpu_pjrt_shim_test`.

**Verified the tests actually catch the bug.** Reverting the fixes (exact-match registry + no transport guard) makes `LocalStageCopiesFromInteriorDeviceOffset` fail exactly as the hardware behaves: status `COMPLETED`, staging buffer filled with `0xDD`. Re-applying the fixes turns it green.

Hardware findings behind this were reproduced with a standalone PJRT probe (`GetPjrtApi` from `libtpu.so` → `BufferFromHostBuffer` → `UnsafePointer` → `memcpy`), confirming the token is readable and holds unrelated bytes.

- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (real TPU VM, v5p-8)

Not covered: the cross-node hop. This VM is single-host (gVNIC, no RDMA), so the device↔host staging hop is exercised, not host↔remote-host.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass — see note below
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

On `pre-commit`: every hook passes on the touched files except `cmake-format`, which rewrites large amounts of *unrelated* code in `tent/tests/CMakeLists.txt` and `common.cmake`. Per `AGENTS.md` ("do not include those unrelated edits in the PR") I kept the diff minimal and left those rewrites out; happy to let `pre-commit.ci` autofix, or to land them separately.

## Related work

- Implements the correctness half of the follow-ups in #2662; the merged feature is #2733.
- Does **not** overlap open PR #2030 (`[TransferEngine] Add TPU integration scaffolding and guards`), which targets the *classic* transfer engine (`mooncake-transfer-engine/src`, `include/gpu_vendor/tpu.h`). That PR introduces its own `USE_TPU` option. If it lands, the `USE_TPU ⇒ USE_TENT` guard here needs revisiting, since `USE_TPU` would then also gate classic-TE code. Flagging for whoever merges second.

Separately, hardware benchmarking turned up an architectural issue — the PJRT sub-range copy entrypoints that `Platform::copy` requires run ~20× slower than the whole-buffer ones (0.8 GB/s vs 18.5 GB/s D2H), capping the staging design near ~1 GB/s per chip. That is a design discussion, not a bugfix, so I'll raise it on #2662 rather than here.

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Claude Code was used to run the TPU-VM investigation (building the PJRT probes that identified the token/interior-pointer behaviour), to implement the fixes, and to draft the tests. I have reviewed every changed line and can defend the change end to end.