### PR TITLE
[Bugfix][TransferEngine] Pause active reconnects to failed peers

### DIFF
--- a/mooncake-transfer-engine/include/config.h
+++ b/mooncake-transfer-engine/include/config.h
@@ -68,6 +68,14 @@ struct GlobalConfig {
     int log_level = google::INFO;
     bool trace = false;
     int64_t slice_timeout = -1;
+    // Active-connect circuit-breaker. After an endpoint to a peer is torn down
+    // (path failure / QP fatal), pause active reconnection to that peer's
+    // address for this many milliseconds, so the posting worker is not
+    // blocked re-handshaking a likely-gone peer (a k8s rolling restart brings
+    // the pod back at a different podIP:port, so the old address is dead). The
+    // not-yet-posted slices fail/redispatch instead of hanging. 0 disables.
+    // Override via MC_CONN_PAUSE_TTL_MS.
+    int conn_pause_ttl_ms = 0;
     uint16_t rpc_min_port = 15000;
     uint16_t rpc_max_port = 17000;
     bool use_ipv6 = false;

--- a/mooncake-transfer-engine/include/transport/rdma_transport/connect_pause_tracker.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/connect_pause_tracker.h
@@ -1,0 +1,85 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CONNECT_PAUSE_TRACKER_H
+#define CONNECT_PAUSE_TRACKER_H
+
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+namespace mooncake {
+
+// Active-connect circuit-breaker state: per peer server name (peer IP), a
+// "pause active reconnection until" timestamp. After an endpoint to a peer is
+// torn down (path failure / QP fatal), the peer is paused so the CQ poller is
+// not blocked re-handshaking a likely-gone peer. The clock is injected so the
+// TTL/expiry/prune logic is unit-testable without RDMA hardware or real sleeps.
+// All methods are thread-safe.
+class ConnectPauseTracker {
+   public:
+    using Clock = std::function<uint64_t()>;  // nanosecond timestamp source
+
+    explicit ConnectPauseTracker(Clock clock) : clock_(std::move(clock)) {}
+
+    // Arm/refresh the pause for `server` until the absolute timestamp
+    // `until_ns`.
+    void pause(const std::string &server, uint64_t until_ns) {
+        std::lock_guard<std::mutex> lock(mu_);
+        until_ns_[server] = until_ns;
+    }
+
+    // Whether `server` is currently paused. Expired entries are deleted on
+    // access (lazy expiry).
+    bool isPaused(const std::string &server) {
+        std::lock_guard<std::mutex> lock(mu_);
+        auto it = until_ns_.find(server);
+        if (it == until_ns_.end()) return false;
+        if (clock_() >= it->second) {
+            until_ns_.erase(it);  // expired -> delete
+            return false;
+        }
+        return true;
+    }
+
+    // Drop all expired entries (so the map doesn't grow for peers that are
+    // never re-checked after their pause lapses). Intended for a periodic tick.
+    void prune() {
+        uint64_t now = clock_();
+        std::lock_guard<std::mutex> lock(mu_);
+        for (auto it = until_ns_.begin(); it != until_ns_.end();) {
+            if (now >= it->second)
+                it = until_ns_.erase(it);
+            else
+                ++it;
+        }
+    }
+
+    // For tests / diagnostics.
+    size_t size() {
+        std::lock_guard<std::mutex> lock(mu_);
+        return until_ns_.size();
+    }
+
+   private:
+    const Clock clock_;
+    std::mutex mu_;
+    std::unordered_map<std::string, uint64_t> until_ns_;
+};
+
+}  // namespace mooncake
+
+#endif  // CONNECT_PAUSE_TRACKER_H

--- a/mooncake-transfer-engine/include/transport/rdma_transport/connect_pause_tracker.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/connect_pause_tracker.h
@@ -1,4 +1,4 @@
-// Copyright 2024 KVCache.AI
+// Copyright 2026 KVCache.AI
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -35,11 +35,12 @@ class ConnectPauseTracker {
 
     explicit ConnectPauseTracker(Clock clock) : clock_(std::move(clock)) {}
 
-    // Arm/refresh the pause for `server` until the absolute timestamp
-    // `until_ns`.
-    void pause(const std::string &server, uint64_t until_ns) {
+    // Arm/refresh the pause for `server` for `duration_ns`. The deadline is
+    // derived from the injected clock so production and tests use one time
+    // source.
+    void pauseFor(const std::string &server, uint64_t duration_ns) {
         std::lock_guard<std::mutex> lock(mu_);
-        until_ns_[server] = until_ns;
+        until_ns_[server] = clock_() + duration_ns;
     }
 
     // Whether `server` is currently paused. Expired entries are deleted on

--- a/mooncake-transfer-engine/include/transport/rdma_transport/endpoint_store.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/endpoint_store.h
@@ -43,7 +43,15 @@ class EndpointStore {
     virtual std::shared_ptr<RdmaEndPoint> insertEndpoint(
         const std::string &peer_nic_path, RdmaContext *context) = 0;
     virtual int deleteEndpoint(const std::string &peer_nic_path) = 0;
-    virtual int deleteEndpointByPtr(const RdmaEndPoint *endpoint_ptr) = 0;
+    // Deletes the endpoint matching endpoint_ptr (by pointer identity, under
+    // the store lock -- the pointer is never dereferenced, so a stale/freed
+    // pointer is safe and simply does not match). If found and
+    // deleted_peer_nic_path is non-null, it is set to that endpoint's peer NIC
+    // path (read from the live map key) so callers can act on the path without
+    // touching the raw pointer.
+    virtual int deleteEndpointByPtr(
+        const RdmaEndPoint *endpoint_ptr,
+        std::string *deleted_peer_nic_path = nullptr) = 0;
     virtual void evictEndpoint() = 0;
     // Takes endpoint_map_lock_; caller must not hold it (RWSpinlock is
     // non-reentrant, so recursive acquisition deadlocks).
@@ -77,7 +85,9 @@ class FIFOEndpointStore : public EndpointStore {
     std::shared_ptr<RdmaEndPoint> insertEndpoint(
         const std::string &peer_nic_path, RdmaContext *context) override;
     int deleteEndpoint(const std::string &peer_nic_path) override;
-    int deleteEndpointByPtr(const RdmaEndPoint *endpoint_ptr) override;
+    int deleteEndpointByPtr(
+        const RdmaEndPoint *endpoint_ptr,
+        std::string *deleted_peer_nic_path = nullptr) override;
     void evictEndpoint() override;
     void reclaimEndpoint() override;
     size_t getSize() override;
@@ -117,7 +127,9 @@ class SIEVEEndpointStore : public EndpointStore {
     std::shared_ptr<RdmaEndPoint> insertEndpoint(
         const std::string &peer_nic_path, RdmaContext *context) override;
     int deleteEndpoint(const std::string &peer_nic_path) override;
-    int deleteEndpointByPtr(const RdmaEndPoint *endpoint_ptr) override;
+    int deleteEndpointByPtr(
+        const RdmaEndPoint *endpoint_ptr,
+        std::string *deleted_peer_nic_path = nullptr) override;
     void evictEndpoint() override;
     void reclaimEndpoint() override;
     size_t getSize() override;

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
@@ -37,6 +37,7 @@
 #include "common.h"
 #include "rdma_gid_probe.h"
 #include "rdma_transport.h"
+#include "transport/rdma_transport/connect_pause_tracker.h"
 #include "transport/transport.h"
 
 namespace mooncake {
@@ -143,6 +144,16 @@ class RdmaContext {
 
     int deleteEndpoint(const std::string &peer_nic_path);
     int deleteEndpointByPtr(const RdmaEndPoint *endpoint_ptr);
+
+    // Active-connect circuit-breaker. After deleteEndpointByPtr tears an
+    // endpoint down, active reconnection to that peer's address is paused for
+    // globalConfig().conn_pause_ttl_ms so the CQ poller isn't blocked
+    // re-handshaking a likely-gone peer. Entries expire (lazily on
+    // isConnectPaused, and via pruneConnectPause from the monitor tick). All
+    // no-ops when the TTL is 0. Keyed by peer server name (the peer IP).
+    void pauseConnect(const std::string &peer_nic_path);
+    bool isConnectPaused(const std::string &peer_nic_path);
+    void pruneConnectPause();
 
     // Drain the endpoint store's waiting list. Safe to call on any thread;
     // intended to be invoked periodically from monitorWorker so reclaim is
@@ -274,6 +285,9 @@ class RdmaContext {
     std::vector<RdmaCq> cq_list_;
 
     std::shared_ptr<EndpointStore> endpoint_store_;
+
+    // Active-connect circuit-breaker (keyed by peer server name).
+    ConnectPauseTracker connect_pause_;
 
     std::vector<std::thread> background_thread_;
     std::atomic<bool> threads_running_;

--- a/mooncake-transfer-engine/src/config.cpp
+++ b/mooncake-transfer-engine/src/config.cpp
@@ -14,6 +14,7 @@
 
 #include "config.h"
 
+#include <charconv>
 #include <cstring>
 #include <cstdio>
 #include <cstdlib>
@@ -399,8 +400,10 @@ void loadGlobalConfig(GlobalConfig& config) {
         // rather than silently resolve to 0. 0 is a valid explicit "disable";
         // negative / out-of-range / garbage are rejected, preserving the
         // default.
-        try {
-            int val = std::stoi(conn_pause_ttl_env);
+        int val = 0;
+        const char* end = conn_pause_ttl_env + strlen(conn_pause_ttl_env);
+        auto [ptr, ec] = std::from_chars(conn_pause_ttl_env, end, val);
+        if (ec == std::errc() && ptr == end) {
             if (val >= 0 && val <= 600000) {
                 config.conn_pause_ttl_ms = val;
             } else {
@@ -409,9 +412,10 @@ void loadGlobalConfig(GlobalConfig& config) {
                              << conn_pause_ttl_env
                              << " out of range (should be 0-600000)";
             }
-        } catch (const std::exception& e) {
+        } else {
             LOG(WARNING) << "Invalid MC_CONN_PAUSE_TTL_MS environment value: "
-                         << conn_pause_ttl_env << ". Error: " << e.what();
+                         << conn_pause_ttl_env
+                         << ". Expected an integer in range 0-600000";
         }
     }
 

--- a/mooncake-transfer-engine/src/config.cpp
+++ b/mooncake-transfer-engine/src/config.cpp
@@ -393,6 +393,28 @@ void loadGlobalConfig(GlobalConfig& config) {
                 << "Ignore value from environment variable MC_SLICE_TIMEOUT";
     }
 
+    const char* conn_pause_ttl_env = std::getenv("MC_CONN_PAUSE_TTL_MS");
+    if (conn_pause_ttl_env) {
+        // Robust parse (not atoi): a non-numeric typo must keep the default
+        // rather than silently resolve to 0. 0 is a valid explicit "disable";
+        // negative / out-of-range / garbage are rejected, preserving the
+        // default.
+        try {
+            int val = std::stoi(conn_pause_ttl_env);
+            if (val >= 0 && val <= 600000) {
+                config.conn_pause_ttl_ms = val;
+            } else {
+                LOG(WARNING) << "Ignore value from environment variable "
+                                "MC_CONN_PAUSE_TTL_MS, value "
+                             << conn_pause_ttl_env
+                             << " out of range (should be 0-600000)";
+            }
+        } catch (const std::exception& e) {
+            LOG(WARNING) << "Invalid MC_CONN_PAUSE_TTL_MS environment value: "
+                         << conn_pause_ttl_env << ". Error: " << e.what();
+        }
+    }
+
     const char* log_dir_path = std::getenv("MC_LOG_DIR");
     if (log_dir_path) {
         google::InitGoogleLogging("mooncake-transfer-engine");

--- a/mooncake-transfer-engine/src/transport/rdma_transport/endpoint_store.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/endpoint_store.cpp
@@ -94,13 +94,15 @@ int FIFOEndpointStore::deleteEndpoint(const std::string &peer_nic_path) {
     return 0;
 }
 
-int FIFOEndpointStore::deleteEndpointByPtr(const RdmaEndPoint *endpoint_ptr) {
+int FIFOEndpointStore::deleteEndpointByPtr(const RdmaEndPoint *endpoint_ptr,
+                                           std::string *deleted_peer_nic_path) {
     RWSpinlock::WriteGuard guard(endpoint_map_lock_);
     // Find endpoint by pointer
     for (auto iter = endpoint_map_.begin(); iter != endpoint_map_.end();
          ++iter) {
         if (iter->second.get() == endpoint_ptr) {
             std::string peer_nic_path = iter->first;
+            if (deleted_peer_nic_path) *deleted_peer_nic_path = peer_nic_path;
             waiting_list_len_++;
             iter->second->beginDestroy();
             waiting_list_.insert(iter->second);
@@ -254,13 +256,15 @@ int SIEVEEndpointStore::deleteEndpoint(const std::string &peer_nic_path) {
     return 0;
 }
 
-int SIEVEEndpointStore::deleteEndpointByPtr(const RdmaEndPoint *endpoint_ptr) {
+int SIEVEEndpointStore::deleteEndpointByPtr(
+    const RdmaEndPoint *endpoint_ptr, std::string *deleted_peer_nic_path) {
     RWSpinlock::WriteGuard guard(endpoint_map_lock_);
     // Find endpoint by pointer
     for (auto iter = endpoint_map_.begin(); iter != endpoint_map_.end();
          ++iter) {
         if (iter->second.first.get() == endpoint_ptr) {
             std::string peer_nic_path = iter->first;
+            if (deleted_peer_nic_path) *deleted_peer_nic_path = peer_nic_path;
             iter->second.first->beginDestroy();
             waiting_list_len_++;
             waiting_list_.insert(iter->second.first);

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -671,9 +671,8 @@ void RdmaContext::pauseConnect(const std::string &peer_nic_path) {
     if (ttl_ms <= 0) return;  // disabled
     auto server_name = getServerNameFromNicPath(peer_nic_path);
     if (server_name.empty()) return;
-    uint64_t until =
-        getCurrentTimeInNano() + static_cast<uint64_t>(ttl_ms) * 1000000ull;
-    connect_pause_.pause(server_name, until);
+    connect_pause_.pauseFor(server_name,
+                            static_cast<uint64_t>(ttl_ms) * 1000000ull);
 }
 
 bool RdmaContext::isConnectPaused(const std::string &peer_nic_path) {

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -161,6 +161,8 @@ std::string gidBytesToString(const uint8_t *raw) {
 RdmaContext::RdmaContext(RdmaTransport &engine, const std::string &device_name)
     : device_name_(device_name),
       engine_(engine),
+      connect_pause_(
+          [] { return static_cast<uint64_t>(getCurrentTimeInNano()); }),
       next_comp_channel_index_(0),
       next_comp_vector_index_(0),
       next_cq_list_index_(0),
@@ -648,8 +650,40 @@ int RdmaContext::deleteEndpoint(const std::string &peer_nic_path) {
 }
 
 int RdmaContext::deleteEndpointByPtr(const RdmaEndPoint *endpoint_ptr) {
-    return endpoint_store_->deleteEndpointByPtr(endpoint_ptr);
+    // Tearing an endpoint down (path failure / QP fatal) means this peer is
+    // failing; pause active reconnection to its address so the CQ poller isn't
+    // blocked re-handshaking a likely-gone peer.
+    //
+    // Resolve the peer path *inside* the store, under its lock: the raw pointer
+    // may already be freed (e.g. an IBV_EVENT_QP_FATAL racing endpoint
+    // destruction), so we must not dereference it here. The store only compares
+    // pointer identity and returns the path from the live map key, and we arm
+    // the pause only if the endpoint was actually found. No-op when TTL is 0.
+    std::string deleted_peer_nic_path;
+    int ret = endpoint_store_->deleteEndpointByPtr(endpoint_ptr,
+                                                   &deleted_peer_nic_path);
+    if (!deleted_peer_nic_path.empty()) pauseConnect(deleted_peer_nic_path);
+    return ret;
 }
+
+void RdmaContext::pauseConnect(const std::string &peer_nic_path) {
+    int ttl_ms = globalConfig().conn_pause_ttl_ms;
+    if (ttl_ms <= 0) return;  // disabled
+    auto server_name = getServerNameFromNicPath(peer_nic_path);
+    if (server_name.empty()) return;
+    uint64_t until =
+        getCurrentTimeInNano() + static_cast<uint64_t>(ttl_ms) * 1000000ull;
+    connect_pause_.pause(server_name, until);
+}
+
+bool RdmaContext::isConnectPaused(const std::string &peer_nic_path) {
+    if (globalConfig().conn_pause_ttl_ms <= 0) return false;  // disabled
+    auto server_name = getServerNameFromNicPath(peer_nic_path);
+    if (server_name.empty()) return false;
+    return connect_pause_.isPaused(server_name);
+}
+
+void RdmaContext::pruneConnectPause() { connect_pause_.prune(); }
 
 void RdmaContext::reclaimEndpoints() { endpoint_store_->reclaimEndpoint(); }
 

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -344,16 +344,6 @@ int RdmaEndPoint::setupConnectionsByActive() {
             return ret;
         }
 
-        // Active-connect circuit-breaker: if we recently tore down an endpoint
-        // to this peer (path failure / QP fatal), skip the handshake for the
-        // configured pause window instead of blocking the posting worker on
-        // an RPC to a likely-gone peer. Fail fast; performPostSend then
-        // redispatches or fails the (not-yet-posted) slices. No-op when
-        // conn_pause_ttl_ms is 0.
-        if (context_.isConnectPaused(peer_nic_path_)) {
-            return ERR_ENDPOINT;
-        }
-
         // Only the first UNCONNECTED caller transitions to CONNECTING.
         auto current_status = status_.load(std::memory_order_relaxed);
         if (current_status == UNCONNECTED) {

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -344,6 +344,16 @@ int RdmaEndPoint::setupConnectionsByActive() {
             return ret;
         }
 
+        // Active-connect circuit-breaker: if we recently tore down an endpoint
+        // to this peer (path failure / QP fatal), skip the handshake for the
+        // configured pause window instead of blocking the posting worker on
+        // an RPC to a likely-gone peer. Fail fast; performPostSend then
+        // redispatches or fails the (not-yet-posted) slices. No-op when
+        // conn_pause_ttl_ms is 0.
+        if (context_.isConnectPaused(peer_nic_path_)) {
+            return ERR_ENDPOINT;
+        }
+
         // Only the first UNCONNECTED caller transitions to CONNECTING.
         auto current_status = status_.load(std::memory_order_relaxed);
         if (current_status == UNCONNECTED) {

--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -368,7 +368,14 @@ void WorkerPool::performPostSend(int thread_id) {
         processed_slice_count_.fetch_add(entry.second.size());
         entry.second.clear();
 #else
-        if (!isRailAvailable(entry.first)) {
+        // Check the connection pause before looking up or creating an endpoint.
+        // A paused peer is a policy decision, not a new path failure: routing
+        // it through setupConnectionsByActive() would return ERR_ENDPOINT,
+        // delete the endpoint, and refresh the pause without attempting a
+        // connection. Keeping the check here gives the pause a hard retry
+        // deadline; only a genuine connection/QP failure can arm or extend it.
+        if (!isRailAvailable(entry.first) ||
+            context_.isConnectPaused(entry.first)) {
             for (auto &slice : entry.second) failed_slice_list.push_back(slice);
             entry.second.clear();
             continue;

--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -833,6 +833,9 @@ void WorkerPool::monitorWorker() {
             // from RdmaContext::endpoint() and the waiting list grows
             // unboundedly under failure load. See issue #1845.
             context_.reclaimEndpoints();
+            // Drop expired active-connect pause entries so the map doesn't grow
+            // for peers that are never re-attempted after their pause lapses.
+            context_.pruneConnectPause();
             last_reset_ts = current_ts;
         }
 

--- a/mooncake-transfer-engine/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tests/CMakeLists.txt
@@ -101,6 +101,15 @@ add_executable(tcp_address_validation_test
 target_link_libraries(tcp_address_validation_test PUBLIC gtest gtest_main)
 add_test(NAME tcp_address_validation_test COMMAND tcp_address_validation_test)
 
+# Hardware-free unit test for the active-connect circuit-breaker state
+# (ConnectPauseTracker is header-only and clock-injectable), runs on every CI
+# runner.
+add_executable(connect_pause_tracker_test
+               ${WORKSPACE}/connect_pause_tracker_test.cpp)
+target_link_libraries(connect_pause_tracker_test PUBLIC gtest gtest_main
+                                                        pthread)
+add_test(NAME connect_pause_tracker_test COMMAND connect_pause_tracker_test)
+
 if(USE_MNNVL)
   add_executable(nvlink_transport_test ${WORKSPACE}/nvlink_transport_test.cpp)
   target_link_libraries(nvlink_transport_test PUBLIC transfer_engine gtest

--- a/mooncake-transfer-engine/tests/config_test.cpp
+++ b/mooncake-transfer-engine/tests/config_test.cpp
@@ -197,5 +197,77 @@ TEST_F(PkeyIndexEnvTest, TeMetadataRefreshIntervalRejectsNonNumericOverride) {
     EXPECT_EQ(config.te_metadata_refresh_interval_seconds, 456);
 }
 
+// MC_CONN_PAUSE_TTL_MS arms the active-connect circuit-breaker: after an
+// endpoint to a peer is torn down, active reconnection to that peer's address
+// is paused for this many ms so the CQ poller isn't blocked re-handshaking a
+// gone peer. 0 disables (and is the default); the range is capped at 600000ms.
+// As with the other knobs, a typo / out-of-range value must preserve the
+// default rather than silently change behavior.
+class ConnPauseTtlEnvTest : public ::testing::Test {
+   protected:
+    void TearDown() override { ::unsetenv("MC_CONN_PAUSE_TTL_MS"); }
+};
+
+TEST_F(ConnPauseTtlEnvTest, DefaultIsZeroWhenUnset) {
+    ::unsetenv("MC_CONN_PAUSE_TTL_MS");
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.conn_pause_ttl_ms, 0);
+}
+
+TEST_F(ConnPauseTtlEnvTest, ValidOverrideIsApplied) {
+    ASSERT_EQ(::setenv("MC_CONN_PAUSE_TTL_MS", "5000", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.conn_pause_ttl_ms, 5000);
+}
+
+TEST_F(ConnPauseTtlEnvTest, ZeroIsAcceptedAndDisables) {
+    ASSERT_EQ(::setenv("MC_CONN_PAUSE_TTL_MS", "0", 1), 0);
+    GlobalConfig config;
+    config.conn_pause_ttl_ms = 99;  // sentinel must be overwritten by 0
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.conn_pause_ttl_ms, 0);
+}
+
+TEST_F(ConnPauseTtlEnvTest, MaxBoundaryIsApplied) {
+    ASSERT_EQ(::setenv("MC_CONN_PAUSE_TTL_MS", "600000", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.conn_pause_ttl_ms, 600000);
+}
+
+TEST_F(ConnPauseTtlEnvTest, OutOfRangeIsIgnored) {
+    ASSERT_EQ(::setenv("MC_CONN_PAUSE_TTL_MS", "600001", 1), 0);
+    GlobalConfig config;
+    config.conn_pause_ttl_ms = 7;  // sentinel preserved when rejected
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.conn_pause_ttl_ms, 7);
+}
+
+TEST_F(ConnPauseTtlEnvTest, NegativeIsIgnored) {
+    ASSERT_EQ(::setenv("MC_CONN_PAUSE_TTL_MS", "-1", 1), 0);
+    GlobalConfig config;
+    config.conn_pause_ttl_ms = 11;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.conn_pause_ttl_ms, 11);
+}
+
+TEST_F(ConnPauseTtlEnvTest, NonNumericKeepsDefault) {
+    ASSERT_EQ(::setenv("MC_CONN_PAUSE_TTL_MS", "abc", 1), 0);
+    GlobalConfig config;
+    config.conn_pause_ttl_ms = 13;  // a typo must NOT silently change behavior
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.conn_pause_ttl_ms, 13);
+}
+
+TEST_F(ConnPauseTtlEnvTest, EmptyStringKeepsDefault) {
+    ASSERT_EQ(::setenv("MC_CONN_PAUSE_TTL_MS", "", 1), 0);
+    GlobalConfig config;
+    config.conn_pause_ttl_ms = 17;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.conn_pause_ttl_ms, 17);
+}
+
 }  // namespace
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tests/config_test.cpp
+++ b/mooncake-transfer-engine/tests/config_test.cpp
@@ -261,6 +261,14 @@ TEST_F(ConnPauseTtlEnvTest, NonNumericKeepsDefault) {
     EXPECT_EQ(config.conn_pause_ttl_ms, 13);
 }
 
+TEST_F(ConnPauseTtlEnvTest, NumericSuffixKeepsDefault) {
+    ASSERT_EQ(::setenv("MC_CONN_PAUSE_TTL_MS", "5000s", 1), 0);
+    GlobalConfig config;
+    config.conn_pause_ttl_ms = 15;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.conn_pause_ttl_ms, 15);
+}
+
 TEST_F(ConnPauseTtlEnvTest, EmptyStringKeepsDefault) {
     ASSERT_EQ(::setenv("MC_CONN_PAUSE_TTL_MS", "", 1), 0);
     GlobalConfig config;

--- a/mooncake-transfer-engine/tests/connect_pause_tracker_test.cpp
+++ b/mooncake-transfer-engine/tests/connect_pause_tracker_test.cpp
@@ -1,0 +1,125 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Hardware-free unit tests for ConnectPauseTracker (the active-connect
+// circuit-breaker state). The tracker takes an injected clock, so the
+// TTL/expiry/prune logic is exercised deterministically with no RDMA device
+// and no real sleeps. The header is inline-only, so the test links just gtest.
+
+#include "transport/rdma_transport/connect_pause_tracker.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+using mooncake::ConnectPauseTracker;
+
+namespace {
+
+// Manually-advanced clock so expiry transitions are deterministic.
+struct FakeClock {
+    std::atomic<uint64_t> now{0};
+    uint64_t operator()() const { return now.load(std::memory_order_relaxed); }
+};
+
+ConnectPauseTracker makeTracker(std::shared_ptr<FakeClock> clk) {
+    return ConnectPauseTracker([clk] { return (*clk)(); });
+}
+
+TEST(ConnectPauseTracker, UnknownPeerNotPaused) {
+    auto clk = std::make_shared<FakeClock>();
+    auto t = makeTracker(clk);
+    EXPECT_FALSE(t.isPaused("10.0.0.1:1234"));
+    EXPECT_EQ(t.size(), 0u);
+}
+
+TEST(ConnectPauseTracker, PausedUntilExpiry) {
+    auto clk = std::make_shared<FakeClock>();
+    auto t = makeTracker(clk);
+    const std::string peer = "10.0.0.1:1234";
+    t.pause(peer, 1000);            // paused until ts == 1000
+    EXPECT_TRUE(t.isPaused(peer));  // now == 0
+    clk->now = 999;
+    EXPECT_TRUE(t.isPaused(peer));   // just before expiry
+    clk->now = 1000;                 // at expiry (>= until)
+    EXPECT_FALSE(t.isPaused(peer));  // expired
+    EXPECT_EQ(t.size(), 0u);         // and lazily deleted on the failing check
+}
+
+TEST(ConnectPauseTracker, RefreshExtendsWindow) {
+    auto clk = std::make_shared<FakeClock>();
+    auto t = makeTracker(clk);
+    const std::string peer = "p";
+    t.pause(peer, 100);
+    clk->now = 50;
+    t.pause(peer, 200);  // re-arm while still paused -> extend
+    clk->now = 150;
+    EXPECT_TRUE(t.isPaused(peer));  // within the extended window
+    clk->now = 200;
+    EXPECT_FALSE(t.isPaused(peer));
+}
+
+TEST(ConnectPauseTracker, PruneDropsOnlyExpired) {
+    auto clk = std::make_shared<FakeClock>();
+    auto t = makeTracker(clk);
+    t.pause("a", 100);
+    t.pause("b", 300);
+    EXPECT_EQ(t.size(), 2u);
+    clk->now = 200;  // "a" expired, "b" still paused
+    t.prune();
+    EXPECT_EQ(t.size(), 1u);
+    EXPECT_FALSE(t.isPaused("a"));
+    EXPECT_TRUE(t.isPaused("b"));
+}
+
+TEST(ConnectPauseTracker, PerPeerIndependent) {
+    auto clk = std::make_shared<FakeClock>();
+    auto t = makeTracker(clk);
+    t.pause("a", 100);
+    t.pause("b", 1000);
+    clk->now = 150;
+    EXPECT_FALSE(t.isPaused("a"));  // a's window lapsed
+    EXPECT_TRUE(t.isPaused("b"));   // b's has not
+}
+
+// Hammer all entry points concurrently; primarily a ThreadSanitizer target
+// (run under -fsanitize=thread). The clock is pinned far in the future so
+// entries don't expire mid-run, isolating the data-race check.
+TEST(ConnectPauseTracker, ConcurrentAccessIsRaceFree) {
+    auto clk = std::make_shared<FakeClock>();
+    auto t = makeTracker(clk);
+    constexpr int kIters = 5000;
+    constexpr uint64_t kFarFuture = 1ull << 40;
+    std::vector<std::thread> threads;
+    for (int i = 0; i < 4; ++i)
+        threads.emplace_back([&t, i] {
+            std::string s = "peer" + std::to_string(i % 3);
+            for (int k = 0; k < kIters; ++k) t.pause(s, kFarFuture);
+        });
+    for (int i = 0; i < 4; ++i)
+        threads.emplace_back([&t] {
+            for (int k = 0; k < kIters; ++k) (void)t.isPaused("peer0");
+        });
+    threads.emplace_back([&t] {
+        for (int k = 0; k < kIters; ++k) t.prune();
+    });
+    for (auto& th : threads) th.join();
+    SUCCEED();  // TSan asserts the absence of data races
+}
+
+}  // namespace

--- a/mooncake-transfer-engine/tests/connect_pause_tracker_test.cpp
+++ b/mooncake-transfer-engine/tests/connect_pause_tracker_test.cpp
@@ -61,6 +61,23 @@ TEST(ConnectPauseTracker, PausedUntilExpiry) {
     EXPECT_EQ(t.size(), 0u);         // and lazily deleted on the failing check
 }
 
+TEST(ConnectPauseTracker, RepeatedChecksDoNotExtendHardDeadline) {
+    auto clk = std::make_shared<FakeClock>();
+    auto t = makeTracker(clk);
+    const std::string peer = "10.0.0.1:1234";
+    t.pause(peer, 1000);
+
+    // Simulate continuous traffic checking the pause. Lookups are not actual
+    // connection failures, so they must not refresh the deadline.
+    for (uint64_t now = 100; now < 1000; now += 100) {
+        clk->now = now;
+        EXPECT_TRUE(t.isPaused(peer));
+    }
+
+    clk->now = 1000;
+    EXPECT_FALSE(t.isPaused(peer));
+}
+
 TEST(ConnectPauseTracker, RefreshExtendsWindow) {
     auto clk = std::make_shared<FakeClock>();
     auto t = makeTracker(clk);

--- a/mooncake-transfer-engine/tests/connect_pause_tracker_test.cpp
+++ b/mooncake-transfer-engine/tests/connect_pause_tracker_test.cpp
@@ -52,11 +52,12 @@ TEST(ConnectPauseTracker, PausedUntilExpiry) {
     auto clk = std::make_shared<FakeClock>();
     auto t = makeTracker(clk);
     const std::string peer = "10.0.0.1:1234";
-    t.pause(peer, 1000);            // paused until ts == 1000
-    EXPECT_TRUE(t.isPaused(peer));  // now == 0
-    clk->now = 999;
+    clk->now = 500;
+    t.pauseFor(peer, 1000);         // paused until ts == 1500
+    EXPECT_TRUE(t.isPaused(peer));  // now == 500
+    clk->now = 1499;
     EXPECT_TRUE(t.isPaused(peer));   // just before expiry
-    clk->now = 1000;                 // at expiry (>= until)
+    clk->now = 1500;                 // at expiry (>= until)
     EXPECT_FALSE(t.isPaused(peer));  // expired
     EXPECT_EQ(t.size(), 0u);         // and lazily deleted on the failing check
 }
@@ -65,7 +66,7 @@ TEST(ConnectPauseTracker, RepeatedChecksDoNotExtendHardDeadline) {
     auto clk = std::make_shared<FakeClock>();
     auto t = makeTracker(clk);
     const std::string peer = "10.0.0.1:1234";
-    t.pause(peer, 1000);
+    t.pauseFor(peer, 1000);
 
     // Simulate continuous traffic checking the pause. Lookups are not actual
     // connection failures, so they must not refresh the deadline.
@@ -82,9 +83,9 @@ TEST(ConnectPauseTracker, RefreshExtendsWindow) {
     auto clk = std::make_shared<FakeClock>();
     auto t = makeTracker(clk);
     const std::string peer = "p";
-    t.pause(peer, 100);
+    t.pauseFor(peer, 100);
     clk->now = 50;
-    t.pause(peer, 200);  // re-arm while still paused -> extend
+    t.pauseFor(peer, 150);  // re-arm while still paused -> extend to ts == 200
     clk->now = 150;
     EXPECT_TRUE(t.isPaused(peer));  // within the extended window
     clk->now = 200;
@@ -94,8 +95,8 @@ TEST(ConnectPauseTracker, RefreshExtendsWindow) {
 TEST(ConnectPauseTracker, PruneDropsOnlyExpired) {
     auto clk = std::make_shared<FakeClock>();
     auto t = makeTracker(clk);
-    t.pause("a", 100);
-    t.pause("b", 300);
+    t.pauseFor("a", 100);
+    t.pauseFor("b", 300);
     EXPECT_EQ(t.size(), 2u);
     clk->now = 200;  // "a" expired, "b" still paused
     t.prune();
@@ -107,8 +108,8 @@ TEST(ConnectPauseTracker, PruneDropsOnlyExpired) {
 TEST(ConnectPauseTracker, PerPeerIndependent) {
     auto clk = std::make_shared<FakeClock>();
     auto t = makeTracker(clk);
-    t.pause("a", 100);
-    t.pause("b", 1000);
+    t.pauseFor("a", 100);
+    t.pauseFor("b", 1000);
     clk->now = 150;
     EXPECT_FALSE(t.isPaused("a"));  // a's window lapsed
     EXPECT_TRUE(t.isPaused("b"));   // b's has not
@@ -126,7 +127,7 @@ TEST(ConnectPauseTracker, ConcurrentAccessIsRaceFree) {
     for (int i = 0; i < 4; ++i)
         threads.emplace_back([&t, i] {
             std::string s = "peer" + std::to_string(i % 3);
-            for (int k = 0; k < kIters; ++k) t.pause(s, kFarFuture);
+            for (int k = 0; k < kIters; ++k) t.pauseFor(s, kFarFuture);
         });
     for (int i = 0; i < 4; ++i)
         threads.emplace_back([&t] {


### PR DESCRIPTION
## Description

After an RDMA endpoint is torn down, pending transfers can immediately try to recreate it. If the peer is unavailable, each active handshake blocks a posting worker for the TCP connection timeout and delays unrelated transfers assigned to that worker.

Add an opt-in, per-context connection pause keyed by peer server address. Deleting an endpoint arms MC_CONN_PAUSE_TTL_MS for that peer, and active connection setup fails fast until the pause expires. Expired entries are removed lazily during lookup and periodically by the monitor worker.

Resolve the deleted peer path inside EndpointStore under its lock using pointer identity. This avoids dereferencing a potentially stale endpoint pointer delivered by an asynchronous QP fatal event.

The feature remains disabled by default with a zero TTL. Add hardware-independent tests for tracker expiry, pruning, concurrency, and configuration parsing.

## Module

- [X] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Ran in production for ~1 month.
Unit tests

**Test results:**
- [X] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [X] AI tools were used (specify below)

Claude Code.
