### PR TITLE
[Store] Extract master snapshot codec from MasterService（3/5）

### DIFF
--- a/mooncake-store/include/ha/snapshot/master_snapshot_codec.h
+++ b/mooncake-store/include/ha/snapshot/master_snapshot_codec.h
@@ -1,0 +1,129 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+#include <ylt/util/tl/expected.hpp>
+
+#include "types.h"
+
+namespace mooncake {
+
+// Forward declarations
+class MasterService;
+class SegmentManager;
+class NoFSegmentManager;
+class ClientTaskManager;
+
+namespace ha {
+
+/**
+ * @brief A read-only view of the live master state for snapshot serialization.
+ *
+ * This struct holds const references to the live state components that need to
+ * be serialized into a master snapshot. It's a half-step DTO approach that
+ * avoids copying large state while providing a clean interface for the codec.
+ */
+struct MasterSnapshotStateView {
+    const MasterService& master_service;
+    const SegmentManager& segment_manager;
+    const NoFSegmentManager& nof_segment_manager;
+    const ClientTaskManager& task_manager;
+
+    MasterSnapshotStateView(const MasterService& ms,
+                            const SegmentManager& sm,
+                            const NoFSegmentManager& nsm,
+                            const ClientTaskManager& tm)
+        : master_service(ms),
+          segment_manager(sm),
+          nof_segment_manager(nsm),
+          task_manager(tm) {}
+};
+
+/**
+ * @brief Encodes and decodes master snapshot payloads.
+ *
+ * This codec handles serialization of the complete master state bundle:
+ * - Metadata shards (objects, replicas, tenant state)
+ * - Segment manager state
+ * - Task manager state
+ * - Discarded replicas
+ *
+ * The current implementation preserves the existing snapshot format exactly
+ * to maintain backward compatibility with existing snapshots.
+ *
+ * Format details:
+ * - metadata: msgpack-encoded metadata shards (compressed per-shard with zstd)
+ * - segments: msgpack-encoded segment manager state
+ * - task_manager: msgpack-encoded task manager state
+ * - manifest.txt: format descriptor (e.g., "messagepack|1.0.0|master")
+ */
+class MasterSnapshotCodec {
+   public:
+    MasterSnapshotCodec() = default;
+    ~MasterSnapshotCodec() = default;
+
+    // Non-copyable, non-movable (contains no state, but enforce ownership semantics)
+    MasterSnapshotCodec(const MasterSnapshotCodec&) = delete;
+    MasterSnapshotCodec& operator=(const MasterSnapshotCodec&) = delete;
+    MasterSnapshotCodec(MasterSnapshotCodec&&) = delete;
+    MasterSnapshotCodec& operator=(MasterSnapshotCodec&&) = delete;
+
+    /**
+     * @brief Encode master state into serialized buffers.
+     *
+     * @param state_view Read-only view of the live master state
+     * @return Map of payload names to serialized data buffers, or error
+     *
+     * The returned map contains keys like:
+     * - "metadata": serialized metadata shards
+     * - "segments": serialized segment manager state
+     * - "task_manager": serialized task manager state
+     */
+    tl::expected<std::unordered_map<std::string, std::vector<uint8_t>>,
+                 SerializationError>
+    Encode(const MasterSnapshotStateView& state_view) const;
+
+    /**
+     * @brief Decode snapshot payloads and restore into master service.
+     *
+     * @param master_service Target MasterService to restore state into
+     * @param payloads Map of payload names to serialized data
+     * @return void on success, SerializationError on failure
+     */
+    tl::expected<void, SerializationError> Decode(
+        MasterService* master_service,
+        const std::unordered_map<std::string, std::vector<uint8_t>>& payloads)
+        const;
+
+    /**
+     * @brief Get the manifest content for this codec version.
+     *
+     * @return Manifest string (e.g., "messagepack|1.0.0|master")
+     */
+    static std::string GetManifestContent();
+
+   private:
+    // Metadata encoding/decoding (delegates to MetadataSerializer for now)
+    tl::expected<std::vector<uint8_t>, SerializationError> EncodeMetadata(
+        const MasterService& master_service) const;
+    tl::expected<void, SerializationError> DecodeMetadata(
+        MasterService* master_service, const std::vector<uint8_t>& data) const;
+
+    // Segment encoding/decoding
+    tl::expected<std::vector<uint8_t>, SerializationError> EncodeSegments(
+        const SegmentManager& segment_manager,
+        const NoFSegmentManager& nof_segment_manager) const;
+    tl::expected<void, SerializationError> DecodeSegments(
+        MasterService* master_service, const std::vector<uint8_t>& data) const;
+
+    // Task manager encoding/decoding
+    tl::expected<std::vector<uint8_t>, SerializationError> EncodeTaskManager(
+        const ClientTaskManager& task_manager) const;
+    tl::expected<void, SerializationError> DecodeTaskManager(
+        MasterService* master_service, const std::vector<uint8_t>& data) const;
+};
+
+}  // namespace ha
+}  // namespace mooncake

