### PR TITLE
[CI/Build] Build release aarch64 wheels in a manylinux container

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -63,7 +63,8 @@ jobs:
     uses: ./.github/workflows/_build-wheel.yaml
     with:
       runner: ubuntu-22.04-arm
-      cuda: sbsa-12.8
+      container: pytorch/manylinuxaarch64-builder:cuda12.8
+      cuda: container
       cmake-generator: Ninja
       torch-cuda-arch-list: '9.0'
       cmake-args: >-
@@ -75,7 +76,8 @@ jobs:
     uses: ./.github/workflows/_build-wheel.yaml
     with:
       runner: ubuntu-22.04-arm
-      cuda: sbsa-13.0
+      container: pytorch/manylinuxaarch64-builder:cuda13.0
+      cuda: container
       cmake-generator: Ninja
       variant-flag: CU13_BUILD
       torch-cuda-arch-list: '9.0'

--- a/.github/workflows/release-cuda13.yaml
+++ b/.github/workflows/release-cuda13.yaml
@@ -27,7 +27,8 @@ jobs:
     uses: ./.github/workflows/_build-wheel.yaml
     with:
       runner: ubuntu-22.04-arm
-      cuda: sbsa-13.0
+      container: pytorch/manylinuxaarch64-builder:cuda13.0
+      cuda: container
       cmake-generator: Ninja
       variant-flag: CU13_BUILD
       torch-cuda-arch-list: '9.0'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,8 @@ jobs:
     uses: ./.github/workflows/_build-wheel.yaml
     with:
       runner: ubuntu-22.04-arm
-      cuda: sbsa-12.8
+      container: pytorch/manylinuxaarch64-builder:cuda12.8
+      cuda: container
       cmake-generator: Ninja
       torch-cuda-arch-list: '9.0'
       cmake-args: >-

