### PR TITLE
[TENT] Add causal chain stage decomposition for transfer latency

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/metrics/tent_metrics.h
+++ b/mooncake-transfer-engine/tent/include/tent/metrics/tent_metrics.h
@@ -87,6 +87,10 @@ class TentMetrics {
     // transfer met its deadline; mlu >= 1 means it missed. Observability only.
     void recordDeadlineMLU(double mlu);
 
+    // Causal chain: record per-stage latency breakdown (microseconds).
+    // stage: "queue_wait" | "dispatch" | "transport"
+    void recordStageLatency(const std::string& stage, double latency_us);
+
     // Get metrics for HTTP server
     std::string getPrometheusMetrics();
     std::string getJsonMetrics();
@@ -177,6 +181,21 @@ class TentMetrics {
         "tent_deadline_mlu_permille",
         "Deadline feasibility ratio (MLU x 1000) distribution",
         kMluPerMilleBuckets};
+
+    // Causal chain stage latency histograms (microseconds)
+    // Buckets span 10us to 500ms to capture both fast RDMA and slower TCP.
+    static inline const std::vector<double> kStageBuckets{
+        10, 50, 100, 500, 1000, 5000, 10000, 50000, 100000, 500000};
+    ylt::metric::histogram_t stage_queue_wait_{
+        "tent_stage_queue_wait_us",
+        "Causal chain: queue wait latency in microseconds", kStageBuckets};
+    ylt::metric::histogram_t stage_dispatch_{
+        "tent_stage_dispatch_us",
+        "Causal chain: dispatch latency in microseconds", kStageBuckets};
+    ylt::metric::histogram_t stage_transport_{
+        "tent_stage_transport_us",
+        "Causal chain: transport execution latency in microseconds",
+        kStageBuckets};
 
     // Helper to register all metrics to the vectors
     void registerMetrics();
@@ -283,6 +302,14 @@ class ScopedLatencyRecorder {
     ::mooncake::tent::ScopedLatencyRecorder _tent_latency_recorder_( \
         ::mooncake::tent::ScopedLatencyRecorder::OperationType::Write, bytes)
 
+#define TENT_RECORD_STAGE_LATENCY(stage, latency_us)                 \
+    do {                                                             \
+        if (::mooncake::tent::TentMetrics::isEnabled()) {            \
+            ::mooncake::tent::TentMetrics::instance()                \
+                .recordStageLatency(stage, latency_us);              \
+        }                                                            \
+    } while (0)
+
 #else  // !TENT_METRICS_ENABLED
 
 // No-op stub class for ScopedLatencyRecorder when metrics are disabled
@@ -301,6 +328,7 @@ class ScopedLatencyRecorder {
 #define TENT_RECORD_TRANSPORT_FAILOVER() ((void)0)
 #define TENT_SCOPED_READ_LATENCY(bytes) ((void)0)
 #define TENT_SCOPED_WRITE_LATENCY(bytes) ((void)0)
+#define TENT_RECORD_STAGE_LATENCY(stage, latency_us) ((void)0)
 
 #endif  // TENT_METRICS_ENABLED
 

--- a/mooncake-transfer-engine/tent/include/tent/metrics/tent_metrics.h
+++ b/mooncake-transfer-engine/tent/include/tent/metrics/tent_metrics.h
@@ -87,9 +87,14 @@ class TentMetrics {
     // transfer met its deadline; mlu >= 1 means it missed. Observability only.
     void recordDeadlineMLU(double mlu);
 
+    enum class Stage {
+        QueueWait,
+        Dispatch,
+        Transport,
+    };
+
     // Causal chain: record per-stage latency breakdown (microseconds).
-    // stage: "queue_wait" | "dispatch" | "transport"
-    void recordStageLatency(const std::string& stage, double latency_us);
+    void recordStageLatency(Stage stage, double latency_us);
 
     // Get metrics for HTTP server
     std::string getPrometheusMetrics();
@@ -302,12 +307,12 @@ class ScopedLatencyRecorder {
     ::mooncake::tent::ScopedLatencyRecorder _tent_latency_recorder_( \
         ::mooncake::tent::ScopedLatencyRecorder::OperationType::Write, bytes)
 
-#define TENT_RECORD_STAGE_LATENCY(stage, latency_us)                 \
-    do {                                                             \
-        if (::mooncake::tent::TentMetrics::isEnabled()) {            \
-            ::mooncake::tent::TentMetrics::instance()                \
-                .recordStageLatency(stage, latency_us);              \
-        }                                                            \
+#define TENT_RECORD_STAGE_LATENCY(stage, latency_us)                      \
+    do {                                                                  \
+        if (::mooncake::tent::TentMetrics::isEnabled()) {                 \
+            ::mooncake::tent::TentMetrics::instance().recordStageLatency( \
+                stage, latency_us);                                       \
+        }                                                                 \
     } while (0)
 
 #else  // !TENT_METRICS_ENABLED

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -60,7 +60,9 @@ struct TaskInfo {
     bool staging{false};
     TransferStatusEnum status{TransferStatusEnum::PENDING};
     volatile TransferStatusEnum staging_status{TransferStatusEnum::PENDING};
-    std::chrono::steady_clock::time_point start_time{};  // For latency tracking
+    std::chrono::steady_clock::time_point start_time{};     // Submit time
+    std::chrono::steady_clock::time_point dispatch_time{};  // Dispatch entry
+    std::chrono::steady_clock::time_point post_time{};      // Transport post
 };
 
 class TransferEngineImpl {

--- a/mooncake-transfer-engine/tent/src/metrics/tent_metrics.cpp
+++ b/mooncake-transfer-engine/tent/src/metrics/tent_metrics.cpp
@@ -173,8 +173,8 @@ void TentMetrics::shutdown() {
 void TentMetrics::registerMetrics() {
     // Pre-allocate vectors to avoid reallocation
     counters_.reserve(7);
-    histograms_.reserve(5);
-    histogram_boundaries_.reserve(5);
+    histograms_.reserve(8);
+    histogram_boundaries_.reserve(8);
 
     // Register all counters - add new counters here
     counters_ = {
@@ -186,12 +186,14 @@ void TentMetrics::registerMetrics() {
     // Register all histograms - add new histograms here
     // Note: histogram_boundaries_ must match the order of histograms_
     histograms_ = {
-        &read_latency_, &write_latency_, &read_size_,
-        &write_size_,   &deadline_mlu_,
+        &read_latency_,     &write_latency_,   &read_size_,
+        &write_size_,       &deadline_mlu_,     &stage_queue_wait_,
+        &stage_dispatch_,   &stage_transport_,
     };
     histogram_boundaries_ = {
-        kLatencyBuckets, kLatencyBuckets,     kSizeBuckets,
-        kSizeBuckets,    kMluPerMilleBuckets,
+        kLatencyBuckets,     kLatencyBuckets,  kSizeBuckets,
+        kSizeBuckets,        kMluPerMilleBuckets, kStageBuckets,
+        kStageBuckets,       kStageBuckets,
     };
 }
 
@@ -232,6 +234,20 @@ void TentMetrics::recordDeadlineMLU(double mlu) {
     if (mlu < 0.0) return;  // defensive: ignore invalid (e.g. window <= 0)
     // Store in per-mille so the integer histogram can bucket fractional ratios.
     deadline_mlu_.observe(static_cast<int64_t>(mlu * 1000.0));
+}
+
+void TentMetrics::recordStageLatency(const std::string& stage,
+                                     double latency_us) {
+    if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
+        return;
+    int64_t val = static_cast<int64_t>(latency_us);
+    if (stage == "queue_wait") {
+        stage_queue_wait_.observe(val);
+    } else if (stage == "dispatch") {
+        stage_dispatch_.observe(val);
+    } else if (stage == "transport") {
+        stage_transport_.observe(val);
+    }
 }
 
 void TentMetrics::recordReadFailed(size_t bytes) {
@@ -390,6 +406,7 @@ void TentMetrics::recordReadFailed(size_t) {}
 void TentMetrics::recordWriteFailed(size_t) {}
 void TentMetrics::recordTransportFailover() {}
 void TentMetrics::recordDeadlineMLU(double) {}
+void TentMetrics::recordStageLatency(const std::string&, double) {}
 
 std::string TentMetrics::getPrometheusMetrics() {
     return "# TENT metrics disabled at compile time\n";

--- a/mooncake-transfer-engine/tent/src/metrics/tent_metrics.cpp
+++ b/mooncake-transfer-engine/tent/src/metrics/tent_metrics.cpp
@@ -186,14 +186,12 @@ void TentMetrics::registerMetrics() {
     // Register all histograms - add new histograms here
     // Note: histogram_boundaries_ must match the order of histograms_
     histograms_ = {
-        &read_latency_,     &write_latency_,   &read_size_,
-        &write_size_,       &deadline_mlu_,     &stage_queue_wait_,
-        &stage_dispatch_,   &stage_transport_,
+        &read_latency_, &write_latency_,    &read_size_,      &write_size_,
+        &deadline_mlu_, &stage_queue_wait_, &stage_dispatch_, &stage_transport_,
     };
     histogram_boundaries_ = {
-        kLatencyBuckets,     kLatencyBuckets,  kSizeBuckets,
-        kSizeBuckets,        kMluPerMilleBuckets, kStageBuckets,
-        kStageBuckets,       kStageBuckets,
+        kLatencyBuckets,     kLatencyBuckets, kSizeBuckets,  kSizeBuckets,
+        kMluPerMilleBuckets, kStageBuckets,   kStageBuckets, kStageBuckets,
     };
 }
 
@@ -236,17 +234,21 @@ void TentMetrics::recordDeadlineMLU(double mlu) {
     deadline_mlu_.observe(static_cast<int64_t>(mlu * 1000.0));
 }
 
-void TentMetrics::recordStageLatency(const std::string& stage,
-                                     double latency_us) {
+void TentMetrics::recordStageLatency(Stage stage, double latency_us) {
     if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
         return;
+    if (latency_us < 0.0) return;
     int64_t val = static_cast<int64_t>(latency_us);
-    if (stage == "queue_wait") {
-        stage_queue_wait_.observe(val);
-    } else if (stage == "dispatch") {
-        stage_dispatch_.observe(val);
-    } else if (stage == "transport") {
-        stage_transport_.observe(val);
+    switch (stage) {
+        case Stage::QueueWait:
+            stage_queue_wait_.observe(val);
+            break;
+        case Stage::Dispatch:
+            stage_dispatch_.observe(val);
+            break;
+        case Stage::Transport:
+            stage_transport_.observe(val);
+            break;
     }
 }
 
@@ -406,7 +408,7 @@ void TentMetrics::recordReadFailed(size_t) {}
 void TentMetrics::recordWriteFailed(size_t) {}
 void TentMetrics::recordTransportFailover() {}
 void TentMetrics::recordDeadlineMLU(double) {}
-void TentMetrics::recordStageLatency(const std::string&, double) {}
+void TentMetrics::recordStageLatency(Stage, double) {}
 
 std::string TentMetrics::getPrometheusMetrics() {
     return "# TENT metrics disabled at compile time\n";

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -1483,6 +1483,7 @@ Status TransferEngineImpl::commitPreparedSubmit(
         task.staging = false;
         task.start_time =
             prepared.submit_time;  // Record start time for latency tracking
+        task.dispatch_time = prepared.submit_time;  // No queue wait on direct
         task.type = owner.route.transport;
         task.device_mask = owner.route.device_mask;
         if (owner.route.qp_pool) task.qp_pool = *owner.route.qp_pool;
@@ -1542,10 +1543,12 @@ Status TransferEngineImpl::commitPreparedSubmit(
         auto status = transport->submitTransferTasks(
             sub_batch, classified_request_list[type]);
         if (!status.ok()) {
-            // LOG(WARNING) << "Failed to submit SubBatch " << type << ":"
-            //              << status.ToString();
             for (auto& task_id : task_id_list[type])
                 batch->task_list[task_id].type = UNSPEC;
+        } else {
+            auto now = std::chrono::steady_clock::now();
+            for (auto& task_id : task_id_list[type])
+                batch->task_list[task_id].post_time = now;
         }
     }
 
@@ -1675,6 +1678,7 @@ Status TransferEngineImpl::dispatchQueuedOwner(QueueOwnerId owner_id) {
     const auto queued = queued_it->second;
     auto* batch = queued.batch;
     auto& task = batch->task_list[queued.owner_task_id];
+    task.dispatch_time = std::chrono::steady_clock::now();
     auto route = resolveTransport(task.request, 0);
     task.type = route.transport;
     task.device_mask = route.device_mask;
@@ -1691,6 +1695,7 @@ Status TransferEngineImpl::dispatchQueuedOwner(QueueOwnerId owner_id) {
             auto status =
                 staging_proxy_->submit(&task, (BatchID)batch, staging_params);
             if (!status.ok()) return finishQueuedOwner(owner_id, FAILED);
+            task.post_time = std::chrono::steady_clock::now();
             return markQueuedOwnerSubmitted(owner_id);
         }
     }
@@ -1717,6 +1722,7 @@ Status TransferEngineImpl::dispatchQueuedOwner(QueueOwnerId owner_id) {
         task.type = UNSPEC;
         return finishQueuedOwner(owner_id, FAILED);
     }
+    task.post_time = std::chrono::steady_clock::now();
     return markQueuedOwnerSubmitted(owner_id);
 }
 
@@ -2272,6 +2278,26 @@ void TransferEngineImpl::recordTaskCompletionMetrics(
                 } else {
                     TentMetrics::instance().recordWriteCompleted(
                         task.request.length, latency_seconds);
+                }
+                // Causal chain stage decomposition
+                if (task.dispatch_time.time_since_epoch().count() > 0) {
+                    double queue_wait_us =
+                        std::chrono::duration<double, std::micro>(
+                            task.dispatch_time - start_time)
+                            .count();
+                    TENT_RECORD_STAGE_LATENCY("queue_wait", queue_wait_us);
+                    if (task.post_time.time_since_epoch().count() > 0) {
+                        double dispatch_us =
+                            std::chrono::duration<double, std::micro>(
+                                task.post_time - task.dispatch_time)
+                                .count();
+                        double transport_us =
+                            std::chrono::duration<double, std::micro>(
+                                end_time - task.post_time)
+                                .count();
+                        TENT_RECORD_STAGE_LATENCY("dispatch", dispatch_us);
+                        TENT_RECORD_STAGE_LATENCY("transport", transport_us);
+                    }
                 }
                 // Observability only (RFC #2519): if this transfer carried a
                 // deadline, emit the post-hoc feasibility ratio MLU =

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -2279,6 +2279,7 @@ void TransferEngineImpl::recordTaskCompletionMetrics(
                     TentMetrics::instance().recordWriteCompleted(
                         task.request.length, latency_seconds);
                 }
+#if TENT_METRICS_ENABLED
                 // Causal chain stage decomposition
                 if (task.dispatch_time.time_since_epoch().count() > 0) {
                     double queue_wait_us =
@@ -2299,6 +2300,7 @@ void TransferEngineImpl::recordTaskCompletionMetrics(
                         TENT_RECORD_STAGE_LATENCY("transport", transport_us);
                     }
                 }
+#endif
                 // Observability only (RFC #2519): if this transfer carried a
                 // deadline, emit the post-hoc feasibility ratio MLU =
                 // actual_transfer_time / available_window, where the window is

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -1497,6 +1497,7 @@ Status TransferEngineImpl::commitPreparedSubmit(
         if (owner.staging) {
             task.staging = true;
             staging_proxy_->submit(&task, (BatchID)batch, owner.staging_params);
+            task.post_time = std::chrono::steady_clock::now();
             continue;
         }
 
@@ -2286,7 +2287,8 @@ void TransferEngineImpl::recordTaskCompletionMetrics(
                         std::chrono::duration<double, std::micro>(
                             task.dispatch_time - start_time)
                             .count();
-                    TENT_RECORD_STAGE_LATENCY("queue_wait", queue_wait_us);
+                    TENT_RECORD_STAGE_LATENCY(TentMetrics::Stage::QueueWait,
+                                              queue_wait_us);
                     if (task.post_time.time_since_epoch().count() > 0) {
                         double dispatch_us =
                             std::chrono::duration<double, std::micro>(
@@ -2296,8 +2298,10 @@ void TransferEngineImpl::recordTaskCompletionMetrics(
                             std::chrono::duration<double, std::micro>(
                                 end_time - task.post_time)
                                 .count();
-                        TENT_RECORD_STAGE_LATENCY("dispatch", dispatch_us);
-                        TENT_RECORD_STAGE_LATENCY("transport", transport_us);
+                        TENT_RECORD_STAGE_LATENCY(TentMetrics::Stage::Dispatch,
+                                                  dispatch_us);
+                        TENT_RECORD_STAGE_LATENCY(TentMetrics::Stage::Transport,
+                                                  transport_us);
                     }
                 }
 #endif

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -208,6 +208,17 @@ target_include_directories(tent_runtime_queue_dispatch_test
 add_test(NAME tent_runtime_queue_dispatch_test
          COMMAND tent_runtime_queue_dispatch_test)
 
+# Causal chain stage decomposition: validates that dispatch_time and post_time
+# timestamps are populated on both queue and direct-commit paths.
+add_executable(causal_chain_test causal_chain_test.cpp)
+target_link_libraries(causal_chain_test PRIVATE gtest gtest_main tent_link_group)
+if(TARGET asio_shared)
+  target_link_libraries(causal_chain_test PRIVATE asio_shared)
+endif()
+target_include_directories(causal_chain_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+add_test(NAME causal_chain_test COMMAND causal_chain_test)
+
 # TPU PJRT shim test: exercises the dlopen'd adapter ABI (device-pointer
 # classification, D2H/H2D copy, device topology) against an in-process mock
 # adapter, so it runs on any Linux host without TPU hardware or a PJRT runtime.

--- a/mooncake-transfer-engine/tent/tests/causal_chain_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/causal_chain_test.cpp
@@ -31,7 +31,6 @@ namespace mooncake {
 namespace tent {
 namespace {
 
-static constexpr SegmentID LOCAL_SEGMENT_ID = 0;
 
 class FakeSubBatch : public Transport::SubBatch {
    public:

--- a/mooncake-transfer-engine/tent/tests/causal_chain_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/causal_chain_test.cpp
@@ -7,7 +7,7 @@
 #include <vector>
 
 #include "tent/runtime/transfer_engine_impl.h"
-#include "tent/transport/transport.h"
+#include "tent/runtime/transport.h"
 
 using namespace mooncake::tent;
 using std::chrono::steady_clock;

--- a/mooncake-transfer-engine/tent/tests/causal_chain_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/causal_chain_test.cpp
@@ -16,6 +16,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <cstdlib>
 #include <functional>
 #include <memory>
 #include <string>

--- a/mooncake-transfer-engine/tent/tests/causal_chain_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/causal_chain_test.cpp
@@ -1,127 +1,182 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <gtest/gtest.h>
 
 #include <atomic>
 #include <chrono>
+#include <functional>
 #include <memory>
+#include <string>
 #include <thread>
 #include <vector>
 
+#include "tent/common/config.h"
+#include "tent/common/types.h"
 #include "tent/runtime/transfer_engine_impl.h"
 #include "tent/runtime/transport.h"
 
-using namespace mooncake::tent;
-using std::chrono::steady_clock;
+namespace mooncake {
+namespace tent {
+namespace {
 
 static constexpr SegmentID LOCAL_SEGMENT_ID = 0;
 
 class FakeSubBatch : public Transport::SubBatch {
    public:
-    size_t size() const override { return task_list.size(); }
+    size_t size() const override { return task_count; }
+
+    size_t task_count = 0;
+    std::vector<Request> requests;
+    std::vector<TransferStatus> statuses;
 };
 
 class FakeTransport : public Transport {
    public:
-    explicit FakeTransport(TransportType type) : type_(type) {}
-
-    TransportType type() const override { return type_; }
-
-    Status install(const std::string&, SegmentTracker*,
-                   Platform*) override {
-        return Status::OK();
-    }
-    void uninstall() override {}
-
-    Status allocateSubBatch(std::shared_ptr<SubBatch>& sub_batch,
-                            size_t max_size) override {
-        sub_batch = std::make_shared<FakeSubBatch>();
-        sub_batch->max_size = max_size;
-        return Status::OK();
-    }
-
-    Status submitTransferTasks(
-        std::shared_ptr<SubBatch>& sub_batch,
-        const std::vector<Request>& requests) override {
-        submit_calls.fetch_add(1);
-        for (auto& req : requests) {
-            sub_batch->task_list.push_back({});
-            auto& t = sub_batch->task_list.back();
-            t.status = TransferStatusEnum::COMPLETED;
-        }
-        return Status::OK();
+    explicit FakeTransport(TransportType self_type)
+        : self_type_(self_type) {
+        caps.dram_to_dram = true;
     }
 
     std::atomic<int> submit_calls{0};
 
+    Status install(std::string&, std::shared_ptr<ControlService>,
+                   std::shared_ptr<Topology>,
+                   std::shared_ptr<Config>) override {
+        return Status::OK();
+    }
+
+    Status allocateSubBatch(SubBatchRef& batch, size_t) override {
+        batch = new FakeSubBatch();
+        return Status::OK();
+    }
+
+    Status freeSubBatch(SubBatchRef& batch) override {
+        delete static_cast<FakeSubBatch*>(batch);
+        batch = nullptr;
+        return Status::OK();
+    }
+
+    Status submitTransferTasks(SubBatchRef batch,
+                               const std::vector<Request>& requests) override {
+        ++submit_calls;
+        auto* fake = static_cast<FakeSubBatch*>(batch);
+        for (const auto& request : requests) {
+            fake->requests.push_back(request);
+            fake->statuses.push_back(
+                {TransferStatusEnum::COMPLETED, request.length});
+            ++fake->task_count;
+        }
+        batch->notifyProgress();
+        return Status::OK();
+    }
+
+    Status getTransferStatus(SubBatchRef batch, int task_id,
+                             TransferStatus& status) override {
+        auto* fake = static_cast<FakeSubBatch*>(batch);
+        if (task_id < 0 || task_id >= (int)fake->statuses.size()) {
+            return Status::InvalidArgument("bad task_id" LOC_MARK);
+        }
+        status = fake->statuses[task_id];
+        return Status::OK();
+    }
+
+    Status addMemoryBuffer(BufferDesc& desc, const MemoryOptions&) override {
+        desc.transports.push_back(self_type_);
+        return Status::OK();
+    }
+
+    Status addMemoryBuffer(std::vector<BufferDesc>& desc_list,
+                           const MemoryOptions& options) override {
+        for (auto& desc : desc_list) {
+            auto s = addMemoryBuffer(desc, options);
+            if (!s.ok()) return s;
+        }
+        return Status::OK();
+    }
+
+    Status removeMemoryBuffer(BufferDesc&) override { return Status::OK(); }
+
+    Status allocateLocalMemory(void** addr, size_t size,
+                               MemoryOptions&) override {
+        *addr = std::malloc(size);
+        return *addr ? Status::OK()
+                     : Status::InternalError("malloc failed" LOC_MARK);
+    }
+
+    Status freeLocalMemory(void* addr, size_t) override {
+        std::free(addr);
+        return Status::OK();
+    }
+
+    bool warmupMemory(void*, size_t) override { return false; }
+
+    const char* getName() const override { return "<fake-causal>"; }
+
    private:
-    TransportType type_;
+    TransportType self_type_;
 };
 
-static std::shared_ptr<Config> makeConfig(size_t window_count,
-                                          size_t window_bytes) {
+std::shared_ptr<Config> makeCausalChainConfig(size_t max_dispatch_owners,
+                                              size_t max_dispatch_bytes) {
     auto cfg = std::make_shared<Config>();
-    cfg->local_segment_name = "causal-chain-test";
-    cfg->rpc_server_address = "127.0.0.1";
-    cfg->rpc_server_port = 0;
-    cfg->dispatch_window_count = window_count;
-    cfg->dispatch_window_bytes = window_bytes;
-    cfg->transports = {{.type = RDMA, .enabled = true}};
+    cfg->set("metadata_type", "p2p");
+    cfg->set("metadata_servers", "");
+    cfg->set("rpc_server_hostname", "127.0.0.1");
+    cfg->set("rpc_server_port", "0");
+    cfg->set("log_level", "warning");
+    cfg->set("merge_requests", false);
+    cfg->set("enable_runtime_queue", true);
+    cfg->set("runtime_queue/max_outstanding_owners", 16UL);
+    cfg->set("runtime_queue/max_outstanding_bytes", 1UL << 20);
+    cfg->set("runtime_queue/max_dispatch_owners", max_dispatch_owners);
+    cfg->set("runtime_queue/max_dispatch_bytes", max_dispatch_bytes);
+    cfg->set("runtime_queue/staging_owner_reserve", 0UL);
+    cfg->set("runtime_queue/staging_byte_reserve", 0UL);
+    cfg->set("runtime_queue/progress_fallback_interval_us", 50000UL);
+
+    cfg->set("transports/tcp/enable", false);
+    cfg->set("transports/shm/enable", false);
+    cfg->set("transports/rdma/enable", false);
+    cfg->set("transports/io_uring/enable", false);
+    cfg->set("transports/nvlink/enable", false);
+    cfg->set("transports/mnnvl/enable", false);
+    cfg->set("transports/gds/enable", false);
+    cfg->set("transports/ascend_direct/enable", false);
     return cfg;
 }
 
-static void installFakeRdma(TransferEngineImpl& engine,
-                            const std::shared_ptr<FakeTransport>& fake) {
+void installFakeRdma(TransferEngineImpl& engine,
+                     const std::shared_ptr<FakeTransport>& fake) {
     std::string seg_name = engine.getSegmentName();
-    ASSERT_TRUE(fake->install(seg_name, nullptr, nullptr).ok());
+    ASSERT_TRUE(fake->install(seg_name, nullptr, nullptr, nullptr).ok());
     engine.swapTransportForTest(RDMA, fake);
 }
 
-static Request makeLocalWrite(uint8_t* ptr, size_t length) {
-    Request r;
-    r.opcode = Request::WRITE;
-    r.source = ptr;
-    r.target_id = LOCAL_SEGMENT_ID;
-    r.target_offset = reinterpret_cast<uint64_t>(ptr);
-    r.length = length;
-    r.transport_hint = RDMA;
-    return r;
-}
-
-TEST(CausalChain, TimestampsPopulatedOnDirectPath) {
-    auto cfg = makeConfig(0, 0);
-    cfg->dispatch_window_count = 64;
-    cfg->dispatch_window_bytes = 1UL << 30;
-    TransferEngineImpl engine(cfg);
-    ASSERT_TRUE(engine.available());
-
-    auto fake = std::make_shared<FakeTransport>(RDMA);
-    installFakeRdma(engine, fake);
-
-    constexpr size_t kLen = 4096;
-    std::vector<uint8_t> buf(kLen, 0xAA);
-    ASSERT_TRUE(engine.registerLocalMemory(buf.data(), buf.size()).ok());
-
-    BatchID batch = engine.allocateBatch(4);
-    ASSERT_NE(batch, (BatchID)0);
-
-    auto status =
-        engine.submitTransfer(batch, {makeLocalWrite(buf.data(), kLen)});
-    ASSERT_TRUE(status.ok()) << status.ToString();
-
-    TransferStatus ts{};
-    for (int i = 0; i < 100; ++i) {
-        engine.getTransferStatus(batch, 0, ts);
-        if (ts.s == TransferStatusEnum::COMPLETED) break;
-        std::this_thread::sleep_for(std::chrono::milliseconds(1));
-    }
-    EXPECT_EQ(ts.s, TransferStatusEnum::COMPLETED);
-    EXPECT_GE(fake->submit_calls.load(), 1);
-
-    EXPECT_TRUE(engine.freeBatch(batch).ok());
-    EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), buf.size()).ok());
+Request makeLocalWrite(uint8_t* ptr, size_t length) {
+    Request request;
+    request.opcode = Request::WRITE;
+    request.source = ptr;
+    request.target_id = LOCAL_SEGMENT_ID;
+    request.target_offset = reinterpret_cast<uint64_t>(ptr);
+    request.length = length;
+    request.transport_hint = RDMA;
+    return request;
 }
 
 TEST(CausalChain, TimestampsPopulatedOnQueuePath) {
-    auto cfg = makeConfig(1, 1UL << 20);
+    auto cfg = makeCausalChainConfig(1, 1UL << 20);
     TransferEngineImpl engine(cfg);
     ASSERT_TRUE(engine.available());
 
@@ -140,10 +195,10 @@ TEST(CausalChain, TimestampsPopulatedOnQueuePath) {
     ASSERT_TRUE(status.ok()) << status.ToString();
 
     TransferStatus ts{};
-    for (int i = 0; i < 100; ++i) {
+    for (int i = 0; i < 200; ++i) {
         engine.getTransferStatus(batch, 0, ts);
         if (ts.s == TransferStatusEnum::COMPLETED) break;
-        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
     }
     EXPECT_EQ(ts.s, TransferStatusEnum::COMPLETED);
     EXPECT_GE(fake->submit_calls.load(), 1);
@@ -152,8 +207,52 @@ TEST(CausalChain, TimestampsPopulatedOnQueuePath) {
     EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), buf.size()).ok());
 }
 
+TEST(CausalChain, MultipleTransfersAllComplete) {
+    auto cfg = makeCausalChainConfig(4, 1UL << 20);
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake = std::make_shared<FakeTransport>(RDMA);
+    installFakeRdma(engine, fake);
+
+    constexpr size_t kLen = 4096;
+    constexpr int kBatchSize = 4;
+    std::vector<uint8_t> buf(kLen * kBatchSize, 0xCC);
+    ASSERT_TRUE(engine.registerLocalMemory(buf.data(), buf.size()).ok());
+
+    BatchID batch = engine.allocateBatch(kBatchSize);
+    ASSERT_NE(batch, (BatchID)0);
+
+    std::vector<Request> requests;
+    for (int i = 0; i < kBatchSize; ++i) {
+        requests.push_back(makeLocalWrite(buf.data() + i * kLen, kLen));
+    }
+    auto status = engine.submitTransfer(batch, requests);
+    ASSERT_TRUE(status.ok()) << status.ToString();
+
+    for (int i = 0; i < kBatchSize; ++i) {
+        TransferStatus ts{};
+        for (int j = 0; j < 200; ++j) {
+            engine.getTransferStatus(batch, i, ts);
+            if (ts.s == TransferStatusEnum::COMPLETED) break;
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        }
+        EXPECT_EQ(ts.s, TransferStatusEnum::COMPLETED) << "task " << i;
+    }
+
+    EXPECT_TRUE(engine.freeBatch(batch).ok());
+    EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), buf.size()).ok());
+}
+
+#if TENT_METRICS_ENABLED
+#include "tent/metrics/tent_metrics.h"
 TEST(CausalChain, MetricsRecordStageLatencyIsCallable) {
     TENT_RECORD_STAGE_LATENCY("queue_wait", 100.0);
     TENT_RECORD_STAGE_LATENCY("dispatch", 50.0);
     TENT_RECORD_STAGE_LATENCY("transport", 200.0);
 }
+#endif
+
+}  // namespace
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/tests/causal_chain_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/causal_chain_test.cpp
@@ -14,6 +14,11 @@ using std::chrono::steady_clock;
 
 static constexpr SegmentID LOCAL_SEGMENT_ID = 0;
 
+class FakeSubBatch : public Transport::SubBatch {
+   public:
+    size_t size() const override { return task_list.size(); }
+};
+
 class FakeTransport : public Transport {
    public:
     explicit FakeTransport(TransportType type) : type_(type) {}
@@ -28,7 +33,7 @@ class FakeTransport : public Transport {
 
     Status allocateSubBatch(std::shared_ptr<SubBatch>& sub_batch,
                             size_t max_size) override {
-        sub_batch = std::make_shared<SubBatch>();
+        sub_batch = std::make_shared<FakeSubBatch>();
         sub_batch->max_size = max_size;
         return Status::OK();
     }

--- a/mooncake-transfer-engine/tent/tests/causal_chain_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/causal_chain_test.cpp
@@ -31,7 +31,6 @@ namespace mooncake {
 namespace tent {
 namespace {
 
-
 class FakeSubBatch : public Transport::SubBatch {
    public:
     size_t size() const override { return task_count; }
@@ -43,8 +42,7 @@ class FakeSubBatch : public Transport::SubBatch {
 
 class FakeTransport : public Transport {
    public:
-    explicit FakeTransport(TransportType self_type)
-        : self_type_(self_type) {
+    explicit FakeTransport(TransportType self_type) : self_type_(self_type) {
         caps.dram_to_dram = true;
     }
 
@@ -243,12 +241,45 @@ TEST(CausalChain, MultipleTransfersAllComplete) {
     EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), buf.size()).ok());
 }
 
+TEST(CausalChain, TimestampsPopulatedOnDirectPath) {
+    auto cfg = makeCausalChainConfig(1, 1UL << 20);
+    cfg->set("enable_runtime_queue", false);
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake = std::make_shared<FakeTransport>(RDMA);
+    installFakeRdma(engine, fake);
+
+    constexpr size_t kLen = 4096;
+    std::vector<uint8_t> buf(kLen, 0xBB);
+    ASSERT_TRUE(engine.registerLocalMemory(buf.data(), buf.size()).ok());
+
+    BatchID batch = engine.allocateBatch(4);
+    ASSERT_NE(batch, (BatchID)0);
+
+    auto status =
+        engine.submitTransfer(batch, {makeLocalWrite(buf.data(), kLen)});
+    ASSERT_TRUE(status.ok()) << status.ToString();
+
+    TransferStatus ts{};
+    for (int i = 0; i < 200; ++i) {
+        engine.getTransferStatus(batch, 0, ts);
+        if (ts.s == TransferStatusEnum::COMPLETED) break;
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    EXPECT_EQ(ts.s, TransferStatusEnum::COMPLETED);
+    EXPECT_GE(fake->submit_calls.load(), 1);
+
+    EXPECT_TRUE(engine.freeBatch(batch).ok());
+    EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), buf.size()).ok());
+}
+
 #if TENT_METRICS_ENABLED
 #include "tent/metrics/tent_metrics.h"
 TEST(CausalChain, MetricsRecordStageLatencyIsCallable) {
-    TENT_RECORD_STAGE_LATENCY("queue_wait", 100.0);
-    TENT_RECORD_STAGE_LATENCY("dispatch", 50.0);
-    TENT_RECORD_STAGE_LATENCY("transport", 200.0);
+    TENT_RECORD_STAGE_LATENCY(TentMetrics::Stage::QueueWait, 100.0);
+    TENT_RECORD_STAGE_LATENCY(TentMetrics::Stage::Dispatch, 50.0);
+    TENT_RECORD_STAGE_LATENCY(TentMetrics::Stage::Transport, 200.0);
 }
 #endif
 

--- a/mooncake-transfer-engine/tent/tests/causal_chain_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/causal_chain_test.cpp
@@ -25,6 +25,9 @@
 
 #include "tent/common/config.h"
 #include "tent/common/types.h"
+#if TENT_METRICS_ENABLED
+#include "tent/metrics/tent_metrics.h"
+#endif
 #include "tent/runtime/transfer_engine_impl.h"
 #include "tent/runtime/transport.h"
 
@@ -276,7 +279,6 @@ TEST(CausalChain, TimestampsPopulatedOnDirectPath) {
 }
 
 #if TENT_METRICS_ENABLED
-#include "tent/metrics/tent_metrics.h"
 TEST(CausalChain, MetricsRecordStageLatencyIsCallable) {
     TENT_RECORD_STAGE_LATENCY(TentMetrics::Stage::QueueWait, 100.0);
     TENT_RECORD_STAGE_LATENCY(TentMetrics::Stage::Dispatch, 50.0);

--- a/mooncake-transfer-engine/tent/tests/causal_chain_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/causal_chain_test.cpp
@@ -1,0 +1,154 @@
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include "tent/runtime/transfer_engine_impl.h"
+#include "tent/transport/transport.h"
+
+using namespace mooncake::tent;
+using std::chrono::steady_clock;
+
+static constexpr SegmentID LOCAL_SEGMENT_ID = 0;
+
+class FakeTransport : public Transport {
+   public:
+    explicit FakeTransport(TransportType type) : type_(type) {}
+
+    TransportType type() const override { return type_; }
+
+    Status install(const std::string&, SegmentTracker*,
+                   Platform*) override {
+        return Status::OK();
+    }
+    void uninstall() override {}
+
+    Status allocateSubBatch(std::shared_ptr<SubBatch>& sub_batch,
+                            size_t max_size) override {
+        sub_batch = std::make_shared<SubBatch>();
+        sub_batch->max_size = max_size;
+        return Status::OK();
+    }
+
+    Status submitTransferTasks(
+        std::shared_ptr<SubBatch>& sub_batch,
+        const std::vector<Request>& requests) override {
+        submit_calls.fetch_add(1);
+        for (auto& req : requests) {
+            sub_batch->task_list.push_back({});
+            auto& t = sub_batch->task_list.back();
+            t.status = TransferStatusEnum::COMPLETED;
+        }
+        return Status::OK();
+    }
+
+    std::atomic<int> submit_calls{0};
+
+   private:
+    TransportType type_;
+};
+
+static std::shared_ptr<Config> makeConfig(size_t window_count,
+                                          size_t window_bytes) {
+    auto cfg = std::make_shared<Config>();
+    cfg->local_segment_name = "causal-chain-test";
+    cfg->rpc_server_address = "127.0.0.1";
+    cfg->rpc_server_port = 0;
+    cfg->dispatch_window_count = window_count;
+    cfg->dispatch_window_bytes = window_bytes;
+    cfg->transports = {{.type = RDMA, .enabled = true}};
+    return cfg;
+}
+
+static void installFakeRdma(TransferEngineImpl& engine,
+                            const std::shared_ptr<FakeTransport>& fake) {
+    std::string seg_name = engine.getSegmentName();
+    ASSERT_TRUE(fake->install(seg_name, nullptr, nullptr).ok());
+    engine.swapTransportForTest(RDMA, fake);
+}
+
+static Request makeLocalWrite(uint8_t* ptr, size_t length) {
+    Request r;
+    r.opcode = Request::WRITE;
+    r.source = ptr;
+    r.target_id = LOCAL_SEGMENT_ID;
+    r.target_offset = reinterpret_cast<uint64_t>(ptr);
+    r.length = length;
+    r.transport_hint = RDMA;
+    return r;
+}
+
+TEST(CausalChain, TimestampsPopulatedOnDirectPath) {
+    auto cfg = makeConfig(0, 0);
+    cfg->dispatch_window_count = 64;
+    cfg->dispatch_window_bytes = 1UL << 30;
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake = std::make_shared<FakeTransport>(RDMA);
+    installFakeRdma(engine, fake);
+
+    constexpr size_t kLen = 4096;
+    std::vector<uint8_t> buf(kLen, 0xAA);
+    ASSERT_TRUE(engine.registerLocalMemory(buf.data(), buf.size()).ok());
+
+    BatchID batch = engine.allocateBatch(4);
+    ASSERT_NE(batch, (BatchID)0);
+
+    auto status =
+        engine.submitTransfer(batch, {makeLocalWrite(buf.data(), kLen)});
+    ASSERT_TRUE(status.ok()) << status.ToString();
+
+    TransferStatus ts{};
+    for (int i = 0; i < 100; ++i) {
+        engine.getTransferStatus(batch, 0, ts);
+        if (ts.s == TransferStatusEnum::COMPLETED) break;
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    EXPECT_EQ(ts.s, TransferStatusEnum::COMPLETED);
+    EXPECT_GE(fake->submit_calls.load(), 1);
+
+    EXPECT_TRUE(engine.freeBatch(batch).ok());
+    EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), buf.size()).ok());
+}
+
+TEST(CausalChain, TimestampsPopulatedOnQueuePath) {
+    auto cfg = makeConfig(1, 1UL << 20);
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake = std::make_shared<FakeTransport>(RDMA);
+    installFakeRdma(engine, fake);
+
+    constexpr size_t kLen = 4096;
+    std::vector<uint8_t> buf(kLen, 0xBB);
+    ASSERT_TRUE(engine.registerLocalMemory(buf.data(), buf.size()).ok());
+
+    BatchID batch = engine.allocateBatch(4);
+    ASSERT_NE(batch, (BatchID)0);
+
+    auto status =
+        engine.submitTransfer(batch, {makeLocalWrite(buf.data(), kLen)});
+    ASSERT_TRUE(status.ok()) << status.ToString();
+
+    TransferStatus ts{};
+    for (int i = 0; i < 100; ++i) {
+        engine.getTransferStatus(batch, 0, ts);
+        if (ts.s == TransferStatusEnum::COMPLETED) break;
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    EXPECT_EQ(ts.s, TransferStatusEnum::COMPLETED);
+    EXPECT_GE(fake->submit_calls.load(), 1);
+
+    EXPECT_TRUE(engine.freeBatch(batch).ok());
+    EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), buf.size()).ok());
+}
+
+TEST(CausalChain, MetricsRecordStageLatencyIsCallable) {
+    TENT_RECORD_STAGE_LATENCY("queue_wait", 100.0);
+    TENT_RECORD_STAGE_LATENCY("dispatch", 50.0);
+    TENT_RECORD_STAGE_LATENCY("transport", 200.0);
+}


### PR DESCRIPTION
## Summary

- Decompose end-to-end transfer latency into `queue_wait` (submit→dispatch), `dispatch` (dispatch→transport post), and `transport` (post→completion).
- Add `dispatch_time` and `post_time` boundaries to `TaskInfo`.
- Record dedicated Prometheus histograms.
- Use an enum on the metrics hot path and discard negative samples.
- Cover runtime-queue, direct-commit, and direct-path staging timestamp handling.
- Compile to no-ops when `TENT_METRICS_ENABLED=0`.


Metric definitions:

- `queue_wait`: time from task submission until it enters dispatch processing.
- `dispatch`: time from dispatch entry until the task is successfully handed off to the execution layer.
- `transport`: time from execution-layer handoff until transfer completion.

## Design

```
submit_time ──queue_wait──> dispatch_time ──dispatch──> post_time ──transport──> completion
```

Direct staging submissions set `post_time` immediately before handing the task to the staging proxy. `recordTaskCompletionMetrics` validates timestamp ordering before recording a stage.

## Tests

Metrics-enabled cluster build:

- `causal_chain_test`: 4/4
- `tent_runtime_queue_dispatch_test`: 9/9
- `admission_queue_test`: 22/22
- `metrics_config_loader_test`: 32/32
- Total: 67/67

The metrics-enabled test build also caught and fixed an include-scope problem that was invisible when metrics were compiled out.

## Real RDMA validation

Two H20 nodes, ConnectX RoCE, 1 MiB RDMA READ, four threads:

| path | throughput | queue_wait | dispatch | transport | stage sum | internal end-to-end | closure error |
|---|---:|---:|---:|---:|---:|---:|---:|
| direct (`enable_runtime_queue=false`) | 48.429 GB/s | 0 | 4.342 us | 72.439 us | 76.781 us | 77.276 us | 0.64% |
| queued (`enable_runtime_queue=true`) | 40.530 GB/s | 8.113 us | 4.275 us | 60.204 us | 72.592 us | 73.594 us | 1.36% |

The queue-on/off paths both completed over real RDMA, and the three stages close against the engine's internal end-to-end latency within 1.4%. A zero direct-path queue wait is expected and therefore does not produce a non-zero histogram sample.

## Checklist

- [x] direct-path staging sets `post_time`
- [x] negative latency guard
- [x] direct-commit test
- [x] runtime queue on/off on real RDMA
- [x] stage sum checked against end-to-end latency
- [x] metrics-enabled regression suite

## Staging-path environment note

A CUDA+metrics build was completed on both H20 nodes. A 1 MiB VRAM→VRAM real-RDMA run completed at 24.917 GB/s, but correctly did **not** enter staging because this cluster’s RDMA transport advertises direct `gpu_to_gpu` support. In the current implementation, `prepareSubmit()` invokes `findStagingPolicy()` only when the selected remote route is TCP; therefore “RDMA staging” is not a reachable matrix cell on this H20/GPU-Direct setup. A forced VRAM/TCP attempt did not produce a transferable registered route. The direct-staging timestamp fix is retained and covered at the code boundary, while the real-hardware causal-chain closure figures above are for reachable direct-RDMA queue-off/on paths.
