### PR TITLE
[wheel ]feat: add schema-guided DataProto field encoding

### DIFF
--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -4,10 +4,11 @@ import ctypes
 import io
 import json
 import uuid
+from collections.abc import Iterable
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import Any, Iterator, Literal, Mapping, Optional, Protocol, Sequence
+from typing import Any, Callable, Iterator, Literal, Mapping, Optional, Protocol, Sequence
 
 import numpy as np
 
@@ -42,6 +43,21 @@ class BundleTransferPolicy:
     max_inflight_put: int = 1
     put_mode: Literal["auto", "batch", "parallel"] = "auto"
     copy_mode: Literal["auto", "zero_copy", "copy"] = "auto"
+
+
+@dataclass(frozen=True)
+class FieldSchema:
+    """Schema hint for DataProto fields.
+
+    ``field_schemas`` maps DataProto field names to hints. Unlisted fields and
+    ``codec="auto"`` keep inference. ``metadata["section"]`` may pin a field to
+    ``"batch"``, ``"non_tensor_batch"``, or ``"meta_info"``. ``ragged_tensor_dict``
+    keys must be a finite iterable of non-empty strings without path separators.
+    """
+
+    codec: str
+    nullable: bool = True
+    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -471,8 +487,9 @@ class MooncakeBundleTransfer:
         stage: str = "default",
         chunk_bytes: Optional[int] = None,
         policy: Optional[BundleTransferPolicy] = None,
+        field_schemas: Optional[Mapping[str, FieldSchema]] = None,
     ) -> MooncakeDataProtoRef:
-        """Store a DataProto-like object as a stage-level structured object."""
+        """Store DataProto fields, optionally using schema hints for non-tensor fields."""
         return self._put_dataproto_stage(
             None,
             data,
@@ -482,6 +499,7 @@ class MooncakeBundleTransfer:
             chunk_bytes=chunk_bytes,
             policy=policy,
             overwrite=False,
+            field_schemas=field_schemas,
         )
 
     def append_dataproto_fields(
@@ -493,8 +511,9 @@ class MooncakeBundleTransfer:
         overwrite: bool = False,
         chunk_bytes: Optional[int] = None,
         policy: Optional[BundleTransferPolicy] = None,
+        field_schemas: Optional[Mapping[str, FieldSchema]] = None,
     ) -> MooncakeDataProtoRef:
-        """Append fields from a later DataProto stage without rewriting previous stages."""
+        """Append DataProto fields, optionally using schema hints for new fields."""
         ref = _resolve_dataproto_ref(ref)
         return self._put_dataproto_stage(
             ref,
@@ -505,6 +524,7 @@ class MooncakeBundleTransfer:
             chunk_bytes=chunk_bytes,
             policy=policy,
             overwrite=overwrite,
+            field_schemas=field_schemas,
         )
 
     def dataproto_manifest_view(self, ref: DataProtoRefLike) -> dict[str, Any]:
@@ -909,6 +929,16 @@ class MooncakeBundleTransfer:
                 "nulls": read_member_indices("nulls", indices),
             }, metadata
 
+        if codec == "ragged_tensor_dict":
+            return self._read_ragged_tensor_dict_payload_with_reader(
+                payload_members,
+                metadata,
+                lambda: read_member_indices("null_mask", indices),
+                lambda encoded: self._read_structured_non_tensor_payload_indices(
+                    stage_ref, encoded, indices
+                ),
+            )
+
         if codec in {"media_bytes", "bytes_ragged", "utf8_ragged", "msgpack_ragged", "json_ragged"}:
             offsets = read_member_indices(
                 "offsets", [index for row in indices for index in (row, row + 1)]
@@ -1074,6 +1104,16 @@ class MooncakeBundleTransfer:
                 "nulls": read_member("nulls", start, end),
             }, metadata
 
+        if codec == "ragged_tensor_dict":
+            return self._read_ragged_tensor_dict_payload_with_reader(
+                payload_members,
+                metadata,
+                lambda: read_member("null_mask", start, end),
+                lambda encoded: self._read_structured_non_tensor_payload_slice(
+                    stage_ref, encoded, row_slice, total_rows
+                ),
+            )
+
         if codec in {"media_bytes", "bytes_ragged", "utf8_ragged", "msgpack_ragged", "json_ragged"}:
             offsets = read_member("offsets", start, end + 1)
             base = int(offsets[0])
@@ -1108,6 +1148,54 @@ class MooncakeBundleTransfer:
             }, metadata
 
         raise ValueError(f"unknown structured non-tensor codec: {codec}")
+
+    def _read_ragged_tensor_dict_payload_with_reader(
+        self,
+        payload_members: Mapping[str, str],
+        metadata: dict[str, Any],
+        read_null_mask: Callable[[], Any],
+        read_key_payload: Callable[
+            [Mapping[str, Any]], tuple[dict[str, Any], Mapping[str, Any]]
+        ],
+    ) -> tuple[dict[str, Any], Mapping[str, Any]]:
+        return self._read_ragged_tensor_dict_payload(
+            payload_members,
+            metadata,
+            read_null_mask=read_null_mask,
+            read_key_payload=lambda key_members, key_metadata: read_key_payload(
+                {
+                    "codec": "ragged_tensor",
+                    "metadata": key_metadata,
+                    "payload_members": key_members,
+                }
+            ),
+        )
+
+    def _read_ragged_tensor_dict_payload(
+        self,
+        payload_members: Mapping[str, str],
+        metadata: dict[str, Any],
+        *,
+        read_null_mask: Callable[[], Any],
+        read_key_payload: Callable[
+            [Mapping[str, str], Mapping[str, Any]],
+            tuple[dict[str, Any], Mapping[str, Any]],
+        ],
+    ) -> tuple[dict[str, Any], Mapping[str, Any]]:
+        key_codecs = dict(metadata.get("key_codecs") or {})
+        metadata["key_codecs"] = key_codecs
+        dict_payload: dict[str, Any] = {"null_mask": read_null_mask()}
+        for key in _normalize_ragged_tensor_dict_keys(metadata.get("keys", [])):
+            key_members = _ragged_tensor_dict_payload_items(
+                payload_members, key, kind="manifest"
+            )
+            key_payload, key_metadata = read_key_payload(
+                key_members, key_codecs.get(key) or {}
+            )
+            key_codecs[key] = key_metadata
+            for name, value in key_payload.items():
+                dict_payload[f"{key}.{name}"] = value
+        return dict_payload, metadata
 
     def cleanup_dataproto(self, ref: DataProtoRefLike) -> None:
         """Remove all structured object stages referenced by a DataProto handle."""
@@ -1183,8 +1271,12 @@ class MooncakeBundleTransfer:
         chunk_bytes: Optional[int],
         policy: Optional[BundleTransferPolicy],
         overwrite: bool,
+        field_schemas: Optional[Mapping[str, FieldSchema]] = None,
     ) -> MooncakeDataProtoRef:
         batch, non_tensor_batch, meta_info = _split_dataproto_like(data)
