### PR TITLE
[Store] Add P2P Redis HA end-to-end coverage

### DIFF
--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -32,12 +32,16 @@ This page summarizes useful flags, environment variables, and HTTP endpoints to 
   - `--election_backend` (str, default `etcd`): Election backend, either `etcd` or `redis`.
   - `--etcd_endpoints` (str, default empty unless HA config): etcd endpoints, semicolon separated.
   - `--redis_endpoint` (str, default empty): Redis endpoint for Redis-based HA, such as `10.0.0.10:6379`.
+  - `--redis_username` (str, default empty): Redis ACL username for Redis-based HA.
   - `--redis_password` (str, default empty): Redis AUTH password for Redis-based HA.
   - `--redis_db_index` (int, default `0`): Redis DB index for Redis-based HA.
   - `--redis_master_view_ttl_sec` (int, default `5`): TTL for the Redis master view key.
   - `--redis_heartbeat_interval_sec` (int, default `2`): Redis leader renewal interval. It must be smaller than `--redis_master_view_ttl_sec`.
   - `--client_ttl` (int64, default `10` s): Client alive TTL after last ping (HA mode).
   - `--cluster_id` (str, default `mooncake_cluster`): Cluster ID for persistence and HA metadata isolation.
+  - `--enable_oplog` (bool, default `false`): Enable master metadata OpLog recording.
+  - `--oplog_store_type` (str, default `localfs`): OpLog backend, for example `localfs` or `redis`.
+  - `--oplog_data_dir` (str, default `/tmp/mooncake_oplog`): OpLog data path for `localfs`; Redis endpoint for `redis`.
 
 ### P2P HA OpLog Coverage
 
@@ -77,19 +81,33 @@ mooncake_master \
   --enable_ha=true \
   --election_backend=redis \
   --redis_endpoint=10.0.0.10:6379 \
+  --redis_username=<redis_user> \
+  --redis_password=<redis_password> \
   --cluster_id=mooncake_cluster \
   --rpc_address=10.0.0.1
 ```
 
 Repeat the command on the other master nodes with their own reachable `--rpc_address` values, for example `10.0.0.2` and `10.0.0.3`, while keeping `--redis_endpoint` and `--cluster_id` identical.
 
-Clients should use the matching Redis endpoint for HA master discovery:
+Client configs should use the matching Redis endpoint for HA master discovery:
 
 ```text
 master_server_entry = "redis://10.0.0.10:6379"
+redis_username = "<redis_user>"
+redis_password = "<redis_password>"
 ```
 
-The client Redis cluster ID must match the masters' `--cluster_id`. If the client does not set a cluster ID explicitly, it uses the default `mooncake_cluster`.
+When starting `mooncake_client`, pass the same settings through the client flags:
+
+```bash
+mooncake_client \
+  --master_server_address=redis://10.0.0.10:6379 \
+  --redis_cluster_id=mooncake_cluster \
+  --redis_username=<redis_user> \
+  --redis_password=<redis_password>
+```
+
+The client Redis cluster ID must match the masters' `--cluster_id`. If the client does not set a cluster ID explicitly, it uses the default `mooncake_cluster`. If Redis does not require ACL authentication, leave `redis_username` and `redis_password` empty.
 
 Operational notes:
 
@@ -98,6 +116,45 @@ Operational notes:
 - The active leader renews the Redis master view key periodically. If the leader process exits or loses renewal, the key expires and another master can be elected.
 - Clients using `redis://` resolve the current leader from Redis and reconnect after heartbeat failures. Existing requests may fail during the failover window and should be retried by the caller.
 - Redis HA metadata is isolated by `--cluster_id`, so different Mooncake Store clusters can share one Redis instance when they use different cluster IDs.
+
+For P2P master HA, run the masters in P2P deployment mode and enable Redis-backed OpLog storage. The election Redis endpoint and the OpLog Redis endpoint may be the same Redis instance, but every master in the cluster must use the same values. Redis-backed OpLog uses the same `--redis_username` and `--redis_password` authentication settings.
+
+```bash
+mooncake_master \
+  --deployment_mode=P2P \
+  --enable_ha=true \
+  --election_backend=redis \
+  --redis_endpoint=10.0.0.10:6379 \
+  --redis_username=<redis_user> \
+  --redis_password=<redis_password> \
+  --cluster_id=p2p_mooncake_cluster \
+  --enable_oplog=true \
+  --oplog_store_type=redis \
+  --oplog_data_dir=10.0.0.10:6379 \
+  --rpc_address=10.0.0.1
+```
+
+P2P clients should also use Redis master discovery and the same cluster ID:
+
+```text
+master_server_entry = "redis://10.0.0.10:6379"
+redis_cluster_id = "p2p_mooncake_cluster"
+redis_username = "<redis_user>"
+redis_password = "<redis_password>"
+deployment_mode = "P2P"
+```
+
+For `mooncake_client` in P2P mode:
+
+```bash
+mooncake_client \
+  --deployment_mode=P2P \
+  --metadata_server=P2PHANDSHAKE \
+  --master_server_address=redis://10.0.0.10:6379 \
+  --redis_cluster_id=p2p_mooncake_cluster \
+  --redis_username=<redis_user> \
+  --redis_password=<redis_password>
+```
 
 **Tips:**
 

--- a/mooncake-store/src/real_client_main.cpp
+++ b/mooncake-store/src/real_client_main.cpp
@@ -16,6 +16,18 @@ DEFINE_string(master_server_address, "127.0.0.1:50051",
               "Master server address");
 DEFINE_string(protocol, "tcp", "Protocol");
 DEFINE_int32(port, 50052, "Real Client service port");
