### PR TITLE
[Doc] Add llm-d Integration page to the Kubernetes deployment guide

### DIFF
--- a/docs/source/deployment/kubernetes-deployment-guide/index.md
+++ b/docs/source/deployment/kubernetes-deployment-guide/index.md
@@ -1,6 +1,6 @@
 # Kubernetes Deployment Guide
 
-Run Mooncake on Kubernetes as a shared **Store** cluster paired with SGLang **prefill/decode** inference — the Store serves as a HiCache L3 backend, while Mooncake's **Transfer Engine** moves KV cache directly between prefill and decode.
+Run Mooncake on Kubernetes as a shared **Store** cluster. The primary scenario below pairs it with SGLang **prefill/decode** inference — the Store serves as a HiCache L3 backend, while Mooncake's **Transfer Engine** moves KV cache directly between prefill and decode. The same Store also backs other orchestrators and engine stacks: see [RBG Integration](rbg-integration) for the RBG operator, and [llm-d Integration](llm-d-integration) for vLLM-based KV offloading and P/D transfer under llm-d.
 
 ---
 
@@ -33,6 +33,7 @@ A long-lived `mooncake-master` plus a replicated set of `mooncake-store` nodes f
 
 - [Mooncake on Kubernetes](mooncake-on-kubernetes) — stand up the Mooncake Store cluster with plain `Deployment` / `Service` objects.
 - [RBG Integration](rbg-integration) — the full Store + P/D scenario with the [sgl-project/rbg](https://github.com/sgl-project/rbg) operator, including a production Mooncake cluster case.
+- [llm-d Integration](llm-d-integration) — Mooncake's two integration points in [llm-d](https://github.com/llm-d/llm-d): the Store as a vLLM KV offload tier, and `MooncakeConnector` for P/D transfer. Links to the upstream llm-d examples.
 
 See also the [Mooncake Store Deployment & Tuning Guide](../mooncake-store-deployment-guide.md) for the component overview, client configuration, and tuning knobs.
 
@@ -42,4 +43,5 @@ See also the [Mooncake Store Deployment & Tuning Guide](../mooncake-store-deploy
 
 mooncake-on-kubernetes
 rbg-integration
+llm-d-integration
 :::

--- a/docs/source/deployment/kubernetes-deployment-guide/llm-d-integration.md
+++ b/docs/source/deployment/kubernetes-deployment-guide/llm-d-integration.md
@@ -1,0 +1,76 @@
+# llm-d Integration
+
+[llm-d](https://github.com/llm-d/llm-d) packages vLLM inference on Kubernetes; Mooncake is the KV layer beneath it. The integration is a **three-layer stack**:
+
+- **Engine — vLLM.** The Mooncake connectors live here: `MooncakeStoreConnector` (offload) and `MooncakeConnector` (P/D transfer), driven by `--kv-transfer-config`, `mooncake_config.json`, and `PYTHONHASHSEED`.
+- **Storage — Mooncake.** The Master/Client binaries, the Transfer Engine (RDMA), and the SSD tier.
+- **Packaging — llm-d.** Kustomize overlays that wire the engine and storage into a Deployment + DaemonSet, plus a routing sidecar.
+
+Mooncake plugs in at **two independent points**, both configured on the vLLM side:
+
+- **KV cache offloading (storage)** — `MooncakeStoreConnector` uses a Mooncake Store pool as a shared offload tier. This is llm-d's primary Mooncake path.
+- **P/D KV transfer** — the routing sidecar's `--kv-connector=mooncake` drives vLLM's `MooncakeConnector` (see [below](#pd-transfer)).
+
+The two share the Transfer Engine but serve different purposes; vLLM's `MultiConnector` can compose them when a deployment needs both. For each layer, this page points at the authoritative source and keeps only what that source leaves for the integrator to reconcile.
+
+## vLLM connector contract
+
+The vLLM side of the integration is a single command. With the Mooncake Master already running and a `mooncake_config.json` on disk, `MooncakeStoreConnector` is wired on a single node with that config file and a connector spec:
+
+```bash
+MOONCAKE_CONFIG_PATH=mooncake_config.json \
+vllm serve meta-llama/Llama-3.1-8B-Instruct \
+    --kv-transfer-config '{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_both"}'
+```
+
+The `mooncake_config.json` this command names has a `mode` field that selects the storage topology:
+
+| Mode | Who owns the DRAM pool | `global_segment_size` | Components |
+|---|---|---|---|
+| `embedded` | each vLLM rank contributes DRAM in-process | **> 0** (e.g. `"80GB"`) | Master + vLLM |
+| `standalone-store` | an external `mooncake_client` owns the CPU DRAM + SSD pool; vLLM ranks are pure requesters | **`0`** | Master + Client + vLLM |
+
+The connector enforces the pairing at startup: `embedded` requires `global_segment_size > 0`, `standalone-store` requires `global_segment_size == 0`, and `local_buffer_size` must be `> 0` in both. `standalone-store` decouples the pool from vLLM — it survives vLLM restarts and can live on GPU-less nodes with large DRAM and NVMe. The SSD tier is a separate switch, not implied by the mode: `enable_offload` must be set together on the vLLM config, the Master, and the Client (vLLM even accepts `embedded` with `enable_offload`).
+
+llm-d instantiates this same contract at scale: the `--kv-transfer-config`, the `MOONCAKE_CONFIG_PATH` JSON, and `PYTHONHASHSEED` set here are what the guide's `patch-vllm.yaml` sets on each model-server Pod. vLLM's docs are the authoritative field reference:
+
+- [MooncakeStore connector usage](https://github.com/vllm-project/vllm/blob/main/docs/features/mooncake_store_connector_usage.md) — the `mooncake_config.json` schema (including the `mode` field), the single-node form above, and the `MultiConnector[MooncakeConnector + MooncakeStoreConnector]` composition for XpYd.
+- [Mooncake connector usage](https://github.com/vllm-project/vllm/blob/main/docs/features/mooncake_connector_usage.md) — the P/D transfer connector and its bootstrap port (`8998`).
+
+```{important}
+Set `PYTHONHASHSEED` to the **same fixed value on every instance sharing a Store**. Mooncake keys blocks by a content hash derived from vLLM's block hashes, and Python randomises its hash seed per process by default — leave it unset and two instances compute different keys for identical tokens, so the pool stays healthy while the cross-instance hit rate sits at zero.
+```
+
+## KV cache offloading on K8s (llm-d)
+
+llm-d's [Tiered Prefix Cache guide](https://github.com/llm-d/llm-d/tree/v0.8.0/guides/tiered-prefix-cache) packages MooncakeStore as an offload backend: evicted KV blocks move out of GPU HBM into a Mooncake Store pool that serves them back on a later hit, saving the recompute. Because the pool is shared, multiple vLLM instances reuse each other's cached prefixes. The guide carries the deployment sequence, node sizing, and manifests; deploy it with `helm install` for the router chart and `kubectl apply -k` over the Mooncake overlays.
+
+```{note}
+**Upstream sources** (llm-d `v0.8.0`):
+- Guide: [Tiered Prefix Cache](https://github.com/llm-d/llm-d/tree/v0.8.0/guides/tiered-prefix-cache) — the deployment walkthrough; the MooncakeStore path has `cpu` and `fs` variants.
+- Architecture: [KV Offloader](https://github.com/llm-d/llm-d/blob/v0.8.0/docs/architecture/advanced/kv-management/kv-offloader.md) — Master/Client roles and a `mooncake_config.json` field table.
+- Overlays: [`helpers/mooncake-master-store/`](https://github.com/llm-d/llm-d/tree/v0.8.0/helpers/mooncake-master-store) (Master; both variants), [`modelserver/gpu/vllm/mooncake-store/`](https://github.com/llm-d/llm-d/tree/v0.8.0/guides/tiered-prefix-cache/modelserver/gpu/vllm/mooncake-store) (`cpu`/`fs` vLLM overlays), [`helpers/mooncake-client/`](https://github.com/llm-d/llm-d/tree/v0.8.0/helpers/mooncake-client) (Client DaemonSet base; `fs` patches it up).
+```
+
+```{note}
+**Confirming Mooncake specifically.** The guide's offload verification inspects the decode Pod's `/mnt/files-storage/kv-cache`, which is the vLLM-native/LMCache filesystem tier — a Mooncake `fs` deployment writes nowhere near it, so an all-`Ready` cluster does not prove the Store is working. Confirm Mooncake on the `mooncake_client` Pod instead: its `/data/mooncake-offload` should grow after a long request, and the Master should show the pool registered (metrics on `:9003`).
+```
+
+(pd-transfer)=
+## P/D KV transfer (MooncakeConnector)
+
+The P/D transfer path is independent of the Store. vLLM ships a runnable single-node example for it — [`examples/disaggregated/mooncake_connector/`](https://github.com/vllm-project/vllm/tree/main/examples/disaggregated/mooncake_connector) (proxy + launch scripts, configurable model and bootstrap port). In a prefill/decode disaggregated deployment, llm-d's routing sidecar drives the same connector:
+
+```bash
+# on the decode pod's routing sidecar
+--kv-connector=mooncake
+```
+
+The sidecar queries a bootstrap endpoint on the prefill pods to resolve the target engine, then dispatches prefill and decode so the decoder pulls KV directly from the prefiller.
+
+| Setting | Default | Notes |
+|---|---|---|
+| `--kv-connector=mooncake` | — | Selects vLLM's `MooncakeConnector` on the sidecar. The router accepts only fixed connector names (`mooncake`, not `MultiConnector`), so the serving pods must run `MooncakeConnector` to match it — either as the top-level `kv_connector`, or nested inside a `MultiConnector`. |
+| `--mooncake-bootstrap-port` / `MOONCAKE_BOOTSTRAP_PORT` | `8998` | Port of the Mooncake bootstrap endpoint on prefill pods. Corresponds to vLLM's `VLLM_MOONCAKE_BOOTSTRAP_PORT`. |
+
+**Capability vs. packaged path.** The `mooncake` connector reached a released sidecar in **llm-d-router v0.9.0** ([`supportedKVConnectors` at that tag](https://github.com/llm-d/llm-d-router/blob/v0.9.0/pkg/sidecar/proxy/options.go)), and the umbrella [llm-d v0.8.0](https://github.com/llm-d/llm-d/tree/v0.8.0) release pins that sidecar — so the sidecar **capability** is present. The **deployment path** is reference-only: neither v0.8.0 nor `main` ships a Mooncake P/D overlay, and llm-d's packaged [P/D disaggregation guide](https://github.com/llm-d/llm-d/tree/main/guides/pd-disaggregation) still wires `--kv-connector=nixlv2`, so standing up Mooncake P/D means adapting the serving-pod and sidecar manifests by hand. For the current connector table and flags, see the sidecar's [disaggregation reference](https://github.com/llm-d/llm-d-router/blob/main/docs/disaggregation.md).


### PR DESCRIPTION
## Description

Adds a new page, **llm-d Integration**, to the Kubernetes Deployment Guide, documenting how Mooncake integrates with [llm-d](https://github.com/llm-d/llm-d) (vLLM-based serving on Kubernetes).

The content on this page is organized around three main sections:

- **vLLM connector contract** — the single-node `MooncakeStoreConnector` command, the `mooncake_config.json` `mode` topology (`embedded` / `standalone-store`), and the `PYTHONHASHSEED` requirement.
- **KV cache offloading on K8s (llm-d)** — defers deployment to llm-d's Tiered Prefix Cache guide and overlays, plus a note on how to verify the **Mooncake** offload path specifically (the upstream generic verification targets the native/LMCache filesystem tier, not Mooncake's).
- **P/D KV transfer (`MooncakeConnector`)** — vLLM's runnable example, the routing-sidecar flags, and the distinction between the sidecar *capability* (present since v0.8.0) and a *packaged* Mooncake P/D path (reference-only; manifests need manual adaptation).

All llm-d references are pinned to **v0.8.0**. Field references defer to the upstream vLLM docs, the llm-d guide, and the Mooncake Store deployment guide.
Also wires the page into the guide's `index.md` (toctree + page list) and broadens the guide intro so the Store is framed as backing multiple orchestrators (SGLang/RBG and llm-d).

Two files, ~79 lines added; no existing pages rewritten. The canonical `kv-cache-storage.md` / `vllm-mooncakestoreconnector.md` pages are untouched.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Docs-only change; validated by building the Sphinx site and previewing the rendered page.

**Test commands:**
```bash
cd docs
make clean && make html
python -m http.server -d build/html/ 9000   # manual preview
```

**Test results:**
- Sphinx build succeeds; **0 warnings/errors on the changed page** (and 0 total in this environment). No MyST, anchor, or cross-reference warnings.
- `pre-commit` on the two changed files: `trailing-whitespace`, `end-of-file-fixer`, and `codespell` pass; no files rewritten. The `mooncake-code-format` (clang-format) hook is not applicable to Markdown and did not run here (`clang-format-20` unavailable in this environment).
- Manually previewed the page and verified the toctree/sidebar entry and all intra-page and cross-page links.
- [ ] Unit tests pass — N/A (documentation only)
- [ ] Integration tests pass (if applicable) — N/A
- [x] Manual testing done (Sphinx build + rendered-page review)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh` — N/A (Markdown only; the script formats C++/Python)
- [ ] I have run `pre-commit run --all-files` and all hooks pass — ran `pre-commit run --files <changed docs>` instead (per docs/AGENTS.md, to avoid unrelated rewrites); docs-relevant hooks pass, see above
- [x] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective — N/A (docs)
- [ ] For changes >500 LOC: I have filed an RFC issue — N/A (~79 LOC)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

AI tools (Claude Code, Claude Opus) drafted the page and its wording. Facts were verified against upstream sources (vLLM `MooncakeStoreConnector` / `MooncakeConnector` docs, llm-d `v0.8.0` guide, overlays, and `llm-d-router` sidecar source). A separate AI review pass surfaced accuracy issues (e.g., the `MultiConnector`/sidecar matching rule and the mode-vs-SSD-offload distinction), which were re-checked against upstream and corrected. The human submitter is responsible for understanding and defending every line.