### PR TITLE
[TE] Reject empty RDMA completion resources during context setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
     hooks:
       - id: codespell
         exclude: '^(extern/|FAST25-release/)'
-        args: ['--ignore-words-list=te,mooncake,KVCache,cann']
+        args: ['--ignore-words-list=te,mooncake,KVCache,cann,hsa']
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v20.1.8

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -181,6 +181,13 @@ RdmaContext::~RdmaContext() {
 int RdmaContext::construct(size_t num_cq_list, size_t num_comp_channels,
                            uint8_t port, int gid_index, size_t max_cqe,
                            int max_endpoints) {
+    if (num_cq_list == 0 || num_comp_channels == 0) {
+        LOG(ERROR) << "Invalid RDMA completion configuration for device "
+                   << device_name_ << ": num_cq_list=" << num_cq_list
+                   << ", num_comp_channels=" << num_comp_channels;
+        return ERR_INVALID_ARGUMENT;
+    }
+
     // Create endpoint store based on configuration
     auto &config = globalConfig();
     switch (config.endpoint_store_type) {
@@ -199,6 +206,12 @@ int RdmaContext::construct(size_t num_cq_list, size_t num_comp_channels,
     if (openRdmaDevice(device_name_, port, gid_index)) {
         LOG(ERROR) << "Failed to open device " << device_name_ << " on port "
                    << port << " with GID " << gid_index;
+        return ERR_CONTEXT;
+    }
+
+    if (context_->num_comp_vectors <= 0) {
+        LOG(ERROR) << "RDMA device " << device_name_
+                   << " exposes no completion vectors";
         return ERR_CONTEXT;
     }
 

--- a/mooncake-transfer-engine/tests/rdma_context_reprobe_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_context_reprobe_test.cpp
@@ -19,6 +19,10 @@
 #include <memory>
 #include <string>
 
+#ifdef __linux__
+#include <limits>
+#endif
+
 #include "common.h"
 #include "error.h"
 #include "transfer_metadata.h"
@@ -38,6 +42,105 @@
 #endif
 
 using namespace mooncake;
+
+#ifdef __linux__
+namespace {
+
+struct FakeVerbsDevice {
+    bool enabled = false;
+    ibv_device device = {};
+    ibv_device *device_list[2] = {&device, nullptr};
+    ibv_context context = {};
+    size_t alloc_pd_calls = 0;
+};
+
+FakeVerbsDevice fake_verbs;
+
+class FakeVerbsDeviceScope {
+   public:
+    explicit FakeVerbsDeviceScope(int num_comp_vectors) {
+        fake_verbs.enabled = true;
+        fake_verbs.context = {};
+        fake_verbs.context.num_comp_vectors = num_comp_vectors;
+        fake_verbs.alloc_pd_calls = 0;
+    }
+
+    ~FakeVerbsDeviceScope() { fake_verbs.enabled = false; }
+
+    size_t allocPdCalls() const { return fake_verbs.alloc_pd_calls; }
+};
+
+}  // namespace
+
+#undef ibv_query_port
+
+// Interpose the libibverbs boundary for this test binary so construct() can
+// exercise device validation without RDMA hardware.
+extern "C" {
+
+ibv_device **ibv_get_device_list(int *num_devices) {
+    if (!fake_verbs.enabled) {
+        *num_devices = 0;
+        return nullptr;
+    }
+    *num_devices = 1;
+    return fake_verbs.device_list;
+}
+
+void ibv_free_device_list(ibv_device **) {}
+
+const char *ibv_get_device_name(ibv_device *device) {
+    if (fake_verbs.enabled && device == &fake_verbs.device)
+        return "nonexistent-device";
+    return "";
+}
+
+ibv_context *ibv_open_device(ibv_device *device) {
+    if (fake_verbs.enabled && device == &fake_verbs.device)
+        return &fake_verbs.context;
+    return nullptr;
+}
+
+int ibv_query_port(ibv_context *context, uint8_t,
+                   _compat_ibv_port_attr *compat_port_attr) {
+    if (!fake_verbs.enabled || context != &fake_verbs.context) return EINVAL;
+    auto *port_attr = reinterpret_cast<ibv_port_attr *>(compat_port_attr);
+    *port_attr = {};
+    port_attr->state = IBV_PORT_ACTIVE;
+    port_attr->lid = 1;
+    port_attr->active_mtu = IBV_MTU_4096;
+    return 0;
+}
+
+int ibv_query_device(ibv_context *context, ibv_device_attr *device_attr) {
+    if (!fake_verbs.enabled || context != &fake_verbs.context) return EINVAL;
+    *device_attr = {};
+    device_attr->max_qp = std::numeric_limits<int>::max();
+    device_attr->max_cq = std::numeric_limits<int>::max();
+    device_attr->max_qp_wr = std::numeric_limits<int>::max();
+    device_attr->max_sge = std::numeric_limits<int>::max();
+    device_attr->max_cqe = std::numeric_limits<int>::max();
+    device_attr->max_mr_size = std::numeric_limits<uint64_t>::max();
+    return 0;
+}
+
+int ibv_query_gid(ibv_context *context, uint8_t, int, ibv_gid *gid) {
+    if (!fake_verbs.enabled || context != &fake_verbs.context) return EINVAL;
+    *gid = {};
+    gid->raw[15] = 1;
+    return 0;
+}
+
+ibv_pd *ibv_alloc_pd(ibv_context *context) {
+    if (!fake_verbs.enabled || context != &fake_verbs.context) return nullptr;
+    ++fake_verbs.alloc_pd_calls;
+    return nullptr;
+}
+
+int ibv_close_device(ibv_context *) { return 0; }
+
+}  // extern "C"
+#endif  // __linux__
 
 namespace mooncake {
 
@@ -105,6 +208,23 @@ TEST_F(RdmaContextConstructionTest, RejectsZeroCompletionChannelsBeforeSetup) {
                                   /*num_comp_channels=*/0),
               ERR_INVALID_ARGUMENT);
     EXPECT_FALSE(RdmaContextTestPeer::hasEndpointStore(*context_));
+}
+
+TEST_F(RdmaContextConstructionTest,
+       RejectsDeviceWithoutCompletionVectorsBeforeAllocatingResources) {
+#ifdef __linux__
+    FakeVerbsDeviceScope fake_device(/*num_comp_vectors=*/0);
+
+    EXPECT_EQ(context_->construct(/*num_cq_list=*/1,
+                                  /*num_comp_channels=*/1,
+                                  /*port=*/1,
+                                  /*gid_index=*/0),
+              ERR_CONTEXT);
+    EXPECT_EQ(fake_device.allocPdCalls(), 0);
+    RdmaContextTestPeer::disableContextForTeardown(*context_);
+#else
+    GTEST_SKIP() << "Requires Linux libibverbs symbol interposition";
+#endif
 }
 
 ibv_gid makeGid(const std::array<uint8_t, 16> &bytes) {

--- a/mooncake-transfer-engine/tests/rdma_context_reprobe_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_context_reprobe_test.cpp
@@ -53,6 +53,10 @@ class RdmaTransportTestPeer {
 
 class RdmaContextTestPeer {
    public:
+    static bool hasEndpointStore(const RdmaContext &context) {
+        return context.endpoint_store_ != nullptr;
+    }
+
     static void seedAutoGidState(RdmaContext &context, ibv_context *verbs_ctx,
                                  uint8_t port, uint16_t lid, const ibv_gid &gid,
                                  int gid_index) {
@@ -72,6 +76,36 @@ class RdmaContextTestPeer {
 }  // namespace mooncake
 
 namespace {
+
+class RdmaContextConstructionTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        // RdmaTransport teardown requires metadata initialized by install().
+        // These tests only need the constructor reference, so match the
+        // existing uninstalled-transport test setup below.
+        transport_ = new RdmaTransport();
+        MC_LSAN_IGNORE_OBJECT(transport_);
+        context_ =
+            std::make_unique<RdmaContext>(*transport_, "nonexistent-device");
+    }
+
+    RdmaTransport *transport_ = nullptr;
+    std::unique_ptr<RdmaContext> context_;
+};
+
+TEST_F(RdmaContextConstructionTest, RejectsZeroCompletionQueuesBeforeSetup) {
+    EXPECT_EQ(context_->construct(/*num_cq_list=*/0,
+                                  /*num_comp_channels=*/1),
+              ERR_INVALID_ARGUMENT);
+    EXPECT_FALSE(RdmaContextTestPeer::hasEndpointStore(*context_));
+}
+
+TEST_F(RdmaContextConstructionTest, RejectsZeroCompletionChannelsBeforeSetup) {
+    EXPECT_EQ(context_->construct(/*num_cq_list=*/1,
+                                  /*num_comp_channels=*/0),
+              ERR_INVALID_ARGUMENT);
+    EXPECT_FALSE(RdmaContextTestPeer::hasEndpointStore(*context_));
+}
 
 ibv_gid makeGid(const std::array<uint8_t, 16> &bytes) {
     ibv_gid gid = {};


### PR DESCRIPTION
Fixes #2889

## Description

`RdmaContext::construct` accepted zero completion queues or completion channels and continued into resource setup.

A context constructed with an empty CQ list could later reach `RdmaContext::cq()`, whose round-robin selection performs modulo by the CQ-list size. An empty completion-channel list has the same invalid precondition, while a device reporting no completion vectors cannot provide a valid completion vector for CQ creation.

This change validates the completion topology at its owning boundary:

- reject zero CQ or completion-channel counts before allocating resources;
- reject an opened verbs context with no completion vectors;
- preserve existing nonzero device-limit clamping;
- propagate failure through the existing rail-disable path;
- prevent endpoints from observing a partially initialized context.

The regression cases verify that zero requested resources return `ERR_INVALID_ARGUMENT` before an endpoint store is allocated. A hardware-independent libibverbs fake also verifies that a device with zero completion vectors returns `ERR_CONTEXT` before protection-domain allocation.

The official HSA acronym is added to the codespell ignore list because the RDMA source uses HSA headers and APIs for HIP DMA-BUF export.

## Suggested Review Order

1. Review the validation in `rdma_context.cpp`.
2. Review the construction regressions and test-only libibverbs boundary in `rdma_context_reprobe_test.cpp`.
3. Review the codespell allow-list update.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

**Test commands:**

```bash
cmake --build build --target rdma_context_reprobe_test -j4
./build/tests/rdma_context_reprobe_test --gtest_color=no
pre-commit run --files $(git diff --name-only origin/main..HEAD)
git diff --check origin/main..HEAD
```

**Results:**

- [x] Unit tests pass: 4/4
- [x] All three regression cases fail against the previous implementation for the intended reason
- [x] All configured pre-commit hooks pass on the touched files
- [x] clang-format 20 passes
- [x] Structured branch review reports no actionable findings

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on all files touched by this change, and all hooks pass
- [x] Documentation is not applicable because the public API is unchanged
- [x] I have added tests to prove the change is effective
- [x] An RFC is not required because the change is under 500 LOC

## AI Assistance Disclosure

- [x] AI tools were used

Codex assisted with call-path analysis, libibverbs contract research, implementation, regression tests, formatting, and structured review. The submitter is responsible for reviewing and understanding every changed line.
