### PR TITLE
[TransferEngine] Roll back partial registration in registerLocalMemory

### DIFF
--- a/mooncake-transfer-engine/src/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine_impl.cpp
@@ -601,10 +601,26 @@ int TransferEngineImpl::registerLocalMemory(void* addr, size_t length,
         return ERR_ADDRESS_OVERLAPPED;
     }
 
+    std::vector<Transport*> attempted_transports;
     for (auto transport : multi_transports_->listTransports()) {
+        attempted_transports.push_back(transport);
         int ret = transport->registerLocalMemory(
             addr, length, location, remote_accessible, update_metadata);
         if (ret < 0) {
+            // Roll back the transports that already registered so a partial
+            // failure doesn't leave the region registered on some of them.
+            // Mirrors registerLocalMemoryBatch (#2869).
+            for (auto it = attempted_transports.rbegin();
+                 it != attempted_transports.rend(); ++it) {
+                int rollback_ret =
+                    (*it)->unregisterLocalMemory(addr, update_metadata);
+                if (rollback_ret != 0 &&
+                    rollback_ret != ERR_ADDRESS_NOT_REGISTERED) {
+                    LOG(WARNING)
+                        << "Failed to roll back registration for "
+                        << (*it)->getName() << ", ret=" << rollback_ret;
+                }
+            }
             releaseMemoryRegions(regions);
             return ret;
         }


### PR DESCRIPTION
## Description

`TransferEngineImpl::registerLocalMemory` registers the region on each transport in turn:

```cpp
for (auto transport : multi_transports_->listTransports()) {
    int ret = transport->registerLocalMemory(...);
    if (ret < 0) {
        releaseMemoryRegions(regions);   // only undoes the reservation bookkeeping
        return ret;
    }
}
```

When a later transport fails, the transports that already registered are **left registered** — only the reservation bookkeeping (`releaseMemoryRegions`) is undone, so the region leaks on the earlier transports.

This is the single-memory sibling of the rollback #2869 added to `registerLocalMemoryBatch`. It tracks the attempted transports and, on failure, unregisters them in reverse (best-effort, ignoring `ERR_ADDRESS_NOT_REGISTERED` and logging other rollback errors) before releasing the reservation. The all-success path is unchanged.

Refs #2869.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

I could not build the full stack on this host (Linux-only deps), so I verified the control-flow change with a standalone harness that mirrors the loop with a fake 4-transport list where the third transport fails:

```
OLD: still-registered after failure = 2 (LEAK)
NEW: ret=-1, still-registered after failure = 0 (rolled back)
```

So the old code leaves the two already-registered transports registered, while the new code rolls them back and still returns the original error. Full compile/tests rely on CI. The rollback mirrors the pattern already merged for `registerLocalMemoryBatch` in the same file (#2869), so `getName()` / `ERR_ADDRESS_NOT_REGISTERED` usage matches the batch path.

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (standalone control-flow harness, above)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh` — clang-format was not available on this host; I hand-matched the existing style (Google, 80 col, mirroring the batch rollback in the same file) and CI will verify
- [ ] I have run `pre-commit run --all-files` and all hooks pass — toolchain unavailable locally; relying on CI
- [ ] I have updated the documentation (if applicable) — not applicable
- [ ] I have added tests to prove my changes are effective — no unit-test seam exists for this multi-transport loop without a full engine; verified with the standalone harness above
- [ ] For changes >500 LOC: I have filed an RFC issue — not applicable (16 LOC)

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

Claude Code helped locate this sibling of #2869 and build the standalone harness above. The change is small and was reviewed line by line: it mirrors the `attempted_transports` reverse-rollback pattern #2869 introduced for `registerLocalMemoryBatch`, applied to the single-memory path in the same file.