### PR TITLE
Add file-level model weight cache control plane

### DIFF
--- a/docs/source/deployment/integrations/sglang/index.md
+++ b/docs/source/deployment/integrations/sglang/index.md
@@ -51,4 +51,5 @@ HiCache extends SGLang's RadixAttention with three memory tiers, using Mooncake 
 pd-disaggregation
 hicache-quick-start
 hicache-integration-v1
+weight-file-cache-control-plane
 ::::

--- a/docs/source/deployment/integrations/sglang/weight-file-cache-control-plane.md
+++ b/docs/source/deployment/integrations/sglang/weight-file-cache-control-plane.md
@@ -1,0 +1,314 @@
+# Mooncake File-level Model Weight Cache
+
+This page describes the experimental file-level model weight cache control
+plane for Mooncake Store.
+
+The feature keeps model artifacts in their normal HuggingFace-style directory
+layout. Operators import a local model directory into Mooncake Store, and
+Mooncake records a file manifest for operational query, verification,
+materialization, and deletion.
+
+## Runtime Topology
+
+Run the weight management CLI as a pure Mooncake Store client. A separate
+standalone Store service owns the memory or SSD capacity:
+
+```text
+mooncake_master
+  |
+  v
+python -m mooncake.mooncake_store_service
+  # resource owner: global_segment_size > 0, local_buffer_size = 0
+
+python -m mooncake.weight_store.cli
+  # pure client: contributes no segment; client buffer is fixed internally
+```
+
+Start the master with the embedded HTTP metadata server:
+
+```bash
+mooncake_master \
+  --enable_http_metadata_server=true \
+  --http_metadata_server_host=0.0.0.0 \
+  --http_metadata_server_port=8080 \
+  --rpc_address=127.0.0.1 \
+  --rpc_port=50051
+```
+
+Create a Store service config:
+
+```json
+{
+  "local_hostname": "storage-node:12345",
+  "metadata_server": "http://127.0.0.1:8080/metadata",
+  "global_segment_size": "300GB",
+  "local_buffer_size": "0",
+  "protocol": "tcp",
+  "device_name": "",
+  "master_server_address": "127.0.0.1:50051"
+}
+```
+
+Start the standalone Store service:
+
+```bash
+python -m mooncake.mooncake_store_service \
+  --config=/etc/mooncake/store-node.json \
+  --port=8081
+```
+
+Do not use the weight management CLI as a temporary resource owner. The CLI is
+always a pure client: it contributes no storage segment, so the model cache
+lifetime is never tied to a short-lived CLI process. Scale the standalone Store
+service to provide capacity instead.
+
+## Import
+
+When running from a source checkout without installing the wheel, use:
+
+```bash
+PYTHONPATH=mooncake-wheel python3 -m mooncake.weight_store.cli ...
+```
+
+After installing the wheel, use the console script directly:
+
+```bash
+mooncake_weight_store ...
+```
+
+Store connection settings can be written once:
+
+```bash
+mooncake_weight_store \
+  --local-hostname cli-client:12346 \
+  --metadata-server http://127.0.0.1:8080/metadata \
+  --master-server-addr 127.0.0.1:50051 \
+  --protocol tcp \
+  config init
+```
+
+`config init` stores connection settings only. Use `--protocol rdma` together
+with `--rdma-devices mlx5_0,mlx5_1` for RDMA transport; leave the default `tcp`
+when RDMA hardware is not available.
+
+By default this writes `~/.config/mooncake/weight_store.json`. Use
+`--config /path/to/weight_store.json` or the `MOONCAKE_WEIGHT_STORE_CONFIG`
+environment variable to select another file. Command-line flags still override
+values loaded from the config file.
+
+```bash
+mooncake_weight_store model import \
+  --checkpoint-id qwen2_5_32b_main \
+  --model-id Qwen/Qwen2.5-32B-Instruct \
+  --revision main \
+  --source /models/qwen2.5-32b \
+  --replica-num 1 \
+  --file-chunk-size 64MB
+```
+
+`--replica-num` and `--file-chunk-size` are import-only options; other model
+commands do not accept them.
+
+The import command scans the source directory, validates
+`model.safetensors.index.json` when present, streams files into fixed-size
+chunk objects, writes weight chunks as `ObjectDataType.WEIGHT`, writes
+config/tokenizer/index chunks as `ObjectDataType.METADATA`, and stores a final
+manifest at:
+
+```text
+weight/models/{checkpoint_id}/manifest
+```
+
+Each manifest file record remains file-level and includes the chunk keys used
+for storage:
+
+```text
+weight/models/{checkpoint_id}/files/{relative_path_sha256}/chunks/{chunk_index}
+```
+
+Import rejects an existing `checkpoint_id`. If object writes fail after import
+has started, the tool writes a `FAILED` manifest so operators can inspect the
+partial state.
+
+## Operations
+
+```bash
+mooncake_weight_store model list
+mooncake_weight_store model inspect qwen2_5_32b_main
+mooncake_weight_store model verify qwen2_5_32b_main
+mooncake_weight_store model materialize-file qwen2_5_32b_main \
+  --path config.json \
+  --output /tmp/config.json
+mooncake_weight_store model delete qwen2_5_32b_main
+```
+
+`verify` checks that the checkpoint is `READY`, every manifest file object is
+readable, each object's size and sha256 match the manifest, and the
+`model.safetensors.index.json` references only files present in the manifest.
+
+`delete` removes file objects, the manifest, and the index entries.
+
+## Implementation Status
+
+The current prototype includes:
+
+- File-level `model import/list/inspect/verify/materialize-file/delete`.
+- A config file for Store connection settings.
+- Pure-client CLI operation that contributes no Store segment.
+- File-level manifests backed by chunk-level Store objects.
+- Safetensors index validation.
+- `ObjectDataType.WEIGHT` and `ObjectDataType.METADATA` tagging.
+- Import progress output with file count, imported bytes, percentage, average
+  throughput, and ETA.
+- Failed manifests for interrupted imports, with cleanup of the current file's
+  partial chunks.
+
+Validated scenarios:
+
+- Unit tests for model cache and CLI behavior.
+- Standalone Store service started with
+  `python -m mooncake.mooncake_store_service`.
+- MiniMax-M2.7 import and verify with a 300 GB Store segment.
+
+## MiniMax Smoke Script
+
+Run this script inside the test container. It does not include a `docker exec`
+wrapper. It starts a fresh master, starts the standalone Store service with a
+300 GB segment, configures the weight CLI as a pure client, imports MiniMax, and
+then verifies the checkpoint.
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CODE=${CODE:-/tmp/mooncake-file-level}
+export MODEL_DIR=${MODEL_DIR:-/data0/models/MiniMax-M2.7}
+export CHECKPOINT_ID=${CHECKPOINT_ID:-MiniMax-M2.7}
+export MODEL_ID=${MODEL_ID:-MiniMax-M2.7}
+export STORE_SIZE=${STORE_SIZE:-300GB}
+export CHUNK_SIZE=${CHUNK_SIZE:-64MB}
+
+export PYTHONPATH=$CODE/mooncake-wheel
+export LD_LIBRARY_PATH=/usr/local/lib/python3.12/dist-packages/mooncake_transfer_engine.libs:/usr/local/lib/python3.12/dist-packages/mooncake:$CODE/mooncake-wheel/mooncake
+
+python3 - <<PY
+import os
+import signal
+import subprocess
+
+patterns = (
+    "mooncake_master",
+    "mooncake_http_metadata_server",
+    "mooncake.mooncake_store_service",
+    "/tmp/weight_store_node.py",
+    "/tmp/storage_node.py",
+)
+
+for line in subprocess.check_output(["ps", "-ef"], text=True).splitlines():
+    if any(pattern in line for pattern in patterns) and "python3 - <<PY" not in line:
+        try:
+            os.kill(int(line.split()[1]), signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+PY
+
+sleep 2
+
+nohup /usr/local/lib/python3.12/dist-packages/mooncake/mooncake_master \
+  --enable_http_metadata_server=true \
+  --http_metadata_server_host=0.0.0.0 \
+  --http_metadata_server_port=8080 \
+  --rpc_address=127.0.0.1 \
+  --rpc_port=50051 \
+  --logtostderr=true \
+  >/tmp/mooncake_master.log 2>&1 &
+
+sleep 3
+
+cat >/tmp/mooncake-store-node.json <<JSON
+{
+  "local_hostname": "storage-node:12345",
+  "metadata_server": "http://127.0.0.1:8080/metadata",
+  "global_segment_size": "$STORE_SIZE",
+  "local_buffer_size": "0",
+  "protocol": "tcp",
+  "device_name": "",
+  "master_server_address": "127.0.0.1:50051"
+}
+JSON
+
+nohup python3 -m mooncake.mooncake_store_service \
+  --config=/tmp/mooncake-store-node.json \
+  --port=8081 \
+  >/tmp/mooncake_store_service.log 2>&1 &
+
+sleep 8
+tail -80 /tmp/mooncake_store_service.log
+
+python3 -m mooncake.weight_store.cli \
+  --config /tmp/weight-store-test.json \
+  config init \
+  --local-hostname cli-client:12346 \
+  --metadata-server http://127.0.0.1:8080/metadata \
+  --master-server-addr 127.0.0.1:50051 \
+  --protocol tcp
+
+cat /tmp/weight-store-test.json
+
+python3 -m mooncake.weight_store.cli \
+  --config /tmp/weight-store-test.json \
+  model delete "$CHECKPOINT_ID" || true
+
+python3 -m mooncake.weight_store.cli \
+  --config /tmp/weight-store-test.json \
+  model import \
+  --checkpoint-id "$CHECKPOINT_ID" \
+  --model-id "$MODEL_ID" \
+  --revision local \
+  --source "$MODEL_DIR" \
+  --replica-num 1 \
+  --file-chunk-size "$CHUNK_SIZE"
+
+python3 -m mooncake.weight_store.cli \
+  --config /tmp/weight-store-test.json \
+  model list
+
+python3 -m mooncake.weight_store.cli \
+  --config /tmp/weight-store-test.json \
+  model verify "$CHECKPOINT_ID"
+```
+
+## SGLang Connector
+
+This control plane only handles import/serve on the store side. Loading a
+`mooncake://` checkpoint into SGLang requires the companion connector that ships
+in the SGLang tree (`python/sglang/srt/connector/mooncake_store_file.py`); it is
+not part of this repository. With that connector present, SGLang loads directly
+from Mooncake Store through the standard remote loader:
+
+```bash
+python -m sglang.launch_server \
+  --model mooncake://MiniMax-M2.7 \
+  --served-model-name MiniMax-M2.7 \
+  --load-format remote \
+  --model-loader-extra-config '{
+    "mooncake_weight_store_config": "/tmp/weight-store-test.json",
+    "materialize_dir": "/tmp/mooncake-sglang-models"
+  }'
+```
+
+`--served-model-name` is required because the `mooncake://` URL contains a colon,
+which SGLang otherwise reserves for LoRA `model:adapter` syntax.
+
+The connector reads Mooncake chunks sequentially, parses the safetensors header,
+identifies tensor boundaries from `data_offsets`, and streams tensors to SGLang
+without materializing complete weight files on local disk. Only small
+metadata/tokenizer/config files are materialized under `materialize_dir`. Reads
+coalesce each tensor batch into one range request against a reused, registered
+RDMA buffer.
+
+## Current Limitations
+
+This first slice is file-level only. It does not create tensor-level
+checkpoints, and does not yet implement serving leases or a production catalog
+backend. The model index is stored as Mooncake objects for the prototype.

--- a/mooncake-wheel/mooncake/weight_store/__init__.py
+++ b/mooncake-wheel/mooncake/weight_store/__init__.py
@@ -1,0 +1,27 @@
+from .model import (
+    FAILED,
+    READY,
+    ModelFileCacheClient,
+    ModelFileManifest,
+    ModelFileRecord,
+)
+from .model_keyspace import (
+    model_file_chunk_key,
+    model_file_key,
+    model_id_index_key,
+    model_index_key,
+    model_manifest_key,
+)
+
+__all__ = [
+    "FAILED",
+    "READY",
+    "ModelFileCacheClient",
+    "ModelFileManifest",
+    "ModelFileRecord",
+    "model_file_chunk_key",
+    "model_file_key",
+    "model_id_index_key",
+    "model_index_key",
+    "model_manifest_key",
+]

--- a/mooncake-wheel/mooncake/weight_store/cli.py
+++ b/mooncake-wheel/mooncake/weight_store/cli.py
@@ -1,0 +1,291 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from .model import DEFAULT_FILE_CHUNK_SIZE, ModelFileCacheClient
+
+
+DEFAULT_CONFIG_PATH = "~/.config/mooncake/weight_store.json"
+
+# The CLI is always a pure Store client: it never contributes a storage
+# segment (global_segment_size = 0) and only needs a small local RDMA buffer.
+_CLIENT_GLOBAL_SEGMENT_SIZE = 0
+_CLIENT_LOCAL_BUFFER_SIZE = 512 * 1024 * 1024
+
+
+def build_parser(argv: Optional[List[str]] = None) -> argparse.ArgumentParser:
+    if argv is None:
+        argv = sys.argv[1:]
+    argv = _normalize_global_args(argv)
+    defaults = _load_config_defaults(argv)
+    parser = argparse.ArgumentParser(description="Manage Mooncake model weight cache.")
+    _add_store_args(parser, defaults)
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    config_parser = subparsers.add_parser("config")
+    config_subparsers = config_parser.add_subparsers(
+        dest="config_command", required=True
+    )
+    config_subparsers.add_parser("init").set_defaults(handler=_cmd_config_init)
+
+    model_parser = subparsers.add_parser("model")
+    model_subparsers = model_parser.add_subparsers(dest="model_command", required=True)
+
+    import_parser = model_subparsers.add_parser("import")
+    import_parser.add_argument("--checkpoint-id", required=True)
+    import_parser.add_argument("--model-id", required=True)
+    import_parser.add_argument("--revision", required=True)
+    import_parser.add_argument("--source", required=True)
+    import_parser.add_argument(
+        "--replica-num", type=int, default=defaults["replica_num"]
+    )
+    import_parser.add_argument("--file-chunk-size", default=defaults["file_chunk_size"])
+    import_parser.set_defaults(handler=_cmd_model_import)
+
+    model_subparsers.add_parser("list").set_defaults(handler=_cmd_model_list)
+
+    handlers = {
+        "inspect": _cmd_model_inspect,
+        "verify": _cmd_model_verify,
+        "delete": _cmd_model_delete,
+    }
+    for command, handler in handlers.items():
+        command_parser = model_subparsers.add_parser(command)
+        command_parser.add_argument("checkpoint_id")
+        command_parser.set_defaults(handler=handler)
+
+    materialize_parser = model_subparsers.add_parser("materialize-file")
+    materialize_parser.add_argument("checkpoint_id")
+    materialize_parser.add_argument("--path", required=True)
+    materialize_parser.add_argument("--output", required=True)
+    materialize_parser.set_defaults(handler=_cmd_model_materialize)
+
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    if argv is None:
+        argv = sys.argv[1:]
+    argv = _normalize_global_args(argv)
+    args = build_parser(argv).parse_args(argv)
+    return args.handler(args)
+
+
+def _cmd_config_init(args) -> int:
+    config_path = Path(args.config).expanduser()
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = _store_config_from_args(args)
+    config_path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    print(_to_json({"config": str(config_path), "written": True}))
+    return 0
+
+
+def _cmd_model_import(args) -> int:
+    manifest = _create_model_client(args).import_model(
+        checkpoint_id=args.checkpoint_id,
+        model_id=args.model_id,
+        revision=args.revision,
+        source_uri=args.source,
+    )
+    print(_to_json(manifest))
+    return 0
+
+
+def _cmd_model_list(args) -> int:
+    print(_to_json(_create_model_client(args).list_models()))
+    return 0
+
+
+def _cmd_model_inspect(args) -> int:
+    print(_to_json(_create_model_client(args).inspect_model(args.checkpoint_id)))
+    return 0
+
+
+def _cmd_model_verify(args) -> int:
+    print(_to_json(_create_model_client(args).verify_model(args.checkpoint_id)))
+    return 0
+
+
+def _cmd_model_delete(args) -> int:
+    _create_model_client(args).delete_model(args.checkpoint_id)
+    print(_to_json({"checkpoint_id": args.checkpoint_id, "deleted": True}))
+    return 0
+
+
+def _cmd_model_materialize(args) -> int:
+    _create_model_client(args).materialize_file(
+        args.checkpoint_id, args.path, args.output
+    )
+    print(
+        _to_json(
+            {
+                "checkpoint_id": args.checkpoint_id,
+                "path": args.path,
+                "output": args.output,
+            }
+        )
+    )
+    return 0
+
+
+def _to_json(value) -> str:
+    if hasattr(value, "to_dict"):
+        value = value.to_dict()
+    return json.dumps(value, ensure_ascii=False, indent=2)
+
+
+def _create_model_client(args) -> ModelFileCacheClient:
+    # replica_num / file_chunk_size only apply to import; other commands do not
+    # define them and fall back to the client defaults.
+    kwargs = {}
+    if getattr(args, "replica_num", None) is not None:
+        kwargs["replica_num"] = args.replica_num
+    if getattr(args, "file_chunk_size", None) is not None:
+        kwargs["file_chunk_size"] = _parse_size(args.file_chunk_size)
+    return ModelFileCacheClient(_connect_store(args), progress=True, **kwargs)
+
+
+def _add_store_args(parser: argparse.ArgumentParser, defaults: dict) -> None:
+    parser.add_argument("--config", default=defaults["config"])
+    parser.add_argument("--local-hostname", default=defaults["local_hostname"])
+    parser.add_argument("--metadata-server", default=defaults["metadata_server"])
+    parser.add_argument("--protocol", default=defaults["protocol"])
+    parser.add_argument("--rdma-devices", default=defaults["rdma_devices"])
+    parser.add_argument("--master-server-addr", default=defaults["master_server_addr"])
+
+
+def _connect_store(args):
+    from mooncake.store import MooncakeDistributedStore
+
+    store = MooncakeDistributedStore()
+    global_segment_size = _CLIENT_GLOBAL_SEGMENT_SIZE
+    local_buffer_size = _CLIENT_LOCAL_BUFFER_SIZE
+    config = {
+        "local_hostname": args.local_hostname,
+        "metadata_server": args.metadata_server,
+        "global_segment_size": global_segment_size,
+        "local_buffer_size": local_buffer_size,
+        "protocol": args.protocol,
+        "rdma_devices": args.rdma_devices,
+        "master_server_addr": args.master_server_addr,
+    }
+
+    try:
+        result = store.setup(
+            args.local_hostname,
+            args.metadata_server,
+            global_segment_size,
+            local_buffer_size,
+            args.protocol,
+            args.rdma_devices,
+            args.master_server_addr,
+        )
+    except TypeError:
+        result = store.setup(config)
+
+    if result not in (0, None):
+        raise RuntimeError(f"failed to setup MooncakeDistributedStore: {result}")
+    return store
+
+
+def _parse_size(value) -> int:
+    if isinstance(value, int):
+        return value
+    text = str(value).strip()
+    if text.isdigit():
+        return int(text)
+    units = {
+        "KB": 1024,
+        "MB": 1024**2,
+        "GB": 1024**3,
+    }
+    upper = text.upper()
+    for suffix, multiplier in units.items():
+        if upper.endswith(suffix):
+            number = upper[: -len(suffix)].strip()
+            return int(float(number) * multiplier)
+    raise ValueError(f"invalid size: {value!r}")
+
+
+def _load_config_defaults(argv: Optional[List[str]]) -> dict:
+    defaults = {
+        "config": os.environ.get("MOONCAKE_WEIGHT_STORE_CONFIG", DEFAULT_CONFIG_PATH),
+        "local_hostname": "localhost",
+        "metadata_server": "http://127.0.0.1:8080/metadata",
+        "protocol": "tcp",
+        "rdma_devices": "",
+        "master_server_addr": "127.0.0.1:50051",
+        "replica_num": 1,
+        "file_chunk_size": DEFAULT_FILE_CHUNK_SIZE,
+    }
+    config_path = _extract_config_path(argv, defaults["config"])
+    defaults["config"] = config_path
+    path = Path(config_path).expanduser()
+    if path.exists():
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+        for key in defaults:
+            if key in loaded and key != "config":
+                defaults[key] = loaded[key]
+    return defaults
+
+
+def _extract_config_path(argv: Optional[List[str]], default: str) -> str:
+    if argv is None:
+        return default
+    for index, item in enumerate(argv):
+        if item == "--config" and index + 1 < len(argv):
+            return argv[index + 1]
+        if item.startswith("--config="):
+            return item.split("=", 1)[1]
+    return default
+
+
+def _normalize_global_args(argv: List[str]) -> List[str]:
+    value_flags = {
+        "--config",
+        "--local-hostname",
+        "--metadata-server",
+        "--protocol",
+        "--rdma-devices",
+        "--master-server-addr",
+    }
+    moved: List[str] = []
+    remaining: List[str] = []
+    index = 0
+    while index < len(argv):
+        item = argv[index]
+        flag = item.split("=", 1)[0]
+        if flag in value_flags:
+            moved.append(item)
+            if "=" not in item:
+                if index + 1 >= len(argv):
+                    remaining.append(item)
+                else:
+                    moved.append(argv[index + 1])
+                    index += 1
+        else:
+            remaining.append(item)
+        index += 1
+    return moved + remaining
+
+
+def _store_config_from_args(args) -> dict:
+    return {
+        "local_hostname": args.local_hostname,
+        "metadata_server": args.metadata_server,
+        "protocol": args.protocol,
+        "rdma_devices": args.rdma_devices,
+        "master_server_addr": args.master_server_addr,
+    }
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/mooncake-wheel/mooncake/weight_store/model.py
+++ b/mooncake-wheel/mooncake/weight_store/model.py
@@ -19,11 +19,15 @@ from .model_keyspace import (
     validate_checkpoint_id,
 )
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 READY = "READY"
 FAILED = "FAILED"
 VALID_STATUSES = {READY, FAILED}
 DEFAULT_FILE_CHUNK_SIZE = 64 * 1024 * 1024
+# Mooncake's native store.remove returns -704 for an object that is already
+# gone (see structured_object_store.MISSING_OBJECT_ERROR). Treat it as success
+# so that re-running a partially-completed delete stays idempotent.
+MISSING_OBJECT_ERROR = -704
 
 WEIGHT_SUFFIXES = {
     ".bin",
@@ -42,6 +46,11 @@ class ModelFileRecord:
     size: int
     sha256: str
     chunks: List[str] = field(default_factory=list)
+    # Authoritative fixed chunk size used at import. Readers mapping file
+    # offsets to chunks MUST use this value, not their own configured chunk
+    # size. 0 means unknown/legacy (pre-schema-2) and a reader MUST refuse
+    # to guess the layout of a multi-chunk file rather than assume a size.
+    chunk_size: int = 0
 
 
 @dataclass(frozen=True)
@@ -76,12 +85,13 @@ class ModelFileManifest:
     @classmethod
     def from_json_bytes(cls, payload: bytes) -> "ModelFileManifest":
         data = json.loads(payload.decode("utf-8"))
-        data["files"] = [
-            ModelFileRecord(chunks=[item["key"]], **item)
-            if "chunks" not in item
-            else ModelFileRecord(**item)
-            for item in data["files"]
-        ]
+        records = []
+        for item in data["files"]:
+            if "chunks" not in item:
+                item = {**item, "chunks": [item["key"]]}
+            # chunk_size defaults to 0 (legacy) when absent from old dicts.
+            records.append(ModelFileRecord(**item))
+        data["files"] = records
         return cls(**data)
 
 
@@ -119,7 +129,19 @@ class ModelFileCacheClient:
         if not source.is_dir():
             raise ValueError(f"source_uri must be a directory: {source_uri}")
         if self._exists(model_manifest_key(checkpoint_id)):
-            raise ValueError(f"model checkpoint already exists: {checkpoint_id}")
+            # A manifest already exists. Only a live (READY) checkpoint blocks a
+            # re-import; a FAILED leftover -- or an unreadable/corrupt manifest
+            # -- is reclaimable, so tear it down idempotently and fall through to
+            # import afresh.
+            try:
+                existing = self._read_manifest(checkpoint_id)
+            except (KeyError, ValueError):
+                existing = None
+            if existing is not None and existing.status == READY:
+                raise ValueError(
+                    f"model checkpoint already exists: {checkpoint_id}"
+                )
+            self.delete_model(checkpoint_id)
 
         files = _list_model_files(source)
         if not files:
@@ -147,12 +169,32 @@ class ModelFileCacheClient:
                         import_started_at,
                     )
                 )
