### PR TITLE
[Store] Add context-aware replica selection model

### DIFF
--- a/mooncake-store/benchmarks/CMakeLists.txt
+++ b/mooncake-store/benchmarks/CMakeLists.txt
@@ -13,6 +13,11 @@ add_executable(batch_get_replica_bench batch_get_replica_bench.cpp)
 target_link_libraries(batch_get_replica_bench PRIVATE cachelib_memory_allocator
                                                        mooncake_store)
 
+# Add the context-aware replica selector microbenchmark. It emits raw CSV and
+# counts heap allocations inside the timed selection window.
+add_executable(replica_selector_v2_bench replica_selector_v2_bench.cpp)
+target_link_libraries(replica_selector_v2_bench PRIVATE mooncake_store pthread)
+
 # Add file interface benchmark executable
 add_executable(file_interface_bench file_interface_bench.cpp)
 target_link_libraries(file_interface_bench PRIVATE mooncake_store glog::glog)

--- a/mooncake-store/benchmarks/replica_selector_v2_bench.cpp
+++ b/mooncake-store/benchmarks/replica_selector_v2_bench.cpp
@@ -1,0 +1,268 @@
+// Copyright 2026 Mooncake Authors
+
+#include "replica_selector.h"
+
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <new>
+#include <span>
+#include <string>
+#include <string_view>
+#include <unordered_set>
+#include <vector>
+
+#include "replica_selection.h"
+
+namespace {
+
+std::atomic<bool> g_count_allocations{false};
+std::atomic<uint64_t> g_allocation_count{0};
+std::atomic<uint64_t> g_allocated_bytes{0};
+
+void RecordAllocation(std::size_t size) noexcept {
+    if (!g_count_allocations.load(std::memory_order_relaxed)) return;
+    g_allocation_count.fetch_add(1, std::memory_order_relaxed);
+    g_allocated_bytes.fetch_add(size, std::memory_order_relaxed);
+}
+
+}  // namespace
+
+void* operator new(std::size_t size) {
+    RecordAllocation(size);
+    if (void* allocation = std::malloc(size)) return allocation;
+    throw std::bad_alloc();
+}
+
+void* operator new[](std::size_t size) { return ::operator new(size); }
+
+void operator delete(void* allocation) noexcept { std::free(allocation); }
+
+void operator delete[](void* allocation) noexcept { std::free(allocation); }
+
+void operator delete(void* allocation, std::size_t) noexcept {
+    std::free(allocation);
+}
+
+void operator delete[](void* allocation, std::size_t) noexcept {
+    std::free(allocation);
+}
+
+namespace mooncake {
+namespace {
+
+enum class ProviderOutcome : uint8_t {
+    SUCCESS = 0,
+    UNAVAILABLE,
+};
+
+enum class BenchmarkMode : uint8_t {
+    DIRECT = 0,
+    LEGACY,
+    SHADOW,
+    ACTIVE,
+};
+
+class BenchmarkProvider final : public ReplicaScoreProvider {
+   public:
+    explicit BenchmarkProvider(ProviderOutcome outcome) : outcome_(outcome) {}
+
+    void ScoreAll(const ReplicaSelectionContext&,
+                  std::span<const ReplicaScoreCandidateView> candidates,
+                  std::span<ReplicaScoreVerdict> verdicts) const override {
+        ++calls_;
+        for (size_t i = 0; i < candidates.size(); ++i) {
+            if (outcome_ == ProviderOutcome::UNAVAILABLE) {
+                verdicts[i] = ReplicaScoreUnavailable{
+                    ReplicaScoreUnavailableReason::SIGNAL_SOURCE_UNAVAILABLE};
+            } else {
+                verdicts[i] = ReplicaEligibleScore{
+                    {static_cast<double>(candidates.size() - i), 0.0, 0.0}};
+            }
+        }
+    }
+
+    void ResetCalls() const noexcept { calls_ = 0; }
+    [[nodiscard]] uint64_t calls() const noexcept { return calls_; }
+
+   private:
+    ProviderOutcome outcome_;
+    mutable uint64_t calls_{0};
+};
+
+Replica::Descriptor MakeMemory(ReplicaID id) {
+    Replica::Descriptor descriptor;
+    descriptor.id = id;
+    MemoryDescriptor memory;
+    memory.buffer_descriptor.size_ = 1024;
+    memory.buffer_descriptor.buffer_address_ = 0x1000 + id * 0x1000;
+    memory.buffer_descriptor.protocol_ = "rdma";
+    memory.buffer_descriptor.transport_endpoint_ =
+        "store-" + std::to_string(id);
+    descriptor.descriptor_variant = std::move(memory);
+    descriptor.status = ReplicaStatus::COMPLETE;
+    return descriptor;
+}
+
+const char* ModeName(BenchmarkMode mode) {
+    switch (mode) {
+        case BenchmarkMode::DIRECT:
+            return "direct";
+        case BenchmarkMode::LEGACY:
+            return "legacy";
+        case BenchmarkMode::SHADOW:
+            return "shadow";
+        case BenchmarkMode::ACTIVE:
+            return "active";
+    }
+    return "unknown";
+}
+
+ReplicaSelectionMode SelectorMode(BenchmarkMode mode) {
+    switch (mode) {
+        case BenchmarkMode::DIRECT:
+        case BenchmarkMode::LEGACY:
+            return ReplicaSelectionMode::LEGACY;
+        case BenchmarkMode::SHADOW:
+            return ReplicaSelectionMode::SHADOW;
+        case BenchmarkMode::ACTIVE:
+            return ReplicaSelectionMode::ACTIVE;
+    }
+    return ReplicaSelectionMode::LEGACY;
+}
+
+const char* OutcomeName(ProviderOutcome outcome) {
+    return outcome == ProviderOutcome::SUCCESS ? "success" : "unavailable";
+}
+
+uint64_t ParseUnsigned(std::string_view argument, std::string_view prefix,
+                       uint64_t fallback) {
+    if (!argument.starts_with(prefix)) return fallback;
+    const std::string value(argument.substr(prefix.size()));
+    char* end = nullptr;
+    const unsigned long long parsed = std::strtoull(value.c_str(), &end, 10);
+    return end && *end == '\0' ? parsed : fallback;
+}
+
+}  // namespace
+}  // namespace mooncake
+
+int main(int argc, char** argv) {
+    using namespace mooncake;
+    uint64_t iterations = 100000;
+    uint64_t windows = 10;
+    ReplicaSelectionDiagnostics diagnostics =
+        ReplicaSelectionDiagnostics::DISABLED;
+    for (int i = 1; i < argc; ++i) {
+        const std::string_view argument(argv[i]);
+        iterations = ParseUnsigned(argument, "--iterations=", iterations);
+        windows = ParseUnsigned(argument, "--windows=", windows);
+        if (argument == "--diagnostics") {
+            diagnostics = ReplicaSelectionDiagnostics::ENABLED;
+        }
+    }
+    if (iterations == 0 || windows == 0) return 2;
+
+    SetRemoteReplicaScorer(nullptr);
+    const std::unordered_set<std::string> local_endpoints;
+    const ReplicaSelectionContext context{
+        "tenant", "model/layer", "decode-0", "rack-b/gpu-0", 1 << 20, 7};
+
+    std::cout
+        << "mode,provider_outcome,diagnostics,candidates,window,ops,elapsed_ns,"
+           "ns_per_op,allocations,allocated_bytes,provider_calls,checksum\n";
+    std::cout << std::fixed << std::setprecision(3);
+
+    for (const size_t candidate_count : {1u, 2u, 4u, 8u, 16u}) {
+        std::vector<Replica::Descriptor> replicas;
+        replicas.reserve(candidate_count);
+        for (size_t i = 0; i < candidate_count; ++i) {
+            replicas.push_back(MakeMemory(static_cast<ReplicaID>(i + 1)));
+        }
+
+        for (const BenchmarkMode mode :
+             {BenchmarkMode::DIRECT, BenchmarkMode::LEGACY,
+              BenchmarkMode::SHADOW, BenchmarkMode::ACTIVE}) {
+            for (const ProviderOutcome provider_outcome :
+                 {ProviderOutcome::SUCCESS, ProviderOutcome::UNAVAILABLE}) {
+                auto provider =
+                    std::make_shared<BenchmarkProvider>(provider_outcome);
+                const ReplicaSelector selector(SelectorMode(mode), provider,
+                                               diagnostics);
+                uint64_t warmup_checksum = 0;
+                for (size_t i = 0; i < 10000; ++i) {
+                    if (mode == BenchmarkMode::DIRECT) {
+                        if (const auto* selected =
+                                SelectBestReplica(replicas, local_endpoints)) {
+                            warmup_checksum += selected->id;
+                        }
+                    } else {
+                        const auto decision =
+                            selector.Select(replicas, local_endpoints, context);
+                        if (const auto* selected =
+                                ResolveReplica(replicas, decision.selected)) {
+                            warmup_checksum += selected->id;
+                        }
+                    }
+                }
+                if (warmup_checksum == std::numeric_limits<uint64_t>::max()) {
+                    return 3;
+                }
+
+                for (uint64_t window = 0; window < windows; ++window) {
+                    provider->ResetCalls();
+                    g_allocation_count.store(0, std::memory_order_relaxed);
+                    g_allocated_bytes.store(0, std::memory_order_relaxed);
+                    uint64_t checksum = 0;
+                    g_count_allocations.store(true, std::memory_order_release);
+                    const auto start = std::chrono::steady_clock::now();
+                    for (uint64_t operation = 0; operation < iterations;
+                         ++operation) {
+                        if (mode == BenchmarkMode::DIRECT) {
+                            if (const auto* selected = SelectBestReplica(
+                                    replicas, local_endpoints)) {
+                                checksum += selected->id;
+                            }
+                        } else {
+                            const auto decision = selector.Select(
+                                replicas, local_endpoints, context);
+                            if (const auto* selected = ResolveReplica(
+                                    replicas, decision.selected)) {
+                                checksum += selected->id;
+                            }
+                        }
+                    }
+                    const auto end = std::chrono::steady_clock::now();
+                    g_count_allocations.store(false, std::memory_order_release);
+                    const auto elapsed =
+                        std::chrono::duration_cast<std::chrono::nanoseconds>(
+                            end - start)
+                            .count();
+                    const uint64_t allocations =
+                        g_allocation_count.load(std::memory_order_relaxed);
+                    const uint64_t allocated_bytes =
+                        g_allocated_bytes.load(std::memory_order_relaxed);
+
+                    std::cout
+                        << ModeName(mode) << ','
+                        << OutcomeName(provider_outcome) << ','
+                        << (diagnostics == ReplicaSelectionDiagnostics::ENABLED
+                                ? "full"
+                                : "off")
+                        << ',' << candidate_count << ',' << window << ','
+                        << iterations << ',' << elapsed << ','
+                        << static_cast<double>(elapsed) /
+                               static_cast<double>(iterations)
+                        << ',' << allocations << ',' << allocated_bytes << ','
+                        << provider->calls() << ',' << checksum << '\n';
+                }
+            }
+        }
+    }
+    return 0;
+}

