### PR TITLE
[TransferEngine] Cancel and drain NVMe-oF batches after slice failures

### DIFF
--- a/mooncake-transfer-engine/include/transport/nvmeof_transport/cufile_desc_pool.h
+++ b/mooncake-transfer-engine/include/transport/nvmeof_transport/cufile_desc_pool.h
@@ -20,6 +20,7 @@
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <mutex>
 #include <vector>
 
@@ -28,6 +29,22 @@
 namespace mooncake {
 
 class CUFileDescPoolTestPeer;
+
+class CUFileBatchAPI {
+   public:
+    virtual ~CUFileBatchAPI() = default;
+
+    virtual CUfileError_t setUp(CUfileBatchHandle_t* batch_handle,
+                                unsigned nr) = 0;
+    virtual CUfileError_t submit(CUfileBatchHandle_t batch_handle, unsigned nr,
+                                 CUfileIOParams_t* params, unsigned flags) = 0;
+    virtual CUfileError_t getStatus(CUfileBatchHandle_t batch_handle,
+                                    unsigned min_nr, unsigned* nr,
+                                    CUfileIOEvents_t* events,
+                                    struct timespec* timeout) = 0;
+    virtual CUfileError_t cancel(CUfileBatchHandle_t batch_handle) = 0;
+    virtual void destroy(CUfileBatchHandle_t batch_handle) = 0;
+};
 
 // Wrapper for reusable CUfileBatchHandle_t
 // cuFileBatchIOSetUp is expensive, so we reuse handles (similar to GDS
@@ -40,13 +57,24 @@ struct BatchHandle {
 // Per-batch descriptor with independent io_params and io_events
 // Each allocation gets a fresh descriptor to avoid parameter confusion
 struct CUFileBatchDesc {
-    BatchHandle* batch_handle;  // Pointer to reusable handle from pool
+    BatchHandle* batch_handle = nullptr;  // Reusable handle from the pool
     std::vector<CUfileIOParams_t> io_params;
     // Completion events returned by cuFile are correlated by cookie and cached
     // by submission index. cuFileBatchIOGetStatus only returns completed I/Os,
     // so its output cannot be treated as a positional status snapshot.
     std::vector<CUfileIOEvents_t> io_events;
     std::vector<CUfileIOEvents_t> polled_events;
+    std::vector<bool> cancel_requested;
+    size_t submitted_count = 0;
+    bool failure_seen = false;
+    bool cancel_attempted = false;
+};
+
+struct CUFileBatchSnapshot {
+    std::vector<CUfileIOEvents_t> io_events;
+    std::vector<bool> cancel_requested;
+    bool failure_seen = false;
+    bool all_terminal = true;
 };
 
 class CUFileDescPool {
@@ -70,8 +98,13 @@ class CUFileDescPool {
     // Submit the batch
     int submitBatch(int idx);
 
-    // Get transfer status for a specific slice
-    CUfileIOEvents_t getTransferStatus(int idx, int slice_id);
+    // Drop parameters appended since the last successful submission.
+    int discardUnsubmittedParams(int idx);
+
+    bool isAcceptingSubmissions(int idx);
+
+    // Poll once and return a descriptor-wide completion snapshot.
+    int pollBatch(int idx, CUFileBatchSnapshot& snapshot);
 
     // Get current number of slices in the descriptor
     int getSliceNum(int idx);
@@ -83,11 +116,17 @@ class CUFileDescPool {
     CUFileBatchDesc* getDesc(int idx);
 
    private:
+    CUFileDescPool(size_t max_batch_size,
+                   std::shared_ptr<CUFileBatchAPI> batch_api);
+
     static bool cachePolledEvent(std::vector<CUfileIOEvents_t>& io_events,
                                  const CUfileIOEvents_t& event);
+    static bool isTerminal(CUfileStatus_t status);
+    static bool allTerminal(const CUFileBatchDesc& desc);
 
     static const size_t MAX_NR_DESC = 256;  // Max number of descriptors
     size_t max_batch_size_;
+    std::shared_ptr<CUFileBatchAPI> batch_api_;
 
     // Object pool for BatchHandle to avoid frequent cuFileBatchIOSetUp/Destroy
     std::vector<BatchHandle*> handle_pool_;

--- a/mooncake-transfer-engine/include/transport/nvmeof_transport/cufile_desc_pool.h
+++ b/mooncake-transfer-engine/include/transport/nvmeof_transport/cufile_desc_pool.h
@@ -77,6 +77,12 @@ struct CUFileBatchSnapshot {
     bool all_terminal = true;
 };
 
+enum class CUFileBatchPollResult {
+    kError = -1,
+    kSuccess = 0,
+    kRetry = 1,
+};
+
 class CUFileDescPool {
     friend class CUFileDescPoolTestPeer;
 
@@ -104,7 +110,7 @@ class CUFileDescPool {
     bool isAcceptingSubmissions(int idx);
 
     // Poll once and return a descriptor-wide completion snapshot.
-    int pollBatch(int idx, CUFileBatchSnapshot& snapshot);
+    CUFileBatchPollResult pollBatch(int idx, CUFileBatchSnapshot& snapshot);
 
     // Get current number of slices in the descriptor
     int getSliceNum(int idx);

--- a/mooncake-transfer-engine/include/transport/nvmeof_transport/nvmeof_transport.h
+++ b/mooncake-transfer-engine/include/transport/nvmeof_transport/nvmeof_transport.h
@@ -103,9 +103,9 @@ class NVMeoFTransport : public Transport {
         return 0;
     }
 
-    void addSliceToCUFileBatch(void *source_addr, uint64_t file_offset,
-                               uint64_t slice_len, uint64_t desc_id,
-                               TransferRequest::OpCode op, CUfileHandle_t fh);
+    int addSliceToCUFileBatch(void *source_addr, uint64_t file_offset,
+                              uint64_t slice_len, uint64_t desc_id,
+                              TransferRequest::OpCode op, CUfileHandle_t fh);
 
     const char *getName() const override { return "nvmeof"; }
 

--- a/mooncake-transfer-engine/src/transport/nvmeof_transport/cufile_desc_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/nvmeof_transport/cufile_desc_pool.cpp
@@ -217,10 +217,20 @@ int CUFileDescPool::submitBatch(int idx) {
     }
 
     const auto submit_count = desc->io_params.size() - desc->submitted_count;
-    CUFILE_CHECK(
+    const auto result =
         batch_api_->submit(desc->batch_handle->handle, submit_count,
-                           desc->io_params.data() + desc->submitted_count, 0));
+                           desc->io_params.data() + desc->submitted_count, 0);
+
+    // cuFile does not guarantee that a failed batch submission accepted no
+    // requests. Keep the attempted range alive and quarantine the descriptor
+    // so status polling can conservatively cancel and drain it.
     desc->submitted_count = desc->io_params.size();
+    if (result.err != CU_FILE_SUCCESS) {
+        desc->failure_seen = true;
+        LOG(ERROR) << "Failed to submit descriptor " << idx << ": "
+                   << cuFileGetErrorString(result);
+        return -1;
+    }
     return 0;
 }
 
@@ -246,11 +256,12 @@ bool CUFileDescPool::isAcceptingSubmissions(int idx) {
     return !descs_[idx]->failure_seen;
 }
 
-int CUFileDescPool::pollBatch(int idx, CUFileBatchSnapshot& snapshot) {
+CUFileBatchPollResult CUFileDescPool::pollBatch(int idx,
+                                                CUFileBatchSnapshot& snapshot) {
     RWSpinlock::WriteGuard guard(mutex_);
     if (idx < 0 || idx >= (int)MAX_NR_DESC || descs_[idx] == nullptr) {
         LOG(ERROR) << "Invalid descriptor index: " << idx;
-        return -1;
+        return CUFileBatchPollResult::kError;
     }
 
     auto* desc = descs_[idx];
@@ -279,23 +290,28 @@ int CUFileDescPool::pollBatch(int idx, CUFileBatchSnapshot& snapshot) {
     unsigned nr = desc->submitted_count;
     if (desc->polled_events.size() < nr) {
         LOG(ERROR) << "Completion buffer is too small for descriptor " << idx;
-        return -1;
+        return CUFileBatchPollResult::kError;
     }
     if (nr > 0) {
         auto result =
             batch_api_->getStatus(desc->batch_handle->handle, 0, &nr,
                                   desc->polled_events.data(), nullptr);
         if (result.err != CU_FILE_SUCCESS) {
-            // The batch-specific internal error is documented as retryable.
+            if (result.err == CU_FILE_INTERNAL_BATCH_GETSTATUS_ERROR) {
+                cancel_active();
+                LOG(WARNING)
+                    << "Failed to poll descriptor " << idx << ": "
+                    << cuFileGetErrorString(result) << "; retrying later";
+                return CUFileBatchPollResult::kRetry;
+            }
+
             // Other errors leave the descriptor state unknown, so quarantine
             // it and attempt cancellation.
-            if (result.err != CU_FILE_INTERNAL_BATCH_GETSTATUS_ERROR) {
-                desc->failure_seen = true;
-            }
+            desc->failure_seen = true;
             cancel_active();
             LOG(ERROR) << "Failed to poll descriptor " << idx << ": "
                        << cuFileGetErrorString(result);
-            return -1;
+            return CUFileBatchPollResult::kError;
         }
     }
 
@@ -329,7 +345,7 @@ int CUFileDescPool::pollBatch(int idx, CUFileBatchSnapshot& snapshot) {
         desc->cancel_requested.begin() + desc->submitted_count);
     snapshot.failure_seen = desc->failure_seen;
     snapshot.all_terminal = !has_active;
-    return 0;
+    return CUFileBatchPollResult::kSuccess;
 }
 
 bool CUFileDescPool::cachePolledEvent(std::vector<CUfileIOEvents_t>& io_events,

--- a/mooncake-transfer-engine/src/transport/nvmeof_transport/cufile_desc_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/nvmeof_transport/cufile_desc_pool.cpp
@@ -18,14 +18,52 @@
 
 #include <cstddef>
 #include <mutex>
+#include <utility>
 
 #include "cufile.h"
 #include "transport/nvmeof_transport/cufile_context.h"
 
 namespace mooncake {
 
+namespace {
+
+class NativeCUFileBatchAPI : public CUFileBatchAPI {
+   public:
+    CUfileError_t setUp(CUfileBatchHandle_t* batch_handle,
+                        unsigned nr) override {
+        return cuFileBatchIOSetUp(batch_handle, nr);
+    }
+
+    CUfileError_t submit(CUfileBatchHandle_t batch_handle, unsigned nr,
+                         CUfileIOParams_t* params, unsigned flags) override {
+        return cuFileBatchIOSubmit(batch_handle, nr, params, flags);
+    }
+
+    CUfileError_t getStatus(CUfileBatchHandle_t batch_handle, unsigned min_nr,
+                            unsigned* nr, CUfileIOEvents_t* events,
+                            struct timespec* timeout) override {
+        return cuFileBatchIOGetStatus(batch_handle, min_nr, nr, events,
+                                      timeout);
+    }
+
+    CUfileError_t cancel(CUfileBatchHandle_t batch_handle) override {
+        return cuFileBatchIOCancel(batch_handle);
+    }
+
+    void destroy(CUfileBatchHandle_t batch_handle) override {
+        cuFileBatchIODestroy(batch_handle);
+    }
+};
+
+}  // namespace
+
 CUFileDescPool::CUFileDescPool(size_t max_batch_size)
-    : max_batch_size_(max_batch_size) {
+    : CUFileDescPool(max_batch_size, std::make_shared<NativeCUFileBatchAPI>()) {
+}
+
+CUFileDescPool::CUFileDescPool(size_t max_batch_size,
+                               std::shared_ptr<CUFileBatchAPI> batch_api)
+    : max_batch_size_(max_batch_size), batch_api_(std::move(batch_api)) {
     // Initialize descriptor array
     for (size_t i = 0; i < MAX_NR_DESC; ++i) {
         descs_[i] = nullptr;
@@ -36,7 +74,7 @@ CUFileDescPool::~CUFileDescPool() {
     // First, collect and destroy batch_handles from allocated descriptors
     for (size_t i = 0; i < MAX_NR_DESC; ++i) {
         if (descs_[i] != nullptr) {
-            cuFileBatchIODestroy(descs_[i]->batch_handle->handle);
+            batch_api_->destroy(descs_[i]->batch_handle->handle);
             delete descs_[i]->batch_handle;
             delete descs_[i];
             descs_[i] = nullptr;
@@ -46,7 +84,7 @@ CUFileDescPool::~CUFileDescPool() {
     // Then clean up any remaining handles in the pool
     std::lock_guard<std::mutex> lock(handle_pool_lock_);
     for (auto* batch_handle : handle_pool_) {
-        cuFileBatchIODestroy(batch_handle->handle);
+        batch_api_->destroy(batch_handle->handle);
         delete batch_handle;
     }
     handle_pool_.clear();
@@ -94,7 +132,7 @@ int CUFileDescPool::allocCUfileDesc(size_t batch_size) {
         if (!batch_handle || batch_handle->max_nr != max_batch_size_) {
             // Destroy mismatched handle if exists
             if (batch_handle) {
-                cuFileBatchIODestroy(batch_handle->handle);
+                batch_api_->destroy(batch_handle->handle);
                 delete batch_handle;
                 batch_handle = nullptr;
             }
@@ -102,8 +140,9 @@ int CUFileDescPool::allocCUfileDesc(size_t batch_size) {
             auto new_batch_handle = std::make_unique<BatchHandle>();
             new_batch_handle->max_nr = max_batch_size_;
             // cuFileBatchIOSetUp is time-costly, so we reuse handles
-            CUFILE_CHECK(
-                cuFileBatchIOSetUp(&new_batch_handle->handle, max_batch_size_));
+            auto result =
+                batch_api_->setUp(&new_batch_handle->handle, max_batch_size_);
+            CUFILE_CHECK(result);
             batch_handle = new_batch_handle.release();
         }
 
@@ -113,6 +152,8 @@ int CUFileDescPool::allocCUfileDesc(size_t batch_size) {
         desc->io_events.clear();
         desc->io_events.reserve(max_batch_size_);
         desc->polled_events.resize(max_batch_size_);
+        desc->cancel_requested.clear();
+        desc->cancel_requested.reserve(max_batch_size_);
 
         descs_[idx] = desc;
         return idx;
@@ -120,7 +161,7 @@ int CUFileDescPool::allocCUfileDesc(size_t batch_size) {
         // Clean up on exception to avoid memory leaks
         delete desc;
         if (batch_handle) {
-            cuFileBatchIODestroy(batch_handle->handle);
+            batch_api_->destroy(batch_handle->handle);
             delete batch_handle;
         }
         throw;  // Re-throw to caller
@@ -135,6 +176,12 @@ int CUFileDescPool::pushParams(int idx, const CUfileIOParams_t& io_params) {
     }
 
     auto* desc = descs_[idx];
+    if (desc->failure_seen) {
+        LOG(ERROR) << "Descriptor " << idx
+                   << " cannot accept parameters while failure cleanup is "
+                      "in progress";
+        return -1;
+    }
     if (desc->io_params.size() >= max_batch_size_) {
         LOG(ERROR) << "Descriptor " << idx << " is full";
         return -1;
@@ -147,6 +194,7 @@ int CUFileDescPool::pushParams(int idx, const CUfileIOParams_t& io_params) {
     desc->io_params.push_back(params);
     desc->io_events.push_back(CUfileIOEvents_t{
         .cookie = params.cookie, .status = CUFILE_WAITING, .ret = 0});
+    desc->cancel_requested.push_back(false);
     return 0;
 }
 
@@ -158,66 +206,149 @@ int CUFileDescPool::submitBatch(int idx) {
     }
 
     auto* desc = descs_[idx];
-    if (desc->io_params.empty()) {
+    if (desc->failure_seen) {
+        LOG(ERROR) << "Descriptor " << idx
+                   << " cannot submit while failure cleanup is in progress";
+        return -1;
+    }
+    if (desc->submitted_count == desc->io_params.size()) {
         LOG(WARNING) << "Submitting empty batch for descriptor " << idx;
         return 0;
     }
 
-    // Submit all params in this descriptor
-    CUFILE_CHECK(cuFileBatchIOSubmit(desc->batch_handle->handle,
-                                     desc->io_params.size(),
-                                     desc->io_params.data(), 0));
+    const auto submit_count = desc->io_params.size() - desc->submitted_count;
+    CUFILE_CHECK(
+        batch_api_->submit(desc->batch_handle->handle, submit_count,
+                           desc->io_params.data() + desc->submitted_count, 0));
+    desc->submitted_count = desc->io_params.size();
     return 0;
 }
 
-CUfileIOEvents_t CUFileDescPool::getTransferStatus(int idx, int slice_id) {
+int CUFileDescPool::discardUnsubmittedParams(int idx) {
     RWSpinlock::WriteGuard guard(mutex_);
     if (idx < 0 || idx >= (int)MAX_NR_DESC || descs_[idx] == nullptr) {
         LOG(ERROR) << "Invalid descriptor index: " << idx;
-        CUfileIOEvents_t event;
-        event.status = CUFILE_FAILED;
-        event.ret = -1;
-        return event;
+        return -1;
     }
 
     auto* desc = descs_[idx];
-    if (slice_id < 0 || slice_id >= (int)desc->io_params.size()) {
-        LOG(ERROR) << "Invalid slice_id " << slice_id << " for descriptor "
-                   << idx << " (size: " << desc->io_params.size() << ")";
-        CUfileIOEvents_t event;
-        event.status = CUFILE_FAILED;
-        event.ret = -1;
-        return event;
+    desc->io_params.resize(desc->submitted_count);
+    desc->io_events.resize(desc->submitted_count);
+    desc->cancel_requested.resize(desc->submitted_count);
+    return 0;
+}
+
+bool CUFileDescPool::isAcceptingSubmissions(int idx) {
+    RWSpinlock::ReadGuard guard(mutex_);
+    if (idx < 0 || idx >= (int)MAX_NR_DESC || descs_[idx] == nullptr) {
+        return false;
+    }
+    return !descs_[idx]->failure_seen;
+}
+
+int CUFileDescPool::pollBatch(int idx, CUFileBatchSnapshot& snapshot) {
+    RWSpinlock::WriteGuard guard(mutex_);
+    if (idx < 0 || idx >= (int)MAX_NR_DESC || descs_[idx] == nullptr) {
+        LOG(ERROR) << "Invalid descriptor index: " << idx;
+        return -1;
     }
 
-    unsigned nr = desc->io_params.size();
+    auto* desc = descs_[idx];
+    auto cancel_active = [&]() {
+        if (!desc->failure_seen || desc->cancel_attempted) return;
+
+        bool has_active = false;
+        for (size_t i = 0; i < desc->submitted_count; ++i) {
+            if (!isTerminal(desc->io_events[i].status)) {
+                desc->cancel_requested[i] = true;
+                has_active = true;
+            }
+        }
+        if (!has_active) return;
+
+        // Set the flag before entering cuFile so an error cannot cause a retry.
+        desc->cancel_attempted = true;
+        auto result = batch_api_->cancel(desc->batch_handle->handle);
+        if (result.err != CU_FILE_SUCCESS) {
+            LOG(ERROR) << "Failed to cancel descriptor " << idx << ": "
+                       << cuFileGetErrorString(result)
+                       << "; continuing to drain completions";
+        }
+    };
+
+    unsigned nr = desc->submitted_count;
     if (desc->polled_events.size() < nr) {
         LOG(ERROR) << "Completion buffer is too small for descriptor " << idx;
-        CUfileIOEvents_t event;
-        event.status = CUFILE_FAILED;
-        event.ret = -1;
-        return event;
+        return -1;
     }
-    CUFILE_CHECK(cuFileBatchIOGetStatus(desc->batch_handle->handle, 0, &nr,
-                                        desc->polled_events.data(), nullptr));
+    if (nr > 0) {
+        auto result =
+            batch_api_->getStatus(desc->batch_handle->handle, 0, &nr,
+                                  desc->polled_events.data(), nullptr);
+        if (result.err != CU_FILE_SUCCESS) {
+            // The batch-specific internal error is documented as retryable.
+            // Other errors leave the descriptor state unknown, so quarantine
+            // it and attempt cancellation.
+            if (result.err != CU_FILE_INTERNAL_BATCH_GETSTATUS_ERROR) {
+                desc->failure_seen = true;
+            }
+            cancel_active();
+            LOG(ERROR) << "Failed to poll descriptor " << idx << ": "
+                       << cuFileGetErrorString(result);
+            return -1;
+        }
+    }
 
     for (unsigned i = 0; i < nr; ++i) {
         const auto& event = desc->polled_events[i];
-        if (!cachePolledEvent(desc->io_events, event)) {
+        const uintptr_t cookie = reinterpret_cast<uintptr_t>(event.cookie);
+        if (cookie == 0 || cookie > desc->submitted_count ||
+            !cachePolledEvent(desc->io_events, event)) {
             LOG(ERROR) << "Invalid completion cookie "
                        << reinterpret_cast<uintptr_t>(event.cookie)
                        << " for descriptor " << idx;
         }
     }
 
-    return desc->io_events[slice_id];
+    bool has_active = false;
+    for (size_t i = 0; i < desc->submitted_count; ++i) {
+        const auto status = desc->io_events[i].status;
+        if (!isTerminal(status)) {
+            has_active = true;
+        } else if (status != CUFILE_COMPLETE) {
+            desc->failure_seen = true;
+        }
+    }
+
+    if (has_active) cancel_active();
+
+    snapshot.io_events.assign(desc->io_events.begin(),
+                              desc->io_events.begin() + desc->submitted_count);
+    snapshot.cancel_requested.assign(
+        desc->cancel_requested.begin(),
+        desc->cancel_requested.begin() + desc->submitted_count);
+    snapshot.failure_seen = desc->failure_seen;
+    snapshot.all_terminal = !has_active;
+    return 0;
 }
 
 bool CUFileDescPool::cachePolledEvent(std::vector<CUfileIOEvents_t>& io_events,
                                       const CUfileIOEvents_t& event) {
     const uintptr_t cookie = reinterpret_cast<uintptr_t>(event.cookie);
     if (cookie == 0 || cookie > io_events.size()) return false;
-    io_events[cookie - 1] = event;
+    auto& cached = io_events[cookie - 1];
+    if (!isTerminal(cached.status)) cached = event;
+    return true;
+}
+
+bool CUFileDescPool::isTerminal(CUfileStatus_t status) {
+    return status != CUFILE_WAITING && status != CUFILE_PENDING;
+}
+
+bool CUFileDescPool::allTerminal(const CUFileBatchDesc& desc) {
+    for (size_t i = 0; i < desc.submitted_count; ++i) {
+        if (!isTerminal(desc.io_events[i].status)) return false;
+    }
     return true;
 }
 
@@ -232,30 +363,37 @@ int CUFileDescPool::getSliceNum(int idx) {
 }
 
 int CUFileDescPool::freeCUfileDesc(int idx) {
-    RWSpinlock::WriteGuard guard(mutex_);
-    if (idx < 0 || idx >= (int)MAX_NR_DESC || descs_[idx] == nullptr) {
-        LOG(ERROR) << "Invalid descriptor index: " << idx;
-        return -1;
-    }
-
-    auto* desc = descs_[idx];
-
-    // IMPORTANT: Caller should ensure all IOs are completed (via
-    // getTransferStatus) before calling freeCUfileDesc, as cuFile may still
-    // access io_params otherwise. This is critical for the handle pooling
-    // optimization - the handle will be immediately reused and could lead to
-    // use-after-free bugs if IOs are in-flight.
-    //
-    // Return the handle to pool for reuse (avoid expensive
-    // cuFileBatchIODestroy)
+    BatchHandle* retired_handle = nullptr;
     {
-        std::lock_guard<std::mutex> lock(handle_pool_lock_);
-        handle_pool_.push_back(desc->batch_handle);
+        RWSpinlock::WriteGuard guard(mutex_);
+        if (idx < 0 || idx >= (int)MAX_NR_DESC || descs_[idx] == nullptr) {
+            LOG(ERROR) << "Invalid descriptor index: " << idx;
+            return -1;
+        }
+
+        auto* desc = descs_[idx];
+        if (!allTerminal(*desc)) {
+            LOG(ERROR) << "Descriptor " << idx
+                       << " cannot be freed while I/O is active";
+            return -1;
+        }
+
+        if (desc->failure_seen) {
+            retired_handle = desc->batch_handle;
+        } else {
+            std::lock_guard<std::mutex> lock(handle_pool_lock_);
+            handle_pool_.push_back(desc->batch_handle);
+        }
+
+        // Delete the descriptor (each allocation gets a fresh one)
+        delete desc;
+        descs_[idx] = nullptr;
     }
 
-    // Delete the descriptor (each allocation gets a fresh one)
-    delete desc;
-    descs_[idx] = nullptr;
+    if (retired_handle) {
+        batch_api_->destroy(retired_handle->handle);
+        delete retired_handle;
+    }
 
     return 0;
 }

--- a/mooncake-transfer-engine/src/transport/nvmeof_transport/nvmeof_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/nvmeof_transport/nvmeof_transport.cpp
@@ -67,13 +67,19 @@ Transport::TransferStatusEnum from_cufile_transfer_status(
 }
 
 NVMeoFTransport::BatchID NVMeoFTransport::allocateBatchID(size_t batch_size) {
-    auto nvmeof_desc = new NVMeoFBatchDesc();
+    auto nvmeof_desc = std::make_unique<NVMeoFBatchDesc>();
     auto batch_id = Transport::allocateBatchID(batch_size);
+    if (batch_id == static_cast<BatchID>(ERR_MEMORY)) return batch_id;
+
     auto &batch_desc = *((BatchDesc *)(batch_id));
     nvmeof_desc->desc_idx_ = desc_pool_->allocCUfileDesc(batch_size);
+    if (nvmeof_desc->desc_idx_ < 0) {
+        Transport::freeBatchID(batch_id);
+        return static_cast<BatchID>(ERR_MEMORY);
+    }
     nvmeof_desc->transfer_status.reserve(batch_size);
     nvmeof_desc->task_to_slices.reserve(batch_size);
-    batch_desc.context = nvmeof_desc;
+    batch_desc.context = nvmeof_desc.release();
     return batch_id;
 }
 
@@ -96,24 +102,110 @@ Status NVMeoFTransport::getTransferStatus(BatchID batch_id, size_t task_id,
         return Status::InvalidArgument(
             "NVMeoFTransport: Task has no submitted slices");
     }
+    const bool all_tasks_finished =
+        std::all_of(batch_desc.task_list.begin(), batch_desc.task_list.end(),
+                    [](const TransferTask &mapped_task) {
+                        return mapped_task.is_finished;
+                    });
+    if (all_tasks_finished && task.is_finished &&
+        task_id < nvmeof_desc.transfer_status.size()) {
+        status = nvmeof_desc.transfer_status[task_id];
+        return Status::OK();
+    }
 
-    auto [slice_id, slice_num] = nvmeof_desc.task_to_slices[task_id];
+    thread_local CUFileBatchSnapshot snapshot;
+    if (desc_pool_->pollBatch(nvmeof_desc.desc_idx_, snapshot) != 0) {
+        return Status::Context("NVMeoFTransport: Failed to poll cuFile batch");
+    }
+
+    if (snapshot.failure_seen && !snapshot.all_terminal) {
+        if (task.is_finished && task_id < nvmeof_desc.transfer_status.size()) {
+            status = nvmeof_desc.transfer_status[task_id];
+            return Status::OK();
+        }
+        const bool has_pending =
+            std::any_of(snapshot.io_events.begin(), snapshot.io_events.end(),
+                        [](const CUfileIOEvents_t &event) {
+                            return event.status == CUFILE_PENDING;
+                        });
+        status = {.s = has_pending ? PENDING : WAITING, .transferred_bytes = 0};
+        return Status::OK();
+    }
+
     thread_local std::vector<TransferStatus> slice_statuses;
-    slice_statuses.clear();
-    slice_statuses.reserve(slice_num);
-    for (size_t i = slice_id; i < slice_id + slice_num; ++i) {
-        auto event = desc_pool_->getTransferStatus(nvmeof_desc.desc_idx_, i);
-        auto slice_status = from_cufile_transfer_status(event.status);
-        slice_statuses.push_back(TransferStatus{
-            .s = slice_status,
-            .transferred_bytes = slice_status == COMPLETED ? event.ret : 0});
+    auto aggregate_task = [&](size_t current_task_id,
+                              TransferStatus &task_status,
+                              bool &is_finished) -> bool {
+        auto [slice_id, slice_num] =
+            nvmeof_desc.task_to_slices[current_task_id];
+        if (slice_id > snapshot.io_events.size() ||
+            slice_num > snapshot.io_events.size() - slice_id) {
+            return false;
+        }
+
+        slice_statuses.clear();
+        slice_statuses.reserve(slice_num);
+        for (size_t i = slice_id; i < slice_id + slice_num; ++i) {
+            const auto &event = snapshot.io_events[i];
+            auto slice_status = from_cufile_transfer_status(event.status);
+            if (slice_status == CANCELED &&
+                i < snapshot.cancel_requested.size() &&
+                snapshot.cancel_requested[i]) {
+                slice_status = FAILED;
+            }
+            slice_statuses.push_back(
+                TransferStatus{.s = slice_status,
+                               .transferred_bytes =
+                                   slice_status == COMPLETED ? event.ret : 0});
+        }
+
+        task_status = aggregateTransferStatus(slice_statuses, is_finished);
+        return true;
+    };
+
+    if (snapshot.all_terminal) {
+        if (nvmeof_desc.task_to_slices.size() < batch_desc.task_list.size()) {
+            return Status::Context(
+                "NVMeoFTransport: Missing task-to-slice mapping");
+        }
+
+        std::vector<TransferStatus> final_statuses(batch_desc.task_list.size());
+        for (size_t i = 0; i < batch_desc.task_list.size(); ++i) {
+            bool is_finished = false;
+            if (!aggregate_task(i, final_statuses[i], is_finished) ||
+                !is_finished) {
+                return Status::Context(
+                    "NVMeoFTransport: Invalid task-to-slice mapping");
+            }
+        }
+
+        nvmeof_desc.transfer_status = std::move(final_statuses);
+        for (auto &mapped_task : batch_desc.task_list) {
+            mapped_task.is_finished = true;
+        }
+        status = nvmeof_desc.transfer_status[task_id];
+        return Status::OK();
+    }
+
+    if (task.is_finished && task_id < nvmeof_desc.transfer_status.size()) {
+        status = nvmeof_desc.transfer_status[task_id];
+        return Status::OK();
     }
 
     bool is_finished = false;
-    status = aggregateTransferStatus(slice_statuses, is_finished);
-    if (is_finished) {
-        task.is_finished = true;
+    if (!aggregate_task(task_id, status, is_finished)) {
+        return Status::Context(
+            "NVMeoFTransport: Invalid task-to-slice mapping");
     }
+    if (!is_finished) return Status::OK();
+
+    if (nvmeof_desc.transfer_status.size() < batch_desc.task_list.size()) {
+        nvmeof_desc.transfer_status.resize(
+            batch_desc.task_list.size(),
+            TransferStatus{.s = PENDING, .transferred_bytes = 0});
+    }
+    nvmeof_desc.transfer_status[task_id] = status;
+    task.is_finished = true;
     return Status::OK();
 }
 
@@ -188,6 +280,11 @@ Status NVMeoFTransport::submitTransfer(
     auto &batch_desc = *((BatchDesc *)(batch_id));
     auto &nvmeof_desc = *((NVMeoFBatchDesc *)(batch_desc.context));
 
+    if (!desc_pool_->isAcceptingSubmissions(nvmeof_desc.desc_idx_)) {
+        return Status::BatchBusy(
+            "NVMeoFTransport: Batch is draining after a cuFile failure");
+    }
+
     if (batch_desc.task_list.size() + entries.size() > batch_desc.batch_size) {
         LOG(ERROR)
             << "NVMeoFTransport: Exceed the limitation of current batch's "
@@ -197,8 +294,24 @@ Status NVMeoFTransport::submitTransfer(
             std::to_string(batch_id));
     }
 
-    size_t task_id = batch_desc.task_list.size();
-    size_t slice_id = desc_pool_->getSliceNum(nvmeof_desc.desc_idx_);
+    const size_t initial_task_count = batch_desc.task_list.size();
+    const size_t initial_status_count = nvmeof_desc.transfer_status.size();
+    const size_t initial_mapping_count = nvmeof_desc.task_to_slices.size();
+    int initial_slice_count = desc_pool_->getSliceNum(nvmeof_desc.desc_idx_);
+    if (initial_slice_count < 0) {
+        return Status::Context(
+            "NVMeoFTransport: Invalid cuFile batch descriptor");
+    }
+
+    auto rollback_unsubmitted = [&]() {
+        desc_pool_->discardUnsubmittedParams(nvmeof_desc.desc_idx_);
+        nvmeof_desc.transfer_status.resize(initial_status_count);
+        nvmeof_desc.task_to_slices.resize(initial_mapping_count);
+        batch_desc.task_list.resize(initial_task_count);
+    };
+
+    size_t task_id = initial_task_count;
+    size_t slice_id = initial_slice_count;
     batch_desc.task_list.resize(task_id + entries.size());
     std::unordered_map<SegmentID, std::shared_ptr<SegmentDesc>>
         segment_desc_map;
@@ -256,9 +369,13 @@ Status NVMeoFTransport::submitTransfer(
                     fh = segment_to_context_.at(buf_key)->getHandle();
                 }
                 // 5. add cufile request
-                addSliceToCUFileBatch(source_addr, file_offset, slice_len,
-                                      nvmeof_desc.desc_idx_, request.opcode,
-                                      fh);
+                if (addSliceToCUFileBatch(source_addr, file_offset, slice_len,
+                                          nvmeof_desc.desc_idx_, request.opcode,
+                                          fh) != 0) {
+                    rollback_unsubmitted();
+                    return Status::Context(
+                        "NVMeoFTransport: Failed to append cuFile request");
+                }
             }
             ++buffer_id;
             current_offset += buffer_desc.length;
@@ -271,22 +388,39 @@ Status NVMeoFTransport::submitTransfer(
         slice_id += task.slice_count;
     }
 
-    desc_pool_->submitBatch(nvmeof_desc.desc_idx_);
+    if (desc_pool_->submitBatch(nvmeof_desc.desc_idx_) != 0) {
+        return Status::Context(
+            "NVMeoFTransport: Failed to submit cuFile batch");
+    }
     // LOG(INFO) << "submit nr " << slice_id << " start " << start_slice_id;
     return Status::OK();
 }
 
 Status NVMeoFTransport::freeBatchID(BatchID batch_id) {
+    if (batch_id == 0) {
+        return Status::InvalidArgument("NVMeoFTransport: Invalid batch ID");
+    }
     auto &batch_desc = *((BatchDesc *)(batch_id));
     auto *nvmeof_desc_ptr = (NVMeoFBatchDesc *)(batch_desc.context);
+    if (nvmeof_desc_ptr == nullptr) {
+        return Status::InvalidArgument(
+            "NVMeoFTransport: Batch was not allocated by this transport");
+    }
+    for (const auto &task : batch_desc.task_list) {
+        if (!task.is_finished) {
+            return Status::BatchBusy(
+                "BatchID cannot be freed until all tasks are done");
+        }
+    }
+
     int desc_idx = nvmeof_desc_ptr->desc_idx_;
-    Status rc = Transport::freeBatchID(batch_id);
-    if (rc != Status::OK()) {
-        return rc;
+    if (desc_pool_->freeCUfileDesc(desc_idx) != 0) {
+        return Status::BatchBusy(
+            "BatchID cannot be freed while cuFile I/O is active");
     }
     delete nvmeof_desc_ptr;
-    desc_pool_->freeCUfileDesc(desc_idx);
-    return Status::OK();
+    batch_desc.context = nullptr;
+    return Transport::freeBatchID(batch_id);
 }
 
 int NVMeoFTransport::install(std::string &local_server_name,
@@ -334,10 +468,12 @@ void NVMeoFTransport::addSliceToTask(void *source_addr, uint64_t slice_len,
     __sync_fetch_and_add(&task.slice_count, 1);
 }
 
-void NVMeoFTransport::addSliceToCUFileBatch(
-    void *source_addr, uint64_t file_offset, uint64_t slice_len,
-    uint64_t desc_id, TransferRequest::OpCode op, CUfileHandle_t fh) {
-    CUfileIOParams_t params;
+int NVMeoFTransport::addSliceToCUFileBatch(void *source_addr,
+                                           uint64_t file_offset,
+                                           uint64_t slice_len, uint64_t desc_id,
+                                           TransferRequest::OpCode op,
+                                           CUfileHandle_t fh) {
+    CUfileIOParams_t params{};
     params.mode = CUFILE_BATCH;
     params.opcode =
         op == Transport::TransferRequest::READ ? CUFILE_READ : CUFILE_WRITE;
@@ -349,6 +485,6 @@ void NVMeoFTransport::addSliceToCUFileBatch(
     params.fh = fh;
     // LOG(INFO) << "params " << "base " << request.source << " offset " <<
     // request.target_offset << " length " << request.length;
-    desc_pool_->pushParams(desc_id, params);
+    return desc_pool_->pushParams(desc_id, params);
 }
 }  // namespace mooncake

--- a/mooncake-transfer-engine/src/transport/nvmeof_transport/nvmeof_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/nvmeof_transport/nvmeof_transport.cpp
@@ -114,7 +114,17 @@ Status NVMeoFTransport::getTransferStatus(BatchID batch_id, size_t task_id,
     }
 
     thread_local CUFileBatchSnapshot snapshot;
-    if (desc_pool_->pollBatch(nvmeof_desc.desc_idx_, snapshot) != 0) {
+    const auto poll_result =
+        desc_pool_->pollBatch(nvmeof_desc.desc_idx_, snapshot);
+    if (poll_result == CUFileBatchPollResult::kRetry) {
+        if (task.is_finished && task_id < nvmeof_desc.transfer_status.size()) {
+            status = nvmeof_desc.transfer_status[task_id];
+        } else {
+            status = {.s = PENDING, .transferred_bytes = 0};
+        }
+        return Status::OK();
+    }
+    if (poll_result == CUFileBatchPollResult::kError) {
         return Status::Context("NVMeoFTransport: Failed to poll cuFile batch");
     }
 

--- a/mooncake-transfer-engine/tests/nvmeof_status_test.cpp
+++ b/mooncake-transfer-engine/tests/nvmeof_status_test.cpp
@@ -14,6 +14,10 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <deque>
+#include <memory>
+#include <utility>
 #include <vector>
 
 #include "transport/nvmeof_transport/nvmeof_transport.h"
@@ -22,6 +26,13 @@ namespace mooncake {
 
 class CUFileDescPoolTestPeer {
    public:
+    static std::shared_ptr<CUFileDescPool> create(
+        std::shared_ptr<CUFileBatchAPI> batch_api,
+        size_t max_batch_size = 128) {
+        return std::shared_ptr<CUFileDescPool>(
+            new CUFileDescPool(max_batch_size, std::move(batch_api)));
+    }
+
     static bool cachePolledEvent(std::vector<CUfileIOEvents_t>& events,
                                  const CUfileIOEvents_t& event) {
         return CUFileDescPool::cachePolledEvent(events, event);
@@ -30,9 +41,11 @@ class CUFileDescPoolTestPeer {
 
 class NVMeoFTransportTestPeer {
    public:
-    static std::unique_ptr<NVMeoFTransport> createWithoutDriver() {
+    static std::unique_ptr<NVMeoFTransport> createWithoutDriver(
+        std::shared_ptr<CUFileDescPool> desc_pool =
+            std::make_shared<CUFileDescPool>()) {
         return std::unique_ptr<NVMeoFTransport>(
-            new NVMeoFTransport(std::make_shared<CUFileDescPool>()));
+            new NVMeoFTransport(std::move(desc_pool)));
     }
 
     static Transport::TransferStatus aggregate(
@@ -40,7 +53,96 @@ class NVMeoFTransportTestPeer {
         bool& is_finished) {
         return NVMeoFTransport::aggregateTransferStatus(statuses, is_finished);
     }
+
+    static int addBatchSlice(NVMeoFTransport& transport, void* source_addr,
+                             uint64_t file_offset, uint64_t slice_len,
+                             uint64_t desc_id,
+                             Transport::TransferRequest::OpCode op,
+                             CUfileHandle_t file_handle) {
+        return transport.addSliceToCUFileBatch(
+            source_addr, file_offset, slice_len, desc_id, op, file_handle);
+    }
 };
+
+class FakeCUFileBatchAPI : public CUFileBatchAPI {
+   public:
+    CUfileError_t setUp(CUfileBatchHandle_t* batch_handle,
+                        unsigned nr) override {
+        ++setup_calls;
+        *batch_handle = reinterpret_cast<void*>(next_handle++);
+        EXPECT_GT(nr, 0);
+        return success();
+    }
+
+    CUfileError_t submit(CUfileBatchHandle_t batch_handle, unsigned nr,
+                         CUfileIOParams_t* params, unsigned flags) override {
+        submitted_handle = batch_handle;
+        submitted_params = params;
+        EXPECT_EQ(flags, 0);
+        submitted_counts.push_back(nr);
+        submitted_first_cookies.push_back(params[0].cookie);
+        return success();
+    }
+
+    CUfileError_t getStatus(CUfileBatchHandle_t batch_handle, unsigned min_nr,
+                            unsigned* nr, CUfileIOEvents_t* events,
+                            struct timespec* timeout) override {
+        ++get_status_calls;
+        EXPECT_EQ(batch_handle, submitted_handle);
+        EXPECT_EQ(min_nr, 0);
+        EXPECT_EQ(timeout, nullptr);
+        if (get_status_result.err != CU_FILE_SUCCESS) {
+            *nr = 0;
+            return get_status_result;
+        }
+
+        std::vector<CUfileIOEvents_t> completions;
+        if (!status_results.empty()) {
+            completions = std::move(status_results.front());
+            status_results.pop_front();
+        }
+        const auto count =
+            std::min<size_t>(completions.size(), static_cast<size_t>(*nr));
+        EXPECT_EQ(count, completions.size());
+        std::copy_n(completions.begin(), count, events);
+        *nr = count;
+        return get_status_result;
+    }
+
+    CUfileError_t cancel(CUfileBatchHandle_t batch_handle) override {
+        ++cancel_calls;
+        EXPECT_EQ(batch_handle, submitted_handle);
+        return cancel_result;
+    }
+
+    void destroy(CUfileBatchHandle_t batch_handle) override {
+        destroyed_handles.push_back(batch_handle);
+    }
+
+    static CUfileError_t success() {
+        return {.err = CU_FILE_SUCCESS, .cu_err = CUDA_SUCCESS};
+    }
+
+    uintptr_t next_handle = 1;
+    int setup_calls = 0;
+    int get_status_calls = 0;
+    int cancel_calls = 0;
+    CUfileBatchHandle_t submitted_handle = nullptr;
+    CUfileIOParams_t* submitted_params = nullptr;
+    CUfileError_t cancel_result = success();
+    CUfileError_t get_status_result = success();
+    std::vector<unsigned> submitted_counts;
+    std::vector<void*> submitted_first_cookies;
+    std::vector<CUfileBatchHandle_t> destroyed_handles;
+    std::deque<std::vector<CUfileIOEvents_t>> status_results;
+};
+
+CUfileIOEvents_t completion(size_t slice_id, CUfileStatus_t status,
+                            size_t ret = 0) {
+    return {.cookie = reinterpret_cast<void*>(slice_id + 1),
+            .status = status,
+            .ret = ret};
+}
 
 TEST(NVMeoFStatusTest, RejectsUnsupportedMultiTransportSubmission) {
     auto transport = NVMeoFTransportTestPeer::createWithoutDriver();
@@ -52,6 +154,17 @@ TEST(NVMeoFStatusTest, RejectsUnsupportedMultiTransportSubmission) {
     EXPECT_EQ(status.message(),
               "NVMeoFTransport does not support MultiTransport batches");
     EXPECT_TRUE(task.is_finished);
+}
+
+TEST(NVMeoFStatusTest, RejectsBatchThatExceedsCUFileCapacity) {
+    auto batch_api = std::make_shared<FakeCUFileBatchAPI>();
+    auto desc_pool = CUFileDescPoolTestPeer::create(batch_api);
+    auto transport = NVMeoFTransportTestPeer::createWithoutDriver(desc_pool);
+
+    auto batch_id = transport->allocateBatchID(129);
+
+    EXPECT_EQ(batch_id, static_cast<Transport::BatchID>(ERR_MEMORY));
+    EXPECT_EQ(batch_api->setup_calls, 0);
 }
 
 TEST(NVMeoFStatusTest, WaitsForEverySliceBeforeReportingTerminalFailure) {
@@ -109,6 +222,469 @@ TEST(NVMeoFStatusTest, CorrelatesPartialCompletionsByCookie) {
     EXPECT_EQ(cached[0].status, CUFILE_WAITING);
     EXPECT_EQ(cached[1].status, CUFILE_COMPLETE);
     EXPECT_EQ(cached[1].ret, 4096);
+
+    CUfileIOEvents_t stale = {.cookie = reinterpret_cast<void*>(2),
+                              .status = CUFILE_PENDING,
+                              .ret = 0};
+    ASSERT_TRUE(CUFileDescPoolTestPeer::cachePolledEvent(cached, stale));
+    EXPECT_EQ(cached[1].status, CUFILE_COMPLETE);
+    EXPECT_EQ(cached[1].ret, 4096);
+}
+
+TEST(NVMeoFStatusTest, RejectsInvalidDescriptorOperations) {
+    auto batch_api = std::make_shared<FakeCUFileBatchAPI>();
+    auto desc_pool = CUFileDescPoolTestPeer::create(batch_api);
+    CUfileIOParams_t params{};
+    CUFileBatchSnapshot snapshot;
+
+    EXPECT_EQ(desc_pool->pushParams(-1, params), -1);
+    EXPECT_EQ(desc_pool->submitBatch(-1), -1);
+    EXPECT_EQ(desc_pool->discardUnsubmittedParams(-1), -1);
+    EXPECT_FALSE(desc_pool->isAcceptingSubmissions(-1));
+    EXPECT_EQ(desc_pool->pollBatch(-1, snapshot), -1);
+    EXPECT_EQ(desc_pool->getSliceNum(-1), -1);
+    EXPECT_EQ(desc_pool->freeCUfileDesc(-1), -1);
+    EXPECT_EQ(desc_pool->getDesc(-1), nullptr);
+}
+
+TEST(NVMeoFStatusTest, DestroysAllocatedHandleWithPool) {
+    auto batch_api = std::make_shared<FakeCUFileBatchAPI>();
+    {
+        auto desc_pool = CUFileDescPoolTestPeer::create(batch_api);
+        ASSERT_GE(desc_pool->allocCUfileDesc(1), 0);
+    }
+
+    EXPECT_EQ(batch_api->destroyed_handles,
+              (std::vector<CUfileBatchHandle_t>{reinterpret_cast<void*>(1)}));
+}
+
+TEST(NVMeoFStatusTest, DefersCrossTaskFailureUntilDescriptorIsDrained) {
+    auto batch_api = std::make_shared<FakeCUFileBatchAPI>();
+    auto desc_pool = CUFileDescPoolTestPeer::create(batch_api);
+    auto transport = NVMeoFTransportTestPeer::createWithoutDriver(desc_pool);
+
+    auto batch_id = transport->allocateBatchID(2);
+    auto& batch_desc = Transport::toBatchDesc(batch_id);
+    auto& nvmeof_desc = *static_cast<NVMeoFBatchDesc*>(batch_desc.context);
+    batch_desc.task_list.resize(2);
+    nvmeof_desc.task_to_slices = {{0, 1}, {1, 1}};
+    nvmeof_desc.transfer_status = {
+        {.s = Transport::PENDING, .transferred_bytes = 0},
+        {.s = Transport::PENDING, .transferred_bytes = 0}};
+
+    int caller_buffers[2] = {};
+    for (size_t i = 0; i < 2; ++i) {
+        CUfileIOParams_t params{};
+        params.u.batch.devPtr_base = &caller_buffers[i];
+        ASSERT_EQ(desc_pool->pushParams(nvmeof_desc.desc_idx_, params), 0);
+        batch_desc.task_list[i].slice_count = 1;
+    }
+    ASSERT_EQ(desc_pool->submitBatch(nvmeof_desc.desc_idx_), 0);
+
+    batch_api->status_results.push_back({completion(0, CUFILE_FAILED)});
+    Transport::TransferStatus status{};
+    ASSERT_TRUE(transport->getTransferStatus(batch_id, 1, status).ok());
+
+    EXPECT_EQ(batch_api->cancel_calls, 1);
+    EXPECT_TRUE(status.s == Transport::WAITING ||
+                status.s == Transport::PENDING);
+    EXPECT_FALSE(batch_desc.task_list[0].is_finished);
+    EXPECT_FALSE(batch_desc.task_list[1].is_finished);
+
+    ASSERT_TRUE(transport->getTransferStatus(batch_id, 1, status).ok());
+    EXPECT_EQ(batch_api->cancel_calls, 1);
+    EXPECT_TRUE(status.s == Transport::WAITING ||
+                status.s == Transport::PENDING);
+    EXPECT_TRUE(transport->freeBatchID(batch_id).IsBatchBusy());
+    ASSERT_NE(desc_pool->getDesc(nvmeof_desc.desc_idx_), nullptr);
+    EXPECT_TRUE(batch_api->destroyed_handles.empty());
+    EXPECT_EQ(batch_api->submitted_params[1].u.batch.devPtr_base,
+              &caller_buffers[1]);
+
+    batch_api->status_results.push_back({completion(1, CUFILE_CANCELED)});
+    ASSERT_TRUE(transport->getTransferStatus(batch_id, 1, status).ok());
+
+    EXPECT_EQ(status.s, Transport::FAILED);
+    EXPECT_TRUE(batch_desc.task_list[0].is_finished);
+    EXPECT_TRUE(batch_desc.task_list[1].is_finished);
+
+    const int poll_count = batch_api->get_status_calls;
+    Transport::TransferStatus initiating_status{};
+    ASSERT_TRUE(
+        transport->getTransferStatus(batch_id, 0, initiating_status).ok());
+    EXPECT_EQ(initiating_status.s, Transport::FAILED);
+    EXPECT_EQ(batch_api->get_status_calls, poll_count);
+
+    auto free_status = transport->freeBatchID(batch_id);
+    EXPECT_TRUE(free_status.ok());
+    EXPECT_EQ(batch_api->destroyed_handles,
+              (std::vector<CUfileBatchHandle_t>{batch_api->submitted_handle}));
+    if (!free_status.ok()) {
+        batch_desc.task_list[0].is_finished = true;
+        batch_desc.task_list[1].is_finished = true;
+        EXPECT_TRUE(transport->freeBatchID(batch_id).ok());
+    }
+}
+
+TEST(NVMeoFStatusTest, FinishedTaskPollStillDrivesDescriptorFailureCleanup) {
+    auto batch_api = std::make_shared<FakeCUFileBatchAPI>();
+    auto desc_pool = CUFileDescPoolTestPeer::create(batch_api);
+    auto transport = NVMeoFTransportTestPeer::createWithoutDriver(desc_pool);
+
+    auto batch_id = transport->allocateBatchID(2);
+    auto& batch_desc = Transport::toBatchDesc(batch_id);
+    auto& nvmeof_desc = *static_cast<NVMeoFBatchDesc*>(batch_desc.context);
+    batch_desc.task_list.resize(2);
+    nvmeof_desc.task_to_slices = {{0, 1}, {1, 2}};
+    nvmeof_desc.transfer_status = {
+        {.s = Transport::PENDING, .transferred_bytes = 0},
+        {.s = Transport::PENDING, .transferred_bytes = 0}};
+
+    CUfileIOParams_t params{};
+    ASSERT_EQ(desc_pool->pushParams(nvmeof_desc.desc_idx_, params), 0);
+    ASSERT_EQ(desc_pool->pushParams(nvmeof_desc.desc_idx_, params), 0);
+    ASSERT_EQ(desc_pool->pushParams(nvmeof_desc.desc_idx_, params), 0);
+    ASSERT_EQ(desc_pool->submitBatch(nvmeof_desc.desc_idx_), 0);
+
+    batch_api->status_results.push_back({completion(0, CUFILE_COMPLETE, 1024)});
+    Transport::TransferStatus status{};
+    ASSERT_TRUE(transport->getTransferStatus(batch_id, 0, status).ok());
+    ASSERT_EQ(status.s, Transport::COMPLETED);
+    ASSERT_TRUE(batch_desc.task_list[0].is_finished);
+    ASSERT_FALSE(batch_desc.task_list[1].is_finished);
+
+    batch_api->status_results.push_back({completion(1, CUFILE_FAILED)});
+    ASSERT_TRUE(transport->getTransferStatus(batch_id, 0, status).ok());
+
+    EXPECT_EQ(status.s, Transport::COMPLETED);
+    EXPECT_EQ(status.transferred_bytes, 1024);
+    EXPECT_EQ(batch_api->cancel_calls, 1);
+    EXPECT_FALSE(batch_desc.task_list[1].is_finished);
+
+    batch_api->status_results.push_back({completion(2, CUFILE_CANCELED)});
+    ASSERT_TRUE(transport->getTransferStatus(batch_id, 0, status).ok());
+    EXPECT_EQ(status.s, Transport::COMPLETED);
+    EXPECT_TRUE(batch_desc.task_list[1].is_finished);
+
+    EXPECT_TRUE(transport->freeBatchID(batch_id).ok());
+}
+
+TEST(NVMeoFStatusTest, PreservesSpontaneousCancellationStatus) {
+    auto batch_api = std::make_shared<FakeCUFileBatchAPI>();
+    auto desc_pool = CUFileDescPoolTestPeer::create(batch_api);
+    auto transport = NVMeoFTransportTestPeer::createWithoutDriver(desc_pool);
+
+    auto batch_id = transport->allocateBatchID(1);
+    auto& batch_desc = Transport::toBatchDesc(batch_id);
+    auto& nvmeof_desc = *static_cast<NVMeoFBatchDesc*>(batch_desc.context);
+    batch_desc.task_list.resize(1);
+    nvmeof_desc.task_to_slices = {{0, 1}};
+    nvmeof_desc.transfer_status = {
+        {.s = Transport::PENDING, .transferred_bytes = 0}};
+
+    CUfileIOParams_t params{};
+    ASSERT_EQ(desc_pool->pushParams(nvmeof_desc.desc_idx_, params), 0);
+    ASSERT_EQ(desc_pool->submitBatch(nvmeof_desc.desc_idx_), 0);
+
+    batch_api->status_results.push_back({completion(0, CUFILE_CANCELED)});
+    Transport::TransferStatus status{};
+    ASSERT_TRUE(transport->getTransferStatus(batch_id, 0, status).ok());
+
+    EXPECT_EQ(status.s, Transport::CANCELED);
+    EXPECT_EQ(batch_api->cancel_calls, 0);
+    EXPECT_TRUE(batch_desc.task_list[0].is_finished);
+    EXPECT_TRUE(transport->freeBatchID(batch_id).ok());
+}
+
+TEST(NVMeoFStatusTest, CancelsAndDrainsRemainingSlicesInOneTask) {
+    auto batch_api = std::make_shared<FakeCUFileBatchAPI>();
+    auto desc_pool = CUFileDescPoolTestPeer::create(batch_api);
+    auto transport = NVMeoFTransportTestPeer::createWithoutDriver(desc_pool);
+
+    auto batch_id = transport->allocateBatchID(1);
+    auto& batch_desc = Transport::toBatchDesc(batch_id);
+    auto& nvmeof_desc = *static_cast<NVMeoFBatchDesc*>(batch_desc.context);
+    batch_desc.task_list.resize(1);
+    batch_desc.task_list[0].slice_count = 2;
+    nvmeof_desc.task_to_slices = {{0, 2}};
+    nvmeof_desc.transfer_status = {
+        {.s = Transport::PENDING, .transferred_bytes = 0}};
+
+    CUfileIOParams_t params{};
+    ASSERT_EQ(desc_pool->pushParams(nvmeof_desc.desc_idx_, params), 0);
+    ASSERT_EQ(desc_pool->pushParams(nvmeof_desc.desc_idx_, params), 0);
+    ASSERT_EQ(desc_pool->submitBatch(nvmeof_desc.desc_idx_), 0);
+
+    batch_api->status_results.push_back({completion(0, CUFILE_FAILED)});
+    Transport::TransferStatus status{};
+    ASSERT_TRUE(transport->getTransferStatus(batch_id, 0, status).ok());
+    EXPECT_EQ(status.s, Transport::WAITING);
+    EXPECT_EQ(batch_api->cancel_calls, 1);
+    EXPECT_FALSE(batch_desc.task_list[0].is_finished);
+    EXPECT_TRUE(transport->freeBatchID(batch_id).IsBatchBusy());
+
+    batch_api->status_results.push_back({completion(1, CUFILE_CANCELED)});
+    ASSERT_TRUE(transport->getTransferStatus(batch_id, 0, status).ok());
+    EXPECT_EQ(status.s, Transport::FAILED);
+    EXPECT_TRUE(batch_desc.task_list[0].is_finished);
+    EXPECT_TRUE(transport->freeBatchID(batch_id).ok());
+}
+
+TEST(NVMeoFStatusTest, CancelFailureStillDrainsAndRetiresHandle) {
+    auto batch_api = std::make_shared<FakeCUFileBatchAPI>();
+    batch_api->cancel_result = {.err = CU_FILE_INTERNAL_BATCH_CANCEL_ERROR,
+                                .cu_err = CUDA_SUCCESS};
+    auto desc_pool = CUFileDescPoolTestPeer::create(batch_api);
+    auto transport = NVMeoFTransportTestPeer::createWithoutDriver(desc_pool);
+
+    auto batch_id = transport->allocateBatchID(1);
+    auto& batch_desc = Transport::toBatchDesc(batch_id);
+    auto& nvmeof_desc = *static_cast<NVMeoFBatchDesc*>(batch_desc.context);
+    batch_desc.task_list.resize(1);
+    batch_desc.task_list[0].slice_count = 2;
+    nvmeof_desc.task_to_slices = {{0, 2}};
+    nvmeof_desc.transfer_status = {
+        {.s = Transport::PENDING, .transferred_bytes = 0}};
+
+    CUfileIOParams_t params{};
+    ASSERT_EQ(desc_pool->pushParams(nvmeof_desc.desc_idx_, params), 0);
+    ASSERT_EQ(desc_pool->pushParams(nvmeof_desc.desc_idx_, params), 0);
+    ASSERT_EQ(desc_pool->submitBatch(nvmeof_desc.desc_idx_), 0);
+    const auto failed_handle = batch_api->submitted_handle;
+
+    batch_api->status_results.push_back({completion(0, CUFILE_FAILED)});
+    Transport::TransferStatus status{};
+    ASSERT_TRUE(transport->getTransferStatus(batch_id, 0, status).ok());
+    EXPECT_TRUE(status.s == Transport::WAITING ||
+                status.s == Transport::PENDING);
+    EXPECT_EQ(batch_api->cancel_calls, 1);
+    EXPECT_TRUE(transport->freeBatchID(batch_id).IsBatchBusy());
+    EXPECT_TRUE(batch_api->destroyed_handles.empty());
+
+    ASSERT_TRUE(transport->getTransferStatus(batch_id, 0, status).ok());
+    EXPECT_EQ(batch_api->cancel_calls, 1);
+    EXPECT_TRUE(transport->submitTransfer(batch_id, {}).IsBatchBusy());
+    EXPECT_EQ(desc_pool->pushParams(nvmeof_desc.desc_idx_, params), -1);
+    EXPECT_EQ(desc_pool->submitBatch(nvmeof_desc.desc_idx_), -1);
+
+    batch_api->status_results.push_back({completion(1, CUFILE_COMPLETE, 1024)});
+    ASSERT_TRUE(transport->getTransferStatus(batch_id, 0, status).ok());
+    EXPECT_EQ(status.s, Transport::FAILED);
+    EXPECT_TRUE(batch_desc.task_list[0].is_finished);
+    ASSERT_TRUE(transport->freeBatchID(batch_id).ok());
+    ASSERT_EQ(batch_api->destroyed_handles.size(), 1);
+    EXPECT_EQ(batch_api->destroyed_handles[0], failed_handle);
+
+    auto next_batch_id = transport->allocateBatchID(1);
+    ASSERT_NE(next_batch_id, static_cast<Transport::BatchID>(ERR_MEMORY));
+    auto& next_batch_desc = Transport::toBatchDesc(next_batch_id);
+    auto& next_nvmeof_desc =
+        *static_cast<NVMeoFBatchDesc*>(next_batch_desc.context);
+    EXPECT_EQ(batch_api->setup_calls, 2);
+    EXPECT_NE(
+        desc_pool->getDesc(next_nvmeof_desc.desc_idx_)->batch_handle->handle,
+        failed_handle);
+    EXPECT_TRUE(transport->freeBatchID(next_batch_id).ok());
+}
+
+TEST(NVMeoFStatusTest, ReusesSuccessfulHandleAndSubmitsOnlyNewParams) {
+    auto batch_api = std::make_shared<FakeCUFileBatchAPI>();
+    auto desc_pool = CUFileDescPoolTestPeer::create(batch_api);
+
+    const int desc_idx = desc_pool->allocCUfileDesc(2);
+    ASSERT_GE(desc_idx, 0);
+    const auto original_handle =
+        desc_pool->getDesc(desc_idx)->batch_handle->handle;
+    CUfileIOParams_t params{};
+    ASSERT_EQ(desc_pool->pushParams(desc_idx, params), 0);
+    ASSERT_EQ(desc_pool->submitBatch(desc_idx), 0);
+    ASSERT_EQ(desc_pool->pushParams(desc_idx, params), 0);
+    ASSERT_EQ(desc_pool->submitBatch(desc_idx), 0);
+
+    EXPECT_EQ(batch_api->submitted_counts, (std::vector<unsigned>{1, 1}));
+    EXPECT_EQ(batch_api->submitted_first_cookies,
+              (std::vector<void*>{reinterpret_cast<void*>(1),
+                                  reinterpret_cast<void*>(2)}));
+
+    batch_api->status_results.push_back({completion(1, CUFILE_COMPLETE, 2048),
+                                         completion(0, CUFILE_COMPLETE, 1024)});
+    CUFileBatchSnapshot snapshot;
+    ASSERT_EQ(desc_pool->pollBatch(desc_idx, snapshot), 0);
+    EXPECT_TRUE(snapshot.all_terminal);
+    EXPECT_FALSE(snapshot.failure_seen);
+    ASSERT_EQ(desc_pool->freeCUfileDesc(desc_idx), 0);
+    EXPECT_TRUE(batch_api->destroyed_handles.empty());
+
+    const int next_desc_idx = desc_pool->allocCUfileDesc(1);
+    ASSERT_GE(next_desc_idx, 0);
+    EXPECT_EQ(batch_api->setup_calls, 1);
+    EXPECT_EQ(desc_pool->getDesc(next_desc_idx)->batch_handle->handle,
+              original_handle);
+    EXPECT_EQ(desc_pool->freeCUfileDesc(next_desc_idx), 0);
+}
+
+TEST(NVMeoFStatusTest, DiscardsOnlyUnsubmittedParams) {
+    auto batch_api = std::make_shared<FakeCUFileBatchAPI>();
+    auto desc_pool = CUFileDescPoolTestPeer::create(batch_api);
+
+    const int desc_idx = desc_pool->allocCUfileDesc(2);
+    ASSERT_GE(desc_idx, 0);
+    CUfileIOParams_t params{};
+    ASSERT_EQ(desc_pool->pushParams(desc_idx, params), 0);
+    ASSERT_EQ(desc_pool->submitBatch(desc_idx), 0);
+    ASSERT_EQ(desc_pool->pushParams(desc_idx, params), 0);
+
+    ASSERT_EQ(desc_pool->discardUnsubmittedParams(desc_idx), 0);
+    EXPECT_EQ(desc_pool->getSliceNum(desc_idx), 1);
+
+    batch_api->status_results.push_back({completion(0, CUFILE_COMPLETE, 1024)});
+    CUFileBatchSnapshot snapshot;
+    ASSERT_EQ(desc_pool->pollBatch(desc_idx, snapshot), 0);
+    ASSERT_TRUE(snapshot.all_terminal);
+    EXPECT_EQ(desc_pool->freeCUfileDesc(desc_idx), 0);
+}
+
+TEST(NVMeoFStatusTest, BuildsCUFileBatchParameters) {
+    auto batch_api = std::make_shared<FakeCUFileBatchAPI>();
+    auto desc_pool = CUFileDescPoolTestPeer::create(batch_api);
+    auto transport = NVMeoFTransportTestPeer::createWithoutDriver(desc_pool);
+    auto batch_id = transport->allocateBatchID(1);
+    auto& batch_desc = Transport::toBatchDesc(batch_id);
+    auto& nvmeof_desc = *static_cast<NVMeoFBatchDesc*>(batch_desc.context);
+    int caller_buffer = 0;
+    auto file_handle = reinterpret_cast<CUfileHandle_t>(0x1234);
+
+    ASSERT_EQ(NVMeoFTransportTestPeer::addBatchSlice(
+                  *transport, &caller_buffer, 4096, 8192, nvmeof_desc.desc_idx_,
+                  Transport::TransferRequest::READ, file_handle),
+              0);
+
+    const auto& params =
+        desc_pool->getDesc(nvmeof_desc.desc_idx_)->io_params.front();
+    EXPECT_EQ(params.mode, CUFILE_BATCH);
+    EXPECT_EQ(params.opcode, CUFILE_READ);
+    EXPECT_EQ(params.u.batch.devPtr_base, &caller_buffer);
+    EXPECT_EQ(params.u.batch.devPtr_offset, 0);
+    EXPECT_EQ(params.u.batch.file_offset, 4096);
+    EXPECT_EQ(params.u.batch.size, 8192);
+    EXPECT_EQ(params.fh, file_handle);
+    EXPECT_EQ(params.cookie, reinterpret_cast<void*>(1));
+
+    EXPECT_TRUE(transport->freeBatchID(batch_id).ok());
+}
+
+TEST(NVMeoFStatusTest, PropagatesStatusPollingErrors) {
+    auto batch_api = std::make_shared<FakeCUFileBatchAPI>();
+    auto desc_pool = CUFileDescPoolTestPeer::create(batch_api);
+    auto transport = NVMeoFTransportTestPeer::createWithoutDriver(desc_pool);
+    auto batch_id = transport->allocateBatchID(1);
+    auto& batch_desc = Transport::toBatchDesc(batch_id);
+    auto& nvmeof_desc = *static_cast<NVMeoFBatchDesc*>(batch_desc.context);
+    batch_desc.task_list.resize(1);
+    nvmeof_desc.task_to_slices = {{0, 1}};
+    nvmeof_desc.transfer_status = {
+        {.s = Transport::PENDING, .transferred_bytes = 0}};
+    CUfileIOParams_t params{};
+    ASSERT_EQ(desc_pool->pushParams(nvmeof_desc.desc_idx_, params), 0);
+    ASSERT_EQ(desc_pool->submitBatch(nvmeof_desc.desc_idx_), 0);
+
+    batch_api->get_status_result = {
+        .err = CU_FILE_INTERNAL_BATCH_GETSTATUS_ERROR, .cu_err = CUDA_SUCCESS};
+    Transport::TransferStatus status{};
+    EXPECT_TRUE(transport->getTransferStatus(batch_id, 0, status).IsContext());
+
+    batch_api->get_status_result = FakeCUFileBatchAPI::success();
+    batch_api->status_results.push_back({completion(0, CUFILE_COMPLETE, 1024)});
+    ASSERT_TRUE(transport->getTransferStatus(batch_id, 0, status).ok());
+    ASSERT_EQ(status.s, Transport::COMPLETED);
+    EXPECT_TRUE(transport->freeBatchID(batch_id).ok());
+}
+
+TEST(NVMeoFStatusTest, ValidatesFreePreconditionsAndPoolQuiescence) {
+    auto batch_api = std::make_shared<FakeCUFileBatchAPI>();
+    auto desc_pool = CUFileDescPoolTestPeer::create(batch_api);
+    auto transport = NVMeoFTransportTestPeer::createWithoutDriver(desc_pool);
+
+    EXPECT_TRUE(transport->freeBatchID(0).IsInvalidArgument());
+
+    auto* foreign_batch = new Transport::BatchDesc();
+    auto foreign_batch_id = reinterpret_cast<Transport::BatchID>(foreign_batch);
+    foreign_batch->context = nullptr;
+    EXPECT_TRUE(transport->freeBatchID(foreign_batch_id).IsInvalidArgument());
+    delete foreign_batch;
+
+    auto batch_id = transport->allocateBatchID(1);
+    auto& batch_desc = Transport::toBatchDesc(batch_id);
+    auto& nvmeof_desc = *static_cast<NVMeoFBatchDesc*>(batch_desc.context);
+    batch_desc.task_list.resize(1);
+    batch_desc.task_list[0].is_finished = true;
+    CUfileIOParams_t params{};
+    ASSERT_EQ(desc_pool->pushParams(nvmeof_desc.desc_idx_, params), 0);
+    ASSERT_EQ(desc_pool->submitBatch(nvmeof_desc.desc_idx_), 0);
+
+    EXPECT_TRUE(transport->freeBatchID(batch_id).IsBatchBusy());
+
+    batch_api->status_results.push_back({completion(0, CUFILE_COMPLETE, 1024)});
+    CUFileBatchSnapshot snapshot;
+    ASSERT_EQ(desc_pool->pollBatch(nvmeof_desc.desc_idx_, snapshot), 0);
+    ASSERT_TRUE(snapshot.all_terminal);
+    EXPECT_TRUE(transport->freeBatchID(batch_id).ok());
+}
+
+TEST(NVMeoFStatusTest, RetriesStatusPollingWithoutCancelingHealthyBatch) {
+    auto batch_api = std::make_shared<FakeCUFileBatchAPI>();
+    auto desc_pool = CUFileDescPoolTestPeer::create(batch_api);
+
+    const int desc_idx = desc_pool->allocCUfileDesc(1);
+    ASSERT_GE(desc_idx, 0);
+    CUfileIOParams_t params{};
+    ASSERT_EQ(desc_pool->pushParams(desc_idx, params), 0);
+    ASSERT_EQ(desc_pool->submitBatch(desc_idx), 0);
+
+    batch_api->get_status_result = {
+        .err = CU_FILE_INTERNAL_BATCH_GETSTATUS_ERROR, .cu_err = CUDA_SUCCESS};
+    CUFileBatchSnapshot snapshot;
+    EXPECT_EQ(desc_pool->pollBatch(desc_idx, snapshot), -1);
+    EXPECT_EQ(batch_api->cancel_calls, 0);
+    EXPECT_TRUE(desc_pool->isAcceptingSubmissions(desc_idx));
+
+    batch_api->get_status_result = FakeCUFileBatchAPI::success();
+    batch_api->status_results.push_back({completion(0, CUFILE_COMPLETE, 1024)});
+    ASSERT_EQ(desc_pool->pollBatch(desc_idx, snapshot), 0);
+    EXPECT_TRUE(snapshot.all_terminal);
+    EXPECT_FALSE(snapshot.failure_seen);
+    EXPECT_EQ(desc_pool->freeCUfileDesc(desc_idx), 0);
+    EXPECT_TRUE(batch_api->destroyed_handles.empty());
+}
+
+TEST(NVMeoFStatusTest, QuarantinesBatchAfterNonRetryableStatusError) {
+    auto batch_api = std::make_shared<FakeCUFileBatchAPI>();
+    auto desc_pool = CUFileDescPoolTestPeer::create(batch_api);
+
+    const int desc_idx = desc_pool->allocCUfileDesc(1);
+    ASSERT_GE(desc_idx, 0);
+    const auto failed_handle =
+        desc_pool->getDesc(desc_idx)->batch_handle->handle;
+    CUfileIOParams_t params{};
+    ASSERT_EQ(desc_pool->pushParams(desc_idx, params), 0);
+    ASSERT_EQ(desc_pool->submitBatch(desc_idx), 0);
+
+    batch_api->get_status_result = {.err = CU_FILE_INVALID_VALUE,
+                                    .cu_err = CUDA_SUCCESS};
+    CUFileBatchSnapshot snapshot;
+    EXPECT_EQ(desc_pool->pollBatch(desc_idx, snapshot), -1);
+    EXPECT_EQ(batch_api->cancel_calls, 1);
+    EXPECT_FALSE(desc_pool->isAcceptingSubmissions(desc_idx));
+    EXPECT_TRUE(batch_api->destroyed_handles.empty());
+
+    batch_api->get_status_result = FakeCUFileBatchAPI::success();
+    batch_api->status_results.push_back({completion(0, CUFILE_CANCELED)});
+    ASSERT_EQ(desc_pool->pollBatch(desc_idx, snapshot), 0);
+    EXPECT_TRUE(snapshot.all_terminal);
+    EXPECT_TRUE(snapshot.failure_seen);
+    EXPECT_EQ(desc_pool->freeCUfileDesc(desc_idx), 0);
+    EXPECT_EQ(batch_api->destroyed_handles,
+              (std::vector<CUfileBatchHandle_t>{failed_handle}));
 }
 
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tests/nvmeof_status_test.cpp
+++ b/mooncake-transfer-engine/tests/nvmeof_status_test.cpp
@@ -81,7 +81,7 @@ class FakeCUFileBatchAPI : public CUFileBatchAPI {
         EXPECT_EQ(flags, 0);
         submitted_counts.push_back(nr);
         submitted_first_cookies.push_back(params[0].cookie);
-        return success();
+        return submit_result;
     }
 
     CUfileError_t getStatus(CUfileBatchHandle_t batch_handle, unsigned min_nr,
@@ -129,6 +129,7 @@ class FakeCUFileBatchAPI : public CUFileBatchAPI {
     int cancel_calls = 0;
     CUfileBatchHandle_t submitted_handle = nullptr;
     CUfileIOParams_t* submitted_params = nullptr;
+    CUfileError_t submit_result = success();
     CUfileError_t cancel_result = success();
     CUfileError_t get_status_result = success();
     std::vector<unsigned> submitted_counts;
@@ -241,7 +242,8 @@ TEST(NVMeoFStatusTest, RejectsInvalidDescriptorOperations) {
     EXPECT_EQ(desc_pool->submitBatch(-1), -1);
     EXPECT_EQ(desc_pool->discardUnsubmittedParams(-1), -1);
     EXPECT_FALSE(desc_pool->isAcceptingSubmissions(-1));
-    EXPECT_EQ(desc_pool->pollBatch(-1, snapshot), -1);
+    EXPECT_EQ(desc_pool->pollBatch(-1, snapshot),
+              CUFileBatchPollResult::kError);
     EXPECT_EQ(desc_pool->getSliceNum(-1), -1);
     EXPECT_EQ(desc_pool->freeCUfileDesc(-1), -1);
     EXPECT_EQ(desc_pool->getDesc(-1), nullptr);
@@ -353,6 +355,14 @@ TEST(NVMeoFStatusTest, FinishedTaskPollStillDrivesDescriptorFailureCleanup) {
     ASSERT_TRUE(batch_desc.task_list[0].is_finished);
     ASSERT_FALSE(batch_desc.task_list[1].is_finished);
 
+    batch_api->get_status_result = {
+        .err = CU_FILE_INTERNAL_BATCH_GETSTATUS_ERROR, .cu_err = CUDA_SUCCESS};
+    ASSERT_TRUE(transport->getTransferStatus(batch_id, 0, status).ok());
+    EXPECT_EQ(status.s, Transport::COMPLETED);
+    EXPECT_EQ(status.transferred_bytes, 1024);
+    EXPECT_EQ(batch_api->cancel_calls, 0);
+
+    batch_api->get_status_result = FakeCUFileBatchAPI::success();
     batch_api->status_results.push_back({completion(1, CUFILE_FAILED)});
     ASSERT_TRUE(transport->getTransferStatus(batch_id, 0, status).ok());
 
@@ -509,7 +519,8 @@ TEST(NVMeoFStatusTest, ReusesSuccessfulHandleAndSubmitsOnlyNewParams) {
     batch_api->status_results.push_back({completion(1, CUFILE_COMPLETE, 2048),
                                          completion(0, CUFILE_COMPLETE, 1024)});
     CUFileBatchSnapshot snapshot;
-    ASSERT_EQ(desc_pool->pollBatch(desc_idx, snapshot), 0);
+    ASSERT_EQ(desc_pool->pollBatch(desc_idx, snapshot),
+              CUFileBatchPollResult::kSuccess);
     EXPECT_TRUE(snapshot.all_terminal);
     EXPECT_FALSE(snapshot.failure_seen);
     ASSERT_EQ(desc_pool->freeCUfileDesc(desc_idx), 0);
@@ -539,7 +550,8 @@ TEST(NVMeoFStatusTest, DiscardsOnlyUnsubmittedParams) {
 
     batch_api->status_results.push_back({completion(0, CUFILE_COMPLETE, 1024)});
     CUFileBatchSnapshot snapshot;
-    ASSERT_EQ(desc_pool->pollBatch(desc_idx, snapshot), 0);
+    ASSERT_EQ(desc_pool->pollBatch(desc_idx, snapshot),
+              CUFileBatchPollResult::kSuccess);
     ASSERT_TRUE(snapshot.all_terminal);
     EXPECT_EQ(desc_pool->freeCUfileDesc(desc_idx), 0);
 }
@@ -573,7 +585,7 @@ TEST(NVMeoFStatusTest, BuildsCUFileBatchParameters) {
     EXPECT_TRUE(transport->freeBatchID(batch_id).ok());
 }
 
-TEST(NVMeoFStatusTest, PropagatesStatusPollingErrors) {
+TEST(NVMeoFStatusTest, RetriesTransientStatusPollingErrors) {
     auto batch_api = std::make_shared<FakeCUFileBatchAPI>();
     auto desc_pool = CUFileDescPoolTestPeer::create(batch_api);
     auto transport = NVMeoFTransportTestPeer::createWithoutDriver(desc_pool);
@@ -591,7 +603,8 @@ TEST(NVMeoFStatusTest, PropagatesStatusPollingErrors) {
     batch_api->get_status_result = {
         .err = CU_FILE_INTERNAL_BATCH_GETSTATUS_ERROR, .cu_err = CUDA_SUCCESS};
     Transport::TransferStatus status{};
-    EXPECT_TRUE(transport->getTransferStatus(batch_id, 0, status).IsContext());
+    EXPECT_TRUE(transport->getTransferStatus(batch_id, 0, status).ok());
+    EXPECT_EQ(status.s, Transport::PENDING);
 
     batch_api->get_status_result = FakeCUFileBatchAPI::success();
     batch_api->status_results.push_back({completion(0, CUFILE_COMPLETE, 1024)});
@@ -626,7 +639,8 @@ TEST(NVMeoFStatusTest, ValidatesFreePreconditionsAndPoolQuiescence) {
 
     batch_api->status_results.push_back({completion(0, CUFILE_COMPLETE, 1024)});
     CUFileBatchSnapshot snapshot;
-    ASSERT_EQ(desc_pool->pollBatch(nvmeof_desc.desc_idx_, snapshot), 0);
+    ASSERT_EQ(desc_pool->pollBatch(nvmeof_desc.desc_idx_, snapshot),
+              CUFileBatchPollResult::kSuccess);
     ASSERT_TRUE(snapshot.all_terminal);
     EXPECT_TRUE(transport->freeBatchID(batch_id).ok());
 }
@@ -644,17 +658,54 @@ TEST(NVMeoFStatusTest, RetriesStatusPollingWithoutCancelingHealthyBatch) {
     batch_api->get_status_result = {
         .err = CU_FILE_INTERNAL_BATCH_GETSTATUS_ERROR, .cu_err = CUDA_SUCCESS};
     CUFileBatchSnapshot snapshot;
-    EXPECT_EQ(desc_pool->pollBatch(desc_idx, snapshot), -1);
+    EXPECT_EQ(desc_pool->pollBatch(desc_idx, snapshot),
+              CUFileBatchPollResult::kRetry);
     EXPECT_EQ(batch_api->cancel_calls, 0);
     EXPECT_TRUE(desc_pool->isAcceptingSubmissions(desc_idx));
 
     batch_api->get_status_result = FakeCUFileBatchAPI::success();
     batch_api->status_results.push_back({completion(0, CUFILE_COMPLETE, 1024)});
-    ASSERT_EQ(desc_pool->pollBatch(desc_idx, snapshot), 0);
+    ASSERT_EQ(desc_pool->pollBatch(desc_idx, snapshot),
+              CUFileBatchPollResult::kSuccess);
     EXPECT_TRUE(snapshot.all_terminal);
     EXPECT_FALSE(snapshot.failure_seen);
     EXPECT_EQ(desc_pool->freeCUfileDesc(desc_idx), 0);
     EXPECT_TRUE(batch_api->destroyed_handles.empty());
+}
+
+TEST(NVMeoFStatusTest, QuarantinesAttemptedRangeAfterSubmitError) {
+    auto batch_api = std::make_shared<FakeCUFileBatchAPI>();
+    auto desc_pool = CUFileDescPoolTestPeer::create(batch_api);
+
+    const int desc_idx = desc_pool->allocCUfileDesc(2);
+    ASSERT_GE(desc_idx, 0);
+    const auto failed_handle =
+        desc_pool->getDesc(desc_idx)->batch_handle->handle;
+    CUfileIOParams_t params{};
+    ASSERT_EQ(desc_pool->pushParams(desc_idx, params), 0);
+    ASSERT_EQ(desc_pool->pushParams(desc_idx, params), 0);
+
+    batch_api->submit_result = {.err = CU_FILE_INTERNAL_BATCH_SUBMIT_ERROR,
+                                .cu_err = CUDA_SUCCESS};
+    EXPECT_EQ(desc_pool->submitBatch(desc_idx), -1);
+    EXPECT_EQ(desc_pool->getDesc(desc_idx)->submitted_count, 2);
+    EXPECT_FALSE(desc_pool->isAcceptingSubmissions(desc_idx));
+
+    CUFileBatchSnapshot snapshot;
+    ASSERT_EQ(desc_pool->pollBatch(desc_idx, snapshot),
+              CUFileBatchPollResult::kSuccess);
+    EXPECT_TRUE(snapshot.failure_seen);
+    EXPECT_FALSE(snapshot.all_terminal);
+    EXPECT_EQ(batch_api->cancel_calls, 1);
+
+    batch_api->status_results.push_back(
+        {completion(0, CUFILE_CANCELED), completion(1, CUFILE_CANCELED)});
+    ASSERT_EQ(desc_pool->pollBatch(desc_idx, snapshot),
+              CUFileBatchPollResult::kSuccess);
+    EXPECT_TRUE(snapshot.all_terminal);
+    EXPECT_EQ(desc_pool->freeCUfileDesc(desc_idx), 0);
+    EXPECT_EQ(batch_api->destroyed_handles,
+              (std::vector<CUfileBatchHandle_t>{failed_handle}));
 }
 
 TEST(NVMeoFStatusTest, QuarantinesBatchAfterNonRetryableStatusError) {
@@ -672,14 +723,16 @@ TEST(NVMeoFStatusTest, QuarantinesBatchAfterNonRetryableStatusError) {
     batch_api->get_status_result = {.err = CU_FILE_INVALID_VALUE,
                                     .cu_err = CUDA_SUCCESS};
     CUFileBatchSnapshot snapshot;
-    EXPECT_EQ(desc_pool->pollBatch(desc_idx, snapshot), -1);
+    EXPECT_EQ(desc_pool->pollBatch(desc_idx, snapshot),
+              CUFileBatchPollResult::kError);
     EXPECT_EQ(batch_api->cancel_calls, 1);
     EXPECT_FALSE(desc_pool->isAcceptingSubmissions(desc_idx));
     EXPECT_TRUE(batch_api->destroyed_handles.empty());
 
     batch_api->get_status_result = FakeCUFileBatchAPI::success();
     batch_api->status_results.push_back({completion(0, CUFILE_CANCELED)});
-    ASSERT_EQ(desc_pool->pollBatch(desc_idx, snapshot), 0);
+    ASSERT_EQ(desc_pool->pollBatch(desc_idx, snapshot),
+              CUFileBatchPollResult::kSuccess);
     EXPECT_TRUE(snapshot.all_terminal);
     EXPECT_TRUE(snapshot.failure_seen);
     EXPECT_EQ(desc_pool->freeCUfileDesc(desc_idx), 0);


### PR DESCRIPTION
## Description

Refs #2916.

This PR builds on #2893, which is now merged. The follow-up diff is commits `797a9e70` and `60e4b2fa`.

#2893 retains a known failure as `WAITING` or `PENDING` while another slice remains active. That prevents the cuFile descriptor and its parameter storage from being released while I/O may still reference them, but it does not initiate recovery.

This follow-up adds descriptor-wide failure cleanup:

- Cache completion events by submission cookie across partial and reordered polls.
- Latch terminal failures and non-retryable polling errors at the descriptor level.
- Treat `CU_FILE_INTERNAL_BATCH_GETSTATUS_ERROR` as retryable without canceling a healthy batch or discarding a cached terminal task result.
- Request handle-wide cancellation once when failed and active operations coexist.
- Keep polling until every submitted operation reaches a terminal state.
- Reject new submissions and descriptor release while cleanup is in progress.
- Cache final statuses for every task after the descriptor drains.
- Report cleanup-induced cancellations as `FAILED`, while preserving spontaneous `CANCELED` results.
- Destroy failed or canceled cuFile handles instead of returning them to the reusable pool.
- Continue pooling handles from all-success batches.
- Submit only parameters appended since the previous submission and roll back unsubmitted parameters when request construction fails.
- Retain and quarantine the full attempted range after a batch submission error so accepted work can still be canceled and drained.

```mermaid
flowchart LR
    A[Submitted batch] --> B{Failure observed?}
    B -->|No, all complete| C[Cache task statuses]
    C --> D[Return handle to pool]

    B -->|Yes| E[Latch descriptor failure]
    E --> F[Cancel active operations once]
    F --> G{All submitted cookies terminal?}
    G -->|No| H[Keep handle and parameters live]
    H --> G
    G -->|Yes| I[Cache final task statuses]
    I --> J[Destroy failed handle]
```

`cuFileBatchIOCancel()` is best-effort. If an operation never reaches a terminal state, the transport continues reporting `WAITING` or `PENDING` and refuses to release the descriptor. Returning a terminal result or destroying the handle in that state would not prove that caller-owned buffers are no longer in use. This PR therefore improves the recoverable failure path but does not close the bounded-recovery requirement in #2916.

### Suggested review order

1. `cufile_desc_pool.h` and `cufile_desc_pool.cpp`: descriptor state, submission ownership, polling, cancellation, and handle retirement.
2. `nvmeof_transport.cpp`: task aggregation, retryable poll handling, submission rollback, and release gating.
3. `nvmeof_status_test.cpp`: cross-task failure, transient polling, submit failure, cancellation, draining, and handle-reuse cases.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

**Test commands:**

```bash
LD_LIBRARY_PATH=/usr/local/lib/python3.12/dist-packages/nvidia/cu13/lib \
ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 \
UBSAN_OPTIONS=halt_on_error=1 \
/tmp/mooncake-nvmeof-asan/nvmeof_status_test --gtest_color=no

pre-commit run --files \
  mooncake-transfer-engine/include/transport/nvmeof_transport/cufile_desc_pool.h \
  mooncake-transfer-engine/include/transport/nvmeof_transport/nvmeof_transport.h \
  mooncake-transfer-engine/src/transport/nvmeof_transport/cufile_desc_pool.cpp \
  mooncake-transfer-engine/src/transport/nvmeof_transport/nvmeof_transport.cpp \
  mooncake-transfer-engine/tests/nvmeof_status_test.cpp

git diff --check origin/main..HEAD
```

**Test results:**

- [x] Unit tests pass: 21/21
- [x] ASan and UBSan report no findings
- [x] All touched-file pre-commit hooks pass
- [x] The pre-fix lifecycle fails the cross-task regression because it never requests cancellation and cannot finish or release the affected batch

## Checklist

- [x] The complete branch diff was reviewed against #2893
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on every file touched by this change, and all hooks pass
- [x] Documentation is not applicable because this does not change the public API
- [x] I have added tests to prove my changes are effective
- [x] An RFC is not required because the non-test diff is under 500 changed lines; #2916 documents the recovery constraints

## AI Assistance Disclosure

- [x] AI tools were used

Codex assisted with source tracing, cuFile contract research, implementation, test design, and adversarial review. The submitter remains responsible for reviewing and understanding the final diff.
