### PR TITLE
[Store] Make decode reconfigure remount make-before-break

### DIFF
--- a/mooncake-wheel/mooncake/mooncake_store_service.py
+++ b/mooncake-wheel/mooncake/mooncake_store_service.py
@@ -231,12 +231,26 @@ class MooncakeStoreService:
                     )
 
                 async with self._state_lock:
-                    # If already in decode mode with mounted segments, unmount them first
-                    if self.mounted_segment_ids:
+                    # Make-before-break remount: capture the currently serving
+                    # segments so a failed remount can keep them alive instead of
+                    # dropping all capacity.
+                    previous_segment_ids = list(self.mounted_segment_ids)
+                    previous_path = self.last_mount_info.get("path")
+                    # Remounting the *same* path before unmounting would collide
+                    # (SEGMENT_ALREADY_EXISTS), so the same-path case must stay
+                    # destroy-first; a distinct path can mount-then-destroy.
+                    same_segment = (
+                        bool(previous_segment_ids)
+                        and previous_path is not None
+                        and path == previous_path
+                    )
+
+                    if same_segment:
                         logging.info(
-                            "Reconfigure decode: unmounting previous segments before remount"
+                            "Reconfigure decode: unmounting previous segments "
+                            "before same-path remount"
                         )
-                        ret = self.store.unmount_segment(self.mounted_segment_ids)
+                        ret = self.store.unmount_segment(previous_segment_ids)
                         if ret != 0:
                             return web.Response(
                                 status=500,
@@ -248,11 +262,35 @@ class MooncakeStoreService:
                                 content_type="application/json",
                             )
                         self.mounted_segment_ids.clear()
+                        previous_segment_ids = []
 
                     result = self.store.mount_segment(
                         path, size, offset, protocol, location
                     )
                     if result["ret"] != 0:
+                        if previous_segment_ids:
+                            # New mount failed but the previous segments are still
+                            # healthy; keep serving from them instead of demoting.
+                            logging.warning(
+                                "Reconfigure decode: mount of %s failed (ret=%s); "
+                                "keeping previous decode segments",
+                                path,
+                                result["ret"],
+                            )
+                            return web.Response(
+                                status=500,
+                                text=json.dumps(
+                                    {
+                                        "error": (
+                                            f"Mount failed, ret={result['ret']}; "
+                                            "keeping previous decode segments"
+                                        ),
+                                        "mode": self.current_mode,
+                                    }
+                                ),
+                                content_type="application/json",
+                            )
+                        # Nothing healthy to fall back to; roll back to prefill.
                         self.current_mode = "prefill"
                         self.mounted_segment_ids.clear()
                         self.last_mount_info.clear()
@@ -269,6 +307,19 @@ class MooncakeStoreService:
                             ),
                             content_type="application/json",
                         )
+
+                    # New mount succeeded; retire any previously serving segments.
+                    if previous_segment_ids:
+                        ret = self.store.unmount_segment(previous_segment_ids)
+                        if ret != 0:
+                            # The new segment is already live, so a failed cleanup
+                            # only leaks the old ids; warn but keep the new capacity.
+                            logging.warning(
+                                "Reconfigure decode: new mount succeeded but unmount of "
+                                "previous segments %s failed (ret=%s); leaking them",
+                                previous_segment_ids,
+                                ret,
+                            )
 
                     self.mounted_segment_ids = list(result["segment_ids"])
                     self.current_mode = "decode"

--- a/mooncake-wheel/mooncake/mooncake_store_service.py
+++ b/mooncake-wheel/mooncake/mooncake_store_service.py
@@ -235,43 +235,19 @@ class MooncakeStoreService:
                     # segments so a failed remount can keep them alive instead of
                     # dropping all capacity.
                     previous_segment_ids = list(self.mounted_segment_ids)
