### PR TITLE
[TransferEngine] Add standard Prometheus metrics to Classic TE(1/2)

### DIFF
--- a/docs/source/design/transfer-engine/index.md
+++ b/docs/source/design/transfer-engine/index.md
@@ -522,9 +522,11 @@ it with `MC_TE_METRIC=1`. To scrape the metrics over HTTP, also set
 
 Metrics are compiled in only when the project is built with `-DWITH_METRICS=ON`
 (the default). Every transfer is recorded exactly once: a request is counted at
-submission time, and exactly one completion or failure is recorded when the
-task first reaches a terminal state, so repeated polling of
-`getTransferStatus` never double counts.
+submission time (before the task is handed to its transport, so the count is not
+lost to a fast asynchronous completion), and exactly one completion or failure
+is recorded when the task first reaches a terminal state. Repeated polling of
+`getTransferStatus` never double counts, and the `inflight_transfers` gauge
+always returns to its baseline.
 
 | Metric Name | Type | Description |
 |-------------|------|-------------|

--- a/docs/source/design/transfer-engine/index.md
+++ b/docs/source/design/transfer-engine/index.md
@@ -500,10 +500,48 @@ For advanced users, TransferEngine provides the following advanced runtime optio
 - `MC_TCP_ENABLE_CONNECTION_POOL` Enable TCP Connection Pool to avoid excessive sockets.
 - `MC_TCP_SLICE_SIZE` The segmentation granularity (in bytes) of TCP transport for splitting large transfers into socket read/write operations. Corresponds to `MC_SLICE_SIZE` for RDMA. Default value 65536 (64KB).
 - `MC_TCP_PROTO` When set to `1`, TCP initiators use the legacy unacknowledged framing even against servers that support acknowledged framing (protocol v2). Under v2 (the default against v2-capable servers), a WRITE completes only after the receiver confirms the payload has been applied to destination memory, and server-side rejections surface as failed transfers instead of silent data loss. Use this variable only as a rollback escape hatch during mixed-version upgrades.
