### PR TITLE
[TE] Add MNNVL support to Device API

### DIFF
--- a/mooncake-transfer-engine/include/transport/device/device_transport.h
+++ b/mooncake-transfer-engine/include/transport/device/device_transport.h
@@ -58,7 +58,7 @@ class P2pTransport {
     // Export the metadata peers need to access this rank's buffer.
     // Returns an opaque byte blob (serialised as int32_t array for Python
     // compat). For classic IPC this is a cudaIpcMemHandle-like payload; for
-    // fabric-backed paths this may instead carry the remote base VA directly.
+    // fabric-backed paths this carries a CUmemFabricHandle plus mapping size.
     virtual std::vector<int32_t> exportIpcHandle(void* ptr) = 0;
 
     // Import peer access metadata and populate the device-visible tables.

--- a/mooncake-transfer-engine/include/transport/device/device_transport.h
+++ b/mooncake-transfer-engine/include/transport/device/device_transport.h
@@ -55,14 +55,14 @@ class P2pTransport {
     // Free a buffer previously returned by allocateBuffer.
     virtual void freeBuffer(void* ptr) = 0;
 
-    // Export an IPC handle for the buffer allocated by this rank.
-    // Returns a byte blob (serialised as int32_t array for Python compat).
-    // Returns empty vector if IPC is not needed (e.g. fabric memory).
+    // Export the metadata peers need to access this rank's buffer.
+    // Returns an opaque byte blob (serialised as int32_t array for Python
+    // compat). For classic IPC this is a cudaIpcMemHandle-like payload; for
+    // fabric-backed paths this may instead carry the remote base VA directly.
     virtual std::vector<int32_t> exportIpcHandle(void* ptr) = 0;
 
-    // Import peer IPC handles and populate the device-visible tables.
-    // remote_handles[i] is the handle exported by rank i (may be empty for
-    // ranks that use fabric memory or are on a different node).
+    // Import peer access metadata and populate the device-visible tables.
+    // remote_handles[i] is the blob exported by rank i.
     // active_ranks_mask[i] == 1 means rank i is participating.
     // After this call, availableTablePtr() and peerPtrsTablePtr() are valid.
     virtual void importPeerHandles(

--- a/mooncake-transfer-engine/include/transport/device/device_transport.h
+++ b/mooncake-transfer-engine/include/transport/device/device_transport.h
@@ -65,6 +65,8 @@ class P2pTransport {
     // remote_handles[i] is the blob exported by rank i.
     // active_ranks_mask[i] == 1 means rank i is participating.
     // After this call, availableTablePtr() and peerPtrsTablePtr() are valid.
+    // The tables are transport-scoped: a later call replaces the previously
+    // imported peer mapping context.
     virtual void importPeerHandles(
         void* local_ptr, int rank, int num_ranks,
         const std::vector<std::vector<int32_t>>& remote_handles,

--- a/mooncake-transfer-engine/src/transport/device/p2p_device_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/device/p2p_device_transport.cpp
@@ -21,8 +21,8 @@
 
 #include <glog/logging.h>
 #include <algorithm>
-#include <array>
 #include <cctype>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <string>
@@ -53,19 +53,35 @@ bool supportFabricMem() {
     return true;
 }
 
-std::vector<int32_t> serializePointer(void* ptr) {
-    std::array<int32_t, 2> encoded{};
-    uint64_t addr = reinterpret_cast<uint64_t>(ptr);
-    encoded[0] = static_cast<int32_t>(addr & 0xffffffffULL);
-    encoded[1] = static_cast<int32_t>((addr >> 32) & 0xffffffffULL);
-    return std::vector<int32_t>(encoded.begin(), encoded.end());
+std::vector<int32_t> serializeFabricHandle(const CUmemFabricHandle& handle,
+                                           size_t bytes) {
+    constexpr size_t kPayloadBytes =
+        sizeof(CUmemFabricHandle) + sizeof(uint64_t);
+    constexpr size_t kNumInt32s =
+        (kPayloadBytes + sizeof(int32_t) - 1) / sizeof(int32_t);
+    std::vector<int32_t> result(kNumInt32s, 0);
+    auto* payload = reinterpret_cast<uint8_t*>(result.data());
+    uint64_t encoded_size = static_cast<uint64_t>(bytes);
+    memcpy(payload, &handle, sizeof(CUmemFabricHandle));
+    memcpy(payload + sizeof(CUmemFabricHandle), &encoded_size,
+           sizeof(encoded_size));
+    return result;
 }
 
-void* deserializePointer(const std::vector<int32_t>& encoded) {
-    if (encoded.size() < 2) return nullptr;
-    uint64_t lo = static_cast<uint32_t>(encoded[0]);
-    uint64_t hi = static_cast<uint32_t>(encoded[1]);
-    return reinterpret_cast<void*>((hi << 32) | lo);
+bool deserializeFabricHandle(const std::vector<int32_t>& encoded,
+                             CUmemFabricHandle* handle, size_t* bytes) {
+    constexpr size_t kPayloadBytes =
+        sizeof(CUmemFabricHandle) + sizeof(uint64_t);
+    constexpr size_t kNumInt32s =
+        (kPayloadBytes + sizeof(int32_t) - 1) / sizeof(int32_t);
+    if (encoded.size() < kNumInt32s) return false;
+    const auto* payload = reinterpret_cast<const uint8_t*>(encoded.data());
+    uint64_t encoded_size = 0;
+    memcpy(handle, payload, sizeof(CUmemFabricHandle));
+    memcpy(&encoded_size, payload + sizeof(CUmemFabricHandle),
+           sizeof(encoded_size));
+    *bytes = static_cast<size_t>(encoded_size);
+    return *bytes != 0;
 }
 #else
 bool supportFabricMem() { return false; }
@@ -218,9 +234,15 @@ class P2pDeviceTransportImpl : public P2pTransport {
         cudaMalloc(&peer_ptrs_dev_, num_ranks_ * sizeof(void*));
         for (int i = 0; i < num_ranks_; ++i) peer_ptrs_host_[i] = nullptr;
         cudaMemset(peer_ptrs_dev_, 0, num_ranks_ * sizeof(void*));
+#if defined(USE_CUDA)
+        fabric_peer_mappings_.resize(num_ranks_);
+#endif
     }
 
     ~P2pDeviceTransportImpl() override {
+#if defined(USE_CUDA)
+        cleanupFabricPeerMappings();
+#endif
         if (available_table_) cudaFree(available_table_);
         if (peer_ptrs_dev_) cudaFree(peer_ptrs_dev_);
         if (peer_ptrs_host_) {
@@ -277,6 +299,7 @@ class P2pDeviceTransportImpl : public P2pTransport {
                                           ~(granularity - 1));
             res = cuMemCreate(&fabric_mem_handle_, fabric_alloc_size_, &prop, 0);
             if (res != CUDA_SUCCESS) {
+                fabric_alloc_size_ = 0;
                 LOG(ERROR) << "[EP P2P] cuMemCreate(FABRIC) failed: " << res;
                 return nullptr;
             }
@@ -287,6 +310,7 @@ class P2pDeviceTransportImpl : public P2pTransport {
             if (res != CUDA_SUCCESS) {
                 cuMemRelease(fabric_mem_handle_);
                 fabric_mem_handle_ = {};
+                fabric_alloc_size_ = 0;
                 LOG(ERROR) << "[EP P2P] cuMemAddressReserve failed: " << res;
                 return nullptr;
             }
@@ -297,6 +321,7 @@ class P2pDeviceTransportImpl : public P2pTransport {
                 cuMemAddressFree(reserved, fabric_alloc_size_);
                 cuMemRelease(fabric_mem_handle_);
                 fabric_mem_handle_ = {};
+                fabric_alloc_size_ = 0;
                 LOG(ERROR) << "[EP P2P] cuMemMap failed: " << res;
                 return nullptr;
             }
@@ -316,6 +341,7 @@ class P2pDeviceTransportImpl : public P2pTransport {
                 cuMemAddressFree(reserved, fabric_alloc_size_);
                 cuMemRelease(fabric_mem_handle_);
                 fabric_mem_handle_ = {};
+                fabric_alloc_size_ = 0;
                 LOG(ERROR) << "[EP P2P] cuMemSetAccess failed: " << res;
                 return nullptr;
             }
@@ -351,6 +377,7 @@ class P2pDeviceTransportImpl : public P2pTransport {
 
     void freeBuffer(void* ptr) override {
 #if defined(USE_CUDA)
+        cleanupFabricPeerMappings();
         if (use_fabric_mem_) {
             CUdeviceptr dptr = reinterpret_cast<CUdeviceptr>(ptr);
             cuMemUnmap(dptr, fabric_alloc_size_);
@@ -367,9 +394,17 @@ class P2pDeviceTransportImpl : public P2pTransport {
     std::vector<int32_t> exportIpcHandle(void* ptr) override {
 #if defined(USE_CUDA)
         if (use_fabric_mem_) {
-            // Fabric allocations are directly addressable once access is
-            // granted; peers only need the remote base VA.
-            return serializePointer(ptr);
+            CUmemFabricHandle export_handle;
+            CUresult res = cuMemExportToShareableHandle(
+                &export_handle, fabric_mem_handle_, CU_MEM_HANDLE_TYPE_FABRIC,
+                0);
+            if (res != CUDA_SUCCESS) {
+                LOG(ERROR)
+                    << "[EP P2P] cuMemExportToShareableHandle(FABRIC) failed: "
+                    << res;
+                return {};
+            }
+            return serializeFabricHandle(export_handle, fabric_alloc_size_);
         }
 #endif
 #ifdef USE_MACA
@@ -447,6 +482,7 @@ class P2pDeviceTransportImpl : public P2pTransport {
 
 #if defined(USE_CUDA)
         if (use_fabric_mem_) {
+            cleanupFabricPeerMappings();
             all_peers_accessible_ = true;
             for (int dst = 0; dst < num_ranks_; ++dst) {
                 if (active_ranks_mask[dst] == 0) continue;
@@ -455,11 +491,77 @@ class P2pDeviceTransportImpl : public P2pTransport {
                     all_peers_accessible_ = false;
                     break;
                 }
-                void* peer_ptr = deserializePointer(remote_handles[dst]);
-                if (peer_ptr == nullptr) {
+                CUmemFabricHandle export_handle;
+                size_t mapped_size = 0;
+                if (!deserializeFabricHandle(remote_handles[dst], &export_handle,
+                                             &mapped_size)) {
                     all_peers_accessible_ = false;
                     break;
                 }
+
+                CUmemGenericAllocationHandle handle;
+                CUresult res = cuMemImportFromShareableHandle(
+                    &handle, &export_handle, CU_MEM_HANDLE_TYPE_FABRIC);
+                if (res != CUDA_SUCCESS) {
+                    LOG(ERROR)
+                        << "[EP P2P] cuMemImportFromShareableHandle(FABRIC) "
+                           "failed for rank "
+                        << dst << ": " << res;
+                    all_peers_accessible_ = false;
+                    break;
+                }
+
+                CUdeviceptr peer_reserved = 0;
+                res = cuMemAddressReserve(&peer_reserved, mapped_size, 0, 0, 0);
+                if (res != CUDA_SUCCESS) {
+                    cuMemRelease(handle);
+                    LOG(ERROR)
+                        << "[EP P2P] cuMemAddressReserve peer fabric mapping "
+                           "failed for rank "
+                        << dst << ": " << res;
+                    all_peers_accessible_ = false;
+                    break;
+                }
+                void* peer_ptr = reinterpret_cast<void*>(peer_reserved);
+
+                res = cuMemMap(reinterpret_cast<CUdeviceptr>(peer_ptr),
+                               mapped_size, 0, handle, 0);
+                if (res != CUDA_SUCCESS) {
+                    cuMemAddressFree(reinterpret_cast<CUdeviceptr>(peer_ptr),
+                                     mapped_size);
+                    cuMemRelease(handle);
+                    LOG(ERROR) << "[EP P2P] cuMemMap peer fabric mapping "
+                                  "failed for rank "
+                               << dst << ": " << res;
+                    all_peers_accessible_ = false;
+                    break;
+                }
+
+                int peer_device_count = 0;
+                cudaGetDeviceCount(&peer_device_count);
+                std::vector<CUmemAccessDesc> access(peer_device_count);
+                for (int i = 0; i < peer_device_count; ++i) {
+                    access[i].location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+                    access[i].location.id = i;
+                    access[i].flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+                }
+                res = cuMemSetAccess(reinterpret_cast<CUdeviceptr>(peer_ptr),
+                                     mapped_size, access.data(),
+                                     peer_device_count);
+                if (res != CUDA_SUCCESS) {
+                    cuMemUnmap(reinterpret_cast<CUdeviceptr>(peer_ptr),
+                               mapped_size);
+                    cuMemAddressFree(reinterpret_cast<CUdeviceptr>(peer_ptr),
+                                     mapped_size);
+                    cuMemRelease(handle);
+                    LOG(ERROR) << "[EP P2P] cuMemSetAccess peer fabric mapping "
+                                  "failed for rank "
+                               << dst << ": " << res;
+                    all_peers_accessible_ = false;
+                    break;
+                }
+
+                fabric_peer_mappings_[dst] = {peer_ptr, mapped_size, handle};
                 available[dst] = 1;
                 peer_ptrs_host_[dst] = peer_ptr;
             }
@@ -677,6 +779,30 @@ class P2pDeviceTransportImpl : public P2pTransport {
     }
 
    private:
+#if defined(USE_CUDA)
+    struct FabricPeerMapping {
+        void* ptr = nullptr;
+        size_t size = 0;
+        CUmemGenericAllocationHandle handle{};
+    };
+
+    void cleanupFabricPeerMappings() {
+        if (!use_fabric_mem_) return;
+        for (int i = 0; i < static_cast<int>(fabric_peer_mappings_.size()); ++i) {
+            auto& mapping = fabric_peer_mappings_[i];
+            if (mapping.ptr == nullptr) continue;
+            cuMemUnmap(reinterpret_cast<CUdeviceptr>(mapping.ptr), mapping.size);
+            cuMemAddressFree(reinterpret_cast<CUdeviceptr>(mapping.ptr),
+                             mapping.size);
+            cuMemRelease(mapping.handle);
+            mapping = {};
+            if (peer_ptrs_host_ && peer_ptrs_host_[i] != local_ptr_) {
+                peer_ptrs_host_[i] = nullptr;
+            }
+        }
+    }
+#endif
+
     int num_ranks_;
     bool use_fabric_mem_ = false;
     void* local_ptr_ = nullptr;
@@ -686,6 +812,9 @@ class P2pDeviceTransportImpl : public P2pTransport {
     bool all_peers_accessible_ = false;
     CUmemGenericAllocationHandle fabric_mem_handle_{};
     size_t fabric_alloc_size_ = 0;
+#if defined(USE_CUDA)
+    std::vector<FabricPeerMapping> fabric_peer_mappings_;
+#endif
 };
 
 std::unique_ptr<P2pTransport> createP2pDeviceTransport(int num_ranks) {

--- a/mooncake-transfer-engine/src/transport/device/p2p_device_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/device/p2p_device_transport.cpp
@@ -26,6 +26,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "cuda_alike.h"
@@ -88,6 +89,12 @@ bool deserializeFabricHandle(const std::vector<int32_t>& encoded,
     *bytes = static_cast<size_t>(encoded_size);
     return *bytes != 0;
 }
+
+struct FabricAllocation {
+    CUdeviceptr ptr = 0;
+    size_t size = 0;
+    CUmemGenericAllocationHandle handle{};
+};
 #else
 bool supportFabricMem() { return false; }
 #endif
@@ -247,6 +254,7 @@ class P2pDeviceTransportImpl : public P2pTransport {
     ~P2pDeviceTransportImpl() override {
 #if defined(USE_CUDA)
         cleanupFabricPeerMappings();
+        cleanupFabricAllocations();
 #endif
         if (available_table_) cudaFree(available_table_);
         if (peer_ptrs_dev_) cudaFree(peer_ptrs_dev_);
@@ -300,34 +308,29 @@ class P2pDeviceTransportImpl : public P2pTransport {
                 return nullptr;
             }
 
-            fabric_alloc_size_ = std::max(
+            size_t fabric_alloc_size = std::max(
                 granularity, (bytes + granularity - 1) & ~(granularity - 1));
-            res =
-                cuMemCreate(&fabric_mem_handle_, fabric_alloc_size_, &prop, 0);
+            CUmemGenericAllocationHandle fabric_mem_handle{};
+            res = cuMemCreate(&fabric_mem_handle, fabric_alloc_size, &prop, 0);
             if (res != CUDA_SUCCESS) {
-                fabric_alloc_size_ = 0;
                 LOG(ERROR) << "[EP P2P] cuMemCreate(FABRIC) failed: " << res;
                 return nullptr;
             }
 
             CUdeviceptr reserved = 0;
-            res = cuMemAddressReserve(&reserved, fabric_alloc_size_,
-                                      granularity, 0, 0);
+            res = cuMemAddressReserve(&reserved, fabric_alloc_size, granularity,
+                                      0, 0);
             if (res != CUDA_SUCCESS) {
-                cuMemRelease(fabric_mem_handle_);
-                fabric_mem_handle_ = {};
-                fabric_alloc_size_ = 0;
+                cuMemRelease(fabric_mem_handle);
                 LOG(ERROR) << "[EP P2P] cuMemAddressReserve failed: " << res;
                 return nullptr;
             }
 
-            res = cuMemMap(reserved, fabric_alloc_size_, 0, fabric_mem_handle_,
-                           0);
+            res =
+                cuMemMap(reserved, fabric_alloc_size, 0, fabric_mem_handle, 0);
             if (res != CUDA_SUCCESS) {
-                cuMemAddressFree(reserved, fabric_alloc_size_);
-                cuMemRelease(fabric_mem_handle_);
-                fabric_mem_handle_ = {};
-                fabric_alloc_size_ = 0;
+                cuMemAddressFree(reserved, fabric_alloc_size);
+                cuMemRelease(fabric_mem_handle);
                 LOG(ERROR) << "[EP P2P] cuMemMap failed: " << res;
                 return nullptr;
             }
@@ -340,21 +343,22 @@ class P2pDeviceTransportImpl : public P2pTransport {
                 access[i].location.id = i;
                 access[i].flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
             }
-            res = cuMemSetAccess(reserved, fabric_alloc_size_, access.data(),
+            res = cuMemSetAccess(reserved, fabric_alloc_size, access.data(),
                                  device_count);
             if (res != CUDA_SUCCESS) {
-                cuMemUnmap(reserved, fabric_alloc_size_);
-                cuMemAddressFree(reserved, fabric_alloc_size_);
-                cuMemRelease(fabric_mem_handle_);
-                fabric_mem_handle_ = {};
-                fabric_alloc_size_ = 0;
+                cuMemUnmap(reserved, fabric_alloc_size);
+                cuMemAddressFree(reserved, fabric_alloc_size);
+                cuMemRelease(fabric_mem_handle);
                 LOG(ERROR) << "[EP P2P] cuMemSetAccess failed: " << res;
                 return nullptr;
             }
 
             ptr = reinterpret_cast<void*>(reserved);
+            fabric_allocations_.emplace(
+                ptr, FabricAllocation{reserved, fabric_alloc_size,
+                                      fabric_mem_handle});
             LOG(INFO) << "[EP P2P] allocated fabric buffer bytes=" << bytes
-                      << " mapped_bytes=" << fabric_alloc_size_;
+                      << " mapped_bytes=" << fabric_alloc_size;
             return ptr;
         }
 #endif
@@ -383,15 +387,22 @@ class P2pDeviceTransportImpl : public P2pTransport {
 
     void freeBuffer(void* ptr) override {
 #if defined(USE_CUDA)
-        cleanupFabricPeerMappings();
         if (ptr == nullptr) return;
         if (use_fabric_mem_) {
-            CUdeviceptr dptr = reinterpret_cast<CUdeviceptr>(ptr);
-            cuMemUnmap(dptr, fabric_alloc_size_);
-            cuMemAddressFree(dptr, fabric_alloc_size_);
-            cuMemRelease(fabric_mem_handle_);
-            fabric_mem_handle_ = {};
-            fabric_alloc_size_ = 0;
+            auto it = fabric_allocations_.find(ptr);
+            if (it == fabric_allocations_.end()) {
+                LOG(ERROR) << "[EP P2P] unknown fabric buffer=" << ptr;
+                return;
+            }
+            if (ptr == local_ptr_) {
+                cleanupFabricPeerMappings();
+                local_ptr_ = nullptr;
+            }
+            FabricAllocation allocation = it->second;
+            fabric_allocations_.erase(it);
+            cuMemUnmap(allocation.ptr, allocation.size);
+            cuMemAddressFree(allocation.ptr, allocation.size);
+            cuMemRelease(allocation.handle);
             return;
         }
 #endif
@@ -401,9 +412,14 @@ class P2pDeviceTransportImpl : public P2pTransport {
     std::vector<int32_t> exportIpcHandle(void* ptr) override {
 #if defined(USE_CUDA)
         if (use_fabric_mem_) {
+            auto it = fabric_allocations_.find(ptr);
+            if (it == fabric_allocations_.end()) {
+                LOG(ERROR) << "[EP P2P] unknown fabric buffer=" << ptr;
+                return {};
+            }
             CUmemFabricHandle export_handle;
             CUresult res =
-                cuMemExportToShareableHandle(&export_handle, fabric_mem_handle_,
+                cuMemExportToShareableHandle(&export_handle, it->second.handle,
                                              CU_MEM_HANDLE_TYPE_FABRIC, 0);
             if (res != CUDA_SUCCESS) {
                 LOG(ERROR)
@@ -411,7 +427,7 @@ class P2pDeviceTransportImpl : public P2pTransport {
                     << res;
                 return {};
             }
-            return serializeFabricHandle(export_handle, fabric_alloc_size_);
+            return serializeFabricHandle(export_handle, it->second.size);
         }
 #endif
 #ifdef USE_MACA
@@ -802,6 +818,16 @@ class P2pDeviceTransportImpl : public P2pTransport {
             }
         }
     }
+
+    void cleanupFabricAllocations() {
+        for (const auto& entry : fabric_allocations_) {
+            const auto& allocation = entry.second;
+            cuMemUnmap(allocation.ptr, allocation.size);
+            cuMemAddressFree(allocation.ptr, allocation.size);
+            cuMemRelease(allocation.handle);
+        }
+        fabric_allocations_.clear();
+    }
 #endif
 
     int num_ranks_;
@@ -811,10 +837,9 @@ class P2pDeviceTransportImpl : public P2pTransport {
     void** peer_ptrs_host_ = nullptr;
     void** peer_ptrs_dev_ = nullptr;
     bool all_peers_accessible_ = false;
-    CUmemGenericAllocationHandle fabric_mem_handle_{};
-    size_t fabric_alloc_size_ = 0;
 #if defined(USE_CUDA)
     std::vector<FabricPeerMapping> fabric_peer_mappings_;
+    std::unordered_map<void*, FabricAllocation> fabric_allocations_;
 #endif
 };
 

--- a/mooncake-transfer-engine/src/transport/device/p2p_device_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/device/p2p_device_transport.cpp
@@ -21,15 +21,57 @@
 
 #include <glog/logging.h>
 #include <algorithm>
+#include <array>
 #include <cctype>
 #include <cstdlib>
 #include <cstring>
 #include <string>
+#include <vector>
 
 #include "cuda_alike.h"
 
 namespace mooncake {
 namespace device {
+
+namespace {
+
+#if defined(USE_CUDA)
+bool supportFabricMem() {
+    if (std::getenv("MC_USE_NVLINK_IPC") != nullptr) return false;
+
+    int num_devices = 0;
+    cudaError_t err = cudaGetDeviceCount(&num_devices);
+    if (err != cudaSuccess || num_devices == 0) return false;
+
+    for (int device_id = 0; device_id < num_devices; ++device_id) {
+        int supported = 0;
+        cuDeviceGetAttribute(&supported,
+                             CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED,
+                             device_id);
+        if (!supported) return false;
+    }
+    return true;
+}
+
+std::vector<int32_t> serializePointer(void* ptr) {
+    std::array<int32_t, 2> encoded{};
+    uint64_t addr = reinterpret_cast<uint64_t>(ptr);
+    encoded[0] = static_cast<int32_t>(addr & 0xffffffffULL);
+    encoded[1] = static_cast<int32_t>((addr >> 32) & 0xffffffffULL);
+    return std::vector<int32_t>(encoded.begin(), encoded.end());
+}
+
+void* deserializePointer(const std::vector<int32_t>& encoded) {
+    if (encoded.size() < 2) return nullptr;
+    uint64_t lo = static_cast<uint32_t>(encoded[0]);
+    uint64_t hi = static_cast<uint32_t>(encoded[1]);
+    return reinterpret_cast<void*>((hi << 32) | lo);
+}
+#else
+bool supportFabricMem() { return false; }
+#endif
+
+}  // namespace
 
 #ifdef USE_MACA
 namespace {
@@ -168,7 +210,8 @@ bool macaP2pPairAllowed(int src_physical, int dst_physical) {
 
 class P2pDeviceTransportImpl : public P2pTransport {
    public:
-    explicit P2pDeviceTransportImpl(int num_ranks) : num_ranks_(num_ranks) {
+    explicit P2pDeviceTransportImpl(int num_ranks)
+        : num_ranks_(num_ranks), use_fabric_mem_(supportFabricMem()) {
         cudaMalloc(&available_table_, num_ranks_ * sizeof(int32_t));
         cudaMemset(available_table_, 0, num_ranks_ * sizeof(int32_t));
         cudaMallocHost(&peer_ptrs_host_, num_ranks_ * sizeof(void*));
@@ -181,7 +224,7 @@ class P2pDeviceTransportImpl : public P2pTransport {
         if (available_table_) cudaFree(available_table_);
         if (peer_ptrs_dev_) cudaFree(peer_ptrs_dev_);
         if (peer_ptrs_host_) {
-            for (int i = 0; i < num_ranks_; ++i) {
+            for (int i = 0; i < num_ranks_ && !use_fabric_mem_; ++i) {
                 if (peer_ptrs_host_[i] && peer_ptrs_host_[i] != local_ptr_) {
                     cudaIpcCloseMemHandle(peer_ptrs_host_[i]);
                 }
@@ -192,6 +235,97 @@ class P2pDeviceTransportImpl : public P2pTransport {
 
     void* allocateBuffer(size_t bytes) override {
         void* ptr = nullptr;
+#if defined(USE_CUDA)
+        if (use_fabric_mem_) {
+            int device_id = 0;
+            if (cudaGetDevice(&device_id) != cudaSuccess) {
+                LOG(ERROR) << "[EP P2P] cudaGetDevice failed before fabric alloc";
+                return nullptr;
+            }
+
+            CUdevice cu_dev;
+            CUresult res = cuDeviceGet(&cu_dev, device_id);
+            if (res != CUDA_SUCCESS) {
+                LOG(ERROR) << "[EP P2P] cuDeviceGet failed: " << res;
+                return nullptr;
+            }
+
+            CUmemAllocationProp prop = {};
+            prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+            prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+            prop.location.id = cu_dev;
+            prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_FABRIC;
+
+            int rdma_capable = 0;
+            cuDeviceGetAttribute(
+                &rdma_capable,
+                CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_WITH_CUDA_VMM_SUPPORTED,
+                cu_dev);
+            if (rdma_capable) prop.allocFlags.gpuDirectRDMACapable = 1;
+
+            size_t granularity = 0;
+            res = cuMemGetAllocationGranularity(
+                &granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM);
+            if (res != CUDA_SUCCESS) {
+                LOG(ERROR) << "[EP P2P] cuMemGetAllocationGranularity failed: "
+                           << res;
+                return nullptr;
+            }
+
+            fabric_alloc_size_ =
+                std::max(granularity, (bytes + granularity - 1) &
+                                          ~(granularity - 1));
+            res = cuMemCreate(&fabric_mem_handle_, fabric_alloc_size_, &prop, 0);
+            if (res != CUDA_SUCCESS) {
+                LOG(ERROR) << "[EP P2P] cuMemCreate(FABRIC) failed: " << res;
+                return nullptr;
+            }
+
+            CUdeviceptr reserved = 0;
+            res = cuMemAddressReserve(&reserved, fabric_alloc_size_, granularity,
+                                      0, 0);
+            if (res != CUDA_SUCCESS) {
+                cuMemRelease(fabric_mem_handle_);
+                fabric_mem_handle_ = {};
+                LOG(ERROR) << "[EP P2P] cuMemAddressReserve failed: " << res;
+                return nullptr;
+            }
+
+            res = cuMemMap(reserved, fabric_alloc_size_, 0, fabric_mem_handle_,
+                           0);
+            if (res != CUDA_SUCCESS) {
+                cuMemAddressFree(reserved, fabric_alloc_size_);
+                cuMemRelease(fabric_mem_handle_);
+                fabric_mem_handle_ = {};
+                LOG(ERROR) << "[EP P2P] cuMemMap failed: " << res;
+                return nullptr;
+            }
+
+            int device_count = 0;
+            cudaGetDeviceCount(&device_count);
+            std::vector<CUmemAccessDesc> access(device_count);
+            for (int i = 0; i < device_count; ++i) {
+                access[i].location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+                access[i].location.id = i;
+                access[i].flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+            }
+            res = cuMemSetAccess(reserved, fabric_alloc_size_, access.data(),
+                                 device_count);
+            if (res != CUDA_SUCCESS) {
+                cuMemUnmap(reserved, fabric_alloc_size_);
+                cuMemAddressFree(reserved, fabric_alloc_size_);
+                cuMemRelease(fabric_mem_handle_);
+                fabric_mem_handle_ = {};
+                LOG(ERROR) << "[EP P2P] cuMemSetAccess failed: " << res;
+                return nullptr;
+            }
+
+            ptr = reinterpret_cast<void*>(reserved);
+            LOG(INFO) << "[EP P2P] allocated fabric buffer bytes=" << bytes
+                      << " mapped_bytes=" << fabric_alloc_size_;
+            return ptr;
+        }
+#endif
 #ifdef USE_MACA
         int alloc_flag = macaAllocFlagFromEnv();
         cudaError_t err = alloc_flag == mcDeviceMallocDefault
@@ -215,9 +349,29 @@ class P2pDeviceTransportImpl : public P2pTransport {
         return ptr;
     }
 
-    void freeBuffer(void* ptr) override { cudaFree(ptr); }
+    void freeBuffer(void* ptr) override {
+#if defined(USE_CUDA)
+        if (use_fabric_mem_) {
+            CUdeviceptr dptr = reinterpret_cast<CUdeviceptr>(ptr);
+            cuMemUnmap(dptr, fabric_alloc_size_);
+            cuMemAddressFree(dptr, fabric_alloc_size_);
+            cuMemRelease(fabric_mem_handle_);
+            fabric_mem_handle_ = {};
+            fabric_alloc_size_ = 0;
+            return;
+        }
+#endif
+        cudaFree(ptr);
+    }
 
     std::vector<int32_t> exportIpcHandle(void* ptr) override {
+#if defined(USE_CUDA)
+        if (use_fabric_mem_) {
+            // Fabric allocations are directly addressable once access is
+            // granted; peers only need the remote base VA.
+            return serializePointer(ptr);
+        }
+#endif
 #ifdef USE_MACA
         if (parseBoolEnv("MOONCAKE_EP_MACA_DISABLE_IPC")) {
             LOG(INFO) << "[EP P2P] MACA IPC handle export disabled by "
@@ -290,6 +444,32 @@ class P2pDeviceTransportImpl : public P2pTransport {
         std::vector<int32_t> available(num_ranks_, 0);
         available[rank] = 1;
         peer_ptrs_host_[rank] = local_ptr;
+
+#if defined(USE_CUDA)
+        if (use_fabric_mem_) {
+            all_peers_accessible_ = true;
+            for (int dst = 0; dst < num_ranks_; ++dst) {
+                if (active_ranks_mask[dst] == 0) continue;
+                if (dst == rank) continue;
+                if (dst >= static_cast<int>(remote_handles.size())) {
+                    all_peers_accessible_ = false;
+                    break;
+                }
+                void* peer_ptr = deserializePointer(remote_handles[dst]);
+                if (peer_ptr == nullptr) {
+                    all_peers_accessible_ = false;
+                    break;
+                }
+                available[dst] = 1;
+                peer_ptrs_host_[dst] = peer_ptr;
+            }
+            cudaMemcpy(available_table_, available.data(),
+                       num_ranks_ * sizeof(int32_t), cudaMemcpyHostToDevice);
+            cudaMemcpy(peer_ptrs_dev_, peer_ptrs_host_,
+                       num_ranks_ * sizeof(void*), cudaMemcpyHostToDevice);
+            return;
+        }
+#endif
 
         int node_id = rank / device_count;
         int group_start = node_id * device_count;
@@ -498,11 +678,14 @@ class P2pDeviceTransportImpl : public P2pTransport {
 
    private:
     int num_ranks_;
+    bool use_fabric_mem_ = false;
     void* local_ptr_ = nullptr;
     int32_t* available_table_ = nullptr;
     void** peer_ptrs_host_ = nullptr;
     void** peer_ptrs_dev_ = nullptr;
     bool all_peers_accessible_ = false;
+    CUmemGenericAllocationHandle fabric_mem_handle_{};
+    size_t fabric_alloc_size_ = 0;
 };
 
 std::unique_ptr<P2pTransport> createP2pDeviceTransport(int num_ranks) {

--- a/mooncake-transfer-engine/src/transport/device/p2p_device_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/device/p2p_device_transport.cpp
@@ -37,7 +37,9 @@ namespace {
 
 #if defined(USE_CUDA)
 bool supportFabricMem() {
-    if (std::getenv("MC_USE_NVLINK_IPC") != nullptr) return false;
+    const char* nvlink_ipc = std::getenv("MC_USE_NVLINK_IPC");
+    if (nvlink_ipc == nullptr || std::strcmp(nvlink_ipc, "0") != 0)
+        return false;
 
     int num_devices = 0;
     cudaError_t err = cudaGetDeviceCount(&num_devices);
@@ -261,7 +263,8 @@ class P2pDeviceTransportImpl : public P2pTransport {
         if (use_fabric_mem_) {
             int device_id = 0;
             if (cudaGetDevice(&device_id) != cudaSuccess) {
-                LOG(ERROR) << "[EP P2P] cudaGetDevice failed before fabric alloc";
+                LOG(ERROR)
+                    << "[EP P2P] cudaGetDevice failed before fabric alloc";
                 return nullptr;
             }
 
@@ -294,10 +297,10 @@ class P2pDeviceTransportImpl : public P2pTransport {
                 return nullptr;
             }
 
-            fabric_alloc_size_ =
-                std::max(granularity, (bytes + granularity - 1) &
-                                          ~(granularity - 1));
-            res = cuMemCreate(&fabric_mem_handle_, fabric_alloc_size_, &prop, 0);
+            fabric_alloc_size_ = std::max(
+                granularity, (bytes + granularity - 1) & ~(granularity - 1));
+            res =
+                cuMemCreate(&fabric_mem_handle_, fabric_alloc_size_, &prop, 0);
             if (res != CUDA_SUCCESS) {
                 fabric_alloc_size_ = 0;
                 LOG(ERROR) << "[EP P2P] cuMemCreate(FABRIC) failed: " << res;
@@ -305,8 +308,8 @@ class P2pDeviceTransportImpl : public P2pTransport {
             }
 
             CUdeviceptr reserved = 0;
-            res = cuMemAddressReserve(&reserved, fabric_alloc_size_, granularity,
-                                      0, 0);
+            res = cuMemAddressReserve(&reserved, fabric_alloc_size_,
+                                      granularity, 0, 0);
             if (res != CUDA_SUCCESS) {
                 cuMemRelease(fabric_mem_handle_);
                 fabric_mem_handle_ = {};
@@ -395,9 +398,9 @@ class P2pDeviceTransportImpl : public P2pTransport {
 #if defined(USE_CUDA)
         if (use_fabric_mem_) {
             CUmemFabricHandle export_handle;
-            CUresult res = cuMemExportToShareableHandle(
-                &export_handle, fabric_mem_handle_, CU_MEM_HANDLE_TYPE_FABRIC,
-                0);
+            CUresult res =
+                cuMemExportToShareableHandle(&export_handle, fabric_mem_handle_,
+                                             CU_MEM_HANDLE_TYPE_FABRIC, 0);
             if (res != CUDA_SUCCESS) {
                 LOG(ERROR)
                     << "[EP P2P] cuMemExportToShareableHandle(FABRIC) failed: "
@@ -493,8 +496,8 @@ class P2pDeviceTransportImpl : public P2pTransport {
                 }
                 CUmemFabricHandle export_handle;
                 size_t mapped_size = 0;
-                if (!deserializeFabricHandle(remote_handles[dst], &export_handle,
-                                             &mapped_size)) {
+                if (!deserializeFabricHandle(remote_handles[dst],
+                                             &export_handle, &mapped_size)) {
                     all_peers_accessible_ = false;
                     break;
                 }
@@ -788,10 +791,12 @@ class P2pDeviceTransportImpl : public P2pTransport {
 
     void cleanupFabricPeerMappings() {
         if (!use_fabric_mem_) return;
-        for (int i = 0; i < static_cast<int>(fabric_peer_mappings_.size()); ++i) {
+        for (int i = 0; i < static_cast<int>(fabric_peer_mappings_.size());
+             ++i) {
             auto& mapping = fabric_peer_mappings_[i];
             if (mapping.ptr == nullptr) continue;
-            cuMemUnmap(reinterpret_cast<CUdeviceptr>(mapping.ptr), mapping.size);
+            cuMemUnmap(reinterpret_cast<CUdeviceptr>(mapping.ptr),
+                       mapping.size);
             cuMemAddressFree(reinterpret_cast<CUdeviceptr>(mapping.ptr),
                              mapping.size);
             cuMemRelease(mapping.handle);

--- a/mooncake-transfer-engine/src/transport/device/p2p_device_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/device/p2p_device_transport.cpp
@@ -46,11 +46,14 @@ bool supportFabricMem() {
     if (err != cudaSuccess || num_devices == 0) return false;
 
     for (int device_id = 0; device_id < num_devices; ++device_id) {
+        CUdevice cu_device;
+        if (cuDeviceGet(&cu_device, device_id) != CUDA_SUCCESS) return false;
         int supported = 0;
-        cuDeviceGetAttribute(&supported,
-                             CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED,
-                             device_id);
-        if (!supported) return false;
+        if (cuDeviceGetAttribute(
+                &supported, CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED,
+                cu_device) != CUDA_SUCCESS ||
+            !supported)
+            return false;
     }
     return true;
 }
@@ -381,6 +384,7 @@ class P2pDeviceTransportImpl : public P2pTransport {
     void freeBuffer(void* ptr) override {
 #if defined(USE_CUDA)
         cleanupFabricPeerMappings();
+        if (ptr == nullptr) return;
         if (use_fabric_mem_) {
             CUdeviceptr dptr = reinterpret_cast<CUdeviceptr>(ptr);
             cuMemUnmap(dptr, fabric_alloc_size_);
@@ -487,6 +491,12 @@ class P2pDeviceTransportImpl : public P2pTransport {
         if (use_fabric_mem_) {
             cleanupFabricPeerMappings();
             all_peers_accessible_ = true;
+            std::vector<CUmemAccessDesc> access(device_count);
+            for (int i = 0; i < device_count; ++i) {
+                access[i].location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+                access[i].location.id = i;
+                access[i].flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+            }
             for (int dst = 0; dst < num_ranks_; ++dst) {
                 if (active_ranks_mask[dst] == 0) continue;
                 if (dst == rank) continue;
@@ -525,13 +535,9 @@ class P2pDeviceTransportImpl : public P2pTransport {
                     all_peers_accessible_ = false;
                     break;
                 }
-                void* peer_ptr = reinterpret_cast<void*>(peer_reserved);
-
-                res = cuMemMap(reinterpret_cast<CUdeviceptr>(peer_ptr),
-                               mapped_size, 0, handle, 0);
+                res = cuMemMap(peer_reserved, mapped_size, 0, handle, 0);
                 if (res != CUDA_SUCCESS) {
-                    cuMemAddressFree(reinterpret_cast<CUdeviceptr>(peer_ptr),
-                                     mapped_size);
+                    cuMemAddressFree(peer_reserved, mapped_size);
                     cuMemRelease(handle);
                     LOG(ERROR) << "[EP P2P] cuMemMap peer fabric mapping "
                                   "failed for rank "
@@ -540,22 +546,11 @@ class P2pDeviceTransportImpl : public P2pTransport {
                     break;
                 }
 
-                int peer_device_count = 0;
-                cudaGetDeviceCount(&peer_device_count);
-                std::vector<CUmemAccessDesc> access(peer_device_count);
-                for (int i = 0; i < peer_device_count; ++i) {
-                    access[i].location.type = CU_MEM_LOCATION_TYPE_DEVICE;
-                    access[i].location.id = i;
-                    access[i].flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
-                }
-                res = cuMemSetAccess(reinterpret_cast<CUdeviceptr>(peer_ptr),
-                                     mapped_size, access.data(),
-                                     peer_device_count);
+                res = cuMemSetAccess(peer_reserved, mapped_size, access.data(),
+                                     device_count);
                 if (res != CUDA_SUCCESS) {
-                    cuMemUnmap(reinterpret_cast<CUdeviceptr>(peer_ptr),
-                               mapped_size);
-                    cuMemAddressFree(reinterpret_cast<CUdeviceptr>(peer_ptr),
-                                     mapped_size);
+                    cuMemUnmap(peer_reserved, mapped_size);
+                    cuMemAddressFree(peer_reserved, mapped_size);
                     cuMemRelease(handle);
                     LOG(ERROR) << "[EP P2P] cuMemSetAccess peer fabric mapping "
                                   "failed for rank "
@@ -564,6 +559,7 @@ class P2pDeviceTransportImpl : public P2pTransport {
                     break;
                 }
 
+                void* peer_ptr = reinterpret_cast<void*>(peer_reserved);
                 fabric_peer_mappings_[dst] = {peer_ptr, mapped_size, handle};
                 available[dst] = 1;
                 peer_ptrs_host_[dst] = peer_ptr;


### PR DESCRIPTION
## Description

Add CUDA Fabric Memory support to the Transfer Engine Device API P2P transport
for MNNVL deployments.

The transport allocates Fabric-capable VMM memory, exchanges a
`CUmemFabricHandle` and mapped allocation size, then imports and maps each
remote allocation into the receiving process. This publishes process-local peer
VAs to EP kernels instead of serializing remote-process VAs.

The change also restores the established `MC_USE_NVLINK_IPC` contract:

- unset or `MC_USE_NVLINK_IPC=1`: use CUDA IPC
- `MC_USE_NVLINK_IPC=0`: explicitly request Fabric Memory

Fabric allocation errors remain explicit. The transport does not silently
fall back to CUDA IPC or `cudaMalloc` after Fabric Memory has been requested.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Validated from source on reserved `h20/qjh003` with CUDA 13.0 and torch
`2.9.1+cu130`. The branch built `device_transport_example`, `mooncake_ep_ext`,
and `mooncake_pg_ext`; the extensions were then loaded by the source wheel.

**Test commands:**
```bash
# Common EP environment
export CUDA_VISIBLE_DEVICES=0,1
export MC_TE_FILTERS=mlx5_1
export PYTHONPATH=/workspace/task/Mooncake/mooncake-wheel
export LD_LIBRARY_PATH=/workspace/task/Mooncake/build-mnnvl-regression/mooncake-common:/workspace/task/Mooncake/mooncake-wheel/mooncake:${LD_LIBRARY_PATH:-}

# Two-rank Device API P2P probe
./run_h20_mnnvl_ipc_regression.sh unset
./run_h20_mnnvl_ipc_regression.sh 1
./run_h20_mnnvl_ipc_regression.sh 0

# Two-rank EP regression
env -u MC_USE_NVLINK_IPC python3 mooncake-wheel/tests/test_mooncake_ep.py
MC_USE_NVLINK_IPC=1 python3 mooncake-wheel/tests/test_mooncake_ep.py
MC_USE_NVLINK_IPC=0 python3 mooncake-wheel/tests/test_mooncake_ep.py
```

**Test results:**
- [ ] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

- unset and `MC_USE_NVLINK_IPC=1`: Device API probe passed on both ranks; EP
  test passed with CUDA IPC peer mappings and `~101 us` dispatch + combine.
- `MC_USE_NVLINK_IPC=0`: both Device API and EP tests reached
  `cuMemCreate(FABRIC)` and failed with CUDA error 800 on H20. This is the
  expected negative control because this H20 environment lacks the Fabric
  Memory permission/runtime required for successful allocation.
- Successful cross-node Fabric allocation, import/map, and kernel access need
  a GB200/B300 MNNVL environment with the required Fabric Memory permission.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

`./scripts/code_format.sh` and `pre-commit run --all-files` were not run
because they can modify unrelated files in the shared worktree. Targeted
checks passed: `git diff --check`, `clang-format-20 --dry-run -Werror`, and
`bash -n` for the regression harness.

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex assisted with static comparison against the historical MNNVL path,
building and running the reserved-H20 regression, and drafting this PR
description. The submitter reviewed the implementation and validation results.