### PR TITLE
[Store] Speed up HugeTLB population before RDMA registration

### DIFF
--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -811,7 +811,6 @@ Local hot cache provides a DRAM read cache on top of SSD-resident objects for fa
 |----------|---------|-------------|
 | `MC_STORE_USE_HUGEPAGE` | unset | Set `1` to request HugeTLB-backed `mmap()` |
 | `MC_STORE_HUGEPAGE_SIZE` | `2MB` | Supported: `2MB`, `1GB` |
-| `MC_DISABLE_RDMA_PRE_TOUCH` | `false` | Disable the RDMA transport's register/deregister pre-touch pass. Accepts `1`/`true`/`yes`/`on`; use with `MC_ENABLE_PARALLEL_REG_MR=1` when Store already populated the mapping and parallel MR registration should remain enabled |
 | `MC_MMAP_ARENA_POOL_SIZE` | unset | Pre-allocated arena pool size (e.g., `8gb`). Explicitly set to enable the arena |
 | `MC_DISABLE_MMAP_ARENA` | unset | Disable arena, fall back to per-call `mmap()`. Accepts `1`/`true`/`yes`/`on` (or `0`/`false`/`no`/`off`) |
 
@@ -822,14 +821,6 @@ required:
 ```bash
 export MC_STORE_USE_HUGEPAGE=1
 export MC_STORE_HUGEPAGE_SIZE=2MB
-```
-
-To skip the transfer engine's separate register/deregister pre-touch pass while
-retaining parallel MR registration, optionally set:
-
-```bash
-export MC_DISABLE_RDMA_PRE_TOUCH=1
-export MC_ENABLE_PARALLEL_REG_MR=1
 ```
 
 For direct mappings, workers divide the mapping into page ranges. For

--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -811,18 +811,23 @@ Local hot cache provides a DRAM read cache on top of SSD-resident objects for fa
 |----------|---------|-------------|
 | `MC_STORE_USE_HUGEPAGE` | unset | Set `1` to request HugeTLB-backed `mmap()` |
 | `MC_STORE_HUGEPAGE_SIZE` | `2MB` | Supported: `2MB`, `1GB` |
-| `MC_STORE_HUGEPAGE_POPULATE_MODE` | unset | Set `parallel` to populate RDMA Store HugeTLB mappings with parallel CPU writes immediately before transfer-engine registration. NUMA mappings use node-local workers |
 | `MC_DISABLE_RDMA_PRE_TOUCH` | `false` | Disable the RDMA transport's register/deregister pre-touch pass. Accepts `1`/`true`/`yes`/`on`; use with `MC_ENABLE_PARALLEL_REG_MR=1` when Store already populated the mapping and parallel MR registration should remain enabled |
 | `MC_MMAP_ARENA_POOL_SIZE` | unset | Pre-allocated arena pool size (e.g., `8gb`). Explicitly set to enable the arena |
 | `MC_DISABLE_MMAP_ARENA` | unset | Disable arena, fall back to per-call `mmap()`. Accepts `1`/`true`/`yes`/`on` (or `0`/`false`/`no`/`off`) |
 
-For large RDMA Store segments, parallel population avoids blocking in
-`mmap(MAP_POPULATE)` or serially faulting pages during registration:
+RDMA Store segments backed by HugeTLB are populated in parallel immediately
+before transfer-engine registration. No additional population-mode setting is
+required:
 
 ```bash
 export MC_STORE_USE_HUGEPAGE=1
 export MC_STORE_HUGEPAGE_SIZE=2MB
-export MC_STORE_HUGEPAGE_POPULATE_MODE=parallel
+```
+
+To skip the transfer engine's separate register/deregister pre-touch pass while
+retaining parallel MR registration, optionally set:
+
+```bash
 export MC_DISABLE_RDMA_PRE_TOUCH=1
 export MC_ENABLE_PARALLEL_REG_MR=1
 ```

--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -811,8 +811,25 @@ Local hot cache provides a DRAM read cache on top of SSD-resident objects for fa
 |----------|---------|-------------|
 | `MC_STORE_USE_HUGEPAGE` | unset | Set `1` to request HugeTLB-backed `mmap()` |
 | `MC_STORE_HUGEPAGE_SIZE` | `2MB` | Supported: `2MB`, `1GB` |
+| `MC_STORE_HUGEPAGE_POPULATE_MODE` | unset | Set `rdma` to defer direct-mmap HugeTLB population until immediately before transfer-engine registration and fault pages in with parallel CPU writes |
+| `MC_DISABLE_RDMA_PRE_TOUCH` | `false` | Disable the RDMA transport's register/deregister pre-touch pass. Accepts `1`/`true`/`yes`/`on`; recommended with `MC_STORE_HUGEPAGE_POPULATE_MODE=rdma` to avoid duplicate preparation |
 | `MC_MMAP_ARENA_POOL_SIZE` | unset | Pre-allocated arena pool size (e.g., `8gb`). Explicitly set to enable the arena |
 | `MC_DISABLE_MMAP_ARENA` | unset | Disable arena, fall back to per-call `mmap()`. Accepts `1`/`true`/`yes`/`on` (or `0`/`false`/`no`/`off`) |
+
+For large RDMA Store segments using the direct-`mmap()` path, deferred
+population avoids blocking in `mmap(MAP_POPULATE)` on the full mapping:
+
+```bash
+export MC_STORE_USE_HUGEPAGE=1
+export MC_STORE_HUGEPAGE_SIZE=2MB
+export MC_STORE_HUGEPAGE_POPULATE_MODE=rdma
+export MC_DISABLE_RDMA_PRE_TOUCH=1
+```
+
+The mmap arena retains its eager `MAP_POPULATE` behavior for DMA safety. If
+the arena is enabled, also set `MC_DISABLE_MMAP_ARENA=1` to benchmark or use
+the deferred direct-mmap path. NUMA-segmented mappings keep their existing
+`mbind()` plus RDMA-registration first-touch behavior.
 
 #### yalantinglibs Log Level
 

--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -811,25 +811,27 @@ Local hot cache provides a DRAM read cache on top of SSD-resident objects for fa
 |----------|---------|-------------|
 | `MC_STORE_USE_HUGEPAGE` | unset | Set `1` to request HugeTLB-backed `mmap()` |
 | `MC_STORE_HUGEPAGE_SIZE` | `2MB` | Supported: `2MB`, `1GB` |
