### PR TITLE
[store] fix SPDK client buffer teardown

### DIFF
--- a/mooncake-store/include/utils.h
+++ b/mooncake-store/include/utils.h
@@ -461,7 +461,8 @@ void* allocate_buffer_numa_segments(size_t total_size,
                                     const std::vector<int>& numa_nodes,
                                     size_t page_size = 0);
 
-void free_memory(const std::string& protocol, void* ptr);
+void free_memory(const std::string& protocol, void* ptr,
+                 bool use_spdk_dma = false);
 
 // Network utility functions
 

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -258,6 +258,7 @@ if(USE_NOF)
       crypto
       aio
       z
+      isal
       elf
       ibverbs
       rdmacm

--- a/mooncake-store/src/client_buffer.cpp
+++ b/mooncake-store/src/client_buffer.cpp
@@ -80,7 +80,7 @@ ClientBufferAllocator::~ClientBufferAllocator() {
         if (use_hugepage_) {
             free_buffer_mmap_memory(buffer_, buffer_size_);
         } else {
-            free_memory(protocol, buffer_);
+            free_memory(protocol, buffer_, use_spdk_dma_);
         }
     }
 }

--- a/mooncake-store/src/utils.cpp
+++ b/mooncake-store/src/utils.cpp
@@ -528,7 +528,7 @@ void *allocate_buffer_numa_segments(size_t total_size,
     return ptr;
 }
 
-void free_memory(const std::string &protocol, void *ptr) {
+void free_memory(const std::string &protocol, void *ptr, bool use_spdk_dma) {
 #if defined(USE_ASCEND_DIRECT) || defined(USE_UBSHMEM)
     if (protocol == "ascend" || protocol == "ubshmem") {
         return ascend_free_memory(protocol, ptr);
@@ -542,6 +542,15 @@ void free_memory(const std::string &protocol, void *ptr) {
 #if defined(USE_UB)
     if (protocol == "ub") {
         mooncake::ub_free_memory(ptr);
+        return;
+    }
+#endif
+#ifdef USE_NOF
+    // Mirror allocate_buffer_allocator_memory(): a buffer taken from the SPDK
+    // hugepage pool (spdk_zmalloc) must be released with spdk_free, not glibc
+    // free(), which would abort with "free(): invalid pointer".
+    if (use_spdk_dma) {
+        mooncake::SpdkWrapper::GetInstance().Free(ptr);
         return;
     }
 #endif

--- a/mooncake-store/tests/client_buffer_test.cpp
+++ b/mooncake-store/tests/client_buffer_test.cpp
@@ -7,6 +7,7 @@
 #include <atomic>
 #include <cstddef>
 #include <cstring>
+#include <new>
 #include <thread>
 #include <vector>
 
@@ -58,6 +59,35 @@ TEST_F(ClientBufferTest, ZeroSizeAllocator) {
     auto handle_opt = allocator->allocate(1024);
     EXPECT_FALSE(handle_opt.has_value());
 }
+
+#if defined(USE_NOF)
+TEST_F(ClientBufferTest, SpdkDmaAllocatorDestroysWithSpdkFree) {
+    constexpr size_t buffer_size = 4096;
+    constexpr size_t alloc_size = 64;
+
+    std::shared_ptr<ClientBufferAllocator> allocator;
+    try {
+        allocator = ClientBufferAllocator::create(
+            buffer_size, "tcp", /*use_hugepage=*/false,
+            /*use_spdk_dma=*/true);
+    } catch (const std::bad_alloc&) {
+        GTEST_SKIP()
+            << "SPDK DMA allocation is unavailable in this environment";
+    }
+
+    ASSERT_NE(allocator, nullptr);
+    VerifyAlignment(allocator->getBase());
+
+    {
+        auto handle_opt = allocator->allocate(alloc_size);
+        ASSERT_TRUE(handle_opt.has_value());
+        BufferHandle handle = std::move(handle_opt.value());
+        VerifyBufferHandle(handle, alloc_size);
+    }
+
+    allocator.reset();
+}
+#endif
 
 // Test multiple allocations
 TEST_F(ClientBufferTest, MultipleAllocations) {


### PR DESCRIPTION
## Description

Fixes https://github.com/kvcache-ai/Mooncake/issues/2913.

When `USE_NOF=ON`, `ClientBufferAllocator` may allocate its local buffer through SPDK DMA memory (`spdk_zmalloc`). The allocator destructor previously released that buffer through the generic `free_memory()` path, which could call glibc `free()` and trigger `free(): invalid pointer` on shutdown.

This PR:
- frees SPDK DMA client buffers with `spdk_free()`;
- adds a regression test covering SPDK DMA allocator teardown;
- links ISA-L for NOF/SPDK static builds, which is required by SPDK utility symbols such as `crc32_iscsi` and `crc16_t10dif`.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
cmake -S . -B $mooncake_dir \
  -DCMAKE_BUILD_TYPE=Release \
  -DBUILD_UNIT_TESTS=ON \
  -DBUILD_EXAMPLES=OFF \
  -DBUILD_BENCHMARK=OFF \
  -DWITH_STORE=ON \
  -DWITH_TE=ON \
  -DWITH_STORE_RUST=OFF \
  -DWITH_EP=OFF \
  -DUSE_NOF=ON \
  -DSTORE_USE_ETCD=OFF

./mooncake-store/tests/client_buffer_test \
  --gtest_filter=ClientBufferTest.SpdkDmaAllocatorDestroysWithSpdkFree \
  --gtest_color=no

ctest -R client_buffer_test --output-on-failure