### PR TITLE
[TransferEngine] Make single unregisterLocalMemory best-effort

### DIFF
--- a/mooncake-transfer-engine/src/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine_impl.cpp
@@ -616,10 +616,14 @@ int TransferEngineImpl::registerLocalMemory(void* addr, size_t length,
 
 int TransferEngineImpl::unregisterLocalMemory(void* addr,
                                               bool update_metadata) {
+    // Best-effort: try every transport so one failure can't leave the region
+    // registered on the others; mirrors unregisterLocalMemoryBatch (#2869).
+    int first_error = 0;
     for (auto& transport : multi_transports_->listTransports()) {
         int ret = transport->unregisterLocalMemory(addr, update_metadata);
-        if (ret) return ret;
+        if (ret && !first_error) first_error = ret;
     }
+    if (first_error) return first_error;
 
     std::unique_lock<std::shared_mutex> lock(mutex_);
     eraseMemoryRegionLocked(addr);


### PR DESCRIPTION
## Description

`TransferEngineImpl::unregisterLocalMemory` iterates every transport and returned on the **first** transport whose `unregisterLocalMemory` failed:

```cpp
for (auto& transport : multi_transports_->listTransports()) {
    int ret = transport->unregisterLocalMemory(addr, update_metadata);
    if (ret) return ret;   // aborts before the remaining transports
}
```

In a multi-transport setup, if the first transport's unregister fails the remaining transports keep the region **registered** (a resource leak) and the local `eraseMemoryRegionLocked(addr)` bookkeeping is skipped.

This makes the single-memory path best-effort — attempt every transport, keep the first error, and return it — exactly the pattern #2869 just established for `registerLocalMemoryBatch` / `unregisterLocalMemoryBatch` (and the Ascend/HCCL unregister loops). Behavior on the all-success path is unchanged.

Refs #2869.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

I could not build the full stack on this host (Linux-only deps), so I verified the control-flow change with a standalone harness that mirrors both the old and new loops with a fake 3-transport list where the first transport fails:

```
OLD: attempts=1 ret=5 -> transports left registered=2 (LEAK)
NEW: attempts=3 ret=5 -> all transports attempted, error still propagated
```

So the old code stops after the first failure (leaving 2 transports registered), while the new code unregisters from all three and still returns the first error. Full compile/tests rely on CI.

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (standalone control-flow harness, above)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh` — clang-format was not available on this host; I hand-matched the existing style (Google, 80 col) and CI will verify
- [ ] I have run `pre-commit run --all-files` and all hooks pass — toolchain unavailable locally; relying on CI
- [ ] I have updated the documentation (if applicable) — not applicable
- [ ] I have added tests to prove my changes are effective — no unit-test seam exists for this transport-loop path without a full multi-transport engine; verified with the standalone harness above
- [ ] For changes >500 LOC: I have filed an RFC issue — not applicable (5 LOC)

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

Claude Code helped locate this sibling of #2869 and build the standalone harness above. The change is small and was reviewed line by line: it mirrors the `first_error` best-effort pattern #2869 introduced for the batch/Ascend/HCCL paths, applied to the single-memory path in the same file.