+DEFINE_string(redis_cluster_id, mooncake::DEFAULT_CLUSTER_ID,
+              "Redis HA cluster ID for redis:// master discovery");
+DEFINE_string(redis_username, "",
+              "Redis ACL username for redis:// master discovery");
+DEFINE_string(redis_password, "",
+              "Redis AUTH password for redis:// master discovery");
+DEFINE_int32(redis_db_index, 0,
+             "Redis database index for redis:// master discovery");
+DEFINE_int32(redis_master_view_ttl_sec, 5,
+             "Redis master view TTL for redis:// master discovery");
+DEFINE_int32(redis_heartbeat_interval_sec, 2,
+             "Redis heartbeat interval for redis:// master discovery");
 DEFINE_string(global_segment_size, "4 GB", "Size of global segment");
 DEFINE_int32(threads, 1, "Number of rpc threads for dummy client");
 DEFINE_bool(enable_offload, false, "Enable offload availability");
@@ -144,7 +156,10 @@ int main(int argc, char* argv[]) {
                 FLAGS_p2p_key_lease_scan_interval_ms,
                 FLAGS_p2p_transfer_direction_mode, FLAGS_runtime_config,
                 FLAGS_enable_client_metric_collection,
-                FLAGS_metric_report_interval_seconds);
+                FLAGS_metric_report_interval_seconds, FLAGS_redis_cluster_id,
+                FLAGS_redis_password, FLAGS_redis_db_index,
+                FLAGS_redis_master_view_ttl_sec,
+                FLAGS_redis_heartbeat_interval_sec, FLAGS_redis_username);
         } else {
             if (FLAGS_deployment_mode != "Centralization") {
                 LOG(WARNING)
@@ -162,7 +177,10 @@ int main(int argc, char* argv[]) {
                 FLAGS_enable_offload, static_cast<uint16_t>(FLAGS_http_port),
                 FLAGS_enable_http_server, {}, static_cast<uint16_t>(FLAGS_port),
                 FLAGS_runtime_config, FLAGS_enable_client_metric_collection,
-                FLAGS_metric_report_interval_seconds);
+                FLAGS_metric_report_interval_seconds, FLAGS_redis_cluster_id,
+                FLAGS_redis_password, FLAGS_redis_db_index,
+                FLAGS_redis_master_view_ttl_sec,
+                FLAGS_redis_heartbeat_interval_sec, FLAGS_redis_username);
         }
     }();
 

--- a/mooncake-store/tests/e2e/CMakeLists.txt
+++ b/mooncake-store/tests/e2e/CMakeLists.txt
@@ -81,6 +81,7 @@ if(STORE_USE_REDIS)
         NAME redis_chaos_test
         COMMAND redis_chaos_test
             --master_path=${CMAKE_BINARY_DIR}/mooncake-store/src/mooncake_master