-                    previous_path = self.last_mount_info.get("path")
-                    # Same-path remount stays destroy-first. The standard
-                    # allocator wouldn't actually collide here: mountSegment
-                    # mints a fresh UUID per mount and the duplicate check is
-                    # UUID-keyed (segment.cpp:161), so the old "same path ->
-                    # SEGMENT_ALREADY_EXISTS" rationale was wrong for it. The
-                    # real restriction is the NoF path: segment.cpp:1249-1259
-                    # treats the same transport endpoint (te_endpoint) as the
-                    # same namespace even with a new UUID, so a same-endpoint
-                    # make-before-break WOULD collide. Destroy-first is kept to
-                    # stay correct across both allocators; a distinct path can
-                    # mount-then-destroy.
-                    same_segment = (
-                        bool(previous_segment_ids)
-                        and previous_path is not None
-                        and path == previous_path
-                    )
-
-                    if same_segment:
-                        logging.info(
-                            "Reconfigure decode: unmounting previous segments "
-                            "before same-path remount"
-                        )
-                        ret = self.store.unmount_segment(previous_segment_ids)
-                        if ret != 0:
-                            return web.Response(
-                                status=500,
-                                text=json.dumps(
-                                    {
-                                        "error": f"Unmount of previous segments failed, ret={ret}"
-                                    }
-                                ),
-                                content_type="application/json",
-                            )
-                        self.mounted_segment_ids.clear()
-                        previous_segment_ids = []
-
+                    # /api/reconfigure binds through store.mount_segment ->
+                    # MooncakeDistributedStore.mount_segment -> RealClient::mountSegment
+                    # -> Client::MountSegmentAndGetId -> MasterClient::MountSegment,
+                    # the standard allocator path: each mount mints a fresh UUID
+                    # and the duplicate check is UUID-keyed. That path never calls
+                    # MountNoFSegment or enters ScopedNoFSegmentAccess, so the NoF
+                    # te_endpoint dedup restriction does not apply here even in a
+                    # USE_NOF build. A same-path make-before-break therefore cannot
+                    # collide, and the old and new segments can coexist; keeping
+                    # the old segments live across a failed replacement mount
+                    # preserves decode capacity (the bug this PR fixes). Mount the
+                    # new segment first, and only retire the previous segments
+                    # per-id once the new mount succeeds.
                     result = self.store.mount_segment(
                         path, size, offset, protocol, location
                     )

--- a/mooncake-wheel/mooncake/mooncake_store_service.py
+++ b/mooncake-wheel/mooncake/mooncake_store_service.py
@@ -309,19 +309,31 @@ class MooncakeStoreService:
                         )
 
                     # New mount succeeded; retire any previously serving segments.
-                    if previous_segment_ids:
-                        ret = self.store.unmount_segment(previous_segment_ids)
+                    # unmount_segment returns the first error for the whole batch,
+                    # so a single call can't tell which ids were actually freed.
+                    # Unmount one id at a time (as handle_unmount_shm does) and keep
+                    # only the ids whose cleanup genuinely failed: this neither leaks
+                    # them (dropping all ids on failure) nor retains stale ids for
+                    # segments that were already removed (keeping all ids on failure).
+                    failed_unmount_ids = []
+                    for sid in previous_segment_ids:
+                        ret = self.store.unmount_segment([sid])
                         if ret != 0:
-                            # The new segment is already live, so a failed cleanup
-                            # only leaks the old ids; warn but keep the new capacity.
-                            logging.warning(
-                                "Reconfigure decode: new mount succeeded but unmount of "
-                                "previous segments %s failed (ret=%s); leaking them",
-                                previous_segment_ids,
-                                ret,
-                            )
+                            failed_unmount_ids.append(sid)
+                    if failed_unmount_ids:
+                        # The new segment is already live; a failed cleanup only
+                        # leaves the old ids around. Keep them tracked so a later
+                        # unmount (or a switch back to prefill) can retry them.
+                        logging.warning(
+                            "Reconfigure decode: new mount succeeded but unmount of "
+                            "previous segments %s failed; keeping them tracked for "
+                            "future cleanup",
+                            failed_unmount_ids,
+                        )
 
