### PR TITLE
[TENT] Fix mismatched cuFileBatchIOGetStatus semantics in gds transport

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/transport/gds/gds_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/gds/gds_transport.h
@@ -36,8 +36,11 @@ namespace tent {
 class GdsFileContext;
 
 struct IOParamRange {
-    size_t base;
-    size_t count;
+    size_t base = 0;
+    size_t count = 0;
+    size_t complete_count = 0;
+    size_t transferred_bytes = 0;
+    TransferStatusEnum status = TransferStatusEnum::PENDING;
 };
 
 // Wrapper for reusable CUfileBatchHandle_t

--- a/mooncake-transfer-engine/tent/src/transport/gds/gds_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/gds/gds_transport.cpp
@@ -279,7 +279,9 @@ Status GdsTransport::submitTransferTasks(
         GdsFileContext* context = findFileContext(request.target_id);
         if (!context || !context->ready())
             return Status::InvalidArgument("Invalid remote segment" LOC_MARK);
-        IOParamRange range{gds_batch->io_params.size(), 0};
+        size_t task_id = gds_batch->io_param_ranges.size();
+        IOParamRange range;
+        range.base = gds_batch->io_params.size();
         for (size_t offset = 0; offset < request.length;
              offset += kMaxSliceSize) {
             size_t length = std::min(kMaxSliceSize, request.length - offset);
@@ -287,7 +289,8 @@ Status GdsTransport::submitTransferTasks(
             params.mode = CUFILE_BATCH;
             params.opcode =
                 (request.opcode == Request::READ) ? CUFILE_READ : CUFILE_WRITE;
-            params.cookie = (void*)0;
+            params.cookie =
+                reinterpret_cast<void*>(static_cast<std::uintptr_t>(task_id));
             params.u.batch.devPtr_base = request.source;
             params.u.batch.devPtr_offset = offset;
             params.u.batch.file_offset = request.target_offset + offset;
@@ -315,26 +318,38 @@ Status GdsTransport::getTransferStatus(SubBatchRef batch, int task_id,
     unsigned num_tasks = gds_batch->io_param_ranges.size();
     if (task_id < 0 || task_id >= (int)num_tasks)
         return Status::InvalidArgument("Invalid task ID");
-    auto range = gds_batch->io_param_ranges[task_id];
+    unsigned num_events = static_cast<unsigned>(gds_batch->io_params.size());
     auto result =
-        cuFileBatchIOGetStatus(gds_batch->batch_handle->handle, 0, &num_tasks,
+        cuFileBatchIOGetStatus(gds_batch->batch_handle->handle, 0, &num_events,
                                gds_batch->io_events.data(), nullptr);
     if (result.err != CU_FILE_SUCCESS)
         return Status::InternalError(
             std::string("Failed to get GDS batch status: Code ") +
             std::to_string(result.err) + LOC_MARK);
-    status.s = PENDING;
-    size_t complete_count = 0;
-    for (size_t index = range.base; index < range.base + range.count; ++index) {
+
+    for (size_t index = 0; index < num_events; ++index) {
         auto& event = gds_batch->io_events[index];
+        auto event_task_id = reinterpret_cast<std::uintptr_t>(event.cookie);
+        if (event_task_id >= gds_batch->io_param_ranges.size()) {
+            LOG(ERROR) << "Invalid GDS batch IO cookie: " << event_task_id;
+            continue;
+        }
+
+        auto& range = gds_batch->io_param_ranges[event_task_id];
+        if (range.status != PENDING) continue;
+
         auto s = parseTransferStatus(event.status);
-        if (s == COMPLETED)
-            complete_count++;
-        else if (s != PENDING)
-            status.s = s;
-        status.transferred_bytes += event.ret;
+        if (s == COMPLETED) {
+            range.complete_count++;
+            range.transferred_bytes += event.ret;
+            if (range.complete_count == range.count) range.status = COMPLETED;
+        } else if (s != PENDING) {
+            range.status = s;
+        }
     }
-    if (complete_count == range.count) status.s = COMPLETED;
+
+    auto& range = gds_batch->io_param_ranges[task_id];
+    status = TransferStatus{range.status, range.transferred_bytes};
     return Status::OK();
 }
 

--- a/mooncake-transfer-engine/tent/src/transport/gds/gds_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/gds/gds_transport.cpp
@@ -340,15 +340,15 @@ Status GdsTransport::getTransferStatus(SubBatchRef batch, int task_id,
         if (s == COMPLETED) {
             range.complete_count++;
             range.transferred_bytes += event.ret;
-            if (range.status == PENDING && range.complete_count == range.count) {
-                range.status = COMPLETED;
-            }
         } else if (s != PENDING) {
             range.status = s;
         }
     }
 
     auto& range = gds_batch->io_param_ranges[task_id];
+    if (range.complete_count == range.count) {
+        range.status = COMPLETED;
+    }
     status = TransferStatus{range.status, range.transferred_bytes};
     return Status::OK();
 }

--- a/mooncake-transfer-engine/tent/src/transport/gds/gds_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/gds/gds_transport.cpp
@@ -336,13 +336,13 @@ Status GdsTransport::getTransferStatus(SubBatchRef batch, int task_id,
         }
 
         auto& range = gds_batch->io_param_ranges[event_task_id];
-        if (range.status != PENDING) continue;
-
         auto s = parseTransferStatus(event.status);
         if (s == COMPLETED) {
             range.complete_count++;
             range.transferred_bytes += event.ret;
-            if (range.complete_count == range.count) range.status = COMPLETED;
+            if (range.status == PENDING && range.complete_count == range.count) {
+                range.status = COMPLETED;
+            }
         } else if (s != PENDING) {
             range.status = s;
         }


### PR DESCRIPTION
## Description



Fix the incorrect handling of `cuFileBatchIOGetStatus()` semantics in the TENT GDS transport.

`cuFileBatchIOGetStatus()` retrieves **available completion events** rather than returning a positional status array corresponding to the submitted `CUfileIOParams_t` entries. Its `nr` argument represents the event-buffer capacity on input and the number of returned events on output. (ref: https://docs.nvidia.com/gpudirect-storage/api-reference-guide/index.html#cufilebatchiogetstatus)


## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



**Test commands:**
```bash
./build/mooncake-transfer-engine/benchmark/tebench \
  --backend=tent \
  --xport_type=gds \
  --seg_type=VRAM \
  --target_seg_name=file://<path/to/file> \
  --op_type=write \
  --local_gpu_id=0 \
  --total_buffer_size=1073741824 \
  --start_block_size=131072 \
  --max_block_size=131072 \
  --start_batch_size=1 \
  --max_batch_size=32 \
  --start_num_threads=1 \
  --max_num_threads=1 \
  --duration=5
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

```
I0715 02:08:35.537213 23241 transfer_engine_impl.cpp:394] TENT Metrics system initialized
I0715 02:08:35.537220 23241 transfer_engine_impl.cpp:411] Transfer Engine 10.0.2.196:16914 started successfully
I0715 02:08:35.577450 23241 tent_backend.cpp:181] Allocated 1073741824 bytes VRAM buffers in 0.47733 ms, registered in 39.7318 ms
BlkSize (B)   Batch   BW (GB/S)     Avg Lat (us)  Avg Tx (us)   P99 Tx (us)   P999 Tx (us)  
----------------------------------------------------------------------------------------------------------------------------------------------------------------
I0715 02:08:35.577541 23241 segment_manager.cpp:56] Opened segment #1: file:///mnt/nvme2n1/tebench_gds
131072        1       2.281926      57.4          56.6          62.0          65.0          
131072        2       2.435615      107.6         106.8         121.0         251.2         
131072        4       2.993483      175.1         174.2         187.0         270.0         
131072        8       3.118137      336.3         335.2         343.0         481.1         
131072        16      3.120948      672.0         670.3         705.0         22378.2       
131072        32      3.369203      1244.9        1242.6        1314.0        2537.2  
```



## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [x] AI tools were used (specify below)

We identified this bug with GPT-5.5 while analyzing a failure when running tebench with the gds transport and a large batch size (batch size > 1).