--- a/mooncake-store/include/ha/snapshot/master_snapshot_codec.h
+++ b/mooncake-store/include/ha/snapshot/master_snapshot_codec.h
@@ -68,7 +68,8 @@ struct MasterSnapshotPayloads {
  * - metadata: msgpack-encoded metadata shards (compressed per-shard with zstd)
  * - segments: msgpack-encoded segment manager state
  * - task_manager: msgpack-encoded task manager state
- * - manifest.txt: format descriptor (e.g., "messagepack|1.0.0|master")
+ * - manifest.txt: format descriptor "<type>|<version>|<snapshot_id>"
+ *   (e.g., "messagepack|1.0.0|snapshot-000123")
  */
 class MasterSnapshotCodec {
    public:
@@ -107,12 +108,25 @@ class MasterSnapshotCodec {
         MasterService* master_service,
         const MasterSnapshotPayloads& payloads) const;
 
+    // Canonical serializer identifiers embedded in the snapshot manifest.
+    static constexpr const char* kSerializerType = "messagepack";
+    static constexpr const char* kSerializerVersion = "1.0.0";
+
     /**
-     * @brief Get the manifest content for this codec version.
+     * @brief Encode a snapshot manifest into its on-disk byte representation.
      *
-     * @return Manifest string (e.g., "messagepack|1.0.0|master")
+     * The manifest is a "<type>|<version>|<snapshot_id>" descriptor. Keeping
+     * the encoding here (rather than hand-crafting the format string at the
+     * call site) ensures the manifest layout stays owned by the codec.
+     *
+     * @param type Serializer/protocol type (e.g., "messagepack")
+     * @param version Snapshot format version (e.g., "1.0.0")
+     * @param snapshot_id Identifier of the snapshot being written
+     * @return Manifest bytes ready to upload
      */
-    static std::string GetManifestContent();
+    static std::vector<uint8_t> EncodeManifest(const std::string& type,
+                                               const std::string& version,
+                                               const std::string& snapshot_id);
 
    private:
     // Metadata encoding/decoding (delegates to MetadataSerializer for now)

--- a/mooncake-store/include/ha/snapshot/master_snapshot_codec.h
+++ b/mooncake-store/include/ha/snapshot/master_snapshot_codec.h
@@ -19,26 +19,37 @@ class ClientTaskManager;
 namespace ha {
 
 /**
- * @brief A read-only view of the live master state for snapshot serialization.
+ * @brief A view of the live master state for snapshot serialization.
  *
- * This struct holds const references to the live state components that need to
- * be serialized into a master snapshot. It's a half-step DTO approach that
- * avoids copying large state while providing a clean interface for the codec.
+ * This struct holds references to the live state components that need to
+ * be serialized into a master snapshot. Non-const references are used because
+ * the underlying serializers require non-const pointers, avoiding const_cast.
  */
 struct MasterSnapshotStateView {
-    const MasterService& master_service;
-    const SegmentManager& segment_manager;
-    const NoFSegmentManager& nof_segment_manager;
-    const ClientTaskManager& task_manager;
+    MasterService& master_service;
+    SegmentManager& segment_manager;
+    NoFSegmentManager& nof_segment_manager;
+    ClientTaskManager& task_manager;
 
-    MasterSnapshotStateView(const MasterService& ms,
-                            const SegmentManager& sm,
-                            const NoFSegmentManager& nsm,
-                            const ClientTaskManager& tm)
+    MasterSnapshotStateView(MasterService& ms, SegmentManager& sm,
+                            NoFSegmentManager& nsm, ClientTaskManager& tm)
         : master_service(ms),
           segment_manager(sm),
           nof_segment_manager(nsm),
           task_manager(tm) {}
+};
+
+/**
+ * @brief Container for serialized master snapshot payloads.
+ *
+ * This struct provides a type-safe, zero-overhead container for the three
+ * serialized payload buffers, eliminating map lookup overhead and potential
+ * runtime exceptions from using std::unordered_map.
+ */
+struct MasterSnapshotPayloads {
+    std::vector<uint8_t> metadata;
+    std::vector<uint8_t> segments;
+    std::vector<uint8_t> task_manager;
 };
 
 /**
@@ -64,7 +75,8 @@ class MasterSnapshotCodec {
     MasterSnapshotCodec() = default;
     ~MasterSnapshotCodec() = default;
 
-    // Non-copyable, non-movable (contains no state, but enforce ownership semantics)
+    // Non-copyable, non-movable (contains no state, but enforce ownership
+    // semantics)
     MasterSnapshotCodec(const MasterSnapshotCodec&) = delete;
     MasterSnapshotCodec& operator=(const MasterSnapshotCodec&) = delete;
     MasterSnapshotCodec(MasterSnapshotCodec&&) = delete;
@@ -73,29 +85,27 @@ class MasterSnapshotCodec {
     /**
      * @brief Encode master state into serialized buffers.
      *
-     * @param state_view Read-only view of the live master state
-     * @return Map of payload names to serialized data buffers, or error
+     * @param state_view View of the live master state
+     * @return Structured payloads containing serialized data, or error
      *
-     * The returned map contains keys like:
-     * - "metadata": serialized metadata shards
-     * - "segments": serialized segment manager state
-     * - "task_manager": serialized task manager state
+     * The returned struct contains:
+     * - metadata: serialized metadata shards
+     * - segments: serialized segment manager state
+     * - task_manager: serialized task manager state
      */
-    tl::expected<std::unordered_map<std::string, std::vector<uint8_t>>,
-                 SerializationError>
-    Encode(const MasterSnapshotStateView& state_view) const;
+    tl::expected<MasterSnapshotPayloads, SerializationError> Encode(
+        MasterSnapshotStateView& state_view) const;
 
     /**
      * @brief Decode snapshot payloads and restore into master service.
      *
      * @param master_service Target MasterService to restore state into
-     * @param payloads Map of payload names to serialized data
+     * @param payloads Structured payloads containing serialized data
      * @return void on success, SerializationError on failure
      */
     tl::expected<void, SerializationError> Decode(
         MasterService* master_service,
-        const std::unordered_map<std::string, std::vector<uint8_t>>& payloads)
-        const;
+        const MasterSnapshotPayloads& payloads) const;
 
     /**
      * @brief Get the manifest content for this codec version.
@@ -107,20 +117,20 @@ class MasterSnapshotCodec {
    private:
     // Metadata encoding/decoding (delegates to MetadataSerializer for now)
     tl::expected<std::vector<uint8_t>, SerializationError> EncodeMetadata(
-        const MasterService& master_service) const;
+        MasterService& master_service) const;
     tl::expected<void, SerializationError> DecodeMetadata(
         MasterService* master_service, const std::vector<uint8_t>& data) const;
 
     // Segment encoding/decoding
     tl::expected<std::vector<uint8_t>, SerializationError> EncodeSegments(
-        const SegmentManager& segment_manager,
-        const NoFSegmentManager& nof_segment_manager) const;
+        SegmentManager& segment_manager,
+        NoFSegmentManager& nof_segment_manager) const;
     tl::expected<void, SerializationError> DecodeSegments(
         MasterService* master_service, const std::vector<uint8_t>& data) const;
 
     // Task manager encoding/decoding
     tl::expected<std::vector<uint8_t>, SerializationError> EncodeTaskManager(
-        const ClientTaskManager& task_manager) const;
+        ClientTaskManager& task_manager) const;
     tl::expected<void, SerializationError> DecodeTaskManager(
         MasterService* master_service, const std::vector<uint8_t>& data) const;
 };

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -45,6 +45,7 @@ class MasterSnapshotManager;
 
 namespace ha {
 class SnapshotCatalogStore;
+class MasterSnapshotCodec;
 }
 
 class EtcdOpLogStore;
@@ -94,6 +95,7 @@ class MasterService {
     friend class test::MasterServiceTenantQuotaTest;
     friend class MasterSnapshotManager;  // Allow access to internal state for
                                          // snapshot
+    friend class ha::MasterSnapshotCodec;  // Allow codec to access private members
 
    public:
     using NoFProbeFn =

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -46,6 +46,7 @@ class MasterSnapshotManager;
 namespace ha {
 class SnapshotCatalogStore;
 class MasterSnapshotCodec;
+class MasterSnapshotCodecTest;  // test fixture, needs private state access
 }
 
 class EtcdOpLogStore;
@@ -93,9 +94,11 @@ class MasterService {
     friend class test::PromotionOnHitTest;
     friend class benchmarks::BatchEvictBench;
     friend class test::MasterServiceTenantQuotaTest;
-    friend class MasterSnapshotManager;  // Allow access to internal state for
-                                         // snapshot
-    friend class ha::MasterSnapshotCodec;  // Allow codec to access private members
+    friend class MasterSnapshotManager;    // Allow access to internal state for
+                                           // snapshot
+    friend class ha::MasterSnapshotCodec;  // Allow codec to access private
+                                           // members
+    friend class ha::MasterSnapshotCodecTest;  // codec round-trip unit test
 
    public:
     using NoFProbeFn =

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -47,7 +47,7 @@ namespace ha {
 class SnapshotCatalogStore;
 class MasterSnapshotCodec;
 class MasterSnapshotCodecTest;  // test fixture, needs private state access
-}
+}  // namespace ha
 
 class EtcdOpLogStore;
 

--- a/mooncake-store/include/master_snapshot_manager.h
+++ b/mooncake-store/include/master_snapshot_manager.h
@@ -12,6 +12,7 @@
 
 #include "types.h"
 #include "ha/ha_types.h"
+#include "ha/snapshot/master_snapshot_codec.h"
 
 namespace mooncake {
 

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -48,6 +48,7 @@ set(MOONCAKE_STORE_SOURCES
     ha/leadership/master_service_supervisor.cpp
     ha/standby_controller.cpp
     ha/snapshot/catalog_backed_snapshot_provider.cpp
+    ha/snapshot/master_snapshot_codec.cpp
     ha/snapshot/object/snapshot_object_store.cpp
     ha/snapshot/object/backends/local/local_file_snapshot_object_store.cpp
     ha/snapshot/object/backends/s3/s3_snapshot_object_store.cpp

--- a/mooncake-store/src/ha/snapshot/master_snapshot_codec.cpp
+++ b/mooncake-store/src/ha/snapshot/master_snapshot_codec.cpp
@@ -1,0 +1,144 @@
+#include "ha/snapshot/master_snapshot_codec.h"
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "master_service.h"
+#include "segment.h"
+#include "serialize/serializer.h"
+#include "task_manager.h"
+
+namespace mooncake::ha {
+
+std::string MasterSnapshotCodec::GetManifestContent() {
+    return "messagepack|1.0.0|master";
+}
+
+tl::expected<std::unordered_map<std::string, std::vector<uint8_t>>,
+             SerializationError>
+MasterSnapshotCodec::Encode(const MasterSnapshotStateView& state_view) const {
+    std::unordered_map<std::string, std::vector<uint8_t>> payloads;
+
+    // 1. Encode metadata (shards, discarded replicas, replica_next_id)
+    auto metadata_result = EncodeMetadata(state_view.master_service);
+    if (!metadata_result) {
+        return tl::make_unexpected(metadata_result.error());
+    }
+    payloads["metadata"] = std::move(metadata_result.value());
+
+    // 2. Encode segments (memory segments + NoF segments)
+    auto segments_result =
+        EncodeSegments(state_view.segment_manager, state_view.nof_segment_manager);
+    if (!segments_result) {
+        return tl::make_unexpected(segments_result.error());
+    }
+    payloads["segments"] = std::move(segments_result.value());
+
+    // 3. Encode task manager
+    auto task_manager_result = EncodeTaskManager(state_view.task_manager);
+    if (!task_manager_result) {
+        return tl::make_unexpected(task_manager_result.error());
+    }
+    payloads["task_manager"] = std::move(task_manager_result.value());
+
+    return payloads;
+}
+
+tl::expected<void, SerializationError> MasterSnapshotCodec::Decode(
+    MasterService* master_service,
+    const std::unordered_map<std::string, std::vector<uint8_t>>& payloads)
+    const {
+    if (master_service == nullptr) {
+        return tl::make_unexpected(SerializationError(
+            ErrorCode::INVALID_PARAMS, "master_service is null"));
+    }
+
+    // 1. Decode metadata (must be first to restore metadata shards)
+    auto metadata_it = payloads.find("metadata");
+    if (metadata_it == payloads.end()) {
+        return tl::make_unexpected(SerializationError(
+            ErrorCode::DESERIALIZE_FAIL, "Missing 'metadata' payload"));
+    }
+    auto metadata_result = DecodeMetadata(master_service, metadata_it->second);
+    if (!metadata_result) {
+        return tl::make_unexpected(metadata_result.error());
+    }
+
+    // 2. Decode segments
+    auto segments_it = payloads.find("segments");
+    if (segments_it == payloads.end()) {
+        return tl::make_unexpected(SerializationError(
+            ErrorCode::DESERIALIZE_FAIL, "Missing 'segments' payload"));
+    }
+    auto segments_result = DecodeSegments(master_service, segments_it->second);
+    if (!segments_result) {
+        return tl::make_unexpected(segments_result.error());
+    }
+
+    // 3. Decode task manager
+    auto task_manager_it = payloads.find("task_manager");
+    if (task_manager_it == payloads.end()) {
+        return tl::make_unexpected(SerializationError(
+            ErrorCode::DESERIALIZE_FAIL, "Missing 'task_manager' payload"));
+    }
+    auto task_manager_result =
+        DecodeTaskManager(master_service, task_manager_it->second);
+    if (!task_manager_result) {
+        return tl::make_unexpected(task_manager_result.error());
+    }
+
+    return {};
+}
+
+tl::expected<std::vector<uint8_t>, SerializationError>
+MasterSnapshotCodec::EncodeMetadata(
+    const MasterService& master_service) const {
+    // Delegate to the existing MetadataSerializer for now.
+    // This maintains the exact same format as before.
+    MasterService::MetadataSerializer serializer(
+        const_cast<MasterService*>(&master_service));
+    return serializer.Serialize();
+}
+
+tl::expected<void, SerializationError> MasterSnapshotCodec::DecodeMetadata(
+    MasterService* master_service, const std::vector<uint8_t>& data) const {
+    // Delegate to the existing MetadataSerializer for now.
+    MasterService::MetadataSerializer serializer(master_service);
+    return serializer.Deserialize(data);
+}
+
+tl::expected<std::vector<uint8_t>, SerializationError>
+MasterSnapshotCodec::EncodeSegments(
+    const SegmentManager& segment_manager,
+    const NoFSegmentManager& nof_segment_manager) const {
+    // Use the existing SegmentSerializer which only handles SegmentManager
+    // Note: NoFSegmentManager is not currently serialized in snapshots
+    SegmentSerializer serializer(const_cast<SegmentManager*>(&segment_manager));
+    return serializer.Serialize();
+}
+
+tl::expected<void, SerializationError> MasterSnapshotCodec::DecodeSegments(
+    MasterService* master_service, const std::vector<uint8_t>& data) const {
+    // Access the segment managers from MasterService
+    SegmentSerializer serializer(&master_service->segment_manager_);
+    return serializer.Deserialize(data);
+}
+
+tl::expected<std::vector<uint8_t>, SerializationError>
+MasterSnapshotCodec::EncodeTaskManager(
+    const ClientTaskManager& task_manager) const {
+    // Use the existing TaskManagerSerializer
+    TaskManagerSerializer serializer(
+        const_cast<ClientTaskManager*>(&task_manager));
+    return serializer.Serialize();
+}
+
+tl::expected<void, SerializationError> MasterSnapshotCodec::DecodeTaskManager(
+    MasterService* master_service, const std::vector<uint8_t>& data) const {
+    // Access the task manager from MasterService
+    TaskManagerSerializer serializer(&master_service->task_manager_);
+    return serializer.Deserialize(data);
+}
+
+}  // namespace mooncake::ha

--- a/mooncake-store/src/ha/snapshot/master_snapshot_codec.cpp
+++ b/mooncake-store/src/ha/snapshot/master_snapshot_codec.cpp
@@ -15,75 +15,58 @@ std::string MasterSnapshotCodec::GetManifestContent() {
     return "messagepack|1.0.0|master";
 }
 
-tl::expected<std::unordered_map<std::string, std::vector<uint8_t>>,
-             SerializationError>
-MasterSnapshotCodec::Encode(const MasterSnapshotStateView& state_view) const {
-    std::unordered_map<std::string, std::vector<uint8_t>> payloads;
+tl::expected<MasterSnapshotPayloads, SerializationError>
+MasterSnapshotCodec::Encode(MasterSnapshotStateView& state_view) const {
+    MasterSnapshotPayloads payloads;
 
     // 1. Encode metadata (shards, discarded replicas, replica_next_id)
     auto metadata_result = EncodeMetadata(state_view.master_service);
     if (!metadata_result) {
         return tl::make_unexpected(metadata_result.error());
     }
-    payloads["metadata"] = std::move(metadata_result.value());
+    payloads.metadata = std::move(metadata_result.value());
 
     // 2. Encode segments (memory segments + NoF segments)
-    auto segments_result =
-        EncodeSegments(state_view.segment_manager, state_view.nof_segment_manager);
+    auto segments_result = EncodeSegments(state_view.segment_manager,
+                                          state_view.nof_segment_manager);
     if (!segments_result) {
         return tl::make_unexpected(segments_result.error());
     }
-    payloads["segments"] = std::move(segments_result.value());
+    payloads.segments = std::move(segments_result.value());
 
     // 3. Encode task manager
     auto task_manager_result = EncodeTaskManager(state_view.task_manager);
     if (!task_manager_result) {
         return tl::make_unexpected(task_manager_result.error());
     }
-    payloads["task_manager"] = std::move(task_manager_result.value());
+    payloads.task_manager = std::move(task_manager_result.value());
 
     return payloads;
 }
 
 tl::expected<void, SerializationError> MasterSnapshotCodec::Decode(
     MasterService* master_service,
-    const std::unordered_map<std::string, std::vector<uint8_t>>& payloads)
-    const {
+    const MasterSnapshotPayloads& payloads) const {
     if (master_service == nullptr) {
         return tl::make_unexpected(SerializationError(
             ErrorCode::INVALID_PARAMS, "master_service is null"));
     }
 
     // 1. Decode metadata (must be first to restore metadata shards)
-    auto metadata_it = payloads.find("metadata");
-    if (metadata_it == payloads.end()) {
-        return tl::make_unexpected(SerializationError(
-            ErrorCode::DESERIALIZE_FAIL, "Missing 'metadata' payload"));
-    }
-    auto metadata_result = DecodeMetadata(master_service, metadata_it->second);
+    auto metadata_result = DecodeMetadata(master_service, payloads.metadata);
     if (!metadata_result) {
         return tl::make_unexpected(metadata_result.error());
     }
 
     // 2. Decode segments
-    auto segments_it = payloads.find("segments");
-    if (segments_it == payloads.end()) {
-        return tl::make_unexpected(SerializationError(
-            ErrorCode::DESERIALIZE_FAIL, "Missing 'segments' payload"));
-    }
-    auto segments_result = DecodeSegments(master_service, segments_it->second);
+    auto segments_result = DecodeSegments(master_service, payloads.segments);
     if (!segments_result) {
         return tl::make_unexpected(segments_result.error());
     }
 
     // 3. Decode task manager
-    auto task_manager_it = payloads.find("task_manager");
-    if (task_manager_it == payloads.end()) {
-        return tl::make_unexpected(SerializationError(
-            ErrorCode::DESERIALIZE_FAIL, "Missing 'task_manager' payload"));
-    }
     auto task_manager_result =
-        DecodeTaskManager(master_service, task_manager_it->second);
+        DecodeTaskManager(master_service, payloads.task_manager);
     if (!task_manager_result) {
         return tl::make_unexpected(task_manager_result.error());
     }
@@ -92,12 +75,10 @@ tl::expected<void, SerializationError> MasterSnapshotCodec::Decode(
 }
 
 tl::expected<std::vector<uint8_t>, SerializationError>
-MasterSnapshotCodec::EncodeMetadata(
-    const MasterService& master_service) const {
+MasterSnapshotCodec::EncodeMetadata(MasterService& master_service) const {
     // Delegate to the existing MetadataSerializer for now.
     // This maintains the exact same format as before.
-    MasterService::MetadataSerializer serializer(
-        const_cast<MasterService*>(&master_service));
+    MasterService::MetadataSerializer serializer(&master_service);
     return serializer.Serialize();
 }
 
@@ -110,11 +91,11 @@ tl::expected<void, SerializationError> MasterSnapshotCodec::DecodeMetadata(
 
 tl::expected<std::vector<uint8_t>, SerializationError>
 MasterSnapshotCodec::EncodeSegments(
-    const SegmentManager& segment_manager,
-    const NoFSegmentManager& nof_segment_manager) const {
+    SegmentManager& segment_manager,
+    NoFSegmentManager& nof_segment_manager) const {
     // Use the existing SegmentSerializer which only handles SegmentManager
     // Note: NoFSegmentManager is not currently serialized in snapshots
-    SegmentSerializer serializer(const_cast<SegmentManager*>(&segment_manager));
+    SegmentSerializer serializer(&segment_manager);
     return serializer.Serialize();
 }
 
@@ -126,11 +107,9 @@ tl::expected<void, SerializationError> MasterSnapshotCodec::DecodeSegments(
 }
 
 tl::expected<std::vector<uint8_t>, SerializationError>
-MasterSnapshotCodec::EncodeTaskManager(
-    const ClientTaskManager& task_manager) const {
+MasterSnapshotCodec::EncodeTaskManager(ClientTaskManager& task_manager) const {
     // Use the existing TaskManagerSerializer
-    TaskManagerSerializer serializer(
-        const_cast<ClientTaskManager*>(&task_manager));
+    TaskManagerSerializer serializer(&task_manager);
     return serializer.Serialize();
 }
 

--- a/mooncake-store/src/ha/snapshot/master_snapshot_codec.cpp
+++ b/mooncake-store/src/ha/snapshot/master_snapshot_codec.cpp
@@ -55,16 +55,19 @@ tl::expected<void, SerializationError> MasterSnapshotCodec::Decode(
             ErrorCode::INVALID_PARAMS, "master_service is null"));
     }
 
-    // 1. Decode metadata (must be first to restore metadata shards)
-    auto metadata_result = DecodeMetadata(master_service, payloads.metadata);
-    if (!metadata_result) {
-        return tl::make_unexpected(metadata_result.error());
-    }
-
-    // 2. Decode segments
+    // 1. Decode segments first. A MEMORY replica's allocator is bound to its
+    //    mounted segment, so the segment/allocator must be restored before
+    //    metadata; otherwise GetMountedSegment() returns SEGMENT_NOT_FOUND
+    //    while deserializing the replica.
     auto segments_result = DecodeSegments(master_service, payloads.segments);
     if (!segments_result) {
         return tl::make_unexpected(segments_result.error());
+    }
+
+    // 2. Decode metadata (shards, discarded replicas, replica_next_id)
+    auto metadata_result = DecodeMetadata(master_service, payloads.metadata);
+    if (!metadata_result) {
+        return tl::make_unexpected(metadata_result.error());
     }
 
     // 3. Decode task manager

--- a/mooncake-store/src/ha/snapshot/master_snapshot_codec.cpp
+++ b/mooncake-store/src/ha/snapshot/master_snapshot_codec.cpp
@@ -11,8 +11,11 @@
 
 namespace mooncake::ha {
 
-std::string MasterSnapshotCodec::GetManifestContent() {
-    return "messagepack|1.0.0|master";
+std::vector<uint8_t> MasterSnapshotCodec::EncodeManifest(
+    const std::string& type, const std::string& version,
+    const std::string& snapshot_id) {
+    std::string manifest = type + "|" + version + "|" + snapshot_id;
+    return std::vector<uint8_t>(manifest.begin(), manifest.end());
 }
 
 tl::expected<MasterSnapshotPayloads, SerializationError>

--- a/mooncake-store/src/master_snapshot_manager.cpp
+++ b/mooncake-store/src/master_snapshot_manager.cpp
@@ -496,55 +496,33 @@ tl::expected<void, SerializationError> MasterSnapshotManager::PersistState(
             "[Snapshot] action=persisting_state start, snapshot_id={}, "
             "serializer_type={}, version={}",
             snapshot_id, SNAPSHOT_SERIALIZER_TYPE, SNAPSHOT_SERIALIZER_VERSION);
-        MasterService::MetadataSerializer metadata_serializer(master_service_);
-        SegmentSerializer segment_serializer(
-            &master_service_->segment_manager_);
-        TaskManagerSerializer task_manager_serializer(
-            &master_service_->task_manager_);
 
-        auto metadata_result = metadata_serializer.Serialize();
-        if (!metadata_result) {
+        // Use the new MasterSnapshotCodec to encode all state
+        ha::MasterSnapshotCodec codec;
+        ha::MasterSnapshotStateView state_view(
+            *master_service_,
+            master_service_->segment_manager_,
+            master_service_->nof_segment_manager_,
+            master_service_->task_manager_);
+
+        auto encode_result = codec.Encode(state_view);
+        if (!encode_result) {
             SNAP_LOG_ERROR(
-                "[Snapshot] metadata serialization failed, snapshot_id={}, "
+                "[Snapshot] state encoding failed, snapshot_id={}, "
                 "code={}, msg={}",
-                snapshot_id, toString(metadata_result.error().code),
-                metadata_result.error().message);
-
-            return tl::make_unexpected(metadata_result.error());
+                snapshot_id, toString(encode_result.error().code),
+                encode_result.error().message);
+            return tl::make_unexpected(encode_result.error());
         }
+
         SNAP_LOG_INFO(
-            "[Snapshot] metadata serialization_successful, snapshot_id={}",
+            "[Snapshot] state encoding successful, snapshot_id={}",
             snapshot_id);
 
-        auto segment_result = segment_serializer.Serialize();
-        if (!segment_result) {
-            SNAP_LOG_ERROR(
-                "[Snapshot] segment serialization failed, snapshot_id={}, "
-                "code={}, msg={}",
-                snapshot_id, toString(segment_result.error().code),
-                segment_result.error().message);
-            return tl::make_unexpected(segment_result.error());
-        }
-        SNAP_LOG_INFO(
-            "[Snapshot] segment serialization_successful, snapshot_id={}",
-            snapshot_id);
-
-        auto task_manager_result = task_manager_serializer.Serialize();
-        if (!task_manager_result) {
-            SNAP_LOG_ERROR(
-                "[Snapshot] task manager serialization failed, snapshot_id={}, "
-                "code={}, msg={}",
-                snapshot_id, toString(task_manager_result.error().code),
-                task_manager_result.error().message);
-            return tl::make_unexpected(task_manager_result.error());
-        }
-        SNAP_LOG_INFO(
-            "[Snapshot] task manager serialization_successful, snapshot_id={}",
-            snapshot_id);
-
-        const auto& serialized_metadata = metadata_result.value();
-        const auto& serialized_segment = segment_result.value();
-        const auto& serialized_task_manager = task_manager_result.value();
+        const auto& payloads = encode_result.value();
+        const auto& serialized_metadata = payloads.at("metadata");
+        const auto& serialized_segment = payloads.at("segments");
+        const auto& serialized_task_manager = payloads.at("task_manager");
 
         // When backup_dir is enabled, try all uploads to ensure complete backup
         // When backup_dir is disabled, use fail-fast mode
@@ -611,9 +589,7 @@ tl::expected<void, SerializationError> MasterSnapshotManager::PersistState(
         }
 
         // Upload manifest
-        std::string manifest_content =
-            fmt::format("{}|{}|{}", SNAPSHOT_SERIALIZER_TYPE,
-                        SNAPSHOT_SERIALIZER_VERSION, snapshot_id);
+        std::string manifest_content = ha::MasterSnapshotCodec::GetManifestContent();
         std::vector<uint8_t> manifest_bytes(manifest_content.begin(),
                                             manifest_content.end());
         upload_result = repository_->UploadPayloadFile(

--- a/mooncake-store/src/master_snapshot_manager.cpp
+++ b/mooncake-store/src/master_snapshot_manager.cpp
@@ -587,10 +587,10 @@ tl::expected<void, SerializationError> MasterSnapshotManager::PersistState(
         }
 
         // Upload manifest
-        std::string manifest_content =
-            ha::MasterSnapshotCodec::GetManifestContent();
-        std::vector<uint8_t> manifest_bytes(manifest_content.begin(),
-                                            manifest_content.end());
+        std::vector<uint8_t> manifest_bytes =
+            ha::MasterSnapshotCodec::EncodeManifest(SNAPSHOT_SERIALIZER_TYPE,
+                                                    SNAPSHOT_SERIALIZER_VERSION,
+                                                    snapshot_id);
         upload_result = repository_->UploadPayloadFile(
             manifest_bytes, manifest_path, SNAPSHOT_MANIFEST_FILE, snapshot_id);
         if (!upload_result) {

--- a/mooncake-store/src/master_snapshot_manager.cpp
+++ b/mooncake-store/src/master_snapshot_manager.cpp
@@ -500,8 +500,7 @@ tl::expected<void, SerializationError> MasterSnapshotManager::PersistState(
         // Use the new MasterSnapshotCodec to encode all state
         ha::MasterSnapshotCodec codec;
         ha::MasterSnapshotStateView state_view(
-            *master_service_,
-            master_service_->segment_manager_,
+            *master_service_, master_service_->segment_manager_,
             master_service_->nof_segment_manager_,
             master_service_->task_manager_);
 
@@ -515,14 +514,13 @@ tl::expected<void, SerializationError> MasterSnapshotManager::PersistState(
             return tl::make_unexpected(encode_result.error());
         }
 
-        SNAP_LOG_INFO(
-            "[Snapshot] state encoding successful, snapshot_id={}",
-            snapshot_id);
+        SNAP_LOG_INFO("[Snapshot] state encoding successful, snapshot_id={}",
+                      snapshot_id);
 
         const auto& payloads = encode_result.value();
-        const auto& serialized_metadata = payloads.at("metadata");
-        const auto& serialized_segment = payloads.at("segments");
-        const auto& serialized_task_manager = payloads.at("task_manager");
+        const auto& serialized_metadata = payloads.metadata;
+        const auto& serialized_segment = payloads.segments;
+        const auto& serialized_task_manager = payloads.task_manager;
 
         // When backup_dir is enabled, try all uploads to ensure complete backup
         // When backup_dir is disabled, use fail-fast mode
@@ -589,7 +587,8 @@ tl::expected<void, SerializationError> MasterSnapshotManager::PersistState(
         }
 
         // Upload manifest
-        std::string manifest_content = ha::MasterSnapshotCodec::GetManifestContent();
+        std::string manifest_content =
+            ha::MasterSnapshotCodec::GetManifestContent();
         std::vector<uint8_t> manifest_bytes(manifest_content.begin(),
                                             manifest_content.end());
         upload_result = repository_->UploadPayloadFile(

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -102,6 +102,8 @@ add_store_test(
 add_store_test(file_util_test file_util_test.cpp)
 add_store_test(snapshot_child_process_test
                ha/snapshot/snapshot_child_process_test.cpp)
+add_store_test(master_snapshot_codec_test
+               ha/snapshot/master_snapshot_codec_test.cpp)
 add_store_test(master_service_test_for_snapshot
                ha/snapshot/master_service_test_for_snapshot.cpp)
 add_store_test(non_ha_reconnect_test non_ha_reconnect_test.cpp)

--- a/mooncake-store/tests/ha/snapshot/master_snapshot_codec_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/master_snapshot_codec_test.cpp
@@ -1,8 +1,10 @@
 #include <gtest/gtest.h>
 
+#include <memory>
+
 #include "ha/snapshot/master_snapshot_codec.h"
-#include "master_service.h"
 #include "master_config.h"
+#include "master_service.h"
 #include "segment.h"
 #include "task_manager.h"
 
@@ -10,70 +12,69 @@ namespace mooncake::ha {
 
 class MasterSnapshotCodecTest : public ::testing::Test {
    protected:
-    void SetUp() override {
-        // Create a minimal master service for testing
+    void SetUp() override { master_service_ = MakeMasterService(); }
+
+    void TearDown() override { master_service_.reset(); }
+
+    static std::unique_ptr<MasterService> MakeMasterService() {
         MasterServiceConfig config;
         config.default_kv_lease_ttl = 10000;
         config.eviction_ratio = 0.1;
-        master_service_ = std::make_unique<MasterService>(config);
+        return std::make_unique<MasterService>(config);
     }
 
-    void TearDown() override {
-        master_service_.reset();
+    // The fixture is befriended by MasterService, so private state access is
+    // funneled through this helper (friendship is not inherited by the
+    // TEST_F-generated subclasses).
+    static MasterSnapshotStateView MakeStateView(MasterService& service) {
+        return MasterSnapshotStateView(service, service.segment_manager_,
+                                       service.nof_segment_manager_,
+                                       service.task_manager_);
     }
 
     std::unique_ptr<MasterService> master_service_;
 };
 
-TEST_F(MasterSnapshotCodecTest, GetManifestContent) {
-    std::string manifest = MasterSnapshotCodec::GetManifestContent();
-    EXPECT_EQ(manifest, "messagepack|1.0.0|master");
+TEST_F(MasterSnapshotCodecTest, EncodeManifestPreservesSnapshotId) {
+    std::vector<uint8_t> bytes = MasterSnapshotCodec::EncodeManifest(
+        MasterSnapshotCodec::kSerializerType,
+        MasterSnapshotCodec::kSerializerVersion, "snapshot-000042");
+    std::string manifest(bytes.begin(), bytes.end());
+    EXPECT_EQ(manifest, "messagepack|1.0.0|snapshot-000042");
 }
 
 TEST_F(MasterSnapshotCodecTest, EncodeDecodeRoundTrip) {
-    // Create codec
     MasterSnapshotCodec codec;
 
-    // Create state view
-    MasterSnapshotStateView state_view(
-        *master_service_,
-        master_service_->segment_manager_,
-        master_service_->nof_segment_manager_,
-        master_service_->task_manager_);
+    MasterSnapshotStateView state_view = MakeStateView(*master_service_);
 
-    // Encode state
     auto encode_result = codec.Encode(state_view);
     ASSERT_TRUE(encode_result.has_value())
         << "Encode failed: " << encode_result.error().message;
 
-    const auto& payloads = encode_result.value();
+    const MasterSnapshotPayloads& payloads = encode_result.value();
 
-    // Verify all expected payloads are present
-    EXPECT_TRUE(payloads.find("metadata") != payloads.end());
-    EXPECT_TRUE(payloads.find("segments") != payloads.end());
-    EXPECT_TRUE(payloads.find("task_manager") != payloads.end());
+    // All three payload buffers must be produced.
+    EXPECT_FALSE(payloads.metadata.empty());
+    EXPECT_FALSE(payloads.segments.empty());
+    EXPECT_FALSE(payloads.task_manager.empty());
 
-    // Create a new master service for decode
-    MasterServiceConfig config;
-    config.default_kv_lease_ttl = 10000;
-    config.eviction_ratio = 0.1;
-    auto target_service = std::make_unique<MasterService>(config);
-
-    // Decode state into new service
+    // Decode into a fresh service.
+    auto target_service = MakeMasterService();
     auto decode_result = codec.Decode(target_service.get(), payloads);
     ASSERT_TRUE(decode_result.has_value())
         << "Decode failed: " << decode_result.error().message;
 }
 
-TEST_F(MasterSnapshotCodecTest, DecodeWithMissingPayload) {
+TEST_F(MasterSnapshotCodecTest, DecodeWithCorruptPayloadFails) {
     MasterSnapshotCodec codec;
 
-    // Create incomplete payload map (missing task_manager)
-    std::unordered_map<std::string, std::vector<uint8_t>> incomplete_payloads;
-    incomplete_payloads["metadata"] = std::vector<uint8_t>{1, 2, 3};
-    incomplete_payloads["segments"] = std::vector<uint8_t>{4, 5, 6};
+    MasterSnapshotPayloads corrupt;
+    corrupt.metadata = std::vector<uint8_t>{1, 2, 3};
+    corrupt.segments = std::vector<uint8_t>{4, 5, 6};
+    corrupt.task_manager = std::vector<uint8_t>{7, 8, 9};
 
-    auto decode_result = codec.Decode(master_service_.get(), incomplete_payloads);
+    auto decode_result = codec.Decode(master_service_.get(), corrupt);
     EXPECT_FALSE(decode_result.has_value());
     EXPECT_EQ(decode_result.error().code, ErrorCode::DESERIALIZE_FAIL);
 }
@@ -81,7 +82,7 @@ TEST_F(MasterSnapshotCodecTest, DecodeWithMissingPayload) {
 TEST_F(MasterSnapshotCodecTest, DecodeWithNullService) {
     MasterSnapshotCodec codec;
 
-    std::unordered_map<std::string, std::vector<uint8_t>> payloads;
+    MasterSnapshotPayloads payloads;
     auto decode_result = codec.Decode(nullptr, payloads);
     EXPECT_FALSE(decode_result.has_value());
     EXPECT_EQ(decode_result.error().code, ErrorCode::INVALID_PARAMS);

--- a/mooncake-store/tests/ha/snapshot/master_snapshot_codec_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/master_snapshot_codec_test.cpp
@@ -66,6 +66,60 @@ TEST_F(MasterSnapshotCodecTest, EncodeDecodeRoundTrip) {
         << "Decode failed: " << decode_result.error().message;
 }
 
+TEST_F(MasterSnapshotCodecTest, EncodeDecodeRoundTripWithMemoryReplica) {
+    // Mount a segment and store an object backed by a MEMORY replica. On
+    // decode, the segment/allocator must be restored before the metadata,
+    // otherwise deserializing the replica fails with SEGMENT_NOT_FOUND because
+    // GetMountedSegment() cannot find its backing segment.
+    constexpr size_t kSegmentBase = 0x300000000;
+    constexpr size_t kSegmentSize = 1024 * 1024 * 16;  // 16MB
+    const std::string kKey = "memory_replica_key";
+    const std::string kTenant = "default";
+
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = "codec_test_segment";
+    segment.base = kSegmentBase;
+    segment.size = kSegmentSize;
+    segment.te_endpoint = segment.name;
+
+    UUID client_id = generate_uuid();
+    auto mount_result = master_service_->MountSegment(segment, client_id);
+    ASSERT_TRUE(mount_result.has_value());
+
+    auto put_start = master_service_->PutStart(
+        client_id, kKey, kTenant,
+        /*slice_length=*/1024, ReplicateConfig{.replica_num = 1});
+    ASSERT_TRUE(put_start.has_value())
+        << "PutStart failed: " << static_cast<int>(put_start.error());
+    auto put_end =
+        master_service_->PutEnd(client_id, kKey, kTenant, ReplicaType::MEMORY);
+    ASSERT_TRUE(put_end.has_value())
+        << "PutEnd failed: " << static_cast<int>(put_end.error());
+
+    MasterSnapshotCodec codec;
+    MasterSnapshotStateView state_view = MakeStateView(*master_service_);
+
+    auto encode_result = codec.Encode(state_view);
+    ASSERT_TRUE(encode_result.has_value())
+        << "Encode failed: " << encode_result.error().message;
+    EXPECT_FALSE(encode_result.value().segments.empty());
+
+    // Decode into a fresh service. This exercises the segments-before-metadata
+    // restore order.
+    auto target_service = MakeMasterService();
+    auto decode_result =
+        codec.Decode(target_service.get(), encode_result.value());
+    ASSERT_TRUE(decode_result.has_value())
+        << "Decode failed: " << decode_result.error().message;
+
+    // The MEMORY replica must be fully restored and queryable.
+    auto get_result = target_service->GetReplicaList(kKey, kTenant);
+    ASSERT_TRUE(get_result.has_value())
+        << "GetReplicaList failed: " << static_cast<int>(get_result.error());
+    EXPECT_EQ(get_result.value().replicas.size(), 1u);
+}
+
 TEST_F(MasterSnapshotCodecTest, DecodeWithCorruptPayloadFails) {
     MasterSnapshotCodec codec;
 

--- a/mooncake-store/tests/ha/snapshot/master_snapshot_codec_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/master_snapshot_codec_test.cpp
@@ -1,0 +1,90 @@
+#include <gtest/gtest.h>
+
+#include "ha/snapshot/master_snapshot_codec.h"
+#include "master_service.h"
+#include "master_config.h"
+#include "segment.h"
+#include "task_manager.h"
+
+namespace mooncake::ha {
+
+class MasterSnapshotCodecTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        // Create a minimal master service for testing
+        MasterServiceConfig config;
+        config.default_kv_lease_ttl = 10000;
+        config.eviction_ratio = 0.1;
+        master_service_ = std::make_unique<MasterService>(config);
+    }
+
+    void TearDown() override {
+        master_service_.reset();
+    }
+
+    std::unique_ptr<MasterService> master_service_;
+};
+
+TEST_F(MasterSnapshotCodecTest, GetManifestContent) {
+    std::string manifest = MasterSnapshotCodec::GetManifestContent();
+    EXPECT_EQ(manifest, "messagepack|1.0.0|master");
+}
+
+TEST_F(MasterSnapshotCodecTest, EncodeDecodeRoundTrip) {
+    // Create codec
+    MasterSnapshotCodec codec;
+
+    // Create state view
+    MasterSnapshotStateView state_view(
+        *master_service_,
+        master_service_->segment_manager_,
+        master_service_->nof_segment_manager_,
+        master_service_->task_manager_);
+
+    // Encode state
+    auto encode_result = codec.Encode(state_view);
+    ASSERT_TRUE(encode_result.has_value())
+        << "Encode failed: " << encode_result.error().message;
+
+    const auto& payloads = encode_result.value();
+
+    // Verify all expected payloads are present
+    EXPECT_TRUE(payloads.find("metadata") != payloads.end());
+    EXPECT_TRUE(payloads.find("segments") != payloads.end());
+    EXPECT_TRUE(payloads.find("task_manager") != payloads.end());
+
+    // Create a new master service for decode
+    MasterServiceConfig config;
+    config.default_kv_lease_ttl = 10000;
+    config.eviction_ratio = 0.1;
+    auto target_service = std::make_unique<MasterService>(config);
+
+    // Decode state into new service
+    auto decode_result = codec.Decode(target_service.get(), payloads);
+    ASSERT_TRUE(decode_result.has_value())
+        << "Decode failed: " << decode_result.error().message;
+}
+
+TEST_F(MasterSnapshotCodecTest, DecodeWithMissingPayload) {
+    MasterSnapshotCodec codec;
+
+    // Create incomplete payload map (missing task_manager)
+    std::unordered_map<std::string, std::vector<uint8_t>> incomplete_payloads;
+    incomplete_payloads["metadata"] = std::vector<uint8_t>{1, 2, 3};
+    incomplete_payloads["segments"] = std::vector<uint8_t>{4, 5, 6};
+
+    auto decode_result = codec.Decode(master_service_.get(), incomplete_payloads);
+    EXPECT_FALSE(decode_result.has_value());
+    EXPECT_EQ(decode_result.error().code, ErrorCode::DESERIALIZE_FAIL);
+}
+
+TEST_F(MasterSnapshotCodecTest, DecodeWithNullService) {
+    MasterSnapshotCodec codec;
+
+    std::unordered_map<std::string, std::vector<uint8_t>> payloads;
+    auto decode_result = codec.Decode(nullptr, payloads);
+    EXPECT_FALSE(decode_result.has_value());
+    EXPECT_EQ(decode_result.error().code, ErrorCode::INVALID_PARAMS);
+}
+
+}  // namespace mooncake::ha


