### PR TITLE
[TE] Improve RDMA NIC failover recovery

### DIFF
--- a/mooncake-transfer-engine/include/config.h
+++ b/mooncake-transfer-engine/include/config.h
@@ -59,6 +59,9 @@ struct GlobalConfig {
     // torn-down pod IP) it stalls for the kernel's full SYN-retry cycle,
     // which is minutes. Override via MC_HANDSHAKE_CONNECT_TIMEOUT.
     int handshake_connect_timeout = 5;
+    // Cooldown before retrying a failed RDMA peer rail. Override via
+    // MC_RDMA_RAIL_PAUSE_SECONDS.
+    uint64_t rdma_rail_pause_seconds = 30;
     bool metacache = true;
     // Periodically refresh Transfer Engine metadata-derived local caches. 0
     // disables the background poller and preserves the manual

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
@@ -105,6 +105,7 @@ struct DmabufExport {
 class RdmaContext {
    public:
     friend class RdmaContextTestPeer;
+    friend class WorkerPool;
 
     RdmaContext(RdmaTransport &engine, const std::string &device_name);
 

--- a/mooncake-transfer-engine/include/transport/rdma_transport/worker_pool.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/worker_pool.h
@@ -22,7 +22,10 @@
 #include "rdma_context.h"
 
 namespace mooncake {
+class WorkerPoolTestPeer;
 class WorkerPool {
+    friend class WorkerPoolTestPeer;
+
    public:
     WorkerPool(RdmaContext &context, int numa_socket_id = 0);
 
@@ -37,11 +40,25 @@ class WorkerPool {
                              size_t first, size_t count);
 
    private:
+    using SliceList = std::vector<Transport::Slice *>;
+    const static int kShardCount = 8;
+
+    // Enqueue slices that were prepared by another WorkerPool. Used for
+    // local-NIC failure handoff: the original worker keeps the remote path
+    // fixed, updates the local lkey, and pushes the slice to this context's
+    // worker queue.
+    int submitPreparedPostSend(
+        const std::vector<Transport::Slice *> &slice_list);
+    void enqueuePreparedSlices(
+        SliceList (&slice_list_map)[kShardCount],
+        uint64_t submitted_slice_count);
+
     void performPostSend(int thread_id);
 
     void performPollCq(int thread_id);
 
-    void redispatch(std::vector<Transport::Slice *> &slice_list, int thread_id);
+    void redispatch(std::vector<Transport::Slice *> &slice_list, int thread_id,
+                    bool handoff_to_local_worker = false);
 
     void transferWorker(int thread_id);
 
@@ -50,6 +67,7 @@ class WorkerPool {
     void monitorWorker();
 
     int doProcessContextEvents();
+    void processContextEventForTest(ibv_event_type event_type);
 
     // Simplified rail monitor: pause problematic paths for a cooldown period
     struct RailState {
@@ -57,36 +75,55 @@ class WorkerPool {
         uint64_t pause_until_ns = 0;  // Timestamp (ns) when pause expires
     };
 
-    void markRailFailed(const std::string &peer_nic_path);
+    void markRailFailed(const std::string &peer_nic_path,
+                        bool immediate_pause = false);
     bool isRailAvailable(const std::string &peer_nic_path);
 
     // Retry helper: increment retry count and return whether retry is allowed
     static bool shouldRetrySlice(Transport::Slice *slice);
 
-    // Unified path failure handler: marks rail failed, notifies other workers,
-    // and optionally deletes the endpoint
-    void handlePathFailure(const std::string &peer_nic_path,
-                           RdmaEndPoint *endpoint = nullptr);
     void refreshPublishedLocalTopology();
     GidRefreshResult refreshPublishedLocalGid();
+    void scheduleContextRecovery(
+        uint64_t delay_ns = kContextRecoveryDelayNs);
+    void maybeActivateRecoveredContext();
+    bool hasAvailablePeerRailAlternative(Transport::Slice *slice,
+                                         const std::string &failed_peer_path);
+
+    static bool isLocalWcFailure(const ibv_wc &wc);
+
+    // Local-side failure handler: degrade current context so retries are
+    // handed off to another local context's worker pool.
+    void handleLocalFailure(const std::string &peer_nic_path,
+                            RdmaEndPoint *endpoint = nullptr);
+
+    bool tryHandoffToAnotherLocalWorker(Transport::Slice *slice);
 
     // Context-level health tracking for catastrophic hardware failure.
     // When all rails through a local RNIC are unavailable, increment the
     // failure counter. Reset on any success. Mark context inactive after
     // consecutive failures exceed threshold.
     bool contextHealthy() const {
-        return context_failure_count_ < kContextFailureThreshold;
+        return context_failure_count_.load(std::memory_order_relaxed) <
+               kContextFailureThreshold;
     }
-    void markContextSuccess() { context_failure_count_ = 0; }
-    void markContextFailure() {
-        context_failure_count_++;
-        if (context_failure_count_ >= kContextFailureThreshold) {
-            LOG(WARNING) << "All rails failed for context "
-                         << context_.deviceName() << " for "
-                         << context_failure_count_
-                         << " consecutive attempts, marking inactive";
-            context_.set_active(false);
+    void markContextSuccess() {
+        context_failure_count_.store(0, std::memory_order_relaxed);
+    }
+    bool markContextFailure() {
+        auto failure_count =
+            context_failure_count_.fetch_add(1, std::memory_order_relaxed) + 1;
+        if (failure_count >= kContextFailureThreshold) {
+            if (context_.active()) {
+                LOG(WARNING) << "All rails failed for context "
+                             << context_.deviceName() << " for "
+                             << failure_count
+                             << " consecutive attempts, marking inactive";
+                context_.set_active(false);
+                return true;
+            }
         }
+        return false;
     }
 
    private:
@@ -113,9 +150,6 @@ class WorkerPool {
     std::mutex cond_mutex_;
     std::condition_variable cond_var_;
 
-    using SliceList = std::vector<Transport::Slice *>;
-
-    const static int kShardCount = 8;
     std::unordered_map<std::string, SliceList> slice_queue_[kShardCount];
     std::atomic<uint64_t> slice_queue_count_[kShardCount];
     TicketLock slice_queue_lock_[kShardCount];
@@ -124,6 +158,7 @@ class WorkerPool {
         collective_slice_queue_;
 
     std::atomic<uint64_t> submitted_slice_count_, processed_slice_count_;
+    std::atomic<uint64_t> recovery_activate_after_ns_{0};
 
     // Rail state management: peer_nic_path -> RailState
     std::unordered_map<std::string, RailState> rail_states_;
@@ -131,10 +166,12 @@ class WorkerPool {
 
     // Rail monitor configuration
     const static int kRailErrorThreshold = 5;            // Errors before pause
-    const static uint64_t kRailPauseNs = 1000000000ull;  // 1 second pause
+    const static uint64_t kRailPauseNs = 30000000000ull;  // 30 second pause
+    const static uint64_t kContextRecoveryDelayNs =
+        30000000000ull;  // 30 seconds before a recovered local RNIC is reused
 
     // Context-level health tracking
-    int context_failure_count_ = 0;
+    std::atomic<int> context_failure_count_{0};
     const static int kContextFailureThreshold =
         32;  // consecutive all-rails-failed
 };

--- a/mooncake-transfer-engine/include/transport/rdma_transport/worker_pool.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/worker_pool.h
@@ -49,9 +49,8 @@ class WorkerPool {
     // worker queue.
     int submitPreparedPostSend(
         const std::vector<Transport::Slice *> &slice_list);
-    void enqueuePreparedSlices(
-        SliceList (&slice_list_map)[kShardCount],
-        uint64_t submitted_slice_count);
+    void enqueuePreparedSlices(SliceList (&slice_list_map)[kShardCount],
+                               uint64_t submitted_slice_count);
 
     void performPostSend(int thread_id);
 
@@ -84,8 +83,7 @@ class WorkerPool {
 
     void refreshPublishedLocalTopology();
     GidRefreshResult refreshPublishedLocalGid();
-    void scheduleContextRecovery(
-        uint64_t delay_ns = kContextRecoveryDelayNs);
+    void scheduleContextRecovery(uint64_t delay_ns = kContextRecoveryDelayNs);
     void maybeActivateRecoveredContext();
     bool hasAvailablePeerRailAlternative(Transport::Slice *slice,
                                          const std::string &failed_peer_path);
@@ -115,10 +113,10 @@ class WorkerPool {
             context_failure_count_.fetch_add(1, std::memory_order_relaxed) + 1;
         if (failure_count >= kContextFailureThreshold) {
             if (context_.active()) {
-                LOG(WARNING) << "All rails failed for context "
-                             << context_.deviceName() << " for "
-                             << failure_count
-                             << " consecutive attempts, marking inactive";
+                LOG(WARNING)
+                    << "All rails failed for context " << context_.deviceName()
+                    << " for " << failure_count
+                    << " consecutive attempts, marking inactive";
                 context_.set_active(false);
                 return true;
             }
@@ -165,7 +163,7 @@ class WorkerPool {
     std::mutex rail_state_lock_;
 
     // Rail monitor configuration
-    const static int kRailErrorThreshold = 5;            // Errors before pause
+    const static int kRailErrorThreshold = 5;             // Errors before pause
     const static uint64_t kRailPauseNs = 30000000000ull;  // 30 second pause
     const static uint64_t kContextRecoveryDelayNs =
         30000000000ull;  // 30 seconds before a recovered local RNIC is reused

--- a/mooncake-transfer-engine/include/transport/rdma_transport/worker_pool.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/worker_pool.h
@@ -83,6 +83,8 @@ class WorkerPool {
 
     void refreshPublishedLocalTopology();
     GidRefreshResult refreshPublishedLocalGid();
+    bool handleContextEvent(ibv_event_type event_type, bool injected_for_test,
+                            struct ibv_async_event *event = nullptr);
     void scheduleContextRecovery(uint64_t delay_ns = kContextRecoveryDelayNs);
     void maybeActivateRecoveredContext();
     bool hasAvailablePeerRailAlternative(Transport::Slice *slice,
@@ -163,8 +165,7 @@ class WorkerPool {
     std::mutex rail_state_lock_;
 
     // Rail monitor configuration
-    const static int kRailErrorThreshold = 5;             // Errors before pause
-    const static uint64_t kRailPauseNs = 30000000000ull;  // 30 second pause
+    const static int kRailErrorThreshold = 5;  // Errors before pause
     const static uint64_t kContextRecoveryDelayNs =
         30000000000ull;  // 30 seconds before a recovered local RNIC is reused
 

--- a/mooncake-transfer-engine/scripts/real_rdma_link_failover.sh
+++ b/mooncake-transfer-engine/scripts/real_rdma_link_failover.sh
@@ -1,0 +1,389 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BUILD_DIR="${BUILD_DIR:-$ROOT_DIR/build}"
+BENCH="${BENCH:-$BUILD_DIR/mooncake-transfer-engine/example/transfer_engine_bench}"
+VALIDATOR="${VALIDATOR:-$BUILD_DIR/mooncake-transfer-engine/example/transfer_engine_validator}"
+LOG_DIR="${LOG_DIR:-/tmp/mooncake-real-rdma-link-failover-$(date +%s)}"
+
+FAULT_SIDE="receiver"
+DOWN_AFTER_SEC=5
+DOWN_FOR_SEC=7
+DURATION_SEC=200
+TARGET_PRIMARY="mlx5_3"
+TARGET_AVAILABLE="mlx5_4"
+SENDER_PRIMARY="mlx5_2"
+SENDER_AVAILABLE="mlx5_1"
+NETDEV_OVERRIDE=""
+VALIDATE_DATA="${VALIDATE_DATA:-1}"
+
+usage() {
+    cat <<EOF
+Usage:
+  $0 [options]
+
+Options:
+  --fault-side sender|receiver   Which side's primary RNIC to link down.
+                                 Default: receiver
+  --target-primary DEV           Target primary RNIC. Default: mlx5_3
+  --target-available DEV         Target available/fallback RNIC. Default: mlx5_4
+  --sender-primary DEV           Sender primary RNIC. Default: mlx5_2
+  --sender-available DEV         Sender available/fallback RNIC. Default: mlx5_1
+  --target-pref DEV              Alias for --target-primary.
+  --target-fallback DEV          Alias for --target-available.
+  --sender-pref DEV              Alias for --sender-primary.
+  --sender-fallback DEV          Alias for --sender-available.
+  --netdev IFACE                 Override Linux netdev to down/up.
+  --down-after SEC               Seconds after initiator starts before down.
+                                 Default: 5
+  --down-for SEC                 Seconds to keep the link down. Default: 7
+  --duration SEC                 Initiator transfer duration. Default: 200
+  --log-dir DIR                  Log/output directory.
+  --validate-data                Use transfer_engine_validator, which performs
+                                 write/read/memcmp integrity checks.
+  --no-validate-data             Use transfer_engine_bench.
+
+Examples:
+  sudo $0 --fault-side receiver
+  sudo $0 --fault-side sender
+  sudo $0 --fault-side sender
+  sudo $0 --fault-side sender --sender-primary mlx5_2 --sender-available mlx5_1
+  sudo $0 --fault-side receiver --target-primary mlx5_3 --target-available mlx5_4
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --fault-side) FAULT_SIDE="$2"; shift 2 ;;
+        --target-primary|--target-pref) TARGET_PRIMARY="$2"; shift 2 ;;
+        --target-available|--target-fallback) TARGET_AVAILABLE="$2"; shift 2 ;;
+        --sender-primary|--sender-pref) SENDER_PRIMARY="$2"; shift 2 ;;
+        --sender-available|--sender-fallback) SENDER_AVAILABLE="$2"; shift 2 ;;
+        --netdev) NETDEV_OVERRIDE="$2"; shift 2 ;;
+        --down-after) DOWN_AFTER_SEC="$2"; shift 2 ;;
+        --down-for) DOWN_FOR_SEC="$2"; shift 2 ;;
+        --duration) DURATION_SEC="$2"; shift 2 ;;
+        --log-dir) LOG_DIR="$2"; shift 2 ;;
+        --validate-data) VALIDATE_DATA=1; shift ;;
+        --no-validate-data) VALIDATE_DATA=0; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "Unknown argument: $1" >&2; usage; exit 2 ;;
+    esac
+done
+
+if [[ "$FAULT_SIDE" != "sender" && "$FAULT_SIDE" != "receiver" ]]; then
+    echo "--fault-side must be sender or receiver" >&2
+    exit 2
+fi
+
+validate_single_rnic() {
+    local label="$1"
+    local value="$2"
+    if [[ -z "$value" ]]; then
+        echo "$label RNIC must not be empty" >&2
+        exit 2
+    fi
+    if [[ "$value" == *,* ]]; then
+        echo "$label RNIC must be exactly one device for this failover validation: $value" >&2
+        exit 2
+    fi
+}
+
+validate_pair() {
+    local side="$1"
+    local primary="$2"
+    local available="$3"
+    validate_single_rnic "$side primary" "$primary"
+    validate_single_rnic "$side available" "$available"
+    if [[ "$primary" == "$available" ]]; then
+        echo "$side primary and available RNIC must be different: $primary" >&2
+        exit 2
+    fi
+}
+
+validate_pair "target" "$TARGET_PRIMARY" "$TARGET_AVAILABLE"
+validate_pair "sender" "$SENDER_PRIMARY" "$SENDER_AVAILABLE"
+
+run_privileged() {
+    if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
+        "$@"
+    else
+        sudo "$@"
+    fi
+}
+
+require_privilege() {
+    if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
+        return
+    fi
+    if ! sudo -n true 2>/dev/null; then
+        echo "This test must change link state. Run it with sudo, for example:" >&2
+        echo "  sudo $0 --fault-side $FAULT_SIDE" >&2
+        exit 1
+    fi
+}
+
+rdma_to_netdev() {
+    local rdma_dev="$1"
+    local ndev_dir="/sys/class/infiniband/$rdma_dev/ports/1/gid_attrs/ndevs"
+    if [[ ! -d "$ndev_dir" ]]; then
+        echo "Cannot find $ndev_dir for RDMA device $rdma_dev" >&2
+        return 1
+    fi
+
+    local netdev=""
+    local entry value
+    while IFS= read -r entry; do
+        value="$(cat "$entry" 2>/dev/null || true)"
+        value="${value%%[[:space:]]*}"
+        if [[ -n "$value" && "$value" != "(null)" &&
+              -e "/sys/class/net/$value" ]]; then
+            netdev="$value"
+            break
+        fi
+    done < <(find "$ndev_dir" -maxdepth 1 -type f -printf '%f %p\n' |
+             sort -n |
+             awk '{ print $2 }')
+    if [[ -z "$netdev" ]]; then
+        echo "No Linux netdev found under $ndev_dir for RDMA device $rdma_dev" >&2
+        return 1
+    fi
+    printf '%s\n' "$netdev"
+}
+
+make_matrix() {
+    local preferred="$1"
+    local fallback="$2"
+    printf '{"cpu:0":[[%s],[%s]],"cpu:1":[[%s],[%s]]}\n' \
+        "$(quote_csv "$preferred")" "$(quote_csv "$fallback")" \
+        "$(quote_csv "$preferred")" "$(quote_csv "$fallback")"
+}
+
+quote_csv() {
+    local csv="$1"
+    local out=""
+    local item
+    IFS=',' read -ra parts <<< "$csv"
+    for item in "${parts[@]}"; do
+        [[ -z "$item" ]] && continue
+        if [[ -n "$out" ]]; then out+=","; fi
+        out+="\"$item\""
+    done
+    printf '%s' "$out"
+}
+
+wait_for_log() {
+    local file="$1"
+    local pattern="$2"
+    local timeout="$3"
+    local deadline=$((SECONDS + timeout))
+    while (( SECONDS < deadline )); do
+        if [[ -f "$file" ]] && grep -q "$pattern" "$file"; then
+            return 0
+        fi
+        sleep 0.2
+    done
+    return 1
+}
+
+RUNNER="$BENCH"
+BUILD_TARGET="transfer_engine_bench"
+if [[ "$VALIDATE_DATA" == "1" ]]; then
+    RUNNER="$VALIDATOR"
+    BUILD_TARGET="transfer_engine_validator"
+fi
+
+if [[ "${SKIP_BUILD:-0}" != "1" ]]; then
+    echo "Building $BUILD_TARGET at $RUNNER ..."
+    cmake --build "$BUILD_DIR" --target "$BUILD_TARGET" -j"$(nproc)"
+elif [[ ! -x "$RUNNER" ]]; then
+    echo "$BUILD_TARGET not found at $RUNNER and SKIP_BUILD=1" >&2
+    exit 1
+fi
+
+require_privilege
+
+FAULT_RDMA="$TARGET_PRIMARY"
+if [[ "$FAULT_SIDE" == "sender" ]]; then
+    FAULT_RDMA="$SENDER_PRIMARY"
+fi
+
+FAULT_NETDEV="$NETDEV_OVERRIDE"
+if [[ -z "$FAULT_NETDEV" ]]; then
+    FAULT_NETDEV="$(rdma_to_netdev "$FAULT_RDMA")"
+fi
+
+mkdir -p "$LOG_DIR"
+TARGET_MATRIX_FILE="$LOG_DIR/target_nic_priority.json"
+SENDER_MATRIX_FILE="$LOG_DIR/sender_nic_priority.json"
+TARGET_LOG="$LOG_DIR/target.log"
+INITIATOR_LOG="$LOG_DIR/initiator.log"
+
+make_matrix "$TARGET_PRIMARY" "$TARGET_AVAILABLE" > "$TARGET_MATRIX_FILE"
+make_matrix "$SENDER_PRIMARY" "$SENDER_AVAILABLE" > "$SENDER_MATRIX_FILE"
+
+TARGET_PORT="${TARGET_PORT:-$((30000 + RANDOM % 10000))}"
+INITIATOR_PORT="${INITIATOR_PORT:-$((40000 + RANDOM % 10000))}"
+TARGET_SERVER="127.0.0.1:$TARGET_PORT"
+INITIATOR_SERVER="127.0.0.1:$INITIATOR_PORT"
+
+COMMON_FLAGS=(
+    --metadata_server=P2PHANDSHAKE
+    --protocol=rdma
+    --buffer_size=$((256 * 1024 * 1024))
+    --block_size=$((4 * 1024 * 1024))
+    --batch_size=1
+    --threads=1
+    --duration="$DURATION_SEC"
+)
+
+if [[ "$VALIDATE_DATA" != "1" ]]; then
+    COMMON_FLAGS+=(--operation=write)
+fi
+
+if "$RUNNER" --help 2>&1 | grep -q -- '--use_vram'; then
+    COMMON_FLAGS+=(--use_vram=false)
+fi
+
+TARGET_PID=""
+LINK_WAS_DOWN=0
+
+cleanup() {
+    local rc=$?
+    if [[ "$LINK_WAS_DOWN" -eq 1 ]]; then
+        echo "[cleanup] Restoring $FAULT_NETDEV up"
+        run_privileged ip link set "$FAULT_NETDEV" up || true
+    fi
+    if [[ -n "$TARGET_PID" ]] && kill -0 "$TARGET_PID" 2>/dev/null; then
+        kill -TERM "$TARGET_PID" 2>/dev/null || true
+        wait "$TARGET_PID" 2>/dev/null || true
+    fi
+    exit "$rc"
+}
+trap cleanup EXIT INT TERM
+
+echo "=== Real RDMA link failover test ==="
+echo "fault_side       : $FAULT_SIDE"
+echo "fault_rdma       : $FAULT_RDMA"
+echo "fault_netdev     : $FAULT_NETDEV"
+echo "target primary   : $TARGET_PRIMARY"
+echo "target available : $TARGET_AVAILABLE"
+echo "sender primary   : $SENDER_PRIMARY"
+echo "sender available : $SENDER_AVAILABLE"
+echo "target matrix    : $(cat "$TARGET_MATRIX_FILE")"
+echo "sender matrix    : $(cat "$SENDER_MATRIX_FILE")"
+echo "target server    : $TARGET_SERVER"
+echo "initiator server : $INITIATOR_SERVER"
+echo "runner           : $RUNNER"
+echo "validate_data    : $VALIDATE_DATA"
+echo "logs             : $LOG_DIR"
+echo
+echo "WARNING: this will run: ip link set $FAULT_NETDEV down; then up."
+echo
+
+"$RUNNER" "${COMMON_FLAGS[@]}" \
+    --mode=target \
+    --local_server_name="$TARGET_SERVER" \
+    --device_name="$TARGET_PRIMARY,$TARGET_AVAILABLE" \
+    --nic_priority_matrix="$TARGET_MATRIX_FILE" \
+    >"$TARGET_LOG" 2>&1 &
+TARGET_PID=$!
+
+if ! wait_for_log "$TARGET_LOG" "RDMA device" 15; then
+    echo "Target did not start successfully. See $TARGET_LOG" >&2
+    exit 1
+fi
+
+TARGET_SEGMENT="$(
+    awk '/Transfer Engine RPC using P2P handshake, listening on / {
+        print $NF;
+        exit;
+    }' "$TARGET_LOG"
+)"
+if [[ -z "$TARGET_SEGMENT" ]]; then
+    TARGET_SEGMENT="$TARGET_SERVER"
+fi
+echo "target segment  : $TARGET_SEGMENT"
+
+"$RUNNER" "${COMMON_FLAGS[@]}" \
+    --mode=initiator \
+    --local_server_name="$INITIATOR_SERVER" \
+    --segment_id="$TARGET_SEGMENT" \
+    --device_name="$SENDER_PRIMARY,$SENDER_AVAILABLE" \
+    --nic_priority_matrix="$SENDER_MATRIX_FILE" \
+    >"$INITIATOR_LOG" 2>&1 &
+INITIATOR_PID=$!
+
+sleep "$DOWN_AFTER_SEC"
+
+echo "[$(date '+%F %T')] Bringing $FAULT_NETDEV down ($FAULT_RDMA)"
+run_privileged ip link set "$FAULT_NETDEV" down
+LINK_WAS_DOWN=1
+
+sleep "$DOWN_FOR_SEC"
+
+echo "[$(date '+%F %T')] Bringing $FAULT_NETDEV up ($FAULT_RDMA)"
+run_privileged ip link set "$FAULT_NETDEV" up
+LINK_WAS_DOWN=0
+
+set +e
+wait "$INITIATOR_PID"
+INITIATOR_RC=$?
+set -e
+
+kill -TERM "$TARGET_PID" 2>/dev/null || true
+wait "$TARGET_PID" 2>/dev/null || true
+TARGET_PID=""
+
+echo
+echo "=== Result ==="
+echo "initiator exit code: $INITIATOR_RC"
+echo "target log         : $TARGET_LOG"
+echo "initiator log      : $INITIATOR_LOG"
+
+if grep -E "FAILED|failed|Transport retry counter exceeded|Cannot make connection|KVTransferError|AddressNotRegistered|Detect data integrity problem" "$INITIATOR_LOG" "$TARGET_LOG" >/tmp/mooncake-real-link-failover-grep.$$ 2>/dev/null; then
+    echo
+    echo "Important failure-like log lines:"
+    tail -n 80 /tmp/mooncake-real-link-failover-grep.$$
+    rm -f /tmp/mooncake-real-link-failover-grep.$$
+fi
+
+if [[ "$FAULT_SIDE" == "sender" ]]; then
+    CHECK_LOG="$INITIATOR_LOG"
+    CHECK_PRIMARY="$SENDER_PRIMARY"
+    CHECK_AVAILABLE="$SENDER_AVAILABLE"
+else
+    CHECK_LOG="$TARGET_LOG"
+    CHECK_PRIMARY="$TARGET_PRIMARY"
+    CHECK_AVAILABLE="$TARGET_AVAILABLE"
+fi
+
+if ! grep -q "RDMA device: $CHECK_PRIMARY" "$CHECK_LOG"; then
+    echo "FAIL: $FAULT_SIDE primary RNIC $CHECK_PRIMARY was not initialized" >&2
+    exit 1
+fi
+if ! grep -q "RDMA device: $CHECK_AVAILABLE" "$CHECK_LOG"; then
+    echo "FAIL: $FAULT_SIDE available RNIC $CHECK_AVAILABLE was not initialized" >&2
+    exit 1
+fi
+if ! grep -q "Context $CHECK_PRIMARY is now inactive" "$CHECK_LOG"; then
+    echo "FAIL: did not observe $FAULT_SIDE primary RNIC $CHECK_PRIMARY going inactive" >&2
+    exit 1
+fi
+if grep -q "Context $CHECK_AVAILABLE is now inactive" "$CHECK_LOG"; then
+    echo "FAIL: $FAULT_SIDE available RNIC $CHECK_AVAILABLE also went inactive" >&2
+    exit 1
+fi
+
+if [[ "$INITIATOR_RC" -ne 0 ]]; then
+    echo "FAIL: initiator exited non-zero"
+    exit "$INITIATOR_RC"
+fi
+
+if ! grep -q "Test completed" "$INITIATOR_LOG"; then
+    echo "FAIL: initiator did not report completion"
+    exit 1
+fi
+
+echo "PASS: transfer completed across real $FAULT_RDMA/$FAULT_NETDEV down/up"

--- a/mooncake-transfer-engine/scripts/real_rdma_link_failover.sh
+++ b/mooncake-transfer-engine/scripts/real_rdma_link_failover.sh
@@ -342,11 +342,11 @@ echo "initiator exit code: $INITIATOR_RC"
 echo "target log         : $TARGET_LOG"
 echo "initiator log      : $INITIATOR_LOG"
 
-if grep -E "FAILED|failed|Transport retry counter exceeded|Cannot make connection|KVTransferError|AddressNotRegistered|Detect data integrity problem" "$INITIATOR_LOG" "$TARGET_LOG" >/tmp/mooncake-real-link-failover-grep.$$ 2>/dev/null; then
+grep_output="$(grep -E "FAILED|failed|Transport retry counter exceeded|Cannot make connection|KVTransferError|AddressNotRegistered|Detect data integrity problem" "$INITIATOR_LOG" "$TARGET_LOG" 2>/dev/null | tail -n 80 || true)"
+if [[ -n "$grep_output" ]]; then
     echo
     echo "Important failure-like log lines:"
-    tail -n 80 /tmp/mooncake-real-link-failover-grep.$$
-    rm -f /tmp/mooncake-real-link-failover-grep.$$
+    echo "$grep_output"
 fi
 
 if [[ "$FAULT_SIDE" == "sender" ]]; then

--- a/mooncake-transfer-engine/src/config.cpp
+++ b/mooncake-transfer-engine/src/config.cpp
@@ -367,6 +367,24 @@ void loadGlobalConfig(GlobalConfig& config) {
                             "MC_HANDSHAKE_CONNECT_TIMEOUT";
     }
 
+    const char* rdma_rail_pause_seconds =
+        std::getenv("MC_RDMA_RAIL_PAUSE_SECONDS");
+    if (rdma_rail_pause_seconds) {
+        try {
+            int val = std::stoi(rdma_rail_pause_seconds);
+            if (val > 0 && val < 3600) {
+                config.rdma_rail_pause_seconds = static_cast<uint64_t>(val);
+            } else {
+                LOG(WARNING) << "Ignore value from environment variable "
+                                "MC_RDMA_RAIL_PAUSE_SECONDS";
+            }
+        } catch (const std::exception& e) {
+            LOG(WARNING) << "Invalid MC_RDMA_RAIL_PAUSE_SECONDS environment "
+                            "value: "
+                         << rdma_rail_pause_seconds << ". Error: " << e.what();
+        }
+    }
+
     const char* log_level = std::getenv("MC_LOG_LEVEL");
     config.trace = false;
     if (log_level) {
@@ -662,6 +680,8 @@ void dumpGlobalConfig() {
     LOG(INFO) << "ib_service_level = " << config.ib_service_level;
     LOG(INFO) << "te_metadata_refresh_interval_seconds = "
               << config.te_metadata_refresh_interval_seconds;
+    LOG(INFO) << "rdma_rail_pause_seconds = "
+              << config.rdma_rail_pause_seconds;
     {
         std::ostringstream oss;
         for (size_t i = 0; i < config.mlx5_qp_udp_sports.size(); ++i) {

--- a/mooncake-transfer-engine/src/config.cpp
+++ b/mooncake-transfer-engine/src/config.cpp
@@ -680,8 +680,7 @@ void dumpGlobalConfig() {
     LOG(INFO) << "ib_service_level = " << config.ib_service_level;
     LOG(INFO) << "te_metadata_refresh_interval_seconds = "
               << config.te_metadata_refresh_interval_seconds;
-    LOG(INFO) << "rdma_rail_pause_seconds = "
-              << config.rdma_rail_pause_seconds;
+    LOG(INFO) << "rdma_rail_pause_seconds = " << config.rdma_rail_pause_seconds;
     {
         std::ostringstream oss;
         for (size_t i = 0; i < config.mlx5_qp_udp_sports.size(); ++i) {

--- a/mooncake-transfer-engine/src/topology.cpp
+++ b/mooncake-transfer-engine/src/topology.cpp
@@ -835,8 +835,8 @@ int Topology::disableDevice(const std::string &device_name) {
     int disabled_hca_index = -1;
     auto hca_iter = std::find(hca_list_.begin(), hca_list_.end(), device_name);
     if (hca_iter != hca_list_.end()) {
-        disabled_hca_index = static_cast<int>(
-            std::distance(hca_list_.begin(), hca_iter));
+        disabled_hca_index =
+            static_cast<int>(std::distance(hca_list_.begin(), hca_iter));
     }
 
     for (auto &record : matrix_) {
@@ -859,16 +859,16 @@ int Topology::disableDevice(const std::string &device_name) {
     // at the wrong RNIC.
     for (auto &record : resolved_matrix_) {
         auto &preferred_hca = record.second.preferred_hca;
-        preferred_hca.erase(std::remove(preferred_hca.begin(),
-                                        preferred_hca.end(),
-                                        disabled_hca_index),
-                            preferred_hca.end());
+        preferred_hca.erase(
+            std::remove(preferred_hca.begin(), preferred_hca.end(),
+                        disabled_hca_index),
+            preferred_hca.end());
         record.second.preferred_hca_name_to_index_map_.erase(device_name);
 
         auto &avail_hca = record.second.avail_hca;
-        avail_hca.erase(std::remove(avail_hca.begin(), avail_hca.end(),
-                                    disabled_hca_index),
-                        avail_hca.end());
+        avail_hca.erase(
+            std::remove(avail_hca.begin(), avail_hca.end(), disabled_hca_index),
+            avail_hca.end());
         record.second.avail_hca_name_to_index_map_.erase(device_name);
     }
     return 0;

--- a/mooncake-transfer-engine/src/topology.cpp
+++ b/mooncake-transfer-engine/src/topology.cpp
@@ -871,6 +871,15 @@ int Topology::disableDevice(const std::string &device_name) {
             avail_hca.end());
         record.second.avail_hca_name_to_index_map_.erase(device_name);
     }
+    for (auto &local_entry : resolved_hca_peer_affinity_by_local_) {
+        for (auto &storage_entry : local_entry.second) {
+            auto &candidates = storage_entry.second;
+            candidates.erase(
+                std::remove(candidates.begin(), candidates.end(),
+                            disabled_hca_index),
+                candidates.end());
+        }
+    }
     return 0;
 }
 }  // namespace mooncake

--- a/mooncake-transfer-engine/src/topology.cpp
+++ b/mooncake-transfer-engine/src/topology.cpp
@@ -874,10 +874,9 @@ int Topology::disableDevice(const std::string &device_name) {
     for (auto &local_entry : resolved_hca_peer_affinity_by_local_) {
         for (auto &storage_entry : local_entry.second) {
             auto &candidates = storage_entry.second;
-            candidates.erase(
-                std::remove(candidates.begin(), candidates.end(),
-                            disabled_hca_index),
-                candidates.end());
+            candidates.erase(std::remove(candidates.begin(), candidates.end(),
+                                         disabled_hca_index),
+                             candidates.end());
         }
     }
     return 0;

--- a/mooncake-transfer-engine/src/topology.cpp
+++ b/mooncake-transfer-engine/src/topology.cpp
@@ -760,6 +760,10 @@ int Topology::selectDevice(const std::string storage_type, int retry_count) {
     if (resolved_matrix_.count(storage_type) == 0) return ERR_DEVICE_NOT_FOUND;
 
     auto &entry = resolved_matrix_[storage_type];
+    if (entry.preferred_hca.empty() && entry.avail_hca.empty()) {
+        return ERR_DEVICE_NOT_FOUND;
+    }
+
     if (retry_count == 0) {
         int rand_value;
         if (use_round_robin_) {
@@ -782,7 +786,7 @@ int Topology::selectDevice(const std::string storage_type, int retry_count) {
             return entry.avail_hca[index];
         }
     }
-    return 0;
+    return ERR_DEVICE_NOT_FOUND;
 }
 
 int Topology::resolve() {
@@ -828,6 +832,13 @@ int Topology::resolve() {
 }
 
 int Topology::disableDevice(const std::string &device_name) {
+    int disabled_hca_index = -1;
+    auto hca_iter = std::find(hca_list_.begin(), hca_list_.end(), device_name);
+    if (hca_iter != hca_list_.end()) {
+        disabled_hca_index = static_cast<int>(
+            std::distance(hca_list_.begin(), hca_iter));
+    }
+
     for (auto &record : matrix_) {
         auto &preferred_hca = record.second.preferred_hca;
         auto preferred_hca_iter =
@@ -839,6 +850,27 @@ int Topology::disableDevice(const std::string &device_name) {
             std::find(avail_hca.begin(), avail_hca.end(), device_name);
         if (avail_hca_iter != avail_hca.end()) avail_hca.erase(avail_hca_iter);
     }
-    return resolve();
+
+    if (disabled_hca_index < 0) return 0;
+
+    // Keep existing HCA indexes stable. RDMA transport stores lkey/rkey and
+    // context arrays by the resolved HCA index, so re-running resolve() here
+    // could compact indexes after a disabled device and make those arrays point
+    // at the wrong RNIC.
+    for (auto &record : resolved_matrix_) {
+        auto &preferred_hca = record.second.preferred_hca;
+        preferred_hca.erase(std::remove(preferred_hca.begin(),
+                                        preferred_hca.end(),
+                                        disabled_hca_index),
+                            preferred_hca.end());
+        record.second.preferred_hca_name_to_index_map_.erase(device_name);
+
+        auto &avail_hca = record.second.avail_hca;
+        avail_hca.erase(std::remove(avail_hca.begin(), avail_hca.end(),
+                                    disabled_hca_index),
+                        avail_hca.end());
+        record.second.avail_hca_name_to_index_map_.erase(device_name);
+    }
+    return 0;
 }
 }  // namespace mooncake

--- a/mooncake-transfer-engine/src/transfer_metadata.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata.cpp
@@ -1414,8 +1414,7 @@ int TransferMetadata::startHandshakeDaemon(
                 if (ret) {
                     if (local_desc.reply_msg.empty()) {
                         local_desc.reply_msg =
-                            "Handshake callback failed: " +
-                            std::to_string(ret);
+                            "Handshake callback failed: " + std::to_string(ret);
                     }
                     // The callback failure is a handshake-level rejection, not
                     // an RPC handler failure. Return a structured reply so the

--- a/mooncake-transfer-engine/src/transfer_metadata.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata.cpp
@@ -1411,7 +1411,19 @@ int TransferMetadata::startHandshakeDaemon(
             TransferHandshakeUtil::decode(peer, peer_desc);
             if (on_receive_handshake) {
                 int ret = on_receive_handshake(peer_desc, local_desc);
-                if (ret) return ret;
+                if (ret) {
+                    if (local_desc.reply_msg.empty()) {
+                        local_desc.reply_msg =
+                            "Handshake callback failed: " +
+                            std::to_string(ret);
+                    }
+                    // The callback failure is a handshake-level rejection, not
+                    // an RPC handler failure. Return a structured reply so the
+                    // peer can report the rejection reason instead of seeing an
+                    // empty/undecodable handshake response.
+                    local = TransferHandshakeUtil::encode(local_desc);
+                    return 0;
+                }
             }
             local = TransferHandshakeUtil::encode(local_desc);
             return 0;

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -1191,8 +1191,7 @@ int RdmaEndPoint::doSetupConnection(int qp_index, const ibv_gid &peer_gid,
             "Failed to modify QP to RTR, check mtu, gid, peer lid, peer qp num";
         PLOG(ERROR) << "[Handshake] " << message
                     << ": local=" << context_.nicPath()
-                    << ", peer=" << peer_nic_path_
-                    << ", qp_index=" << qp_index
+                    << ", peer=" << peer_nic_path_ << ", qp_index=" << qp_index
                     << ", local_qp=" << qp->qp_num
                     << ", peer_qp=" << peer_qp_num
                     << ", local_gid=" << context_.gid()

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -77,6 +77,18 @@ static std::string qpListToString(const std::vector<uint32_t> &qp_num) {
     return oss.str();
 }
 
+static std::string gidToString(const ibv_gid &gid) {
+    char buffer[48];
+    snprintf(buffer, sizeof(buffer),
+             "%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:"
+             "%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x",
+             gid.raw[0], gid.raw[1], gid.raw[2], gid.raw[3], gid.raw[4],
+             gid.raw[5], gid.raw[6], gid.raw[7], gid.raw[8], gid.raw[9],
+             gid.raw[10], gid.raw[11], gid.raw[12], gid.raw[13], gid.raw[14],
+             gid.raw[15]);
+    return buffer;
+}
+
 RdmaEndPoint::RdmaEndPoint(RdmaContext &context)
     : context_(context),
       status_(INITIALIZING),
@@ -232,14 +244,22 @@ void RdmaEndPoint::beginDestroyLocked() {
     status_.store(DESTROYING, std::memory_order_release);
     ready_wait_start_ts_.store(0, std::memory_order_relaxed);
 
-    // Transition QPs to ERR state so hardware flushes all inflight WRs to CQ.
-    // This allows performPollCq to drain them naturally.
-    ibv_qp_attr attr;
-    memset(&attr, 0, sizeof(attr));
-    attr.qp_state = IBV_QPS_ERR;
+    // Only endpoints that reached CONNECTED can have user WRs to flush. For
+    // pre-connected endpoints, skip RESET/INIT -> ERR because there are no WRs
+    // and some providers reject that state transition.
+    if (!has_connected_) return;
+
+    // Transition connected QPs to ERR state so hardware flushes inflight WRs to
+    // CQ. This allows performPollCq to drain them naturally.
     for (size_t i = 0; i < qp_list_.size(); ++i) {
+        if (!qp_list_[i]) continue;
+
+        ibv_qp_attr attr;
+        memset(&attr, 0, sizeof(attr));
+        attr.qp_state = IBV_QPS_ERR;
         if (ibv_modify_qp(qp_list_[i], &attr, IBV_QP_STATE)) {
-            PLOG(WARNING) << "Failed to modify QP to ERR during beginDestroy";
+            PLOG(WARNING) << "Failed to modify QP[" << i
+                          << "] to ERR during beginDestroy";
         }
     }
 }
@@ -805,33 +825,17 @@ int RdmaEndPoint::disconnectUnlocked() {
     ready_wait_start_ts_.store(0, std::memory_order_relaxed);
 
     if (!has_connected_) {
-        // Pre-connected handshake retries are allowed to reuse this endpoint:
-        // no user WR has been posted yet. eRDMA still needs fresh QPs because
-        // a QP that reached RTS cannot be reliably reset back to RTS.
-#ifdef CONFIG_ERDMA
+        // This endpoint has not posted user WRs yet, but its handshake may
+        // already have reached the peer. The peer can cache our QP numbers and
+        // rebuild its passive endpoint around them before the active side sees
+        // a setup failure. Reusing the same local QPs after RESET would make a
+        // later retry ambiguous with that partially processed handshake, so
+        // retry with fresh QP numbers instead.
         for (size_t i = 0; i < qp_list_.size(); ++i) {
             CHECK_EQ(wr_depth_list_[i].load(std::memory_order_relaxed), 0)
                 << "Pre-connected endpoint must not have outstanding WRs";
         }
         return reconstruct();
-#else
-        ibv_qp_attr attr;
-        memset(&attr, 0, sizeof(attr));
-        attr.qp_state = IBV_QPS_RESET;
-        int ret = 0;
-        for (size_t i = 0; i < qp_list_.size(); ++i) {
-            int curr_ret = ibv_modify_qp(qp_list_[i], &attr, IBV_QP_STATE);
-            if (curr_ret) {
-                PLOG(ERROR) << "Failed to modify pre-connected QP to RESET";
-                ret = ERR_ENDPOINT;
-            }
-            CHECK_EQ(wr_depth_list_[i].load(std::memory_order_relaxed), 0)
-                << "Pre-connected endpoint must not have outstanding WRs";
-        }
-        peer_qp_num_list_.clear();
-        status_.store(UNCONNECTED, std::memory_order_release);
-        return ret;
-#endif
     }
 
     beginDestroyLocked();
@@ -1185,7 +1189,18 @@ int RdmaEndPoint::doSetupConnection(int qp_index, const ibv_gid &peer_gid,
     if (ret) {
         std::string message =
             "Failed to modify QP to RTR, check mtu, gid, peer lid, peer qp num";
-        PLOG(ERROR) << "[Handshake] " << message;
+        PLOG(ERROR) << "[Handshake] " << message
+                    << ": local=" << context_.nicPath()
+                    << ", peer=" << peer_nic_path_
+                    << ", qp_index=" << qp_index
+                    << ", local_qp=" << qp->qp_num
+                    << ", peer_qp=" << peer_qp_num
+                    << ", local_gid=" << context_.gid()
+                    << ", local_gid_index=" << local_gid_index
+                    << ", peer_gid=" << gidToString(peer_gid)
+                    << ", peer_lid=" << peer_lid
+                    << ", path_mtu=" << attr.path_mtu
+                    << ", port_num=" << static_cast<int>(context_.portNum());
         if (reply_msg) *reply_msg = message + ": " + strerror(errno);
         if (failure_info) {
             failure_info->stage = SetupConnectionFailureStage::kRtr;

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
@@ -615,9 +615,12 @@ Status RdmaTransport::submitTransferTask(
                 retry_cnt = request.advise_retry_cnt;
             bool found_device = false;
             if (request_buffer_id >= 0 && request_device_id >= 0) {
-                found_device = true;
-                buffer_id = request_buffer_id;
-                device_id = request_device_id;
+                auto &request_context = context_list_[request_device_id];
+                if (request_context && request_context->active()) {
+                    found_device = true;
+                    buffer_id = request_buffer_id;
+                    device_id = request_device_id;
+                }
             }
             while (retry_cnt < kMaxRetryCount && !found_device) {
                 if (selectDevice(local_segment_desc.get(),
@@ -741,7 +744,11 @@ RdmaTransport::SegmentID RdmaTransport::getSegmentID(
 int RdmaTransport::onSetupRdmaConnections(const HandShakeDesc &peer_desc,
                                           HandShakeDesc &local_desc) {
     auto local_nic_name = getNicNameFromNicPath(peer_desc.peer_nic_path);
-    if (local_nic_name.empty()) return ERR_INVALID_ARGUMENT;
+    if (local_nic_name.empty()) {
+        local_desc.reply_msg =
+            "Invalid peer_nic_path in handshake: " + peer_desc.peer_nic_path;
+        return ERR_INVALID_ARGUMENT;
+    }
 
     std::shared_ptr<RdmaContext> context;
     int index = 0;
@@ -752,13 +759,42 @@ int RdmaTransport::onSetupRdmaConnections(const HandShakeDesc &peer_desc,
         }
         index++;
     }
-    if (!context) return ERR_INVALID_ARGUMENT;
+    if (!context) {
+        local_desc.reply_msg =
+            "Local RDMA context not found for handshake NIC: " +
+            local_nic_name;
+        return ERR_INVALID_ARGUMENT;
+    }
 
     // Use existing endpoint or create new one.
     auto endpoint = context->endpoint(peer_desc.local_nic_path);
-    if (!endpoint) return ERR_ENDPOINT;
+    if (!endpoint) {
+        local_desc.reply_msg =
+            "Local RDMA endpoint unavailable for " + local_nic_name +
+            " <- " + peer_desc.local_nic_path;
+        return ERR_ENDPOINT;
+    }
     int ret = endpoint->setupConnectionsByPassive(peer_desc, local_desc);
-    if (endpoint->retired()) context->deleteEndpointByPtr(endpoint.get());
+    if (endpoint->retired()) {
+        context->deleteEndpointByPtr(endpoint.get());
+        if (ret == ERR_ENDPOINT) {
+            // setupConnectionsByPassive() can retire a stale endpoint before
+            // creating a usable passive connection for this incoming handshake.
+            // That is a local endpoint-store race, not necessarily a peer
+            // handshake failure, so absorb it once with a fresh endpoint.
+            local_desc = HandShakeDesc();
+            endpoint = context->endpoint(peer_desc.local_nic_path);
+            if (!endpoint) {
+                local_desc.reply_msg =
+                    "Fresh local RDMA endpoint unavailable after retiring "
+                    "stale endpoint for " +
+                    local_nic_name + " <- " + peer_desc.local_nic_path;
+                return ERR_ENDPOINT;
+            }
+            ret = endpoint->setupConnectionsByPassive(peer_desc, local_desc);
+            if (endpoint->retired()) context->deleteEndpointByPtr(endpoint.get());
+        }
+    }
     return ret;
 }
 

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
@@ -761,17 +761,16 @@ int RdmaTransport::onSetupRdmaConnections(const HandShakeDesc &peer_desc,
     }
     if (!context) {
         local_desc.reply_msg =
-            "Local RDMA context not found for handshake NIC: " +
-            local_nic_name;
+            "Local RDMA context not found for handshake NIC: " + local_nic_name;
         return ERR_INVALID_ARGUMENT;
     }
 
     // Use existing endpoint or create new one.
     auto endpoint = context->endpoint(peer_desc.local_nic_path);
     if (!endpoint) {
-        local_desc.reply_msg =
-            "Local RDMA endpoint unavailable for " + local_nic_name +
-            " <- " + peer_desc.local_nic_path;
+        local_desc.reply_msg = "Local RDMA endpoint unavailable for " +
+                               local_nic_name + " <- " +
+                               peer_desc.local_nic_path;
         return ERR_ENDPOINT;
     }
     int ret = endpoint->setupConnectionsByPassive(peer_desc, local_desc);
@@ -792,7 +791,8 @@ int RdmaTransport::onSetupRdmaConnections(const HandShakeDesc &peer_desc,
                 return ERR_ENDPOINT;
             }
             ret = endpoint->setupConnectionsByPassive(peer_desc, local_desc);
-            if (endpoint->retired()) context->deleteEndpointByPtr(endpoint.get());
+            if (endpoint->retired())
+                context->deleteEndpointByPtr(endpoint.get());
         }
     }
     return ret;

--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -957,11 +957,32 @@ int WorkerPool::doProcessContextEvents() {
          * endpoint.
          */
         context_.deleteEndpointByPtr(endpoint_ptr);
-    } else if (event.event_type == IBV_EVENT_DEVICE_FATAL ||
-               event.event_type == IBV_EVENT_CQ_ERR ||
-               event.event_type == IBV_EVENT_WQ_FATAL ||
-               event.event_type == IBV_EVENT_PORT_ERR ||
-               event.event_type == IBV_EVENT_LID_CHANGE) {
+    } else if (handleContextEvent(event.event_type, false, &event)) {
+        event_acked = true;
+    }
+
+    if (!event_acked) {
+        ibv_ack_async_event(&event);
+    }
+
+    return 0;
+}
+
+void WorkerPool::processContextEventForTest(ibv_event_type event_type) {
+    LOG(WARNING) << "Worker: Injected context async event "
+                 << ibv_event_type_str(event_type) << " for context "
+                 << context_.deviceName();
+
+    handleContextEvent(event_type, true);
+}
+
+bool WorkerPool::handleContextEvent(ibv_event_type event_type,
+                                    bool injected_for_test,
+                                    struct ibv_async_event *event) {
+    if (event_type == IBV_EVENT_DEVICE_FATAL ||
+        event_type == IBV_EVENT_CQ_ERR || event_type == IBV_EVENT_WQ_FATAL ||
+        event_type == IBV_EVENT_PORT_ERR ||
+        event_type == IBV_EVENT_LID_CHANGE) {
         recovery_activate_after_ns_.store(0, std::memory_order_relaxed);
         context_.set_active(false);
         refreshPublishedLocalTopology();
@@ -978,69 +999,38 @@ int WorkerPool::doProcessContextEvents() {
          *     Calling endpoint->disconnect(), which blocks as endpoint->lock_
          * is held by Thread A.
          */
-        ibv_ack_async_event(&event);
-        event_acked = true;
+        if (event != nullptr) ibv_ack_async_event(event);
 
         context_.disconnectAllEndpoints();
         LOG(INFO) << "Worker: Context " << context_.deviceName()
-                  << " is now inactive due to fatal event: "
-                  << event.event_type;
-    } else if (event.event_type == IBV_EVENT_GID_CHANGE) {
-        auto gid_refresh_result = refreshPublishedLocalGid();
-        ibv_ack_async_event(&event);
-        event_acked = true;
-
-        if (gid_refresh_result != GidRefreshResult::UNCHANGED) {
-            context_.disconnectAllEndpoints();
-            LOG(INFO) << "Worker: Context " << context_.deviceName()
-                      << " GID refresh result="
-                      << static_cast<int>(gid_refresh_result)
-                      << ", disconnected all endpoints";
-        }
-    } else if (event.event_type == IBV_EVENT_PORT_ACTIVE) {
-        // PORT_ACTIVE only means the link started coming back. Real mlx5/RoCE
-        // data path can still reject RTR for a while after link-up, so delay
-        // publishing this local RNIC back to metadata.
-        scheduleContextRecovery();
-    }
-
-    if (!event_acked) {
-        ibv_ack_async_event(&event);
-    }
-
-    return 0;
-}
-
-void WorkerPool::processContextEventForTest(ibv_event_type event_type) {
-    LOG(WARNING) << "Worker: Injected context async event "
-                 << ibv_event_type_str(event_type) << " for context "
-                 << context_.deviceName();
-
-    if (event_type == IBV_EVENT_DEVICE_FATAL ||
-        event_type == IBV_EVENT_CQ_ERR || event_type == IBV_EVENT_WQ_FATAL ||
-        event_type == IBV_EVENT_PORT_ERR ||
-        event_type == IBV_EVENT_LID_CHANGE) {
-        recovery_activate_after_ns_.store(0, std::memory_order_relaxed);
-        context_.set_active(false);
-        refreshPublishedLocalTopology();
-        context_.disconnectAllEndpoints();
-        LOG(INFO) << "Worker: Context " << context_.deviceName()
-                  << " is now inactive due to injected fatal event: "
+                  << " is now inactive due to "
+                  << (injected_for_test ? "injected fatal event: "
+                                        : "fatal event: ")
                   << event_type;
     } else if (event_type == IBV_EVENT_GID_CHANGE) {
         auto gid_refresh_result = refreshPublishedLocalGid();
+        if (event != nullptr) ibv_ack_async_event(event);
+
         if (gid_refresh_result != GidRefreshResult::UNCHANGED) {
             context_.disconnectAllEndpoints();
             LOG(INFO) << "Worker: Context " << context_.deviceName()
-                      << " injected GID refresh result="
+                      << (injected_for_test ? " injected GID refresh result="
+                                            : " GID refresh result=")
                       << static_cast<int>(gid_refresh_result)
                       << ", disconnected all endpoints";
         }
     } else if (event_type == IBV_EVENT_PORT_ACTIVE) {
-        // Match the real async-event path: injected recovery also waits before
-        // re-enabling the local RNIC.
+        // PORT_ACTIVE only means the link started coming back. Real mlx5/RoCE
+        // data path can still reject RTR for a while after link-up, so delay
+        // publishing this local RNIC back to metadata. Injected tests follow
+        // the same path.
         scheduleContextRecovery();
+        if (event != nullptr) ibv_ack_async_event(event);
+    } else {
+        return false;
     }
+
+    return true;
 }
 
 void WorkerPool::scheduleContextRecovery(uint64_t delay_ns) {
@@ -1308,10 +1298,12 @@ void WorkerPool::markRailFailed(const std::string &peer_nic_path,
         state.error_count = kRailErrorThreshold;
     }
     if (state.error_count >= kRailErrorThreshold) {
-        state.pause_until_ns = now + kRailPauseNs;
+        const uint64_t rail_pause_ns =
+            globalConfig().rdma_rail_pause_seconds * 1000000000ull;
+        state.pause_until_ns = now + rail_pause_ns;
         LOG(WARNING) << "Rail paused: peer=" << peer_nic_path
                      << " error_count=" << state.error_count
-                     << " pause_ms=" << kRailPauseNs / 1000000ull;
+                     << " pause_ms=" << rail_pause_ns / 1000000ull;
     }
 }
 

--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -1091,7 +1091,7 @@ void WorkerPool::maybeActivateRecoveredContext() {
 bool WorkerPool::hasAvailablePeerRailAlternative(
     Transport::Slice *slice, const std::string &failed_peer_path) {
     auto peer_segment_desc =
-        context_.engine().meta()->getSegmentDescByID(slice->target_id, true);
+        context_.engine().meta()->getSegmentDescByID(slice->target_id, false);
     if (!peer_segment_desc) return false;
 
     int buffer_id = -1;

--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -261,8 +261,8 @@ int WorkerPool::submitPostSend(
     return 0;
 }
 
-void WorkerPool::enqueuePreparedSlices(
-    SliceList (&slice_list_map)[kShardCount], uint64_t submitted_slice_count) {
+void WorkerPool::enqueuePreparedSlices(SliceList (&slice_list_map)[kShardCount],
+                                       uint64_t submitted_slice_count) {
     for (int shard_id = 0; shard_id < kShardCount; ++shard_id) {
         if (slice_list_map[shard_id].empty()) continue;
         slice_queue_lock_[shard_id].lock();
@@ -508,7 +508,8 @@ void WorkerPool::performPostSend(int thread_id) {
         if (!retry_list.empty()) {
             redispatch(retry_list, thread_id);
         }
-        if (!local_retry_list.empty()) redispatch(local_retry_list, thread_id, true);
+        if (!local_retry_list.empty())
+            redispatch(local_retry_list, thread_id, true);
     }
 }
 
@@ -566,12 +567,11 @@ void WorkerPool::performPollCq(int thread_id) {
                 if (wc[i].status == IBV_WC_WR_FLUSH_ERR) {
                     if (!context_.active()) {
                         if (globalConfig().trace)
-                            LOG(INFO) << "Worker: WR flush error on inactive "
-                                      << "local context "
-                                      << context_.deviceName()
-                                      << " (peer_nic: "
-                                      << slice->peer_nic_path
-                                      << "), handing off if retry allows";
+                            LOG(INFO)
+                                << "Worker: WR flush error on inactive "
+                                << "local context " << context_.deviceName()
+                                << " (peer_nic: " << slice->peer_nic_path
+                                << "), handing off if retry allows";
                         if (shouldRetrySlice(slice))
                             local_failed_slice_list.push_back(slice);
                         else {
@@ -678,7 +678,8 @@ void WorkerPool::redispatch(std::vector<Transport::Slice *> &slice_list,
             auto target_id = slice->target_id;
             if (!segment_desc_map.count(target_id)) {
                 segment_desc_map[target_id] =
-                    context_.engine().meta()->getSegmentDescByID(target_id, true);
+                    context_.engine().meta()->getSegmentDescByID(target_id,
+                                                                 true);
             }
         }
     }
@@ -751,9 +752,9 @@ void WorkerPool::redispatch(std::vector<Transport::Slice *> &slice_list,
                     LOG(ERROR)
                         << "Worker: Cannot redispatch slice because all peer "
                            "rails are paused for target "
-                        << slice->target_id << ", selected peer="
-                        << peer_nic_path << ", retry_cnt="
-                        << slice->rdma.retry_cnt;
+                        << slice->target_id
+                        << ", selected peer=" << peer_nic_path
+                        << ", retry_cnt=" << slice->rdma.retry_cnt;
                     slice->markFailed();
                     processed_slice_count_++;
                     continue;
@@ -838,7 +839,8 @@ bool WorkerPool::tryHandoffToAnotherLocalWorker(Transport::Slice *slice) {
             auto source = reinterpret_cast<uint64_t>(slice->source_addr);
             auto buffer_start = reinterpret_cast<uint64_t>(buffer.addr);
             auto buffer_end = buffer_start + buffer.length;
-            if (buffer_start <= source && source + slice->length <= buffer_end) {
+            if (buffer_start <= source &&
+                source + slice->length <= buffer_end) {
                 buffer_id = static_cast<int>(idx);
                 break;
             }
@@ -846,8 +848,9 @@ bool WorkerPool::tryHandoffToAnotherLocalWorker(Transport::Slice *slice) {
         if (buffer_id < 0) {
             continue;
         }
-        if (device_id >= static_cast<int>(
-                             local_segment_desc->buffers[buffer_id].lkey.size())) {
+        if (device_id >=
+            static_cast<int>(
+                local_segment_desc->buffers[buffer_id].lkey.size())) {
             continue;
         }
 
@@ -1042,10 +1045,11 @@ void WorkerPool::processContextEventForTest(ibv_event_type event_type) {
 
 void WorkerPool::scheduleContextRecovery(uint64_t delay_ns) {
     uint64_t activate_after = getCurrentTimeInNano() + delay_ns;
-    recovery_activate_after_ns_.store(activate_after, std::memory_order_relaxed);
+    recovery_activate_after_ns_.store(activate_after,
+                                      std::memory_order_relaxed);
     LOG(INFO) << "Worker: Context " << context_.deviceName()
-              << " scheduled recovery probe after "
-              << delay_ns / 1000000000ull << " seconds";
+              << " scheduled recovery probe after " << delay_ns / 1000000000ull
+              << " seconds";
 }
 
 void WorkerPool::maybeActivateRecoveredContext() {

--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -17,6 +17,7 @@
 #include <sys/epoll.h>
 
 #include <cassert>
+#include <functional>
 
 #include "config.h"
 #include "memory_location.h"
@@ -247,6 +248,21 @@ int WorkerPool::submitPostSend(
         submitted_slice_count++;
     }
 
+    enqueuePreparedSlices(slice_list_map, submitted_slice_count);
+
+    // Context-level health tracking: if all slices failed due to no available
+    // rails, increment the context failure counter. This detects catastrophic
+    // local RNIC hardware failure where all paths through the RNIC are down.
+    if (submitted_slice_count == 0 &&
+        all_rails_failed_count == (int)slice_list.size()) {
+        if (markContextFailure()) refreshPublishedLocalTopology();
+    }
+
+    return 0;
+}
+
+void WorkerPool::enqueuePreparedSlices(
+    SliceList (&slice_list_map)[kShardCount], uint64_t submitted_slice_count) {
     for (int shard_id = 0; shard_id < kShardCount; ++shard_id) {
         if (slice_list_map[shard_id].empty()) continue;
         slice_queue_lock_[shard_id].lock();
@@ -263,14 +279,28 @@ int WorkerPool::submitPostSend(
         std::lock_guard<std::mutex> lock(cond_mutex_);
         cond_var_.notify_all();
     }
+}
 
-    // Context-level health tracking: if all slices failed due to no available
-    // rails, increment the context failure counter. This detects catastrophic
-    // local RNIC hardware failure where all paths through the RNIC are down.
-    if (submitted_slice_count == 0 &&
-        all_rails_failed_count == (int)slice_list.size()) {
-        markContextFailure();
+int WorkerPool::submitPreparedPostSend(
+    const std::vector<Transport::Slice *> &slice_list) {
+    // Called by a different local RNIC's worker during local failover. The
+    // slice already carries the chosen peer_nic_path and refreshed local lkey,
+    // so enqueue it directly instead of running remote-path selection again.
+    SliceList slice_list_map[kShardCount];
+    uint64_t submitted_slice_count = 0;
+
+    for (auto &slice : slice_list) {
+        if (slice->peer_nic_path.empty()) {
+            slice->markFailed();
+            continue;
+        }
+        auto shard_id = static_cast<int>(
+            std::hash<std::string>{}(slice->peer_nic_path) % kShardCount);
+        slice_list_map[shard_id].push_back(slice);
+        submitted_slice_count++;
     }
+
+    enqueuePreparedSlices(slice_list_map, submitted_slice_count);
 
     return 0;
 }
@@ -299,27 +329,33 @@ void WorkerPool::performPostSend(int thread_id) {
     int post_tid = 0;
     int post_count = 0;
     getPostingShardAssignment(thread_id, post_tid, post_count);
+    auto &local_slice_queue = collective_slice_queue_[thread_id];
 
-    // Fast-fail if context is unhealthy due to catastrophic hardware failure
-    if (!contextHealthy()) {
+    // If this local RNIC is inactive/unhealthy, the remote rail is not the
+    // problem. Move queued work to another local RNIC while preserving the
+    // already selected peer rail.
+    if (!context_.active() || !contextHealthy()) {
+        auto local_slice_queue_clone = local_slice_queue;
+        local_slice_queue.clear();
+        for (auto &entry : local_slice_queue_clone)
+            redispatch(entry.second, thread_id, true);
+
         for (int shard_id = post_tid; shard_id < kShardCount;
              shard_id += post_count) {
             if (slice_queue_count_[shard_id].load(std::memory_order_relaxed) ==
                 0)
                 continue;
             slice_queue_lock_[shard_id].lock();
-            for (auto &entry : slice_queue_[shard_id]) {
-                for (auto &slice : entry.second) slice->markFailed();
-                processed_slice_count_ += entry.second.size();
-            }
+            auto slice_queue_clone = slice_queue_[shard_id];
             slice_queue_[shard_id].clear();
             slice_queue_count_[shard_id].store(0, std::memory_order_relaxed);
             slice_queue_lock_[shard_id].unlock();
+            for (auto &entry : slice_queue_clone)
+                redispatch(entry.second, thread_id, true);
         }
         return;
     }
 
-    auto &local_slice_queue = collective_slice_queue_[thread_id];
     for (int shard_id = post_tid; shard_id < kShardCount;
          shard_id += post_count) {
         if (slice_queue_count_[shard_id].load(std::memory_order_relaxed) == 0)
@@ -343,8 +379,9 @@ void WorkerPool::performPostSend(int thread_id) {
             redispatch_counter_.load(std::memory_order_relaxed);
         auto local_slice_queue_clone = local_slice_queue;
         local_slice_queue.clear();
+        bool handoff_to_local_worker = !context_.active() || !contextHealthy();
         for (auto &entry : local_slice_queue_clone)
-            redispatch(entry.second, thread_id);
+            redispatch(entry.second, thread_id, handoff_to_local_worker);
         return;
     }
 
@@ -385,21 +422,61 @@ void WorkerPool::performPostSend(int thread_id) {
             entry.second.clear();
             continue;
         }
-        if (!endpoint->connected() && endpoint->setupConnectionsByActive()) {
-            LOG(ERROR) << "Worker: Cannot make connection for endpoint: "
-                       << entry.first << ", deleting endpoint";
-            // Unified path failure handling
-            handlePathFailure(entry.first, endpoint.get());
-            for (auto &slice : entry.second) failed_slice_list.push_back(slice);
-            entry.second.clear();
-            continue;
+        if (!endpoint->connected()) {
+            int setup_ret = endpoint->setupConnectionsByActive();
+            if (setup_ret) {
+                // Active handshake setup failures are ambiguous: the failed
+                // side may be the peer rail, or this local RNIC may have just
+                // gone inactive. Prefer switching peer rails when one is
+                // available; otherwise hand off to another local RNIC only when
+                // this context is already known inactive.
+                bool local_context_inactive = !context_.active();
+                bool has_peer_alternative = false;
+                for (auto &slice : entry.second) {
+                    if (hasAvailablePeerRailAlternative(slice, entry.first)) {
+                        has_peer_alternative = true;
+                        break;
+                    }
+                }
+                LOG(WARNING) << "Worker: Cannot make connection for endpoint: "
+                             << entry.first
+                             << (has_peer_alternative
+                                     ? ", pausing peer rail and retrying "
+                                       "through an alternate peer RNIC"
+                                 : local_context_inactive
+                                     ? ", local RNIC is inactive; "
+                                       "trying another local RNIC"
+                                     : ", no alternate peer RNIC is available; "
+                                       "retrying without pausing peer rail");
+                if (has_peer_alternative) {
+                    markRailFailed(entry.first, true);
+                    redispatch_counter_++;
+                } else if (local_context_inactive) {
+                    context_.set_active(false);
+                    refreshPublishedLocalTopology();
+                    redispatch_counter_++;
+                }
+                context_.deleteEndpointByPtr(endpoint.get());
+                for (auto &slice : entry.second) {
+                    if (!has_peer_alternative && local_context_inactive &&
+                        tryHandoffToAnotherLocalWorker(slice)) {
+                        processed_slice_count_++;
+                    } else {
+                        failed_slice_list.push_back(slice);
+                    }
+                }
+                entry.second.clear();
+                continue;
+            }
         }
         if (!endpoint->readyToSend()) {
             if (endpoint->readyAckTimedOut()) {
                 LOG(ERROR) << "Worker: Timed out waiting for RDMA ready ACK "
                            << "for endpoint: " << entry.first
                            << ", deleting endpoint";
-                handlePathFailure(entry.first, endpoint.get());
+                markRailFailed(entry.first, true);
+                redispatch_counter_++;
+                context_.deleteEndpointByPtr(endpoint.get());
                 for (auto &slice : entry.second)
                     failed_slice_list.push_back(slice);
                 entry.second.clear();
@@ -416,9 +493,13 @@ void WorkerPool::performPostSend(int thread_id) {
 
     if (!failed_slice_list.empty()) {
         SliceList retry_list;
+        SliceList local_retry_list;
         for (auto &slice : failed_slice_list) {
             if (shouldRetrySlice(slice)) {
-                retry_list.push_back(slice);
+                if (!context_.active())
+                    local_retry_list.push_back(slice);
+                else
+                    retry_list.push_back(slice);
             } else {
                 slice->markFailed();
                 processed_slice_count_++;
@@ -427,6 +508,7 @@ void WorkerPool::performPostSend(int thread_id) {
         if (!retry_list.empty()) {
             redispatch(retry_list, thread_id);
         }
+        if (!local_retry_list.empty()) redispatch(local_retry_list, thread_id, true);
     }
 }
 
@@ -448,7 +530,10 @@ void WorkerPool::performPollCq(int thread_id) {
     int processed_slice_count = 0;
     const static size_t kPollCount = 64;
     std::unordered_map<std::atomic<int> *, int> qp_depth_set;
-    SliceList failed_slice_list;  // Unified: collect all slices for redispatch
+    std::unordered_set<RdmaEndPoint *> local_failed_endpoints;
+    bool recorded_local_context_failure = false;
+    SliceList failed_slice_list;
+    SliceList local_failed_slice_list;
     for (int cq_index = 0; cq_index < context_.cqCount(); cq_index++) {
         ibv_wc wc[kPollCount];
         int nr_poll = context_.poll(kPollCount, wc, cq_index);
@@ -479,18 +564,38 @@ void WorkerPool::performPollCq(int thread_id) {
                 // not real network errors and should not trigger rail failure
                 // handling or endpoint deletion.
                 if (wc[i].status == IBV_WC_WR_FLUSH_ERR) {
-                    if (globalConfig().trace)
-                        LOG(INFO) << "Worker: WR flush error (peer_nic: "
-                                  << slice->peer_nic_path
-                                  << "), marking failed without retry";
-                    slice->markFailed();
-                    processed_slice_count++;
+                    if (!context_.active()) {
+                        if (globalConfig().trace)
+                            LOG(INFO) << "Worker: WR flush error on inactive "
+                                      << "local context "
+                                      << context_.deviceName()
+                                      << " (peer_nic: "
+                                      << slice->peer_nic_path
+                                      << "), handing off if retry allows";
+                        if (shouldRetrySlice(slice))
+                            local_failed_slice_list.push_back(slice);
+                        else {
+                            slice->markFailed();
+                            processed_slice_count++;
+                        }
+                    } else {
+                        if (globalConfig().trace)
+                            LOG(INFO) << "Worker: WR flush error (peer_nic: "
+                                      << slice->peer_nic_path
+                                      << "), redispatching if retry allows";
+                        if (shouldRetrySlice(slice))
+                            failed_slice_list.push_back(slice);
+                        else {
+                            slice->markFailed();
+                            processed_slice_count++;
+                        }
+                    }
                     continue;
                 }
 
-                // All other WC errors indicate real path/network failures and
-                // should trigger redispatch to an alternate path (or fail if
-                // retry exhausted)
+                // Completion errors are split by local context health. Local
+                // faults hand off to another local RNIC; remote/default faults
+                // keep this local context and switch peer rails.
                 LOG(ERROR) << "Worker: Process failed for slice (opcode: "
                            << slice->opcode
                            << ", source_addr: " << slice->source_addr
@@ -500,11 +605,35 @@ void WorkerPool::performPollCq(int thread_id) {
                            << ", peer_nic: " << slice->peer_nic_path
                            << ", dest_rkey: " << slice->rdma.dest_rkey
                            << ", retry_cnt: " << slice->rdma.retry_cnt
+                           << ", max_retry_cnt: " << slice->rdma.max_retry_cnt
                            << "): " << ibv_wc_status_str(wc[i].status);
-                // Unified path failure handling
-                handlePathFailure(slice->peer_nic_path, slice->rdma.endpoint);
+                auto *retry_list = &failed_slice_list;
+                if (!context_.active() || isLocalWcFailure(wc[i])) {
+                    if (!recorded_local_context_failure) {
+                        handleLocalFailure(slice->peer_nic_path,
+                                           slice->rdma.endpoint);
+                        recorded_local_context_failure = true;
+                        if (slice->rdma.endpoint)
+                            local_failed_endpoints.insert(slice->rdma.endpoint);
+                    } else if (slice->rdma.endpoint &&
+                               !local_failed_endpoints.count(
+                                   slice->rdma.endpoint)) {
+                        context_.deleteEndpointByPtr(slice->rdma.endpoint);
+                        local_failed_endpoints.insert(slice->rdma.endpoint);
+                    }
+                    retry_list = &local_failed_slice_list;
+                } else {
+                    if (hasAvailablePeerRailAlternative(slice,
+                                                        slice->peer_nic_path)) {
+                        markRailFailed(slice->peer_nic_path, true);
+                        redispatch_counter_++;
+                    }
+                    if (slice->rdma.endpoint) {
+                        context_.deleteEndpointByPtr(slice->rdma.endpoint);
+                    }
+                }
                 if (shouldRetrySlice(slice)) {
-                    failed_slice_list.push_back(slice);
+                    retry_list->push_back(slice);
                 } else {
                     slice->markFailed();
                     processed_slice_count_++;
@@ -527,22 +656,30 @@ void WorkerPool::performPollCq(int thread_id) {
         markContextSuccess();
     }
 
+    if (!local_failed_slice_list.empty()) {
+        redispatch(local_failed_slice_list, thread_id, true);
+    }
     if (!failed_slice_list.empty()) {
         redispatch(failed_slice_list, thread_id);
     }
 }
 
 void WorkerPool::redispatch(std::vector<Transport::Slice *> &slice_list,
-                            int thread_id) {
+                            int thread_id, bool handoff_to_local_worker) {
     std::unordered_map<SegmentID, std::shared_ptr<Transport::SegmentDesc>>
         segment_desc_map;
     const bool use_local_queue = workerCanPost(thread_id);
     int shared_redispatch_count = 0;
-    for (auto &slice : slice_list) {
-        auto target_id = slice->target_id;
-        if (!segment_desc_map.count(target_id)) {
-            segment_desc_map[target_id] =
-                context_.engine().meta()->getSegmentDescByID(target_id, true);
+    // Remote redispatch needs target metadata to choose a new peer RNIC.
+    // Local handoff keeps the peer RNIC fixed and only switches source RNIC, so
+    // it can skip this lookup.
+    if (!handoff_to_local_worker) {
+        for (auto &slice : slice_list) {
+            auto target_id = slice->target_id;
+            if (!segment_desc_map.count(target_id)) {
+                segment_desc_map[target_id] =
+                    context_.engine().meta()->getSegmentDescByID(target_id, true);
+            }
         }
     }
 
@@ -551,12 +688,33 @@ void WorkerPool::redispatch(std::vector<Transport::Slice *> &slice_list,
             slice->markFailed();
             processed_slice_count_++;
         } else {
+            if (handoff_to_local_worker) {
+                if (tryHandoffToAnotherLocalWorker(slice)) {
+                    processed_slice_count_++;
+                    continue;
+                }
+                // A local RNIC failure cannot be repaired by keeping this
+                // worker/context and changing the remote rail. If no other
+                // local worker can take the slice, fail it immediately.
+                slice->markFailed();
+                processed_slice_count_++;
+                continue;
+            }
+
+            // Remote-side/default policy: keep local context fixed and switch
+            // remote path.
             auto &peer_segment_desc = segment_desc_map[slice->target_id];
             int buffer_id, device_id;
             if (!peer_segment_desc ||
                 selectPeerDevice(peer_segment_desc.get(), slice->rdma.dest_addr,
                                  slice->length, context_.deviceName(),
                                  buffer_id, device_id, slice->rdma.retry_cnt)) {
+                LOG(ERROR) << "Worker: Cannot redispatch slice for target "
+                           << slice->target_id
+                           << ", peer segment unavailable or no target RNIC, "
+                           << "dest_addr=" << (void *)slice->rdma.dest_addr
+                           << ", length=" << slice->length
+                           << ", retry_cnt=" << slice->rdma.retry_cnt;
                 slice->markFailed();
                 processed_slice_count_++;
                 continue;
@@ -577,7 +735,7 @@ void WorkerPool::redispatch(std::vector<Transport::Slice *> &slice_list,
                         continue;
                     }
                     auto alt_path = MakeNicPath(
-                        peer_segment_desc->name,
+                        peer_segment_desc->nicPathServerName(),
                         peer_segment_desc->devices[alt_dev_id].name);
                     if (isRailAvailable(alt_path)) {
                         device_id = alt_dev_id;
@@ -590,6 +748,12 @@ void WorkerPool::redispatch(std::vector<Transport::Slice *> &slice_list,
                     }
                 }
                 if (!found) {
+                    LOG(ERROR)
+                        << "Worker: Cannot redispatch slice because all peer "
+                           "rails are paused for target "
+                        << slice->target_id << ", selected peer="
+                        << peer_nic_path << ", retry_cnt="
+                        << slice->rdma.retry_cnt;
                     slice->markFailed();
                     processed_slice_count_++;
                     continue;
@@ -635,6 +799,74 @@ void WorkerPool::redispatch(std::vector<Transport::Slice *> &slice_list,
         std::lock_guard<std::mutex> lock(cond_mutex_);
         cond_var_.notify_all();
     }
+}
+
+bool WorkerPool::tryHandoffToAnotherLocalWorker(Transport::Slice *slice) {
+    // Local failover changes only the source RNIC. Keep target_id,
+    // peer_nic_path, dest_addr, and dest_rkey intact; only replace source_lkey
+    // for the selected alternate local context.
+    auto local_segment_desc =
+        context_.engine().meta()->getSegmentDescByID(LOCAL_SEGMENT_ID);
+    auto &contexts = context_.engine().context_list_;
+    if (!local_segment_desc || contexts.size() <= 1) {
+        return false;
+    }
+
+    int current_ctx_id = -1;
+    for (size_t i = 0; i < contexts.size(); ++i) {
+        if (contexts[i] && contexts[i].get() == &context_) {
+            current_ctx_id = static_cast<int>(i);
+            break;
+        }
+    }
+    if (current_ctx_id < 0) {
+        return false;
+    }
+
+    int start_ctx = static_cast<int>(slice->rdma.retry_cnt % contexts.size());
+    for (size_t offset = 0; offset < contexts.size(); ++offset) {
+        int device_id = (start_ctx + static_cast<int>(offset)) %
+                        static_cast<int>(contexts.size());
+        if (device_id == current_ctx_id) continue;
+
+        auto &alt_ctx = contexts[device_id];
+        if (!alt_ctx || !alt_ctx->active()) continue;
+
+        int buffer_id = -1;
+        for (size_t idx = 0; idx < local_segment_desc->buffers.size(); ++idx) {
+            auto &buffer = local_segment_desc->buffers[idx];
+            auto source = reinterpret_cast<uint64_t>(slice->source_addr);
+            auto buffer_start = reinterpret_cast<uint64_t>(buffer.addr);
+            auto buffer_end = buffer_start + buffer.length;
+            if (buffer_start <= source && source + slice->length <= buffer_end) {
+                buffer_id = static_cast<int>(idx);
+                break;
+            }
+        }
+        if (buffer_id < 0) {
+            continue;
+        }
+        if (device_id >= static_cast<int>(
+                             local_segment_desc->buffers[buffer_id].lkey.size())) {
+            continue;
+        }
+
+        slice->rdma.source_lkey =
+            local_segment_desc->buffers[buffer_id].lkey[device_id];
+        slice->rdma.endpoint = nullptr;
+        slice->ts = 0;
+
+        std::vector<Transport::Slice *> handoff{slice};
+        alt_ctx->worker_pool_->submitPreparedPostSend(handoff);
+
+        VLOG(1) << "Local-side retry handed slice from worker pool on "
+                << context_.deviceName() << " to worker pool on "
+                << alt_ctx->deviceName() << " while keeping remote peer "
+                << slice->peer_nic_path;
+        return true;
+    }
+
+    return false;
 }
 
 bool WorkerPool::hasOutstandingCq(int thread_id) {
@@ -727,6 +959,7 @@ int WorkerPool::doProcessContextEvents() {
                event.event_type == IBV_EVENT_WQ_FATAL ||
                event.event_type == IBV_EVENT_PORT_ERR ||
                event.event_type == IBV_EVENT_LID_CHANGE) {
+        recovery_activate_after_ns_.store(0, std::memory_order_relaxed);
         context_.set_active(false);
         refreshPublishedLocalTopology();
 
@@ -762,11 +995,10 @@ int WorkerPool::doProcessContextEvents() {
                       << ", disconnected all endpoints";
         }
     } else if (event.event_type == IBV_EVENT_PORT_ACTIVE) {
-        context_.set_active(true);
-        refreshPublishedLocalTopology();
-        markContextSuccess();  // Reset failure counter on port recovery
-        LOG(INFO) << "Worker: Context " << context_.deviceName()
-                  << " is now active";
+        // PORT_ACTIVE only means the link started coming back. Real mlx5/RoCE
+        // data path can still reject RTR for a while after link-up, so delay
+        // publishing this local RNIC back to metadata.
+        scheduleContextRecovery();
     }
 
     if (!event_acked) {
@@ -774,6 +1006,116 @@ int WorkerPool::doProcessContextEvents() {
     }
 
     return 0;
+}
+
+void WorkerPool::processContextEventForTest(ibv_event_type event_type) {
+    LOG(WARNING) << "Worker: Injected context async event "
+                 << ibv_event_type_str(event_type) << " for context "
+                 << context_.deviceName();
+
+    if (event_type == IBV_EVENT_DEVICE_FATAL ||
+        event_type == IBV_EVENT_CQ_ERR || event_type == IBV_EVENT_WQ_FATAL ||
+        event_type == IBV_EVENT_PORT_ERR ||
+        event_type == IBV_EVENT_LID_CHANGE) {
+        recovery_activate_after_ns_.store(0, std::memory_order_relaxed);
+        context_.set_active(false);
+        refreshPublishedLocalTopology();
+        context_.disconnectAllEndpoints();
+        LOG(INFO) << "Worker: Context " << context_.deviceName()
+                  << " is now inactive due to injected fatal event: "
+                  << event_type;
+    } else if (event_type == IBV_EVENT_GID_CHANGE) {
+        auto gid_refresh_result = refreshPublishedLocalGid();
+        if (gid_refresh_result != GidRefreshResult::UNCHANGED) {
+            context_.disconnectAllEndpoints();
+            LOG(INFO) << "Worker: Context " << context_.deviceName()
+                      << " injected GID refresh result="
+                      << static_cast<int>(gid_refresh_result)
+                      << ", disconnected all endpoints";
+        }
+    } else if (event_type == IBV_EVENT_PORT_ACTIVE) {
+        // Match the real async-event path: injected recovery also waits before
+        // re-enabling the local RNIC.
+        scheduleContextRecovery();
+    }
+}
+
+void WorkerPool::scheduleContextRecovery(uint64_t delay_ns) {
+    uint64_t activate_after = getCurrentTimeInNano() + delay_ns;
+    recovery_activate_after_ns_.store(activate_after, std::memory_order_relaxed);
+    LOG(INFO) << "Worker: Context " << context_.deviceName()
+              << " scheduled recovery probe after "
+              << delay_ns / 1000000000ull << " seconds";
+}
+
+void WorkerPool::maybeActivateRecoveredContext() {
+    uint64_t activate_after =
+        recovery_activate_after_ns_.load(std::memory_order_relaxed);
+    if (activate_after == 0 ||
+        static_cast<uint64_t>(getCurrentTimeInNano()) < activate_after)
+        return;
+
+    uint64_t expected = activate_after;
+    if (!recovery_activate_after_ns_.compare_exchange_strong(
+            expected, 0, std::memory_order_relaxed)) {
+        return;
+    }
+
+    auto gid_refresh_result = refreshPublishedLocalGid();
+    if (gid_refresh_result == GidRefreshResult::FAILED) {
+        context_.set_active(false);
+        refreshPublishedLocalTopology();
+        scheduleContextRecovery();
+        LOG(WARNING) << "Worker: Context " << context_.deviceName()
+                     << " failed to refresh GID during recovery; "
+                        "keeping inactive";
+        return;
+    }
+    if (gid_refresh_result == GidRefreshResult::CHANGED) {
+        context_.disconnectAllEndpoints();
+        LOG(INFO) << "Worker: Context " << context_.deviceName()
+                  << " GID changed during recovery, disconnected all endpoints";
+    }
+
+    context_.set_active(true);
+    refreshPublishedLocalTopology();
+    context_failure_count_.store(0, std::memory_order_relaxed);
+    LOG(INFO) << "Worker: Context " << context_.deviceName()
+              << " is now active after recovery delay";
+}
+
+bool WorkerPool::hasAvailablePeerRailAlternative(
+    Transport::Slice *slice, const std::string &failed_peer_path) {
+    auto peer_segment_desc =
+        context_.engine().meta()->getSegmentDescByID(slice->target_id, true);
+    if (!peer_segment_desc) return false;
+
+    int buffer_id = -1;
+    for (size_t idx = 0; idx < peer_segment_desc->buffers.size(); ++idx) {
+        auto &buffer = peer_segment_desc->buffers[idx];
+        uint64_t buffer_start = reinterpret_cast<uint64_t>(buffer.addr);
+        uint64_t buffer_end = buffer_start + buffer.length;
+        if (buffer_start <= slice->rdma.dest_addr &&
+            slice->rdma.dest_addr + slice->length <= buffer_end) {
+            buffer_id = static_cast<int>(idx);
+            break;
+        }
+    }
+    if (buffer_id < 0) return false;
+
+    auto server_name = peer_segment_desc->nicPathServerName();
+    for (size_t dev_id = 0; dev_id < peer_segment_desc->devices.size();
+         ++dev_id) {
+        if (dev_id >= peer_segment_desc->buffers[buffer_id].rkey.size()) {
+            continue;
+        }
+        auto peer_path =
+            MakeNicPath(server_name, peer_segment_desc->devices[dev_id].name);
+        if (peer_path != failed_peer_path && isRailAvailable(peer_path)) {
+            return true;
+        }
+    }
+    return false;
 }
 
 void WorkerPool::refreshPublishedLocalTopology() {
@@ -827,6 +1169,7 @@ void WorkerPool::monitorWorker() {
     while (workers_running_) {
         const uint64_t current_ts =
             static_cast<uint64_t>(getCurrentTimeInNano());
+        maybeActivateRecoveredContext();
         if (current_ts - last_reset_ts > 1000000000ll) {
             // Drain endpoint_store_->waiting_list_ even when no new
             // insertions are happening. Without this, reclaim only runs
@@ -951,15 +1294,20 @@ void WorkerPool::monitorWorker() {
     }
 }
 
-void WorkerPool::markRailFailed(const std::string &peer_nic_path) {
+void WorkerPool::markRailFailed(const std::string &peer_nic_path,
+                                bool immediate_pause) {
     std::lock_guard<std::mutex> lock(rail_state_lock_);
     auto &state = rail_states_[peer_nic_path];
+    uint64_t now = getCurrentTimeInNano();
     state.error_count++;
+    if (immediate_pause && state.error_count < kRailErrorThreshold) {
+        state.error_count = kRailErrorThreshold;
+    }
     if (state.error_count >= kRailErrorThreshold) {
-        uint64_t now = getCurrentTimeInNano();
         state.pause_until_ns = now + kRailPauseNs;
         LOG(WARNING) << "Rail paused: peer=" << peer_nic_path
-                     << " error_count=" << state.error_count;
+                     << " error_count=" << state.error_count
+                     << " pause_ms=" << kRailPauseNs / 1000000ull;
     }
 }
 
@@ -986,14 +1334,49 @@ bool WorkerPool::shouldRetrySlice(Transport::Slice *slice) {
     return slice->rdma.retry_cnt < slice->rdma.max_retry_cnt;
 }
 
-// Unified path failure handler
-void WorkerPool::handlePathFailure(const std::string &peer_nic_path,
-                                   RdmaEndPoint *endpoint) {
-    markRailFailed(peer_nic_path);
-    redispatch_counter_++;  // Notify all workers to redispatch their queues
+bool WorkerPool::isLocalWcFailure(const ibv_wc &wc) {
+    // IBV_WC_GENERAL_ERR is intentionally not treated as a local RNIC failure.
+    // Providers use it for broad connection/path failures too, and disabling
+    // the local context here can mask endpoint GID reprobe and remote rail
+    // recovery paths.
+    switch (wc.status) {
+        case IBV_WC_LOC_LEN_ERR:
+        case IBV_WC_LOC_QP_OP_ERR:
+        case IBV_WC_LOC_PROT_ERR:
+        case IBV_WC_MW_BIND_ERR:
+        case IBV_WC_LOC_ACCESS_ERR:
+#ifdef IBV_WC_LOC_RDD_VIOL_ERR
+        case IBV_WC_LOC_RDD_VIOL_ERR:
+#endif
+#ifdef IBV_WC_LOC_EEC_OP_ERR
+        case IBV_WC_LOC_EEC_OP_ERR:
+#endif
+#ifdef IBV_WC_LOC_EEC_STATE_ERR
+        case IBV_WC_LOC_EEC_STATE_ERR:
+#endif
+            return true;
+
+        default:
+            return false;
+    }
+}
+
+void WorkerPool::handleLocalFailure(const std::string &peer_nic_path,
+                                    RdmaEndPoint *endpoint) {
+    // Local completion faults can be caused by a poisoned QP/MR as well as a
+    // bad RNIC. Retry this slice elsewhere, but only disable the whole context
+    // after repeated local failures or an async port/device event.
+    bool context_disabled = markContextFailure();
+    if (context_disabled) refreshPublishedLocalTopology();
+    redispatch_counter_++;
+
+    // Endpoint may also be poisoned; retire it for safety.
     if (endpoint) {
         context_.deleteEndpointByPtr(endpoint);
     }
+
+    LOG(WARNING) << "Local-side RDMA failure detected on context "
+                 << context_.deviceName() << ", peer=" << peer_nic_path;
 }
 
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tests/rdma_endpoint_reestablish_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_endpoint_reestablish_test.cpp
@@ -29,6 +29,8 @@
  */
 
 #include <algorithm>
+#include <atomic>
+#include <chrono>
 #include <cerrno>
 #include <cstdlib>
 #include <fstream>
@@ -37,6 +39,7 @@
 #include <mutex>
 #include <sstream>
 #include <string>
+#include <thread>
 #include <unordered_map>
 #include <vector>
 
@@ -50,9 +53,80 @@
 
 #include "common.h"
 #include "transfer_engine.h"
+#include "transport/rdma_transport/rdma_context.h"
+#include "transport/rdma_transport/rdma_transport.h"
+#include "transport/rdma_transport/worker_pool.h"
 #include "transport/transport.h"
 
 using namespace mooncake;
+
+namespace mooncake {
+
+class RdmaTransportTestPeer {
+   public:
+    static bool setContextActive(RdmaTransport* transport,
+                                 const std::string& device_name, bool active) {
+        if (!transport) return false;
+        for (auto& context : transport->context_list_) {
+            if (context && context->deviceName() == device_name) {
+                context->set_active(active);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static bool contextActive(RdmaTransport* transport,
+                              const std::string& device_name) {
+        if (!transport) return false;
+        for (auto& context : transport->context_list_) {
+            if (context && context->deviceName() == device_name) {
+                return context->active();
+            }
+        }
+        return false;
+    }
+
+    static bool injectContextEvent(RdmaTransport* transport,
+                                   const std::string& device_name,
+                                   ibv_event_type event_type);
+};
+
+class WorkerPoolTestPeer {
+   public:
+    static void processContextEvent(WorkerPool& worker_pool,
+                                    ibv_event_type event_type) {
+        worker_pool.processContextEventForTest(event_type);
+    }
+};
+
+class RdmaContextTestPeer {
+   public:
+    static bool injectContextEvent(RdmaContext* context,
+                                   ibv_event_type event_type) {
+        if (context && context->worker_pool_) {
+            WorkerPoolTestPeer::processContextEvent(*context->worker_pool_,
+                                                    event_type);
+            return true;
+        }
+        return false;
+    }
+};
+
+bool RdmaTransportTestPeer::injectContextEvent(RdmaTransport* transport,
+                                               const std::string& device_name,
+                                               ibv_event_type event_type) {
+    if (!transport) return false;
+    for (auto& context : transport->context_list_) {
+        if (context && context->deviceName() == device_name) {
+            return RdmaContextTestPeer::injectContextEvent(context.get(),
+                                                          event_type);
+        }
+    }
+    return false;
+}
+
+}  // namespace mooncake
 
 namespace {
 
@@ -82,8 +156,11 @@ struct RtrFaultInjectionState {
     std::mutex mu;
     bool synthetic_gid_swap_enabled = false;
     std::string synthetic_gid_device;
+    int synthetic_gid_a = 0;
+    int synthetic_gid_b = 1;
     bool fail_first_rtr_einval = false;
     std::string fail_rtr_device;
+    bool first_rtr_attempted = false;
     int injected_failures = 0;
     std::unordered_map<std::string, std::vector<int>> rtr_sgid_history;
     std::unordered_map<std::string, std::vector<std::string>> rtr_gid_history;
@@ -105,8 +182,11 @@ void resetRtrFaultInjectionState() {
     std::lock_guard<std::mutex> guard(g_rtr_fault_injection_state.mu);
     g_rtr_fault_injection_state.synthetic_gid_swap_enabled = false;
     g_rtr_fault_injection_state.synthetic_gid_device.clear();
+    g_rtr_fault_injection_state.synthetic_gid_a = 0;
+    g_rtr_fault_injection_state.synthetic_gid_b = 1;
     g_rtr_fault_injection_state.fail_first_rtr_einval = false;
     g_rtr_fault_injection_state.fail_rtr_device.clear();
+    g_rtr_fault_injection_state.first_rtr_attempted = false;
     g_rtr_fault_injection_state.injected_failures = 0;
     g_rtr_fault_injection_state.rtr_sgid_history.clear();
     g_rtr_fault_injection_state.rtr_gid_history.clear();
@@ -116,8 +196,11 @@ void configureRtrFaultInjection(const std::string& device_name) {
     std::lock_guard<std::mutex> guard(g_rtr_fault_injection_state.mu);
     g_rtr_fault_injection_state.synthetic_gid_swap_enabled = true;
     g_rtr_fault_injection_state.synthetic_gid_device = device_name;
+    g_rtr_fault_injection_state.synthetic_gid_a = 0;
+    g_rtr_fault_injection_state.synthetic_gid_b = 1;
     g_rtr_fault_injection_state.fail_first_rtr_einval = true;
     g_rtr_fault_injection_state.fail_rtr_device = device_name;
+    g_rtr_fault_injection_state.first_rtr_attempted = false;
     g_rtr_fault_injection_state.injected_failures = 0;
     g_rtr_fault_injection_state.rtr_sgid_history.clear();
     g_rtr_fault_injection_state.rtr_gid_history.clear();
@@ -160,22 +243,40 @@ int maybeSwapSyntheticGidIndex(const std::string& device_name, int gid_index) {
         g_rtr_fault_injection_state.synthetic_gid_device != device_name) {
         return gid_index;
     }
-    if (gid_index == 0) return 1;
-    if (gid_index == 1) return 0;
+    if (gid_index == g_rtr_fault_injection_state.synthetic_gid_a)
+        return g_rtr_fault_injection_state.synthetic_gid_b;
+    if (gid_index == g_rtr_fault_injection_state.synthetic_gid_b)
+        return g_rtr_fault_injection_state.synthetic_gid_a;
     return gid_index;
 }
 
-bool shouldInjectRtrEinval(const std::string& device_name, int sgid_index) {
+int injectedRtrErrnoOrZero(const std::string& device_name, int sgid_index) {
     std::lock_guard<std::mutex> guard(g_rtr_fault_injection_state.mu);
     if (!g_rtr_fault_injection_state.fail_first_rtr_einval ||
         g_rtr_fault_injection_state.fail_rtr_device != device_name ||
-        sgid_index != 0) {
-        return false;
+        sgid_index != g_rtr_fault_injection_state.synthetic_gid_a ||
+        g_rtr_fault_injection_state.first_rtr_attempted) {
+        return 0;
     }
     g_rtr_fault_injection_state.fail_first_rtr_einval = false;
     g_rtr_fault_injection_state.synthetic_gid_swap_enabled = false;
+    g_rtr_fault_injection_state.first_rtr_attempted = true;
     ++g_rtr_fault_injection_state.injected_failures;
-    return true;
+    return EINVAL;
+}
+
+void expectRtrEinvalRecoveredWithRetry(const std::string& device_name) {
+    EXPECT_EQ(getInjectedFailureCount(), 1);
+    auto sgid_history = getRtrSgidHistory(device_name);
+    auto gid_history = getRtrGidHistory(device_name);
+    ASSERT_EQ(sgid_history.size(), gid_history.size());
+    ASSERT_GE(sgid_history.size(), 2u)
+        << "RTR/EINVAL was injected, but the endpoint did not retry RTR";
+    EXPECT_FALSE(gid_history.front().empty());
+
+    EXPECT_TRUE(std::any_of(
+        gid_history.begin() + 1, gid_history.end(),
+        [&](const std::string& gid) { return gid != gid_history.front(); }));
 }
 
 std::string formatDeviceNames(const std::string& device_names) {
@@ -204,6 +305,16 @@ std::string makeNicPriorityMatrix(const std::string& device_name) {
            formatted_devices + "],[]]}";
 }
 
+std::string makeNicPriorityMatrix(const std::string& preferred_devices,
+                                  const std::string& fallback_devices) {
+    auto formatted_preferred = formatDeviceNames(preferred_devices);
+    auto formatted_fallback = formatDeviceNames(fallback_devices);
+    return "{\"cpu:0\": [[" + formatted_preferred + "],[" +
+           formatted_fallback + "]], "
+           " \"cpu:1\": [[" +
+           formatted_preferred + "],[" + formatted_fallback + "]]}";
+}
+
 void waitForTransfer(TransferEngine* engine, BatchID batch_id,
                      const std::string& op_name) {
     bool completed = false;
@@ -221,8 +332,46 @@ void waitForTransfer(TransferEngine* engine, BatchID batch_id,
     EXPECT_EQ(s, Status::OK());
 }
 
+bool waitForTransferWithTimeout(TransferEngine* engine, BatchID batch_id,
+                                const std::string& op_name,
+                                std::chrono::seconds timeout) {
+    auto deadline = std::chrono::steady_clock::now() + timeout;
+    TransferStatus status;
+    while (std::chrono::steady_clock::now() < deadline) {
+        Status s = engine->getTransferStatus(batch_id, 0, status);
+        if (s != Status::OK()) {
+            ADD_FAILURE() << op_name << " getTransferStatus failed: "
+                          << s.ToString();
+            return false;
+        }
+        if (status.s == TransferStatusEnum::COMPLETED) {
+            s = engine->freeBatchID(batch_id);
+            if (s != Status::OK()) {
+                ADD_FAILURE() << op_name << " freeBatchID failed: "
+                              << s.ToString();
+                return false;
+            }
+            return true;
+        }
+        if (status.s == TransferStatusEnum::FAILED) {
+            ADD_FAILURE() << op_name << " FAILED";
+            engine->freeBatchID(batch_id);
+            return false;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+
+    ADD_FAILURE() << op_name << " timed out after " << timeout.count()
+                  << " seconds";
+    engine->freeBatchID(batch_id);
+    return false;
+}
+
+struct RawNicPriorityMatrix {};
+
 struct TEContext {
     std::unique_ptr<TransferEngine> engine_{};
+    RdmaTransport* rdma_transport_{};
     uint8_t* local_addr_{};
     bool segment_opened_{false};
     SegmentHandle segment_handle_{};
@@ -230,17 +379,25 @@ struct TEContext {
 
     TEContext(const std::string& local_server_name,
               const std::string& metadata_server, const std::string& segment_id,
-              const std::string& device_name) {
+              const std::string& device_name)
+        : TEContext(local_server_name, metadata_server, segment_id,
+                    makeNicPriorityMatrix(device_name), RawNicPriorityMatrix{}) {
+    }
+
+    TEContext(const std::string& local_server_name,
+              const std::string& metadata_server, const std::string& segment_id,
+              const std::string& nic_priority_matrix, RawNicPriorityMatrix) {
         engine_ = std::make_unique<TransferEngine>(false);
         auto hostname_port = parseHostNameWithPort(local_server_name);
         engine_->init(metadata_server, local_server_name, hostname_port.first,
                       hostname_port.second);
 
-        auto nic_priority_matrix = makeNicPriorityMatrix(device_name);
         void* args[2] = {const_cast<char*>(nic_priority_matrix.c_str()),
                          nullptr};
         Transport* xport = engine_->installTransport("rdma", args);
         LOG_ASSERT(xport);
+        rdma_transport_ = dynamic_cast<RdmaTransport*>(xport);
+        LOG_ASSERT(rdma_transport_);
 
         local_addr_ = static_cast<uint8_t*>(numa_alloc_onnode(kRAMBufSize, 0));
         memset(local_addr_, 0, kDataLength);
@@ -401,34 +558,261 @@ TEST_F(RDMAEndpointReestablishTest, EndpointReestablishReverseDevices) {
 TEST_F(RDMAEndpointReestablishTest, ActiveHandshakeRetriesAfterAutoGidReprobe) {
     configureRtrFaultInjection(initiator_device_name);
     runEndpointReestablishScenario(target_device_name, initiator_device_name);
-
-    EXPECT_EQ(getInjectedFailureCount(), 1);
-    auto sgid_history = getRtrSgidHistory(initiator_device_name);
-    auto gid_history = getRtrGidHistory(initiator_device_name);
-    ASSERT_EQ(sgid_history.size(), gid_history.size());
-    ASSERT_GE(sgid_history.size(), 2u);
-    EXPECT_EQ(sgid_history.front(), 0);
-    EXPECT_FALSE(gid_history.front().empty());
-    EXPECT_TRUE(std::any_of(
-        gid_history.begin() + 1, gid_history.end(),
-        [&](const std::string& gid) { return gid != gid_history.front(); }));
+    expectRtrEinvalRecoveredWithRetry(initiator_device_name);
 }
 
 TEST_F(RDMAEndpointReestablishTest,
        PassiveHandshakeRetriesAfterAutoGidReprobe) {
     configureRtrFaultInjection(target_device_name);
     runEndpointReestablishScenario(target_device_name, initiator_device_name);
+    expectRtrEinvalRecoveredWithRetry(target_device_name);
+}
 
-    EXPECT_EQ(getInjectedFailureCount(), 1);
-    auto sgid_history = getRtrSgidHistory(target_device_name);
-    auto gid_history = getRtrGidHistory(target_device_name);
-    ASSERT_EQ(sgid_history.size(), gid_history.size());
-    ASSERT_GE(sgid_history.size(), 2u);
-    EXPECT_EQ(sgid_history.front(), 0);
-    EXPECT_FALSE(gid_history.front().empty());
-    EXPECT_TRUE(std::any_of(
-        gid_history.begin() + 1, gid_history.end(),
-        [&](const std::string& gid) { return gid != gid_history.front(); }));
+TEST_F(RDMAEndpointReestablishTest,
+       SenderSingleRnicDownUsesFallbackLocalRnic) {
+    if (target_device_name == initiator_device_name) {
+        GTEST_SKIP() << "Need two distinct RDMA devices for sender failover";
+    }
+
+    const std::string both_devices =
+        target_device_name + "," + initiator_device_name;
+    const std::string target_matrix = makeNicPriorityMatrix(both_devices);
+    LOG(INFO) << "========== Setting up dual-RNIC Target ==========";
+    TEContext target_ctx(target_server_name, metadata_server, "",
+                         target_matrix, RawNicPriorityMatrix{});
+    const std::string target_segment_name =
+        usesP2PHandshake(metadata_server) ? target_ctx.localSegmentName()
+                                          : target_server_name;
+
+    // Put the soon-to-be-down sender RNIC in the preferred tier and the
+    // surviving sender RNIC in the fallback tier. This proves TE can skip the
+    // inactive preferred local context and still complete the transfer through
+    // another local RNIC.
+    const std::string sender_matrix =
+        makeNicPriorityMatrix(initiator_device_name, target_device_name);
+    TEContext init_ctx(initiator_server_name, metadata_server,
+                       target_segment_name, sender_matrix,
+                       RawNicPriorityMatrix{});
+
+    ASSERT_TRUE(RdmaTransportTestPeer::setContextActive(
+        init_ctx.rdma_transport_, initiator_device_name, false));
+    ASSERT_FALSE(RdmaTransportTestPeer::contextActive(
+        init_ctx.rdma_transport_, initiator_device_name));
+    ASSERT_TRUE(RdmaTransportTestPeer::contextActive(init_ctx.rdma_transport_,
+                                                    target_device_name));
+
+    for (size_t i = 0; i < kDataLength; ++i) {
+        init_ctx.local_addr_[i] = static_cast<uint8_t>((i * 17) % 251);
+    }
+
+    auto batch_id = init_ctx.engine_->allocateBatchID(1);
+    TransferRequest entry;
+    entry.opcode = TransferRequest::WRITE;
+    entry.length = kDataLength;
+    entry.source = init_ctx.local_addr_;
+    entry.target_id = init_ctx.segment_handle_;
+    entry.target_offset = init_ctx.remote_base_;
+
+    Status s = init_ctx.engine_->submitTransfer(batch_id, {entry});
+    ASSERT_EQ(s, Status::OK());
+    waitForTransfer(init_ctx.engine_.get(), batch_id,
+                    "WRITE with one sender RNIC down");
+
+    for (size_t i = 0; i < kDataLength; ++i) {
+        ASSERT_EQ(target_ctx.local_addr_[i],
+                  static_cast<uint8_t>((i * 17) % 251))
+            << "Data mismatch at offset " << i;
+    }
+}
+
+TEST_F(RDMAEndpointReestablishTest,
+       InjectedSenderRnicDownKeepsFallbackTransfersSmoothForTwentySeconds) {
+    auto devices = getAvailableRdmaDevices();
+    for (const auto* device : {"mlx5_1", "mlx5_2", "mlx5_3", "mlx5_4"}) {
+        if (std::find(devices.begin(), devices.end(), device) ==
+            devices.end()) {
+            GTEST_SKIP() << "Need " << device << " for this 4-RNIC test";
+        }
+    }
+
+    const std::string target_matrix = makeNicPriorityMatrix("mlx5_3,mlx5_4");
+    TEContext target_ctx(target_server_name, metadata_server, "",
+                         target_matrix, RawNicPriorityMatrix{});
+    const std::string target_segment_name =
+        usesP2PHandshake(metadata_server) ? target_ctx.localSegmentName()
+                                          : target_server_name;
+
+    const std::string sender_matrix = makeNicPriorityMatrix("mlx5_2", "mlx5_1");
+    TEContext init_ctx(initiator_server_name, metadata_server,
+                       target_segment_name, sender_matrix,
+                       RawNicPriorityMatrix{});
+
+    std::atomic<bool> injected_down{false};
+    std::atomic<bool> injected_up{false};
+    std::atomic<bool> inject_down_ok{false};
+    std::atomic<bool> inject_up_ok{false};
+    std::thread injector([&] {
+        std::this_thread::sleep_for(std::chrono::seconds(5));
+        inject_down_ok.store(RdmaTransportTestPeer::injectContextEvent(
+                                 init_ctx.rdma_transport_, "mlx5_2",
+                                 IBV_EVENT_PORT_ERR),
+                             std::memory_order_release);
+        injected_down.store(true, std::memory_order_release);
+
+        std::this_thread::sleep_for(std::chrono::seconds(7));
+        inject_up_ok.store(RdmaTransportTestPeer::injectContextEvent(
+                               init_ctx.rdma_transport_, "mlx5_2",
+                               IBV_EVENT_PORT_ACTIVE),
+                           std::memory_order_release);
+        injected_up.store(true, std::memory_order_release);
+    });
+
+    constexpr size_t kFaultLoopLength = 4ull << 20;
+    auto start = std::chrono::steady_clock::now();
+    auto deadline = start + std::chrono::seconds(20);
+    size_t completed_transfers = 0;
+    uint8_t last_pattern = 0;
+    bool transfer_ok = true;
+
+    while (std::chrono::steady_clock::now() < deadline) {
+        last_pattern = static_cast<uint8_t>((completed_transfers * 37) % 251);
+        memset(init_ctx.local_addr_, last_pattern, kFaultLoopLength);
+
+        auto batch_id = init_ctx.engine_->allocateBatchID(1);
+        TransferRequest entry;
+        entry.opcode = TransferRequest::WRITE;
+        entry.length = kFaultLoopLength;
+        entry.source = init_ctx.local_addr_;
+        entry.target_id = init_ctx.segment_handle_;
+        entry.target_offset = init_ctx.remote_base_;
+
+        Status s = init_ctx.engine_->submitTransfer(batch_id, {entry});
+        if (s != Status::OK()) {
+            ADD_FAILURE() << "submitTransfer failed during injected sender "
+                             "RNIC down/fallback: "
+                          << s.ToString();
+            transfer_ok = false;
+            break;
+        }
+        if (!waitForTransferWithTimeout(
+                init_ctx.engine_.get(), batch_id,
+                "20s WRITE during injected sender RNIC down/fallback",
+                std::chrono::seconds(5))) {
+            transfer_ok = false;
+            break;
+        }
+        ++completed_transfers;
+    }
+
+    injector.join();
+    ASSERT_TRUE(injected_down.load(std::memory_order_acquire));
+    ASSERT_TRUE(injected_up.load(std::memory_order_acquire));
+    ASSERT_TRUE(inject_down_ok.load(std::memory_order_acquire));
+    ASSERT_TRUE(inject_up_ok.load(std::memory_order_acquire));
+    ASSERT_TRUE(transfer_ok);
+    ASSERT_GT(completed_transfers, 0u);
+
+    for (size_t i = 0; i < kFaultLoopLength; ++i) {
+        ASSERT_EQ(target_ctx.local_addr_[i], last_pattern)
+            << "Data mismatch at offset " << i;
+    }
+    LOG(INFO) << "Completed " << completed_transfers
+              << " transfers during injected mlx5_2 down/fallback";
+}
+
+TEST_F(RDMAEndpointReestablishTest,
+       InjectedReceiverRnicDownKeepsFallbackTransfersSmoothForTwentySeconds) {
+    auto devices = getAvailableRdmaDevices();
+    for (const auto* device : {"mlx5_1", "mlx5_2", "mlx5_3", "mlx5_4"}) {
+        if (std::find(devices.begin(), devices.end(), device) ==
+            devices.end()) {
+            GTEST_SKIP() << "Need " << device << " for this 4-RNIC test";
+        }
+    }
+
+    const std::string target_matrix = makeNicPriorityMatrix("mlx5_3", "mlx5_4");
+    TEContext target_ctx(target_server_name, metadata_server, "",
+                         target_matrix, RawNicPriorityMatrix{});
+    const std::string target_segment_name =
+        usesP2PHandshake(metadata_server) ? target_ctx.localSegmentName()
+                                          : target_server_name;
+
+    const std::string sender_matrix = makeNicPriorityMatrix("mlx5_1,mlx5_2");
+    TEContext init_ctx(initiator_server_name, metadata_server,
+                       target_segment_name, sender_matrix,
+                       RawNicPriorityMatrix{});
+
+    std::atomic<bool> injected_down{false};
+    std::atomic<bool> injected_up{false};
+    std::atomic<bool> inject_down_ok{false};
+    std::atomic<bool> inject_up_ok{false};
+    std::thread injector([&] {
+        std::this_thread::sleep_for(std::chrono::seconds(5));
+        inject_down_ok.store(RdmaTransportTestPeer::injectContextEvent(
+                                 target_ctx.rdma_transport_, "mlx5_3",
+                                 IBV_EVENT_PORT_ERR),
+                             std::memory_order_release);
+        injected_down.store(true, std::memory_order_release);
+
+        std::this_thread::sleep_for(std::chrono::seconds(7));
+        inject_up_ok.store(RdmaTransportTestPeer::injectContextEvent(
+                               target_ctx.rdma_transport_, "mlx5_3",
+                               IBV_EVENT_PORT_ACTIVE),
+                           std::memory_order_release);
+        injected_up.store(true, std::memory_order_release);
+    });
+
+    constexpr size_t kFaultLoopLength = 4ull << 20;
+    auto start = std::chrono::steady_clock::now();
+    auto deadline = start + std::chrono::seconds(20);
+    size_t completed_transfers = 0;
+    uint8_t last_pattern = 0;
+    bool transfer_ok = true;
+
+    while (std::chrono::steady_clock::now() < deadline) {
+        last_pattern = static_cast<uint8_t>((completed_transfers * 41) % 251);
+        memset(init_ctx.local_addr_, last_pattern, kFaultLoopLength);
+
+        auto batch_id = init_ctx.engine_->allocateBatchID(1);
+        TransferRequest entry;
+        entry.opcode = TransferRequest::WRITE;
+        entry.length = kFaultLoopLength;
+        entry.source = init_ctx.local_addr_;
+        entry.target_id = init_ctx.segment_handle_;
+        entry.target_offset = init_ctx.remote_base_;
+
+        Status s = init_ctx.engine_->submitTransfer(batch_id, {entry});
+        if (s != Status::OK()) {
+            ADD_FAILURE() << "submitTransfer failed during injected receiver "
+                             "RNIC down/fallback: "
+                          << s.ToString();
+            transfer_ok = false;
+            break;
+        }
+        if (!waitForTransferWithTimeout(
+                init_ctx.engine_.get(), batch_id,
+                "20s WRITE during injected receiver RNIC down/fallback",
+                std::chrono::seconds(5))) {
+            transfer_ok = false;
+            break;
+        }
+        ++completed_transfers;
+    }
+
+    injector.join();
+    ASSERT_TRUE(injected_down.load(std::memory_order_acquire));
+    ASSERT_TRUE(injected_up.load(std::memory_order_acquire));
+    ASSERT_TRUE(inject_down_ok.load(std::memory_order_acquire));
+    ASSERT_TRUE(inject_up_ok.load(std::memory_order_acquire));
+    ASSERT_TRUE(transfer_ok);
+    ASSERT_GT(completed_transfers, 0u);
+
+    for (size_t i = 0; i < kFaultLoopLength; ++i) {
+        ASSERT_EQ(target_ctx.local_addr_[i], last_pattern)
+            << "Data mismatch at offset " << i;
+    }
+    LOG(INFO) << "Completed " << completed_transfers
+              << " transfers during injected receiver mlx5_3 down/fallback";
 }
 
 }  // namespace
@@ -475,8 +859,9 @@ extern "C" int __wrap_ibv_modify_qp(ibv_qp* qp, ibv_qp_attr* attr,
             gid_string = formatGidBytes(actual_gid.raw);
         }
         recordRtrAttempt(device_name, sgid_index, gid_string);
-        if (shouldInjectRtrEinval(device_name, sgid_index)) {
-            errno = EINVAL;
+        int injected_errno = injectedRtrErrnoOrZero(device_name, sgid_index);
+        if (injected_errno != 0) {
+            errno = injected_errno;
             return -1;
         }
     }

--- a/mooncake-transfer-engine/tests/rdma_endpoint_reestablish_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_endpoint_reestablish_test.cpp
@@ -120,7 +120,7 @@ bool RdmaTransportTestPeer::injectContextEvent(RdmaTransport* transport,
     for (auto& context : transport->context_list_) {
         if (context && context->deviceName() == device_name) {
             return RdmaContextTestPeer::injectContextEvent(context.get(),
-                                                          event_type);
+                                                           event_type);
         }
     }
     return false;
@@ -309,8 +309,8 @@ std::string makeNicPriorityMatrix(const std::string& preferred_devices,
                                   const std::string& fallback_devices) {
     auto formatted_preferred = formatDeviceNames(preferred_devices);
     auto formatted_fallback = formatDeviceNames(fallback_devices);
-    return "{\"cpu:0\": [[" + formatted_preferred + "],[" +
-           formatted_fallback + "]], "
+    return "{\"cpu:0\": [[" + formatted_preferred + "],[" + formatted_fallback +
+           "]], "
            " \"cpu:1\": [[" +
            formatted_preferred + "],[" + formatted_fallback + "]]}";
 }
@@ -340,15 +340,15 @@ bool waitForTransferWithTimeout(TransferEngine* engine, BatchID batch_id,
     while (std::chrono::steady_clock::now() < deadline) {
         Status s = engine->getTransferStatus(batch_id, 0, status);
         if (s != Status::OK()) {
-            ADD_FAILURE() << op_name << " getTransferStatus failed: "
-                          << s.ToString();
+            ADD_FAILURE() << op_name
+                          << " getTransferStatus failed: " << s.ToString();
             return false;
         }
         if (status.s == TransferStatusEnum::COMPLETED) {
             s = engine->freeBatchID(batch_id);
             if (s != Status::OK()) {
-                ADD_FAILURE() << op_name << " freeBatchID failed: "
-                              << s.ToString();
+                ADD_FAILURE()
+                    << op_name << " freeBatchID failed: " << s.ToString();
                 return false;
             }
             return true;
@@ -381,8 +381,8 @@ struct TEContext {
               const std::string& metadata_server, const std::string& segment_id,
               const std::string& device_name)
         : TEContext(local_server_name, metadata_server, segment_id,
-                    makeNicPriorityMatrix(device_name), RawNicPriorityMatrix{}) {
-    }
+                    makeNicPriorityMatrix(device_name),
+                    RawNicPriorityMatrix{}) {}
 
     TEContext(const std::string& local_server_name,
               const std::string& metadata_server, const std::string& segment_id,
@@ -568,8 +568,7 @@ TEST_F(RDMAEndpointReestablishTest,
     expectRtrEinvalRecoveredWithRetry(target_device_name);
 }
 
-TEST_F(RDMAEndpointReestablishTest,
-       SenderSingleRnicDownUsesFallbackLocalRnic) {
+TEST_F(RDMAEndpointReestablishTest, SenderSingleRnicDownUsesFallbackLocalRnic) {
     if (target_device_name == initiator_device_name) {
         GTEST_SKIP() << "Need two distinct RDMA devices for sender failover";
     }
@@ -578,11 +577,11 @@ TEST_F(RDMAEndpointReestablishTest,
         target_device_name + "," + initiator_device_name;
     const std::string target_matrix = makeNicPriorityMatrix(both_devices);
     LOG(INFO) << "========== Setting up dual-RNIC Target ==========";
-    TEContext target_ctx(target_server_name, metadata_server, "",
-                         target_matrix, RawNicPriorityMatrix{});
-    const std::string target_segment_name =
-        usesP2PHandshake(metadata_server) ? target_ctx.localSegmentName()
-                                          : target_server_name;
+    TEContext target_ctx(target_server_name, metadata_server, "", target_matrix,
+                         RawNicPriorityMatrix{});
+    const std::string target_segment_name = usesP2PHandshake(metadata_server)
+                                                ? target_ctx.localSegmentName()
+                                                : target_server_name;
 
     // Put the soon-to-be-down sender RNIC in the preferred tier and the
     // surviving sender RNIC in the fallback tier. This proves TE can skip the
@@ -596,10 +595,10 @@ TEST_F(RDMAEndpointReestablishTest,
 
     ASSERT_TRUE(RdmaTransportTestPeer::setContextActive(
         init_ctx.rdma_transport_, initiator_device_name, false));
-    ASSERT_FALSE(RdmaTransportTestPeer::contextActive(
-        init_ctx.rdma_transport_, initiator_device_name));
+    ASSERT_FALSE(RdmaTransportTestPeer::contextActive(init_ctx.rdma_transport_,
+                                                      initiator_device_name));
     ASSERT_TRUE(RdmaTransportTestPeer::contextActive(init_ctx.rdma_transport_,
-                                                    target_device_name));
+                                                     target_device_name));
 
     for (size_t i = 0; i < kDataLength; ++i) {
         init_ctx.local_addr_[i] = static_cast<uint8_t>((i * 17) % 251);
@@ -636,11 +635,11 @@ TEST_F(RDMAEndpointReestablishTest,
     }
 
     const std::string target_matrix = makeNicPriorityMatrix("mlx5_3,mlx5_4");
-    TEContext target_ctx(target_server_name, metadata_server, "",
-                         target_matrix, RawNicPriorityMatrix{});
-    const std::string target_segment_name =
-        usesP2PHandshake(metadata_server) ? target_ctx.localSegmentName()
-                                          : target_server_name;
+    TEContext target_ctx(target_server_name, metadata_server, "", target_matrix,
+                         RawNicPriorityMatrix{});
+    const std::string target_segment_name = usesP2PHandshake(metadata_server)
+                                                ? target_ctx.localSegmentName()
+                                                : target_server_name;
 
     const std::string sender_matrix = makeNicPriorityMatrix("mlx5_2", "mlx5_1");
     TEContext init_ctx(initiator_server_name, metadata_server,
@@ -653,17 +652,17 @@ TEST_F(RDMAEndpointReestablishTest,
     std::atomic<bool> inject_up_ok{false};
     std::thread injector([&] {
         std::this_thread::sleep_for(std::chrono::seconds(5));
-        inject_down_ok.store(RdmaTransportTestPeer::injectContextEvent(
-                                 init_ctx.rdma_transport_, "mlx5_2",
-                                 IBV_EVENT_PORT_ERR),
-                             std::memory_order_release);
+        inject_down_ok.store(
+            RdmaTransportTestPeer::injectContextEvent(
+                init_ctx.rdma_transport_, "mlx5_2", IBV_EVENT_PORT_ERR),
+            std::memory_order_release);
         injected_down.store(true, std::memory_order_release);
 
         std::this_thread::sleep_for(std::chrono::seconds(7));
-        inject_up_ok.store(RdmaTransportTestPeer::injectContextEvent(
-                               init_ctx.rdma_transport_, "mlx5_2",
-                               IBV_EVENT_PORT_ACTIVE),
-                           std::memory_order_release);
+        inject_up_ok.store(
+            RdmaTransportTestPeer::injectContextEvent(
+                init_ctx.rdma_transport_, "mlx5_2", IBV_EVENT_PORT_ACTIVE),
+            std::memory_order_release);
         injected_up.store(true, std::memory_order_release);
     });
 
@@ -731,11 +730,11 @@ TEST_F(RDMAEndpointReestablishTest,
     }
 
     const std::string target_matrix = makeNicPriorityMatrix("mlx5_3", "mlx5_4");
-    TEContext target_ctx(target_server_name, metadata_server, "",
-                         target_matrix, RawNicPriorityMatrix{});
-    const std::string target_segment_name =
-        usesP2PHandshake(metadata_server) ? target_ctx.localSegmentName()
-                                          : target_server_name;
+    TEContext target_ctx(target_server_name, metadata_server, "", target_matrix,
+                         RawNicPriorityMatrix{});
+    const std::string target_segment_name = usesP2PHandshake(metadata_server)
+                                                ? target_ctx.localSegmentName()
+                                                : target_server_name;
 
     const std::string sender_matrix = makeNicPriorityMatrix("mlx5_1,mlx5_2");
     TEContext init_ctx(initiator_server_name, metadata_server,
@@ -748,17 +747,17 @@ TEST_F(RDMAEndpointReestablishTest,
     std::atomic<bool> inject_up_ok{false};
     std::thread injector([&] {
         std::this_thread::sleep_for(std::chrono::seconds(5));
-        inject_down_ok.store(RdmaTransportTestPeer::injectContextEvent(
-                                 target_ctx.rdma_transport_, "mlx5_3",
-                                 IBV_EVENT_PORT_ERR),
-                             std::memory_order_release);
+        inject_down_ok.store(
+            RdmaTransportTestPeer::injectContextEvent(
+                target_ctx.rdma_transport_, "mlx5_3", IBV_EVENT_PORT_ERR),
+            std::memory_order_release);
         injected_down.store(true, std::memory_order_release);
 
         std::this_thread::sleep_for(std::chrono::seconds(7));
-        inject_up_ok.store(RdmaTransportTestPeer::injectContextEvent(
-                               target_ctx.rdma_transport_, "mlx5_3",
-                               IBV_EVENT_PORT_ACTIVE),
-                           std::memory_order_release);
+        inject_up_ok.store(
+            RdmaTransportTestPeer::injectContextEvent(
+                target_ctx.rdma_transport_, "mlx5_3", IBV_EVENT_PORT_ACTIVE),
+            std::memory_order_release);
         injected_up.store(true, std::memory_order_release);
     });
 

--- a/mooncake-transfer-engine/tests/topology_test.cpp
+++ b/mooncake-transfer-engine/tests/topology_test.cpp
@@ -145,8 +145,7 @@ TEST(ToplogyTest, TestDisableDeviceRemovesLocalHcaAffinityCandidate) {
     ASSERT_EQ(topology.parse(json_str), 0);
 
     const auto &hca_list = topology.getHcaList();
-    auto disabled_iter =
-        std::find(hca_list.begin(), hca_list.end(), "mlx5_2");
+    auto disabled_iter = std::find(hca_list.begin(), hca_list.end(), "mlx5_2");
     ASSERT_NE(disabled_iter, hca_list.end());
     const int disabled_index =
         static_cast<int>(std::distance(hca_list.begin(), disabled_iter));

--- a/mooncake-transfer-engine/tests/topology_test.cpp
+++ b/mooncake-transfer-engine/tests/topology_test.cpp
@@ -114,6 +114,28 @@ TEST(ToplogyTest, TestSelectDeviceAny) {
     ASSERT_TRUE(items.empty());
 }
 
+TEST(ToplogyTest, TestSelectDeviceEmptyEntry) {
+    mooncake::Topology topology;
+    std::string json_str = "{\"gpu:0\" : [[],[]]}";
+    topology.clear();
+    ASSERT_EQ(topology.parse(json_str), 0);
+
+    ASSERT_EQ(topology.selectDevice("gpu:0", 0), ERR_DEVICE_NOT_FOUND);
+    ASSERT_EQ(topology.selectDevice("gpu:0", 1), ERR_DEVICE_NOT_FOUND);
+}
+
+TEST(ToplogyTest, TestDisableOnlyPreferredDeviceLeavesNoSelection) {
+    mooncake::Topology topology;
+    std::string json_str = "{\"gpu:0\" : [[\"mlx5_2\"],[]]}";
+    topology.clear();
+    ASSERT_EQ(topology.parse(json_str), 0);
+    ASSERT_EQ(topology.selectDevice("gpu:0", 0), 0);
+
+    ASSERT_EQ(topology.disableDevice("mlx5_2"), 0);
+    ASSERT_EQ(topology.selectDevice("gpu:0", 0), ERR_DEVICE_NOT_FOUND);
+    ASSERT_EQ(topology.selectDevice("gpu:0", 1), ERR_DEVICE_NOT_FOUND);
+}
+
 int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/mooncake-transfer-engine/tests/topology_test.cpp
+++ b/mooncake-transfer-engine/tests/topology_test.cpp
@@ -136,6 +136,26 @@ TEST(ToplogyTest, TestDisableOnlyPreferredDeviceLeavesNoSelection) {
     ASSERT_EQ(topology.selectDevice("gpu:0", 1), ERR_DEVICE_NOT_FOUND);
 }
 
+TEST(ToplogyTest, TestDisableDeviceRemovesLocalHcaAffinityCandidate) {
+    mooncake::Topology topology;
+    std::string json_str =
+        "{\"cpu:0\" : [[\"mlx5_1\"],[\"mlx5_2\"]],"
+        "\"cpu:1\" : [[\"mlx5_2\"],[\"mlx5_1\"]]}";
+    topology.clear();
+    ASSERT_EQ(topology.parse(json_str), 0);
+
+    const auto &hca_list = topology.getHcaList();
+    auto disabled_iter =
+        std::find(hca_list.begin(), hca_list.end(), "mlx5_2");
+    ASSERT_NE(disabled_iter, hca_list.end());
+    const int disabled_index =
+        static_cast<int>(std::distance(hca_list.begin(), disabled_iter));
+
+    ASSERT_EQ(topology.disableDevice("mlx5_2"), 0);
+    ASSERT_NE(topology.selectDeviceByLocalHca("cpu:0", "mlx5_2", 0),
+              disabled_index);
+}
+
 int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();


### PR DESCRIPTION
## Description



This PR improves recovery when a local or peer RNIC becomes unavailable during RDMA transfers, especially under real link down/up scenarios. Refer to #2960

### Changes

- Add local RNIC failure handoff so slices can be retried through another active local RDMA context.
- Publish updated local topology when a context becomes inactive or recovers.
- Delay reactivating a recovered RNIC after `IBV_EVENT_PORT_ACTIVE`.
- Improve passive handshake failure replies so peers receive structured rejection reasons.
- Retry passive setup once with a fresh endpoint when a stale endpoint is retired.
- Rebuild pre-connected QPs instead of reusing partially handshaken QPs.
- Avoid selecting an inactive local context from request-level device preselection.
- Add a real RDMA link failover validation script.
- Extend RDMA reestablish/topology tests for sender and receiver RNIC failover.

## Module

- [X] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



**Test commands:**
```bash
# Example: bash scripts/run_ci_test.sh
```

**Test results:**
- [X] Unit tests pass
- [X] Integration tests pass (if applicable)
- [X] Manual testing done (describe below)

- Ran unit tests:

  ```bash
  ./build/mooncake-transfer-engine/tests/topology_test
  ./build/mooncake-transfer-engine/tests/rdma_context_reprobe_test
  ```

- Ran RDMA failover tests with `mlx5_1` through `mlx5_4`:

  ```bash
  MC_METADATA_SERVER=P2PHANDSHAKE \
  MC_TARGET_DEVICE_NAME=mlx5_3,mlx5_4 \
  MC_INITIATOR_DEVICE_NAME=mlx5_2,mlx5_1 \
  ./build/mooncake-transfer-engine/tests/rdma_endpoint_reestablish_test
  ```

- Ran real RDMA link failover validation with `mlx5_1` to `mlx5_4`; test passed.
  ```
  sudo mooncake-transfer-engine/scripts/real_rdma_link_failover.sh --fault-side sender
  sudo mooncake-transfer-engine/scripts/real_rdma_link_failover.sh --fault-side receiver
  ```

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have formatted my code using `./scripts/code_format.sh`
- [X] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [X] I have added tests to prove my changes are effective
- [X] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [X] AI tools were used (specify below): CodeX