### PR TITLE
[Store] pin host segments with quota

### DIFF
--- a/docs/source/python-api-reference/mooncake-store.md
+++ b/docs/source/python-api-reference/mooncake-store.md
@@ -1081,23 +1081,15 @@ def setup(
 - `ssd_offload_path` (str): SSD offload directory. When provided, overrides the storage path environment configuration.
 - `tenant_id` (str): Tenant namespace for object keys. Defaults to `"default"`.
 
-**Store segment pinned memory:**
-
-CUDA-enabled builds can register Store-managed host segments as pinned memory
-when the process is given an explicit pinned-memory quota. This applies only to
-Store segment memory for host transfer protocols allocated by `setup()`
-(`global_segment_size`) and `allocateAndMountSegment()`. It does not pin
-file-backed `mountSegment()` mappings, CXL/device segments, the
-`local_buffer_size` client buffer, user buffers, dummy-client shared memory, or
-temporary staging buffers.
-
-- `MC_STORE_PIN_MEMORY_MAX_BYTES`: positive process-wide quota, in bytes. Store
-  segment pinning is disabled when this is unset, empty, `0`, or invalid.
-- `MC_STORE_PIN_MEMORY`: optional override. Set to `0`, `false`, `off`, or `no`
-  to disable Store segment pinning even when a quota is configured.
-
-If the quota is exhausted or CUDA registration fails, Mooncake continues with
-pageable Store segment memory.
+**Store segment pinned memory:** CUDA-enabled builds can register Store-managed
+host segments as pinned memory when `MC_STORE_PIN_MEMORY_MAX_BYTES` is set to a
+positive process-wide quota; unset, empty, `0`, or invalid values disable it.
+The scope is limited to host Store segments allocated by `setup()`
+(`global_segment_size`) and `allocateAndMountSegment()`; it excludes file-backed
+`mountSegment()` mappings, CXL/device segments, `local_buffer_size`, user
+buffers, dummy-client shared memory, and temporary staging buffers. If the quota
+is exhausted or CUDA registration fails, Mooncake continues with pageable Store
+segment memory.
 
 **Returns:**
 - `int`: Status code (0 = success, non-zero = error code)

--- a/docs/source/python-api-reference/mooncake-store.md
+++ b/docs/source/python-api-reference/mooncake-store.md
@@ -1081,6 +1081,24 @@ def setup(
 - `ssd_offload_path` (str): SSD offload directory. When provided, overrides the storage path environment configuration.
 - `tenant_id` (str): Tenant namespace for object keys. Defaults to `"default"`.
 
+**Store segment pinned memory:**
+
+CUDA-enabled builds can register Store-managed host segments as pinned memory
+when the process is given an explicit pinned-memory quota. This applies only to
+Store segment memory for host transfer protocols allocated by `setup()`
+(`global_segment_size`) and `allocateAndMountSegment()`. It does not pin
+file-backed `mountSegment()` mappings, CXL/device segments, the
+`local_buffer_size` client buffer, user buffers, dummy-client shared memory, or
+temporary staging buffers.
+
+- `MC_STORE_PIN_MEMORY_MAX_BYTES`: positive process-wide quota, in bytes. Store
+  segment pinning is disabled when this is unset, empty, `0`, or invalid.
+- `MC_STORE_PIN_MEMORY`: optional override. Set to `0`, `false`, `off`, or `no`
+  to disable Store segment pinning even when a quota is configured.
+
+If the quota is exhausted or CUDA registration fails, Mooncake continues with
+pageable Store segment memory.
+
 **Returns:**
 - `int`: Status code (0 = success, non-zero = error code)
 

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -760,6 +760,8 @@ class RealClient : public PyClient {
         std::shared_ptr<RegisteredPinnedRegion> pinned_region;
     };
 
+    void FreeAllocatedStoreSegment(AllocatedSegmentRecord &record);
+
     std::unique_ptr<AutoPortBinder> port_binder_ = nullptr;
 
     struct SegmentDeleter {
@@ -820,6 +822,7 @@ class RealClient : public PyClient {
 #endif
     std::vector<std::shared_ptr<RegisteredPinnedRegion>>
         setup_segment_pinned_regions_;
+    bool setup_segment_memory_must_leak_ = false;
     std::string protocol;
     std::string device_name;
     std::string local_hostname;

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -29,6 +29,7 @@
 namespace mooncake {
 
 class RealClient;
+class RegisteredPinnedRegion;
 class UdsAcceptor;
 class UdsConnection;
 
@@ -756,6 +757,7 @@ class RealClient : public PyClient {
         void *base = nullptr;
         size_t size = 0;
         std::string protocol;
+        std::shared_ptr<RegisteredPinnedRegion> pinned_region;
     };
 
     std::unique_ptr<AutoPortBinder> port_binder_ = nullptr;
@@ -816,6 +818,8 @@ class RealClient : public PyClient {
     std::vector<std::unique_ptr<void, SunriseSegmentDeleter>>
         sunrise_segment_ptrs_;
 #endif
+    std::vector<std::shared_ptr<RegisteredPinnedRegion>>
+        setup_segment_pinned_regions_;
     std::string protocol;
     std::string device_name;
     std::string local_hostname;

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -27,6 +27,7 @@ set(MOONCAKE_STORE_SOURCES
     client_buffer.cpp
     aligned_client_buffer.cpp
     real_client.cpp
+    registered_pinned_memory.cpp
     dummy_client.cpp
     uds_transport.cpp
     shm_helper.cpp

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include "real_client.h"
+#include "registered_pinned_memory.h"
 #include "client_buffer.h"
 #include "replica_selection.h"
 #include "common.h"
@@ -50,6 +51,21 @@ DEFINE_int32(http_port, 9300,
 namespace mooncake {
 namespace {
 constexpr std::chrono::seconds kIpcRequestRecvTimeout{5};
+
+bool IsHostStoreSegmentProtocol(const std::string &protocol) {
+    return protocol.empty() || protocol == "tcp" || protocol == "rdma" ||
+           protocol == "efa" || protocol == "cxi" || protocol == "rpc_only";
+}
+
+std::shared_ptr<RegisteredPinnedRegion> TryPinStoreSegment(
+    void *ptr, size_t size, const std::string &protocol,
+    const char *segment_owner) {
+    if (!IsHostStoreSegmentProtocol(protocol)) return nullptr;
+    return RegisteredPinnedMemoryManager::instance().try_pin(
+        ptr, size,
+        std::string("Store segment ") + segment_owner +
+            " protocol=" + protocol);
+}
 
 #ifdef USE_ASCEND_DIRECT
 bool checkAcl(aclError result, const char *message) {
@@ -869,12 +885,19 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
                 }
             }
 
+            auto pinned_region =
+                TryPinStoreSegment(ptr, mapped_size, this->protocol, "setup");
             auto mount_result =
                 client_->MountSegment(ptr, mapped_size, protocol, seg_location);
             if (!mount_result.has_value()) {
+                pinned_region.reset();
                 LOG(ERROR) << "Failed to mount segment: "
                            << toString(mount_result.error());
                 return tl::unexpected(mount_result.error());
+            }
+            if (pinned_region) {
+                setup_segment_pinned_regions_.push_back(
+                    std::move(pinned_region));
             }
         }
         if (total_glbseg_size == 0) {
@@ -1187,6 +1210,7 @@ tl::expected<void, ErrorCode> RealClient::tearDownAll_internal() {
     ReleaseAllAllocatedSegmentRecords();
     client_buffer_allocator_.reset();
     port_binder_.reset();
+    setup_segment_pinned_regions_.clear();
     hugepage_segment_ptrs_.clear();
     ub_segment_ptrs_.clear();
 #if defined(USE_SUNRISE)
@@ -1380,6 +1404,7 @@ void RealClient::ReleaseAllocatedSegmentRecord(const std::string &segment_id) {
         }
     }
     if (found && record.base) {
+        record.pinned_region.reset();
         free_memory(record.protocol, record.base);
     }
 }
@@ -1392,6 +1417,7 @@ void RealClient::ReleaseAllAllocatedSegmentRecords() {
     }
     for (auto &entry : records) {
         if (entry.second.base) {
+            entry.second.pinned_region.reset();
             free_memory(entry.second.protocol, entry.second.base);
         }
     }
@@ -1533,17 +1559,21 @@ int RealClient::allocateAndMountSegment(
             break;
         }
 
+        auto pinned_region =
+            TryPinStoreSegment(ptr, chunk_size, protocol, "allocated");
         auto result =
             client_->MountSegmentAndGetId(ptr, chunk_size, protocol, location);
         if (!result.has_value()) {
             LOG(ERROR) << "MountSegmentAndGetId failed";
+            pinned_region.reset();
             free_memory(protocol, ptr);
             break;
         }
 
         std::string segment_id = UuidToString(result.value());
         mounted_ids.push_back(segment_id);
-        allocated_records.push_back({ptr, chunk_size, protocol});
+        allocated_records.push_back(
+            {ptr, chunk_size, protocol, std::move(pinned_region)});
 
         remaining -= chunk_size;
     }
@@ -1555,6 +1585,7 @@ int RealClient::allocateAndMountSegment(
                 client_->UnmountSegmentById(id);
             }
             if (allocated_records[i].base) {
+                allocated_records[i].pinned_region.reset();
                 free_memory(allocated_records[i].protocol,
                             allocated_records[i].base);
             }
@@ -1643,6 +1674,7 @@ int RealClient::unmountAndFreeSegment(
 
     for (auto &p : to_cleanup) {
         if (p.second.base) {
+            p.second.pinned_region.reset();
             free_memory(p.second.protocol, p.second.base);
         }
     }

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -67,6 +67,31 @@ std::shared_ptr<RegisteredPinnedRegion> TryPinStoreSegment(
             " protocol=" + protocol);
 }
 
+bool ReleasePinnedRegionForFree(
+    std::shared_ptr<RegisteredPinnedRegion> &pinned_region,
+    const char *segment_owner) {
+    if (!pinned_region) return true;
+    const bool safe_to_free = pinned_region->release();
+    pinned_region.reset();
+    if (!safe_to_free) {
+        LOG(ERROR) << "Leaking " << segment_owner
+                   << " backing memory because cudaHostUnregister failed";
+    }
+    return safe_to_free;
+}
+
+bool ReleasePinnedRegionsForFree(
+    std::vector<std::shared_ptr<RegisteredPinnedRegion>> &pinned_regions,
+    const char *segment_owner) {
+    bool safe_to_free = true;
+    for (auto &pinned_region : pinned_regions) {
+        safe_to_free &= ReleasePinnedRegionForFree(pinned_region,
+                                                   segment_owner);
+    }
+    pinned_regions.clear();
+    return safe_to_free;
+}
+
 #ifdef USE_ASCEND_DIRECT
 bool checkAcl(aclError result, const char *message) {
     if (result != ACL_ERROR_NONE) {
@@ -890,7 +915,10 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
             auto mount_result =
                 client_->MountSegment(ptr, mapped_size, protocol, seg_location);
             if (!mount_result.has_value()) {
-                pinned_region.reset();
+                if (!ReleasePinnedRegionForFree(pinned_region,
+                                                "Store setup segment")) {
+                    setup_segment_memory_must_leak_ = true;
+                }
                 LOG(ERROR) << "Failed to mount segment: "
                            << toString(mount_result.error());
                 return tl::unexpected(mount_result.error());
@@ -1210,13 +1238,19 @@ tl::expected<void, ErrorCode> RealClient::tearDownAll_internal() {
     ReleaseAllAllocatedSegmentRecords();
     client_buffer_allocator_.reset();
     port_binder_.reset();
-    setup_segment_pinned_regions_.clear();
+    const bool setup_segments_safe_to_free = ReleasePinnedRegionsForFree(
+        setup_segment_pinned_regions_, "Store setup segment");
+    if (!setup_segments_safe_to_free || setup_segment_memory_must_leak_) {
+        for (auto &ptr : hugepage_segment_ptrs_) ptr.release();
+        for (auto &ptr : segment_ptrs_) ptr.release();
+        setup_segment_memory_must_leak_ = false;
+    }
     hugepage_segment_ptrs_.clear();
+    segment_ptrs_.clear();
     ub_segment_ptrs_.clear();
 #if defined(USE_SUNRISE)
     sunrise_segment_ptrs_.clear();
 #endif
-    segment_ptrs_.clear();
     local_hostname = "";
     device_name = "";
     protocol = "";
@@ -1391,6 +1425,14 @@ void RealClient::ReleaseAllMountedSegmentRecords() {
     }
 }
 
+void RealClient::FreeAllocatedStoreSegment(AllocatedSegmentRecord &record) {
+    if (record.base &&
+        ReleasePinnedRegionForFree(record.pinned_region,
+                                   "allocated Store segment")) {
+        free_memory(record.protocol, record.base);
+    }
+}
+
 void RealClient::ReleaseAllocatedSegmentRecord(const std::string &segment_id) {
     AllocatedSegmentRecord record;
     bool found = false;
@@ -1404,8 +1446,7 @@ void RealClient::ReleaseAllocatedSegmentRecord(const std::string &segment_id) {
         }
     }
     if (found && record.base) {
-        record.pinned_region.reset();
-        free_memory(record.protocol, record.base);
+        FreeAllocatedStoreSegment(record);
     }
 }
 
@@ -1416,10 +1457,7 @@ void RealClient::ReleaseAllAllocatedSegmentRecords() {
         records.swap(allocated_segment_records_);
     }
     for (auto &entry : records) {
-        if (entry.second.base) {
-            entry.second.pinned_region.reset();
-            free_memory(entry.second.protocol, entry.second.base);
-        }
+        FreeAllocatedStoreSegment(entry.second);
     }
 }
 
@@ -1565,8 +1603,10 @@ int RealClient::allocateAndMountSegment(
             client_->MountSegmentAndGetId(ptr, chunk_size, protocol, location);
         if (!result.has_value()) {
             LOG(ERROR) << "MountSegmentAndGetId failed";
-            pinned_region.reset();
-            free_memory(protocol, ptr);
+            if (ReleasePinnedRegionForFree(pinned_region,
+                                           "allocated Store segment")) {
+                free_memory(protocol, ptr);
+            }
             break;
         }
 
@@ -1585,9 +1625,7 @@ int RealClient::allocateAndMountSegment(
                 client_->UnmountSegmentById(id);
             }
             if (allocated_records[i].base) {
-                allocated_records[i].pinned_region.reset();
-                free_memory(allocated_records[i].protocol,
-                            allocated_records[i].base);
+                FreeAllocatedStoreSegment(allocated_records[i]);
             }
         }
         out_segment_ids.clear();
@@ -1673,10 +1711,7 @@ int RealClient::unmountAndFreeSegment(
     }
 
     for (auto &p : to_cleanup) {
-        if (p.second.base) {
-            p.second.pinned_region.reset();
-            free_memory(p.second.protocol, p.second.base);
-        }
+        FreeAllocatedStoreSegment(p.second);
     }
 
     return first_error;

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -85,8 +85,8 @@ bool ReleasePinnedRegionsForFree(
     const char *segment_owner) {
     bool safe_to_free = true;
     for (auto &pinned_region : pinned_regions) {
-        safe_to_free &= ReleasePinnedRegionForFree(pinned_region,
-                                                   segment_owner);
+        safe_to_free &=
+            ReleasePinnedRegionForFree(pinned_region, segment_owner);
     }
     pinned_regions.clear();
     return safe_to_free;
@@ -1426,9 +1426,8 @@ void RealClient::ReleaseAllMountedSegmentRecords() {
 }
 
 void RealClient::FreeAllocatedStoreSegment(AllocatedSegmentRecord &record) {
-    if (record.base &&
-        ReleasePinnedRegionForFree(record.pinned_region,
-                                   "allocated Store segment")) {
+    if (record.base && ReleasePinnedRegionForFree(record.pinned_region,
+                                                  "allocated Store segment")) {
         free_memory(record.protocol, record.base);
     }
 }

--- a/mooncake-store/src/registered_pinned_memory.cpp
+++ b/mooncake-store/src/registered_pinned_memory.cpp
@@ -1,13 +1,12 @@
 #include "registered_pinned_memory.h"
 
-#include <cctype>
-#include <charconv>
 #include <cstdlib>
-#include <optional>
 #include <string>
-#include <system_error>
+#include <string_view>
 
 #include <glog/logging.h>
+
+#include "utils/type_util.h"
 
 #if defined(USE_CUDA)
 #include <cuda_runtime_api.h>
@@ -16,51 +15,31 @@
 namespace mooncake {
 namespace {
 
-std::pair<const char*, const char*> TrimAsciiWhitespace(const char* value) {
-    const char* begin = value;
-    while (std::isspace(static_cast<unsigned char>(*begin))) {
-        ++begin;
-    }
-
-    const char* end = begin;
-    while (*end != '\0') {
-        ++end;
-    }
-    while (end > begin &&
-           std::isspace(static_cast<unsigned char>(*(end - 1)))) {
-        --end;
-    }
-
-    return {begin, end};
-}
-
-std::optional<uint64_t> ParsePinnedMemoryLimit() {
-    const char* value = std::getenv("MC_STORE_PIN_MEMORY_MAX_BYTES");
-    if (!value || value[0] == '\0') return 0;
-
-    auto [number, end] = TrimAsciiWhitespace(value);
-    if (*number == '-') {
-        LOG(WARNING) << "Invalid MC_STORE_PIN_MEMORY_MAX_BYTES='" << value
-                     << "', disabling Store segment pinning";
-        return std::nullopt;
-    }
-
-    uint64_t parsed = 0;
-    auto [ptr, ec] = std::from_chars(number, end, parsed);
-    if (ec != std::errc{} || ptr != end) {
-        LOG(WARNING) << "Invalid MC_STORE_PIN_MEMORY_MAX_BYTES='" << value
-                     << "', disabling Store segment pinning";
-        return std::nullopt;
-    }
-    return parsed;
+std::string_view TrimAsciiWhitespace(std::string_view value) {
+    constexpr std::string_view whitespace = " \t\r\n\f\v";
+    size_t begin = value.find_first_not_of(whitespace);
+    if (begin == std::string_view::npos) return {};
+    size_t end = value.find_last_not_of(whitespace);
+    return value.substr(begin, end - begin + 1);
 }
 
 std::pair<bool, uint64_t> ParsePinnedMemoryConfig() {
-    auto limit = ParsePinnedMemoryLimit();
-    if (!limit.has_value() || *limit == 0) {
+    const char* raw_value = std::getenv("MC_STORE_PIN_MEMORY_MAX_BYTES");
+    if (!raw_value || raw_value[0] == '\0') return {false, 0};
+
+    uint64_t limit = 0;
+    auto value = TrimAsciiWhitespace(raw_value);
+    if (value.empty() || !TypeUtil::ParseUint64(value, limit)) {
+        LOG(WARNING) << "Invalid MC_STORE_PIN_MEMORY_MAX_BYTES='" << raw_value
+                     << "', disabling Store segment pinning";
         return {false, 0};
     }
-    return {true, *limit};
+    return {limit != 0, limit};
+}
+
+void LogPinSkip(const std::string& owner, const char* reason, size_t size) {
+    LOG(WARNING) << "Skip cudaHostRegister for " << owner << ": " << reason
+                 << ", size=" << size;
 }
 
 #if defined(USE_CUDA)
@@ -110,11 +89,8 @@ RegisteredPinnedMemoryManager& RegisteredPinnedMemoryManager::instance() {
 }
 
 RegisteredPinnedMemoryManager::RegisteredPinnedMemoryManager()
-    : RegisteredPinnedMemoryManager(ParsePinnedMemoryConfig()) {}
-
-RegisteredPinnedMemoryManager::RegisteredPinnedMemoryManager(
-    std::pair<bool, uint64_t> config)
-    : RegisteredPinnedMemoryManager(config, DefaultPinOps()) {}
+    : RegisteredPinnedMemoryManager(ParsePinnedMemoryConfig(),
+                                    DefaultPinOps()) {}
 
 RegisteredPinnedMemoryManager::RegisteredPinnedMemoryManager(
     std::pair<bool, uint64_t> config, PinOps pin_ops)
@@ -141,17 +117,15 @@ std::shared_ptr<RegisteredPinnedRegion> RegisteredPinnedMemoryManager::try_pin(
     const auto start = reinterpret_cast<uintptr_t>(addr);
     const auto end = start + size;
     if (end < start) {
-        LOG(WARNING) << "Skip cudaHostRegister for " << owner
-                     << ": address range overflow, size=" << size;
+        LogPinSkip(owner, "address range overflow", size);
         return nullptr;
     }
 
     std::shared_ptr<RegisteredPinnedRegion> region;
     try {
-        region.reset(new RegisteredPinnedRegion(this, addr, size, owner));
+        region.reset(new RegisteredPinnedRegion(this, addr, size));
     } catch (...) {
-        LOG(WARNING) << "Skip cudaHostRegister for " << owner
-                     << ": failed to allocate pin tracking, size=" << size;
+        LogPinSkip(owner, "failed to allocate pin tracking", size);
         return nullptr;
     }
 
@@ -160,18 +134,9 @@ std::shared_ptr<RegisteredPinnedRegion> RegisteredPinnedMemoryManager::try_pin(
         for (const auto& entry : regions_) {
             const auto region_start = reinterpret_cast<uintptr_t>(entry.addr);
             const auto region_end = region_start + entry.size;
-            if (region_end < region_start) {
-                LOG(WARNING)
-                    << "Skip cudaHostRegister for " << owner
-                    << ": existing active range overflow, size=" << entry.size;
-                return nullptr;
-            }
-
             const bool overlaps = start < region_end && end > region_start;
             if (overlaps) {
-                LOG(WARNING)
-                    << "Skip cudaHostRegister for " << owner
-                    << ": overlaps an active pinned region, size=" << size;
+                LogPinSkip(owner, "overlaps an active pinned region", size);
                 return nullptr;
             }
         }
@@ -187,8 +152,7 @@ std::shared_ptr<RegisteredPinnedRegion> RegisteredPinnedMemoryManager::try_pin(
         try {
             regions_.push_back({addr, size, nullptr});
         } catch (...) {
-            LOG(WARNING) << "Skip cudaHostRegister for " << owner
-                         << ": failed to allocate pin tracking, size=" << size;
+            LogPinSkip(owner, "failed to allocate pin tracking", size);
             return nullptr;
         }
         pinned_bytes_ += size;
@@ -208,7 +172,6 @@ std::shared_ptr<RegisteredPinnedRegion> RegisteredPinnedMemoryManager::try_pin(
         return nullptr;
     }
 
-    bool tracking_ready = false;
     uint64_t pinned_bytes = 0;
     {
         std::lock_guard<std::mutex> lock(mutex_);
@@ -216,25 +179,9 @@ std::shared_ptr<RegisteredPinnedRegion> RegisteredPinnedMemoryManager::try_pin(
             if (entry.addr == addr && entry.size == size && !entry.region) {
                 entry.region = region.get();
                 pinned_bytes = pinned_bytes_;
-                tracking_ready = true;
                 break;
             }
         }
-    }
-    if (!tracking_ready) {
-        error_message.clear();
-        auto unregister_result =
-            pin_ops_.unregister_region(addr, &error_message);
-        if (unregister_result != UnregisterResult::kSuccess) {
-            LOG(ERROR) << "cudaHostUnregister failed after active range "
-                          "tracking mismatch for "
-                       << owner << ", size=" << size
-                       << ", error=" << error_message
-                       << ". Continue with best-effort cleanup.";
-        }
-        std::lock_guard<std::mutex> lock(mutex_);
-        remove_inactive_region_locked(addr, size);
-        return nullptr;
     }
 
     LOG(INFO) << "cudaHostRegister succeeded for " << owner << ", size=" << size
@@ -266,12 +213,11 @@ void RegisteredPinnedMemoryManager::release(RegisteredPinnedRegion* region) {
     // stale raw tracking pointers do not outlive the Store segment owner.
     if (unregister_result != UnregisterResult::kSuccess) {
         if (unregister_result == UnregisterResult::kRuntimeUnloading) {
-            LOG(WARNING) << "Skip cudaHostUnregister for " << region->owner_
-                         << " because CUDA runtime is unloading, size="
+            LOG(WARNING) << "Skip cudaHostUnregister because CUDA runtime "
+                            "is unloading, size="
                          << region->size_;
         } else {
-            LOG(ERROR) << "cudaHostUnregister failed for " << region->owner_
-                       << ", size=" << region->size_
+            LOG(ERROR) << "cudaHostUnregister failed, size=" << region->size_
                        << ", error=" << error_message
                        << ". Continue with best-effort cleanup.";
         }

--- a/mooncake-store/src/registered_pinned_memory.cpp
+++ b/mooncake-store/src/registered_pinned_memory.cpp
@@ -5,6 +5,7 @@
 #include <charconv>
 #include <cstdlib>
 #include <optional>
+#include <string>
 #include <system_error>
 
 #include <glog/logging.h>
@@ -16,11 +17,30 @@
 namespace mooncake {
 namespace {
 
+std::pair<const char*, const char*> TrimAsciiWhitespace(const char* value) {
+    const char* begin = value;
+    while (std::isspace(static_cast<unsigned char>(*begin))) {
+        ++begin;
+    }
+
+    const char* end = begin;
+    while (*end != '\0') {
+        ++end;
+    }
+    while (end > begin &&
+           std::isspace(static_cast<unsigned char>(*(end - 1)))) {
+        --end;
+    }
+
+    return {begin, end};
+}
+
 bool ParsePinnedMemoryEnabled() {
     const char* value = std::getenv("MC_STORE_PIN_MEMORY");
     if (!value) return true;
 
-    std::string normalized(value);
+    auto [begin, end] = TrimAsciiWhitespace(value);
+    std::string normalized(begin, end);
     std::transform(
         normalized.begin(), normalized.end(), normalized.begin(),
         [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
@@ -32,23 +52,11 @@ std::optional<uint64_t> ParsePinnedMemoryLimit() {
     const char* value = std::getenv("MC_STORE_PIN_MEMORY_MAX_BYTES");
     if (!value || value[0] == '\0') return 0;
 
-    const char* number = value;
-    while (std::isspace(static_cast<unsigned char>(*number))) {
-        ++number;
-    }
+    auto [number, end] = TrimAsciiWhitespace(value);
     if (*number == '-') {
         LOG(WARNING) << "Invalid MC_STORE_PIN_MEMORY_MAX_BYTES='" << value
                      << "', disabling Store segment pinning";
         return std::nullopt;
-    }
-
-    const char* end = number;
-    while (*end != '\0') {
-        ++end;
-    }
-    while (end > number &&
-           std::isspace(static_cast<unsigned char>(*(end - 1)))) {
-        --end;
     }
 
     uint64_t parsed = 0;
@@ -232,9 +240,15 @@ void RegisteredPinnedMemoryManager::release(RegisteredPinnedRegion* region) {
 #if defined(USE_CUDA)
     cudaError_t err = cudaHostUnregister(region->addr_);
     if (err != cudaSuccess) {
-        LOG(FATAL) << "cudaHostUnregister failed for " << region->owner_
-                   << ", size=" << region->size_
-                   << ", error=" << cudaGetErrorString(err);
+        if (err == cudaErrorCudartUnloading) {
+            LOG(WARNING) << "Skip cudaHostUnregister for " << region->owner_
+                         << " because CUDA runtime is unloading, size="
+                         << region->size_;
+        } else {
+            LOG(FATAL) << "cudaHostUnregister failed for " << region->owner_
+                       << ", size=" << region->size_
+                       << ", error=" << cudaGetErrorString(err);
+        }
     }
 #endif
 

--- a/mooncake-store/src/registered_pinned_memory.cpp
+++ b/mooncake-store/src/registered_pinned_memory.cpp
@@ -1,11 +1,11 @@
 #include "registered_pinned_memory.h"
 
 #include <algorithm>
-#include <cerrno>
 #include <cctype>
+#include <charconv>
 #include <cstdlib>
-#include <limits>
 #include <optional>
+#include <system_error>
 
 #include <glog/logging.h>
 
@@ -42,19 +42,23 @@ std::optional<uint64_t> ParsePinnedMemoryLimit() {
         return std::nullopt;
     }
 
-    char* end = nullptr;
-    errno = 0;
-    unsigned long long parsed = std::strtoull(number, &end, 10);
-    while (end && std::isspace(static_cast<unsigned char>(*end))) {
+    const char* end = number;
+    while (*end != '\0') {
         ++end;
     }
-    if (end == number || (end && *end != '\0') || errno == ERANGE ||
-        parsed > std::numeric_limits<uint64_t>::max()) {
+    while (end > number &&
+           std::isspace(static_cast<unsigned char>(*(end - 1)))) {
+        --end;
+    }
+
+    uint64_t parsed = 0;
+    auto [ptr, ec] = std::from_chars(number, end, parsed);
+    if (ec != std::errc{} || ptr != end) {
         LOG(WARNING) << "Invalid MC_STORE_PIN_MEMORY_MAX_BYTES='" << value
                      << "', disabling Store segment pinning";
         return std::nullopt;
     }
-    return static_cast<uint64_t>(parsed);
+    return parsed;
 }
 
 std::pair<bool, uint64_t> ParsePinnedMemoryConfig() {
@@ -74,8 +78,9 @@ RegisteredPinnedRegion::~RegisteredPinnedRegion() {
 }
 
 RegisteredPinnedMemoryManager& RegisteredPinnedMemoryManager::instance() {
-    static RegisteredPinnedMemoryManager manager;
-    return manager;
+    static RegisteredPinnedMemoryManager* manager =
+        new RegisteredPinnedMemoryManager();
+    return *manager;
 }
 
 RegisteredPinnedMemoryManager::RegisteredPinnedMemoryManager()

--- a/mooncake-store/src/registered_pinned_memory.cpp
+++ b/mooncake-store/src/registered_pinned_memory.cpp
@@ -1,0 +1,256 @@
+#include "registered_pinned_memory.h"
+
+#include <algorithm>
+#include <cerrno>
+#include <cctype>
+#include <cstdlib>
+#include <limits>
+#include <optional>
+
+#include <glog/logging.h>
+
+#if defined(USE_CUDA)
+#include <cuda_runtime_api.h>
+#endif
+
+namespace mooncake {
+namespace {
+
+bool ParsePinnedMemoryEnabled() {
+    const char* value = std::getenv("MC_STORE_PIN_MEMORY");
+    if (!value) return true;
+
+    std::string normalized(value);
+    std::transform(
+        normalized.begin(), normalized.end(), normalized.begin(),
+        [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+    return !(normalized == "0" || normalized == "false" ||
+             normalized == "off" || normalized == "no");
+}
+
+std::optional<uint64_t> ParsePinnedMemoryLimit() {
+    const char* value = std::getenv("MC_STORE_PIN_MEMORY_MAX_BYTES");
+    if (!value || value[0] == '\0') return 0;
+
+    const char* number = value;
+    while (std::isspace(static_cast<unsigned char>(*number))) {
+        ++number;
+    }
+    if (*number == '-') {
+        LOG(WARNING) << "Invalid MC_STORE_PIN_MEMORY_MAX_BYTES='" << value
+                     << "', disabling Store segment pinning";
+        return std::nullopt;
+    }
+
+    char* end = nullptr;
+    errno = 0;
+    unsigned long long parsed = std::strtoull(number, &end, 10);
+    while (end && std::isspace(static_cast<unsigned char>(*end))) {
+        ++end;
+    }
+    if (end == number || (end && *end != '\0') || errno == ERANGE ||
+        parsed > std::numeric_limits<uint64_t>::max()) {
+        LOG(WARNING) << "Invalid MC_STORE_PIN_MEMORY_MAX_BYTES='" << value
+                     << "', disabling Store segment pinning";
+        return std::nullopt;
+    }
+    return static_cast<uint64_t>(parsed);
+}
+
+std::pair<bool, uint64_t> ParsePinnedMemoryConfig() {
+    if (!ParsePinnedMemoryEnabled()) return {false, 0};
+
+    auto limit = ParsePinnedMemoryLimit();
+    if (!limit.has_value() || *limit == 0) {
+        return {false, 0};
+    }
+    return {true, *limit};
+}
+
+}  // namespace
+
+RegisteredPinnedRegion::~RegisteredPinnedRegion() {
+    RegisteredPinnedMemoryManager::instance().release(this);
+}
+
+RegisteredPinnedMemoryManager& RegisteredPinnedMemoryManager::instance() {
+    static RegisteredPinnedMemoryManager manager;
+    return manager;
+}
+
+RegisteredPinnedMemoryManager::RegisteredPinnedMemoryManager()
+    : RegisteredPinnedMemoryManager(ParsePinnedMemoryConfig()) {}
+
+RegisteredPinnedMemoryManager::RegisteredPinnedMemoryManager(
+    std::pair<bool, uint64_t> config)
+    : enabled_(config.first), limit_bytes_(config.second) {
+#if defined(USE_CUDA)
+    LOG(INFO) << "Store segment pinned memory is "
+              << (enabled_ ? "enabled" : "disabled")
+              << ", max_bytes=" << limit_bytes_;
+#else
+    if (enabled_) {
+        LOG(INFO) << "Store segment pinning requested but this build has no "
+                     "CUDA runtime support";
+    }
+#endif
+}
+
+std::shared_ptr<RegisteredPinnedRegion> RegisteredPinnedMemoryManager::try_pin(
+    void* addr, size_t size, const std::string& owner) {
+    if (!addr || size == 0 || !enabled_) return nullptr;
+
+#if !defined(USE_CUDA)
+    (void)owner;
+    return nullptr;
+#else
+    RegionKey key{addr, size};
+    const auto start = reinterpret_cast<uintptr_t>(addr);
+    const auto end = start + size;
+    if (end < start) {
+        LOG(WARNING) << "Skip cudaHostRegister for " << owner
+                     << ": address range overflow, size=" << size;
+        return nullptr;
+    }
+
+    std::shared_ptr<RegisteredPinnedRegion> region;
+    try {
+        region.reset(new RegisteredPinnedRegion(addr, size, owner));
+    } catch (...) {
+        LOG(WARNING) << "Skip cudaHostRegister for " << owner
+                     << ": failed to allocate pin tracking, size=" << size;
+        return nullptr;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        for (const auto& entry : regions_) {
+            const auto region_start =
+                reinterpret_cast<uintptr_t>(entry.first.addr);
+            const auto region_end = region_start + entry.first.size;
+            if (region_end < region_start) {
+                LOG(WARNING) << "Skip cudaHostRegister for " << owner
+                             << ": existing active range overflow, size="
+                             << entry.first.size;
+                return nullptr;
+            }
+
+            const bool overlaps = start < region_end && end > region_start;
+            if (overlaps) {
+                LOG(WARNING)
+                    << "Skip cudaHostRegister for " << owner
+                    << ": overlaps an active pinned region, size=" << size;
+                return nullptr;
+            }
+        }
+
+        if (size > limit_bytes_ || pinned_bytes_ > limit_bytes_ - size) {
+            LOG(WARNING) << "Skip cudaHostRegister for " << owner
+                         << ": quota exceeded, requested=" << size
+                         << ", pinned=" << pinned_bytes_
+                         << ", limit=" << limit_bytes_;
+            return nullptr;
+        }
+
+        try {
+            auto [_, inserted] = regions_.emplace(key, nullptr);
+            if (!inserted) {
+                LOG(WARNING) << "Skip cudaHostRegister for " << owner
+                             << ": active region already exists, size=" << size;
+                return nullptr;
+            }
+        } catch (...) {
+            LOG(WARNING) << "Skip cudaHostRegister for " << owner
+                         << ": failed to allocate pin tracking, size=" << size;
+            return nullptr;
+        }
+        pinned_bytes_ += size;
+    }
+
+    cudaError_t err = cudaHostRegister(addr, size, cudaHostRegisterPortable);
+    if (err != cudaSuccess) {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            drop_reservation_locked(key, size);
+        }
+        LOG(WARNING) << "cudaHostRegister failed for " << owner
+                     << ", size=" << size
+                     << ", error=" << cudaGetErrorString(err)
+                     << ". Continue with pageable host memory.";
+        cudaGetLastError();
+        return nullptr;
+    }
+
+    bool tracking_ready = false;
+    uint64_t pinned_bytes = 0;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto it = regions_.find(key);
+        if (it != regions_.end() && it->second == nullptr) {
+            it->second = region.get();
+            pinned_bytes = pinned_bytes_;
+            tracking_ready = true;
+        }
+    }
+    if (!tracking_ready) {
+        err = cudaHostUnregister(addr);
+        if (err != cudaSuccess) {
+            LOG(FATAL) << "cudaHostUnregister failed after active range "
+                          "tracking mismatch for "
+                       << owner << ", size=" << size
+                       << ", error=" << cudaGetErrorString(err);
+        }
+        std::lock_guard<std::mutex> lock(mutex_);
+        drop_reservation_locked(key, size);
+        return nullptr;
+    }
+
+    LOG(INFO) << "cudaHostRegister succeeded for " << owner << ", size=" << size
+              << ", pinned=" << pinned_bytes << ", limit=" << limit_bytes_;
+    return region;
+#endif
+}
+
+void RegisteredPinnedMemoryManager::release(RegisteredPinnedRegion* region) {
+    if (!region || !region->addr_ || region->size_ == 0) return;
+
+    RegionKey key{region->addr_, region->size_};
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto region_it = regions_.find(key);
+        if (region_it == regions_.end() || region_it->second != region) {
+            return;
+        }
+        region_it->second = nullptr;
+    }
+
+#if defined(USE_CUDA)
+    cudaError_t err = cudaHostUnregister(region->addr_);
+    if (err != cudaSuccess) {
+        LOG(FATAL) << "cudaHostUnregister failed for " << region->owner_
+                   << ", size=" << region->size_
+                   << ", error=" << cudaGetErrorString(err);
+    }
+#endif
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = regions_.find(key);
+    if (it == regions_.end() || it->second != nullptr) return;
+    regions_.erase(it);
+    if (pinned_bytes_ >= region->size_) {
+        pinned_bytes_ -= region->size_;
+    } else {
+        pinned_bytes_ = 0;
+    }
+}
+
+void RegisteredPinnedMemoryManager::drop_reservation_locked(
+    const RegionKey& key, size_t size) {
+    auto it = regions_.find(key);
+    if (it != regions_.end() && it->second == nullptr) {
+        regions_.erase(it);
+        pinned_bytes_ = pinned_bytes_ >= size ? pinned_bytes_ - size : 0;
+    }
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/registered_pinned_memory.cpp
+++ b/mooncake-store/src/registered_pinned_memory.cpp
@@ -78,9 +78,7 @@ RegisteredPinnedMemoryManager::PinOps DefaultPinOps() {
 
 }  // namespace
 
-RegisteredPinnedRegion::~RegisteredPinnedRegion() {
-    release();
-}
+RegisteredPinnedRegion::~RegisteredPinnedRegion() { release(); }
 
 bool RegisteredPinnedRegion::release() {
     if (!manager_) return release_succeeded_;

--- a/mooncake-store/src/registered_pinned_memory.cpp
+++ b/mooncake-store/src/registered_pinned_memory.cpp
@@ -154,7 +154,6 @@ std::shared_ptr<RegisteredPinnedRegion> RegisteredPinnedMemoryManager::try_pin(
         return nullptr;
     }
 
-    RegionKey key{addr, size};
     const auto start = reinterpret_cast<uintptr_t>(addr);
     const auto end = start + size;
     if (end < start) {
@@ -175,13 +174,12 @@ std::shared_ptr<RegisteredPinnedRegion> RegisteredPinnedMemoryManager::try_pin(
     {
         std::lock_guard<std::mutex> lock(mutex_);
         for (const auto& entry : regions_) {
-            const auto region_start =
-                reinterpret_cast<uintptr_t>(entry.first.addr);
-            const auto region_end = region_start + entry.first.size;
+            const auto region_start = reinterpret_cast<uintptr_t>(entry.addr);
+            const auto region_end = region_start + entry.size;
             if (region_end < region_start) {
-                LOG(WARNING) << "Skip cudaHostRegister for " << owner
-                             << ": existing active range overflow, size="
-                             << entry.first.size;
+                LOG(WARNING)
+                    << "Skip cudaHostRegister for " << owner
+                    << ": existing active range overflow, size=" << entry.size;
                 return nullptr;
             }
 
@@ -203,12 +201,7 @@ std::shared_ptr<RegisteredPinnedRegion> RegisteredPinnedMemoryManager::try_pin(
         }
 
         try {
-            auto [_, inserted] = regions_.emplace(key, nullptr);
-            if (!inserted) {
-                LOG(WARNING) << "Skip cudaHostRegister for " << owner
-                             << ": active region already exists, size=" << size;
-                return nullptr;
-            }
+            regions_.push_back({addr, size, nullptr});
         } catch (...) {
             LOG(WARNING) << "Skip cudaHostRegister for " << owner
                          << ": failed to allocate pin tracking, size=" << size;
@@ -223,7 +216,7 @@ std::shared_ptr<RegisteredPinnedRegion> RegisteredPinnedMemoryManager::try_pin(
     if (!registered) {
         {
             std::lock_guard<std::mutex> lock(mutex_);
-            drop_reservation_locked(key, size);
+            remove_inactive_region_locked(addr, size);
         }
         LOG(WARNING) << "cudaHostRegister failed for " << owner
                      << ", size=" << size << ", error=" << error_message
@@ -235,11 +228,14 @@ std::shared_ptr<RegisteredPinnedRegion> RegisteredPinnedMemoryManager::try_pin(
     uint64_t pinned_bytes = 0;
     {
         std::lock_guard<std::mutex> lock(mutex_);
-        auto it = regions_.find(key);
-        if (it != regions_.end() && it->second == nullptr) {
-            it->second = region.get();
+        for (auto& entry : regions_) {
+            if (entry.addr != addr || entry.size != size || entry.region) {
+                continue;
+            }
+            entry.region = region.get();
             pinned_bytes = pinned_bytes_;
             tracking_ready = true;
+            break;
         }
     }
     if (!tracking_ready) {
@@ -254,7 +250,7 @@ std::shared_ptr<RegisteredPinnedRegion> RegisteredPinnedMemoryManager::try_pin(
                        << ". Continue with best-effort cleanup.";
         }
         std::lock_guard<std::mutex> lock(mutex_);
-        drop_reservation_locked(key, size);
+        remove_inactive_region_locked(addr, size);
         return nullptr;
     }
 
@@ -266,15 +262,20 @@ std::shared_ptr<RegisteredPinnedRegion> RegisteredPinnedMemoryManager::try_pin(
 void RegisteredPinnedMemoryManager::release(RegisteredPinnedRegion* region) {
     if (!region || !region->addr_ || region->size_ == 0) return;
 
-    RegionKey key{region->addr_, region->size_};
+    bool should_unregister = false;
     {
         std::lock_guard<std::mutex> lock(mutex_);
-        auto region_it = regions_.find(key);
-        if (region_it == regions_.end() || region_it->second != region) {
-            return;
+        for (auto& entry : regions_) {
+            if (entry.addr != region->addr_ || entry.size != region->size_ ||
+                entry.region != region) {
+                continue;
+            }
+            entry.region = nullptr;
+            should_unregister = true;
+            break;
         }
-        region_it->second = nullptr;
     }
+    if (!should_unregister) return;
 
     std::string error_message;
     if (!pin_ops_.unregister_region) return;
@@ -296,22 +297,16 @@ void RegisteredPinnedMemoryManager::release(RegisteredPinnedRegion* region) {
     }
 
     std::lock_guard<std::mutex> lock(mutex_);
-    auto it = regions_.find(key);
-    if (it == regions_.end() || it->second != nullptr) return;
-    regions_.erase(it);
-    if (pinned_bytes_ >= region->size_) {
-        pinned_bytes_ -= region->size_;
-    } else {
-        pinned_bytes_ = 0;
-    }
+    remove_inactive_region_locked(region->addr_, region->size_);
 }
 
-void RegisteredPinnedMemoryManager::drop_reservation_locked(
-    const RegionKey& key, size_t size) {
-    auto it = regions_.find(key);
-    if (it != regions_.end() && it->second == nullptr) {
+void RegisteredPinnedMemoryManager::remove_inactive_region_locked(void* addr,
+                                                                  size_t size) {
+    for (auto it = regions_.begin(); it != regions_.end(); ++it) {
+        if (it->addr != addr || it->size != size || it->region) continue;
         regions_.erase(it);
         pinned_bytes_ = pinned_bytes_ >= size ? pinned_bytes_ - size : 0;
+        return;
     }
 }
 

--- a/mooncake-store/src/registered_pinned_memory.cpp
+++ b/mooncake-store/src/registered_pinned_memory.cpp
@@ -79,7 +79,15 @@ RegisteredPinnedMemoryManager::PinOps DefaultPinOps() {
 }  // namespace
 
 RegisteredPinnedRegion::~RegisteredPinnedRegion() {
-    if (manager_) manager_->release(this);
+    release();
+}
+
+bool RegisteredPinnedRegion::release() {
+    if (!manager_) return release_succeeded_;
+    auto* manager = manager_;
+    manager_ = nullptr;
+    release_succeeded_ = manager->release(this);
+    return release_succeeded_;
 }
 
 RegisteredPinnedMemoryManager& RegisteredPinnedMemoryManager::instance() {
@@ -189,8 +197,8 @@ std::shared_ptr<RegisteredPinnedRegion> RegisteredPinnedMemoryManager::try_pin(
     return region;
 }
 
-void RegisteredPinnedMemoryManager::release(RegisteredPinnedRegion* region) {
-    if (!region || !region->addr_ || region->size_ == 0) return;
+bool RegisteredPinnedMemoryManager::release(RegisteredPinnedRegion* region) {
+    if (!region || !region->addr_ || region->size_ == 0) return true;
 
     bool should_unregister = false;
     {
@@ -204,13 +212,11 @@ void RegisteredPinnedMemoryManager::release(RegisteredPinnedRegion* region) {
             }
         }
     }
-    if (!should_unregister) return;
+    if (!should_unregister) return true;
 
     std::string error_message;
     auto unregister_result =
         pin_ops_.unregister_region(region->addr_, &error_message);
-    // Treat CUDA unregistration as best-effort cleanup: drop manager state so
-    // stale raw tracking pointers do not outlive the Store segment owner.
     if (unregister_result != UnregisterResult::kSuccess) {
         if (unregister_result == UnregisterResult::kRuntimeUnloading) {
             LOG(WARNING) << "Skip cudaHostUnregister because CUDA runtime "
@@ -219,12 +225,15 @@ void RegisteredPinnedMemoryManager::release(RegisteredPinnedRegion* region) {
         } else {
             LOG(ERROR) << "cudaHostUnregister failed, size=" << region->size_
                        << ", error=" << error_message
-                       << ". Continue with best-effort cleanup.";
+                       << ". Keep the range reserved; backing memory must not "
+                          "be freed.";
+            return false;
         }
     }
 
     std::lock_guard<std::mutex> lock(mutex_);
     remove_inactive_region_locked(region->addr_, region->size_);
+    return true;
 }
 
 void RegisteredPinnedMemoryManager::remove_inactive_region_locked(void* addr,

--- a/mooncake-store/src/registered_pinned_memory.cpp
+++ b/mooncake-store/src/registered_pinned_memory.cpp
@@ -1,6 +1,5 @@
 #include "registered_pinned_memory.h"
 
-#include <algorithm>
 #include <cctype>
 #include <charconv>
 #include <cstdlib>
@@ -35,19 +34,6 @@ std::pair<const char*, const char*> TrimAsciiWhitespace(const char* value) {
     return {begin, end};
 }
 
-bool ParsePinnedMemoryEnabled() {
-    const char* value = std::getenv("MC_STORE_PIN_MEMORY");
-    if (!value) return true;
-
-    auto [begin, end] = TrimAsciiWhitespace(value);
-    std::string normalized(begin, end);
-    std::transform(
-        normalized.begin(), normalized.end(), normalized.begin(),
-        [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
-    return !(normalized == "0" || normalized == "false" ||
-             normalized == "off" || normalized == "no");
-}
-
 std::optional<uint64_t> ParsePinnedMemoryLimit() {
     const char* value = std::getenv("MC_STORE_PIN_MEMORY_MAX_BYTES");
     if (!value || value[0] == '\0') return 0;
@@ -70,8 +56,6 @@ std::optional<uint64_t> ParsePinnedMemoryLimit() {
 }
 
 std::pair<bool, uint64_t> ParsePinnedMemoryConfig() {
-    if (!ParsePinnedMemoryEnabled()) return {false, 0};
-
     auto limit = ParsePinnedMemoryLimit();
     if (!limit.has_value() || *limit == 0) {
         return {false, 0};
@@ -229,13 +213,12 @@ std::shared_ptr<RegisteredPinnedRegion> RegisteredPinnedMemoryManager::try_pin(
     {
         std::lock_guard<std::mutex> lock(mutex_);
         for (auto& entry : regions_) {
-            if (entry.addr != addr || entry.size != size || entry.region) {
-                continue;
+            if (entry.addr == addr && entry.size == size && !entry.region) {
+                entry.region = region.get();
+                pinned_bytes = pinned_bytes_;
+                tracking_ready = true;
+                break;
             }
-            entry.region = region.get();
-            pinned_bytes = pinned_bytes_;
-            tracking_ready = true;
-            break;
         }
     }
     if (!tracking_ready) {
@@ -266,19 +249,17 @@ void RegisteredPinnedMemoryManager::release(RegisteredPinnedRegion* region) {
     {
         std::lock_guard<std::mutex> lock(mutex_);
         for (auto& entry : regions_) {
-            if (entry.addr != region->addr_ || entry.size != region->size_ ||
-                entry.region != region) {
-                continue;
+            if (entry.addr == region->addr_ && entry.size == region->size_ &&
+                entry.region == region) {
+                entry.region = nullptr;
+                should_unregister = true;
+                break;
             }
-            entry.region = nullptr;
-            should_unregister = true;
-            break;
         }
     }
     if (!should_unregister) return;
 
     std::string error_message;
-    if (!pin_ops_.unregister_region) return;
     auto unregister_result =
         pin_ops_.unregister_region(region->addr_, &error_message);
     // Treat CUDA unregistration as best-effort cleanup: drop manager state so
@@ -303,10 +284,11 @@ void RegisteredPinnedMemoryManager::release(RegisteredPinnedRegion* region) {
 void RegisteredPinnedMemoryManager::remove_inactive_region_locked(void* addr,
                                                                   size_t size) {
     for (auto it = regions_.begin(); it != regions_.end(); ++it) {
-        if (it->addr != addr || it->size != size || it->region) continue;
-        regions_.erase(it);
-        pinned_bytes_ = pinned_bytes_ >= size ? pinned_bytes_ - size : 0;
-        return;
+        if (it->addr == addr && it->size == size && !it->region) {
+            regions_.erase(it);
+            pinned_bytes_ = pinned_bytes_ >= size ? pinned_bytes_ - size : 0;
+            return;
+        }
     }
 }
 

--- a/mooncake-store/src/registered_pinned_memory.cpp
+++ b/mooncake-store/src/registered_pinned_memory.cpp
@@ -79,10 +79,44 @@ std::pair<bool, uint64_t> ParsePinnedMemoryConfig() {
     return {true, *limit};
 }
 
+#if defined(USE_CUDA)
+bool RegisterPinnedRegionWithCuda(void* addr, size_t size,
+                                  std::string* error_message) {
+    cudaError_t err = cudaHostRegister(addr, size, cudaHostRegisterPortable);
+    if (err == cudaSuccess) return true;
+    if (error_message) *error_message = cudaGetErrorString(err);
+    cudaGetLastError();
+    return false;
+}
+
+RegisteredPinnedMemoryManager::UnregisterResult UnregisterPinnedRegionWithCuda(
+    void* addr, std::string* error_message) {
+    cudaError_t err = cudaHostUnregister(addr);
+    if (err == cudaSuccess) {
+        return RegisteredPinnedMemoryManager::UnregisterResult::kSuccess;
+    }
+    if (error_message) *error_message = cudaGetErrorString(err);
+    if (err == cudaErrorCudartUnloading) {
+        return RegisteredPinnedMemoryManager::UnregisterResult::
+            kRuntimeUnloading;
+    }
+    return RegisteredPinnedMemoryManager::UnregisterResult::kError;
+}
+
+#endif
+
+RegisteredPinnedMemoryManager::PinOps DefaultPinOps() {
+#if defined(USE_CUDA)
+    return {RegisterPinnedRegionWithCuda, UnregisterPinnedRegionWithCuda};
+#else
+    return {};
+#endif
+}
+
 }  // namespace
 
 RegisteredPinnedRegion::~RegisteredPinnedRegion() {
-    RegisteredPinnedMemoryManager::instance().release(this);
+    if (manager_) manager_->release(this);
 }
 
 RegisteredPinnedMemoryManager& RegisteredPinnedMemoryManager::instance() {
@@ -96,7 +130,11 @@ RegisteredPinnedMemoryManager::RegisteredPinnedMemoryManager()
 
 RegisteredPinnedMemoryManager::RegisteredPinnedMemoryManager(
     std::pair<bool, uint64_t> config)
-    : enabled_(config.first), limit_bytes_(config.second) {
+    : RegisteredPinnedMemoryManager(config, DefaultPinOps()) {}
+
+RegisteredPinnedMemoryManager::RegisteredPinnedMemoryManager(
+    std::pair<bool, uint64_t> config, PinOps pin_ops)
+    : enabled_(config.first), limit_bytes_(config.second), pin_ops_(pin_ops) {
 #if defined(USE_CUDA)
     LOG(INFO) << "Store segment pinned memory is "
               << (enabled_ ? "enabled" : "disabled")
@@ -112,11 +150,10 @@ RegisteredPinnedMemoryManager::RegisteredPinnedMemoryManager(
 std::shared_ptr<RegisteredPinnedRegion> RegisteredPinnedMemoryManager::try_pin(
     void* addr, size_t size, const std::string& owner) {
     if (!addr || size == 0 || !enabled_) return nullptr;
+    if (!pin_ops_.register_region || !pin_ops_.unregister_region) {
+        return nullptr;
+    }
 
-#if !defined(USE_CUDA)
-    (void)owner;
-    return nullptr;
-#else
     RegionKey key{addr, size};
     const auto start = reinterpret_cast<uintptr_t>(addr);
     const auto end = start + size;
@@ -128,7 +165,7 @@ std::shared_ptr<RegisteredPinnedRegion> RegisteredPinnedMemoryManager::try_pin(
 
     std::shared_ptr<RegisteredPinnedRegion> region;
     try {
-        region.reset(new RegisteredPinnedRegion(addr, size, owner));
+        region.reset(new RegisteredPinnedRegion(this, addr, size, owner));
     } catch (...) {
         LOG(WARNING) << "Skip cudaHostRegister for " << owner
                      << ": failed to allocate pin tracking, size=" << size;
@@ -180,17 +217,17 @@ std::shared_ptr<RegisteredPinnedRegion> RegisteredPinnedMemoryManager::try_pin(
         pinned_bytes_ += size;
     }
 
-    cudaError_t err = cudaHostRegister(addr, size, cudaHostRegisterPortable);
-    if (err != cudaSuccess) {
+    std::string error_message;
+    const bool registered =
+        pin_ops_.register_region(addr, size, &error_message);
+    if (!registered) {
         {
             std::lock_guard<std::mutex> lock(mutex_);
             drop_reservation_locked(key, size);
         }
         LOG(WARNING) << "cudaHostRegister failed for " << owner
-                     << ", size=" << size
-                     << ", error=" << cudaGetErrorString(err)
+                     << ", size=" << size << ", error=" << error_message
                      << ". Continue with pageable host memory.";
-        cudaGetLastError();
         return nullptr;
     }
 
@@ -206,12 +243,14 @@ std::shared_ptr<RegisteredPinnedRegion> RegisteredPinnedMemoryManager::try_pin(
         }
     }
     if (!tracking_ready) {
-        err = cudaHostUnregister(addr);
-        if (err != cudaSuccess) {
+        error_message.clear();
+        auto unregister_result =
+            pin_ops_.unregister_region(addr, &error_message);
+        if (unregister_result != UnregisterResult::kSuccess) {
             LOG(FATAL) << "cudaHostUnregister failed after active range "
                           "tracking mismatch for "
                        << owner << ", size=" << size
-                       << ", error=" << cudaGetErrorString(err);
+                       << ", error=" << error_message;
         }
         std::lock_guard<std::mutex> lock(mutex_);
         drop_reservation_locked(key, size);
@@ -221,7 +260,6 @@ std::shared_ptr<RegisteredPinnedRegion> RegisteredPinnedMemoryManager::try_pin(
     LOG(INFO) << "cudaHostRegister succeeded for " << owner << ", size=" << size
               << ", pinned=" << pinned_bytes << ", limit=" << limit_bytes_;
     return region;
-#endif
 }
 
 void RegisteredPinnedMemoryManager::release(RegisteredPinnedRegion* region) {
@@ -237,20 +275,21 @@ void RegisteredPinnedMemoryManager::release(RegisteredPinnedRegion* region) {
         region_it->second = nullptr;
     }
 
-#if defined(USE_CUDA)
-    cudaError_t err = cudaHostUnregister(region->addr_);
-    if (err != cudaSuccess) {
-        if (err == cudaErrorCudartUnloading) {
+    std::string error_message;
+    if (!pin_ops_.unregister_region) return;
+    auto unregister_result =
+        pin_ops_.unregister_region(region->addr_, &error_message);
+    if (unregister_result != UnregisterResult::kSuccess) {
+        if (unregister_result == UnregisterResult::kRuntimeUnloading) {
             LOG(WARNING) << "Skip cudaHostUnregister for " << region->owner_
                          << " because CUDA runtime is unloading, size="
                          << region->size_;
         } else {
             LOG(FATAL) << "cudaHostUnregister failed for " << region->owner_
                        << ", size=" << region->size_
-                       << ", error=" << cudaGetErrorString(err);
+                       << ", error=" << error_message;
         }
     }
-#endif
 
     std::lock_guard<std::mutex> lock(mutex_);
     auto it = regions_.find(key);

--- a/mooncake-store/src/registered_pinned_memory.cpp
+++ b/mooncake-store/src/registered_pinned_memory.cpp
@@ -247,10 +247,11 @@ std::shared_ptr<RegisteredPinnedRegion> RegisteredPinnedMemoryManager::try_pin(
         auto unregister_result =
             pin_ops_.unregister_region(addr, &error_message);
         if (unregister_result != UnregisterResult::kSuccess) {
-            LOG(FATAL) << "cudaHostUnregister failed after active range "
+            LOG(ERROR) << "cudaHostUnregister failed after active range "
                           "tracking mismatch for "
                        << owner << ", size=" << size
-                       << ", error=" << error_message;
+                       << ", error=" << error_message
+                       << ". Continue with best-effort cleanup.";
         }
         std::lock_guard<std::mutex> lock(mutex_);
         drop_reservation_locked(key, size);
@@ -279,15 +280,18 @@ void RegisteredPinnedMemoryManager::release(RegisteredPinnedRegion* region) {
     if (!pin_ops_.unregister_region) return;
     auto unregister_result =
         pin_ops_.unregister_region(region->addr_, &error_message);
+    // Treat CUDA unregistration as best-effort cleanup: drop manager state so
+    // stale raw tracking pointers do not outlive the Store segment owner.
     if (unregister_result != UnregisterResult::kSuccess) {
         if (unregister_result == UnregisterResult::kRuntimeUnloading) {
             LOG(WARNING) << "Skip cudaHostUnregister for " << region->owner_
                          << " because CUDA runtime is unloading, size="
                          << region->size_;
         } else {
-            LOG(FATAL) << "cudaHostUnregister failed for " << region->owner_
+            LOG(ERROR) << "cudaHostUnregister failed for " << region->owner_
                        << ", size=" << region->size_
-                       << ", error=" << error_message;
+                       << ", error=" << error_message
+                       << ". Continue with best-effort cleanup.";
         }
     }
 

--- a/mooncake-store/src/registered_pinned_memory.h
+++ b/mooncake-store/src/registered_pinned_memory.h
@@ -54,9 +54,9 @@ class RegisteredPinnedMemoryManager {
     friend class RegisteredPinnedRegion;
 
     struct ActiveRegion {
-        void* addr = nullptr;
-        size_t size = 0;
-        RegisteredPinnedRegion* region = nullptr;
+        void* addr;
+        size_t size;
+        RegisteredPinnedRegion* region;
     };
 
     RegisteredPinnedMemoryManager();

--- a/mooncake-store/src/registered_pinned_memory.h
+++ b/mooncake-store/src/registered_pinned_memory.h
@@ -18,6 +18,8 @@ class RegisteredPinnedRegion {
     RegisteredPinnedRegion& operator=(const RegisteredPinnedRegion&) = delete;
     ~RegisteredPinnedRegion();
 
+    bool release();
+
    private:
     friend class RegisteredPinnedMemoryManager;
 
@@ -28,6 +30,7 @@ class RegisteredPinnedRegion {
     RegisteredPinnedMemoryManager* manager_ = nullptr;
     void* addr_ = nullptr;
     size_t size_ = 0;
+    bool release_succeeded_ = true;
 };
 
 class RegisteredPinnedMemoryManager {
@@ -65,7 +68,7 @@ class RegisteredPinnedMemoryManager {
    private:
 #endif
 
-    void release(RegisteredPinnedRegion* region);
+    bool release(RegisteredPinnedRegion* region);
     void remove_inactive_region_locked(void* addr, size_t size);
 
     const bool enabled_;

--- a/mooncake-store/src/registered_pinned_memory.h
+++ b/mooncake-store/src/registered_pinned_memory.h
@@ -22,16 +22,12 @@ class RegisteredPinnedRegion {
     friend class RegisteredPinnedMemoryManager;
 
     RegisteredPinnedRegion(RegisteredPinnedMemoryManager* manager, void* addr,
-                           size_t size, std::string owner)
-        : manager_(manager),
-          addr_(addr),
-          size_(size),
-          owner_(std::move(owner)) {}
+                           size_t size)
+        : manager_(manager), addr_(addr), size_(size) {}
 
     RegisteredPinnedMemoryManager* manager_ = nullptr;
     void* addr_ = nullptr;
     size_t size_ = 0;
-    std::string owner_;
 };
 
 class RegisteredPinnedMemoryManager {
@@ -60,7 +56,6 @@ class RegisteredPinnedMemoryManager {
     };
 
     RegisteredPinnedMemoryManager();
-    explicit RegisteredPinnedMemoryManager(std::pair<bool, uint64_t> config);
 #if defined(MOONCAKE_STORE_TEST)
    public:
 #endif

--- a/mooncake-store/src/registered_pinned_memory.h
+++ b/mooncake-store/src/registered_pinned_memory.h
@@ -21,9 +21,14 @@ class RegisteredPinnedRegion {
    private:
     friend class RegisteredPinnedMemoryManager;
 
-    RegisteredPinnedRegion(void* addr, size_t size, std::string owner)
-        : addr_(addr), size_(size), owner_(std::move(owner)) {}
+    RegisteredPinnedRegion(RegisteredPinnedMemoryManager* manager, void* addr,
+                           size_t size, std::string owner)
+        : manager_(manager),
+          addr_(addr),
+          size_(size),
+          owner_(std::move(owner)) {}
 
+    RegisteredPinnedMemoryManager* manager_ = nullptr;
     void* addr_ = nullptr;
     size_t size_ = 0;
     std::string owner_;
@@ -31,6 +36,15 @@ class RegisteredPinnedRegion {
 
 class RegisteredPinnedMemoryManager {
    public:
+    enum class UnregisterResult { kSuccess, kRuntimeUnloading, kError };
+
+    struct PinOps {
+        bool (*register_region)(void* addr, size_t size,
+                                std::string* error_message) = nullptr;
+        UnregisterResult (*unregister_region)(
+            void* addr, std::string* error_message) = nullptr;
+    };
+
     static RegisteredPinnedMemoryManager& instance();
 
     std::shared_ptr<RegisteredPinnedRegion> try_pin(void* addr, size_t size,
@@ -59,12 +73,21 @@ class RegisteredPinnedMemoryManager {
 
     RegisteredPinnedMemoryManager();
     explicit RegisteredPinnedMemoryManager(std::pair<bool, uint64_t> config);
+#if defined(MOONCAKE_STORE_TEST)
+   public:
+#endif
+    RegisteredPinnedMemoryManager(std::pair<bool, uint64_t> config,
+                                  PinOps pin_ops);
+#if defined(MOONCAKE_STORE_TEST)
+   private:
+#endif
 
     void release(RegisteredPinnedRegion* region);
     void drop_reservation_locked(const RegionKey& key, size_t size);
 
     const bool enabled_;
     const uint64_t limit_bytes_;
+    const PinOps pin_ops_;
 
     mutable std::mutex mutex_;
     uint64_t pinned_bytes_ = 0;

--- a/mooncake-store/src/registered_pinned_memory.h
+++ b/mooncake-store/src/registered_pinned_memory.h
@@ -5,8 +5,8 @@
 #include <memory>
 #include <mutex>
 #include <string>
-#include <unordered_map>
 #include <utility>
+#include <vector>
 
 namespace mooncake {
 
@@ -53,22 +53,10 @@ class RegisteredPinnedMemoryManager {
    private:
     friend class RegisteredPinnedRegion;
 
-    struct RegionKey {
+    struct ActiveRegion {
         void* addr = nullptr;
         size_t size = 0;
-
-        bool operator==(const RegionKey& other) const {
-            return addr == other.addr && size == other.size;
-        }
-    };
-
-    struct RegionKeyHash {
-        size_t operator()(const RegionKey& key) const {
-            const size_t addr_hash = std::hash<void*>{}(key.addr);
-            return addr_hash ^
-                   (std::hash<size_t>{}(key.size) + 0x9e3779b97f4a7c15ULL +
-                    (addr_hash << 6) + (addr_hash >> 2));
-        }
+        RegisteredPinnedRegion* region = nullptr;
     };
 
     RegisteredPinnedMemoryManager();
@@ -83,7 +71,7 @@ class RegisteredPinnedMemoryManager {
 #endif
 
     void release(RegisteredPinnedRegion* region);
-    void drop_reservation_locked(const RegionKey& key, size_t size);
+    void remove_inactive_region_locked(void* addr, size_t size);
 
     const bool enabled_;
     const uint64_t limit_bytes_;
@@ -91,8 +79,7 @@ class RegisteredPinnedMemoryManager {
 
     mutable std::mutex mutex_;
     uint64_t pinned_bytes_ = 0;
-    std::unordered_map<RegionKey, RegisteredPinnedRegion*, RegionKeyHash>
-        regions_;
+    std::vector<ActiveRegion> regions_;
 };
 
 }  // namespace mooncake

--- a/mooncake-store/src/registered_pinned_memory.h
+++ b/mooncake-store/src/registered_pinned_memory.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+namespace mooncake {
+
+class RegisteredPinnedMemoryManager;
+
+class RegisteredPinnedRegion {
+   public:
+    RegisteredPinnedRegion(const RegisteredPinnedRegion&) = delete;
+    RegisteredPinnedRegion& operator=(const RegisteredPinnedRegion&) = delete;
+    ~RegisteredPinnedRegion();
+
+   private:
+    friend class RegisteredPinnedMemoryManager;
+
+    RegisteredPinnedRegion(void* addr, size_t size, std::string owner)
+        : addr_(addr), size_(size), owner_(std::move(owner)) {}
+
+    void* addr_ = nullptr;
+    size_t size_ = 0;
+    std::string owner_;
+};
+
+class RegisteredPinnedMemoryManager {
+   public:
+    static RegisteredPinnedMemoryManager& instance();
+
+    std::shared_ptr<RegisteredPinnedRegion> try_pin(void* addr, size_t size,
+                                                    const std::string& owner);
+
+   private:
+    friend class RegisteredPinnedRegion;
+
+    struct RegionKey {
+        void* addr = nullptr;
+        size_t size = 0;
+
+        bool operator==(const RegionKey& other) const {
+            return addr == other.addr && size == other.size;
+        }
+    };
+
+    struct RegionKeyHash {
+        size_t operator()(const RegionKey& key) const {
+            const size_t addr_hash = std::hash<void*>{}(key.addr);
+            return addr_hash ^
+                   (std::hash<size_t>{}(key.size) + 0x9e3779b97f4a7c15ULL +
+                    (addr_hash << 6) + (addr_hash >> 2));
+        }
+    };
+
+    RegisteredPinnedMemoryManager();
+    explicit RegisteredPinnedMemoryManager(std::pair<bool, uint64_t> config);
+
+    void release(RegisteredPinnedRegion* region);
+    void drop_reservation_locked(const RegionKey& key, size_t size);
+
+    const bool enabled_;
+    const uint64_t limit_bytes_;
+
+    mutable std::mutex mutex_;
+    uint64_t pinned_bytes_ = 0;
+    std::unordered_map<RegionKey, RegisteredPinnedRegion*, RegionKeyHash>
+        regions_;
+};
+
+}  // namespace mooncake

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ endfunction()
 
 add_store_test(buffer_allocator_test buffer_allocator_test.cpp)
 add_store_test(runtime_accelerator_test runtime_accelerator_test.cpp)
+add_store_test(registered_pinned_memory_test registered_pinned_memory_test.cpp)
 add_store_test(allocation_strategy_test allocation_strategy_test.cpp)
 add_store_test(replica_selection_test replica_selection_test.cpp)
 add_test(

--- a/mooncake-store/tests/registered_pinned_memory_test.cpp
+++ b/mooncake-store/tests/registered_pinned_memory_test.cpp
@@ -8,10 +8,12 @@
 namespace mooncake {
 namespace {
 
+using Manager = RegisteredPinnedMemoryManager;
+using UnregisterResult = Manager::UnregisterResult;
+
 struct FakePinState {
     bool register_succeeds = true;
-    RegisteredPinnedMemoryManager::UnregisterResult unregister_result =
-        RegisteredPinnedMemoryManager::UnregisterResult::kSuccess;
+    UnregisterResult unregister_result = UnregisterResult::kSuccess;
     int register_calls = 0;
     int unregister_calls = 0;
 };
@@ -21,120 +23,102 @@ FakePinState& State() {
     return state;
 }
 
-void ResetState() { State() = FakePinState(); }
-
-bool FakeRegister(void* addr, size_t size, std::string* error_message) {
-    (void)addr;
-    (void)size;
+bool FakeRegister(void*, size_t, std::string* error_message) {
     ++State().register_calls;
     if (State().register_succeeds) return true;
     if (error_message) *error_message = "fake register failure";
     return false;
 }
 
-RegisteredPinnedMemoryManager::UnregisterResult FakeUnregister(
-    void* addr, std::string* error_message) {
-    (void)addr;
+UnregisterResult FakeUnregister(void*, std::string* error_message) {
     ++State().unregister_calls;
-    if (State().unregister_result ==
-            RegisteredPinnedMemoryManager::UnregisterResult::kError &&
+    if (State().unregister_result == UnregisterResult::kError &&
         error_message) {
         *error_message = "fake unregister failure";
     }
     return State().unregister_result;
 }
 
-RegisteredPinnedMemoryManager::PinOps FakeOps() {
-    return {FakeRegister, FakeUnregister};
-}
-
 class RegisteredPinnedMemoryManagerTest : public ::testing::Test {
    protected:
-    void SetUp() override { ResetState(); }
+    void SetUp() override { State() = FakePinState(); }
+
+    Manager MakeManager(size_t limit) {
+        return Manager({true, limit}, {FakeRegister, FakeUnregister});
+    }
+
+    std::shared_ptr<RegisteredPinnedRegion> Pin(Manager& manager, size_t offset,
+                                                size_t size) {
+        return manager.try_pin(buffer_.data() + offset, size, "segment");
+    }
+
+    void ExpectCalls(int register_calls, int unregister_calls) {
+        EXPECT_EQ(State().register_calls, register_calls);
+        EXPECT_EQ(State().unregister_calls, unregister_calls);
+    }
 
     std::array<char, 128> buffer_{};
 };
 
 TEST_F(RegisteredPinnedMemoryManagerTest, QuotaRejectsAndReleaseRefunds) {
-    RegisteredPinnedMemoryManager manager({true, 64}, FakeOps());
+    auto manager = MakeManager(64);
 
-    auto first = manager.try_pin(buffer_.data(), 64, "first");
+    auto first = Pin(manager, 0, 64);
     ASSERT_NE(first, nullptr);
-
-    auto over_quota = manager.try_pin(buffer_.data() + 64, 1, "over quota");
-    EXPECT_EQ(over_quota, nullptr);
-    EXPECT_EQ(State().register_calls, 1);
+    EXPECT_EQ(Pin(manager, 64, 1), nullptr);
+    ExpectCalls(1, 0);
 
     first.reset();
-    EXPECT_EQ(State().unregister_calls, 1);
+    ExpectCalls(1, 1);
 
-    auto second = manager.try_pin(buffer_.data() + 64, 64, "second");
+    auto second = Pin(manager, 64, 64);
     ASSERT_NE(second, nullptr);
-    EXPECT_EQ(State().register_calls, 2);
+    ExpectCalls(2, 1);
 
     second.reset();
-    EXPECT_EQ(State().unregister_calls, 2);
+    ExpectCalls(2, 2);
 }
 
 TEST_F(RegisteredPinnedMemoryManagerTest, OverlapAndDuplicateAreRejected) {
-    RegisteredPinnedMemoryManager manager({true, 128}, FakeOps());
+    auto manager = MakeManager(128);
 
-    auto first = manager.try_pin(buffer_.data() + 16, 32, "first");
+    auto first = Pin(manager, 16, 32);
     ASSERT_NE(first, nullptr);
 
-    auto duplicate = manager.try_pin(buffer_.data() + 16, 32, "duplicate");
-    EXPECT_EQ(duplicate, nullptr);
+    EXPECT_EQ(Pin(manager, 16, 32), nullptr);
+    EXPECT_EQ(Pin(manager, 32, 16), nullptr);
 
-    auto overlap = manager.try_pin(buffer_.data() + 32, 16, "overlap");
-    EXPECT_EQ(overlap, nullptr);
-
-    auto adjacent = manager.try_pin(buffer_.data() + 48, 16, "adjacent");
+    auto adjacent = Pin(manager, 48, 16);
     ASSERT_NE(adjacent, nullptr);
+    ExpectCalls(2, 0);
 
-    EXPECT_EQ(State().register_calls, 2);
     adjacent.reset();
     first.reset();
-    EXPECT_EQ(State().unregister_calls, 2);
+    ExpectCalls(2, 2);
 }
 
-TEST_F(RegisteredPinnedMemoryManagerTest,
-       UnregisterFailureDropsTrackingAndRefunds) {
-    RegisteredPinnedMemoryManager manager({true, 32}, FakeOps());
+TEST_F(RegisteredPinnedMemoryManagerTest, FailurePathsRefundReservations) {
+    auto manager = MakeManager(32);
 
-    auto first = manager.try_pin(buffer_.data(), 32, "first");
+    auto first = Pin(manager, 0, 32);
     ASSERT_NE(first, nullptr);
 
-    State().unregister_result =
-        RegisteredPinnedMemoryManager::UnregisterResult::kError;
+    State().unregister_result = UnregisterResult::kError;
     first.reset();
-    EXPECT_EQ(State().unregister_calls, 1);
+    ExpectCalls(1, 1);
 
-    State().unregister_result =
-        RegisteredPinnedMemoryManager::UnregisterResult::kSuccess;
-    auto second = manager.try_pin(buffer_.data(), 32, "second");
-    ASSERT_NE(second, nullptr);
-    EXPECT_EQ(State().register_calls, 2);
-
-    second.reset();
-    EXPECT_EQ(State().unregister_calls, 2);
-}
-
-TEST_F(RegisteredPinnedMemoryManagerTest, RegisterFailureRefundsReservation) {
-    RegisteredPinnedMemoryManager manager({true, 32}, FakeOps());
-
+    State().unregister_result = UnregisterResult::kSuccess;
     State().register_succeeds = false;
-    auto failed = manager.try_pin(buffer_.data(), 32, "failed");
-    EXPECT_EQ(failed, nullptr);
-    EXPECT_EQ(State().register_calls, 1);
-    EXPECT_EQ(State().unregister_calls, 0);
+    EXPECT_EQ(Pin(manager, 0, 32), nullptr);
+    ExpectCalls(2, 1);
 
     State().register_succeeds = true;
-    auto retried = manager.try_pin(buffer_.data(), 32, "retried");
+    auto retried = Pin(manager, 0, 32);
     ASSERT_NE(retried, nullptr);
-    EXPECT_EQ(State().register_calls, 2);
+    ExpectCalls(3, 1);
 
     retried.reset();
-    EXPECT_EQ(State().unregister_calls, 1);
+    ExpectCalls(3, 2);
 }
 
 }  // namespace

--- a/mooncake-store/tests/registered_pinned_memory_test.cpp
+++ b/mooncake-store/tests/registered_pinned_memory_test.cpp
@@ -95,6 +95,30 @@ TEST(RegisteredPinnedMemoryManagerTest, OverlapAndDuplicateAreRejected) {
     EXPECT_EQ(State().unregister_calls, 2);
 }
 
+TEST(RegisteredPinnedMemoryManagerTest,
+     UnregisterFailureDropsTrackingAndRefunds) {
+    ResetState();
+    RegisteredPinnedMemoryManager manager({true, 32}, FakeOps());
+    std::array<char, 32> buffer{};
+
+    auto first = manager.try_pin(buffer.data(), 32, "first");
+    ASSERT_NE(first, nullptr);
+
+    State().unregister_result =
+        RegisteredPinnedMemoryManager::UnregisterResult::kError;
+    first.reset();
+    EXPECT_EQ(State().unregister_calls, 1);
+
+    State().unregister_result =
+        RegisteredPinnedMemoryManager::UnregisterResult::kSuccess;
+    auto second = manager.try_pin(buffer.data(), 32, "second");
+    ASSERT_NE(second, nullptr);
+    EXPECT_EQ(State().register_calls, 2);
+
+    second.reset();
+    EXPECT_EQ(State().unregister_calls, 2);
+}
+
 TEST(RegisteredPinnedMemoryManagerTest, RegisterFailureRefundsReservation) {
     ResetState();
     RegisteredPinnedMemoryManager manager({true, 32}, FakeOps());

--- a/mooncake-store/tests/registered_pinned_memory_test.cpp
+++ b/mooncake-store/tests/registered_pinned_memory_test.cpp
@@ -97,28 +97,37 @@ TEST_F(RegisteredPinnedMemoryManagerTest, OverlapAndDuplicateAreRejected) {
     ExpectCalls(2, 2);
 }
 
-TEST_F(RegisteredPinnedMemoryManagerTest, FailurePathsRefundReservations) {
+TEST_F(RegisteredPinnedMemoryManagerTest, RegisterFailureRefundsReservation) {
+    auto manager = MakeManager(32);
+
+    State().register_succeeds = false;
+    EXPECT_EQ(Pin(manager, 0, 32), nullptr);
+    ExpectCalls(1, 0);
+
+    State().register_succeeds = true;
+    auto retried = Pin(manager, 0, 32);
+    ASSERT_NE(retried, nullptr);
+    ExpectCalls(2, 0);
+
+    retried.reset();
+    ExpectCalls(2, 1);
+}
+
+TEST_F(RegisteredPinnedMemoryManagerTest,
+       UnregisterFailureRetainsReservation) {
     auto manager = MakeManager(32);
 
     auto first = Pin(manager, 0, 32);
     ASSERT_NE(first, nullptr);
 
     State().unregister_result = UnregisterResult::kError;
-    first.reset();
+    EXPECT_FALSE(first->release());
     ExpectCalls(1, 1);
 
     State().unregister_result = UnregisterResult::kSuccess;
-    State().register_succeeds = false;
     EXPECT_EQ(Pin(manager, 0, 32), nullptr);
-    ExpectCalls(2, 1);
-
-    State().register_succeeds = true;
-    auto retried = Pin(manager, 0, 32);
-    ASSERT_NE(retried, nullptr);
-    ExpectCalls(3, 1);
-
-    retried.reset();
-    ExpectCalls(3, 2);
+    EXPECT_EQ(Pin(manager, 32, 32), nullptr);
+    ExpectCalls(1, 1);
 }
 
 }  // namespace

--- a/mooncake-store/tests/registered_pinned_memory_test.cpp
+++ b/mooncake-store/tests/registered_pinned_memory_test.cpp
@@ -2,7 +2,6 @@
 #include "../src/registered_pinned_memory.h"
 
 #include <array>
-#include <string>
 
 #include <gtest/gtest.h>
 
@@ -49,22 +48,27 @@ RegisteredPinnedMemoryManager::PinOps FakeOps() {
     return {FakeRegister, FakeUnregister};
 }
 
-TEST(RegisteredPinnedMemoryManagerTest, QuotaRejectsAndReleaseRefunds) {
-    ResetState();
-    RegisteredPinnedMemoryManager manager({true, 64}, FakeOps());
-    std::array<char, 128> buffer{};
+class RegisteredPinnedMemoryManagerTest : public ::testing::Test {
+   protected:
+    void SetUp() override { ResetState(); }
 
-    auto first = manager.try_pin(buffer.data(), 64, "first");
+    std::array<char, 128> buffer_{};
+};
+
+TEST_F(RegisteredPinnedMemoryManagerTest, QuotaRejectsAndReleaseRefunds) {
+    RegisteredPinnedMemoryManager manager({true, 64}, FakeOps());
+
+    auto first = manager.try_pin(buffer_.data(), 64, "first");
     ASSERT_NE(first, nullptr);
 
-    auto over_quota = manager.try_pin(buffer.data() + 64, 1, "over quota");
+    auto over_quota = manager.try_pin(buffer_.data() + 64, 1, "over quota");
     EXPECT_EQ(over_quota, nullptr);
     EXPECT_EQ(State().register_calls, 1);
 
     first.reset();
     EXPECT_EQ(State().unregister_calls, 1);
 
-    auto second = manager.try_pin(buffer.data() + 64, 64, "second");
+    auto second = manager.try_pin(buffer_.data() + 64, 64, "second");
     ASSERT_NE(second, nullptr);
     EXPECT_EQ(State().register_calls, 2);
 
@@ -72,21 +76,19 @@ TEST(RegisteredPinnedMemoryManagerTest, QuotaRejectsAndReleaseRefunds) {
     EXPECT_EQ(State().unregister_calls, 2);
 }
 
-TEST(RegisteredPinnedMemoryManagerTest, OverlapAndDuplicateAreRejected) {
-    ResetState();
+TEST_F(RegisteredPinnedMemoryManagerTest, OverlapAndDuplicateAreRejected) {
     RegisteredPinnedMemoryManager manager({true, 128}, FakeOps());
-    std::array<char, 128> buffer{};
 
-    auto first = manager.try_pin(buffer.data() + 16, 32, "first");
+    auto first = manager.try_pin(buffer_.data() + 16, 32, "first");
     ASSERT_NE(first, nullptr);
 
-    auto duplicate = manager.try_pin(buffer.data() + 16, 32, "duplicate");
+    auto duplicate = manager.try_pin(buffer_.data() + 16, 32, "duplicate");
     EXPECT_EQ(duplicate, nullptr);
 
-    auto overlap = manager.try_pin(buffer.data() + 32, 16, "overlap");
+    auto overlap = manager.try_pin(buffer_.data() + 32, 16, "overlap");
     EXPECT_EQ(overlap, nullptr);
 
-    auto adjacent = manager.try_pin(buffer.data() + 48, 16, "adjacent");
+    auto adjacent = manager.try_pin(buffer_.data() + 48, 16, "adjacent");
     ASSERT_NE(adjacent, nullptr);
 
     EXPECT_EQ(State().register_calls, 2);
@@ -95,13 +97,11 @@ TEST(RegisteredPinnedMemoryManagerTest, OverlapAndDuplicateAreRejected) {
     EXPECT_EQ(State().unregister_calls, 2);
 }
 
-TEST(RegisteredPinnedMemoryManagerTest,
-     UnregisterFailureDropsTrackingAndRefunds) {
-    ResetState();
+TEST_F(RegisteredPinnedMemoryManagerTest,
+       UnregisterFailureDropsTrackingAndRefunds) {
     RegisteredPinnedMemoryManager manager({true, 32}, FakeOps());
-    std::array<char, 32> buffer{};
 
-    auto first = manager.try_pin(buffer.data(), 32, "first");
+    auto first = manager.try_pin(buffer_.data(), 32, "first");
     ASSERT_NE(first, nullptr);
 
     State().unregister_result =
@@ -111,7 +111,7 @@ TEST(RegisteredPinnedMemoryManagerTest,
 
     State().unregister_result =
         RegisteredPinnedMemoryManager::UnregisterResult::kSuccess;
-    auto second = manager.try_pin(buffer.data(), 32, "second");
+    auto second = manager.try_pin(buffer_.data(), 32, "second");
     ASSERT_NE(second, nullptr);
     EXPECT_EQ(State().register_calls, 2);
 
@@ -119,19 +119,17 @@ TEST(RegisteredPinnedMemoryManagerTest,
     EXPECT_EQ(State().unregister_calls, 2);
 }
 
-TEST(RegisteredPinnedMemoryManagerTest, RegisterFailureRefundsReservation) {
-    ResetState();
+TEST_F(RegisteredPinnedMemoryManagerTest, RegisterFailureRefundsReservation) {
     RegisteredPinnedMemoryManager manager({true, 32}, FakeOps());
-    std::array<char, 32> buffer{};
 
     State().register_succeeds = false;
-    auto failed = manager.try_pin(buffer.data(), 32, "failed");
+    auto failed = manager.try_pin(buffer_.data(), 32, "failed");
     EXPECT_EQ(failed, nullptr);
     EXPECT_EQ(State().register_calls, 1);
     EXPECT_EQ(State().unregister_calls, 0);
 
     State().register_succeeds = true;
-    auto retried = manager.try_pin(buffer.data(), 32, "retried");
+    auto retried = manager.try_pin(buffer_.data(), 32, "retried");
     ASSERT_NE(retried, nullptr);
     EXPECT_EQ(State().register_calls, 2);
 

--- a/mooncake-store/tests/registered_pinned_memory_test.cpp
+++ b/mooncake-store/tests/registered_pinned_memory_test.cpp
@@ -1,0 +1,119 @@
+#define MOONCAKE_STORE_TEST
+#include "../src/registered_pinned_memory.h"
+
+#include <array>
+#include <string>
+
+#include <gtest/gtest.h>
+
+namespace mooncake {
+namespace {
+
+struct FakePinState {
+    bool register_succeeds = true;
+    RegisteredPinnedMemoryManager::UnregisterResult unregister_result =
+        RegisteredPinnedMemoryManager::UnregisterResult::kSuccess;
+    int register_calls = 0;
+    int unregister_calls = 0;
+};
+
+FakePinState& State() {
+    static FakePinState state;
+    return state;
+}
+
+void ResetState() { State() = FakePinState(); }
+
+bool FakeRegister(void* addr, size_t size, std::string* error_message) {
+    (void)addr;
+    (void)size;
+    ++State().register_calls;
+    if (State().register_succeeds) return true;
+    if (error_message) *error_message = "fake register failure";
+    return false;
+}
+
+RegisteredPinnedMemoryManager::UnregisterResult FakeUnregister(
+    void* addr, std::string* error_message) {
+    (void)addr;
+    ++State().unregister_calls;
+    if (State().unregister_result ==
+            RegisteredPinnedMemoryManager::UnregisterResult::kError &&
+        error_message) {
+        *error_message = "fake unregister failure";
+    }
+    return State().unregister_result;
+}
+
+RegisteredPinnedMemoryManager::PinOps FakeOps() {
+    return {FakeRegister, FakeUnregister};
+}
+
+TEST(RegisteredPinnedMemoryManagerTest, QuotaRejectsAndReleaseRefunds) {
+    ResetState();
+    RegisteredPinnedMemoryManager manager({true, 64}, FakeOps());
+    std::array<char, 128> buffer{};
+
+    auto first = manager.try_pin(buffer.data(), 64, "first");
+    ASSERT_NE(first, nullptr);
+
+    auto over_quota = manager.try_pin(buffer.data() + 64, 1, "over quota");
+    EXPECT_EQ(over_quota, nullptr);
+    EXPECT_EQ(State().register_calls, 1);
+
+    first.reset();
+    EXPECT_EQ(State().unregister_calls, 1);
+
+    auto second = manager.try_pin(buffer.data() + 64, 64, "second");
+    ASSERT_NE(second, nullptr);
+    EXPECT_EQ(State().register_calls, 2);
+
+    second.reset();
+    EXPECT_EQ(State().unregister_calls, 2);
+}
+
+TEST(RegisteredPinnedMemoryManagerTest, OverlapAndDuplicateAreRejected) {
+    ResetState();
+    RegisteredPinnedMemoryManager manager({true, 128}, FakeOps());
+    std::array<char, 128> buffer{};
+
+    auto first = manager.try_pin(buffer.data() + 16, 32, "first");
+    ASSERT_NE(first, nullptr);
+
+    auto duplicate = manager.try_pin(buffer.data() + 16, 32, "duplicate");
+    EXPECT_EQ(duplicate, nullptr);
+
+    auto overlap = manager.try_pin(buffer.data() + 32, 16, "overlap");
+    EXPECT_EQ(overlap, nullptr);
+
+    auto adjacent = manager.try_pin(buffer.data() + 48, 16, "adjacent");
+    ASSERT_NE(adjacent, nullptr);
+
+    EXPECT_EQ(State().register_calls, 2);
+    adjacent.reset();
+    first.reset();
+    EXPECT_EQ(State().unregister_calls, 2);
+}
+
+TEST(RegisteredPinnedMemoryManagerTest, RegisterFailureRefundsReservation) {
+    ResetState();
+    RegisteredPinnedMemoryManager manager({true, 32}, FakeOps());
+    std::array<char, 32> buffer{};
+
+    State().register_succeeds = false;
+    auto failed = manager.try_pin(buffer.data(), 32, "failed");
+    EXPECT_EQ(failed, nullptr);
+    EXPECT_EQ(State().register_calls, 1);
+    EXPECT_EQ(State().unregister_calls, 0);
+
+    State().register_succeeds = true;
+    auto retried = manager.try_pin(buffer.data(), 32, "retried");
+    ASSERT_NE(retried, nullptr);
+    EXPECT_EQ(State().register_calls, 2);
+
+    retried.reset();
+    EXPECT_EQ(State().unregister_calls, 1);
+}
+
+}  // namespace
+}  // namespace mooncake

--- a/mooncake-store/tests/registered_pinned_memory_test.cpp
+++ b/mooncake-store/tests/registered_pinned_memory_test.cpp
@@ -113,8 +113,7 @@ TEST_F(RegisteredPinnedMemoryManagerTest, RegisterFailureRefundsReservation) {
     ExpectCalls(2, 1);
 }
 
-TEST_F(RegisteredPinnedMemoryManagerTest,
-       UnregisterFailureRetainsReservation) {
+TEST_F(RegisteredPinnedMemoryManagerTest, UnregisterFailureRetainsReservation) {
     auto manager = MakeManager(32);
 
     auto first = Pin(manager, 0, 32);


### PR DESCRIPTION
## Description

This PR adds opt-in CUDA pinned-memory registration for Mooncake Store-managed host segment memory.

The pinned memory is limited to Store segment memory only. It does not pin client local buffers, staging buffers, dummy-client SHM buffers, user-provided buffers, file-backed `mountSegment()` mappings, CXL/device segments, or tensor-wrapper temporary buffers.

The feature is disabled by default and controlled by a process-wide quota:

- `MC_STORE_PIN_MEMORY_MAX_BYTES=<bytes>` enables pinned registration up to the configured quota.
- unset, empty, `0`, or invalid values disable the feature.
- `MC_STORE_PIN_MEMORY=0|false|off|no` explicitly disables the feature.

When enabled, Store host segments are registered with `cudaHostRegister()` after allocation and before the segment is mounted. Registration failures fall back to pageable memory so Store startup and allocation remain usable.

This PR is intentionally scoped to Store segment memory. GPU-destination reads still copy through the client local buffer / staging path before the final CPU -> GPU copy, so `get` only sees a smaller improvement. Removing or pinning that final staging path is follow-up work and is not part of this PR.

The tensor wrapper path is also not the primary target of this PR. `put_tensor(cuda)` currently goes through `put_parts`, which still stages through the client local buffer before writing into Store. Optimizing tensor / `put_parts` to avoid that staging copy is also follow-up work.

This PR is split from https://github.com/kvcache-ai/Mooncake/pull/2598.

## Module

- Store

## Type of Change

- Performance improvement
- Documentation update

## How Has This Been Tested?

### Manual performance validation

Manual benchmark on one NVIDIA A10 GPU, local TCP Store setup, 4 GiB Store segment, 2 GiB client local buffer.

Baseline:

- `MC_STORE_PIN_MEMORY_MAX_BYTES=0`

Pinned Store segment:

- `MC_STORE_PIN_MEMORY_MAX_BYTES=4294967296`

The benchmark directly exercised the lower-level Store APIs with CUDA source/destination buffers.

| Direction | Size | Pageable | Pinned Store segment |
| --- | ---: | ---: | ---: |
| put from CUDA buffer | 64 MB | 8.887 GB/s | 24.960 GB/s |
| put from CUDA buffer | 256 MB | 9.034 GB/s | 25.686 GB/s |
| put from CUDA buffer | 512 MB | 9.003 GB/s | 25.823 GB/s |
| get into CUDA buffer | 64 MB | 5.295 GB/s | 5.955 GB/s |
| get into CUDA buffer | 256 MB | 5.232 GB/s | 6.019 GB/s |
| get into CUDA buffer | 512 MB | 5.290 GB/s | 6.044 GB/s |

The main improvement is on GPU-source writes, where the Store segment is the host destination of the device-to-host copy.

Read-side GPU destinations improve less because the current read path still stages through the client local buffer before the final CPU -> GPU copy. Optimizing that staging path is follow-up work.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have run clang-format / formatting checks.
- [x] I have updated the documentation.
- [ ] I have added or updated committed tests.
- [ ] I have run pre-commit checks.
- [x] The change is scoped to Store segment memory and does not pin unrelated buffers.

## AI Assistance Disclosure

- [x] AI tools were used for implementation, review, benchmarking, and PR description preparation.