### PR TITLE
[TE] Use std::atomic to support ARM64 relaxed ordering

### DIFF
--- a/mooncake-transfer-engine/include/common.h
+++ b/mooncake-transfer-engine/include/common.h
@@ -555,18 +555,19 @@ class RWSpinlock {
         if (t.users != t.write) return false;
         ++t.users;
         return ticket.compare_exchange_weak(expected.whole, t.whole,
-                                             std::memory_order_acquire);
+                                            std::memory_order_acquire);
     }
 
     void writeLockAggressive() {
         uint32_t count = 0;
         RWTicket increment;
         increment.users = 1;
-        RWTicket old(ticket.fetch_add(increment.whole,
-                                      std::memory_order_acquire));
+        RWTicket old(
+            ticket.fetch_add(increment.whole, std::memory_order_acquire));
         uint16_t val = old.users;
         RWTicket t;
-        while (val != (t.whole = ticket.load(std::memory_order_acquire), t.write)) {
+        while (val !=
+               (t.whole = ticket.load(std::memory_order_acquire), t.write)) {
             PAUSE();
             if (++count > 1000) std::this_thread::yield();
         }
@@ -594,9 +595,9 @@ class RWSpinlock {
             ++t.read;
             ++t.write;
             new_val = t.whole;
-        } while (!ticket.compare_exchange_weak(
-            expected, new_val, std::memory_order_release,
-            std::memory_order_relaxed));
+        } while (!ticket.compare_exchange_weak(expected, new_val,
+                                               std::memory_order_release,
+                                               std::memory_order_relaxed));
     }
 
     void lockShared() {
@@ -615,7 +616,7 @@ class RWSpinlock {
         ++t.read;
         ++t.users;
         return ticket.compare_exchange_weak(expected.whole, t.whole,
-                                             std::memory_order_acquire);
+                                            std::memory_order_acquire);
     }
 
     void unlockShared() { fetch_add_write(1); }
@@ -630,7 +631,7 @@ class RWSpinlock {
             t.read += delta;
             new_val = t.whole;
         } while (!ticket.compare_exchange_weak(expected, new_val,
-                                                std::memory_order_acquire));
+                                               std::memory_order_acquire));
         return static_cast<uint16_t>(t.read - delta);
     }
 
@@ -643,7 +644,7 @@ class RWSpinlock {
             t.write += delta;
             new_val = t.whole;
         } while (!ticket.compare_exchange_weak(expected, new_val,
-                                                std::memory_order_release));
+                                               std::memory_order_release));
         return static_cast<uint16_t>(t.write - delta);
     }
 