-                size, digest, chunks = self._put_file_chunks(
-                    checkpoint_id=checkpoint_id,
-                    relative_path=rel,
-                    source_path=path,
-                    file_type=file_type,
-                )
+                journal: List[str] = []
+                try:
+                    size, digest, chunks = self._put_file_chunks(
+                        checkpoint_id=checkpoint_id,
+                        relative_path=rel,
+                        source_path=path,
+                        file_type=file_type,
+                        journal=journal,
+                    )
+                except BaseException:
+                    if journal:
+                        # Preserve the partial file's chunk keys so the FAILED
+                        # manifest and delete_model can sweep any survivor whose
+                        # immediate cleanup failed (Finding 3).
+                        records.append(
+                            ModelFileRecord(
+                                path=rel,
+                                type=file_type,
+                                key=key,
+                                size=0,
+                                sha256="",
+                                chunks=list(journal),
+                                chunk_size=self.file_chunk_size,
+                            )
+                        )
+                    raise
                 records.append(
                     ModelFileRecord(
                         path=rel,
@@ -161,6 +203,7 @@ class ModelFileCacheClient:
                         size=size,
                         sha256=digest,
                         chunks=chunks,
+                        chunk_size=self.file_chunk_size,
                     )
                 )
                 imported_bytes += size
