### PR TITLE
[Transfer Engine] Schedule TCP transfers on bounded per-peer connection lanes

### DIFF
--- a/mooncake-transfer-engine/include/transport/tcp_transport/tcp_transport.h
+++ b/mooncake-transfer-engine/include/transport/tcp_transport/tcp_transport.h
@@ -19,19 +19,25 @@
 
 #include <atomic>
 #include <chrono>
+#include <csignal>
 #include <cstddef>
+#include <cstdint>
 #include <deque>
 #include <functional>
 #include <map>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
+#include <thread>
+#include <type_traits>
 #include <unordered_map>
-#include <unordered_set>
+#include <utility>
 #include <vector>
-#include <csignal>
 
+#include <asio/io_context.hpp>
 #include <asio/ip/tcp.hpp>
+#include <asio/steady_timer.hpp>
 
 #include "transfer_metadata.h"
 #include "transport/transport.h"
@@ -39,25 +45,9 @@
 
 namespace mooncake {
 class TransferMetadata;
+struct ClientSession;
 class TcpContext;
 class TcpTransport;
-
-// Pooled connection for reusing client-side connections
-struct PooledConnection {
-    std::shared_ptr<asio::ip::tcp::socket> socket;
-    std::string host;
-    uint16_t port;
-    std::chrono::steady_clock::time_point last_used;
-    bool in_use;
-
-    PooledConnection(std::shared_ptr<asio::ip::tcp::socket> s,
-                     const std::string &h, uint16_t p)
-        : socket(std::move(s)),
-          host(h),
-          port(p),
-          last_used(std::chrono::steady_clock::now()),
-          in_use(true) {}
-};
 
 class TcpTransport : public Transport {
    public:
@@ -122,10 +112,9 @@ class TcpTransport : public Transport {
     TcpContext *context_;
     std::atomic_bool running_;
     std::thread thread_;
-    bool enable_connection_pool_ =
-        false;  // Use MC_TCP_ENABLE_CONNECTION_POOL=1 to enable connection pool
+    bool enable_connection_pool_ = false;
 
-    // Client-side connection pool
+    // Client-side bounded work queues and fixed connection lanes.
     struct ConnectionKey {
         std::string host;
         uint16_t port;
@@ -142,23 +131,262 @@ class TcpTransport : public Transport {
         }
     };
 
-    std::unordered_map<ConnectionKey,
-                       std::deque<std::shared_ptr<PooledConnection>>,
-                       ConnectionKeyHash>
-        connection_pool_;
-    std::mutex pool_mutex_;
+    enum class WorkFailureReason {
+        QUEUE_FULL,
+        QUEUE_TIMEOUT,
+        RUNTIME_UNAVAILABLE,
+        CONNECT_FAILED,
+        SESSION_FAILED,
+        SHUTDOWN,
+    };
+
+    struct FailureCounters {
+        std::atomic<uint64_t> queue_full{0};
+        std::atomic<uint64_t> queue_timeout{0};
+        std::atomic<uint64_t> connect_failed{0};
+        std::atomic<uint64_t> runtime_unavailable{0};
+        std::atomic<uint64_t> session_failed{0};
+        std::atomic<uint64_t> shutdown{0};
+    };
+
+    struct TcpWorkItem {
+        Slice *slice = nullptr;
+        bool use_v2 = false;
+        std::function<void()> continuation;
+        uint64_t admission_sequence = 0;
+        std::chrono::steady_clock::time_point enqueued_at;
+        std::chrono::steady_clock::time_point admission_deadline;
+
+        TcpWorkItem() = default;
+        TcpWorkItem(Slice *slice_arg, bool use_v2_arg,
+                    std::function<void()> continuation_arg = nullptr)
+            : slice(slice_arg),
+              use_v2(use_v2_arg),
+              continuation(std::move(continuation_arg)) {}
+        TcpWorkItem(TcpWorkItem &&other) noexcept
+            : slice(other.slice),
+              use_v2(other.use_v2),
+              continuation(std::move(other.continuation)),
+              admission_sequence(other.admission_sequence),
+              enqueued_at(other.enqueued_at),
+              admission_deadline(other.admission_deadline) {
+            other.slice = nullptr;
+        }
+        TcpWorkItem &operator=(TcpWorkItem &&) = delete;
+        TcpWorkItem(const TcpWorkItem &) = delete;
+        TcpWorkItem &operator=(const TcpWorkItem &) = delete;
+    };
+
+    struct TerminalAction {
+        TcpWorkItem work;
+        TransferStatusEnum status;
+        bool connection_clean;
+
+        TerminalAction(TcpWorkItem &&work_arg, TransferStatusEnum status_arg,
+                       bool clean_arg)
+            : work(std::move(work_arg)),
+              status(status_arg),
+              connection_clean(clean_arg) {}
+        TerminalAction(TerminalAction &&) noexcept = default;
+        TerminalAction &operator=(TerminalAction &&) = delete;
+        TerminalAction(const TerminalAction &) = delete;
+        TerminalAction &operator=(const TerminalAction &) = delete;
+    };
+
+    static_assert(!std::is_copy_constructible<TcpWorkItem>::value,
+                  "TcpWorkItem must remain move-only");
+    static_assert(!std::is_copy_assignable<TcpWorkItem>::value,
+                  "TcpWorkItem must remain move-only");
+    static_assert(!std::is_copy_constructible<TerminalAction>::value,
+                  "TerminalAction must remain move-only");
+    static_assert(!std::is_copy_assignable<TerminalAction>::value,
+                  "TerminalAction must remain move-only");
+
+    enum class GroupState { OPEN, CLOSING, CLOSED };
+    enum class LaneState {
+        DISCONNECTED,
+        CONNECTING,
+        IDLE,
+        BUSY,
+        COMPLETING,
+        CLOSING,
+        CLOSED,
+    };
+    enum class LaneConnectStage { NONE, RESOLVING, CONNECTING };
+
+    struct ConnectionLaneRuntime {
+        explicit ConnectionLaneRuntime(asio::io_context &io_context)
+            : executor(io_context.get_executor()) {}
+
+        asio::io_context::executor_type executor;
+    };
+
+    struct PeerConnectionGroup;
+
+    struct ConnectionLane {
+        ConnectionLane(size_t lane_id_arg,
+                       const std::shared_ptr<PeerConnectionGroup> &group_arg)
+            : lane_id(lane_id_arg), group(group_arg) {}
+
+        size_t lane_id;
+        std::weak_ptr<PeerConnectionGroup> group;
+        LaneState state = LaneState::DISCONNECTED;
+        LaneConnectStage connect_stage = LaneConnectStage::NONE;
+        uint64_t operation_epoch = 0;
+        uint64_t last_connect_round = 0;
+        std::shared_ptr<asio::ip::tcp::resolver> resolver;
+        std::shared_ptr<asio::ip::tcp::socket> socket;
+        std::shared_ptr<ClientSession> session;
+        std::optional<TcpWorkItem> current;
+    };
+
+    struct PeerConnectionGroup {
+        PeerConnectionGroup(ConnectionKey key_arg,
+                            const asio::io_context::executor_type &executor_arg,
+                            size_t lane_count_arg, size_t queue_capacity_arg,
+                            size_t pending_admission_capacity_arg,
+                            std::chrono::milliseconds admission_timeout_arg,
+                            std::shared_ptr<FailureCounters> counters_arg)
+            : key(std::move(key_arg)),
+              executor(executor_arg),
+              lane_count(lane_count_arg),
+              queue_capacity(queue_capacity_arg),
+              pending_admission_capacity(pending_admission_capacity_arg),
+              admission_timeout(admission_timeout_arg),
+              failure_counters(std::move(counters_arg)) {}
+
+        std::mutex mutex;
+        GroupState state = GroupState::OPEN;
+        ConnectionKey key;
+        asio::io_context::executor_type executor;
+        size_t lane_count;
+        size_t queue_capacity;
+        std::deque<TcpWorkItem> queue;
+        std::deque<TcpWorkItem> pending_admissions;
+        size_t pending_admission_capacity;
+        std::chrono::milliseconds admission_timeout;
+        std::shared_ptr<asio::steady_timer> admission_timer;
+        bool admission_timer_armed = false;
+        uint64_t admission_epoch = 0;
+        uint64_t queued_bytes = 0;
+        bool queued_bytes_saturated = false;
+        uint64_t next_admission_sequence = 1;
+        std::vector<std::shared_ptr<ConnectionLane>> lanes;
+        bool pump_scheduled = false;
+        uint64_t pump_epoch = 0;
+        uint64_t connect_round = 1;
+        size_t connect_attempts_in_round = 0;
+        size_t probes_in_flight = 0;
+        bool connect_round_had_success = false;
+        std::chrono::steady_clock::time_point next_probe_not_before{};
+        std::shared_ptr<asio::steady_timer> retry_timer;
+        uint64_t retry_epoch = 0;
+        uint64_t connect_failure_log_count = 0;
+        std::shared_ptr<FailureCounters> failure_counters;
+    };
+
+    struct ConnectionLaneState {
+        std::mutex mutex;
+        bool shutting_down = false;
+        size_t lanes_per_peer = 4;
+        size_t max_queued_transfers_per_peer = 1024;
+        size_t max_pending_admissions_per_peer = 1024;
+        std::chrono::milliseconds admission_timeout{1000};
+        std::unordered_map<ConnectionKey, std::shared_ptr<PeerConnectionGroup>,
+                           ConnectionKeyHash>
+            groups;
+        std::weak_ptr<ConnectionLaneRuntime> runtime;
+        std::shared_ptr<FailureCounters> failure_counters =
+            std::make_shared<FailureCounters>();
+    };
+
+    std::shared_ptr<ConnectionLaneRuntime> lane_runtime_;
+    std::shared_ptr<ConnectionLaneState> lane_state_;
+
+    // TODO(#2930): The queue item bound does not bound queued source bytes,
+    // and a connected payload without a progress deadline can still stall a
+    // lane indefinitely. Peer-generation recovery is also a separate phase.
 
     std::shared_ptr<asio::ip::tcp::socket> getConnection(
-        const std::string &host, uint16_t port, bool use_pool);
-    void returnConnection(const std::string &host, uint16_t port,
-                          std::shared_ptr<asio::ip::tcp::socket> socket);
-    // Close `socket` and drop it from the pool: used for requests that did
-    // not terminate in a well-defined protocol state (#2086).
-    void discardConnection(const std::string &host, uint16_t port,
-                           std::shared_ptr<asio::ip::tcp::socket> socket);
-    void cleanupIdleConnections();
+        const std::string &host, uint16_t port);
+    void enqueuePooledTransfer(const ConnectionKey &key, TcpWorkItem work);
+    static uint64_t requestGroupPumpLocked(PeerConnectionGroup &group);
+    static void postGroupPump(const std::shared_ptr<PeerConnectionGroup> &group,
+                              uint64_t pump_epoch);
+    static void runGroupPump(const std::shared_ptr<PeerConnectionGroup> &group,
+                             uint64_t pump_epoch);
+    static void startLaneConnect(
+        const std::shared_ptr<PeerConnectionGroup> &group,
+        const std::shared_ptr<ConnectionLane> &lane, uint64_t epoch);
+    static void handleLaneResolved(
+        const std::shared_ptr<PeerConnectionGroup> &group,
+        const std::shared_ptr<ConnectionLane> &lane, uint64_t epoch,
+        asio::error_code ec, asio::ip::tcp::resolver::results_type results);
+    static void handleLaneConnected(
+        const std::shared_ptr<PeerConnectionGroup> &group,
+        const std::shared_ptr<ConnectionLane> &lane, uint64_t epoch,
+        asio::error_code ec);
+    static void handleLaneConnectFailure(
+        const std::shared_ptr<PeerConnectionGroup> &group,
+        const std::shared_ptr<ConnectionLane> &lane, uint64_t epoch,
+        const std::string &error);
+    static bool armRetryTimerLocked(
+        const std::shared_ptr<PeerConnectionGroup> &group);
+    static void handleRetryTimer(
+        const std::shared_ptr<PeerConnectionGroup> &group,
+        const std::shared_ptr<asio::steady_timer> &timer, uint64_t retry_epoch,
+        asio::error_code ec);
+    static size_t expirePendingAdmissionsLocked(
+        PeerConnectionGroup &group, std::chrono::steady_clock::time_point now,
+        std::deque<TcpWorkItem> &expired);
+    static size_t promotePendingAdmissionsLocked(PeerConnectionGroup &group);
+    static void refreshAdmissionTimerLocked(
+        const std::shared_ptr<PeerConnectionGroup> &group,
+        std::deque<TcpWorkItem> &runtime_failed,
+        std::shared_ptr<asio::steady_timer> &timer_to_cancel,
+        bool &timer_armed);
+    static void handleAdmissionTimer(
+        const std::shared_ptr<PeerConnectionGroup> &group,
+        const std::shared_ptr<asio::steady_timer> &timer,
+        uint64_t admission_epoch, asio::error_code ec);
+    static void startLaneSession(
+        const std::shared_ptr<PeerConnectionGroup> &group,
+        const std::shared_ptr<ConnectionLane> &lane, uint64_t epoch);
+    static void handleLaneTerminal(
+        const std::shared_ptr<PeerConnectionGroup> &group,
+        const std::shared_ptr<ConnectionLane> &lane, uint64_t epoch,
+        TransferStatusEnum status, bool connection_clean) noexcept;
+    static void completeTerminalAction(TerminalAction action) noexcept;
+    static void failWorkItem(
+        TcpWorkItem work, WorkFailureReason reason,
+        const std::shared_ptr<FailureCounters> &counters) noexcept;
+    static void failWorkItems(
+        std::deque<TcpWorkItem> work, WorkFailureReason reason,
+        const std::shared_ptr<FailureCounters> &counters) noexcept;
+    static uint64_t recordWorkFailure(
+        WorkFailureReason reason,
+        const std::shared_ptr<FailureCounters> &counters) noexcept;
+    static bool hasUsableLaneLocked(const PeerConnectionGroup &group);
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+    static size_t activeSocketCountLocked(const PeerConnectionGroup &group);
+#endif
+    static void beginConnectRoundLocked(PeerConnectionGroup &group);
+    static void enterReconnectCooldownLocked(PeerConnectionGroup &group);
+    static void addQueuedBytesLocked(PeerConnectionGroup &group,
+                                     uint64_t length);
+    static void removeQueuedBytesLocked(PeerConnectionGroup &group,
+                                        uint64_t length);
+    static void clearQueuedBytesLocked(PeerConnectionGroup &group);
+    static void closeSocketNoThrow(
+        const std::shared_ptr<asio::ip::tcp::socket> &socket) noexcept;
+    void shutdownConnectionLanes();
+    void startTransferWithSocket(
+        TcpWorkItem work,
+        std::shared_ptr<asio::ip::tcp::socket> socket) noexcept;
 
-    static constexpr std::chrono::seconds kConnectionIdleTimeout{60};
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+    friend bool tcpTransportLaneTypesAreMoveOnlyForTest() noexcept;
+#endif
 };
 }  // namespace mooncake
 

