### PR TITLE
[Transfer Engine] Refresh RDMA metadata on HCA and GID change events

### DIFF
--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
@@ -170,6 +170,12 @@ class RdmaContext {
         const std::vector<AutoGidSelectionIdentity> &tried_selections = {},
         std::string *previous_gid = nullptr, std::string *next_gid = nullptr);
 
+    // Refresh the runtime GID after IBV_EVENT_GID_CHANGE. Auto-GID mode uses
+    // the same candidate filtering/ranking as initial device open; explicit
+    // MC_GID_INDEX keeps the configured index and refreshes only its value.
+    bool refreshCurrentGid(std::string *previous_gid = nullptr,
+                           std::string *next_gid = nullptr);
+
     ibv_context *context() const { return context_; }
 
     RdmaTransport &engine() const { return engine_; }

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
@@ -59,6 +59,12 @@ struct GidSelectionSnapshot {
     int gid_index = -1;
 };
 
+enum class GidRefreshResult {
+    UNCHANGED = 0,
+    CHANGED = 1,
+    FAILED = 2,
+};
+
 struct RdmaCq {
     RdmaCq() : native(nullptr), outstanding(0) {}
     ibv_cq *native;
@@ -173,8 +179,8 @@ class RdmaContext {
     // Refresh the runtime GID after IBV_EVENT_GID_CHANGE. Auto-GID mode uses
     // the same candidate filtering/ranking as initial device open; explicit
     // MC_GID_INDEX keeps the configured index and refreshes only its value.
-    bool refreshCurrentGid(std::string *previous_gid = nullptr,
-                           std::string *next_gid = nullptr);
+    GidRefreshResult refreshCurrentGid(std::string *previous_gid = nullptr,
+                                       std::string *next_gid = nullptr);
 
     ibv_context *context() const { return context_; }
 

--- a/mooncake-transfer-engine/include/transport/rdma_transport/worker_pool.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/worker_pool.h
@@ -63,7 +63,7 @@ class WorkerPool {
     void handlePathFailure(const std::string &peer_nic_path,
                            RdmaEndPoint *endpoint = nullptr);
     void refreshPublishedLocalTopology();
-    bool refreshPublishedLocalGid();
+    GidRefreshResult refreshPublishedLocalGid();
 
     // Context-level health tracking for catastrophic hardware failure.
     // When all rails through a local RNIC are unavailable, increment the

--- a/mooncake-transfer-engine/include/transport/rdma_transport/worker_pool.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/worker_pool.h
@@ -62,6 +62,8 @@ class WorkerPool {
     // and optionally deletes the endpoint
     void handlePathFailure(const std::string &peer_nic_path,
                            RdmaEndPoint *endpoint = nullptr);
+    void refreshPublishedLocalTopology();
+    bool refreshPublishedLocalGid();
 
     // Context-level health tracking for catastrophic hardware failure.
     // When all rails through a local RNIC are unavailable, increment the

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -925,6 +925,120 @@ bool RdmaContext::reprobeAutoGid(
     return true;
 }
 
+bool RdmaContext::refreshCurrentGid(std::string *previous_gid,
+                                    std::string *next_gid) {
+    std::lock_guard<std::mutex> reprobe_guard(gid_reprobe_lock_);
+    std::string current_gid_string;
+    int current_gid_index = -1;
+    int next_gid_index = -1;
+    uint16_t current_lid = 0;
+    ibv_context *current_context = nullptr;
+    uint8_t current_port = 0;
+    bool auto_gid_selection_enabled = false;
+    {
+        std::lock_guard<std::mutex> guard(gid_lock_);
+        if (!context_) {
+            return false;
+        }
+        current_gid_index = gid_index_;
+        current_gid_string = gidBytesToString(gid_.raw);
+        current_lid = lid_;
+        current_context = context_;
+        current_port = port_;
+        auto_gid_selection_enabled = auto_gid_selection_enabled_;
+    }
+
+    if (auto_gid_selection_enabled) {
+        ibv_port_attr port_attr;
+        if (ibv_query_port(current_context, current_port, &port_attr)) {
+            PLOG(WARNING) << "Failed to refresh port attributes on "
+                          << device_name_ << "/"
+                          << static_cast<int>(current_port);
+            return false;
+        }
+
+        std::vector<AutoGidCandidate> candidates;
+        candidates.reserve(port_attr.gid_tbl_len);
+        for (int i = 0; i < port_attr.gid_tbl_len; ++i) {
+            AutoGidCandidate candidate;
+            candidate.gid_index = i;
+
+            struct ibv_gid_entry gid_entry;
+            if (ibv_query_gid_ex(current_context, current_port, i, &gid_entry,
+                                 0)) {
+                candidate.query_succeeded = false;
+                candidates.push_back(candidate);
+                continue;
+            }
+
+            const auto *gid_addr =
+                reinterpret_cast<const struct in6_addr *>(gid_entry.gid.raw);
+            std::string ndev = readGidNdev(device_name_, current_port, i);
+            candidate.gid = gidBytesToString(gid_entry.gid.raw);
+            candidate.gid_type = gid_entry.gid_type;
+            candidate.has_network_device = !ndev.empty();
+            candidate.is_ipv4_mapped = ipv6_addr_v4mapped(gid_addr);
+            candidate.is_link_local_ipv6 = isLinkLocalIpv6(gid_addr);
+            candidate.is_overlay_network =
+                candidate.has_network_device && isOverlayNetwork(ndev);
+            candidate.is_overlay_ipv4 =
+                candidate.is_ipv4_mapped && isOverlayIPv4(gid_addr);
+            candidate.is_null_gid = isNullGid(&gid_entry.gid);
+            candidates.push_back(candidate);
+        }
+
+        auto selection = selectBestAutoGidCandidate(candidates);
+        if (!selection.has_value()) {
+            LOG(WARNING) << "No suitable GID found while refreshing "
+                         << device_name_ << "/"
+                         << static_cast<int>(current_port);
+            return false;
+        }
+        next_gid_index = selection->gid_index;
+    } else {
+        next_gid_index = current_gid_index;
+    }
+
+    ibv_gid new_gid = {};
+    std::string next_gid_string;
+    if (ibv_query_gid(current_context, current_port, next_gid_index,
+                      &new_gid)) {
+        return false;
+    }
+    if (isNullGid(&new_gid)) {
+        return false;
+    }
+    next_gid_string = gidBytesToString(new_gid.raw);
+
+    if (next_gid_index == current_gid_index &&
+        next_gid_string == current_gid_string) {
+        if (next_gid) *next_gid = current_gid_string;
+        return false;
+    }
+
+    int publish_ret = engine_.refreshLocalDeviceDesc(device_name_, current_lid,
+                                                     next_gid_string);
+    if (publish_ret) {
+        LOG(ERROR) << "Failed to refresh local device descriptor for "
+                   << device_name_ << ": " << publish_ret;
+        return false;
+    }
+
+    {
+        std::lock_guard<std::mutex> guard(gid_lock_);
+        gid_ = new_gid;
+        gid_index_ = next_gid_index;
+    }
+    if (previous_gid) *previous_gid = current_gid_string;
+    if (next_gid) *next_gid = next_gid_string;
+
+    LOG(WARNING) << "Refreshed GID on " << device_name_ << "/"
+                 << static_cast<int>(port_) << ": index " << current_gid_index
+                 << " (" << current_gid_string << ") -> " << next_gid_index
+                 << " (" << next_gid_string << ")";
+    return true;
+}
+
 int RdmaContext::openRdmaDevice(const std::string &device_name, uint8_t port,
                                 int gid_index) {
     int num_devices = 0;

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -925,8 +925,8 @@ bool RdmaContext::reprobeAutoGid(
     return true;
 }
 
-bool RdmaContext::refreshCurrentGid(std::string *previous_gid,
-                                    std::string *next_gid) {
+GidRefreshResult RdmaContext::refreshCurrentGid(std::string *previous_gid,
+                                                std::string *next_gid) {
     std::lock_guard<std::mutex> reprobe_guard(gid_reprobe_lock_);
     std::string current_gid_string;
     int current_gid_index = -1;
@@ -938,7 +938,7 @@ bool RdmaContext::refreshCurrentGid(std::string *previous_gid,
     {
         std::lock_guard<std::mutex> guard(gid_lock_);
         if (!context_) {
-            return false;
+            return GidRefreshResult::FAILED;
         }
         current_gid_index = gid_index_;
         current_gid_string = gidBytesToString(gid_.raw);
@@ -954,7 +954,7 @@ bool RdmaContext::refreshCurrentGid(std::string *previous_gid,
             PLOG(WARNING) << "Failed to refresh port attributes on "
                           << device_name_ << "/"
                           << static_cast<int>(current_port);
-            return false;
+            return GidRefreshResult::FAILED;
         }
 
         std::vector<AutoGidCandidate> candidates;
@@ -992,7 +992,7 @@ bool RdmaContext::refreshCurrentGid(std::string *previous_gid,
             LOG(WARNING) << "No suitable GID found while refreshing "
                          << device_name_ << "/"
                          << static_cast<int>(current_port);
-            return false;
+            return GidRefreshResult::FAILED;
         }
         next_gid_index = selection->gid_index;
     } else {
@@ -1003,17 +1003,17 @@ bool RdmaContext::refreshCurrentGid(std::string *previous_gid,
     std::string next_gid_string;
     if (ibv_query_gid(current_context, current_port, next_gid_index,
                       &new_gid)) {
-        return false;
+        return GidRefreshResult::FAILED;
     }
     if (isNullGid(&new_gid)) {
-        return false;
+        return GidRefreshResult::FAILED;
     }
     next_gid_string = gidBytesToString(new_gid.raw);
 
     if (next_gid_index == current_gid_index &&
         next_gid_string == current_gid_string) {
         if (next_gid) *next_gid = current_gid_string;
-        return false;
+        return GidRefreshResult::UNCHANGED;
     }
 
     int publish_ret = engine_.refreshLocalDeviceDesc(device_name_, current_lid,
@@ -1021,7 +1021,7 @@ bool RdmaContext::refreshCurrentGid(std::string *previous_gid,
     if (publish_ret) {
         LOG(ERROR) << "Failed to refresh local device descriptor for "
                    << device_name_ << ": " << publish_ret;
-        return false;
+        return GidRefreshResult::FAILED;
     }
 
     {
@@ -1036,7 +1036,7 @@ bool RdmaContext::refreshCurrentGid(std::string *previous_gid,
                  << static_cast<int>(port_) << ": index " << current_gid_index
                  << " (" << current_gid_string << ") -> " << next_gid_index
                  << " (" << next_gid_string << ")";
-    return true;
+    return GidRefreshResult::CHANGED;
 }
 
 int RdmaContext::openRdmaDevice(const std::string &device_name, uint8_t port,

--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -655,14 +655,16 @@ int WorkerPool::doProcessContextEvents() {
                   << " is now inactive due to fatal event: "
                   << event.event_type;
     } else if (event.event_type == IBV_EVENT_GID_CHANGE) {
-        bool gid_changed = refreshPublishedLocalGid();
+        auto gid_refresh_result = refreshPublishedLocalGid();
         ibv_ack_async_event(&event);
         event_acked = true;
 
-        if (gid_changed) {
+        if (gid_refresh_result != GidRefreshResult::UNCHANGED) {
             context_.disconnectAllEndpoints();
             LOG(INFO) << "Worker: Context " << context_.deviceName()
-                      << " GID changed, disconnected all endpoints";
+                      << " GID refresh result="
+                      << static_cast<int>(gid_refresh_result)
+                      << ", disconnected all endpoints";
         }
     } else if (event.event_type == IBV_EVENT_PORT_ACTIVE) {
         context_.set_active(true);
@@ -701,20 +703,23 @@ void WorkerPool::refreshPublishedLocalTopology() {
     }
 }
 
-bool WorkerPool::refreshPublishedLocalGid() {
+GidRefreshResult WorkerPool::refreshPublishedLocalGid() {
     std::string previous_gid;
     std::string next_gid;
-    bool changed = context_.refreshCurrentGid(&previous_gid, &next_gid);
-    if (changed) {
+    auto result = context_.refreshCurrentGid(&previous_gid, &next_gid);
+    if (result == GidRefreshResult::CHANGED) {
         LOG(WARNING) << "Worker: refreshed published GID for "
                      << context_.deviceName() << ": " << previous_gid << " -> "
                      << next_gid;
+    } else if (result == GidRefreshResult::UNCHANGED) {
+        LOG(INFO) << "Worker: received GID change event for "
+                  << context_.deviceName() << ", current GID is unchanged";
     } else {
-        LOG(WARNING) << "Worker: received GID change event for "
-                     << context_.deviceName()
-                     << ", but current GID did not change";
+        LOG(ERROR) << "Worker: failed to refresh published GID for "
+                   << context_.deviceName()
+                   << ", disconnecting endpoints to avoid stale GID reuse";
     }
-    return changed;
+    return result;
 }
 
 void WorkerPool::monitorWorker() {

--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -205,7 +205,7 @@ int WorkerPool::submitPostSend(
                  alt_dev_id < peer_segment_desc->devices.size(); ++alt_dev_id) {
                 if (alt_dev_id == (size_t)device_id) continue;
                 auto alt_path =
-                    MakeNicPath(peer_segment_desc->name,
+                    MakeNicPath(peer_segment_desc->nicPathServerName(),
                                 peer_segment_desc->devices[alt_dev_id].name);
                 if (isRailAvailable(alt_path)) {
                     device_id = alt_dev_id;
@@ -633,6 +633,7 @@ int WorkerPool::doProcessContextEvents() {
                event.event_type == IBV_EVENT_PORT_ERR ||
                event.event_type == IBV_EVENT_LID_CHANGE) {
         context_.set_active(false);
+        refreshPublishedLocalTopology();
 
         /**
          * Similar deadlock might happen if we call
@@ -651,9 +652,21 @@ int WorkerPool::doProcessContextEvents() {
 
         context_.disconnectAllEndpoints();
         LOG(INFO) << "Worker: Context " << context_.deviceName()
-                  << " is now inactive";
+                  << " is now inactive due to fatal event: "
+                  << event.event_type;
+    } else if (event.event_type == IBV_EVENT_GID_CHANGE) {
+        bool gid_changed = refreshPublishedLocalGid();
+        ibv_ack_async_event(&event);
+        event_acked = true;
+
+        if (gid_changed) {
+            context_.disconnectAllEndpoints();
+            LOG(INFO) << "Worker: Context " << context_.deviceName()
+                      << " GID changed, disconnected all endpoints";
+        }
     } else if (event.event_type == IBV_EVENT_PORT_ACTIVE) {
         context_.set_active(true);
+        refreshPublishedLocalTopology();
         markContextSuccess();  // Reset failure counter on port recovery
         LOG(INFO) << "Worker: Context " << context_.deviceName()
                   << " is now active";
@@ -664,6 +677,43 @@ int WorkerPool::doProcessContextEvents() {
     }
 
     return 0;
+}
+
+void WorkerPool::refreshPublishedLocalTopology() {
+    std::lock_guard<std::mutex> guard(context_.engine().local_desc_lock_);
+    auto desc = context_.engine().metadata_->getSegmentDescByID(LOCAL_SEGMENT_ID);
+    if (!desc || !context_.engine().local_topology_) return;
+
+    auto updated_desc = std::make_shared<RdmaTransport::SegmentDesc>(*desc);
+    updated_desc->topology = *context_.engine().local_topology_;
+    for (const auto &context : context_.engine().context_list_) {
+        if (context->active()) continue;
+        updated_desc->topology.disableDevice(context->deviceName());
+    }
+
+    context_.engine().metadata_->addLocalSegment(
+        LOCAL_SEGMENT_ID, updated_desc->name, std::move(updated_desc));
+    int ret = context_.engine().metadata_->updateLocalSegmentDesc();
+    if (ret) {
+        LOG(WARNING) << "Failed to publish RDMA topology update for "
+                     << context_.deviceName() << ", ret=" << ret;
+    }
+}
+
+bool WorkerPool::refreshPublishedLocalGid() {
+    std::string previous_gid;
+    std::string next_gid;
+    bool changed = context_.refreshCurrentGid(&previous_gid, &next_gid);
+    if (changed) {
+        LOG(WARNING) << "Worker: refreshed published GID for "
+                     << context_.deviceName() << ": " << previous_gid << " -> "
+                     << next_gid;
+    } else {
+        LOG(WARNING) << "Worker: received GID change event for "
+                     << context_.deviceName()
+                     << ", but current GID did not change";
+    }
+    return changed;
 }
 
 void WorkerPool::monitorWorker() {

--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -681,7 +681,8 @@ int WorkerPool::doProcessContextEvents() {
 
 void WorkerPool::refreshPublishedLocalTopology() {
     std::lock_guard<std::mutex> guard(context_.engine().local_desc_lock_);
-    auto desc = context_.engine().metadata_->getSegmentDescByID(LOCAL_SEGMENT_ID);
+    auto desc =
+        context_.engine().metadata_->getSegmentDescByID(LOCAL_SEGMENT_ID);
     if (!desc || !context_.engine().local_topology_) return;
 
     auto updated_desc = std::make_shared<RdmaTransport::SegmentDesc>(*desc);


### PR DESCRIPTION
## Description

This PR improves RDMA Transfer Engine fault tolerance when a local HCA becomes unavailable or its GID changes at runtime.

Previously, a node could continue publishing metadata that allowed peers to select a failed HCA, or peers could keep rebuilding endpoints with stale GID information after a runtime GID change. This made recovery depend heavily on repeated endpoint failures.

This change updates the local published RDMA metadata when verbs async events indicate local path state changes:

- On HCA/port failure events, mark the local RDMA context inactive and republish the local topology with inactive HCAs disabled.
- On `IBV_EVENT_PORT_ACTIVE`, mark the context active again and republish topology based on all current context states.
- On `IBV_EVENT_GID_CHANGE`, refresh the local GID, update the published `DeviceDesc.gid`, and disconnect old endpoints so future handshakes rebuild with current metadata.
- Keep `devices[]` stable and disable failed HCAs only through topology selection, preserving `devices[]` / `rkey[]` index alignment.
- Use `nicPathServerName()` when constructing alternate peer NIC paths, fixing dual-NIC / `rdma_server_name` path-key mismatches.

**Notes**
This PR does not implement metadata cache TTL (#2795). Peers still need an existing force-refresh path or a future TTL-based refresh change to observe republished metadata automatically after their cache expires.

## Module

- [X] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



**Test commands:**
```bash
# Example: bash scripts/run_ci_test.sh
```

**Test results:**
- [X] Unit tests pass
- [X] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have formatted my code using `./scripts/code_format.sh`
- [X] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [X] AI tools were used (specify below) CodeX