### PR TITLE
Improve P2P primary oplog persistence handling

### DIFF
--- a/mooncake-store/include/ha/oplog/oplog_manager.h
+++ b/mooncake-store/include/ha/oplog/oplog_manager.h
@@ -80,7 +80,7 @@ class OpLogManager {
 
     // Persist an already-allocated entry to the store using its sequence_id.
     // Does NOT modify sequence counters.
-    ErrorCode PersistEntry(const OpLogEntry& entry) const;
+    ErrorCode PersistEntry(const OpLogEntry& entry, bool sync = true) const;
 
     // Append a new entry and durably persist it to the store (if OpLogStore is
     // set).
@@ -96,7 +96,7 @@ class OpLogManager {
     //   entry (sequence_id fixed and "smaller" than later entries).
     tl::expected<uint64_t, ErrorCode> AppendAndPersist(
         OpType type, const std::string& key,
-        const std::string& payload = std::string());
+        const std::string& payload = std::string(), bool sync = true);
 
     // Get the latest assigned sequence id. Returns 0 if no entry exists.
     uint64_t GetLastSequenceId() const;

--- a/mooncake-store/include/ha/oplog/p2p_oplog_types.h
+++ b/mooncake-store/include/ha/oplog/p2p_oplog_types.h
@@ -67,7 +67,7 @@ struct AddReplicaPayload {
     YLT_REFL(AddReplicaPayload, object_key, client_id, segment_id, size);
 };
 
-/// Payload for REMOVE_REPLICA (OpType=11, async).
+/// Payload for REMOVE_REPLICA (OpType=11, sync).
 /// Records that a replica was removed from an object.
 struct RemoveReplicaPayload {
     std::string object_key;

--- a/mooncake-store/include/ha/oplog/redis_oplog_store.h
+++ b/mooncake-store/include/ha/oplog/redis_oplog_store.h
@@ -2,11 +2,18 @@
 
 #ifdef STORE_USE_REDIS
 
+#include <atomic>
+#include <condition_variable>
+#include <deque>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <set>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include <hiredis/hiredis.h>
-#include <mutex>
 
 #include "ha/oplog/oplog_store.h"
 #include "redis_util.h"
@@ -42,10 +49,30 @@ class RedisOpLogStore : public OpLogStore {
         const std::string& cluster_id) override;
 
    private:
+    struct PendingWrite {
+        explicit PendingWrite(OpLogEntry entry, bool sync)
+            : entry(std::move(entry)), sync(sync) {}
+
+        OpLogEntry entry;
+        bool sync{true};
+        bool done{false};
+        ErrorCode result{ErrorCode::OK};
+        size_t attempts{0};
+    };
+
     redisContext* CreateConnection() const;
     ErrorCode EnsureConnectedUnlocked();
     ErrorCode ReadOpLogUnlocked(uint64_t sequence_id, OpLogEntry& entry);
     bool IsValidSnapshotId(const std::string& snapshot_id) const;
+    ErrorCode EnqueueWrite(const OpLogEntry& entry, bool sync);
+    void StartAsyncWorkers();
+    void StopAsyncWorkers();
+    void AsyncWriteLoop(size_t worker_id);
+    ErrorCode PersistEntryNoLatest(redisContext* ctx, const OpLogEntry& entry);
+    ErrorCode AdvanceCommittedLatestUnlocked(redisContext* ctx);
+    void CompleteWrite(redisContext* ctx,
+                       const std::shared_ptr<PendingWrite>& pending,
+                       ErrorCode result);
 
     std::string EntryKey(uint64_t sequence_id) const;
     std::string SnapshotKey(const std::string& snapshot_id) const;
@@ -57,12 +84,34 @@ class RedisOpLogStore : public OpLogStore {
     int db_index_;
     bool enable_write_;
     int poll_interval_ms_;
+
+    // Redis oplog key model:
+    // - latest: committed contiguous sequence watermark, safe for standby
+    // replay
+    // - trimmed: highest sequence already removed by cleanup
+    // - entry:<seq>: serialized oplog payload
     std::string key_tag_;
-    std::string index_key_;
     std::string latest_key_;
+    std::string trimmed_key_;
     std::string snapshot_prefix_;
     redisContext* ctx_{nullptr};
     mutable std::mutex mutex_;
+
+    mutable std::mutex async_mutex_;
+    std::condition_variable async_cv_;
+    std::condition_variable sync_cv_;
+    std::deque<std::shared_ptr<PendingWrite>> pending_writes_;
+    std::map<uint64_t, std::shared_ptr<PendingWrite>> inflight_writes_;
+    std::set<uint64_t> persisted_sequences_;
+    uint64_t committed_sequence_id_{0};
+    std::atomic<bool> async_running_{false};
+    std::vector<std::thread> async_workers_;
+
+    static constexpr size_t kAsyncWorkerCount = 4;
+    static constexpr size_t kMaxAsyncQueueSize = 100000;
+    static constexpr size_t kCleanupBatchSize = 1000;
+    static constexpr int kAsyncRetryDelayMs = 100;
+    static constexpr int kSyncWaitTimeoutMs = 30000;
 };
 
 }  // namespace mooncake

--- a/mooncake-store/include/ha/oplog/redis_oplog_store.h
+++ b/mooncake-store/include/ha/oplog/redis_oplog_store.h
@@ -16,6 +16,7 @@
 #include <hiredis/hiredis.h>
 
 #include "ha/oplog/oplog_store.h"
+#include "mutex.h"
 #include "redis_util.h"
 
 namespace mooncake {
@@ -94,16 +95,18 @@ class RedisOpLogStore : public OpLogStore {
     std::string latest_key_;
     std::string trimmed_key_;
     std::string snapshot_prefix_;
-    redisContext* ctx_{nullptr};
     mutable std::mutex mutex_;
+    redisContext* ctx_ GUARDED_BY(mutex_) = nullptr;
 
     mutable std::mutex async_mutex_;
     std::condition_variable async_cv_;
     std::condition_variable sync_cv_;
-    std::deque<std::shared_ptr<PendingWrite>> pending_writes_;
-    std::map<uint64_t, std::shared_ptr<PendingWrite>> inflight_writes_;
-    std::set<uint64_t> persisted_sequences_;
-    uint64_t committed_sequence_id_{0};
+    std::deque<std::shared_ptr<PendingWrite>> pending_writes_
+        GUARDED_BY(async_mutex_);
+    std::map<uint64_t, std::shared_ptr<PendingWrite>> inflight_writes_
+        GUARDED_BY(async_mutex_);
+    std::set<uint64_t> persisted_sequences_ GUARDED_BY(async_mutex_);
+    uint64_t committed_sequence_id_ GUARDED_BY(async_mutex_) = 0;
     std::atomic<bool> async_running_{false};
     std::vector<std::thread> async_workers_;
 

--- a/mooncake-store/include/p2p_master_service.h
+++ b/mooncake-store/include/p2p_master_service.h
@@ -84,7 +84,8 @@ class P2PMasterService : public MasterService {
         uint64_t last_applied_sequence_id = 0);
 
     ErrorCode RecordOplog(OpType type, const std::string& key,
-                          const std::string& payload = std::string());
+                          const std::string& payload = std::string(),
+                          bool sync = true);
 
     std::vector<Replica::Descriptor> FilterReplicas(
         const GetReplicaListRequestConfig& config,
@@ -130,12 +131,19 @@ class P2PMasterService : public MasterService {
         MetadataShard& shard, std::string_view key, const UUID& client_id,
         const UUID& segment_id) NO_THREAD_SAFETY_ANALYSIS;
 
+    ErrorCode RecordOplogOrError(OpType type, const std::string& key,
+                                 const std::string& payload,
+                                 const char* operation,
+                                 const std::string& details = std::string(),
+                                 bool sync = true);
+
     std::shared_ptr<P2PClientManager> client_manager_;
     std::array<P2PMetadataShard, kNumShards> metadata_shards_;
     // for the number of clients owning a key:
     // 1. max_replicas_per_key_ == 0 means no limitation
     // 2. max_replicas_per_key_ > 0 means the max client owner count
     uint64_t max_replicas_per_key_;
+    bool async_add_replica_oplog_{false};
 };
 
 }  // namespace mooncake

--- a/mooncake-store/include/p2p_master_service.h
+++ b/mooncake-store/include/p2p_master_service.h
@@ -131,12 +131,6 @@ class P2PMasterService : public MasterService {
         MetadataShard& shard, std::string_view key, const UUID& client_id,
         const UUID& segment_id) NO_THREAD_SAFETY_ANALYSIS;
 
-    ErrorCode RecordOplogOrError(OpType type, const std::string& key,
-                                 const std::string& payload,
-                                 const char* operation,
-                                 const std::string& details = std::string(),
-                                 bool sync = true);
-
     std::shared_ptr<P2PClientManager> client_manager_;
     std::array<P2PMetadataShard, kNumShards> metadata_shards_;
     // for the number of clients owning a key:

--- a/mooncake-store/src/ha/oplog/oplog_manager.cpp
+++ b/mooncake-store/src/ha/oplog/oplog_manager.cpp
@@ -82,23 +82,22 @@ OpLogEntry OpLogManager::AllocateEntry(OpType type, const std::string& key,
     return entry;
 }
 
-ErrorCode OpLogManager::PersistEntry(const OpLogEntry& entry) const {
+ErrorCode OpLogManager::PersistEntry(const OpLogEntry& entry, bool sync) const {
     std::shared_lock<std::shared_mutex> lock(mutex_);
     auto store = oplog_store_;
     lock.unlock();
     if (!store) {
         return ErrorCode::INTERNAL_ERROR;
     }
-    // Strategy 2+: PUT_END is Async, REMOVE (and others) are Sync
-    bool sync = (entry.op_type != OpType::PUT_END);
     return store->WriteOpLog(entry, sync);
 }
 
 tl::expected<uint64_t, ErrorCode> OpLogManager::AppendAndPersist(
-    OpType type, const std::string& key, const std::string& payload) {
+    OpType type, const std::string& key, const std::string& payload,
+    bool sync) {
     // Seq pre-allocation semantics: allocate first, then persist.
     OpLogEntry entry = AllocateEntry(type, key, payload);
-    ErrorCode err = PersistEntry(entry);
+    ErrorCode err = PersistEntry(entry, sync);
     if (err != ErrorCode::OK) {
         return tl::make_unexpected(err);
     }

--- a/mooncake-store/src/ha/oplog/redis_oplog_store.cpp
+++ b/mooncake-store/src/ha/oplog/redis_oplog_store.cpp
@@ -8,6 +8,7 @@
 #include <cstring>
 #include <iomanip>
 #include <sstream>
+#include <string_view>
 
 #include "ha/oplog/oplog_serializer.h"
 #include "ha/oplog/polling_oplog_change_notifier.h"
@@ -341,10 +342,26 @@ ErrorCode RedisOpLogStore::PersistEntryNoLatest(redisContext* ctx,
         return ErrorCode::OK;
     }
     if (reply->type == REDIS_REPLY_NIL) {
-        // TODO(P2P HA): Read and compare an existing entry. Treat identical
-        // content as idempotent retry success and only reject conflicts.
-        LOG(ERROR) << "RedisOpLogStore::PersistEntryNoLatest: sequence already "
-                      "exists"
+        RedisReplyPtr existing((redisReply*)redisCommand(
+            ctx, "GET %b", entry_key.data(), entry_key.size()));
+        if (!existing || existing->type == REDIS_REPLY_ERROR) {
+            LOG(ERROR) << "RedisOpLogStore::PersistEntryNoLatest: GET existing "
+                          "entry failed"
+                       << ", sequence_id=" << entry.sequence_id;
+            return ErrorCode::INTERNAL_ERROR;
+        }
+        if (existing->type == REDIS_REPLY_STRING &&
+            std::string_view(existing->str, existing->len) == serialized) {
+            return ErrorCode::OK;
+        }
+        if (existing->type == REDIS_REPLY_NIL) {
+            LOG(WARNING) << "RedisOpLogStore::PersistEntryNoLatest: existing "
+                            "entry disappeared before comparison, retrying"
+                         << ", sequence_id=" << entry.sequence_id;
+            return ErrorCode::INTERNAL_ERROR;
+        }
+        LOG(ERROR) << "RedisOpLogStore::PersistEntryNoLatest: conflicting "
+                      "entry already exists"
                    << ", sequence_id=" << entry.sequence_id;
         return ErrorCode::INVALID_PARAMS;
     }
@@ -500,6 +517,9 @@ ErrorCode RedisOpLogStore::ReadOpLogSince(uint64_t start_sequence_id,
         return ErrorCode::INTERNAL_ERROR;
     }
 
+    // TODO(P2P HA): Do not silently advance a lagging standby past the trim
+    // horizon. Detect start_sequence_id < trimmed_sequence_id and handle it
+    // together with standby snapshot/bootstrap recovery.
     const uint64_t effective_start =
         std::max(start_sequence_id, trimmed_sequence_id);
     if (effective_start >= latest_sequence_id) {
@@ -624,6 +644,8 @@ ErrorCode RedisOpLogStore::GetMaxSequenceId(uint64_t& sequence_id) {
     return ErrorCode::OK;
 }
 
+// Recovery/admin operation inherited from OpLogStore. It must not run
+// concurrently with normal writes.
 ErrorCode RedisOpLogStore::UpdateLatestSequenceId(uint64_t sequence_id) {
     std::lock_guard<std::mutex> lock(mutex_);
     auto err = EnsureConnectedUnlocked();

--- a/mooncake-store/src/ha/oplog/redis_oplog_store.cpp
+++ b/mooncake-store/src/ha/oplog/redis_oplog_store.cpp
@@ -59,12 +59,13 @@ RedisOpLogStore::RedisOpLogStore(const std::string& cluster_id,
         cluster_id_ = "default";
     }
     key_tag_ = "mooncake:{" + cluster_id_ + "}:oplog";
-    index_key_ = key_tag_ + ":index";
     latest_key_ = key_tag_ + ":latest";
+    trimmed_key_ = key_tag_ + ":trimmed";
     snapshot_prefix_ = key_tag_ + ":snapshot:";
 }
 
 RedisOpLogStore::~RedisOpLogStore() {
+    StopAsyncWorkers();
     std::lock_guard<std::mutex> lock(mutex_);
     if (ctx_) {
         redisFree(ctx_);
@@ -102,6 +103,7 @@ ErrorCode RedisOpLogStore::Init() {
     if (err != ErrorCode::OK) {
         return err;
     }
+    uint64_t latest = 0;
     if (enable_write_) {
         const std::string zero_seq = SequenceMember(0);
         RedisReplyPtr reply((redisReply*)redisCommand(
@@ -111,6 +113,32 @@ ErrorCode RedisOpLogStore::Init() {
             LOG(ERROR) << "RedisOpLogStore::Init: SETNX latest failed";
             return ErrorCode::INTERNAL_ERROR;
         }
+        RedisReplyPtr trim_reply((redisReply*)redisCommand(
+            ctx_, "SETNX %b %b", trimmed_key_.data(), trimmed_key_.size(),
+            zero_seq.data(), zero_seq.size()));
+        if (!trim_reply || trim_reply->type == REDIS_REPLY_ERROR) {
+            LOG(ERROR) << "RedisOpLogStore::Init: SETNX trimmed failed";
+            return ErrorCode::INTERNAL_ERROR;
+        }
+    }
+    RedisReplyPtr latest_reply((redisReply*)redisCommand(
+        ctx_, "GET %b", latest_key_.data(), latest_key_.size()));
+    if (!latest_reply || latest_reply->type == REDIS_REPLY_ERROR) {
+        LOG(ERROR) << "RedisOpLogStore::Init: GET latest failed";
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    if (latest_reply->type == REDIS_REPLY_STRING &&
+        !ParseUint64(std::string(latest_reply->str, latest_reply->len),
+                     latest)) {
+        LOG(ERROR) << "RedisOpLogStore::Init: invalid latest value";
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    {
+        std::lock_guard<std::mutex> async_lock(async_mutex_);
+        committed_sequence_id_ = latest;
+    }
+    if (enable_write_) {
+        StartAsyncWorkers();
     }
     return ErrorCode::OK;
 }
@@ -123,56 +151,271 @@ std::string RedisOpLogStore::SnapshotKey(const std::string& snapshot_id) const {
     return snapshot_prefix_ + snapshot_id;
 }
 
-ErrorCode RedisOpLogStore::WriteOpLog(const OpLogEntry& entry, bool /*sync*/) {
-    std::lock_guard<std::mutex> lock(mutex_);
+// TODO(P2P HA): Redis now uses latest as a committed watermark. Async
+// workers may persist entries out of order, but latest only advances across
+// contiguous successful sequence IDs. A future throughput optimization can add
+// larger pipelined batches per worker; standby should continue to replay only
+// entries <= committed latest.
+ErrorCode RedisOpLogStore::WriteOpLog(const OpLogEntry& entry, bool sync) {
+    return EnqueueWrite(entry, sync);
+}
+
+ErrorCode RedisOpLogStore::EnqueueWrite(const OpLogEntry& entry, bool sync) {
     if (!enable_write_) {
         LOG(ERROR) << "RedisOpLogStore::WriteOpLog called on reader";
         return ErrorCode::INVALID_PARAMS;
     }
-    auto err = EnsureConnectedUnlocked();
-    if (err != ErrorCode::OK) {
-        return err;
+
+    std::shared_ptr<PendingWrite> pending;
+    bool wait_for_completion = sync;
+    {
+        std::lock_guard<std::mutex> lock(async_mutex_);
+        if (!async_running_.load()) {
+            LOG(ERROR) << "RedisOpLogStore: write queue is not running"
+                       << ", sequence_id=" << entry.sequence_id
+                       << ", sync=" << sync;
+            return ErrorCode::INTERNAL_ERROR;
+        }
+
+        auto existing = inflight_writes_.find(entry.sequence_id);
+        if (existing != inflight_writes_.end()) {
+            pending = existing->second;
+        } else {
+            if (!sync && pending_writes_.size() + inflight_writes_.size() >=
+                             kMaxAsyncQueueSize) {
+                wait_for_completion = true;
+                LOG(WARNING) << "RedisOpLogStore: async queue full, falling "
+                                "back to sync write"
+                             << ", sequence_id=" << entry.sequence_id
+                             << ", queue_size=" << pending_writes_.size()
+                             << ", inflight_size=" << inflight_writes_.size();
+            }
+            pending =
+                std::make_shared<PendingWrite>(entry, wait_for_completion);
+            inflight_writes_[entry.sequence_id] = pending;
+            pending_writes_.push_back(pending);
+        }
+    }
+    async_cv_.notify_one();
+
+    if (!wait_for_completion) {
+        return ErrorCode::OK;
     }
 
+    std::unique_lock<std::mutex> lock(async_mutex_);
+    bool completed = sync_cv_.wait_for(
+        lock, std::chrono::milliseconds(kSyncWaitTimeoutMs),
+        [&] { return pending->done || !async_running_.load(); });
+    if (!completed) {
+        // TODO(P2P HA): Return an explicit commit-unknown status; this entry
+        // remains pending and may still be committed.
+        LOG(ERROR) << "RedisOpLogStore::WriteOpLog: sync wait timed out"
+                   << ", sequence_id=" << entry.sequence_id;
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    return pending->result;
+}
+
+void RedisOpLogStore::StartAsyncWorkers() {
+    bool expected = false;
+    if (!async_running_.compare_exchange_strong(expected, true)) {
+        return;
+    }
+    async_workers_.reserve(kAsyncWorkerCount);
+    for (size_t i = 0; i < kAsyncWorkerCount; ++i) {
+        async_workers_.emplace_back(&RedisOpLogStore::AsyncWriteLoop, this, i);
+    }
+}
+
+void RedisOpLogStore::StopAsyncWorkers() {
+    // TODO(P2P HA): Support graceful flush/drain before stopping workers.
+    if (!async_running_.exchange(false)) {
+        return;
+    }
+    async_cv_.notify_all();
+    for (auto& worker : async_workers_) {
+        if (worker.joinable()) {
+            worker.join();
+        }
+    }
+    async_workers_.clear();
+
+    std::lock_guard<std::mutex> lock(async_mutex_);
+    size_t unfinished_count = 0;
+    for (const auto& [seq, pending] : inflight_writes_) {
+        if (!pending->done) {
+            ++unfinished_count;
+        }
+    }
+    if (unfinished_count > 0) {
+        LOG(ERROR) << "RedisOpLogStore: stopping with unfinished writes"
+                   << ", unfinished_count=" << unfinished_count;
+    }
+    for (auto& [seq, pending] : inflight_writes_) {
+        if (!pending->done) {
+            pending->done = true;
+            pending->result = ErrorCode::INTERNAL_ERROR;
+        }
+    }
+    sync_cv_.notify_all();
+}
+
+void RedisOpLogStore::AsyncWriteLoop(size_t worker_id) {
+    redisContext* ctx = CreateConnection();
+    while (async_running_.load()) {
+        std::shared_ptr<PendingWrite> pending;
+        {
+            std::unique_lock<std::mutex> lock(async_mutex_);
+            async_cv_.wait(lock, [&] {
+                return !async_running_.load() || !pending_writes_.empty();
+            });
+            if (!async_running_.load() && pending_writes_.empty()) {
+                break;
+            }
+            pending = pending_writes_.front();
+            pending_writes_.pop_front();
+        }
+
+        if (!ctx || ctx->err) {
+            if (ctx) {
+                redisFree(ctx);
+            }
+            ctx = CreateConnection();
+        }
+        // TODO(P2P HA): Batch several queued entries per worker and pipeline
+        // their SET NX commands to reduce Redis round trips. Keep the current
+        // one-entry retry path until batch error handling and partial reply
+        // draining are covered by tests.
+        ErrorCode err = ctx ? PersistEntryNoLatest(ctx, pending->entry)
+                            : ErrorCode::INTERNAL_ERROR;
+        if (err != ErrorCode::OK) {
+            if (err == ErrorCode::INVALID_PARAMS) {
+                CompleteWrite(ctx, pending, err);
+                continue;
+            }
+            if (ctx) {
+                redisFree(ctx);
+                ctx = nullptr;
+            }
+            ++pending->attempts;
+            // TODO(P2P HA): Add bounded exponential backoff, jitter, and
+            // pending/retry metrics.
+            LOG(WARNING) << "RedisOpLogStore: async write failed, retrying"
+                         << ", worker_id=" << worker_id
+                         << ", sequence_id=" << pending->entry.sequence_id
+                         << ", attempts=" << pending->attempts
+                         << ", error=" << toString(err);
+            std::this_thread::sleep_for(
+                std::chrono::milliseconds(kAsyncRetryDelayMs));
+            {
+                std::lock_guard<std::mutex> lock(async_mutex_);
+                if (async_running_.load()) {
+                    pending_writes_.push_front(pending);
+                }
+            }
+            async_cv_.notify_one();
+            continue;
+        }
+
+        CompleteWrite(ctx, pending, ErrorCode::OK);
+    }
+    if (ctx) {
+        redisFree(ctx);
+    }
+}
+
+ErrorCode RedisOpLogStore::PersistEntryNoLatest(redisContext* ctx,
+                                                const OpLogEntry& entry) {
     const std::string entry_key = EntryKey(entry.sequence_id);
     const std::string serialized = SerializeOpLogEntry(entry);
-    const std::string seq_member = SequenceMember(entry.sequence_id);
-    const std::string zero_seq = SequenceMember(0);
-    static constexpr const char* kWriteScript = R"(
-local existing = redis.call('GET', KEYS[1])
-if existing then
-  if existing == ARGV[1] then
-    redis.call('ZADD', KEYS[2], 0, ARGV[2])
-    local latest = redis.call('GET', KEYS[3]) or ARGV[3]
-    if ARGV[2] > latest then redis.call('SET', KEYS[3], ARGV[2]) end
-    return 1
-  end
-  return -1
-end
-redis.call('SET', KEYS[1], ARGV[1])
-redis.call('ZADD', KEYS[2], 0, ARGV[2])
-local latest = redis.call('GET', KEYS[3]) or ARGV[3]
-if ARGV[2] > latest then redis.call('SET', KEYS[3], ARGV[2]) end
-return 1
-)";
-
     RedisReplyPtr reply((redisReply*)redisCommand(
-        ctx_, "EVAL %s 3 %b %b %b %b %b %b", kWriteScript, entry_key.data(),
-        entry_key.size(), index_key_.data(), index_key_.size(),
-        latest_key_.data(), latest_key_.size(), serialized.data(),
-        serialized.size(), seq_member.data(), seq_member.size(),
-        zero_seq.data(), zero_seq.size()));
+        ctx, "SET %b %b NX", entry_key.data(), entry_key.size(),
+        serialized.data(), serialized.size()));
     if (!reply || reply->type == REDIS_REPLY_ERROR) {
-        LOG(ERROR) << "RedisOpLogStore::WriteOpLog: Redis command failed"
+        LOG(ERROR) << "RedisOpLogStore::PersistEntryNoLatest: Redis command "
+                      "failed"
                    << ", sequence_id=" << entry.sequence_id;
         return ErrorCode::INTERNAL_ERROR;
     }
-    if (reply->type != REDIS_REPLY_INTEGER || reply->integer != 1) {
-        LOG(ERROR) << "RedisOpLogStore::WriteOpLog: fencing violation"
+    if (reply->type == REDIS_REPLY_STATUS) {
+        return ErrorCode::OK;
+    }
+    if (reply->type == REDIS_REPLY_NIL) {
+        // TODO(P2P HA): Read and compare an existing entry. Treat identical
+        // content as idempotent retry success and only reject conflicts.
+        LOG(ERROR) << "RedisOpLogStore::PersistEntryNoLatest: sequence already "
+                      "exists"
                    << ", sequence_id=" << entry.sequence_id;
+        return ErrorCode::INVALID_PARAMS;
+    }
+    LOG(ERROR) << "RedisOpLogStore::PersistEntryNoLatest: unexpected reply "
+                  "type"
+               << ", type=" << reply->type
+               << ", sequence_id=" << entry.sequence_id;
+    return ErrorCode::INTERNAL_ERROR;
+}
+
+ErrorCode RedisOpLogStore::AdvanceCommittedLatestUnlocked(redisContext* ctx) {
+    uint64_t target = committed_sequence_id_;
+    while (persisted_sequences_.find(target + 1) !=
+           persisted_sequences_.end()) {
+        ++target;
+    }
+    if (target == committed_sequence_id_) {
+        return ErrorCode::OK;
+    }
+
+    const std::string seq = SequenceMember(target);
+    RedisReplyPtr reply(
+        (redisReply*)redisCommand(ctx, "SET %b %b", latest_key_.data(),
+                                  latest_key_.size(), seq.data(), seq.size()));
+    if (!reply || reply->type == REDIS_REPLY_ERROR) {
+        LOG(ERROR) << "RedisOpLogStore::AdvanceCommittedLatest: SET failed"
+                   << ", target=" << target;
         return ErrorCode::INTERNAL_ERROR;
     }
+
+    for (uint64_t seq_id = committed_sequence_id_ + 1; seq_id <= target;
+         ++seq_id) {
+        persisted_sequences_.erase(seq_id);
+        auto it = inflight_writes_.find(seq_id);
+        if (it != inflight_writes_.end()) {
+            it->second->done = true;
+            it->second->result = ErrorCode::OK;
+            inflight_writes_.erase(it);
+        }
+    }
+    committed_sequence_id_ = target;
+    sync_cv_.notify_all();
     return ErrorCode::OK;
+}
+
+void RedisOpLogStore::CompleteWrite(
+    redisContext* ctx, const std::shared_ptr<PendingWrite>& pending,
+    ErrorCode result) {
+    std::lock_guard<std::mutex> lock(async_mutex_);
+    if (result != ErrorCode::OK) {
+        pending->done = true;
+        pending->result = result;
+        inflight_writes_.erase(pending->entry.sequence_id);
+        sync_cv_.notify_all();
+        return;
+    }
+
+    if (pending->entry.sequence_id <= committed_sequence_id_) {
+        pending->done = true;
+        pending->result = ErrorCode::OK;
+        inflight_writes_.erase(pending->entry.sequence_id);
+        sync_cv_.notify_all();
+        return;
+    }
+
+    persisted_sequences_.insert(pending->entry.sequence_id);
+    ErrorCode latest_err = AdvanceCommittedLatestUnlocked(ctx);
+    if (latest_err != ErrorCode::OK) {
+        pending_writes_.push_front(pending);
+        async_cv_.notify_one();
+    }
 }
 
 ErrorCode RedisOpLogStore::ReadOpLog(uint64_t sequence_id, OpLogEntry& entry) {
@@ -227,36 +470,50 @@ ErrorCode RedisOpLogStore::ReadOpLogSince(uint64_t start_sequence_id,
         return err;
     }
 
-    const std::string min_member = "(" + SequenceMember(start_sequence_id);
-    const std::string limit_str = std::to_string(limit);
-    RedisReplyPtr reply((redisReply*)redisCommand(
-        ctx_, "ZRANGEBYLEX %b %b + LIMIT 0 %b", index_key_.data(),
-        index_key_.size(), min_member.data(), min_member.size(),
-        limit_str.data(), limit_str.size()));
-    if (!reply || reply->type == REDIS_REPLY_ERROR) {
-        LOG(ERROR) << "RedisOpLogStore::ReadOpLogSince: ZRANGEBYLEX failed"
+    uint64_t latest_sequence_id = 0;
+    RedisReplyPtr latest_reply((redisReply*)redisCommand(
+        ctx_, "GET %b", latest_key_.data(), latest_key_.size()));
+    if (!latest_reply || latest_reply->type == REDIS_REPLY_ERROR) {
+        LOG(ERROR) << "RedisOpLogStore::ReadOpLogSince: GET latest failed"
                    << ", start_sequence_id=" << start_sequence_id;
         return ErrorCode::INTERNAL_ERROR;
     }
-    if (reply->type != REDIS_REPLY_ARRAY) {
-        LOG(ERROR) << "RedisOpLogStore::ReadOpLogSince: unexpected reply type"
-                   << ", type=" << reply->type;
+    if (latest_reply->type == REDIS_REPLY_STRING &&
+        !ParseUint64(std::string(latest_reply->str, latest_reply->len),
+                     latest_sequence_id)) {
+        LOG(ERROR) << "RedisOpLogStore::ReadOpLogSince: invalid latest value";
         return ErrorCode::INTERNAL_ERROR;
     }
 
+    uint64_t trimmed_sequence_id = 0;
+    RedisReplyPtr trimmed_reply((redisReply*)redisCommand(
+        ctx_, "GET %b", trimmed_key_.data(), trimmed_key_.size()));
+    if (!trimmed_reply || trimmed_reply->type == REDIS_REPLY_ERROR) {
+        LOG(ERROR) << "RedisOpLogStore::ReadOpLogSince: GET trimmed failed"
+                   << ", start_sequence_id=" << start_sequence_id;
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    if (trimmed_reply->type == REDIS_REPLY_STRING &&
+        !ParseUint64(std::string(trimmed_reply->str, trimmed_reply->len),
+                     trimmed_sequence_id)) {
+        LOG(ERROR) << "RedisOpLogStore::ReadOpLogSince: invalid trimmed value";
+        return ErrorCode::INTERNAL_ERROR;
+    }
+
+    const uint64_t effective_start =
+        std::max(start_sequence_id, trimmed_sequence_id);
+    if (effective_start >= latest_sequence_id) {
+        return ErrorCode::OK;
+    }
+
     std::vector<uint64_t> sequence_ids;
-    sequence_ids.reserve(reply->elements);
-    for (size_t i = 0; i < reply->elements; ++i) {
-        redisReply* item = reply->element[i];
-        if (!item || item->type != REDIS_REPLY_STRING) {
-            LOG(ERROR) << "RedisOpLogStore::ReadOpLogSince: invalid seq reply";
-            return ErrorCode::INTERNAL_ERROR;
-        }
-        uint64_t sequence_id = 0;
-        if (!ParseUint64(std::string(item->str, item->len), sequence_id)) {
-            LOG(ERROR) << "RedisOpLogStore::ReadOpLogSince: invalid seq value";
-            return ErrorCode::INTERNAL_ERROR;
-        }
+    const uint64_t available = latest_sequence_id - effective_start;
+    const size_t read_count =
+        static_cast<size_t>(std::min<uint64_t>(available, limit));
+    sequence_ids.reserve(read_count);
+    for (uint64_t sequence_id = effective_start + 1;
+         sequence_id <= latest_sequence_id && sequence_ids.size() < read_count;
+         ++sequence_id) {
         sequence_ids.push_back(sequence_id);
     }
 
@@ -288,9 +545,10 @@ ErrorCode RedisOpLogStore::ReadOpLogSince(uint64_t start_sequence_id,
         }
         RedisReplyPtr entry_reply(raw_reply);
         if (entry_reply->type == REDIS_REPLY_NIL) {
-            LOG(ERROR) << "RedisOpLogStore::ReadOpLogSince: missing indexed "
+            LOG(ERROR) << "RedisOpLogStore::ReadOpLogSince: missing committed "
                           "entry"
-                       << ", sequence_id=" << sequence_ids[i];
+                       << ", sequence_id=" << sequence_ids[i]
+                       << ", latest_sequence_id=" << latest_sequence_id;
             redisFree(ctx_);
             ctx_ = nullptr;
             entries.clear();
@@ -356,33 +614,12 @@ ErrorCode RedisOpLogStore::GetLatestSequenceId(uint64_t& sequence_id) {
 }
 
 ErrorCode RedisOpLogStore::GetMaxSequenceId(uint64_t& sequence_id) {
-    std::lock_guard<std::mutex> lock(mutex_);
-    auto err = EnsureConnectedUnlocked();
+    auto err = GetLatestSequenceId(sequence_id);
     if (err != ErrorCode::OK) {
         return err;
     }
-    RedisReplyPtr reply(
-        (redisReply*)redisCommand(ctx_, "ZREVRANGEBYLEX %b + - LIMIT 0 1",
-                                  index_key_.data(), index_key_.size()));
-    if (!reply || reply->type == REDIS_REPLY_ERROR) {
-        LOG(ERROR)
-            << "RedisOpLogStore::GetMaxSequenceId: ZREVRANGEBYLEX failed";
-        return ErrorCode::INTERNAL_ERROR;
-    }
-    if (reply->type != REDIS_REPLY_ARRAY) {
-        LOG(ERROR) << "RedisOpLogStore::GetMaxSequenceId: unexpected reply "
-                      "type"
-                   << ", type=" << reply->type;
-        return ErrorCode::INTERNAL_ERROR;
-    }
-    if (reply->elements == 0) {
+    if (sequence_id == 0) {
         return ErrorCode::OPLOG_ENTRY_NOT_FOUND;
-    }
-    redisReply* item = reply->element[0];
-    if (!item || item->type != REDIS_REPLY_STRING ||
-        !ParseUint64(std::string(item->str, item->len), sequence_id)) {
-        LOG(ERROR) << "RedisOpLogStore::GetMaxSequenceId: invalid seq value";
-        return ErrorCode::INTERNAL_ERROR;
     }
     return ErrorCode::OK;
 }
@@ -401,6 +638,14 @@ ErrorCode RedisOpLogStore::UpdateLatestSequenceId(uint64_t sequence_id) {
         LOG(ERROR) << "RedisOpLogStore::UpdateLatestSequenceId: SET failed";
         return ErrorCode::INTERNAL_ERROR;
     }
+    {
+        std::lock_guard<std::mutex> async_lock(async_mutex_);
+        committed_sequence_id_ = sequence_id;
+        persisted_sequences_.erase(
+            persisted_sequences_.begin(),
+            persisted_sequences_.upper_bound(sequence_id));
+    }
+    sync_cv_.notify_all();
     return ErrorCode::OK;
 }
 
@@ -466,34 +711,110 @@ ErrorCode RedisOpLogStore::GetSnapshotSequenceId(const std::string& snapshot_id,
 }
 
 ErrorCode RedisOpLogStore::CleanupOpLogBefore(uint64_t before_sequence_id) {
-    std::lock_guard<std::mutex> lock(mutex_);
     if (before_sequence_id == 0) {
         return ErrorCode::OK;
     }
-    auto err = EnsureConnectedUnlocked();
-    if (err != ErrorCode::OK) {
-        return err;
-    }
+    const uint64_t requested_target = before_sequence_id - 1;
 
-    const std::string max_member = "[" + SequenceMember(before_sequence_id - 1);
-    static constexpr const char* kCleanupScript = R"(
-local members = redis.call('ZRANGEBYLEX', KEYS[1], '-', ARGV[1])
-for _, member in ipairs(members) do
-  redis.call('DEL', ARGV[2] .. member)
-end
-redis.call('ZREMRANGEBYLEX', KEYS[1], '-', ARGV[1])
-return #members
-)";
-    const std::string entry_prefix = key_tag_ + ":entry:";
-    RedisReplyPtr reply((redisReply*)redisCommand(
-        ctx_, "EVAL %s 1 %b %b %b", kCleanupScript, index_key_.data(),
-        index_key_.size(), max_member.data(), max_member.size(),
-        entry_prefix.data(), entry_prefix.size()));
-    if (!reply || reply->type == REDIS_REPLY_ERROR) {
-        LOG(ERROR) << "RedisOpLogStore::CleanupOpLogBefore: cleanup failed";
-        return ErrorCode::INTERNAL_ERROR;
+    while (true) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto err = EnsureConnectedUnlocked();
+        if (err != ErrorCode::OK) {
+            return err;
+        }
+
+        uint64_t latest_sequence_id = 0;
+        RedisReplyPtr latest_reply((redisReply*)redisCommand(
+            ctx_, "GET %b", latest_key_.data(), latest_key_.size()));
+        if (!latest_reply || latest_reply->type == REDIS_REPLY_ERROR) {
+            LOG(ERROR)
+                << "RedisOpLogStore::CleanupOpLogBefore: GET latest failed";
+            return ErrorCode::INTERNAL_ERROR;
+        }
+        if (latest_reply->type == REDIS_REPLY_STRING &&
+            !ParseUint64(std::string(latest_reply->str, latest_reply->len),
+                         latest_sequence_id)) {
+            LOG(ERROR)
+                << "RedisOpLogStore::CleanupOpLogBefore: invalid latest value";
+            return ErrorCode::INTERNAL_ERROR;
+        }
+
+        uint64_t trimmed_sequence_id = 0;
+        RedisReplyPtr trimmed_reply((redisReply*)redisCommand(
+            ctx_, "GET %b", trimmed_key_.data(), trimmed_key_.size()));
+        if (!trimmed_reply || trimmed_reply->type == REDIS_REPLY_ERROR) {
+            LOG(ERROR)
+                << "RedisOpLogStore::CleanupOpLogBefore: GET trimmed failed";
+            return ErrorCode::INTERNAL_ERROR;
+        }
+        if (trimmed_reply->type == REDIS_REPLY_STRING &&
+            !ParseUint64(std::string(trimmed_reply->str, trimmed_reply->len),
+                         trimmed_sequence_id)) {
+            LOG(ERROR)
+                << "RedisOpLogStore::CleanupOpLogBefore: invalid trimmed value";
+            return ErrorCode::INTERNAL_ERROR;
+        }
+
+        const uint64_t cleanup_target =
+            std::min(requested_target, latest_sequence_id);
+        if (cleanup_target <= trimmed_sequence_id) {
+            return ErrorCode::OK;
+        }
+
+        const uint64_t batch_start = trimmed_sequence_id + 1;
+        const uint64_t remaining = cleanup_target - trimmed_sequence_id;
+        const uint64_t batch_count =
+            std::min<uint64_t>(remaining, kCleanupBatchSize);
+        const uint64_t batch_end = batch_start + batch_count - 1;
+
+        for (uint64_t sequence_id = batch_start; sequence_id <= batch_end;
+             ++sequence_id) {
+            const std::string entry_key = EntryKey(sequence_id);
+            if (redisAppendCommand(ctx_, "DEL %b", entry_key.data(),
+                                   entry_key.size()) != REDIS_OK) {
+                LOG(ERROR)
+                    << "RedisOpLogStore::CleanupOpLogBefore: append DEL failed"
+                    << ", sequence_id=" << sequence_id;
+                redisFree(ctx_);
+                ctx_ = nullptr;
+                return ErrorCode::INTERNAL_ERROR;
+            }
+        }
+
+        for (uint64_t sequence_id = batch_start; sequence_id <= batch_end;
+             ++sequence_id) {
+            redisReply* raw_reply = nullptr;
+            if (redisGetReply(ctx_, reinterpret_cast<void**>(&raw_reply)) !=
+                    REDIS_OK ||
+                !raw_reply) {
+                LOG(ERROR) << "RedisOpLogStore::CleanupOpLogBefore: DEL failed"
+                           << ", sequence_id=" << sequence_id;
+                redisFree(ctx_);
+                ctx_ = nullptr;
+                return ErrorCode::INTERNAL_ERROR;
+            }
+            RedisReplyPtr del_reply(raw_reply);
+            if (del_reply->type == REDIS_REPLY_ERROR) {
+                LOG(ERROR) << "RedisOpLogStore::CleanupOpLogBefore: DEL error"
+                           << ", sequence_id=" << sequence_id << ", error="
+                           << (del_reply->str ? del_reply->str : "null");
+                redisFree(ctx_);
+                ctx_ = nullptr;
+                return ErrorCode::INTERNAL_ERROR;
+            }
+        }
+
+        const std::string trimmed_seq = SequenceMember(batch_end);
+        RedisReplyPtr update_reply((redisReply*)redisCommand(
+            ctx_, "SET %b %b", trimmed_key_.data(), trimmed_key_.size(),
+            trimmed_seq.data(), trimmed_seq.size()));
+        if (!update_reply || update_reply->type == REDIS_REPLY_ERROR) {
+            LOG(ERROR)
+                << "RedisOpLogStore::CleanupOpLogBefore: SET trimmed failed"
+                << ", trimmed_sequence_id=" << batch_end;
+            return ErrorCode::INTERNAL_ERROR;
+        }
     }
-    return ErrorCode::OK;
 }
 
 std::unique_ptr<OpLogChangeNotifier> RedisOpLogStore::CreateChangeNotifier(

--- a/mooncake-store/src/ha/oplog/redis_oplog_store.cpp
+++ b/mooncake-store/src/ha/oplog/redis_oplog_store.cpp
@@ -102,6 +102,9 @@ ErrorCode RedisOpLogStore::Init() {
     std::lock_guard<std::mutex> lock(mutex_);
     auto err = EnsureConnectedUnlocked();
     if (err != ErrorCode::OK) {
+        LOG(ERROR) << "RedisOpLogStore::Init: failed to ensure Redis "
+                      "connection"
+                   << ", error=" << toString(err);
         return err;
     }
     uint64_t latest = 0;
@@ -298,13 +301,18 @@ void RedisOpLogStore::AsyncWriteLoop(size_t worker_id) {
                 redisFree(ctx);
                 ctx = nullptr;
             }
-            ++pending->attempts;
+            size_t attempts;
+            {
+                // Mutable PendingWrite state is protected by async_mutex_.
+                std::lock_guard<std::mutex> lock(async_mutex_);
+                attempts = ++pending->attempts;
+            }
             // TODO(P2P HA): Add bounded exponential backoff, jitter, and
             // pending/retry metrics.
             LOG(WARNING) << "RedisOpLogStore: async write failed, retrying"
                          << ", worker_id=" << worker_id
                          << ", sequence_id=" << pending->entry.sequence_id
-                         << ", attempts=" << pending->attempts
+                         << ", attempts=" << attempts
                          << ", error=" << toString(err);
             std::this_thread::sleep_for(
                 std::chrono::milliseconds(kAsyncRetryDelayMs));
@@ -444,6 +452,10 @@ ErrorCode RedisOpLogStore::ReadOpLogUnlocked(uint64_t sequence_id,
                                              OpLogEntry& entry) {
     auto err = EnsureConnectedUnlocked();
     if (err != ErrorCode::OK) {
+        LOG(ERROR) << "RedisOpLogStore::ReadOpLog: failed to ensure Redis "
+                      "connection"
+                   << ", sequence_id=" << sequence_id
+                   << ", error=" << toString(err);
         return err;
     }
 
@@ -484,6 +496,10 @@ ErrorCode RedisOpLogStore::ReadOpLogSince(uint64_t start_sequence_id,
     }
     auto err = EnsureConnectedUnlocked();
     if (err != ErrorCode::OK) {
+        LOG(ERROR) << "RedisOpLogStore::ReadOpLogSince: failed to ensure "
+                      "Redis connection"
+                   << ", start_sequence_id=" << start_sequence_id
+                   << ", limit=" << limit << ", error=" << toString(err);
         return err;
     }
 
@@ -613,6 +629,9 @@ ErrorCode RedisOpLogStore::GetLatestSequenceId(uint64_t& sequence_id) {
     std::lock_guard<std::mutex> lock(mutex_);
     auto err = EnsureConnectedUnlocked();
     if (err != ErrorCode::OK) {
+        LOG(ERROR) << "RedisOpLogStore::GetLatestSequenceId: failed to ensure "
+                      "Redis connection"
+                   << ", error=" << toString(err);
         return err;
     }
     RedisReplyPtr reply((redisReply*)redisCommand(
@@ -636,6 +655,9 @@ ErrorCode RedisOpLogStore::GetLatestSequenceId(uint64_t& sequence_id) {
 ErrorCode RedisOpLogStore::GetMaxSequenceId(uint64_t& sequence_id) {
     auto err = GetLatestSequenceId(sequence_id);
     if (err != ErrorCode::OK) {
+        LOG(ERROR) << "RedisOpLogStore::GetMaxSequenceId: failed to get latest "
+                      "sequence ID"
+                   << ", error=" << toString(err);
         return err;
     }
     if (sequence_id == 0) {
@@ -650,6 +672,10 @@ ErrorCode RedisOpLogStore::UpdateLatestSequenceId(uint64_t sequence_id) {
     std::lock_guard<std::mutex> lock(mutex_);
     auto err = EnsureConnectedUnlocked();
     if (err != ErrorCode::OK) {
+        LOG(ERROR) << "RedisOpLogStore::UpdateLatestSequenceId: failed to "
+                      "ensure Redis connection"
+                   << ", sequence_id=" << sequence_id
+                   << ", error=" << toString(err);
         return err;
     }
     const std::string seq = SequenceMember(sequence_id);
@@ -688,6 +714,11 @@ ErrorCode RedisOpLogStore::RecordSnapshotSequenceId(
     }
     auto err = EnsureConnectedUnlocked();
     if (err != ErrorCode::OK) {
+        LOG(ERROR) << "RedisOpLogStore::RecordSnapshotSequenceId: failed to "
+                      "ensure Redis connection"
+                   << ", snapshot_id=" << snapshot_id
+                   << ", sequence_id=" << sequence_id
+                   << ", error=" << toString(err);
         return err;
     }
     const std::string key = SnapshotKey(snapshot_id);
@@ -712,6 +743,10 @@ ErrorCode RedisOpLogStore::GetSnapshotSequenceId(const std::string& snapshot_id,
     }
     auto err = EnsureConnectedUnlocked();
     if (err != ErrorCode::OK) {
+        LOG(ERROR) << "RedisOpLogStore::GetSnapshotSequenceId: failed to "
+                      "ensure Redis connection"
+                   << ", snapshot_id=" << snapshot_id
+                   << ", error=" << toString(err);
         return err;
     }
     const std::string key = SnapshotKey(snapshot_id);
@@ -742,6 +777,10 @@ ErrorCode RedisOpLogStore::CleanupOpLogBefore(uint64_t before_sequence_id) {
         std::lock_guard<std::mutex> lock(mutex_);
         auto err = EnsureConnectedUnlocked();
         if (err != ErrorCode::OK) {
+            LOG(ERROR) << "RedisOpLogStore::CleanupOpLogBefore: failed to "
+                          "ensure Redis connection"
+                       << ", before_sequence_id=" << before_sequence_id
+                       << ", error=" << toString(err);
             return err;
         }
 

--- a/mooncake-store/src/p2p_master_service.cpp
+++ b/mooncake-store/src/p2p_master_service.cpp
@@ -2,23 +2,12 @@
 
 #include <glog/logging.h>
 #include <algorithm>
-#include <sstream>
 #include <variant>
 
 #include "ha/oplog/p2p_oplog_types.h"
 #include "p2p_client_meta.h"
 
 namespace mooncake {
-namespace {
-
-template <typename... Args>
-std::string LogContext(Args&&... args) {
-    std::ostringstream oss;
-    (oss << ... << args);
-    return oss.str();
-}
-
-}  // namespace
 
 P2PMasterService::P2PMasterService(const MasterServiceConfig& config)
     : MasterService(config),
@@ -51,19 +40,6 @@ ErrorCode P2PMasterService::RecordOplog(OpType type, const std::string& key,
     return ErrorCode::OK;
 }
 
-ErrorCode P2PMasterService::RecordOplogOrError(
-    OpType type, const std::string& key, const std::string& payload,
-    const char* operation, const std::string& details, bool sync) {
-    ErrorCode err = RecordOplog(type, key, payload, sync);
-    if (err != ErrorCode::OK) {
-        LOG(ERROR) << operation << "(P2P): failed to record oplog"
-                   << ", op_type=" << static_cast<int>(type) << ", key=" << key
-                   << ", error=" << toString(err)
-                   << (details.empty() ? "" : ", ") << details;
-    }
-    return err;
-}
-
 // XXX(P2P HA): Lifecycle mutations update memory before OpLog persistence,
 // unlike WAL-first designs. Revisit this ordering.
 auto P2PMasterService::RegisterClient(const RegisterClientRequest& req)
@@ -93,10 +69,12 @@ auto P2PMasterService::RegisterClient(const RegisterClientRequest& req)
     payload.ip_address = *req.ip_address;
     payload.rpc_port = *req.rpc_port;
     payload.segments = req.segments;
-    auto err = RecordOplogOrError(
-        OpType_REGISTER_CLIENT, "", SerializeP2PPayload(payload),
-        "RegisterClient", LogContext("client_id=", req.client_id));
+    auto err =
+        RecordOplog(OpType_REGISTER_CLIENT, "", SerializeP2PPayload(payload));
     if (err != ErrorCode::OK) {
+        LOG(ERROR) << "RegisterClient(P2P): failed to record oplog"
+                   << ", client_id=" << req.client_id
+                   << ", error=" << toString(err);
         return tl::make_unexpected(err);
     }
     return result;
@@ -114,10 +92,12 @@ auto P2PMasterService::UnregisterClient(const UnregisterClientRequest& req)
 
     UnregisterClientPayload payload;
     payload.client_id = req.client_id;
-    auto err = RecordOplogOrError(
-        OpType_UNREGISTER_CLIENT, "", SerializeP2PPayload(payload),
-        "UnregisterClient", LogContext("client_id=", req.client_id));
+    auto err =
+        RecordOplog(OpType_UNREGISTER_CLIENT, "", SerializeP2PPayload(payload));
     if (err != ErrorCode::OK) {
+        LOG(ERROR) << "UnregisterClient(P2P): failed to record oplog"
+                   << ", client_id=" << req.client_id
+                   << ", error=" << toString(err);
         return tl::make_unexpected(err);
     }
     return result;
@@ -139,11 +119,14 @@ auto P2PMasterService::MountSegment(const Segment& segment,
     MountSegmentPayload payload;
     payload.client_id = client_id;
     payload.segment = segment;
-    auto err = RecordOplogOrError(
-        OpType_MOUNT_SEGMENT, "", SerializeP2PPayload(payload), "MountSegment",
-        LogContext("client_id=", client_id, ", segment_id=", segment.id,
-                   ", segment_name=", segment.name));
+    auto err =
+        RecordOplog(OpType_MOUNT_SEGMENT, "", SerializeP2PPayload(payload));
     if (err != ErrorCode::OK) {
+        LOG(ERROR) << "MountSegment(P2P): failed to record oplog"
+                   << ", client_id=" << client_id
+                   << ", segment_id=" << segment.id
+                   << ", segment_name=" << segment.name
+                   << ", error=" << toString(err);
         return tl::make_unexpected(err);
     }
     return {};
@@ -164,11 +147,13 @@ auto P2PMasterService::UnmountSegment(const UUID& segment_id,
     UnmountSegmentPayload payload;
     payload.segment_id = segment_id;
     payload.client_id = client_id;
-    auto err = RecordOplogOrError(
-        OpType_UNMOUNT_SEGMENT, "", SerializeP2PPayload(payload),
-        "UnmountSegment",
-        LogContext("client_id=", client_id, ", segment_id=", segment_id));
+    auto err =
+        RecordOplog(OpType_UNMOUNT_SEGMENT, "", SerializeP2PPayload(payload));
     if (err != ErrorCode::OK) {
+        LOG(ERROR) << "UnmountSegment(P2P): failed to record oplog"
+                   << ", client_id=" << client_id
+                   << ", segment_id=" << segment_id
+                   << ", error=" << toString(err);
         return tl::make_unexpected(err);
     }
     return {};
@@ -430,12 +415,15 @@ tl::expected<void, ErrorCode> P2PMasterService::InnerAddReplica(
         payload.client_id = client_id;
         payload.segment_id = segment_id;
         payload.size = size;
-        ErrorCode record_err = RecordOplogOrError(
-            OpType_ADD_REPLICA, payload.object_key,
-            SerializeP2PPayload(payload), "AddReplica",
-            LogContext("client_id=", client_id, ", segment_id=", segment_id),
-            /*sync=*/!async_add_replica_oplog_);
+        ErrorCode record_err =
+            RecordOplog(OpType_ADD_REPLICA, payload.object_key,
+                        SerializeP2PPayload(payload),
+                        /*sync=*/!async_add_replica_oplog_);
         if (record_err != ErrorCode::OK) {
+            LOG(ERROR) << "AddReplica(P2P): failed to record oplog"
+                       << ", client_id=" << client_id
+                       << ", segment_id=" << segment_id
+                       << ", error=" << toString(record_err);
             return tl::make_unexpected(record_err);
         }
         AddReplicaToSegmentIndex(shard, it->first, new_replica);
@@ -451,12 +439,15 @@ tl::expected<void, ErrorCode> P2PMasterService::InnerAddReplica(
         payload.client_id = client_id;
         payload.segment_id = segment_id;
         payload.size = size;
-        ErrorCode record_err = RecordOplogOrError(
-            OpType_ADD_REPLICA, payload.object_key,
-            SerializeP2PPayload(payload), "AddReplica",
-            LogContext("client_id=", client_id, ", segment_id=", segment_id),
-            /*sync=*/!async_add_replica_oplog_);
+        ErrorCode record_err =
+            RecordOplog(OpType_ADD_REPLICA, payload.object_key,
+                        SerializeP2PPayload(payload),
+                        /*sync=*/!async_add_replica_oplog_);
         if (record_err != ErrorCode::OK) {
+            LOG(ERROR) << "AddReplica(P2P): failed to record oplog"
+                       << ", client_id=" << client_id
+                       << ", segment_id=" << segment_id
+                       << ", error=" << toString(record_err);
             return tl::make_unexpected(record_err);
         }
         auto emplace_it =
@@ -503,12 +494,14 @@ tl::expected<void, ErrorCode> P2PMasterService::InnerRemoveReplica(
             payload.object_key = std::string(key);
             payload.client_id = client_id;
             payload.segment_id = segment_id;
-            ErrorCode record_err = RecordOplogOrError(
-                OpType_REMOVE_REPLICA, payload.object_key,
-                SerializeP2PPayload(payload), "RemoveReplica",
-                LogContext("client_id=", client_id,
-                           ", segment_id=", segment_id));
+            ErrorCode record_err =
+                RecordOplog(OpType_REMOVE_REPLICA, payload.object_key,
+                            SerializeP2PPayload(payload));
             if (record_err != ErrorCode::OK) {
+                LOG(ERROR) << "RemoveReplica(P2P): failed to record oplog"
+                           << ", client_id=" << client_id
+                           << ", segment_id=" << segment_id
+                           << ", error=" << toString(record_err);
                 return tl::make_unexpected(record_err);
             }
             RemoveReplicaFromSegmentIndex(shard, it->first, *rit);

--- a/mooncake-store/src/p2p_master_service.cpp
+++ b/mooncake-store/src/p2p_master_service.cpp
@@ -2,16 +2,28 @@
 
 #include <glog/logging.h>
 #include <algorithm>
+#include <sstream>
 #include <variant>
 
 #include "ha/oplog/p2p_oplog_types.h"
 #include "p2p_client_meta.h"
 
 namespace mooncake {
+namespace {
+
+template <typename... Args>
+std::string LogContext(Args&&... args) {
+    std::ostringstream oss;
+    (oss << ... << args);
+    return oss.str();
+}
+
+}  // namespace
 
 P2PMasterService::P2PMasterService(const MasterServiceConfig& config)
     : MasterService(config),
-      max_replicas_per_key_(config.max_replicas_per_key) {
+      max_replicas_per_key_(config.max_replicas_per_key),
+      async_add_replica_oplog_(config.oplog_store_type == "redis") {
     client_manager_ = std::make_shared<P2PClientManager>(
         config.client_live_ttl_sec, config.client_crashed_ttl_sec,
         config.view_version);
@@ -20,7 +32,7 @@ P2PMasterService::P2PMasterService(const MasterServiceConfig& config)
 }
 
 ErrorCode P2PMasterService::RecordOplog(OpType type, const std::string& key,
-                                        const std::string& payload) {
+                                        const std::string& payload, bool sync) {
     // TODO: Record remaining failover-visible P2P mutations: client crash
     // cleanup, heartbeat state transitions, replica eviction/rebalance, and
     // task metadata.
@@ -29,7 +41,7 @@ ErrorCode P2PMasterService::RecordOplog(OpType type, const std::string& key,
         return ErrorCode::OK;
     }
 
-    auto result = manager->AppendAndPersist(type, key, payload);
+    auto result = manager->AppendAndPersist(type, key, payload, sync);
     if (!result.has_value()) {
         LOG(ERROR) << "P2PMasterService: failed to persist oplog"
                    << ", op_type=" << static_cast<int>(type) << ", key=" << key
@@ -39,11 +51,21 @@ ErrorCode P2PMasterService::RecordOplog(OpType type, const std::string& key,
     return ErrorCode::OK;
 }
 
-// TODO: Make client/segment lifecycle updates transactional with oplog
-// persistence. These wrappers currently call MasterService first, so an oplog
-// persistence failure can leave Primary memory ahead of Standby. A robust fix
-// needs a separate prepare/log/apply flow or durable retry/outbox mechanism;
-// local rollback is fragile because these calls have nested side effects.
+ErrorCode P2PMasterService::RecordOplogOrError(
+    OpType type, const std::string& key, const std::string& payload,
+    const char* operation, const std::string& details, bool sync) {
+    ErrorCode err = RecordOplog(type, key, payload, sync);
+    if (err != ErrorCode::OK) {
+        LOG(ERROR) << operation << "(P2P): failed to record oplog"
+                   << ", op_type=" << static_cast<int>(type) << ", key=" << key
+                   << ", error=" << toString(err)
+                   << (details.empty() ? "" : ", ") << details;
+    }
+    return err;
+}
+
+// XXX(P2P HA): Lifecycle mutations update memory before OpLog persistence,
+// unlike WAL-first designs. Revisit this ordering.
 auto P2PMasterService::RegisterClient(const RegisterClientRequest& req)
     -> tl::expected<RegisterClientResponse, ErrorCode> {
     if (GetClientManager().GetClient(req.client_id)) {
@@ -71,11 +93,10 @@ auto P2PMasterService::RegisterClient(const RegisterClientRequest& req)
     payload.ip_address = *req.ip_address;
     payload.rpc_port = *req.rpc_port;
     payload.segments = req.segments;
-    auto err =
-        RecordOplog(OpType_REGISTER_CLIENT, "", SerializeP2PPayload(payload));
+    auto err = RecordOplogOrError(
+        OpType_REGISTER_CLIENT, "", SerializeP2PPayload(payload),
+        "RegisterClient", LogContext("client_id=", req.client_id));
     if (err != ErrorCode::OK) {
-        LOG(ERROR) << "RegisterClient(P2P): failed to record oplog"
-                   << ", client_id=" << req.client_id << ", error=" << err;
         return tl::make_unexpected(err);
     }
     return result;
@@ -93,11 +114,10 @@ auto P2PMasterService::UnregisterClient(const UnregisterClientRequest& req)
 
     UnregisterClientPayload payload;
     payload.client_id = req.client_id;
-    auto err =
-        RecordOplog(OpType_UNREGISTER_CLIENT, "", SerializeP2PPayload(payload));
+    auto err = RecordOplogOrError(
+        OpType_UNREGISTER_CLIENT, "", SerializeP2PPayload(payload),
+        "UnregisterClient", LogContext("client_id=", req.client_id));
     if (err != ErrorCode::OK) {
-        LOG(ERROR) << "UnregisterClient(P2P): failed to record oplog"
-                   << ", client_id=" << req.client_id << ", error=" << err;
         return tl::make_unexpected(err);
     }
     return result;
@@ -119,13 +139,11 @@ auto P2PMasterService::MountSegment(const Segment& segment,
     MountSegmentPayload payload;
     payload.client_id = client_id;
     payload.segment = segment;
-    auto err =
-        RecordOplog(OpType_MOUNT_SEGMENT, "", SerializeP2PPayload(payload));
+    auto err = RecordOplogOrError(
+        OpType_MOUNT_SEGMENT, "", SerializeP2PPayload(payload), "MountSegment",
+        LogContext("client_id=", client_id, ", segment_id=", segment.id,
+                   ", segment_name=", segment.name));
     if (err != ErrorCode::OK) {
-        LOG(ERROR) << "MountSegment(P2P): failed to record oplog"
-                   << ", client_id=" << client_id
-                   << ", segment_id=" << segment.id
-                   << ", segment_name=" << segment.name << ", error=" << err;
         return tl::make_unexpected(err);
     }
     return {};
@@ -146,12 +164,11 @@ auto P2PMasterService::UnmountSegment(const UUID& segment_id,
     UnmountSegmentPayload payload;
     payload.segment_id = segment_id;
     payload.client_id = client_id;
-    auto err =
-        RecordOplog(OpType_UNMOUNT_SEGMENT, "", SerializeP2PPayload(payload));
+    auto err = RecordOplogOrError(
+        OpType_UNMOUNT_SEGMENT, "", SerializeP2PPayload(payload),
+        "UnmountSegment",
+        LogContext("client_id=", client_id, ", segment_id=", segment_id));
     if (err != ErrorCode::OK) {
-        LOG(ERROR) << "UnmountSegment(P2P): failed to record oplog"
-                   << ", client_id=" << client_id
-                   << ", segment_id=" << segment_id << ", error=" << err;
         return tl::make_unexpected(err);
     }
     return {};
@@ -163,14 +180,14 @@ auto P2PMasterService::CollectReplicaOwnerClients(
     std::unordered_set<UUID, boost::hash<UUID>> owner_clients;
     for (const auto& replica : metadata.replicas_) {
         if (!replica.is_p2p_proxy_replica()) {
-            LOG(ERROR) << "unexpected replica type" << ", key: " << key
-                       << ", replica:" << replica;
+            LOG(ERROR) << "unexpected replica type"
+                       << ", key: " << key << ", replica:" << replica;
             return tl::make_unexpected(ErrorCode::INVALID_REPLICA);
         }
         auto client_id = replica.get_p2p_client_id();
         if (!client_id) {
-            LOG(ERROR) << "invalid p2p replica" << ", key: " << key
-                       << ", replica:" << replica;
+            LOG(ERROR) << "invalid p2p replica"
+                       << ", key: " << key << ", replica:" << replica;
             return tl::make_unexpected(ErrorCode::INVALID_REPLICA);
         }
         owner_clients.insert(*client_id);
@@ -413,14 +430,12 @@ tl::expected<void, ErrorCode> P2PMasterService::InnerAddReplica(
         payload.client_id = client_id;
         payload.segment_id = segment_id;
         payload.size = size;
-        ErrorCode record_err =
-            RecordOplog(OpType_ADD_REPLICA, payload.object_key,
-                        SerializeP2PPayload(payload));
+        ErrorCode record_err = RecordOplogOrError(
+            OpType_ADD_REPLICA, payload.object_key,
+            SerializeP2PPayload(payload), "AddReplica",
+            LogContext("client_id=", client_id, ", segment_id=", segment_id),
+            /*sync=*/!async_add_replica_oplog_);
         if (record_err != ErrorCode::OK) {
-            LOG(ERROR) << "AddReplica(P2P): failed to record oplog"
-                       << ", key=" << key << ", client_id=" << client_id
-                       << ", segment_id=" << segment_id
-                       << ", error=" << record_err;
             return tl::make_unexpected(record_err);
         }
         AddReplicaToSegmentIndex(shard, it->first, new_replica);
@@ -436,14 +451,12 @@ tl::expected<void, ErrorCode> P2PMasterService::InnerAddReplica(
         payload.client_id = client_id;
         payload.segment_id = segment_id;
         payload.size = size;
-        ErrorCode record_err =
-            RecordOplog(OpType_ADD_REPLICA, payload.object_key,
-                        SerializeP2PPayload(payload));
+        ErrorCode record_err = RecordOplogOrError(
+            OpType_ADD_REPLICA, payload.object_key,
+            SerializeP2PPayload(payload), "AddReplica",
+            LogContext("client_id=", client_id, ", segment_id=", segment_id),
+            /*sync=*/!async_add_replica_oplog_);
         if (record_err != ErrorCode::OK) {
-            LOG(ERROR) << "AddReplica(P2P): failed to record oplog"
-                       << ", key=" << key << ", client_id=" << client_id
-                       << ", segment_id=" << segment_id
-                       << ", error=" << record_err;
             return tl::make_unexpected(record_err);
         }
         auto emplace_it =
@@ -490,14 +503,12 @@ tl::expected<void, ErrorCode> P2PMasterService::InnerRemoveReplica(
             payload.object_key = std::string(key);
             payload.client_id = client_id;
             payload.segment_id = segment_id;
-            ErrorCode record_err =
-                RecordOplog(OpType_REMOVE_REPLICA, payload.object_key,
-                            SerializeP2PPayload(payload));
+            ErrorCode record_err = RecordOplogOrError(
+                OpType_REMOVE_REPLICA, payload.object_key,
+                SerializeP2PPayload(payload), "RemoveReplica",
+                LogContext("client_id=", client_id,
+                           ", segment_id=", segment_id));
             if (record_err != ErrorCode::OK) {
-                LOG(ERROR) << "RemoveReplica(P2P): failed to record oplog"
-                           << ", key=" << key << ", client_id=" << client_id
-                           << ", segment_id=" << segment_id
-                           << ", error=" << record_err;
                 return tl::make_unexpected(record_err);
             }
             RemoveReplicaFromSegmentIndex(shard, it->first, *rit);

--- a/mooncake-store/tests/ha/oplog/p2p_hot_standby_service_test.cpp
+++ b/mooncake-store/tests/ha/oplog/p2p_hot_standby_service_test.cpp
@@ -8,8 +8,10 @@
 #include <cstdint>
 #include <filesystem>
 #include <string>
+#include <thread>
 #include <variant>
 
+#include "ha/oplog/localfs_oplog_store.h"
 #include "p2p_master_service.h"
 #include "p2p_rpc_service.h"
 #include "p2p_rpc_types.h"
@@ -78,6 +80,23 @@ class P2PHotStandbyServiceTest : public ::testing::Test {
             .memory_type = MemoryType::DRAM,
         };
         return segment;
+    }
+
+    bool WaitForPersistedEntry(uint64_t sequence_id,
+                               std::chrono::milliseconds timeout) const {
+        const auto deadline = std::chrono::steady_clock::now() + timeout;
+        while (std::chrono::steady_clock::now() < deadline) {
+            LocalFsOpLogStore reader(kClusterId, test_dir_.string(),
+                                     /*enable_batch_write=*/false);
+            if (reader.Init() == ErrorCode::OK) {
+                OpLogEntry entry;
+                if (reader.ReadOpLog(sequence_id, entry) == ErrorCode::OK) {
+                    return true;
+                }
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+        return false;
     }
 
     void RegisterClient(P2PMasterService& service, const UUID& client_id,
@@ -190,6 +209,7 @@ TEST_F(P2PHotStandbyServiceTest, PromoteFinalCatchUpExportsLateEntry) {
         standby.WaitForAppliedSequence(1, std::chrono::milliseconds(2000)));
 
     AddReplica(master, "key-late", client_id, segment_id, 8192);
+    ASSERT_TRUE(WaitForPersistedEntry(2, std::chrono::milliseconds(2000)));
     ASSERT_EQ(standby.Promote(), ErrorCode::OK);
     EXPECT_EQ(standby.GetState(), StandbyState::PROMOTED);
     EXPECT_GE(standby.GetLatestAppliedSequenceId(), 2);

--- a/mooncake-store/tests/ha/oplog/p2p_record_oplog_test.cpp
+++ b/mooncake-store/tests/ha/oplog/p2p_record_oplog_test.cpp
@@ -5,13 +5,17 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <chrono>
 #include <filesystem>
 #include <fstream>
+#include <memory>
 #include <stdexcept>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "ha/oplog/localfs_oplog_store.h"
+#include "ha/oplog/oplog_store.h"
 #include "ha/oplog/p2p_oplog_types.h"
 #include "master_config.h"
 #include "p2p_rpc_types.h"
@@ -19,6 +23,56 @@
 
 namespace mooncake::test {
 namespace {
+
+class FailingOpLogStore : public OpLogStore {
+   public:
+    ErrorCode Init() override { return ErrorCode::OK; }
+    ErrorCode WriteOpLog(const OpLogEntry& entry, bool sync) override {
+        (void)entry;
+        (void)sync;
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    ErrorCode ReadOpLog(uint64_t sequence_id, OpLogEntry& entry) override {
+        (void)sequence_id;
+        (void)entry;
+        return ErrorCode::OPLOG_ENTRY_NOT_FOUND;
+    }
+    ErrorCode ReadOpLogSince(uint64_t start_sequence_id, size_t limit,
+                             std::vector<OpLogEntry>& entries) override {
+        (void)start_sequence_id;
+        (void)limit;
+        entries.clear();
+        return ErrorCode::OK;
+    }
+    ErrorCode GetLatestSequenceId(uint64_t& sequence_id) override {
+        sequence_id = 0;
+        return ErrorCode::OK;
+    }
+    ErrorCode GetMaxSequenceId(uint64_t& sequence_id) override {
+        sequence_id = 0;
+        return ErrorCode::OK;
+    }
+    ErrorCode UpdateLatestSequenceId(uint64_t sequence_id) override {
+        (void)sequence_id;
+        return ErrorCode::OK;
+    }
+    ErrorCode RecordSnapshotSequenceId(const std::string& snapshot_id,
+                                       uint64_t sequence_id) override {
+        (void)snapshot_id;
+        (void)sequence_id;
+        return ErrorCode::OK;
+    }
+    ErrorCode GetSnapshotSequenceId(const std::string& snapshot_id,
+                                    uint64_t& sequence_id) override {
+        (void)snapshot_id;
+        sequence_id = 0;
+        return ErrorCode::OPLOG_ENTRY_NOT_FOUND;
+    }
+    ErrorCode CleanupOpLogBefore(uint64_t before_sequence_id) override {
+        (void)before_sequence_id;
+        return ErrorCode::OK;
+    }
+};
 
 class P2PRecordOplogTest : public ::testing::Test {
    protected:
@@ -113,13 +167,28 @@ class P2PRecordOplogTest : public ::testing::Test {
     }
 
     OpLogEntry ReadEntry(uint64_t sequence_id) const {
+        OpLogEntry entry;
+        for (int i = 0; i < 100; ++i) {
+            LocalFsOpLogStore reader(kClusterId, test_dir_.string(),
+                                     /*enable_batch_write=*/false);
+            EXPECT_EQ(reader.Init(), ErrorCode::OK);
+            if (reader.ReadOpLog(sequence_id, entry) == ErrorCode::OK) {
+                return entry;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+
         LocalFsOpLogStore reader(kClusterId, test_dir_.string(),
                                  /*enable_batch_write=*/false);
         EXPECT_EQ(reader.Init(), ErrorCode::OK);
-
-        OpLogEntry entry;
         EXPECT_EQ(reader.ReadOpLog(sequence_id, entry), ErrorCode::OK);
         return entry;
+    }
+
+    void InjectFailingOpLogStore(P2PMasterService& service) const {
+        auto* manager = service.GetOpLogManager();
+        ASSERT_NE(manager, nullptr);
+        manager->SetOpLogStore(std::make_shared<FailingOpLogStore>());
     }
 
     static constexpr const char* kClusterId = "p2p-record-oplog-test";
@@ -317,6 +386,74 @@ TEST_F(P2PRecordOplogTest, BatchSyncReplicaRecordsSuccessfulOps) {
 
     EXPECT_TRUE(has_entry(OpType_REMOVE_REPLICA, "old-key"));
     EXPECT_TRUE(has_entry(OpType_ADD_REPLICA, "new-key"));
+}
+
+TEST_F(P2PRecordOplogTest,
+       RegisterClientReturnsErrorWhenOplogPersistenceFails) {
+    P2PMasterService service(MakeConfig());
+    InjectFailingOpLogStore(service);
+
+    RegisterClientRequest req;
+    req.client_id = {30, 30};
+    req.ip_address = "127.0.0.1";
+    req.rpc_port = 50051;
+    req.segments = {MakeSegment({31, 31})};
+    req.deployment_mode = DeploymentMode::P2P;
+
+    auto result = service.RegisterClient(req);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), ErrorCode::INTERNAL_ERROR);
+
+    // Current primary-side policy is apply-memory-then-record for lifecycle
+    // operations. Do not silently roll this back in the error path; a follow-up
+    // durable retry/outbox or prepare-log-apply flow should make this stronger.
+    EXPECT_NE(service.GetClientManager().GetClient(req.client_id), nullptr);
+}
+
+TEST_F(P2PRecordOplogTest, AddReplicaDoesNotApplyWhenOplogPersistenceFails) {
+    P2PMasterService service(MakeConfig());
+    const UUID client_id{32, 32};
+    const UUID segment_id{33, 33};
+    RegisterClient(service, client_id, MakeSegment(segment_id));
+    InjectFailingOpLogStore(service);
+
+    AddReplicaRequest req;
+    req.key = "failed-add";
+    req.client_id = client_id;
+    req.segment_id = segment_id;
+    req.size = 4096;
+
+    auto result = service.AddReplica(req);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), ErrorCode::INTERNAL_ERROR);
+
+    auto replicas = service.GetReplicaList(req.key);
+    ASSERT_FALSE(replicas.has_value());
+    EXPECT_EQ(replicas.error(), ErrorCode::OBJECT_NOT_FOUND);
+}
+
+TEST_F(P2PRecordOplogTest, RemoveReplicaDoesNotApplyWhenOplogPersistenceFails) {
+    P2PMasterService service(MakeConfig());
+    const UUID client_id{34, 34};
+    const UUID segment_id{35, 35};
+    RegisterClient(service, client_id, MakeSegment(segment_id));
+    AddReplica(service, "failed-remove", client_id, segment_id);
+    InjectFailingOpLogStore(service);
+
+    RemoveReplicaRequest req;
+    req.key = "failed-remove";
+    req.client_id = client_id;
+    req.segment_id = segment_id;
+
+    auto result = service.RemoveReplica(req);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), ErrorCode::INTERNAL_ERROR);
+
+    auto replicas = service.GetReplicaList(req.key);
+    ASSERT_TRUE(replicas.has_value()) << toString(replicas.error());
+    ASSERT_EQ(replicas->replicas.size(), 1);
+    EXPECT_EQ(replicas->replicas[0].get_p2p_proxy_descriptor().client_id,
+              client_id);
 }
 
 TEST_F(P2PRecordOplogTest, EnabledOplogFailsFastWhenStoreInitFails) {

--- a/mooncake-store/tests/ha/oplog/redis_oplog_store_test.cpp
+++ b/mooncake-store/tests/ha/oplog/redis_oplog_store_test.cpp
@@ -2,8 +2,10 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <cstdlib>
 #include <string>
+#include <thread>
 
 #include <unistd.h>
 #include <hiredis/hiredis.h>
@@ -172,9 +174,9 @@ TEST_F(RedisOpLogStoreTest, WriteReadAndLatestSequence) {
 
 TEST_F(RedisOpLogStoreTest, ReadSinceReturnsOrderedEntries) {
     auto writer = CreateWriter();
-    ASSERT_EQ(ErrorCode::OK, writer->WriteOpLog(MakeEntry(3), true));
     ASSERT_EQ(ErrorCode::OK, writer->WriteOpLog(MakeEntry(1), true));
     ASSERT_EQ(ErrorCode::OK, writer->WriteOpLog(MakeEntry(2), true));
+    ASSERT_EQ(ErrorCode::OK, writer->WriteOpLog(MakeEntry(3), true));
 
     std::vector<OpLogEntry> entries;
     ASSERT_EQ(ErrorCode::OK, writer->ReadOpLogSince(1, 10, entries));
@@ -186,9 +188,10 @@ TEST_F(RedisOpLogStoreTest, ReadSinceReturnsOrderedEntries) {
 TEST_F(RedisOpLogStoreTest, ReadSinceKeepsUint64Ordering) {
     auto writer = CreateWriter();
     constexpr uint64_t kBase = 9007199254740993ULL;
-    ASSERT_EQ(ErrorCode::OK, writer->WriteOpLog(MakeEntry(kBase + 2), true));
+    ASSERT_EQ(ErrorCode::OK, writer->UpdateLatestSequenceId(kBase - 1));
     ASSERT_EQ(ErrorCode::OK, writer->WriteOpLog(MakeEntry(kBase), true));
     ASSERT_EQ(ErrorCode::OK, writer->WriteOpLog(MakeEntry(kBase + 1), true));
+    ASSERT_EQ(ErrorCode::OK, writer->WriteOpLog(MakeEntry(kBase + 2), true));
 
     std::vector<OpLogEntry> entries;
     ASSERT_EQ(ErrorCode::OK, writer->ReadOpLogSince(kBase, 10, entries));
@@ -205,15 +208,67 @@ TEST_F(RedisOpLogStoreTest, ReadSinceKeepsUint64Ordering) {
     EXPECT_EQ(kBase + 2, max_sequence_id);
 }
 
-TEST_F(RedisOpLogStoreTest, RewriteDifferentPayloadFails) {
+TEST_F(RedisOpLogStoreTest, AsyncWriteEventuallyAdvancesLatest) {
+    auto writer = CreateWriter();
+    ASSERT_EQ(ErrorCode::OK, writer->WriteOpLog(MakeEntry(1), false));
+    ASSERT_EQ(ErrorCode::OK, writer->WriteOpLog(MakeEntry(2), false));
+
+    uint64_t latest = 0;
+    for (int i = 0; i < 100; ++i) {
+        ASSERT_EQ(ErrorCode::OK, writer->GetLatestSequenceId(latest));
+        if (latest == 2) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    EXPECT_EQ(2u, latest);
+
+    std::vector<OpLogEntry> entries;
+    ASSERT_EQ(ErrorCode::OK, writer->ReadOpLogSince(0, 10, entries));
+    ASSERT_EQ(2u, entries.size());
+    EXPECT_EQ(1u, entries[0].sequence_id);
+    EXPECT_EQ(2u, entries[1].sequence_id);
+}
+
+TEST_F(RedisOpLogStoreTest, ReadSinceHonorsCommittedLatest) {
+    auto writer = CreateWriter();
+    ASSERT_EQ(ErrorCode::OK, writer->WriteOpLog(MakeEntry(1), true));
+    ASSERT_EQ(ErrorCode::OK, writer->WriteOpLog(MakeEntry(2), true));
+    ASSERT_EQ(ErrorCode::OK, writer->UpdateLatestSequenceId(1));
+
+    std::vector<OpLogEntry> entries;
+    ASSERT_EQ(ErrorCode::OK, writer->ReadOpLogSince(0, 10, entries));
+    ASSERT_EQ(1u, entries.size());
+    EXPECT_EQ(1u, entries[0].sequence_id);
+}
+
+TEST_F(RedisOpLogStoreTest, AsyncWriteDoesNotAdvanceLatestPastGap) {
+    auto writer = CreateWriter();
+    ASSERT_EQ(ErrorCode::OK, writer->WriteOpLog(MakeEntry(2), false));
+
+    uint64_t latest = 0;
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    ASSERT_EQ(ErrorCode::OK, writer->GetLatestSequenceId(latest));
+    EXPECT_EQ(0u, latest);
+
+    ASSERT_EQ(ErrorCode::OK, writer->WriteOpLog(MakeEntry(1), true));
+    ASSERT_EQ(ErrorCode::OK, writer->GetLatestSequenceId(latest));
+    EXPECT_EQ(2u, latest);
+}
+
+TEST_F(RedisOpLogStoreTest, RewriteExistingSequenceFails) {
     auto writer = CreateWriter();
     auto entry = MakeEntry(1);
     ASSERT_EQ(ErrorCode::OK, writer->WriteOpLog(entry, true));
-    ASSERT_EQ(ErrorCode::OK, writer->WriteOpLog(entry, true));
+    EXPECT_NE(ErrorCode::OK, writer->WriteOpLog(entry, true));
 
     auto conflicting = entry;
     conflicting.payload = "different_payload";
     EXPECT_NE(ErrorCode::OK, writer->WriteOpLog(conflicting, true));
+
+    OpLogEntry stored;
+    ASSERT_EQ(ErrorCode::OK, writer->ReadOpLog(1, stored));
+    EXPECT_EQ(entry.payload, stored.payload);
 }
 
 TEST_F(RedisOpLogStoreTest, CleanupRemovesOldEntries) {
@@ -232,6 +287,10 @@ TEST_F(RedisOpLogStoreTest, CleanupRemovesOldEntries) {
     ASSERT_EQ(2u, entries.size());
     EXPECT_EQ(4u, entries[0].sequence_id);
     EXPECT_EQ(5u, entries[1].sequence_id);
+
+    uint64_t max_sequence_id = 0;
+    ASSERT_EQ(ErrorCode::OK, writer->GetMaxSequenceId(max_sequence_id));
+    EXPECT_EQ(5u, max_sequence_id);
 }
 
 TEST_F(RedisOpLogStoreTest, SnapshotSequenceRoundTrip) {

--- a/mooncake-store/tests/ha/oplog/redis_oplog_store_test.cpp
+++ b/mooncake-store/tests/ha/oplog/redis_oplog_store_test.cpp
@@ -256,11 +256,11 @@ TEST_F(RedisOpLogStoreTest, AsyncWriteDoesNotAdvanceLatestPastGap) {
     EXPECT_EQ(2u, latest);
 }
 
-TEST_F(RedisOpLogStoreTest, RewriteExistingSequenceFails) {
+TEST_F(RedisOpLogStoreTest, RewriteExistingSequenceIsIdempotent) {
     auto writer = CreateWriter();
     auto entry = MakeEntry(1);
     ASSERT_EQ(ErrorCode::OK, writer->WriteOpLog(entry, true));
-    EXPECT_NE(ErrorCode::OK, writer->WriteOpLog(entry, true));
+    EXPECT_EQ(ErrorCode::OK, writer->WriteOpLog(entry, true));
 
     auto conflicting = entry;
     conflicting.payload = "different_payload";


### PR DESCRIPTION
## Description

  Improve P2P primary metadata OpLog persistence handling.

  - Add explicit synchronous/asynchronous persistence control to `OpLogManager`.
  - Propagate Redis OpLog write failures back to P2P metadata operations.
  - Keep replica-removal OpLogs synchronous to avoid silently losing required metadata updates.
  - Add an optional asynchronous path for add-replica OpLogs.
  - Refactor Redis OpLog persistence and batching behavior.
  - Add coverage for persistence failures, sync/async writes, and standby application.

  ## Module

  - [ ] Transfer Engine (`mooncake-transfer-engine`)
  - [x] Mooncake Store (`mooncake-store`)
  - [ ] Mooncake EP (`mooncake-ep`)
  - [ ] Mooncake PG (`mooncake-pg`)
  - [ ] Integration (`mooncake-integration`)
  - [x] P2P Store (`mooncake-p2p-store`)
  - [ ] Python Wheel (`mooncake-wheel`)
  - [ ] Common (`mooncake-common`)
  - [ ] Mooncake RL (`mooncake-rl`)
  - [ ] CI/CD
  - [ ] Docs
  - [ ] Other

  ## Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [x] Refactor
  - [ ] Breaking change
  - [ ] Documentation update
  - [ ] Performance improvement
  - [ ] Other

  ## How Has This Been Tested?

  Built and tested in the local development container with Redis support enabled.

  **Test commands:**
  ```bash
  clang-format --dry-run --Werror <changed-files>

  cmake --build build-redis-oplog \
    --target mooncake_master p2p_oplog_test redis_oplog_store_test -j2

  ctest --test-dir build-redis-oplog --output-on-failure \
    -R 'p2p_oplog_test|redis_oplog_store_test'
```
  Test results:

  - [ ] Unit tests pass
  - [ ] Integration tests pass (if applicable)
  - [ ] Manual testing done (describe below)

  ## Checklist

  - [x] I have performed a self-review of my own code
  - [ ] I have formatted my code using ./scripts/code_format.sh
  - [ ] I have run pre-commit run --all-files and all hooks pass
  - [ ] I have updated the documentation (if applicable)
  - [x] I have added tests to prove my changes are effective
  - [ ] For changes >500 LOC: I have filed an RFC issue

  ## AI Assistance Disclosure

  - [ ] No AI tools were used
  - [x] AI tools were used (specify below)

  Codex was used to help rebase the branch, review the changes, run local formatting/build/tests, and prepare the PR description. The submitter reviewed the resulting changes.