### PR TITLE
[Wheel] Gracefully stop Store REST service on SIGTERM

### DIFF
--- a/mooncake-wheel/mooncake/mooncake_store_service.py
+++ b/mooncake-wheel/mooncake/mooncake_store_service.py
@@ -181,6 +181,7 @@ class MooncakeStoreService:
                         logging.info(
                             "Store startup cancelled by shutdown request"
                         )
+                        await self.stop()
                         return False
 
                 if ret != 0:
@@ -684,6 +685,7 @@ class MooncakeStoreService:
     async def stop(self):
         if self.store:
             ret = self.store.close()
+            self.store = None
             if ret != 0:
                 logging.warning("Mooncake service close returned %s", ret)
             else:
@@ -723,8 +725,8 @@ async def main():
     shutdown_event = asyncio.Event()
     loop = asyncio.get_running_loop()
 
-    _unblock_shutdown_signals()
     _install_shutdown_signal_handlers(loop, shutdown_event)
+    _unblock_shutdown_signals()
 
     try:
         if not await service.start_store_service(

--- a/mooncake-wheel/mooncake/mooncake_store_service.py
+++ b/mooncake-wheel/mooncake/mooncake_store_service.py
@@ -5,6 +5,7 @@ import argparse
 import asyncio
 import json
 import logging
+import signal
 import time
 
 from aiohttp import web
@@ -30,6 +31,32 @@ def _shm_name_to_path(name):
     if not normalized or "/" in normalized or normalized in {".", ".."}:
         return None
     return f"/dev/shm/{normalized}"
+
+
+def _unblock_shutdown_signals():
+    try:
+        signal.pthread_sigmask(
+            signal.SIG_UNBLOCK, {signal.SIGINT, signal.SIGTERM}
+        )
+    except AttributeError:
+        pass
+
+
+def _install_shutdown_signal_handlers(loop, shutdown_event):
+    def request_shutdown(signum):
+        logging.info("Received signal %s, shutting down", signum)
+        shutdown_event.set()
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        try:
+            loop.add_signal_handler(sig, request_shutdown, sig)
+        except (NotImplementedError, RuntimeError):
+            signal.signal(
+                sig,
+                lambda signum, _frame: loop.call_soon_threadsafe(
+                    request_shutdown, signum
+                ),
+            )
 
 
 class MooncakeStoreService:
@@ -91,12 +118,15 @@ class MooncakeStoreService:
             format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
         )
 
