### PR TITLE
[Store] feat: expose client metrics HTTP config to Python

### DIFF
--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -652,9 +652,11 @@ Arguments of `MooncakeDistributedStore.setup(...)`:
 | `enable_ssd_offload` | bool | `false` | *(advanced)* Enable client-side SSD offload |
 | `ssd_offload_path` | str | empty | *(advanced)* SSD offload directory |
 | `tenant_id` | str | `default` | *(advanced)* Tenant identifier |
+| `enable_client_http_server` | bool | `false` | Enable the client-side HTTP `/health`, `/metrics`, and `/metrics/summary` endpoints |
+| `client_http_port` | int | `9300` | Client-side HTTP endpoint port, used only when `enable_client_http_server=true` |
 
 ```{note}
-The first seven arguments have **no Python default** — the C++ defaults are not exposed by the pybind binding, so they must all be supplied (a bare `setup(local_hostname, metadata_server)` raises `TypeError`). Only `engine` / `enable_ssd_offload` / `ssd_offload_path` / `tenant_id` are optional. Also, in Method A the `MOONCAKE_*` variables used by `MooncakeConfig` are ignored; low-level runtime variables such as the `MC_*` engine variables below are still read by the C++ client.
+The first seven arguments have **no Python default** — the C++ defaults are not exposed by the pybind binding, so they must all be supplied (a bare `setup(local_hostname, metadata_server)` raises `TypeError`). The later arguments (`engine`, SSD offload fields, `tenant_id`, and client HTTP endpoint fields) are optional. Also, in Method A the `MOONCAKE_*` variables used by `MooncakeConfig` are ignored; low-level runtime variables such as the `MC_*` engine variables below are still read by the C++ client.
 ```
 
 ### Method B — Service / Integration (`MOONCAKE_*` + CLI)
@@ -681,6 +683,8 @@ The store service CLI only accepts `--config`, `-D/--define`, `--port`, and `--m
 | `MOONCAKE_OFFLOAD_ENABLED` | `enable_ssd_offload` | `false` | Client-side SSD offload |
 | `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH` | `ssd_offload_path` | empty | Offload directory |
 | `MOONCAKE_TENANT_ID` | `tenant_id` | `default` | Tenant identifier |
+| `MOONCAKE_ENABLE_CLIENT_HTTP_SERVER` | `enable_client_http_server` | `false` | Enable client-side `/health`, `/metrics`, and `/metrics/summary` endpoints |
+| `MOONCAKE_CLIENT_HTTP_PORT` | `client_http_port` | `9300` | Client-side HTTP endpoint port |
 | `MOONCAKE_CONFIG_PATH` | — | unset | Path to a JSON config file (takes precedence over the variables above) |
 
 ```{note}
@@ -712,7 +716,9 @@ Or via a JSON config file. The service also exposes a lightweight HTTP API (on `
   "protocol": "tcp",
   "device_name": "",
   "master_server_address": "127.0.0.1:50051",
-  "tenant_id": "default"
+  "tenant_id": "default",
+  "enable_client_http_server": false,
+  "client_http_port": 9300
 }
 ```
 
@@ -746,6 +752,38 @@ mooncake_client \
 | `--tenant_id` | `default` | Tenant identifier |
 | `--enable_offload` | `false` | Enable client-side SSD offload |
 | `--start_offload_rpc_server` | `true` | Start the offload RPC server for dummy clients |
+| `--enable_http_server` | `false` | Enable client-side `/health`, `/metrics`, and `/metrics/summary` endpoints |
+| `--http_port` | `9300` | Client-side HTTP endpoint port |
+
+### Client HTTP Health and Metrics Endpoint
+
+Each real client can expose its own lightweight HTTP endpoint independently of the master admin HTTP server and the Python store REST API. This endpoint is disabled by default for programmatic clients and `mooncake_store_service`; enable it explicitly when you want to scrape client-local metrics:
+
+```python
+store.setup(
+    local_hostname,
+    metadata_server,
+    global_segment_size,
+    local_buffer_size,
+    protocol,
+    rdma_devices,
+    master_server_addr,
+    enable_client_http_server=True,
+    client_http_port=9300,
+)
+```
+
+For `mooncake_store_service`, use `MOONCAKE_ENABLE_CLIENT_HTTP_SERVER=true` and optionally `MOONCAKE_CLIENT_HTTP_PORT=<port>`, or set the same fields in the JSON config. For `mooncake_client`, use `--enable_http_server=true --http_port=<port>`.
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /health` | Client health check |
+| `GET /metrics` | Prometheus-format client metrics |
+| `GET /metrics/summary` | Human-readable client metrics summary |
+
+```{note}
+`MC_STORE_CLIENT_METRIC` controls whether client metrics are collected. If the client HTTP server is enabled but `MC_STORE_CLIENT_METRIC=0`, `/metrics` and `/metrics/summary` return HTTP 503 with `metrics not available`.
+```
 
 ### Engine Runtime Tuning (`MC_*`)
 

--- a/docs/source/getting_started/observability.md
+++ b/docs/source/getting_started/observability.md
@@ -165,3 +165,46 @@ The admin HTTP server is configured in the master config file (`master.json` or 
 ```
 
 Set `enable_metric_reporting` to `false` to disable the periodic metrics log. HTTP endpoints (`/metrics`, `/health`, etc.) remain available regardless of this setting.
+
+## Client Metrics Endpoint
+
+Mooncake clients can also expose a client-local HTTP endpoint for health checks
+and client metrics. This is separate from the master admin endpoint above and is
+disabled by default for Python/programmatic clients.
+
+Enable it through the Python setup arguments:
+
+```python
+store.setup(
+    local_hostname,
+    metadata_server,
+    global_segment_size,
+    local_buffer_size,
+    protocol,
+    rdma_devices,
+    master_server_addr,
+    enable_client_http_server=True,
+    client_http_port=9300,
+)
+```
+
+For `mooncake.mooncake_store_service`, set
+`MOONCAKE_ENABLE_CLIENT_HTTP_SERVER=true` and optionally
+`MOONCAKE_CLIENT_HTTP_PORT=<port>`. For the standalone `mooncake_client`, use
+`--enable_http_server=true --http_port=<port>`.
+
+| Endpoint | Content-Type | Description |
+|----------|--------------|-------------|
+| `GET /health` | `application/json` | Client health check |
+| `GET /metrics` | `text/plain; version=0.0.4` | Prometheus-format client metrics |
+| `GET /metrics/summary` | `text/plain` | Human-readable client metrics summary |
+
+```bash
+curl http://<client-host>:9300/health
+curl http://<client-host>:9300/metrics
+curl http://<client-host>:9300/metrics/summary
+```
+
+Set `MC_STORE_CLIENT_METRIC=0` to disable client metric collection. If the
+client HTTP server remains enabled while metrics are disabled, `/metrics` and
+`/metrics/summary` return HTTP 503 with `metrics not available`.

--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -2117,7 +2117,9 @@ PYBIND11_MODULE(store, m) {
                const py::object &engine = py::none(),
                bool enable_ssd_offload = false,
                const std::string &ssd_offload_path = "",
-               const std::string &tenant_id = "default") {
+               const std::string &tenant_id = "default",
+               bool enable_client_http_server = false,
+               int client_http_port = DEFAULT_CLIENT_HTTP_PORT) {
                 auto real_client = self.init_real_client();
                 std::shared_ptr<mooncake::TransferEngine> transfer_engine =
                     nullptr;
@@ -2129,14 +2131,17 @@ PYBIND11_MODULE(store, m) {
                     local_hostname, metadata_server, global_segment_size,
                     local_buffer_size, protocol, rdma_devices,
                     master_server_addr, transfer_engine, "", enable_ssd_offload,
-                    ssd_offload_path, tenant_id);
+                    ssd_offload_path, tenant_id, enable_client_http_server,
+                    client_http_port);
             },
             py::arg("local_hostname"), py::arg("metadata_server"),
             py::arg("global_segment_size"), py::arg("local_buffer_size"),
             py::arg("protocol"), py::arg("rdma_devices"),
             py::arg("master_server_addr"), py::arg("engine") = py::none(),
             py::arg("enable_ssd_offload") = false,
