### PR TITLE
[Store] Free SPDK client buffer with spdk_free on NOF exit (#2913)

### DIFF
--- a/mooncake-store/include/utils.h
+++ b/mooncake-store/include/utils.h
@@ -461,7 +461,8 @@ void* allocate_buffer_numa_segments(size_t total_size,
                                     const std::vector<int>& numa_nodes,
                                     size_t page_size = 0);
 
-void free_memory(const std::string& protocol, void* ptr);
+void free_memory(const std::string& protocol, void* ptr,
+                 bool use_spdk_dma = false);
 
 // Network utility functions
 

--- a/mooncake-store/src/client_buffer.cpp
+++ b/mooncake-store/src/client_buffer.cpp
@@ -80,7 +80,7 @@ ClientBufferAllocator::~ClientBufferAllocator() {
         if (use_hugepage_) {
             free_buffer_mmap_memory(buffer_, buffer_size_);
         } else {
-            free_memory(protocol, buffer_);
+            free_memory(protocol, buffer_, use_spdk_dma_);
         }
     }
 }

--- a/mooncake-store/src/utils.cpp
+++ b/mooncake-store/src/utils.cpp
@@ -528,7 +528,7 @@ void *allocate_buffer_numa_segments(size_t total_size,
     return ptr;
 }
 
-void free_memory(const std::string &protocol, void *ptr) {
+void free_memory(const std::string &protocol, void *ptr, bool use_spdk_dma) {
 #if defined(USE_ASCEND_DIRECT) || defined(USE_UBSHMEM)
     if (protocol == "ascend" || protocol == "ubshmem") {
         return ascend_free_memory(protocol, ptr);
@@ -542,6 +542,15 @@ void free_memory(const std::string &protocol, void *ptr) {
 #if defined(USE_UB)
     if (protocol == "ub") {
         mooncake::ub_free_memory(ptr);
+        return;
+    }
+#endif
+#ifdef USE_NOF
+    // Mirror allocate_buffer_allocator_memory(): a buffer taken from the SPDK
+    // hugepage pool (spdk_zmalloc) must be released with spdk_free, not glibc
+    // free(), which would abort with "free(): invalid pointer".
+    if (use_spdk_dma) {
+        mooncake::SpdkWrapper::GetInstance().Free(ptr);
         return;
     }
 #endif


### PR DESCRIPTION
## Description

Fixes #2913. When built with `USE_NOF`, `mooncake_master`'s Python SDK client aborts on exit with `free(): invalid pointer` whenever `local_buffer_size > 0`.

`ClientBufferAllocator` takes its local buffer from the SPDK hugepage pool — `allocate_buffer_allocator_memory()` calls `SpdkWrapper::Alloc()` (`spdk_zmalloc`) under `#ifdef USE_NOF` when `use_spdk_dma` is set. But the destructor routed every non-hugepage buffer through `free_memory()`, whose fallback is glibc `free()`. Releasing SPDK/DPDK memory with `free()` makes glibc abort with `free(): invalid pointer`. The three pieces needed to fix this already existed but were never wired together: the `use_spdk_dma_` member on the allocator, `SpdkWrapper::Free()` (which calls `spdk_free`), and the destructor's `if/else`.

The fix makes `free_memory()` the exact inverse of `allocate_buffer_allocator_memory()`: it gains a `use_spdk_dma` flag and, after the `ascend`/`sunrise`/`ub` protocol branches (so those still take priority exactly as they do on the allocation side), releases the buffer via `SpdkWrapper::Free()`. The destructor forwards its existing `use_spdk_dma_` member. Putting the SPDK branch inside `free_memory()` rather than the destructor keeps the free path symmetric with the alloc path even if a build combines `USE_NOF` with `USE_ASCEND_DIRECT` and an `ascend` protocol — that buffer is `ascend`-allocated, and `free_memory()` still `ascend`-frees it. The flag defaults to `false`, so non-`USE_NOF` builds and every other `free_memory()` call site are unchanged.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

`USE_NOF` needs an SPDK/EBOF target, which I don't have locally, so I verified the fix with a standalone program that reproduces the exact branch structure of `allocate_buffer_allocator_memory()` and `free_memory()` with a stub SPDK pool that aborts if SPDK memory reaches glibc `free()`:

- **Reproduces the bug**: a `tcp`-protocol buffer allocated via the SPDK branch, freed by the old `free_memory()`, aborts with `free(): invalid pointer` (SIGABRT) — matching the report.
- **Fix routes correctly**: the same buffer freed by the new `free_memory(protocol, ptr, use_spdk_dma=true)` goes through `spdk_free`, no abort, no pool leak.
- **Symmetry holds**: with `USE_NOF` + `USE_ASCEND_DIRECT` and an `ascend` buffer (allocated on the ascend path, `use_spdk_dma` still true), the new `free_memory()` takes the `ascend` branch first and does not mis-route to `spdk_free`.

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (standalone branch-logic repro, described above)

I didn't add a repo unit test because the path is `USE_NOF`-gated and `SpdkWrapper` performs real SPDK init, so it can't run in CI without SPDK hardware. Happy to add a test that mocks `SpdkWrapper::Free` to assert the destructor calls it if you'd prefer one.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh` — `clang-format` isn't available in my environment; I matched the repo's `.clang-format` (Google, 4-space indent, 80 columns) by hand
- [ ] I have run `pre-commit run --all-files` and all hooks pass — toolchain unavailable locally; please let CI run it
- [ ] I have updated the documentation (if applicable) — no doc change needed
- [ ] I have added tests to prove my changes are effective — see the note above re: SPDK-gated path
- [x] For changes >500 LOC: I have filed an RFC issue — N/A (13 lines)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Claude Code assisted while writing this fix. I've reviewed every changed line, verified the alloc/free symmetry and the standalone repro myself, and can defend the change end-to-end.