### PR TITLE
[TransferEngine] Skip the CUDA pointer probe on GPU-less hosts

### DIFF
--- a/mooncake-transfer-engine/src/memory_location.cpp
+++ b/mooncake-transfer-engine/src/memory_location.cpp
@@ -38,19 +38,37 @@ const std::vector<MemoryLocationEntry> getMemoryLocation(void *start,
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX) || defined(USE_SUNRISE)
-    cudaPointerAttributes attributes;
-    cudaError_t result = cudaPointerGetAttributes(&attributes, start);
-    if (result != cudaSuccess) {
-        LOG(ERROR) << "cudaPointerGetAttributes failed (Error code: " << result
-                   << " - " << cudaGetErrorString(result) << ")" << std::endl;
-        entries.push_back({(uint64_t)start, len, kWildcardLocation});
-        return entries;
-    }
+    // A GPU-less host (e.g. an RDMA-only sidecar) has no device for
+    // cudaPointerGetAttributes to classify, yet a CUDA-enabled build probes
+    // every buffer, each call failing and logging a per-buffer ERROR that
+    // buries real logs. Detect the absence once and skip the probe.
+    static const bool cuda_device_present = [] {
+        int device_count = 0;
+        if (cudaGetDeviceCount(&device_count) != cudaSuccess ||
+            device_count == 0) {
+            LOG(WARNING) << "No CUDA device detected; treating buffers as "
+                            "host memory";
+            return false;
+        }
+        return true;
+    }();
 