--- a/mooncake-store/include/replica_selection.h
+++ b/mooncake-store/include/replica_selection.h
@@ -35,16 +35,16 @@
 namespace mooncake {
 
 // Scores a remote replica candidate; lower score == more preferred.
-using ReplicaScorer = std::function<double(const Replica::Descriptor &)>;
+using ReplicaScorer = std::function<double(const Replica::Descriptor&)>;
 
 namespace detail {
 
-inline std::shared_mutex &ScorerMutex() {
+inline std::shared_mutex& ScorerMutex() {
     static std::shared_mutex mu;
     return mu;
 }
 
-inline ReplicaScorer &ScorerStorage() {
+inline ReplicaScorer& ScorerStorage() {
     static ReplicaScorer scorer;
     return scorer;
 }
@@ -69,9 +69,9 @@ inline void SetRemoteReplicaScorer(ReplicaScorer scorer) {
 
 // Built-in remote-replica score: prefer RDMA over TCP. Purely a function of
 // info the replica already carries (protocol_), so it needs no topology.
-inline double BuiltinRemoteReplicaScore(const Replica::Descriptor &r) {
+inline double BuiltinRemoteReplicaScore(const Replica::Descriptor& r) {
     if (!r.is_memory_replica()) return 100.0;
-    const std::string &proto =
+    const std::string& proto =
         r.get_memory_descriptor().buffer_descriptor.protocol_;
     if (proto == "rdma") return 0.0;
     if (proto == "tcp") return 1.0;
@@ -83,7 +83,7 @@ inline double BuiltinRemoteReplicaScore(const Replica::Descriptor &r) {
 // live so tests / late injection take effect.
 inline bool RemoteReplicaScoringEnabled() {
     static const bool env_enabled = [] {
-        const char *env = std::getenv("MC_STORE_REPLICA_SCORING");
+        const char* env = std::getenv("MC_STORE_REPLICA_SCORING");
         return env && std::string(env) == "1";
     }();
     if (env_enabled) return true;
@@ -94,13 +94,13 @@ inline bool RemoteReplicaScoringEnabled() {
 // Among the remote MEMORY replicas, return the lowest-scoring one (nullptr if
 // none). Ties keep master return order (strictly-less comparison), so a
 // symmetric cluster degrades to the historical "first remote MEMORY" pick.
-inline const Replica::Descriptor *PickBestRemoteMemory(
-    const std::vector<Replica::Descriptor> &replicas,
-    const std::unordered_set<std::string> &local_endpoints) {
+inline const Replica::Descriptor* PickBestRemoteMemory(
+    const std::vector<Replica::Descriptor>& replicas,
+    const std::unordered_set<std::string>& local_endpoints) {
     ReplicaScorer scorer = GetRemoteReplicaScorer();
-    const Replica::Descriptor *best = nullptr;
+    const Replica::Descriptor* best = nullptr;
     double best_score = std::numeric_limits<double>::max();
-    for (const auto &r : replicas) {
+    for (const auto& r : replicas) {
         if (r.status != ReplicaStatus::COMPLETE) continue;
         if (!r.is_memory_replica()) continue;
         if (local_endpoints.count(r.get_memory_descriptor()
@@ -119,12 +119,12 @@ inline const Replica::Descriptor *PickBestRemoteMemory(
 // then LOCAL_DISK, then DISK. Master may return replicas in any order, so we
 // always scan. When scoring is enabled and there are multiple remote MEMORY
 // replicas, the best-scoring one is chosen instead of the first encountered.
-inline const Replica::Descriptor *SelectBestReplica(
-    const std::vector<Replica::Descriptor> &replicas,
-    const std::unordered_set<std::string> &local_endpoints) {
-    const Replica::Descriptor *first_memory = nullptr;
-    const Replica::Descriptor *first_nof = nullptr;
-    for (const auto &r : replicas) {
+inline const Replica::Descriptor* SelectBestReplicaWithoutRemoteScoring(
+    const std::vector<Replica::Descriptor>& replicas,
+    const std::unordered_set<std::string>& local_endpoints) {
+    const Replica::Descriptor* first_memory = nullptr;
+    const Replica::Descriptor* first_nof = nullptr;
+    for (const auto& r : replicas) {
         if (r.status != ReplicaStatus::COMPLETE) continue;
         if (r.is_memory_replica()) {
             if (local_endpoints.count(
@@ -142,19 +142,11 @@ inline const Replica::Descriptor *SelectBestReplica(
             if (!first_nof) first_nof = &r;
         }
     }
-    // No local replica. Among remote MEMORY replicas, optionally pick the
-    // best-scoring one instead of the first encountered (issue #2516).
-    if (first_memory && RemoteReplicaScoringEnabled()) {
-        if (const auto *scored =
-                PickBestRemoteMemory(replicas, local_endpoints)) {
-            return scored;
-        }
-    }
     if (first_memory) return first_memory;
     if (first_nof) return first_nof;
 
-    const Replica::Descriptor *best = nullptr;
-    for (const auto &r : replicas) {
+    const Replica::Descriptor* best = nullptr;
+    for (const auto& r : replicas) {
         if (r.status != ReplicaStatus::COMPLETE) continue;
         if (r.is_local_disk_replica()) {
             best = &r;  // LOCAL_DISK always overrides DISK
@@ -163,6 +155,41 @@ inline const Replica::Descriptor *SelectBestReplica(
         }
     }
     return best;
+}
+
+namespace detail {
+
+// Apply the opt-in V1 remote-memory scorer to an already computed structural
+// baseline. Keeping this step separate lets SHADOW reuse its own structural
+// scan without changing any V1 enablement, scorer, or tie-breaking semantics.
+inline const Replica::Descriptor* ApplyRemoteReplicaScoring(
+    const std::vector<Replica::Descriptor>& replicas,
+    const std::unordered_set<std::string>& local_endpoints,
+    const Replica::Descriptor* baseline) {
+    if (!baseline || !baseline->is_memory_replica()) return baseline;
+
+    const auto& endpoint =
+        baseline->get_memory_descriptor().buffer_descriptor.transport_endpoint_;
+    if (local_endpoints.count(endpoint)) return baseline;
+
+    if (RemoteReplicaScoringEnabled()) {
+        if (const auto* scored =
+                PickBestRemoteMemory(replicas, local_endpoints)) {
+            return scored;
+        }
+    }
+    return baseline;
+}
+
+}  // namespace detail
+
+inline const Replica::Descriptor* SelectBestReplica(
+    const std::vector<Replica::Descriptor>& replicas,
+    const std::unordered_set<std::string>& local_endpoints) {
+    const auto* baseline =
+        SelectBestReplicaWithoutRemoteScoring(replicas, local_endpoints);
+    return detail::ApplyRemoteReplicaScoring(replicas, local_endpoints,
+                                             baseline);
 }
 
 }  // namespace mooncake

--- a/mooncake-store/include/replica_selector.h
+++ b/mooncake-store/include/replica_selector.h
@@ -1,0 +1,216 @@
+// Copyright 2026 Mooncake Authors
+//
+// Experimental, instance-scoped replica selection model. This API contains no
+// signal collection or client integration: callers provide request context and
+// a provider backed by cached signals, then receive a value-only decision.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <unordered_set>
+#include <variant>
+#include <vector>
+
+#include "replica.h"
+
+namespace mooncake {
+
+// LEGACY and SHADOW preserve the process-global V1 policy for the selected
+// replica. SHADOW computes an instance-scoped V2 recommendation without
+// applying it. ACTIVE is fully isolated from V1 and applies the V2 result.
+enum class ReplicaSelectionMode : uint8_t {
+    LEGACY = 0,
+    SHADOW,
+    ACTIVE,
+};
+
+enum class ReplicaSelectionDiagnostics : uint8_t {
+    DISABLED = 0,
+    ENABLED,
+};
+
+// Views are valid only for the duration of ReplicaScoreProvider::ScoreAll().
+struct ReplicaSelectionContext {
+    std::string_view tenant_id{};
+    std::string_view key{};
+    std::string_view requester_endpoint{};
+    std::string_view destination_location{};
+    uint64_t requested_bytes{0};
+    uint64_t request_nonce{0};
+};
+
+// A stable value reference to a descriptor in the master-returned list.
+// ResolveReplica also verifies replica_id, so reordering or replacement is
+// detected instead of silently resolving the wrong descriptor.
+struct ReplicaRef {
+    size_t master_order{0};
+    ReplicaID replica_id{0};
+
+    friend bool operator==(const ReplicaRef&, const ReplicaRef&) = default;
+};
+
+struct ReplicaScoreCandidateView {
+    ReplicaRef replica;
+    std::string_view transport_endpoint;
+    std::string_view protocol;
+};
+
+// Weighted, normalized cost contributions. Lower is better. Every component
+// and their sum must be finite and non-negative.
+struct ReplicaScoreBreakdown {
+    double topology_cost{0.0};
+    double load_cost{0.0};
+    double health_cost{0.0};
+};
+
+struct ReplicaEligibleScore {
+    ReplicaScoreBreakdown breakdown;
+};
+
+enum class ReplicaHardVetoReason : uint8_t {
+    UNHEALTHY = 0,
+    CIRCUIT_OPEN,
+};
+
+struct ReplicaHardVeto {
+    ReplicaHardVetoReason reason{ReplicaHardVetoReason::UNHEALTHY};
+};
+
+// Signal unavailability is not proof that a replica is unreadable. It causes
+// a structural fallback; it must never be treated as a hard veto.
+enum class ReplicaScoreUnavailableReason : uint8_t {
+    STALE = 0,
+    MISSING_SIGNAL,
+    SIGNAL_SOURCE_UNAVAILABLE,
+};
+
+struct ReplicaScoreUnavailable {
+    ReplicaScoreUnavailableReason reason{
+        ReplicaScoreUnavailableReason::SIGNAL_SOURCE_UNAVAILABLE};
+};
+
+// monostate is an output sentinel. ScoreAll must replace every element.
+using ReplicaScoreVerdict =
+    std::variant<std::monostate, ReplicaEligibleScore, ReplicaHardVeto,
+                 ReplicaScoreUnavailable>;
+
+class ReplicaScoreProvider {
+   public:
+    virtual ~ReplicaScoreProvider() = default;
+
+    // Select calls this method at most once. The provider must capture one
+    // immutable request-scoped snapshot and evaluate every candidate from that
+    // same snapshot. It must use cached state only: no blocking I/O and no
+    // retaining candidate/context views after return. Expected stale/missing
+    // data is returned as ReplicaScoreUnavailable; exceptions are reserved for
+    // unexpected program failures. Concurrent Select calls require a
+    // thread-safe implementation.
+    virtual void ScoreAll(const ReplicaSelectionContext& context,
+                          std::span<const ReplicaScoreCandidateView> candidates,
+                          std::span<ReplicaScoreVerdict> verdicts) const = 0;
+};
+
+enum class ReplicaSelectionOutcome : uint8_t {
+    LEGACY_MODE = 0,
+    LOCAL_FAST_PATH,
+    NO_REMOTE_MEMORY,
+    SCORED_REMOTE_MEMORY,
+    SCORED_STORAGE_FALLBACK,
+    NO_SAFE_REPLICA,
+    FALLBACK_NO_PROVIDER,
+    FALLBACK_PROVIDER_EXCEPTION,
+    FALLBACK_SIGNAL_STALE,
+    FALLBACK_MISSING_SIGNAL,
+    FALLBACK_SIGNAL_SOURCE_UNAVAILABLE,
+    FALLBACK_INVALID_RESULT,
+    FALLBACK_INVALID_SCORE,
+};
+
+enum class ReplicaSkipReason : uint8_t {
+    INCOMPLETE = 0,
+    NON_MEMORY,
+    LOCAL,
+};
+
+struct ReplicaCandidateScore {
+    ReplicaRef replica;
+    ReplicaScoreBreakdown breakdown;
+    double total_score{0.0};
+};
+
+struct ReplicaHardVetoObservation {
+    ReplicaRef replica;
+    ReplicaHardVetoReason reason{ReplicaHardVetoReason::UNHEALTHY};
+};
+
+struct ReplicaUnavailableObservation {
+    ReplicaRef replica;
+    ReplicaScoreUnavailableReason reason{
+        ReplicaScoreUnavailableReason::SIGNAL_SOURCE_UNAVAILABLE};
+};
+
+struct ReplicaSkipObservation {
+    ReplicaRef replica;
+    ReplicaSkipReason reason{ReplicaSkipReason::NON_MEMORY};
+};
+
+struct ReplicaSelectionTrace {
+    std::vector<ReplicaCandidateScore> candidate_scores;
+    std::vector<ReplicaHardVetoObservation> hard_vetoes;
+    std::vector<ReplicaUnavailableObservation> unavailable_scores;
+    std::vector<ReplicaSkipObservation> skipped;
+};
+
+struct ReplicaSelectionDecision {
+    ReplicaSelectionMode mode{ReplicaSelectionMode::LEGACY};
+    ReplicaSelectionOutcome outcome{ReplicaSelectionOutcome::LEGACY_MODE};
+    // Scorer-free policy result used when V2 cannot produce a complete safe
+    // ranking. Populated for SHADOW/ACTIVE. LEGACY leaves this empty to avoid
+    // scanning the descriptor list once for diagnostics and again for V1.
+    std::optional<ReplicaRef> structural_baseline;
+    // Effective V2 counterfactual, including its structural fallback.
+    std::optional<ReplicaRef> recommendation;
+    // Replica the caller must actually use for I/O. In SHADOW this remains the
+    // V1 incumbent; in ACTIVE it equals recommendation.
+    std::optional<ReplicaRef> selected;
+    // Empty when diagnostics are disabled. The core outcome never depends on
+    // whether trace collection was requested.
+    ReplicaSelectionTrace trace;
+};
+
+[[nodiscard]] const Replica::Descriptor* ResolveReplica(
+    std::span<const Replica::Descriptor> replicas,
+    const std::optional<ReplicaRef>& reference) noexcept;
+
+// Immutable after construction. SHADOW reads V1 only to preserve the current
+// online selection; its recommendation and every ACTIVE decision are isolated
+// from V1. Diagnostics are opt-in so the common selection path does not
+// allocate merely to build per-candidate trace vectors.
+class ReplicaSelector final {
+   public:
+    explicit ReplicaSelector(
+        ReplicaSelectionMode mode = ReplicaSelectionMode::LEGACY,
+        std::shared_ptr<const ReplicaScoreProvider> provider = nullptr,
+        ReplicaSelectionDiagnostics diagnostics =
+            ReplicaSelectionDiagnostics::DISABLED);
+
+    [[nodiscard]] ReplicaSelectionMode mode() const noexcept { return mode_; }
+
+    [[nodiscard]] ReplicaSelectionDecision Select(
+        const std::vector<Replica::Descriptor>& replicas,
+        const std::unordered_set<std::string>& local_endpoints,
+        const ReplicaSelectionContext& context = {}) const;
+
+   private:
+    ReplicaSelectionMode mode_;
+    std::shared_ptr<const ReplicaScoreProvider> provider_;
+    ReplicaSelectionDiagnostics diagnostics_;
+};
+
+}  // namespace mooncake

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -72,6 +72,7 @@ set(MOONCAKE_STORE_SOURCES
     store_c.cpp
     memory_alloc.cpp
     ssd_register_client.cpp
+    replica_selector.cpp
     engram/engram_store.cpp)
 
 set(EXTRA_LIBS "")

--- a/mooncake-store/src/replica_selector.cpp
+++ b/mooncake-store/src/replica_selector.cpp
@@ -1,0 +1,397 @@
+// Copyright 2026 Mooncake Authors
+
+#include "replica_selector.h"
+
+#include <array>
+#include <cmath>
+#include <limits>
+#include <utility>
+
+#include "replica_selection.h"
+
+namespace mooncake {
+namespace {
+
+constexpr size_t kInlineCandidateCapacity = 16;
+
+ReplicaRef MakeRef(const Replica::Descriptor& replica, size_t master_order) {
+    return {master_order, replica.id};
+}
+
+std::optional<ReplicaRef> FindRef(std::span<const Replica::Descriptor> replicas,
+                                  const Replica::Descriptor* replica) {
+    if (!replica) return std::nullopt;
+    // Equality is defined for unrelated pointers; relational comparison and
+    // subtraction are not. Scan the small master-ordered list so the defensive
+    // foreign-pointer path remains well-defined too.
+    for (size_t index = 0; index < replicas.size(); ++index) {
+        if (replica == std::addressof(replicas[index])) {
+            return MakeRef(replicas[index], index);
+        }
+    }
+    return std::nullopt;
+}
+
+std::optional<ReplicaRef> SelectStructural(
+    std::span<const Replica::Descriptor> replicas,
+    const std::unordered_set<std::string>& local_endpoints,
+    std::span<const ReplicaRef> hard_vetoes = {}) {
+    const auto is_hard_vetoed = [hard_vetoes](size_t master_order) {
+        for (const auto& veto : hard_vetoes) {
+            if (veto.master_order == master_order) return true;
+        }
+        return false;
+    };
+    std::optional<ReplicaRef> first_memory;
+    std::optional<ReplicaRef> first_nof;
+    for (size_t i = 0; i < replicas.size(); ++i) {
+        const auto& replica = replicas[i];
+        if (replica.status != ReplicaStatus::COMPLETE) continue;
+        if (replica.is_memory_replica()) {
+            const auto& endpoint = replica.get_memory_descriptor()
+                                       .buffer_descriptor.transport_endpoint_;
+            if (local_endpoints.count(endpoint)) return MakeRef(replica, i);
+            if (is_hard_vetoed(i)) continue;
+            if (!first_memory) first_memory = MakeRef(replica, i);
+        } else if (replica.is_nof_replica()) {
+            const auto& endpoint = replica.get_nof_descriptor()
+                                       .buffer_descriptor.transport_endpoint_;
+            if (local_endpoints.count(endpoint)) return MakeRef(replica, i);
+            if (!first_nof) first_nof = MakeRef(replica, i);
+        }
+    }
+    if (first_memory) return first_memory;
+    if (first_nof) return first_nof;
+
+    std::optional<ReplicaRef> best;
+    for (size_t i = 0; i < replicas.size(); ++i) {
+        const auto& replica = replicas[i];
+        if (replica.status != ReplicaStatus::COMPLETE) continue;
+        if (replica.is_local_disk_replica()) {
+            best = MakeRef(replica, i);
+        } else if (replica.is_disk_replica() && !best) {
+            best = MakeRef(replica, i);
+        }
+    }
+    return best;
+}
+
+bool IsLocalBuffered(const Replica::Descriptor& replica,
+                     const std::unordered_set<std::string>& local_endpoints) {
+    if (replica.is_memory_replica()) {
+        return local_endpoints.count(
+                   replica.get_memory_descriptor()
+                       .buffer_descriptor.transport_endpoint_) != 0;
+    }
+    if (replica.is_nof_replica()) {
+        return local_endpoints.count(
+                   replica.get_nof_descriptor()
+                       .buffer_descriptor.transport_endpoint_) != 0;
+    }
+    return false;
+}
+
+bool ComputeValidTotal(const ReplicaScoreBreakdown& breakdown, double& total) {
+    if (!std::isfinite(breakdown.topology_cost) ||
+        !std::isfinite(breakdown.load_cost) ||
+        !std::isfinite(breakdown.health_cost) ||
+        breakdown.topology_cost < 0.0 || breakdown.load_cost < 0.0 ||
+        breakdown.health_cost < 0.0) {
+        return false;
+    }
+    total =
+        breakdown.topology_cost + breakdown.load_cost + breakdown.health_cost;
+    return std::isfinite(total);
+}
+
+ReplicaSelectionOutcome OutcomeForUnavailable(
+    ReplicaScoreUnavailableReason reason) {
+    switch (reason) {
+        case ReplicaScoreUnavailableReason::STALE:
+            return ReplicaSelectionOutcome::FALLBACK_SIGNAL_STALE;
+        case ReplicaScoreUnavailableReason::MISSING_SIGNAL:
+            return ReplicaSelectionOutcome::FALLBACK_MISSING_SIGNAL;
+        case ReplicaScoreUnavailableReason::SIGNAL_SOURCE_UNAVAILABLE:
+            return ReplicaSelectionOutcome::FALLBACK_SIGNAL_SOURCE_UNAVAILABLE;
+    }
+    return ReplicaSelectionOutcome::FALLBACK_INVALID_RESULT;
+}
+
+int UnavailablePriority(ReplicaScoreUnavailableReason reason) noexcept {
+    switch (reason) {
+        case ReplicaScoreUnavailableReason::MISSING_SIGNAL:
+            return 0;
+        case ReplicaScoreUnavailableReason::STALE:
+            return 1;
+        case ReplicaScoreUnavailableReason::SIGNAL_SOURCE_UNAVAILABLE:
+            return 2;
+    }
+    // An unknown enum value is a provider contract violation and must dominate
+    // valid soft-unavailable reasons so the batch reports INVALID_RESULT.
+    return 3;
+}
+
+void MergeUnavailable(std::optional<ReplicaScoreUnavailableReason>& aggregate,
+                      ReplicaScoreUnavailableReason reason) noexcept {
+    if (!aggregate ||
+        UnavailablePriority(reason) > UnavailablePriority(*aggregate)) {
+        aggregate = reason;
+    }
+}
+
+}  // namespace
+
+const Replica::Descriptor* ResolveReplica(
+    std::span<const Replica::Descriptor> replicas,
+    const std::optional<ReplicaRef>& reference) noexcept {
+    if (!reference || reference->master_order >= replicas.size()) {
+        return nullptr;
+    }
+    const auto& replica = replicas[reference->master_order];
+    return replica.id == reference->replica_id ? &replica : nullptr;
+}
+
+ReplicaSelector::ReplicaSelector(
+    ReplicaSelectionMode mode,
+    std::shared_ptr<const ReplicaScoreProvider> provider,
+    ReplicaSelectionDiagnostics diagnostics)
+    : mode_(mode), provider_(std::move(provider)), diagnostics_(diagnostics) {}
+
+ReplicaSelectionDecision ReplicaSelector::Select(
+    const std::vector<Replica::Descriptor>& replicas,
+    const std::unordered_set<std::string>& local_endpoints,
+    const ReplicaSelectionContext& context) const {
+    ReplicaSelectionDecision decision;
+    decision.mode = mode_;
+    const bool collect_trace =
+        diagnostics_ == ReplicaSelectionDiagnostics::ENABLED;
+
+    if (mode_ == ReplicaSelectionMode::LEGACY) {
+        // LEGACY intentionally preserves the process-global V1 policy. No V2
+        // provider or separate structural diagnostic scan runs in this mode.
+        decision.selected =
+            FindRef(replicas, SelectBestReplica(replicas, local_endpoints));
+        decision.recommendation = decision.selected;
+        return decision;
+    }
+
+    // SHADOW must be a strict online no-op, including when the existing V1
+    // scorer is enabled. Its V2 recommendation remains based on the
+    // instance-scoped provider and scorer-free structural fallback.
+    decision.structural_baseline = SelectStructural(replicas, local_endpoints);
+    if (mode_ == ReplicaSelectionMode::SHADOW) {
+        const auto* baseline =
+            ResolveReplica(replicas, decision.structural_baseline);
+        decision.selected =
+            FindRef(replicas, detail::ApplyRemoteReplicaScoring(
+                                  replicas, local_endpoints, baseline));
+    } else {
+        decision.selected = decision.structural_baseline;
+    }
+
+    if (decision.structural_baseline) {
+        const auto& baseline =
+            replicas[decision.structural_baseline->master_order];
+        if (IsLocalBuffered(baseline, local_endpoints)) {
+            decision.outcome = ReplicaSelectionOutcome::LOCAL_FAST_PATH;
+            decision.recommendation = decision.structural_baseline;
+            if (collect_trace) {
+                decision.trace.skipped.push_back(
+                    {*decision.structural_baseline, ReplicaSkipReason::LOCAL});
+            }
+            return decision;
+        }
+    }
+
+    std::array<ReplicaScoreCandidateView, kInlineCandidateCapacity>
+        inline_candidates;
+    std::vector<ReplicaScoreCandidateView> overflow_candidates;
+    size_t candidate_count = 0;
+    for (size_t i = 0; i < replicas.size(); ++i) {
+        const auto& replica = replicas[i];
+        if (replica.status != ReplicaStatus::COMPLETE) {
+            if (collect_trace) {
+                decision.trace.skipped.push_back(
+                    {MakeRef(replica, i), ReplicaSkipReason::INCOMPLETE});
+            }
+            continue;
+        }
+        if (!replica.is_memory_replica()) {
+            if (collect_trace) {
+                decision.trace.skipped.push_back(
+                    {MakeRef(replica, i), ReplicaSkipReason::NON_MEMORY});
+            }
+            continue;
+        }
+        const auto& buffer = replica.get_memory_descriptor().buffer_descriptor;
+        ReplicaScoreCandidateView candidate{
+            MakeRef(replica, i), buffer.transport_endpoint_, buffer.protocol_};
+        if (candidate_count < kInlineCandidateCapacity) {
+            inline_candidates[candidate_count] = candidate;
+        } else {
+            if (overflow_candidates.empty()) {
+                overflow_candidates.reserve(replicas.size());
+                overflow_candidates.insert(overflow_candidates.end(),
+                                           inline_candidates.begin(),
+                                           inline_candidates.end());
+            }
+            overflow_candidates.push_back(candidate);
+        }
+        ++candidate_count;
+    }
+
+    if (candidate_count == 0) {
+        decision.outcome = ReplicaSelectionOutcome::NO_REMOTE_MEMORY;
+        decision.recommendation = decision.structural_baseline;
+        return decision;
+    }
+
+    const std::span<const ReplicaScoreCandidateView> candidates =
+        overflow_candidates.empty()
+            ? std::span<const ReplicaScoreCandidateView>(
+                  inline_candidates.data(), candidate_count)
+            : std::span<const ReplicaScoreCandidateView>(overflow_candidates);
+
+    if (!provider_) {
+        decision.outcome = ReplicaSelectionOutcome::FALLBACK_NO_PROVIDER;
+        decision.recommendation = decision.structural_baseline;
+        return decision;
+    }
+
+    std::array<ReplicaScoreVerdict, kInlineCandidateCapacity> inline_verdicts;
+    std::vector<ReplicaScoreVerdict> overflow_verdicts;
+    std::span<ReplicaScoreVerdict> verdicts;
+    if (candidate_count <= kInlineCandidateCapacity) {
+        verdicts = {inline_verdicts.data(), candidate_count};
+    } else {
+        overflow_verdicts.resize(candidate_count);
+        verdicts = overflow_verdicts;
+    }
+
+    try {
+        provider_->ScoreAll(context, candidates, verdicts);
+    } catch (...) {
+        decision.outcome = ReplicaSelectionOutcome::FALLBACK_PROVIDER_EXCEPTION;
+        decision.recommendation = decision.structural_baseline;
+        return decision;
+    }
+
+    // Validate the complete batch before publishing scores or vetoes. A
+    // provider exception or unset element therefore cannot leak partial state.
+    for (const auto& verdict : verdicts) {
+        if (std::holds_alternative<std::monostate>(verdict)) {
+            decision.outcome = ReplicaSelectionOutcome::FALLBACK_INVALID_RESULT;
+            decision.recommendation = decision.structural_baseline;
+            return decision;
+        }
+    }
+
+    std::array<ReplicaRef, kInlineCandidateCapacity> inline_hard_vetoes;
+    std::vector<ReplicaRef> overflow_hard_vetoes;
+    size_t hard_veto_count = 0;
+    const auto add_hard_veto = [&](ReplicaRef reference) {
+        if (hard_veto_count < kInlineCandidateCapacity) {
+            inline_hard_vetoes[hard_veto_count] = reference;
+        } else {
+            if (overflow_hard_vetoes.empty()) {
+                overflow_hard_vetoes.reserve(candidate_count);
+                overflow_hard_vetoes.insert(overflow_hard_vetoes.end(),
+                                            inline_hard_vetoes.begin(),
+                                            inline_hard_vetoes.end());
+            }
+            overflow_hard_vetoes.push_back(reference);
+        }
+        ++hard_veto_count;
+    };
+    std::optional<ReplicaScoreUnavailableReason> unavailable;
+    std::optional<ReplicaRef> best;
+    double best_total = std::numeric_limits<double>::max();
+    bool invalid_score = false;
+
+    for (size_t i = 0; i < verdicts.size(); ++i) {
+        const auto& candidate = candidates[i];
+        const auto& verdict = verdicts[i];
+        if (const auto* score = std::get_if<ReplicaEligibleScore>(&verdict)) {
+            double total = 0.0;
+            if (!ComputeValidTotal(score->breakdown, total)) {
+                invalid_score = true;
+                continue;
+            }
+            if (!best || total < best_total) {
+                best = candidate.replica;
+                best_total = total;
+            }
+        } else if (const auto* veto = std::get_if<ReplicaHardVeto>(&verdict)) {
+            add_hard_veto(candidate.replica);
+            if (collect_trace) {
+                decision.trace.hard_vetoes.push_back(
+                    {candidate.replica, veto->reason});
+            }
+        } else if (const auto* missing =
+                       std::get_if<ReplicaScoreUnavailable>(&verdict)) {
+            MergeUnavailable(unavailable, missing->reason);
+            if (collect_trace) {
+                decision.trace.unavailable_scores.push_back(
+                    {candidate.replica, missing->reason});
+            }
+        }
+    }
+
+    if (invalid_score || unavailable) {
+        // Numeric scores are never applied partially. Hard vetoes from this
+        // complete atomic batch remain authoritative.
+        decision.trace.candidate_scores.clear();
+        const std::span<const ReplicaRef> hard_vetoes =
+            overflow_hard_vetoes.empty()
+                ? std::span<const ReplicaRef>(inline_hard_vetoes.data(),
+                                              hard_veto_count)
+                : std::span<const ReplicaRef>(overflow_hard_vetoes);
+        decision.recommendation =
+            SelectStructural(replicas, local_endpoints, hard_vetoes);
+        if (invalid_score) {
+            decision.outcome = ReplicaSelectionOutcome::FALLBACK_INVALID_SCORE;
+        } else {
+            decision.outcome = OutcomeForUnavailable(*unavailable);
+        }
+        if (mode_ == ReplicaSelectionMode::ACTIVE) {
+            decision.selected = decision.recommendation;
+        }
+        return decision;
+    }
+
+    if (collect_trace) {
+        for (size_t i = 0; i < verdicts.size(); ++i) {
+            const auto* score = std::get_if<ReplicaEligibleScore>(&verdicts[i]);
+            if (!score) continue;
+            double total = 0.0;
+            const bool valid = ComputeValidTotal(score->breakdown, total);
+            if (valid) {
+                decision.trace.candidate_scores.push_back(
+                    {candidates[i].replica, score->breakdown, total});
+            }
+        }
+    }
+
+    if (best) {
+        decision.outcome = ReplicaSelectionOutcome::SCORED_REMOTE_MEMORY;
+        decision.recommendation = best;
+    } else {
+        const std::span<const ReplicaRef> hard_vetoes =
+            overflow_hard_vetoes.empty()
+                ? std::span<const ReplicaRef>(inline_hard_vetoes.data(),
+                                              hard_veto_count)
+                : std::span<const ReplicaRef>(overflow_hard_vetoes);
+        decision.recommendation =
+            SelectStructural(replicas, local_endpoints, hard_vetoes);
+        decision.outcome =
+            decision.recommendation
+                ? ReplicaSelectionOutcome::SCORED_STORAGE_FALLBACK
+                : ReplicaSelectionOutcome::NO_SAFE_REPLICA;
+    }
+    if (mode_ == ReplicaSelectionMode::ACTIVE) {
+        decision.selected = decision.recommendation;
+    }
+    return decision;
+}
+
+}  // namespace mooncake

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -44,6 +44,14 @@ add_test(
 set_tests_properties(
   replica_selection_env_opt_in_test
   PROPERTIES ENVIRONMENT "MC_STORE_REPLICA_SCORING=1")
+add_store_test(replica_selector_v2_test replica_selector_v2_test.cpp)
+add_test(
+  NAME replica_selector_v2_env_v1_isolation_test
+  COMMAND replica_selector_v2_test
+          --gtest_filter=ReplicaSelectorV2Test.EnvironmentV1OptInDoesNotAffectActiveFallback)
+set_tests_properties(
+  replica_selector_v2_env_v1_isolation_test
+  PROPERTIES ENVIRONMENT "MC_STORE_REPLICA_SCORING=1")
 add_store_test(eviction_strategy_test eviction_strategy_test.cpp)
 add_store_test(deadline_scheduler_test deadline_scheduler_test.cpp)
 add_store_test(kv_event_publisher_test kv_event_publisher_test.cpp)

--- a/mooncake-store/tests/replica_selector_v2_test.cpp
+++ b/mooncake-store/tests/replica_selector_v2_test.cpp
@@ -1,0 +1,970 @@
+// Copyright 2026 Mooncake Authors
+
+#include "replica_selector.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cmath>
+#include <cstdlib>
+#include <functional>
+#include <limits>
+#include <memory>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <unordered_set>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "replica_selection.h"
+
+namespace mooncake {
+namespace {
+
+static_assert(std::variant_size_v<ReplicaScoreVerdict> == 4);
+
+Replica::Descriptor MakeMemory(ReplicaID id, const std::string& endpoint,
+                               ReplicaStatus status = ReplicaStatus::COMPLETE,
+                               const std::string& protocol = "rdma") {
+    Replica::Descriptor descriptor;
+    descriptor.id = id;
+    MemoryDescriptor memory;
+    memory.buffer_descriptor.size_ = 1024;
+    memory.buffer_descriptor.buffer_address_ = 0x1000;
+    memory.buffer_descriptor.protocol_ = protocol;
+    memory.buffer_descriptor.transport_endpoint_ = endpoint;
+    descriptor.descriptor_variant = std::move(memory);
+    descriptor.status = status;
+    return descriptor;
+}
+
+Replica::Descriptor MakeNoF(ReplicaID id, const std::string& endpoint) {
+    Replica::Descriptor descriptor;
+    descriptor.id = id;
+    NoFDescriptor nof;
+    nof.buffer_descriptor.size_ = 1024;
+    nof.buffer_descriptor.buffer_address_ = 0x2000;
+    nof.buffer_descriptor.protocol_ = "nvmeof";
+    nof.buffer_descriptor.transport_endpoint_ = endpoint;
+    descriptor.descriptor_variant = std::move(nof);
+    descriptor.status = ReplicaStatus::COMPLETE;
+    return descriptor;
+}
+
+Replica::Descriptor MakeDisk(ReplicaID id) {
+    Replica::Descriptor descriptor;
+    descriptor.id = id;
+    descriptor.descriptor_variant = DiskDescriptor{"/tmp/object", 1024};
+    descriptor.status = ReplicaStatus::COMPLETE;
+    return descriptor;
+}
+
+Replica::Descriptor MakeLocalDisk(ReplicaID id) {
+    Replica::Descriptor descriptor;
+    descriptor.id = id;
+    LocalDiskDescriptor local_disk;
+    local_disk.object_size = 1024;
+    local_disk.transport_endpoint = "client";
+    descriptor.descriptor_variant = std::move(local_disk);
+    descriptor.status = ReplicaStatus::COMPLETE;
+    return descriptor;
+}
+
+ReplicaScoreVerdict Score(double topology, double load, double health) {
+    return ReplicaEligibleScore{{topology, load, health}};
+}
+
+ReplicaScoreVerdict Veto(ReplicaHardVetoReason reason) {
+    return ReplicaHardVeto{reason};
+}
+
+ReplicaScoreVerdict Unavailable(ReplicaScoreUnavailableReason reason) {
+    return ReplicaScoreUnavailable{reason};
+}
+
+class FunctionBatchProvider final : public ReplicaScoreProvider {
+   public:
+    using Function =
+        std::function<void(const ReplicaSelectionContext&,
+                           std::span<const ReplicaScoreCandidateView>,
+                           std::span<ReplicaScoreVerdict>)>;
+
+    explicit FunctionBatchProvider(Function function)
+        : function_(std::move(function)) {}
+
+    void ScoreAll(const ReplicaSelectionContext& context,
+                  std::span<const ReplicaScoreCandidateView> candidates,
+                  std::span<ReplicaScoreVerdict> verdicts) const override {
+        calls.fetch_add(1, std::memory_order_relaxed);
+        function_(context, candidates, verdicts);
+    }
+
+    mutable std::atomic<uint64_t> calls{0};
+
+   private:
+    Function function_;
+};
+
+class AtomicPreferProvider final : public ReplicaScoreProvider {
+   public:
+    explicit AtomicPreferProvider(ReplicaID preferred_id)
+        : preferred_id_(preferred_id) {}
+
+    void ScoreAll(const ReplicaSelectionContext&,
+                  std::span<const ReplicaScoreCandidateView> candidates,
+                  std::span<ReplicaScoreVerdict> verdicts) const override {
+        calls.fetch_add(1, std::memory_order_relaxed);
+        for (size_t i = 0; i < candidates.size(); ++i) {
+            verdicts[i] = candidates[i].replica.replica_id == preferred_id_
+                              ? Score(0.0, 0.0, 0.0)
+                              : Score(1.0, 1.0, 1.0);
+        }
+    }
+
+    mutable std::atomic<uint64_t> calls{0};
+
+   private:
+    ReplicaID preferred_id_;
+};
+
+const Replica::Descriptor* Selected(
+    const ReplicaSelectionDecision& decision,
+    const std::vector<Replica::Descriptor>& replicas) {
+    return ResolveReplica(replicas, decision.selected);
+}
+
+const Replica::Descriptor* Recommended(
+    const ReplicaSelectionDecision& decision,
+    const std::vector<Replica::Descriptor>& replicas) {
+    return ResolveReplica(replicas, decision.recommendation);
+}
+
+void FillAll(std::span<ReplicaScoreVerdict> verdicts,
+             const ReplicaScoreVerdict& verdict) {
+    std::fill(verdicts.begin(), verdicts.end(), verdict);
+}
+
+class ReplicaSelectorV2Test : public ::testing::Test {
+   protected:
+    void TearDown() override { SetRemoteReplicaScorer(nullptr); }
+};
+
+TEST_F(ReplicaSelectorV2Test, DefaultLegacyUsesV1AndNeverCallsV2) {
+    std::atomic<uint64_t> v1_calls{0};
+    SetRemoteReplicaScorer([&](const Replica::Descriptor& replica) {
+        v1_calls.fetch_add(1, std::memory_order_relaxed);
+        return replica.id == 2 ? 0.0 : 10.0;
+    });
+    auto provider = std::make_shared<FunctionBatchProvider>(
+        [](const ReplicaSelectionContext&,
+           std::span<const ReplicaScoreCandidateView>,
+           std::span<ReplicaScoreVerdict>) {
+            ADD_FAILURE() << "V2 must not run in LEGACY mode";
+        });
+    ReplicaSelector selector(ReplicaSelectionMode::LEGACY, provider);
+    std::vector<Replica::Descriptor> replicas = {MakeMemory(1, "first"),
+                                                 MakeMemory(2, "second")};
+
+    const auto decision = selector.Select(replicas, {});
+
+    ASSERT_NE(Selected(decision, replicas), nullptr);
+    EXPECT_EQ(Selected(decision, replicas)->id, 2u);
+    EXPECT_FALSE(decision.structural_baseline);
+    EXPECT_EQ(decision.outcome, ReplicaSelectionOutcome::LEGACY_MODE);
+    EXPECT_EQ(v1_calls.load(std::memory_order_relaxed), 2u);
+    EXPECT_EQ(provider->calls.load(std::memory_order_relaxed), 0u);
+}
+
+TEST_F(ReplicaSelectorV2Test, ActiveIgnoresThrowingGlobalV1Scorer) {
+    std::atomic<uint64_t> v1_calls{0};
+    SetRemoteReplicaScorer([&](const Replica::Descriptor&) -> double {
+        v1_calls.fetch_add(1, std::memory_order_relaxed);
+        throw std::runtime_error("V1 must be isolated");
+    });
+    auto provider = std::make_shared<AtomicPreferProvider>(2);
+    ReplicaSelector selector(ReplicaSelectionMode::ACTIVE, provider);
+    std::vector<Replica::Descriptor> replicas = {MakeMemory(1, "first"),
+                                                 MakeMemory(2, "second")};
+
+    ReplicaSelectionDecision decision;
+    EXPECT_NO_THROW(decision = selector.Select(replicas, {}));
+
+    ASSERT_NE(Selected(decision, replicas), nullptr);
+    EXPECT_EQ(Selected(decision, replicas)->id, 2u);
+    EXPECT_EQ(v1_calls.load(std::memory_order_relaxed), 0u);
+    EXPECT_EQ(provider->calls.load(std::memory_order_relaxed), 1u);
+}
+
+TEST_F(ReplicaSelectorV2Test,
+       ShadowPreservesV1SelectionAndKeepsRecommendationInstanceScoped) {
+    std::atomic<uint64_t> v1_calls{0};
+    SetRemoteReplicaScorer([&](const Replica::Descriptor& replica) {
+        v1_calls.fetch_add(1, std::memory_order_relaxed);
+        return replica.id == 2 ? 0.0 : 10.0;
+    });
+    auto provider = std::make_shared<AtomicPreferProvider>(3);
+    ReplicaSelector selector(ReplicaSelectionMode::SHADOW, provider);
+    std::vector<Replica::Descriptor> replicas = {MakeMemory(1, "first"),
+                                                 MakeMemory(2, "second"),
+                                                 MakeMemory(3, "third")};
+
+    const auto decision = selector.Select(replicas, {});
+
+    ASSERT_NE(Selected(decision, replicas), nullptr);
+    ASSERT_NE(Recommended(decision, replicas), nullptr);
+    ASSERT_TRUE(decision.structural_baseline);
+    EXPECT_EQ(Selected(decision, replicas)->id, 2u);
+    EXPECT_EQ(Recommended(decision, replicas)->id, 3u);
+    EXPECT_EQ(decision.structural_baseline->replica_id, 1u);
+    EXPECT_EQ(v1_calls.load(std::memory_order_relaxed), 3u);
+    EXPECT_EQ(provider->calls.load(std::memory_order_relaxed), 1u);
+}
+
+TEST_F(ReplicaSelectorV2Test,
+       ShadowSelectedMatchesLegacyAcrossReplicaFallbackKinds) {
+    SetRemoteReplicaScorer([](const Replica::Descriptor& replica) {
+        return replica.id == 2 ? 0.0 : 10.0;
+    });
+    const auto provider = std::make_shared<AtomicPreferProvider>(3);
+    const ReplicaSelector legacy(ReplicaSelectionMode::LEGACY, provider);
+    const ReplicaSelector shadow(ReplicaSelectionMode::SHADOW, provider);
+
+    struct Scenario {
+        std::vector<Replica::Descriptor> replicas;
+        std::unordered_set<std::string> local_endpoints;
+    };
+    std::vector<Scenario> scenarios;
+    scenarios.push_back({{MakeMemory(1, "first"), MakeMemory(2, "second"),
+                          MakeMemory(3, "third")},
+                         {}});
+    scenarios.push_back(
+        {{MakeMemory(1, "local"), MakeMemory(2, "remote")}, {"local"}});
+    scenarios.push_back(
+        {{MakeNoF(4, "nof"), MakeLocalDisk(5), MakeDisk(6)}, {}});
+    scenarios.push_back(
+        {{MakeMemory(7, "incomplete", ReplicaStatus::PROCESSING)}, {}});
+
+    for (const auto& scenario : scenarios) {
+        const auto legacy_decision =
+            legacy.Select(scenario.replicas, scenario.local_endpoints);
+        const auto shadow_decision =
+            shadow.Select(scenario.replicas, scenario.local_endpoints);
+        EXPECT_EQ(shadow_decision.selected, legacy_decision.selected);
+    }
+}
+
+TEST_F(ReplicaSelectorV2Test, ShadowLocalFastPathsSkipV1AndV2Scorers) {
+    std::atomic<uint64_t> v1_calls{0};
+    SetRemoteReplicaScorer([&](const Replica::Descriptor&) {
+        v1_calls.fetch_add(1, std::memory_order_relaxed);
+        return 0.0;
+    });
+    auto provider = std::make_shared<FunctionBatchProvider>(
+        [](const ReplicaSelectionContext&,
+           std::span<const ReplicaScoreCandidateView>,
+           std::span<ReplicaScoreVerdict>) {
+            ADD_FAILURE() << "V2 must not run for a local fast path";
+        });
+    const ReplicaSelector legacy(ReplicaSelectionMode::LEGACY, provider);
+    const ReplicaSelector shadow(ReplicaSelectionMode::SHADOW, provider);
+    const std::vector<std::vector<Replica::Descriptor>> scenarios = {
+        {MakeMemory(1, "remote"), MakeMemory(2, "local")},
+        {MakeMemory(3, "remote"), MakeNoF(4, "local")}};
+
+    for (const auto& replicas : scenarios) {
+        const auto legacy_decision = legacy.Select(replicas, {"local"});
+        const auto shadow_decision = shadow.Select(replicas, {"local"});
+
+        EXPECT_EQ(shadow_decision.selected, legacy_decision.selected);
+        EXPECT_EQ(shadow_decision.recommendation,
+                  shadow_decision.structural_baseline);
+        EXPECT_EQ(shadow_decision.outcome,
+                  ReplicaSelectionOutcome::LOCAL_FAST_PATH);
+    }
+    EXPECT_EQ(v1_calls.load(std::memory_order_relaxed), 0u);
+    EXPECT_EQ(provider->calls.load(std::memory_order_relaxed), 0u);
+}
+
+TEST_F(ReplicaSelectorV2Test, PureStructuralBaselineIgnoresV1) {
+    std::atomic<uint64_t> calls{0};
+    SetRemoteReplicaScorer([&](const Replica::Descriptor& replica) {
+        calls.fetch_add(1, std::memory_order_relaxed);
+        return replica.id == 2 ? 0.0 : 10.0;
+    });
+    std::vector<Replica::Descriptor> replicas = {
+        MakeMemory(1, "first", ReplicaStatus::COMPLETE, "tcp"),
+        MakeMemory(2, "second", ReplicaStatus::COMPLETE, "rdma")};
+
+    const auto* structural =
+        SelectBestReplicaWithoutRemoteScoring(replicas, {});
+
+    ASSERT_NE(structural, nullptr);
+    EXPECT_EQ(structural->id, 1u);
+    EXPECT_EQ(calls.load(std::memory_order_relaxed), 0u);
+    EXPECT_EQ(SelectBestReplica(replicas, {})->id, 2u);
+    EXPECT_EQ(calls.load(std::memory_order_relaxed), 2u);
+}
+
+TEST_F(ReplicaSelectorV2Test, LocalMemoryAndNoFSkipProvider) {
+    auto provider = std::make_shared<FunctionBatchProvider>(
+        [](const ReplicaSelectionContext&,
+           std::span<const ReplicaScoreCandidateView>,
+           std::span<ReplicaScoreVerdict>) {
+            ADD_FAILURE() << "local fast path must not score";
+        });
+    ReplicaSelector selector(ReplicaSelectionMode::ACTIVE, provider);
+
+    std::vector<Replica::Descriptor> memory = {MakeMemory(1, "remote"),
+                                               MakeMemory(2, "local")};
+    std::vector<Replica::Descriptor> nof = {MakeNoF(3, "local"),
+                                            MakeMemory(4, "remote")};
+
+    const auto memory_decision = selector.Select(memory, {"local"});
+    const auto nof_decision = selector.Select(nof, {"local"});
+
+    EXPECT_EQ(Selected(memory_decision, memory)->id, 2u);
+    EXPECT_EQ(Selected(nof_decision, nof)->id, 3u);
+    EXPECT_EQ(memory_decision.outcome,
+              ReplicaSelectionOutcome::LOCAL_FAST_PATH);
+    EXPECT_EQ(nof_decision.outcome, ReplicaSelectionOutcome::LOCAL_FAST_PATH);
+    EXPECT_EQ(provider->calls.load(std::memory_order_relaxed), 0u);
+}
+
+TEST_F(ReplicaSelectorV2Test, NoRemoteMemorySkipsProvider) {
+    auto provider = std::make_shared<FunctionBatchProvider>(
+        [](const ReplicaSelectionContext&,
+           std::span<const ReplicaScoreCandidateView>,
+           std::span<ReplicaScoreVerdict>) { ADD_FAILURE(); });
+    ReplicaSelector selector(ReplicaSelectionMode::ACTIVE, provider);
+    std::vector<Replica::Descriptor> replicas = {MakeDisk(1), MakeLocalDisk(2)};
+
+    const auto decision = selector.Select(replicas, {});
+
+    EXPECT_EQ(Selected(decision, replicas)->id, 2u);
+    EXPECT_EQ(decision.outcome, ReplicaSelectionOutcome::NO_REMOTE_MEMORY);
+    EXPECT_EQ(provider->calls.load(std::memory_order_relaxed), 0u);
+}
+
+TEST_F(ReplicaSelectorV2Test, BatchSeesContextAndCandidatesOnceInMasterOrder) {
+    auto provider = std::make_shared<FunctionBatchProvider>(
+        [](const ReplicaSelectionContext& context,
+           std::span<const ReplicaScoreCandidateView> candidates,
+           std::span<ReplicaScoreVerdict> verdicts) {
+            EXPECT_EQ(context.tenant_id, "tenant-a");
+            EXPECT_EQ(context.key, "model/layer/7");
+            EXPECT_EQ(context.requester_endpoint, "decode-0");
+            EXPECT_EQ(context.destination_location, "rack-b/gpu-3");
+            EXPECT_EQ(context.requested_bytes, 4096u);
+            EXPECT_EQ(context.request_nonce, 99u);
+            ASSERT_EQ(candidates.size(), 2u);
+            EXPECT_EQ(candidates[0].replica, (ReplicaRef{0, 1}));
+            EXPECT_EQ(candidates[1].replica, (ReplicaRef{2, 2}));
+            EXPECT_EQ(candidates[0].transport_endpoint, "store-0");
+            EXPECT_EQ(candidates[1].protocol, "tcp");
+            verdicts[0] = Score(5.0, 2.0, 1.0);
+            verdicts[1] = Score(0.5, 0.25, 0.25);
+        });
+    ReplicaSelector selector(ReplicaSelectionMode::ACTIVE, provider);
+    std::vector<Replica::Descriptor> replicas = {
+        MakeMemory(1, "store-0"),
+        MakeMemory(9, "incomplete", ReplicaStatus::PROCESSING),
+        MakeMemory(2, "store-1", ReplicaStatus::COMPLETE, "tcp")};
+    ReplicaSelectionContext context{
+        "tenant-a", "model/layer/7", "decode-0", "rack-b/gpu-3", 4096, 99};
+
+    const auto decision = selector.Select(replicas, {}, context);
+
+    EXPECT_EQ(Selected(decision, replicas)->id, 2u);
+    EXPECT_EQ(decision.outcome, ReplicaSelectionOutcome::SCORED_REMOTE_MEMORY);
+    EXPECT_EQ(provider->calls.load(std::memory_order_relaxed), 1u);
+}
+
+TEST_F(ReplicaSelectorV2Test, TieKeepsMasterOrder) {
+    auto provider = std::make_shared<FunctionBatchProvider>(
+        [](const ReplicaSelectionContext&,
+           std::span<const ReplicaScoreCandidateView>,
+           std::span<ReplicaScoreVerdict> verdicts) {
+            FillAll(verdicts, Score(1.0, 2.0, 3.0));
+        });
+    ReplicaSelector selector(ReplicaSelectionMode::ACTIVE, provider);
+    std::vector<Replica::Descriptor> replicas = {MakeMemory(1, "first"),
+                                                 MakeMemory(2, "second")};
+
+    const auto decision = selector.Select(replicas, {});
+
+    EXPECT_EQ(Selected(decision, replicas)->id, 1u);
+}
+
+TEST_F(ReplicaSelectorV2Test, MissingProviderUsesStructuralFallback) {
+    ReplicaSelector selector(ReplicaSelectionMode::ACTIVE);
+    std::vector<Replica::Descriptor> replicas = {MakeMemory(1, "first"),
+                                                 MakeMemory(2, "second")};
+
+    const auto decision = selector.Select(replicas, {});
+
+    EXPECT_EQ(Selected(decision, replicas)->id, 1u);
+    EXPECT_EQ(decision.outcome, ReplicaSelectionOutcome::FALLBACK_NO_PROVIDER);
+}
+
+TEST_F(ReplicaSelectorV2Test, StaleIsSoftAndDoesNotTriggerStorageFallback) {
+    auto provider = std::make_shared<FunctionBatchProvider>(
+        [](const ReplicaSelectionContext&,
+           std::span<const ReplicaScoreCandidateView>,
+           std::span<ReplicaScoreVerdict> verdicts) {
+            FillAll(verdicts,
+                    Unavailable(ReplicaScoreUnavailableReason::STALE));
+        });
+    ReplicaSelector selector(ReplicaSelectionMode::ACTIVE, provider);
+    std::vector<Replica::Descriptor> replicas = {
+        MakeMemory(1, "first"), MakeMemory(2, "second"), MakeDisk(3)};
+
+    const auto decision = selector.Select(replicas, {});
+
+    EXPECT_EQ(Selected(decision, replicas)->id, 1u);
+    EXPECT_EQ(decision.outcome, ReplicaSelectionOutcome::FALLBACK_SIGNAL_STALE);
+}
+
+TEST_F(ReplicaSelectorV2Test, SignalSourceUnavailableIsSoftAndTraced) {
+    auto provider = std::make_shared<FunctionBatchProvider>(
+        [](const ReplicaSelectionContext&,
+           std::span<const ReplicaScoreCandidateView>,
+           std::span<ReplicaScoreVerdict> verdicts) {
+            FillAll(
+                verdicts,
+                Unavailable(
+                    ReplicaScoreUnavailableReason::SIGNAL_SOURCE_UNAVAILABLE));
+        });
+    ReplicaSelector selector(ReplicaSelectionMode::ACTIVE, provider,
+                             ReplicaSelectionDiagnostics::ENABLED);
+    std::vector<Replica::Descriptor> replicas = {MakeMemory(1, "first"),
+                                                 MakeMemory(2, "second")};
+
+    const auto decision = selector.Select(replicas, {});
+
+    EXPECT_EQ(Selected(decision, replicas)->id, 1u);
+    EXPECT_EQ(decision.outcome,
+              ReplicaSelectionOutcome::FALLBACK_SIGNAL_SOURCE_UNAVAILABLE);
+    ASSERT_EQ(decision.trace.unavailable_scores.size(), 2u);
+    EXPECT_EQ(decision.trace.unavailable_scores[0].reason,
+              ReplicaScoreUnavailableReason::SIGNAL_SOURCE_UNAVAILABLE);
+    EXPECT_TRUE(decision.trace.candidate_scores.empty());
+}
+
+TEST_F(ReplicaSelectorV2Test,
+       MixedUnavailableOutcomeDoesNotDependOnMasterOrder) {
+    auto provider = std::make_shared<FunctionBatchProvider>(
+        [](const ReplicaSelectionContext&,
+           std::span<const ReplicaScoreCandidateView> candidates,
+           std::span<ReplicaScoreVerdict> verdicts) {
+            for (size_t i = 0; i < candidates.size(); ++i) {
+                switch (candidates[i].replica.replica_id) {
+                    case 1:
+                        verdicts[i] = Unavailable(
+                            ReplicaScoreUnavailableReason::MISSING_SIGNAL);
+                        break;
+                    case 2:
+                        verdicts[i] =
+                            Unavailable(ReplicaScoreUnavailableReason::STALE);
+                        break;
+                    case 3:
+                        verdicts[i] =
+                            Unavailable(ReplicaScoreUnavailableReason::
+                                            SIGNAL_SOURCE_UNAVAILABLE);
+                        break;
+                    default:
+                        FAIL() << "unexpected replica id";
+                }
+            }
+        });
+    ReplicaSelector selector(ReplicaSelectionMode::ACTIVE, provider);
+    std::vector<ReplicaID> order = {1, 2, 3};
+
+    do {
+        std::vector<Replica::Descriptor> replicas;
+        for (const auto id : order) {
+            replicas.push_back(MakeMemory(id, "store-" + std::to_string(id)));
+        }
+
+        const auto decision = selector.Select(replicas, {});
+
+        EXPECT_EQ(decision.outcome,
+                  ReplicaSelectionOutcome::FALLBACK_SIGNAL_SOURCE_UNAVAILABLE);
+        ASSERT_NE(Selected(decision, replicas), nullptr);
+        EXPECT_EQ(Selected(decision, replicas)->id, order.front());
+    } while (std::next_permutation(order.begin(), order.end()));
+}
+
+TEST_F(ReplicaSelectorV2Test,
+       InvalidUnavailableReasonDominatesRegardlessOfMasterOrder) {
+    constexpr auto invalid_reason =
+        static_cast<ReplicaScoreUnavailableReason>(255);
+    auto provider = std::make_shared<FunctionBatchProvider>(
+        [&](const ReplicaSelectionContext&,
+            std::span<const ReplicaScoreCandidateView> candidates,
+            std::span<ReplicaScoreVerdict> verdicts) {
+            for (size_t i = 0; i < candidates.size(); ++i) {
+                verdicts[i] =
+                    Unavailable(candidates[i].replica.replica_id == 1
+                                    ? invalid_reason
+                                    : ReplicaScoreUnavailableReason::STALE);
+            }
+        });
+    ReplicaSelector selector(ReplicaSelectionMode::ACTIVE, provider);
+    std::vector<ReplicaID> order = {1, 2};
+
+    do {
+        std::vector<Replica::Descriptor> replicas;
+        for (const auto id : order) {
+            replicas.push_back(MakeMemory(id, "store-" + std::to_string(id)));
+        }
+
+        const auto decision = selector.Select(replicas, {});
+
+        EXPECT_EQ(decision.outcome,
+                  ReplicaSelectionOutcome::FALLBACK_INVALID_RESULT);
+    } while (std::next_permutation(order.begin(), order.end()));
+}
+
+TEST_F(ReplicaSelectorV2Test,
+       HardVetoThenStaleFallsBackWithoutSelectingVetoedReplica) {
+    auto provider = std::make_shared<FunctionBatchProvider>(
+        [](const ReplicaSelectionContext&,
+           std::span<const ReplicaScoreCandidateView>,
+           std::span<ReplicaScoreVerdict> verdicts) {
+            verdicts[0] = Veto(ReplicaHardVetoReason::UNHEALTHY);
+            verdicts[1] = Unavailable(ReplicaScoreUnavailableReason::STALE);
+        });
+    ReplicaSelector selector(ReplicaSelectionMode::ACTIVE, provider);
+    std::vector<Replica::Descriptor> replicas = {
+        MakeMemory(1, "first"), MakeMemory(2, "second"), MakeDisk(3)};
+
+    const auto decision = selector.Select(replicas, {});
+
+    EXPECT_EQ(Selected(decision, replicas)->id, 2u);
+    EXPECT_EQ(decision.outcome, ReplicaSelectionOutcome::FALLBACK_SIGNAL_STALE);
+}
+
+TEST_F(ReplicaSelectorV2Test,
+       HardVetoThenMissingSignalFallsBackWithoutSelectingVetoedReplica) {
+    auto provider = std::make_shared<FunctionBatchProvider>(
+        [](const ReplicaSelectionContext&,
+           std::span<const ReplicaScoreCandidateView>,
+           std::span<ReplicaScoreVerdict> verdicts) {
+            verdicts[0] = Veto(ReplicaHardVetoReason::CIRCUIT_OPEN);
+            verdicts[1] =
+                Unavailable(ReplicaScoreUnavailableReason::MISSING_SIGNAL);
+        });
+    ReplicaSelector selector(ReplicaSelectionMode::ACTIVE, provider);
+    std::vector<Replica::Descriptor> replicas = {MakeMemory(1, "first"),
+                                                 MakeMemory(2, "second")};
+
+    const auto decision = selector.Select(replicas, {});
+
+    EXPECT_EQ(Selected(decision, replicas)->id, 2u);
+    EXPECT_EQ(decision.outcome,
+              ReplicaSelectionOutcome::FALLBACK_MISSING_SIGNAL);
+}
+
+TEST_F(ReplicaSelectorV2Test, HardVetoThenEligibleSelectsEligibleReplica) {
+    auto provider = std::make_shared<FunctionBatchProvider>(
+        [](const ReplicaSelectionContext&,
+           std::span<const ReplicaScoreCandidateView>,
+           std::span<ReplicaScoreVerdict> verdicts) {
+            verdicts[0] = Veto(ReplicaHardVetoReason::UNHEALTHY);
+            verdicts[1] = Score(1.0, 1.0, 1.0);
+        });
+    ReplicaSelector selector(ReplicaSelectionMode::ACTIVE, provider);
+    std::vector<Replica::Descriptor> replicas = {MakeMemory(1, "first"),
+                                                 MakeMemory(2, "second")};
+
+    const auto decision = selector.Select(replicas, {});
+
+    EXPECT_EQ(Selected(decision, replicas)->id, 2u);
+    EXPECT_EQ(decision.outcome, ReplicaSelectionOutcome::SCORED_REMOTE_MEMORY);
+}
+
+TEST_F(ReplicaSelectorV2Test, AllHardVetoUsesNoFStorageFallback) {
+    auto provider = std::make_shared<FunctionBatchProvider>(
+        [](const ReplicaSelectionContext&,
+           std::span<const ReplicaScoreCandidateView>,
+           std::span<ReplicaScoreVerdict> verdicts) {
+            FillAll(verdicts, Veto(ReplicaHardVetoReason::CIRCUIT_OPEN));
+        });
+    ReplicaSelector selector(ReplicaSelectionMode::ACTIVE, provider);
+    std::vector<Replica::Descriptor> replicas = {
+        MakeMemory(1, "first"), MakeMemory(2, "second"),
+        MakeNoF(3, "remote-nof"), MakeLocalDisk(4), MakeDisk(5)};
+
+    const auto decision = selector.Select(replicas, {});
+
+    EXPECT_EQ(Selected(decision, replicas)->id, 3u);
+    EXPECT_EQ(decision.outcome,
+              ReplicaSelectionOutcome::SCORED_STORAGE_FALLBACK);
+}
+
+TEST_F(ReplicaSelectorV2Test, AllHardVetoPrefersLocalDiskOverDisk) {
+    auto provider = std::make_shared<FunctionBatchProvider>(
+        [](const ReplicaSelectionContext&,
+           std::span<const ReplicaScoreCandidateView>,
+           std::span<ReplicaScoreVerdict> verdicts) {
+            FillAll(verdicts, Veto(ReplicaHardVetoReason::UNHEALTHY));
+        });
+    ReplicaSelector selector(ReplicaSelectionMode::ACTIVE, provider);
+    std::vector<Replica::Descriptor> replicas = {MakeMemory(1, "remote"),
+                                                 MakeDisk(2), MakeLocalDisk(3)};
+
+    const auto decision = selector.Select(replicas, {});
+
+    EXPECT_EQ(Selected(decision, replicas)->id, 3u);
+}
+
+TEST_F(ReplicaSelectorV2Test, SeventeenHardVetoesUseOverflowFallback) {
+    auto provider = std::make_shared<FunctionBatchProvider>(
+        [](const ReplicaSelectionContext&,
+           std::span<const ReplicaScoreCandidateView>,
+           std::span<ReplicaScoreVerdict> verdicts) {
+            FillAll(verdicts, Veto(ReplicaHardVetoReason::UNHEALTHY));
+        });
+    ReplicaSelector selector(ReplicaSelectionMode::ACTIVE, provider);
+    std::vector<Replica::Descriptor> replicas;
+    for (ReplicaID id = 1; id <= 17; ++id) {
+        replicas.push_back(MakeMemory(id, "store-" + std::to_string(id)));
+    }
+    replicas.push_back(MakeDisk(18));
+
+    const auto decision = selector.Select(replicas, {});
+
+    EXPECT_EQ(Selected(decision, replicas)->id, 18u);
+    EXPECT_EQ(decision.outcome,
+              ReplicaSelectionOutcome::SCORED_STORAGE_FALLBACK);
+}
+
+TEST_F(ReplicaSelectorV2Test, AllHardVetoWithoutStorageFailsClosedInActive) {
+    auto provider = std::make_shared<FunctionBatchProvider>(
+        [](const ReplicaSelectionContext&,
+           std::span<const ReplicaScoreCandidateView>,
+           std::span<ReplicaScoreVerdict> verdicts) {
+            FillAll(verdicts, Veto(ReplicaHardVetoReason::UNHEALTHY));
+        });
+    ReplicaSelector selector(ReplicaSelectionMode::ACTIVE, provider);
+    std::vector<Replica::Descriptor> replicas = {MakeMemory(1, "first"),
+                                                 MakeMemory(2, "second")};
+
+    const auto decision = selector.Select(replicas, {});
+
+    EXPECT_EQ(Selected(decision, replicas), nullptr);
+    EXPECT_EQ(Recommended(decision, replicas), nullptr);
+    EXPECT_EQ(decision.outcome, ReplicaSelectionOutcome::NO_SAFE_REPLICA);
+}
+
+TEST_F(ReplicaSelectorV2Test, ShadowKeepsBaselineWhenRecommendationIsEmpty) {
+    auto provider = std::make_shared<FunctionBatchProvider>(
+        [](const ReplicaSelectionContext&,
+           std::span<const ReplicaScoreCandidateView>,
+           std::span<ReplicaScoreVerdict> verdicts) {
+            FillAll(verdicts, Veto(ReplicaHardVetoReason::UNHEALTHY));
+        });
+    ReplicaSelector selector(ReplicaSelectionMode::SHADOW, provider);
+    std::vector<Replica::Descriptor> replicas = {MakeMemory(1, "first"),
+                                                 MakeMemory(2, "second")};
+
+    const auto decision = selector.Select(replicas, {});
+
+    EXPECT_EQ(Selected(decision, replicas)->id, 1u);
+    EXPECT_EQ(Recommended(decision, replicas), nullptr);
+    EXPECT_EQ(decision.outcome, ReplicaSelectionOutcome::NO_SAFE_REPLICA);
+}
+
+TEST_F(ReplicaSelectorV2Test, ProviderExceptionPublishesNoPartialBatch) {
+    auto provider = std::make_shared<FunctionBatchProvider>(
+        [](const ReplicaSelectionContext&,
+           std::span<const ReplicaScoreCandidateView>,
+           std::span<ReplicaScoreVerdict> verdicts) {
+            verdicts[0] = Veto(ReplicaHardVetoReason::UNHEALTHY);
+            throw std::runtime_error("snapshot failed");
+        });
+    ReplicaSelector selector(ReplicaSelectionMode::ACTIVE, provider,
+                             ReplicaSelectionDiagnostics::ENABLED);
+    std::vector<Replica::Descriptor> replicas = {MakeMemory(1, "first"),
+                                                 MakeMemory(2, "second")};
+
+    const auto decision = selector.Select(replicas, {});
+
+    EXPECT_EQ(Selected(decision, replicas)->id, 1u);
+    EXPECT_EQ(decision.outcome,
+              ReplicaSelectionOutcome::FALLBACK_PROVIDER_EXCEPTION);
+    EXPECT_TRUE(decision.trace.hard_vetoes.empty());
+    EXPECT_TRUE(decision.trace.candidate_scores.empty());
+}
+
+TEST_F(ReplicaSelectorV2Test, UnsetOutputInvalidatesWholeBatch) {
+    auto provider = std::make_shared<FunctionBatchProvider>(
+        [](const ReplicaSelectionContext&,
+           std::span<const ReplicaScoreCandidateView>,
+           std::span<ReplicaScoreVerdict> verdicts) {
+            verdicts[0] = Veto(ReplicaHardVetoReason::UNHEALTHY);
+            // verdicts[1] deliberately remains monostate.
+        });
+    ReplicaSelector selector(ReplicaSelectionMode::ACTIVE, provider,
+                             ReplicaSelectionDiagnostics::ENABLED);
+    std::vector<Replica::Descriptor> replicas = {MakeMemory(1, "first"),
+                                                 MakeMemory(2, "second")};
+
+    const auto decision = selector.Select(replicas, {});
+
+    EXPECT_EQ(Selected(decision, replicas)->id, 1u);
+    EXPECT_EQ(decision.outcome,
+              ReplicaSelectionOutcome::FALLBACK_INVALID_RESULT);
+    EXPECT_TRUE(decision.trace.hard_vetoes.empty());
+}
+
+TEST_F(ReplicaSelectorV2Test, InvalidScoresNeverApplyPartialRanking) {
+    const double max = std::numeric_limits<double>::max();
+    const std::vector<ReplicaScoreVerdict> invalid = {
+        Score(-1.0, 0.0, 0.0),
+        Score(0.0, -1.0, 0.0),
+        Score(0.0, 0.0, -1.0),
+        Score(std::numeric_limits<double>::quiet_NaN(), 0.0, 0.0),
+        Score(0.0, std::numeric_limits<double>::infinity(), 0.0),
+        Score(0.0, 0.0, -std::numeric_limits<double>::infinity()),
+        Score(max, max, max),
+    };
+
+    for (const auto& invalid_score : invalid) {
+        auto provider = std::make_shared<FunctionBatchProvider>(
+            [invalid_score](const ReplicaSelectionContext&,
+                            std::span<const ReplicaScoreCandidateView>,
+                            std::span<ReplicaScoreVerdict> verdicts) {
+                verdicts[0] = invalid_score;
+                verdicts[1] = Score(0.0, 0.0, 0.0);
+            });
+        ReplicaSelector selector(ReplicaSelectionMode::ACTIVE, provider);
+        std::vector<Replica::Descriptor> replicas = {MakeMemory(1, "first"),
+                                                     MakeMemory(2, "second")};
+
+        const auto decision = selector.Select(replicas, {});
+
+        EXPECT_EQ(Selected(decision, replicas)->id, 1u);
+        EXPECT_EQ(decision.outcome,
+                  ReplicaSelectionOutcome::FALLBACK_INVALID_SCORE);
+    }
+}
+
+TEST_F(ReplicaSelectorV2Test, HardVetoSurvivesInvalidScoreFallback) {
+    auto provider = std::make_shared<FunctionBatchProvider>(
+        [](const ReplicaSelectionContext&,
+           std::span<const ReplicaScoreCandidateView>,
+           std::span<ReplicaScoreVerdict> verdicts) {
+            verdicts[0] = Veto(ReplicaHardVetoReason::UNHEALTHY);
+            verdicts[1] = Score(-1.0, 0.0, 0.0);
+        });
+    ReplicaSelector selector(ReplicaSelectionMode::ACTIVE, provider);
+    std::vector<Replica::Descriptor> replicas = {MakeMemory(1, "first"),
+                                                 MakeMemory(2, "second")};
+
+    const auto decision = selector.Select(replicas, {});
+
+    EXPECT_EQ(Selected(decision, replicas)->id, 2u);
+    EXPECT_EQ(decision.outcome,
+              ReplicaSelectionOutcome::FALLBACK_INVALID_SCORE);
+}
+
+TEST_F(ReplicaSelectorV2Test, DiagnosticsAreDisabledByDefault) {
+    auto provider = std::make_shared<AtomicPreferProvider>(2);
+    ReplicaSelector selector(ReplicaSelectionMode::ACTIVE, provider);
+    std::vector<Replica::Descriptor> replicas = {
+        MakeMemory(9, "incomplete", ReplicaStatus::PROCESSING), MakeDisk(8),
+        MakeMemory(1, "first"), MakeMemory(2, "second")};
+
+    const auto decision = selector.Select(replicas, {});
+
+    EXPECT_TRUE(decision.trace.candidate_scores.empty());
+    EXPECT_TRUE(decision.trace.hard_vetoes.empty());
+    EXPECT_TRUE(decision.trace.unavailable_scores.empty());
+    EXPECT_TRUE(decision.trace.skipped.empty());
+}
+
+TEST_F(ReplicaSelectorV2Test, DiagnosticsCaptureCompleteAtomicDecision) {
+    auto provider = std::make_shared<FunctionBatchProvider>(
+        [](const ReplicaSelectionContext&,
+           std::span<const ReplicaScoreCandidateView>,
+           std::span<ReplicaScoreVerdict> verdicts) {
+            verdicts[0] = Veto(ReplicaHardVetoReason::CIRCUIT_OPEN);
+            verdicts[1] = Score(1.0, 2.0, 3.0);
+        });
+    ReplicaSelector selector(ReplicaSelectionMode::ACTIVE, provider,
+                             ReplicaSelectionDiagnostics::ENABLED);
+    std::vector<Replica::Descriptor> replicas = {
+        MakeMemory(9, "incomplete", ReplicaStatus::PROCESSING), MakeDisk(8),
+        MakeMemory(1, "first"), MakeMemory(2, "second")};
+
+    const auto decision = selector.Select(replicas, {});
+
+    ASSERT_EQ(decision.trace.hard_vetoes.size(), 1u);
+    EXPECT_EQ(decision.trace.hard_vetoes[0].replica.replica_id, 1u);
+    ASSERT_EQ(decision.trace.candidate_scores.size(), 1u);
+    EXPECT_EQ(decision.trace.candidate_scores[0].replica.replica_id, 2u);
+    EXPECT_DOUBLE_EQ(decision.trace.candidate_scores[0].total_score, 6.0);
+    ASSERT_EQ(decision.trace.skipped.size(), 2u);
+}
+
+TEST_F(ReplicaSelectorV2Test, LocalDiagnosticsCaptureFastPath) {
+    auto provider = std::make_shared<AtomicPreferProvider>(1);
+    ReplicaSelector selector(ReplicaSelectionMode::ACTIVE, provider,
+                             ReplicaSelectionDiagnostics::ENABLED);
+    std::vector<Replica::Descriptor> replicas = {MakeMemory(1, "local")};
+
+    const auto decision = selector.Select(replicas, {"local"});
+
+    ASSERT_EQ(decision.trace.skipped.size(), 1u);
+    EXPECT_EQ(decision.trace.skipped[0].reason, ReplicaSkipReason::LOCAL);
+    EXPECT_EQ(provider->calls.load(std::memory_order_relaxed), 0u);
+}
+
+TEST_F(ReplicaSelectorV2Test, InlineAndOverflowCandidateCountsUseOneBatch) {
+    for (const size_t count : {1u, 2u, 16u, 17u}) {
+        auto provider = std::make_shared<FunctionBatchProvider>(
+            [](const ReplicaSelectionContext&,
+               std::span<const ReplicaScoreCandidateView> candidates,
+               std::span<ReplicaScoreVerdict> verdicts) {
+                for (size_t i = 0; i < candidates.size(); ++i) {
+                    verdicts[i] = Score(
+                        static_cast<double>(candidates.size() - i), 0.0, 0.0);
+                }
+            });
+        ReplicaSelector selector(ReplicaSelectionMode::ACTIVE, provider);
+        std::vector<Replica::Descriptor> replicas;
+        replicas.reserve(count);
+        for (size_t i = 0; i < count; ++i) {
+            replicas.push_back(MakeMemory(static_cast<ReplicaID>(i + 1),
+                                          "endpoint-" + std::to_string(i + 1)));
+        }
+
+        const auto decision = selector.Select(replicas, {});
+
+        EXPECT_EQ(Selected(decision, replicas)->id, count);
+        EXPECT_EQ(provider->calls.load(std::memory_order_relaxed), 1u);
+    }
+}
+
+TEST_F(ReplicaSelectorV2Test, TwoSelectorsKeepProvidersIsolated) {
+    auto first = std::make_shared<AtomicPreferProvider>(1);
+    auto second = std::make_shared<AtomicPreferProvider>(2);
+    const ReplicaSelector first_selector(ReplicaSelectionMode::ACTIVE, first);
+    const ReplicaSelector second_selector(ReplicaSelectionMode::ACTIVE, second);
+    std::vector<Replica::Descriptor> replicas = {MakeMemory(1, "first"),
+                                                 MakeMemory(2, "second")};
+
+    for (size_t i = 0; i < 100; ++i) {
+        EXPECT_EQ(Selected(first_selector.Select(replicas, {}), replicas)->id,
+                  1u);
+        EXPECT_EQ(Selected(second_selector.Select(replicas, {}), replicas)->id,
+                  2u);
+    }
+
+    EXPECT_EQ(first->calls.load(std::memory_order_relaxed), 100u);
+    EXPECT_EQ(second->calls.load(std::memory_order_relaxed), 100u);
+}
+
+TEST_F(ReplicaSelectorV2Test, ConcurrentConstSelectIsRaceFree) {
+    constexpr size_t kThreadCount = 8;
+    constexpr size_t kIterationsPerThread = 10000;
+    auto provider = std::make_shared<AtomicPreferProvider>(2);
+    const ReplicaSelector selector(ReplicaSelectionMode::ACTIVE, provider);
+    const std::vector<Replica::Descriptor> replicas = {MakeMemory(1, "first"),
+                                                       MakeMemory(2, "second")};
+    const std::unordered_set<std::string> local_endpoints;
+    std::atomic<uint64_t> wrong_decisions{0};
+    std::vector<std::thread> threads;
+
+    for (size_t thread = 0; thread < kThreadCount; ++thread) {
+        threads.emplace_back([&] {
+            for (size_t i = 0; i < kIterationsPerThread; ++i) {
+                const auto decision =
+                    selector.Select(replicas, local_endpoints);
+                const auto* selected = Selected(decision, replicas);
+                if (!selected || selected->id != 2) {
+                    wrong_decisions.fetch_add(1, std::memory_order_relaxed);
+                }
+            }
+        });
+    }
+    for (auto& thread : threads) thread.join();
+
+    EXPECT_EQ(wrong_decisions.load(std::memory_order_relaxed), 0u);
+    EXPECT_EQ(provider->calls.load(std::memory_order_relaxed),
+              kThreadCount * kIterationsPerThread);
+}
+
+TEST_F(ReplicaSelectorV2Test, ValueReferenceSurvivesVectorReallocation) {
+    auto provider = std::make_shared<AtomicPreferProvider>(2);
+    ReplicaSelector selector(ReplicaSelectionMode::ACTIVE, provider);
+    std::vector<Replica::Descriptor> replicas = {MakeMemory(1, "first"),
+                                                 MakeMemory(2, "second")};
+    const auto decision = selector.Select(replicas, {});
+
+    replicas.reserve(1024);
+
+    ASSERT_NE(ResolveReplica(replicas, decision.selected), nullptr);
+    EXPECT_EQ(ResolveReplica(replicas, decision.selected)->id, 2u);
+}
+
+TEST_F(ReplicaSelectorV2Test, ValueReferenceRejectsReorderAndReplacement) {
+    auto provider = std::make_shared<AtomicPreferProvider>(2);
+    ReplicaSelector selector(ReplicaSelectionMode::ACTIVE, provider);
+    std::vector<Replica::Descriptor> replicas = {MakeMemory(1, "first"),
+                                                 MakeMemory(2, "second")};
+    const auto decision = selector.Select(replicas, {});
+
+    std::swap(replicas[0], replicas[1]);
+    EXPECT_EQ(ResolveReplica(replicas, decision.selected), nullptr);
+
+    replicas[1] = MakeMemory(3, "replacement");
+    EXPECT_EQ(ResolveReplica(replicas, decision.selected), nullptr);
+    EXPECT_EQ(ResolveReplica(replicas, ReplicaRef{99, 2}), nullptr);
+}
+
+TEST_F(ReplicaSelectorV2Test, EmptyAndIncompleteInputsReturnNoSelection) {
+    ReplicaSelector selector(ReplicaSelectionMode::ACTIVE);
+    std::vector<Replica::Descriptor> empty;
+    std::vector<Replica::Descriptor> incomplete = {
+        MakeMemory(1, "remote", ReplicaStatus::PROCESSING)};
+
+    const auto empty_decision = selector.Select(empty, {});
+    const auto incomplete_decision = selector.Select(incomplete, {});
+
+    EXPECT_EQ(Selected(empty_decision, empty), nullptr);
+    EXPECT_EQ(Selected(incomplete_decision, incomplete), nullptr);
+    EXPECT_EQ(empty_decision.outcome,
+              ReplicaSelectionOutcome::NO_REMOTE_MEMORY);
+    EXPECT_EQ(incomplete_decision.outcome,
+              ReplicaSelectionOutcome::NO_REMOTE_MEMORY);
+}
+
+TEST_F(ReplicaSelectorV2Test, EnvironmentV1OptInDoesNotAffectActiveFallback) {
+    const char* env = std::getenv("MC_STORE_REPLICA_SCORING");
+    if (!env || std::string(env) != "1") {
+        GTEST_SKIP() << "covered by the env-enabled CTest process";
+    }
+    ReplicaSelector active_selector(ReplicaSelectionMode::ACTIVE);
+    ReplicaSelector shadow_selector(ReplicaSelectionMode::SHADOW);
+    std::vector<Replica::Descriptor> replicas = {
+        MakeMemory(1, "first", ReplicaStatus::COMPLETE, "tcp"),
+        MakeMemory(2, "second", ReplicaStatus::COMPLETE, "rdma")};
+
+    const auto active = active_selector.Select(replicas, {});
+    const auto shadow = shadow_selector.Select(replicas, {});
+
+    EXPECT_EQ(Selected(active, replicas)->id, 1u);
+    EXPECT_EQ(active.outcome, ReplicaSelectionOutcome::FALLBACK_NO_PROVIDER);
+    EXPECT_EQ(Selected(shadow, replicas)->id, 2u);
+    EXPECT_EQ(Recommended(shadow, replicas)->id, 1u);
+    EXPECT_EQ(shadow.outcome, ReplicaSelectionOutcome::FALLBACK_NO_PROVIDER);
+}
+
+}  // namespace
+}  // namespace mooncake


### PR DESCRIPTION
## Summary

This is the first follow-up to merged #2781. It adds an instance-scoped, context-aware replica selection model that evaluates an atomic batch of replica verdicts without changing existing Store I/O by default.

- add immutable `ReplicaSelector` configuration with `LEGACY`, `SHADOW`, and internal `ACTIVE` semantics
- keep `SHADOW` strictly observational: actual selection remains the V1 incumbent while the V2 recommendation is recorded separately
- introduce typed batch outcomes (`EligibleScore`, `HardVeto`, and `ScoreUnavailable`) and one atomic `ScoreAll()` result per selection
- preserve structural fallback, deterministic unavailable-outcome precedence, and fresh health/circuit-open hard vetoes
- return stable value references (`ReplicaRef`) instead of publishing descriptor pointers
- keep diagnostics opt-in and the default hot path allocation-free for up to 16 candidates

## Safety and scope

This PR intentionally does **not** collect topology/load/health signals, expose ACTIVE mode through public client configuration, or claim Store hit-rate/TTFT/throughput improvement. A cached signal provider and read-path SHADOW instrumentation are the next stage; ACTIVE remains gated on that evidence.

Existing callers retain legacy behavior. SHADOW cannot alter online I/O when a provider returns stale, missing, invalid, unavailable, veto, or throws.

## Validation

Validated on two independent H20 cluster nodes (2x Xeon Platinum 8575C, 192 logical CPUs, 2 TiB RAM, Ubuntu 24.04 container, GCC 13.3), then rebuilt and rerun after rebasing onto the merge commit of #2781.

- Release build: 92/92 targets on node100 and 91/91 on node102
- post-rebase selector suite: 36 passed and 1 environment-only skip on each node
- deterministic regression: 1,000x35 on node100 and 500x35 on node102
- isolated environment regression: 200 runs on node100 and 100 on node102
- concurrency stress: 49.6 million selections across Release, ASan/LSan, and TSan; zero wrong decisions, sanitizer findings, leaks, or data races
- coverage: 99.59% lines (240/241) and 100% branch execution (222/222) for `replica_selector.cpp`
- benchmark: 176 million measured operations across two nodes; all 1,600 diagnostics-off windows had zero heap allocations
- N=16 SHADOW success after the pointer-safety review fix: 226.962 ns/op on node100 and 240.254 ns/op on node102, below the 500 ns/op gate
- LEGACY wrapper overhead versus direct V1 selection remained below 20 ns

The only uncovered statement is a private defensive return for a pointer outside the input span; legal public calls cannot construct that condition.

## Follow-up

The next patch adds a bounded monotonic-TTL cached topology/load/health provider and typed low-cardinality SHADOW metrics. Stable/hotspot/failure/stale/source-down end-to-end experiments remain required before any ACTIVE rollout or performance claim.

Post-review validation for final SHA `416bf0b5`: the defensive pointer lookup now uses only defined equality comparisons (no cross-allocation ordering or subtraction). On each node, V1 ran 500x16 cases and V2 ran 500x37 cases; two-node selector benchmarks added 160 million operations with zero allocations in all 1,600 windows. ASan/LSan and targeted TSan regressions remained clean.