### PR TITLE
[TransferEngine] Validate batch memory registrations

### DIFF
--- a/mooncake-transfer-engine/src/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine_impl.cpp
@@ -742,7 +742,32 @@ int TransferEngineImpl::mp_unregisterLocalMemory(
 
 int TransferEngineImpl::registerLocalMemoryBatch(
     const std::vector<BufferEntry>& buffer_list, const std::string& location) {
-    for (auto& buffer : buffer_list) {
+    std::vector<BufferEntry> sorted_buffers = buffer_list;
+    std::sort(sorted_buffers.begin(), sorted_buffers.end(),
+              [](const BufferEntry& lhs, const BufferEntry& rhs) {
+                  return reinterpret_cast<uintptr_t>(lhs.addr) <
+                         reinterpret_cast<uintptr_t>(rhs.addr);
+              });
+
+    for (size_t i = 0; i < sorted_buffers.size(); ++i) {
+        const auto& buffer = sorted_buffers[i];
+        if (buffer.length == 0) {
+            LOG(ERROR)
+                << "Transfer Engine does not support zero length memory region";
+            return ERR_INVALID_ARGUMENT;
+        }
+
+        if (i > 0) {
+            const auto& previous = sorted_buffers[i - 1];
+            auto address = reinterpret_cast<uintptr_t>(buffer.addr);
+            auto previous_address = reinterpret_cast<uintptr_t>(previous.addr);
+            if (address - previous_address < previous.length) {
+                LOG(ERROR) << "Transfer Engine does not support overlapped "
+                              "memory region";
+                return ERR_ADDRESS_OVERLAPPED;
+            }
+        }
+
         if (checkOverlap(buffer.addr, buffer.length)) {
             LOG(ERROR)
                 << "Transfer Engine does not support overlapped memory region";

--- a/mooncake-transfer-engine/tests/transport_uint_test.cpp
+++ b/mooncake-transfer-engine/tests/transport_uint_test.cpp
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 #include <sys/time.h>
 
+#include <array>
 #include <cstdlib>
 #include <fstream>
 #include <iomanip>
@@ -170,6 +171,46 @@ TEST_F(TransportTest, ReadEmptyFile) {
     EXPECT_EQ(bytesRead, static_cast<ssize_t>(0));
 
     close(fd);
+}
+
+TEST_F(TransportTest, RegisterLocalMemoryBatchRejectsOverlappingBuffers) {
+    TransferEngine engine(false);
+    ASSERT_EQ(engine.init(P2PHANDSHAKE, "127.0.0.1:12345"), 0);
+
+    std::array<char, 256> buffer{};
+    std::vector<BufferEntry> entries = {
+        {buffer.data() + 64, 128},
+        {buffer.data(), 128},
+    };
+
+    EXPECT_EQ(engine.registerLocalMemoryBatch(entries, "cpu:0"),
+              ERR_ADDRESS_OVERLAPPED);
+}
+
+TEST_F(TransportTest, RegisterLocalMemoryBatchRejectsZeroLengthBuffer) {
+    TransferEngine engine(false);
+    ASSERT_EQ(engine.init(P2PHANDSHAKE, "127.0.0.1:12345"), 0);
+
+    std::array<char, 1> buffer{};
+    std::vector<BufferEntry> entries = {
+        {buffer.data(), 0},
+    };
+
+    EXPECT_EQ(engine.registerLocalMemoryBatch(entries, "cpu:0"),
+              ERR_INVALID_ARGUMENT);
+}
+
+TEST_F(TransportTest, RegisterLocalMemoryBatchAllowsAdjacentBuffers) {
+    TransferEngine engine(false);
+    ASSERT_EQ(engine.init(P2PHANDSHAKE, "127.0.0.1:12345"), 0);
+
+    std::array<char, 256> buffer{};
+    std::vector<BufferEntry> entries = {
+        {buffer.data() + 128, 128},
+        {buffer.data(), 128},
+    };
+
+    EXPECT_EQ(engine.registerLocalMemoryBatch(entries, "cpu:0"), 0);
 }
 }  // namespace mooncake
 


### PR DESCRIPTION
## Description

Fixes #2853.

`registerLocalMemoryBatch()` previously checked each entry only against existing registrations, so overlapping entries within the same batch and zero-length entries could be accepted.

This PR validates the complete batch before invoking transports:

- Rejects zero-length entries with `ERR_INVALID_ARGUMENT`.
- Rejects intra-batch overlaps with `ERR_ADDRESS_OVERLAPPED`.
- Preserves support for adjacent, non-overlapping entries.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

**Test commands:**
```bash
cmake --build build-batch --target transport_uint_test -j 16
ctest --test-dir build-batch -R '^transport_uint_test$' --output-on-failure
```

**Test results:**
- [x] Unit tests pass (11 test cases)
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (not applicable for this internal validation fix)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue (not applicable; 68 insertions / 2 deletions)

## AI Assistance Disclosure

- [x] AI tools were used: Codex assisted with testing