### PR TITLE
[TransferEngine] Add NVLink VMM Fabric memory lifecycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -379,7 +379,7 @@ jobs:
         sudo bash -x dependencies.sh -y
         mkdir build
         cd build
-        cmake -G Ninja .. -DUSE_HTTP=ON -DUSE_CUDA=ON -DUSE_MNNVL=ON -DWITH_EP=OFF -DWITH_STORE_RUST=OFF -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Release
+        cmake -G Ninja .. -DUSE_HTTP=ON -DUSE_CUDA=ON -DUSE_MNNVL=ON -DUSE_EVENT_DRIVEN_COMPLETION=ON -DWITH_EP=OFF -DWITH_STORE_RUST=OFF -DBUILD_UNIT_TESTS=ON -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Release
       shell: bash
 
     - name: Build project
@@ -393,6 +393,39 @@ jobs:
         cd build
         cmake --build .
         sudo cmake --install .
+      shell: bash
+
+    - name: Gate NVLink VMM unit tests
+      run: |
+        cuda_driver_stub=""
+        for stub_dir in /usr/local/cuda/lib64/stubs /usr/local/cuda/targets/*/lib/stubs; do
+          if [ -f "$stub_dir/libcuda.so" ]; then
+            cuda_driver_stub="$stub_dir/libcuda.so"
+            break
+          fi
+        done
+        if [ -z "$cuda_driver_stub" ]; then
+          echo "::error::CUDA driver stub libcuda.so was not found"
+          exit 1
+        fi
+
+        cuda_driver_stub_runtime="$RUNNER_TEMP/cuda-driver-stubs"
+        mkdir -p "$cuda_driver_stub_runtime"
+        cp -L "$cuda_driver_stub" "$cuda_driver_stub_runtime/libcuda.so.1"
+        export LD_LIBRARY_PATH="$cuda_driver_stub_runtime:$(dirname "$cuda_driver_stub"):/usr/local/cuda/lib64:/usr/local/lib:${LD_LIBRARY_PATH:-}"
+
+        cd build
+        discovered_tests="$(ctest -N -L nvlink_vmm_unit)"
+        printf '%s\n' "$discovered_tests"
+        test_count="$(
+          awk '$1 == "Total" && $2 == "Tests:" {print $3}' \
+            <<<"$discovered_tests"
+        )"
+        if [[ ! "$test_count" =~ ^[1-9][0-9]*$ ]]; then
+          echo "::error::No nvlink_vmm_unit tests were discovered"
+          exit 1
+        fi
+        ctest -L nvlink_vmm_unit --output-on-failure
       shell: bash
 
     - name: Run sccache stat for check

--- a/mooncake-transfer-engine/include/multi_transport.h
+++ b/mooncake-transfer-engine/include/multi_transport.h
@@ -67,7 +67,18 @@ class MultiTransport {
      */
     bool isTcpOnly() const;
 
+    /**
+     * @brief Check the strict transport prerequisite for an EGM Store Pool.
+     *
+     * The V1 data path must publish only Fabric NVLink descriptors. A mixed
+     * auto-discovered transport set (for example RDMA plus NVLink) is rejected
+     * instead of silently selecting or publishing another protocol.
+     */
+    bool isNvlinkFabricTransportReady() const;
+
     std::vector<Transport *> listTransports();
+
+    void appendTransportMetrics(std::string &output);
 
     void *getBaseAddr();
 

--- a/mooncake-transfer-engine/include/transfer_engine.h
+++ b/mooncake-transfer-engine/include/transfer_engine.h
@@ -98,6 +98,8 @@ class TransferEngine {
 
     bool isUsingTent() const { return use_tent_; }
 
+    [[nodiscard]] bool isNvlinkFabricTransportReady() const;
+
     SegmentHandle openSegment(const std::string& segment_name);
 
     Status CheckSegmentStatus(SegmentID sid);
@@ -165,6 +167,8 @@ class TransferEngine {
     Status getBatchTransferStatus(BatchID batch_id, TransferStatus& status);
 
     Transport* getTransport(const std::string& proto);
+
+    void appendTransportMetrics(std::string& output);
 
 #if (defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA)) && \
     !defined(USE_CXI)

--- a/mooncake-transfer-engine/include/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/include/transfer_engine_impl.h
@@ -350,6 +350,17 @@ class TransferEngineImpl {
         return multi_transports_->getTransport(proto);
     }
 
+    void appendTransportMetrics(std::string& output) {
+        if (multi_transports_ != nullptr) {
+            multi_transports_->appendTransportMetrics(output);
+        }
+    }
+
+    [[nodiscard]] bool isNvlinkFabricTransportReady() const {
+        return multi_transports_ != nullptr &&
+               multi_transports_->isNvlinkFabricTransportReady();
+    }
+
 #if (defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA)) && \
     !defined(USE_CXI)
     // Device transport accessors — lazily created, owned by this impl.

--- a/mooncake-transfer-engine/include/transfer_metadata.h
+++ b/mooncake-transfer-engine/include/transfer_metadata.h
@@ -251,6 +251,8 @@ class TransferMetadata {
     void dumpMetadataContentUnlocked();
 
    private:
+    friend class TransferMetadataTestPeer;
+
     int encodeSegmentDesc(const SegmentDesc &desc, Json::Value &segmentJSON);
     std::shared_ptr<TransferMetadata::SegmentDesc> decodeSegmentDesc(
         Json::Value &segmentJSON, const std::string &segment_name);
@@ -268,6 +270,11 @@ class TransferMetadata {
     std::string common_key_prefix_;
     std::string rpc_meta_prefix_;
     // local cache
+    // Serializes every mutation/publication transaction for the local segment.
+    // The segment spinlock still protects short in-memory snapshots; this
+    // mutex may span metadata I/O so a failed publication can restore its COW
+    // snapshot before another registration changes it.
+    std::mutex local_segment_publish_mutex_;
     RWSpinlock segment_lock_;
     std::unordered_map<uint64_t, std::shared_ptr<SegmentDesc>>
         segment_id_to_desc_map_;

--- a/mooncake-transfer-engine/include/transport/nvlink_transport/nvlink_transport.h
+++ b/mooncake-transfer-engine/include/transport/nvlink_transport/nvlink_transport.h
@@ -5,18 +5,24 @@
 
 #include "cuda_alike.h"
 
+#include <array>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <iostream>
 #include <memory>
 #include <mutex>
 #include <queue>
 #include <string>
-#include <vector>
+#include <unordered_map>
 #include <utility>
+#include <vector>
 
 #include "common/hash_utils.h"
 #include "topology.h"
 #include "transfer_metadata.h"
+#include "transport/nvlink_transport/nvlink_vmm_allocation.h"
 #include "transport/transport.h"
 
 namespace mooncake {
@@ -38,9 +44,15 @@ class NvlinkTransport : public Transport {
     Status getTransferStatus(BatchID batch_id, size_t task_id,
                              TransferStatus& status) override;
 
+    void finalizeTransferResult(TransferTask& task, bool success) override;
+
+    void appendMetrics(std::string& output) override;
+
     static void* allocatePinnedLocalMemory(size_t length);
 
     static void freePinnedLocalMemory(void* addr);
+
+    [[nodiscard]] bool isFabricMemoryEnabled() const { return use_fabric_mem_; }
 
    protected:
     int install(std::string& local_server_name,
@@ -65,11 +77,44 @@ class NvlinkTransport : public Transport {
     const char* getName() const override { return "nvlink"; }
 
    private:
+    friend class NvlinkTransportTestPeer;
+
+    enum class ConsumerFailureStage {
+        IMPORT,
+        RESERVE,
+        MAP,
+        SET_ACCESS,
+        COPY,
+    };
+
+    struct ConsumerMetrics;
+
+    void observeCacheLookup(bool hit);
+    void observeLazyImportLatency(uint64_t duration_us);
+    void observeConsumerFailure(ConsumerFailureStage stage);
+    void observeTransferResult(TransferRequest::OpCode operation, bool success);
+    bool observeTransferResultOnce(TransferTask& task, bool success);
+    void finalizeSubmissionFailure(TransferTask& task, bool copy_failure);
+
     std::atomic_bool running_;
 
+    enum class OpenedMappingKind { IPC, FABRIC };
+
     struct OpenedShmEntry {
-        void* shm_addr;
-        uint64_t length;
+        void* shm_addr = nullptr;
+        uint64_t length = 0;
+        OpenedMappingKind kind = OpenedMappingKind::IPC;
+    };
+
+    struct LocalRegistration {
+        void* requested_addr = nullptr;
+        uint64_t requested_length = 0;
+        void* mapped_base = nullptr;
+        uint64_t mapped_length = 0;
+        bool remote_accessible = false;
+        bool published = false;
+        bool retained_handle_owned = false;
+        uint64_t retained_handle = 0;
     };
 
     std::unordered_map<std::pair<uint64_t, uint64_t>, OpenedShmEntry, PairHash>
@@ -78,6 +123,44 @@ class NvlinkTransport : public Transport {
     bool use_fabric_mem_;
 
     std::mutex register_mutex_;
+    std::unordered_map<void*, LocalRegistration> local_registrations_;
+    int publishLocalRegistration(void* registration_addr,
+                                 const BufferDesc& descriptor,
+                                 bool update_metadata);
+#if defined(USE_MNNVL) && defined(USE_CUDA)
+    NvlinkVmmAllocation::DriverApi fabric_driver_api_;
+    struct FabricMappingCleanup {
+        CUmemGenericAllocationHandle handle = 0;
+        CUdeviceptr address = 0;
+        size_t length = 0;
+        bool handle_owned = false;
+        bool address_reserved = false;
+        bool mapped = false;
+    };
+    class FabricMappingAttempt;
+    bool CleanupFabricMapping(FabricMappingCleanup& cleanup,
+                              const char* failure_stage) noexcept;
+    bool RetryQuarantinedFabricMappings() noexcept;
+    void ReleaseOrQuarantineFabricMapping(FabricMappingCleanup cleanup,
+                                          const char* failure_stage) noexcept;
+    static void PreserveProcessLifetimeFabricCleanup(
+        FabricMappingCleanup cleanup) noexcept;
+    std::vector<FabricMappingCleanup> quarantined_fabric_mappings_;
+    class RetainedHandleGuard;
+    bool RetryQuarantinedRetainedHandles();
+    void ReleaseOrQuarantineRetainedHandle(CUmemGenericAllocationHandle handle,
+                                           const char* failure_stage) noexcept;
+    std::vector<uint64_t> quarantined_retained_handles_;
+    static bool TrackPinnedVmmAllocation(
+        std::unique_ptr<NvlinkVmmAllocation> owner);
+    static bool ReleasePinnedVmmAllocation(void* ptr);
+#endif
+
+    std::function<int(const BufferDesc&, bool)> add_buffer_for_testing_;
+    std::function<int(void*, bool)> remove_buffer_for_testing_;
+    std::function<std::shared_ptr<SegmentDesc>(uint64_t)>
+        get_segment_for_testing_;
+    std::unique_ptr<ConsumerMetrics> consumer_metrics_;
 };
 
 }  // namespace mooncake

--- a/mooncake-transfer-engine/include/transport/nvlink_transport/nvlink_vmm_allocation.h
+++ b/mooncake-transfer-engine/include/transport/nvlink_transport/nvlink_vmm_allocation.h
@@ -1,0 +1,173 @@
+// Copyright 2024 KVCache.AI
+
+#ifndef NVLINK_VMM_ALLOCATION_H_
+#define NVLINK_VMM_ALLOCATION_H_
+
+#include "cuda_alike.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+
+#include "common/base/status.h"
+
+namespace mooncake {
+
+class NvlinkTransport;
+class NvlinkTransportTestPeer;
+
+class NvlinkVmmAllocation {
+   public:
+    enum class LocationType { DEVICE, HOST_NUMA };
+
+    struct Options {
+        LocationType location_type = LocationType::DEVICE;
+        int location_id = 0;
+        size_t requested_length = 0;
+        bool fabric_exportable = false;
+        // Zero selects the CUDA allocation granularity. Store global chunks can
+        // request a stronger alignment (for example Cachelib slab alignment).
+        size_t required_va_alignment = 0;
+        // Optional bounded observability hook for the access-grant portion of
+        // Create(). It is invoked once when that stage is reached.
+        std::function<void(uint64_t duration_us, bool success)> access_observer;
+    };
+
+    NvlinkVmmAllocation(const NvlinkVmmAllocation&) = delete;
+    NvlinkVmmAllocation& operator=(const NvlinkVmmAllocation&) = delete;
+
+#if defined(USE_MNNVL) && defined(USE_CUDA)
+    NvlinkVmmAllocation(NvlinkVmmAllocation&& other) noexcept;
+    NvlinkVmmAllocation& operator=(NvlinkVmmAllocation&&) noexcept = delete;
+    ~NvlinkVmmAllocation();
+
+    static Status Create(const Options& options,
+                         std::unique_ptr<NvlinkVmmAllocation>& allocation);
+    static Status GetAllocationGranularity(LocationType location_type,
+                                           int location_id,
+                                           bool fabric_exportable,
+                                           size_t& granularity);
+    static Status CheckStrictFabricCapability();
+
+    // Releases CUDA VMM resources in reverse creation order. Each completed
+    // stage is committed independently; on failure the remaining ownership is
+    // retained so an explicit caller can retry safely.
+    [[nodiscard]] Status Release();
+#else
+    NvlinkVmmAllocation(NvlinkVmmAllocation&&) noexcept = default;
+    NvlinkVmmAllocation& operator=(NvlinkVmmAllocation&&) noexcept = delete;
+    ~NvlinkVmmAllocation() = default;
+
+    static Status Create(const Options&,
+                         std::unique_ptr<NvlinkVmmAllocation>& allocation) {
+        allocation.reset();
+        return Status::NotSupportedTransport(
+            "NVLink VMM requires USE_MNNVL and USE_CUDA");
+    }
+    static Status GetAllocationGranularity(LocationType, int, bool,
+                                           size_t& granularity) {
+        granularity = 0;
+        return Status::NotSupportedTransport(
+            "NVLink VMM requires USE_MNNVL and USE_CUDA");
+    }
+    static Status CheckStrictFabricCapability() {
+        return Status::NotSupportedTransport(
+            "NVLink VMM requires USE_MNNVL and USE_CUDA");
+    }
+    [[nodiscard]] Status Release() { return Status::OK(); }
+#endif
+
+    void* base() const { return base_; }
+    size_t length() const { return length_; }
+    size_t granularity() const { return granularity_; }
+    size_t va_alignment() const { return va_alignment_; }
+    LocationType location_type() const { return location_type_; }
+    int location_id() const { return location_id_; }
+    bool fabric_exportable() const { return fabric_exportable_; }
+
+   private:
+    friend class NvlinkTransport;
+    friend class NvlinkTransportTestPeer;
+    NvlinkVmmAllocation() = default;
+
+#if defined(USE_MNNVL) && defined(USE_CUDA)
+    // Private fake-driver seam. Production callers use Create(),
+    // GetAllocationGranularity(), and CheckStrictFabricCapability(); the friend
+    // test peer exposes only a test-local alias and forwarding methods.
+    struct DriverApi {
+        std::function<CUresult(int*)> device_get_count;
+        std::function<CUresult(CUdevice*, int)> device_get;
+        std::function<CUresult(int*, CUdevice_attribute, CUdevice)>
+            device_get_attribute;
+        std::function<CUresult(size_t*, const CUmemAllocationProp*,
+                               CUmemAllocationGranularity_flags)>
+            mem_get_allocation_granularity;
+        std::function<CUresult(CUmemGenericAllocationHandle*, size_t,
+                               const CUmemAllocationProp*, unsigned long long)>
+            mem_create;
+        std::function<CUresult(CUdeviceptr*, size_t, size_t, CUdeviceptr,
+                               unsigned long long)>
+            mem_address_reserve;
+        std::function<CUresult(CUdeviceptr, size_t, size_t,
+                               CUmemGenericAllocationHandle,
+                               unsigned long long)>
+            mem_map;
+        std::function<CUresult(CUdeviceptr, size_t, const CUmemAccessDesc*,
+                               size_t)>
+            mem_set_access;
+        std::function<CUresult(CUdeviceptr, size_t)> mem_unmap;
+        std::function<CUresult(CUdeviceptr, size_t)> mem_address_free;
+        std::function<CUresult(CUmemGenericAllocationHandle)> mem_release;
+        std::function<CUresult(CUmemGenericAllocationHandle*, void*)>
+            mem_retain_allocation_handle;
+        std::function<CUresult(CUmemAllocationProp*,
+                               CUmemGenericAllocationHandle)>
+            mem_get_allocation_properties_from_handle;
+        std::function<CUresult(CUdeviceptr*, size_t*, CUdeviceptr)>
+            mem_get_address_range;
+        std::function<CUresult(void*, CUmemGenericAllocationHandle,
+                               CUmemAllocationHandleType, unsigned long long)>
+            mem_export_to_shareable_handle;
+        std::function<CUresult(CUmemGenericAllocationHandle*, void*,
+                               CUmemAllocationHandleType)>
+            mem_import_from_shareable_handle;
+    };
+
+    static DriverApi ProductionDriverApi();
+    static Status CreateWithDriverApi(
+        const Options& options, const DriverApi& api,
+        std::unique_ptr<NvlinkVmmAllocation>& allocation);
+    static Status GetAllocationGranularityWithDriverApi(
+        LocationType location_type, int location_id, bool fabric_exportable,
+        const DriverApi& api, size_t& granularity);
+    static Status CheckStrictFabricCapabilityWithDriverApi(
+        const DriverApi& api);
+    static bool RegisterOwnedRange(void* base, size_t length);
+    static bool UnregisterOwnedRange(void* base, size_t length);
+    static bool IsExactOwnedRange(void* base, size_t length);
+    static bool RetryCleanupPendingOwners();
+    static size_t CleanupPendingOwnerCount();
+    void reset() noexcept;
+#endif
+
+    void* base_ = nullptr;
+    size_t length_ = 0;
+    size_t granularity_ = 0;
+    size_t va_alignment_ = 0;
+    LocationType location_type_ = LocationType::DEVICE;
+    int location_id_ = 0;
+    bool fabric_exportable_ = false;
+    bool mapped_ = false;
+    bool address_reserved_ = false;
+    bool handle_owned_ = false;
+    uint64_t allocation_handle_ = 0;
+#if defined(USE_MNNVL) && defined(USE_CUDA)
+    bool owned_range_registered_ = false;
+    DriverApi driver_api_;
+#endif
+};
+
+}  // namespace mooncake
+
+#endif  // NVLINK_VMM_ALLOCATION_H_

--- a/mooncake-transfer-engine/include/transport/transport.h
+++ b/mooncake-transfer-engine/include/transport/transport.h
@@ -300,6 +300,20 @@ class Transport {
         volatile uint64_t failed_slice_count = 0;
         volatile uint64_t transferred_bytes = 0;
         volatile bool is_finished = false;
+        // Explicit terminal state for failures that happen before a transport
+        // can create a Slice (for example address relocation or stream setup).
+        // A zero-slice task otherwise looks spuriously successful to legacy
+        // completion code.
+        volatile bool submission_failed = false;
+        // NvlinkTransport may be polled repeatedly after a task reaches a
+        // terminal state. Keep its bounded result metric idempotent per task.
+        volatile bool transport_result_observed = false;
+        // The request storage is owned by the submit caller and may be gone by
+        // the time an asynchronous transfer completes. Snapshot the operation
+        // while staging the task so terminal metrics never dereference the
+        // borrowed request pointer.
+        TransferRequest::OpCode operation = TransferRequest::READ;
+        bool operation_initialized = false;
         uint64_t total_bytes = 0;
         BatchID batch_id = 0;
 
@@ -315,6 +329,11 @@ class Transport {
 
 #ifdef USE_EVENT_DRIVEN_COMPLETION
         volatile uint64_t completed_slice_count = 0;
+        // NVLink POSTED slices require getTransferStatus() to drive
+        // cudaStreamQuery progress even when no completion notification fires.
+        // Other event-driven transports leave this false and remain purely
+        // condition-variable driven.
+        bool requires_periodic_status_polling = false;
 #endif
 
         // record the origin request
@@ -356,6 +375,33 @@ class Transport {
 #endif
     };
 
+    // Mark a task terminal when submission failed before Slice ownership was
+    // established. This is shared by transports and MultiTransport so every
+    // batch remains queryable/freeable even when submitTransfer() returns an
+    // error. The operation is idempotent.
+    static void markSubmissionFailed(TransferTask &task) {
+        if (__atomic_exchange_n(&task.submission_failed, true,
+                                __ATOMIC_ACQ_REL)) {
+            return;
+        }
+        __atomic_store_n(&task.is_finished, true, __ATOMIC_RELEASE);
+
+        if (task.batch_id == 0) return;
+        auto &batch_desc = toBatchDesc(task.batch_id);
+        batch_desc.has_failure.store(true, std::memory_order_release);
+#ifdef USE_EVENT_DRIVEN_COMPLETION
+        auto previous = batch_desc.finished_task_count.fetch_add(
+            1, std::memory_order_relaxed);
+        if (previous + 1 == batch_desc.batch_size) {
+            {
+                std::lock_guard<std::mutex> lock(batch_desc.completion_mutex);
+                batch_desc.is_finished.store(true, std::memory_order_release);
+            }
+            batch_desc.completion_cv.notify_all();
+        }
+#endif
+    }
+
    public:
     virtual ~Transport() {}
 
@@ -384,6 +430,14 @@ class Transport {
     virtual Status getTransferStatus(BatchID batch_id, size_t task_id,
                                      TransferStatus &status) = 0;
 
+    // Called when a terminal task is observed without necessarily polling the
+    // transport (for example MultiTransport's event-driven batch fast path).
+    // Implementations must tolerate repeated calls.
+    virtual void finalizeTransferResult(TransferTask &task, bool success) {
+        (void)task;
+        (void)success;
+    }
+
     std::shared_ptr<TransferMetadata> &meta() { return metadata_; }
 
     struct BufferEntry {
@@ -395,6 +449,8 @@ class Transport {
         return Status::OK();
     }
     virtual Status CheckStatus(SegmentID sid) { return Status::OK(); }
+
+    virtual void appendMetrics(std::string &output) { (void)output; }
 
    protected:
     virtual int install(std::string &local_server_name,

--- a/mooncake-transfer-engine/src/multi_transport.cpp
+++ b/mooncake-transfer-engine/src/multi_transport.cpp
@@ -120,31 +120,52 @@ Status MultiTransport::submitTransfer(
             "Exceed the limitation of batch capacity");
     }
 
-    size_t task_id = batch_desc.task_list.size();
-    batch_desc.task_list.resize(task_id + entries.size());
+    const size_t first_task_id = batch_desc.task_list.size();
+    batch_desc.task_list.resize(first_task_id + entries.size());
+
+    for (size_t index = 0; index < entries.size(); ++index) {
+        auto& task = batch_desc.task_list[first_task_id + index];
+        task.batch_id = batch_id;
+#ifdef USE_ASCEND_HETEROGENEOUS
+        task.request = const_cast<Transport::TransferRequest*>(&entries[index]);
+#else
+        task.request = &entries[index];
+#endif
+        task.operation = entries[index].opcode;
+        task.operation_initialized = true;
+    }
 
     std::unordered_map<Transport*, std::vector<Transport::TransferTask*> >
         submit_tasks;
-    for (auto& request : entries) {
+    for (size_t index = 0; index < entries.size(); ++index) {
+        auto& request = entries[index];
         Transport* transport = nullptr;
         auto status = selectTransport(request, transport);
-        if (!status.ok()) return status;
+        if (!status.ok()) {
+            for (size_t failed = first_task_id;
+                 failed < batch_desc.task_list.size(); ++failed) {
+                Transport::markSubmissionFailed(batch_desc.task_list[failed]);
+            }
+            return status;
+        }
         assert(transport);
-        auto& task = batch_desc.task_list[task_id];
-        task.batch_id = batch_id;
+        auto& task = batch_desc.task_list[first_task_id + index];
         task.transport_ = transport;
 #ifdef USE_ASCEND_HETEROGENEOUS
         task.request = const_cast<Transport::TransferRequest*>(&request);
-#else
-        task.request = &request;
 #endif
-        ++task_id;
         submit_tasks[transport].push_back(&task);
     }
     Status overall_status = Status::OK();
     for (auto& entry : submit_tasks) {
         auto status = entry.first->submitTransferTask(entry.second);
         if (!status.ok()) {
+            for (auto* task : entry.second) {
+                if (task != nullptr && !task->is_finished &&
+                    task->slice_count == 0) {
+                    Transport::markSubmissionFailed(*task);
+                }
+            }
             // LOG(ERROR) << "Failed to submit transfer task to "
             //            << entry.first->getName();
             overall_status = status;
@@ -163,31 +184,52 @@ Status MultiTransport::mp_submitTransfer(
             "Exceed the limitation of batch capacity");
     }
 
-    size_t task_id = batch_desc.task_list.size();
-    batch_desc.task_list.resize(task_id + entries.size());
+    const size_t first_task_id = batch_desc.task_list.size();
+    batch_desc.task_list.resize(first_task_id + entries.size());
+
+    for (size_t index = 0; index < entries.size(); ++index) {
+        auto& task = batch_desc.task_list[first_task_id + index];
+        task.batch_id = batch_id;
+#ifdef USE_ASCEND_HETEROGENEOUS
+        task.request = const_cast<Transport::TransferRequest*>(&entries[index]);
+#else
+        task.request = &entries[index];
+#endif
+        task.operation = entries[index].opcode;
+        task.operation_initialized = true;
+    }
 
     std::unordered_map<Transport*, std::vector<Transport::TransferTask*> >
         submit_tasks;
-    for (auto& request : entries) {
+    for (size_t index = 0; index < entries.size(); ++index) {
+        auto& request = entries[index];
         Transport* transport = nullptr;
         auto status = mp_selectTransport(request, transport, proto);
-        if (!status.ok()) return status;
+        if (!status.ok()) {
+            for (size_t failed = first_task_id;
+                 failed < batch_desc.task_list.size(); ++failed) {
+                Transport::markSubmissionFailed(batch_desc.task_list[failed]);
+            }
+            return status;
+        }
         assert(transport);
-        auto& task = batch_desc.task_list[task_id];
-        task.batch_id = batch_id;
+        auto& task = batch_desc.task_list[first_task_id + index];
         task.transport_ = transport;
 #ifdef USE_ASCEND_HETEROGENEOUS
         task.request = const_cast<Transport::TransferRequest*>(&request);
-#else
-        task.request = &request;
 #endif
-        ++task_id;
         submit_tasks[transport].push_back(&task);
     }
     Status overall_status = Status::OK();
     for (auto& entry : submit_tasks) {
         auto status = entry.first->submitTransferTask(entry.second);
         if (!status.ok()) {
+            for (auto* task : entry.second) {
+                if (task != nullptr && !task->is_finished &&
+                    task->slice_count == 0) {
+                    Transport::markSubmissionFailed(*task);
+                }
+            }
             // LOG(ERROR) << "Failed to submit transfer task to "
             //            << entry.first->getName();
             overall_status = status;
@@ -205,6 +247,12 @@ Status MultiTransport::getTransferStatus(BatchID batch_id, size_t task_id,
         return Status::InvalidArgument("Task ID out of range");
     }
     auto& task = batch_desc.task_list[task_id];
+
+    if (__atomic_load_n(&task.submission_failed, __ATOMIC_ACQUIRE)) {
+        status.s = Transport::TransferStatusEnum::FAILED;
+        status.transferred_bytes = task.transferred_bytes;
+        return Status::OK();
+    }
 
     // Helper: check if any slice has exceeded the configured timeout.
     // Returns true if a timeout was detected (and logs it).
@@ -271,9 +319,25 @@ Status MultiTransport::getBatchTransferStatus(BatchID batch_id,
     const size_t task_count = batch_desc.task_list.size();
     status.transferred_bytes = 0;
 
-    if (batch_desc.is_finished.load(std::memory_order_acquire) ||
-        task_count == 0) {
-        status.s = Transport::TransferStatusEnum::COMPLETED;
+    const bool batch_finished =
+        batch_desc.is_finished.load(std::memory_order_acquire);
+    if (batch_finished || task_count == 0) {
+        // Event-driven completion may publish the batch before the caller ever
+        // polls an individual task. Give each selected transport a narrow,
+        // idempotent opportunity to finalize per-task result metrics.
+        if (batch_finished) {
+            for (auto& task : batch_desc.task_list) {
+                if (task.transport_ == nullptr) continue;
+                const bool success = !__atomic_load_n(&task.submission_failed,
+                                                      __ATOMIC_ACQUIRE) &&
+                                     __atomic_load_n(&task.failed_slice_count,
+                                                     __ATOMIC_ACQUIRE) == 0;
+                task.transport_->finalizeTransferResult(task, success);
+            }
+        }
+        status.s = batch_desc.has_failure.load(std::memory_order_acquire)
+                       ? Transport::TransferStatusEnum::FAILED
+                       : Transport::TransferStatusEnum::COMPLETED;
         status.transferred_bytes =
             batch_desc.finished_transfer_bytes.load(std::memory_order_relaxed);
         return Status::OK();
@@ -293,6 +357,7 @@ Status MultiTransport::getBatchTransferStatus(BatchID batch_id,
             status.transferred_bytes += task_status.transferred_bytes;
             success_count++;
         } else if (task_status.s == Transport::TransferStatusEnum::FAILED) {
+            batch_desc.has_failure.store(true, std::memory_order_release);
             status.s = Transport::TransferStatusEnum::FAILED;
             return Status::OK();
         }
@@ -612,11 +677,31 @@ bool MultiTransport::isTcpOnly() const {
     return transport_map_.size() == 1 && transport_map_.count("tcp") == 1;
 }
 
+bool MultiTransport::isNvlinkFabricTransportReady() const {
+#ifdef USE_MNNVL
+    if (transport_map_.size() != 1) return false;
+    auto it = transport_map_.find("nvlink");
+    if (it == transport_map_.end()) return false;
+    auto* transport = dynamic_cast<NvlinkTransport*>(it->second.get());
+    return transport != nullptr && transport->isFabricMemoryEnabled();
+#else
+    return false;
+#endif
+}
+
 std::vector<Transport*> MultiTransport::listTransports() {
     std::vector<Transport*> transport_list;
     for (auto& entry : transport_map_)
         transport_list.push_back(entry.second.get());
     return transport_list;
+}
+
+void MultiTransport::appendTransportMetrics(std::string& output) {
+    for (auto* transport : listTransports()) {
+        if (transport != nullptr) {
+            transport->appendMetrics(output);
+        }
+    }
 }
 
 void* MultiTransport::getBaseAddr() {

--- a/mooncake-transfer-engine/src/multi_transport.cpp
+++ b/mooncake-transfer-engine/src/multi_transport.cpp
@@ -151,9 +151,6 @@ Status MultiTransport::submitTransfer(
         assert(transport);
         auto& task = batch_desc.task_list[first_task_id + index];
         task.transport_ = transport;
-#ifdef USE_ASCEND_HETEROGENEOUS
-        task.request = const_cast<Transport::TransferRequest*>(&request);
-#endif
         submit_tasks[transport].push_back(&task);
     }
     Status overall_status = Status::OK();
@@ -215,9 +212,6 @@ Status MultiTransport::mp_submitTransfer(
         assert(transport);
         auto& task = batch_desc.task_list[first_task_id + index];
         task.transport_ = transport;
-#ifdef USE_ASCEND_HETEROGENEOUS
-        task.request = const_cast<Transport::TransferRequest*>(&request);
-#endif
         submit_tasks[transport].push_back(&task);
     }
     Status overall_status = Status::OK();

--- a/mooncake-transfer-engine/src/transfer_engine.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine.cpp
@@ -125,6 +125,10 @@ int TransferEngine::uninstallTransport(const std::string& proto) {
     return impl_->uninstallTransport(proto);
 }
 
+bool TransferEngine::isNvlinkFabricTransportReady() const {
+    return impl_ != nullptr && impl_->isNvlinkFabricTransportReady();
+}
+
 std::string TransferEngine::getLocalIpAndPort() {
     return impl_->getLocalIpAndPort();
 }
@@ -249,6 +253,12 @@ Status TransferEngine::getBatchTransferStatus(BatchID batch_id,
 
 Transport* TransferEngine::getTransport(const std::string& proto) {
     return impl_->getTransport(proto);
+}
+
+void TransferEngine::appendTransportMetrics(std::string& output) {
+    if (impl_ != nullptr) {
+        impl_->appendTransportMetrics(output);
+    }
 }
 
 #if (defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA)) && \
@@ -486,6 +496,11 @@ int TransferEngine::uninstallTransport(const std::string& proto) {
         return 0;
     else
         return impl_->uninstallTransport(proto);
+}
+
+bool TransferEngine::isNvlinkFabricTransportReady() const {
+    return !use_tent_ && impl_ != nullptr &&
+           impl_->isNvlinkFabricTransportReady();
 }
 
 std::string TransferEngine::getLocalIpAndPort() {
@@ -752,6 +767,12 @@ Transport* TransferEngine::getTransport(const std::string& proto) {
         return nullptr;
     else
         return impl_->getTransport(proto);
+}
+
+void TransferEngine::appendTransportMetrics(std::string& output) {
+    if (!use_tent_ && impl_ != nullptr) {
+        impl_->appendTransportMetrics(output);
+    }
 }
 
 #if (defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA)) && \

--- a/mooncake-transfer-engine/src/transfer_metadata.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata.cpp
@@ -1225,6 +1225,7 @@ TransferMetadata::SegmentID TransferMetadata::getSegmentID(
 }
 
 int TransferMetadata::updateLocalSegmentDesc(uint64_t segment_id) {
+    std::lock_guard<std::mutex> publish_guard(local_segment_publish_mutex_);
     std::shared_ptr<SegmentDesc> desc;
     {
         RWSpinlock::ReadGuard guard(segment_lock_);
@@ -1241,6 +1242,7 @@ int TransferMetadata::updateLocalSegmentDesc(uint64_t segment_id) {
 int TransferMetadata::addLocalSegment(SegmentID segment_id,
                                       const std::string &segment_name,
                                       std::shared_ptr<SegmentDesc> &&desc) {
+    std::lock_guard<std::mutex> publish_guard(local_segment_publish_mutex_);
     RWSpinlock::WriteGuard guard(segment_lock_);
     segment_id_to_desc_map_[segment_id] = desc;
     segment_name_to_id_map_[segment_name] = segment_id;
@@ -1248,6 +1250,7 @@ int TransferMetadata::addLocalSegment(SegmentID segment_id,
 }
 
 int TransferMetadata::removeLocalSegment(const std::string &segment_name) {
+    std::lock_guard<std::mutex> publish_guard(local_segment_publish_mutex_);
     RWSpinlock::WriteGuard guard(segment_lock_);
     if (segment_name_to_id_map_.count(segment_name)) {
         int segment_id = segment_name_to_id_map_[segment_name];
@@ -1259,25 +1262,32 @@ int TransferMetadata::removeLocalSegment(const std::string &segment_name) {
 
 int TransferMetadata::addLocalMemoryBuffer(const BufferDesc &buffer_desc,
                                            bool update_metadata) {
+    std::lock_guard<std::mutex> publish_guard(local_segment_publish_mutex_);
+    std::shared_ptr<SegmentDesc> new_segment_desc;
     {
         RWSpinlock::WriteGuard guard(segment_lock_);
-        auto new_segment_desc = std::make_shared<SegmentDesc>();
+        new_segment_desc = std::make_shared<SegmentDesc>();
         auto &segment_desc = segment_id_to_desc_map_[LOCAL_SEGMENT_ID];
         *new_segment_desc = *segment_desc;
         segment_desc = new_segment_desc;
         segment_desc->buffers.push_back(buffer_desc);
     }
-    if (update_metadata) return updateLocalSegmentDesc();
+    if (update_metadata)
+        return updateSegmentDesc(new_segment_desc->name, *new_segment_desc);
     return 0;
 }
 
 int TransferMetadata::removeLocalMemoryBuffer(void *addr,
                                               bool update_metadata) {
+    std::lock_guard<std::mutex> publish_guard(local_segment_publish_mutex_);
     bool addr_exist = false;
+    std::shared_ptr<SegmentDesc> old_segment_desc;
+    std::shared_ptr<SegmentDesc> new_segment_desc;
     {
         RWSpinlock::WriteGuard guard(segment_lock_);
-        auto new_segment_desc = std::make_shared<SegmentDesc>();
         auto &segment_desc = segment_id_to_desc_map_[LOCAL_SEGMENT_ID];
+        old_segment_desc = segment_desc;
+        new_segment_desc = std::make_shared<SegmentDesc>();
         *new_segment_desc = *segment_desc;
         segment_desc = new_segment_desc;
         for (auto iter = segment_desc->buffers.begin();
@@ -1295,7 +1305,18 @@ int TransferMetadata::removeLocalMemoryBuffer(void *addr,
         }
     }
     if (addr_exist) {
-        if (update_metadata) return updateLocalSegmentDesc();
+        if (update_metadata) {
+            int rc =
+                updateSegmentDesc(new_segment_desc->name, *new_segment_desc);
+            if (rc != 0) {
+                RWSpinlock::WriteGuard guard(segment_lock_);
+                // local_segment_publish_mutex_ prevents another COW mutation
+                // from interleaving with this remote update. Restore the exact
+                // pre-removal snapshot so the caller can retry safely.
+                segment_id_to_desc_map_[LOCAL_SEGMENT_ID] = old_segment_desc;
+            }
+            return rc;
+        }
         return 0;
     }
     return ERR_ADDRESS_NOT_REGISTERED;

--- a/mooncake-transfer-engine/src/transfer_metadata.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata.cpp
@@ -1263,17 +1263,25 @@ int TransferMetadata::removeLocalSegment(const std::string &segment_name) {
 int TransferMetadata::addLocalMemoryBuffer(const BufferDesc &buffer_desc,
                                            bool update_metadata) {
     std::lock_guard<std::mutex> publish_guard(local_segment_publish_mutex_);
+    std::shared_ptr<SegmentDesc> old_segment_desc;
     std::shared_ptr<SegmentDesc> new_segment_desc;
     {
         RWSpinlock::WriteGuard guard(segment_lock_);
-        new_segment_desc = std::make_shared<SegmentDesc>();
         auto &segment_desc = segment_id_to_desc_map_[LOCAL_SEGMENT_ID];
+        old_segment_desc = segment_desc;
+        new_segment_desc = std::make_shared<SegmentDesc>();
         *new_segment_desc = *segment_desc;
         segment_desc = new_segment_desc;
         segment_desc->buffers.push_back(buffer_desc);
     }
-    if (update_metadata)
-        return updateSegmentDesc(new_segment_desc->name, *new_segment_desc);
+    if (update_metadata) {
+        int rc = updateSegmentDesc(new_segment_desc->name, *new_segment_desc);
+        if (rc != 0) {
+            RWSpinlock::WriteGuard guard(segment_lock_);
+            segment_id_to_desc_map_[LOCAL_SEGMENT_ID] = old_segment_desc;
+        }
+        return rc;
+    }
     return 0;
 }
 

--- a/mooncake-transfer-engine/src/transport/nvlink_transport/nvlink_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/nvlink_transport/nvlink_transport.cpp
@@ -19,11 +19,20 @@
 #include <glog/logging.h>
 
 #include <algorithm>
+#include <array>
+#include <atomic>
 #include <cassert>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
+#include <exception>
 #include <iomanip>
+#include <limits>
 #include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "common.h"
@@ -33,7 +42,7 @@
 #include "transfer_metadata.h"
 #include "transport/transport.h"
 
-static bool checkCudaErrorReturn(cudaError_t result, const char *message) {
+static bool checkCudaErrorReturn(cudaError_t result, const char* message) {
     if (result != cudaSuccess) {
         LOG(ERROR) << message << " (Error code: " << result << " - "
                    << cudaGetErrorString(result) << ")" << std::endl;
@@ -44,7 +53,376 @@ static bool checkCudaErrorReturn(cudaError_t result, const char *message) {
 
 namespace mooncake {
 
+#if defined(USE_MNNVL) && defined(USE_CUDA)
 namespace {
+
+struct OwnedVmmRange {
+    size_t length = 0;
+    size_t owners = 0;
+};
+
+struct OwnedVmmRangeRegistry {
+    std::mutex mutex;
+    std::unordered_map<uintptr_t, OwnedVmmRange> ranges;
+};
+
+OwnedVmmRangeRegistry& ownedVmmRangeRegistry() {
+    // HOST_NUMA allocations can be released by Store's atexit handler after
+    // ordinary function-local static objects have already been destroyed. Keep
+    // this
+    // tiny process-lifetime registry alive so late cleanup never observes a
+    // destructed mutex or map.
+    static auto* registry = new OwnedVmmRangeRegistry();
+    return *registry;
+}
+
+struct CleanupPendingVmmOwnerNode {
+    std::unique_ptr<NvlinkVmmAllocation> owner;
+    CleanupPendingVmmOwnerNode* next = nullptr;
+};
+
+struct CleanupPendingVmmOwnerRegistry {
+    std::atomic_flag lock = ATOMIC_FLAG_INIT;
+    CleanupPendingVmmOwnerNode* head = nullptr;
+    size_t count = 0;
+};
+
+CleanupPendingVmmOwnerRegistry& cleanupPendingVmmOwnerRegistry() {
+    // A factory rollback can outlive ordinary static destruction if CUDA keeps
+    // rejecting a teardown stage. The intrusive nodes are preallocated before
+    // CUDA ownership is acquired and intentionally live until a later retry or
+    // process exit, so recording a failed cleanup cannot itself allocate.
+    static auto* registry = new CleanupPendingVmmOwnerRegistry();
+    return *registry;
+}
+
+class CleanupPendingRegistryGuard {
+   public:
+    explicit CleanupPendingRegistryGuard(CleanupPendingVmmOwnerRegistry& owner)
+        : owner_(owner) {
+        while (owner_.lock.test_and_set(std::memory_order_acquire)) {
+        }
+    }
+
+    ~CleanupPendingRegistryGuard() {
+        owner_.lock.clear(std::memory_order_release);
+    }
+
+   private:
+    CleanupPendingVmmOwnerRegistry& owner_;
+};
+
+void quarantineCleanupPendingVmmOwner(
+    std::unique_ptr<CleanupPendingVmmOwnerNode> node) noexcept {
+    auto& registry = cleanupPendingVmmOwnerRegistry();
+    CleanupPendingRegistryGuard guard(registry);
+    node->next = registry.head;
+    registry.head = node.release();
+    ++registry.count;
+}
+
+size_t cleanupPendingVmmOwnerCount() noexcept {
+    auto& registry = cleanupPendingVmmOwnerRegistry();
+    CleanupPendingRegistryGuard guard(registry);
+    return registry.count;
+}
+
+bool retryCleanupPendingVmmOwners() noexcept {
+    auto& registry = cleanupPendingVmmOwnerRegistry();
+    CleanupPendingVmmOwnerNode* pending = nullptr;
+    {
+        CleanupPendingRegistryGuard guard(registry);
+        pending = registry.head;
+        registry.head = nullptr;
+        registry.count = 0;
+    }
+
+    bool all_released = true;
+    while (pending != nullptr) {
+        std::unique_ptr<CleanupPendingVmmOwnerNode> node(pending);
+        pending = pending->next;
+        node->next = nullptr;
+
+        Status status;
+        try {
+            status = node->owner->Release();
+        } catch (const std::exception& error) {
+            status = Status::Memory(
+                std::string("cleanup-pending VMM retry threw: ") +
+                error.what());
+        } catch (...) {
+            status = Status::Memory(
+                "cleanup-pending VMM retry threw an unknown exception");
+        }
+        if (!status.ok()) {
+            LOG(ERROR) << "NvlinkVmmAllocation: cleanup-pending owner retry "
+                          "failed; retaining CUDA ownership: "
+                       << status;
+            all_released = false;
+            quarantineCleanupPendingVmmOwner(std::move(node));
+        }
+    }
+    return all_released;
+}
+
+struct ProcessLifetimeRetainedHandleQuarantine {
+    std::mutex mutex;
+    std::vector<uint64_t> handles;
+};
+
+ProcessLifetimeRetainedHandleQuarantine&
+processLifetimeRetainedHandleQuarantine() {
+    // A CUDA driver teardown failure must not make Mooncake forget that the
+    // retained handle is still live. Intentionally keep the ownership marker
+    // until process exit after the transport and CUDA adapter are gone.
+    static auto* quarantine = new ProcessLifetimeRetainedHandleQuarantine();
+    return *quarantine;
+}
+
+void quarantineRetainedHandleForProcessLifetime(uint64_t handle) noexcept {
+    try {
+        auto& quarantine = processLifetimeRetainedHandleQuarantine();
+        std::lock_guard<std::mutex> lock(quarantine.mutex);
+        quarantine.handles.push_back(handle);
+    } catch (const std::exception& error) {
+        // Never let allocation failure escape NvlinkTransport's destructor.
+        // The CUDA handle itself remains live until process exit even if the
+        // diagnostic ownership marker cannot be allocated.
+        LOG(ERROR) << "NvlinkTransport: unable to record process-lifetime "
+                      "retained-handle quarantine: "
+                   << error.what();
+    } catch (...) {
+        LOG(ERROR) << "NvlinkTransport: unknown failure while recording "
+                      "process-lifetime retained-handle quarantine";
+    }
+}
+
+}  // namespace
+#endif
+
+struct NvlinkTransport::ConsumerMetrics {
+    std::array<std::atomic<uint64_t>, 2> mapping_cache_total{};
+    std::atomic<uint64_t> lazy_import_duration_us_total{0};
+    std::atomic<uint64_t> lazy_import_observations_total{0};
+    std::array<std::atomic<uint64_t>, 5> failures_total{};
+    std::array<std::atomic<uint64_t>, 4> transfer_results_total{};
+};
+
+void NvlinkTransport::observeCacheLookup(bool hit) {
+    consumer_metrics_->mapping_cache_total[hit ? 0 : 1].fetch_add(
+        1, std::memory_order_relaxed);
+}
+
+void NvlinkTransport::observeLazyImportLatency(uint64_t duration_us) {
+    consumer_metrics_->lazy_import_duration_us_total.fetch_add(
+        std::max<uint64_t>(duration_us, 1), std::memory_order_relaxed);
+    consumer_metrics_->lazy_import_observations_total.fetch_add(
+        1, std::memory_order_relaxed);
+}
+
+void NvlinkTransport::observeConsumerFailure(ConsumerFailureStage stage) {
+    consumer_metrics_->failures_total[static_cast<size_t>(stage)].fetch_add(
+        1, std::memory_order_relaxed);
+}
+
+void NvlinkTransport::observeTransferResult(TransferRequest::OpCode operation,
+                                            bool success) {
+    const size_t operation_offset = operation == TransferRequest::READ ? 0 : 2;
+    consumer_metrics_
+        ->transfer_results_total[operation_offset + (success ? 0 : 1)]
+        .fetch_add(1, std::memory_order_relaxed);
+}
+
+bool NvlinkTransport::observeTransferResultOnce(TransferTask& task,
+                                                bool success) {
+    if (!task.operation_initialized) return false;
+    if (__atomic_exchange_n(&task.transport_result_observed, true,
+                            __ATOMIC_ACQ_REL)) {
+        return false;
+    }
+    observeTransferResult(task.operation, success);
+    return true;
+}
+
+void NvlinkTransport::finalizeTransferResult(TransferTask& task, bool success) {
+    if (observeTransferResultOnce(task, success) && !success) {
+        observeConsumerFailure(ConsumerFailureStage::COPY);
+    }
+}
+
+void NvlinkTransport::finalizeSubmissionFailure(TransferTask& task,
+                                                bool copy_failure) {
+    const bool first_result = observeTransferResultOnce(task, false);
+    if (copy_failure && first_result) {
+        observeConsumerFailure(ConsumerFailureStage::COPY);
+    }
+    // Publish task/batch completion only after its result and exact failure
+    // category are stable. Otherwise the event-driven batch fast path could
+    // win the result CAS and misclassify a non-copy failure as copy.
+    markSubmissionFailed(task);
+}
+
+void NvlinkTransport::appendMetrics(std::string& output) {
+    if (!output.empty() && output.back() != '\n') output.push_back('\n');
+    auto append_header = [&output](const char* name, const char* help) {
+        output.append("# HELP ").append(name).append(" ").append(help).append(
+            "\n# TYPE ");
+        output.append(name).append(" counter\n");
+    };
+    auto append_sample = [&output](const char* name, const char* labels,
+                                   uint64_t value) {
+        output.append(name);
+        if (labels != nullptr && labels[0] != '\0') {
+            output.append("{").append(labels).append("}");
+        }
+        output.append(" ").append(std::to_string(value)).append("\n");
+    };
+
+    constexpr const char* cache_name =
+        "mooncake_nvlink_consumer_mapping_cache_total";
+    append_header(cache_name, "NVLink Consumer mapping cache lookups");
+    append_sample(cache_name, "result=\"hit\"",
+                  consumer_metrics_->mapping_cache_total[0].load(
+                      std::memory_order_relaxed));
+    append_sample(cache_name, "result=\"miss\"",
+                  consumer_metrics_->mapping_cache_total[1].load(
+                      std::memory_order_relaxed));
+
+    constexpr const char* duration_name =
+        "mooncake_nvlink_consumer_lazy_import_duration_us_total";
+    append_header(duration_name,
+                  "Cumulative NVLink Consumer lazy import duration in "
+                  "microseconds");
+    append_sample(duration_name, nullptr,
+                  consumer_metrics_->lazy_import_duration_us_total.load(
+                      std::memory_order_relaxed));
+    constexpr const char* observations_name =
+        "mooncake_nvlink_consumer_lazy_import_observations_total";
+    append_header(observations_name,
+                  "Observed NVLink Consumer lazy import attempts");
+    append_sample(observations_name, nullptr,
+                  consumer_metrics_->lazy_import_observations_total.load(
+                      std::memory_order_relaxed));
+
+    constexpr const char* failure_name =
+        "mooncake_nvlink_consumer_failures_total";
+    constexpr std::array<const char*, 5> failure_labels = {
+        "stage=\"import\"", "stage=\"reserve\"", "stage=\"map\"",
+        "stage=\"set_access\"", "stage=\"copy\""};
+    append_header(failure_name, "NVLink Consumer failures by stage");
+    for (size_t index = 0; index < failure_labels.size(); ++index) {
+        append_sample(failure_name, failure_labels[index],
+                      consumer_metrics_->failures_total[index].load(
+                          std::memory_order_relaxed));
+    }
+
+    constexpr const char* transfer_name =
+        "mooncake_nvlink_consumer_transfer_results_total";
+    constexpr std::array<const char*, 4> transfer_labels = {
+        "operation=\"read\",result=\"success\"",
+        "operation=\"read\",result=\"failure\"",
+        "operation=\"write\",result=\"success\"",
+        "operation=\"write\",result=\"failure\""};
+    append_header(transfer_name, "NVLink Consumer transfer results");
+    for (size_t index = 0; index < transfer_labels.size(); ++index) {
+        append_sample(transfer_name, transfer_labels[index],
+                      consumer_metrics_->transfer_results_total[index].load(
+                          std::memory_order_relaxed));
+    }
+}
+
+namespace {
+
+class ScopedLatencyObservation {
+   public:
+    explicit ScopedLatencyObservation(std::function<void(uint64_t)> observer)
+        : observer_(std::move(observer)),
+          start_(std::chrono::steady_clock::now()) {}
+
+    ScopedLatencyObservation(const ScopedLatencyObservation&) = delete;
+    ScopedLatencyObservation& operator=(const ScopedLatencyObservation&) =
+        delete;
+
+    ~ScopedLatencyObservation() {
+        const auto duration_us =
+            std::chrono::duration_cast<std::chrono::microseconds>(
+                std::chrono::steady_clock::now() - start_)
+                .count();
+        observer_(static_cast<uint64_t>(std::max<int64_t>(duration_us, 1)));
+    }
+
+   private:
+    std::function<void(uint64_t)> observer_;
+    std::chrono::steady_clock::time_point start_;
+};
+
+#if defined(USE_MNNVL) && defined(USE_CUDA)
+
+Status cudaDriverFailure(const char* stage, CUresult result) {
+    return Status::Memory(std::string(stage) + " failed with CUDA result " +
+                          std::to_string(static_cast<int>(result)));
+}
+
+Status missingDriverFunction(const char* name) {
+    return Status::InvalidArgument(
+        std::string("missing CUDA driver adapter: ") + name);
+}
+
+bool isPowerOfTwo(size_t value) {
+    return value != 0 && (value & (value - 1)) == 0;
+}
+
+template <typename DriverApi>
+Status buildAllocationProp(const NvlinkVmmAllocation::Options& options,
+                           const DriverApi& api, CUmemAllocationProp& prop) {
+    prop = {};
+    prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+    prop.requestedHandleTypes = options.fabric_exportable
+                                    ? CU_MEM_HANDLE_TYPE_FABRIC
+                                    : static_cast<CUmemAllocationHandleType>(0);
+
+    if (options.location_type == NvlinkVmmAllocation::LocationType::HOST_NUMA) {
+        prop.location.type = CU_MEM_LOCATION_TYPE_HOST_NUMA;
+        prop.location.id = options.location_id;
+        return Status::OK();
+    }
+
+    if (!api.device_get) return missingDriverFunction("cuDeviceGet");
+    if (!api.device_get_attribute)
+        return missingDriverFunction("cuDeviceGetAttribute");
+
+    CUdevice device;
+    CUresult result = api.device_get(&device, options.location_id);
+    if (result != CUDA_SUCCESS) return cudaDriverFailure("cuDeviceGet", result);
+
+    prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+    prop.location.id = device;
+
+    int gpu_direct_rdma_supported = 0;
+    result = api.device_get_attribute(
+        &gpu_direct_rdma_supported,
+        CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_WITH_CUDA_VMM_SUPPORTED, device);
+    if (result != CUDA_SUCCESS)
+        return cudaDriverFailure("cuDeviceGetAttribute(GPU Direct RDMA)",
+                                 result);
+    if (gpu_direct_rdma_supported) prop.allocFlags.gpuDirectRDMACapable = 1;
+    return Status::OK();
+}
+
+struct VmmAllocationOwnerRegistry {
+    std::mutex mutex;
+    std::unordered_map<void*, std::unique_ptr<NvlinkVmmAllocation>> owners;
+};
+
+VmmAllocationOwnerRegistry& vmmAllocationOwnerRegistry() {
+    // Legacy pinned allocations may intentionally remain quarantined until
+    // process exit after a CUDA cleanup failure. Avoid running their owners'
+    // destructors against already-destroyed provenance state.
+    static auto* registry = new VmmAllocationOwnerRegistry();
+    return *registry;
+}
+
+#endif
 
 /// Per-device CUDA stream pool (thread-local).
 /// Each thread maintains a map of device_id → stream.
@@ -84,7 +462,7 @@ class PerDeviceStreamPool {
                   std::to_string(prop.pciBusID) + ":" +
                   std::to_string(prop.pciDeviceID);
         }
-        const char *visible = getenv("CUDA_VISIBLE_DEVICES");
+        const char* visible = getenv("CUDA_VISIBLE_DEVICES");
         LOG(INFO) << "NvlinkTransport: NVLink CUDA stream created on device "
                   << device_id << " [physical: " << pci
                   << "] CUDA_VISIBLE_DEVICES="
@@ -95,7 +473,7 @@ class PerDeviceStreamPool {
     ~PerDeviceStreamPool() {
         int saved_device = 0;
         cudaGetDevice(&saved_device);
-        for (auto &kv : pool_) {
+        for (auto& kv : pool_) {
             cudaSetDevice(kv.first);
             if (kv.second.stream) cudaStreamDestroy(kv.second.stream);
         }
@@ -136,7 +514,7 @@ class PerDeviceEventPool {
     ~PerDeviceEventPool() {
         int saved_device = 0;
         cudaGetDevice(&saved_device);
-        for (auto &kv : pool_) {
+        for (auto& kv : pool_) {
             cudaSetDevice(kv.first);
             if (kv.second) cudaEventDestroy(kv.second);
         }
@@ -155,7 +533,7 @@ static cudaEvent_t getCallerSyncEvent() {
     return tl_device_event_pool.getOrCreate(current_device);
 }
 
-static int getDeviceForPointer(const void *ptr) {
+static int getDeviceForPointer(const void* ptr) {
     cudaPointerAttributes attr;
     if (cudaPointerGetAttributes(&attr, ptr) != cudaSuccess) {
         cudaGetLastError();
@@ -164,7 +542,7 @@ static int getDeviceForPointer(const void *ptr) {
     return (attr.type == cudaMemoryTypeDevice) ? attr.device : -1;
 }
 
-static CudaStreamEntry getStreamForRequest(const void *source) {
+static CudaStreamEntry getStreamForRequest(const void* source) {
     int device_id = getDeviceForPointer(source);
     if (device_id < 0) {
         cudaGetDevice(&device_id);
@@ -174,6 +552,713 @@ static CudaStreamEntry getStreamForRequest(const void *source) {
 }
 
 }  // anonymous namespace
+
+#if defined(USE_MNNVL) && defined(USE_CUDA)
+class NvlinkTransport::FabricMappingAttempt {
+   public:
+    explicit FabricMappingAttempt(NvlinkTransport& transport)
+        : transport_(transport) {}
+    FabricMappingAttempt(const FabricMappingAttempt&) = delete;
+    FabricMappingAttempt& operator=(const FabricMappingAttempt&) = delete;
+
+    ~FabricMappingAttempt() {
+        if (cleanup_.mapped || cleanup_.address_reserved ||
+            cleanup_.handle_owned) {
+            transport_.ReleaseOrQuarantineFabricMapping(
+                cleanup_, "lazy Fabric import failure");
+        }
+    }
+
+    CUmemGenericAllocationHandle* handleOut() { return &cleanup_.handle; }
+    CUmemGenericAllocationHandle handle() const { return cleanup_.handle; }
+    void markHandleOwned() { cleanup_.handle_owned = true; }
+
+    CUdeviceptr* addressOut() { return &cleanup_.address; }
+    CUdeviceptr address() const { return cleanup_.address; }
+    void markAddressReserved(size_t length) {
+        cleanup_.length = length;
+        cleanup_.address_reserved = true;
+    }
+    void markMapped() { cleanup_.mapped = true; }
+
+    CUresult releaseHandle() {
+        if (!cleanup_.handle_owned) return CUDA_SUCCESS;
+        CUresult result =
+            transport_.fabric_driver_api_.mem_release(cleanup_.handle);
+        if (result == CUDA_SUCCESS) {
+            cleanup_.handle_owned = false;
+            cleanup_.handle = 0;
+        }
+        return result;
+    }
+
+    void transferMappingOwnership() {
+        cleanup_.mapped = false;
+        cleanup_.address_reserved = false;
+        cleanup_.address = 0;
+        cleanup_.length = 0;
+    }
+
+   private:
+    NvlinkTransport& transport_;
+    FabricMappingCleanup cleanup_;
+};
+
+class NvlinkTransport::RetainedHandleGuard {
+   public:
+    RetainedHandleGuard(NvlinkTransport& transport,
+                        CUmemGenericAllocationHandle handle,
+                        const char* failure_stage)
+        : transport_(transport),
+          handle_(handle),
+          failure_stage_(failure_stage) {}
+
+    RetainedHandleGuard(const RetainedHandleGuard&) = delete;
+    RetainedHandleGuard& operator=(const RetainedHandleGuard&) = delete;
+
+    ~RetainedHandleGuard() {
+        if (owned_) {
+            transport_.ReleaseOrQuarantineRetainedHandle(handle_,
+                                                         failure_stage_);
+        }
+    }
+
+    void TransferOwnership() { owned_ = false; }
+
+   private:
+    NvlinkTransport& transport_;
+    CUmemGenericAllocationHandle handle_ = 0;
+    const char* failure_stage_ = nullptr;
+    bool owned_ = true;
+};
+
+bool NvlinkTransport::CleanupFabricMapping(FabricMappingCleanup& cleanup,
+                                           const char* failure_stage) noexcept {
+    try {
+        // Cleanup is a staged state machine. A later CUDA primitive is unsafe
+        // until the preceding ownership stage has completed successfully.
+        if (cleanup.mapped) {
+            if (!fabric_driver_api_.mem_unmap) {
+                LOG(ERROR) << "NvlinkTransport: missing cuMemUnmap while "
+                           << failure_stage;
+                return false;
+            }
+            const CUresult result =
+                fabric_driver_api_.mem_unmap(cleanup.address, cleanup.length);
+            if (result != CUDA_SUCCESS) {
+                LOG(ERROR) << "NvlinkTransport: cuMemUnmap failed while "
+                           << failure_stage << ": " << result;
+                return false;
+            }
+            cleanup.mapped = false;
+        }
+
+        if (cleanup.address_reserved) {
+            if (!fabric_driver_api_.mem_address_free) {
+                LOG(ERROR) << "NvlinkTransport: missing cuMemAddressFree while "
+                           << failure_stage;
+                return false;
+            }
+            const CUresult result = fabric_driver_api_.mem_address_free(
+                cleanup.address, cleanup.length);
+            if (result != CUDA_SUCCESS) {
+                LOG(ERROR) << "NvlinkTransport: cuMemAddressFree failed while "
+                           << failure_stage << ": " << result;
+                return false;
+            }
+            cleanup.address_reserved = false;
+            cleanup.address = 0;
+        }
+
+        if (cleanup.handle_owned) {
+            if (!fabric_driver_api_.mem_release) {
+                LOG(ERROR) << "NvlinkTransport: missing cuMemRelease while "
+                           << failure_stage;
+                return false;
+            }
+            const CUresult result =
+                fabric_driver_api_.mem_release(cleanup.handle);
+            if (result != CUDA_SUCCESS) {
+                LOG(ERROR) << "NvlinkTransport: cuMemRelease failed while "
+                           << failure_stage << ": " << result;
+                return false;
+            }
+            cleanup.handle_owned = false;
+            cleanup.handle = 0;
+        }
+
+        cleanup.length = 0;
+        return true;
+    } catch (const std::exception& error) {
+        LOG(ERROR) << "NvlinkTransport: CUDA cleanup adapter threw while "
+                   << failure_stage << ": " << error.what();
+    } catch (...) {
+        LOG(ERROR) << "NvlinkTransport: CUDA cleanup adapter threw while "
+                   << failure_stage;
+    }
+    return false;
+}
+
+bool NvlinkTransport::RetryQuarantinedFabricMappings() noexcept {
+    auto retained = quarantined_fabric_mappings_.begin();
+    for (auto it = quarantined_fabric_mappings_.begin();
+         it != quarantined_fabric_mappings_.end(); ++it) {
+        if (!CleanupFabricMapping(*it, "retrying lazy Fabric cleanup")) {
+            if (retained != it) *retained = *it;
+            ++retained;
+        }
+    }
+    quarantined_fabric_mappings_.erase(retained,
+                                       quarantined_fabric_mappings_.end());
+    return quarantined_fabric_mappings_.empty();
+}
+
+void NvlinkTransport::PreserveProcessLifetimeFabricCleanup(
+    FabricMappingCleanup cleanup) noexcept {
+    struct ProcessLifetimeFabricCleanupQuarantine {
+        std::mutex mutex;
+        std::vector<FabricMappingCleanup> cleanups;
+    };
+    try {
+        static auto* quarantine = new ProcessLifetimeFabricCleanupQuarantine();
+        std::lock_guard<std::mutex> lock(quarantine->mutex);
+        quarantine->cleanups.push_back(cleanup);
+    } catch (const std::exception& error) {
+        LOG(ERROR) << "NvlinkTransport: could not record process-lifetime "
+                      "Fabric cleanup ownership: "
+                   << error.what();
+    } catch (...) {
+        LOG(ERROR) << "NvlinkTransport: could not record process-lifetime "
+                      "Fabric cleanup ownership";
+    }
+}
+
+void NvlinkTransport::ReleaseOrQuarantineFabricMapping(
+    FabricMappingCleanup cleanup, const char* failure_stage) noexcept {
+    if (CleanupFabricMapping(cleanup, failure_stage)) return;
+
+    try {
+        // relocateSharedMemoryAddress() reserves this slot before importing a
+        // handle. The catch remains as a destructor-safe last line of defense.
+        quarantined_fabric_mappings_.push_back(cleanup);
+        LOG(ERROR) << "NvlinkTransport: retaining failed Fabric cleanup for "
+                      "a later retry";
+    } catch (...) {
+        PreserveProcessLifetimeFabricCleanup(cleanup);
+        LOG(ERROR) << "NvlinkTransport: preserving failed Fabric cleanup in "
+                      "the process-lifetime quarantine";
+    }
+}
+#endif
+
+#if defined(USE_MNNVL) && defined(USE_CUDA)
+
+NvlinkVmmAllocation::DriverApi NvlinkVmmAllocation::ProductionDriverApi() {
+    DriverApi api;
+    api.device_get_count = [](int* count) { return cuDeviceGetCount(count); };
+    api.device_get = [](CUdevice* device, int ordinal) {
+        return cuDeviceGet(device, ordinal);
+    };
+    api.device_get_attribute = [](int* value, CUdevice_attribute attribute,
+                                  CUdevice device) {
+        return cuDeviceGetAttribute(value, attribute, device);
+    };
+    api.mem_get_allocation_granularity =
+        [](size_t* granularity, const CUmemAllocationProp* prop,
+           CUmemAllocationGranularity_flags flags) {
+            return cuMemGetAllocationGranularity(granularity, prop, flags);
+        };
+    api.mem_create = [](CUmemGenericAllocationHandle* handle, size_t size,
+                        const CUmemAllocationProp* prop,
+                        unsigned long long flags) {
+        return cuMemCreate(handle, size, prop, flags);
+    };
+    api.mem_address_reserve = [](CUdeviceptr* ptr, size_t size,
+                                 size_t alignment, CUdeviceptr addr,
+                                 unsigned long long flags) {
+        return cuMemAddressReserve(ptr, size, alignment, addr, flags);
+    };
+    api.mem_map = [](CUdeviceptr ptr, size_t size, size_t offset,
+                     CUmemGenericAllocationHandle handle,
+                     unsigned long long flags) {
+        return cuMemMap(ptr, size, offset, handle, flags);
+    };
+    api.mem_set_access = [](CUdeviceptr ptr, size_t size,
+                            const CUmemAccessDesc* desc, size_t count) {
+        return cuMemSetAccess(ptr, size, desc, count);
+    };
+    api.mem_unmap = [](CUdeviceptr ptr, size_t size) {
+        return cuMemUnmap(ptr, size);
+    };
+    api.mem_address_free = [](CUdeviceptr ptr, size_t size) {
+        return cuMemAddressFree(ptr, size);
+    };
+    api.mem_release = [](CUmemGenericAllocationHandle handle) {
+        return cuMemRelease(handle);
+    };
+    api.mem_retain_allocation_handle = [](CUmemGenericAllocationHandle* handle,
+                                          void* ptr) {
+        return cuMemRetainAllocationHandle(handle, ptr);
+    };
+    api.mem_get_allocation_properties_from_handle =
+        [](CUmemAllocationProp* prop, CUmemGenericAllocationHandle handle) {
+            return cuMemGetAllocationPropertiesFromHandle(prop, handle);
+        };
+    api.mem_get_address_range = [](CUdeviceptr* base, size_t* size,
+                                   CUdeviceptr ptr) {
+        return cuMemGetAddressRange(base, size, ptr);
+    };
+    api.mem_export_to_shareable_handle =
+        [](void* shareable_handle, CUmemGenericAllocationHandle handle,
+           CUmemAllocationHandleType type, unsigned long long flags) {
+            return cuMemExportToShareableHandle(shareable_handle, handle, type,
+                                                flags);
+        };
+    api.mem_import_from_shareable_handle =
+        [](CUmemGenericAllocationHandle* handle, void* shareable_handle,
+           CUmemAllocationHandleType type) {
+            return cuMemImportFromShareableHandle(handle, shareable_handle,
+                                                  type);
+        };
+    return api;
+}
+
+bool NvlinkVmmAllocation::RegisterOwnedRange(void* base, size_t length) {
+    if (base == nullptr || length == 0) return false;
+    auto& registry = ownedVmmRangeRegistry();
+    std::lock_guard<std::mutex> lock(registry.mutex);
+    auto& ranges = registry.ranges;
+    const uintptr_t address = reinterpret_cast<uintptr_t>(base);
+    auto [it, inserted] = ranges.emplace(address, OwnedVmmRange{length, 0});
+    if (!inserted && it->second.length != length) return false;
+    ++it->second.owners;
+    return true;
+}
+
+bool NvlinkVmmAllocation::UnregisterOwnedRange(void* base, size_t length) {
+    if (base == nullptr || length == 0) return false;
+    auto& registry = ownedVmmRangeRegistry();
+    std::lock_guard<std::mutex> lock(registry.mutex);
+    auto& ranges = registry.ranges;
+    const auto it = ranges.find(reinterpret_cast<uintptr_t>(base));
+    if (it == ranges.end() || it->second.length != length ||
+        it->second.owners == 0) {
+        LOG(ERROR) << "NvlinkVmmAllocation: owned range registry mismatch";
+        return false;
+    }
+    if (--it->second.owners == 0) ranges.erase(it);
+    return true;
+}
+
+bool NvlinkVmmAllocation::IsExactOwnedRange(void* base, size_t length) {
+    if (base == nullptr || length == 0) return false;
+    auto& registry = ownedVmmRangeRegistry();
+    std::lock_guard<std::mutex> lock(registry.mutex);
+    const auto& ranges = registry.ranges;
+    const auto it = ranges.find(reinterpret_cast<uintptr_t>(base));
+    return it != ranges.end() && it->second.length == length &&
+           it->second.owners > 0;
+}
+
+NvlinkVmmAllocation::NvlinkVmmAllocation(NvlinkVmmAllocation&& other) noexcept
+    : base_(other.base_),
+      length_(other.length_),
+      granularity_(other.granularity_),
+      va_alignment_(other.va_alignment_),
+      location_type_(other.location_type_),
+      location_id_(other.location_id_),
+      fabric_exportable_(other.fabric_exportable_),
+      mapped_(other.mapped_),
+      address_reserved_(other.address_reserved_),
+      handle_owned_(other.handle_owned_),
+      allocation_handle_(other.allocation_handle_),
+      owned_range_registered_(other.owned_range_registered_),
+      driver_api_(std::move(other.driver_api_)) {
+    other.base_ = nullptr;
+    other.length_ = 0;
+    other.granularity_ = 0;
+    other.va_alignment_ = 0;
+    other.mapped_ = false;
+    other.address_reserved_ = false;
+    other.handle_owned_ = false;
+    other.allocation_handle_ = 0;
+    other.owned_range_registered_ = false;
+}
+
+NvlinkVmmAllocation::~NvlinkVmmAllocation() { reset(); }
+
+Status NvlinkVmmAllocation::Release() {
+    const CUdeviceptr ptr = reinterpret_cast<CUdeviceptr>(base_);
+
+    // Cleanup-pending Fabric memory must stop satisfying provenance checks
+    // before the first unmap attempt. Otherwise a failed unmap would leave a
+    // range eligible for a new remote-accessible registration while teardown
+    // is already in progress. This registry transition is idempotent and does
+    // not need to be repeated by later release retries.
+    if (owned_range_registered_) {
+        if (!UnregisterOwnedRange(base_, length_)) {
+            return Status::Memory(
+                "HOST_NUMA VMM owned-range provenance removal failed");
+        }
+        owned_range_registered_ = false;
+    }
+
+    // These operations are deliberately serialized in reverse creation order.
+    // A later stage must not run after an earlier stage fails: for example, a
+    // still-mapped VA cannot safely be returned to the CUDA address allocator.
+    if (mapped_) {
+        if (!driver_api_.mem_unmap) return missingDriverFunction("cuMemUnmap");
+        CUresult result = driver_api_.mem_unmap(ptr, length_);
+        if (result != CUDA_SUCCESS)
+            return cudaDriverFailure("cuMemUnmap", result);
+        mapped_ = false;
+    }
+
+    if (address_reserved_) {
+        if (!driver_api_.mem_address_free)
+            return missingDriverFunction("cuMemAddressFree");
+        CUresult result = driver_api_.mem_address_free(ptr, length_);
+        if (result != CUDA_SUCCESS)
+            return cudaDriverFailure("cuMemAddressFree", result);
+        address_reserved_ = false;
+        base_ = nullptr;
+    }
+
+    if (handle_owned_) {
+        if (!driver_api_.mem_release)
+            return missingDriverFunction("cuMemRelease");
+        CUresult result = driver_api_.mem_release(
+            static_cast<CUmemGenericAllocationHandle>(allocation_handle_));
+        if (result != CUDA_SUCCESS)
+            return cudaDriverFailure("cuMemRelease", result);
+        handle_owned_ = false;
+        allocation_handle_ = 0;
+    }
+
+    base_ = nullptr;
+    length_ = 0;
+    granularity_ = 0;
+    va_alignment_ = 0;
+    return Status::OK();
+}
+
+void NvlinkVmmAllocation::reset() noexcept {
+    try {
+        Status status = Release();
+        if (!status.ok()) {
+            LOG(ERROR) << "NvlinkVmmAllocation: best-effort cleanup retained "
+                          "unreleased CUDA ownership: "
+                       << status;
+        }
+    } catch (const std::exception& error) {
+        LOG(ERROR) << "NvlinkVmmAllocation: best-effort cleanup threw: "
+                   << error.what();
+    } catch (...) {
+        LOG(ERROR) << "NvlinkVmmAllocation: best-effort cleanup threw an "
+                      "unknown exception";
+    }
+}
+
+bool NvlinkVmmAllocation::RetryCleanupPendingOwners() {
+    return retryCleanupPendingVmmOwners();
+}
+
+size_t NvlinkVmmAllocation::CleanupPendingOwnerCount() {
+    return cleanupPendingVmmOwnerCount();
+}
+
+Status NvlinkVmmAllocation::CheckStrictFabricCapability() {
+    return CheckStrictFabricCapabilityWithDriverApi(ProductionDriverApi());
+}
+
+Status NvlinkVmmAllocation::CheckStrictFabricCapabilityWithDriverApi(
+    const DriverApi& api) {
+    if (std::getenv("MC_USE_NVLINK_IPC") != nullptr) {
+        return Status::NotSupportedTransport(
+            "MC_USE_NVLINK_IPC disables Fabric VMM allocations");
+    }
+    if (!api.device_get_count) return missingDriverFunction("cuDeviceGetCount");
+    if (!api.device_get) return missingDriverFunction("cuDeviceGet");
+    if (!api.device_get_attribute)
+        return missingDriverFunction("cuDeviceGetAttribute");
+
+    int device_count = 0;
+    CUresult result = api.device_get_count(&device_count);
+    if (result != CUDA_SUCCESS)
+        return cudaDriverFailure("cuDeviceGetCount", result);
+    if (device_count <= 0)
+        return Status::NotSupportedTransport(
+            "Fabric VMM requires at least one visible CUDA device");
+
+    for (int ordinal = 0; ordinal < device_count; ++ordinal) {
+        CUdevice device;
+        result = api.device_get(&device, ordinal);
+        if (result != CUDA_SUCCESS)
+            return cudaDriverFailure("cuDeviceGet", result);
+
+        int fabric_supported = 0;
+        result = api.device_get_attribute(
+            &fabric_supported, CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED,
+            device);
+        if (result != CUDA_SUCCESS)
+            return cudaDriverFailure(
+                "cuDeviceGetAttribute(Fabric handle support)", result);
+        if (!fabric_supported) {
+            return Status::NotSupportedTransport(
+                "visible CUDA device " + std::to_string(ordinal) +
+                " does not support Fabric allocation handles");
+        }
+    }
+    return Status::OK();
+}
+
+Status NvlinkVmmAllocation::GetAllocationGranularity(LocationType location_type,
+                                                     int location_id,
+                                                     bool fabric_exportable,
+                                                     size_t& granularity) {
+    return GetAllocationGranularityWithDriverApi(
+        location_type, location_id, fabric_exportable, ProductionDriverApi(),
+        granularity);
+}
+
+Status NvlinkVmmAllocation::GetAllocationGranularityWithDriverApi(
+    LocationType location_type, int location_id, bool fabric_exportable,
+    const DriverApi& api, size_t& granularity) {
+    granularity = 0;
+    if (location_id < 0)
+        return Status::InvalidArgument("VMM location id must be non-negative");
+    if (!api.mem_get_allocation_granularity)
+        return missingDriverFunction("cuMemGetAllocationGranularity");
+
+    Options options;
+    options.location_type = location_type;
+    options.location_id = location_id;
+    options.fabric_exportable = fabric_exportable;
+    CUmemAllocationProp prop = {};
+    Status status = buildAllocationProp(options, api, prop);
+    if (!status.ok()) return status;
+
+    CUresult result = api.mem_get_allocation_granularity(
+        &granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM);
+    if (result != CUDA_SUCCESS)
+        return cudaDriverFailure("cuMemGetAllocationGranularity", result);
+    if (!isPowerOfTwo(granularity)) {
+        granularity = 0;
+        return Status::Memory(
+            "CUDA VMM allocation granularity is zero or not a power of two");
+    }
+    return Status::OK();
+}
+
+Status NvlinkVmmAllocation::Create(
+    const Options& options, std::unique_ptr<NvlinkVmmAllocation>& allocation) {
+    return CreateWithDriverApi(options, ProductionDriverApi(), allocation);
+}
+
+Status NvlinkVmmAllocation::CreateWithDriverApi(
+    const Options& options, const DriverApi& api,
+    std::unique_ptr<NvlinkVmmAllocation>& allocation) {
+    allocation.reset();
+    if (!RetryCleanupPendingOwners()) {
+        return Status::Memory(
+            "a previous VMM factory rollback is still pending cleanup");
+    }
+    if (options.requested_length == 0)
+        return Status::InvalidArgument(
+            "VMM allocation length must be greater than zero");
+    if (options.location_id < 0)
+        return Status::InvalidArgument("VMM location id must be non-negative");
+    if (!api.mem_create) return missingDriverFunction("cuMemCreate");
+    if (!api.mem_address_reserve)
+        return missingDriverFunction("cuMemAddressReserve");
+    if (!api.mem_map) return missingDriverFunction("cuMemMap");
+    if (!api.mem_set_access) return missingDriverFunction("cuMemSetAccess");
+    if (!api.mem_unmap) return missingDriverFunction("cuMemUnmap");
+    if (!api.mem_address_free) return missingDriverFunction("cuMemAddressFree");
+    if (!api.mem_release) return missingDriverFunction("cuMemRelease");
+    if (!api.device_get_count) return missingDriverFunction("cuDeviceGetCount");
+    if (!api.device_get) return missingDriverFunction("cuDeviceGet");
+
+    if (options.fabric_exportable) {
+        Status status = CheckStrictFabricCapabilityWithDriverApi(api);
+        if (!status.ok()) return status;
+    }
+
+    size_t granularity = 0;
+    Status status = GetAllocationGranularityWithDriverApi(
+        options.location_type, options.location_id, options.fabric_exportable,
+        api, granularity);
+    if (!status.ok()) return status;
+
+    size_t va_alignment = granularity;
+    if (options.required_va_alignment != 0) {
+        if (!isPowerOfTwo(options.required_va_alignment) ||
+            options.required_va_alignment < granularity ||
+            options.required_va_alignment % granularity != 0) {
+            return Status::InvalidArgument(
+                "required VA alignment must be a power-of-two multiple of "
+                "CUDA allocation granularity");
+        }
+        va_alignment = options.required_va_alignment;
+    }
+
+    const size_t remainder = options.requested_length % va_alignment;
+    size_t length = options.requested_length;
+    if (remainder != 0) {
+        const size_t padding = va_alignment - remainder;
+        if (length > std::numeric_limits<size_t>::max() - padding)
+            return Status::InvalidArgument(
+                "VMM allocation length overflows during alignment");
+        length += padding;
+    }
+
+    CUmemAllocationProp prop = {};
+    status = buildAllocationProp(options, api, prop);
+    if (!status.ok()) return status;
+
+    std::unique_ptr<CleanupPendingVmmOwnerNode> cleanup_node;
+    std::unique_ptr<NvlinkVmmAllocation> owner;
+    try {
+        // Preallocate the intrusive quarantine node before acquiring any CUDA
+        // resource. Moving this node into the process-lifetime registry cannot
+        // fail even under memory pressure during rollback.
+        cleanup_node = std::make_unique<CleanupPendingVmmOwnerNode>();
+        owner = std::unique_ptr<NvlinkVmmAllocation>(new NvlinkVmmAllocation());
+    } catch (const std::exception& error) {
+        return Status::Memory(std::string("VMM owner allocation failed: ") +
+                              error.what());
+    }
+    owner->length_ = length;
+    owner->granularity_ = granularity;
+    owner->va_alignment_ = va_alignment;
+    owner->location_type_ = options.location_type;
+    owner->location_id_ = options.location_id;
+    owner->fabric_exportable_ = options.fabric_exportable;
+    owner->driver_api_ = api;
+
+    auto rollback = [&](Status cause) -> Status {
+        Status cleanup;
+        try {
+            cleanup = owner->Release();
+        } catch (const std::exception& error) {
+            cleanup = Status::Memory(std::string("VMM rollback threw: ") +
+                                     error.what());
+        } catch (...) {
+            cleanup = Status::Memory("VMM rollback threw an unknown exception");
+        }
+        if (!cleanup.ok()) {
+            LOG(ERROR) << "NvlinkVmmAllocation: factory rollback failed; "
+                          "quarantining complete CUDA ownership for retry: "
+                       << cleanup;
+            cleanup_node->owner = std::move(owner);
+            quarantineCleanupPendingVmmOwner(std::move(cleanup_node));
+        }
+        return cause;
+    };
+
+    CUmemGenericAllocationHandle handle;
+    CUresult result = api.mem_create(&handle, length, &prop, 0);
+    if (result != CUDA_SUCCESS) return cudaDriverFailure("cuMemCreate", result);
+    owner->allocation_handle_ = static_cast<uint64_t>(handle);
+    owner->handle_owned_ = true;
+
+    CUdeviceptr ptr = 0;
+    result = api.mem_address_reserve(&ptr, length, va_alignment, 0, 0);
+    if (result != CUDA_SUCCESS) {
+        status = cudaDriverFailure("cuMemAddressReserve", result);
+        return rollback(status);
+    }
+    owner->base_ = reinterpret_cast<void*>(ptr);
+    owner->address_reserved_ = true;
+
+    result = api.mem_map(ptr, length, 0, handle, 0);
+    if (result != CUDA_SUCCESS) {
+        status = cudaDriverFailure("cuMemMap", result);
+        return rollback(status);
+    }
+    owner->mapped_ = true;
+
+    const auto access_start = std::chrono::steady_clock::now();
+    auto observe_access = [&](bool success) {
+        if (!options.access_observer) return;
+        const auto elapsed =
+            std::chrono::duration_cast<std::chrono::microseconds>(
+                std::chrono::steady_clock::now() - access_start)
+                .count();
+        options.access_observer(
+            static_cast<uint64_t>(std::max<int64_t>(elapsed, 0)), success);
+    };
+
+    auto grant_access = [&](CUmemLocationType location_type,
+                            int location_id) -> Status {
+        CUmemAccessDesc access = {};
+        access.location.type = location_type;
+        access.location.id = location_id;
+        access.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+        CUresult access_result = api.mem_set_access(ptr, length, &access, 1);
+        if (access_result != CUDA_SUCCESS)
+            return cudaDriverFailure("cuMemSetAccess", access_result);
+        return Status::OK();
+    };
+
+    if (options.location_type == LocationType::HOST_NUMA) {
+        status =
+            grant_access(CU_MEM_LOCATION_TYPE_HOST_NUMA, options.location_id);
+        if (!status.ok()) {
+            observe_access(false);
+            return rollback(status);
+        }
+    }
+
+    int device_count = 0;
+    result = api.device_get_count(&device_count);
+    if (result != CUDA_SUCCESS) {
+        status = cudaDriverFailure("cuDeviceGetCount", result);
+        observe_access(false);
+        return rollback(status);
+    }
+    if (device_count <= 0) {
+        observe_access(false);
+        return rollback(Status::NotSupportedTransport(
+            "VMM allocation requires at least one visible CUDA device"));
+    }
+
+    for (int ordinal = 0; ordinal < device_count; ++ordinal) {
+        CUdevice device;
+        result = api.device_get(&device, ordinal);
+        if (result != CUDA_SUCCESS) {
+            status = cudaDriverFailure("cuDeviceGet", result);
+            observe_access(false);
+            return rollback(status);
+        }
+        status = grant_access(CU_MEM_LOCATION_TYPE_DEVICE, device);
+        if (!status.ok()) {
+            observe_access(false);
+            return rollback(status);
+        }
+    }
+    observe_access(true);
+
+    result = api.mem_release(handle);
+    if (result != CUDA_SUCCESS) {
+        status = cudaDriverFailure("cuMemRelease", result);
+        return rollback(status);
+    }
+    owner->handle_owned_ = false;
+    owner->allocation_handle_ = 0;
+    if (options.location_type == LocationType::HOST_NUMA &&
+        options.fabric_exportable) {
+        if (!RegisterOwnedRange(owner->base_, owner->length_)) {
+            return rollback(Status::Memory(
+                "HOST_NUMA VMM owned-range provenance registration failed"));
+        }
+        owner->owned_range_registered_ = true;
+    }
+    allocation = std::move(owner);
+    return Status::OK();
+}
+
+#endif
 
 using Slice = Transport::Slice;
 
@@ -186,10 +1271,10 @@ using Slice = Transport::Slice;
 /// (via cudaEventRecord + cudaStreamWaitEvent) before calling this function.
 /// Individual slice errors are tracked so that slices whose memcpy failed
 /// are marked as FAILED while successfully submitted ones are POSTED.
-static void submitBatchMemcpy(const std::vector<Slice *> &slices,
-                              const std::vector<void *> &srcs,
-                              const std::vector<void *> &dsts,
-                              const std::vector<size_t> &sizes,
+static void submitBatchMemcpy(const std::vector<Slice*>& slices,
+                              const std::vector<void*>& srcs,
+                              const std::vector<void*>& dsts,
+                              const std::vector<size_t>& sizes,
                               cudaStream_t stream) {
     if (slices.empty()) return;
 
@@ -228,8 +1313,8 @@ static void submitBatchMemcpy(const std::vector<Slice *> &slices,
 #endif
 
 #if CUDART_VERSION >= 13000
-    err = cudaMemcpyBatchAsync(const_cast<const void **>(dsts.data()),
-                               const_cast<const void **>(srcs.data()),
+    err = cudaMemcpyBatchAsync(const_cast<const void**>(dsts.data()),
+                               const_cast<const void**>(srcs.data()),
                                mutable_sizes.data(), static_cast<size_t>(count),
                                &attr, &attrs_idx, 1, stream);
     if (err != cudaSuccess) {
@@ -245,12 +1330,12 @@ static void submitBatchMemcpy(const std::vector<Slice *> &slices,
     } else {
         for (size_t i = 0; i < count; ++i) {
             slices[i]->status = Slice::POSTED;
-            slices[i]->local.cuda_stream = (void *)stream;
+            slices[i]->local.cuda_stream = (void*)stream;
         }
     }
 #elif CUDART_VERSION >= 12080
-    err = cudaMemcpyBatchAsync(const_cast<void **>(dsts.data()),
-                               const_cast<void **>(srcs.data()),
+    err = cudaMemcpyBatchAsync(const_cast<void**>(dsts.data()),
+                               const_cast<void**>(srcs.data()),
                                mutable_sizes.data(), static_cast<size_t>(count),
                                &attr, &attrs_idx, 1, &fail_idx, stream);
     if (err != cudaSuccess) {
@@ -270,7 +1355,7 @@ static void submitBatchMemcpy(const std::vector<Slice *> &slices,
         // Copies (fail_idx, count) were never submitted → FAILED.
         for (size_t i = 0; i < fail_idx; ++i) {
             slices[i]->status = Slice::POSTED;
-            slices[i]->local.cuda_stream = (void *)stream;
+            slices[i]->local.cuda_stream = (void*)stream;
         }
         for (size_t i = fail_idx; i < count; ++i) {
             if (slices[i]->status == Slice::PENDING) {
@@ -280,7 +1365,7 @@ static void submitBatchMemcpy(const std::vector<Slice *> &slices,
     } else {
         for (size_t i = 0; i < count; ++i) {
             slices[i]->status = Slice::POSTED;
-            slices[i]->local.cuda_stream = (void *)stream;
+            slices[i]->local.cuda_stream = (void*)stream;
         }
     }
 #else
@@ -296,7 +1381,7 @@ static void submitBatchMemcpy(const std::vector<Slice *> &slices,
             continue;
         }
         slices[i]->status = Slice::POSTED;
-        slices[i]->local.cuda_stream = (void *)stream;
+        slices[i]->local.cuda_stream = (void*)stream;
     }
     return;  // Slice states already set above
 #endif
@@ -315,6 +1400,9 @@ static int getNumDevices() {
 }
 
 static bool supportFabricMem() {
+#ifndef USE_CUDA
+    return false;
+#else
     if (getenv("MC_USE_NVLINK_IPC")) return false;
 
     int num_devices = 0;
@@ -329,7 +1417,6 @@ static bool supportFabricMem() {
         return false;
     }
 
-#ifdef USE_CUDA
     for (int device_id = 0; device_id < num_devices; ++device_id) {
         int device_support_fabric_mem = 0;
         cuDeviceGetAttribute(&device_support_fabric_mem,
@@ -339,8 +1426,8 @@ static bool supportFabricMem() {
             return false;
         }
     }
-#endif
     return true;
+#endif
 }
 
 static bool enableP2PAccess(int src_device_id, int dst_device_id) {
@@ -392,7 +1479,17 @@ static bool enableP2PAccess(int src_device_id, int dst_device_id) {
     return true;
 }
 
-NvlinkTransport::NvlinkTransport() : use_fabric_mem_(supportFabricMem()) {}
+NvlinkTransport::NvlinkTransport()
+#if defined(USE_MNNVL) && defined(USE_CUDA)
+    : use_fabric_mem_(supportFabricMem()),
+      fabric_driver_api_(NvlinkVmmAllocation::ProductionDriverApi()),
+      consumer_metrics_(std::make_unique<ConsumerMetrics>())
+#else
+    : use_fabric_mem_(supportFabricMem()),
+      consumer_metrics_(std::make_unique<ConsumerMetrics>())
+#endif
+{
+}
 //     int num_devices = getNumDevices();
 //     if (globalConfig().trace) {
 //         LOG(INFO) << "NvlinkTransport: use_fabric_mem_:" << use_fabric_mem_
@@ -421,19 +1518,143 @@ NvlinkTransport::NvlinkTransport() : use_fabric_mem_(supportFabricMem()) {}
 // }
 
 NvlinkTransport::~NvlinkTransport() {
-    if (use_fabric_mem_) {
-        for (auto &entry : remap_entries_) {
-            freePinnedLocalMemory(entry.second.shm_addr);
-        }
-    } else {
-        for (auto &entry : remap_entries_) {
-            cudaIpcCloseMemHandle(entry.second.shm_addr);
+#if defined(USE_MNNVL) && defined(USE_CUDA)
+    size_t cached_fabric_mapping_count = 0;
+    for (const auto& entry : remap_entries_) {
+        cached_fabric_mapping_count +=
+            entry.second.kind == OpenedMappingKind::FABRIC;
+    }
+    try {
+        quarantined_fabric_mappings_.reserve(
+            quarantined_fabric_mappings_.size() + cached_fabric_mapping_count);
+    } catch (const std::exception& error) {
+        LOG(ERROR) << "NvlinkTransport: unable to reserve teardown Fabric "
+                      "cleanup quarantine: "
+                   << error.what();
+    }
+#endif
+    for (auto& entry : remap_entries_) {
+        if (entry.second.kind == OpenedMappingKind::FABRIC) {
+#if defined(USE_MNNVL) && defined(USE_CUDA)
+            FabricMappingCleanup cleanup;
+            cleanup.address =
+                reinterpret_cast<CUdeviceptr>(entry.second.shm_addr);
+            cleanup.length = entry.second.length;
+            cleanup.mapped = true;
+            cleanup.address_reserved = true;
+            ReleaseOrQuarantineFabricMapping(
+                cleanup, "releasing cached Fabric mapping during teardown");
+#endif
+        } else {
+            cudaError_t result = cudaIpcCloseMemHandle(entry.second.shm_addr);
+            if (result != cudaSuccess)
+                LOG(ERROR) << "NvlinkTransport: cudaIpcCloseMemHandle failed "
+                              "during teardown: "
+                           << cudaGetErrorString(result);
         }
     }
     remap_entries_.clear();
+
+#if defined(USE_MNNVL) && defined(USE_CUDA)
+    if (!RetryQuarantinedFabricMappings()) {
+        const size_t pending_count = quarantined_fabric_mappings_.size();
+        for (const auto& cleanup : quarantined_fabric_mappings_) {
+            PreserveProcessLifetimeFabricCleanup(cleanup);
+        }
+        LOG(ERROR) << "NvlinkTransport: " << pending_count
+                   << " Fabric mapping cleanup(s) remain live after teardown "
+                      "retries; preserving ownership in the process-lifetime "
+                      "quarantine";
+        quarantined_fabric_mappings_.clear();
+    }
+
+    std::lock_guard<std::mutex> lock(register_mutex_);
+    size_t retained_registration_count = 0;
+    for (const auto& [_, registration] : local_registrations_) {
+        retained_registration_count += registration.retained_handle_owned;
+    }
+    try {
+        quarantined_retained_handles_.reserve(
+            quarantined_retained_handles_.size() + retained_registration_count);
+    } catch (const std::exception& error) {
+        // ReleaseOrQuarantineRetainedHandle() falls back to the process-wide
+        // quarantine if this transport-local vector cannot grow.
+        LOG(ERROR) << "NvlinkTransport: unable to reserve teardown "
+                      "retained-handle quarantine: "
+                   << error.what();
+    }
+    for (auto& [_, registration] : local_registrations_) {
+        if (registration.retained_handle_owned) {
+            ReleaseOrQuarantineRetainedHandle(
+                static_cast<CUmemGenericAllocationHandle>(
+                    registration.retained_handle),
+                "transport teardown");
+        }
+    }
+    if (!RetryQuarantinedRetainedHandles()) {
+        const size_t pending_count = quarantined_retained_handles_.size();
+        for (uint64_t handle : quarantined_retained_handles_) {
+            quarantineRetainedHandleForProcessLifetime(handle);
+        }
+        LOG(ERROR) << "NvlinkTransport: " << pending_count
+                   << " retained registration handle(s) remain live after "
+                      "teardown retries; preserving ownership in the "
+                      "process-lifetime quarantine";
+        quarantined_retained_handles_.clear();
+    }
+#endif
+    local_registrations_.clear();
 }
 
-int NvlinkTransport::install(std::string &local_server_name,
+#if defined(USE_MNNVL) && defined(USE_CUDA)
+bool NvlinkTransport::RetryQuarantinedRetainedHandles() {
+    auto retained = quarantined_retained_handles_.begin();
+    for (auto it = quarantined_retained_handles_.begin();
+         it != quarantined_retained_handles_.end(); ++it) {
+        const CUresult result = fabric_driver_api_.mem_release(
+            static_cast<CUmemGenericAllocationHandle>(*it));
+        if (result != CUDA_SUCCESS) {
+            LOG(ERROR) << "NvlinkTransport: quarantined registration "
+                          "cuMemRelease retry failed: "
+                       << result;
+            *retained++ = *it;
+        }
+    }
+    quarantined_retained_handles_.erase(retained,
+                                        quarantined_retained_handles_.end());
+    return quarantined_retained_handles_.empty();
+}
+
+void NvlinkTransport::ReleaseOrQuarantineRetainedHandle(
+    CUmemGenericAllocationHandle handle, const char* failure_stage) noexcept {
+    const CUresult result = fabric_driver_api_.mem_release(handle);
+    if (result == CUDA_SUCCESS) return;
+
+    // registerLocalMemory() reserves one quarantine slot before retaining a
+    // handle. Teardown also reserves for every live registration; if an
+    // allocation still fails, retain the marker in a process-lifetime owner.
+    try {
+        quarantined_retained_handles_.push_back(static_cast<uint64_t>(handle));
+    } catch (const std::exception& error) {
+        LOG(ERROR) << "NvlinkTransport: local retained-handle quarantine "
+                      "allocation failed: "
+                   << error.what();
+        quarantineRetainedHandleForProcessLifetime(
+            static_cast<uint64_t>(handle));
+    } catch (...) {
+        LOG(ERROR) << "NvlinkTransport: unknown failure while quarantining "
+                      "a retained registration handle";
+        quarantineRetainedHandleForProcessLifetime(
+            static_cast<uint64_t>(handle));
+    }
+    LOG(ERROR) << "NvlinkTransport: registration cleanup cuMemRelease failed "
+                  "after "
+               << failure_stage << ": " << result
+               << "; retaining ownership for a later retry";
+}
+#endif
+
+int NvlinkTransport::install(std::string& local_server_name,
                              std::shared_ptr<TransferMetadata> metadata,
                              std::shared_ptr<Topology> topology) {
     metadata_ = metadata;
@@ -449,8 +1670,8 @@ int NvlinkTransport::install(std::string &local_server_name,
 }
 
 Status NvlinkTransport::submitTransfer(
-    BatchID batch_id, const std::vector<TransferRequest> &entries) {
-    auto &batch_desc = *((BatchDesc *)(batch_id));
+    BatchID batch_id, const std::vector<TransferRequest>& entries) {
+    auto& batch_desc = *((BatchDesc*)(batch_id));
     if (batch_desc.task_list.size() + entries.size() > batch_desc.batch_size) {
         LOG(ERROR)
             << "NvlinkTransport: Exceed the limitation of current batch's "
@@ -460,14 +1681,60 @@ Status NvlinkTransport::submitTransfer(
             std::to_string(batch_id));
     }
 
-    size_t task_id = batch_desc.task_list.size();
-    batch_desc.task_list.resize(task_id + entries.size());
+    const size_t first_task_id = batch_desc.task_list.size();
+    batch_desc.task_list.resize(first_task_id + entries.size());
+    std::vector<TransferTask*> tasks;
+    tasks.reserve(entries.size());
+    for (size_t index = 0; index < entries.size(); ++index) {
+        auto& task = batch_desc.task_list[first_task_id + index];
+        task.batch_id = batch_id;
+        task.transport_ = this;
+#ifdef USE_EVENT_DRIVEN_COMPLETION
+        task.requires_periodic_status_polling = true;
+#endif
+#ifdef USE_ASCEND_HETEROGENEOUS
+        task.request = const_cast<TransferRequest*>(&entries[index]);
+#else
+        task.request = &entries[index];
+#endif
+        task.operation = entries[index].opcode;
+        task.operation_initialized = true;
+        task.total_bytes = entries[index].length;
+        tasks.push_back(&task);
+    }
+
+    auto fail_submission = [&](Status status, bool copy_failure) {
+        for (auto* task : tasks) {
+            finalizeSubmissionFailure(*task, copy_failure);
+        }
+        return status;
+    };
+
+    // Resolve every remote range before allocating any Slice. A relocation
+    // failure therefore has no partially staged Slice ownership to unwind.
+    std::vector<uint64_t> resolved_addresses;
+    resolved_addresses.reserve(entries.size());
+    for (const auto& request : entries) {
+        uint64_t dest_addr = request.target_offset;
+        if (request.target_id != LOCAL_SEGMENT_ID) {
+            int rc = relocateSharedMemoryAddress(dest_addr, request.length,
+                                                 request.target_id);
+            if (rc != 0) {
+                return fail_submission(
+                    Status::Memory("NVLink remote address relocation failed"),
+                    false);
+            }
+        }
+        resolved_addresses.push_back(dest_addr);
+    }
 
     // Get per-device transfer stream for the source buffer's device.
     CudaStreamEntry stream_entry =
         getStreamForRequest(entries.empty() ? nullptr : entries[0].source);
     cudaStream_t stream = stream_entry.stream;
-    if (!stream) return Status::Context("Failed to create NVLink CUDA stream");
+    if (!stream)
+        return fail_submission(
+            Status::Context("Failed to create NVLink CUDA stream"), true);
 
     // Synchronize with the caller's GPU work (e.g., PyTorch gather operations)
     // that produced the source data. We use cudaEventSynchronize (CPU-blocking)
@@ -479,35 +1746,33 @@ Status NvlinkTransport::submitTransfer(
     if (sync_err != cudaSuccess) {
         LOG(ERROR) << "NvlinkTransport: cudaEventRecord failed: "
                    << cudaGetErrorString(sync_err);
-        return Status::Context("cudaEventRecord failed: " +
-                               std::string(cudaGetErrorString(sync_err)));
+        return fail_submission(
+            Status::Context("cudaEventRecord failed: " +
+                            std::string(cudaGetErrorString(sync_err))),
+            true);
     }
     sync_err = cudaEventSynchronize(sync_event);
     if (sync_err != cudaSuccess) {
         LOG(ERROR) << "NvlinkTransport: cudaEventSynchronize failed: "
                    << cudaGetErrorString(sync_err);
-        return Status::Context("cudaEventSynchronize failed: " +
-                               std::string(cudaGetErrorString(sync_err)));
+        return fail_submission(
+            Status::Context("cudaEventSynchronize failed: " +
+                            std::string(cudaGetErrorString(sync_err))),
+            true);
     }
 
     // Phase 1: Prepare slices and collect memcpy parameters
-    std::vector<void *> dsts, srcs;
+    std::vector<void*> dsts, srcs;
     std::vector<size_t> sizes;
-    std::vector<Slice *> slices;
+    std::vector<Slice*> slices;
 
-    for (auto &request : entries) {
-        TransferTask &task = batch_desc.task_list[task_id];
-        ++task_id;
-        uint64_t dest_addr = request.target_offset;
-        if (request.target_id != LOCAL_SEGMENT_ID) {
-            int rc = relocateSharedMemoryAddress(dest_addr, request.length,
-                                                 request.target_id);
-            if (rc) return Status::Memory("device memory not registered");
-        }
-        task.total_bytes = request.length;
-        Slice *slice = getSliceCache().allocate();
-        slice->source_addr = (char *)request.source;
-        slice->local.dest_addr = (char *)dest_addr;
+    for (size_t index = 0; index < entries.size(); ++index) {
+        const auto& request = entries[index];
+        TransferTask& task = *tasks[index];
+        const uint64_t dest_addr = resolved_addresses[index];
+        Slice* slice = getSliceCache().allocate();
+        slice->source_addr = (char*)request.source;
+        slice->local.dest_addr = (char*)dest_addr;
         slice->length = request.length;
         slice->opcode = request.opcode;
         slice->task = &task;
@@ -517,12 +1782,12 @@ Status NvlinkTransport::submitTransfer(
         task.slice_list.push_back(slice);
         __sync_fetch_and_add(&task.slice_count, 1);
 
-        void *src = (request.opcode == TransferRequest::READ)
-                        ? (void *)slice->local.dest_addr
-                        : (void *)slice->source_addr;
-        void *dst = (request.opcode == TransferRequest::READ)
+        void* src = (request.opcode == TransferRequest::READ)
+                        ? (void*)slice->local.dest_addr
+                        : (void*)slice->source_addr;
+        void* dst = (request.opcode == TransferRequest::READ)
                         ? slice->source_addr
-                        : (void *)slice->local.dest_addr;
+                        : (void*)slice->local.dest_addr;
         srcs.push_back(src);
         dsts.push_back(dst);
         sizes.push_back(slice->length);
@@ -531,27 +1796,40 @@ Status NvlinkTransport::submitTransfer(
 
     // Phase 2: Submit all memcpy operations
     submitBatchMemcpy(slices, srcs, dsts, sizes, stream);
+    for (auto* task : tasks) {
+        const uint64_t completed =
+            task->success_slice_count + task->failed_slice_count;
+        if (task->slice_count > 0 && completed == task->slice_count) {
+            const bool success = task->failed_slice_count == 0;
+            finalizeTransferResult(*task, success);
+        }
+    }
 
     return Status::OK();
 }
 
 Status NvlinkTransport::getTransferStatus(BatchID batch_id, size_t task_id,
-                                          TransferStatus &status) {
-    auto &batch_desc = *((BatchDesc *)(batch_id));
+                                          TransferStatus& status) {
+    auto& batch_desc = *((BatchDesc*)(batch_id));
     const size_t task_count = batch_desc.task_list.size();
     if (task_id >= task_count) {
         return Status::InvalidArgument(
             "NvlinkTransport::getTransportStatus invalid argument, batch id: " +
             std::to_string(batch_id));
     }
-    auto &task = batch_desc.task_list[task_id];
+    auto& task = batch_desc.task_list[task_id];
+    if (__atomic_load_n(&task.submission_failed, __ATOMIC_ACQUIRE)) {
+        status.transferred_bytes = task.transferred_bytes;
+        status.s = TransferStatusEnum::FAILED;
+        return Status::OK();
+    }
     // Poll POSTED slices for async completion via cudaStreamQuery.
     // Cache the query result per stream to avoid redundant driver calls.
     // With SGLang-side torch.cuda.device(gpu_id), the calling thread's
     // active device matches the stream's device, so no device switching
     // is needed.
     std::unordered_map<cudaStream_t, cudaError_t> stream_status_cache;
-    for (auto *slice : task.slice_list) {
+    for (auto* slice : task.slice_list) {
         if (slice && slice->status == Slice::POSTED) {
             cudaStream_t stream = (cudaStream_t)slice->local.cuda_stream;
             auto it = stream_status_cache.find(stream);
@@ -573,6 +1851,8 @@ Status NvlinkTransport::getTransferStatus(BatchID batch_id, size_t task_id,
     uint64_t success_slice_count = task.success_slice_count;
     uint64_t failed_slice_count = task.failed_slice_count;
     if (success_slice_count + failed_slice_count == task.slice_count) {
+        const bool success = failed_slice_count == 0;
+        finalizeTransferResult(task, success);
         if (failed_slice_count) {
             status.s = TransferStatusEnum::FAILED;
         } else {
@@ -586,49 +1866,85 @@ Status NvlinkTransport::getTransferStatus(BatchID batch_id, size_t task_id,
 }
 
 Status NvlinkTransport::submitTransferTask(
-    const std::vector<TransferTask *> &task_list) {
+    const std::vector<TransferTask*>& task_list) {
+    auto fail_submission = [&](Status status, bool copy_failure) {
+        for (auto* task : task_list) {
+            if (task == nullptr) continue;
+            finalizeSubmissionFailure(*task, copy_failure);
+        }
+        return status;
+    };
+
+    std::vector<uint64_t> resolved_addresses;
+    resolved_addresses.reserve(task_list.size());
+    for (auto* task : task_list) {
+        if (task == nullptr || task->request == nullptr) {
+            return fail_submission(
+                Status::InvalidArgument("NVLink transfer task is incomplete"),
+                false);
+        }
+#ifdef USE_EVENT_DRIVEN_COMPLETION
+        task->requires_periodic_status_polling = true;
+#endif
+        auto& request = *task->request;
+        task->operation = request.opcode;
+        task->operation_initialized = true;
+        task->total_bytes = request.length;
+        uint64_t dest_addr = request.target_offset;
+        if (request.target_id != LOCAL_SEGMENT_ID) {
+            int rc = relocateSharedMemoryAddress(dest_addr, request.length,
+                                                 request.target_id);
+            if (rc != 0) {
+                return fail_submission(
+                    Status::Memory("NVLink remote address relocation failed"),
+                    false);
+            }
+        }
+        resolved_addresses.push_back(dest_addr);
+    }
+
     // Get per-device transfer stream. See submitTransfer() for rationale.
     CudaStreamEntry stream_entry = getStreamForRequest(
         task_list.empty() ? nullptr : task_list[0]->request->source);
     cudaStream_t stream = stream_entry.stream;
-    if (!stream) return Status::Context("Failed to create NVLink CUDA stream");
+    if (!stream)
+        return fail_submission(
+            Status::Context("Failed to create NVLink CUDA stream"), true);
     // Synchronize with caller's GPU work via cudaEventSynchronize.
     cudaEvent_t sync_event = getCallerSyncEvent();
     cudaError_t sync_err = cudaEventRecord(sync_event, cudaStreamPerThread);
     if (sync_err != cudaSuccess) {
         LOG(ERROR) << "NvlinkTransport: cudaEventRecord failed: "
                    << cudaGetErrorString(sync_err);
-        return Status::Context("cudaEventRecord failed: " +
-                               std::string(cudaGetErrorString(sync_err)));
+        return fail_submission(
+            Status::Context("cudaEventRecord failed: " +
+                            std::string(cudaGetErrorString(sync_err))),
+            true);
     }
     sync_err = cudaEventSynchronize(sync_event);
     if (sync_err != cudaSuccess) {
         LOG(ERROR) << "NvlinkTransport: cudaEventSynchronize failed: "
                    << cudaGetErrorString(sync_err);
-        return Status::Context("cudaEventSynchronize failed: " +
-                               std::string(cudaGetErrorString(sync_err)));
+        return fail_submission(
+            Status::Context("cudaEventSynchronize failed: " +
+                            std::string(cudaGetErrorString(sync_err))),
+            true);
     }
 
     // Phase 1: Prepare slices and collect memcpy parameters
-    std::vector<void *> dsts, srcs;
+    std::vector<void*> dsts, srcs;
     std::vector<size_t> sizes;
-    std::vector<Slice *> slices;
+    std::vector<Slice*> slices;
 
     for (size_t index = 0; index < task_list.size(); ++index) {
         assert(task_list[index]);
-        auto &task = *task_list[index];
+        auto& task = *task_list[index];
         assert(task.request);
-        auto &request = *task.request;
-        uint64_t dest_addr = request.target_offset;
-        if (request.target_id != LOCAL_SEGMENT_ID) {
-            int rc = relocateSharedMemoryAddress(dest_addr, request.length,
-                                                 request.target_id);
-            if (rc) return Status::Memory("device memory not registered");
-        }
-        task.total_bytes = request.length;
-        Slice *slice = getSliceCache().allocate();
-        slice->source_addr = (char *)request.source;
-        slice->local.dest_addr = (char *)dest_addr;
+        auto& request = *task.request;
+        const uint64_t dest_addr = resolved_addresses[index];
+        Slice* slice = getSliceCache().allocate();
+        slice->source_addr = (char*)request.source;
+        slice->local.dest_addr = (char*)dest_addr;
         slice->length = request.length;
         slice->opcode = request.opcode;
         slice->task = &task;
@@ -638,12 +1954,12 @@ Status NvlinkTransport::submitTransferTask(
         task.slice_list.push_back(slice);
         __sync_fetch_and_add(&task.slice_count, 1);
 
-        void *src = (request.opcode == TransferRequest::READ)
-                        ? (void *)slice->local.dest_addr
-                        : (void *)slice->source_addr;
-        void *dst = (request.opcode == TransferRequest::READ)
+        void* src = (request.opcode == TransferRequest::READ)
+                        ? (void*)slice->local.dest_addr
+                        : (void*)slice->source_addr;
+        void* dst = (request.opcode == TransferRequest::READ)
                         ? slice->source_addr
-                        : (void *)slice->local.dest_addr;
+                        : (void*)slice->local.dest_addr;
         srcs.push_back(src);
         dsts.push_back(dst);
         sizes.push_back(slice->length);
@@ -652,322 +1968,761 @@ Status NvlinkTransport::submitTransferTask(
 
     // Phase 2: Submit all memcpy operations
     submitBatchMemcpy(slices, srcs, dsts, sizes, stream);
+    for (auto* task : task_list) {
+        const uint64_t completed =
+            task->success_slice_count + task->failed_slice_count;
+        if (task->slice_count > 0 && completed == task->slice_count) {
+            const bool success = task->failed_slice_count == 0;
+            finalizeTransferResult(*task, success);
+        }
+    }
 
     return Status::OK();
 }
 
-int NvlinkTransport::registerLocalMemory(void *addr, size_t length,
-                                         const std::string &location,
+int NvlinkTransport::registerLocalMemory(void* addr, size_t length,
+                                         const std::string& location,
                                          bool remote_accessible,
                                          bool update_metadata) {
     std::lock_guard<std::mutex> lock(register_mutex_);
     if (globalConfig().trace) {
         LOG(INFO) << "register memory: addr " << addr << ", length " << length;
     }
+    if (addr == nullptr || length == 0 ||
+        reinterpret_cast<uintptr_t>(addr) >
+            std::numeric_limits<uintptr_t>::max() - length) {
+        LOG(ERROR) << "NvlinkTransport: invalid registration range addr="
+                   << addr << " length=" << length;
+        return ERR_INVALID_ARGUMENT;
+    }
+    if (local_registrations_.count(addr) != 0) {
+        LOG(ERROR) << "NvlinkTransport: address is already registered: "
+                   << addr;
+        return ERR_ADDRESS_OVERLAPPED;
+    }
+
+    LocalRegistration registration;
+    registration.requested_addr = addr;
+    registration.requested_length = length;
+    registration.mapped_base = addr;
+    registration.mapped_length = length;
+    registration.remote_accessible = remote_accessible;
+
+    // Local-only registrations deliberately accept ordinary HBM, VMM, and
+    // legacy CPU memory. They are execution ownership records only and never
+    // mutate remotely visible metadata.
+    if (!remote_accessible) {
+        local_registrations_.emplace(addr, registration);
+        return 0;
+    }
+
+    BufferDesc desc;
+    desc.name = location;
+
     if (!use_fabric_mem_) {
         cudaPointerAttributes attr;
         cudaError_t err = cudaPointerGetAttributes(&attr, addr);
         if (err != cudaSuccess) {
-            LOG(ERROR) << "NvlinkTransport: cudaPointerGetAttributes failed";
-            return -1;
+            LOG(ERROR) << "NvlinkTransport: cudaPointerGetAttributes failed: "
+                       << cudaGetErrorString(err);
+            return ERR_INVALID_ARGUMENT;
         }
 
         if (attr.type != cudaMemoryTypeDevice) {
             LOG(ERROR) << "Unsupported memory type, " << addr << " "
                        << attr.type;
-            return -1;
+            return ERR_INVALID_ARGUMENT;
         }
 
         cudaIpcMemHandle_t handle;
         err = cudaIpcGetMemHandle(&handle, addr);
         if (err != cudaSuccess) {
-            LOG(ERROR) << "NvlinkTransport: cudaIpcGetMemHandle failed";
-            return -1;
+            LOG(ERROR) << "NvlinkTransport: cudaIpcGetMemHandle failed: "
+                       << cudaGetErrorString(err);
+            return ERR_MEMORY;
         }
 
-        (void)remote_accessible;
-        BufferDesc desc;
         desc.addr = (uint64_t)addr;
         desc.length = length;
-        desc.name = location;
         desc.shm_name =
             serializeBinaryData(&handle, sizeof(cudaIpcMemHandle_t));
-        return metadata_->addLocalMemoryBuffer(desc, true);
+        registration.published = false;
+        local_registrations_.emplace(addr, registration);
+        return publishLocalRegistration(addr, desc, update_metadata);
     } else {
-        CUmemGenericAllocationHandle handle;
-        auto result = cuMemRetainAllocationHandle(&handle, addr);
-        if (result != CUDA_SUCCESS) {
-            LOG(WARNING) << "Memory region " << addr
-                         << " is not allocated by cuMemCreate, "
-                         << "but it can be used as local buffer";
-            return 0;
+#if defined(USE_MNNVL) && defined(USE_CUDA)
+        if (!fabric_driver_api_.mem_retain_allocation_handle ||
+            !fabric_driver_api_.mem_get_allocation_properties_from_handle ||
+            !fabric_driver_api_.mem_export_to_shareable_handle ||
+            !fabric_driver_api_.mem_release) {
+            LOG(ERROR) << "NvlinkTransport: incomplete Fabric driver adapter "
+                          "for registration";
+            return ERR_CONTEXT;
+        }
+        if (!RetryQuarantinedRetainedHandles()) {
+            LOG(ERROR)
+                << "NvlinkTransport: a retained registration handle "
+                   "is still pending cleanup; refusing to retain another";
+            return ERR_MEMORY;
+        }
+        try {
+            quarantined_retained_handles_.reserve(
+                quarantined_retained_handles_.size() + 1);
+        } catch (const std::exception& error) {
+            LOG(ERROR) << "NvlinkTransport: failed to reserve retained-handle "
+                          "cleanup ownership: "
+                       << error.what();
+            return ERR_MEMORY;
+        }
+        Status capability =
+            NvlinkVmmAllocation::CheckStrictFabricCapabilityWithDriverApi(
+                fabric_driver_api_);
+        if (!capability.ok()) {
+            LOG(ERROR) << "NvlinkTransport: Fabric registration preflight "
+                          "failed: "
+                       << capability.ToString();
+            return ERR_CONTEXT;
         }
 
-        // Find whole physical page for memory registration
-        void *real_addr;
-        size_t real_size;
-        result = cuMemGetAddressRange((CUdeviceptr *)&real_addr, &real_size,
-                                      (CUdeviceptr)addr);
+        CUmemGenericAllocationHandle handle;
+        auto result =
+            fabric_driver_api_.mem_retain_allocation_handle(&handle, addr);
         if (result != CUDA_SUCCESS) {
-            LOG(WARNING) << "NvlinkTransport: cuMemGetAddressRange failed: "
-                         << result;
-            const uint64_t granularity = 2 * 1024 * 1024;
-            real_addr = addr;
-            real_size = (length + granularity - 1) & ~(granularity - 1);
+            LOG(ERROR) << "NvlinkTransport: remote Fabric registration "
+                          "requires cuMemCreate memory; retain failed: "
+                       << result;
+            return ERR_INVALID_ARGUMENT;
+        }
+        registration.retained_handle_owned = true;
+        registration.retained_handle = static_cast<uint64_t>(handle);
+        RetainedHandleGuard retained_handle(*this, handle,
+                                            "Fabric registration failure");
+
+        CUmemAllocationProp allocation_prop = {};
+        result = fabric_driver_api_.mem_get_allocation_properties_from_handle(
+            &allocation_prop, handle);
+        if (result != CUDA_SUCCESS) {
+            LOG(ERROR) << "NvlinkTransport: "
+                          "cuMemGetAllocationPropertiesFromHandle failed: "
+                       << result;
+            return ERR_MEMORY;
+        }
+        const bool is_host_numa =
+            allocation_prop.location.type == CU_MEM_LOCATION_TYPE_HOST_NUMA;
+        const bool is_exact_owned_range =
+            NvlinkVmmAllocation::IsExactOwnedRange(addr, length);
+
+        CUdeviceptr real_address = 0;
+        size_t real_size = 0;
+        if (is_exact_owned_range) {
+            if (!is_host_numa) {
+                LOG(ERROR)
+                    << "NvlinkTransport: Mooncake-owned HOST_NUMA provenance "
+                       "does not match retained allocation properties";
+                return ERR_INVALID_ARGUMENT;
+            }
+
+            // NvlinkVmmAllocation created and owns this exact base/length
+            // mapping. cuMemRetainAllocationHandle above independently
+            // verified that addr is still backed by a cuMemMap allocation, so
+            // querying the range again would add only a current-context
+            // dependency and no new range information.
+            real_address = reinterpret_cast<CUdeviceptr>(addr);
+            real_size = length;
+        } else {
+            if (!fabric_driver_api_.mem_get_address_range) {
+                LOG(ERROR) << "NvlinkTransport: incomplete Fabric driver "
+                              "adapter for external range registration";
+                return ERR_CONTEXT;
+            }
+            result = fabric_driver_api_.mem_get_address_range(
+                &real_address, &real_size, reinterpret_cast<CUdeviceptr>(addr));
+            if (result != CUDA_SUCCESS) {
+                LOG(ERROR) << "NvlinkTransport: cuMemGetAddressRange failed: "
+                           << result;
+                return ERR_MEMORY;
+            }
+            if (real_address == 0) {
+                LOG(ERROR) << "NvlinkTransport: cuMemGetAddressRange returned "
+                              "a null allocation base";
+                return ERR_MEMORY;
+            }
+            if (is_host_numa &&
+                NvlinkVmmAllocation::IsExactOwnedRange(
+                    reinterpret_cast<void*>(real_address), real_size)) {
+                LOG(ERROR) << "NvlinkTransport: Mooncake-owned HOST_NUMA VMM "
+                              "registration requires its exact base and length";
+                return ERR_INVALID_ARGUMENT;
+            }
+        }
+        const uint64_t requested = reinterpret_cast<uint64_t>(addr);
+        const uint64_t real = static_cast<uint64_t>(real_address);
+        if (real_size == 0 || requested < real || length > real_size ||
+            requested - real > real_size - length) {
+            LOG(ERROR) << "NvlinkTransport: requested range is outside the "
+                          "retained VMM mapping";
+            return ERR_INVALID_ARGUMENT;
         }
 
         CUmemFabricHandle export_handle;
-        result = cuMemExportToShareableHandle(&export_handle, handle,
-                                              CU_MEM_HANDLE_TYPE_FABRIC, 0);
+        result = fabric_driver_api_.mem_export_to_shareable_handle(
+            &export_handle, handle, CU_MEM_HANDLE_TYPE_FABRIC, 0);
         if (result != CUDA_SUCCESS) {
             LOG(ERROR)
                 << "NvlinkTransport: cuMemExportToShareableHandle failed: "
                 << result;
-            return -1;
+            return ERR_MEMORY;
         }
 
-        (void)remote_accessible;
-        BufferDesc desc;
-        desc.addr = (uint64_t)real_addr;  // (uint64_t)addr;
-        desc.length = real_size;          // length;
-        desc.name = location;
+        desc.addr = real;
+        desc.length = real_size;
         desc.shm_name =
             serializeBinaryData(&export_handle, sizeof(CUmemFabricHandle));
-        return metadata_->addLocalMemoryBuffer(desc, true);
+        registration.mapped_base = reinterpret_cast<void*>(real_address);
+        registration.mapped_length = real_size;
+        local_registrations_.emplace(addr, registration);
+        int rc = publishLocalRegistration(addr, desc, update_metadata);
+        if (local_registrations_.count(addr) != 0) {
+            retained_handle.TransferOwnership();
+        }
+        return rc;
+#else
+        LOG(ERROR) << "NvlinkTransport: Fabric registration requires CUDA";
+        return ERR_CONTEXT;
+#endif
     }
 }
 
-int NvlinkTransport::unregisterLocalMemory(void *addr, bool update_metadata) {
-    return metadata_->removeLocalMemoryBuffer(addr, update_metadata);
+int NvlinkTransport::publishLocalRegistration(void* registration_addr,
+                                              const BufferDesc& descriptor,
+                                              bool update_metadata) {
+    int rc = ERR_METADATA;
+    bool publication_threw = false;
+    try {
+        rc = add_buffer_for_testing_
+                 ? add_buffer_for_testing_(descriptor, update_metadata)
+                 : metadata_->addLocalMemoryBuffer(descriptor, update_metadata);
+    } catch (const std::exception& error) {
+        // A storage backend can throw after committing the descriptor. Treat
+        // the remote state as unknown and keep the tentative registration
+        // fail-closed until an explicit unregister confirms deletion.
+        LOG(ERROR) << "NvlinkTransport: metadata registration threw: "
+                   << error.what();
+        publication_threw = true;
+        rc = ERR_MEMORY;
+    } catch (...) {
+        LOG(ERROR) << "NvlinkTransport: metadata registration threw an "
+                      "unknown exception";
+        publication_threw = true;
+        rc = ERR_MEMORY;
+    }
+    if (publication_threw) {
+        // Fabric's caller observes that the record remains present and moves
+        // RetainedHandleGuard ownership into it. IPC follows the same
+        // conservative metadata lifetime even though it has no CUDA handle.
+        local_registrations_[registration_addr].published = true;
+        return rc;
+    }
+    if (rc != 0) {
+        int rollback_rc = ERR_METADATA;
+        try {
+            rollback_rc = remove_buffer_for_testing_
+                              ? remove_buffer_for_testing_(
+                                    reinterpret_cast<void*>(descriptor.addr),
+                                    update_metadata)
+                              : metadata_->removeLocalMemoryBuffer(
+                                    reinterpret_cast<void*>(descriptor.addr),
+                                    update_metadata);
+        } catch (const std::exception& error) {
+            LOG(ERROR) << "NvlinkTransport: metadata registration rollback "
+                          "threw: "
+                       << error.what();
+            rollback_rc = ERR_METADATA;
+        } catch (...) {
+            LOG(ERROR) << "NvlinkTransport: metadata registration rollback "
+                          "threw an unknown exception";
+            rollback_rc = ERR_METADATA;
+        }
+        if (rollback_rc != 0 && rollback_rc != ERR_ADDRESS_NOT_REGISTERED) {
+            LOG(ERROR) << "NvlinkTransport: metadata registration rollback "
+                          "failed: "
+                       << rollback_rc;
+            // IPC and Fabric descriptors can both still be visible remotely.
+            // Keep the record so the caller can retry unregistering the same
+            // base; Fabric's caller also transfers the retained handle into it.
+            local_registrations_[registration_addr].published = true;
+            return rc;
+        }
+        local_registrations_.erase(registration_addr);
+        return rc;
+    }
+    local_registrations_[registration_addr].published = true;
+    return 0;
 }
 
-int NvlinkTransport::relocateSharedMemoryAddress(uint64_t &dest_addr,
+int NvlinkTransport::unregisterLocalMemory(void* addr, bool update_metadata) {
+    std::lock_guard<std::mutex> lock(register_mutex_);
+    auto it = local_registrations_.find(addr);
+    if (it == local_registrations_.end()) {
+        LOG(WARNING) << "NvlinkTransport: unbalanced unregister for " << addr;
+        return ERR_ADDRESS_NOT_REGISTERED;
+    }
+
+    LocalRegistration& registration = it->second;
+    if (registration.published) {
+        int rc = ERR_METADATA;
+        try {
+            rc = remove_buffer_for_testing_
+                     ? remove_buffer_for_testing_(registration.mapped_base,
+                                                  update_metadata)
+                     : metadata_->removeLocalMemoryBuffer(
+                           registration.mapped_base, update_metadata);
+        } catch (const std::exception& error) {
+            LOG(ERROR) << "NvlinkTransport: metadata unregistration threw; "
+                          "retaining descriptor and handle ownership: "
+                       << error.what();
+            return ERR_MEMORY;
+        } catch (...) {
+            LOG(ERROR) << "NvlinkTransport: metadata unregistration threw an "
+                          "unknown exception; retaining descriptor and handle "
+                          "ownership";
+            return ERR_MEMORY;
+        }
+        if (rc != 0 && rc != ERR_ADDRESS_NOT_REGISTERED) return rc;
+        if (rc == ERR_ADDRESS_NOT_REGISTERED) {
+            LOG(WARNING) << "NvlinkTransport: published descriptor was "
+                            "already absent for "
+                         << registration.mapped_base;
+        }
+        registration.published = false;
+    }
+
+#if defined(USE_MNNVL) && defined(USE_CUDA)
+    if (registration.retained_handle_owned) {
+        CUresult result = fabric_driver_api_.mem_release(
+            static_cast<CUmemGenericAllocationHandle>(
+                registration.retained_handle));
+        if (result != CUDA_SUCCESS) {
+            LOG(ERROR) << "NvlinkTransport: registration cuMemRelease failed: "
+                       << result;
+            return ERR_MEMORY;
+        }
+        registration.retained_handle_owned = false;
+    }
+#endif
+    local_registrations_.erase(it);
+    return 0;
+}
+
+int NvlinkTransport::relocateSharedMemoryAddress(uint64_t& dest_addr,
                                                  uint64_t length,
                                                  uint64_t target_id) {
-    auto desc = metadata_->getSegmentDescByID(target_id);
-    int index = 0;
-    for (auto &entry : desc->buffers) {
-        if (!entry.shm_name.empty() && entry.addr <= dest_addr &&
-            dest_addr + length <= entry.addr + entry.length) {
+    auto desc = get_segment_for_testing_
+                    ? get_segment_for_testing_(target_id)
+                    : metadata_->getSegmentDescByID(target_id);
+    if (!desc) {
+        observeConsumerFailure(ConsumerFailureStage::IMPORT);
+        LOG(ERROR) << "NvlinkTransport: target segment descriptor not found: "
+                   << target_id;
+        return ERR_METADATA;
+    }
+    if (length == 0) {
+        observeConsumerFailure(ConsumerFailureStage::IMPORT);
+        LOG(ERROR) << "NvlinkTransport: cannot relocate an empty range";
+        return ERR_INVALID_ARGUMENT;
+    }
+
+    for (auto& entry : desc->buffers) {
+        const bool range_matches =
+            !entry.shm_name.empty() && entry.addr <= dest_addr &&
+            length <= entry.length &&
+            dest_addr - entry.addr <= entry.length - length;
+        if (range_matches) {
+            const auto cache_key = std::make_pair(target_id, entry.addr);
             remap_lock_.lockShared();
-            if (remap_entries_.count(std::make_pair(target_id, entry.addr))) {
-                auto shm_addr =
-                    remap_entries_[std::make_pair(target_id, entry.addr)]
-                        .shm_addr;
+            auto cached = remap_entries_.find(cache_key);
+            if (cached != remap_entries_.end()) {
+                void* shm_addr = cached->second.shm_addr;
                 remap_lock_.unlockShared();
+                observeCacheLookup(true);
                 dest_addr = dest_addr - entry.addr + ((uint64_t)shm_addr);
                 return 0;
             }
             remap_lock_.unlockShared();
+
             RWSpinlock::WriteGuard lock_guard(remap_lock_);
-            if (!remap_entries_.count(std::make_pair(target_id, entry.addr))) {
+            cached = remap_entries_.find(cache_key);
+            if (cached == remap_entries_.end()) {
+                observeCacheLookup(false);
+                ScopedLatencyObservation observe_import_latency(
+                    [this](uint64_t duration_us) {
+                        observeLazyImportLatency(duration_us);
+                    });
                 std::vector<unsigned char> output_buffer;
-                deserializeBinaryData(entry.shm_name, output_buffer);
+                try {
+                    deserializeBinaryData(entry.shm_name, output_buffer);
+                } catch (const std::exception& error) {
+                    observeConsumerFailure(ConsumerFailureStage::IMPORT);
+                    LOG(ERROR) << "NvlinkTransport: invalid serialized remote "
+                                  "handle: "
+                               << error.what();
+                    return ERR_INVALID_ARGUMENT;
+                }
+
                 if (output_buffer.size() == sizeof(cudaIpcMemHandle_t) &&
                     !use_fabric_mem_) {
                     cudaIpcMemHandle_t handle;
                     memcpy(&handle, output_buffer.data(), sizeof(handle));
-                    void *shm_addr = nullptr;
+                    void* shm_addr = nullptr;
                     cudaError_t err = cudaIpcOpenMemHandle(
                         &shm_addr, handle, cudaIpcMemLazyEnablePeerAccess);
                     if (err != cudaSuccess) {
+                        observeConsumerFailure(ConsumerFailureStage::IMPORT);
                         LOG(ERROR)
                             << "NvlinkTransport: cudaIpcOpenMemHandle failed: "
                             << cudaGetErrorString(err);
-                        return -1;
+                        return ERR_MEMORY;
                     }
                     OpenedShmEntry shm_entry;
                     shm_entry.shm_addr = shm_addr;
                     shm_entry.length = entry.length;
-                    remap_entries_[std::make_pair(target_id, entry.addr)] =
-                        shm_entry;
+                    shm_entry.kind = OpenedMappingKind::IPC;
+                    auto inserted =
+                        remap_entries_.emplace(cache_key, shm_entry).second;
+                    if (!inserted) {
+                        cudaIpcCloseMemHandle(shm_addr);
+                        observeConsumerFailure(ConsumerFailureStage::IMPORT);
+                        return ERR_ADDRESS_OVERLAPPED;
+                    }
                 } else if (output_buffer.size() == sizeof(CUmemFabricHandle) &&
                            use_fabric_mem_) {
+#if defined(USE_MNNVL) && defined(USE_CUDA)
+                    if (entry.length == 0 ||
+                        entry.length > std::numeric_limits<size_t>::max()) {
+                        observeConsumerFailure(ConsumerFailureStage::IMPORT);
+                        LOG(ERROR) << "NvlinkTransport: invalid Fabric mapping "
+                                      "length "
+                                   << entry.length;
+                        return ERR_INVALID_ARGUMENT;
+                    }
                     CUmemFabricHandle export_handle;
                     memcpy(&export_handle, output_buffer.data(),
                            sizeof(export_handle));
-                    void *shm_addr = nullptr;
-                    CUmemGenericAllocationHandle handle;
-                    auto result = cuMemImportFromShareableHandle(
-                        &handle, &export_handle, CU_MEM_HANDLE_TYPE_FABRIC);
+                    if (!fabric_driver_api_.mem_import_from_shareable_handle ||
+                        !fabric_driver_api_.mem_address_reserve ||
+                        !fabric_driver_api_.mem_map ||
+                        !fabric_driver_api_.mem_set_access ||
+                        !fabric_driver_api_.mem_unmap ||
+                        !fabric_driver_api_.mem_address_free ||
+                        !fabric_driver_api_.mem_release ||
+                        !fabric_driver_api_.device_get_count ||
+                        !fabric_driver_api_.device_get) {
+                        observeConsumerFailure(ConsumerFailureStage::IMPORT);
+                        LOG(ERROR) << "NvlinkTransport: incomplete Fabric "
+                                      "driver adapter for lazy import";
+                        return ERR_CONTEXT;
+                    }
+                    if (!RetryQuarantinedFabricMappings()) {
+                        observeConsumerFailure(ConsumerFailureStage::IMPORT);
+                        LOG(ERROR)
+                            << "NvlinkTransport: a prior lazy Fabric import "
+                               "is still pending staged cleanup; refusing to "
+                               "import another handle";
+                        return ERR_MEMORY;
+                    }
+                    try {
+                        quarantined_fabric_mappings_.reserve(
+                            quarantined_fabric_mappings_.size() + 1);
+                    } catch (const std::exception& error) {
+                        observeConsumerFailure(ConsumerFailureStage::IMPORT);
+                        LOG(ERROR) << "NvlinkTransport: failed to reserve "
+                                      "lazy Fabric cleanup ownership: "
+                                   << error.what();
+                        return ERR_MEMORY;
+                    }
+                    FabricMappingAttempt attempt(*this);
+                    auto result =
+                        fabric_driver_api_.mem_import_from_shareable_handle(
+                            attempt.handleOut(), &export_handle,
+                            CU_MEM_HANDLE_TYPE_FABRIC);
                     if (result != CUDA_SUCCESS) {
+                        observeConsumerFailure(ConsumerFailureStage::IMPORT);
                         LOG(ERROR) << "NvlinkTransport: "
                                       "cuMemImportFromShareableHandle failed: "
                                    << result;
-                        return -1;
+                        return ERR_MEMORY;
                     }
-                    result = cuMemAddressReserve((CUdeviceptr *)&shm_addr,
-                                                 entry.length, 0, 0, 0);
+                    attempt.markHandleOwned();
+
+                    result = fabric_driver_api_.mem_address_reserve(
+                        attempt.addressOut(), static_cast<size_t>(entry.length),
+                        0, 0, 0);
                     if (result != CUDA_SUCCESS) {
+                        observeConsumerFailure(ConsumerFailureStage::RESERVE);
                         LOG(ERROR)
                             << "NvlinkTransport: cuMemAddressReserve failed: "
                             << result;
-                        return -1;
+                        return ERR_MEMORY;
                     }
-                    result = cuMemMap((CUdeviceptr)shm_addr, entry.length, 0,
-                                      handle, 0);
+                    attempt.markAddressReserved(
+                        static_cast<size_t>(entry.length));
+
+                    result = fabric_driver_api_.mem_map(attempt.address(),
+                                                        entry.length, 0,
+                                                        attempt.handle(), 0);
                     if (result != CUDA_SUCCESS) {
+                        observeConsumerFailure(ConsumerFailureStage::MAP);
                         LOG(ERROR)
                             << "NvlinkTransport: cuMemMap failed: " << result;
-                        return -1;
+                        return ERR_MEMORY;
+                    }
+                    attempt.markMapped();
+
+                    int device_count = 0;
+                    result = fabric_driver_api_.device_get_count(&device_count);
+                    if (result != CUDA_SUCCESS || device_count <= 0) {
+                        observeConsumerFailure(
+                            ConsumerFailureStage::SET_ACCESS);
+                        LOG(ERROR) << "NvlinkTransport: cuDeviceGetCount "
+                                      "failed during lazy import: "
+                                   << result;
+                        return ERR_CONTEXT;
                     }
 
-                    int device_count;
-                    cudaGetDeviceCount(&device_count);
-                    CUmemAccessDesc accessDesc[device_count];
-                    for (int device_id = 0; device_id < device_count;
-                         ++device_id) {
-                        accessDesc[device_id].location.type =
-                            CU_MEM_LOCATION_TYPE_DEVICE;
-                        accessDesc[device_id].location.id = device_id;
-                        accessDesc[device_id].flags =
-                            CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+                    for (int ordinal = 0; ordinal < device_count; ++ordinal) {
+                        CUdevice device;
+                        result =
+                            fabric_driver_api_.device_get(&device, ordinal);
+                        if (result != CUDA_SUCCESS) {
+                            observeConsumerFailure(
+                                ConsumerFailureStage::SET_ACCESS);
+                            LOG(ERROR) << "NvlinkTransport: cuDeviceGet failed "
+                                          "during lazy import: "
+                                       << result;
+                            return ERR_CONTEXT;
+                        }
+                        CUmemAccessDesc access = {};
+                        access.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+                        access.location.id = device;
+                        access.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+                        result = fabric_driver_api_.mem_set_access(
+                            attempt.address(), entry.length, &access, 1);
+                        if (result != CUDA_SUCCESS) {
+                            observeConsumerFailure(
+                                ConsumerFailureStage::SET_ACCESS);
+                            LOG(ERROR)
+                                << "NvlinkTransport: cuMemSetAccess failed for "
+                                   "visible device "
+                                << ordinal << ": " << result;
+                            return ERR_MEMORY;
+                        }
                     }
-                    result = cuMemSetAccess((CUdeviceptr)shm_addr, entry.length,
-                                            accessDesc, device_count);
+
+                    result = attempt.releaseHandle();
                     if (result != CUDA_SUCCESS) {
-                        LOG(ERROR) << "NvlinkTransport: cuMemSetAccess failed: "
+                        observeConsumerFailure(ConsumerFailureStage::IMPORT);
+                        LOG(ERROR) << "NvlinkTransport: post-map cuMemRelease "
+                                      "failed: "
                                    << result;
-                        return -1;
+                        return ERR_MEMORY;
                     }
+
                     OpenedShmEntry shm_entry;
-                    shm_entry.shm_addr = shm_addr;
+                    shm_entry.shm_addr =
+                        reinterpret_cast<void*>(attempt.address());
                     shm_entry.length = entry.length;
-                    remap_entries_[std::make_pair(target_id, entry.addr)] =
-                        shm_entry;
+                    shm_entry.kind = OpenedMappingKind::FABRIC;
+                    auto inserted =
+                        remap_entries_.emplace(cache_key, shm_entry).second;
+                    if (!inserted) {
+                        observeConsumerFailure(ConsumerFailureStage::MAP);
+                        return ERR_ADDRESS_OVERLAPPED;
+                    }
+                    attempt.transferMappingOwnership();
+#else
+                    observeConsumerFailure(ConsumerFailureStage::IMPORT);
+                    LOG(ERROR) << "NvlinkTransport: Fabric mapping requires "
+                                  "CUDA/MNNVL support";
+                    return ERR_CONTEXT;
+#endif
                 } else {
-                    LOG(ERROR) << "Mismatched NVLink data transfer method";
-                    return -1;
+                    observeConsumerFailure(ConsumerFailureStage::IMPORT);
+                    LOG(ERROR) << "NvlinkTransport: serialized handle size "
+                                  "does not match active IPC/Fabric mode";
+                    return ERR_INVALID_ARGUMENT;
                 }
+                cached = remap_entries_.find(cache_key);
+            } else {
+                observeCacheLookup(true);
             }
-            auto shm_addr =
-                remap_entries_[std::make_pair(target_id, entry.addr)].shm_addr;
+            if (cached == remap_entries_.end()) {
+                observeConsumerFailure(ConsumerFailureStage::IMPORT);
+                return ERR_MEMORY;
+            }
+            auto shm_addr = cached->second.shm_addr;
             dest_addr = dest_addr - entry.addr + ((uint64_t)shm_addr);
             return 0;
         }
-        index++;
     }
-    LOG(ERROR) << "Requested address " << (void *)dest_addr << " to "
-               << (void *)(dest_addr + length) << " not found!";
+    observeConsumerFailure(ConsumerFailureStage::IMPORT);
+    LOG(ERROR) << "Requested address " << (void*)dest_addr << " to "
+               << (void*)(dest_addr + length) << " not found!";
     return ERR_INVALID_ARGUMENT;
 }
 
 int NvlinkTransport::registerLocalMemoryBatch(
-    const std::vector<Transport::BufferEntry> &buffer_list,
-    const std::string &location) {
-    for (auto &buffer : buffer_list)
-        registerLocalMemory(buffer.addr, buffer.length, location, true, false);
-    return metadata_->updateLocalSegmentDesc();
+    const std::vector<Transport::BufferEntry>& buffer_list,
+    const std::string& location) {
+    std::vector<void*> registered;
+    registered.reserve(buffer_list.size());
+    for (auto& buffer : buffer_list) {
+        int rc = registerLocalMemory(buffer.addr, buffer.length, location, true,
+                                     false);
+        if (rc != 0) {
+            for (auto it = registered.rbegin(); it != registered.rend(); ++it)
+                unregisterLocalMemory(*it, false);
+            return rc;
+        }
+        registered.push_back(buffer.addr);
+    }
+
+    int rc = metadata_->updateLocalSegmentDesc();
+    if (rc == 0) return 0;
+
+    for (auto it = registered.rbegin(); it != registered.rend(); ++it)
+        unregisterLocalMemory(*it, false);
+    int rollback_rc = metadata_->updateLocalSegmentDesc();
+    if (rollback_rc != 0) {
+        LOG(ERROR) << "NvlinkTransport: batch registration metadata rollback "
+                      "failed: "
+                   << rollback_rc;
+    }
+    return rc;
 }
 
 int NvlinkTransport::unregisterLocalMemoryBatch(
-    const std::vector<void *> &addr_list) {
-    for (auto &addr : addr_list) unregisterLocalMemory(addr, false);
+    const std::vector<void*>& addr_list) {
+    for (auto& addr : addr_list) {
+        int rc = unregisterLocalMemory(addr, false);
+        if (rc != 0 && rc != ERR_ADDRESS_NOT_REGISTERED) return rc;
+    }
     return metadata_->updateLocalSegmentDesc();
 }
 
-void *NvlinkTransport::allocatePinnedLocalMemory(size_t size) {
+#if defined(USE_MNNVL) && defined(USE_CUDA)
+bool NvlinkTransport::TrackPinnedVmmAllocation(
+    std::unique_ptr<NvlinkVmmAllocation> owner) {
+    if (!owner || owner->base() == nullptr) return false;
+    void* const ptr = owner->base();
+    auto& registry = vmmAllocationOwnerRegistry();
+    std::lock_guard<std::mutex> lock(registry.mutex);
+    return registry.owners.emplace(ptr, std::move(owner)).second;
+}
+
+bool NvlinkTransport::ReleasePinnedVmmAllocation(void* ptr) {
+    auto& registry = vmmAllocationOwnerRegistry();
+    std::lock_guard<std::mutex> lock(registry.mutex);
+    auto it = registry.owners.find(ptr);
+    if (it == registry.owners.end()) return false;
+
+    try {
+        Status status = it->second->Release();
+        if (!status.ok()) {
+            LOG(ERROR) << "NvlinkTransport: pinned VMM release failed; "
+                          "retaining owner for repeated free: "
+                       << status;
+            return true;
+        }
+    } catch (const std::exception& error) {
+        LOG(ERROR) << "NvlinkTransport: pinned VMM release threw; retaining "
+                      "owner for repeated free: "
+                   << error.what();
+        return true;
+    } catch (...) {
+        LOG(ERROR) << "NvlinkTransport: pinned VMM release threw an unknown "
+                      "exception; retaining owner for repeated free";
+        return true;
+    }
+
+    registry.owners.erase(it);
+    return true;
+}
+#endif
+
+void* NvlinkTransport::allocatePinnedLocalMemory(size_t size) {
+#if defined(USE_MNNVL) && defined(USE_CUDA)
     if (!supportFabricMem()) {
-        void *ptr = nullptr;
+        void* ptr = nullptr;
         cudaMalloc(&ptr, size);
         return ptr;
     }
-    size_t granularity = 0;
-    CUdevice currentDev;
-    CUmemAllocationProp prop = {};
-    CUmemGenericAllocationHandle handle;
-    void *ptr = nullptr;
+
     int cudaDev;
-    int flag = 0;
     cudaError_t err = cudaGetDevice(&cudaDev);
     if (err != cudaSuccess) {
         LOG(ERROR) << "NvlinkTransport: cudaGetDevice failed: "
                    << cudaGetErrorString(err);
         return nullptr;
     }
-    CUresult result = cuDeviceGet(&currentDev, cudaDev);
-    if (result != CUDA_SUCCESS) {
-        LOG(ERROR) << "NvlinkTransport: cuDeviceGet failed: " << result;
+
+    NvlinkVmmAllocation::Options options;
+    options.location_type = NvlinkVmmAllocation::LocationType::DEVICE;
+    options.location_id = cudaDev;
+    options.requested_length = size;
+    options.fabric_exportable = true;
+
+    std::unique_ptr<NvlinkVmmAllocation> owner;
+    Status status = NvlinkVmmAllocation::Create(options, owner);
+    if (!status.ok()) {
+        LOG(ERROR) << "NvlinkTransport: DEVICE Fabric VMM allocation failed: "
+                   << status.ToString();
         return nullptr;
     }
-    prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
-    prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
-    prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_FABRIC;
-    prop.location.id = currentDev;
-    result = cuDeviceGetAttribute(
-        &flag, CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_WITH_CUDA_VMM_SUPPORTED,
-        currentDev);
-    if (result != CUDA_SUCCESS) {
-        LOG(ERROR) << "NvlinkTransport: cuDeviceGetAttribute failed: "
-                   << result;
-        return nullptr;
-    }
-    if (flag) prop.allocFlags.gpuDirectRDMACapable = 1;
-    result = cuMemGetAllocationGranularity(&granularity, &prop,
-                                           CU_MEM_ALLOC_GRANULARITY_MINIMUM);
-    if (result != CUDA_SUCCESS) {
-        LOG(ERROR) << "NvlinkTransport: cuMemGetAllocationGranularity failed: "
-                   << result;
-        return nullptr;
-    }
-    // fix size
-    size = (size + granularity - 1) & ~(granularity - 1);
-    if (size == 0) size = granularity;
-    result = cuMemCreate(&handle, size, &prop, 0);
-    if (result != CUDA_SUCCESS) {
-        LOG(ERROR) << "NvlinkTransport: cuMemCreate failed: " << result;
-        return nullptr;
-    }
-    result = cuMemAddressReserve((CUdeviceptr *)&ptr, size, granularity, 0, 0);
-    if (result != CUDA_SUCCESS) {
-        LOG(ERROR) << "NvlinkTransport: cuMemAddressReserve failed: " << result;
-        cuMemRelease(handle);
-        return nullptr;
-    }
-    result = cuMemMap((CUdeviceptr)ptr, size, 0, handle, 0);
-    if (result != CUDA_SUCCESS) {
-        LOG(ERROR) << "NvlinkTransport: cuMemMap failed: " << result;
-        cuMemAddressFree((CUdeviceptr)ptr, size);
-        cuMemRelease(handle);
-        return nullptr;
-    }
-    int device_count;
-    cudaGetDeviceCount(&device_count);
-    CUmemAccessDesc accessDesc[device_count];
-    for (int idx = 0; idx < device_count; ++idx) {
-        accessDesc[idx].location.type = CU_MEM_LOCATION_TYPE_DEVICE;
-        accessDesc[idx].location.id = idx;
-        accessDesc[idx].flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
-    }
-    result = cuMemSetAccess((CUdeviceptr)ptr, size, accessDesc, device_count);
-    if (result != CUDA_SUCCESS) {
-        LOG(ERROR) << "NvlinkTransport: cuMemSetAccess failed: " << result;
-        cuMemUnmap((CUdeviceptr)ptr, size);
-        cuMemAddressFree((CUdeviceptr)ptr, size);
-        cuMemRelease(handle);
+
+    void* ptr = owner->base();
+    if (!TrackPinnedVmmAllocation(std::move(owner))) {
+        LOG(ERROR) << "NvlinkTransport: duplicate VMM allocation address "
+                   << ptr;
         return nullptr;
     }
     return ptr;
+#else
+    void* ptr = nullptr;
+    cudaMalloc(&ptr, size);
+    return ptr;
+#endif
 }
 
-void NvlinkTransport::freePinnedLocalMemory(void *ptr) {
-    if (!supportFabricMem()) {
-        cudaFree(ptr);
-        return;
-    }
+void NvlinkTransport::freePinnedLocalMemory(void* ptr) {
+#if defined(USE_MNNVL) && defined(USE_CUDA)
+    if (ptr == nullptr) return;
+
+    if (ReleasePinnedVmmAllocation(ptr)) return;
+
+    // Preserve compatibility with imported Fabric mappings until their
+    // ownership moves to the registration/import RAII objects. Such mappings
+    // are not present in the legacy allocation-owner map.
     CUmemGenericAllocationHandle handle;
     size_t size = 0;
     auto result = cuMemRetainAllocationHandle(&handle, ptr);
     if (result != CUDA_SUCCESS) {
-        LOG(ERROR) << "NvlinkTransport: cuMemRetainAllocationHandle failed: "
-                   << result;
+        cudaGetLastError();
+        cudaFree(ptr);
         return;
     }
-    result = cuMemGetAddressRange(NULL, &size, (CUdeviceptr)ptr);
+    CUdeviceptr base = 0;
+    result =
+        cuMemGetAddressRange(&base, &size, reinterpret_cast<CUdeviceptr>(ptr));
     if (result == CUDA_SUCCESS) {
-        cuMemUnmap((CUdeviceptr)ptr, size);
-        cuMemAddressFree((CUdeviceptr)ptr, size);
+        cuMemUnmap(base, size);
+        cuMemAddressFree(base, size);
+    } else {
+        LOG(ERROR) << "NvlinkTransport: cuMemGetAddressRange failed: "
+                   << result;
     }
     cuMemRelease(handle);
+#else
+    cudaFree(ptr);
+#endif
 }
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tests/CMakeLists.txt
@@ -324,7 +324,7 @@ add_test(
   NAME nvlink_vmm_transfer_metadata_test
   COMMAND
     $<TARGET_FILE:transfer_metadata_test>
-    --gtest_filter=TransferMetadataSchemaTest.*:TransferMetadataRemovalTest.*:TransferTaskSubmissionFailureTest.*
+    --gtest_filter=TransferMetadataSchemaTest.*:TransferMetadataAdditionTest.*:TransferMetadataRemovalTest.*:TransferTaskSubmissionFailureTest.*
 )
 set_tests_properties(nvlink_vmm_transfer_metadata_test
                      PROPERTIES LABELS "nvlink_vmm_unit")

--- a/mooncake-transfer-engine/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tests/CMakeLists.txt
@@ -108,10 +108,70 @@ add_executable(dmabuf_export_test ${WORKSPACE}/dmabuf_export_test.cpp)
 target_link_libraries(dmabuf_export_test PUBLIC transfer_engine gtest gtest_main)
 add_test(NAME dmabuf_export_test COMMAND dmabuf_export_test)
 
-if (USE_MNNVL)
-    add_executable(nvlink_transport_test ${WORKSPACE}/nvlink_transport_test.cpp)
-    target_link_libraries(nvlink_transport_test PUBLIC transfer_engine gtest gtest_main )
-    add_test(NAME nvlink_transport_test COMMAND nvlink_transport_test)
+if(USE_MNNVL
+   AND USE_CUDA
+   AND NOT USE_HIP)
+  add_executable(nvlink_transport_test ${WORKSPACE}/nvlink_transport_test.cpp)
+  target_link_libraries(nvlink_transport_test PUBLIC transfer_engine gtest
+                                                     gtest_main)
+  add_test(
+    NAME nvlink_transport_fake_driver_test
+    COMMAND
+      ${CMAKE_COMMAND} -E env --unset=MC_USE_NVLINK_IPC
+      GTEST_FILTER=NvlinkTransportUnitTest.*
+      $<TARGET_FILE:nvlink_transport_test>)
+  set_tests_properties(nvlink_transport_fake_driver_test
+                       PROPERTIES LABELS "nvlink_vmm_unit")
+  add_executable(nvlink_transport_metrics_test
+                 ${WORKSPACE}/nvlink_transport_metrics_test.cpp)
+  target_link_libraries(nvlink_transport_metrics_test PUBLIC transfer_engine
+                                                             gtest gtest_main)
+  add_test(NAME nvlink_transport_metrics_test
+           COMMAND nvlink_transport_metrics_test)
+  set_tests_properties(nvlink_transport_metrics_test
+                       PROPERTIES LABELS "nvlink_vmm_unit")
+  add_test(
+    NAME nvlink_transport_fabric_hbm_test
+    COMMAND
+      ${CMAKE_COMMAND} -E env --unset=MC_USE_NVLINK_IPC
+      GTEST_FILTER=NvlinkTransportTest.WriteAndRead
+      $<TARGET_FILE:nvlink_transport_test>)
+  add_test(
+    NAME nvlink_transport_ipc_cuda_malloc_test
+    COMMAND
+      ${CMAKE_COMMAND} -E env MC_USE_NVLINK_IPC=1
+      GTEST_FILTER=NvlinkTransportTest.WriteAndRead
+      $<TARGET_FILE:nvlink_transport_test>)
+  set_tests_properties(
+    nvlink_transport_fabric_hbm_test nvlink_transport_ipc_cuda_malloc_test
+    PROPERTIES LABELS "nvlink_hbm_regression;nvlink_vmm_hardware")
+endif()
+
+if(USE_MNNVL
+   AND USE_CUDA
+   AND NOT USE_HIP)
+  add_executable(nvlink_vmm_allocation_test
+                 ${WORKSPACE}/nvlink_vmm_allocation_test.cpp)
+  target_link_libraries(nvlink_vmm_allocation_test PUBLIC transfer_engine gtest
+                                                          gtest_main)
+  add_test(NAME nvlink_vmm_allocation_test COMMAND nvlink_vmm_allocation_test)
+  set_tests_properties(nvlink_vmm_allocation_test PROPERTIES LABELS
+                                                             "nvlink_vmm_unit")
+
+  add_executable(nvlink_vmm_fabric_test ${WORKSPACE}/nvlink_vmm_fabric_test.cpp)
+  target_link_libraries(nvlink_vmm_fabric_test PUBLIC transfer_engine gtest
+                                                      gtest_main)
+  add_test(NAME nvlink_vmm_fabric_test COMMAND nvlink_vmm_fabric_test)
+  set_tests_properties(nvlink_vmm_fabric_test PROPERTIES LABELS
+                                                         "nvlink_vmm_hardware")
+
+  add_executable(nvlink_vmm_rdma_smoke_test
+                 ${WORKSPACE}/nvlink_vmm_rdma_smoke_test.cpp)
+  target_link_libraries(nvlink_vmm_rdma_smoke_test PUBLIC transfer_engine gtest
+                                                          gtest_main ibverbs)
+  add_test(NAME nvlink_vmm_rdma_smoke_test COMMAND nvlink_vmm_rdma_smoke_test)
+  set_tests_properties(nvlink_vmm_rdma_smoke_test PROPERTIES LABELS
+                                                             "nvlink_vmm_rdma")
 endif()
 
 if(USE_HIP)
@@ -260,6 +320,14 @@ add_executable(transfer_metadata_test ${WORKSPACE}/transfer_metadata_test.cpp)
 target_link_libraries(transfer_metadata_test PUBLIC transfer_engine gtest
                                                     gtest_main)
 add_test(NAME transfer_metadata_test COMMAND transfer_metadata_test)
+add_test(
+  NAME nvlink_vmm_transfer_metadata_test
+  COMMAND
+    $<TARGET_FILE:transfer_metadata_test>
+    --gtest_filter=TransferMetadataSchemaTest.*:TransferMetadataRemovalTest.*:TransferTaskSubmissionFailureTest.*
+)
+set_tests_properties(nvlink_vmm_transfer_metadata_test
+                     PROPERTIES LABELS "nvlink_vmm_unit")
 
 add_executable(config_test ${WORKSPACE}/config_test.cpp)
 target_link_libraries(config_test PUBLIC transfer_engine gtest gtest_main)

--- a/mooncake-transfer-engine/tests/nvlink_transport_metrics_test.cpp
+++ b/mooncake-transfer-engine/tests/nvlink_transport_metrics_test.cpp
@@ -1,0 +1,326 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdlib>
+#include <set>
+#include <string>
+
+#include "multi_transport.h"
+#include "transport/nvlink_transport/nvlink_transport.h"
+
+namespace mooncake {
+
+class NvlinkTransportTestPeer {
+   public:
+    enum class FailureStage { IMPORT, RESERVE, MAP, SET_ACCESS, COPY };
+
+    static void ObserveCacheLookup(NvlinkTransport& transport, bool hit) {
+        transport.observeCacheLookup(hit);
+    }
+
+    static void ObserveLazyImport(NvlinkTransport& transport,
+                                  uint64_t duration_us) {
+        transport.observeLazyImportLatency(duration_us);
+    }
+
+    static void ObserveFailure(NvlinkTransport& transport, FailureStage stage) {
+        NvlinkTransport::ConsumerFailureStage consumer_stage =
+            NvlinkTransport::ConsumerFailureStage::IMPORT;
+        switch (stage) {
+            case FailureStage::IMPORT:
+                consumer_stage = NvlinkTransport::ConsumerFailureStage::IMPORT;
+                break;
+            case FailureStage::RESERVE:
+                consumer_stage = NvlinkTransport::ConsumerFailureStage::RESERVE;
+                break;
+            case FailureStage::MAP:
+                consumer_stage = NvlinkTransport::ConsumerFailureStage::MAP;
+                break;
+            case FailureStage::SET_ACCESS:
+                consumer_stage =
+                    NvlinkTransport::ConsumerFailureStage::SET_ACCESS;
+                break;
+            case FailureStage::COPY:
+                consumer_stage = NvlinkTransport::ConsumerFailureStage::COPY;
+                break;
+        }
+        transport.observeConsumerFailure(consumer_stage);
+    }
+
+    static bool ObserveTransferResultOnce(NvlinkTransport& transport,
+                                          Transport::TransferTask& task,
+                                          bool success) {
+        return transport.observeTransferResultOnce(task, success);
+    }
+
+    static void FinalizeSubmissionFailure(NvlinkTransport& transport,
+                                          Transport::TransferTask& task,
+                                          bool copy_failure) {
+        transport.finalizeSubmissionFailure(task, copy_failure);
+    }
+};
+
+namespace {
+
+class ScopedEnvironmentVariable {
+   public:
+    ScopedEnvironmentVariable(const char* name, const char* value)
+        : name_(name) {
+        const char* previous = std::getenv(name);
+        if (previous != nullptr) {
+            had_previous_ = true;
+            previous_ = previous;
+        }
+        setenv(name, value, 1);
+    }
+
+    ScopedEnvironmentVariable(const ScopedEnvironmentVariable&) = delete;
+    ScopedEnvironmentVariable& operator=(const ScopedEnvironmentVariable&) =
+        delete;
+
+    ~ScopedEnvironmentVariable() {
+        if (had_previous_) {
+            setenv(name_.c_str(), previous_.c_str(), 1);
+        } else {
+            unsetenv(name_.c_str());
+        }
+    }
+
+   private:
+    std::string name_;
+    std::string previous_;
+    bool had_previous_ = false;
+};
+
+void ExpectSample(const std::string& metrics, const std::string& sample) {
+    EXPECT_NE(metrics.find(sample), std::string::npos) << metrics;
+}
+
+void ExpectOnlyBoundedLabels(const std::string& metrics) {
+    const std::set<std::string> allowed = {"operation", "result", "stage"};
+    size_t cursor = 0;
+    while (cursor < metrics.size()) {
+        const size_t line_end = metrics.find('\n', cursor);
+        const size_t end =
+            line_end == std::string::npos ? metrics.size() : line_end;
+        const std::string line = metrics.substr(cursor, end - cursor);
+        if (!line.empty() && line.front() != '#') {
+            const size_t labels_begin = line.find('{');
+            const size_t labels_end = line.find('}', labels_begin);
+            if (labels_begin != std::string::npos &&
+                labels_end != std::string::npos) {
+                size_t label_cursor = labels_begin + 1;
+                while (label_cursor < labels_end) {
+                    const size_t equal = line.find('=', label_cursor);
+                    ASSERT_NE(equal, std::string::npos) << line;
+                    const std::string name =
+                        line.substr(label_cursor, equal - label_cursor);
+                    EXPECT_TRUE(allowed.contains(name))
+                        << "unexpected label " << name << " in " << line;
+                    const size_t comma = line.find(',', equal);
+                    label_cursor =
+                        comma == std::string::npos || comma > labels_end
+                            ? labels_end
+                            : comma + 1;
+                }
+            }
+        }
+        if (line_end == std::string::npos) break;
+        cursor = line_end + 1;
+    }
+}
+
+TEST(NvlinkTransportMetricsTest, SerializesBoundedConsumerMetrics) {
+    ScopedEnvironmentVariable force_ipc("MC_USE_NVLINK_IPC", "1");
+    NvlinkTransport transport;
+
+    NvlinkTransportTestPeer::ObserveCacheLookup(transport, true);
+    NvlinkTransportTestPeer::ObserveCacheLookup(transport, true);
+    NvlinkTransportTestPeer::ObserveCacheLookup(transport, false);
+    NvlinkTransportTestPeer::ObserveLazyImport(transport, 7);
+    NvlinkTransportTestPeer::ObserveLazyImport(transport, 13);
+
+    using FailureStage = NvlinkTransportTestPeer::FailureStage;
+    NvlinkTransportTestPeer::ObserveFailure(transport, FailureStage::IMPORT);
+    NvlinkTransportTestPeer::ObserveFailure(transport, FailureStage::RESERVE);
+    NvlinkTransportTestPeer::ObserveFailure(transport, FailureStage::MAP);
+    NvlinkTransportTestPeer::ObserveFailure(transport,
+                                            FailureStage::SET_ACCESS);
+    NvlinkTransportTestPeer::ObserveFailure(transport, FailureStage::COPY);
+    NvlinkTransportTestPeer::ObserveFailure(transport, FailureStage::COPY);
+
+    constexpr std::array<Transport::TransferRequest::OpCode, 7> operations = {
+        Transport::TransferRequest::READ,  Transport::TransferRequest::READ,
+        Transport::TransferRequest::READ,  Transport::TransferRequest::WRITE,
+        Transport::TransferRequest::WRITE, Transport::TransferRequest::WRITE,
+        Transport::TransferRequest::WRITE};
+    constexpr std::array<bool, 7> successes = {true,  true,  false, true,
+                                               false, false, false};
+    std::array<Transport::TransferRequest, 7> requests{};
+    std::array<Transport::TransferTask, 7> tasks{};
+    for (size_t index = 0; index < tasks.size(); ++index) {
+        requests[index].opcode = operations[index];
+        tasks[index].request = &requests[index];
+        tasks[index].operation = requests[index].opcode;
+        tasks[index].operation_initialized = true;
+        tasks[index].request = nullptr;
+        EXPECT_TRUE(NvlinkTransportTestPeer::ObserveTransferResultOnce(
+            transport, tasks[index], successes[index]));
+        EXPECT_FALSE(NvlinkTransportTestPeer::ObserveTransferResultOnce(
+            transport, tasks[index], successes[index]))
+            << "repeated terminal polling must not duplicate task metrics";
+    }
+
+    std::string metrics;
+    transport.appendMetrics(metrics);
+
+    ExpectSample(
+        metrics,
+        "mooncake_nvlink_consumer_mapping_cache_total{result=\"hit\"} 2");
+    ExpectSample(
+        metrics,
+        "mooncake_nvlink_consumer_mapping_cache_total{result=\"miss\"} 1");
+    ExpectSample(metrics,
+                 "mooncake_nvlink_consumer_lazy_import_duration_us_total 20");
+    ExpectSample(metrics,
+                 "mooncake_nvlink_consumer_lazy_import_observations_total 2");
+    ExpectSample(metrics,
+                 "mooncake_nvlink_consumer_failures_total{stage=\"import\"} 1");
+    ExpectSample(
+        metrics,
+        "mooncake_nvlink_consumer_failures_total{stage=\"reserve\"} 1");
+    ExpectSample(metrics,
+                 "mooncake_nvlink_consumer_failures_total{stage=\"map\"} 1");
+    ExpectSample(
+        metrics,
+        "mooncake_nvlink_consumer_failures_total{stage=\"set_access\"} 1");
+    ExpectSample(metrics,
+                 "mooncake_nvlink_consumer_failures_total{stage=\"copy\"} 2");
+    ExpectSample(metrics,
+                 "mooncake_nvlink_consumer_transfer_results_total{operation="
+                 "\"read\",result=\"success\"} 2");
+    ExpectSample(metrics,
+                 "mooncake_nvlink_consumer_transfer_results_total{operation="
+                 "\"read\",result=\"failure\"} 1");
+    ExpectSample(metrics,
+                 "mooncake_nvlink_consumer_transfer_results_total{operation="
+                 "\"write\",result=\"success\"} 1");
+    ExpectSample(metrics,
+                 "mooncake_nvlink_consumer_transfer_results_total{operation="
+                 "\"write\",result=\"failure\"} 3");
+
+    ExpectOnlyBoundedLabels(metrics);
+    for (const std::string& forbidden :
+         {"endpoint", "uuid", "address", "fabric_handle"}) {
+        EXPECT_EQ(metrics.find(forbidden), std::string::npos) << metrics;
+    }
+}
+
+TEST(NvlinkTransportMetricsTest,
+     EventDrivenBatchFastPathFinalizesStableResultsOnce) {
+    ScopedEnvironmentVariable force_ipc("MC_USE_NVLINK_IPC", "1");
+    NvlinkTransport transport;
+    std::string local_server_name = "metrics-test";
+    MultiTransport multi_transport(nullptr, local_server_name);
+
+    const auto batch_id = multi_transport.allocateBatchID(2);
+    ASSERT_NE(batch_id, 0u);
+    auto& batch = Transport::toBatchDesc(batch_id);
+    batch.task_list.resize(2);
+
+    std::array<Transport::TransferRequest, 2> requests{};
+    requests[0].opcode = Transport::TransferRequest::READ;
+    requests[1].opcode = Transport::TransferRequest::WRITE;
+    for (size_t index = 0; index < batch.task_list.size(); ++index) {
+        auto& task = batch.task_list[index];
+        task.batch_id = batch_id;
+        task.transport_ = &transport;
+        task.request = &requests[index];
+        task.operation = requests[index].opcode;
+        task.operation_initialized = true;
+        task.slice_count = 1;
+        task.is_finished = true;
+        // Model the caller-owned entries going out of scope before an
+        // event-driven completion is observed.
+        task.request = nullptr;
+    }
+    batch.task_list[0].success_slice_count = 1;
+    batch.task_list[0].transferred_bytes = 64;
+    batch.task_list[1].failed_slice_count = 1;
+    batch.has_failure.store(true, std::memory_order_relaxed);
+    batch.finished_transfer_bytes.store(64, std::memory_order_relaxed);
+    batch.is_finished.store(true, std::memory_order_release);
+
+    Transport::TransferStatus status;
+    ASSERT_TRUE(multi_transport.getBatchTransferStatus(batch_id, status).ok());
+    EXPECT_EQ(status.s, Transport::TransferStatusEnum::FAILED);
+    EXPECT_EQ(status.transferred_bytes, 64u);
+    ASSERT_TRUE(multi_transport.getBatchTransferStatus(batch_id, status).ok());
+
+    std::string metrics;
+    transport.appendMetrics(metrics);
+    ExpectSample(metrics,
+                 "mooncake_nvlink_consumer_transfer_results_total{operation="
+                 "\"read\",result=\"success\"} 1");
+    ExpectSample(metrics,
+                 "mooncake_nvlink_consumer_transfer_results_total{operation="
+                 "\"write\",result=\"failure\"} 1");
+    ExpectSample(metrics,
+                 "mooncake_nvlink_consumer_failures_total{stage=\"copy\"} 1");
+
+    EXPECT_TRUE(multi_transport.freeBatchID(batch_id).ok());
+}
+
+TEST(NvlinkTransportMetricsTest,
+     NonCopySubmissionFailureStaysClassifiedAcrossBatchFastPath) {
+    ScopedEnvironmentVariable force_ipc("MC_USE_NVLINK_IPC", "1");
+    NvlinkTransport transport;
+    std::string local_server_name = "metrics-test";
+    MultiTransport multi_transport(nullptr, local_server_name);
+
+    const auto batch_id = multi_transport.allocateBatchID(1);
+    ASSERT_NE(batch_id, 0u);
+    auto& batch = Transport::toBatchDesc(batch_id);
+    batch.task_list.resize(1);
+    auto& task = batch.task_list.front();
+    task.batch_id = batch_id;
+    task.transport_ = &transport;
+    task.operation = Transport::TransferRequest::READ;
+    task.operation_initialized = true;
+
+    NvlinkTransportTestPeer::FinalizeSubmissionFailure(transport, task, false);
+    EXPECT_TRUE(task.submission_failed);
+    batch.is_finished.store(true, std::memory_order_release);
+
+    Transport::TransferStatus status;
+    ASSERT_TRUE(multi_transport.getBatchTransferStatus(batch_id, status).ok());
+    EXPECT_EQ(status.s, Transport::TransferStatusEnum::FAILED);
+    ASSERT_TRUE(multi_transport.getBatchTransferStatus(batch_id, status).ok());
+
+    std::string metrics;
+    transport.appendMetrics(metrics);
+    ExpectSample(metrics,
+                 "mooncake_nvlink_consumer_transfer_results_total{operation="
+                 "\"read\",result=\"failure\"} 1");
+    ExpectSample(metrics,
+                 "mooncake_nvlink_consumer_failures_total{stage=\"copy\"} 0");
+
+    EXPECT_TRUE(multi_transport.freeBatchID(batch_id).ok());
+}
+
+}  // namespace
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tests/nvlink_transport_test.cpp
+++ b/mooncake-transfer-engine/tests/nvlink_transport_test.cpp
@@ -1,12 +1,22 @@
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <gtest/gtest.h>
-#include <thread>
-#include <memory>
 #include <cstring>
+#include <cstdlib>
+#include <functional>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
 
+#include "common/serialization.h"
 #include "cuda_alike.h"
+#include "error.h"
 #include "transfer_engine.h"
+#include "transfer_metadata.h"
+#include "transport/nvlink_transport/nvlink_transport.h"
 #include "transport/transport.h"
 
 using namespace mooncake;
@@ -22,6 +32,339 @@ DEFINE_string(metadata_server, "127.0.0.1:2379", "etcd server host address");
 DEFINE_string(local_server_name, "cuda_server:12345", "Local server name");
 DEFINE_string(segment_id, "cuda_server:12345", "Segment ID to access data");
 DEFINE_int32(gpu_id, 0, "GPU ID to use");
+
+namespace {
+
+bool ParseStrictFabricRequirement(bool& strict, std::string& error) {
+    strict = false;
+    error.clear();
+    const char* value = std::getenv("MC_REQUIRE_MNNVL_FABRIC");
+    if (value == nullptr || std::string(value) == "0") return true;
+    if (std::string(value) == "1") {
+        strict = true;
+        return true;
+    }
+    error = "MC_REQUIRE_MNNVL_FABRIC must be either 0 or 1";
+    return false;
+}
+
+class ScopedEnvironmentVariable {
+   public:
+    ScopedEnvironmentVariable(const char* name, const char* value)
+        : name_(name) {
+        const char* previous = std::getenv(name);
+        if (previous != nullptr) {
+            had_previous_ = true;
+            previous_ = previous;
+        }
+        if (value != nullptr) {
+            setenv(name, value, 1);
+        } else {
+            unsetenv(name);
+        }
+    }
+
+    ScopedEnvironmentVariable(const ScopedEnvironmentVariable&) = delete;
+    ScopedEnvironmentVariable& operator=(const ScopedEnvironmentVariable&) =
+        delete;
+
+    ~ScopedEnvironmentVariable() {
+        if (had_previous_) {
+            setenv(name_.c_str(), previous_.c_str(), 1);
+        } else {
+            unsetenv(name_.c_str());
+        }
+    }
+
+   private:
+    std::string name_;
+    std::string previous_;
+    bool had_previous_ = false;
+};
+
+}  // namespace
+
+#if defined(USE_MNNVL) && defined(USE_CUDA)
+namespace mooncake {
+
+class NvlinkTransportTestPeer {
+   public:
+    using DriverApi = NvlinkVmmAllocation::DriverApi;
+
+    static void configureFabric(
+        NvlinkTransport& transport, DriverApi driver_api,
+        std::function<int(const TransferMetadata::BufferDesc&, bool)> add = {},
+        std::function<int(void*, bool)> remove = {},
+        std::function<std::shared_ptr<TransferMetadata::SegmentDesc>(uint64_t)>
+            get_segment = {}) {
+        transport.use_fabric_mem_ = true;
+        transport.fabric_driver_api_ = std::move(driver_api);
+        transport.add_buffer_for_testing_ = std::move(add);
+        transport.remove_buffer_for_testing_ = std::move(remove);
+        transport.get_segment_for_testing_ = std::move(get_segment);
+    }
+
+    static int registerRemote(NvlinkTransport& transport, void* addr,
+                              size_t length) {
+        return transport.registerLocalMemory(addr, length, "cuda:0", true,
+                                             true);
+    }
+
+    static int registerLocalOnly(NvlinkTransport& transport, void* addr,
+                                 size_t length) {
+        return transport.registerLocalMemory(addr, length, "cpu:0", false,
+                                             true);
+    }
+
+    static int unregister(NvlinkTransport& transport, void* addr) {
+        return transport.unregisterLocalMemory(addr, true);
+    }
+
+    static int relocate(NvlinkTransport& transport, uint64_t& addr,
+                        uint64_t length, uint64_t target_id) {
+        return transport.relocateSharedMemoryAddress(addr, length, target_id);
+    }
+
+    static size_t mappingCount(const NvlinkTransport& transport) {
+        return transport.remap_entries_.size();
+    }
+
+    static size_t registrationCount(const NvlinkTransport& transport) {
+        return transport.local_registrations_.size();
+    }
+
+    static size_t quarantinedRetainedHandleCount(
+        const NvlinkTransport& transport) {
+        return transport.quarantined_retained_handles_.size();
+    }
+
+    static size_t quarantinedFabricMappingCount(
+        const NvlinkTransport& transport) {
+        return transport.quarantined_fabric_mappings_.size();
+    }
+
+    static int publishIpcDescriptorForTesting(
+        NvlinkTransport& transport, void* registration_addr,
+        std::function<int(const TransferMetadata::BufferDesc&, bool)> add,
+        std::function<int(void*, bool)> remove) {
+        transport.use_fabric_mem_ = false;
+        transport.add_buffer_for_testing_ = std::move(add);
+        transport.remove_buffer_for_testing_ = std::move(remove);
+        NvlinkTransport::LocalRegistration registration;
+        registration.requested_addr = registration_addr;
+        registration.requested_length = 4096;
+        registration.mapped_base = registration_addr;
+        registration.mapped_length = 4096;
+        registration.remote_accessible = true;
+        transport.local_registrations_.emplace(registration_addr, registration);
+        TransferMetadata::BufferDesc descriptor;
+        descriptor.addr = reinterpret_cast<uint64_t>(registration_addr);
+        descriptor.length = 4096;
+        descriptor.shm_name = "fake-ipc-handle";
+        return transport.publishLocalRegistration(registration_addr, descriptor,
+                                                  true);
+    }
+
+    static std::unique_ptr<NvlinkVmmAllocation> makeOwnedHostNumaRange(
+        void* base, size_t length) {
+        std::unique_ptr<NvlinkVmmAllocation> allocation(
+            new NvlinkVmmAllocation());
+        allocation->base_ = base;
+        allocation->length_ = length;
+        allocation->location_type_ =
+            NvlinkVmmAllocation::LocationType::HOST_NUMA;
+        allocation->fabric_exportable_ = true;
+        allocation->owned_range_registered_ =
+            NvlinkVmmAllocation::RegisterOwnedRange(base, length);
+        if (!allocation->owned_range_registered_) return nullptr;
+        return allocation;
+    }
+};
+
+}  // namespace mooncake
+
+namespace {
+
+class FakeFabricDriver {
+   public:
+    enum class Failure {
+        NONE,
+        ALLOCATION_PROPERTIES,
+        ADDRESS_RANGE,
+        EXPORT,
+        IMPORT,
+        RESERVE,
+        MAP,
+        ACCESS,
+        POST_MAP_RELEASE,
+    };
+
+    NvlinkTransportTestPeer::DriverApi api() {
+        NvlinkTransportTestPeer::DriverApi api;
+        api.device_get_count = [](int* count) {
+            *count = 2;
+            return CUDA_SUCCESS;
+        };
+        api.device_get = [](CUdevice* device, int ordinal) {
+            *device = ordinal;
+            return CUDA_SUCCESS;
+        };
+        api.device_get_attribute = [](int* value, CUdevice_attribute attribute,
+                                      CUdevice) {
+            *value =
+                attribute == CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED
+                    ? 1
+                    : 0;
+            return CUDA_SUCCESS;
+        };
+        api.mem_retain_allocation_handle =
+            [this](CUmemGenericAllocationHandle* handle, void*) {
+                *handle = kRetainedHandle;
+                ++live_handles;
+                return CUDA_SUCCESS;
+            };
+        api.mem_get_allocation_properties_from_handle =
+            [this](CUmemAllocationProp* prop, CUmemGenericAllocationHandle) {
+                if (failure == Failure::ALLOCATION_PROPERTIES)
+                    return CUDA_ERROR_INVALID_HANDLE;
+                *prop = {};
+                prop->location.type = allocation_location_type;
+                return CUDA_SUCCESS;
+            };
+        api.mem_get_address_range = [this](CUdeviceptr* base, size_t* length,
+                                           CUdeviceptr) {
+            ++address_range_calls;
+            if (failure == Failure::ADDRESS_RANGE)
+                return CUDA_ERROR_INVALID_CONTEXT;
+            *base = kPublishedBase;
+            *length = kMappedLength;
+            return CUDA_SUCCESS;
+        };
+        api.mem_export_to_shareable_handle =
+            [this](void* shareable, CUmemGenericAllocationHandle,
+                   CUmemAllocationHandleType, unsigned long long) {
+                if (failure == Failure::EXPORT)
+                    return CUDA_ERROR_INVALID_HANDLE;
+                std::memset(shareable, 0, sizeof(CUmemFabricHandle));
+                return CUDA_SUCCESS;
+            };
+        api.mem_import_from_shareable_handle =
+            [this](CUmemGenericAllocationHandle* handle, void*,
+                   CUmemAllocationHandleType) {
+                ++import_calls;
+                if (failure == Failure::IMPORT) return CUDA_ERROR_INVALID_VALUE;
+                *handle = kImportedHandle;
+                ++live_handles;
+                return CUDA_SUCCESS;
+            };
+        api.mem_address_reserve = [this](CUdeviceptr* address, size_t, size_t,
+                                         CUdeviceptr, unsigned long long) {
+            if (failure == Failure::RESERVE) return CUDA_ERROR_INVALID_VALUE;
+            *address = kImportedBase;
+            ++reserved_ranges;
+            return CUDA_SUCCESS;
+        };
+        api.mem_map = [this](CUdeviceptr, size_t, size_t,
+                             CUmemGenericAllocationHandle, unsigned long long) {
+            if (failure == Failure::MAP) return CUDA_ERROR_INVALID_VALUE;
+            ++mapped_ranges;
+            return CUDA_SUCCESS;
+        };
+        api.mem_set_access = [this](CUdeviceptr, size_t, const CUmemAccessDesc*,
+                                    size_t) {
+            ++access_calls;
+            if (failure == Failure::ACCESS) return CUDA_ERROR_INVALID_VALUE;
+            return CUDA_SUCCESS;
+        };
+        api.mem_unmap = [this](CUdeviceptr, size_t) {
+            ++unmap_calls;
+            if (unmap_failures_remaining > 0) {
+                --unmap_failures_remaining;
+                return CUDA_ERROR_INVALID_VALUE;
+            }
+            if (mapped_ranges > 0) --mapped_ranges;
+            return CUDA_SUCCESS;
+        };
+        api.mem_address_free = [this](CUdeviceptr, size_t) {
+            ++address_free_calls;
+            if (address_free_failures_remaining > 0) {
+                --address_free_failures_remaining;
+                return CUDA_ERROR_INVALID_VALUE;
+            }
+            if (reserved_ranges > 0) --reserved_ranges;
+            return CUDA_SUCCESS;
+        };
+        api.mem_release = [this](CUmemGenericAllocationHandle handle) {
+            ++release_calls;
+            if (handle == kRetainedHandle &&
+                retained_release_failures_remaining > 0) {
+                --retained_release_failures_remaining;
+                return CUDA_ERROR_INVALID_VALUE;
+            }
+            if (handle == kImportedHandle) {
+                ++imported_release_calls;
+                if (imported_release_failures_remaining > 0) {
+                    --imported_release_failures_remaining;
+                    return CUDA_ERROR_INVALID_VALUE;
+                }
+            }
+            if (failure == Failure::POST_MAP_RELEASE &&
+                handle == kImportedHandle && !release_failed_once) {
+                release_failed_once = true;
+                return CUDA_ERROR_INVALID_VALUE;
+            }
+            if (live_handles > 0) --live_handles;
+            return CUDA_SUCCESS;
+        };
+        return api;
+    }
+
+    void expectNoResources() const {
+        EXPECT_EQ(live_handles, 0);
+        EXPECT_EQ(reserved_ranges, 0);
+        EXPECT_EQ(mapped_ranges, 0);
+    }
+
+    static constexpr CUmemGenericAllocationHandle kRetainedHandle = 101;
+    static constexpr CUmemGenericAllocationHandle kImportedHandle = 202;
+    static constexpr CUdeviceptr kPublishedBase = 0x10000000ULL;
+    static constexpr CUdeviceptr kImportedBase = 0x20000000ULL;
+    static constexpr size_t kMappedLength = 64 * 1024;
+
+    Failure failure = Failure::NONE;
+    CUmemLocationType allocation_location_type = CU_MEM_LOCATION_TYPE_DEVICE;
+    int live_handles = 0;
+    int reserved_ranges = 0;
+    int mapped_ranges = 0;
+    int import_calls = 0;
+    int address_range_calls = 0;
+    int access_calls = 0;
+    int release_calls = 0;
+    int unmap_calls = 0;
+    int address_free_calls = 0;
+    int imported_release_calls = 0;
+    int unmap_failures_remaining = 0;
+    int address_free_failures_remaining = 0;
+    int imported_release_failures_remaining = 0;
+    int retained_release_failures_remaining = 0;
+    bool release_failed_once = false;
+};
+
+std::shared_ptr<TransferMetadata::SegmentDesc> fakeFabricSegment() {
+    auto segment = std::make_shared<TransferMetadata::SegmentDesc>();
+    segment->name = "fake-provider";
+    segment->protocol = "nvlink";
+    TransferMetadata::BufferDesc buffer;
+    buffer.addr = FakeFabricDriver::kPublishedBase;
+    buffer.length = FakeFabricDriver::kMappedLength;
+    CUmemFabricHandle handle = {};
+    buffer.shm_name = serializeBinaryData(&handle, sizeof(handle));
+    segment->buffers.push_back(std::move(buffer));
+    return segment;
+}
+
+}  // namespace
+#endif
 
 static void checkCudaError(cudaError_t result, const char* message) {
     if (result != cudaSuccess) {
@@ -43,29 +386,778 @@ static void freeCudaBuffer(void* addr) {
     checkCudaError(cudaFree(addr), "Failed to free device memory");
 }
 
+static void* allocatePublishedBuffer(size_t size, int gpu_id) {
+#ifdef USE_CUDA
+    if (std::getenv("MC_USE_NVLINK_IPC") != nullptr)
+        return allocateCudaBuffer(size, gpu_id);
+    checkCudaError(cudaSetDevice(gpu_id), "Failed to set device");
+    return NvlinkTransport::allocatePinnedLocalMemory(size);
+#else
+    return allocateCudaBuffer(size, gpu_id);
+#endif
+}
+
+static void freePublishedBuffer(void* addr) {
+#ifdef USE_CUDA
+    if (std::getenv("MC_USE_NVLINK_IPC") != nullptr)
+        freeCudaBuffer(addr);
+    else
+        NvlinkTransport::freePinnedLocalMemory(addr);
+#else
+    freeCudaBuffer(addr);
+#endif
+}
+
+#if defined(USE_MNNVL) && defined(USE_CUDA)
+TEST(NvlinkTransportUnitTest, StrictFabricRequirementParsingIsExact) {
+    bool strict = true;
+    std::string error = "stale";
+    {
+        ScopedEnvironmentVariable unset_strict("MC_REQUIRE_MNNVL_FABRIC",
+                                               nullptr);
+        EXPECT_TRUE(ParseStrictFabricRequirement(strict, error));
+        EXPECT_FALSE(strict);
+        EXPECT_TRUE(error.empty());
+    }
+    {
+        ScopedEnvironmentVariable disabled_strict("MC_REQUIRE_MNNVL_FABRIC",
+                                                  "0");
+        EXPECT_TRUE(ParseStrictFabricRequirement(strict, error));
+        EXPECT_FALSE(strict);
+        EXPECT_TRUE(error.empty());
+    }
+    {
+        ScopedEnvironmentVariable enabled_strict("MC_REQUIRE_MNNVL_FABRIC",
+                                                 "1");
+        EXPECT_TRUE(ParseStrictFabricRequirement(strict, error));
+        EXPECT_TRUE(strict);
+        EXPECT_TRUE(error.empty());
+    }
+    {
+        ScopedEnvironmentVariable invalid_strict("MC_REQUIRE_MNNVL_FABRIC",
+                                                 "true");
+        EXPECT_FALSE(ParseStrictFabricRequirement(strict, error));
+        EXPECT_FALSE(strict);
+        EXPECT_EQ(error, "MC_REQUIRE_MNNVL_FABRIC must be either 0 or 1");
+    }
+}
+
+TEST(NvlinkTransportUnitTest, LocalOnlyCpuRegistrationNeverPublishesMetadata) {
+    NvlinkTransport transport;
+    int add_calls = 0;
+    int remove_calls = 0;
+    NvlinkTransportTestPeer::configureFabric(
+        transport, {},
+        [&](const TransferMetadata::BufferDesc&, bool) {
+            ++add_calls;
+            return 0;
+        },
+        [&](void*, bool) {
+            ++remove_calls;
+            return 0;
+        });
+
+    std::vector<char> cpu_buffer(4096);
+    ASSERT_EQ(NvlinkTransportTestPeer::registerLocalOnly(
+                  transport, cpu_buffer.data(), cpu_buffer.size()),
+              0);
+    EXPECT_EQ(NvlinkTransportTestPeer::registrationCount(transport), 1);
+    EXPECT_EQ(add_calls, 0);
+    EXPECT_EQ(remove_calls, 0);
+    EXPECT_EQ(NvlinkTransportTestPeer::registerLocalOnly(
+                  transport, cpu_buffer.data(), cpu_buffer.size()),
+              ERR_ADDRESS_OVERLAPPED);
+
+    EXPECT_EQ(NvlinkTransportTestPeer::unregister(transport, cpu_buffer.data()),
+              0);
+    EXPECT_EQ(NvlinkTransportTestPeer::registrationCount(transport), 0);
+    EXPECT_EQ(add_calls, 0);
+    EXPECT_EQ(remove_calls, 0);
+    EXPECT_EQ(NvlinkTransportTestPeer::unregister(transport, cpu_buffer.data()),
+              ERR_ADDRESS_NOT_REGISTERED);
+}
+
+TEST(NvlinkTransportUnitTest, LazyImportFailuresCleanUpAndRetry) {
+    const std::vector<FakeFabricDriver::Failure> failures = {
+        FakeFabricDriver::Failure::IMPORT,
+        FakeFabricDriver::Failure::RESERVE,
+        FakeFabricDriver::Failure::MAP,
+        FakeFabricDriver::Failure::ACCESS,
+        FakeFabricDriver::Failure::POST_MAP_RELEASE,
+    };
+
+    for (auto failure : failures) {
+        FakeFabricDriver driver;
+        {
+            NvlinkTransport transport;
+            NvlinkTransportTestPeer::configureFabric(
+                transport, driver.api(), {}, {},
+                [](uint64_t) { return fakeFabricSegment(); });
+            driver.failure = failure;
+
+            uint64_t address = FakeFabricDriver::kPublishedBase + 128;
+            EXPECT_NE(
+                NvlinkTransportTestPeer::relocate(transport, address, 256, 7),
+                0);
+            EXPECT_EQ(NvlinkTransportTestPeer::mappingCount(transport), 0);
+            driver.expectNoResources();
+
+            driver.failure = FakeFabricDriver::Failure::NONE;
+            address = FakeFabricDriver::kPublishedBase + 128;
+            ASSERT_EQ(
+                NvlinkTransportTestPeer::relocate(transport, address, 256, 7),
+                0);
+            EXPECT_EQ(address, FakeFabricDriver::kImportedBase + 128);
+            EXPECT_EQ(NvlinkTransportTestPeer::mappingCount(transport), 1);
+            EXPECT_EQ(driver.live_handles, 0);
+            EXPECT_EQ(driver.reserved_ranges, 1);
+            EXPECT_EQ(driver.mapped_ranges, 1);
+
+            const int imports_after_success = driver.import_calls;
+            address = FakeFabricDriver::kPublishedBase + 256;
+            ASSERT_EQ(
+                NvlinkTransportTestPeer::relocate(transport, address, 128, 7),
+                0);
+            EXPECT_EQ(address, FakeFabricDriver::kImportedBase + 256);
+            EXPECT_EQ(driver.import_calls, imports_after_success);
+        }
+        driver.expectNoResources();
+    }
+}
+
+TEST(NvlinkTransportUnitTest,
+     LazyImportCleanupIsStagedQuarantinedAndRetriedBeforeNewImport) {
+    enum class CleanupFailure { UNMAP, ADDRESS_FREE, RELEASE };
+    struct FailureCase {
+        const char* name;
+        CleanupFailure failure;
+        int expected_unmap_calls_after_first;
+        int expected_address_free_calls_after_first;
+        int expected_release_calls_after_first;
+        int expected_unmap_calls_after_retry;
+        int expected_address_free_calls_after_retry;
+        int expected_release_calls_after_retry;
+    };
+    const std::vector<FailureCase> cases = {
+        {"unmap", CleanupFailure::UNMAP, 1, 0, 0, 2, 0, 0},
+        {"address_free", CleanupFailure::ADDRESS_FREE, 1, 1, 0, 1, 2, 0},
+        {"release", CleanupFailure::RELEASE, 1, 1, 1, 1, 1, 2},
+    };
+
+    for (const auto& test_case : cases) {
+        SCOPED_TRACE(test_case.name);
+        FakeFabricDriver driver;
+        {
+            NvlinkTransport transport;
+            NvlinkTransportTestPeer::configureFabric(
+                transport, driver.api(), {}, {},
+                [](uint64_t) { return fakeFabricSegment(); });
+            driver.failure = FakeFabricDriver::Failure::ACCESS;
+            switch (test_case.failure) {
+                case CleanupFailure::UNMAP:
+                    driver.unmap_failures_remaining = 2;
+                    break;
+                case CleanupFailure::ADDRESS_FREE:
+                    driver.address_free_failures_remaining = 2;
+                    break;
+                case CleanupFailure::RELEASE:
+                    driver.imported_release_failures_remaining = 2;
+                    break;
+            }
+
+            uint64_t address = FakeFabricDriver::kPublishedBase + 128;
+            EXPECT_NE(
+                NvlinkTransportTestPeer::relocate(transport, address, 256, 7),
+                0);
+            EXPECT_EQ(NvlinkTransportTestPeer::mappingCount(transport), 0);
+            EXPECT_EQ(NvlinkTransportTestPeer::quarantinedFabricMappingCount(
+                          transport),
+                      1);
+            EXPECT_EQ(driver.import_calls, 1);
+            EXPECT_EQ(driver.unmap_calls,
+                      test_case.expected_unmap_calls_after_first);
+            EXPECT_EQ(driver.address_free_calls,
+                      test_case.expected_address_free_calls_after_first);
+            EXPECT_EQ(driver.imported_release_calls,
+                      test_case.expected_release_calls_after_first);
+
+            // A persistent earlier cleanup failure must stop at that stage and
+            // block a second import rather than accumulating more CUDA state.
+            address = FakeFabricDriver::kPublishedBase + 128;
+            EXPECT_NE(
+                NvlinkTransportTestPeer::relocate(transport, address, 256, 7),
+                0);
+            EXPECT_EQ(driver.import_calls, 1);
+            EXPECT_EQ(NvlinkTransportTestPeer::quarantinedFabricMappingCount(
+                          transport),
+                      1);
+            EXPECT_EQ(driver.unmap_calls,
+                      test_case.expected_unmap_calls_after_retry);
+            EXPECT_EQ(driver.address_free_calls,
+                      test_case.expected_address_free_calls_after_retry);
+            EXPECT_EQ(driver.imported_release_calls,
+                      test_case.expected_release_calls_after_retry);
+
+            driver.failure = FakeFabricDriver::Failure::NONE;
+            driver.unmap_failures_remaining = 0;
+            driver.address_free_failures_remaining = 0;
+            driver.imported_release_failures_remaining = 0;
+            address = FakeFabricDriver::kPublishedBase + 128;
+            ASSERT_EQ(
+                NvlinkTransportTestPeer::relocate(transport, address, 256, 7),
+                0);
+            EXPECT_EQ(address, FakeFabricDriver::kImportedBase + 128);
+            EXPECT_EQ(driver.import_calls, 2);
+            EXPECT_EQ(NvlinkTransportTestPeer::quarantinedFabricMappingCount(
+                          transport),
+                      0);
+            EXPECT_EQ(driver.live_handles, 0);
+            EXPECT_EQ(driver.reserved_ranges, 1);
+            EXPECT_EQ(driver.mapped_ranges, 1);
+        }
+        driver.expectNoResources();
+    }
+}
+
+TEST(NvlinkTransportUnitTest,
+     CachedFabricMappingTeardownRetriesWithoutFreeingMappedAddress) {
+    FakeFabricDriver driver;
+    {
+        NvlinkTransport transport;
+        NvlinkTransportTestPeer::configureFabric(
+            transport, driver.api(), {}, {},
+            [](uint64_t) { return fakeFabricSegment(); });
+
+        uint64_t address = FakeFabricDriver::kPublishedBase + 128;
+        ASSERT_EQ(NvlinkTransportTestPeer::relocate(transport, address, 256, 7),
+                  0);
+        ASSERT_EQ(NvlinkTransportTestPeer::mappingCount(transport), 1);
+        driver.unmap_failures_remaining = 1;
+    }
+
+    EXPECT_EQ(driver.unmap_calls, 2);
+    EXPECT_EQ(driver.address_free_calls, 1);
+    driver.expectNoResources();
+}
+
+TEST(NvlinkTransportUnitTest,
+     RegistrationMetadataFailureRollsBackDescriptorAndHandle) {
+    FakeFabricDriver driver;
+    int add_calls = 0;
+    int remove_calls = 0;
+    bool fail_metadata_write = true;
+    bool descriptor_present = false;
+    bool rollback_requested_metadata_update = false;
+    TransferMetadata::BufferDesc last_descriptor;
+    {
+        NvlinkTransport transport;
+        NvlinkTransportTestPeer::configureFabric(
+            transport, driver.api(),
+            [&](const TransferMetadata::BufferDesc& descriptor,
+                bool update_metadata) {
+                ++add_calls;
+                EXPECT_TRUE(update_metadata);
+                last_descriptor = descriptor;
+                descriptor_present = true;
+                return fail_metadata_write ? ERR_METADATA : 0;
+            },
+            [&](void* descriptor_addr, bool update_metadata) {
+                ++remove_calls;
+                EXPECT_EQ(
+                    descriptor_addr,
+                    reinterpret_cast<void*>(FakeFabricDriver::kPublishedBase));
+                descriptor_present = false;
+                rollback_requested_metadata_update = update_metadata;
+                return 0;
+            });
+
+        void* address =
+            reinterpret_cast<void*>(FakeFabricDriver::kPublishedBase + 4096);
+        EXPECT_EQ(
+            NvlinkTransportTestPeer::registerRemote(transport, address, 4096),
+            ERR_METADATA);
+        EXPECT_EQ(add_calls, 1);
+        EXPECT_EQ(remove_calls, 1);
+        EXPECT_EQ(last_descriptor.addr, FakeFabricDriver::kPublishedBase);
+        EXPECT_EQ(last_descriptor.length, FakeFabricDriver::kMappedLength);
+        EXPECT_FALSE(descriptor_present);
+        EXPECT_TRUE(rollback_requested_metadata_update);
+        EXPECT_EQ(NvlinkTransportTestPeer::registrationCount(transport), 0);
+        EXPECT_EQ(driver.release_calls, 1);
+        driver.expectNoResources();
+
+        fail_metadata_write = false;
+        ASSERT_EQ(
+            NvlinkTransportTestPeer::registerRemote(transport, address, 4096),
+            0);
+        EXPECT_EQ(NvlinkTransportTestPeer::registrationCount(transport), 1);
+        EXPECT_TRUE(descriptor_present);
+        EXPECT_EQ(driver.live_handles, 1);
+        EXPECT_EQ(NvlinkTransportTestPeer::unregister(transport, address), 0);
+        EXPECT_EQ(NvlinkTransportTestPeer::registrationCount(transport), 0);
+        EXPECT_EQ(remove_calls, 2);
+        EXPECT_FALSE(descriptor_present);
+        EXPECT_EQ(driver.release_calls, 2);
+        driver.expectNoResources();
+    }
+    driver.expectNoResources();
+}
+
+TEST(NvlinkTransportUnitTest,
+     RegistrationMetadataExceptionRetainsSingleHandleOwnerUntilUnregister) {
+    FakeFabricDriver driver;
+    bool descriptor_present = false;
+    bool throw_unregistration = true;
+    int remove_calls = 0;
+    {
+        NvlinkTransport transport;
+        NvlinkTransportTestPeer::configureFabric(
+            transport, driver.api(),
+            [&](const TransferMetadata::BufferDesc&, bool) -> int {
+                descriptor_present = true;
+                throw std::runtime_error("injected metadata publication");
+            },
+            [&](void*, bool) {
+                ++remove_calls;
+                if (throw_unregistration) {
+                    throw std::runtime_error(
+                        "injected metadata unregistration");
+                }
+                descriptor_present = false;
+                return 0;
+            });
+
+        void* address =
+            reinterpret_cast<void*>(FakeFabricDriver::kPublishedBase);
+        EXPECT_EQ(NvlinkTransportTestPeer::registerRemote(
+                      transport, address, FakeFabricDriver::kMappedLength),
+                  ERR_MEMORY);
+        EXPECT_EQ(remove_calls, 0)
+            << "unknown remote publication state must not release eagerly";
+        EXPECT_TRUE(descriptor_present);
+        EXPECT_EQ(NvlinkTransportTestPeer::registrationCount(transport), 1);
+        EXPECT_EQ(driver.release_calls, 0)
+            << "the retained record, not the guard, owns the live handle";
+        EXPECT_EQ(driver.live_handles, 1);
+
+        EXPECT_EQ(NvlinkTransportTestPeer::unregister(transport, address),
+                  ERR_MEMORY);
+        EXPECT_TRUE(descriptor_present);
+        EXPECT_EQ(NvlinkTransportTestPeer::registrationCount(transport), 1);
+        EXPECT_EQ(driver.release_calls, 0)
+            << "a throwing deletion must preserve the retained handle";
+
+        throw_unregistration = false;
+        ASSERT_EQ(NvlinkTransportTestPeer::unregister(transport, address), 0);
+        EXPECT_EQ(remove_calls, 2);
+        EXPECT_FALSE(descriptor_present);
+        EXPECT_EQ(NvlinkTransportTestPeer::registrationCount(transport), 0);
+        EXPECT_EQ(driver.release_calls, 1);
+        driver.expectNoResources();
+    }
+    EXPECT_EQ(driver.release_calls, 1);
+    driver.expectNoResources();
+}
+
+TEST(NvlinkTransportUnitTest,
+     RegistrationErrorCleanupQuarantinesFailedHandleReleaseAndRetries) {
+    struct FailureCase {
+        const char* name;
+        FakeFabricDriver::Failure driver_failure;
+        bool metadata_failure;
+        int expected_error;
+    };
+    const std::vector<FailureCase> cases = {
+        {"allocation_properties",
+         FakeFabricDriver::Failure::ALLOCATION_PROPERTIES, false, ERR_MEMORY},
+        {"address_range", FakeFabricDriver::Failure::ADDRESS_RANGE, false,
+         ERR_MEMORY},
+        {"export", FakeFabricDriver::Failure::EXPORT, false, ERR_MEMORY},
+        {"metadata", FakeFabricDriver::Failure::NONE, true, ERR_METADATA},
+    };
+
+    for (const auto& test_case : cases) {
+        SCOPED_TRACE(test_case.name);
+        FakeFabricDriver driver;
+        driver.failure = test_case.driver_failure;
+        driver.retained_release_failures_remaining = 1;
+        bool metadata_failure = test_case.metadata_failure;
+        bool descriptor_present = false;
+
+        NvlinkTransport transport;
+        NvlinkTransportTestPeer::configureFabric(
+            transport, driver.api(),
+            [&](const TransferMetadata::BufferDesc&, bool) {
+                descriptor_present = true;
+                return metadata_failure ? ERR_METADATA : 0;
+            },
+            [&](void*, bool) {
+                descriptor_present = false;
+                return 0;
+            });
+
+        void* address =
+            reinterpret_cast<void*>(FakeFabricDriver::kPublishedBase);
+        EXPECT_EQ(NvlinkTransportTestPeer::registerRemote(
+                      transport, address, FakeFabricDriver::kMappedLength),
+                  test_case.expected_error);
+        EXPECT_EQ(NvlinkTransportTestPeer::registrationCount(transport), 0);
+        EXPECT_EQ(
+            NvlinkTransportTestPeer::quarantinedRetainedHandleCount(transport),
+            1);
+        EXPECT_FALSE(descriptor_present);
+        EXPECT_EQ(driver.live_handles, 1)
+            << "failed cuMemRelease must retain handle ownership";
+
+        driver.failure = FakeFabricDriver::Failure::NONE;
+        metadata_failure = false;
+        ASSERT_EQ(NvlinkTransportTestPeer::registerRemote(
+                      transport, address, FakeFabricDriver::kMappedLength),
+                  0);
+        EXPECT_EQ(
+            NvlinkTransportTestPeer::quarantinedRetainedHandleCount(transport),
+            0);
+        EXPECT_TRUE(descriptor_present);
+        EXPECT_EQ(driver.live_handles, 1);
+
+        ASSERT_EQ(NvlinkTransportTestPeer::unregister(transport, address), 0);
+        EXPECT_FALSE(descriptor_present);
+        EXPECT_EQ(driver.release_calls, 3);
+        driver.expectNoResources();
+    }
+}
+
+TEST(NvlinkTransportUnitTest,
+     RegistrationMetadataRollbackFailureRetainsStateForCallerRetry) {
+    FakeFabricDriver driver;
+    bool descriptor_present = false;
+    int remove_calls = 0;
+
+    NvlinkTransport transport;
+    NvlinkTransportTestPeer::configureFabric(
+        transport, driver.api(),
+        [&](const TransferMetadata::BufferDesc&, bool) {
+            descriptor_present = true;
+            return ERR_METADATA;
+        },
+        [&](void*, bool) {
+            ++remove_calls;
+            if (remove_calls == 1) return ERR_METADATA;
+            descriptor_present = false;
+            return 0;
+        });
+
+    void* address = reinterpret_cast<void*>(FakeFabricDriver::kPublishedBase);
+    EXPECT_EQ(NvlinkTransportTestPeer::registerRemote(
+                  transport, address, FakeFabricDriver::kMappedLength),
+              ERR_METADATA);
+    EXPECT_EQ(NvlinkTransportTestPeer::registrationCount(transport), 1);
+    EXPECT_EQ(
+        NvlinkTransportTestPeer::quarantinedRetainedHandleCount(transport), 0);
+    EXPECT_TRUE(descriptor_present);
+    EXPECT_EQ(driver.live_handles, 1);
+    EXPECT_EQ(driver.release_calls, 0);
+
+    ASSERT_EQ(NvlinkTransportTestPeer::unregister(transport, address), 0);
+    EXPECT_EQ(remove_calls, 2);
+    EXPECT_EQ(NvlinkTransportTestPeer::registrationCount(transport), 0);
+    EXPECT_FALSE(descriptor_present);
+    EXPECT_EQ(driver.release_calls, 1);
+    driver.expectNoResources();
+}
+
+TEST(NvlinkTransportUnitTest,
+     IpcMetadataRollbackFailureRetainsStateForCallerRetry) {
+    bool descriptor_present = false;
+    int remove_calls = 0;
+    void* address = reinterpret_cast<void*>(0xabc000);
+
+    NvlinkTransport transport;
+    EXPECT_EQ(NvlinkTransportTestPeer::publishIpcDescriptorForTesting(
+                  transport, address,
+                  [&](const TransferMetadata::BufferDesc&, bool) {
+                      descriptor_present = true;
+                      return ERR_METADATA;
+                  },
+                  [&](void*, bool) {
+                      ++remove_calls;
+                      if (remove_calls == 1) return ERR_METADATA;
+                      descriptor_present = false;
+                      return 0;
+                  }),
+              ERR_METADATA);
+    EXPECT_EQ(NvlinkTransportTestPeer::registrationCount(transport), 1);
+    EXPECT_TRUE(descriptor_present);
+
+    ASSERT_EQ(NvlinkTransportTestPeer::unregister(transport, address), 0);
+    EXPECT_EQ(remove_calls, 2);
+    EXPECT_EQ(NvlinkTransportTestPeer::registrationCount(transport), 0);
+    EXPECT_FALSE(descriptor_present);
+}
+
+TEST(NvlinkTransportUnitTest,
+     DestructorPersistentReleaseFailureKeepsHandleLiveForProcessLifetime) {
+    FakeFabricDriver driver;
+    driver.retained_release_failures_remaining = 2;
+    {
+        NvlinkTransport transport;
+        NvlinkTransportTestPeer::configureFabric(
+            transport, driver.api(),
+            [](const TransferMetadata::BufferDesc&, bool) { return 0; },
+            [](void*, bool) { return 0; });
+        void* address =
+            reinterpret_cast<void*>(FakeFabricDriver::kPublishedBase);
+        ASSERT_EQ(NvlinkTransportTestPeer::registerRemote(
+                      transport, address, FakeFabricDriver::kMappedLength),
+                  0);
+        EXPECT_EQ(driver.live_handles, 1);
+    }
+    EXPECT_EQ(driver.release_calls, 2);
+    EXPECT_EQ(driver.live_handles, 1)
+        << "persistent teardown failure must leave the CUDA handle live and "
+           "owned by the process-lifetime quarantine";
+}
+
+TEST(NvlinkTransportUnitTest, OwnedHostNumaRegistrationSkipsAddressRangeQuery) {
+    FakeFabricDriver driver;
+    driver.failure = FakeFabricDriver::Failure::ADDRESS_RANGE;
+    driver.allocation_location_type = CU_MEM_LOCATION_TYPE_HOST_NUMA;
+    int add_calls = 0;
+    TransferMetadata::BufferDesc published;
+    auto owner = NvlinkTransportTestPeer::makeOwnedHostNumaRange(
+        reinterpret_cast<void*>(FakeFabricDriver::kPublishedBase),
+        FakeFabricDriver::kMappedLength);
+    ASSERT_NE(owner, nullptr);
+
+    NvlinkTransport transport;
+    NvlinkTransportTestPeer::configureFabric(
+        transport, driver.api(),
+        [&](const TransferMetadata::BufferDesc& descriptor, bool) {
+            ++add_calls;
+            published = descriptor;
+            return 0;
+        },
+        [](void*, bool) { return 0; });
+
+    void* address = reinterpret_cast<void*>(FakeFabricDriver::kPublishedBase);
+    ASSERT_EQ(NvlinkTransportTestPeer::registerRemote(
+                  transport, address, FakeFabricDriver::kMappedLength),
+              0);
+    EXPECT_EQ(add_calls, 1);
+    EXPECT_EQ(published.addr, FakeFabricDriver::kPublishedBase);
+    EXPECT_EQ(published.length, FakeFabricDriver::kMappedLength);
+    EXPECT_EQ(driver.address_range_calls, 0);
+    EXPECT_EQ(driver.live_handles, 1);
+
+    ASSERT_EQ(NvlinkTransportTestPeer::unregister(transport, address), 0);
+    driver.expectNoResources();
+}
+
+TEST(NvlinkTransportUnitTest,
+     OwnedHostNumaRegistrationRejectsInteriorSubrange) {
+    FakeFabricDriver driver;
+    driver.allocation_location_type = CU_MEM_LOCATION_TYPE_HOST_NUMA;
+    int add_calls = 0;
+    auto owner = NvlinkTransportTestPeer::makeOwnedHostNumaRange(
+        reinterpret_cast<void*>(FakeFabricDriver::kPublishedBase),
+        FakeFabricDriver::kMappedLength);
+    ASSERT_NE(owner, nullptr);
+
+    NvlinkTransport transport;
+    NvlinkTransportTestPeer::configureFabric(
+        transport, driver.api(),
+        [&](const TransferMetadata::BufferDesc&, bool) {
+            ++add_calls;
+            return 0;
+        });
+
+    constexpr size_t kInteriorOffset = 4096;
+    void* interior = reinterpret_cast<void*>(FakeFabricDriver::kPublishedBase +
+                                             kInteriorOffset);
+    EXPECT_EQ(NvlinkTransportTestPeer::registerRemote(
+                  transport, interior,
+                  FakeFabricDriver::kMappedLength - kInteriorOffset),
+              ERR_INVALID_ARGUMENT);
+    EXPECT_EQ(add_calls, 0);
+    EXPECT_EQ(NvlinkTransportTestPeer::registrationCount(transport), 0);
+    EXPECT_EQ(driver.address_range_calls, 1);
+    EXPECT_EQ(driver.release_calls, 1);
+    driver.expectNoResources();
+}
+
+TEST(NvlinkTransportUnitTest,
+     ExternalHostNumaRegistrationRejectsAddressRangeQueryFailure) {
+    FakeFabricDriver driver;
+    driver.failure = FakeFabricDriver::Failure::ADDRESS_RANGE;
+    driver.allocation_location_type = CU_MEM_LOCATION_TYPE_HOST_NUMA;
+    int add_calls = 0;
+
+    NvlinkTransport transport;
+    NvlinkTransportTestPeer::configureFabric(
+        transport, driver.api(),
+        [&](const TransferMetadata::BufferDesc&, bool) {
+            ++add_calls;
+            return 0;
+        });
+
+    void* address = reinterpret_cast<void*>(FakeFabricDriver::kPublishedBase);
+    EXPECT_EQ(NvlinkTransportTestPeer::registerRemote(
+                  transport, address, FakeFabricDriver::kMappedLength),
+              ERR_MEMORY);
+    EXPECT_EQ(add_calls, 0);
+    EXPECT_EQ(NvlinkTransportTestPeer::registrationCount(transport), 0);
+    EXPECT_EQ(driver.address_range_calls, 1);
+    EXPECT_EQ(driver.release_calls, 1);
+    driver.expectNoResources();
+}
+
+TEST(NvlinkTransportUnitTest,
+     ExternalHostNumaRegistrationUsesSuccessfulAddressRangeQuery) {
+    FakeFabricDriver driver;
+    driver.allocation_location_type = CU_MEM_LOCATION_TYPE_HOST_NUMA;
+    int add_calls = 0;
+    TransferMetadata::BufferDesc published;
+
+    NvlinkTransport transport;
+    NvlinkTransportTestPeer::configureFabric(
+        transport, driver.api(),
+        [&](const TransferMetadata::BufferDesc& descriptor, bool) {
+            ++add_calls;
+            published = descriptor;
+            return 0;
+        },
+        [](void*, bool) { return 0; });
+
+    void* address = reinterpret_cast<void*>(FakeFabricDriver::kPublishedBase);
+    ASSERT_EQ(NvlinkTransportTestPeer::registerRemote(
+                  transport, address, FakeFabricDriver::kMappedLength),
+              0);
+    EXPECT_EQ(add_calls, 1);
+    EXPECT_EQ(driver.address_range_calls, 1);
+    EXPECT_EQ(published.addr, FakeFabricDriver::kPublishedBase);
+    EXPECT_EQ(published.length, FakeFabricDriver::kMappedLength);
+    EXPECT_EQ(driver.live_handles, 1);
+
+    ASSERT_EQ(NvlinkTransportTestPeer::unregister(transport, address), 0);
+    driver.expectNoResources();
+}
+
+TEST(NvlinkTransportUnitTest,
+     RegistrationPropertyQueryFailureReleasesRetainedHandle) {
+    FakeFabricDriver driver;
+    driver.failure = FakeFabricDriver::Failure::ALLOCATION_PROPERTIES;
+    int add_calls = 0;
+
+    NvlinkTransport transport;
+    NvlinkTransportTestPeer::configureFabric(
+        transport, driver.api(),
+        [&](const TransferMetadata::BufferDesc&, bool) {
+            ++add_calls;
+            return 0;
+        });
+
+    void* address = reinterpret_cast<void*>(FakeFabricDriver::kPublishedBase);
+    EXPECT_EQ(NvlinkTransportTestPeer::registerRemote(
+                  transport, address, FakeFabricDriver::kMappedLength),
+              ERR_MEMORY);
+    EXPECT_EQ(add_calls, 0);
+    EXPECT_EQ(NvlinkTransportTestPeer::registrationCount(transport), 0);
+    EXPECT_EQ(driver.release_calls, 1);
+    driver.expectNoResources();
+}
+
+TEST(NvlinkTransportUnitTest,
+     DeviceRegistrationStillRejectsAddressRangeQueryFailure) {
+    FakeFabricDriver driver;
+    driver.failure = FakeFabricDriver::Failure::ADDRESS_RANGE;
+    driver.allocation_location_type = CU_MEM_LOCATION_TYPE_DEVICE;
+    int add_calls = 0;
+
+    NvlinkTransport transport;
+    NvlinkTransportTestPeer::configureFabric(
+        transport, driver.api(),
+        [&](const TransferMetadata::BufferDesc&, bool) {
+            ++add_calls;
+            return 0;
+        });
+
+    void* address = reinterpret_cast<void*>(FakeFabricDriver::kPublishedBase);
+    EXPECT_EQ(NvlinkTransportTestPeer::registerRemote(
+                  transport, address, FakeFabricDriver::kMappedLength),
+              ERR_MEMORY);
+    EXPECT_EQ(add_calls, 0);
+    EXPECT_EQ(NvlinkTransportTestPeer::registrationCount(transport), 0);
+    EXPECT_EQ(driver.address_range_calls, 1);
+    EXPECT_EQ(driver.release_calls, 1);
+    driver.expectNoResources();
+}
+#endif
+
 TEST(NvlinkTransportTest, WriteAndRead) {
+    bool strict_fabric = false;
+    std::string strict_error;
+    ASSERT_TRUE(ParseStrictFabricRequirement(strict_fabric, strict_error))
+        << strict_error;
+
     const size_t kDataLength = 4096000;
     int gpu_id = FLAGS_gpu_id;
+#ifdef USE_CUDA
+    if (std::getenv("MC_USE_NVLINK_IPC") == nullptr) {
+        Status capability = NvlinkVmmAllocation::CheckStrictFabricCapability();
+        if (!capability.ok()) {
+            if (strict_fabric) {
+                FAIL() << "Fabric DEVICE VMM is unavailable in strict mode: "
+                       << capability.ToString();
+            } else {
+                GTEST_SKIP() << "Fabric DEVICE VMM is unavailable: "
+                             << capability.ToString();
+            }
+        }
+    }
+#endif
 
     // Server (target) setup
     auto server_engine = std::make_unique<TransferEngine>(false);
-    server_engine->init(FLAGS_metadata_server, FLAGS_local_server_name);
+    ASSERT_EQ(server_engine->init(P2PHANDSHAKE, "127.0.0.1:0", "127.0.0.1", 0),
+              0);
 
     // Install MNNVL transport (nvlink or hip) on server
     Transport* server_transport =
         server_engine->installTransport(MNNVL_PROTOCOL, nullptr);
     ASSERT_NE(server_transport, nullptr);
 
-    void* server_buffer = allocateCudaBuffer(kDataLength * 2, gpu_id);
-    int rc = server_engine->registerLocalMemory(server_buffer, kDataLength * 2,
-                                                "cuda:0");
-    ASSERT_EQ(rc, 0);
+    auto server_metadata = server_engine->getMetadata();
+    auto local_desc =
+        server_metadata->getSegmentDescByID(LOCAL_SEGMENT_ID, false);
+    ASSERT_NE(local_desc, nullptr);
+    const size_t initial_buffer_count = local_desc->buffers.size();
+    int rc = 0;
 
-    auto segment_id = server_engine->openSegment(FLAGS_segment_id);
+#ifdef USE_CUDA
+    // A local-only legacy CPU workspace is tracked by NVLink but never
+    // published to peer metadata.
+    std::vector<char> local_workspace(4096);
+    rc = server_engine->registerLocalMemory(
+        local_workspace.data(), local_workspace.size(), "cpu:0", false);
+    ASSERT_EQ(rc, 0);
+    local_desc = server_metadata->getSegmentDescByID(LOCAL_SEGMENT_ID, false);
+    ASSERT_EQ(local_desc->buffers.size(), initial_buffer_count);
+    ASSERT_EQ(server_engine->unregisterLocalMemory(local_workspace.data()), 0);
+#endif
+
+    void* server_buffer = allocatePublishedBuffer(kDataLength * 2, gpu_id);
+    ASSERT_NE(server_buffer, nullptr);
+    rc = server_engine->registerLocalMemory(server_buffer, kDataLength * 2,
+                                            "cuda:0");
+    ASSERT_EQ(rc, 0);
+    local_desc = server_metadata->getSegmentDescByID(LOCAL_SEGMENT_ID, false);
+    ASSERT_EQ(local_desc->buffers.size(), initial_buffer_count + 1);
+    const auto published_buffer = local_desc->buffers.back();
 
     // Client (initiator) setup
     auto client_engine = std::make_unique<TransferEngine>(false);
-    client_engine->init(FLAGS_metadata_server, "cuda_client:12346");
+    ASSERT_EQ(client_engine->init(P2PHANDSHAKE, "127.0.0.1:0", "127.0.0.1", 0),
+              0);
 
     // Install MNNVL transport (nvlink or hip) on client
     Transport* client_transport =
@@ -74,8 +1166,59 @@ TEST(NvlinkTransportTest, WriteAndRead) {
 
     void* client_buffer = allocateCudaBuffer(kDataLength * 2, gpu_id);
     rc = client_engine->registerLocalMemory(client_buffer, kDataLength * 2,
-                                            "cuda:" + std::to_string(gpu_id));
+                                            "cuda:" + std::to_string(gpu_id),
+#ifdef USE_CUDA
+                                            false);
+#else
+                                            true);
+#endif
     ASSERT_EQ(rc, 0);
+
+    const std::string server_endpoint = server_engine->getLocalIpAndPort();
+    auto segment_id = client_engine->openSegment(server_endpoint);
+    ASSERT_NE(segment_id, static_cast<SegmentID>(-1));
+
+#ifdef USE_CUDA
+    // A relocation failure is terminal at task level even though no Slice was
+    // allocated, so status polling and freeBatchID cannot hang or report a
+    // false zero-slice success.
+    {
+        auto batch_id = client_engine->allocateBatchID(1);
+        TransferRequest invalid;
+        invalid.opcode = TransferRequest::WRITE;
+        invalid.length = 64;
+        invalid.source = client_buffer;
+        invalid.target_id = segment_id;
+        invalid.target_offset = published_buffer.addr + published_buffer.length;
+        Status submit_status =
+            client_engine->submitTransfer(batch_id, {invalid});
+        ASSERT_FALSE(submit_status.ok());
+        TransferStatus failed_status;
+        ASSERT_TRUE(
+            client_engine->getTransferStatus(batch_id, 0, failed_status).ok());
+        EXPECT_EQ(failed_status.s, TransferStatusEnum::FAILED);
+        EXPECT_TRUE(client_engine->freeBatchID(batch_id).ok());
+    }
+
+    {
+        auto batch_id = client_transport->allocateBatchID(1);
+        TransferRequest invalid;
+        invalid.opcode = TransferRequest::WRITE;
+        invalid.length = 64;
+        invalid.source = client_buffer;
+        invalid.target_id = segment_id;
+        invalid.target_offset = published_buffer.addr + published_buffer.length;
+        Status submit_status =
+            client_transport->submitTransfer(batch_id, {invalid});
+        ASSERT_FALSE(submit_status.ok());
+        TransferStatus failed_status;
+        ASSERT_TRUE(
+            client_transport->getTransferStatus(batch_id, 0, failed_status)
+                .ok());
+        EXPECT_EQ(failed_status.s, TransferStatusEnum::FAILED);
+        EXPECT_TRUE(client_transport->freeBatchID(batch_id).ok());
+    }
+#endif
 
     // Write: client -> server
     {
@@ -145,7 +1288,9 @@ TEST(NvlinkTransportTest, WriteAndRead) {
     client_engine->unregisterLocalMemory(client_buffer);
     freeCudaBuffer(client_buffer);
     server_engine->unregisterLocalMemory(server_buffer);
-    freeCudaBuffer(server_buffer);
+    local_desc = server_metadata->getSegmentDescByID(LOCAL_SEGMENT_ID, false);
+    EXPECT_EQ(local_desc->buffers.size(), initial_buffer_count);
+    freePublishedBuffer(server_buffer);
 }
 
 int main(int argc, char** argv) {

--- a/mooncake-transfer-engine/tests/nvlink_vmm_allocation_test.cpp
+++ b/mooncake-transfer-engine/tests/nvlink_vmm_allocation_test.cpp
@@ -1,0 +1,722 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "transport/nvlink_transport/nvlink_transport.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace mooncake {
+
+class NvlinkTransportTestPeer {
+   public:
+    using DriverApi = NvlinkVmmAllocation::DriverApi;
+
+    static Status CreateWithDriverApi(
+        const NvlinkVmmAllocation::Options& options, const DriverApi& api,
+        std::unique_ptr<NvlinkVmmAllocation>& allocation) {
+        return NvlinkVmmAllocation::CreateWithDriverApi(options, api,
+                                                        allocation);
+    }
+
+    static Status CheckStrictFabricCapabilityWithDriverApi(
+        const DriverApi& api) {
+        return NvlinkVmmAllocation::CheckStrictFabricCapabilityWithDriverApi(
+            api);
+    }
+
+    static bool IsExactOwnedRange(void* base, size_t length) {
+        return NvlinkVmmAllocation::IsExactOwnedRange(base, length);
+    }
+
+    static bool RegisterOwnedRange(void* base, size_t length) {
+        return NvlinkVmmAllocation::RegisterOwnedRange(base, length);
+    }
+
+    static bool UnregisterOwnedRange(void* base, size_t length) {
+        return NvlinkVmmAllocation::UnregisterOwnedRange(base, length);
+    }
+
+    static bool TrackPinnedVmmAllocation(
+        std::unique_ptr<NvlinkVmmAllocation> allocation) {
+        return NvlinkTransport::TrackPinnedVmmAllocation(std::move(allocation));
+    }
+
+    static bool RetryCleanupPendingOwners() {
+        return NvlinkVmmAllocation::RetryCleanupPendingOwners();
+    }
+
+    static size_t CleanupPendingOwnerCount() {
+        return NvlinkVmmAllocation::CleanupPendingOwnerCount();
+    }
+};
+
+namespace {
+
+class FakeCudaDriver {
+   public:
+    enum class Failure {
+        NONE,
+        GRANULARITY,
+        CREATE,
+        RESERVE,
+        MAP,
+    };
+
+    NvlinkTransportTestPeer::DriverApi api() {
+        NvlinkTransportTestPeer::DriverApi result;
+        result.device_get_count = [this](int* count) {
+            *count = device_count;
+            return CUDA_SUCCESS;
+        };
+        result.device_get = [](CUdevice* device, int ordinal) {
+            *device = ordinal;
+            return CUDA_SUCCESS;
+        };
+        result.device_get_attribute = [this](int* value,
+                                             CUdevice_attribute attribute,
+                                             CUdevice device) {
+            if (attribute == CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED) {
+                *value = device == unsupported_fabric_device ? 0 : 1;
+            } else if (
+                attribute ==
+                CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_WITH_CUDA_VMM_SUPPORTED) {
+                *value = 1;
+            } else {
+                *value = 0;
+            }
+            return CUDA_SUCCESS;
+        };
+        result.mem_get_allocation_granularity =
+            [this](size_t* value, const CUmemAllocationProp* prop,
+                   CUmemAllocationGranularity_flags) {
+                operations.push_back("granularity");
+                last_prop = *prop;
+                if (failure == Failure::GRANULARITY)
+                    return CUDA_ERROR_INVALID_VALUE;
+                *value = granularity;
+                return CUDA_SUCCESS;
+            };
+        result.mem_create = [this](CUmemGenericAllocationHandle* handle,
+                                   size_t size, const CUmemAllocationProp* prop,
+                                   unsigned long long) {
+            operations.push_back("create");
+            last_prop = *prop;
+            created_size = size;
+            if (failure == Failure::CREATE) return CUDA_ERROR_INVALID_VALUE;
+            *handle = next_handle++;
+            ++owned_handles;
+            return CUDA_SUCCESS;
+        };
+        result.mem_address_reserve = [this](CUdeviceptr* ptr, size_t size,
+                                            size_t alignment, CUdeviceptr,
+                                            unsigned long long) {
+            operations.push_back("reserve");
+            reserved_size = size;
+            reserved_alignment = alignment;
+            if (failure == Failure::RESERVE) return CUDA_ERROR_INVALID_VALUE;
+            *ptr = next_address;
+            ++reserved_ranges;
+            return CUDA_SUCCESS;
+        };
+        result.mem_map = [this](CUdeviceptr, size_t, size_t,
+                                CUmemGenericAllocationHandle,
+                                unsigned long long) {
+            operations.push_back("map");
+            if (failure == Failure::MAP) return CUDA_ERROR_INVALID_VALUE;
+            ++mapped_ranges;
+            return CUDA_SUCCESS;
+        };
+        result.mem_set_access = [this](CUdeviceptr, size_t,
+                                       const CUmemAccessDesc* desc,
+                                       size_t count) {
+            operations.push_back("access");
+            const int call = access_call_count++;
+            for (size_t i = 0; i < count; ++i)
+                access_descriptors.push_back(desc[i]);
+            if (call == fail_access_call) return CUDA_ERROR_INVALID_VALUE;
+            return CUDA_SUCCESS;
+        };
+        result.mem_unmap = [this](CUdeviceptr, size_t) {
+            operations.push_back("unmap");
+            ++unmap_calls;
+            if (unmap_failures_remaining > 0) {
+                --unmap_failures_remaining;
+                return CUDA_ERROR_INVALID_VALUE;
+            }
+            if (mapped_ranges > 0) --mapped_ranges;
+            return CUDA_SUCCESS;
+        };
+        result.mem_address_free = [this](CUdeviceptr, size_t) {
+            operations.push_back("address_free");
+            ++address_free_calls;
+            if (address_free_failures_remaining > 0) {
+                --address_free_failures_remaining;
+                return CUDA_ERROR_INVALID_VALUE;
+            }
+            if (reserved_ranges > 0) --reserved_ranges;
+            return CUDA_SUCCESS;
+        };
+        result.mem_release = [this](CUmemGenericAllocationHandle) {
+            operations.push_back("release");
+            ++release_calls;
+            if (release_failures_remaining > 0) {
+                --release_failures_remaining;
+                return CUDA_ERROR_INVALID_VALUE;
+            }
+            if (owned_handles > 0) --owned_handles;
+            return CUDA_SUCCESS;
+        };
+        result.mem_retain_allocation_handle = [](CUmemGenericAllocationHandle*,
+                                                 void*) {
+            return CUDA_ERROR_NOT_SUPPORTED;
+        };
+        result.mem_get_address_range = [](CUdeviceptr*, size_t*, CUdeviceptr) {
+            return CUDA_ERROR_NOT_SUPPORTED;
+        };
+        return result;
+    }
+
+    void expectNoResources() const {
+        EXPECT_EQ(owned_handles, 0);
+        EXPECT_EQ(reserved_ranges, 0);
+        EXPECT_EQ(mapped_ranges, 0);
+    }
+
+    Failure failure = Failure::NONE;
+    size_t granularity = 64 * 1024;
+    int device_count = 2;
+    int unsupported_fabric_device = -1;
+    int fail_access_call = -1;
+    int unmap_failures_remaining = 0;
+    int address_free_failures_remaining = 0;
+    int release_failures_remaining = 0;
+
+    int owned_handles = 0;
+    int reserved_ranges = 0;
+    int mapped_ranges = 0;
+    int access_call_count = 0;
+    int unmap_calls = 0;
+    int address_free_calls = 0;
+    int release_calls = 0;
+    size_t created_size = 0;
+    size_t reserved_size = 0;
+    size_t reserved_alignment = 0;
+    CUmemAllocationProp last_prop = {};
+    std::vector<CUmemAccessDesc> access_descriptors;
+    std::vector<std::string> operations;
+
+   private:
+    CUmemGenericAllocationHandle next_handle = 1;
+    CUdeviceptr next_address = static_cast<CUdeviceptr>(0x100000000ULL);
+};
+
+class ScopedIpcEnvironment {
+   public:
+    ScopedIpcEnvironment() {
+        const char* value = std::getenv("MC_USE_NVLINK_IPC");
+        if (value != nullptr) {
+            was_set_ = true;
+            value_ = value;
+        }
+        unsetenv("MC_USE_NVLINK_IPC");
+    }
+
+    ~ScopedIpcEnvironment() {
+        if (was_set_)
+            setenv("MC_USE_NVLINK_IPC", value_.c_str(), 1);
+        else
+            unsetenv("MC_USE_NVLINK_IPC");
+    }
+
+   private:
+    bool was_set_ = false;
+    std::string value_;
+};
+
+TEST(NvlinkVmmAllocationTest, DeviceExportableHonorsRequiredVaAlignment) {
+    ScopedIpcEnvironment environment;
+    FakeCudaDriver driver;
+    NvlinkVmmAllocation::Options options;
+    options.location_type = NvlinkVmmAllocation::LocationType::DEVICE;
+    options.location_id = 1;
+    options.requested_length = 100000;
+    options.fabric_exportable = true;
+    options.required_va_alignment = 256 * 1024;
+
+    std::unique_ptr<NvlinkVmmAllocation> allocation;
+    ASSERT_TRUE(NvlinkTransportTestPeer::CreateWithDriverApi(
+                    options, driver.api(), allocation)
+                    .ok());
+    ASSERT_NE(allocation, nullptr);
+    EXPECT_EQ(allocation->base(), reinterpret_cast<void*>(0x100000000ULL));
+    EXPECT_EQ(allocation->length(), 256 * 1024);
+    EXPECT_EQ(allocation->granularity(), 64 * 1024);
+    EXPECT_EQ(allocation->va_alignment(), 256 * 1024);
+    EXPECT_EQ(allocation->location_type(),
+              NvlinkVmmAllocation::LocationType::DEVICE);
+    EXPECT_EQ(allocation->location_id(), 1);
+    EXPECT_TRUE(allocation->fabric_exportable());
+    EXPECT_EQ(driver.last_prop.location.type, CU_MEM_LOCATION_TYPE_DEVICE);
+    EXPECT_EQ(driver.last_prop.location.id, 1);
+    EXPECT_EQ(driver.last_prop.requestedHandleTypes, CU_MEM_HANDLE_TYPE_FABRIC);
+    EXPECT_EQ(driver.created_size, 256 * 1024);
+    EXPECT_EQ(driver.reserved_alignment, 256 * 1024);
+    ASSERT_EQ(driver.access_descriptors.size(), 2);
+    EXPECT_EQ(driver.access_descriptors[0].location.type,
+              CU_MEM_LOCATION_TYPE_DEVICE);
+    EXPECT_EQ(driver.access_descriptors[1].location.type,
+              CU_MEM_LOCATION_TYPE_DEVICE);
+    EXPECT_EQ(driver.release_calls, 1);
+    EXPECT_EQ(driver.owned_handles, 0);
+    EXPECT_EQ(driver.reserved_ranges, 1);
+    EXPECT_EQ(driver.mapped_ranges, 1);
+
+    {
+        NvlinkVmmAllocation moved(std::move(*allocation));
+        allocation.reset();
+        EXPECT_EQ(moved.base(), reinterpret_cast<void*>(0x100000000ULL));
+        EXPECT_EQ(driver.reserved_ranges, 1);
+        EXPECT_EQ(driver.mapped_ranges, 1);
+    }
+    driver.expectNoResources();
+    EXPECT_EQ(driver.unmap_calls, 1);
+    EXPECT_EQ(driver.address_free_calls, 1);
+}
+
+TEST(NvlinkVmmAllocationTest, HostNumaLocalOnlyGrantsCpuAndAllGpuAccess) {
+    ScopedIpcEnvironment environment;
+    FakeCudaDriver driver;
+    NvlinkVmmAllocation::Options options;
+    options.location_type = NvlinkVmmAllocation::LocationType::HOST_NUMA;
+    options.location_id = 3;
+    options.requested_length = 64 * 1024;
+    options.fabric_exportable = false;
+    int access_observations = 0;
+    bool access_success = false;
+    options.access_observer = [&](uint64_t, bool success) {
+        ++access_observations;
+        access_success = success;
+    };
+
+    std::unique_ptr<NvlinkVmmAllocation> allocation;
+    ASSERT_TRUE(NvlinkTransportTestPeer::CreateWithDriverApi(
+                    options, driver.api(), allocation)
+                    .ok());
+    EXPECT_EQ(driver.last_prop.location.type, CU_MEM_LOCATION_TYPE_HOST_NUMA);
+    EXPECT_EQ(driver.last_prop.location.id, 3);
+    EXPECT_EQ(driver.last_prop.requestedHandleTypes,
+              static_cast<CUmemAllocationHandleType>(0));
+    ASSERT_EQ(driver.access_descriptors.size(), 3);
+    EXPECT_EQ(driver.access_descriptors[0].location.type,
+              CU_MEM_LOCATION_TYPE_HOST_NUMA);
+    EXPECT_EQ(driver.access_descriptors[0].location.id, 3);
+    EXPECT_EQ(driver.access_descriptors[1].location.type,
+              CU_MEM_LOCATION_TYPE_DEVICE);
+    EXPECT_EQ(driver.access_descriptors[1].location.id, 0);
+    EXPECT_EQ(driver.access_descriptors[2].location.type,
+              CU_MEM_LOCATION_TYPE_DEVICE);
+    EXPECT_EQ(driver.access_descriptors[2].location.id, 1);
+    EXPECT_EQ(access_observations, 1);
+    EXPECT_TRUE(access_success);
+
+    allocation.reset();
+    driver.expectNoResources();
+    EXPECT_EQ(driver.unmap_calls, 1);
+    EXPECT_EQ(driver.address_free_calls, 1);
+}
+
+TEST(NvlinkVmmAllocationTest, CleansEveryCreateFailureStage) {
+    ScopedIpcEnvironment environment;
+    const std::vector<FakeCudaDriver::Failure> failures = {
+        FakeCudaDriver::Failure::GRANULARITY,
+        FakeCudaDriver::Failure::CREATE,
+        FakeCudaDriver::Failure::RESERVE,
+        FakeCudaDriver::Failure::MAP,
+    };
+
+    for (FakeCudaDriver::Failure failure : failures) {
+        FakeCudaDriver driver;
+        driver.failure = failure;
+        NvlinkVmmAllocation::Options options;
+        options.location_type = NvlinkVmmAllocation::LocationType::HOST_NUMA;
+        options.location_id = 0;
+        options.requested_length = 64 * 1024;
+        options.fabric_exportable = false;
+
+        std::unique_ptr<NvlinkVmmAllocation> allocation;
+        EXPECT_FALSE(NvlinkTransportTestPeer::CreateWithDriverApi(
+                         options, driver.api(), allocation)
+                         .ok());
+        EXPECT_EQ(allocation, nullptr);
+        driver.expectNoResources();
+
+        if (failure == FakeCudaDriver::Failure::RESERVE) {
+            EXPECT_EQ(driver.operations,
+                      (std::vector<std::string>{"granularity", "create",
+                                                "reserve", "release"}));
+        } else if (failure == FakeCudaDriver::Failure::MAP) {
+            EXPECT_EQ(
+                driver.operations,
+                (std::vector<std::string>{"granularity", "create", "reserve",
+                                          "map", "address_free", "release"}));
+        }
+    }
+}
+
+TEST(NvlinkVmmAllocationTest, CleansEveryAccessDescriptorFailure) {
+    ScopedIpcEnvironment environment;
+    for (int fail_call = 0; fail_call < 3; ++fail_call) {
+        FakeCudaDriver driver;
+        driver.fail_access_call = fail_call;
+        NvlinkVmmAllocation::Options options;
+        options.location_type = NvlinkVmmAllocation::LocationType::HOST_NUMA;
+        options.location_id = 0;
+        options.requested_length = 64 * 1024;
+        int access_observations = 0;
+        bool access_success = true;
+        options.access_observer = [&](uint64_t, bool success) {
+            ++access_observations;
+            access_success = success;
+        };
+
+        std::unique_ptr<NvlinkVmmAllocation> allocation;
+        EXPECT_FALSE(NvlinkTransportTestPeer::CreateWithDriverApi(
+                         options, driver.api(), allocation)
+                         .ok());
+        EXPECT_EQ(allocation, nullptr);
+        EXPECT_EQ(access_observations, 1);
+        EXPECT_FALSE(access_success);
+        driver.expectNoResources();
+        EXPECT_EQ(driver.unmap_calls, 1);
+        EXPECT_EQ(driver.address_free_calls, 1);
+        EXPECT_EQ(driver.release_calls, 1);
+        ASSERT_GE(driver.operations.size(), 3);
+        EXPECT_EQ(
+            std::vector<std::string>(driver.operations.end() - 3,
+                                     driver.operations.end()),
+            (std::vector<std::string>{"unmap", "address_free", "release"}));
+    }
+}
+
+TEST(NvlinkVmmAllocationTest, RetriesOriginalHandleReleaseDuringRollback) {
+    ScopedIpcEnvironment environment;
+    FakeCudaDriver driver;
+    // The normal post-map release fails, the first rollback release also
+    // fails, and the owner's non-throwing destructor retries only that
+    // remaining stage.
+    driver.release_failures_remaining = 2;
+    NvlinkVmmAllocation::Options options;
+    options.location_type = NvlinkVmmAllocation::LocationType::HOST_NUMA;
+    options.location_id = 0;
+    options.requested_length = 64 * 1024;
+
+    std::unique_ptr<NvlinkVmmAllocation> allocation;
+    EXPECT_FALSE(NvlinkTransportTestPeer::CreateWithDriverApi(
+                     options, driver.api(), allocation)
+                     .ok());
+    EXPECT_EQ(allocation, nullptr);
+    EXPECT_EQ(NvlinkTransportTestPeer::CleanupPendingOwnerCount(), 1U);
+    EXPECT_EQ(driver.owned_handles, 1);
+    EXPECT_EQ(driver.release_calls, 2);
+    EXPECT_EQ(driver.unmap_calls, 1);
+    EXPECT_EQ(driver.address_free_calls, 1);
+
+    EXPECT_TRUE(NvlinkTransportTestPeer::RetryCleanupPendingOwners());
+    EXPECT_EQ(NvlinkTransportTestPeer::CleanupPendingOwnerCount(), 0U);
+    driver.expectNoResources();
+    EXPECT_EQ(driver.release_calls, 3);
+    ASSERT_GE(driver.operations.size(), 5);
+    EXPECT_EQ(std::vector<std::string>(driver.operations.end() - 5,
+                                       driver.operations.end()),
+              (std::vector<std::string>{"release", "unmap", "address_free",
+                                        "release", "release"}));
+}
+
+TEST(NvlinkVmmAllocationTest,
+     PersistentRollbackUnmapFailureRetainsCompleteOwnerForRetry) {
+    ScopedIpcEnvironment environment;
+    FakeCudaDriver driver;
+    driver.fail_access_call = 0;
+    driver.unmap_failures_remaining = 1000;
+    NvlinkVmmAllocation::Options options;
+    options.location_type = NvlinkVmmAllocation::LocationType::HOST_NUMA;
+    options.location_id = 0;
+    options.requested_length = 64 * 1024;
+
+    std::unique_ptr<NvlinkVmmAllocation> allocation;
+    EXPECT_FALSE(NvlinkTransportTestPeer::CreateWithDriverApi(
+                     options, driver.api(), allocation)
+                     .ok());
+    EXPECT_EQ(allocation, nullptr);
+    EXPECT_EQ(NvlinkTransportTestPeer::CleanupPendingOwnerCount(), 1U);
+    EXPECT_EQ(driver.mapped_ranges, 1);
+    EXPECT_EQ(driver.reserved_ranges, 1);
+    EXPECT_EQ(driver.owned_handles, 1);
+    EXPECT_EQ(driver.address_free_calls, 0);
+    EXPECT_EQ(driver.release_calls, 0);
+
+    driver.unmap_failures_remaining = 0;
+    EXPECT_TRUE(NvlinkTransportTestPeer::RetryCleanupPendingOwners());
+    EXPECT_EQ(NvlinkTransportTestPeer::CleanupPendingOwnerCount(), 0U);
+    driver.expectNoResources();
+    EXPECT_EQ(driver.address_free_calls, 1);
+    EXPECT_EQ(driver.release_calls, 1);
+}
+
+TEST(NvlinkVmmAllocationTest,
+     PersistentRollbackHandleFailureRetainsOwnerForRetry) {
+    ScopedIpcEnvironment environment;
+    FakeCudaDriver driver;
+    driver.release_failures_remaining = 1000;
+    NvlinkVmmAllocation::Options options;
+    options.location_type = NvlinkVmmAllocation::LocationType::HOST_NUMA;
+    options.location_id = 0;
+    options.requested_length = 64 * 1024;
+
+    std::unique_ptr<NvlinkVmmAllocation> allocation;
+    EXPECT_FALSE(NvlinkTransportTestPeer::CreateWithDriverApi(
+                     options, driver.api(), allocation)
+                     .ok());
+    EXPECT_EQ(allocation, nullptr);
+    EXPECT_EQ(NvlinkTransportTestPeer::CleanupPendingOwnerCount(), 1U);
+    EXPECT_EQ(driver.mapped_ranges, 0);
+    EXPECT_EQ(driver.reserved_ranges, 0);
+    EXPECT_EQ(driver.owned_handles, 1);
+
+    driver.release_failures_remaining = 0;
+    EXPECT_TRUE(NvlinkTransportTestPeer::RetryCleanupPendingOwners());
+    EXPECT_EQ(NvlinkTransportTestPeer::CleanupPendingOwnerCount(), 0U);
+    driver.expectNoResources();
+}
+
+TEST(NvlinkVmmAllocationTest, ReleaseRetriesUnmapBeforeLaterStages) {
+    ScopedIpcEnvironment environment;
+    FakeCudaDriver driver;
+    NvlinkVmmAllocation::Options options;
+    options.location_type = NvlinkVmmAllocation::LocationType::HOST_NUMA;
+    options.location_id = 0;
+    options.requested_length = 64 * 1024;
+    options.fabric_exportable = true;
+
+    std::unique_ptr<NvlinkVmmAllocation> allocation;
+    ASSERT_TRUE(NvlinkTransportTestPeer::CreateWithDriverApi(
+                    options, driver.api(), allocation)
+                    .ok());
+    ASSERT_TRUE(NvlinkTransportTestPeer::IsExactOwnedRange(
+        allocation->base(), allocation->length()));
+    driver.unmap_failures_remaining = 1;
+
+    Status first = allocation->Release();
+    EXPECT_FALSE(first.ok());
+    EXPECT_EQ(allocation->base(), reinterpret_cast<void*>(0x100000000ULL));
+    EXPECT_EQ(allocation->length(), 64 * 1024);
+    EXPECT_EQ(driver.unmap_calls, 1);
+    EXPECT_EQ(driver.address_free_calls, 0);
+    EXPECT_EQ(driver.mapped_ranges, 1);
+    EXPECT_EQ(driver.reserved_ranges, 1);
+    EXPECT_FALSE(NvlinkTransportTestPeer::IsExactOwnedRange(
+        allocation->base(), allocation->length()));
+
+    EXPECT_TRUE(allocation->Release().ok());
+    EXPECT_EQ(driver.unmap_calls, 2);
+    EXPECT_EQ(driver.address_free_calls, 1);
+    EXPECT_EQ(allocation->base(), nullptr);
+    EXPECT_EQ(allocation->length(), 0U);
+    driver.expectNoResources();
+
+    allocation.reset();
+    EXPECT_EQ(driver.unmap_calls, 2);
+    EXPECT_EQ(driver.address_free_calls, 1);
+}
+
+TEST(NvlinkVmmAllocationTest, ReleaseRetriesAddressFreeWithoutRepeatingUnmap) {
+    ScopedIpcEnvironment environment;
+    FakeCudaDriver driver;
+    NvlinkVmmAllocation::Options options;
+    options.location_type = NvlinkVmmAllocation::LocationType::HOST_NUMA;
+    options.location_id = 0;
+    options.requested_length = 64 * 1024;
+
+    std::unique_ptr<NvlinkVmmAllocation> allocation;
+    ASSERT_TRUE(NvlinkTransportTestPeer::CreateWithDriverApi(
+                    options, driver.api(), allocation)
+                    .ok());
+    driver.address_free_failures_remaining = 1;
+
+    Status first = allocation->Release();
+    EXPECT_FALSE(first.ok());
+    EXPECT_EQ(allocation->base(), reinterpret_cast<void*>(0x100000000ULL));
+    EXPECT_EQ(allocation->length(), 64 * 1024);
+    EXPECT_EQ(driver.unmap_calls, 1);
+    EXPECT_EQ(driver.address_free_calls, 1);
+    EXPECT_EQ(driver.mapped_ranges, 0);
+    EXPECT_EQ(driver.reserved_ranges, 1);
+
+    EXPECT_TRUE(allocation->Release().ok());
+    EXPECT_EQ(driver.unmap_calls, 1);
+    EXPECT_EQ(driver.address_free_calls, 2);
+    EXPECT_EQ(allocation->base(), nullptr);
+    EXPECT_EQ(allocation->length(), 0U);
+    driver.expectNoResources();
+
+    allocation.reset();
+    EXPECT_EQ(driver.unmap_calls, 1);
+    EXPECT_EQ(driver.address_free_calls, 2);
+}
+
+TEST(NvlinkVmmAllocationTest,
+     ReleaseStopsBeforeCudaWhenProvenanceRemovalFails) {
+    ScopedIpcEnvironment environment;
+    FakeCudaDriver driver;
+    NvlinkVmmAllocation::Options options;
+    options.location_type = NvlinkVmmAllocation::LocationType::HOST_NUMA;
+    options.location_id = 0;
+    options.requested_length = 64 * 1024;
+    options.fabric_exportable = true;
+
+    std::unique_ptr<NvlinkVmmAllocation> allocation;
+    ASSERT_TRUE(NvlinkTransportTestPeer::CreateWithDriverApi(
+                    options, driver.api(), allocation)
+                    .ok());
+    void* const base = allocation->base();
+    const size_t length = allocation->length();
+    ASSERT_TRUE(NvlinkTransportTestPeer::IsExactOwnedRange(base, length));
+    ASSERT_TRUE(NvlinkTransportTestPeer::UnregisterOwnedRange(base, length));
+
+    Status first = allocation->Release();
+    EXPECT_FALSE(first.ok());
+    EXPECT_TRUE(first.IsMemory());
+    EXPECT_EQ(driver.unmap_calls, 0);
+    EXPECT_EQ(driver.address_free_calls, 0);
+    EXPECT_EQ(driver.mapped_ranges, 1);
+    EXPECT_EQ(driver.reserved_ranges, 1);
+
+    ASSERT_TRUE(NvlinkTransportTestPeer::RegisterOwnedRange(base, length));
+    EXPECT_TRUE(allocation->Release().ok());
+    driver.expectNoResources();
+}
+
+TEST(NvlinkVmmAllocationTest,
+     MoveConstructorTransfersOwnerWithoutEarlyRelease) {
+    ScopedIpcEnvironment environment;
+    FakeCudaDriver driver;
+    NvlinkVmmAllocation::Options options;
+    options.location_type = NvlinkVmmAllocation::LocationType::HOST_NUMA;
+    options.location_id = 0;
+    options.requested_length = 64 * 1024;
+
+    std::unique_ptr<NvlinkVmmAllocation> allocation;
+    ASSERT_TRUE(NvlinkTransportTestPeer::CreateWithDriverApi(
+                    options, driver.api(), allocation)
+                    .ok());
+    void* const base = allocation->base();
+
+    {
+        NvlinkVmmAllocation moved(std::move(*allocation));
+        allocation.reset();
+        EXPECT_EQ(moved.base(), base);
+        EXPECT_EQ(driver.unmap_calls, 0);
+        EXPECT_EQ(driver.address_free_calls, 0);
+        EXPECT_EQ(driver.mapped_ranges, 1);
+        EXPECT_EQ(driver.reserved_ranges, 1);
+    }
+    driver.expectNoResources();
+    EXPECT_EQ(driver.unmap_calls, 1);
+    EXPECT_EQ(driver.address_free_calls, 1);
+}
+
+TEST(NvlinkVmmAllocationTest, PinnedOwnerFreeRetainsAndRetriesFailedRelease) {
+    ScopedIpcEnvironment environment;
+    FakeCudaDriver driver;
+    NvlinkVmmAllocation::Options options;
+    options.location_type = NvlinkVmmAllocation::LocationType::HOST_NUMA;
+    options.location_id = 0;
+    options.requested_length = 64 * 1024;
+
+    std::unique_ptr<NvlinkVmmAllocation> allocation;
+    ASSERT_TRUE(NvlinkTransportTestPeer::CreateWithDriverApi(
+                    options, driver.api(), allocation)
+                    .ok());
+    void* const base = allocation->base();
+    ASSERT_TRUE(NvlinkTransportTestPeer::TrackPinnedVmmAllocation(
+        std::move(allocation)));
+    driver.unmap_failures_remaining = 1;
+
+    NvlinkTransport::freePinnedLocalMemory(base);
+    ASSERT_EQ(driver.mapped_ranges, 1)
+        << "failed release must retain the pinned owner map entry";
+    EXPECT_EQ(driver.reserved_ranges, 1);
+    EXPECT_EQ(driver.unmap_calls, 1);
+    EXPECT_EQ(driver.address_free_calls, 0);
+
+    NvlinkTransport::freePinnedLocalMemory(base);
+    driver.expectNoResources();
+    EXPECT_EQ(driver.unmap_calls, 2);
+    EXPECT_EQ(driver.address_free_calls, 1);
+}
+
+TEST(NvlinkVmmAllocationTest, RejectsInvalidAlignmentBeforeCreatingResources) {
+    ScopedIpcEnvironment environment;
+    FakeCudaDriver driver;
+    NvlinkVmmAllocation::Options options;
+    options.location_type = NvlinkVmmAllocation::LocationType::HOST_NUMA;
+    options.location_id = 0;
+    options.requested_length = 64 * 1024;
+    options.required_va_alignment = 96 * 1024;
+
+    std::unique_ptr<NvlinkVmmAllocation> allocation;
+    Status status = NvlinkTransportTestPeer::CreateWithDriverApi(
+        options, driver.api(), allocation);
+    EXPECT_TRUE(status.IsInvalidArgument());
+    EXPECT_EQ(allocation, nullptr);
+    driver.expectNoResources();
+}
+
+TEST(NvlinkVmmAllocationTest, StrictCapabilityRequiresEveryVisibleDevice) {
+    ScopedIpcEnvironment environment;
+    FakeCudaDriver driver;
+    EXPECT_TRUE(
+        NvlinkTransportTestPeer::CheckStrictFabricCapabilityWithDriverApi(
+            driver.api())
+            .ok());
+
+    driver.unsupported_fabric_device = 1;
+    Status status =
+        NvlinkTransportTestPeer::CheckStrictFabricCapabilityWithDriverApi(
+            driver.api());
+    EXPECT_TRUE(status.IsNotSupportedTransport());
+
+    setenv("MC_USE_NVLINK_IPC", "1", 1);
+    status = NvlinkTransportTestPeer::CheckStrictFabricCapabilityWithDriverApi(
+        driver.api());
+    EXPECT_TRUE(status.IsNotSupportedTransport());
+}
+
+static_assert(
+    std::is_same_v<decltype(&NvlinkTransport::allocatePinnedLocalMemory),
+                   void* (*)(size_t)>);
+static_assert(std::is_same_v<decltype(&NvlinkTransport::freePinnedLocalMemory),
+                             void (*)(void*)>);
+static_assert(std::is_move_constructible_v<NvlinkVmmAllocation>);
+static_assert(!std::is_move_assignable_v<NvlinkVmmAllocation>);
+
+}  // namespace
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tests/nvlink_vmm_fabric_test.cpp
+++ b/mooncake-transfer-engine/tests/nvlink_vmm_fabric_test.cpp
@@ -1,0 +1,769 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cctype>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <fstream>
+#include <functional>
+#include <limits>
+#include <memory>
+#include <set>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include <sys/stat.h>
+
+#include "cuda_alike.h"
+#include "error.h"
+#include "transfer_engine.h"
+#include "transfer_metadata.h"
+#include "transport/nvlink_transport/nvlink_transport.h"
+#include "transport/transport.h"
+
+namespace mooncake {
+
+#if defined(USE_MNNVL) && defined(USE_CUDA)
+struct FabricImportAudit {
+    std::atomic<bool> fail_next_map{true};
+    std::atomic<int> import_calls{0};
+    std::atomic<int> injected_map_failures{0};
+    std::atomic<int> live_handles{0};
+    std::atomic<int> live_reserved_ranges{0};
+    std::atomic<int> live_mappings{0};
+};
+
+class NvlinkTransportTestPeer {
+   public:
+    static void InstallOneShotMapFailure(
+        NvlinkTransport& transport,
+        const std::shared_ptr<FabricImportAudit>& audit) {
+        auto api = transport.fabric_driver_api_;
+        auto original_import = api.mem_import_from_shareable_handle;
+        auto original_reserve = api.mem_address_reserve;
+        auto original_map = api.mem_map;
+        auto original_unmap = api.mem_unmap;
+        auto original_free = api.mem_address_free;
+        auto original_release = api.mem_release;
+
+        api.mem_import_from_shareable_handle =
+            [audit, original_import](CUmemGenericAllocationHandle* handle,
+                                     void* shareable,
+                                     CUmemAllocationHandleType type) {
+                ++audit->import_calls;
+                const CUresult result =
+                    original_import(handle, shareable, type);
+                if (result == CUDA_SUCCESS) ++audit->live_handles;
+                return result;
+            };
+        api.mem_address_reserve = [audit, original_reserve](
+                                      CUdeviceptr* address, size_t size,
+                                      size_t alignment, CUdeviceptr requested,
+                                      unsigned long long flags) {
+            const CUresult result =
+                original_reserve(address, size, alignment, requested, flags);
+            if (result == CUDA_SUCCESS) ++audit->live_reserved_ranges;
+            return result;
+        };
+        api.mem_map = [audit, original_map](CUdeviceptr address, size_t size,
+                                            size_t offset,
+                                            CUmemGenericAllocationHandle handle,
+                                            unsigned long long flags) {
+            if (audit->fail_next_map.exchange(false)) {
+                ++audit->injected_map_failures;
+                return CUDA_ERROR_INVALID_VALUE;
+            }
+            const CUresult result =
+                original_map(address, size, offset, handle, flags);
+            if (result == CUDA_SUCCESS) ++audit->live_mappings;
+            return result;
+        };
+        api.mem_unmap = [audit, original_unmap](CUdeviceptr address,
+                                                size_t size) {
+            const CUresult result = original_unmap(address, size);
+            if (result == CUDA_SUCCESS) --audit->live_mappings;
+            return result;
+        };
+        api.mem_address_free = [audit, original_free](CUdeviceptr address,
+                                                      size_t size) {
+            const CUresult result = original_free(address, size);
+            if (result == CUDA_SUCCESS) --audit->live_reserved_ranges;
+            return result;
+        };
+        api.mem_release =
+            [audit, original_release](CUmemGenericAllocationHandle handle) {
+                const CUresult result = original_release(handle);
+                if (result == CUDA_SUCCESS) --audit->live_handles;
+                return result;
+            };
+        transport.fabric_driver_api_ = std::move(api);
+    }
+
+    static size_t MappingCount(const NvlinkTransport& transport) {
+        return transport.remap_entries_.size();
+    }
+};
+#endif
+
+namespace {
+
+constexpr size_t kTransferBytes = 1U << 20;
+constexpr auto kTransferTimeout = std::chrono::seconds(30);
+
+struct HardwareSelection {
+    std::vector<int> devices;
+    std::vector<int> numa_nodes;
+    std::string source;
+};
+
+bool ParseStrictMode(const char* name, bool& strict, std::string& error) {
+    strict = false;
+    const char* value = std::getenv(name);
+    if (value == nullptr || std::string(value) == "0") return true;
+    if (std::string(value) == "1") {
+        strict = true;
+        return true;
+    }
+    error = std::string(name) + " must be 0 or 1";
+    return false;
+}
+
+bool ParseNonNegativeInt(const std::string& text, int& value) {
+    if (text.empty()) return false;
+    size_t parsed = 0;
+    try {
+        const long result = std::stol(text, &parsed, 10);
+        if (parsed != text.size() || result < 0 ||
+            result > std::numeric_limits<int>::max()) {
+            return false;
+        }
+        value = static_cast<int>(result);
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+bool ParseNumaNodeList(const std::string& text, std::vector<int>& nodes,
+                       std::string& error) {
+    if (text.empty()) {
+        error = "NUMA node list must not be empty";
+        return false;
+    }
+
+    std::set<int> unique_nodes;
+    std::stringstream input(text);
+    std::string token;
+    while (std::getline(input, token, ',')) {
+        int node = -1;
+        if (!ParseNonNegativeInt(token, node)) {
+            error =
+                "NUMA node list must contain comma-separated "
+                "non-negative integers";
+            return false;
+        }
+        unique_nodes.insert(node);
+    }
+    if (unique_nodes.empty()) {
+        error = "NUMA node list must contain at least one node";
+        return false;
+    }
+    nodes.assign(unique_nodes.begin(), unique_nodes.end());
+    return true;
+}
+
+bool IsOnlineNumaNode(int node, std::string& error) {
+    const std::string node_path =
+        "/sys/devices/system/node/node" + std::to_string(node);
+    struct stat node_stat{};
+    if (stat(node_path.c_str(), &node_stat) != 0 ||
+        !S_ISDIR(node_stat.st_mode)) {
+        error = "NUMA node " + std::to_string(node) + " is absent from sysfs";
+        return false;
+    }
+
+    std::ifstream online(node_path + "/online");
+    if (!online.is_open()) {
+        // Linux commonly omits node0/online. An existing node directory is
+        // online in that case.
+        return true;
+    }
+    int flag = 0;
+    if (!(online >> flag) || flag != 1) {
+        error = "NUMA node " + std::to_string(node) + " is not online";
+        return false;
+    }
+    return true;
+}
+
+bool DeviceNumaNodeFromSysfs(int device, int& node, std::string& error) {
+    char pci_bus_id[64] = {};
+    cudaError_t result =
+        cudaDeviceGetPCIBusId(pci_bus_id, sizeof(pci_bus_id), device);
+    if (result != cudaSuccess) {
+        error = "cudaDeviceGetPCIBusId failed for visible GPU " +
+                std::to_string(device) + ": " + cudaGetErrorString(result);
+        return false;
+    }
+
+    std::string bdf(pci_bus_id);
+    std::transform(bdf.begin(), bdf.end(), bdf.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+    });
+    if (std::count(bdf.begin(), bdf.end(), ':') == 1) bdf = "0000:" + bdf;
+
+    const std::string numa_path = "/sys/bus/pci/devices/" + bdf + "/numa_node";
+    std::ifstream numa_file(numa_path);
+    if (!numa_file.is_open() || !(numa_file >> node) || node < 0) {
+        error = "visible GPU " + std::to_string(device) +
+                " has no usable PCI-to-NUMA mapping in sysfs";
+        return false;
+    }
+    return IsOnlineNumaNode(node, error);
+}
+
+bool SelectHardware(HardwareSelection& selection, std::string& error) {
+    int device_count = 0;
+    cudaError_t runtime_result = cudaGetDeviceCount(&device_count);
+    if (runtime_result != cudaSuccess) {
+        error = std::string("cudaGetDeviceCount failed: ") +
+                cudaGetErrorString(runtime_result);
+        return false;
+    }
+    if (device_count <= 0) {
+        error = "no visible CUDA GPU";
+        return false;
+    }
+    selection.devices.reserve(device_count);
+    for (int device = 0; device < device_count; ++device)
+        selection.devices.push_back(device);
+
+    const char* override_nodes = std::getenv("MC_NVLINK_VMM_TEST_NODES");
+    const char* override_node = std::getenv("MC_NVLINK_VMM_TEST_NODE");
+    const bool has_node_list =
+        override_nodes != nullptr && *override_nodes != '\0';
+    const bool has_single_node =
+        override_node != nullptr && *override_node != '\0';
+    if (has_node_list && has_single_node) {
+        error =
+            "set only one of MC_NVLINK_VMM_TEST_NODES and "
+            "MC_NVLINK_VMM_TEST_NODE";
+        return false;
+    }
+    if (has_node_list) {
+        if (!ParseNumaNodeList(override_nodes, selection.numa_nodes, error))
+            return false;
+        for (int node : selection.numa_nodes) {
+            if (!IsOnlineNumaNode(node, error)) return false;
+        }
+        selection.source = "MC_NVLINK_VMM_TEST_NODES";
+        return true;
+    }
+    if (has_single_node) {
+        int node = -1;
+        if (!ParseNonNegativeInt(override_node, node)) {
+            error =
+                "MC_NVLINK_VMM_TEST_NODE must be a non-negative "
+                "integer";
+            return false;
+        }
+        if (!IsOnlineNumaNode(node, error)) return false;
+        selection.numa_nodes = {node};
+        selection.source = "MC_NVLINK_VMM_TEST_NODE";
+        return true;
+    }
+
+    std::set<int> gpu_nodes;
+    for (int device : selection.devices) {
+        int node = -1;
+        if (!DeviceNumaNodeFromSysfs(device, node, error)) return false;
+        gpu_nodes.insert(node);
+    }
+    if (gpu_nodes.empty()) {
+        error = "visible GPU PCI sysfs discovery produced no online NUMA node";
+        return false;
+    }
+    selection.numa_nodes.assign(gpu_nodes.begin(), gpu_nodes.end());
+    selection.source = "visible GPU PCI sysfs";
+    return true;
+}
+
+class ScopedCudaDevice {
+   public:
+    explicit ScopedCudaDevice(int device) {
+        result_ = cudaGetDevice(&previous_device_);
+        if (result_ != cudaSuccess) return;
+        result_ = cudaSetDevice(device);
+        restore_ = result_ == cudaSuccess && previous_device_ != device;
+    }
+
+    ScopedCudaDevice(const ScopedCudaDevice&) = delete;
+    ScopedCudaDevice& operator=(const ScopedCudaDevice&) = delete;
+
+    ~ScopedCudaDevice() {
+        if (restore_) (void)cudaSetDevice(previous_device_);
+    }
+
+    cudaError_t result() const { return result_; }
+
+   private:
+    int previous_device_ = 0;
+    cudaError_t result_ = cudaSuccess;
+    bool restore_ = false;
+};
+
+class CudaBuffer {
+   public:
+    explicit CudaBuffer(int device) : device_(device) {}
+    CudaBuffer(const CudaBuffer&) = delete;
+    CudaBuffer& operator=(const CudaBuffer&) = delete;
+    ~CudaBuffer() { (void)Reset(); }
+
+    cudaError_t Allocate(size_t length) {
+        ScopedCudaDevice current(device_);
+        if (current.result() != cudaSuccess) return current.result();
+        return cudaMalloc(&address_, length);
+    }
+
+    cudaError_t Reset() {
+        if (address_ == nullptr) return cudaSuccess;
+        ScopedCudaDevice current(device_);
+        if (current.result() != cudaSuccess) return current.result();
+        cudaError_t result = cudaFree(address_);
+        if (result == cudaSuccess) address_ = nullptr;
+        return result;
+    }
+
+    void* get() const { return address_; }
+
+   private:
+    int device_;
+    void* address_ = nullptr;
+};
+
+class RegisteredMemory {
+   public:
+    RegisteredMemory(TransferEngine& engine, void* address)
+        : engine_(engine), address_(address) {}
+    RegisteredMemory(const RegisteredMemory&) = delete;
+    RegisteredMemory& operator=(const RegisteredMemory&) = delete;
+    ~RegisteredMemory() { (void)Reset(); }
+
+    int Register(size_t length, const std::string& location,
+                 bool remote_accessible) {
+        const int result = engine_.registerLocalMemory(
+            address_, length, location, remote_accessible);
+        active_ = result == 0;
+        return result;
+    }
+
+    int Reset() {
+        if (!active_) return 0;
+        const int result = engine_.unregisterLocalMemory(address_);
+        if (result == 0) active_ = false;
+        return result;
+    }
+
+   private:
+    TransferEngine& engine_;
+    void* address_;
+    bool active_ = false;
+};
+
+class ScopedBatch {
+   public:
+    explicit ScopedBatch(TransferEngine& engine)
+        : engine_(engine), id_(engine.allocateBatchID(1)) {
+        if (id_ == static_cast<BatchID>(ERR_MEMORY)) id_ = INVALID_BATCH_ID;
+    }
+    ScopedBatch(const ScopedBatch&) = delete;
+    ScopedBatch& operator=(const ScopedBatch&) = delete;
+    ~ScopedBatch() { (void)Reset(); }
+
+    BatchID id() const { return id_; }
+
+    Status Reset() {
+        if (id_ == INVALID_BATCH_ID) return Status::OK();
+        Status status = engine_.freeBatchID(id_);
+        if (status.ok()) id_ = INVALID_BATCH_ID;
+        return status;
+    }
+
+    Status ForceReset() {
+        if (id_ == INVALID_BATCH_ID) return Status::OK();
+        // Once device work is quiescent, forcing every task terminal makes a
+        // batch releasable even if status polling itself failed.
+        (void)cudaDeviceSynchronize();
+        auto& desc = Transport::toBatchDesc(id_);
+        for (auto& task : desc.task_list) Transport::markSubmissionFailed(task);
+        return Reset();
+    }
+
+   private:
+    TransferEngine& engine_;
+    BatchID id_ = INVALID_BATCH_ID;
+};
+
+std::vector<unsigned char> MakePattern(size_t length, unsigned int seed) {
+    std::vector<unsigned char> pattern(length);
+    for (size_t index = 0; index < length; ++index) {
+        pattern[index] = static_cast<unsigned char>(
+            (seed + index * 17U + (index >> 8U) * 29U) & 0xffU);
+    }
+    return pattern;
+}
+
+testing::AssertionResult MatchesPattern(
+    const unsigned char* actual, const std::vector<unsigned char>& expected) {
+    for (size_t index = 0; index < expected.size(); ++index) {
+        if (actual[index] != expected[index]) {
+            return testing::AssertionFailure()
+                   << "byte mismatch at offset " << index << ": expected "
+                   << static_cast<unsigned int>(expected[index]) << ", got "
+                   << static_cast<unsigned int>(actual[index]);
+        }
+    }
+    return testing::AssertionSuccess();
+}
+
+std::string RunTransfer(TransferEngine& engine, TransferRequest::OpCode opcode,
+                        void* local_address, SegmentID target_id,
+                        void* remote_address, size_t length) {
+    ScopedBatch batch(engine);
+    if (batch.id() == INVALID_BATCH_ID) return "batch allocation failed";
+
+    TransferRequest request;
+    request.opcode = opcode;
+    request.source = local_address;
+    request.target_id = target_id;
+    request.target_offset = reinterpret_cast<uint64_t>(remote_address);
+    request.length = length;
+
+    Status status = engine.submitTransfer(batch.id(), {request});
+    if (!status.ok()) {
+        const std::string error = "submitTransfer failed: " + status.ToString();
+        Status cleanup = batch.ForceReset();
+        return cleanup.ok()
+                   ? error
+                   : error + "; batch cleanup failed: " + cleanup.ToString();
+    }
+
+    const auto deadline = std::chrono::steady_clock::now() + kTransferTimeout;
+    TransferStatus transfer_status{};
+    for (;;) {
+        status = engine.getTransferStatus(batch.id(), 0, transfer_status);
+        if (!status.ok()) {
+            const std::string error =
+                "getTransferStatus failed: " + status.ToString();
+            Status cleanup = batch.ForceReset();
+            return cleanup.ok()
+                       ? error
+                       : error +
+                             "; batch cleanup failed: " + cleanup.ToString();
+        }
+        if (transfer_status.s == TransferStatusEnum::COMPLETED) break;
+        if (transfer_status.s == TransferStatusEnum::FAILED) {
+            Status cleanup = batch.Reset();
+            return cleanup.ok() ? "transfer completed with FAILED status"
+                                : "transfer failed and batch cleanup failed: " +
+                                      cleanup.ToString();
+        }
+        if (std::chrono::steady_clock::now() >= deadline) {
+            // Synchronize before marking the task terminal so no in-flight
+            // copy can retain Slice ownership after the batch is released.
+            const cudaError_t sync_result = cudaDeviceSynchronize();
+            status = engine.getTransferStatus(batch.id(), 0, transfer_status);
+            if (status.ok() &&
+                transfer_status.s == TransferStatusEnum::COMPLETED) {
+                break;
+            }
+            Status cleanup = batch.ForceReset();
+            std::ostringstream error;
+            error << "transfer timed out; cudaDeviceSynchronize result="
+                  << static_cast<int>(sync_result);
+            if (!cleanup.ok())
+                error << "; batch cleanup failed: " << cleanup.ToString();
+            return error.str();
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+
+    if (transfer_status.transferred_bytes != length) {
+        std::ostringstream error;
+        error << "transferred byte count mismatch: expected " << length
+              << ", got " << transfer_status.transferred_bytes;
+        return error.str();
+    }
+    status = batch.Reset();
+    return status.ok() ? std::string()
+                       : "freeBatchID failed: " + status.ToString();
+}
+
+#define REQUIRE_FABRIC_OR_SKIP(strict, reason) \
+    do {                                       \
+        if (strict) {                          \
+            FAIL() << (reason);                \
+        } else {                               \
+            GTEST_SKIP() << (reason);          \
+        }                                      \
+    } while (false)
+
+TEST(NvlinkVmmFabricTest, CpuAllVisibleGpusAndColdWarmFabricPath) {
+    bool strict = false;
+    std::string prerequisite_error;
+    ASSERT_TRUE(
+        ParseStrictMode("MC_REQUIRE_MNNVL_FABRIC", strict, prerequisite_error))
+        << prerequisite_error;
+
+    HardwareSelection hardware;
+    if (!SelectHardware(hardware, prerequisite_error)) {
+        REQUIRE_FABRIC_OR_SKIP(strict, prerequisite_error);
+    }
+
+    Status capability = NvlinkVmmAllocation::CheckStrictFabricCapability();
+    if (!capability.ok()) {
+        REQUIRE_FABRIC_OR_SKIP(
+            strict,
+            "Fabric capability prerequisite failed: " + capability.ToString());
+    }
+
+    ASSERT_FALSE(hardware.numa_nodes.empty());
+    std::ostringstream selected_nodes;
+    for (size_t index = 0; index < hardware.numa_nodes.size(); ++index) {
+        if (index != 0) selected_nodes << ',';
+        selected_nodes << hardware.numa_nodes[index];
+    }
+    ::testing::Test::RecordProperty("host_numa_nodes", selected_nodes.str());
+    ::testing::Test::RecordProperty("visible_gpu_count",
+                                    std::to_string(hardware.devices.size()));
+    ::testing::Test::RecordProperty("numa_selection_source", hardware.source);
+
+    for (int numa_node : hardware.numa_nodes) {
+        SCOPED_TRACE("HOST_NUMA node " + std::to_string(numa_node));
+
+        NvlinkVmmAllocation::Options options;
+        options.location_type = NvlinkVmmAllocation::LocationType::HOST_NUMA;
+        options.location_id = numa_node;
+        options.requested_length = kTransferBytes;
+        options.fabric_exportable = true;
+
+        auto server = std::make_unique<TransferEngine>(false);
+        ASSERT_EQ(server->init(P2PHANDSHAKE, "127.0.0.1:0", "127.0.0.1", 0), 0);
+        ASSERT_NE(server->installTransport("nvlink", nullptr), nullptr);
+
+        std::unique_ptr<NvlinkVmmAllocation> allocation;
+        Status allocation_status =
+            NvlinkVmmAllocation::Create(options, allocation);
+        if (!allocation_status.ok()) {
+            REQUIRE_FABRIC_OR_SKIP(
+                strict,
+                "HOST_NUMA Fabric VMM allocation prerequisite failed on " +
+                    hardware.source + ": " + allocation_status.ToString());
+        }
+        ASSERT_NE(allocation, nullptr);
+        ASSERT_NE(allocation->base(), nullptr);
+        ASSERT_GE(allocation->length(), kTransferBytes);
+        ASSERT_EQ(allocation->location_type(),
+                  NvlinkVmmAllocation::LocationType::HOST_NUMA);
+        ASSERT_EQ(allocation->location_id(), numa_node);
+        ASSERT_TRUE(allocation->fabric_exportable());
+
+        auto* host_numa = static_cast<unsigned char*>(allocation->base());
+        const auto cpu_pattern = MakePattern(kTransferBytes, 0x21U);
+        std::copy(cpu_pattern.begin(), cpu_pattern.end(), host_numa);
+        ASSERT_TRUE(MatchesPattern(host_numa, cpu_pattern));
+
+        RegisteredMemory server_registration(*server, allocation->base());
+        const int registration_result = server_registration.Register(
+            allocation->length(), "cpu:numa" + std::to_string(numa_node), true);
+        if (registration_result != 0) {
+            REQUIRE_FABRIC_OR_SKIP(strict,
+                                   "Fabric export/IMEX prerequisite failed "
+                                   "during NVLink registration"
+                                   " (rc=" +
+                                       std::to_string(registration_result) +
+                                       ")");
+        }
+
+        auto local_desc =
+            server->getMetadata()->getSegmentDescByID(LOCAL_SEGMENT_ID, false);
+        ASSERT_NE(local_desc, nullptr);
+        bool exported = false;
+        for (const auto& buffer : local_desc->buffers) {
+            if (buffer.addr == reinterpret_cast<uint64_t>(allocation->base()) &&
+                buffer.length == allocation->length()) {
+                exported = !buffer.shm_name.empty();
+                break;
+            }
+        }
+        ASSERT_TRUE(exported)
+            << "remote registration must publish one serialized Fabric handle";
+
+        auto client = std::make_unique<TransferEngine>(false);
+        ASSERT_EQ(client->init(P2PHANDSHAKE, "127.0.0.1:0", "127.0.0.1", 0), 0);
+        ASSERT_NE(client->installTransport("nvlink", nullptr), nullptr);
+        auto* client_nvlink =
+            dynamic_cast<NvlinkTransport*>(client->getTransport("nvlink"));
+        ASSERT_NE(client_nvlink, nullptr);
+        auto import_audit = std::make_shared<FabricImportAudit>();
+        NvlinkTransportTestPeer::InstallOneShotMapFailure(*client_nvlink,
+                                                          import_audit);
+        const SegmentID provider_segment =
+            client->openSegment(server->getLocalIpAndPort());
+        ASSERT_NE(provider_segment, static_cast<SegmentID>(-1));
+
+        bool cold_transfer_completed = false;
+        for (int device : hardware.devices) {
+            SCOPED_TRACE("visible CUDA device " + std::to_string(device));
+            ScopedCudaDevice current(device);
+            ASSERT_EQ(current.result(), cudaSuccess)
+                << cudaGetErrorString(current.result());
+
+            CudaBuffer hbm(device);
+            ASSERT_EQ(hbm.Allocate(kTransferBytes), cudaSuccess);
+            ASSERT_NE(hbm.get(), nullptr);
+
+            RegisteredMemory client_registration(*client, hbm.get());
+            ASSERT_EQ(
+                client_registration.Register(
+                    kTransferBytes, "cuda:" + std::to_string(device), false),
+                0);
+
+            // Direct copies prove that the owning CPU and every visible GPU
+            // have read/write access to the HOST_NUMA mapping.
+            const auto direct_to_hbm =
+                MakePattern(kTransferBytes, 0x40U + device);
+            std::copy(direct_to_hbm.begin(), direct_to_hbm.end(), host_numa);
+            std::atomic_thread_fence(std::memory_order_seq_cst);
+            ASSERT_EQ(cudaMemcpy(hbm.get(), host_numa, kTransferBytes,
+                                 cudaMemcpyDefault),
+                      cudaSuccess);
+            std::vector<unsigned char> observed(kTransferBytes);
+            ASSERT_EQ(cudaMemcpy(observed.data(), hbm.get(), kTransferBytes,
+                                 cudaMemcpyDeviceToHost),
+                      cudaSuccess);
+            ASSERT_TRUE(MatchesPattern(observed.data(), direct_to_hbm));
+
+            const auto direct_to_dram =
+                MakePattern(kTransferBytes, 0x60U + device);
+            ASSERT_EQ(cudaMemcpy(hbm.get(), direct_to_dram.data(),
+                                 kTransferBytes, cudaMemcpyHostToDevice),
+                      cudaSuccess);
+            ASSERT_EQ(cudaMemcpy(host_numa, hbm.get(), kTransferBytes,
+                                 cudaMemcpyDefault),
+                      cudaSuccess);
+            ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+            ASSERT_TRUE(MatchesPattern(host_numa, direct_to_dram));
+
+            const auto write_pattern =
+                MakePattern(kTransferBytes, 0x80U + device);
+            ASSERT_EQ(cudaMemcpy(hbm.get(), write_pattern.data(),
+                                 kTransferBytes, cudaMemcpyHostToDevice),
+                      cudaSuccess);
+            if (!cold_transfer_completed) {
+                const std::string injected_error = RunTransfer(
+                    *client, TransferRequest::WRITE, hbm.get(),
+                    provider_segment, allocation->base(), kTransferBytes);
+                ASSERT_FALSE(injected_error.empty())
+                    << "one-shot cuMemMap failure was not surfaced";
+                if (import_audit->injected_map_failures.load() == 0) {
+                    REQUIRE_FABRIC_OR_SKIP(
+                        strict,
+                        "cold Fabric import prerequisite failed before "
+                        "the injected cuMemMap stage: " +
+                            injected_error);
+                }
+                ASSERT_EQ(import_audit->injected_map_failures.load(), 1);
+                ASSERT_EQ(NvlinkTransportTestPeer::MappingCount(*client_nvlink),
+                          0U);
+                ASSERT_EQ(import_audit->live_handles.load(), 0);
+                ASSERT_EQ(import_audit->live_reserved_ranges.load(), 0);
+                ASSERT_EQ(import_audit->live_mappings.load(), 0);
+            }
+
+            const int imports_before_success =
+                import_audit->import_calls.load();
+            const std::string write_error = RunTransfer(
+                *client, TransferRequest::WRITE, hbm.get(), provider_segment,
+                allocation->base(), kTransferBytes);
+            if (!cold_transfer_completed && !write_error.empty()) {
+                REQUIRE_FABRIC_OR_SKIP(
+                    strict,
+                    "Fabric import retry prerequisite failed after clean "
+                    "rollback: " +
+                        write_error);
+            }
+            ASSERT_TRUE(write_error.empty()) << write_error;
+            if (!cold_transfer_completed) {
+                ASSERT_EQ(import_audit->import_calls.load(),
+                          imports_before_success + 1);
+                ASSERT_EQ(NvlinkTransportTestPeer::MappingCount(*client_nvlink),
+                          1U);
+                ASSERT_EQ(import_audit->live_handles.load(), 0);
+                ASSERT_EQ(import_audit->live_reserved_ranges.load(), 1);
+                ASSERT_EQ(import_audit->live_mappings.load(), 1);
+            }
+            cold_transfer_completed = true;
+            std::atomic_thread_fence(std::memory_order_seq_cst);
+            ASSERT_TRUE(MatchesPattern(host_numa, write_pattern));
+
+            // The next request uses the same Consumer engine, segment, and
+            // remote BufferDesc. It therefore exercises the warm mapping-cache
+            // path.
+            const auto read_pattern =
+                MakePattern(kTransferBytes, 0xa0U + device);
+            std::copy(read_pattern.begin(), read_pattern.end(), host_numa);
+            std::atomic_thread_fence(std::memory_order_seq_cst);
+            const int imports_before_warm = import_audit->import_calls.load();
+            const std::string read_error = RunTransfer(
+                *client, TransferRequest::READ, hbm.get(), provider_segment,
+                allocation->base(), kTransferBytes);
+            ASSERT_TRUE(read_error.empty()) << read_error;
+            ASSERT_EQ(import_audit->import_calls.load(), imports_before_warm)
+                << "warm transfer unexpectedly missed the Fabric map cache";
+            ASSERT_EQ(cudaMemcpy(observed.data(), hbm.get(), kTransferBytes,
+                                 cudaMemcpyDeviceToHost),
+                      cudaSuccess);
+            ASSERT_TRUE(MatchesPattern(observed.data(), read_pattern));
+
+            ASSERT_EQ(client_registration.Reset(), 0);
+            ASSERT_EQ(hbm.Reset(), cudaSuccess);
+        }
+        ASSERT_TRUE(cold_transfer_completed);
+
+        // Destroy the Consumer first so imported mappings are unmapped before
+        // the Provider unregisters and releases the owning VMM allocation.
+        client.reset();
+        ASSERT_EQ(import_audit->live_handles.load(), 0);
+        ASSERT_EQ(import_audit->live_reserved_ranges.load(), 0);
+        ASSERT_EQ(import_audit->live_mappings.load(), 0);
+        ASSERT_EQ(server_registration.Reset(), 0);
+        allocation.reset();
+        server.reset();
+    }
+}
+
+#undef REQUIRE_FABRIC_OR_SKIP
+
+}  // namespace
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tests/nvlink_vmm_rdma_smoke_test.cpp
+++ b/mooncake-transfer-engine/tests/nvlink_vmm_rdma_smoke_test.cpp
@@ -1,0 +1,385 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <infiniband/verbs.h>
+
+#include <algorithm>
+#include <cerrno>
+#include <cctype>
+#include <cstddef>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <limits>
+#include <memory>
+#include <set>
+#include <string>
+
+#include <sys/stat.h>
+
+#include "cuda_alike.h"
+#include "transport/nvlink_transport/nvlink_transport.h"
+
+namespace mooncake {
+namespace {
+
+constexpr size_t kRegistrationBytes = 2U << 20;
+
+bool ParseStrictMode(const char* name, bool& strict, std::string& error) {
+    strict = false;
+    const char* value = std::getenv(name);
+    if (value == nullptr || std::string(value) == "0") return true;
+    if (std::string(value) == "1") {
+        strict = true;
+        return true;
+    }
+    error = std::string(name) + " must be 0 or 1";
+    return false;
+}
+
+bool ParseNonNegativeInt(const std::string& text, int& value) {
+    if (text.empty()) return false;
+    size_t parsed = 0;
+    try {
+        const long result = std::stol(text, &parsed, 10);
+        if (parsed != text.size() || result < 0 ||
+            result > std::numeric_limits<int>::max()) {
+            return false;
+        }
+        value = static_cast<int>(result);
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+bool IsOnlineNumaNode(int node, std::string& error) {
+    const std::string node_path =
+        "/sys/devices/system/node/node" + std::to_string(node);
+    struct stat node_stat{};
+    if (stat(node_path.c_str(), &node_stat) != 0 ||
+        !S_ISDIR(node_stat.st_mode)) {
+        error = "NUMA node " + std::to_string(node) + " is absent from sysfs";
+        return false;
+    }
+
+    std::ifstream online(node_path + "/online");
+    if (!online.is_open()) return true;
+    int flag = 0;
+    if (!(online >> flag) || flag != 1) {
+        error = "NUMA node " + std::to_string(node) + " is not online";
+        return false;
+    }
+    return true;
+}
+
+bool DeviceNumaNodeFromSysfs(int device, int& node, std::string& error) {
+    char pci_bus_id[64] = {};
+    cudaError_t result =
+        cudaDeviceGetPCIBusId(pci_bus_id, sizeof(pci_bus_id), device);
+    if (result != cudaSuccess) {
+        error = "cudaDeviceGetPCIBusId failed for visible GPU " +
+                std::to_string(device) + ": " + cudaGetErrorString(result);
+        return false;
+    }
+
+    std::string bdf(pci_bus_id);
+    std::transform(bdf.begin(), bdf.end(), bdf.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+    });
+    if (std::count(bdf.begin(), bdf.end(), ':') == 1) bdf = "0000:" + bdf;
+
+    std::ifstream numa_file("/sys/bus/pci/devices/" + bdf + "/numa_node");
+    if (!numa_file.is_open() || !(numa_file >> node) || node < 0) {
+        error = "visible GPU " + std::to_string(device) +
+                " has no usable PCI-to-NUMA mapping in sysfs";
+        return false;
+    }
+    return IsOnlineNumaNode(node, error);
+}
+
+bool SelectHostNumaNode(int& node, std::string& source, std::string& error) {
+    int device_count = 0;
+    const cudaError_t result = cudaGetDeviceCount(&device_count);
+    if (result != cudaSuccess) {
+        error = std::string("cudaGetDeviceCount failed: ") +
+                cudaGetErrorString(result);
+        return false;
+    }
+    if (device_count <= 0) {
+        error = "no visible CUDA GPU";
+        return false;
+    }
+
+    const char* override_node = std::getenv("MC_NVLINK_VMM_TEST_NODE");
+    if (override_node != nullptr && *override_node != '\0') {
+        if (!ParseNonNegativeInt(override_node, node)) {
+            error =
+                "MC_NVLINK_VMM_TEST_NODE must be a non-negative "
+                "integer";
+            return false;
+        }
+        if (!IsOnlineNumaNode(node, error)) return false;
+        source = "MC_NVLINK_VMM_TEST_NODE";
+        return true;
+    }
+
+    std::set<int> gpu_nodes;
+    for (int device = 0; device < device_count; ++device) {
+        int gpu_node = -1;
+        if (!DeviceNumaNodeFromSysfs(device, gpu_node, error)) return false;
+        gpu_nodes.insert(gpu_node);
+    }
+    if (gpu_nodes.empty()) {
+        error = "visible GPU PCI sysfs discovery produced no online NUMA node";
+        return false;
+    }
+    node = *gpu_nodes.begin();
+    source = "visible GPU PCI sysfs";
+    return true;
+}
+
+class DeviceList {
+   public:
+    DeviceList() { devices_ = ibv_get_device_list(&count_); }
+    DeviceList(const DeviceList&) = delete;
+    DeviceList& operator=(const DeviceList&) = delete;
+    ~DeviceList() {
+        if (devices_ != nullptr) ibv_free_device_list(devices_);
+    }
+
+    ibv_device** get() const { return devices_; }
+    int count() const { return count_; }
+
+   private:
+    ibv_device** devices_ = nullptr;
+    int count_ = 0;
+};
+
+class VerbsContext {
+   public:
+    VerbsContext() = default;
+    VerbsContext(const VerbsContext&) = delete;
+    VerbsContext& operator=(const VerbsContext&) = delete;
+    ~VerbsContext() { (void)Reset(); }
+
+    bool Open(ibv_device* device) {
+        context_ = ibv_open_device(device);
+        return context_ != nullptr;
+    }
+
+    int Reset() {
+        if (context_ == nullptr) return 0;
+        const int result = ibv_close_device(context_);
+        if (result == 0) context_ = nullptr;
+        return result;
+    }
+
+    ibv_context* get() const { return context_; }
+
+   private:
+    ibv_context* context_ = nullptr;
+};
+
+class ProtectionDomain {
+   public:
+    ProtectionDomain() = default;
+    ProtectionDomain(const ProtectionDomain&) = delete;
+    ProtectionDomain& operator=(const ProtectionDomain&) = delete;
+    ~ProtectionDomain() { (void)Reset(); }
+
+    bool Allocate(ibv_context* context) {
+        domain_ = ibv_alloc_pd(context);
+        return domain_ != nullptr;
+    }
+
+    int Reset() {
+        if (domain_ == nullptr) return 0;
+        const int result = ibv_dealloc_pd(domain_);
+        if (result == 0) domain_ = nullptr;
+        return result;
+    }
+
+    ibv_pd* get() const { return domain_; }
+
+   private:
+    ibv_pd* domain_ = nullptr;
+};
+
+class MemoryRegion {
+   public:
+    MemoryRegion() = default;
+    MemoryRegion(const MemoryRegion&) = delete;
+    MemoryRegion& operator=(const MemoryRegion&) = delete;
+    ~MemoryRegion() { (void)Reset(); }
+
+    bool Register(ibv_pd* domain, void* address, size_t length) {
+        region_ = ibv_reg_mr(domain, address, length,
+                             IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ |
+                                 IBV_ACCESS_REMOTE_WRITE);
+        return region_ != nullptr;
+    }
+
+    int Reset() {
+        if (region_ == nullptr) return 0;
+        const int result = ibv_dereg_mr(region_);
+        if (result == 0) region_ = nullptr;
+        return result;
+    }
+
+   private:
+    ibv_mr* region_ = nullptr;
+};
+
+ibv_device* SelectRdmaDevice(const DeviceList& list, std::string& name,
+                             std::string& error) {
+    if (list.get() == nullptr) {
+        error =
+            "ibv_get_device_list failed: " + std::string(std::strerror(errno));
+        return nullptr;
+    }
+    if (list.count() <= 0) {
+        error = "no RNIC is visible through libibverbs";
+        return nullptr;
+    }
+
+    const char* requested = std::getenv("MC_NVLINK_VMM_RDMA_DEVICE");
+    if (requested == nullptr || *requested == '\0') {
+        const char* first_name = ibv_get_device_name(list.get()[0]);
+        if (first_name == nullptr) {
+            error = "the first libibverbs device has no name";
+            return nullptr;
+        }
+        name = first_name;
+        return list.get()[0];
+    }
+
+    for (int index = 0; index < list.count(); ++index) {
+        const char* candidate = ibv_get_device_name(list.get()[index]);
+        if (candidate != nullptr && std::string(candidate) == requested) {
+            name = candidate;
+            return list.get()[index];
+        }
+    }
+    error = "requested RNIC is not visible: " + std::string(requested);
+    return nullptr;
+}
+
+int ReadRdmaDeviceNumaNode(const std::string& device_name) {
+    std::ifstream numa_file("/sys/class/infiniband/" + device_name +
+                            "/device/numa_node");
+    int node = -1;
+    if (!(numa_file >> node)) return -1;
+    return node;
+}
+
+#define REQUIRE_RDMA_OR_SKIP(strict, reason) \
+    do {                                     \
+        if (strict) {                        \
+            FAIL() << (reason);              \
+        } else {                             \
+            GTEST_SKIP() << (reason);        \
+        }                                    \
+    } while (false)
+
+TEST(NvlinkVmmRdmaSmokeTest, VerbsCanRegisterProviderVmmAllocation) {
+    bool strict = false;
+    std::string prerequisite_error;
+    ASSERT_TRUE(ParseStrictMode("MC_REQUIRE_NVLINK_VMM_RDMA", strict,
+                                prerequisite_error))
+        << prerequisite_error;
+
+    int host_numa_node = -1;
+    std::string node_source;
+    if (!SelectHostNumaNode(host_numa_node, node_source, prerequisite_error)) {
+        REQUIRE_RDMA_OR_SKIP(strict, prerequisite_error);
+    }
+
+    Status capability = NvlinkVmmAllocation::CheckStrictFabricCapability();
+    if (!capability.ok()) {
+        REQUIRE_RDMA_OR_SKIP(
+            strict, "Fabric-capable HOST_NUMA VMM prerequisite failed: " +
+                        capability.ToString());
+    }
+
+    NvlinkVmmAllocation::Options options;
+    options.location_type = NvlinkVmmAllocation::LocationType::HOST_NUMA;
+    options.location_id = host_numa_node;
+    options.requested_length = kRegistrationBytes;
+    options.fabric_exportable = true;
+
+    std::unique_ptr<NvlinkVmmAllocation> allocation;
+    Status allocation_status = NvlinkVmmAllocation::Create(options, allocation);
+    if (!allocation_status.ok()) {
+        REQUIRE_RDMA_OR_SKIP(
+            strict, "HOST_NUMA Fabric VMM allocation prerequisite failed via " +
+                        node_source + ": " + allocation_status.ToString());
+    }
+    ASSERT_NE(allocation, nullptr);
+    ASSERT_NE(allocation->base(), nullptr);
+    ASSERT_GE(allocation->length(), kRegistrationBytes);
+    std::memset(allocation->base(), 0x5a, kRegistrationBytes);
+
+    DeviceList devices;
+    std::string rdma_device_name;
+    ibv_device* device =
+        SelectRdmaDevice(devices, rdma_device_name, prerequisite_error);
+    if (device == nullptr) {
+        REQUIRE_RDMA_OR_SKIP(strict, prerequisite_error);
+    }
+
+    ::testing::Test::RecordProperty("host_numa_node",
+                                    std::to_string(host_numa_node));
+    ::testing::Test::RecordProperty("rdma_device", rdma_device_name);
+    ::testing::Test::RecordProperty(
+        "rdma_device_numa_node",
+        std::to_string(ReadRdmaDeviceNumaNode(rdma_device_name)));
+
+    VerbsContext context;
+    if (!context.Open(device)) {
+        const std::string error = "ibv_open_device failed for " +
+                                  rdma_device_name + ": " +
+                                  std::strerror(errno);
+        REQUIRE_RDMA_OR_SKIP(strict, error);
+    }
+
+    ProtectionDomain domain;
+    if (!domain.Allocate(context.get())) {
+        const std::string error = "ibv_alloc_pd failed for " +
+                                  rdma_device_name + ": " +
+                                  std::strerror(errno);
+        REQUIRE_RDMA_OR_SKIP(strict, error);
+    }
+
+    MemoryRegion region;
+    if (!region.Register(domain.get(), allocation->base(),
+                         allocation->length())) {
+        const std::string error =
+            "ibv_reg_mr rejected the HOST_NUMA VMM allocation on " +
+            rdma_device_name + ": " + std::strerror(errno);
+        REQUIRE_RDMA_OR_SKIP(strict, error);
+    }
+
+    ASSERT_EQ(region.Reset(), 0) << "ibv_dereg_mr failed";
+    ASSERT_EQ(domain.Reset(), 0) << "ibv_dealloc_pd failed";
+    ASSERT_EQ(context.Reset(), 0) << "ibv_close_device failed";
+    allocation.reset();
+    ::testing::Test::RecordProperty("result", "ibv_reg_mr_and_dereg_mr_pass");
+}
+
+#undef REQUIRE_RDMA_OR_SKIP
+
+}  // namespace
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
+++ b/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
@@ -20,7 +20,10 @@
 #include <sys/time.h>
 
 #include <chrono>
+#include <condition_variable>
 #include <cstdlib>
+#include <future>
+#include <mutex>
 #include <thread>
 
 #include "config.h"
@@ -30,6 +33,355 @@
 using namespace mooncake;
 
 namespace mooncake {
+
+class TransferMetadataTestPeer {
+   public:
+    static int EncodeSegmentDesc(TransferMetadata& metadata,
+                                 const TransferMetadata::SegmentDesc& desc,
+                                 Json::Value& encoded) {
+        return metadata.encodeSegmentDesc(desc, encoded);
+    }
+
+    static std::shared_ptr<TransferMetadata::SegmentDesc> DecodeSegmentDesc(
+        TransferMetadata& metadata, Json::Value& encoded,
+        const std::string& segment_name) {
+        return metadata.decodeSegmentDesc(encoded, segment_name);
+    }
+
+    static void SetStoragePlugin(
+        TransferMetadata& metadata,
+        std::shared_ptr<MetadataStoragePlugin> storage_plugin) {
+        metadata.p2p_handshake_mode_ = false;
+        metadata.storage_plugin_ = std::move(storage_plugin);
+    }
+};
+
+class FailOnceMetadataStoragePlugin : public MetadataStoragePlugin {
+   public:
+    bool get(const std::string&, Json::Value& value) override {
+        value = last_successful_value;
+        return has_successful_value;
+    }
+
+    bool set(const std::string&, const Json::Value& value) override {
+        ++set_calls;
+        last_attempted_value = value;
+        if (fail_next_set) {
+            fail_next_set = false;
+            return false;
+        }
+        last_successful_value = value;
+        has_successful_value = true;
+        return true;
+    }
+
+    bool remove(const std::string&) override { return true; }
+
+    int set_calls = 0;
+    bool fail_next_set = false;
+    bool has_successful_value = false;
+    Json::Value last_attempted_value;
+    Json::Value last_successful_value;
+};
+
+class BlockingFailOnceMetadataStoragePlugin : public MetadataStoragePlugin {
+   public:
+    bool get(const std::string&, Json::Value& value) override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        value = last_successful_value;
+        return has_successful_value;
+    }
+
+    bool set(const std::string&, const Json::Value& value) override {
+        std::unique_lock<std::mutex> lock(mutex_);
+        ++set_calls;
+        last_attempted_value = value;
+        if (block_and_fail_next_set_) {
+            block_and_fail_next_set_ = false;
+            blocked_ = true;
+            condition_.notify_all();
+            condition_.wait(lock, [this] { return release_blocked_set_; });
+            release_blocked_set_ = false;
+            return false;
+        }
+        last_successful_value = value;
+        has_successful_value = true;
+        return true;
+    }
+
+    bool remove(const std::string&) override { return true; }
+
+    void BlockAndFailNextSet() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        block_and_fail_next_set_ = true;
+        blocked_ = false;
+    }
+
+    void WaitUntilSetIsBlocked() {
+        std::unique_lock<std::mutex> lock(mutex_);
+        condition_.wait(lock, [this] { return blocked_; });
+    }
+
+    void ReleaseBlockedSet() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        release_blocked_set_ = true;
+        condition_.notify_all();
+    }
+
+    int SetCalls() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return set_calls;
+    }
+
+    Json::Value LastSuccessfulValue() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return last_successful_value;
+    }
+
+   private:
+    mutable std::mutex mutex_;
+    std::condition_variable condition_;
+    int set_calls = 0;
+    bool block_and_fail_next_set_ = false;
+    bool blocked_ = false;
+    bool release_blocked_set_ = false;
+    bool has_successful_value = false;
+    Json::Value last_attempted_value;
+    Json::Value last_successful_value;
+};
+
+template <typename T>
+concept HasMemoryKind = requires(T value) { value.memory_kind; };
+template <typename T>
+concept HasNumaNode = requires(T value) { value.numa_node; };
+template <typename T>
+concept HasFabricDomain = requires(T value) { value.fabric_domain_id; };
+template <typename T>
+concept HasGeneration = requires(T value) { value.generation; };
+
+static_assert(!HasMemoryKind<TransferMetadata::SegmentDesc>);
+static_assert(!HasNumaNode<TransferMetadata::SegmentDesc>);
+static_assert(!HasFabricDomain<TransferMetadata::SegmentDesc>);
+static_assert(!HasGeneration<TransferMetadata::SegmentDesc>);
+static_assert(!HasMemoryKind<TransferMetadata::BufferDesc>);
+static_assert(!HasNumaNode<TransferMetadata::BufferDesc>);
+static_assert(!HasFabricDomain<TransferMetadata::BufferDesc>);
+static_assert(!HasGeneration<TransferMetadata::BufferDesc>);
+
+TEST(TransferMetadataSchemaTest, NvlinkDescriptorMatchesV1GoldenJson) {
+    TransferMetadata metadata(P2PHANDSHAKE);
+    // Freeze the NVLink JSON contract inherited from the current origin/main.
+    // Compare parsed values so key order and whitespace do not become an
+    // accidental ABI.
+    TransferMetadata::SegmentDesc descriptor{};
+    descriptor.name = "provider:12345";
+    descriptor.protocol = "nvlink";
+    descriptor.tcp_data_port = 0;
+    descriptor.tcp_proto_version = 1;
+
+    TransferMetadata::BufferDesc buffer{};
+    buffer.name = descriptor.name;
+    buffer.addr = 0x100000000ULL;
+    buffer.length = 0x20000ULL;
+    buffer.shm_name = "fabric-handle-v1";
+    descriptor.buffers.push_back(buffer);
+
+    Json::Value encoded;
+    ASSERT_EQ(TransferMetadataTestPeer::EncodeSegmentDesc(metadata, descriptor,
+                                                          encoded),
+              0);
+    ASSERT_TRUE(encoded.isMember("timestamp"));
+    ASSERT_TRUE(encoded["timestamp"].isString());
+    ASSERT_FALSE(encoded["timestamp"].asString().empty());
+    encoded["timestamp"] = "<timestamp>";
+
+    Json::Value expected;
+    expected["name"] = descriptor.name;
+    expected["protocol"] = descriptor.protocol;
+    expected["tcp_data_port"] = descriptor.tcp_data_port;
+    expected["tcp_proto_version"] = descriptor.tcp_proto_version;
+    expected["timestamp"] = "<timestamp>";
+    Json::Value expected_buffers(Json::arrayValue);
+    Json::Value expected_buffer;
+    expected_buffer["name"] = buffer.name;
+    expected_buffer["addr"] = static_cast<Json::UInt64>(buffer.addr);
+    expected_buffer["length"] = static_cast<Json::UInt64>(buffer.length);
+    expected_buffer["shm_name"] = buffer.shm_name;
+    expected_buffers.append(expected_buffer);
+    expected["buffers"] = expected_buffers;
+
+    EXPECT_EQ(encoded, expected)
+        << "NVLink SegmentDesc wire fields changed from the V1 golden schema";
+    for (const char* forbidden :
+         {"memory_kind", "numa_node", "fabric_domain_id", "generation"}) {
+        EXPECT_FALSE(encoded.isMember(forbidden));
+        EXPECT_FALSE(encoded["buffers"][0].isMember(forbidden));
+    }
+
+    Json::Value baseline_golden = expected;
+    auto decoded = TransferMetadataTestPeer::DecodeSegmentDesc(
+        metadata, baseline_golden, descriptor.name);
+    ASSERT_NE(decoded, nullptr);
+    EXPECT_EQ(decoded->name, descriptor.name);
+    EXPECT_EQ(decoded->protocol, descriptor.protocol);
+    EXPECT_EQ(decoded->tcp_data_port, descriptor.tcp_data_port);
+    EXPECT_EQ(decoded->tcp_proto_version, descriptor.tcp_proto_version);
+    ASSERT_EQ(decoded->buffers.size(), 1U);
+    EXPECT_EQ(decoded->buffers[0].name, buffer.name);
+    EXPECT_EQ(decoded->buffers[0].addr, buffer.addr);
+    EXPECT_EQ(decoded->buffers[0].length, buffer.length);
+    EXPECT_EQ(decoded->buffers[0].shm_name, buffer.shm_name);
+
+    Json::Value reencoded;
+    ASSERT_EQ(TransferMetadataTestPeer::EncodeSegmentDesc(metadata, *decoded,
+                                                          reencoded),
+              0);
+    ASSERT_TRUE(reencoded.isMember("timestamp"));
+    ASSERT_TRUE(reencoded["timestamp"].isString());
+    ASSERT_FALSE(reencoded["timestamp"].asString().empty());
+    reencoded["timestamp"] = "<timestamp>";
+    EXPECT_EQ(reencoded, expected);
+}
+
+TEST(TransferMetadataRemovalTest,
+     FailedRemoteUpdateRestoresLocalDescriptorForRetry) {
+    TransferMetadata metadata(P2PHANDSHAKE);
+    auto storage = std::make_shared<FailOnceMetadataStoragePlugin>();
+    TransferMetadataTestPeer::SetStoragePlugin(metadata, storage);
+
+    auto segment = std::make_shared<TransferMetadata::SegmentDesc>();
+    segment->name = "provider:12345";
+    segment->protocol = "nvlink";
+    TransferMetadata::BufferDesc buffer{};
+    buffer.name = segment->name;
+    buffer.addr = 0x100000000ULL;
+    buffer.length = 0x20000ULL;
+    buffer.shm_name = "fabric-handle-v1";
+    segment->buffers.push_back(buffer);
+    auto original_segment = segment;
+    ASSERT_EQ(metadata.addLocalSegment(LOCAL_SEGMENT_ID, segment->name,
+                                       std::move(segment)),
+              0);
+
+    ASSERT_EQ(metadata.updateLocalSegmentDesc(), 0);
+    ASSERT_TRUE(storage->has_successful_value);
+    ASSERT_EQ(storage->last_successful_value["buffers"].size(), 1U);
+
+    storage->fail_next_set = true;
+    EXPECT_EQ(metadata.removeLocalMemoryBuffer(
+                  reinterpret_cast<void*>(buffer.addr), true),
+              ERR_METADATA);
+    EXPECT_EQ(storage->set_calls, 2);
+    EXPECT_EQ(storage->last_attempted_value["buffers"].size(), 0U);
+    EXPECT_EQ(storage->last_successful_value["buffers"].size(), 1U);
+
+    auto local = metadata.getSegmentDescByID(LOCAL_SEGMENT_ID);
+    ASSERT_NE(local, nullptr);
+    EXPECT_EQ(local, original_segment)
+        << "failed deletion must restore the previous descriptor snapshot";
+    ASSERT_EQ(local->buffers.size(), 1U);
+    EXPECT_EQ(local->buffers[0].addr, buffer.addr)
+        << "failed deletion must remain retryable in the local descriptor";
+
+    EXPECT_EQ(metadata.removeLocalMemoryBuffer(
+                  reinterpret_cast<void*>(buffer.addr), true),
+              0);
+    EXPECT_EQ(storage->set_calls, 3);
+    EXPECT_EQ(storage->last_successful_value["buffers"].size(), 0U);
+    local = metadata.getSegmentDescByID(LOCAL_SEGMENT_ID);
+    ASSERT_NE(local, nullptr);
+    EXPECT_TRUE(local->buffers.empty());
+}
+
+TEST(TransferMetadataRemovalTest,
+     FailedRemoteUpdateSerializesConcurrentCowMutationAndRetry) {
+    using namespace std::chrono_literals;
+
+    TransferMetadata metadata(P2PHANDSHAKE);
+    auto storage = std::make_shared<BlockingFailOnceMetadataStoragePlugin>();
+    TransferMetadataTestPeer::SetStoragePlugin(metadata, storage);
+
+    auto segment = std::make_shared<TransferMetadata::SegmentDesc>();
+    segment->name = "provider:concurrent";
+    segment->protocol = "nvlink";
+    TransferMetadata::BufferDesc first{};
+    first.name = segment->name;
+    first.addr = 0x100000000ULL;
+    first.length = 0x20000ULL;
+    first.shm_name = "fabric-handle-first";
+    segment->buffers.push_back(first);
+    ASSERT_EQ(metadata.addLocalSegment(LOCAL_SEGMENT_ID, segment->name,
+                                       std::move(segment)),
+              0);
+    ASSERT_EQ(metadata.updateLocalSegmentDesc(), 0);
+
+    TransferMetadata::BufferDesc second{};
+    second.name = first.name;
+    second.addr = 0x200000000ULL;
+    second.length = 0x40000ULL;
+    second.shm_name = "fabric-handle-second";
+
+    storage->BlockAndFailNextSet();
+    auto remove = std::async(std::launch::async, [&] {
+        return metadata.removeLocalMemoryBuffer(
+            reinterpret_cast<void*>(first.addr), true);
+    });
+    storage->WaitUntilSetIsBlocked();
+
+    std::promise<void> add_started_promise;
+    auto add_started = add_started_promise.get_future();
+    auto add = std::async(std::launch::async, [&] {
+        add_started_promise.set_value();
+        return metadata.addLocalMemoryBuffer(second, false);
+    });
+    add_started.wait();
+    EXPECT_EQ(add.wait_for(50ms), std::future_status::timeout)
+        << "concurrent COW mutation must wait for removal publication/rollback";
+
+    storage->ReleaseBlockedSet();
+    EXPECT_EQ(remove.get(), ERR_METADATA);
+    EXPECT_EQ(add.get(), 0);
+
+    auto local = metadata.getSegmentDescByID(LOCAL_SEGMENT_ID);
+    ASSERT_NE(local, nullptr);
+    ASSERT_EQ(local->buffers.size(), 2U);
+    EXPECT_EQ(local->buffers[0].addr, first.addr);
+    EXPECT_EQ(local->buffers[1].addr, second.addr);
+
+    EXPECT_EQ(metadata.removeLocalMemoryBuffer(
+                  reinterpret_cast<void*>(first.addr), true),
+              0);
+    EXPECT_EQ(storage->SetCalls(), 3);
+    Json::Value published = storage->LastSuccessfulValue();
+    ASSERT_EQ(published["buffers"].size(), 1U);
+    EXPECT_EQ(published["buffers"][0]["addr"].asUInt64(), second.addr);
+
+    local = metadata.getSegmentDescByID(LOCAL_SEGMENT_ID);
+    ASSERT_NE(local, nullptr);
+    ASSERT_EQ(local->buffers.size(), 1U);
+    EXPECT_EQ(local->buffers[0].addr, second.addr);
+}
+
+TEST(TransferTaskSubmissionFailureTest, ZeroSliceFailureIsExplicitlyTerminal) {
+    Transport::BatchDesc batch;
+    batch.batch_size = 1;
+    batch.id = reinterpret_cast<Transport::BatchID>(&batch);
+    batch.task_list.resize(1);
+    auto& task = batch.task_list.front();
+    task.batch_id = batch.id;
+
+    Transport::markSubmissionFailed(task);
+    Transport::markSubmissionFailed(task);
+
+    EXPECT_TRUE(task.submission_failed);
+    EXPECT_TRUE(task.is_finished);
+    EXPECT_EQ(task.slice_count, 0);
+    EXPECT_TRUE(batch.has_failure.load());
+#ifdef USE_EVENT_DRIVEN_COMPLETION
+    EXPECT_TRUE(batch.is_finished.load());
+    EXPECT_EQ(batch.finished_task_count.load(), 1);
+#endif
+}
 
 class TransferMetadataTest : public ::testing::Test {
    protected:

--- a/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
+++ b/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
@@ -243,6 +243,128 @@ TEST(TransferMetadataSchemaTest, NvlinkDescriptorMatchesV1GoldenJson) {
     EXPECT_EQ(reencoded, expected);
 }
 
+TEST(TransferMetadataAdditionTest,
+     FailedRemoteUpdateRestoresLocalDescriptorForRetry) {
+    TransferMetadata metadata(P2PHANDSHAKE);
+    auto storage = std::make_shared<FailOnceMetadataStoragePlugin>();
+    TransferMetadataTestPeer::SetStoragePlugin(metadata, storage);
+
+    auto segment = std::make_shared<TransferMetadata::SegmentDesc>();
+    segment->name = "provider:add-retry";
+    segment->protocol = "nvlink";
+    auto original_segment = segment;
+    ASSERT_EQ(metadata.addLocalSegment(LOCAL_SEGMENT_ID, segment->name,
+                                       std::move(segment)),
+              0);
+    ASSERT_EQ(metadata.updateLocalSegmentDesc(), 0);
+    ASSERT_TRUE(storage->has_successful_value);
+    ASSERT_EQ(storage->last_successful_value["buffers"].size(), 0U);
+
+    TransferMetadata::BufferDesc buffer{};
+    buffer.name = original_segment->name;
+    buffer.addr = 0x100000000ULL;
+    buffer.length = 0x20000ULL;
+    buffer.shm_name = "fabric-handle-add-retry";
+
+    storage->fail_next_set = true;
+    EXPECT_EQ(metadata.addLocalMemoryBuffer(buffer, true), ERR_METADATA);
+    EXPECT_EQ(storage->set_calls, 2);
+    EXPECT_EQ(storage->last_attempted_value["buffers"].size(), 1U);
+    EXPECT_EQ(storage->last_successful_value["buffers"].size(), 0U);
+
+    auto local = metadata.getSegmentDescByID(LOCAL_SEGMENT_ID);
+    ASSERT_NE(local, nullptr);
+    EXPECT_EQ(local, original_segment)
+        << "failed addition must restore the previous descriptor snapshot";
+    EXPECT_TRUE(local->buffers.empty());
+
+    EXPECT_EQ(metadata.addLocalMemoryBuffer(buffer, true), 0);
+    EXPECT_EQ(storage->set_calls, 3);
+    ASSERT_EQ(storage->last_successful_value["buffers"].size(), 1U);
+    EXPECT_EQ(storage->last_successful_value["buffers"][0]["addr"].asUInt64(),
+              buffer.addr);
+    local = metadata.getSegmentDescByID(LOCAL_SEGMENT_ID);
+    ASSERT_NE(local, nullptr);
+    ASSERT_EQ(local->buffers.size(), 1U);
+    EXPECT_EQ(local->buffers[0].addr, buffer.addr);
+}
+
+TEST(TransferMetadataAdditionTest,
+     FailedRemoteUpdateSerializesConcurrentCowMutationAndRetry) {
+    using namespace std::chrono_literals;
+
+    TransferMetadata metadata(P2PHANDSHAKE);
+    auto storage = std::make_shared<BlockingFailOnceMetadataStoragePlugin>();
+    TransferMetadataTestPeer::SetStoragePlugin(metadata, storage);
+
+    auto segment = std::make_shared<TransferMetadata::SegmentDesc>();
+    segment->name = "provider:add-concurrent";
+    segment->protocol = "nvlink";
+    TransferMetadata::BufferDesc first{};
+    first.name = segment->name;
+    first.addr = 0x100000000ULL;
+    first.length = 0x20000ULL;
+    first.shm_name = "fabric-handle-first";
+    segment->buffers.push_back(first);
+    ASSERT_EQ(metadata.addLocalSegment(LOCAL_SEGMENT_ID, segment->name,
+                                       std::move(segment)),
+              0);
+    ASSERT_EQ(metadata.updateLocalSegmentDesc(), 0);
+
+    TransferMetadata::BufferDesc second{};
+    second.name = first.name;
+    second.addr = 0x200000000ULL;
+    second.length = 0x40000ULL;
+    second.shm_name = "fabric-handle-second";
+    TransferMetadata::BufferDesc third{};
+    third.name = first.name;
+    third.addr = 0x300000000ULL;
+    third.length = 0x60000ULL;
+    third.shm_name = "fabric-handle-third";
+
+    storage->BlockAndFailNextSet();
+    auto failed_add = std::async(std::launch::async, [&] {
+        return metadata.addLocalMemoryBuffer(second, true);
+    });
+    storage->WaitUntilSetIsBlocked();
+
+    std::promise<void> concurrent_add_started_promise;
+    auto concurrent_add_started = concurrent_add_started_promise.get_future();
+    auto concurrent_add = std::async(std::launch::async, [&] {
+        concurrent_add_started_promise.set_value();
+        return metadata.addLocalMemoryBuffer(third, false);
+    });
+    concurrent_add_started.wait();
+    EXPECT_EQ(concurrent_add.wait_for(50ms), std::future_status::timeout)
+        << "concurrent COW mutation must wait for addition "
+           "publication/rollback";
+
+    storage->ReleaseBlockedSet();
+    EXPECT_EQ(failed_add.get(), ERR_METADATA);
+    EXPECT_EQ(concurrent_add.get(), 0);
+
+    auto local = metadata.getSegmentDescByID(LOCAL_SEGMENT_ID);
+    ASSERT_NE(local, nullptr);
+    ASSERT_EQ(local->buffers.size(), 2U);
+    EXPECT_EQ(local->buffers[0].addr, first.addr);
+    EXPECT_EQ(local->buffers[1].addr, third.addr);
+
+    EXPECT_EQ(metadata.addLocalMemoryBuffer(second, true), 0);
+    EXPECT_EQ(storage->SetCalls(), 3);
+    Json::Value published = storage->LastSuccessfulValue();
+    ASSERT_EQ(published["buffers"].size(), 3U);
+    EXPECT_EQ(published["buffers"][0]["addr"].asUInt64(), first.addr);
+    EXPECT_EQ(published["buffers"][1]["addr"].asUInt64(), third.addr);
+    EXPECT_EQ(published["buffers"][2]["addr"].asUInt64(), second.addr);
+
+    local = metadata.getSegmentDescByID(LOCAL_SEGMENT_ID);
+    ASSERT_NE(local, nullptr);
+    ASSERT_EQ(local->buffers.size(), 3U);
+    EXPECT_EQ(local->buffers[0].addr, first.addr);
+    EXPECT_EQ(local->buffers[1].addr, third.addr);
+    EXPECT_EQ(local->buffers[2].addr, second.addr);
+}
+
 TEST(TransferMetadataRemovalTest,
      FailedRemoteUpdateRestoresLocalDescriptorForRetry) {
     TransferMetadata metadata(P2PHANDSHAKE);


### PR DESCRIPTION
## Description

Adds the Transfer Engine primitives required to own, publish, import, and
clean up CUDA VMM allocations over legacy `NvlinkTransport`.

- Introduces `NvlinkVmmAllocation` for DEVICE and CUDA HOST_NUMA allocation
  locations, with Fabric capability checks and explicit ownership.
- Validates Mooncake-owned ranges by exact base/length provenance and retains
  the CUDA allocation handle directly; external registrations still require a
  successful CUDA range query.
- Makes Provider publication transactional and retryable, and isolates failed
  Consumer import/map cleanup without recycling a potentially published VA.
- Adds transport readiness/metrics aggregation and label-based unit, hardware,
  and RDMA smoke tests.
- Does not add a protocol or change the Transfer Engine wire schema.

Related RFC: [#2914](https://github.com/kvcache-ai/Mooncake/issues/2914)

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [x] CI/CD

## Type of Change

- [x] New feature
- [x] Refactor

## How Has This Been Tested?

**Test commands:**

```bash
cmake -S . -B /build -G Ninja \
  -DUSE_HTTP=ON -DUSE_CUDA=ON -DUSE_MNNVL=ON \
  -DUSE_EVENT_DRIVEN_COMPLETION=ON -DWITH_EP=OFF \
  -DWITH_STORE_RUST=OFF -DBUILD_UNIT_TESTS=ON \
  -DCMAKE_BUILD_TYPE=Release
cmake --build /build -j2
ctest --test-dir /build -L nvlink_vmm_unit --output-on-failure

cmake -S . -B /build-off -G Ninja \
  -DUSE_HTTP=ON -DUSE_CUDA=OFF -DUSE_MNNVL=OFF \
  -DUSE_EVENT_DRIVEN_COMPLETION=ON -DWITH_EP=OFF \
  -DWITH_STORE_RUST=OFF -DBUILD_UNIT_TESTS=ON \
  -DCMAKE_BUILD_TYPE=Release
cmake --build /build-off -j2
ctest --test-dir /build-off -L nvlink_vmm_unit --output-on-failure

PATH=<clang-format-20-env>:$PATH \
  pre-commit run --from-ref origin/main --to-ref HEAD
git diff --check
```

**Test results:**

- [x] ARM64 CUDA/MNNVL build passed.
- [x] `nvlink_vmm_unit`: 4/4 passed with CUDA/MNNVL enabled.
- [x] Ordinary CUDA/MNNVL-off build passed; `nvlink_vmm_unit`: 1/1 passed.
- [x] PR-scoped pre-commit hooks and `git diff --check` passed.
- [x] The earlier development branch completed a dual-node GB200 data-plane
  PASS that exercised Provider Fabric publication, Consumer lazy import, and
  mapping reuse.
- [x] The GB200 run was executed against the development-branch revision
  reported as `6dd6331ea3ced193b05b8aad28f2fe70e19ed6f3` and is used as the
  hardware data-plane evidence for this PR.

### GB200/NVL72 data-plane results

Run `gb200-0714-2` used a dual-node Provider/Consumer topology.

| Validation item | Observed result | Status |
|---|---:|:---:|
| Provider EGM capacity | 600 MiB requested; 592 MiB effective | PASS |
| Fabric publication | 5 chunks; effective capacity matched Master | PASS |
| Standalone correctness | GPU 0, 128 MiB, 4 iterations, SHA256 verified | PASS |
| Concurrent correctness | 4 GPUs x 4 payload sizes x 4 iterations = 64 results | PASS |
| Payload range | 4 KiB, 1 MiB, 16 MiB, and 128 MiB | PASS |
| Lazy mapping lifecycle | First access miss/import followed by mapping hits | PASS |
| Peak live data | 512 MiB across 4 keys, followed by 0 B / 0 keys | PASS |
| Selected transport | `NvlinkTransport` with `cudaMemcpyBatchAsync` | PASS |

The throughput comparison uses 50 GiB/s as the expected single-GPU RDMA
ceiling. It is a reference line rather than an RDMA measurement from this run.

| Payload | NVLink cold/mixed Put mean | NVLink warm Put mean | NVLink warm Get mean | RDMA single-GPU reference | Result versus RDMA reference |
|---:|---:|---:|---:|---:|---|
| 4 KiB | 0.0046 GiB/s | 0.0167 GiB/s | 0.0260 GiB/s | 50 GiB/s | Latency-bound |
| 1 MiB | 0.7790 GiB/s | 3.3498 GiB/s | 5.7235 GiB/s | 50 GiB/s | Payload still too small to expose link ceiling |
| 16 MiB | 12.7487 GiB/s | 37.1024 GiB/s | 63.4150 GiB/s | 50 GiB/s | Warm Get reaches 1.27x |
| 128 MiB | 51.3996 GiB/s | 90.7113 GiB/s | 147.1797 GiB/s | 50 GiB/s | Put 1.03x, warm Put 1.81x, warm Get 2.94x |

NVLink/NVLink-C2C has a higher theoretical transport ceiling than the
single-GPU RDMA reference. At 128 MiB, fixed costs are sufficiently amortized
and all three measured transfer categories exceed 50 GiB/s, demonstrating
that the observed EGM data-path ceiling is already above the expected RDMA
single-GPU limit.

`pre-commit run --all-files` was attempted. It emitted roughly 49,000 lines of
diff output from unrelated files on the current `origin/main` baseline, so
those unrelated changes were discarded per `AGENTS.md`; the PR-scoped hook run
above passes.

## Checklist

- [ ] I have performed a self-review of every changed line
- [x] I have formatted the changed code using the repository format hooks
- [ ] I have run `pre-commit run --all-files` and all hooks pass (blocked by
  unrelated upstream-baseline rewrites; PR-scoped hooks pass)
- [x] I have added tests to prove the changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [x] AI tools were used

Codex assisted with the upstream replay, conflict resolution, implementation
cleanup, tests, and PR preparation. The human submitter remains responsible
for reviewing, understanding, and defending every changed line.
