### PR TITLE
[CI] Harden ARM64 package access and Docker disk usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,10 +355,29 @@ jobs:
 
     - name: Install CUDA Toolkit 13.0 (arm64 SBSA)
       run: |
-        wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/sbsa/cuda-keyring_1.1-1_all.deb
+        for source_file in \
+          /etc/apt/sources.list \
+          /etc/apt/sources.list.d/*.list \
+          /etc/apt/sources.list.d/*.sources; do
+          if [[ -f "$source_file" ]]; then
+            sudo sed -i \
+              's|http://ports.ubuntu.com/ubuntu-ports|https://ports.ubuntu.com/ubuntu-ports|g' \
+              "$source_file"
+          fi
+        done
+
+        apt_options=(
+          -o Acquire::ForceIPv4=true
+          -o Acquire::Retries=3
+          -o Acquire::http::Timeout=30
+          -o Acquire::https::Timeout=30
+        )
+
+        wget --inet4-only --tries=3 --timeout=30 \
+          https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/sbsa/cuda-keyring_1.1-1_all.deb
         sudo dpkg -i cuda-keyring_1.1-1_all.deb
-        sudo apt-get update
-        sudo apt-get install -y cuda-toolkit-13-0
+        sudo apt-get "${apt_options[@]}" update
+        sudo apt-get "${apt_options[@]}" install -y cuda-toolkit-13-0
         echo "/usr/local/cuda/bin" >> $GITHUB_PATH
         /usr/local/cuda/bin/nvcc --version
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -799,15 +799,37 @@ jobs:
       with:
         persist-credentials: false
 
+    - name: Free up disk space
+      run: |
+        echo "Disk usage before cleanup:"
+        df -h
+        docker system df || true
+
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /opt/ghc
+        sudo rm -rf /opt/hostedtoolcache/CodeQL
+        docker system prune --all --force --volumes
+
+        echo "Disk usage after cleanup:"
+        df -h
+        docker system df || true
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
 
     - name: Build Docker image
       run: |
-        docker build -f docker/mooncake.Dockerfile \
+        docker build --progress=plain -f docker/mooncake.Dockerfile \
           --build-arg PYTHON_VERSION=3.10 \
+          --build-arg CMAKE_BUILD_TYPE=Release \
           --build-arg EP_TORCH_VERSIONS="2.12.1" \
           -t mooncake:from-source .
+
+    - name: Report final disk usage
+      if: always()
+      run: |
+        df -h
+        docker system df || true
 
   spell-check:
     name: Spell Check with Typos


### PR DESCRIPTION
## Summary

- switch Ubuntu Ports entries from HTTP to HTTPS before the ARM64 CUDA install
- force IPv4 and add apt retry/timeout options
- make the NVIDIA keyring download use IPv4 with bounded retries
- free hosted-runner disk before the source Docker build and report disk usage before/after
- make the Docker build's existing Release configuration explicit and enable plain progress logs

## Motivation

### ARM64 package access

The ARM64 matrix fails before Mooncake is configured or built. In PR #2934 run 29479306961, Python 3.10 failed in `Install CUDA Toolkit 13.0 (arm64 SBSA)` and Python 3.12 was cancelled by matrix fail-fast. PR #2935 reproduced the same failure in run 29479320966. The completed logs show IPv6 is unreachable and all IPv4 connections to `ports.ubuntu.com:80` time out while fetching Ubuntu packages.

### Docker build capacity

PR #2934 run 29479306961 also failed while linking inside `docker/mooncake.Dockerfile` with `/tmp ... No space left on device`; pip then reported `[Errno 28]`. The same Docker job passed on the larger stacked #2935 old SHA, so this is hosted-runner capacity pressure rather than a source error. The cleanup removes large unused hosted-toolcache directories before Buildx starts and leaves disk diagnostics in every run.

This PR is intentionally separate from #2934 and #2935 because both failures are runner/CI reliability issues, not their feature code.

## Validation

Local checks:

- parsed `.github/workflows/ci.yml` with PyYAML
- extracted the modified ARM64 and Docker `run` blocks and passed them through `bash -n`
- `git diff --check`
- `typos-cli 1.30.2 .github/workflows/ci.yml`

Remote ARM64 validation on commit `140d8e76` in run 29480368390:

- [build-arm64 (3.10)](https://github.com/kvcache-ai/Mooncake/actions/runs/29480368390/job/87565559308): success, including CUDA installation, project build, wheel build, and artifact upload
- [build-arm64 (3.12)](https://github.com/kvcache-ai/Mooncake/actions/runs/29480368390/job/87565559281): success, including CUDA installation, project build, wheel build, and artifact upload

A new full Actions run on head `a06a81df` will validate the added Docker cleanup and reconfirm ARM64.