-| `MC_STORE_HUGEPAGE_POPULATE_MODE` | unset | Set `rdma` to defer direct-mmap HugeTLB population until immediately before transfer-engine registration and fault pages in with parallel CPU writes |
-| `MC_DISABLE_RDMA_PRE_TOUCH` | `false` | Disable the RDMA transport's register/deregister pre-touch pass. Accepts `1`/`true`/`yes`/`on`; recommended with `MC_STORE_HUGEPAGE_POPULATE_MODE=rdma` to avoid duplicate preparation |
+| `MC_STORE_HUGEPAGE_POPULATE_MODE` | unset | Set `parallel` to populate RDMA Store HugeTLB mappings with parallel CPU writes immediately before transfer-engine registration. NUMA mappings use node-local workers |
+| `MC_DISABLE_RDMA_PRE_TOUCH` | `false` | Disable the RDMA transport's register/deregister pre-touch pass. Accepts `1`/`true`/`yes`/`on`; use with `MC_ENABLE_PARALLEL_REG_MR=1` when Store already populated the mapping and parallel MR registration should remain enabled |
 | `MC_MMAP_ARENA_POOL_SIZE` | unset | Pre-allocated arena pool size (e.g., `8gb`). Explicitly set to enable the arena |
 | `MC_DISABLE_MMAP_ARENA` | unset | Disable arena, fall back to per-call `mmap()`. Accepts `1`/`true`/`yes`/`on` (or `0`/`false`/`no`/`off`) |
 
-For large RDMA Store segments using the direct-`mmap()` path, deferred
-population avoids blocking in `mmap(MAP_POPULATE)` on the full mapping:
+For large RDMA Store segments, parallel population avoids blocking in
+`mmap(MAP_POPULATE)` or serially faulting pages during registration:
 
 ```bash
 export MC_STORE_USE_HUGEPAGE=1
 export MC_STORE_HUGEPAGE_SIZE=2MB
-export MC_STORE_HUGEPAGE_POPULATE_MODE=rdma
+export MC_STORE_HUGEPAGE_POPULATE_MODE=parallel
 export MC_DISABLE_RDMA_PRE_TOUCH=1
+export MC_ENABLE_PARALLEL_REG_MR=1
 ```
 
-The mmap arena retains its eager `MAP_POPULATE` behavior for DMA safety. If
-the arena is enabled, also set `MC_DISABLE_MMAP_ARENA=1` to benchmark or use
-the deferred direct-mmap path. NUMA-segmented mappings keep their existing
-`mbind()` plus RDMA-registration first-touch behavior.
+For direct mappings, workers divide the mapping into page ranges. For
+NUMA-segmented mappings, each worker is scheduled on the NUMA node associated
+with its `mbind()` region before touching pages. The mmap arena retains its
+eager `MAP_POPULATE` behavior for DMA safety; set `MC_DISABLE_MMAP_ARENA=1` if
+the deferred direct-mmap path is desired while the arena is otherwise enabled.
 
 #### yalantinglibs Log Level
 

--- a/docs/source/getting_started/build.md
+++ b/docs/source/getting_started/build.md
@@ -121,13 +121,19 @@ sudo docker run --gpus all \
 The `64gb` / `56gb` values above are tuned examples for large HiCache deployments, not defaults. The arena remains disabled unless you explicitly enable it, and if you enable it via gflag without an env override the default pool size is `8gb`. On smaller hosts, start with `8gb` or `16gb` and size upward with the helper. When you want the baseline direct-`mmap()` path instead of the arena, set `MC_DISABLE_MMAP_ARENA=1` (also accepts `true`, `yes`, or `on`) and omit `MC_MMAP_ARENA_POOL_SIZE`. Set it before the first Mooncake mmap-buffer allocation in the process. If you build the image from source with `docker/mooncake.Dockerfile`, that source-built image also installs the helper as `mooncake-hicache-sizing`.
 Without `MC_STORE_USE_HUGEPAGE=1`, the arena may opportunistically try hugepages and then retry on regular pages if HugeTLB is unavailable. When `MC_STORE_USE_HUGEPAGE=1` is set, both the arena path and the direct-`mmap()` fallback path require HugeTLB pages. Mooncake will not silently degrade that explicit hugepage request to regular pages.
 
-For very large RDMA segments, page population can be moved to immediately
-before transfer-engine registration and parallelized across CPU threads:
+For RDMA Store segments backed by HugeTLB, page population is automatically
+deferred until immediately before transfer-engine registration and
+parallelized across CPU threads:
 
 ```bash
 export MC_STORE_USE_HUGEPAGE=1
 export MC_STORE_HUGEPAGE_SIZE=2MB
-export MC_STORE_HUGEPAGE_POPULATE_MODE=parallel
+```
+
+The transfer engine's separate register/deregister pre-touch pass can be
+skipped while retaining parallel MR registration with:
+
+```bash
 export MC_DISABLE_RDMA_PRE_TOUCH=1
 export MC_ENABLE_PARALLEL_REG_MR=1
 ```

--- a/docs/source/getting_started/build.md
+++ b/docs/source/getting_started/build.md
@@ -121,6 +121,21 @@ sudo docker run --gpus all \
 The `64gb` / `56gb` values above are tuned examples for large HiCache deployments, not defaults. The arena remains disabled unless you explicitly enable it, and if you enable it via gflag without an env override the default pool size is `8gb`. On smaller hosts, start with `8gb` or `16gb` and size upward with the helper. When you want the baseline direct-`mmap()` path instead of the arena, set `MC_DISABLE_MMAP_ARENA=1` (also accepts `true`, `yes`, or `on`) and omit `MC_MMAP_ARENA_POOL_SIZE`. Set it before the first Mooncake mmap-buffer allocation in the process. If you build the image from source with `docker/mooncake.Dockerfile`, that source-built image also installs the helper as `mooncake-hicache-sizing`.
 Without `MC_STORE_USE_HUGEPAGE=1`, the arena may opportunistically try hugepages and then retry on regular pages if HugeTLB is unavailable. When `MC_STORE_USE_HUGEPAGE=1` is set, both the arena path and the direct-`mmap()` fallback path require HugeTLB pages. Mooncake will not silently degrade that explicit hugepage request to regular pages.
 
+For very large direct-`mmap()` RDMA segments, page population can be deferred
+until immediately before transfer-engine registration and parallelized across
+CPU threads:
+
+```bash
+export MC_STORE_USE_HUGEPAGE=1
+export MC_STORE_HUGEPAGE_SIZE=2MB
+export MC_STORE_HUGEPAGE_POPULATE_MODE=rdma
+export MC_DISABLE_RDMA_PRE_TOUCH=1
+```
+
+This mode applies to the direct-mmap Store segment path. The mmap arena keeps
+its eager population behavior; set `MC_DISABLE_MMAP_ARENA=1` if an arena was
+otherwise enabled and the deferred path is desired.
+
 ## Advanced Compile Options
 The following options can be passed to `cmake ..`.
 

--- a/docs/source/getting_started/build.md
+++ b/docs/source/getting_started/build.md
@@ -121,20 +121,23 @@ sudo docker run --gpus all \
 The `64gb` / `56gb` values above are tuned examples for large HiCache deployments, not defaults. The arena remains disabled unless you explicitly enable it, and if you enable it via gflag without an env override the default pool size is `8gb`. On smaller hosts, start with `8gb` or `16gb` and size upward with the helper. When you want the baseline direct-`mmap()` path instead of the arena, set `MC_DISABLE_MMAP_ARENA=1` (also accepts `true`, `yes`, or `on`) and omit `MC_MMAP_ARENA_POOL_SIZE`. Set it before the first Mooncake mmap-buffer allocation in the process. If you build the image from source with `docker/mooncake.Dockerfile`, that source-built image also installs the helper as `mooncake-hicache-sizing`.
 Without `MC_STORE_USE_HUGEPAGE=1`, the arena may opportunistically try hugepages and then retry on regular pages if HugeTLB is unavailable. When `MC_STORE_USE_HUGEPAGE=1` is set, both the arena path and the direct-`mmap()` fallback path require HugeTLB pages. Mooncake will not silently degrade that explicit hugepage request to regular pages.
 
