### PR TITLE
[CI/Build] Fix test-wheel-ubuntu flake

### DIFF
--- a/mooncake-wheel/tests/test_cli.py
+++ b/mooncake-wheel/tests/test_cli.py
@@ -55,9 +55,15 @@ def test_entry_point_installed():
 def test_run_master_and_client():
     """Test running the master service through the entry point."""
     try:
-        # Run mooncake_master with a non-default port to avoid conflicts
+        # Run mooncake_master on a non-default gRPC port. Do NOT enable the
+        # embedded HTTP metadata server: the CI test-wheel-ubuntu job runs a
+        # shared Python mooncake_http_metadata_server on the default port 8080
+        # for the whole run_tests.sh suite, so enabling it here would collide
+        # on 8080 and LOG(FATAL). This smoke test connects the client via
+        # direct gRPC (--master_server_address), so it does not need the HTTP
+        # metadata server.
         process = subprocess.Popen(
-            ["mooncake_master", "--port=61351", "--max_threads=2", "--enable_http_metadata_server=true"],
+            ["mooncake_master", "--port=61351", "--max_threads=2"],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE
         )

--- a/mooncake-wheel/tests/test_cli.py
+++ b/mooncake-wheel/tests/test_cli.py
@@ -55,15 +55,21 @@ def test_entry_point_installed():
 def test_run_master_and_client():
     """Test running the master service through the entry point."""
     try:
-        # Run mooncake_master on a non-default gRPC port. Do NOT enable the
-        # embedded HTTP metadata server: the CI test-wheel-ubuntu job runs a
-        # shared Python mooncake_http_metadata_server on the default port 8080
-        # for the whole run_tests.sh suite, so enabling it here would collide
-        # on 8080 and LOG(FATAL). This smoke test connects the client via
-        # direct gRPC (--master_server_address), so it does not need the HTTP
-        # metadata server.
+        # Use non-default ports to avoid collisions with processes started
+        # earlier in the CI test-wheel-ubuntu job:
+        #  * --port: gRPC port. The test client connects via
+        #    --master_server_address (direct gRPC), so it does not need the
+        #    embedded HTTP metadata server on the default 8080 — the job runs a
+        #    shared Python mooncake_http_metadata_server on 8080 for the whole
+        #    run_tests.sh suite, so enabling it here would collide and
+        #    LOG(FATAL) (master.cpp:1449).
+        #  * --metrics_port: the master admin server always binds this port
+        #    (master.cpp:1485, created unconditionally and cannot be disabled),
+        #    and the default 9003 is still held by a lingering master from the
+        #    prior CXL test step when this smoke test runs.
         process = subprocess.Popen(
-            ["mooncake_master", "--port=61351", "--max_threads=2"],
+            ["mooncake_master", "--port=61351", "--max_threads=2",
+             "--metrics_port=19003"],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE
         )


### PR DESCRIPTION
## Description

The `test-wheel-ubuntu` CI job flakes because `test_cli.py` spawns `mooncake_master` with default ports that collide with other processes started earlier in the same job:

1. **Port 8080 (HTTP metadata server):** `--enable_http_metadata_server=true` bound the embedded HTTP metadata server to the default 8080, but the job already runs a shared Python `mooncake_http_metadata_server --port 8080 &` (`ci.yml:484-488`) for the whole `run_tests.sh` suite → bind failed → `LOG(FATAL)` at `master.cpp:1449`.

2. **Port 9003 (master admin server):** the master admin server (`master.cpp:1485`) always binds `metrics_port` (default 9003) and cannot be disabled. When `test_cli.py` runs right after the CXL test step, a lingering previous master still holds 9003 → bind failed (`master_admin_service.cpp:271`) → `LOG(FATAL)` at `master.cpp:1492`.

This has been failing ~6 of the last 7 `Build & Test (Linux)` runs on `main` and is blocking unrelated PRs (e.g. #2978).

## Fix

The test's client connects via **direct gRPC** (`--master_server_address=127.0.0.1:61351`), so it needs neither the HTTP metadata server nor the admin metrics endpoint. Two changes in `test_cli.py`:

- Drop `--enable_http_metadata_server=true` — removes the 8080 collision deterministically (`master.cpp:1443` only binds 8080 when the flag is true).
- Add `--metrics_port=19003` — moves the admin server off the default 9003 (the admin server is created unconditionally at `master.cpp:1485` and cannot be disabled, so the port must be moved). Mirrors the existing `--port=61351` approach of keeping all of this smoke test's ports off the defaults.

Coverage of `--enable_http_metadata_server=true` is preserved elsewhere:
- `run_tests.sh:130` starts a C++ master with that flag (after killing the Python server at line 127).
- `test_upsert_api.py` uses `--http_metadata_server_port=18080`.

## Module

- [x] Python Wheel (`mooncake-wheel`)
- [x] CI/CD

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

**Root-cause analysis (code-level, deterministic):**
- `master.cpp:1443` gates the 8080 bind behind `enable_http_metadata_server`. With the flag removed, the master never calls `StartHttpMetadataServer`, so it cannot collide with the shared Python server.
- `master.cpp:1485` creates the admin server unconditionally and `master_admin_service.cpp:268` always calls `http_server_.async_start()` on `metrics_port`. Moving `--metrics_port` off 9003 avoids the lingering-master collision.
- Confirmed the test client uses direct gRPC (`--master_server_address`), independent of both the HTTP metadata server and the admin metrics endpoint.
- Confirmed CI does not run ruff on Python files (`scripts/code_format.sh` only formats C/C++; no `pre-commit`/`ruff` reference in any `.github/workflows/` file).

**CI log evidence:**
- The 8080 failure reproduces on `main` (run `29569407914`): `Failed to start HTTP metadata server on 0.0.0.0:8080`.
- After the first commit (8080 fix), the 8080 error was gone but a second latent failure surfaced on 9003 (`Failed to start master admin server on port 9003`) — confirming the 9003 conflict was previously masked by the earlier 8080 `LOG(FATAL)`.

**Test results:**
- [x] Manual testing done (CI log trace + source verification above)
- Verification pending: `test-wheel-ubuntu` should go green after the 9003 fix.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh` — N/A, the script only formats C/C++; this is a Python file
- [ ] I have run `pre-commit run --all-files` and all hooks pass — pre-commit surfaces only pre-existing, unrelated ruff findings in this file (unused `import os`, `subprocess.run` reformatting); per AGENTS.md these unrelated edits are intentionally left out of scope. CI does not enforce pre-commit on Python.
- [x] I have updated the documentation (if applicable) — N/A
- [x] I have added tests to prove my changes are effective — the fix *is* to a test; no new test needed
- [x] For changes >500 LOC: I have filed an RFC issue — N/A (~20 LOC)

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

AI-assisted diagnosis and fix. The human submitter has reviewed the change end-to-end and can defend it: both port collisions (8080 shared Python metadata server, 9003 lingering CXL master) were traced through CI logs and source, and the fix (drop the unnecessary flag + move the admin port) was verified against `master.cpp:1443`, `master.cpp:1485`, and the test's client connection path (`test_cli.py:72`).
