### PR TITLE
[TE] Add host control fallback for IBGDA QP setup

### DIFF
--- a/mooncake-transfer-engine/include/transport/device/ibgda/mlx5gda.h
+++ b/mooncake-transfer-engine/include/transport/device/ibgda/mlx5gda.h
@@ -87,6 +87,16 @@ struct mlx5gda_qp_devctx {
     uint16_t wq_tail;    // last non-completed wqeid
 };
 
+struct mlx5gda_create_qp_failure {
+    bool valid;
+    uint32_t status;
+    uint32_t syndrome;
+    int sys_errno;
+};
+
+void mlx5gda_reset_create_qp_failure();
+mlx5gda_create_qp_failure mlx5gda_last_create_qp_failure();
+
 struct mlx5gda_qp *mlx5gda_create_rc_qp(struct mlx5dv_pd mpd, void *ctrl_buf,
                                         struct mlx5dv_devx_umem *ctrl_buf_umem,
                                         struct memheap *ctrl_buf_heap,

--- a/mooncake-transfer-engine/src/transport/device/ibgda_device_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/device/ibgda_device_transport.cpp
@@ -335,12 +335,14 @@ class IbgdaDeviceTransportImpl : public RdmaTransport {
     int allocateControlBuffer(bool host_backed) {
         ctrl_buf_host_ = host_backed;
         if (ctrl_buf_host_) {
-            int ret = posix_memalign(&ctrl_buf_, 4096, kCtrlBufSize);
+            void* ptr = nullptr;
+            int ret = posix_memalign(&ptr, 4096, kCtrlBufSize);
             if (ret != 0) {
                 LOG(ERROR) << "[EP IBGDA] posix_memalign ctrl_buf failed: "
                            << ret;
                 return -1;
             }
+            ctrl_buf_ = ptr;
             std::memset(ctrl_buf_, 0, kCtrlBufSize);
 
             cudaError_t err = cudaHostRegister(

--- a/mooncake-transfer-engine/src/transport/device/ibgda_device_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/device/ibgda_device_transport.cpp
@@ -25,11 +25,13 @@
 #include <infiniband/mlx5dv.h>
 #include <infiniband/verbs.h>
 
+#include <cstdlib>
 #include <cstring>
 #include <stdexcept>
 
 #include "cuda_alike.h"
 #include "transport/device/ibgda/memheap.h"
+#include "transport/device/ibgda/mlx5_ifc.h"
 #include "transport/device/ibgda/mlx5gda.h"
 #include "topology.h"
 
@@ -199,28 +201,7 @@ class IbgdaDeviceTransportImpl : public RdmaTransport {
     }
 
     int allocateControlBuffer() override {
-        cudaError_t err = cudaMalloc(&ctrl_buf_, kCtrlBufSize);
-        if (err != cudaSuccess) {
-            LOG(ERROR) << "[EP IBGDA] cudaMalloc ctrl_buf failed: "
-                       << cudaGetErrorString(err);
-            return -1;
-        }
-
-        ctrl_buf_umem_ = mlx5dv_devx_umem_reg(ctx_, ctrl_buf_, kCtrlBufSize,
-                                              IBV_ACCESS_LOCAL_WRITE);
-        if (!ctrl_buf_umem_) {
-            LOG(ERROR) << "[EP IBGDA] mlx5dv_devx_umem_reg failed (errno="
-                       << errno << ")";
-            return -1;
-        }
-        LOG(INFO) << "[EP IBGDA] ctrl_buf UMEM registered via VA path";
-
-        ctrl_buf_heap_ = memheap_create(kCtrlBufSize);
-        if (!ctrl_buf_heap_) {
-            LOG(ERROR) << "[EP IBGDA] memheap_create failed";
-            return -1;
-        }
-        return 0;
+        return allocateControlBuffer(false);
     }
 
     int createQueuePairs(void* stream_ptr) override {
@@ -231,6 +212,8 @@ class IbgdaDeviceTransportImpl : public RdmaTransport {
                                      ctrl_buf_heap_, pd_, 16384, 1, stream);
             if (!qp) {
                 LOG(ERROR) << "[EP IBGDA] mlx5gda_create_rc_qp failed at " << i;
+                if (retryWithHostControlBuffer())
+                    return createQueuePairs(stream_ptr);
                 return -1;
             }
             if (mlx5gda_modify_rc_qp_rst2init(qp, 0)) {
@@ -243,11 +226,11 @@ class IbgdaDeviceTransportImpl : public RdmaTransport {
                 .qpn = qp->qpn,
                 .wqeid_mask = qp->num_wqebb - 1,
                 .wq = reinterpret_cast<mlx5gda_wqebb*>(
-                    static_cast<char*>(ctrl_buf_) + qp->wq_offset),
+                    static_cast<char*>(ctrl_buf_dev_) + qp->wq_offset),
                 .cq = reinterpret_cast<mlx5_cqe64*>(
-                    static_cast<char*>(ctrl_buf_) + qp->send_cq->cq_offset),
+                    static_cast<char*>(ctrl_buf_dev_) + qp->send_cq->cq_offset),
                 .dbr = reinterpret_cast<mlx5gda_wq_dbr*>(
-                    static_cast<char*>(ctrl_buf_) + qp->dbr_offset),
+                    static_cast<char*>(ctrl_buf_dev_) + qp->dbr_offset),
                 .bf = static_cast<char*>(qp->uar->reg_addr),
             };
             cudaMemcpy(
@@ -259,11 +242,7 @@ class IbgdaDeviceTransportImpl : public RdmaTransport {
     }
 
     int recreateQueuePairs(void* stream_ptr) override {
-        auto stream = static_cast<cudaStream_t>(stream_ptr);
-        for (auto* qp : qps_) {
-            if (qp) mlx5gda_destroy_qp(ctrl_buf_heap_, qp);
-        }
-        qps_.clear();
+        destroyQueuePairs();
         return createQueuePairs(stream_ptr);
     }
 
@@ -349,11 +328,96 @@ class IbgdaDeviceTransportImpl : public RdmaTransport {
     int gidIndex() const override { return gid_index_; }
 
    private:
-    void teardown() {
+    static bool isCreateQpBadParam(const mlx5gda_create_qp_failure& failure) {
+        return failure.valid && failure.status == MLX5_CMD_STAT_BAD_PARAM_ERR;
+    }
+
+    int allocateControlBuffer(bool host_backed) {
+        ctrl_buf_host_ = host_backed;
+        if (ctrl_buf_host_) {
+            int ret = posix_memalign(&ctrl_buf_, 4096, kCtrlBufSize);
+            if (ret != 0) {
+                LOG(ERROR) << "[EP IBGDA] posix_memalign ctrl_buf failed: "
+                           << ret;
+                return -1;
+            }
+            std::memset(ctrl_buf_, 0, kCtrlBufSize);
+
+            cudaError_t err = cudaHostRegister(
+                ctrl_buf_, kCtrlBufSize,
+                cudaHostRegisterPortable | cudaHostRegisterMapped);
+            if (err != cudaSuccess) {
+                LOG(ERROR) << "[EP IBGDA] cudaHostRegister ctrl_buf failed: "
+                           << cudaGetErrorString(err);
+                free(ctrl_buf_);
+                ctrl_buf_ = nullptr;
+                return -1;
+            }
+
+            err = cudaHostGetDevicePointer(&ctrl_buf_dev_, ctrl_buf_, 0);
+            if (err != cudaSuccess) {
+                LOG(ERROR)
+                    << "[EP IBGDA] cudaHostGetDevicePointer ctrl_buf failed: "
+                    << cudaGetErrorString(err);
+                cudaHostUnregister(ctrl_buf_);
+                free(ctrl_buf_);
+                ctrl_buf_ = nullptr;
+                ctrl_buf_host_ = false;
+                return -1;
+            }
+            LOG(INFO) << "[EP IBGDA] Using host-backed mapped control buffer";
+        } else {
+            cudaError_t err = cudaMalloc(&ctrl_buf_, kCtrlBufSize);
+            if (err != cudaSuccess) {
+                LOG(ERROR) << "[EP IBGDA] cudaMalloc ctrl_buf failed: "
+                           << cudaGetErrorString(err);
+                return -1;
+            }
+            ctrl_buf_dev_ = ctrl_buf_;
+        }
+
+        ctrl_buf_umem_ = mlx5dv_devx_umem_reg(ctx_, ctrl_buf_, kCtrlBufSize,
+                                              IBV_ACCESS_LOCAL_WRITE);
+        if (!ctrl_buf_umem_) {
+            LOG(ERROR) << "[EP IBGDA] mlx5dv_devx_umem_reg failed (errno="
+                       << errno << ")";
+            freeControlBuffer();
+            return -1;
+        }
+        LOG(INFO) << "[EP IBGDA] ctrl_buf UMEM registered via VA path";
+
+        ctrl_buf_heap_ = memheap_create(kCtrlBufSize);
+        if (!ctrl_buf_heap_) {
+            LOG(ERROR) << "[EP IBGDA] memheap_create failed";
+            freeControlBuffer();
+            return -1;
+        }
+        return 0;
+    }
+
+    bool retryWithHostControlBuffer() {
+        auto failure = mlx5gda_last_create_qp_failure();
+        if (ctrl_buf_host_ || !isCreateQpBadParam(failure)) return false;
+
+        LOG(WARNING) << "[EP IBGDA] GPU-backed control buffer was rejected by "
+                        "DevX CREATE_QP"
+                     << " (status=0x" << std::hex << failure.status
+                     << " syndrome=0x" << failure.syndrome << std::dec
+                     << "); retrying with host-backed mapped control buffer";
+
+        destroyQueuePairs();
+        freeControlBuffer();
+        return allocateControlBuffer(true) == 0;
+    }
+
+    void destroyQueuePairs() {
         for (auto* qp : qps_) {
             if (qp) mlx5gda_destroy_qp(ctrl_buf_heap_, qp);
         }
         qps_.clear();
+    }
+
+    void freeControlBuffer() {
         if (ctrl_buf_heap_) {
             memheap_destroy(ctrl_buf_heap_);
             ctrl_buf_heap_ = nullptr;
@@ -363,9 +427,21 @@ class IbgdaDeviceTransportImpl : public RdmaTransport {
             ctrl_buf_umem_ = nullptr;
         }
         if (ctrl_buf_) {
-            cudaFree(ctrl_buf_);
+            if (ctrl_buf_host_) {
+                cudaHostUnregister(ctrl_buf_);
+                free(ctrl_buf_);
+            } else {
+                cudaFree(ctrl_buf_);
+            }
             ctrl_buf_ = nullptr;
+            ctrl_buf_dev_ = nullptr;
+            ctrl_buf_host_ = false;
         }
+    }
+
+    void teardown() {
+        destroyQueuePairs();
+        freeControlBuffer();
         if (mr_) {
             ibv_dereg_mr(mr_);
             mr_ = nullptr;
@@ -407,6 +483,8 @@ class IbgdaDeviceTransportImpl : public RdmaTransport {
 
     // Control buffer
     void* ctrl_buf_ = nullptr;  // GPU VA
+    void* ctrl_buf_dev_ = nullptr;
+    bool ctrl_buf_host_ = false;
     mlx5dv_devx_umem* ctrl_buf_umem_ = nullptr;
     memheap* ctrl_buf_heap_ = nullptr;
 

--- a/mooncake-transfer-engine/src/transport/device/mlx5gda.cpp
+++ b/mooncake-transfer-engine/src/transport/device/mlx5gda.cpp
@@ -5,6 +5,7 @@
 #include <infiniband/verbs.h>
 #include <infiniband/mlx5dv.h>
 
+#include <cstring>
 #include <transport/device/ibgda/memheap.h>
 #include <transport/device/ibgda/mlx5gda.h>
 #include <transport/device/ibgda/mlx5_ifc.h>
@@ -36,6 +37,47 @@ static void print_cuda_error(const char* msg) {
     const char* err_str = cudaGetErrorString(cudaGetLastError());
 #endif
     fprintf(stderr, "%s: %s\n", msg, err_str);
+}
+
+static thread_local mlx5gda_create_qp_failure g_last_create_qp_failure{};
+
+void mlx5gda_reset_create_qp_failure() { g_last_create_qp_failure = {}; }
+
+mlx5gda_create_qp_failure mlx5gda_last_create_qp_failure() {
+    return g_last_create_qp_failure;
+}
+
+static bool is_host_control_buffer(void* ptr) {
+    cudaPointerAttributes attr{};
+    cudaError_t err = cudaPointerGetAttributes(&attr, ptr);
+    if (err != cudaSuccess) {
+        cudaGetLastError();
+        return false;
+    }
+    return attr.type == cudaMemoryTypeHost;
+}
+
+static void print_devx_create_qp_failure(const uint8_t* cmd_out,
+                                         uint32_t num_wqebb, uint8_t port_num,
+                                         uint32_t pdn, uint32_t uar_page,
+                                         uint32_t cqn, uint32_t umem_id,
+                                         size_t wq_offset, size_t dbr_offset,
+                                         int sys_errno) {
+    uint32_t status = DEVX_GET(create_qp_out, cmd_out, status);
+    uint32_t syndrome = DEVX_GET(create_qp_out, cmd_out, syndrome);
+    g_last_create_qp_failure = mlx5gda_create_qp_failure{
+        .valid = true,
+        .status = status,
+        .syndrome = syndrome,
+        .sys_errno = sys_errno,
+    };
+    fprintf(stderr,
+            "mlx5dv_devx_obj_create(create_qp) failed: errno=%d (%s) "
+            "status=0x%x syndrome=0x%x port=%u pdn=0x%x uar_page=0x%x "
+            "cqn=0x%x umem_id=0x%x num_wqebb=%u wq_offset=0x%zx "
+            "dbr_offset=0x%zx\n",
+            sys_errno, strerror(sys_errno), status, syndrome, port_num, pdn,
+            uar_page, cqn, umem_id, num_wqebb, wq_offset, dbr_offset);
 }
 
 // Create UAR for BF (Blue Flame) doorbell ringing.
@@ -99,6 +141,7 @@ struct mlx5gda_cq* mlx5gda_create_cq(void* ctrl_buf,
 
     struct ibv_context* ctx = pd->context;
     void* cq_context = NULL;
+    bool ctrl_host = is_host_control_buffer(ctrl_buf);
 
     if (cqe <= 0) {
         errno = EINVAL;
@@ -120,11 +163,16 @@ struct mlx5gda_cq* mlx5gda_create_cq(void* ctrl_buf,
     // initialized to 0xFF (-1) to mark them as invalid. The hardware checks the
     // owner bit in CQE to determine if it's valid. This is mandatory for proper
     // CQ operation. Use async version to avoid blocking.
-    if (cudaMemsetAsync(ctrl_buf + cq_offset, -1,
-                        num_cqe * sizeof(struct mlx5_cqe64),
-                        stream) != cudaSuccess) {
-        print_cuda_error("Failed to memset CQ memory");
-        goto fail;
+    if (ctrl_host) {
+        memset(static_cast<char*>(ctrl_buf) + cq_offset, -1,
+               num_cqe * sizeof(struct mlx5_cqe64));
+    } else {
+        if (cudaMemsetAsync(static_cast<char*>(ctrl_buf) + cq_offset, -1,
+                            num_cqe * sizeof(struct mlx5_cqe64),
+                            stream) != cudaSuccess) {
+            print_cuda_error("Failed to memset CQ memory");
+            goto fail;
+        }
     }
     dbr_offset = memheap_alloc(ctrl_buf_heap, sizeof(struct mlx5gda_cq_dbr));
     if (dbr_offset == -1) {
@@ -162,9 +210,11 @@ struct mlx5gda_cq* mlx5gda_create_cq(void* ctrl_buf,
 
     // Synchronize stream before creating CQ object, as hardware will read the
     // CQE memory
-    if (cudaStreamSynchronize(stream) != cudaSuccess) {
-        print_cuda_error("Failed to synchronize stream before CQ creation");
-        goto fail;
+    if (!ctrl_host) {
+        if (cudaStreamSynchronize(stream) != cudaSuccess) {
+            print_cuda_error("Failed to synchronize stream before CQ creation");
+            goto fail;
+        }
     }
 
     mlx5_cq = mlx5dv_devx_obj_create(ctx, cmd_in, sizeof(cmd_in), cmd_out,
@@ -208,6 +258,8 @@ struct mlx5gda_qp* mlx5gda_create_rc_qp(struct mlx5dv_pd mpd, void* ctrl_buf,
                                         struct memheap* ctrl_buf_heap,
                                         struct ibv_pd* pd, int wqe,
                                         uint8_t port_num, cudaStream_t stream) {
+    mlx5gda_reset_create_qp_failure();
+
     struct mlx5gda_qp* qp = NULL;
     struct mlx5gda_cq* send_cq = NULL;
     struct mlx5dv_devx_uar* uar = NULL;
@@ -219,6 +271,7 @@ struct mlx5gda_qp* mlx5gda_create_rc_qp(struct mlx5dv_pd mpd, void* ctrl_buf,
     void* qp_context = NULL;
     void* cap = NULL;
     uint32_t cqe_version = 0;
+    bool ctrl_host = is_host_control_buffer(ctrl_buf);
 
     if (wqe <= 0) {
         errno = EINVAL;
@@ -291,10 +344,16 @@ struct mlx5gda_qp* mlx5gda_create_rc_qp(struct mlx5dv_pd mpd, void* ctrl_buf,
         goto fail;
     }
     // DBR must be zero-initialized. Use async version to avoid blocking.
-    if (cudaMemsetAsync(ctrl_buf + dbr_offset, 0, sizeof(struct mlx5gda_wq_dbr),
-                        stream) != cudaSuccess) {
-        print_cuda_error("Failed to zero DBR memory");
-        goto fail;
+    if (ctrl_host) {
+        memset(static_cast<char*>(ctrl_buf) + dbr_offset, 0,
+               sizeof(struct mlx5gda_wq_dbr));
+    } else {
+        if (cudaMemsetAsync(static_cast<char*>(ctrl_buf) + dbr_offset, 0,
+                            sizeof(struct mlx5gda_wq_dbr),
+                            stream) != cudaSuccess) {
+            print_cuda_error("Failed to zero DBR memory");
+            goto fail;
+        }
     }
 
     DEVX_SET(create_qp_in, cmd_in, opcode, MLX5_CMD_OP_CREATE_QP);
@@ -326,14 +385,19 @@ struct mlx5gda_qp* mlx5gda_create_rc_qp(struct mlx5dv_pd mpd, void* ctrl_buf,
 
     // Synchronize stream before creating QP object, as hardware will read the
     // DBR memory
-    if (cudaStreamSynchronize(stream) != cudaSuccess) {
-        print_cuda_error("Failed to synchronize stream before QP creation");
-        goto fail;
+    if (!ctrl_host) {
+        if (cudaStreamSynchronize(stream) != cudaSuccess) {
+            print_cuda_error("Failed to synchronize stream before QP creation");
+            goto fail;
+        }
     }
 
     mlx5_qp = mlx5dv_devx_obj_create(ctx, cmd_in, sizeof(cmd_in), cmd_out,
                                      sizeof(cmd_out));
     if (mlx5_qp == NULL) {
+        print_devx_create_qp_failure(
+            cmd_out, num_wqebb, port_num, mpd.pdn, uar->page_id, send_cq->cqn,
+            ctrl_buf_umem->umem_id, wq_offset, dbr_offset, errno);
         goto fail;
     }
 


### PR DESCRIPTION
## Description

This PR adds an automatic host-backed control-buffer fallback for the IBGDA Device API transport.

Some devices reject DevX `CREATE_QP` when the IBGDA WQ/DBR control memory is backed by GPU memory. The transport now keeps the GPU-backed control buffer as the default fast path, records the DevX `CREATE_QP` failure status, and retries initialization once with host-backed mapped control memory only for `CREATE_QP` `BAD_PARAM` failures.

The fallback is intentionally narrow: UAR creation failures, CQ creation failures, MR registration failures, QP modify failures, and non-`CREATE_QP BAD_PARAM` errors remain hard failures.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
# Format check with clang-format 20.1.8
./scripts/code_format.sh --check

# Targeted pre-commit on changed files
pre-commit run --files \
  mooncake-transfer-engine/include/transport/device/ibgda/mlx5gda.h \
  mooncake-transfer-engine/src/transport/device/ibgda_device_transport.cpp \
  mooncake-transfer-engine/src/transport/device/mlx5gda.cpp

# H20/qjh007 container build and smoke
cmake --build build-hostctrl --target device_ibgda_transport_smoke_test -j 16
./build-hostctrl/mooncake-transfer-engine/tests/device_ibgda_transport_smoke_test \
  --device=mlx5_1 --num_ranks=1 --num_qps=1 --gpu_id=0

# End-to-end EP test with IBGDA initialized
CUDA_VISIBLE_DEVICES=0,1 MC_TE_FILTERS=mlx5_1 \
  python3 mooncake-wheel/tests/test_mooncake_ep.py
```

**Test results:**
- [ ] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

Manual validation summary:

- `device_ibgda_transport_smoke_test` passed on `mlx5_1` with the default GPU-backed control path.
- The same smoke on a NIC with UAR creation failure did not trigger the fallback, confirming the retry gate is narrow.
- `test_mooncake_ep.py` passed with IBGDA initialized on `mlx5_1`.
- A temporary no-IPC validation run confirmed the IBGDA data path still passes; the temporary test-only Python change was removed and is not part of this PR.
- A temporary forced host-control run measured a small compatibility-path cost, about 3% on the tested H20 setup.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

Notes:

- `pre-commit run --all-files` was not run to avoid applying auto-fixes across unrelated files in the shared worktree. Targeted pre-commit hooks passed for all changed files.
- No docs update is required for this runtime compatibility fallback.
- No test file is added because this path requires specific IBGDA hardware behavior; targeted hardware smoke and end-to-end EP validation were used instead.

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

AI assistance was used to draft and organize the implementation, validation steps, and PR text. The human submitter is responsible for reviewing and defending the final changes.