### PR TITLE
[Store] Fix SSD offload publish-before-commit race (#2799)

### DIFF
--- a/mooncake-store/include/storage_backend.h
+++ b/mooncake-store/include/storage_backend.h
@@ -881,6 +881,21 @@ class BucketStorageBackend : public StorageBackendInterface {
      */
     void CleanupOrphanedBucket(int64_t bucket_id);
 
+    /**
+     * @brief Rollback a committed bucket from the local index when
+     * NotifyOffloadSuccess fails after local commit. Removes keys from
+     * object_bucket_map_, removes the bucket from buckets_ and lru_index_,
+     * waits for inflight reads to drain, then cleans up on-disk files.
+     *
+     * Called from BatchOffload when complete_handler fails after the local
+     * index has already been committed.
+     *
+     * @param bucket_id The bucket ID to roll back.
+     * @param keys The keys that were committed.
+     */
+    void RollbackCommittedBucket(int64_t bucket_id,
+                                 const std::vector<std::string>& keys);
+
     // Holds eviction state between PrepareEviction and FinalizeEviction.
     // PrepareEviction removes buckets from metadata maps and returns this.
     // FinalizeEviction waits for in-flight reads and deletes the files.

--- a/mooncake-store/src/storage_backend.cpp
+++ b/mooncake-store/src/storage_backend.cpp
@@ -1330,23 +1330,20 @@ tl::expected<int64_t, ErrorCode> BucketStorageBackend::BatchOffload(
         LOG(ERROR) << "Failed to write bucket with id: " << bucket_id;
         return tl::make_unexpected(write_bucket_result.error());
     }
-    if (complete_handler != nullptr) {
-        auto error_code = complete_handler(bucket->keys, metadatas);
-        if (error_code != ErrorCode::OK) {
-            LOG(ERROR) << "Complete handler failed: " << error_code
-                       << ", Key count: " << bucket->keys.size()
-                       << ", Bucket id: " << bucket_id;
-            return tl::make_unexpected(error_code);
-        }
-    }
+    // Save a copy of bucket->keys before std::move(bucket) into buckets_
+    // consumes the shared_ptr. Needed for complete_handler and rollback.
+    const auto bucket_keys = bucket->keys;
 
-    // Commit to metadata maps under exclusive lock.
-    // Check for duplicate keys and rollback if any found.
+    // Commit to metadata maps under exclusive lock FIRST.
+    // This ensures any concurrent BatchLoad arriving after Master redirects
+    // reads to this node can find the key in object_bucket_map_.
+    // Even if complete_handler fails later, the read path is correct —
+    // RollbackCommittedBucket will undo the commit safely.
     {
         SharedMutexLocker lock(&mutex_);
 
         // Pre-check for duplicates before modifying any state
-        for (const auto& key : bucket->keys) {
+        for (const auto& key : bucket_keys) {
             if (object_bucket_map_.find(key) != object_bucket_map_.end()) {
                 LOG(WARNING)
                     << "Duplicate key detected in BatchOffload: " << key
@@ -1361,17 +1358,39 @@ tl::expected<int64_t, ErrorCode> BucketStorageBackend::BatchOffload(
         // No duplicates found, safe to commit
         total_size_ += bucket->data_size + bucket->meta_size;
         object_bucket_map_.reserve(object_bucket_map_.size() +
-                                   bucket->keys.size());
-        for (size_t i = 0; i < bucket->keys.size(); ++i) {
+                                   bucket_keys.size());
+        for (size_t i = 0; i < bucket_keys.size(); ++i) {
             auto [it, inserted] = object_bucket_map_.insert(
-                {bucket->keys[i], std::move(metadatas[i])});
+                {bucket_keys[i], std::move(metadatas[i])});
             if (!inserted) {
                 LOG(ERROR) << "Unexpected duplicate key after pre-check: "
-                           << bucket->keys[i] << ", bucket_id=" << bucket_id;
+                           << bucket_keys[i] << ", bucket_id=" << bucket_id;
             }
         }
         buckets_.emplace(bucket_id, std::move(bucket));
         lru_index_.emplace(0LL, bucket_id);
+    }
+    // Lock released. From this point forward, concurrent BatchLoad
+    // can find the keys and read from the committed bucket files.
+
+    // Notify Master AFTER local index is committed.
+    // metadatas[i] were moved-from above: int64_t fields (bucket_id, offset,
+    // key_size, data_size) survive std::move unchanged; transport_endpoint
+    // (std::string) is empty but complete_handler rewrites it before the RPC.
+    if (complete_handler != nullptr) {
+        auto error_code = complete_handler(bucket_keys, metadatas);
+        if (error_code != ErrorCode::OK) {
+            LOG(ERROR) << "Complete handler failed: " << error_code
+                       << ", Key count: " << bucket_keys.size()
+                       << ", Bucket id: " << bucket_id;
+            // Master was NOT notified. The local index has entries that
+            // Master doesn't know about — a "client can read but Master
+            // doesn't know" ghost replica. Rollback the local commit
+            // (removes index entries + waits for inflight reads + deletes
+            // on-disk files).
+            RollbackCommittedBucket(bucket_id, bucket_keys);
+            return tl::make_unexpected(error_code);
+        }
     }
 
     return bucket_id;
@@ -2153,6 +2172,14 @@ void BucketStorageBackend::CleanupOrphanedBucket(int64_t bucket_id) {
 
     auto data_path_res = GetBucketDataPath(bucket_id);
     if (data_path_res) {
+        // Evict the cached file handle before deleting the file, matching
+        // the pattern in FinalizeEviction. Without this, a subsequent open
+        // on the same path (e.g. after bucket_id reuse) may return a stale
+        // handle pointing to the now-deleted file.
+        {
+            MutexLocker cache_locker(&file_cache_mutex_);
+            file_cache_.erase(data_path_res.value());
+        }
         if (fs::remove(data_path_res.value(), ec)) {
             LOG(INFO) << "Cleaned up orphaned bucket data file: "
                       << data_path_res.value();
@@ -2175,6 +2202,97 @@ void BucketStorageBackend::CleanupOrphanedBucket(int64_t bucket_id) {
                          << ", error: " << ec.message();
         }
     }
+}
+
+void BucketStorageBackend::RollbackCommittedBucket(
+    int64_t bucket_id, const std::vector<std::string>& keys) {
+    std::shared_ptr<BucketMetadata> bucket_meta;
+
+    // Phase 1: Remove from metadata maps under exclusive lock.
+    // This prevents new readers from finding the keys.
+    {
+        SharedMutexLocker lock(&mutex_);
+
+        auto bucket_it = buckets_.find(bucket_id);
+        if (bucket_it == buckets_.end()) {
+            LOG(WARNING) << "RollbackCommittedBucket: bucket " << bucket_id
+                         << " not found in buckets_ — already removed?";
+            // Still clean up disk files in case they are orphaned
+            CleanupOrphanedBucket(bucket_id);
+            return;
+        }
+
+        // Save a reference for inflight-read waiting
+        bucket_meta = bucket_it->second;
+
+        // Remove all keys from object_bucket_map_
+        for (const auto& key : keys) {
+            auto obj_it = object_bucket_map_.find(key);
+            if (obj_it != object_bucket_map_.end() &&
+                obj_it->second.bucket_id == bucket_id) {
+                total_size_ -=
+                    obj_it->second.data_size + obj_it->second.key_size;
+                object_bucket_map_.erase(obj_it);
+            }
+        }
+
+        // Remove bucket metadata
+        total_size_ -= bucket_meta->meta_size;
+        lru_index_.erase({0LL, bucket_id});
+        buckets_.erase(bucket_it);
+    }
+
+    // Phase 2: Wait for inflight reads to drain.
+    // Readers that found the key before we removed it from the map
+    // hold a BucketReadGuard that keeps inflight_reads_ > 0.
+    // In practice this should never block: the bucket was committed and
+    // rolled back within microseconds — no reader had time to acquire a
+    // guard. But guard against the edge case anyway.
+    //
+    // Uses the same spin-then-sleep pattern as DeleteBucket (not the
+    // spin-then-yield pattern of FinalizeEviction) because rollback is a
+    // rare error-recovery path where CPU friendliness matters more than
+    // latency.
+    {
+        constexpr int kMaxSpinIterations = 1000;
+        constexpr auto kSleepDuration = std::chrono::microseconds(100);
+        constexpr auto kMaxWaitTime = std::chrono::seconds(10);
+        int spin_count = 0;
+        auto wait_start = std::chrono::steady_clock::now();
+        while (bucket_meta->inflight_reads_.load(std::memory_order_acquire) >
+               0) {
+            if (++spin_count > kMaxSpinIterations) {
+                std::this_thread::sleep_for(kSleepDuration);
+                spin_count = 0;
+                if (std::chrono::steady_clock::now() - wait_start >
+                    kMaxWaitTime) {
+                    LOG(ERROR)
+                        << "RollbackCommittedBucket: timed out waiting "
+                        << "for inflight reads on bucket " << bucket_id
+                        << " (inflight="
+                        << bucket_meta->inflight_reads_.load(
+                               std::memory_order_relaxed)
+                        << "). Leaving orphaned files on disk; they will "
+                        << "be cleaned up by Init() on next restart.";
+                    // Return WITHOUT deleting files. A reader is still
+                    // holding a guard, so deleting the files could cause
+                    // I/O errors on the read path. This matches
+                    // DeleteBucket's behavior (returns INTERNAL_ERROR
+                    // instead of deleting). The orphan will be recovered
+                    // by Init()'s orphan scan.
+                    return;
+                }
+            } else {
+                PAUSE();
+            }
+        }
+    }
+
+    // Phase 3: Delete on-disk files now that no readers remain.
+    CleanupOrphanedBucket(bucket_id);
+
+    LOG(INFO) << "RollbackCommittedBucket: rolled back bucket " << bucket_id
+              << " with " << keys.size() << " keys";
 }
 
 std::map<int64_t, std::shared_ptr<BucketMetadata>>::iterator

--- a/mooncake-store/src/storage_backend.cpp
+++ b/mooncake-store/src/storage_backend.cpp
@@ -1360,8 +1360,8 @@ tl::expected<int64_t, ErrorCode> BucketStorageBackend::BatchOffload(
         object_bucket_map_.reserve(object_bucket_map_.size() +
                                    bucket_keys.size());
         for (size_t i = 0; i < bucket_keys.size(); ++i) {
-            auto [it, inserted] = object_bucket_map_.insert(
-                {bucket_keys[i], std::move(metadatas[i])});
+            auto [it, inserted] =
+                object_bucket_map_.insert({bucket_keys[i], metadatas[i]});
             if (!inserted) {
                 LOG(ERROR) << "Unexpected duplicate key after pre-check: "
                            << bucket_keys[i] << ", bucket_id=" << bucket_id;
@@ -1374,9 +1374,9 @@ tl::expected<int64_t, ErrorCode> BucketStorageBackend::BatchOffload(
     // can find the keys and read from the committed bucket files.
 
     // Notify Master AFTER local index is committed.
-    // metadatas[i] were moved-from above: int64_t fields (bucket_id, offset,
-    // key_size, data_size) survive std::move unchanged; transport_endpoint
-    // (std::string) is empty but complete_handler rewrites it before the RPC.
+    // metadatas[i].transport_endpoint is empty here (it gets populated by
+    // complete_handler before the RPC); int64_t fields carry the metadata
+    // from BuildBucket unchanged.
     if (complete_handler != nullptr) {
         auto error_code = complete_handler(bucket_keys, metadatas);
         if (error_code != ErrorCode::OK) {

--- a/mooncake-store/tests/storage_backend_test.cpp
+++ b/mooncake-store/tests/storage_backend_test.cpp
@@ -507,6 +507,82 @@ TEST_F(StorageBackendTest, OrphanedBucketFileCleanup) {
     ASSERT_TRUE(is_exist.value());
 }
 
+TEST_F(StorageBackendTest, BatchOffloadRollbackOnCompleteHandlerFailure) {
+    std::string test_dir = data_path + "/rollback_test";
+    fs::create_directories(test_dir);
+
+    FileStorageConfig config;
+    config.storage_filepath = test_dir;
+    BucketBackendConfig bucket_config;
+    BucketStorageBackend storage_backend(config, bucket_config);
+    ASSERT_TRUE(storage_backend.Init());
+
+    std::shared_ptr<SimpleAllocator> client_buffer_allocator =
+        std::make_shared<SimpleAllocator>(128 * 1024 * 1024);
+
+    // Prepare 3 keys to verify ALL keys are rolled back, not just one
+    std::unordered_map<std::string, std::vector<Slice>> batched_slices;
+    std::vector<std::string> test_keys;
+    for (int i = 0; i < 3; ++i) {
+        std::string key = "rollback_test_key_" + std::to_string(i);
+        std::string data = "test_data_for_rollback_" + std::to_string(i);
+        void* buffer = client_buffer_allocator->allocate(data.size());
+        memcpy(buffer, data.data(), data.size());
+        batched_slices.emplace(key,
+                               std::vector<Slice>{Slice{buffer, data.size()}});
+        test_keys.push_back(key);
+    }
+
+    // Capture pre-offload state
+    auto pre_meta = storage_backend.GetStoreMetadata();
+    ASSERT_TRUE(pre_meta.has_value());
+    int64_t pre_total_size = pre_meta->total_size;
+    int64_t pre_total_keys = pre_meta->total_keys;
+
+    // Trigger rollback via failing complete_handler
+    auto offload_res = storage_backend.BatchOffload(
+        batched_slices, [](const std::vector<std::string>& keys,
+                           std::vector<StorageObjectMetadata>& metadatas) {
+            return ErrorCode::INTERNAL_ERROR;
+        });
+
+    // Assertion 1: Offload returns the handler's error
+    EXPECT_FALSE(offload_res.has_value());
+    EXPECT_EQ(offload_res.error(), ErrorCode::INTERNAL_ERROR);
+
+    // Assertion 2: All keys removed from object_bucket_map_
+    for (const auto& key : test_keys) {
+        auto exist_res = storage_backend.IsExist(key);
+        ASSERT_TRUE(exist_res.has_value());
+        EXPECT_FALSE(exist_res.value())
+            << "Key '" << key << "' should not exist after rollback";
+    }
+
+    // Assertion 3: total_size_ and total_keys restored to pre-offload values
+    auto post_meta = storage_backend.GetStoreMetadata();
+    ASSERT_TRUE(post_meta.has_value());
+    EXPECT_EQ(post_meta->total_size, pre_total_size)
+        << "total_size_ should be restored after rollback";
+    EXPECT_EQ(post_meta->total_keys, pre_total_keys)
+        << "total_keys should be restored after rollback";
+
+    // Assertions 4 & 5: Bucket files deleted from disk.
+    // The bucket ID is generated from a timestamp-based BucketIdGenerator, so
+    // we can't hardcode it. Instead, scan the test directory to confirm no
+    // .bucket or .meta files remain after rollback.
+    int bucket_file_count = 0;
+    for (const auto& entry : fs::directory_iterator(test_dir)) {
+        if (entry.is_regular_file()) {
+            std::string ext = entry.path().extension().string();
+            if (ext == ".bucket" || ext == ".meta") {
+                bucket_file_count++;
+            }
+        }
+    }
+    EXPECT_EQ(bucket_file_count, 0)
+        << "No bucket data or metadata files should remain after rollback";
+}
+
 TEST_F(StorageBackendTest, AdaptorBatchOffloadAndBatchLoad) {
     FileStorageConfig cfg;
 


### PR DESCRIPTION
## Description

Fixed #2799 .


In BucketStorageBackend::BatchOffload, commit the local index before calling NotifyOffloadSuccess. This closes the race where Master redirects reads to this node before object_bucket_map_ contains the key, causing INVALID_KEY errors.

If NotifyOffloadSuccess fails after local commit, roll back the local index via RollbackCommittedBucket: remove metadata entries, wait for in-flight reads, and clean up on-disk files. On timeout we leave the orphan files rather than risk I/O errors for active readers.

Also evict cached file handles in CleanupOrphanedBucket before deleting files to avoid stale handles.


## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue