### PR TITLE
[Store] Add Redis OpLog store backend

### DIFF
--- a/mooncake-store/include/client_config_builder.h
+++ b/mooncake-store/include/client_config_builder.h
@@ -127,6 +127,7 @@ struct RealClientConfigBase {
     // Redis election backend configuration.
     // Only used when master_server_entry starts with "redis://".
     std::string redis_cluster_id = DEFAULT_CLUSTER_ID;
+    std::string redis_username;
     std::string redis_password;
     int redis_db_index = 0;
     int redis_master_view_ttl_sec = 5;
@@ -251,8 +252,8 @@ class ClientConfigBuilder {
         uint64_t metric_report_interval_seconds = 60,
         const std::string& redis_cluster_id = DEFAULT_CLUSTER_ID,
         const std::string& redis_password = "", int redis_db_index = 0,
-        int redis_master_view_ttl_sec = 5,
-        int redis_heartbeat_interval_sec = 2) {
+        int redis_master_view_ttl_sec = 5, int redis_heartbeat_interval_sec = 2,
+        const std::string& redis_username = "") {
         CentralizedClientConfig config;
         fill_real_client_config_base(
             config, local_hostname, metadata_connstring, protocol, rdma_devices,
@@ -262,7 +263,8 @@ class ClientConfigBuilder {
             metric_report_interval_seconds);
         fill_redis_discovery_config(config, redis_cluster_id, redis_password,
                                     redis_db_index, redis_master_view_ttl_sec,
-                                    redis_heartbeat_interval_sec);
+                                    redis_heartbeat_interval_sec,
+                                    redis_username);
         config.global_segment_size = global_segment_size;
         config.enable_offload = enable_offload;
         config.local_rpc_port = local_rpc_port;
@@ -311,7 +313,7 @@ class ClientConfigBuilder {
             enable_metric_collection, metric_report_interval_seconds,
             redis_config.cluster_id, redis_config.password,
             redis_config.db_index, redis_config.master_view_ttl_sec,
-            redis_config.heartbeat_interval_sec);
+            redis_config.heartbeat_interval_sec, redis_config.username);
     }
 
     static P2PClientConfig build_p2p_real_client(
@@ -343,8 +345,8 @@ class ClientConfigBuilder {
         uint64_t metric_report_interval_seconds = 60,
         const std::string& redis_cluster_id = DEFAULT_CLUSTER_ID,
         const std::string& redis_password = "", int redis_db_index = 0,
-        int redis_master_view_ttl_sec = 5,
-        int redis_heartbeat_interval_sec = 2) {
+        int redis_master_view_ttl_sec = 5, int redis_heartbeat_interval_sec = 2,
+        const std::string& redis_username = "") {
         P2PClientConfig config;
         fill_real_client_config_base(
             config, local_hostname, metadata_connstring, protocol, rdma_devices,
@@ -354,7 +356,8 @@ class ClientConfigBuilder {
             metric_report_interval_seconds);
         fill_redis_discovery_config(config, redis_cluster_id, redis_password,
                                     redis_db_index, redis_master_view_ttl_sec,
-                                    redis_heartbeat_interval_sec);
+                                    redis_heartbeat_interval_sec,
+                                    redis_username);
         config.client_rpc_port = client_rpc_port;
         config.rpc_thread_num = rpc_thread_num;
         config.lock_shard_count = lock_shard_count;
@@ -465,12 +468,13 @@ class ClientConfigBuilder {
             metric_report_interval_seconds, redis_config.cluster_id,
             redis_config.password, redis_config.db_index,
             redis_config.master_view_ttl_sec,
-            redis_config.heartbeat_interval_sec);
+            redis_config.heartbeat_interval_sec, redis_config.username);
     }
 
    private:
     struct RedisDiscoveryConfig {
         std::string cluster_id = DEFAULT_CLUSTER_ID;
+        std::string username;
         std::string password;
         int db_index = 0;
         int master_view_ttl_sec = 5;
@@ -489,6 +493,7 @@ class ClientConfigBuilder {
         static constexpr const char* kIpcSocketPath = "ipc_socket_path";
         static constexpr const char* kRuntimeConfig = "runtime_config";
         static constexpr const char* kRedisClusterId = "redis_cluster_id";
+        static constexpr const char* kRedisUsername = "redis_username";
         static constexpr const char* kRedisPassword = "redis_password";
         static constexpr const char* kRedisDbIndex = "redis_db_index";
         static constexpr const char* kRedisMasterViewTtlSec =
@@ -641,6 +646,8 @@ class ClientConfigBuilder {
         RedisDiscoveryConfig redis_config;
         redis_config.cluster_id = get_config_str(
             config, DictCommon::kRedisClusterId, DEFAULT_CLUSTER_ID);
+        redis_config.username =
+            get_config_str(config, DictCommon::kRedisUsername);
         redis_config.password =
             get_config_str(config, DictCommon::kRedisPassword);
         redis_config.db_index =
@@ -657,8 +664,10 @@ class ClientConfigBuilder {
                                             const std::string& redis_password,
                                             int redis_db_index,
                                             int redis_master_view_ttl_sec,
-                                            int redis_heartbeat_interval_sec) {
+                                            int redis_heartbeat_interval_sec,
+                                            const std::string& redis_username) {
         config.redis_cluster_id = redis_cluster_id;
+        config.redis_username = redis_username;
         config.redis_password = redis_password;
         config.redis_db_index = redis_db_index;
         config.redis_master_view_ttl_sec = redis_master_view_ttl_sec;

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -35,6 +35,7 @@ using WriteConfig = std::variant<ReplicateConfig, WriteRouteRequestConfig>;
 
 struct ClientMasterDiscoveryConfig {
     std::string redis_cluster_id = DEFAULT_CLUSTER_ID;
+    std::string redis_username;
     std::string redis_password;
     int redis_db_index = 0;
     int redis_master_view_ttl_sec = 5;

--- a/mooncake-store/include/ha/oplog/oplog_store_factory.h
+++ b/mooncake-store/include/ha/oplog/oplog_store_factory.h
@@ -75,7 +75,8 @@ class OpLogStoreFactory {
         OpLogStoreType type, const std::string& cluster_id, OpLogStoreRole role,
         const std::string& oplog_root_dir = kDefaultOpLogRootDir,
         int poll_interval_ms = kDefaultOpLogPollIntervalMs,
-        const std::string& password = "", const std::string& username = "");
+        const std::string& password = "", const std::string& username = "",
+        int db_index = 0);
 };
 
 }  // namespace mooncake

--- a/mooncake-store/include/ha/oplog/oplog_store_factory.h
+++ b/mooncake-store/include/ha/oplog/oplog_store_factory.h
@@ -17,6 +17,7 @@ enum class OpLogStoreRole {
 enum class OpLogStoreType {
     ETCD,
     LOCAL_FS,
+    REDIS,
 };
 
 #ifdef STORE_USE_ETCD
@@ -38,6 +39,9 @@ inline OpLogStoreType ParseOpLogStoreType(const std::string& type_str) {
     if (lower == "etcd") {
         return OpLogStoreType::ETCD;
     }
+    if (lower == "redis") {
+        return OpLogStoreType::REDIS;
+    }
     return kDefaultOpLogStoreType;
 }
 
@@ -45,6 +49,8 @@ inline std::string OpLogStoreTypeToString(OpLogStoreType type) {
     switch (type) {
         case OpLogStoreType::LOCAL_FS:
             return "localfs";
+        case OpLogStoreType::REDIS:
+            return "redis";
         case OpLogStoreType::ETCD:
         default:
             return "etcd";
@@ -68,7 +74,8 @@ class OpLogStoreFactory {
     static std::unique_ptr<OpLogStore> Create(
         OpLogStoreType type, const std::string& cluster_id, OpLogStoreRole role,
         const std::string& oplog_root_dir = kDefaultOpLogRootDir,
-        int poll_interval_ms = kDefaultOpLogPollIntervalMs);
+        int poll_interval_ms = kDefaultOpLogPollIntervalMs,
+        const std::string& password = "", const std::string& username = "");
 };
 
 }  // namespace mooncake

--- a/mooncake-store/include/ha/oplog/p2p_hot_standby_service.h
+++ b/mooncake-store/include/ha/oplog/p2p_hot_standby_service.h
@@ -23,6 +23,7 @@ struct P2PHotStandbyConfig {
     std::string redis_endpoint;
     std::string redis_username;
     std::string redis_password;
+    int redis_db_index{0};
     int oplog_poll_interval_ms{kDefaultOpLogPollIntervalMs};
 };
 

--- a/mooncake-store/include/ha/oplog/p2p_hot_standby_service.h
+++ b/mooncake-store/include/ha/oplog/p2p_hot_standby_service.h
@@ -20,6 +20,9 @@ struct P2PHotStandbyConfig {
     std::string cluster_id;
     OpLogStoreType oplog_store_type{kDefaultOpLogStoreType};
     std::string oplog_store_root_dir{kDefaultOpLogRootDir};
+    std::string redis_endpoint;
+    std::string redis_username;
+    std::string redis_password;
     int oplog_poll_interval_ms{kDefaultOpLogPollIntervalMs};
 };
 

--- a/mooncake-store/include/ha/oplog/redis_oplog_store.h
+++ b/mooncake-store/include/ha/oplog/redis_oplog_store.h
@@ -22,6 +22,9 @@ class RedisOpLogStore : public OpLogStore {
                     const std::string& username = "");
     ~RedisOpLogStore() override;
 
+    RedisOpLogStore(const RedisOpLogStore&) = delete;
+    RedisOpLogStore& operator=(const RedisOpLogStore&) = delete;
+
     ErrorCode Init() override;
     ErrorCode WriteOpLog(const OpLogEntry& entry, bool sync = true) override;
     ErrorCode ReadOpLog(uint64_t sequence_id, OpLogEntry& entry) override;

--- a/mooncake-store/include/ha/oplog/redis_oplog_store.h
+++ b/mooncake-store/include/ha/oplog/redis_oplog_store.h
@@ -19,7 +19,7 @@ class RedisOpLogStore : public OpLogStore {
                     const std::string& redis_endpoint, bool enable_write,
                     int poll_interval_ms = 1000,
                     const std::string& password = "",
-                    const std::string& username = "");
+                    const std::string& username = "", int db_index = 0);
     ~RedisOpLogStore() override;
 
     RedisOpLogStore(const RedisOpLogStore&) = delete;
@@ -54,6 +54,7 @@ class RedisOpLogStore : public OpLogStore {
     std::string redis_endpoint_;
     std::string username_;
     std::string password_;
+    int db_index_;
     bool enable_write_;
     int poll_interval_ms_;
     std::string key_tag_;

--- a/mooncake-store/include/ha/oplog/redis_oplog_store.h
+++ b/mooncake-store/include/ha/oplog/redis_oplog_store.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#ifdef STORE_USE_REDIS
+
+#include <string>
+#include <vector>
+
+#include <hiredis/hiredis.h>
+#include <mutex>
+
+#include "ha/oplog/oplog_store.h"
+#include "redis_helper.h"
+
+namespace mooncake {
+
+class RedisOpLogStore : public OpLogStore {
+   public:
+    RedisOpLogStore(const std::string& cluster_id,
+                    const std::string& redis_endpoint, bool enable_write,
+                    int poll_interval_ms = 1000,
+                    const std::string& password = "",
+                    const std::string& username = "");
+    ~RedisOpLogStore() override;
+
+    ErrorCode Init() override;
+    ErrorCode WriteOpLog(const OpLogEntry& entry, bool sync = true) override;
+    ErrorCode ReadOpLog(uint64_t sequence_id, OpLogEntry& entry) override;
+    ErrorCode ReadOpLogSince(uint64_t start_sequence_id, size_t limit,
+                             std::vector<OpLogEntry>& entries) override;
+    ErrorCode GetLatestSequenceId(uint64_t& sequence_id) override;
+    ErrorCode GetMaxSequenceId(uint64_t& sequence_id) override;
+    ErrorCode UpdateLatestSequenceId(uint64_t sequence_id) override;
+    ErrorCode RecordSnapshotSequenceId(const std::string& snapshot_id,
+                                       uint64_t sequence_id) override;
+    ErrorCode GetSnapshotSequenceId(const std::string& snapshot_id,
+                                    uint64_t& sequence_id) override;
+    ErrorCode CleanupOpLogBefore(uint64_t before_sequence_id) override;
+    std::unique_ptr<OpLogChangeNotifier> CreateChangeNotifier(
+        const std::string& cluster_id) override;
+
+   private:
+    redisContext* CreateConnection() const;
+    ErrorCode EnsureConnectedUnlocked();
+    ErrorCode ReadOpLogUnlocked(uint64_t sequence_id, OpLogEntry& entry);
+    bool IsValidSnapshotId(const std::string& snapshot_id) const;
+
+    std::string EntryKey(uint64_t sequence_id) const;
+    std::string SnapshotKey(const std::string& snapshot_id) const;
+
+    std::string cluster_id_;
+    std::string redis_endpoint_;
+    std::string username_;
+    std::string password_;
+    bool enable_write_;
+    int poll_interval_ms_;
+    std::string key_tag_;
+    std::string index_key_;
+    std::string latest_key_;
+    std::string snapshot_prefix_;
+    redisContext* ctx_{nullptr};
+    mutable std::mutex mutex_;
+};
+
+}  // namespace mooncake
+
+#endif  // STORE_USE_REDIS

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -67,6 +67,7 @@ struct MasterConfig {
     // "redis")
     std::string election_backend = "etcd";  // "etcd" (default) or "redis"
     std::string redis_endpoint;         // Redis endpoint, e.g. "10.0.0.1:6379"
+    std::string redis_username;         // Redis ACL username
     std::string redis_password;         // Redis AUTH password (empty = no auth)
     int redis_db_index = 0;             // Redis DB index
     int redis_master_view_ttl_sec = 5;  // Leader key TTL in seconds
@@ -126,6 +127,7 @@ class MasterServiceSupervisorConfig {
     // Redis election backend configuration
     ElectionBackend election_backend = ElectionBackend::ETCD;
     std::string redis_endpoint;            // Redis endpoint for election
+    std::string redis_username;            // Redis ACL username
     std::string redis_password;            // Redis AUTH password
     int redis_db_index = 0;                // Redis DB index
     int redis_master_view_ttl_sec = 5;     // Leader key TTL in seconds
@@ -203,6 +205,7 @@ class MasterServiceSupervisorConfig {
                 ". Must be 'etcd' or 'redis'");
         }
         redis_endpoint = config.redis_endpoint;
+        redis_username = config.redis_username;
         redis_password = config.redis_password;
         redis_db_index = config.redis_db_index;
         redis_master_view_ttl_sec = config.redis_master_view_ttl_sec;
@@ -298,6 +301,9 @@ class WrappedMasterServiceConfig {
     bool enable_oplog = false;
     std::string oplog_store_type = "localfs";
     std::string oplog_data_dir = "/tmp/mooncake_oplog";
+    std::string redis_endpoint;
+    std::string redis_username;
+    std::string redis_password;
     bool enable_offload = false;
     std::string cluster_id = DEFAULT_CLUSTER_ID;
     std::string root_fs_dir = DEFAULT_ROOT_FS_DIR;
@@ -343,6 +349,9 @@ class WrappedMasterServiceConfig {
         enable_oplog = config.enable_oplog;
         oplog_store_type = config.oplog_store_type;
         oplog_data_dir = config.oplog_data_dir;
+        redis_endpoint = config.redis_endpoint;
+        redis_username = config.redis_username;
+        redis_password = config.redis_password;
         enable_offload = config.enable_offload;
         cluster_id = config.cluster_id;
         root_fs_dir = config.root_fs_dir;
@@ -393,6 +402,9 @@ class WrappedMasterServiceConfig {
         enable_oplog = config.enable_oplog;
         oplog_store_type = config.oplog_store_type;
         oplog_data_dir = config.oplog_data_dir;
+        redis_endpoint = config.redis_endpoint;
+        redis_username = config.redis_username;
+        redis_password = config.redis_password;
         enable_offload = config.enable_offload;
         cluster_id = config.cluster_id;
         root_fs_dir = config.root_fs_dir;
@@ -639,6 +651,9 @@ class MasterServiceConfig {
     bool enable_oplog = false;
     std::string oplog_store_type = "localfs";
     std::string oplog_data_dir = "/tmp/mooncake_oplog";
+    std::string redis_endpoint;
+    std::string redis_username;
+    std::string redis_password;
     bool enable_offload = false;
     std::string cluster_id = DEFAULT_CLUSTER_ID;
     std::string root_fs_dir = DEFAULT_ROOT_FS_DIR;
@@ -680,6 +695,9 @@ class MasterServiceConfig {
         enable_oplog = config.enable_oplog;
         oplog_store_type = config.oplog_store_type;
         oplog_data_dir = config.oplog_data_dir;
+        redis_endpoint = config.redis_endpoint;
+        redis_username = config.redis_username;
+        redis_password = config.redis_password;
         enable_offload = config.enable_offload;
         cluster_id = config.cluster_id;
         root_fs_dir = config.root_fs_dir;

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -304,6 +304,7 @@ class WrappedMasterServiceConfig {
     std::string redis_endpoint;
     std::string redis_username;
     std::string redis_password;
+    int redis_db_index = 0;
     bool enable_offload = false;
     std::string cluster_id = DEFAULT_CLUSTER_ID;
     std::string root_fs_dir = DEFAULT_ROOT_FS_DIR;
@@ -352,6 +353,7 @@ class WrappedMasterServiceConfig {
         redis_endpoint = config.redis_endpoint;
         redis_username = config.redis_username;
         redis_password = config.redis_password;
+        redis_db_index = config.redis_db_index;
         enable_offload = config.enable_offload;
         cluster_id = config.cluster_id;
         root_fs_dir = config.root_fs_dir;
@@ -405,6 +407,7 @@ class WrappedMasterServiceConfig {
         redis_endpoint = config.redis_endpoint;
         redis_username = config.redis_username;
         redis_password = config.redis_password;
+        redis_db_index = config.redis_db_index;
         enable_offload = config.enable_offload;
         cluster_id = config.cluster_id;
         root_fs_dir = config.root_fs_dir;
@@ -654,6 +657,7 @@ class MasterServiceConfig {
     std::string redis_endpoint;
     std::string redis_username;
     std::string redis_password;
+    int redis_db_index = 0;
     bool enable_offload = false;
     std::string cluster_id = DEFAULT_CLUSTER_ID;
     std::string root_fs_dir = DEFAULT_ROOT_FS_DIR;
@@ -698,6 +702,7 @@ class MasterServiceConfig {
         redis_endpoint = config.redis_endpoint;
         redis_username = config.redis_username;
         redis_password = config.redis_password;
+        redis_db_index = config.redis_db_index;
         enable_offload = config.enable_offload;
         cluster_id = config.cluster_id;
         root_fs_dir = config.root_fs_dir;

--- a/mooncake-store/include/redis_helper.h
+++ b/mooncake-store/include/redis_helper.h
@@ -44,7 +44,8 @@ class RedisHelper {
     RedisHelper(const std::string& cluster_id,
                 const std::string& redis_endpoint,
                 const std::string& password = "", int db_index = 0,
-                int ttl_sec = 5, int heartbeat_interval_sec = 2);
+                int ttl_sec = 5, int heartbeat_interval_sec = 2,
+                const std::string& username = "");
     ~RedisHelper();
 
     RedisHelper(const RedisHelper&) = delete;
@@ -173,6 +174,7 @@ class RedisHelper {
     // === Connection state ===
 
     std::string redis_endpoint_;
+    std::string username_;
     std::string password_;
     int db_index_;
     redisContext* election_ctx_ =

--- a/mooncake-store/include/redis_master_view_helper.h
+++ b/mooncake-store/include/redis_master_view_helper.h
@@ -24,7 +24,8 @@ class RedisMasterViewHelper : public MasterViewHelper {
     RedisMasterViewHelper(const std::string& cluster_id,
                           const std::string& redis_endpoint,
                           const std::string& password, int db_index,
-                          int ttl_sec, int heartbeat_interval_sec);
+                          int ttl_sec, int heartbeat_interval_sec,
+                          const std::string& username = "");
 
     ErrorCode Connect();
 

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -91,6 +91,7 @@ if(STORE_USE_REDIS)
     message(STATUS "Found hiredis: include=${HIREDIS_INCLUDE_DIR} lib=${HIREDIS_LIB}")
     list(APPEND MOONCAKE_STORE_SOURCES redis_helper.cpp)
     list(APPEND MOONCAKE_STORE_SOURCES redis_master_view_helper.cpp)
+    list(APPEND MOONCAKE_STORE_SOURCES ha/oplog/redis_oplog_store.cpp)
     list(APPEND EXTRA_LIBS ${HIREDIS_LIB})
 endif()
 

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -77,7 +77,7 @@ CreateClientMasterViewHelper(const std::string& master_server_entry,
         auto helper = std::make_unique<RedisMasterViewHelper>(
             config.redis_cluster_id, redis_entry, config.redis_password,
             config.redis_db_index, config.redis_master_view_ttl_sec,
-            config.redis_heartbeat_interval_sec);
+            config.redis_heartbeat_interval_sec, config.redis_username);
         auto err = helper->Connect();
         if (err != ErrorCode::OK) {
             LOG(ERROR) << "Failed to connect to Redis at: " << redis_entry;
@@ -226,6 +226,7 @@ void ClientService::SetMasterDiscoveryConfig(
     master_discovery_config_.redis_cluster_id = config.redis_cluster_id.empty()
                                                     ? DEFAULT_CLUSTER_ID
                                                     : config.redis_cluster_id;
+    master_discovery_config_.redis_username = config.redis_username;
     master_discovery_config_.redis_password = config.redis_password;
     master_discovery_config_.redis_db_index = config.redis_db_index;
     master_discovery_config_.redis_master_view_ttl_sec =

--- a/mooncake-store/src/ha/oplog/oplog_store_factory.cpp
+++ b/mooncake-store/src/ha/oplog/oplog_store_factory.cpp
@@ -12,7 +12,7 @@ namespace mooncake {
 std::unique_ptr<OpLogStore> OpLogStoreFactory::Create(
     OpLogStoreType type, const std::string& cluster_id, OpLogStoreRole role,
     const std::string& oplog_root_dir, int poll_interval_ms,
-    const std::string& password, const std::string& username) {
+    const std::string& password, const std::string& username, int db_index) {
     switch (type) {
         case OpLogStoreType::ETCD: {
             // EtcdOpLogStore is not yet ported to this branch.
@@ -40,7 +40,7 @@ std::unique_ptr<OpLogStore> OpLogStoreFactory::Create(
             bool enable_write = (role == OpLogStoreRole::WRITER);
             auto store = std::make_unique<RedisOpLogStore>(
                 cluster_id, oplog_root_dir, enable_write, poll_interval_ms,
-                password, username);
+                password, username, db_index);
             if (store->Init() != ErrorCode::OK) {
                 LOG(ERROR)
                     << "OpLogStoreFactory: failed to init RedisOpLogStore"

--- a/mooncake-store/src/ha/oplog/oplog_store_factory.cpp
+++ b/mooncake-store/src/ha/oplog/oplog_store_factory.cpp
@@ -3,12 +3,16 @@
 #include <glog/logging.h>
 
 #include "ha/oplog/localfs_oplog_store.h"
+#ifdef STORE_USE_REDIS
+#include "ha/oplog/redis_oplog_store.h"
+#endif
 
 namespace mooncake {
 
 std::unique_ptr<OpLogStore> OpLogStoreFactory::Create(
     OpLogStoreType type, const std::string& cluster_id, OpLogStoreRole role,
-    const std::string& oplog_root_dir, int poll_interval_ms) {
+    const std::string& oplog_root_dir, int poll_interval_ms,
+    const std::string& password, const std::string& username) {
     switch (type) {
         case OpLogStoreType::ETCD: {
             // EtcdOpLogStore is not yet ported to this branch.
@@ -30,6 +34,26 @@ std::unique_ptr<OpLogStore> OpLogStoreFactory::Create(
                 return nullptr;
             }
             return store;
+        }
+        case OpLogStoreType::REDIS: {
+#ifdef STORE_USE_REDIS
+            bool enable_write = (role == OpLogStoreRole::WRITER);
+            auto store = std::make_unique<RedisOpLogStore>(
+                cluster_id, oplog_root_dir, enable_write, poll_interval_ms,
+                password, username);
+            if (store->Init() != ErrorCode::OK) {
+                LOG(ERROR)
+                    << "OpLogStoreFactory: failed to init RedisOpLogStore"
+                    << ", cluster_id=" << cluster_id
+                    << ", endpoint=" << oplog_root_dir;
+                return nullptr;
+            }
+            return store;
+#else
+            LOG(ERROR) << "OpLogStoreFactory: REDIS store requested but "
+                          "STORE_USE_REDIS is not enabled";
+            return nullptr;
+#endif
         }
         default:
             LOG(ERROR) << "OpLogStoreFactory: unknown store type";

--- a/mooncake-store/src/ha/oplog/p2p_hot_standby_service.cpp
+++ b/mooncake-store/src/ha/oplog/p2p_hot_standby_service.cpp
@@ -64,7 +64,7 @@ ErrorCode P2PHotStandbyService::StartOplogFollowingLocked(
             ? config_.redis_endpoint
             : config_.oplog_store_root_dir,
         config_.oplog_poll_interval_ms, config_.redis_password,
-        config_.redis_username);
+        config_.redis_username, config_.redis_db_index);
     if (!watcher_oplog_store_) {
         LOG(ERROR) << "P2PHotStandbyService: failed to create reader store"
                    << ", cluster_id=" << config_.cluster_id;
@@ -190,7 +190,7 @@ ErrorCode P2PHotStandbyService::FinalCatchUpForPromotionLocked(
             ? config_.redis_endpoint
             : config_.oplog_store_root_dir,
         config_.oplog_poll_interval_ms, config_.redis_password,
-        config_.redis_username);
+        config_.redis_username, config_.redis_db_index);
     if (!catch_up_store) {
         LOG(ERROR) << "P2PHotStandbyService: failed to create catch-up store";
         return ErrorCode::INTERNAL_ERROR;

--- a/mooncake-store/src/ha/oplog/p2p_hot_standby_service.cpp
+++ b/mooncake-store/src/ha/oplog/p2p_hot_standby_service.cpp
@@ -60,7 +60,11 @@ ErrorCode P2PHotStandbyService::StartOplogFollowingLocked(
 
     watcher_oplog_store_ = OpLogStoreFactory::Create(
         config_.oplog_store_type, config_.cluster_id, OpLogStoreRole::READER,
-        config_.oplog_store_root_dir, config_.oplog_poll_interval_ms);
+        config_.oplog_store_type == OpLogStoreType::REDIS
+            ? config_.redis_endpoint
+            : config_.oplog_store_root_dir,
+        config_.oplog_poll_interval_ms, config_.redis_password,
+        config_.redis_username);
     if (!watcher_oplog_store_) {
         LOG(ERROR) << "P2PHotStandbyService: failed to create reader store"
                    << ", cluster_id=" << config_.cluster_id;
@@ -182,7 +186,11 @@ ErrorCode P2PHotStandbyService::FinalCatchUpForPromotionLocked(
     uint64_t current_applied_seq_id) {
     auto catch_up_store = OpLogStoreFactory::Create(
         config_.oplog_store_type, config_.cluster_id, OpLogStoreRole::READER,
-        config_.oplog_store_root_dir, config_.oplog_poll_interval_ms);
+        config_.oplog_store_type == OpLogStoreType::REDIS
+            ? config_.redis_endpoint
+            : config_.oplog_store_root_dir,
+        config_.oplog_poll_interval_ms, config_.redis_password,
+        config_.redis_username);
     if (!catch_up_store) {
         LOG(ERROR) << "P2PHotStandbyService: failed to create catch-up store";
         return ErrorCode::INTERNAL_ERROR;

--- a/mooncake-store/src/ha/oplog/redis_oplog_store.cpp
+++ b/mooncake-store/src/ha/oplog/redis_oplog_store.cpp
@@ -34,8 +34,38 @@ bool ParseRedisEndpoint(const std::string& redis_endpoint, std::string& host,
                         int& port) {
     host = "127.0.0.1";
     port = 6379;
-    auto colon_pos = redis_endpoint.rfind(':');
-    if (colon_pos != std::string::npos) {
+    if (redis_endpoint.empty()) {
+        return true;
+    }
+
+    if (redis_endpoint.front() == '[') {
+        auto bracket_pos = redis_endpoint.find(']');
+        if (bracket_pos == std::string::npos) {
+            return false;
+        }
+        host = redis_endpoint.substr(1, bracket_pos - 1);
+        if (bracket_pos + 1 == redis_endpoint.size()) {
+            return !host.empty();
+        }
+        if (redis_endpoint[bracket_pos + 1] != ':') {
+            return false;
+        }
+        uint64_t parsed_port = 0;
+        const std::string port_str = redis_endpoint.substr(bracket_pos + 2);
+        if (port_str.empty() || !ParseUint64(port_str, parsed_port) ||
+            parsed_port == 0 || parsed_port > 65535) {
+            return false;
+        }
+        port = static_cast<int>(parsed_port);
+        return !host.empty();
+    }
+
+    const auto colon_count =
+        std::count(redis_endpoint.begin(), redis_endpoint.end(), ':');
+    if (colon_count > 1) {
+        host = redis_endpoint;
+    } else if (colon_count == 1) {
+        auto colon_pos = redis_endpoint.find(':');
         host = redis_endpoint.substr(0, colon_pos);
         uint64_t parsed_port = 0;
         const std::string port_str = redis_endpoint.substr(colon_pos + 1);
@@ -45,7 +75,7 @@ bool ParseRedisEndpoint(const std::string& redis_endpoint, std::string& host,
             return false;
         }
         port = static_cast<int>(parsed_port);
-    } else if (!redis_endpoint.empty()) {
+    } else {
         host = redis_endpoint;
     }
     return !host.empty();
@@ -308,7 +338,8 @@ ErrorCode RedisOpLogStore::ReadOpLogSince(uint64_t start_sequence_id,
         return ErrorCode::INTERNAL_ERROR;
     }
 
-    entries.reserve(reply->elements);
+    std::vector<uint64_t> sequence_ids;
+    sequence_ids.reserve(reply->elements);
     for (size_t i = 0; i < reply->elements; ++i) {
         redisReply* item = reply->element[i];
         if (!item || item->type != REDIS_REPLY_STRING) {
@@ -320,14 +351,62 @@ ErrorCode RedisOpLogStore::ReadOpLogSince(uint64_t start_sequence_id,
             LOG(ERROR) << "RedisOpLogStore::ReadOpLogSince: invalid seq value";
             return ErrorCode::INTERNAL_ERROR;
         }
-        OpLogEntry entry;
-        err = ReadOpLogUnlocked(sequence_id, entry);
-        if (err != ErrorCode::OK) {
+        sequence_ids.push_back(sequence_id);
+    }
+
+    for (uint64_t sequence_id : sequence_ids) {
+        const std::string entry_key = EntryKey(sequence_id);
+        if (redisAppendCommand(ctx_, "GET %b", entry_key.data(),
+                               entry_key.size()) != REDIS_OK) {
+            LOG(ERROR) << "RedisOpLogStore::ReadOpLogSince: append GET failed"
+                       << ", sequence_id=" << sequence_id;
+            redisFree(ctx_);
+            ctx_ = nullptr;
+            return ErrorCode::INTERNAL_ERROR;
+        }
+    }
+
+    entries.reserve(sequence_ids.size());
+    for (size_t i = 0; i < sequence_ids.size(); ++i) {
+        redisReply* raw_reply = nullptr;
+        if (redisGetReply(ctx_, reinterpret_cast<void**>(&raw_reply)) !=
+                REDIS_OK ||
+            !raw_reply) {
+            LOG(ERROR) << "RedisOpLogStore::ReadOpLogSince: pipeline GET failed"
+                       << ", sequence_id=" << sequence_ids[i];
+            redisFree(ctx_);
+            ctx_ = nullptr;
+            return ErrorCode::INTERNAL_ERROR;
+        }
+        RedisReplyPtr entry_reply(raw_reply);
+        if (entry_reply->type == REDIS_REPLY_NIL) {
             LOG(ERROR) << "RedisOpLogStore::ReadOpLogSince: missing indexed "
                           "entry"
-                       << ", sequence_id=" << sequence_id
-                       << ", error=" << toString(err);
-            return err;
+                       << ", sequence_id=" << sequence_ids[i];
+            return ErrorCode::OPLOG_ENTRY_NOT_FOUND;
+        }
+        if (entry_reply->type == REDIS_REPLY_ERROR) {
+            LOG(ERROR) << "RedisOpLogStore::ReadOpLogSince: GET failed"
+                       << ", sequence_id=" << sequence_ids[i] << ", error="
+                       << (entry_reply->str ? entry_reply->str : "null");
+            redisFree(ctx_);
+            ctx_ = nullptr;
+            return ErrorCode::INTERNAL_ERROR;
+        }
+        if (entry_reply->type != REDIS_REPLY_STRING) {
+            LOG(ERROR)
+                << "RedisOpLogStore::ReadOpLogSince: unexpected GET reply type"
+                << ", type=" << entry_reply->type
+                << ", sequence_id=" << sequence_ids[i];
+            return ErrorCode::INTERNAL_ERROR;
+        }
+
+        OpLogEntry entry;
+        std::string serialized(entry_reply->str, entry_reply->len);
+        if (!DeserializeOpLogEntry(serialized, entry)) {
+            LOG(ERROR) << "RedisOpLogStore::ReadOpLogSince: deserialize failed"
+                       << ", sequence_id=" << sequence_ids[i];
+            return ErrorCode::INTERNAL_ERROR;
         }
         entries.push_back(std::move(entry));
     }

--- a/mooncake-store/src/ha/oplog/redis_oplog_store.cpp
+++ b/mooncake-store/src/ha/oplog/redis_oplog_store.cpp
@@ -32,10 +32,8 @@ bool ParseUint64(const std::string& value, uint64_t& result) {
 
 bool ParseRedisEndpoint(const std::string& redis_endpoint, std::string& host,
                         int& port) {
-    host = "127.0.0.1";
-    port = 6379;
     if (redis_endpoint.empty()) {
-        return true;
+        return false;
     }
 
     if (redis_endpoint.front() == '[') {
@@ -44,10 +42,8 @@ bool ParseRedisEndpoint(const std::string& redis_endpoint, std::string& host,
             return false;
         }
         host = redis_endpoint.substr(1, bracket_pos - 1);
-        if (bracket_pos + 1 == redis_endpoint.size()) {
-            return !host.empty();
-        }
-        if (redis_endpoint[bracket_pos + 1] != ':') {
+        if (bracket_pos + 1 == redis_endpoint.size() ||
+            redis_endpoint[bracket_pos + 1] != ':') {
             return false;
         }
         uint64_t parsed_port = 0;
@@ -62,9 +58,7 @@ bool ParseRedisEndpoint(const std::string& redis_endpoint, std::string& host,
 
     const auto colon_count =
         std::count(redis_endpoint.begin(), redis_endpoint.end(), ':');
-    if (colon_count > 1) {
-        host = redis_endpoint;
-    } else if (colon_count == 1) {
+    if (colon_count == 1) {
         auto colon_pos = redis_endpoint.find(':');
         host = redis_endpoint.substr(0, colon_pos);
         uint64_t parsed_port = 0;
@@ -76,7 +70,7 @@ bool ParseRedisEndpoint(const std::string& redis_endpoint, std::string& host,
         }
         port = static_cast<int>(parsed_port);
     } else {
-        host = redis_endpoint;
+        return false;
     }
     return !host.empty();
 }
@@ -95,11 +89,12 @@ RedisOpLogStore::RedisOpLogStore(const std::string& cluster_id,
                                  const std::string& redis_endpoint,
                                  bool enable_write, int poll_interval_ms,
                                  const std::string& password,
-                                 const std::string& username)
+                                 const std::string& username, int db_index)
     : cluster_id_(cluster_id),
       redis_endpoint_(redis_endpoint),
       username_(username),
       password_(password),
+      db_index_(db_index),
       enable_write_(enable_write),
       poll_interval_ms_(poll_interval_ms) {
     if (!NormalizeAndValidateClusterId(cluster_id_)) {
@@ -175,6 +170,20 @@ redisContext* RedisOpLogStore::CreateConnection() const {
         }
     }
 
+    if (db_index_ != 0) {
+        RedisReplyPtr select_reply(
+            (redisReply*)redisCommand(ctx, "SELECT %d", db_index_));
+        if (!select_reply || select_reply->type == REDIS_REPLY_ERROR) {
+            LOG(ERROR) << "RedisOpLogStore: SELECT failed"
+                       << ", endpoint=" << redis_endpoint_
+                       << ", db_index=" << db_index_ << ", error="
+                       << (select_reply && select_reply->str ? select_reply->str
+                                                             : "null");
+            redisFree(ctx);
+            return nullptr;
+        }
+    }
+
     return ctx;
 }
 
@@ -187,7 +196,13 @@ ErrorCode RedisOpLogStore::EnsureConnectedUnlocked() {
         ctx_ = nullptr;
     }
     ctx_ = CreateConnection();
-    return ctx_ ? ErrorCode::OK : ErrorCode::INTERNAL_ERROR;
+    if (!ctx_) {
+        LOG(ERROR) << "RedisOpLogStore: failed to create Redis connection"
+                   << ", endpoint=" << redis_endpoint_
+                   << ", db_index=" << db_index_;
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    return ErrorCode::OK;
 }
 
 ErrorCode RedisOpLogStore::Init() {
@@ -362,6 +377,7 @@ ErrorCode RedisOpLogStore::ReadOpLogSince(uint64_t start_sequence_id,
                        << ", sequence_id=" << sequence_id;
             redisFree(ctx_);
             ctx_ = nullptr;
+            entries.clear();
             return ErrorCode::INTERNAL_ERROR;
         }
     }
@@ -376,6 +392,7 @@ ErrorCode RedisOpLogStore::ReadOpLogSince(uint64_t start_sequence_id,
                        << ", sequence_id=" << sequence_ids[i];
             redisFree(ctx_);
             ctx_ = nullptr;
+            entries.clear();
             return ErrorCode::INTERNAL_ERROR;
         }
         RedisReplyPtr entry_reply(raw_reply);
@@ -383,6 +400,9 @@ ErrorCode RedisOpLogStore::ReadOpLogSince(uint64_t start_sequence_id,
             LOG(ERROR) << "RedisOpLogStore::ReadOpLogSince: missing indexed "
                           "entry"
                        << ", sequence_id=" << sequence_ids[i];
+            redisFree(ctx_);
+            ctx_ = nullptr;
+            entries.clear();
             return ErrorCode::OPLOG_ENTRY_NOT_FOUND;
         }
         if (entry_reply->type == REDIS_REPLY_ERROR) {
@@ -391,6 +411,7 @@ ErrorCode RedisOpLogStore::ReadOpLogSince(uint64_t start_sequence_id,
                        << (entry_reply->str ? entry_reply->str : "null");
             redisFree(ctx_);
             ctx_ = nullptr;
+            entries.clear();
             return ErrorCode::INTERNAL_ERROR;
         }
         if (entry_reply->type != REDIS_REPLY_STRING) {
@@ -398,6 +419,9 @@ ErrorCode RedisOpLogStore::ReadOpLogSince(uint64_t start_sequence_id,
                 << "RedisOpLogStore::ReadOpLogSince: unexpected GET reply type"
                 << ", type=" << entry_reply->type
                 << ", sequence_id=" << sequence_ids[i];
+            redisFree(ctx_);
+            ctx_ = nullptr;
+            entries.clear();
             return ErrorCode::INTERNAL_ERROR;
         }
 
@@ -406,6 +430,9 @@ ErrorCode RedisOpLogStore::ReadOpLogSince(uint64_t start_sequence_id,
         if (!DeserializeOpLogEntry(serialized, entry)) {
             LOG(ERROR) << "RedisOpLogStore::ReadOpLogSince: deserialize failed"
                        << ", sequence_id=" << sequence_ids[i];
+            redisFree(ctx_);
+            ctx_ = nullptr;
+            entries.clear();
             return ErrorCode::INTERNAL_ERROR;
         }
         entries.push_back(std::move(entry));
@@ -496,6 +523,9 @@ ErrorCode RedisOpLogStore::RecordSnapshotSequenceId(
     const std::string& snapshot_id, uint64_t sequence_id) {
     std::lock_guard<std::mutex> lock(mutex_);
     if (!IsValidSnapshotId(snapshot_id)) {
+        LOG(ERROR) << "RedisOpLogStore::RecordSnapshotSequenceId: invalid "
+                      "snapshot_id"
+                   << ", snapshot_id=" << snapshot_id;
         return ErrorCode::INVALID_PARAMS;
     }
     auto err = EnsureConnectedUnlocked();
@@ -517,6 +547,9 @@ ErrorCode RedisOpLogStore::GetSnapshotSequenceId(const std::string& snapshot_id,
                                                  uint64_t& sequence_id) {
     std::lock_guard<std::mutex> lock(mutex_);
     if (!IsValidSnapshotId(snapshot_id)) {
+        LOG(ERROR) << "RedisOpLogStore::GetSnapshotSequenceId: invalid "
+                      "snapshot_id"
+                   << ", snapshot_id=" << snapshot_id;
         return ErrorCode::INVALID_PARAMS;
     }
     auto err = EnsureConnectedUnlocked();

--- a/mooncake-store/src/ha/oplog/redis_oplog_store.cpp
+++ b/mooncake-store/src/ha/oplog/redis_oplog_store.cpp
@@ -1,0 +1,504 @@
+#ifdef STORE_USE_REDIS
+
+#include "ha/oplog/redis_oplog_store.h"
+
+#include <glog/logging.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstring>
+#include <iomanip>
+#include <sstream>
+
+#include "ha/oplog/oplog_serializer.h"
+#include "ha/oplog/polling_oplog_change_notifier.h"
+
+namespace mooncake {
+
+namespace {
+
+constexpr int kConnectTimeoutMs = 5000;
+constexpr int kCommandTimeoutMs = 3000;
+
+bool ParseUint64(const std::string& value, uint64_t& result) {
+    try {
+        size_t pos = 0;
+        result = std::stoull(value, &pos);
+        return pos == value.size();
+    } catch (...) {
+        return false;
+    }
+}
+
+bool ParseRedisEndpoint(const std::string& redis_endpoint, std::string& host,
+                        int& port) {
+    host = "127.0.0.1";
+    port = 6379;
+    auto colon_pos = redis_endpoint.rfind(':');
+    if (colon_pos != std::string::npos) {
+        host = redis_endpoint.substr(0, colon_pos);
+        uint64_t parsed_port = 0;
+        const std::string port_str = redis_endpoint.substr(colon_pos + 1);
+        if (host.empty() || port_str.empty() ||
+            !ParseUint64(port_str, parsed_port) || parsed_port == 0 ||
+            parsed_port > 65535) {
+            return false;
+        }
+        port = static_cast<int>(parsed_port);
+    } else if (!redis_endpoint.empty()) {
+        host = redis_endpoint;
+    }
+    return !host.empty();
+}
+
+std::string Uint64ToString(uint64_t value) { return std::to_string(value); }
+
+std::string SequenceMember(uint64_t value) {
+    std::ostringstream oss;
+    oss << std::setw(20) << std::setfill('0') << value;
+    return oss.str();
+}
+
+}  // namespace
+
+RedisOpLogStore::RedisOpLogStore(const std::string& cluster_id,
+                                 const std::string& redis_endpoint,
+                                 bool enable_write, int poll_interval_ms,
+                                 const std::string& password,
+                                 const std::string& username)
+    : cluster_id_(cluster_id),
+      redis_endpoint_(redis_endpoint),
+      username_(username),
+      password_(password),
+      enable_write_(enable_write),
+      poll_interval_ms_(poll_interval_ms) {
+    if (!NormalizeAndValidateClusterId(cluster_id_)) {
+        LOG(FATAL) << "Invalid cluster_id for RedisOpLogStore: '" << cluster_id
+                   << "'. Allowed chars: [A-Za-z0-9_.-], max_len=128.";
+    }
+    if (cluster_id_.empty()) {
+        cluster_id_ = "default";
+    }
+    key_tag_ = "mooncake:{" + cluster_id_ + "}:oplog";
+    index_key_ = key_tag_ + ":index";
+    latest_key_ = key_tag_ + ":latest";
+    snapshot_prefix_ = key_tag_ + ":snapshot:";
+}
+
+RedisOpLogStore::~RedisOpLogStore() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (ctx_) {
+        redisFree(ctx_);
+        ctx_ = nullptr;
+    }
+}
+
+redisContext* RedisOpLogStore::CreateConnection() const {
+    std::string host;
+    int port = 0;
+    if (!ParseRedisEndpoint(redis_endpoint_, host, port)) {
+        LOG(ERROR) << "RedisOpLogStore: invalid Redis endpoint"
+                   << ", endpoint=" << redis_endpoint_;
+        return nullptr;
+    }
+    struct timeval connect_timeout;
+    connect_timeout.tv_sec = kConnectTimeoutMs / 1000;
+    connect_timeout.tv_usec = (kConnectTimeoutMs % 1000) * 1000;
+
+    redisContext* ctx =
+        redisConnectWithTimeout(host.c_str(), port, connect_timeout);
+    if (!ctx || ctx->err) {
+        LOG(ERROR) << "RedisOpLogStore: failed to connect to Redis"
+                   << ", endpoint=" << redis_endpoint_
+                   << ", error=" << (ctx ? ctx->errstr : "null");
+        if (ctx) {
+            redisFree(ctx);
+        }
+        return nullptr;
+    }
+
+    struct timeval command_timeout;
+    command_timeout.tv_sec = kCommandTimeoutMs / 1000;
+    command_timeout.tv_usec = (kCommandTimeoutMs % 1000) * 1000;
+    redisSetTimeout(ctx, command_timeout);
+
+    if (!username_.empty()) {
+        RedisReplyPtr auth((redisReply*)redisCommand(
+            ctx, "AUTH %b %b", username_.data(), username_.size(),
+            password_.data(), password_.size()));
+        if (!auth || auth->type == REDIS_REPLY_ERROR) {
+            LOG(ERROR) << "RedisOpLogStore: AUTH failed"
+                       << ", endpoint=" << redis_endpoint_ << ", error="
+                       << (auth && auth->str ? auth->str : "null");
+            redisFree(ctx);
+            return nullptr;
+        }
+    } else if (!password_.empty()) {
+        RedisReplyPtr auth((redisReply*)redisCommand(
+            ctx, "AUTH %b", password_.data(), password_.size()));
+        if (!auth || auth->type == REDIS_REPLY_ERROR) {
+            LOG(ERROR) << "RedisOpLogStore: AUTH failed"
+                       << ", endpoint=" << redis_endpoint_ << ", error="
+                       << (auth && auth->str ? auth->str : "null");
+            redisFree(ctx);
+            return nullptr;
+        }
+    }
+
+    return ctx;
+}
+
+ErrorCode RedisOpLogStore::EnsureConnectedUnlocked() {
+    if (ctx_ && ctx_->err == 0) {
+        return ErrorCode::OK;
+    }
+    if (ctx_) {
+        redisFree(ctx_);
+        ctx_ = nullptr;
+    }
+    ctx_ = CreateConnection();
+    return ctx_ ? ErrorCode::OK : ErrorCode::INTERNAL_ERROR;
+}
+
+ErrorCode RedisOpLogStore::Init() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto err = EnsureConnectedUnlocked();
+    if (err != ErrorCode::OK) {
+        return err;
+    }
+    if (enable_write_) {
+        const std::string zero_seq = SequenceMember(0);
+        RedisReplyPtr reply((redisReply*)redisCommand(
+            ctx_, "SETNX %b %b", latest_key_.data(), latest_key_.size(),
+            zero_seq.data(), zero_seq.size()));
+        if (!reply || reply->type == REDIS_REPLY_ERROR) {
+            LOG(ERROR) << "RedisOpLogStore::Init: SETNX latest failed";
+            return ErrorCode::INTERNAL_ERROR;
+        }
+    }
+    return ErrorCode::OK;
+}
+
+std::string RedisOpLogStore::EntryKey(uint64_t sequence_id) const {
+    return key_tag_ + ":entry:" + SequenceMember(sequence_id);
+}
+
+std::string RedisOpLogStore::SnapshotKey(const std::string& snapshot_id) const {
+    return snapshot_prefix_ + snapshot_id;
+}
+
+ErrorCode RedisOpLogStore::WriteOpLog(const OpLogEntry& entry, bool /*sync*/) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!enable_write_) {
+        LOG(ERROR) << "RedisOpLogStore::WriteOpLog called on reader";
+        return ErrorCode::INVALID_PARAMS;
+    }
+    auto err = EnsureConnectedUnlocked();
+    if (err != ErrorCode::OK) {
+        return err;
+    }
+
+    const std::string entry_key = EntryKey(entry.sequence_id);
+    const std::string serialized = SerializeOpLogEntry(entry);
+    const std::string seq_member = SequenceMember(entry.sequence_id);
+    const std::string zero_seq = SequenceMember(0);
+    static constexpr const char* kWriteScript = R"(
+local existing = redis.call('GET', KEYS[1])
+if existing then
+  if existing == ARGV[1] then
+    redis.call('ZADD', KEYS[2], 0, ARGV[2])
+    local latest = redis.call('GET', KEYS[3]) or ARGV[3]
+    if ARGV[2] > latest then redis.call('SET', KEYS[3], ARGV[2]) end
+    return 1
+  end
+  return -1
+end
+redis.call('SET', KEYS[1], ARGV[1])
+redis.call('ZADD', KEYS[2], 0, ARGV[2])
+local latest = redis.call('GET', KEYS[3]) or ARGV[3]
+if ARGV[2] > latest then redis.call('SET', KEYS[3], ARGV[2]) end
+return 1
+)";
+
+    RedisReplyPtr reply((redisReply*)redisCommand(
+        ctx_, "EVAL %s 3 %b %b %b %b %b %b", kWriteScript, entry_key.data(),
+        entry_key.size(), index_key_.data(), index_key_.size(),
+        latest_key_.data(), latest_key_.size(), serialized.data(),
+        serialized.size(), seq_member.data(), seq_member.size(),
+        zero_seq.data(), zero_seq.size()));
+    if (!reply || reply->type == REDIS_REPLY_ERROR) {
+        LOG(ERROR) << "RedisOpLogStore::WriteOpLog: Redis command failed"
+                   << ", sequence_id=" << entry.sequence_id;
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    if (reply->type != REDIS_REPLY_INTEGER || reply->integer != 1) {
+        LOG(ERROR) << "RedisOpLogStore::WriteOpLog: fencing violation"
+                   << ", sequence_id=" << entry.sequence_id;
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    return ErrorCode::OK;
+}
+
+ErrorCode RedisOpLogStore::ReadOpLog(uint64_t sequence_id, OpLogEntry& entry) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return ReadOpLogUnlocked(sequence_id, entry);
+}
+
+ErrorCode RedisOpLogStore::ReadOpLogUnlocked(uint64_t sequence_id,
+                                             OpLogEntry& entry) {
+    auto err = EnsureConnectedUnlocked();
+    if (err != ErrorCode::OK) {
+        return err;
+    }
+
+    const std::string entry_key = EntryKey(sequence_id);
+    RedisReplyPtr reply((redisReply*)redisCommand(
+        ctx_, "GET %b", entry_key.data(), entry_key.size()));
+    if (!reply || reply->type == REDIS_REPLY_ERROR) {
+        LOG(ERROR) << "RedisOpLogStore::ReadOpLog: GET failed"
+                   << ", sequence_id=" << sequence_id;
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    if (reply->type == REDIS_REPLY_NIL) {
+        return ErrorCode::OPLOG_ENTRY_NOT_FOUND;
+    }
+    if (reply->type != REDIS_REPLY_STRING) {
+        LOG(ERROR) << "RedisOpLogStore::ReadOpLog: unexpected reply type"
+                   << ", type=" << reply->type
+                   << ", sequence_id=" << sequence_id;
+        return ErrorCode::INTERNAL_ERROR;
+    }
+
+    std::string serialized(reply->str, reply->len);
+    if (!DeserializeOpLogEntry(serialized, entry)) {
+        LOG(ERROR) << "RedisOpLogStore::ReadOpLog: deserialize failed"
+                   << ", sequence_id=" << sequence_id;
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    return ErrorCode::OK;
+}
+
+ErrorCode RedisOpLogStore::ReadOpLogSince(uint64_t start_sequence_id,
+                                          size_t limit,
+                                          std::vector<OpLogEntry>& entries) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    entries.clear();
+    if (limit == 0) {
+        return ErrorCode::OK;
+    }
+    auto err = EnsureConnectedUnlocked();
+    if (err != ErrorCode::OK) {
+        return err;
+    }
+
+    const std::string min_member = "(" + SequenceMember(start_sequence_id);
+    const std::string limit_str = std::to_string(limit);
+    RedisReplyPtr reply((redisReply*)redisCommand(
+        ctx_, "ZRANGEBYLEX %b %b + LIMIT 0 %b", index_key_.data(),
+        index_key_.size(), min_member.data(), min_member.size(),
+        limit_str.data(), limit_str.size()));
+    if (!reply || reply->type == REDIS_REPLY_ERROR) {
+        LOG(ERROR) << "RedisOpLogStore::ReadOpLogSince: ZRANGEBYLEX failed"
+                   << ", start_sequence_id=" << start_sequence_id;
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    if (reply->type != REDIS_REPLY_ARRAY) {
+        LOG(ERROR) << "RedisOpLogStore::ReadOpLogSince: unexpected reply type"
+                   << ", type=" << reply->type;
+        return ErrorCode::INTERNAL_ERROR;
+    }
+
+    entries.reserve(reply->elements);
+    for (size_t i = 0; i < reply->elements; ++i) {
+        redisReply* item = reply->element[i];
+        if (!item || item->type != REDIS_REPLY_STRING) {
+            LOG(ERROR) << "RedisOpLogStore::ReadOpLogSince: invalid seq reply";
+            return ErrorCode::INTERNAL_ERROR;
+        }
+        uint64_t sequence_id = 0;
+        if (!ParseUint64(std::string(item->str, item->len), sequence_id)) {
+            LOG(ERROR) << "RedisOpLogStore::ReadOpLogSince: invalid seq value";
+            return ErrorCode::INTERNAL_ERROR;
+        }
+        OpLogEntry entry;
+        err = ReadOpLogUnlocked(sequence_id, entry);
+        if (err != ErrorCode::OK) {
+            LOG(ERROR) << "RedisOpLogStore::ReadOpLogSince: missing indexed "
+                          "entry"
+                       << ", sequence_id=" << sequence_id
+                       << ", error=" << toString(err);
+            return err;
+        }
+        entries.push_back(std::move(entry));
+    }
+    return ErrorCode::OK;
+}
+
+ErrorCode RedisOpLogStore::GetLatestSequenceId(uint64_t& sequence_id) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto err = EnsureConnectedUnlocked();
+    if (err != ErrorCode::OK) {
+        return err;
+    }
+    RedisReplyPtr reply((redisReply*)redisCommand(
+        ctx_, "GET %b", latest_key_.data(), latest_key_.size()));
+    if (!reply || reply->type == REDIS_REPLY_ERROR) {
+        LOG(ERROR) << "RedisOpLogStore::GetLatestSequenceId: GET failed";
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    if (reply->type == REDIS_REPLY_NIL) {
+        sequence_id = 0;
+        return ErrorCode::OK;
+    }
+    if (reply->type != REDIS_REPLY_STRING ||
+        !ParseUint64(std::string(reply->str, reply->len), sequence_id)) {
+        LOG(ERROR) << "RedisOpLogStore::GetLatestSequenceId: invalid value";
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    return ErrorCode::OK;
+}
+
+ErrorCode RedisOpLogStore::GetMaxSequenceId(uint64_t& sequence_id) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto err = EnsureConnectedUnlocked();
+    if (err != ErrorCode::OK) {
+        return err;
+    }
+    RedisReplyPtr reply(
+        (redisReply*)redisCommand(ctx_, "ZREVRANGEBYLEX %b + - LIMIT 0 1",
+                                  index_key_.data(), index_key_.size()));
+    if (!reply || reply->type == REDIS_REPLY_ERROR) {
+        LOG(ERROR)
+            << "RedisOpLogStore::GetMaxSequenceId: ZREVRANGEBYLEX failed";
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    if (reply->type != REDIS_REPLY_ARRAY) {
+        LOG(ERROR) << "RedisOpLogStore::GetMaxSequenceId: unexpected reply "
+                      "type"
+                   << ", type=" << reply->type;
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    if (reply->elements == 0) {
+        return ErrorCode::OPLOG_ENTRY_NOT_FOUND;
+    }
+    redisReply* item = reply->element[0];
+    if (!item || item->type != REDIS_REPLY_STRING ||
+        !ParseUint64(std::string(item->str, item->len), sequence_id)) {
+        LOG(ERROR) << "RedisOpLogStore::GetMaxSequenceId: invalid seq value";
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    return ErrorCode::OK;
+}
+
+ErrorCode RedisOpLogStore::UpdateLatestSequenceId(uint64_t sequence_id) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto err = EnsureConnectedUnlocked();
+    if (err != ErrorCode::OK) {
+        return err;
+    }
+    const std::string seq = SequenceMember(sequence_id);
+    RedisReplyPtr reply(
+        (redisReply*)redisCommand(ctx_, "SET %b %b", latest_key_.data(),
+                                  latest_key_.size(), seq.data(), seq.size()));
+    if (!reply || reply->type == REDIS_REPLY_ERROR) {
+        LOG(ERROR) << "RedisOpLogStore::UpdateLatestSequenceId: SET failed";
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    return ErrorCode::OK;
+}
+
+bool RedisOpLogStore::IsValidSnapshotId(const std::string& snapshot_id) const {
+    return !snapshot_id.empty() && snapshot_id.find('/') == std::string::npos &&
+           snapshot_id.find("..") == std::string::npos &&
+           snapshot_id.find('\0') == std::string::npos;
+}
+
+ErrorCode RedisOpLogStore::RecordSnapshotSequenceId(
+    const std::string& snapshot_id, uint64_t sequence_id) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!IsValidSnapshotId(snapshot_id)) {
+        return ErrorCode::INVALID_PARAMS;
+    }
+    auto err = EnsureConnectedUnlocked();
+    if (err != ErrorCode::OK) {
+        return err;
+    }
+    const std::string key = SnapshotKey(snapshot_id);
+    const std::string seq = Uint64ToString(sequence_id);
+    RedisReplyPtr reply((redisReply*)redisCommand(
+        ctx_, "SET %b %b", key.data(), key.size(), seq.data(), seq.size()));
+    if (!reply || reply->type == REDIS_REPLY_ERROR) {
+        LOG(ERROR) << "RedisOpLogStore::RecordSnapshotSequenceId: SET failed";
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    return ErrorCode::OK;
+}
+
+ErrorCode RedisOpLogStore::GetSnapshotSequenceId(const std::string& snapshot_id,
+                                                 uint64_t& sequence_id) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!IsValidSnapshotId(snapshot_id)) {
+        return ErrorCode::INVALID_PARAMS;
+    }
+    auto err = EnsureConnectedUnlocked();
+    if (err != ErrorCode::OK) {
+        return err;
+    }
+    const std::string key = SnapshotKey(snapshot_id);
+    RedisReplyPtr reply(
+        (redisReply*)redisCommand(ctx_, "GET %b", key.data(), key.size()));
+    if (!reply || reply->type == REDIS_REPLY_ERROR) {
+        LOG(ERROR) << "RedisOpLogStore::GetSnapshotSequenceId: GET failed";
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    if (reply->type == REDIS_REPLY_NIL) {
+        return ErrorCode::OPLOG_ENTRY_NOT_FOUND;
+    }
+    if (reply->type != REDIS_REPLY_STRING ||
+        !ParseUint64(std::string(reply->str, reply->len), sequence_id)) {
+        LOG(ERROR) << "RedisOpLogStore::GetSnapshotSequenceId: invalid value";
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    return ErrorCode::OK;
+}
+
+ErrorCode RedisOpLogStore::CleanupOpLogBefore(uint64_t before_sequence_id) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (before_sequence_id == 0) {
+        return ErrorCode::OK;
+    }
+    auto err = EnsureConnectedUnlocked();
+    if (err != ErrorCode::OK) {
+        return err;
+    }
+
+    const std::string max_member = "[" + SequenceMember(before_sequence_id - 1);
+    static constexpr const char* kCleanupScript = R"(
+local members = redis.call('ZRANGEBYLEX', KEYS[1], '-', ARGV[1])
+for _, member in ipairs(members) do
+  redis.call('DEL', ARGV[2] .. member)
+end
+redis.call('ZREMRANGEBYLEX', KEYS[1], '-', ARGV[1])
+return #members
+)";
+    const std::string entry_prefix = key_tag_ + ":entry:";
+    RedisReplyPtr reply((redisReply*)redisCommand(
+        ctx_, "EVAL %s 1 %b %b %b", kCleanupScript, index_key_.data(),
+        index_key_.size(), max_member.data(), max_member.size(),
+        entry_prefix.data(), entry_prefix.size()));
+    if (!reply || reply->type == REDIS_REPLY_ERROR) {
+        LOG(ERROR) << "RedisOpLogStore::CleanupOpLogBefore: cleanup failed";
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    return ErrorCode::OK;
+}
+
+std::unique_ptr<OpLogChangeNotifier> RedisOpLogStore::CreateChangeNotifier(
+    const std::string& /*cluster_id*/) {
+    return std::make_unique<PollingOpLogChangeNotifier>(this,
+                                                        poll_interval_ms_);
+}
+
+}  // namespace mooncake
+
+#endif  // STORE_USE_REDIS

--- a/mooncake-store/src/ha_helper.cpp
+++ b/mooncake-store/src/ha_helper.cpp
@@ -168,6 +168,9 @@ int MasterServiceSupervisor::Start() {
             standby_config.oplog_store_type =
                 ParseOpLogStoreType(config_.oplog_store_type);
             standby_config.oplog_store_root_dir = config_.oplog_data_dir;
+            standby_config.redis_endpoint = config_.redis_endpoint;
+            standby_config.redis_username = config_.redis_username;
+            standby_config.redis_password = config_.redis_password;
 
             p2p_standby =
                 std::make_unique<P2PHotStandbyService>(standby_config);
@@ -285,7 +288,7 @@ std::unique_ptr<MasterViewHelper> CreateMasterViewHelper(
         auto helper = std::make_unique<RedisMasterViewHelper>(
             config.cluster_id, config.redis_endpoint, config.redis_password,
             config.redis_db_index, config.redis_master_view_ttl_sec,
-            config.redis_heartbeat_interval_sec);
+            config.redis_heartbeat_interval_sec, config.redis_username);
         auto rc = helper->Connect();
         if (rc != ErrorCode::OK) {
             LOG(ERROR) << "Failed to connect to Redis at: "

--- a/mooncake-store/src/ha_helper.cpp
+++ b/mooncake-store/src/ha_helper.cpp
@@ -171,6 +171,7 @@ int MasterServiceSupervisor::Start() {
             standby_config.redis_endpoint = config_.redis_endpoint;
             standby_config.redis_username = config_.redis_username;
             standby_config.redis_password = config_.redis_password;
+            standby_config.redis_db_index = config_.redis_db_index;
 
             p2p_standby =
                 std::make_unique<P2PHotStandbyService>(standby_config);

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -140,6 +140,7 @@ DEFINE_string(election_backend, "etcd",
 DEFINE_string(redis_endpoint, "",
               "Redis endpoint for election (required when "
               "election_backend=redis), e.g. '10.0.0.1:6379'");
+DEFINE_string(redis_username, "", "Redis ACL username (empty = one-arg AUTH)");
 DEFINE_string(redis_password, "", "Redis AUTH password (empty = no auth)");
 DEFINE_int32(redis_db_index, 0, "Redis database index (default: 0)");
 DEFINE_int32(
@@ -264,6 +265,8 @@ void InitMasterConf(const mooncake::DefaultConfig& default_config,
                              FLAGS_election_backend);
     default_config.GetString("redis_endpoint", &master_config.redis_endpoint,
                              FLAGS_redis_endpoint);
+    default_config.GetString("redis_username", &master_config.redis_username,
+                             FLAGS_redis_username);
     default_config.GetString("redis_password", &master_config.redis_password,
                              FLAGS_redis_password);
     default_config.GetInt32("redis_db_index", &master_config.redis_db_index,
@@ -546,6 +549,11 @@ void LoadConfigFromCmdline(mooncake::MasterConfig& master_config,
          !info.is_default) ||
         !conf_set) {
         master_config.redis_password = FLAGS_redis_password;
+    }
+    if ((google::GetCommandLineFlagInfo("redis_username", &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.redis_username = FLAGS_redis_username;
     }
     if ((google::GetCommandLineFlagInfo("redis_db_index", &info) &&
          !info.is_default) ||

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -31,17 +31,22 @@ MasterService::MasterService(const MasterServiceConfig& config)
         return;
     }
 
+    auto store_type = ParseOpLogStoreType(config.oplog_store_type);
+    const std::string& store_location = store_type == OpLogStoreType::REDIS
+                                            ? config.redis_endpoint
+                                            : config.oplog_data_dir;
     auto store = OpLogStoreFactory::Create(
-        ParseOpLogStoreType(config.oplog_store_type), config.cluster_id,
-        OpLogStoreRole::WRITER, config.oplog_data_dir);
+        store_type, config.cluster_id, OpLogStoreRole::WRITER, store_location,
+        kDefaultOpLogPollIntervalMs, config.redis_password,
+        config.redis_username);
     if (!store) {
         LOG(ERROR) << "MasterService: failed to initialize OpLogStore"
                    << ", type=" << config.oplog_store_type
-                   << ", data_dir=" << config.oplog_data_dir
+                   << ", location=" << store_location
                    << ", cluster_id=" << config.cluster_id;
         throw std::runtime_error(
             "failed to initialize OpLogStore while oplog is enabled: type=" +
-            config.oplog_store_type + ", data_dir=" + config.oplog_data_dir +
+            config.oplog_store_type + ", location=" + store_location +
             ", cluster_id=" + config.cluster_id);
     }
 

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -38,7 +38,7 @@ MasterService::MasterService(const MasterServiceConfig& config)
     auto store = OpLogStoreFactory::Create(
         store_type, config.cluster_id, OpLogStoreRole::WRITER, store_location,
         kDefaultOpLogPollIntervalMs, config.redis_password,
-        config.redis_username);
+        config.redis_username, config.redis_db_index);
     if (!store) {
         LOG(ERROR) << "MasterService: failed to initialize OpLogStore"
                    << ", type=" << config.oplog_store_type

--- a/mooncake-store/src/redis_helper.cpp
+++ b/mooncake-store/src/redis_helper.cpp
@@ -17,8 +17,10 @@ namespace mooncake {
 RedisHelper::RedisHelper(const std::string& cluster_id,
                          const std::string& redis_endpoint,
                          const std::string& password, int db_index, int ttl_sec,
-                         int heartbeat_interval_sec)
+                         int heartbeat_interval_sec,
+                         const std::string& username)
     : redis_endpoint_(redis_endpoint),
+      username_(username),
       password_(password),
       db_index_(db_index),
       ttl_sec_(ttl_sec),
@@ -90,8 +92,18 @@ redisContext* RedisHelper::CreateConnection() {
     }
     redisSetTimeout(ctx, tv);
 
-    // Authenticate if password provided
-    if (!password_.empty()) {
+    // Authenticate if credentials are provided. Redis ACL uses two arguments;
+    // older Redis/TBase deployments may still use one password argument.
+    if (!username_.empty()) {
+        RedisReplyPtr reply((redisReply*)redisCommand(
+            ctx, "AUTH %b %b", username_.data(), username_.size(),
+            password_.data(), password_.size()));
+        if (!reply || reply->type == REDIS_REPLY_ERROR) {
+            LOG(ERROR) << "Redis AUTH failed";
+            redisFree(ctx);
+            return nullptr;
+        }
+    } else if (!password_.empty()) {
         RedisReplyPtr reply((redisReply*)redisCommand(
             ctx, "AUTH %b", password_.data(), password_.size()));
         if (!reply || reply->type == REDIS_REPLY_ERROR) {

--- a/mooncake-store/src/redis_master_view_helper.cpp
+++ b/mooncake-store/src/redis_master_view_helper.cpp
@@ -8,9 +8,10 @@ RedisMasterViewHelper::RedisMasterViewHelper(const std::string& cluster_id,
                                              const std::string& redis_endpoint,
                                              const std::string& password,
                                              int db_index, int ttl_sec,
-                                             int heartbeat_interval_sec)
+                                             int heartbeat_interval_sec,
+                                             const std::string& username)
     : redis_helper_(cluster_id, redis_endpoint, password, db_index, ttl_sec,
-                    heartbeat_interval_sec),
+                    heartbeat_interval_sec, username),
       ttl_sec_(ttl_sec) {}
 
 ErrorCode RedisMasterViewHelper::Connect() { return redis_helper_.Connect(); }

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -102,6 +102,10 @@ if(STORE_USE_REDIS)
     add_test(NAME redis_helper_test COMMAND redis_helper_test)
 endif()
 
+if(STORE_USE_REDIS)
+    add_store_test(redis_oplog_store_test ha/oplog/redis_oplog_store_test.cpp)
+endif()
+
 add_executable(stress_workload_test stress_workload_test.cpp)
 target_link_libraries(stress_workload_test PUBLIC
     mooncake_store

--- a/mooncake-store/tests/e2e/process_handler.cpp
+++ b/mooncake-store/tests/e2e/process_handler.cpp
@@ -136,6 +136,9 @@ bool MasterProcessHandler::start() {
             args.emplace_back(
                 "--redis-heartbeat-interval-sec=" +
                 std::to_string(config_.redis_heartbeat_interval_sec));
+            if (!config_.redis_username.empty()) {
+                args.emplace_back("--redis-username=" + config_.redis_username);
+            }
             if (!config_.redis_password.empty()) {
                 args.emplace_back("--redis-password=" + config_.redis_password);
             }

--- a/mooncake-store/tests/e2e/process_handler.h
+++ b/mooncake-store/tests/e2e/process_handler.h
@@ -30,6 +30,7 @@ struct MasterRunnerConfig {
     std::string election_backend = "etcd";
     std::string etcd_endpoints;
     std::string redis_endpoint;
+    std::string redis_username;
     std::string redis_password;
     int redis_db_index = 0;
     int redis_master_view_ttl_sec = 5;

--- a/mooncake-store/tests/e2e/redis_chaos_test.cpp
+++ b/mooncake-store/tests/e2e/redis_chaos_test.cpp
@@ -13,6 +13,7 @@
 #include "e2e_utils.h"
 #include "process_handler.h"
 #include "redis_master_view_helper.h"
+#include "../redis_test_utils.h"
 #include "types.h"
 
 #include <hiredis/hiredis.h>
@@ -21,6 +22,10 @@ FLAG_master_path;
 FLAG_out_dir;
 DEFINE_string(redis_endpoint, "127.0.0.1:6379",
               "Redis endpoint for Redis master failover test");
+DEFINE_string(redis_username, "",
+              "Redis ACL username for Redis master failover test");
+DEFINE_string(redis_password, "",
+              "Redis password for Redis master failover test");
 DEFINE_string(redis_cluster_id, "redis_chaos_test",
               "Redis cluster ID for Redis master failover test");
 DEFINE_int32(redis_master_view_ttl_sec, 5,
@@ -67,7 +72,8 @@ std::string MasterEpochKey() {
 bool DeleteRedisKey(const std::string& key) {
     auto [host, port] = ParseRedisEndpoint();
     redisContext* ctx = redisConnect(host.c_str(), port);
-    if (!ctx || ctx->err) {
+    if (!AuthenticateRedisContext(ctx, FLAGS_redis_username,
+                                  FLAGS_redis_password)) {
         if (ctx) redisFree(ctx);
         return false;
     }
@@ -84,7 +90,8 @@ bool DeleteRedisKey(const std::string& key) {
 void CleanupRedisKeys() {
     auto [host, port] = ParseRedisEndpoint();
     redisContext* ctx = redisConnect(host.c_str(), port);
-    if (!ctx || ctx->err) {
+    if (!AuthenticateRedisContext(ctx, FLAGS_redis_username,
+                                  FLAGS_redis_password)) {
         if (ctx) redisFree(ctx);
         return;
     }
@@ -121,14 +128,16 @@ class RedisChaosTest : public ::testing::Test {
     void SetUp() override {
         CleanupRedisKeys();
         master_view_helper_ = std::make_unique<RedisMasterViewHelper>(
-            FLAGS_redis_cluster_id, FLAGS_redis_endpoint, "",
+            FLAGS_redis_cluster_id, FLAGS_redis_endpoint, FLAGS_redis_password,
             /*db_index=*/0, FLAGS_redis_master_view_ttl_sec,
-            FLAGS_redis_heartbeat_interval_sec);
+            FLAGS_redis_heartbeat_interval_sec, FLAGS_redis_username);
         ASSERT_EQ(master_view_helper_->Connect(), ErrorCode::OK);
 
         MasterRunnerConfig config;
         config.election_backend = "redis";
         config.redis_endpoint = FLAGS_redis_endpoint;
+        config.redis_username = FLAGS_redis_username;
+        config.redis_password = FLAGS_redis_password;
         config.redis_master_view_ttl_sec = FLAGS_redis_master_view_ttl_sec;
         config.redis_heartbeat_interval_sec =
             FLAGS_redis_heartbeat_interval_sec;

--- a/mooncake-store/tests/ha/oplog/redis_oplog_store_test.cpp
+++ b/mooncake-store/tests/ha/oplog/redis_oplog_store_test.cpp
@@ -1,0 +1,264 @@
+#ifdef STORE_USE_REDIS
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <string>
+
+#include <unistd.h>
+#include <hiredis/hiredis.h>
+
+#include "ha/oplog/oplog_store_factory.h"
+#include "ha/oplog/redis_oplog_store.h"
+#include "p2p_master_service.h"
+#include "redis_helper.h"
+#include "../../redis_test_utils.h"
+
+namespace mooncake {
+namespace {
+
+TEST(RedisOpLogStoreStandaloneTest, InvalidEndpointReturnsError) {
+    RedisOpLogStore store("invalid_endpoint_test", "127.0.0.1:notaport",
+                          /*enable_write=*/true, /*poll_interval_ms=*/10);
+    EXPECT_EQ(ErrorCode::INTERNAL_ERROR, store.Init());
+
+    auto factory_store = OpLogStoreFactory::Create(
+        OpLogStoreType::REDIS, "invalid_endpoint_test", OpLogStoreRole::WRITER,
+        "127.0.0.1:notaport",
+        /*poll_interval_ms=*/10);
+    EXPECT_EQ(nullptr, factory_store);
+}
+
+class RedisOpLogStoreTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        const char* endpoint = std::getenv("MOONCAKE_REDIS_ENDPOINT");
+        const char* username = std::getenv("MOONCAKE_REDIS_USERNAME");
+        const char* password = std::getenv("MOONCAKE_REDIS_PASSWORD");
+        redis_endpoint_ = endpoint ? endpoint : "127.0.0.1:6379";
+        redis_username_ = username ? username : "";
+        redis_password_ = password ? password : "";
+        cluster_id_ = "redis_oplog_test_" + std::to_string(::getpid()) + "_" +
+                      std::to_string(test_counter_++);
+        if (!RedisAvailable()) {
+            GTEST_SKIP() << "Redis is not available at " << redis_endpoint_;
+        }
+        CleanupKeys();
+    }
+
+    void TearDown() override { CleanupKeys(); }
+
+    bool RedisAvailable() const {
+        auto [host, port] = ParseEndpoint();
+        redisContext* ctx = redisConnect(host.c_str(), port);
+        if (!ctx || ctx->err) {
+            if (ctx) redisFree(ctx);
+            return false;
+        }
+        bool ok = testing::AuthenticateRedisContext(ctx, redis_username_,
+                                                    redis_password_);
+        redisFree(ctx);
+        if (!ok) {
+            return false;
+        }
+        return true;
+    }
+
+    std::pair<std::string, int> ParseEndpoint() const {
+        std::string host = "127.0.0.1";
+        int port = 6379;
+        auto colon_pos = redis_endpoint_.rfind(':');
+        if (colon_pos != std::string::npos) {
+            host = redis_endpoint_.substr(0, colon_pos);
+            port = std::stoi(redis_endpoint_.substr(colon_pos + 1));
+        } else if (!redis_endpoint_.empty()) {
+            host = redis_endpoint_;
+        }
+        return {host, port};
+    }
+
+    void CleanupKeys() const {
+        auto [host, port] = ParseEndpoint();
+        redisContext* ctx = redisConnect(host.c_str(), port);
+        if (!testing::AuthenticateRedisContext(ctx, redis_username_,
+                                               redis_password_)) {
+            if (ctx) redisFree(ctx);
+            return;
+        }
+        std::string cursor = "0";
+        const std::string pattern = "mooncake:{" + cluster_id_ + "}:oplog*";
+        do {
+            RedisReplyPtr scan((redisReply*)redisCommand(
+                ctx, "SCAN %b MATCH %b COUNT 100", cursor.data(), cursor.size(),
+                pattern.data(), pattern.size()));
+            if (!scan || scan->type != REDIS_REPLY_ARRAY ||
+                scan->elements != 2 || !scan->element[0] ||
+                scan->element[0]->type != REDIS_REPLY_STRING ||
+                !scan->element[1] ||
+                scan->element[1]->type != REDIS_REPLY_ARRAY) {
+                break;
+            }
+            cursor.assign(scan->element[0]->str, scan->element[0]->len);
+            redisReply* keys = scan->element[1];
+            for (size_t i = 0; i < keys->elements; ++i) {
+                redisReply* key = keys->element[i];
+                if (!key || key->type != REDIS_REPLY_STRING) continue;
+                RedisReplyPtr del((redisReply*)redisCommand(
+                    ctx, "DEL %b", key->str, key->len));
+            }
+        } while (cursor != "0");
+        redisFree(ctx);
+    }
+
+    std::unique_ptr<RedisOpLogStore> CreateWriter() const {
+        auto store = std::make_unique<RedisOpLogStore>(
+            cluster_id_, redis_endpoint_, /*enable_write=*/true,
+            /*poll_interval_ms=*/10, redis_password_, redis_username_);
+        EXPECT_EQ(ErrorCode::OK, store->Init());
+        return store;
+    }
+
+    std::unique_ptr<RedisOpLogStore> CreateReader() const {
+        auto store = std::make_unique<RedisOpLogStore>(
+            cluster_id_, redis_endpoint_, /*enable_write=*/false,
+            /*poll_interval_ms=*/10, redis_password_, redis_username_);
+        EXPECT_EQ(ErrorCode::OK, store->Init());
+        return store;
+    }
+
+    OpLogEntry MakeEntry(uint64_t sequence_id,
+                         const std::string& key = "redis_key") const {
+        OpLogEntry entry;
+        entry.sequence_id = sequence_id;
+        entry.op_type = OpType::PUT_END;
+        entry.object_key = key;
+        entry.payload = "payload_" + std::to_string(sequence_id);
+        entry.timestamp_ms = sequence_id * 10;
+        return entry;
+    }
+
+    std::string redis_endpoint_;
+    std::string redis_username_;
+    std::string redis_password_;
+    std::string cluster_id_;
+    static inline int test_counter_ = 0;
+};
+
+TEST_F(RedisOpLogStoreTest, WriteReadAndLatestSequence) {
+    auto writer = CreateWriter();
+    ASSERT_EQ(ErrorCode::OK, writer->WriteOpLog(MakeEntry(1), true));
+    ASSERT_EQ(ErrorCode::OK, writer->WriteOpLog(MakeEntry(2), true));
+
+    auto reader = CreateReader();
+    OpLogEntry entry;
+    ASSERT_EQ(ErrorCode::OK, reader->ReadOpLog(2, entry));
+    EXPECT_EQ(2u, entry.sequence_id);
+    EXPECT_EQ("payload_2", entry.payload);
+
+    uint64_t latest = 0;
+    ASSERT_EQ(ErrorCode::OK, reader->GetLatestSequenceId(latest));
+    EXPECT_EQ(2u, latest);
+}
+
+TEST_F(RedisOpLogStoreTest, ReadSinceReturnsOrderedEntries) {
+    auto writer = CreateWriter();
+    ASSERT_EQ(ErrorCode::OK, writer->WriteOpLog(MakeEntry(3), true));
+    ASSERT_EQ(ErrorCode::OK, writer->WriteOpLog(MakeEntry(1), true));
+    ASSERT_EQ(ErrorCode::OK, writer->WriteOpLog(MakeEntry(2), true));
+
+    std::vector<OpLogEntry> entries;
+    ASSERT_EQ(ErrorCode::OK, writer->ReadOpLogSince(1, 10, entries));
+    ASSERT_EQ(2u, entries.size());
+    EXPECT_EQ(2u, entries[0].sequence_id);
+    EXPECT_EQ(3u, entries[1].sequence_id);
+}
+
+TEST_F(RedisOpLogStoreTest, ReadSinceKeepsUint64Ordering) {
+    auto writer = CreateWriter();
+    constexpr uint64_t kBase = 9007199254740993ULL;
+    ASSERT_EQ(ErrorCode::OK, writer->WriteOpLog(MakeEntry(kBase + 2), true));
+    ASSERT_EQ(ErrorCode::OK, writer->WriteOpLog(MakeEntry(kBase), true));
+    ASSERT_EQ(ErrorCode::OK, writer->WriteOpLog(MakeEntry(kBase + 1), true));
+
+    std::vector<OpLogEntry> entries;
+    ASSERT_EQ(ErrorCode::OK, writer->ReadOpLogSince(kBase, 10, entries));
+    ASSERT_EQ(2u, entries.size());
+    EXPECT_EQ(kBase + 1, entries[0].sequence_id);
+    EXPECT_EQ(kBase + 2, entries[1].sequence_id);
+
+    uint64_t latest = 0;
+    ASSERT_EQ(ErrorCode::OK, writer->GetLatestSequenceId(latest));
+    EXPECT_EQ(kBase + 2, latest);
+
+    uint64_t max_sequence_id = 0;
+    ASSERT_EQ(ErrorCode::OK, writer->GetMaxSequenceId(max_sequence_id));
+    EXPECT_EQ(kBase + 2, max_sequence_id);
+}
+
+TEST_F(RedisOpLogStoreTest, RewriteDifferentPayloadFails) {
+    auto writer = CreateWriter();
+    auto entry = MakeEntry(1);
+    ASSERT_EQ(ErrorCode::OK, writer->WriteOpLog(entry, true));
+    ASSERT_EQ(ErrorCode::OK, writer->WriteOpLog(entry, true));
+
+    auto conflicting = entry;
+    conflicting.payload = "different_payload";
+    EXPECT_NE(ErrorCode::OK, writer->WriteOpLog(conflicting, true));
+}
+
+TEST_F(RedisOpLogStoreTest, CleanupRemovesOldEntries) {
+    auto writer = CreateWriter();
+    for (uint64_t i = 1; i <= 5; ++i) {
+        ASSERT_EQ(ErrorCode::OK, writer->WriteOpLog(MakeEntry(i), true));
+    }
+    ASSERT_EQ(ErrorCode::OK, writer->CleanupOpLogBefore(4));
+
+    OpLogEntry entry;
+    EXPECT_EQ(ErrorCode::OPLOG_ENTRY_NOT_FOUND, writer->ReadOpLog(3, entry));
+    ASSERT_EQ(ErrorCode::OK, writer->ReadOpLog(4, entry));
+
+    std::vector<OpLogEntry> entries;
+    ASSERT_EQ(ErrorCode::OK, writer->ReadOpLogSince(0, 10, entries));
+    ASSERT_EQ(2u, entries.size());
+    EXPECT_EQ(4u, entries[0].sequence_id);
+    EXPECT_EQ(5u, entries[1].sequence_id);
+}
+
+TEST_F(RedisOpLogStoreTest, SnapshotSequenceRoundTrip) {
+    auto writer = CreateWriter();
+    ASSERT_EQ(ErrorCode::OK, writer->RecordSnapshotSequenceId("snap-a", 42));
+
+    uint64_t sequence_id = 0;
+    ASSERT_EQ(ErrorCode::OK,
+              writer->GetSnapshotSequenceId("snap-a", sequence_id));
+    EXPECT_EQ(42u, sequence_id);
+    EXPECT_EQ(ErrorCode::OPLOG_ENTRY_NOT_FOUND,
+              writer->GetSnapshotSequenceId("missing", sequence_id));
+}
+
+TEST_F(RedisOpLogStoreTest, FactoryCreatesRedisStore) {
+    auto store = OpLogStoreFactory::Create(
+        OpLogStoreType::REDIS, cluster_id_, OpLogStoreRole::WRITER,
+        redis_endpoint_, /*poll_interval_ms=*/10, redis_password_,
+        redis_username_);
+    ASSERT_NE(store, nullptr);
+    ASSERT_EQ(ErrorCode::OK, store->WriteOpLog(MakeEntry(1), true));
+}
+
+TEST_F(RedisOpLogStoreTest, MasterServiceUsesRedisEndpointForRedisOpLog) {
+    MasterServiceConfig config;
+    config.enable_oplog = true;
+    config.oplog_store_type = "redis";
+    config.cluster_id = cluster_id_;
+    config.redis_endpoint = redis_endpoint_;
+    config.redis_username = redis_username_;
+    config.redis_password = redis_password_;
+    config.oplog_data_dir = "127.0.0.1:notaport";
+
+    EXPECT_NO_THROW({ P2PMasterService service(config); });
+}
+
+}  // namespace
+}  // namespace mooncake
+
+#endif  // STORE_USE_REDIS

--- a/mooncake-store/tests/ha/oplog/redis_oplog_store_test.cpp
+++ b/mooncake-store/tests/ha/oplog/redis_oplog_store_test.cpp
@@ -29,6 +29,16 @@ TEST(RedisOpLogStoreStandaloneTest, InvalidEndpointReturnsError) {
     EXPECT_EQ(nullptr, factory_store);
 }
 
+TEST(RedisOpLogStoreStandaloneTest, EndpointRequiresExplicitPort) {
+    for (const std::string& endpoint : {"", "127.0.0.1", "[::1]", "::1"}) {
+        RedisOpLogStore store("invalid_endpoint_test", endpoint,
+                              /*enable_write=*/true,
+                              /*poll_interval_ms=*/10);
+        EXPECT_EQ(ErrorCode::INTERNAL_ERROR, store.Init())
+            << "endpoint=" << endpoint;
+    }
+}
+
 class RedisOpLogStoreTest : public ::testing::Test {
    protected:
     void SetUp() override {
@@ -243,6 +253,14 @@ TEST_F(RedisOpLogStoreTest, FactoryCreatesRedisStore) {
         redis_username_);
     ASSERT_NE(store, nullptr);
     ASSERT_EQ(ErrorCode::OK, store->WriteOpLog(MakeEntry(1), true));
+}
+
+TEST_F(RedisOpLogStoreTest, RejectsInvalidDatabaseIndex) {
+    RedisOpLogStore store(cluster_id_, redis_endpoint_,
+                          /*enable_write=*/true,
+                          /*poll_interval_ms=*/10, redis_password_,
+                          redis_username_, /*db_index=*/-1);
+    EXPECT_EQ(ErrorCode::INTERNAL_ERROR, store.Init());
 }
 
 TEST_F(RedisOpLogStoreTest, MasterServiceUsesRedisEndpointForRedisOpLog) {

--- a/mooncake-store/tests/redis_helper_test.cpp
+++ b/mooncake-store/tests/redis_helper_test.cpp
@@ -12,6 +12,7 @@
 #ifdef STORE_USE_REDIS
 #include "redis_helper.h"
 #include "redis_master_view_helper.h"
+#include "redis_test_utils.h"
 #include <hiredis/hiredis.h>
 
 namespace mooncake {
@@ -19,14 +20,20 @@ namespace testing {
 
 DEFINE_string(redis_endpoint, "127.0.0.1:6379",
               "Redis endpoint for Redis test");
+DEFINE_string(redis_username, "",
+              "Redis ACL username for Redis test. Empty uses password-only "
+              "AUTH.");
+DEFINE_string(redis_password, "", "Redis password for Redis test");
 DEFINE_int32(redis_ttl_sec, 2, "Short TTL for testing fast key expiration");
 DEFINE_string(cluster_id, "test_helper", "Cluster ID for Redis test");
+DEFINE_bool(redis_supports_client_kill, true,
+            "Whether the Redis-compatible backend supports CLIENT KILL.");
 
 // ============================================================
 // Helper: clean up Redis keys between tests
 // ============================================================
 
-static void CleanupRedisKeys() {
+static std::pair<std::string, int> ParseRedisEndpoint() {
     std::string host = "127.0.0.1";
     int port = 6379;
     auto colon_pos = FLAGS_redis_endpoint.rfind(':');
@@ -34,8 +41,14 @@ static void CleanupRedisKeys() {
         host = FLAGS_redis_endpoint.substr(0, colon_pos);
         port = std::stoi(FLAGS_redis_endpoint.substr(colon_pos + 1));
     }
+    return {host, port};
+}
+
+static void CleanupRedisKeys() {
+    auto [host, port] = ParseRedisEndpoint();
     redisContext* ctx = redisConnect(host.c_str(), port);
-    if (ctx && !ctx->err) {
+    if (AuthenticateRedisContext(ctx, FLAGS_redis_username,
+                                 FLAGS_redis_password)) {
         std::string master_view_key =
             "mooncake:{" + FLAGS_cluster_id + "/}master_view";
         std::string master_epoch_key =
@@ -69,21 +82,24 @@ class RedisHelperTest : public ::testing::Test {
 };
 
 TEST_F(RedisHelperTest, Connect) {
-    RedisHelper helper(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0,
-                       FLAGS_redis_ttl_sec, 1);
+    RedisHelper helper(FLAGS_cluster_id, FLAGS_redis_endpoint,
+                       FLAGS_redis_password, 0, FLAGS_redis_ttl_sec, 1,
+                       FLAGS_redis_username);
     ASSERT_EQ(ErrorCode::OK, helper.Connect());
 
     // Second connection (empty password = no auth) should also work
-    RedisHelper helper2(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0,
-                        FLAGS_redis_ttl_sec, 1);
+    RedisHelper helper2(FLAGS_cluster_id, FLAGS_redis_endpoint,
+                        FLAGS_redis_password, 0, FLAGS_redis_ttl_sec, 1,
+                        FLAGS_redis_username);
     ASSERT_EQ(ErrorCode::OK, helper2.Connect());
 }
 
 // === Test 2: ElectLeader + GetMasterView ===
 
 TEST_F(RedisHelperTest, ElectLeaderAndGetMasterView) {
-    RedisHelper helper(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0,
-                       FLAGS_redis_ttl_sec, 1);
+    RedisHelper helper(FLAGS_cluster_id, FLAGS_redis_endpoint,
+                       FLAGS_redis_password, 0, FLAGS_redis_ttl_sec, 1,
+                       FLAGS_redis_username);
     ASSERT_EQ(ErrorCode::OK, helper.Connect());
 
     std::string master_address = "10.0.0.1:50051";
@@ -95,8 +111,9 @@ TEST_F(RedisHelperTest, ElectLeaderAndGetMasterView) {
     ASSERT_GT(lease_id, 0);
 
     // Read back via a separate helper
-    RedisHelper reader(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0,
-                       FLAGS_redis_ttl_sec, 1);
+    RedisHelper reader(FLAGS_cluster_id, FLAGS_redis_endpoint,
+                       FLAGS_redis_password, 0, FLAGS_redis_ttl_sec, 1,
+                       FLAGS_redis_username);
     ASSERT_EQ(ErrorCode::OK, reader.Connect());
 
     std::string got_address;
@@ -109,8 +126,9 @@ TEST_F(RedisHelperTest, ElectLeaderAndGetMasterView) {
 // === Test 3: KeepLeader keeps key alive past TTL ===
 
 TEST_F(RedisHelperTest, KeepLeaderRenewsTTL) {
-    RedisHelper helper(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0,
-                       FLAGS_redis_ttl_sec, 1);
+    RedisHelper helper(FLAGS_cluster_id, FLAGS_redis_endpoint,
+                       FLAGS_redis_password, 0, FLAGS_redis_ttl_sec, 1,
+                       FLAGS_redis_username);
     ASSERT_EQ(ErrorCode::OK, helper.Connect());
 
     std::string master_address = "10.0.0.2:50051";
@@ -138,8 +156,9 @@ TEST_F(RedisHelperTest, KeepLeaderRenewsTTL) {
 
 TEST_F(RedisHelperTest, KeyExpiresAfterKeepLeaderStops) {
     const int short_ttl = 1;
-    RedisHelper helper(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0, short_ttl,
-                       1);
+    RedisHelper helper(FLAGS_cluster_id, FLAGS_redis_endpoint,
+                       FLAGS_redis_password, 0, short_ttl, 1,
+                       FLAGS_redis_username);
     ASSERT_EQ(ErrorCode::OK, helper.Connect());
 
     std::string master_address = "10.0.0.3:50051";
@@ -162,8 +181,9 @@ TEST_F(RedisHelperTest, ElectLeaderWaitsForKeyExpiry) {
     const int short_ttl = 1;
 
     // First helper: elect and let key expire (no KeepLeader)
-    RedisHelper first(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0, short_ttl,
-                      1);
+    RedisHelper first(FLAGS_cluster_id, FLAGS_redis_endpoint,
+                      FLAGS_redis_password, 0, short_ttl, 1,
+                      FLAGS_redis_username);
     ASSERT_EQ(ErrorCode::OK, first.Connect());
     std::string first_addr = "10.0.0.4:50051";
     ViewVersionId first_version = 0;
@@ -171,8 +191,9 @@ TEST_F(RedisHelperTest, ElectLeaderWaitsForKeyExpiry) {
     first.ElectLeader(first_addr, first_version, first_lease);
 
     // Second helper: try to elect — should block until key expires
-    RedisHelper second(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0, short_ttl,
-                       1);
+    RedisHelper second(FLAGS_cluster_id, FLAGS_redis_endpoint,
+                       FLAGS_redis_password, 0, short_ttl, 1,
+                       FLAGS_redis_username);
     ASSERT_EQ(ErrorCode::OK, second.Connect());
     ViewVersionId second_version = 0;
     int second_lease = 0;
@@ -203,8 +224,9 @@ TEST_F(RedisHelperTest, ElectLeaderWaitsForKeyExpiry) {
 
 TEST_F(RedisHelperTest, EpochMonotonicallyIncreases) {
     const int short_ttl = 1;
-    RedisHelper helper(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0, short_ttl,
-                       1);
+    RedisHelper helper(FLAGS_cluster_id, FLAGS_redis_endpoint,
+                       FLAGS_redis_password, 0, short_ttl, 1,
+                       FLAGS_redis_username);
     ASSERT_EQ(ErrorCode::OK, helper.Connect());
 
     ViewVersionId prev_epoch = 0;
@@ -222,8 +244,9 @@ TEST_F(RedisHelperTest, EpochMonotonicallyIncreases) {
 // === Test 7: CancelKeepAlive stops KeepLeader promptly ===
 
 TEST_F(RedisHelperTest, CancelKeepAliveStopsPromptly) {
-    RedisHelper helper(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0,
-                       FLAGS_redis_ttl_sec, 1);
+    RedisHelper helper(FLAGS_cluster_id, FLAGS_redis_endpoint,
+                       FLAGS_redis_password, 0, FLAGS_redis_ttl_sec, 1,
+                       FLAGS_redis_username);
     ASSERT_EQ(ErrorCode::OK, helper.Connect());
 
     std::string master_address = "10.0.0.7:50051";
@@ -275,8 +298,9 @@ TEST_F(RedisHelperTest, CreateConnectionUnreachable) {
 // Covers: redis_helper.cpp:130-131, 145-146
 
 TEST_F(RedisHelperTest, ConnectTwice) {
-    RedisHelper helper(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0,
-                       FLAGS_redis_ttl_sec, 1);
+    RedisHelper helper(FLAGS_cluster_id, FLAGS_redis_endpoint,
+                       FLAGS_redis_password, 0, FLAGS_redis_ttl_sec, 1,
+                       FLAGS_redis_username);
     ASSERT_EQ(ErrorCode::OK, helper.Connect());
     // Second Connect should free old contexts and create new ones
     EXPECT_EQ(ErrorCode::OK, helper.Connect());
@@ -286,8 +310,9 @@ TEST_F(RedisHelperTest, ConnectTwice) {
 // Covers: redis_helper.cpp:510
 
 TEST_F(RedisHelperTest, GetMasterViewWithoutConnect) {
-    RedisHelper helper(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0,
-                       FLAGS_redis_ttl_sec, 1);
+    RedisHelper helper(FLAGS_cluster_id, FLAGS_redis_endpoint,
+                       FLAGS_redis_password, 0, FLAGS_redis_ttl_sec, 1,
+                       FLAGS_redis_username);
     // Don't call Connect — election_ctx_ is null
     std::string addr;
     ViewVersionId ver = 0;
@@ -302,11 +327,10 @@ TEST_F(RedisHelperTest, ElectLeaderUnparsableExistingValue) {
     // Write garbage into the master_view key directly
     std::string master_view_key =
         "mooncake:{" + FLAGS_cluster_id + "/}master_view";
-    redisContext* ctx = redisConnect(
-        FLAGS_redis_endpoint.substr(0, FLAGS_redis_endpoint.rfind(':')).c_str(),
-        std::stoi(
-            FLAGS_redis_endpoint.substr(FLAGS_redis_endpoint.rfind(':') + 1)));
-    ASSERT_TRUE(ctx && !ctx->err);
+    auto [host, port] = ParseRedisEndpoint();
+    redisContext* ctx = redisConnect(host.c_str(), port);
+    ASSERT_TRUE(AuthenticateRedisContext(ctx, FLAGS_redis_username,
+                                         FLAGS_redis_password));
     RedisReplyPtr r((redisReply*)redisCommand(
         ctx, "SET %b %b EX %d", master_view_key.data(), master_view_key.size(),
         "garbage", 7, short_ttl));
@@ -314,8 +338,9 @@ TEST_F(RedisHelperTest, ElectLeaderUnparsableExistingValue) {
 
     // ElectLeader should still work — it sees an unparsable leader value
     // and waits for it to expire, then wins election
-    RedisHelper helper(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0, short_ttl,
-                       1);
+    RedisHelper helper(FLAGS_cluster_id, FLAGS_redis_endpoint,
+                       FLAGS_redis_password, 0, short_ttl, 1,
+                       FLAGS_redis_username);
     ASSERT_EQ(ErrorCode::OK, helper.Connect());
 
     ViewVersionId version = 0;
@@ -333,8 +358,9 @@ TEST_F(RedisHelperTest, ElectLeaderContendedThenWin) {
     const int short_ttl = 1;
 
     // First helper: elect as leader
-    RedisHelper first(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0, short_ttl,
-                      1);
+    RedisHelper first(FLAGS_cluster_id, FLAGS_redis_endpoint,
+                      FLAGS_redis_password, 0, short_ttl, 1,
+                      FLAGS_redis_username);
     ASSERT_EQ(ErrorCode::OK, first.Connect());
     ViewVersionId first_version = 0;
     int first_lease = 0;
@@ -342,8 +368,9 @@ TEST_F(RedisHelperTest, ElectLeaderContendedThenWin) {
 
     // Second helper: try to elect while key exists — will watch until expiry
     // Then TryElectOnce may race and lose once before winning
-    RedisHelper second(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0, short_ttl,
-                       1);
+    RedisHelper second(FLAGS_cluster_id, FLAGS_redis_endpoint,
+                       FLAGS_redis_password, 0, short_ttl, 1,
+                       FLAGS_redis_username);
     ASSERT_EQ(ErrorCode::OK, second.Connect());
 
     ViewVersionId second_version = 0;
@@ -357,8 +384,9 @@ TEST_F(RedisHelperTest, ElectLeaderContendedThenWin) {
 // Covers: redis_helper.cpp:532-536
 
 TEST_F(RedisHelperTest, GetMasterViewNoLeader) {
-    RedisHelper helper(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0,
-                       FLAGS_redis_ttl_sec, 1);
+    RedisHelper helper(FLAGS_cluster_id, FLAGS_redis_endpoint,
+                       FLAGS_redis_password, 0, FLAGS_redis_ttl_sec, 1,
+                       FLAGS_redis_username);
     ASSERT_EQ(ErrorCode::OK, helper.Connect());
 
     // No election has happened, so master_view key should not exist
@@ -371,19 +399,18 @@ TEST_F(RedisHelperTest, GetMasterViewNoLeader) {
 // Covers: redis_helper.cpp:532-536 (ParseLeaderValue failure path)
 
 TEST_F(RedisHelperTest, GetMasterViewCorruptedValue) {
-    RedisHelper helper(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0,
-                       FLAGS_redis_ttl_sec, 1);
+    RedisHelper helper(FLAGS_cluster_id, FLAGS_redis_endpoint,
+                       FLAGS_redis_password, 0, FLAGS_redis_ttl_sec, 1,
+                       FLAGS_redis_username);
     ASSERT_EQ(ErrorCode::OK, helper.Connect());
 
     // Write corrupt value directly
     std::string master_view_key =
         "mooncake:{" + FLAGS_cluster_id + "/}master_view";
-    std::string host =
-        FLAGS_redis_endpoint.substr(0, FLAGS_redis_endpoint.rfind(':'));
-    int port = std::stoi(
-        FLAGS_redis_endpoint.substr(FLAGS_redis_endpoint.rfind(':') + 1));
+    auto [host, port] = ParseRedisEndpoint();
     redisContext* ctx = redisConnect(host.c_str(), port);
-    ASSERT_TRUE(ctx && !ctx->err);
+    ASSERT_TRUE(AuthenticateRedisContext(ctx, FLAGS_redis_username,
+                                         FLAGS_redis_password));
     RedisReplyPtr r((redisReply*)redisCommand(
         ctx, "SET %b %b EX %d", master_view_key.data(), master_view_key.size(),
         "not-json", 8, FLAGS_redis_ttl_sec));
@@ -422,8 +449,9 @@ TEST_F(RedisHelperTest, ParseLeaderValueMissingFields) {
 
 TEST_F(RedisHelperTest, KeepLeaderLosesLeadership) {
     const int short_ttl = 2;
-    RedisHelper helper(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0, short_ttl,
-                       1);
+    RedisHelper helper(FLAGS_cluster_id, FLAGS_redis_endpoint,
+                       FLAGS_redis_password, 0, short_ttl, 1,
+                       FLAGS_redis_username);
     ASSERT_EQ(ErrorCode::OK, helper.Connect());
 
     std::string master_address = "10.0.0.11:50051";
@@ -435,12 +463,10 @@ TEST_F(RedisHelperTest, KeepLeaderLosesLeadership) {
     // taking over)
     std::string master_view_key =
         "mooncake:{" + FLAGS_cluster_id + "/}master_view";
-    std::string host =
-        FLAGS_redis_endpoint.substr(0, FLAGS_redis_endpoint.rfind(':'));
-    int port = std::stoi(
-        FLAGS_redis_endpoint.substr(FLAGS_redis_endpoint.rfind(':') + 1));
+    auto [host, port] = ParseRedisEndpoint();
     redisContext* ctx = redisConnect(host.c_str(), port);
-    ASSERT_TRUE(ctx && !ctx->err);
+    ASSERT_TRUE(AuthenticateRedisContext(ctx, FLAGS_redis_username,
+                                         FLAGS_redis_password));
     RedisReplyPtr r((redisReply*)redisCommand(
         ctx, "SET %b %b EX %d", master_view_key.data(), master_view_key.size(),
         R"({"address":"10.0.0.99:50051","epoch":999,"ts":0,"ttl":2})", 57,
@@ -464,28 +490,32 @@ TEST_F(RedisHelperTest, KeepLeaderLosesLeadership) {
 // forcing WatchLeader to fall through to the pure polling path.
 
 TEST_F(RedisHelperTest, WatchLeaderPollingFallback) {
+    if (!FLAGS_redis_supports_client_kill) {
+        GTEST_SKIP() << "Redis-compatible backend does not support CLIENT KILL";
+    }
+
     const int short_ttl = 3;
 
     // First helper: elect as leader (key lives for short_ttl seconds)
-    RedisHelper first(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0, short_ttl,
-                      1);
+    RedisHelper first(FLAGS_cluster_id, FLAGS_redis_endpoint,
+                      FLAGS_redis_password, 0, short_ttl, 1,
+                      FLAGS_redis_username);
     ASSERT_EQ(ErrorCode::OK, first.Connect());
     ViewVersionId first_version = 0;
     int first_lease = 0;
     first.ElectLeader("10.0.0.12:50051", first_version, first_lease);
 
     // Second helper: Connect, then break its subscribe connection
-    RedisHelper second(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0, short_ttl,
-                       1);
+    RedisHelper second(FLAGS_cluster_id, FLAGS_redis_endpoint,
+                       FLAGS_redis_password, 0, short_ttl, 1,
+                       FLAGS_redis_username);
     ASSERT_EQ(ErrorCode::OK, second.Connect());
 
     // Kill all normal client connections to break subscribe_ctx_
-    std::string host =
-        FLAGS_redis_endpoint.substr(0, FLAGS_redis_endpoint.rfind(':'));
-    int port = std::stoi(
-        FLAGS_redis_endpoint.substr(FLAGS_redis_endpoint.rfind(':') + 1));
+    auto [host, port] = ParseRedisEndpoint();
     redisContext* admin = redisConnect(host.c_str(), port);
-    ASSERT_TRUE(admin && !admin->err);
+    ASSERT_TRUE(AuthenticateRedisContext(admin, FLAGS_redis_username,
+                                         FLAGS_redis_password));
     RedisReplyPtr kr(
         (redisReply*)redisCommand(admin, "CLIENT KILL TYPE normal"));
     redisFree(admin);
@@ -506,9 +536,14 @@ TEST_F(RedisHelperTest, WatchLeaderPollingFallback) {
 // operation that retries.
 
 TEST_F(RedisHelperTest, ReconnectAfterConnectionLoss) {
+    if (!FLAGS_redis_supports_client_kill) {
+        GTEST_SKIP() << "Redis-compatible backend does not support CLIENT KILL";
+    }
+
     const int short_ttl = 2;
-    RedisHelper helper(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0, short_ttl,
-                       1);
+    RedisHelper helper(FLAGS_cluster_id, FLAGS_redis_endpoint,
+                       FLAGS_redis_password, 0, short_ttl, 1,
+                       FLAGS_redis_username);
     ASSERT_EQ(ErrorCode::OK, helper.Connect());
 
     std::string master_address = "10.0.0.14:50051";
@@ -524,12 +559,10 @@ TEST_F(RedisHelperTest, ReconnectAfterConnectionLoss) {
     std::this_thread::sleep_for(std::chrono::seconds(2));
 
     // Kill the redis client connections to force a reconnect
-    std::string host =
-        FLAGS_redis_endpoint.substr(0, FLAGS_redis_endpoint.rfind(':'));
-    int port = std::stoi(
-        FLAGS_redis_endpoint.substr(FLAGS_redis_endpoint.rfind(':') + 1));
+    auto [host, port] = ParseRedisEndpoint();
     redisContext* admin = redisConnect(host.c_str(), port);
-    ASSERT_TRUE(admin && !admin->err);
+    ASSERT_TRUE(AuthenticateRedisContext(admin, FLAGS_redis_username,
+                                         FLAGS_redis_password));
 
     // CLIENT KILL to drop all normal clients except our admin connection
     RedisReplyPtr r(
@@ -551,8 +584,9 @@ TEST_F(RedisHelperTest, ElectLeaderCancelledViaWatchLeader) {
     const int short_ttl = 2;
 
     // First helper: elect as leader and keep it alive
-    RedisHelper first(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0, short_ttl,
-                      1);
+    RedisHelper first(FLAGS_cluster_id, FLAGS_redis_endpoint,
+                      FLAGS_redis_password, 0, short_ttl, 1,
+                      FLAGS_redis_username);
     ASSERT_EQ(ErrorCode::OK, first.Connect());
     ViewVersionId first_version = 0;
     int first_lease = 0;
@@ -561,8 +595,9 @@ TEST_F(RedisHelperTest, ElectLeaderCancelledViaWatchLeader) {
     std::thread first_keep([&]() { first.KeepLeader(first_lease); });
 
     // Second helper: will block in ElectLeader → WatchLeader
-    RedisHelper second(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0, short_ttl,
-                       1);
+    RedisHelper second(FLAGS_cluster_id, FLAGS_redis_endpoint,
+                       FLAGS_redis_password, 0, short_ttl, 1,
+                       FLAGS_redis_username);
     ASSERT_EQ(ErrorCode::OK, second.Connect());
     ViewVersionId second_version = 0;
     int second_lease = 0;
@@ -590,8 +625,9 @@ TEST_F(RedisHelperTest, SubscribeReceivesVacantMessage) {
     const int short_ttl = 2;
 
     // First helper: elect as leader with a short TTL
-    RedisHelper first(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0, short_ttl,
-                      1);
+    RedisHelper first(FLAGS_cluster_id, FLAGS_redis_endpoint,
+                      FLAGS_redis_password, 0, short_ttl, 1,
+                      FLAGS_redis_username);
     ASSERT_EQ(ErrorCode::OK, first.Connect());
     ViewVersionId first_version = 0;
     int first_lease = 0;
@@ -601,8 +637,9 @@ TEST_F(RedisHelperTest, SubscribeReceivesVacantMessage) {
     std::thread first_keep([&]() { first.KeepLeader(first_lease); });
 
     // Second helper: elect — will block in WatchLeader subscribing
-    RedisHelper second(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0, short_ttl,
-                       1);
+    RedisHelper second(FLAGS_cluster_id, FLAGS_redis_endpoint,
+                       FLAGS_redis_password, 0, short_ttl, 1,
+                       FLAGS_redis_username);
     ASSERT_EQ(ErrorCode::OK, second.Connect());
     ViewVersionId second_version = 0;
     int second_lease = 0;
@@ -639,8 +676,9 @@ class RedisElectionTest : public ::testing::Test {
 // === Test 8: MasterViewHelper ElectLeader + GetMasterView ===
 
 TEST_F(RedisElectionTest, ElectAndGetMasterView) {
-    RedisMasterViewHelper mv_helper(FLAGS_cluster_id, FLAGS_redis_endpoint, "",
-                                    0, FLAGS_redis_ttl_sec, 1);
+    RedisMasterViewHelper mv_helper(
+        FLAGS_cluster_id, FLAGS_redis_endpoint, FLAGS_redis_password, 0,
+        FLAGS_redis_ttl_sec, 1, FLAGS_redis_username);
     ASSERT_EQ(ErrorCode::OK, mv_helper.Connect());
 
     std::string master_address = "10.0.0.10:50051";
@@ -661,8 +699,9 @@ TEST_F(RedisElectionTest, ElectAndGetMasterView) {
 // === Test 9: MasterViewHelper KeepLeader ===
 
 TEST_F(RedisElectionTest, KeepLeaderRenewsTTL) {
-    RedisMasterViewHelper mv_helper(FLAGS_cluster_id, FLAGS_redis_endpoint, "",
-                                    0, FLAGS_redis_ttl_sec, 1);
+    RedisMasterViewHelper mv_helper(
+        FLAGS_cluster_id, FLAGS_redis_endpoint, FLAGS_redis_password, 0,
+        FLAGS_redis_ttl_sec, 1, FLAGS_redis_username);
     ASSERT_EQ(ErrorCode::OK, mv_helper.Connect());
 
     std::string master_address = "10.0.0.11:50051";
@@ -687,8 +726,9 @@ TEST_F(RedisElectionTest, KeepLeaderRenewsTTL) {
 
 TEST_F(RedisElectionTest, KeyExpiresAfterKeepLeaderStops) {
     const int short_ttl = 1;
-    RedisMasterViewHelper mv_helper(FLAGS_cluster_id, FLAGS_redis_endpoint, "",
-                                    0, short_ttl, 1);
+    RedisMasterViewHelper mv_helper(FLAGS_cluster_id, FLAGS_redis_endpoint,
+                                    FLAGS_redis_password, 0, short_ttl, 1,
+                                    FLAGS_redis_username);
     ASSERT_EQ(ErrorCode::OK, mv_helper.Connect());
 
     std::string master_address = "10.0.0.12:50051";
@@ -700,8 +740,9 @@ TEST_F(RedisElectionTest, KeyExpiresAfterKeepLeaderStops) {
     // Don't start KeepLeader — let the key expire naturally
     std::this_thread::sleep_for(std::chrono::seconds(short_ttl * 3));
 
-    RedisMasterViewHelper reader(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0,
-                                 short_ttl, 1);
+    RedisMasterViewHelper reader(FLAGS_cluster_id, FLAGS_redis_endpoint,
+                                 FLAGS_redis_password, 0, short_ttl, 1,
+                                 FLAGS_redis_username);
     ASSERT_EQ(ErrorCode::OK, reader.Connect());
     std::string got_address;
     ViewVersionId got_version = 0;
@@ -713,15 +754,17 @@ TEST_F(RedisElectionTest, KeyExpiresAfterKeepLeaderStops) {
 TEST_F(RedisElectionTest, ElectLeaderWaitsForKeyExpiry) {
     const int short_ttl = 1;
 
-    RedisMasterViewHelper first(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0,
-                                short_ttl, 1);
+    RedisMasterViewHelper first(FLAGS_cluster_id, FLAGS_redis_endpoint,
+                                FLAGS_redis_password, 0, short_ttl, 1,
+                                FLAGS_redis_username);
     ASSERT_EQ(ErrorCode::OK, first.Connect());
     ViewVersionId first_version = 0;
     EtcdLeaseId first_lease = 0;
     first.ElectLeader("10.0.0.13:50051", first_version, first_lease);
 
-    RedisMasterViewHelper second(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0,
-                                 short_ttl, 1);
+    RedisMasterViewHelper second(FLAGS_cluster_id, FLAGS_redis_endpoint,
+                                 FLAGS_redis_password, 0, short_ttl, 1,
+                                 FLAGS_redis_username);
     ASSERT_EQ(ErrorCode::OK, second.Connect());
     ViewVersionId second_version = 0;
     EtcdLeaseId second_lease = 0;
@@ -751,8 +794,9 @@ TEST_F(RedisElectionTest, ElectLeaderWaitsForKeyExpiry) {
 
 TEST_F(RedisElectionTest, EpochMonotonicallyIncreases) {
     const int short_ttl = 1;
-    RedisMasterViewHelper helper(FLAGS_cluster_id, FLAGS_redis_endpoint, "", 0,
-                                 short_ttl, 1);
+    RedisMasterViewHelper helper(FLAGS_cluster_id, FLAGS_redis_endpoint,
+                                 FLAGS_redis_password, 0, short_ttl, 1,
+                                 FLAGS_redis_username);
     ASSERT_EQ(ErrorCode::OK, helper.Connect());
 
     ViewVersionId prev_epoch = 0;

--- a/mooncake-store/tests/redis_test_utils.h
+++ b/mooncake-store/tests/redis_test_utils.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#ifdef STORE_USE_REDIS
+
+#include <string>
+
+#include <hiredis/hiredis.h>
+
+namespace mooncake::testing {
+
+inline bool AuthenticateRedisContext(redisContext* ctx,
+                                     const std::string& username,
+                                     const std::string& password) {
+    if (!ctx || ctx->err) {
+        return false;
+    }
+
+    redisReply* reply = nullptr;
+    if (!username.empty()) {
+        reply = static_cast<redisReply*>(
+            redisCommand(ctx, "AUTH %b %b", username.data(), username.size(),
+                         password.data(), password.size()));
+    } else if (!password.empty()) {
+        reply = static_cast<redisReply*>(
+            redisCommand(ctx, "AUTH %b", password.data(), password.size()));
+    } else {
+        return true;
+    }
+
+    bool ok = reply && reply->type != REDIS_REPLY_ERROR;
+    if (reply) {
+        freeReplyObject(reply);
+    }
+    return ok;
+}
+
+}  // namespace mooncake::testing
+
+#endif  // STORE_USE_REDIS


### PR DESCRIPTION
## Description

  Add Redis as an OpLog store backend for P2P master HA. This lets the primary write P2P metadata OpLogs to Redis and lets
  standby services read/follow the same Redis-backed OpLog stream.

  Also adds Redis username/password propagation for Redis election and Redis OpLog paths, plus Redis OpLog unit coverage and
  Redis-compatible test auth helpers.

  ## Module

  - [ ] Mooncake Store (mooncake-store)
  - [ ] Transfer Engine (mooncake-transfer-engine)
  - [ ] Mooncake EP (mooncake-ep)
  - [ ] Mooncake PG (mooncake-pg)
  - [ ] Integration (mooncake-integration)
  - [x] P2P Store (mooncake-p2p-store)
  - [ ] Python Wheel (mooncake-wheel)
  - [ ] Common (mooncake-common)
  - [ ] Mooncake RL (mooncake-rl)
  - [ ] CI/CD
  - [ ] Docs
  - [ ] Other

  ## Type of Change

  - [ ] Bug fix
  - [x] New feature
  - [ ] Refactor
  - [ ] Breaking change
  - [ ] Documentation update
  - [ ] Performance improvement
  - [ ] Other

  ## How Has This Been Tested?

  Test commands:
```
  docker exec mooncake-dev bash -lc 'cd /workspace && clang-format-20 -style=file -i <modified files>'

  docker exec mooncake-dev bash -lc 'cd /workspace && cmake --build build-redis-oplog --target redis_helper_test
  redis_oplog_store_test redis_chaos_test -j3'

  docker exec mooncake-dev bash -lc 'cd /workspace/build-redis-oplog && ctest -R "^(redis_helper_test|redis_oplog_store_test)$"
  --output-on-failure'
```
  Test results:

  - [x] Unit tests pass
  - [ ] Integration tests pass (if applicable)
  - [x] Manual testing done: built Redis-related test targets locally in container
  - redis_helper_test passed
  - redis_oplog_store_test passed
  - redis_chaos_test build passed

  ## Checklist

  - [x] I have performed a self-review of my own code
  - [x] I have formatted my code using ./scripts/code_format.sh
  - [ ] I have run pre-commit run --all-files and all hooks pass
  - [ ] I have updated the documentation (if applicable)
  - [x] I have added tests to prove my changes are effective
  - [ ] For changes >500 LOC: I have filed an RFC issue

  ## AI Assistance Disclosure

  - [ ] No AI tools were used
  - [x] AI tools were used (specify below)

  AI assistance was used to inspect the code paths, implement the Redis OpLog backend changes, and prepare/review test
  coverage.