+        _validate_dataproto_schema_sections(
+            batch, non_tensor_batch, meta_info, field_schemas
+        )
         batch_size = _dataproto_batch_size(batch, non_tensor_batch)
         if ref is not None and batch_size != ref.batch_size:
             raise ValueError(
@@ -1203,10 +1295,24 @@ class MooncakeBundleTransfer:
             field_updates[name] = StructuredFieldLocation(stage, member, "batch")
         encoded_updates: dict[str, Any] = {}
         for name, value in non_tensor_batch.items():
-            if _should_encode_non_tensor_field(value):
+            schema = field_schemas.get(name) if field_schemas else None
+            encoded: _EncodedStructuredLeaf | None = None
+            if schema is not None and schema.codec != "auto":
+                try:
+                    encode_value = _coerce_schema_non_tensor_value(name, value)
+                    encoded = _encode_with_schema(
+                        f"non_tensor_batch.{name}", encode_value, schema
+                    )
+                except (TypeError, ValueError, RuntimeError, AttributeError) as exc:
+                    raise type(exc)(
+                        f"failed to encode non_tensor_batch field {name!r} "
+                        f"with FieldSchema codec {schema.codec!r}: {exc}"
+                    ) from exc
+            elif _should_encode_non_tensor_field(value):
                 encoded = _encode_structured_non_tensor_field(
                     f"non_tensor_batch.{name}", value
                 )
+            if encoded is not None:
                 payload_members: dict[str, str] = {}
                 for payload_name, payload_value in encoded.payload.items():
                     member = f"non_tensor_batch.{name}.{payload_name}"
@@ -1585,6 +1691,87 @@ def _select_mapping(
     return {key: value[key] for key in keys if key in value}
 
 
+_DATAPROTO_SCHEMA_SECTIONS = frozenset({"batch", "non_tensor_batch", "meta_info"})
+_FIELD_SCHEMA_CODECS = frozenset(
+    {
+        "auto", "ragged_tensor_dict", "ragged_tensor", "typed_ragged",
+        "ndarray", "bytes_ragged", "media_bytes", "media_list_ragged",
+        "utf8_ragged", "msgpack_ragged", "json_ragged",
+    }
+)
+_RAGGED_TENSOR_PAYLOAD_NAMES = frozenset({"data", "offsets", "shapes", "ndims", "nulls"})
+
+
+def _schema_section(name: str, schema: FieldSchema) -> str | None:
+    section = schema.metadata.get("section")
+    if section is None:
+        return None
+    if section not in _DATAPROTO_SCHEMA_SECTIONS:
+        raise ValueError(
+            f"FieldSchema for {name!r} metadata['section'] must be one of "
+            f"{sorted(_DATAPROTO_SCHEMA_SECTIONS)}"
+        )
+    return section
+
+
+def _schema_ndarray_dtype(
+    schema: FieldSchema, *, required: bool = False
+) -> np.dtype[Any] | None:
+    dtype_name = schema.metadata.get("dtype")
+    if dtype_name is None:
+        if required:
+            raise ValueError("FieldSchema metadata['dtype'] is required")
+        return None
+    try:
+        dtype = np.dtype(dtype_name)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"invalid FieldSchema metadata['dtype']: {dtype_name!r}") from exc
+    if dtype.kind not in "biufc":
+        raise ValueError(
+            f"FieldSchema metadata['dtype'] must be numeric or bool, got {dtype}"
+        )
+    return dtype
+
+
+def _validate_dataproto_schema_sections(
+    batch: Mapping[str, Any],
+    non_tensor_batch: Mapping[str, Any],
+    meta_info: Mapping[str, Any],
+    field_schemas: Optional[Mapping[str, FieldSchema]],
+) -> None:
+    if not field_schemas:
+        return
+    for section, fields in (
+        ("batch", batch),
+        ("non_tensor_batch", non_tensor_batch),
+        ("meta_info", meta_info),
+    ):
+        for name in fields:
+            schema = field_schemas.get(name)
+            if schema is None:
+                continue
+            declared = _schema_section(name, schema)
+            if declared is None:
+                continue
+            if declared != section:
+                raise ValueError(
+                    f"FieldSchema for {name!r} declares section {declared!r}, "
+                    f"but data contains it in {section!r}"
+                )
+
+
+def _coerce_schema_non_tensor_value(name: str, value: Any) -> np.ndarray:
+    if isinstance(value, np.ndarray):
+        return value
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        result = np.empty(len(value), dtype=object)
+        result[:] = list(value)
+        return result
+    raise TypeError(
+        f"non_tensor_batch field {name!r} with FieldSchema must be an ndarray or non-string sequence"
+    )
+
+
 def _should_encode_non_tensor_field(value: Any) -> bool:
     return isinstance(value, np.ndarray) and value.dtype == object
 
@@ -1600,6 +1787,68 @@ def _encode_structured_non_tensor_field(
         return _encode_recursive_structured_non_tensor_field(path, values, leaves, nodes)
     decision = _choose_leaf_codec(values)
     return _encode_structured_leaf(values, decision)
+
+
+def _encode_with_schema(
+    path: str, value: np.ndarray, schema: FieldSchema
+) -> _EncodedStructuredLeaf:
+    """Encode a non_tensor_batch field using an explicit schema."""
+    values = list(value)
+    if not schema.nullable and any(item is None for item in values):
+        raise ValueError(f"FieldSchema for {path!r} is not nullable")
+    codec = schema.codec
+    if codec not in _FIELD_SCHEMA_CODECS:
+        raise ValueError(f"unsupported schema codec: {codec!r}")
+    if codec == "auto":
+        return _encode_structured_non_tensor_field(path, value)
+    if codec == "ragged_tensor_dict":
+        return _encode_ragged_tensor_dict_values(values, schema)
+    if codec == "ragged_tensor":
+        payload, metadata = _encode_ragged_tensor_values(values)
+    elif codec == "typed_ragged":
+        payload, metadata = _encode_typed_ragged_values(
+            values, dtype_hint=_schema_ndarray_dtype(schema)
+        )
+    elif codec == "ndarray":
+        dtype = _schema_ndarray_dtype(schema, required=True)
+        decision = _CodecDecision(
+            True, "ndarray", "schema", "numeric scalar", {"dtype": str(dtype)}
+        )
+        payload, metadata = _encode_numeric_scalar_values(values, decision)
+    elif codec in ("bytes_ragged", "media_bytes"):
+        payload, metadata = _encode_bytes_like_values(values)
+    elif codec == "media_list_ragged":
+        payload, metadata = _encode_media_list_values(values)
+    elif codec == "utf8_ragged":
+        payload, metadata = _encode_bytes_like_values(
+            [None if item is None else item.encode("utf-8") for item in values]
+        )
+    elif codec == "msgpack_ragged":
+        payload, metadata = _encode_bytes_like_values(
+            [
+                None
+                if item is None
+                else _msgpack.packb(item, use_bin_type=True, strict_types=True)
+                for item in values
+            ]
+        )
+    elif codec == "json_ragged":
+        payload, metadata = _encode_bytes_like_values(
+            [
+                None
+                if item is None
+                else json.dumps(item, ensure_ascii=False, separators=(",", ":")).encode(
+                    "utf-8"
+                )
+                for item in values
+            ]
+        )
+    else:
+        raise ValueError(f"unsupported schema codec: {codec!r}")
+    metadata.update({"schema_source": "field_schema"})
+    return _EncodedStructuredLeaf(
+        codec=codec, rows=len(values), payload=payload, metadata=metadata
+    )
 
 
 def _should_encode_recursive_structure(leaves: Sequence[_InferredLeaf]) -> bool:
@@ -1920,6 +2169,8 @@ def _decode_structured_leaf(
 ) -> list[Any]:
     if codec == "ragged_tensor":
         return _decode_ragged_tensor_values(payload, rows)
+    if codec == "ragged_tensor_dict":
+        return _decode_ragged_tensor_dict_values(payload, rows, metadata or {})
     if codec == "typed_ragged":
         return _decode_typed_ragged_values(payload, rows)
     if codec == "media_list_ragged":
@@ -2026,11 +2277,138 @@ def _decode_ragged_tensor_values(payload: dict[str, Any], rows: int) -> list[Any
     return values
 
 
-def _encode_typed_ragged_values(
+def _normalize_ragged_tensor_dict_keys(keys: Any) -> list[str]:
+    if isinstance(keys, (str, bytes, bytearray)) or not isinstance(keys, Iterable):
+        raise TypeError("ragged_tensor_dict keys must be an iterable of strings")
+    normalized = list(keys)
+    if any(not isinstance(key, str) for key in normalized):
+        raise TypeError("ragged_tensor_dict keys must contain only strings")
+    if any(not key for key in normalized):
+        raise ValueError("ragged_tensor_dict keys must not be empty")
+    if len(set(normalized)) != len(normalized):
+        raise ValueError("ragged_tensor_dict keys must not contain duplicates")
+    if any(any(separator in key for separator in (".", "/", "\\")) for key in normalized):
+        raise ValueError("ragged_tensor_dict keys must not contain path separators")
+    return normalized
+
+
+def _ragged_tensor_dict_payload_items(
+    payload: Mapping[str, Any], key: str, *, kind: str
+) -> dict[str, Any]:
+    prefix = f"{key}."
+    items = {
+        name[len(prefix) :]: value
+        for name, value in payload.items()
+        if name.startswith(prefix)
+    }
+    missing = sorted(_RAGGED_TENSOR_PAYLOAD_NAMES - set(items))
+    if missing:
+        raise ValueError(
+            f"ragged_tensor_dict {kind} for key {key!r} is missing payloads: {missing}"
+        )
+    return items
+
+
+def _encode_ragged_tensor_dict_values(
     values: list[Any],
+    schema: FieldSchema,
+) -> _EncodedStructuredLeaf:
+    """Encode list[dict[str, Tensor] | None] without runtime structure inference."""
+    rows = len(values)
+    null_mask = np.asarray([item is None for item in values], dtype=np.bool_)
+    for row, item in enumerate(values):
+        if item is not None and not isinstance(item, Mapping):
+            raise TypeError(
+                "ragged_tensor_dict rows must be mappings or None; "
+                f"row {row} is {type(item).__name__}"
+            )
+    schema_keys = schema.metadata.get("keys")
+    keys = (
+        None
+        if schema_keys is None
+        else _normalize_ragged_tensor_dict_keys(schema_keys)
+    )
+    non_null = [item for item in values if item is not None]
+    if not non_null:
+        return _EncodedStructuredLeaf(
+            codec="ragged_tensor_dict",
+            rows=rows,
+            payload={"null_mask": null_mask},
+            metadata={
+                "keys": keys or [],
+                "key_codecs": {},
+                "schema_source": "field_schema",
+            },
+        )
+    if keys is None:
+        all_keys: set[str] = set()
+        for item in non_null:
+            all_keys.update(item.keys())
+        keys = _normalize_ragged_tensor_dict_keys(sorted(all_keys))
+    if _torch is None:
+        raise RuntimeError("torch is required to encode ragged_tensor_dict fields")
+    payload: dict[str, Any] = {"null_mask": null_mask}
+    key_codecs: dict[str, Any] = {}
+    for key in keys:
+        key_values = [None if item is None else item.get(key) for item in values]
+        sub_payload, sub_metadata = _encode_ragged_tensor_values(key_values)
+        for payload_name, payload_value in sub_payload.items():
+            payload[f"{key}.{payload_name}"] = payload_value
+        key_codecs[key] = sub_metadata
+    return _EncodedStructuredLeaf(
+        codec="ragged_tensor_dict",
+        rows=rows,
+        payload=payload,
+        metadata={
+            "keys": list(keys),
+            "key_codecs": key_codecs,
+            "schema_source": "field_schema",
+        },
+    )
+
+
+def _decode_ragged_tensor_dict_values(
+    payload: dict[str, Any], rows: int, metadata: Mapping[str, Any]
+) -> list[Any]:
+    null_mask = payload["null_mask"]
+    if len(null_mask) != rows:
+        raise ValueError(
+            f"ragged_tensor_dict null_mask row count {len(null_mask)} != expected {rows}"
+        )
+    keys = _normalize_ragged_tensor_dict_keys(metadata.get("keys", []))
+    key_values: dict[str, list[Any]] = {}
+    for key in keys:
+        sub_payload = _ragged_tensor_dict_payload_items(payload, key, kind="payload")
+        values = _decode_ragged_tensor_values(sub_payload, rows)
+        if len(values) != rows:
+            raise ValueError(
+                f"ragged_tensor_dict key {key!r} row count {len(values)} != expected {rows}"
+            )
+        key_values[key] = values
+    result: list[Any] = []
+    for row in range(rows):
+        if bool(null_mask[row]):
+            result.append(None)
+            continue
+        item: dict[str, Any] = {}
+        for key in keys:
+            value = key_values[key][row]
+            if value is not None:
+                item[key] = value
+        result.append(item)
+    return result
+
+
+def _encode_typed_ragged_values(
+    values: list[Any], dtype_hint: np.dtype[Any] | None = None
 ) -> tuple[dict[str, Any], dict[str, Any]]:
-    source_arrays = [np.asarray(value) for value in values if value is not None]
-    dtype = np.result_type(*source_arrays) if source_arrays else np.dtype(np.int64)
+    if dtype_hint is None:
+        source_arrays = [np.asarray(value) for value in values if value is not None]
+        dtype = np.result_type(*source_arrays) if source_arrays else np.dtype(np.int64)
+    else:
+        dtype = np.dtype(dtype_hint)
+    if dtype.hasobject:
+        raise ValueError("typed_ragged codec requires non-object dtype")
     arrays = [
         np.asarray([], dtype=dtype)
         if value is None

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -49,10 +49,8 @@ class BundleTransferPolicy:
 class FieldSchema:
     """Schema hint for DataProto fields.
 
-    ``field_schemas`` maps DataProto field names to hints. Unlisted fields and
-    ``codec="auto"`` keep inference. ``metadata["section"]`` may pin a field to
-    ``"batch"``, ``"non_tensor_batch"``, or ``"meta_info"``. ``ragged_tensor_dict``
-    keys must be a finite iterable of non-empty strings without path separators.
+    ``metadata["section"]`` may pin a field to ``batch``,
+    ``non_tensor_batch``, or ``meta_info``.
     """
 
     codec: str
@@ -930,11 +928,11 @@ class MooncakeBundleTransfer:
             }, metadata
 
         if codec == "ragged_tensor_dict":
-            return self._read_ragged_tensor_dict_payload_with_reader(
+            return self._read_ragged_tensor_dict_payload(
                 payload_members,
                 metadata,
-                lambda: read_member_indices("null_mask", indices),
-                lambda encoded: self._read_structured_non_tensor_payload_indices(
+                read_null_mask=lambda: read_member_indices("null_mask", indices),
+                read_key_payload=lambda encoded: self._read_structured_non_tensor_payload_indices(
                     stage_ref, encoded, indices
                 ),
             )
@@ -1105,11 +1103,11 @@ class MooncakeBundleTransfer:
             }, metadata
 
         if codec == "ragged_tensor_dict":
-            return self._read_ragged_tensor_dict_payload_with_reader(
+            return self._read_ragged_tensor_dict_payload(
                 payload_members,
                 metadata,
-                lambda: read_member("null_mask", start, end),
-                lambda encoded: self._read_structured_non_tensor_payload_slice(
+                read_null_mask=lambda: read_member("null_mask", start, end),
+                read_key_payload=lambda encoded: self._read_structured_non_tensor_payload_slice(
                     stage_ref, encoded, row_slice, total_rows
                 ),
             )
@@ -1149,28 +1147,6 @@ class MooncakeBundleTransfer:
 
         raise ValueError(f"unknown structured non-tensor codec: {codec}")
 
-    def _read_ragged_tensor_dict_payload_with_reader(
-        self,
-        payload_members: Mapping[str, str],
-        metadata: dict[str, Any],
-        read_null_mask: Callable[[], Any],
-        read_key_payload: Callable[
-            [Mapping[str, Any]], tuple[dict[str, Any], Mapping[str, Any]]
-        ],
-    ) -> tuple[dict[str, Any], Mapping[str, Any]]:
-        return self._read_ragged_tensor_dict_payload(
-            payload_members,
-            metadata,
-            read_null_mask=read_null_mask,
-            read_key_payload=lambda key_members, key_metadata: read_key_payload(
-                {
-                    "codec": "ragged_tensor",
-                    "metadata": key_metadata,
-                    "payload_members": key_members,
-                }
-            ),
-        )
-
     def _read_ragged_tensor_dict_payload(
         self,
         payload_members: Mapping[str, str],
@@ -1178,8 +1154,7 @@ class MooncakeBundleTransfer:
         *,
         read_null_mask: Callable[[], Any],
         read_key_payload: Callable[
-            [Mapping[str, str], Mapping[str, Any]],
-            tuple[dict[str, Any], Mapping[str, Any]],
+            [Mapping[str, Any]], tuple[dict[str, Any], Mapping[str, Any]]
         ],
     ) -> tuple[dict[str, Any], Mapping[str, Any]]:
         key_codecs = dict(metadata.get("key_codecs") or {})
@@ -1190,7 +1165,11 @@ class MooncakeBundleTransfer:
                 payload_members, key, kind="manifest"
             )
             key_payload, key_metadata = read_key_payload(
-                key_members, key_codecs.get(key) or {}
+                {
+                    "codec": "ragged_tensor",
+                    "metadata": key_codecs.get(key) or {},
+                    "payload_members": key_members,
+                }
             )
             key_codecs[key] = key_metadata
             for name, value in key_payload.items():
@@ -1697,13 +1676,11 @@ def _select_mapping(
 
 
 _DATAPROTO_SCHEMA_SECTIONS = frozenset({"batch", "non_tensor_batch", "meta_info"})
-_FIELD_SCHEMA_CODECS = frozenset(
-    {
-        "auto", "ragged_tensor_dict", "ragged_tensor", "typed_ragged",
-        "ndarray", "bytes_ragged", "media_bytes", "media_list_ragged",
-        "utf8_ragged", "msgpack_ragged", "json_ragged",
-    }
-)
+_FIELD_SCHEMA_CODECS = frozenset({
+    "auto", "ragged_tensor_dict", "ragged_tensor", "typed_ragged", "ndarray",
+    "bytes_ragged", "media_bytes", "media_list_ragged", "utf8_ragged",
+    "msgpack_ragged", "json_ragged",
+})
 _RAGGED_TENSOR_PAYLOAD_NAMES = frozenset({"data", "offsets", "shapes", "ndims", "nulls"})
 
 
@@ -1746,24 +1723,23 @@ def _validate_dataproto_schema_sections(
 ) -> None:
     if not field_schemas:
         return
-    sections = {
-        "batch": batch,
-        "non_tensor_batch": non_tensor_batch,
-        "meta_info": meta_info,
+    actual_sections = {
+        name: section
+        for section, fields in {
+            "batch": batch,
+            "non_tensor_batch": non_tensor_batch,
+            "meta_info": meta_info,
+        }.items()
+        for name in fields
     }
     for name, schema in field_schemas.items():
         declared = _schema_section(name, schema)
-        if declared is None:
-            continue
-        if name in sections[declared]:
-            continue
-        for section, fields in sections.items():
-            if section != declared and name in fields:
-                raise ValueError(
-                    f"FieldSchema for {name!r} declares section {declared!r}, "
-                    f"but data contains it in {section!r}"
-                )
-
+        actual = actual_sections.get(name)
+        if declared is not None and actual is not None and actual != declared:
+            raise ValueError(
+                f"FieldSchema for {name!r} declares section {declared!r}, "
+                f"but data contains it in {actual!r}"
+            )
 
 def _coerce_schema_non_tensor_value(name: str, value: Any) -> np.ndarray:
     if isinstance(value, np.ndarray):
@@ -1802,7 +1778,6 @@ def _encode_structured_non_tensor_field(
 def _encode_with_schema(
     path: str, value: np.ndarray, schema: FieldSchema
 ) -> _EncodedStructuredLeaf:
-    """Encode a non_tensor_batch field using an explicit schema."""
     values = list(value)
     _validate_schema_nullable(path, value, schema)
     codec = schema.codec
@@ -2296,7 +2271,7 @@ def _normalize_ragged_tensor_dict_keys(keys: Any) -> list[str]:
         raise ValueError("ragged_tensor_dict keys must not be empty")
     if len(set(normalized)) != len(normalized):
         raise ValueError("ragged_tensor_dict keys must not contain duplicates")
-    if any(any(separator in key for separator in (".", "/", "\\")) for key in normalized):
+    if any(separator in key for key in normalized for separator in (".", "/", "\\")):
         raise ValueError("ragged_tensor_dict keys must not contain path separators")
     return normalized
 
@@ -2322,9 +2297,12 @@ def _encode_ragged_tensor_dict_values(
     values: list[Any],
     schema: FieldSchema,
 ) -> _EncodedStructuredLeaf:
-    """Encode list[dict[str, Tensor] | None] without runtime structure inference."""
     rows = len(values)
     null_mask = np.asarray([item is None for item in values], dtype=np.bool_)
+    schema_keys = schema.metadata.get("keys")
+    keys = None if schema_keys is None else _normalize_ragged_tensor_dict_keys(schema_keys)
+    declared_keys = None if keys is None else set(keys)
+    inferred_keys: set[str] = set()
     for row, item in enumerate(values):
         if item is None:
             continue
@@ -2339,49 +2317,28 @@ def _encode_ragged_tensor_dict_values(
                 "ragged_tensor_dict rows cannot contain explicit None tensor values; "
                 f"row {row} has {explicit_null_keys}"
             )
-    schema_keys = schema.metadata.get("keys")
-    keys = (
-        None
-        if schema_keys is None
-        else _normalize_ragged_tensor_dict_keys(schema_keys)
-    )
-    non_null = [item for item in values if item is not None]
-    if not non_null and keys is None:
-        return _EncodedStructuredLeaf(
-            codec="ragged_tensor_dict",
-            rows=rows,
-            payload={"null_mask": null_mask},
-            metadata={
-                "keys": [],
-                "key_codecs": {},
-                "schema_source": "field_schema",
-            },
-        )
+        if declared_keys is None:
+            inferred_keys.update(item)
+            continue
+        extra_keys = sorted(set(item) - declared_keys)
+        if extra_keys:
+            raise ValueError(
+                "ragged_tensor_dict rows contain keys not declared in "
+                f"FieldSchema metadata['keys']; row {row} has {extra_keys}"
+            )
     if keys is None:
-        all_keys: set[str] = set()
-        for item in non_null:
-            all_keys.update(item.keys())
-        keys = _normalize_ragged_tensor_dict_keys(sorted(all_keys))
-    else:
-        declared_keys = set(keys)
-        for row, item in enumerate(values):
-            if item is None:
-                continue
-            extra_keys = sorted(set(item) - declared_keys)
-            if extra_keys:
-                raise ValueError(
-                    "ragged_tensor_dict rows contain keys not declared in "
-                    f"FieldSchema metadata['keys']; row {row} has {extra_keys}"
-                )
-    if _torch is None:
+        keys = _normalize_ragged_tensor_dict_keys(sorted(inferred_keys))
+    if keys and _torch is None:
         raise RuntimeError("torch is required to encode ragged_tensor_dict fields")
     payload: dict[str, Any] = {"null_mask": null_mask}
     key_codecs: dict[str, Any] = {}
     for key in keys:
-        key_values = [None if item is None else item.get(key) for item in values]
-        sub_payload, sub_metadata = _encode_ragged_tensor_values(key_values)
-        for payload_name, payload_value in sub_payload.items():
-            payload[f"{key}.{payload_name}"] = payload_value
+        sub_payload, sub_metadata = _encode_ragged_tensor_values(
+            [None if item is None else item.get(key) for item in values]
+        )
+        payload.update(
+            {f"{key}.{name}": value for name, value in sub_payload.items()}
+        )
         key_codecs[key] = sub_metadata
     return _EncodedStructuredLeaf(
         codec="ragged_tensor_dict",
@@ -2394,7 +2351,6 @@ def _encode_ragged_tensor_dict_values(
         },
     )
 
-
 def _decode_ragged_tensor_dict_values(
     payload: dict[str, Any], rows: int, metadata: Mapping[str, Any]
 ) -> list[Any]:
@@ -2403,29 +2359,23 @@ def _decode_ragged_tensor_dict_values(
         raise ValueError(
             f"ragged_tensor_dict null_mask row count {len(null_mask)} != expected {rows}"
         )
-    keys = _normalize_ragged_tensor_dict_keys(metadata.get("keys", []))
-    key_values: dict[str, list[Any]] = {}
-    for key in keys:
-        sub_payload = _ragged_tensor_dict_payload_items(payload, key, kind="payload")
-        values = _decode_ragged_tensor_values(sub_payload, rows)
-        if len(values) != rows:
-            raise ValueError(
-                f"ragged_tensor_dict key {key!r} row count {len(values)} != expected {rows}"
-            )
-        key_values[key] = values
+    key_values = {
+        key: _decode_ragged_tensor_values(
+            _ragged_tensor_dict_payload_items(payload, key, kind="payload"), rows
+        )
+        for key in _normalize_ragged_tensor_dict_keys(metadata.get("keys", []))
+    }
     result: list[Any] = []
     for row in range(rows):
         if bool(null_mask[row]):
             result.append(None)
-            continue
-        item: dict[str, Any] = {}
-        for key in keys:
-            value = key_values[key][row]
-            if value is not None:
-                item[key] = value
-        result.append(item)
+        else:
+            result.append({
+                key: values[row]
+                for key, values in key_values.items()
+                if values[row] is not None
+            })
     return result
-
 
 def _encode_typed_ragged_values(
     values: list[Any], dtype_hint: np.dtype[Any] | None = None

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -2329,13 +2329,13 @@ def _encode_ragged_tensor_dict_values(
         else _normalize_ragged_tensor_dict_keys(schema_keys)
     )
     non_null = [item for item in values if item is not None]
-    if not non_null:
+    if not non_null and keys is None:
         return _EncodedStructuredLeaf(
             codec="ragged_tensor_dict",
             rows=rows,
             payload={"null_mask": null_mask},
             metadata={
-                "keys": keys or [],
+                "keys": [],
                 "key_codecs": {},
                 "schema_source": "field_schema",
             },

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -1274,7 +1274,9 @@ class MooncakeBundleTransfer:
             field_updates[name] = StructuredFieldLocation(stage, member, "batch")
         encoded_updates: dict[str, Any] = {}
         for name, value in non_tensor_batch.items():
-            schema = field_schemas.get(name) if field_schemas else None
+            schema = _schema_for_section(
+                field_schemas, name, "non_tensor_batch"
+            )
             encoded: _EncodedStructuredLeaf | None = None
             if schema is not None:
                 try:
@@ -1696,6 +1698,20 @@ def _schema_section(name: str, schema: FieldSchema) -> str | None:
     return section
 
 
+def _schema_for_section(
+    field_schemas: Optional[Mapping[str, FieldSchema]],
+    name: str,
+    section: str,
+) -> FieldSchema | None:
+    if not field_schemas:
+        return None
+    schema = field_schemas.get(name)
+    if schema is None:
+        return None
+    declared = _schema_section(name, schema)
+    return schema if declared is None or declared == section else None
+
+
 def _schema_ndarray_dtype(
     schema: FieldSchema, *, required: bool = False
 ) -> np.dtype[Any] | None:
@@ -1723,23 +1739,27 @@ def _validate_dataproto_schema_sections(
 ) -> None:
     if not field_schemas:
         return
-    actual_sections = {
-        name: section
-        for section, fields in {
-            "batch": batch,
-            "non_tensor_batch": non_tensor_batch,
-            "meta_info": meta_info,
-        }.items()
-        for name in fields
+    sections = {
+        "batch": batch,
+        "non_tensor_batch": non_tensor_batch,
+        "meta_info": meta_info,
     }
+    actual_sections: dict[str, set[str]] = {}
+    for section, fields in sections.items():
+        for name in fields:
+            actual_sections.setdefault(name, set()).add(section)
     for name, schema in field_schemas.items():
         declared = _schema_section(name, schema)
+        if declared is None:
+            continue
         actual = actual_sections.get(name)
-        if declared is not None and actual is not None and actual != declared:
-            raise ValueError(
-                f"FieldSchema for {name!r} declares section {declared!r}, "
-                f"but data contains it in {actual!r}"
-            )
+        if not actual or declared in actual:
+            continue
+        actual_text = ", ".join(repr(section) for section in sorted(actual))
+        raise ValueError(
+            f"FieldSchema for {name!r} declares section {declared!r}, "
+            f"but data contains it in {actual_text}"
+        )
 
 def _coerce_schema_non_tensor_value(name: str, value: Any) -> np.ndarray:
     if isinstance(value, np.ndarray):

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -1297,18 +1297,23 @@ class MooncakeBundleTransfer:
         for name, value in non_tensor_batch.items():
             schema = field_schemas.get(name) if field_schemas else None
             encoded: _EncodedStructuredLeaf | None = None
-            if schema is not None and schema.codec != "auto":
+            if schema is not None:
                 try:
                     encode_value = _coerce_schema_non_tensor_value(name, value)
-                    encoded = _encode_with_schema(
-                        f"non_tensor_batch.{name}", encode_value, schema
-                    )
+                    if schema.codec == "auto":
+                        _validate_schema_nullable(
+                            f"non_tensor_batch.{name}", encode_value, schema
+                        )
+                    else:
+                        encoded = _encode_with_schema(
+                            f"non_tensor_batch.{name}", encode_value, schema
+                        )
                 except (TypeError, ValueError, RuntimeError, AttributeError) as exc:
                     raise type(exc)(
                         f"failed to encode non_tensor_batch field {name!r} "
                         f"with FieldSchema codec {schema.codec!r}: {exc}"
                     ) from exc
-            elif _should_encode_non_tensor_field(value):
+            if encoded is None and _should_encode_non_tensor_field(value):
                 encoded = _encode_structured_non_tensor_field(
                     f"non_tensor_batch.{name}", value
                 )
@@ -1741,19 +1746,19 @@ def _validate_dataproto_schema_sections(
 ) -> None:
     if not field_schemas:
         return
-    for section, fields in (
-        ("batch", batch),
-        ("non_tensor_batch", non_tensor_batch),
-        ("meta_info", meta_info),
-    ):
-        for name in fields:
-            schema = field_schemas.get(name)
-            if schema is None:
-                continue
-            declared = _schema_section(name, schema)
-            if declared is None:
-                continue
-            if declared != section:
+    sections = {
+        "batch": batch,
+        "non_tensor_batch": non_tensor_batch,
+        "meta_info": meta_info,
+    }
+    for name, schema in field_schemas.items():
+        declared = _schema_section(name, schema)
+        if declared is None:
+            continue
+        if name in sections[declared]:
+            continue
+        for section, fields in sections.items():
+            if section != declared and name in fields:
                 raise ValueError(
                     f"FieldSchema for {name!r} declares section {declared!r}, "
                     f"but data contains it in {section!r}"
@@ -1770,6 +1775,11 @@ def _coerce_schema_non_tensor_value(name: str, value: Any) -> np.ndarray:
     raise TypeError(
         f"non_tensor_batch field {name!r} with FieldSchema must be an ndarray or non-string sequence"
     )
+
+
+def _validate_schema_nullable(path: str, value: np.ndarray, schema: FieldSchema) -> None:
+    if not schema.nullable and any(item is None for item in value):
+        raise ValueError(f"FieldSchema for {path!r} is not nullable")
 
 
 def _should_encode_non_tensor_field(value: Any) -> bool:
@@ -1794,8 +1804,7 @@ def _encode_with_schema(
 ) -> _EncodedStructuredLeaf:
     """Encode a non_tensor_batch field using an explicit schema."""
     values = list(value)
-    if not schema.nullable and any(item is None for item in values):
-        raise ValueError(f"FieldSchema for {path!r} is not nullable")
+    _validate_schema_nullable(path, value, schema)
     codec = schema.codec
     if codec not in _FIELD_SCHEMA_CODECS:
         raise ValueError(f"unsupported schema codec: {codec!r}")
@@ -2317,10 +2326,18 @@ def _encode_ragged_tensor_dict_values(
     rows = len(values)
     null_mask = np.asarray([item is None for item in values], dtype=np.bool_)
     for row, item in enumerate(values):
-        if item is not None and not isinstance(item, Mapping):
+        if item is None:
+            continue
+        if not isinstance(item, Mapping):
             raise TypeError(
                 "ragged_tensor_dict rows must be mappings or None; "
                 f"row {row} is {type(item).__name__}"
+            )
+        explicit_null_keys = sorted(key for key, value in item.items() if value is None)
+        if explicit_null_keys:
+            raise TypeError(
+                "ragged_tensor_dict rows cannot contain explicit None tensor values; "
+                f"row {row} has {explicit_null_keys}"
             )
     schema_keys = schema.metadata.get("keys")
     keys = (
@@ -2345,6 +2362,17 @@ def _encode_ragged_tensor_dict_values(
         for item in non_null:
             all_keys.update(item.keys())
         keys = _normalize_ragged_tensor_dict_keys(sorted(all_keys))
+    else:
+        declared_keys = set(keys)
+        for row, item in enumerate(values):
+            if item is None:
+                continue
+            extra_keys = sorted(set(item) - declared_keys)
+            if extra_keys:
+                raise ValueError(
+                    "ragged_tensor_dict rows contain keys not declared in "
+                    f"FieldSchema metadata['keys']; row {row} has {extra_keys}"
+                )
     if _torch is None:
         raise RuntimeError("torch is required to encode ragged_tensor_dict fields")
     payload: dict[str, Any] = {"null_mask": null_mask}

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -1664,6 +1664,44 @@ def test_dataproto_field_schema_encodes_ragged_tensor_dict() -> None:
     assert torch.equal(indexed[1]["image"], rows[0]["image"])
 
 
+def test_dataproto_field_schema_encodes_all_null_ragged_tensor_dict() -> None:
+    pytest.importorskip("torch", exc_type=ImportError)
+    _store, transfer = make_transfer()
+    rows = np.empty(3, dtype=object)
+    rows[:] = [None, None, None]
+
+    ref = transfer.put_dataproto(
+        {
+            "batch": {"input_ids": np.arange(3)},
+            "non_tensor_batch": {"multi_modal_inputs": rows},
+        },
+        field_schemas={
+            "multi_modal_inputs": FieldSchema(
+                codec="ragged_tensor_dict",
+                metadata={"section": "non_tensor_batch", "keys": ["image"]},
+            )
+        },
+    )
+
+    encoded = ref.encoded_non_tensor["multi_modal_inputs"]
+    assert encoded["codec"] == "ragged_tensor_dict"
+    assert encoded["metadata"]["keys"] == ["image"]
+    assert "image.data" in encoded["payload"]
+
+    full = transfer.get_dataproto(ref)["non_tensor_batch"]["multi_modal_inputs"]
+    assert full.tolist() == [None, None, None]
+
+    sliced = transfer.get_dataproto(ref, rows=slice(1, 3))["non_tensor_batch"][
+        "multi_modal_inputs"
+    ]
+    assert sliced.tolist() == [None, None]
+
+    indexed = transfer.get_dataproto(ref, rows=[2, 0])["non_tensor_batch"][
+        "multi_modal_inputs"
+    ]
+    assert indexed.tolist() == [None, None]
+
+
 def test_dataproto_helper_treats_reserved_plain_dict_keys_as_batch_fields() -> None:
     _store, transfer = make_transfer()
     ref = transfer.put_dataproto({"batch": np.arange(4), "meta_info": np.arange(4)})

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -1686,7 +1686,7 @@ def test_dataproto_field_schema_encodes_all_null_ragged_tensor_dict() -> None:
     encoded = ref.encoded_non_tensor["multi_modal_inputs"]
     assert encoded["codec"] == "ragged_tensor_dict"
     assert encoded["metadata"]["keys"] == ["image"]
-    assert "image.data" in encoded["payload"]
+    assert "image.data" in encoded["payload_members"]
 
     full = transfer.get_dataproto(ref)["non_tensor_batch"]["multi_modal_inputs"]
     assert full.tolist() == [None, None, None]
@@ -1700,6 +1700,92 @@ def test_dataproto_field_schema_encodes_all_null_ragged_tensor_dict() -> None:
         "multi_modal_inputs"
     ]
     assert indexed.tolist() == [None, None]
+
+
+def test_dataproto_field_schema_rejects_lossy_ragged_tensor_dict_rows() -> None:
+    torch = pytest.importorskip("torch", exc_type=ImportError)
+    _store, transfer = make_transfer()
+
+    extra_key_rows = np.empty(1, dtype=object)
+    extra_key_rows[:] = [
+        {
+            "image": torch.arange(1, dtype=torch.float32),
+            "audio": torch.arange(1, dtype=torch.float32),
+        }
+    ]
+    with pytest.raises(ValueError, match="keys not declared"):
+        transfer.put_dataproto(
+            {
+                "batch": {"input_ids": np.arange(1)},
+                "non_tensor_batch": {"mm": extra_key_rows},
+            },
+            field_schemas={
+                "mm": FieldSchema(
+                    codec="ragged_tensor_dict",
+                    metadata={"section": "non_tensor_batch", "keys": ["image"]},
+                )
+            },
+        )
+
+    explicit_null_rows = np.empty(1, dtype=object)
+    explicit_null_rows[:] = [{"image": None}]
+    with pytest.raises(TypeError, match="explicit None"):
+        transfer.put_dataproto(
+            {
+                "batch": {"input_ids": np.arange(1)},
+                "non_tensor_batch": {"mm": explicit_null_rows},
+            },
+            field_schemas={
+                "mm": FieldSchema(
+                    codec="ragged_tensor_dict",
+                    metadata={"section": "non_tensor_batch", "keys": ["image"]},
+                )
+            },
+        )
+
+
+def test_dataproto_field_schema_auto_enforces_nullable() -> None:
+    _store, transfer = make_transfer()
+    values = np.empty(2, dtype=object)
+    values[:] = ["ok", None]
+
+    with pytest.raises(ValueError, match="not nullable"):
+        transfer.put_dataproto(
+            {
+                "batch": {"input_ids": np.arange(2)},
+                "non_tensor_batch": {"text": values},
+            },
+            field_schemas={
+                "text": FieldSchema(
+                    codec="auto",
+                    nullable=False,
+                    metadata={"section": "non_tensor_batch"},
+                )
+            },
+        )
+
+
+def test_dataproto_field_schema_allows_same_named_meta_info() -> None:
+    _store, transfer = make_transfer()
+    values = np.asarray(["a", "b"], dtype=object)
+
+    ref = transfer.put_dataproto(
+        {
+            "batch": {"input_ids": np.arange(2)},
+            "non_tensor_batch": {"label": values},
+            "meta_info": {"label": "metadata-label"},
+        },
+        field_schemas={
+            "label": FieldSchema(
+                codec="utf8_ragged", metadata={"section": "non_tensor_batch"}
+            )
+        },
+    )
+
+    result = transfer.get_dataproto(ref)
+
+    assert result["non_tensor_batch"]["label"].tolist() == ["a", "b"]
+    assert result["meta_info"]["label"] == "metadata-label"
 
 
 def test_dataproto_helper_treats_reserved_plain_dict_keys_as_batch_fields() -> None:

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -11,6 +11,7 @@ import pytest
 
 from mooncake.structured_object_store import (
     BundleTransferPolicy,
+    FieldSchema,
     MooncakeBundleTransfer,
     RemoteBundleRef,
     StructuredObjectPayload,
@@ -1547,6 +1548,120 @@ def test_dataproto_helper_accepts_legacy_dict_inputs() -> None:
     assert np.array_equal(envelope["batch"]["tokens"], np.arange(6).reshape(3, 2))
     assert envelope["non_tensor_batch"]["uid"].tolist() == ["a", "b", "c"]
     assert envelope["meta_info"] == {"step": 3}
+
+
+def test_dataproto_field_schema_encodes_typed_ragged_non_tensor_field() -> None:
+    _store, transfer = make_transfer()
+    values = np.empty(3, dtype=object)
+    values[:] = [
+        np.asarray([1, 2], dtype=np.int32),
+        None,
+        np.asarray([3], dtype=np.int32),
+    ]
+
+    ref = transfer.put_dataproto(
+        {
+            "batch": {"input_ids": np.arange(3)},
+            "non_tensor_batch": {"tokens": values},
+        },
+        field_schemas={
+            "tokens": FieldSchema(
+                codec="typed_ragged",
+                metadata={"section": "non_tensor_batch", "dtype": "int32"},
+            )
+        },
+    )
+
+    result = transfer.get_dataproto(ref)
+
+    assert result["non_tensor_batch"]["tokens"][0] == [1, 2]
+    assert result["non_tensor_batch"]["tokens"][1] is None
+    assert result["non_tensor_batch"]["tokens"][2] == [3]
+
+    bad_text = np.asarray([object()], dtype=object)
+    with pytest.raises(AttributeError, match="failed to encode.*'text'.*utf8_ragged"):
+        transfer.put_dataproto(
+            {"batch": {"input_ids": np.arange(1)}, "non_tensor_batch": {"text": bad_text}},
+            field_schemas={"text": FieldSchema(codec="utf8_ragged")},
+        )
+
+
+def test_dataproto_field_schema_validates_declared_section() -> None:
+    _store, transfer = make_transfer()
+
+    with pytest.raises(ValueError, match="declares section"):
+        transfer.put_dataproto(
+            {"batch": {"input_ids": np.arange(3)}},
+            field_schemas={
+                "input_ids": FieldSchema(
+                    codec="ndarray", metadata={"section": "non_tensor_batch"}
+                )
+            },
+        )
+
+
+def test_dataproto_field_schema_rejects_ambiguous_tensor_dict_keys() -> None:
+    _store, transfer = make_transfer()
+    rows = np.empty(1, dtype=object)
+    rows[:] = [{"image.data": object()}]
+
+    with pytest.raises(ValueError, match="must not contain"):
+        transfer.put_dataproto(
+            {"batch": {"input_ids": np.arange(1)}, "non_tensor_batch": {"mm": rows}},
+            field_schemas={
+                "mm": FieldSchema(
+                    codec="ragged_tensor_dict",
+                    metadata={"section": "non_tensor_batch"},
+                )
+            },
+        )
+
+
+def test_dataproto_field_schema_encodes_ragged_tensor_dict() -> None:
+    torch = pytest.importorskip("torch", exc_type=ImportError)
+    _store, transfer = make_transfer()
+    rows = np.empty(4, dtype=object)
+    rows[:] = [
+        {"image": torch.arange(4, dtype=torch.float32).reshape(2, 2)},
+        None,
+        {},
+        {"image": torch.arange(2, dtype=torch.float32)},
+    ]
+
+    ref = transfer.put_dataproto(
+        {
+            "batch": {"input_ids": np.arange(4)},
+            "non_tensor_batch": {"multi_modal_inputs": rows},
+        },
+        field_schemas={
+            "multi_modal_inputs": FieldSchema(
+                codec="ragged_tensor_dict",
+                metadata={"section": "non_tensor_batch", "keys": {"image": None}},
+            )
+        },
+    )
+
+    result = transfer.get_dataproto(ref)
+    actual = result["non_tensor_batch"]["multi_modal_inputs"]
+
+    assert ref.encoded_non_tensor["multi_modal_inputs"]["codec"] == "ragged_tensor_dict"
+    assert torch.equal(actual[0]["image"], rows[0]["image"])
+    assert actual[1] is None
+    assert actual[2] == {}
+    assert torch.equal(actual[3]["image"], rows[3]["image"])
+
+    sliced = transfer.get_dataproto(ref, rows=slice(1, 4))["non_tensor_batch"][
+        "multi_modal_inputs"
+    ]
+    assert sliced[0] is None
+    assert sliced[1] == {}
+    assert torch.equal(sliced[2]["image"], rows[3]["image"])
+
+    indexed = transfer.get_dataproto(ref, rows=[3, 0])["non_tensor_batch"][
+        "multi_modal_inputs"
+    ]
+    assert torch.equal(indexed[0]["image"], rows[3]["image"])
+    assert torch.equal(indexed[1]["image"], rows[0]["image"])
 
 
 def test_dataproto_helper_treats_reserved_plain_dict_keys_as_batch_fields() -> None:

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -1550,6 +1550,13 @@ def test_dataproto_helper_accepts_legacy_dict_inputs() -> None:
     assert envelope["meta_info"] == {"step": 3}
 
 
+def _schema_test_data(field: str, values: np.ndarray) -> dict[str, object]:
+    return {
+        "batch": {"input_ids": np.arange(len(values))},
+        "non_tensor_batch": {field: values},
+    }
+
+
 def test_dataproto_field_schema_encodes_typed_ragged_non_tensor_field() -> None:
     _store, transfer = make_transfer()
     values = np.empty(3, dtype=object)
@@ -1560,10 +1567,7 @@ def test_dataproto_field_schema_encodes_typed_ragged_non_tensor_field() -> None:
     ]
 
     ref = transfer.put_dataproto(
-        {
-            "batch": {"input_ids": np.arange(3)},
-            "non_tensor_batch": {"tokens": values},
-        },
+        _schema_test_data("tokens", values),
         field_schemas={
             "tokens": FieldSchema(
                 codec="typed_ragged",
@@ -1571,22 +1575,14 @@ def test_dataproto_field_schema_encodes_typed_ragged_non_tensor_field() -> None:
             )
         },
     )
+    result = transfer.get_dataproto(ref)["non_tensor_batch"]["tokens"]
 
-    result = transfer.get_dataproto(ref)
-
-    assert result["non_tensor_batch"]["tokens"][0] == [1, 2]
-    assert result["non_tensor_batch"]["tokens"][1] is None
-    assert result["non_tensor_batch"]["tokens"][2] == [3]
-
-    bad_text = np.asarray([object()], dtype=object)
-    with pytest.raises(AttributeError, match="failed to encode.*'text'.*utf8_ragged"):
-        transfer.put_dataproto(
-            {"batch": {"input_ids": np.arange(1)}, "non_tensor_batch": {"text": bad_text}},
-            field_schemas={"text": FieldSchema(codec="utf8_ragged")},
-        )
+    assert result[0] == [1, 2]
+    assert result[1] is None
+    assert result[2] == [3]
 
 
-def test_dataproto_field_schema_validates_declared_section() -> None:
+def test_dataproto_field_schema_validates_schema_errors() -> None:
     _store, transfer = make_transfer()
 
     with pytest.raises(ValueError, match="declares section"):
@@ -1599,18 +1595,28 @@ def test_dataproto_field_schema_validates_declared_section() -> None:
             },
         )
 
-
-def test_dataproto_field_schema_rejects_ambiguous_tensor_dict_keys() -> None:
-    _store, transfer = make_transfer()
     rows = np.empty(1, dtype=object)
     rows[:] = [{"image.data": object()}]
-
     with pytest.raises(ValueError, match="must not contain"):
         transfer.put_dataproto(
-            {"batch": {"input_ids": np.arange(1)}, "non_tensor_batch": {"mm": rows}},
+            _schema_test_data("mm", rows),
             field_schemas={
                 "mm": FieldSchema(
                     codec="ragged_tensor_dict",
+                    metadata={"section": "non_tensor_batch"},
+                )
+            },
+        )
+
+    values = np.empty(2, dtype=object)
+    values[:] = ["ok", None]
+    with pytest.raises(ValueError, match="not nullable"):
+        transfer.put_dataproto(
+            _schema_test_data("text", values),
+            field_schemas={
+                "text": FieldSchema(
+                    codec="auto",
+                    nullable=False,
                     metadata={"section": "non_tensor_batch"},
                 )
             },
@@ -1629,10 +1635,7 @@ def test_dataproto_field_schema_encodes_ragged_tensor_dict() -> None:
     ]
 
     ref = transfer.put_dataproto(
-        {
-            "batch": {"input_ids": np.arange(4)},
-            "non_tensor_batch": {"multi_modal_inputs": rows},
-        },
+        _schema_test_data("multi_modal_inputs", rows),
         field_schemas={
             "multi_modal_inputs": FieldSchema(
                 codec="ragged_tensor_dict",
@@ -1641,9 +1644,7 @@ def test_dataproto_field_schema_encodes_ragged_tensor_dict() -> None:
         },
     )
 
-    result = transfer.get_dataproto(ref)
-    actual = result["non_tensor_batch"]["multi_modal_inputs"]
-
+    actual = transfer.get_dataproto(ref)["non_tensor_batch"]["multi_modal_inputs"]
     assert ref.encoded_non_tensor["multi_modal_inputs"]["codec"] == "ragged_tensor_dict"
     assert torch.equal(actual[0]["image"], rows[0]["image"])
     assert actual[1] is None
@@ -1653,28 +1654,18 @@ def test_dataproto_field_schema_encodes_ragged_tensor_dict() -> None:
     sliced = transfer.get_dataproto(ref, rows=slice(1, 4))["non_tensor_batch"][
         "multi_modal_inputs"
     ]
-    assert sliced[0] is None
-    assert sliced[1] == {}
-    assert torch.equal(sliced[2]["image"], rows[3]["image"])
-
     indexed = transfer.get_dataproto(ref, rows=[3, 0])["non_tensor_batch"][
         "multi_modal_inputs"
     ]
+    assert sliced[0] is None
+    assert sliced[1] == {}
+    assert torch.equal(sliced[2]["image"], rows[3]["image"])
     assert torch.equal(indexed[0]["image"], rows[3]["image"])
     assert torch.equal(indexed[1]["image"], rows[0]["image"])
-
-
-def test_dataproto_field_schema_encodes_all_null_ragged_tensor_dict() -> None:
-    pytest.importorskip("torch", exc_type=ImportError)
-    _store, transfer = make_transfer()
-    rows = np.empty(3, dtype=object)
-    rows[:] = [None, None, None]
-
-    ref = transfer.put_dataproto(
-        {
-            "batch": {"input_ids": np.arange(3)},
-            "non_tensor_batch": {"multi_modal_inputs": rows},
-        },
+    all_null = np.empty(3, dtype=object)
+    all_null[:] = [None, None, None]
+    all_null_ref = transfer.put_dataproto(
+        _schema_test_data("multi_modal_inputs", all_null),
         field_schemas={
             "multi_modal_inputs": FieldSchema(
                 codec="ragged_tensor_dict",
@@ -1682,110 +1673,12 @@ def test_dataproto_field_schema_encodes_all_null_ragged_tensor_dict() -> None:
             )
         },
     )
-
-    encoded = ref.encoded_non_tensor["multi_modal_inputs"]
-    assert encoded["codec"] == "ragged_tensor_dict"
+    encoded = all_null_ref.encoded_non_tensor["multi_modal_inputs"]
     assert encoded["metadata"]["keys"] == ["image"]
     assert "image.data" in encoded["payload_members"]
-
-    full = transfer.get_dataproto(ref)["non_tensor_batch"]["multi_modal_inputs"]
-    assert full.tolist() == [None, None, None]
-
-    sliced = transfer.get_dataproto(ref, rows=slice(1, 3))["non_tensor_batch"][
+    assert transfer.get_dataproto(all_null_ref)["non_tensor_batch"][
         "multi_modal_inputs"
-    ]
-    assert sliced.tolist() == [None, None]
-
-    indexed = transfer.get_dataproto(ref, rows=[2, 0])["non_tensor_batch"][
-        "multi_modal_inputs"
-    ]
-    assert indexed.tolist() == [None, None]
-
-
-def test_dataproto_field_schema_rejects_lossy_ragged_tensor_dict_rows() -> None:
-    torch = pytest.importorskip("torch", exc_type=ImportError)
-    _store, transfer = make_transfer()
-
-    extra_key_rows = np.empty(1, dtype=object)
-    extra_key_rows[:] = [
-        {
-            "image": torch.arange(1, dtype=torch.float32),
-            "audio": torch.arange(1, dtype=torch.float32),
-        }
-    ]
-    with pytest.raises(ValueError, match="keys not declared"):
-        transfer.put_dataproto(
-            {
-                "batch": {"input_ids": np.arange(1)},
-                "non_tensor_batch": {"mm": extra_key_rows},
-            },
-            field_schemas={
-                "mm": FieldSchema(
-                    codec="ragged_tensor_dict",
-                    metadata={"section": "non_tensor_batch", "keys": ["image"]},
-                )
-            },
-        )
-
-    explicit_null_rows = np.empty(1, dtype=object)
-    explicit_null_rows[:] = [{"image": None}]
-    with pytest.raises(TypeError, match="explicit None"):
-        transfer.put_dataproto(
-            {
-                "batch": {"input_ids": np.arange(1)},
-                "non_tensor_batch": {"mm": explicit_null_rows},
-            },
-            field_schemas={
-                "mm": FieldSchema(
-                    codec="ragged_tensor_dict",
-                    metadata={"section": "non_tensor_batch", "keys": ["image"]},
-                )
-            },
-        )
-
-
-def test_dataproto_field_schema_auto_enforces_nullable() -> None:
-    _store, transfer = make_transfer()
-    values = np.empty(2, dtype=object)
-    values[:] = ["ok", None]
-
-    with pytest.raises(ValueError, match="not nullable"):
-        transfer.put_dataproto(
-            {
-                "batch": {"input_ids": np.arange(2)},
-                "non_tensor_batch": {"text": values},
-            },
-            field_schemas={
-                "text": FieldSchema(
-                    codec="auto",
-                    nullable=False,
-                    metadata={"section": "non_tensor_batch"},
-                )
-            },
-        )
-
-
-def test_dataproto_field_schema_allows_same_named_meta_info() -> None:
-    _store, transfer = make_transfer()
-    values = np.asarray(["a", "b"], dtype=object)
-
-    ref = transfer.put_dataproto(
-        {
-            "batch": {"input_ids": np.arange(2)},
-            "non_tensor_batch": {"label": values},
-            "meta_info": {"label": "metadata-label"},
-        },
-        field_schemas={
-            "label": FieldSchema(
-                codec="utf8_ragged", metadata={"section": "non_tensor_batch"}
-            )
-        },
-    )
-
-    result = transfer.get_dataproto(ref)
-
-    assert result["non_tensor_batch"]["label"].tolist() == ["a", "b"]
-    assert result["meta_info"]["label"] == "metadata-label"
+    ].tolist() == [None, None, None]
 
 
 def test_dataproto_helper_treats_reserved_plain_dict_keys_as_batch_fields() -> None:

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -1621,6 +1621,19 @@ def test_dataproto_field_schema_validates_schema_errors() -> None:
                 )
             },
         )
+    schema = {
+        "mm": FieldSchema(
+            codec="ragged_tensor_dict",
+            metadata={"section": "non_tensor_batch", "keys": ["image"]},
+        )
+    }
+    for row_value, error_type, message in [
+        ({"image": object(), "audio": object()}, ValueError, "keys not declared"),
+        ({"image": None}, TypeError, "explicit None"),
+    ]:
+        rows[:] = [row_value]
+        with pytest.raises(error_type, match=message):
+            transfer.put_dataproto(_schema_test_data("mm", rows), field_schemas=schema)
 
 
 def test_dataproto_field_schema_encodes_ragged_tensor_dict() -> None:
@@ -1679,6 +1692,12 @@ def test_dataproto_field_schema_encodes_ragged_tensor_dict() -> None:
     assert transfer.get_dataproto(all_null_ref)["non_tensor_batch"][
         "multi_modal_inputs"
     ].tolist() == [None, None, None]
+    assert transfer.get_dataproto(all_null_ref, rows=slice(1, 3))[
+        "non_tensor_batch"
+    ]["multi_modal_inputs"].tolist() == [None, None]
+    assert transfer.get_dataproto(all_null_ref, rows=[2, 0])["non_tensor_batch"][
+        "multi_modal_inputs"
+    ].tolist() == [None, None]
 
 
 def test_dataproto_helper_treats_reserved_plain_dict_keys_as_batch_fields() -> None:

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -1581,6 +1581,15 @@ def test_dataproto_field_schema_encodes_typed_ragged_non_tensor_field() -> None:
     assert result[1] is None
     assert result[2] == [3]
 
+    bad_text = np.asarray([object()], dtype=object)
+    with pytest.raises(AttributeError, match="failed to encode.*'text'.*utf8_ragged"):
+        transfer.put_dataproto(
+            _schema_test_data("text", bad_text),
+            field_schemas={
+                "text": FieldSchema(codec="utf8_ragged")
+            },
+        )
+
 
 def test_dataproto_field_schema_validates_schema_errors() -> None:
     _store, transfer = make_transfer()
@@ -1634,6 +1643,51 @@ def test_dataproto_field_schema_validates_schema_errors() -> None:
         rows[:] = [row_value]
         with pytest.raises(error_type, match=message):
             transfer.put_dataproto(_schema_test_data("mm", rows), field_schemas=schema)
+
+
+def test_dataproto_field_schema_allows_same_named_meta_info() -> None:
+    _store, transfer = make_transfer()
+    values = np.asarray(["a", "b"], dtype=object)
+
+    ref = transfer.put_dataproto(
+        {
+            "batch": {"input_ids": np.arange(2)},
+            "non_tensor_batch": {"label": values},
+            "meta_info": {"label": "metadata-label"},
+        },
+        field_schemas={
+            "label": FieldSchema(
+                codec="utf8_ragged", metadata={"section": "non_tensor_batch"}
+            )
+        },
+    )
+
+    result = transfer.get_dataproto(ref)
+
+    assert result["non_tensor_batch"]["label"].tolist() == ["a", "b"]
+    assert result["meta_info"]["label"] == "metadata-label"
+
+
+def test_dataproto_field_schema_does_not_apply_meta_info_schema_to_non_tensor() -> None:
+    _store, transfer = make_transfer()
+    values = np.asarray([{"k": 1}, {"k": 2}], dtype=object)
+
+    ref = transfer.put_dataproto(
+        {
+            "batch": {"input_ids": np.arange(2)},
+            "non_tensor_batch": {"label": values},
+            "meta_info": {"label": "metadata-label"},
+        },
+        field_schemas={
+            "label": FieldSchema(
+                codec="utf8_ragged", metadata={"section": "meta_info"}
+            )
+        },
+    )
+
+    result = transfer.get_dataproto(ref)
+    assert result["non_tensor_batch"]["label"].tolist() == [{"k": 1}, {"k": 2}]
+    assert result["meta_info"]["label"] == "metadata-label"
 
 
 def test_dataproto_field_schema_encodes_ragged_tensor_dict() -> None:


### PR DESCRIPTION
## Motivation

This PR is split out from the larger PR2671 rollout data transfer optimization work.

PR2671 currently mixes multiple review scopes, including schema-guided DataProto encoding, legacy dict/DataProto API changes, codec changes, BufferPool-backed GET, multi-buffer PUT, native copy acceleration, packaging updates, and broader structured object refactoring. To make the work easier to review and validate, this branch extracts the schema-driven DataProto field encoding part as the first standalone PR.

The goal of this PR is to make rollout data transfer less dependent on runtime sampling and codec inference for known non-tensor rollout fields. Different RL frameworks produce rollout data with different field shapes, including typed ragged arrays and dict-like multimodal tensor payloads. Schema hints allow these fields to select the intended structured codec explicitly while preserving the existing inferred path for fields without schema.

This branch is based on `kvcache/main` and is split from PR2671.

## Description

This PR adds schema-guided encoding support for DataProto non-tensor fields in `mooncake-wheel`.

Main changes:

- Add `FieldSchema` as an optional schema hint for DataProto fields.
- Extend `put_dataproto()` and `append_dataproto_fields()` with keyword-only `field_schemas`.
- Keep existing behavior unchanged for fields without schema hints and for `codec="auto"`.
- Add schema section validation for `batch`, `non_tensor_batch`, and `meta_info`.
- Add explicit schema-driven codec dispatch for non-tensor fields.
- Support typed ragged non-tensor fields with explicit dtype hints.
- Add schema-guided `ragged_tensor_dict` support for dict rows containing ragged tensor values.
- Support full, slice, and index reads for `ragged_tensor_dict`.
- Harden `ragged_tensor_dict` manifest/payload validation:
  - reject ambiguous keys
  - reject empty or path-like keys
  - validate expected payload members
  - validate `null_mask` and per-key row counts
- Add focused unit tests for schema-driven DataProto behavior.

This PR intentionally does not include the rest of PR2671, such as BufferPool-backed GET, multi-buffer PUT, native copy extension, packaging changes, or broader structured object refactoring. Those changes should be reviewed as follow-up PRs.

Layering of this PR:

1. External API:
   - Adds optional `field_schemas` to DataProto put/append APIs.

2. Leaf / manifest / schema:
   - Adds `FieldSchema`.
   - Adds schema section validation.
   - Adds schema codec/key validation.

3. Encode:
   - Adds schema-driven non-tensor encode dispatch.
   - Adds typed ragged and ragged tensor dict schema paths.

4. Decode:
   - Adds `ragged_tensor_dict` decode support.
   - Adds manifest/payload consistency checks.

5. Put:
   - Reuses the existing structured object put path.
   - Does not introduce new publish or storage lifecycle logic.

6. Get:
   - Adds full/slice/index read support for schema-guided ragged tensor dict fields.
   - Reuses existing ragged tensor range-read helpers.

Code size:

```text
2 files changed, 493 insertions(+), 7 deletions(-)
```

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**

```bash
PYTHONPATH=/root/Mooncake-PR2671-schema/mooncake-wheel \
python3 -m py_compile \
  mooncake-wheel/mooncake/structured_object_store.py \
  mooncake-wheel/tests/test_structured_object_store.py
```

```bash
PYTHONPATH=/root/Mooncake-PR2671-schema/mooncake-wheel \
python3 -m pytest --collect-only -q \
  mooncake-wheel/tests/test_structured_object_store.py \
  mooncake-wheel/tests/test_put_get_tensor.py
```

```bash
PYTHONPATH=/root/Mooncake-PR2671-schema/mooncake-wheel \
python3 -m pytest -q \
  mooncake-wheel/tests/test_structured_object_store.py \
  -k "field_schema"
```

```bash
PYTHONPATH=/root/Mooncake-PR2671-schema/mooncake-wheel \
python3 -m pytest -q \
  mooncake-wheel/tests/test_structured_object_store.py \
  -k "dataproto_helper_accepts_legacy_dict_inputs or dataproto_helper_treats_reserved_plain_dict_keys_as_batch_fields or dataproto_helper_rejects_cross_section_field_name_collision or dataproto_ref_handle_roundtrip_materializes_and_cleans_up or dataproto_helper_appends_stage_fields_without_rewriting_existing or put_object_roundtrips_numpy_and_torch_tensor_fields or put_object_roundtrips_wrapped_numpy_and_torch_values or field_schema"
```

**Test results:**

- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

Results:

```text
117 tests collected
```

```text
field_schema: 3 passed, 1 skipped
```

```text
DataProto focused regression set: 8 passed, 3 skipped
```

The skipped tests are due to the local torch/CUDA import issue on the test machine:

```text
ImportError: libc10_cuda.so: undefined symbol: cudaGetDriverEntryPointByVersion
```

This is an environment issue on the test host and is not caused by this PR.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

Notes:

- Commit-time pre-commit hooks ran successfully during local commit.
- Full `pre-commit run --all-files` was not run.
- This PR is kept under the >500 LOC RFC threshold
- This PR is split from PR2671 specifically to keep the review scope small.

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

AI tools were used to help inspect the existing PR2671 changes, prepare the split branch, run review checklists, and draft this PR description. I‘m responsible for understanding, validating, and defending all changes.