### PR TITLE
[Store] fix GPU-addressed local copy crashes

### DIFF
--- a/mooncake-store/src/device/accelerator_registry.cpp
+++ b/mooncake-store/src/device/accelerator_registry.cpp
@@ -7,6 +7,12 @@
 
 namespace mooncake {
 namespace device {
+
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA) || \
+    defined(USE_HYGON) || defined(USE_COREX)
+void EnsureCudaLikeAcceleratorDeviceLinked();
+#endif
+
 namespace {
 
 void RegisterStaticAcceleratorDevice(const AcceleratorDevice& device);
@@ -90,6 +96,10 @@ void RegisterStaticAcceleratorDevice(const AcceleratorDevice& device) {
 }  // namespace
 
 const AcceleratorRegistry& GetAcceleratorRegistry() {
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA) || \
+    defined(USE_HYGON) || defined(USE_COREX)
+    EnsureCudaLikeAcceleratorDeviceLinked();
+#endif
     return MutableRegistry();
 }
 

--- a/mooncake-store/src/device/cuda_like_accelerator_device.cpp
+++ b/mooncake-store/src/device/cuda_like_accelerator_device.cpp
@@ -8,6 +8,9 @@
 
 namespace mooncake {
 namespace device {
+
+void EnsureCudaLikeAcceleratorDeviceLinked() {}
+
 namespace {
 
 void FreeCudaLikePinnedHostBuffer(void* addr) { cudaFreeHost(addr); }

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -279,6 +279,18 @@ inline tl::expected<void, ErrorCode> scatter_host_to_maybe_device(
     return {};
 }
 
+// Gather memory that may be GPU or host into a host destination.
+inline tl::expected<void, ErrorCode> gather_maybe_device_to_host(
+    void *dst, const void *src, size_t size, const std::string &context) {
+    auto runtime_accelerator =
+        device::GetAcceleratorRegistry().RuntimeAccelerators();
+    if (!runtime_accelerator.CopyToHost(dst, src, size)) {
+        LOG(ERROR) << "D2H copy failed: " << context;
+        return tl::unexpected(ErrorCode::TRANSFER_FAIL);
+    }
+    return {};
+}
+
 // SelectBestReplica and the replica-scoring helpers live in
 // replica_selection.h (included above) so they can be unit-tested directly.
 using mooncake::SelectBestReplica;
@@ -1758,7 +1770,7 @@ tl::expected<void, ErrorCode> RealClient::put_internal(
         return tl::unexpected(ErrorCode::INVALID_PARAMS);
     }
     auto &buffer_handle = *alloc_result;
-    auto scatter_result = scatter_host_to_maybe_device(
+    auto scatter_result = gather_maybe_device_to_host(
         buffer_handle.ptr(), value.data(), value.size_bytes(), "put:" + key);
     if (!scatter_result) {
         return tl::unexpected(scatter_result.error());
@@ -1840,7 +1852,7 @@ tl::expected<void, ErrorCode> RealClient::put_batch_internal(
             return tl::unexpected(ErrorCode::INVALID_PARAMS);
         }
         auto &buffer_handle = *alloc_result;
-        auto scatter_result = scatter_host_to_maybe_device(
+        auto scatter_result = gather_maybe_device_to_host(
             buffer_handle.ptr(), value.data(), value.size_bytes(),
             "put_batch:" + key);
         if (!scatter_result) {
@@ -1949,7 +1961,7 @@ tl::expected<void, ErrorCode> RealClient::put_parts_internal(
     // Copy all parts into the contiguous buffer
     size_t offset = 0;
     for (const auto &value : values) {
-        auto scatter_result = scatter_host_to_maybe_device(
+        auto scatter_result = gather_maybe_device_to_host(
             static_cast<char *>(buffer_handle.ptr()) + offset, value.data(),
             value.size_bytes(), "put_multi_value");
         if (!scatter_result) {
@@ -3267,9 +3279,42 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
             return static_cast<int64_t>(total_size);
         }
 
+        auto runtime_accelerator =
+            device::GetAcceleratorRegistry().RuntimeAccelerators();
+        void *dst = static_cast<char *>(buffer) + dst_offset;
+        if (runtime_accelerator.FindDeviceForPointer(dst)) {
+            if (!client_buffer_allocator_) {
+                LOG(ERROR) << "Client buffer allocator is not provided";
+                return tl::unexpected(ErrorCode::INVALID_PARAMS);
+            }
+            auto alloc_result = client_buffer_allocator_->allocate(total_size);
+            if (!alloc_result) {
+                LOG(ERROR) << "Failed to allocate temp buffer for GPU memory "
+                           << "read, key: " << key << ", size: " << total_size;
+                return tl::unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
+            }
+            BufferHandle tmp_handle(std::move(*alloc_result));
+            std::vector<mooncake::Slice> tmp_slices;
+            allocateSlices(tmp_slices, replica, tmp_handle.ptr());
+
+            auto filtered_qr = FilterQueryResult(query_result, replica);
+            auto get_result = client_->Get(key, filtered_qr, tmp_slices);
+            if (!get_result) {
+                LOG(ERROR) << "Get failed for key: " << key
+                           << " with error: " << toString(get_result.error());
+                return tl::unexpected(get_result.error());
+            }
+            if (auto r = scatter_host_to_maybe_device(
+                    dst, tmp_handle.ptr(), total_size,
+                    "MEMORY full read, key: " + key);
+                !r) {
+                return tl::unexpected(r.error());
+            }
+            return static_cast<int64_t>(total_size);
+        }
+
         std::vector<mooncake::Slice> slices;
-        allocateSlices(slices, replica,
-                       static_cast<char *>(buffer) + dst_offset);
+        allocateSlices(slices, replica, dst);
 
         auto filtered_qr = FilterQueryResult(query_result, replica);
         auto get_result = client_->Get(key, filtered_qr, slices);
@@ -3353,8 +3398,39 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
         return tl::unexpected(ErrorCode::INVALID_REPLICA);
     }
 
+    auto runtime_accelerator =
+        device::GetAcceleratorRegistry().RuntimeAccelerators();
+    void *dst = static_cast<char *>(buffer) + dst_offset;
+    if (runtime_accelerator.FindDeviceForPointer(dst)) {
+        if (!client_buffer_allocator_) {
+            LOG(ERROR) << "Client buffer allocator is not provided";
+            return tl::unexpected(ErrorCode::INVALID_PARAMS);
+        }
+        auto alloc_result = client_buffer_allocator_->allocate(size);
+        if (!alloc_result) {
+            LOG(ERROR) << "Failed to allocate temp buffer for GPU ranged "
+                       << "read, key: " << key << ", size: " << size;
+            return tl::unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
+        }
+        BufferHandle tmp_handle(std::move(*alloc_result));
+        std::vector<Slice> tmp_slices;
+        tmp_slices.emplace_back(Slice{tmp_handle.ptr(), size});
+
+        auto get_result =
+            client_->Get(key, query_result, tmp_slices, src_offset);
+        if (!get_result) {
+            return tl::unexpected(get_result.error());
+        }
+        if (auto r = scatter_host_to_maybe_device(
+                dst, tmp_handle.ptr(), size, "MEMORY ranged read, key: " + key);
+            !r) {
+            return tl::unexpected(r.error());
+        }
+        return static_cast<int64_t>(size);
+    }
+
     std::vector<Slice> slices;
-    slices.emplace_back(Slice{static_cast<char *>(buffer) + dst_offset, size});
+    slices.emplace_back(Slice{dst, size});
 
     auto get_result = client_->Get(key, query_result, slices, src_offset);
     if (!get_result) {
@@ -3789,7 +3865,7 @@ tl::expected<void, ErrorCode> RealClient::upsert_internal(
         return tl::unexpected(ErrorCode::INVALID_PARAMS);
     }
     auto &buffer_handle = *alloc_result;
-    auto scatter_result = scatter_host_to_maybe_device(
+    auto scatter_result = gather_maybe_device_to_host(
         buffer_handle.ptr(), value.data(), value.size_bytes(), "upsert:" + key);
     if (!scatter_result) {
         return tl::unexpected(scatter_result.error());
@@ -4025,7 +4101,7 @@ tl::expected<void, ErrorCode> RealClient::upsert_parts_internal(
     auto &buffer_handle = *alloc_result;
     size_t offset = 0;
     for (const auto &value : values) {
-        auto scatter_result = scatter_host_to_maybe_device(
+        auto scatter_result = gather_maybe_device_to_host(
             static_cast<char *>(buffer_handle.ptr()) + offset, value.data(),
             value.size_bytes(), "upsert_parts:" + key);
         if (!scatter_result) {
@@ -4113,7 +4189,7 @@ tl::expected<void, ErrorCode> RealClient::upsert_batch_internal(
             return tl::unexpected(ErrorCode::INVALID_PARAMS);
         }
         auto &buffer_handle = *alloc_result;
-        auto scatter_result = scatter_host_to_maybe_device(
+        auto scatter_result = gather_maybe_device_to_host(
             buffer_handle.ptr(), value.data(), value.size_bytes(),
             "upsert_batch:" + key);
         if (!scatter_result) {

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -1852,9 +1852,9 @@ tl::expected<void, ErrorCode> RealClient::put_batch_internal(
             return tl::unexpected(ErrorCode::INVALID_PARAMS);
         }
         auto &buffer_handle = *alloc_result;
-        auto scatter_result = gather_maybe_device_to_host(
-            buffer_handle.ptr(), value.data(), value.size_bytes(),
-            "put_batch:" + key);
+        auto scatter_result =
+            gather_maybe_device_to_host(buffer_handle.ptr(), value.data(),
+                                        value.size_bytes(), "put_batch:" + key);
         if (!scatter_result) {
             return tl::unexpected(scatter_result.error());
         }

--- a/mooncake-wheel/tests/test_put_get_tensor.py
+++ b/mooncake-wheel/tests/test_put_get_tensor.py
@@ -5,6 +5,12 @@ import os
 import time
 import threading
 import random
+
+try:
+    import torch as _torch
+except Exception:
+    _torch = None
+
 from mooncake.store import MooncakeDistributedStore
 
 # The lease time of the kv object, should be set equal to
@@ -12,6 +18,9 @@ from mooncake.store import MooncakeDistributedStore
 DEFAULT_DEFAULT_KV_LEASE_TTL = 5000 # 5000 milliseconds
 # Use environment variable if set, otherwise use default
 default_kv_lease_ttl = int(os.getenv("DEFAULT_KV_LEASE_TTL", DEFAULT_DEFAULT_KV_LEASE_TTL))
+
+def cuda_available():
+    return _torch is not None and _torch.cuda.is_available()
 
 # Define a test class for serialization
 class TestClass:
@@ -118,6 +127,32 @@ class TestDistributedObjectStore(unittest.TestCase):
         self.store.remove(key_int)
         self.store.remove(key_bool)
         self.store.remove(key_rand)
+
+    @unittest.skipUnless(cuda_available(), "CUDA is not available")
+    def test_cuda_local_copy_paths(self):
+        """Test CUDA source writes and CUDA destination reads."""
+        import torch
+
+        prefix = f"test_cuda_local_copy_{os.getpid()}"
+        put_key = f"{prefix}_put"
+        upsert_key = f"{prefix}_upsert"
+        raw_key = f"{prefix}_raw"
+
+        tensor = torch.arange(16, dtype=torch.float32, device="cuda")
+        self.assertEqual(self.store.put_tensor(put_key, tensor), 0)
+        self.assertEqual(self.store.upsert_tensor(upsert_key, tensor), 0)
+
+        raw = bytes(range(32))
+        self.assertEqual(self.store.put(raw_key, raw), 0)
+
+        dst = torch.empty(len(raw), dtype=torch.uint8, device="cuda")
+        self.assertEqual(self.store.get_into(raw_key, dst.data_ptr(), len(raw)), len(raw))
+        expected = torch.tensor(list(raw), dtype=torch.uint8, device="cuda")
+        self.assertTrue(torch.equal(dst, expected))
+
+        self.store.remove(put_key)
+        self.store.remove(upsert_key)
+        self.store.remove(raw_key)
 
     def test_put_get_tensor_with_metadata(self):
         """Test storing and retrieving PyTorch tensors with metadata using put_tensor_with_metadata/get_tensor_with_metadata."""


### PR DESCRIPTION
## Description

Fix crashes when Mooncake Store local copy paths receive CUDA-addressed source or destination buffers.

The tensor API is one reproducer, but the affected scope is lower than tensor-only APIs. On current upstream `origin/main`, local Store copy paths can still reach host `memcpy` with CUDA pointers, which crashes for both GPU-source writes and GPU-destination reads.

This PR fixes the issue by:

- Forcing the CUDA-like accelerator device object to be linked into the Python module, so CUDA pointer copies can use the accelerator registry instead of falling back to host `memcpy`.
- Making host-staging write paths use D2H-aware gather logic:
  - `put`
  - `put_batch`
  - `put_parts`
  - `upsert`
  - `upsert_parts`
  - `upsert_batch`
- Making local MEMORY `get_into` / `get_into_ranges` avoid direct host `memcpy` into CUDA destinations by using a CPU temporary buffer plus H2D scatter.
- Keeping direct `put_from` / `batch_put_from` paths unchanged; they are covered by the CUDA accelerator registration/linkage fix.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Verified in a clean checkout by comparing current upstream `origin/main` with `origin/main` plus this single patch.

Manual CUDA smoke cases:

```text
1. GPU-source tensor write
   - Create a CUDA tensor.
   - Write it through the Store tensor API.

2. GPU-destination read
   - Write an object from CPU memory.
   - Read it into a CUDA destination pointer.

3. Direct GPU-source put_from
   - Call put_from() with a CUDA source pointer.

4. Batched direct GPU write/read
   - Batch-write CUDA-backed objects.
   - Batch-read them into CUDA destination buffers.
```

**Test commands:**

```bash
cmake -S . -B build -G Ninja \
  -DCMAKE_BUILD_TYPE=Release \
  -DBUILD_UNIT_TESTS=OFF \
  -DBUILD_BENCHMARK=ON \
  -DBUILD_EXAMPLES=ON \
  -DCUDAToolkit_ROOT=/usr/local/cuda

cmake --build build --target store mooncake_client mooncake_master -j$(nproc)
```

**Test results:**

- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

Baseline on upstream `origin/main`:

```text
GPU-source tensor write:
Segmentation fault, rc=139

GPU-destination read:
Segmentation fault, rc=139
```

After applying this patch:

```text
GPU-source tensor write:
put ret 0, rc=0

GPU-destination read:
get ret 16777216, rc=0

Direct GPU-source put_from:
put_from ret 0, rc=0

Batched direct GPU write/read:
batch_put_from ret [0, 0]
batch_get_into ret [8388608, 8388608]
rc=0

git diff --check HEAD~1..HEAD:
pass
```

Build notes:

```text
Build passed. Existing third-party / LTO warnings were emitted from pybind11, async_simple, and struct_pack paths.
```

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

Notes:

- No repository test file is added in this PR; validation was done with manual CUDA smoke cases.
- This PR is below 500 LOC.

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex was used to inspect the affected Store copy paths, prepare the patch, and run manual validation. I am responsible for reviewing, understanding, and maintaining the change.