--- a/mooncake-transfer-engine/include/common.h
+++ b/mooncake-transfer-engine/include/common.h
@@ -586,11 +586,17 @@ class RWSpinlock {
     }
 
     void unlock() {
+        uint64_t expected = ticket.load(std::memory_order_relaxed);
+        uint64_t new_val;
         RWTicket t;
-        t.whole = ticket.load(std::memory_order_relaxed);
-        ++t.read;
-        ++t.write;
-        ticket.store(t.whole, std::memory_order_release);
+        do {
+            t.whole = expected;
+            ++t.read;
+            ++t.write;
+            new_val = t.whole;
+        } while (!ticket.compare_exchange_weak(
+            expected, new_val, std::memory_order_release,
+            std::memory_order_relaxed));
     }
 
     void lockShared() {

--- a/mooncake-transfer-engine/include/common.h
+++ b/mooncake-transfer-engine/include/common.h
@@ -528,6 +528,7 @@ static inline bool overlap(const void *a, size_t a_len, const void *b,
 class RWSpinlock {
     union RWTicket {
         constexpr RWTicket() : whole(0) {}
+        constexpr RWTicket(uint64_t v) : whole(v) {}
         uint64_t whole;
         uint32_t readWrite;
         struct {
@@ -535,26 +536,12 @@ class RWSpinlock {
             uint16_t read;
             uint16_t users;
         };
-    } ticket;
+    };
 
-   private:
-    static void asm_volatile_memory() { asm volatile("" ::: "memory"); }
-
-    template <class T>
-    static T load_acquire(T *addr) {
-        T t = *addr;
-        asm_volatile_memory();
-        return t;
-    }
-
-    template <class T>
-    static void store_release(T *addr, T v) {
-        asm_volatile_memory();
-        *addr = v;
-    }
+    std::atomic<uint64_t> ticket;
 
    public:
-    RWSpinlock() {}
+    RWSpinlock() : ticket(0) {}
 
     RWSpinlock(RWSpinlock const &) = delete;
     RWSpinlock &operator=(RWSpinlock const &) = delete;
@@ -562,17 +549,24 @@ class RWSpinlock {
     void lock() { writeLockNice(); }
 
     bool tryLock() {
-        RWTicket t;
-        uint64_t old = t.whole = load_acquire(&ticket.whole);
+        RWTicket t, expected;
+        expected.whole = ticket.load(std::memory_order_acquire);
+        t.whole = expected.whole;
         if (t.users != t.write) return false;
         ++t.users;
-        return __sync_bool_compare_and_swap(&ticket.whole, old, t.whole);
+        return ticket.compare_exchange_weak(expected.whole, t.whole,
+                                             std::memory_order_acquire);
     }
 
     void writeLockAggressive() {
         uint32_t count = 0;
-        uint16_t val = __sync_fetch_and_add(&ticket.users, 1);
-        while (val != load_acquire(&ticket.write)) {
+        RWTicket increment;
+        increment.users = 1;
+        RWTicket old(ticket.fetch_add(increment.whole,
+                                      std::memory_order_acquire));
+        uint16_t val = old.users;
+        RWTicket t;
+        while (val != (t.whole = ticket.load(std::memory_order_acquire), t.write)) {
             PAUSE();
             if (++count > 1000) std::this_thread::yield();
         }
@@ -587,16 +581,16 @@ class RWSpinlock {
     }
 
     void unlockAndLockShared() {
-        uint16_t val = __sync_fetch_and_add(&ticket.read, 1);
+        uint16_t val = fetch_add_read(1);
         (void)val;
     }
 
     void unlock() {
         RWTicket t;
-        t.whole = load_acquire(&ticket.whole);
+        t.whole = ticket.load(std::memory_order_relaxed);
         ++t.read;
         ++t.write;
-        store_release(&ticket.readWrite, t.readWrite);
+        ticket.store(t.whole, std::memory_order_release);
     }
 
     void lockShared() {
@@ -608,15 +602,44 @@ class RWSpinlock {
     }
 
     bool tryLockShared() {
-        RWTicket t, old;
-        old.whole = t.whole = load_acquire(&ticket.whole);
-        old.users = old.read;
+        RWTicket t, expected;
+        expected.whole = ticket.load(std::memory_order_acquire);
+        t.whole = expected.whole;
+        expected.users = expected.read;
         ++t.read;
         ++t.users;
-        return __sync_bool_compare_and_swap(&ticket.whole, old.whole, t.whole);
+        return ticket.compare_exchange_weak(expected.whole, t.whole,
+                                             std::memory_order_acquire);
     }
 
-    void unlockShared() { __sync_fetch_and_add(&ticket.write, 1); }
+    void unlockShared() { fetch_add_write(1); }
+
+   private:
+    uint16_t fetch_add_read(uint16_t delta) {
+        uint64_t expected = ticket.load(std::memory_order_relaxed);
+        uint64_t new_val;
+        RWTicket t;
+        do {
+            t.whole = expected;
+            t.read += delta;
+            new_val = t.whole;
+        } while (!ticket.compare_exchange_weak(expected, new_val,
+                                                std::memory_order_acquire));
+        return static_cast<uint16_t>(t.read - delta);
+    }
+
+    uint16_t fetch_add_write(uint16_t delta) {
+        uint64_t expected = ticket.load(std::memory_order_relaxed);
+        uint64_t new_val;
+        RWTicket t;
+        do {
+            t.whole = expected;
+            t.write += delta;
+            new_val = t.whole;
+        } while (!ticket.compare_exchange_weak(expected, new_val,
+                                                std::memory_order_release));
+        return static_cast<uint16_t>(t.write - delta);
+    }
 
    public:
     struct WriteGuard {

--- a/mooncake-transfer-engine/include/common.h
+++ b/mooncake-transfer-engine/include/common.h
@@ -560,11 +560,7 @@ class RWSpinlock {
 
     void writeLockAggressive() {
         uint32_t count = 0;
-        RWTicket increment;
-        increment.users = 1;
-        RWTicket old(
-            ticket.fetch_add(increment.whole, std::memory_order_acquire));
-        uint16_t val = old.users;
+        uint16_t val = fetch_add_users(1);
         RWTicket t;
         while (val !=
                (t.whole = ticket.load(std::memory_order_acquire), t.write)) {
@@ -622,6 +618,20 @@ class RWSpinlock {
     void unlockShared() { fetch_add_write(1); }
 
    private:
+    uint16_t fetch_add_users(uint16_t delta) {
+        uint64_t expected = ticket.load(std::memory_order_relaxed);
+        uint64_t new_val;
+        RWTicket t;
+        do {
+            t.whole = expected;
+            t.users += delta;
+            new_val = t.whole;
+        } while (!ticket.compare_exchange_weak(expected, new_val,
+                                               std::memory_order_acquire,
+                                               std::memory_order_relaxed));
+        return static_cast<uint16_t>(t.users - delta);
+    }
+
     uint16_t fetch_add_read(uint16_t delta) {
         uint64_t expected = ticket.load(std::memory_order_relaxed);
         uint64_t new_val;
@@ -631,7 +641,7 @@ class RWSpinlock {
             t.read += delta;
             new_val = t.whole;
         } while (!ticket.compare_exchange_weak(expected, new_val,
-                                               std::memory_order_acquire));
+                                               std::memory_order_release));
         return static_cast<uint16_t>(t.read - delta);
     }
 

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
@@ -61,8 +61,27 @@ struct GidSelectionSnapshot {
 
 struct RdmaCq {
     RdmaCq() : native(nullptr), outstanding(0) {}
+    RdmaCq(const RdmaCq &other)
+        : native(other.native),
+          outstanding(other.outstanding.load(std::memory_order_relaxed)) {}
+    RdmaCq(RdmaCq &&other) noexcept
+        : native(other.native),
+          outstanding(other.outstanding.load(std::memory_order_relaxed)) {}
+    RdmaCq &operator=(const RdmaCq &other) {
+        native = other.native;
+        outstanding.store(other.outstanding.load(std::memory_order_relaxed),
+                          std::memory_order_relaxed);
+        return *this;
+    }
+    RdmaCq &operator=(RdmaCq &&other) noexcept {
+        native = other.native;
+        outstanding.store(other.outstanding.load(std::memory_order_relaxed),
+                          std::memory_order_relaxed);
+        return *this;
+    }
+
     ibv_cq *native;
-    volatile int outstanding;
+    std::atomic<int> outstanding;
 };
 
 struct MemoryRegionMeta {
@@ -113,9 +132,11 @@ class RdmaContext {
         uintptr_t addr) const;
 
    public:
-    bool active() const { return active_; }
+    bool active() const { return active_.load(std::memory_order_acquire); }
 
-    void set_active(bool flag) { active_ = flag; }
+    void set_active(bool flag) {
+        active_.store(flag, std::memory_order_release);
+    }
 
    public:
     // EndPoint Management
@@ -193,7 +214,7 @@ class RdmaContext {
 
     ibv_cq *cq();
 
-    volatile int *cqOutstandingCount(int cq_index) {
+    std::atomic<int> *cqOutstandingCount(int cq_index) {
         return &cq_list_[cq_index].outstanding;
     }
 
@@ -261,7 +282,7 @@ class RdmaContext {
 
     std::shared_ptr<WorkerPool> worker_pool_;
 
-    volatile bool active_;
+    std::atomic<bool> active_;
 };
 
 }  // namespace mooncake

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
@@ -61,24 +61,14 @@ struct GidSelectionSnapshot {
 
 struct RdmaCq {
     RdmaCq() : native(nullptr), outstanding(0) {}
-    RdmaCq(const RdmaCq &other)
-        : native(other.native),
-          outstanding(other.outstanding.load(std::memory_order_relaxed)) {}
+    RdmaCq(const RdmaCq &) = delete;
+    RdmaCq &operator=(const RdmaCq &) = delete;
     RdmaCq(RdmaCq &&other) noexcept
         : native(other.native),
-          outstanding(other.outstanding.load(std::memory_order_relaxed)) {}
-    RdmaCq &operator=(const RdmaCq &other) {
-        native = other.native;
-        outstanding.store(other.outstanding.load(std::memory_order_relaxed),
-                          std::memory_order_relaxed);
-        return *this;
+          outstanding(other.outstanding.load(std::memory_order_relaxed)) {
+        other.native = nullptr;
     }
-    RdmaCq &operator=(RdmaCq &&other) noexcept {
-        native = other.native;
-        outstanding.store(other.outstanding.load(std::memory_order_relaxed),
-                          std::memory_order_relaxed);
-        return *this;
-    }
+    RdmaCq &operator=(RdmaCq &&) = delete;
 
     ibv_cq *native;
     std::atomic<int> outstanding;

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_endpoint.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_endpoint.h
@@ -83,17 +83,21 @@ class RdmaEndPoint {
     int setupConnectionsByPassive(const HandShakeDesc &peer_desc,
                                   HandShakeDesc &local_desc);
 
-    bool active() const { return active_; }
+    bool active() const { return active_.load(std::memory_order_acquire); }
 
     void set_active(bool flag) {
         RWSpinlock::WriteGuard guard(lock_);
-        active_ = flag;
-        if (!flag) inactive_time_ = getCurrentTimeInNano();
+        if (!flag)
+            inactive_time_.store(getCurrentTimeInNano(),
+                                 std::memory_order_relaxed);
+        active_.store(flag, std::memory_order_release);
     }
 
     double inactiveTime() {
-        if (active_) return 0.0;
-        return (getCurrentTimeInNano() - inactive_time_) / 1000000000.0;
+        if (active_.load(std::memory_order_acquire)) return 0.0;
+        return (getCurrentTimeInNano() -
+                inactive_time_.load(std::memory_order_relaxed)) /
+               1000000000.0;
     }
 
    public:
@@ -214,14 +218,14 @@ class RdmaEndPoint {
     bool has_connected_;
     std::atomic<uint64_t> ready_wait_start_ts_;
 
-    volatile int *wr_depth_list_;
+    std::atomic<int> *wr_depth_list_;
     int max_wr_depth_;
     size_t max_sge_per_wr_;
     size_t max_inline_bytes_;
 
-    volatile bool active_;
-    volatile int *cq_outstanding_;
-    volatile uint64_t inactive_time_;
+    std::atomic<bool> active_;
+    std::atomic<int> *cq_outstanding_;
+    std::atomic<uint64_t> inactive_time_;
     int finish_destroy_retries_ = 0;
 };
 

--- a/mooncake-transfer-engine/include/transport/transport.h
+++ b/mooncake-transfer-engine/include/transport/transport.h
@@ -133,7 +133,7 @@ class Transport {
                 mr_key_t dest_rkey;
                 int lkey_index;
                 int rkey_index;
-                volatile int *qp_depth;
+                std::atomic<int> *qp_depth;
                 uint32_t retry_cnt;
                 uint32_t max_retry_cnt;
                 RdmaEndPoint *endpoint;  // Endpoint used for this transfer

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -601,7 +601,7 @@ RdmaContext::findMemoryRegionContaining(uintptr_t addr) const {
 
 std::shared_ptr<RdmaEndPoint> RdmaContext::endpoint(
     const std::string &peer_nic_path) {
-    if (!active_) {
+    if (!active_.load(std::memory_order_acquire)) {
         LOG(ERROR) << "Context is not active: " << deviceName();
         return nullptr;
     }

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -282,10 +282,9 @@ bool RdmaEndPoint::finishDestroy() {
             }
         }
         if (has_outstanding) {
-            double elapsed =
-                (getCurrentTimeInNano() -
-                 inactive_time_.load(std::memory_order_relaxed)) /
-                1e9;
+            double elapsed = (getCurrentTimeInNano() -
+                              inactive_time_.load(std::memory_order_relaxed)) /
+                             1e9;
             if (elapsed < kFinishDestroyTimeoutSec) return false;
             LOG(WARNING) << "finishDestroy timed out after " << elapsed
                          << "s with outstanding WRs, forcing destruction";
@@ -939,8 +938,7 @@ int RdmaEndPoint::submitPostSend(
          qp_index < num_qp && cq_remaining > 0 && cursor < requested;
          ++qp_index) {
         int qp_avail = max_wr_depth_ -
-                       wr_depth_list_[qp_index].load(
-                           std::memory_order_relaxed);
+                       wr_depth_list_[qp_index].load(std::memory_order_relaxed);
         if (qp_avail <= 0) continue;
 
         size_t remaining_qps = num_qp - qp_index;
@@ -978,8 +976,7 @@ int RdmaEndPoint::submitPostSend(
         }
 
         ibv_send_wr *bad_wr = nullptr;
-        wr_depth_list_[qp_index].fetch_add(wr_count,
-                                           std::memory_order_acq_rel);
+        wr_depth_list_[qp_index].fetch_add(wr_count, std::memory_order_acq_rel);
         cq_outstanding_->fetch_add(wr_count, std::memory_order_acq_rel);
         // Register before ringing the doorbell. A fast completion may otherwise
         // be polled before the diagnostic registry sees the slice.

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -105,19 +105,19 @@ int RdmaEndPoint::construct(ibv_cq *cq, size_t num_qp_list,
     }
 
     qp_list_.resize(num_qp_list);
-    cq_outstanding_ = (volatile int *)cq->cq_context;
+    cq_outstanding_ = static_cast<std::atomic<int> *>(cq->cq_context);
 
     max_wr_depth_ = (int)max_wr_depth;
     max_sge_per_wr_ = max_sge_per_wr;
     max_inline_bytes_ = max_inline_bytes;
 
-    wr_depth_list_ = new volatile int[num_qp_list]();
+    wr_depth_list_ = new std::atomic<int>[num_qp_list]();
     if (!wr_depth_list_) {
         LOG(ERROR) << "Failed to allocate memory for work request depth list";
         return ERR_MEMORY;
     }
     for (size_t i = 0; i < num_qp_list; ++i) {
-        wr_depth_list_[i] = 0;
+        wr_depth_list_[i].store(0, std::memory_order_relaxed);
         ibv_qp_init_attr attr;
         memset(&attr, 0, sizeof(attr));
         attr.send_cq = cq;
@@ -165,7 +165,7 @@ int RdmaEndPoint::reconstruct() {
     // Reconstruct with same parameters as original construction
     status_.store(INITIALIZING, std::memory_order_relaxed);
     ready_wait_start_ts_.store(0, std::memory_order_relaxed);
-    active_ = true;
+    active_.store(true, std::memory_order_release);
 
     return construct(cq, num_qp, max_sge_per_wr, max_wr_depth,
                      max_inline_bytes);
@@ -182,15 +182,16 @@ int RdmaEndPoint::deconstructLocked() {
     bool displayed = false;
     if (wr_depth_list_) {
         for (size_t i = 0; i < qp_list_.size(); ++i) {
-            if (wr_depth_list_[i] != 0) {
+            int wr_depth = wr_depth_list_[i].load(std::memory_order_relaxed);
+            if (wr_depth != 0) {
                 if (!displayed) {
                     LOG(WARNING)
                         << "Outstanding work requests found, CQ will not "
                            "be generated";
                     displayed = true;
                 }
-                __sync_fetch_and_sub(cq_outstanding_, wr_depth_list_[i]);
-                wr_depth_list_[i] = 0;
+                cq_outstanding_->fetch_sub(wr_depth, std::memory_order_acq_rel);
+                wr_depth_list_[i].store(0, std::memory_order_relaxed);
             }
         }
     }
@@ -226,8 +227,8 @@ void RdmaEndPoint::beginDestroyLocked() {
     auto current_status = status_.load(std::memory_order_relaxed);
     if (current_status == DESTROYING || current_status == DESTROYED) return;
 
-    active_ = false;
-    inactive_time_ = getCurrentTimeInNano();
+    inactive_time_.store(getCurrentTimeInNano(), std::memory_order_relaxed);
+    active_.store(false, std::memory_order_release);
     status_.store(DESTROYING, std::memory_order_release);
     ready_wait_start_ts_.store(0, std::memory_order_relaxed);
 
@@ -257,7 +258,7 @@ bool RdmaEndPoint::finishDestroy() {
     // pre-two-phase predicate (!hasOutstandingSlice == !active_): only
     // inactive endpoints are eligible for reclaim; active ones must stay.
     if (current_status != DESTROYING) {
-        if (active_) return false;
+        if (active_.load(std::memory_order_acquire)) return false;
         // Endpoints that never reached construct() own no RDMA resources
         // and have wr_depth_list_ uninitialized; deconstructLocked() would
         // delete[] a wild pointer. Drop them directly.
@@ -275,13 +276,16 @@ bool RdmaEndPoint::finishDestroy() {
         // never be flushed; enforce a timeout to avoid leaking forever.
         bool has_outstanding = false;
         for (size_t i = 0; i < qp_list_.size(); ++i) {
-            if (wr_depth_list_[i] != 0) {
+            if (wr_depth_list_[i].load(std::memory_order_relaxed) != 0) {
                 has_outstanding = true;
                 break;
             }
         }
         if (has_outstanding) {
-            double elapsed = (getCurrentTimeInNano() - inactive_time_) / 1e9;
+            double elapsed =
+                (getCurrentTimeInNano() -
+                 inactive_time_.load(std::memory_order_relaxed)) /
+                1e9;
             if (elapsed < kFinishDestroyTimeoutSec) return false;
             LOG(WARNING) << "finishDestroy timed out after " << elapsed
                          << "s with outstanding WRs, forcing destruction";
@@ -807,7 +811,7 @@ int RdmaEndPoint::disconnectUnlocked() {
         // a QP that reached RTS cannot be reliably reset back to RTS.
 #ifdef CONFIG_ERDMA
         for (size_t i = 0; i < qp_list_.size(); ++i) {
-            CHECK_EQ(wr_depth_list_[i], 0)
+            CHECK_EQ(wr_depth_list_[i].load(std::memory_order_relaxed), 0)
                 << "Pre-connected endpoint must not have outstanding WRs";
         }
         return reconstruct();
@@ -822,7 +826,7 @@ int RdmaEndPoint::disconnectUnlocked() {
                 PLOG(ERROR) << "Failed to modify pre-connected QP to RESET";
                 ret = ERR_ENDPOINT;
             }
-            CHECK_EQ(wr_depth_list_[i], 0)
+            CHECK_EQ(wr_depth_list_[i].load(std::memory_order_relaxed), 0)
                 << "Pre-connected endpoint must not have outstanding WRs";
         }
         peer_qp_num_list_.clear();
@@ -907,7 +911,8 @@ int RdmaEndPoint::submitPostSend(
     std::vector<Transport::Slice *> &slice_list,
     std::vector<Transport::Slice *> &failed_slice_list) {
     RWSpinlock::WriteGuard guard(lock_);
-    if (!active_ || status_.load(std::memory_order_relaxed) != CONNECTED) {
+    if (!active_.load(std::memory_order_acquire) ||
+        status_.load(std::memory_order_relaxed) != CONNECTED) {
         for (auto &slice : slice_list) failed_slice_list.push_back(slice);
         slice_list.clear();
         return 0;
@@ -916,7 +921,8 @@ int RdmaEndPoint::submitPostSend(
     const size_t num_qp = qp_list_.size();
     if (slice_list.empty()) return 0;
     const size_t requested = slice_list.size();
-    int cq_remaining = int(globalConfig().max_cqe) - *cq_outstanding_;
+    int cq_remaining = int(globalConfig().max_cqe) -
+                       cq_outstanding_->load(std::memory_order_relaxed);
     if (cq_remaining <= 0) return 0;
 
     // Only allocate for the max number of WRs we can actually post per QP,
@@ -932,7 +938,9 @@ int RdmaEndPoint::submitPostSend(
     for (size_t qp_index = 0;
          qp_index < num_qp && cq_remaining > 0 && cursor < requested;
          ++qp_index) {
-        int qp_avail = max_wr_depth_ - wr_depth_list_[qp_index];
+        int qp_avail = max_wr_depth_ -
+                       wr_depth_list_[qp_index].load(
+                           std::memory_order_relaxed);
         if (qp_avail <= 0) continue;
 
         size_t remaining_qps = num_qp - qp_index;
@@ -970,8 +978,9 @@ int RdmaEndPoint::submitPostSend(
         }
 
         ibv_send_wr *bad_wr = nullptr;
-        __sync_fetch_and_add(&wr_depth_list_[qp_index], wr_count);
-        __sync_fetch_and_add(cq_outstanding_, wr_count);
+        wr_depth_list_[qp_index].fetch_add(wr_count,
+                                           std::memory_order_acq_rel);
+        cq_outstanding_->fetch_add(wr_count, std::memory_order_acq_rel);
         // Register before ringing the doorbell. A fast completion may otherwise
         // be polled before the diagnostic registry sees the slice.
         context_.trackPostedSlices(slice_list, start, wr_count);
@@ -985,8 +994,9 @@ int RdmaEndPoint::submitPostSend(
             while (bad_wr) {
                 int i = bad_wr - wr_list.data();
                 failed_slice_list.push_back(slice_list[start + i]);
-                __sync_fetch_and_sub(&wr_depth_list_[qp_index], 1);
-                __sync_fetch_and_sub(cq_outstanding_, 1);
+                wr_depth_list_[qp_index].fetch_sub(1,
+                                                   std::memory_order_acq_rel);
+                cq_outstanding_->fetch_sub(1, std::memory_order_acq_rel);
                 bad_wr = bad_wr->next;
             }
             total_posted += wr_count;

--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -447,7 +447,7 @@ void WorkerPool::performPollCq(int thread_id) {
 
     int processed_slice_count = 0;
     const static size_t kPollCount = 64;
-    std::unordered_map<volatile int *, int> qp_depth_set;
+    std::unordered_map<std::atomic<int> *, int> qp_depth_set;
     SliceList failed_slice_list;  // Unified: collect all slices for redispatch
     for (int cq_index = 0; cq_index < context_.cqCount(); cq_index++) {
         ibv_wc wc[kPollCount];
@@ -515,12 +515,12 @@ void WorkerPool::performPollCq(int thread_id) {
             }
         }
         if (nr_poll)
-            __sync_fetch_and_sub(context_.cqOutstandingCount(cq_index),
-                                 nr_poll);
+            context_.cqOutstandingCount(cq_index)->fetch_sub(
+                nr_poll, std::memory_order_acq_rel);
     }
 
     for (auto &entry : qp_depth_set)
-        __sync_fetch_and_sub(entry.first, entry.second);
+        entry.first->fetch_sub(entry.second, std::memory_order_acq_rel);
 
     if (processed_slice_count) {
         processed_slice_count_.fetch_add(processed_slice_count);
@@ -640,7 +640,9 @@ void WorkerPool::redispatch(std::vector<Transport::Slice *> &slice_list,
 bool WorkerPool::hasOutstandingCq(int thread_id) {
     if (!workerCanPoll(thread_id)) return false;
     for (int cq_index = 0; cq_index < context_.cqCount(); ++cq_index) {
-        if (*context_.cqOutstandingCount(cq_index) > 0) return true;
+        if (context_.cqOutstandingCount(cq_index)->load(
+                std::memory_order_relaxed) > 0)
+            return true;
     }
     return false;
 }
@@ -780,7 +782,8 @@ void WorkerPool::monitorWorker() {
 
         int64_t cq_outstanding = 0;
         for (int cq_index = 0; cq_index < context_.cqCount(); ++cq_index) {
-            cq_outstanding += *context_.cqOutstandingCount(cq_index);
+            cq_outstanding += context_.cqOutstandingCount(cq_index)->load(
+                std::memory_order_relaxed);
         }
         const uint64_t processed_count =
             processed_slice_count_.load(std::memory_order_relaxed);

--- a/mooncake-transfer-engine/tent/include/tent/common/concurrent/rw_spinlock.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/concurrent/rw_spinlock.h
@@ -58,11 +58,7 @@ class RWSpinlock {
 
     void writeLockAggressive() {
         uint32_t count = 0;
-        RWTicket increment;
-        increment.users = 1;
-        RWTicket old(
-            ticket.fetch_add(increment.whole, std::memory_order_acquire));
-        uint16_t val = old.users;
+        uint16_t val = fetch_add_users(1);
         RWTicket t;
         while (val !=
                (t.whole = ticket.load(std::memory_order_acquire), t.write)) {
@@ -120,6 +116,20 @@ class RWSpinlock {
     void unlockShared() { fetch_add_write(1); }
 
    private:
+    uint16_t fetch_add_users(uint16_t delta) {
+        uint64_t expected = ticket.load(std::memory_order_relaxed);
+        uint64_t new_val;
+        RWTicket t;
+        do {
+            t.whole = expected;
+            t.users += delta;
+            new_val = t.whole;
+        } while (!ticket.compare_exchange_weak(expected, new_val,
+                                               std::memory_order_acquire,
+                                               std::memory_order_relaxed));
+        return static_cast<uint16_t>(t.users - delta);
+    }
+
     uint16_t fetch_add_read(uint16_t delta) {
         uint64_t expected = ticket.load(std::memory_order_relaxed);
         uint64_t new_val;
@@ -129,7 +139,7 @@ class RWSpinlock {
             t.read += delta;
             new_val = t.whole;
         } while (!ticket.compare_exchange_weak(expected, new_val,
-                                               std::memory_order_acquire));
+                                               std::memory_order_release));
         return static_cast<uint16_t>(t.read - delta);
     }
 

--- a/mooncake-transfer-engine/tent/include/tent/common/concurrent/rw_spinlock.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/concurrent/rw_spinlock.h
@@ -85,11 +85,17 @@ class RWSpinlock {
     }
 
     void unlock() {
+        uint64_t expected = ticket.load(std::memory_order_relaxed);
+        uint64_t new_val;
         RWTicket t;
-        t.whole = ticket.load(std::memory_order_relaxed);
-        ++t.read;
-        ++t.write;
-        ticket.store(t.whole, std::memory_order_release);
+        do {
+            t.whole = expected;
+            ++t.read;
+            ++t.write;
+            new_val = t.whole;
+        } while (!ticket.compare_exchange_weak(
+            expected, new_val, std::memory_order_release,
+            std::memory_order_relaxed));
     }
 
     void lockShared() {

--- a/mooncake-transfer-engine/tent/include/tent/common/concurrent/rw_spinlock.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/concurrent/rw_spinlock.h
@@ -26,6 +26,7 @@ namespace tent {
 class RWSpinlock {
     union RWTicket {
         constexpr RWTicket() : whole(0) {}
+        constexpr RWTicket(uint64_t v) : whole(v) {}
         uint64_t whole;
         uint32_t readWrite;
         struct {
@@ -33,26 +34,12 @@ class RWSpinlock {
             uint16_t read;
             uint16_t users;
         };
-    } ticket;
+    };
 
-   private:
-    static void asm_volatile_memory() { asm volatile("" ::: "memory"); }
-
-    template <class T>
-    static T load_acquire(T *addr) {
-        T t = *addr;
-        asm_volatile_memory();
-        return t;
-    }
-
-    template <class T>
-    static void store_release(T *addr, T v) {
-        asm_volatile_memory();
-        *addr = v;
-    }
+    std::atomic<uint64_t> ticket;
 
    public:
-    RWSpinlock() {}
+    RWSpinlock() : ticket(0) {}
 
     RWSpinlock(RWSpinlock const &) = delete;
     RWSpinlock &operator=(RWSpinlock const &) = delete;
@@ -60,17 +47,25 @@ class RWSpinlock {
     void lock() { writeLockNice(); }
 
     bool tryLock() {
-        RWTicket t;
-        uint64_t old = t.whole = load_acquire(&ticket.whole);
+        RWTicket t, expected;
+        expected.whole = ticket.load(std::memory_order_acquire);
+        t.whole = expected.whole;
         if (t.users != t.write) return false;
         ++t.users;
-        return __sync_bool_compare_and_swap(&ticket.whole, old, t.whole);
+        return ticket.compare_exchange_weak(expected.whole, t.whole,
+                                            std::memory_order_acquire);
     }
 
     void writeLockAggressive() {
         uint32_t count = 0;
-        uint16_t val = __sync_fetch_and_add(&ticket.users, 1);
-        while (val != load_acquire(&ticket.write)) {
+        RWTicket increment;
+        increment.users = 1;
+        RWTicket old(ticket.fetch_add(increment.whole,
+                                      std::memory_order_acquire));
+        uint16_t val = old.users;
+        RWTicket t;
+        while (val != (t.whole = ticket.load(std::memory_order_acquire),
+                       t.write)) {
             PAUSE();
             if (++count > 1000) std::this_thread::yield();
         }
@@ -85,16 +80,16 @@ class RWSpinlock {
     }
 
     void unlockAndLockShared() {
-        uint16_t val = __sync_fetch_and_add(&ticket.read, 1);
+        uint16_t val = fetch_add_read(1);
         (void)val;
     }
 
     void unlock() {
         RWTicket t;
-        t.whole = load_acquire(&ticket.whole);
+        t.whole = ticket.load(std::memory_order_relaxed);
         ++t.read;
         ++t.write;
-        store_release(&ticket.readWrite, t.readWrite);
+        ticket.store(t.whole, std::memory_order_release);
     }
 
     void lockShared() {
@@ -106,15 +101,44 @@ class RWSpinlock {
     }
 
     bool tryLockShared() {
-        RWTicket t, old;
-        old.whole = t.whole = load_acquire(&ticket.whole);
-        old.users = old.read;
+        RWTicket t, expected;
+        expected.whole = ticket.load(std::memory_order_acquire);
+        t.whole = expected.whole;
+        expected.users = expected.read;
         ++t.read;
         ++t.users;
-        return __sync_bool_compare_and_swap(&ticket.whole, old.whole, t.whole);
+        return ticket.compare_exchange_weak(expected.whole, t.whole,
+                                            std::memory_order_acquire);
     }
 
-    void unlockShared() { __sync_fetch_and_add(&ticket.write, 1); }
+    void unlockShared() { fetch_add_write(1); }
+
+   private:
+    uint16_t fetch_add_read(uint16_t delta) {
+        uint64_t expected = ticket.load(std::memory_order_relaxed);
+        uint64_t new_val;
+        RWTicket t;
+        do {
+            t.whole = expected;
+            t.read += delta;
+            new_val = t.whole;
+        } while (!ticket.compare_exchange_weak(expected, new_val,
+                                               std::memory_order_acquire));
+        return static_cast<uint16_t>(t.read - delta);
+    }
+
+    uint16_t fetch_add_write(uint16_t delta) {
+        uint64_t expected = ticket.load(std::memory_order_relaxed);
+        uint64_t new_val;
+        RWTicket t;
+        do {
+            t.whole = expected;
+            t.write += delta;
+            new_val = t.whole;
+        } while (!ticket.compare_exchange_weak(expected, new_val,
+                                               std::memory_order_release));
+        return static_cast<uint16_t>(t.write - delta);
+    }
 
    public:
     struct WriteGuard {

--- a/mooncake-transfer-engine/tent/include/tent/common/concurrent/rw_spinlock.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/concurrent/rw_spinlock.h
@@ -60,12 +60,12 @@ class RWSpinlock {
         uint32_t count = 0;
         RWTicket increment;
         increment.users = 1;
-        RWTicket old(ticket.fetch_add(increment.whole,
-                                      std::memory_order_acquire));
+        RWTicket old(
+            ticket.fetch_add(increment.whole, std::memory_order_acquire));
         uint16_t val = old.users;
         RWTicket t;
-        while (val != (t.whole = ticket.load(std::memory_order_acquire),
-                       t.write)) {
+        while (val !=
+               (t.whole = ticket.load(std::memory_order_acquire), t.write)) {
             PAUSE();
             if (++count > 1000) std::this_thread::yield();
         }
@@ -93,9 +93,9 @@ class RWSpinlock {
             ++t.read;
             ++t.write;
             new_val = t.whole;
-        } while (!ticket.compare_exchange_weak(
-            expected, new_val, std::memory_order_release,
-            std::memory_order_relaxed));
+        } while (!ticket.compare_exchange_weak(expected, new_val,
+                                               std::memory_order_release,
+                                               std::memory_order_relaxed));
     }
 
     void lockShared() {

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/cq.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/cq.h
@@ -31,32 +31,10 @@ class RdmaContext;
 class RdmaCQ {
    public:
     RdmaCQ() : cq_(nullptr), cqe_now_(0), cqe_limit_(-1), context_(nullptr) {}
-    RdmaCQ(const RdmaCQ &other)
-        : cq_(other.cq_),
-          cqe_now_(other.cqe_now_.load(std::memory_order_relaxed)),
-          cqe_limit_(other.cqe_limit_),
-          context_(other.context_) {}
-    RdmaCQ(RdmaCQ &&other) noexcept
-        : cq_(other.cq_),
-          cqe_now_(other.cqe_now_.load(std::memory_order_relaxed)),
-          cqe_limit_(other.cqe_limit_),
-          context_(other.context_) {}
-    RdmaCQ &operator=(const RdmaCQ &other) {
-        cq_ = other.cq_;
-        cqe_now_.store(other.cqe_now_.load(std::memory_order_relaxed),
-                       std::memory_order_relaxed);
-        cqe_limit_ = other.cqe_limit_;
-        context_ = other.context_;
-        return *this;
-    }
-    RdmaCQ &operator=(RdmaCQ &&other) noexcept {
-        cq_ = other.cq_;
-        cqe_now_.store(other.cqe_now_.load(std::memory_order_relaxed),
-                       std::memory_order_relaxed);
-        cqe_limit_ = other.cqe_limit_;
-        context_ = other.context_;
-        return *this;
-    }
+    RdmaCQ(const RdmaCQ &) = delete;
+    RdmaCQ &operator=(const RdmaCQ &) = delete;
+    RdmaCQ(RdmaCQ &&) = delete;
+    RdmaCQ &operator=(RdmaCQ &&) = delete;
 
     ~RdmaCQ();
 

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/cq.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/cq.h
@@ -53,9 +53,7 @@ class RdmaCQ {
 
     int maxCqe() const { return cqe_limit_; }
 
-    bool empty() const {
-        return cqe_now_.load(std::memory_order_relaxed) == 0;
-    }
+    bool empty() const { return cqe_now_.load(std::memory_order_relaxed) == 0; }
 
     int poll(int num_entries, ibv_wc *wc);
 

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/cq.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/cq.h
@@ -19,6 +19,8 @@
 #include <glog/logging.h>
 #include <infiniband/verbs.h>
 
+#include <atomic>
+
 #include "tent/common/status.h"
 
 namespace mooncake {
@@ -29,6 +31,32 @@ class RdmaContext;
 class RdmaCQ {
    public:
     RdmaCQ() : cq_(nullptr), cqe_now_(0), cqe_limit_(-1), context_(nullptr) {}
+    RdmaCQ(const RdmaCQ &other)
+        : cq_(other.cq_),
+          cqe_now_(other.cqe_now_.load(std::memory_order_relaxed)),
+          cqe_limit_(other.cqe_limit_),
+          context_(other.context_) {}
+    RdmaCQ(RdmaCQ &&other) noexcept
+        : cq_(other.cq_),
+          cqe_now_(other.cqe_now_.load(std::memory_order_relaxed)),
+          cqe_limit_(other.cqe_limit_),
+          context_(other.context_) {}
+    RdmaCQ &operator=(const RdmaCQ &other) {
+        cq_ = other.cq_;
+        cqe_now_.store(other.cqe_now_.load(std::memory_order_relaxed),
+                       std::memory_order_relaxed);
+        cqe_limit_ = other.cqe_limit_;
+        context_ = other.context_;
+        return *this;
+    }
+    RdmaCQ &operator=(RdmaCQ &&other) noexcept {
+        cq_ = other.cq_;
+        cqe_now_.store(other.cqe_now_.load(std::memory_order_relaxed),
+                       std::memory_order_relaxed);
+        cqe_limit_ = other.cqe_limit_;
+        context_ = other.context_;
+        return *this;
+    }
 
     ~RdmaCQ();
 
@@ -43,11 +71,13 @@ class RdmaCQ {
 
     void cancelQuota(int num_entries);
 
-    int getQuota() const { return cqe_now_; }
+    int getQuota() const { return cqe_now_.load(std::memory_order_relaxed); }
 
     int maxCqe() const { return cqe_limit_; }
 
-    bool empty() const { return cqe_now_ == 0; }
+    bool empty() const {
+        return cqe_now_.load(std::memory_order_relaxed) == 0;
+    }
 
     int poll(int num_entries, ibv_wc *wc);
 
@@ -57,7 +87,7 @@ class RdmaCQ {
 
    private:
     ibv_cq *cq_;
-    volatile int cqe_now_;
+    std::atomic<int> cqe_now_;
     int cqe_limit_;
     RdmaContext *context_;
 };

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint.h
@@ -15,6 +15,7 @@
 #ifndef TENT_ENDPOINT_H
 #define TENT_ENDPOINT_H
 
+#include <atomic>
 #include <memory>
 #include <queue>
 #include <unordered_set>
@@ -26,7 +27,7 @@ namespace mooncake {
 namespace tent {
 class RdmaEndPoint : public std::enable_shared_from_this<RdmaEndPoint> {
     struct WrDepthBlock {
-        volatile int value;
+        std::atomic<int> value;
         uint64_t padding[7];
     };
 
@@ -160,7 +161,7 @@ class RdmaEndPoint : public std::enable_shared_from_this<RdmaEndPoint> {
 
     size_t acknowledge(RdmaSlice* slice, TransferStatusEnum status);
 
-    volatile int* getQuotaCounter(int qp_index) const {
+    std::atomic<int>* getQuotaCounter(int qp_index) const {
         return &wr_depth_list_[qp_index].value;
     }
 
@@ -205,7 +206,7 @@ class RdmaEndPoint : public std::enable_shared_from_this<RdmaEndPoint> {
     // are synchronized by the endpoint lifecycle lock.
     std::vector<BoundedSliceQueue> slice_queue_;
     WrDepthBlock* wr_depth_list_;
-    volatile int inflight_slices_;
+    std::atomic<int> inflight_slices_;
     uint32_t padding_[7];
     RWSpinlock lock_;
 

--- a/mooncake-transfer-engine/tent/src/transport/rdma/cq.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/cq.cpp
@@ -55,7 +55,8 @@ int RdmaCQ::construct(RdmaContext* context, int cqe_limit, int index) {
 }
 
 bool RdmaCQ::reserveQuota(int num_entries) {
-    int prev_cqe_now = __sync_fetch_and_add(&cqe_now_, num_entries);
+    int prev_cqe_now =
+        cqe_now_.fetch_add(num_entries, std::memory_order_acq_rel);
     if (prev_cqe_now + num_entries > cqe_limit_) {
         cancelQuota(num_entries);
         return false;
@@ -64,11 +65,11 @@ bool RdmaCQ::reserveQuota(int num_entries) {
 }
 
 void RdmaCQ::cancelQuota(int num_entries) {
-    __sync_fetch_and_sub(&cqe_now_, num_entries);
+    cqe_now_.fetch_sub(num_entries, std::memory_order_acq_rel);
 }
 
 int RdmaCQ::poll(int num_entries, ibv_wc* wc) {
-    if (!cqe_now_) return 0;
+    if (cqe_now_.load(std::memory_order_relaxed) == 0) return 0;
     int rc = ibv_poll_cq(cq_, num_entries, wc);
     if (rc < 0) {
         PLOG(ERROR) << "ibv_poll_cq";

--- a/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
@@ -82,7 +82,7 @@ int RdmaEndPoint::construct(RdmaContext* context, EndPointParams* params,
     context_ = context;
     params_ = params;
     endpoint_name_ = endpoint_name;
-    inflight_slices_ = 0;
+    inflight_slices_.store(0, std::memory_order_relaxed);
 
     // Resolve the per-pool QP layout (see computeQpPoolSegments). Empty
     // qp_pools (the default) keeps the historical single homogeneous run of
@@ -105,7 +105,7 @@ int RdmaEndPoint::construct(RdmaContext* context, EndPointParams* params,
     wr_depth_list_ = new WrDepthBlock[total_qp]();
 
     for (int i = 0; i < total_qp; ++i) {
-        wr_depth_list_[i].value = 0;
+        wr_depth_list_[i].value.store(0, std::memory_order_relaxed);
         ibv_qp_init_attr attr;
         memset(&attr, 0, sizeof(attr));
         auto cq = context_->cq(i % context_->cqCount())->cq();
@@ -271,9 +271,10 @@ int RdmaEndPoint::deconstructUnlocked() {
 
     bool all_qps_destroyed = true;
     for (size_t i = 0; i < qp_list_.size(); ++i) {
-        if (wr_depth_list_ && wr_depth_list_[i].value != 0) {
-            const int outstanding = wr_depth_list_[i].value;
-            cancelQuota(i, outstanding);
+        if (wr_depth_list_) {
+            const int outstanding =
+                wr_depth_list_[i].value.load(std::memory_order_relaxed);
+            if (outstanding != 0) cancelQuota(i, outstanding);
         }
         if (!qp_list_[i]) continue;
         if (context_->verbs_.ibv_destroy_qp(qp_list_[i])) {
@@ -367,7 +368,7 @@ bool RdmaEndPoint::finishDestroy() {
     // failed, enforce a timeout so cleanup can still make progress.
     bool has_outstanding = false;
     for (size_t i = 0; wr_depth_list_ && i < qp_list_.size(); ++i) {
-        if (wr_depth_list_[i].value != 0) {
+        if (wr_depth_list_[i].value.load(std::memory_order_relaxed) != 0) {
             has_outstanding = true;
             break;
         }
@@ -734,7 +735,9 @@ int RdmaEndPoint::submitSlices(std::vector<RdmaSlice*>& slice_list,
     auto cq = context_->cq(qp_index % context_->cqCount());
     int wr_count =
         std::min(cq->maxCqe() - cq->getQuota(),
-                 std::min(params_->max_qp_wr - wr_depth_list_[qp_index].value,
+                 std::min(params_->max_qp_wr -
+                              wr_depth_list_[qp_index].value.load(
+                                  std::memory_order_relaxed),
                           (int)slice_list.size()));
     int sge_count = wr_count * kSgeEntries;
 
@@ -851,15 +854,17 @@ std::vector<uint32_t> RdmaEndPoint::qpNum() {
     return ret;
 }
 
-int RdmaEndPoint::getInflightSlices() const { return inflight_slices_; }
+int RdmaEndPoint::getInflightSlices() const {
+    return inflight_slices_.load(std::memory_order_relaxed);
+}
 
 bool RdmaEndPoint::reserveQuota(int qp_index, int num_entries) {
     assert(qp_index >= 0 && qp_index < (int)qp_list_.size());
     auto cq = context_->cq(qp_index % context_->cqCount());
     if (!cq->reserveQuota(num_entries)) return false;
-    auto prev_depth_list =
-        __sync_fetch_and_add(&wr_depth_list_[qp_index].value, num_entries);
-    __sync_fetch_and_add(&inflight_slices_, num_entries);
+    auto prev_depth_list = wr_depth_list_[qp_index].value.fetch_add(
+        num_entries, std::memory_order_acq_rel);
+    inflight_slices_.fetch_add(num_entries, std::memory_order_acq_rel);
     if (prev_depth_list + num_entries > params_->max_qp_wr) {
         cancelQuota(qp_index, num_entries);
         return false;
@@ -869,8 +874,9 @@ bool RdmaEndPoint::reserveQuota(int qp_index, int num_entries) {
 
 void RdmaEndPoint::cancelQuota(int qp_index, int num_entries) {
     assert(qp_index >= 0 && qp_index < (int)qp_list_.size());
-    __sync_fetch_and_sub(&wr_depth_list_[qp_index].value, num_entries);
-    __sync_fetch_and_sub(&inflight_slices_, num_entries);
+    wr_depth_list_[qp_index].value.fetch_sub(num_entries,
+                                             std::memory_order_acq_rel);
+    inflight_slices_.fetch_sub(num_entries, std::memory_order_acq_rel);
     auto cq = context_->cq(qp_index % context_->cqCount());
     cq->cancelQuota(num_entries);
 }

--- a/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
@@ -733,12 +733,11 @@ int RdmaEndPoint::submitSlices(std::vector<RdmaSlice*>& slice_list,
     // Check endpoint status before submitting
     if (status_.load(std::memory_order_relaxed) != EP_READY) return 0;
     auto cq = context_->cq(qp_index % context_->cqCount());
-    int wr_count =
-        std::min(cq->maxCqe() - cq->getQuota(),
-                 std::min(params_->max_qp_wr -
-                              wr_depth_list_[qp_index].value.load(
-                                  std::memory_order_relaxed),
-                          (int)slice_list.size()));
+    int wr_count = std::min(
+        cq->maxCqe() - cq->getQuota(),
+        std::min(params_->max_qp_wr - wr_depth_list_[qp_index].value.load(
+                                          std::memory_order_relaxed),
+                 (int)slice_list.size()));
     int sge_count = wr_count * kSgeEntries;
 
     if (wr_count <= 0 || !reserveQuota(qp_index, wr_count)) return 0;

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -60,6 +60,12 @@ target_include_directories(thread_local_storage_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME thread_local_storage_test COMMAND thread_local_storage_test)
 
+add_executable(tent_rw_spinlock_test rw_spinlock_test.cpp)
+target_link_libraries(tent_rw_spinlock_test PRIVATE gtest gtest_main)
+target_include_directories(tent_rw_spinlock_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+add_test(NAME tent_rw_spinlock_test COMMAND tent_rw_spinlock_test)
+
 add_executable(tent_ip_utils_test ip_utils_test.cpp)
 target_link_libraries(tent_ip_utils_test PRIVATE tent_common gtest gtest_main)
 target_include_directories(tent_ip_utils_test

--- a/mooncake-transfer-engine/tent/tests/rw_spinlock_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/rw_spinlock_test.cpp
@@ -1,0 +1,88 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+#include "tent/common/concurrent/rw_spinlock.h"
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+using namespace std::chrono_literals;
+
+TEST(RWSpinlockTest, AggressiveWriteLockProgressesAcrossTicketWraparound) {
+    RWSpinlock lock;
+    int protected_value = 0;
+
+    constexpr int kIterations = 65536 + 3;
+    for (int i = 0; i < kIterations; ++i) {
+        lock.writeLockAggressive();
+        ++protected_value;
+        lock.unlock();
+    }
+
+    RWSpinlock::ReadGuard guard(lock);
+    EXPECT_EQ(protected_value, kIterations);
+}
+
+TEST(RWSpinlockTest, DowngradePublishesToReadersAndBlocksWriters) {
+    RWSpinlock lock;
+    int protected_value = 0;
+    std::atomic<bool> writer_started{false};
+    std::atomic<bool> writer_entered{false};
+    std::atomic<bool> reader_observed{false};
+
+    lock.writeLockAggressive();
+    protected_value = 42;
+    lock.unlockAndLockShared();
+
+    std::thread reader([&] {
+        RWSpinlock::ReadGuard guard(lock);
+        reader_observed.store(protected_value == 42, std::memory_order_release);
+    });
+
+    reader.join();
+    EXPECT_TRUE(reader_observed.load(std::memory_order_acquire));
+
+    std::thread writer([&] {
+        writer_started.store(true, std::memory_order_release);
+        lock.writeLockAggressive();
+        writer_entered.store(true, std::memory_order_release);
+        protected_value = 99;
+        lock.unlock();
+    });
+
+    while (!writer_started.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+    }
+
+    std::this_thread::sleep_for(10ms);
+    EXPECT_FALSE(writer_entered.load(std::memory_order_acquire));
+
+    lock.unlockShared();
+    writer.join();
+
+    RWSpinlock::ReadGuard guard(lock);
+    EXPECT_TRUE(writer_entered.load(std::memory_order_acquire));
+    EXPECT_EQ(protected_value, 99);
+}
+
+}  // namespace
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tests/common_test.cpp
+++ b/mooncake-transfer-engine/tests/common_test.cpp
@@ -1,15 +1,80 @@
 #include <gtest/gtest.h>
+#include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <thread>
 
 #include "common.h"
 
 namespace {
 
 using namespace mooncake;
+using namespace std::chrono_literals;
 
 const uint16_t kDefaultPort = getDefaultHandshakePort();
+
+//------------------------------------------------------------------------------
+// RWSpinlock
+//------------------------------------------------------------------------------
+
+TEST(RWSpinlockTest, AggressiveWriteLockProgressesAcrossTicketWraparound) {
+    RWSpinlock lock;
+    int protected_value = 0;
+
+    constexpr int kIterations = 65536 + 3;
+    for (int i = 0; i < kIterations; ++i) {
+        lock.writeLockAggressive();
+        ++protected_value;
+        lock.unlock();
+    }
+
+    RWSpinlock::ReadGuard guard(lock);
+    EXPECT_EQ(protected_value, kIterations);
+}
+
+TEST(RWSpinlockTest, DowngradePublishesToReadersAndBlocksWriters) {
+    RWSpinlock lock;
+    int protected_value = 0;
+    std::atomic<bool> writer_started{false};
+    std::atomic<bool> writer_entered{false};
+    std::atomic<bool> reader_observed{false};
+
+    lock.writeLockAggressive();
+    protected_value = 42;
+    lock.unlockAndLockShared();
+
+    std::thread reader([&] {
+        RWSpinlock::ReadGuard guard(lock);
+        reader_observed.store(protected_value == 42, std::memory_order_release);
+    });
+
+    reader.join();
+    EXPECT_TRUE(reader_observed.load(std::memory_order_acquire));
+
+    std::thread writer([&] {
+        writer_started.store(true, std::memory_order_release);
+        lock.writeLockAggressive();
+        writer_entered.store(true, std::memory_order_release);
+        protected_value = 99;
+        lock.unlock();
+    });
+
+    while (!writer_started.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+    }
+
+    std::this_thread::sleep_for(10ms);
+    EXPECT_FALSE(writer_entered.load(std::memory_order_acquire));
+
+    lock.unlockShared();
+    writer.join();
+
+    RWSpinlock::ReadGuard guard(lock);
+    EXPECT_TRUE(writer_entered.load(std::memory_order_acquire));
+    EXPECT_EQ(protected_value, 99);
+}
 
 //------------------------------------------------------------------------------
 // parseFromString<T>


### PR DESCRIPTION
## Description



This change replaces several TE/TENT synchronization paths that relied on `volatile`, `__sync_*` builtins, or mixed-width atomic access with `std::atomic` operations.

The main fixes are:
- Convert TE/TENT `RWSpinlock` ticket state to a single `std::atomic<uint64_t>`, so lock acquisition/release no longer mixes 64-bit CAS with 16-bit subfield atomics.
- Convert TE RDMA CQ/QP outstanding counters from `volatile int` plus `__sync_*` to `std::atomic<int>`.
- Convert TE RDMA endpoint/context lifecycle flags (`active_`, `inactive_time_`) to atomics.
- Convert TENT RDMA quota counters (`cqe_now_`, QP depth, inflight slices) to atomics.

This avoids relying on x86-style ordering assumptions and makes the affected hot paths valid under the C++ memory model on ARM64.

## Module

- [X] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



**Test commands:**
```bash
# Example: bash scripts/run_ci_test.sh
```

**Test results:**
- [X] Unit tests pass
- [X] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have formatted my code using `./scripts/code_format.sh`
- [X] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [ ] AI tools were used (specify below)



CodeX