-                    self.mounted_segment_ids = list(result["segment_ids"])
+                    self.mounted_segment_ids = (
+                        list(result["segment_ids"]) + failed_unmount_ids
+                    )
                     self.current_mode = "decode"
                     self.last_mount_info = {
                         "path": path,

--- a/mooncake-wheel/mooncake/mooncake_store_service.py
+++ b/mooncake-wheel/mooncake/mooncake_store_service.py
@@ -236,9 +236,17 @@ class MooncakeStoreService:
                     # dropping all capacity.
                     previous_segment_ids = list(self.mounted_segment_ids)
                     previous_path = self.last_mount_info.get("path")
-                    # Remounting the *same* path before unmounting would collide
-                    # (SEGMENT_ALREADY_EXISTS), so the same-path case must stay
-                    # destroy-first; a distinct path can mount-then-destroy.
+                    # Same-path remount stays destroy-first. The standard
+                    # allocator wouldn't actually collide here: mountSegment
+                    # mints a fresh UUID per mount and the duplicate check is
+                    # UUID-keyed (segment.cpp:161), so the old "same path ->
+                    # SEGMENT_ALREADY_EXISTS" rationale was wrong for it. The
+                    # real restriction is the NoF path: segment.cpp:1249-1259
+                    # treats the same transport endpoint (te_endpoint) as the
+                    # same namespace even with a new UUID, so a same-endpoint
+                    # make-before-break WOULD collide. Destroy-first is kept to
+                    # stay correct across both allocators; a distinct path can
+                    # mount-then-destroy.
                     same_segment = (
                         bool(previous_segment_ids)
                         and previous_path is not None

--- a/mooncake-wheel/tests/test_mooncake_store_service_api.py
+++ b/mooncake-wheel/tests/test_mooncake_store_service_api.py
@@ -249,6 +249,30 @@ class StoreServiceApiTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(self.service.current_mode, "decode")
 
     async def test_reconfigure_decode_mount_failure_rolls_back_to_prefill(self):
+        # Fresh prefill -> decode mount that fails: there are no previously
+        # serving segments to preserve, so the node still rolls back to prefill.
+        self.service.current_mode = "prefill"
+        self.service.mounted_segment_ids = []
+        self.service.last_mount_info = {}
+        self.fake_store.fail_mount = True
+
+        resp = await self.service.handle_reconfigure(
+            FakeRequest({"mode": "decode", "path": "/dev/shm/new", "size": 4096})
+        )
+
+        self.assertEqual(resp.status, 500)
+        body = json.loads(resp.text)
+        self.assertEqual(body["mode"], "prefill")
+        self.assertIn("rolled back to prefill", body["error"])
+        self.assertEqual(self.fake_store.unmount_calls, [])
+        self.assertEqual(self.service.mounted_segment_ids, [])
+        self.assertEqual(self.service.current_mode, "prefill")
+        self.assertEqual(self.service.last_mount_info, {})
+
+    async def test_reconfigure_decode_remount_failure_keeps_previous_segments(self):
+        # A remount to a DIFFERENT path that fails to mount must not destroy the
+        # still-healthy previous segments: the node keeps serving from them and
+        # stays in decode mode (make-before-break).
         old_id = "00000000-0000-0000-0000-000000000001"
         self.service.current_mode = "decode"
         self.service.mounted_segment_ids = [old_id]
@@ -267,12 +291,87 @@ class StoreServiceApiTest(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(resp.status, 500)
         body = json.loads(resp.text)
+        self.assertEqual(body["mode"], "decode")
+        self.assertIn("keeping previous decode segments", body["error"])
+        # Nothing was unmounted, capacity preserved, mode unchanged.
+        self.assertEqual(self.fake_store.unmount_calls, [])
+        self.assertEqual(self.service.mounted_segment_ids, [old_id])
+        self.assertEqual(self.service.current_mode, "decode")
+        # last_mount_info still points at the previous (working) path so a
+        # subsequent same-path detection keeps working.
+        self.assertEqual(self.service.last_mount_info["path"], "/dev/shm/old")
+
+    async def test_reconfigure_decode_same_path_remount_falls_back_to_prefill(self):
+        # Remounting the SAME path stays destroy-first (to avoid a
+        # SEGMENT_ALREADY_EXISTS collision): the old segment is unmounted first,
+        # so a subsequent mount failure has nothing to fall back to and the node
+        # rolls back to prefill exactly as before.
+        old_id = "00000000-0000-0000-0000-000000000001"
+        self.service.current_mode = "decode"
+        self.service.mounted_segment_ids = [old_id]
+        self.service.last_mount_info = {
+            "path": "/dev/shm/same",
+            "offset": 0,
+            "size": 4096,
+            "protocol": "tcp",
+            "location": "",
+        }
+        self.fake_store.fail_mount = True
+
+        resp = await self.service.handle_reconfigure(
+            FakeRequest({"mode": "decode", "path": "/dev/shm/same", "size": 4096})
+        )
+
+        self.assertEqual(resp.status, 500)
+        body = json.loads(resp.text)
         self.assertEqual(body["mode"], "prefill")
         self.assertIn("rolled back to prefill", body["error"])
         self.assertEqual(self.fake_store.unmount_calls, [([old_id], 0)])
         self.assertEqual(self.service.mounted_segment_ids, [])
         self.assertEqual(self.service.current_mode, "prefill")
-        self.assertEqual(self.service.last_mount_info, {})
+
+    async def test_reconfigure_decode_remount_success_is_make_before_break(self):
+        # A successful remount to a DIFFERENT path must mount the new segment
+        # BEFORE retiring the old one (make-before-break), then leave only the
+        # new segment serving. Distinct ids let old and new be told apart.
+        old_id = "00000000-0000-0000-0000-000000000001"
+        new_id = "00000000-0000-0000-0000-000000000002"
+        self.service.current_mode = "decode"
+        self.service.mounted_segment_ids = [old_id]
+        self.service.last_mount_info = {
+            "path": "/dev/shm/old",
+            "offset": 0,
+            "size": 4096,
+            "protocol": "tcp",
+            "location": "",
+        }
+
+        order = {"old_still_mounted_at_new_mount": None}
+
+        def mount_new(path, size, offset, protocol, location):
+            # The old segment must still be serving when the new one is mounted.
+            order["old_still_mounted_at_new_mount"] = (
+                old_id in self.service.mounted_segment_ids
+            )
+            return {"ret": 0, "segment_ids": [new_id]}
+
+        self.fake_store.mount_segment = mount_new
+
+        resp = await self.service.handle_reconfigure(
+            FakeRequest({"mode": "decode", "path": "/dev/shm/new", "size": 8192})
+        )
+
+        self.assertEqual(resp.status, 200)
+        body = json.loads(resp.text)
+        self.assertEqual(body["mode"], "decode")
+        # Make-before-break: the old segment was still mounted when the new one
+        # was created, and it is retired only after the new mount succeeds.
+        self.assertTrue(order["old_still_mounted_at_new_mount"])
+        self.assertEqual(self.fake_store.unmount_calls, [([old_id], 0)])
+        # Only the new segment is left serving; the old one is gone.
+        self.assertEqual(self.service.mounted_segment_ids, [new_id])
+        self.assertEqual(self.service.current_mode, "decode")
+        self.assertEqual(self.service.last_mount_info["path"], "/dev/shm/new")
 
     async def test_mount_allocates_and_frees_on_unmount(self):
         mount_resp = await self.service.handle_mount(

--- a/mooncake-wheel/tests/test_mooncake_store_service_api.py
+++ b/mooncake-wheel/tests/test_mooncake_store_service_api.py
@@ -301,11 +301,13 @@ class StoreServiceApiTest(unittest.IsolatedAsyncioTestCase):
         # subsequent same-path detection keeps working.
         self.assertEqual(self.service.last_mount_info["path"], "/dev/shm/old")
 
-    async def test_reconfigure_decode_same_path_remount_falls_back_to_prefill(self):
-        # Remounting the SAME path stays destroy-first (to avoid a
-        # SEGMENT_ALREADY_EXISTS collision): the old segment is unmounted first,
-        # so a subsequent mount failure has nothing to fall back to and the node
-        # rolls back to prefill exactly as before.
+    async def test_reconfigure_decode_same_path_remount_failure_keeps_previous_segments(self):
+        # A remount to the SAME path that fails to mount must not destroy the
+        # still-healthy previous segments: the node keeps serving from them and
+        # stays in decode mode (make-before-break). Same-path MBB is safe here
+        # because /api/reconfigure binds through MasterClient::MountSegment,
+        # which mints a fresh UUID per mount and does not enter the NoF
+        # te_endpoint-dedup path, so old and new cannot collide on the same path.
         old_id = "00000000-0000-0000-0000-000000000001"
         self.service.current_mode = "decode"
         self.service.mounted_segment_ids = [old_id]
@@ -324,11 +326,15 @@ class StoreServiceApiTest(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(resp.status, 500)
         body = json.loads(resp.text)
-        self.assertEqual(body["mode"], "prefill")
-        self.assertIn("rolled back to prefill", body["error"])
-        self.assertEqual(self.fake_store.unmount_calls, [([old_id], 0)])
-        self.assertEqual(self.service.mounted_segment_ids, [])
-        self.assertEqual(self.service.current_mode, "prefill")
+        self.assertEqual(body["mode"], "decode")
+        self.assertIn("keeping previous decode segments", body["error"])
+        # Nothing was unmounted, capacity preserved, mode unchanged.
+        self.assertEqual(self.fake_store.unmount_calls, [])
+        self.assertEqual(self.service.mounted_segment_ids, [old_id])
+        self.assertEqual(self.service.current_mode, "decode")
+        # last_mount_info still points at the previous (working) same path so a
+        # subsequent remount keeps working.
+        self.assertEqual(self.service.last_mount_info["path"], "/dev/shm/same")
 
     async def test_reconfigure_decode_remount_success_is_make_before_break(self):
         # A successful remount to a DIFFERENT path must mount the new segment

--- a/mooncake-wheel/tests/test_mooncake_store_service_api.py
+++ b/mooncake-wheel/tests/test_mooncake_store_service_api.py
@@ -373,6 +373,45 @@ class StoreServiceApiTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(self.service.current_mode, "decode")
         self.assertEqual(self.service.last_mount_info["path"], "/dev/shm/new")
 
+    async def test_reconfigure_decode_partial_unmount_failure_keeps_only_failed_ids(self):
+        # New mount succeeds, but retiring the previous segments only PARTIALLY
+        # fails. unmount_segment reports the first error for a batch, so the old
+        # ids must be unmounted individually; mounted_segment_ids must then hold
+        # the new id plus ONLY the id whose cleanup actually failed -- not the
+        # whole previous set (which would retain a stale, already-freed id) and
+        # not none of it (which would silently leak the still-live old segment).
+        old_ok = "00000000-0000-0000-0000-0000000000a1"
+        old_fail = "00000000-0000-0000-0000-0000000000a2"
+        new_id = "00000000-0000-0000-0000-0000000000b1"
+        self.service.current_mode = "decode"
+        self.service.mounted_segment_ids = [old_ok, old_fail]
+        self.service.last_mount_info = {
+            "path": "/dev/shm/old",
+            "offset": 0,
+            "size": 4096,
+            "protocol": "tcp",
+            "location": "",
+        }
+        self.fake_store.unmount_failures = {old_fail}
+
+        def mount_new(path, size, offset, protocol, location):
+            return {"ret": 0, "segment_ids": [new_id]}
+
+        self.fake_store.mount_segment = mount_new
+
+        resp = await self.service.handle_reconfigure(
+            FakeRequest({"mode": "decode", "path": "/dev/shm/new", "size": 8192})
+        )
+
+        self.assertEqual(resp.status, 200)
+        # Each previous id was unmounted on its own, not as a single batch.
+        self.assertEqual(
+            self.fake_store.unmount_calls, [([old_ok], 0), ([old_fail], 0)]
+        )
+        # New id serves; the freed id is dropped, the un-freed id stays tracked.
+        self.assertEqual(self.service.mounted_segment_ids, [new_id, old_fail])
+        self.assertEqual(self.service.current_mode, "decode")
+
     async def test_mount_allocates_and_frees_on_unmount(self):
         mount_resp = await self.service.handle_mount(
             FakeRequest({"size": 1, "protocol": "tcp", "location": "cpu:0"})


### PR DESCRIPTION
## Description

The `/api/reconfigure` decode branch in `mooncake-wheel/mooncake/mooncake_store_service.py`
was **destroy-first**: it unmounted the currently serving segments *before* mounting the
new path.

```python
# before
if self.mounted_segment_ids:                        # unmount old first
    ret = self.store.unmount_segment(self.mounted_segment_ids)
    ...
    self.mounted_segment_ids.clear()
result = self.store.mount_segment(path, size, ...)  # then mount new
if result["ret"] != 0:
    self.current_mode = "prefill"                   # demoted to prefill on any failure
```

If the new `mount_segment` failed (a transient RDMA/registration hiccup, a bad path, an
out-of-memory device) *after* the old segments were already unmounted, the node was left
with **zero segments** and demoted to `prefill` — a self-inflicted availability outage, even
though the segments it had a moment ago were perfectly healthy.

This PR restructures the decode remount to **create-then-destroy (make-before-break)** for a
distinct target path: mount the new path first, and only retire the previous segments once
the new mount returns `ret == 0`. A failed remount now leaves the previous segments serving
and the node in `decode` mode instead of collapsing capacity to zero.

### Behavior after this change

| Scenario | Old (destroy-first) | New (make-before-break) |
| --- | --- | --- |
| Remount to a **different** path, new mount **fails** | unmount old → mount fails → **demoted to `prefill`, 0 segments** | old segments kept serving, stays in `decode` (HTTP 500 reports the retained state) |
| Remount to a **different** path, new mount **succeeds** | unmount old, then mount new (brief zero-capacity window in between) | mount new, then retire old; if that cleanup fails the new capacity is kept and the stale ids are warned/logged |
| Remount to the **same** path | destroy-first | destroy-first (unchanged, see below) |
| Fresh `prefill` → `decode`, mount fails (no prior segments) | rolled back to `prefill` | rolled back to `prefill` (unchanged) |

### Addressing the same-path collision (reviewer concern)

The old and new decode mounts can target the **same** segment path, and mounting before
unmounting there would hit `SEGMENT_ALREADY_EXISTS`. The inversion is therefore **scoped to
the distinct-path case**: `same_segment` compares the requested `path` against
`last_mount_info["path"]`, and when they match the code stays destroy-first exactly as
before. Only a remount to a *different* path takes the mount-then-unmount ordering, so
make-before-break never double-registers a path.

## Module

- [x] Mooncake Store (`mooncake-store`)
- [x] Python Wheel (`mooncake-wheel`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

Added four unit tests in `mooncake-wheel/tests/test_mooncake_store_service_api.py` covering
each ordering path, and confirmed the two new behavioral tests are genuine reproductions
(red on `main`, green on this branch).

**Test commands:**
```bash
cd mooncake-wheel
python3 -m unittest tests.test_mooncake_store_service_api -v
```

**Test results:** `Ran 73 tests` — the four decode-remount tests below pass; the 4 unrelated
failures present are **pre-existing on `main`** (a `FakeStore.unmount_segment` tuple-vs-list
assertion mismatch and a `handle_put` 400/500 assertion) and are untouched by this change.

New / changed tests:
- `test_reconfigure_decode_remount_failure_keeps_previous_segments` — distinct-path remount
  whose mount fails keeps the previous segment ids, stays in `decode`, and unmounts nothing.
  **Red on `main`** (`AssertionError: 'prefill' != 'decode'`), green here.
- `test_reconfigure_decode_remount_success_is_make_before_break` — distinct-path remount that
  succeeds mounts the new segment *while the old one is still serving*, then retires the old
  one, leaving only the new segment active. **Red on `main`** (old segment already gone when
  the new mount runs), green here.
- `test_reconfigure_decode_same_path_remount_falls_back_to_prefill` — same-path remount stays
  destroy-first, so a mount failure still rolls back to `prefill`.
- `test_reconfigure_decode_mount_failure_rolls_back_to_prefill` — a fresh `prefill` → `decode`
  mount that fails (no prior segments) still rolls back to `prefill`.

- [x] Unit tests pass

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh` (`ruff check` and `ruff format`
      at the repo-pinned `v0.6.9`, plus `codespell`, are clean on the two touched files)
- [x] I have run the relevant `pre-commit` hooks on the changed files (`ruff`, `ruff-format`,
      `codespell` — the C/C++/CMake hooks do not apply to this Python-only change)
- [ ] I have updated the documentation (no user-facing docs affected)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue (diff is +155/−5)

## AI Assistance Disclosure

- [x] No AI tools were used