### PR TITLE
[TransferEngine] Acknowledged TCP framing: COMPLETED means applied at destination

### DIFF
--- a/docs/source/design/transfer-engine/index.md
+++ b/docs/source/design/transfer-engine/index.md
@@ -497,6 +497,7 @@ For advanced users, TransferEngine provides the following advanced runtime optio
 - `MC_ENDPOINT_STORE_TYPE` Choose FIFO Endpoint Store (`FIFO`) or Sieve Endpoint Store (`SIEVE`), default is `SIEVE`.
 - `MC_TCP_ENABLE_CONNECTION_POOL` Enable TCP Connection Pool to avoid excessive sockets.
 - `MC_TCP_SLICE_SIZE` The segmentation granularity (in bytes) of TCP transport for splitting large transfers into socket read/write operations. Corresponds to `MC_SLICE_SIZE` for RDMA. Default value 65536 (64KB).
+- `MC_TCP_PROTO` When set to `1`, TCP initiators use the legacy unacknowledged framing even against servers that support acknowledged framing (protocol v2). Under v2 (the default against v2-capable servers), a WRITE completes only after the receiver confirms the payload has been applied to destination memory, and server-side rejections surface as failed transfers instead of silent data loss. Use this variable only as a rollback escape hatch during mixed-version upgrades.
 
 ## C++ API Reference
 