@@ -177,6 +220,14 @@ class ModelFileCacheClient:
                     )
                 )
 
+            sorted_records = sorted(records, key=lambda record: record.path)
+            total_size = sum(record.size for record in records)
+
+            # Build the READY manifest but do NOT publish it yet. On a
+            # write-once store we cannot persist an in-progress state and later
+            # overwrite it with READY (the second put is dropped), so instead we
+            # verify from the in-memory records and make the READY manifest the
+            # single, final publication step (Finding 1).
             manifest = ModelFileManifest(
                 checkpoint_id=checkpoint_id,
                 model_id=model_id,
@@ -185,13 +236,16 @@ class ModelFileCacheClient:
                 source_uri=str(source),
                 created_at=now,
                 updated_at=now,
-                total_size=sum(record.size for record in records),
-                files=sorted(records, key=lambda record: record.path),
+                total_size=total_size,
+                files=sorted_records,
                 error=None,
             )
+            # Verify the just-written chunks while still unpublished.
+            self._verify_manifest(manifest)
+            # Publish: one manifest write (first write on an empty key), then
+            # index.
             self._write_manifest(manifest)
             self._add_to_indexes(manifest)
-            self.verify_model(checkpoint_id)
             return manifest
         except BaseException as exc:
             failed = ModelFileManifest(
@@ -217,9 +271,13 @@ class ModelFileCacheClient:
 
     def verify_model(self, checkpoint_id: str) -> ModelFileManifest:
         manifest = self._read_manifest(checkpoint_id)
+        return self._verify_manifest(manifest)
+
+    def _verify_manifest(self, manifest: ModelFileManifest) -> ModelFileManifest:
+        checkpoint_id = manifest.checkpoint_id
         if manifest.status != READY:
             raise ValueError(
-                f"model checkpoint {checkpoint_id!r} is not READY: "
+                f"model checkpoint {checkpoint_id!r} is not verifiable: "
                 f"{manifest.status}"
             )
 
@@ -249,11 +307,32 @@ class ModelFileCacheClient:
         return manifest
 
     def delete_model(self, checkpoint_id: str) -> None:
-        manifest = self._read_manifest(checkpoint_id)
+        # Delete is a multi-key operation over a store with no transactions, so
+        # it must be safe to crash after any step and re-run to completion.
+        try:
+            manifest = self._read_manifest(checkpoint_id)
+        except KeyError:
+            # Manifest already gone: a prior delete finished (or never wrote a
+            # manifest). Treat as an idempotent no-op success.
+            return
+        except ValueError:
+            # Manifest is present but unparseable (corrupt/non-JSON), so we
+            # cannot recover model_id to de-index. Best-effort drop the dangling
+            # manifest key so the checkpoint id is no longer stuck, then return.
+            self._remove(model_manifest_key(checkpoint_id), force=True)
+            return
+
+        # De-index FIRST while the manifest (and thus model_id) is still
+        # readable. Discard-based, so idempotent on retry. We deliberately do
+        # NOT persist an in-progress delete marker: on a write-once store that
+        # would mean remove(READY)+put(marker), whose crash window is the
+        # Finding-4 zombie (manifest gone while index/chunks survive).
+        self._remove_from_indexes(manifest)
         for record in manifest.files:
             self._remove_file_chunks(record)
+        # Remove the manifest LAST: only once every dependent key is gone do we
+        # drop the record that keeps this delete recoverable.
         self._remove(model_manifest_key(checkpoint_id), force=True)
-        self._remove_from_indexes(manifest)
 
     def materialize_file(self, checkpoint_id: str, path: str, output_path: str) -> None:
         manifest = self._read_manifest(checkpoint_id)
@@ -378,6 +457,7 @@ class ModelFileCacheClient:
         relative_path: str,
         source_path: Path,
         file_type: str,
+        journal: Optional[List[str]] = None,
     ) -> tuple[int, str, List[str]]:
         digest = hashlib.sha256()
         size = 0
@@ -400,6 +480,10 @@ class ModelFileCacheClient:
                     )
                     self._put(chunk_key, chunk, config)
                     chunks.append(chunk_key)
+                    if journal is not None:
+                        # Authoritative survivor list carried back to
+                        # import_model so a failed put still records its keys.
+                        journal.append(chunk_key)
                     digest.update(chunk)
                     size += len(chunk)
             except BaseException:
@@ -431,10 +515,12 @@ class ModelFileCacheClient:
             self._remove(chunk_key, force=True)
 
     def _record_chunks(self, record: ModelFileRecord) -> List[str]:
-        if record.size == 0:
-            return []
+        # ``chunks`` is authoritative when present (a partial-import record
+        # has size==0 but a non-empty chunks list that delete must sweep).
         if record.chunks:
             return record.chunks
+        if record.size == 0:
+            return []
         return [record.key]
 
     def _put(self, key: str, value: bytes, config) -> None:
@@ -443,10 +529,24 @@ class ModelFileCacheClient:
             raise RuntimeError(f"failed to put {key}: {result}")
 
     def _put_control(self, key: str, value: bytes, config) -> None:
-        writer = getattr(self.store, "upsert", None)
-        if writer is None:
-            writer = self.store.put
-        result = writer(key, value, config)
+        # Control objects (the manifest and the index sets) are the only
+        # mutable keys in this keyspace. The native store's ``put`` is
+        # write-once: a second put to an existing key returns OK but silently
+        # discards the new bytes (Client::Put maps OBJECT_ALREADY_EXISTS ->
+        # success). So an in-place overwrite would be dropped. Prefer a real
+        # ``upsert`` if the store offers one; otherwise emulate overwrite by
+        # removing any prior value first.
+        #
+        # Callers guarantee a *live* manifest is never overwritten this way
+        # (import never persists an in-progress state; delete removes the
+        # manifest last), so this pre-remove only ever clears an absent or
+        # superseded key.
+        upsert = getattr(self.store, "upsert", None)
+        if upsert is not None:
+            result = upsert(key, value, config)
+        else:
+            self._remove(key, force=True)  # idempotent; -704 tolerated
+            result = self.store.put(key, value, config)
         if result not in (0, None):
             raise RuntimeError(f"failed to write control object {key}: {result}")
 
@@ -463,7 +563,7 @@ class ModelFileCacheClient:
             result = self.store.remove(key, force)
         except TypeError:
             result = self.store.remove(key)
-        if result not in (0, None):
+        if result not in (0, None, MISSING_OBJECT_ERROR):
             raise RuntimeError(f"failed to remove {key}: {result}")
 
     def _exists(self, key: str) -> bool:

