### PR TITLE
[transport/nvmeof] surface terminal slice failures

### DIFF
--- a/mooncake-transfer-engine/include/transport/nvmeof_transport/cufile_desc_pool.h
+++ b/mooncake-transfer-engine/include/transport/nvmeof_transport/cufile_desc_pool.h
@@ -74,6 +74,12 @@ class CUFileDescPool {
     // Get transfer status for a specific slice
     CUfileIOEvents_t getTransferStatus(int idx, int slice_id);
 
+    // Poll cuFile once for the batch and update cached completion events.
+    bool updateBatchStatus(int idx);
+
+    // Get cached transfer status for a specific slice.
+    CUfileIOEvents_t getCachedTransferStatus(int idx, int slice_id);
+
     // Best-effort cancellation for a submitted batch.
     bool cancelBatch(int idx);
 
@@ -92,8 +98,14 @@ class CUFileDescPool {
    private:
     static bool cachePolledEvent(std::vector<CUfileIOEvents_t>& io_events,
                                  const CUfileIOEvents_t& event);
+    static bool isTerminalStatus(CUfileStatus_t status);
+    static CUfileIOEvents_t failedEvent();
+    static void destroyDesc(CUFileBatchDesc* desc);
+    static bool updateBatchStatus(CUFileBatchDesc* desc, int idx);
 
     static const size_t MAX_NR_DESC = 256;  // Max number of descriptors
+    void cleanupQuarantinedDescs();
+
     size_t max_batch_size_;
 
     // Object pool for BatchHandle to avoid frequent cuFileBatchIOSetUp/Destroy

--- a/mooncake-transfer-engine/include/transport/nvmeof_transport/cufile_desc_pool.h
+++ b/mooncake-transfer-engine/include/transport/nvmeof_transport/cufile_desc_pool.h
@@ -47,6 +47,7 @@ struct CUFileBatchDesc {
     // so its output cannot be treated as a positional status snapshot.
     std::vector<CUfileIOEvents_t> io_events;
     std::vector<CUfileIOEvents_t> polled_events;
+    bool reusable = true;
 };
 
 class CUFileDescPool {
@@ -73,6 +74,12 @@ class CUFileDescPool {
     // Get transfer status for a specific slice
     CUfileIOEvents_t getTransferStatus(int idx, int slice_id);
 
+    // Best-effort cancellation for a submitted batch.
+    bool cancelBatch(int idx);
+
+    // Prevent an unsafe batch handle from being returned to the reusable pool.
+    void markUnreusable(int idx);
+
     // Get current number of slices in the descriptor
     int getSliceNum(int idx);
 
@@ -92,6 +99,8 @@ class CUFileDescPool {
     // Object pool for BatchHandle to avoid frequent cuFileBatchIOSetUp/Destroy
     std::vector<BatchHandle*> handle_pool_;
     std::mutex handle_pool_lock_;
+
+    std::vector<CUFileBatchDesc*> quarantined_descs_;
 
     // Array of descriptors (nullptr = free slot)
     CUFileBatchDesc* descs_[MAX_NR_DESC];

--- a/mooncake-transfer-engine/include/transport/nvmeof_transport/nvmeof_transport.h
+++ b/mooncake-transfer-engine/include/transport/nvmeof_transport/nvmeof_transport.h
@@ -69,6 +69,11 @@ class NVMeoFTransport : public Transport {
     static TransferStatus aggregateTransferStatus(
         const std::vector<TransferStatus> &slice_statuses, bool &is_finished);
 
+    void collectSliceStatuses(int desc_idx, size_t slice_id, size_t slice_num,
+                              std::vector<TransferStatus> &slice_statuses);
+
+    static bool isTerminalFailure(TransferStatusEnum status);
+
     void startTransfer(Slice *slice);
 
    private:

--- a/mooncake-transfer-engine/src/transport/nvmeof_transport/cufile_desc_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/nvmeof_transport/cufile_desc_pool.cpp
@@ -33,16 +33,10 @@ CUFileDescPool::CUFileDescPool(size_t max_batch_size)
 }
 
 CUFileDescPool::~CUFileDescPool() {
-    auto destroy_desc = [](CUFileBatchDesc* desc) {
-        cuFileBatchIODestroy(desc->batch_handle->handle);
-        delete desc->batch_handle;
-        delete desc;
-    };
-
     // First, collect and destroy batch_handles from allocated descriptors
     for (size_t i = 0; i < MAX_NR_DESC; ++i) {
         if (descs_[i] != nullptr) {
-            destroy_desc(descs_[i]);
+            destroyDesc(descs_[i]);
             descs_[i] = nullptr;
         }
     }
@@ -55,7 +49,7 @@ CUFileDescPool::~CUFileDescPool() {
     }
     handle_pool_.clear();
     for (auto* desc : quarantined_descs_) {
-        destroy_desc(desc);
+        destroyDesc(desc);
     }
     quarantined_descs_.clear();
 }
@@ -180,35 +174,54 @@ int CUFileDescPool::submitBatch(int idx) {
 }
 
 CUfileIOEvents_t CUFileDescPool::getTransferStatus(int idx, int slice_id) {
+    if (!updateBatchStatus(idx)) {
+        return failedEvent();
+    }
+    return getCachedTransferStatus(idx, slice_id);
+}
+
+bool CUFileDescPool::updateBatchStatus(int idx) {
     RWSpinlock::WriteGuard guard(mutex_);
     if (idx < 0 || idx >= (int)MAX_NR_DESC || descs_[idx] == nullptr) {
         LOG(ERROR) << "Invalid descriptor index: " << idx;
-        CUfileIOEvents_t event;
-        event.status = CUFILE_FAILED;
-        event.ret = -1;
-        return event;
+        return false;
+    }
+
+    return updateBatchStatus(descs_[idx], idx);
+}
+
+CUfileIOEvents_t CUFileDescPool::getCachedTransferStatus(int idx,
+                                                         int slice_id) {
+    RWSpinlock::ReadGuard guard(mutex_);
+    if (idx < 0 || idx >= (int)MAX_NR_DESC || descs_[idx] == nullptr) {
+        LOG(ERROR) << "Invalid descriptor index: " << idx;
+        return failedEvent();
     }
 
     auto* desc = descs_[idx];
     if (slice_id < 0 || slice_id >= (int)desc->io_params.size()) {
         LOG(ERROR) << "Invalid slice_id " << slice_id << " for descriptor "
                    << idx << " (size: " << desc->io_params.size() << ")";
-        CUfileIOEvents_t event;
-        event.status = CUFILE_FAILED;
-        event.ret = -1;
-        return event;
+        return failedEvent();
     }
 
+    return desc->io_events[slice_id];
+}
+
+bool CUFileDescPool::updateBatchStatus(CUFileBatchDesc* desc, int idx) {
     unsigned nr = desc->io_params.size();
     if (desc->polled_events.size() < nr) {
         LOG(ERROR) << "Completion buffer is too small for descriptor " << idx;
-        CUfileIOEvents_t event;
-        event.status = CUFILE_FAILED;
-        event.ret = -1;
-        return event;
+        return false;
     }
-    CUFILE_CHECK(cuFileBatchIOGetStatus(desc->batch_handle->handle, 0, &nr,
-                                        desc->polled_events.data(), nullptr));
+
+    CUfileError_t rc = cuFileBatchIOGetStatus(
+        desc->batch_handle->handle, 0, &nr, desc->polled_events.data(), nullptr);
+    if (rc.err != CU_FILE_SUCCESS) {
+        LOG(WARNING) << "cuFileBatchIOGetStatus failed for descriptor " << idx
+                     << ": " << cuFileGetErrorString(rc);
+        return false;
+    }
 
     for (unsigned i = 0; i < nr; ++i) {
         const auto& event = desc->polled_events[i];
@@ -219,7 +232,7 @@ CUfileIOEvents_t CUFileDescPool::getTransferStatus(int idx, int slice_id) {
         }
     }
 
-    return desc->io_events[slice_id];
+    return true;
 }
 
 bool CUFileDescPool::cachePolledEvent(std::vector<CUfileIOEvents_t>& io_events,
@@ -228,6 +241,46 @@ bool CUFileDescPool::cachePolledEvent(std::vector<CUfileIOEvents_t>& io_events,
     if (cookie == 0 || cookie > io_events.size()) return false;
     io_events[cookie - 1] = event;
     return true;
+}
+
+bool CUFileDescPool::isTerminalStatus(CUfileStatus_t status) {
+    return status != CUFILE_WAITING && status != CUFILE_PENDING;
+}
+
+CUfileIOEvents_t CUFileDescPool::failedEvent() {
+    CUfileIOEvents_t event = {};
+    event.status = CUFILE_FAILED;
+    event.ret = -1;
+    return event;
+}
+
+void CUFileDescPool::destroyDesc(CUFileBatchDesc* desc) {
+    cuFileBatchIODestroy(desc->batch_handle->handle);
+    delete desc->batch_handle;
+    delete desc;
+}
+
+void CUFileDescPool::cleanupQuarantinedDescs() {
+    auto it = quarantined_descs_.begin();
+    while (it != quarantined_descs_.end()) {
+        auto* desc = *it;
+        updateBatchStatus(desc, -1);
+
+        bool all_terminal = true;
+        for (const auto& event : desc->io_events) {
+            if (!isTerminalStatus(event.status)) {
+                all_terminal = false;
+                break;
+            }
+        }
+
+        if (all_terminal) {
+            destroyDesc(desc);
+            it = quarantined_descs_.erase(it);
+        } else {
+            ++it;
+        }
+    }
 }
 
 bool CUFileDescPool::cancelBatch(int idx) {
@@ -273,28 +326,28 @@ int CUFileDescPool::freeCUfileDesc(int idx) {
     }
 
     auto* desc = descs_[idx];
+    const bool reusable = desc->reusable;
 
-    // IMPORTANT: Caller should ensure all IOs are completed (via
-    // getTransferStatus) before calling freeCUfileDesc, as cuFile may still
-    // access io_params otherwise. This is critical for the handle pooling
-    // optimization - the handle will be immediately reused and could lead to
-    // use-after-free bugs if IOs are in-flight.
-    //
+    // Reusable descriptors are safe to recycle only after the caller observed
+    // all IOs complete. Non-reusable descriptors may still be referenced by
+    // cuFile after a bounded failure cleanup, so keep their handle and params
+    // quarantined until a later poll observes terminal status for every IO.
     // Return the handle to pool for reuse (avoid expensive
     // cuFileBatchIODestroy)
     {
         std::lock_guard<std::mutex> lock(handle_pool_lock_);
-        if (desc->reusable) {
+        if (reusable) {
             handle_pool_.push_back(desc->batch_handle);
         } else {
             quarantined_descs_.push_back(desc);
         }
     }
 
-    if (desc->reusable) {
+    if (reusable) {
         delete desc;
     }
     descs_[idx] = nullptr;
+    cleanupQuarantinedDescs();
 
     return 0;
 }

--- a/mooncake-transfer-engine/src/transport/nvmeof_transport/cufile_desc_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/nvmeof_transport/cufile_desc_pool.cpp
@@ -215,8 +215,9 @@ bool CUFileDescPool::updateBatchStatus(CUFileBatchDesc* desc, int idx) {
         return false;
     }
 
-    CUfileError_t rc = cuFileBatchIOGetStatus(
-        desc->batch_handle->handle, 0, &nr, desc->polled_events.data(), nullptr);
+    CUfileError_t rc =
+        cuFileBatchIOGetStatus(desc->batch_handle->handle, 0, &nr,
+                               desc->polled_events.data(), nullptr);
     if (rc.err != CU_FILE_SUCCESS) {
         LOG(WARNING) << "cuFileBatchIOGetStatus failed for descriptor " << idx
                      << ": " << cuFileGetErrorString(rc);

--- a/mooncake-transfer-engine/src/transport/nvmeof_transport/cufile_desc_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/nvmeof_transport/cufile_desc_pool.cpp
@@ -33,12 +33,16 @@ CUFileDescPool::CUFileDescPool(size_t max_batch_size)
 }
 
 CUFileDescPool::~CUFileDescPool() {
+    auto destroy_desc = [](CUFileBatchDesc* desc) {
+        cuFileBatchIODestroy(desc->batch_handle->handle);
+        delete desc->batch_handle;
+        delete desc;
+    };
+
     // First, collect and destroy batch_handles from allocated descriptors
     for (size_t i = 0; i < MAX_NR_DESC; ++i) {
         if (descs_[i] != nullptr) {
-            cuFileBatchIODestroy(descs_[i]->batch_handle->handle);
-            delete descs_[i]->batch_handle;
-            delete descs_[i];
+            destroy_desc(descs_[i]);
             descs_[i] = nullptr;
         }
     }
@@ -50,6 +54,10 @@ CUFileDescPool::~CUFileDescPool() {
         delete batch_handle;
     }
     handle_pool_.clear();
+    for (auto* desc : quarantined_descs_) {
+        destroy_desc(desc);
+    }
+    quarantined_descs_.clear();
 }
 
 int CUFileDescPool::allocCUfileDesc(size_t batch_size) {
@@ -113,6 +121,7 @@ int CUFileDescPool::allocCUfileDesc(size_t batch_size) {
         desc->io_events.clear();
         desc->io_events.reserve(max_batch_size_);
         desc->polled_events.resize(max_batch_size_);
+        desc->reusable = true;
 
         descs_[idx] = desc;
         return idx;
@@ -221,6 +230,31 @@ bool CUFileDescPool::cachePolledEvent(std::vector<CUfileIOEvents_t>& io_events,
     return true;
 }
 
+bool CUFileDescPool::cancelBatch(int idx) {
+    RWSpinlock::WriteGuard guard(mutex_);
+    if (idx < 0 || idx >= (int)MAX_NR_DESC || descs_[idx] == nullptr) {
+        LOG(ERROR) << "Invalid descriptor index: " << idx;
+        return false;
+    }
+
+    CUfileError_t rc = cuFileBatchIOCancel(descs_[idx]->batch_handle->handle);
+    if (rc.err != CU_FILE_SUCCESS) {
+        LOG(WARNING) << "cuFileBatchIOCancel failed for descriptor " << idx
+                     << ": " << cuFileGetErrorString(rc);
+        return false;
+    }
+    return true;
+}
+
+void CUFileDescPool::markUnreusable(int idx) {
+    RWSpinlock::WriteGuard guard(mutex_);
+    if (idx < 0 || idx >= (int)MAX_NR_DESC || descs_[idx] == nullptr) {
+        LOG(ERROR) << "Invalid descriptor index: " << idx;
+        return;
+    }
+    descs_[idx]->reusable = false;
+}
+
 int CUFileDescPool::getSliceNum(int idx) {
     RWSpinlock::ReadGuard guard(mutex_);
     if (idx < 0 || idx >= (int)MAX_NR_DESC || descs_[idx] == nullptr) {
@@ -250,11 +284,16 @@ int CUFileDescPool::freeCUfileDesc(int idx) {
     // cuFileBatchIODestroy)
     {
         std::lock_guard<std::mutex> lock(handle_pool_lock_);
-        handle_pool_.push_back(desc->batch_handle);
+        if (desc->reusable) {
+            handle_pool_.push_back(desc->batch_handle);
+        } else {
+            quarantined_descs_.push_back(desc);
+        }
     }
 
-    // Delete the descriptor (each allocation gets a fresh one)
-    delete desc;
+    if (desc->reusable) {
+        delete desc;
+    }
     descs_[idx] = nullptr;
 
     return 0;

--- a/mooncake-transfer-engine/src/transport/nvmeof_transport/nvmeof_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/nvmeof_transport/nvmeof_transport.cpp
@@ -199,8 +199,9 @@ void NVMeoFTransport::collectSliceStatuses(
     std::vector<TransferStatus> &slice_statuses) {
     slice_statuses.clear();
     slice_statuses.reserve(slice_num);
+    desc_pool_->updateBatchStatus(desc_idx);
     for (size_t i = slice_id; i < slice_id + slice_num; ++i) {
-        auto event = desc_pool_->getTransferStatus(desc_idx, i);
+        auto event = desc_pool_->getCachedTransferStatus(desc_idx, i);
         auto slice_status = from_cufile_transfer_status(event.status);
         slice_statuses.push_back(TransferStatus{
             .s = slice_status,

--- a/mooncake-transfer-engine/src/transport/nvmeof_transport/nvmeof_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/nvmeof_transport/nvmeof_transport.cpp
@@ -97,21 +97,32 @@ Status NVMeoFTransport::getTransferStatus(BatchID batch_id, size_t task_id,
             "NVMeoFTransport: Task has no submitted slices");
     }
 
+    if (task.is_finished && task_id < nvmeof_desc.transfer_status.size()) {
+        status = nvmeof_desc.transfer_status[task_id];
+        return Status::OK();
+    }
+
     auto [slice_id, slice_num] = nvmeof_desc.task_to_slices[task_id];
     thread_local std::vector<TransferStatus> slice_statuses;
-    slice_statuses.clear();
-    slice_statuses.reserve(slice_num);
-    for (size_t i = slice_id; i < slice_id + slice_num; ++i) {
-        auto event = desc_pool_->getTransferStatus(nvmeof_desc.desc_idx_, i);
-        auto slice_status = from_cufile_transfer_status(event.status);
-        slice_statuses.push_back(TransferStatus{
-            .s = slice_status,
-            .transferred_bytes = slice_status == COMPLETED ? event.ret : 0});
-    }
+    collectSliceStatuses(nvmeof_desc.desc_idx_, slice_id, slice_num,
+                         slice_statuses);
 
     bool is_finished = false;
     status = aggregateTransferStatus(slice_statuses, is_finished);
+    if (!is_finished && isTerminalFailure(status.s)) {
+        desc_pool_->cancelBatch(nvmeof_desc.desc_idx_);
+        collectSliceStatuses(nvmeof_desc.desc_idx_, slice_id, slice_num,
+                             slice_statuses);
+        status = aggregateTransferStatus(slice_statuses, is_finished);
+        if (!is_finished && isTerminalFailure(status.s)) {
+            desc_pool_->markUnreusable(nvmeof_desc.desc_idx_);
+            is_finished = true;
+        }
+    }
     if (is_finished) {
+        if (task_id < nvmeof_desc.transfer_status.size()) {
+            nvmeof_desc.transfer_status[task_id] = status;
+        }
         task.is_finished = true;
     }
     return Status::OK();
@@ -177,10 +188,29 @@ Transport::TransferStatus NVMeoFTransport::aggregateTransferStatus(
 
     if (slice_statuses.empty()) {
         result.s = INVALID;
-    } else if (!is_finished) {
+    } else if (!is_finished && failure_priority == 0) {
         result.s = has_pending ? PENDING : WAITING;
     }
     return result;
+}
+
+void NVMeoFTransport::collectSliceStatuses(
+    int desc_idx, size_t slice_id, size_t slice_num,
+    std::vector<TransferStatus> &slice_statuses) {
+    slice_statuses.clear();
+    slice_statuses.reserve(slice_num);
+    for (size_t i = slice_id; i < slice_id + slice_num; ++i) {
+        auto event = desc_pool_->getTransferStatus(desc_idx, i);
+        auto slice_status = from_cufile_transfer_status(event.status);
+        slice_statuses.push_back(TransferStatus{
+            .s = slice_status,
+            .transferred_bytes = slice_status == COMPLETED ? event.ret : 0});
+    }
+}
+
+bool NVMeoFTransport::isTerminalFailure(TransferStatusEnum status) {
+    return status == INVALID || status == CANCELED || status == TIMEOUT ||
+           status == FAILED;
 }
 
 Status NVMeoFTransport::submitTransfer(

--- a/mooncake-transfer-engine/tests/nvmeof_status_test.cpp
+++ b/mooncake-transfer-engine/tests/nvmeof_status_test.cpp
@@ -54,10 +54,23 @@ TEST(NVMeoFStatusTest, RejectsUnsupportedMultiTransportSubmission) {
     EXPECT_TRUE(task.is_finished);
 }
 
-TEST(NVMeoFStatusTest, WaitsForEverySliceBeforeReportingTerminalFailure) {
+TEST(NVMeoFStatusTest, ReportsKnownFailureBeforeAllSlicesFinish) {
+    bool is_finished = true;
+    auto waiting_status = NVMeoFTransportTestPeer::aggregate(
+        {{Transport::FAILED, 0}, {Transport::WAITING, 0}}, is_finished);
+    EXPECT_EQ(waiting_status.s, Transport::FAILED);
+    EXPECT_FALSE(is_finished);
+
+    auto pending_status = NVMeoFTransportTestPeer::aggregate(
+        {{Transport::FAILED, 0}, {Transport::PENDING, 0}}, is_finished);
+    EXPECT_EQ(pending_status.s, Transport::FAILED);
+    EXPECT_FALSE(is_finished);
+}
+
+TEST(NVMeoFStatusTest, ReportsPendingOnlyWhenNoFailureIsKnown) {
     bool is_finished = true;
     auto status = NVMeoFTransportTestPeer::aggregate(
-        {{Transport::FAILED, 0}, {Transport::PENDING, 0}}, is_finished);
+        {{Transport::COMPLETED, 1024}, {Transport::PENDING, 0}}, is_finished);
 
     EXPECT_EQ(status.s, Transport::PENDING);
     EXPECT_FALSE(is_finished);


### PR DESCRIPTION
## Description

Fixes https://github.com/kvcache-ai/Mooncake/issues/2916.

NVMe-oF direct-batch status aggregation previously waited for every submitted slice to reach a terminal state before reporting a terminal task result. This meant a known failure could be hidden by another active slice, for example `[FAILED, WAITING] -> WAITING`, causing callers to keep polling indefinitely.

This PR separates the known transfer outcome from descriptor reuse safety:

- Preserve terminal slice failures during aggregation even when sibling slices are still `WAITING` or `PENDING`.
- Try to cancel the remaining cuFile batch work once a terminal failure is known.
- If the batch still has active slices after cancellation, mark the descriptor as not reusable so its cuFile handle and IO parameter storage are not returned to the reusable pool.
- Cache the terminal task result so repeated status queries remain stable.
- Keep normal `PENDING/WAITING` behavior when no terminal failure is known.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
cmake -S . -B $mooncake_dir \
  -DCMAKE_BUILD_TYPE=Release \
  -DBUILD_UNIT_TESTS=ON \
  -DBUILD_EXAMPLES=OFF \
  -DBUILD_BENCHMARK=OFF \
  -DWITH_STORE=OFF \
  -DWITH_TE=ON \
  -DWITH_STORE_RUST=OFF \
  -DWITH_EP=OFF \
  -DUSE_CUDA=ON \
  -DUSE_NVMEOF=ON \
  -DUSE_ETCD=OFF

ctest -R nvmeof_status_test --output-on-failure