### PR TITLE
[TENT] Reuse and release SHM relocation mappings across threads

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/transport/shm/shm_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/shm/shm_transport.h
@@ -75,6 +75,8 @@ class ShmTransport : public Transport {
     virtual Status freeLocalMemory(void *addr, size_t size);
 
    private:
+    friend class ShmTransportTestPeer;
+
     void startTransfer(ShmTask *task, ShmSubBatch *batch);
 
     void *createSharedMemory(const std::string &path, size_t size);
@@ -89,7 +91,6 @@ class ShmTransport : public Transport {
     std::shared_ptr<ControlService> metadata_;
 
     struct OpenedShmEntry {
-        int shm_fd;
         void *shm_addr;
         uint64_t length;
     };

--- a/mooncake-transfer-engine/tent/include/tent/transport/shm/shm_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/shm/shm_transport.h
@@ -95,9 +95,11 @@ class ShmTransport : public Transport {
         uint64_t length;
     };
 
-    using HashMap =
-        std::unordered_map<SegmentID,
-                           std::unordered_map<uint64_t, OpenedShmEntry>>;
+    using RelocateMap = std::unordered_map<uint64_t, OpenedShmEntry>;
+    using HashMap = std::unordered_map<SegmentID, RelocateMap>;
+
+    static bool tryResolve(const RelocateMap &relocate_map, uint64_t &dest_addr,
+                           uint64_t length);
 
     RWSpinlock relocate_lock_;
     HashMap relocate_map_;

--- a/mooncake-transfer-engine/tent/src/transport/shm/shm_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/shm/shm_transport.cpp
@@ -60,11 +60,11 @@ Status ShmTransport::install(std::string &local_segment_name,
 
 Status ShmTransport::uninstall() {
     if (installed_) {
+        RWSpinlock::WriteGuard guard(relocate_lock_);
         metadata_.reset();
         for (auto &relocate_map : relocate_map_) {
             for (auto &entry : relocate_map.second) {
                 munmap(entry.second.shm_addr, entry.second.length);
-                close(entry.second.shm_fd);
             }
         }
         relocate_map_.clear();
@@ -244,13 +244,26 @@ void *ShmTransport::createSharedMemory(const std::string &path, size_t size) {
 Status ShmTransport::relocateSharedMemoryAddress(uint64_t &dest_addr,
                                                  uint64_t length,
                                                  uint64_t target_id) {
-    thread_local HashMap tl_relocate_map;
-    if (tl_relocate_map.empty()) {
+    {
         RWSpinlock::ReadGuard guard(relocate_lock_);
-        tl_relocate_map = relocate_map_;
+        auto target = relocate_map_.find(target_id);
+        if (target != relocate_map_.end()) {
+            for (auto &entry : target->second) {
+                if (entry.first <= dest_addr &&
+                    dest_addr + length <= entry.first + entry.second.length) {
+                    auto shm_addr = entry.second.shm_addr;
+                    dest_addr = dest_addr - entry.first + ((uint64_t)shm_addr);
+                    return Status::OK();
+                }
+            }
+        }
     }
 
-    auto &relocate_map = tl_relocate_map[target_id];
+    RWSpinlock::WriteGuard guard(relocate_lock_);
+    auto &relocate_map = relocate_map_[target_id];
+
+    // Another thread may have published this mapping while the writer lock was
+    // pending. Recheck before opening and mapping the same shared-memory file.
     for (auto &entry : relocate_map) {
         if (entry.first <= dest_addr &&
             dest_addr + length <= entry.first + entry.second.length) {
@@ -259,8 +272,6 @@ Status ShmTransport::relocateSharedMemoryAddress(uint64_t &dest_addr,
             return Status::OK();
         }
     }
-
-    RWSpinlock::WriteGuard guard(relocate_lock_);
 
     BufferDesc *buffer;
     // Owning reference: `buffer` is used after the lambda returns.
@@ -301,12 +312,12 @@ Status ShmTransport::relocateSharedMemoryAddress(uint64_t &dest_addr,
                 return Status::InternalError(
                     "Failed to map shared memory " LOC_MARK);
             }
+            close(shm_fd);
             LOG(INFO) << "Original shared memory: " << (void *)buffer->addr
                       << "--" << (void *)(buffer->addr + buffer->length);
             LOG(INFO) << "Remapped shared memory: " << (void *)shm_addr << "--"
                       << (void *)((uintptr_t)shm_addr + buffer->length);
             OpenedShmEntry shm_entry;
-            shm_entry.shm_fd = shm_fd;
             shm_entry.shm_addr = shm_addr;
             shm_entry.length = buffer->length;
             relocate_map[buffer->addr] = shm_entry;

--- a/mooncake-transfer-engine/tent/src/transport/shm/shm_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/shm/shm_transport.cpp
@@ -260,6 +260,10 @@ Status ShmTransport::relocateSharedMemoryAddress(uint64_t &dest_addr,
     }
 
     RWSpinlock::WriteGuard guard(relocate_lock_);
+    if (!metadata_) {
+        return Status::InvalidArgument(
+            "SHM transport is not installed" LOC_MARK);
+    }
     auto &relocate_map = relocate_map_[target_id];
 
     // Another thread may have published this mapping while the writer lock was

--- a/mooncake-transfer-engine/tent/src/transport/shm/shm_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/shm/shm_transport.cpp
@@ -241,22 +241,28 @@ void *ShmTransport::createSharedMemory(const std::string &path, size_t size) {
     return mapped_addr;
 }
 
+bool ShmTransport::tryResolve(const RelocateMap &relocate_map,
+                              uint64_t &dest_addr, uint64_t length) {
+    for (const auto &entry : relocate_map) {
+        if (entry.first <= dest_addr &&
+            dest_addr + length <= entry.first + entry.second.length) {
+            dest_addr = dest_addr - entry.first +
+                        reinterpret_cast<uint64_t>(entry.second.shm_addr);
+            return true;
+        }
+    }
+    return false;
+}
+
 Status ShmTransport::relocateSharedMemoryAddress(uint64_t &dest_addr,
                                                  uint64_t length,
                                                  uint64_t target_id) {
     {
         RWSpinlock::ReadGuard guard(relocate_lock_);
         auto target = relocate_map_.find(target_id);
-        if (target != relocate_map_.end()) {
-            for (auto &entry : target->second) {
-                if (entry.first <= dest_addr &&
-                    dest_addr + length <= entry.first + entry.second.length) {
-                    auto shm_addr = entry.second.shm_addr;
-                    dest_addr = dest_addr - entry.first + ((uint64_t)shm_addr);
-                    return Status::OK();
-                }
-            }
-        }
+        if (target != relocate_map_.end() &&
+            tryResolve(target->second, dest_addr, length))
+            return Status::OK();
     }
 
     RWSpinlock::WriteGuard guard(relocate_lock_);
@@ -264,18 +270,12 @@ Status ShmTransport::relocateSharedMemoryAddress(uint64_t &dest_addr,
         return Status::InvalidArgument(
             "SHM transport is not installed" LOC_MARK);
     }
-    auto &relocate_map = relocate_map_[target_id];
-
     // Another thread may have published this mapping while the writer lock was
     // pending. Recheck before opening and mapping the same shared-memory file.
-    for (auto &entry : relocate_map) {
-        if (entry.first <= dest_addr &&
-            dest_addr + length <= entry.first + entry.second.length) {
-            auto shm_addr = entry.second.shm_addr;
-            dest_addr = dest_addr - entry.first + ((uint64_t)shm_addr);
-            return Status::OK();
-        }
-    }
+    auto target = relocate_map_.find(target_id);
+    if (target != relocate_map_.end() &&
+        tryResolve(target->second, dest_addr, length))
+        return Status::OK();
 
     BufferDesc *buffer;
     // Owning reference: `buffer` is used after the lambda returns.
@@ -290,8 +290,17 @@ Status ShmTransport::relocateSharedMemoryAddress(uint64_t &dest_addr,
             return Status::OK();
         }));
 
-    if (!relocate_map.count(buffer->addr)) {
-        void *shm_addr = nullptr;
+    void *shm_addr = nullptr;
+    bool mapping_found = false;
+    if (target != relocate_map_.end()) {
+        auto mapping = target->second.find(buffer->addr);
+        if (mapping != target->second.end()) {
+            shm_addr = mapping->second.shm_addr;
+            mapping_found = true;
+        }
+    }
+
+    if (!mapping_found) {
         LocationParser location(buffer->location);
         if (location.type() == "cuda") {
             return Status::NotImplemented(
@@ -324,12 +333,11 @@ Status ShmTransport::relocateSharedMemoryAddress(uint64_t &dest_addr,
             OpenedShmEntry shm_entry;
             shm_entry.shm_addr = shm_addr;
             shm_entry.length = buffer->length;
-            relocate_map[buffer->addr] = shm_entry;
+            relocate_map_[target_id][buffer->addr] = shm_entry;
         }
     }
 
-    auto shm_addr = relocate_map[buffer->addr].shm_addr;
-    dest_addr = dest_addr - buffer->addr + ((uint64_t)shm_addr);
+    dest_addr = dest_addr - buffer->addr + reinterpret_cast<uint64_t>(shm_addr);
     return Status::OK();
 }
 

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -111,6 +111,13 @@ target_include_directories(tent_tcp_transport_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME tent_tcp_transport_test COMMAND tent_tcp_transport_test)
 
+add_executable(tent_shm_transport_test shm_transport_test.cpp)
+target_link_libraries(tent_shm_transport_test PRIVATE gtest gtest_main
+                                                      tent_link_group)
+target_include_directories(tent_shm_transport_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+add_test(NAME tent_shm_transport_test COMMAND tent_shm_transport_test)
+
 add_executable(tent_failover_test failover_test.cpp)
 target_link_libraries(tent_failover_test PRIVATE gtest gtest_main
                                                  tent_link_group)
@@ -241,7 +248,8 @@ add_test(NAME tent_runtime_queue_dispatch_test
 # Causal chain stage decomposition: validates that dispatch_time and post_time
 # timestamps are populated on both queue and direct-commit paths.
 add_executable(causal_chain_test causal_chain_test.cpp)
-target_link_libraries(causal_chain_test PRIVATE gtest gtest_main tent_link_group)
+target_link_libraries(causal_chain_test PRIVATE gtest gtest_main
+                                                tent_link_group)
 if(TARGET asio_shared)
   target_link_libraries(causal_chain_test PRIVATE asio_shared)
 endif()

--- a/mooncake-transfer-engine/tent/tests/shm_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/shm_transport_test.cpp
@@ -141,6 +141,12 @@ TEST(ShmTransportTest, SharesAndReleasesRelocationAcrossThreads) {
     errno = 0;
     EXPECT_EQ(mincore(mapped, page_size, &residency), -1);
     EXPECT_EQ(errno, ENOMEM);
+
+    uint64_t address_after_uninstall = kRemoteAddress;
+    EXPECT_TRUE(ShmTransportTestPeer::relocate(transport,
+                                               address_after_uninstall,
+                                               page_size, LOCAL_SEGMENT_ID)
+                    .IsInvalidArgument());
 }
 
 }  // namespace

--- a/mooncake-transfer-engine/tent/tests/shm_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/shm_transport_test.cpp
@@ -1,0 +1,148 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <cerrno>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "tent/common/config.h"
+#include "tent/runtime/control_plane.h"
+#include "tent/transport/shm/shm_transport.h"
+
+namespace mooncake {
+namespace tent {
+
+class ShmTransportTestPeer {
+   public:
+    static Status relocate(ShmTransport& transport, uint64_t& address,
+                           uint64_t length, SegmentID target_id) {
+        return transport.relocateSharedMemoryAddress(address, length,
+                                                     target_id);
+    }
+
+    static size_t mappingCount(ShmTransport& transport, SegmentID target_id) {
+        RWSpinlock::ReadGuard guard(transport.relocate_lock_);
+        auto it = transport.relocate_map_.find(target_id);
+        return it == transport.relocate_map_.end() ? 0 : it->second.size();
+    }
+};
+
+namespace {
+
+class ScopedShmFile {
+   public:
+    explicit ScopedShmFile(size_t length)
+        : name_("/mooncake_tent_shm_test_" + std::to_string(getpid())),
+          length_(length) {
+        shm_unlink(name_.c_str());
+        fd_ = shm_open(name_.c_str(), O_CREAT | O_EXCL | O_RDWR, 0600);
+        EXPECT_GE(fd_, 0);
+        if (fd_ >= 0) EXPECT_EQ(ftruncate(fd_, length_), 0);
+    }
+
+    ~ScopedShmFile() {
+        if (fd_ >= 0) close(fd_);
+        shm_unlink(name_.c_str());
+    }
+
+    const std::string& name() const { return name_; }
+
+   private:
+    std::string name_;
+    size_t length_;
+    int fd_{-1};
+};
+
+TEST(ShmTransportTest, SharesAndReleasesRelocationAcrossThreads) {
+    const size_t page_size = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+    constexpr uint64_t kRemoteAddress = 0x10000000;
+    constexpr size_t kThreadCount = 8;
+    ScopedShmFile shm_file(page_size);
+
+    auto metadata = std::make_shared<ControlService>("p2p", "", nullptr);
+    ASSERT_TRUE(metadata->segmentManager()
+                    .updateLocal([&](SegmentDesc& segment) -> Status {
+                        segment.name = "shm_test_segment";
+                        segment.machine_id = "shm_test_machine";
+                        segment.type = SegmentType::Memory;
+                        auto& memory =
+                            std::get<MemorySegmentDesc>(segment.detail);
+                        BufferDesc buffer;
+                        buffer.addr = kRemoteAddress;
+                        buffer.length = page_size;
+                        buffer.location = "cpu:0";
+                        buffer.shm_path = shm_file.name();
+                        memory.buffers.push_back(std::move(buffer));
+                        return Status::OK();
+                    })
+                    .ok());
+
+    ShmTransport transport;
+    std::string local_segment_name = "shm_test_segment";
+    ASSERT_TRUE(transport
+                    .install(local_segment_name, metadata, nullptr,
+                             std::make_shared<Config>())
+                    .ok());
+
+    std::atomic<size_t> ready{0};
+    std::atomic<bool> start{false};
+    std::vector<uint64_t> relocated(kThreadCount, kRemoteAddress);
+    std::vector<uint8_t> succeeded(kThreadCount, 0);
+    std::vector<std::thread> threads;
+    threads.reserve(kThreadCount);
+    for (size_t i = 0; i < kThreadCount; ++i) {
+        threads.emplace_back([&, i] {
+            ready.fetch_add(1, std::memory_order_release);
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            succeeded[i] =
+                ShmTransportTestPeer::relocate(transport, relocated[i],
+                                               page_size, LOCAL_SEGMENT_ID)
+                    .ok();
+        });
+    }
+    while (ready.load(std::memory_order_acquire) != kThreadCount) {
+        std::this_thread::yield();
+    }
+    start.store(true, std::memory_order_release);
+    for (auto& thread : threads) thread.join();
+
+    for (uint8_t success : succeeded) EXPECT_TRUE(success);
+    for (uint64_t address : relocated) EXPECT_EQ(address, relocated.front());
+    EXPECT_EQ(ShmTransportTestPeer::mappingCount(transport, LOCAL_SEGMENT_ID),
+              1u);
+
+    auto* mapped = reinterpret_cast<void*>(relocated.front());
+    ASSERT_TRUE(transport.uninstall().ok());
+    unsigned char residency = 0;
+    errno = 0;
+    EXPECT_EQ(mincore(mapped, page_size, &residency), -1);
+    EXPECT_EQ(errno, ENOMEM);
+}
+
+}  // namespace
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/tests/shm_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/shm_transport_test.cpp
@@ -47,6 +47,12 @@ class ShmTransportTestPeer {
         auto it = transport.relocate_map_.find(target_id);
         return it == transport.relocate_map_.end() ? 0 : it->second.size();
     }
+
+    static bool hasTarget(ShmTransport& transport, SegmentID target_id) {
+        RWSpinlock::ReadGuard guard(transport.relocate_lock_);
+        return transport.relocate_map_.find(target_id) !=
+               transport.relocate_map_.end();
+    }
 };
 
 namespace {
@@ -105,6 +111,12 @@ TEST(ShmTransportTest, SharesAndReleasesRelocationAcrossThreads) {
                     .install(local_segment_name, metadata, nullptr,
                              std::make_shared<Config>())
                     .ok());
+
+    uint64_t missing_address = kRemoteAddress + page_size;
+    EXPECT_TRUE(ShmTransportTestPeer::relocate(transport, missing_address,
+                                               page_size, LOCAL_SEGMENT_ID)
+                    .IsNeedsRefreshCache());
+    EXPECT_FALSE(ShmTransportTestPeer::hasTarget(transport, LOCAL_SEGMENT_ID));
 
     std::atomic<size_t> ready{0};
     std::atomic<bool> start{false};


### PR DESCRIPTION
Fixes #2888

## Description

`ShmTransport::relocateSharedMemoryAddress` stored newly opened mappings in a function-local thread-local map. The transport member map was copied into that cache but never updated when new mappings were created.

Consequently, each submission thread could independently open and map the same shared-memory buffer, while `uninstall()` could not see or release those mappings.

This change makes the transport member map the single mapping owner:

- lookups use the existing read lock;
- misses acquire the write lock and recheck before creating a mapping;
- both lookup paths use the same address-resolution helper;
- failed metadata, open, and mapping operations do not publish empty cache buckets;
- relocation rejects calls after `uninstall()` while holding the owner lock;
- concurrent threads reuse the mapping published by the first thread;
- file descriptors close immediately after a successful `mmap`;
- `uninstall()` unmaps every published region under the owner lock;
- no relocation ownership remains in thread-local state.

A regression test synchronizes eight threads relocating the same buffer and checks that they receive one shared mapping owned by the transport. It also checks that a failed lookup does not create a target cache entry, `uninstall()` releases the mapping, and subsequent relocation is rejected.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

**Validation commands:**

```bash
pre-commit run --files $(git diff --name-only origin/main..HEAD)
git diff --check origin/main..HEAD
```

**Results:**

- [x] All configured pre-commit hooks pass on the touched files
- [x] clang-format 20 passes
- [x] CMake formatting passes
- [x] Regression coverage was added
- [x] Structured branch review reports no actionable findings

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on all files touched by this change, and all hooks pass
- [x] Documentation is not applicable because the public API is unchanged
- [x] I have added tests to prove the change is effective
- [x] An RFC is not required because the change is under 500 LOC

## AI Assistance Disclosure

- [x] AI tools were used

Codex assisted with source tracing, mapping-lifetime research, implementation, regression-test design, formatting, and structured review. The submitter is responsible for reviewing and understanding every changed line.