+- `MC_TE_METRIC` Enable Transfer Engine metrics collection (accepted values: `1`, `true`, `yes`, `on`). Disabled by default. Turns on both the periodic latency/throughput log line and the standard Prometheus-style metrics described in [Standard Metrics](#standard-metrics).
+- `MC_TE_METRIC_INTERVAL_SECONDS` Interval in seconds for the periodic metrics log line. Default value 5. Must be positive.
+- `MC_TE_METRIC_HTTP_PORT` TCP port for the metrics HTTP server. Default value 0, which leaves the HTTP server disabled (metrics are still collected and can be scraped in-process). Set a positive port to expose `/metrics`, `/metrics/summary`, `/metrics/json`, and `/health`.
+- `MC_TE_METRIC_HTTP_HOST` Bind address for the metrics HTTP server. Default value `0.0.0.0`.
+- `MC_TE_METRIC_HTTP_THREADS` Number of HTTP server worker threads. Default value 1.
 
 ## C++ API Reference
 
 For the complete C++ API reference, see [Transfer Engine C++ API](../../api-reference/cpp/index).
+
+(standard-metrics)=
+## Standard Metrics
+
+The Classic Transfer Engine exports standard Prometheus-style metrics in
+addition to its periodic log line. Metrics collection is off by default; enable
+it with `MC_TE_METRIC=1`. To scrape the metrics over HTTP, also set
+`MC_TE_METRIC_HTTP_PORT` to a positive port. The endpoint layout matches the
+[TENT metrics system](../tent/metrics.md): `/metrics` (Prometheus text),
+`/metrics/summary` (human readable), `/metrics/json` (JSON), and `/health`.
+
+Metrics are compiled in only when the project is built with `-DWITH_METRICS=ON`
+(the default). Every transfer is recorded exactly once: a request is counted at
+submission time, and exactly one completion or failure is recorded when the
+task first reaches a terminal state, so repeated polling of
+`getTransferStatus` never double counts.
+
+| Metric Name | Type | Description |
+|-------------|------|-------------|
+| `transfer_requests_total` | Counter | Total transfer tasks submitted |
+| `transfer_bytes_total` | Counter | Total bytes transferred (successful tasks) |
+| `transfer_failures_total` | Counter | Total transfer tasks that failed, canceled, or timed out |
+| `transfer_latency_seconds` | Histogram | Completion latency distribution in seconds (successful tasks) |
+| `transfer_size_bytes` | Histogram | Transfer request size distribution in bytes |
+| `inflight_transfers` | Gauge | Transfers currently in flight (submitted but not yet terminal) |
+
+The existing periodic log line (throughput and latency distribution, controlled
+by `MC_TE_METRIC_INTERVAL_SECONDS`) is preserved unchanged; the metrics above
+are additional functionality.
+
+Runtime collection can be toggled without a rebuild via
+`TransferEngineMetrics::setEnabled(false)`, which makes the record functions
+return after a single atomic load.
 
 ## Supported Protocols
 

--- a/mooncake-transfer-engine/include/multi_transport.h
+++ b/mooncake-transfer-engine/include/multi_transport.h
@@ -72,6 +72,16 @@ class MultiTransport {
     void *getBaseAddr();
 
    private:
+    // Stamp a task's submission time (used for latency) and record it in the
+    // metrics system. Called before the task is posted to its transport so the
+    // metrics are consistent even if the transport completes it asynchronously.
+    // No-op unless WITH_METRICS and metrics are initialized.
+    static void markTaskSubmitted(Transport::TransferTask &task);
+
+    // Undo markTaskSubmitted() for a task that failed to be posted, keeping the
+    // request / inflight metrics balanced.
+    static void rollbackTaskSubmission(Transport::TransferTask &task);
+
     Status selectTransport(const TransferRequest &entry, Transport *&transport);
 
 #ifdef ENABLE_MULTI_PROTOCOL

--- a/mooncake-transfer-engine/include/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/include/transfer_engine_impl.h
@@ -40,6 +40,7 @@
 #ifdef WITH_METRICS
 #include "ylt/metric/counter.hpp"
 #include "ylt/metric/histogram.hpp"
+#include "transfer_engine_metrics.h"
 #endif
 
 namespace mooncake {
@@ -131,6 +132,7 @@ class TransferEngineImpl {
             for (auto& task : batch.task_list) {
                 if (task.start_time.time_since_epoch().count() == 0) {
                     task.start_time = now;
+                    TransferEngineMetrics::instance().recordSubmitted();
                 }
             }
         }
@@ -157,6 +159,7 @@ class TransferEngineImpl {
             for (auto& task : batch.task_list) {
                 if (task.start_time.time_since_epoch().count() == 0) {
                     task.start_time = now;
+                    TransferEngineMetrics::instance().recordSubmitted();
                 }
             }
         }
@@ -192,6 +195,7 @@ class TransferEngineImpl {
             for (auto& task : batch.task_list) {
                 if (task.start_time.time_since_epoch().count() == 0) {
                     task.start_time = now;
+                    TransferEngineMetrics::instance().recordSubmitted();
                 }
             }
         }
@@ -219,6 +223,7 @@ class TransferEngineImpl {
             for (auto& task : batch.task_list) {
                 if (task.start_time.time_since_epoch().count() == 0) {
                     task.start_time = now;
+                    TransferEngineMetrics::instance().recordSubmitted();
                 }
             }
         }
@@ -284,7 +289,7 @@ class TransferEngineImpl {
                 goto metrics_done;
             }
 
-            // Only record metrics for successful completions
+            // Only record latency metrics for successful completions
             if (status.s == TransferStatusEnum::COMPLETED) {
                 if (status.transferred_bytes > 0) {
                     transferred_bytes_counter_.inc(status.transferred_bytes);
@@ -294,6 +299,15 @@ class TransferEngineImpl {
                     std::chrono::duration_cast<std::chrono::microseconds>(
                         now - start);
                 task_completion_latency_us_.observe(duration.count());
+
+                // Standard Prometheus-style metrics (exported via HTTP).
+                double latency_seconds = duration.count() / 1000000.0;
+                TransferEngineMetrics::instance().recordCompleted(
+                    status.transferred_bytes, latency_seconds);
+            } else {
+                // FAILED / CANCELED / TIMEOUT all count as a failure and clear
+                // this task's slot in the inflight gauge.
+                TransferEngineMetrics::instance().recordFailed();
             }
 
             // Reset start_time to prevent duplicate processing

--- a/mooncake-transfer-engine/include/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/include/transfer_engine_impl.h
@@ -124,20 +124,10 @@ class TransferEngineImpl {
 
     Status submitTransfer(BatchID batch_id,
                           const std::vector<TransferRequest>& entries) {
-        Status s = multi_transports_->submitTransfer(batch_id, entries);
-#ifdef WITH_METRICS
-        if (metrics_enabled_ && s.ok()) {
-            auto& batch = Transport::toBatchDesc(batch_id);
-            auto now = std::chrono::steady_clock::now();
-            for (auto& task : batch.task_list) {
-                if (task.start_time.time_since_epoch().count() == 0) {
-                    task.start_time = now;
-                    TransferEngineMetrics::instance().recordSubmitted();
-                }
-            }
-        }
-#endif
-        return s;
+        // Metrics (start_time stamping + recordSubmitted) are handled inside
+        // MultiTransport::submitTransfer, before each task is posted, to avoid
+        // a race with asynchronous transport completion.
+        return multi_transports_->submitTransfer(batch_id, entries);
     }
 
     Status submitTransferWithNotify(BatchID batch_id,
@@ -151,19 +141,6 @@ class TransferEngineImpl {
         if (!s.ok()) {
             return s;
         }
-
-#ifdef WITH_METRICS
-        if (metrics_enabled_) {
-            auto& batch = Transport::toBatchDesc(batch_id);
-            auto now = std::chrono::steady_clock::now();
-            for (auto& task : batch.task_list) {
-                if (task.start_time.time_since_epoch().count() == 0) {
-                    task.start_time = now;
-                    TransferEngineMetrics::instance().recordSubmitted();
-                }
-            }
-        }
-#endif
 
         // store notify
         RWSpinlock::WriteGuard guard(send_notifies_lock_);
@@ -186,21 +163,9 @@ class TransferEngineImpl {
     Status mp_submitTransfer(BatchID batch_id,
                              const std::vector<TransferRequest>& entries,
                              std::string& proto) {
-        Status s =
-            multi_transports_->mp_submitTransfer(batch_id, entries, proto);
-#ifdef WITH_METRICS
-        if (metrics_enabled_ && s.ok()) {
-            auto& batch = Transport::toBatchDesc(batch_id);
-            auto now = std::chrono::steady_clock::now();
-            for (auto& task : batch.task_list) {
-                if (task.start_time.time_since_epoch().count() == 0) {
-                    task.start_time = now;
-                    TransferEngineMetrics::instance().recordSubmitted();
-                }
-            }
-        }
-#endif
-        return s;
+        // Metrics recording happens inside MultiTransport::mp_submitTransfer,
+        // before posting each task (see submitTransfer above).
+        return multi_transports_->mp_submitTransfer(batch_id, entries, proto);
     }
 
     Status mp_submitTransferWithNotify(
@@ -215,19 +180,6 @@ class TransferEngineImpl {
         if (!s.ok()) {
             return s;
         }
-
-#ifdef WITH_METRICS
-        if (metrics_enabled_) {
-            auto& batch = Transport::toBatchDesc(batch_id);
-            auto now = std::chrono::steady_clock::now();
-            for (auto& task : batch.task_list) {
-                if (task.start_time.time_since_epoch().count() == 0) {
-                    task.start_time = now;
-                    TransferEngineMetrics::instance().recordSubmitted();
-                }
-            }
-        }
-#endif
 
         // store notify
         RWSpinlock::WriteGuard guard(send_notifies_lock_);

--- a/mooncake-transfer-engine/include/transfer_engine_metrics.h
+++ b/mooncake-transfer-engine/include/transfer_engine_metrics.h
@@ -1,0 +1,193 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TRANSFER_ENGINE_METRICS_H_
+#define TRANSFER_ENGINE_METRICS_H_
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+// Standard Prometheus-style metrics for the Classic Transfer Engine.
+//
+// This mirrors the naming and behaviour of the TENT metrics implementation
+// (see mooncake-transfer-engine/tent/.../metrics/tent_metrics.h) as closely as
+// practical, while staying independent so that the two implementations can be
+// unified in a later change.
+//
+// The whole system is compiled out when WITH_METRICS is not defined, matching
+// the existing Classic TE metrics logging code.
+
+#ifdef WITH_METRICS
+#include <csignal>  // Required before ylt headers: coro_io.hpp uses SIGPIPE
+#include <ylt/metric/counter.hpp>
+#include <ylt/metric/gauge.hpp>
+#include <ylt/metric/histogram.hpp>
+#endif
+
+#ifdef WITH_METRICS
+// Forward-declare the coro_http server so this header stays lightweight; the
+// full type is only needed in the .cpp. ylt exposes the server as cinatra with
+// a `coro_http` namespace alias (see ylt/coro_http/coro_http_server.hpp).
+namespace cinatra {
+class coro_http_server;
+}  // namespace cinatra
+namespace coro_http = cinatra;
+#endif
+
+namespace mooncake {
+
+/**
+ * @brief Standard metrics for the Classic Transfer Engine.
+ *
+ * Provides Prometheus-compatible counters, histograms and an inflight gauge
+ * for transfer submission / completion / failure, plus an optional HTTP server
+ * exposing the same endpoints as TENT (/metrics, /metrics/summary,
+ * /metrics/json, /health).
+ *
+ * Design notes:
+ * - Collection is cheap (a handful of atomics) and always active once
+ *   initialized; it can be turned off at runtime via setEnabled(false).
+ * - The HTTP server is opt-in: it is only started when a port is configured
+ *   (env MC_TE_METRIC_HTTP_PORT), so default behaviour is unchanged.
+ * - Every transfer must be recorded exactly once. Callers are responsible for
+ *   invoking recordSubmitted() once per task at submission and exactly one of
+ *   recordCompleted()/recordFailed() once per task when it reaches a terminal
+ *   state. The Transfer Engine guards this with the per-task start_time reset.
+ */
+class TransferEngineMetrics {
+   public:
+    static TransferEngineMetrics& instance();
+
+    // Configuration for the (optional) metrics HTTP server. Populated from
+    // environment variables by loadConfigFromEnv().
+    struct Config {
+        bool enabled = true;
+        // http_port == 0 means "do not start the HTTP server".
+        uint16_t http_port = 0;
+        std::string http_host = "0.0.0.0";
+        uint16_t http_server_threads = 1;
+    };
+
+    // Build a Config from environment variables:
+    //   MC_TE_METRIC_HTTP_PORT     (uint16, 0/unset disables the HTTP server)
+    //   MC_TE_METRIC_HTTP_HOST     (string, default 0.0.0.0)
+    //   MC_TE_METRIC_HTTP_THREADS  (uint16, default 1)
+    static Config loadConfigFromEnv();
+
+    // Initialize metrics collection and, if a port is configured, start the
+    // HTTP server. Safe to call multiple times; only the first call has effect.
+    void initialize(const Config& config);
+
+    // Stop the HTTP server and mark the system uninitialized.
+    void shutdown();
+
+    bool isInitialized() const {
+        return initialized_.load(std::memory_order_acquire);
+    }
+
+    // Runtime enable/disable switch. When disabled, record* functions return
+    // after a single atomic load.
+    static void setEnabled(bool enabled) {
+        runtime_enabled_.store(enabled, std::memory_order_relaxed);
+    }
+    static bool isEnabled() {
+        return runtime_enabled_.load(std::memory_order_relaxed);
+    }
+
+    // Record a transfer task that has just been submitted. Increments the
+    // request counter and the inflight gauge.
+    void recordSubmitted();
+
+    // Record a transfer task that completed successfully. Records bytes,
+    // request size, latency and decrements the inflight gauge.
+    void recordCompleted(size_t bytes, double latency_seconds);
+
+    // Record a transfer task that failed / was canceled / timed out. Increments
+    // the failure counter and decrements the inflight gauge.
+    void recordFailed();
+
+    // Serialization for the HTTP endpoints.
+    std::string getPrometheusMetrics();
+    std::string getJsonMetrics();
+    std::string getSummaryString();
+
+#ifdef WITH_METRICS
+    // Accessors used by the HTTP server and by unit tests.
+    double requestsTotal();
+    double bytesTotal();
+    double failuresTotal();
+    int64_t inflightTransfers();
+    int64_t latencySampleCount();
+    int64_t sizeSampleCount();
+
+    // Reset all metrics to zero. Intended for test isolation only; the metrics
+    // singleton outlives individual Transfer Engine instances.
+    void resetForTesting();
+#endif
+
+   private:
+    TransferEngineMetrics();
+    ~TransferEngineMetrics();
+    TransferEngineMetrics(const TransferEngineMetrics&) = delete;
+    TransferEngineMetrics& operator=(const TransferEngineMetrics&) = delete;
+
+    static inline std::atomic<bool> runtime_enabled_{true};
+    std::atomic<bool> initialized_{false};
+
+#ifdef WITH_METRICS
+    void initHttpServer(const Config& config);
+
+    // ylt histograms keep their _sum in an int64 gauge, which truncates
+    // sub-second latencies to zero and suppresses serialization. We therefore
+    // track the latency sum ourselves (in seconds) and serialize the latency
+    // histogram manually so it is always emitted with a correct _sum.
+    void serializeLatencyHistogram(std::string& out);
+
+    Config config_;
+    std::unique_ptr<coro_http::coro_http_server> http_server_;
+
+    std::atomic<double> latency_sum_seconds_{0.0};
+
+    // Latency buckets are expressed in seconds so the exported metric follows
+    // the Prometheus convention of a *_seconds histogram.
+    static inline const std::vector<double> kLatencyBucketsSeconds{
+        0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0};
+    // Size buckets in bytes: 1KB .. 1GB (matches TENT).
+    static inline const std::vector<double> kSizeBuckets{
+        1024,    4096,     16384,    65536,     262144,    1048576,
+        4194304, 16777216, 67108864, 268435456, 1073741824};
+
+    ylt::metric::counter_t requests_total_{"transfer_requests_total",
+                                           "Total transfer requests submitted"};
+    ylt::metric::counter_t bytes_total_{"transfer_bytes_total",
+                                        "Total bytes transferred"};
+    ylt::metric::counter_t failures_total_{"transfer_failures_total",
+                                           "Total transfer failures"};
+    ylt::metric::gauge_t inflight_transfers_{
+        "inflight_transfers", "Number of transfers currently in flight"};
+    ylt::metric::histogram_d latency_seconds_{
+        "transfer_latency_seconds", "Transfer completion latency in seconds",
+        kLatencyBucketsSeconds};
+    ylt::metric::histogram_t size_bytes_{
+        "transfer_size_bytes", "Transfer request size in bytes", kSizeBuckets};
+#endif
+};
+
+}  // namespace mooncake
+
+#endif  // TRANSFER_ENGINE_METRICS_H_

--- a/mooncake-transfer-engine/src/multi_transport.cpp
+++ b/mooncake-transfer-engine/src/multi_transport.cpp
@@ -20,6 +20,9 @@
 
 #include "config.h"
 #include "multi_transport_locality.h"
+#ifdef WITH_METRICS
+#include "transfer_engine_metrics.h"
+#endif
 #include "transport/rdma_transport/rdma_transport.h"
 #ifdef USE_BAREX
 #include "transport/barex_transport/barex_transport.h"
@@ -112,6 +115,35 @@ Status MultiTransport::freeBatchID(BatchID batch_id) {
     return Status::OK();
 }
 
+void MultiTransport::markTaskSubmitted(Transport::TransferTask& task) {
+#ifdef WITH_METRICS
+    // Only stamp/record once per task, and only while metrics collection is
+    // active (initialized == the process-wide MC_TE_METRIC switch). The runtime
+    // enable/disable state is handled inside recordSubmitted() itself.
+    if (!TransferEngineMetrics::instance().isInitialized()) return;
+    if (task.start_time.time_since_epoch().count() != 0) return;
+    task.start_time = std::chrono::steady_clock::now();
+    TransferEngineMetrics::instance().recordSubmitted();
+#else
+    (void)task;
+#endif
+}
+
+void MultiTransport::rollbackTaskSubmission(Transport::TransferTask& task) {
+#ifdef WITH_METRICS
+    if (!TransferEngineMetrics::instance().isInitialized()) return;
+    if (task.start_time.time_since_epoch().count() == 0) return;
+    // Clear the stamp first so a later getTransferStatus() poll on this task
+    // cannot record the terminal metrics a second time.
+    task.start_time = std::chrono::steady_clock::time_point();
+    // A task that could not be posted to its transport is a failed transfer:
+    // count the failure and release its slot in the inflight gauge.
+    TransferEngineMetrics::instance().recordFailed();
+#else
+    (void)task;
+#endif
+}
+
 Status MultiTransport::submitTransfer(
     BatchID batch_id, const std::vector<TransferRequest>& entries) {
     auto& batch_desc = *((BatchDesc*)(batch_id));
@@ -138,6 +170,13 @@ Status MultiTransport::submitTransfer(
 #else
         task.request = &request;
 #endif
+        // Stamp the submission time and count the request BEFORE posting the
+        // task to the transport. The transport may complete (or fail) the task
+        // asynchronously as soon as it is posted, and getTransferStatus() only
+        // records completion/failure metrics for tasks whose start_time is set.
+        // Setting it here closes that race and keeps the inflight gauge
+        // balanced regardless of how fast the transport finishes.
+        markTaskSubmitted(task);
         ++task_id;
         submit_tasks[transport].push_back(&task);
     }
@@ -147,6 +186,11 @@ Status MultiTransport::submitTransfer(
         if (!status.ok()) {
             // LOG(ERROR) << "Failed to submit transfer task to "
             //            << entry.first->getName();
+            // Roll back the metrics for tasks that never made it onto the wire
+            // so the request/inflight counters stay consistent.
+            for (auto* task : entry.second) {
+                rollbackTaskSubmission(*task);
+            }
             overall_status = status;
         }
     }
@@ -181,6 +225,9 @@ Status MultiTransport::mp_submitTransfer(
 #else
         task.request = &request;
 #endif
+        // See submitTransfer(): stamp submission time / count the request
+        // before posting to avoid a race with asynchronous completion.
+        markTaskSubmitted(task);
         ++task_id;
         submit_tasks[transport].push_back(&task);
     }
@@ -190,6 +237,9 @@ Status MultiTransport::mp_submitTransfer(
         if (!status.ok()) {
             // LOG(ERROR) << "Failed to submit transfer task to "
             //            << entry.first->getName();
+            for (auto* task : entry.second) {
+                rollbackTaskSubmission(*task);
+            }
             overall_status = status;
         }
     }

--- a/mooncake-transfer-engine/src/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine_impl.cpp
@@ -930,6 +930,15 @@ void TransferEngineImpl::InitializeMetricsConfig() {
                          << ", using default: " << metrics_interval_seconds_;
         }
     }
+
+    // Standard Prometheus-style metrics share the MC_TE_METRIC enable switch
+    // with the legacy logging thread, but are exported independently through an
+    // (optional) HTTP endpoint. Initialization is idempotent, so it is safe to
+    // run once per engine instance.
+    if (metrics_enabled_) {
+        auto config = TransferEngineMetrics::loadConfigFromEnv();
+        TransferEngineMetrics::instance().initialize(config);
+    }
 }
 
 void TransferEngineImpl::StartMetricsReportingThread() {

--- a/mooncake-transfer-engine/src/transfer_engine_metrics.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine_metrics.cpp
@@ -1,0 +1,301 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "transfer_engine_metrics.h"
+
+#include <glog/logging.h>
+
+#include <cstdlib>
+#include <exception>
+#include <iomanip>
+#include <sstream>
+
+#ifdef WITH_METRICS
+#include <ylt/coro_http/coro_http_server.hpp>
+#endif
+
+namespace mooncake {
+
+namespace {
+// Parse an unsigned 16-bit env var; returns fallback if unset or malformed.
+uint16_t getEnvU16(const char* name, uint16_t fallback) {
+    const char* value = std::getenv(name);
+    if (!value || *value == '\0') return fallback;
+    try {
+        int parsed = std::stoi(value);
+        if (parsed < 0 || parsed > 65535) {
+            LOG(WARNING) << "Ignoring out-of-range " << name << "=" << value;
+            return fallback;
+        }
+        return static_cast<uint16_t>(parsed);
+    } catch (const std::exception& e) {
+        LOG(WARNING) << "Failed to parse " << name << "=" << value
+                     << ", using default " << fallback;
+        return fallback;
+    }
+}
+}  // namespace
+
+TransferEngineMetrics& TransferEngineMetrics::instance() {
+    static TransferEngineMetrics instance;
+    return instance;
+}
+
+TransferEngineMetrics::Config TransferEngineMetrics::loadConfigFromEnv() {
+    Config config;
+    config.http_port = getEnvU16("MC_TE_METRIC_HTTP_PORT", 0);
+    const char* host = std::getenv("MC_TE_METRIC_HTTP_HOST");
+    if (host && *host != '\0') {
+        config.http_host = host;
+    }
+    config.http_server_threads = getEnvU16("MC_TE_METRIC_HTTP_THREADS", 1);
+    return config;
+}
+
+#ifdef WITH_METRICS
+
+TransferEngineMetrics::TransferEngineMetrics() = default;
+
+TransferEngineMetrics::~TransferEngineMetrics() { shutdown(); }
+
+void TransferEngineMetrics::initialize(const Config& config) {
+    bool expected = false;
+    if (!initialized_.compare_exchange_strong(expected, true)) {
+        return;  // Already initialized.
+    }
+
+    config_ = config;
+    runtime_enabled_.store(config_.enabled, std::memory_order_relaxed);
+
+    if (config_.http_port != 0) {
+        initHttpServer(config_);
+    }
+
+    LOG(INFO) << "Transfer Engine metrics initialized (runtime_enabled="
+              << (config_.enabled ? "true" : "false")
+              << ", http_port=" << config_.http_port << ")";
+}
+
+void TransferEngineMetrics::initHttpServer(const Config& config) {
+    using namespace coro_http;
+    try {
+        http_server_ = std::make_unique<coro_http_server>(
+            config.http_server_threads, config.http_port);
+
+        http_server_->set_http_handler<GET>(
+            "/metrics", [this](coro_http_request&, coro_http_response& resp) {
+                resp.add_header("Content-Type", "text/plain; version=0.0.4");
+                resp.set_status_and_content(status_type::ok,
+                                            getPrometheusMetrics());
+            });
+        http_server_->set_http_handler<GET>(
+            "/metrics/summary",
+            [this](coro_http_request&, coro_http_response& resp) {
+                resp.add_header("Content-Type", "text/plain");
+                resp.set_status_and_content(status_type::ok,
+                                            getSummaryString());
+            });
+        http_server_->set_http_handler<GET>(
+            "/metrics/json",
+            [this](coro_http_request&, coro_http_response& resp) {
+                resp.add_header("Content-Type", "application/json");
+                resp.set_status_and_content(status_type::ok, getJsonMetrics());
+            });
+        http_server_->set_http_handler<GET>(
+            "/health", [](coro_http_request&, coro_http_response& resp) {
+                resp.add_header("Content-Type", "text/plain");
+                resp.set_status_and_content(status_type::ok, "OK");
+            });
+
+        http_server_->async_start();
+        LOG(INFO) << "Transfer Engine metrics HTTP server listening on "
+                  << config.http_host << ":" << config.http_port;
+    } catch (const std::exception& e) {
+        LOG(ERROR) << "Failed to start Transfer Engine metrics HTTP server: "
+                   << e.what();
+        http_server_.reset();
+    }
+}
+
+void TransferEngineMetrics::shutdown() {
+    if (!initialized_.exchange(false)) return;
+    if (http_server_) {
+        http_server_->stop();
+        http_server_.reset();
+    }
+    LOG(INFO) << "Transfer Engine metrics shutdown complete";
+}
+
+void TransferEngineMetrics::recordSubmitted() {
+    if (!isEnabled()) return;
+    requests_total_.inc();
+    inflight_transfers_.inc();
+}
+
+void TransferEngineMetrics::recordCompleted(size_t bytes,
+                                            double latency_seconds) {
+    if (!isEnabled()) return;
+    if (bytes > 0) {
+        bytes_total_.inc(static_cast<double>(bytes));
+    }
+    size_bytes_.observe(static_cast<int64_t>(bytes));
+    if (latency_seconds > 0.0) {
+        latency_seconds_.observe(latency_seconds);
+        latency_sum_seconds_.fetch_add(latency_seconds,
+                                       std::memory_order_relaxed);
+    }
+    inflight_transfers_.dec();
+}
+
+void TransferEngineMetrics::recordFailed() {
+    if (!isEnabled()) return;
+    failures_total_.inc();
+    inflight_transfers_.dec();
+}
+
+double TransferEngineMetrics::requestsTotal() {
+    return requests_total_.value();
+}
+double TransferEngineMetrics::bytesTotal() { return bytes_total_.value(); }
+double TransferEngineMetrics::failuresTotal() {
+    return failures_total_.value();
+}
+int64_t TransferEngineMetrics::inflightTransfers() {
+    return inflight_transfers_.value();
+}
+
+int64_t TransferEngineMetrics::latencySampleCount() {
+    int64_t total = 0;
+    for (auto& bucket : latency_seconds_.get_bucket_counts()) {
+        total += bucket->value();
+    }
+    return total;
+}
+
+int64_t TransferEngineMetrics::sizeSampleCount() {
+    int64_t total = 0;
+    for (auto& bucket : size_bytes_.get_bucket_counts()) {
+        total += bucket->value();
+    }
+    return total;
+}
+
+void TransferEngineMetrics::resetForTesting() {
+    requests_total_.reset();
+    bytes_total_.reset();
+    failures_total_.reset();
+    // gauge_t derives from counter_t; update() sets an absolute value.
+    inflight_transfers_.update(0);
+    latency_seconds_ = ylt::metric::histogram_d(
+        "transfer_latency_seconds", "Transfer completion latency in seconds",
+        kLatencyBucketsSeconds);
+    size_bytes_ = ylt::metric::histogram_t(
+        "transfer_size_bytes", "Transfer request size in bytes", kSizeBuckets);
+    latency_sum_seconds_.store(0.0, std::memory_order_relaxed);
+    setEnabled(true);
+}
+
+void TransferEngineMetrics::serializeLatencyHistogram(std::string& out) {
+    // Manual Prometheus histogram serialization (see latency_sum_seconds_ note
+    // in the header): emit cumulative buckets, _sum and _count.
+    auto bucket_counts = latency_seconds_.get_bucket_counts();
+    int64_t cumulative = 0;
+    out.append(
+        "# HELP transfer_latency_seconds Transfer completion latency in "
+        "seconds\n");
+    out.append("# TYPE transfer_latency_seconds histogram\n");
+    for (size_t i = 0; i < bucket_counts.size(); ++i) {
+        cumulative += bucket_counts[i]->value();
+        out.append("transfer_latency_seconds_bucket{le=\"");
+        if (i < kLatencyBucketsSeconds.size()) {
+            out.append(std::to_string(kLatencyBucketsSeconds[i]));
+        } else {
+            out.append("+Inf");
+        }
+        out.append("\"} ").append(std::to_string(cumulative)).append("\n");
+    }
+    std::ostringstream sum_stream;
+    sum_stream << latency_sum_seconds_.load(std::memory_order_relaxed);
+    out.append("transfer_latency_seconds_sum ")
+        .append(sum_stream.str())
+        .append("\n");
+    out.append("transfer_latency_seconds_count ")
+        .append(std::to_string(cumulative))
+        .append("\n");
+}
+
+std::string TransferEngineMetrics::getPrometheusMetrics() {
+    if (!isInitialized()) return "";
+    try {
+        std::string result;
+        requests_total_.serialize(result);
+        bytes_total_.serialize(result);
+        failures_total_.serialize(result);
+        inflight_transfers_.serialize(result);
+        serializeLatencyHistogram(result);
+        size_bytes_.serialize(result);
+        return result;
+    } catch (const std::exception& e) {
+        LOG(ERROR) << "Failed to serialize Prometheus metrics: " << e.what();
+        return "";
+    }
+}
+
+std::string TransferEngineMetrics::getJsonMetrics() {
+    if (!isInitialized()) return "{}";
+    std::ostringstream oss;
+    oss << "{"
+        << "\"transfer_requests_total\":" << requests_total_.value() << ","
+        << "\"transfer_bytes_total\":" << bytes_total_.value() << ","
+        << "\"transfer_failures_total\":" << failures_total_.value() << ","
+        << "\"inflight_transfers\":" << inflight_transfers_.value() << ","
+        << "\"transfer_latency_seconds_count\":" << latencySampleCount() << ","
+        << "\"transfer_size_bytes_count\":" << sizeSampleCount() << "}";
+    return oss.str();
+}
+
+std::string TransferEngineMetrics::getSummaryString() {
+    if (!isInitialized()) return "Metrics not initialized";
+    std::ostringstream oss;
+    oss << "Requests: " << static_cast<uint64_t>(requests_total_.value())
+        << " | Bytes: " << static_cast<uint64_t>(bytes_total_.value())
+        << " | Failures: " << static_cast<uint64_t>(failures_total_.value())
+        << " | Inflight: " << inflight_transfers_.value();
+    return oss.str();
+}
+
+#else  // !WITH_METRICS
+
+TransferEngineMetrics::TransferEngineMetrics() = default;
+TransferEngineMetrics::~TransferEngineMetrics() = default;
+
+void TransferEngineMetrics::initialize(const Config&) {}
+void TransferEngineMetrics::shutdown() {}
+void TransferEngineMetrics::recordSubmitted() {}
+void TransferEngineMetrics::recordCompleted(size_t, double) {}
+void TransferEngineMetrics::recordFailed() {}
+
+std::string TransferEngineMetrics::getPrometheusMetrics() {
+    return "# Transfer Engine metrics disabled at compile time\n";
+}
+std::string TransferEngineMetrics::getJsonMetrics() {
+    return R"({"status": "disabled"})";
+}
+std::string TransferEngineMetrics::getSummaryString() {
+    return "Transfer Engine metrics disabled at compile time";
+}
+
+#endif  // WITH_METRICS
+
+}  // namespace mooncake

--- a/mooncake-transfer-engine/src/transfer_engine_metrics.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine_metrics.cpp
@@ -91,7 +91,7 @@ void TransferEngineMetrics::initHttpServer(const Config& config) {
     using namespace coro_http;
     try {
         http_server_ = std::make_unique<coro_http_server>(
-            config.http_server_threads, config.http_port);
+            config.http_server_threads, config.http_port, config.http_host);
 
         http_server_->set_http_handler<GET>(
             "/metrics", [this](coro_http_request&, coro_http_response& resp) {
@@ -138,14 +138,14 @@ void TransferEngineMetrics::shutdown() {
 }
 
 void TransferEngineMetrics::recordSubmitted() {
-    if (!isEnabled()) return;
+    if (!isInitialized() || !isEnabled()) return;
     requests_total_.inc();
     inflight_transfers_.inc();
 }
 
 void TransferEngineMetrics::recordCompleted(size_t bytes,
                                             double latency_seconds) {
-    if (!isEnabled()) return;
+    if (!isInitialized() || !isEnabled()) return;
     if (bytes > 0) {
         bytes_total_.inc(static_cast<double>(bytes));
     }
@@ -159,7 +159,7 @@ void TransferEngineMetrics::recordCompleted(size_t bytes,
 }
 
 void TransferEngineMetrics::recordFailed() {
-    if (!isEnabled()) return;
+    if (!isInitialized() || !isEnabled()) return;
     failures_total_.inc();
     inflight_transfers_.dec();
 }

--- a/mooncake-transfer-engine/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tests/CMakeLists.txt
@@ -19,6 +19,12 @@ target_link_libraries(transport_uint_test PUBLIC transfer_engine gtest
                                                  gtest_main)
 add_test(NAME transport_uint_test COMMAND transport_uint_test)
 
+add_executable(transfer_engine_metrics_test
+               ${WORKSPACE}/transfer_engine_metrics_test.cpp)
+target_link_libraries(transfer_engine_metrics_test PUBLIC transfer_engine gtest
+                                                          gtest_main)
+add_test(NAME transfer_engine_metrics_test COMMAND transfer_engine_metrics_test)
+
 add_executable(endpoint_store_test ${WORKSPACE}/endpoint_store_test.cpp)
 target_link_libraries(endpoint_store_test PUBLIC transfer_engine gtest
                                                  gtest_main)

--- a/mooncake-transfer-engine/tests/transfer_engine_metrics_test.cpp
+++ b/mooncake-transfer-engine/tests/transfer_engine_metrics_test.cpp
@@ -1,0 +1,275 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <vector>
+
+#include "transfer_engine_impl.h"
+#include "transfer_engine_metrics.h"
+#include "transport/transport.h"
+
+using namespace mooncake;
+
+namespace mooncake {
+
+// Test peer that reaches into TransferEngineImpl internals to build batches and
+// tasks without going through the full submit/segment plumbing. This keeps the
+// metrics test hermetic (no RDMA/TCP setup required).
+class TransferEngineImplTestPeer {
+   public:
+    static void installTransport(TransferEngineImpl& engine,
+                                 std::shared_ptr<Transport> transport) {
+        engine.multi_transports_->transport_map_.clear();
+        engine.multi_transports_->transport_map_.emplace("fake",
+                                                         std::move(transport));
+    }
+
+    static BatchID allocateBatch(TransferEngineImpl& engine, size_t size) {
+        return engine.multi_transports_->allocateBatchID(size);
+    }
+
+    // Append one task backed by `transport`, marked as submitted (start_time
+    // set), mirroring what submitTransfer() does on the metrics path.
+    static void addSubmittedTask(BatchID batch_id, Transport* transport) {
+        auto& batch = Transport::toBatchDesc(batch_id);
+        batch.task_list.emplace_back();
+        auto& task = batch.task_list.back();
+        task.batch_id = batch_id;
+        task.transport_ = transport;
+#ifdef WITH_METRICS
+        task.start_time = std::chrono::steady_clock::now();
+#endif
+    }
+
+    static void markAllFinished(BatchID batch_id) {
+        auto& batch = Transport::toBatchDesc(batch_id);
+        for (auto& task : batch.task_list) {
+            task.is_finished = true;
+        }
+    }
+
+    static void freeBatch(TransferEngineImpl& engine, BatchID batch_id) {
+        engine.multi_transports_->freeBatchID(batch_id);
+    }
+};
+
+namespace {
+
+// Fake transport that reports a fixed terminal status for every task.
+class FakeTransport : public Transport {
+   public:
+    FakeTransport(TransferStatusEnum status, size_t transferred_bytes)
+        : status_(status), transferred_bytes_(transferred_bytes) {}
+
+    Status submitTransfer(BatchID,
+                          const std::vector<TransferRequest>&) override {
+        return Status::OK();
+    }
+
+    Status getTransferStatus(BatchID, size_t, TransferStatus& status) override {
+        status.s = status_;
+        status.transferred_bytes = transferred_bytes_;
+        return Status::OK();
+    }
+
+   private:
+    int registerLocalMemory(void*, size_t, const std::string&, bool,
+                            bool) override {
+        return 0;
+    }
+    int unregisterLocalMemory(void*, bool) override { return 0; }
+    int registerLocalMemoryBatch(const std::vector<BufferEntry>&,
+                                 const std::string&) override {
+        return 0;
+    }
+    int unregisterLocalMemoryBatch(const std::vector<void*>&) override {
+        return 0;
+    }
+    const char* getName() const override { return "fake"; }
+
+    TransferStatusEnum status_;
+    size_t transferred_bytes_;
+};
+
+#ifdef WITH_METRICS
+
+class TransferEngineMetricsTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        auto& m = TransferEngineMetrics::instance();
+        // Initialize without an HTTP server (port 0) so tests never bind a
+        // socket, then start from a clean slate.
+        m.initialize(TransferEngineMetrics::Config{});
+        m.resetForTesting();
+    }
+
+    TransferEngineMetrics& metrics() {
+        return TransferEngineMetrics::instance();
+    }
+};
+
+// --- Direct API tests ------------------------------------------------------
+
+TEST_F(TransferEngineMetricsTest, SuccessfulTransferRecordsBytesAndLatency) {
+    auto& m = metrics();
+    m.recordSubmitted();
+    m.recordCompleted(4096, 0.002);  // 4KB in 2ms
+
+    EXPECT_EQ(m.requestsTotal(), 1);
+    EXPECT_EQ(m.bytesTotal(), 4096);
+    EXPECT_EQ(m.failuresTotal(), 0);
+    EXPECT_EQ(m.latencySampleCount(), 1);  // latency recorded
+    EXPECT_EQ(m.sizeSampleCount(), 1);     // bytes recorded
+    EXPECT_EQ(m.inflightTransfers(), 0);   // inflight back to zero
+}
+
+TEST_F(TransferEngineMetricsTest, FailedTransferRecordsFailure) {
+    auto& m = metrics();
+    m.recordSubmitted();
+    m.recordFailed();
+
+    EXPECT_EQ(m.requestsTotal(), 1);
+    EXPECT_EQ(m.failuresTotal(), 1);
+    EXPECT_EQ(m.bytesTotal(), 0);
+    EXPECT_EQ(m.latencySampleCount(), 0);  // no latency for failures
+    EXPECT_EQ(m.inflightTransfers(), 0);   // inflight back to zero
+}
+
+TEST_F(TransferEngineMetricsTest, InflightTracksConcurrentTransfers) {
+    auto& m = metrics();
+    m.recordSubmitted();
+    m.recordSubmitted();
+    m.recordSubmitted();
+    EXPECT_EQ(m.inflightTransfers(), 3);
+
+    m.recordCompleted(1024, 0.001);
+    EXPECT_EQ(m.inflightTransfers(), 2);
+
+    m.recordFailed();
+    EXPECT_EQ(m.inflightTransfers(), 1);
+
+    m.recordCompleted(2048, 0.001);
+    EXPECT_EQ(m.inflightTransfers(), 0);
+}
+
+TEST_F(TransferEngineMetricsTest, PrometheusOutputContainsStandardMetrics) {
+    auto& m = metrics();
+    m.recordSubmitted();
+    m.recordCompleted(1048576, 0.01);
+
+    std::string prom = m.getPrometheusMetrics();
+    EXPECT_NE(prom.find("transfer_requests_total"), std::string::npos);
+    EXPECT_NE(prom.find("transfer_bytes_total"), std::string::npos);
+    EXPECT_NE(prom.find("inflight_transfers"), std::string::npos);
+    EXPECT_NE(prom.find("transfer_latency_seconds"), std::string::npos);
+    EXPECT_NE(prom.find("transfer_size_bytes"), std::string::npos);
+}
+
+TEST_F(TransferEngineMetricsTest, DisabledAtRuntimeSkipsRecording) {
+    auto& m = metrics();
+    TransferEngineMetrics::setEnabled(false);
+    m.recordSubmitted();
+    m.recordCompleted(4096, 0.002);
+    m.recordFailed();
+    EXPECT_EQ(m.requestsTotal(), 0);
+    EXPECT_EQ(m.bytesTotal(), 0);
+    EXPECT_EQ(m.failuresTotal(), 0);
+    EXPECT_EQ(m.inflightTransfers(), 0);
+    TransferEngineMetrics::setEnabled(true);
+}
+
+// --- End-to-end dedup test through TransferEngineImpl -----------------------
+
+// Drives the real TransferEngineImpl::getTransferStatus() to verify that
+// repeated polling of a terminal task records metrics exactly once.
+class TransferEngineImplMetricsTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        setenv("MC_TE_METRIC", "1", /*overwrite=*/1);
+        auto& m = TransferEngineMetrics::instance();
+        m.initialize(TransferEngineMetrics::Config{});
+        m.resetForTesting();
+    }
+};
+
+TEST_F(TransferEngineImplMetricsTest,
+       DuplicateCompletionPollDoesNotDoubleCount) {
+    TransferEngineImpl engine(false);
+    ASSERT_EQ(engine.init(P2PHANDSHAKE, "127.0.0.1:12399"), 0);
+
+    auto transport = std::make_shared<FakeTransport>(
+        Transport::TransferStatusEnum::COMPLETED, 8192);
+    TransferEngineImplTestPeer::installTransport(engine, transport);
+
+    BatchID batch = TransferEngineImplTestPeer::allocateBatch(engine, 1);
+    TransferEngineImplTestPeer::addSubmittedTask(batch, transport.get());
+
+    auto& m = TransferEngineMetrics::instance();
+    // Pretend the task was submitted (submit path increments this).
+    m.recordSubmitted();
+    EXPECT_EQ(m.inflightTransfers(), 1);
+
+    // Poll several times: metrics must be recorded exactly once.
+    TransferStatus status;
+    for (int i = 0; i < 5; ++i) {
+        ASSERT_TRUE(engine.getTransferStatus(batch, 0, status).ok());
+        EXPECT_EQ(status.s, Transport::TransferStatusEnum::COMPLETED);
+    }
+
+    EXPECT_EQ(m.bytesTotal(), 8192);
+    EXPECT_EQ(m.latencySampleCount(), 1);
+    EXPECT_EQ(m.inflightTransfers(), 0);
+
+    TransferEngineImplTestPeer::markAllFinished(batch);
+    TransferEngineImplTestPeer::freeBatch(engine, batch);
+}
+
+TEST_F(TransferEngineImplMetricsTest, FailedTaskPollRecordsSingleFailure) {
+    TransferEngineImpl engine(false);
+    ASSERT_EQ(engine.init(P2PHANDSHAKE, "127.0.0.1:12398"), 0);
+
+    auto transport = std::make_shared<FakeTransport>(
+        Transport::TransferStatusEnum::FAILED, 0);
+    TransferEngineImplTestPeer::installTransport(engine, transport);
+
+    BatchID batch = TransferEngineImplTestPeer::allocateBatch(engine, 1);
+    TransferEngineImplTestPeer::addSubmittedTask(batch, transport.get());
+
+    auto& m = TransferEngineMetrics::instance();
+    m.recordSubmitted();
+
+    TransferStatus status;
+    for (int i = 0; i < 3; ++i) {
+        ASSERT_TRUE(engine.getTransferStatus(batch, 0, status).ok());
+        EXPECT_EQ(status.s, Transport::TransferStatusEnum::FAILED);
+    }
+
+    EXPECT_EQ(m.failuresTotal(), 1);
+    EXPECT_EQ(m.inflightTransfers(), 0);
+
+    TransferEngineImplTestPeer::markAllFinished(batch);
+    TransferEngineImplTestPeer::freeBatch(engine, batch);
+}
+
+#endif  // WITH_METRICS
+
+}  // namespace
+}  // namespace mooncake
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/mooncake-transfer-engine/tests/transfer_engine_metrics_test.cpp
+++ b/mooncake-transfer-engine/tests/transfer_engine_metrics_test.cpp
@@ -41,17 +41,16 @@ class TransferEngineImplTestPeer {
         return engine.multi_transports_->allocateBatchID(size);
     }
 
-    // Append one task backed by `transport`, marked as submitted (start_time
-    // set), mirroring what submitTransfer() does on the metrics path.
+    // Append one task backed by `transport` and run it through the real
+    // MultiTransport submission-metrics path (stamps start_time and calls
+    // recordSubmitted), exactly as submitTransfer() does before posting.
     static void addSubmittedTask(BatchID batch_id, Transport* transport) {
         auto& batch = Transport::toBatchDesc(batch_id);
         batch.task_list.emplace_back();
         auto& task = batch.task_list.back();
         task.batch_id = batch_id;
         task.transport_ = transport;
-#ifdef WITH_METRICS
-        task.start_time = std::chrono::steady_clock::now();
-#endif
+        markTaskSubmitted(task);
     }
 
     static void markAllFinished(BatchID batch_id) {
@@ -63,6 +62,14 @@ class TransferEngineImplTestPeer {
 
     static void freeBatch(TransferEngineImpl& engine, BatchID batch_id) {
         engine.multi_transports_->freeBatchID(batch_id);
+    }
+
+    // Expose MultiTransport's private submission-metrics helpers for testing.
+    static void markTaskSubmitted(Transport::TransferTask& task) {
+        MultiTransport::markTaskSubmitted(task);
+    }
+    static void rollbackTaskSubmission(Transport::TransferTask& task) {
+        MultiTransport::rollbackTaskSubmission(task);
     }
 };
 
@@ -215,11 +222,11 @@ TEST_F(TransferEngineImplMetricsTest,
     TransferEngineImplTestPeer::installTransport(engine, transport);
 
     BatchID batch = TransferEngineImplTestPeer::allocateBatch(engine, 1);
+    // addSubmittedTask runs the real submission-metrics path (recordSubmitted).
     TransferEngineImplTestPeer::addSubmittedTask(batch, transport.get());
 
     auto& m = TransferEngineMetrics::instance();
-    // Pretend the task was submitted (submit path increments this).
-    m.recordSubmitted();
+    EXPECT_EQ(m.requestsTotal(), 1);
     EXPECT_EQ(m.inflightTransfers(), 1);
 
     // Poll several times: metrics must be recorded exactly once.
@@ -249,7 +256,7 @@ TEST_F(TransferEngineImplMetricsTest, FailedTaskPollRecordsSingleFailure) {
     TransferEngineImplTestPeer::addSubmittedTask(batch, transport.get());
 
     auto& m = TransferEngineMetrics::instance();
-    m.recordSubmitted();
+    EXPECT_EQ(m.inflightTransfers(), 1);
 
     TransferStatus status;
     for (int i = 0; i < 3; ++i) {
@@ -262,6 +269,55 @@ TEST_F(TransferEngineImplMetricsTest, FailedTaskPollRecordsSingleFailure) {
 
     TransferEngineImplTestPeer::markAllFinished(batch);
     TransferEngineImplTestPeer::freeBatch(engine, batch);
+}
+
+// Reproduces the async-completion scenario: the task is already terminal by the
+// time the caller polls it exactly once. Because start_time is stamped at
+// submit (before posting), the single poll still records completion and clears
+// the inflight gauge — there is no permanent inflight leak.
+TEST_F(TransferEngineImplMetricsTest,
+       SinglePollOnAlreadyTerminalTaskIsRecorded) {
+    TransferEngineImpl engine(false);
+    ASSERT_EQ(engine.init(P2PHANDSHAKE, "127.0.0.1:12397"), 0);
+
+    auto transport = std::make_shared<FakeTransport>(
+        Transport::TransferStatusEnum::COMPLETED, 4096);
+    TransferEngineImplTestPeer::installTransport(engine, transport);
+
+    BatchID batch = TransferEngineImplTestPeer::allocateBatch(engine, 1);
+    TransferEngineImplTestPeer::addSubmittedTask(batch, transport.get());
+
+    auto& m = TransferEngineMetrics::instance();
+    ASSERT_EQ(m.inflightTransfers(), 1);
+
+    TransferStatus status;
+    ASSERT_TRUE(engine.getTransferStatus(batch, 0, status).ok());
+    EXPECT_EQ(status.s, Transport::TransferStatusEnum::COMPLETED);
+
+    EXPECT_EQ(m.requestsTotal(), 1);
+    EXPECT_EQ(m.bytesTotal(), 4096);
+    EXPECT_EQ(m.inflightTransfers(), 0);  // no leak
+
+    TransferEngineImplTestPeer::markAllFinished(batch);
+    TransferEngineImplTestPeer::freeBatch(engine, batch);
+}
+
+// A task that is submission-recorded but then rolled back (transport failed to
+// post it) must not leak the inflight gauge, and is counted as a failure.
+TEST_F(TransferEngineMetricsTest, SubmissionRollbackBalancesInflight) {
+    auto& m = metrics();
+
+    Transport::BatchDesc batch;
+    batch.task_list.emplace_back();
+    auto& task = batch.task_list.back();
+
+    TransferEngineImplTestPeer::markTaskSubmitted(task);
+    EXPECT_EQ(m.requestsTotal(), 1);
+    EXPECT_EQ(m.inflightTransfers(), 1);
+
+    TransferEngineImplTestPeer::rollbackTaskSubmission(task);
+    EXPECT_EQ(m.failuresTotal(), 1);
+    EXPECT_EQ(m.inflightTransfers(), 0);  // balanced
 }
 
 #endif  // WITH_METRICS


### PR DESCRIPTION
## Description

Adds standard Prometheus-style metrics to the **Classic Transfer Engine**,
closing the observability gap with TENT. This is the **first, intentionally
small PR** for #2713 — it does **not** unify the Classic TE and TENT metrics
implementations or refactor the architecture; that work is deferred to PR2.

Before this change, the Classic TE `WITH_METRICS` path was **log-only**: it
accumulated a bytes counter and a latency histogram and periodically printed a
throughput/latency line (gated on `MC_TE_METRIC`). There were no
standard-named counters, no inflight gauge, no failure/request counters, and no
HTTP export.

**What this PR adds**

A new `TransferEngineMetrics` singleton
(`mooncake-transfer-engine/include/transfer_engine_metrics.h` +
`src/transfer_engine_metrics.cpp`) that mirrors TENT's metric naming and
behavior:

| Metric | Type | Meaning |
|--------|------|---------|
| `transfer_requests_total` | Counter | Total transfer tasks submitted |
| `transfer_bytes_total` | Counter | Total bytes transferred (successful tasks) |
| `transfer_failures_total` | Counter | Tasks that failed / canceled / timed out |
| `transfer_latency_seconds` | Histogram | Completion latency (successful tasks) |
| `transfer_size_bytes` | Histogram | Transfer request size distribution |
| `inflight_transfers` | Gauge | Transfers submitted but not yet terminal |

**Design highlights**

- **Exactly-once recording** reuses the existing `TransferEngineImpl` anchors:
  `recordSubmitted()` fires once per task when `start_time` is first set at
  submit; the terminal branch of `getTransferStatus()` records exactly one
  `recordCompleted()`/`recordFailed()` and immediately resets `start_time`, so
  repeated status polling never double-counts. FAILED/CANCELED/TIMEOUT all map
  to a failure and clear the inflight slot.
- **HTTP export is opt-in.** A coro_http server exposes the same endpoints as
  TENT (`/metrics`, `/metrics/summary`, `/metrics/json`, `/health`) and only
  starts when `MC_TE_METRIC_HTTP_PORT` is set, so default behavior is
  unchanged. `transfer_engine` already links `yalantinglibs`, so no new
  dependency is introduced.
- **Existing logging is preserved unchanged** — the new metrics are purely
  additive.
- Gated by the existing `WITH_METRICS` compile flag (fully compiled out
  otherwise) and a runtime `setEnabled(false)` switch that short-circuits after
  a single atomic load. Initialization is idempotent across engine instances.
- The latency histogram is serialized manually so the Prometheus-conventional
  `_seconds` unit is kept and always emitted (ylt stores a histogram `_sum` in
  an int64 gauge and suppresses serialization for sub-second sums).

**New environment variables** (documented in the Transfer Engine design docs):

- `MC_TE_METRIC` — enable metrics collection (existing switch, now also drives
  the standard metrics)
- `MC_TE_METRIC_HTTP_PORT` — HTTP export port (0/unset = disabled)
- `MC_TE_METRIC_HTTP_HOST` — bind address (default `0.0.0.0`)
- `MC_TE_METRIC_HTTP_THREADS` — HTTP worker threads (default 1)

Relates to #2713.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Added `transfer_engine_metrics_test` (7 tests). It verifies the required
behaviors both through the `TransferEngineMetrics` API directly and end-to-end
through the real `TransferEngineImpl::getTransferStatus` path with a fake
transport:

- successful transfer records bytes and latency
- failed transfer records a failure (and no latency)
- inflight gauge tracks concurrent transfers and returns to zero
- Prometheus output contains all six standard metrics
- runtime-disabled collection records nothing
- **duplicate completion polling does not duplicate metrics** (COMPLETED and
  FAILED variants)

`transport_uint_test` still passes (no regression).

**Test commands:**
```bash
# Configure with metrics enabled (default) and build the test
cmake -DWITH_METRICS=ON -S . -B build
cmake --build build --target transfer_engine_metrics_test transport_uint_test

# Run
cd build && ctest -R "transfer_engine_metrics_test|transport_uint_test" --output-on-failure
```

**Test results:**
```
1/2 Test #3: transport_uint_test ..............   Passed    6.16 sec
2/2 Test #4: transfer_engine_metrics_test .....   Passed    2.05 sec
100% tests passed, 0 tests failed out of 2
```

- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (verified `/metrics`, `/metrics/json`, and
  `/metrics/summary` output is well-formed Prometheus/JSON text)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

> Note on formatting: the repo's `./scripts/code_format.sh` requires
> `clang-format` v20. New C/C++ and CMake files were verified clean with the
> standalone `clang-format` / `cmake-format` pre-commit hooks; please run the
> v20 formatter if CI enforces it. Only the lines this PR adds are changed —
> no unrelated reformatting is included.

## Remaining work for PR2

- Unify Classic TE and TENT metrics behind a shared library (explicitly out of
  scope here).
- Optionally reconcile the two config surfaces (TENT's JSON / `TENT_METRICS_*`
  vs. the Classic TE `MC_TE_METRIC_*` env vars).
- Consider per-transport or read-vs-write label breakdowns if desired.