--- a/mooncake-wheel/mooncake/weight_store/model.py
+++ b/mooncake-wheel/mooncake/weight_store/model.py
@@ -1,0 +1,559 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+import tempfile
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from .model_keyspace import (
+    model_file_chunk_key,
+    model_file_key,
+    model_id_index_key,
+    model_index_key,
+    model_manifest_key,
+    validate_checkpoint_id,
+)
+
+SCHEMA_VERSION = 1
+READY = "READY"
+FAILED = "FAILED"
+VALID_STATUSES = {READY, FAILED}
+DEFAULT_FILE_CHUNK_SIZE = 64 * 1024 * 1024
+
+WEIGHT_SUFFIXES = {
+    ".bin",
+    ".gguf",
+    ".pt",
+    ".pth",
+    ".safetensors",
+}
+
+
+@dataclass(frozen=True)
+class ModelFileRecord:
+    path: str
+    type: str
+    key: str
+    size: int
+    sha256: str
+    chunks: List[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class ModelFileManifest:
+    checkpoint_id: str
+    model_id: str
+    revision: str
+    status: str
+    source_uri: str
+    created_at: int
+    updated_at: int
+    total_size: int
+    files: List[ModelFileRecord]
+    error: Optional[str]
+    schema_version: int = SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if self.status not in VALID_STATUSES:
+            raise ValueError(f"invalid model status: {self.status!r}")
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    def to_json_bytes(self) -> bytes:
+        return json.dumps(
+            self.to_dict(),
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+
+    @classmethod
+    def from_json_bytes(cls, payload: bytes) -> "ModelFileManifest":
+        data = json.loads(payload.decode("utf-8"))
+        data["files"] = [
+            ModelFileRecord(chunks=[item["key"]], **item)
+            if "chunks" not in item
+            else ModelFileRecord(**item)
+            for item in data["files"]
+        ]
+        return cls(**data)
+
+
+class ModelFileCacheClient:
+    def __init__(
+        self,
+        store,
+        *,
+        replica_num: int = 1,
+        hard_pin_weights: bool = True,
+        hard_pin_metadata: bool = True,
+        file_chunk_size: int = DEFAULT_FILE_CHUNK_SIZE,
+        progress: bool = False,
+    ) -> None:
+        if file_chunk_size <= 0:
+            raise ValueError("file_chunk_size must be positive")
+        self.store = store
+        self.replica_num = replica_num
+        self.hard_pin_weights = hard_pin_weights
+        self.hard_pin_metadata = hard_pin_metadata
+        self.file_chunk_size = file_chunk_size
+        self.progress = progress
+        self.file_key = model_file_key
+
+    def import_model(
+        self,
+        *,
+        checkpoint_id: str,
+        model_id: str,
+        revision: str,
+        source_uri: str,
+    ) -> ModelFileManifest:
+        validate_checkpoint_id(checkpoint_id)
+        source = Path(source_uri)
+        if not source.is_dir():
+            raise ValueError(f"source_uri must be a directory: {source_uri}")
+        if self._exists(model_manifest_key(checkpoint_id)):
+            raise ValueError(f"model checkpoint already exists: {checkpoint_id}")
+
+        files = _list_model_files(source)
+        if not files:
+            raise ValueError(f"model directory has no files: {source_uri}")
+        _validate_safetensors_index(source, files)
+
+        now = int(time.time())
+        records: List[ModelFileRecord] = []
+        total_bytes = sum(path.stat().st_size for path in files)
+        imported_bytes = 0
+        import_started_at = time.time()
+        try:
+            for index, path in enumerate(files, start=1):
+                rel = path.relative_to(source).as_posix()
+                file_type = _file_type(rel)
+                key = self.file_key(checkpoint_id, rel)
+                self._log_progress(
+                    self._format_progress(
+                        "start",
+                        rel,
+                        index,
+                        len(files),
+                        imported_bytes,
+                        total_bytes,
+                        import_started_at,
+                    )
+                )
+                size, digest, chunks = self._put_file_chunks(
+                    checkpoint_id=checkpoint_id,
+                    relative_path=rel,
+                    source_path=path,
+                    file_type=file_type,
+                )
+                records.append(
+                    ModelFileRecord(
+                        path=rel,
+                        type=file_type,
+                        key=key,
+                        size=size,
+                        sha256=digest,
+                        chunks=chunks,
+                    )
+                )
+                imported_bytes += size
+                self._log_progress(
+                    self._format_progress(
+                        "done",
+                        rel,
+                        index,
+                        len(files),
+                        imported_bytes,
+                        total_bytes,
+                        import_started_at,
+                        chunks=len(chunks),
+                    )
+                )
+
+            manifest = ModelFileManifest(
+                checkpoint_id=checkpoint_id,
+                model_id=model_id,
+                revision=revision,
+                status=READY,
+                source_uri=str(source),
+                created_at=now,
+                updated_at=now,
+                total_size=sum(record.size for record in records),
+                files=sorted(records, key=lambda record: record.path),
+                error=None,
+            )
+            self._write_manifest(manifest)
+            self._add_to_indexes(manifest)
+            self.verify_model(checkpoint_id)
+            return manifest
+        except BaseException as exc:
+            failed = ModelFileManifest(
+                checkpoint_id=checkpoint_id,
+                model_id=model_id,
+                revision=revision,
+                status=FAILED,
+                source_uri=str(source),
+                created_at=now,
+                updated_at=int(time.time()),
+                total_size=sum(record.size for record in records),
+                files=sorted(records, key=lambda record: record.path),
+                error=repr(exc),
+            )
+            self._write_manifest(failed)
+            raise
+
+    def list_models(self) -> List[str]:
+        return sorted(self._read_index(model_index_key()))
+
+    def inspect_model(self, checkpoint_id: str) -> ModelFileManifest:
+        return self._read_manifest(checkpoint_id)
+
+    def verify_model(self, checkpoint_id: str) -> ModelFileManifest:
+        manifest = self._read_manifest(checkpoint_id)
+        if manifest.status != READY:
+            raise ValueError(
+                f"model checkpoint {checkpoint_id!r} is not READY: "
+                f"{manifest.status}"
+            )
+
+        by_path = {record.path for record in manifest.files}
+        payload_by_path: Dict[str, bytes] = {}
+        for record in manifest.files:
+            size, digest, payload = self._read_file_chunks(
+                record, keep_payload=(record.path == "model.safetensors.index.json")
+            )
+            if size != record.size:
+                raise ValueError(
+                    f"file size mismatch for {record.path}: "
+                    f"expected {record.size}, got {size}"
+                )
+            if digest != record.sha256:
+                raise ValueError(
+                    f"sha256 mismatch for {record.path}: "
+                    f"expected {record.sha256}, got {digest}"
+                )
+            if payload is not None:
+                payload_by_path[record.path] = payload
+        if "model.safetensors.index.json" in payload_by_path:
+            index = json.loads(
+                payload_by_path["model.safetensors.index.json"].decode("utf-8")
+            )
+            _validate_weight_map(index.get("weight_map", {}), by_path)
+        return manifest
+
+    def delete_model(self, checkpoint_id: str) -> None:
+        manifest = self._read_manifest(checkpoint_id)
+        for record in manifest.files:
+            self._remove_file_chunks(record)
+        self._remove(model_manifest_key(checkpoint_id), force=True)
+        self._remove_from_indexes(manifest)
+
+    def materialize_file(self, checkpoint_id: str, path: str, output_path: str) -> None:
+        manifest = self._read_manifest(checkpoint_id)
+        matches = [record for record in manifest.files if record.path == path]
+        if not matches:
+            raise KeyError(path)
+        output = Path(output_path)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        record = matches[0]
+        digest = hashlib.sha256()
+        size = 0
+        temp_fd, temp_name = tempfile.mkstemp(
+            prefix=f".{output.name}.", suffix=".tmp", dir=output.parent
+        )
+        os.close(temp_fd)
+        temp_output = Path(temp_name)
+        try:
+            with temp_output.open("wb") as output_file:
+                for chunk_key in self._record_chunks(record):
+                    chunk = self._get(chunk_key)
+                    output_file.write(chunk)
+                    digest.update(chunk)
+                    size += len(chunk)
+            if size != record.size:
+                raise ValueError(
+                    f"file size mismatch for {record.path}: "
+                    f"expected {record.size}, got {size}"
+                )
+            if digest.hexdigest() != record.sha256:
+                raise ValueError(f"sha256 mismatch for {record.path}")
+            os.replace(temp_output, output)
+        except BaseException:
+            temp_output.unlink(missing_ok=True)
+            raise
+
+    def _write_manifest(self, manifest: ModelFileManifest) -> None:
+        self._put_control(
+            model_manifest_key(manifest.checkpoint_id),
+            manifest.to_json_bytes(),
+            self._new_config("METADATA", hard_pin=self.hard_pin_metadata),
+        )
+
+    def _read_manifest(self, checkpoint_id: str) -> ModelFileManifest:
+        key = model_manifest_key(checkpoint_id)
+        payload = self._get(key)
+        if not payload:
+            raise KeyError(
+                f"model checkpoint {checkpoint_id!r} has no readable manifest"
+            )
+        try:
+            return ModelFileManifest.from_json_bytes(payload)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"model checkpoint {checkpoint_id!r} manifest is not valid JSON"
+            ) from exc
+
+    def _add_to_indexes(self, manifest: ModelFileManifest) -> None:
+        all_models = self._read_index(model_index_key())
+        all_models.add(manifest.checkpoint_id)
+        self._write_index(model_index_key(), all_models)
+
+        per_model = self._read_index(model_id_index_key(manifest.model_id))
+        per_model.add(manifest.checkpoint_id)
+        self._write_index(model_id_index_key(manifest.model_id), per_model)
+
+    def _remove_from_indexes(self, manifest: ModelFileManifest) -> None:
+        all_models = self._read_index(model_index_key())
+        all_models.discard(manifest.checkpoint_id)
+        self._write_index(model_index_key(), all_models)
+
+        per_model = self._read_index(model_id_index_key(manifest.model_id))
+        per_model.discard(manifest.checkpoint_id)
+        self._write_index(model_id_index_key(manifest.model_id), per_model)
+
+    def _read_index(self, key: str) -> set[str]:
+        if not self._exists(key):
+            return set()
+        value = self.store.get(key)
+        if value is None:
+            return set()
+        if isinstance(value, str):
+            payload = value.encode("utf-8")
+        else:
+            payload = bytes(value)
+        if not payload:
+            return set()
+        return set(json.loads(payload.decode("utf-8")))
+
+    def _write_index(self, key: str, values: set[str]) -> None:
+        self._put_control(
+            key,
+            json.dumps(sorted(values), separators=(",", ":")).encode("utf-8"),
+            self._new_config("METADATA", hard_pin=self.hard_pin_metadata),
+        )
+
+    def _new_config(self, data_type_name: str, *, hard_pin: bool):
+        config_cls = getattr(self.store, "ReplicateConfig", None)
+        data_type_cls = getattr(self.store, "ObjectDataType", None)
+        if config_cls is None:
+            from mooncake.store import ReplicateConfig
+
+            config_cls = ReplicateConfig
+        if data_type_cls is None:
+            try:
+                from mooncake.store import ObjectDataType
+
+                data_type_cls = ObjectDataType
+            except ImportError:
+                data_type_cls = None
+
+        config = config_cls()
+        config.replica_num = self.replica_num
+        config.with_hard_pin = hard_pin
+        if data_type_cls is not None and hasattr(config, "data_type"):
+            config.data_type = getattr(data_type_cls, data_type_name)
+        return config
+
+    def _put_file_chunks(
+        self,
+        *,
+        checkpoint_id: str,
+        relative_path: str,
+        source_path: Path,
+        file_type: str,
+    ) -> tuple[int, str, List[str]]:
+        digest = hashlib.sha256()
+        size = 0
+        chunks: List[str] = []
+        config = self._new_config(
+            file_type,
+            hard_pin=(
+                self.hard_pin_weights
+                if file_type == "WEIGHT"
+                else self.hard_pin_metadata
+            ),
+        )
+        with source_path.open("rb") as source_file:
+            try:
+                for chunk_index, chunk in enumerate(
+                    iter(lambda: source_file.read(self.file_chunk_size), b"")
+                ):
+                    chunk_key = model_file_chunk_key(
+                        checkpoint_id, relative_path, chunk_index
+                    )
+                    self._put(chunk_key, chunk, config)
+                    chunks.append(chunk_key)
+                    digest.update(chunk)
+                    size += len(chunk)
+            except BaseException:
+                for chunk_key in chunks:
+                    try:
+                        self._remove(chunk_key, force=True)
+                    except BaseException:
+                        pass
+                raise
+        return size, digest.hexdigest(), chunks
+
+    def _read_file_chunks(
+        self, record: ModelFileRecord, *, keep_payload: bool
+    ) -> tuple[int, str, Optional[bytes]]:
+        digest = hashlib.sha256()
+        size = 0
+        payload_chunks: List[bytes] = []
+        for chunk_key in self._record_chunks(record):
+            chunk = self._get(chunk_key)
+            digest.update(chunk)
+            size += len(chunk)
+            if keep_payload:
+                payload_chunks.append(chunk)
+        payload = b"".join(payload_chunks) if keep_payload else None
+        return size, digest.hexdigest(), payload
+
+    def _remove_file_chunks(self, record: ModelFileRecord) -> None:
+        for chunk_key in self._record_chunks(record):
+            self._remove(chunk_key, force=True)
+
+    def _record_chunks(self, record: ModelFileRecord) -> List[str]:
+        if record.size == 0:
+            return []
+        if record.chunks:
+            return record.chunks
+        return [record.key]
+
+    def _put(self, key: str, value: bytes, config) -> None:
+        result = self.store.put(key, value, config)
+        if result not in (0, None):
+            raise RuntimeError(f"failed to put {key}: {result}")
+
+    def _put_control(self, key: str, value: bytes, config) -> None:
+        writer = getattr(self.store, "upsert", None)
+        if writer is None:
+            writer = self.store.put
+        result = writer(key, value, config)
+        if result not in (0, None):
+            raise RuntimeError(f"failed to write control object {key}: {result}")
+
+    def _get(self, key: str) -> bytes:
+        value = self.store.get(key)
+        if value is None:
+            raise KeyError(key)
+        if isinstance(value, str):
+            return value.encode("utf-8")
+        return bytes(value)
+
+    def _remove(self, key: str, *, force: bool) -> None:
+        try:
+            result = self.store.remove(key, force)
+        except TypeError:
+            result = self.store.remove(key)
+        if result not in (0, None):
+            raise RuntimeError(f"failed to remove {key}: {result}")
+
+    def _exists(self, key: str) -> bool:
+        checker = getattr(self.store, "is_exist", None)
+        if checker is not None:
+            result = checker(key)
+            if result < 0:
+                raise RuntimeError(f"failed to check {key}: {result}")
+            return bool(result)
+        return self.store.get(key) is not None
+
+    def _log_progress(self, message: str) -> None:
+        if self.progress:
+            print(f"[weight-store] {message}", file=sys.stderr, flush=True)
+
+    def _format_progress(
+        self,
+        phase: str,
+        relative_path: str,
+        file_index: int,
+        file_count: int,
+        imported_bytes: int,
+        total_bytes: int,
+        started_at: float,
+        *,
+        chunks: Optional[int] = None,
+    ) -> str:
+        elapsed = max(time.time() - started_at, 1e-6)
+        rate = imported_bytes / elapsed if imported_bytes else 0
+        percent = (imported_bytes / total_bytes * 100) if total_bytes else 0
+        eta = (total_bytes - imported_bytes) / rate if rate > 0 else None
+        details = [
+            f"{phase} file {file_index}/{file_count}",
+            relative_path,
+            f"{_format_bytes(imported_bytes)}/{_format_bytes(total_bytes)}",
+            f"{percent:.1f}%",
+        ]
+        if rate > 0:
+            details.append(f"{_format_bytes(rate)}/s")
+        if eta is not None:
+            details.append(f"eta {_format_duration(eta)}")
+        if chunks is not None:
+            details.append(f"{chunks} chunks")
+        return " | ".join(details)
+
+
+def _list_model_files(source: Path) -> List[Path]:
+    return sorted(path for path in source.rglob("*") if path.is_file())
+
+
+def _file_type(relative_path: str) -> str:
+    suffix = Path(relative_path).suffix.lower()
+    return "WEIGHT" if suffix in WEIGHT_SUFFIXES else "METADATA"
+
+
+def _validate_safetensors_index(source: Path, files: List[Path]) -> None:
+    relative_files = {path.relative_to(source).as_posix() for path in files}
+    index_path = source / "model.safetensors.index.json"
+    if not index_path.exists():
+        return
+    data = json.loads(index_path.read_text(encoding="utf-8"))
+    _validate_weight_map(data.get("weight_map", {}), relative_files)
+
+
+def _validate_weight_map(weight_map: Dict[str, str], relative_files: set[str]) -> None:
+    missing = sorted(
+        {path for path in weight_map.values() if path not in relative_files}
+    )
+    if missing:
+        raise ValueError(
+            "safetensors index references missing shard(s): " + ", ".join(missing)
+        )
+
+
+def _format_bytes(value: float) -> str:
+    units = ["B", "KiB", "MiB", "GiB", "TiB"]
+    size = float(value)
+    for unit in units:
+        if abs(size) < 1024 or unit == units[-1]:
+            return f"{size:.1f}{unit}" if unit != "B" else f"{int(size)}B"
+        size /= 1024
+    raise AssertionError("unreachable")
+
+
+def _format_duration(seconds: float) -> str:
+    total = max(0, int(seconds))
+    hours, remainder = divmod(total, 3600)
+    minutes, secs = divmod(remainder, 60)
+    if hours:
+        return f"{hours}h{minutes:02d}m"
+    if minutes:
+        return f"{minutes}m{secs:02d}s"
+    return f"{secs}s"

--- a/mooncake-wheel/mooncake/weight_store/model_keyspace.py
+++ b/mooncake-wheel/mooncake/weight_store/model_keyspace.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import hashlib
+import re
+
+
+_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+def model_manifest_key(checkpoint_id: str) -> str:
+    _validate_id("checkpoint_id", checkpoint_id)
+    return f"weight/models/{checkpoint_id}/manifest"
+
+
+def model_file_key(checkpoint_id: str, relative_path: str) -> str:
+    _validate_id("checkpoint_id", checkpoint_id)
+    return f"weight/models/{checkpoint_id}/files/{_sha256_text(relative_path)}"
+
+
+def model_file_chunk_key(
+    checkpoint_id: str, relative_path: str, chunk_index: int
+) -> str:
+    if chunk_index < 0:
+        raise ValueError(f"invalid chunk_index: {chunk_index!r}")
+    return f"{model_file_key(checkpoint_id, relative_path)}/chunks/{chunk_index:08d}"
+
+
+def model_index_key() -> str:
+    return "weight/index/models"
+
+
+def model_id_index_key(model_id: str) -> str:
+    return f"weight/index/model/{_sha256_text(model_id)}"
+
+
+def validate_checkpoint_id(checkpoint_id: str) -> None:
+    _validate_id("checkpoint_id", checkpoint_id)
+
+
+def _sha256_text(value: str) -> str:
+    if not value:
+        raise ValueError("value must not be empty")
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _validate_id(name: str, value: str) -> None:
+    if not _ID_RE.fullmatch(value):
+        raise ValueError(f"invalid {name}: {value!r}")

--- a/mooncake-wheel/mooncake/weight_store/model_keyspace.py
+++ b/mooncake-wheel/mooncake/weight_store/model_keyspace.py
@@ -5,6 +5,7 @@ import re
 
 
 _ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+_MAX_ID_LEN = 255
 
 
 def model_manifest_key(checkpoint_id: str) -> str:
@@ -44,5 +45,7 @@ def _sha256_text(value: str) -> str:
 
 
 def _validate_id(name: str, value: str) -> None:
+    if not isinstance(value, str) or not (1 <= len(value) <= _MAX_ID_LEN):
+        raise ValueError(f"invalid {name}: {value!r}")
     if not _ID_RE.fullmatch(value):
         raise ValueError(f"invalid {name}: {value!r}")

--- a/mooncake-wheel/pyproject.toml
+++ b/mooncake-wheel/pyproject.toml
@@ -50,6 +50,7 @@ transfer_engine_bench = "mooncake.cli_bench:main"
 mooncake_http_metadata_server = "mooncake.http_metadata_server:main"
 mc_store_rest_server = "mooncake.mooncake_store_service:sync_main"
 transfer_engine_topology_dump = "mooncake.transfer_engine_topology_dump:main"
+mooncake_weight_store = "mooncake.weight_store.cli:main"
 
 [tool.setuptools]
 zip-safe = false

--- a/mooncake-wheel/tests/test_weight_model_cache.py
+++ b/mooncake-wheel/tests/test_weight_model_cache.py
@@ -1,0 +1,403 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from mooncake.weight_store.model import ModelFileCacheClient, READY
+from mooncake.weight_store.model_keyspace import (
+    model_file_chunk_key,
+    model_file_key,
+    model_index_key,
+    model_manifest_key,
+    validate_checkpoint_id,
+)
+
+
+class FakeReplicateConfig:
+    def __init__(self) -> None:
+        self.replica_num = 0
+        self.with_hard_pin = False
+        self.data_type = None
+
+
+class FakeObjectDataType:
+    WEIGHT = "WEIGHT"
+    METADATA = "METADATA"
+
+
+class FakeStore:
+    ReplicateConfig = FakeReplicateConfig
+    ObjectDataType = FakeObjectDataType
+
+    def __init__(self) -> None:
+        self.objects: dict[str, bytes] = {}
+        self.configs: dict[str, FakeReplicateConfig] = {}
+
+    def put(self, key: str, value: bytes, config: FakeReplicateConfig) -> int:
+        self.objects[key] = bytes(value)
+        self.configs[key] = config
+        return 0
+
+    def upsert(self, key: str, value: bytes, config: FakeReplicateConfig) -> int:
+        self.objects[key] = bytes(value)
+        self.configs[key] = config
+        return 0
+
+    def get(self, key: str) -> bytes | None:
+        return self.objects.get(key)
+
+    def remove(self, key: str, force: bool = False) -> int:
+        self.objects.pop(key, None)
+        self.configs.pop(key, None)
+        return 0
+
+    def is_exist(self, key: str) -> int:
+        return int(key in self.objects)
+
+
+class EmptyBytesMissingStore(FakeStore):
+    def get(self, key: str) -> bytes | None:
+        return self.objects.get(key, b"")
+
+
+class FailingStore(FakeStore):
+    def __init__(self, fail_on_key_part: str) -> None:
+        super().__init__()
+        self.fail_on_key_part = fail_on_key_part
+
+    def put(self, key: str, value: bytes, config: FakeReplicateConfig) -> int:
+        if self.fail_on_key_part in key:
+            return -1
+        return super().put(key, value, config)
+
+
+class InterruptingStore(FakeStore):
+    def __init__(self) -> None:
+        super().__init__()
+        self.chunk_puts = 0
+
+    def put(self, key: str, value: bytes, config: FakeReplicateConfig) -> int:
+        if "/chunks/" in key:
+            self.chunk_puts += 1
+            if self.chunk_puts == 2:
+                raise KeyboardInterrupt()
+        return super().put(key, value, config)
+
+
+class CleanupFailingStore(InterruptingStore):
+    def __init__(self) -> None:
+        super().__init__()
+        self.remove_calls: list[str] = []
+
+    def put(self, key: str, value: bytes, config: FakeReplicateConfig) -> int:
+        if "/chunks/" in key:
+            self.chunk_puts += 1
+            if self.chunk_puts == 4:
+                raise KeyboardInterrupt()
+        return FakeStore.put(self, key, value, config)
+
+    def remove(self, key: str, force: bool = False) -> int:
+        self.remove_calls.append(key)
+        if len(self.remove_calls) == 1:
+            return -1
+        return super().remove(key, force)
+
+
+class MaterializeFailingStore(FakeStore):
+    def __init__(self) -> None:
+        super().__init__()
+        self.fail_get = False
+
+    def get(self, key: str) -> bytes | None:
+        if self.fail_get and "/chunks/" in key:
+            raise RuntimeError("read failed")
+        return super().get(key)
+
+
+def write_demo_model(root: Path) -> None:
+    (root / "config.json").write_text('{"model_type":"demo"}', encoding="utf-8")
+    (root / "tokenizer.json").write_text('{"tokens":[]}', encoding="utf-8")
+    (root / "model-00001-of-00002.safetensors").write_bytes(b"weights-1")
+    (root / "model-00002-of-00002.safetensors").write_bytes(b"weights-2")
+    index = {
+        "metadata": {"total_size": 18},
+        "weight_map": {
+            "layer.0.weight": "model-00001-of-00002.safetensors",
+            "layer.1.weight": "model-00002-of-00002.safetensors",
+        },
+    }
+    (root / "model.safetensors.index.json").write_text(
+        json.dumps(index), encoding="utf-8"
+    )
+
+
+class TestModelFileCacheClient(unittest.TestCase):
+    def test_import_model_writes_file_manifest_weight_metadata_and_index(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp)
+            write_demo_model(source)
+            store = FakeStore()
+            client = ModelFileCacheClient(store, file_chunk_size=4)
+
+            manifest = client.import_model(
+                checkpoint_id="demo-main",
+                model_id="demo/model",
+                revision="main",
+                source_uri=str(source),
+            )
+
+        self.assertEqual(manifest.status, READY)
+        self.assertEqual(
+            manifest.total_size, sum(record.size for record in manifest.files)
+        )
+        self.assertIn(model_manifest_key("demo-main"), store.objects)
+        self.assertIn("demo-main", client.list_models())
+        self.assertEqual(client.inspect_model("demo-main"), manifest)
+
+        by_path = {record.path: record for record in manifest.files}
+        weight_record = by_path["model-00001-of-00002.safetensors"]
+        metadata_record = by_path["config.json"]
+        self.assertEqual(
+            weight_record.chunks[0],
+            model_file_chunk_key("demo-main", "model-00001-of-00002.safetensors", 0),
+        )
+        self.assertGreater(len(weight_record.chunks), 1)
+        self.assertEqual(
+            store.configs[weight_record.chunks[0]].data_type, FakeObjectDataType.WEIGHT
+        )
+        self.assertEqual(
+            store.configs[metadata_record.chunks[0]].data_type,
+            FakeObjectDataType.METADATA,
+        )
+        self.assertTrue(store.configs[weight_record.chunks[0]].with_hard_pin)
+        self.assertIn(model_index_key(), store.objects)
+
+    def test_import_model_rejects_safetensors_index_with_missing_shard(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp)
+            (source / "config.json").write_text("{}", encoding="utf-8")
+            (source / "model.safetensors.index.json").write_text(
+                json.dumps({"weight_map": {"x": "missing.safetensors"}}),
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(ValueError):
+                ModelFileCacheClient(FakeStore()).import_model(
+                    checkpoint_id="bad",
+                    model_id="demo/model",
+                    revision="main",
+                    source_uri=str(source),
+                )
+
+    def test_list_models_treats_empty_bytes_missing_index_as_empty(self) -> None:
+        client = ModelFileCacheClient(EmptyBytesMissingStore())
+
+        self.assertEqual(client.list_models(), [])
+
+    def test_inspect_model_reports_empty_manifest_as_missing(self) -> None:
+        store = FakeStore()
+        store.objects[model_manifest_key("demo-main")] = b""
+        client = ModelFileCacheClient(store)
+
+        with self.assertRaises(KeyError):
+            client.inspect_model("demo-main")
+
+    def test_import_model_rejects_existing_checkpoint_id(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp)
+            write_demo_model(source)
+            client = ModelFileCacheClient(FakeStore())
+            client.import_model(
+                checkpoint_id="demo-main",
+                model_id="demo/model",
+                revision="main",
+                source_uri=str(source),
+            )
+
+            with self.assertRaises(ValueError):
+                client.import_model(
+                    checkpoint_id="demo-main",
+                    model_id="demo/model",
+                    revision="main",
+                    source_uri=str(source),
+                )
+
+    def test_checkpoint_id_validation_uses_a_single_segment_whitelist(self) -> None:
+        for valid in ("demo-main", "Qwen3_32B", "model.v2-alpha"):
+            with self.subTest(valid=valid):
+                validate_checkpoint_id(valid)
+
+        for invalid in ("", "a//b", "/a", "a/b/", ".hidden", "a b", "a/b", "a?b"):
+            with self.subTest(invalid=invalid):
+                with self.assertRaises(ValueError):
+                    validate_checkpoint_id(invalid)
+
+    def test_import_model_rejects_invalid_checkpoint_id(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp)
+            write_demo_model(source)
+            client = ModelFileCacheClient(FakeStore())
+
+            with self.assertRaises(ValueError):
+                client.import_model(
+                    checkpoint_id="a//b",
+                    model_id="demo/model",
+                    revision="main",
+                    source_uri=str(source),
+                )
+
+    def test_verify_model_detects_missing_or_modified_file_objects(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp)
+            write_demo_model(source)
+            store = FakeStore()
+            client = ModelFileCacheClient(store)
+            manifest = client.import_model(
+                checkpoint_id="demo-main",
+                model_id="demo/model",
+                revision="main",
+                source_uri=str(source),
+            )
+
+        verified = client.verify_model("demo-main")
+        self.assertEqual(verified.status, READY)
+
+        store.objects[manifest.files[0].chunks[0]] = b"corrupted"
+        with self.assertRaises(ValueError):
+            client.verify_model("demo-main")
+
+    def test_import_failure_writes_failed_manifest_for_inspection(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp)
+            write_demo_model(source)
+            store = FailingStore(fail_on_key_part="/chunks/")
+            client = ModelFileCacheClient(store)
+
+            with self.assertRaises(RuntimeError):
+                client.import_model(
+                    checkpoint_id="demo-main",
+                    model_id="demo/model",
+                    revision="main",
+                    source_uri=str(source),
+                )
+
+            failed = client.inspect_model("demo-main")
+            self.assertEqual(failed.status, "FAILED")
+            self.assertIn("failed to put", failed.error or "")
+
+    def test_import_interrupt_writes_failed_manifest_and_removes_partial_chunks(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp)
+            write_demo_model(source)
+            store = InterruptingStore()
+            client = ModelFileCacheClient(store, file_chunk_size=4)
+
+            with self.assertRaises(KeyboardInterrupt):
+                client.import_model(
+                    checkpoint_id="demo-main",
+                    model_id="demo/model",
+                    revision="main",
+                    source_uri=str(source),
+                )
+
+            failed = client.inspect_model("demo-main")
+            self.assertEqual(failed.status, "FAILED")
+            self.assertIn("KeyboardInterrupt", failed.error or "")
+            self.assertFalse(
+                any(key.endswith("/chunks/00000000") for key in store.objects)
+            )
+
+    def test_import_cleanup_attempts_all_chunks_after_remove_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp)
+            write_demo_model(source)
+            store = CleanupFailingStore()
+            client = ModelFileCacheClient(store, file_chunk_size=4)
+
+            with self.assertRaises(KeyboardInterrupt):
+                client.import_model(
+                    checkpoint_id="demo-main",
+                    model_id="demo/model",
+                    revision="main",
+                    source_uri=str(source),
+                )
+
+            self.assertGreaterEqual(len(store.remove_calls), 2)
+            self.assertTrue(
+                any("/chunks/00000000" in key for key in store.remove_calls)
+            )
+            self.assertTrue(
+                any("/chunks/00000001" in key for key in store.remove_calls)
+            )
+
+    def test_materialize_failure_preserves_existing_output(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp) / "source"
+            output = Path(tmp) / "out" / "model.safetensors"
+            source.mkdir()
+            write_demo_model(source)
+            store = MaterializeFailingStore()
+            client = ModelFileCacheClient(store, file_chunk_size=4)
+            client.import_model(
+                checkpoint_id="demo-main",
+                model_id="demo/model",
+                revision="main",
+                source_uri=str(source),
+            )
+            output.parent.mkdir(parents=True)
+            output.write_bytes(b"original")
+            store.fail_get = True
+
+            with self.assertRaises(RuntimeError):
+                client.materialize_file(
+                    "demo-main", "model-00001-of-00002.safetensors", str(output)
+                )
+
+            self.assertEqual(output.read_bytes(), b"original")
+            self.assertEqual(list(output.parent.glob(f".{output.name}.*.tmp")), [])
+
+    def test_materialize_and_delete_model_follow_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp) / "source"
+            output = Path(tmp) / "out" / "config.json"
+            source.mkdir()
+            write_demo_model(source)
+            store = FakeStore()
+            client = ModelFileCacheClient(store)
+            manifest = client.import_model(
+                checkpoint_id="demo-main",
+                model_id="demo/model",
+                revision="main",
+                source_uri=str(source),
+            )
+
+            client.materialize_file("demo-main", "config.json", str(output))
+            self.assertEqual(
+                output.read_text(encoding="utf-8"), '{"model_type":"demo"}'
+            )
+
+            client.delete_model("demo-main")
+            for record in manifest.files:
+                for chunk in record.chunks:
+                    self.assertNotIn(chunk, store.objects)
+            self.assertNotIn(model_manifest_key("demo-main"), store.objects)
+            self.assertNotIn("demo-main", client.list_models())
+
+    def test_model_file_keys_are_stable_and_sanitize_paths(self) -> None:
+        self.assertEqual(
+            model_manifest_key("demo-main"),
+            "weight/models/demo-main/manifest",
+        )
+        self.assertTrue(
+            model_file_key("demo-main", "nested/model.safetensors").startswith(
+                "weight/models/demo-main/files/"
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mooncake-wheel/tests/test_weight_model_cache.py
+++ b/mooncake-wheel/tests/test_weight_model_cache.py
@@ -5,7 +5,12 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from mooncake.weight_store.model import ModelFileCacheClient, READY
+from mooncake.weight_store.model import (
+    ModelFileCacheClient,
+    ModelFileManifest,
+    READY,
+    SCHEMA_VERSION,
+)
 from mooncake.weight_store.model_keyspace import (
     model_file_chunk_key,
     model_file_key,
@@ -114,6 +119,142 @@ class MaterializeFailingStore(FakeStore):
         if self.fail_get and "/chunks/" in key:
             raise RuntimeError("read failed")
         return super().get(key)
+
+
+class CorruptReadStore(FakeStore):
+    """Returns wrong bytes for exactly one chunk key on read."""
+
+    def __init__(self, corrupt_key: str) -> None:
+        super().__init__()
+        self.corrupt_key = corrupt_key
+
+    def get(self, key: str) -> bytes | None:
+        value = super().get(key)
+        if key == self.corrupt_key and value is not None:
+            return b"corrupted-bytes-that-differ"
+        return value
+
+
+class RecordingStore(FakeStore):
+    """Logs every write as (op, key, value) to prove ordering."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.writes: list[tuple[str, str, bytes]] = []
+
+    def put(self, key: str, value: bytes, config: FakeReplicateConfig) -> int:
+        self.writes.append(("put", key, bytes(value)))
+        return super().put(key, value, config)
+
+    def upsert(self, key: str, value: bytes, config: FakeReplicateConfig) -> int:
+        self.writes.append(("upsert", key, bytes(value)))
+        return super().upsert(key, value, config)
+
+
+class MissingObjectRemoveStore(FakeStore):
+    """Mimics mooncake native remove: -704 for an already-absent key."""
+
+    def remove(self, key: str, force: bool = False) -> int:
+        if key not in self.objects:
+            return -704
+        self.objects.pop(key, None)
+        self.configs.pop(key, None)
+        return 0
+
+
+class ManifestRemoveFailingStore(FakeStore):
+    """Fails remove() of the manifest key while a flag is set."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.fail_manifest_remove = False
+
+    def remove(self, key: str, force: bool = False) -> int:
+        if self.fail_manifest_remove and key.endswith("/manifest"):
+            return -1
+        return super().remove(key, force)
+
+
+class ToggleChunkFailStore(FakeStore):
+    """Fails chunk puts while ``fail_chunks`` is set, healthy otherwise."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.fail_chunks = True
+
+    def put(self, key: str, value: bytes, config: FakeReplicateConfig) -> int:
+        if self.fail_chunks and "/chunks/" in key:
+            return -1
+        return super().put(key, value, config)
+
+
+
+class WriteOnceStore(FakeStore):
+    """Mimics the native mooncake store: it has NO ``upsert`` at all, and its
+    ``put`` is write-once -- a second put to an existing key returns OK (0) but
+    silently keeps the old bytes (Client::Put maps OBJECT_ALREADY_EXISTS ->
+    success). ``remove`` works and returns -704 for an already-absent key. This
+    is the store the blocker fix (_put_control delete-then-put) must survive.
+    """
+
+    def __getattribute__(self, name: str):
+        # The real store exposes no ``upsert``; hide the one FakeStore defines so
+        # the client is forced onto the delete-then-put path, as in production.
+        if name == "upsert":
+            raise AttributeError(name)
+        return super().__getattribute__(name)
+
+    def put(self, key: str, value: bytes, config: FakeReplicateConfig) -> int:
+        if key in self.objects:
+            return 0  # OBJECT_ALREADY_EXISTS -> silent success; bytes unchanged
+        self.objects[key] = bytes(value)
+        self.configs[key] = config
+        return 0
+
+    def remove(self, key: str, force: bool = False) -> int:
+        if key not in self.objects:
+            return -704
+        self.objects.pop(key, None)
+        self.configs.pop(key, None)
+        return 0
+
+
+class WriteOnceManifestRemoveFailingStore(WriteOnceStore):
+    """A write-once store whose manifest ``remove`` fails while a flag is set,
+    to exercise a delete crash between de-index and manifest removal."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.fail_manifest_remove = False
+
+    def remove(self, key: str, force: bool = False) -> int:
+        if self.fail_manifest_remove and key.endswith("/manifest"):
+            return -1
+        return super().remove(key, force)
+
+
+class SurvivorChunkStore(FakeStore):
+    """Interrupts the 2nd chunk put, then fails the cleanup ``remove`` of the
+    first (already-stored) chunk exactly once so it survives in the store; any
+    later remove (e.g. from delete_model) succeeds."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.chunk_puts = 0
+        self.cleanup_remove_failed = False
+
+    def put(self, key: str, value: bytes, config: FakeReplicateConfig) -> int:
+        if "/chunks/" in key:
+            self.chunk_puts += 1
+            if self.chunk_puts == 2:
+                raise KeyboardInterrupt()
+        return super().put(key, value, config)
+
+    def remove(self, key: str, force: bool = False) -> int:
+        if "/chunks/" in key and not self.cleanup_remove_failed:
+            self.cleanup_remove_failed = True
+            return -1
+        return super().remove(key, force)
 
 
 def write_demo_model(root: Path) -> None:
@@ -225,11 +366,24 @@ class TestModelFileCacheClient(unittest.TestCase):
                 )
 
     def test_checkpoint_id_validation_uses_a_single_segment_whitelist(self) -> None:
-        for valid in ("demo-main", "Qwen3_32B", "model.v2-alpha"):
+        for valid in ("demo-main", "Qwen3_32B", "model.v2-alpha", "a..b", "a" * 255):
             with self.subTest(valid=valid):
                 validate_checkpoint_id(valid)
 
-        for invalid in ("", "a//b", "/a", "a/b/", ".hidden", "a b", "a/b", "a?b"):
+        for invalid in (
+            "",
+            "a//b",
+            "/a",
+            "a/b/",
+            "a/",
+            ".hidden",
+            "a b",
+            "a/b",
+            "a?b",
+            ".",
+            "..",
+            "a" * 256,
+        ):
             with self.subTest(invalid=invalid):
                 with self.assertRaises(ValueError):
                     validate_checkpoint_id(invalid)
@@ -397,6 +551,384 @@ class TestModelFileCacheClient(unittest.TestCase):
                 "weight/models/demo-main/files/"
             )
         )
+
+    def test_import_corrupt_chunk_is_never_published(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp)
+            write_demo_model(source)
+            corrupt_key = model_file_chunk_key("demo-main", "config.json", 0)
+            store = CorruptReadStore(corrupt_key)
+            client = ModelFileCacheClient(store)
+
+            with self.assertRaises(ValueError):
+                client.import_model(
+                    checkpoint_id="demo-main",
+                    model_id="demo/model",
+                    revision="main",
+                    source_uri=str(source),
+                )
+
+            self.assertEqual(client.list_models(), [])
+            self.assertEqual(client.inspect_model("demo-main").status, "FAILED")
+
+    def test_import_writes_index_only_after_ready_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp)
+            write_demo_model(source)
+            store = RecordingStore()
+            client = ModelFileCacheClient(store)
+            client.import_model(
+                checkpoint_id="demo-main",
+                model_id="demo/model",
+                revision="main",
+                source_uri=str(source),
+            )
+
+        manifest_key = model_manifest_key("demo-main")
+        index_key = model_index_key()
+
+        manifest_statuses = [
+            json.loads(value.decode("utf-8"))["status"]
+            for (_op, key, value) in store.writes
+            if key == manifest_key
+        ]
+        # The manifest is written exactly once, and only as READY:
+        # IMPORTING is never persisted (blocker/F1 redesign), so a
+        # write-once store cannot strand it at IMPORTING.
+        self.assertEqual(manifest_statuses, [READY])
+
+        ready_pos = next(
+            i
+            for i, (_op, key, value) in enumerate(store.writes)
+            if key == manifest_key
+            and json.loads(value.decode("utf-8"))["status"] == READY
+        )
+        index_positions = [
+            i for i, (_op, key, _v) in enumerate(store.writes) if key == index_key
+        ]
+        self.assertTrue(index_positions)
+        self.assertTrue(all(pos > ready_pos for pos in index_positions))
+
+    def test_delete_is_idempotent_with_missing_object_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp)
+            write_demo_model(source)
+            store = MissingObjectRemoveStore()
+            client = ModelFileCacheClient(store)
+            manifest = client.import_model(
+                checkpoint_id="demo-main",
+                model_id="demo/model",
+                revision="main",
+                source_uri=str(source),
+            )
+
+            # Simulate a chunk a prior partial delete already removed, so the
+            # next delete hits the real -704 "already gone" path in _remove.
+            first_chunk = manifest.files[0].chunks[0]
+            store.objects.pop(first_chunk, None)
+
+            client.delete_model("demo-main")
+            client.delete_model("demo-main")
+
+            self.assertEqual(client.list_models(), [])
+            self.assertNotIn(model_manifest_key("demo-main"), store.objects)
+            for record in manifest.files:
+                for chunk in record.chunks:
+                    self.assertNotIn(chunk, store.objects)
+
+    def test_delete_crash_between_deindex_and_manifest_then_recovers(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp)
+            write_demo_model(source)
+            store = ManifestRemoveFailingStore()
+            client = ModelFileCacheClient(store)
+            manifest = client.import_model(
+                checkpoint_id="demo-main",
+                model_id="demo/model",
+                revision="main",
+                source_uri=str(source),
+            )
+
+            store.fail_manifest_remove = True
+            with self.assertRaises(RuntimeError):
+                client.delete_model("demo-main")
+
+            for record in manifest.files:
+                for chunk in record.chunks:
+                    self.assertNotIn(chunk, store.objects)
+            self.assertNotIn("demo-main", client.list_models())
+
+            # After a crash between de-index and manifest removal the
+            # manifest STILL EXISTS and is readable with its model_id
+            # intact. DELETING is no longer persisted, so it stays at its
+            # prior status (READY); the id is already de-indexed (asserted
+            # above) and a retry finishes teardown.
+            stranded = client.inspect_model("demo-main")
+            self.assertEqual(stranded.status, READY)
+            self.assertEqual(stranded.model_id, "demo/model")
+            self.assertIn(model_manifest_key("demo-main"), store.objects)
+
+            store.fail_manifest_remove = False
+            client.delete_model("demo-main")
+
+            self.assertNotIn(model_manifest_key("demo-main"), store.objects)
+            self.assertEqual(client.list_models(), [])
+
+    def test_delete_of_never_imported_id_is_a_noop(self) -> None:
+        store = FakeStore()
+        client = ModelFileCacheClient(store)
+
+        client.delete_model("ghost")
+
+        self.assertEqual(client.list_models(), [])
+
+    def test_delete_of_corrupt_manifest_removes_dangling_key(self) -> None:
+        store = FakeStore()
+        manifest_key = model_manifest_key("demo-main")
+        store.objects[manifest_key] = b"{not json"
+        client = ModelFileCacheClient(store)
+
+        client.delete_model("demo-main")
+
+        self.assertNotIn(manifest_key, store.objects)
+
+    def test_import_reclaims_failed_checkpoint_and_reimports(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp)
+            write_demo_model(source)
+            store = ToggleChunkFailStore()
+            client = ModelFileCacheClient(store)
+
+            with self.assertRaises(RuntimeError):
+                client.import_model(
+                    checkpoint_id="demo-main",
+                    model_id="demo/model",
+                    revision="main",
+                    source_uri=str(source),
+                )
+            self.assertEqual(client.inspect_model("demo-main").status, "FAILED")
+            self.assertEqual(client.list_models(), [])
+
+            store.fail_chunks = False
+            manifest = client.import_model(
+                checkpoint_id="demo-main",
+                model_id="demo/model",
+                revision="main",
+                source_uri=str(source),
+            )
+
+            self.assertEqual(manifest.status, READY)
+            self.assertIn("demo-main", client.list_models())
+
+    def test_import_still_rejects_ready_checkpoint(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp)
+            write_demo_model(source)
+            client = ModelFileCacheClient(FakeStore())
+            client.import_model(
+                checkpoint_id="demo-main",
+                model_id="demo/model",
+                revision="main",
+                source_uri=str(source),
+            )
+
+            with self.assertRaises(ValueError) as ctx:
+                client.import_model(
+                    checkpoint_id="demo-main",
+                    model_id="demo/model",
+                    revision="main",
+                    source_uri=str(source),
+                )
+            self.assertIn("demo-main", str(ctx.exception))
+
+    # ------------------------------------------------------------------
+    # Blocker: the native store is write-once and has no ``upsert``.
+    # ------------------------------------------------------------------
+    def test_two_imports_visible_on_write_once_store(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp)
+            write_demo_model(source)
+            store = WriteOnceStore()
+            self.assertFalse(hasattr(store, "upsert"))
+            client = ModelFileCacheClient(store, file_chunk_size=4)
+            client.import_model(
+                checkpoint_id="ckpt-a",
+                model_id="demo/model",
+                revision="main",
+                source_uri=str(source),
+            )
+            client.import_model(
+                checkpoint_id="ckpt-b",
+                model_id="demo/model",
+                revision="main",
+                source_uri=str(source),
+            )
+
+        # With a naive write-once put the 2nd index write is silently dropped
+        # and ckpt-b vanishes; delete-then-put in _put_control keeps both.
+        self.assertEqual(client.list_models(), ["ckpt-a", "ckpt-b"])
+
+    def test_import_ready_on_write_once_store(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp)
+            write_demo_model(source)
+            store = WriteOnceStore()
+            client = ModelFileCacheClient(store, file_chunk_size=4)
+            manifest = client.import_model(
+                checkpoint_id="demo-main",
+                model_id="demo/model",
+                revision="main",
+                source_uri=str(source),
+            )
+
+        self.assertEqual(manifest.status, READY)
+        # The persisted manifest is READY, not stranded at IMPORTING (which a
+        # write-once put would do if IMPORTING were persisted then overwritten).
+        self.assertEqual(client.inspect_model("demo-main").status, READY)
+        self.assertEqual(client.verify_model("demo-main").status, READY)
+        self.assertIn("demo-main", client.list_models())
+
+    def test_delete_then_reimport_same_id_on_write_once_store(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp)
+            write_demo_model(source)
+            store = WriteOnceStore()
+            client = ModelFileCacheClient(store, file_chunk_size=4)
+            first = client.import_model(
+                checkpoint_id="demo-main",
+                model_id="demo/model",
+                revision="main",
+                source_uri=str(source),
+            )
+
+            client.delete_model("demo-main")
+
+            # Delete leaves nothing behind: manifest gone, all chunks gone,
+            # nothing indexed.
+            self.assertEqual(client.list_models(), [])
+            self.assertNotIn(model_manifest_key("demo-main"), store.objects)
+            for record in first.files:
+                for chunk in record.chunks:
+                    self.assertNotIn(chunk, store.objects)
+
+            # The manifest (and index) key is reusable after remove: a re-import
+            # of the same id succeeds and ends READY.
+            second = client.import_model(
+                checkpoint_id="demo-main",
+                model_id="demo/model",
+                revision="main",
+                source_uri=str(source),
+            )
+
+        self.assertEqual(second.status, READY)
+        self.assertEqual(client.inspect_model("demo-main").status, READY)
+        self.assertIn("demo-main", client.list_models())
+
+    def test_delete_deindexes_before_removing_manifest_write_once(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp)
+            write_demo_model(source)
+            store = WriteOnceManifestRemoveFailingStore()
+            client = ModelFileCacheClient(store, file_chunk_size=4)
+            manifest = client.import_model(
+                checkpoint_id="demo-main",
+                model_id="demo/model",
+                revision="main",
+                source_uri=str(source),
+            )
+
+            store.fail_manifest_remove = True
+            with self.assertRaises(RuntimeError):
+                client.delete_model("demo-main")
+
+            # De-indexed and chunks gone, but the manifest survives the crash and
+            # stays parseable with an intact model_id and status READY (never
+            # DELETING) -- so the id can never be stranded (Finding 4).
+            self.assertNotIn("demo-main", client.list_models())
+            for record in manifest.files:
+                for chunk in record.chunks:
+                    self.assertNotIn(chunk, store.objects)
+            stranded = client.inspect_model("demo-main")
+            self.assertEqual(stranded.status, READY)
+            self.assertEqual(stranded.model_id, "demo/model")
+
+            store.fail_manifest_remove = False
+            client.delete_model("demo-main")
+
+            self.assertNotIn(model_manifest_key("demo-main"), store.objects)
+            self.assertEqual(client.list_models(), [])
+
+    # ------------------------------------------------------------------
+    # F2: the authoritative chunk_size is persisted (and legacy-safe).
+    # ------------------------------------------------------------------
+    def test_manifest_records_carry_chunk_size(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp)
+            write_demo_model(source)
+            store = FakeStore()
+            client = ModelFileCacheClient(store, file_chunk_size=4)
+            manifest = client.import_model(
+                checkpoint_id="demo-main",
+                model_id="demo/model",
+                revision="main",
+                source_uri=str(source),
+            )
+
+        self.assertEqual(manifest.schema_version, SCHEMA_VERSION)
+        self.assertEqual(SCHEMA_VERSION, 2)
+        self.assertTrue(manifest.files)
+        for record in manifest.files:
+            self.assertEqual(record.chunk_size, 4)
+
+        # A JSON round-trip preserves chunk_size.
+        round_tripped = ModelFileManifest.from_json_bytes(manifest.to_json_bytes())
+        for record in round_tripped.files:
+            self.assertEqual(record.chunk_size, 4)
+
+        # A legacy manifest dict WITHOUT chunk_size parses with the default 0.
+        legacy = json.loads(manifest.to_json_bytes().decode("utf-8"))
+        for item in legacy["files"]:
+            item.pop("chunk_size", None)
+        legacy_manifest = ModelFileManifest.from_json_bytes(
+            json.dumps(legacy).encode("utf-8")
+        )
+        self.assertTrue(legacy_manifest.files)
+        for record in legacy_manifest.files:
+            self.assertEqual(record.chunk_size, 0)
+
+    # ------------------------------------------------------------------
+    # F3: a chunk whose cleanup remove fails is recorded and later swept.
+    # ------------------------------------------------------------------
+    def test_failed_import_preserves_unremovable_chunk_for_later_delete(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp)
+            write_demo_model(source)
+            store = SurvivorChunkStore()
+            client = ModelFileCacheClient(store, file_chunk_size=4)
+
+            with self.assertRaises(KeyboardInterrupt):
+                client.import_model(
+                    checkpoint_id="demo-main",
+                    model_id="demo/model",
+                    revision="main",
+                    source_uri=str(source),
+                )
+
+            # The immediate cleanup remove of the first chunk failed, so it
+            # survives in the store.
+            survivor = model_file_chunk_key("demo-main", "config.json", 0)
+            self.assertIn(survivor, store.objects)
+
+            # The FAILED manifest records the survivor so it is not orphaned.
+            failed = client.inspect_model("demo-main")
+            self.assertEqual(failed.status, "FAILED")
+            recorded = [chunk for record in failed.files for chunk in record.chunks]
+            self.assertIn(survivor, recorded)
+
+            # delete_model then sweeps it: no orphan chunk remains.
+            client.delete_model("demo-main")
+            self.assertNotIn(survivor, store.objects)
+            self.assertNotIn(model_manifest_key("demo-main"), store.objects)
 
 
 if __name__ == "__main__":

--- a/mooncake-wheel/tests/test_weight_model_cli.py
+++ b/mooncake-wheel/tests/test_weight_model_cli.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+import io
+import json
+import tempfile
+import sys
+import types
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+from mooncake.weight_store.cli import build_parser, main
+
+
+class FakeModelClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple] = []
+
+    def import_model(self, **kwargs):
+        self.calls.append(("import", kwargs))
+        return {"checkpoint_id": kwargs["checkpoint_id"], "status": "READY"}
+
+    def list_models(self):
+        self.calls.append(("list",))
+        return ["ckpt-a"]
+
+    def inspect_model(self, checkpoint_id):
+        self.calls.append(("inspect", checkpoint_id))
+        return {"checkpoint_id": checkpoint_id, "status": "READY"}
+
+    def verify_model(self, checkpoint_id):
+        self.calls.append(("verify", checkpoint_id))
+        return {"checkpoint_id": checkpoint_id, "status": "READY"}
+
+    def delete_model(self, checkpoint_id):
+        self.calls.append(("delete", checkpoint_id))
+
+    def materialize_file(self, checkpoint_id, path, output_path):
+        self.calls.append(("materialize", checkpoint_id, path, output_path))
+
+
+class FakeStoreForSetup:
+    def __init__(self) -> None:
+        self.calls: list[tuple] = []
+
+    def setup(self, *args):
+        self.calls.append(args)
+        return 0
+
+
+class NoneSetupStore(FakeStoreForSetup):
+    def setup(self, *args):
+        self.calls.append(args)
+        return None
+
+
+class TestModelCacheCli(unittest.TestCase):
+    def test_parser_accepts_model_import_command(self) -> None:
+        args = build_parser().parse_args(
+            [
+                "model",
+                "import",
+                "--checkpoint-id",
+                "ckpt-a",
+                "--model-id",
+                "demo/model",
+                "--revision",
+                "main",
+                "--source",
+                "/models/demo",
+            ]
+        )
+
+        self.assertEqual(args.command, "model")
+        self.assertEqual(args.model_command, "import")
+        self.assertEqual(args.checkpoint_id, "ckpt-a")
+
+    def test_model_commands_call_client_and_print_json(self) -> None:
+        client = FakeModelClient()
+        with (
+            mock.patch(
+                "mooncake.weight_store.cli._create_model_client",
+                return_value=client,
+            ),
+            redirect_stdout(io.StringIO()) as stdout,
+        ):
+            result = main(["model", "verify", "ckpt-a"])
+
+        self.assertEqual(result, 0)
+        self.assertEqual(
+            json.loads(stdout.getvalue()),
+            {"checkpoint_id": "ckpt-a", "status": "READY"},
+        )
+        self.assertEqual(client.calls, [("verify", "ckpt-a")])
+
+    def test_model_materialize_command_accepts_path_and_output(self) -> None:
+        client = FakeModelClient()
+        with tempfile.TemporaryDirectory() as tmp:
+            output = str(Path(tmp) / "config.json")
+            with (
+                mock.patch(
+                    "mooncake.weight_store.cli._create_model_client",
+                    return_value=client,
+                ),
+                redirect_stdout(io.StringIO()) as stdout,
+            ):
+                result = main(
+                    [
+                        "model",
+                        "materialize-file",
+                        "ckpt-a",
+                        "--path",
+                        "config.json",
+                        "--output",
+                        output,
+                    ]
+                )
+
+        self.assertEqual(result, 0)
+        self.assertEqual(
+            json.loads(stdout.getvalue()),
+            {"checkpoint_id": "ckpt-a", "path": "config.json", "output": output},
+        )
+        self.assertEqual(
+            client.calls,
+            [("materialize", "ckpt-a", "config.json", output)],
+        )
+
+    def test_config_init_writes_store_defaults(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            config_path = Path(tmp) / "weight-store.json"
+
+            with redirect_stdout(io.StringIO()) as stdout:
+                result = main(
+                    [
+                        "--config",
+                        str(config_path),
+                        "--metadata-server",
+                        "http://meta.example/metadata",
+                        "--master-server-addr",
+                        "10.0.0.1:50051",
+                        "config",
+                        "init",
+                    ]
+                )
+
+            self.assertEqual(result, 0)
+            self.assertEqual(
+                json.loads(stdout.getvalue()),
+                {"config": str(config_path), "written": True},
+            )
+            saved = json.loads(config_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(saved["metadata_server"], "http://meta.example/metadata")
+        self.assertEqual(saved["master_server_addr"], "10.0.0.1:50051")
+        # config init only writes connection settings, not import-only options.
+        self.assertNotIn("replica_num", saved)
+        self.assertNotIn("file_chunk_size", saved)
+        self.assertNotIn("global_segment_size", saved)
+        self.assertNotIn("local_buffer_size", saved)
+
+    def test_config_init_accepts_store_args_after_subcommand(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            config_path = Path(tmp) / "weight-store.json"
+
+            with redirect_stdout(io.StringIO()):
+                result = main(
+                    [
+                        "config",
+                        "init",
+                        "--config",
+                        str(config_path),
+                        "--local-hostname",
+                        "cli-client:12346",
+                        "--protocol",
+                        "rdma",
+                    ]
+                )
+
+            self.assertEqual(result, 0)
+            saved = json.loads(config_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(saved["local_hostname"], "cli-client:12346")
+        self.assertEqual(saved["protocol"], "rdma")
+
+    def test_config_file_supplies_store_defaults_and_cli_can_override(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            config_path = Path(tmp) / "weight-store.json"
+            config_path.write_text(
+                json.dumps(
+                    {
+                        "metadata_server": "http://meta.example/metadata",
+                        "master_server_addr": "10.0.0.1:50051",
+                        "replica_num": 3,
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            # Connection defaults come from the config file; the import-only
+            # --replica-num overrides the value the config file pre-stored.
+            args = build_parser(["--config", str(config_path)]).parse_args(
+                [
+                    "--config",
+                    str(config_path),
+                    "model",
+                    "import",
+                    "--checkpoint-id",
+                    "ckpt-a",
+                    "--model-id",
+                    "demo/model",
+                    "--revision",
+                    "main",
+                    "--source",
+                    "/models/demo",
+                    "--replica-num",
+                    "4",
+                ]
+            )
+
+        self.assertEqual(args.metadata_server, "http://meta.example/metadata")
+        self.assertEqual(args.master_server_addr, "10.0.0.1:50051")
+        self.assertEqual(args.replica_num, 4)
+
+    def test_build_parser_loads_config_from_sys_argv_when_argv_is_none(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            config_path = Path(tmp) / "weight-store.json"
+            config_path.write_text(
+                json.dumps({"metadata_server": "http://meta.example/metadata"}),
+                encoding="utf-8",
+            )
+            with mock.patch(
+                "sys.argv",
+                [
+                    "mooncake_weight_store",
+                    "--config",
+                    str(config_path),
+                    "model",
+                    "list",
+                ],
+            ):
+                args = build_parser().parse_args()
+
+        self.assertEqual(args.metadata_server, "http://meta.example/metadata")
+
+    def test_connect_store_uses_positional_setup_for_existing_bindings(self) -> None:
+        from mooncake.weight_store import cli
+
+        fake_store = FakeStoreForSetup()
+        args = build_parser().parse_args(["model", "list"])
+
+        fake_module = types.SimpleNamespace(MooncakeDistributedStore=lambda: fake_store)
+        with mock.patch.dict(sys.modules, {"mooncake.store": fake_module}):
+            created = cli._connect_store(args)
+
+        self.assertIs(created, fake_store)
+        # The CLI is always a pure client: segment size 0, fixed local buffer.
+        self.assertEqual(fake_store.calls[0][2], cli._CLIENT_GLOBAL_SEGMENT_SIZE)
+        self.assertEqual(fake_store.calls[0][3], cli._CLIENT_LOCAL_BUFFER_SIZE)
+
+    def test_connect_store_accepts_none_setup_result(self) -> None:
+        from mooncake.weight_store import cli
+
+        fake_store = NoneSetupStore()
+        args = build_parser().parse_args(["model", "list"])
+
+        fake_module = types.SimpleNamespace(MooncakeDistributedStore=lambda: fake_store)
+        with mock.patch.dict(sys.modules, {"mooncake.store": fake_module}):
+            created = cli._connect_store(args)
+
+        self.assertIs(created, fake_store)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Add a file-level weight caching control plane on top of MooncakeStore, so model checkpoints can be imported into the store and served to inference engines (e.g. SGLang) as plain files — without a tensor-level, GPU-coupled save path.

The idea is to treat MooncakeStore as a **generic model cache** that is decoupled from the inference engine: weights are stored file-level (HuggingFace safetensors chunked with a per-model manifest), and engines load files exactly as they would from disk, only the source changes (disk → MooncakeStore). This control plane provides the management side — import / list / inspect / verify / delete — independently of any serving process.

The matching SGLang connector (data plane) is in sgl-project/sglang#30728. Design discussion / RFC: #2282 (Unified KVCache and Model Weight Management); this PR implements Phase 1 (store-backed weight loading) plus the import/manage control plane.

## Module

- [x] Python Wheel (`mooncake-wheel`)
- [x] Docs

## Type of Change

- [x] New feature

## How Has This Been Tested?

**Test commands:**
```bash
cd mooncake-wheel
python -m pytest tests/test_weight_model_cache.py tests/test_weight_model_cli.py -v
```

**End-to-end (cross-machine, one storage node + one 8×H20 node):**
```bash
# import a checkpoint into MooncakeStore
python -m mooncake.weight_store.cli \
    --master-server-addr <master_ip:50051> \
    --metadata-server <metadata_ip:8080> \
    --protocol rdma --rdma-devices <mlx5_x> \
    --local-hostname <host_ip:port> \
    model import \
    --checkpoint-id Qwen3-235B-A22B \
    --model-id Qwen/Qwen3-235B-A22B \
    --revision main \
    --source /path/to/local/weights

# confirm it landed
python -m mooncake.weight_store.cli ... model list
python -m mooncake.weight_store.cli ... model inspect Qwen3-235B-A22B
python -m mooncake.weight_store.cli ... model verify  Qwen3-235B-A22B
```
Then loaded Qwen3-235B-A22B from the store via the SGLang connector in ~30s
with correct inference output.

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (cross-machine import + SGLang load + inference, above)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue (#2282)

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

AI assistance (Claude Code) was used for parts of the implementation, tests, and documentation. All changes have been reviewed and are understood by the human submitter.