-For very large direct-`mmap()` RDMA segments, page population can be deferred
-until immediately before transfer-engine registration and parallelized across
-CPU threads:
+For very large RDMA segments, page population can be moved to immediately
+before transfer-engine registration and parallelized across CPU threads:
 
 ```bash
 export MC_STORE_USE_HUGEPAGE=1
 export MC_STORE_HUGEPAGE_SIZE=2MB
-export MC_STORE_HUGEPAGE_POPULATE_MODE=rdma
+export MC_STORE_HUGEPAGE_POPULATE_MODE=parallel
 export MC_DISABLE_RDMA_PRE_TOUCH=1
+export MC_ENABLE_PARALLEL_REG_MR=1
 ```
 
-This mode applies to the direct-mmap Store segment path. The mmap arena keeps
-its eager population behavior; set `MC_DISABLE_MMAP_ARENA=1` if an arena was
-otherwise enabled and the deferred path is desired.
+Direct mappings use a generic worker pool. NUMA-segmented mappings bind each
+worker to the node associated with its memory region. The mmap arena keeps its
+eager population behavior; set `MC_DISABLE_MMAP_ARENA=1` if an arena was
+otherwise enabled and deferred direct-mmap population is desired. Explicitly
+enabling parallel MR registration preserves the transport's parallel
+registration path when its own pre-touch pass is disabled.
 
 ## Advanced Compile Options
 The following options can be passed to `cmake ..`.

--- a/docs/source/getting_started/build.md
+++ b/docs/source/getting_started/build.md
@@ -130,20 +130,10 @@ export MC_STORE_USE_HUGEPAGE=1
 export MC_STORE_HUGEPAGE_SIZE=2MB
 ```
 
-The transfer engine's separate register/deregister pre-touch pass can be
-skipped while retaining parallel MR registration with:
-
-```bash
-export MC_DISABLE_RDMA_PRE_TOUCH=1
-export MC_ENABLE_PARALLEL_REG_MR=1
-```
-
 Direct mappings use a generic worker pool. NUMA-segmented mappings bind each
 worker to the node associated with its memory region. The mmap arena keeps its
 eager population behavior; set `MC_DISABLE_MMAP_ARENA=1` if an arena was
-otherwise enabled and deferred direct-mmap population is desired. Explicitly
-enabling parallel MR registration preserves the transport's parallel
-registration path when its own pre-touch pass is disabled.
+otherwise enabled and deferred direct-mmap population is desired.
 
 ## Advanced Compile Options
 The following options can be passed to `cmake ..`.

--- a/mooncake-store/include/utils.h
+++ b/mooncake-store/include/utils.h
@@ -377,19 +377,6 @@ inline size_t align_up(size_t size, size_t alignment) {
     return size;
 }
 
-enum class HugepagePopulateMode {
-    kEager,
-    kParallel,
-};
-
-/**
- * @brief Parse MC_STORE_HUGEPAGE_POPULATE_MODE.
- *
- * "parallel" requests deferred, parallel population immediately before Store
- * segment registration. Unset or invalid values use the eager default.
- */
-[[nodiscard]] HugepagePopulateMode get_hugepage_populate_mode();
-
 /**
  * @brief Fault in a fresh HugeTLB mapping with parallel CPU writes.
  *

--- a/mooncake-store/include/utils.h
+++ b/mooncake-store/include/utils.h
@@ -377,22 +377,36 @@ inline size_t align_up(size_t size, size_t alignment) {
     return size;
 }
 
+enum class HugepagePopulateMode {
+    kEager,
+    kParallel,
+};
+
 /**
- * @brief Whether HugeTLB page population should be deferred until the Store
- * segment is about to be registered with the transfer engine.
+ * @brief Parse MC_STORE_HUGEPAGE_POPULATE_MODE.
  *
- * Enabled when MC_STORE_USE_HUGEPAGE is set and
- * MC_STORE_HUGEPAGE_POPULATE_MODE=rdma.
+ * "parallel" requests deferred, parallel population immediately before Store
+ * segment registration. Unset or invalid values use the eager default.
  */
-[[nodiscard]] bool should_defer_hugetlb_population();
+[[nodiscard]] HugepagePopulateMode get_hugepage_populate_mode();
 
 /**
  * @brief Fault in a fresh HugeTLB mapping with parallel CPU writes.
  *
- * Touches one byte per configured hugepage and the final byte of the mapping.
- * Call this only for a newly allocated mapping whose contents may be zeroed.
+ * Touches one byte per configured hugepage. Call this only for a newly
+ * allocated mapping whose contents may be zeroed.
  */
 void populate_hugetlb_mapping(void* ptr, size_t total_size);
+
+/**
+ * @brief Fault in an mbind-partitioned HugeTLB mapping with NUMA-local workers.
+ *
+ * The mapping is divided into equal regions in the same order as numa_nodes.
+ * Workers are scheduled on the corresponding node before touching that
+ * region.
+ */
+void populate_hugetlb_numa_mapping(void* ptr, size_t total_size,
+                                   const std::vector<int>& numa_nodes);
 
 /**
  * Allocate mmap-backed buffer memory for host KV / transfer buffers.
@@ -446,8 +460,9 @@ void free_buffer_mmap_memory(void* ptr, size_t total_size);
  *
  * Reserves a single VMA via mmap, divides it into N equal regions,
  * binds each region to the corresponding NUMA node via mbind(MPOL_BIND).
- * No explicit prefault — ibv_reg_mr() will fault and pin pages respecting
- * the mbind policy, allocating directly on the target NUMA node.
+ * The mapping remains lazy after allocation. The caller may populate it with
+ * NUMA-local workers or let ibv_reg_mr() fault and pin pages while respecting
+ * the mbind policy.
  *
  * @param total_size  Total buffer size in bytes
  * @param numa_nodes  NUMA node IDs to bind regions to (e.g., {1,3,5,7})

--- a/mooncake-store/include/utils.h
+++ b/mooncake-store/include/utils.h
@@ -378,6 +378,23 @@ inline size_t align_up(size_t size, size_t alignment) {
 }
 
 /**
+ * @brief Whether HugeTLB page population should be deferred until the Store
+ * segment is about to be registered with the transfer engine.
+ *
+ * Enabled when MC_STORE_USE_HUGEPAGE is set and
+ * MC_STORE_HUGEPAGE_POPULATE_MODE=rdma.
+ */
+[[nodiscard]] bool should_defer_hugetlb_population();
+
+/**
+ * @brief Fault in a fresh HugeTLB mapping with parallel CPU writes.
+ *
+ * Touches one byte per configured hugepage and the final byte of the mapping.
+ * Call this only for a newly allocated mapping whose contents may be zeroed.
+ */
+void populate_hugetlb_mapping(void* ptr, size_t total_size);
+
+/**
  * Allocate mmap-backed buffer memory for host KV / transfer buffers.
  *
  * When the global mmap arena is enabled, this function serves allocations
@@ -393,6 +410,24 @@ inline size_t align_up(size_t size, size_t alignment) {
  * @return Pointer to the allocation, or nullptr on failure.
  */
 void* allocate_buffer_mmap_memory(size_t total_size, size_t alignment);
+
+/**
+ * Allocate mmap-backed memory, optionally deferring direct HugeTLB population.
+ *
+ * When defer_hugetlb_population is true, a direct HugeTLB mmap omits
+ * MAP_POPULATE so the caller can populate the mapping later. Arena allocations
+ * retain their existing eager-population behavior.
+ */
+void* allocate_buffer_mmap_memory(size_t total_size, size_t alignment,
+                                  bool defer_hugetlb_population);
+
+/**
+ * @brief Return whether ptr is backed by the global mmap arena.
+ *
+ * Intended for callers that need to distinguish an eagerly populated arena
+ * allocation from a direct mmap fallback.
+ */
+[[nodiscard]] bool is_mmap_arena_allocation(const void* ptr);
 
 /**
  * Release memory previously returned by allocate_buffer_mmap_memory().

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -816,6 +816,10 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
             }
         }
 
+        const bool parallel_hugetlb_population =
+            protocol == "rdma" && should_use_hugepage &&
+            get_hugepage_populate_mode() == HugepagePopulateMode::kParallel;
+
         while (global_segment_size > 0) {
             size_t segment_size = std::min(global_segment_size, max_mr_size);
             global_segment_size -= segment_size;
@@ -826,9 +830,6 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
             size_t mapped_size = segment_size;
             void *ptr = nullptr;
             std::string seg_location = kWildcardLocation;
-            const bool defer_hugetlb_population =
-                should_use_hugepage && seg_numa_nodes.empty() &&
-                should_defer_hugetlb_population();
 
             if (!seg_numa_nodes.empty()) {
                 // NUMA-segmented allocation: contiguous VMA, per-region binding
@@ -845,7 +846,7 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
                     align_up(segment_size, get_hugepage_size_from_env());
                 ptr = allocate_buffer_mmap_memory(mapped_size,
                                                   get_hugepage_size_from_env(),
-                                                  defer_hugetlb_population);
+                                                  parallel_hugetlb_population);
             } else {
                 ptr = allocate_buffer_allocator_memory(segment_size,
                                                        this->protocol);
@@ -879,13 +880,16 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
                 segment_ptrs_.emplace_back(ptr);
             }
 
-            // The direct HugeTLB path can defer population so mmap() does not
-            // synchronously fault a very large Store segment. Populate it in
-            // parallel immediately before transfer-engine registration. Keep
-            // NUMA-segmented mappings on their existing ibv_reg_mr()-driven
-            // first-touch path so mbind placement is preserved.
-            if (defer_hugetlb_population && !is_mmap_arena_allocation(ptr)) {
-                populate_hugetlb_mapping(ptr, mapped_size);
+            // Populate HugeTLB pages in parallel immediately before transfer-
+            // engine registration. NUMA mappings use node-local workers for
+            // each mbind region; direct mappings use the generic worker pool.
+            if (parallel_hugetlb_population) {
+                if (!seg_numa_nodes.empty()) {
+                    populate_hugetlb_numa_mapping(ptr, mapped_size,
+                                                  seg_numa_nodes);
+                } else if (!is_mmap_arena_allocation(ptr)) {
+                    populate_hugetlb_mapping(ptr, mapped_size);
+                }
             }
 
             auto mount_result =

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -817,8 +817,7 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
         }
 
         const bool parallel_hugetlb_population =
-            protocol == "rdma" && should_use_hugepage &&
-            get_hugepage_populate_mode() == HugepagePopulateMode::kParallel;
+            protocol == "rdma" && should_use_hugepage;
 
         while (global_segment_size > 0) {
             size_t segment_size = std::min(global_segment_size, max_mr_size);

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -826,6 +826,9 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
             size_t mapped_size = segment_size;
             void *ptr = nullptr;
             std::string seg_location = kWildcardLocation;
+            const bool defer_hugetlb_population =
+                should_use_hugepage && seg_numa_nodes.empty() &&
+                should_defer_hugetlb_population();
 
             if (!seg_numa_nodes.empty()) {
                 // NUMA-segmented allocation: contiguous VMA, per-region binding
@@ -841,7 +844,8 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
                 mapped_size =
                     align_up(segment_size, get_hugepage_size_from_env());
                 ptr = allocate_buffer_mmap_memory(mapped_size,
-                                                  get_hugepage_size_from_env());
+                                                  get_hugepage_size_from_env(),
+                                                  defer_hugetlb_population);
             } else {
                 ptr = allocate_buffer_allocator_memory(segment_size,
                                                        this->protocol);
@@ -874,6 +878,16 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
             } else {
                 segment_ptrs_.emplace_back(ptr);
             }
+
+            // The direct HugeTLB path can defer population so mmap() does not
+            // synchronously fault a very large Store segment. Populate it in
+            // parallel immediately before transfer-engine registration. Keep
+            // NUMA-segmented mappings on their existing ibv_reg_mr()-driven
+            // first-touch path so mbind placement is preserved.
+            if (defer_hugetlb_population && !is_mmap_arena_allocation(ptr)) {
+                populate_hugetlb_mapping(ptr, mapped_size);
+            }
+
             auto mount_result =
                 client_->MountSegment(ptr, mapped_size, protocol, seg_location);
             if (!mount_result.has_value()) {

--- a/mooncake-store/src/utils.cpp
+++ b/mooncake-store/src/utils.cpp
@@ -17,15 +17,18 @@
 
 #include <algorithm>
 #include <atomic>
-#include <memory>
-#include <random>
 #include <cerrno>
 #include <csignal>
+#include <cstdlib>
 #include <cstring>
-#include <sys/mman.h>
+#include <memory>
+#include <mutex>
 #include <numa.h>
 #include <numaif.h>
-#include <mutex>
+#include <random>
+#include <sys/mman.h>
+#include <thread>
+#include <vector>
 
 // Feature flag to enable/disable arena allocator. Disabled by default so the
 // library does not pre-map a large pool unless the operator opts in via gflag
@@ -237,7 +240,72 @@ static inline size_t mmap_map_size(size_t total_size, size_t hugepage_size) {
     return align_up(total_size, page_size);
 }
 
+bool should_defer_hugetlb_population() {
+    const char *populate_mode = std::getenv("MC_STORE_HUGEPAGE_POPULATE_MODE");
+    return get_hugepage_size_from_env() > 0 && populate_mode != nullptr &&
+           std::strcmp(populate_mode, "rdma") == 0;
+}
+
+namespace {
+
+void touch_mmap_pages(void *ptr, size_t map_size, size_t page_size) {
+    if (ptr == nullptr || map_size == 0 || page_size == 0) {
+        return;
+    }
+
+    const size_t page_count = (map_size + page_size - 1) / page_size;
+    const unsigned int hardware_threads = std::thread::hardware_concurrency();
+    size_t num_threads =
+        hardware_threads == 0 ? 1 : std::min<size_t>(hardware_threads, 16);
+    num_threads = std::min(num_threads, page_count);
+
+    auto *data = static_cast<volatile char *>(ptr);
+    if (num_threads <= 1) {
+        for (size_t page = 0; page < page_count; ++page) {
+            data[page * page_size] = 0;
+        }
+        data[map_size - 1] = 0;
+        return;
+    }
+
+    std::vector<std::thread> threads;
+    threads.reserve(num_threads);
+    const size_t pages_per_thread =
+        (page_count + num_threads - 1) / num_threads;
+    for (size_t thread_index = 0; thread_index < num_threads; ++thread_index) {
+        const size_t begin_page = thread_index * pages_per_thread;
+        const size_t end_page =
+            std::min(begin_page + pages_per_thread, page_count);
+        threads.emplace_back([data, page_size, begin_page, end_page]() {
+            for (size_t page = begin_page; page < end_page; ++page) {
+                data[page * page_size] = 0;
+            }
+        });
+    }
+    for (auto &thread : threads) {
+        thread.join();
+    }
+    data[map_size - 1] = 0;
+}
+
+}  // namespace
+
+void populate_hugetlb_mapping(void *ptr, size_t total_size) {
+    const size_t hugepage_size = get_hugepage_size_from_env();
+    if (ptr == nullptr || total_size == 0 || hugepage_size == 0) {
+        return;
+    }
+
+    touch_mmap_pages(ptr, mmap_map_size(total_size, hugepage_size),
+                     hugepage_size);
+}
+
 void *allocate_buffer_mmap_memory(size_t total_size, size_t alignment) {
+    return allocate_buffer_mmap_memory(total_size, alignment, false);
+}
+
+void *allocate_buffer_mmap_memory(size_t total_size, size_t alignment,
+                                  bool defer_hugetlb_population) {
     if (total_size == 0) {
         LOG(ERROR) << "Total size must be greater than 0 for mmap";
         return nullptr;
@@ -266,7 +334,12 @@ void *allocate_buffer_mmap_memory(size_t total_size, size_t alignment) {
     }
 
     // Traditional mmap allocation (fallback or arena disabled).
-    unsigned int flags = MAP_PRIVATE | MAP_ANONYMOUS | MAP_POPULATE;
+    const bool defer_direct_population =
+        defer_hugetlb_population && get_hugepage_size_from_env() > 0;
+    unsigned int flags = MAP_PRIVATE | MAP_ANONYMOUS;
+    if (!defer_direct_population) {
+        flags |= MAP_POPULATE;
+    }
     const size_t hugepage_size = get_hugepage_size_from_env(&flags);
     const size_t map_size = mmap_map_size(total_size, hugepage_size);
     const size_t guaranteed_alignment =
@@ -288,6 +361,11 @@ void *allocate_buffer_mmap_memory(size_t total_size, size_t alignment) {
 
     VLOG(1) << "Allocated " << total_size << " bytes via mmap() at " << ptr;
     return ptr;
+}
+
+bool is_mmap_arena_allocation(const void *ptr) {
+    return ptr != nullptr && g_mmap_arena && g_mmap_arena->isInitialized() &&
+           g_mmap_arena->owns(ptr);
 }
 
 void free_buffer_mmap_memory(void *ptr, size_t total_size) {

--- a/mooncake-store/src/utils.cpp
+++ b/mooncake-store/src/utils.cpp
@@ -240,13 +240,42 @@ static inline size_t mmap_map_size(size_t total_size, size_t hugepage_size) {
     return align_up(total_size, page_size);
 }
 
-bool should_defer_hugetlb_population() {
+HugepagePopulateMode get_hugepage_populate_mode() {
     const char *populate_mode = std::getenv("MC_STORE_HUGEPAGE_POPULATE_MODE");
-    return get_hugepage_size_from_env() > 0 && populate_mode != nullptr &&
-           std::strcmp(populate_mode, "rdma") == 0;
+    if (populate_mode == nullptr) {
+        return HugepagePopulateMode::kEager;
+    }
+    if (std::strcmp(populate_mode, "eager") == 0) {
+        return HugepagePopulateMode::kEager;
+    }
+    if (std::strcmp(populate_mode, "parallel") == 0) {
+        return HugepagePopulateMode::kParallel;
+    }
+    LOG(WARNING) << "Invalid MC_STORE_HUGEPAGE_POPULATE_MODE='" << populate_mode
+                 << "'; supported values: eager, parallel. "
+                 << "Using eager.";
+    return HugepagePopulateMode::kEager;
 }
 
 namespace {
+
+size_t touch_thread_count(size_t page_count) {
+    const unsigned int hardware_threads = std::thread::hardware_concurrency();
+    const size_t available_threads =
+        hardware_threads == 0 ? 1 : std::min<size_t>(hardware_threads, 16);
+    return std::min(available_threads, page_count);
+}
+
+void touch_page_range(volatile char *data, size_t page_size, size_t begin_page,
+                      size_t end_page, int numa_node) {
+    if (numa_node >= 0 && numa_run_on_node(numa_node) != 0) {
+        LOG(WARNING) << "Failed to bind HugeTLB population worker to NUMA node "
+                     << numa_node << ": " << std::strerror(errno);
+    }
+    for (size_t page = begin_page; page < end_page; ++page) {
+        data[page * page_size] = 0;
+    }
+}
 
 void touch_mmap_pages(void *ptr, size_t map_size, size_t page_size) {
     if (ptr == nullptr || map_size == 0 || page_size == 0) {
@@ -254,21 +283,15 @@ void touch_mmap_pages(void *ptr, size_t map_size, size_t page_size) {
     }
 
     const size_t page_count = (map_size + page_size - 1) / page_size;
-    const unsigned int hardware_threads = std::thread::hardware_concurrency();
-    size_t num_threads =
-        hardware_threads == 0 ? 1 : std::min<size_t>(hardware_threads, 16);
-    num_threads = std::min(num_threads, page_count);
+    const size_t num_threads = touch_thread_count(page_count);
 
     auto *data = static_cast<volatile char *>(ptr);
     if (num_threads <= 1) {
-        for (size_t page = 0; page < page_count; ++page) {
-            data[page * page_size] = 0;
-        }
-        data[map_size - 1] = 0;
+        touch_page_range(data, page_size, 0, page_count, -1);
         return;
     }
 
-    std::vector<std::thread> threads;
+    std::vector<std::jthread> threads;
     threads.reserve(num_threads);
     const size_t pages_per_thread =
         (page_count + num_threads - 1) / num_threads;
@@ -276,16 +299,60 @@ void touch_mmap_pages(void *ptr, size_t map_size, size_t page_size) {
         const size_t begin_page = thread_index * pages_per_thread;
         const size_t end_page =
             std::min(begin_page + pages_per_thread, page_count);
-        threads.emplace_back([data, page_size, begin_page, end_page]() {
-            for (size_t page = begin_page; page < end_page; ++page) {
-                data[page * page_size] = 0;
+        if (begin_page >= end_page) {
+            break;
+        }
+        threads.emplace_back(touch_page_range, data, page_size, begin_page,
+                             end_page, -1);
+    }
+}
+
+void touch_numa_mmap_pages(void *ptr, size_t map_size, size_t page_size,
+                           const std::vector<int> &numa_nodes) {
+    if (ptr == nullptr || map_size == 0 || page_size == 0 ||
+        numa_nodes.empty()) {
+        return;
+    }
+
+    const size_t node_count = numa_nodes.size();
+    if (map_size % node_count != 0 ||
+        (map_size / node_count) % page_size != 0) {
+        LOG(ERROR) << "Invalid NUMA HugeTLB mapping layout: size=" << map_size
+                   << ", page_size=" << page_size << ", nodes=" << node_count;
+        return;
+    }
+
+    const size_t region_size = map_size / node_count;
+    const size_t pages_per_region = region_size / page_size;
+    const size_t page_count = pages_per_region * node_count;
+    const size_t num_threads =
+        std::max(node_count, touch_thread_count(page_count));
+    const size_t base_threads_per_node = num_threads / node_count;
+    const size_t extra_threads = num_threads % node_count;
+
+    auto *data = static_cast<volatile char *>(ptr);
+    std::vector<std::jthread> threads;
+    threads.reserve(num_threads);
+    for (size_t node_index = 0; node_index < node_count; ++node_index) {
+        const size_t node_threads =
+            base_threads_per_node + (node_index < extra_threads ? 1 : 0);
+        const size_t pages_per_thread =
+            (pages_per_region + node_threads - 1) / node_threads;
+        const size_t region_begin_page = node_index * pages_per_region;
+        for (size_t thread_index = 0; thread_index < node_threads;
+             ++thread_index) {
+            const size_t begin_page =
+                region_begin_page + thread_index * pages_per_thread;
+            const size_t end_page =
+                std::min(begin_page + pages_per_thread,
+                         region_begin_page + pages_per_region);
+            if (begin_page >= end_page) {
+                continue;
             }
-        });
+            threads.emplace_back(touch_page_range, data, page_size, begin_page,
+                                 end_page, numa_nodes[node_index]);
+        }
     }
-    for (auto &thread : threads) {
-        thread.join();
-    }
-    data[map_size - 1] = 0;
 }
 
 }  // namespace
@@ -298,6 +365,17 @@ void populate_hugetlb_mapping(void *ptr, size_t total_size) {
 
     touch_mmap_pages(ptr, mmap_map_size(total_size, hugepage_size),
                      hugepage_size);
+}
+
+void populate_hugetlb_numa_mapping(void *ptr, size_t total_size,
+                                   const std::vector<int> &numa_nodes) {
+    const size_t hugepage_size = get_hugepage_size_from_env();
+    if (ptr == nullptr || total_size == 0 || hugepage_size == 0 ||
+        numa_nodes.empty()) {
+        return;
+    }
+
+    touch_numa_mmap_pages(ptr, total_size, hugepage_size, numa_nodes);
 }
 
 void *allocate_buffer_mmap_memory(size_t total_size, size_t alignment) {
@@ -450,10 +528,9 @@ void *allocate_buffer_numa_segments(size_t total_size,
         }
     }
 
-    // No explicit prefault needed — ibv_reg_mr() will call get_user_pages()
-    // which triggers page faults that respect the mbind NUMA policy.
-    // Pages are allocated directly on the target NUMA during MR registration,
-    // avoiding a redundant full-buffer traversal.
+    // Leave the mapping lazy. The caller may explicitly populate it with
+    // NUMA-local workers before registration; otherwise ibv_reg_mr() calls
+    // get_user_pages(), whose faults respect the mbind policy.
 
     LOG(INFO) << "Allocated NUMA-segmented buffer: " << map_size << " bytes, "
               << n << " regions, page_size=" << page_size << ", nodes=[" <<

--- a/mooncake-store/src/utils.cpp
+++ b/mooncake-store/src/utils.cpp
@@ -240,23 +240,6 @@ static inline size_t mmap_map_size(size_t total_size, size_t hugepage_size) {
     return align_up(total_size, page_size);
 }
 
-HugepagePopulateMode get_hugepage_populate_mode() {
-    const char *populate_mode = std::getenv("MC_STORE_HUGEPAGE_POPULATE_MODE");
-    if (populate_mode == nullptr) {
-        return HugepagePopulateMode::kEager;
-    }
-    if (std::strcmp(populate_mode, "eager") == 0) {
-        return HugepagePopulateMode::kEager;
-    }
-    if (std::strcmp(populate_mode, "parallel") == 0) {
-        return HugepagePopulateMode::kParallel;
-    }
-    LOG(WARNING) << "Invalid MC_STORE_HUGEPAGE_POPULATE_MODE='" << populate_mode
-                 << "'; supported values: eager, parallel. "
-                 << "Using eager.";
-    return HugepagePopulateMode::kEager;
-}
-
 namespace {
 
 size_t touch_thread_count(size_t page_count) {

--- a/mooncake-store/tests/mmap_arena_fallback_test.cpp
+++ b/mooncake-store/tests/mmap_arena_fallback_test.cpp
@@ -45,25 +45,10 @@ class MmapArenaFallbackTest : public ::testing::Test {
     void TearDown() override {
         unsetenv("MC_DISABLE_MMAP_ARENA");
         unsetenv("MC_MMAP_ARENA_POOL_SIZE");
-        unsetenv("MC_STORE_HUGEPAGE_POPULATE_MODE");
         unsetenv("MC_STORE_HUGEPAGE_SIZE");
         unsetenv("MC_STORE_USE_HUGEPAGE");
     }
 };
-
-TEST_F(MmapArenaFallbackTest, ParsesHugepagePopulateMode) {
-    unsetenv("MC_STORE_HUGEPAGE_POPULATE_MODE");
-    EXPECT_EQ(get_hugepage_populate_mode(), HugepagePopulateMode::kEager);
-
-    setenv("MC_STORE_HUGEPAGE_POPULATE_MODE", "eager", 1);
-    EXPECT_EQ(get_hugepage_populate_mode(), HugepagePopulateMode::kEager);
-
-    setenv("MC_STORE_HUGEPAGE_POPULATE_MODE", "parallel", 1);
-    EXPECT_EQ(get_hugepage_populate_mode(), HugepagePopulateMode::kParallel);
-
-    setenv("MC_STORE_HUGEPAGE_POPULATE_MODE", "invalid", 1);
-    EXPECT_EQ(get_hugepage_populate_mode(), HugepagePopulateMode::kEager);
-}
 
 TEST_F(MmapArenaFallbackTest, PopulateHugetlbMappingUsesConfiguredPageStride) {
     setenv("MC_STORE_USE_HUGEPAGE", "1", 1);

--- a/mooncake-store/tests/mmap_arena_fallback_test.cpp
+++ b/mooncake-store/tests/mmap_arena_fallback_test.cpp
@@ -3,6 +3,7 @@
 
 #include <glog/logging.h>
 #include <gtest/gtest.h>
+#include <sys/mman.h>
 
 #include <cstdint>
 #include <cstring>
@@ -42,9 +43,52 @@ class MmapArenaFallbackTest : public ::testing::Test {
     void TearDown() override {
         unsetenv("MC_DISABLE_MMAP_ARENA");
         unsetenv("MC_MMAP_ARENA_POOL_SIZE");
+        unsetenv("MC_STORE_HUGEPAGE_POPULATE_MODE");
+        unsetenv("MC_STORE_HUGEPAGE_SIZE");
         unsetenv("MC_STORE_USE_HUGEPAGE");
     }
 };
+
+TEST_F(MmapArenaFallbackTest,
+       DeferredHugetlbPopulationRequiresHugepagesAndRdmaMode) {
+    unsetenv("MC_STORE_USE_HUGEPAGE");
+    unsetenv("MC_STORE_HUGEPAGE_POPULATE_MODE");
+    EXPECT_FALSE(should_defer_hugetlb_population());
+
+    setenv("MC_STORE_HUGEPAGE_POPULATE_MODE", "rdma", 1);
+    EXPECT_FALSE(should_defer_hugetlb_population());
+
+    setenv("MC_STORE_USE_HUGEPAGE", "1", 1);
+    EXPECT_TRUE(should_defer_hugetlb_population());
+
+    setenv("MC_STORE_HUGEPAGE_POPULATE_MODE", "mmap", 1);
+    EXPECT_FALSE(should_defer_hugetlb_population());
+}
+
+TEST_F(MmapArenaFallbackTest, PopulateHugetlbMappingUsesConfiguredPageStride) {
+    setenv("MC_STORE_USE_HUGEPAGE", "1", 1);
+    setenv("MC_STORE_HUGEPAGE_SIZE", "2MB", 1);
+
+    constexpr size_t kPageCount = 3;
+    constexpr size_t kMapSize = kPageCount * SZ_2MB;
+    void* mapping = mmap(nullptr, kMapSize, PROT_READ | PROT_WRITE,
+                         MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    ASSERT_NE(mapping, MAP_FAILED);
+
+    auto* bytes = static_cast<unsigned char*>(mapping);
+    for (size_t page = 0; page < kPageCount; ++page) {
+        bytes[page * SZ_2MB] = 0xAB;
+    }
+    bytes[kMapSize - 1] = 0xAB;
+
+    populate_hugetlb_mapping(mapping, kMapSize);
+
+    for (size_t page = 0; page < kPageCount; ++page) {
+        EXPECT_EQ(bytes[page * SZ_2MB], 0);
+    }
+    EXPECT_EQ(bytes[kMapSize - 1], 0);
+    EXPECT_EQ(munmap(mapping, kMapSize), 0);
+}
 
 TEST_F(MmapArenaFallbackTest, ArenaInitFailureIsStickyForProcessLifetime) {
     unsetenv("MC_DISABLE_MMAP_ARENA");

--- a/mooncake-store/tests/mmap_arena_fallback_test.cpp
+++ b/mooncake-store/tests/mmap_arena_fallback_test.cpp
@@ -3,6 +3,7 @@
 
 #include <glog/logging.h>
 #include <gtest/gtest.h>
+#include <numa.h>
 #include <sys/mman.h>
 
 #include <cstdint>
@@ -10,6 +11,7 @@
 #include <cstdlib>
 #include <fstream>
 #include <string>
+#include <vector>
 
 #include "utils.h"
 
@@ -49,20 +51,18 @@ class MmapArenaFallbackTest : public ::testing::Test {
     }
 };
 
-TEST_F(MmapArenaFallbackTest,
-       DeferredHugetlbPopulationRequiresHugepagesAndRdmaMode) {
-    unsetenv("MC_STORE_USE_HUGEPAGE");
+TEST_F(MmapArenaFallbackTest, ParsesHugepagePopulateMode) {
     unsetenv("MC_STORE_HUGEPAGE_POPULATE_MODE");
-    EXPECT_FALSE(should_defer_hugetlb_population());
+    EXPECT_EQ(get_hugepage_populate_mode(), HugepagePopulateMode::kEager);
 
-    setenv("MC_STORE_HUGEPAGE_POPULATE_MODE", "rdma", 1);
-    EXPECT_FALSE(should_defer_hugetlb_population());
+    setenv("MC_STORE_HUGEPAGE_POPULATE_MODE", "eager", 1);
+    EXPECT_EQ(get_hugepage_populate_mode(), HugepagePopulateMode::kEager);
 
-    setenv("MC_STORE_USE_HUGEPAGE", "1", 1);
-    EXPECT_TRUE(should_defer_hugetlb_population());
+    setenv("MC_STORE_HUGEPAGE_POPULATE_MODE", "parallel", 1);
+    EXPECT_EQ(get_hugepage_populate_mode(), HugepagePopulateMode::kParallel);
 
-    setenv("MC_STORE_HUGEPAGE_POPULATE_MODE", "mmap", 1);
-    EXPECT_FALSE(should_defer_hugetlb_population());
+    setenv("MC_STORE_HUGEPAGE_POPULATE_MODE", "invalid", 1);
+    EXPECT_EQ(get_hugepage_populate_mode(), HugepagePopulateMode::kEager);
 }
 
 TEST_F(MmapArenaFallbackTest, PopulateHugetlbMappingUsesConfiguredPageStride) {
@@ -79,15 +79,50 @@ TEST_F(MmapArenaFallbackTest, PopulateHugetlbMappingUsesConfiguredPageStride) {
     for (size_t page = 0; page < kPageCount; ++page) {
         bytes[page * SZ_2MB] = 0xAB;
     }
-    bytes[kMapSize - 1] = 0xAB;
 
     populate_hugetlb_mapping(mapping, kMapSize);
 
     for (size_t page = 0; page < kPageCount; ++page) {
         EXPECT_EQ(bytes[page * SZ_2MB], 0);
     }
-    EXPECT_EQ(bytes[kMapSize - 1], 0);
     EXPECT_EQ(munmap(mapping, kMapSize), 0);
+}
+
+TEST_F(MmapArenaFallbackTest, PopulateNumaHugetlbMappingTouchesEveryRegion) {
+    if (numa_available() < 0) {
+        GTEST_SKIP() << "NUMA is unavailable";
+    }
+
+    setenv("MC_STORE_USE_HUGEPAGE", "1", 1);
+    setenv("MC_STORE_HUGEPAGE_SIZE", "2MB", 1);
+
+    std::vector<int> numa_nodes;
+    for (int node = 0; node <= numa_max_node() && numa_nodes.size() < 2;
+         ++node) {
+        if (numa_bitmask_isbitset(numa_all_nodes_ptr, node)) {
+            numa_nodes.push_back(node);
+        }
+    }
+    ASSERT_FALSE(numa_nodes.empty());
+
+    constexpr size_t kPagesPerRegion = 2;
+    const size_t page_count = kPagesPerRegion * numa_nodes.size();
+    const size_t map_size = page_count * SZ_2MB;
+    void* mapping = mmap(nullptr, map_size, PROT_READ | PROT_WRITE,
+                         MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    ASSERT_NE(mapping, MAP_FAILED);
+
+    auto* bytes = static_cast<unsigned char*>(mapping);
+    for (size_t page = 0; page < page_count; ++page) {
+        bytes[page * SZ_2MB] = 0xAB;
+    }
+
+    populate_hugetlb_numa_mapping(mapping, map_size, numa_nodes);
+
+    for (size_t page = 0; page < page_count; ++page) {
+        EXPECT_EQ(bytes[page * SZ_2MB], 0);
+    }
+    EXPECT_EQ(munmap(mapping, map_size), 0);
 }
 
 TEST_F(MmapArenaFallbackTest, ArenaInitFailureIsStickyForProcessLifetime) {

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
@@ -18,10 +18,8 @@
 #include <sys/mman.h>
 #include <sys/time.h>
 
-#include <algorithm>
 #include <cassert>
 #include <chrono>
-#include <cctype>
 #include <cstddef>
 #include <cstdlib>
 #include <future>
@@ -42,18 +40,6 @@ namespace mooncake {
 
 static bool MCIbRelaxedOrderingEnabled = false;
 static int MCIbRelaxedOrderingMode = 2;
-
-static bool envVarEnabled(const char *name) {
-    const char *value = std::getenv(name);
-    if (value == nullptr) {
-        return false;
-    }
-    std::string normalized(value);
-    std::transform(normalized.begin(), normalized.end(), normalized.begin(),
-                   [](unsigned char c) { return std::tolower(c); });
-    return normalized == "1" || normalized == "true" || normalized == "yes" ||
-           normalized == "on";
-}
 
 static std::string resolveBufferLocation(
     const TransferMetadata::BufferDesc &buffer, uint64_t offset) {
@@ -239,9 +225,6 @@ int RdmaTransport::registerLocalMemoryInternal(void *addr, size_t length,
     bool do_pre_touch = context_list_.size() > 0 &&
                         std::thread::hardware_concurrency() >= 4 &&
                         length >= (size_t)4 * 1024 * 1024 * 1024;
-    if (do_pre_touch && envVarEnabled("MC_DISABLE_RDMA_PRE_TOUCH")) {
-        do_pre_touch = false;
-    }
     if (do_pre_touch) {
         // Parallel Pre-touch the memory to speedup the registration process.
         int ret = preTouchMemory(addr, length);

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
@@ -18,8 +18,10 @@
 #include <sys/mman.h>
 #include <sys/time.h>
 
+#include <algorithm>
 #include <cassert>
 #include <chrono>
+#include <cctype>
 #include <cstddef>
 #include <cstdlib>
 #include <future>
@@ -40,6 +42,18 @@ namespace mooncake {
 
 static bool MCIbRelaxedOrderingEnabled = false;
 static int MCIbRelaxedOrderingMode = 2;
+
+static bool envVarEnabled(const char *name) {
+    const char *value = std::getenv(name);
+    if (value == nullptr) {
+        return false;
+    }
+    std::string normalized(value);
+    std::transform(normalized.begin(), normalized.end(), normalized.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    return normalized == "1" || normalized == "true" || normalized == "yes" ||
+           normalized == "on";
+}
 
 static std::string resolveBufferLocation(
     const TransferMetadata::BufferDesc &buffer, uint64_t offset) {
@@ -225,7 +239,7 @@ int RdmaTransport::registerLocalMemoryInternal(void *addr, size_t length,
     bool do_pre_touch = context_list_.size() > 0 &&
                         std::thread::hardware_concurrency() >= 4 &&
                         length >= (size_t)4 * 1024 * 1024 * 1024;
-    if (do_pre_touch && Environ::GetBool("MC_DISABLE_RDMA_PRE_TOUCH", false)) {
+    if (do_pre_touch && envVarEnabled("MC_DISABLE_RDMA_PRE_TOUCH")) {
         do_pre_touch = false;
     }
     if (do_pre_touch) {

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
@@ -225,6 +225,9 @@ int RdmaTransport::registerLocalMemoryInternal(void *addr, size_t length,
     bool do_pre_touch = context_list_.size() > 0 &&
                         std::thread::hardware_concurrency() >= 4 &&
                         length >= (size_t)4 * 1024 * 1024 * 1024;
+    if (do_pre_touch && Environ::GetBool("MC_DISABLE_RDMA_PRE_TOUCH", false)) {
+        do_pre_touch = false;
+    }
     if (do_pre_touch) {
         // Parallel Pre-touch the memory to speedup the registration process.
         int ret = preTouchMemory(addr, length);


### PR DESCRIPTION
## Description

Large HugeTLB-backed Store segments can spend most of startup faulting pages
before RDMA registration. This PR makes parallel population the default for
RDMA Store segments using HugeTLB; no population-mode environment variable is
required.

Allocation remains lazy, then the Store faults one byte per configured
hugepage with up to 16 CPU workers immediately before `MountSegment()`.

Both Store allocation layouts are covered:

- Direct `mmap()` mappings use a generic parallel worker pool.
- NUMA-segmented mappings retain their existing `mbind()` layout. Each worker
  is scheduled on the NUMA node associated with its region before touching
  pages, preserving first-touch placement.

Non-RDMA protocols and non-HugeTLB mappings keep their existing behavior. The
mmap arena also retains its eager `MAP_POPULATE` behavior, and the existing
two-argument `allocate_buffer_mmap_memory()` symbol is preserved.

The transfer engine is unchanged: after Store population, the existing RDMA
pre-touch and automatic parallel MR registration logic still run under their
original conditions.

The same direct-mapping strategy was previously measured on qjh002 with a
500 GiB Store, reserved 2 MiB hugepages, and RDMA device `mlx5_4`:

- `MAP_POPULATE` baseline: about 55.3 seconds during setup
- Deferred parallel population: about 7.1 seconds during setup
- Deferred-mode close: about 1.2 seconds

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other

## How Has This Been Tested?

On Ubuntu 22.04 / GCC 11.4:

```bash
cmake --build build \
  --target mmap_arena_fallback_test mooncake_store rdma_transport \
           mooncake_master \
  -j16

./build/mooncake-store/tests/mmap_arena_fallback_test
```

All selected targets link successfully and all 7 tests pass, including the
NUMA-region population test. The NUMA path was validated on qjh002, which has
two CPU/NIC NUMA nodes. The host currently has no reserved HugeTLB pages, so the
new NUMA scheduling logic was exercised with an anonymous test mapping; the
500 GiB performance numbers above are from the earlier HugeTLB benchmark.

Also run:

```bash
clang-format --dry-run --Werror <changed C++ files>
git diff --check
```

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.
