### PR TITLE
[Store][POC] Add TTL-bounded group retention leases

### DIFF
--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -2289,6 +2289,22 @@ PYBIND11_MODULE(store, m) {
             py::arg("keys"),
             "Check if multiple objects exist. Returns list of results: 1 if "
             "exists, 0 if not exists, -1 if error")
+        .def(
+            "retain_groups",
+            [](MooncakeStorePyWrapper &self,
+               const std::vector<std::string> &group_ids, uint64_t ttl_ms) {
+                if (!self.real_client_) {
+                    return std::vector<int>(
+                        group_ids.size(),
+                        static_cast<int>(ErrorCode::INVALID_PARAMS));
+                }
+                py::gil_scoped_release release;
+                return self.real_client_->retainGroups(group_ids, ttl_ms);
+            },
+            py::arg("group_ids"), py::arg("ttl_ms"),
+            "Retain all complete objects in each group for the requested TTL. "
+            "Returns 1 if retained, 0 if absent or incomplete, and a negative "
+            "error code on failure.")
         .def("close",
              [](MooncakeStorePyWrapper &self) {
                  if (!self.store_) return 0;

--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -2303,7 +2303,8 @@ PYBIND11_MODULE(store, m) {
             },
             py::arg("group_ids"), py::arg("ttl_ms"),
             "Retain current and future objects in each group for the requested "
-            "TTL. Returns 1 if accepted and a negative error code on failure.")
+            "TTL. Returns 1 if accepted, 0 if admission is full, and a "
+            "negative error code on failure.")
         .def("close",
              [](MooncakeStorePyWrapper &self) {
                  if (!self.store_) return 0;

--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -2302,9 +2302,8 @@ PYBIND11_MODULE(store, m) {
                 return self.real_client_->retainGroups(group_ids, ttl_ms);
             },
             py::arg("group_ids"), py::arg("ttl_ms"),
-            "Retain all complete objects in each group for the requested TTL. "
-            "Returns 1 if retained, 0 if absent or incomplete, and a negative "
-            "error code on failure.")
+            "Retain current and future objects in each group for the requested "
+            "TTL. Returns 1 if accepted and a negative error code on failure.")
         .def("close",
              [](MooncakeStorePyWrapper &self) {
                  if (!self.store_) return 0;

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -363,6 +363,9 @@ class Client {
     std::vector<tl::expected<bool, ErrorCode>> BatchIsExist(
         const std::vector<std::string>& keys);
 
+    std::vector<tl::expected<bool, ErrorCode>> RetainGroups(
+        const std::vector<std::string>& group_ids, uint64_t ttl_ms);
+
     /**
      * @brief Create a copy task to copy an object's replicas to target segments
      * @param key Object key

--- a/mooncake-store/include/master_client.h
+++ b/mooncake-store/include/master_client.h
@@ -120,6 +120,9 @@ class MasterClient {
     [[nodiscard]] std::vector<tl::expected<bool, ErrorCode>> BatchExistKey(
         const std::vector<std::string>& object_keys);
 
+    [[nodiscard]] std::vector<tl::expected<bool, ErrorCode>> RetainGroups(
+        const std::vector<std::string>& group_ids, uint64_t ttl_ms);
+
     /**
      * @brief Calculate Store-observed cache reuse metrics
      * @param object_keys None

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -694,6 +694,8 @@ class MasterServiceConfigBuilder {
    private:
     uint64_t default_kv_lease_ttl_ = DEFAULT_DEFAULT_KV_LEASE_TTL;
     uint64_t default_kv_soft_pin_ttl_ = DEFAULT_KV_SOFT_PIN_TTL_MS;
+    size_t max_retained_groups_ = DEFAULT_MAX_RETAINED_GROUPS;
+    uint64_t max_group_retention_ttl_ms_ = DEFAULT_MAX_GROUP_RETENTION_TTL_MS;
     bool allow_evict_soft_pinned_objects_ =
         DEFAULT_ALLOW_EVICT_SOFT_PINNED_OBJECTS;
     double eviction_ratio_ = DEFAULT_EVICTION_RATIO;
@@ -757,6 +759,16 @@ class MasterServiceConfigBuilder {
 
     MasterServiceConfigBuilder& set_default_kv_soft_pin_ttl(uint64_t ttl) {
         default_kv_soft_pin_ttl_ = ttl;
+        return *this;
+    }
+
+    MasterServiceConfigBuilder& set_max_retained_groups(size_t max_groups) {
+        max_retained_groups_ = max_groups;
+        return *this;
+    }
+
+    MasterServiceConfigBuilder& set_max_group_retention_ttl_ms(uint64_t ttl) {
+        max_group_retention_ttl_ms_ = ttl;
         return *this;
     }
 
@@ -1032,6 +1044,8 @@ class MasterServiceConfig {
    public:
     uint64_t default_kv_lease_ttl = DEFAULT_DEFAULT_KV_LEASE_TTL;
     uint64_t default_kv_soft_pin_ttl = DEFAULT_KV_SOFT_PIN_TTL_MS;
+    size_t max_retained_groups = DEFAULT_MAX_RETAINED_GROUPS;
+    uint64_t max_group_retention_ttl_ms = DEFAULT_MAX_GROUP_RETENTION_TTL_MS;
     bool allow_evict_soft_pinned_objects =
         DEFAULT_ALLOW_EVICT_SOFT_PINNED_OBJECTS;
     double eviction_ratio = DEFAULT_EVICTION_RATIO;
@@ -1202,6 +1216,8 @@ inline MasterServiceConfig MasterServiceConfigBuilder::build() const {
     MasterServiceConfig config;
     config.default_kv_lease_ttl = default_kv_lease_ttl_;
     config.default_kv_soft_pin_ttl = default_kv_soft_pin_ttl_;
+    config.max_retained_groups = max_retained_groups_;
+    config.max_group_retention_ttl_ms = max_group_retention_ttl_ms_;
     config.allow_evict_soft_pinned_objects = allow_evict_soft_pinned_objects_;
     config.eviction_ratio = eviction_ratio_;
     config.eviction_high_watermark_ratio = eviction_high_watermark_ratio_;

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1547,6 +1547,9 @@ class MasterService {
     // Lease related members
     const uint64_t default_kv_lease_ttl_;     // in milliseconds
     const uint64_t default_kv_soft_pin_ttl_;  // in milliseconds
+    const size_t max_retained_groups_;
+    const uint64_t max_group_retention_ttl_ms_;
+    std::atomic<size_t> retained_group_count_{0};
     const bool allow_evict_soft_pinned_objects_;
 
     // Eviction related members

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -205,6 +205,10 @@ class MasterService {
     std::vector<tl::expected<bool, ErrorCode>> BatchExistKey(
         const std::vector<std::string>& keys, const std::string& tenant_id);
 
+    std::vector<tl::expected<bool, ErrorCode>> RetainGroups(
+        const std::vector<std::string>& group_ids, uint64_t ttl_ms,
+        const std::string& tenant_id);
+
     /**
      * @brief Fetch all keys for a single tenant.
      * @return ErrorCode::OK if exists

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1222,11 +1222,15 @@ class MasterService {
 
         std::unordered_map<std::string, std::unordered_set<std::string>>
             group_members;  // group_id → set of keys
+        std::unordered_map<std::string,
+                           std::chrono::system_clock::time_point>
+            group_retention_deadlines;
 
         bool Empty() const {
             return metadata.empty() && processing_keys.empty() &&
                    replication_tasks.empty() && offloading_tasks.empty() &&
-                   promotion_tasks.empty() && group_members.empty();
+                   promotion_tasks.empty() && group_members.empty() &&
+                   group_retention_deadlines.empty();
         }
     };
 
@@ -1401,6 +1405,7 @@ class MasterService {
                                const std::string& tenant_id,
                                const std::string& key,
                                const std::string& group_id);
+    void PruneExpiredGroupRetentions();
     std::unordered_map<std::string, ObjectMetadata>::iterator EraseMetadata(
         TenantState& tenant_state,
         std::unordered_map<std::string, ObjectMetadata>::iterator it,

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1222,8 +1222,7 @@ class MasterService {
 
         std::unordered_map<std::string, std::unordered_set<std::string>>
             group_members;  // group_id → set of keys
-        std::unordered_map<std::string,
-                           std::chrono::system_clock::time_point>
+        std::unordered_map<std::string, std::chrono::system_clock::time_point>
             group_retention_deadlines;
 
         bool Empty() const {

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -314,6 +314,9 @@ class RealClient : public PyClient {
      */
     std::vector<int> batchIsExist(const std::vector<std::string> &keys);
 
+    std::vector<int> retainGroups(const std::vector<std::string> &group_ids,
+                                  uint64_t ttl_ms);
+
     /**
      * @brief Get the size of an object
      * @param key Key of the object
@@ -654,6 +657,9 @@ class RealClient : public PyClient {
 
     std::vector<tl::expected<bool, ErrorCode>> batchIsExist_internal(
         const std::vector<std::string> &keys);
+
+    std::vector<tl::expected<bool, ErrorCode>> retainGroups_internal(
+        const std::vector<std::string> &group_ids, uint64_t ttl_ms);
 
     tl::expected<int64_t, ErrorCode> getSize_internal(const std::string &key);
 

--- a/mooncake-store/include/rpc_service.h
+++ b/mooncake-store/include/rpc_service.h
@@ -44,6 +44,10 @@ class WrappedMasterService {
         const std::vector<std::string>& keys,
         const std::string& tenant_id = "default");
 
+    std::vector<tl::expected<bool, ErrorCode>> RetainGroups(
+        const std::vector<std::string>& group_ids, uint64_t ttl_ms,
+        const std::string& tenant_id = "default");
+
     tl::expected<
         std::unordered_map<UUID, std::vector<std::string>, boost::hash<UUID>>,
         ErrorCode>

--- a/mooncake-store/include/types.h
+++ b/mooncake-store/include/types.h
@@ -86,6 +86,9 @@ static constexpr uint64_t DEFAULT_DEFAULT_KV_LEASE_TTL =
     5000;  // in milliseconds
 static constexpr uint64_t DEFAULT_KV_SOFT_PIN_TTL_MS =
     30 * 60 * 1000;  // 30 minutes
+static constexpr size_t DEFAULT_MAX_RETAINED_GROUPS = 65536;
+static constexpr uint64_t DEFAULT_MAX_GROUP_RETENTION_TTL_MS =
+    24 * 60 * 60 * 1000;  // 24 hours
 static constexpr bool DEFAULT_ALLOW_EVICT_SOFT_PINNED_OBJECTS = true;
 static constexpr double DEFAULT_EVICTION_RATIO = 0.05;
 static constexpr double DEFAULT_EVICTION_HIGH_WATERMARK_RATIO = 0.95;

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -3013,6 +3013,16 @@ std::vector<tl::expected<bool, ErrorCode>> Client::BatchIsExist(
     return response;
 }
 
+std::vector<tl::expected<bool, ErrorCode>> Client::RetainGroups(
+    const std::vector<std::string>& group_ids, uint64_t ttl_ms) {
+    auto response = master_client_.RetainGroups(group_ids, ttl_ms);
+    if (response.size() != group_ids.size()) {
+        return std::vector<tl::expected<bool, ErrorCode>>(
+            group_ids.size(), tl::unexpected(ErrorCode::RPC_FAIL));
+    }
+    return response;
+}
+
 void* Client::GetBaseAddr() { return transfer_engine_->getBaseAddr(); }
 
 tl::expected<void, ErrorCode> Client::MountLocalDiskSegment(

--- a/mooncake-store/src/master_client.cpp
+++ b/mooncake-store/src/master_client.cpp
@@ -33,6 +33,11 @@ struct RpcNameTraits<&WrappedMasterService::BatchExistKey> {
 };
 
 template <>
+struct RpcNameTraits<&WrappedMasterService::RetainGroups> {
+    static constexpr const char* value = "RetainGroups";
+};
+
+template <>
 struct RpcNameTraits<&WrappedMasterService::GetReplicaList> {
     static constexpr const char* value = "GetReplicaList";
 };
@@ -467,6 +472,12 @@ std::vector<tl::expected<bool, ErrorCode>> MasterClient::BatchExistKey(
         object_keys.size(), object_keys, tenant_id_);
     timer.LogResponse("result=", result.size(), " keys");
     return result;
+}
+
+std::vector<tl::expected<bool, ErrorCode>> MasterClient::RetainGroups(
+    const std::vector<std::string>& group_ids, uint64_t ttl_ms) {
+    return invoke_batch_rpc<&WrappedMasterService::RetainGroups, bool>(
+        group_ids.size(), group_ids, ttl_ms, tenant_id_);
 }
 
 tl::expected<MasterMetricManager::CacheHitStatDict, ErrorCode>

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -1606,11 +1606,32 @@ void MasterService::RegisterGroupMember(TenantState& tenant_state,
         return;
     }
     const auto& normalized_tenant = NormalizeTenantIdRef(tenant_id);
-    std::unique_lock<std::shared_mutex> lock(group_routing_mutex_);
-    object_group_ids_[MakeTenantScopedKey(normalized_tenant, key)] = group_id;
-    groups_needing_lease_refresh_.insert(
-        MakeTenantScopedKey(normalized_tenant, group_id));
+    {
+        std::unique_lock<std::shared_mutex> lock(group_routing_mutex_);
+        object_group_ids_[MakeTenantScopedKey(normalized_tenant, key)] =
+            group_id;
+        groups_needing_lease_refresh_.insert(
+            MakeTenantScopedKey(normalized_tenant, group_id));
+    }
     tenant_state.group_members[group_id].insert(key);
+
+    auto retention_it = tenant_state.group_retention_deadlines.find(group_id);
+    if (retention_it == tenant_state.group_retention_deadlines.end()) {
+        return;
+    }
+    const auto now = std::chrono::system_clock::now();
+    if (retention_it->second <= now) {
+        tenant_state.group_retention_deadlines.erase(retention_it);
+        return;
+    }
+    auto metadata_it = tenant_state.metadata.find(key);
+    if (metadata_it != tenant_state.metadata.end()) {
+        const auto remaining_ms =
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+                retention_it->second - now)
+                .count();
+        metadata_it->second.GrantLease(static_cast<uint64_t>(remaining_ms), 0);
+    }
 }
 
 void MasterService::UnregisterGroupMember(TenantState& tenant_state,
@@ -1951,9 +1972,12 @@ void MasterService::TaskCleanupThreadFunc() {
         }
 
         std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-        auto write_access = task_manager_.get_write_access();
-        write_access.prune_expired_tasks();
-        write_access.prune_finished_tasks();
+        {
+            auto write_access = task_manager_.get_write_access();
+            write_access.prune_expired_tasks();
+            write_access.prune_finished_tasks();
+        }
+        PruneExpiredGroupRetentions();
     }
     LOG(INFO) << "Task cleanup thread stopped";
 }
@@ -2205,46 +2229,67 @@ std::vector<tl::expected<bool, ErrorCode>> MasterService::RetainGroups(
         }
 
         std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
-        MetadataShardAccessorRO shard(this, shard_idx);
-        auto tenant_it = shard->tenants.find(normalized_tenant);
-        if (tenant_it == shard->tenants.end()) {
-            for (const size_t i : group_indices) {
-                results[i] = false;
+        MetadataShardAccessorRW shard(this, shard_idx);
+        auto& tenant_state = shard->tenants[normalized_tenant];
+        const auto now = std::chrono::system_clock::now();
+        for (auto it = tenant_state.group_retention_deadlines.begin();
+             it != tenant_state.group_retention_deadlines.end();) {
+            if (it->second <= now) {
+                it = tenant_state.group_retention_deadlines.erase(it);
+            } else {
+                ++it;
             }
-            continue;
         }
-
-        const auto& tenant_state = tenant_it->second;
         for (const size_t i : group_indices) {
+            if (group_ids[i].empty()) {
+                results[i] = tl::unexpected(ErrorCode::INVALID_PARAMS);
+                continue;
+            }
+            const auto deadline = now + std::chrono::milliseconds(ttl_ms);
+            auto& retained_until =
+                tenant_state.group_retention_deadlines[group_ids[i]];
+            retained_until = std::max(retained_until, deadline);
+
             auto group_it = tenant_state.group_members.find(group_ids[i]);
             if (group_it == tenant_state.group_members.end() ||
                 group_it->second.empty()) {
-                results[i] = false;
+                results[i] = true;
                 continue;
             }
-
-            bool complete = true;
             for (const auto& member_key : group_it->second) {
                 auto member_it = tenant_state.metadata.find(member_key);
-                if (member_it == tenant_state.metadata.end() ||
-                    !member_it->second.IsValid() ||
-                    !member_it->second.HasReplica(&Replica::fn_is_completed)) {
-                    complete = false;
-                    break;
+                if (member_it != tenant_state.metadata.end()) {
+                    member_it->second.GrantLease(ttl_ms, 0);
                 }
-            }
-            if (!complete) {
-                results[i] = false;
-                continue;
-            }
-
-            for (const auto& member_key : group_it->second) {
-                tenant_state.metadata.at(member_key).GrantLease(ttl_ms, 0);
             }
             results[i] = true;
         }
     }
     return results;
+}
+
+void MasterService::PruneExpiredGroupRetentions() {
+    const auto now = std::chrono::system_clock::now();
+    for (size_t shard_idx = 0; shard_idx < kNumShards; ++shard_idx) {
+        MetadataShardAccessorRW shard(this, shard_idx);
+        for (auto tenant_it = shard->tenants.begin();
+             tenant_it != shard->tenants.end();) {
+            auto& tenant_state = tenant_it->second;
+            for (auto it = tenant_state.group_retention_deadlines.begin();
+                 it != tenant_state.group_retention_deadlines.end();) {
+                if (it->second <= now) {
+                    it = tenant_state.group_retention_deadlines.erase(it);
+                } else {
+                    ++it;
+                }
+            }
+            if (tenant_state.Empty()) {
+                tenant_it = shard->tenants.erase(tenant_it);
+            } else {
+                ++tenant_it;
+            }
+        }
+    }
 }
 
 auto MasterService::GetAllKeys(const std::string& tenant_id)

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -192,6 +192,8 @@ MasterService::MasterService(const MasterServiceConfig& config)
           }),
       default_kv_lease_ttl_(config.default_kv_lease_ttl),
       default_kv_soft_pin_ttl_(config.default_kv_soft_pin_ttl),
+      max_retained_groups_(config.max_retained_groups),
+      max_group_retention_ttl_ms_(config.max_group_retention_ttl_ms),
       allow_evict_soft_pinned_objects_(config.allow_evict_soft_pinned_objects),
       eviction_ratio_(config.eviction_ratio),
       eviction_high_watermark_ratio_(config.eviction_high_watermark_ratio),
@@ -1622,6 +1624,7 @@ void MasterService::RegisterGroupMember(TenantState& tenant_state,
     const auto now = std::chrono::system_clock::now();
     if (retention_it->second <= now) {
         tenant_state.group_retention_deadlines.erase(retention_it);
+        retained_group_count_.fetch_sub(1, std::memory_order_relaxed);
         return;
     }
     auto metadata_it = tenant_state.metadata.find(key);
@@ -2207,9 +2210,13 @@ std::vector<tl::expected<bool, ErrorCode>> MasterService::RetainGroups(
     if (group_ids.empty()) {
         return results;
     }
-    if (ttl_ms == 0) {
+    if (ttl_ms == 0 || ttl_ms > max_group_retention_ttl_ms_) {
         std::fill(results.begin(), results.end(),
                   tl::unexpected(ErrorCode::INVALID_PARAMS));
+        return results;
+    }
+    if (max_retained_groups_ == 0) {
+        std::fill(results.begin(), results.end(), false);
         return results;
     }
 
@@ -2236,6 +2243,7 @@ std::vector<tl::expected<bool, ErrorCode>> MasterService::RetainGroups(
              it != tenant_state.group_retention_deadlines.end();) {
             if (it->second <= now) {
                 it = tenant_state.group_retention_deadlines.erase(it);
+                retained_group_count_.fetch_sub(1, std::memory_order_relaxed);
             } else {
                 ++it;
             }
@@ -2246,9 +2254,23 @@ std::vector<tl::expected<bool, ErrorCode>> MasterService::RetainGroups(
                 continue;
             }
             const auto deadline = now + std::chrono::milliseconds(ttl_ms);
-            auto& retained_until =
-                tenant_state.group_retention_deadlines[group_ids[i]];
-            retained_until = std::max(retained_until, deadline);
+            auto retention_it =
+                tenant_state.group_retention_deadlines.find(group_ids[i]);
+            if (retention_it == tenant_state.group_retention_deadlines.end()) {
+                const auto previous = retained_group_count_.fetch_add(
+                    1, std::memory_order_relaxed);
+                if (previous >= max_retained_groups_) {
+                    retained_group_count_.fetch_sub(1,
+                                                    std::memory_order_relaxed);
+                    results[i] = false;
+                    continue;
+                }
+                retention_it = tenant_state.group_retention_deadlines
+                                   .emplace(group_ids[i], deadline)
+                                   .first;
+            } else {
+                retention_it->second = std::max(retention_it->second, deadline);
+            }
 
             auto group_it = tenant_state.group_members.find(group_ids[i]);
             if (group_it == tenant_state.group_members.end() ||
@@ -2279,6 +2301,8 @@ void MasterService::PruneExpiredGroupRetentions() {
                  it != tenant_state.group_retention_deadlines.end();) {
                 if (it->second <= now) {
                     it = tenant_state.group_retention_deadlines.erase(it);
+                    retained_group_count_.fetch_sub(1,
+                                                    std::memory_order_relaxed);
                 } else {
                     ++it;
                 }
@@ -7877,6 +7901,7 @@ void MasterService::MetadataSerializer::Reset() {
     for (auto& shard : service_->metadata_shards_) {
         shard.tenants.clear();
     }
+    service_->retained_group_count_.store(0, std::memory_order_relaxed);
     {
         std::unique_lock<std::shared_mutex> lock(
             service_->group_routing_mutex_);

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -2176,6 +2176,77 @@ std::vector<tl::expected<bool, ErrorCode>> MasterService::BatchExistKey(
     return results;
 }
 
+std::vector<tl::expected<bool, ErrorCode>> MasterService::RetainGroups(
+    const std::vector<std::string>& group_ids, uint64_t ttl_ms,
+    const std::string& tenant_id) {
+    std::vector<tl::expected<bool, ErrorCode>> results(group_ids.size());
+    if (group_ids.empty()) {
+        return results;
+    }
+    if (ttl_ms == 0) {
+        std::fill(results.begin(), results.end(),
+                  tl::unexpected(ErrorCode::INVALID_PARAMS));
+        return results;
+    }
+
+    const std::string normalized_tenant = NormalizeRequestTenantId(tenant_id);
+    std::vector<std::vector<size_t>> indices_by_shard(kNumShards);
+    for (size_t i = 0; i < group_ids.size(); ++i) {
+        indices_by_shard[getShardIndex(group_ids[i])].push_back(i);
+    }
+
+    const size_t start_shard = RandomIndex(kNumShards);
+    for (size_t scanned = 0; scanned < kNumShards; ++scanned) {
+        const size_t shard_idx =
+            (start_shard + kNumShards - scanned) % kNumShards;
+        const auto& group_indices = indices_by_shard[shard_idx];
+        if (group_indices.empty()) {
+            continue;
+        }
+
+        std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+        MetadataShardAccessorRO shard(this, shard_idx);
+        auto tenant_it = shard->tenants.find(normalized_tenant);
+        if (tenant_it == shard->tenants.end()) {
+            for (const size_t i : group_indices) {
+                results[i] = false;
+            }
+            continue;
+        }
+
+        const auto& tenant_state = tenant_it->second;
+        for (const size_t i : group_indices) {
+            auto group_it = tenant_state.group_members.find(group_ids[i]);
+            if (group_it == tenant_state.group_members.end() ||
+                group_it->second.empty()) {
+                results[i] = false;
+                continue;
+            }
+
+            bool complete = true;
+            for (const auto& member_key : group_it->second) {
+                auto member_it = tenant_state.metadata.find(member_key);
+                if (member_it == tenant_state.metadata.end() ||
+                    !member_it->second.IsValid() ||
+                    !member_it->second.HasReplica(&Replica::fn_is_completed)) {
+                    complete = false;
+                    break;
+                }
+            }
+            if (!complete) {
+                results[i] = false;
+                continue;
+            }
+
+            for (const auto& member_key : group_it->second) {
+                tenant_state.metadata.at(member_key).GrantLease(ttl_ms, 0);
+            }
+            results[i] = true;
+        }
+    }
+    return results;
+}
+
 auto MasterService::GetAllKeys(const std::string& tenant_id)
     -> tl::expected<std::vector<std::string>, ErrorCode> {
     std::vector<std::string> all_keys;

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -2053,6 +2053,19 @@ std::vector<int> RealClient::batchIsExist(
     return results;
 }
 
+std::vector<int> RealClient::retainGroups(
+    const std::vector<std::string> &group_ids, uint64_t ttl_ms) {
+    auto internal_results = retainGroups_internal(group_ids, ttl_ms);
+    std::vector<int> results;
+    results.reserve(internal_results.size());
+    for (const auto &result : internal_results) {
+        results.push_back(result.has_value()
+                              ? (result.value() ? 1 : 0)
+                              : toInt(result.error()));
+    }
+    return results;
+}
+
 tl::expected<int64_t, ErrorCode> RealClient::getSize_internal(
     const std::string &key) {
     if (!client_) {
@@ -4696,6 +4709,15 @@ std::vector<tl::expected<bool, ErrorCode>> RealClient::batchIsExist_internal(
 
     // Call client BatchIsExist and return the vector<expected> directly
     return client_->BatchIsExist(keys);
+}
+
+std::vector<tl::expected<bool, ErrorCode>> RealClient::retainGroups_internal(
+    const std::vector<std::string> &group_ids, uint64_t ttl_ms) {
+    if (!client_ || ttl_ms == 0) {
+        return std::vector<tl::expected<bool, ErrorCode>>(
+            group_ids.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
+    }
+    return client_->RetainGroups(group_ids, ttl_ms);
 }
 
 int RealClient::put_from_with_metadata(const std::string &key, void *buffer,

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -2059,9 +2059,8 @@ std::vector<int> RealClient::retainGroups(
     std::vector<int> results;
     results.reserve(internal_results.size());
     for (const auto &result : internal_results) {
-        results.push_back(result.has_value()
-                              ? (result.value() ? 1 : 0)
-                              : toInt(result.error()));
+        results.push_back(result.has_value() ? (result.value() ? 1 : 0)
+                                             : toInt(result.error()));
     }
     return results;
 }

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -1,5 +1,7 @@
 #include "rpc_service.h"
 
+#include <algorithm>
+
 #include <ylt/coro_rpc/coro_rpc_server.hpp>
 #include <ylt/util/tl/expected.hpp>
 
@@ -79,7 +81,14 @@ std::vector<tl::expected<bool, ErrorCode>> WrappedMasterService::BatchExistKey(
 std::vector<tl::expected<bool, ErrorCode>> WrappedMasterService::RetainGroups(
     const std::vector<std::string>& group_ids, uint64_t ttl_ms,
     const std::string& tenant_id) {
-    return master_service_.RetainGroups(group_ids, ttl_ms, tenant_id);
+    auto result = master_service_.RetainGroups(group_ids, ttl_ms, tenant_id);
+    const auto accepted = std::count_if(
+        result.begin(), result.end(),
+        [](const auto& item) { return item.has_value() && item.value(); });
+    LOG(INFO) << "RetainGroups accepted " << accepted << "/"
+              << group_ids.size() << " groups for ttl_ms=" << ttl_ms
+              << ", tenant_id=" << tenant_id;
+    return result;
 }
 
 tl::expected<

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -76,6 +76,12 @@ std::vector<tl::expected<bool, ErrorCode>> WrappedMasterService::BatchExistKey(
     return result;
 }
 
+std::vector<tl::expected<bool, ErrorCode>> WrappedMasterService::RetainGroups(
+    const std::vector<std::string>& group_ids, uint64_t ttl_ms,
+    const std::string& tenant_id) {
+    return master_service_.RetainGroups(group_ids, ttl_ms, tenant_id);
+}
+
 tl::expected<
     std::unordered_map<UUID, std::vector<std::string>, boost::hash<UUID>>,
     ErrorCode>
@@ -1348,6 +1354,8 @@ void RegisterRpcService(
     server.register_handler<&mooncake::WrappedMasterService::GetStorageConfig>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::BatchExistKey>(
+        &wrapped_master_service);
+    server.register_handler<&mooncake::WrappedMasterService::RetainGroups>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::ServiceReady>(
         &wrapped_master_service);

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -85,9 +85,8 @@ std::vector<tl::expected<bool, ErrorCode>> WrappedMasterService::RetainGroups(
     const auto accepted = std::count_if(
         result.begin(), result.end(),
         [](const auto& item) { return item.has_value() && item.value(); });
-    LOG(INFO) << "RetainGroups accepted " << accepted << "/"
-              << group_ids.size() << " groups for ttl_ms=" << ttl_ms
-              << ", tenant_id=" << tenant_id;
+    LOG(INFO) << "RetainGroups accepted " << accepted << "/" << group_ids.size()
+              << " groups for ttl_ms=" << ttl_ms << ", tenant_id=" << tenant_id;
     return result;
 }
 

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -1487,6 +1487,103 @@ TEST_F(MasterServiceTest, RetainGroupsProtectsFutureGroupMembers) {
     EXPECT_EQ(ErrorCode::INVALID_PARAMS, invalid[0].error());
 }
 
+TEST_F(MasterServiceTest, RetainGroupsEnforcesAdmissionBounds) {
+    auto service_config = MasterServiceConfig::builder()
+                              .set_max_retained_groups(1)
+                              .set_max_group_retention_ttl_ms(100)
+                              .build();
+    std::unique_ptr<MasterService> service_(new MasterService(service_config));
+
+    auto accepted = service_->RetainGroups({"retained_group_a"}, 80, "default");
+    ASSERT_EQ(accepted.size(), 1);
+    ASSERT_TRUE(accepted[0].has_value());
+    EXPECT_TRUE(accepted[0].value());
+
+    auto extended =
+        service_->RetainGroups({"retained_group_a"}, 100, "default");
+    ASSERT_EQ(extended.size(), 1);
+    ASSERT_TRUE(extended[0].has_value());
+    EXPECT_TRUE(extended[0].value());
+
+    auto rejected = service_->RetainGroups({"retained_group_b"}, 80, "default");
+    ASSERT_EQ(rejected.size(), 1);
+    ASSERT_TRUE(rejected[0].has_value());
+    EXPECT_FALSE(rejected[0].value());
+
+    auto too_long =
+        service_->RetainGroups({"retained_group_a"}, 101, "default");
+    ASSERT_EQ(too_long.size(), 1);
+    ASSERT_FALSE(too_long[0].has_value());
+    EXPECT_EQ(ErrorCode::INVALID_PARAMS, too_long[0].error());
+}
+
+TEST_F(MasterServiceTest, RetainGroupsAdmissionCapIsConcurrent) {
+    constexpr size_t kMaxRetainedGroups = 8;
+    constexpr size_t kRequests = 32;
+    auto service_config = MasterServiceConfig::builder()
+                              .set_max_retained_groups(kMaxRetainedGroups)
+                              .build();
+    std::unique_ptr<MasterService> service_(new MasterService(service_config));
+    std::atomic<size_t> accepted{0};
+    std::vector<std::thread> threads;
+    threads.reserve(kRequests);
+
+    for (size_t i = 0; i < kRequests; ++i) {
+        threads.emplace_back([&, i] {
+            auto result = service_->RetainGroups(
+                {"concurrent_retained_group_" + std::to_string(i)}, 1000,
+                "default");
+            if (result[0].has_value() && result[0].value()) {
+                accepted.fetch_add(1, std::memory_order_relaxed);
+            }
+        });
+    }
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    EXPECT_EQ(accepted.load(std::memory_order_relaxed), kMaxRetainedGroups);
+}
+
+TEST_F(MasterServiceTest, RetainedGroupBecomesEvictableAfterTtl) {
+    auto service_config =
+        MasterServiceConfig::builder().set_default_kv_lease_ttl(20).build();
+    constexpr size_t kSegmentSize = 4 * 1024 * 1024;
+    constexpr size_t kObjectSize = 2 * 1024 * 1024;
+    std::unique_ptr<MasterService> service_(new MasterService(service_config));
+    [[maybe_unused]] const auto context =
+        PrepareSimpleSegment(*service_, "expired_retained_group_segment",
+                             kDefaultSegmentBase, kSegmentSize);
+    const UUID client_id = generate_uuid();
+
+    const std::string key_a = "expired_retained_group_key_a";
+    const std::string key_b = "expired_retained_group_key_b";
+    const std::string group_id = FindGroupIdOnDifferentShard(key_a);
+    ReplicateConfig config;
+    config.replica_num = 1;
+    config.group_ids = std::vector<std::string>{group_id};
+
+    auto retained = service_->RetainGroups({group_id}, 60, "default");
+    ASSERT_EQ(retained.size(), 1);
+    ASSERT_TRUE(retained[0].has_value());
+    ASSERT_TRUE(retained[0].value());
+    PutCompletedObject(*service_, client_id, key_a, config, kObjectSize);
+    PutCompletedObject(*service_, client_id, key_b, config, kObjectSize);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(150));
+    ReplicateConfig trigger_config;
+    trigger_config.replica_num = 1;
+    auto trigger_result =
+        service_->PutStart(client_id, "trigger_expired_retained_group_eviction",
+                           "default", kObjectSize, trigger_config);
+    ASSERT_FALSE(trigger_result.has_value());
+    EXPECT_EQ(ErrorCode::NO_AVAILABLE_HANDLE, trigger_result.error());
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    EXPECT_FALSE(service_->ExistKey(key_a, "default").value_or(true));
+    EXPECT_FALSE(service_->ExistKey(key_b, "default").value_or(true));
+}
+
 TEST_F(MasterServiceTest, GroupedEvictionSkipsUnsafeMembersAndEvictsSafePeers) {
     constexpr size_t kSegmentSize = 4 * 1024 * 1024;
     constexpr size_t kObjectSize = 2 * 1024 * 1024;

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -1441,6 +1441,51 @@ TEST_F(MasterServiceTest,
     }
 }
 
+TEST_F(MasterServiceTest, RetainGroupsExtendsTheWholeGroupLease) {
+    auto service_config =
+        MasterServiceConfig::builder().set_default_kv_lease_ttl(100).build();
+    constexpr size_t kSegmentSize = 4 * 1024 * 1024;
+    constexpr size_t kObjectSize = 2 * 1024 * 1024;
+    std::unique_ptr<MasterService> service_(new MasterService(service_config));
+    [[maybe_unused]] const auto context =
+        PrepareSimpleSegment(*service_, "retained_group_segment",
+                             kDefaultSegmentBase, kSegmentSize);
+    const UUID client_id = generate_uuid();
+
+    const std::string key_a = "retained_group_key_a";
+    const std::string key_b = "retained_group_key_b";
+    const std::string group_id = FindGroupIdOnDifferentShard(key_a);
+    ReplicateConfig config;
+    config.replica_num = 1;
+    config.group_ids = std::vector<std::string>{group_id};
+    PutCompletedObject(*service_, client_id, key_a, config, kObjectSize);
+    PutCompletedObject(*service_, client_id, key_b, config, kObjectSize);
+
+    auto retained = service_->RetainGroups({group_id, "missing_group"}, 1000,
+                                           "default");
+    ASSERT_EQ(retained.size(), 2);
+    ASSERT_TRUE(retained[0].has_value());
+    EXPECT_TRUE(retained[0].value());
+    ASSERT_TRUE(retained[1].has_value());
+    EXPECT_FALSE(retained[1].value());
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    ReplicateConfig trigger_config;
+    trigger_config.replica_num = 1;
+    auto trigger_result = service_->PutStart(
+        client_id, "trigger_retained_group_eviction", "default", kObjectSize,
+        trigger_config);
+    ASSERT_FALSE(trigger_result.has_value());
+    EXPECT_EQ(ErrorCode::NO_AVAILABLE_HANDLE, trigger_result.error());
+    EXPECT_TRUE(service_->GetReplicaList(key_a, "default").has_value());
+    EXPECT_TRUE(service_->GetReplicaList(key_b, "default").has_value());
+
+    auto invalid = service_->RetainGroups({group_id}, 0, "default");
+    ASSERT_EQ(invalid.size(), 1);
+    ASSERT_FALSE(invalid[0].has_value());
+    EXPECT_EQ(ErrorCode::INVALID_PARAMS, invalid[0].error());
+}
+
 TEST_F(MasterServiceTest, GroupedEvictionSkipsUnsafeMembersAndEvictsSafePeers) {
     constexpr size_t kSegmentSize = 4 * 1024 * 1024;
     constexpr size_t kObjectSize = 2 * 1024 * 1024;

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -1447,9 +1447,8 @@ TEST_F(MasterServiceTest, RetainGroupsProtectsFutureGroupMembers) {
     constexpr size_t kSegmentSize = 4 * 1024 * 1024;
     constexpr size_t kObjectSize = 2 * 1024 * 1024;
     std::unique_ptr<MasterService> service_(new MasterService(service_config));
-    [[maybe_unused]] const auto context =
-        PrepareSimpleSegment(*service_, "retained_group_segment",
-                             kDefaultSegmentBase, kSegmentSize);
+    [[maybe_unused]] const auto context = PrepareSimpleSegment(
+        *service_, "retained_group_segment", kDefaultSegmentBase, kSegmentSize);
     const UUID client_id = generate_uuid();
 
     const std::string key_a = "retained_group_key_a";
@@ -1459,8 +1458,8 @@ TEST_F(MasterServiceTest, RetainGroupsProtectsFutureGroupMembers) {
     config.replica_num = 1;
     config.group_ids = std::vector<std::string>{group_id};
 
-    auto retained = service_->RetainGroups({group_id, "missing_group"}, 1000,
-                                           "default");
+    auto retained =
+        service_->RetainGroups({group_id, "missing_group"}, 1000, "default");
     ASSERT_EQ(retained.size(), 2);
     ASSERT_TRUE(retained[0].has_value());
     EXPECT_TRUE(retained[0].value());
@@ -1473,9 +1472,9 @@ TEST_F(MasterServiceTest, RetainGroupsProtectsFutureGroupMembers) {
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     ReplicateConfig trigger_config;
     trigger_config.replica_num = 1;
-    auto trigger_result = service_->PutStart(
-        client_id, "trigger_retained_group_eviction", "default", kObjectSize,
-        trigger_config);
+    auto trigger_result =
+        service_->PutStart(client_id, "trigger_retained_group_eviction",
+                           "default", kObjectSize, trigger_config);
     ASSERT_FALSE(trigger_result.has_value());
     EXPECT_EQ(ErrorCode::NO_AVAILABLE_HANDLE, trigger_result.error());
     EXPECT_TRUE(service_->GetReplicaList(key_a, "default").has_value());

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -1441,7 +1441,7 @@ TEST_F(MasterServiceTest,
     }
 }
 
-TEST_F(MasterServiceTest, RetainGroupsExtendsTheWholeGroupLease) {
+TEST_F(MasterServiceTest, RetainGroupsProtectsFutureGroupMembers) {
     auto service_config =
         MasterServiceConfig::builder().set_default_kv_lease_ttl(100).build();
     constexpr size_t kSegmentSize = 4 * 1024 * 1024;
@@ -1458,8 +1458,6 @@ TEST_F(MasterServiceTest, RetainGroupsExtendsTheWholeGroupLease) {
     ReplicateConfig config;
     config.replica_num = 1;
     config.group_ids = std::vector<std::string>{group_id};
-    PutCompletedObject(*service_, client_id, key_a, config, kObjectSize);
-    PutCompletedObject(*service_, client_id, key_b, config, kObjectSize);
 
     auto retained = service_->RetainGroups({group_id, "missing_group"}, 1000,
                                            "default");
@@ -1467,7 +1465,10 @@ TEST_F(MasterServiceTest, RetainGroupsExtendsTheWholeGroupLease) {
     ASSERT_TRUE(retained[0].has_value());
     EXPECT_TRUE(retained[0].value());
     ASSERT_TRUE(retained[1].has_value());
-    EXPECT_FALSE(retained[1].value());
+    EXPECT_TRUE(retained[1].value());
+
+    PutCompletedObject(*service_, client_id, key_a, config, kObjectSize);
+    PutCompletedObject(*service_, client_id, key_b, config, kObjectSize);
 
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     ReplicateConfig trigger_config;


### PR DESCRIPTION
[generated with AI - this is currently a testing POC to start discussion]

<!-- codex-pr-description:start -->
This draft POC adds master-owned, TTL-bounded retention leases for logical Mooncake object groups and supports intent recorded before group members are published. It is the L3 ownership layer for the companion Dynamo and SGLang prompt-KV retention path, without pinning GPU/host cache or importing provider/session semantics into Mooncake.

Tracking: DYN-3309

Companion PRs: [Dynamo #11534](https://github.com/ai-dynamo/dynamo/pull/11534), [SGLang #30796](https://github.com/sgl-project/sglang/pull/30796), and [frontend-crates #107](https://github.com/ai-dynamo/frontend-crates/pull/107). Parent design: [SGLang RFC #27574](https://github.com/sgl-project/sglang/issues/27574).

### How This Was Implemented
- Adds `RetainGroups(group_ids, ttl_ms)` through the master RPC, client interfaces, Store client, RealClient, and Python binding.
- Extends current member leases and records group intent so objects published after request completion inherit the remaining deadline.
- Uses max-deadline semantics, preventing a later shorter request from reducing existing retention.
- Bounds new retention intent to 65,536 groups and 24 hours by default while allowing existing groups to extend at capacity.
- Reuses grouped eviction: retained objects become ordinary eviction candidates automatically after the deadline expires.

<details>
<summary>Walkthrough</summary>

#### Mental model

Mooncake receives only exact logical group IDs and TTLs. Dynamo owns provider normalization, SGLang owns prompt-to-page resolution, and Mooncake owns the resulting L3 lease.

```mermaid
flowchart LR
    A["OpenAI prompt_cache_options or Anthropic cache_control"] --> B["Dynamo KvHintEnvelope"]
    B --> C["SGLang resolves committed HiCache page hashes"]
    C --> D["Mooncake retain_groups(group_ids, ttl_ms)"]
    D --> E["Master extends current leases"]
    D --> F["Master records future-member intent"]
    E --> G["Grouped eviction skips retained objects"]
    F --> G
```

#### State and ordering

The master stores one retention deadline per logical group. Repeated calls take the maximum of the existing deadline and `now + ttl`, and expired entries are lazily removed as normal master operations encounter them.

SGLang can finish radix insertion before its asynchronous write-through publication reaches Mooncake. `retain_groups` therefore accepts a new group with no members, and a later grouped put applies the remaining deadline to every newly published member. This closes the completion/publication race without SGLang lease-renewal polling.

#### Request lifecycle

1. SGLang derives the exact tagged group IDs for page-aligned committed prompt KV.
2. The Python Store client issues one `retain_groups` request from HiCache's storage worker.
3. The master admits or extends each group independently and returns per-group acceptance.
4. Current members receive ordinary leases; future members inherit the group deadline during publication.
5. Existing eviction skips live leases and resumes ordinary behavior after expiry.

New groups return `false` when the admission cap is full; invalid TTLs return `INVALID_PARAMS`; partial acceptance is observable to SGLang while inference remains fail-open.

#### Boundaries and limitations

- This is L3 retention only; it does not pin SGLang L1/L2, prefetch, demote, route, or schedule requests.
- Admission is count- and TTL-bounded, not byte-aware or tenant-fair.
- Retention intent is master-memory state and is not yet HA/snapshot durable.
- Embedded data segments remain tied to publishing clients; worker-death survival requires standalone or replicated Mooncake storage.
- The Python binding uses the RealClient path; standalone/dummy-client parity and explicit retention telemetry remain outside this POC.

</details>

### Validation
- `PATH=/tmp/mooncake-clang-format:$PATH pre-commit run --from-ref origin/main --to-ref HEAD` — passed all scoped hooks.
- `cmake --build build-retention --target master_service_test -j2` — passed.
- `master_service_test --gtest_filter='MasterServiceTest.*Group*'` — 24/24 passed, including future-member inheritance, expiry, bounds, and 32-thread concurrent admission.
- Source-matched MiniMax M2.7 TP4 H100 validation through Dynamo, SGLang, real Codex, real Claude Code, compressed `DYN_REQUEST_TRACE`, and Tachometer — passed functional retention attribution.
- GitHub's external SGLang integration gate reported a remote job failure without an in-job diagnostic; all other build, wheel, format, unit, and analysis jobs passed.

### Benchmark Results

The current A/B seeded and probed on different SGLang workers, applied 70 × 16,384-token pressure requests, waited for drain, flushed worker-local caches, and observed `router_cached=0` on every final probe.

| Probe | Control L3 tokens | Retained L3 tokens | Mooncake acceptance | Probe latency delta |
|---|---:|---:|---:|---:|
| Codex | 4,640 shared-prefix tokens | 20,800 tokens | 1,300/1,300 groups for 30 minutes | +23.1% |
| Claude Code | 0 tokens | 13,600 tokens | 850/850 groups for 1 hour | +34.0% |

| Pressure outcome | Result |
|---|---:|
| Completed requests | 70 |
| Total pressure input | 1,146,881 tokens |
| Successful eviction cycles | 14 |
| Evicted data | 144,904 keys / 34.27 GiB |

Retention survived measured eviction, but Mooncake materialization was slower than recompute on this single-node topology. The POC establishes ownership and correctness; it does not justify blanket retention policy enablement.
<!-- codex-pr-description:end -->

This draft POC adds a master-owned, TTL-bounded `retain_groups` operation for logical Mooncake object groups. It lets agentic endpoints preserve explicitly retained prompt KV through ordinary store eviction without pinning GPU/host cache or polling Mooncake from SGLang.

Related design discussion: [SGLang programmatic KV cache RFC #27574](https://github.com/sgl-project/sglang/issues/27574). Companion Dynamo and SGLang PRs will be released soon.

### How This Was Implemented
- Added `RetainGroups(group_ids, ttl_ms)` through the Mooncake master, RPC client, Store client, RealClient, and Python binding.
- Reused ordinary object leases: current group members receive the requested lease, while retention intent recorded before publication is inherited by future members.
- Applied `retain_until = max(existing_deadline, now + ttl)`, automatic expiry, and bounded admission with a 65,536-group default cap and 24-hour maximum TTL.
- Preserved best-effort behavior: new groups return `false` when admission is full, invalid TTLs return `INVALID_PARAMS`, and existing groups can still extend while full.

<details>
<summary>Walkthrough</summary>

#### Mental model

Provider APIs express retention intent, Dynamo normalizes that intent, SGLang resolves the token prefix into exact HiCache page groups, and Mooncake owns the resulting L3 lease. Mooncake never receives provider, agent, session, or routing semantics.

```mermaid
flowchart LR
    A["OpenAI prompt_cache_retention or Anthropic cache_control"] --> B["Dynamo normalizes KvHintEnvelope"]
    B --> C["SGLang receives prefix_tokens and ttl_seconds"]
    C --> D["HiCache page-aligns the prefix and resolves group_ids"]
    D --> E["Mooncake retain_groups(group_ids, ttl_ms)"]
    E --> F["Master extends current leases and records future-member intent"]
    F --> G["Existing Mooncake eviction skips leased groups"]
```

`prompt_cache_key` alone is not treated as retention intent. The normalized envelope is carried after Dynamo routing/admission, so it does not change worker selection or queue policy.

#### State and ordering

The master stores one deadline per logical group. Repeated requests use max semantics: if a group already has 60 minutes remaining, a later 5-minute request cannot shorten it.

SGLang applies the hint after finished-request radix insertion, but HiCache publication to L3 is asynchronous. Therefore `RetainGroups` accepts a group even when it has no current members; objects published later inherit the remaining group deadline. This closes the request-completion/publication race without SGLang renewal polling.

#### Request lifecycle

1. Dynamo converts provider-native retention controls into `prefix_tokens + ttl_seconds`.
2. SGLang page-aligns the retained token span and derives the exact tagged Mooncake group IDs.
3. One `retain_groups` call records or extends the master-owned deadline and grants ordinary leases to current members.
4. Existing grouped eviction logic rejects a group while any member lease remains active.
5. When the deadline expires, objects become ordinary eviction candidates without an explicit release RPC.

Admission is globally count-bounded and concurrency-safe. Extensions remain accepted at capacity; new groups return `false`, allowing SGLang to log partial acceptance while inference continues.

#### Boundaries and limitations

- This is a POC for L3 retention only. It does not pin SGLang GPU or host KV, add prefetch/demotion, or change router/scheduler policy.
- Admission is count- and TTL-bounded, not byte-aware or tenant-fair.
- Retention intent is master-memory state and is not yet HA/snapshot durable.
- Embedded Mooncake data segments remain tied to the publishing client; survival across SGLang worker death requires standalone or replicated Mooncake storage.
- The Python binding currently uses the RealClient path. A standalone/dummy-client control path and explicit retention telemetry are follow-ups.

</details>

### Validation
- `PATH=/tmp/mooncake-clang-format:$PATH pre-commit run --from-ref origin/main --to-ref HEAD` — passed all hooks.
- `cmake --build build-retention --target master_service_test -j2` — passed on current upstream `main`.
- `master_service_test --gtest_filter='MasterServiceTest.*Group*'` — 24/24 passed, including future-member inheritance, TTL expiry, bounded admission, and a 32-thread concurrent cap test.

### Benchmark Results

Fresh MiniMax M2.7 H100 validation used two TP4 workers, an 8 GiB-per-worker embedded Mooncake tier, a retained 10k-token prefix, and 60 seconds of c=8 unique-prompt pressure.

| Outcome | Result |
|---|---:|
| Store eviction during pressure | 24.18 GB / 95,232 keys |
| Unretained cold probe | 10,032 tokens recomputed |
| Retained cold probe | 10,016 tokens restored from L3; 16 recomputed |
| Idle renewal polling | 0 additional BatchExistKey requests over 12 seconds |

### PR Classification
- [x] Mooncake Store
- [x] Integration / Python binding
- [x] New feature
- [x] POC / experimental

### Checklist
- [x] Self-reviewed the scoped diff.
- [x] Formatted with Mooncake's LLVM 20 formatter.
- [x] Ran scoped pre-commit hooks.
- [x] Added tests for retention, expiry, admission bounds, and concurrency.
- [ ] Public configuration and user documentation are deferred until the POC API is agreed.

### AI Assistance Disclosure
- [x] AI tools assisted with implementation, testing, benchmark analysis, and PR drafting. The human submitter is responsible for reviewing and defending the changes.