--- a/mooncake-transfer-engine/include/transfer_metadata.h
+++ b/mooncake-transfer-engine/include/transfer_metadata.h
@@ -111,6 +111,10 @@ class TransferMetadata {
         RankInfoDesc rank_info;
 
         int tcp_data_port;
+        // TCP data-plane protocol version advertised by this segment's
+        // server. v2 adds acknowledged WRITE framing and status-prefixed
+        // READ responses (#2086); absent/1 = legacy unacknowledged framing.
+        int tcp_proto_version{1};
 
         // In dual-NIC setups (MC_RDMA_BIND_ADDRESS), the RDMA-reachable
         // address may differ from the TCP-routable segment name.  When

--- a/mooncake-transfer-engine/include/transport/tcp_transport/tcp_transport.h
+++ b/mooncake-transfer-engine/include/transport/tcp_transport/tcp_transport.h
@@ -142,6 +142,10 @@ class TcpTransport : public Transport {
         const std::string &host, uint16_t port);
     void returnConnection(const std::string &host, uint16_t port,
                           std::shared_ptr<asio::ip::tcp::socket> socket);
+    // Close `socket` and drop it from the pool: used for requests that did
+    // not terminate in a well-defined protocol state (#2086).
+    void discardConnection(const std::string &host, uint16_t port,
+                           std::shared_ptr<asio::ip::tcp::socket> socket);
     void cleanupIdleConnections();
 
     static constexpr std::chrono::seconds kConnectionIdleTimeout{60};

--- a/mooncake-transfer-engine/src/transfer_metadata.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata.cpp
@@ -278,6 +278,7 @@ static int encodeMultiProtocolSegmentDesc(
     segmentJSON["buffers"] = buffersJSON;
     segmentJSON["protocol"] = protocolJSON;
     segmentJSON["tcp_data_port"] = desc.tcp_data_port;
+    segmentJSON["tcp_proto_version"] = desc.tcp_proto_version;
     segmentJSON["timestamp"] = getCurrentDateTime();
 
     return 0;
@@ -319,6 +320,7 @@ int TransferMetadata::encodeSegmentDesc(const SegmentDesc &desc,
     segmentJSON["name"] = desc.name;
     segmentJSON["protocol"] = desc.protocol;
     segmentJSON["tcp_data_port"] = desc.tcp_data_port;
+    segmentJSON["tcp_proto_version"] = desc.tcp_proto_version;
     segmentJSON["timestamp"] = getCurrentDateTime();
     if (!desc.rdma_server_name.empty()) {
         segmentJSON["rdma_server_name"] = desc.rdma_server_name;
@@ -515,6 +517,9 @@ decodeMultiProtocolSegmentDesc(Json::Value &segmentJSON,
     auto desc = std::make_shared<TransferMetadata::SegmentDesc>();
     desc->name = segmentJSON["name"].asString();
     desc->tcp_data_port = segmentJSON["tcp_data_port"].asInt();
+    desc->tcp_proto_version = segmentJSON.isMember("tcp_proto_version")
+                                  ? segmentJSON["tcp_proto_version"].asInt()
+                                  : 1;
     if (segmentJSON.isMember("timestamp"))
         desc->timestamp = segmentJSON["timestamp"].asString();
     if (segmentJSON.isMember("rdma_server_name"))
@@ -670,6 +675,9 @@ TransferMetadata::decodeSegmentDesc(Json::Value &segmentJSON,
     desc->name = segmentJSON["name"].asString();
     desc->protocol = segmentJSON["protocol"].asString();
     desc->tcp_data_port = segmentJSON["tcp_data_port"].asInt();
+    desc->tcp_proto_version = segmentJSON.isMember("tcp_proto_version")
+                                  ? segmentJSON["tcp_proto_version"].asInt()
+                                  : 1;
     if (segmentJSON.isMember("timestamp"))
         desc->timestamp = segmentJSON["timestamp"].asString();
     if (segmentJSON.isMember("rdma_server_name"))

--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
@@ -17,6 +17,7 @@
 #include <bits/stdint-uintn.h>
 #include <glog/logging.h>
 #include <asio/ip/v6_only.hpp>
+#include <asio/steady_timer.hpp>
 
 #include <algorithm>
 #include <cassert>
@@ -26,6 +27,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <memory>
+#include <optional>
 #include <random>
 
 #include "common.h"
@@ -407,6 +409,25 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
     // the transfer becomes terminal.
     bool write_body_in_flight_ = false;
     bool write_abort_requested_ = false;
+    // A v2 status frame is prompt by construction: a READ status precedes
+    // any payload, and a WRITE ack follows at most one chunk's apply after
+    // the body is done. The only peer that never sends one is a legacy
+    // server reached through a stale v2 descriptor — and for requests
+    // shorter than a frame it also keeps the connection open (it streamed
+    // size < 8 bytes of "READ payload" and is waiting for our next header),
+    // so without a deadline both sides wait forever. Bound that wait; the
+    // default is generous so no healthy slow path can trip it, since it only
+    // covers the frame itself, never payload streaming.
+    static int statusFrameTimeoutSec() {
+        const char* env = std::getenv("MC_TCP_STATUS_TIMEOUT_SEC");
+        if (env) {
+            int v = std::atoi(env);
+            if (v > 0) return v;
+        }
+        return 30;
+    }
+    std::optional<asio::steady_timer> status_timer_;
+    bool status_deadline_disarmed_ = false;
     std::function<void(TransferStatusEnum)> on_finalize_;
     // Invoked exactly once per request with clean=true iff the protocol
     // exchange terminated in a well-defined connection state. A socket whose
@@ -426,9 +447,44 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
     }
 
    private:
+    // All handlers run on the transport's single io thread, so arm/cancel
+    // and the expiry handler never race. Expiry only closes the socket: the
+    // pending status read then completes with an error and its handler owns
+    // the failure path (including source-buffer quiescence for WRITE).
+    void armStatusDeadline() {
+        auto self(shared_from_this());
+        status_deadline_disarmed_ = false;
+        status_timer_.emplace(socket_->get_executor());
+        status_timer_->expires_after(
+            std::chrono::seconds(statusFrameTimeoutSec()));
+        status_timer_->async_wait([this, self](const asio::error_code& ec) {
+            // The disarmed flag also covers an expiry that was already
+            // queued when cancel() ran (cancel cannot revoke those, and by
+            // then the socket may have been re-pooled).
+            if (ec == asio::error::operation_aborted ||
+                status_deadline_disarmed_) {
+                return;
+            }
+            LOG(ERROR) << "ClientSession: no status frame within "
+                       << statusFrameTimeoutSec()
+                       << "s (peer likely speaks the legacy protocol); "
+                          "dropping connection";
+            if (socket_ && socket_->is_open()) {
+                asio::error_code cec;
+                socket_->close(cec);
+            }
+        });
+    }
+
+    void cancelStatusDeadline() {
+        status_deadline_disarmed_ = true;
+        if (status_timer_) status_timer_->cancel();
+    }
+
     // Single terminal path: finish connection ownership, then report the
     // outcome. Posted so it runs after the invoking callback returns.
     void finalize(TransferStatusEnum status, bool clean) {
+        cancelStatusDeadline();
         auto self(shared_from_this());
         asio::post(
             socket_->get_executor(),
@@ -482,9 +538,11 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
     // v2 READ: the server prefixes the data with a status frame.
     void readReadStatus() {
         auto self(shared_from_this());
+        armStatusDeadline();
         asio::async_read(
             *socket_, asio::buffer(&status_frame_, sizeof(status_frame_)),
             [this, self](const asio::error_code& ec, std::size_t len) {
+                cancelStatusDeadline();
                 if (ec || len != sizeof(status_frame_)) {
                     LOG(ERROR)
                         << "ClientSession: failed to read READ status "
@@ -523,6 +581,7 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
         asio::async_read(
             *socket_, asio::buffer(&status_frame_, sizeof(status_frame_)),
             [this, self](const asio::error_code& ec, std::size_t len) {
+                cancelStatusDeadline();
                 if (ec || len != sizeof(status_frame_)) {
                     // The body path may have already finalized a failure and
                     // closed the socket; finalize() is idempotent (moved-from
@@ -655,8 +714,14 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
                 // read is already in flight (armed in writeHeader) and may
                 // have finished first.
                 write_body_done_ = true;
-                if (write_acked_ok_)
+                if (write_acked_ok_) {
                     finalize(TransferStatusEnum::COMPLETED, true);
+                } else {
+                    // From here a well-behaved server owes at most one
+                    // chunk's apply plus the frame; a legacy peer behind a
+                    // stale descriptor may owe nothing, ever.
+                    armStatusDeadline();
+                }
             } else {
                 // v1: no acknowledgment exists in the protocol; this only
                 // means the payload left the initiator (#2086).

--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
@@ -113,7 +113,45 @@ class TcpTransport;
 
 using ValidateAddrFn = std::function<bool(uint64_t, uint64_t)>;
 
-// Server-side session: handles one transfer request on a persistent connection
+// --- Acknowledged framing (protocol v2, #2086) ------------------------------
+// v1 framing gives the initiator no channel to learn whether the receiver
+// applied (or even accepted) a WRITE: COMPLETED fires when the final chunk
+// enters the initiator's kernel socket buffer, while megabytes may still be
+// in flight toward destination memory, and a rejected request is silently
+// "successful". v2 requests set the high bit of the opcode; the server then
+// (a) prefixes every READ response with an 8-byte status frame and (b) sends
+// an 8-byte status frame for WRITE only after the final chunk has been
+// applied to destination memory. Initiators enable v2 only when the target
+// segment advertises tcp_proto_version >= 2, so old servers never see
+// flagged opcodes and old initiators keep receiving v1 framing.
+static constexpr uint8_t kOpcodeV2Flag = 0x80;
+// Status frames carry a magic in the high 32 bits so that a v2 initiator
+// which reaches a v1 server through a stale descriptor (v1 treats unknown
+// opcodes as READ and immediately streams payload bytes) fails fast on the
+// first frame instead of misinterpreting the stream. Residual risk: payload
+// bytes that happen to equal a valid frame (2^-64 per request, data
+// dependent) are indistinguishable in-band; eliminating that would need a
+// nonce/checksum handshake, which this deliberately avoids.
+static constexpr uint64_t kStatusMagic = 0x4D435456ull << 32;  // "MCTV"
+static constexpr uint64_t kStatusOk = kStatusMagic | 0;
+static constexpr uint64_t kStatusAddrRejected = kStatusMagic | 1;
+static inline bool statusFrameValid(uint64_t frame) {
+    return (frame & 0xFFFFFFFF00000000ull) == kStatusMagic;
+}
+
+// Operational escape hatch: MC_TCP_PROTO=1 forces initiators to speak the
+// legacy unacknowledged framing even to v2-capable servers. Also used by
+// tests to cover the mixed-version matrix in one process.
+static bool forceLegacyTcpProto() {
+    // Read per call (startTransfer already does metadata lookups; getenv is
+    // noise) so tests can cover both protocol modes in one process.
+    const char* env = std::getenv("MC_TCP_PROTO");
+    return env && env[0] == '1' && env[1] == '\0';
+}
+
+// Server-side session: handles transfer requests on a persistent connection.
+// The session owns the socket; ending the callback chain without rearming
+// (start()/next handler) drops the last reference and closes the connection.
 struct ServerSession : public std::enable_shared_from_this<ServerSession> {
     explicit ServerSession(std::shared_ptr<tcpsocket> socket,
                            ValidateAddrFn validate_addr)
@@ -125,16 +163,30 @@ struct ServerSession : public std::enable_shared_from_this<ServerSession> {
     SessionHeader header_;
     uint64_t total_transferred_bytes_;
     char* local_buffer_;
-    std::function<void(TransferStatusEnum)> on_finalize_;
-    std::mutex session_mutex_;
+    bool v2_ = false;
+    uint64_t status_frame_;
 
     void start() {
-        session_mutex_.lock();
         total_transferred_bytes_ = 0;
         readHeader();
     }
 
    private:
+    // Send an 8-byte status frame, then run `next` (or end the session —
+    // closing the connection — when `next` is empty or the send fails).
+    void sendStatus(uint64_t status, std::function<void()> next) {
+        status_frame_ = htole64(status);
+        auto self(shared_from_this());
+        asio::async_write(*socket_,
+                          asio::buffer(&status_frame_, sizeof(status_frame_)),
+                          [this, self, next = std::move(next)](
+                              const asio::error_code& ec, std::size_t) {
+                              if (ec)
+                                  return;  // connection closes with the session
+                              if (next) next();
+                          });
+    }
+
     void readHeader() {
         auto self(shared_from_this());
         asio::async_read(
@@ -147,10 +199,11 @@ struct ServerSession : public std::enable_shared_from_this<ServerSession> {
                             << ec.message() << " (value: " << ec.value() << ")"
                             << ", bytes read: " << len;
                     }
-                    session_mutex_.unlock();
                     return;
                 }
 
+                v2_ = (header_.opcode & kOpcodeV2Flag) != 0;
+                const uint8_t opcode = header_.opcode & ~kOpcodeV2Flag;
                 local_buffer_ = (char*)(le64toh(header_.addr));
                 uint64_t size = le64toh(header_.size);
                 if (validate_addr_ &&
@@ -159,13 +212,21 @@ struct ServerSession : public std::enable_shared_from_this<ServerSession> {
                                << std::hex << (uint64_t)local_buffer_
                                << std::dec << " with size " << size
                                << " is not within any registered buffer";
-                    session_mutex_.unlock();
+                    // v2 initiators learn of the rejection; v1 initiators
+                    // only see the connection close (and, for small WRITEs,
+                    // may have already reported success — the defect v2
+                    // exists to fix).
+                    if (v2_) sendStatus(kStatusAddrRejected, nullptr);
                     return;
                 }
-                if (header_.opcode == (uint8_t)TransferRequest::WRITE)
+                if (opcode == (uint8_t)TransferRequest::WRITE) {
                     readBody();
-                else
+                } else if (v2_) {
+                    // READ, v2: status frame precedes the data.
+                    sendStatus(kStatusOk, [this] { writeBody(); });
+                } else {
                     writeBody();
+                }
             });
     }
 
@@ -177,7 +238,6 @@ struct ServerSession : public std::enable_shared_from_this<ServerSession> {
         size_t buffer_size =
             std::min(getChunkSize(), size - total_transferred_bytes_);
         if (buffer_size == 0) {
-            session_mutex_.unlock();
             // Transfer complete, wait for next request on this connection
             start();
             return;
@@ -205,7 +265,6 @@ struct ServerSession : public std::enable_shared_from_this<ServerSession> {
                 LOG(ERROR) << "ServerSession::writeBody failed to copy from "
                               "CUDA memory. "
                            << "Error: " << cudaGetErrorString(cuda_status);
-                session_mutex_.unlock();
                 delete[] dram_buffer;
                 return;  // Connection will be closed
             }
@@ -230,7 +289,6 @@ struct ServerSession : public std::enable_shared_from_this<ServerSession> {
                         << " using buffer " << static_cast<void*>(dram_buffer)
                         << ". Error: " << ec.message()
                         << " (value: " << ec.value() << ")";
-                    session_mutex_.unlock();
                     return;  // Connection will be closed
                 }
                 total_transferred_bytes_ += transferred_bytes;
@@ -246,9 +304,15 @@ struct ServerSession : public std::enable_shared_from_this<ServerSession> {
         size_t buffer_size =
             std::min(getChunkSize(), size - total_transferred_bytes_);
         if (buffer_size == 0) {
-            session_mutex_.unlock();
-            // Transfer complete, wait for next request on this connection
-            start();
+            // Destination memory now holds the complete payload. Under v2,
+            // acknowledge before accepting the next request — this is what
+            // makes the initiator's COMPLETED mean "applied at the
+            // destination" rather than "left my socket buffer".
+            if (v2_) {
+                sendStatus(kStatusOk, [this] { start(); });
+            } else {
+                start();
+            }
             return;
         }
 
@@ -280,7 +344,6 @@ struct ServerSession : public std::enable_shared_from_this<ServerSession> {
                             << ". Error: " << ec.message()
                             << " (value: " << ec.value() << ")";
                     }
-                    session_mutex_.unlock();
                     if (cuda_device >= 0) delete[] dram_buffer;
                     return;  // Connection will be closed
                 }
@@ -305,7 +368,6 @@ struct ServerSession : public std::enable_shared_from_this<ServerSession> {
                                "memory. "
                             << "Error: " << cudaGetErrorString(cuda_status);
                         delete[] dram_buffer;
-                        session_mutex_.unlock();
                         return;  // Connection will be closed
                     }
                     delete[] dram_buffer;
@@ -319,30 +381,79 @@ struct ServerSession : public std::enable_shared_from_this<ServerSession> {
 
 // Client-side session: initiates one transfer request
 struct ClientSession : public std::enable_shared_from_this<ClientSession> {
-    explicit ClientSession(std::shared_ptr<tcpsocket> socket,
-                           std::function<void()> on_complete = nullptr)
-        : socket_(std::move(socket)), on_complete_(std::move(on_complete)) {}
+    explicit ClientSession(std::shared_ptr<tcpsocket> socket, bool use_v2,
+                           std::function<void(bool)> on_complete = nullptr)
+        : socket_(std::move(socket)),
+          v2_(use_v2),
+          on_complete_(std::move(on_complete)) {}
 
     std::shared_ptr<tcpsocket> socket_;
     SessionHeader header_;
     uint64_t total_transferred_bytes_;
     char* local_buffer_;
+    bool v2_;
+    uint64_t status_frame_;
+    // v2 WRITE runs the body stream and the ack read concurrently (one
+    // async op per direction; handlers serialize on the io thread). The
+    // concurrent read lets a rejection — or a v1 server's bogus payload —
+    // abort a large in-flight WRITE instead of deadlocking on mutually
+    // full socket buffers, and delivers rejection frames before the close.
+    bool write_body_done_ = false;
+    bool write_acked_ok_ = false;
+    // An early negative/malformed ack can arrive while asio::async_write still
+    // owns a buffer pointing into the caller's source memory. Do not publish a
+    // terminal status until that body operation has completed or been
+    // cancelled: callers are allowed to release the source buffer as soon as
+    // the transfer becomes terminal.
+    bool write_body_in_flight_ = false;
+    bool write_abort_requested_ = false;
     std::function<void(TransferStatusEnum)> on_finalize_;
-    std::function<void()> on_complete_;  // Callback when transfer completes
-    std::mutex session_mutex_;
+    // Invoked exactly once per request with clean=true iff the protocol
+    // exchange terminated in a well-defined connection state. A socket whose
+    // request did not end cleanly must not be reused: the server-side session
+    // may be mid-frame, and the next request's header would be consumed as
+    // body bytes.
+    std::function<void(bool)> on_complete_;
 
     void initiate(void* buffer, uint64_t dest_addr, size_t size,
                   TransferRequest::OpCode opcode) {
-        session_mutex_.lock();
         local_buffer_ = (char*)buffer;
         header_.addr = htole64(dest_addr);
         header_.size = htole64(size);
-        header_.opcode = (uint8_t)opcode;
+        header_.opcode = (uint8_t)opcode | (v2_ ? kOpcodeV2Flag : 0);
         total_transferred_bytes_ = 0;
         writeHeader();
     }
 
    private:
+    // Single terminal path: finish connection ownership, then report the
+    // outcome. Posted so it runs after the invoking callback returns.
+    void finalize(TransferStatusEnum status, bool clean) {
+        auto self(shared_from_this());
+        asio::post(
+            socket_->get_executor(),
+            [this, self, status, clean, on_finalize = std::move(on_finalize_),
+             on_complete = std::move(on_complete_)]() {
+                // Finish connection ownership before publishing terminal
+                // status. Once on_finalize marks the slice, the caller may
+                // immediately free the batch or destroy the transport.
+                if (on_complete) on_complete(clean);
+                if (on_finalize) on_finalize(status);
+            });
+    }
+
+    // Abort a v2 WRITE and cancel any body operation. If asio still owns the
+    // current source buffer, its completion handler is responsible for
+    // finalizing after the buffer is quiescent.
+    void abortWrite() {
+        write_abort_requested_ = true;
+        if (socket_ && socket_->is_open()) {
+            asio::error_code ec;
+            socket_->close(ec);
+        }
+        if (!write_body_in_flight_) finalize(TransferStatusEnum::FAILED, false);
+    }
+
     void writeHeader() {
         auto self(shared_from_this());
         asio::async_write(
@@ -353,21 +464,102 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
                         << "ClientSession::writeHeader failed. Error: "
                         << ec.message() << " (value: " << ec.value() << ")"
                         << ", bytes written: " << len;
-                    asio::post(
-                        socket_->get_executor(),
-                        [this, self, on_finalize = std::move(on_finalize_),
-                         on_complete = std::move(on_complete_)]() {
-                            if (on_finalize)
-                                on_finalize(TransferStatusEnum::FAILED);
-                            session_mutex_.unlock();
-                            if (on_complete) on_complete();
-                        });
+                    finalize(TransferStatusEnum::FAILED, false);
                     return;
                 }
-                if (header_.opcode == (uint8_t)TransferRequest::WRITE)
+                if ((header_.opcode & ~kOpcodeV2Flag) ==
+                    (uint8_t)TransferRequest::WRITE) {
+                    if (v2_) readWriteAck();  // concurrent with the body
                     writeBody();
-                else
+                } else if (v2_) {
+                    readReadStatus();
+                } else {
                     readBody();
+                }
+            });
+    }
+
+    // v2 READ: the server prefixes the data with a status frame.
+    void readReadStatus() {
+        auto self(shared_from_this());
+        asio::async_read(
+            *socket_, asio::buffer(&status_frame_, sizeof(status_frame_)),
+            [this, self](const asio::error_code& ec, std::size_t len) {
+                if (ec || len != sizeof(status_frame_)) {
+                    LOG(ERROR)
+                        << "ClientSession: failed to read READ status "
+                           "frame. Error: "
+                        << ec.message() << " (value: " << ec.value() << ")";
+                    finalize(TransferStatusEnum::FAILED, false);
+                    return;
+                }
+                uint64_t frame = le64toh(status_frame_);
+                if (!statusFrameValid(frame)) {
+                    LOG(ERROR) << "ClientSession: malformed READ status "
+                                  "frame (peer likely speaks the legacy "
+                                  "protocol); dropping connection";
+                    finalize(TransferStatusEnum::FAILED, false);
+                    return;
+                }
+                if (frame != kStatusOk) {
+                    LOG(ERROR) << "ClientSession: READ rejected by server, "
+                                  "status "
+                               << (frame & 0xFFFFFFFFull);
+                    finalize(TransferStatusEnum::FAILED, false);
+                    return;
+                }
+                readBody();
+            });
+    }
+
+    // v2 WRITE: completion is the server's acknowledgment that the payload
+    // has been applied to destination memory. Armed concurrently with the
+    // body stream; a well-behaved v2 server only sends the frame after the
+    // final chunk, so a frame arriving before the body is done is either a
+    // rejection or a legacy peer's payload — both close the socket immediately
+    // and publish failure only after the outstanding body write is quiescent.
+    void readWriteAck() {
+        auto self(shared_from_this());
+        asio::async_read(
+            *socket_, asio::buffer(&status_frame_, sizeof(status_frame_)),
+            [this, self](const asio::error_code& ec, std::size_t len) {
+                if (ec || len != sizeof(status_frame_)) {
+                    // The body path may have already finalized a failure and
+                    // closed the socket; finalize() is idempotent (moved-from
+                    // callbacks are null-checked).
+                    if (ec != asio::error::operation_aborted) {
+                        LOG(ERROR)
+                            << "ClientSession: failed to read WRITE "
+                               "ack frame. Error: "
+                            << ec.message() << " (value: " << ec.value() << ")";
+                    }
+                    abortWrite();
+                    return;
+                }
+                uint64_t frame = le64toh(status_frame_);
+                if (!statusFrameValid(frame)) {
+                    LOG(ERROR) << "ClientSession: malformed WRITE ack frame "
+                                  "(peer likely speaks the legacy protocol); "
+                                  "dropping connection";
+                    abortWrite();
+                    return;
+                }
+                if (frame != kStatusOk) {
+                    LOG(ERROR) << "ClientSession: WRITE rejected by server, "
+                                  "status "
+                               << (frame & 0xFFFFFFFFull);
+                    abortWrite();
+                    return;
+                }
+                if (!write_body_done_) {
+                    // The server's ack can legitimately overtake the final
+                    // local write-completion handler (both become ready
+                    // together for small writes; the io thread may run this
+                    // handler first). Record it; the body path finalizes.
+                    write_acked_ok_ = true;
+                    return;
+                }
+                finalize(TransferStatusEnum::COMPLETED, true);
             });
     }
 
@@ -379,14 +571,7 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
         size_t buffer_size =
             std::min(getChunkSize(), size - total_transferred_bytes_);
         if (buffer_size == 0) {
-            asio::post(socket_->get_executor(),
-                       [this, self, on_finalize = std::move(on_finalize_),
-                        on_complete = std::move(on_complete_)]() {
-                           if (on_finalize)
-                               on_finalize(TransferStatusEnum::COMPLETED);
-                           session_mutex_.unlock();
-                           if (on_complete) on_complete();
-                       });
+            finalize(TransferStatusEnum::COMPLETED, true);
             return;
         }
 
@@ -413,22 +598,12 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
                         << " using buffer " << static_cast<void*>(dram_buffer)
                         << ". Error: " << ec.message()
                         << " (value: " << ec.value() << ")";
-                    // Post entire cleanup to ensure it runs after callback
-                    // returns
-                    asio::post(socket_->get_executor(),
-                               [this, self, dram_buffer, cuda_device,
-                                on_finalize = std::move(on_finalize_),
-                                on_complete = std::move(on_complete_)]() {
-                                   if (on_finalize)
-                                       on_finalize(TransferStatusEnum::FAILED);
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX)
-                                   if (cuda_device >= 0) delete[] dram_buffer;
+                    if (cuda_device >= 0) delete[] dram_buffer;
 #endif
-                                   session_mutex_.unlock();
-                                   if (on_complete) on_complete();
-                               });
+                    finalize(TransferStatusEnum::FAILED, false);
                     return;
                 }
 
@@ -451,19 +626,8 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
                             << "ClientSession::readBody failed to copy to CUDA "
                                "memory. "
                             << "Error: " << cudaGetErrorString(cuda_status);
-                        // Post entire cleanup to ensure it runs after callback
-                        // returns
-                        asio::post(
-                            socket_->get_executor(),
-                            [this, self, dram_buffer,
-                             on_finalize = std::move(on_finalize_),
-                             on_complete = std::move(on_complete_)]() {
-                                if (on_finalize)
-                                    on_finalize(TransferStatusEnum::FAILED);
-                                delete[] dram_buffer;
-                                session_mutex_.unlock();
-                                if (on_complete) on_complete();
-                            });
+                        delete[] dram_buffer;
+                        finalize(TransferStatusEnum::FAILED, false);
                         return;
                     }
                     delete[] dram_buffer;
@@ -482,15 +646,22 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
         size_t buffer_size =
             std::min(getChunkSize(), size - total_transferred_bytes_);
         if (buffer_size == 0) {
-            // Post cleanup to ensure it runs after callback returns
-            asio::post(socket_->get_executor(),
-                       [this, self, on_finalize = std::move(on_finalize_),
-                        on_complete = std::move(on_complete_)]() {
-                           if (on_finalize)
-                               on_finalize(TransferStatusEnum::COMPLETED);
-                           session_mutex_.unlock();
-                           if (on_complete) on_complete();
-                       });
+            if (v2_) {
+                if (write_abort_requested_) {
+                    finalize(TransferStatusEnum::FAILED, false);
+                    return;
+                }
+                // Completion comes from the server's acknowledgment, whose
+                // read is already in flight (armed in writeHeader) and may
+                // have finished first.
+                write_body_done_ = true;
+                if (write_acked_ok_)
+                    finalize(TransferStatusEnum::COMPLETED, true);
+            } else {
+                // v1: no acknowledgment exists in the protocol; this only
+                // means the payload left the initiator (#2086).
+                finalize(TransferStatusEnum::COMPLETED, true);
+            }
             return;
         }
 
@@ -516,26 +687,19 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
                 LOG(ERROR) << "ClientSession::writeBody failed to copy from "
                               "CUDA memory. "
                            << "Error: " << cudaGetErrorString(cuda_status);
-                // Post entire cleanup to ensure it runs after callback returns
-                asio::post(socket_->get_executor(),
-                           [this, self, dram_buffer,
-                            on_finalize = std::move(on_finalize_),
-                            on_complete = std::move(on_complete_)]() {
-                               if (on_finalize)
-                                   on_finalize(TransferStatusEnum::FAILED);
-                               delete[] dram_buffer;
-                               session_mutex_.unlock();
-                               if (on_complete) on_complete();
-                           });
+                delete[] dram_buffer;
+                abortWrite();
                 return;
             }
         }
 #endif
 
+        write_body_in_flight_ = true;
         asio::async_write(
             *socket_, asio::buffer(dram_buffer, buffer_size),
             [this, addr, dram_buffer, cuda_device, self](
                 const asio::error_code& ec, std::size_t transferred_bytes) {
+                write_body_in_flight_ = false;
                 if (cuda_device >= 0) {
                     delete[] dram_buffer;
                 }
@@ -546,17 +710,14 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
                         << " using buffer " << static_cast<void*>(dram_buffer)
                         << ". Error: " << ec.message()
                         << " (value: " << ec.value() << ")";
-                    // Post entire cleanup to ensure it runs after callback
-                    // returns
-                    asio::post(
-                        socket_->get_executor(),
-                        [this, self, on_finalize = std::move(on_finalize_),
-                         on_complete = std::move(on_complete_)]() {
-                            if (on_finalize)
-                                on_finalize(TransferStatusEnum::FAILED);
-                            session_mutex_.unlock();
-                            if (on_complete) on_complete();
-                        });
+                    abortWrite();
+                    return;
+                }
+                if (write_abort_requested_) {
+                    // The early ack path closed the socket while this
+                    // operation still owned the caller's source buffer. It is
+                    // safe to publish failure now that the handler has run.
+                    finalize(TransferStatusEnum::FAILED, false);
                     return;
                 }
                 total_transferred_bytes_ += transferred_bytes;
@@ -708,6 +869,9 @@ int TcpTransport::allocateLocalSegmentID(int tcp_data_port) {
     desc->protocol = "tcp";
 #endif
     desc->tcp_data_port = tcp_data_port;
+    // Advertise acknowledged framing (#2086); initiators fall back to v1
+    // against descriptors that do not carry the field.
+    desc->tcp_proto_version = 2;
     metadata_->addLocalSegment(LOCAL_SEGMENT_ID, local_server_name_,
                                std::move(desc));
     return 0;
@@ -1026,6 +1190,28 @@ bool TcpTransport::validateAddress(uint64_t addr, uint64_t size) const {
     return false;
 }
 
+void TcpTransport::discardConnection(
+    const std::string& host, uint16_t port,
+    std::shared_ptr<asio::ip::tcp::socket> socket) {
+    if (socket && socket->is_open()) {
+        asio::error_code ec;
+        socket->close(ec);
+    }
+    std::lock_guard<std::mutex> lock(pool_mutex_);
+    auto it = connection_pool_.find(ConnectionKey{host, port});
+    if (it != connection_pool_.end()) {
+        auto& queue = it->second;
+        for (auto queue_it = queue.begin(); queue_it != queue.end();
+             ++queue_it) {
+            if ((*queue_it)->socket == socket) {
+                queue.erase(queue_it);
+                break;
+            }
+        }
+        if (queue.empty()) connection_pool_.erase(it);
+    }
+}
+
 void TcpTransport::startTransfer(Slice* slice) {
     auto desc = metadata_->getSegmentDescByID(slice->target_id);
     if (!desc) {
@@ -1045,6 +1231,15 @@ void TcpTransport::startTransfer(Slice* slice) {
         return;
     }
 
+    // Zero-length requests are complete by definition. v1 reported them
+    // COMPLETED while the server silently rejected size==0 in address
+    // validation; short-circuiting keeps that outcome (rather than turning
+    // no-ops into v2 rejection failures) without the pointless round trip.
+    if (slice->length == 0) {
+        slice->markSuccess();
+        return;
+    }
+
     // Get connection from pool
     auto socket =
         getConnection(meta_entry.ip_or_host_name, desc->tcp_data_port);
@@ -1056,7 +1251,9 @@ void TcpTransport::startTransfer(Slice* slice) {
     }
 
     try {
-        auto session = std::make_shared<ClientSession>(socket);
+        const bool use_v2 =
+            desc->tcp_proto_version >= 2 && !forceLegacyTcpProto();
+        auto session = std::make_shared<ClientSession>(socket, use_v2);
 
         session->on_finalize_ = [slice](TransferStatusEnum status) {
             if (status == TransferStatusEnum::COMPLETED)
@@ -1065,15 +1262,21 @@ void TcpTransport::startTransfer(Slice* slice) {
                 slice->markFailed();
         };
 
-        // Return connection to pool when transfer completes, or close if
-        // disabled
+        // Return connection to pool when the request terminated cleanly;
+        // otherwise the server-side session state is unknown (it may be
+        // mid-frame), so reusing the socket would desynchronize the next
+        // request. Discard it instead.
         if (enable_connection_pool_) {
             session->on_complete_ = [this, host = meta_entry.ip_or_host_name,
-                                     port = desc->tcp_data_port, socket]() {
-                returnConnection(host, port, socket);
+                                     port = desc->tcp_data_port,
+                                     socket](bool clean) {
+                if (clean)
+                    returnConnection(host, port, socket);
+                else
+                    discardConnection(host, port, socket);
             };
         } else {
-            session->on_complete_ = [socket]() {
+            session->on_complete_ = [socket](bool) {
                 // Close connection immediately after transfer
                 if (socket && socket->is_open()) {
                     asio::error_code ec;
@@ -1091,32 +1294,11 @@ void TcpTransport::startTransfer(Slice* slice) {
                    << ", opcode: " << (int)slice->opcode
                    << ", target_id: " << slice->target_id
                    << ". Exception: " << e.what();
-        // On exception, always close the socket and remove from pool if present
-        // Don't return it to the pool as it may be in an inconsistent state
-        if (socket && socket->is_open()) {
-            asio::error_code ec;
-            socket->close(ec);
-        }
-        if (enable_connection_pool_) {
-            // Remove the connection from pool if it was pooled
-            ConnectionKey key{meta_entry.ip_or_host_name,
-                              static_cast<uint16_t>(desc->tcp_data_port)};
-            std::lock_guard<std::mutex> lock(pool_mutex_);
-            auto it = connection_pool_.find(key);
-            if (it != connection_pool_.end()) {
-                auto& queue = it->second;
-                for (auto queue_it = queue.begin(); queue_it != queue.end();
-                     ++queue_it) {
-                    if ((*queue_it)->socket == socket) {
-                        queue.erase(queue_it);
-                        break;
-                    }
-                }
-                if (queue.empty()) {
-                    connection_pool_.erase(it);
-                }
-            }
-        }
+        // On exception, always close the socket and remove from pool if
+        // present. Don't return it to the pool as it may be in an
+        // inconsistent state.
+        discardConnection(meta_entry.ip_or_host_name,
+                          static_cast<uint16_t>(desc->tcp_data_port), socket);
         slice->markFailed();
     }
 }

--- a/mooncake-transfer-engine/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tests/CMakeLists.txt
@@ -77,6 +77,12 @@ if(USE_TCP)
   target_link_libraries(tcp_transport_test PUBLIC transfer_engine gtest
                                                   gtest_main)
   add_test(NAME tcp_transport_test COMMAND tcp_transport_test)
+
+  add_executable(tcp_write_visibility_test
+                 ${WORKSPACE}/tcp_write_visibility_test.cpp)
+  target_link_libraries(tcp_write_visibility_test PUBLIC transfer_engine gtest
+                                                         gtest_main)
+  add_test(NAME tcp_write_visibility_test COMMAND tcp_write_visibility_test)
 endif()
 
 add_executable(tcp_address_validation_test

--- a/mooncake-transfer-engine/tests/tcp_write_visibility_test.cpp
+++ b/mooncake-transfer-engine/tests/tcp_write_visibility_test.cpp
@@ -110,7 +110,12 @@ class LegacyReadServer {
         sockaddr_in addr{};
         addr.sin_family = AF_INET;
         addr.sin_port = 0;
-        if (inet_pton(AF_INET, "127.0.0.2", &addr.sin_addr) != 1) return;
+        // The production HTTP-metadata path advertises the engine-selected
+        // LAN address in RPC metadata even when local_server_name is a
+        // loopback test name. Listen on every local interface so the stale
+        // descriptor can redirect either that path or P2PHANDSHAKE's
+        // loopback path to this fake legacy peer.
+        addr.sin_addr.s_addr = htonl(INADDR_ANY);
         if (bind(listen_fd_, reinterpret_cast<sockaddr*>(&addr),
                  sizeof(addr)) != 0)
             return;
@@ -218,9 +223,15 @@ struct EngineHandle {
         memset(pool, 0, pool_size);
         rc = engine->registerLocalMemory(pool, pool_size, "cpu:0");
         ASSERT_EQ(rc, 0);
-        // With P2PHANDSHAKE metadata the engine's actual RPC port is
-        // auto-assigned; open the segment via the engine-reported address.
-        segment_id = engine->openSegment(engine->getLocalIpAndPort());
+        // The descriptor is fetchable under the name it was registered
+        // with: in P2P-handshake mode the RPC port is auto-assigned, so
+        // that is the engine-reported ip:port; against a real metadata
+        // service (CI runs one at http://...) it is the requested
+        // server_name, matching how production callers open segments.
+        std::string segment_name = (metadata_server == P2PHANDSHAKE)
+                                       ? engine->getLocalIpAndPort()
+                                       : server_name;
+        segment_id = engine->openSegment(segment_name);
         auto desc = engine->getMetadata()->getSegmentDescByID(segment_id);
         ASSERT_NE(desc, nullptr);
         remote_base = (uint64_t)desc->buffers[0].addr;

--- a/mooncake-transfer-engine/tests/tcp_write_visibility_test.cpp
+++ b/mooncake-transfer-engine/tests/tcp_write_visibility_test.cpp
@@ -99,7 +99,12 @@ static_assert(sizeof(TestSessionHeader) == 24,
 // reject the non-status bytes and cancel the body promptly.
 class LegacyReadServer {
    public:
-    LegacyReadServer() {
+    // keep_open=true models the real v1 server loop: after streaming the
+    // "READ payload" it does NOT close, it waits for the next 24-byte
+    // header. For flagged requests shorter than a status frame this is the
+    // configuration that used to hang a v2 initiator forever (fewer than 8
+    // payload bytes ever arrive, no EOF, no deadline).
+    explicit LegacyReadServer(bool keep_open = false) : keep_open_(keep_open) {
         listen_fd_ = socket(AF_INET, SOCK_STREAM, 0);
         if (listen_fd_ < 0) return;
         int one = 1;
@@ -167,6 +172,8 @@ class LegacyReadServer {
         timeval timeout{8, 0};
         (void)setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &timeout,
                          sizeof(timeout));
+        (void)setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout,
+                         sizeof(timeout));
 
         TestSessionHeader header{};
         if (!recvExact(fd, &header, sizeof(header))) {
@@ -184,12 +191,20 @@ class LegacyReadServer {
             if (n <= 0) break;
             sent += static_cast<uint64_t>(n);
         }
+        if (keep_open_) {
+            // v1 loop: wait for the next header; leaves only when the
+            // client drops the connection (or the test tears down the
+            // listener, which shuts the accepted fd's peer down too).
+            TestSessionHeader next{};
+            (void)recvExact(fd, &next, sizeof(next));
+        }
         close(fd);
     }
 
     int listen_fd_ = -1;
     uint16_t port_ = 0;
     bool ok_ = false;
+    bool keep_open_ = false;
     std::thread thread_;
     std::atomic<bool> saw_flagged_write_{false};
 };
@@ -570,4 +585,54 @@ TEST(TcpWriteVisibilityTest,
 
     legacy_server.join();
     EXPECT_TRUE(legacy_server.sawFlaggedWrite());
+}
+
+// A stale v2 descriptor can also point at a legacy server with a request
+// SHORTER than a status frame (1-7 bytes). The v1 peer treats the flagged
+// opcode as READ, streams fewer than 8 "payload" bytes, and then keeps the
+// connection open waiting for the next header — no EOF ever arrives, and for
+// WRITE it is symmetrically stuck parsing our body bytes as a partial
+// header. Without a status-frame deadline both directions wait forever;
+// with it they must fail, and only after actually waiting the deadline out
+// (an early failure would mean something else broke).
+TEST(TcpWriteVisibilityTest, StaleV2DescriptorShortRequestFailsWithinDeadline) {
+    ScopedEnvVar fast_deadline("MC_TCP_STATUS_TIMEOUT_SEC", "2");
+    const char* env = std::getenv("MC_METADATA_SERVER");
+    std::string metadata_server = env ? env : "P2PHANDSHAKE";
+    EngineHandle h;
+    h.init(metadata_server, "127.0.0.2:17906", 8ull << 20);
+    ASSERT_TRUE(h.ok) << "engine/segment setup failed";
+
+    auto desc = h.engine->getMetadata()->getSegmentDescByID(h.segment_id);
+    ASSERT_NE(desc, nullptr);
+    desc->tcp_proto_version = 2;  // deliberately stale capability advertisement
+
+    char buf[4] = {0x11, 0x22, 0x33, 0x44};
+    for (auto opcode : {TransferRequest::WRITE, TransferRequest::READ}) {
+        // One server per direction: the previous connection was (correctly)
+        // discarded rather than re-pooled, so each request dials anew.
+        LegacyReadServer legacy_server(/*keep_open=*/true);
+        ASSERT_TRUE(legacy_server.ok());
+        desc->tcp_data_port = legacy_server.port();
+
+        TransferRequest r;
+        r.opcode = opcode;
+        r.length = sizeof(buf);
+        r.source = buf;
+        r.target_id = h.segment_id;
+        r.target_offset = h.remote_base;
+
+        auto start = std::chrono::steady_clock::now();
+        EXPECT_EQ(runOne(h.engine.get(), r), TransferStatusEnum::FAILED)
+            << "opcode " << static_cast<int>(opcode);
+        auto elapsed = std::chrono::steady_clock::now() - start;
+        EXPECT_GE(elapsed, std::chrono::seconds(1))
+            << "failure arrived before the status deadline could have fired; "
+               "the wrong path failed (opcode "
+            << static_cast<int>(opcode) << ")";
+        EXPECT_LT(elapsed, std::chrono::seconds(6))
+            << "deadline did not bound the stale-descriptor wait (opcode "
+            << static_cast<int>(opcode) << ")";
+        legacy_server.join();
+    }
 }

--- a/mooncake-transfer-engine/tests/tcp_write_visibility_test.cpp
+++ b/mooncake-transfer-engine/tests/tcp_write_visibility_test.cpp
@@ -1,0 +1,562 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Contract tests for TcpTransport completion semantics (issue #2086).
+//
+// Under the legacy (v1) framing, a WRITE was reported COMPLETED when the
+// final chunk reached the initiator's kernel socket buffer: destination
+// memory could still be mutating megabytes later (measured 166/400
+// iterations torn, worst case the entire 2.4 MB descriptor undelivered),
+// and a server-side rejection was invisible to the initiator (a
+// single-chunk WRITE to an unregistered address "succeeded"). The v2
+// acknowledged framing makes COMPLETED mean "applied at the destination"
+// and failures mean failures; these tests pin that contract and the
+// mixed-version behavior. The main visibility test fails against the
+// legacy framing (which the MC_TCP_PROTO=1 escape hatch still selects).
+
+#include <arpa/inet.h>
+#include <endian.h>
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "transfer_engine.h"
+#include "transport/transport.h"
+
+using namespace mooncake;
+
+namespace {
+
+constexpr size_t kBigLength = 2432 * 1024;  // ~2.4 MB, as reported in #2086
+constexpr size_t kSmallLength = 16 * 1024;  // 16 KB control size
+constexpr size_t kRegionAlign = 4 * 1024 * 1024;
+constexpr int kIterations = 400;
+constexpr int kNoiseThreads = 3;
+
+class ScopedEnvVar {
+   public:
+    ScopedEnvVar(const char* name, const char* value) : name_(name) {
+        if (const char* old = std::getenv(name)) {
+            had_old_value_ = true;
+            old_value_ = old;
+        }
+        setenv(name_.c_str(), value, 1);
+    }
+
+    ~ScopedEnvVar() {
+        if (had_old_value_)
+            setenv(name_.c_str(), old_value_.c_str(), 1);
+        else
+            unsetenv(name_.c_str());
+    }
+
+    ScopedEnvVar(const ScopedEnvVar&) = delete;
+    ScopedEnvVar& operator=(const ScopedEnvVar&) = delete;
+
+   private:
+    std::string name_;
+    std::string old_value_;
+    bool had_old_value_ = false;
+};
+
+struct TestSessionHeader {
+    uint64_t size;
+    uint64_t addr;
+    uint8_t opcode;
+};
+
+static_assert(sizeof(TestSessionHeader) == 24,
+              "legacy TCP header ABI changed unexpectedly");
+
+// Minimal legacy-server behavior for a flagged WRITE: v1 does not recognize
+// opcode 0x81 as WRITE, so it treats the request as READ and streams payload
+// bytes without consuming the initiator's body. A sequential v2 client then
+// deadlocks once both socket directions fill; the concurrent status read must
+// reject the non-status bytes and cancel the body promptly.
+class LegacyReadServer {
+   public:
+    LegacyReadServer() {
+        listen_fd_ = socket(AF_INET, SOCK_STREAM, 0);
+        if (listen_fd_ < 0) return;
+        int one = 1;
+        if (setsockopt(listen_fd_, SOL_SOCKET, SO_REUSEADDR, &one,
+                       sizeof(one)) != 0)
+            return;
+
+        sockaddr_in addr{};
+        addr.sin_family = AF_INET;
+        addr.sin_port = 0;
+        if (inet_pton(AF_INET, "127.0.0.2", &addr.sin_addr) != 1) return;
+        if (bind(listen_fd_, reinterpret_cast<sockaddr*>(&addr),
+                 sizeof(addr)) != 0)
+            return;
+        if (listen(listen_fd_, 1) != 0) return;
+
+        socklen_t len = sizeof(addr);
+        if (getsockname(listen_fd_, reinterpret_cast<sockaddr*>(&addr), &len) !=
+            0)
+            return;
+        port_ = ntohs(addr.sin_port);
+        ok_ = true;
+        thread_ = std::thread([this] { serve(); });
+    }
+
+    ~LegacyReadServer() { join(); }
+
+    uint16_t port() const { return port_; }
+    bool ok() const { return ok_; }
+
+    void join() {
+        // Wake a blocked accept if the client failed before connecting. This
+        // keeps a failed assertion from turning into a hung test process.
+        if (listen_fd_ >= 0) (void)shutdown(listen_fd_, SHUT_RDWR);
+        if (thread_.joinable()) thread_.join();
+        if (listen_fd_ >= 0) {
+            close(listen_fd_);
+            listen_fd_ = -1;
+        }
+    }
+
+    bool sawFlaggedWrite() const { return saw_flagged_write_.load(); }
+
+   private:
+    static bool recvExact(int fd, void* buffer, size_t size) {
+        char* out = static_cast<char*>(buffer);
+        while (size) {
+            ssize_t n = recv(fd, out, size, 0);
+            if (n <= 0) return false;
+            out += n;
+            size -= static_cast<size_t>(n);
+        }
+        return true;
+    }
+
+    void serve() {
+        int fd = accept(listen_fd_, nullptr, nullptr);
+        if (fd < 0) return;
+
+        timeval timeout{8, 0};
+        (void)setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &timeout,
+                         sizeof(timeout));
+
+        TestSessionHeader header{};
+        if (!recvExact(fd, &header, sizeof(header))) {
+            close(fd);
+            return;
+        }
+        saw_flagged_write_.store(header.opcode == 0x81);
+
+        const uint64_t total = le64toh(header.size);
+        std::vector<char> payload(64 * 1024, static_cast<char>(0xA5));
+        uint64_t sent = 0;
+        while (sent < total) {
+            size_t chunk = std::min<uint64_t>(payload.size(), total - sent);
+            ssize_t n = send(fd, payload.data(), chunk, MSG_NOSIGNAL);
+            if (n <= 0) break;
+            sent += static_cast<uint64_t>(n);
+        }
+        close(fd);
+    }
+
+    int listen_fd_ = -1;
+    uint16_t port_ = 0;
+    bool ok_ = false;
+    std::thread thread_;
+    std::atomic<bool> saw_flagged_write_{false};
+};
+
+struct EngineHandle {
+    std::unique_ptr<TransferEngine> engine;
+    void* pool = nullptr;
+
+    ~EngineHandle() {
+        engine.reset();  // unregisters memory before the pool goes away
+        free(pool);
+    }
+    Transport::SegmentID segment_id = 0;
+    uint64_t remote_base = 0;
+    bool ok = false;  // ASSERT_* in a helper only aborts the helper
+
+    void init(const std::string& metadata_server,
+              const std::string& server_name, size_t pool_size) {
+        // Exercise the pooled-connection path (default off): connection
+        // reuse vs. discard-on-unclean-exchange is part of the contract
+        // under test.
+        setenv("MC_TCP_ENABLE_CONNECTION_POOL", "1", 1);
+        engine = std::make_unique<TransferEngine>(false);
+        auto hp = parseHostNameWithPort(server_name);
+        int rc = engine->init(metadata_server, server_name, hp.first.c_str(),
+                              hp.second);
+        ASSERT_EQ(rc, 0);
+        ASSERT_NE(engine->installTransport("tcp", nullptr), nullptr);
+        pool = malloc(pool_size);
+        ASSERT_NE(pool, nullptr);
+        memset(pool, 0, pool_size);
+        rc = engine->registerLocalMemory(pool, pool_size, "cpu:0");
+        ASSERT_EQ(rc, 0);
+        // With P2PHANDSHAKE metadata the engine's actual RPC port is
+        // auto-assigned; open the segment via the engine-reported address.
+        segment_id = engine->openSegment(engine->getLocalIpAndPort());
+        auto desc = engine->getMetadata()->getSegmentDescByID(segment_id);
+        ASSERT_NE(desc, nullptr);
+        remote_base = (uint64_t)desc->buffers[0].addr;
+        ok = true;
+    }
+};
+
+// Submit one request and poll until terminal state; returns final status.
+TransferStatusEnum runOne(TransferEngine* engine, TransferRequest entry) {
+    auto batch_id = engine->allocateBatchID(1);
+    Status s = engine->submitTransfer(batch_id, {entry});
+    if (!s.ok()) return TransferStatusEnum::FAILED;
+    TransferStatus status;
+    status.s = TransferStatusEnum::WAITING;
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(15);
+    while (status.s != TransferStatusEnum::COMPLETED &&
+           status.s != TransferStatusEnum::FAILED) {
+        if (std::chrono::steady_clock::now() >= deadline)
+            return TransferStatusEnum::TIMEOUT;
+        s = engine->getTransferStatus(batch_id, 0, status);
+        if (!s.ok()) return TransferStatusEnum::FAILED;
+        std::this_thread::yield();
+    }
+    (void)engine->freeBatchID(batch_id);
+    return status.s;
+}
+
+}  // namespace
+
+TEST(TcpWriteVisibilityTest, CompletedWriteIsVisibleToSubsequentRead) {
+    const char* env = std::getenv("MC_METADATA_SERVER");
+    std::string metadata_server = env ? env : "P2PHANDSHAKE";
+    const char* name_env = std::getenv("MC_LOCAL_SERVER_NAME");
+    std::string server_name = name_env ? name_env : "127.0.0.2:17901";
+
+    const size_t pool_size = 64ull << 20;
+    EngineHandle h;
+    h.init(metadata_server, server_name, pool_size);
+    ASSERT_TRUE(h.ok) << "engine/segment setup failed";
+
+    // Region layout inside the registered pool (all offsets from pool base):
+    //   [0, kBigLength)                       : WRITE target region
+    //   [kRegionAlign, +kBigLength)           : local staging for WRITE
+    //   [3*kRegionAlign + t*kRegionAlign, ...): per-noise-thread scratch
+    char* base = (char*)h.pool;
+    char* write_src = base + kRegionAlign;
+
+    std::atomic<bool> stop{false};
+    std::atomic<uint64_t> noise_failures{0};
+    std::vector<std::thread> noise;
+    for (int t = 0; t < kNoiseThreads; ++t) {
+        noise.emplace_back([&, t] {
+            char* src = base + (3 + 2 * t) * kRegionAlign;
+            uint64_t dst_off = (4 + 2 * t) * kRegionAlign;
+            memset(src, 0x5A + t, kSmallLength);
+            while (!stop.load(std::memory_order_relaxed)) {
+                TransferRequest entry;
+                entry.opcode = TransferRequest::WRITE;
+                entry.length = kSmallLength;
+                entry.source = src;
+                entry.target_id = h.segment_id;
+                entry.target_offset = h.remote_base + dst_off;
+                if (runOne(h.engine.get(), entry) !=
+                    TransferStatusEnum::COMPLETED)
+                    noise_failures++;
+            }
+        });
+    }
+
+    uint64_t torn_reads = 0;
+    uint64_t torn_bytes_worst = 0;
+    int first_bad_iter = -1;
+    for (int iter = 1; iter <= kIterations; ++iter) {
+        // Generation-stamped pattern: every byte identifies the iteration.
+        memset(write_src, iter & 0xFF, kBigLength);
+
+        TransferRequest w;
+        w.opcode = TransferRequest::WRITE;
+        w.length = kBigLength;
+        w.source = write_src;
+        w.target_id = h.segment_id;
+        w.target_offset = h.remote_base;  // region at pool offset 0
+        ASSERT_EQ(runOne(h.engine.get(), w), TransferStatusEnum::COMPLETED)
+            << "WRITE failed at iteration " << iter;
+
+        // The WRITE is COMPLETED. The API contract (matching RDMA WRITE
+        // semantics, which disaggregated-serving integrations rely on when
+        // they notify the consumer out-of-band) is that destination memory
+        // is now fully written. Verify by direct local inspection of the
+        // destination region — this is exactly what a decode instance does
+        // after the prefill side signals transfer completion. Scan backwards:
+        // the tail chunks are the ones still in flight when the initiator's
+        // final local send completes.
+        size_t bad = 0;
+        for (size_t i = kBigLength; i-- > 0;) {
+            if ((unsigned char)base[i] != (unsigned char)(iter & 0xFF)) {
+                bad = i + 1;  // bytes [0, i] not yet guaranteed; count prefix
+                break;
+            }
+        }
+        if (bad) {
+            torn_reads++;
+            torn_bytes_worst = std::max<uint64_t>(torn_bytes_worst, bad);
+            if (first_bad_iter < 0) first_bad_iter = iter;
+            // Show it is a visibility delay, not data loss: wait for the
+            // server-side drain to finish before the next iteration so
+            // generations do not overlap.
+            while (memcmp(base, write_src, kBigLength) != 0)
+                std::this_thread::yield();
+        }
+    }
+
+    stop = true;
+    for (auto& t : noise) t.join();
+
+    EXPECT_EQ(torn_reads, 0u)
+        << torn_reads << "/" << kIterations
+        << " reads observed destination bytes not matching the COMPLETED "
+           "write (worst: "
+        << torn_bytes_worst << " stale bytes; first at iteration "
+        << first_bad_iter << "; noise failures: " << noise_failures.load()
+        << ")";
+}
+
+// A server-side rejection must surface as FAILED, not silent success: under
+// v1 framing a single-chunk WRITE to an unregistered address reported
+// COMPLETED because the protocol had no channel for the server to say no.
+TEST(TcpWriteVisibilityTest, RejectedWriteMustFail) {
+    const char* env = std::getenv("MC_METADATA_SERVER");
+    std::string metadata_server = env ? env : "P2PHANDSHAKE";
+    EngineHandle h;
+    h.init(metadata_server, "127.0.0.2:17902", 8ull << 20);
+    ASSERT_TRUE(h.ok) << "engine/segment setup failed";
+
+    char* src = (char*)h.pool;
+    memset(src, 0xAB, kSmallLength);
+    TransferRequest w;
+    w.opcode = TransferRequest::WRITE;
+    w.length = kSmallLength;
+    w.source = src;
+    w.target_id = h.segment_id;
+    // One page past the registered pool: the server rejects it in address
+    // validation.
+    w.target_offset = h.remote_base + (8ull << 20) + 4096;
+    EXPECT_EQ(runOne(h.engine.get(), w), TransferStatusEnum::FAILED);
+
+    // The connection that carried the rejected request must not poison
+    // subsequent transfers.
+    w.target_offset = h.remote_base + kRegionAlign;
+    EXPECT_EQ(runOne(h.engine.get(), w), TransferStatusEnum::COMPLETED);
+}
+
+// A v2 server rejects an invalid destination immediately after the header,
+// while a large client body is still in flight. FAILED is also the caller's
+// source-buffer lifetime boundary, so it must not be published until closing
+// the socket has quiesced the outstanding async_write.
+TEST(TcpWriteVisibilityTest, LargeRejectedWriteQuiescesSourceBeforeFailure) {
+    const char* env = std::getenv("MC_METADATA_SERVER");
+    std::string metadata_server = env ? env : "P2PHANDSHAKE";
+    EngineHandle h;
+    h.init(metadata_server, "127.0.0.2:17906", 8ull << 20);
+    ASSERT_TRUE(h.ok) << "engine/segment setup failed";
+
+    constexpr size_t kLength = 32ull << 20;  // exceed the socket buffers
+    void* source = mmap(nullptr, kLength, PROT_READ | PROT_WRITE,
+                        MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    ASSERT_NE(source, MAP_FAILED);
+    memset(source, 0x6D, kLength);
+
+    TransferRequest w;
+    w.opcode = TransferRequest::WRITE;
+    w.length = kLength;
+    w.source = source;
+    w.target_id = h.segment_id;
+    w.target_offset = h.remote_base + (8ull << 20) + 4096;
+
+    auto start = std::chrono::steady_clock::now();
+    EXPECT_EQ(runOne(h.engine.get(), w), TransferStatusEnum::FAILED);
+    EXPECT_LT(std::chrono::steady_clock::now() - start,
+              std::chrono::seconds(3));
+
+    ASSERT_EQ(mprotect(source, kLength, PROT_NONE), 0);
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    ASSERT_EQ(mprotect(source, kLength, PROT_READ | PROT_WRITE), 0);
+    ASSERT_EQ(munmap(source, kLength), 0);
+
+    // The rejected exchange is unclean, so the next request must use a fresh
+    // connection rather than inheriting the server's mid-session state.
+    char* small_source = static_cast<char*>(h.pool);
+    memset(small_source, 0x42, kSmallLength);
+    w.length = kSmallLength;
+    w.source = small_source;
+    w.target_offset = h.remote_base + kRegionAlign;
+    EXPECT_EQ(runOne(h.engine.get(), w), TransferStatusEnum::COMPLETED);
+}
+
+// v2 READ round-trip: exercises the status-frame-then-data framing in both
+// directions, including content integrity and a rejected READ surfacing as
+// FAILED (v1 could only signal that by dropping the connection).
+TEST(TcpWriteVisibilityTest, V2ReadRoundTripAndRejectedRead) {
+    const char* env = std::getenv("MC_METADATA_SERVER");
+    std::string metadata_server = env ? env : "P2PHANDSHAKE";
+    EngineHandle h;
+    h.init(metadata_server, "127.0.0.2:17904", 16ull << 20);
+    ASSERT_TRUE(h.ok) << "engine/segment setup failed";
+
+    char* base = (char*)h.pool;
+    char* src = base + kRegionAlign;
+    char* dst = base + 2 * kRegionAlign;
+    for (size_t i = 0; i < kBigLength; ++i) src[i] = (char)(i * 131 + 7);
+
+    TransferRequest w;
+    w.opcode = TransferRequest::WRITE;
+    w.length = kBigLength;
+    w.source = src;
+    w.target_id = h.segment_id;
+    w.target_offset = h.remote_base;
+    ASSERT_EQ(runOne(h.engine.get(), w), TransferStatusEnum::COMPLETED);
+
+    TransferRequest r;
+    r.opcode = TransferRequest::READ;
+    r.length = kBigLength;
+    r.source = dst;
+    r.target_id = h.segment_id;
+    r.target_offset = h.remote_base;
+    ASSERT_EQ(runOne(h.engine.get(), r), TransferStatusEnum::COMPLETED);
+    // v2 WRITE completion means the destination was already applied, so the
+    // read-back must match immediately — no drain wait.
+    EXPECT_EQ(memcmp(dst, src, kBigLength), 0);
+
+    // A READ of an unregistered range must fail via the error status frame.
+    r.target_offset = h.remote_base + (16ull << 20) + 4096;
+    EXPECT_EQ(runOne(h.engine.get(), r), TransferStatusEnum::FAILED);
+
+    // And the pool must still be usable afterwards.
+    r.target_offset = h.remote_base;
+    EXPECT_EQ(runOne(h.engine.get(), r), TransferStatusEnum::COMPLETED);
+}
+
+// Mixed-version quadrant: a legacy (v1) initiator against the v2 server —
+// selected via the MC_TCP_PROTO=1 escape hatch — still transfers data
+// correctly (with the old weaker completion semantics).
+TEST(TcpWriteVisibilityTest, LegacyInitiatorInteropWithV2Server) {
+    const char* env = std::getenv("MC_METADATA_SERVER");
+    std::string metadata_server = env ? env : "P2PHANDSHAKE";
+    // Set the process environment before the engine starts any threads, and
+    // restore it only after those threads have stopped. POSIX does not require
+    // setenv()/unsetenv() to synchronize with concurrent getenv() calls.
+    ScopedEnvVar legacy_proto("MC_TCP_PROTO", "1");
+    {
+        EngineHandle h;
+        h.init(metadata_server, "127.0.0.2:17903", 16ull << 20);
+        ASSERT_TRUE(h.ok) << "engine/segment setup failed";
+
+        char* base = (char*)h.pool;
+        char* src = base + kRegionAlign;
+        memset(src, 0x3C, kSmallLength);
+        TransferRequest w;
+        w.opcode = TransferRequest::WRITE;
+        w.length = kSmallLength;
+        w.source = src;
+        w.target_id = h.segment_id;
+        w.target_offset = h.remote_base;
+        EXPECT_EQ(runOne(h.engine.get(), w), TransferStatusEnum::COMPLETED);
+
+        // v1 completion does not guarantee destination visibility; wait for
+        // the server drain before checking content.
+        auto deadline =
+            std::chrono::steady_clock::now() + std::chrono::seconds(10);
+        while (memcmp(base, src, kSmallLength) != 0 &&
+               std::chrono::steady_clock::now() < deadline)
+            std::this_thread::yield();
+        EXPECT_EQ(memcmp(base, src, kSmallLength), 0);
+
+        // Read-back over the transport under v1 framing.
+        char* dst = base + 2 * kRegionAlign;
+        TransferRequest r;
+        r.opcode = TransferRequest::READ;
+        r.length = kSmallLength;
+        r.source = dst;
+        r.target_id = h.segment_id;
+        r.target_offset = h.remote_base;
+        EXPECT_EQ(runOne(h.engine.get(), r), TransferStatusEnum::COMPLETED);
+        EXPECT_EQ(memcmp(dst, src, kSmallLength), 0);
+    }
+}
+
+// A cached v2 descriptor can briefly outlive a server downgrade/restart. A
+// legacy server interprets the flagged WRITE opcode as READ and sends payload
+// while the client sends its body. The concurrent status read must break this
+// full-duplex deadlock, and FAILED must not become visible until asio has
+// released the caller-owned source buffer.
+TEST(TcpWriteVisibilityTest,
+     StaleV2DescriptorAgainstLegacyServerQuiescesWriteBeforeFailure) {
+    const char* env = std::getenv("MC_METADATA_SERVER");
+    std::string metadata_server = env ? env : "P2PHANDSHAKE";
+    EngineHandle h;
+    h.init(metadata_server, "127.0.0.2:17905", 8ull << 20);
+    ASSERT_TRUE(h.ok) << "engine/segment setup failed";
+
+    auto desc = h.engine->getMetadata()->getSegmentDescByID(h.segment_id);
+    ASSERT_NE(desc, nullptr);
+
+    LegacyReadServer legacy_server;
+    ASSERT_TRUE(legacy_server.ok());
+    desc->tcp_data_port = legacy_server.port();
+    desc->tcp_proto_version = 2;  // deliberately stale capability advertisement
+
+    constexpr size_t kLength = 32ull << 20;  // exceed both socket buffers
+    void* source = mmap(nullptr, kLength, PROT_READ | PROT_WRITE,
+                        MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    ASSERT_NE(source, MAP_FAILED);
+    memset(source, 0x5C, kLength);
+
+    TransferRequest w;
+    w.opcode = TransferRequest::WRITE;
+    w.length = kLength;
+    w.source = source;
+    w.target_id = h.segment_id;
+    w.target_offset = h.remote_base;
+
+    auto start = std::chrono::steady_clock::now();
+    EXPECT_EQ(runOne(h.engine.get(), w), TransferStatusEnum::FAILED);
+    auto elapsed = std::chrono::steady_clock::now() - start;
+    // The fake legacy peer waits up to 8s for the old mutual-write deadlock.
+    // Leave generous CI headroom while still proving the concurrent-read path.
+    EXPECT_LT(elapsed, std::chrono::seconds(3));
+
+    // Terminal status is the source-buffer lifetime boundary. Protecting the
+    // pages immediately after FAILED would crash if an async_write still owned
+    // them and attempted further progress.
+    ASSERT_EQ(mprotect(source, kLength, PROT_NONE), 0);
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    ASSERT_EQ(mprotect(source, kLength, PROT_READ | PROT_WRITE), 0);
+    ASSERT_EQ(munmap(source, kLength), 0);
+
+    legacy_server.join();
+    EXPECT_TRUE(legacy_server.sawFlaggedWrite());
+}


### PR DESCRIPTION
## Description

Fixes the TCP data-integrity half of #2086 (the CUDA-13 wheel half was answered in the thread).

`TcpTransport` reported a WRITE as `COMPLETED` when its final chunk entered the *initiator's* kernel socket buffer. There is no frame in the v1 protocol by which the receiver confirms — or rejects — anything, so:

- destination memory can still be mutating megabytes after `COMPLETED` — measured **166/400 iterations torn** with the reported ~2.4 MB descriptor size on loopback, worst case the *entire* descriptor undelivered ([repro details](https://github.com/kvcache-ai/Mooncake/issues/2086#issuecomment-4892802494)). Any consumer notified out-of-band (the RDMA-WRITE semantics this same API provides on the rdma path, which disaggregated serving relies on) reads a torn or stale region — matching the reporter's `dst_hash` differing between consecutive reads, only on large descriptors, with TcpTransport silently serving a `protocol=rdma` config;
- a server-side rejection is invisible: a single-chunk WRITE to an unregistered address reported `COMPLETED` — silent data loss;
- errored connections were re-pooled on `is_open()` alone, so a protocol-desynced socket could corrupt subsequent requests;
- `session_mutex_` was locked and unlocked on different threads (UB per [thread.mutex.requirements]) while synchronizing nothing.

## Design: negotiated, wire-compatible acknowledged framing (v2)

- **Negotiation**: servers advertise `tcp_proto_version: 2` in the segment descriptor (old readers ignore the unknown JSON field; decode tolerates absence, defaulting 1). Initiators set the opcode high bit (`0x80`) only against v2-capable descriptors — all four mixed-version pairings behave: old↔old and old-initiator→new-server are byte-identical to today; new-initiator→old-server can only occur through a stale descriptor and fails fast (below).
- **WRITE**: the server sends an 8-byte status frame only after the final chunk has been applied to destination memory; the initiator completes on that frame. The ack read is armed *concurrently* with the body stream, so a rejection (or a legacy peer) aborts a large in-flight WRITE instead of deadlocking on mutually full socket buffers. If that frame is negative or malformed while `asio::async_write` still owns caller memory, the socket closes immediately but `FAILED` is not published until the body handler has quiesced — terminal status remains the source-buffer lifetime boundary.
- **READ**: the server prefixes the payload with a status frame (sent back-to-back — no added RTT), so rejections are signaled rather than inferred from a dropped connection.
- **Magic-tagged frames**: status frames carry `"MCTV"` in the high 32 bits; an initiator that reaches a v1 server through a stale descriptor (v1 streams payload for unknown opcodes) fails on the first frame instead of mis-framing the stream. The 2⁻⁶⁴ data-dependent residual is documented at the definition.
- **Pool hygiene**: `on_complete_` now reports whether the exchange terminated cleanly; only clean exchanges re-pool the socket, everything else is closed and dropped (fixes the desync-reuse hazard for v1 traffic too).
- **`session_mutex_` removed**: sessions are kept alive by `shared_from_this` in every handler; the mutex had no second owner anywhere and its cross-thread unlock was UB.
- **`MC_TCP_PROTO=1`** forces legacy initiator framing (documented operational escape hatch; also lets the tests cover the mixed-version matrix in one process). Zero-length transfers short-circuit to `COMPLETED` client-side, preserving their (accidental) v1 outcome.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

Multi-core x86_64 Linux test host with a recent GCC/CUDA toolchain; loopback data path (no NIC/GPU required by the tests).

**Test commands:**
```bash
cmake .. -DBUILD_UNIT_TESTS=ON   # USE_TCP default
make tcp_write_visibility_test && ./mooncake-transfer-engine/tests/tcp_write_visibility_test
```

**Results (new `tcp_write_visibility_test`, connection pool enabled):**

| test | main (v1) | this PR |
|---|---|---|
| `CompletedWriteIsVisibleToSubsequentRead` (400 × 2.4 MB generation-stamped writes + 3 noise writers, destination inspected right after COMPLETED) | **fails: 166/400 torn**, worst case 2,432 KB stale | passes, 0/400 |
| `RejectedWriteMustFail` (unregistered address; pool must not be poisoned after) | fails (reports COMPLETED) | passes |
| `LargeRejectedWriteQuiescesSourceBeforeFailure` (32 MB body, immediate valid negative ack, source `mprotect(PROT_NONE)` at FAILED) | hangs/unsafe terminal boundary | passes |
| `StaleV2DescriptorAgainstLegacyServerQuiescesWriteBeforeFailure` (real POSIX v1 fake server, 32 MB full-duplex deadlock cell, malformed ack, source protection) | hangs once both socket directions fill | passes |
| `V2ReadRoundTripAndRejectedRead` (content integrity; rejected READ = FAILED; pool usable after) | n/a | passes |
| `LegacyInitiatorInteropWithV2Server` (`MC_TCP_PROTO=1`) | n/a | passes |

Throughput A/B, `transfer_engine_bench` TCP loopback (equal build flags, write, 4 threads × batch 32, two runs each):

| block | main GB/s | this PR GB/s |
|---|---|---|
| 16 KB | 0.25 / 0.29 | 0.24 / 0.30 |
| 64 KB | 0.88 / 0.84 | 0.88 / 0.97 |
| 256 KB | 1.28 / 1.15 | 1.34 / 1.30 |
| 1 MB | 1.54 / 1.53 | 1.62 / 1.46 |

Flat within noise — the per-request ack bubble is hidden by connection-level parallelism. (While measuring this we found an unrelated pre-existing ~2× TCP throughput loss on `USE_CUDA` builds — filed as #2843.)

Additional final-byte validation on a dedicated Linux test host: normal suite **6/6 × 5**; the two large early-abort/quiescence cells **20/20 each**; CUDA-enabled ASAN/UBSAN/LSAN **6/6 clean**. A CPU TSan build also passes the two new quiescence cells after suppressing three pre-existing engine-wide races in the custom `RWSpinlock`, polling counters, and slice-cache reuse (raw full-suite TSan reports those unrelated existing races).

- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual testing done (matrix above)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] Focused pre-commit hooks pass on every touched non-CMake file; `cmake-format` leaves the added target block unchanged but proposes unrelated reflows elsewhere in the upstream test CMake file, which are intentionally excluded per `AGENTS.md`
- [x] I have updated the documentation (if applicable) — `MC_TCP_PROTO` added to the transfer-engine env-var list
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: N/A — the non-test diff is 459 changed lines (329 additions, 130 deletions), below the governance threshold; #2086 contains the design/root-cause discussion

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

Claude (Anthropic) was used for implementation, test drafting, and adversarial review under my direction (those passes surfaced the mixed-version large-WRITE deadlock cell, missing pool-path coverage, and the requirement to delay terminal failure until an outstanding body write releases caller memory). I reviewed every changed line; all numbers are from real runs on my hardware, and the failure numbers were measured against unmodified main with the same test binary.

---

cc @stmatengss (assignee of #2086) — the root-cause analysis and reproducer data are in the issue thread; happy to adjust protocol details (e.g. frame layout, or gating v2 behind a config) if you'd prefer a different rollout shape.

