### PR TITLE
[TE] Reject unsupported NVMe-oF task batches and correlate cuFile completions

### DIFF
--- a/mooncake-transfer-engine/include/transport/nvmeof_transport/cufile_desc_pool.h
+++ b/mooncake-transfer-engine/include/transport/nvmeof_transport/cufile_desc_pool.h
@@ -27,6 +27,8 @@
 
 namespace mooncake {
 
+class CUFileDescPoolTestPeer;
+
 // Wrapper for reusable CUfileBatchHandle_t
 // cuFileBatchIOSetUp is expensive, so we reuse handles (similar to GDS
 // transport)
@@ -40,10 +42,16 @@ struct BatchHandle {
 struct CUFileBatchDesc {
     BatchHandle* batch_handle;  // Pointer to reusable handle from pool
     std::vector<CUfileIOParams_t> io_params;
+    // Completion events returned by cuFile are correlated by cookie and cached
+    // by submission index. cuFileBatchIOGetStatus only returns completed I/Os,
+    // so its output cannot be treated as a positional status snapshot.
     std::vector<CUfileIOEvents_t> io_events;
+    std::vector<CUfileIOEvents_t> polled_events;
 };
 
 class CUFileDescPool {
+    friend class CUFileDescPoolTestPeer;
+
    public:
     explicit CUFileDescPool(size_t max_batch_size = 128);
     ~CUFileDescPool();
@@ -75,6 +83,9 @@ class CUFileDescPool {
     CUFileBatchDesc* getDesc(int idx);
 
    private:
+    static bool cachePolledEvent(std::vector<CUfileIOEvents_t>& io_events,
+                                 const CUfileIOEvents_t& event);
+
     static const size_t MAX_NR_DESC = 256;  // Max number of descriptors
     size_t max_batch_size_;
 

--- a/mooncake-transfer-engine/include/transport/nvmeof_transport/nvmeof_transport.h
+++ b/mooncake-transfer-engine/include/transport/nvmeof_transport/nvmeof_transport.h
@@ -30,6 +30,8 @@
 
 namespace mooncake {
 
+class NVMeoFTransportTestPeer;
+
 struct NVMeoFBatchDesc {
     int desc_idx_;
     std::vector<TransferStatus> transfer_status;
@@ -37,6 +39,8 @@ struct NVMeoFBatchDesc {
 };
 
 class NVMeoFTransport : public Transport {
+    friend class NVMeoFTransportTestPeer;
+
    public:
     NVMeoFTransport();
 
@@ -60,6 +64,11 @@ class NVMeoFTransport : public Transport {
                         TransferTask &task, const char *file_path);
 
    private:
+    explicit NVMeoFTransport(std::shared_ptr<CUFileDescPool> desc_pool);
+
+    static TransferStatus aggregateTransferStatus(
+        const std::vector<TransferStatus> &slice_statuses, bool &is_finished);
+
     void startTransfer(Slice *slice);
 
    private:

--- a/mooncake-transfer-engine/src/transport/nvmeof_transport/cufile_desc_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/nvmeof_transport/cufile_desc_pool.cpp
@@ -110,7 +110,9 @@ int CUFileDescPool::allocCUfileDesc(size_t batch_size) {
         desc->batch_handle = batch_handle;
         desc->io_params.clear();
         desc->io_params.reserve(max_batch_size_);
-        desc->io_events.resize(max_batch_size_);
+        desc->io_events.clear();
+        desc->io_events.reserve(max_batch_size_);
+        desc->polled_events.resize(max_batch_size_);
 
         descs_[idx] = desc;
         return idx;
@@ -138,7 +140,13 @@ int CUFileDescPool::pushParams(int idx, const CUfileIOParams_t& io_params) {
         return -1;
     }
 
-    desc->io_params.push_back(io_params);
+    CUfileIOParams_t params = io_params;
+    const size_t slice_id = desc->io_params.size();
+    params.cookie =
+        reinterpret_cast<void*>(static_cast<uintptr_t>(slice_id + 1));
+    desc->io_params.push_back(params);
+    desc->io_events.push_back(CUfileIOEvents_t{
+        .cookie = params.cookie, .status = CUFILE_WAITING, .ret = 0});
     return 0;
 }
 
@@ -184,9 +192,26 @@ CUfileIOEvents_t CUFileDescPool::getTransferStatus(int idx, int slice_id) {
 
     unsigned nr = desc->io_params.size();
     CUFILE_CHECK(cuFileBatchIOGetStatus(desc->batch_handle->handle, 0, &nr,
-                                        desc->io_events.data(), nullptr));
+                                        desc->polled_events.data(), nullptr));
+
+    for (unsigned i = 0; i < nr; ++i) {
+        const auto& event = desc->polled_events[i];
+        if (!cachePolledEvent(desc->io_events, event)) {
+            LOG(ERROR) << "Invalid completion cookie "
+                       << reinterpret_cast<uintptr_t>(event.cookie)
+                       << " for descriptor " << idx;
+        }
+    }
 
     return desc->io_events[slice_id];
+}
+
+bool CUFileDescPool::cachePolledEvent(std::vector<CUfileIOEvents_t>& io_events,
+                                      const CUfileIOEvents_t& event) {
+    const uintptr_t cookie = reinterpret_cast<uintptr_t>(event.cookie);
+    if (cookie == 0 || cookie > io_events.size()) return false;
+    io_events[cookie - 1] = event;
+    return true;
 }
 
 int CUFileDescPool::getSliceNum(int idx) {

--- a/mooncake-transfer-engine/src/transport/nvmeof_transport/cufile_desc_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/nvmeof_transport/cufile_desc_pool.cpp
@@ -135,7 +135,7 @@ int CUFileDescPool::pushParams(int idx, const CUfileIOParams_t& io_params) {
     }
 
     auto* desc = descs_[idx];
-    if (desc->io_params.size() >= desc->io_params.capacity()) {
+    if (desc->io_params.size() >= max_batch_size_) {
         LOG(ERROR) << "Descriptor " << idx << " is full";
         return -1;
     }
@@ -191,6 +191,13 @@ CUfileIOEvents_t CUFileDescPool::getTransferStatus(int idx, int slice_id) {
     }
 
     unsigned nr = desc->io_params.size();
+    if (desc->polled_events.size() < nr) {
+        LOG(ERROR) << "Completion buffer is too small for descriptor " << idx;
+        CUfileIOEvents_t event;
+        event.status = CUFILE_FAILED;
+        event.ret = -1;
+        return event;
+    }
     CUFILE_CHECK(cuFileBatchIOGetStatus(desc->batch_handle->handle, 0, &nr,
                                         desc->polled_events.data(), nullptr));
 

--- a/mooncake-transfer-engine/src/transport/nvmeof_transport/nvmeof_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/nvmeof_transport/nvmeof_transport.cpp
@@ -39,6 +39,9 @@ NVMeoFTransport::NVMeoFTransport() {
     desc_pool_ = std::make_shared<CUFileDescPool>();
 }
 
+NVMeoFTransport::NVMeoFTransport(std::shared_ptr<CUFileDescPool> desc_pool)
+    : desc_pool_(std::move(desc_pool)) {}
+
 NVMeoFTransport::~NVMeoFTransport() {}
 
 Transport::TransferStatusEnum from_cufile_transfer_status(
@@ -76,38 +79,107 @@ NVMeoFTransport::BatchID NVMeoFTransport::allocateBatchID(size_t batch_size) {
 
 Status NVMeoFTransport::getTransferStatus(BatchID batch_id, size_t task_id,
                                           TransferStatus &status) {
+    if (batch_id == 0) {
+        return Status::InvalidArgument("NVMeoFTransport: Invalid batch ID");
+    }
     auto &batch_desc = *((BatchDesc *)(batch_id));
+    if (task_id >= batch_desc.task_list.size()) {
+        return Status::InvalidArgument("NVMeoFTransport: Task ID out of range");
+    }
+    if (batch_desc.context == nullptr) {
+        return Status::InvalidArgument(
+            "NVMeoFTransport: Batch was not allocated by this transport");
+    }
     auto &task = batch_desc.task_list[task_id];
     auto &nvmeof_desc = *((NVMeoFBatchDesc *)(batch_desc.context));
-    // LOG(DEBUG) << "get t n " << nr;
-    // 1. get task -> id map
-    TransferStatus transfer_status = {.s = Transport::PENDING,
-                                      .transferred_bytes = 0};
-    auto [slice_id, slice_num] = nvmeof_desc.task_to_slices[task_id];
-    for (size_t i = slice_id; i < slice_id + slice_num; ++i) {
-        // LOG(INFO) << "task " << task_id << " i " << i << " upper bound " <<
-        // slice_num;
-        auto event = desc_pool_->getTransferStatus(nvmeof_desc.desc_idx_, i);
-        transfer_status.s = from_cufile_transfer_status(event.status);
-        // TODO(FIXME): what to do if multi slices have different status?
-        if (transfer_status.s == COMPLETED) {
-            transfer_status.transferred_bytes += event.ret;
-        } else {
-            break;
-        }
+    if (task_id >= nvmeof_desc.task_to_slices.size()) {
+        return Status::InvalidArgument(
+            "NVMeoFTransport: Task has no submitted slices");
     }
-    if (transfer_status.s == COMPLETED) {
+
+    auto [slice_id, slice_num] = nvmeof_desc.task_to_slices[task_id];
+    std::vector<TransferStatus> slice_statuses;
+    slice_statuses.reserve(slice_num);
+    for (size_t i = slice_id; i < slice_id + slice_num; ++i) {
+        auto event = desc_pool_->getTransferStatus(nvmeof_desc.desc_idx_, i);
+        auto slice_status = from_cufile_transfer_status(event.status);
+        slice_statuses.push_back(TransferStatus{
+            .s = slice_status,
+            .transferred_bytes = slice_status == COMPLETED ? event.ret : 0});
+    }
+
+    bool is_finished = false;
+    status = aggregateTransferStatus(slice_statuses, is_finished);
+    if (is_finished) {
         task.is_finished = true;
     }
-    status = transfer_status;
     return Status::OK();
 }
 
-// Dummy implement for solving build issues, WIP
 Status NVMeoFTransport::submitTransferTask(
     const std::vector<TransferTask *> &task_list) {
-    /* TBD */
-    return Status::OK();
+    // MultiTransport owns these generic BatchDesc objects, so this transport
+    // cannot attach or reclaim the NVMe-specific descriptor required by
+    // cuFile. No asynchronous work was started; make the tasks releasable.
+    for (auto *task : task_list) {
+        if (task != nullptr) task->is_finished = true;
+    }
+    return Status::NotImplemented(
+        "NVMeoFTransport does not support MultiTransport batches");
+}
+
+Transport::TransferStatus NVMeoFTransport::aggregateTransferStatus(
+    const std::vector<TransferStatus> &slice_statuses, bool &is_finished) {
+    TransferStatus result = {.s = COMPLETED, .transferred_bytes = 0};
+    is_finished = true;
+    bool has_pending = false;
+
+    // Terminal failures use a fixed precedence so the result does not depend
+    // on the order in which cuFile reports completions.
+    int failure_priority = 0;
+    for (const auto &slice_status : slice_statuses) {
+        switch (slice_status.s) {
+            case COMPLETED:
+                result.transferred_bytes += slice_status.transferred_bytes;
+                break;
+            case WAITING:
+                is_finished = false;
+                break;
+            case PENDING:
+                has_pending = true;
+                is_finished = false;
+                break;
+            case INVALID:
+                if (failure_priority < 1) {
+                    result.s = INVALID;
+                    failure_priority = 1;
+                }
+                break;
+            case CANCELED:
+                if (failure_priority < 2) {
+                    result.s = CANCELED;
+                    failure_priority = 2;
+                }
+                break;
+            case TIMEOUT:
+                if (failure_priority < 3) {
+                    result.s = TIMEOUT;
+                    failure_priority = 3;
+                }
+                break;
+            case FAILED:
+                result.s = FAILED;
+                failure_priority = 4;
+                break;
+        }
+    }
+
+    if (slice_statuses.empty()) {
+        result.s = INVALID;
+    } else if (!is_finished) {
+        result.s = has_pending ? PENDING : WAITING;
+    }
+    return result;
 }
 
 Status NVMeoFTransport::submitTransfer(

--- a/mooncake-transfer-engine/src/transport/nvmeof_transport/nvmeof_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/nvmeof_transport/nvmeof_transport.cpp
@@ -98,7 +98,8 @@ Status NVMeoFTransport::getTransferStatus(BatchID batch_id, size_t task_id,
     }
 
     auto [slice_id, slice_num] = nvmeof_desc.task_to_slices[task_id];
-    std::vector<TransferStatus> slice_statuses;
+    thread_local std::vector<TransferStatus> slice_statuses;
+    slice_statuses.clear();
     slice_statuses.reserve(slice_num);
     for (size_t i = slice_id; i < slice_id + slice_num; ++i) {
         auto event = desc_pool_->getTransferStatus(nvmeof_desc.desc_idx_, i);

--- a/mooncake-transfer-engine/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tests/CMakeLists.txt
@@ -72,6 +72,11 @@ if(USE_CXL)
 endif()
 
 if(USE_NVMEOF)
+  add_executable(nvmeof_status_test ${WORKSPACE}/nvmeof_status_test.cpp)
+  target_link_libraries(nvmeof_status_test PUBLIC transfer_engine gtest
+                                                  gtest_main)
+  add_test(NAME nvmeof_status_test COMMAND nvmeof_status_test)
+
   add_executable(nvmeof_transport_test ${WORKSPACE}/nvmeof_transport_test.cpp)
   target_link_libraries(nvmeof_transport_test PUBLIC transfer_engine gtest
                                                      gtest_main)
@@ -193,20 +198,22 @@ if(USE_SUNRISE)
                  ${WORKSPACE}/sunrise_link_transport_test.cpp)
   target_include_directories(sunrise_link_transport_test
                              PRIVATE ${MC_TANGRT_ROOT}/include)
-  target_link_libraries(sunrise_link_transport_test PUBLIC transfer_engine
-                                                           gtest gtest_main
-                                                           ${MC_TANGRT_ROOT}/lib/libtangrt_shared.so
-                                                           ${MC_TANGRT_ROOT}/lib/libptml_shared.so dl)
+  target_link_libraries(
+    sunrise_link_transport_test
+    PUBLIC transfer_engine gtest gtest_main
+           ${MC_TANGRT_ROOT}/lib/libtangrt_shared.so
+           ${MC_TANGRT_ROOT}/lib/libptml_shared.so dl)
   add_test(NAME sunrise_link_transport_test COMMAND sunrise_link_transport_test)
 
   add_executable(sunrise_link_transport_runtime_test
                  ${WORKSPACE}/sunrise_link_transport_runtime_test.cpp)
   target_include_directories(sunrise_link_transport_runtime_test
                              PRIVATE ${MC_TANGRT_ROOT}/include)
-  target_link_libraries(sunrise_link_transport_runtime_test
-                        PUBLIC transfer_engine gtest gtest_main
-                               ${MC_TANGRT_ROOT}/lib/libtangrt_shared.so
-                               ${MC_TANGRT_ROOT}/lib/libptml_shared.so dl)
+  target_link_libraries(
+    sunrise_link_transport_runtime_test
+    PUBLIC transfer_engine gtest gtest_main
+           ${MC_TANGRT_ROOT}/lib/libtangrt_shared.so
+           ${MC_TANGRT_ROOT}/lib/libptml_shared.so dl)
   add_test(NAME sunrise_link_transport_runtime_test
            COMMAND sunrise_link_transport_runtime_test)
 
@@ -214,31 +221,32 @@ if(USE_SUNRISE)
                  ${WORKSPACE}/sunrise_link_transport_unit_test.cpp)
   target_include_directories(sunrise_link_transport_unit_test
                              PRIVATE ${MC_TANGRT_ROOT}/include)
-  target_link_libraries(sunrise_link_transport_unit_test
-                        PUBLIC transfer_engine gtest gtest_main
-                               ${MC_TANGRT_ROOT}/lib/libtangrt_shared.so
-                               ${MC_TANGRT_ROOT}/lib/libptml_shared.so dl)
+  target_link_libraries(
+    sunrise_link_transport_unit_test
+    PUBLIC transfer_engine gtest gtest_main
+           ${MC_TANGRT_ROOT}/lib/libtangrt_shared.so
+           ${MC_TANGRT_ROOT}/lib/libptml_shared.so dl)
   add_test(NAME sunrise_link_transport_unit_test
            COMMAND sunrise_link_transport_unit_test)
 
-  add_executable(sunrise_allocator_test
-                 ${WORKSPACE}/sunrise_allocator_test.cpp)
+  add_executable(sunrise_allocator_test ${WORKSPACE}/sunrise_allocator_test.cpp)
   target_include_directories(sunrise_allocator_test
                              PRIVATE ${MC_TANGRT_ROOT}/include)
-  target_link_libraries(sunrise_allocator_test
-                        PUBLIC transfer_engine gtest gtest_main
-                               ${MC_TANGRT_ROOT}/lib/libtangrt_shared.so
-                               ${MC_TANGRT_ROOT}/lib/libptml_shared.so dl)
+  target_link_libraries(
+    sunrise_allocator_test
+    PUBLIC transfer_engine gtest gtest_main
+           ${MC_TANGRT_ROOT}/lib/libtangrt_shared.so
+           ${MC_TANGRT_ROOT}/lib/libptml_shared.so dl)
   add_test(NAME sunrise_allocator_test COMMAND sunrise_allocator_test)
 
-  add_executable(sunrise_link_copy_test
-                 ${WORKSPACE}/sunrise_link_copy_test.cpp)
+  add_executable(sunrise_link_copy_test ${WORKSPACE}/sunrise_link_copy_test.cpp)
   target_include_directories(sunrise_link_copy_test
                              PRIVATE ${MC_TANGRT_ROOT}/include)
-  target_link_libraries(sunrise_link_copy_test
-                        PUBLIC transfer_engine gtest gtest_main
-                               ${MC_TANGRT_ROOT}/lib/libtangrt_shared.so
-                               ${MC_TANGRT_ROOT}/lib/libptml_shared.so dl)
+  target_link_libraries(
+    sunrise_link_copy_test
+    PUBLIC transfer_engine gtest gtest_main
+           ${MC_TANGRT_ROOT}/lib/libtangrt_shared.so
+           ${MC_TANGRT_ROOT}/lib/libptml_shared.so dl)
   add_test(NAME sunrise_link_copy_test COMMAND sunrise_link_copy_test)
 endif()
 
@@ -258,8 +266,8 @@ add_test(NAME rdma_gid_probe_test COMMAND rdma_gid_probe_test)
 
 add_executable(multi_transport_locality_test
                ${WORKSPACE}/multi_transport_locality_test.cpp)
-target_link_libraries(multi_transport_locality_test PUBLIC transfer_engine gtest
-                                                           gtest_main)
+target_link_libraries(multi_transport_locality_test PUBLIC transfer_engine
+                                                           gtest gtest_main)
 add_test(NAME multi_transport_locality_test
          COMMAND multi_transport_locality_test)
 
@@ -307,7 +315,7 @@ endif()
 
 add_executable(graceful_shutdown_test ${WORKSPACE}/graceful_shutdown_test.cpp)
 target_link_libraries(graceful_shutdown_test PUBLIC transfer_engine gtest
-                                                   gtest_main)
+                                                    gtest_main)
 add_test(NAME graceful_shutdown_test COMMAND graceful_shutdown_test)
 
 add_executable(show_links_test ${WORKSPACE}/show_links_test.cpp)

--- a/mooncake-transfer-engine/tests/nvmeof_status_test.cpp
+++ b/mooncake-transfer-engine/tests/nvmeof_status_test.cpp
@@ -1,0 +1,114 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "transport/nvmeof_transport/nvmeof_transport.h"
+
+namespace mooncake {
+
+class CUFileDescPoolTestPeer {
+   public:
+    static bool cachePolledEvent(std::vector<CUfileIOEvents_t>& events,
+                                 const CUfileIOEvents_t& event) {
+        return CUFileDescPool::cachePolledEvent(events, event);
+    }
+};
+
+class NVMeoFTransportTestPeer {
+   public:
+    static std::unique_ptr<NVMeoFTransport> createWithoutDriver() {
+        return std::unique_ptr<NVMeoFTransport>(
+            new NVMeoFTransport(std::make_shared<CUFileDescPool>()));
+    }
+
+    static Transport::TransferStatus aggregate(
+        const std::vector<Transport::TransferStatus>& statuses,
+        bool& is_finished) {
+        return NVMeoFTransport::aggregateTransferStatus(statuses, is_finished);
+    }
+};
+
+TEST(NVMeoFStatusTest, RejectsUnsupportedMultiTransportSubmission) {
+    auto transport = NVMeoFTransportTestPeer::createWithoutDriver();
+    Transport::TransferTask task;
+
+    auto status = transport->submitTransferTask({&task});
+
+    EXPECT_TRUE(status.IsNotImplemented());
+    EXPECT_EQ(status.message(),
+              "NVMeoFTransport does not support MultiTransport batches");
+    EXPECT_TRUE(task.is_finished);
+}
+
+TEST(NVMeoFStatusTest, WaitsForEverySliceBeforeReportingTerminalFailure) {
+    bool is_finished = true;
+    auto status = NVMeoFTransportTestPeer::aggregate(
+        {{Transport::FAILED, 0}, {Transport::PENDING, 0}}, is_finished);
+
+    EXPECT_EQ(status.s, Transport::PENDING);
+    EXPECT_FALSE(is_finished);
+}
+
+TEST(NVMeoFStatusTest, AggregatesCompletedBytes) {
+    bool is_finished = false;
+    auto status = NVMeoFTransportTestPeer::aggregate(
+        {{Transport::COMPLETED, 1024}, {Transport::COMPLETED, 2048}},
+        is_finished);
+
+    EXPECT_EQ(status.s, Transport::COMPLETED);
+    EXPECT_EQ(status.transferred_bytes, 3072);
+    EXPECT_TRUE(is_finished);
+}
+
+TEST(NVMeoFStatusTest, UsesDeterministicTerminalFailurePrecedence) {
+    bool first_finished = false;
+    auto first = NVMeoFTransportTestPeer::aggregate({{Transport::INVALID, 0},
+                                                     {Transport::FAILED, 0},
+                                                     {Transport::TIMEOUT, 0}},
+                                                    first_finished);
+
+    bool second_finished = false;
+    auto second = NVMeoFTransportTestPeer::aggregate({{Transport::TIMEOUT, 0},
+                                                      {Transport::FAILED, 0},
+                                                      {Transport::INVALID, 0}},
+                                                     second_finished);
+
+    EXPECT_EQ(first.s, Transport::FAILED);
+    EXPECT_EQ(second.s, Transport::FAILED);
+    EXPECT_TRUE(first_finished);
+    EXPECT_TRUE(second_finished);
+}
+
+TEST(NVMeoFStatusTest, CorrelatesPartialCompletionsByCookie) {
+    std::vector<CUfileIOEvents_t> cached = {
+        {.cookie = reinterpret_cast<void*>(1),
+         .status = CUFILE_WAITING,
+         .ret = 0},
+        {.cookie = reinterpret_cast<void*>(2),
+         .status = CUFILE_WAITING,
+         .ret = 0}};
+    CUfileIOEvents_t second = {.cookie = reinterpret_cast<void*>(2),
+                               .status = CUFILE_COMPLETE,
+                               .ret = 4096};
+
+    ASSERT_TRUE(CUFileDescPoolTestPeer::cachePolledEvent(cached, second));
+    EXPECT_EQ(cached[0].status, CUFILE_WAITING);
+    EXPECT_EQ(cached[1].status, CUFILE_COMPLETE);
+    EXPECT_EQ(cached[1].ret, 4096);
+}
+
+}  // namespace mooncake


### PR DESCRIPTION
Fixes #2890

## Description

The NVMe-oF transport exposed two incorrect task-state behaviors.

First, `submitTransferTask`, which is called by `MultiTransport`, returned success without submitting I/O. Generic MultiTransport batches do not own the NVMe-specific cuFile descriptor required by the direct NVMe-oF path.

The method now returns `NotImplemented` and marks tasks for which no I/O was started as releasable. This avoids false submission success without introducing a new descriptor-ownership protocol.

Second, the supported direct-batch path treated `cuFileBatchIOGetStatus` output as a positional status array. cuFile can return partial completion events whose order does not match submission order.

Completion handling now:

- enforces the configured batch-size limit rather than allocator-selected vector capacity;
- assigns each submitted slice a cookie derived from its submission index;
- validates the completion buffer before polling cuFile;
- correlates returned events by cookie;
- caches partial and reordered completions;
- reuses per-thread scratch storage while aggregating slice status;
- reports `WAITING` or `PENDING` while any slice remains active;
- sums bytes from successfully completed slices;
- marks a task finished only after every slice becomes terminal;
- applies deterministic terminal precedence: `FAILED`, `TIMEOUT`, `CANCELED`, then `INVALID`;
- rejects status polling for batches without NVMe-specific context.

No MultiTransport NVMe-oF submission protocol is added.

```mermaid
flowchart TD
    A[Transfer request] --> B{Batch owner}
    B -->|MultiTransport| C[Generic BatchDesc]
    C --> D[No NVMe/cuFile descriptor]
    D --> E[Return NotImplemented]
    E --> F[Mark unstarted tasks releasable]

    B -->|Direct NVMe-oF| G[NVMeoFBatchDesc]
    G --> H[Submit cuFile slices]
    H --> I[Poll partial completion events]
    I --> J[Correlate events by cookie]
    J --> K{All slices terminal?}
    K -->|No| L[WAITING or PENDING]
    K -->|Yes| M[Aggregate bytes and deterministic failure]
```

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

Focused tests cover:

- explicit rejection of unsupported MultiTransport submission;
- release of tasks for which no I/O started;
- mixed terminal-failure and pending slices;
- completed-byte aggregation;
- order-independent terminal failure precedence;
- partial and reordered completion correlation by cookie.

**Test commands:**

```bash
cmake --build build-nvmeof-status --target nvmeof_status_test -j4
./build-nvmeof-status/tests/nvmeof_status_test --gtest_color=no
pre-commit run --files $(git diff --name-only origin/main..HEAD)
git diff --check origin/main..HEAD
```

**Results:**

- [x] Unit tests pass: 5/5
- [x] The previous submission stub fails its regression case for the intended reason
- [x] All configured pre-commit hooks pass on the touched files
- [x] clang-format 20 passes
- [x] CMake formatting passes
- [x] Structured branch review reports no actionable findings

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on all files touched by this change, and all hooks pass
- [x] Documentation is not applicable because no supported API was added
- [x] I have added tests to prove the change is effective
- [x] An RFC is not required because the change is under 500 LOC

## AI Assistance Disclosure

- [x] AI tools were used

Codex assisted with source tracing, cuFile contract research, implementation, test design, formatting, and structured review. The submitter is responsible for reviewing and understanding every changed line.
