### PR TITLE
[CI] Align pre-release artifact names with release naming

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -28,7 +28,7 @@ jobs:
       cmake-args: >-
         -DBUILD_UNIT_TESTS=OFF -DUSE_HTTP=ON -DUSE_ETCD=ON -DUSE_CUDA=ON
         -DWITH_EP=ON -DSTORE_USE_ETCD=ON -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Release
-      artifact-prefix: pre-release-cuda
+      artifact-prefix: mooncake-wheel-pre-release
 
   build-non-cuda:
     uses: ./.github/workflows/_build-wheel.yaml
@@ -41,7 +41,7 @@ jobs:
       cmake-args: >-
         -DUSE_HTTP=ON -DUSE_ETCD=ON -DUSE_CUDA=OFF -DWITH_EP=OFF
         -DSTORE_USE_ETCD=ON -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Release
-      artifact-prefix: pre-release-non-cuda
+      artifact-prefix: mooncake-wheel-non-cuda-pre-release
 
   build-cuda13:
     uses: ./.github/workflows/_build-wheel.yaml
@@ -57,7 +57,7 @@ jobs:
       cmake-args: >-
         -DBUILD_UNIT_TESTS=OFF -DUSE_HTTP=ON -DUSE_ETCD=ON -DUSE_CUDA=ON
         -DWITH_EP=ON -DSTORE_USE_ETCD=ON -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Release
-      artifact-prefix: pre-release-cuda13
+      artifact-prefix: mooncake-wheel-cuda13-pre-release
 
   build-cuda-arm64:
     uses: ./.github/workflows/_build-wheel.yaml
@@ -69,7 +69,7 @@ jobs:
       cmake-args: >-
         -DUSE_HTTP=ON -DUSE_CUDA=ON -DUSE_MNNVL=ON -DWITH_EP=OFF
         -DWITH_STORE_RUST=OFF -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Release
-      artifact-prefix: pre-release-cuda-arm64
+      artifact-prefix: mooncake-wheel-arm64-pre-release
 
   build-cuda13-arm64:
     uses: ./.github/workflows/_build-wheel.yaml
@@ -82,7 +82,7 @@ jobs:
       cmake-args: >-
         -DUSE_HTTP=ON -DUSE_CUDA=ON -DUSE_MNNVL=ON -DWITH_EP=OFF
         -DWITH_STORE_RUST=OFF -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Release
-      artifact-prefix: pre-release-cuda13-arm64
+      artifact-prefix: mooncake-wheel-cuda13-arm64-pre-release
 
   validate-release:
     name: Validate release artifacts
@@ -98,7 +98,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: mooncake-wheel/dist-all
-          pattern: pre-release-*
+          pattern: mooncake-wheel*pre-release*
 
       - name: Prepare wheels for validation
         run: |
@@ -127,7 +127,7 @@ jobs:
       - name: Upload validated wheels as workflow artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: pre-release-wheels-${{ github.ref_name }}
+          name: mooncake-wheels-pre-release-${{ github.ref_name }}
           path: mooncake-wheel/dist-release/*.whl
           retention-days: 14
 


### PR DESCRIPTION
## Summary
- Rename pre-release workflow artifacts from `pre-release-*` to `mooncake-wheel-*-pre-release`, mirroring formal release naming.
- Update artifact download pattern and bundled upload name to match the new convention.

## Module
- [x] CI/CD

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?
Workflow YAML change only; no runtime tests run locally.

**Test plan**
- [ ] Push a pre-release tag (e.g. `v*-rc*`) and confirm build artifacts appear as `mooncake-wheel-*-pre-release-py*`
- [ ] Confirm validate job downloads artifacts via `mooncake-wheel*pre-release*` and uploads `mooncake-wheels-pre-release-${tag}`

## AI Assistance
- [x] AI-assisted (Cursor)
- Human reviewed all changed lines before submission.


Made with [Cursor](https://cursor.com)