--- a/mooncake-transfer-engine/include/transport/tcp_transport/tcp_transport.h
+++ b/mooncake-transfer-engine/include/transport/tcp_transport/tcp_transport.h
@@ -153,8 +153,6 @@ class TcpTransport : public Transport {
         Slice *slice = nullptr;
         bool use_v2 = false;
         std::function<void()> continuation;
-        uint64_t admission_sequence = 0;
-        std::chrono::steady_clock::time_point enqueued_at;
         std::chrono::steady_clock::time_point admission_deadline;
 
         TcpWorkItem() = default;
@@ -167,8 +165,6 @@ class TcpTransport : public Transport {
             : slice(other.slice),
               use_v2(other.use_v2),
               continuation(std::move(other.continuation)),
-              admission_sequence(other.admission_sequence),
-              enqueued_at(other.enqueued_at),
               admission_deadline(other.admission_deadline) {
             other.slice = nullptr;
         }
@@ -243,13 +239,12 @@ class TcpTransport : public Transport {
     struct PeerConnectionGroup {
         PeerConnectionGroup(ConnectionKey key_arg,
                             const asio::io_context::executor_type &executor_arg,
-                            size_t lane_count_arg, size_t queue_capacity_arg,
+                            size_t queue_capacity_arg,
                             size_t pending_admission_capacity_arg,
                             std::chrono::milliseconds admission_timeout_arg,
                             std::shared_ptr<FailureCounters> counters_arg)
             : key(std::move(key_arg)),
               executor(executor_arg),
-              lane_count(lane_count_arg),
               queue_capacity(queue_capacity_arg),
               pending_admission_capacity(pending_admission_capacity_arg),
               admission_timeout(admission_timeout_arg),
@@ -259,23 +254,19 @@ class TcpTransport : public Transport {
         GroupState state = GroupState::OPEN;
         ConnectionKey key;
         asio::io_context::executor_type executor;
-        size_t lane_count;
         size_t queue_capacity;
         std::deque<TcpWorkItem> queue;
         std::deque<TcpWorkItem> pending_admissions;
         size_t pending_admission_capacity;
         std::chrono::milliseconds admission_timeout;
         std::shared_ptr<asio::steady_timer> admission_timer;
-        bool admission_timer_armed = false;
         uint64_t admission_epoch = 0;
         uint64_t queued_bytes = 0;
         bool queued_bytes_saturated = false;
-        uint64_t next_admission_sequence = 1;
         std::vector<std::shared_ptr<ConnectionLane>> lanes;
         bool pump_scheduled = false;
         uint64_t pump_epoch = 0;
         uint64_t connect_round = 1;
-        size_t connect_attempts_in_round = 0;
         size_t probes_in_flight = 0;
         bool connect_round_had_success = false;
         std::chrono::steady_clock::time_point next_probe_not_before{};
@@ -367,6 +358,9 @@ class TcpTransport : public Transport {
         WorkFailureReason reason,
         const std::shared_ptr<FailureCounters> &counters) noexcept;
     static bool hasUsableLaneLocked(const PeerConnectionGroup &group);
+    static bool hasDisconnectedLaneLocked(const PeerConnectionGroup &group);
+    static bool hasUntriedDisconnectedLaneLocked(
+        const PeerConnectionGroup &group);
 #ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
     static size_t activeSocketCountLocked(const PeerConnectionGroup &group);
 #endif

--- a/mooncake-transfer-engine/src/transport/tcp_transport/CMakeLists.txt
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/CMakeLists.txt
@@ -1,8 +1,15 @@
 file(GLOB TCP_SOURCES "*.cpp")
+file(GLOB TCP_IMPL_HEADERS "*_impl.h")
 
 if (USE_HIP)
+  list(APPEND TCP_SOURCES ${TCP_IMPL_HEADERS})
   hipify_files(TCP_SOURCES)
 endif()
 
 add_library(tcp_transport OBJECT ${TCP_SOURCES})
 target_link_libraries(tcp_transport PRIVATE JsonCpp::JsonCpp yalantinglibs::yalantinglibs)
+
+if(BUILD_UNIT_TESTS)
+  target_compile_definitions(tcp_transport
+                             PRIVATE MOONCAKE_TCP_TRANSPORT_TEST_HOOKS)
+endif()

--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
@@ -503,26 +503,69 @@ Transport::Slice* TcpTransport::prepareTransfer(
 
 void TcpTransport::startTransferSequence(std::vector<Slice*> slices) {
     struct Sequence {
+        std::mutex mutex;
         std::vector<Slice*> slices;
         size_t next = 0;
+        bool advancing = false;
+        bool resume_requested = false;
     };
+
     auto sequence = std::make_shared<Sequence>();
     sequence->slices = std::move(slices);
+
     auto advance = std::make_shared<std::function<void()>>();
     std::weak_ptr<std::function<void()>> weak_advance = advance;
+
     *advance = [this, sequence, weak_advance]() {
         auto advance = weak_advance.lock();
-        if (!advance || sequence->next == sequence->slices.size()) return;
-        auto* slice = sequence->slices[sequence->next++];
-        std::function<void()> continuation;
-        if (sequence->next < sequence->slices.size()) {
-            auto executor = context_->io_context.get_executor();
-            continuation = [executor, advance]() mutable {
-                asio::post(executor, [advance]() { (*advance)(); });
-            };
+        if (!advance) return;
+
+        {
+            std::lock_guard<std::mutex> lock(sequence->mutex);
+            if (sequence->next == sequence->slices.size()) return;
+            if (sequence->advancing) {
+                sequence->resume_requested = true;
+                return;
+            }
+            sequence->advancing = true;
         }
-        startTransfer(slice, std::move(continuation), true);
+
+        while (true) {
+            Slice* slice = nullptr;
+            bool has_more = false;
+            {
+                std::lock_guard<std::mutex> lock(sequence->mutex);
+                if (sequence->next == sequence->slices.size()) {
+                    sequence->advancing = false;
+                    return;
+                }
+                slice = sequence->slices[sequence->next++];
+                has_more = sequence->next < sequence->slices.size();
+                sequence->resume_requested = false;
+            }
+
+            std::function<void()> continuation;
+            if (has_more) {
+                continuation = [advance]() { (*advance)(); };
+            }
+
+            // startTransfer may fail synchronously (including during shutdown).
+            // The trampoline above turns a synchronous continuation into
+            // another loop iteration rather than recursive calls. For an
+            // asynchronous completion, this invocation returns and the
+            // continuation becomes the next runner.
+            startTransfer(slice, std::move(continuation), true);
+
+            {
+                std::lock_guard<std::mutex> lock(sequence->mutex);
+                if (!sequence->resume_requested) {
+                    sequence->advancing = false;
+                    return;
+                }
+            }
+        }
     };
+
     (*advance)();
 }
 

--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
@@ -51,7 +51,7 @@ using tcpsocket = asio::ip::tcp::socket;
 #ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
 namespace {
 using LaneConnectHandlerHook = void (*)() noexcept;
-using LaneConnectFailureInjectionHook = bool (*)() noexcept;
+using LaneConnectFailureInjectionHook = bool (*)(size_t) noexcept;
 using LaneRetryHandlerHook = void (*)() noexcept;
 using LaneAdmissionHandlerHook = void (*)() noexcept;
 using LaneObserverHook = void (*)(int, size_t, uint64_t, size_t, bool) noexcept;
@@ -94,13 +94,13 @@ void invokeLaneConnectHandlerHook() noexcept {
     if (hook) hook();
 }
 
-bool invokeLaneConnectFailureInjectionHook() noexcept {
+bool invokeLaneConnectFailureInjectionHook(size_t lane_id) noexcept {
     LaneConnectFailureInjectionHook hook;
     {
         std::lock_guard<std::mutex> lock(lane_test_hook_mutex);
         hook = lane_connect_failure_injection_hook;
     }
-    return hook && hook();
+    return hook && hook(lane_id);
 }
 
 void invokeLaneRetryHandlerHook() noexcept {
@@ -251,43 +251,43 @@ TcpTransport::TcpTransport()
         }
     }
 
-    if (enable_connection_pool_) {
-        constexpr size_t kDefaultLanesPerPeer = 4;
-        constexpr size_t kDefaultQueuedTransfersPerPeer = 1024;
-        constexpr size_t kMaxQueuedTransfersPerPeer = 65535;
-        constexpr size_t kDefaultPendingAdmissionsPerPeer = 1024;
-        constexpr size_t kMaxPendingAdmissionsPerPeer = 65535;
-        constexpr size_t kDefaultAdmissionTimeoutMs = 1000;
-        constexpr size_t kMaxAdmissionTimeoutMs = 600000;
+    constexpr size_t kDefaultLanesPerPeer = 4;
+    constexpr size_t kDefaultQueuedTransfersPerPeer = 1024;
+    constexpr size_t kMaxQueuedTransfersPerPeer = 65535;
+    constexpr size_t kDefaultPendingAdmissionsPerPeer = 1024;
+    constexpr size_t kMaxPendingAdmissionsPerPeer = 65535;
+    constexpr size_t kDefaultAdmissionTimeoutMs = 1000;
+    constexpr size_t kMaxAdmissionTimeoutMs = 600000;
 
-        const char* lanes_env = getenv("MC_TCP_LANES_PER_PEER");
+    const char* lanes_env = getenv("MC_TCP_LANES_PER_PEER");
+    if (lanes_env) {
+        lane_state_->lanes_per_peer = parseBoundedTcpSetting(
+            "MC_TCP_LANES_PER_PEER", lanes_env, kDefaultLanesPerPeer, 1,
+            kMaxTcpLanesPerPeer);
+    } else {
         const char* deprecated_env = getenv("MC_TCP_MAX_CONNECTIONS_PER_PEER");
-        if (lanes_env) {
-            lane_state_->lanes_per_peer = parseBoundedTcpSetting(
-                "MC_TCP_LANES_PER_PEER", lanes_env, kDefaultLanesPerPeer, 1,
-                kMaxTcpLanesPerPeer);
-        } else if (deprecated_env) {
+        if (deprecated_env) {
             LOG(WARNING) << "MC_TCP_MAX_CONNECTIONS_PER_PEER is deprecated; "
                             "use MC_TCP_LANES_PER_PEER";
             lane_state_->lanes_per_peer = parseBoundedTcpSetting(
                 "MC_TCP_MAX_CONNECTIONS_PER_PEER", deprecated_env,
                 kDefaultLanesPerPeer, 1, kMaxTcpLanesPerPeer);
         }
-
-        lane_state_->max_queued_transfers_per_peer = parseBoundedTcpSetting(
-            "MC_TCP_MAX_QUEUED_TRANSFERS_PER_PEER",
-            getenv("MC_TCP_MAX_QUEUED_TRANSFERS_PER_PEER"),
-            kDefaultQueuedTransfersPerPeer, 1, kMaxQueuedTransfersPerPeer);
-        lane_state_->max_pending_admissions_per_peer = parseBoundedTcpSetting(
-            "MC_TCP_MAX_PENDING_ADMISSIONS_PER_PEER",
-            getenv("MC_TCP_MAX_PENDING_ADMISSIONS_PER_PEER"),
-            kDefaultPendingAdmissionsPerPeer, 1, kMaxPendingAdmissionsPerPeer);
-        lane_state_->admission_timeout =
-            std::chrono::milliseconds(parseBoundedTcpSetting(
-                "MC_TCP_ADMISSION_TIMEOUT_MS",
-                getenv("MC_TCP_ADMISSION_TIMEOUT_MS"),
-                kDefaultAdmissionTimeoutMs, 1, kMaxAdmissionTimeoutMs));
     }
+
+    lane_state_->max_queued_transfers_per_peer = parseBoundedTcpSetting(
+        "MC_TCP_MAX_QUEUED_TRANSFERS_PER_PEER",
+        getenv("MC_TCP_MAX_QUEUED_TRANSFERS_PER_PEER"),
+        kDefaultQueuedTransfersPerPeer, 1, kMaxQueuedTransfersPerPeer);
+    lane_state_->max_pending_admissions_per_peer = parseBoundedTcpSetting(
+        "MC_TCP_MAX_PENDING_ADMISSIONS_PER_PEER",
+        getenv("MC_TCP_MAX_PENDING_ADMISSIONS_PER_PEER"),
+        kDefaultPendingAdmissionsPerPeer, 1, kMaxPendingAdmissionsPerPeer);
+    lane_state_->admission_timeout =
+        std::chrono::milliseconds(parseBoundedTcpSetting(
+            "MC_TCP_ADMISSION_TIMEOUT_MS",
+            getenv("MC_TCP_ADMISSION_TIMEOUT_MS"), kDefaultAdmissionTimeoutMs,
+            1, kMaxAdmissionTimeoutMs));
 }
 
 TcpTransport::~TcpTransport() {

--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
@@ -17,18 +17,25 @@
 #include <bits/stdint-uintn.h>
 #include <glog/logging.h>
 #include <asio/ip/v6_only.hpp>
+#include <asio/post.hpp>
 #include <asio/steady_timer.hpp>
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <cctype>
 #include <chrono>
+#include <condition_variable>
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
+#include <deque>
+#include <functional>
+#include <limits>
 #include <memory>
+#include <mutex>
 #include <optional>
-#include <random>
+#include <type_traits>
 
 #include "common.h"
 #include "transfer_engine.h"
@@ -40,807 +47,199 @@
 
 namespace mooncake {
 using tcpsocket = asio::ip::tcp::socket;
-static size_t getChunkSize() {
-    static const size_t val = [] {
-        const char* env = std::getenv("MC_TCP_SLICE_SIZE");
-        if (env) {
-            try {
-                size_t v = std::stoull(env);
-                if (v > 0) return v;
-                LOG(WARNING)
-                    << "Ignore non-positive MC_TCP_SLICE_SIZE value: " << env
-                    << ", using default 65536";
-            } catch (const std::exception& e) {
-                // A non-numeric or out-of-range value makes std::stoull throw;
-                // fall through to the default instead of letting the exception
-                // propagate out of this static initializer and abort the
-                // transfer that first reads the chunk size.
-                LOG(WARNING)
-                    << "Invalid MC_TCP_SLICE_SIZE value: " << env
-                    << ". Error: " << e.what() << ", using default 65536";
-            }
-        }
-        return size_t(65536);  // 64KB default
-    }();
-    return val;
-}
 
-struct SessionHeader {
-    uint64_t size;
-    uint64_t addr;
-    uint8_t opcode;
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+namespace {
+using LaneConnectHandlerHook = void (*)() noexcept;
+using LaneConnectFailureInjectionHook = bool (*)() noexcept;
+using LaneRetryHandlerHook = void (*)() noexcept;
+using LaneAdmissionHandlerHook = void (*)() noexcept;
+using LaneObserverHook = void (*)(int, size_t, uint64_t, size_t, bool) noexcept;
+using LaneFailureReasonHook = void (*)(int) noexcept;
+
+std::mutex lane_test_hook_mutex;
+LaneConnectHandlerHook lane_connect_handler_hook = nullptr;
+LaneConnectFailureInjectionHook lane_connect_failure_injection_hook = nullptr;
+LaneRetryHandlerHook lane_retry_handler_hook = nullptr;
+LaneAdmissionHandlerHook lane_admission_handler_hook = nullptr;
+LaneObserverHook lane_observer_hook = nullptr;
+LaneFailureReasonHook lane_failure_reason_hook = nullptr;
+
+enum LaneTestEvent {
+    kLaneQueueAdmitted = 1,
+    kLaneQueueRejected = 2,
+    kLaneConnecting = 3,
+    kLaneBusy = 4,
+    kLaneTerminal = 5,
+    kLaneShutdownClean = 6,
+    kLaneLateHandler = 7,
+    kLaneRetryArmed = 8,
+    kLaneRetryFired = 9,
+    kLaneRetryLate = 10,
+    kLaneCooldownStarted = 11,
+    kLaneAdmissionPending = 12,
+    kLaneAdmissionPromoted = 13,
+    kLaneAdmissionTimerArmed = 14,
+    kLaneAdmissionTimerFired = 15,
+    kLaneAdmissionTimerLate = 16,
+    kLaneAdmissionHardRejected = 17,
 };
 
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
-    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
-    defined(USE_COREX)
-static bool isCudaMemory(void* addr) {
-    cudaPointerAttributes attributes;
-    auto status = cudaPointerGetAttributes(&attributes, addr);
-    if (status != cudaSuccess) return false;
-    return attributes.type == cudaMemoryTypeDevice;
+void invokeLaneConnectHandlerHook() noexcept {
+    LaneConnectHandlerHook hook;
+    {
+        std::lock_guard<std::mutex> lock(lane_test_hook_mutex);
+        hook = lane_connect_handler_hook;
+    }
+    if (hook) hook();
 }
 
-// Returns the CUDA device ordinal if addr is device memory, or -1 otherwise.
-// Callers must call cudaSetDevice before any cudaMemcpy to avoid implicit
-// GPU 0 context creation.
-static int getCudaDeviceId(void* addr) {
-    cudaPointerAttributes attributes;
-    auto status = cudaPointerGetAttributes(&attributes, addr);
-    if (status != cudaSuccess) return -1;
-    if (attributes.type == cudaMemoryTypeDevice) return attributes.device;
-    return -1;
+bool invokeLaneConnectFailureInjectionHook() noexcept {
+    LaneConnectFailureInjectionHook hook;
+    {
+        std::lock_guard<std::mutex> lock(lane_test_hook_mutex);
+        hook = lane_connect_failure_injection_hook;
+    }
+    return hook && hook();
 }
 
-#ifdef USE_MACA
-static cudaError_t copyTcpCudaMemory(void* dst, const void* src, size_t size) {
-    cudaStream_t stream;
-    cudaError_t status =
-        cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking);
-    if (status != cudaSuccess) return status;
-
-    status = cudaMemcpyAsync(dst, src, size, cudaMemcpyDefault, stream);
-    if (status == cudaSuccess) {
-        status = cudaStreamSynchronize(stream);
+void invokeLaneRetryHandlerHook() noexcept {
+    LaneRetryHandlerHook hook;
+    {
+        std::lock_guard<std::mutex> lock(lane_test_hook_mutex);
+        hook = lane_retry_handler_hook;
     }
-
-    cudaError_t destroy_status = cudaStreamDestroy(stream);
-    return status == cudaSuccess ? destroy_status : status;
-}
-#endif
-#endif
-
-// Forward declaration
-class TcpTransport;
-
-using ValidateAddrFn = std::function<bool(uint64_t, uint64_t)>;
-
-// --- Acknowledged framing (protocol v2, #2086) ------------------------------
-// v1 framing gives the initiator no channel to learn whether the receiver
-// applied (or even accepted) a WRITE: COMPLETED fires when the final chunk
-// enters the initiator's kernel socket buffer, while megabytes may still be
-// in flight toward destination memory, and a rejected request is silently
-// "successful". v2 requests set the high bit of the opcode; the server then
-// (a) prefixes every READ response with an 8-byte status frame and (b) sends
-// an 8-byte status frame for WRITE only after the final chunk has been
-// applied to destination memory. Initiators enable v2 only when the target
-// segment advertises tcp_proto_version >= 2, so old servers never see
-// flagged opcodes and old initiators keep receiving v1 framing.
-static constexpr uint8_t kOpcodeV2Flag = 0x80;
-// Status frames carry a magic in the high 32 bits so that a v2 initiator
-// which reaches a v1 server through a stale descriptor (v1 treats unknown
-// opcodes as READ and immediately streams payload bytes) fails fast on the
-// first frame instead of misinterpreting the stream. Residual risk: payload
-// bytes that happen to equal a valid frame (2^-64 per request, data
-// dependent) are indistinguishable in-band; eliminating that would need a
-// nonce/checksum handshake, which this deliberately avoids.
-static constexpr uint64_t kStatusMagic = 0x4D435456ull << 32;  // "MCTV"
-static constexpr uint64_t kStatusOk = kStatusMagic | 0;
-static constexpr uint64_t kStatusAddrRejected = kStatusMagic | 1;
-static inline bool statusFrameValid(uint64_t frame) {
-    return (frame & 0xFFFFFFFF00000000ull) == kStatusMagic;
+    if (hook) hook();
 }
 
-// Operational escape hatch: MC_TCP_PROTO=1 forces initiators to speak the
-// legacy unacknowledged framing even to v2-capable servers. Also used by
-// tests to cover the mixed-version matrix in one process.
-static bool forceLegacyTcpProto() {
-    // Read per call (startTransfer already does metadata lookups; getenv is
-    // noise) so tests can cover both protocol modes in one process.
-    const char* env = std::getenv("MC_TCP_PROTO");
-    return env && env[0] == '1' && env[1] == '\0';
+void invokeLaneAdmissionHandlerHook() noexcept {
+    LaneAdmissionHandlerHook hook;
+    {
+        std::lock_guard<std::mutex> lock(lane_test_hook_mutex);
+        hook = lane_admission_handler_hook;
+    }
+    if (hook) hook();
 }
 
-// Server-side session: handles transfer requests on a persistent connection.
-// The session owns the socket; ending the callback chain without rearming
-// (start()/next handler) drops the last reference and closes the connection.
-struct ServerSession : public std::enable_shared_from_this<ServerSession> {
-    explicit ServerSession(std::shared_ptr<tcpsocket> socket,
-                           ValidateAddrFn validate_addr)
-        : socket_(std::move(socket)),
-          validate_addr_(std::move(validate_addr)) {}
-
-    std::shared_ptr<tcpsocket> socket_;
-    ValidateAddrFn validate_addr_;
-    SessionHeader header_;
-    uint64_t total_transferred_bytes_;
-    char* local_buffer_;
-    bool v2_ = false;
-    uint64_t status_frame_;
-
-    void start() {
-        total_transferred_bytes_ = 0;
-        readHeader();
+void invokeLaneObserverHook(int event, size_t queue_depth,
+                            uint64_t queued_bytes, size_t active_sockets,
+                            bool lane_has_current) noexcept {
+    LaneObserverHook hook;
+    {
+        std::lock_guard<std::mutex> lock(lane_test_hook_mutex);
+        hook = lane_observer_hook;
     }
+    if (hook)
+        hook(event, queue_depth, queued_bytes, active_sockets,
+             lane_has_current);
+}
 
-   private:
-    // Send an 8-byte status frame, then run `next` (or end the session —
-    // closing the connection — when `next` is empty or the send fails).
-    void sendStatus(uint64_t status, std::function<void()> next) {
-        status_frame_ = htole64(status);
-        auto self(shared_from_this());
-        asio::async_write(*socket_,
-                          asio::buffer(&status_frame_, sizeof(status_frame_)),
-                          [this, self, next = std::move(next)](
-                              const asio::error_code& ec, std::size_t) {
-                              if (ec)
-                                  return;  // connection closes with the session
-                              if (next) next();
-                          });
+void invokeLaneFailureReasonHook(int reason) noexcept {
+    LaneFailureReasonHook hook;
+    {
+        std::lock_guard<std::mutex> lock(lane_test_hook_mutex);
+        hook = lane_failure_reason_hook;
     }
+    if (hook) hook(reason);
+}
+}  // namespace
 
-    void readHeader() {
-        auto self(shared_from_this());
-        asio::async_read(
-            *socket_, asio::buffer(&header_, sizeof(SessionHeader)),
-            [this, self](const asio::error_code& ec, std::size_t len) {
-                if (ec || len != sizeof(SessionHeader)) {
-                    if (ec.value() != asio::error::eof) {
-                        LOG(WARNING)
-                            << "ServerSession::readHeader failed. Error: "
-                            << ec.message() << " (value: " << ec.value() << ")"
-                            << ", bytes read: " << len;
-                    }
-                    return;
-                }
+void tcpTransportSetLaneConnectHandlerHookForTest(
+    LaneConnectHandlerHook hook) noexcept {
+    std::lock_guard<std::mutex> lock(lane_test_hook_mutex);
+    lane_connect_handler_hook = hook;
+}
 
-                v2_ = (header_.opcode & kOpcodeV2Flag) != 0;
-                const uint8_t opcode = header_.opcode & ~kOpcodeV2Flag;
-                local_buffer_ = (char*)(le64toh(header_.addr));
-                uint64_t size = le64toh(header_.size);
-                if (validate_addr_ &&
-                    !validate_addr_((uint64_t)local_buffer_, size)) {
-                    LOG(ERROR) << "ServerSession: remote-supplied address 0x"
-                               << std::hex << (uint64_t)local_buffer_
-                               << std::dec << " with size " << size
-                               << " is not within any registered buffer";
-                    // v2 initiators learn of the rejection; v1 initiators
-                    // only see the connection close (and, for small WRITEs,
-                    // may have already reported success — the defect v2
-                    // exists to fix).
-                    if (v2_) sendStatus(kStatusAddrRejected, nullptr);
-                    return;
-                }
-                if (opcode == (uint8_t)TransferRequest::WRITE) {
-                    readBody();
-                } else if (v2_) {
-                    // READ, v2: status frame precedes the data.
-                    sendStatus(kStatusOk, [this] { writeBody(); });
-                } else {
-                    writeBody();
-                }
-            });
-    }
+void tcpTransportSetLaneConnectFailureInjectionHookForTest(
+    LaneConnectFailureInjectionHook hook) noexcept {
+    std::lock_guard<std::mutex> lock(lane_test_hook_mutex);
+    lane_connect_failure_injection_hook = hook;
+}
 
-    void writeBody() {
-        auto self(shared_from_this());
-        uint64_t size = le64toh(header_.size);
-        char* addr = local_buffer_;
+void tcpTransportSetLaneObserverHookForTest(LaneObserverHook hook) noexcept {
+    std::lock_guard<std::mutex> lock(lane_test_hook_mutex);
+    lane_observer_hook = hook;
+}
 
-        size_t buffer_size =
-            std::min(getChunkSize(), size - total_transferred_bytes_);
-        if (buffer_size == 0) {
-            // Transfer complete, wait for next request on this connection
-            start();
-            return;
+void tcpTransportSetLaneRetryHandlerHookForTest(
+    LaneRetryHandlerHook hook) noexcept {
+    std::lock_guard<std::mutex> lock(lane_test_hook_mutex);
+    lane_retry_handler_hook = hook;
+}
+
+void tcpTransportSetLaneAdmissionHandlerHookForTest(
+    LaneAdmissionHandlerHook hook) noexcept {
+    std::lock_guard<std::mutex> lock(lane_test_hook_mutex);
+    lane_admission_handler_hook = hook;
+}
+
+void tcpTransportSetLaneFailureReasonHookForTest(
+    LaneFailureReasonHook hook) noexcept {
+    std::lock_guard<std::mutex> lock(lane_test_hook_mutex);
+    lane_failure_reason_hook = hook;
+}
+
+bool tcpTransportLaneTypesAreMoveOnlyForTest() noexcept {
+    return std::is_move_constructible<TcpTransport::TcpWorkItem>::value &&
+           !std::is_copy_constructible<TcpTransport::TcpWorkItem>::value &&
+           !std::is_copy_assignable<TcpTransport::TcpWorkItem>::value &&
+           std::is_move_constructible<TcpTransport::TerminalAction>::value &&
+           !std::is_copy_constructible<TcpTransport::TerminalAction>::value &&
+           !std::is_copy_assignable<TcpTransport::TerminalAction>::value;
+}
+#endif
+
+#include "tcp_transport_session_impl.h"
+
+namespace {
+constexpr size_t kMaxTcpLanesPerPeer = 16;
+
+size_t parseBoundedTcpSetting(const char* name, const char* value,
+                              size_t default_value, size_t minimum,
+                              size_t maximum) {
+    if (!value) return default_value;
+
+    const std::string text(value);
+    size_t parsed = 0;
+    bool valid = !text.empty();
+    for (char c : text) {
+        if (c < '0' || c > '9') {
+            valid = false;
+            break;
         }
-
-        char* dram_buffer = addr + total_transferred_bytes_;
-        int cuda_device = -1;
-
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
-    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
-    defined(USE_COREX)
-        cuda_device = getCudaDeviceId(addr);
-        if (cuda_device >= 0) {
-            dram_buffer = new char[buffer_size];
-            cudaSetDevice(cuda_device);
-#ifdef USE_MACA
-            cudaError_t cuda_status = copyTcpCudaMemory(
-                dram_buffer, addr + total_transferred_bytes_, buffer_size);
-#else
-            cudaError_t cuda_status =
-                cudaMemcpy(dram_buffer, addr + total_transferred_bytes_,
-                           buffer_size, cudaMemcpyDefault);
-#endif
-            if (cuda_status != cudaSuccess) {
-                LOG(ERROR) << "ServerSession::writeBody failed to copy from "
-                              "CUDA memory. "
-                           << "Error: " << cudaGetErrorString(cuda_status);
-                delete[] dram_buffer;
-                return;  // Connection will be closed
-            }
+        const size_t digit = static_cast<size_t>(c - '0');
+        if (parsed > (maximum - digit) / size_t(10)) {
+            valid = false;
+            break;
         }
-#endif
-
-        asio::async_write(
-            *socket_, asio::buffer(dram_buffer, buffer_size),
-            [this, addr, dram_buffer, cuda_device, self](
-                const asio::error_code& ec, std::size_t transferred_bytes) {
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
-    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
-    defined(USE_COREX)
-                if (cuda_device >= 0) {
-                    delete[] dram_buffer;
-                }
-#endif
-                if (ec) {
-                    LOG(ERROR)
-                        << "ServerSession::writeBody failed. "
-                        << "Attempt to write data " << static_cast<void*>(addr)
-                        << " using buffer " << static_cast<void*>(dram_buffer)
-                        << ". Error: " << ec.message()
-                        << " (value: " << ec.value() << ")";
-                    return;  // Connection will be closed
-                }
-                total_transferred_bytes_ += transferred_bytes;
-                writeBody();
-            });
+        parsed = parsed * 10 + digit;
     }
+    if (valid && parsed >= minimum && parsed <= maximum) return parsed;
 
-    void readBody() {
-        auto self(shared_from_this());
-        uint64_t size = le64toh(header_.size);
-        char* addr = local_buffer_;
+    LOG(WARNING) << "Invalid " << name << " value: " << text
+                 << ", using default " << default_value;
+    return default_value;
+}
 
-        size_t buffer_size =
-            std::min(getChunkSize(), size - total_transferred_bytes_);
-        if (buffer_size == 0) {
-            // Destination memory now holds the complete payload. Under v2,
-            // acknowledge before accepting the next request — this is what
-            // makes the initiator's COMPLETED mean "applied at the
-            // destination" rather than "left my socket buffer".
-            if (v2_) {
-                sendStatus(kStatusOk, [this] { start(); });
-            } else {
-                start();
-            }
-            return;
-        }
+bool validateTcpAddress(const std::shared_ptr<TransferMetadata>& metadata,
+                        uint64_t addr, uint64_t size) {
+    if (size == 0 || addr + size < addr) return false;
 
-        char* dram_buffer = addr + total_transferred_bytes_;
-        int cuda_device = -1;
-
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
-    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
-    defined(USE_COREX)
-        cuda_device = getCudaDeviceId(addr);
-        if (cuda_device >= 0) {
-            dram_buffer = new char[buffer_size];
-        }
-#endif
-
-        asio::async_read(
-            *socket_, asio::buffer(dram_buffer, buffer_size),
-            [this, addr, dram_buffer, cuda_device, self](
-                const asio::error_code& ec, std::size_t transferred_bytes) {
-                if (ec) {
-                    // If client closed connection (EOF), this is normal - don't
-                    // log
-                    if (ec.value() != asio::error::eof) {
-                        LOG(WARNING)
-                            << "ServerSession::readBody failed. "
-                            << "Attempt to read data "
-                            << static_cast<void*>(addr) << " using buffer "
-                            << static_cast<void*>(dram_buffer)
-                            << ". Error: " << ec.message()
-                            << " (value: " << ec.value() << ")";
-                    }
-                    if (cuda_device >= 0) delete[] dram_buffer;
-                    return;  // Connection will be closed
-                }
-
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
-    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
-    defined(USE_COREX)
-                if (cuda_device >= 0) {
-                    cudaSetDevice(cuda_device);
-#ifdef USE_MACA
-                    cudaError_t cuda_status =
-                        copyTcpCudaMemory(addr + total_transferred_bytes_,
-                                          dram_buffer, transferred_bytes);
-#else
-                    cudaError_t cuda_status =
-                        cudaMemcpy(addr + total_transferred_bytes_, dram_buffer,
-                                   transferred_bytes, cudaMemcpyDefault);
-#endif
-                    if (cuda_status != cudaSuccess) {
-                        LOG(ERROR)
-                            << "ServerSession::readBody failed to copy to CUDA "
-                               "memory. "
-                            << "Error: " << cudaGetErrorString(cuda_status);
-                        delete[] dram_buffer;
-                        return;  // Connection will be closed
-                    }
-                    delete[] dram_buffer;
-                }
-#endif
-                total_transferred_bytes_ += transferred_bytes;
-                readBody();
-            });
+    auto desc = metadata->getSegmentDescByID(LOCAL_SEGMENT_ID);
+    if (!desc) return false;
+    for (const auto& buffer : desc->buffers) {
+        if (buffer.addr + buffer.length < buffer.addr) continue;
+        if (buffer.addr <= addr && addr + size <= buffer.addr + buffer.length)
+            return true;
     }
-};
+    return false;
+}
+}  // namespace
 
-// Client-side session: initiates one transfer request
-struct ClientSession : public std::enable_shared_from_this<ClientSession> {
-    explicit ClientSession(std::shared_ptr<tcpsocket> socket, bool use_v2,
-                           std::function<void(bool)> on_complete = nullptr)
-        : socket_(std::move(socket)),
-          v2_(use_v2),
-          on_complete_(std::move(on_complete)) {}
-
-    std::shared_ptr<tcpsocket> socket_;
-    SessionHeader header_;
-    uint64_t total_transferred_bytes_;
-    char* local_buffer_;
-    bool v2_;
-    uint64_t status_frame_;
-    // v2 WRITE runs the body stream and the ack read concurrently (one
-    // async op per direction; handlers serialize on the io thread). The
-    // concurrent read lets a rejection — or a v1 server's bogus payload —
-    // abort a large in-flight WRITE instead of deadlocking on mutually
-    // full socket buffers, and delivers rejection frames before the close.
-    bool write_body_done_ = false;
-    bool write_acked_ok_ = false;
-    // An early negative/malformed ack can arrive while asio::async_write still
-    // owns a buffer pointing into the caller's source memory. Do not publish a
-    // terminal status until that body operation has completed or been
-    // cancelled: callers are allowed to release the source buffer as soon as
-    // the transfer becomes terminal.
-    bool write_body_in_flight_ = false;
-    bool write_abort_requested_ = false;
-    // A v2 status frame is prompt by construction: a READ status precedes
-    // any payload, and a WRITE ack follows at most one chunk's apply after
-    // the body is done. The only peer that never sends one is a legacy
-    // server reached through a stale v2 descriptor — and for requests
-    // shorter than a frame it also keeps the connection open (it streamed
-    // size < 8 bytes of "READ payload" and is waiting for our next header),
-    // so without a deadline both sides wait forever. Bound that wait; the
-    // default is generous so no healthy slow path can trip it, since it only
-    // covers the frame itself, never payload streaming.
-    static int statusFrameTimeoutSec() {
-        const char* env = std::getenv("MC_TCP_STATUS_TIMEOUT_SEC");
-        if (env) {
-            int v = std::atoi(env);
-            if (v > 0) return v;
-        }
-        return 30;
-    }
-    std::optional<asio::steady_timer> status_timer_;
-    bool status_deadline_disarmed_ = false;
-    std::function<void(TransferStatusEnum)> on_finalize_;
-    // Invoked exactly once per request with clean=true iff the protocol
-    // exchange terminated in a well-defined connection state. A socket whose
-    // request did not end cleanly must not be reused: the server-side session
-    // may be mid-frame, and the next request's header would be consumed as
-    // body bytes.
-    std::function<void(bool)> on_complete_;
-
-    void initiate(void* buffer, uint64_t dest_addr, size_t size,
-                  TransferRequest::OpCode opcode) {
-        local_buffer_ = (char*)buffer;
-        header_.addr = htole64(dest_addr);
-        header_.size = htole64(size);
-        header_.opcode = (uint8_t)opcode | (v2_ ? kOpcodeV2Flag : 0);
-        total_transferred_bytes_ = 0;
-        writeHeader();
-    }
-
-   private:
-    // All handlers run on the transport's single io thread, so arm/cancel
-    // and the expiry handler never race. Expiry only closes the socket: the
-    // pending status read then completes with an error and its handler owns
-    // the failure path (including source-buffer quiescence for WRITE).
-    void armStatusDeadline() {
-        auto self(shared_from_this());
-        status_deadline_disarmed_ = false;
-        status_timer_.emplace(socket_->get_executor());
-        status_timer_->expires_after(
-            std::chrono::seconds(statusFrameTimeoutSec()));
-        status_timer_->async_wait([this, self](const asio::error_code& ec) {
-            // The disarmed flag also covers an expiry that was already
-            // queued when cancel() ran (cancel cannot revoke those, and by
-            // then the socket may have been re-pooled).
-            if (ec == asio::error::operation_aborted ||
-                status_deadline_disarmed_) {
-                return;
-            }
-            LOG(ERROR) << "ClientSession: no status frame within "
-                       << statusFrameTimeoutSec()
-                       << "s (peer likely speaks the legacy protocol); "
-                          "dropping connection";
-            if (socket_ && socket_->is_open()) {
-                asio::error_code cec;
-                socket_->close(cec);
-            }
-        });
-    }
-
-    void cancelStatusDeadline() {
-        status_deadline_disarmed_ = true;
-        if (status_timer_) status_timer_->cancel();
-    }
-
-    // Single terminal path: finish connection ownership, then report the
-    // outcome. Posted so it runs after the invoking callback returns.
-    void finalize(TransferStatusEnum status, bool clean) {
-        cancelStatusDeadline();
-        auto self(shared_from_this());
-        asio::post(
-            socket_->get_executor(),
-            [this, self, status, clean, on_finalize = std::move(on_finalize_),
-             on_complete = std::move(on_complete_)]() {
-                // Finish connection ownership before publishing terminal
-                // status. Once on_finalize marks the slice, the caller may
-                // immediately free the batch or destroy the transport.
-                if (on_complete) on_complete(clean);
-                if (on_finalize) on_finalize(status);
-            });
-    }
-
-    // Abort a v2 WRITE and cancel any body operation. If asio still owns the
-    // current source buffer, its completion handler is responsible for
-    // finalizing after the buffer is quiescent.
-    void abortWrite() {
-        write_abort_requested_ = true;
-        if (socket_ && socket_->is_open()) {
-            asio::error_code ec;
-            socket_->close(ec);
-        }
-        if (!write_body_in_flight_) finalize(TransferStatusEnum::FAILED, false);
-    }
-
-    void writeHeader() {
-        auto self(shared_from_this());
-        asio::async_write(
-            *socket_, asio::buffer(&header_, sizeof(SessionHeader)),
-            [this, self](const asio::error_code& ec, std::size_t len) {
-                if (ec || len != sizeof(SessionHeader)) {
-                    LOG(ERROR)
-                        << "ClientSession::writeHeader failed. Error: "
-                        << ec.message() << " (value: " << ec.value() << ")"
-                        << ", bytes written: " << len;
-                    finalize(TransferStatusEnum::FAILED, false);
-                    return;
-                }
-                if ((header_.opcode & ~kOpcodeV2Flag) ==
-                    (uint8_t)TransferRequest::WRITE) {
-                    if (v2_) readWriteAck();  // concurrent with the body
-                    writeBody();
-                } else if (v2_) {
-                    readReadStatus();
-                } else {
-                    readBody();
-                }
-            });
-    }
-
-    // v2 READ: the server prefixes the data with a status frame.
-    void readReadStatus() {
-        auto self(shared_from_this());
-        armStatusDeadline();
-        asio::async_read(
-            *socket_, asio::buffer(&status_frame_, sizeof(status_frame_)),
-            [this, self](const asio::error_code& ec, std::size_t len) {
-                cancelStatusDeadline();
-                if (ec || len != sizeof(status_frame_)) {
-                    LOG(ERROR)
-                        << "ClientSession: failed to read READ status "
-                           "frame. Error: "
-                        << ec.message() << " (value: " << ec.value() << ")";
-                    finalize(TransferStatusEnum::FAILED, false);
-                    return;
-                }
-                uint64_t frame = le64toh(status_frame_);
-                if (!statusFrameValid(frame)) {
-                    LOG(ERROR) << "ClientSession: malformed READ status "
-                                  "frame (peer likely speaks the legacy "
-                                  "protocol); dropping connection";
-                    finalize(TransferStatusEnum::FAILED, false);
-                    return;
-                }
-                if (frame != kStatusOk) {
-                    LOG(ERROR) << "ClientSession: READ rejected by server, "
-                                  "status "
-                               << (frame & 0xFFFFFFFFull);
-                    finalize(TransferStatusEnum::FAILED, false);
-                    return;
-                }
-                readBody();
-            });
-    }
-
-    // v2 WRITE: completion is the server's acknowledgment that the payload
-    // has been applied to destination memory. Armed concurrently with the
-    // body stream; a well-behaved v2 server only sends the frame after the
-    // final chunk, so a frame arriving before the body is done is either a
-    // rejection or a legacy peer's payload — both close the socket immediately
-    // and publish failure only after the outstanding body write is quiescent.
-    void readWriteAck() {
-        auto self(shared_from_this());
-        asio::async_read(
-            *socket_, asio::buffer(&status_frame_, sizeof(status_frame_)),
-            [this, self](const asio::error_code& ec, std::size_t len) {
-                cancelStatusDeadline();
-                if (ec || len != sizeof(status_frame_)) {
-                    // The body path may have already finalized a failure and
-                    // closed the socket; finalize() is idempotent (moved-from
-                    // callbacks are null-checked).
-                    if (ec != asio::error::operation_aborted) {
-                        LOG(ERROR)
-                            << "ClientSession: failed to read WRITE "
-                               "ack frame. Error: "
-                            << ec.message() << " (value: " << ec.value() << ")";
-                    }
-                    abortWrite();
-                    return;
-                }
-                uint64_t frame = le64toh(status_frame_);
-                if (!statusFrameValid(frame)) {
-                    LOG(ERROR) << "ClientSession: malformed WRITE ack frame "
-                                  "(peer likely speaks the legacy protocol); "
-                                  "dropping connection";
-                    abortWrite();
-                    return;
-                }
-                if (frame != kStatusOk) {
-                    LOG(ERROR) << "ClientSession: WRITE rejected by server, "
-                                  "status "
-                               << (frame & 0xFFFFFFFFull);
-                    abortWrite();
-                    return;
-                }
-                if (!write_body_done_) {
-                    // The server's ack can legitimately overtake the final
-                    // local write-completion handler (both become ready
-                    // together for small writes; the io thread may run this
-                    // handler first). Record it; the body path finalizes.
-                    write_acked_ok_ = true;
-                    return;
-                }
-                finalize(TransferStatusEnum::COMPLETED, true);
-            });
-    }
-
-    void readBody() {
-        auto self(shared_from_this());
-        uint64_t size = le64toh(header_.size);
-        char* addr = local_buffer_;
-
-        size_t buffer_size =
-            std::min(getChunkSize(), size - total_transferred_bytes_);
-        if (buffer_size == 0) {
-            finalize(TransferStatusEnum::COMPLETED, true);
-            return;
-        }
-
-        char* dram_buffer = addr + total_transferred_bytes_;
-        int cuda_device = -1;
-
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
-    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
-    defined(USE_COREX)
-        cuda_device = getCudaDeviceId(addr);
-        if (cuda_device >= 0) {
-            dram_buffer = new char[buffer_size];
-        }
-#endif
-
-        asio::async_read(
-            *socket_, asio::buffer(dram_buffer, buffer_size),
-            [this, addr, dram_buffer, cuda_device, self](
-                const asio::error_code& ec, std::size_t transferred_bytes) {
-                if (ec) {
-                    LOG(ERROR)
-                        << "ClientSession::readBody failed. "
-                        << "Attempt to read data " << static_cast<void*>(addr)
-                        << " using buffer " << static_cast<void*>(dram_buffer)
-                        << ". Error: " << ec.message()
-                        << " (value: " << ec.value() << ")";
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
-    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
-    defined(USE_COREX)
-                    if (cuda_device >= 0) delete[] dram_buffer;
-#endif
-                    finalize(TransferStatusEnum::FAILED, false);
-                    return;
-                }
-
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
-    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
-    defined(USE_COREX)
-                if (cuda_device >= 0) {
-                    cudaSetDevice(cuda_device);
-#ifdef USE_MACA
-                    cudaError_t cuda_status =
-                        copyTcpCudaMemory(addr + total_transferred_bytes_,
-                                          dram_buffer, transferred_bytes);
-#else
-                    cudaError_t cuda_status =
-                        cudaMemcpy(addr + total_transferred_bytes_, dram_buffer,
-                                   transferred_bytes, cudaMemcpyDefault);
-#endif
-                    if (cuda_status != cudaSuccess) {
-                        LOG(ERROR)
-                            << "ClientSession::readBody failed to copy to CUDA "
-                               "memory. "
-                            << "Error: " << cudaGetErrorString(cuda_status);
-                        delete[] dram_buffer;
-                        finalize(TransferStatusEnum::FAILED, false);
-                        return;
-                    }
-                    delete[] dram_buffer;
-                }
-#endif
-                total_transferred_bytes_ += transferred_bytes;
-                readBody();
-            });
-    }
-
-    void writeBody() {
-        auto self(shared_from_this());
-        uint64_t size = le64toh(header_.size);
-        char* addr = local_buffer_;
-
-        size_t buffer_size =
-            std::min(getChunkSize(), size - total_transferred_bytes_);
-        if (buffer_size == 0) {
-            if (v2_) {
-                if (write_abort_requested_) {
-                    finalize(TransferStatusEnum::FAILED, false);
-                    return;
-                }
-                // Completion comes from the server's acknowledgment, whose
-                // read is already in flight (armed in writeHeader) and may
-                // have finished first.
-                write_body_done_ = true;
-                if (write_acked_ok_) {
-                    finalize(TransferStatusEnum::COMPLETED, true);
-                } else {
-                    // From here a well-behaved server owes at most one
-                    // chunk's apply plus the frame; a legacy peer behind a
-                    // stale descriptor may owe nothing, ever.
-                    armStatusDeadline();
-                }
-            } else {
-                // v1: no acknowledgment exists in the protocol; this only
-                // means the payload left the initiator (#2086).
-                finalize(TransferStatusEnum::COMPLETED, true);
-            }
-            return;
-        }
-
-        char* dram_buffer = addr + total_transferred_bytes_;
-        int cuda_device = -1;
-
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
-    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
-    defined(USE_COREX)
-        cuda_device = getCudaDeviceId(addr);
-        if (cuda_device >= 0) {
-            dram_buffer = new char[buffer_size];
-            cudaSetDevice(cuda_device);
-#ifdef USE_MACA
-            cudaError_t cuda_status = copyTcpCudaMemory(
-                dram_buffer, addr + total_transferred_bytes_, buffer_size);
-#else
-            cudaError_t cuda_status =
-                cudaMemcpy(dram_buffer, addr + total_transferred_bytes_,
-                           buffer_size, cudaMemcpyDefault);
-#endif
-            if (cuda_status != cudaSuccess) {
-                LOG(ERROR) << "ClientSession::writeBody failed to copy from "
-                              "CUDA memory. "
-                           << "Error: " << cudaGetErrorString(cuda_status);
-                delete[] dram_buffer;
-                abortWrite();
-                return;
-            }
-        }
-#endif
-
-        write_body_in_flight_ = true;
-        asio::async_write(
-            *socket_, asio::buffer(dram_buffer, buffer_size),
-            [this, addr, dram_buffer, cuda_device, self](
-                const asio::error_code& ec, std::size_t transferred_bytes) {
-                write_body_in_flight_ = false;
-                if (cuda_device >= 0) {
-                    delete[] dram_buffer;
-                }
-                if (ec) {
-                    LOG(ERROR)
-                        << "ClientSession::writeBody failed. "
-                        << "Attempt to write data " << static_cast<void*>(addr)
-                        << " using buffer " << static_cast<void*>(dram_buffer)
-                        << ". Error: " << ec.message()
-                        << " (value: " << ec.value() << ")";
-                    abortWrite();
-                    return;
-                }
-                if (write_abort_requested_) {
-                    // The early ack path closed the socket while this
-                    // operation still owned the caller's source buffer. It is
-                    // safe to publish failure now that the handler has run.
-                    finalize(TransferStatusEnum::FAILED, false);
-                    return;
-                }
-                total_transferred_bytes_ += transferred_bytes;
-                writeBody();
-            });
-    }
-};
-
-struct TcpContext {
-    TcpContext(short port, ValidateAddrFn validate_addr)
-        : acceptor(io_context), validate_addr_(std::move(validate_addr)) {
-        std::error_code ec;
-        asio::ip::tcp::endpoint endpoint(asio::ip::tcp::v6(), port);
-
-        acceptor.open(endpoint.protocol(), ec);
-        if (!ec) {
-            acceptor.set_option(asio::ip::v6_only(false), ec);
-            if (!ec) {
-                acceptor.set_option(
-                    asio::ip::tcp::acceptor::reuse_address(true));
-                acceptor.bind(endpoint, ec);
-                if (!ec) {
-                    acceptor.listen();
-                    return;
-                }
-            }
-            acceptor.close();
-        }
-        LOG(ERROR) << "Failed to set up IPv6 dual-stack listener: "
-                   << ec.message() << " (error code: " << ec.value() << ")";
-        asio::ip::tcp::endpoint endpoint_v4(asio::ip::tcp::v4(), port);
-        acceptor.open(endpoint_v4.protocol());
-        acceptor.set_option(asio::ip::tcp::acceptor::reuse_address(true));
-        acceptor.bind(endpoint_v4);
-        acceptor.listen();
-    }
-
-    void doAccept() {
-        acceptor.async_accept([this](asio::error_code ec, tcpsocket socket) {
-            if (!ec) {
-                asio::error_code nodelay_ec;
-                socket.set_option(asio::ip::tcp::no_delay(true), nodelay_ec);
-                auto socket_ptr =
-                    std::make_shared<tcpsocket>(std::move(socket));
-                auto session =
-                    std::make_shared<ServerSession>(socket_ptr, validate_addr_);
-                session->start();
-            }
-            doAccept();
-        });
-    }
-
-    asio::io_context io_context;
-    asio::ip::tcp::acceptor acceptor;
-    ValidateAddrFn validate_addr_;
-};
-
-TcpTransport::TcpTransport() : context_(nullptr), running_(false) {
+TcpTransport::TcpTransport()
+    : context_(nullptr),
+      running_(false),
+      lane_state_(std::make_shared<ConnectionLaneState>()) {
     if (getenv("MC_TCP_ENABLE_CONNECTION_POOL") != nullptr) {
         std::string val(getenv("MC_TCP_ENABLE_CONNECTION_POOL"));
         std::transform(val.begin(), val.end(), val.begin(),
@@ -851,21 +250,48 @@ TcpTransport::TcpTransport() : context_(nullptr), running_(false) {
             enable_connection_pool_ = true;
         }
     }
+
+    if (enable_connection_pool_) {
+        constexpr size_t kDefaultLanesPerPeer = 4;
+        constexpr size_t kDefaultQueuedTransfersPerPeer = 1024;
+        constexpr size_t kMaxQueuedTransfersPerPeer = 65535;
+        constexpr size_t kDefaultPendingAdmissionsPerPeer = 1024;
+        constexpr size_t kMaxPendingAdmissionsPerPeer = 65535;
+        constexpr size_t kDefaultAdmissionTimeoutMs = 1000;
+        constexpr size_t kMaxAdmissionTimeoutMs = 600000;
+
+        const char* lanes_env = getenv("MC_TCP_LANES_PER_PEER");
+        const char* deprecated_env = getenv("MC_TCP_MAX_CONNECTIONS_PER_PEER");
+        if (lanes_env) {
+            lane_state_->lanes_per_peer = parseBoundedTcpSetting(
+                "MC_TCP_LANES_PER_PEER", lanes_env, kDefaultLanesPerPeer, 1,
+                kMaxTcpLanesPerPeer);
+        } else if (deprecated_env) {
+            LOG(WARNING) << "MC_TCP_MAX_CONNECTIONS_PER_PEER is deprecated; "
+                            "use MC_TCP_LANES_PER_PEER";
+            lane_state_->lanes_per_peer = parseBoundedTcpSetting(
+                "MC_TCP_MAX_CONNECTIONS_PER_PEER", deprecated_env,
+                kDefaultLanesPerPeer, 1, kMaxTcpLanesPerPeer);
+        }
+
+        lane_state_->max_queued_transfers_per_peer = parseBoundedTcpSetting(
+            "MC_TCP_MAX_QUEUED_TRANSFERS_PER_PEER",
+            getenv("MC_TCP_MAX_QUEUED_TRANSFERS_PER_PEER"),
+            kDefaultQueuedTransfersPerPeer, 1, kMaxQueuedTransfersPerPeer);
+        lane_state_->max_pending_admissions_per_peer = parseBoundedTcpSetting(
+            "MC_TCP_MAX_PENDING_ADMISSIONS_PER_PEER",
+            getenv("MC_TCP_MAX_PENDING_ADMISSIONS_PER_PEER"),
+            kDefaultPendingAdmissionsPerPeer, 1, kMaxPendingAdmissionsPerPeer);
+        lane_state_->admission_timeout =
+            std::chrono::milliseconds(parseBoundedTcpSetting(
+                "MC_TCP_ADMISSION_TIMEOUT_MS",
+                getenv("MC_TCP_ADMISSION_TIMEOUT_MS"),
+                kDefaultAdmissionTimeoutMs, 1, kMaxAdmissionTimeoutMs));
+    }
 }
 
 TcpTransport::~TcpTransport() {
-    if (running_) {
-        running_ = false;
-        context_->io_context.stop();
-        thread_.join();
-    }
-
-    // Clear connection pool BEFORE deleting context
-    // because sockets in the pool reference io_context
-    {
-        std::lock_guard<std::mutex> lock(pool_mutex_);
-        connection_pool_.clear();
-    }
+    shutdownConnectionLanes();
 
     if (context_) {
         delete context_;
@@ -915,9 +341,14 @@ int TcpTransport::install(std::string& local_server_name,
 
     close(sockfd);  // the above function has opened a socket
     LOG(INFO) << "TcpTransport: listen on port " << tcp_port;
-    context_ = new TcpContext(tcp_port, [this](uint64_t addr, uint64_t size) {
-        return validateAddress(addr, size);
+    auto metadata = metadata_;
+    context_ = new TcpContext(tcp_port, [metadata = std::move(metadata)](
+                                            uint64_t addr, uint64_t size) {
+        return validateTcpAddress(metadata, addr, size);
     });
+    lane_runtime_ =
+        std::make_shared<ConnectionLaneRuntime>(context_->io_context);
+    lane_state_->runtime = lane_runtime_;
     running_ = true;
     thread_ = std::thread(&TcpTransport::worker, this);
     return 0;
@@ -1084,8 +515,12 @@ void TcpTransport::startTransferSequence(std::vector<Slice*> slices) {
         if (!advance || sequence->next == sequence->slices.size()) return;
         auto* slice = sequence->slices[sequence->next++];
         std::function<void()> continuation;
-        if (sequence->next < sequence->slices.size())
-            continuation = [advance]() { (*advance)(); };
+        if (sequence->next < sequence->slices.size()) {
+            auto executor = context_->io_context.get_executor();
+            continuation = [executor, advance]() mutable {
+                asio::post(executor, [advance]() { (*advance)(); });
+            };
+        }
         startTransfer(slice, std::move(continuation), true);
     };
     (*advance)();
@@ -1106,220 +541,41 @@ void TcpTransport::worker() {
 }
 
 std::shared_ptr<asio::ip::tcp::socket> TcpTransport::getConnection(
-    const std::string& host, uint16_t port, bool use_pool) {
-    // Ungrouped transfers keep the configured connection-pool behavior.
-    if (!use_pool) {
-        try {
-            asio::ip::tcp::resolver resolver(context_->io_context);
-            auto endpoint_iterator =
-                resolver.resolve(host, std::to_string(port));
-            auto socket_ptr =
-                std::make_shared<asio::ip::tcp::socket>(context_->io_context);
-            asio::connect(*socket_ptr, endpoint_iterator);
-            socket_ptr->set_option(asio::ip::tcp::no_delay(true));
-            return socket_ptr;
-        } catch (std::exception& e) {
-            LOG(ERROR)
-                << "TcpTransport::getConnection failed to create connection to "
-                << host << ":" << port << ". Error: " << e.what();
-            return nullptr;
-        }
-    }
-
-    ConnectionKey key{host, port};
-
-    // First phase: search for available connection while holding the lock
-    {
-        std::lock_guard<std::mutex> lock(pool_mutex_);
-
-        // Cleanup idle and dead connections
-        cleanupIdleConnections();
-
-        auto it = connection_pool_.find(key);
-        if (it != connection_pool_.end()) {
-            auto& queue = it->second;
-
-            // Find an available connection
-            for (auto queue_it = queue.begin(); queue_it != queue.end();) {
-                auto& entry = *queue_it;
-                if (!entry->in_use) {
-                    // Check if connection is still alive
-                    if (entry->socket->is_open()) {
-                        entry->in_use = true;
-                        entry->last_used = std::chrono::steady_clock::now();
-                        return entry->socket;
-                    } else {
-                        // Remove dead connection immediately
-                        queue_it = queue.erase(queue_it);
-                        continue;
-                    }
-                }
-                ++queue_it;
-            }
-        }
-    }
-
-    // No available connection, create a new one (pool grows dynamically)
-    // Release lock before creating new connection to avoid blocking other
-    // threads during slow DNS resolution and TCP handshake
-    std::shared_ptr<asio::ip::tcp::socket> new_socket;
+    const std::string& host, uint16_t port) {
+    // The reusable path is owned by fixed connection lanes. This helper is
+    // only for the connection-pool-disabled one-shot path.
     try {
         asio::ip::tcp::resolver resolver(context_->io_context);
         auto endpoint_iterator = resolver.resolve(host, std::to_string(port));
-        new_socket =
+        auto socket_ptr =
             std::make_shared<asio::ip::tcp::socket>(context_->io_context);
-        asio::connect(*new_socket, endpoint_iterator);
-        new_socket->set_option(asio::ip::tcp::no_delay(true));
+        asio::connect(*socket_ptr, endpoint_iterator);
+        socket_ptr->set_option(asio::ip::tcp::no_delay(true));
+        return socket_ptr;
     } catch (std::exception& e) {
         LOG(ERROR)
             << "TcpTransport::getConnection failed to create connection to "
             << host << ":" << port << ". Error: " << e.what();
         return nullptr;
     }
-
-    // Re-acquire lock to add the new connection to the pool
-    std::shared_ptr<PooledConnection> entry;
-    {
-        std::lock_guard<std::mutex> lock(pool_mutex_);
-        // Re-check if another thread already added a connection while we were
-        // creating this one
-        auto& queue = connection_pool_[key];
-        for (auto it = queue.begin(); it != queue.end(); ++it) {
-            auto& existing_entry = *it;
-            if (!existing_entry->in_use && existing_entry->socket->is_open()) {
-                // Another thread added an available connection, use that
-                // instead and close the one we just created
-                if (new_socket && new_socket->is_open()) {
-                    asio::error_code ec;
-                    new_socket->close(ec);
-                }
-                existing_entry->in_use = true;
-                existing_entry->last_used = std::chrono::steady_clock::now();
-                return existing_entry->socket;
-            }
-        }
-
-        // No other connection available, add the one we created to the pool
-        entry = std::make_shared<PooledConnection>(new_socket, host, port);
-        queue.push_back(entry);
-    }
-
-    return entry->socket;
 }
 
-void TcpTransport::returnConnection(
-    const std::string& host, uint16_t port,
-    std::shared_ptr<asio::ip::tcp::socket> socket) {
-    ConnectionKey key{host, port};
-
-    std::lock_guard<std::mutex> lock(pool_mutex_);
-
-    auto it = connection_pool_.find(key);
-    if (it != connection_pool_.end()) {
-        for (auto entry_it = it->second.begin(); entry_it != it->second.end();
-             ++entry_it) {
-            if ((*entry_it)->socket == socket) {
-                if (socket->is_open()) {
-                    (*entry_it)->in_use = false;
-                    (*entry_it)->last_used = std::chrono::steady_clock::now();
-                } else {
-                    // Connection is dead, remove from pool
-                    it->second.erase(entry_it);
-                }
-                return;
-            }
-        }
-    }
-
-    // Connection not found in pool (might be temporary), close it
-    if (socket && socket->is_open()) {
-        asio::error_code ec;
-        socket->close(ec);
-    }
-}
-
-void TcpTransport::cleanupIdleConnections() {
-    auto now = std::chrono::steady_clock::now();
-
-    for (auto it = connection_pool_.begin(); it != connection_pool_.end();) {
-        auto& queue = it->second;
-
-        for (auto entry_it = queue.begin(); entry_it != queue.end();) {
-            auto& entry = *entry_it;
-            if (!entry->in_use) {
-                auto idle_duration =
-                    std::chrono::duration_cast<std::chrono::seconds>(
-                        now - entry->last_used)
-                        .count();
-                if (idle_duration > kConnectionIdleTimeout.count()) {
-                    if (entry->socket && entry->socket->is_open()) {
-                        asio::error_code ec;
-                        entry->socket->close(ec);
-                    }
-                    entry_it = queue.erase(entry_it);
-                    continue;
-                }
-            }
-            ++entry_it;
-        }
-
-        if (queue.empty()) {
-            it = connection_pool_.erase(it);
-        } else {
-            ++it;
-        }
-    }
-}
-
-bool TcpTransport::validateAddress(uint64_t addr, uint64_t size) const {
-    if (size == 0) return false;
-    if (addr + size < addr) return false;
-
-    auto desc = metadata_->getSegmentDescByID(LOCAL_SEGMENT_ID);
-    if (!desc) return false;
-
-    for (const auto& buffer : desc->buffers) {
-        if (buffer.addr + buffer.length < buffer.addr) continue;
-        if (buffer.addr <= addr && addr + size <= buffer.addr + buffer.length)
-            return true;
-    }
-    return false;
-}
-
-void TcpTransport::discardConnection(
-    const std::string& host, uint16_t port,
-    std::shared_ptr<asio::ip::tcp::socket> socket) {
-    if (socket && socket->is_open()) {
-        asio::error_code ec;
-        socket->close(ec);
-    }
-    std::lock_guard<std::mutex> lock(pool_mutex_);
-    auto it = connection_pool_.find(ConnectionKey{host, port});
-    if (it != connection_pool_.end()) {
-        auto& queue = it->second;
-        for (auto queue_it = queue.begin(); queue_it != queue.end();
-             ++queue_it) {
-            if ((*queue_it)->socket == socket) {
-                queue.erase(queue_it);
-                break;
-            }
-        }
-        if (queue.empty()) connection_pool_.erase(it);
-    }
-}
+#include "tcp_transport_lane_impl.h"
 
 void TcpTransport::startTransfer(Slice* slice,
                                  std::function<void()> continuation,
                                  bool reuse_connection) {
-    auto finish = [this, slice, continuation = std::move(continuation)](
-                      TransferStatusEnum status) mutable {
+    auto finish = [slice, &continuation](TransferStatusEnum status) mutable {
         if (status == TransferStatusEnum::COMPLETED)
             slice->markSuccess();
         else
             slice->markFailed();
-        if (continuation)
-            asio::post(context_->io_context, std::move(continuation));
+        if (continuation) {
+            auto next = std::move(continuation);
+            next();
+        }
     };
+
     auto desc = metadata_->getSegmentDescByID(slice->target_id);
     if (!desc) {
         LOG(ERROR) << "TcpTransport::startTransfer failed to get segment "
@@ -1340,68 +596,91 @@ void TcpTransport::startTransfer(Slice* slice,
 
     // Zero-length requests are complete by definition. v1 reported them
     // COMPLETED while the server silently rejected size==0 in address
-    // validation; short-circuiting keeps that outcome (rather than turning
-    // no-ops into v2 rejection failures) without the pointless round trip.
+    // validation; preserve that outcome without a round trip.
     if (slice->length == 0) {
         finish(TransferStatusEnum::COMPLETED);
         return;
     }
 
-    const bool use_pool = enable_connection_pool_ || reuse_connection;
-    auto socket = getConnection(meta_entry.ip_or_host_name, desc->tcp_data_port,
-                                use_pool);
-    if (!socket) {
-        LOG(ERROR) << "TcpTransport::startTransfer failed to get connection to "
-                   << meta_entry.ip_or_host_name << ":" << desc->tcp_data_port;
-        finish(TransferStatusEnum::FAILED);
+    const ConnectionKey key{meta_entry.ip_or_host_name,
+                            static_cast<uint16_t>(desc->tcp_data_port)};
+    const bool use_v2 = desc->tcp_proto_version >= 2 && !forceLegacyTcpProto();
+    TcpWorkItem work(slice, use_v2, std::move(continuation));
+
+    // Scatter task groups request reuse even when the general pool setting is
+    // disabled. Fixed lanes provide the same serial socket reuse without
+    // reviving the old unbounded dynamic pool.
+    if (enable_connection_pool_ || reuse_connection) {
+        enqueuePooledTransfer(key, std::move(work));
         return;
     }
 
+    // Preserve the connection-pool-disabled synchronous one-shot path.
+    auto socket = getConnection(key.host, key.port);
+    if (!socket) {
+        LOG(ERROR) << "TcpTransport::startTransfer failed to get connection to "
+                   << key.host << ":" << key.port;
+        completeTerminalAction(
+            TerminalAction(std::move(work), TransferStatusEnum::FAILED, false));
+        return;
+    }
+    startTransferWithSocket(std::move(work), std::move(socket));
+}
+
+void TcpTransport::startTransferWithSocket(
+    TcpWorkItem work, std::shared_ptr<asio::ip::tcp::socket> socket) noexcept {
+    const Slice* slice = work.slice;
+    std::shared_ptr<std::optional<TcpWorkItem>> terminal_work;
     try {
-        const bool use_v2 =
-            desc->tcp_proto_version >= 2 && !forceLegacyTcpProto();
-        auto session = std::make_shared<ClientSession>(socket, use_v2);
-
-        session->on_finalize_ = finish;
-
-        // Return connection to pool when the request terminated cleanly;
-        // otherwise the server-side session state is unknown (it may be
-        // mid-frame), so reusing the socket would desynchronize the next
-        // request. Discard it instead.
-        if (use_pool) {
-            session->on_complete_ = [this, host = meta_entry.ip_or_host_name,
-                                     port = desc->tcp_data_port,
-                                     socket](bool clean) {
-                if (clean)
-                    returnConnection(host, port, socket);
-                else
-                    discardConnection(host, port, socket);
-            };
-        } else {
-            session->on_complete_ = [socket](bool) {
-                // Close connection immediately after transfer
-                if (socket && socket->is_open()) {
-                    asio::error_code ec;
-                    socket->close(ec);
-                }
-            };
-        }
-
-        session->initiate(slice->source_addr, slice->tcp.dest_addr,
-                          slice->length, slice->opcode);
-    } catch (std::exception& e) {
+        terminal_work =
+            std::make_shared<std::optional<TcpWorkItem>>(std::move(work));
+        auto session = std::make_shared<ClientSession>(
+            socket, terminal_work->value().use_v2,
+            [terminal_work, socket](TransferStatusEnum status, bool) noexcept {
+                closeSocketNoThrow(socket);
+                if (!terminal_work->has_value()) return;
+                auto completed = std::move(terminal_work->value());
+                terminal_work->reset();
+                completeTerminalAction(
+                    TerminalAction(std::move(completed), status, false));
+            });
+        session->initiate(terminal_work->value().slice->source_addr,
+                          terminal_work->value().slice->tcp.dest_addr,
+                          terminal_work->value().slice->length,
+                          terminal_work->value().slice->opcode);
+    } catch (const std::exception& e) {
         LOG(ERROR) << "TcpTransport::startTransfer encountered an exception. "
                       "Slice details - source_addr: "
                    << slice->source_addr << ", length: " << slice->length
                    << ", opcode: " << (int)slice->opcode
                    << ", target_id: " << slice->target_id
                    << ". Exception: " << e.what();
-        // On exception, always close the socket and remove from pool if
-        // present. Don't return it to the pool as it may be in an
-        // inconsistent state.
-        discardConnection(meta_entry.ip_or_host_name,
-                          static_cast<uint16_t>(desc->tcp_data_port), socket);
-        finish(TransferStatusEnum::FAILED);
+        closeSocketNoThrow(socket);
+        if (terminal_work && terminal_work->has_value()) {
+            auto failed = std::move(terminal_work->value());
+            terminal_work->reset();
+            failWorkItem(std::move(failed), WorkFailureReason::SESSION_FAILED,
+                         lane_state_->failure_counters);
+        } else if (work.slice) {
+            failWorkItem(std::move(work), WorkFailureReason::SESSION_FAILED,
+                         lane_state_->failure_counters);
+        }
+    } catch (...) {
+        LOG(ERROR) << "TcpTransport::startTransfer encountered an unknown "
+                      "exception. Slice details - source_addr: "
+                   << slice->source_addr << ", length: " << slice->length
+                   << ", opcode: " << (int)slice->opcode
+                   << ", target_id: " << slice->target_id;
+        closeSocketNoThrow(socket);
+        if (terminal_work && terminal_work->has_value()) {
+            auto failed = std::move(terminal_work->value());
+            terminal_work->reset();
+            failWorkItem(std::move(failed), WorkFailureReason::SESSION_FAILED,
+                         lane_state_->failure_counters);
+        } else if (work.slice) {
+            failWorkItem(std::move(work), WorkFailureReason::SESSION_FAILED,
+                         lane_state_->failure_counters);
+        }
     }
 }
 

--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport_lane_impl.h
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport_lane_impl.h
@@ -1,0 +1,1383 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Private implementation fragment included by tcp_transport.cpp from inside
+// namespace mooncake. This file contains the bounded connection-lane state
+// machine and its test hooks; it is intentionally not a standalone translation
+// unit so this review-only split does not change linkage or initialization.
+
+namespace {
+constexpr size_t kMaxConcurrentLaneProbes = 1;
+// Conservative fixed policy for the first rate-limited implementation. The
+// exact cooldown/backoff policy remains subject to maintainer review.
+constexpr auto kReconnectRoundCooldown = std::chrono::seconds(1);
+constexpr auto kShutdownCancellationWait = std::chrono::seconds(2);
+
+bool shouldLogOccurrence(uint64_t occurrence) {
+    return occurrence != 0 && (occurrence & (occurrence - 1)) == 0;
+}
+
+void cancelTimerNoThrow(
+    const std::shared_ptr<asio::steady_timer>& timer) noexcept {
+    if (!timer) return;
+    asio::error_code ec;
+    timer->cancel(ec);
+}
+
+// Tracks only whether executor-posted cancellation actions ran. It is not an
+// asynchronous-handler quiescence barrier; stop/join provides that boundary.
+struct LaneCancellationPostTracker {
+    std::mutex mutex;
+    std::condition_variable cv;
+    size_t pending = 0;
+
+    void add() {
+        std::lock_guard<std::mutex> lock(mutex);
+        ++pending;
+    }
+
+    void done() {
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            if (pending != 0) --pending;
+        }
+        cv.notify_all();
+    }
+
+    void waitUntil(std::chrono::steady_clock::time_point deadline) {
+        std::unique_lock<std::mutex> lock(mutex);
+        cv.wait_until(lock, deadline, [this] { return pending == 0; });
+    }
+};
+}  // namespace
+
+bool TcpTransport::hasUsableLaneLocked(const PeerConnectionGroup& group) {
+    for (const auto& lane : group.lanes) {
+        if ((lane->state == LaneState::IDLE || lane->state == LaneState::BUSY ||
+             lane->state == LaneState::COMPLETING) &&
+            lane->socket && lane->socket->is_open()) {
+            return true;
+        }
+    }
+    return false;
+}
+
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+size_t TcpTransport::activeSocketCountLocked(const PeerConnectionGroup& group) {
+    size_t count = 0;
+    for (const auto& lane : group.lanes) {
+        if (lane->resolver || lane->socket) ++count;
+    }
+    return count;
+}
+#endif
+
+void TcpTransport::beginConnectRoundLocked(PeerConnectionGroup& group) {
+    ++group.connect_round;
+    if (group.connect_round == 0) group.connect_round = 1;
+    group.connect_attempts_in_round = 0;
+    group.connect_round_had_success = false;
+    group.next_probe_not_before = {};
+}
+
+void TcpTransport::enterReconnectCooldownLocked(PeerConnectionGroup& group) {
+    group.next_probe_not_before =
+        std::chrono::steady_clock::now() + kReconnectRoundCooldown;
+}
+
+void TcpTransport::addQueuedBytesLocked(PeerConnectionGroup& group,
+                                        uint64_t length) {
+    if (group.queued_bytes_saturated) return;
+    if (group.queued_bytes > std::numeric_limits<uint64_t>::max() - length) {
+        group.queued_bytes = std::numeric_limits<uint64_t>::max();
+        group.queued_bytes_saturated = true;
+        return;
+    }
+    group.queued_bytes += length;
+}
+
+void TcpTransport::removeQueuedBytesLocked(PeerConnectionGroup& group,
+                                           uint64_t length) {
+    if (!group.queued_bytes_saturated) {
+        group.queued_bytes =
+            group.queued_bytes >= length ? group.queued_bytes - length : 0;
+        return;
+    }
+
+    // Once saturated, UINT64_MAX is only an explicit lower-fidelity marker,
+    // not an exact sum. Recompute after removal so exact accounting resumes as
+    // soon as the remaining queue fits in uint64_t.
+    group.queued_bytes = 0;
+    group.queued_bytes_saturated = false;
+    for (const auto& item : group.queue) {
+        addQueuedBytesLocked(group, item.slice->length);
+        if (group.queued_bytes_saturated) break;
+    }
+}
+
+void TcpTransport::clearQueuedBytesLocked(PeerConnectionGroup& group) {
+    group.queued_bytes = 0;
+    group.queued_bytes_saturated = false;
+}
+
+size_t TcpTransport::expirePendingAdmissionsLocked(
+    PeerConnectionGroup& group, std::chrono::steady_clock::time_point now,
+    std::deque<TcpWorkItem>& expired) {
+    size_t count = 0;
+    while (!group.pending_admissions.empty() &&
+           group.pending_admissions.front().admission_deadline <= now) {
+        expired.emplace_back(std::move(group.pending_admissions.front()));
+        group.pending_admissions.pop_front();
+        ++count;
+    }
+    return count;
+}
+
+size_t TcpTransport::promotePendingAdmissionsLocked(
+    PeerConnectionGroup& group) {
+    size_t count = 0;
+    while (group.queue.size() < group.queue_capacity &&
+           !group.pending_admissions.empty()) {
+        group.queue.emplace_back(std::move(group.pending_admissions.front()));
+        group.pending_admissions.pop_front();
+        addQueuedBytesLocked(group, group.queue.back().slice->length);
+        ++count;
+    }
+    return count;
+}
+
+void TcpTransport::refreshAdmissionTimerLocked(
+    const std::shared_ptr<PeerConnectionGroup>& group,
+    std::deque<TcpWorkItem>& runtime_failed,
+    std::shared_ptr<asio::steady_timer>& timer_to_cancel, bool& timer_armed) {
+    timer_armed = false;
+    if (group->pending_admissions.empty()) {
+        if (group->admission_timer_armed || group->admission_timer) {
+            ++group->admission_epoch;
+            if (group->admission_epoch == 0) ++group->admission_epoch;
+            group->admission_timer_armed = false;
+            timer_to_cancel = std::move(group->admission_timer);
+        }
+        return;
+    }
+
+    if (group->admission_timer_armed && group->admission_timer) return;
+
+    if (group->admission_timer) {
+        timer_to_cancel = std::move(group->admission_timer);
+        ++group->admission_epoch;
+        if (group->admission_epoch == 0) ++group->admission_epoch;
+    }
+
+    try {
+        auto timer = std::make_shared<asio::steady_timer>(group->executor);
+        timer->expires_at(group->pending_admissions.front().admission_deadline);
+        ++group->admission_epoch;
+        if (group->admission_epoch == 0) ++group->admission_epoch;
+        const uint64_t admission_epoch = group->admission_epoch;
+        group->admission_timer = timer;
+        group->admission_timer_armed = true;
+        timer->async_wait([group, timer, admission_epoch](asio::error_code ec) {
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+            invokeLaneAdmissionHandlerHook();
+#endif
+            handleAdmissionTimer(group, timer, admission_epoch, ec);
+        });
+        timer_armed = true;
+        return;
+    } catch (...) {
+        ++group->admission_epoch;
+        if (group->admission_epoch == 0) ++group->admission_epoch;
+        group->admission_timer_armed = false;
+        if (group->admission_timer)
+            timer_to_cancel = std::move(group->admission_timer);
+        while (!group->pending_admissions.empty()) {
+            runtime_failed.emplace_back(
+                std::move(group->pending_admissions.front()));
+            group->pending_admissions.pop_front();
+        }
+        return;
+    }
+}
+
+void TcpTransport::handleAdmissionTimer(
+    const std::shared_ptr<PeerConnectionGroup>& group,
+    const std::shared_ptr<asio::steady_timer>& timer, uint64_t admission_epoch,
+    asio::error_code ec) {
+    std::deque<TcpWorkItem> expired;
+    std::deque<TcpWorkItem> runtime_failed;
+    std::shared_ptr<asio::steady_timer> timer_to_cancel;
+    uint64_t pump_epoch = 0;
+    size_t promoted = 0;
+    [[maybe_unused]] size_t pending_depth = 0;
+    bool timer_armed = false;
+    [[maybe_unused]] bool fired = false;
+    [[maybe_unused]] bool late = false;
+    {
+        std::lock_guard<std::mutex> lock(group->mutex);
+        if (group->state != GroupState::OPEN ||
+            group->admission_epoch != admission_epoch ||
+            !group->admission_timer_armed || group->admission_timer != timer) {
+            late = true;
+        } else {
+            group->admission_timer.reset();
+            group->admission_timer_armed = false;
+            fired = true;
+            if (ec) {
+                while (!group->pending_admissions.empty()) {
+                    runtime_failed.emplace_back(
+                        std::move(group->pending_admissions.front()));
+                    group->pending_admissions.pop_front();
+                }
+            } else {
+                expirePendingAdmissionsLocked(
+                    *group, std::chrono::steady_clock::now(), expired);
+                promoted = promotePendingAdmissionsLocked(*group);
+                refreshAdmissionTimerLocked(group, runtime_failed,
+                                            timer_to_cancel, timer_armed);
+                if (promoted != 0) pump_epoch = requestGroupPumpLocked(*group);
+            }
+            pending_depth = group->pending_admissions.size();
+        }
+    }
+
+    cancelTimerNoThrow(timer_to_cancel);
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+    if (late) {
+        invokeLaneObserverHook(kLaneAdmissionTimerLate, 0, 0, 0, false);
+    } else if (fired) {
+        invokeLaneObserverHook(kLaneAdmissionTimerFired, pending_depth, 0, 0,
+                               false);
+    }
+    if (promoted != 0)
+        invokeLaneObserverHook(kLaneAdmissionPromoted, pending_depth, promoted,
+                               0, false);
+    if (timer_armed)
+        invokeLaneObserverHook(kLaneAdmissionTimerArmed, pending_depth, 0, 0,
+                               false);
+#endif
+    failWorkItems(std::move(expired), WorkFailureReason::QUEUE_TIMEOUT,
+                  group->failure_counters);
+    failWorkItems(std::move(runtime_failed),
+                  WorkFailureReason::RUNTIME_UNAVAILABLE,
+                  group->failure_counters);
+    if (pump_epoch != 0) postGroupPump(group, pump_epoch);
+}
+
+bool TcpTransport::armRetryTimerLocked(
+    const std::shared_ptr<PeerConnectionGroup>& group) {
+    if (group->retry_timer || group->state != GroupState::OPEN ||
+        group->queue.empty()) {
+        return true;
+    }
+
+    try {
+        auto timer = std::make_shared<asio::steady_timer>(group->executor);
+        timer->expires_at(group->next_probe_not_before);
+        ++group->retry_epoch;
+        if (group->retry_epoch == 0) ++group->retry_epoch;
+        const uint64_t retry_epoch = group->retry_epoch;
+        group->retry_timer = timer;
+        // A handler abandoned by io_context.stop() is harmless: it holds only
+        // group/timer shared state and can only request a new connection round.
+        timer->async_wait([group, timer, retry_epoch](asio::error_code ec) {
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+            invokeLaneRetryHandlerHook();
+#endif
+            handleRetryTimer(group, timer, retry_epoch, ec);
+        });
+        return true;
+    } catch (...) {
+        group->retry_timer.reset();
+        ++group->retry_epoch;
+        if (group->retry_epoch == 0) ++group->retry_epoch;
+        return false;
+    }
+}
+
+void TcpTransport::handleRetryTimer(
+    const std::shared_ptr<PeerConnectionGroup>& group,
+    const std::shared_ptr<asio::steady_timer>& timer, uint64_t retry_epoch,
+    asio::error_code ec) {
+    uint64_t pump_epoch = 0;
+    [[maybe_unused]] bool fired = false;
+    [[maybe_unused]] bool late = false;
+    {
+        std::lock_guard<std::mutex> lock(group->mutex);
+        if (group->retry_epoch != retry_epoch || group->retry_timer != timer) {
+            late = true;
+        } else {
+            group->retry_timer.reset();
+            if (group->state != GroupState::OPEN) {
+                late = group->state != GroupState::OPEN;
+            } else if (!group->queue.empty() && !ec &&
+                       !hasUsableLaneLocked(*group) &&
+                       group->probes_in_flight == 0 &&
+                       group->connect_attempts_in_round >=
+                           group->lanes.size()) {
+                beginConnectRoundLocked(*group);
+                pump_epoch = requestGroupPumpLocked(*group);
+                fired = true;
+            } else if (!group->queue.empty() && group->probes_in_flight == 0) {
+                pump_epoch = requestGroupPumpLocked(*group);
+            }
+        }
+    }
+
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+    if (late)
+        invokeLaneObserverHook(kLaneRetryLate, 0, 0, 0, false);
+    else if (fired)
+        invokeLaneObserverHook(kLaneRetryFired, 0, 0, 0, false);
+#endif
+    if (pump_epoch != 0) postGroupPump(group, pump_epoch);
+}
+
+uint64_t TcpTransport::requestGroupPumpLocked(PeerConnectionGroup& group) {
+    if (group.state != GroupState::OPEN || group.pump_scheduled ||
+        group.queue.empty()) {
+        return 0;
+    }
+    group.pump_scheduled = true;
+    ++group.pump_epoch;
+    if (group.pump_epoch == 0) ++group.pump_epoch;
+    return group.pump_epoch;
+}
+
+void TcpTransport::enqueuePooledTransfer(const ConnectionKey& key,
+                                         TcpWorkItem work) {
+    const auto state = lane_state_;
+    std::shared_ptr<PeerConnectionGroup> group;
+    std::optional<TcpWorkItem> rejected;
+    std::deque<TcpWorkItem> expired;
+    std::deque<TcpWorkItem> runtime_failed;
+    std::shared_ptr<asio::steady_timer> timer_to_cancel;
+    WorkFailureReason rejection_reason = WorkFailureReason::QUEUE_FULL;
+    uint64_t pump_epoch = 0;
+    [[maybe_unused]] size_t promoted = 0;
+    [[maybe_unused]] size_t pending_depth = 0;
+    [[maybe_unused]] bool direct_admission = false;
+    [[maybe_unused]] bool pending_admission = false;
+    [[maybe_unused]] bool hard_rejection = false;
+    bool timer_armed = false;
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+    size_t queue_depth = 0;
+    uint64_t queued_bytes = 0;
+    size_t active_sockets = 0;
+#endif
+
+    try {
+        std::lock_guard<std::mutex> state_lock(state->mutex);
+        if (state->shutting_down) {
+            rejected.emplace(std::move(work));
+            rejection_reason = WorkFailureReason::SHUTDOWN;
+        } else {
+            auto runtime = state->runtime.lock();
+            if (!runtime) {
+                rejected.emplace(std::move(work));
+                rejection_reason = WorkFailureReason::RUNTIME_UNAVAILABLE;
+            } else {
+                auto group_it = state->groups.find(key);
+                if (group_it == state->groups.end()) {
+                    group = std::make_shared<PeerConnectionGroup>(
+                        key, runtime->executor, state->lanes_per_peer,
+                        state->max_queued_transfers_per_peer,
+                        state->max_pending_admissions_per_peer,
+                        state->admission_timeout, state->failure_counters);
+                    group->lanes.reserve(state->lanes_per_peer);
+                    for (size_t i = 0; i < state->lanes_per_peer; ++i) {
+                        group->lanes.push_back(
+                            std::make_shared<ConnectionLane>(i, group));
+                    }
+                    auto [inserted_it, inserted] =
+                        state->groups.emplace(key, group);
+                    if (!inserted) group = inserted_it->second;
+                } else {
+                    group = group_it->second;
+                }
+
+                std::lock_guard<std::mutex> group_lock(group->mutex);
+                if (group->state != GroupState::OPEN) {
+                    rejected.emplace(std::move(work));
+                    rejection_reason = WorkFailureReason::SHUTDOWN;
+                } else {
+                    // Submissions arriving during cooldown remain subject to
+                    // the bounded queue and wait until the retry timer expires
+                    // and a new round begins, so their added latency is bounded
+                    // by the cooldown length.
+                    const auto admission_time =
+                        std::chrono::steady_clock::now();
+                    work.admission_sequence = group->next_admission_sequence++;
+                    work.enqueued_at = admission_time;
+                    expirePendingAdmissionsLocked(*group, admission_time,
+                                                  expired);
+                    promoted = promotePendingAdmissionsLocked(*group);
+
+                    if (group->pending_admissions.empty() &&
+                        group->queue.size() < group->queue_capacity) {
+                        group->queue.emplace_back(std::move(work));
+                        addQueuedBytesLocked(*group,
+                                             group->queue.back().slice->length);
+                        direct_admission = true;
+                    } else if (group->pending_admissions.size() <
+                               group->pending_admission_capacity) {
+                        work.admission_deadline =
+                            work.enqueued_at + group->admission_timeout;
+                        group->pending_admissions.emplace_back(std::move(work));
+                        pending_admission = true;
+                    } else {
+                        rejected.emplace(std::move(work));
+                        hard_rejection = true;
+                    }
+
+                    refreshAdmissionTimerLocked(group, runtime_failed,
+                                                timer_to_cancel, timer_armed);
+                    pump_epoch = requestGroupPumpLocked(*group);
+                    pending_depth = group->pending_admissions.size();
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+                    queue_depth = group->queue.size();
+                    queued_bytes = group->queued_bytes;
+                    active_sockets = activeSocketCountLocked(*group);
+#endif
+                }
+            }
+        }
+    } catch (const std::exception& e) {
+        LOG(ERROR) << "Failed to admit TCP work for " << key.host << ":"
+                   << key.port << ". Error: " << e.what();
+        if (work.slice) rejected.emplace(std::move(work));
+        rejection_reason = WorkFailureReason::RUNTIME_UNAVAILABLE;
+    } catch (...) {
+        LOG(ERROR) << "Failed to admit TCP work for " << key.host << ":"
+                   << key.port << ". Error: unknown exception";
+        if (work.slice) rejected.emplace(std::move(work));
+        rejection_reason = WorkFailureReason::RUNTIME_UNAVAILABLE;
+    }
+
+    cancelTimerNoThrow(timer_to_cancel);
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+    if (rejected) {
+        invokeLaneObserverHook(kLaneQueueRejected, queue_depth, queued_bytes,
+                               active_sockets, false);
+    } else if (direct_admission) {
+        invokeLaneObserverHook(kLaneQueueAdmitted, queue_depth, queued_bytes,
+                               active_sockets, false);
+    }
+    if (pending_admission)
+        invokeLaneObserverHook(kLaneAdmissionPending, pending_depth, 0, 0,
+                               false);
+    if (promoted != 0)
+        invokeLaneObserverHook(kLaneAdmissionPromoted, pending_depth, promoted,
+                               0, false);
+    if (timer_armed)
+        invokeLaneObserverHook(kLaneAdmissionTimerArmed, pending_depth, 0, 0,
+                               false);
+    if (hard_rejection)
+        invokeLaneObserverHook(kLaneAdmissionHardRejected, pending_depth, 0, 0,
+                               false);
+#endif
+
+    failWorkItems(std::move(expired), WorkFailureReason::QUEUE_TIMEOUT,
+                  state->failure_counters);
+    failWorkItems(std::move(runtime_failed),
+                  WorkFailureReason::RUNTIME_UNAVAILABLE,
+                  state->failure_counters);
+    if (rejected)
+        failWorkItem(std::move(*rejected), rejection_reason,
+                     state->failure_counters);
+    else if (pump_epoch != 0)
+        postGroupPump(group, pump_epoch);
+}
+
+void TcpTransport::postGroupPump(
+    const std::shared_ptr<PeerConnectionGroup>& group, uint64_t pump_epoch) {
+    auto fail_posted_work = [&](const std::string& error) {
+        std::deque<TcpWorkItem> failed;
+        std::shared_ptr<asio::steady_timer> admission_timer;
+        [[maybe_unused]] size_t promoted = 0;
+        {
+            std::lock_guard<std::mutex> lock(group->mutex);
+            if (group->pump_scheduled && group->pump_epoch == pump_epoch) {
+                group->pump_scheduled = false;
+                failed.swap(group->queue);
+                clearQueuedBytesLocked(*group);
+                promoted = promotePendingAdmissionsLocked(*group);
+                while (!group->queue.empty()) {
+                    failed.emplace_back(std::move(group->queue.front()));
+                    group->queue.pop_front();
+                }
+                clearQueuedBytesLocked(*group);
+                while (!group->pending_admissions.empty()) {
+                    failed.emplace_back(
+                        std::move(group->pending_admissions.front()));
+                    group->pending_admissions.pop_front();
+                }
+                ++group->admission_epoch;
+                if (group->admission_epoch == 0) ++group->admission_epoch;
+                group->admission_timer_armed = false;
+                admission_timer = std::move(group->admission_timer);
+            }
+        }
+        cancelTimerNoThrow(admission_timer);
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+        if (promoted != 0)
+            invokeLaneObserverHook(kLaneAdmissionPromoted, 0, promoted, 0,
+                                   false);
+#endif
+        LOG(ERROR) << "Failed to schedule TCP lane pump for " << group->key.host
+                   << ":" << group->key.port << error;
+        failWorkItems(std::move(failed), WorkFailureReason::RUNTIME_UNAVAILABLE,
+                      group->failure_counters);
+    };
+
+    try {
+        asio::post(group->executor,
+                   [group, pump_epoch] { runGroupPump(group, pump_epoch); });
+    } catch (const std::exception& e) {
+        fail_posted_work(". Error: " + std::string(e.what()));
+    } catch (...) {
+        fail_posted_work("");
+    }
+}
+
+void TcpTransport::runGroupPump(
+    const std::shared_ptr<PeerConnectionGroup>& group, uint64_t pump_epoch) {
+    struct LaneStart {
+        std::shared_ptr<ConnectionLane> lane;
+        uint64_t epoch;
+    };
+    std::array<LaneStart, kMaxTcpLanesPerPeer> sessions;
+    std::array<LaneStart, kMaxTcpLanesPerPeer> connects;
+    size_t session_count = 0;
+    size_t connect_count = 0;
+    std::deque<TcpWorkItem> failed;
+    std::deque<TcpWorkItem> expired;
+    std::deque<TcpWorkItem> runtime_failed;
+    std::shared_ptr<asio::steady_timer> admission_timer_to_cancel;
+    WorkFailureReason failure_reason = WorkFailureReason::CONNECT_FAILED;
+    uint64_t followup_pump_epoch = 0;
+    [[maybe_unused]] size_t promoted = 0;
+    [[maybe_unused]] size_t pending_depth = 0;
+    bool queue_detached_after_scheduling = false;
+    [[maybe_unused]] bool retry_armed = false;
+    [[maybe_unused]] bool cooldown_started = false;
+    [[maybe_unused]] bool admission_timer_armed = false;
+
+    {
+        std::lock_guard<std::mutex> lock(group->mutex);
+        if (!group->pump_scheduled || group->pump_epoch != pump_epoch) return;
+        group->pump_scheduled = false;
+        if (group->state != GroupState::OPEN) return;
+
+        expirePendingAdmissionsLocked(*group, std::chrono::steady_clock::now(),
+                                      expired);
+        promoted += promotePendingAdmissionsLocked(*group);
+
+        for (const auto& lane : group->lanes) {
+            if (group->queue.empty()) break;
+            if (lane->state != LaneState::IDLE) continue;
+            if (!lane->socket || !lane->socket->is_open()) {
+                lane->socket.reset();
+                lane->state = LaneState::DISCONNECTED;
+                continue;
+            }
+
+            lane->current.emplace(std::move(group->queue.front()));
+            const uint64_t length = lane->current->slice->length;
+            group->queue.pop_front();
+            removeQueuedBytesLocked(*group, length);
+            if (group->queue.empty()) clearQueuedBytesLocked(*group);
+            promoted += promotePendingAdmissionsLocked(*group);
+            lane->state = LaneState::BUSY;
+            ++lane->operation_epoch;
+            if (lane->operation_epoch == 0) ++lane->operation_epoch;
+            sessions[session_count++] = {lane, lane->operation_epoch};
+        }
+
+        // Once armed, the retry timer exclusively owns the transition out of
+        // cooldown. A delayed pump must not reset round accounting or start a
+        // probe before the matching timer handler validates the group.
+        bool waiting_for_cooldown = group->retry_timer != nullptr;
+        if (!waiting_for_cooldown && !group->queue.empty() &&
+            !hasUsableLaneLocked(*group) && group->probes_in_flight == 0 &&
+            group->connect_attempts_in_round >= group->lanes.size()) {
+            if (std::chrono::steady_clock::now() <
+                group->next_probe_not_before) {
+                if (armRetryTimerLocked(group)) {
+                    waiting_for_cooldown = true;
+                    retry_armed = group->retry_timer != nullptr;
+                } else {
+                    failed.swap(group->queue);
+                    clearQueuedBytesLocked(*group);
+                    failure_reason = WorkFailureReason::RUNTIME_UNAVAILABLE;
+                    queue_detached_after_scheduling = true;
+                }
+            } else {
+                beginConnectRoundLocked(*group);
+            }
+        }
+
+        // A lane-local failure may defer only connection probes while healthy
+        // siblings continue pulling work above. Reuse the per-group timer so
+        // repeated failures cannot create a tight reconnect loop.
+        if (!waiting_for_cooldown && failed.empty() && !group->queue.empty() &&
+            group->probes_in_flight == 0 &&
+            std::chrono::steady_clock::now() < group->next_probe_not_before &&
+            armRetryTimerLocked(group)) {
+            waiting_for_cooldown = group->retry_timer != nullptr;
+            retry_armed = waiting_for_cooldown;
+        }
+
+        if (!waiting_for_cooldown && failed.empty()) {
+            const size_t probe_limit =
+                std::min(group->lane_count, kMaxConcurrentLaneProbes);
+            while (!group->queue.empty() &&
+                   group->probes_in_flight < probe_limit) {
+                auto lane_it = std::find_if(
+                    group->lanes.begin(), group->lanes.end(),
+                    [&group](const auto& lane) {
+                        return lane->state == LaneState::DISCONNECTED &&
+                               lane->last_connect_round != group->connect_round;
+                    });
+                if (lane_it == group->lanes.end()) break;
+
+                auto lane = *lane_it;
+                lane->state = LaneState::CONNECTING;
+                lane->connect_stage = LaneConnectStage::NONE;
+                lane->last_connect_round = group->connect_round;
+                ++lane->operation_epoch;
+                if (lane->operation_epoch == 0) ++lane->operation_epoch;
+                ++group->probes_in_flight;
+                ++group->connect_attempts_in_round;
+                connects[connect_count++] = {lane, lane->operation_epoch};
+            }
+
+            if (!group->queue.empty() && !hasUsableLaneLocked(*group) &&
+                group->probes_in_flight == 0 &&
+                group->connect_attempts_in_round >= group->lanes.size()) {
+                failed.swap(group->queue);
+                clearQueuedBytesLocked(*group);
+                enterReconnectCooldownLocked(*group);
+                cooldown_started = true;
+                queue_detached_after_scheduling = true;
+            }
+        }
+
+        promoted += promotePendingAdmissionsLocked(*group);
+        refreshAdmissionTimerLocked(group, runtime_failed,
+                                    admission_timer_to_cancel,
+                                    admission_timer_armed);
+        pending_depth = group->pending_admissions.size();
+        if (queue_detached_after_scheduling && !group->queue.empty())
+            followup_pump_epoch = requestGroupPumpLocked(*group);
+    }
+
+    cancelTimerNoThrow(admission_timer_to_cancel);
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+    if (retry_armed) invokeLaneObserverHook(kLaneRetryArmed, 0, 0, 0, false);
+    if (cooldown_started)
+        invokeLaneObserverHook(kLaneCooldownStarted, 0, 0, 0, false);
+    if (promoted != 0)
+        invokeLaneObserverHook(kLaneAdmissionPromoted, pending_depth, promoted,
+                               0, false);
+    if (admission_timer_armed)
+        invokeLaneObserverHook(kLaneAdmissionTimerArmed, pending_depth, 0, 0,
+                               false);
+#endif
+    for (size_t i = 0; i < connect_count; ++i)
+        startLaneConnect(group, connects[i].lane, connects[i].epoch);
+    for (size_t i = 0; i < session_count; ++i)
+        startLaneSession(group, sessions[i].lane, sessions[i].epoch);
+    failWorkItems(std::move(failed), failure_reason, group->failure_counters);
+    failWorkItems(std::move(expired), WorkFailureReason::QUEUE_TIMEOUT,
+                  group->failure_counters);
+    failWorkItems(std::move(runtime_failed),
+                  WorkFailureReason::RUNTIME_UNAVAILABLE,
+                  group->failure_counters);
+    if (followup_pump_epoch != 0) postGroupPump(group, followup_pump_epoch);
+}
+
+void TcpTransport::startLaneConnect(
+    const std::shared_ptr<PeerConnectionGroup>& group,
+    const std::shared_ptr<ConnectionLane>& lane, uint64_t epoch) {
+    std::string initiation_error;
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+    size_t queue_depth = 0;
+    uint64_t queued_bytes = 0;
+    size_t active_sockets = 0;
+#endif
+    {
+        std::lock_guard<std::mutex> lock(group->mutex);
+        if (group->state != GroupState::OPEN ||
+            lane->state != LaneState::CONNECTING ||
+            lane->operation_epoch != epoch) {
+            return;
+        }
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+        if (invokeLaneConnectFailureInjectionHook()) {
+            initiation_error = "injected lane connect failure";
+        } else
+#endif
+            try {
+                lane->resolver =
+                    std::make_shared<asio::ip::tcp::resolver>(group->executor);
+                lane->socket =
+                    std::make_shared<asio::ip::tcp::socket>(group->executor);
+                lane->connect_stage = LaneConnectStage::RESOLVING;
+                lane->resolver->async_resolve(
+                    group->key.host, std::to_string(group->key.port),
+                    [group, lane, epoch](
+                        asio::error_code ec,
+                        asio::ip::tcp::resolver::results_type results) {
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+                        invokeLaneConnectHandlerHook();
+#endif
+                        handleLaneResolved(group, lane, epoch, ec,
+                                           std::move(results));
+                    });
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+                queue_depth = group->queue.size();
+                queued_bytes = group->queued_bytes;
+                active_sockets = activeSocketCountLocked(*group);
+#endif
+            } catch (const std::exception& e) {
+                initiation_error = e.what();
+            } catch (...) {
+                initiation_error = "unknown exception";
+            }
+    }
+
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+    if (initiation_error.empty()) {
+        invokeLaneObserverHook(kLaneConnecting, queue_depth, queued_bytes,
+                               active_sockets, false);
+    }
+#endif
+    if (!initiation_error.empty())
+        handleLaneConnectFailure(group, lane, epoch, initiation_error);
+}
+
+void TcpTransport::handleLaneResolved(
+    const std::shared_ptr<PeerConnectionGroup>& group,
+    const std::shared_ptr<ConnectionLane>& lane, uint64_t epoch,
+    asio::error_code ec, asio::ip::tcp::resolver::results_type results) {
+    if (ec) {
+        handleLaneConnectFailure(group, lane, epoch, ec.message());
+        return;
+    }
+
+    std::string initiation_error;
+    [[maybe_unused]] bool stale = false;
+    {
+        std::lock_guard<std::mutex> lock(group->mutex);
+        if (group->state != GroupState::OPEN ||
+            lane->state != LaneState::CONNECTING ||
+            lane->connect_stage != LaneConnectStage::RESOLVING ||
+            lane->operation_epoch != epoch || !lane->socket) {
+            stale = true;
+        } else {
+            lane->connect_stage = LaneConnectStage::CONNECTING;
+            try {
+                asio::async_connect(
+                    *lane->socket, results,
+                    [group, lane, epoch](asio::error_code connect_ec,
+                                         const asio::ip::tcp::endpoint&) {
+                        handleLaneConnected(group, lane, epoch, connect_ec);
+                    });
+            } catch (const std::exception& e) {
+                initiation_error = e.what();
+            } catch (...) {
+                initiation_error = "unknown exception";
+            }
+        }
+    }
+
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+    if (stale) invokeLaneObserverHook(kLaneLateHandler, 0, 0, 0, false);
+#endif
+    if (!initiation_error.empty())
+        handleLaneConnectFailure(group, lane, epoch, initiation_error);
+}
+
+void TcpTransport::handleLaneConnected(
+    const std::shared_ptr<PeerConnectionGroup>& group,
+    const std::shared_ptr<ConnectionLane>& lane, uint64_t epoch,
+    asio::error_code ec) {
+    if (ec) {
+        handleLaneConnectFailure(group, lane, epoch, ec.message());
+        return;
+    }
+
+    uint64_t pump_epoch = 0;
+    [[maybe_unused]] bool stale = false;
+    std::string option_error;
+    {
+        std::lock_guard<std::mutex> lock(group->mutex);
+        if (group->state != GroupState::OPEN ||
+            lane->state != LaneState::CONNECTING ||
+            lane->connect_stage != LaneConnectStage::CONNECTING ||
+            lane->operation_epoch != epoch || !lane->socket) {
+            stale = true;
+        } else {
+            asio::error_code option_ec;
+            lane->socket->set_option(asio::ip::tcp::no_delay(true), option_ec);
+            if (option_ec) {
+                option_error = option_ec.message();
+            } else {
+                if (group->probes_in_flight != 0) --group->probes_in_flight;
+                group->connect_round_had_success = true;
+                lane->resolver.reset();
+                lane->connect_stage = LaneConnectStage::NONE;
+                lane->state = LaneState::IDLE;
+                pump_epoch = requestGroupPumpLocked(*group);
+            }
+        }
+    }
+
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+    if (stale) invokeLaneObserverHook(kLaneLateHandler, 0, 0, 0, false);
+#endif
+    if (!option_error.empty()) {
+        handleLaneConnectFailure(group, lane, epoch, option_error);
+    } else if (pump_epoch != 0) {
+        postGroupPump(group, pump_epoch);
+    }
+}
+
+void TcpTransport::handleLaneConnectFailure(
+    const std::shared_ptr<PeerConnectionGroup>& group,
+    const std::shared_ptr<ConnectionLane>& lane, uint64_t epoch,
+    const std::string& error) {
+    std::shared_ptr<asio::ip::tcp::resolver> resolver;
+    std::shared_ptr<asio::ip::tcp::socket> socket;
+    std::deque<TcpWorkItem> failed;
+    std::deque<TcpWorkItem> expired;
+    std::deque<TcpWorkItem> runtime_failed;
+    std::shared_ptr<asio::steady_timer> admission_timer_to_cancel;
+    uint64_t pump_epoch = 0;
+    [[maybe_unused]] size_t promoted = 0;
+    [[maybe_unused]] size_t pending_depth = 0;
+    bool stale = false;
+    [[maybe_unused]] bool cooldown_started = false;
+    [[maybe_unused]] bool admission_timer_armed = false;
+    uint64_t connect_failure_log_count = 0;
+    {
+        std::lock_guard<std::mutex> lock(group->mutex);
+        if (lane->state != LaneState::CONNECTING ||
+            lane->operation_epoch != epoch) {
+            stale = true;
+        } else {
+            connect_failure_log_count = ++group->connect_failure_log_count;
+            if (group->probes_in_flight != 0) --group->probes_in_flight;
+            resolver = std::move(lane->resolver);
+            socket = std::move(lane->socket);
+            lane->connect_stage = LaneConnectStage::NONE;
+            lane->state = group->state == GroupState::OPEN
+                              ? LaneState::DISCONNECTED
+                              : LaneState::CLOSING;
+
+            const bool sibling_usable =
+                group->state == GroupState::OPEN && hasUsableLaneLocked(*group);
+            if (sibling_usable) {
+                // A lane-local connect failure must not consume this lane's
+                // eligibility for the rest of a round while another lane
+                // continues serving the peer. Delay the new probe to avoid a
+                // tight loop when the peer temporarily refuses extra lanes.
+                lane->last_connect_round = 0;
+                enterReconnectCooldownLocked(*group);
+            }
+
+            if (group->state == GroupState::OPEN && !group->queue.empty() &&
+                !sibling_usable && group->probes_in_flight == 0 &&
+                group->connect_attempts_in_round >= group->lanes.size()) {
+                failed.swap(group->queue);
+                clearQueuedBytesLocked(*group);
+                enterReconnectCooldownLocked(*group);
+                cooldown_started = true;
+                expirePendingAdmissionsLocked(
+                    *group, std::chrono::steady_clock::now(), expired);
+                promoted = promotePendingAdmissionsLocked(*group);
+                refreshAdmissionTimerLocked(group, runtime_failed,
+                                            admission_timer_to_cancel,
+                                            admission_timer_armed);
+                pending_depth = group->pending_admissions.size();
+                pump_epoch = requestGroupPumpLocked(*group);
+            } else {
+                pump_epoch = requestGroupPumpLocked(*group);
+            }
+        }
+    }
+
+    if (resolver) {
+        try {
+            resolver->cancel();
+        } catch (...) {
+        }
+    }
+    closeSocketNoThrow(socket);
+    cancelTimerNoThrow(admission_timer_to_cancel);
+    if (!stale && shouldLogOccurrence(connect_failure_log_count)) {
+        LOG(ERROR) << "TCP lane connection to " << group->key.host << ":"
+                   << group->key.port << " failed: " << error
+                   << " (attempt failure " << connect_failure_log_count << ")";
+    }
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+    if (stale) invokeLaneObserverHook(kLaneLateHandler, 0, 0, 0, false);
+    if (cooldown_started)
+        invokeLaneObserverHook(kLaneCooldownStarted, 0, 0, 0, false);
+    if (promoted != 0)
+        invokeLaneObserverHook(kLaneAdmissionPromoted, pending_depth, promoted,
+                               0, false);
+    if (admission_timer_armed)
+        invokeLaneObserverHook(kLaneAdmissionTimerArmed, pending_depth, 0, 0,
+                               false);
+#endif
+    failWorkItems(std::move(failed), WorkFailureReason::CONNECT_FAILED,
+                  group->failure_counters);
+    failWorkItems(std::move(expired), WorkFailureReason::QUEUE_TIMEOUT,
+                  group->failure_counters);
+    failWorkItems(std::move(runtime_failed),
+                  WorkFailureReason::RUNTIME_UNAVAILABLE,
+                  group->failure_counters);
+    if (pump_epoch != 0) postGroupPump(group, pump_epoch);
+}
+
+void TcpTransport::startLaneSession(
+    const std::shared_ptr<PeerConnectionGroup>& group,
+    const std::shared_ptr<ConnectionLane>& lane, uint64_t epoch) {
+    std::string initiation_error;
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+    size_t queue_depth = 0;
+    uint64_t queued_bytes = 0;
+    size_t active_sockets = 0;
+#endif
+    {
+        std::lock_guard<std::mutex> lock(group->mutex);
+        if (group->state != GroupState::OPEN ||
+            lane->state != LaneState::BUSY || lane->operation_epoch != epoch ||
+            !lane->current) {
+            return;
+        }
+        if (!lane->socket || !lane->socket->is_open()) {
+            initiation_error = "lane socket is not open";
+        } else {
+            // This function runs on the TCP executor. Keep construction and
+            // initial Asio initiation under the group lock so shutdown cannot
+            // invalidate the checked epoch between validation and initiation.
+            // Asio initiating functions do not invoke their completion handler
+            // inline, so this cannot call lane terminal completion under the
+            // mutex.
+            try {
+                std::weak_ptr<PeerConnectionGroup> weak_group(group);
+                std::weak_ptr<ConnectionLane> weak_lane(lane);
+                auto session = std::make_shared<ClientSession>(
+                    lane->socket, lane->current->use_v2,
+                    [weak_group, weak_lane, epoch](TransferStatusEnum status,
+                                                   bool clean) noexcept {
+                        auto callback_group = weak_group.lock();
+                        auto callback_lane = weak_lane.lock();
+                        if (!callback_group || !callback_lane) return;
+                        handleLaneTerminal(callback_group, callback_lane, epoch,
+                                           status, clean);
+                    });
+                lane->session = session;
+                session->initiate(lane->current->slice->source_addr,
+                                  lane->current->slice->tcp.dest_addr,
+                                  lane->current->slice->length,
+                                  lane->current->slice->opcode);
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+                queue_depth = group->queue.size();
+                queued_bytes = group->queued_bytes;
+                active_sockets = activeSocketCountLocked(*group);
+#endif
+            } catch (const std::exception& e) {
+                lane->session.reset();
+                initiation_error = e.what();
+            } catch (...) {
+                lane->session.reset();
+                initiation_error = "unknown exception";
+            }
+        }
+    }
+
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+    if (initiation_error.empty()) {
+        invokeLaneObserverHook(kLaneBusy, queue_depth, queued_bytes,
+                               active_sockets, true);
+    }
+#endif
+    if (!initiation_error.empty()) {
+        LOG(ERROR) << "Failed to start TCP lane session for " << group->key.host
+                   << ":" << group->key.port << ". Error: " << initiation_error;
+        handleLaneTerminal(group, lane, epoch, TransferStatusEnum::FAILED,
+                           false);
+    }
+}
+
+void TcpTransport::handleLaneTerminal(
+    const std::shared_ptr<PeerConnectionGroup>& group,
+    const std::shared_ptr<ConnectionLane>& lane, uint64_t epoch,
+    TransferStatusEnum status, bool connection_clean) noexcept {
+    std::optional<TerminalAction> action;
+    std::shared_ptr<asio::ip::tcp::socket> socket_to_close;
+    bool stale = false;
+    {
+        std::lock_guard<std::mutex> lock(group->mutex);
+        if (lane->operation_epoch != epoch || lane->state != LaneState::BUSY ||
+            !lane->current) {
+            stale = true;
+        } else {
+            action.emplace(std::move(*lane->current), status, connection_clean);
+            lane->current.reset();
+            lane->session.reset();
+            lane->state = LaneState::COMPLETING;
+            if (!connection_clean || group->state != GroupState::OPEN)
+                socket_to_close = std::move(lane->socket);
+        }
+    }
+
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+    if (stale) {
+        invokeLaneObserverHook(kLaneLateHandler, 0, 0, 0, false);
+    }
+#endif
+    if (stale) return;
+
+    if (status != TransferStatusEnum::COMPLETED) {
+        recordWorkFailure(WorkFailureReason::SESSION_FAILED,
+                          group->failure_counters);
+    }
+
+    // A dirty protocol stream must be closed before terminal Slice status is
+    // visible to the caller.
+    closeSocketNoThrow(socket_to_close);
+    completeTerminalAction(std::move(*action));
+
+    uint64_t pump_epoch = 0;
+    std::shared_ptr<asio::ip::tcp::socket> shutdown_socket;
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+    size_t queue_depth = 0;
+    uint64_t queued_bytes = 0;
+    size_t active_sockets = 0;
+#endif
+    {
+        std::lock_guard<std::mutex> lock(group->mutex);
+        if (group->state != GroupState::OPEN ||
+            lane->operation_epoch != epoch) {
+            lane->state = LaneState::CLOSING;
+            shutdown_socket = std::move(lane->socket);
+        } else if (connection_clean && lane->socket &&
+                   lane->socket->is_open()) {
+            lane->state = LaneState::IDLE;
+        } else {
+            lane->socket.reset();
+            lane->state = LaneState::DISCONNECTED;
+            // A dirty session is a lane-local failure. Let this lane refill
+            // capacity in the current round even while a sibling remains
+            // usable, but rate-limit the replacement probe.
+            lane->last_connect_round = 0;
+            const bool sibling_usable = hasUsableLaneLocked(*group);
+            if (sibling_usable) {
+                enterReconnectCooldownLocked(*group);
+            } else if (!group->queue.empty() && group->probes_in_flight == 0 &&
+                       group->connect_round_had_success) {
+                beginConnectRoundLocked(*group);
+            }
+        }
+        pump_epoch = requestGroupPumpLocked(*group);
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+        queue_depth = group->queue.size();
+        queued_bytes = group->queued_bytes;
+        active_sockets = activeSocketCountLocked(*group);
+#endif
+    }
+    closeSocketNoThrow(shutdown_socket);
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+    invokeLaneObserverHook(kLaneTerminal, queue_depth, queued_bytes,
+                           active_sockets, false);
+#endif
+    if (pump_epoch != 0) postGroupPump(group, pump_epoch);
+}
+
+void TcpTransport::completeTerminalAction(TerminalAction action) noexcept {
+    auto continuation = std::move(action.work.continuation);
+    try {
+        if (action.status == TransferStatusEnum::COMPLETED)
+            action.work.slice->markSuccess();
+        else
+            action.work.slice->markFailed();
+    } catch (const std::exception& e) {
+        LOG(ERROR) << "TCP Slice terminal completion threw: " << e.what();
+    } catch (...) {
+        LOG(ERROR) << "TCP Slice terminal completion threw";
+    }
+
+    if (continuation) {
+        try {
+            continuation();
+        } catch (const std::exception& e) {
+            LOG(ERROR) << "TCP Slice continuation threw: " << e.what();
+        } catch (...) {
+            LOG(ERROR) << "TCP Slice continuation threw";
+        }
+    }
+}
+
+uint64_t TcpTransport::recordWorkFailure(
+    WorkFailureReason reason,
+    const std::shared_ptr<FailureCounters>& counters) noexcept {
+    if (!counters) return 0;
+
+    std::atomic<uint64_t>* counter = nullptr;
+    switch (reason) {
+        case WorkFailureReason::QUEUE_FULL:
+            counter = &counters->queue_full;
+            break;
+        case WorkFailureReason::QUEUE_TIMEOUT:
+            counter = &counters->queue_timeout;
+            break;
+        case WorkFailureReason::RUNTIME_UNAVAILABLE:
+            counter = &counters->runtime_unavailable;
+            break;
+        case WorkFailureReason::CONNECT_FAILED:
+            counter = &counters->connect_failed;
+            break;
+        case WorkFailureReason::SESSION_FAILED:
+            counter = &counters->session_failed;
+            break;
+        case WorkFailureReason::SHUTDOWN:
+            counter = &counters->shutdown;
+            break;
+    }
+    if (!counter) return 0;
+
+    const uint64_t occurrence =
+        counter->fetch_add(1, std::memory_order_relaxed) + 1;
+    if (reason == WorkFailureReason::QUEUE_FULL &&
+        shouldLogOccurrence(occurrence)) {
+        LOG(WARNING) << "TCP lane queue-full rejection count: " << occurrence;
+    }
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+    invokeLaneFailureReasonHook(static_cast<int>(reason));
+#endif
+    return occurrence;
+}
+
+void TcpTransport::failWorkItem(
+    TcpWorkItem work, WorkFailureReason reason,
+    const std::shared_ptr<FailureCounters>& counters) noexcept {
+    recordWorkFailure(reason, counters);
+    completeTerminalAction(
+        TerminalAction(std::move(work), TransferStatusEnum::FAILED, false));
+}
+
+void TcpTransport::failWorkItems(
+    std::deque<TcpWorkItem> work, WorkFailureReason reason,
+    const std::shared_ptr<FailureCounters>& counters) noexcept {
+    while (!work.empty()) {
+        auto item = std::move(work.front());
+        work.pop_front();
+        failWorkItem(std::move(item), reason, counters);
+    }
+}
+
+void TcpTransport::closeSocketNoThrow(
+    const std::shared_ptr<asio::ip::tcp::socket>& socket) noexcept {
+    if (!socket) return;
+    asio::error_code error;
+    socket->cancel(error);
+    socket->close(error);
+}
+
+void TcpTransport::shutdownConnectionLanes() {
+    const auto state = lane_state_;
+    std::vector<std::shared_ptr<PeerConnectionGroup>> groups;
+    {
+        std::lock_guard<std::mutex> state_lock(state->mutex);
+        if (state->shutting_down) return;
+        state->shutting_down = true;
+        groups.reserve(state->groups.size());
+        for (const auto& entry : state->groups) groups.push_back(entry.second);
+    }
+
+    for (const auto& group : groups) {
+        std::deque<TcpWorkItem> accepted;
+        {
+            std::lock_guard<std::mutex> lock(group->mutex);
+            group->state = GroupState::CLOSING;
+            group->pump_scheduled = false;
+            ++group->pump_epoch;
+            accepted.swap(group->queue);
+            while (!group->pending_admissions.empty()) {
+                accepted.emplace_back(
+                    std::move(group->pending_admissions.front()));
+                group->pending_admissions.pop_front();
+            }
+            clearQueuedBytesLocked(*group);
+            ++group->retry_epoch;
+            if (group->retry_epoch == 0) ++group->retry_epoch;
+            ++group->admission_epoch;
+            if (group->admission_epoch == 0) ++group->admission_epoch;
+            group->admission_timer_armed = false;
+            for (const auto& lane : group->lanes) {
+                ++lane->operation_epoch;
+                if (lane->operation_epoch == 0) ++lane->operation_epoch;
+                if (lane->state != LaneState::CLOSED)
+                    lane->state = LaneState::CLOSING;
+            }
+        }
+        failWorkItems(std::move(accepted), WorkFailureReason::SHUTDOWN,
+                      state->failure_counters);
+    }
+
+    auto cancellation_posts = std::make_shared<LaneCancellationPostTracker>();
+    if (context_ && running_) {
+        for (const auto& group : groups) {
+            cancellation_posts->add();
+            try {
+                asio::post(group->executor, [group, cancellation_posts] {
+                    std::vector<std::shared_ptr<ClientSession>> sessions;
+                    std::vector<std::shared_ptr<asio::ip::tcp::resolver>>
+                        resolvers;
+                    std::vector<std::shared_ptr<asio::ip::tcp::socket>> sockets;
+                    std::shared_ptr<asio::steady_timer> retry_timer;
+                    std::shared_ptr<asio::steady_timer> admission_timer;
+                    {
+                        std::lock_guard<std::mutex> lock(group->mutex);
+                        retry_timer = group->retry_timer;
+                        admission_timer = group->admission_timer;
+                        for (const auto& lane : group->lanes) {
+                            if (lane->session)
+                                sessions.push_back(lane->session);
+                            if (lane->resolver)
+                                resolvers.push_back(lane->resolver);
+                            if (lane->socket) sockets.push_back(lane->socket);
+                        }
+                    }
+                    for (const auto& session : sessions)
+                        if (session) session->cancel();
+                    for (const auto& resolver : resolvers) {
+                        if (!resolver) continue;
+                        try {
+                            resolver->cancel();
+                        } catch (...) {
+                        }
+                    }
+                    for (const auto& socket : sockets)
+                        closeSocketNoThrow(socket);
+                    if (retry_timer) {
+                        asio::error_code timer_ec;
+                        retry_timer->cancel(timer_ec);
+                    }
+                    cancelTimerNoThrow(admission_timer);
+                    cancellation_posts->done();
+                });
+            } catch (...) {
+                cancellation_posts->done();
+            }
+        }
+        cancellation_posts->waitUntil(std::chrono::steady_clock::now() +
+                                      kShutdownCancellationWait);
+    }
+
+    running_ = false;
+    if (context_) context_->io_context.stop();
+    if (thread_.joinable()) thread_.join();
+
+    std::deque<TcpWorkItem> deferred;
+    std::vector<std::shared_ptr<ClientSession>> sessions;
+    std::vector<std::shared_ptr<asio::ip::tcp::resolver>> resolvers;
+    std::vector<std::shared_ptr<asio::ip::tcp::socket>> sockets;
+    std::vector<std::shared_ptr<asio::steady_timer>> retry_timers;
+    std::vector<std::shared_ptr<asio::steady_timer>> admission_timers;
+
+    for (const auto& group : groups) {
+        {
+            std::lock_guard<std::mutex> lock(group->mutex);
+            if (group->retry_timer)
+                retry_timers.push_back(std::move(group->retry_timer));
+            if (group->admission_timer)
+                admission_timers.push_back(std::move(group->admission_timer));
+            for (const auto& lane : group->lanes) {
+                if (lane->current) {
+                    deferred.emplace_back(std::move(*lane->current));
+                    lane->current.reset();
+                }
+                if (lane->session) sessions.push_back(std::move(lane->session));
+                if (lane->resolver)
+                    resolvers.push_back(std::move(lane->resolver));
+                if (lane->socket) sockets.push_back(std::move(lane->socket));
+                lane->connect_stage = LaneConnectStage::NONE;
+                lane->state = LaneState::CLOSED;
+            }
+            group->probes_in_flight = 0;
+            group->state = GroupState::CLOSED;
+        }
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+        invokeLaneObserverHook(kLaneShutdownClean, 0, 0, 0, false);
+#endif
+    }
+
+    // No handler is running after join. Reset every Asio-owning field while
+    // TcpContext and its execution_context are still alive, then publish
+    // terminal failure for work that had been BUSY.
+    for (const auto& session : sessions)
+        if (session) session->cancel();
+    for (const auto& resolver : resolvers) {
+        if (!resolver) continue;
+        try {
+            resolver->cancel();
+        } catch (...) {
+        }
+    }
+    for (const auto& socket : sockets) closeSocketNoThrow(socket);
+    for (const auto& timer : retry_timers) {
+        cancelTimerNoThrow(timer);
+    }
+    for (const auto& timer : admission_timers) cancelTimerNoThrow(timer);
+    sessions.clear();
+    resolvers.clear();
+    sockets.clear();
+    retry_timers.clear();
+    admission_timers.clear();
+
+    failWorkItems(std::move(deferred), WorkFailureReason::SHUTDOWN,
+                  state->failure_counters);
+
+    const auto& counters = state->failure_counters;
+    VLOG(1) << "TCP lane failure totals: queue_full="
+            << counters->queue_full.load(std::memory_order_relaxed)
+            << ", queue_timeout="
+            << counters->queue_timeout.load(std::memory_order_relaxed)
+            << ", connect_failed="
+            << counters->connect_failed.load(std::memory_order_relaxed)
+            << ", runtime_unavailable="
+            << counters->runtime_unavailable.load(std::memory_order_relaxed)
+            << ", session_failed="
+            << counters->session_failed.load(std::memory_order_relaxed)
+            << ", shutdown="
+            << counters->shutdown.load(std::memory_order_relaxed);
+
+    {
+        std::lock_guard<std::mutex> state_lock(state->mutex);
+        state->groups.clear();
+        state->runtime.reset();
+    }
+    groups.clear();
+    lane_runtime_.reset();
+}
+
+bool TcpTransport::validateAddress(uint64_t addr, uint64_t size) const {
+    return validateTcpAddress(metadata_, addr, size);
+}

--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport_lane_impl.h
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport_lane_impl.h
@@ -73,6 +73,22 @@ bool TcpTransport::hasUsableLaneLocked(const PeerConnectionGroup& group) {
     return false;
 }
 
+bool TcpTransport::hasDisconnectedLaneLocked(const PeerConnectionGroup& group) {
+    return std::any_of(group.lanes.begin(), group.lanes.end(),
+                       [](const auto& lane) {
+                           return lane->state == LaneState::DISCONNECTED;
+                       });
+}
+
+bool TcpTransport::hasUntriedDisconnectedLaneLocked(
+    const PeerConnectionGroup& group) {
+    return std::any_of(
+        group.lanes.begin(), group.lanes.end(), [&group](const auto& lane) {
+            return lane->state == LaneState::DISCONNECTED &&
+                   lane->last_connect_round != group.connect_round;
+        });
+}
+
 #ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
 size_t TcpTransport::activeSocketCountLocked(const PeerConnectionGroup& group) {
     size_t count = 0;
@@ -86,7 +102,6 @@ size_t TcpTransport::activeSocketCountLocked(const PeerConnectionGroup& group) {
 void TcpTransport::beginConnectRoundLocked(PeerConnectionGroup& group) {
     ++group.connect_round;
     if (group.connect_round == 0) group.connect_round = 1;
-    group.connect_attempts_in_round = 0;
     group.connect_round_had_success = false;
     group.next_probe_not_before = {};
 }
@@ -163,22 +178,15 @@ void TcpTransport::refreshAdmissionTimerLocked(
     std::shared_ptr<asio::steady_timer>& timer_to_cancel, bool& timer_armed) {
     timer_armed = false;
     if (group->pending_admissions.empty()) {
-        if (group->admission_timer_armed || group->admission_timer) {
+        if (group->admission_timer) {
             ++group->admission_epoch;
             if (group->admission_epoch == 0) ++group->admission_epoch;
-            group->admission_timer_armed = false;
             timer_to_cancel = std::move(group->admission_timer);
         }
         return;
     }
 
-    if (group->admission_timer_armed && group->admission_timer) return;
-
-    if (group->admission_timer) {
-        timer_to_cancel = std::move(group->admission_timer);
-        ++group->admission_epoch;
-        if (group->admission_epoch == 0) ++group->admission_epoch;
-    }
+    if (group->admission_timer) return;
 
     try {
         auto timer = std::make_shared<asio::steady_timer>(group->executor);
@@ -187,7 +195,6 @@ void TcpTransport::refreshAdmissionTimerLocked(
         if (group->admission_epoch == 0) ++group->admission_epoch;
         const uint64_t admission_epoch = group->admission_epoch;
         group->admission_timer = timer;
-        group->admission_timer_armed = true;
         timer->async_wait([group, timer, admission_epoch](asio::error_code ec) {
 #ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
             invokeLaneAdmissionHandlerHook();
@@ -199,7 +206,6 @@ void TcpTransport::refreshAdmissionTimerLocked(
     } catch (...) {
         ++group->admission_epoch;
         if (group->admission_epoch == 0) ++group->admission_epoch;
-        group->admission_timer_armed = false;
         if (group->admission_timer)
             timer_to_cancel = std::move(group->admission_timer);
         while (!group->pending_admissions.empty()) {
@@ -228,13 +234,15 @@ void TcpTransport::handleAdmissionTimer(
         std::lock_guard<std::mutex> lock(group->mutex);
         if (group->state != GroupState::OPEN ||
             group->admission_epoch != admission_epoch ||
-            !group->admission_timer_armed || group->admission_timer != timer) {
+            group->admission_timer != timer) {
             late = true;
         } else {
             group->admission_timer.reset();
-            group->admission_timer_armed = false;
             fired = true;
             if (ec) {
+                // Cancellation normally increments admission_epoch first and
+                // is therefore stale. Keep this guard for other Asio timer
+                // errors delivered while the matching timer is still active.
                 while (!group->pending_admissions.empty()) {
                     runtime_failed.emplace_back(
                         std::move(group->pending_admissions.front()));
@@ -320,12 +328,14 @@ void TcpTransport::handleRetryTimer(
         } else {
             group->retry_timer.reset();
             if (group->state != GroupState::OPEN) {
+                // Shutdown also bumps retry_epoch, so this is normally caught
+                // by the identity check above. Retain the state guard for a
+                // handler that observes the transition at this boundary.
                 late = group->state != GroupState::OPEN;
             } else if (!group->queue.empty() && !ec &&
-                       !hasUsableLaneLocked(*group) &&
                        group->probes_in_flight == 0 &&
-                       group->connect_attempts_in_round >=
-                           group->lanes.size()) {
+                       hasDisconnectedLaneLocked(*group) &&
+                       !hasUntriedDisconnectedLaneLocked(*group)) {
                 beginConnectRoundLocked(*group);
                 pump_epoch = requestGroupPumpLocked(*group);
                 fired = true;
@@ -391,7 +401,7 @@ void TcpTransport::enqueuePooledTransfer(const ConnectionKey& key,
                 auto group_it = state->groups.find(key);
                 if (group_it == state->groups.end()) {
                     group = std::make_shared<PeerConnectionGroup>(
-                        key, runtime->executor, state->lanes_per_peer,
+                        key, runtime->executor,
                         state->max_queued_transfers_per_peer,
                         state->max_pending_admissions_per_peer,
                         state->admission_timeout, state->failure_counters);
@@ -418,8 +428,6 @@ void TcpTransport::enqueuePooledTransfer(const ConnectionKey& key,
                     // by the cooldown length.
                     const auto admission_time =
                         std::chrono::steady_clock::now();
-                    work.admission_sequence = group->next_admission_sequence++;
-                    work.enqueued_at = admission_time;
                     expirePendingAdmissionsLocked(*group, admission_time,
                                                   expired);
                     promoted = promotePendingAdmissionsLocked(*group);
@@ -433,7 +441,7 @@ void TcpTransport::enqueuePooledTransfer(const ConnectionKey& key,
                     } else if (group->pending_admissions.size() <
                                group->pending_admission_capacity) {
                         work.admission_deadline =
-                            work.enqueued_at + group->admission_timeout;
+                            admission_time + group->admission_timeout;
                         group->pending_admissions.emplace_back(std::move(work));
                         pending_admission = true;
                     } else {
@@ -502,52 +510,42 @@ void TcpTransport::enqueuePooledTransfer(const ConnectionKey& key,
 
 void TcpTransport::postGroupPump(
     const std::shared_ptr<PeerConnectionGroup>& group, uint64_t pump_epoch) {
-    auto fail_posted_work = [&](const std::string& error) {
-        std::deque<TcpWorkItem> failed;
+    auto fail_posted_work = [&](const char* error) {
+        std::deque<TcpWorkItem> failed_queue;
+        std::deque<TcpWorkItem> failed_pending;
         std::shared_ptr<asio::steady_timer> admission_timer;
-        [[maybe_unused]] size_t promoted = 0;
         {
             std::lock_guard<std::mutex> lock(group->mutex);
             if (group->pump_scheduled && group->pump_epoch == pump_epoch) {
                 group->pump_scheduled = false;
-                failed.swap(group->queue);
+                failed_queue.swap(group->queue);
                 clearQueuedBytesLocked(*group);
-                promoted = promotePendingAdmissionsLocked(*group);
-                while (!group->queue.empty()) {
-                    failed.emplace_back(std::move(group->queue.front()));
-                    group->queue.pop_front();
-                }
-                clearQueuedBytesLocked(*group);
-                while (!group->pending_admissions.empty()) {
-                    failed.emplace_back(
-                        std::move(group->pending_admissions.front()));
-                    group->pending_admissions.pop_front();
-                }
+                failed_pending.swap(group->pending_admissions);
                 ++group->admission_epoch;
                 if (group->admission_epoch == 0) ++group->admission_epoch;
-                group->admission_timer_armed = false;
                 admission_timer = std::move(group->admission_timer);
             }
         }
         cancelTimerNoThrow(admission_timer);
-#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
-        if (promoted != 0)
-            invokeLaneObserverHook(kLaneAdmissionPromoted, 0, promoted, 0,
-                                   false);
-#endif
-        LOG(ERROR) << "Failed to schedule TCP lane pump for " << group->key.host
-                   << ":" << group->key.port << error;
-        failWorkItems(std::move(failed), WorkFailureReason::RUNTIME_UNAVAILABLE,
+        failWorkItems(std::move(failed_queue),
+                      WorkFailureReason::RUNTIME_UNAVAILABLE,
                       group->failure_counters);
+        failWorkItems(std::move(failed_pending),
+                      WorkFailureReason::RUNTIME_UNAVAILABLE,
+                      group->failure_counters);
+        LOG(ERROR) << "Failed to schedule TCP lane pump for " << group->key.host
+                   << ":" << group->key.port
+                   << (error && *error ? ". Error: " : "")
+                   << (error && *error ? error : "");
     };
 
     try {
         asio::post(group->executor,
                    [group, pump_epoch] { runGroupPump(group, pump_epoch); });
     } catch (const std::exception& e) {
-        fail_posted_work(". Error: " + std::string(e.what()));
+        fail_posted_work(e.what());
     } catch (...) {
-        fail_posted_work("");
+        fail_posted_work(nullptr);
     }
 }
 
@@ -609,9 +607,23 @@ void TcpTransport::runGroupPump(
         // cooldown. A delayed pump must not reset round accounting or start a
         // probe before the matching timer handler validates the group.
         bool waiting_for_cooldown = group->retry_timer != nullptr;
+        const bool round_exhausted = hasDisconnectedLaneLocked(*group) &&
+                                     !hasUntriedDisconnectedLaneLocked(*group);
         if (!waiting_for_cooldown && !group->queue.empty() &&
-            !hasUsableLaneLocked(*group) && group->probes_in_flight == 0 &&
-            group->connect_attempts_in_round >= group->lanes.size()) {
+            group->probes_in_flight == 0 && round_exhausted) {
+            const bool cooldown_already_started =
+                group->next_probe_not_before !=
+                std::chrono::steady_clock::time_point{};
+            if (!hasUsableLaneLocked(*group) && !cooldown_already_started) {
+                failed.swap(group->queue);
+                clearQueuedBytesLocked(*group);
+                enterReconnectCooldownLocked(*group);
+                failure_reason = WorkFailureReason::CONNECT_FAILED;
+                queue_detached_after_scheduling = true;
+            } else if (group->next_probe_not_before ==
+                       std::chrono::steady_clock::time_point{}) {
+                enterReconnectCooldownLocked(*group);
+            }
             if (std::chrono::steady_clock::now() <
                 group->next_probe_not_before) {
                 if (armRetryTimerLocked(group)) {
@@ -641,7 +653,7 @@ void TcpTransport::runGroupPump(
 
         if (!waiting_for_cooldown && failed.empty()) {
             const size_t probe_limit =
-                std::min(group->lane_count, kMaxConcurrentLaneProbes);
+                std::min(group->lanes.size(), kMaxConcurrentLaneProbes);
             while (!group->queue.empty() &&
                    group->probes_in_flight < probe_limit) {
                 auto lane_it = std::find_if(
@@ -659,18 +671,21 @@ void TcpTransport::runGroupPump(
                 ++lane->operation_epoch;
                 if (lane->operation_epoch == 0) ++lane->operation_epoch;
                 ++group->probes_in_flight;
-                ++group->connect_attempts_in_round;
                 connects[connect_count++] = {lane, lane->operation_epoch};
             }
 
-            if (!group->queue.empty() && !hasUsableLaneLocked(*group) &&
-                group->probes_in_flight == 0 &&
-                group->connect_attempts_in_round >= group->lanes.size()) {
-                failed.swap(group->queue);
-                clearQueuedBytesLocked(*group);
-                enterReconnectCooldownLocked(*group);
+            if (!group->queue.empty() && group->probes_in_flight == 0 &&
+                hasDisconnectedLaneLocked(*group) &&
+                !hasUntriedDisconnectedLaneLocked(*group)) {
+                if (!hasUsableLaneLocked(*group)) {
+                    failed.swap(group->queue);
+                    clearQueuedBytesLocked(*group);
+                    enterReconnectCooldownLocked(*group);
+                    queue_detached_after_scheduling = true;
+                } else {
+                    enterReconnectCooldownLocked(*group);
+                }
                 cooldown_started = true;
-                queue_detached_after_scheduling = true;
             }
         }
 
@@ -725,7 +740,7 @@ void TcpTransport::startLaneConnect(
             return;
         }
 #ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
-        if (invokeLaneConnectFailureInjectionHook()) {
+        if (invokeLaneConnectFailureInjectionHook(lane->lane_id)) {
             initiation_error = "injected lane connect failure";
         } else
 #endif
@@ -889,18 +904,10 @@ void TcpTransport::handleLaneConnectFailure(
 
             const bool sibling_usable =
                 group->state == GroupState::OPEN && hasUsableLaneLocked(*group);
-            if (sibling_usable) {
-                // A lane-local connect failure must not consume this lane's
-                // eligibility for the rest of a round while another lane
-                // continues serving the peer. Delay the new probe to avoid a
-                // tight loop when the peer temporarily refuses extra lanes.
-                lane->last_connect_round = 0;
-                enterReconnectCooldownLocked(*group);
-            }
 
             if (group->state == GroupState::OPEN && !group->queue.empty() &&
                 !sibling_usable && group->probes_in_flight == 0 &&
-                group->connect_attempts_in_round >= group->lanes.size()) {
+                !hasUntriedDisconnectedLaneLocked(*group)) {
                 failed.swap(group->queue);
                 clearQueuedBytesLocked(*group);
                 enterReconnectCooldownLocked(*group);
@@ -1083,14 +1090,17 @@ void TcpTransport::handleLaneTerminal(
         } else {
             lane->socket.reset();
             lane->state = LaneState::DISCONNECTED;
-            // A dirty session is a lane-local failure. Let this lane refill
-            // capacity in the current round even while a sibling remains
-            // usable, but rate-limit the replacement probe.
-            lane->last_connect_round = 0;
+            // Keep this lane marked as tried in the current round. If another
+            // lane is still usable, wait for the group cooldown before a new
+            // round can retry disconnected lanes. If this was the last usable
+            // lane and the round had previously connected successfully, start
+            // a fresh round immediately so queued work is not mistaken for an
+            // all-probes-failed round.
             const bool sibling_usable = hasUsableLaneLocked(*group);
             if (sibling_usable) {
                 enterReconnectCooldownLocked(*group);
-            } else if (!group->queue.empty() && group->probes_in_flight == 0 &&
+            } else if (!group->queue.empty() &&
+                       group->probes_in_flight == 0 &&
                        group->connect_round_had_success) {
                 beginConnectRoundLocked(*group);
             }
@@ -1212,24 +1222,20 @@ void TcpTransport::shutdownConnectionLanes() {
     }
 
     for (const auto& group : groups) {
-        std::deque<TcpWorkItem> accepted;
+        std::deque<TcpWorkItem> accepted_queue;
+        std::deque<TcpWorkItem> accepted_pending;
         {
             std::lock_guard<std::mutex> lock(group->mutex);
             group->state = GroupState::CLOSING;
             group->pump_scheduled = false;
             ++group->pump_epoch;
-            accepted.swap(group->queue);
-            while (!group->pending_admissions.empty()) {
-                accepted.emplace_back(
-                    std::move(group->pending_admissions.front()));
-                group->pending_admissions.pop_front();
-            }
+            accepted_queue.swap(group->queue);
+            accepted_pending.swap(group->pending_admissions);
             clearQueuedBytesLocked(*group);
             ++group->retry_epoch;
             if (group->retry_epoch == 0) ++group->retry_epoch;
             ++group->admission_epoch;
             if (group->admission_epoch == 0) ++group->admission_epoch;
-            group->admission_timer_armed = false;
             for (const auto& lane : group->lanes) {
                 ++lane->operation_epoch;
                 if (lane->operation_epoch == 0) ++lane->operation_epoch;
@@ -1237,7 +1243,9 @@ void TcpTransport::shutdownConnectionLanes() {
                     lane->state = LaneState::CLOSING;
             }
         }
-        failWorkItems(std::move(accepted), WorkFailureReason::SHUTDOWN,
+        failWorkItems(std::move(accepted_queue), WorkFailureReason::SHUTDOWN,
+                      state->failure_counters);
+        failWorkItems(std::move(accepted_pending), WorkFailureReason::SHUTDOWN,
                       state->failure_counters);
     }
 

--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport_lane_impl.h
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport_lane_impl.h
@@ -1099,8 +1099,7 @@ void TcpTransport::handleLaneTerminal(
             const bool sibling_usable = hasUsableLaneLocked(*group);
             if (sibling_usable) {
                 enterReconnectCooldownLocked(*group);
-            } else if (!group->queue.empty() &&
-                       group->probes_in_flight == 0 &&
+            } else if (!group->queue.empty() && group->probes_in_flight == 0 &&
                        group->connect_round_had_success) {
                 beginConnectRoundLocked(*group);
             }

--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport_session_impl.h
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport_session_impl.h
@@ -51,13 +51,6 @@ struct SessionHeader {
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX)
-static bool isCudaMemory(void* addr) {
-    cudaPointerAttributes attributes;
-    auto status = cudaPointerGetAttributes(&attributes, addr);
-    if (status != cudaSuccess) return false;
-    return attributes.type == cudaMemoryTypeDevice;
-}
-
 // Returns the CUDA device ordinal if addr is device memory, or -1 otherwise.
 // Callers must call cudaSetDevice before any cudaMemcpy to avoid implicit
 // GPU 0 context creation.

--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport_session_impl.h
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport_session_impl.h
@@ -1,0 +1,822 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Private implementation fragment included by tcp_transport.cpp from inside
+// namespace mooncake. Keeping the protocol/session state here makes the public
+// transport entry points and the lane scheduler independently reviewable
+// without changing linkage or lifetime behavior.
+
+static size_t getChunkSize() {
+    static const size_t val = [] {
+        const char* env = std::getenv("MC_TCP_SLICE_SIZE");
+        if (env) {
+            try {
+                size_t v = std::stoull(env);
+                if (v > 0) return v;
+                LOG(WARNING)
+                    << "Ignore non-positive MC_TCP_SLICE_SIZE value: " << env
+                    << ", using default 65536";
+            } catch (const std::exception& e) {
+                // A non-numeric or out-of-range value makes std::stoull throw;
+                // fall through to the default instead of letting the exception
+                // propagate out of this static initializer and abort the
+                // transfer that first reads the chunk size.
+                LOG(WARNING)
+                    << "Invalid MC_TCP_SLICE_SIZE value: " << env
+                    << ". Error: " << e.what() << ", using default 65536";
+            }
+        }
+        return size_t(65536);  // 64KB default
+    }();
+    return val;
+}
+
+struct SessionHeader {
+    uint64_t size;
+    uint64_t addr;
+    uint8_t opcode;
+};
+
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
+    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
+static bool isCudaMemory(void* addr) {
+    cudaPointerAttributes attributes;
+    auto status = cudaPointerGetAttributes(&attributes, addr);
+    if (status != cudaSuccess) return false;
+    return attributes.type == cudaMemoryTypeDevice;
+}
+
+// Returns the CUDA device ordinal if addr is device memory, or -1 otherwise.
+// Callers must call cudaSetDevice before any cudaMemcpy to avoid implicit
+// GPU 0 context creation.
+static int getCudaDeviceId(void* addr) {
+    cudaPointerAttributes attributes;
+    auto status = cudaPointerGetAttributes(&attributes, addr);
+    if (status != cudaSuccess) return -1;
+    if (attributes.type == cudaMemoryTypeDevice) return attributes.device;
+    return -1;
+}
+
+#ifdef USE_MACA
+static cudaError_t copyTcpCudaMemory(void* dst, const void* src, size_t size) {
+    cudaStream_t stream;
+    cudaError_t status =
+        cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking);
+    if (status != cudaSuccess) return status;
+
+    status = cudaMemcpyAsync(dst, src, size, cudaMemcpyDefault, stream);
+    if (status == cudaSuccess) {
+        status = cudaStreamSynchronize(stream);
+    }
+
+    cudaError_t destroy_status = cudaStreamDestroy(stream);
+    return status == cudaSuccess ? destroy_status : status;
+}
+#endif
+#endif
+
+// Forward declaration
+class TcpTransport;
+
+using ValidateAddrFn = std::function<bool(uint64_t, uint64_t)>;
+
+// --- Acknowledged framing (protocol v2, #2086) ------------------------------
+// v1 framing gives the initiator no channel to learn whether the receiver
+// applied (or even accepted) a WRITE: COMPLETED fires when the final chunk
+// enters the initiator's kernel socket buffer, while megabytes may still be
+// in flight toward destination memory, and a rejected request is silently
+// "successful". v2 requests set the high bit of the opcode; the server then
+// (a) prefixes every READ response with an 8-byte status frame and (b) sends
+// an 8-byte status frame for WRITE only after the final chunk has been
+// applied to destination memory. Initiators enable v2 only when the target
+// segment advertises tcp_proto_version >= 2, so old servers never see
+// flagged opcodes and old initiators keep receiving v1 framing.
+static constexpr uint8_t kOpcodeV2Flag = 0x80;
+// Status frames carry a magic in the high 32 bits so that a v2 initiator
+// which reaches a v1 server through a stale descriptor (v1 treats unknown
+// opcodes as READ and immediately streams payload bytes) fails fast on the
+// first frame instead of misinterpreting the stream. Residual risk: payload
+// bytes that happen to equal a valid frame (2^-64 per request, data
+// dependent) are indistinguishable in-band; eliminating that would need a
+// nonce/checksum handshake, which this deliberately avoids.
+static constexpr uint64_t kStatusMagic = 0x4D435456ull << 32;  // "MCTV"
+static constexpr uint64_t kStatusOk = kStatusMagic | 0;
+static constexpr uint64_t kStatusAddrRejected = kStatusMagic | 1;
+static inline bool statusFrameValid(uint64_t frame) {
+    return (frame & 0xFFFFFFFF00000000ull) == kStatusMagic;
+}
+
+// Operational escape hatch: MC_TCP_PROTO=1 forces initiators to speak the
+// legacy unacknowledged framing even to v2-capable servers. Also used by
+// tests to cover the mixed-version matrix in one process.
+static bool forceLegacyTcpProto() {
+    // Read per call (startTransfer already does metadata lookups; getenv is
+    // noise) so tests can cover both protocol modes in one process.
+    const char* env = std::getenv("MC_TCP_PROTO");
+    return env && env[0] == '1' && env[1] == '\0';
+}
+
+// Server-side session: handles transfer requests on a persistent connection.
+// The session owns the socket; ending the callback chain without rearming
+// (start()/next handler) drops the last reference and closes the connection.
+struct ServerSession : public std::enable_shared_from_this<ServerSession> {
+    explicit ServerSession(std::shared_ptr<tcpsocket> socket,
+                           ValidateAddrFn validate_addr)
+        : socket_(std::move(socket)),
+          validate_addr_(std::move(validate_addr)) {}
+
+    std::shared_ptr<tcpsocket> socket_;
+    ValidateAddrFn validate_addr_;
+    SessionHeader header_;
+    uint64_t total_transferred_bytes_;
+    char* local_buffer_;
+    bool v2_ = false;
+    uint64_t status_frame_;
+
+    void start() {
+        total_transferred_bytes_ = 0;
+        readHeader();
+    }
+
+   private:
+    // Send an 8-byte status frame, then run `next` (or end the session —
+    // closing the connection — when `next` is empty or the send fails).
+    void sendStatus(uint64_t status, std::function<void()> next) {
+        status_frame_ = htole64(status);
+        auto self(shared_from_this());
+        asio::async_write(*socket_,
+                          asio::buffer(&status_frame_, sizeof(status_frame_)),
+                          [this, self, next = std::move(next)](
+                              const asio::error_code& ec, std::size_t) {
+                              if (ec)
+                                  return;  // connection closes with the session
+                              if (next) next();
+                          });
+    }
+
+    void readHeader() {
+        auto self(shared_from_this());
+        asio::async_read(
+            *socket_, asio::buffer(&header_, sizeof(SessionHeader)),
+            [this, self](const asio::error_code& ec, std::size_t len) {
+                if (ec || len != sizeof(SessionHeader)) {
+                    if (ec.value() != asio::error::eof) {
+                        LOG(WARNING)
+                            << "ServerSession::readHeader failed. Error: "
+                            << ec.message() << " (value: " << ec.value() << ")"
+                            << ", bytes read: " << len;
+                    }
+                    return;
+                }
+
+                v2_ = (header_.opcode & kOpcodeV2Flag) != 0;
+                const uint8_t opcode = header_.opcode & ~kOpcodeV2Flag;
+                local_buffer_ = (char*)(le64toh(header_.addr));
+                uint64_t size = le64toh(header_.size);
+                if (validate_addr_ &&
+                    !validate_addr_((uint64_t)local_buffer_, size)) {
+                    LOG(ERROR) << "ServerSession: remote-supplied address 0x"
+                               << std::hex << (uint64_t)local_buffer_
+                               << std::dec << " with size " << size
+                               << " is not within any registered buffer";
+                    // v2 initiators learn of the rejection; v1 initiators
+                    // only see the connection close (and, for small WRITEs,
+                    // may have already reported success — the defect v2
+                    // exists to fix).
+                    if (v2_) sendStatus(kStatusAddrRejected, nullptr);
+                    return;
+                }
+                if (opcode == (uint8_t)TransferRequest::WRITE) {
+                    readBody();
+                } else if (v2_) {
+                    // READ, v2: status frame precedes the data.
+                    sendStatus(kStatusOk, [this] { writeBody(); });
+                } else {
+                    writeBody();
+                }
+            });
+    }
+
+    void writeBody() {
+        auto self(shared_from_this());
+        uint64_t size = le64toh(header_.size);
+        char* addr = local_buffer_;
+
+        size_t buffer_size =
+            std::min(getChunkSize(), size - total_transferred_bytes_);
+        if (buffer_size == 0) {
+            // Transfer complete, wait for next request on this connection
+            start();
+            return;
+        }
+
+        char* dram_buffer = addr + total_transferred_bytes_;
+        int cuda_device = -1;
+
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
+    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
+        cuda_device = getCudaDeviceId(addr);
+        if (cuda_device >= 0) {
+            dram_buffer = new char[buffer_size];
+            cudaSetDevice(cuda_device);
+#ifdef USE_MACA
+            cudaError_t cuda_status = copyTcpCudaMemory(
+                dram_buffer, addr + total_transferred_bytes_, buffer_size);
+#else
+            cudaError_t cuda_status =
+                cudaMemcpy(dram_buffer, addr + total_transferred_bytes_,
+                           buffer_size, cudaMemcpyDefault);
+#endif
+            if (cuda_status != cudaSuccess) {
+                LOG(ERROR) << "ServerSession::writeBody failed to copy from "
+                              "CUDA memory. "
+                           << "Error: " << cudaGetErrorString(cuda_status);
+                delete[] dram_buffer;
+                return;  // Connection will be closed
+            }
+        }
+#endif
+
+        asio::async_write(
+            *socket_, asio::buffer(dram_buffer, buffer_size),
+            [this, addr, dram_buffer, cuda_device, self](
+                const asio::error_code& ec, std::size_t transferred_bytes) {
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
+    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
+                if (cuda_device >= 0) {
+                    delete[] dram_buffer;
+                }
+#endif
+                if (ec) {
+                    LOG(ERROR)
+                        << "ServerSession::writeBody failed. "
+                        << "Attempt to write data " << static_cast<void*>(addr)
+                        << " using buffer " << static_cast<void*>(dram_buffer)
+                        << ". Error: " << ec.message()
+                        << " (value: " << ec.value() << ")";
+                    return;  // Connection will be closed
+                }
+                total_transferred_bytes_ += transferred_bytes;
+                writeBody();
+            });
+    }
+
+    void readBody() {
+        auto self(shared_from_this());
+        uint64_t size = le64toh(header_.size);
+        char* addr = local_buffer_;
+
+        size_t buffer_size =
+            std::min(getChunkSize(), size - total_transferred_bytes_);
+        if (buffer_size == 0) {
+            // Destination memory now holds the complete payload. Under v2,
+            // acknowledge before accepting the next request — this is what
+            // makes the initiator's COMPLETED mean "applied at the
+            // destination" rather than "left my socket buffer".
+            if (v2_) {
+                sendStatus(kStatusOk, [this] { start(); });
+            } else {
+                start();
+            }
+            return;
+        }
+
+        char* dram_buffer = addr + total_transferred_bytes_;
+        int cuda_device = -1;
+
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
+    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
+        cuda_device = getCudaDeviceId(addr);
+        if (cuda_device >= 0) {
+            dram_buffer = new char[buffer_size];
+        }
+#endif
+
+        asio::async_read(
+            *socket_, asio::buffer(dram_buffer, buffer_size),
+            [this, addr, dram_buffer, cuda_device, self](
+                const asio::error_code& ec, std::size_t transferred_bytes) {
+                if (ec) {
+                    // If client closed connection (EOF), this is normal - don't
+                    // log
+                    if (ec.value() != asio::error::eof) {
+                        LOG(WARNING)
+                            << "ServerSession::readBody failed. "
+                            << "Attempt to read data "
+                            << static_cast<void*>(addr) << " using buffer "
+                            << static_cast<void*>(dram_buffer)
+                            << ". Error: " << ec.message()
+                            << " (value: " << ec.value() << ")";
+                    }
+                    if (cuda_device >= 0) delete[] dram_buffer;
+                    return;  // Connection will be closed
+                }
+
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
+    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
+                if (cuda_device >= 0) {
+                    cudaSetDevice(cuda_device);
+#ifdef USE_MACA
+                    cudaError_t cuda_status =
+                        copyTcpCudaMemory(addr + total_transferred_bytes_,
+                                          dram_buffer, transferred_bytes);
+#else
+                    cudaError_t cuda_status =
+                        cudaMemcpy(addr + total_transferred_bytes_, dram_buffer,
+                                   transferred_bytes, cudaMemcpyDefault);
+#endif
+                    if (cuda_status != cudaSuccess) {
+                        LOG(ERROR)
+                            << "ServerSession::readBody failed to copy to CUDA "
+                               "memory. "
+                            << "Error: " << cudaGetErrorString(cuda_status);
+                        delete[] dram_buffer;
+                        return;  // Connection will be closed
+                    }
+                    delete[] dram_buffer;
+                }
+#endif
+                total_transferred_bytes_ += transferred_bytes;
+                readBody();
+            });
+    }
+};
+
+// Client-side session: initiates one transfer request
+struct ClientSession : public std::enable_shared_from_this<ClientSession> {
+    using OnTerminal =
+        std::function<void(TransferStatusEnum, bool connection_clean)>;
+
+    explicit ClientSession(std::shared_ptr<tcpsocket> socket, bool use_v2,
+                           OnTerminal on_terminal)
+        : socket_(std::move(socket)),
+          v2_(use_v2),
+          on_terminal_(std::move(on_terminal)) {}
+
+    std::shared_ptr<tcpsocket> socket_;
+    SessionHeader header_;
+    uint64_t total_transferred_bytes_;
+    char* local_buffer_;
+    bool v2_;
+    uint64_t status_frame_;
+    // v2 WRITE runs the body stream and the ack read concurrently (one
+    // async op per direction; handlers serialize on the io thread). The
+    // concurrent read lets a rejection — or a v1 server's bogus payload —
+    // abort a large in-flight WRITE instead of deadlocking on mutually
+    // full socket buffers, and delivers rejection frames before the close.
+    bool write_body_done_ = false;
+    bool write_acked_ok_ = false;
+    // An early negative/malformed ack can arrive while asio::async_write still
+    // owns a buffer pointing into the caller's source memory. Do not publish a
+    // terminal status until that body operation has completed or been
+    // cancelled: callers are allowed to release the source buffer as soon as
+    // the transfer becomes terminal.
+    bool write_body_in_flight_ = false;
+    bool write_abort_requested_ = false;
+    // A v2 status frame is prompt by construction: a READ status precedes
+    // any payload, and a WRITE ack follows at most one chunk's apply after
+    // the body is done. The only peer that never sends one is a legacy
+    // server reached through a stale v2 descriptor — and for requests
+    // shorter than a frame it also keeps the connection open (it streamed
+    // size < 8 bytes of "READ payload" and is waiting for our next header),
+    // so without a deadline both sides wait forever. Bound that wait; the
+    // default is generous so no healthy slow path can trip it, since it only
+    // covers the frame itself, never payload streaming.
+    static int statusFrameTimeoutSec() {
+        const char* env = std::getenv("MC_TCP_STATUS_TIMEOUT_SEC");
+        if (env) {
+            int v = std::atoi(env);
+            if (v > 0) return v;
+        }
+        return 30;
+    }
+    std::optional<asio::steady_timer> status_timer_;
+    bool status_deadline_disarmed_ = false;
+    bool terminal_reported_ = false;
+    OnTerminal on_terminal_;
+
+    void initiate(void* buffer, uint64_t dest_addr, size_t size,
+                  TransferRequest::OpCode opcode) {
+        local_buffer_ = (char*)buffer;
+        header_.addr = htole64(dest_addr);
+        header_.size = htole64(size);
+        header_.opcode = (uint8_t)opcode | (v2_ ? kOpcodeV2Flag : 0);
+        total_transferred_bytes_ = 0;
+        writeHeader();
+    }
+
+    void cancel() noexcept {
+        cancelStatusDeadline();
+        if (!socket_) return;
+        asio::error_code cancel_ec;
+        socket_->cancel(cancel_ec);
+        asio::error_code close_ec;
+        socket_->close(close_ec);
+    }
+
+   private:
+    // All handlers run on the transport's single io thread, so arm/cancel
+    // and the expiry handler never race. Expiry only closes the socket: the
+    // pending status read then completes with an error and its handler owns
+    // the failure path (including source-buffer quiescence for WRITE).
+    void armStatusDeadline() {
+        auto self(shared_from_this());
+        status_deadline_disarmed_ = false;
+        status_timer_.emplace(socket_->get_executor());
+        status_timer_->expires_after(
+            std::chrono::seconds(statusFrameTimeoutSec()));
+        status_timer_->async_wait([this, self](const asio::error_code& ec) {
+            // The disarmed flag also covers an expiry that was already
+            // queued when cancel() ran (cancel cannot revoke those, and by
+            // then the socket may have been re-pooled).
+            if (ec == asio::error::operation_aborted ||
+                status_deadline_disarmed_) {
+                return;
+            }
+            LOG(ERROR) << "ClientSession: no status frame within "
+                       << statusFrameTimeoutSec()
+                       << "s (peer likely speaks the legacy protocol); "
+                          "dropping connection";
+            if (socket_ && socket_->is_open()) {
+                asio::error_code cec;
+                socket_->close(cec);
+            }
+        });
+    }
+
+    void cancelStatusDeadline() {
+        status_deadline_disarmed_ = true;
+        if (status_timer_) {
+            asio::error_code ec;
+            status_timer_->cancel(ec);
+        }
+    }
+
+    // Single terminal path. The invoking Asio operation has already released
+    // its buffer before entering its completion handler. The lane posts any
+    // follow-up pump, so a clean socket cannot be reused inline here.
+    void finalize(TransferStatusEnum status, bool clean) {
+        if (terminal_reported_) return;
+        terminal_reported_ = true;
+        cancelStatusDeadline();
+        auto on_terminal = std::move(on_terminal_);
+        if (on_terminal) on_terminal(status, clean);
+    }
+
+    // Abort a v2 WRITE and cancel any body operation. If asio still owns the
+    // current source buffer, its completion handler is responsible for
+    // finalizing after the buffer is quiescent.
+    void abortWrite() {
+        write_abort_requested_ = true;
+        if (socket_ && socket_->is_open()) {
+            asio::error_code ec;
+            socket_->close(ec);
+        }
+        if (!write_body_in_flight_) finalize(TransferStatusEnum::FAILED, false);
+    }
+
+    void writeHeader() {
+        auto self(shared_from_this());
+        asio::async_write(
+            *socket_, asio::buffer(&header_, sizeof(SessionHeader)),
+            [this, self](const asio::error_code& ec, std::size_t len) {
+                if (ec || len != sizeof(SessionHeader)) {
+                    LOG(ERROR)
+                        << "ClientSession::writeHeader failed. Error: "
+                        << ec.message() << " (value: " << ec.value() << ")"
+                        << ", bytes written: " << len;
+                    finalize(TransferStatusEnum::FAILED, false);
+                    return;
+                }
+                if ((header_.opcode & ~kOpcodeV2Flag) ==
+                    (uint8_t)TransferRequest::WRITE) {
+                    if (v2_) readWriteAck();  // concurrent with the body
+                    writeBody();
+                } else if (v2_) {
+                    readReadStatus();
+                } else {
+                    readBody();
+                }
+            });
+    }
+
+    // v2 READ: the server prefixes the data with a status frame.
+    void readReadStatus() {
+        auto self(shared_from_this());
+        armStatusDeadline();
+        asio::async_read(
+            *socket_, asio::buffer(&status_frame_, sizeof(status_frame_)),
+            [this, self](const asio::error_code& ec, std::size_t len) {
+                cancelStatusDeadline();
+                if (ec || len != sizeof(status_frame_)) {
+                    LOG(ERROR)
+                        << "ClientSession: failed to read READ status "
+                           "frame. Error: "
+                        << ec.message() << " (value: " << ec.value() << ")";
+                    finalize(TransferStatusEnum::FAILED, false);
+                    return;
+                }
+                uint64_t frame = le64toh(status_frame_);
+                if (!statusFrameValid(frame)) {
+                    LOG(ERROR) << "ClientSession: malformed READ status "
+                                  "frame (peer likely speaks the legacy "
+                                  "protocol); dropping connection";
+                    finalize(TransferStatusEnum::FAILED, false);
+                    return;
+                }
+                if (frame != kStatusOk) {
+                    LOG(ERROR) << "ClientSession: READ rejected by server, "
+                                  "status "
+                               << (frame & 0xFFFFFFFFull);
+                    finalize(TransferStatusEnum::FAILED, false);
+                    return;
+                }
+                readBody();
+            });
+    }
+
+    // v2 WRITE: completion is the server's acknowledgment that the payload
+    // has been applied to destination memory. Armed concurrently with the
+    // body stream; a well-behaved v2 server only sends the frame after the
+    // final chunk, so a frame arriving before the body is done is either a
+    // rejection or a legacy peer's payload — both close the socket immediately
+    // and publish failure only after the outstanding body write is quiescent.
+    void readWriteAck() {
+        auto self(shared_from_this());
+        asio::async_read(
+            *socket_, asio::buffer(&status_frame_, sizeof(status_frame_)),
+            [this, self](const asio::error_code& ec, std::size_t len) {
+                cancelStatusDeadline();
+                if (ec || len != sizeof(status_frame_)) {
+                    // The body path may have already finalized a failure and
+                    // closed the socket; finalize() is idempotent (moved-from
+                    // callbacks are null-checked).
+                    if (ec != asio::error::operation_aborted) {
+                        LOG(ERROR)
+                            << "ClientSession: failed to read WRITE "
+                               "ack frame. Error: "
+                            << ec.message() << " (value: " << ec.value() << ")";
+                    }
+                    abortWrite();
+                    return;
+                }
+                uint64_t frame = le64toh(status_frame_);
+                if (!statusFrameValid(frame)) {
+                    LOG(ERROR) << "ClientSession: malformed WRITE ack frame "
+                                  "(peer likely speaks the legacy protocol); "
+                                  "dropping connection";
+                    abortWrite();
+                    return;
+                }
+                if (frame != kStatusOk) {
+                    LOG(ERROR) << "ClientSession: WRITE rejected by server, "
+                                  "status "
+                               << (frame & 0xFFFFFFFFull);
+                    abortWrite();
+                    return;
+                }
+                if (!write_body_done_) {
+                    // The server's ack can legitimately overtake the final
+                    // local write-completion handler (both become ready
+                    // together for small writes; the io thread may run this
+                    // handler first). Record it; the body path finalizes.
+                    write_acked_ok_ = true;
+                    return;
+                }
+                finalize(TransferStatusEnum::COMPLETED, true);
+            });
+    }
+
+    void readBody() {
+        auto self(shared_from_this());
+        uint64_t size = le64toh(header_.size);
+        char* addr = local_buffer_;
+
+        size_t buffer_size =
+            std::min(getChunkSize(), size - total_transferred_bytes_);
+        if (buffer_size == 0) {
+            finalize(TransferStatusEnum::COMPLETED, true);
+            return;
+        }
+
+        char* dram_buffer = addr + total_transferred_bytes_;
+        int cuda_device = -1;
+
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
+    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
+        cuda_device = getCudaDeviceId(addr);
+        if (cuda_device >= 0) {
+            dram_buffer = new char[buffer_size];
+        }
+#endif
+
+        asio::async_read(
+            *socket_, asio::buffer(dram_buffer, buffer_size),
+            [this, addr, dram_buffer, cuda_device, self](
+                const asio::error_code& ec, std::size_t transferred_bytes) {
+                if (ec) {
+                    LOG(ERROR)
+                        << "ClientSession::readBody failed. "
+                        << "Attempt to read data " << static_cast<void*>(addr)
+                        << " using buffer " << static_cast<void*>(dram_buffer)
+                        << ". Error: " << ec.message()
+                        << " (value: " << ec.value() << ")";
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
+    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
+                    if (cuda_device >= 0) delete[] dram_buffer;
+#endif
+                    finalize(TransferStatusEnum::FAILED, false);
+                    return;
+                }
+
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
+    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
+                if (cuda_device >= 0) {
+                    cudaSetDevice(cuda_device);
+#ifdef USE_MACA
+                    cudaError_t cuda_status =
+                        copyTcpCudaMemory(addr + total_transferred_bytes_,
+                                          dram_buffer, transferred_bytes);
+#else
+                    cudaError_t cuda_status =
+                        cudaMemcpy(addr + total_transferred_bytes_, dram_buffer,
+                                   transferred_bytes, cudaMemcpyDefault);
+#endif
+                    if (cuda_status != cudaSuccess) {
+                        LOG(ERROR)
+                            << "ClientSession::readBody failed to copy to CUDA "
+                               "memory. "
+                            << "Error: " << cudaGetErrorString(cuda_status);
+                        delete[] dram_buffer;
+                        finalize(TransferStatusEnum::FAILED, false);
+                        return;
+                    }
+                    delete[] dram_buffer;
+                }
+#endif
+                total_transferred_bytes_ += transferred_bytes;
+                readBody();
+            });
+    }
+
+    void writeBody() {
+        auto self(shared_from_this());
+        uint64_t size = le64toh(header_.size);
+        char* addr = local_buffer_;
+
+        size_t buffer_size =
+            std::min(getChunkSize(), size - total_transferred_bytes_);
+        if (buffer_size == 0) {
+            if (v2_) {
+                if (write_abort_requested_) {
+                    finalize(TransferStatusEnum::FAILED, false);
+                    return;
+                }
+                // Completion comes from the server's acknowledgment, whose
+                // read is already in flight (armed in writeHeader) and may
+                // have finished first.
+                write_body_done_ = true;
+                if (write_acked_ok_) {
+                    finalize(TransferStatusEnum::COMPLETED, true);
+                } else {
+                    // From here a well-behaved server owes at most one
+                    // chunk's apply plus the frame; a legacy peer behind a
+                    // stale descriptor may owe nothing, ever.
+                    armStatusDeadline();
+                }
+            } else {
+                // v1: no acknowledgment exists in the protocol; this only
+                // means the payload left the initiator (#2086).
+                finalize(TransferStatusEnum::COMPLETED, true);
+            }
+            return;
+        }
+
+        char* dram_buffer = addr + total_transferred_bytes_;
+        int cuda_device = -1;
+
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
+    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
+        cuda_device = getCudaDeviceId(addr);
+        if (cuda_device >= 0) {
+            dram_buffer = new char[buffer_size];
+            cudaSetDevice(cuda_device);
+#ifdef USE_MACA
+            cudaError_t cuda_status = copyTcpCudaMemory(
+                dram_buffer, addr + total_transferred_bytes_, buffer_size);
+#else
+            cudaError_t cuda_status =
+                cudaMemcpy(dram_buffer, addr + total_transferred_bytes_,
+                           buffer_size, cudaMemcpyDefault);
+#endif
+            if (cuda_status != cudaSuccess) {
+                LOG(ERROR) << "ClientSession::writeBody failed to copy from "
+                              "CUDA memory. "
+                           << "Error: " << cudaGetErrorString(cuda_status);
+                delete[] dram_buffer;
+                abortWrite();
+                return;
+            }
+        }
+#endif
+
+        write_body_in_flight_ = true;
+        asio::async_write(
+            *socket_, asio::buffer(dram_buffer, buffer_size),
+            [this, addr, dram_buffer, cuda_device, self](
+                const asio::error_code& ec, std::size_t transferred_bytes) {
+                write_body_in_flight_ = false;
+                if (cuda_device >= 0) {
+                    delete[] dram_buffer;
+                }
+                if (ec) {
+                    LOG(ERROR)
+                        << "ClientSession::writeBody failed. "
+                        << "Attempt to write data " << static_cast<void*>(addr)
+                        << " using buffer " << static_cast<void*>(dram_buffer)
+                        << ". Error: " << ec.message()
+                        << " (value: " << ec.value() << ")";
+                    abortWrite();
+                    return;
+                }
+                if (write_abort_requested_) {
+                    // The early ack path closed the socket while this
+                    // operation still owned the caller's source buffer. It is
+                    // safe to publish failure now that the handler has run.
+                    finalize(TransferStatusEnum::FAILED, false);
+                    return;
+                }
+                total_transferred_bytes_ += transferred_bytes;
+                writeBody();
+            });
+    }
+};
+
+struct TcpContext {
+    TcpContext(short port, ValidateAddrFn validate_addr)
+        : acceptor(io_context), validate_addr_(std::move(validate_addr)) {
+        std::error_code ec;
+        asio::ip::tcp::endpoint endpoint(asio::ip::tcp::v6(), port);
+
+        acceptor.open(endpoint.protocol(), ec);
+        if (!ec) {
+            acceptor.set_option(asio::ip::v6_only(false), ec);
+            if (!ec) {
+                acceptor.set_option(
+                    asio::ip::tcp::acceptor::reuse_address(true));
+                acceptor.bind(endpoint, ec);
+                if (!ec) {
+                    acceptor.listen();
+                    return;
+                }
+            }
+            acceptor.close();
+        }
+        LOG(ERROR) << "Failed to set up IPv6 dual-stack listener: "
+                   << ec.message() << " (error code: " << ec.value() << ")";
+        asio::ip::tcp::endpoint endpoint_v4(asio::ip::tcp::v4(), port);
+        acceptor.open(endpoint_v4.protocol());
+        acceptor.set_option(asio::ip::tcp::acceptor::reuse_address(true));
+        acceptor.bind(endpoint_v4);
+        acceptor.listen();
+    }
+
+    void doAccept() {
+        acceptor.async_accept([this](asio::error_code ec, tcpsocket socket) {
+            if (!ec) {
+                asio::error_code nodelay_ec;
+                socket.set_option(asio::ip::tcp::no_delay(true), nodelay_ec);
+                auto socket_ptr =
+                    std::make_shared<tcpsocket>(std::move(socket));
+                auto session =
+                    std::make_shared<ServerSession>(socket_ptr, validate_addr_);
+                session->start();
+            }
+            doAccept();
+        });
+    }
+
+    asio::io_context io_context;
+    asio::ip::tcp::acceptor acceptor;
+    ValidateAddrFn validate_addr_;
+};

--- a/mooncake-transfer-engine/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tests/CMakeLists.txt
@@ -113,6 +113,8 @@ if(USE_TCP)
 
   add_executable(tcp_write_visibility_test
                  ${WORKSPACE}/tcp_write_visibility_test.cpp)
+  target_compile_definitions(tcp_write_visibility_test
+                             PRIVATE MOONCAKE_TCP_TRANSPORT_TEST_HOOKS)
   target_link_libraries(tcp_write_visibility_test PUBLIC transfer_engine gtest
                                                          gtest_main)
   add_test(NAME tcp_write_visibility_test COMMAND tcp_write_visibility_test)

--- a/mooncake-transfer-engine/tests/tcp_write_visibility_test.cpp
+++ b/mooncake-transfer-engine/tests/tcp_write_visibility_test.cpp
@@ -1581,7 +1581,6 @@ TEST(TcpWriteVisibilityTest,
     EXPECT_EQ(fake_peer.activeAcceptedCount(), 2);
     EXPECT_EQ(cooldown_started_count.load(std::memory_order_acquire), 0);
     EXPECT_GE(retry_armed_count.load(std::memory_order_acquire), 1);
-    EXPECT_GE(retry_fired_count.load(std::memory_order_acquire), 1);
     EXPECT_EQ(session_failure_count.load(std::memory_order_acquire), 1);
     EXPECT_LE(maximum_observed_socket_count.load(std::memory_order_acquire),
               2u);
@@ -1639,7 +1638,6 @@ TEST(TcpWriteVisibilityTest,
               3);
     EXPECT_EQ(cooldown_started_count.load(std::memory_order_acquire), 0);
     EXPECT_GE(retry_armed_count.load(std::memory_order_acquire), 1);
-    EXPECT_GE(retry_fired_count.load(std::memory_order_acquire), 1);
     EXPECT_EQ(connect_failure_count.load(std::memory_order_acquire), 0);
     EXPECT_LE(maximum_observed_socket_count.load(std::memory_order_acquire),
               2u);

--- a/mooncake-transfer-engine/tests/tcp_write_visibility_test.cpp
+++ b/mooncake-transfer-engine/tests/tcp_write_visibility_test.cpp
@@ -54,7 +54,7 @@ namespace mooncake {
 void tcpTransportSetLaneConnectHandlerHookForTest(
     void (*hook)() noexcept) noexcept;
 void tcpTransportSetLaneConnectFailureInjectionHookForTest(
-    bool (*hook)() noexcept) noexcept;
+    bool (*hook)(size_t) noexcept) noexcept;
 void tcpTransportSetLaneObserverHookForTest(
     void (*hook)(int, size_t, uint64_t, size_t, bool) noexcept) noexcept;
 void tcpTransportSetLaneRetryHandlerHookForTest(
@@ -211,9 +211,14 @@ void resetLaneTestState() noexcept {
     shutdown_failure_count.store(0, std::memory_order_release);
 }
 
-bool failSecondLaneConnectAttemptOnce() noexcept {
+bool failSecondLaneConnectAttemptOnce(size_t) noexcept {
     const int attempt = lane_connect_injection_call_count.fetch_add(1) + 1;
     return attempt == 2;
+}
+
+bool failLaneOneAndTwoConnectAttempt(size_t lane_id) noexcept {
+    lane_connect_injection_call_count.fetch_add(1, std::memory_order_relaxed);
+    return lane_id == 1 || lane_id == 2;
 }
 
 void releaseLaneConnectHandler() noexcept {
@@ -1641,6 +1646,115 @@ TEST(TcpWriteVisibilityTest,
     EXPECT_EQ(connect_failure_count.load(std::memory_order_acquire), 0);
     EXPECT_LE(maximum_observed_socket_count.load(std::memory_order_acquire),
               2u);
+
+    fake_peer.closePeer();
+    ASSERT_TRUE(waitForBatchTerminal(h.engine.get(), batch_id, kRequestCount,
+                                     std::chrono::seconds(10)));
+    expectEverySliceCompletedExactlyOnceAfterShutdown(batch_id);
+
+    hooks.reset();
+    (void)h.engine->freeBatchID(batch_id);
+}
+
+TEST(TcpWriteVisibilityTest, DirtyLastUsableLaneStartsFreshConnectRound) {
+    constexpr int kRequestCount = 2;
+    constexpr size_t kLength = 64 * 1024;
+    ScopedEnvVar lanes("MC_TCP_LANES_PER_PEER", "1");
+    ScopedEnvVar queue_capacity("MC_TCP_MAX_QUEUED_TRANSFERS_PER_PEER", "8");
+    ScopedEnvVar status_timeout("MC_TCP_STATUS_TIMEOUT_SEC", "30");
+    ScopedLaneHooks hooks;
+    const char* env = std::getenv("MC_METADATA_SERVER");
+    const std::string metadata_server = env ? env : "P2PHANDSHAKE";
+
+    HoldingWriteServer fake_peer;
+    ASSERT_TRUE(fake_peer.ok());
+
+    EngineHandle h;
+    h.init(metadata_server, "127.0.0.2:17936", kLength);
+    ASSERT_TRUE(h.ok);
+    pointTcpSegmentAt(h, fake_peer.port());
+
+    memset(h.pool, 0x6E, kLength);
+    const TransferRequest request = makeWriteRequest(h, kLength);
+    const std::vector<TransferRequest> requests(kRequestCount, request);
+    const auto batch_id = h.engine->allocateBatchID(kRequestCount);
+    ASSERT_TRUE(h.engine->submitTransfer(batch_id, requests).ok());
+
+    ASSERT_TRUE(fake_peer.waitForAccepted(1, std::chrono::seconds(5)));
+    ASSERT_TRUE(waitForPredicate(
+        [] { return lane_busy_count.load(std::memory_order_acquire) >= 1; },
+        std::chrono::seconds(5)));
+    ASSERT_EQ(fake_peer.activeAcceptedCount(), 1);
+
+    // The only established lane fails while another request is still queued.
+    // Because this round had a successful connection, the queued request must
+    // get a fresh connect round instead of being failed as CONNECT_FAILED.
+    ASSERT_TRUE(fake_peer.closeOneAccepted());
+    ASSERT_TRUE(waitForPredicate(
+        [] { return lane_terminal_count.load(std::memory_order_acquire) >= 1; },
+        std::chrono::seconds(5)));
+    ASSERT_TRUE(fake_peer.waitForAccepted(2, std::chrono::seconds(5)));
+    ASSERT_TRUE(waitForPredicate(
+        [] { return lane_busy_count.load(std::memory_order_acquire) >= 2; },
+        std::chrono::seconds(5)));
+
+    EXPECT_EQ(fake_peer.activeAcceptedCount(), 1);
+    EXPECT_EQ(connect_failure_count.load(std::memory_order_acquire), 0);
+    EXPECT_GE(session_failure_count.load(std::memory_order_acquire), 1);
+    EXPECT_LE(maximum_observed_socket_count.load(std::memory_order_acquire),
+              1u);
+
+    fake_peer.closePeer();
+    ASSERT_TRUE(waitForBatchTerminal(h.engine.get(), batch_id, kRequestCount,
+                                     std::chrono::seconds(10)));
+    expectEverySliceCompletedExactlyOnceAfterShutdown(batch_id);
+
+    hooks.reset();
+    (void)h.engine->freeBatchID(batch_id);
+}
+
+TEST(TcpWriteVisibilityTest,
+     ReconnectProbePrefersNeverTriedLanesOverFailedLane) {
+    constexpr int kRequestCount = 5;
+    constexpr size_t kLength = 64 * 1024;
+    ScopedEnvVar lanes("MC_TCP_LANES_PER_PEER", "4");
+    ScopedEnvVar queue_capacity("MC_TCP_MAX_QUEUED_TRANSFERS_PER_PEER", "8");
+    ScopedEnvVar status_timeout("MC_TCP_STATUS_TIMEOUT_SEC", "30");
+    ScopedLaneHooks hooks;
+    tcpTransportSetLaneConnectFailureInjectionHookForTest(
+        failLaneOneAndTwoConnectAttempt);
+    const char* env = std::getenv("MC_METADATA_SERVER");
+    const std::string metadata_server = env ? env : "P2PHANDSHAKE";
+
+    HoldingWriteServer fake_peer;
+    ASSERT_TRUE(fake_peer.ok());
+
+    EngineHandle h;
+    h.init(metadata_server, "127.0.0.2:17937", kLength);
+    ASSERT_TRUE(h.ok);
+    pointTcpSegmentAt(h, fake_peer.port());
+
+    memset(h.pool, 0x6D, kLength);
+    const TransferRequest request = makeWriteRequest(h, kLength);
+    const std::vector<TransferRequest> requests(kRequestCount, request);
+    const auto batch_id = h.engine->allocateBatchID(kRequestCount);
+    ASSERT_TRUE(h.engine->submitTransfer(batch_id, requests).ok());
+
+    // Lanes 1 and 2 fail on every probe. A starvation-prone selector retries
+    // lane 1 forever and never reaches the other retryable lane or lane 3.
+    // Each lane gets one probe per round, so lanes 0 and 3 are accepted.
+    ASSERT_TRUE(fake_peer.waitForAccepted(2, std::chrono::seconds(5)));
+    ASSERT_TRUE(waitForPredicate(
+        [] {
+            return lane_connect_injection_call_count.load(
+                       std::memory_order_acquire) >= 4;
+        },
+        std::chrono::seconds(5)));
+    EXPECT_EQ(fake_peer.activeAcceptedCount(), 2);
+    EXPECT_GE(lane_connect_injection_call_count.load(std::memory_order_acquire),
+              4);
+    EXPECT_LE(maximum_observed_socket_count.load(std::memory_order_acquire),
+              4u);
 
     fake_peer.closePeer();
     ASSERT_TRUE(waitForBatchTerminal(h.engine.get(), batch_id, kRequestCount,

--- a/mooncake-transfer-engine/tests/tcp_write_visibility_test.cpp
+++ b/mooncake-transfer-engine/tests/tcp_write_visibility_test.cpp
@@ -39,13 +39,33 @@
 #include <chrono>
 #include <cstdlib>
 #include <cstring>
+#include <future>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <thread>
 #include <vector>
 
 #include "transfer_engine.h"
 #include "transport/transport.h"
+
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+namespace mooncake {
+void tcpTransportSetLaneConnectHandlerHookForTest(
+    void (*hook)() noexcept) noexcept;
+void tcpTransportSetLaneConnectFailureInjectionHookForTest(
+    bool (*hook)() noexcept) noexcept;
+void tcpTransportSetLaneObserverHookForTest(
+    void (*hook)(int, size_t, uint64_t, size_t, bool) noexcept) noexcept;
+void tcpTransportSetLaneRetryHandlerHookForTest(
+    void (*hook)() noexcept) noexcept;
+void tcpTransportSetLaneAdmissionHandlerHookForTest(
+    void (*hook)() noexcept) noexcept;
+void tcpTransportSetLaneFailureReasonHookForTest(
+    void (*hook)(int) noexcept) noexcept;
+bool tcpTransportLaneTypesAreMoveOnlyForTest() noexcept;
+}  // namespace mooncake
+#endif
 
 using namespace mooncake;
 
@@ -56,6 +76,328 @@ constexpr size_t kSmallLength = 16 * 1024;  // 16 KB control size
 constexpr size_t kRegionAlign = 4 * 1024 * 1024;
 constexpr int kIterations = 400;
 constexpr int kNoiseThreads = 3;
+
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+enum LaneTestEvent {
+    kLaneQueueAdmitted = 1,
+    kLaneQueueRejected = 2,
+    kLaneConnecting = 3,
+    kLaneBusy = 4,
+    kLaneTerminal = 5,
+    kLaneShutdownClean = 6,
+    kLaneLateHandler = 7,
+    kLaneRetryArmed = 8,
+    kLaneRetryFired = 9,
+    kLaneRetryLate = 10,
+    kLaneCooldownStarted = 11,
+    kLaneAdmissionPending = 12,
+    kLaneAdmissionPromoted = 13,
+    kLaneAdmissionTimerArmed = 14,
+    kLaneAdmissionTimerFired = 15,
+    kLaneAdmissionTimerLate = 16,
+    kLaneAdmissionHardRejected = 17,
+};
+
+enum WorkFailureReasonForTest {
+    kWorkQueueFull = 0,
+    kWorkQueueTimeout = 1,
+    kWorkRuntimeUnavailable = 2,
+    kWorkConnectFailed = 3,
+    kWorkSessionFailed = 4,
+    kWorkShutdown = 5,
+};
+
+std::atomic<bool> lane_connect_handler_entered{false};
+std::atomic<int> lane_connect_injection_call_count{0};
+std::atomic<bool> release_lane_connect_handler{false};
+std::atomic<bool> hold_lane_connect_handler{false};
+std::atomic<bool> hold_lane_connect_after_busy{false};
+std::atomic<bool> connecting_lane_had_current{false};
+std::atomic<bool> retry_handler_entered{false};
+std::atomic<bool> release_retry_handler{false};
+std::atomic<bool> hold_retry_handler{false};
+std::atomic<bool> retry_armed_observer_entered{false};
+std::atomic<bool> release_retry_armed_observer{false};
+std::atomic<bool> hold_retry_armed_observer{false};
+std::atomic<bool> admission_handler_entered{false};
+std::atomic<bool> release_admission_handler{false};
+std::atomic<bool> hold_admission_handler{false};
+std::atomic<size_t> maximum_observed_queue_depth{0};
+std::atomic<size_t> maximum_observed_pending_depth{0};
+std::atomic<size_t> maximum_observed_socket_count{0};
+std::atomic<int> queue_rejection_count{0};
+std::atomic<int> lane_connecting_count{0};
+std::atomic<int> lane_busy_count{0};
+std::atomic<int> lane_terminal_count{0};
+std::atomic<int> lane_shutdown_clean_count{0};
+std::atomic<int> late_lane_handler_count{0};
+std::atomic<int> retry_armed_count{0};
+std::atomic<int> retry_fired_count{0};
+std::atomic<int> retry_late_count{0};
+std::atomic<int> cooldown_started_count{0};
+std::atomic<int> admission_pending_count{0};
+std::atomic<int> admission_promoted_count{0};
+std::atomic<int> admission_timer_armed_count{0};
+std::atomic<int> admission_timer_fired_count{0};
+std::atomic<int> admission_timer_late_count{0};
+std::atomic<int> admission_hard_rejection_count{0};
+std::atomic<int> queue_full_failure_count{0};
+std::atomic<int> queue_timeout_failure_count{0};
+std::atomic<int> connect_failure_count{0};
+std::atomic<int> runtime_unavailable_failure_count{0};
+std::atomic<int> session_failure_count{0};
+std::atomic<int> shutdown_failure_count{0};
+
+template <typename Predicate, typename Rep, typename Period>
+bool waitForPredicate(Predicate&& predicate,
+                      std::chrono::duration<Rep, Period> timeout) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (predicate()) return true;
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    return predicate();
+}
+
+template <typename T>
+void updateMaximum(std::atomic<T>& value, T candidate) noexcept {
+    T previous = value.load(std::memory_order_relaxed);
+    while (previous < candidate &&
+           !value.compare_exchange_weak(previous, candidate,
+                                        std::memory_order_relaxed)) {
+    }
+}
+
+void resetLaneTestState() noexcept {
+    lane_connect_handler_entered.store(false, std::memory_order_release);
+    lane_connect_injection_call_count.store(0, std::memory_order_release);
+    release_lane_connect_handler.store(false, std::memory_order_release);
+    hold_lane_connect_handler.store(false, std::memory_order_release);
+    hold_lane_connect_after_busy.store(false, std::memory_order_release);
+    connecting_lane_had_current.store(false, std::memory_order_release);
+    retry_handler_entered.store(false, std::memory_order_release);
+    release_retry_handler.store(false, std::memory_order_release);
+    hold_retry_handler.store(false, std::memory_order_release);
+    retry_armed_observer_entered.store(false, std::memory_order_release);
+    release_retry_armed_observer.store(false, std::memory_order_release);
+    hold_retry_armed_observer.store(false, std::memory_order_release);
+    admission_handler_entered.store(false, std::memory_order_release);
+    release_admission_handler.store(false, std::memory_order_release);
+    hold_admission_handler.store(false, std::memory_order_release);
+    maximum_observed_queue_depth.store(0, std::memory_order_release);
+    maximum_observed_pending_depth.store(0, std::memory_order_release);
+    maximum_observed_socket_count.store(0, std::memory_order_release);
+    queue_rejection_count.store(0, std::memory_order_release);
+    lane_connecting_count.store(0, std::memory_order_release);
+    lane_busy_count.store(0, std::memory_order_release);
+    lane_terminal_count.store(0, std::memory_order_release);
+    lane_shutdown_clean_count.store(0, std::memory_order_release);
+    late_lane_handler_count.store(0, std::memory_order_release);
+    retry_armed_count.store(0, std::memory_order_release);
+    retry_fired_count.store(0, std::memory_order_release);
+    retry_late_count.store(0, std::memory_order_release);
+    cooldown_started_count.store(0, std::memory_order_release);
+    admission_pending_count.store(0, std::memory_order_release);
+    admission_promoted_count.store(0, std::memory_order_release);
+    admission_timer_armed_count.store(0, std::memory_order_release);
+    admission_timer_fired_count.store(0, std::memory_order_release);
+    admission_timer_late_count.store(0, std::memory_order_release);
+    admission_hard_rejection_count.store(0, std::memory_order_release);
+    queue_full_failure_count.store(0, std::memory_order_release);
+    queue_timeout_failure_count.store(0, std::memory_order_release);
+    connect_failure_count.store(0, std::memory_order_release);
+    runtime_unavailable_failure_count.store(0, std::memory_order_release);
+    session_failure_count.store(0, std::memory_order_release);
+    shutdown_failure_count.store(0, std::memory_order_release);
+}
+
+bool failSecondLaneConnectAttemptOnce() noexcept {
+    const int attempt = lane_connect_injection_call_count.fetch_add(1) + 1;
+    return attempt == 2;
+}
+
+void releaseLaneConnectHandler() noexcept {
+    release_lane_connect_handler.store(true, std::memory_order_release);
+}
+
+void blockLaneConnectHandler() noexcept {
+    if (!hold_lane_connect_handler.load(std::memory_order_acquire)) return;
+    lane_connect_handler_entered.store(true, std::memory_order_release);
+    while (!release_lane_connect_handler.load(std::memory_order_acquire)) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+}
+
+void releaseRetryHandler() noexcept {
+    release_retry_handler.store(true, std::memory_order_release);
+}
+
+void blockRetryHandler() noexcept {
+    if (!hold_retry_handler.load(std::memory_order_acquire)) return;
+    retry_handler_entered.store(true, std::memory_order_release);
+    while (!release_retry_handler.load(std::memory_order_acquire)) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+}
+
+void releaseRetryArmedObserver() noexcept {
+    release_retry_armed_observer.store(true, std::memory_order_release);
+}
+
+void releaseAdmissionHandler() noexcept {
+    release_admission_handler.store(true, std::memory_order_release);
+}
+
+void blockAdmissionHandler() noexcept {
+    if (!hold_admission_handler.load(std::memory_order_acquire)) return;
+    admission_handler_entered.store(true, std::memory_order_release);
+    while (!release_admission_handler.load(std::memory_order_acquire)) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+}
+
+void observeLaneState(int event, size_t queue_depth, uint64_t,
+                      size_t active_sockets, bool lane_has_current) noexcept {
+    if (event < kLaneAdmissionPending || event > kLaneAdmissionHardRejected)
+        updateMaximum(maximum_observed_queue_depth, queue_depth);
+    updateMaximum(maximum_observed_socket_count, active_sockets);
+    if (event == kLaneConnecting && lane_has_current)
+        connecting_lane_had_current.store(true, std::memory_order_release);
+    if (event == kLaneConnecting)
+        lane_connecting_count.fetch_add(1, std::memory_order_relaxed);
+    if (event == kLaneBusy) {
+        lane_busy_count.fetch_add(1, std::memory_order_relaxed);
+        if (hold_lane_connect_after_busy.load(std::memory_order_acquire))
+            hold_lane_connect_handler.store(true, std::memory_order_release);
+    }
+    if (event == kLaneQueueRejected)
+        queue_rejection_count.fetch_add(1, std::memory_order_relaxed);
+    if (event == kLaneTerminal)
+        lane_terminal_count.fetch_add(1, std::memory_order_relaxed);
+    if (event == kLaneShutdownClean)
+        lane_shutdown_clean_count.fetch_add(1, std::memory_order_relaxed);
+    if (event == kLaneLateHandler)
+        late_lane_handler_count.fetch_add(1, std::memory_order_relaxed);
+    if (event == kLaneRetryArmed) {
+        retry_armed_count.fetch_add(1, std::memory_order_relaxed);
+        if (hold_retry_armed_observer.load(std::memory_order_acquire)) {
+            retry_armed_observer_entered.store(true, std::memory_order_release);
+            while (
+                !release_retry_armed_observer.load(std::memory_order_acquire)) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            }
+        }
+    }
+    if (event == kLaneRetryFired)
+        retry_fired_count.fetch_add(1, std::memory_order_relaxed);
+    if (event == kLaneRetryLate)
+        retry_late_count.fetch_add(1, std::memory_order_relaxed);
+    if (event == kLaneCooldownStarted)
+        cooldown_started_count.fetch_add(1, std::memory_order_relaxed);
+    if (event == kLaneAdmissionPending) {
+        admission_pending_count.fetch_add(1, std::memory_order_relaxed);
+        updateMaximum(maximum_observed_pending_depth, queue_depth);
+    }
+    if (event == kLaneAdmissionPromoted) {
+        admission_promoted_count.fetch_add(1, std::memory_order_relaxed);
+        updateMaximum(maximum_observed_pending_depth, queue_depth);
+    }
+    if (event == kLaneAdmissionTimerArmed)
+        admission_timer_armed_count.fetch_add(1, std::memory_order_relaxed);
+    if (event == kLaneAdmissionTimerFired)
+        admission_timer_fired_count.fetch_add(1, std::memory_order_relaxed);
+    if (event == kLaneAdmissionTimerLate)
+        admission_timer_late_count.fetch_add(1, std::memory_order_relaxed);
+    if (event == kLaneAdmissionHardRejected)
+        admission_hard_rejection_count.fetch_add(1, std::memory_order_relaxed);
+}
+
+void observeWorkFailureReason(int reason) noexcept {
+    if (reason == kWorkQueueFull)
+        queue_full_failure_count.fetch_add(1, std::memory_order_relaxed);
+    if (reason == kWorkQueueTimeout)
+        queue_timeout_failure_count.fetch_add(1, std::memory_order_relaxed);
+    if (reason == kWorkConnectFailed)
+        connect_failure_count.fetch_add(1, std::memory_order_relaxed);
+    if (reason == kWorkRuntimeUnavailable)
+        runtime_unavailable_failure_count.fetch_add(1,
+                                                    std::memory_order_relaxed);
+    if (reason == kWorkSessionFailed)
+        session_failure_count.fetch_add(1, std::memory_order_relaxed);
+    if (reason == kWorkShutdown)
+        shutdown_failure_count.fetch_add(1, std::memory_order_relaxed);
+}
+
+class ScopedLaneHooks {
+   public:
+    explicit ScopedLaneHooks(bool block_first_connect_handler = false,
+                             bool block_after_busy = false,
+                             bool block_retry = false,
+                             bool block_retry_armed = false,
+                             bool block_admission = false,
+                             bool fail_second_connect = false) {
+        resetLaneTestState();
+        tcpTransportSetLaneObserverHookForTest(observeLaneState);
+        tcpTransportSetLaneFailureReasonHookForTest(observeWorkFailureReason);
+        if (fail_second_connect) {
+            tcpTransportSetLaneConnectFailureInjectionHookForTest(
+                failSecondLaneConnectAttemptOnce);
+        }
+        if (block_first_connect_handler || block_after_busy) {
+            hold_lane_connect_handler.store(block_first_connect_handler,
+                                            std::memory_order_release);
+            hold_lane_connect_after_busy.store(block_after_busy,
+                                               std::memory_order_release);
+            tcpTransportSetLaneConnectHandlerHookForTest(
+                blockLaneConnectHandler);
+        }
+        if (block_retry) {
+            hold_retry_handler.store(true, std::memory_order_release);
+            tcpTransportSetLaneRetryHandlerHookForTest(blockRetryHandler);
+        }
+        hold_retry_armed_observer.store(block_retry_armed,
+                                        std::memory_order_release);
+        if (block_admission) {
+            hold_admission_handler.store(true, std::memory_order_release);
+            tcpTransportSetLaneAdmissionHandlerHookForTest(
+                blockAdmissionHandler);
+        }
+    }
+
+    ~ScopedLaneHooks() { reset(); }
+
+    void reset() noexcept {
+        if (!active_) return;
+        releaseLaneConnectHandler();
+        releaseRetryHandler();
+        releaseRetryArmedObserver();
+        releaseAdmissionHandler();
+        tcpTransportSetLaneConnectHandlerHookForTest(nullptr);
+        tcpTransportSetLaneConnectFailureInjectionHookForTest(nullptr);
+        tcpTransportSetLaneRetryHandlerHookForTest(nullptr);
+        tcpTransportSetLaneAdmissionHandlerHookForTest(nullptr);
+        tcpTransportSetLaneObserverHookForTest(nullptr);
+        tcpTransportSetLaneFailureReasonHookForTest(nullptr);
+        active_ = false;
+    }
+
+   private:
+    bool active_ = true;
+};
+#endif
+
+void reclaimBatchDescAfterEngineShutdownForTest(Transport::BatchID batch_id) {
+#ifndef CONFIG_USE_BATCH_DESC_SET
+    // These shutdown tests deliberately destroy TransferEngine with work still
+    // outstanding, so normal freeBatchID cannot be called. The caller must
+    // wait for engine destruction to return (and thus for its worker to join)
+    // before reclaiming a descriptor that no callback can touch anymore.
+    delete &Transport::toBatchDesc(batch_id);
+#else
+    // The batch descriptor registry owns (and may already reclaim) this object.
+    (void)batch_id;
+#endif
+}
 
 class ScopedEnvVar {
    public:
@@ -209,6 +551,350 @@ class LegacyReadServer {
     std::atomic<bool> saw_flagged_write_{false};
 };
 
+// Accepts TCP connections but deliberately never reads request headers or
+// bodies. Large writes therefore remain in progress until closePeer() drops
+// the accepted sockets.
+class HoldingWriteServer {
+   public:
+    HoldingWriteServer() {
+        listen_fd_ = socket(AF_INET, SOCK_STREAM, 0);
+        if (listen_fd_ < 0) return;
+        int one = 1;
+        if (setsockopt(listen_fd_, SOL_SOCKET, SO_REUSEADDR, &one,
+                       sizeof(one)) != 0)
+            return;
+
+        sockaddr_in addr{};
+        addr.sin_family = AF_INET;
+        addr.sin_port = 0;
+        addr.sin_addr.s_addr = htonl(INADDR_ANY);
+        if (bind(listen_fd_, reinterpret_cast<sockaddr*>(&addr),
+                 sizeof(addr)) != 0)
+            return;
+        if (listen(listen_fd_, 64) != 0) return;
+
+        socklen_t len = sizeof(addr);
+        if (getsockname(listen_fd_, reinterpret_cast<sockaddr*>(&addr), &len) !=
+            0)
+            return;
+        port_ = ntohs(addr.sin_port);
+        ok_ = true;
+        thread_ = std::thread([this] { acceptLoop(); });
+    }
+
+    ~HoldingWriteServer() {
+        closePeer();
+        if (listen_fd_ >= 0) close(listen_fd_);
+    }
+
+    bool ok() const { return ok_; }
+    uint16_t port() const { return port_; }
+    int acceptedCount() const { return accepted_count_.load(); }
+    int maxAcceptedCount() const { return max_accepted_count_.load(); }
+
+    bool waitForAccepted(int count, std::chrono::seconds timeout) const {
+        const auto deadline = std::chrono::steady_clock::now() + timeout;
+        while (acceptedCount() < count &&
+               std::chrono::steady_clock::now() < deadline) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        return acceptedCount() >= count;
+    }
+
+    int activeAcceptedCount() const {
+        std::lock_guard<std::mutex> lock(accepted_mutex_);
+        return static_cast<int>(accepted_fds_.size());
+    }
+
+    bool closeOneAccepted() {
+        int fd = -1;
+        {
+            std::lock_guard<std::mutex> lock(accepted_mutex_);
+            if (accepted_fds_.empty()) return false;
+            fd = accepted_fds_.front();
+            accepted_fds_.erase(accepted_fds_.begin());
+        }
+        (void)shutdown(fd, SHUT_RDWR);
+        close(fd);
+        return true;
+    }
+
+    void closePeer() {
+        if (closed_.exchange(true)) return;
+        if (listen_fd_ >= 0) (void)shutdown(listen_fd_, SHUT_RDWR);
+        if (thread_.joinable()) thread_.join();
+
+        std::vector<int> accepted;
+        {
+            std::lock_guard<std::mutex> lock(accepted_mutex_);
+            accepted.swap(accepted_fds_);
+        }
+        for (int fd : accepted) {
+            (void)shutdown(fd, SHUT_RDWR);
+            close(fd);
+        }
+    }
+
+   private:
+    void acceptLoop() {
+        while (!closed_.load()) {
+            int fd = accept(listen_fd_, nullptr, nullptr);
+            if (fd < 0) break;
+            if (closed_.load()) {
+                close(fd);
+                break;
+            }
+
+            {
+                std::lock_guard<std::mutex> lock(accepted_mutex_);
+                accepted_fds_.push_back(fd);
+            }
+            const int count = accepted_count_.fetch_add(1) + 1;
+            int previous_max = max_accepted_count_.load();
+            while (previous_max < count &&
+                   !max_accepted_count_.compare_exchange_weak(previous_max,
+                                                              count)) {
+            }
+        }
+    }
+
+    int listen_fd_ = -1;
+    uint16_t port_ = 0;
+    bool ok_ = false;
+    std::thread thread_;
+    mutable std::mutex accepted_mutex_;
+    std::vector<int> accepted_fds_;
+    std::atomic<bool> closed_{false};
+    std::atomic<int> accepted_count_{0};
+    std::atomic<int> max_accepted_count_{0};
+};
+
+// Keeps a local TCP port bound but deliberately never listens. Linux rejects
+// connect attempts deterministically, without blackhole-address timing.
+class UnavailableTcpPeer {
+   public:
+    UnavailableTcpPeer() {
+        fd_ = socket(AF_INET, SOCK_STREAM, 0);
+        if (fd_ < 0) return;
+
+        sockaddr_in addr{};
+        addr.sin_family = AF_INET;
+        addr.sin_port = 0;
+        addr.sin_addr.s_addr = htonl(INADDR_ANY);
+        if (bind(fd_, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0)
+            return;
+
+        socklen_t len = sizeof(addr);
+        if (getsockname(fd_, reinterpret_cast<sockaddr*>(&addr), &len) != 0)
+            return;
+        port_ = ntohs(addr.sin_port);
+        ok_ = true;
+    }
+
+    ~UnavailableTcpPeer() {
+        if (fd_ >= 0) close(fd_);
+    }
+
+    bool ok() const { return ok_; }
+    uint16_t port() const { return port_; }
+
+   private:
+    int fd_ = -1;
+    uint16_t port_ = 0;
+    bool ok_ = false;
+};
+
+// Minimal v2 WRITE server that keeps accepted connections open and processes
+// multiple request/ack exchanges on each one.
+class ReusingWriteServer {
+   public:
+    explicit ReusingWriteServer(bool hold_first_ack = false)
+        : hold_first_ack_(hold_first_ack) {
+        listen_fd_ = socket(AF_INET, SOCK_STREAM, 0);
+        if (listen_fd_ < 0) return;
+        int one = 1;
+        if (setsockopt(listen_fd_, SOL_SOCKET, SO_REUSEADDR, &one,
+                       sizeof(one)) != 0)
+            return;
+
+        sockaddr_in addr{};
+        addr.sin_family = AF_INET;
+        addr.sin_port = 0;
+        addr.sin_addr.s_addr = htonl(INADDR_ANY);
+        if (bind(listen_fd_, reinterpret_cast<sockaddr*>(&addr),
+                 sizeof(addr)) != 0)
+            return;
+        if (listen(listen_fd_, 16) != 0) return;
+
+        socklen_t len = sizeof(addr);
+        if (getsockname(listen_fd_, reinterpret_cast<sockaddr*>(&addr), &len) !=
+            0)
+            return;
+        port_ = ntohs(addr.sin_port);
+        ok_ = true;
+        accept_thread_ = std::thread([this] { acceptLoop(); });
+    }
+
+    ~ReusingWriteServer() { stop(); }
+
+    bool ok() const { return ok_; }
+    uint16_t port() const { return port_; }
+    int acceptedCount() const { return accepted_count_.load(); }
+
+    bool waitForRequests(int count, std::chrono::seconds timeout) const {
+        const auto deadline = std::chrono::steady_clock::now() + timeout;
+        while (request_count_.load() < count &&
+               std::chrono::steady_clock::now() < deadline) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        return request_count_.load() >= count;
+    }
+
+    bool waitForFirstRequest(std::chrono::seconds timeout) const {
+        return waitForPredicate(
+            [this] {
+                return first_request_received_.load(std::memory_order_acquire);
+            },
+            timeout);
+    }
+
+    void releaseFirstAck() noexcept {
+        release_first_ack_.store(true, std::memory_order_release);
+    }
+
+    bool waitForFirstAckSent(std::chrono::seconds timeout) const {
+        return waitForPredicate(
+            [this] { return first_ack_sent_.load(std::memory_order_acquire); },
+            timeout);
+    }
+
+    std::vector<uint64_t> requestAddresses() const {
+        std::lock_guard<std::mutex> lock(request_mutex_);
+        return request_addresses_;
+    }
+
+   private:
+    static bool recvExact(int fd, void* buffer, size_t size) {
+        char* out = static_cast<char*>(buffer);
+        while (size) {
+            ssize_t n = recv(fd, out, size, 0);
+            if (n <= 0) return false;
+            out += n;
+            size -= static_cast<size_t>(n);
+        }
+        return true;
+    }
+
+    static bool sendExact(int fd, const void* buffer, size_t size) {
+        const char* in = static_cast<const char*>(buffer);
+        while (size) {
+            ssize_t n = send(fd, in, size, MSG_NOSIGNAL);
+            if (n <= 0) return false;
+            in += n;
+            size -= static_cast<size_t>(n);
+        }
+        return true;
+    }
+
+    void acceptLoop() {
+        while (!stopped_.load()) {
+            int fd = accept(listen_fd_, nullptr, nullptr);
+            if (fd < 0) break;
+            if (stopped_.load()) {
+                close(fd);
+                break;
+            }
+            {
+                std::lock_guard<std::mutex> lock(connection_mutex_);
+                accepted_fds_.push_back(fd);
+                connection_threads_.emplace_back(
+                    [this, fd] { serveConnection(fd); });
+            }
+            accepted_count_.fetch_add(1);
+        }
+    }
+
+    void serveConnection(int fd) {
+        std::vector<char> payload(64 * 1024);
+        bool keep_serving = true;
+        while (!stopped_.load()) {
+            TestSessionHeader header{};
+            if (!recvExact(fd, &header, sizeof(header))) break;
+            {
+                std::lock_guard<std::mutex> lock(request_mutex_);
+                request_addresses_.push_back(le64toh(header.addr));
+            }
+            uint64_t remaining = le64toh(header.size);
+            while (remaining) {
+                const size_t chunk =
+                    std::min<uint64_t>(payload.size(), remaining);
+                if (!recvExact(fd, payload.data(), chunk)) {
+                    keep_serving = false;
+                    break;
+                }
+                remaining -= chunk;
+            }
+            if (!keep_serving) break;
+
+            const int request_index =
+                requests_received_.fetch_add(1, std::memory_order_acq_rel);
+            if (hold_first_ack_ && request_index == 0) {
+                first_request_received_.store(true, std::memory_order_release);
+                while (!release_first_ack_.load(std::memory_order_acquire) &&
+                       !stopped_.load(std::memory_order_acquire)) {
+                    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+                }
+            }
+
+            constexpr uint64_t kStatusOk = 0x4D435456ull << 32;
+            const uint64_t status = htole64(kStatusOk);
+            if (!sendExact(fd, &status, sizeof(status))) break;
+            if (hold_first_ack_ && request_index == 0)
+                first_ack_sent_.store(true, std::memory_order_release);
+            request_count_.fetch_add(1);
+        }
+        {
+            std::lock_guard<std::mutex> lock(connection_mutex_);
+            auto it = std::find(accepted_fds_.begin(), accepted_fds_.end(), fd);
+            if (it != accepted_fds_.end()) accepted_fds_.erase(it);
+        }
+        close(fd);
+    }
+
+    void stop() {
+        if (stopped_.exchange(true)) return;
+        releaseFirstAck();
+        if (listen_fd_ >= 0) (void)shutdown(listen_fd_, SHUT_RDWR);
+        if (accept_thread_.joinable()) accept_thread_.join();
+
+        {
+            std::lock_guard<std::mutex> lock(connection_mutex_);
+            for (int fd : accepted_fds_) (void)shutdown(fd, SHUT_RDWR);
+        }
+        for (auto& thread : connection_threads_)
+            if (thread.joinable()) thread.join();
+        if (listen_fd_ >= 0) close(listen_fd_);
+    }
+
+    int listen_fd_ = -1;
+    uint16_t port_ = 0;
+    bool ok_ = false;
+    std::thread accept_thread_;
+    std::mutex connection_mutex_;
+    mutable std::mutex request_mutex_;
+    std::vector<int> accepted_fds_;
+    std::vector<std::thread> connection_threads_;
+    std::vector<uint64_t> request_addresses_;
+    std::atomic<bool> stopped_{false};
+    std::atomic<int> accepted_count_{0};
+    std::atomic<int> request_count_{0};
+    const bool hold_first_ack_;
+    std::atomic<int> requests_received_{0};
+    std::atomic<bool> first_request_received_{false};
+    std::atomic<bool> release_first_ack_{false};
+    std::atomic<bool> first_ack_sent_{false};
+};
+
 struct EngineHandle {
     std::unique_ptr<TransferEngine> engine;
     void* pool = nullptr;
@@ -254,6 +940,26 @@ struct EngineHandle {
     }
 };
 
+void pointTcpSegmentAt(EngineHandle& handle, uint16_t port) {
+    auto desc =
+        handle.engine->getMetadata()->getSegmentDescByID(handle.segment_id);
+    ASSERT_NE(desc, nullptr);
+    desc->tcp_data_port = port;
+    desc->tcp_proto_version = 2;
+}
+
+TransferRequest makeWriteRequest(const EngineHandle& handle, size_t length,
+                                 uint64_t target_offset = 0) {
+    TransferRequest request;
+    request.opcode = TransferRequest::WRITE;
+    request.length = length;
+    request.source = handle.pool;
+    request.target_id = handle.segment_id;
+    request.target_offset =
+        target_offset == 0 ? handle.remote_base : target_offset;
+    return request;
+}
+
 // Submit one request and poll until terminal state; returns final status.
 TransferStatusEnum runOne(TransferEngine* engine, TransferRequest entry) {
     auto batch_id = engine->allocateBatchID(1);
@@ -272,6 +978,75 @@ TransferStatusEnum runOne(TransferEngine* engine, TransferRequest entry) {
     }
     (void)engine->freeBatchID(batch_id);
     return status.s;
+}
+
+bool waitForBatchTerminal(TransferEngine* engine, Transport::BatchID batch_id,
+                          size_t task_count, std::chrono::seconds timeout) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+        bool all_terminal = true;
+        for (size_t task_id = 0; task_id < task_count; ++task_id) {
+            TransferStatus status;
+            status.s = TransferStatusEnum::WAITING;
+            if (!engine->getTransferStatus(batch_id, task_id, status).ok() ||
+                (status.s != TransferStatusEnum::COMPLETED &&
+                 status.s != TransferStatusEnum::FAILED)) {
+                all_terminal = false;
+            }
+        }
+        if (all_terminal) return true;
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+
+    for (size_t task_id = 0; task_id < task_count; ++task_id) {
+        TransferStatus status;
+        status.s = TransferStatusEnum::WAITING;
+        if (!engine->getTransferStatus(batch_id, task_id, status).ok() ||
+            (status.s != TransferStatusEnum::COMPLETED &&
+             status.s != TransferStatusEnum::FAILED)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void expectEverySliceCompletedExactlyOnceAfterShutdown(
+    Transport::BatchID batch_id) {
+    const auto& batch = Transport::toBatchDesc(batch_id);
+    for (size_t task_id = 0; task_id < batch.task_list.size(); ++task_id) {
+        const auto& task = batch.task_list[task_id];
+        const uint64_t success =
+            __atomic_load_n(&task.success_slice_count, __ATOMIC_RELAXED);
+        const uint64_t failed =
+            __atomic_load_n(&task.failed_slice_count, __ATOMIC_RELAXED);
+        const uint64_t slices =
+            __atomic_load_n(&task.slice_count, __ATOMIC_RELAXED);
+        EXPECT_EQ(success + failed, slices) << "task " << task_id;
+        for (const auto* slice : task.slice_list) {
+            EXPECT_TRUE(slice->status == Transport::Slice::SUCCESS ||
+                        slice->status == Transport::Slice::FAILED)
+                << "task " << task_id;
+        }
+    }
+}
+
+void expectEverySliceSucceededExactlyOnceAfterShutdown(
+    Transport::BatchID batch_id) {
+    const auto& batch = Transport::toBatchDesc(batch_id);
+    for (size_t task_id = 0; task_id < batch.task_list.size(); ++task_id) {
+        const auto& task = batch.task_list[task_id];
+        const uint64_t success =
+            __atomic_load_n(&task.success_slice_count, __ATOMIC_RELAXED);
+        const uint64_t failed =
+            __atomic_load_n(&task.failed_slice_count, __ATOMIC_RELAXED);
+        const uint64_t slices =
+            __atomic_load_n(&task.slice_count, __ATOMIC_RELAXED);
+        EXPECT_EQ(success, slices) << "task " << task_id;
+        EXPECT_EQ(failed, 0u) << "task " << task_id;
+        for (const auto* slice : task.slice_list)
+            EXPECT_EQ(slice->status, Transport::Slice::SUCCESS)
+                << "task " << task_id;
+    }
 }
 
 }  // namespace
@@ -486,16 +1261,26 @@ TEST(TcpWriteVisibilityTest, V2ReadRoundTripAndRejectedRead) {
     EXPECT_EQ(runOne(h.engine.get(), r), TransferStatusEnum::COMPLETED);
 }
 
-// Mixed-version quadrant: a legacy (v1) initiator against the v2 server —
-// selected via the MC_TCP_PROTO=1 escape hatch — still transfers data
-// correctly (with the old weaker completion semantics).
-TEST(TcpWriteVisibilityTest, LegacyInitiatorInteropWithV2Server) {
+// Mixed-version quadrant: a pooled legacy (v1) initiator against the current
+// server still transfers data correctly over repeated exchanges on one fixed
+// lane (with the old weaker WRITE completion semantics).
+TEST(TcpWriteVisibilityTest,
+     PooledLegacyInitiatorInteroperatesWithCurrentServer) {
     const char* env = std::getenv("MC_METADATA_SERVER");
     std::string metadata_server = env ? env : "P2PHANDSHAKE";
     // Set the process environment before the engine starts any threads, and
     // restore it only after those threads have stopped. POSIX does not require
     // setenv()/unsetenv() to synchronize with concurrent getenv() calls.
+    ScopedEnvVar pooling("MC_TCP_ENABLE_CONNECTION_POOL", "1");
+    ScopedEnvVar lanes("MC_TCP_LANES_PER_PEER", "1");
+    ScopedEnvVar queue_capacity("MC_TCP_MAX_QUEUED_TRANSFERS_PER_PEER", "2");
+    ScopedEnvVar pending_capacity("MC_TCP_MAX_PENDING_ADMISSIONS_PER_PEER",
+                                  "2");
+    ScopedEnvVar admission_timeout("MC_TCP_ADMISSION_TIMEOUT_MS", "10000");
     ScopedEnvVar legacy_proto("MC_TCP_PROTO", "1");
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+    ScopedLaneHooks hooks;
+#endif
     {
         EngineHandle h;
         h.init(metadata_server, "127.0.0.2:17903", 16ull << 20);
@@ -531,7 +1316,15 @@ TEST(TcpWriteVisibilityTest, LegacyInitiatorInteropWithV2Server) {
         r.target_offset = h.remote_base;
         EXPECT_EQ(runOne(h.engine.get(), r), TransferStatusEnum::COMPLETED);
         EXPECT_EQ(memcmp(dst, src, kSmallLength), 0);
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+        EXPECT_EQ(lane_connecting_count.load(std::memory_order_acquire), 1);
+        EXPECT_LE(maximum_observed_socket_count.load(std::memory_order_acquire),
+                  1u);
+#endif
     }
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+    hooks.reset();
+#endif
 }
 
 // A cached v2 descriptor can briefly outlive a server downgrade/restart. A
@@ -636,3 +1429,1271 @@ TEST(TcpWriteVisibilityTest, StaleV2DescriptorShortRequestFailsWithinDeadline) {
         legacy_server.join();
     }
 }
+
+TEST(TcpWriteVisibilityTest, PerPeerLaneAndQueueBoundsHoldUnderLoad) {
+    constexpr int kRounds = 3;
+    constexpr int kRequestCount = 32;
+    constexpr size_t kLength = 64 * 1024;
+    ScopedEnvVar lanes("MC_TCP_LANES_PER_PEER", "2");
+    ScopedEnvVar queue_capacity("MC_TCP_MAX_QUEUED_TRANSFERS_PER_PEER", "64");
+    const char* env = std::getenv("MC_METADATA_SERVER");
+    const std::string metadata_server = env ? env : "P2PHANDSHAKE";
+
+    for (int round = 0; round < kRounds; ++round) {
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+        ScopedLaneHooks hooks;
+#endif
+        HoldingWriteServer fake_peer;
+        ASSERT_TRUE(fake_peer.ok()) << "round " << round;
+
+        EngineHandle h;
+        h.init(metadata_server, "127.0.0.2:" + std::to_string(17907 + round),
+               kLength);
+        ASSERT_TRUE(h.ok) << "engine/segment setup failed in round " << round;
+
+        auto desc = h.engine->getMetadata()->getSegmentDescByID(h.segment_id);
+        ASSERT_NE(desc, nullptr);
+        desc->tcp_data_port = fake_peer.port();
+        desc->tcp_proto_version = 2;
+
+        memset(h.pool, 0x4D + round, kLength);
+        std::vector<TransferRequest> requests(kRequestCount);
+        for (auto& request : requests) {
+            request.opcode = TransferRequest::WRITE;
+            request.length = kLength;
+            request.source = h.pool;
+            request.target_id = h.segment_id;
+            request.target_offset = h.remote_base;
+        }
+
+        auto batch_id = h.engine->allocateBatchID(kRequestCount);
+        Status submission = h.engine->submitTransfer(batch_id, requests);
+        ASSERT_TRUE(submission.ok()) << "round " << round;
+
+        EXPECT_TRUE(fake_peer.waitForAccepted(2, std::chrono::seconds(5)))
+            << "round " << round << " accepted only "
+            << fake_peer.acceptedCount() << " connections";
+        // Give any incorrectly uncapped attempts time to reach accept().
+        std::this_thread::sleep_for(std::chrono::milliseconds(250));
+        EXPECT_LE(fake_peer.maxAcceptedCount(), 2)
+            << "per-peer lane count exceeded in round " << round;
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+        EXPECT_LE(maximum_observed_queue_depth.load(std::memory_order_acquire),
+                  64u);
+        EXPECT_LE(maximum_observed_socket_count.load(std::memory_order_acquire),
+                  2u);
+        EXPECT_FALSE(
+            connecting_lane_had_current.load(std::memory_order_acquire));
+#endif
+
+        fake_peer.closePeer();
+
+        std::vector<TransferStatusEnum> final_states(
+            kRequestCount, TransferStatusEnum::WAITING);
+        bool status_query_failed = false;
+        bool all_terminal = false;
+        const auto deadline =
+            std::chrono::steady_clock::now() + std::chrono::seconds(20);
+        while (!all_terminal && std::chrono::steady_clock::now() < deadline) {
+            all_terminal = true;
+            for (int i = 0; i < kRequestCount; ++i) {
+                if (final_states[i] == TransferStatusEnum::COMPLETED ||
+                    final_states[i] == TransferStatusEnum::FAILED)
+                    continue;
+
+                TransferStatus status;
+                status.s = TransferStatusEnum::WAITING;
+                Status query = h.engine->getTransferStatus(batch_id, i, status);
+                if (!query.ok()) {
+                    status_query_failed = true;
+                    all_terminal = false;
+                    continue;
+                }
+                final_states[i] = status.s;
+                if (status.s != TransferStatusEnum::COMPLETED &&
+                    status.s != TransferStatusEnum::FAILED)
+                    all_terminal = false;
+            }
+            if (!all_terminal)
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+
+        EXPECT_FALSE(status_query_failed) << "round " << round;
+        EXPECT_TRUE(all_terminal) << "round " << round;
+        for (int i = 0; i < kRequestCount; ++i) {
+            EXPECT_NE(final_states[i], TransferStatusEnum::WAITING)
+                << "request " << i << " remained WAITING in round " << round;
+            EXPECT_TRUE(final_states[i] == TransferStatusEnum::COMPLETED ||
+                        final_states[i] == TransferStatusEnum::FAILED)
+                << "request " << i << " was not terminal in round " << round;
+        }
+        if (all_terminal) (void)h.engine->freeBatchID(batch_id);
+    }
+}
+
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+TEST(TcpWriteVisibilityTest,
+     FailedLaneReconnectsWhileSiblingLaneRemainsUsable) {
+    constexpr int kRequestCount = 3;
+    constexpr size_t kLength = 64 * 1024;
+    ScopedEnvVar lanes("MC_TCP_LANES_PER_PEER", "2");
+    ScopedEnvVar queue_capacity("MC_TCP_MAX_QUEUED_TRANSFERS_PER_PEER", "8");
+    ScopedEnvVar status_timeout("MC_TCP_STATUS_TIMEOUT_SEC", "30");
+    ScopedLaneHooks hooks;
+    const char* env = std::getenv("MC_METADATA_SERVER");
+    const std::string metadata_server = env ? env : "P2PHANDSHAKE";
+
+    HoldingWriteServer fake_peer;
+    ASSERT_TRUE(fake_peer.ok());
+
+    EngineHandle h;
+    h.init(metadata_server, "127.0.0.2:17931", kLength);
+    ASSERT_TRUE(h.ok);
+    pointTcpSegmentAt(h, fake_peer.port());
+
+    memset(h.pool, 0x6B, kLength);
+    const TransferRequest request = makeWriteRequest(h, kLength);
+    std::vector<TransferRequest> requests(kRequestCount, request);
+    const auto batch_id = h.engine->allocateBatchID(kRequestCount);
+    ASSERT_TRUE(h.engine->submitTransfer(batch_id, requests).ok());
+
+    ASSERT_TRUE(fake_peer.waitForAccepted(2, std::chrono::seconds(5)));
+    ASSERT_TRUE(waitForPredicate(
+        [] { return lane_busy_count.load(std::memory_order_acquire) >= 2; },
+        std::chrono::seconds(5)));
+    ASSERT_EQ(fake_peer.activeAcceptedCount(), 2);
+
+    // Drop one busy lane while the sibling remains busy and therefore usable.
+    // The third request remains queued and must be pulled by a replacement
+    // connection for the failed lane, without entering peer-wide cooldown.
+    ASSERT_TRUE(fake_peer.closeOneAccepted());
+    ASSERT_TRUE(waitForPredicate(
+        [] { return lane_terminal_count.load(std::memory_order_acquire) >= 1; },
+        std::chrono::seconds(5)));
+    ASSERT_TRUE(fake_peer.waitForAccepted(3, std::chrono::seconds(5)));
+    ASSERT_TRUE(waitForPredicate(
+        [] {
+            return lane_connecting_count.load(std::memory_order_acquire) >= 3 &&
+                   lane_busy_count.load(std::memory_order_acquire) >= 3;
+        },
+        std::chrono::seconds(5)));
+
+    EXPECT_EQ(fake_peer.activeAcceptedCount(), 2);
+    EXPECT_EQ(cooldown_started_count.load(std::memory_order_acquire), 0);
+    EXPECT_GE(retry_armed_count.load(std::memory_order_acquire), 1);
+    EXPECT_GE(retry_fired_count.load(std::memory_order_acquire), 1);
+    EXPECT_EQ(session_failure_count.load(std::memory_order_acquire), 1);
+    EXPECT_LE(maximum_observed_socket_count.load(std::memory_order_acquire),
+              2u);
+
+    fake_peer.closePeer();
+    ASSERT_TRUE(waitForBatchTerminal(h.engine.get(), batch_id, kRequestCount,
+                                     std::chrono::seconds(10)));
+    expectEverySliceCompletedExactlyOnceAfterShutdown(batch_id);
+
+    hooks.reset();
+    (void)h.engine->freeBatchID(batch_id);
+}
+
+TEST(TcpWriteVisibilityTest,
+     ConnectFailedLaneRetriesWhileSiblingLaneRemainsUsable) {
+    constexpr int kRequestCount = 2;
+    constexpr size_t kLength = 64 * 1024;
+    ScopedEnvVar lanes("MC_TCP_LANES_PER_PEER", "2");
+    ScopedEnvVar queue_capacity("MC_TCP_MAX_QUEUED_TRANSFERS_PER_PEER", "8");
+    ScopedEnvVar status_timeout("MC_TCP_STATUS_TIMEOUT_SEC", "30");
+    ScopedLaneHooks hooks(/*block_first_connect_handler=*/false,
+                          /*block_after_busy=*/false,
+                          /*block_retry=*/false,
+                          /*block_retry_armed=*/false,
+                          /*block_admission=*/false,
+                          /*fail_second_connect=*/true);
+    const char* env = std::getenv("MC_METADATA_SERVER");
+    const std::string metadata_server = env ? env : "P2PHANDSHAKE";
+
+    HoldingWriteServer fake_peer;
+    ASSERT_TRUE(fake_peer.ok());
+
+    EngineHandle h;
+    h.init(metadata_server, "127.0.0.2:17935", kLength);
+    ASSERT_TRUE(h.ok);
+    pointTcpSegmentAt(h, fake_peer.port());
+
+    memset(h.pool, 0x6C, kLength);
+    const TransferRequest request = makeWriteRequest(h, kLength);
+    std::vector<TransferRequest> requests(kRequestCount, request);
+    const auto batch_id = h.engine->allocateBatchID(kRequestCount);
+    ASSERT_TRUE(h.engine->submitTransfer(batch_id, requests).ok());
+
+    ASSERT_TRUE(fake_peer.waitForAccepted(2, std::chrono::seconds(5)));
+    ASSERT_TRUE(waitForPredicate(
+        [] {
+            return lane_connect_injection_call_count.load(
+                       std::memory_order_acquire) >= 3 &&
+                   lane_busy_count.load(std::memory_order_acquire) >= 2;
+        },
+        std::chrono::seconds(5)));
+
+    EXPECT_EQ(fake_peer.activeAcceptedCount(), 2);
+    EXPECT_EQ(lane_connect_injection_call_count.load(std::memory_order_acquire),
+              3);
+    EXPECT_EQ(cooldown_started_count.load(std::memory_order_acquire), 0);
+    EXPECT_GE(retry_armed_count.load(std::memory_order_acquire), 1);
+    EXPECT_GE(retry_fired_count.load(std::memory_order_acquire), 1);
+    EXPECT_EQ(connect_failure_count.load(std::memory_order_acquire), 0);
+    EXPECT_LE(maximum_observed_socket_count.load(std::memory_order_acquire),
+              2u);
+
+    fake_peer.closePeer();
+    ASSERT_TRUE(waitForBatchTerminal(h.engine.get(), batch_id, kRequestCount,
+                                     std::chrono::seconds(10)));
+    expectEverySliceCompletedExactlyOnceAfterShutdown(batch_id);
+
+    hooks.reset();
+    (void)h.engine->freeBatchID(batch_id);
+}
+#endif
+
+TEST(TcpWriteVisibilityTest,
+     QueuedWorkAndBusyLanesCompleteExactlyOnceDuringShutdown) {
+    constexpr int kRequestCount = 16;
+    constexpr size_t kLength = 64 * 1024;
+    ScopedEnvVar lanes("MC_TCP_LANES_PER_PEER", "2");
+    ScopedEnvVar queue_capacity("MC_TCP_MAX_QUEUED_TRANSFERS_PER_PEER", "64");
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+    ScopedLaneHooks hooks;
+#endif
+    const char* env = std::getenv("MC_METADATA_SERVER");
+    const std::string metadata_server = env ? env : "P2PHANDSHAKE";
+
+    HoldingWriteServer fake_peer;
+    ASSERT_TRUE(fake_peer.ok());
+
+    EngineHandle h;
+    h.init(metadata_server, "127.0.0.2:17920", kLength);
+    ASSERT_TRUE(h.ok);
+
+    auto desc = h.engine->getMetadata()->getSegmentDescByID(h.segment_id);
+    ASSERT_NE(desc, nullptr);
+    desc->tcp_data_port = fake_peer.port();
+    desc->tcp_proto_version = 2;
+
+    memset(h.pool, 0x5A, kLength);
+    std::vector<TransferRequest> requests(kRequestCount);
+    for (auto& request : requests) {
+        request.opcode = TransferRequest::WRITE;
+        request.length = kLength;
+        request.source = h.pool;
+        request.target_id = h.segment_id;
+        request.target_offset = h.remote_base;
+    }
+
+    auto batch_id = h.engine->allocateBatchID(kRequestCount);
+    ASSERT_TRUE(h.engine->submitTransfer(batch_id, requests).ok());
+    ASSERT_TRUE(fake_peer.waitForAccepted(2, std::chrono::seconds(5)));
+    EXPECT_LE(fake_peer.maxAcceptedCount(), 2);
+
+    const auto start = std::chrono::steady_clock::now();
+    h.engine.reset();
+    const auto elapsed = std::chrono::steady_clock::now() - start;
+    EXPECT_LT(elapsed, std::chrono::seconds(5));
+    expectEverySliceCompletedExactlyOnceAfterShutdown(batch_id);
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+    EXPECT_EQ(lane_shutdown_clean_count.load(std::memory_order_acquire), 1);
+    EXPECT_LE(maximum_observed_queue_depth.load(std::memory_order_acquire),
+              64u);
+    EXPECT_LE(maximum_observed_socket_count.load(std::memory_order_acquire),
+              2u);
+    hooks.reset();
+#endif
+    reclaimBatchDescAfterEngineShutdownForTest(batch_id);
+}
+
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+TEST(TcpWriteVisibilityTest,
+     ConnectingLaneShutdownDetachesOwnershipAndIgnoresLateHandler) {
+    constexpr size_t kLength = 64 * 1024;
+    ScopedEnvVar lanes("MC_TCP_LANES_PER_PEER", "1");
+    ScopedEnvVar queue_capacity("MC_TCP_MAX_QUEUED_TRANSFERS_PER_PEER", "8");
+    ScopedLaneHooks hooks(/*block_first_connect_handler=*/true);
+    const char* env = std::getenv("MC_METADATA_SERVER");
+    const std::string metadata_server = env ? env : "P2PHANDSHAKE";
+
+    HoldingWriteServer fake_peer;
+    ASSERT_TRUE(fake_peer.ok());
+
+    EngineHandle h;
+    h.init(metadata_server, "127.0.0.2:17921", kLength);
+    ASSERT_TRUE(h.ok);
+
+    auto desc = h.engine->getMetadata()->getSegmentDescByID(h.segment_id);
+    ASSERT_NE(desc, nullptr);
+    desc->tcp_data_port = fake_peer.port();
+    desc->tcp_proto_version = 2;
+
+    TransferRequest request;
+    request.opcode = TransferRequest::WRITE;
+    request.length = kLength;
+    request.source = h.pool;
+    request.target_id = h.segment_id;
+    request.target_offset = h.remote_base;
+    auto batch_id = h.engine->allocateBatchID(1);
+    ASSERT_TRUE(h.engine->submitTransfer(batch_id, {request}).ok());
+
+    ASSERT_TRUE(waitForPredicate(
+        [] {
+            return lane_connect_handler_entered.load(std::memory_order_acquire);
+        },
+        std::chrono::seconds(5)));
+    EXPECT_FALSE(connecting_lane_had_current.load(std::memory_order_acquire));
+
+    auto engine = std::move(h.engine);
+    auto destruction =
+        std::async(std::launch::async,
+                   [engine = std::move(engine)]() mutable { engine.reset(); });
+
+    // Let shutdown invalidate the lane epoch before the blocked resolve
+    // handler returns. io_context::stop() cannot interrupt that handler, so
+    // destruction must wait for this explicit release and then join it.
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    EXPECT_EQ(destruction.wait_for(std::chrono::milliseconds(0)),
+              std::future_status::timeout);
+    releaseLaneConnectHandler();
+
+    ASSERT_EQ(destruction.wait_for(std::chrono::seconds(5)),
+              std::future_status::ready);
+    destruction.get();
+
+    expectEverySliceCompletedExactlyOnceAfterShutdown(batch_id);
+    EXPECT_EQ(lane_shutdown_clean_count.load(std::memory_order_acquire), 1);
+    EXPECT_GE(late_lane_handler_count.load(std::memory_order_acquire), 1);
+    EXPECT_LE(maximum_observed_socket_count.load(std::memory_order_acquire),
+              1u);
+    hooks.reset();
+    reclaimBatchDescAfterEngineShutdownForTest(batch_id);
+}
+
+TEST(TcpWriteVisibilityTest,
+     ReconnectRoundsAreRateLimitedAndCooldownQueueIsBounded) {
+    constexpr int kCooldownRequestCount = 4;
+    ScopedEnvVar lanes("MC_TCP_LANES_PER_PEER", "1");
+    ScopedEnvVar queue_capacity("MC_TCP_MAX_QUEUED_TRANSFERS_PER_PEER", "3");
+    ScopedEnvVar pending_capacity("MC_TCP_MAX_PENDING_ADMISSIONS_PER_PEER",
+                                  "1");
+    ScopedEnvVar admission_timeout("MC_TCP_ADMISSION_TIMEOUT_MS", "500");
+    ScopedLaneHooks hooks;
+    const char* env = std::getenv("MC_METADATA_SERVER");
+    const std::string metadata_server = env ? env : "P2PHANDSHAKE";
+
+    UnavailableTcpPeer unavailable_peer;
+    ASSERT_TRUE(unavailable_peer.ok());
+
+    EngineHandle h;
+    h.init(metadata_server, "127.0.0.2:17925", 64 * 1024);
+    ASSERT_TRUE(h.ok);
+
+    auto desc = h.engine->getMetadata()->getSegmentDescByID(h.segment_id);
+    ASSERT_NE(desc, nullptr);
+    desc->tcp_data_port = unavailable_peer.port();
+    desc->tcp_proto_version = 2;
+
+    TransferRequest request;
+    request.opcode = TransferRequest::WRITE;
+    request.length = 1;
+    request.source = h.pool;
+    request.target_id = h.segment_id;
+    request.target_offset = h.remote_base;
+
+    const auto first_batch = h.engine->allocateBatchID(1);
+    ASSERT_TRUE(h.engine->submitTransfer(first_batch, {request}).ok());
+    ASSERT_TRUE(waitForBatchTerminal(h.engine.get(), first_batch, 1,
+                                     std::chrono::seconds(5)));
+    ASSERT_TRUE(waitForPredicate(
+        [] {
+            return cooldown_started_count.load(std::memory_order_acquire) >= 1;
+        },
+        std::chrono::seconds(2)));
+    EXPECT_EQ(lane_connecting_count.load(std::memory_order_acquire), 1);
+
+    std::vector<TransferRequest> cooldown_requests(kCooldownRequestCount,
+                                                   request);
+    const auto cooldown_batch =
+        h.engine->allocateBatchID(kCooldownRequestCount);
+    ASSERT_TRUE(
+        h.engine->submitTransfer(cooldown_batch, cooldown_requests).ok());
+    ASSERT_TRUE(waitForPredicate(
+        [] { return retry_armed_count.load(std::memory_order_acquire) == 1; },
+        std::chrono::seconds(2)));
+
+    // The first three requests enter the work queue; the fourth waits in the
+    // pending-admission FIFO instead of failing synchronously. No second
+    // connection round starts before the retry timer.
+    for (int task_id = 0; task_id < 3; ++task_id) {
+        TransferStatus status;
+        status.s = TransferStatusEnum::WAITING;
+        ASSERT_TRUE(
+            h.engine->getTransferStatus(cooldown_batch, task_id, status).ok());
+        EXPECT_EQ(status.s, TransferStatusEnum::WAITING);
+    }
+    TransferStatus overflow_status;
+    overflow_status.s = TransferStatusEnum::WAITING;
+    ASSERT_TRUE(
+        h.engine->getTransferStatus(cooldown_batch, 3, overflow_status).ok());
+    EXPECT_EQ(overflow_status.s, TransferStatusEnum::WAITING);
+    EXPECT_EQ(queue_full_failure_count.load(std::memory_order_acquire), 0);
+    EXPECT_EQ(admission_pending_count.load(std::memory_order_acquire), 1);
+    EXPECT_LE(maximum_observed_queue_depth.load(std::memory_order_acquire), 3u);
+    ASSERT_TRUE(waitForPredicate(
+        [] {
+            return queue_timeout_failure_count.load(
+                       std::memory_order_acquire) == 1;
+        },
+        std::chrono::seconds(2)));
+    EXPECT_EQ(lane_connecting_count.load(std::memory_order_acquire), 1);
+    EXPECT_EQ(retry_armed_count.load(std::memory_order_acquire), 1);
+
+    ASSERT_TRUE(waitForBatchTerminal(h.engine.get(), cooldown_batch,
+                                     kCooldownRequestCount,
+                                     std::chrono::seconds(5)));
+    EXPECT_EQ(retry_fired_count.load(std::memory_order_acquire), 1);
+    EXPECT_EQ(retry_armed_count.load(std::memory_order_acquire), 1);
+    EXPECT_EQ(lane_connecting_count.load(std::memory_order_acquire), 2);
+    EXPECT_EQ(connect_failure_count.load(std::memory_order_acquire), 4);
+    expectEverySliceCompletedExactlyOnceAfterShutdown(first_batch);
+    expectEverySliceCompletedExactlyOnceAfterShutdown(cooldown_batch);
+
+    hooks.reset();
+    (void)h.engine->freeBatchID(first_batch);
+    (void)h.engine->freeBatchID(cooldown_batch);
+}
+
+TEST(TcpWriteVisibilityTest,
+     RetryTimerSerializesDelayedPumpAndCooldownTransition) {
+    ScopedEnvVar lanes("MC_TCP_LANES_PER_PEER", "1");
+    ScopedEnvVar queue_capacity("MC_TCP_MAX_QUEUED_TRANSFERS_PER_PEER", "2");
+    ScopedLaneHooks hooks(/*block_first_connect_handler=*/false,
+                          /*block_after_busy=*/false,
+                          /*block_retry=*/false,
+                          /*block_retry_armed=*/true);
+    const char* env = std::getenv("MC_METADATA_SERVER");
+    const std::string metadata_server = env ? env : "P2PHANDSHAKE";
+
+    UnavailableTcpPeer unavailable_peer;
+    ASSERT_TRUE(unavailable_peer.ok());
+
+    EngineHandle h;
+    h.init(metadata_server, "127.0.0.2:17928", 64 * 1024);
+    ASSERT_TRUE(h.ok);
+
+    auto desc = h.engine->getMetadata()->getSegmentDescByID(h.segment_id);
+    ASSERT_NE(desc, nullptr);
+    desc->tcp_data_port = unavailable_peer.port();
+    desc->tcp_proto_version = 2;
+
+    TransferRequest request;
+    request.opcode = TransferRequest::WRITE;
+    request.length = 1;
+    request.source = h.pool;
+    request.target_id = h.segment_id;
+    request.target_offset = h.remote_base;
+
+    const auto exhausted_batch = h.engine->allocateBatchID(1);
+    ASSERT_TRUE(h.engine->submitTransfer(exhausted_batch, {request}).ok());
+    ASSERT_TRUE(waitForPredicate(
+        [] {
+            return cooldown_started_count.load(std::memory_order_acquire) >=
+                       1 &&
+                   connect_failure_count.load(std::memory_order_acquire) >= 1;
+        },
+        std::chrono::seconds(2)));
+
+    const auto first_pending_batch = h.engine->allocateBatchID(1);
+    ASSERT_TRUE(h.engine->submitTransfer(first_pending_batch, {request}).ok());
+    ASSERT_TRUE(waitForPredicate(
+        [] {
+            return retry_armed_observer_entered.load(std::memory_order_acquire);
+        },
+        std::chrono::seconds(2)));
+
+    // The worker is blocked after timer registration and outside the group
+    // mutex. This admission posts a pump before the deadline; keeping the
+    // worker blocked past expiry makes that pump run before the ready timer.
+    const auto second_pending_batch = h.engine->allocateBatchID(1);
+    ASSERT_TRUE(h.engine->submitTransfer(second_pending_batch, {request}).ok());
+    ASSERT_TRUE(waitForPredicate(
+        [] {
+            return maximum_observed_queue_depth.load(
+                       std::memory_order_acquire) == 2;
+        },
+        std::chrono::seconds(2)));
+    std::this_thread::sleep_for(std::chrono::milliseconds(1200));
+
+    EXPECT_EQ(retry_armed_count.load(std::memory_order_acquire), 1);
+    EXPECT_EQ(lane_connecting_count.load(std::memory_order_acquire), 1);
+    EXPECT_EQ(queue_rejection_count.load(std::memory_order_acquire), 0);
+    EXPECT_LE(maximum_observed_queue_depth.load(std::memory_order_acquire), 2u);
+
+    releaseRetryArmedObserver();
+    ASSERT_TRUE(waitForPredicate(
+        [] {
+            return retry_fired_count.load(std::memory_order_acquire) == 1 &&
+                   connect_failure_count.load(std::memory_order_acquire) == 3;
+        },
+        std::chrono::seconds(5)));
+
+    h.engine.reset();
+    expectEverySliceCompletedExactlyOnceAfterShutdown(exhausted_batch);
+    expectEverySliceCompletedExactlyOnceAfterShutdown(first_pending_batch);
+    expectEverySliceCompletedExactlyOnceAfterShutdown(second_pending_batch);
+    EXPECT_EQ(retry_armed_count.load(std::memory_order_acquire), 1);
+    EXPECT_EQ(retry_fired_count.load(std::memory_order_acquire), 1);
+    // One initial attempt plus one timer-owned retry proves the delayed pump
+    // neither reset an active round nor created an extra immediate attempt.
+    EXPECT_EQ(lane_connecting_count.load(std::memory_order_acquire), 2);
+    EXPECT_EQ(connect_failure_count.load(std::memory_order_acquire), 3);
+    EXPECT_LE(maximum_observed_queue_depth.load(std::memory_order_acquire), 2u);
+
+    hooks.reset();
+    reclaimBatchDescAfterEngineShutdownForTest(exhausted_batch);
+    reclaimBatchDescAfterEngineShutdownForTest(first_pending_batch);
+    reclaimBatchDescAfterEngineShutdownForTest(second_pending_batch);
+}
+
+TEST(TcpWriteVisibilityTest,
+     ShutdownWithPendingRetryTimerCompletesAcceptedWorkOnce) {
+    ScopedEnvVar lanes("MC_TCP_LANES_PER_PEER", "1");
+    ScopedEnvVar queue_capacity("MC_TCP_MAX_QUEUED_TRANSFERS_PER_PEER", "4");
+    ScopedLaneHooks hooks;
+    const char* env = std::getenv("MC_METADATA_SERVER");
+    const std::string metadata_server = env ? env : "P2PHANDSHAKE";
+
+    UnavailableTcpPeer unavailable_peer;
+    ASSERT_TRUE(unavailable_peer.ok());
+
+    EngineHandle h;
+    h.init(metadata_server, "127.0.0.2:17927", 64 * 1024);
+    ASSERT_TRUE(h.ok);
+
+    auto desc = h.engine->getMetadata()->getSegmentDescByID(h.segment_id);
+    ASSERT_NE(desc, nullptr);
+    desc->tcp_data_port = unavailable_peer.port();
+    desc->tcp_proto_version = 2;
+
+    TransferRequest request;
+    request.opcode = TransferRequest::WRITE;
+    request.length = 1;
+    request.source = h.pool;
+    request.target_id = h.segment_id;
+    request.target_offset = h.remote_base;
+
+    const auto exhausted_batch = h.engine->allocateBatchID(1);
+    ASSERT_TRUE(h.engine->submitTransfer(exhausted_batch, {request}).ok());
+    ASSERT_TRUE(waitForPredicate(
+        [] {
+            return cooldown_started_count.load(std::memory_order_acquire) >=
+                       1 &&
+                   connect_failure_count.load(std::memory_order_acquire) >= 1;
+        },
+        std::chrono::seconds(2)));
+
+    const auto pending_batch = h.engine->allocateBatchID(1);
+    ASSERT_TRUE(h.engine->submitTransfer(pending_batch, {request}).ok());
+    ASSERT_TRUE(waitForPredicate(
+        [] { return retry_armed_count.load(std::memory_order_acquire) == 1; },
+        std::chrono::seconds(2)));
+
+    const auto shutdown_start = std::chrono::steady_clock::now();
+    h.engine.reset();
+    EXPECT_LT(std::chrono::steady_clock::now() - shutdown_start,
+              std::chrono::seconds(5));
+
+    expectEverySliceCompletedExactlyOnceAfterShutdown(exhausted_batch);
+    expectEverySliceCompletedExactlyOnceAfterShutdown(pending_batch);
+    EXPECT_EQ(shutdown_failure_count.load(std::memory_order_acquire), 1);
+    EXPECT_EQ(retry_fired_count.load(std::memory_order_acquire), 0);
+    EXPECT_EQ(lane_connecting_count.load(std::memory_order_acquire), 1);
+    EXPECT_EQ(lane_shutdown_clean_count.load(std::memory_order_acquire), 1);
+
+    hooks.reset();
+    reclaimBatchDescAfterEngineShutdownForTest(exhausted_batch);
+    reclaimBatchDescAfterEngineShutdownForTest(pending_batch);
+}
+
+TEST(TcpWriteVisibilityTest,
+     ShutdownInvalidatesPendingRetryAndLateHandlerCannotReconnect) {
+    ScopedEnvVar lanes("MC_TCP_LANES_PER_PEER", "1");
+    ScopedEnvVar queue_capacity("MC_TCP_MAX_QUEUED_TRANSFERS_PER_PEER", "4");
+    ScopedLaneHooks hooks(/*block_first_connect_handler=*/false,
+                          /*block_after_busy=*/false,
+                          /*block_retry=*/true);
+    const char* env = std::getenv("MC_METADATA_SERVER");
+    const std::string metadata_server = env ? env : "P2PHANDSHAKE";
+
+    UnavailableTcpPeer unavailable_peer;
+    ASSERT_TRUE(unavailable_peer.ok());
+
+    EngineHandle h;
+    h.init(metadata_server, "127.0.0.2:17926", 64 * 1024);
+    ASSERT_TRUE(h.ok);
+
+    auto desc = h.engine->getMetadata()->getSegmentDescByID(h.segment_id);
+    ASSERT_NE(desc, nullptr);
+    desc->tcp_data_port = unavailable_peer.port();
+    desc->tcp_proto_version = 2;
+
+    TransferRequest request;
+    request.opcode = TransferRequest::WRITE;
+    request.length = 1;
+    request.source = h.pool;
+    request.target_id = h.segment_id;
+    request.target_offset = h.remote_base;
+
+    const auto exhausted_batch = h.engine->allocateBatchID(1);
+    ASSERT_TRUE(h.engine->submitTransfer(exhausted_batch, {request}).ok());
+    ASSERT_TRUE(waitForPredicate(
+        [] {
+            return cooldown_started_count.load(std::memory_order_acquire) >=
+                       1 &&
+                   connect_failure_count.load(std::memory_order_acquire) >= 1;
+        },
+        std::chrono::seconds(2)));
+
+    const auto pending_batch = h.engine->allocateBatchID(1);
+    ASSERT_TRUE(h.engine->submitTransfer(pending_batch, {request}).ok());
+    ASSERT_TRUE(waitForPredicate(
+        [] { return retry_armed_count.load(std::memory_order_acquire) == 1; },
+        std::chrono::seconds(2)));
+    ASSERT_TRUE(waitForPredicate(
+        [] { return retry_handler_entered.load(std::memory_order_acquire); },
+        std::chrono::seconds(3)));
+
+    auto engine = std::move(h.engine);
+    auto destruction =
+        std::async(std::launch::async,
+                   [engine = std::move(engine)]() mutable { engine.reset(); });
+    ASSERT_TRUE(waitForPredicate(
+        [] {
+            return shutdown_failure_count.load(std::memory_order_acquire) == 1;
+        },
+        std::chrono::seconds(2)));
+    EXPECT_EQ(destruction.wait_for(std::chrono::milliseconds(0)),
+              std::future_status::timeout);
+
+    const int connects_before_release =
+        lane_connecting_count.load(std::memory_order_acquire);
+    releaseRetryHandler();
+    ASSERT_EQ(destruction.wait_for(std::chrono::seconds(5)),
+              std::future_status::ready);
+    destruction.get();
+
+    expectEverySliceCompletedExactlyOnceAfterShutdown(exhausted_batch);
+    expectEverySliceCompletedExactlyOnceAfterShutdown(pending_batch);
+    EXPECT_EQ(lane_connecting_count.load(std::memory_order_acquire),
+              connects_before_release);
+    EXPECT_EQ(retry_fired_count.load(std::memory_order_acquire), 0);
+    EXPECT_GE(retry_late_count.load(std::memory_order_acquire), 1);
+    EXPECT_EQ(lane_shutdown_clean_count.load(std::memory_order_acquire), 1);
+
+    hooks.reset();
+    reclaimBatchDescAfterEngineShutdownForTest(exhausted_batch);
+    reclaimBatchDescAfterEngineShutdownForTest(pending_batch);
+}
+
+TEST(TcpWriteVisibilityTest, LaneTerminalTypesAreMoveOnly) {
+    EXPECT_TRUE(tcpTransportLaneTypesAreMoveOnlyForTest());
+}
+#endif
+
+TEST(TcpWriteVisibilityTest, OneLaneReusesCleanSocketInFifoOrder) {
+    constexpr int kRequestCount = 8;
+    constexpr size_t kLength = 64 * 1024;
+    constexpr size_t kPoolSize = kRequestCount * kLength;
+    ScopedEnvVar lanes("MC_TCP_LANES_PER_PEER", "1");
+    ScopedEnvVar queue_capacity("MC_TCP_MAX_QUEUED_TRANSFERS_PER_PEER", "16");
+    const char* env = std::getenv("MC_METADATA_SERVER");
+    const std::string metadata_server = env ? env : "P2PHANDSHAKE";
+
+    ReusingWriteServer fake_peer;
+    ASSERT_TRUE(fake_peer.ok());
+
+    EngineHandle h;
+    h.init(metadata_server, "127.0.0.2:17922", kPoolSize);
+    ASSERT_TRUE(h.ok);
+
+    auto desc = h.engine->getMetadata()->getSegmentDescByID(h.segment_id);
+    ASSERT_NE(desc, nullptr);
+    desc->tcp_data_port = fake_peer.port();
+    desc->tcp_proto_version = 2;
+
+    memset(h.pool, 0x6B, kLength);
+    std::vector<TransferRequest> requests(kRequestCount);
+    std::vector<uint64_t> expected_addresses;
+    expected_addresses.reserve(kRequestCount);
+    for (int i = 0; i < kRequestCount; ++i) {
+        auto& request = requests[i];
+        request.opcode = TransferRequest::WRITE;
+        request.length = kLength;
+        request.source = h.pool;
+        request.target_id = h.segment_id;
+        request.target_offset = h.remote_base + i * kLength;
+        expected_addresses.push_back(request.target_offset);
+    }
+
+    auto batch_id = h.engine->allocateBatchID(kRequestCount);
+    ASSERT_TRUE(h.engine->submitTransfer(batch_id, requests).ok());
+    ASSERT_TRUE(
+        fake_peer.waitForRequests(kRequestCount, std::chrono::seconds(10)));
+
+    for (int i = 0; i < kRequestCount; ++i) {
+        TransferStatus status;
+        status.s = TransferStatusEnum::WAITING;
+        const auto deadline =
+            std::chrono::steady_clock::now() + std::chrono::seconds(5);
+        while (status.s == TransferStatusEnum::WAITING &&
+               std::chrono::steady_clock::now() < deadline) {
+            ASSERT_TRUE(h.engine->getTransferStatus(batch_id, i, status).ok());
+            if (status.s == TransferStatusEnum::WAITING)
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        EXPECT_EQ(status.s, TransferStatusEnum::COMPLETED) << "request " << i;
+    }
+
+    EXPECT_EQ(fake_peer.acceptedCount(), 1);
+    EXPECT_EQ(fake_peer.requestAddresses(), expected_addresses);
+    (void)h.engine->freeBatchID(batch_id);
+}
+
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+TEST(TcpWriteVisibilityTest,
+     PendingAdmissionWaitsInsteadOfFailingSynchronously) {
+    ScopedEnvVar lanes("MC_TCP_LANES_PER_PEER", "1");
+    ScopedEnvVar queue_capacity("MC_TCP_MAX_QUEUED_TRANSFERS_PER_PEER", "1");
+    ScopedEnvVar pending_capacity("MC_TCP_MAX_PENDING_ADMISSIONS_PER_PEER",
+                                  "2");
+    ScopedEnvVar admission_timeout("MC_TCP_ADMISSION_TIMEOUT_MS", "10000");
+    ScopedLaneHooks hooks(/*block_first_connect_handler=*/true);
+    const char* env = std::getenv("MC_METADATA_SERVER");
+    const std::string metadata_server = env ? env : "P2PHANDSHAKE";
+
+    HoldingWriteServer fake_peer;
+    ASSERT_TRUE(fake_peer.ok());
+
+    EngineHandle h;
+    h.init(metadata_server, "127.0.0.2:17929", 64 * 1024);
+    ASSERT_TRUE(h.ok);
+    pointTcpSegmentAt(h, fake_peer.port());
+
+    const auto request = makeWriteRequest(h, 1);
+    const auto batch_id = h.engine->allocateBatchID(2);
+    const auto submit_start = std::chrono::steady_clock::now();
+    ASSERT_TRUE(h.engine->submitTransfer(batch_id, {request, request}).ok());
+    const auto submit_elapsed = std::chrono::steady_clock::now() - submit_start;
+    ASSERT_TRUE(waitForPredicate(
+        [] {
+            return lane_connect_handler_entered.load(
+                       std::memory_order_acquire) &&
+                   admission_pending_count.load(std::memory_order_acquire) == 1;
+        },
+        std::chrono::seconds(5)));
+
+    TransferStatus pending_status;
+    pending_status.s = TransferStatusEnum::WAITING;
+    ASSERT_TRUE(h.engine->getTransferStatus(batch_id, 1, pending_status).ok());
+    EXPECT_EQ(pending_status.s, TransferStatusEnum::WAITING);
+    EXPECT_LT(submit_elapsed, std::chrono::seconds(2));
+    EXPECT_EQ(queue_full_failure_count.load(std::memory_order_acquire), 0);
+    EXPECT_EQ(queue_timeout_failure_count.load(std::memory_order_acquire), 0);
+    EXPECT_EQ(maximum_observed_queue_depth.load(std::memory_order_acquire), 1u);
+    EXPECT_EQ(maximum_observed_pending_depth.load(std::memory_order_acquire),
+              1u);
+
+    releaseLaneConnectHandler();
+    h.engine.reset();
+    expectEverySliceCompletedExactlyOnceAfterShutdown(batch_id);
+    hooks.reset();
+    reclaimBatchDescAfterEngineShutdownForTest(batch_id);
+}
+
+TEST(TcpWriteVisibilityTest, PendingAdmissionTimesOutExactlyOnce) {
+    constexpr size_t kLength = 64 * 1024;
+    ScopedEnvVar lanes("MC_TCP_LANES_PER_PEER", "1");
+    ScopedEnvVar queue_capacity("MC_TCP_MAX_QUEUED_TRANSFERS_PER_PEER", "1");
+    ScopedEnvVar pending_capacity("MC_TCP_MAX_PENDING_ADMISSIONS_PER_PEER",
+                                  "1");
+    ScopedEnvVar admission_timeout("MC_TCP_ADMISSION_TIMEOUT_MS", "100");
+    ScopedLaneHooks hooks;
+    const char* env = std::getenv("MC_METADATA_SERVER");
+    const std::string metadata_server = env ? env : "P2PHANDSHAKE";
+
+    HoldingWriteServer fake_peer;
+    ASSERT_TRUE(fake_peer.ok());
+
+    EngineHandle h;
+    h.init(metadata_server, "127.0.0.2:17930", kLength);
+    ASSERT_TRUE(h.ok);
+    pointTcpSegmentAt(h, fake_peer.port());
+
+    const auto request = makeWriteRequest(h, kLength);
+    const auto active_batch = h.engine->allocateBatchID(1);
+    ASSERT_TRUE(h.engine->submitTransfer(active_batch, {request}).ok());
+    ASSERT_TRUE(waitForPredicate(
+        [] { return lane_busy_count.load(std::memory_order_acquire) >= 1; },
+        std::chrono::seconds(5)));
+    ASSERT_TRUE(fake_peer.waitForAccepted(1, std::chrono::seconds(5)));
+
+    const auto queued_batch = h.engine->allocateBatchID(1);
+    const auto pending_batch = h.engine->allocateBatchID(1);
+    ASSERT_TRUE(h.engine->submitTransfer(queued_batch, {request}).ok());
+    ASSERT_TRUE(h.engine->submitTransfer(pending_batch, {request}).ok());
+    ASSERT_TRUE(waitForPredicate(
+        [] {
+            return queue_timeout_failure_count.load(
+                       std::memory_order_acquire) == 1;
+        },
+        std::chrono::seconds(5)));
+
+    EXPECT_EQ(queue_full_failure_count.load(std::memory_order_acquire), 0);
+    EXPECT_EQ(admission_timer_fired_count.load(std::memory_order_acquire), 1);
+    EXPECT_EQ(admission_promoted_count.load(std::memory_order_acquire), 0);
+    h.engine.reset();
+    expectEverySliceCompletedExactlyOnceAfterShutdown(active_batch);
+    expectEverySliceCompletedExactlyOnceAfterShutdown(queued_batch);
+    expectEverySliceCompletedExactlyOnceAfterShutdown(pending_batch);
+    EXPECT_EQ(queue_timeout_failure_count.load(std::memory_order_acquire), 1);
+
+    hooks.reset();
+    reclaimBatchDescAfterEngineShutdownForTest(active_batch);
+    reclaimBatchDescAfterEngineShutdownForTest(queued_batch);
+    reclaimBatchDescAfterEngineShutdownForTest(pending_batch);
+}
+
+TEST(TcpWriteVisibilityTest, PendingAdmissionsPromoteInFifoOrder) {
+    constexpr int kRequestCount = 4;
+    ScopedEnvVar lanes("MC_TCP_LANES_PER_PEER", "1");
+    ScopedEnvVar queue_capacity("MC_TCP_MAX_QUEUED_TRANSFERS_PER_PEER", "1");
+    ScopedEnvVar pending_capacity("MC_TCP_MAX_PENDING_ADMISSIONS_PER_PEER",
+                                  "3");
+    ScopedEnvVar admission_timeout("MC_TCP_ADMISSION_TIMEOUT_MS", "10000");
+    ScopedLaneHooks hooks(/*block_first_connect_handler=*/true);
+    const char* env = std::getenv("MC_METADATA_SERVER");
+    const std::string metadata_server = env ? env : "P2PHANDSHAKE";
+
+    ReusingWriteServer fake_peer;
+    ASSERT_TRUE(fake_peer.ok());
+
+    EngineHandle h;
+    h.init(metadata_server, "127.0.0.2:17931", 64 * 1024);
+    ASSERT_TRUE(h.ok);
+    pointTcpSegmentAt(h, fake_peer.port());
+
+    std::vector<TransferRequest> requests;
+    std::vector<uint64_t> expected_addresses;
+    for (int i = 0; i < kRequestCount; ++i) {
+        const uint64_t address = h.remote_base + static_cast<uint64_t>(i);
+        requests.push_back(makeWriteRequest(h, 1, address));
+        expected_addresses.push_back(address);
+    }
+
+    const auto batch_id = h.engine->allocateBatchID(kRequestCount);
+    ASSERT_TRUE(h.engine->submitTransfer(batch_id, requests).ok());
+    ASSERT_TRUE(waitForPredicate(
+        [] {
+            return lane_connect_handler_entered.load(
+                       std::memory_order_acquire) &&
+                   admission_pending_count.load(std::memory_order_acquire) == 3;
+        },
+        std::chrono::seconds(5)));
+    EXPECT_EQ(maximum_observed_queue_depth.load(std::memory_order_acquire), 1u);
+    EXPECT_EQ(maximum_observed_pending_depth.load(std::memory_order_acquire),
+              3u);
+
+    releaseLaneConnectHandler();
+    ASSERT_TRUE(
+        fake_peer.waitForRequests(kRequestCount, std::chrono::seconds(10)));
+    ASSERT_TRUE(waitForBatchTerminal(h.engine.get(), batch_id, kRequestCount,
+                                     std::chrono::seconds(5)));
+    EXPECT_EQ(fake_peer.requestAddresses(), expected_addresses);
+    EXPECT_GE(admission_promoted_count.load(std::memory_order_acquire), 1);
+    EXPECT_EQ(queue_full_failure_count.load(std::memory_order_acquire), 0);
+    EXPECT_EQ(queue_timeout_failure_count.load(std::memory_order_acquire), 0);
+
+    hooks.reset();
+    (void)h.engine->freeBatchID(batch_id);
+}
+
+TEST(TcpWriteVisibilityTest, PendingAdmissionHardBoundRejectsImmediately) {
+    constexpr int kRequestCount = 3;
+    ScopedEnvVar lanes("MC_TCP_LANES_PER_PEER", "1");
+    ScopedEnvVar queue_capacity("MC_TCP_MAX_QUEUED_TRANSFERS_PER_PEER", "1");
+    ScopedEnvVar pending_capacity("MC_TCP_MAX_PENDING_ADMISSIONS_PER_PEER",
+                                  "1");
+    ScopedEnvVar admission_timeout("MC_TCP_ADMISSION_TIMEOUT_MS", "10000");
+    ScopedLaneHooks hooks(/*block_first_connect_handler=*/true);
+    const char* env = std::getenv("MC_METADATA_SERVER");
+    const std::string metadata_server = env ? env : "P2PHANDSHAKE";
+
+    HoldingWriteServer fake_peer;
+    ASSERT_TRUE(fake_peer.ok());
+
+    EngineHandle h;
+    h.init(metadata_server, "127.0.0.2:17923", 64 * 1024);
+    ASSERT_TRUE(h.ok);
+    pointTcpSegmentAt(h, fake_peer.port());
+
+    std::vector<TransferRequest> requests(kRequestCount);
+    for (auto& request : requests) {
+        request.opcode = TransferRequest::WRITE;
+        request.length = 1;
+        request.source = h.pool;
+        request.target_id = h.segment_id;
+        request.target_offset = h.remote_base;
+    }
+
+    const auto batch_id = h.engine->allocateBatchID(kRequestCount);
+    ASSERT_TRUE(h.engine->submitTransfer(batch_id, requests).ok());
+    ASSERT_TRUE(waitForPredicate(
+        [] {
+            return lane_connect_handler_entered.load(std::memory_order_acquire);
+        },
+        std::chrono::seconds(5)));
+
+    EXPECT_EQ(queue_rejection_count.load(std::memory_order_acquire), 1);
+    EXPECT_EQ(admission_hard_rejection_count.load(std::memory_order_acquire),
+              1);
+    EXPECT_EQ(queue_full_failure_count.load(std::memory_order_acquire), 1);
+    EXPECT_EQ(queue_timeout_failure_count.load(std::memory_order_acquire), 0);
+    EXPECT_EQ(connect_failure_count.load(std::memory_order_acquire), 0);
+    EXPECT_EQ(maximum_observed_queue_depth.load(std::memory_order_acquire), 1u);
+    EXPECT_EQ(maximum_observed_pending_depth.load(std::memory_order_acquire),
+              1u);
+    EXPECT_FALSE(connecting_lane_had_current.load(std::memory_order_acquire));
+    for (int task_id = 0; task_id < kRequestCount; ++task_id) {
+        TransferStatus status;
+        status.s = TransferStatusEnum::WAITING;
+        ASSERT_TRUE(
+            h.engine->getTransferStatus(batch_id, task_id, status).ok());
+        EXPECT_EQ(status.s, task_id == kRequestCount - 1
+                                ? TransferStatusEnum::FAILED
+                                : TransferStatusEnum::WAITING);
+    }
+
+    releaseLaneConnectHandler();
+    h.engine.reset();
+    expectEverySliceCompletedExactlyOnceAfterShutdown(batch_id);
+    hooks.reset();
+    reclaimBatchDescAfterEngineShutdownForTest(batch_id);
+}
+
+TEST(TcpWriteVisibilityTest,
+     ShutdownWithPendingAdmissionsAndArmedTimerCompletesOnce) {
+    constexpr size_t kLength = 64 * 1024;
+    ScopedEnvVar lanes("MC_TCP_LANES_PER_PEER", "1");
+    ScopedEnvVar queue_capacity("MC_TCP_MAX_QUEUED_TRANSFERS_PER_PEER", "1");
+    ScopedEnvVar pending_capacity("MC_TCP_MAX_PENDING_ADMISSIONS_PER_PEER",
+                                  "1");
+    ScopedEnvVar admission_timeout("MC_TCP_ADMISSION_TIMEOUT_MS", "10000");
+    ScopedLaneHooks hooks;
+    const char* env = std::getenv("MC_METADATA_SERVER");
+    const std::string metadata_server = env ? env : "P2PHANDSHAKE";
+
+    HoldingWriteServer fake_peer;
+    ASSERT_TRUE(fake_peer.ok());
+
+    EngineHandle h;
+    h.init(metadata_server, "127.0.0.2:17932", kLength);
+    ASSERT_TRUE(h.ok);
+    pointTcpSegmentAt(h, fake_peer.port());
+
+    const auto request = makeWriteRequest(h, kLength);
+    const auto active_batch = h.engine->allocateBatchID(1);
+    ASSERT_TRUE(h.engine->submitTransfer(active_batch, {request}).ok());
+    ASSERT_TRUE(waitForPredicate(
+        [] { return lane_busy_count.load(std::memory_order_acquire) >= 1; },
+        std::chrono::seconds(5)));
+    ASSERT_TRUE(fake_peer.waitForAccepted(1, std::chrono::seconds(5)));
+
+    const auto queued_batch = h.engine->allocateBatchID(1);
+    const auto pending_batch = h.engine->allocateBatchID(1);
+    ASSERT_TRUE(h.engine->submitTransfer(queued_batch, {request}).ok());
+    ASSERT_TRUE(h.engine->submitTransfer(pending_batch, {request}).ok());
+    ASSERT_TRUE(waitForPredicate(
+        [] {
+            return admission_pending_count.load(std::memory_order_acquire) ==
+                       1 &&
+                   admission_timer_armed_count.load(
+                       std::memory_order_acquire) == 1;
+        },
+        std::chrono::seconds(5)));
+
+    const auto shutdown_start = std::chrono::steady_clock::now();
+    h.engine.reset();
+    EXPECT_LT(std::chrono::steady_clock::now() - shutdown_start,
+              std::chrono::seconds(5));
+    expectEverySliceCompletedExactlyOnceAfterShutdown(active_batch);
+    expectEverySliceCompletedExactlyOnceAfterShutdown(queued_batch);
+    expectEverySliceCompletedExactlyOnceAfterShutdown(pending_batch);
+    EXPECT_EQ(shutdown_failure_count.load(std::memory_order_acquire), 3);
+    EXPECT_EQ(queue_timeout_failure_count.load(std::memory_order_acquire), 0);
+    EXPECT_EQ(admission_promoted_count.load(std::memory_order_acquire), 0);
+    EXPECT_EQ(admission_timer_fired_count.load(std::memory_order_acquire), 0);
+
+    hooks.reset();
+    reclaimBatchDescAfterEngineShutdownForTest(active_batch);
+    reclaimBatchDescAfterEngineShutdownForTest(queued_batch);
+    reclaimBatchDescAfterEngineShutdownForTest(pending_batch);
+}
+
+TEST(TcpWriteVisibilityTest,
+     AdmissionTimeoutWinsBeforeCapacityReleasePreservesOneOwner) {
+    ScopedEnvVar lanes("MC_TCP_LANES_PER_PEER", "1");
+    ScopedEnvVar queue_capacity("MC_TCP_MAX_QUEUED_TRANSFERS_PER_PEER", "1");
+    ScopedEnvVar pending_capacity("MC_TCP_MAX_PENDING_ADMISSIONS_PER_PEER",
+                                  "1");
+    ScopedEnvVar admission_timeout("MC_TCP_ADMISSION_TIMEOUT_MS", "100");
+    ScopedLaneHooks hooks(/*block_first_connect_handler=*/false,
+                          /*block_after_busy=*/false,
+                          /*block_retry=*/false,
+                          /*block_retry_armed=*/false,
+                          /*block_admission=*/true);
+    const char* env = std::getenv("MC_METADATA_SERVER");
+    const std::string metadata_server = env ? env : "P2PHANDSHAKE";
+
+    ReusingWriteServer fake_peer(/*hold_first_ack=*/true);
+    ASSERT_TRUE(fake_peer.ok());
+
+    EngineHandle h;
+    h.init(metadata_server, "127.0.0.2:17933", 64 * 1024);
+    ASSERT_TRUE(h.ok);
+    pointTcpSegmentAt(h, fake_peer.port());
+
+    const auto request = makeWriteRequest(h, 1);
+    const auto active_batch = h.engine->allocateBatchID(1);
+    ASSERT_TRUE(h.engine->submitTransfer(active_batch, {request}).ok());
+    ASSERT_TRUE(fake_peer.waitForFirstRequest(std::chrono::seconds(5)));
+
+    const auto queued_batch = h.engine->allocateBatchID(1);
+    const auto pending_batch = h.engine->allocateBatchID(1);
+    ASSERT_TRUE(h.engine->submitTransfer(queued_batch, {request}).ok());
+    ASSERT_TRUE(h.engine->submitTransfer(pending_batch, {request}).ok());
+    ASSERT_TRUE(waitForPredicate(
+        [] {
+            return admission_handler_entered.load(std::memory_order_acquire);
+        },
+        std::chrono::seconds(5)));
+
+    // The expired timer handler is paused outside the group mutex. Make the
+    // active session's capacity release ready, then let the timer and queued
+    // completion contend in a deterministic order on the single io worker.
+    fake_peer.releaseFirstAck();
+    ASSERT_TRUE(fake_peer.waitForFirstAckSent(std::chrono::seconds(5)));
+    releaseAdmissionHandler();
+    ASSERT_TRUE(waitForPredicate(
+        [] {
+            return queue_timeout_failure_count.load(
+                       std::memory_order_acquire) == 1;
+        },
+        std::chrono::seconds(5)));
+    ASSERT_TRUE(fake_peer.waitForRequests(2, std::chrono::seconds(5)));
+
+    h.engine.reset();
+    expectEverySliceCompletedExactlyOnceAfterShutdown(active_batch);
+    expectEverySliceCompletedExactlyOnceAfterShutdown(queued_batch);
+    expectEverySliceCompletedExactlyOnceAfterShutdown(pending_batch);
+    EXPECT_EQ(queue_timeout_failure_count.load(std::memory_order_acquire), 1);
+    EXPECT_EQ(queue_full_failure_count.load(std::memory_order_acquire), 0);
+    EXPECT_EQ(admission_promoted_count.load(std::memory_order_acquire), 0);
+    EXPECT_EQ(admission_timer_fired_count.load(std::memory_order_acquire), 1);
+
+    hooks.reset();
+    reclaimBatchDescAfterEngineShutdownForTest(active_batch);
+    reclaimBatchDescAfterEngineShutdownForTest(queued_batch);
+    reclaimBatchDescAfterEngineShutdownForTest(pending_batch);
+}
+
+TEST(TcpWriteVisibilityTest,
+     CapacityReleasePromotesBeforeDeadlineAndCancelledTimerIsLate) {
+    ScopedEnvVar lanes("MC_TCP_LANES_PER_PEER", "1");
+    ScopedEnvVar queue_capacity("MC_TCP_MAX_QUEUED_TRANSFERS_PER_PEER", "1");
+    ScopedEnvVar pending_capacity("MC_TCP_MAX_PENDING_ADMISSIONS_PER_PEER",
+                                  "1");
+    ScopedEnvVar admission_timeout("MC_TCP_ADMISSION_TIMEOUT_MS", "10000");
+    ScopedLaneHooks hooks(/*block_first_connect_handler=*/false,
+                          /*block_after_busy=*/false,
+                          /*block_retry=*/false,
+                          /*block_retry_armed=*/false,
+                          /*block_admission=*/true);
+    const char* env = std::getenv("MC_METADATA_SERVER");
+    const std::string metadata_server = env ? env : "P2PHANDSHAKE";
+
+    ReusingWriteServer fake_peer(/*hold_first_ack=*/true);
+    ASSERT_TRUE(fake_peer.ok());
+
+    EngineHandle h;
+    h.init(metadata_server, "127.0.0.2:17934", 64 * 1024);
+    ASSERT_TRUE(h.ok);
+    pointTcpSegmentAt(h, fake_peer.port());
+
+    const auto request = makeWriteRequest(h, 1);
+    const auto active_batch = h.engine->allocateBatchID(1);
+    ASSERT_TRUE(h.engine->submitTransfer(active_batch, {request}).ok());
+    ASSERT_TRUE(fake_peer.waitForFirstRequest(std::chrono::seconds(5)));
+
+    const auto queued_batch = h.engine->allocateBatchID(1);
+    const auto pending_batch = h.engine->allocateBatchID(1);
+    ASSERT_TRUE(h.engine->submitTransfer(queued_batch, {request}).ok());
+    ASSERT_TRUE(h.engine->submitTransfer(pending_batch, {request}).ok());
+    ASSERT_TRUE(waitForPredicate(
+        [] {
+            return admission_pending_count.load(std::memory_order_acquire) ==
+                       1 &&
+                   admission_timer_armed_count.load(
+                       std::memory_order_acquire) == 1;
+        },
+        std::chrono::seconds(5)));
+
+    // Completing the active exchange frees a work-queue slot before the long
+    // deadline. The pump promotes the pending item, invalidates the timer
+    // epoch, and cancels the now-unneeded shared admission timer.
+    fake_peer.releaseFirstAck();
+    ASSERT_TRUE(fake_peer.waitForFirstAckSent(std::chrono::seconds(5)));
+    ASSERT_TRUE(waitForPredicate(
+        [] {
+            return admission_promoted_count.load(std::memory_order_acquire) >=
+                   1;
+        },
+        std::chrono::seconds(5)));
+    ASSERT_TRUE(waitForPredicate(
+        [] {
+            return admission_handler_entered.load(std::memory_order_acquire);
+        },
+        std::chrono::seconds(5)));
+    EXPECT_EQ(queue_timeout_failure_count.load(std::memory_order_acquire), 0);
+    EXPECT_EQ(admission_timer_fired_count.load(std::memory_order_acquire), 0);
+
+    releaseAdmissionHandler();
+    ASSERT_TRUE(waitForPredicate(
+        [] {
+            return admission_timer_late_count.load(std::memory_order_acquire) >=
+                   1;
+        },
+        std::chrono::seconds(5)));
+    ASSERT_TRUE(fake_peer.waitForRequests(3, std::chrono::seconds(5)));
+    ASSERT_TRUE(waitForPredicate(
+        [] { return lane_terminal_count.load(std::memory_order_acquire) >= 3; },
+        std::chrono::seconds(5)));
+
+    h.engine.reset();
+    expectEverySliceSucceededExactlyOnceAfterShutdown(active_batch);
+    expectEverySliceSucceededExactlyOnceAfterShutdown(queued_batch);
+    expectEverySliceSucceededExactlyOnceAfterShutdown(pending_batch);
+    EXPECT_EQ(queue_timeout_failure_count.load(std::memory_order_acquire), 0);
+    EXPECT_EQ(queue_full_failure_count.load(std::memory_order_acquire), 0);
+    EXPECT_GE(admission_promoted_count.load(std::memory_order_acquire), 1);
+    EXPECT_EQ(admission_timer_fired_count.load(std::memory_order_acquire), 0);
+    EXPECT_GE(admission_timer_late_count.load(std::memory_order_acquire), 1);
+
+    hooks.reset();
+    reclaimBatchDescAfterEngineShutdownForTest(active_batch);
+    reclaimBatchDescAfterEngineShutdownForTest(queued_batch);
+    reclaimBatchDescAfterEngineShutdownForTest(pending_batch);
+}
+
+TEST(TcpWriteVisibilityTest,
+     ConcurrentAdmissionShutdownStressPreservesLaneOwnership) {
+    constexpr size_t kSubmissionCount = 40;
+    constexpr size_t kSubmitterCount = 4;
+    constexpr size_t kQueueCapacity = 8;
+    ScopedEnvVar lanes("MC_TCP_LANES_PER_PEER", "2");
+    ScopedEnvVar queue_capacity("MC_TCP_MAX_QUEUED_TRANSFERS_PER_PEER", "8");
+    ScopedEnvVar pending_capacity("MC_TCP_MAX_PENDING_ADMISSIONS_PER_PEER",
+                                  "1");
+    ScopedEnvVar admission_timeout("MC_TCP_ADMISSION_TIMEOUT_MS", "10000");
+    ScopedLaneHooks hooks(/*block_first_connect_handler=*/false,
+                          /*block_after_busy=*/true);
+    const char* env = std::getenv("MC_METADATA_SERVER");
+    const std::string metadata_server = env ? env : "P2PHANDSHAKE";
+
+    HoldingWriteServer fake_peer;
+    ASSERT_TRUE(fake_peer.ok());
+
+    EngineHandle h;
+    h.init(metadata_server, "127.0.0.2:17924", 64 * 1024);
+    ASSERT_TRUE(h.ok);
+
+    auto desc = h.engine->getMetadata()->getSegmentDescByID(h.segment_id);
+    ASSERT_NE(desc, nullptr);
+    desc->tcp_data_port = fake_peer.port();
+    desc->tcp_proto_version = 2;
+
+    TransferRequest request;
+    request.opcode = TransferRequest::WRITE;
+    request.length = 1;
+    request.source = h.pool;
+    request.target_id = h.segment_id;
+    request.target_offset = h.remote_base;
+
+    const auto busy_batch_id = h.engine->allocateBatchID(2);
+    ASSERT_TRUE(
+        h.engine->submitTransfer(busy_batch_id, {request, request}).ok());
+    ASSERT_TRUE(waitForPredicate(
+        [] {
+            return lane_connect_handler_entered.load(
+                       std::memory_order_acquire) &&
+                   lane_busy_count.load(std::memory_order_acquire) >= 1;
+        },
+        std::chrono::seconds(5)));
+    ASSERT_TRUE(fake_peer.waitForAccepted(1, std::chrono::seconds(5)));
+
+    std::vector<Transport::BatchID> batch_ids(kSubmissionCount);
+    for (auto& batch_id : batch_ids) batch_id = h.engine->allocateBatchID(1);
+    std::vector<std::atomic<int>> submit_results(kSubmissionCount);
+    for (auto& result : submit_results) result.store(0);
+
+    std::vector<std::thread> submitters;
+    for (size_t thread_id = 0; thread_id < kSubmitterCount; ++thread_id) {
+        submitters.emplace_back([&, thread_id] {
+            for (size_t i = thread_id; i < kSubmissionCount;
+                 i += kSubmitterCount) {
+                submit_results[i].store(
+                    h.engine->submitTransfer(batch_ids[i], {request}).ok() ? 1
+                                                                           : -1,
+                    std::memory_order_release);
+            }
+        });
+    }
+    for (auto& submitter : submitters) submitter.join();
+    for (const auto& result : submit_results)
+        EXPECT_EQ(result.load(std::memory_order_acquire), 1);
+
+    EXPECT_EQ(maximum_observed_queue_depth.load(std::memory_order_acquire),
+              kQueueCapacity);
+    EXPECT_LE(maximum_observed_socket_count.load(std::memory_order_acquire),
+              2u);
+    EXPECT_FALSE(connecting_lane_had_current.load(std::memory_order_acquire));
+    EXPECT_EQ(queue_rejection_count.load(std::memory_order_acquire),
+              static_cast<int>(kSubmissionCount - (kQueueCapacity - 1) - 1));
+    EXPECT_LE(maximum_observed_pending_depth.load(std::memory_order_acquire),
+              1u);
+
+    auto engine = std::move(h.engine);
+    auto destruction =
+        std::async(std::launch::async,
+                   [engine = std::move(engine)]() mutable { engine.reset(); });
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    releaseLaneConnectHandler();
+    ASSERT_EQ(destruction.wait_for(std::chrono::seconds(5)),
+              std::future_status::ready);
+    destruction.get();
+
+    expectEverySliceCompletedExactlyOnceAfterShutdown(busy_batch_id);
+    for (const auto batch_id : batch_ids)
+        expectEverySliceCompletedExactlyOnceAfterShutdown(batch_id);
+    EXPECT_EQ(lane_shutdown_clean_count.load(std::memory_order_acquire), 1);
+    EXPECT_GE(late_lane_handler_count.load(std::memory_order_acquire), 1);
+
+    hooks.reset();
+    reclaimBatchDescAfterEngineShutdownForTest(busy_batch_id);
+    for (const auto batch_id : batch_ids)
+        reclaimBatchDescAfterEngineShutdownForTest(batch_id);
+}
+#endif

--- a/mooncake-transfer-engine/tests/tcp_write_visibility_test.cpp
+++ b/mooncake-transfer-engine/tests/tcp_write_visibility_test.cpp
@@ -2097,6 +2097,75 @@ TEST(TcpWriteVisibilityTest,
     reclaimBatchDescAfterEngineShutdownForTest(pending_batch);
 }
 
+TEST(TcpWriteVisibilityTest,
+     TaskGroupShutdownCompletesNotYetStartedSlicesExactlyOnce) {
+    constexpr int kRequestCount = 3;
+    constexpr size_t kLength = 64 * 1024;
+
+    ScopedEnvVar lanes("MC_TCP_LANES_PER_PEER", "1");
+    ScopedEnvVar queue_capacity("MC_TCP_MAX_QUEUED_TRANSFERS_PER_PEER", "8");
+    ScopedLaneHooks hooks;
+
+    const char* env = std::getenv("MC_METADATA_SERVER");
+    const std::string metadata_server = env ? env : "P2PHANDSHAKE";
+
+    HoldingWriteServer fake_peer;
+    ASSERT_TRUE(fake_peer.ok());
+
+    EngineHandle h;
+    h.init(metadata_server, "127.0.0.2:17936", kLength);
+    ASSERT_TRUE(h.ok);
+    pointTcpSegmentAt(h, fake_peer.port());
+
+    memset(h.pool, 0x6D, kLength);
+    TransferRequest request = makeWriteRequest(h, kLength);
+    request.task_group_id = 1;
+
+    std::vector<TransferRequest> requests(kRequestCount, request);
+    const auto batch_id = h.engine->allocateBatchID(kRequestCount);
+    ASSERT_TRUE(h.engine->submitTransfer(batch_id, requests).ok());
+
+    // Task-group sequencing starts only the first Slice. Hold it BUSY so the
+    // remaining Slices have been created but have not entered the lane queue.
+    ASSERT_TRUE(fake_peer.waitForAccepted(1, std::chrono::seconds(5)));
+    ASSERT_TRUE(waitForPredicate(
+        [] { return lane_busy_count.load(std::memory_order_acquire) >= 1; },
+        std::chrono::seconds(5)));
+
+    h.engine.reset();
+
+    // Shutdown must not strand the sequence tail merely because the TCP
+    // io_context has already been stopped. Every pre-created Slice must become
+    // terminal exactly once.
+    expectEverySliceCompletedExactlyOnceAfterShutdown(batch_id);
+
+    const auto& batch = Transport::toBatchDesc(batch_id);
+    ASSERT_EQ(batch.task_list.size(), kRequestCount);
+    for (size_t task_id = 0; task_id < batch.task_list.size(); ++task_id) {
+        const auto& task = batch.task_list[task_id];
+        const uint64_t success =
+            __atomic_load_n(&task.success_slice_count, __ATOMIC_RELAXED);
+        const uint64_t failed =
+            __atomic_load_n(&task.failed_slice_count, __ATOMIC_RELAXED);
+        const uint64_t slices =
+            __atomic_load_n(&task.slice_count, __ATOMIC_RELAXED);
+
+        EXPECT_EQ(slices, 1u) << "task " << task_id;
+        EXPECT_EQ(success, 0u) << "task " << task_id;
+        EXPECT_EQ(failed, 1u) << "task " << task_id;
+        ASSERT_EQ(task.slice_list.size(), 1u);
+        EXPECT_EQ(task.slice_list.front()->status, Transport::Slice::FAILED)
+            << "task " << task_id;
+    }
+
+    EXPECT_EQ(shutdown_failure_count.load(std::memory_order_acquire),
+              kRequestCount);
+    EXPECT_EQ(lane_shutdown_clean_count.load(std::memory_order_acquire), 1);
+
+    hooks.reset();
+    reclaimBatchDescAfterEngineShutdownForTest(batch_id);
+}
+
 TEST(TcpWriteVisibilityTest, LaneTerminalTypesAreMoveOnly) {
     EXPECT_TRUE(tcpTransportLaneTypesAreMoveOnlyForTest());
 }


### PR DESCRIPTION
## Summary

Revised implementation for #2930, following review feedback on the earlier
revision of this PR.

The original TCP transport opens a new connection whenever no idle connection
is available for a destination, so socket count follows peak concurrency with
no upper bound. The first revision of this PR bounded sockets with a per-peer
cap plus a FIFO queue of acquisition callbacks; review correctly noted that
this moved the unbounded state from sockets into waiter state rather than
establishing end-to-end boundedness.

This revision changes the ownership model accordingly: **sockets are owned by
fixed per-destination lanes, not by individual Slices.**

```text
bounded pending-admission FIFO
→ bounded Slice work queue
→ fixed per-peer connection lanes
```

A Slice never acquires or owns a socket. It remains in bounded group-owned state
until an idle connected lane pulls it for execution, so backpressure is applied
when transfer work enters the transport rather than during socket acquisition.

## Scope

Implemented:

- a per-destination `PeerConnectionGroup` owning a fixed set of long-lived
  `ConnectionLane`s;
- a bounded work queue and a bounded pending-admission FIFO;
- admission deadlines for Slices waiting to enter the work queue;
- pull-at-idle scheduling, so a slow transfer blocks only its own lane;
- group-level reconnect rounds with a serialized cooldown timer;
- move-only work ownership and exactly-once terminal completion;
- internal failure accounting by reason;
- deterministic shutdown handling for queued, pending-admission, connecting,
  and busy state;
- interoperability coverage for the existing legacy framing path.

Intentionally **not** implemented:

- peer-generation or stale/half-closed socket detection after peer restart;
- payload or transfer-progress deadlines;
- a global bound on the number of peer groups;
- public exposure of transport-internal failure reasons;
- changes to transfer-status counter synchronization.

## Design

### Object model

Each destination `ConnectionKey` maps to one `PeerConnectionGroup`.

The group owns, under a single mutex:

- its fixed lane vector;
- the bounded admitted-work queue;
- the bounded pending-admission FIFO;
- admission and reconnect timer state;
- reconnect-round accounting;
- internal failure counters.

Each `ConnectionLane` owns its resolver, socket, session, lifecycle state, and
operation epoch, plus at most one active work item.

The epoch is validated by asynchronous handlers so that late resolve, connect,
timer, session, and shutdown handlers cannot reclaim ownership that has already
moved elsewhere.

### Admission

A new submission is admitted directly to the work queue only when:

- work-queue capacity is available; and
- no older pending admission is waiting.

Otherwise it enters the bounded pending-admission FIFO with a deadline.
Pending admissions are promoted into the work queue in FIFO order whenever
capacity becomes available; newer submissions cannot bypass older pending
ones.

One per-group timer tracks the earliest pending deadline. If the deadline
expires first, the Slice is completed as `FAILED` with the internal
`QUEUE_TIMEOUT` reason.

Only when both the work queue and pending-admission FIFO are at their hard
bounds is a newly submitted Slice rejected with `QUEUE_FULL`. Rejection and
terminal Slice completion occur after releasing the group mutex.

Failure reasons are counted internally through `recordWorkFailure`, including:

- queue full;
- admission timeout;
- runtime unavailable;
- connect failure;
- session failure;
- shutdown.

External callers currently continue to observe a generic `FAILED` transfer
status; the transport-internal enum is not exposed through the public API by
this revision.

### Lane behavior

A disconnected lane attempts to resolve and connect only while admitted work
exists. Connecting lanes do not remove work from the queue.

Once connected, a lane becomes idle. An idle lane pulls the queue head,
transitions to busy, and starts a session for that work item.

After a terminal session result:

- a clean connection returns to the idle state and may serve the next Slice;
- an unusable connection is discarded and the lane returns to disconnected.

Mid-transfer work is never transparently replayed on another lane. A failed
session completes its Slice as failed and leaves retry policy to the caller or
upper layer.

### Ownership and exactly-once completion

```text
submitter-local work item
    → pending-admission FIFO or work queue
    → lane.current
    → local terminal action
    → exactly one Slice terminal call
```

`TcpWorkItem` and `TerminalAction` are move-only. Every ownership transition
moves the work item from exactly one location to the next.

`ClientSession` does not mark the Slice directly. It reports one terminal
`(status, connection_clean)` result to its owning lane. The lane validates its
epoch and claims the current work item under the group mutex; terminal Slice
completion is then performed outside the mutex.

Timeout, promotion, terminal handling, and shutdown compete for ownership
through the same group state, preventing a Slice from being dropped or
completed twice.

### Reconnect rounds and cooldown

Reconnect is demand-driven and rate-limited per destination.

A reconnect round permits:

- at most one concurrent connection probe;
- at most one connection attempt per lane during that round.

If all lane attempts in a round fail without establishing a usable connection,
the admitted work waiting on that round is completed with `CONNECT_FAILED` and
the group enters a one-second cooldown.

A single per-group retry timer owns the transition out of cooldown. Delayed
pumps cannot start a new round while that timer is armed. The timer handler
validates its group state and epoch before beginning another round, and cannot
restart a closing group.

Submissions during cooldown remain subject to the same bounded admission
structures and cannot bypass the cooldown transition.

### Shutdown

Shutdown first stops new admission and marks all groups closing.

Under each group mutex it detaches:

- admitted queued work;
- pending admissions;
- admission and reconnect timer ownership;
- lane-owned state required for cancellation.

Slice completion and cancellation dispatch occur outside the group mutex.

Lane operation epochs and timer epochs are invalidated so late handlers cannot
claim work that shutdown has already detached. Executor-posted cancellation
actions are allowed to run before the existing stop-and-join boundary; this is
a cancellation-dispatch barrier, not a claim that every asynchronous handler
has already quiesced.

After the worker is stopped and joined, remaining Asio ownership is released
while the context is still valid, and deferred busy work is completed exactly
once.

The existing stop/join ordering is preserved. This revision strengthens
admission-, queue-, reconnect-, and shutdown-path ownership without adding a
drain guarantee for transfers already in flight.

## Configuration

Connection-lane scheduling remains controlled by the existing:

```text
MC_TCP_ENABLE_CONNECTION_POOL
```

When enabled, the following settings are available:

| Environment variable | Default | Valid range |
|---|---:|---:|
| `MC_TCP_LANES_PER_PEER` | `4` | `1`–`16` |
| `MC_TCP_MAX_QUEUED_TRANSFERS_PER_PEER` | `1024` | `1`–`65535` |
| `MC_TCP_MAX_PENDING_ADMISSIONS_PER_PEER` | `1024` | `1`–`65535` |
| `MC_TCP_ADMISSION_TIMEOUT_MS` | `1000` | `1`–`600000` |

Invalid values fall back to their defaults.

`MC_TCP_MAX_CONNECTIONS_PER_PEER` from the earlier revision is retained as a
deprecated alias for `MC_TCP_LANES_PER_PEER` when the new variable is not set,
and emits a warning.

These defaults are initial guardrails rather than workload-specific tuning
claims; feedback on them is welcome.

## Compatibility

When connection pooling is disabled, the existing one-shot connection path is
unchanged.

For legacy protocol compatibility, the test suite covers a pooled legacy
framing initiator communicating with the current server for both WRITE and
READ, including transferred-data verification:

```text
legacy-framing initiator → current server: successful WRITE and READ
```

The stale-descriptor tests separately cover the opposite mismatch:

```text
current v2 initiator → legacy server: bounded, safe failure
```

They verify that a stale v2 descriptor does not cause an indefinite hang or an
unsafe successful completion. This revision does not claim successful
cross-version v2-to-v1 operation, nor does it build and launch a binary from an
older Mooncake commit.

## Tests and validation

New behavioral coverage includes:

- per-peer lane, work-queue, and pending-admission bounds;
- immediate `QUEUE_FULL` rejection only after the pending-admission hard bound
  is also reached;
- FIFO promotion from pending admission into the work queue;
- admission timeout completing exactly once;
- both timeout-versus-capacity-release race orderings;
- clean socket reuse by a single lane;
- work remaining queued while a lane connects;
- concurrent admission and shutdown ownership;
- shutdown with queued, pending-admission, connecting, and busy state;
- late connect, retry-timer, and admission-timer handlers;
- group-level reconnect cooldown against an unavailable peer;
- pooled legacy-framing WRITE and READ interoperability;
- safe bounded failure against a legacy server reached through a stale v2
  descriptor.

Local validation:

- `tcp_write_visibility_test`: `24/24` passed;
- ASan/LSan/UBSan: `24/24` passed with no sanitizer or leak diagnostics;
- targeted TSan admission/retry/shutdown/ownership subset: `10/10` passed;
- production `BUILD_UNIT_TESTS=OFF` build: passed, with no TCP test-hook symbols.

TSan was run on targeted ownership and shutdown tests rather than claimed for
the full suite. A pre-existing race exists between
`Transport::Slice::markSuccess()` and `TcpTransport::getTransferStatus()`;
neither access site is modified by this revision, so a globally clean TSan run
is not claimed.

One `tent-ci (cuda-off)` run failed because the GitHub runner exhausted its
disk space (`No space left on device`). A maintainer confirmed that this
infrastructure failure can be ignored for this PR.

## Known limitations

The pending-admission deadline bounds only the time spent waiting to enter the
work queue.

Once a Slice has been promoted into the admitted-work queue, it no longer has
an admission deadline. A connected transfer that makes no progress and
surfaces no I/O error can therefore hold its lane indefinitely and may leave
already-admitted work waiting behind the fixed lanes.

Payload-progress deadlines, stale-connection detection, and peer-generation
recovery are deliberately left to a follow-up phase of #2930.

The queue bounds also limit item counts rather than total queued source bytes.
`queued_bytes` is maintained as internal accounting, including saturation-safe
handling, but it is not currently an admission limit.

## Suggested review order

1. `tcp_transport.h`
   - `TcpWorkItem` and `TerminalAction`;
   - `PeerConnectionGroup`;
   - `ConnectionLane`;
   - timer, queue, and failure-counter state.
2. `tcp_transport.cpp`
   - configuration parsing and group creation;
   - admission, pending FIFO, promotion, and timeout;
   - pull-at-idle lane scheduling;
   - terminal ownership and completion;
   - reconnect rounds and cooldown;
   - shutdown extraction and deferred completion.
3. `tcp_write_visibility_test.cpp`
   - bounds and FIFO behavior;
   - admission timeout races;
   - reconnect cooldown;
   - shutdown and late-handler ownership;
   - legacy protocol interoperability.