### PR TITLE
[TENT] Add QoS contract schema resolver

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/runtime/qos_contract.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/qos_contract.h
@@ -31,34 +31,22 @@ namespace tent {
 
 struct QosPolicyFields {
     std::optional<int> priority;
-    std::optional<double> min_bandwidth_gbps;
-    std::optional<double> max_bandwidth_gbps;
-    std::optional<uint32_t> weight;
-    std::optional<uint64_t> burst_bytes;
     std::optional<uint64_t> max_inflight_bytes;
     std::optional<uint64_t> max_inflight_requests;
-    std::optional<std::string> deadline_profile;
     std::optional<std::vector<std::string>> allowed_degraded_actions;
 };
 
 struct QosRequestContext {
-    // Tenant is the administrative isolation domain for QoS resolution
-    // (for example a user, workload group, or serving deployment). When no
-    // explicit policy_name is matched, the resolver applies this tenant's
-    // defaults and then this tenant's intent-specific override. Empty values
+    // Opaque administrative isolation identifier supplied by the caller. A
+    // Store integration should pass its canonical Store tenant ID here rather
+    // than create a second TENT-specific tenant namespace. Empty values
     // normalize to "default".
-    std::string tenant = "default";
+    std::string tenant_id = "default";
     // Intent is the normalized business meaning of the transfer
     // (foreground_get, background_prefetch, checkpoint, ...). When no explicit
-    // policy_name is matched, it first selects global intent defaults and then
     // selects the tenant-local intent override. Empty values normalize to
     // "unspec".
     std::string intent = "unspec";
-    // Optional explicit contract name requested by the caller. If it matches a
-    // named contract, that contract is selected after global defaults and the
-    // tenant/intent lookup is skipped. If it is unknown, compatibility mode
-    // falls back to tenant/intent resolution; strict mode rejects the request.
-    std::optional<std::string> policy_name;
     // Legacy caller priority. It is preserved when no resolved contract sets a
     // priority, and is overridden by the effective QoS contract priority when
     // present.
@@ -69,11 +57,11 @@ struct EffectiveQosPolicy : public QosPolicyFields {
     bool enabled = false;
     bool matched = false;
     // Normalized request identity used for resolution and explain output.
-    std::string tenant = "default";
+    std::string tenant_id = "default";
     std::string intent = "unspec";
     // Name of the contract layer that supplied the most specific match:
-    // compatibility_default, global_default, intent_default.<intent>,
-    // <tenant>.default, <tenant>.<intent>, or an explicit policy_name.
+    // compatibility_default, global_default, <tenant>.default, or
+    // <tenant>.<intent>.
     std::string matched_contract = "compatibility_default";
     int requested_priority = PRIO_HIGH;
     int effective_priority = PRIO_HIGH;
@@ -84,7 +72,6 @@ class QosContractResolver {
     Status loadFromConfig(const Config& config);
 
     bool enabled() const { return enabled_; }
-    bool strictMode() const { return strict_mode_; }
 
     Status resolve(const QosRequestContext& context,
                    EffectiveQosPolicy* out) const;
@@ -113,11 +100,8 @@ class QosContractResolver {
     static void fieldsToJson(json* out, const QosPolicyFields& fields);
 
     bool enabled_{false};
-    bool strict_mode_{false};
     QosPolicyFields global_defaults_;
-    std::unordered_map<std::string, QosPolicyFields> intent_defaults_;
     std::unordered_map<std::string, TenantContract> tenants_;
-    std::unordered_map<std::string, QosPolicyFields> named_contracts_;
 };
 
 }  // namespace tent

--- a/mooncake-transfer-engine/tent/include/tent/runtime/qos_contract.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/qos_contract.h
@@ -38,7 +38,7 @@ struct QosPolicyFields {
     std::optional<uint64_t> max_inflight_bytes;
     std::optional<uint64_t> max_inflight_requests;
     std::optional<std::string> deadline_profile;
-    std::vector<std::string> allowed_degraded_actions;
+    std::optional<std::vector<std::string>> allowed_degraded_actions;
 };
 
 struct QosRequestContext {

--- a/mooncake-transfer-engine/tent/include/tent/runtime/qos_contract.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/qos_contract.h
@@ -1,0 +1,105 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TENT_RUNTIME_QOS_CONTRACT_H
+#define TENT_RUNTIME_QOS_CONTRACT_H
+
+#include "tent/common/config.h"
+#include "tent/common/status.h"
+#include "tent/common/types.h"
+#include "tent/thirdparty/nlohmann/json.h"
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace mooncake {
+namespace tent {
+
+struct QosPolicyFields {
+    std::optional<int> priority;
+    std::optional<double> min_bandwidth_gbps;
+    std::optional<double> max_bandwidth_gbps;
+    std::optional<uint32_t> weight;
+    std::optional<uint64_t> burst_bytes;
+    std::optional<uint64_t> max_inflight_bytes;
+    std::optional<uint64_t> max_inflight_requests;
+    std::optional<std::string> deadline_profile;
+    std::vector<std::string> allowed_degraded_actions;
+};
+
+struct QosRequestContext {
+    std::string tenant = "default";
+    std::string intent = "unspec";
+    std::optional<std::string> policy_name;
+    int requested_priority = PRIO_HIGH;
+};
+
+struct EffectiveQosPolicy : public QosPolicyFields {
+    bool enabled = false;
+    bool matched = false;
+    std::string tenant = "default";
+    std::string intent = "unspec";
+    std::string matched_contract = "compatibility_default";
+    int requested_priority = PRIO_HIGH;
+    int effective_priority = PRIO_HIGH;
+};
+
+class QosContractResolver {
+   public:
+    Status loadFromConfig(const Config& config);
+
+    bool enabled() const { return enabled_; }
+    bool strictMode() const { return strict_mode_; }
+
+    Status resolve(const QosRequestContext& context,
+                   EffectiveQosPolicy* out) const;
+
+    std::string explainJson(const EffectiveQosPolicy& policy,
+                            int indent = 2) const;
+
+    static std::string intentTypeName(IntentType intent);
+
+   private:
+    struct TenantContract {
+        QosPolicyFields defaults;
+        std::unordered_map<std::string, QosPolicyFields> intents;
+    };
+
+    static Status parsePolicyFields(const json& node, QosPolicyFields* out,
+                                    const std::string& path);
+    static Status parsePriority(const json& node, int* out,
+                                const std::string& path);
+    static Status parseBytes(const json& node, uint64_t* out,
+                             const std::string& path);
+    static Status parseUint64(const json& node, uint64_t* out,
+                              const std::string& path);
+    static std::string normalizeKey(const std::string& value);
+    static void mergeFields(QosPolicyFields* dst, const QosPolicyFields& src);
+    static void fieldsToJson(json* out, const QosPolicyFields& fields);
+
+    bool enabled_{false};
+    bool strict_mode_{false};
+    QosPolicyFields global_defaults_;
+    std::unordered_map<std::string, QosPolicyFields> intent_defaults_;
+    std::unordered_map<std::string, TenantContract> tenants_;
+    std::unordered_map<std::string, QosPolicyFields> named_contracts_;
+};
+
+}  // namespace tent
+}  // namespace mooncake
+
+#endif  // TENT_RUNTIME_QOS_CONTRACT_H

--- a/mooncake-transfer-engine/tent/include/tent/runtime/qos_contract.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/qos_contract.h
@@ -42,17 +42,38 @@ struct QosPolicyFields {
 };
 
 struct QosRequestContext {
+    // Tenant is the administrative isolation domain for QoS resolution
+    // (for example a user, workload group, or serving deployment). When no
+    // explicit policy_name is matched, the resolver applies this tenant's
+    // defaults and then this tenant's intent-specific override. Empty values
+    // normalize to "default".
     std::string tenant = "default";
+    // Intent is the normalized business meaning of the transfer
+    // (foreground_get, background_prefetch, checkpoint, ...). When no explicit
+    // policy_name is matched, it first selects global intent defaults and then
+    // selects the tenant-local intent override. Empty values normalize to
+    // "unspec".
     std::string intent = "unspec";
+    // Optional explicit contract name requested by the caller. If it matches a
+    // named contract, that contract is selected after global defaults and the
+    // tenant/intent lookup is skipped. If it is unknown, compatibility mode
+    // falls back to tenant/intent resolution; strict mode rejects the request.
     std::optional<std::string> policy_name;
+    // Legacy caller priority. It is preserved when no resolved contract sets a
+    // priority, and is overridden by the effective QoS contract priority when
+    // present.
     int requested_priority = PRIO_HIGH;
 };
 
 struct EffectiveQosPolicy : public QosPolicyFields {
     bool enabled = false;
     bool matched = false;
+    // Normalized request identity used for resolution and explain output.
     std::string tenant = "default";
     std::string intent = "unspec";
+    // Name of the contract layer that supplied the most specific match:
+    // compatibility_default, global_default, intent_default.<intent>,
+    // <tenant>.default, <tenant>.<intent>, or an explicit policy_name.
     std::string matched_contract = "compatibility_default";
     int requested_priority = PRIO_HIGH;
     int effective_priority = PRIO_HIGH;

--- a/mooncake-transfer-engine/tent/src/runtime/qos_contract.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/qos_contract.cpp
@@ -65,16 +65,6 @@ Status validateKnownKeys(const json& node,
     return Status::OK();
 }
 
-Status validateBandwidthRange(const QosPolicyFields& fields,
-                              const std::string& path) {
-    if (fields.min_bandwidth_gbps && fields.max_bandwidth_gbps &&
-        *fields.min_bandwidth_gbps > *fields.max_bandwidth_gbps) {
-        return Status::InvalidArgument(
-            path + " min_bandwidth_gbps exceeds max_bandwidth_gbps");
-    }
-    return Status::OK();
-}
-
 }  // namespace
 
 std::string QosContractResolver::normalizeKey(const std::string& value) {
@@ -213,16 +203,8 @@ Status QosContractResolver::parsePolicyFields(const json& node,
         return Status::InvalidArgument(path + " must be an object");
     }
     static const std::vector<std::string> kAllowedPolicyKeys = {
-        "priority",
-        "min_bandwidth_gbps",
-        "max_bandwidth_gbps",
-        "weight",
-        "burst_bytes",
-        "max_inflight_bytes",
-        "max_inflight_requests",
-        "deadline_profile",
-        "allowed_degraded_actions",
-        "name"};
+        "priority", "max_inflight_bytes", "max_inflight_requests",
+        "allowed_degraded_actions"};
     CHECK_STATUS(validateKnownKeys(node, kAllowedPolicyKeys, path));
 
     if (node.contains("priority")) {
@@ -230,37 +212,6 @@ Status QosContractResolver::parsePolicyFields(const json& node,
         CHECK_STATUS(
             parsePriority(node["priority"], &priority, path + ".priority"));
         out->priority = priority;
-    }
-
-    auto parse_double = [&](const char* key,
-                            std::optional<double>* dst) -> Status {
-        if (!node.contains(key)) return Status::OK();
-        if (!node[key].is_number()) {
-            return Status::InvalidArgument(path + "." + key +
-                                           " must be numeric");
-        }
-        double value = node[key].get<double>();
-        if (value < 0.0) {
-            return Status::InvalidArgument(path + "." + key + " must be >= 0");
-        }
-        *dst = value;
-        return Status::OK();
-    };
-    CHECK_STATUS(parse_double("min_bandwidth_gbps", &out->min_bandwidth_gbps));
-    CHECK_STATUS(parse_double("max_bandwidth_gbps", &out->max_bandwidth_gbps));
-    CHECK_STATUS(validateBandwidthRange(*out, path));
-
-    if (node.contains("weight")) {
-        if (!node["weight"].is_number_unsigned() &&
-            !node["weight"].is_number_integer()) {
-            return Status::InvalidArgument(path + ".weight must be integer");
-        }
-        auto weight = node["weight"].get<int64_t>();
-        if (weight <= 0 || weight > std::numeric_limits<uint32_t>::max()) {
-            return Status::InvalidArgument(path +
-                                           ".weight must be positive uint32");
-        }
-        out->weight = static_cast<uint32_t>(weight);
     }
 
     auto parse_bytes_field = [&](const char* key,
@@ -279,24 +230,10 @@ Status QosContractResolver::parsePolicyFields(const json& node,
         *dst = value;
         return Status::OK();
     };
-    CHECK_STATUS(parse_bytes_field("burst_bytes", &out->burst_bytes));
     CHECK_STATUS(
         parse_bytes_field("max_inflight_bytes", &out->max_inflight_bytes));
     CHECK_STATUS(parse_uint64_field("max_inflight_requests",
                                     &out->max_inflight_requests));
-
-    if (node.contains("deadline_profile")) {
-        if (!node["deadline_profile"].is_string()) {
-            return Status::InvalidArgument(path +
-                                           ".deadline_profile must be string");
-        }
-        auto profile =
-            normalizeKey(node["deadline_profile"].get<std::string>());
-        if (profile.empty()) {
-            return Status::InvalidArgument(path + ".deadline_profile is empty");
-        }
-        out->deadline_profile = profile;
-    }
 
     if (node.contains("allowed_degraded_actions")) {
         if (!node["allowed_degraded_actions"].is_array()) {
@@ -325,17 +262,10 @@ Status QosContractResolver::parsePolicyFields(const json& node,
 void QosContractResolver::mergeFields(QosPolicyFields* dst,
                                       const QosPolicyFields& src) {
     if (src.priority) dst->priority = src.priority;
-    if (src.min_bandwidth_gbps)
-        dst->min_bandwidth_gbps = src.min_bandwidth_gbps;
-    if (src.max_bandwidth_gbps)
-        dst->max_bandwidth_gbps = src.max_bandwidth_gbps;
-    if (src.weight) dst->weight = src.weight;
-    if (src.burst_bytes) dst->burst_bytes = src.burst_bytes;
     if (src.max_inflight_bytes)
         dst->max_inflight_bytes = src.max_inflight_bytes;
     if (src.max_inflight_requests)
         dst->max_inflight_requests = src.max_inflight_requests;
-    if (src.deadline_profile) dst->deadline_profile = src.deadline_profile;
     if (src.allowed_degraded_actions) {
         dst->allowed_degraded_actions = src.allowed_degraded_actions;
     }
@@ -343,11 +273,8 @@ void QosContractResolver::mergeFields(QosPolicyFields* dst,
 
 Status QosContractResolver::loadFromConfig(const Config& config) {
     enabled_ = false;
-    strict_mode_ = false;
     global_defaults_ = QosPolicyFields{};
-    intent_defaults_.clear();
     tenants_.clear();
-    named_contracts_.clear();
 
     try {
         json qos = config.get<json>("qos", json{});
@@ -356,7 +283,7 @@ Status QosContractResolver::loadFromConfig(const Config& config) {
             return Status::InvalidArgument("qos must be an object");
         }
         static const std::vector<std::string> kAllowedQosKeys = {
-            "version", "strict_mode", "defaults", "intent_defaults", "tenants"};
+            "version", "defaults", "tenants"};
         CHECK_STATUS(validateKnownKeys(qos, kAllowedQosKeys, "qos"));
 
         if (qos.contains("version") && !qos["version"].is_number_integer()) {
@@ -367,28 +294,9 @@ Status QosContractResolver::loadFromConfig(const Config& config) {
             return Status::InvalidArgument("unsupported qos.version: " +
                                            std::to_string(version));
         }
-        if (qos.contains("strict_mode") && !qos["strict_mode"].is_boolean()) {
-            return Status::InvalidArgument("qos.strict_mode must be boolean");
-        }
-        strict_mode_ = qos.value("strict_mode", false);
-
         if (qos.contains("defaults")) {
             CHECK_STATUS(parsePolicyFields(qos["defaults"], &global_defaults_,
                                            "qos.defaults"));
-        }
-
-        if (qos.contains("intent_defaults")) {
-            if (!qos["intent_defaults"].is_object()) {
-                return Status::InvalidArgument(
-                    "qos.intent_defaults must be an object");
-            }
-            for (auto it = qos["intent_defaults"].begin();
-                 it != qos["intent_defaults"].end(); ++it) {
-                QosPolicyFields fields;
-                CHECK_STATUS(parsePolicyFields(
-                    it.value(), &fields, "qos.intent_defaults." + it.key()));
-                intent_defaults_[normalizeKey(it.key())] = std::move(fields);
-            }
         }
 
         if (qos.contains("tenants")) {
@@ -438,35 +346,6 @@ Status QosContractResolver::loadFromConfig(const Config& config) {
                         CHECK_STATUS(
                             parsePolicyFields(it.value(), &fields,
                                               path + ".intents." + it.key()));
-                        if (it.value().contains("name")) {
-                            if (!it.value()["name"].is_string()) {
-                                return Status::InvalidArgument(
-                                    path + ".intents." + it.key() +
-                                    ".name must be string");
-                            }
-                            auto contract_name = normalizeKey(
-                                it.value()["name"].get<std::string>());
-                            if (contract_name.empty()) {
-                                return Status::InvalidArgument(
-                                    path + ".intents." + it.key() +
-                                    ".name is empty");
-                            }
-                            if (named_contracts_.contains(contract_name)) {
-                                return Status::InvalidArgument(
-                                    "duplicate qos contract name: " +
-                                    contract_name);
-                            }
-                            QosPolicyFields named = global_defaults_;
-                            auto intent_default = intent_defaults_.find(intent);
-                            if (intent_default != intent_defaults_.end()) {
-                                mergeFields(&named, intent_default->second);
-                            }
-                            mergeFields(&named, tenant.defaults);
-                            mergeFields(&named, fields);
-                            CHECK_STATUS(validateBandwidthRange(
-                                named, "qos contract " + contract_name));
-                            named_contracts_[contract_name] = named;
-                        }
                         tenant.intents[intent] = std::move(fields);
                     }
                 }
@@ -474,16 +353,12 @@ Status QosContractResolver::loadFromConfig(const Config& config) {
             }
         }
 
-        enabled_ = qos.contains("defaults") ||
-                   qos.contains("intent_defaults") || qos.contains("tenants");
+        enabled_ = qos.contains("defaults") || qos.contains("tenants");
         return Status::OK();
     } catch (const std::exception& e) {
         enabled_ = false;
-        strict_mode_ = false;
         global_defaults_ = QosPolicyFields{};
-        intent_defaults_.clear();
         tenants_.clear();
-        named_contracts_.clear();
         return Status::InvalidArgument(
             std::string("failed to parse qos config: ") + e.what());
     }
@@ -493,8 +368,8 @@ Status QosContractResolver::resolve(const QosRequestContext& context,
                                     EffectiveQosPolicy* out) const {
     if (!out) return Status::InvalidArgument("effective qos output is null");
     *out = EffectiveQosPolicy{};
-    out->tenant =
-        normalizeKey(context.tenant.empty() ? "default" : context.tenant);
+    out->tenant_id =
+        normalizeKey(context.tenant_id.empty() ? "default" : context.tenant_id);
     out->intent =
         normalizeKey(context.intent.empty() ? "unspec" : context.intent);
     out->requested_priority = context.requested_priority;
@@ -508,44 +383,19 @@ Status QosContractResolver::resolve(const QosRequestContext& context,
     QosPolicyFields fields = global_defaults_;
     out->matched_contract = "global_default";
 
-    if (context.policy_name) {
-        auto policy_name = normalizeKey(*context.policy_name);
-        auto named_it = named_contracts_.find(policy_name);
-        if (named_it != named_contracts_.end()) {
-            mergeFields(&fields, named_it->second);
+    auto tenant_it = tenants_.find(out->tenant_id);
+    if (tenant_it != tenants_.end()) {
+        mergeFields(&fields, tenant_it->second.defaults);
+        out->matched_contract = out->tenant_id + ".default";
+        auto intent_it = tenant_it->second.intents.find(out->intent);
+        if (intent_it != tenant_it->second.intents.end()) {
+            mergeFields(&fields, intent_it->second);
             out->matched = true;
-            out->matched_contract = policy_name;
-        } else if (strict_mode_) {
-            return Status::InvalidArgument("unknown qos policy_name: " +
-                                           policy_name);
-        }
-    }
-
-    if (!out->matched) {
-        auto intent_default = intent_defaults_.find(out->intent);
-        if (intent_default != intent_defaults_.end()) {
-            mergeFields(&fields, intent_default->second);
-            out->matched_contract = "intent_default." + out->intent;
-        }
-
-        auto tenant_it = tenants_.find(out->tenant);
-        if (tenant_it != tenants_.end()) {
-            mergeFields(&fields, tenant_it->second.defaults);
-            out->matched_contract = out->tenant + ".default";
-            auto intent_it = tenant_it->second.intents.find(out->intent);
-            if (intent_it != tenant_it->second.intents.end()) {
-                mergeFields(&fields, intent_it->second);
-                out->matched = true;
-                out->matched_contract = out->tenant + "." + out->intent;
-            }
-        } else if (strict_mode_) {
-            return Status::InvalidArgument("unknown qos tenant: " +
-                                           out->tenant);
+            out->matched_contract = out->tenant_id + "." + out->intent;
         }
     }
 
     static_cast<QosPolicyFields&>(*out) = fields;
-    CHECK_STATUS(validateBandwidthRange(*out, "resolved qos policy"));
     if (out->priority) out->effective_priority = *out->priority;
     return Status::OK();
 }
@@ -553,22 +403,11 @@ Status QosContractResolver::resolve(const QosRequestContext& context,
 void QosContractResolver::fieldsToJson(json* out,
                                        const QosPolicyFields& fields) {
     if (fields.priority) (*out)["priority"] = *fields.priority;
-    if (fields.min_bandwidth_gbps) {
-        (*out)["min_bandwidth_gbps"] = *fields.min_bandwidth_gbps;
-    }
-    if (fields.max_bandwidth_gbps) {
-        (*out)["max_bandwidth_gbps"] = *fields.max_bandwidth_gbps;
-    }
-    if (fields.weight) (*out)["weight"] = *fields.weight;
-    if (fields.burst_bytes) (*out)["burst_bytes"] = *fields.burst_bytes;
     if (fields.max_inflight_bytes) {
         (*out)["max_inflight_bytes"] = *fields.max_inflight_bytes;
     }
     if (fields.max_inflight_requests) {
         (*out)["max_inflight_requests"] = *fields.max_inflight_requests;
-    }
-    if (fields.deadline_profile) {
-        (*out)["deadline_profile"] = *fields.deadline_profile;
     }
     if (fields.allowed_degraded_actions) {
         (*out)["allowed_degraded_actions"] = *fields.allowed_degraded_actions;
@@ -580,19 +419,13 @@ std::string QosContractResolver::explainJson(const EffectiveQosPolicy& policy,
     json out;
     out["enabled"] = policy.enabled;
     out["matched"] = policy.matched;
-    out["tenant"] = policy.tenant;
+    out["tenant_id"] = policy.tenant_id;
     out["intent"] = policy.intent;
     out["matched_contract"] = policy.matched_contract;
     out["requested_priority"] = policy.requested_priority;
     out["effective_priority"] = policy.effective_priority;
+    out["diagnostic_scope"] = "resolution_only";
     fieldsToJson(&out, policy);
-    out["enforcement"] = {
-        {"priority_authorization", "planned"},
-        {"max_inflight_bytes", "planned"},
-        {"max_inflight_requests", "planned"},
-        {"bandwidth_cap", "planned"},
-        {"receiver_credits", "planned"},
-    };
     return out.dump(indent);
 }
 

--- a/mooncake-transfer-engine/tent/src/runtime/qos_contract.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/qos_contract.cpp
@@ -1,0 +1,535 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tent/runtime/qos_contract.h"
+
+#include <algorithm>
+#include <cctype>
+#include <limits>
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+bool isValidPriority(int priority) {
+    return priority == PRIO_HIGH || priority == PRIO_MEDIUM ||
+           priority == PRIO_LOW;
+}
+
+bool isKnownDegradedAction(const std::string& action) {
+    static const std::vector<std::string> kActions = {
+        "delay", "fallback_transport", "local_recompute", "compress", "reject"};
+    return std::find(kActions.begin(), kActions.end(), action) !=
+           kActions.end();
+}
+
+std::string trim(const std::string& input) {
+    size_t begin = 0;
+    while (begin < input.size() &&
+           std::isspace(static_cast<unsigned char>(input[begin]))) {
+        ++begin;
+    }
+    size_t end = input.size();
+    while (end > begin &&
+           std::isspace(static_cast<unsigned char>(input[end - 1]))) {
+        --end;
+    }
+    return input.substr(begin, end - begin);
+}
+
+}  // namespace
+
+std::string QosContractResolver::normalizeKey(const std::string& value) {
+    std::string out = trim(value);
+    std::transform(out.begin(), out.end(), out.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+    });
+    return out;
+}
+
+std::string QosContractResolver::intentTypeName(IntentType intent) {
+    switch (intent) {
+        case IntentType::INTENT_UNSPEC:
+            return "unspec";
+        case IntentType::FOREGROUND_GET:
+            return "foreground_get";
+        case IntentType::BACKGROUND_PREFETCH:
+            return "background_prefetch";
+        case IntentType::MIGRATION:
+            return "migration";
+        case IntentType::CHECKPOINT:
+            return "checkpoint";
+        case IntentType::WEIGHT_LOADING:
+            return "weight_loading";
+        case IntentType::STAGING_INTERNAL:
+            return "staging_internal";
+    }
+    return "unspec";
+}
+
+Status QosContractResolver::parsePriority(const json& node, int* out,
+                                          const std::string& path) {
+    if (!out) return Status::InvalidArgument("priority output is null");
+    if (node.is_number_integer()) {
+        int value = node.get<int>();
+        if (!isValidPriority(value)) {
+            return Status::InvalidArgument(path + " priority out of range");
+        }
+        *out = value;
+        return Status::OK();
+    }
+    if (!node.is_string()) {
+        return Status::InvalidArgument(path +
+                                       " priority must be string or int");
+    }
+    auto value = normalizeKey(node.get<std::string>());
+    if (value == "high" || value == "0") {
+        *out = PRIO_HIGH;
+    } else if (value == "medium" || value == "1") {
+        *out = PRIO_MEDIUM;
+    } else if (value == "low" || value == "2") {
+        *out = PRIO_LOW;
+    } else {
+        return Status::InvalidArgument(path + " priority is unknown: " + value);
+    }
+    return Status::OK();
+}
+
+Status QosContractResolver::parseBytes(const json& node, uint64_t* out,
+                                       const std::string& path) {
+    if (!out) return Status::InvalidArgument("bytes output is null");
+    if (node.is_number_unsigned()) {
+        *out = node.get<uint64_t>();
+        return Status::OK();
+    }
+    if (node.is_number_integer()) {
+        auto value = node.get<int64_t>();
+        if (value < 0) return Status::InvalidArgument(path + " must be >= 0");
+        *out = static_cast<uint64_t>(value);
+        return Status::OK();
+    }
+    if (!node.is_string()) {
+        return Status::InvalidArgument(path + " must be bytes string or int");
+    }
+
+    std::string text = normalizeKey(node.get<std::string>());
+    if (text.empty()) return Status::InvalidArgument(path + " is empty");
+
+    size_t pos = 0;
+    while (pos < text.size() &&
+           std::isdigit(static_cast<unsigned char>(text[pos]))) {
+        ++pos;
+    }
+    if (pos == 0) return Status::InvalidArgument(path + " missing number");
+
+    uint64_t base = 0;
+    try {
+        base = std::stoull(text.substr(0, pos));
+    } catch (const std::exception&) {
+        return Status::InvalidArgument(path + " invalid number");
+    }
+
+    std::string unit = trim(text.substr(pos));
+    uint64_t mul = 1;
+    if (unit.empty() || unit == "b") {
+        mul = 1;
+    } else if (unit == "kib" || unit == "kb") {
+        mul = 1024ull;
+    } else if (unit == "mib" || unit == "mb") {
+        mul = 1024ull * 1024ull;
+    } else if (unit == "gib" || unit == "gb") {
+        mul = 1024ull * 1024ull * 1024ull;
+    } else if (unit == "tib" || unit == "tb") {
+        mul = 1024ull * 1024ull * 1024ull * 1024ull;
+    } else {
+        return Status::InvalidArgument(path + " unsupported unit: " + unit);
+    }
+    if (base > std::numeric_limits<uint64_t>::max() / mul) {
+        return Status::InvalidArgument(path + " overflows uint64");
+    }
+    *out = base * mul;
+    return Status::OK();
+}
+
+Status QosContractResolver::parseUint64(const json& node, uint64_t* out,
+                                        const std::string& path) {
+    if (!out) return Status::InvalidArgument("uint64 output is null");
+    if (node.is_number_unsigned()) {
+        *out = node.get<uint64_t>();
+        return Status::OK();
+    }
+    if (node.is_number_integer()) {
+        auto value = node.get<int64_t>();
+        if (value < 0) return Status::InvalidArgument(path + " must be >= 0");
+        *out = static_cast<uint64_t>(value);
+        return Status::OK();
+    }
+    return Status::InvalidArgument(path + " must be unsigned integer");
+}
+
+Status QosContractResolver::parsePolicyFields(const json& node,
+                                              QosPolicyFields* out,
+                                              const std::string& path) {
+    if (!out) return Status::InvalidArgument("policy fields output is null");
+    if (!node.is_object()) {
+        return Status::InvalidArgument(path + " must be an object");
+    }
+
+    if (node.contains("priority")) {
+        int priority = PRIO_LOW;
+        CHECK_STATUS(
+            parsePriority(node["priority"], &priority, path + ".priority"));
+        out->priority = priority;
+    }
+
+    auto parse_double = [&](const char* key,
+                            std::optional<double>* dst) -> Status {
+        if (!node.contains(key)) return Status::OK();
+        if (!node[key].is_number()) {
+            return Status::InvalidArgument(path + "." + key +
+                                           " must be numeric");
+        }
+        double value = node[key].get<double>();
+        if (value < 0.0) {
+            return Status::InvalidArgument(path + "." + key + " must be >= 0");
+        }
+        *dst = value;
+        return Status::OK();
+    };
+    CHECK_STATUS(parse_double("min_bandwidth_gbps", &out->min_bandwidth_gbps));
+    CHECK_STATUS(parse_double("max_bandwidth_gbps", &out->max_bandwidth_gbps));
+    if (out->min_bandwidth_gbps && out->max_bandwidth_gbps &&
+        *out->min_bandwidth_gbps > *out->max_bandwidth_gbps) {
+        return Status::InvalidArgument(
+            path + " min_bandwidth_gbps exceeds max_bandwidth_gbps");
+    }
+
+    if (node.contains("weight")) {
+        if (!node["weight"].is_number_unsigned() &&
+            !node["weight"].is_number_integer()) {
+            return Status::InvalidArgument(path + ".weight must be integer");
+        }
+        auto weight = node["weight"].get<int64_t>();
+        if (weight <= 0 || weight > std::numeric_limits<uint32_t>::max()) {
+            return Status::InvalidArgument(path +
+                                           ".weight must be positive uint32");
+        }
+        out->weight = static_cast<uint32_t>(weight);
+    }
+
+    auto parse_bytes_field = [&](const char* key,
+                                 std::optional<uint64_t>* dst) -> Status {
+        if (!node.contains(key)) return Status::OK();
+        uint64_t bytes = 0;
+        CHECK_STATUS(parseBytes(node[key], &bytes, path + "." + key));
+        *dst = bytes;
+        return Status::OK();
+    };
+    auto parse_uint64_field = [&](const char* key,
+                                  std::optional<uint64_t>* dst) -> Status {
+        if (!node.contains(key)) return Status::OK();
+        uint64_t value = 0;
+        CHECK_STATUS(parseUint64(node[key], &value, path + "." + key));
+        *dst = value;
+        return Status::OK();
+    };
+    CHECK_STATUS(parse_bytes_field("burst_bytes", &out->burst_bytes));
+    CHECK_STATUS(
+        parse_bytes_field("max_inflight_bytes", &out->max_inflight_bytes));
+    CHECK_STATUS(parse_uint64_field("max_inflight_requests",
+                                    &out->max_inflight_requests));
+
+    if (node.contains("deadline_profile")) {
+        if (!node["deadline_profile"].is_string()) {
+            return Status::InvalidArgument(path +
+                                           ".deadline_profile must be string");
+        }
+        auto profile =
+            normalizeKey(node["deadline_profile"].get<std::string>());
+        if (profile.empty()) {
+            return Status::InvalidArgument(path + ".deadline_profile is empty");
+        }
+        out->deadline_profile = profile;
+    }
+
+    if (node.contains("allowed_degraded_actions")) {
+        if (!node["allowed_degraded_actions"].is_array()) {
+            return Status::InvalidArgument(
+                path + ".allowed_degraded_actions must be array");
+        }
+        out->allowed_degraded_actions.clear();
+        for (const auto& action_node : node["allowed_degraded_actions"]) {
+            if (!action_node.is_string()) {
+                return Status::InvalidArgument(
+                    path + ".allowed_degraded_actions entry must be string");
+            }
+            auto action = normalizeKey(action_node.get<std::string>());
+            if (!isKnownDegradedAction(action)) {
+                return Status::InvalidArgument(
+                    path + " unknown degraded action: " + action);
+            }
+            out->allowed_degraded_actions.push_back(action);
+        }
+    }
+
+    return Status::OK();
+}
+
+void QosContractResolver::mergeFields(QosPolicyFields* dst,
+                                      const QosPolicyFields& src) {
+    if (src.priority) dst->priority = src.priority;
+    if (src.min_bandwidth_gbps)
+        dst->min_bandwidth_gbps = src.min_bandwidth_gbps;
+    if (src.max_bandwidth_gbps)
+        dst->max_bandwidth_gbps = src.max_bandwidth_gbps;
+    if (src.weight) dst->weight = src.weight;
+    if (src.burst_bytes) dst->burst_bytes = src.burst_bytes;
+    if (src.max_inflight_bytes)
+        dst->max_inflight_bytes = src.max_inflight_bytes;
+    if (src.max_inflight_requests)
+        dst->max_inflight_requests = src.max_inflight_requests;
+    if (src.deadline_profile) dst->deadline_profile = src.deadline_profile;
+    if (!src.allowed_degraded_actions.empty()) {
+        dst->allowed_degraded_actions = src.allowed_degraded_actions;
+    }
+}
+
+Status QosContractResolver::loadFromConfig(const Config& config) {
+    enabled_ = false;
+    strict_mode_ = false;
+    global_defaults_ = QosPolicyFields{};
+    intent_defaults_.clear();
+    tenants_.clear();
+    named_contracts_.clear();
+
+    json qos = config.get<json>("qos", json{});
+    if (qos.is_null() || qos.empty()) return Status::OK();
+    if (!qos.is_object()) {
+        return Status::InvalidArgument("qos must be an object");
+    }
+
+    int version = qos.value("version", 1);
+    if (version != 1) {
+        return Status::InvalidArgument("unsupported qos.version: " +
+                                       std::to_string(version));
+    }
+    strict_mode_ = qos.value("strict_mode", false);
+
+    if (qos.contains("defaults")) {
+        CHECK_STATUS(parsePolicyFields(qos["defaults"], &global_defaults_,
+                                       "qos.defaults"));
+    }
+
+    if (qos.contains("intent_defaults")) {
+        if (!qos["intent_defaults"].is_object()) {
+            return Status::InvalidArgument(
+                "qos.intent_defaults must be an object");
+        }
+        for (auto it = qos["intent_defaults"].begin();
+             it != qos["intent_defaults"].end(); ++it) {
+            QosPolicyFields fields;
+            CHECK_STATUS(parsePolicyFields(it.value(), &fields,
+                                           "qos.intent_defaults." + it.key()));
+            intent_defaults_[normalizeKey(it.key())] = std::move(fields);
+        }
+    }
+
+    if (qos.contains("tenants")) {
+        if (!qos["tenants"].is_array()) {
+            return Status::InvalidArgument("qos.tenants must be an array");
+        }
+        for (size_t i = 0; i < qos["tenants"].size(); ++i) {
+            const auto& tenant_node = qos["tenants"][i];
+            const std::string path = "qos.tenants[" + std::to_string(i) + "]";
+            if (!tenant_node.is_object()) {
+                return Status::InvalidArgument(path + " must be an object");
+            }
+            if (!tenant_node.contains("name") ||
+                !tenant_node["name"].is_string()) {
+                return Status::InvalidArgument(path + ".name is required");
+            }
+            auto tenant_name =
+                normalizeKey(tenant_node["name"].get<std::string>());
+            if (tenant_name.empty()) {
+                return Status::InvalidArgument(path + ".name is empty");
+            }
+            if (tenants_.contains(tenant_name)) {
+                return Status::InvalidArgument("duplicate qos tenant: " +
+                                               tenant_name);
+            }
+
+            TenantContract tenant;
+            if (tenant_node.contains("defaults")) {
+                CHECK_STATUS(parsePolicyFields(tenant_node["defaults"],
+                                               &tenant.defaults,
+                                               path + ".defaults"));
+            }
+            if (tenant_node.contains("intents")) {
+                if (!tenant_node["intents"].is_object()) {
+                    return Status::InvalidArgument(
+                        path + ".intents must be an object");
+                }
+                for (auto it = tenant_node["intents"].begin();
+                     it != tenant_node["intents"].end(); ++it) {
+                    QosPolicyFields fields;
+                    const auto intent = normalizeKey(it.key());
+                    CHECK_STATUS(parsePolicyFields(
+                        it.value(), &fields, path + ".intents." + it.key()));
+                    if (it.value().contains("name")) {
+                        if (!it.value()["name"].is_string()) {
+                            return Status::InvalidArgument(
+                                path + ".intents." + it.key() +
+                                ".name must be string");
+                        }
+                        auto contract_name =
+                            normalizeKey(it.value()["name"].get<std::string>());
+                        if (contract_name.empty()) {
+                            return Status::InvalidArgument(path + ".intents." +
+                                                           it.key() +
+                                                           ".name is empty");
+                        }
+                        if (named_contracts_.contains(contract_name)) {
+                            return Status::InvalidArgument(
+                                "duplicate qos contract name: " +
+                                contract_name);
+                        }
+                        QosPolicyFields named = global_defaults_;
+                        auto intent_default = intent_defaults_.find(intent);
+                        if (intent_default != intent_defaults_.end()) {
+                            mergeFields(&named, intent_default->second);
+                        }
+                        mergeFields(&named, tenant.defaults);
+                        mergeFields(&named, fields);
+                        named_contracts_[contract_name] = named;
+                    }
+                    tenant.intents[intent] = std::move(fields);
+                }
+            }
+            tenants_[tenant_name] = std::move(tenant);
+        }
+    }
+
+    enabled_ = qos.contains("defaults") || qos.contains("intent_defaults") ||
+               qos.contains("tenants");
+    return Status::OK();
+}
+
+Status QosContractResolver::resolve(const QosRequestContext& context,
+                                    EffectiveQosPolicy* out) const {
+    if (!out) return Status::InvalidArgument("effective qos output is null");
+    *out = EffectiveQosPolicy{};
+    out->tenant =
+        normalizeKey(context.tenant.empty() ? "default" : context.tenant);
+    out->intent =
+        normalizeKey(context.intent.empty() ? "unspec" : context.intent);
+    out->requested_priority = context.requested_priority;
+    out->effective_priority = isValidPriority(context.requested_priority)
+                                  ? context.requested_priority
+                                  : PRIO_LOW;
+
+    if (!enabled_) return Status::OK();
+
+    out->enabled = true;
+    QosPolicyFields fields = global_defaults_;
+    out->matched_contract = "global_default";
+
+    if (context.policy_name) {
+        auto policy_name = normalizeKey(*context.policy_name);
+        auto named_it = named_contracts_.find(policy_name);
+        if (named_it != named_contracts_.end()) {
+            mergeFields(&fields, named_it->second);
+            out->matched = true;
+            out->matched_contract = policy_name;
+        } else if (strict_mode_) {
+            return Status::InvalidArgument("unknown qos policy_name: " +
+                                           policy_name);
+        }
+    }
+
+    if (!out->matched) {
+        auto intent_default = intent_defaults_.find(out->intent);
+        if (intent_default != intent_defaults_.end()) {
+            mergeFields(&fields, intent_default->second);
+            out->matched_contract = "intent_default." + out->intent;
+        }
+
+        auto tenant_it = tenants_.find(out->tenant);
+        if (tenant_it != tenants_.end()) {
+            mergeFields(&fields, tenant_it->second.defaults);
+            out->matched_contract = out->tenant + ".default";
+            auto intent_it = tenant_it->second.intents.find(out->intent);
+            if (intent_it != tenant_it->second.intents.end()) {
+                mergeFields(&fields, intent_it->second);
+                out->matched = true;
+                out->matched_contract = out->tenant + "." + out->intent;
+            }
+        } else if (strict_mode_) {
+            return Status::InvalidArgument("unknown qos tenant: " +
+                                           out->tenant);
+        }
+    }
+
+    static_cast<QosPolicyFields&>(*out) = fields;
+    if (out->priority) out->effective_priority = *out->priority;
+    return Status::OK();
+}
+
+void QosContractResolver::fieldsToJson(json* out,
+                                       const QosPolicyFields& fields) {
+    if (fields.priority) (*out)["priority"] = *fields.priority;
+    if (fields.min_bandwidth_gbps) {
+        (*out)["min_bandwidth_gbps"] = *fields.min_bandwidth_gbps;
+    }
+    if (fields.max_bandwidth_gbps) {
+        (*out)["max_bandwidth_gbps"] = *fields.max_bandwidth_gbps;
+    }
+    if (fields.weight) (*out)["weight"] = *fields.weight;
+    if (fields.burst_bytes) (*out)["burst_bytes"] = *fields.burst_bytes;
+    if (fields.max_inflight_bytes) {
+        (*out)["max_inflight_bytes"] = *fields.max_inflight_bytes;
+    }
+    if (fields.max_inflight_requests) {
+        (*out)["max_inflight_requests"] = *fields.max_inflight_requests;
+    }
+    if (fields.deadline_profile) {
+        (*out)["deadline_profile"] = *fields.deadline_profile;
+    }
+    if (!fields.allowed_degraded_actions.empty()) {
+        (*out)["allowed_degraded_actions"] = fields.allowed_degraded_actions;
+    }
+}
+
+std::string QosContractResolver::explainJson(const EffectiveQosPolicy& policy,
+                                             int indent) const {
+    json out;
+    out["enabled"] = policy.enabled;
+    out["matched"] = policy.matched;
+    out["tenant"] = policy.tenant;
+    out["intent"] = policy.intent;
+    out["matched_contract"] = policy.matched_contract;
+    out["requested_priority"] = policy.requested_priority;
+    out["effective_priority"] = policy.effective_priority;
+    fieldsToJson(&out, policy);
+    out["enforcement"] = {
+        {"priority_authorization", "planned"},
+        {"max_inflight_bytes", "planned"},
+        {"max_inflight_requests", "planned"},
+        {"bandwidth_cap", "planned"},
+        {"receiver_credits", "planned"},
+    };
+    return out.dump(indent);
+}
+
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/src/runtime/qos_contract.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/qos_contract.cpp
@@ -48,6 +48,33 @@ std::string trim(const std::string& input) {
     return input.substr(begin, end - begin);
 }
 
+bool containsKey(const std::vector<std::string>& allowed,
+                 const std::string& key) {
+    return std::find(allowed.begin(), allowed.end(), key) != allowed.end();
+}
+
+Status validateKnownKeys(const json& node,
+                         const std::vector<std::string>& allowed,
+                         const std::string& path) {
+    for (auto it = node.begin(); it != node.end(); ++it) {
+        if (!containsKey(allowed, it.key())) {
+            return Status::InvalidArgument(
+                path + " contains unknown key: " + it.key());
+        }
+    }
+    return Status::OK();
+}
+
+Status validateBandwidthRange(const QosPolicyFields& fields,
+                              const std::string& path) {
+    if (fields.min_bandwidth_gbps && fields.max_bandwidth_gbps &&
+        *fields.min_bandwidth_gbps > *fields.max_bandwidth_gbps) {
+        return Status::InvalidArgument(
+            path + " min_bandwidth_gbps exceeds max_bandwidth_gbps");
+    }
+    return Status::OK();
+}
+
 }  // namespace
 
 std::string QosContractResolver::normalizeKey(const std::string& value) {
@@ -185,6 +212,18 @@ Status QosContractResolver::parsePolicyFields(const json& node,
     if (!node.is_object()) {
         return Status::InvalidArgument(path + " must be an object");
     }
+    static const std::vector<std::string> kAllowedPolicyKeys = {
+        "priority",
+        "min_bandwidth_gbps",
+        "max_bandwidth_gbps",
+        "weight",
+        "burst_bytes",
+        "max_inflight_bytes",
+        "max_inflight_requests",
+        "deadline_profile",
+        "allowed_degraded_actions",
+        "name"};
+    CHECK_STATUS(validateKnownKeys(node, kAllowedPolicyKeys, path));
 
     if (node.contains("priority")) {
         int priority = PRIO_LOW;
@@ -209,11 +248,7 @@ Status QosContractResolver::parsePolicyFields(const json& node,
     };
     CHECK_STATUS(parse_double("min_bandwidth_gbps", &out->min_bandwidth_gbps));
     CHECK_STATUS(parse_double("max_bandwidth_gbps", &out->max_bandwidth_gbps));
-    if (out->min_bandwidth_gbps && out->max_bandwidth_gbps &&
-        *out->min_bandwidth_gbps > *out->max_bandwidth_gbps) {
-        return Status::InvalidArgument(
-            path + " min_bandwidth_gbps exceeds max_bandwidth_gbps");
-    }
+    CHECK_STATUS(validateBandwidthRange(*out, path));
 
     if (node.contains("weight")) {
         if (!node["weight"].is_number_unsigned() &&
@@ -268,7 +303,7 @@ Status QosContractResolver::parsePolicyFields(const json& node,
             return Status::InvalidArgument(
                 path + ".allowed_degraded_actions must be array");
         }
-        out->allowed_degraded_actions.clear();
+        std::vector<std::string> actions;
         for (const auto& action_node : node["allowed_degraded_actions"]) {
             if (!action_node.is_string()) {
                 return Status::InvalidArgument(
@@ -279,8 +314,9 @@ Status QosContractResolver::parsePolicyFields(const json& node,
                 return Status::InvalidArgument(
                     path + " unknown degraded action: " + action);
             }
-            out->allowed_degraded_actions.push_back(action);
+            actions.push_back(action);
         }
+        out->allowed_degraded_actions = std::move(actions);
     }
 
     return Status::OK();
@@ -300,7 +336,7 @@ void QosContractResolver::mergeFields(QosPolicyFields* dst,
     if (src.max_inflight_requests)
         dst->max_inflight_requests = src.max_inflight_requests;
     if (src.deadline_profile) dst->deadline_profile = src.deadline_profile;
-    if (!src.allowed_degraded_actions.empty()) {
+    if (src.allowed_degraded_actions) {
         dst->allowed_degraded_actions = src.allowed_degraded_actions;
     }
 }
@@ -313,116 +349,144 @@ Status QosContractResolver::loadFromConfig(const Config& config) {
     tenants_.clear();
     named_contracts_.clear();
 
-    json qos = config.get<json>("qos", json{});
-    if (qos.is_null() || qos.empty()) return Status::OK();
-    if (!qos.is_object()) {
-        return Status::InvalidArgument("qos must be an object");
-    }
-
-    int version = qos.value("version", 1);
-    if (version != 1) {
-        return Status::InvalidArgument("unsupported qos.version: " +
-                                       std::to_string(version));
-    }
-    strict_mode_ = qos.value("strict_mode", false);
-
-    if (qos.contains("defaults")) {
-        CHECK_STATUS(parsePolicyFields(qos["defaults"], &global_defaults_,
-                                       "qos.defaults"));
-    }
-
-    if (qos.contains("intent_defaults")) {
-        if (!qos["intent_defaults"].is_object()) {
-            return Status::InvalidArgument(
-                "qos.intent_defaults must be an object");
+    try {
+        json qos = config.get<json>("qos", json{});
+        if (qos.is_null() || qos.empty()) return Status::OK();
+        if (!qos.is_object()) {
+            return Status::InvalidArgument("qos must be an object");
         }
-        for (auto it = qos["intent_defaults"].begin();
-             it != qos["intent_defaults"].end(); ++it) {
-            QosPolicyFields fields;
-            CHECK_STATUS(parsePolicyFields(it.value(), &fields,
-                                           "qos.intent_defaults." + it.key()));
-            intent_defaults_[normalizeKey(it.key())] = std::move(fields);
-        }
-    }
+        static const std::vector<std::string> kAllowedQosKeys = {
+            "version", "strict_mode", "defaults", "intent_defaults", "tenants"};
+        CHECK_STATUS(validateKnownKeys(qos, kAllowedQosKeys, "qos"));
 
-    if (qos.contains("tenants")) {
-        if (!qos["tenants"].is_array()) {
-            return Status::InvalidArgument("qos.tenants must be an array");
+        if (qos.contains("version") && !qos["version"].is_number_integer()) {
+            return Status::InvalidArgument("qos.version must be an integer");
         }
-        for (size_t i = 0; i < qos["tenants"].size(); ++i) {
-            const auto& tenant_node = qos["tenants"][i];
-            const std::string path = "qos.tenants[" + std::to_string(i) + "]";
-            if (!tenant_node.is_object()) {
-                return Status::InvalidArgument(path + " must be an object");
-            }
-            if (!tenant_node.contains("name") ||
-                !tenant_node["name"].is_string()) {
-                return Status::InvalidArgument(path + ".name is required");
-            }
-            auto tenant_name =
-                normalizeKey(tenant_node["name"].get<std::string>());
-            if (tenant_name.empty()) {
-                return Status::InvalidArgument(path + ".name is empty");
-            }
-            if (tenants_.contains(tenant_name)) {
-                return Status::InvalidArgument("duplicate qos tenant: " +
-                                               tenant_name);
-            }
+        int version = qos.value("version", 1);
+        if (version != 1) {
+            return Status::InvalidArgument("unsupported qos.version: " +
+                                           std::to_string(version));
+        }
+        if (qos.contains("strict_mode") && !qos["strict_mode"].is_boolean()) {
+            return Status::InvalidArgument("qos.strict_mode must be boolean");
+        }
+        strict_mode_ = qos.value("strict_mode", false);
 
-            TenantContract tenant;
-            if (tenant_node.contains("defaults")) {
-                CHECK_STATUS(parsePolicyFields(tenant_node["defaults"],
-                                               &tenant.defaults,
-                                               path + ".defaults"));
+        if (qos.contains("defaults")) {
+            CHECK_STATUS(parsePolicyFields(qos["defaults"], &global_defaults_,
+                                           "qos.defaults"));
+        }
+
+        if (qos.contains("intent_defaults")) {
+            if (!qos["intent_defaults"].is_object()) {
+                return Status::InvalidArgument(
+                    "qos.intent_defaults must be an object");
             }
-            if (tenant_node.contains("intents")) {
-                if (!tenant_node["intents"].is_object()) {
-                    return Status::InvalidArgument(
-                        path + ".intents must be an object");
+            for (auto it = qos["intent_defaults"].begin();
+                 it != qos["intent_defaults"].end(); ++it) {
+                QosPolicyFields fields;
+                CHECK_STATUS(parsePolicyFields(
+                    it.value(), &fields, "qos.intent_defaults." + it.key()));
+                intent_defaults_[normalizeKey(it.key())] = std::move(fields);
+            }
+        }
+
+        if (qos.contains("tenants")) {
+            if (!qos["tenants"].is_array()) {
+                return Status::InvalidArgument("qos.tenants must be an array");
+            }
+            static const std::vector<std::string> kAllowedTenantKeys = {
+                "name", "defaults", "intents"};
+            for (size_t i = 0; i < qos["tenants"].size(); ++i) {
+                const auto& tenant_node = qos["tenants"][i];
+                const std::string path =
+                    "qos.tenants[" + std::to_string(i) + "]";
+                if (!tenant_node.is_object()) {
+                    return Status::InvalidArgument(path + " must be an object");
                 }
-                for (auto it = tenant_node["intents"].begin();
-                     it != tenant_node["intents"].end(); ++it) {
-                    QosPolicyFields fields;
-                    const auto intent = normalizeKey(it.key());
-                    CHECK_STATUS(parsePolicyFields(
-                        it.value(), &fields, path + ".intents." + it.key()));
-                    if (it.value().contains("name")) {
-                        if (!it.value()["name"].is_string()) {
-                            return Status::InvalidArgument(
-                                path + ".intents." + it.key() +
-                                ".name must be string");
-                        }
-                        auto contract_name =
-                            normalizeKey(it.value()["name"].get<std::string>());
-                        if (contract_name.empty()) {
-                            return Status::InvalidArgument(path + ".intents." +
-                                                           it.key() +
-                                                           ".name is empty");
-                        }
-                        if (named_contracts_.contains(contract_name)) {
-                            return Status::InvalidArgument(
-                                "duplicate qos contract name: " +
-                                contract_name);
-                        }
-                        QosPolicyFields named = global_defaults_;
-                        auto intent_default = intent_defaults_.find(intent);
-                        if (intent_default != intent_defaults_.end()) {
-                            mergeFields(&named, intent_default->second);
-                        }
-                        mergeFields(&named, tenant.defaults);
-                        mergeFields(&named, fields);
-                        named_contracts_[contract_name] = named;
+                CHECK_STATUS(
+                    validateKnownKeys(tenant_node, kAllowedTenantKeys, path));
+                if (!tenant_node.contains("name") ||
+                    !tenant_node["name"].is_string()) {
+                    return Status::InvalidArgument(path + ".name is required");
+                }
+                auto tenant_name =
+                    normalizeKey(tenant_node["name"].get<std::string>());
+                if (tenant_name.empty()) {
+                    return Status::InvalidArgument(path + ".name is empty");
+                }
+                if (tenants_.contains(tenant_name)) {
+                    return Status::InvalidArgument("duplicate qos tenant: " +
+                                                   tenant_name);
+                }
+
+                TenantContract tenant;
+                if (tenant_node.contains("defaults")) {
+                    CHECK_STATUS(parsePolicyFields(tenant_node["defaults"],
+                                                   &tenant.defaults,
+                                                   path + ".defaults"));
+                }
+                if (tenant_node.contains("intents")) {
+                    if (!tenant_node["intents"].is_object()) {
+                        return Status::InvalidArgument(
+                            path + ".intents must be an object");
                     }
-                    tenant.intents[intent] = std::move(fields);
+                    for (auto it = tenant_node["intents"].begin();
+                         it != tenant_node["intents"].end(); ++it) {
+                        QosPolicyFields fields;
+                        const auto intent = normalizeKey(it.key());
+                        CHECK_STATUS(
+                            parsePolicyFields(it.value(), &fields,
+                                              path + ".intents." + it.key()));
+                        if (it.value().contains("name")) {
+                            if (!it.value()["name"].is_string()) {
+                                return Status::InvalidArgument(
+                                    path + ".intents." + it.key() +
+                                    ".name must be string");
+                            }
+                            auto contract_name = normalizeKey(
+                                it.value()["name"].get<std::string>());
+                            if (contract_name.empty()) {
+                                return Status::InvalidArgument(
+                                    path + ".intents." + it.key() +
+                                    ".name is empty");
+                            }
+                            if (named_contracts_.contains(contract_name)) {
+                                return Status::InvalidArgument(
+                                    "duplicate qos contract name: " +
+                                    contract_name);
+                            }
+                            QosPolicyFields named = global_defaults_;
+                            auto intent_default = intent_defaults_.find(intent);
+                            if (intent_default != intent_defaults_.end()) {
+                                mergeFields(&named, intent_default->second);
+                            }
+                            mergeFields(&named, tenant.defaults);
+                            mergeFields(&named, fields);
+                            CHECK_STATUS(validateBandwidthRange(
+                                named, "qos contract " + contract_name));
+                            named_contracts_[contract_name] = named;
+                        }
+                        tenant.intents[intent] = std::move(fields);
+                    }
                 }
+                tenants_[tenant_name] = std::move(tenant);
             }
-            tenants_[tenant_name] = std::move(tenant);
         }
-    }
 
-    enabled_ = qos.contains("defaults") || qos.contains("intent_defaults") ||
-               qos.contains("tenants");
-    return Status::OK();
+        enabled_ = qos.contains("defaults") ||
+                   qos.contains("intent_defaults") || qos.contains("tenants");
+        return Status::OK();
+    } catch (const std::exception& e) {
+        enabled_ = false;
+        strict_mode_ = false;
+        global_defaults_ = QosPolicyFields{};
+        intent_defaults_.clear();
+        tenants_.clear();
+        named_contracts_.clear();
+        return Status::InvalidArgument(
+            std::string("failed to parse qos config: ") + e.what());
+    }
 }
 
 Status QosContractResolver::resolve(const QosRequestContext& context,
@@ -481,6 +545,7 @@ Status QosContractResolver::resolve(const QosRequestContext& context,
     }
 
     static_cast<QosPolicyFields&>(*out) = fields;
+    CHECK_STATUS(validateBandwidthRange(*out, "resolved qos policy"));
     if (out->priority) out->effective_priority = *out->priority;
     return Status::OK();
 }
@@ -505,8 +570,8 @@ void QosContractResolver::fieldsToJson(json* out,
     if (fields.deadline_profile) {
         (*out)["deadline_profile"] = *fields.deadline_profile;
     }
-    if (!fields.allowed_degraded_actions.empty()) {
-        (*out)["allowed_degraded_actions"] = fields.allowed_degraded_actions;
+    if (fields.allowed_degraded_actions) {
+        (*out)["allowed_degraded_actions"] = *fields.allowed_degraded_actions;
     }
 }
 

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -164,7 +164,15 @@ target_include_directories(tent_rail_monitor_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME tent_rail_monitor_test COMMAND tent_rail_monitor_test)
 
-# Transport Selector Unit Test
+# QoS Contract Schema Unit Test
+add_executable(tent_qos_contract_test qos_contract_test.cpp
+                                      ../src/runtime/qos_contract.cpp)
+target_link_libraries(tent_qos_contract_test PRIVATE gtest gtest_main
+                                                     tent_common)
+target_include_directories(tent_qos_contract_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+add_test(NAME tent_qos_contract_test COMMAND tent_qos_contract_test)
+
 add_executable(tent_transport_selector_test transport_selector_test.cpp)
 target_link_libraries(tent_transport_selector_test PRIVATE gtest gtest_main
                                                             tent_link_group)

--- a/mooncake-transfer-engine/tent/tests/qos_contract_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/qos_contract_test.cpp
@@ -36,9 +36,8 @@ TEST(QosContractTest, EmptyConfigIsDisabledAndPreservesRequestPriority) {
     EXPECT_FALSE(resolver.enabled());
 
     EffectiveQosPolicy effective;
-    status = resolver.resolve({.tenant = "tenant-a",
+    status = resolver.resolve({.tenant_id = "tenant-a",
                                .intent = "foreground_get",
-                               .policy_name = std::nullopt,
                                .requested_priority = PRIO_LOW},
                               &effective);
     ASSERT_TRUE(status.ok()) << status.ToString();
@@ -47,7 +46,7 @@ TEST(QosContractTest, EmptyConfigIsDisabledAndPreservesRequestPriority) {
     EXPECT_EQ(effective.matched_contract, "compatibility_default");
 }
 
-TEST(QosContractTest, ResolvesTenantIntentContractWithInheritedDefaults) {
+TEST(QosContractTest, ResolvesGlobalTenantAndIntentLayers) {
     Config config;
     loadConfig(&config, R"json(
 {
@@ -55,30 +54,16 @@ TEST(QosContractTest, ResolvesTenantIntentContractWithInheritedDefaults) {
     "version": 1,
     "defaults": {
       "priority": "medium",
-      "weight": 1,
       "max_inflight_requests": 128,
       "allowed_degraded_actions": ["fallback_transport", "reject"]
-    },
-    "intent_defaults": {
-      "foreground_get": {
-        "deadline_profile": "interactive",
-        "weight": 4
-      }
     },
     "tenants": [
       {
         "name": "tenant-a",
-        "defaults": {
-          "max_inflight_bytes": "1GiB"
-        },
+        "defaults": {"max_inflight_bytes": "1GiB"},
         "intents": {
           "foreground_get": {
-            "name": "tenant-a-fg",
             "priority": "high",
-            "min_bandwidth_gbps": 40,
-            "max_bandwidth_gbps": 100,
-            "weight": 8,
-            "burst_bytes": "2GiB",
             "max_inflight_bytes": "4GiB",
             "max_inflight_requests": 4096,
             "allowed_degraded_actions": ["fallback_transport", "local_recompute", "reject"]
@@ -96,61 +81,47 @@ TEST(QosContractTest, ResolvesTenantIntentContractWithInheritedDefaults) {
     EXPECT_TRUE(resolver.enabled());
 
     EffectiveQosPolicy effective;
-    status = resolver.resolve({.tenant = "Tenant-A",
+    status = resolver.resolve({.tenant_id = " Tenant-A ",
                                .intent = "Foreground_Get",
-                               .policy_name = std::nullopt,
                                .requested_priority = PRIO_LOW},
                               &effective);
     ASSERT_TRUE(status.ok()) << status.ToString();
     EXPECT_TRUE(effective.enabled);
     EXPECT_TRUE(effective.matched);
-    EXPECT_EQ(effective.tenant, "tenant-a");
+    EXPECT_EQ(effective.tenant_id, "tenant-a");
     EXPECT_EQ(effective.intent, "foreground_get");
     EXPECT_EQ(effective.matched_contract, "tenant-a.foreground_get");
     ASSERT_TRUE(effective.priority.has_value());
     EXPECT_EQ(*effective.priority, PRIO_HIGH);
     EXPECT_EQ(effective.effective_priority, PRIO_HIGH);
-    ASSERT_TRUE(effective.min_bandwidth_gbps.has_value());
-    EXPECT_DOUBLE_EQ(*effective.min_bandwidth_gbps, 40.0);
-    ASSERT_TRUE(effective.max_bandwidth_gbps.has_value());
-    EXPECT_DOUBLE_EQ(*effective.max_bandwidth_gbps, 100.0);
-    ASSERT_TRUE(effective.weight.has_value());
-    EXPECT_EQ(*effective.weight, 8u);
-    ASSERT_TRUE(effective.burst_bytes.has_value());
-    EXPECT_EQ(*effective.burst_bytes, 2ull * 1024 * 1024 * 1024);
     ASSERT_TRUE(effective.max_inflight_bytes.has_value());
     EXPECT_EQ(*effective.max_inflight_bytes, 4ull * 1024 * 1024 * 1024);
     ASSERT_TRUE(effective.max_inflight_requests.has_value());
     EXPECT_EQ(*effective.max_inflight_requests, 4096u);
-    ASSERT_TRUE(effective.deadline_profile.has_value());
-    EXPECT_EQ(*effective.deadline_profile, "interactive");
     ASSERT_TRUE(effective.allowed_degraded_actions.has_value());
     EXPECT_EQ(effective.allowed_degraded_actions->size(), 3u);
 
     auto explain = nlohmann::json::parse(resolver.explainJson(effective));
+    EXPECT_EQ(explain["tenant_id"], "tenant-a");
     EXPECT_EQ(explain["matched_contract"], "tenant-a.foreground_get");
     EXPECT_EQ(explain["effective_priority"], PRIO_HIGH);
-    EXPECT_EQ(explain["enforcement"]["bandwidth_cap"], "planned");
+    EXPECT_EQ(explain["diagnostic_scope"], "resolution_only");
+    EXPECT_FALSE(explain.contains("enforcement"));
+    EXPECT_FALSE(explain.contains("max_bandwidth_gbps"));
+    EXPECT_FALSE(explain.contains("weight"));
+    EXPECT_FALSE(explain.contains("deadline_profile"));
 }
 
-TEST(QosContractTest, ExplicitPolicyNameCanResolveNamedContract) {
+TEST(QosContractTest, TenantDefaultAppliesWithoutIntentMatch) {
     Config config;
     loadConfig(&config, R"json(
 {
   "qos": {
-    "version": 1,
-    "defaults": {"priority": "low"},
+    "defaults": {"priority": "low", "max_inflight_requests": 16},
     "tenants": [
       {
         "name": "tenant-a",
-        "intents": {
-          "checkpoint": {
-            "name": "bulk-checkpoint",
-            "priority": "low",
-            "max_bandwidth_gbps": 10,
-            "burst_bytes": "256MiB"
-          }
-        }
+        "defaults": {"priority": "medium", "max_inflight_bytes": "64MiB"}
       }
     ]
   }
@@ -160,64 +131,19 @@ TEST(QosContractTest, ExplicitPolicyNameCanResolveNamedContract) {
     ASSERT_TRUE(resolver.loadFromConfig(config).ok());
 
     EffectiveQosPolicy effective;
-    auto status = resolver.resolve({.tenant = "other",
-                                    .intent = "foreground_get",
-                                    .policy_name = "bulk-checkpoint",
+    auto status = resolver.resolve({.tenant_id = "tenant-a",
+                                    .intent = "checkpoint",
                                     .requested_priority = PRIO_HIGH},
                                    &effective);
     ASSERT_TRUE(status.ok()) << status.ToString();
-    EXPECT_TRUE(effective.matched);
-    EXPECT_EQ(effective.matched_contract, "bulk-checkpoint");
-    EXPECT_EQ(effective.effective_priority, PRIO_LOW);
-    ASSERT_TRUE(effective.max_bandwidth_gbps.has_value());
-    EXPECT_DOUBLE_EQ(*effective.max_bandwidth_gbps, 10.0);
+    EXPECT_FALSE(effective.matched);
+    EXPECT_EQ(effective.matched_contract, "tenant-a.default");
+    EXPECT_EQ(effective.effective_priority, PRIO_MEDIUM);
+    EXPECT_EQ(*effective.max_inflight_bytes, 64ull * 1024 * 1024);
+    EXPECT_EQ(*effective.max_inflight_requests, 16u);
 }
 
-TEST(QosContractTest, ExplicitPolicyNameSkipsTenantIntentResolution) {
-    Config config;
-    loadConfig(&config, R"json(
-{
-  "qos": {
-    "version": 1,
-    "defaults": {"priority": "low"},
-    "tenants": [
-      {
-        "name": "tenant-a",
-        "defaults": {"priority": "medium"},
-        "intents": {
-          "foreground_get": {
-            "name": "tenant-critical",
-            "priority": "high"
-          },
-          "checkpoint": {
-            "name": "bulk-checkpoint",
-            "priority": "low",
-            "max_bandwidth_gbps": 10
-          }
-        }
-      }
-    ]
-  }
-}
-)json");
-    QosContractResolver resolver;
-    ASSERT_TRUE(resolver.loadFromConfig(config).ok());
-
-    EffectiveQosPolicy effective;
-    auto status = resolver.resolve({.tenant = "tenant-a",
-                                    .intent = "foreground_get",
-                                    .policy_name = "bulk-checkpoint",
-                                    .requested_priority = PRIO_HIGH},
-                                   &effective);
-    ASSERT_TRUE(status.ok()) << status.ToString();
-    EXPECT_TRUE(effective.matched);
-    EXPECT_EQ(effective.matched_contract, "bulk-checkpoint");
-    EXPECT_EQ(effective.effective_priority, PRIO_LOW);
-    ASSERT_TRUE(effective.max_bandwidth_gbps.has_value());
-    EXPECT_DOUBLE_EQ(*effective.max_bandwidth_gbps, 10.0);
-}
-
-TEST(QosContractTest, UnknownTenantFallsBackInCompatibilityMode) {
+TEST(QosContractTest, UnknownTenantFallsBackToGlobalDefaults) {
     Config config;
     loadConfig(&config, R"json(
 {"qos":{"version":1,"defaults":{"priority":"medium","max_inflight_bytes":"64MiB"}}}
@@ -226,9 +152,8 @@ TEST(QosContractTest, UnknownTenantFallsBackInCompatibilityMode) {
     ASSERT_TRUE(resolver.loadFromConfig(config).ok());
 
     EffectiveQosPolicy effective;
-    auto status = resolver.resolve({.tenant = "missing",
+    auto status = resolver.resolve({.tenant_id = "missing",
                                     .intent = "foreground_get",
-                                    .policy_name = std::nullopt,
                                     .requested_priority = PRIO_HIGH},
                                    &effective);
     ASSERT_TRUE(status.ok()) << status.ToString();
@@ -239,22 +164,30 @@ TEST(QosContractTest, UnknownTenantFallsBackInCompatibilityMode) {
     EXPECT_EQ(*effective.max_inflight_bytes, 64ull * 1024 * 1024);
 }
 
-TEST(QosContractTest, StrictModeRejectsUnknownTenant) {
+TEST(QosContractTest, EmptyIdentityNormalizesToCompatibilityKeys) {
     Config config;
     loadConfig(&config, R"json(
-{"qos":{"version":1,"strict_mode":true,"defaults":{"priority":"medium"}}}
+{
+  "qos": {
+    "defaults": {"priority": "low"},
+    "tenants": [
+      {"name": "default", "intents": {"unspec": {"priority": "medium"}}}
+    ]
+  }
+}
 )json");
     QosContractResolver resolver;
     ASSERT_TRUE(resolver.loadFromConfig(config).ok());
 
     EffectiveQosPolicy effective;
-    auto status = resolver.resolve({.tenant = "missing",
-                                    .intent = "foreground_get",
-                                    .policy_name = std::nullopt,
-                                    .requested_priority = PRIO_HIGH},
-                                   &effective);
-    EXPECT_FALSE(status.ok());
-    EXPECT_TRUE(status.IsInvalidArgument());
+    auto status = resolver.resolve(
+        {.tenant_id = "", .intent = "", .requested_priority = PRIO_HIGH},
+        &effective);
+    ASSERT_TRUE(status.ok()) << status.ToString();
+    EXPECT_EQ(effective.tenant_id, "default");
+    EXPECT_EQ(effective.intent, "unspec");
+    EXPECT_EQ(effective.matched_contract, "default.unspec");
+    EXPECT_EQ(effective.effective_priority, PRIO_MEDIUM);
 }
 
 TEST(QosContractTest, EmptyAllowedDegradedActionsOverridesInherited) {
@@ -262,7 +195,6 @@ TEST(QosContractTest, EmptyAllowedDegradedActionsOverridesInherited) {
     loadConfig(&config, R"json(
 {
   "qos": {
-    "version": 1,
     "defaults": {
       "allowed_degraded_actions": ["fallback_transport", "reject"]
     },
@@ -270,9 +202,7 @@ TEST(QosContractTest, EmptyAllowedDegradedActionsOverridesInherited) {
       {
         "name": "tenant-a",
         "intents": {
-          "foreground_get": {
-            "allowed_degraded_actions": []
-          }
+          "foreground_get": {"allowed_degraded_actions": []}
         }
       }
     ]
@@ -283,9 +213,8 @@ TEST(QosContractTest, EmptyAllowedDegradedActionsOverridesInherited) {
     ASSERT_TRUE(resolver.loadFromConfig(config).ok());
 
     EffectiveQosPolicy effective;
-    auto status = resolver.resolve({.tenant = "tenant-a",
+    auto status = resolver.resolve({.tenant_id = "tenant-a",
                                     .intent = "foreground_get",
-                                    .policy_name = std::nullopt,
                                     .requested_priority = PRIO_HIGH},
                                    &effective);
     ASSERT_TRUE(status.ok()) << status.ToString();
@@ -293,79 +222,63 @@ TEST(QosContractTest, EmptyAllowedDegradedActionsOverridesInherited) {
     EXPECT_TRUE(effective.allowed_degraded_actions->empty());
 }
 
-TEST(QosContractTest, MergedBandwidthRangeFailsClosed) {
-    Config config;
-    loadConfig(&config, R"json(
-{
-  "qos": {
-    "version": 1,
-    "defaults": {"max_bandwidth_gbps": 10},
-    "intent_defaults": {"foreground_get": {"min_bandwidth_gbps": 20}}
-  }
-}
-)json");
-    QosContractResolver resolver;
-    ASSERT_TRUE(resolver.loadFromConfig(config).ok());
+TEST(QosContractTest, DeferredM3ToM5FieldsFailClosed) {
+    static const std::vector<std::string> kDeferredFields = {
+        R"json("min_bandwidth_gbps":20)json",
+        R"json("max_bandwidth_gbps":100)json",
+        R"json("burst_bytes":"1GiB")json", R"json("weight":8)json",
+        R"json("deadline_profile":"interactive")json"};
 
-    EffectiveQosPolicy effective;
-    auto status = resolver.resolve({.tenant = "tenant-a",
-                                    .intent = "foreground_get",
-                                    .policy_name = std::nullopt,
-                                    .requested_priority = PRIO_HIGH},
-                                   &effective);
-    EXPECT_FALSE(status.ok());
-    EXPECT_TRUE(status.IsInvalidArgument());
+    for (const auto& field : kDeferredFields) {
+        Config config;
+        loadConfig(&config, "{\"qos\":{\"defaults\":{" + field + "}}}");
+        QosContractResolver resolver;
+        auto status = resolver.loadFromConfig(config);
+        EXPECT_FALSE(status.ok()) << field;
+        EXPECT_TRUE(status.IsInvalidArgument()) << field;
+        EXPECT_FALSE(resolver.enabled()) << field;
+    }
 }
 
-TEST(QosContractTest, InvalidSchemaFailsClosed) {
-    Config config;
-    loadConfig(&config, R"json(
-{"qos":{"version":1,"defaults":{"priority":"urgent"}}}
-)json");
+TEST(QosContractTest, DeferredResolutionFeaturesFailClosed) {
+    static const std::vector<std::string> kConfigs = {
+        R"json({"qos":{"strict_mode":true,"defaults":{"priority":"high"}}})json",
+        R"json({"qos":{"intent_defaults":{"foreground_get":{"priority":"high"}}}})json",
+        R"json({"qos":{"tenants":[{"name":"tenant-a","intents":{"foreground_get":{"name":"named-policy","priority":"high"}}}]}})json"};
+
+    for (const auto& text : kConfigs) {
+        Config config;
+        loadConfig(&config, text);
+        QosContractResolver resolver;
+        auto status = resolver.loadFromConfig(config);
+        EXPECT_FALSE(status.ok()) << text;
+        EXPECT_TRUE(status.IsInvalidArgument()) << text;
+        EXPECT_FALSE(resolver.enabled()) << text;
+    }
+}
+
+TEST(QosContractTest, InvalidSchemaFailsClosedAndClearsPriorState) {
+    Config valid;
+    loadConfig(&valid, R"json({"qos":{"defaults":{"priority":"medium"}}})json");
     QosContractResolver resolver;
-    auto status = resolver.loadFromConfig(config);
-    EXPECT_FALSE(status.ok());
-    EXPECT_TRUE(status.IsInvalidArgument());
+    ASSERT_TRUE(resolver.loadFromConfig(valid).ok());
+    ASSERT_TRUE(resolver.enabled());
 
-    Config bad_bw;
-    loadConfig(&bad_bw, R"json(
-{"qos":{"version":1,"defaults":{"min_bandwidth_gbps":20,"max_bandwidth_gbps":10}}}
-)json");
-    status = resolver.loadFromConfig(bad_bw);
-    EXPECT_FALSE(status.ok());
-    EXPECT_TRUE(status.IsInvalidArgument());
+    static const std::vector<std::string> kInvalidConfigs = {
+        R"json({"qos":{"defaults":{"priority":"urgent"}}})json",
+        R"json({"qos":{"defaults":{"allowed_degraded_actions":["teleport"]}}})json",
+        R"json({"qos":{"defaults":{"max_inflight_requests":"64MiB"}}})json",
+        R"json({"qos":{"defaults":{"unexpected_qos_key":10}}})json",
+        R"json({"qos":{"version":"1","defaults":{"priority":"high"}}})json"};
 
-    Config bad_action;
-    loadConfig(&bad_action, R"json(
-{"qos":{"version":1,"defaults":{"allowed_degraded_actions":["teleport"]}}}
-)json");
-    status = resolver.loadFromConfig(bad_action);
-    EXPECT_FALSE(status.ok());
-    EXPECT_TRUE(status.IsInvalidArgument());
-
-    Config bad_request_count;
-    loadConfig(&bad_request_count, R"json(
-{"qos":{"version":1,"defaults":{"max_inflight_requests":"64MiB"}}}
-)json");
-    status = resolver.loadFromConfig(bad_request_count);
-    EXPECT_FALSE(status.ok());
-    EXPECT_TRUE(status.IsInvalidArgument());
-
-    Config unknown_key;
-    loadConfig(&unknown_key, R"json(
-{"qos":{"version":1,"defaults":{"unexpected_qos_key":10}}}
-)json");
-    status = resolver.loadFromConfig(unknown_key);
-    EXPECT_FALSE(status.ok());
-    EXPECT_TRUE(status.IsInvalidArgument());
-
-    Config bad_version_type;
-    loadConfig(&bad_version_type, R"json(
-{"qos":{"version":"1","defaults":{"priority":"high"}}}
-)json");
-    status = resolver.loadFromConfig(bad_version_type);
-    EXPECT_FALSE(status.ok());
-    EXPECT_TRUE(status.IsInvalidArgument());
+    for (const auto& text : kInvalidConfigs) {
+        Config config;
+        loadConfig(&config, text);
+        auto status = resolver.loadFromConfig(config);
+        EXPECT_FALSE(status.ok()) << text;
+        EXPECT_TRUE(status.IsInvalidArgument()) << text;
+        EXPECT_FALSE(resolver.enabled()) << text;
+    }
 }
 
 TEST(QosContractTest, IntentTypeNamesAreStable) {

--- a/mooncake-transfer-engine/tent/tests/qos_contract_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/qos_contract_test.cpp
@@ -124,7 +124,8 @@ TEST(QosContractTest, ResolvesTenantIntentContractWithInheritedDefaults) {
     EXPECT_EQ(*effective.max_inflight_requests, 4096u);
     ASSERT_TRUE(effective.deadline_profile.has_value());
     EXPECT_EQ(*effective.deadline_profile, "interactive");
-    EXPECT_EQ(effective.allowed_degraded_actions.size(), 3u);
+    ASSERT_TRUE(effective.allowed_degraded_actions.has_value());
+    EXPECT_EQ(effective.allowed_degraded_actions->size(), 3u);
 
     auto explain = nlohmann::json::parse(resolver.explainJson(effective));
     EXPECT_EQ(explain["matched_contract"], "tenant-a.foreground_get");
@@ -212,6 +213,66 @@ TEST(QosContractTest, StrictModeRejectsUnknownTenant) {
     EXPECT_TRUE(status.IsInvalidArgument());
 }
 
+TEST(QosContractTest, EmptyAllowedDegradedActionsOverridesInherited) {
+    Config config;
+    loadConfig(&config, R"json(
+{
+  "qos": {
+    "version": 1,
+    "defaults": {
+      "allowed_degraded_actions": ["fallback_transport", "reject"]
+    },
+    "tenants": [
+      {
+        "name": "tenant-a",
+        "intents": {
+          "foreground_get": {
+            "allowed_degraded_actions": []
+          }
+        }
+      }
+    ]
+  }
+}
+)json");
+    QosContractResolver resolver;
+    ASSERT_TRUE(resolver.loadFromConfig(config).ok());
+
+    EffectiveQosPolicy effective;
+    auto status = resolver.resolve({.tenant = "tenant-a",
+                                    .intent = "foreground_get",
+                                    .policy_name = std::nullopt,
+                                    .requested_priority = PRIO_HIGH},
+                                   &effective);
+    ASSERT_TRUE(status.ok()) << status.ToString();
+    ASSERT_TRUE(effective.allowed_degraded_actions.has_value());
+    EXPECT_TRUE(effective.allowed_degraded_actions->empty());
+}
+
+TEST(QosContractTest, MergedBandwidthRangeFailsClosed) {
+    Config config;
+    loadConfig(&config, R"json(
+{
+  "qos": {
+    "version": 1,
+    "defaults": {"max_bandwidth_gbps": 10},
+    "intent_defaults": {"foreground_get": {"min_bandwidth_gbps": 20}}
+  }
+}
+)json");
+    QosContractResolver resolver;
+    ASSERT_TRUE(resolver.loadFromConfig(config).ok());
+
+    EffectiveQosPolicy effective;
+    auto status = resolver.resolve({.tenant = "tenant-a",
+                                    .intent = "foreground_get",
+                                    .policy_name = std::nullopt,
+                                    .requested_priority = PRIO_HIGH},
+                                   &effective);
+    EXPECT_FALSE(status.ok());
+    EXPECT_TRUE(status.IsInvalidArgument());
+}
+
 TEST(QosContractTest, InvalidSchemaFailsClosed) {
     Config config;
     loadConfig(&config, R"json(
@@ -243,6 +304,22 @@ TEST(QosContractTest, InvalidSchemaFailsClosed) {
 {"qos":{"version":1,"defaults":{"max_inflight_requests":"64MiB"}}}
 )json");
     status = resolver.loadFromConfig(bad_request_count);
+    EXPECT_FALSE(status.ok());
+    EXPECT_TRUE(status.IsInvalidArgument());
+
+    Config unknown_key;
+    loadConfig(&unknown_key, R"json(
+{"qos":{"version":1,"defaults":{"unexpected_qos_key":10}}}
+)json");
+    status = resolver.loadFromConfig(unknown_key);
+    EXPECT_FALSE(status.ok());
+    EXPECT_TRUE(status.IsInvalidArgument());
+
+    Config bad_version_type;
+    loadConfig(&bad_version_type, R"json(
+{"qos":{"version":"1","defaults":{"priority":"high"}}}
+)json");
+    status = resolver.loadFromConfig(bad_version_type);
     EXPECT_FALSE(status.ok());
     EXPECT_TRUE(status.IsInvalidArgument());
 }

--- a/mooncake-transfer-engine/tent/tests/qos_contract_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/qos_contract_test.cpp
@@ -173,6 +173,50 @@ TEST(QosContractTest, ExplicitPolicyNameCanResolveNamedContract) {
     EXPECT_DOUBLE_EQ(*effective.max_bandwidth_gbps, 10.0);
 }
 
+TEST(QosContractTest, ExplicitPolicyNameSkipsTenantIntentResolution) {
+    Config config;
+    loadConfig(&config, R"json(
+{
+  "qos": {
+    "version": 1,
+    "defaults": {"priority": "low"},
+    "tenants": [
+      {
+        "name": "tenant-a",
+        "defaults": {"priority": "medium"},
+        "intents": {
+          "foreground_get": {
+            "name": "tenant-critical",
+            "priority": "high"
+          },
+          "checkpoint": {
+            "name": "bulk-checkpoint",
+            "priority": "low",
+            "max_bandwidth_gbps": 10
+          }
+        }
+      }
+    ]
+  }
+}
+)json");
+    QosContractResolver resolver;
+    ASSERT_TRUE(resolver.loadFromConfig(config).ok());
+
+    EffectiveQosPolicy effective;
+    auto status = resolver.resolve({.tenant = "tenant-a",
+                                    .intent = "foreground_get",
+                                    .policy_name = "bulk-checkpoint",
+                                    .requested_priority = PRIO_HIGH},
+                                   &effective);
+    ASSERT_TRUE(status.ok()) << status.ToString();
+    EXPECT_TRUE(effective.matched);
+    EXPECT_EQ(effective.matched_contract, "bulk-checkpoint");
+    EXPECT_EQ(effective.effective_priority, PRIO_LOW);
+    ASSERT_TRUE(effective.max_bandwidth_gbps.has_value());
+    EXPECT_DOUBLE_EQ(*effective.max_bandwidth_gbps, 10.0);
+}
+
 TEST(QosContractTest, UnknownTenantFallsBackInCompatibilityMode) {
     Config config;
     loadConfig(&config, R"json(

--- a/mooncake-transfer-engine/tent/tests/qos_contract_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/qos_contract_test.cpp
@@ -1,0 +1,270 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "tent/common/config.h"
+#include "tent/runtime/qos_contract.h"
+#include "tent/thirdparty/nlohmann/json.h"
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+void loadConfig(Config* config, const std::string& json_text) {
+    ASSERT_NE(config, nullptr);
+    auto status = config->load(json_text);
+    ASSERT_TRUE(status.ok()) << status.ToString();
+}
+
+TEST(QosContractTest, EmptyConfigIsDisabledAndPreservesRequestPriority) {
+    Config config;
+    QosContractResolver resolver;
+    auto status = resolver.loadFromConfig(config);
+    ASSERT_TRUE(status.ok()) << status.ToString();
+    EXPECT_FALSE(resolver.enabled());
+
+    EffectiveQosPolicy effective;
+    status = resolver.resolve({.tenant = "tenant-a",
+                               .intent = "foreground_get",
+                               .policy_name = std::nullopt,
+                               .requested_priority = PRIO_LOW},
+                              &effective);
+    ASSERT_TRUE(status.ok()) << status.ToString();
+    EXPECT_FALSE(effective.enabled);
+    EXPECT_EQ(effective.effective_priority, PRIO_LOW);
+    EXPECT_EQ(effective.matched_contract, "compatibility_default");
+}
+
+TEST(QosContractTest, ResolvesTenantIntentContractWithInheritedDefaults) {
+    Config config;
+    loadConfig(&config, R"json(
+{
+  "qos": {
+    "version": 1,
+    "defaults": {
+      "priority": "medium",
+      "weight": 1,
+      "max_inflight_requests": 128,
+      "allowed_degraded_actions": ["fallback_transport", "reject"]
+    },
+    "intent_defaults": {
+      "foreground_get": {
+        "deadline_profile": "interactive",
+        "weight": 4
+      }
+    },
+    "tenants": [
+      {
+        "name": "tenant-a",
+        "defaults": {
+          "max_inflight_bytes": "1GiB"
+        },
+        "intents": {
+          "foreground_get": {
+            "name": "tenant-a-fg",
+            "priority": "high",
+            "min_bandwidth_gbps": 40,
+            "max_bandwidth_gbps": 100,
+            "weight": 8,
+            "burst_bytes": "2GiB",
+            "max_inflight_bytes": "4GiB",
+            "max_inflight_requests": 4096,
+            "allowed_degraded_actions": ["fallback_transport", "local_recompute", "reject"]
+          }
+        }
+      }
+    ]
+  }
+}
+)json");
+
+    QosContractResolver resolver;
+    auto status = resolver.loadFromConfig(config);
+    ASSERT_TRUE(status.ok()) << status.ToString();
+    EXPECT_TRUE(resolver.enabled());
+
+    EffectiveQosPolicy effective;
+    status = resolver.resolve({.tenant = "Tenant-A",
+                               .intent = "Foreground_Get",
+                               .policy_name = std::nullopt,
+                               .requested_priority = PRIO_LOW},
+                              &effective);
+    ASSERT_TRUE(status.ok()) << status.ToString();
+    EXPECT_TRUE(effective.enabled);
+    EXPECT_TRUE(effective.matched);
+    EXPECT_EQ(effective.tenant, "tenant-a");
+    EXPECT_EQ(effective.intent, "foreground_get");
+    EXPECT_EQ(effective.matched_contract, "tenant-a.foreground_get");
+    ASSERT_TRUE(effective.priority.has_value());
+    EXPECT_EQ(*effective.priority, PRIO_HIGH);
+    EXPECT_EQ(effective.effective_priority, PRIO_HIGH);
+    ASSERT_TRUE(effective.min_bandwidth_gbps.has_value());
+    EXPECT_DOUBLE_EQ(*effective.min_bandwidth_gbps, 40.0);
+    ASSERT_TRUE(effective.max_bandwidth_gbps.has_value());
+    EXPECT_DOUBLE_EQ(*effective.max_bandwidth_gbps, 100.0);
+    ASSERT_TRUE(effective.weight.has_value());
+    EXPECT_EQ(*effective.weight, 8u);
+    ASSERT_TRUE(effective.burst_bytes.has_value());
+    EXPECT_EQ(*effective.burst_bytes, 2ull * 1024 * 1024 * 1024);
+    ASSERT_TRUE(effective.max_inflight_bytes.has_value());
+    EXPECT_EQ(*effective.max_inflight_bytes, 4ull * 1024 * 1024 * 1024);
+    ASSERT_TRUE(effective.max_inflight_requests.has_value());
+    EXPECT_EQ(*effective.max_inflight_requests, 4096u);
+    ASSERT_TRUE(effective.deadline_profile.has_value());
+    EXPECT_EQ(*effective.deadline_profile, "interactive");
+    EXPECT_EQ(effective.allowed_degraded_actions.size(), 3u);
+
+    auto explain = nlohmann::json::parse(resolver.explainJson(effective));
+    EXPECT_EQ(explain["matched_contract"], "tenant-a.foreground_get");
+    EXPECT_EQ(explain["effective_priority"], PRIO_HIGH);
+    EXPECT_EQ(explain["enforcement"]["bandwidth_cap"], "planned");
+}
+
+TEST(QosContractTest, ExplicitPolicyNameCanResolveNamedContract) {
+    Config config;
+    loadConfig(&config, R"json(
+{
+  "qos": {
+    "version": 1,
+    "defaults": {"priority": "low"},
+    "tenants": [
+      {
+        "name": "tenant-a",
+        "intents": {
+          "checkpoint": {
+            "name": "bulk-checkpoint",
+            "priority": "low",
+            "max_bandwidth_gbps": 10,
+            "burst_bytes": "256MiB"
+          }
+        }
+      }
+    ]
+  }
+}
+)json");
+    QosContractResolver resolver;
+    ASSERT_TRUE(resolver.loadFromConfig(config).ok());
+
+    EffectiveQosPolicy effective;
+    auto status = resolver.resolve({.tenant = "other",
+                                    .intent = "foreground_get",
+                                    .policy_name = "bulk-checkpoint",
+                                    .requested_priority = PRIO_HIGH},
+                                   &effective);
+    ASSERT_TRUE(status.ok()) << status.ToString();
+    EXPECT_TRUE(effective.matched);
+    EXPECT_EQ(effective.matched_contract, "bulk-checkpoint");
+    EXPECT_EQ(effective.effective_priority, PRIO_LOW);
+    ASSERT_TRUE(effective.max_bandwidth_gbps.has_value());
+    EXPECT_DOUBLE_EQ(*effective.max_bandwidth_gbps, 10.0);
+}
+
+TEST(QosContractTest, UnknownTenantFallsBackInCompatibilityMode) {
+    Config config;
+    loadConfig(&config, R"json(
+{"qos":{"version":1,"defaults":{"priority":"medium","max_inflight_bytes":"64MiB"}}}
+)json");
+    QosContractResolver resolver;
+    ASSERT_TRUE(resolver.loadFromConfig(config).ok());
+
+    EffectiveQosPolicy effective;
+    auto status = resolver.resolve({.tenant = "missing",
+                                    .intent = "foreground_get",
+                                    .policy_name = std::nullopt,
+                                    .requested_priority = PRIO_HIGH},
+                                   &effective);
+    ASSERT_TRUE(status.ok()) << status.ToString();
+    EXPECT_FALSE(effective.matched);
+    EXPECT_EQ(effective.matched_contract, "global_default");
+    EXPECT_EQ(effective.effective_priority, PRIO_MEDIUM);
+    ASSERT_TRUE(effective.max_inflight_bytes.has_value());
+    EXPECT_EQ(*effective.max_inflight_bytes, 64ull * 1024 * 1024);
+}
+
+TEST(QosContractTest, StrictModeRejectsUnknownTenant) {
+    Config config;
+    loadConfig(&config, R"json(
+{"qos":{"version":1,"strict_mode":true,"defaults":{"priority":"medium"}}}
+)json");
+    QosContractResolver resolver;
+    ASSERT_TRUE(resolver.loadFromConfig(config).ok());
+
+    EffectiveQosPolicy effective;
+    auto status = resolver.resolve({.tenant = "missing",
+                                    .intent = "foreground_get",
+                                    .policy_name = std::nullopt,
+                                    .requested_priority = PRIO_HIGH},
+                                   &effective);
+    EXPECT_FALSE(status.ok());
+    EXPECT_TRUE(status.IsInvalidArgument());
+}
+
+TEST(QosContractTest, InvalidSchemaFailsClosed) {
+    Config config;
+    loadConfig(&config, R"json(
+{"qos":{"version":1,"defaults":{"priority":"urgent"}}}
+)json");
+    QosContractResolver resolver;
+    auto status = resolver.loadFromConfig(config);
+    EXPECT_FALSE(status.ok());
+    EXPECT_TRUE(status.IsInvalidArgument());
+
+    Config bad_bw;
+    loadConfig(&bad_bw, R"json(
+{"qos":{"version":1,"defaults":{"min_bandwidth_gbps":20,"max_bandwidth_gbps":10}}}
+)json");
+    status = resolver.loadFromConfig(bad_bw);
+    EXPECT_FALSE(status.ok());
+    EXPECT_TRUE(status.IsInvalidArgument());
+
+    Config bad_action;
+    loadConfig(&bad_action, R"json(
+{"qos":{"version":1,"defaults":{"allowed_degraded_actions":["teleport"]}}}
+)json");
+    status = resolver.loadFromConfig(bad_action);
+    EXPECT_FALSE(status.ok());
+    EXPECT_TRUE(status.IsInvalidArgument());
+
+    Config bad_request_count;
+    loadConfig(&bad_request_count, R"json(
+{"qos":{"version":1,"defaults":{"max_inflight_requests":"64MiB"}}}
+)json");
+    status = resolver.loadFromConfig(bad_request_count);
+    EXPECT_FALSE(status.ok());
+    EXPECT_TRUE(status.IsInvalidArgument());
+}
+
+TEST(QosContractTest, IntentTypeNamesAreStable) {
+    EXPECT_EQ(QosContractResolver::intentTypeName(IntentType::INTENT_UNSPEC),
+              "unspec");
+    EXPECT_EQ(QosContractResolver::intentTypeName(IntentType::FOREGROUND_GET),
+              "foreground_get");
+    EXPECT_EQ(
+        QosContractResolver::intentTypeName(IntentType::BACKGROUND_PREFETCH),
+        "background_prefetch");
+    EXPECT_EQ(QosContractResolver::intentTypeName(IntentType::MIGRATION),
+              "migration");
+    EXPECT_EQ(QosContractResolver::intentTypeName(IntentType::CHECKPOINT),
+              "checkpoint");
+    EXPECT_EQ(QosContractResolver::intentTypeName(IntentType::WEIGHT_LOADING),
+              "weight_loading");
+    EXPECT_EQ(QosContractResolver::intentTypeName(IntentType::STAGING_INTERNAL),
+              "staging_internal");
+}
+
+}  // namespace
+}  // namespace tent
+}  // namespace mooncake


### PR DESCRIPTION
## Motivation

TENT carries priority, deadline, and intent metadata, but it lacks a minimal contract boundary for the next runtime-enforcement milestone. This PR implements the narrowed M1 from #2856: schema parsing, deterministic resolution, and resolution-only diagnostics, with no runtime behavior change.

## M1 scope

The schema contains only fields with a near-term M2 consumer:

- `priority`
- `max_inflight_bytes`
- `max_inflight_requests`
- `allowed_degraded_actions`

Resolution is deliberately limited to:

```text
global defaults -> tenant defaults -> tenant + intent override
```

`tenant_id` is an opaque caller-supplied identity. A Store integration should pass its canonical Store tenant ID value rather than create a parallel TENT tenant namespace.

## Changes

- Add `QosContractResolver` for fail-closed parsing and effective-policy resolution.
- Preserve compatibility when `qos` is absent: the resolver stays disabled and preserves requested priority.
- Normalize opaque `tenant_id` and intent keys.
- Validate priority, byte units, request counts, duplicate tenants, unknown keys, and supported degraded actions.
- Preserve explicit empty `allowed_degraded_actions: []` as an override instead of inheritance.
- Add `explainJson()` with `diagnostic_scope: resolution_only` and no planned-enforcement claims.
- Add focused tests for inheritance, fallback, empty identity, explicit-empty override, invalid schema, state reset, and deferred-feature rejection.

## Explicitly deferred

This PR does not define or accept:

- `min_bandwidth_gbps` / `max_bandwidth_gbps`
- `burst_bytes`
- `weight`
- `deadline_profile`
- global `intent_defaults`
- named contracts / QoS `policy_name` override
- runtime `strict_mode`

These fields and features fail closed if configured. They should be introduced only with the milestone that defines and enforces them.

## Runtime non-goals

- No priority authorization or inflight enforcement.
- No admission/dispatch behavior change.
- No bandwidth policing, borrowing, or weighted scheduling.
- No receiver-credit allocation.
- No Store implementation dependency.
- No default behavior change.

## Cluster validation

Validation ran remotely on the Lingjun H20 cluster, not on the local workstation.

| Item | Value |
|---|---|
| Node | `lingjun-100` |
| Container | `codex_mooncake_pr_eval` |
| Commit | `251a029` |
| Compiler / CMake | GCC 13.3.0 / CMake 3.28.3 |
| Release config | `USE_TENT=ON`, `BUILD_UNIT_TESTS=ON`, CUDA/Store disabled |
| Sanitizer config | Debug, ASan+UBSan, leak detection enabled |

No local-to-remote `scp` was used; the cluster cloned the branch directly.

### Release build and adjacent regression

Built these eight targets:

- `tent_qos_contract_test`
- `admission_queue_test`
- `promotion_policy_test`
- `tent_runtime_queue_dispatch_test`
- `tent_transport_hint_test`
- `tent_transport_selector_test`
- `tent_intent_type_test`
- `transfer_engine_config_override_test`

CTest result:

```text
100% tests passed, 0 tests failed out of 8
Total Test time (real) = 1.05 sec
```

### Repeated resolver campaign

```text
tent_qos_contract_test: 1000/1000 passed
0 failures
Total Test time (real) = 1.66 sec
```

### ASan+UBSan

Independent Debug build with:

```text
-fsanitize=address,undefined -fno-omit-frame-pointer
ASAN_OPTIONS=detect_leaks=1:halt_on_error=1
UBSAN_OPTIONS=halt_on_error=1
```

Result:

```text
tent_qos_contract_test: 1/1 passed
0 ASan findings
0 UBSan findings
0 leak findings
```

`git diff --check` also passes.

## Claims boundary

The evidence validates configuration parsing, resolution precedence, fallback, fail-closed rejection, diagnostics, and memory/undefined-behavior safety for M1. This PR makes no bandwidth, fairness, TTFT, or isolation-performance claim because it intentionally changes no runtime enforcement.

Refs #2856
