### PR TITLE
[Store] Surface HTTP metadata server bind failures in start()

### DIFF
--- a/mooncake-store/src/http_metadata_server.cpp
+++ b/mooncake-store/src/http_metadata_server.cpp
@@ -112,7 +112,16 @@ bool HttpMetadataServer::start() {
         return true;
     }
 
-    server_->async_start();
+    // async_start() binds synchronously and hands back a future that is already
+    // resolved (hasResult()) when the bind failed; otherwise the server keeps
+    // running. Mirror MasterAdminServer::Start() so a failed bind is surfaced
+    // instead of reporting a healthy server that never came up.
+    auto ec = server_->async_start();
+    if (ec.hasResult()) {
+        LOG(ERROR) << "Failed to start HTTP metadata server on " << host_ << ":"
+                   << port_;
+        return false;
+    }
     running_ = true;
     LOG(INFO) << "HTTP metadata server started on " << host_ << ":" << port_;
     return true;

--- a/mooncake-store/tests/http_metadata_server_test.cpp
+++ b/mooncake-store/tests/http_metadata_server_test.cpp
@@ -96,4 +96,19 @@ TEST_F(HttpMetadataServerTest, RejectsChangedRpcMetaRepublish) {
     server.stop();
 }
 
+TEST_F(HttpMetadataServerTest, StartReportsBindFailure) {
+    int port = getFreeTcpPort();
+    HttpMetadataServer first(static_cast<uint16_t>(port), "127.0.0.1");
+    ASSERT_TRUE(first.start());
+    WaitUntilReady(port);
+
+    // A second server cannot bind the already-taken port; start() must report
+    // the failure instead of claiming a healthy server that never came up.
+    HttpMetadataServer second(static_cast<uint16_t>(port), "127.0.0.1");
+    EXPECT_FALSE(second.start());
+    EXPECT_FALSE(second.is_running());
+
+    first.stop();
+}
+
 }  // namespace mooncake::testing


### PR DESCRIPTION
## Description

`HttpMetadataServer::start()` called `server_->async_start()` and dropped its result, then unconditionally set `running_ = true`, logged "started", and returned `true`. `coro_http_server`'s `async_start()` binds synchronously and hands back a future that is already resolved (`hasResult()`) when the bind failed, so a failed bind — e.g. the port is already in use — was reported as a healthy server: `start()` returned `true` and `poll()` reported `KVPoll::Success` off `running_`.

This is the C++ counterpart of the Python bug fixed in #2924. @stmatengss asked there whether the built-in C++ metadata server had the same issue, and @toffee-desuwa confirmed it does (`async_start()` hands back an already-resolved future on failure, but `start()` dropped it).

## Fix

Check the future the same way `MasterAdminServer::Start()` already does for the same `coro_http_server` type: on a failed bind, log and return `false`, leaving `running_` unset so `poll()` reports `KVPoll::Failed`.

## Module

mooncake-store (metadata server)

## Type of change

Bug fix.

## Testing

Added `HttpMetadataServerTest.StartReportsBindFailure`: it starts one server on a free port, then starts a second server on the same (now-taken) port and asserts `start()` returns `false` and `is_running()` is `false`.

Local-verification note: I could not run the full mooncake-store build/test locally — it pulls in Linux-only deps (NUMA/SPDK) that aren't available on my macOS box. The fix is a direct mirror of the proven `MasterAdminServer::Start()` pattern for the same server type, and the test follows the existing tests in this file; both are exercised by CI.

## Checklist

- [x] The change is scoped to the reported bug.
- [x] Follows the existing code style and the sibling `MasterAdminServer::Start()` pattern.
- [x] Adds a regression test.

## AI assistance disclosure

Assisted by Claude Code. I have reviewed every changed line and can defend the change end-to-end.