### PR TITLE
[TransferEngine] Reject concurrent overlapping memory registrations

### DIFF
--- a/mooncake-transfer-engine/include/multi_transport.h
+++ b/mooncake-transfer-engine/include/multi_transport.h
@@ -20,7 +20,11 @@
 #include "transport/transport.h"
 
 namespace mooncake {
+class TransferEngineImplTestPeer;
+
 class MultiTransport {
+    friend class TransferEngineImplTestPeer;
+
    public:
     using BatchID = Transport::BatchID;
     using TransferRequest = Transport::TransferRequest;

--- a/mooncake-transfer-engine/include/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/include/transfer_engine_impl.h
@@ -43,6 +43,8 @@
 #endif
 
 namespace mooncake {
+class TransferEngineImplTestPeer;
+
 using TransferRequest = Transport::TransferRequest;
 using TransferStatus = Transport::TransferStatus;
 using TransferStatusEnum = Transport::TransferStatusEnum;
@@ -56,6 +58,8 @@ using RegisteredBuffer = TransferEngine::RegisteredBuffer;
 #endif
 
 class TransferEngineImpl {
+    friend class TransferEngineImplTestPeer;
+
    public:
     TransferEngineImpl(bool auto_discover = false)
         : metadata_(nullptr),
@@ -401,12 +405,16 @@ class TransferEngineImpl {
 
     using MemoryRegionMap = std::map<uintptr_t, MemoryRegion>;
 
-    MemoryRegionMap::iterator findMemoryRegionContaining(uintptr_t addr);
-
-    MemoryRegionMap::const_iterator findMemoryRegionContaining(
-        uintptr_t addr) const;
-
     bool hasOverlapLocked(uintptr_t addr, uint64_t length) const;
+
+    bool hasOverlapInMapLocked(const MemoryRegionMap& regions, uintptr_t addr,
+                               uint64_t length) const;
+
+    bool tryReserveMemoryRegions(const std::vector<MemoryRegion>& regions);
+
+    void commitMemoryRegions(const std::vector<MemoryRegion>& regions);
+
+    void releaseMemoryRegions(const std::vector<MemoryRegion>& regions);
 
     void insertMemoryRegionLocked(const MemoryRegion& region);
 
@@ -417,6 +425,7 @@ class TransferEngineImpl {
     std::shared_ptr<MultiTransport> multi_transports_;
     std::shared_mutex mutex_;
     MemoryRegionMap local_memory_regions_;
+    MemoryRegionMap registering_memory_regions_;
     std::shared_ptr<Topology> local_topology_;
 
     RWSpinlock send_notifies_lock_;

--- a/mooncake-transfer-engine/src/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine_impl.cpp
@@ -587,24 +587,30 @@ int TransferEngineImpl::registerLocalMemory(void* addr, size_t length,
                                             const std::string& location,
                                             bool remote_accessible,
                                             bool update_metadata) {
-    if (checkOverlap(addr, length)) {
-        LOG(ERROR)
-            << "Transfer Engine does not support overlapped memory region";
-        return ERR_ADDRESS_OVERLAPPED;
-    }
     if (length == 0) {
         LOG(ERROR)
             << "Transfer Engine does not support zero length memory region";
         return ERR_INVALID_ARGUMENT;
     }
+
+    std::vector<MemoryRegion> regions = {
+        {addr, length, location, remote_accessible}};
+    if (!tryReserveMemoryRegions(regions)) {
+        LOG(ERROR)
+            << "Transfer Engine does not support overlapped memory region";
+        return ERR_ADDRESS_OVERLAPPED;
+    }
+
     for (auto transport : multi_transports_->listTransports()) {
         int ret = transport->registerLocalMemory(
             addr, length, location, remote_accessible, update_metadata);
-        if (ret < 0) return ret;
+        if (ret < 0) {
+            releaseMemoryRegions(regions);
+            return ret;
+        }
     }
 
-    std::unique_lock<std::shared_mutex> lock(mutex_);
-    insertMemoryRegionLocked({addr, length, location, remote_accessible});
+    commitMemoryRegions(regions);
     return 0;
 }
 
@@ -767,22 +773,28 @@ int TransferEngineImpl::registerLocalMemoryBatch(
                 return ERR_ADDRESS_OVERLAPPED;
             }
         }
-
-        if (checkOverlap(buffer.addr, buffer.length)) {
-            LOG(ERROR)
-                << "Transfer Engine does not support overlapped memory region";
-            return ERR_ADDRESS_OVERLAPPED;
-        }
     }
+
+    std::vector<MemoryRegion> regions;
+    regions.reserve(buffer_list.size());
+    for (const auto& buffer : buffer_list) {
+        regions.push_back({buffer.addr, buffer.length, location, true});
+    }
+    if (!tryReserveMemoryRegions(regions)) {
+        LOG(ERROR)
+            << "Transfer Engine does not support overlapped memory region";
+        return ERR_ADDRESS_OVERLAPPED;
+    }
+
     for (auto transport : multi_transports_->listTransports()) {
         int ret = transport->registerLocalMemoryBatch(buffer_list, location);
-        if (ret < 0) return ret;
+        if (ret < 0) {
+            releaseMemoryRegions(regions);
+            return ret;
+        }
     }
 
-    std::unique_lock<std::shared_mutex> lock(mutex_);
-    for (auto& buffer : buffer_list) {
-        insertMemoryRegionLocked({buffer.addr, buffer.length, location, true});
-    }
+    commitMemoryRegions(regions);
     return 0;
 }
 
@@ -800,51 +812,27 @@ int TransferEngineImpl::unregisterLocalMemoryBatch(
     return 0;
 }
 
-TransferEngineImpl::MemoryRegionMap::iterator
-TransferEngineImpl::findMemoryRegionContaining(uintptr_t addr) {
-    auto upper = local_memory_regions_.upper_bound(addr);
-    if (upper == local_memory_regions_.begin()) {
-        return local_memory_regions_.end();
-    }
-    auto candidate = std::prev(upper);
-    return overlapWithRegion(addr, 1, candidate->second.addr,
-                             candidate->second.length)
-               ? candidate
-               : local_memory_regions_.end();
-}
-
-TransferEngineImpl::MemoryRegionMap::const_iterator
-TransferEngineImpl::findMemoryRegionContaining(uintptr_t addr) const {
-    auto upper = local_memory_regions_.upper_bound(addr);
-    if (upper == local_memory_regions_.begin()) {
-        return local_memory_regions_.end();
-    }
-    auto candidate = std::prev(upper);
-    return overlapWithRegion(addr, 1, candidate->second.addr,
-                             candidate->second.length)
-               ? candidate
-               : local_memory_regions_.end();
-}
-
 bool TransferEngineImpl::hasOverlapLocked(uintptr_t addr,
                                           uint64_t length) const {
+    return hasOverlapInMapLocked(local_memory_regions_, addr, length) ||
+           hasOverlapInMapLocked(registering_memory_regions_, addr, length);
+}
+
+bool TransferEngineImpl::hasOverlapInMapLocked(const MemoryRegionMap& regions,
+                                               uintptr_t addr,
+                                               uint64_t length) const {
     if (length == 0) {
         return false;
     }
 
-    auto containing = findMemoryRegionContaining(addr);
-    if (containing != local_memory_regions_.end()) {
-        return true;
-    }
-
-    auto next = local_memory_regions_.lower_bound(addr);
-    if (next != local_memory_regions_.end() &&
+    auto next = regions.lower_bound(addr);
+    if (next != regions.end() &&
         overlapWithRegion(addr, length, next->second.addr,
                           next->second.length)) {
         return true;
     }
 
-    if (next != local_memory_regions_.begin()) {
+    if (next != regions.begin()) {
         auto prev = std::prev(next);
         if (overlapWithRegion(addr, length, prev->second.addr,
                               prev->second.length)) {
@@ -853,6 +841,45 @@ bool TransferEngineImpl::hasOverlapLocked(uintptr_t addr,
     }
 
     return false;
+}
+
+bool TransferEngineImpl::tryReserveMemoryRegions(
+    const std::vector<MemoryRegion>& regions) {
+    std::unique_lock<std::shared_mutex> lock(mutex_);
+    std::vector<uintptr_t> reserved;
+    reserved.reserve(regions.size());
+
+    for (const auto& region : regions) {
+        auto addr = reinterpret_cast<uintptr_t>(region.addr);
+        if (hasOverlapLocked(addr, region.length)) {
+            for (auto reserved_addr : reserved) {
+                registering_memory_regions_.erase(reserved_addr);
+            }
+            return false;
+        }
+        registering_memory_regions_[addr] = region;
+        reserved.push_back(addr);
+    }
+    return true;
+}
+
+void TransferEngineImpl::commitMemoryRegions(
+    const std::vector<MemoryRegion>& regions) {
+    std::unique_lock<std::shared_mutex> lock(mutex_);
+    for (const auto& region : regions) {
+        registering_memory_regions_.erase(
+            reinterpret_cast<uintptr_t>(region.addr));
+        insertMemoryRegionLocked(region);
+    }
+}
+
+void TransferEngineImpl::releaseMemoryRegions(
+    const std::vector<MemoryRegion>& regions) {
+    std::unique_lock<std::shared_mutex> lock(mutex_);
+    for (const auto& region : regions) {
+        registering_memory_regions_.erase(
+            reinterpret_cast<uintptr_t>(region.addr));
+    }
 }
 
 void TransferEngineImpl::insertMemoryRegionLocked(const MemoryRegion& region) {

--- a/mooncake-transfer-engine/tests/transport_uint_test.cpp
+++ b/mooncake-transfer-engine/tests/transport_uint_test.cpp
@@ -18,17 +18,103 @@
 #include <sys/time.h>
 
 #include <array>
+#include <condition_variable>
 #include <cstdlib>
 #include <fstream>
+#include <future>
 #include <iomanip>
 #include <memory>
+#include <mutex>
+#include <utility>
 
 #include "transfer_engine.h"
+#include "transfer_engine_impl.h"
 #include "transport/transport.h"
 
 using namespace mooncake;
 
 namespace mooncake {
+
+class TransferEngineImplTestPeer {
+   public:
+    static void replaceTransports(TransferEngineImpl& engine,
+                                  std::shared_ptr<Transport> transport) {
+        engine.multi_transports_->transport_map_.clear();
+        engine.multi_transports_->transport_map_.emplace("blocking",
+                                                         std::move(transport));
+    }
+};
+
+class BlockingRegistrationTransport : public Transport {
+   public:
+    explicit BlockingRegistrationTransport(int first_registration_result = 0)
+        : first_registration_result_(first_registration_result) {}
+
+    void waitForFirstRegistration() {
+        std::unique_lock<std::mutex> lock(mutex_);
+        cv_.wait(lock, [this] { return first_registration_started_; });
+    }
+
+    void releaseFirstRegistration() {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            release_first_registration_ = true;
+        }
+        cv_.notify_all();
+    }
+
+    int registrationCalls() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return registration_calls_;
+    }
+
+    Status submitTransfer(BatchID,
+                          const std::vector<TransferRequest>&) override {
+        return Status::OK();
+    }
+
+    Status getTransferStatus(BatchID, size_t, TransferStatus&) override {
+        return Status::OK();
+    }
+
+   private:
+    int waitOnFirstRegistration() {
+        std::unique_lock<std::mutex> lock(mutex_);
+        ++registration_calls_;
+        if (registration_calls_ == 1) {
+            first_registration_started_ = true;
+            cv_.notify_all();
+            cv_.wait(lock, [this] { return release_first_registration_; });
+            return first_registration_result_;
+        }
+        return 0;
+    }
+
+    int registerLocalMemory(void*, size_t, const std::string&, bool,
+                            bool) override {
+        return waitOnFirstRegistration();
+    }
+
+    int unregisterLocalMemory(void*, bool) override { return 0; }
+
+    int registerLocalMemoryBatch(const std::vector<BufferEntry>&,
+                                 const std::string&) override {
+        return waitOnFirstRegistration();
+    }
+
+    int unregisterLocalMemoryBatch(const std::vector<void*>&) override {
+        return 0;
+    }
+
+    const char* getName() const override { return "blocking"; }
+
+    std::mutex mutex_;
+    std::condition_variable cv_;
+    int first_registration_result_;
+    int registration_calls_ = 0;
+    bool first_registration_started_ = false;
+    bool release_first_registration_ = false;
+};
 
 class TransportTest : public ::testing::Test {
    protected:
@@ -211,6 +297,74 @@ TEST_F(TransportTest, RegisterLocalMemoryBatchAllowsAdjacentBuffers) {
     };
 
     EXPECT_EQ(engine.registerLocalMemoryBatch(entries, "cpu:0"), 0);
+}
+
+TEST_F(TransportTest, ConcurrentRegisterLocalMemoryRejectsOverlap) {
+    TransferEngineImpl engine(false);
+    ASSERT_EQ(engine.init(P2PHANDSHAKE, "127.0.0.1:12345"), 0);
+    auto transport = std::make_shared<BlockingRegistrationTransport>();
+    TransferEngineImplTestPeer::replaceTransports(engine, transport);
+
+    std::array<char, 128> buffer{};
+    auto first = std::async(std::launch::async, [&] {
+        return engine.registerLocalMemory(buffer.data(), buffer.size(),
+                                          "cpu:0");
+    });
+    transport->waitForFirstRegistration();
+
+    int second =
+        engine.registerLocalMemory(buffer.data(), buffer.size(), "cpu:0");
+    int registration_calls = transport->registrationCalls();
+    transport->releaseFirstRegistration();
+
+    EXPECT_EQ(second, ERR_ADDRESS_OVERLAPPED);
+    EXPECT_EQ(registration_calls, 1);
+    EXPECT_EQ(first.get(), 0);
+    EXPECT_EQ(engine.unregisterLocalMemory(buffer.data()), 0);
+}
+
+TEST_F(TransportTest, ConcurrentRegisterLocalMemoryBatchRejectsOverlap) {
+    TransferEngineImpl engine(false);
+    ASSERT_EQ(engine.init(P2PHANDSHAKE, "127.0.0.1:12345"), 0);
+    auto transport = std::make_shared<BlockingRegistrationTransport>();
+    TransferEngineImplTestPeer::replaceTransports(engine, transport);
+
+    std::array<char, 128> buffer{};
+    std::vector<BufferEntry> entries = {{buffer.data(), buffer.size()}};
+    auto first = std::async(std::launch::async, [&] {
+        return engine.registerLocalMemoryBatch(entries, "cpu:0");
+    });
+    transport->waitForFirstRegistration();
+
+    int second = engine.registerLocalMemoryBatch(entries, "cpu:0");
+    int registration_calls = transport->registrationCalls();
+    transport->releaseFirstRegistration();
+
+    EXPECT_EQ(second, ERR_ADDRESS_OVERLAPPED);
+    EXPECT_EQ(registration_calls, 1);
+    EXPECT_EQ(first.get(), 0);
+    EXPECT_EQ(engine.unregisterLocalMemoryBatch({buffer.data()}), 0);
+}
+
+TEST_F(TransportTest, FailedRegistrationReleasesReservedRegion) {
+    TransferEngineImpl engine(false);
+    ASSERT_EQ(engine.init(P2PHANDSHAKE, "127.0.0.1:12345"), 0);
+    auto transport =
+        std::make_shared<BlockingRegistrationTransport>(ERR_MEMORY);
+    TransferEngineImplTestPeer::replaceTransports(engine, transport);
+
+    std::array<char, 128> buffer{};
+    auto first = std::async(std::launch::async, [&] {
+        return engine.registerLocalMemory(buffer.data(), buffer.size(),
+                                          "cpu:0");
+    });
+    transport->waitForFirstRegistration();
+    transport->releaseFirstRegistration();
+
+    EXPECT_EQ(first.get(), ERR_MEMORY);
+    EXPECT_EQ(engine.registerLocalMemory(buffer.data(), buffer.size(), "cpu:0"),
+              0);
+    EXPECT_EQ(engine.unregisterLocalMemory(buffer.data()), 0);
 }
 }  // namespace mooncake
 


### PR DESCRIPTION
## Description

`registerLocalMemory()` and `registerLocalMemoryBatch()` checked `local_memory_regions_` before transport registration, then inserted the regions after transport calls completed. Concurrent callers could both pass the overlap check and register the same or overlapping memory.

This PR adds an in-flight region map protected by the existing mutex. Classic single and batch registrations now reserve their complete interval set atomically, promote it after transport success, and release it on failure. A deterministic blocking transport test covers both APIs and verifies failed registrations release their reservations.

This change is independent of #2869, which handles transport error propagation.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

**Test commands:**
```bash
cmake -S . -B build -G Ninja -DBUILD_UNIT_TESTS=ON -DBUILD_EXAMPLES=OFF -DBUILD_BENCHMARK=OFF -DWITH_TE=ON -DWITH_STORE=OFF -DWITH_STORE_RUST=OFF -DWITH_EP=OFF -DWITH_P2P_STORE=OFF -DUSE_TCP=ON -DENABLE_DEBUG_SYMBOLS=OFF
cmake --build build --target transport_uint_test -j 12
./build/mooncake-transfer-engine/tests/transport_uint_test
./build/mooncake-transfer-engine/tests/transport_uint_test --gtest_filter=TransportTest.ConcurrentRegisterLocalMemoryRejectsOverlap:TransportTest.ConcurrentRegisterLocalMemoryBatchRejectsOverlap --gtest_repeat=20
```

**Test results:**
- [x] Unit tests pass (14/14 on Ubuntu; concurrency tests pass 20 repetitions)
- [ ] Integration tests pass (not applicable)
- [x] Manual testing done: with reservation calls removed, both deterministic concurrency tests return success for the second overlapping registration and call the transport twice

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass (touched-file hooks pass)
- [x] I have updated the documentation (not applicable; no user-facing API change)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue (not applicable)

## AI Assistance Disclosure

- [x] AI tools were used: Codex assisted with test preparation.