--- a/mooncake-wheel/tests/test_release_wheel_tags.py
+++ b/mooncake-wheel/tests/test_release_wheel_tags.py
@@ -1,0 +1,88 @@
+"""Guard the glibc floor of released wheels.
+
+Release wheels must take their manylinux platform tag from a pinned container
+image, never from the GitHub runner. ``scripts/build_wheel.sh`` derives
+``PLATFORM_TAG`` from the *build host's* glibc (``detect_glibc_version``), so a
+job running on a bare runner silently re-tags itself whenever GitHub bumps the
+runner image. That is not hypothetical: the published aarch64 floor moved from
+``manylinux_2_35`` (0.3.9) to ``manylinux_2_39`` (0.3.10) with no code change,
+which stops ARM Ubuntu 22.04 from resolving any wheel and contradicts the
+"OS: Ubuntu 22.04 LTS+" contract in docs/source/getting_started/build.md.
+
+Running inside a manylinux container makes the detected glibc a constant of the
+image instead of a property of the runner. See #2858.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+# Jobs delegating to this reusable workflow are the ones that publish wheels.
+# release-{efa,efa-non-cuda,musa,npu}.yaml do not call it and are out of scope.
+SHARED_BUILD_WORKFLOW = "_build-wheel.yaml"
+
+# The floor must come from a named manylinux image. Deliberately not a digest
+# assertion: pinning digests is worth doing for both arches at once, not here.
+ALLOWED_CONTAINER = re.compile(
+    r"^pytorch/manylinux(2_28|aarch64)-builder:cuda\d+\.\d+$"
+)
+
+
+def _find_workflows_dir() -> Path | None:
+    """Locate .github/workflows, or None when the suite has been detached.
+
+    scripts/test_installation.sh copies this directory into a scratch tree, so
+    the workflow sources are not always reachable from __file__.
+    """
+    for parent in Path(__file__).resolve().parents:
+        candidate = parent / ".github" / "workflows"
+        if candidate.is_dir():
+            return candidate
+    return None
+
+
+def _collect_build_jobs() -> list:
+    workflows_dir = _find_workflows_dir()
+    if workflows_dir is None:
+        return []
+
+    jobs = []
+    for path in sorted(workflows_dir.glob("*.yaml")):
+        workflow = yaml.safe_load(path.read_text()) or {}
+        for job_name, job in (workflow.get("jobs") or {}).items():
+            if SHARED_BUILD_WORKFLOW in str(job.get("uses", "")):
+                jobs.append(
+                    pytest.param(job.get("with") or {}, id=f"{path.name}:{job_name}")
+                )
+    return jobs
+
+
+BUILD_JOBS = _collect_build_jobs()
+
+if not BUILD_JOBS:
+    pytest.skip("workflow sources not available", allow_module_level=True)
+
+
+@pytest.mark.parametrize("with_block", BUILD_JOBS)
+def test_release_build_pins_glibc_floor_to_a_container(with_block: dict) -> None:
+    container = with_block.get("container", "")
+    assert container, (
+        "job builds release wheels on a bare runner, so its manylinux tag "
+        "follows the runner's glibc and drifts when GitHub bumps the image; "
+        f"set container to a {ALLOWED_CONTAINER.pattern} image"
+    )
+    assert ALLOWED_CONTAINER.match(container), (
+        f"container {container!r} is not a pinned manylinux builder image; "
+        f"expected one matching {ALLOWED_CONTAINER.pattern}"
+    )
+    # CUDA must come from that image; otherwise the job installs a toolkit with
+    # the host package manager, which the manylinux (AlmaLinux) image lacks.
+    assert with_block.get("cuda") == "container", (
+        f"cuda is {with_block.get('cuda')!r}; a job pinned to a manylinux "
+        "container must take CUDA from the image"
+    )

--- a/mooncake-wheel/tests/test_release_wheel_tags.py
+++ b/mooncake-wheel/tests/test_release_wheel_tags.py
@@ -26,11 +26,18 @@ yaml = pytest.importorskip("yaml")
 # release-{efa,efa-non-cuda,musa,npu}.yaml do not call it and are out of scope.
 SHARED_BUILD_WORKFLOW = "_build-wheel.yaml"
 
-# The floor must come from a named manylinux image. Deliberately not a digest
-# assertion: pinning digests is worth doing for both arches at once, not here.
-ALLOWED_CONTAINER = re.compile(
-    r"^pytorch/manylinux(2_28|aarch64)-builder:cuda\d+\.\d+$"
-)
+# The floor must come from a named manylinux image, matched to the runner's
+# architecture: an aarch64 image on an x86 runner (or vice versa) is a
+# misconfiguration, not a pinned floor. Deliberately not a digest assertion;
+# pinning digests is worth doing for both arches at once, not here.
+ARCH_CONTAINER = {
+    "aarch64": re.compile(r"^pytorch/manylinuxaarch64-builder:cuda\d+\.\d+$"),
+    "x86_64": re.compile(r"^pytorch/manylinux2_28-builder:cuda\d+\.\d+$"),
+}
+
+
+def _runner_arch(runner: str) -> str:
+    return "aarch64" if runner.endswith("-arm") else "x86_64"
 
 
 def _find_workflows_dir() -> Path | None:
@@ -46,13 +53,17 @@ def _find_workflows_dir() -> Path | None:
     return None
 
 
-def _collect_build_jobs() -> list:
-    workflows_dir = _find_workflows_dir()
-    if workflows_dir is None:
-        return []
+WORKFLOWS_DIR = _find_workflows_dir()
 
+if WORKFLOWS_DIR is None:
+    pytest.skip("workflow sources not available", allow_module_level=True)
+
+
+def _collect_build_jobs() -> list:
     jobs = []
-    for path in sorted(workflows_dir.glob("*.yaml")):
+    # Both extensions: the repo uses .yml for most workflows and .yaml for the
+    # release set, so globbing one silently ignores callers named in the other.
+    for path in sorted(WORKFLOWS_DIR.glob("*.y*ml")):
         workflow = yaml.safe_load(path.read_text()) or {}
         for job_name, job in (workflow.get("jobs") or {}).items():
             if SHARED_BUILD_WORKFLOW in str(job.get("uses", "")):
@@ -64,25 +75,41 @@ def _collect_build_jobs() -> list:
 
 BUILD_JOBS = _collect_build_jobs()
 
-if not BUILD_JOBS:
-    pytest.skip("workflow sources not available", allow_module_level=True)
+
+def test_shared_build_workflow_still_has_callers() -> None:
+    """Fail loudly rather than skip if the marker stops matching.
+
+    Without this, renaming _build-wheel.yaml would empty BUILD_JOBS and leave
+    every assertion below silently unenforced.
+    """
+    assert BUILD_JOBS, (
+        f"no job delegates to {SHARED_BUILD_WORKFLOW}; it was renamed or the "
+        "release workflows stopped using it, so this guard is disarmed"
+    )
 
 
 @pytest.mark.parametrize("with_block", BUILD_JOBS)
 def test_release_build_pins_glibc_floor_to_a_container(with_block: dict) -> None:
+    runner = str(with_block.get("runner", ""))
     container = with_block.get("container", "")
+    arch = _runner_arch(runner)
+    expected = ARCH_CONTAINER[arch]
+
     assert container, (
         "job builds release wheels on a bare runner, so its manylinux tag "
         "follows the runner's glibc and drifts when GitHub bumps the image; "
-        f"set container to a {ALLOWED_CONTAINER.pattern} image"
+        f"set container to a {expected.pattern} image"
     )
-    assert ALLOWED_CONTAINER.match(container), (
-        f"container {container!r} is not a pinned manylinux builder image; "
-        f"expected one matching {ALLOWED_CONTAINER.pattern}"
+    assert expected.match(container), (
+        f"container {container!r} is not the pinned manylinux builder image "
+        f"for {arch} (runner {runner!r}); expected one matching "
+        f"{expected.pattern}"
     )
-    # CUDA must come from that image; otherwise the job installs a toolkit with
-    # the host package manager, which the manylinux (AlmaLinux) image lacks.
-    assert with_block.get("cuda") == "container", (
-        f"cuda is {with_block.get('cuda')!r}; a job pinned to a manylinux "
-        "container must take CUDA from the image"
+    # sbsa-* makes _build-wheel.yaml install the CUDA toolkit with apt, which
+    # the AlmaLinux-based manylinux image does not have. Any other value
+    # ('container', 'none') keeps the build inside the image.
+    cuda = str(with_block.get("cuda", ""))
+    assert not cuda.startswith("sbsa-"), (
+        f"cuda is {cuda!r}; a job pinned to a manylinux container cannot "
+        "install CUDA via the host package manager"
     )


### PR DESCRIPTION
## Description

Release aarch64 wheels build on a bare `ubuntu-22.04-arm` runner, so `scripts/build_wheel.sh`
stamps their manylinux tag from **the runner's own glibc**:

```sh
# scripts/build_wheel.sh:308-351
ver=$(getconf GNU_LIBC_VERSION ...)
PLATFORM_TAG=${PLATFORM_TAG:-"manylinux_${GLIBC_VERSION}_${ARCH_SUFFIX}"}
```

The published floor therefore tracks whatever image GitHub happens to ship rather than a declared
target. It has already drifted once, with no code change in between:

| version | uploaded | aarch64 tag | x86_64 tag |
|---|---|---|---|
| 0.3.9 | 2026-02-05 | `manylinux_2_35_aarch64` | `manylinux_2_35_x86_64` |
| 0.3.10 | 2026-03-19 | **`manylinux_2_39_aarch64`** | `manylinux_2_35_x86_64` |
| 0.3.11.post1 | 2026-05-24 | `manylinux_2_39_aarch64` | `manylinux_2_35_x86_64` |

`manylinux_2_39` needs glibc 2.39 (Ubuntu 24.04), so since 0.3.10 an ARM user on Ubuntu 22.04
(glibc 2.35) matches **no wheel** — contradicting the `OS: Ubuntu 22.04 LTS+` support statement in
`docs/source/getting_started/build.md:8`. pip then falls back to the `0.3.0a0`/`b0`/`b1`/`b3`
sdists, which fail their own metadata check, and the user sees the error in #2858:

```
ERROR: Could not find a version that satisfies the requirement mooncake-transfer-engine
(from versions: 0.3.0a0, 0.3.0b0, 0.3.0b1, 0.3.0b3)
```

x86_64 is already immune: #2605 moved it into `pytorch/manylinux2_28-builder`, whose comment in
`_build-wheel.yaml:13-15` states the intent — *"x86 builds run in manylinux2_28 so the wheel's
libstdc++/glibc floor stays low enough to import on RHEL/Rocky/Alma 8+."* aarch64 was simply never
given the same treatment; this PR finishes that work by pinning each ARM job to the aarch64 twin of
the same image and taking CUDA from it.

Inside the container the glibc `build_wheel.sh` detects is a constant of a pinned image rather than
a property of the runner, so the tag can no longer drift when GitHub bumps the runner.

**Why no other file changes are needed** (all pre-verified against the current tree):

- `_build-wheel.yaml:101-102` gates the apt/`dpkg` SBSA CUDA install on
  `startsWith(inputs.cuda, 'sbsa-')`, so `cuda: container` skips it — necessary, since the
  AlmaLinux-based manylinux image has no apt.
- `dependencies.sh:138,190` already branch to `yum`/`dnf` for `almalinux`/`rhel`, which is why the
  x86 container job works today.
- `_build-wheel.yaml:88-93` already selects `/opt/python/cp3XX-cp3XX/bin` when `container != ''`,
  and `:70-72` already handles the container's root/`safe.directory` case.

Both images verified `linux/arm64` on 2026-07-16:

| tag | digest |
|---|---|
| `pytorch/manylinuxaarch64-builder:cuda12.8` | `sha256:2cc59f7d17aa82fda0869bd2ddaba80335a6df9843fd42750c651e39d6a414d0` |
| `pytorch/manylinuxaarch64-builder:cuda13.0` | `sha256:2ddb7952ac60964189ad5c692796766d277da6c15d28dc9bcce8dd95a80acd1a` |

Precedent for the shape: `NVIDIA/Megatron-LM` runs `quay.io/pypa/manylinux_2_28_aarch64` on
`ubuntu-22.04-arm` for its CUDA ARM wheels. We use the pytorch image because it ships CUDA, matching
the x86 job already in this repo.

### Scope — what this does NOT fix

This does **not**, on its own, make the reporter's `pip install` succeed, and #2858 should stay open
until two maintainer-only actions happen:

1. **Yank `0.3.0a0`, `0.3.0b0`, `0.3.0b1`, `0.3.0b3` on PyPI** (all currently `yanked=false`). They
   are the only sdists published, so they are the fallback for *every* environment no wheel matches.
   They were built when `setup.py` read `VERSION = os.environ.get("VERSION", "0.1.0")`, so a rebuild
   on a user machine reports `0.1.0` and pip discards them — that is the confusing error text in the
   issue. The class of bug is long fixed (version is a static literal in `pyproject.toml`; no
   workflow builds an sdist), but the four artifacts are immortal. Yanking is safe: pinned installs
   still resolve.
2. **Cut a release.** The x86 floor fix (#2605) and `requires-python = ">=3.10"` (#2677) are both on
   `main` but unpublished — the newest release, 0.3.11.post1, predates them.

Also out of scope, deliberately: Python 3.14 wheels (`_build-wheel.yaml:19` stops at 3.13 while
`pyproject.toml:30` declares `>=3.10` with no upper bound — a real gap and a plausible alternate
trigger of this report, but an independent matrix change), and digest-pinning the container tags
(worth doing for both arches at once, not for ARM alone).

Fixes the aarch64 half of #2858.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Written test-first. `mooncake-wheel/tests/test_release_wheel_tags.py` parses every job delegating to
`_build-wheel.yaml` and asserts each pins a manylinux container matched to its runner's
architecture, and does not install CUDA via the host package manager. It failed on exactly the four
aarch64 jobs before the fix and passes after — no build or network needed.

**Test commands:**
```bash
# RED — before the workflow change
python3 -m pytest mooncake-wheel/tests/test_release_wheel_tags.py -v
# 4 failed, 6 passed
#   FAILED ...[release.yaml:build-arm64]           <- container='', cuda='sbsa-12.8'
#   FAILED ...[release-cuda13.yaml:build-arm64]    <- container='', cuda='sbsa-13.0'
#   FAILED ...[pre-release.yaml:build-cuda-arm64]  <- container='', cuda='sbsa-12.8'
#   FAILED ...[pre-release.yaml:build-cuda13-arm64]<- container='', cuda='sbsa-13.0'

# GREEN — after
python3 -m pytest mooncake-wheel/tests/test_release_wheel_tags.py -v
# 11 passed

# Touched-area suite
python3 -m pytest mooncake-wheel/tests/ -q --continue-on-collection-errors
# 6 failed, 115 passed, 1 skipped, 28 errors

# pre-commit
pre-commit run --files mooncake-wheel/tests/test_release_wheel_tags.py \
  .github/workflows/release.yaml .github/workflows/release-cuda13.yaml \
  .github/workflows/pre-release.yaml
# trim trailing whitespace / fix end of files / check yaml / check for merge conflicts /
# check for added large files / ruff / ruff-format / codespell ......... all Passed
```

The `6 failed / 28 errors` above are **pre-existing and unrelated** — identical on base `4234180a`
(same test IDs, verified by diffing both sets, not just the counts). They need a compiled wheel plus
`torch`/`aiohttp`/`msgpack`, none present in the sandbox. This PR moves passes `104 → 115`.

The guard was self-reviewed and hardened after an initial version proved weaker than the invariant
it advertised; each hole was confirmed by injecting the misconfiguration and watching the old test
pass:

- globbed `*.yaml` only, while 13 of 24 workflows are `.yml` — a `.yml` caller was silently ignored;
- an empty match set skipped the module as *"workflow sources not available"*, so renaming
  `_build-wheel.yaml` would disarm every assertion while looking green;
- the container regex was arch-blind — an aarch64 image on an x86 runner passed;
- it required `cuda == "container"`, rejecting `cuda: none`, which `_build-wheel.yaml:21` documents
  as valid.

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

**Not verified, and it needs a maintainer.** No PR CI job builds an ARM wheel, so CI can only prove
the container invariant — not the resulting glibc floor. Before this is relied on, please push an rc
tag to run `pre-release.yaml` and confirm `build-cuda-arm64` emits `…-manylinux_2_28_aarch64.whl`.
Any floor **≤ 2.35** satisfies the documented support contract and fixes the ARM half of #2858; a
floor **> 2.35** means the pytorch aarch64 image is not 2_28-based and this PR's assumption is
wrong — please say so and I will rework it. The ARM build could also fail inside AlmaLinux if some
dependency turns out to be apt-only; that would surface in the same rc run, never for a user, and
`git revert` restores the previous behaviour.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

Note on `./scripts/code_format.sh`: it formats C/C++ changed against `origin/main`, and this diff
contains no C/C++/CMake files, so it is a no-op here — `clang-format` and `cmake-format` both report
"no files to check".

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Claude Code was used to investigate the PyPI tag history, draft the workflow change and the test,
and write this description. The human submitter has reviewed every changed line and can defend the
change end-to-end.