-            py::arg("ssd_offload_path") = "", py::arg("tenant_id") = "default")
+            py::arg("ssd_offload_path") = "", py::arg("tenant_id") = "default",
+            py::arg("enable_client_http_server") = false,
+            py::arg("client_http_port") = DEFAULT_CLIENT_HTTP_PORT)
         .def(
             "setup",
             [](MooncakeStorePyWrapper &self, const py::dict &config_dict) {
@@ -2168,7 +2173,10 @@ PYBIND11_MODULE(store, m) {
             "  enable_ssd_offload: Enable SSD offload (default false).\n"
             "  ssd_offload_path: SSD storage directory path (overrides env "
             "var).\n"
-            "  tenant_id: Tenant identifier (default 'default').")
+            "  tenant_id: Tenant identifier (default 'default').\n"
+            "  enable_client_http_server: Enable client HTTP endpoints "
+            "(default false).\n"
+            "  client_http_port: Client HTTP metrics port (default 9300).")
         .def(
             "setup_dummy",
             [](MooncakeStorePyWrapper &self, size_t mem_pool_size,

--- a/mooncake-store/include/client_metric.h
+++ b/mooncake-store/include/client_metric.h
@@ -23,11 +23,12 @@ namespace mooncake {
 // Tuned for RDMA: fine-grained in <1ms, with ms-scale tail up to 1s
 const std::vector<double> kLatencyBucket = {
     // sub-ms to 1ms region
-    125, 150, 200, 250, 300, 400, 500, 750, 1000,
+    50, 75, 125, 150, 200, 250, 300, 400, 500, 750, 1000,
     // ms-level tail for batch/occasional spikes
     1500, 2000, 3000, 5000, 7000, 15000, 20000,
     // safeguards for long tails
-    50000, 100000, 200000, 500000, 1000000};
+    50000, 100000, 200000, 500000, 1000000, 2000000, 5000000, 10000000,
+    20000000};
 
 static inline std::string get_env_or_default(
     const char* env_var, const std::string& default_val = "") {

--- a/mooncake-store/include/dummy_client.h
+++ b/mooncake-store/include/dummy_client.h
@@ -30,7 +30,9 @@ class DummyClient : public PyClient {
                    const std::string &ipc_socket_path,
                    bool enable_ssd_offload = false,
                    const std::string &ssd_offload_path = "",
-                   const std::string &tenant_id = "default") {
+                   const std::string &tenant_id = "default",
+                   bool enable_client_http_server = false,
+                   int client_http_port = DEFAULT_CLIENT_HTTP_PORT) {
         // Dummy client does not support real setup
         return -1;
     };

--- a/mooncake-store/include/pyclient.h
+++ b/mooncake-store/include/pyclient.h
@@ -225,7 +225,9 @@ class PyClient {
         const std::shared_ptr<TransferEngine> &transfer_engine,
         const std::string &ipc_socket_path, bool enable_ssd_offload = false,
         const std::string &ssd_offload_path = "",
-        const std::string &tenant_id = "default") = 0;
+        const std::string &tenant_id = "default",
+        bool enable_client_http_server = false,
+        int client_http_port = DEFAULT_CLIENT_HTTP_PORT) = 0;
 
     virtual int setup_dummy(size_t mem_pool_size, size_t local_buffer_size,
                             const std::string &server_address,

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -89,7 +89,9 @@ class RealClient : public PyClient {
         const std::string &ipc_socket_path = "",
         bool enable_ssd_offload = false,
         const std::string &ssd_offload_path = "",
-        const std::string &tenant_id = "default");
+        const std::string &tenant_id = "default",
+        bool enable_client_http_server = false,
+        int client_http_port = DEFAULT_CLIENT_HTTP_PORT);
 
     int setup_dummy(size_t mem_pool_size, size_t local_buffer_size,
                     const std::string &server_address,
@@ -511,7 +513,9 @@ class RealClient : public PyClient {
         const std::string &ipc_socket_path = "", int local_rpc_port = 50052,
         bool enable_ssd_offload = false, bool start_offload_rpc_server = false,
         const std::string &ssd_offload_path = "",
-        const std::string &tenant_id = "default");
+        const std::string &tenant_id = "default",
+        bool enable_client_http_server = false,
+        int client_http_port = DEFAULT_CLIENT_HTTP_PORT);
 
     // Overload that accepts a configuration dictionary
     tl::expected<void, ErrorCode> setup_internal(const ConfigDict &config);
@@ -909,7 +913,7 @@ class RealClient : public PyClient {
     int stop_ipc_server();
     // Embedded HTTP server for health-check / metrics
     std::unique_ptr<coro_http::coro_http_server> http_server_;
-    int start_http_server();
+    int start_http_server(int port);
     void stop_http_server();
 
     void handle_ipc_shm_register(UdsConnection &connection);

--- a/mooncake-store/include/types.h
+++ b/mooncake-store/include/types.h
@@ -216,12 +216,16 @@ constexpr const char* CONFIG_KEY_RDMA_DEVICES = "rdma_devices";
 constexpr const char* CONFIG_KEY_MASTER_SERVER_ADDR = "master_server_addr";
 constexpr const char* CONFIG_KEY_IPC_SOCKET_PATH = "ipc_socket_path";
 constexpr const char* CONFIG_KEY_TENANT_ID = "tenant_id";
+constexpr const char* CONFIG_KEY_ENABLE_CLIENT_HTTP_SERVER =
+    "enable_client_http_server";
+constexpr const char* CONFIG_KEY_CLIENT_HTTP_PORT = "client_http_port";
 
 // Store client configuration defaults
 static constexpr size_t DEFAULT_GLOBAL_SEGMENT_SIZE = 1024 * 1024 * 16;  // 16MB
 static constexpr size_t DEFAULT_LOCAL_BUFFER_SIZE = 1024 * 1024 * 16;    // 16MB
 constexpr const char* DEFAULT_PROTOCOL = "tcp";
 constexpr const char* DEFAULT_MASTER_SERVER_ADDR = "127.0.0.1:50051";
+static constexpr int DEFAULT_CLIENT_HTTP_PORT = 9300;
 
 // Original: returns a new string (copies when tenant_id is non-empty).
 // Kept for backward compatibility with callers that need an owned string.

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -626,7 +626,8 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
     const std::shared_ptr<TransferEngine> &transfer_engine,
     const std::string &ipc_socket_path, int local_rpc_port,
     bool enable_ssd_offload, bool start_offload_rpc_server,
-    const std::string &ssd_offload_path, const std::string &tenant_id) {
+    const std::string &ssd_offload_path, const std::string &tenant_id,
+    bool enable_client_http_server, int client_http_port) {
     this->protocol = protocol;
     this->ipc_socket_path_ = ipc_socket_path;
     const bool should_use_hugepage =
@@ -935,10 +936,20 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
         }
     }
     client_requester_ = std::make_shared<ClientRequester>();
-    if (FLAGS_enable_http_server) {
-        if (start_http_server() != 0) {
-            LOG(ERROR) << "Failed to start HTTP server on port "
-                       << FLAGS_http_port;
+    const bool should_start_http_server =
+        enable_client_http_server || FLAGS_enable_http_server;
+    const int selected_http_port =
+        enable_client_http_server ? client_http_port : FLAGS_http_port;
+    if (should_start_http_server) {
+        if (selected_http_port <= 0 || selected_http_port > 65535) {
+            LOG(ERROR) << "Invalid client HTTP server port: "
+                       << selected_http_port;
+            return tl::unexpected(ErrorCode::INVALID_PARAMS);
+        }
+        if (start_http_server(selected_http_port) != 0) {
+            LOG(WARNING) << "Failed to start client HTTP server on port "
+                         << selected_http_port
+                         << "; continuing without HTTP endpoints";
         }
     }
 
@@ -952,12 +963,13 @@ int RealClient::setup_real(
     const std::string &master_server_addr,
     const std::shared_ptr<TransferEngine> &transfer_engine,
     const std::string &ipc_socket_path, bool enable_ssd_offload,
-    const std::string &ssd_offload_path, const std::string &tenant_id) {
+    const std::string &ssd_offload_path, const std::string &tenant_id,
+    bool enable_client_http_server, int client_http_port) {
     return to_py_ret(setup_internal(
         local_hostname, metadata_server, global_segment_size, local_buffer_size,
         protocol, rdma_devices, master_server_addr, transfer_engine,
         ipc_socket_path, 50052, enable_ssd_offload, true, ssd_offload_path,
-        tenant_id));
+        tenant_id, enable_client_http_server, client_http_port));
 }
 
 namespace {
@@ -983,6 +995,54 @@ inline std::optional<size_t> get_config_size(const ConfigDict &config,
         return std::nullopt;
     }
     return static_cast<size_t>(parsed_size_opt.value());
+}
+
+inline bool get_config_bool(const ConfigDict &config, const std::string &key,
+                            bool default_value) {
+    auto it = config.find(key);
+    if (it == config.end()) {
+        return default_value;
+    }
+
+    std::string value = it->second;
+    std::transform(value.begin(), value.end(), value.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    if (value == "true" || value == "1" || value == "yes" || value == "on" ||
+        value == "enable") {
+        return true;
+    }
+    if (value == "false" || value == "0" || value == "no" || value == "off" ||
+        value == "disable") {
+        return false;
+    }
+
+    LOG(WARNING) << "Invalid boolean value for config key '" << key
+                 << "': " << it->second << ", using default: " << default_value;
+    return default_value;
+}
+
+inline std::optional<int> get_config_int(const ConfigDict &config,
+                                         const std::string &key,
+                                         int default_value) {
+    auto it = config.find(key);
+    if (it == config.end()) {
+        return default_value;
+    }
+
+    try {
+        size_t pos = 0;
+        int value = std::stoi(it->second, &pos);
+        if (pos != it->second.size()) {
+            LOG(ERROR) << "Invalid integer value for config key '" << key
+                       << "': " << it->second;
+            return std::nullopt;
+        }
+        return value;
+    } catch (const std::exception &) {
+        LOG(ERROR) << "Invalid integer value for config key '" << key
+                   << "': " << it->second;
+        return std::nullopt;
+    }
 }
 }  // namespace
 
@@ -1054,19 +1114,22 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
 
     std::string ssd_offload_path = get_config(config, "ssd_offload_path");
     std::string tenant_id = get_config(config, CONFIG_KEY_TENANT_ID, "default");
-
-    std::string enable_ssd_offload_str =
-        get_config(config, "enable_ssd_offload", "false");
-    std::transform(enable_ssd_offload_str.begin(), enable_ssd_offload_str.end(),
-                   enable_ssd_offload_str.begin(),
-                   [](unsigned char c) { return std::tolower(c); });
     bool enable_ssd_offload =
-        (enable_ssd_offload_str == "true" || enable_ssd_offload_str == "1");
+        get_config_bool(config, "enable_ssd_offload", false);
+    bool enable_client_http_server =
+        get_config_bool(config, CONFIG_KEY_ENABLE_CLIENT_HTTP_SERVER, false);
+    auto client_http_port_opt = get_config_int(
+        config, CONFIG_KEY_CLIENT_HTTP_PORT, DEFAULT_CLIENT_HTTP_PORT);
+    if (!client_http_port_opt.has_value()) {
+        return tl::unexpected(ErrorCode::INVALID_PARAMS);
+    }
+    int client_http_port = client_http_port_opt.value();
 
-    return setup_internal(
-        local_hostname, metadata_server, global_segment_size, local_buffer_size,
-        protocol, rdma_devices, master_server_addr, nullptr, ipc_socket_path,
-        50052, enable_ssd_offload, true, ssd_offload_path, tenant_id);
+    return setup_internal(local_hostname, metadata_server, global_segment_size,
+                          local_buffer_size, protocol, rdma_devices,
+                          master_server_addr, nullptr, ipc_socket_path, 50052,
+                          enable_ssd_offload, true, ssd_offload_path, tenant_id,
+                          enable_client_http_server, client_http_port);
 }
 
 tl::expected<void, ErrorCode> RealClient::initAll_internal(
@@ -1594,11 +1657,15 @@ int RealClient::health_check() {
     return HC_HEALTHY;
 }
 
-int RealClient::start_http_server() {
+int RealClient::start_http_server(int port) {
     using namespace coro_http;
 
-    http_server_ =
-        std::make_unique<coro_http_server>(/*thread_num=*/1, FLAGS_http_port);
+    if (http_server_) {
+        LOG(WARNING) << "Client HTTP server is already running";
+        return 0;
+    }
+
+    http_server_ = std::make_unique<coro_http_server>(/*thread_num=*/1, port);
 
     http_server_->set_http_handler<GET>(
         "/health", [this](coro_http_request &req, coro_http_response &resp) {
@@ -1664,11 +1731,11 @@ int RealClient::start_http_server() {
 
     auto ec = http_server_->async_start();
     if (ec.hasResult()) {
-        LOG(ERROR) << "Failed to start HTTP server on port " << FLAGS_http_port;
+        LOG(WARNING) << "Failed to start HTTP server on port " << port;
         http_server_.reset();
         return -1;
     }
-    LOG(INFO) << "Client HTTP server started on port " << FLAGS_http_port;
+    LOG(INFO) << "Client HTTP server started on port " << port;
     return 0;
 }
 

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -12,6 +12,7 @@
 #include <cstdlib>  // for atexit
 #include <algorithm>
 #include <cctype>
+#include <charconv>
 #include <functional>
 #include <limits>
 #include <optional>
@@ -1038,21 +1039,17 @@ inline std::optional<int> get_config_int(const ConfigDict &config,
         return default_value;
     }
 
-    try {
-        std::string value = trim(it->second);
-        size_t pos = 0;
-        int parsed_value = std::stoi(value, &pos);
-        if (pos != value.size()) {
-            LOG(ERROR) << "Invalid integer value for config key '" << key
-                       << "': " << it->second;
-            return std::nullopt;
-        }
-        return parsed_value;
-    } catch (const std::exception &) {
+    std::string value = trim(it->second);
+    int parsed_value = 0;
+    const char *begin = value.data();
+    const char *end = begin + value.size();
+    auto [ptr, ec] = std::from_chars(begin, end, parsed_value);
+    if (ec != std::errc{} || ptr != end) {
         LOG(ERROR) << "Invalid integer value for config key '" << key
                    << "': " << it->second;
         return std::nullopt;
     }
+    return parsed_value;
 }
 }  // namespace
 

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -997,6 +997,15 @@ inline std::optional<size_t> get_config_size(const ConfigDict &config,
     return static_cast<size_t>(parsed_size_opt.value());
 }
 
+inline std::string trim(const std::string &value) {
+    auto start = value.find_first_not_of(" \t\r\n");
+    if (start == std::string::npos) {
+        return "";
+    }
+    auto end = value.find_last_not_of(" \t\r\n");
+    return value.substr(start, end - start + 1);
+}
+
 inline bool get_config_bool(const ConfigDict &config, const std::string &key,
                             bool default_value) {
     auto it = config.find(key);
@@ -1004,7 +1013,7 @@ inline bool get_config_bool(const ConfigDict &config, const std::string &key,
         return default_value;
     }
 
-    std::string value = it->second;
+    std::string value = trim(it->second);
     std::transform(value.begin(), value.end(), value.begin(),
                    [](unsigned char c) { return std::tolower(c); });
     if (value == "true" || value == "1" || value == "yes" || value == "on" ||
@@ -1030,14 +1039,15 @@ inline std::optional<int> get_config_int(const ConfigDict &config,
     }
 
     try {
+        std::string value = trim(it->second);
         size_t pos = 0;
-        int value = std::stoi(it->second, &pos);
-        if (pos != it->second.size()) {
+        int parsed_value = std::stoi(value, &pos);
+        if (pos != value.size()) {
             LOG(ERROR) << "Invalid integer value for config key '" << key
                        << "': " << it->second;
             return std::nullopt;
         }
-        return value;
+        return parsed_value;
     } catch (const std::exception &) {
         LOG(ERROR) << "Invalid integer value for config key '" << key
                    << "': " << it->second;

--- a/mooncake-store/src/real_client_main.cpp
+++ b/mooncake-store/src/real_client_main.cpp
@@ -118,7 +118,7 @@ int main(int argc, char *argv[]) {
         FLAGS_master_server_address, nullptr,
         "@mooncake_client_" + std::to_string(FLAGS_port) + ".sock", FLAGS_port,
         FLAGS_enable_offload, FLAGS_start_offload_rpc_server, "",
-        FLAGS_tenant_id);
+        FLAGS_tenant_id, FLAGS_enable_http_server, FLAGS_http_port);
     if (!res) {
         LOG(FATAL) << "Failed to setup client: " << toString(res.error());
         return -1;

--- a/mooncake-store/tests/client_metrics_test.cpp
+++ b/mooncake-store/tests/client_metrics_test.cpp
@@ -1,12 +1,77 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
+// csignal must precede coro_http_client.hpp: the bundled ylt's coro_io.hpp
+// calls std::signal without including <csignal> itself.
+#include <csignal>
 #include <cstdlib>
+#include <optional>
 #include <string>
+#include <unordered_set>
+#include <ylt/coro_http/coro_http_client.hpp>
 
 #include "client_metric.h"
+#include "real_client.h"
+#include "test_server_helpers.h"
+#include "utils.h"
 
 namespace mooncake::test {
+namespace {
+
+struct HttpResponse {
+    int status;
+    std::string body;
+};
+
+HttpResponse FetchUrl(const std::string& url) {
+    coro_http::coro_http_client client;
+    auto res = client.get(url);
+    return HttpResponse{res.status, std::string(res.resp_body)};
+}
+
+int GetTestPort(std::unordered_set<int>& used_ports) {
+    for (int i = 0; i < 100; ++i) {
+        int port = getFreeTcpPort();
+        if (port > 0 && port < 65535 && !used_ports.contains(port)) {
+            used_ports.insert(port);
+            return port;
+        }
+    }
+    return -1;
+}
+
+class ScopedEnv {
+   public:
+    explicit ScopedEnv(const char* name) : name_(name) {
+        const char* value = std::getenv(name);
+        if (value) old_value_ = value;
+    }
+
+    ~ScopedEnv() {
+        if (old_value_) {
+            setenv(name_, old_value_->c_str(), 1);
+        } else {
+            unsetenv(name_);
+        }
+    }
+
+   private:
+    const char* name_;
+    std::optional<std::string> old_value_;
+};
+
+tl::expected<void, ErrorCode> SetupClientWithHttp(
+    const std::shared_ptr<RealClient>& client, const std::string& client_addr,
+    const std::string& master_addr, bool enable_http, int http_port) {
+    return client->setup_internal(
+        client_addr, "P2PHANDSHAKE", /*global_segment_size=*/0,
+        /*local_buffer_size=*/0, "tcp", "", master_addr, nullptr, "",
+        /*local_rpc_port=*/50052, /*enable_ssd_offload=*/false,
+        /*start_offload_rpc_server=*/false, /*ssd_offload_path=*/"",
+        /*tenant_id=*/"default", enable_http, http_port);
+}
+
+}  // namespace
 
 class ClientMetricsTest : public ::testing::Test {
    protected:
@@ -302,6 +367,114 @@ TEST_F(ClientMetricsTest, SerializeWithoutDynamicLabels) {
         metrics.serialize(serialized);
         verify(serialized);
     }
+}
+
+TEST_F(ClientMetricsTest, HttpMetricsEndpointsReturnData) {
+    std::unordered_set<int> used_ports;
+    int master_rpc_port = GetTestPort(used_ports);
+    int master_http_port = GetTestPort(used_ports);
+    int http_port = GetTestPort(used_ports);
+    int client_port = GetTestPort(used_ports);
+    ASSERT_GT(master_rpc_port, 0);
+    ASSERT_GT(master_http_port, 0);
+    ASSERT_GT(http_port, 0);
+    ASSERT_GT(client_port, 0);
+
+    mooncake::testing::InProcMaster master;
+    ASSERT_TRUE(master.Start(mooncake::InProcMasterConfigBuilder()
+                                 .set_rpc_port(master_rpc_port)
+                                 .set_http_metrics_port(master_http_port)
+                                 .set_http_metadata_port(0)
+                                 .build()));
+
+    auto client = RealClient::create();
+    auto setup_result = SetupClientWithHttp(
+        client, "127.0.0.1:" + std::to_string(client_port),
+        master.master_address(), /*enable_http=*/true, http_port);
+    ASSERT_TRUE(setup_result.has_value()) << toString(setup_result.error());
+
+    auto metrics =
+        FetchUrl("http://127.0.0.1:" + std::to_string(http_port) + "/metrics");
+    EXPECT_EQ(metrics.status, 200);
+    EXPECT_EQ(metrics.body.find("metrics not available"), std::string::npos);
+
+    auto summary = FetchUrl("http://127.0.0.1:" + std::to_string(http_port) +
+                            "/metrics/summary");
+    EXPECT_EQ(summary.status, 200);
+    EXPECT_NE(summary.body.find("Client Metrics Summary"), std::string::npos);
+
+    EXPECT_EQ(client->tearDownAll(), 0);
+}
+
+TEST_F(ClientMetricsTest, HttpMetricsEndpointReturns503WhenMetricsDisabled) {
+    ScopedEnv metrics_env("MC_STORE_CLIENT_METRIC");
+    setenv("MC_STORE_CLIENT_METRIC", "0", 1);
+
+    std::unordered_set<int> used_ports;
+    int master_rpc_port = GetTestPort(used_ports);
+    int master_http_port = GetTestPort(used_ports);
+    int http_port = GetTestPort(used_ports);
+    int client_port = GetTestPort(used_ports);
+    ASSERT_GT(master_rpc_port, 0);
+    ASSERT_GT(master_http_port, 0);
+    ASSERT_GT(http_port, 0);
+    ASSERT_GT(client_port, 0);
+
+    mooncake::testing::InProcMaster master;
+    ASSERT_TRUE(master.Start(mooncake::InProcMasterConfigBuilder()
+                                 .set_rpc_port(master_rpc_port)
+                                 .set_http_metrics_port(master_http_port)
+                                 .set_http_metadata_port(0)
+                                 .build()));
+
+    auto client = RealClient::create();
+    auto setup_result = SetupClientWithHttp(
+        client, "127.0.0.1:" + std::to_string(client_port),
+        master.master_address(), /*enable_http=*/true, http_port);
+    ASSERT_TRUE(setup_result.has_value()) << toString(setup_result.error());
+
+    auto metrics =
+        FetchUrl("http://127.0.0.1:" + std::to_string(http_port) + "/metrics");
+    EXPECT_EQ(metrics.status, 503);
+    EXPECT_NE(metrics.body.find("metrics not available"), std::string::npos);
+
+    EXPECT_EQ(client->tearDownAll(), 0);
+}
+
+TEST_F(ClientMetricsTest, HttpMetricsPortConflictDoesNotFailSetup) {
+    std::unordered_set<int> used_ports;
+    int master_rpc_port = GetTestPort(used_ports);
+    int master_http_port = GetTestPort(used_ports);
+    int http_port = GetTestPort(used_ports);
+    int first_client_port = GetTestPort(used_ports);
+    int second_client_port = GetTestPort(used_ports);
+    ASSERT_GT(master_rpc_port, 0);
+    ASSERT_GT(master_http_port, 0);
+    ASSERT_GT(http_port, 0);
+    ASSERT_GT(first_client_port, 0);
+    ASSERT_GT(second_client_port, 0);
+
+    mooncake::testing::InProcMaster master;
+    ASSERT_TRUE(master.Start(mooncake::InProcMasterConfigBuilder()
+                                 .set_rpc_port(master_rpc_port)
+                                 .set_http_metrics_port(master_http_port)
+                                 .set_http_metadata_port(0)
+                                 .build()));
+
+    auto first_client = RealClient::create();
+    auto first_setup = SetupClientWithHttp(
+        first_client, "127.0.0.1:" + std::to_string(first_client_port),
+        master.master_address(), /*enable_http=*/true, http_port);
+    ASSERT_TRUE(first_setup.has_value()) << toString(first_setup.error());
+
+    auto second_client = RealClient::create();
+    auto second_setup = SetupClientWithHttp(
+        second_client, "127.0.0.1:" + std::to_string(second_client_port),
+        master.master_address(), /*enable_http=*/true, http_port);
+    EXPECT_TRUE(second_setup.has_value()) << toString(second_setup.error());
+
+    EXPECT_EQ(second_client->tearDownAll(), 0);
+    EXPECT_EQ(first_client->tearDownAll(), 0);
 }
 
 }  // namespace mooncake::test

--- a/mooncake-store/tests/client_metrics_test.cpp
+++ b/mooncake-store/tests/client_metrics_test.cpp
@@ -447,6 +447,31 @@ TEST_F(ClientMetricsTest, HttpMetricsConfigParserTrimsWhitespace) {
     EXPECT_EQ(client->tearDownAll(), 0);
 }
 
+TEST_F(ClientMetricsTest, HttpMetricsConfigParserRejectsInvalidIntegers) {
+    const char* invalid_ports[] = {
+        "9300x",
+        "999999999999999999999999",
+    };
+
+    for (const char* invalid_port : invalid_ports) {
+        ConfigDict config = {
+            {CONFIG_KEY_LOCAL_HOSTNAME, "127.0.0.1:1"},
+            {CONFIG_KEY_METADATA_SERVER, "P2PHANDSHAKE"},
+            {CONFIG_KEY_GLOBAL_SEGMENT_SIZE, "0"},
+            {CONFIG_KEY_LOCAL_BUFFER_SIZE, "0"},
+            {CONFIG_KEY_PROTOCOL, "tcp"},
+            {CONFIG_KEY_ENABLE_CLIENT_HTTP_SERVER, "true"},
+            {CONFIG_KEY_CLIENT_HTTP_PORT, invalid_port},
+        };
+
+        auto client = RealClient::create();
+        auto setup_result = client->setup_internal(config);
+        ASSERT_FALSE(setup_result.has_value()) << invalid_port;
+        EXPECT_EQ(setup_result.error(), ErrorCode::INVALID_PARAMS)
+            << invalid_port;
+    }
+}
+
 TEST_F(ClientMetricsTest, HttpMetricsEndpointReturns503WhenMetricsDisabled) {
     ScopedEnv metrics_env("MC_STORE_CLIENT_METRIC");
     setenv("MC_STORE_CLIENT_METRIC", "0", 1);

--- a/mooncake-store/tests/client_metrics_test.cpp
+++ b/mooncake-store/tests/client_metrics_test.cpp
@@ -406,6 +406,47 @@ TEST_F(ClientMetricsTest, HttpMetricsEndpointsReturnData) {
     EXPECT_EQ(client->tearDownAll(), 0);
 }
 
+TEST_F(ClientMetricsTest, HttpMetricsConfigParserTrimsWhitespace) {
+    std::unordered_set<int> used_ports;
+    int master_rpc_port = GetTestPort(used_ports);
+    int master_http_port = GetTestPort(used_ports);
+    int http_port = GetTestPort(used_ports);
+    int client_port = GetTestPort(used_ports);
+    ASSERT_GT(master_rpc_port, 0);
+    ASSERT_GT(master_http_port, 0);
+    ASSERT_GT(http_port, 0);
+    ASSERT_GT(client_port, 0);
+
+    mooncake::testing::InProcMaster master;
+    ASSERT_TRUE(master.Start(mooncake::InProcMasterConfigBuilder()
+                                 .set_rpc_port(master_rpc_port)
+                                 .set_http_metrics_port(master_http_port)
+                                 .set_http_metadata_port(0)
+                                 .build()));
+
+    ConfigDict config = {
+        {CONFIG_KEY_LOCAL_HOSTNAME, "127.0.0.1:" + std::to_string(client_port)},
+        {CONFIG_KEY_METADATA_SERVER, "P2PHANDSHAKE"},
+        {CONFIG_KEY_GLOBAL_SEGMENT_SIZE, "0"},
+        {CONFIG_KEY_LOCAL_BUFFER_SIZE, "0"},
+        {CONFIG_KEY_PROTOCOL, "tcp"},
+        {CONFIG_KEY_MASTER_SERVER_ADDR, master.master_address()},
+        {CONFIG_KEY_ENABLE_CLIENT_HTTP_SERVER, " true "},
+        {CONFIG_KEY_CLIENT_HTTP_PORT, " " + std::to_string(http_port) + " "},
+    };
+
+    auto client = RealClient::create();
+    auto setup_result = client->setup_internal(config);
+    ASSERT_TRUE(setup_result.has_value()) << toString(setup_result.error());
+
+    auto health =
+        FetchUrl("http://127.0.0.1:" + std::to_string(http_port) + "/health");
+    EXPECT_EQ(health.status, 200);
+    EXPECT_NE(health.body.find("\"status\":\"healthy\""), std::string::npos);
+
+    EXPECT_EQ(client->tearDownAll(), 0);
+}
+
 TEST_F(ClientMetricsTest, HttpMetricsEndpointReturns503WhenMetricsDisabled) {
     ScopedEnv metrics_env("MC_STORE_CLIENT_METRIC");
     setenv("MC_STORE_CLIENT_METRIC", "0", 1);

--- a/mooncake-wheel/mooncake/mooncake_config.py
+++ b/mooncake-wheel/mooncake/mooncake_config.py
@@ -59,6 +59,7 @@ export MOONCAKE_DEVICE="mlx5_0"
 export MOONCAKE_PROTOCOL="rdma"
 export MOONCAKE_DEVICE="auto-discovery"
 """
+
 import json
 import logging
 import os
@@ -72,13 +73,13 @@ DEFAULT_LOCAL_BUFFER_SIZE = 1073741824  # 1.0 GiB
 
 _SIZE_SUFFIXES = [
     ("kb", 1024),
-    ("mb", 1024 ** 2),
-    ("gb", 1024 ** 3),
-    ("tb", 1024 ** 4),
+    ("mb", 1024**2),
+    ("gb", 1024**3),
+    ("tb", 1024**4),
     ("k", 1024),
-    ("m", 1024 ** 2),
-    ("g", 1024 ** 3),
-    ("t", 1024 ** 4),
+    ("m", 1024**2),
+    ("g", 1024**3),
+    ("t", 1024**4),
     ("b", 1),
 ]
 
@@ -91,25 +92,27 @@ _SIZE_SUFFIXES = [
 # canonicalised to lowercase below and an unrecognised value only warns.
 # Union of Transfer Engine transports and Store-only modes. Keep in sync with
 # the protocol list documented in the module docstring above.
-_KNOWN_PROTOCOLS = frozenset({
-    # Transfer Engine transports (mooncake-transfer-engine installTransport)
-    "tcp",
-    "rdma",
-    "efa",
-    "nvmeof",
-    "nvlink",
-    "nvlink_intra",
-    "hip",
-    "barex",
-    "cxl",
-    "ascend",
-    "ub",
-    "ubshmem",
-    "maca",
-    "sunrise_link",
-    # Store-only mode (mooncake-store client_service.cpp: no transfer engine)
-    "rpc_only",
-})
+_KNOWN_PROTOCOLS = frozenset(
+    {
+        # Transfer Engine transports (mooncake-transfer-engine installTransport)
+        "tcp",
+        "rdma",
+        "efa",
+        "nvmeof",
+        "nvlink",
+        "nvlink_intra",
+        "hip",
+        "barex",
+        "cxl",
+        "ascend",
+        "ub",
+        "ubshmem",
+        "maca",
+        "sunrise_link",
+        # Store-only mode (mooncake-store client_service.cpp: no transfer engine)
+        "rpc_only",
+    }
+)
 
 # Required fields that must be present AND non-empty.
 _REQUIRED_NON_EMPTY_FIELDS = (
@@ -156,9 +159,9 @@ def _parse_bool(value) -> bool:
     s = str(value).strip().lower()
     if not s:
         return False
-    if s in ("true", "1", "yes", "on"):
+    if s in ("true", "1", "yes", "on", "enable"):
         return True
-    if s in ("false", "0", "no", "off"):
+    if s in ("false", "0", "no", "off", "disable"):
         return False
     raise ValueError(f"Invalid boolean value: {value!r}")
 
@@ -187,6 +190,10 @@ class MooncakeConfig:
         enable_ssd_offload (bool): Enable SSD offload. Default is False.
         ssd_offload_path (str): The path to the SSD directory for offloading.
         tenant_id (str): Tenant identifier. Default is "default".
+        enable_client_http_server (bool): Enable the client HTTP health/metrics
+            endpoints. Default is False.
+        client_http_port (int): Port for the client HTTP endpoints.
+            Defaults to 9300.
 
     Example of configuration file:
         {
@@ -199,9 +206,11 @@ class MooncakeConfig:
             "master_server_address": "localhost:8081",
             "enable_ssd_offload": true,
             "ssd_offload_path": "/nvme/mooncake_offload",
-            "tenant_id": "default"
+            "tenant_id": "default",
+            "enable_client_http_server": false,
+            "client_http_port": 9300
         }
-        
+
         For RDMA:
         {
             "local_hostname": "node1",
@@ -213,9 +222,12 @@ class MooncakeConfig:
             "master_server_address": "master:8081",
             "enable_ssd_offload": true,
             "ssd_offload_path": "/nvme/mooncake_offload",
-            "tenant_id": "default"
+            "tenant_id": "default",
+            "enable_client_http_server": false,
+            "client_http_port": 9300
         }
     """
+
     local_hostname: str
     metadata_server: str
     global_segment_size: int
@@ -226,6 +238,8 @@ class MooncakeConfig:
     enable_ssd_offload: bool = False
     ssd_offload_path: str = ""
     tenant_id: str = "default"
+    enable_client_http_server: bool = False
+    client_http_port: int = 9300
 
     def __post_init__(self):
         """Validate and normalise configuration invariants.
@@ -278,7 +292,7 @@ class MooncakeConfig:
                 )
 
     @staticmethod
-    def from_file(file_path: str) -> 'MooncakeConfig':
+    def from_file(file_path: str) -> "MooncakeConfig":
         """Load the config from a JSON file."""
         with open(file_path) as fin:
             config = json.load(fin)
@@ -305,27 +319,39 @@ class MooncakeConfig:
             device_name=config.get("device_name", ""),
             master_server_address=config.get("master_server_address"),
             enable_ssd_offload=_parse_bool(config.get("enable_ssd_offload", False)),
-            ssd_offload_path=str(ssd_offload_path) if ssd_offload_path is not None else "",
+            ssd_offload_path=str(ssd_offload_path)
+            if ssd_offload_path is not None
+            else "",
             tenant_id=str(tenant_id) if tenant_id is not None else "default",
+            enable_client_http_server=_parse_bool(
+                config.get("enable_client_http_server", False)
+            ),
+            client_http_port=int(config.get("client_http_port", 9300)),
         )
 
     @staticmethod
-    def load_from_env() -> 'MooncakeConfig':
+    def load_from_env() -> "MooncakeConfig":
         """Load config from a file specified in the environment variable.
         export MOONCAKE_MASTER=10.13.3.232:50051
         export MOONCAKE_PROTOCOL="rdma"
         export MOONCAKE_DEVICE=""
         export MOONCAKE_TE_META_DATA_SERVER="P2PHANDSHAKE"
         """
-        config_file_path = os.getenv('MOONCAKE_CONFIG_PATH')
+        config_file_path = os.getenv("MOONCAKE_CONFIG_PATH")
         if config_file_path is None:
             if not os.getenv("MOONCAKE_MASTER"):
-                raise ValueError("Neither the environment variable 'MOONCAKE_CONFIG_PATH' nor 'MOONCAKE_MASTER' is set.")
+                raise ValueError(
+                    "Neither the environment variable 'MOONCAKE_CONFIG_PATH' nor 'MOONCAKE_MASTER' is set."
+                )
             return MooncakeConfig(
                 local_hostname=os.getenv("MOONCAKE_LOCAL_HOSTNAME", "localhost"),
-                metadata_server=os.getenv("MOONCAKE_TE_META_DATA_SERVER", "P2PHANDSHAKE"),
+                metadata_server=os.getenv(
+                    "MOONCAKE_TE_META_DATA_SERVER", "P2PHANDSHAKE"
+                ),
                 global_segment_size=_parse_segment_size(
-                    os.getenv("MOONCAKE_GLOBAL_SEGMENT_SIZE", DEFAULT_GLOBAL_SEGMENT_SIZE)
+                    os.getenv(
+                        "MOONCAKE_GLOBAL_SEGMENT_SIZE", DEFAULT_GLOBAL_SEGMENT_SIZE
+                    )
                 ),
                 local_buffer_size=_parse_segment_size(
                     os.getenv("MOONCAKE_LOCAL_BUFFER_SIZE", DEFAULT_LOCAL_BUFFER_SIZE)
@@ -333,8 +359,14 @@ class MooncakeConfig:
                 protocol=os.getenv("MOONCAKE_PROTOCOL", "tcp"),
                 device_name=os.getenv("MOONCAKE_DEVICE", ""),
                 master_server_address=os.getenv("MOONCAKE_MASTER"),
-                enable_ssd_offload=_parse_bool(os.getenv("MOONCAKE_OFFLOAD_ENABLED", "false")),
+                enable_ssd_offload=_parse_bool(
+                    os.getenv("MOONCAKE_OFFLOAD_ENABLED", "false")
+                ),
                 ssd_offload_path=os.getenv("MOONCAKE_OFFLOAD_FILE_STORAGE_PATH", ""),
                 tenant_id=os.getenv("MOONCAKE_TENANT_ID", "default"),
+                enable_client_http_server=_parse_bool(
+                    os.getenv("MOONCAKE_ENABLE_CLIENT_HTTP_SERVER", "false")
+                ),
+                client_http_port=int(os.getenv("MOONCAKE_CLIENT_HTTP_PORT", 9300)),
             )
         return MooncakeConfig.from_file(config_file_path)

--- a/mooncake-wheel/mooncake/mooncake_store_service.py
+++ b/mooncake-wheel/mooncake/mooncake_store_service.py
@@ -20,6 +20,7 @@ def _timed_handler(operation_name, handler):
         finally:
             elapsed_ms = (time.perf_counter() - start_time) * 1000
             logging.info(f"{operation_name} operation completed in {elapsed_ms:.2f} ms")
+
     return wrapper
 
 
@@ -63,10 +64,12 @@ class MooncakeStoreService:
         self._setup_logging()
 
         # State for /api/reconfigure (Prefill/Decode mode switch)
-        self.current_mode = "prefill"          # "prefill" or "decode"
-        self.mounted_segment_ids = []          # persisted segment_ids from last decode mount
-        self.last_mount_info = {}              # last mount parameters for debugging
-        self._state_lock = asyncio.Lock()      # serialize reconfigure/mount/unmount state changes
+        self.current_mode = "prefill"  # "prefill" or "decode"
+        self.mounted_segment_ids = []  # persisted segment_ids from last decode mount
+        self.last_mount_info = {}  # last mount parameters for debugging
+        self._state_lock = (
+            asyncio.Lock()
+        )  # serialize reconfigure/mount/unmount state changes
 
         try:
             if config_path:
@@ -88,7 +91,7 @@ class MooncakeStoreService:
     def _setup_logging(self):
         logging.basicConfig(
             level=logging.INFO,
-            format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
         )
 
     async def start_store_service(self, max_wait_time: float = 60):
@@ -122,23 +125,30 @@ class MooncakeStoreService:
 
                 self.store = MooncakeDistributedStore()
                 ret = self.store.setup(
-                    self.config.local_hostname,
-                    self.config.metadata_server,
-                    self.config.global_segment_size,
-                    self.config.local_buffer_size,
-                    self.config.protocol,
-                    self.config.device_name,
-                    self.config.master_server_address,
-                    None,
-                    self.config.enable_ssd_offload,
-                    self.config.ssd_offload_path,
-                    self.config.tenant_id
+                    {
+                        "local_hostname": self.config.local_hostname,
+                        "metadata_server": self.config.metadata_server,
+                        "global_segment_size": self.config.global_segment_size,
+                        "local_buffer_size": self.config.local_buffer_size,
+                        "protocol": self.config.protocol,
+                        "rdma_devices": self.config.device_name,
+                        "master_server_addr": self.config.master_server_address,
+                        "enable_ssd_offload": self.config.enable_ssd_offload,
+                        "ssd_offload_path": self.config.ssd_offload_path,
+                        "tenant_id": self.config.tenant_id,
+                        "enable_client_http_server": (
+                            self.config.enable_client_http_server
+                        ),
+                        "client_http_port": self.config.client_http_port,
+                    }
                 )
 
                 if ret != 0:
                     raise RuntimeError("Store initialization failed")
 
-                logging.info(f"Store service started successfully on {self.config.local_hostname}")
+                logging.info(
+                    f"Store service started successfully on {self.config.local_hostname}"
+                )
                 return True
 
             except Exception as e:
@@ -147,7 +157,9 @@ class MooncakeStoreService:
                 remaining_time = max_wait_time - elapsed_after_attempt
 
                 # Calculate actual sleep duration
-                actual_sleep_time = min(retry_interval, remaining_time) if remaining_time > 0 else 0
+                actual_sleep_time = (
+                    min(retry_interval, remaining_time) if remaining_time > 0 else 0
+                )
 
                 logging.warning(
                     f"Store startup failed (attempt {retry_count}): {e}. "
@@ -158,24 +170,40 @@ class MooncakeStoreService:
                 if actual_sleep_time > 0:
                     await asyncio.sleep(actual_sleep_time)
 
-
     async def start_http_service(self, port: int = 8080):
         app = web.Application(client_max_size=1024 * 1024 * 100)  # 100MB limit
-        app.add_routes([
-            web.post('/api/reconfigure', _timed_handler("RECONFIGURE", self.handle_reconfigure)),
-            web.post('/api/mount_shm', _timed_handler("MOUNT_SHM", self.handle_mount_shm)),
-            web.post('/api/unmount_shm', _timed_handler("UNMOUNT_SHM", self.handle_unmount_shm)),
-            web.post('/api/mount', _timed_handler("MOUNT", self.handle_mount)),
-            web.post('/api/unmount', _timed_handler("UNMOUNT", self.handle_unmount)),
-            web.put('/api/put', _timed_handler("PUT", self.handle_put)),
-            web.get('/api/get/{key}', _timed_handler("GET", self.handle_get)),
-            web.get('/api/exist/{key}', _timed_handler("EXIST", self.handle_exist)),
-            web.delete('/api/remove/{key}', _timed_handler("REMOVE", self.handle_remove)),
-            web.delete('/api/remove_all', _timed_handler("REMOVE_ALL", self.handle_remove_all))
-        ])
+        app.add_routes(
+            [
+                web.post(
+                    "/api/reconfigure",
+                    _timed_handler("RECONFIGURE", self.handle_reconfigure),
+                ),
+                web.post(
+                    "/api/mount_shm", _timed_handler("MOUNT_SHM", self.handle_mount_shm)
+                ),
+                web.post(
+                    "/api/unmount_shm",
+                    _timed_handler("UNMOUNT_SHM", self.handle_unmount_shm),
+                ),
+                web.post("/api/mount", _timed_handler("MOUNT", self.handle_mount)),
+                web.post(
+                    "/api/unmount", _timed_handler("UNMOUNT", self.handle_unmount)
+                ),
+                web.put("/api/put", _timed_handler("PUT", self.handle_put)),
+                web.get("/api/get/{key}", _timed_handler("GET", self.handle_get)),
+                web.get("/api/exist/{key}", _timed_handler("EXIST", self.handle_exist)),
+                web.delete(
+                    "/api/remove/{key}", _timed_handler("REMOVE", self.handle_remove)
+                ),
+                web.delete(
+                    "/api/remove_all",
+                    _timed_handler("REMOVE_ALL", self.handle_remove_all),
+                ),
+            ]
+        )
         runner = web.AppRunner(app)
         await runner.setup()
-        site = web.TCPSite(runner, '0.0.0.0', port)
+        site = web.TCPSite(runner, "0.0.0.0", port)
         await site.start()
         logging.info(f"REST API started on port {port}")
         return True
@@ -196,24 +224,34 @@ class MooncakeStoreService:
                 if not path or size is None:
                     return web.Response(
                         status=400,
-                        text=json.dumps({"error": "Missing path or size for decode mode"}),
-                        content_type="application/json"
+                        text=json.dumps(
+                            {"error": "Missing path or size for decode mode"}
+                        ),
+                        content_type="application/json",
                     )
 
                 async with self._state_lock:
                     # If already in decode mode with mounted segments, unmount them first
                     if self.mounted_segment_ids:
-                        logging.info("Reconfigure decode: unmounting previous segments before remount")
+                        logging.info(
+                            "Reconfigure decode: unmounting previous segments before remount"
+                        )
                         ret = self.store.unmount_segment(self.mounted_segment_ids)
                         if ret != 0:
                             return web.Response(
                                 status=500,
-                                text=json.dumps({"error": f"Unmount of previous segments failed, ret={ret}"}),
-                                content_type="application/json"
+                                text=json.dumps(
+                                    {
+                                        "error": f"Unmount of previous segments failed, ret={ret}"
+                                    }
+                                ),
+                                content_type="application/json",
                             )
                         self.mounted_segment_ids.clear()
 
-                    result = self.store.mount_segment(path, size, offset, protocol, location)
+                    result = self.store.mount_segment(
+                        path, size, offset, protocol, location
+                    )
                     if result["ret"] != 0:
                         self.current_mode = "prefill"
                         self.mounted_segment_ids.clear()
@@ -229,24 +267,29 @@ class MooncakeStoreService:
                                     "mode": self.current_mode,
                                 }
                             ),
-                            content_type="application/json"
+                            content_type="application/json",
                         )
 
                     self.mounted_segment_ids = list(result["segment_ids"])
                     self.current_mode = "decode"
                     self.last_mount_info = {
-                        "path": path, "offset": offset, "size": size,
-                        "protocol": protocol, "location": location
+                        "path": path,
+                        "offset": offset,
+                        "size": size,
+                        "protocol": protocol,
+                        "location": location,
                     }
 
                 return web.Response(
                     status=200,
-                    text=json.dumps({
-                        "status": "success",
-                        "mode": self.current_mode,
-                        "segment_ids": self.mounted_segment_ids,
-                    }),
-                    content_type="application/json"
+                    text=json.dumps(
+                        {
+                            "status": "success",
+                            "mode": self.current_mode,
+                            "segment_ids": self.mounted_segment_ids,
+                        }
+                    ),
+                    content_type="application/json",
                 )
 
             elif mode == "prefill":
@@ -256,8 +299,10 @@ class MooncakeStoreService:
                         if ret != 0:
                             return web.Response(
                                 status=500,
-                                text=json.dumps({"error": f"Unmount failed, ret={ret}"}),
-                                content_type="application/json"
+                                text=json.dumps(
+                                    {"error": f"Unmount failed, ret={ret}"}
+                                ),
+                                content_type="application/json",
                             )
                         self.mounted_segment_ids.clear()
 
@@ -267,21 +312,23 @@ class MooncakeStoreService:
                 return web.Response(
                     status=200,
                     text=json.dumps({"status": "success", "mode": self.current_mode}),
-                    content_type="application/json"
+                    content_type="application/json",
                 )
 
             else:
                 return web.Response(
                     status=400,
-                    text=json.dumps({"error": "Invalid mode. Use 'decode' or 'prefill'"}),
-                    content_type="application/json"
+                    text=json.dumps(
+                        {"error": "Invalid mode. Use 'decode' or 'prefill'"}
+                    ),
+                    content_type="application/json",
                 )
         except Exception as e:
             logging.error("RECONFIGURE error: %s", e)
             return web.Response(
                 status=500,
                 text=json.dumps({"error": str(e)}),
-                content_type="application/json"
+                content_type="application/json",
             )
 
     async def handle_mount_shm(self, request):
@@ -298,7 +345,7 @@ class MooncakeStoreService:
                 return web.Response(
                     status=400,
                     text=json.dumps({"error": "Missing or invalid name or size"}),
-                    content_type="application/json"
+                    content_type="application/json",
                 )
 
             result = self.store.mount_segment(path, size, offset, protocol, location)
@@ -306,7 +353,7 @@ class MooncakeStoreService:
                 return web.Response(
                     status=500,
                     text=json.dumps({"error": f"Mount failed, ret={result['ret']}"}),
-                    content_type="application/json"
+                    content_type="application/json",
                 )
 
             return web.Response(
@@ -324,7 +371,7 @@ class MooncakeStoreService:
             return web.Response(
                 status=500,
                 text=json.dumps({"error": str(e)}),
-                content_type="application/json"
+                content_type="application/json",
             )
 
     async def handle_unmount_shm(self, request):
@@ -375,7 +422,7 @@ class MooncakeStoreService:
             return web.Response(
                 status=500,
                 text=json.dumps({"error": str(e)}),
-                content_type="application/json"
+                content_type="application/json",
             )
 
     async def handle_mount(self, request):
@@ -388,16 +435,20 @@ class MooncakeStoreService:
             if type(size) is not int or size <= 0:
                 return web.Response(
                     status=400,
-                    text=json.dumps({"error": "Invalid size, must be a positive integer"}),
-                    content_type="application/json"
+                    text=json.dumps(
+                        {"error": "Invalid size, must be a positive integer"}
+                    ),
+                    content_type="application/json",
                 )
 
             result = self.store.allocate_and_mount_segment(size, protocol, location)
             if result["ret"] != 0:
                 return web.Response(
                     status=500,
-                    text=json.dumps({"error": f"Allocate and mount failed, ret={result['ret']}"}),
-                    content_type="application/json"
+                    text=json.dumps(
+                        {"error": f"Allocate and mount failed, ret={result['ret']}"}
+                    ),
+                    content_type="application/json",
                 )
 
             return web.Response(
@@ -416,7 +467,7 @@ class MooncakeStoreService:
             return web.Response(
                 status=500,
                 text=json.dumps({"error": str(e)}),
-                content_type="application/json"
+                content_type="application/json",
             )
 
     async def handle_unmount(self, request):
@@ -433,15 +484,11 @@ class MooncakeStoreService:
                 )
 
             grace_period_seconds = data.get("grace_period_seconds", 0)
-            ret = self.store.unmount_and_free_segment(
-                segment_ids, grace_period_seconds
-            )
+            ret = self.store.unmount_and_free_segment(segment_ids, grace_period_seconds)
             if ret != 0:
                 return web.Response(
                     status=500,
-                    text=json.dumps(
-                        {"error": f"Unmount and free failed, ret={ret}"}
-                    ),
+                    text=json.dumps({"error": f"Unmount and free failed, ret={ret}"}),
                     content_type="application/json",
                 )
 
@@ -455,20 +502,20 @@ class MooncakeStoreService:
             return web.Response(
                 status=500,
                 text=json.dumps({"error": str(e)}),
-                content_type="application/json"
+                content_type="application/json",
             )
 
     async def handle_put(self, request):
         try:
             data = await request.json()
-            key = data.get('key')
-            raw_value = data.get('value')
+            key = data.get("key")
+            raw_value = data.get("value")
 
             if not key or raw_value is None:
                 return web.Response(
                     status=400,
-                    text=json.dumps({'error': 'Missing key or value'}),
-                    content_type='application/json'
+                    text=json.dumps({"error": "Missing key or value"}),
+                    content_type="application/json",
                 )
 
             value = raw_value.encode()
@@ -476,124 +523,122 @@ class MooncakeStoreService:
             if ret != 0:
                 return web.Response(
                     status=500,
-                    text=json.dumps({'error': 'PUT operation failed'}),
-                    content_type='application/json'
+                    text=json.dumps({"error": "PUT operation failed"}),
+                    content_type="application/json",
                 )
 
             return web.Response(
                 status=200,
-                text=json.dumps({'status': 'success'}),
-                content_type='application/json'
+                text=json.dumps({"status": "success"}),
+                content_type="application/json",
             )
         except Exception as e:
             logging.error("PUT error: %s", e)
             return web.Response(
                 status=500,
-                text=json.dumps({'error': str(e)}),
-                content_type='application/json'
+                text=json.dumps({"error": str(e)}),
+                content_type="application/json",
             )
 
     async def handle_get(self, request):
         try:
-            key = request.match_info['key']
+            key = request.match_info["key"]
             exists = self.store.is_exist(key)
 
             if exists == 0:
                 return web.Response(
                     status=404,
-                    text=json.dumps({'error': 'Key not found'}),
-                    content_type='application/json'
+                    text=json.dumps({"error": "Key not found"}),
+                    content_type="application/json",
                 )
             if exists < 0:
                 return web.Response(
                     status=500,
-                    text=json.dumps({'error': 'Exist check failed'}),
-                    content_type='application/json'
+                    text=json.dumps({"error": "Exist check failed"}),
+                    content_type="application/json",
                 )
 
             value = self.store.get(key)
             if value is None:
                 return web.Response(
                     status=500,
-                    text=json.dumps({'error': 'GET operation failed'}),
-                    content_type='application/json'
+                    text=json.dumps({"error": "GET operation failed"}),
+                    content_type="application/json",
                 )
             if value == b"":
                 exists = self.store.is_exist(key)
                 if exists == 0:
                     return web.Response(
                         status=404,
-                        text=json.dumps({'error': 'Key not found'}),
-                        content_type='application/json'
+                        text=json.dumps({"error": "Key not found"}),
+                        content_type="application/json",
                     )
                 if exists < 0:
                     return web.Response(
                         status=500,
-                        text=json.dumps({'error': 'Exist check failed'}),
-                        content_type='application/json'
+                        text=json.dumps({"error": "Exist check failed"}),
+                        content_type="application/json",
                     )
 
             return web.Response(
-                status=200,
-                body=value,
-                content_type='application/octet-stream'
+                status=200, body=value, content_type="application/octet-stream"
             )
         except Exception as e:
             logging.error("GET error: %s", e)
             return web.Response(
                 status=500,
-                text=json.dumps({'error': str(e)}),
-                content_type='application/json'
+                text=json.dumps({"error": str(e)}),
+                content_type="application/json",
             )
 
     async def handle_exist(self, request):
         try:
-            key = request.match_info['key']
+            key = request.match_info["key"]
             exists = self.store.is_exist(key)
 
             if exists < 0:
                 return web.Response(
                     status=500,
-                    text=json.dumps({'error': 'Exist check failed'}),
-                    content_type='application/json'
+                    text=json.dumps({"error": "Exist check failed"}),
+                    content_type="application/json",
                 )
 
             return web.Response(
                 status=200,
-                text=json.dumps({'exists': exists > 0}),
-                content_type='application/json'
+                text=json.dumps({"exists": exists > 0}),
+                content_type="application/json",
             )
         except Exception as e:
             logging.error("EXIST error: %s", e)
             return web.Response(
                 status=500,
-                text=json.dumps({'error': str(e)}),
-                content_type='application/json'
+                text=json.dumps({"error": str(e)}),
+                content_type="application/json",
             )
 
     async def handle_remove(self, request):
         try:
-            key = request.match_info['key']
+            key = request.match_info["key"]
             ret = self.store.remove(key)
 
             if ret != 0:
                 return web.Response(
                     status=500,
-                    text=json.dumps({'error': 'Remove operation failed'}),
-                    content_type='application/json'
+                    text=json.dumps({"error": "Remove operation failed"}),
+                    content_type="application/json",
                 )
 
             return web.Response(
                 status=200,
-                text=json.dumps({'status': 'success'}),
-                content_type='application/json'
+                text=json.dumps({"status": "success"}),
+                content_type="application/json",
             )
         except Exception as e:
             logging.error("REMOVE error: %s", e)
             return web.Response(
                 status=500,
-                text=json.dumps({'error': str(e)}),
-                content_type='application/json'
+                text=json.dumps({"error": str(e)}),
+                content_type="application/json",
             )
 
     async def handle_remove_all(self, request):
@@ -603,21 +648,21 @@ class MooncakeStoreService:
             if ret < 0:
                 return web.Response(
                     status=500,
-                    text=json.dumps({'error': 'RemoveAll operation failed'}),
-                    content_type='application/json'
+                    text=json.dumps({"error": "RemoveAll operation failed"}),
+                    content_type="application/json",
                 )
 
             return web.Response(
                 status=200,
-                text=json.dumps({'status': 'success removed ' + str(ret) + ' keys'}),
-                content_type='application/json'
+                text=json.dumps({"status": "success removed " + str(ret) + " keys"}),
+                content_type="application/json",
             )
         except Exception as e:
             logging.error("REMOVE_ALL error: %s", e)
             return web.Response(
                 status=500,
-                text=json.dumps({'error': str(e)}),
-                content_type='application/json'
+                text=json.dumps({"error": str(e)}),
+                content_type="application/json",
             )
 
     async def stop(self):
@@ -625,23 +670,35 @@ class MooncakeStoreService:
             self.store.close()
             logging.info("Mooncake service stopped")
 
+
 def parse_arguments():
-    parser = argparse.ArgumentParser(description='Mooncake Store Service with REST API')
-    parser.add_argument('--config', type=str,
-                        help='Path to Mooncake config file',
-                        required=False)
-    parser.add_argument('-D', '--define', action='append',
-                        help='Override configuration with key=value pairs (e.g., -Dlocal_hostname=example.com)',
-                        default=[])
-    parser.add_argument('--port', type=int,
-                        help='HTTP API port (default: 8080)',
-                        default=8080,
-                        required=False)
-    parser.add_argument('--max-wait-time', type=float,
-                        help='Maximum total wait time in seconds (default: 60)',
-                        default=60,
-                        required=False)
+    parser = argparse.ArgumentParser(description="Mooncake Store Service with REST API")
+    parser.add_argument(
+        "--config", type=str, help="Path to Mooncake config file", required=False
+    )
+    parser.add_argument(
+        "-D",
+        "--define",
+        action="append",
+        help="Override configuration with key=value pairs (e.g., -Dlocal_hostname=example.com)",
+        default=[],
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        help="HTTP API port (default: 8080)",
+        default=8080,
+        required=False,
+    )
+    parser.add_argument(
+        "--max-wait-time",
+        type=float,
+        help="Maximum total wait time in seconds (default: 60)",
+        default=60,
+        required=False,
+    )
     return parser.parse_args()
+
 
 async def main():
     args = parse_arguments()
@@ -649,8 +706,8 @@ async def main():
     # Parse -D key=value pairs into a dictionary
     cli_config = {}
     for item in args.define:
-        if '=' in item:
-            key, value = item.split('=', 1)
+        if "=" in item:
+            key, value = item.split("=", 1)
             cli_config[key] = value
         else:
             logging.warning(f"Ignoring invalid CLI config: {item}")

--- a/mooncake-wheel/tests/test_mooncake_config.py
+++ b/mooncake-wheel/tests/test_mooncake_config.py
@@ -29,7 +29,9 @@ class TestMooncakeConfig(unittest.TestCase):
             "device_name": "eth0",
             "enable_ssd_offload": True,
             "ssd_offload_path": "/nvme/mooncake_offload",
-            "tenant_id": "tenant-a"
+            "tenant_id": "tenant-a",
+            "enable_client_http_server": True,
+            "client_http_port": 19300,
         }
 
     def tearDown(self):
@@ -37,7 +39,7 @@ class TestMooncakeConfig(unittest.TestCase):
 
     def write_config(self, config_data):
         """Write configuration to file"""
-        with open(self.config_file, 'w') as f:
+        with open(self.config_file, "w") as f:
             json.dump(config_data, f)
 
     def test_load_valid_config(self):
@@ -55,13 +57,15 @@ class TestMooncakeConfig(unittest.TestCase):
         self.assertEqual(config.enable_ssd_offload, True)
         self.assertEqual(config.ssd_offload_path, "/nvme/mooncake_offload")
         self.assertEqual(config.tenant_id, "tenant-a")
+        self.assertEqual(config.enable_client_http_server, True)
+        self.assertEqual(config.client_http_port, 19300)
 
     def test_load_with_default_values(self):
         """Test loading configuration with default values"""
         minimal_config = {
             "local_hostname": "localhost",
             "metadata_server": "localhost:8080",
-            "master_server_address": "localhost:8081"
+            "master_server_address": "localhost:8081",
         }
         self.write_config(minimal_config)
         config = MooncakeConfig.from_file(self.config_file)
@@ -73,6 +77,8 @@ class TestMooncakeConfig(unittest.TestCase):
         self.assertEqual(config.enable_ssd_offload, False)
         self.assertEqual(config.ssd_offload_path, "")
         self.assertEqual(config.tenant_id, "default")
+        self.assertEqual(config.enable_client_http_server, False)
+        self.assertEqual(config.client_http_port, 9300)
 
     def test_load_tenant_id_from_file(self):
         """Test loading tenant_id from configuration file"""
@@ -86,7 +92,7 @@ class TestMooncakeConfig(unittest.TestCase):
         minimal_config = {
             "local_hostname": "localhost",
             "metadata_server": "localhost:8080",
-            "master_server_address": "localhost:8081"
+            "master_server_address": "localhost:8081",
         }
         self.write_config(minimal_config)
         config = MooncakeConfig.from_file(self.config_file)
@@ -144,6 +150,20 @@ class TestMooncakeConfig(unittest.TestCase):
         with self.assertRaises(ValueError):
             MooncakeConfig.from_file(self.config_file)
 
+    def test_client_http_config_from_file(self):
+        """Test loading client HTTP metrics settings from configuration file"""
+        self.write_config(
+            {
+                **self.valid_config,
+                "enable_client_http_server": "enable",
+                "client_http_port": "19444",
+            }
+        )
+        config = MooncakeConfig.from_file(self.config_file)
+
+        self.assertEqual(config.enable_client_http_server, True)
+        self.assertEqual(config.client_http_port, 19444)
+
     def test_missing_required_field(self):
         """Test missing required field"""
         for field in ["local_hostname", "metadata_server", "master_server_address"]:
@@ -154,58 +174,93 @@ class TestMooncakeConfig(unittest.TestCase):
 
                 with self.assertRaises(ValueError) as cm:
                     MooncakeConfig.from_file(self.config_file)
-                self.assertIn(f"Missing required config field: {field}", str(cm.exception))
+                self.assertIn(
+                    f"Missing required config field: {field}", str(cm.exception)
+                )
 
     def test_load_from_config_path_env(self):
         """Test loading configuration from environment variable MOONCAKE_CONFIG_PATH"""
         self.write_config(self.valid_config)
 
         # Set environment variable
-        os.environ['MOONCAKE_CONFIG_PATH'] = self.config_file
+        os.environ["MOONCAKE_CONFIG_PATH"] = self.config_file
 
         try:
             config = MooncakeConfig.load_from_env()
             self.assertEqual(config.local_hostname, "localhost")
         finally:
             # Clean up environment variable
-            del os.environ['MOONCAKE_CONFIG_PATH']
+            del os.environ["MOONCAKE_CONFIG_PATH"]
 
     def test_load_from_config_env(self):
         """Test loading configuration from environment variable MOONCAKE_MASTER"""
         # Set environment variable
-        os.environ['MOONCAKE_MASTER'] = self.valid_config["master_server_address"]
-        os.environ['LOCAL_HOSTNAME'] = self.valid_config["local_hostname"]
-        os.environ['MOONCAKE_TE_META_DATA_SERVER'] = self.valid_config["metadata_server"]
-        os.environ['MOONCAKE_GLOBAL_SEGMENT_SIZE'] = str(self.valid_config["global_segment_size"])
-        os.environ['MOONCAKE_PROTOCOL'] = self.valid_config["protocol"]
-        os.environ['MOONCAKE_DEVICE'] = self.valid_config["device_name"]
-        os.environ['MOONCAKE_OFFLOAD_ENABLED'] = str(self.valid_config["enable_ssd_offload"])
-        os.environ['MOONCAKE_OFFLOAD_FILE_STORAGE_PATH'] = self.valid_config["ssd_offload_path"]
-        os.environ['MOONCAKE_TENANT_ID'] = self.valid_config["tenant_id"]
+        os.environ["MOONCAKE_MASTER"] = self.valid_config["master_server_address"]
+        os.environ["LOCAL_HOSTNAME"] = self.valid_config["local_hostname"]
+        os.environ["MOONCAKE_TE_META_DATA_SERVER"] = self.valid_config[
+            "metadata_server"
+        ]
+        os.environ["MOONCAKE_GLOBAL_SEGMENT_SIZE"] = str(
+            self.valid_config["global_segment_size"]
+        )
+        os.environ["MOONCAKE_PROTOCOL"] = self.valid_config["protocol"]
+        os.environ["MOONCAKE_DEVICE"] = self.valid_config["device_name"]
+        os.environ["MOONCAKE_OFFLOAD_ENABLED"] = str(
+            self.valid_config["enable_ssd_offload"]
+        )
+        os.environ["MOONCAKE_OFFLOAD_FILE_STORAGE_PATH"] = self.valid_config[
+            "ssd_offload_path"
+        ]
+        os.environ["MOONCAKE_TENANT_ID"] = self.valid_config["tenant_id"]
+        os.environ["MOONCAKE_ENABLE_CLIENT_HTTP_SERVER"] = str(
+            self.valid_config["enable_client_http_server"]
+        )
+        os.environ["MOONCAKE_CLIENT_HTTP_PORT"] = str(
+            self.valid_config["client_http_port"]
+        )
 
         try:
             config = MooncakeConfig.load_from_env()
-            self.assertEqual(config.master_server_address, self.valid_config["master_server_address"])
-            self.assertEqual(config.metadata_server, self.valid_config["metadata_server"])
+            self.assertEqual(
+                config.master_server_address, self.valid_config["master_server_address"]
+            )
+            self.assertEqual(
+                config.metadata_server, self.valid_config["metadata_server"]
+            )
             self.assertEqual(config.local_hostname, self.valid_config["local_hostname"])
-            self.assertEqual(config.global_segment_size, self.valid_config["global_segment_size"])
+            self.assertEqual(
+                config.global_segment_size, self.valid_config["global_segment_size"]
+            )
             self.assertEqual(config.protocol, self.valid_config["protocol"])
             self.assertEqual(config.device_name, self.valid_config["device_name"])
-            self.assertEqual(config.enable_ssd_offload, self.valid_config["enable_ssd_offload"])
-            self.assertEqual(config.ssd_offload_path, self.valid_config["ssd_offload_path"])
+            self.assertEqual(
+                config.enable_ssd_offload, self.valid_config["enable_ssd_offload"]
+            )
+            self.assertEqual(
+                config.ssd_offload_path, self.valid_config["ssd_offload_path"]
+            )
             self.assertEqual(config.tenant_id, self.valid_config["tenant_id"])
+            self.assertEqual(
+                config.enable_client_http_server,
+                self.valid_config["enable_client_http_server"],
+            )
+            self.assertEqual(
+                config.client_http_port, self.valid_config["client_http_port"]
+            )
 
         finally:
             # Clean up environment variable
-            del os.environ['MOONCAKE_MASTER']
-            del os.environ['LOCAL_HOSTNAME']
-            del os.environ['MOONCAKE_TE_META_DATA_SERVER']
-            del os.environ['MOONCAKE_GLOBAL_SEGMENT_SIZE']
-            del os.environ['MOONCAKE_PROTOCOL']
-            del os.environ['MOONCAKE_DEVICE']
-            del os.environ['MOONCAKE_OFFLOAD_ENABLED']
-            del os.environ['MOONCAKE_OFFLOAD_FILE_STORAGE_PATH']
-            del os.environ['MOONCAKE_TENANT_ID']
+            del os.environ["MOONCAKE_MASTER"]
+            del os.environ["LOCAL_HOSTNAME"]
+            del os.environ["MOONCAKE_TE_META_DATA_SERVER"]
+            del os.environ["MOONCAKE_GLOBAL_SEGMENT_SIZE"]
+            del os.environ["MOONCAKE_PROTOCOL"]
+            del os.environ["MOONCAKE_DEVICE"]
+            del os.environ["MOONCAKE_OFFLOAD_ENABLED"]
+            del os.environ["MOONCAKE_OFFLOAD_FILE_STORAGE_PATH"]
+            del os.environ["MOONCAKE_TENANT_ID"]
+            del os.environ["MOONCAKE_ENABLE_CLIENT_HTTP_SERVER"]
+            del os.environ["MOONCAKE_CLIENT_HTTP_PORT"]
 
     def test_tenant_id_from_env(self):
         """Test loading tenant_id from MOONCAKE_TENANT_ID"""
@@ -254,7 +309,10 @@ class TestMooncakeConfig(unittest.TestCase):
         """Test loading configuration from environment variable when not set"""
         with self.assertRaises(ValueError) as cm:
             MooncakeConfig.load_from_env()
-        self.assertIn("Neither the environment variable 'MOONCAKE_CONFIG_PATH' nor 'MOONCAKE_MASTER' is set.", str(cm.exception))
+        self.assertIn(
+            "Neither the environment variable 'MOONCAKE_CONFIG_PATH' nor 'MOONCAKE_MASTER' is set.",
+            str(cm.exception),
+        )
 
 
 class TestParseSegmentSize(unittest.TestCase):
@@ -276,20 +334,20 @@ class TestParseSegmentSize(unittest.TestCase):
         self.assertEqual(_parse_segment_size("1.5kb"), int(1.5 * 1024))
 
     def test_mb_suffix(self):
-        self.assertEqual(_parse_segment_size("1mb"), 1024 ** 2)
-        self.assertEqual(_parse_segment_size("512MB"), 512 * 1024 ** 2)
-        self.assertEqual(_parse_segment_size("1m"), 1024 ** 2)
+        self.assertEqual(_parse_segment_size("1mb"), 1024**2)
+        self.assertEqual(_parse_segment_size("512MB"), 512 * 1024**2)
+        self.assertEqual(_parse_segment_size("1m"), 1024**2)
 
     def test_gb_suffix(self):
-        self.assertEqual(_parse_segment_size("1gb"), 1024 ** 3)
-        self.assertEqual(_parse_segment_size("3GB"), 3 * 1024 ** 3)
-        self.assertEqual(_parse_segment_size("1g"), 1024 ** 3)
-        self.assertEqual(_parse_segment_size("1.5gb"), int(1.5 * 1024 ** 3))
+        self.assertEqual(_parse_segment_size("1gb"), 1024**3)
+        self.assertEqual(_parse_segment_size("3GB"), 3 * 1024**3)
+        self.assertEqual(_parse_segment_size("1g"), 1024**3)
+        self.assertEqual(_parse_segment_size("1.5gb"), int(1.5 * 1024**3))
 
     def test_tb_suffix(self):
-        self.assertEqual(_parse_segment_size("1tb"), 1024 ** 4)
-        self.assertEqual(_parse_segment_size("1TB"), 1024 ** 4)
-        self.assertEqual(_parse_segment_size("1t"), 1024 ** 4)
+        self.assertEqual(_parse_segment_size("1tb"), 1024**4)
+        self.assertEqual(_parse_segment_size("1TB"), 1024**4)
+        self.assertEqual(_parse_segment_size("1t"), 1024**4)
 
     def test_b_suffix(self):
         self.assertEqual(_parse_segment_size("4096b"), 4096)
@@ -316,7 +374,7 @@ class TestParseSegmentSize(unittest.TestCase):
             _parse_segment_size("abc")
 
     def test_whitespace_handling(self):
-        self.assertEqual(_parse_segment_size("  3 gb  "), 3 * 1024 ** 3)
+        self.assertEqual(_parse_segment_size("  3 gb  "), 3 * 1024**3)
 
 
 class TestMooncakeConfigValidation(unittest.TestCase):
@@ -382,9 +440,7 @@ class TestMooncakeConfigValidation(unittest.TestCase):
                 with self.assertLogs(_cfg_mod.logger, level="WARNING") as cm:
                     config = self.make(protocol=given)
                 self.assertEqual(config.protocol, expected)
-                self.assertTrue(
-                    any("Unrecognised protocol" in m for m in cm.output)
-                )
+                self.assertTrue(any("Unrecognised protocol" in m for m in cm.output))
 
     def test_non_string_protocol_raises(self):
         with self.assertRaises(ValueError):
@@ -415,12 +471,15 @@ class TestMooncakeConfigValidation(unittest.TestCase):
 
     def test_from_file_warns_on_unknown_protocol(self):
         with open(self.config_path, "w") as f:
-            json.dump({
-                "local_hostname": "localhost",
-                "metadata_server": "localhost:8080",
-                "master_server_address": "localhost:8081",
-                "protocol": "rmda",  # typo -> unknown, warned not rejected
-            }, f)
+            json.dump(
+                {
+                    "local_hostname": "localhost",
+                    "metadata_server": "localhost:8080",
+                    "master_server_address": "localhost:8081",
+                    "protocol": "rmda",  # typo -> unknown, warned not rejected
+                },
+                f,
+            )
         with self.assertLogs(_cfg_mod.logger, level="WARNING") as cm:
             config = MooncakeConfig.from_file(self.config_path)
         self.assertEqual(config.protocol, "rmda")
@@ -434,5 +493,5 @@ class TestMooncakeConfigValidation(unittest.TestCase):
         self._tmp.cleanup()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/mooncake-wheel/tests/test_mooncake_store_service_api.py
+++ b/mooncake-wheel/tests/test_mooncake_store_service_api.py
@@ -127,6 +127,8 @@ class StoreServiceApiTest(unittest.IsolatedAsyncioTestCase):
             enable_ssd_offload=False,
             ssd_offload_path="",
             tenant_id="tenant-a",
+            enable_client_http_server=False,
+            client_http_port=9300,
         )
 
         with patch(
@@ -140,17 +142,20 @@ class StoreServiceApiTest(unittest.IsolatedAsyncioTestCase):
             fake_store.setup_calls,
             [
                 (
-                    "localhost",
-                    "P2PHANDSHAKE",
-                    1024,
-                    2048,
-                    "tcp",
-                    "",
-                    "127.0.0.1:50051",
-                    None,
-                    False,
-                    "",
-                    "tenant-a",
+                    {
+                        "local_hostname": "localhost",
+                        "metadata_server": "P2PHANDSHAKE",
+                        "global_segment_size": 1024,
+                        "local_buffer_size": 2048,
+                        "protocol": "tcp",
+                        "rdma_devices": "",
+                        "master_server_addr": "127.0.0.1:50051",
+                        "enable_ssd_offload": False,
+                        "ssd_offload_path": "",
+                        "tenant_id": "tenant-a",
+                        "enable_client_http_server": False,
+                        "client_http_port": 9300,
+                    },
                 )
             ],
         )


### PR DESCRIPTION
## Description

Expose the Mooncake Store client-side health and metrics HTTP endpoint through the Python-facing client setup APIs and the packaged store service configuration.

This change migrates the client Python metrics exposure behavior from Mooncake-taas PR5 and includes the relevant PR9 compatibility fix. It adds:

- Python and pybind setup arguments for `enable_client_http_server` and `client_http_port`.
- `MooncakeConfig` JSON/env support via `MOONCAKE_ENABLE_CLIENT_HTTP_SERVER` and `MOONCAKE_CLIENT_HTTP_PORT`.
- Store service propagation of the new config fields into `MooncakeDistributedStore.setup`.
- Client HTTP endpoint tests for `/health`, `/metrics`, and `/metrics/summary`, including disabled-metrics and port-conflict behavior.
- Additional metrics latency buckets for the long-tail ranges.
- Documentation for deployment and observability usage.

The client HTTP endpoint remains disabled by default, so existing Python and SGLang integrations keep their current behavior unless they opt in.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [x] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
git diff --check

SKIP=mooncake-code-format pre-commit run --files docs/source/deployment/mooncake-store-deployment-guide.md docs/source/getting_started/observability.md mooncake-integration/store/store_py.cpp mooncake-store/include/client_metric.h mooncake-store/include/dummy_client.h mooncake-store/include/pyclient.h mooncake-store/include/real_client.h mooncake-store/include/types.h mooncake-store/src/real_client.cpp mooncake-store/src/real_client_main.cpp mooncake-store/tests/client_metrics_test.cpp mooncake-wheel/mooncake/mooncake_config.py mooncake-wheel/mooncake/mooncake_store_service.py mooncake-wheel/tests/test_mooncake_config.py mooncake-wheel/tests/test_mooncake_store_service_api.py

cmake --build build --target client_metrics_test store
build/mooncake-store/tests/client_metrics_test

PYTHONPATH=/home/lzw/Mooncake/mooncake-wheel python3 -m unittest mooncake-wheel/tests/test_mooncake_config.py mooncake-wheel.tests.test_mooncake_store_service_api.StoreServiceApiTest.test_start_store_service_passes_tenant_id_to_setup mooncake-wheel.tests.test_mooncake_store_service_api.StoreServiceApiTest.test_cli_config_can_override_tenant_id

PATH=/home/lzw/Mooncake/docs/.venv/bin:$PATH make html
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

Manual validation:

- `client_metrics_test` passed: 12 tests.
- Python unittest passed: 37 tests.
- Sphinx `make html` passed with only sandbox-network intersphinx inventory warnings.
- `mooncake-code-format` was run through the pre-commit hook and formatted the touched C++ files. It was skipped on the final targeted pre-commit/commit because the hook compares against local `origin/main`, which was older than the rebased `upstream/main` and attempted to format unrelated upstream files.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

AI assistance: OpenAI Codex was used to inspect the codebase, port the changes, resolve rebase conflicts, run validation, and draft this PR description. I reviewed and edited the generated code before submission.