### PR TITLE
[CI/Build] Fix pre-release wheel builds

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -190,6 +190,7 @@ if [ "$OS" = "ubuntu" ] || [ "$OS" = "debian" ]; then
 elif [ "$OS" = "centos" ] || [ "$OS" = "rhel" ] || [ "$OS" = "rocky" ] || [ "$OS" = "almalinux" ] || [ "$OS" = "euleros" ] || [ "$OS" = "openeuler" ]; then
     SYSTEM_PACKAGES="@development \
                      cmake \
+                     ninja-build \
                      git \
                      wget \
                      rdma-core-devel \

--- a/mooncake-transfer-engine/tests/rdma_loopback_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_loopback_test.cpp
@@ -27,10 +27,10 @@
 
 using namespace mooncake;
 
-namespace mooncake {
-
 DEFINE_string(metadata_server, "127.0.0.1:2379",
               "central metadata server for transfer engine");
+
+namespace mooncake {
 
 class RDMALoopbackTest : public ::testing::Test {
    public:

--- a/mooncake-transfer-engine/tests/rdma_transport_test2.cpp
+++ b/mooncake-transfer-engine/tests/rdma_transport_test2.cpp
@@ -28,8 +28,6 @@
 
 using namespace mooncake;
 
-namespace mooncake {
-
 DEFINE_string(local_server_name, getHostname(),
               "Local server name for segment discovery");
 DEFINE_string(metadata_server, "127.0.0.1:2379", "etcd server host address");
@@ -46,6 +44,8 @@ DEFINE_string(nic_priority_matrix, "",
               "Path to RDMA NIC priority matrix file (Advanced)");
 
 DEFINE_string(segment_id, "127.0.0.2", "Segment ID to access data");
+
+namespace mooncake {
 
 std::string formatDeviceNames(const std::string &device_names) {
     std::stringstream ss(device_names);


### PR DESCRIPTION
## Description

Fix the failures observed in Pre-Release run 29564712756 while preserving the existing wheel test coverage:

- install `ninja-build` on RHEL-family systems so the manylinux arm64 jobs can use their configured Ninja generator;
- keep unit-test targets enabled in wheel builds;
- move the affected RDMA test `DEFINE_string` declarations to global scope, as required by the older gflags 2.1.2 shipped in the AlmaLinux 8 manylinux image.

The arm64 jobs failed during CMake configuration because Ninja was unavailable. The non-CUDA Python 3.13 job reached unit-test compilation but gflags 2.1.2 expanded `DEFINE_string` inside `namespace mooncake`, where its internal `StringFlagDestructor` type was unavailable.

No overlapping open issue or pull request was found.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [x] Python Wheel (`mooncake-wheel`)
- [x] CI/CD

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

**Test commands:**
```bash
bash -n dependencies.sh
git diff --check
cmake --build build-v0.3.12-pre4 \
  --target rdma_transport_test2 rdma_loopback_test -j2
pre-commit run --files \
  dependencies.sh \
  mooncake-transfer-engine/tests/rdma_transport_test2.cpp \
  mooncake-transfer-engine/tests/rdma_loopback_test.cpp
```

**Test results:**
- [x] Both affected RDMA test executables compile and link successfully
- [x] Targeted repository pre-commit hooks pass
- [ ] Integration tests pass (not applicable)

## Checklist

- [ ] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh` (via pre-commit)
- [ ] I have run `pre-commit run --all-files` and all hooks pass (targeted hooks passed for changed files)
- [x] I have updated the documentation (not applicable; no user-facing behavior changed)
- [x] I have added tests to prove my changes are effective (existing affected targets were compiled directly)
- [x] For changes >500 LOC: I have filed an RFC issue (not applicable; 13 changed lines)

## AI Assistance Disclosure

- [x] AI tools were used

Codex inspected the failing GitHub Actions logs, identified the missing Ninja package and the old-gflags namespace incompatibility, implemented the focused fixes, and ran the listed checks. The human submitter must review every changed line and be able to defend the change end-to-end before marking this PR ready for review.