### PR TITLE
[Store] Support direct SSD write

### DIFF
--- a/docs/source/deployment/ssd-offload.md
+++ b/docs/source/deployment/ssd-offload.md
@@ -88,6 +88,130 @@ store.setup_dummy(
 
 ---
 
+## Direct SSD Write (`direct_ssd`)
+
+`direct_ssd` writes object data directly to SSD during `Put`, bypassing DRAM entirely. Instead of allocating MEMORY replicas, the master allocates LOCAL_DISK replicas on available SSD nodes.
+
+There are two roles in a `direct_ssd` deployment:
+
+- **SSD storage nodes**: contribute local SSD capacity via `enable_ssd_offload=true`. They receive data (local `DirectWrite` or remote TransferEngine READ → `DirectWrite`) and store it on their local SSDs.
+- **Pure compute nodes** (no local SSD): set `direct_ssd=True` only. They push data to remote SSD nodes via TransferEngine (RDMA/TCP) — no local SSD backend required.
+
+**Prerequisites**:
+
+| Role | Setup | Why |
+|------|-------|-----|
+| Master | `--enable_offload=true` | Allows `LocalDiskSegment` registration |
+| SSD storage node | `enable_ssd_offload=true` + `ssd_offload_path` | Creates `FileStorage` backend, mounts local disk segment |
+| Pure compute node | `direct_ssd=True` (no `enable_ssd_offload` needed) | `ClientRequester` is always injected; remote writes use `write_offload_from_engine` RPC |
+
+**Mode A — Embedded Real Client (SSD storage node that also does Puts):**
+
+Set `enable_ssd_offload=True` and `direct_ssd=True` to both contribute SSD capacity and default Puts to direct SSD writes:
+
+```python
+store = MooncakeDistributedStore()
+store.setup(
+    local_hostname="192.168.1.1",
+    metadata_server="P2PHANDSHAKE",
+    global_segment_size=0,                     # no DRAM contribution
+    local_buffer_size=1024 * 1024 * 1024,      # staging buffer for SSD I/O
+    protocol="rdma",
+    rdma_devices="mlx5_0",                     # RDMA verbs device name (see `ibv_devices`)
+    master_server_addr="127.0.0.1:50051",
+    enable_ssd_offload=True,                   # contribute SSD capacity
+    ssd_offload_path="/nvme/mooncake_offload",
+    direct_ssd=True,                           # default all Puts to direct SSD
+)
+
+# All Puts now use direct SSD by default
+store.put("my_kv_key", data)
+```
+
+Or config dict:
+
+```python
+store.setup({
+    "local_hostname": "192.168.1.1",
+    "metadata_server": "P2PHANDSHAKE",
+    "master_server_addr": "127.0.0.1:50051",
+    "protocol": "rdma",
+    "rdma_devices": "mlx5_0",
+    "global_segment_size": "0",
+    "local_buffer_size": "1073741824",
+    "enable_ssd_offload": "true",
+    "ssd_offload_path": "/nvme/mooncake_offload",
+    "direct_ssd": "true",
+})
+```
+
+**Mode B — Standalone Real Client + DummyClient:**
+
+The standalone `mooncake_client` starts the same way as regular offload (see Step 3B). On the application side (vLLM/SGLang), set `direct_ssd` in `ReplicateConfig`:
+
+```python
+from mooncake.store import ReplicateConfig
+
+config = ReplicateConfig()
+config.replica_num = 2      # controls LOCAL_DISK replicas
+config.direct_ssd = True    # write directly to SSD, bypass DRAM
+store.put("key", data, config)
+```
+
+**Mode C — Pure compute node** (no local SSD, pushes data to remote SSD nodes):
+
+Set only `direct_ssd=True` — no `enable_ssd_offload` or `ssd_offload_path` needed. On each Put the compute node concatenates the slices into a transient staging buffer, registers it with the TransferEngine, and calls `write_offload_from_engine` on the remote SSD nodes selected by the master (the staging buffer is per-Put and independent of `local_buffer_size`):
+
+```python
+store = MooncakeDistributedStore()
+store.setup(
+    local_hostname="192.168.1.2",
+    metadata_server="P2PHANDSHAKE",
+    global_segment_size=0,                     # no DRAM contribution
+    local_buffer_size=1024 * 1024 * 1024,      # for Get-path reads, not direct_ssd staging
+    protocol="rdma",
+    rdma_devices="mlx5_0",                     # RDMA verbs device name (see `ibv_devices`)
+    master_server_addr="192.168.1.1:50051",
+    direct_ssd=True,                           # only this — no SSD backend needed
+)
+
+# Master allocates LOCAL_DISK replicas on storage nodes (Mode A / Step 3A).
+# Compute node concatenates slices → TE registers staging buffer →
+# RPC calls write_offload_from_engine on each target → target TE-READs + DirectWrite.
+store.put("my_key", data)
+```
+
+**Behavior summary:**
+
+| `direct_ssd` at setup | Effect |
+|---|---|
+| `false` (default) | All Puts use the normal memory + async offload path |
+| `true` | All Puts default to direct SSD write; can be overridden per-request via `ReplicateConfig.direct_ssd=False` |
+
+When `direct_ssd=True`, `replica_num` controls LOCAL_DISK replicas instead of MEMORY replicas. No DRAM quota is consumed.
+
+Per-request override via `ReplicateConfig`:
+
+```python
+from mooncake.store import ReplicateConfig
+
+# Override to use normal memory path even when setup default is direct_ssd=True
+config = ReplicateConfig()
+config.direct_ssd = False
+config.replica_num = 1     # MEMORY replicas
+store.put("key", data, config)
+
+# Override to use direct SSD even when setup default is direct_ssd=False
+config2 = ReplicateConfig()
+config2.direct_ssd = True
+config2.replica_num = 3    # LOCAL_DISK replicas
+store.put("key2", data, config2)
+```
+
+For architecture details and data flow, see the "Direct SSD Write" section in the design document.
+
+---
+
 ## Real Client Parameters
 
 | Flag | Default | Description |

--- a/docs/source/design/ssd-offload.md
+++ b/docs/source/design/ssd-offload.md
@@ -91,6 +91,83 @@ Step by step:
 4. **Write to SSD**: `StorageBackend::BatchOffload` serializes and writes the key-value data to disk.
 5. **Notify master**: On success, the `complete_handler` calls `client_->NotifyOffloadSuccess(keys, metadatas)`. The master adds a `LOCAL_DISK` replica entry (carrying the real client's RPC address as `transport_endpoint`) to the object's replica list.
 
+(direct-ssd-write)=
+### Direct SSD Write (`direct_ssd`) — Bypass DRAM
+
+The standard offload path always writes to DRAM first and asynchronously migrates data to SSD. The `direct_ssd` feature reverses this: objects are written directly to SSD during `Put`, bypassing DRAM entirely. This reduces memory pressure and eliminates the heartbeat-driven offload delay.
+
+**Data flow:**
+
+```
+Client                         Master                         Target SSD Nodes
+  │                               │                                   │
+  │─ PutStart(direct_ssd=true) ──▶│                                   │
+  │  replica_num=3                │  Phase C: select 3 SSD nodes      │
+  │                               │  (sorted by free capacity)        │
+  │◀─ 3 LOCAL_DISK replicas ─────│  status=PROCESSING                │
+  │                               │                                   │
+  │  [SubmitTransfers]            │                                   │
+  │  ┌─ local replica ──▶ DirectWrite ──▶ local SSD                  │
+  │  ├─ remote replica ──▶  RPC(control) ──▶ Target: TE READ ──▶ SSD │
+  │  └─ remote replica ──▶  RPC(control) ──▶ Target: TE READ ──▶ SSD │
+  │  (all enqueued in parallel on write_thread_pool_)                │
+  │                               │                                   │
+  │─ PutEnd(LOCAL_DISK) ─────────▶│                                   │
+  │                               │  mark COMPLETE                    │
+  │                               │  ssd_used_bytes += object_size    │
+  │                               │  (skip offload queue)             │
+```
+
+**Key differences from the heartbeat offload path:**
+
+| Aspect | Heartbeat offload | direct_ssd |
+|--------|------------------|------------|
+| Write timing | Async (heartbeat cycle) | Synchronous with `Put` |
+| Memory allocation | Yes (MEMORY replica) | No (only a transient staging buffer) |
+| Memory quota | Consumed | Not consumed |
+| Transport | Read MEMORY locally → write SSD | Local: DirectWrite; Remote: TransferEngine (RDMA/TCP) |
+| Replica allocation | `PutStart` allocates MEMORY; offload creates LOCAL_DISK later | `PutStart` allocates LOCAL_DISK directly (Phase C) |
+| ssd_used_bytes tracking | Incremented in `NotifyOffloadSuccess` | Incremented in `PutEnd` (PROCESSING→COMPLETE) |
+| Eviction | Unified with heartbeat data (same FIFO/LRU via `BucketStorageBackend`) | Same |
+
+**Prerequisites**:
+
+There are two roles in a `direct_ssd` deployment: **SSD storage nodes** that contribute local SSD capacity, and **pure compute nodes** that push data to remote SSDs without a local SSD backend.
+
+| Role | Setup | Purpose |
+|------|-------|---------|
+| Master | `--enable_offload=true` | Allows `LocalDiskSegment` registration |
+| SSD storage node | `enable_ssd_offload=true` + `direct_ssd=true` (optional) at setup | Creates `FileStorage`, mounts local disk segment; optionally defaults Puts to direct SSD |
+| Pure compute node | `direct_ssd=True` at setup (no `enable_ssd_offload` needed) | `ClientRequester` is always injected; remote writes use TransferEngine + `write_offload_from_engine` RPC |
+
+For deployment instructions and full setup examples, see [SSD Offload deployment](../deployment/ssd-offload.md#direct-ssd-write-direct_ssd).
+
+**Per-request control:**
+
+When `direct_ssd=True` is set at client setup, all Puts default to direct SSD writes. Individual calls can override this via `ReplicateConfig`:
+
+```python
+from mooncake.store import ReplicateConfig
+
+# Override to use normal memory path (even with direct_ssd=True at setup)
+config = ReplicateConfig()
+config.direct_ssd = False
+config.replica_num = 1     # MEMORY replicas
+store.put("key", data, config)
+
+# Override to use direct SSD (even with direct_ssd=False at setup)
+config2 = ReplicateConfig()
+config2.direct_ssd = True
+config2.replica_num = 3    # LOCAL_DISK replicas
+store.put("key2", data, config2)
+```
+
+When `direct_ssd=True`, `replica_num` controls the number of **LOCAL_DISK replicas** (not MEMORY replicas). No DRAM quota is consumed. Each replica is written in parallel — locally via `DirectWrite`, remotely via TransferEngine (RDMA/TCP). Evicted data from both `direct_ssd` and the heartbeat-offload path shares the same SSD pool and eviction policy.
+
+**Allocation:** The master selects `replica_num` SSD clients with the largest free capacity (sorted by `(total_capacity - ssd_used_bytes - object_size) / total_capacity` descending). This ensures load-balanced SSD utilization across nodes.
+
+**Fallback:** If `direct_ssd=true` but no SSD clients are registered, `PutStart` returns `NO_AVAILABLE_HANDLE`. If a subset of replicas fail during write, the successful ones are kept and failed ones are revoked via `PutRevoke`.
+
 ### Load (SSD → memory)
 
 The load path involves three parties: the **requesting client**, the **target client** that holds the SSD data, and the **Transfer Engine** for zero-copy data movement.

--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -1842,6 +1842,7 @@ PYBIND11_MODULE(store, m) {
                        &ReplicateConfig::prefer_alloc_in_same_node)
         .def_readwrite("data_type", &ReplicateConfig::data_type)
         .def_readwrite("group_ids", &ReplicateConfig::group_ids)
+        .def_readwrite("direct_ssd", &ReplicateConfig::direct_ssd)
         .def("__str__", [](const ReplicateConfig &config) {
             std::ostringstream oss;
             oss << config;
@@ -2119,7 +2120,8 @@ PYBIND11_MODULE(store, m) {
                const std::string &ssd_offload_path = "",
                const std::string &tenant_id = "default",
                bool enable_client_http_server = false,
-               int client_http_port = DEFAULT_CLIENT_HTTP_PORT) {
+               int client_http_port = DEFAULT_CLIENT_HTTP_PORT,
+               bool direct_ssd = false) {
                 auto real_client = self.init_real_client();
                 std::shared_ptr<mooncake::TransferEngine> transfer_engine =
                     nullptr;
@@ -2132,7 +2134,7 @@ PYBIND11_MODULE(store, m) {
                     local_buffer_size, protocol, rdma_devices,
                     master_server_addr, transfer_engine, "", enable_ssd_offload,
                     ssd_offload_path, tenant_id, enable_client_http_server,
-                    client_http_port);
+                    client_http_port, direct_ssd);
             },
             py::arg("local_hostname"), py::arg("metadata_server"),
             py::arg("global_segment_size"), py::arg("local_buffer_size"),
@@ -2141,7 +2143,8 @@ PYBIND11_MODULE(store, m) {
             py::arg("enable_ssd_offload") = false,
             py::arg("ssd_offload_path") = "", py::arg("tenant_id") = "default",
             py::arg("enable_client_http_server") = false,
-            py::arg("client_http_port") = DEFAULT_CLIENT_HTTP_PORT)
+            py::arg("client_http_port") = DEFAULT_CLIENT_HTTP_PORT,
+            py::arg("direct_ssd") = false)
         .def(
             "setup",
             [](MooncakeStorePyWrapper &self, const py::dict &config_dict) {
@@ -2171,6 +2174,8 @@ PYBIND11_MODULE(store, m) {
             "  master_server_addr: Master server address.\n"
             "  ipc_socket_path: IPC socket path.\n"
             "  enable_ssd_offload: Enable SSD offload (default false).\n"
+            "  direct_ssd: Write directly to SSD during Put, bypassing "
+            "MEMORY (default false).\n"
             "  ssd_offload_path: SSD storage directory path (overrides env "
             "var).\n"
             "  tenant_id: Tenant identifier (default 'default').\n"

--- a/mooncake-store/go/mooncakestore/config.go
+++ b/mooncake-store/go/mooncakestore/config.go
@@ -19,6 +19,7 @@ type ReplicateConfig struct {
 	ReplicaNum        int
 	WithSoftPin       bool
 	WithHardPin       bool
+	DirectSsd         *bool // write directly to SSD, bypassing memory; nil = use client default
 	PreferredSegments []string
 }
 
@@ -28,5 +29,6 @@ func DefaultReplicateConfig() ReplicateConfig {
 		ReplicaNum:  1,
 		WithSoftPin: false,
 		WithHardPin: false,
+		DirectSsd:   nil,
 	}
 }

--- a/mooncake-store/go/mooncakestore/store.go
+++ b/mooncake-store/go/mooncakestore/store.go
@@ -129,6 +129,7 @@ func (s *Store) toCConfig(cfg *ReplicateConfig) (C.mooncake_replicate_config_t, 
 
 	if cfg == nil {
 		cc.replica_num = 1
+		cc.direct_ssd = -1 // unset — use client default
 		return cc, nil, nil
 	}
 
@@ -142,6 +143,15 @@ func (s *Store) toCConfig(cfg *ReplicateConfig) (C.mooncake_replicate_config_t, 
 	}
 	if cfg.WithHardPin {
 		cc.with_hard_pin = 1
+	}
+	if cfg.DirectSsd != nil {
+		if *cfg.DirectSsd {
+			cc.direct_ssd = 1
+		} else {
+			cc.direct_ssd = 0
+		}
+	} else {
+		cc.direct_ssd = -1 // unset — use client default
 	}
 
 	if len(cfg.PreferredSegments) > 0 {

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -31,6 +31,7 @@
 namespace mooncake {
 
 class PutOperation;
+class ClientRequester;
 
 /**
  * @brief Result of a query operation containing replica information and lease
@@ -411,7 +412,8 @@ class Client {
      * @brief Mounts a local disk segment into the master.
      * @param enable_offloading If true, enables offloading (write-to-file).
      */
-    tl::expected<void, ErrorCode> MountLocalDiskSegment(bool enable_offloading);
+    tl::expected<void, ErrorCode> MountLocalDiskSegment(
+        bool enable_offloading, const std::string& rpc_endpoint = {});
 
     /**
      * @brief Heartbeat call to collect object-level statistics and retrieve the
@@ -571,6 +573,10 @@ class Client {
 
     [[nodiscard]] const std::string& GetProtocol() const { return protocol_; }
 
+    [[nodiscard]] std::shared_ptr<TransferEngine> GetTransferEngine() const {
+        return transfer_engine_;
+    }
+
     /**
      * @brief Get the endpoint address for segment operations.
      * @return For P2PHANDSHAKE mode, returns the actual RPC endpoint (IP:Port).
@@ -648,6 +654,26 @@ class Client {
     }
 
     bool IsReplicaOnLocalMemory(const Replica::Descriptor& replica);
+
+    /**
+     * @brief Set storage backend for direct_ssd direct SSD writes.
+     */
+    void SetLocalDiskStorageBackend(
+        std::shared_ptr<StorageBackendInterface> backend) {
+        local_disk_storage_backend_ = std::move(backend);
+    }
+
+    /**
+     * @brief Set client requester for direct_ssd cross-node RPC calls.
+     */
+    void SetClientRequester(std::shared_ptr<ClientRequester> requester) {
+        rpc_client_requester_ = std::move(requester);
+    }
+
+    // If true, all Puts default to direct_ssd (caller can still override
+    // per-request via ReplicateConfig).
+    void SetDefaultDirectSsd(bool val) { default_direct_ssd_ = val; }
+    bool GetDefaultDirectSsd() const { return default_direct_ssd_; }
 
    protected:
     /**
@@ -762,6 +788,19 @@ class Client {
     void StartBatchPut(std::vector<PutOperation>& ops,
                        const ReplicateConfig& config);
     void SubmitTransfers(std::vector<PutOperation>& ops);
+    void SubmitLocalDiskTransfers(PutOperation& op);
+    // Submit LOCAL_DISK replica writes (direct_ssd) for one object and
+    // return the in-flight futures. Shared by the batch path
+    // (SubmitLocalDiskTransfers) and the single-key Put path.
+    std::vector<std::pair<ReplicaType, TransferFuture>>
+    SubmitLocalDiskReplicaWrites(
+        const ObjectKey& key, const std::vector<Slice>& slices,
+        const std::vector<Replica::Descriptor>& replicas);
+    // Report SSD objects evicted by a local DirectWrite to the master so it
+    // drops their LOCAL_DISK replicas (mirrors FileStorage::DirectWrite on
+    // the remote-write leg).
+    void NotifyLocalDiskEvictions(
+        const std::vector<std::string>& evicted_storage_keys);
     void WaitForTransfers(std::vector<PutOperation>& ops);
     void FinalizeBatchPut(std::vector<PutOperation>& ops);
     void StartBatchUpsert(std::vector<PutOperation>& ops,
@@ -828,6 +867,11 @@ class Client {
     std::unique_ptr<PinnedBufferPool> pinned_buffer_pool_;
     ThreadPool write_thread_pool_;
     std::shared_ptr<StorageBackend> storage_backend_;
+    // Injected storage backend for direct_ssd direct LOCAL_DISK writes.
+    std::shared_ptr<StorageBackendInterface> local_disk_storage_backend_;
+    // Injected client requester for direct_ssd cross-node RPC calls.
+    std::shared_ptr<ClientRequester> rpc_client_requester_;
+    bool default_direct_ssd_ = false;
 
     // For high availability
     std::unique_ptr<ha::LeaderCoordinator> leader_coordinator_;

--- a/mooncake-store/include/dummy_client.h
+++ b/mooncake-store/include/dummy_client.h
@@ -32,7 +32,8 @@ class DummyClient : public PyClient {
                    const std::string &ssd_offload_path = "",
                    const std::string &tenant_id = "default",
                    bool enable_client_http_server = false,
-                   int client_http_port = DEFAULT_CLIENT_HTTP_PORT) {
+                   int client_http_port = DEFAULT_CLIENT_HTTP_PORT,
+                   bool direct_ssd = false) {
         // Dummy client does not support real setup
         return -1;
     };

--- a/mooncake-store/include/file_storage.h
+++ b/mooncake-store/include/file_storage.h
@@ -49,6 +49,29 @@ class FileStorage {
      */
     bool ReleaseBuffer(uint64_t batch_id);
 
+    /**
+     * @brief Get the storage backend for direct SSD writes (direct_ssd).
+     */
+    std::shared_ptr<StorageBackendInterface> getStorageBackend() const {
+        return storage_backend_;
+    }
+
+    /**
+     * @brief Direct SSD write for direct_ssd. Writes key+slices synchronously.
+     * @return StorageObjectMetadata for master LOCAL_DISK registration and
+     *         any keys evicted during the write.
+     */
+    tl::expected<std::pair<StorageObjectMetadata, std::vector<std::string>>,
+                 ErrorCode>
+    DirectWrite(const std::string& key, const std::vector<Slice>& slices);
+
+    /**
+     * @brief Get the client buffer allocator (for TE READ staging buffers).
+     */
+    std::shared_ptr<ClientBufferAllocator> getClientBufferAllocator() const {
+        return client_buffer_allocator_;
+    }
+
    private:
     friend class FileStorageTest;
     friend class FileStoragePromotionTest;

--- a/mooncake-store/include/master_client.h
+++ b/mooncake-store/include/master_client.h
@@ -420,7 +420,8 @@ class MasterClient {
      * @param enable_offloading If true, enables offloading (write-to-file).
      */
     [[nodiscard]] tl::expected<void, ErrorCode> MountLocalDiskSegment(
-        const UUID& client_id, bool enable_offloading);
+        const UUID& client_id, bool enable_offloading,
+        const std::string& rpc_endpoint = {});
 
     /**
      * @brief Heartbeat call to collect object-level statistics and retrieve the

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -631,8 +631,11 @@ class MasterService {
     /**
      * @brief Mounts a file storage segment into the master.
      * @param enable_offloading If true, enables offloading (write-to-file).
+     * @param rpc_endpoint RPC address of the client, used for direct_ssd
+     * cross-node TransferEngine reads.
      */
-    auto MountLocalDiskSegment(const UUID& client_id, bool enable_offloading)
+    auto MountLocalDiskSegment(const UUID& client_id, bool enable_offloading,
+                               const std::string& rpc_endpoint = {})
         -> tl::expected<void, ErrorCode>;
 
     /**
@@ -1045,7 +1048,8 @@ class MasterService {
             return EraseReplicas([replica_type](const Replica& replica) {
                 if (replica_type == ReplicaType::ALL) {
                     return replica.is_memory_replica() ||
-                           replica.is_nof_replica();
+                           replica.is_nof_replica() ||
+                           replica.is_local_disk_replica();
                 }
                 return replica.type() == replica_type;
             });

--- a/mooncake-store/include/pyclient.h
+++ b/mooncake-store/include/pyclient.h
@@ -163,6 +163,10 @@ class ClientRequester {
     void release_offload_buffer(const std::string &client_addr,
                                 uint64_t batch_id);
 
+    tl::expected<void, ErrorCode> write_offload_from_engine(
+        const std::string &client_addr, const std::string &engine_addr,
+        uint64_t buffer_addr, uint64_t size, const std::string &key);
+
    private:
     /**
      * @brief A batch of allocated memory buffers, tracking both handles and
@@ -227,7 +231,8 @@ class PyClient {
         const std::string &ssd_offload_path = "",
         const std::string &tenant_id = "default",
         bool enable_client_http_server = false,
-        int client_http_port = DEFAULT_CLIENT_HTTP_PORT) = 0;
+        int client_http_port = DEFAULT_CLIENT_HTTP_PORT,
+        bool direct_ssd = false) = 0;
 
     virtual int setup_dummy(size_t mem_pool_size, size_t local_buffer_size,
                             const std::string &server_address,

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -91,7 +91,8 @@ class RealClient : public PyClient {
         const std::string &ssd_offload_path = "",
         const std::string &tenant_id = "default",
         bool enable_client_http_server = false,
-        int client_http_port = DEFAULT_CLIENT_HTTP_PORT);
+        int client_http_port = DEFAULT_CLIENT_HTTP_PORT,
+        bool direct_ssd = false);
 
     int setup_dummy(size_t mem_pool_size, size_t local_buffer_size,
                     const std::string &server_address,
@@ -515,7 +516,8 @@ class RealClient : public PyClient {
         const std::string &ssd_offload_path = "",
         const std::string &tenant_id = "default",
         bool enable_client_http_server = false,
-        int client_http_port = DEFAULT_CLIENT_HTTP_PORT);
+        int client_http_port = DEFAULT_CLIENT_HTTP_PORT,
+        bool direct_ssd = false);
 
     // Overload that accepts a configuration dictionary
     tl::expected<void, ErrorCode> setup_internal(const ConfigDict &config);
@@ -695,6 +697,14 @@ class RealClient : public PyClient {
      * @return true if batch was found and released, false otherwise
      */
     bool release_offload_buffer(uint64_t batch_id);
+
+    /**
+     * @brief TransferEngine-based write: TE READ from writer's buffer,
+     *        then DirectWrite to SSD.
+     */
+    tl::expected<void, ErrorCode> write_offload_from_engine(
+        const std::string &engine_addr, uint64_t buffer_addr, uint64_t size,
+        const std::string &key);
 
     /**
      * @brief Retrieves multiple stored objects from a remote service.

--- a/mooncake-store/include/replica.h
+++ b/mooncake-store/include/replica.h
@@ -92,6 +92,10 @@ struct ReplicateConfig {
     bool prefer_alloc_in_same_node{false};
     ObjectDataType data_type{ObjectDataType::UNKNOWN};
     std::string host_id{};
+    // When true, replica_num controls LOCAL_DISK replicas instead of MEMORY
+    // replicas. Data is written directly to SSD during Put, bypassing the
+    // MEMORY + async offload cycle.
+    std::optional<bool> direct_ssd;
     // Optional per-key routing group IDs. Empty string keeps that key
     // ungrouped. Grouped keys share metadata routing, coalesced lease refresh,
     // and memory eviction behavior.
@@ -134,6 +138,10 @@ struct ReplicateConfig {
         if (!config.host_id.empty()) {
             os << ", host_id: " << config.host_id;
         }
+        os << ", direct_ssd: "
+           << (config.direct_ssd.has_value()
+                   ? (config.direct_ssd.value() ? "true" : "false")
+                   : "not-set");
         if (config.group_ids.has_value()) {
             os << ", group_ids: [";
             for (size_t i = 0; i < config.group_ids->size(); ++i) {
@@ -679,6 +687,11 @@ inline std::ostream& operator<<(std::ostream& os, const Replica& replica) {
         const auto& disk_data = std::get<DiskReplicaData>(replica.data_);
         os << "type: DISK, file_path: " << disk_data.file_path
            << ", object_size: " << disk_data.object_size;
+    } else if (replica.is_local_disk_replica()) {
+        const auto& local_disk_data =
+            std::get<LocalDiskReplicaData>(replica.data_);
+        os << "type: LOCAL_DISK, client_id: " << local_disk_data.client_id
+           << ", object_size: " << local_disk_data.object_size;
     }
 
     os << ", refcnt: " << replica.refcnt_.load() << " }";

--- a/mooncake-store/include/rpc_service.h
+++ b/mooncake-store/include/rpc_service.h
@@ -207,8 +207,9 @@ class WrappedMasterService {
     tl::expected<std::pair<uint64_t, uint64_t>, ErrorCode> QuerySegmentForAdmin(
         const std::string& segment);
 
-    tl::expected<void, ErrorCode> MountLocalDiskSegment(const UUID& client_id,
-                                                        bool enable_offloading);
+    tl::expected<void, ErrorCode> MountLocalDiskSegment(
+        const UUID& client_id, bool enable_offloading,
+        const std::string& rpc_endpoint = {});
 
     tl::expected<std::vector<OffloadTaskItem>, ErrorCode>
     OffloadObjectHeartbeat(const UUID& client_id, bool enable_offloading);

--- a/mooncake-store/include/segment.h
+++ b/mooncake-store/include/segment.h
@@ -91,6 +91,7 @@ struct LocalDiskSegment {
     mutable Mutex offloading_mutex_;
     bool enable_offloading;
     int64_t ssd_total_capacity_bytes = 0;  // last reported by client heartbeat
+    std::string rpc_endpoint;  // RPC address for offload reads/writes
     std::atomic<int64_t> ssd_used_bytes{0};
     std::unordered_map<std::string, OffloadTaskItem> GUARDED_BY(
         offloading_mutex_) offloading_objects;
@@ -132,7 +133,8 @@ class ScopedSegmentAccess {
     ErrorCode MountSegment(const Segment& segment, const UUID& client_id);
 
     ErrorCode MountLocalDiskSegment(const UUID& client_id,
-                                    bool enable_offloading);
+                                    bool enable_offloading,
+                                    const std::string& rpc_endpoint = {});
 
     /**
      * @brief Re-mount a segment. To avoid infinite remount trying, only the

--- a/mooncake-store/include/storage/distributed/distributed_storage_backend.h
+++ b/mooncake-store/include/storage/distributed/distributed_storage_backend.h
@@ -40,6 +40,11 @@ class DistributedStorageBackend : public StorageBackendInterface {
         std::function<void(const std::vector<std::string>& evicted_keys)>
             eviction_handler = nullptr) override;
 
+    tl::expected<std::pair<StorageObjectMetadata, std::vector<std::string>>,
+                 ErrorCode>
+    DirectWrite(const std::string& key,
+                const std::vector<Slice>& slices) override;
+
     tl::expected<void, ErrorCode> BatchLoad(
         std::unordered_map<std::string, Slice>& batched_slices) override;
 

--- a/mooncake-store/include/storage_backend.h
+++ b/mooncake-store/include/storage_backend.h
@@ -277,6 +277,16 @@ class StorageBackendInterface {
     // cursor-based iteration (e.g. BucketStorageBackend).
     virtual void ResetScanIterator() {}
 
+    // Direct (single-key) write for direct_ssd during Put.
+    // Writes key+slices to the storage backend synchronously.
+    // Returns StorageObjectMetadata for LOCAL_DISK replica registration
+    // and any keys evicted during the write to satisfy quota.
+    // Each backend must implement DirectWrite. Backends using BatchOffload
+    // can delegate to it.
+    virtual tl::expected<
+        std::pair<StorageObjectMetadata, std::vector<std::string>>, ErrorCode>
+    DirectWrite(const std::string& key, const std::vector<Slice>& slices) = 0;
+
     // Test-only: Set predicate to force failures for specific keys in
     // BatchOffload. Default implementation does nothing (no failures injected).
     // Concrete backends can override to provide test failure injection.
@@ -631,6 +641,11 @@ class StorageBackendAdaptor : public StorageBackendInterface {
         std::function<void(const std::vector<std::string>& evicted_keys)>
             eviction_handler = nullptr) override;
 
+    tl::expected<std::pair<StorageObjectMetadata, std::vector<std::string>>,
+                 ErrorCode>
+    DirectWrite(const std::string& key,
+                const std::vector<Slice>& slices) override;
+
     tl::expected<void, ErrorCode> BatchLoad(
         std::unordered_map<std::string, Slice>& batched_slices) override;
 
@@ -706,9 +721,14 @@ class BucketStorageBackend : public StorageBackendInterface {
         std::function<void(const std::vector<std::string>& evicted_keys)>
             eviction_handler = nullptr) override;
 
+    tl::expected<std::pair<StorageObjectMetadata, std::vector<std::string>>,
+                 ErrorCode>
+    DirectWrite(const std::string& key,
+                const std::vector<Slice>& slices) override;
+
     /**
      * @brief Retrieves metadata for multiple objects in a single batch
-     * operation.
+     * operation. (BucketStorageBackend)
      * @param keys A list of object keys to query metadata for.
      * @param batch_object_metadata Output parameter that receives the
      * retrieved metadata.
@@ -1018,8 +1038,14 @@ class OffsetAllocatorStorageBackend : public StorageBackendInterface {
         std::function<void(const std::vector<std::string>& evicted_keys)>
             eviction_handler = nullptr) override;
 
+    tl::expected<std::pair<StorageObjectMetadata, std::vector<std::string>>,
+                 ErrorCode>
+    DirectWrite(const std::string& key,
+                const std::vector<Slice>& slices) override;
+
     /**
      * @brief Loads data for multiple objects in a batch operation.
+     * (OffsetAllocator)
      * @param batched_slices A map from object key to a pre-allocated writable
      * buffer (Slice).
      * @return tl::expected<void, ErrorCode> indicating operation status.

--- a/mooncake-store/include/store_c.h
+++ b/mooncake-store/include/store_c.h
@@ -28,6 +28,7 @@ struct mooncake_replicate_config {
     size_t replica_num;
     int with_soft_pin;
     int with_hard_pin;
+    int direct_ssd;
     const char **preferred_segments;
     size_t preferred_segments_count;
 };

--- a/mooncake-store/include/transfer_task.h
+++ b/mooncake-store/include/transfer_task.h
@@ -1,9 +1,11 @@
 #pragma once
 
 #include <atomic>
+#include <chrono>
 #include <condition_variable>
 #include <cstdint>
 #include <cstring>
+#include <future>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -120,6 +122,42 @@ class EmptyOperationState : public OperationState {
     TransferStrategy get_strategy() const override {
         return TransferStrategy::EMPTY;
     }
+};
+
+/**
+ * @brief Operation state that wraps a std::future for external async I/O
+ *        (used by direct_ssd LOCAL_DISK writes, future GDS, etc).
+ *        On wait_for_completion() the future result is stored in result_
+ *        so the base class get_result() can read it.
+ */
+class FutureOperationState : public OperationState {
+   public:
+    explicit FutureOperationState(std::future<tl::expected<void, ErrorCode>> f)
+        : future_(std::move(f)) {}
+
+    bool is_completed() override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return result_.has_value();
+    }
+
+    void wait_for_completion() override {
+        if (future_.valid()) {
+            std::lock_guard<std::mutex> lock(mutex_);
+            auto result = future_.get();
+            if (result && result.has_value()) {
+                result_.emplace(ErrorCode::OK);
+            } else {
+                result_.emplace(result.error());
+            }
+        }
+    }
+
+    TransferStrategy get_strategy() const override {
+        return TransferStrategy::FILE_READ;
+    }
+
+   private:
+    std::future<tl::expected<void, ErrorCode>> future_;
 };
 
 /**

--- a/mooncake-store/rust/src/store.rs
+++ b/mooncake-store/rust/src/store.rs
@@ -44,6 +44,8 @@ pub struct ReplicateConfig {
     pub with_soft_pin: bool,
     /// Declare whether the object will never be evicted.
     pub with_hard_pin: bool,
+    /// Write directly to SSD, bypassing DRAM. None = use client default.
+    pub direct_ssd: Option<bool>,
     /// Whitelist of segment names that should host a replica.
     pub preferred_segments: Vec<String>,
 }
@@ -76,6 +78,11 @@ impl ReplicateConfig {
             replica_num: self.replica_num,
             with_soft_pin: i32::from(self.with_soft_pin),
             with_hard_pin: i32::from(self.with_hard_pin),
+            direct_ssd: match self.direct_ssd {
+                Some(true) => 1,
+                Some(false) => 0,
+                None => -1,
+            },
             preferred_segments: if ptrs.is_empty() {
                 std::ptr::null_mut()
             } else {
@@ -615,6 +622,7 @@ mod tests {
             replica_num: 2,
             with_soft_pin: true,
             with_hard_pin: false,
+            direct_ssd: None,
             preferred_segments: Vec::new(),
         };
 
@@ -622,6 +630,7 @@ mod tests {
         assert_eq!(ffi_cfg.replica_num, 2);
         assert_eq!(ffi_cfg.with_soft_pin, 1);
         assert_eq!(ffi_cfg.with_hard_pin, 0);
+        assert_eq!(ffi_cfg.direct_ssd, -1);
         assert!(ffi_cfg.preferred_segments.is_null());
         assert_eq!(ffi_cfg.preferred_segments_count, 0);
         assert!(strings.is_empty());
@@ -634,6 +643,7 @@ mod tests {
             replica_num: 3,
             with_soft_pin: false,
             with_hard_pin: false,
+            direct_ssd: None,
             preferred_segments: vec!["seg-a".to_string(), "seg-b".to_string()],
         };
 
@@ -641,6 +651,7 @@ mod tests {
         assert_eq!(ffi_cfg.replica_num, 3);
         assert_eq!(ffi_cfg.with_soft_pin, 0);
         assert_eq!(ffi_cfg.with_hard_pin, 0);
+        assert_eq!(ffi_cfg.direct_ssd, -1);
         assert!(!ffi_cfg.preferred_segments.is_null());
         assert_eq!(ffi_cfg.preferred_segments_count, 2);
         assert_eq!(strings.len(), 2);
@@ -658,6 +669,7 @@ mod tests {
             replica_num: 1,
             with_soft_pin: false,
             with_hard_pin: false,
+            direct_ssd: None,
             preferred_segments: vec!["bad\0segment".to_string()],
         };
 
@@ -679,6 +691,7 @@ mod tests {
             replica_num: 4,
             with_soft_pin: true,
             with_hard_pin: false,
+            direct_ssd: None,
             preferred_segments: vec!["x".to_string(), "y".to_string()],
         };
 

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -3,10 +3,12 @@
 #include <glog/logging.h>
 
 #include "allocator.h"
+#include "pyclient.h"
 #include "segment.h"
 
 #include <csignal>
 #include <algorithm>
+#include <future>
 #include <cassert>
 #include <cerrno>
 #include <chrono>
@@ -129,10 +131,13 @@ std::optional<ContiguousSliceRange> GetContiguousSliceRange(
 struct ReplicaTransferSummary {
     size_t allocated_memory_replicas = 0;
     size_t allocated_nof_replicas = 0;
+    size_t allocated_local_disk_replicas = 0;
     size_t successful_memory_transfers = 0;
     size_t successful_nof_transfers = 0;
+    size_t successful_local_disk_transfers = 0;
     size_t failed_memory_transfers = 0;
     size_t failed_nof_transfers = 0;
+    size_t failed_local_disk_transfers = 0;
     ErrorCode first_error = ErrorCode::OK;
 
     void RecordAllocatedReplica(const Replica::Descriptor& replica) {
@@ -140,6 +145,8 @@ struct ReplicaTransferSummary {
             ++allocated_memory_replicas;
         } else if (replica.is_nof_replica()) {
             ++allocated_nof_replicas;
+        } else if (replica.is_local_disk_replica()) {
+            ++allocated_local_disk_replicas;
         }
     }
 
@@ -148,6 +155,8 @@ struct ReplicaTransferSummary {
             ++successful_memory_transfers;
         } else if (replica_type == ReplicaType::NOF_SSD) {
             ++successful_nof_transfers;
+        } else if (replica_type == ReplicaType::LOCAL_DISK) {
+            ++successful_local_disk_transfers;
         }
     }
 
@@ -156,15 +165,46 @@ struct ReplicaTransferSummary {
             ++failed_memory_transfers;
         } else if (replica_type == ReplicaType::NOF_SSD) {
             ++failed_nof_transfers;
+        } else if (replica_type == ReplicaType::LOCAL_DISK) {
+            ++failed_local_disk_transfers;
         }
         if (first_error == ErrorCode::OK) {
             first_error = error;
         }
     }
+
+    // True when every allocated replica (of any type) transferred
+    // successfully. This is the safe criterion for finalize paths that can
+    // only end/revoke ALL replica types at once (the upsert paths): ending
+    // with an unwritten replica would mark it COMPLETE without data.
+    bool AllAllocatedSucceeded() const {
+        return failed_memory_transfers == 0 && failed_nof_transfers == 0 &&
+               failed_local_disk_transfers == 0 &&
+               successful_memory_transfers == allocated_memory_replicas &&
+               successful_nof_transfers == allocated_nof_replicas &&
+               successful_local_disk_transfers ==
+                   allocated_local_disk_replicas &&
+               (allocated_memory_replicas + allocated_nof_replicas +
+                allocated_local_disk_replicas) > 0;
+    }
 };
 
 bool HasExpectedReplicaAllocation(const ReplicateConfig& config,
                                   const ReplicaTransferSummary& summary) {
+    // direct_ssd: replica_num controls LOCAL_DISK replicas, no MEMORY replicas
+    if (config.direct_ssd.value_or(false)) {
+        if (config.nof_replica_num == 0) {
+            return summary.allocated_local_disk_replicas > 0;
+        }
+        if (DetermineReplicaWriteMode(config) ==
+            ReplicaWriteMode::FLEXIBLE_DUAL_REPLICA) {
+            return summary.allocated_local_disk_replicas +
+                       summary.allocated_nof_replicas >
+                   0;
+        }
+        return summary.allocated_local_disk_replicas == config.replica_num &&
+               summary.allocated_nof_replicas == config.nof_replica_num;
+    }
     if (config.nof_replica_num == 0) {
         return summary.allocated_memory_replicas > 0;
     }
@@ -201,8 +241,11 @@ FinalizeDecision DetermineFinalizeDecision(
                 summary.allocated_memory_replicas &&
             summary.successful_nof_transfers ==
                 summary.allocated_nof_replicas &&
+            summary.successful_local_disk_transfers ==
+                summary.allocated_local_disk_replicas &&
             summary.failed_memory_transfers == 0 &&
-            summary.failed_nof_transfers == 0;
+            summary.failed_nof_transfers == 0 &&
+            summary.failed_local_disk_transfers == 0;
         if (allocation_satisfied && all_transfers_succeeded) {
             return {.end_type = ReplicaType::ALL,
                     .revoke_type = std::nullopt,
@@ -221,6 +264,8 @@ FinalizeDecision DetermineFinalizeDecision(
 
     const bool memory_succeeded = summary.successful_memory_transfers > 0;
     const bool nof_succeeded = summary.successful_nof_transfers > 0;
+    const bool local_disk_succeeded =
+        summary.successful_local_disk_transfers > 0;
 
     if (memory_succeeded && nof_succeeded) {
         return {.end_type = ReplicaType::ALL,
@@ -228,17 +273,39 @@ FinalizeDecision DetermineFinalizeDecision(
                 .success = true,
                 .error = ErrorCode::OK};
     }
-    if (memory_succeeded) {
-        return {.end_type = ReplicaType::MEMORY,
-                .revoke_type = ReplicaType::NOF_SSD,
-                .success = true,
-                .error = ErrorCode::OK};
-    }
-    if (nof_succeeded) {
-        return {.end_type = ReplicaType::NOF_SSD,
-                .revoke_type = ReplicaType::MEMORY,
-                .success = true,
-                .error = ErrorCode::OK};
+    // direct_ssd: LOCAL_DISK replaces MEMORY in flexible dual-replica mode
+    if (config.direct_ssd.value_or(false)) {
+        if (local_disk_succeeded && nof_succeeded) {
+            return {.end_type = ReplicaType::ALL,
+                    .revoke_type = std::nullopt,
+                    .success = true,
+                    .error = ErrorCode::OK};
+        }
+        if (local_disk_succeeded) {
+            return {.end_type = ReplicaType::LOCAL_DISK,
+                    .revoke_type = ReplicaType::NOF_SSD,
+                    .success = true,
+                    .error = ErrorCode::OK};
+        }
+        if (nof_succeeded) {
+            return {.end_type = ReplicaType::NOF_SSD,
+                    .revoke_type = ReplicaType::LOCAL_DISK,
+                    .success = true,
+                    .error = ErrorCode::OK};
+        }
+    } else {
+        if (memory_succeeded) {
+            return {.end_type = ReplicaType::MEMORY,
+                    .revoke_type = ReplicaType::NOF_SSD,
+                    .success = true,
+                    .error = ErrorCode::OK};
+        }
+        if (nof_succeeded) {
+            return {.end_type = ReplicaType::NOF_SSD,
+                    .revoke_type = ReplicaType::MEMORY,
+                    .success = true,
+                    .error = ErrorCode::OK};
+        }
     }
 
     return {.end_type = std::nullopt,
@@ -1538,6 +1605,7 @@ tl::expected<void, ErrorCode> Client::Put(const ObjectKey& key,
     }
 
     ReplicateConfig client_cfg = AttachHostId(config);
+    client_cfg.direct_ssd = config.direct_ssd.value_or(default_direct_ssd_);
     if (protocol_ == "cxl") {
         client_cfg.preferred_segment = local_hostname_;
     }
@@ -1587,6 +1655,12 @@ tl::expected<void, ErrorCode> Client::Put(const ObjectKey& key,
         }
     }
 
+    // Submit LOCAL_DISK replica writes (direct_ssd) first so they run in
+    // parallel with the memory/NoF transfers below; futures are drained
+    // after the loop.
+    auto local_disk_transfers =
+        SubmitLocalDiskReplicaWrites(key, slices, start_result.value());
+
     for (const auto& replica : start_result.value()) {
         if (replica.is_memory_replica() || replica.is_nof_replica()) {
             // Transfer data using allocated handles from all replicas
@@ -1602,6 +1676,16 @@ tl::expected<void, ErrorCode> Client::Put(const ObjectKey& key,
         }
     }
 
+    // Drain LOCAL_DISK writes and merge results into the summary.
+    for (auto& [replica_type, future] : local_disk_transfers) {
+        ErrorCode transfer_err = future.get();
+        if (transfer_err != ErrorCode::OK) {
+            transfer_summary.RecordFailure(replica_type, transfer_err);
+            continue;
+        }
+        transfer_summary.RecordSuccess(replica_type);
+    }
+
     auto us_put = std::chrono::duration_cast<std::chrono::microseconds>(
                       std::chrono::steady_clock::now() - t0_put)
                       .count();
@@ -1609,8 +1693,10 @@ tl::expected<void, ErrorCode> Client::Put(const ObjectKey& key,
         metrics_->transfer_metric.put_latency_us.observe(us_put);
     }
 
+    // Use client_cfg (direct_ssd resolved against the client default) so the
+    // finalize decision matches the config the master allocated with.
     const auto finalize_decision =
-        DetermineFinalizeDecision(config, transfer_summary);
+        DetermineFinalizeDecision(client_cfg, transfer_summary);
 
     if (finalize_decision.end_type.has_value()) {
         auto end_result =
@@ -1648,6 +1734,7 @@ tl::expected<void, ErrorCode> Client::Upsert(const ObjectKey& key,
     }
 
     ReplicateConfig client_cfg = AttachHostId(config);
+    client_cfg.direct_ssd = config.direct_ssd.value_or(default_direct_ssd_);
     if (protocol_ == "cxl") {
         client_cfg.preferred_segment = local_hostname_;
     }
@@ -1687,19 +1774,74 @@ tl::expected<void, ErrorCode> Client::Upsert(const ObjectKey& key,
         }
     }
 
-    // Transfer to memory replicas
-    for (const auto& replica : start_result.value()) {
-        if (replica.is_memory_replica()) {
-            ErrorCode transfer_err = TransferWrite(replica, slices);
-            if (transfer_err != ErrorCode::OK) {
-                auto revoke_result =
-                    master_client_.UpsertRevoke(key, ReplicaType::MEMORY);
-                if (!revoke_result) {
-                    LOG(ERROR) << "Failed to revoke upsert operation";
-                    return tl::unexpected(revoke_result.error());
+    const bool direct_ssd_mode = client_cfg.direct_ssd.value_or(false);
+
+    if (!direct_ssd_mode) {
+        // Legacy memory-only path — behavior unchanged.
+        for (const auto& replica : start_result.value()) {
+            if (replica.is_memory_replica()) {
+                ErrorCode transfer_err = TransferWrite(replica, slices);
+                if (transfer_err != ErrorCode::OK) {
+                    auto revoke_result =
+                        master_client_.UpsertRevoke(key, ReplicaType::MEMORY);
+                    if (!revoke_result) {
+                        LOG(ERROR) << "Failed to revoke upsert operation";
+                        return tl::unexpected(revoke_result.error());
+                    }
+                    return tl::unexpected(transfer_err);
                 }
-                return tl::unexpected(transfer_err);
             }
+        }
+    } else {
+        // direct_ssd: write every replica UpsertStart returned. An in-place
+        // (same-size) upsert marks the object's existing replicas PROCESSING
+        // and returns their descriptors — possibly MEMORY (object was memory
+        // resident) and/or stale LOCAL_DISK (object was offloaded) — so all
+        // of them must be rewritten before UpsertEnd(ALL).
+        ReplicaTransferSummary transfer_summary;
+        for (const auto& replica : start_result.value()) {
+            transfer_summary.RecordAllocatedReplica(replica);
+        }
+
+        auto local_disk_transfers =
+            SubmitLocalDiskReplicaWrites(key, slices, start_result.value());
+
+        for (const auto& replica : start_result.value()) {
+            if (replica.is_memory_replica() || replica.is_nof_replica()) {
+                const auto replica_type = replica.is_memory_replica()
+                                              ? ReplicaType::MEMORY
+                                              : ReplicaType::NOF_SSD;
+                ErrorCode transfer_err = TransferWrite(replica, slices);
+                if (transfer_err != ErrorCode::OK) {
+                    transfer_summary.RecordFailure(replica_type, transfer_err);
+                    continue;
+                }
+                transfer_summary.RecordSuccess(replica_type);
+            }
+        }
+
+        // Drain LOCAL_DISK writes and merge results into the summary.
+        for (auto& [replica_type, future] : local_disk_transfers) {
+            ErrorCode transfer_err = future.get();
+            if (transfer_err != ErrorCode::OK) {
+                transfer_summary.RecordFailure(replica_type, transfer_err);
+                continue;
+            }
+            transfer_summary.RecordSuccess(replica_type);
+        }
+
+        // UpsertEnd(ALL) below marks every PROCESSING replica COMPLETE, so
+        // succeed only when every allocated replica was actually written.
+        if (!transfer_summary.AllAllocatedSucceeded()) {
+            auto revoke_result =
+                master_client_.UpsertRevoke(key, ReplicaType::ALL);
+            if (!revoke_result) {
+                LOG(ERROR) << "Failed to revoke upsert operation";
+                return tl::unexpected(revoke_result.error());
+            }
+            return tl::unexpected(transfer_summary.first_error != ErrorCode::OK
+                                      ? transfer_summary.first_error
+                                      : ErrorCode::TRANSFER_FAIL);
         }
     }
 
@@ -1710,8 +1852,10 @@ tl::expected<void, ErrorCode> Client::Upsert(const ObjectKey& key,
         metrics_->transfer_metric.put_latency_us.observe(us);
     }
 
-    // End upsert operation
-    auto end_result = master_client_.UpsertEnd(key, ReplicaType::MEMORY);
+    // End upsert operation. direct_ssd covers every replica type returned
+    // by UpsertStart; the legacy path completes MEMORY replicas as before.
+    auto end_result = master_client_.UpsertEnd(
+        key, direct_ssd_mode ? ReplicaType::ALL : ReplicaType::MEMORY);
     if (!end_result) {
         ErrorCode err = end_result.error();
         LOG(ERROR) << "Failed to end upsert operation: " << err;
@@ -1734,6 +1878,7 @@ std::vector<tl::expected<void, ErrorCode>> Client::BatchUpsert(
     std::vector<std::vector<Slice>>& batched_slices,
     const ReplicateConfig& config) {
     ReplicateConfig client_cfg = AttachHostId(config);
+    client_cfg.direct_ssd = config.direct_ssd.value_or(default_direct_ssd_);
     if (protocol_ == "cxl") {
         client_cfg.preferred_segment = local_hostname_;
     }
@@ -1798,6 +1943,7 @@ class PutOperation {
 
     size_t requested_memory_replicas = 0;
     size_t requested_nof_replicas = 0;
+    std::optional<bool> requested_direct_ssd;
     ReplicaTransferSummary transfer_summary;
 
     // Error context for debugging
@@ -1850,12 +1996,14 @@ class PutOperation {
     void InitializeRequestedReplicas(const ReplicateConfig& config) {
         requested_memory_replicas = config.replica_num;
         requested_nof_replicas = config.nof_replica_num;
+        requested_direct_ssd = config.direct_ssd;
     }
 
     ReplicateConfig ToReplicateConfig() const {
         ReplicateConfig config;
         config.replica_num = requested_memory_replicas;
         config.nof_replica_num = requested_nof_replicas;
+        config.direct_ssd = requested_direct_ssd;
         return config;
     }
 
@@ -1997,6 +2145,9 @@ void Client::StartBatchUpsert(std::vector<PutOperation>& ops,
                             "Master failed to start upsert operation");
         } else {
             ops[i].replicas = start_responses[i].value();
+            // Populate allocated_* counts so FinalizeBatchUpsert can check
+            // AllAllocatedSucceeded against the transfer results.
+            ops[i].RecordAllocatedReplicas();
             VLOG(1) << "Successfully started upsert for key " << ops[i].key
                     << " with " << ops[i].replicas.size() << " replicas";
         }
@@ -2042,9 +2193,16 @@ void Client::SubmitTransfers(std::vector<PutOperation>& ops) {
             }
         }
 
+        // Direct-storage transports (LOCAL_DISK, future GDS, etc).
+        SubmitLocalDiskTransfers(op);
+
         for (size_t replica_idx = 0; replica_idx < op.replicas.size();
              ++replica_idx) {
             const auto& replica = op.replicas[replica_idx];
+            if (replica.is_local_disk_replica()) {
+                // LOCAL_DISK replicas are handled above, skip TransferEngine
+                continue;
+            }
             if (replica.is_memory_replica() || replica.is_nof_replica()) {
                 const auto replica_type = replica.is_memory_replica()
                                               ? ReplicaType::MEMORY
@@ -2090,6 +2248,178 @@ void Client::SubmitTransfers(std::vector<PutOperation>& ops) {
     }
 }
 
+std::vector<std::pair<ReplicaType, TransferFuture>>
+Client::SubmitLocalDiskReplicaWrites(
+    const ObjectKey& key, const std::vector<Slice>& slices,
+    const std::vector<Replica::Descriptor>& replicas) {
+    std::vector<std::pair<ReplicaType, TransferFuture>> transfers;
+
+    // Check whether there are any LOCAL_DISK replicas at all.
+    bool has_local_disk = false;
+    for (const auto& replica : replicas) {
+        if (replica.is_local_disk_replica()) {
+            has_local_disk = true;
+            break;
+        }
+    }
+    if (!has_local_disk) return transfers;
+
+    // The SSD storage backend namespaces objects by tenant-scoped storage
+    // keys (same convention as the heartbeat offload path and all read
+    // paths, e.g. batch_get_offload_object). Writing under the raw user
+    // key would make the object unreadable.
+    const std::string storage_key = MakeTenantScopedStorageKey(tenant_id(), key);
+
+    // Concatenate slices once (shared by all replicas).
+    auto staged_data = std::make_shared<std::string>();
+    size_t total_size = 0;
+    for (const auto& slice : slices) total_size += slice.size;
+    staged_data->reserve(total_size);
+    for (const auto& slice : slices) {
+        staged_data->append(static_cast<const char*>(slice.ptr), slice.size);
+    }
+
+    // Register staging buffer with TransferEngine for remote RDMA/TCP reads.
+    // Wrapped in shared_ptr with custom deleter: buffer is unregistered
+    // when all async tasks have finished and dropped their references.
+    bool te_registered = false;
+    std::string te_endpoint;
+    uintptr_t te_buffer_addr = 0;
+    auto te_cleanup = std::shared_ptr<void>(nullptr, [](void*) {});
+
+    if (transfer_engine_) {
+        auto rc = transfer_engine_->registerLocalMemory(
+            const_cast<char*>(staged_data->data()), staged_data->size(),
+            kWildcardLocation, true, false);
+        if (rc == 0) {
+            te_registered = true;
+            te_endpoint = GetSegmentEndpoint();
+            te_buffer_addr = reinterpret_cast<uintptr_t>(staged_data->data());
+            // Capture engine + ptr for deferred unregistration.
+            te_cleanup = std::shared_ptr<void>(
+                staged_data->data(), [engine = transfer_engine_](void* ptr) {
+                    engine->unregisterLocalMemory(ptr);
+                });
+        } else {
+            LOG(WARNING) << "direct_ssd: TE registerLocalMemory failed, "
+                         << "remote LOCAL_DISK writes will fail, key=" << key;
+        }
+    }
+
+    // Enqueue each LOCAL_DISK replica write in parallel.
+    // Wrap futures into TransferFuture via FutureOperationState so they
+    // are waited on uniformly alongside MEMORY/NoF transfers.
+    for (const auto& replica : replicas) {
+        if (!replica.is_local_disk_replica()) continue;
+
+        auto local_disk_desc = replica.get_local_disk_descriptor();
+        auto promise =
+            std::make_shared<std::promise<tl::expected<void, ErrorCode>>>();
+        auto future = promise->get_future();
+
+        if (local_disk_desc.client_id == getClientId()) {
+            // Local SSD write — requires storage backend.
+            if (!local_disk_storage_backend_) {
+                LOG(ERROR) << "direct_ssd: local LOCAL_DISK replica but "
+                           << "no SSD backend available, key=" << key;
+                // Failure is recorded by the caller when the
+                // future resolves — do not RecordFailure here.
+                promise->set_value(
+                    tl::make_unexpected(ErrorCode::UNABLE_OFFLOAD));
+            } else {
+                write_thread_pool_.enqueue(
+                    [this, promise, backend = local_disk_storage_backend_,
+                     storage_key, data = staged_data, cleanup = te_cleanup]() {
+                        std::vector<Slice> slices = {
+                            Slice{const_cast<char*>(data->data()),
+                                  data->size()}};
+                        auto result = backend->DirectWrite(storage_key, slices);
+                        // Report evicted victims before resolving the promise
+                        // (the caller may tear the client down right after all
+                        // futures resolve). Mirrors FileStorage::DirectWrite
+                        // on the remote-write leg.
+                        if (result) {
+                            NotifyLocalDiskEvictions(result->second);
+                        }
+                        promise->set_value(
+                            result ? tl::expected<void, ErrorCode>{}
+                                   : tl::make_unexpected(result.error()));
+                    });
+            }
+        } else if (rpc_client_requester_ &&
+                   !local_disk_desc.transport_endpoint.empty()) {
+            // Remote SSD write via TransferEngine (RDMA/TCP).
+            // Target TE-READs from our registered buffer, then writes to SSD.
+            // Same transport as MEMORY replicas — no RPC fallback needed.
+            if (!te_registered) {
+                LOG(ERROR) << "direct_ssd: TransferEngine unavailable for "
+                           << "remote LOCAL_DISK write, key=" << key;
+                promise->set_value(
+                    tl::make_unexpected(ErrorCode::TRANSFER_FAIL));
+            } else {
+                write_thread_pool_.enqueue(
+                    [promise, requester = rpc_client_requester_,
+                     endpoint = local_disk_desc.transport_endpoint,
+                     engine_addr = te_endpoint, buffer_addr = te_buffer_addr,
+                     size = total_size, storage_key, data = staged_data,
+                     cleanup = te_cleanup]() {
+                        auto result = requester->write_offload_from_engine(
+                            endpoint, engine_addr, buffer_addr, size,
+                            storage_key);
+                        promise->set_value(
+                            result ? tl::expected<void, ErrorCode>{}
+                                   : tl::make_unexpected(result.error()));
+                    });
+            }
+        } else {
+            LOG(WARNING)
+                << "direct_ssd: no RPC requester or empty transport_endpoint"
+                << " for remote LOCAL_DISK replica, key=" << key;
+            promise->set_value(tl::make_unexpected(ErrorCode::INVALID_PARAMS));
+        }
+
+        // Wrap std::future as TransferFuture.
+        auto op_state =
+            std::make_shared<FutureOperationState>(std::move(future));
+        transfers.emplace_back(ReplicaType::LOCAL_DISK,
+                               TransferFuture(std::move(op_state)));
+    }
+    return transfers;
+}
+
+void Client::SubmitLocalDiskTransfers(PutOperation& op) {
+    auto transfers = SubmitLocalDiskReplicaWrites(op.key, op.slices,
+                                                  op.replicas);
+    for (auto& [replica_type, future] : transfers) {
+        op.pending_transfers.emplace_back(replica_type, std::move(future));
+    }
+}
+
+void Client::NotifyLocalDiskEvictions(
+    const std::vector<std::string>& evicted_storage_keys) {
+    if (evicted_storage_keys.empty()) {
+        return;
+    }
+    // Notify master about keys evicted from the local SSD to make room for
+    // this write, grouped by tenant (mirrors FileStorage::DirectWrite).
+    std::unordered_map<std::string, std::vector<std::string>> keys_by_tenant;
+    for (const auto& storage_key : evicted_storage_keys) {
+        auto [tenant_id, user_key] = ParseTenantScopedStorageKey(storage_key);
+        keys_by_tenant[std::move(tenant_id)].push_back(std::move(user_key));
+    }
+    for (const auto& [tenant_id, keys] : keys_by_tenant) {
+        auto results =
+            BatchEvictDiskReplica(keys, tenant_id, ReplicaType::LOCAL_DISK);
+        for (size_t i = 0; i < results.size(); ++i) {
+            if (!results[i]) {
+                LOG(WARNING) << "direct_ssd: failed to notify master about "
+                                "evicted key: "
+                             << keys[i] << ", error: " << results[i].error();
+            }
+        }
+    }
+}
+
 void Client::WaitForTransfers(std::vector<PutOperation>& ops) {
     for (auto& op : ops) {
         // Skip operations that already failed or completed
@@ -2115,8 +2445,12 @@ void Client::WaitForTransfers(std::vector<PutOperation>& ops) {
         VLOG(1) << "Transfers finished for key " << op.key << ", success(mem="
                 << op.transfer_summary.successful_memory_transfers
                 << ", nof=" << op.transfer_summary.successful_nof_transfers
+                << ", local_disk="
+                << op.transfer_summary.successful_local_disk_transfers
                 << "), fail(mem=" << op.transfer_summary.failed_memory_transfers
-                << ", nof=" << op.transfer_summary.failed_nof_transfers << ")";
+                << ", nof=" << op.transfer_summary.failed_nof_transfers
+                << ", local_disk="
+                << op.transfer_summary.failed_local_disk_transfers << ")";
     }
 }
 
@@ -2129,9 +2463,11 @@ void Client::FinalizeBatchPut(std::vector<PutOperation>& ops) {
     BatchFinalizeGroup end_all_group;
     BatchFinalizeGroup end_memory_group;
     BatchFinalizeGroup end_nof_group;
+    BatchFinalizeGroup end_local_disk_group;
     BatchFinalizeGroup revoke_all_group;
     BatchFinalizeGroup revoke_memory_group;
     BatchFinalizeGroup revoke_nof_group;
+    BatchFinalizeGroup revoke_local_disk_group;
 
     std::vector<size_t> pending_finalize_actions(ops.size(), 0);
     std::vector<bool> should_succeed(ops.size(), false);
@@ -2165,6 +2501,12 @@ void Client::FinalizeBatchPut(std::vector<PutOperation>& ops) {
                 case ReplicaType::NOF_SSD:
                     add_group_entry(is_end ? end_nof_group : revoke_nof_group,
                                     key, index);
+                    ++pending_finalize_actions[index];
+                    break;
+                case ReplicaType::LOCAL_DISK:
+                    add_group_entry(
+                        is_end ? end_local_disk_group : revoke_local_disk_group,
+                        key, index);
                     ++pending_finalize_actions[index];
                     break;
                 default:
@@ -2263,9 +2605,11 @@ void Client::FinalizeBatchPut(std::vector<PutOperation>& ops) {
     process_end_group(end_all_group, ReplicaType::ALL);
     process_end_group(end_memory_group, ReplicaType::MEMORY);
     process_end_group(end_nof_group, ReplicaType::NOF_SSD);
+    process_end_group(end_local_disk_group, ReplicaType::LOCAL_DISK);
     process_revoke_group(revoke_all_group, ReplicaType::ALL);
     process_revoke_group(revoke_memory_group, ReplicaType::MEMORY);
     process_revoke_group(revoke_nof_group, ReplicaType::NOF_SSD);
+    process_revoke_group(revoke_local_disk_group, ReplicaType::LOCAL_DISK);
 
     auto append_finalize_error_context = [&](PutOperation& op, size_t index) {
         if (finalize_rpc_errors[index].has_value()) {
@@ -2328,13 +2672,33 @@ void Client::FinalizeBatchUpsert(std::vector<PutOperation>& ops) {
     failed_keys.reserve(ops.size());
     failed_indices.reserve(ops.size());
 
+    // Per-op terminal error for ops newly classified as transfer-failed here.
+    std::vector<ErrorCode> transfer_errors(ops.size(), ErrorCode::OK);
+
     for (size_t i = 0; i < ops.size(); ++i) {
         auto& op = ops[i];
 
         if (!op.IsResolved() && !op.replicas.empty() &&
             !op.pending_transfers.empty()) {
-            successful_keys.emplace_back(op.key);
-            successful_indices.emplace_back(i);
+            // Classify by actual transfer results, not merely by having
+            // submitted transfers. BatchUpsertEnd/BatchUpsertRevoke operate
+            // on ReplicaType::ALL, so an op may only be finalized as
+            // successful when every allocated replica transferred —
+            // otherwise BatchUpsertEnd would mark replicas that hold no
+            // data as COMPLETE (silent data loss on read). Judged on what
+            // UpsertStart actually returned: an in-place upsert may return
+            // existing MEMORY replicas even when direct_ssd was requested.
+            if (op.transfer_summary.AllAllocatedSucceeded()) {
+                successful_keys.emplace_back(op.key);
+                successful_indices.emplace_back(i);
+            } else {
+                transfer_errors[i] =
+                    op.transfer_summary.first_error != ErrorCode::OK
+                        ? op.transfer_summary.first_error
+                        : ErrorCode::TRANSFER_FAIL;
+                failed_keys.emplace_back(op.key);
+                failed_indices.emplace_back(i);
+            }
         } else if (op.state != PutOperationState::PENDING &&
                    !op.replicas.empty()) {
             failed_keys.emplace_back(op.key);
@@ -2410,6 +2774,19 @@ void Client::FinalizeBatchUpsert(std::vector<PutOperation>& ops) {
                               << failed_keys[i];
                 }
             }
+        }
+    }
+
+    // Ops classified as transfer-failed above are still PENDING — give them
+    // their terminal transfer error now that revoke has been attempted.
+    // (Ops that were already resolved, or hit a revoke RPC size mismatch,
+    // keep the error set earlier.)
+    for (size_t idx : failed_indices) {
+        if (!ops[idx].IsResolved() && transfer_errors[idx] != ErrorCode::OK) {
+            ops[idx].SetTerminalError(
+                transfer_errors[idx], PutOperationState::TRANSFER_FAILED,
+                ops[idx].failure_context.value_or(
+                    "Replica transfer failed before finalize"));
         }
     }
 
@@ -2570,11 +2947,21 @@ std::vector<tl::expected<void, ErrorCode>> Client::BatchPut(
     std::vector<std::vector<Slice>>& batched_slices,
     const ReplicateConfig& config) {
     ReplicateConfig client_cfg = AttachHostId(config);
+    client_cfg.direct_ssd = config.direct_ssd.value_or(default_direct_ssd_);
     if (protocol_ == "cxl") {
         client_cfg.preferred_segment = local_hostname_;
     }
     std::vector<PutOperation> ops = CreatePutOperations(keys, batched_slices);
     if (client_cfg.prefer_alloc_in_same_node) {
+        if (client_cfg.direct_ssd.value_or(false)) {
+            // BatchPutWhenPreferSameNode only supports MEMORY replicas;
+            // direct_ssd allocates LOCAL_DISK ones, which would fail every
+            // op after a wasted master allocate/revoke round trip.
+            LOG(ERROR) << "prefer_alloc_in_same_node is not supported with "
+                          "direct_ssd";
+            return std::vector<tl::expected<void, ErrorCode>>(
+                keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
+        }
         if (client_cfg.nof_replica_num > 0) {
             LOG(ERROR) << "prefer_alloc_in_same_node is not supported with "
                           "NoF replicas";
@@ -3016,9 +3403,9 @@ std::vector<tl::expected<bool, ErrorCode>> Client::BatchIsExist(
 void* Client::GetBaseAddr() { return transfer_engine_->getBaseAddr(); }
 
 tl::expected<void, ErrorCode> Client::MountLocalDiskSegment(
-    bool enable_offloading) {
-    auto response =
-        master_client_.MountLocalDiskSegment(client_id_, enable_offloading);
+    bool enable_offloading, const std::string& rpc_endpoint) {
+    auto response = master_client_.MountLocalDiskSegment(
+        client_id_, enable_offloading, rpc_endpoint);
 
     if (!response) {
         LOG(ERROR) << "MountLocalDiskSegment failed, error code is "

--- a/mooncake-store/src/file_storage.cpp
+++ b/mooncake-store/src/file_storage.cpp
@@ -258,7 +258,7 @@ tl::expected<void, ErrorCode> FileStorage::Init() {
         MutexLocker locker(&offloading_mutex_);
         enable_offloading_ = enable_offloading_result.value();
         auto mount_file_storage_result =
-            client_->MountLocalDiskSegment(enable_offloading_);
+            client_->MountLocalDiskSegment(enable_offloading_, local_rpc_addr_);
         if (!mount_file_storage_result) {
             LOG(ERROR) << "Failed to mount file storage: "
                        << mount_file_storage_result.error();
@@ -661,8 +661,8 @@ tl::expected<void, ErrorCode> FileStorage::Heartbeat() {
                              << "SEGMENT_NOT_FOUND, attempting to "
                              << "re-register local disk segment and "
                              << "re-register object metadata";
-                auto remount_result =
-                    client_->MountLocalDiskSegment(enable_offloading_);
+                auto remount_result = client_->MountLocalDiskSegment(
+                    enable_offloading_, local_rpc_addr_);
                 if (remount_result) {
                     heartbeat_result = client_->OffloadObjectHeartbeat(
                         enable_offloading_, offloading_objects);
@@ -1056,6 +1056,43 @@ bool FileStorage::ReleaseBuffer(uint64_t batch_id) {
     VLOG(1) << "batch_id " << batch_id
             << " not found (may have been GC'd already)";
     return false;
+}
+
+tl::expected<std::pair<StorageObjectMetadata, std::vector<std::string>>,
+             ErrorCode>
+FileStorage::DirectWrite(const std::string& key,
+                         const std::vector<Slice>& slices) {
+    auto result = storage_backend_->DirectWrite(key, slices);
+    if (!result) {
+        return tl::make_unexpected(result.error());
+    }
+    auto& [metadata, evicted_keys] = result.value();
+    metadata.transport_endpoint = local_rpc_addr_;
+
+    // Notify master about any keys evicted during the write.
+    if (!evicted_keys.empty()) {
+        std::unordered_map<std::string, std::vector<std::string>>
+            keys_by_tenant;
+        for (const auto& storage_key : evicted_keys) {
+            auto [tenant_id, user_key] =
+                ParseTenantScopedStorageKey(storage_key);
+            keys_by_tenant[tenant_id].push_back(user_key);
+        }
+        for (const auto& [tenant_id, keys] : keys_by_tenant) {
+            auto results = client_->BatchEvictDiskReplica(
+                keys, tenant_id, ReplicaType::LOCAL_DISK);
+            for (size_t i = 0; i < results.size(); ++i) {
+                if (!results[i]) {
+                    LOG(WARNING)
+                        << "DirectWrite: failed to notify master about evicted "
+                           "key: "
+                        << keys[i] << ", error: " << results[i].error();
+                }
+            }
+        }
+    }
+
+    return std::make_pair(metadata, evicted_keys);
 }
 
 tl::expected<void, ErrorCode> FileStorage::ReRegisterOffloadedObjects() {

--- a/mooncake-store/src/master_client.cpp
+++ b/mooncake-store/src/master_client.cpp
@@ -926,14 +926,16 @@ MasterClient::GetStorageConfig() {
 }
 
 tl::expected<void, ErrorCode> MasterClient::MountLocalDiskSegment(
-    const UUID& client_id, bool enable_offloading) {
+    const UUID& client_id, bool enable_offloading,
+    const std::string& rpc_endpoint) {
     ScopedVLogTimer timer(1, "MasterClient::MountLocalDiskSegment");
     timer.LogRequest("client_id=", client_id,
-                     ", enable_offloading=", enable_offloading);
+                     ", enable_offloading=", enable_offloading,
+                     ", rpc_endpoint=", rpc_endpoint);
 
     auto result =
         invoke_rpc<&WrappedMasterService::MountLocalDiskSegment, void>(
-            client_id, enable_offloading);
+            client_id, enable_offloading, rpc_endpoint);
     timer.LogResponseExpected(result);
     return result;
 }

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -120,7 +120,20 @@ uint64_t SaturatingMultiply(uint64_t lhs, uint64_t rhs) {
 
 bool HasExpectedReplicaAllocation(const ReplicateConfig& config,
                                   size_t allocated_memory_replicas,
-                                  size_t allocated_nof_replicas) {
+                                  size_t allocated_nof_replicas,
+                                  size_t allocated_local_disk_replicas = 0) {
+    // direct_ssd: replica_num controls LOCAL_DISK replicas
+    if (config.direct_ssd.value_or(false)) {
+        if (config.nof_replica_num == 0) {
+            return allocated_local_disk_replicas > 0;
+        }
+        if (DetermineReplicaWriteMode(config) ==
+            ReplicaWriteMode::FLEXIBLE_DUAL_REPLICA) {
+            return allocated_local_disk_replicas + allocated_nof_replicas > 0;
+        }
+        return allocated_local_disk_replicas == config.replica_num &&
+               allocated_nof_replicas == config.nof_replica_num;
+    }
     if (config.nof_replica_num == 0) {
         return allocated_memory_replicas > 0;
     }
@@ -1139,6 +1152,8 @@ uint64_t MasterService::CompletedMemoryQuotaCharge(
 
 uint64_t MasterService::RequestedMemoryQuotaCharge(
     uint64_t value_length, const ReplicateConfig& config) const {
+    // direct_ssd uses LOCAL_DISK replicas, no MEMORY quota consumed.
+    if (config.direct_ssd.value_or(false)) return 0;
     const unsigned __int128 charge =
         static_cast<unsigned __int128>(value_length) * config.replica_num;
     if (charge > std::numeric_limits<uint64_t>::max()) {
@@ -1808,6 +1823,13 @@ void MasterService::ReleaseLocalDiskUsage(
     std::unordered_map<UUID, int64_t, boost::hash<UUID>> bytes_by_client;
     for (const auto& replica : replicas) {
         if (!replica.is_local_disk_replica()) {
+            continue;
+        }
+        // Only release bytes for COMPLETE replicas — ssd_used_bytes is
+        // incremented in PutEnd (PROCESSING→COMPLETE) or NotifyOffloadSuccess
+        // (direct COMPLETE). PROCESSING replicas (e.g. failed direct_ssd)
+        // never had their bytes counted.
+        if (!replica.is_completed()) {
             continue;
         }
         const auto descriptor =
@@ -2866,7 +2888,8 @@ auto MasterService::AllocateAndInsertMetadata(
     const auto write_mode = DetermineReplicaWriteMode(config);
     size_t allocated_memory_replicas = 0;
     size_t allocated_nof_replicas = 0;
-    if (config.replica_num > 0) {
+    size_t allocated_local_disk_replicas = 0;
+    if (config.replica_num > 0 && !config.direct_ssd.value_or(false)) {
         const bool use_local_first =
             allocation_strategy_type_ == AllocationStrategyType::LOCAL_FIRST &&
             config.replica_num == 1;
@@ -2978,14 +3001,84 @@ auto MasterService::AllocateAndInsertMetadata(
     }
 #endif
 
+    // Phase C: LOCAL_DISK replicas for direct_ssd.
+    // replica_num controls how many SSD clients to write to.
+    // Must run BEFORE HasExpectedReplicaAllocation below, which validates
+    // allocated_local_disk_replicas for direct_ssd configs.
+    if (config.direct_ssd.value_or(false) && config.replica_num > 0) {
+        ScopedLocalDiskSegmentAccess ssd_access =
+            segment_manager_.getLocalDiskSegmentAccess();
+        auto& client_segments = ssd_access.getClientLocalDiskSegment();
+
+        // Collect available SSD clients, sorted by free ratio descending.
+        struct SsdCandidate {
+            UUID client_id;
+            std::shared_ptr<LocalDiskSegment> segment;
+            double free_ratio;
+        };
+        std::vector<SsdCandidate> candidates;
+        for (const auto& [cid, seg] : client_segments) {
+            if (seg->ssd_total_capacity_bytes > 0) {
+                int64_t used =
+                    seg->ssd_used_bytes.load(std::memory_order_relaxed);
+                int64_t total = seg->ssd_total_capacity_bytes;
+                // Avoid signed overflow when value_length exceeds INT64_MAX.
+                int64_t remaining = total - used;
+                int64_t free_bytes = (remaining <= 0) ? 0 : remaining;
+                if (value_length < static_cast<uint64_t>(
+                                       std::numeric_limits<int64_t>::max())) {
+                    free_bytes = std::max<int64_t>(
+                        0, remaining - static_cast<int64_t>(value_length));
+                }
+                double ratio = static_cast<double>(free_bytes) /
+                               static_cast<double>(total);
+                candidates.push_back({cid, seg, ratio});
+            } else {
+                // Unknown capacity: place at end with neutral ratio.
+                candidates.push_back({cid, seg, 0.5});
+            }
+        }
+
+        if (candidates.empty()) {
+            LOG(WARNING) << "direct_ssd: no LocalDiskSegments registered, "
+                         << "cannot allocate LOCAL_DISK replicas, key=" << key;
+        } else {
+            // Select top N by free ratio, no more than available.
+            size_t to_alloc = std::min(config.replica_num, candidates.size());
+            // Partial sort: only order the top N candidates.
+            std::partial_sort(candidates.begin(), candidates.begin() + to_alloc,
+                              candidates.end(),
+                              [](const SsdCandidate& a, const SsdCandidate& b) {
+                                  return a.free_ratio > b.free_ratio;
+                              });
+            if (to_alloc < config.replica_num) {
+                LOG(WARNING) << "direct_ssd: requested " << config.replica_num
+                             << " LOCAL_DISK replicas but only "
+                             << candidates.size() << " SSD clients available, "
+                             << "allocating " << to_alloc;
+            }
+            for (size_t i = 0; i < to_alloc; ++i) {
+                replicas.emplace_back(candidates[i].client_id, value_length,
+                                      candidates[i].segment->rpc_endpoint,
+                                      ReplicaStatus::PROCESSING);
+                ++allocated_local_disk_replicas;
+            }
+        }
+    }
+
     if (!HasExpectedReplicaAllocation(config, allocated_memory_replicas,
-                                      allocated_nof_replicas)) {
+                                      allocated_nof_replicas,
+                                      allocated_local_disk_replicas)) {
+        // direct_ssd failures stem from SSD-segment shortage; evicting
+        // MEMORY would not help, so skip the mem-eviction signal for them
+        // (the alloc-failure metric is still incremented).
+        const bool direct_ssd_requested = config.direct_ssd.value_or(false);
         if ((config.replica_num > 0 &&
              allocated_memory_replicas != config.replica_num) ||
             (config.nof_replica_num > 0 &&
              allocated_nof_replicas != config.nof_replica_num)) {
             MasterMetricManager::instance().inc_put_start_alloc_failures();
-            if (config.replica_num > 0 &&
+            if (config.replica_num > 0 && !direct_ssd_requested &&
                 allocated_memory_replicas != config.replica_num) {
                 need_mem_eviction_ = true;
             }
@@ -2998,7 +3091,9 @@ auto MasterService::AllocateAndInsertMetadata(
                 << key << ", requested_memory_replicas=" << config.replica_num
                 << ", allocated_memory_replicas=" << allocated_memory_replicas
                 << ", requested_nof_replicas=" << config.nof_replica_num
-                << ", allocated_nof_replicas=" << allocated_nof_replicas;
+                << ", allocated_nof_replicas=" << allocated_nof_replicas
+                << ", allocated_local_disk_replicas="
+                << allocated_local_disk_replicas;
         abort_reserved_quota();
         return tl::make_unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
     }
@@ -3062,10 +3157,16 @@ auto MasterService::PutStart(const UUID& client_id, const std::string& key,
         return tl::make_unexpected(normalized_tenant_result.error());
     }
     const ObjectIdentity object_id{normalized_tenant_result.value(), key};
+    // replica_num counts LOCAL_DISK replicas when direct_ssd is set, so a
+    // (0, 0) config can never allocate anything regardless of direct_ssd.
     if ((config.replica_num == 0 && config.nof_replica_num == 0) ||
         key.empty() || slice_length == 0) {
         LOG(ERROR) << "key=" << key << ", replica_num=" << config.replica_num
                    << ", nof_replica_num=" << config.nof_replica_num
+                   << ", direct_ssd="
+                   << (config.direct_ssd.has_value()
+                           ? (config.direct_ssd.value() ? "true" : "false")
+                           : "not-set")
                    << ", slice_length=" << slice_length
                    << ", key_size=" << key.size() << ", error=invalid_params";
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
@@ -3246,7 +3347,8 @@ auto MasterService::PutEnd(const UUID& client_id, const std::string& key,
                 return (replica.is_memory_replica() &&
                         !replica.has_invalid_mem_handle()) ||
                        (replica.is_nof_replica() &&
-                        !replica.has_invalid_nof_handle());
+                        !replica.has_invalid_nof_handle()) ||
+                       (replica.is_local_disk_replica());
             }
             if (replica_type == ReplicaType::MEMORY) {
                 return replica.is_memory_replica() &&
@@ -3258,7 +3360,31 @@ auto MasterService::PutEnd(const UUID& client_id, const std::string& key,
             }
             return replica.type() == replica_type;
         },
-        [](Replica& replica) { replica.mark_complete(); });
+        [this](Replica& replica) {
+            // For LOCAL_DISK replicas transitioning PROCESSING→COMPLETE,
+            // update ssd_used_bytes (mirrors NotifyOffloadSuccess for
+            // the direct_ssd path). Lock ordering is safe per the
+            // documented convention: snapshot → metadata → segment.
+            bool is_local = replica.is_local_disk_replica();
+            bool was_processing = replica.is_processing();
+            replica.mark_complete();
+            if (is_local && was_processing) {
+                auto client_id = replica.get_local_disk_client_id();
+                if (client_id.has_value()) {
+                    ScopedLocalDiskSegmentAccess ssd_access =
+                        segment_manager_.getLocalDiskSegmentAccess();
+                    auto& segs = ssd_access.getClientLocalDiskSegment();
+                    auto it = segs.find(client_id.value());
+                    if (it != segs.end()) {
+                        auto size = replica.get_descriptor()
+                                        .get_local_disk_descriptor()
+                                        .object_size;
+                        it->second->ssd_used_bytes.fetch_add(
+                            size, std::memory_order_relaxed);
+                    }
+                }
+            }
+        });
 
     const bool has_memory_replica = metadata.HasMemReplica();
     const bool should_settle_quota =
@@ -3285,25 +3411,38 @@ auto MasterService::PutEnd(const UUID& client_id, const std::string& key,
     }
 
     if (enable_offload_ && !offload_on_evict_) {
-        auto& tenant_state = accessor.GetTenantState();
-        bool task_created = false;
-        metadata.VisitReplicas(
-            [](const Replica& replica) {
-                return replica.is_completed() && replica.is_memory_replica();
-            },
-            [this, &object_id, &tenant_state, &task_created](Replica& replica) {
-                auto result = PushOffloadingQueue(object_id, replica);
-                if (result) {
-                    if (!task_created) {
-                        replica.inc_refcnt();
-                        tenant_state.offloading_tasks.emplace(
-                            object_id.user_key,
-                            OffloadingTask{replica.id(),
-                                           std::chrono::system_clock::now()});
-                        task_created = true;
-                    }
-                }
+        // Skip offload if the object has a COMPLETED LOCAL_DISK replica
+        // (data is already on SSD via direct_ssd).
+        // Only count COMPLETED replicas — PROCESSING LOCAL_DISK replicas
+        // are from a prior Upsert cycle and should not suppress offload.
+        bool has_completed_local_disk =
+            metadata.HasReplica([](const Replica& r) {
+                return r.is_local_disk_replica() && r.is_completed();
             });
+        if (!has_completed_local_disk) {
+            auto& tenant_state = accessor.GetTenantState();
+            bool task_created = false;
+            metadata.VisitReplicas(
+                [](const Replica& replica) {
+                    return replica.is_completed() &&
+                           replica.is_memory_replica();
+                },
+                [this, &object_id, &tenant_state,
+                 &task_created](Replica& replica) {
+                    auto result = PushOffloadingQueue(object_id, replica);
+                    if (result) {
+                        if (!task_created) {
+                            replica.inc_refcnt();
+                            tenant_state.offloading_tasks.emplace(
+                                object_id.user_key,
+                                OffloadingTask{
+                                    replica.id(),
+                                    std::chrono::system_clock::now()});
+                            task_created = true;
+                        }
+                    }
+                });
+        }
     }
 
     // If the object is completed, remove it from the processing set.
@@ -3402,14 +3541,16 @@ auto MasterService::PutRevoke(const UUID& client_id, const std::string& key,
         return tl::make_unexpected(ErrorCode::ILLEGAL_CLIENT);
     }
 
-    auto processing_rep = metadata.GetFirstReplica([replica_type](
-                                                       const Replica& replica) {
-        if (replica_type == ReplicaType::ALL) {
-            return (replica.is_memory_replica() || replica.is_nof_replica()) &&
-                   !replica.is_processing();
-        }
-        return replica.type() == replica_type && !replica.is_processing();
-    });
+    auto processing_rep =
+        metadata.GetFirstReplica([replica_type](const Replica& replica) {
+            if (replica_type == ReplicaType::ALL) {
+                return (replica.is_memory_replica() ||
+                        replica.is_nof_replica() ||
+                        replica.is_local_disk_replica()) &&
+                       !replica.is_processing();
+            }
+            return replica.type() == replica_type && !replica.is_processing();
+        });
     if (processing_rep != nullptr) {
         LOG(ERROR) << "key=" << key << ", status=" << processing_rep->status()
                    << ", error=invalid_replica_status";
@@ -3420,7 +3561,9 @@ auto MasterService::PutRevoke(const UUID& client_id, const std::string& key,
     EraseReplicasWithCacheTotalAccounting(
         metadata, [replica_type](const Replica& replica) {
             if (replica_type == ReplicaType::ALL) {
-                return replica.is_memory_replica() || replica.is_nof_replica();
+                return replica.is_memory_replica() ||
+                       replica.is_nof_replica() ||
+                       replica.is_local_disk_replica();
             }
             return replica.type() == replica_type;
         });
@@ -3494,6 +3637,8 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
     }
     const ObjectIdentity object_id{normalized_tenant_result.value(), key};
     // --- Parameter validation (same as PutStart) ---
+    // replica_num counts LOCAL_DISK replicas when direct_ssd is set, so a
+    // (0, 0) config can never allocate anything regardless of direct_ssd.
     if ((config.replica_num == 0 && config.nof_replica_num == 0) ||
         key.empty() || slice_length == 0) {
         LOG(ERROR) << "key=" << key << ", replica_num=" << config.replica_num
@@ -3703,6 +3848,14 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
                     // Mark COMPLETE → PROCESSING so readers won't see stale
                     // data mid-transfer.  The key becomes unreadable until
                     // UpsertEnd.
+                    //
+                    // LOCAL_DISK bytes are accounted only while a replica is
+                    // COMPLETE (see ReleaseLocalDiskUsage), and PutEnd re-adds
+                    // them on the PROCESSING→COMPLETE transition. Release them
+                    // before flipping the status so a successful UpsertEnd(ALL)
+                    // does not double-count and a revoke does not leak the
+                    // previously counted bytes.
+                    ReleaseLocalDiskUsage(metadata.GetAllReplicas());
                     metadata.VisitReplicas(
                         &Replica::fn_is_completed,
                         [](Replica& replica) { replica.mark_processing(); });
@@ -4883,7 +5036,8 @@ MasterService::GetStorageConfig() const {
 }
 
 auto MasterService::MountLocalDiskSegment(const UUID& client_id,
-                                          bool enable_offloading)
+                                          bool enable_offloading,
+                                          const std::string& rpc_endpoint)
     -> tl::expected<void, ErrorCode> {
     if (!enable_offload_) {
         LOG(ERROR) << "	The offload functionality is not enabled";
@@ -4892,10 +5046,11 @@ auto MasterService::MountLocalDiskSegment(const UUID& client_id,
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
     ScopedSegmentAccess segment_access = segment_manager_.getSegmentAccess();
 
-    auto err =
-        segment_access.MountLocalDiskSegment(client_id, enable_offloading);
+    auto err = segment_access.MountLocalDiskSegment(
+        client_id, enable_offloading, rpc_endpoint);
     if (err == ErrorCode::SEGMENT_ALREADY_EXISTS) {
-        // Return OK because this is an idempotent operation
+        // Return OK because this is an idempotent operation;
+        // rpc_endpoint was already updated in the SEGMENT_ALREADY_EXISTS path.
         return {};
     } else if (err != ErrorCode::OK) {
         return tl::make_unexpected(err);

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -592,7 +592,7 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
     const std::string &ipc_socket_path, int local_rpc_port,
     bool enable_ssd_offload, bool start_offload_rpc_server,
     const std::string &ssd_offload_path, const std::string &tenant_id,
-    bool enable_client_http_server, int client_http_port) {
+    bool enable_client_http_server, int client_http_port, bool direct_ssd) {
     this->protocol = protocol;
     this->ipc_socket_path_ = ipc_socket_path;
     const bool should_use_hugepage =
@@ -887,6 +887,8 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
             ->register_handler<&RealClient::batch_get_offload_object>(this);
         offload_rpc_server_
             ->register_handler<&RealClient::release_offload_buffer>(this);
+        offload_rpc_server_
+            ->register_handler<&RealClient::write_offload_from_engine>(this);
         offload_rpc_server_->async_start();
         auto err = offload_rpc_server_->get_errc();
         if (err) {
@@ -918,6 +920,24 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
         }
     }
     client_requester_ = std::make_shared<ClientRequester>();
+    // ClientRequester is needed for both SSD offload reads and direct_ssd
+    // cross-node writes (write_offload_from_engine). Pure compute nodes with
+    // direct_ssd=True use remote LOCAL_DISK writes that depend on it.
+    client_->SetClientRequester(client_requester_);
+
+    // Inject storage backend into Client so that direct_ssd Put
+    // (controlled per-request via ReplicateConfig) can write directly
+    // to local SSD. Storage-backend nodes that contribute SSD capacity
+    // must also set enable_ssd_offload=true.
+    if (enable_ssd_offload) {
+        client_->SetLocalDiskStorageBackend(file_storage_->getStorageBackend());
+        LOG(INFO) << "SSD offload: injected StorageBackendInterface "
+                     "into Client";
+    }
+    client_->SetDefaultDirectSsd(direct_ssd);
+    if (direct_ssd) {
+        LOG(INFO) << "direct_ssd: defaulting all Puts to direct SSD write";
+    }
     const bool should_start_http_server =
         enable_client_http_server || FLAGS_enable_http_server;
     const int selected_http_port =
@@ -946,12 +966,12 @@ int RealClient::setup_real(
     const std::shared_ptr<TransferEngine> &transfer_engine,
     const std::string &ipc_socket_path, bool enable_ssd_offload,
     const std::string &ssd_offload_path, const std::string &tenant_id,
-    bool enable_client_http_server, int client_http_port) {
+    bool enable_client_http_server, int client_http_port, bool direct_ssd) {
     return to_py_ret(setup_internal(
         local_hostname, metadata_server, global_segment_size, local_buffer_size,
         protocol, rdma_devices, master_server_addr, transfer_engine,
         ipc_socket_path, 50052, enable_ssd_offload, true, ssd_offload_path,
-        tenant_id, enable_client_http_server, client_http_port));
+        tenant_id, enable_client_http_server, client_http_port, direct_ssd));
 }
 
 namespace {
@@ -1104,6 +1124,7 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
     std::string tenant_id = get_config(config, CONFIG_KEY_TENANT_ID, "default");
     bool enable_ssd_offload =
         get_config_bool(config, "enable_ssd_offload", false);
+    bool direct_ssd = get_config_bool(config, "direct_ssd", false);
     bool enable_client_http_server =
         get_config_bool(config, CONFIG_KEY_ENABLE_CLIENT_HTTP_SERVER, false);
     auto client_http_port_opt = get_config_int(
@@ -1113,11 +1134,11 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
     }
     int client_http_port = client_http_port_opt.value();
 
-    return setup_internal(local_hostname, metadata_server, global_segment_size,
-                          local_buffer_size, protocol, rdma_devices,
-                          master_server_addr, nullptr, ipc_socket_path, 50052,
-                          enable_ssd_offload, true, ssd_offload_path, tenant_id,
-                          enable_client_http_server, client_http_port);
+    return setup_internal(
+        local_hostname, metadata_server, global_segment_size, local_buffer_size,
+        protocol, rdma_devices, master_server_addr, nullptr, ipc_socket_path,
+        50052, enable_ssd_offload, true, ssd_offload_path, tenant_id,
+        enable_client_http_server, client_http_port, direct_ssd);
 }
 
 tl::expected<void, ErrorCode> RealClient::initAll_internal(
@@ -5573,6 +5594,108 @@ bool RealClient::release_offload_buffer(uint64_t batch_id) {
     return file_storage_->ReleaseBuffer(batch_id);
 }
 
+tl::expected<void, ErrorCode> RealClient::write_offload_from_engine(
+    const std::string &engine_addr, uint64_t buffer_addr, uint64_t size,
+    const std::string &key) {
+    if (!file_storage_ || !client_) {
+        LOG(ERROR) << "write_offload_from_engine: not initialized";
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+    // TE READ from writer's buffer into a local staging buffer.
+    auto allocator = file_storage_->getClientBufferAllocator();
+    if (!allocator) {
+        LOG(ERROR) << "write_offload_from_engine: no client buffer allocator";
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+    auto alloc_result = allocator->allocate(size);
+    if (!alloc_result) {
+        LOG(ERROR) << "write_offload_from_engine: failed to alloc buffer";
+        return tl::make_unexpected(ErrorCode::BUFFER_OVERFLOW);
+    }
+    auto &handle = *alloc_result;
+    std::vector<Slice> slices = {Slice{handle.ptr(), size}};
+
+    // Open remote segment and do a TE READ.
+    auto seg = client_->GetSegmentEndpoint();
+    auto transfer_engine = client_->GetTransferEngine();
+    if (!transfer_engine) {
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+    uint64_t seg_handle = transfer_engine->openSegment(engine_addr);
+    if (seg_handle == static_cast<uint64_t>(ERR_INVALID_ARGUMENT)) {
+        LOG(ERROR) << "write_offload_from_engine: failed to open segment "
+                   << engine_addr;
+        return tl::make_unexpected(ErrorCode::TRANSFER_FAIL);
+    }
+    struct SegGuard {
+        std::shared_ptr<TransferEngine> engine;
+        uint64_t handle;
+        ~SegGuard() { engine->closeSegment(handle); }
+    } seg_guard{transfer_engine, seg_handle};
+
+    TransferRequest req;
+    req.opcode = TransferRequest::READ;
+    req.source = static_cast<char *>(slices[0].ptr);
+    req.target_id = seg_handle;
+    req.target_offset = buffer_addr;
+    req.length = size;
+
+    BatchID batch_id = transfer_engine->allocateBatchID(1);
+    if (batch_id == INVALID_BATCH_ID) {
+        LOG(ERROR) << "write_offload_from_engine: allocateBatchID failed";
+        return tl::make_unexpected(ErrorCode::TRANSFER_FAIL);
+    }
+    struct BatchGuard {
+        std::shared_ptr<TransferEngine> engine;
+        BatchID id;
+        ~BatchGuard() { engine->freeBatchID(id); }
+    } batch_guard{transfer_engine, batch_id};
+
+    std::vector<TransferRequest> requests = {req};
+    Status s = transfer_engine->submitTransfer(batch_id, requests);
+    if (!s.ok()) {
+        LOG(ERROR) << "write_offload_from_engine: TE submit failed: "
+                   << s.message();
+        return tl::make_unexpected(ErrorCode::TRANSFER_FAIL);
+    }
+
+    TransferStatus status;
+    bool completed = false;
+    auto start = std::chrono::steady_clock::now();
+    static constexpr auto kTimeout = std::chrono::seconds(30);
+    while (!completed) {
+        Status st = transfer_engine->getTransferStatus(batch_id, 0, status);
+        if (!st.ok()) {
+            LOG(ERROR) << "write_offload_from_engine: getTransferStatus error: "
+                       << st.message();
+            return tl::make_unexpected(ErrorCode::TRANSFER_FAIL);
+        }
+        if (status.s == TransferStatusEnum::COMPLETED) {
+            completed = true;
+        } else if (status.s == TransferStatusEnum::FAILED ||
+                   status.s == TransferStatusEnum::TIMEOUT) {
+            LOG(ERROR)
+                << "write_offload_from_engine: TE transfer failed with status="
+                << static_cast<int>(status.s);
+            return tl::make_unexpected(ErrorCode::TRANSFER_FAIL);
+        } else if (std::chrono::steady_clock::now() - start > kTimeout) {
+            LOG(ERROR) << "write_offload_from_engine: TE read timed out";
+            return tl::make_unexpected(ErrorCode::TRANSFER_FAIL);
+        } else {
+            std::this_thread::sleep_for(std::chrono::microseconds(100));
+        }
+    }
+
+    // Write staged data to local SSD.
+    auto result = file_storage_->DirectWrite(key, slices);
+    if (!result) {
+        LOG(ERROR) << "write_offload_from_engine: DirectWrite failed, key="
+                   << key << ", error=" << result.error();
+        return tl::make_unexpected(result.error());
+    }
+    return {};
+}
+
 tl::expected<void, ErrorCode>
 RealClient::batch_get_into_offload_object_internal(
     const std::string &target_rpc_service_addr,
@@ -5668,6 +5791,20 @@ ClientRequester::batch_get_offload_object(const std::string &client_addr,
         LOG(ERROR)
             << "Failed to invoke batch_get_offload_object, client_addr = "
             << client_addr << ", error is: " << result.error();
+    }
+    return result;
+}
+
+tl::expected<void, ErrorCode> ClientRequester::write_offload_from_engine(
+    const std::string &client_addr, const std::string &engine_addr,
+    uint64_t buffer_addr, uint64_t size, const std::string &key) {
+    auto result = invoke_rpc<&RealClient::write_offload_from_engine, void>(
+        client_addr, engine_addr, buffer_addr, size, key);
+    if (!result) {
+        LOG(ERROR)
+            << "Failed to invoke write_offload_from_engine, client_addr = "
+            << client_addr << ", key=" << key
+            << ", error is: " << result.error();
     }
     return result;
 }

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -1149,13 +1149,15 @@ WrappedMasterService::QuerySegmentForAdmin(const std::string& segment) {
 }
 
 tl::expected<void, ErrorCode> WrappedMasterService::MountLocalDiskSegment(
-    const UUID& client_id, bool enable_offloading) {
+    const UUID& client_id, bool enable_offloading,
+    const std::string& rpc_endpoint) {
     ScopedVLogTimer timer(1, "MountLocalDiskSegment");
     timer.LogRequest("action=mount_local_disk_segment");
     LOG(INFO) << "Mount local disk segment with client id is : " << client_id
-              << ", enable offloading is: " << enable_offloading;
-    auto result =
-        master_service_.MountLocalDiskSegment(client_id, enable_offloading);
+              << ", enable offloading is: " << enable_offloading
+              << ", rpc_endpoint=" << rpc_endpoint;
+    auto result = master_service_.MountLocalDiskSegment(
+        client_id, enable_offloading, rpc_endpoint);
 
     timer.LogResponseExpected(result);
     return result;

--- a/mooncake-store/src/segment.cpp
+++ b/mooncake-store/src/segment.cpp
@@ -219,18 +219,23 @@ ErrorCode ScopedSegmentAccess::MountSegment(const Segment& segment,
     return ErrorCode::OK;
 }
 
-ErrorCode ScopedSegmentAccess::MountLocalDiskSegment(const UUID& client_id,
-                                                     bool enable_offloading) {
+ErrorCode ScopedSegmentAccess::MountLocalDiskSegment(
+    const UUID& client_id, bool enable_offloading,
+    const std::string& rpc_endpoint) {
     auto exist_segment_it =
         segment_manager_->client_local_disk_segment_.find(client_id);
     if (exist_segment_it !=
         segment_manager_->client_local_disk_segment_.end()) {
         LOG(WARNING) << "client_id=" << client_id
                      << ", warn=local_disk_segment_already_exists";
+        // Update rpc_endpoint even if segment already exists (re-registration).
+        exist_segment_it->second->rpc_endpoint = rpc_endpoint;
         return ErrorCode::SEGMENT_ALREADY_EXISTS;
     }
-    segment_manager_->client_local_disk_segment_.emplace(
-        client_id, std::make_shared<LocalDiskSegment>(enable_offloading));
+    auto segment = std::make_shared<LocalDiskSegment>(enable_offloading);
+    segment->rpc_endpoint = rpc_endpoint;
+    segment_manager_->client_local_disk_segment_.emplace(client_id,
+                                                         std::move(segment));
     return ErrorCode::OK;
 }
 
@@ -673,14 +678,17 @@ SegmentSerializer::Serialize() {
         packer.pack(UuidToString(client_uuid));
 
         // Serialize LocalDiskSegment: [enable_offloading, count, storage_key1,
-        // task1, storage_key2, task2, ...] Sort keys to ensure determinism.
+        // task1, storage_key2, task2, ..., rpc_endpoint]
+        // Sort keys to ensure determinism. rpc_endpoint is appended at the
+        // tail so snapshots written before it existed (array size
+        // 2 + count * 2) still deserialize; readers detect it by length.
         std::vector<std::string> sorted_keys;
         for (const auto& [key, _] : segment->offloading_objects) {
             sorted_keys.push_back(key);
         }
         std::sort(sorted_keys.begin(), sorted_keys.end());
 
-        packer.pack_array(2 + sorted_keys.size() * 2);
+        packer.pack_array(2 + sorted_keys.size() * 2 + 1);
         packer.pack(segment->enable_offloading);
         packer.pack(static_cast<uint64_t>(sorted_keys.size()));
 
@@ -692,6 +700,11 @@ SegmentSerializer::Serialize() {
             packer.pack(task.key);
             packer.pack(task.size);
         }
+
+        // Tail field: RPC endpoint used by direct_ssd Phase C placement.
+        // Without it, a master restored from snapshot would hand out
+        // LOCAL_DISK descriptors with an empty transport_endpoint.
+        packer.pack(segment->rpc_endpoint);
     }
 
     // Compress entire data
@@ -1086,6 +1099,25 @@ tl::expected<void, SerializationError> SegmentSerializer::Deserialize(
                         OffloadTaskItem{.tenant_id = std::move(tenant_id),
                                         .key = std::move(user_key),
                                         .size = task_obj.as<int64_t>()};
+                }
+            }
+
+            // Tail field (added with direct_ssd): rpc_endpoint. Snapshots
+            // written before it existed have array size 2 + count * 2;
+            // detect the extra element by length. Missing field leaves
+            // rpc_endpoint empty — same as the pre-fix behavior.
+            const size_t endpoint_idx = 2 + count * 2;
+            if (endpoint_idx < client_value.via.array.size) {
+                const auto& endpoint_obj =
+                    client_value.via.array.ptr[endpoint_idx];
+                if (endpoint_obj.type == msgpack::type::STR) {
+                    segment->rpc_endpoint.assign(endpoint_obj.via.str.ptr,
+                                                 endpoint_obj.via.str.size);
+                } else {
+                    return tl::unexpected(SerializationError(
+                        ErrorCode::DESERIALIZE_FAIL,
+                        "deserialize local_disk_segments rpc_endpoint is "
+                        "not string"));
                 }
             }
 

--- a/mooncake-store/src/storage/distributed/distributed_storage_backend.cpp
+++ b/mooncake-store/src/storage/distributed/distributed_storage_backend.cpp
@@ -187,6 +187,40 @@ tl::expected<int64_t, ErrorCode> DistributedStorageBackend::BatchOffload(
     return static_cast<int64_t>(success_keys.size());
 }
 
+tl::expected<std::pair<StorageObjectMetadata, std::vector<std::string>>,
+             ErrorCode>
+DistributedStorageBackend::DirectWrite(const std::string& key,
+                                       const std::vector<Slice>& slices) {
+    std::unordered_map<std::string, std::vector<Slice>> batch_object;
+    batch_object[key] = slices;
+
+    StorageObjectMetadata result_meta;
+    std::vector<std::string> result_evicted;
+
+    auto complete_handler =
+        [&result_meta](
+            const std::vector<std::string>& /*keys*/,
+            std::vector<StorageObjectMetadata>& metadatas) -> ErrorCode {
+        if (!metadatas.empty()) {
+            result_meta = metadatas[0];
+        }
+        return ErrorCode::OK;
+    };
+
+    auto eviction_handler =
+        [&result_evicted](const std::vector<std::string>& evicted_keys) {
+            result_evicted = evicted_keys;
+        };
+
+    auto offload_result =
+        BatchOffload(batch_object, complete_handler, eviction_handler);
+    if (!offload_result) {
+        return tl::make_unexpected(offload_result.error());
+    }
+
+    return std::make_pair(result_meta, result_evicted);
+}
+
 tl::expected<void, ErrorCode> DistributedStorageBackend::BatchLoad(
     std::unordered_map<std::string, Slice>& batched_slices) {
     if (!initialized_) {

--- a/mooncake-store/src/storage_backend.cpp
+++ b/mooncake-store/src/storage_backend.cpp
@@ -1088,6 +1088,41 @@ tl::expected<int64_t, ErrorCode> StorageBackendAdaptor::BatchOffload(
     return static_cast<int64_t>(keys.size());
 }
 
+tl::expected<std::pair<StorageObjectMetadata, std::vector<std::string>>,
+             ErrorCode>
+StorageBackendAdaptor::DirectWrite(const std::string& key,
+                                   const std::vector<Slice>& slices) {
+    // Delegate to BatchOffload with single-key map.
+    std::unordered_map<std::string, std::vector<Slice>> batch_object;
+    batch_object[key] = slices;
+
+    StorageObjectMetadata result_meta;
+    std::vector<std::string> result_evicted;
+
+    auto complete_handler =
+        [&result_meta](
+            const std::vector<std::string>& /*keys*/,
+            std::vector<StorageObjectMetadata>& metadatas) -> ErrorCode {
+        if (!metadatas.empty()) {
+            result_meta = metadatas[0];
+        }
+        return ErrorCode::OK;
+    };
+
+    auto eviction_handler =
+        [&result_evicted](const std::vector<std::string>& evicted_keys) {
+            result_evicted = evicted_keys;
+        };
+
+    auto offload_result =
+        BatchOffload(batch_object, complete_handler, eviction_handler);
+    if (!offload_result) {
+        return tl::make_unexpected(offload_result.error());
+    }
+
+    return std::make_pair(result_meta, result_evicted);
+}
+
 tl::expected<bool, ErrorCode> StorageBackendAdaptor::IsExist(
     const std::string& key) {
     auto path = ResolvePathFromKey(key, file_storage_config_.storage_filepath,
@@ -1316,6 +1351,19 @@ tl::expected<int64_t, ErrorCode> BucketStorageBackend::BatchOffload(
     const int64_t required_size = bucket->data_size + bucket->meta_size;
     PendingEviction pending = PrepareEviction(required_size);
 
+    // Keys of the current batch may route to an evicted bucket (direct_ssd
+    // overwrite of an existing key). The commit below re-points them to the
+    // new bucket, so they must NOT be reported as evicted — the master would
+    // otherwise erase the very replica this write is fulfilling.
+    if (!pending.keys.empty()) {
+        pending.keys.erase(
+            std::remove_if(pending.keys.begin(), pending.keys.end(),
+                           [&batch_object](const std::string& evicted_key) {
+                               return batch_object.count(evicted_key) > 0;
+                           }),
+            pending.keys.end());
+    }
+
     // Notify master about evicted keys BEFORE touching the files.
     if (eviction_handler && !pending.keys.empty()) {
         eviction_handler(pending.keys);
@@ -1340,34 +1388,24 @@ tl::expected<int64_t, ErrorCode> BucketStorageBackend::BatchOffload(
         }
     }
 
-    // Commit to metadata maps under exclusive lock.
-    // Check for duplicate keys and rollback if any found.
+    // Commit to metadata maps under exclusive lock. A key that already
+    // exists (direct_ssd overwrite: in-place upsert, re-put after remove,
+    // write retry) is re-pointed to this newer bucket; the stale entry in
+    // its old bucket becomes unreachable and its space is reclaimed when
+    // that bucket is evicted (PrepareEviction only erases/reports keys
+    // still routed to the evicted bucket).
     {
         SharedMutexLocker lock(&mutex_);
 
-        // Pre-check for duplicates before modifying any state
-        for (const auto& key : bucket->keys) {
-            if (object_bucket_map_.find(key) != object_bucket_map_.end()) {
-                LOG(WARNING)
-                    << "Duplicate key detected in BatchOffload: " << key
-                    << ", bucket_id=" << bucket_id
-                    << ". Returning OBJECT_ALREADY_EXISTS.";
-                lock.unlock();
-                CleanupOrphanedBucket(bucket_id);
-                return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
-            }
-        }
-
-        // No duplicates found, safe to commit
         total_size_ += bucket->data_size + bucket->meta_size;
         object_bucket_map_.reserve(object_bucket_map_.size() +
                                    bucket->keys.size());
         for (size_t i = 0; i < bucket->keys.size(); ++i) {
-            auto [it, inserted] = object_bucket_map_.insert(
-                {bucket->keys[i], std::move(metadatas[i])});
+            auto [it, inserted] = object_bucket_map_.insert_or_assign(
+                bucket->keys[i], std::move(metadatas[i]));
             if (!inserted) {
-                LOG(ERROR) << "Unexpected duplicate key after pre-check: "
-                           << bucket->keys[i] << ", bucket_id=" << bucket_id;
+                VLOG(1) << "Overwriting existing key in BatchOffload: "
+                        << bucket->keys[i] << ", new bucket_id=" << bucket_id;
             }
         }
         buckets_.emplace(bucket_id, std::move(bucket));
@@ -1375,6 +1413,41 @@ tl::expected<int64_t, ErrorCode> BucketStorageBackend::BatchOffload(
     }
 
     return bucket_id;
+}
+
+tl::expected<std::pair<StorageObjectMetadata, std::vector<std::string>>,
+             ErrorCode>
+BucketStorageBackend::DirectWrite(const std::string& key,
+                                  const std::vector<Slice>& slices) {
+    // Wrap single-key write as a one-element BatchOffload.
+    std::unordered_map<std::string, std::vector<Slice>> batch_object;
+    batch_object[key] = slices;
+
+    StorageObjectMetadata result_meta;
+    std::vector<std::string> result_evicted;
+
+    auto complete_handler =
+        [&result_meta](
+            const std::vector<std::string>& /*keys*/,
+            std::vector<StorageObjectMetadata>& metadatas) -> ErrorCode {
+        if (!metadatas.empty()) {
+            result_meta = metadatas[0];
+        }
+        return ErrorCode::OK;
+    };
+
+    auto eviction_handler =
+        [&result_evicted](const std::vector<std::string>& evicted_keys) {
+            result_evicted = evicted_keys;
+        };
+
+    auto offload_result =
+        BatchOffload(batch_object, complete_handler, eviction_handler);
+    if (!offload_result) {
+        return tl::make_unexpected(offload_result.error());
+    }
+
+    return std::make_pair(result_meta, result_evicted);
 }
 
 tl::expected<void, ErrorCode> BucketStorageBackend::BatchQuery(
@@ -1659,13 +1732,22 @@ tl::expected<void, ErrorCode> BucketStorageBackend::Init() {
                 total_size_ += metadata_it->second->data_size +
                                metadata_it->second->meta_size;
                 for (size_t i = 0; i < metadata_it->second->keys.size(); i++) {
-                    object_bucket_map_.emplace(
-                        metadata_it->second->keys[i],
-                        StorageObjectMetadata{
-                            metadata_it->first,
-                            metadata_it->second->metadatas[i].offset,
-                            metadata_it->second->metadatas[i].key_size,
-                            metadata_it->second->metadatas[i].data_size, ""});
+                    StorageObjectMetadata object_metadata{
+                        metadata_it->first,
+                        metadata_it->second->metadatas[i].offset,
+                        metadata_it->second->metadatas[i].key_size,
+                        metadata_it->second->metadatas[i].data_size, ""};
+                    auto [obj_it, inserted] = object_bucket_map_.try_emplace(
+                        metadata_it->second->keys[i], object_metadata);
+                    if (!inserted &&
+                        metadata_it->first > obj_it->second.bucket_id) {
+                        // Duplicate key across buckets: a direct_ssd
+                        // overwrite happened before the older bucket was
+                        // evicted. Bucket ids are monotonically increasing
+                        // timestamps, so the newest bucket holds the live
+                        // copy.
+                        obj_it->second = object_metadata;
+                    }
                 }
             }
         }
@@ -2297,22 +2379,24 @@ BucketStorageBackend::PendingEviction BucketStorageBackend::PrepareEviction(
             std::move(evict_it->second);
         buckets_.erase(evict_it);
 
-        // Remove all keys belonging to this bucket from the object map.
+        // Remove keys still routed to this bucket from the object map and
+        // report only those to the master. Keys overwritten by a newer
+        // bucket (direct_ssd) stay live in that bucket and must not be
+        // reported as evicted.
         for (const auto& key : evict_meta->keys) {
             auto obj_it = object_bucket_map_.find(key);
             if (obj_it != object_bucket_map_.end() &&
                 obj_it->second.bucket_id == evict_id) {
-                total_size_ -=
-                    obj_it->second.data_size + obj_it->second.key_size;
                 object_bucket_map_.erase(obj_it);
+                result.keys.push_back(key);
             }
         }
-        total_size_ -= evict_meta->meta_size;
+        // Physical accounting: FinalizeEviction deletes the whole bucket's
+        // files — including entries already overwritten by newer buckets —
+        // so subtract the bucket's full size (equals the amount added at
+        // BatchOffload commit).
+        total_size_ -= evict_meta->data_size + evict_meta->meta_size;
 
-        // Collect for notification and file deletion.
-        for (const auto& key : evict_meta->keys) {
-            result.keys.push_back(key);
-        }
         accumulated_freed_space +=
             static_cast<uint64_t>(evict_meta->data_size) +
             static_cast<uint64_t>(evict_meta->meta_size);
@@ -3022,6 +3106,40 @@ tl::expected<int64_t, ErrorCode> OffsetAllocatorStorageBackend::BatchOffload(
     }
 
     return static_cast<int64_t>(keys.size());
+}
+
+tl::expected<std::pair<StorageObjectMetadata, std::vector<std::string>>,
+             ErrorCode>
+OffsetAllocatorStorageBackend::DirectWrite(const std::string& key,
+                                           const std::vector<Slice>& slices) {
+    std::unordered_map<std::string, std::vector<Slice>> batch_object;
+    batch_object[key] = slices;
+
+    StorageObjectMetadata result_meta;
+    std::vector<std::string> result_evicted;
+
+    auto complete_handler =
+        [&result_meta](
+            const std::vector<std::string>& /*keys*/,
+            std::vector<StorageObjectMetadata>& metadatas) -> ErrorCode {
+        if (!metadatas.empty()) {
+            result_meta = metadatas[0];
+        }
+        return ErrorCode::OK;
+    };
+
+    auto eviction_handler =
+        [&result_evicted](const std::vector<std::string>& evicted_keys) {
+            result_evicted = evicted_keys;
+        };
+
+    auto offload_result =
+        BatchOffload(batch_object, complete_handler, eviction_handler);
+    if (!offload_result) {
+        return tl::make_unexpected(offload_result.error());
+    }
+
+    return std::make_pair(result_meta, result_evicted);
 }
 
 //-----------------------------------------------------------------------------

--- a/mooncake-store/src/store_c.cpp
+++ b/mooncake-store/src/store_c.cpp
@@ -46,6 +46,8 @@ mooncake::ReplicateConfig to_replicate_config(
     config.replica_num = c_config->replica_num;
     config.with_soft_pin = c_config->with_soft_pin != 0;
     config.with_hard_pin = c_config->with_hard_pin != 0;
+    if (c_config->direct_ssd >= 0)
+        config.direct_ssd = (c_config->direct_ssd != 0);
     if (c_config->preferred_segments &&
         c_config->preferred_segments_count > 0) {
         for (size_t i = 0; i < c_config->preferred_segments_count; ++i) {

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -67,6 +67,7 @@ add_store_test(master_service_tenant_quota_test
 add_store_test(batch_remove_test batch_remove_test.cpp)
 add_store_test(master_service_ssd_test master_service_ssd_test.cpp)
 add_store_test(offload_on_evict_test offload_on_evict_test.cpp)
+add_store_test(direct_ssd_test direct_ssd_test.cpp)
 add_store_test(promotion_on_hit_test promotion_on_hit_test.cpp)
 add_store_test(file_storage_promotion_test file_storage_promotion_test.cpp)
 add_store_test(master_service_ssd_test_for_snapshot

--- a/mooncake-store/tests/direct_ssd_test.cpp
+++ b/mooncake-store/tests/direct_ssd_test.cpp
@@ -1,0 +1,268 @@
+#include "master_service.h"
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "types.h"
+
+namespace mooncake::test {
+
+class DirectSsdTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        google::InitGoogleLogging("DirectSsdTest");
+        FLAGS_logtostderr = true;
+    }
+
+    void TearDown() override { google::ShutdownGoogleLogging(); }
+
+    static constexpr size_t kDefaultSegmentBase = 0x300000000;
+
+    Segment MakeSegment(const std::string& name, size_t base,
+                        size_t size) const {
+        Segment seg;
+        seg.id = generate_uuid();
+        seg.name = name;
+        seg.base = base;
+        seg.size = size;
+        seg.te_endpoint = name;
+        return seg;
+    }
+
+    struct MountedContext {
+        UUID segment_id;
+        UUID client_id;
+    };
+
+    MountedContext PrepareMemorySegment(MasterService& service,
+                                        const std::string& name, size_t base,
+                                        size_t size) const {
+        auto seg = MakeSegment(name, base, size);
+        UUID cid = generate_uuid();
+        EXPECT_TRUE(service.MountSegment(seg, cid).has_value());
+        return {seg.id, cid};
+    }
+
+    UUID PrepareLocalDiskSegment(
+        MasterService& service, int64_t total_capacity,
+        const std::string& rpc_endpoint = "10.0.0.1:50052") {
+        UUID cid = generate_uuid();
+        EXPECT_TRUE(
+            service.MountLocalDiskSegment(cid, true, rpc_endpoint).has_value());
+        EXPECT_TRUE(service.ReportSsdCapacity(cid, total_capacity).has_value());
+        return cid;
+    }
+
+    // Put via memory path (normal offload flow, for comparison).
+    void PutObjectMemory(MasterService& service, const UUID& client_id,
+                         const std::string& key, size_t size = 1024) {
+        ReplicateConfig cfg;
+        cfg.replica_num = 1;
+        auto start = service.PutStart(client_id, key, "default", size, cfg);
+        ASSERT_TRUE(start.has_value()) << key;
+        auto end =
+            service.PutEnd(client_id, key, "default", ReplicaType::MEMORY);
+        ASSERT_TRUE(end.has_value()) << key;
+    }
+
+    // Put via direct_ssd path. Returns allocated replicas.
+    std::vector<Replica::Descriptor> PutDirectSsd(MasterService& service,
+                                                  const UUID& client_id,
+                                                  const std::string& key,
+                                                  size_t size,
+                                                  size_t replica_num = 1) {
+        ReplicateConfig cfg;
+        cfg.replica_num = replica_num;
+        cfg.direct_ssd = true;
+        auto start = service.PutStart(client_id, key, "default", size, cfg);
+        if (!start.has_value()) {
+            LOG(ERROR) << "PutStart failed for key=" << key
+                       << ", error=" << toString(start.error());
+        }
+        EXPECT_TRUE(start.has_value()) << key;
+        if (!start.has_value()) return {};
+        return start.value();
+    }
+
+    // Drain offload queue.
+    std::vector<OffloadTaskItem> DrainOffloadQueue(MasterService& service,
+                                                   const UUID& client_id) {
+        auto res = service.OffloadObjectHeartbeat(client_id, true);
+        if (!res.has_value()) return {};
+        return res.value();
+    }
+};
+
+// =========================================================================
+// 1. Basic direct_ssd Put: allocate LOCAL_DISK, no MEMORY
+// =========================================================================
+
+TEST_F(DirectSsdTest, PutDirectSsdAllocatesLocalDiskReplica) {
+    auto service = std::make_unique<MasterService>(
+        MasterServiceConfig::builder().set_enable_offload(true).build());
+    auto mem_ctx = PrepareMemorySegment(*service, "mem_seg",
+                                        kDefaultSegmentBase, 16 * 1024 * 1024);
+    // Use same client_id for memory segment and LocalDiskSegment so the
+    // offload queue push works correctly (same as existing test pattern).
+    auto ssd_client = PrepareLocalDiskSegment(*service, 10ULL * 1024 * 1024);
+
+    // Phase A (MEMORY) skipped. Phase C allocates LOCAL_DISK.
+    auto replicas = PutDirectSsd(*service, mem_ctx.client_id, "key1", 1024, 1);
+    ASSERT_GE(replicas.size(), 1u);
+    EXPECT_TRUE(replicas[0].is_local_disk_replica());
+    EXPECT_FALSE(replicas[0].is_memory_replica());
+
+    // PutEnd marks COMPLETE.
+    auto end = service->PutEnd(mem_ctx.client_id, "key1", "default",
+                               ReplicaType::LOCAL_DISK);
+    ASSERT_TRUE(end.has_value());
+
+    // Offload queue must be empty — direct_ssd skips the offload queue.
+    auto queue = DrainOffloadQueue(*service, ssd_client);
+    EXPECT_TRUE(queue.empty());
+}
+
+// =========================================================================
+// 2. Multiple LOCAL_DISK replicas
+// =========================================================================
+
+TEST_F(DirectSsdTest, PutDirectSsdMultipleReplicas) {
+    auto service = std::make_unique<MasterService>(
+        MasterServiceConfig::builder().set_enable_offload(true).build());
+    auto mem_ctx = PrepareMemorySegment(*service, "mem_seg",
+                                        kDefaultSegmentBase, 16 * 1024 * 1024);
+
+    auto c1 = PrepareLocalDiskSegment(*service, 1000, "10.0.0.1:50052");
+    auto c2 = PrepareLocalDiskSegment(*service, 2000, "10.0.0.2:50052");
+    auto c3 = PrepareLocalDiskSegment(*service, 500, "10.0.0.3:50052");
+
+    auto replicas =
+        PutDirectSsd(*service, mem_ctx.client_id, "key_multi", 1024, 3);
+    EXPECT_EQ(replicas.size(), 3u);
+    for (const auto& r : replicas) {
+        EXPECT_TRUE(r.is_local_disk_replica());
+    }
+
+    auto end = service->PutEnd(mem_ctx.client_id, "key_multi", "default",
+                               ReplicaType::LOCAL_DISK);
+    ASSERT_TRUE(end.has_value());
+}
+
+// =========================================================================
+// 3. Phase C caps at available SSD count (no duplicate clients)
+// =========================================================================
+
+TEST_F(DirectSsdTest, PhaseCCapsAtAvailableSsdCount) {
+    auto service = std::make_unique<MasterService>(
+        MasterServiceConfig::builder().set_enable_offload(true).build());
+    auto mem_ctx = PrepareMemorySegment(*service, "mem_seg",
+                                        kDefaultSegmentBase, 16 * 1024 * 1024);
+
+    // Only 1 SSD but request 3 replicas → should get 1.
+    PrepareLocalDiskSegment(*service, 1000, "10.0.0.1:50052");
+    auto replicas =
+        PutDirectSsd(*service, mem_ctx.client_id, "key_cap", 100, 3);
+    EXPECT_EQ(replicas.size(), 1u);
+}
+
+// =========================================================================
+// 4. Fails cleanly when no SSD clients registered
+// =========================================================================
+
+TEST_F(DirectSsdTest, FailsWithoutSsdClients) {
+    auto service = std::make_unique<MasterService>(
+        MasterServiceConfig::builder().set_enable_offload(true).build());
+    auto mem_ctx = PrepareMemorySegment(*service, "mem_seg",
+                                        kDefaultSegmentBase, 16 * 1024 * 1024);
+
+    ReplicateConfig cfg;
+    cfg.replica_num = 1;
+    cfg.direct_ssd = true;
+    auto start =
+        service->PutStart(mem_ctx.client_id, "key_none", "default", 1024, cfg);
+    EXPECT_FALSE(start.has_value());
+    EXPECT_EQ(start.error(), ErrorCode::NO_AVAILABLE_HANDLE);
+}
+
+// =========================================================================
+// 5. direct_ssd PutEnd skips offload queue; normal Put enters it
+// =========================================================================
+
+TEST_F(DirectSsdTest, DirectSsdSkipsOffloadQueue) {
+    auto service = std::make_unique<MasterService>(
+        MasterServiceConfig::builder().set_enable_offload(true).build());
+    auto mem_ctx = PrepareMemorySegment(*service, "mem_seg",
+                                        kDefaultSegmentBase, 16 * 1024 * 1024);
+    // Mount LocalDiskSegment under the SAME client_id as the memory segment.
+    // This is how existing tests (offload_on_evict_test) structure it:
+    // PushOffloadingQueue needs the memory segment's owner to also have
+    // a LocalDiskSegment for the offload task to land.
+    ASSERT_TRUE(
+        service->MountLocalDiskSegment(mem_ctx.client_id, true).has_value());
+    ASSERT_TRUE(
+        service->ReportSsdCapacity(mem_ctx.client_id, 10000).has_value());
+
+    // direct_ssd write.
+    auto reps = PutDirectSsd(*service, mem_ctx.client_id, "key_ds", 1024, 1);
+    ASSERT_GE(reps.size(), 1u);
+    ASSERT_TRUE(service
+                    ->PutEnd(mem_ctx.client_id, "key_ds", "default",
+                             ReplicaType::LOCAL_DISK)
+                    .has_value());
+
+    // Normal (non-direct_ssd) write.
+    PutObjectMemory(*service, mem_ctx.client_id, "key_mem", 1024);
+
+    // Offload queue should only contain key_mem (key_ds was direct_ssd).
+    auto queue = DrainOffloadQueue(*service, mem_ctx.client_id);
+    EXPECT_EQ(queue.size(), 1u);
+    if (!queue.empty()) {
+        EXPECT_EQ(queue[0].key, "key_mem");
+    }
+}
+
+// =========================================================================
+// 6. PutRevoke cleans up PROCESSING LOCAL_DISK without error
+// =========================================================================
+
+TEST_F(DirectSsdTest, PutRevokeCleansUpLocalDisk) {
+    auto service = std::make_unique<MasterService>(
+        MasterServiceConfig::builder().set_enable_offload(true).build());
+    auto mem_ctx = PrepareMemorySegment(*service, "mem_seg",
+                                        kDefaultSegmentBase, 16 * 1024 * 1024);
+    PrepareLocalDiskSegment(*service, 10000, "10.0.0.1:50052");
+
+    auto reps = PutDirectSsd(*service, mem_ctx.client_id, "key_rv", 1024, 1);
+    ASSERT_GE(reps.size(), 1u);
+
+    // Revoke instead of PutEnd.
+    auto revoke = service->PutRevoke(mem_ctx.client_id, "key_rv", "default",
+                                     ReplicaType::ALL);
+    EXPECT_TRUE(revoke.has_value());
+}
+
+// =========================================================================
+// 7. Transport endpoint correctly stored in replica descriptor
+// =========================================================================
+
+TEST_F(DirectSsdTest, TransportEndpointInReplica) {
+    auto service = std::make_unique<MasterService>(
+        MasterServiceConfig::builder().set_enable_offload(true).build());
+    auto mem_ctx = PrepareMemorySegment(*service, "mem_seg",
+                                        kDefaultSegmentBase, 16 * 1024 * 1024);
+    const std::string rpc_ep = "192.168.1.100:50052";
+    auto ssd_client = PrepareLocalDiskSegment(*service, 10000, rpc_ep);
+
+    auto replicas =
+        PutDirectSsd(*service, mem_ctx.client_id, "key_ep", 1024, 1);
+    ASSERT_GE(replicas.size(), 1u);
+    auto desc = replicas[0].get_local_disk_descriptor();
+    EXPECT_EQ(desc.client_id, ssd_client);
+    EXPECT_EQ(desc.transport_endpoint, rpc_ep);
+}
+
+}  // namespace mooncake::test

--- a/mooncake-store/tests/file_storage_test.cpp
+++ b/mooncake-store/tests/file_storage_test.cpp
@@ -58,6 +58,11 @@ class FileStorageTest : public ::testing::Test {
         return fileStorage.AllocateBatch(keys, sizes);
     }
 
+    tl::expected<void, ErrorCode> FileStorageInitBackend(
+        FileStorage& fileStorage) {
+        return fileStorage.storage_backend_->Init();
+    }
+
     tl::expected<void, ErrorCode> FileStorageBatchLoad(
         FileStorage& fileStorage,
         std::unordered_map<std::string, Slice>& batch_object) {
@@ -162,6 +167,78 @@ TEST_F(FileStorageTest, BatchLoad) {
         LOG(INFO) << "key: " << slice_it.first;
         ASSERT_EQ(data, batch_data.at(slice_it.first));
     }
+}
+
+// =========================================================================
+// direct_ssd data path: DirectWrite → BatchLoad read-back
+// =========================================================================
+
+TEST_F(FileStorageTest, DirectWriteReadBack) {
+    auto file_storage_config = FileStorageConfig::FromEnvironment();
+    file_storage_config.storage_filepath = data_path;
+    FileStorage fileStorage(file_storage_config, nullptr, "localhost:9003");
+    // FileStorage::Init() needs a live master client; initialize just the
+    // storage backend, matching what BatchOffloadUtil does for other tests.
+    ASSERT_TRUE(FileStorageInitBackend(fileStorage));
+
+    // direct_ssd writers store under tenant-scoped storage keys (see
+    // Client::SubmitLocalDiskReplicaWrites), matching what the read path
+    // (batch_get_offload_object → BatchGet/BatchLoad) looks up.
+    const std::string storage_key =
+        MakeTenantScopedStorageKey("default", "direct_ssd_key");
+    std::string value = "direct_ssd_payload_0123456789";
+    std::vector<Slice> slices = {Slice{value.data(), value.size()}};
+
+    auto write_res = fileStorage.DirectWrite(storage_key, slices);
+    ASSERT_TRUE(write_res);
+    // FileStorage::DirectWrite stamps the local RPC endpoint used by remote
+    // readers, and no eviction is expected on an empty store.
+    EXPECT_EQ(write_res->first.transport_endpoint, "localhost:9003");
+    EXPECT_TRUE(write_res->second.empty());
+
+    std::vector<std::string> keys = {storage_key};
+    std::vector<int64_t> sizes = {static_cast<int64_t>(value.size())};
+    auto allocate_res = FileStorageAllocateBatch(fileStorage, keys, sizes);
+    ASSERT_TRUE(allocate_res);
+    ASSERT_TRUE(
+        FileStorageBatchLoad(fileStorage, allocate_res.value()->slices));
+
+    const auto& loaded = allocate_res.value()->slices.at(storage_key);
+    std::string read_back(static_cast<char*>(loaded.ptr), loaded.size);
+    EXPECT_EQ(read_back, value);
+}
+
+TEST_F(FileStorageTest, DirectWriteOverwriteReadsNewValue) {
+    auto file_storage_config = FileStorageConfig::FromEnvironment();
+    file_storage_config.storage_filepath = data_path;
+    FileStorage fileStorage(file_storage_config, nullptr, "localhost:9003");
+    ASSERT_TRUE(FileStorageInitBackend(fileStorage));
+
+    const std::string storage_key =
+        MakeTenantScopedStorageKey("default", "direct_ssd_overwrite_key");
+    std::string v1 = "old_value_aaaaaaaaaaaaaaaa";
+    std::vector<Slice> slices_v1 = {Slice{v1.data(), v1.size()}};
+    ASSERT_TRUE(fileStorage.DirectWrite(storage_key, slices_v1));
+
+    // Overwriting the same key must succeed (in-place upsert, re-put after
+    // remove, write retry). Before overwrite support in BatchOffload this
+    // returned OBJECT_ALREADY_EXISTS.
+    std::string v2 = "new_value_bbbb";  // different length on purpose
+    std::vector<Slice> slices_v2 = {Slice{v2.data(), v2.size()}};
+    auto second_write = fileStorage.DirectWrite(storage_key, slices_v2);
+    ASSERT_TRUE(second_write)
+        << "DirectWrite overwrite failed: " << second_write.error();
+
+    std::vector<std::string> keys = {storage_key};
+    std::vector<int64_t> sizes = {static_cast<int64_t>(v2.size())};
+    auto allocate_res = FileStorageAllocateBatch(fileStorage, keys, sizes);
+    ASSERT_TRUE(allocate_res);
+    ASSERT_TRUE(
+        FileStorageBatchLoad(fileStorage, allocate_res.value()->slices));
+
+    const auto& loaded = allocate_res.value()->slices.at(storage_key);
+    std::string read_back(static_cast<char*>(loaded.ptr), loaded.size);
+    EXPECT_EQ(read_back, v2);
 }
 
 TEST_F(FileStorageTest, GroupOffloadingKeysByBucket_bucket_keys_limit) {

--- a/mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot_base.h
+++ b/mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot_base.h
@@ -74,6 +74,7 @@ class MasterServiceSnapshotTestBase : public ::testing::Test {
     // LocalDiskSegment state for comparison
     struct LocalDiskSegmentState {
         bool enable_offloading = false;
+        std::string rpc_endpoint;
         std::map<std::string, OffloadTaskItem>
             offloading_objects;  // storage key -> task (sorted)
     };
@@ -294,6 +295,7 @@ class MasterServiceSnapshotTestBase : public ::testing::Test {
                  access.getClientLocalDiskSegment()) {
                 LocalDiskSegmentState seg_state;
                 seg_state.enable_offloading = segment->enable_offloading;
+                seg_state.rpc_endpoint = segment->rpc_endpoint;
                 // Copy offloading_objects to sorted map
                 std::lock_guard<Mutex> lock(segment->offloading_mutex_);
                 for (const auto& [key, task] : segment->offloading_objects) {
@@ -400,6 +402,9 @@ class MasterServiceSnapshotTestBase : public ::testing::Test {
     bool CompareLocalDiskSegmentState(const LocalDiskSegmentState& a,
                                       const LocalDiskSegmentState& b) const {
         if (a.enable_offloading != b.enable_offloading) {
+            return false;
+        }
+        if (a.rpc_endpoint != b.rpc_endpoint) {
             return false;
         }
         if (a.offloading_objects != b.offloading_objects) {

--- a/mooncake-store/tests/storage_backend_test.cpp
+++ b/mooncake-store/tests/storage_backend_test.cpp
@@ -1749,10 +1749,10 @@ TEST_F(StorageBackendTest,
 }
 
 //-----------------------------------------------------------------------------
-// BucketStorageBackend: Duplicate Key Detection Tests (Phase 0 - D0)
+// BucketStorageBackend: Duplicate Key Overwrite Tests (direct_ssd rewrite)
 //-----------------------------------------------------------------------------
 
-TEST_F(StorageBackendTest, BucketStorageBackend_DuplicateKeyRejected) {
+TEST_F(StorageBackendTest, BucketStorageBackend_DuplicateKeyOverwrites) {
     FileStorageConfig config;
     config.storage_filepath = data_path;
     BucketBackendConfig bucket_config;
@@ -1774,7 +1774,9 @@ TEST_F(StorageBackendTest, BucketStorageBackend_DuplicateKeyRejected) {
            std::vector<StorageObjectMetadata>&) { return ErrorCode::OK; });
     ASSERT_TRUE(result1.has_value()) << "First write should succeed";
 
-    // Attempt to write the same key again
+    // Writing the same key again overwrites it (direct_ssd in-place upsert,
+    // re-put after remove, write retry). The old copy in the previous bucket
+    // becomes unreachable garbage until that bucket is evicted.
     std::string value2 = "duplicate_value_data";
     auto buf2 = std::make_unique<char[]>(value2.size());
     std::memcpy(buf2.get(), value2.data(), value2.size());
@@ -1786,29 +1788,28 @@ TEST_F(StorageBackendTest, BucketStorageBackend_DuplicateKeyRejected) {
         batch2,
         [](const std::vector<std::string>&,
            std::vector<StorageObjectMetadata>&) { return ErrorCode::OK; });
-    ASSERT_FALSE(result2.has_value()) << "Duplicate key should be rejected";
-    EXPECT_EQ(result2.error(), ErrorCode::OBJECT_ALREADY_EXISTS);
+    ASSERT_TRUE(result2.has_value()) << "Overwrite should succeed";
 
-    // Verify original data is still readable and not corrupted
+    // The key now resolves to the new value.
     auto is_exist = storage_backend.IsExist(key);
     ASSERT_TRUE(is_exist.has_value());
     EXPECT_TRUE(is_exist.value());
 
-    auto read_buf = std::make_unique<char[]>(value1.size());
+    auto read_buf = std::make_unique<char[]>(value2.size());
     std::unordered_map<std::string, Slice> load_slices;
-    load_slices.emplace(key, Slice{read_buf.get(), value1.size()});
+    load_slices.emplace(key, Slice{read_buf.get(), value2.size()});
 
     auto load_result = storage_backend.BatchLoad(load_slices);
     ASSERT_TRUE(load_result.has_value()) << "Load should succeed";
 
-    std::string loaded(read_buf.get(), value1.size());
-    EXPECT_EQ(loaded, value1) << "Original data should be intact";
+    std::string loaded(read_buf.get(), value2.size());
+    EXPECT_EQ(loaded, value2) << "Read must observe the overwritten value";
 }
 
 //-----------------------------------------------------------------------------
 
 TEST_F(StorageBackendTest,
-       BucketStorageBackend_DuplicateKeyCleanupOrphanedFiles) {
+       BucketStorageBackend_DuplicateKeyOverwriteKeepsOldBucketFiles) {
     FileStorageConfig config;
     config.storage_filepath = data_path;
     BucketBackendConfig bucket_config;
@@ -1831,7 +1832,7 @@ TEST_F(StorageBackendTest,
     ASSERT_TRUE(result1.has_value());
     int64_t bucket1_id = result1.value();
 
-    // Count files before duplicate attempt
+    // Count files before the overwrite
     int file_count_before = 0;
     for (const auto& entry : fs::directory_iterator(data_path)) {
         if (entry.is_regular_file()) {
@@ -1841,8 +1842,9 @@ TEST_F(StorageBackendTest,
     // Should have 1 .bucket + 1 .meta = 2 files
     EXPECT_EQ(file_count_before, 2);
 
-    // Attempt to write duplicate key (this creates bucket files before
-    // detecting duplicate)
+    // Overwrite the key: a new bucket is written; the old bucket's files
+    // stay on disk (its entry is now unreachable garbage reclaimed when the
+    // bucket is evicted).
     std::string value2 = "duplicate_value";
     auto buf2 = std::make_unique<char[]>(value2.size());
     std::memcpy(buf2.get(), value2.data(), value2.size());
@@ -1854,36 +1856,45 @@ TEST_F(StorageBackendTest,
         batch2,
         [](const std::vector<std::string>&,
            std::vector<StorageObjectMetadata>&) { return ErrorCode::OK; });
-    ASSERT_FALSE(result2.has_value());
-    EXPECT_EQ(result2.error(), ErrorCode::OBJECT_ALREADY_EXISTS);
+    ASSERT_TRUE(result2.has_value());
+    int64_t bucket2_id = result2.value();
+    EXPECT_GT(bucket2_id, bucket1_id);
 
-    // Count files after duplicate attempt - orphaned files should be cleaned up
+    // Both buckets' files exist: 2 .bucket + 2 .meta = 4 files.
     int file_count_after = 0;
     for (const auto& entry : fs::directory_iterator(data_path)) {
         if (entry.is_regular_file()) {
             file_count_after++;
         }
     }
-    // Should still have only 2 files (orphaned bucket 2 files should be cleaned
-    // up)
-    EXPECT_EQ(file_count_after, 2) << "Orphaned bucket files should be cleaned "
-                                      "up after duplicate detection";
+    EXPECT_EQ(file_count_after, 4)
+        << "Old bucket files are kept until eviction; new bucket added";
 
-    // Verify bucket 1 files still exist
-    std::string bucket1_data_path =
-        data_path + "/" + std::to_string(bucket1_id) + ".bucket";
-    std::string bucket1_meta_path =
-        data_path + "/" + std::to_string(bucket1_id) + ".meta";
-    EXPECT_TRUE(fs::exists(bucket1_data_path))
-        << "Original bucket data file should still exist";
-    EXPECT_TRUE(fs::exists(bucket1_meta_path))
-        << "Original bucket metadata file should still exist";
+    // Verify both buckets' files exist on disk.
+    for (int64_t bucket_id : {bucket1_id, bucket2_id}) {
+        std::string bucket_data_path =
+            data_path + "/" + std::to_string(bucket_id) + ".bucket";
+        std::string bucket_meta_path =
+            data_path + "/" + std::to_string(bucket_id) + ".meta";
+        EXPECT_TRUE(fs::exists(bucket_data_path))
+            << "Bucket data file should exist for bucket " << bucket_id;
+        EXPECT_TRUE(fs::exists(bucket_meta_path))
+            << "Bucket metadata file should exist for bucket " << bucket_id;
+    }
+
+    // Reads resolve to the new value.
+    auto read_buf = std::make_unique<char[]>(value2.size());
+    std::unordered_map<std::string, Slice> load_slices;
+    load_slices.emplace(key, Slice{read_buf.get(), value2.size()});
+    auto load_result = storage_backend.BatchLoad(load_slices);
+    ASSERT_TRUE(load_result.has_value());
+    std::string loaded(read_buf.get(), value2.size());
+    EXPECT_EQ(loaded, value2);
 }
 
 //-----------------------------------------------------------------------------
 
-TEST_F(StorageBackendTest,
-       BucketStorageBackend_DuplicateBatchPartialRejection) {
+TEST_F(StorageBackendTest, BucketStorageBackend_DuplicateBatchOverwrites) {
     FileStorageConfig config;
     config.storage_filepath = data_path;
     BucketBackendConfig bucket_config;
@@ -1905,7 +1916,8 @@ TEST_F(StorageBackendTest,
            std::vector<StorageObjectMetadata>&) { return ErrorCode::OK; });
     ASSERT_TRUE(result1.has_value());
 
-    // Attempt BatchOffload with batch containing ["keyA", "keyB"]
+    // A batch containing an existing key ("keyA") and a new key ("keyB")
+    // commits both: keyA is overwritten, keyB is inserted.
     std::string keyB = "keyB";
     std::string valueA2 = "duplicate_value_A";
     std::string valueB = "value_for_keyB";
@@ -1924,27 +1936,78 @@ TEST_F(StorageBackendTest,
         batch2,
         [](const std::vector<std::string>&,
            std::vector<StorageObjectMetadata>&) { return ErrorCode::OK; });
+    ASSERT_TRUE(result2.has_value());
 
-    // Entire batch should be rejected
-    ASSERT_FALSE(result2.has_value());
-    EXPECT_EQ(result2.error(), ErrorCode::OBJECT_ALREADY_EXISTS);
-
-    // Verify "keyB" was NOT written (batch is atomic)
+    // keyB was written.
     auto is_exist_B = storage_backend.IsExist(keyB);
     ASSERT_TRUE(is_exist_B.has_value());
-    EXPECT_FALSE(is_exist_B.value())
-        << "keyB should not exist - batch should be atomic";
+    EXPECT_TRUE(is_exist_B.value());
 
-    // Verify "keyA" still has original value
-    auto read_buf = std::make_unique<char[]>(valueA.size());
+    // keyA resolves to the overwritten value.
+    auto read_buf = std::make_unique<char[]>(valueA2.size());
     std::unordered_map<std::string, Slice> load_slices;
-    load_slices.emplace(keyA, Slice{read_buf.get(), valueA.size()});
+    load_slices.emplace(keyA, Slice{read_buf.get(), valueA2.size()});
 
     auto load_result = storage_backend.BatchLoad(load_slices);
     ASSERT_TRUE(load_result.has_value());
 
-    std::string loaded(read_buf.get(), valueA.size());
-    EXPECT_EQ(loaded, valueA) << "keyA should still have original value";
+    std::string loaded(read_buf.get(), valueA2.size());
+    EXPECT_EQ(loaded, valueA2) << "keyA should read the overwritten value";
+}
+
+//-----------------------------------------------------------------------------
+
+TEST_F(StorageBackendTest,
+       BucketStorageBackend_OverwriteEvictionDoesNotReportSelf) {
+    FileStorageConfig config;
+    config.storage_filepath = data_path;
+    BucketBackendConfig bucket_config;
+    // Force eviction on every write: any pre-existing bucket is evicted to
+    // make room for the incoming one.
+    bucket_config.eviction_policy = BucketEvictionPolicy::FIFO;
+    bucket_config.max_total_size = 1;
+    BucketStorageBackend storage_backend(config, bucket_config);
+    ASSERT_TRUE(storage_backend.Init());
+
+    std::string key = "self_evict_key";
+    std::string v1 = "old_value_xxxxxxxxxxxx";
+    std::vector<Slice> slices_v1 = {Slice{v1.data(), v1.size()}};
+    auto write1 = storage_backend.DirectWrite(key, slices_v1);
+    ASSERT_TRUE(write1);
+
+    // Overwrite the same key. This evicts the old bucket (which holds the
+    // key's old copy), but the key itself is re-added by this very write —
+    // it must NOT appear in the evicted-keys report, or the master would
+    // drop the in-flight replica of this write.
+    std::string v2 = "new_value_yyyy";
+    std::vector<Slice> slices_v2 = {Slice{v2.data(), v2.size()}};
+    auto write2 = storage_backend.DirectWrite(key, slices_v2);
+    ASSERT_TRUE(write2);
+    EXPECT_TRUE(write2->second.empty())
+        << "A key overwritten by the current write must not be reported "
+           "as evicted";
+
+    // The key still reads back the new value.
+    auto read_buf = std::make_unique<char[]>(v2.size());
+    std::unordered_map<std::string, Slice> load_slices;
+    load_slices.emplace(key, Slice{read_buf.get(), v2.size()});
+    ASSERT_TRUE(storage_backend.BatchLoad(load_slices));
+    EXPECT_EQ(std::string(read_buf.get(), v2.size()), v2);
+
+    // Cross-key eviction is still reported: writing a DIFFERENT key evicts
+    // the bucket holding `key`, which is genuinely gone this time.
+    std::string other_key = "other_key";
+    std::string v3 = "other_value_zzzz";
+    std::vector<Slice> slices_v3 = {Slice{v3.data(), v3.size()}};
+    auto write3 = storage_backend.DirectWrite(other_key, slices_v3);
+    ASSERT_TRUE(write3);
+    ASSERT_EQ(write3->second.size(), 1u)
+        << "Eviction of other keys must still be reported";
+    EXPECT_EQ(write3->second[0], key);
+
+    auto is_exist = storage_backend.IsExist(key);
+    ASSERT_TRUE(is_exist.has_value());
+    EXPECT_FALSE(is_exist.value()) << "Evicted key should be gone";
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Add a direct_ssd flag to ReplicateConfig. When set, replaces MEMORY replicas with LOCAL_DISK replicas during Put, writing object data directly to SSDs without staging in DRAM. Requires master --enable_offload=true and client enable_ssd_offload=true at setup.

```
Master: Phase C allocation selects SSD clients by free capacity;
         ssd_used_bytes tracked in PutEnd mark_complete transition.

Client: SubmitLocalDiskTransfers writes replicas in parallel via
         TransferEngine (RDMA/TCP) for remote, DirectWrite for local.

Transport: TransferEngine-based write_offload_from_engine RPC handler
           for cross-node SSD writes; FutureOperationState wraps
           std::future into TransferFuture for unified WaitForTransfers.

Storage: DirectWrite API on all backends (BucketStorageBackend,
         OffsetAllocatorStorageBackend, StorageBackendAdaptor,
         DistributedStorageBackend).

Eviction: unified with heartbeat-offload path via same
          BucketStorageBackend FIFO/LRU.

Bindings: Python (pybind11), Go, and C API updated with default false.

Data flow:
Client                         Master                         Target SSD Nodes
  │                               │                                   │
  │─ PutStart(direct_ssd=true) ──▶│                                   │
  │  replica_num=3                │  Phase C: select 3 SSD nodes      │
  │                               │  (sorted by free capacity)        │
  │◀─ 3 LOCAL_DISK replicas ─────│  status=PROCESSING                │
  │                               │                                   │
  │  [SubmitTransfers]            │                                   │
  │  ┌─ local replica ──▶ DirectWrite ──▶ local SSD                  │
  │  ├─ remote replica ──▶  RPC(control) ──▶ Target: TE READ ──▶ SSD │
  │  └─ remote replica ──▶  RPC(control) ──▶ Target: TE READ ──▶ SSD │
  │  (all enqueued in parallel on write_thread_pool_)                │
  │                               │                                   │
  │─ PutEnd(LOCAL_DISK) ─────────▶│                                   │
  │                               │  mark COMPLETE                    │
  │                               │  ssd_used_bytes += object_size    │
  │                               │  (skip offload queue)             │

```

## Description



## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



**Test commands:**
```bash
# Example: bash scripts/run_ci_test.sh
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [ ] AI tools were used (specify below)