### PR TITLE
[Store] Add P2P hot standby runtime

### DIFF
--- a/mooncake-store/include/ha/oplog/p2p_hot_standby_service.h
+++ b/mooncake-store/include/ha/oplog/p2p_hot_standby_service.h
@@ -68,6 +68,7 @@ class P2PHotStandbyService {
 
    private:
     ErrorCode StartOplogFollowingLocked(uint64_t baseline_sequence_id);
+    void ResetOplogFollowingLocked();
     ErrorCode FinalCatchUpForPromotionLocked(uint64_t current_applied_seq_id);
     uint64_t GetLocalLastAppliedSequenceIdLocked() const;
     void OnWatcherEvent(StandbyEvent event);

--- a/mooncake-store/include/ha/oplog/p2p_hot_standby_service.h
+++ b/mooncake-store/include/ha/oplog/p2p_hot_standby_service.h
@@ -1,0 +1,87 @@
+// mooncake-store/include/ha/oplog/p2p_hot_standby_service.h
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+
+#include "ha/oplog/oplog_replicator.h"
+#include "ha/oplog/oplog_store_factory.h"
+#include "ha/oplog/p2p_oplog_applier.h"
+#include "ha/oplog/p2p_standby_metadata_store.h"
+#include "standby_state_machine.h"
+#include "types.h"
+
+namespace mooncake {
+
+struct P2PHotStandbyConfig {
+    std::string cluster_id;
+    OpLogStoreType oplog_store_type{kDefaultOpLogStoreType};
+    std::string oplog_store_root_dir{kDefaultOpLogRootDir};
+    int oplog_poll_interval_ms{kDefaultOpLogPollIntervalMs};
+};
+
+struct P2PStandbySyncStatus {
+    uint64_t applied_seq_id{0};
+    uint64_t primary_seq_id{0};
+    uint64_t lag_entries{0};
+    bool is_connected{false};
+    StandbyState state{StandbyState::STOPPED};
+    std::chrono::milliseconds time_in_state{0};
+};
+
+// NOTE: P2PHotStandbyService intentionally does not inherit from the
+// centralized HotStandbyService. The centralized service owns centralized
+// metadata/apply/export semantics, while P2P promotion needs
+// P2PStandbyMetadataStore, P2POpLogApplier, and an export shape that includes
+// clients, segments, objects, and replicas. This class reuses the shared
+// lower-level components (StandbyStateMachine, OpLogStoreFactory,
+// OpLogChangeNotifier, and OpLogReplicator) and keeps only the orchestration
+// layer P2P-specific.
+class P2PHotStandbyService {
+   public:
+    explicit P2PHotStandbyService(P2PHotStandbyConfig config);
+    ~P2PHotStandbyService();
+
+    P2PHotStandbyService(const P2PHotStandbyService&) = delete;
+    P2PHotStandbyService& operator=(const P2PHotStandbyService&) = delete;
+
+    ErrorCode Start(uint64_t baseline_sequence_id = 0);
+    void Stop();
+    ErrorCode Promote();
+
+    P2PStandbySyncStatus GetSyncStatus() const;
+    bool IsReadyForPromotion() const;
+    uint64_t GetLatestAppliedSequenceId() const;
+
+    P2PStandbyMetadataStore::ExportedMetadata ExportMetadata() const;
+    bool WaitForAppliedSequence(
+        uint64_t sequence_id,
+        std::chrono::milliseconds timeout = std::chrono::seconds(5)) const;
+
+    StandbyState GetState() const { return state_machine_.GetState(); }
+    P2PStandbyMetadataStore* GetMetadataStore() const {
+        return metadata_store_.get();
+    }
+
+   private:
+    ErrorCode StartOplogFollowingLocked(uint64_t baseline_sequence_id);
+    ErrorCode FinalCatchUpForPromotionLocked(uint64_t current_applied_seq_id);
+    uint64_t GetLocalLastAppliedSequenceIdLocked() const;
+    void OnWatcherEvent(StandbyEvent event);
+
+    P2PHotStandbyConfig config_;
+
+    std::unique_ptr<P2PStandbyMetadataStore> metadata_store_;
+    std::unique_ptr<P2POpLogApplier> oplog_applier_;
+    std::shared_ptr<OpLogStore> watcher_oplog_store_;
+    std::unique_ptr<OpLogChangeNotifier> oplog_change_notifier_;
+    std::unique_ptr<OpLogReplicator> oplog_replicator_;
+
+    StandbyStateMachine state_machine_;
+    mutable std::mutex mutex_;
+};
+
+}  // namespace mooncake

--- a/mooncake-store/include/ha/oplog/p2p_oplog_applier.h
+++ b/mooncake-store/include/ha/oplog/p2p_oplog_applier.h
@@ -22,8 +22,6 @@ namespace mooncake {
 /// maintains both object metadata (via MetadataStore) and P2P-specific state
 /// (client registrations, segment mappings).
 ///
-/// Note: primary-side recording for UNREGISTER_CLIENT is intentionally deferred
-/// to the follow-up change that wires lifecycle events into RecordOplog().
 class P2POpLogApplier : public OpLogApplier {
    public:
     /// Constructor.

--- a/mooncake-store/include/ha/oplog/p2p_standby_metadata_store.h
+++ b/mooncake-store/include/ha/oplog/p2p_standby_metadata_store.h
@@ -2,6 +2,8 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -38,10 +40,9 @@ struct P2PStandbyClientInfo {
 ///   - objects_: key → replica list (mirrors Primary's object metadata)
 ///   - clients_: client_id → client info (ip, port, segments)
 ///
-/// Thread safety: this class is NOT thread-safe. It is accessed by a single
-/// thread — the OpLogReplicator callback thread writes via P2POpLogApplier,
-/// and ExportMetadata() is called only after Replicator::Stop() has joined
-/// the callback thread during promotion.
+/// Thread safety: public methods protect objects_ and clients_ with an
+/// internal mutex so ExportMetadata() and diagnostic reads can run safely while
+/// the OpLogReplicator callback thread is applying new entries.
 class P2PStandbyMetadataStore : public MetadataStore {
    public:
     P2PStandbyMetadataStore() = default;
@@ -116,19 +117,15 @@ class P2PStandbyMetadataStore : public MetadataStore {
     // ========================================================================
 
     /// Get client info by client_id. Returns nullptr if not found.
-    const P2PStandbyClientInfo* GetClient(const UUID& client_id) const;
+    std::shared_ptr<const P2PStandbyClientInfo> GetClient(
+        const UUID& client_id) const;
 
     /// Get all objects. For testing/diagnostics only.
-    const std::unordered_map<std::string, StandbyObjectMetadata>& GetObjects()
-        const {
-        return objects_;
-    }
+    std::unordered_map<std::string, StandbyObjectMetadata> GetObjects() const;
 
     /// Get all clients. For testing/diagnostics only.
-    const std::unordered_map<UUID, P2PStandbyClientInfo, boost::hash<UUID>>&
-    GetClients() const {
-        return clients_;
-    }
+    std::unordered_map<UUID, P2PStandbyClientInfo, boost::hash<UUID>>
+    GetClients() const;
 
    private:
     // Remove all replicas referencing a segment.
@@ -139,6 +136,8 @@ class P2PStandbyMetadataStore : public MetadataStore {
 
     // Client UUID → client info (ip, port, segments)
     std::unordered_map<UUID, P2PStandbyClientInfo, boost::hash<UUID>> clients_;
+
+    mutable std::mutex mutex_;
 };
 
 }  // namespace mooncake

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -77,6 +77,7 @@ set(MOONCAKE_STORE_SOURCES
     ha/oplog/p2p_oplog_types.cpp
     ha/oplog/p2p_oplog_applier.cpp
     ha/oplog/p2p_standby_metadata_store.cpp
+    ha/oplog/p2p_hot_standby_service.cpp
     standby_state_machine.cpp
     ha_metric_manager.cpp
 )

--- a/mooncake-store/src/ha/oplog/p2p_hot_standby_service.cpp
+++ b/mooncake-store/src/ha/oplog/p2p_hot_standby_service.cpp
@@ -1,0 +1,281 @@
+#include "ha/oplog/p2p_hot_standby_service.h"
+
+#include <glog/logging.h>
+
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace mooncake {
+
+P2PHotStandbyService::P2PHotStandbyService(P2PHotStandbyConfig config)
+    : config_(std::move(config)) {
+    metadata_store_ = std::make_unique<P2PStandbyMetadataStore>();
+    oplog_applier_ = std::make_unique<P2POpLogApplier>(metadata_store_.get(),
+                                                       config_.cluster_id);
+}
+
+P2PHotStandbyService::~P2PHotStandbyService() { Stop(); }
+
+ErrorCode P2PHotStandbyService::Start(uint64_t baseline_sequence_id) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (state_machine_.IsRunning()) {
+        LOG(WARNING) << "P2PHotStandbyService is already running";
+        return ErrorCode::OK;
+    }
+
+    auto start_result = state_machine_.ProcessEvent(StandbyEvent::START);
+    if (!start_result.allowed) {
+        LOG(ERROR) << "P2PHotStandbyService: cannot start: "
+                   << start_result.reason;
+        return ErrorCode::INTERNAL_ERROR;
+    }
+
+    state_machine_.ProcessEvent(StandbyEvent::CONNECTED);
+    metadata_store_->RemoveAllMetadata();
+    oplog_applier_ = std::make_unique<P2POpLogApplier>(metadata_store_.get(),
+                                                       config_.cluster_id);
+    oplog_applier_->Recover(baseline_sequence_id);
+
+    auto err = StartOplogFollowingLocked(baseline_sequence_id);
+    if (err != ErrorCode::OK) {
+        state_machine_.ProcessEvent(StandbyEvent::FATAL_ERROR);
+        return err;
+    }
+
+    state_machine_.ProcessEvent(StandbyEvent::SYNC_COMPLETE);
+    LOG(INFO) << "P2PHotStandbyService started"
+              << ", cluster_id=" << config_.cluster_id
+              << ", baseline_sequence_id=" << baseline_sequence_id;
+    return ErrorCode::OK;
+}
+
+ErrorCode P2PHotStandbyService::StartOplogFollowingLocked(
+    uint64_t baseline_sequence_id) {
+    watcher_oplog_store_ = OpLogStoreFactory::Create(
+        config_.oplog_store_type, config_.cluster_id, OpLogStoreRole::READER,
+        config_.oplog_store_root_dir, config_.oplog_poll_interval_ms);
+    if (!watcher_oplog_store_) {
+        LOG(ERROR) << "P2PHotStandbyService: failed to create reader store"
+                   << ", cluster_id=" << config_.cluster_id;
+        return ErrorCode::INTERNAL_ERROR;
+    }
+
+    oplog_applier_->SetOpLogStore(watcher_oplog_store_.get());
+    oplog_change_notifier_ =
+        watcher_oplog_store_->CreateChangeNotifier(config_.cluster_id);
+    if (!oplog_change_notifier_) {
+        LOG(ERROR)
+            << "P2PHotStandbyService: failed to create OpLogChangeNotifier"
+            << ", cluster_id=" << config_.cluster_id;
+        return ErrorCode::INTERNAL_ERROR;
+    }
+
+    oplog_replicator_ = std::make_unique<OpLogReplicator>(
+        oplog_change_notifier_.get(), oplog_applier_.get());
+    oplog_replicator_->SetStateCallback(
+        [this](StandbyEvent event) { OnWatcherEvent(event); });
+
+    static constexpr int kMaxStartRetries = 3;
+    for (int attempt = 0; attempt < kMaxStartRetries; ++attempt) {
+        if (oplog_replicator_->StartFromSequenceId(baseline_sequence_id)) {
+            return ErrorCode::OK;
+        }
+        if (attempt + 1 < kMaxStartRetries) {
+            std::this_thread::sleep_for(
+                std::chrono::milliseconds(100 * (1 << attempt)));
+        }
+    }
+
+    LOG(ERROR) << "P2PHotStandbyService: failed to start OpLogReplicator";
+    return ErrorCode::INTERNAL_ERROR;
+}
+
+void P2PHotStandbyService::Stop() {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    if (oplog_replicator_) {
+        oplog_replicator_->Stop();
+        oplog_replicator_.reset();
+    }
+    oplog_change_notifier_.reset();
+    watcher_oplog_store_.reset();
+
+    StandbyState state = state_machine_.GetState();
+    if (state != StandbyState::STOPPED) {
+        auto result = state_machine_.ProcessEvent(StandbyEvent::STOP);
+        if (!result.allowed) {
+            LOG(WARNING) << "P2PHotStandbyService: stop transition rejected: "
+                         << result.reason;
+        }
+    }
+}
+
+ErrorCode P2PHotStandbyService::Promote() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!IsReadyForPromotion()) {
+        LOG(ERROR) << "P2PHotStandbyService: not ready for promotion"
+                   << ", state=" << StandbyStateToString(GetState());
+        return ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS;
+    }
+
+    auto promote_result = state_machine_.ProcessEvent(StandbyEvent::PROMOTE);
+    if (!promote_result.allowed) {
+        LOG(ERROR) << "P2PHotStandbyService: cannot promote: "
+                   << promote_result.reason;
+        return ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS;
+    }
+
+    const uint64_t applied_before_catch_up =
+        GetLocalLastAppliedSequenceIdLocked();
+    if (oplog_replicator_) {
+        oplog_replicator_->Stop();
+    }
+
+    auto gaps = oplog_applier_->TryResolveGapsOnceForPromotion();
+    if (gaps.attempted > 0) {
+        LOG(INFO) << "P2PHotStandbyService: promotion gap resolve"
+                  << ", attempted=" << gaps.attempted
+                  << ", fetched=" << gaps.fetched
+                  << ", applied_deletes=" << gaps.applied_deletes;
+    }
+
+    auto err = FinalCatchUpForPromotionLocked(applied_before_catch_up);
+    if (err != ErrorCode::OK) {
+        state_machine_.ProcessEvent(StandbyEvent::PROMOTION_FAILED);
+        return err;
+    }
+
+    auto success = state_machine_.ProcessEvent(StandbyEvent::PROMOTION_SUCCESS);
+    if (!success.allowed) {
+        LOG(ERROR) << "P2PHotStandbyService: cannot finish promotion: "
+                   << success.reason;
+        return ErrorCode::INTERNAL_ERROR;
+    }
+
+    oplog_replicator_.reset();
+    oplog_change_notifier_.reset();
+    watcher_oplog_store_.reset();
+    LOG(INFO) << "P2PHotStandbyService promoted"
+              << ", latest_applied_sequence_id="
+              << GetLocalLastAppliedSequenceIdLocked();
+    return ErrorCode::OK;
+}
+
+ErrorCode P2PHotStandbyService::FinalCatchUpForPromotionLocked(
+    uint64_t current_applied_seq_id) {
+    auto catch_up_store = OpLogStoreFactory::Create(
+        config_.oplog_store_type, config_.cluster_id, OpLogStoreRole::READER,
+        config_.oplog_store_root_dir, config_.oplog_poll_interval_ms);
+    if (!catch_up_store) {
+        LOG(ERROR) << "P2PHotStandbyService: failed to create catch-up store";
+        return ErrorCode::INTERNAL_ERROR;
+    }
+
+    static constexpr size_t kBatchSize = 1000;
+    static constexpr size_t kMaxCatchUpBatches = 100;
+    uint64_t read_from_seq = current_applied_seq_id;
+    size_t total_applied = 0;
+    size_t batch_count = 0;
+
+    for (; batch_count < kMaxCatchUpBatches; ++batch_count) {
+        std::vector<OpLogEntry> batch;
+        ErrorCode read_err =
+            catch_up_store->ReadOpLogSince(read_from_seq, kBatchSize, batch);
+        if (read_err != ErrorCode::OK) {
+            LOG(WARNING) << "P2PHotStandbyService: final catch-up read failed"
+                         << ", from_seq=" << read_from_seq
+                         << ", error=" << toString(read_err)
+                         << ". Proceeding with promotion.";
+            break;
+        }
+        if (batch.empty()) {
+            break;
+        }
+
+        // Keep promotion catch-up best-effort, matching the centralized
+        // HotStandbyService availability-first behavior. Complete gap,
+        // out-of-order, and apply-retry hardening is handled by follow-up PRs.
+        total_applied += oplog_applier_->ApplyOpLogEntries(batch);
+        read_from_seq = batch.back().sequence_id;
+    }
+
+    if (batch_count >= kMaxCatchUpBatches) {
+        // Do not block promotion solely on the bounded catch-up loop. The
+        // promoted primary continues from the best applied state in this phase.
+        LOG(WARNING) << "P2PHotStandbyService: final catch-up reached batch "
+                        "limit"
+                     << ", max_batches=" << kMaxCatchUpBatches;
+    }
+    LOG(INFO) << "P2PHotStandbyService: final catch-up done"
+              << ", total_applied=" << total_applied
+              << ", batches=" << batch_count;
+    return ErrorCode::OK;
+}
+
+P2PStandbySyncStatus P2PHotStandbyService::GetSyncStatus() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    P2PStandbySyncStatus status;
+    status.state = state_machine_.GetState();
+    status.time_in_state = state_machine_.GetTimeInCurrentState();
+    status.is_connected = state_machine_.IsConnected();
+    status.applied_seq_id = GetLocalLastAppliedSequenceIdLocked();
+
+    if (watcher_oplog_store_) {
+        uint64_t latest_seq = 0;
+        if (watcher_oplog_store_->GetLatestSequenceId(latest_seq) ==
+            ErrorCode::OK) {
+            status.primary_seq_id = latest_seq;
+        }
+    }
+    if (status.primary_seq_id > status.applied_seq_id) {
+        status.lag_entries = status.primary_seq_id - status.applied_seq_id;
+    }
+    return status;
+}
+
+bool P2PHotStandbyService::IsReadyForPromotion() const {
+    return state_machine_.IsReadyForPromotion();
+}
+
+uint64_t P2PHotStandbyService::GetLatestAppliedSequenceId() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return GetLocalLastAppliedSequenceIdLocked();
+}
+
+uint64_t P2PHotStandbyService::GetLocalLastAppliedSequenceIdLocked() const {
+    if (!oplog_applier_) {
+        return 0;
+    }
+    uint64_t expected = oplog_applier_->GetExpectedSequenceId();
+    return expected > 0 ? expected - 1 : 0;
+}
+
+P2PStandbyMetadataStore::ExportedMetadata P2PHotStandbyService::ExportMetadata()
+    const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return metadata_store_->ExportMetadata();
+}
+
+bool P2PHotStandbyService::WaitForAppliedSequence(
+    uint64_t sequence_id, std::chrono::milliseconds timeout) const {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (GetLatestAppliedSequenceId() >= sequence_id) {
+            return true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    return GetLatestAppliedSequenceId() >= sequence_id;
+}
+
+void P2PHotStandbyService::OnWatcherEvent(StandbyEvent event) {
+    auto result = state_machine_.ProcessEvent(event);
+    if (!result.allowed) {
+        VLOG(1) << "P2PHotStandbyService: watcher event rejected"
+                << ", event=" << StandbyEventToString(event)
+                << ", reason=" << result.reason;
+    }
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/ha/oplog/p2p_hot_standby_service.cpp
+++ b/mooncake-store/src/ha/oplog/p2p_hot_standby_service.cpp
@@ -39,6 +39,9 @@ ErrorCode P2PHotStandbyService::Start(uint64_t baseline_sequence_id) {
 
     auto err = StartOplogFollowingLocked(baseline_sequence_id);
     if (err != ErrorCode::OK) {
+        LOG(ERROR) << "P2PHotStandbyService: failed to start oplog following"
+                   << ", baseline_sequence_id=" << baseline_sequence_id
+                   << ", err=" << err;
         state_machine_.ProcessEvent(StandbyEvent::FATAL_ERROR);
         ResetOplogFollowingLocked();
         return err;
@@ -99,6 +102,9 @@ void P2PHotStandbyService::ResetOplogFollowingLocked() {
         oplog_replicator_->Stop();
         oplog_replicator_.reset();
     }
+    if (oplog_applier_) {
+        oplog_applier_->SetOpLogStore(nullptr);
+    }
     oplog_change_notifier_.reset();
     watcher_oplog_store_.reset();
 }
@@ -149,6 +155,10 @@ ErrorCode P2PHotStandbyService::Promote() {
 
     auto err = FinalCatchUpForPromotionLocked(applied_before_catch_up);
     if (err != ErrorCode::OK) {
+        LOG(ERROR) << "P2PHotStandbyService: final catch-up for promotion "
+                      "failed"
+                   << ", applied_before_catch_up=" << applied_before_catch_up
+                   << ", err=" << err;
         state_machine_.ProcessEvent(StandbyEvent::PROMOTION_FAILED);
         ResetOplogFollowingLocked();
         return err;
@@ -180,6 +190,8 @@ ErrorCode P2PHotStandbyService::FinalCatchUpForPromotionLocked(
 
     static constexpr size_t kBatchSize = 1000;
     static constexpr size_t kMaxCatchUpBatches = 100;
+    // TODO: Add election/readiness gating before allowing promotion: require
+    // initial sync completion, enforce max standby lag, and monitor apply rate.
     uint64_t read_from_seq = current_applied_seq_id;
     size_t total_applied = 0;
     size_t batch_count = 0;

--- a/mooncake-store/src/ha/oplog/p2p_hot_standby_service.cpp
+++ b/mooncake-store/src/ha/oplog/p2p_hot_standby_service.cpp
@@ -40,6 +40,7 @@ ErrorCode P2PHotStandbyService::Start(uint64_t baseline_sequence_id) {
     auto err = StartOplogFollowingLocked(baseline_sequence_id);
     if (err != ErrorCode::OK) {
         state_machine_.ProcessEvent(StandbyEvent::FATAL_ERROR);
+        ResetOplogFollowingLocked();
         return err;
     }
 
@@ -52,6 +53,8 @@ ErrorCode P2PHotStandbyService::Start(uint64_t baseline_sequence_id) {
 
 ErrorCode P2PHotStandbyService::StartOplogFollowingLocked(
     uint64_t baseline_sequence_id) {
+    ResetOplogFollowingLocked();
+
     watcher_oplog_store_ = OpLogStoreFactory::Create(
         config_.oplog_store_type, config_.cluster_id, OpLogStoreRole::READER,
         config_.oplog_store_root_dir, config_.oplog_poll_interval_ms);
@@ -91,15 +94,19 @@ ErrorCode P2PHotStandbyService::StartOplogFollowingLocked(
     return ErrorCode::INTERNAL_ERROR;
 }
 
-void P2PHotStandbyService::Stop() {
-    std::lock_guard<std::mutex> lock(mutex_);
-
+void P2PHotStandbyService::ResetOplogFollowingLocked() {
     if (oplog_replicator_) {
         oplog_replicator_->Stop();
         oplog_replicator_.reset();
     }
     oplog_change_notifier_.reset();
     watcher_oplog_store_.reset();
+}
+
+void P2PHotStandbyService::Stop() {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    ResetOplogFollowingLocked();
 
     StandbyState state = state_machine_.GetState();
     if (state != StandbyState::STOPPED) {
@@ -143,6 +150,7 @@ ErrorCode P2PHotStandbyService::Promote() {
     auto err = FinalCatchUpForPromotionLocked(applied_before_catch_up);
     if (err != ErrorCode::OK) {
         state_machine_.ProcessEvent(StandbyEvent::PROMOTION_FAILED);
+        ResetOplogFollowingLocked();
         return err;
     }
 
@@ -153,9 +161,7 @@ ErrorCode P2PHotStandbyService::Promote() {
         return ErrorCode::INTERNAL_ERROR;
     }
 
-    oplog_replicator_.reset();
-    oplog_change_notifier_.reset();
-    watcher_oplog_store_.reset();
+    ResetOplogFollowingLocked();
     LOG(INFO) << "P2PHotStandbyService promoted"
               << ", latest_applied_sequence_id="
               << GetLocalLastAppliedSequenceIdLocked();
@@ -276,6 +282,8 @@ void P2PHotStandbyService::OnWatcherEvent(StandbyEvent event) {
                 << ", event=" << StandbyEventToString(event)
                 << ", reason=" << result.reason;
     }
+    // TODO: Add service-level recovery orchestration for RECONNECTING and
+    // RECOVERING states in the follow-up error handling PR.
 }
 
 }  // namespace mooncake

--- a/mooncake-store/src/ha/oplog/p2p_standby_metadata_store.cpp
+++ b/mooncake-store/src/ha/oplog/p2p_standby_metadata_store.cpp
@@ -25,6 +25,7 @@ bool P2PStandbyMetadataStore::Put(const std::string& /*key*/,
 
 std::optional<StandbyObjectMetadata> P2PStandbyMetadataStore::GetMetadata(
     const std::string& key) const {
+    std::lock_guard<std::mutex> lock(mutex_);
     auto it = objects_.find(key);
     if (it == objects_.end()) {
         return std::nullopt;
@@ -33,14 +34,19 @@ std::optional<StandbyObjectMetadata> P2PStandbyMetadataStore::GetMetadata(
 }
 
 bool P2PStandbyMetadataStore::Remove(const std::string& key) {
+    std::lock_guard<std::mutex> lock(mutex_);
     return objects_.erase(key) > 0;
 }
 
 bool P2PStandbyMetadataStore::Exists(const std::string& key) const {
+    std::lock_guard<std::mutex> lock(mutex_);
     return objects_.find(key) != objects_.end();
 }
 
-size_t P2PStandbyMetadataStore::GetKeyCount() const { return objects_.size(); }
+size_t P2PStandbyMetadataStore::GetKeyCount() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return objects_.size();
+}
 
 // ============================================================================
 // P2P-specific operations
@@ -50,6 +56,7 @@ void P2PStandbyMetadataStore::AddReplica(const std::string& object_key,
                                          const UUID& client_id,
                                          const UUID& segment_id, size_t size,
                                          uint64_t sequence_id) {
+    std::lock_guard<std::mutex> lock(mutex_);
     auto& metadata = objects_[object_key];
     metadata.size = size;
     metadata.last_sequence_id = sequence_id;
@@ -110,6 +117,7 @@ void P2PStandbyMetadataStore::AddReplica(const std::string& object_key,
 void P2PStandbyMetadataStore::RemoveReplica(const std::string& object_key,
                                             const UUID& client_id,
                                             const UUID& segment_id) {
+    std::lock_guard<std::mutex> lock(mutex_);
     auto it = objects_.find(object_key);
     if (it == objects_.end()) {
         VLOG(1) << "P2PStandbyMetadataStore::RemoveReplica key=" << object_key
@@ -146,6 +154,7 @@ void P2PStandbyMetadataStore::RemoveReplica(const std::string& object_key,
 void P2PStandbyMetadataStore::RegisterClient(
     const UUID& client_id, const std::string& ip_address, uint16_t rpc_port,
     const std::vector<Segment>& segments) {
+    std::lock_guard<std::mutex> lock(mutex_);
     auto& info = clients_[client_id];
     info.client_id = client_id;
     info.ip_address = ip_address;
@@ -173,6 +182,7 @@ void P2PStandbyMetadataStore::RegisterClient(
 }
 
 void P2PStandbyMetadataStore::UnRegisterClient(const UUID& client_id) {
+    std::lock_guard<std::mutex> lock(mutex_);
     clients_.erase(client_id);
 
     // Cascade delete: remove all replicas owned by this client.
@@ -204,6 +214,7 @@ void P2PStandbyMetadataStore::UnRegisterClient(const UUID& client_id) {
 
 void P2PStandbyMetadataStore::AddSegment(const UUID& client_id,
                                          const Segment& segment) {
+    std::lock_guard<std::mutex> lock(mutex_);
     auto& info = clients_[client_id];
     info.client_id = client_id;  // In case client wasn't registered yet
 
@@ -225,6 +236,7 @@ void P2PStandbyMetadataStore::AddSegment(const UUID& client_id,
 
 void P2PStandbyMetadataStore::RemoveSegment(const UUID& segment_id,
                                             const UUID& client_id) {
+    std::lock_guard<std::mutex> lock(mutex_);
     // Remove segment from client
     auto client_it = clients_.find(client_id);
     if (client_it != clients_.end()) {
@@ -245,10 +257,12 @@ void P2PStandbyMetadataStore::RemoveSegment(const UUID& segment_id,
 }
 
 void P2PStandbyMetadataStore::RemoveReplicasBySegment(const UUID& segment_id) {
+    std::lock_guard<std::mutex> lock(mutex_);
     RemoveReplicasBySegmentInternal(segment_id);
 }
 
 void P2PStandbyMetadataStore::RemoveAllMetadata() {
+    std::lock_guard<std::mutex> lock(mutex_);
     objects_.clear();
     clients_.clear();
     VLOG(1) << "P2PStandbyMetadataStore::RemoveAllMetadata";
@@ -260,6 +274,7 @@ void P2PStandbyMetadataStore::RemoveAllMetadata() {
 
 P2PStandbyMetadataStore::ExportedMetadata
 P2PStandbyMetadataStore::ExportMetadata() const {
+    std::lock_guard<std::mutex> lock(mutex_);
     ExportedMetadata result;
     result.objects = objects_;
     result.clients = clients_;
@@ -292,10 +307,26 @@ P2PStandbyMetadataStore::ExportMetadata() const {
 // Query helpers
 // ============================================================================
 
-const P2PStandbyClientInfo* P2PStandbyMetadataStore::GetClient(
+std::shared_ptr<const P2PStandbyClientInfo> P2PStandbyMetadataStore::GetClient(
     const UUID& client_id) const {
+    std::lock_guard<std::mutex> lock(mutex_);
     auto it = clients_.find(client_id);
-    return it != clients_.end() ? &it->second : nullptr;
+    if (it == clients_.end()) {
+        return nullptr;
+    }
+    return std::make_shared<P2PStandbyClientInfo>(it->second);
+}
+
+std::unordered_map<std::string, StandbyObjectMetadata>
+P2PStandbyMetadataStore::GetObjects() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return objects_;
+}
+
+std::unordered_map<UUID, P2PStandbyClientInfo, boost::hash<UUID>>
+P2PStandbyMetadataStore::GetClients() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return clients_;
 }
 
 // ============================================================================

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -86,6 +86,7 @@ add_store_test(p2p_oplog_test
     ha/oplog/p2p_oplog_applier_test.cpp
     ha/oplog/p2p_record_oplog_test.cpp
     ha/oplog/p2p_standby_metadata_store_test.cpp
+    ha/oplog/p2p_hot_standby_service_test.cpp
 )
 add_subdirectory(e2e)
 

--- a/mooncake-store/tests/ha/oplog/p2p_hot_standby_service_test.cpp
+++ b/mooncake-store/tests/ha/oplog/p2p_hot_standby_service_test.cpp
@@ -1,0 +1,176 @@
+#include "ha/oplog/p2p_hot_standby_service.h"
+
+#include <unistd.h>
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <string>
+#include <variant>
+
+#include "p2p_master_service.h"
+#include "p2p_rpc_types.h"
+
+namespace mooncake::test {
+namespace {
+
+class P2PHotStandbyServiceTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        test_dir_ =
+            std::filesystem::temp_directory_path() /
+            ("mooncake_p2p_hot_standby_test_" + std::to_string(::getpid()) +
+             "_" + std::to_string(reinterpret_cast<uintptr_t>(this)));
+        std::filesystem::remove_all(test_dir_);
+    }
+
+    void TearDown() override { std::filesystem::remove_all(test_dir_); }
+
+    MasterServiceConfig MakeMasterConfig() const {
+        return MasterServiceConfig::builder()
+            .set_enable_ha(true)
+            .set_enable_oplog(true)
+            .set_cluster_id(kClusterId)
+            .set_oplog_store_type("localfs")
+            .set_oplog_data_dir(test_dir_.string())
+            .set_max_replicas_per_key(0)
+            .build();
+    }
+
+    P2PHotStandbyConfig MakeStandbyConfig() const {
+        P2PHotStandbyConfig config;
+        config.cluster_id = kClusterId;
+        config.oplog_store_type = OpLogStoreType::LOCAL_FS;
+        config.oplog_store_root_dir = test_dir_.string();
+        config.oplog_poll_interval_ms = 10;
+        return config;
+    }
+
+    Segment MakeSegment(const UUID& segment_id) const {
+        Segment segment;
+        segment.id = segment_id;
+        segment.name = "segment-" + std::to_string(segment_id.first) + "-" +
+                       std::to_string(segment_id.second);
+        segment.size = 1024 * 1024;
+        segment.extra = P2PSegmentExtraData{
+            .priority = 1,
+            .tags = {},
+            .memory_type = MemoryType::DRAM,
+        };
+        return segment;
+    }
+
+    void RegisterClient(P2PMasterService& service, const UUID& client_id,
+                        const Segment& segment) const {
+        RegisterClientRequest req;
+        req.client_id = client_id;
+        req.ip_address = "127.0.0.1";
+        req.rpc_port = 50051;
+        req.segments = {segment};
+        req.deployment_mode = DeploymentMode::P2P;
+        auto result = service.RegisterClient(req);
+        ASSERT_TRUE(result.has_value()) << toString(result.error());
+    }
+
+    void AddReplica(P2PMasterService& service, const std::string& key,
+                    const UUID& client_id, const UUID& segment_id,
+                    size_t size = 4096) const {
+        AddReplicaRequest req;
+        req.key = key;
+        req.client_id = client_id;
+        req.segment_id = segment_id;
+        req.size = size;
+        auto result = service.AddReplica(req);
+        ASSERT_TRUE(result.has_value()) << toString(result.error());
+    }
+
+    static constexpr const char* kClusterId = "p2p-hot-standby-test";
+    std::filesystem::path test_dir_;
+};
+
+TEST_F(P2PHotStandbyServiceTest, ReplicatesMasterWrittenP2POplog) {
+    P2PMasterService master(MakeMasterConfig());
+    const UUID client_id{1, 1};
+    const UUID segment_id{2, 2};
+
+    RegisterClient(master, client_id, MakeSegment(segment_id));
+    AddReplica(master, "key-a", client_id, segment_id, 1234);
+
+    P2PHotStandbyService standby(MakeStandbyConfig());
+    ASSERT_EQ(standby.Start(), ErrorCode::OK);
+    ASSERT_TRUE(
+        standby.WaitForAppliedSequence(2, std::chrono::milliseconds(2000)));
+    standby.Stop();
+
+    auto exported = standby.ExportMetadata();
+    auto client_it = exported.clients.find(client_id);
+    ASSERT_NE(client_it, exported.clients.end());
+    EXPECT_EQ(client_it->second.ip_address, "127.0.0.1");
+    EXPECT_EQ(client_it->second.rpc_port, 50051);
+    ASSERT_EQ(client_it->second.segments.size(), 1);
+    EXPECT_EQ(client_it->second.segments[0].id, segment_id);
+
+    auto object_it = exported.objects.find("key-a");
+    ASSERT_NE(object_it, exported.objects.end());
+    EXPECT_EQ(object_it->second.size, 1234);
+    ASSERT_EQ(object_it->second.replicas.size(), 1);
+    ASSERT_TRUE(std::holds_alternative<P2PProxyDescriptor>(
+        object_it->second.replicas[0].descriptor_variant));
+    const auto& desc = std::get<P2PProxyDescriptor>(
+        object_it->second.replicas[0].descriptor_variant);
+    EXPECT_EQ(desc.client_id, client_id);
+    EXPECT_EQ(desc.segment_id, segment_id);
+    EXPECT_EQ(desc.ip_address, "127.0.0.1");
+    EXPECT_EQ(desc.rpc_port, 50051);
+}
+
+TEST_F(P2PHotStandbyServiceTest, UnmountSegmentCascadeIsReplayed) {
+    P2PMasterService master(MakeMasterConfig());
+    const UUID client_id{3, 3};
+    const UUID segment_id{4, 4};
+
+    RegisterClient(master, client_id, MakeSegment(segment_id));
+    AddReplica(master, "key-cascade", client_id, segment_id);
+    auto unmount = master.UnmountSegment(segment_id, client_id);
+    ASSERT_TRUE(unmount.has_value()) << toString(unmount.error());
+
+    P2PHotStandbyService standby(MakeStandbyConfig());
+    ASSERT_EQ(standby.Start(), ErrorCode::OK);
+    ASSERT_TRUE(
+        standby.WaitForAppliedSequence(3, std::chrono::milliseconds(2000)));
+    standby.Stop();
+
+    auto exported = standby.ExportMetadata();
+    EXPECT_EQ(exported.objects.find("key-cascade"), exported.objects.end());
+    auto client_it = exported.clients.find(client_id);
+    ASSERT_NE(client_it, exported.clients.end());
+    EXPECT_TRUE(client_it->second.segments.empty());
+}
+
+TEST_F(P2PHotStandbyServiceTest, PromoteFinalCatchUpExportsLateEntry) {
+    P2PMasterService master(MakeMasterConfig());
+    const UUID client_id{5, 5};
+    const UUID segment_id{6, 6};
+
+    RegisterClient(master, client_id, MakeSegment(segment_id));
+
+    P2PHotStandbyService standby(MakeStandbyConfig());
+    ASSERT_EQ(standby.Start(), ErrorCode::OK);
+    ASSERT_TRUE(
+        standby.WaitForAppliedSequence(1, std::chrono::milliseconds(2000)));
+
+    AddReplica(master, "key-late", client_id, segment_id, 8192);
+    ASSERT_EQ(standby.Promote(), ErrorCode::OK);
+    EXPECT_EQ(standby.GetState(), StandbyState::PROMOTED);
+    EXPECT_GE(standby.GetLatestAppliedSequenceId(), 2);
+
+    auto exported = standby.ExportMetadata();
+    auto object_it = exported.objects.find("key-late");
+    ASSERT_NE(object_it, exported.objects.end());
+    EXPECT_EQ(object_it->second.size, 8192);
+}
+
+}  // namespace
+}  // namespace mooncake::test

--- a/mooncake-store/tests/ha/oplog/p2p_oplog_applier_test.cpp
+++ b/mooncake-store/tests/ha/oplog/p2p_oplog_applier_test.cpp
@@ -109,7 +109,7 @@ TEST(P2POpLogApplierTest, ApplyAddReplica) {
     auto entry = MakeAddReplicaEntry(1, "model-weights", payload);
     EXPECT_TRUE(applier.ApplyOpLogEntry(entry));
 
-    auto& objects = store.GetObjects();
+    auto objects = store.GetObjects();
     ASSERT_EQ(objects.size(), 1u);
     EXPECT_NE(objects.find("model-weights"), objects.end());
     EXPECT_EQ(objects.at("model-weights").replicas.size(), 1u);
@@ -207,7 +207,7 @@ TEST(P2POpLogApplierTest, ApplyMountSegment) {
     auto entry = MakeMountSegmentEntry(1, payload);
     EXPECT_TRUE(applier.ApplyOpLogEntry(entry));
 
-    auto* info = store.GetClient(client);
+    auto info = store.GetClient(client);
     ASSERT_NE(info, nullptr);
     ASSERT_EQ(info->segments.size(), 1u);
     EXPECT_EQ(info->segments[0].id, seg_id);
@@ -249,7 +249,7 @@ TEST(P2POpLogApplierTest, ApplyUnmountSegment) {
     applier.ApplyOpLogEntry(MakeUnmountSegmentEntry(3, umount_payload));
 
     EXPECT_EQ(store.GetKeyCount(), 0u);  // Object removed (no replicas)
-    auto* info = store.GetClient(client);
+    auto info = store.GetClient(client);
     ASSERT_NE(info, nullptr);
     EXPECT_EQ(info->segments.size(), 0u);  // Segment removed
 }
@@ -274,7 +274,7 @@ TEST(P2POpLogApplierTest, ApplyRegisterClient) {
     auto entry = MakeRegisterClientEntry(1, payload);
     EXPECT_TRUE(applier.ApplyOpLogEntry(entry));
 
-    auto* info = store.GetClient(client);
+    auto info = store.GetClient(client);
     ASSERT_NE(info, nullptr);
     EXPECT_EQ(info->ip_address, "192.168.1.100");
     EXPECT_EQ(info->rpc_port, 50051u);
@@ -330,8 +330,9 @@ TEST(P2POpLogApplierTest, ApplyUnregisterClient) {
 
     EXPECT_EQ(store.GetClient(client), nullptr);
     ASSERT_NE(store.GetClient(other_client), nullptr);
-    auto object_it = store.GetObjects().find("shared-key");
-    ASSERT_NE(object_it, store.GetObjects().end());
+    auto objects = store.GetObjects();
+    auto object_it = objects.find("shared-key");
+    ASSERT_NE(object_it, objects.end());
     ASSERT_EQ(object_it->second.replicas.size(), 1u);
     const auto& p2p = std::get<P2PProxyDescriptor>(
         object_it->second.replicas[0].descriptor_variant);

--- a/mooncake-store/tests/ha/oplog/p2p_standby_metadata_store_test.cpp
+++ b/mooncake-store/tests/ha/oplog/p2p_standby_metadata_store_test.cpp
@@ -94,8 +94,9 @@ TEST(P2PStandbyMetadataStoreTest, AddReplicaAfterClientRegistered) {
     store.RegisterClient(client_id, "10.0.0.1", 50051, {});
     store.AddReplica("key1", client_id, seg_id, 1024, 1);
 
-    auto it = store.GetObjects().find("key1");
-    ASSERT_NE(it, store.GetObjects().end());
+    auto objects = store.GetObjects();
+    auto it = objects.find("key1");
+    ASSERT_NE(it, objects.end());
     ASSERT_EQ(it->second.replicas.size(), 1u);
     auto& p2p =
         std::get<P2PProxyDescriptor>(it->second.replicas[0].descriptor_variant);
@@ -118,7 +119,7 @@ TEST(P2PStandbyMetadataStoreTest, AddReplicaPreservesSegmentExtra) {
 
     store.AddReplica("key1", client_id, seg_id, 1024, 1);
 
-    auto* info = store.GetClient(client_id);
+    auto info = store.GetClient(client_id);
     ASSERT_NE(info, nullptr);
     ASSERT_EQ(info->segments.size(), 1u);
     ASSERT_TRUE(info->segments[0].IsP2PSegment());
@@ -136,7 +137,7 @@ TEST(P2PStandbyMetadataStoreTest, AddReplicaCreatesObject) {
 
     store.AddReplica("model-weights", client_id, seg_id, 4096, 123);
 
-    const auto& objects = store.GetObjects();
+    auto objects = store.GetObjects();
     ASSERT_EQ(objects.size(), 1u);
     auto it = objects.find("model-weights");
     ASSERT_NE(it, objects.end());
@@ -154,8 +155,9 @@ TEST(P2PStandbyMetadataStoreTest, AddReplicaMultiple) {
     store.AddReplica("key1", client1, seg1, 1024, 1);
     store.AddReplica("key1", client2, seg2, 2048, 2);
 
-    auto it = store.GetObjects().find("key1");
-    ASSERT_NE(it, store.GetObjects().end());
+    auto objects = store.GetObjects();
+    auto it = objects.find("key1");
+    ASSERT_NE(it, objects.end());
     EXPECT_EQ(it->second.last_sequence_id, 2u);
     EXPECT_EQ(it->second.replicas.size(), 2u);
 }
@@ -168,8 +170,9 @@ TEST(P2PStandbyMetadataStoreTest, AddReplicaDuplicateIgnored) {
     store.AddReplica("key1", client, seg, 1024, 1);
     store.AddReplica("key1", client, seg, 1024, 2);
 
-    auto it = store.GetObjects().find("key1");
-    ASSERT_NE(it, store.GetObjects().end());
+    auto objects = store.GetObjects();
+    auto it = objects.find("key1");
+    ASSERT_NE(it, objects.end());
     EXPECT_EQ(it->second.last_sequence_id, 2u);
     EXPECT_EQ(it->second.replicas.size(), 1u);
 }
@@ -187,8 +190,9 @@ TEST(P2PStandbyMetadataStoreTest, RemoveReplica) {
     // Remove one replica
     store.RemoveReplica("key1", client1, seg1);
 
-    auto it = store.GetObjects().find("key1");
-    ASSERT_NE(it, store.GetObjects().end());
+    auto objects = store.GetObjects();
+    auto it = objects.find("key1");
+    ASSERT_NE(it, objects.end());
     EXPECT_EQ(it->second.replicas.size(), 1u);
 }
 
@@ -227,7 +231,7 @@ TEST(P2PStandbyMetadataStoreTest, RegisterClientBasic) {
 
     store.RegisterClient(client_id, "192.168.1.1", 50051, segments);
 
-    auto* info = store.GetClient(client_id);
+    auto info = store.GetClient(client_id);
     ASSERT_NE(info, nullptr);
     EXPECT_EQ(info->ip_address, "192.168.1.1");
     EXPECT_EQ(info->rpc_port, 50051u);
@@ -242,7 +246,7 @@ TEST(P2PStandbyMetadataStoreTest, RegisterClientUpdatesExisting) {
     store.RegisterClient(client_id, "10.0.0.1", 50052,
                          {MakeSegment(MakeUUID(100, 0))});
 
-    auto* info = store.GetClient(client_id);
+    auto info = store.GetClient(client_id);
     ASSERT_NE(info, nullptr);
     EXPECT_EQ(info->ip_address, "10.0.0.1");
     EXPECT_EQ(info->rpc_port, 50052u);
@@ -265,7 +269,7 @@ TEST(P2PStandbyMetadataStoreTest, RegisterClientPreservesEarlyMountSegment) {
     store.RegisterClient(client_id, "192.168.1.1", 50051, {reg_seg});
 
     // Both segments should be preserved (merge, not overwrite)
-    auto* info = store.GetClient(client_id);
+    auto info = store.GetClient(client_id);
     ASSERT_NE(info, nullptr);
     EXPECT_EQ(info->segments.size(), 2u);
 }
@@ -282,7 +286,7 @@ TEST(P2PStandbyMetadataStoreTest, RegisterClientDuplicateSegmentIgnored) {
     // REGISTER_CLIENT with same segment — should not duplicate
     store.RegisterClient(client_id, "10.0.0.1", 50051, {seg});
 
-    auto* info = store.GetClient(client_id);
+    auto info = store.GetClient(client_id);
     ASSERT_NE(info, nullptr);
     EXPECT_EQ(info->segments.size(), 1u);
 }
@@ -296,8 +300,9 @@ TEST(P2PStandbyMetadataStoreTest, RegisterClientUpdatesReplicaIPs) {
     store.AddReplica("key1", client_id, seg_id, 1024, 1);
 
     // Verify replica has empty ip/port (backfilling deferred to ExportMetadata)
-    auto it = store.GetObjects().find("key1");
-    ASSERT_NE(it, store.GetObjects().end());
+    auto objects = store.GetObjects();
+    auto it = objects.find("key1");
+    ASSERT_NE(it, objects.end());
     ASSERT_EQ(it->second.replicas.size(), 1u);
     auto& desc = it->second.replicas[0];
     auto& p2p = std::get<P2PProxyDescriptor>(desc.descriptor_variant);
@@ -308,8 +313,9 @@ TEST(P2PStandbyMetadataStoreTest, RegisterClientUpdatesReplicaIPs) {
     store.RegisterClient(client_id, "192.168.1.1", 50051, {});
 
     // In-place replicas still have empty ip/port
-    it = store.GetObjects().find("key1");
-    ASSERT_NE(it, store.GetObjects().end());
+    objects = store.GetObjects();
+    it = objects.find("key1");
+    ASSERT_NE(it, objects.end());
     auto& in_place_p2p =
         std::get<P2PProxyDescriptor>(it->second.replicas[0].descriptor_variant);
     EXPECT_TRUE(in_place_p2p.ip_address.empty());
@@ -393,14 +399,14 @@ TEST(P2PStandbyMetadataStoreTest, UnRegisterClientPreservesOtherClients) {
     ASSERT_NE(store.GetClient(client2), nullptr);
     EXPECT_EQ(store.GetKeyCount(), 1u);
 
-    auto shared_it = store.GetObjects().find("shared-key");
-    ASSERT_NE(shared_it, store.GetObjects().end());
+    auto objects = store.GetObjects();
+    auto shared_it = objects.find("shared-key");
+    ASSERT_NE(shared_it, objects.end());
     ASSERT_EQ(shared_it->second.replicas.size(), 1u);
     const auto& p2p = std::get<P2PProxyDescriptor>(
         shared_it->second.replicas[0].descriptor_variant);
     EXPECT_EQ(p2p.client_id, client2);
-    EXPECT_EQ(store.GetObjects().find("client1-only"),
-              store.GetObjects().end());
+    EXPECT_EQ(objects.find("client1-only"), objects.end());
 }
 
 // ============================================================================
@@ -416,7 +422,7 @@ TEST(P2PStandbyMetadataStoreTest, AddSegmentDuplicateIgnored) {
     store.AddSegment(client_id, seg);
     store.AddSegment(client_id, seg);  // duplicate — should be ignored
 
-    auto* info = store.GetClient(client_id);
+    auto info = store.GetClient(client_id);
     ASSERT_NE(info, nullptr);
     EXPECT_EQ(info->segments.size(), 1u);
 }
@@ -439,7 +445,7 @@ TEST(P2PStandbyMetadataStoreTest, AddAndRemoveSegment) {
 
     store.AddSegment(client_id, seg);
 
-    auto* info = store.GetClient(client_id);
+    auto info = store.GetClient(client_id);
     ASSERT_NE(info, nullptr);
     EXPECT_EQ(info->segments.size(), 1u);
     EXPECT_EQ(info->segments[0].id, seg_id);
@@ -458,13 +464,15 @@ TEST(P2PStandbyMetadataStoreTest, RemoveSegmentCascadeDeletesReplicas) {
 
     // Add replica on this segment
     store.AddReplica("key1", client_id, seg_id, 1024, 1);
-    ASSERT_EQ(store.GetObjects().size(), 1u);
+    auto objects = store.GetObjects();
+    ASSERT_EQ(objects.size(), 1u);
 
     // Unmount the segment — should cascade delete replicas
     store.RemoveSegment(seg_id, client_id);
 
     // Object should be gone (no replicas left)
-    EXPECT_EQ(store.GetObjects().size(), 0u);
+    objects = store.GetObjects();
+    EXPECT_EQ(objects.size(), 0u);
 }
 
 TEST(P2PStandbyMetadataStoreTest, RemoveSegmentDoesNotAffectOtherSegments) {
@@ -477,13 +485,15 @@ TEST(P2PStandbyMetadataStoreTest, RemoveSegmentDoesNotAffectOtherSegments) {
     store.AddReplica("key1", client_id, seg1, 1024, 1);
     store.AddReplica("key1", client_id, seg2, 2048, 1);
 
-    ASSERT_EQ(store.GetObjects().find("key1")->second.replicas.size(), 2u);
+    auto objects = store.GetObjects();
+    ASSERT_EQ(objects.find("key1")->second.replicas.size(), 2u);
 
     // Remove seg1 — should only remove replica on seg1
     store.RemoveSegment(seg1, client_id);
 
-    auto it = store.GetObjects().find("key1");
-    ASSERT_NE(it, store.GetObjects().end());
+    objects = store.GetObjects();
+    auto it = objects.find("key1");
+    ASSERT_NE(it, objects.end());
     EXPECT_EQ(it->second.replicas.size(), 1u);
 }
 


### PR DESCRIPTION
## Description

  Add a P2P-specific hot standby runtime for replaying P2P metadata OpLog entries into `P2PStandbyMetadataStore`.

  This PR introduces `P2PHotStandbyService`, which reuses the shared OpLog and standby components (`StandbyStateMachine`, `OpLogStoreFactory`, `OpLogChangeNotifier`, and `OpLogReplicator`) while keeping the orchestration layer P2P-specific. It
  intentionally does not inherit from the centralized `HotStandbyService` because P2P promotion needs `P2PStandbyMetadataStore`, `P2POpLogApplier`, and an export shape covering clients, segments, objects, and replicas.

  ## Module

  - [ ] Transfer Engine (`mooncake-transfer-engine`)
  - [ ] Mooncake Store (`mooncake-store`)
  - [ ] Mooncake EP (`mooncake-ep`)
  - [ ] Mooncake PG (`mooncake-pg`)
  - [ ] Integration (`mooncake-integration`)
  - [x] P2P Store (`mooncake-p2p-store`)
  - [ ] Python Wheel (`mooncake-wheel`)
  - [ ] Common (`mooncake-common`)
  - [ ] Mooncake RL (`mooncake-rl`)
  - [ ] CI/CD
  - [ ] Docs
  - [ ] Other

  ## Type of Change

  - [ ] Bug fix
  - [x] New feature
  - [ ] Refactor
  - [ ] Breaking change
  - [ ] Documentation update
  - [ ] Performance improvement
  - [ ] Other

  ## How Has This Been Tested?

  **Test commands:**
  ```bash
  ./scripts/code_format.sh --base P2P-Mooncake-Store
  cmake --build build-verify-noetcd --target p2p_oplog_test -j3
  cd build-verify-noetcd && ctest -R "^p2p_oplog_test$" --output-on-failure
```
  Test results:

  - [x] Unit tests pass
  - [ ] Integration tests pass (if applicable)
  - [ ] Manual testing done (describe below)

  p2p_oplog_test passed in the local verification container. The new p2p_hot_standby_service_test.cpp is included in the p2p_oplog_test target.

  ## Checklist

  - [x] I have performed a self-review of my own code
  - [x] I have formatted my code using ./scripts/code_format.sh
  - [ ] I have run pre-commit run --all-files and all hooks pass
  - [ ] I have updated the documentation (if applicable)
  - [x] I have added tests to prove my changes are effective
  - [x] For changes >500 LOC: I have filed an RFC issue

  ## AI Assistance Disclosure

  - [ ] No AI tools were used
  - [x] AI tools were used (specify below)

  AI tools were used to help draft code changes, review diffs, and prepare PR text. The human submitter reviewed the changes and is responsible for them.