### PR TITLE
Record P2P metadata oplog

### DIFF
--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -33,6 +33,10 @@ This page summarizes useful flags, environment variables, and HTTP endpoints to 
   - `--client_ttl` (int64, default `10` s): Client alive TTL after last ping (HA mode).
   - `--cluster_id` (str, default `mooncake_cluster`): Cluster ID for persistence in HA mode.
 
+### P2P HA OpLog Coverage
+
+The current P2P primary master records oplog entries for explicit client and segment lifecycle changes (`REGISTER_CLIENT`, `UNREGISTER_CLIENT`, `MOUNT_SEGMENT`, `UNMOUNT_SEGMENT`) and replica mapping changes (`ADD_REPLICA`, `REMOVE_REPLICA`). Remaining failover-visible metadata mutations still need follow-up coverage, including client crash cleanup, heartbeat state transitions, replica eviction/rebalance, and task metadata.
+
 - DFS Storage (optional)
   - `--root_fs_dir` (str, default empty): DFS mount directory for storage backend, used in Multi-layer Storage Support.
   - `--global_file_segment_size` (int64, default `int64_max`): Maximum available space for DFS segments.

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -27,6 +27,9 @@ struct MasterConfig {
     int64_t client_crashed_ttl_sec = -1;
 
     bool enable_ha;
+    bool enable_oplog = false;
+    std::string oplog_store_type = "localfs";
+    std::string oplog_data_dir = "/tmp/mooncake_oplog";
     bool enable_offload;
     std::string etcd_endpoints;
 
@@ -103,6 +106,9 @@ class MasterServiceSupervisorConfig {
     uint64_t put_start_release_timeout_sec = DEFAULT_PUT_START_RELEASE_TIMEOUT;
     bool enable_disk_eviction = true;
     uint64_t quota_bytes = 0;
+    bool enable_oplog = false;
+    std::string oplog_store_type = "localfs";
+    std::string oplog_data_dir = "/tmp/mooncake_oplog";
     uint32_t max_total_finished_tasks = DEFAULT_MAX_TOTAL_FINISHED_TASKS;
     uint32_t max_total_pending_tasks = DEFAULT_MAX_TOTAL_PENDING_TASKS;
     uint32_t max_total_processing_tasks = DEFAULT_MAX_TOTAL_PROCESSING_TASKS;
@@ -166,6 +172,9 @@ class MasterServiceSupervisorConfig {
         put_start_release_timeout_sec = config.put_start_release_timeout_sec;
         enable_disk_eviction = config.enable_disk_eviction;
         quota_bytes = config.quota_bytes;
+        enable_oplog = config.enable_oplog;
+        oplog_store_type = config.oplog_store_type;
+        oplog_data_dir = config.oplog_data_dir;
 
         max_total_finished_tasks = config.max_total_finished_tasks;
         max_total_pending_tasks = config.max_total_pending_tasks;
@@ -286,6 +295,9 @@ class WrappedMasterServiceConfig {
     int64_t client_live_ttl_sec = DEFAULT_CLIENT_LIVE_TTL_SEC;
     int64_t client_crashed_ttl_sec = DEFAULT_CLIENT_CRASHED_TTL_SEC;
     bool enable_ha = false;
+    bool enable_oplog = false;
+    std::string oplog_store_type = "localfs";
+    std::string oplog_data_dir = "/tmp/mooncake_oplog";
     bool enable_offload = false;
     std::string cluster_id = DEFAULT_CLUSTER_ID;
     std::string root_fs_dir = DEFAULT_ROOT_FS_DIR;
@@ -328,6 +340,9 @@ class WrappedMasterServiceConfig {
         client_live_ttl_sec = config.client_live_ttl_sec;
         client_crashed_ttl_sec = config.client_crashed_ttl_sec;
         enable_ha = config.enable_ha;
+        enable_oplog = config.enable_oplog;
+        oplog_store_type = config.oplog_store_type;
+        oplog_data_dir = config.oplog_data_dir;
         enable_offload = config.enable_offload;
         cluster_id = config.cluster_id;
         root_fs_dir = config.root_fs_dir;
@@ -375,6 +390,9 @@ class WrappedMasterServiceConfig {
         client_live_ttl_sec = config.client_live_ttl_sec;
         enable_ha =
             true;  // This is used in HA mode, so enable_ha should be true
+        enable_oplog = config.enable_oplog;
+        oplog_store_type = config.oplog_store_type;
+        oplog_data_dir = config.oplog_data_dir;
         enable_offload = config.enable_offload;
         cluster_id = config.cluster_id;
         root_fs_dir = config.root_fs_dir;
@@ -417,6 +435,9 @@ class MasterServiceConfigBuilder {
     int64_t client_crashed_ttl_sec_ = DEFAULT_CLIENT_CRASHED_TTL_SEC;
 
     bool enable_ha_ = false;
+    bool enable_oplog_ = false;
+    std::string oplog_store_type_ = "localfs";
+    std::string oplog_data_dir_ = "/tmp/mooncake_oplog";
     bool enable_offload_ = false;
     std::string cluster_id_ = DEFAULT_CLUSTER_ID;
     std::string root_fs_dir_ = DEFAULT_ROOT_FS_DIR;
@@ -485,6 +506,21 @@ class MasterServiceConfigBuilder {
 
     MasterServiceConfigBuilder& set_enable_ha(bool enable) {
         enable_ha_ = enable;
+        return *this;
+    }
+
+    MasterServiceConfigBuilder& set_enable_oplog(bool enable) {
+        enable_oplog_ = enable;
+        return *this;
+    }
+
+    MasterServiceConfigBuilder& set_oplog_store_type(const std::string& type) {
+        oplog_store_type_ = type;
+        return *this;
+    }
+
+    MasterServiceConfigBuilder& set_oplog_data_dir(const std::string& dir) {
+        oplog_data_dir_ = dir;
         return *this;
     }
 
@@ -600,6 +636,9 @@ class MasterServiceConfig {
     int64_t client_live_ttl_sec = DEFAULT_CLIENT_LIVE_TTL_SEC;
     int64_t client_crashed_ttl_sec = DEFAULT_CLIENT_CRASHED_TTL_SEC;
     bool enable_ha = false;
+    bool enable_oplog = false;
+    std::string oplog_store_type = "localfs";
+    std::string oplog_data_dir = "/tmp/mooncake_oplog";
     bool enable_offload = false;
     std::string cluster_id = DEFAULT_CLUSTER_ID;
     std::string root_fs_dir = DEFAULT_ROOT_FS_DIR;
@@ -638,6 +677,9 @@ class MasterServiceConfig {
         client_live_ttl_sec = config.client_live_ttl_sec;
         client_crashed_ttl_sec = config.client_crashed_ttl_sec;
         enable_ha = config.enable_ha;
+        enable_oplog = config.enable_oplog;
+        oplog_store_type = config.oplog_store_type;
+        oplog_data_dir = config.oplog_data_dir;
         enable_offload = config.enable_offload;
         cluster_id = config.cluster_id;
         root_fs_dir = config.root_fs_dir;
@@ -680,6 +722,9 @@ inline MasterServiceConfig MasterServiceConfigBuilder::build() const {
     config.client_live_ttl_sec = client_live_ttl_sec_;
     config.client_crashed_ttl_sec = client_crashed_ttl_sec_;
     config.enable_ha = enable_ha_;
+    config.enable_oplog = enable_oplog_;
+    config.oplog_store_type = oplog_store_type_;
+    config.oplog_data_dir = oplog_data_dir_;
     config.enable_offload = enable_offload_;
     config.cluster_id = cluster_id_;
     config.root_fs_dir = root_fs_dir_;

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -3,12 +3,14 @@
 #include <algorithm>
 #include <boost/functional/hash.hpp>
 #include <functional>
+#include <memory>
 #include <string>
 #include <string_view>
 #include <unordered_map>
 #include <vector>
 #include <ylt/util/tl/expected.hpp>
 
+#include "ha/oplog/oplog_manager.h"
 #include "types.h"
 #include "rpc_types.h"
 #include "replica.h"
@@ -47,13 +49,13 @@ class MasterService {
     /**
      * @brief Register a client with its segments.
      */
-    auto RegisterClient(const RegisterClientRequest& req)
+    virtual auto RegisterClient(const RegisterClientRequest& req)
         -> tl::expected<RegisterClientResponse, ErrorCode>;
 
     /**
      * @brief Unregister a client, removing all its routing metadata
      */
-    auto UnregisterClient(const UnregisterClientRequest& req)
+    virtual auto UnregisterClient(const UnregisterClientRequest& req)
         -> tl::expected<UnregisterClientResponse, ErrorCode>;
 
     /**
@@ -76,7 +78,7 @@ class MasterService {
      * @return ErrorCode::SEGMENT_ALREADY_EXISTS if it is already mounted.
      *         ErrorCode::CLIENT_UNHEALTHY if the client is unhealthy.
      */
-    auto MountSegment(const Segment& segment, const UUID& client_id)
+    virtual auto MountSegment(const Segment& segment, const UUID& client_id)
         -> tl::expected<void, ErrorCode>;
 
     /**
@@ -85,7 +87,7 @@ class MasterService {
      *         ErrorCode::SEGMENT_NOT_FOUND if the segment doesn't exist
      *         ErrorCode::CLIENT_UNHEALTHY if the client is unhealthy
      */
-    auto UnmountSegment(const UUID& segment_id, const UUID& client_id)
+    virtual auto UnmountSegment(const UUID& segment_id, const UUID& client_id)
         -> tl::expected<void, ErrorCode>;
 
     /**
@@ -206,6 +208,8 @@ class MasterService {
      * @return The count of keys
      */
     size_t GetKeyCount() const;
+
+    OpLogManager* GetOpLogManager() const { return oplog_manager_.get(); }
 
    protected:
     struct ObjectMetadata {
@@ -577,6 +581,7 @@ class MasterService {
     // if high availability features enabled
     const bool enable_ha_;
     ViewVersionId view_version_;
+    std::unique_ptr<OpLogManager> oplog_manager_;
 
     friend class MetadataAccessorRW;
     friend class MetadataAccessorRO;

--- a/mooncake-store/include/p2p_master_service.h
+++ b/mooncake-store/include/p2p_master_service.h
@@ -5,6 +5,7 @@
 #include "master_service.h"
 #include "p2p_client_manager.h"
 #include "p2p_rpc_types.h"
+#include "ha/oplog/oplog_manager.h"
 
 namespace mooncake {
 
@@ -17,6 +18,15 @@ class P2PMasterService : public MasterService {
     const ClientManager& GetClientManager() const override {
         return *client_manager_;
     }
+
+    auto RegisterClient(const RegisterClientRequest& req)
+        -> tl::expected<RegisterClientResponse, ErrorCode> override;
+    auto UnregisterClient(const UnregisterClientRequest& req)
+        -> tl::expected<UnregisterClientResponse, ErrorCode> override;
+    auto MountSegment(const Segment& segment, const UUID& client_id)
+        -> tl::expected<void, ErrorCode> override;
+    auto UnmountSegment(const UUID& segment_id, const UUID& client_id)
+        -> tl::expected<void, ErrorCode> override;
 
     /**
      * @brief Get write route based on the config in the request
@@ -59,6 +69,10 @@ class P2PMasterService : public MasterService {
      * @brief Client notifies Master that metadata sync is complete
      */
     auto SetSyncCompleted(UUID client_id) -> tl::expected<void, ErrorCode>;
+
+    ErrorCode RecordOplog(OpType type, const std::string& key,
+                          const std::string& payload = std::string(),
+                          bool sync = true);
 
     std::vector<Replica::Descriptor> FilterReplicas(
         const GetReplicaListRequestConfig& config,

--- a/mooncake-store/include/p2p_master_service.h
+++ b/mooncake-store/include/p2p_master_service.h
@@ -71,8 +71,7 @@ class P2PMasterService : public MasterService {
     auto SetSyncCompleted(UUID client_id) -> tl::expected<void, ErrorCode>;
 
     ErrorCode RecordOplog(OpType type, const std::string& key,
-                          const std::string& payload = std::string(),
-                          bool sync = true);
+                          const std::string& payload = std::string());
 
     std::vector<Replica::Descriptor> FilterReplicas(
         const GetReplicaListRequestConfig& config,

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -127,6 +127,12 @@ DEFINE_string(cxl_path, mooncake::DEFAULT_CXL_PATH,
 DEFINE_uint64(cxl_size, mooncake::DEFAULT_CXL_SIZE, "CXL memory size in bytes");
 DEFINE_bool(enable_cxl, false, "Whether to enable CXL memory support");
 
+DEFINE_bool(enable_oplog, false, "Enable OpLog recording for master metadata");
+DEFINE_string(oplog_store_type, "localfs",
+              "OpLog store backend type. Currently supports localfs");
+DEFINE_string(oplog_data_dir, "/tmp/mooncake_oplog",
+              "Root directory for localfs OpLog data");
+
 // Redis election backend configuration
 DEFINE_string(election_backend, "etcd",
               "Election backend for HA leader election: 'etcd' (default) or "
@@ -190,6 +196,13 @@ void InitMasterConf(const mooncake::DefaultConfig& default_config,
 
     default_config.GetBool("enable_ha", &master_config.enable_ha,
                            FLAGS_enable_ha);
+    default_config.GetBool("enable_oplog", &master_config.enable_oplog,
+                           FLAGS_enable_oplog);
+    default_config.GetString("oplog_store_type",
+                             &master_config.oplog_store_type,
+                             FLAGS_oplog_store_type);
+    default_config.GetString("oplog_data_dir", &master_config.oplog_data_dir,
+                             FLAGS_oplog_data_dir);
     default_config.GetBool("enable_offload", &master_config.enable_offload,
                            FLAGS_enable_offload);
     default_config.GetString("etcd_endpoints", &master_config.etcd_endpoints,
@@ -383,6 +396,21 @@ void LoadConfigFromCmdline(mooncake::MasterConfig& master_config,
          !info.is_default) ||
         !conf_set) {
         master_config.enable_ha = FLAGS_enable_ha;
+    }
+    if ((google::GetCommandLineFlagInfo("enable_oplog", &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.enable_oplog = FLAGS_enable_oplog;
+    }
+    if ((google::GetCommandLineFlagInfo("oplog_store_type", &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.oplog_store_type = FLAGS_oplog_store_type;
+    }
+    if ((google::GetCommandLineFlagInfo("oplog_data_dir", &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.oplog_data_dir = FLAGS_oplog_data_dir;
     }
     if ((google::GetCommandLineFlagInfo("enable_offload", &info) &&
          !info.is_default) ||
@@ -684,6 +712,9 @@ int main(int argc, char* argv[]) {
         << ", eviction_high_watermark_ratio="
         << master_config.eviction_high_watermark_ratio
         << ", enable_ha=" << master_config.enable_ha
+        << ", enable_oplog=" << master_config.enable_oplog
+        << ", oplog_store_type=" << master_config.oplog_store_type
+        << ", oplog_data_dir=" << master_config.oplog_data_dir
         << ", enable_offload=" << master_config.enable_offload
         << ", etcd_endpoints=" << master_config.etcd_endpoints
         << ", client_ttl=" << master_config.client_live_ttl_sec

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -2,9 +2,12 @@
 
 #include <cassert>
 #include <regex>
+#include <stdexcept>
 #include <ylt/util/tl/expected.hpp>
 
 #include "client_manager.h"
+#include "ha/oplog/oplog_manager.h"
+#include "ha/oplog/oplog_store_factory.h"
 #include "master_metric_manager.h"
 #include "types.h"
 
@@ -23,7 +26,29 @@ MasterService::ObjectMetadata::ObjectMetadata(size_t value_length,
 }
 
 MasterService::MasterService(const MasterServiceConfig& config)
-    : enable_ha_(config.enable_ha), view_version_(config.view_version) {}
+    : enable_ha_(config.enable_ha), view_version_(config.view_version) {
+    if (!config.enable_oplog) {
+        return;
+    }
+
+    auto store = OpLogStoreFactory::Create(
+        ParseOpLogStoreType(config.oplog_store_type), config.cluster_id,
+        OpLogStoreRole::WRITER, config.oplog_data_dir);
+    if (!store) {
+        LOG(ERROR) << "MasterService: failed to initialize OpLogStore"
+                   << ", type=" << config.oplog_store_type
+                   << ", data_dir=" << config.oplog_data_dir
+                   << ", cluster_id=" << config.cluster_id;
+        throw std::runtime_error(
+            "failed to initialize OpLogStore while oplog is enabled: type=" +
+            config.oplog_store_type + ", data_dir=" + config.oplog_data_dir +
+            ", cluster_id=" + config.cluster_id);
+    }
+
+    oplog_manager_ = std::make_unique<OpLogManager>();
+    oplog_manager_->SetOpLogStore(
+        std::shared_ptr<OpLogStore>(std::move(store)));
+}
 
 void MasterService::InitializeClientManager() {
     GetClientManager().SetSegmentRemovalCallback(

--- a/mooncake-store/src/p2p_master_service.cpp
+++ b/mooncake-store/src/p2p_master_service.cpp
@@ -19,7 +19,7 @@ P2PMasterService::P2PMasterService(const MasterServiceConfig& config)
 }
 
 ErrorCode P2PMasterService::RecordOplog(OpType type, const std::string& key,
-                                        const std::string& payload, bool sync) {
+                                        const std::string& payload) {
     // TODO: Record remaining failover-visible P2P mutations: client crash
     // cleanup, heartbeat state transitions, replica eviction/rebalance, and
     // task metadata.
@@ -28,21 +28,21 @@ ErrorCode P2PMasterService::RecordOplog(OpType type, const std::string& key,
         return ErrorCode::OK;
     }
 
-    if (sync) {
-        auto result = manager->AppendAndPersist(type, key, payload);
-        if (!result.has_value()) {
-            LOG(ERROR) << "P2PMasterService: failed to persist oplog"
-                       << ", op_type=" << static_cast<int>(type)
-                       << ", key=" << key
-                       << ", error=" << toString(result.error());
-            return result.error();
-        }
-    } else {
-        manager->Append(type, key, payload);
+    auto result = manager->AppendAndPersist(type, key, payload);
+    if (!result.has_value()) {
+        LOG(ERROR) << "P2PMasterService: failed to persist oplog"
+                   << ", op_type=" << static_cast<int>(type) << ", key=" << key
+                   << ", error=" << toString(result.error());
+        return result.error();
     }
     return ErrorCode::OK;
 }
 
+// TODO: Make client/segment lifecycle updates transactional with oplog
+// persistence. These wrappers currently call MasterService first, so an oplog
+// persistence failure can leave Primary memory ahead of Standby. A robust fix
+// needs a separate prepare/log/apply flow or durable retry/outbox mechanism;
+// local rollback is fragile because these calls have nested side effects.
 auto P2PMasterService::RegisterClient(const RegisterClientRequest& req)
     -> tl::expected<RegisterClientResponse, ErrorCode> {
     if (GetClientManager().GetClient(req.client_id)) {
@@ -59,6 +59,9 @@ auto P2PMasterService::RegisterClient(const RegisterClientRequest& req)
 
     auto result = MasterService::RegisterClient(req);
     if (!result.has_value()) {
+        LOG(ERROR) << "RegisterClient(P2P): failed"
+                   << ", client_id=" << req.client_id
+                   << ", error=" << result.error();
         return result;
     }
 
@@ -70,6 +73,8 @@ auto P2PMasterService::RegisterClient(const RegisterClientRequest& req)
     auto err =
         RecordOplog(OpType_REGISTER_CLIENT, "", SerializeP2PPayload(payload));
     if (err != ErrorCode::OK) {
+        LOG(ERROR) << "RegisterClient(P2P): failed to record oplog"
+                   << ", client_id=" << req.client_id << ", error=" << err;
         return tl::make_unexpected(err);
     }
     return result;
@@ -79,6 +84,9 @@ auto P2PMasterService::UnregisterClient(const UnregisterClientRequest& req)
     -> tl::expected<UnregisterClientResponse, ErrorCode> {
     auto result = MasterService::UnregisterClient(req);
     if (!result.has_value()) {
+        LOG(ERROR) << "UnregisterClient(P2P): failed"
+                   << ", client_id=" << req.client_id
+                   << ", error=" << result.error();
         return result;
     }
 
@@ -87,6 +95,8 @@ auto P2PMasterService::UnregisterClient(const UnregisterClientRequest& req)
     auto err =
         RecordOplog(OpType_UNREGISTER_CLIENT, "", SerializeP2PPayload(payload));
     if (err != ErrorCode::OK) {
+        LOG(ERROR) << "UnregisterClient(P2P): failed to record oplog"
+                   << ", client_id=" << req.client_id << ", error=" << err;
         return tl::make_unexpected(err);
     }
     return result;
@@ -97,6 +107,11 @@ auto P2PMasterService::MountSegment(const Segment& segment,
     -> tl::expected<void, ErrorCode> {
     auto result = MasterService::MountSegment(segment, client_id);
     if (!result.has_value()) {
+        LOG(ERROR) << "MountSegment(P2P): failed"
+                   << ", client_id=" << client_id
+                   << ", segment_id=" << segment.id
+                   << ", segment_name=" << segment.name
+                   << ", error=" << result.error();
         return result;
     }
 
@@ -106,6 +121,10 @@ auto P2PMasterService::MountSegment(const Segment& segment,
     auto err =
         RecordOplog(OpType_MOUNT_SEGMENT, "", SerializeP2PPayload(payload));
     if (err != ErrorCode::OK) {
+        LOG(ERROR) << "MountSegment(P2P): failed to record oplog"
+                   << ", client_id=" << client_id
+                   << ", segment_id=" << segment.id
+                   << ", segment_name=" << segment.name << ", error=" << err;
         return tl::make_unexpected(err);
     }
     return {};
@@ -116,6 +135,10 @@ auto P2PMasterService::UnmountSegment(const UUID& segment_id,
     -> tl::expected<void, ErrorCode> {
     auto result = MasterService::UnmountSegment(segment_id, client_id);
     if (!result.has_value()) {
+        LOG(ERROR) << "UnmountSegment(P2P): failed"
+                   << ", client_id=" << client_id
+                   << ", segment_id=" << segment_id
+                   << ", error=" << result.error();
         return result;
     }
 
@@ -125,6 +148,9 @@ auto P2PMasterService::UnmountSegment(const UUID& segment_id,
     auto err =
         RecordOplog(OpType_UNMOUNT_SEGMENT, "", SerializeP2PPayload(payload));
     if (err != ErrorCode::OK) {
+        LOG(ERROR) << "UnmountSegment(P2P): failed to record oplog"
+                   << ", client_id=" << client_id
+                   << ", segment_id=" << segment_id << ", error=" << err;
         return tl::make_unexpected(err);
     }
     return {};
@@ -390,6 +416,10 @@ tl::expected<void, ErrorCode> P2PMasterService::InnerAddReplica(
             RecordOplog(OpType_ADD_REPLICA, payload.object_key,
                         SerializeP2PPayload(payload));
         if (record_err != ErrorCode::OK) {
+            LOG(ERROR) << "AddReplica(P2P): failed to record oplog"
+                       << ", key=" << key << ", client_id=" << client_id
+                       << ", segment_id=" << segment_id
+                       << ", error=" << record_err;
             return tl::make_unexpected(record_err);
         }
         AddReplicaToSegmentIndex(shard, it->first, new_replica);
@@ -409,6 +439,10 @@ tl::expected<void, ErrorCode> P2PMasterService::InnerAddReplica(
             RecordOplog(OpType_ADD_REPLICA, payload.object_key,
                         SerializeP2PPayload(payload));
         if (record_err != ErrorCode::OK) {
+            LOG(ERROR) << "AddReplica(P2P): failed to record oplog"
+                       << ", key=" << key << ", client_id=" << client_id
+                       << ", segment_id=" << segment_id
+                       << ", error=" << record_err;
             return tl::make_unexpected(record_err);
         }
         auto emplace_it =
@@ -459,6 +493,10 @@ tl::expected<void, ErrorCode> P2PMasterService::InnerRemoveReplica(
                 RecordOplog(OpType_REMOVE_REPLICA, payload.object_key,
                             SerializeP2PPayload(payload));
             if (record_err != ErrorCode::OK) {
+                LOG(ERROR) << "RemoveReplica(P2P): failed to record oplog"
+                           << ", key=" << key << ", client_id=" << client_id
+                           << ", segment_id=" << segment_id
+                           << ", error=" << record_err;
                 return tl::make_unexpected(record_err);
             }
             RemoveReplicaFromSegmentIndex(shard, it->first, *rit);

--- a/mooncake-store/src/p2p_master_service.cpp
+++ b/mooncake-store/src/p2p_master_service.cpp
@@ -45,6 +45,12 @@ ErrorCode P2PMasterService::RecordOplog(OpType type, const std::string& key,
 
 auto P2PMasterService::RegisterClient(const RegisterClientRequest& req)
     -> tl::expected<RegisterClientResponse, ErrorCode> {
+    if (GetClientManager().GetClient(req.client_id)) {
+        LOG(WARNING) << "RegisterClient(P2P): client already exists"
+                     << ", client_id=" << req.client_id;
+        return tl::make_unexpected(ErrorCode::CLIENT_ALREADY_EXISTS);
+    }
+
     if (!req.ip_address || !req.rpc_port) {
         LOG(ERROR) << "RegisterClient(P2P): missing endpoint"
                    << ", client_id=" << req.client_id;

--- a/mooncake-store/src/p2p_master_service.cpp
+++ b/mooncake-store/src/p2p_master_service.cpp
@@ -3,6 +3,7 @@
 #include <glog/logging.h>
 #include <algorithm>
 
+#include "ha/oplog/p2p_oplog_types.h"
 #include "p2p_client_meta.h"
 
 namespace mooncake {
@@ -15,6 +16,106 @@ P2PMasterService::P2PMasterService(const MasterServiceConfig& config)
         config.view_version);
     InitializeClientManager();
     client_manager_->Start();
+}
+
+ErrorCode P2PMasterService::RecordOplog(OpType type, const std::string& key,
+                                        const std::string& payload, bool sync) {
+    // TODO: Record remaining failover-visible P2P mutations: client crash
+    // cleanup, heartbeat state transitions, replica eviction/rebalance, and
+    // task metadata.
+    auto* manager = GetOpLogManager();
+    if (manager == nullptr) {
+        return ErrorCode::OK;
+    }
+
+    if (sync) {
+        auto result = manager->AppendAndPersist(type, key, payload);
+        if (!result.has_value()) {
+            LOG(ERROR) << "P2PMasterService: failed to persist oplog"
+                       << ", op_type=" << static_cast<int>(type)
+                       << ", key=" << key
+                       << ", error=" << toString(result.error());
+            return result.error();
+        }
+    } else {
+        manager->Append(type, key, payload);
+    }
+    return ErrorCode::OK;
+}
+
+auto P2PMasterService::RegisterClient(const RegisterClientRequest& req)
+    -> tl::expected<RegisterClientResponse, ErrorCode> {
+    auto result = MasterService::RegisterClient(req);
+    if (!result.has_value()) {
+        return result;
+    }
+
+    RegisterClientPayload payload;
+    payload.client_id = req.client_id;
+    payload.ip_address = *req.ip_address;
+    payload.rpc_port = *req.rpc_port;
+    payload.segments = req.segments;
+    auto err =
+        RecordOplog(OpType_REGISTER_CLIENT, "", SerializeP2PPayload(payload));
+    if (err != ErrorCode::OK) {
+        return tl::make_unexpected(err);
+    }
+    return result;
+}
+
+auto P2PMasterService::UnregisterClient(const UnregisterClientRequest& req)
+    -> tl::expected<UnregisterClientResponse, ErrorCode> {
+    auto result = MasterService::UnregisterClient(req);
+    if (!result.has_value()) {
+        return result;
+    }
+
+    UnregisterClientPayload payload;
+    payload.client_id = req.client_id;
+    auto err =
+        RecordOplog(OpType_UNREGISTER_CLIENT, "", SerializeP2PPayload(payload));
+    if (err != ErrorCode::OK) {
+        return tl::make_unexpected(err);
+    }
+    return result;
+}
+
+auto P2PMasterService::MountSegment(const Segment& segment,
+                                    const UUID& client_id)
+    -> tl::expected<void, ErrorCode> {
+    auto result = MasterService::MountSegment(segment, client_id);
+    if (!result.has_value()) {
+        return result;
+    }
+
+    MountSegmentPayload payload;
+    payload.client_id = client_id;
+    payload.segment = segment;
+    auto err =
+        RecordOplog(OpType_MOUNT_SEGMENT, "", SerializeP2PPayload(payload));
+    if (err != ErrorCode::OK) {
+        return tl::make_unexpected(err);
+    }
+    return {};
+}
+
+auto P2PMasterService::UnmountSegment(const UUID& segment_id,
+                                      const UUID& client_id)
+    -> tl::expected<void, ErrorCode> {
+    auto result = MasterService::UnmountSegment(segment_id, client_id);
+    if (!result.has_value()) {
+        return result;
+    }
+
+    UnmountSegmentPayload payload;
+    payload.segment_id = segment_id;
+    payload.client_id = client_id;
+    auto err =
+        RecordOplog(OpType_UNMOUNT_SEGMENT, "", SerializeP2PPayload(payload));
+    if (err != ErrorCode::OK) {
+        return tl::make_unexpected(err);
+    }
+    return {};
 }
 
 auto P2PMasterService::CollectReplicaOwnerClients(
@@ -268,6 +369,17 @@ tl::expected<void, ErrorCode> P2PMasterService::InnerAddReplica(
                          << ", max owner client num: " << max_replicas_per_key_;
             return tl::make_unexpected(ErrorCode::REPLICA_NUM_EXCEEDED);
         }
+        AddReplicaPayload payload;
+        payload.object_key = std::string(key);
+        payload.client_id = client_id;
+        payload.segment_id = segment_id;
+        payload.size = size;
+        ErrorCode record_err =
+            RecordOplog(OpType_ADD_REPLICA, payload.object_key,
+                        SerializeP2PPayload(payload));
+        if (record_err != ErrorCode::OK) {
+            return tl::make_unexpected(record_err);
+        }
         AddReplicaToSegmentIndex(shard, it->first, new_replica);
         OnReplicaAdded(new_replica);
         metadata.replicas_.push_back(std::move(new_replica));
@@ -276,6 +388,17 @@ tl::expected<void, ErrorCode> P2PMasterService::InnerAddReplica(
         replicas.push_back(std::move(new_replica));
         auto new_meta =
             std::make_unique<ObjectMetadata>(size, std::move(replicas));
+        AddReplicaPayload payload;
+        payload.object_key = std::string(key);
+        payload.client_id = client_id;
+        payload.segment_id = segment_id;
+        payload.size = size;
+        ErrorCode record_err =
+            RecordOplog(OpType_ADD_REPLICA, payload.object_key,
+                        SerializeP2PPayload(payload));
+        if (record_err != ErrorCode::OK) {
+            return tl::make_unexpected(record_err);
+        }
         auto emplace_it =
             shard.metadata.emplace(std::string(key), std::move(new_meta)).first;
         AddReplicaToSegmentIndex(shard, emplace_it->first,
@@ -316,6 +439,16 @@ tl::expected<void, ErrorCode> P2PMasterService::InnerRemoveReplica(
         auto seg_id = rit->get_segment_id();
         auto cli_id = rit->get_p2p_client_id();
         if (cli_id && seg_id && cli_id == client_id && *seg_id == segment_id) {
+            RemoveReplicaPayload payload;
+            payload.object_key = std::string(key);
+            payload.client_id = client_id;
+            payload.segment_id = segment_id;
+            ErrorCode record_err =
+                RecordOplog(OpType_REMOVE_REPLICA, payload.object_key,
+                            SerializeP2PPayload(payload));
+            if (record_err != ErrorCode::OK) {
+                return tl::make_unexpected(record_err);
+            }
             RemoveReplicaFromSegmentIndex(shard, it->first, *rit);
             OnReplicaRemoved(*rit);
             metadata.replicas_.erase(rit);

--- a/mooncake-store/src/p2p_master_service.cpp
+++ b/mooncake-store/src/p2p_master_service.cpp
@@ -45,6 +45,12 @@ ErrorCode P2PMasterService::RecordOplog(OpType type, const std::string& key,
 
 auto P2PMasterService::RegisterClient(const RegisterClientRequest& req)
     -> tl::expected<RegisterClientResponse, ErrorCode> {
+    if (!req.ip_address || !req.rpc_port) {
+        LOG(ERROR) << "RegisterClient(P2P): missing endpoint"
+                   << ", client_id=" << req.client_id;
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
     auto result = MasterService::RegisterClient(req);
     if (!result.has_value()) {
         return result;

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -84,6 +84,7 @@ add_store_test(oplog_replicator_test ha/oplog/oplog_replicator_test.cpp)
 add_store_test(p2p_oplog_test
     ha/oplog/p2p_oplog_test.cpp
     ha/oplog/p2p_oplog_applier_test.cpp
+    ha/oplog/p2p_record_oplog_test.cpp
     ha/oplog/p2p_standby_metadata_store_test.cpp
 )
 add_subdirectory(e2e)

--- a/mooncake-store/tests/ha/oplog/p2p_record_oplog_test.cpp
+++ b/mooncake-store/tests/ha/oplog/p2p_record_oplog_test.cpp
@@ -1,125 +1,319 @@
 #include "p2p_master_service.h"
 
+#include <unistd.h>
+
 #include <gtest/gtest.h>
 
-#include <memory>
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <stdexcept>
 #include <string>
+#include <vector>
 
-#include "ha/oplog/oplog_manager.h"
-#include "ha/oplog/oplog_store_factory.h"
+#include "ha/oplog/localfs_oplog_store.h"
 #include "ha/oplog/p2p_oplog_types.h"
-#include "mock_oplog_store.h"
+#include "master_config.h"
+#include "p2p_rpc_types.h"
+#include "types.h"
 
 namespace mooncake::test {
-
 namespace {
 
-// Helper to create a minimal MasterServiceConfig for P2P mode with oplog
-// enabled.
-MasterServiceConfig MakeP2PConfig(bool enable_oplog = true) {
-    MasterServiceConfig config;
-    config.enable_metric_reporting = false;
-    config.metrics_port = 0;
-    config.rpc_port = 0;
-    config.rpc_thread_num = 1;
-    config.default_kv_lease_ttl = 30000;
-    config.default_kv_soft_pin_ttl = 30000;
-    config.allow_evict_soft_pinned_objects = false;
-    config.eviction_ratio = 0.8;
-    config.eviction_high_watermark_ratio = 0.9;
-    config.client_live_ttl_sec = 30;
-    config.client_crashed_ttl_sec = 90;
-    config.enable_ha = enable_oplog;
-    config.enable_offload = false;
-    config.cluster_id = "test-cluster";
-    config.max_replicas_per_key = 0;
-    config.enable_oplog = enable_oplog;
-    config.oplog_store_type = "localfs";
-    config.oplog_data_dir = "/tmp/mooncake_oplog_test";
-    return config;
-}
+class P2PRecordOplogTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        test_dir_ =
+            std::filesystem::temp_directory_path() /
+            ("mooncake_p2p_record_oplog_test_" + std::to_string(::getpid()) +
+             "_" + std::to_string(reinterpret_cast<uintptr_t>(this)));
+        std::filesystem::remove_all(test_dir_);
+    }
 
-// Verify that RecordOplog writes entries to the OpLogManager.
-TEST(P2PRecordOplogTest, RecordOplogWritesToManager) {
-    MasterServiceConfig config = MakeP2PConfig(/*enable_oplog=*/true);
-    P2PMasterService service(config);
+    void TearDown() override { std::filesystem::remove_all(test_dir_); }
 
-    // With oplog enabled, oplog_manager_ should be initialized.
+    MasterServiceConfig MakeConfig(bool enable_oplog = true) const {
+        return MasterServiceConfig::builder()
+            .set_enable_ha(enable_oplog)
+            .set_enable_oplog(enable_oplog)
+            .set_cluster_id(kClusterId)
+            .set_oplog_store_type("localfs")
+            .set_oplog_data_dir(test_dir_.string())
+            .set_max_replicas_per_key(0)
+            .build();
+    }
+
+    Segment MakeSegment(const UUID& segment_id) const {
+        Segment segment;
+        segment.id = segment_id;
+        segment.name = "segment-" + std::to_string(segment_id.first) + "-" +
+                       std::to_string(segment_id.second);
+        segment.size = 1024 * 1024;
+        segment.extra = P2PSegmentExtraData{
+            .priority = 1,
+            .tags = {},
+            .memory_type = MemoryType::DRAM,
+        };
+        return segment;
+    }
+
+    void RegisterClient(P2PMasterService& service, const UUID& client_id,
+                        const Segment& segment) const {
+        RegisterClientRequest req;
+        req.client_id = client_id;
+        req.ip_address = "127.0.0.1";
+        req.rpc_port = 50051;
+        req.segments = {segment};
+        req.deployment_mode = DeploymentMode::P2P;
+        auto result = service.RegisterClient(req);
+        ASSERT_TRUE(result.has_value()) << toString(result.error());
+    }
+
+    void UnregisterClient(P2PMasterService& service,
+                          const UUID& client_id) const {
+        UnregisterClientRequest req;
+        req.client_id = client_id;
+        req.deployment_mode = DeploymentMode::P2P;
+        auto result = service.UnregisterClient(req);
+        ASSERT_TRUE(result.has_value()) << toString(result.error());
+    }
+
+    void MountSegment(P2PMasterService& service, const Segment& segment,
+                      const UUID& client_id) const {
+        auto result = service.MountSegment(segment, client_id);
+        ASSERT_TRUE(result.has_value()) << toString(result.error());
+    }
+
+    void UnmountSegment(P2PMasterService& service, const UUID& segment_id,
+                        const UUID& client_id) const {
+        auto result = service.UnmountSegment(segment_id, client_id);
+        ASSERT_TRUE(result.has_value()) << toString(result.error());
+    }
+
+    void AddReplica(P2PMasterService& service, const std::string& key,
+                    const UUID& client_id, const UUID& segment_id,
+                    size_t size = 4096) const {
+        AddReplicaRequest req;
+        req.key = key;
+        req.client_id = client_id;
+        req.segment_id = segment_id;
+        req.size = size;
+        auto result = service.AddReplica(req);
+        ASSERT_TRUE(result.has_value()) << toString(result.error());
+    }
+
+    void RemoveReplica(P2PMasterService& service, const std::string& key,
+                       const UUID& client_id, const UUID& segment_id) const {
+        RemoveReplicaRequest req;
+        req.key = key;
+        req.client_id = client_id;
+        req.segment_id = segment_id;
+        auto result = service.RemoveReplica(req);
+        ASSERT_TRUE(result.has_value()) << toString(result.error());
+    }
+
+    OpLogEntry ReadEntry(uint64_t sequence_id) const {
+        LocalFsOpLogStore reader(kClusterId, test_dir_.string(),
+                                 /*enable_batch_write=*/false);
+        EXPECT_EQ(reader.Init(), ErrorCode::OK);
+
+        OpLogEntry entry;
+        EXPECT_EQ(reader.ReadOpLog(sequence_id, entry), ErrorCode::OK);
+        return entry;
+    }
+
+    static constexpr const char* kClusterId = "p2p-record-oplog-test";
+    std::filesystem::path test_dir_;
+};
+
+TEST_F(P2PRecordOplogTest, RegisterClientRecordsOplog) {
+    P2PMasterService service(MakeConfig());
+    const UUID client_id{1, 1};
+    const UUID segment_id{2, 2};
+    Segment segment = MakeSegment(segment_id);
+    RegisterClient(service, client_id, segment);
+
     auto* manager = service.GetOpLogManager();
     ASSERT_NE(manager, nullptr);
+    EXPECT_EQ(manager->GetLastSequenceId(), 1);
 
-    // Write an ADD_REPLICA entry via RecordOplog.
+    OpLogEntry entry = ReadEntry(1);
+    EXPECT_EQ(entry.op_type, OpType_REGISTER_CLIENT);
+    EXPECT_EQ(entry.object_key, "");
+
+    RegisterClientPayload payload;
+    ASSERT_TRUE(DeserializeP2PPayload(entry.payload, payload));
+    EXPECT_EQ(payload.client_id, client_id);
+    EXPECT_EQ(payload.ip_address, "127.0.0.1");
+    EXPECT_EQ(payload.rpc_port, 50051);
+    ASSERT_EQ(payload.segments.size(), 1);
+    EXPECT_EQ(payload.segments[0].id, segment.id);
+    EXPECT_EQ(payload.segments[0].name, segment.name);
+}
+
+TEST_F(P2PRecordOplogTest, MountAndUnmountSegmentRecordOplog) {
+    P2PMasterService service(MakeConfig());
+    const UUID client_id{3, 3};
+    const UUID initial_segment_id{4, 4};
+    const UUID extra_segment_id{5, 5};
+    RegisterClient(service, client_id, MakeSegment(initial_segment_id));
+
+    Segment extra_segment = MakeSegment(extra_segment_id);
+    MountSegment(service, extra_segment, client_id);
+    UnmountSegment(service, extra_segment_id, client_id);
+
+    auto* manager = service.GetOpLogManager();
+    ASSERT_NE(manager, nullptr);
+    EXPECT_EQ(manager->GetLastSequenceId(), 3);
+
+    OpLogEntry mount_entry = ReadEntry(2);
+    EXPECT_EQ(mount_entry.op_type, OpType_MOUNT_SEGMENT);
+    EXPECT_EQ(mount_entry.object_key, "");
+
+    MountSegmentPayload mount_payload;
+    ASSERT_TRUE(DeserializeP2PPayload(mount_entry.payload, mount_payload));
+    EXPECT_EQ(mount_payload.client_id, client_id);
+    EXPECT_EQ(mount_payload.segment.id, extra_segment_id);
+    EXPECT_EQ(mount_payload.segment.name, extra_segment.name);
+
+    OpLogEntry unmount_entry = ReadEntry(3);
+    EXPECT_EQ(unmount_entry.op_type, OpType_UNMOUNT_SEGMENT);
+    EXPECT_EQ(unmount_entry.object_key, "");
+
+    UnmountSegmentPayload unmount_payload;
+    ASSERT_TRUE(DeserializeP2PPayload(unmount_entry.payload, unmount_payload));
+    EXPECT_EQ(unmount_payload.client_id, client_id);
+    EXPECT_EQ(unmount_payload.segment_id, extra_segment_id);
+}
+
+TEST_F(P2PRecordOplogTest, UnregisterClientRecordsOplog) {
+    P2PMasterService service(MakeConfig());
+    const UUID client_id{6, 6};
+    const UUID segment_id{7, 7};
+    RegisterClient(service, client_id, MakeSegment(segment_id));
+
+    UnregisterClient(service, client_id);
+
+    auto* manager = service.GetOpLogManager();
+    ASSERT_NE(manager, nullptr);
+    EXPECT_EQ(manager->GetLastSequenceId(), 2);
+
+    OpLogEntry entry = ReadEntry(2);
+    EXPECT_EQ(entry.op_type, OpType_UNREGISTER_CLIENT);
+    EXPECT_EQ(entry.object_key, "");
+
+    UnregisterClientPayload payload;
+    ASSERT_TRUE(DeserializeP2PPayload(entry.payload, payload));
+    EXPECT_EQ(payload.client_id, client_id);
+}
+
+TEST_F(P2PRecordOplogTest, AddReplicaRecordsOplog) {
+    P2PMasterService service(MakeConfig());
+    const UUID client_id{8, 8};
+    const UUID segment_id{9, 9};
+    RegisterClient(service, client_id, MakeSegment(segment_id));
+
+    AddReplica(service, "key-a", client_id, segment_id, 1234);
+
+    auto* manager = service.GetOpLogManager();
+    ASSERT_NE(manager, nullptr);
+    EXPECT_EQ(manager->GetLastSequenceId(), 2);
+
+    OpLogEntry entry = ReadEntry(2);
+    EXPECT_EQ(entry.op_type, OpType_ADD_REPLICA);
+    EXPECT_EQ(entry.object_key, "key-a");
+
     AddReplicaPayload payload;
-    payload.object_key = "test-key";
-    payload.client_id = {1, 0};
-    payload.segment_id = {10, 0};
-    payload.size = 1024;
-    service.RecordOplog(OpType_ADD_REPLICA, "test-key",
-                        SerializeP2PPayload(payload));
-
-    // Verify the entry was written.
-    uint64_t latest = 0;
-    EXPECT_EQ(manager->GetLastSequenceId(), 1u);
+    ASSERT_TRUE(DeserializeP2PPayload(entry.payload, payload));
+    EXPECT_EQ(payload.object_key, "key-a");
+    EXPECT_EQ(payload.client_id, client_id);
+    EXPECT_EQ(payload.segment_id, segment_id);
+    EXPECT_EQ(payload.size, 1234);
 }
 
-// Verify that RecordOplog with sync=true calls AppendAndPersist.
-TEST(P2PRecordOplogTest, RecordOplogSyncWritesToManager) {
-    MasterServiceConfig config = MakeP2PConfig(/*enable_oplog=*/true);
-    P2PMasterService service(config);
+TEST_F(P2PRecordOplogTest, RemoveReplicaRecordsOplog) {
+    P2PMasterService service(MakeConfig());
+    const UUID client_id{10, 10};
+    const UUID segment_id{11, 11};
+    RegisterClient(service, client_id, MakeSegment(segment_id));
+    AddReplica(service, "key-r", client_id, segment_id);
+
+    RemoveReplica(service, "key-r", client_id, segment_id);
 
     auto* manager = service.GetOpLogManager();
     ASSERT_NE(manager, nullptr);
+    EXPECT_EQ(manager->GetLastSequenceId(), 3);
+
+    OpLogEntry entry = ReadEntry(3);
+    EXPECT_EQ(entry.op_type, OpType_REMOVE_REPLICA);
+    EXPECT_EQ(entry.object_key, "key-r");
 
     RemoveReplicaPayload payload;
-    payload.object_key = "test-key";
-    payload.client_id = {1, 0};
-    payload.segment_id = {10, 0};
-    service.RecordOplog(OpType_REMOVE_REPLICA, "test-key",
-                        SerializeP2PPayload(payload), /*sync=*/true);
-
-    EXPECT_EQ(manager->GetLastSequenceId(), 1u);
+    ASSERT_TRUE(DeserializeP2PPayload(entry.payload, payload));
+    EXPECT_EQ(payload.object_key, "key-r");
+    EXPECT_EQ(payload.client_id, client_id);
+    EXPECT_EQ(payload.segment_id, segment_id);
 }
 
-// Verify that RecordOplog is no-op when HA is disabled.
-TEST(P2PRecordOplogTest, RecordOplogNoopWhenDisabled) {
-    MasterServiceConfig config = MakeP2PConfig(/*enable_oplog=*/false);
-    P2PMasterService service(config);
+TEST_F(P2PRecordOplogTest, BatchSyncReplicaRecordsSuccessfulOps) {
+    P2PMasterService service(MakeConfig());
+    const UUID client_id{12, 12};
+    const UUID segment_id{13, 13};
+    RegisterClient(service, client_id, MakeSegment(segment_id));
+    AddReplica(service, "old-key", client_id, segment_id);
 
-    auto* manager = service.GetOpLogManager();
-    EXPECT_EQ(manager, nullptr);
+    BatchSyncReplicaRequest req;
+    req.client_id = client_id;
+    req.add_keys = {"new-key"};
+    req.add_segment_ids = {segment_id};
+    req.add_sizes = {2048};
+    req.remove_keys = {"old-key"};
+    req.remove_segment_ids = {segment_id};
 
-    // Should not crash — just a no-op.
-    AddReplicaPayload payload;
-    payload.object_key = "test-key";
-    service.RecordOplog(OpType_ADD_REPLICA, "test-key",
-                        SerializeP2PPayload(payload));
-}
-
-// Verify that multiple RecordOplog calls result in sequential sequence IDs.
-TEST(P2PRecordOplogTest, MultipleRecordsGetSequentialIds) {
-    MasterServiceConfig config = MakeP2PConfig(/*enable_oplog=*/true);
-    P2PMasterService service(config);
+    auto response = service.BatchSyncReplica(req);
+    ASSERT_EQ(response.add_results.size(), 1);
+    ASSERT_EQ(response.remove_results.size(), 1);
+    EXPECT_EQ(response.add_results[0], ErrorCode::OK);
+    EXPECT_EQ(response.remove_results[0], ErrorCode::OK);
 
     auto* manager = service.GetOpLogManager();
     ASSERT_NE(manager, nullptr);
+    EXPECT_EQ(manager->GetLastSequenceId(), 4);
 
-    AddReplicaPayload add_payload;
-    add_payload.object_key = "key1";
-    add_payload.client_id = {1, 0};
-    add_payload.segment_id = {10, 0};
-    add_payload.size = 1024;
-    service.RecordOplog(OpType_ADD_REPLICA, "key1",
-                        SerializeP2PPayload(add_payload));
+    std::vector<OpLogEntry> entries = {ReadEntry(3), ReadEntry(4)};
+    auto has_entry = [&](OpType type, const std::string& key) {
+        return std::any_of(
+            entries.begin(), entries.end(), [&](const OpLogEntry& entry) {
+                return entry.op_type == type && entry.object_key == key;
+            });
+    };
 
-    RemoveReplicaPayload rm_payload;
-    rm_payload.object_key = "key1";
-    rm_payload.client_id = {1, 0};
-    rm_payload.segment_id = {10, 0};
-    service.RecordOplog(OpType_REMOVE_REPLICA, "key1",
-                        SerializeP2PPayload(rm_payload));
-
-    uint64_t latest = 0;
-    EXPECT_EQ(manager->GetLastSequenceId(), 2u);
+    EXPECT_TRUE(has_entry(OpType_REMOVE_REPLICA, "old-key"));
+    EXPECT_TRUE(has_entry(OpType_ADD_REPLICA, "new-key"));
 }
 
+TEST_F(P2PRecordOplogTest, EnabledOplogFailsFastWhenStoreInitFails) {
+    std::filesystem::create_directories(test_dir_);
+    const auto invalid_root = test_dir_ / "not-a-directory";
+    std::ofstream(invalid_root) << "file";
+    ASSERT_TRUE(std::filesystem::is_regular_file(invalid_root));
+
+    auto config = MakeConfig();
+    config.oplog_data_dir = invalid_root.string();
+
+    EXPECT_THROW(P2PMasterService service(config), std::runtime_error);
+}
+
+TEST_F(P2PRecordOplogTest, DisabledOplogDoesNotCreateManager) {
+    P2PMasterService service(MakeConfig(/*enable_oplog=*/false));
+    const UUID client_id{14, 14};
+    const UUID segment_id{15, 15};
+    RegisterClient(service, client_id, MakeSegment(segment_id));
+
+    AddReplica(service, "key-disabled", client_id, segment_id);
+
+    EXPECT_EQ(service.GetOpLogManager(), nullptr);
+}
+
+}  // namespace
 }  // namespace mooncake::test

--- a/mooncake-store/tests/ha/oplog/p2p_record_oplog_test.cpp
+++ b/mooncake-store/tests/ha/oplog/p2p_record_oplog_test.cpp
@@ -151,6 +151,33 @@ TEST_F(P2PRecordOplogTest, RegisterClientRecordsOplog) {
     EXPECT_EQ(payload.segments[0].name, segment.name);
 }
 
+TEST_F(P2PRecordOplogTest, RegisterClientRejectsMissingEndpoint) {
+    P2PMasterService service(MakeConfig());
+    const UUID segment_id{2, 2};
+
+    RegisterClientRequest missing_ip;
+    missing_ip.client_id = {1, 1};
+    missing_ip.rpc_port = 50051;
+    missing_ip.segments = {MakeSegment(segment_id)};
+    missing_ip.deployment_mode = DeploymentMode::P2P;
+    auto missing_ip_result = service.RegisterClient(missing_ip);
+    ASSERT_FALSE(missing_ip_result.has_value());
+    EXPECT_EQ(missing_ip_result.error(), ErrorCode::INVALID_PARAMS);
+
+    RegisterClientRequest missing_port;
+    missing_port.client_id = {3, 3};
+    missing_port.ip_address = "127.0.0.1";
+    missing_port.segments = {MakeSegment(segment_id)};
+    missing_port.deployment_mode = DeploymentMode::P2P;
+    auto missing_port_result = service.RegisterClient(missing_port);
+    ASSERT_FALSE(missing_port_result.has_value());
+    EXPECT_EQ(missing_port_result.error(), ErrorCode::INVALID_PARAMS);
+
+    auto* manager = service.GetOpLogManager();
+    ASSERT_NE(manager, nullptr);
+    EXPECT_EQ(manager->GetLastSequenceId(), 0);
+}
+
 TEST_F(P2PRecordOplogTest, MountAndUnmountSegmentRecordOplog) {
     P2PMasterService service(MakeConfig());
     const UUID client_id{3, 3};


### PR DESCRIPTION
## Description

  Record P2P metadata mutations into OpLog so standby metadata can replay failover-visible P2P state changes.

  This change adds OpLog recording for:
  - P2P client register/unregister
  - P2P segment mount/unmount
  - P2P replica add/remove
  - successful `BatchSyncReplica` add/remove operations

  It also wires OpLog configuration through master config, initializes the master-side OpLog manager when enabled, fails fast if the OpLog
  store cannot be initialized, and adds P2P OpLog recording tests.

  ## Module

  - [ ] Transfer Engine (`mooncake-transfer-engine`)
  - [ ] Mooncake Store (`mooncake-store`)
  - [ ] Mooncake EP (`mooncake-ep`)
  - [ ] Mooncake PG (`mooncake-pg`)
  - [ ] Integration (`mooncake-integration`)
  - [x] P2P Store (`mooncake-p2p-store`)
  - [ ] Python Wheel (`mooncake-wheel`)
  - [ ] Common (`mooncake-common`)
  - [ ] Mooncake RL (`mooncake-rl`)
  - [ ] CI/CD
  - [x] Docs
  - [ ] Other

  ## Type of Change

  - [ ] Bug fix
  - [x] New feature
  - [ ] Refactor
  - [ ] Breaking change
  - [x] Documentation update
  - [ ] Performance improvement
  - [ ] Other

  ## How Has This Been Tested?

  Built and ran the P2P OpLog unit test target in container `mooncake-redis-ha-verify`.

  **Test commands:**
  ```bash
  clang-format-20 -style=file -i \
    mooncake-store/src/master_service.cpp \
    mooncake-store/tests/ha/oplog/p2p_record_oplog_test.cpp

  cd /tmp/mooncake-record-oplog-build
  cmake --build . --target p2p_oplog_test -j$(nproc)
  ./mooncake-store/tests/p2p_oplog_test
```
  Test results:

  - [x] Unit tests pass
  - [ ] Integration tests pass (if applicable)
  - [ ] Manual testing done (describe below)

  p2p_oplog_test: 66 tests passed.

  ## Checklist

  - [x] I have performed a self-review of my own code
  - [x] I have formatted my code using ./scripts/code_format.sh
  - [ ] I have run pre-commit run --all-files and all hooks pass
  - [x] I have updated the documentation (if applicable)
  - [x] I have added tests to prove my changes are effective
  - [ ] For changes >500 LOC: I have filed an RFC issue

  ## AI Assistance Disclosure

  - [ ] No AI tools were used
  - [x] AI tools were used (specify below)

  AI tools were used to review the change, identify consistency risks, adjust tests, and prepare this PR description. The submitter reviewed
  and validated the final changes.