-    if (attributes.type == cudaMemoryTypeDevice) {
-        entries.push_back(
-            {(uint64_t)start, len, genGpuNodeName(attributes.device)});
-        return entries;
+    if (cuda_device_present) {
+        cudaPointerAttributes attributes;
+        cudaError_t result = cudaPointerGetAttributes(&attributes, start);
+        if (result != cudaSuccess) {
+            LOG(ERROR) << "cudaPointerGetAttributes failed (Error code: "
+                       << result << " - " << cudaGetErrorString(result) << ")"
+                       << std::endl;
+            entries.push_back({(uint64_t)start, len, kWildcardLocation});
+            return entries;
+        }
+
+        if (attributes.type == cudaMemoryTypeDevice) {
+            entries.push_back(
+                {(uint64_t)start, len, genGpuNodeName(attributes.device)});
+            return entries;
+        }
     }
 #endif
 

--- a/mooncake-transfer-engine/src/memory_location.cpp
+++ b/mooncake-transfer-engine/src/memory_location.cpp
@@ -30,6 +30,25 @@ std::string genGpuNodeName(int node) {
     return kWildcardLocation;
 }
 
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
+    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
+    defined(USE_COREX) || defined(USE_SUNRISE)
+// A GPU-less host (e.g. an RDMA-only sidecar) has no device for
+// cudaPointerGetAttributes to classify, yet a CUDA-enabled build probes
+// every buffer, each call failing and logging a per-buffer ERROR that
+// buries real logs. Detect the absence once and skip the probe.
+static bool detectCudaDevicePresent() {
+    int device_count = 0;
+    if (cudaGetDeviceCount(&device_count) != cudaSuccess ||
+        device_count == 0) {
+        LOG(WARNING) << "No CUDA device detected; treating buffers as "
+                        "host memory";
+        return false;
+    }
+    return true;
+}
+#endif
+
 const std::vector<MemoryLocationEntry> getMemoryLocation(void *start,
                                                          size_t len,
                                                          bool only_first_page) {
@@ -38,20 +57,7 @@ const std::vector<MemoryLocationEntry> getMemoryLocation(void *start,
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX) || defined(USE_SUNRISE)
-    // A GPU-less host (e.g. an RDMA-only sidecar) has no device for
-    // cudaPointerGetAttributes to classify, yet a CUDA-enabled build probes
-    // every buffer, each call failing and logging a per-buffer ERROR that
-    // buries real logs. Detect the absence once and skip the probe.
-    static const bool cuda_device_present = [] {
-        int device_count = 0;
-        if (cudaGetDeviceCount(&device_count) != cudaSuccess ||
-            device_count == 0) {
-            LOG(WARNING) << "No CUDA device detected; treating buffers as "
-                            "host memory";
-            return false;
-        }
-        return true;
-    }();
+    static const bool cuda_device_present = detectCudaDevicePresent();
 
     if (cuda_device_present) {
         cudaPointerAttributes attributes;

--- a/mooncake-transfer-engine/src/memory_location.cpp
+++ b/mooncake-transfer-engine/src/memory_location.cpp
@@ -39,8 +39,7 @@ std::string genGpuNodeName(int node) {
 // buries real logs. Detect the absence once and skip the probe.
 static bool detectCudaDevicePresent() {
     int device_count = 0;
-    if (cudaGetDeviceCount(&device_count) != cudaSuccess ||
-        device_count == 0) {
+    if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
         LOG(WARNING) << "No CUDA device detected; treating buffers as "
                         "host memory";
         return false;


### PR DESCRIPTION
## Description

`getMemoryLocation()` probes `cudaPointerGetAttributes` for every registered buffer in a CUDA-enabled build. On a GPU-less host — e.g. the RDMA-only `mooncake_client` real-client sidecar in the deployment from #2937 — that call fails with "no CUDA-capable device is detected" and logs an `ERROR` for **every** buffer before falling back to the host/NUMA path. Registration still succeeds, but the per-buffer `ERROR` becomes the dominant line in the sidecar's stderr and buries the real problem (symptom 1 in #2937).

This detects device presence once via `cudaGetDeviceCount` and skips the probe entirely when no device exists, emitting a single `WARNING` instead. Hosts with a GPU keep the exact previous behavior. This addresses only symptom 1 (the diagnostic noise); the `client_expired` liveness behavior (symptoms 2–3) needs the full deployment and is out of scope here.

`cudaGetDeviceCount` is already aliased in every `gpu_vendor/*.h` shim (`musaGetDeviceCount`, `mcGetDeviceCount`, `tangGetDeviceCount`, the MLU inline, …), so the change compiles for all `USE_*` GPU backends, not just `USE_CUDA`.

Addresses #2937.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix
- [x] Performance improvement

## How Has This Been Tested?

I could not build the full stack on this host (Linux-only deps), so I verified the new control flow with a standalone harness that mirrors the patched branch with fake CUDA-alike calls and a call counter:

```
# GPU-less (the fix path): probe must be skipped, warning emitted once
MOCK_DEVICES=0 -> probe_calls=0 warn_calls=1 last=host
# GPU present (no regression): probe runs on every call as before
MOCK_DEVICES=2 -> probe_calls=5 warn_calls=0 last=host
```

So a GPU-less host no longer calls `cudaPointerGetAttributes` per buffer (0 calls, one `WARNING`) and still classifies buffers via the host/NUMA path, while a host with a device keeps probing every buffer unchanged. Portability was checked by grepping each `gpu_vendor` header for the `cudaGetDeviceCount` alias. Full compile/tests rely on CI.

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (standalone control-flow harness, above)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh` — clang-format was not available on this host; I hand-matched the repo `.clang-format` (Google, 80 col) and CI will verify
- [ ] I have run `pre-commit run --all-files` and all hooks pass — toolchain unavailable locally; relying on CI
- [ ] I have updated the documentation (if applicable) — not applicable
- [ ] I have added tests to prove my changes are effective — the CUDA-gated path has no repo unit test harness; verified with the standalone harness above
- [ ] For changes >500 LOC: I have filed an RFC issue — not applicable (30 LOC)

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

Claude Code helped analyze the issue, draft the change, and build the standalone verification harness above. The change is small and was reviewed line by line: the root cause matches @Icedcoco's analysis on #2937, `cudaGetDeviceCount` portability was checked against each `gpu_vendor` header, and the branch behavior was confirmed with the harness.