### PR TITLE
[Store] Serialize ssd_total_capacity_bytes in local disk snapshot (#2783)

### DIFF
--- a/mooncake-store/src/segment.cpp
+++ b/mooncake-store/src/segment.cpp
@@ -680,7 +680,9 @@ SegmentSerializer::Serialize() {
         }
         std::sort(sorted_keys.begin(), sorted_keys.end());
 
-        packer.pack_array(2 + sorted_keys.size() * 2);
+        // Trailing ssd_total_capacity_bytes so a restored master keeps the
+        // client-reported SSD capacity across a snapshot restore (#2783).
+        packer.pack_array(2 + sorted_keys.size() * 2 + 1);
         packer.pack(segment->enable_offloading);
         packer.pack(static_cast<uint64_t>(sorted_keys.size()));
 
@@ -692,6 +694,7 @@ SegmentSerializer::Serialize() {
             packer.pack(task.key);
             packer.pack(task.size);
         }
+        packer.pack(segment->ssd_total_capacity_bytes);
     }
 
     // Compress entire data
@@ -1087,6 +1090,17 @@ tl::expected<void, SerializationError> SegmentSerializer::Deserialize(
                                         .key = std::move(user_key),
                                         .size = task_obj.as<int64_t>()};
                 }
+            }
+
+            // ssd_total_capacity_bytes is appended after the offloading
+            // objects. Pre-#2783 snapshots omit it, so read it only when
+            // present; otherwise it keeps the default 0 until the client
+            // re-reports capacity.
+            size_t capacity_idx = 2 + count * 2;
+            if (client_value.via.array.size > capacity_idx &&
+                IsMsgpackInteger(client_value.via.array.ptr[capacity_idx])) {
+                segment->ssd_total_capacity_bytes =
+                    client_value.via.array.ptr[capacity_idx].as<int64_t>();
             }
 
             segment_manager_->client_local_disk_segment_[client_id] =


### PR DESCRIPTION
## Description

Fixes #2783. After a master restart with snapshot restore, the SSD **total** capacity in metrics drops to `0 B` (the used-bytes numerator stays correct), and it stays wrong until the client also restarts and re-runs `FileStorage::Init`:

```
Before restart: SSD Storage: 400MB / 2TB
After restart:  SSD Storage: 400MB / 0 B
```

`SegmentSerializer` packs a `LocalDiskSegment` as `[enable_offloading, count, key1, task1, ...]` and never includes `ssd_total_capacity_bytes`, so a segment rebuilt from a snapshot keeps its default `0` until the next client heartbeat that carries capacity (which today only happens on client re-init).

This appends `ssd_total_capacity_bytes` to the packed array and reads it back when present. Snapshots written before this change lack the trailing field, so `Deserialize` reads it only when `array.size` extends past the offloading objects; older snapshots deserialize exactly as before (capacity stays `0` until the client re-reports it). The format bump is therefore backward compatible — this mirrors the existing legacy-format handling already in `Deserialize`.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

The change is confined to the msgpack serialize/deserialize path, so I verified it with a standalone program that replicates the exact `LocalDiskSegment` pack/unpack logic:

- **New format round-trips capacity**: a segment serialized with the trailing field deserializes back with `ssd_total_capacity_bytes` intact (2 TiB in the test).
- **Old format is backward compatible**: a segment serialized *without* the field (pre-fix snapshot) deserializes with `enable_offloading` and the offloading objects intact and capacity `0` — reproducing the pre-fix behavior without crashing on the shorter array.
- **Empty-objects edge case**: with no offloading objects the capacity sits at index `2` and still round-trips.

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (standalone serialize/deserialize round-trip, described above)

I didn't wire a repo test through the full snapshot child-process harness (it needs a Linux/etcd environment I can't run locally), but I'm happy to add a `SegmentSerializer` round-trip test asserting capacity survives if you'd like one in-tree.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh` — `clang-format` isn't available in my environment; I matched `.clang-format` (Google, 4-space, 80 cols) by hand
- [ ] I have run `pre-commit run --all-files` and all hooks pass — toolchain unavailable locally; please let CI run it
- [ ] I have updated the documentation (if applicable) — no doc change needed
- [ ] I have added tests to prove my changes are effective — see the standalone verification note above
- [x] For changes >500 LOC: I have filed an RFC issue — N/A (12 lines)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Claude Code assisted while writing this fix. I've reviewed every changed line, traced the serialize/deserialize indices myself, and verified the round-trip and backward-compatibility with the standalone described above.