### PR TITLE
[Bug]: [SSD] DSV4 enable SSD offload，stress testing, repeat offloading the same batch key, lead to OBJECT_ALREADY_EXISTS/persist failed/INVALID_KEY

### DIFF
--- a/mooncake-store/include/file_storage.h
+++ b/mooncake-store/include/file_storage.h
@@ -78,6 +78,26 @@ class FileStorage {
         const std::vector<OffloadTaskItem>& offloading_objects);
 
     /**
+     * @brief Classifies a BatchOffload error as affecting only the current
+     * bucket rather than the whole offload cycle.
+     *
+     * Such an error means the bucket's keys simply cannot be persisted this
+     * round; OffloadObjects reports them back to the master as failed (so their
+     * offloading tasks and source-replica refcounts are released) and continues
+     * with the remaining buckets, instead of aborting the entire cycle.
+     *
+     *   - INVALID_READ: source data for these keys could not be read/staged.
+     *   - OBJECT_ALREADY_EXISTS: the key(s) were already offloaded, or are
+     *     being offloaded concurrently. The bucket backend rejects the whole
+     *     bucket atomically by design (see BucketStorageBackend::BatchOffload
+     *     and its PrepareEviction duplicate guard). Treating this as fatal
+     *     aborted the cycle, leaked offloading tasks, and left master/SSD
+     *     metadata inconsistent, which surfaced as spurious INVALID_KEY on the
+     *     read path (issue #2827).
+     */
+    static bool IsPerBucketSoftOffloadError(ErrorCode error);
+
+    /**
      * @brief Performs a heartbeat operation for the FileStorage component.
      * 1. Sends object status (e.g., access frequency, size) to the master via
      * client.

--- a/mooncake-store/src/file_storage.cpp
+++ b/mooncake-store/src/file_storage.cpp
@@ -440,6 +440,11 @@ tl::expected<FileStorage::BatchGetResult, ErrorCode> FileStorage::BatchGet(
     return batch_result;
 }
 
+bool FileStorage::IsPerBucketSoftOffloadError(ErrorCode error) {
+    return error == ErrorCode::INVALID_READ ||
+           error == ErrorCode::OBJECT_ALREADY_EXISTS;
+}
+
 tl::expected<void, ErrorCode> FileStorage::OffloadObjects(
     const std::vector<OffloadTaskItem>& offloading_objects) {
     if (offloading_objects.empty()) {
@@ -628,7 +633,11 @@ tl::expected<void, ErrorCode> FileStorage::OffloadObjects(
                 enable_offloading_ = false;
                 return tl::make_unexpected(offload_res.error());
             }
-            if (offload_res.error() == ErrorCode::INVALID_READ) {
+            if (IsPerBucketSoftOffloadError(offload_res.error())) {
+                // Only this bucket failed to persist; report its keys back to
+                // the master as failed (releasing their offloading tasks and
+                // source-replica refcounts) and keep processing the remaining
+                // buckets instead of aborting the whole offload cycle.
                 for (const auto& [key, _] : host_batch_object) {
                     failed_tasks.push_back(task_by_storage_key.at(key));
                 }

--- a/mooncake-store/src/file_storage.cpp
+++ b/mooncake-store/src/file_storage.cpp
@@ -512,6 +512,10 @@ tl::expected<void, ErrorCode> FileStorage::OffloadObjects(
     // orphaned offloading_tasks and release source replica refcounts.
     std::vector<OffloadTaskItem> failed_tasks;
     std::unordered_set<std::string> all_bucket_keys;
+    // Set when a whole-cycle error aborts the bucket loop early. We still fall
+    // through to the NACK flush below before returning it, so no drained key is
+    // left waiting on the TTL reaper.
+    std::optional<ErrorCode> abort_error;
 
     for (const auto& keys : buckets_keys) {
         for (const auto& k : keys) all_bucket_keys.insert(k);
@@ -589,6 +593,14 @@ tl::expected<void, ErrorCode> FileStorage::OffloadObjects(
             }
         }
 
+        // If every object in this bucket failed D2H staging, host_batch_object
+        // is empty (those keys are already in failed_tasks). Skip BatchOffload,
+        // which rejects an empty map as INVALID_KEY and would otherwise trip the
+        // whole-cycle abort below for a bucket that has nothing left to persist.
+        if (host_batch_object.empty()) {
+            continue;
+        }
+
         auto offload_start = std::chrono::steady_clock::now();
         auto bucket_complete_handler =
             [this, offload_start, complete_handler](
@@ -628,22 +640,29 @@ tl::expected<void, ErrorCode> FileStorage::OffloadObjects(
         if (!offload_res) {
             LOG(ERROR) << "Failed to store objects with error: "
                        << offload_res.error();
+            // This bucket did not persist, so report its keys back to the
+            // master as failed regardless of whether we continue or abort.
+            // Doing it here (rather than only on the soft path) keeps their
+            // offloading tasks and source-replica refcounts from leaking until
+            // the put_start_release_timeout_sec_ TTL reaper fires.
+            for (const auto& [key, _] : host_batch_object) {
+                failed_tasks.push_back(task_by_storage_key.at(key));
+            }
             if (offload_res.error() == ErrorCode::KEYS_ULTRA_LIMIT) {
+                // Disk is over the key-count limit: stop offloading entirely.
                 MutexLocker locker(&offloading_mutex_);
                 enable_offloading_ = false;
-                return tl::make_unexpected(offload_res.error());
             }
-            if (IsPerBucketSoftOffloadError(offload_res.error())) {
-                // Only this bucket failed to persist; report its keys back to
-                // the master as failed (releasing their offloading tasks and
-                // source-replica refcounts) and keep processing the remaining
-                // buckets instead of aborting the whole offload cycle.
-                for (const auto& [key, _] : host_batch_object) {
-                    failed_tasks.push_back(task_by_storage_key.at(key));
-                }
-            } else {
-                return tl::make_unexpected(offload_res.error());
+            if (!IsPerBucketSoftOffloadError(offload_res.error())) {
+                // Whole-cycle error (KEYS_ULTRA_LIMIT or any hard failure):
+                // stop processing further buckets, but fall through to the NACK
+                // flush below so every drained key is released. Unvisited
+                // buckets are not yet in all_bucket_keys, so the sweep NACKs
+                // them too; this bucket's keys were just pushed above.
+                abort_error = offload_res.error();
+                break;
             }
+            // Soft per-bucket error: keep processing the remaining buckets.
         }
     }
 
@@ -670,6 +689,9 @@ tl::expected<void, ErrorCode> FileStorage::OffloadObjects(
         }
     }
 
+    if (abort_error) {
+        return tl::make_unexpected(*abort_error);
+    }
     return {};
 }
 

--- a/mooncake-store/src/file_storage.cpp
+++ b/mooncake-store/src/file_storage.cpp
@@ -595,8 +595,9 @@ tl::expected<void, ErrorCode> FileStorage::OffloadObjects(
 
         // If every object in this bucket failed D2H staging, host_batch_object
         // is empty (those keys are already in failed_tasks). Skip BatchOffload,
-        // which rejects an empty map as INVALID_KEY and would otherwise trip the
-        // whole-cycle abort below for a bucket that has nothing left to persist.
+        // which rejects an empty map as INVALID_KEY and would otherwise trip
+        // the whole-cycle abort below for a bucket that has nothing left to
+        // persist.
         if (host_batch_object.empty()) {
             continue;
         }

--- a/mooncake-store/src/file_storage.cpp
+++ b/mooncake-store/src/file_storage.cpp
@@ -597,8 +597,14 @@ tl::expected<void, ErrorCode> FileStorage::OffloadObjects(
         // is empty (those keys are already in failed_tasks). Skip BatchOffload,
         // which rejects an empty map as INVALID_KEY and would otherwise trip
         // the whole-cycle abort below for a bucket that has nothing left to
-        // persist.
+        // persist. staging_bufs can still be non-empty here (an object whose
+        // first slices copied fine but a later one failed), so hand those
+        // buffers back before continuing: the release loop after BatchOffload
+        // is unreachable on this path.
         if (host_batch_object.empty()) {
+            for (auto& buf : staging_bufs) {
+                pinned_buffer_pool_->Release(std::move(buf));
+            }
             continue;
         }
 

--- a/mooncake-store/tests/file_storage_test.cpp
+++ b/mooncake-store/tests/file_storage_test.cpp
@@ -108,6 +108,12 @@ class FileStorageTest : public ::testing::Test {
         return bucket_backend->UngroupedOffloadingObjectsSize();
     }
 
+    // Static funnel to the private FileStorage::IsPerBucketSoftOffloadError.
+    // FileStorageTest is friended; TEST_F-generated subclasses are not.
+    static bool CallIsPerBucketSoftOffloadError(ErrorCode error) {
+        return FileStorage::IsPerBucketSoftOffloadError(error);
+    }
+
     void AssertHeartbeatEvictsAllKeys(
         FileStorage& fileStorage, const std::vector<std::string>& expected_keys,
         const std::unordered_map<std::string, std::vector<Slice>>&
@@ -519,6 +525,25 @@ TEST_F(FileStorageTest, NotifyEvictedDiskReplicasUsesTenantScopedKeys) {
         ASSERT_FALSE(after[0].has_value());
         EXPECT_EQ(after[0].error(), ErrorCode::OBJECT_NOT_FOUND);
     }
+}
+
+// Regression test for issue #2827: under concurrent/repeat offload of the same
+// keys, the bucket backend rejects a whole bucket atomically with
+// OBJECT_ALREADY_EXISTS (see BucketStorageBackend duplicate-key tests). That
+// error must be treated as a per-bucket soft failure so OffloadObjects reports
+// the keys back to the master and continues, rather than aborting the whole
+// offload cycle and leaving master/SSD metadata inconsistent (which surfaced as
+// spurious INVALID_KEY on the read path). It stays alongside INVALID_READ,
+// while genuinely fatal errors (e.g. KEYS_ULTRA_LIMIT, INTERNAL_ERROR) do not.
+TEST_F(FileStorageTest, DuplicateOffloadErrorIsPerBucketSoftError) {
+    EXPECT_TRUE(
+        CallIsPerBucketSoftOffloadError(ErrorCode::OBJECT_ALREADY_EXISTS));
+    EXPECT_TRUE(CallIsPerBucketSoftOffloadError(ErrorCode::INVALID_READ));
+
+    EXPECT_FALSE(CallIsPerBucketSoftOffloadError(ErrorCode::KEYS_ULTRA_LIMIT));
+    EXPECT_FALSE(CallIsPerBucketSoftOffloadError(ErrorCode::INTERNAL_ERROR));
+    EXPECT_FALSE(CallIsPerBucketSoftOffloadError(ErrorCode::INVALID_KEY));
+    EXPECT_FALSE(CallIsPerBucketSoftOffloadError(ErrorCode::OK));
 }
 
 TEST_F(FileStorageTest, InvalidIntValueUsesDefault) {


### PR DESCRIPTION
# Issue #2827 — SSD offload duplicate-key storm (`OBJECT_ALREADY_EXISTS` →
persist failed → `INVALID_KEY`)

Upstream issue: kvcache-ai/Mooncake#2827

Symptom (DeepSeek‑V4, PD‑disaggregated, SSD offload enabled, 32‑concurrency
stress): the same batch KV keys are offloaded repeatedly, the P node logs
`Duplicate key detected in BatchOffload … Returning OBJECT_ALREADY_EXISTS`,
whole‑batch `persist failed`, and the D node then gets floods of
`Key not found … BatchQuerySlices/BatchLoad … INVALID_KEY`. A single request
never triggers it — only concurrent/repeat offload of the same key does.

## 1. Root cause

Under concurrency, two offload flows on the same node can target an overlapping
KV key (shared prefix block → identical block hash). The bucket storage backend
is, **by design, a strict single‑writer‑per‑key store that commits a bucket
atomically**:

- `BucketStorageBackend::BatchOffload` first calls `PrepareEviction`
  (`mooncake-store/src/storage_backend.cpp`), which reserves every key of the
  bucket in `pending_write_keys_` and returns `OBJECT_ALREADY_EXISTS` for the
  **entire bucket** if *any* key is already committed (`object_bucket_map_`),
  already reserved (`pending_write_keys_`), or being evicted
  (`pending_eviction_keys_`).
- A secondary commit‑time pre‑check does the same.

This atomic‑bucket rejection is intentional and is locked in by existing tests
(`storage_backend_test.cpp`: `BucketStorageBackend_DuplicateKeyRejected`,
`BucketStorageBackend_DuplicateBatchPartialRejection` — the latter asserts a
batch `[keyA(dup), keyB(new)]` rejects the whole batch and `keyB` is *not*
written).

The actual bug is in the **caller**, `FileStorage::OffloadObjects`
(`mooncake-store/src/file_storage.cpp`). Its per‑bucket error handling treated
only `INVALID_READ` as a recoverable, per‑bucket condition and treated
everything else — including `OBJECT_ALREADY_EXISTS` — as fatal:

```cpp
if (offload_res.error() == ErrorCode::INVALID_READ) {
    for (…) failed_tasks.push_back(…);        // report keys, keep going
} else {
    return tl::make_unexpected(offload_res.error());   // abort whole cycle
}
```

So a single duplicate key would `return` out of `OffloadObjects`, which:

1. **Skips the remaining buckets** in this offload cycle.
2. **Skips the `failed_tasks` NACK reporting** at the end of the function
   (the early `return` jumps over it). Those keys were drained from the
   master's offloading queue but are never resolved.
3. Leaves the master's per‑key `offloading_tasks` dangling and never releases
   the source‑replica refcounts (`dec_refcnt`), so master and local‑SSD
   metadata drift apart. Keys the master believes are already offloaded are
   not actually on this node's SSD.

When the D node later reads those keys, the master redirects the read to the P
node's SSD, `object_bucket_map_` has no entry → `BatchLoad`/`BatchQuerySlices`
return `INVALID_KEY` — exactly the flood in the report.

## 2. The fix and why

Treat `OBJECT_ALREADY_EXISTS` from `BatchOffload` the same way `INVALID_READ`
is already treated: a **per‑bucket soft failure**, not a fatal one. The
bucket's keys are pushed into `failed_tasks` and the loop continues to the next
bucket; at the end of `OffloadObjects` those keys are reported back to the
master with the existing `data_size == -1` NACK sentinel.

This is the minimal change that resolves the reported failure chain, and it is
aligned with the issue's own primary recommendation (#1: handle
`OBJECT_ALREADY_EXISTS` idempotently, do not fail the whole batch). It does
**not** touch the backend's deliberate atomic‑bucket contract.

Why it is correct and safe:

- The master's NACK handler (`MasterService::NotifyOffloadSuccess`, the
  `metadata.data_size < 0` branch) only erases the key's `offloading_task` and
  `dec_refcnt`s the source replica **if a task is present**; it never removes
  or overwrites an existing valid replica. So NACK'ing a key that another flow
  legitimately committed is a harmless no‑op on that valid replica, and it
  correctly releases *this* flow's dangling task/refcount. This holds under any
  ordering of the concurrent success/NACK RPCs.
- No more ghost `LOCAL_DISK` replicas → no more spurious `INVALID_KEY` on the
  read path.
- Remaining buckets in the cycle are still processed; every drained key is
  resolved on the master (success or NACK), so tasks/refcounts no longer leak
  (which otherwise also blocks future writes via `OBJECT_HAS_REPLICATION_TASK`).

The classification is factored into a small, documented, testable predicate
`FileStorage::IsPerBucketSoftOffloadError(ErrorCode)`. Genuinely global errors
(`KEYS_ULTRA_LIMIT`, `INTERNAL_ERROR`, `BUCKET_NOT_FOUND`, …) still abort the
cycle as before.

Trade‑off: on the rare colliding bucket, the non‑duplicate keys in that bucket
are not persisted this round (they are NACK'd and can be re‑offloaded or
recomputed later). This is **not a regression** — the previous behaviour
discarded the whole bucket too, and additionally aborted the entire cycle and
leaked master state. Correctness (no data loss on the read path) is preserved
because a NACK never deletes a valid replica.

## 3. Files changed

- `mooncake-store/include/file_storage.h` — declare the private static
  predicate `IsPerBucketSoftOffloadError(ErrorCode)` with rationale doc.
- `mooncake-store/src/file_storage.cpp` — define the predicate and use it in
  `OffloadObjects`' per‑bucket error handling so `OBJECT_ALREADY_EXISTS` is
  handled alongside `INVALID_READ` (report keys as failed, continue) instead of
  aborting the cycle.
- `mooncake-store/tests/file_storage_test.cpp` — add
  `DuplicateOffloadErrorIsPerBucketSoftError` (with a static funnel, mirroring
  the repo's existing friend‑access pattern) asserting the classification:
  `OBJECT_ALREADY_EXISTS` and `INVALID_READ` are per‑bucket soft errors, while
  `KEYS_ULTRA_LIMIT` / `INTERNAL_ERROR` / `INVALID_KEY` / `OK` are not.

## 4. Risk / uncertainty

- **Low risk.** The change reuses the already‑tested `failed_tasks` → NACK path
  and adds one error code to a classification. The backend contract and all its
  duplicate‑key tests are untouched.
- The concurrency **origin** of the duplicate (which specific interleaving
  produces `OBJECT_ALREADY_EXISTS` at runtime — `pending_write_keys_`
  reservation vs. `pending_eviction_keys_` vs. commit‑time race) was analysed
  statically but not reproduced live; the fix is deliberately defensive and
  correct regardless of which interleaving triggers it.
- The added test is a focused unit test of the decision logic rather than a
  full concurrent end‑to‑end reproduction. A deterministic end‑to‑end test
  would need to force the transient backend state (in‑flight eviction /
  concurrent writer) and heavy `InProcMaster` + real MEM‑replica setup; that
  was judged disproportionate and flaky for a one‑condition caller fix.

## 5. How I verified it

- **Static tracing** of the full failure chain across
  `storage_backend.cpp` (`BatchOffload` / `PrepareEviction` /
  `RollbackCommittedBucket` / eviction), `file_storage.cpp`
  (`OffloadObjects` / `BatchQuerySegmentSlices` / `NotifyEvictedDiskReplicas`),
  and `master_service.cpp` (`NotifyOffloadSuccess` NACK path,
  `OffloadObjectHeartbeat`) — confirming (a) where the whole‑bucket
  `OBJECT_ALREADY_EXISTS` originates, (b) that the early `return` skips the
  `failed_tasks` NACK, and (c) that the master NACK path never removes a valid
  replica and `dec_refcnt`s at most once per task.
- **Confirmed the backend behaviour is intentional** via the existing
  `storage_backend_test.cpp` duplicate‑key tests, so the fix belongs in the
  caller.
- Added `DuplicateOffloadErrorIsPerBucketSoftError` covering the changed
  classification.
- **Style/format:** verified all edited lines are within the repo's
  `ColumnLimit: 80` (Google‑based `.clang-format`) and match surrounding
  4‑space indentation and naming.
- **Not run:** the C++ test binaries were not compiled/executed in this
  environment (no configured build; RDMA/uring/etc. toolchain not provisioned),
  so runtime verification is limited to the reasoning above. `git commit`/
  `push`/`gh` were intentionally not run.