+            --clientctl_path=${CMAKE_BINARY_DIR}/mooncake-store/tests/e2e/clientctl
             --out_dir=${CMAKE_BINARY_DIR}/redis_chaos_output
     )
     set_tests_properties(redis_chaos_test PROPERTIES

--- a/mooncake-store/tests/e2e/client_wrapper.cpp
+++ b/mooncake-store/tests/e2e/client_wrapper.cpp
@@ -3,14 +3,16 @@
 #include <cstring>
 #include <stdexcept>
 
+#include "p2p_client_service.h"
 #include "utils.h"
 
 namespace mooncake {
 namespace testing {
 
 ClientTestWrapper::ClientTestWrapper(std::shared_ptr<ClientService> client,
-                                     std::shared_ptr<SimpleAllocator> allocator)
-    : client_(client), allocator_(allocator) {}
+                                     std::shared_ptr<SimpleAllocator> allocator,
+                                     bool is_p2p)
+    : client_(client), is_p2p_(is_p2p), allocator_(allocator) {}
 
 ClientTestWrapper::~ClientTestWrapper() {
     for (auto& [base, segment] : segments_) {
@@ -23,18 +25,52 @@ ClientTestWrapper::CreateClientWrapper(
     const std::string& hostname, const std::string& metadata_connstring,
     const std::string& protocol, const std::string& device_name,
     const std::string& master_server_entry, size_t local_buffer_size,
-    const std::string& redis_cluster_id, bool enable_http_server) {
-    auto config = ClientConfigBuilder::build_centralized_real_client(
-        hostname, metadata_connstring, protocol, device_name,
-        master_server_entry, 0, local_buffer_size, nullptr, "", false, 9003,
-        enable_http_server);
-    if (!redis_cluster_id.empty()) {
-        config.redis_cluster_id = redis_cluster_id;
-    }
-    auto client_opt = ClientService::Create(config);
-
-    if (!client_opt.has_value()) {
-        return std::nullopt;
+    const std::string& redis_cluster_id, bool enable_http_server,
+    const std::string& deployment_mode,
+    const std::string& p2p_local_transfer_mode, uint16_t p2p_client_rpc_port,
+    const std::string& redis_username, const std::string& redis_password) {
+    std::shared_ptr<ClientService> client;
+    if (deployment_mode == "P2P") {
+        static constexpr const char* kP2PTierConfig =
+            R"({"tiers": [{"type": "DRAM", "capacity": 67108864, "priority": 100}]})";
+        auto config = ClientConfigBuilder::build_p2p_real_client(
+            hostname, metadata_connstring, protocol, device_name,
+            master_server_entry, kP2PTierConfig, local_buffer_size, nullptr, "",
+            p2p_client_rpc_port, /*rpc_thread_num=*/2,
+            /*lock_shard_count=*/1024,
+            /*route_cache_max_memory_bytes=*/300 * 1024 * 1024,
+            /*route_cache_ttl_ms=*/60 * 1000, p2p_local_transfer_mode,
+            /*local_memcpy_async_worker_num=*/32, /*http_port=*/9003,
+            enable_http_server);
+        if (!redis_cluster_id.empty()) {
+            config.redis_cluster_id = redis_cluster_id;
+        }
+        config.redis_username = redis_username;
+        config.redis_password = redis_password;
+        client = std::make_shared<P2PClientService>(
+            config.metadata_connstring, config.http_port,
+            config.enable_http_server, config.labels);
+        auto err =
+            std::static_pointer_cast<P2PClientService>(client)->Init(config);
+        if (err != ErrorCode::OK) {
+            LOG(ERROR) << "failed to init P2P client, error=" << err;
+            return std::nullopt;
+        }
+    } else {
+        auto config = ClientConfigBuilder::build_centralized_real_client(
+            hostname, metadata_connstring, protocol, device_name,
+            master_server_entry, 0, local_buffer_size, nullptr, "", false, 9003,
+            enable_http_server);
+        if (!redis_cluster_id.empty()) {
+            config.redis_cluster_id = redis_cluster_id;
+        }
+        config.redis_username = redis_username;
+        config.redis_password = redis_password;
+        auto client_opt = ClientService::Create(config);
+        if (!client_opt.has_value()) {
+            return std::nullopt;
+        }
+        client = client_opt.value();
     }
 
     std::shared_ptr<SimpleAllocator> allocator =
@@ -44,7 +80,7 @@ ClientTestWrapper::CreateClientWrapper(
         return std::nullopt;
     }
 
-    auto register_result = client_opt.value()->RegisterLocalMemory(
+    auto register_result = client->RegisterLocalMemory(
         allocator->getBase(), local_buffer_size, "cpu:0", false, false);
     ErrorCode error_code =
         register_result.has_value() ? ErrorCode::OK : register_result.error();
@@ -54,7 +90,8 @@ ClientTestWrapper::CreateClientWrapper(
                    << ", error=" << error_code;
         return std::nullopt;
     }
-    return std::make_shared<ClientTestWrapper>(client_opt.value(), allocator);
+    return std::make_shared<ClientTestWrapper>(client, allocator,
+                                               deployment_mode == "P2P");
 }
 
 ErrorCode ClientTestWrapper::Mount(const size_t size, void*& buffer) {
@@ -105,7 +142,6 @@ ErrorCode ClientTestWrapper::Get(const std::string& key, std::string& value) {
     if (query_result.value()->replicas.empty()) {
         return ErrorCode::INVALID_REPLICA;
     }
-
     uint64_t total_size =
         calculate_total_size(query_result.value()->replicas[0]);
     if (total_size == 0) {
@@ -140,11 +176,11 @@ ErrorCode ClientTestWrapper::Put(const std::string& key,
         offset += slice.size;
     }
 
-    // Configure replication
-    ReplicateConfig config;
-    config.replica_num = 1;
-
     // Perform put operation
+    ReplicateConfig replicate_config;
+    replicate_config.replica_num = 1;
+    WriteConfig config = is_p2p_ ? WriteConfig{WriteRouteRequestConfig{}}
+                                 : WriteConfig{replicate_config};
     auto put_result = client_->Put(key, slice_guard.slices_, config);
     return put_result.has_value() ? ErrorCode::OK : put_result.error();
 }

--- a/mooncake-store/tests/e2e/client_wrapper.cpp
+++ b/mooncake-store/tests/e2e/client_wrapper.cpp
@@ -47,15 +47,15 @@ ClientTestWrapper::CreateClientWrapper(
         }
         config.redis_username = redis_username;
         config.redis_password = redis_password;
-        client = std::make_shared<P2PClientService>(
+        auto p2p_client = std::make_shared<P2PClientService>(
             config.metadata_connstring, config.http_port,
             config.enable_http_server, config.labels);
-        auto err =
-            std::static_pointer_cast<P2PClientService>(client)->Init(config);
+        auto err = p2p_client->Init(config);
         if (err != ErrorCode::OK) {
             LOG(ERROR) << "failed to init P2P client, error=" << err;
             return std::nullopt;
         }
+        client = std::move(p2p_client);
     } else {
         auto config = ClientConfigBuilder::build_centralized_real_client(
             hostname, metadata_connstring, protocol, device_name,

--- a/mooncake-store/tests/e2e/client_wrapper.h
+++ b/mooncake-store/tests/e2e/client_wrapper.h
@@ -33,7 +33,8 @@ class ClientTestWrapper {
      * @param allocator Allocate slice memory for get and put operations.
      */
     ClientTestWrapper(std::shared_ptr<ClientService> client,
-                      std::shared_ptr<SimpleAllocator> allocator);
+                      std::shared_ptr<SimpleAllocator> allocator,
+                      bool is_p2p = false);
     ~ClientTestWrapper();
 
     // The client wrapper is not copyable.
@@ -64,7 +65,12 @@ class ClientTestWrapper {
                         const std::string& master_server_entry,
                         size_t local_buffer_size = 1024 * 1024 * 128,
                         const std::string& redis_cluster_id = "",
-                        bool enable_http_server = true);
+                        bool enable_http_server = true,
+                        const std::string& deployment_mode = "Centralization",
+                        const std::string& p2p_local_transfer_mode = "memcpy",
+                        uint16_t p2p_client_rpc_port = 0,
+                        const std::string& redis_username = "",
+                        const std::string& redis_password = "");
 
     // Mount a segment. The buffer will be used to unmount the segment.
     ErrorCode Mount(const size_t size, void*& buffer);
@@ -97,6 +103,7 @@ class ClientTestWrapper {
 
     // The client instance.
     std::shared_ptr<ClientService> client_;
+    bool is_p2p_{false};
     // The segments that are mounted by the client.
     std::unordered_map<uintptr_t, SegmentInfo> segments_;
     // Manage the memory allocation for get and put operations.

--- a/mooncake-store/tests/e2e/clientctl.cpp
+++ b/mooncake-store/tests/e2e/clientctl.cpp
@@ -14,6 +14,16 @@
 // Command line flags
 USE_engine_flags DEFINE_string(master_server_entry, "localhost:50051",
                                "Master server address");
+DEFINE_string(deployment_mode, "Centralization",
+              "Client deployment mode: Centralization or P2P");
+DEFINE_string(p2p_local_transfer_mode, "memcpy",
+              "P2P local transfer mode: memcpy or te");
+DEFINE_string(redis_cluster_id, "",
+              "Redis HA cluster ID for redis:// master discovery");
+DEFINE_string(redis_username, "",
+              "Redis ACL username for redis:// master discovery");
+DEFINE_string(redis_password, "",
+              "Redis AUTH password for redis:// master discovery");
 
 namespace mooncake {
 namespace testing {
@@ -39,6 +49,8 @@ class ClientCtl {
                 HandlePut(iss);
             } else if (cmd == "get") {
                 HandleGet(iss);
+            } else if (cmd == "expect_get") {
+                HandleExpectGet(iss);
             } else if (cmd == "mount") {
                 HandleMount(iss);
             } else if (cmd == "remove") {
@@ -73,7 +85,12 @@ class ClientCtl {
 
         auto client_opt = ClientTestWrapper::CreateClientWrapper(
             hostname, FLAGS_engine_meta_url, FLAGS_protocol, FLAGS_device_name,
-            FLAGS_master_server_entry);
+            FLAGS_master_server_entry,
+            /*local_buffer_size=*/1024 * 1024 * 128, FLAGS_redis_cluster_id,
+            /*enable_http_server=*/false, FLAGS_deployment_mode,
+            FLAGS_p2p_local_transfer_mode,
+            static_cast<uint16_t>(std::stoi(port)), FLAGS_redis_username,
+            FLAGS_redis_password);
 
         if (!client_opt.has_value()) {
             std::cout << "Failed to create client: " << name << std::endl;
@@ -133,6 +150,40 @@ class ClientCtl {
             return;
         }
         std::cout << "Get value: " << value << std::endl;
+    }
+
+    void HandleExpectGet(std::istringstream& iss) {
+        std::string name, key, expected;
+        iss >> name >> key >> expected;
+
+        auto it = clients_.find(name);
+        if (it == clients_.end()) {
+            std::cout << "Failed to expect value: client not found: " << name
+                      << std::endl;
+            return;
+        }
+
+        if (key.empty() || expected.empty()) {
+            std::cout << "Failed to expect value: empty key or value"
+                      << std::endl;
+            return;
+        }
+
+        std::string value;
+        ErrorCode error_code = it->second.client->Get(key, value);
+        if (error_code != ErrorCode::OK) {
+            std::cout << "Failed to expect value: " << toString(error_code)
+                      << std::endl;
+            return;
+        }
+        if (value != expected) {
+            std::cout << "Failed to expect value: key=" << key
+                      << " expected=" << expected << " actual=" << value
+                      << std::endl;
+            return;
+        }
+        std::cout << "Successfully expected value for key: " << key
+                  << std::endl;
     }
 
     void HandleMount(std::istringstream& iss) {

--- a/mooncake-store/tests/e2e/process_handler.cpp
+++ b/mooncake-store/tests/e2e/process_handler.cpp
@@ -122,8 +122,22 @@ bool MasterProcessHandler::start() {
         // Execute the master
         std::string rpc_address_arg = "--rpc-address=" + config_.rpc_address;
         std::string rpc_port_arg = "--rpc-port=" + std::to_string(port_);
-        std::vector<std::string> args = {master_path_, "--enable-ha=true",
-                                         rpc_address_arg, rpc_port_arg};
+        std::vector<std::string> args = {
+            master_path_,
+            "--enable-ha=true",
+            rpc_address_arg,
+            rpc_port_arg,
+            "--deployment-mode=" + config_.deployment_mode,
+            "--max-replicas-per-key=" +
+                std::to_string(config_.max_replicas_per_key)};
+
+        if (config_.enable_oplog) {
+            args.emplace_back("--enable-oplog=true");
+            args.emplace_back("--oplog-store-type=" + config_.oplog_store_type);
+            if (!config_.oplog_data_dir.empty()) {
+                args.emplace_back("--oplog-data-dir=" + config_.oplog_data_dir);
+            }
+        }
 
         if (config_.election_backend == "redis") {
             args.emplace_back("--election-backend=redis");
@@ -151,7 +165,9 @@ bool MasterProcessHandler::start() {
 
         LOG(INFO) << "[m" << index_ << "] Exec master " << rpc_address_arg
                   << " " << rpc_port_arg
-                  << " backend=" << config_.election_backend;
+                  << " backend=" << config_.election_backend
+                  << " deployment=" << config_.deployment_mode
+                  << " enable_oplog=" << config_.enable_oplog;
         std::vector<char*> argv;
         argv.reserve(args.size() + 1);
         for (auto& arg : args) {

--- a/mooncake-store/tests/e2e/process_handler.h
+++ b/mooncake-store/tests/e2e/process_handler.h
@@ -37,6 +37,11 @@ struct MasterRunnerConfig {
     int redis_heartbeat_interval_sec = 2;
     std::string cluster_id;
     std::string rpc_address = "0.0.0.0";
+    std::string deployment_mode = "Centralization";
+    bool enable_oplog = false;
+    std::string oplog_store_type = "localfs";
+    std::string oplog_data_dir;
+    int max_replicas_per_key = 0;
 };
 
 class MasterProcessHandler {

--- a/mooncake-store/tests/e2e/redis_chaos_test.cpp
+++ b/mooncake-store/tests/e2e/redis_chaos_test.cpp
@@ -1,16 +1,26 @@
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <gtest/gtest.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 #include <chrono>
+#include <cerrno>
+#include <cstring>
 #include <memory>
+#include <sstream>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <vector>
 
 #include "client_wrapper.h"
 #include "e2e_utils.h"
+#include "ha/oplog/p2p_oplog_types.h"
+#include "ha/oplog/redis_oplog_store.h"
 #include "process_handler.h"
 #include "redis_master_view_helper.h"
 #include "../redis_test_utils.h"
@@ -20,6 +30,8 @@
 
 FLAG_master_path;
 FLAG_out_dir;
+DEFINE_string(clientctl_path, "./mooncake-store/tests/e2e/clientctl",
+              "Path to the clientctl executable");
 DEFINE_string(redis_endpoint, "127.0.0.1:6379",
               "Redis endpoint for Redis master failover test");
 DEFINE_string(redis_username, "",
@@ -96,12 +108,26 @@ void CleanupRedisKeys() {
         return;
     }
 
-    std::string master_view_key = MasterViewKey();
-    std::string master_epoch_key = MasterEpochKey();
-    redisReply* reply = static_cast<redisReply*>(redisCommand(
-        ctx, "DEL %b %b", master_view_key.data(), master_view_key.size(),
-        master_epoch_key.data(), master_epoch_key.size()));
-    if (reply) freeReplyObject(reply);
+    std::vector<std::string> keys = {MasterViewKey(), MasterEpochKey()};
+    std::string oplog_pattern =
+        "mooncake:{" + FLAGS_redis_cluster_id + "}:oplog*";
+    redisReply* keys_reply = static_cast<redisReply*>(redisCommand(
+        ctx, "KEYS %b", oplog_pattern.data(), oplog_pattern.size()));
+    if (keys_reply && keys_reply->type == REDIS_REPLY_ARRAY) {
+        for (size_t i = 0; i < keys_reply->elements; ++i) {
+            redisReply* key = keys_reply->element[i];
+            if (key && key->type == REDIS_REPLY_STRING) {
+                keys.emplace_back(key->str, key->len);
+            }
+        }
+    }
+    if (keys_reply) freeReplyObject(keys_reply);
+
+    for (const auto& key : keys) {
+        redisReply* reply = static_cast<redisReply*>(
+            redisCommand(ctx, "DEL %b", key.data(), key.size()));
+        if (reply) freeReplyObject(reply);
+    }
     redisFree(ctx);
 }
 
@@ -113,6 +139,179 @@ int MasterIndexFromAddress(const std::string& master_address) {
     int port = std::stoi(master_address.substr(colon_pos + 1));
     return port - kMasterPortBase;
 }
+
+class ClientCtlProcess {
+   public:
+    ClientCtlProcess(int index, const std::string& out_dir)
+        : index_(index), out_dir_(out_dir) {}
+
+    ~ClientCtlProcess() { Stop(); }
+
+    bool Start() {
+        if (mkdir(out_dir_.c_str(), 0755) != 0 && errno != EEXIST) {
+            LOG(ERROR) << "failed to create output dir: " << out_dir_
+                       << ", error=" << strerror(errno);
+            return false;
+        }
+        int stdin_pipe[2] = {-1, -1};
+        int stdout_pipe[2] = {-1, -1};
+        if (pipe(stdin_pipe) != 0) {
+            LOG(ERROR) << "failed to create clientctl pipes: "
+                       << strerror(errno);
+            return false;
+        }
+        if (pipe(stdout_pipe) != 0) {
+            LOG(ERROR) << "failed to create clientctl pipes: "
+                       << strerror(errno);
+            close(stdin_pipe[0]);
+            close(stdin_pipe[1]);
+            return false;
+        }
+
+        pid_t pid = fork();
+        if (pid == -1) {
+            LOG(ERROR) << "failed to fork clientctl: " << strerror(errno);
+            close(stdin_pipe[0]);
+            close(stdin_pipe[1]);
+            close(stdout_pipe[0]);
+            close(stdout_pipe[1]);
+            return false;
+        }
+
+        if (pid == 0) {
+            dup2(stdin_pipe[0], STDIN_FILENO);
+            dup2(stdout_pipe[1], STDOUT_FILENO);
+
+            std::string stderr_file =
+                out_dir_ + "/clientctl_" + std::to_string(index_) + ".err";
+            int stderr_fd =
+                open(stderr_file.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
+            if (stderr_fd >= 0) {
+                dup2(stderr_fd, STDERR_FILENO);
+                close(stderr_fd);
+            }
+
+            close(stdin_pipe[0]);
+            close(stdin_pipe[1]);
+            close(stdout_pipe[0]);
+            close(stdout_pipe[1]);
+
+            std::vector<std::string> args = {
+                FLAGS_clientctl_path,
+                "--master_server_entry=redis://" + FLAGS_redis_endpoint,
+                "--redis_cluster_id=" + FLAGS_redis_cluster_id,
+                "--redis_username=" + FLAGS_redis_username,
+                "--redis_password=" + FLAGS_redis_password,
+                "--deployment_mode=P2P",
+                "--p2p_local_transfer_mode=memcpy",
+                "--engine_meta_url=P2PHANDSHAKE",
+                "--protocol=tcp",
+                "--device_name="};
+            std::vector<char*> argv;
+            argv.reserve(args.size() + 1);
+            for (auto& arg : args) {
+                argv.push_back(arg.data());
+            }
+            argv.push_back(nullptr);
+            execv(FLAGS_clientctl_path.c_str(), argv.data());
+            LOG(ERROR) << "clientctl exec failed: " << strerror(errno);
+            _exit(1);
+        }
+
+        pid_ = pid;
+        stdin_fd_ = stdin_pipe[1];
+        stdout_fd_ = stdout_pipe[0];
+        close(stdin_pipe[0]);
+        close(stdout_pipe[1]);
+        int flags = fcntl(stdout_fd_, F_GETFL, 0);
+        fcntl(stdout_fd_, F_SETFL, flags | O_NONBLOCK);
+        return true;
+    }
+
+    bool SendAndWait(const std::string& command,
+                     const std::string& expected_output,
+                     std::chrono::seconds timeout) {
+        size_t start_pos = output_.size();
+        std::string line = command + "\n";
+        if (write(stdin_fd_, line.data(), line.size()) < 0) {
+            LOG(ERROR) << "failed to write clientctl command: "
+                       << strerror(errno);
+            return false;
+        }
+
+        auto deadline = std::chrono::steady_clock::now() + timeout;
+        char buffer[1024];
+        while (std::chrono::steady_clock::now() < deadline) {
+            ssize_t n = read(stdout_fd_, buffer, sizeof(buffer));
+            if (n > 0) {
+                output_.append(buffer, n);
+                std::string_view new_output(output_.data() + start_pos,
+                                            output_.size() - start_pos);
+                if (new_output.find(expected_output) !=
+                    std::string_view::npos) {
+                    return true;
+                }
+                if (new_output.find("Failed to ") != std::string_view::npos ||
+                    new_output.find("Unknown command") !=
+                        std::string_view::npos) {
+                    LOG(ERROR)
+                        << "clientctl command failed, output=" << new_output;
+                    return false;
+                }
+            } else if (n == 0) {
+                LOG(ERROR) << "clientctl exited, output=" << output_;
+                return false;
+            } else if (errno != EAGAIN && errno != EWOULDBLOCK) {
+                LOG(ERROR) << "failed to read clientctl output: "
+                           << strerror(errno);
+                return false;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        }
+        std::string_view new_output(output_.data() + start_pos,
+                                    output_.size() - start_pos);
+        LOG(ERROR) << "timed out waiting for clientctl output: "
+                   << expected_output << ", output=" << new_output;
+        return false;
+    }
+
+    void Stop() {
+        if (stdin_fd_ >= 0) {
+            std::string command = "terminate\n";
+            (void)write(stdin_fd_, command.data(), command.size());
+            close(stdin_fd_);
+            stdin_fd_ = -1;
+        }
+        if (stdout_fd_ >= 0) {
+            close(stdout_fd_);
+            stdout_fd_ = -1;
+        }
+        if (pid_ > 0) {
+            int status = 0;
+            auto deadline =
+                std::chrono::steady_clock::now() + std::chrono::seconds(5);
+            while (std::chrono::steady_clock::now() < deadline) {
+                pid_t ret = waitpid(pid_, &status, WNOHANG);
+                if (ret == pid_) {
+                    pid_ = 0;
+                    return;
+                }
+                std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            }
+            kill(pid_, SIGKILL);
+            waitpid(pid_, &status, 0);
+            pid_ = 0;
+        }
+    }
+
+   private:
+    int index_;
+    std::string out_dir_;
+    pid_t pid_{0};
+    int stdin_fd_{-1};
+    int stdout_fd_{-1};
+    std::string output_;
+};
 
 }  // namespace
 
@@ -143,6 +342,11 @@ class RedisChaosTest : public ::testing::Test {
             FLAGS_redis_heartbeat_interval_sec;
         config.cluster_id = FLAGS_redis_cluster_id;
         config.rpc_address = "127.0.0.1";
+        config.deployment_mode = "P2P";
+        config.enable_oplog = true;
+        config.oplog_store_type = "redis";
+        config.oplog_data_dir = FLAGS_redis_endpoint;
+        config.max_replicas_per_key = 0;
 
         for (int i = 0; i < kMasterNum; ++i) {
             masters_.emplace_back(std::make_unique<MasterProcessHandler>(
@@ -222,7 +426,10 @@ class RedisChaosTest : public ::testing::Test {
                 "127.0.0.1:" + std::to_string(kClientPortBase + index),
                 "P2PHANDSHAKE", "tcp", "", "redis://" + FLAGS_redis_endpoint,
                 /*local_buffer_size=*/1024 * 1024 * 128, FLAGS_redis_cluster_id,
-                /*enable_http_server=*/false);
+                /*enable_http_server=*/false, /*deployment_mode=*/"P2P",
+                /*p2p_local_transfer_mode=*/"memcpy",
+                static_cast<uint16_t>(kClientPortBase + index),
+                FLAGS_redis_username, FLAGS_redis_password);
             if (client.has_value()) {
                 return client.value();
             }
@@ -244,6 +451,66 @@ class RedisChaosTest : public ::testing::Test {
                 if (client.Get(key, got) == ErrorCode::OK && got == value) {
                     return true;
                 }
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        }
+        return false;
+    }
+
+    bool WaitForClientGet(ClientTestWrapper& client, const std::string& key,
+                          const std::string& value,
+                          std::chrono::seconds timeout) {
+        auto deadline = std::chrono::steady_clock::now() + timeout;
+        while (std::chrono::steady_clock::now() < deadline) {
+            std::string got;
+            if (client.Get(key, got) == ErrorCode::OK && got == value) {
+                return true;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        }
+        return false;
+    }
+
+    bool WaitForReplicaOpLog(const std::string& key,
+                             std::chrono::seconds timeout) {
+        RedisOpLogStore store(FLAGS_redis_cluster_id, FLAGS_redis_endpoint,
+                              /*enable_write=*/false,
+                              /*poll_interval_ms=*/100, FLAGS_redis_password,
+                              FLAGS_redis_username);
+        if (store.Init() != ErrorCode::OK) {
+            return false;
+        }
+
+        uint64_t read_from_seq = 0;
+        auto deadline = std::chrono::steady_clock::now() + timeout;
+        while (std::chrono::steady_clock::now() < deadline) {
+            std::vector<OpLogEntry> entries;
+            if (store.ReadOpLogSince(read_from_seq, 100, entries) ==
+                ErrorCode::OK) {
+                for (const auto& entry : entries) {
+                    if (entry.sequence_id > read_from_seq) {
+                        read_from_seq = entry.sequence_id;
+                    }
+                    if (entry.op_type == OpType_ADD_REPLICA &&
+                        entry.object_key == key) {
+                        return true;
+                    }
+                }
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        }
+        return false;
+    }
+
+    bool WaitForClientCtlCommand(ClientCtlProcess& client,
+                                 const std::string& command,
+                                 const std::string& expected_output,
+                                 std::chrono::seconds timeout) {
+        auto deadline = std::chrono::steady_clock::now() + timeout;
+        while (std::chrono::steady_clock::now() < deadline) {
+            if (client.SendAndWait(command, expected_output,
+                                   std::chrono::seconds(5))) {
+                return true;
             }
             std::this_thread::sleep_for(std::chrono::milliseconds(500));
         }
@@ -294,13 +561,22 @@ TEST_F(RedisChaosTest, ClientRedisDiscoverySurvivesLeaderFailover) {
     ASSERT_TRUE(WaitForLeader(leader_index, version, std::chrono::seconds(10)));
     WaitForLeaderServiceReady();
 
-    auto client = CreateRedisClient(/*index=*/0, std::chrono::seconds(30));
-    ASSERT_NE(client, nullptr);
+    ClientCtlProcess client(/*index=*/0, FLAGS_out_dir);
+    ASSERT_TRUE(client.Start());
+    ASSERT_TRUE(client.SendAndWait(
+        "create c0 " + std::to_string(kClientPortBase),
+        "Successfully created client: c0", std::chrono::seconds(30)));
 
-    void* buffer = nullptr;
-    ASSERT_EQ(client->Mount(1024 * 1024 * 16, buffer), ErrorCode::OK);
-    ASSERT_TRUE(WaitForClientPutGet(*client, "redis_failover_before", "value",
-                                    std::chrono::seconds(5)));
+    const std::string key = "redis_oplog_before_failover";
+    const std::string value = "value_before_failover";
+    ASSERT_TRUE(client.SendAndWait("put c0 " + key + " " + value,
+                                   "Successfully put value for key: " + key,
+                                   std::chrono::seconds(10)));
+    ASSERT_TRUE(
+        client.SendAndWait("expect_get c0 " + key + " " + value,
+                           "Successfully expected value for key: " + key,
+                           std::chrono::seconds(10)));
+    ASSERT_TRUE(WaitForReplicaOpLog(key, std::chrono::seconds(10)));
 
     ASSERT_TRUE(masters_[leader_index]->kill());
 
@@ -310,8 +586,20 @@ TEST_F(RedisChaosTest, ClientRedisDiscoverySurvivesLeaderFailover) {
         WaitForNewLeader(leader_index, version, new_leader_index, new_version));
     WaitForLeaderServiceReady();
 
-    ASSERT_TRUE(WaitForClientPutGet(*client, "redis_failover_after", "value2",
-                                    std::chrono::seconds(60)));
+    ASSERT_TRUE(
+        client.SendAndWait("expect_get c0 " + key + " " + value,
+                           "Successfully expected value for key: " + key,
+                           std::chrono::seconds(60)));
+    const std::string after_key = "redis_failover_after";
+    const std::string after_value = "value2";
+    ASSERT_TRUE(WaitForClientCtlCommand(
+        client, "put c0 " + after_key + " " + after_value,
+        "Successfully put value for key: " + after_key,
+        std::chrono::seconds(60)));
+    ASSERT_TRUE(
+        client.SendAndWait("expect_get c0 " + after_key + " " + after_value,
+                           "Successfully expected value for key: " + after_key,
+                           std::chrono::seconds(30)));
 }
 
 }  // namespace testing

--- a/mooncake-store/tests/e2e/redis_chaos_test.cpp
+++ b/mooncake-store/tests/e2e/redis_chaos_test.cpp
@@ -179,6 +179,13 @@ class ClientCtlProcess {
         }
 
         if (pid == 0) {
+            struct sigaction default_action = {};
+            default_action.sa_handler = SIG_DFL;
+            sigemptyset(&default_action.sa_mask);
+            if (sigaction(SIGPIPE, &default_action, nullptr) != 0) {
+                _exit(1);
+            }
+
             dup2(stdin_pipe[0], STDIN_FILENO);
             dup2(stdout_pipe[1], STDOUT_FILENO);
 
@@ -296,6 +303,17 @@ class ClientCtlProcess {
                     pid_ = 0;
                     return;
                 }
+                if (ret < 0) {
+                    if (errno == EINTR) {
+                        continue;
+                    }
+                    if (errno != ECHILD) {
+                        LOG(ERROR) << "failed to wait for clientctl: "
+                                   << strerror(errno);
+                    }
+                    pid_ = 0;
+                    return;
+                }
                 std::this_thread::sleep_for(std::chrono::milliseconds(100));
             }
             kill(pid_, SIGKILL);
@@ -320,9 +338,19 @@ class RedisChaosTest : public ::testing::Test {
     static void SetUpTestSuite() {
         google::InitGoogleLogging("RedisChaosTest");
         FLAGS_logtostderr = 1;
+
+        struct sigaction ignore_action = {};
+        ignore_action.sa_handler = SIG_IGN;
+        sigemptyset(&ignore_action.sa_mask);
+        ASSERT_EQ(sigaction(SIGPIPE, &ignore_action, &old_sigpipe_action_), 0)
+            << strerror(errno);
     }
 
-    static void TearDownTestSuite() { google::ShutdownGoogleLogging(); }
+    static void TearDownTestSuite() {
+        EXPECT_EQ(sigaction(SIGPIPE, &old_sigpipe_action_, nullptr), 0)
+            << strerror(errno);
+        google::ShutdownGoogleLogging();
+    }
 
     void SetUp() override {
         CleanupRedisKeys();
@@ -519,6 +547,7 @@ class RedisChaosTest : public ::testing::Test {
 
     std::vector<std::unique_ptr<MasterProcessHandler>> masters_;
     std::unique_ptr<RedisMasterViewHelper> master_view_helper_;
+    inline static struct sigaction old_sigpipe_action_ = {};
 };
 
 TEST_F(RedisChaosTest, LeaderKilledFailover) {


### PR DESCRIPTION
## Description

  Add end-to-end coverage for Redis-backed P2P Store high availability.

  - Add Redis HA test scenarios covering leader termination, leader-key deletion and automatic re-election.
  - Verify that P2P clients rediscover the leader and continue operating after failover.
  - Extend E2E client and process helpers to support Redis discovery, authentication, P2P deployment mode and OpLog configuration.
  - Add Redis HA configuration flags to mooncake_client.
  - Document Redis-backed P2P HA deployment, client discovery and OpLog configuration.

  ## Module

  - [ ] Transfer Engine (mooncake-transfer-engine)
  - [ ] Mooncake Store (mooncake-store)
  - [ ] Mooncake EP (mooncake-ep)
  - [ ] Mooncake PG (mooncake-pg)
  - [ ] Integration (mooncake-integration)
  - [x] P2P Store (mooncake-p2p-store)
  - [ ] Python Wheel (mooncake-wheel)
  - [ ] Common (mooncake-common)
  - [ ] Mooncake RL (mooncake-rl)
  - [ ] CI/CD
  - [x] Docs
  - [ ] Other

  ## Type of Change

  - [ ] Bug fix
  - [x] New feature
  - [ ] Refactor
  - [ ] Breaking change
  - [x] Documentation update
  - [ ] Performance improvement
  - [ ] Other

  ## How Has This Been Tested?

  Formatted the changed C/C++ files and built the project in the local Mooncake verification container. The Redis HA E2E test exercises leader termination, leader-key deletion and client recovery after failover.

  Test commands:
```
  ./scripts/code_format.sh --base P2P-Mooncake-Store
  cmake --build build-oplog-v4 -j$(nproc)
  ctest --test-dir build-oplog-v4 -L redis_ha --output-on-failure
```
  Test results:

  - [ ] Unit tests pass
  - [ ] Integration tests pass (in progress)
  - [ ] Manual testing done (describe below)

  ## Checklist

  - [x] I have performed a self-review of my own code
  - [x] I have formatted my code using ./scripts/code_format.sh
  - [ ] I have run pre-commit run --all-files and all hooks pass
  - [x] I have updated the documentation (if applicable)
  - [x] I have added tests to prove my changes are effective
  - [ ] For changes >500 LOC: I have filed an RFC issue

  ## AI Assistance Disclosure

  - [ ] No AI tools were used
  - [x] AI tools were used (specify below)

  Codex was used to help rebase the branch, review the changes, format the code, run build and test commands, and prepare the PR description.