-    async def start_store_service(self, max_wait_time: float = 60):
+    async def start_store_service(
+        self, max_wait_time: float = 60, shutdown_event=None
+    ):
         """
         Start the store service with retry mechanism.
 
         Args:
             max_wait_time: Maximum total wait time in seconds (default: 60)
+            shutdown_event: Optional asyncio event used to cancel startup
 
         Returns:
             True if successful, False otherwise
@@ -105,7 +135,15 @@ class MooncakeStoreService:
         retry_interval = 1.0  # Fixed retry interval: 1 second
         start_time = time.perf_counter()
 
+        if shutdown_event is not None:
+            # Process any signal callback queued immediately before startup.
+            await asyncio.sleep(0)
+
         while True:
+            if shutdown_event is not None and shutdown_event.is_set():
+                logging.info("Store startup cancelled by shutdown request")
+                return False
+
             elapsed = time.perf_counter() - start_time
             if elapsed >= max_wait_time:
                 logging.error(
@@ -135,6 +173,16 @@ class MooncakeStoreService:
                     self.config.tenant_id
                 )
 
+                if shutdown_event is not None:
+                    # setup() is synchronous. Give asyncio signal callbacks a
+                    # chance to publish a shutdown requested while it ran.
+                    await asyncio.sleep(0)
+                    if shutdown_event.is_set():
+                        logging.info(
+                            "Store startup cancelled by shutdown request"
+                        )
+                        return False
+
                 if ret != 0:
                     raise RuntimeError("Store initialization failed")
 
@@ -156,7 +204,20 @@ class MooncakeStoreService:
 
                 # Wait before retry, but don't exceed max_wait_time
                 if actual_sleep_time > 0:
-                    await asyncio.sleep(actual_sleep_time)
+                    if shutdown_event is not None:
+                        try:
+                            await asyncio.wait_for(
+                                shutdown_event.wait(),
+                                timeout=actual_sleep_time,
+                            )
+                            logging.info(
+                                "Store startup cancelled by shutdown request"
+                            )
+                            return False
+                        except asyncio.TimeoutError:
+                            pass
+                    else:
+                        await asyncio.sleep(actual_sleep_time)
 
 
     async def start_http_service(self, port: int = 8080):
@@ -622,8 +683,11 @@ class MooncakeStoreService:
 
     async def stop(self):
         if self.store:
-            self.store.close()
-            logging.info("Mooncake service stopped")
+            ret = self.store.close()
+            if ret != 0:
+                logging.warning("Mooncake service close returned %s", ret)
+            else:
+                logging.info("Mooncake service stopped")
 
 def parse_arguments():
     parser = argparse.ArgumentParser(description='Mooncake Store Service with REST API')
@@ -656,25 +720,39 @@ async def main():
             logging.warning(f"Ignoring invalid CLI config: {item}")
 
     service = MooncakeStoreService(args.config, cli_config)
+    shutdown_event = asyncio.Event()
+    loop = asyncio.get_running_loop()
+
+    _unblock_shutdown_signals()
+    _install_shutdown_signal_handlers(loop, shutdown_event)
 
     try:
-        if not await service.start_store_service(max_wait_time=args.max_wait_time):
+        if not await service.start_store_service(
+            max_wait_time=args.max_wait_time,
+            shutdown_event=shutdown_event,
+        ):
+            if shutdown_event.is_set():
+                return
             raise RuntimeError("Failed to start store service")
+
+        _unblock_shutdown_signals()
+        await asyncio.sleep(0)
+        if shutdown_event.is_set():
+            return
 
         if not await service.start_http_service(args.port):
             raise RuntimeError("Failed to start HTTP service")
 
-        logging.info("Mooncake Store Service is running. Press Ctrl+C to stop.")
-        while True:
-            await asyncio.sleep(1)
+        logging.info("Mooncake Store Service is running")
+        await shutdown_event.wait()
 
     except KeyboardInterrupt:
-        logging.info("Received shutdown signal")
-        await service.stop()
+        logging.info("Received keyboard interrupt, shutting down")
     except Exception as e:
         logging.error("Service error: %s", e)
-        await service.stop()
         raise
+    finally:
+        await service.stop()
 
 
 def sync_main():

--- a/mooncake-wheel/tests/test_mooncake_store_service_api.py
+++ b/mooncake-wheel/tests/test_mooncake_store_service_api.py
@@ -1,12 +1,16 @@
 #!/usr/bin/env python3
 import asyncio
 import json
+import logging
+import signal
 import sys
 import tempfile
+import time
 import types
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
+from unittest import mock
 from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -40,7 +44,12 @@ except ModuleNotFoundError:
     store_module.MooncakeDistributedStore = MooncakeDistributedStore
     sys.modules["mooncake.store"] = store_module
 
-from mooncake.mooncake_store_service import MooncakeStoreService, _shm_name_to_path
+from mooncake.mooncake_store_service import (
+    MooncakeStoreService,
+    _install_shutdown_signal_handlers,
+    _shm_name_to_path,
+    main as store_service_main,
+)
 
 
 class FakeStore:
@@ -748,6 +757,134 @@ class StoreServiceApiTest(unittest.IsolatedAsyncioTestCase):
     async def test_unmount_shm_empty_list(self):
         resp = await self.service.handle_unmount_shm(FakeRequest({"segment_ids": []}))
         self.assertEqual(resp.status, 400)
+
+
+class StoreServiceShutdownTest(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.service = MooncakeStoreService.__new__(MooncakeStoreService)
+        self.service.store = None
+        self.service.config = SimpleNamespace(
+            local_hostname="localhost",
+            metadata_server="P2PHANDSHAKE",
+            global_segment_size=1,
+            local_buffer_size=0,
+            protocol="tcp",
+            device_name="",
+            master_server_address="localhost:50051",
+            enable_ssd_offload=False,
+            ssd_offload_path="",
+            tenant_id="",
+        )
+
+    async def test_shutdown_event_stops_startup_retry_sleep(self):
+        class FailingStore:
+            def setup(self, *_args):
+                raise RuntimeError("setup failed")
+
+        shutdown_event = asyncio.Event()
+
+        async def trigger_shutdown():
+            await asyncio.sleep(0)
+            shutdown_event.set()
+
+        with mock.patch(
+            "mooncake.mooncake_store_service.MooncakeDistributedStore",
+            FailingStore,
+        ):
+            shutdown_task = asyncio.create_task(trigger_shutdown())
+            start_time = time.perf_counter()
+            with self.assertLogs(level=logging.WARNING):
+                result = await self.service.start_store_service(
+                    max_wait_time=2, shutdown_event=shutdown_event
+                )
+            elapsed = time.perf_counter() - start_time
+            await shutdown_task
+
+        self.assertFalse(result)
+        self.assertLess(elapsed, 0.5)
+
+    async def test_shutdown_during_setup_is_observed_before_success(self):
+        shutdown_event = asyncio.Event()
+        loop = asyncio.get_running_loop()
+
+        class SchedulingStore(FakeStore):
+            def setup(self, *args):
+                ret = super().setup(*args)
+                loop.call_soon(shutdown_event.set)
+                return ret
+
+        with mock.patch(
+            "mooncake.mooncake_store_service.MooncakeDistributedStore",
+            SchedulingStore,
+        ):
+            result = await self.service.start_store_service(
+                max_wait_time=1, shutdown_event=shutdown_event
+            )
+
+        self.assertFalse(result)
+
+    async def test_stop_logs_nonzero_close_return(self):
+        self.service.store = mock.Mock()
+        self.service.store.close.return_value = 7
+
+        with self.assertLogs(level=logging.WARNING) as logs:
+            await self.service.stop()
+
+        self.assertTrue(
+            any("close returned 7" in message for message in logs.output)
+        )
+
+    async def test_signal_handler_requests_shutdown(self):
+        loop = mock.Mock()
+        shutdown_event = asyncio.Event()
+
+        _install_shutdown_signal_handlers(loop, shutdown_event)
+
+        sigterm_call = next(
+            call
+            for call in loop.add_signal_handler.call_args_list
+            if call.args[0] == signal.SIGTERM
+        )
+        sigterm_call.args[1](sigterm_call.args[2])
+        self.assertTrue(shutdown_event.is_set())
+
+    async def test_main_closes_store_when_shutdown_requested_during_startup(self):
+        args = SimpleNamespace(
+            config=None,
+            define=[],
+            max_wait_time=60,
+            port=8080,
+        )
+        service = mock.Mock()
+        service.start_store_service = mock.AsyncMock(return_value=False)
+        service.start_http_service = mock.AsyncMock(return_value=True)
+        service.stop = mock.AsyncMock()
+
+        def request_shutdown(_loop, shutdown_event):
+            shutdown_event.set()
+
+        with (
+            mock.patch(
+                "mooncake.mooncake_store_service.parse_arguments",
+                return_value=args,
+            ),
+            mock.patch(
+                "mooncake.mooncake_store_service.MooncakeStoreService",
+                return_value=service,
+            ),
+            mock.patch(
+                "mooncake.mooncake_store_service._unblock_shutdown_signals"
+            ),
+            mock.patch(
+                "mooncake.mooncake_store_service._install_shutdown_signal_handlers",
+                side_effect=request_shutdown,
+            ),
+        ):
+            await store_service_main()
+
+        service.start_store_service.assert_awaited_once()
+        service.start_http_service.assert_not_awaited()
+        service.stop.assert_awaited_once()
 
 
 class ShmNameToPathTest(unittest.TestCase):

--- a/mooncake-wheel/tests/test_mooncake_store_service_api.py
+++ b/mooncake-wheel/tests/test_mooncake_store_service_api.py
@@ -808,31 +808,46 @@ class StoreServiceShutdownTest(unittest.IsolatedAsyncioTestCase):
         loop = asyncio.get_running_loop()
 
         class SchedulingStore(FakeStore):
+            def __init__(self):
+                super().__init__()
+                self.close_calls = 0
+
             def setup(self, *args):
                 ret = super().setup(*args)
                 loop.call_soon(shutdown_event.set)
                 return ret
 
+            def close(self):
+                self.close_calls += 1
+                return 0
+
+        store = SchedulingStore()
         with mock.patch(
             "mooncake.mooncake_store_service.MooncakeDistributedStore",
-            SchedulingStore,
+            return_value=store,
         ):
             result = await self.service.start_store_service(
                 max_wait_time=1, shutdown_event=shutdown_event
             )
 
         self.assertFalse(result)
+        self.assertEqual(store.close_calls, 1)
+        self.assertIsNone(self.service.store)
 
     async def test_stop_logs_nonzero_close_return(self):
-        self.service.store = mock.Mock()
-        self.service.store.close.return_value = 7
+        store = mock.Mock()
+        store.close.return_value = 7
+        self.service.store = store
 
         with self.assertLogs(level=logging.WARNING) as logs:
             await self.service.stop()
 
+        self.assertIsNone(self.service.store)
         self.assertTrue(
             any("close returned 7" in message for message in logs.output)
         )
+        await self.service.stop()
+        store.close.assert_called_once_with()
 
     async def test_signal_handler_requests_shutdown(self):
         loop = mock.Mock()
@@ -860,8 +875,14 @@ class StoreServiceShutdownTest(unittest.IsolatedAsyncioTestCase):
         service.start_http_service = mock.AsyncMock(return_value=True)
         service.stop = mock.AsyncMock()
 
+        startup_calls = []
+
         def request_shutdown(_loop, shutdown_event):
+            startup_calls.append("install")
             shutdown_event.set()
+
+        def unblock_shutdown_signals():
+            startup_calls.append("unblock")
 
         with (
             mock.patch(
@@ -873,7 +894,8 @@ class StoreServiceShutdownTest(unittest.IsolatedAsyncioTestCase):
                 return_value=service,
             ),
             mock.patch(
-                "mooncake.mooncake_store_service._unblock_shutdown_signals"
+                "mooncake.mooncake_store_service._unblock_shutdown_signals",
+                side_effect=unblock_shutdown_signals,
             ),
             mock.patch(
                 "mooncake.mooncake_store_service._install_shutdown_signal_handlers",
@@ -885,6 +907,7 @@ class StoreServiceShutdownTest(unittest.IsolatedAsyncioTestCase):
         service.start_store_service.assert_awaited_once()
         service.start_http_service.assert_not_awaited()
         service.stop.assert_awaited_once()
+        self.assertEqual(startup_calls, ["install", "unblock"])
 
 
 class ShmNameToPathTest(unittest.TestCase):


### PR DESCRIPTION
## Description

The Store REST service currently relies on `KeyboardInterrupt` around a polling loop for shutdown. Process managers commonly terminate services with `SIGTERM`, and a shutdown request received during startup can remain pending while the service is retrying or proceed into HTTP startup before the asyncio signal callback runs. Cleanup is also duplicated across exception paths instead of being guaranteed for every exit path.

This PR:

- installs asyncio handlers for `SIGINT` and `SIGTERM` and unblocks inherited signal masks;
- uses an `asyncio.Event` to drive the service lifetime;
- makes startup retry waits interruptible by a shutdown request;
- observes queued shutdown callbacks before and immediately after synchronous Store setup, preventing HTTP startup after termination was requested;
- closes the Store from a `finally` block and reports nonzero close results.

`MooncakeDistributedStore.setup()` remains synchronous and is not cancelled while it is executing. A pending shutdown request is honored as soon as setup returns.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

The shutdown tests cover signal-handler dispatch, cancellation before and after Store setup, interruption of retry sleeps, guaranteed cleanup from `main()`, and nonzero close results.

**Test commands:**

```bash
PYTHONDONTWRITEBYTECODE=1 python3 \
  mooncake-wheel/tests/test_mooncake_store_service_api.py \
  StoreServiceShutdownTest

uvx --from ruff==0.6.9 ruff check \
  mooncake-wheel/mooncake/mooncake_store_service.py \
  mooncake-wheel/tests/test_mooncake_store_service_api.py

uvx --from ruff==0.6.9 ruff format --check \
  mooncake-wheel/mooncake/mooncake_store_service.py \
  mooncake-wheel/tests/test_mooncake_store_service_api.py

git diff --check upstream/main...HEAD
```

**Test results:**

- [x] Unit tests pass (5 shutdown tests)
- [ ] Integration tests pass (not run)
- [ ] Manual testing done

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh` (no C/C++ files changed; Python files pass Ruff format check)
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [x] Documentation is not required because no user-facing configuration or API was added
- [x] I have added tests to prove my changes are effective
- [x] RFC is not required because the change is under 500 lines

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specified below)

Codex assisted with implementation, test design, and validation. The submitter reviewed the resulting changes.