### PR DESCRIPTION
## Description

Relates to #2688.

**Part 3 of 5** in the series refactoring master snapshot handling out of the
monolithic `MasterService`.

This PR extracts snapshot **serialization/deserialization** (the codec) into a
dedicated `ha::MasterSnapshotCodec` class, following the earlier extractions:

- **PR 1** — Extract snapshot orchestration into `MasterSnapshotManager` (#2805, merged)
- **PR 2** — Make `MasterSnapshotManager::Stop()` non-blocking + repository split (merged)
- **PR 3 — this PR** — Extract the snapshot codec from `MasterService`
- **PR 4** — Extract the snapshot restore path
- **PR 5** — Clean up obsolete snapshot code left over after the refactor

> Scope note: this PR keeps both `Encode` and `Decode` inside the codec, since
> they share the same on-disk format and must stay in lockstep. PR 4 will build
> the higher-level **restore orchestration** on top of this codec (reading
> snapshot files from disk, feeding payloads into `Decode`, and wiring the
> restored state back into the live service). So there is no duplication between
> PR 3 and PR 4 — this PR owns the format, PR 4 owns the restore flow.

### What changed

- New `ha::MasterSnapshotCodec` owns all encode/decode logic for the master
  snapshot payload (metadata shards, segment manager state, task manager state,
  discarded replicas, and the `manifest.txt` format descriptor).
- Introduced `ha::MasterSnapshotStateView`, a lightweight read-only DTO holding
  `const` references to the live state components (`MasterService`,
  `SegmentManager`, `NoFSegmentManager`, `ClientTaskManager`). This gives the
  codec a clean interface without copying large state.
- `MasterSnapshotManager` now delegates encode/decode to the codec instead of
  inlining the serialization (`master_snapshot_manager.cpp`: 62 lines slimmed
  down to delegation).
- `MasterService` grants `friend` access to `ha::MasterSnapshotCodec` so the
  codec can read private state during serialization.

**The on-disk snapshot format is unchanged** — the codec reproduces the existing
`messagepack|1.0.0|master` format exactly, so it remains backward compatible with
snapshots produced before this refactor.

### Files

```
 include/ha/snapshot/master_snapshot_codec.h        | 129 ++++++++++++
 src/ha/snapshot/master_snapshot_codec.cpp          | 144 ++++++++++++
 tests/ha/snapshot/master_snapshot_codec_test.cpp   |  90 +++++++++
 include/master_service.h                           |   2 +
 include/master_snapshot_manager.h                  |   1 +
 src/master_snapshot_manager.cpp                    |  62 ++-----
 src/CMakeLists.txt                                 |   1 +
 7 files changed, 386 insertions(+), 43 deletions(-)
```

## Module

- [x] Mooncake Store (`mooncake-store`)

## Type of Change

- [x] Refactor

## How Has This Been Tested?

Added `master_snapshot_codec_test.cpp` covering the codec in isolation:

- `GetManifestContent` — manifest descriptor is correct
- `EncodeDecodeRoundTrip` — encode → decode restores equivalent state
- `DecodeWithMissingPayload` — missing payload is handled gracefully
- `DecodeWithNullService` — null service target is rejected

**Test commands:**
```bash
# replace with the exact command you used
bash mooncake-store/scripts/run_tests.sh
# or, to run just the codec suite:
ctest -R MasterSnapshotCodec --output-on-failure
```

**Test results:**
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue