### PR TITLE
[TE] Make ThreadLocalStorage per-instance and reclaim per-thread holders

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/common/concurrent/thread_local_storage.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/concurrent/thread_local_storage.h
@@ -15,68 +15,176 @@
 #ifndef TENT_THREAD_LOCAL_STORAGE_H
 #define TENT_THREAD_LOCAL_STORAGE_H
 
+#include <atomic>
+#include <cstdint>
 #include <functional>
+#include <memory>
 #include <mutex>
-#include <thread>
+#include <unordered_map>
 #include <unordered_set>
 
 namespace mooncake {
 namespace tent {
 
+namespace detail {
+// Hoisted out of the class template so ids are unique across ALL
+// ThreadLocalStorage instantiations, not just within one T. The per-thread
+// maps are per-T, so per-T uniqueness would suffice today — global
+// uniqueness removes the aliasing hazard if the per-thread state is ever
+// shared across instantiations.
+inline uint64_t nextThreadLocalStorageId() {
+    static std::atomic<uint64_t> counter{1};
+    return counter.fetch_add(1, std::memory_order_relaxed);
+}
+}  // namespace detail
+
+// Per-instance thread-local storage (#2717).
+//
+// Each (ThreadLocalStorage instance, thread) pair owns a distinct T. The
+// previous implementation kept one `thread_local` slot per template
+// instantiation, so all instances of ThreadLocalStorage<T> in a process
+// aliased each other's per-thread state, and its heap-allocated holders were
+// never destroyed (the deregistration path was unreachable).
+//
+// Lifetime rules:
+// - A thread's T values are destroyed when the thread exits.
+// - Destroying the storage does not destroy other threads' values; they are
+//   orphaned (at most one T per thread per destroyed storage) and reclaimed
+//   at those threads' exit. Instance ids are process-monotonic and never
+//   reused, so an orphaned value can never be served to a new instance that
+//   happens to reuse the same address.
+// - Both teardown orders are safe: a thread exiting while the owner is alive
+//   deregisters its value from the owner's registry; an owner destroyed
+//   while threads are alive marks the jointly-owned control block dead, and
+//   those threads skip deregistration at exit. Orphans are additionally
+//   swept opportunistically: the next first-use get() of ANY instance on
+//   that thread reclaims all of the thread's dead-owner values, so orphan
+//   count stays bounded by live instances even under storage churn.
+//
+// Precondition: callers must keep the storage alive across every get() /
+// forEach() call (the usual member-of-owner pattern satisfies this); the
+// destructor may run concurrently only with other threads' exits, not with
+// their accesses.
+//
+// Concurrency:
+// - get() is lock-free after the first call per (instance, thread): one
+//   thread_local access plus an id compare on the hot path.
+// - forEach() runs under the registry mutex and visits exactly the values of
+//   live registered threads. It synchronizes registry membership only — if
+//   owning threads mutate their T concurrently, the callback observes those
+//   fields with whatever synchronization T itself provides (unchanged from
+//   the previous implementation).
 template <typename T>
 class ThreadLocalStorage {
    public:
     ThreadLocalStorage() = default;
-    ~ThreadLocalStorage() = default;
 
-    // Disable copy/move
+    ~ThreadLocalStorage() {
+        std::lock_guard<std::mutex> lock(control_->mutex);
+        control_->owner_alive.store(false, std::memory_order_release);
+        control_->values.clear();
+    }
+
     ThreadLocalStorage(const ThreadLocalStorage&) = delete;
     ThreadLocalStorage& operator=(const ThreadLocalStorage&) = delete;
 
-    // Access the thread-local instance (lock-free)
+    // Access the calling thread's instance, constructing it on first use.
     T& get() {
-        if (!instance_) {
-            instance_ = new InstanceHolder(this);
+        ThreadState& state = threadState();
+        if (state.cached_id == id_) return *state.cached_value;
+        auto it = state.nodes.find(id_);
+        if (it == state.nodes.end()) {
+            // First use of this instance on this thread — the cold path.
+            // Piggyback a sweep of values whose owners are gone, so a
+            // long-lived thread does not accumulate one orphan per
+            // destroyed storage it ever touched (their T contents would
+            // otherwise stay pinned until thread exit).
+            sweepDeadNodes(state);
+            it = state.nodes.try_emplace(id_).first;
+            ThreadNode& node = it->second;
+            node.control = control_;
+            // The caller holds a reference to *this, so the owner is alive
+            // and registration cannot race ~ThreadLocalStorage's clear().
+            std::lock_guard<std::mutex> lock(control_->mutex);
+            control_->values.insert(&node.value);
         }
-        return instance_->value;
+        state.cached_id = id_;
+        state.cached_value = &it->second.value;
+        return *state.cached_value;
     }
 
-    // Safe iteration over all instances (with locking)
+    // Safe iteration over the values of all live threads that have called
+    // get() on this instance.
     void forEach(const std::function<void(T&)>& fn) {
-        std::lock_guard<std::mutex> lock(global_mutex_);
-        for (auto* inst : instances_) {
-            fn(inst->value);
+        std::lock_guard<std::mutex> lock(control_->mutex);
+        for (T* value : control_->values) {
+            fn(*value);
         }
     }
 
    private:
-    struct InstanceHolder {
-        T value;
-        ThreadLocalStorage<T>* owner;
+    // Shared between the owner and every thread node so that whichever side
+    // is torn down last still has a valid registry (or a dead flag) to look
+    // at.
+    struct ControlBlock {
+        std::mutex mutex;
+        std::unordered_set<T*> values;
+        // Atomic so the orphan sweep can test liveness without taking the
+        // mutex of every node it scans.
+        std::atomic<bool> owner_alive{true};
+    };
 
-        InstanceHolder(ThreadLocalStorage<T>* owner) : owner(owner) {
-            std::lock_guard<std::mutex> lock(owner->global_mutex_);
-            owner->instances_.insert(this);
-        }
+    struct ThreadNode {
+        T value{};
+        std::shared_ptr<ControlBlock> control;
 
-        ~InstanceHolder() {
-            std::lock_guard<std::mutex> lock(owner->global_mutex_);
-            owner->instances_.erase(this);
+        ThreadNode() = default;
+        ThreadNode(const ThreadNode&) = delete;
+        ThreadNode& operator=(const ThreadNode&) = delete;
+
+        ~ThreadNode() {
+            if (!control) return;
+            std::lock_guard<std::mutex> lock(control->mutex);
+            if (control->owner_alive.load(std::memory_order_acquire))
+                control->values.erase(&value);
         }
     };
 
-    // Thread-local pointer to the per-thread instance
-    thread_local static InstanceHolder* instance_;
+    struct ThreadState {
+        // Node-based map: ThreadNode addresses are stable across rehash,
+        // which the registry and the one-entry cache below rely on.
+        std::unordered_map<uint64_t, ThreadNode> nodes;
+        // One-entry cache so the common get() is a single thread_local
+        // access plus a compare. Entries live until thread exit, so the
+        // cached pointer cannot dangle while the id matches.
+        uint64_t cached_id = 0;  // ids start at 1; 0 never matches
+        T* cached_value = nullptr;
+    };
 
-    // Global list of all thread instances
-    std::unordered_set<InstanceHolder*> instances_;
-    std::mutex global_mutex_;
+    static void sweepDeadNodes(ThreadState& state) {
+        for (auto it = state.nodes.begin(); it != state.nodes.end();) {
+            if (!it->second.control->owner_alive.load(
+                    std::memory_order_acquire)) {
+                if (state.cached_value == &it->second.value) {
+                    state.cached_id = 0;
+                    state.cached_value = nullptr;
+                }
+                // ~ThreadNode sees the dead owner and skips the registry.
+                it = state.nodes.erase(it);
+            } else {
+                ++it;
+            }
+        }
+    }
+
+    static ThreadState& threadState() {
+        thread_local ThreadState state;
+        return state;
+    }
+
+    const uint64_t id_ = detail::nextThreadLocalStorageId();
+    std::shared_ptr<ControlBlock> control_ = std::make_shared<ControlBlock>();
 };
-
-// Definition of thread_local variable (must be outside the class)
-template <typename T>
-thread_local typename ThreadLocalStorage<T>::InstanceHolder*
-    ThreadLocalStorage<T>::instance_ = nullptr;
 
 }  // namespace tent
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tent/include/tent/common/concurrent/thread_local_storage.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/concurrent/thread_local_storage.h
@@ -163,8 +163,13 @@ class ThreadLocalStorage {
 
     static void sweepDeadNodes(ThreadState& state) {
         for (auto it = state.nodes.begin(); it != state.nodes.end();) {
-            if (!it->second.control->owner_alive.load(
-                    std::memory_order_acquire)) {
+            // A null control cannot be observed today (the sweep runs before
+            // try_emplace on the same thread, and control is assigned
+            // immediately after emplace by a nothrow shared_ptr copy), but
+            // check it for consistency with ~ThreadNode and robustness to
+            // reordering.
+            if (!it->second.control || !it->second.control->owner_alive.load(
+                                           std::memory_order_acquire)) {
                 if (state.cached_value == &it->second.value) {
                     state.cached_id = 0;
                     state.cached_value = nullptr;

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -41,6 +41,12 @@ target_include_directories(promotion_policy_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME promotion_policy_test COMMAND promotion_policy_test)
 
+add_executable(thread_local_storage_test thread_local_storage_test.cpp)
+target_link_libraries(thread_local_storage_test PRIVATE gtest gtest_main)
+target_include_directories(thread_local_storage_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+add_test(NAME thread_local_storage_test COMMAND thread_local_storage_test)
+
 add_executable(tent_ip_utils_test ip_utils_test.cpp)
 target_link_libraries(tent_ip_utils_test PRIVATE tent_common gtest gtest_main)
 target_include_directories(tent_ip_utils_test

--- a/mooncake-transfer-engine/tent/tests/thread_local_storage_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/thread_local_storage_test.cpp
@@ -225,7 +225,9 @@ TEST(ThreadLocalStorageTest, HotPathMicrobench) {
     // Wall-clock assertions flake under sanitizers (TSAN alone is ~14x);
     // elsewhere keep a loose ceiling that still catches syscall- or
     // contention-class regressions on the hot path.
-    if (!kSanitized) EXPECT_LT(ns, 100.0);
+    if (!kSanitized) {
+        EXPECT_LT(ns, 100.0);
+    }
 }
 
 }  // namespace tent

--- a/mooncake-transfer-engine/tent/tests/thread_local_storage_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/thread_local_storage_test.cpp
@@ -1,0 +1,232 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Regression tests for #2717: ThreadLocalStorage used one `thread_local`
+// slot per template instantiation (all instances aliased each other's
+// per-thread state) and never destroyed its per-thread holders (the
+// deregistration path was unreachable). These tests pin the per-instance
+// semantics and both teardown orders; run them under ASAN/LSAN to verify
+// the holder-leak fix and the owner-destroyed-first ordering.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include "tent/common/concurrent/thread_local_storage.h"
+
+namespace mooncake {
+namespace tent {
+
+namespace {
+struct Cache {
+    int value = 0;
+};
+
+size_t countValues(ThreadLocalStorage<Cache>& storage) {
+    size_t n = 0;
+    storage.forEach([&](Cache&) { n++; });
+    return n;
+}
+}  // namespace
+
+// The original aliasing bug: two instances in the same thread must own
+// distinct per-thread values.
+TEST(ThreadLocalStorageTest, InstancesDoNotAlias) {
+    ThreadLocalStorage<Cache> a;
+    ThreadLocalStorage<Cache> b;
+    a.get().value = 42;
+    EXPECT_EQ(b.get().value, 0);
+    EXPECT_NE(&a.get(), &b.get());
+    b.get().value = 7;
+    EXPECT_EQ(a.get().value, 42);
+}
+
+// Thread exits while the owner is alive: the value deregisters (forEach no
+// longer sees it) and its memory is reclaimed (LSAN would flag the previous
+// implementation, which leaked one holder per thread per instantiation).
+TEST(ThreadLocalStorageTest, ThreadExitDeregistersAndReclaims) {
+    ThreadLocalStorage<Cache> storage;
+    storage.get().value = 1;  // main thread's value
+    EXPECT_EQ(countValues(storage), 1u);
+
+    std::thread t([&] {
+        storage.get().value = 2;
+        EXPECT_EQ(countValues(storage), 2u);
+    });
+    t.join();
+
+    EXPECT_EQ(countValues(storage), 1u);  // worker's value deregistered
+    EXPECT_EQ(storage.get().value, 1);    // main's value untouched
+}
+
+// Owner destroyed while a using thread is still alive: the thread's later
+// exit must not touch the dead owner (the jointly-owned control block keeps
+// the registry memory valid; ASAN pins this ordering).
+TEST(ThreadLocalStorageTest, OwnerDestroyedBeforeThreadExitIsSafe) {
+    std::atomic<bool> used{false};
+    std::atomic<bool> release{false};
+    auto storage = std::make_unique<ThreadLocalStorage<Cache>>();
+    std::thread t([&] {
+        storage->get().value = 7;
+        used.store(true);
+        while (!release.load()) std::this_thread::yield();
+        // Thread exit here runs the node destructor against a dead owner.
+    });
+    while (!used.load()) std::this_thread::yield();
+    storage.reset();  // owner gone first
+    release.store(true);
+    t.join();
+}
+
+// Instance ids are never reused: a new storage that may occupy the same
+// address as a destroyed one must not see the old orphaned value.
+TEST(ThreadLocalStorageTest, DestroyedInstanceStateIsNotResurrected) {
+    for (int round = 0; round < 8; ++round) {
+        auto storage = std::make_unique<ThreadLocalStorage<Cache>>();
+        EXPECT_EQ(storage->get().value, 0) << "round " << round;
+        storage->get().value = 100 + round;
+    }
+}
+
+// forEach synchronizes registry membership: it sees exactly the values of
+// live threads that used this instance.
+TEST(ThreadLocalStorageTest, ForEachVisitsExactlyLiveRegisteredValues) {
+    ThreadLocalStorage<Cache> storage;
+    constexpr int kThreads = 8;
+    std::atomic<int> ready{0};
+    std::atomic<bool> release{false};
+    std::vector<std::thread> threads;
+    for (int i = 0; i < kThreads; ++i) {
+        threads.emplace_back([&, i] {
+            storage.get().value = i + 1;
+            ready++;
+            while (!release.load()) std::this_thread::yield();
+        });
+    }
+    while (ready.load() < kThreads) std::this_thread::yield();
+
+    int sum = 0;
+    size_t n = 0;
+    storage.forEach([&](Cache& c) {
+        sum += c.value;
+        n++;
+    });
+    EXPECT_EQ(n, (size_t)kThreads);
+    EXPECT_EQ(sum, kThreads * (kThreads + 1) / 2);
+
+    release.store(true);
+    for (auto& t : threads) t.join();
+    EXPECT_EQ(countValues(storage), 0u);
+}
+
+// Concurrent churn: threads exercising get() across shared storages while
+// other storages are created/destroyed, with forEach mixed in. Run under
+// TSAN/ASAN for the full effect; asserts basic integrity without them.
+TEST(ThreadLocalStorageTest, ConcurrentChurnStress) {
+    constexpr int kThreads = 8;
+    constexpr int kIterations = 2000;
+    ThreadLocalStorage<Cache> shared_a;
+    ThreadLocalStorage<Cache> shared_b;
+    std::atomic<uint64_t> failures{0};
+    std::vector<std::thread> threads;
+    for (int i = 0; i < kThreads; ++i) {
+        threads.emplace_back([&, i] {
+            for (int iter = 0; iter < kIterations; ++iter) {
+                shared_a.get().value = i;
+                shared_b.get().value = -i;
+                if (shared_a.get().value != i) failures++;
+                if (shared_b.get().value != -i) failures++;
+                // Thread-private storages churn creation/destruction.
+                ThreadLocalStorage<Cache> ephemeral;
+                ephemeral.get().value = iter;
+                if (ephemeral.get().value != iter) failures++;
+                if (iter % 64 == 0) {
+                    shared_a.forEach([](Cache&) {});
+                }
+            }
+        });
+    }
+    for (auto& t : threads) t.join();
+    EXPECT_EQ(failures.load(), 0u);
+    EXPECT_EQ(countValues(shared_a), 0u);
+}
+
+namespace {
+struct Counted {
+    static std::atomic<int> live;
+    int value = 0;
+    Counted() { live.fetch_add(1, std::memory_order_relaxed); }
+    ~Counted() { live.fetch_sub(1, std::memory_order_relaxed); }
+};
+std::atomic<int> Counted::live{0};
+}  // namespace
+
+// Storage churn on a long-lived thread: values of destroyed storages must be
+// swept by the next first-use get() rather than accumulating until thread
+// exit (one orphaned T — pinning its contents — per destroyed storage).
+TEST(ThreadLocalStorageTest, OrphanedValuesSweptOnInstanceChurn) {
+    constexpr int kRounds = 1000;
+    for (int i = 0; i < kRounds; ++i) {
+        ThreadLocalStorage<Counted> storage;
+        storage.get().value = i;
+        // Previous round's orphan must have been swept by this round's
+        // first-use get(): at most this round's value plus one not-yet-swept
+        // orphan may be alive.
+        ASSERT_LE(Counted::live.load(), 2) << "round " << i;
+    }
+}
+
+// Informational: hot-path cost of get(). The remote-desc cache consults this
+// on every transfer submit, so the common case must stay a thread_local
+// access plus a compare.
+TEST(ThreadLocalStorageTest, HotPathMicrobench) {
+    ThreadLocalStorage<Cache> storage;
+    storage.get().value = 1;
+    constexpr uint64_t kOps = 20'000'000;
+    volatile int sink = 0;
+    auto t0 = std::chrono::steady_clock::now();
+    for (uint64_t i = 0; i < kOps; ++i) {
+        sink += storage.get().value;
+    }
+    auto t1 = std::chrono::steady_clock::now();
+    double ns =
+        (double)std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0)
+            .count() /
+        (double)kOps;
+    printf("get_hot_path_ns_per_op %.2f\n", ns);
+    (void)sink;
+#if defined(__SANITIZE_THREAD__) || defined(__SANITIZE_ADDRESS__)
+    constexpr bool kSanitized = true;
+#elif defined(__has_feature)
+#if __has_feature(thread_sanitizer) || __has_feature(address_sanitizer)
+    constexpr bool kSanitized = true;
+#else
+    constexpr bool kSanitized = false;
+#endif
+#else
+    constexpr bool kSanitized = false;
+#endif
+    // Wall-clock assertions flake under sanitizers (TSAN alone is ~14x);
+    // elsewhere keep a loose ceiling that still catches syscall- or
+    // contention-class regressions on the hot path.
+    if (!kSanitized) EXPECT_LT(ns, 100.0);
+}
+
+}  // namespace tent
+}  // namespace mooncake


### PR DESCRIPTION
## Description

Fixes #2717.

`ThreadLocalStorage<T>` kept its thread-local slot as a `thread_local static` member of the class template — one slot per template *instantiation*, shared by every instance in the process — so two instances (e.g. two engines' `SegmentManager::tl_remote_cache_`) aliased each other's per-thread state: whichever instance first called `get()` on a thread owned the slot, and the second instance read/wrote the first one's cache. The slot was also a raw pointer to a heap holder that nothing ever deleted, so the deregistration logic in the holder's destructor was unreachable and every thread leaked one holder per instantiation (`ASAN: 288 bytes in 18 allocations` in the new test binary against the old header).

This reworks the storage to be genuinely per-instance:

- **Per-instance keying**: the per-thread state is a map keyed by a process-monotonic instance id (ids are never reused, so a destroyed-then-reallocated storage can never be served a stale entry), with a one-entry cache in front so the common `get()` stays one `thread_local` access plus an id compare.
- **Owned values**: a thread's `T` values are owned by that thread's map and destroyed at thread exit — no leaked holders.
- **Both teardown orders are safe** via a control block jointly owned by the storage and every thread node: a thread exiting while the owner is alive deregisters from the registry (the path that was unreachable before); an owner destroyed while threads live marks the block dead, and those threads skip the registry at exit.
- **Orphans are swept, not accumulated**: an adversarial-review pass on the first draft found that a long-lived thread would retain one orphaned `T` per destroyed storage until thread exit — under engine create/destroy churn that silently pins one `RemoteSegmentCache` (and every `SegmentDescRef` snapshot inside it) per destroyed engine per thread. The cold path of `get()` (first use of an instance on a thread) now sweeps all of the thread's dead-owner values, so orphan count is bounded by live instances; a churn regression test pins this (1000 create/use/destroy rounds, ≤2 live values throughout).
- **`forEach()`** runs under the registry mutex and visits exactly the values of live registered threads (previously it could visit holders of exited threads, and its cleanup half was dead code). It still synchronizes membership only, not `T`'s contents — unchanged semantics for the existing caller.

The public API (`get()`, `forEach(const std::function<void(T&)>&)`) is unchanged; `SegmentManager` needs no modification.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

Multi-core x86_64 Linux test host with a recent GCC toolchain.

**Test commands:**
```bash
cmake -S . -B build-tls-normal -DWITH_STORE=OFF -DWITH_STORE_RUST=OFF \
  -DUSE_TENT=ON -DUSE_CUDA=OFF -DBUILD_UNIT_TESTS=ON
cmake --build build-tls-normal --target thread_local_storage_test -j16
build-tls-normal/mooncake-transfer-engine/tent/tests/thread_local_storage_test
ctest --test-dir build-tls-normal/mooncake-transfer-engine/tent/tests -j1
# Separate Debug builds used -fsanitize=address,undefined and -fsanitize=thread.
```

**Results:**

| build | result |
|---|---|
| new impl, `thread_local_storage_test` | **8/8 × 100** |
| new impl, ASAN/UBSAN/LSAN | **8/8 × 50**, no reports |
| new impl, TSAN | **8/8 × 50**, 0 warnings |
| full TENT suite (includes `SegmentManager` integration via `tl_remote_cache_`) | **23/23** |
| **old impl + same test binary** (control) | **5/7 fail** of the applicable tests (aliasing, thread-exit deregistration, instance resurrection, forEach liveness, churn) + **LSAN: 288 B / 18 allocs leaked** |

`get()` hot path at `-O3`: 0.33–0.41 ns before → 0.66–0.69 ns after (+~0.3 ns; the caller's next step in `getRemoteCached()` is a `clock_gettime` and a map lookup, so this is noise). The orphan sweep runs only on the first-use cold path. The unit test pins a loose ceiling (skipped under sanitizers, where wall-clock asserts flake) to catch lock-on-hot-path-class regressions.

- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual testing done (sanitizer matrix above)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] Focused pre-commit hooks pass on every touched C/C++ file; the full-file `cmake-format` hook also proposes unrelated reflows in the upstream TENT test CMake file, which are intentionally excluded per `AGENTS.md`
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

Claude (Anthropic) was used for implementation and test drafting under my direction; I reviewed every changed line, and the design (per-instance keying, control-block teardown) follows the sketch I posted on #2717 before implementation. All numbers above are from real runs on my hardware.

---

cc @catyans — as discussed on the issue, a careful pass on the teardown paths would be much appreciated; the concurrency stress slice is also still yours if you want to extend it.
