### PR TITLE
[TENT] Fix metrics recording zero-overhead, MLU sentinel, and parallel-vector contract

### DIFF
--- a/docs/source/design/tent/metrics.md
+++ b/docs/source/design/tent/metrics.md
@@ -23,7 +23,7 @@ By default, metrics are **disabled** at compile time for maximum performance. To
 cmake -DTENT_METRICS_ENABLED=ON ..
 ```
 
-When disabled at compile time (`TENT_METRICS_ENABLED=OFF`, the default), all metrics macros expand to `((void)0)`, resulting in **zero runtime overhead**.
+When disabled at compile time (`TENT_METRICS_ENABLED=OFF`, the default), all metrics macros expand to `((void)0)` and the `recordTaskCompletionMetrics` body is `#if`-gated out, resulting in **zero runtime overhead** on the transfer hot path.
 
 ### Runtime Disable (Minimal Overhead)
 
@@ -67,9 +67,7 @@ TENT metrics configuration is integrated into the main `transfer-engine.json` co
     "http_server_threads": 2,
     "report_interval_seconds": 30,
     "enable_prometheus": true,
-    "enable_json": true,
-    "latency_buckets": [0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0],
-    "size_buckets": [1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864, 268435456, 1073741824]
+    "enable_json": true
   },
   "transports": {
     // ... transport configuration
@@ -77,10 +75,9 @@ TENT metrics configuration is integrated into the main `transfer-engine.json` co
 }
 ```
 
-**Note**: 
+**Note**:
 - `report_interval_seconds`: Set to 0 to disable periodic logging
-- `latency_buckets`: Values are in **seconds** (e.g., 0.001 = 1ms). The system internally converts to microseconds for histogram storage.
-- `size_buckets`: Values are in bytes
+- Histogram buckets are fixed at compile time (see `kLatencyBuckets` / `kSizeBuckets` in `tent_metrics.h`) for reproducible observability across deployments.
 
 ### Environment Variables
 
@@ -95,10 +92,6 @@ TENT_METRICS_REPORT_INTERVAL=30  # Set to 0 to disable periodic logging
 # Output formats
 TENT_METRICS_ENABLE_PROMETHEUS=true
 TENT_METRICS_ENABLE_JSON=true
-
-# Custom buckets (comma-separated, latency in seconds, size in bytes)
-TENT_METRICS_LATENCY_BUCKETS="0.0001,0.0005,0.001,0.005,0.01,0.05,0.1,0.5,1.0"
-TENT_METRICS_SIZE_BUCKETS="1024,4096,16384,65536,262144,1048576"
 ```
 
 ## Quick Start
@@ -133,15 +126,26 @@ tent_metrics.initialize(config);
 // Using convenience macros (recommended)
 TENT_RECORD_READ_COMPLETED(1024*1024, 0.025);   // 1MB read in 25ms
 TENT_RECORD_WRITE_COMPLETED(512*1024, 0.015);   // 512KB write in 15ms
-TENT_RECORD_READ_FAILED(1024*1024);             // 1MB read failed
-TENT_RECORD_WRITE_FAILED(512*1024);             // 512KB write failed
+TENT_RECORD_READ_FAILED();                       // read failed (no bytes recorded)
+TENT_RECORD_WRITE_FAILED();                      // write failed (no bytes recorded)
+TENT_RECORD_TRANSPORT_FAILOVER();                // cross-transport failover event
 
 // Direct API usage
 auto& tent_metrics = TentMetrics::instance();
 tent_metrics.recordReadCompleted(1024*1024, 0.025);
 tent_metrics.recordWriteCompleted(512*1024, 0.015);
-tent_metrics.recordReadFailed(1024*1024);
-tent_metrics.recordWriteFailed(512*1024);
+tent_metrics.recordReadFailed();
+tent_metrics.recordWriteFailed();
+tent_metrics.recordTransportFailover();
+
+// Deadline feasibility (RFC #2519, observability only):
+tent_metrics.recordDeadlineMLU(0.8);        // MLU < 1 met the deadline
+tent_metrics.recordDeadlineInfeasible();     // deadline was in the past at submit
+
+// Causal-chain per-stage latency breakdown (microseconds):
+tent_metrics.recordStageLatency(TentMetrics::Stage::QueueWait, 12.0);
+tent_metrics.recordStageLatency(TentMetrics::Stage::Dispatch, 45.0);
+tent_metrics.recordStageLatency(TentMetrics::Stage::Transport, 130.0);
 ```
 
 ### RAII Latency Measurement
@@ -224,16 +228,28 @@ Read: 1.00 MB (100 reqs, 2 fails) | Write: 512.00 KB (50 reqs, 1 fails)
 
 | Metric Name | Type | Description |
 |-------------|------|-------------|
-| `tent_read_bytes_total` | Counter | Total bytes read via TENT |
-| `tent_write_bytes_total` | Counter | Total bytes written via TENT |
-| `tent_read_requests_total` | Counter | Total read requests via TENT |
-| `tent_write_requests_total` | Counter | Total write requests via TENT |
+| `tent_read_bytes_total` | Counter | Total bytes read via TENT (success only; failures record no bytes) |
+| `tent_write_bytes_total` | Counter | Total bytes written via TENT (success only) |
+| `tent_read_requests_total` | Counter | Total read requests via TENT (success + failure) |
+| `tent_write_requests_total` | Counter | Total write requests via TENT (success + failure) |
 | `tent_read_failures_total` | Counter | Total read failures via TENT |
 | `tent_write_failures_total` | Counter | Total write failures via TENT |
+| `tent_transport_failover_total` | Counter | Total cross-transport failover events |
+| `tent_deadline_infeasible_total` | Counter | Transfers whose deadline was already in the past at submit time |
 | `tent_read_latency_us` | Histogram | Read latency distribution in microseconds |
 | `tent_write_latency_us` | Histogram | Write latency distribution in microseconds |
 | `tent_read_size_bytes` | Histogram | Read request size distribution in bytes |
 | `tent_write_size_bytes` | Histogram | Write request size distribution in bytes |
+| `tent_deadline_mlu_permille` | Histogram | Deadline feasibility ratio (MLU x 1000); 1000 = MLU 1.0 (the met/missed boundary) |
+| `tent_stage_queue_wait_us` | Histogram | Causal chain: queue wait latency in microseconds |
+| `tent_stage_dispatch_us` | Histogram | Causal chain: dispatch latency in microseconds |
+| `tent_stage_transport_us` | Histogram | Causal chain: transport execution latency in microseconds |
+
+**Notes**:
+- `*_requests_total` counts both successful and failed requests. To compute the success rate, use `1 - (failures / requests)`.
+- `*_failures_total` does not record bytes; failed transfers transfer no bytes.
+- `tent_deadline_infeasible_total` is a dedicated counter (not a histogram sentinel) so infeasible-at-submit cases are distinguishable from genuine high-MLU samples.
+- yalantinglibs omits zero-valued counters/histograms from the Prometheus output, so a metric only appears once it has been observed at least once.
 
 ## Integration with TransferEngine
 
@@ -289,11 +305,11 @@ void TentMetrics::registerMetrics() {
         // ... existing counters ...
         &new_counter_,  // Add new counter here
     };
-    
+
     histograms_ = {
-        &read_latency_,
+        {&read_latency_, &kLatencyBuckets},
         // ... existing histograms ...
-        &new_histogram_,  // Add new histogram here
+        {&new_histogram_, &kNewBuckets},  // Add new histogram + its buckets here
     };
 }
 ```
@@ -325,22 +341,9 @@ No changes to `getPrometheusMetrics()` or `getJsonMetrics()` are required.
 
 ## Advanced Configuration
 
-### Custom Buckets
+### Histogram Buckets
 
-Define custom histogram buckets for specific use cases:
-
-```cpp
-// Latency buckets (in seconds, converted to microseconds internally)
-std::vector<double> rdma_latency_buckets = {
-    0.000001, 0.000005, 0.00001, 0.00005, 0.0001,  // 1-100μs
-    0.0005, 0.001, 0.005, 0.01, 0.05, 0.1          // 0.5-100ms
-};
-
-// Size buckets for different data patterns (in bytes)
-std::vector<double> message_size_buckets = {
-    64, 256, 1024, 4096, 16384, 65536, 262144  // 64B to 256KB
-};
-```
+Histogram bucket boundaries are fixed at compile time (defined as `static inline const std::vector<double>` members in `tent_metrics.h`: `kLatencyBuckets`, `kSizeBuckets`, `kMluPerMilleBuckets`, `kStageBuckets`). They are intentionally not runtime-configurable so that observability is reproducible across deployments. To change buckets, edit the constant in `tent_metrics.h` and rebuild.
 
 ### Validation
 

--- a/docs/source/design/tent/metrics.md
+++ b/docs/source/design/tent/metrics.md
@@ -347,7 +347,7 @@ Histogram bucket boundaries are fixed at compile time (defined as `static inline
 
 ### Compatibility
 
-The `metrics/latency_buckets` and `metrics/size_buckets` config keys, and the `TENT_METRICS_LATENCY_BUCKETS` / `TENT_METRICS_SIZE_BUCKETS` environment variables, were removed and are now silently ignored. Histogram buckets are fixed at compile time (see [Histogram Buckets](#histogram-buckets) above).
+The `metrics/latency_buckets` and `metrics/size_buckets` config keys, and the `TENT_METRICS_LATENCY_BUCKETS` / `TENT_METRICS_SIZE_BUCKETS` environment variables, were removed and are now silently ignored. Histogram buckets are fixed at compile time (see Histogram Buckets above).
 
 **Migration:** remove these keys from your `transfer-engine.json` and unset the environment variables. If custom bucket boundaries are required, edit `kLatencyBuckets` / `kSizeBuckets` in `tent/metrics/tent_metrics.h` and rebuild.
 

--- a/docs/source/design/tent/metrics.md
+++ b/docs/source/design/tent/metrics.md
@@ -388,4 +388,3 @@ rate(tent_read_failures_total[5m]) / rate(tent_read_requests_total[5m])
 histogram_quantile(0.99, rate(tent_read_latency_us_bucket[5m])) / 1000000
 histogram_quantile(0.99, rate(tent_write_latency_us_bucket[5m])) / 1000000
 ```
-

--- a/docs/source/design/tent/metrics.md
+++ b/docs/source/design/tent/metrics.md
@@ -345,6 +345,14 @@ No changes to `getPrometheusMetrics()` or `getJsonMetrics()` are required.
 
 Histogram bucket boundaries are fixed at compile time (defined as `static inline const std::vector<double>` members in `tent_metrics.h`: `kLatencyBuckets`, `kSizeBuckets`, `kMluPerMilleBuckets`, `kStageBuckets`). They are intentionally not runtime-configurable so that observability is reproducible across deployments. To change buckets, edit the constant in `tent_metrics.h` and rebuild.
 
+### Compatibility
+
+The `metrics/latency_buckets` and `metrics/size_buckets` config keys, and the `TENT_METRICS_LATENCY_BUCKETS` / `TENT_METRICS_SIZE_BUCKETS` environment variables, were removed and are now silently ignored. Histogram buckets are fixed at compile time (see [Histogram Buckets](#histogram-buckets) above).
+
+**Migration:** remove these keys from your `transfer-engine.json` and unset the environment variables. If custom bucket boundaries are required, edit `kLatencyBuckets` / `kSizeBuckets` in `tent/metrics/tent_metrics.h` and rebuild.
+
+> **Note:** the previous runtime-configurable implementation had a latent bug — the JSON output labeled custom buckets with the compile-time default boundaries, so `/metrics/json` was already mislabeled for custom-bucket deployments. Removing the knob fixes this rather than preserving a buggy code path.
+
 ### Validation
 
 ```cpp

--- a/mooncake-transfer-engine/tent/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/CMakeLists.txt
@@ -1,18 +1,18 @@
 cmake_minimum_required(VERSION 3.16)
 
-if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
-    project(mc_tent LANGUAGES CXX)
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+  project(mc_tent LANGUAGES CXX)
 endif()
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# Compile-time metrics switch (default OFF for zero overhead on the transfer
-# hot path). Declared at the top level so it is discoverable; the actual
-# compile definition is applied in tent/src/metrics/CMakeLists.txt.
+# Compile-time metrics switch (default OFF for zero overhead on the transfer hot
+# path). Declared at the top level so it is discoverable; the actual compile
+# definition is applied in tent/src/metrics/CMakeLists.txt.
 option(TENT_METRICS_ENABLED "Enable TENT metrics collection" OFF)
 
 add_subdirectory(src)
 add_subdirectory(plugins)
-if (BUILD_UNIT_TESTS)
-    add_subdirectory(tests)
+if(BUILD_UNIT_TESTS)
+  add_subdirectory(tests)
 endif()

--- a/mooncake-transfer-engine/tent/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/CMakeLists.txt
@@ -6,6 +6,11 @@ endif()
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+# Compile-time metrics switch (default OFF for zero overhead on the transfer
+# hot path). Declared at the top level so it is discoverable; the actual
+# compile definition is applied in tent/src/metrics/CMakeLists.txt.
+option(TENT_METRICS_ENABLED "Enable TENT metrics collection" OFF)
+
 add_subdirectory(src)
 add_subdirectory(plugins)
 if (BUILD_UNIT_TESTS)

--- a/mooncake-transfer-engine/tent/include/tent/metrics/config_loader.h
+++ b/mooncake-transfer-engine/tent/include/tent/metrics/config_loader.h
@@ -31,8 +31,6 @@ struct MetricsConfig {
     uint32_t report_interval_seconds = 30;  // 0 means disabled
     bool enable_prometheus = true;
     bool enable_json = true;
-    std::vector<double> latency_buckets;
-    std::vector<double> size_buckets;
 };
 
 // Helper class to load metrics configuration from various sources
@@ -74,10 +72,6 @@ constexpr const char* METRICS_REPORT_INTERVAL =
 constexpr const char* METRICS_ENABLE_PROMETHEUS = "metrics/enable_prometheus";
 constexpr const char* METRICS_ENABLE_JSON = "metrics/enable_json";
 
-// Bucket configurations
-constexpr const char* METRICS_LATENCY_BUCKETS = "metrics/latency_buckets";
-constexpr const char* METRICS_SIZE_BUCKETS = "metrics/size_buckets";
-
 // Environment variable names (with TENT_ prefix)
 constexpr const char* ENV_METRICS_ENABLED = "TENT_METRICS_ENABLED";
 constexpr const char* ENV_METRICS_HTTP_PORT = "TENT_METRICS_HTTP_PORT";
@@ -89,9 +83,6 @@ constexpr const char* ENV_METRICS_REPORT_INTERVAL =
 constexpr const char* ENV_METRICS_ENABLE_PROMETHEUS =
     "TENT_METRICS_ENABLE_PROMETHEUS";
 constexpr const char* ENV_METRICS_ENABLE_JSON = "TENT_METRICS_ENABLE_JSON";
-constexpr const char* ENV_METRICS_LATENCY_BUCKETS =
-    "TENT_METRICS_LATENCY_BUCKETS";
-constexpr const char* ENV_METRICS_SIZE_BUCKETS = "TENT_METRICS_SIZE_BUCKETS";
 }  // namespace config_keys
 
 }  // namespace tent

--- a/mooncake-transfer-engine/tent/include/tent/metrics/tent_metrics.h
+++ b/mooncake-transfer-engine/tent/include/tent/metrics/tent_metrics.h
@@ -87,6 +87,11 @@ class TentMetrics {
     // transfer met its deadline; mlu >= 1 means it missed. Observability only.
     void recordDeadlineMLU(double mlu);
 
+    // Record a transfer whose deadline was already in the past at submit time
+    // (infeasible window). Recorded into a dedicated counter so it is
+    // distinguishable from genuine MLU samples in the histogram above.
+    void recordDeadlineInfeasible();
+
     enum class Stage {
         QueueWait,
         Dispatch,
@@ -166,6 +171,9 @@ class TentMetrics {
     ylt::metric::counter_t failover_total_{
         "tent_transport_failover_total",
         "Total cross-transport failover events"};
+    ylt::metric::counter_t deadline_infeasible_total_{
+        "tent_deadline_infeasible_total",
+        "Transfers whose deadline was already in the past at submit"};
 
     // Histograms - stored as pointers for unified management
     std::vector<ylt::metric::histogram_t*> histograms_;

--- a/mooncake-transfer-engine/tent/include/tent/metrics/tent_metrics.h
+++ b/mooncake-transfer-engine/tent/include/tent/metrics/tent_metrics.h
@@ -175,11 +175,14 @@ class TentMetrics {
         "tent_deadline_infeasible_total",
         "Transfers whose deadline was already in the past at submit"};
 
-    // Histograms - stored as pointers for unified management
-    std::vector<ylt::metric::histogram_t*> histograms_;
-    // Store bucket boundaries separately since ylt histogram doesn't expose
-    // them publicly
-    std::vector<std::vector<double>> histogram_boundaries_;
+    // Histograms - paired with their bucket boundaries in a single vector so
+    // the two cannot drift out of sync (ylt histogram doesn't expose its
+    // boundaries publicly, so we hold them alongside the pointer).
+    struct HistogramEntry {
+        ylt::metric::histogram_t* h;
+        const std::vector<double>* boundaries;
+    };
+    std::vector<HistogramEntry> histograms_;
 
     // Latency histograms use microseconds (us) as unit
     // Default buckets: 100us, 500us, 1ms, 5ms, 10ms, 50ms, 100ms, 500ms, 1s

--- a/mooncake-transfer-engine/tent/include/tent/metrics/tent_metrics.h
+++ b/mooncake-transfer-engine/tent/include/tent/metrics/tent_metrics.h
@@ -77,8 +77,8 @@ class TentMetrics {
     // Record transfer operations
     void recordReadCompleted(size_t bytes, double latency_seconds = 0.0);
     void recordWriteCompleted(size_t bytes, double latency_seconds = 0.0);
-    void recordReadFailed(size_t bytes);
-    void recordWriteFailed(size_t bytes);
+    void recordReadFailed();
+    void recordWriteFailed();
     void recordTransportFailover();
 
     // Record the deadline feasibility ratio (MLU) for a completed transfer
@@ -264,9 +264,9 @@ class ScopedLatencyRecorder {
         if (!enabled_) return;  // Skip if disabled
         failed_ = true;
         if (type_ == OperationType::Read) {
-            TentMetrics::instance().recordReadFailed(bytes_);
+            TentMetrics::instance().recordReadFailed();
         } else {
-            TentMetrics::instance().recordWriteFailed(bytes_);
+            TentMetrics::instance().recordWriteFailed();
         }
     }
 
@@ -295,19 +295,18 @@ class ScopedLatencyRecorder {
         }                                                                   \
     } while (0)
 
-#define TENT_RECORD_READ_FAILED(bytes)                                         \
-    do {                                                                       \
-        if (::mooncake::tent::TentMetrics::isEnabled()) {                      \
-            ::mooncake::tent::TentMetrics::instance().recordReadFailed(bytes); \
-        }                                                                      \
+#define TENT_RECORD_READ_FAILED()                                         \
+    do {                                                                  \
+        if (::mooncake::tent::TentMetrics::isEnabled()) {                 \
+            ::mooncake::tent::TentMetrics::instance().recordReadFailed(); \
+        }                                                                 \
     } while (0)
 
-#define TENT_RECORD_WRITE_FAILED(bytes)                                  \
-    do {                                                                 \
-        if (::mooncake::tent::TentMetrics::isEnabled()) {                \
-            ::mooncake::tent::TentMetrics::instance().recordWriteFailed( \
-                bytes);                                                  \
-        }                                                                \
+#define TENT_RECORD_WRITE_FAILED()                                         \
+    do {                                                                   \
+        if (::mooncake::tent::TentMetrics::isEnabled()) {                  \
+            ::mooncake::tent::TentMetrics::instance().recordWriteFailed(); \
+        }                                                                  \
     } while (0)
 
 #define TENT_RECORD_TRANSPORT_FAILOVER()                  \
@@ -348,8 +347,8 @@ class ScopedLatencyRecorder {
 // Zero-overhead macros when metrics are disabled at compile time
 #define TENT_RECORD_READ_COMPLETED(bytes, latency) ((void)0)
 #define TENT_RECORD_WRITE_COMPLETED(bytes, latency) ((void)0)
-#define TENT_RECORD_READ_FAILED(bytes) ((void)0)
-#define TENT_RECORD_WRITE_FAILED(bytes) ((void)0)
+#define TENT_RECORD_READ_FAILED() ((void)0)
+#define TENT_RECORD_WRITE_FAILED() ((void)0)
 #define TENT_RECORD_TRANSPORT_FAILOVER() ((void)0)
 #define TENT_SCOPED_READ_LATENCY(bytes) ((void)0)
 #define TENT_SCOPED_WRITE_LATENCY(bytes) ((void)0)

--- a/mooncake-transfer-engine/tent/src/metrics/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/src/metrics/CMakeLists.txt
@@ -1,6 +1,4 @@
-# Option to enable/disable TENT metrics at compile time
-option(TENT_METRICS_ENABLED "Enable TENT metrics collection" OFF)
-
+# TENT_METRICS_ENABLED option is declared in tent/CMakeLists.txt.
 file(GLOB TENT_METRICS_SOURCES "*.cpp")
 add_library(tent_metrics STATIC ${TENT_METRICS_SOURCES})
 # Link yalantinglibs::yalantinglibs for metrics and HTTP server (ylt headers + transitive deps).

--- a/mooncake-transfer-engine/tent/src/metrics/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/src/metrics/CMakeLists.txt
@@ -1,18 +1,22 @@
 # TENT_METRICS_ENABLED option is declared in tent/CMakeLists.txt.
 file(GLOB TENT_METRICS_SOURCES "*.cpp")
 add_library(tent_metrics STATIC ${TENT_METRICS_SOURCES})
-# Link yalantinglibs::yalantinglibs for metrics and HTTP server (ylt headers + transitive deps).
-# ODR safety: yalantinglibs bundles ASIO headers but does NOT compile ASIO inline because
-# ASIO_SEPARATE_COMPILATION is set globally. All ASIO symbols live exclusively in asio_shared.so,
-# so there is no risk of duplicate symbols between yalantinglibs and the rest of TE.
-# (See mooncake-common/src/CMakeLists.txt: "Build asio as a shared library to avoid ODR violations")
-target_link_libraries(tent_metrics PUBLIC tent_common tent_interface yalantinglibs::yalantinglibs glog pthread)
+# Link yalantinglibs::yalantinglibs for metrics and HTTP server (ylt headers +
+# transitive deps). ODR safety: yalantinglibs bundles ASIO headers but does NOT
+# compile ASIO inline because ASIO_SEPARATE_COMPILATION is set globally. All
+# ASIO symbols live exclusively in asio_shared.so, so there is no risk of
+# duplicate symbols between yalantinglibs and the rest of TE. (See
+# mooncake-common/src/CMakeLists.txt: "Build asio as a shared library to avoid
+# ODR violations")
+target_link_libraries(
+  tent_metrics PUBLIC tent_common tent_interface yalantinglibs::yalantinglibs
+                      glog pthread)
 
 # Pass compile definition based on option
 if(TENT_METRICS_ENABLED)
-    target_compile_definitions(tent_metrics PUBLIC TENT_METRICS_ENABLED=1)
-    message(STATUS "TENT metrics: ENABLED")
+  target_compile_definitions(tent_metrics PUBLIC TENT_METRICS_ENABLED=1)
+  message(STATUS "TENT metrics: ENABLED")
 else()
-    target_compile_definitions(tent_metrics PUBLIC TENT_METRICS_ENABLED=0)
-    message(STATUS "TENT metrics: DISABLED (zero overhead)")
+  target_compile_definitions(tent_metrics PUBLIC TENT_METRICS_ENABLED=0)
+  message(STATUS "TENT metrics: DISABLED (zero overhead)")
 endif()

--- a/mooncake-transfer-engine/tent/src/metrics/config_loader.cpp
+++ b/mooncake-transfer-engine/tent/src/metrics/config_loader.cpp
@@ -60,22 +60,6 @@ void MetricsConfigLoader::applyEnvironmentOverrides(MetricsConfig& config) {
         config.enable_json =
             ConfigHelper::parseBool(env_val, config.enable_json);
     }
-
-    if (const char* env_val =
-            std::getenv(config_keys::ENV_METRICS_LATENCY_BUCKETS)) {
-        auto buckets = ConfigHelper::parseDoubleArray(env_val);
-        if (!buckets.empty()) {
-            config.latency_buckets = buckets;
-        }
-    }
-
-    if (const char* env_val =
-            std::getenv(config_keys::ENV_METRICS_SIZE_BUCKETS)) {
-        auto buckets = ConfigHelper::parseDoubleArray(env_val);
-        if (!buckets.empty()) {
-            config.size_buckets = buckets;
-        }
-    }
 }
 
 MetricsConfig MetricsConfigLoader::loadFromConfig(const Config& config) {
@@ -100,19 +84,6 @@ MetricsConfig MetricsConfigLoader::loadFromConfig(const Config& config) {
                    metrics_config.enable_prometheus);
     metrics_config.enable_json = config.get(config_keys::METRICS_ENABLE_JSON,
                                             metrics_config.enable_json);
-
-    // Load bucket configurations
-    auto latency_buckets_array =
-        config.getArray<double>(config_keys::METRICS_LATENCY_BUCKETS);
-    if (!latency_buckets_array.empty()) {
-        metrics_config.latency_buckets = latency_buckets_array;
-    }
-
-    auto size_buckets_array =
-        config.getArray<double>(config_keys::METRICS_SIZE_BUCKETS);
-    if (!size_buckets_array.empty()) {
-        metrics_config.size_buckets = size_buckets_array;
-    }
 
     LOG(INFO) << "Loaded metrics config from Config object: enabled="
               << metrics_config.enabled
@@ -161,18 +132,6 @@ MetricsConfig MetricsConfigLoader::loadWithDefaults(const Config* config) {
                         metrics_config.enable_prometheus);
         metrics_config.enable_json = config->get(
             config_keys::METRICS_ENABLE_JSON, metrics_config.enable_json);
-
-        auto latency_buckets_array =
-            config->getArray<double>(config_keys::METRICS_LATENCY_BUCKETS);
-        if (!latency_buckets_array.empty()) {
-            metrics_config.latency_buckets = latency_buckets_array;
-        }
-
-        auto size_buckets_array =
-            config->getArray<double>(config_keys::METRICS_SIZE_BUCKETS);
-        if (!size_buckets_array.empty()) {
-            metrics_config.size_buckets = size_buckets_array;
-        }
     }
 
     return metrics_config;
@@ -204,26 +163,6 @@ bool MetricsConfigLoader::validateConfig(const MetricsConfig& config,
                 "enabled";
         }
         return false;
-    }
-
-    // Validate buckets are sorted and positive
-    for (size_t i = 1; i < config.latency_buckets.size(); ++i) {
-        if (config.latency_buckets[i] <= config.latency_buckets[i - 1]) {
-            if (error_msg) {
-                *error_msg =
-                    "Latency buckets must be sorted in ascending order";
-            }
-            return false;
-        }
-    }
-
-    for (size_t i = 1; i < config.size_buckets.size(); ++i) {
-        if (config.size_buckets[i] <= config.size_buckets[i - 1]) {
-            if (error_msg) {
-                *error_msg = "Size buckets must be sorted in ascending order";
-            }
-            return false;
-        }
     }
 
     return true;

--- a/mooncake-transfer-engine/tent/src/metrics/tent_metrics.cpp
+++ b/mooncake-transfer-engine/tent/src/metrics/tent_metrics.cpp
@@ -187,9 +187,10 @@ void TentMetrics::registerMetrics() {
 
     // Register all counters - add new counters here
     counters_ = {
-        &read_bytes_total_,     &write_bytes_total_,   &read_requests_total_,
-        &write_requests_total_, &read_failures_total_, &write_failures_total_,
-        &failover_total_,       &deadline_infeasible_total_,
+        &read_bytes_total_,    &write_bytes_total_,
+        &read_requests_total_, &write_requests_total_,
+        &read_failures_total_, &write_failures_total_,
+        &failover_total_,      &deadline_infeasible_total_,
     };
 
     // Register all histograms - add new histograms here. Each entry pairs the

--- a/mooncake-transfer-engine/tent/src/metrics/tent_metrics.cpp
+++ b/mooncake-transfer-engine/tent/src/metrics/tent_metrics.cpp
@@ -220,7 +220,7 @@ void TentMetrics::registerMetrics() {
     counters_ = {
         &read_bytes_total_,     &write_bytes_total_,   &read_requests_total_,
         &write_requests_total_, &read_failures_total_, &write_failures_total_,
-        &failover_total_,
+        &failover_total_,       &deadline_infeasible_total_,
     };
 
     // Register all histograms - add new histograms here
@@ -272,6 +272,12 @@ void TentMetrics::recordDeadlineMLU(double mlu) {
     if (mlu < 0.0) return;  // defensive: ignore invalid (e.g. window <= 0)
     // Store in per-mille so the integer histogram can bucket fractional ratios.
     deadline_mlu_.observe(static_cast<int64_t>(mlu * 1000.0));
+}
+
+void TentMetrics::recordDeadlineInfeasible() {
+    if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
+        return;
+    deadline_infeasible_total_.inc();
 }
 
 void TentMetrics::recordStageLatency(Stage stage, double latency_us) {
@@ -448,6 +454,7 @@ void TentMetrics::recordReadFailed() {}
 void TentMetrics::recordWriteFailed() {}
 void TentMetrics::recordTransportFailover() {}
 void TentMetrics::recordDeadlineMLU(double) {}
+void TentMetrics::recordDeadlineInfeasible() {}
 void TentMetrics::recordStageLatency(Stage, double) {}
 
 std::string TentMetrics::getPrometheusMetrics() {

--- a/mooncake-transfer-engine/tent/src/metrics/tent_metrics.cpp
+++ b/mooncake-transfer-engine/tent/src/metrics/tent_metrics.cpp
@@ -175,7 +175,6 @@ void TentMetrics::shutdown() {
     // Clear metric vectors
     counters_.clear();
     histograms_.clear();
-    histogram_boundaries_.clear();
 
     initialized_ = false;
     LOG(INFO) << "TENT metrics shutdown complete";
@@ -183,9 +182,8 @@ void TentMetrics::shutdown() {
 
 void TentMetrics::registerMetrics() {
     // Pre-allocate vectors to avoid reallocation
-    counters_.reserve(7);
+    counters_.reserve(8);
     histograms_.reserve(8);
-    histogram_boundaries_.reserve(8);
 
     // Register all counters - add new counters here
     counters_ = {
@@ -194,15 +192,18 @@ void TentMetrics::registerMetrics() {
         &failover_total_,       &deadline_infeasible_total_,
     };
 
-    // Register all histograms - add new histograms here
-    // Note: histogram_boundaries_ must match the order of histograms_
+    // Register all histograms - add new histograms here. Each entry pairs the
+    // histogram with its compile-time bucket boundaries; the struct keeps the
+    // two in sync so getJsonMetrics() cannot mislabel buckets.
     histograms_ = {
-        &read_latency_, &write_latency_,    &read_size_,      &write_size_,
-        &deadline_mlu_, &stage_queue_wait_, &stage_dispatch_, &stage_transport_,
-    };
-    histogram_boundaries_ = {
-        kLatencyBuckets,     kLatencyBuckets, kSizeBuckets,  kSizeBuckets,
-        kMluPerMilleBuckets, kStageBuckets,   kStageBuckets, kStageBuckets,
+        {&read_latency_, &kLatencyBuckets},
+        {&write_latency_, &kLatencyBuckets},
+        {&read_size_, &kSizeBuckets},
+        {&write_size_, &kSizeBuckets},
+        {&deadline_mlu_, &kMluPerMilleBuckets},
+        {&stage_queue_wait_, &kStageBuckets},
+        {&stage_dispatch_, &kStageBuckets},
+        {&stage_transport_, &kStageBuckets},
     };
 }
 
@@ -308,8 +309,8 @@ std::string TentMetrics::getPrometheusMetrics() {
         }
 
         // Serialize all histograms
-        for (auto* histogram : histograms_) {
-            histogram->serialize(result);
+        for (const auto& entry : histograms_) {
+            entry.h->serialize(result);
         }
 
         return result;
@@ -331,9 +332,9 @@ std::string TentMetrics::getJsonMetrics() {
         }
 
         // Serialize all histograms
-        for (size_t h = 0; h < histograms_.size(); ++h) {
-            auto* histogram = histograms_[h];
-            const auto& boundaries = histogram_boundaries_[h];
+        for (const auto& entry : histograms_) {
+            auto* histogram = entry.h;
+            const auto& boundaries = *entry.boundaries;
 
             auto bucket_counts = histogram->get_bucket_counts();
 

--- a/mooncake-transfer-engine/tent/src/metrics/tent_metrics.cpp
+++ b/mooncake-transfer-engine/tent/src/metrics/tent_metrics.cpp
@@ -42,35 +42,6 @@ Status TentMetrics::initialize(const MetricsConfig& config) {
     // Set runtime enabled state from config
     runtime_enabled_.store(config_.enabled, std::memory_order_relaxed);
 
-    // Configure histogram buckets if provided (recreate histograms)
-    // Note: config latency_buckets are in seconds, convert to microseconds for
-    // histogram
-    if (!config_.latency_buckets.empty()) {
-        // Convert seconds to microseconds for histogram buckets
-        std::vector<double> latency_buckets_us;
-        latency_buckets_us.reserve(config_.latency_buckets.size());
-        for (double bucket_sec : config_.latency_buckets) {
-            latency_buckets_us.push_back(bucket_sec *
-                                         1000000.0);  // seconds -> microseconds
-        }
-        read_latency_ = ylt::metric::histogram_t(
-            "tent_read_latency_us", "Read latency distribution in microseconds",
-            latency_buckets_us);
-        write_latency_ = ylt::metric::histogram_t(
-            "tent_write_latency_us",
-            "Write latency distribution in microseconds", latency_buckets_us);
-    }
-
-    // Configure size histogram buckets if provided
-    if (!config_.size_buckets.empty()) {
-        read_size_ = ylt::metric::histogram_t(
-            "tent_read_size_bytes", "Read request size distribution in bytes",
-            config_.size_buckets);
-        write_size_ = ylt::metric::histogram_t(
-            "tent_write_size_bytes", "Write request size distribution in bytes",
-            config_.size_buckets);
-    }
-
     // Register all metrics to vectors for unified serialization
     registerMetrics();
 

--- a/mooncake-transfer-engine/tent/src/metrics/tent_metrics.cpp
+++ b/mooncake-transfer-engine/tent/src/metrics/tent_metrics.cpp
@@ -292,7 +292,7 @@ void TentMetrics::recordStageLatency(Stage stage, double latency_us) {
     }
 }
 
-void TentMetrics::recordReadFailed(size_t bytes) {
+void TentMetrics::recordReadFailed() {
     // Fast path: check runtime switch first
     if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
         return;
@@ -301,7 +301,7 @@ void TentMetrics::recordReadFailed(size_t bytes) {
     read_requests_total_.inc();  // Count failed requests too
 }
 
-void TentMetrics::recordWriteFailed(size_t bytes) {
+void TentMetrics::recordWriteFailed() {
     // Fast path: check runtime switch first
     if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
         return;
@@ -444,8 +444,8 @@ void TentMetrics::shutdown() { initialized_ = false; }
 
 void TentMetrics::recordReadCompleted(size_t, double) {}
 void TentMetrics::recordWriteCompleted(size_t, double) {}
-void TentMetrics::recordReadFailed(size_t) {}
-void TentMetrics::recordWriteFailed(size_t) {}
+void TentMetrics::recordReadFailed() {}
+void TentMetrics::recordWriteFailed() {}
 void TentMetrics::recordTransportFailover() {}
 void TentMetrics::recordDeadlineMLU(double) {}
 void TentMetrics::recordStageLatency(Stage, double) {}

--- a/mooncake-transfer-engine/tent/src/metrics/tent_metrics.cpp
+++ b/mooncake-transfer-engine/tent/src/metrics/tent_metrics.cpp
@@ -181,10 +181,6 @@ void TentMetrics::shutdown() {
 }
 
 void TentMetrics::registerMetrics() {
-    // Pre-allocate vectors to avoid reallocation
-    counters_.reserve(8);
-    histograms_.reserve(8);
-
     // Register all counters - add new counters here
     counters_ = {
         &read_bytes_total_,    &write_bytes_total_,

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -2426,33 +2426,36 @@ void TransferEngineImpl::recordTaskCompletionMetrics(
                                                   transport_us);
                     }
                 }
-                // Observability only (RFC #2519): if this transfer carried a
-                // deadline, emit the post-hoc feasibility ratio MLU =
-                // actual_transfer_time / available_window, where the window is
-                // (deadline - submit_time). MLU < 1 met the deadline; >= 1
-                // missed it. This does not drive any admission/scheduling yet.
-                if (task.request.deadline_ns != 0) {
-                    uint64_t start_ns = static_cast<uint64_t>(
-                        std::chrono::duration_cast<std::chrono::nanoseconds>(
-                            start_time.time_since_epoch())
-                            .count());
-                    if (task.request.deadline_ns > start_ns) {
-                        double window_seconds =
-                            (task.request.deadline_ns - start_ns) / 1e9;
-                        TentMetrics::instance().recordDeadlineMLU(
-                            latency_seconds / window_seconds);
-                    } else {
-                        // Deadline already in the past at submit: infeasible.
-                        // Recorded into a dedicated counter so it does not
-                        // pollute the MLU histogram with a sentinel value.
-                        TentMetrics::instance().recordDeadlineInfeasible();
-                    }
-                }
             } else if (new_status == FAILED) {
                 if (task.request.opcode == Request::READ) {
                     TentMetrics::instance().recordReadFailed();
                 } else {
                     TentMetrics::instance().recordWriteFailed();
+                }
+            }
+            // Observability only (RFC #2519): deadline feasibility. The
+            // infeasible-at-submit case (deadline already in the past when
+            // the transfer was submitted) is independent of whether the
+            // transfer ultimately completed or failed, so it is recorded for
+            // both outcomes. The feasible MLU ratio requires the actual
+            // transfer latency, so it is only recorded on COMPLETED.
+            if (task.request.deadline_ns != 0) {
+                uint64_t start_ns = static_cast<uint64_t>(
+                    std::chrono::duration_cast<std::chrono::nanoseconds>(
+                        start_time.time_since_epoch())
+                        .count());
+                if (task.request.deadline_ns > start_ns) {
+                    if (new_status == COMPLETED) {
+                        double window_seconds =
+                            (task.request.deadline_ns - start_ns) / 1e9;
+                        TentMetrics::instance().recordDeadlineMLU(
+                            latency_seconds / window_seconds);
+                    }
+                } else {
+                    // Deadline already in the past at submit: infeasible.
+                    // Recorded into a dedicated counter so it does not
+                    // pollute the MLU histogram with a sentinel value.
+                    TentMetrics::instance().recordDeadlineInfeasible();
                 }
             }
             // Reset start_time to prevent duplicate recording

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -2443,7 +2443,9 @@ void TransferEngineImpl::recordTaskCompletionMetrics(
                             latency_seconds / window_seconds);
                     } else {
                         // Deadline already in the past at submit: infeasible.
-                        TentMetrics::instance().recordDeadlineMLU(5.0);
+                        // Recorded into a dedicated counter so it does not
+                        // pollute the MLU histogram with a sentinel value.
+                        TentMetrics::instance().recordDeadlineInfeasible();
                     }
                 }
             } else if (new_status == FAILED) {

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -2388,6 +2388,7 @@ Status TransferEngineImpl::unlockStageBuffer(uint64_t addr) {
 void TransferEngineImpl::recordTaskCompletionMetrics(
     TaskInfo& task, TransferStatusEnum prev_status,
     TransferStatusEnum new_status) {
+#if TENT_METRICS_ENABLED
     if (prev_status == PENDING && new_status != PENDING && !task.derived) {
         auto start_time = task.start_time;
         if (start_time.time_since_epoch().count() > 0) {
@@ -2402,7 +2403,6 @@ void TransferEngineImpl::recordTaskCompletionMetrics(
                     TentMetrics::instance().recordWriteCompleted(
                         task.request.length, latency_seconds);
                 }
-#if TENT_METRICS_ENABLED
                 // Causal chain stage decomposition
                 if (task.dispatch_time.time_since_epoch().count() > 0) {
                     double queue_wait_us =
@@ -2426,7 +2426,6 @@ void TransferEngineImpl::recordTaskCompletionMetrics(
                                                   transport_us);
                     }
                 }
-#endif
                 // Observability only (RFC #2519): if this transfer carried a
                 // deadline, emit the post-hoc feasibility ratio MLU =
                 // actual_transfer_time / available_window, where the window is
@@ -2449,17 +2448,16 @@ void TransferEngineImpl::recordTaskCompletionMetrics(
                 }
             } else if (new_status == FAILED) {
                 if (task.request.opcode == Request::READ) {
-                    TentMetrics::instance().recordReadFailed(
-                        task.request.length);
+                    TentMetrics::instance().recordReadFailed();
                 } else {
-                    TentMetrics::instance().recordWriteFailed(
-                        task.request.length);
+                    TentMetrics::instance().recordWriteFailed();
                 }
             }
             // Reset start_time to prevent duplicate recording
             task.start_time = std::chrono::steady_clock::time_point{};
         }
     }
+#endif  // TENT_METRICS_ENABLED
 }
 
 }  // namespace tent

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -35,13 +35,13 @@ add_test(NAME tent_metrics_http_server_test
          COMMAND tent_metrics_http_server_test)
 
 # TENT Metrics recording test: drives a real TransferEngineImpl with a
-# FakeTransport and asserts that counters/histograms move correctly via the
-# JSON output. Covers completed/failed/infeasible-deadline recording and
-# histogram bucket invariants. Compiles to a stub test when metrics are
-# disabled at compile time.
+# FakeTransport and asserts that counters/histograms move correctly via the JSON
+# output. Covers completed/failed/infeasible-deadline recording and histogram
+# bucket invariants. Compiles to a stub test when metrics are disabled at
+# compile time.
 add_executable(tent_metrics_recording_test metrics_recording_test.cpp)
-target_link_libraries(tent_metrics_recording_test
-                      PRIVATE gtest gtest_main tent_link_group glog)
+target_link_libraries(tent_metrics_recording_test PRIVATE gtest gtest_main
+                                                          tent_link_group glog)
 if(TARGET asio_shared)
   target_link_libraries(tent_metrics_recording_test PRIVATE asio_shared)
 endif()
@@ -69,8 +69,8 @@ target_include_directories(bw_arbitration_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME bw_arbitration_test COMMAND bw_arbitration_test)
 
-# Reproducible hot-path microbenchmark; intentionally not registered with
-# ctest. Run manually when changing deadline promotion partitioning.
+# Reproducible hot-path microbenchmark; intentionally not registered with ctest.
+# Run manually when changing deadline promotion partitioning.
 add_executable(deadline_promotion_bench deadline_promotion_bench.cpp
                                         ../src/runtime/admission_queue.cpp)
 target_link_libraries(deadline_promotion_bench PRIVATE tent_common)

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -34,6 +34,21 @@ target_include_directories(tent_metrics_http_server_test
 add_test(NAME tent_metrics_http_server_test
          COMMAND tent_metrics_http_server_test)
 
+# TENT Metrics recording test: drives a real TransferEngineImpl with a
+# FakeTransport and asserts that counters/histograms move correctly via the
+# JSON output. Covers completed/failed/infeasible-deadline recording and
+# histogram bucket invariants. Compiles to a stub test when metrics are
+# disabled at compile time.
+add_executable(tent_metrics_recording_test metrics_recording_test.cpp)
+target_link_libraries(tent_metrics_recording_test
+                      PRIVATE gtest gtest_main tent_link_group glog)
+if(TARGET asio_shared)
+  target_link_libraries(tent_metrics_recording_test PRIVATE asio_shared)
+endif()
+target_include_directories(tent_metrics_recording_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+add_test(NAME tent_metrics_recording_test COMMAND tent_metrics_recording_test)
+
 add_executable(admission_queue_test admission_queue_test.cpp
                                     ../src/runtime/admission_queue.cpp)
 target_link_libraries(admission_queue_test PRIVATE tent_common gtest gtest_main)

--- a/mooncake-transfer-engine/tent/tests/metrics_config_loader_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/metrics_config_loader_test.cpp
@@ -66,8 +66,6 @@ TEST(MetricsConfigLoaderTest, GetDefaultConfigReturnsExpectedDefaults) {
     EXPECT_EQ(config.report_interval_seconds, 30);
     EXPECT_TRUE(config.enable_prometheus);
     EXPECT_TRUE(config.enable_json);
-    EXPECT_TRUE(config.latency_buckets.empty());
-    EXPECT_TRUE(config.size_buckets.empty());
 }
 
 //------------------------------------------------------------------------------
@@ -83,9 +81,7 @@ TEST(MetricsConfigLoaderTest, LoadFromConfigWithAllValues) {
         "metrics/http_server_threads": 4,
         "metrics/report_interval_seconds": 60,
         "metrics/enable_prometheus": false,
-        "metrics/enable_json": true,
-        "metrics/latency_buckets": [0.001, 0.01, 0.1, 1.0],
-        "metrics/size_buckets": [1024, 10240, 102400]
+        "metrics/enable_json": true
     })";
     ASSERT_TRUE(config.load(json_content).ok());
 
@@ -98,11 +94,6 @@ TEST(MetricsConfigLoaderTest, LoadFromConfigWithAllValues) {
     EXPECT_EQ(metrics_config.report_interval_seconds, 60);
     EXPECT_FALSE(metrics_config.enable_prometheus);
     EXPECT_TRUE(metrics_config.enable_json);
-    ASSERT_EQ(metrics_config.latency_buckets.size(), 4);
-    EXPECT_DOUBLE_EQ(metrics_config.latency_buckets[0], 0.001);
-    EXPECT_DOUBLE_EQ(metrics_config.latency_buckets[3], 1.0);
-    ASSERT_EQ(metrics_config.size_buckets.size(), 3);
-    EXPECT_DOUBLE_EQ(metrics_config.size_buckets[0], 1024);
 }
 
 TEST(MetricsConfigLoaderTest, LoadFromConfigWithPartialValues) {
@@ -168,29 +159,6 @@ TEST(MetricsConfigLoaderTest, LoadFromEnvironmentWithPartialVars) {
     // Other values should be defaults
     EXPECT_TRUE(config.enabled);
     EXPECT_EQ(config.http_host, "0.0.0.0");
-}
-
-TEST(MetricsConfigLoaderTest, LoadFromEnvironmentWithLatencyBuckets) {
-    EnvVarGuard g1(config_keys::ENV_METRICS_LATENCY_BUCKETS,
-                   "0.001,0.005,0.01");
-
-    MetricsConfig config = MetricsConfigLoader::loadFromEnvironment();
-
-    ASSERT_EQ(config.latency_buckets.size(), 3);
-    EXPECT_DOUBLE_EQ(config.latency_buckets[0], 0.001);
-    EXPECT_DOUBLE_EQ(config.latency_buckets[1], 0.005);
-    EXPECT_DOUBLE_EQ(config.latency_buckets[2], 0.01);
-}
-
-TEST(MetricsConfigLoaderTest, LoadFromEnvironmentWithSizeBuckets) {
-    EnvVarGuard g1(config_keys::ENV_METRICS_SIZE_BUCKETS, "1024,2048,4096");
-
-    MetricsConfig config = MetricsConfigLoader::loadFromEnvironment();
-
-    ASSERT_EQ(config.size_buckets.size(), 3);
-    EXPECT_DOUBLE_EQ(config.size_buckets[0], 1024);
-    EXPECT_DOUBLE_EQ(config.size_buckets[1], 2048);
-    EXPECT_DOUBLE_EQ(config.size_buckets[2], 4096);
 }
 
 //------------------------------------------------------------------------------
@@ -271,45 +239,6 @@ TEST(MetricsConfigLoaderTest, ValidateConfigNoOutputFormatEnabled) {
     EXPECT_FALSE(MetricsConfigLoader::validateConfig(config, &error_msg));
     EXPECT_FALSE(error_msg.empty());
     EXPECT_NE(error_msg.find("format"), std::string::npos);
-}
-
-TEST(MetricsConfigLoaderTest, ValidateConfigUnsortedLatencyBuckets) {
-    MetricsConfig config = MetricsConfigLoader::getDefaultConfig();
-    config.latency_buckets = {0.1, 0.05, 0.2};  // Not sorted
-    std::string error_msg;
-
-    EXPECT_FALSE(MetricsConfigLoader::validateConfig(config, &error_msg));
-    EXPECT_FALSE(error_msg.empty());
-    EXPECT_NE(error_msg.find("Latency"), std::string::npos);
-}
-
-TEST(MetricsConfigLoaderTest, ValidateConfigUnsortedSizeBuckets) {
-    MetricsConfig config = MetricsConfigLoader::getDefaultConfig();
-    config.size_buckets = {1024, 512, 2048};  // Not sorted
-    std::string error_msg;
-
-    EXPECT_FALSE(MetricsConfigLoader::validateConfig(config, &error_msg));
-    EXPECT_FALSE(error_msg.empty());
-    EXPECT_NE(error_msg.find("Size"), std::string::npos);
-}
-
-TEST(MetricsConfigLoaderTest, ValidateConfigDuplicateBucketValues) {
-    MetricsConfig config = MetricsConfigLoader::getDefaultConfig();
-    config.latency_buckets = {0.1, 0.1, 0.2};  // Duplicate values
-    std::string error_msg;
-
-    EXPECT_FALSE(MetricsConfigLoader::validateConfig(config, &error_msg));
-    EXPECT_FALSE(error_msg.empty());
-}
-
-TEST(MetricsConfigLoaderTest, ValidateConfigValidSortedBuckets) {
-    MetricsConfig config = MetricsConfigLoader::getDefaultConfig();
-    config.latency_buckets = {0.001, 0.01, 0.1, 1.0};
-    config.size_buckets = {1024, 10240, 102400};
-    std::string error_msg;
-
-    EXPECT_TRUE(MetricsConfigLoader::validateConfig(config, &error_msg));
-    EXPECT_TRUE(error_msg.empty());
 }
 
 TEST(MetricsConfigLoaderTest, ValidateConfigNullErrorMsg) {
@@ -404,9 +333,6 @@ TEST(ConfigKeysTest, ConfigKeyConstants) {
     EXPECT_STREQ(config_keys::METRICS_ENABLE_PROMETHEUS,
                  "metrics/enable_prometheus");
     EXPECT_STREQ(config_keys::METRICS_ENABLE_JSON, "metrics/enable_json");
-    EXPECT_STREQ(config_keys::METRICS_LATENCY_BUCKETS,
-                 "metrics/latency_buckets");
-    EXPECT_STREQ(config_keys::METRICS_SIZE_BUCKETS, "metrics/size_buckets");
 }
 
 TEST(ConfigKeysTest, EnvVarConstants) {
@@ -422,10 +348,6 @@ TEST(ConfigKeysTest, EnvVarConstants) {
                  "TENT_METRICS_ENABLE_PROMETHEUS");
     EXPECT_STREQ(config_keys::ENV_METRICS_ENABLE_JSON,
                  "TENT_METRICS_ENABLE_JSON");
-    EXPECT_STREQ(config_keys::ENV_METRICS_LATENCY_BUCKETS,
-                 "TENT_METRICS_LATENCY_BUCKETS");
-    EXPECT_STREQ(config_keys::ENV_METRICS_SIZE_BUCKETS,
-                 "TENT_METRICS_SIZE_BUCKETS");
 }
 
 }  // namespace

--- a/mooncake-transfer-engine/tent/tests/metrics_recording_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/metrics_recording_test.cpp
@@ -92,8 +92,7 @@ struct HttpResponse {
 
 HttpResponse FetchUrl(uint16_t port, const std::string& path) {
     coro_http::coro_http_client client;
-    auto result =
-        client.get("http://127.0.0.1:" + std::to_string(port) + path);
+    auto result = client.get("http://127.0.0.1:" + std::to_string(port) + path);
     return {result.status, std::string(result.resp_body)};
 }
 
@@ -135,7 +134,8 @@ class MetricsSnapshot {
     // All bucket keys for a histogram (sorted ascending as integers).
     std::vector<int64_t> bucketKeys(const std::string& name) const {
         std::vector<int64_t> keys;
-        if (!json_.contains(name) || !json_[name].contains("buckets")) return keys;
+        if (!json_.contains(name) || !json_[name].contains("buckets"))
+            return keys;
         for (auto it = json_[name]["buckets"].begin();
              it != json_[name]["buckets"].end(); ++it) {
             try {
@@ -276,8 +276,7 @@ void installFakeRdma(TransferEngineImpl& engine,
     engine.swapTransportForTest(RDMA, fake);
 }
 
-Request makeLocalWrite(uint8_t* ptr, size_t length,
-                       uint64_t deadline_ns = 0) {
+Request makeLocalWrite(uint8_t* ptr, size_t length, uint64_t deadline_ns = 0) {
     Request request;
     request.opcode = Request::WRITE;
     request.source = ptr;
@@ -323,9 +322,7 @@ class MetricsRecordingTest : public ::testing::Test {
         TentMetrics::setEnabled(true);
     }
 
-    void TearDown() override {
-        TentMetrics::instance().shutdown();
-    }
+    void TearDown() override { TentMetrics::instance().shutdown(); }
 };
 
 // ---------------------------------------------------------------------------
@@ -350,7 +347,8 @@ TEST_F(MetricsRecordingTest, CompletedTransferRecordsBytesAndLatency) {
     auto before = MetricsSnapshot(TentMetrics::instance());
     ASSERT_TRUE(
         engine.submitTransfer(batch, {makeLocalWrite(buf.data(), kLen)}).ok());
-    ASSERT_EQ(pollUntilTerminal(engine, batch, 0), TransferStatusEnum::COMPLETED);
+    ASSERT_EQ(pollUntilTerminal(engine, batch, 0),
+              TransferStatusEnum::COMPLETED);
     auto after = MetricsSnapshot(TentMetrics::instance());
 
     EXPECT_EQ(after.counter("tent_write_bytes_total") -
@@ -435,10 +433,11 @@ TEST_F(MetricsRecordingTest, InfeasibleDeadlineRecordsSeparateCounter) {
     auto before = MetricsSnapshot(TentMetrics::instance());
     // deadline_ns = 1 is always in the past relative to steady_clock now.
     ASSERT_TRUE(engine
-                    .submitTransfer(batch,
-                                    {makeLocalWrite(buf.data(), kLen, /*deadline_ns=*/1)})
+                    .submitTransfer(batch, {makeLocalWrite(buf.data(), kLen,
+                                                           /*deadline_ns=*/1)})
                     .ok());
-    ASSERT_EQ(pollUntilTerminal(engine, batch, 0), TransferStatusEnum::COMPLETED);
+    ASSERT_EQ(pollUntilTerminal(engine, batch, 0),
+              TransferStatusEnum::COMPLETED);
     auto after = MetricsSnapshot(TentMetrics::instance());
 
     // The infeasible counter must exist and increment by exactly 1.
@@ -480,13 +479,15 @@ TEST_F(MetricsRecordingTest, FeasibleDeadlineRecordsMLU) {
     // Deadline far in the future -> window is huge -> MLU is tiny but > 0.
     uint64_t future_ns = static_cast<uint64_t>(
         std::chrono::duration_cast<std::chrono::nanoseconds>(
-            std::chrono::steady_clock::now().time_since_epoch() + std::chrono::hours(1))
+            std::chrono::steady_clock::now().time_since_epoch() +
+            std::chrono::hours(1))
             .count());
     ASSERT_TRUE(engine
-                    .submitTransfer(batch,
-                                    {makeLocalWrite(buf.data(), kLen, future_ns)})
+                    .submitTransfer(
+                        batch, {makeLocalWrite(buf.data(), kLen, future_ns)})
                     .ok());
-    ASSERT_EQ(pollUntilTerminal(engine, batch, 0), TransferStatusEnum::COMPLETED);
+    ASSERT_EQ(pollUntilTerminal(engine, batch, 0),
+              TransferStatusEnum::COMPLETED);
     auto after = MetricsSnapshot(TentMetrics::instance());
 
     EXPECT_EQ(after.histogramCount("tent_deadline_mlu_permille") -
@@ -561,7 +562,7 @@ TEST_F(MetricsRecordingTest, BucketsAreCompileTimeDefaults) {
 
     // Compile-time kLatencyBuckets: 100, 500, 1000, 5000, 10000, 50000,
     // 100000, 500000, 1000000.
-    std::vector<int64_t> expected = {100,  500,   1000,   5000,   10000,
+    std::vector<int64_t> expected = {100,   500,    1000,   5000,   10000,
                                      50000, 100000, 500000, 1000000};
     EXPECT_EQ(keys, expected)
         << "latency buckets must be the compile-time defaults";
@@ -593,9 +594,7 @@ class MetricsHttpTest : public ::testing::Test {
         }
     }
 
-    void TearDown() override {
-        TentMetrics::instance().shutdown();
-    }
+    void TearDown() override { TentMetrics::instance().shutdown(); }
 
     // Retry a GET a few times to absorb the brief window between
     // async_start() returning and the server accepting connections.
@@ -624,7 +623,8 @@ TEST_F(MetricsHttpTest, PrometheusEndpointExposesAllCounters) {
     EXPECT_NE(resp.body.find("tent_write_bytes_total"), std::string::npos);
     EXPECT_NE(resp.body.find("tent_deadline_infeasible_total"),
               std::string::npos);
-    EXPECT_NE(resp.body.find("tent_write_latency_us_bucket"), std::string::npos);
+    EXPECT_NE(resp.body.find("tent_write_latency_us_bucket"),
+              std::string::npos);
 }
 
 TEST_F(MetricsHttpTest, JsonEndpointValid) {
@@ -633,8 +633,10 @@ TEST_F(MetricsHttpTest, JsonEndpointValid) {
     auto resp = retryGet("/metrics/json");
     EXPECT_EQ(resp.http_status, 200);
     // Must be parseable JSON and contain expected keys.
-    auto json = nlohmann::json::parse(resp.body, nullptr, /*allow_exceptions=*/false);
-    ASSERT_FALSE(json.is_discarded()) << "body was not valid JSON: " << resp.body;
+    auto json =
+        nlohmann::json::parse(resp.body, nullptr, /*allow_exceptions=*/false);
+    ASSERT_FALSE(json.is_discarded())
+        << "body was not valid JSON: " << resp.body;
     EXPECT_TRUE(json.contains("tent_read_bytes_total"));
     EXPECT_TRUE(json.contains("tent_deadline_infeasible_total"));
     EXPECT_TRUE(json.contains("tent_read_latency_us"));

--- a/mooncake-transfer-engine/tent/tests/metrics_recording_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/metrics_recording_test.cpp
@@ -167,7 +167,8 @@ class FakeSubBatch : public Transport::SubBatch {
 
 class FakeTransport : public Transport {
    public:
-    explicit FakeTransport(TransportType self_type) : self_type_(self_type) {
+    explicit FakeTransport(TransportType self_type, bool force_fail = false)
+        : self_type_(self_type), force_fail_(force_fail) {
         caps.dram_to_dram = true;
     }
     std::atomic<int> submit_calls{0};
@@ -196,7 +197,10 @@ class FakeTransport : public Transport {
         for (const auto& request : requests) {
             fake->requests.push_back(request);
             fake->statuses.push_back(
-                {TransferStatusEnum::COMPLETED, request.length});
+                force_fail_
+                    ? TransferStatus{TransferStatusEnum::FAILED, 0}
+                    : TransferStatus{TransferStatusEnum::COMPLETED,
+                                      request.length});
             ++fake->task_count;
         }
         batch->notifyProgress();
@@ -247,6 +251,7 @@ class FakeTransport : public Transport {
 
    private:
     TransportType self_type_;
+    bool force_fail_;
 };
 
 std::shared_ptr<Config> makeMetricsTestConfig() {
@@ -497,6 +502,55 @@ TEST_F(MetricsRecordingTest, FeasibleDeadlineRecordsMLU) {
     EXPECT_EQ(after.counter("tent_deadline_infeasible_total") -
                   before.counter("tent_deadline_infeasible_total"),
               0);
+
+    EXPECT_TRUE(engine.freeBatch(batch).ok());
+    EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), buf.size()).ok());
+}
+
+// ---------------------------------------------------------------------------
+// A failed transfer whose deadline was already in the past at submit must
+// also increment the infeasible counter. The infeasible-at-submit condition
+// is independent of the transfer outcome, so it is recorded for both
+// COMPLETED and FAILED (the MLU histogram, which needs actual latency, is
+// only recorded on COMPLETED).
+// ---------------------------------------------------------------------------
+TEST_F(MetricsRecordingTest, InfeasibleDeadlineRecordedOnFailedTransfer) {
+    auto cfg = makeMetricsTestConfig();
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake = std::make_shared<FakeTransport>(RDMA, /*force_fail=*/true);
+    installFakeRdma(engine, fake);
+
+    constexpr size_t kLen = 4096;
+    std::vector<uint8_t> buf(kLen, 0xBB);
+    ASSERT_TRUE(engine.registerLocalMemory(buf.data(), buf.size()).ok());
+
+    BatchID batch = engine.allocateBatch(4);
+    ASSERT_NE(batch, (BatchID)0);
+
+    auto before = MetricsSnapshot(TentMetrics::instance());
+    // deadline_ns = 1 is always in the past relative to steady_clock now.
+    ASSERT_TRUE(engine
+                    .submitTransfer(batch,
+                                    {makeLocalWrite(buf.data(), kLen, /*deadline_ns=*/1)})
+                    .ok());
+    // The failing transport reports FAILED; poll until terminal.
+    ASSERT_EQ(pollUntilTerminal(engine, batch, 0), TransferStatusEnum::FAILED);
+    auto after = MetricsSnapshot(TentMetrics::instance());
+
+    // Infeasible counter must increment even though the transfer failed.
+    EXPECT_EQ(after.counter("tent_deadline_infeasible_total") -
+                  before.counter("tent_deadline_infeasible_total"),
+              1);
+    // MLU histogram must not receive a sample (no completion, no latency).
+    EXPECT_EQ(after.histogramCount("tent_deadline_mlu_permille") -
+                  before.histogramCount("tent_deadline_mlu_permille"),
+              0);
+    // And the write failure was recorded.
+    EXPECT_EQ(after.counter("tent_write_failures_total") -
+                  before.counter("tent_write_failures_total"),
+              1);
 
     EXPECT_TRUE(engine.freeBatch(batch).ok());
     EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), buf.size()).ok());

--- a/mooncake-transfer-engine/tent/tests/metrics_recording_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/metrics_recording_test.cpp
@@ -529,29 +529,12 @@ TEST_F(MetricsRecordingTest, HistogramJsonBucketsMatchBoundaries) {
 }
 
 // ---------------------------------------------------------------------------
-// Fix C (Red): when latency_buckets is set in config, the histograms must
-// STILL use the compile-time kLatencyBuckets (the config knob is being
-// removed). Today the code reassigns the histograms to the configured
-// buckets, so the bucket keys would be {"1000","2000"} -> assertion fails.
-// After Fix C removes the knob, the latency_buckets field is gone; this test
-// is updated then to drop the config assignment.
-//
-// NOTE: intentionally last — the reassignment below destructively overwrites
-// the singleton's histogram members and cannot be undone without Fix C.
+// Fix C (Green): histogram buckets are fixed at compile time. The runtime
+// config knob (latency_buckets/size_buckets) has been removed; buckets are
+// version-controlled in code for reproducible observability. This test
+// asserts the latency histogram exposes exactly the kLatencyBuckets keys.
 // ---------------------------------------------------------------------------
-TEST_F(MetricsRecordingTest, BucketsAreCompileTimeDefaultsIgnoringConfig) {
-    // Re-initialize with a config that tries to override buckets.
-    TentMetrics::instance().shutdown();
-    MetricsConfig config;
-    config.enabled = true;
-    config.http_host = "127.0.0.1";
-    config.http_port = getFreeTcpPort();
-    config.report_interval_seconds = 0;
-    config.latency_buckets = {0.001, 0.002};  // would become {1000, 2000} us
-    config.size_buckets = {1, 2};
-    ASSERT_TRUE(TentMetrics::instance().initialize(config).ok());
-    TentMetrics::setEnabled(true);
-
+TEST_F(MetricsRecordingTest, BucketsAreCompileTimeDefaults) {
     // Record one sample so the histogram is non-empty.
     TentMetrics::instance().recordReadCompleted(4096, 0.001);
 
@@ -564,7 +547,7 @@ TEST_F(MetricsRecordingTest, BucketsAreCompileTimeDefaultsIgnoringConfig) {
     std::vector<int64_t> expected = {100,  500,   1000,   5000,   10000,
                                      50000, 100000, 500000, 1000000};
     EXPECT_EQ(keys, expected)
-        << "latency buckets must be the compile-time defaults, not config-driven";
+        << "latency buckets must be the compile-time defaults";
 }
 
 #else  // !TENT_METRICS_ENABLED

--- a/mooncake-transfer-engine/tent/tests/metrics_recording_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/metrics_recording_test.cpp
@@ -197,10 +197,9 @@ class FakeTransport : public Transport {
         for (const auto& request : requests) {
             fake->requests.push_back(request);
             fake->statuses.push_back(
-                force_fail_
-                    ? TransferStatus{TransferStatusEnum::FAILED, 0}
-                    : TransferStatus{TransferStatusEnum::COMPLETED,
-                                      request.length});
+                force_fail_ ? TransferStatus{TransferStatusEnum::FAILED, 0}
+                            : TransferStatus{TransferStatusEnum::COMPLETED,
+                                             request.length});
             ++fake->task_count;
         }
         batch->notifyProgress();
@@ -331,8 +330,8 @@ class MetricsRecordingTest : public ::testing::Test {
 };
 
 // ---------------------------------------------------------------------------
-// Fix A (Red -> Green): completed transfer records bytes, requests, latency.
-// Drives the real recordTaskCompletionMetrics path via FakeTransport.
+// Completed transfer records bytes, requests, latency. Drives the real
+// recordTaskCompletionMetrics path via FakeTransport.
 // ---------------------------------------------------------------------------
 TEST_F(MetricsRecordingTest, CompletedTransferRecordsBytesAndLatency) {
     auto cfg = makeMetricsTestConfig();
@@ -374,9 +373,9 @@ TEST_F(MetricsRecordingTest, CompletedTransferRecordsBytesAndLatency) {
 }
 
 // ---------------------------------------------------------------------------
-// Fix A (Red -> Green): failed transfer increments failures and requests but
-// NOT bytes or size histogram. Uses the direct API so the assertion is
-// deterministic and does not depend on engine failover behavior.
+// Failed transfer increments failures and requests but NOT bytes or size
+// histogram. Uses the direct API so the assertion is deterministic and does
+// not depend on engine failover behavior.
 // ---------------------------------------------------------------------------
 TEST_F(MetricsRecordingTest, FailedTransferCountsFailureNotBytes) {
     auto before = MetricsSnapshot(TentMetrics::instance());
@@ -415,10 +414,9 @@ TEST_F(MetricsRecordingTest, FailedTransferCountsFailureNotBytes) {
 }
 
 // ---------------------------------------------------------------------------
-// Fix B (Red): a transfer whose deadline was already in the past at submit
-// must increment a SEPARATE tent_deadline_infeasible_total counter, and must
-// NOT pollute the tent_deadline_mlu_permille histogram. Today there is no
-// such counter and the sentinel (5.0) lands in the histogram, so this fails.
+// A transfer whose deadline was already in the past at submit must increment
+// the dedicated tent_deadline_infeasible_total counter, and must NOT pollute
+// the tent_deadline_mlu_permille histogram with a sentinel value.
 // ---------------------------------------------------------------------------
 TEST_F(MetricsRecordingTest, InfeasibleDeadlineRecordsSeparateCounter) {
     auto cfg = makeMetricsTestConfig();
@@ -462,8 +460,8 @@ TEST_F(MetricsRecordingTest, InfeasibleDeadlineRecordsSeparateCounter) {
 }
 
 // ---------------------------------------------------------------------------
-// Fix B (companion): a transfer whose deadline is in the future records a
-// genuine MLU sample into the histogram (feasible or missed, but real).
+// A transfer whose deadline is in the future records a genuine MLU sample
+// into the histogram (feasible or missed, but real).
 // ---------------------------------------------------------------------------
 TEST_F(MetricsRecordingTest, FeasibleDeadlineRecordsMLU) {
     auto cfg = makeMetricsTestConfig();
@@ -532,8 +530,8 @@ TEST_F(MetricsRecordingTest, InfeasibleDeadlineRecordedOnFailedTransfer) {
     auto before = MetricsSnapshot(TentMetrics::instance());
     // deadline_ns = 1 is always in the past relative to steady_clock now.
     ASSERT_TRUE(engine
-                    .submitTransfer(batch,
-                                    {makeLocalWrite(buf.data(), kLen, /*deadline_ns=*/1)})
+                    .submitTransfer(batch, {makeLocalWrite(buf.data(), kLen,
+                                                           /*deadline_ns=*/1)})
                     .ok());
     // The failing transport reports FAILED; poll until terminal.
     ASSERT_EQ(pollUntilTerminal(engine, batch, 0), TransferStatusEnum::FAILED);
@@ -557,14 +555,9 @@ TEST_F(MetricsRecordingTest, InfeasibleDeadlineRecordedOnFailedTransfer) {
 }
 
 // ---------------------------------------------------------------------------
-// Fix D (regression guard): every histogram's JSON bucket keys must match its
-// compile-time boundary vector. Passes before AND after the parallel-vector
-// -> struct refactor; locks the invariant the refactor must preserve.
-//
-// Runs BEFORE BucketsAreCompileTimeDefaultsIgnoringConfig because that test
-// destructively reassigns the singleton's histogram members (pre-Fix-C), which
-// would pollute the bucket structure observed here. After Fix C removes the
-// reassignment, the ordering constraint is moot.
+// Regression guard: every histogram's JSON bucket keys must match its
+// compile-time boundary vector. Locks the invariant that the HistogramEntry
+// struct pairing must preserve.
 // ---------------------------------------------------------------------------
 TEST_F(MetricsRecordingTest, HistogramJsonBucketsMatchBoundaries) {
     struct HistSpec {
@@ -601,10 +594,10 @@ TEST_F(MetricsRecordingTest, HistogramJsonBucketsMatchBoundaries) {
 }
 
 // ---------------------------------------------------------------------------
-// Fix C (Green): histogram buckets are fixed at compile time. The runtime
-// config knob (latency_buckets/size_buckets) has been removed; buckets are
-// version-controlled in code for reproducible observability. This test
-// asserts the latency histogram exposes exactly the kLatencyBuckets keys.
+// Histogram buckets are fixed at compile time. The runtime config knob
+// (latency_buckets/size_buckets) has been removed; buckets are version-
+// controlled in code for reproducible observability. This test asserts the
+// latency histogram exposes exactly the kLatencyBuckets keys.
 // ---------------------------------------------------------------------------
 TEST_F(MetricsRecordingTest, BucketsAreCompileTimeDefaults) {
     // Record one sample so the histogram is non-empty.

--- a/mooncake-transfer-engine/tent/tests/metrics_recording_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/metrics_recording_test.cpp
@@ -52,6 +52,9 @@ namespace {
 
 #if TENT_METRICS_ENABLED
 
+#include <csignal>  // required before ylt headers (coro_io uses std::signal)
+#include <ylt/coro_http/coro_http_client.hpp>
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -78,6 +81,20 @@ uint16_t getFreeTcpPort() {
     int port = ntohs(addr.sin_port);
     ::close(sock);
     return static_cast<uint16_t>(port);
+}
+
+// HTTP GET helper. Adapted from
+// mooncake-store/tests/master_metrics_test.cpp FetchUrl().
+struct HttpResponse {
+    int http_status;
+    std::string body;
+};
+
+HttpResponse FetchUrl(uint16_t port, const std::string& path) {
+    coro_http::coro_http_client client;
+    auto result =
+        client.get("http://127.0.0.1:" + std::to_string(port) + path);
+    return {result.status, std::string(result.resp_body)};
 }
 
 // Snapshot of TentMetrics JSON output. Provides delta-based accessors so
@@ -548,6 +565,85 @@ TEST_F(MetricsRecordingTest, BucketsAreCompileTimeDefaults) {
                                      50000, 100000, 500000, 1000000};
     EXPECT_EQ(keys, expected)
         << "latency buckets must be the compile-time defaults";
+}
+
+// ---------------------------------------------------------------------------
+// L2 HTTP integration: scrape the real /metrics, /metrics/json, /health
+// endpoints via coro_http_client and assert on status + body. Validates the
+// HTTP wiring (handlers, content, status codes) on top of the L1 recording
+// assertions.
+// ---------------------------------------------------------------------------
+class MetricsHttpTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        TentMetrics::instance().shutdown();
+        MetricsConfig config;
+        config.enabled = true;
+        config.http_host = "127.0.0.1";
+        config.http_port = getFreeTcpPort();
+        config.report_interval_seconds = 0;
+        ASSERT_TRUE(TentMetrics::instance().initialize(config).ok());
+        TentMetrics::setEnabled(true);
+        port_ = TentMetrics::instance().httpPort();
+        // If the port bind raced (another process grabbed it), degrade
+        // gracefully rather than failing the build.
+        if (port_ == 0) {
+            GTEST_SKIP() << "metrics HTTP server did not bind; skipping HTTP "
+                            "integration test";
+        }
+    }
+
+    void TearDown() override {
+        TentMetrics::instance().shutdown();
+    }
+
+    // Retry a GET a few times to absorb the brief window between
+    // async_start() returning and the server accepting connections.
+    HttpResponse retryGet(const std::string& path, int attempts = 20) {
+        HttpResponse resp{0, ""};
+        for (int i = 0; i < attempts; ++i) {
+            resp = FetchUrl(port_, path);
+            if (resp.http_status == 200) return resp;
+            std::this_thread::sleep_for(std::chrono::milliseconds(25));
+        }
+        return resp;
+    }
+
+    uint16_t port_ = 0;
+};
+
+TEST_F(MetricsHttpTest, PrometheusEndpointExposesAllCounters) {
+    // Record a mix of operations so the counters are non-zero.
+    TentMetrics::instance().recordReadCompleted(1024, 0.001);
+    TentMetrics::instance().recordWriteCompleted(2048, 0.002);
+    TentMetrics::instance().recordDeadlineInfeasible();
+
+    auto resp = retryGet("/metrics");
+    EXPECT_EQ(resp.http_status, 200);
+    EXPECT_NE(resp.body.find("tent_read_bytes_total"), std::string::npos);
+    EXPECT_NE(resp.body.find("tent_write_bytes_total"), std::string::npos);
+    EXPECT_NE(resp.body.find("tent_deadline_infeasible_total"),
+              std::string::npos);
+    EXPECT_NE(resp.body.find("tent_write_latency_us_bucket"), std::string::npos);
+}
+
+TEST_F(MetricsHttpTest, JsonEndpointValid) {
+    TentMetrics::instance().recordReadCompleted(512, 0.0005);
+
+    auto resp = retryGet("/metrics/json");
+    EXPECT_EQ(resp.http_status, 200);
+    // Must be parseable JSON and contain expected keys.
+    auto json = nlohmann::json::parse(resp.body, nullptr, /*allow_exceptions=*/false);
+    ASSERT_FALSE(json.is_discarded()) << "body was not valid JSON: " << resp.body;
+    EXPECT_TRUE(json.contains("tent_read_bytes_total"));
+    EXPECT_TRUE(json.contains("tent_deadline_infeasible_total"));
+    EXPECT_TRUE(json.contains("tent_read_latency_us"));
+}
+
+TEST_F(MetricsHttpTest, HealthEndpointOk) {
+    auto resp = retryGet("/health");
+    EXPECT_EQ(resp.http_status, 200);
+    EXPECT_EQ(resp.body, "OK");
 }
 
 #else  // !TENT_METRICS_ENABLED

--- a/mooncake-transfer-engine/tent/tests/metrics_recording_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/metrics_recording_test.cpp
@@ -1,0 +1,584 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// TDD tests for the TENT metrics recording path. Drives a real
+// TransferEngineImpl with a FakeTransport (pattern borrowed from
+// causal_chain_test.cpp) and asserts on TentMetrics JSON/Prometheus output.
+//
+// All assertions are DELTA-based (snapshot before, act, snapshot after,
+// compare). TentMetrics is a process-wide singleton whose counter/histogram
+// values are not reset by shutdown()/initialize(), so absolute-value
+// assertions would be order-dependent across tests.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "tent/common/config.h"
+#include "tent/common/types.h"
+#include "tent/metrics/config_loader.h"
+#include "tent/metrics/tent_metrics.h"
+#include "tent/runtime/transfer_engine_impl.h"
+#include "tent/runtime/transport.h"
+#include "tent/thirdparty/nlohmann/json.h"
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+#if TENT_METRICS_ENABLED
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// Bind a loopback socket on port 0, read the assigned port, close, return it.
+// TOCTOU race is inherent; callers re-check via TentMetrics::httpPort().
+// Adapted from mooncake-store/src/utils.cpp getFreeTcpPort().
+uint16_t getFreeTcpPort() {
+    int sock = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (sock < 0) return 0;
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = htons(0);
+    if (::bind(sock, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0) {
+        ::close(sock);
+        return 0;
+    }
+    socklen_t len = sizeof(addr);
+    if (::getsockname(sock, reinterpret_cast<sockaddr*>(&addr), &len) != 0) {
+        ::close(sock);
+        return 0;
+    }
+    int port = ntohs(addr.sin_port);
+    ::close(sock);
+    return static_cast<uint16_t>(port);
+}
+
+// Snapshot of TentMetrics JSON output. Provides delta-based accessors so
+// tests are robust to singleton state accumulated by prior tests.
+class MetricsSnapshot {
+   public:
+    explicit MetricsSnapshot(TentMetrics& m) {
+        std::string body = m.getJsonMetrics();
+        try {
+            json_ = nlohmann::json::parse(body);
+        } catch (...) {
+            json_ = nlohmann::json::object();
+        }
+    }
+
+    // Counter value (0 if absent).
+    double counter(const std::string& name) const {
+        if (!json_.contains(name)) return 0.0;
+        const auto& v = json_[name];
+        return v.is_number() ? v.get<double>() : 0.0;
+    }
+
+    // Histogram total sample count (0 if absent).
+    int64_t histogramCount(const std::string& name) const {
+        if (!json_.contains(name) || !json_[name].is_object()) return 0;
+        if (!json_[name].contains("count")) return 0;
+        return json_[name]["count"].get<int64_t>();
+    }
+
+    // Histogram bucket value by boundary key (e.g. "100"). 0 if absent.
+    int64_t bucket(const std::string& name, const std::string& le) const {
+        if (!json_.contains(name) || !json_[name].contains("buckets")) return 0;
+        const auto& buckets = json_[name]["buckets"];
+        if (!buckets.contains(le)) return 0;
+        return buckets[le].get<int64_t>();
+    }
+
+    // All bucket keys for a histogram (sorted ascending as integers).
+    std::vector<int64_t> bucketKeys(const std::string& name) const {
+        std::vector<int64_t> keys;
+        if (!json_.contains(name) || !json_[name].contains("buckets")) return keys;
+        for (auto it = json_[name]["buckets"].begin();
+             it != json_[name]["buckets"].end(); ++it) {
+            try {
+                keys.push_back(std::stoll(it.key()));
+            } catch (...) {
+                // skip non-numeric keys (shouldn't happen for our histograms)
+            }
+        }
+        std::sort(keys.begin(), keys.end());
+        return keys;
+    }
+
+   private:
+    nlohmann::json json_;
+};
+
+// ---------------------------------------------------------------------------
+// FakeTransport: minimal Transport that completes every submitted task.
+// Pattern borrowed from causal_chain_test.cpp.
+// ---------------------------------------------------------------------------
+
+class FakeSubBatch : public Transport::SubBatch {
+   public:
+    size_t size() const override { return task_count; }
+    size_t task_count = 0;
+    std::vector<Request> requests;
+    std::vector<TransferStatus> statuses;
+};
+
+class FakeTransport : public Transport {
+   public:
+    explicit FakeTransport(TransportType self_type) : self_type_(self_type) {
+        caps.dram_to_dram = true;
+    }
+    std::atomic<int> submit_calls{0};
+
+    Status install(std::string&, std::shared_ptr<ControlService>,
+                   std::shared_ptr<Topology>,
+                   std::shared_ptr<Config>) override {
+        return Status::OK();
+    }
+
+    Status allocateSubBatch(SubBatchRef& batch, size_t) override {
+        batch = new FakeSubBatch();
+        return Status::OK();
+    }
+
+    Status freeSubBatch(SubBatchRef& batch) override {
+        delete static_cast<FakeSubBatch*>(batch);
+        batch = nullptr;
+        return Status::OK();
+    }
+
+    Status submitTransferTasks(SubBatchRef batch,
+                               const std::vector<Request>& requests) override {
+        ++submit_calls;
+        auto* fake = static_cast<FakeSubBatch*>(batch);
+        for (const auto& request : requests) {
+            fake->requests.push_back(request);
+            fake->statuses.push_back(
+                {TransferStatusEnum::COMPLETED, request.length});
+            ++fake->task_count;
+        }
+        batch->notifyProgress();
+        return Status::OK();
+    }
+
+    Status getTransferStatus(SubBatchRef batch, int task_id,
+                             TransferStatus& status) override {
+        auto* fake = static_cast<FakeSubBatch*>(batch);
+        if (task_id < 0 || task_id >= (int)fake->statuses.size()) {
+            return Status::InvalidArgument("bad task_id" LOC_MARK);
+        }
+        status = fake->statuses[task_id];
+        return Status::OK();
+    }
+
+    Status addMemoryBuffer(BufferDesc& desc, const MemoryOptions&) override {
+        desc.transports.push_back(self_type_);
+        return Status::OK();
+    }
+
+    Status addMemoryBuffer(std::vector<BufferDesc>& desc_list,
+                           const MemoryOptions& options) override {
+        for (auto& desc : desc_list) {
+            auto s = addMemoryBuffer(desc, options);
+            if (!s.ok()) return s;
+        }
+        return Status::OK();
+    }
+
+    Status removeMemoryBuffer(BufferDesc&) override { return Status::OK(); }
+
+    Status allocateLocalMemory(void** addr, size_t size,
+                               MemoryOptions&) override {
+        *addr = std::malloc(size);
+        return *addr ? Status::OK()
+                     : Status::InternalError("malloc failed" LOC_MARK);
+    }
+
+    Status freeLocalMemory(void* addr, size_t) override {
+        std::free(addr);
+        return Status::OK();
+    }
+
+    bool warmupMemory(void*, size_t) override { return false; }
+
+    const char* getName() const override { return "<fake-metrics>"; }
+
+   private:
+    TransportType self_type_;
+};
+
+std::shared_ptr<Config> makeMetricsTestConfig() {
+    auto cfg = std::make_shared<Config>();
+    cfg->set("metadata_type", "p2p");
+    cfg->set("metadata_servers", "");
+    cfg->set("rpc_server_hostname", "127.0.0.1");
+    cfg->set("rpc_server_port", "0");
+    cfg->set("log_level", "warning");
+    cfg->set("merge_requests", false);
+    cfg->set("enable_runtime_queue", false);
+    cfg->set("transports/tcp/enable", false);
+    cfg->set("transports/shm/enable", false);
+    cfg->set("transports/rdma/enable", false);
+    cfg->set("transports/io_uring/enable", false);
+    cfg->set("transports/nvlink/enable", false);
+    cfg->set("transports/mnnvl/enable", false);
+    cfg->set("transports/gds/enable", false);
+    cfg->set("transports/ascend_direct/enable", false);
+    return cfg;
+}
+
+void installFakeRdma(TransferEngineImpl& engine,
+                     const std::shared_ptr<FakeTransport>& fake) {
+    std::string seg_name = engine.getSegmentName();
+    ASSERT_TRUE(fake->install(seg_name, nullptr, nullptr, nullptr).ok());
+    engine.swapTransportForTest(RDMA, fake);
+}
+
+Request makeLocalWrite(uint8_t* ptr, size_t length,
+                       uint64_t deadline_ns = 0) {
+    Request request;
+    request.opcode = Request::WRITE;
+    request.source = ptr;
+    request.target_id = LOCAL_SEGMENT_ID;
+    request.target_offset = reinterpret_cast<uint64_t>(ptr);
+    request.length = length;
+    request.transport_hint = RDMA;
+    request.deadline_ns = deadline_ns;
+    return request;
+}
+
+// Poll a batch/task until it reaches a terminal status or timeout (1s).
+TransferStatusEnum pollUntilTerminal(TransferEngineImpl& engine, BatchID batch,
+                                     int task_id = 0) {
+    TransferStatus ts{};
+    for (int i = 0; i < 200; ++i) {
+        engine.getTransferStatus(batch, task_id, ts);
+        if (ts.s == TransferStatusEnum::COMPLETED ||
+            ts.s == TransferStatusEnum::FAILED) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    return ts.s;
+}
+
+// ---------------------------------------------------------------------------
+// Test fixture: re-initialize the TentMetrics singleton per test with a free
+// HTTP port and no periodic reporting thread. Counter/histogram values are
+// NOT reset (singleton members), so tests use delta assertions.
+// ---------------------------------------------------------------------------
+class MetricsRecordingTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        TentMetrics::instance().shutdown();
+        MetricsConfig config;
+        config.enabled = true;
+        config.http_host = "127.0.0.1";
+        config.http_port = getFreeTcpPort();
+        config.report_interval_seconds = 0;
+        auto status = TentMetrics::instance().initialize(config);
+        ASSERT_TRUE(status.ok()) << status.ToString();
+        TentMetrics::setEnabled(true);
+    }
+
+    void TearDown() override {
+        TentMetrics::instance().shutdown();
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Fix A (Red -> Green): completed transfer records bytes, requests, latency.
+// Drives the real recordTaskCompletionMetrics path via FakeTransport.
+// ---------------------------------------------------------------------------
+TEST_F(MetricsRecordingTest, CompletedTransferRecordsBytesAndLatency) {
+    auto cfg = makeMetricsTestConfig();
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake = std::make_shared<FakeTransport>(RDMA);
+    installFakeRdma(engine, fake);
+
+    constexpr size_t kLen = 4096;
+    std::vector<uint8_t> buf(kLen, 0xBB);
+    ASSERT_TRUE(engine.registerLocalMemory(buf.data(), buf.size()).ok());
+
+    BatchID batch = engine.allocateBatch(4);
+    ASSERT_NE(batch, (BatchID)0);
+
+    auto before = MetricsSnapshot(TentMetrics::instance());
+    ASSERT_TRUE(
+        engine.submitTransfer(batch, {makeLocalWrite(buf.data(), kLen)}).ok());
+    ASSERT_EQ(pollUntilTerminal(engine, batch, 0), TransferStatusEnum::COMPLETED);
+    auto after = MetricsSnapshot(TentMetrics::instance());
+
+    EXPECT_EQ(after.counter("tent_write_bytes_total") -
+                  before.counter("tent_write_bytes_total"),
+              kLen);
+    EXPECT_EQ(after.counter("tent_write_requests_total") -
+                  before.counter("tent_write_requests_total"),
+              1);
+    EXPECT_EQ(after.histogramCount("tent_write_latency_us") -
+                  before.histogramCount("tent_write_latency_us"),
+              1);
+    EXPECT_EQ(after.histogramCount("tent_write_size_bytes") -
+                  before.histogramCount("tent_write_size_bytes"),
+              1);
+
+    EXPECT_TRUE(engine.freeBatch(batch).ok());
+    EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), buf.size()).ok());
+}
+
+// ---------------------------------------------------------------------------
+// Fix A (Red -> Green): failed transfer increments failures and requests but
+// NOT bytes or size histogram. Uses the direct API so the assertion is
+// deterministic and does not depend on engine failover behavior.
+// ---------------------------------------------------------------------------
+TEST_F(MetricsRecordingTest, FailedTransferCountsFailureNotBytes) {
+    auto before = MetricsSnapshot(TentMetrics::instance());
+
+    TentMetrics::instance().recordReadFailed(4096);
+    TentMetrics::instance().recordWriteFailed(8192);
+
+    auto after = MetricsSnapshot(TentMetrics::instance());
+
+    EXPECT_EQ(after.counter("tent_read_failures_total") -
+                  before.counter("tent_read_failures_total"),
+              1);
+    EXPECT_EQ(after.counter("tent_write_failures_total") -
+                  before.counter("tent_write_failures_total"),
+              1);
+    EXPECT_EQ(after.counter("tent_read_requests_total") -
+                  before.counter("tent_read_requests_total"),
+              1);
+    EXPECT_EQ(after.counter("tent_write_requests_total") -
+                  before.counter("tent_write_requests_total"),
+              1);
+    // Bytes must NOT move on failure.
+    EXPECT_EQ(after.counter("tent_read_bytes_total") -
+                  before.counter("tent_read_bytes_total"),
+              0);
+    EXPECT_EQ(after.counter("tent_write_bytes_total") -
+                  before.counter("tent_write_bytes_total"),
+              0);
+    // Size histograms must NOT observe failures.
+    EXPECT_EQ(after.histogramCount("tent_read_size_bytes") -
+                  before.histogramCount("tent_read_size_bytes"),
+              0);
+    EXPECT_EQ(after.histogramCount("tent_write_size_bytes") -
+                  before.histogramCount("tent_write_size_bytes"),
+              0);
+}
+
+// ---------------------------------------------------------------------------
+// Fix B (Red): a transfer whose deadline was already in the past at submit
+// must increment a SEPARATE tent_deadline_infeasible_total counter, and must
+// NOT pollute the tent_deadline_mlu_permille histogram. Today there is no
+// such counter and the sentinel (5.0) lands in the histogram, so this fails.
+// ---------------------------------------------------------------------------
+TEST_F(MetricsRecordingTest, InfeasibleDeadlineRecordsSeparateCounter) {
+    auto cfg = makeMetricsTestConfig();
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake = std::make_shared<FakeTransport>(RDMA);
+    installFakeRdma(engine, fake);
+
+    constexpr size_t kLen = 4096;
+    std::vector<uint8_t> buf(kLen, 0xBB);
+    ASSERT_TRUE(engine.registerLocalMemory(buf.data(), buf.size()).ok());
+
+    BatchID batch = engine.allocateBatch(4);
+    ASSERT_NE(batch, (BatchID)0);
+
+    auto before = MetricsSnapshot(TentMetrics::instance());
+    // deadline_ns = 1 is always in the past relative to steady_clock now.
+    ASSERT_TRUE(engine
+                    .submitTransfer(batch,
+                                    {makeLocalWrite(buf.data(), kLen, /*deadline_ns=*/1)})
+                    .ok());
+    ASSERT_EQ(pollUntilTerminal(engine, batch, 0), TransferStatusEnum::COMPLETED);
+    auto after = MetricsSnapshot(TentMetrics::instance());
+
+    // The infeasible counter must exist and increment by exactly 1.
+    EXPECT_EQ(after.counter("tent_deadline_infeasible_total") -
+                  before.counter("tent_deadline_infeasible_total"),
+              1)
+        << "expected a dedicated tent_deadline_infeasible_total counter";
+    // The MLU histogram must NOT receive a sentinel sample for the infeasible
+    // case (the old code observed MLU=5.0 here).
+    EXPECT_EQ(after.histogramCount("tent_deadline_mlu_permille") -
+                  before.histogramCount("tent_deadline_mlu_permille"),
+              0)
+        << "infeasible deadline must not pollute the MLU histogram";
+
+    EXPECT_TRUE(engine.freeBatch(batch).ok());
+    EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), buf.size()).ok());
+}
+
+// ---------------------------------------------------------------------------
+// Fix B (companion): a transfer whose deadline is in the future records a
+// genuine MLU sample into the histogram (feasible or missed, but real).
+// ---------------------------------------------------------------------------
+TEST_F(MetricsRecordingTest, FeasibleDeadlineRecordsMLU) {
+    auto cfg = makeMetricsTestConfig();
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake = std::make_shared<FakeTransport>(RDMA);
+    installFakeRdma(engine, fake);
+
+    constexpr size_t kLen = 4096;
+    std::vector<uint8_t> buf(kLen, 0xBB);
+    ASSERT_TRUE(engine.registerLocalMemory(buf.data(), buf.size()).ok());
+
+    BatchID batch = engine.allocateBatch(4);
+    ASSERT_NE(batch, (BatchID)0);
+
+    auto before = MetricsSnapshot(TentMetrics::instance());
+    // Deadline far in the future -> window is huge -> MLU is tiny but > 0.
+    uint64_t future_ns = static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(
+            std::chrono::steady_clock::now().time_since_epoch() + std::chrono::hours(1))
+            .count());
+    ASSERT_TRUE(engine
+                    .submitTransfer(batch,
+                                    {makeLocalWrite(buf.data(), kLen, future_ns)})
+                    .ok());
+    ASSERT_EQ(pollUntilTerminal(engine, batch, 0), TransferStatusEnum::COMPLETED);
+    auto after = MetricsSnapshot(TentMetrics::instance());
+
+    EXPECT_EQ(after.histogramCount("tent_deadline_mlu_permille") -
+                  before.histogramCount("tent_deadline_mlu_permille"),
+              1);
+    // And the infeasible counter must NOT move for a feasible deadline.
+    EXPECT_EQ(after.counter("tent_deadline_infeasible_total") -
+                  before.counter("tent_deadline_infeasible_total"),
+              0);
+
+    EXPECT_TRUE(engine.freeBatch(batch).ok());
+    EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), buf.size()).ok());
+}
+
+// ---------------------------------------------------------------------------
+// Fix D (regression guard): every histogram's JSON bucket keys must match its
+// compile-time boundary vector. Passes before AND after the parallel-vector
+// -> struct refactor; locks the invariant the refactor must preserve.
+//
+// Runs BEFORE BucketsAreCompileTimeDefaultsIgnoringConfig because that test
+// destructively reassigns the singleton's histogram members (pre-Fix-C), which
+// would pollute the bucket structure observed here. After Fix C removes the
+// reassignment, the ordering constraint is moot.
+// ---------------------------------------------------------------------------
+TEST_F(MetricsRecordingTest, HistogramJsonBucketsMatchBoundaries) {
+    struct HistSpec {
+        const char* name;
+        std::vector<int64_t> expected_keys;
+    };
+    const std::vector<HistSpec> specs = {
+        {"tent_read_latency_us",
+         {100, 500, 1000, 5000, 10000, 50000, 100000, 500000, 1000000}},
+        {"tent_write_latency_us",
+         {100, 500, 1000, 5000, 10000, 50000, 100000, 500000, 1000000}},
+        {"tent_read_size_bytes",
+         {1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216,
+          67108864, 268435456, 1073741824}},
+        {"tent_write_size_bytes",
+         {1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216,
+          67108864, 268435456, 1073741824}},
+        {"tent_deadline_mlu_permille",
+         {100, 250, 500, 750, 900, 1000, 1250, 1500, 2000, 5000}},
+        {"tent_stage_queue_wait_us",
+         {10, 50, 100, 500, 1000, 5000, 10000, 50000, 100000, 500000}},
+        {"tent_stage_dispatch_us",
+         {10, 50, 100, 500, 1000, 5000, 10000, 50000, 100000, 500000}},
+        {"tent_stage_transport_us",
+         {10, 50, 100, 500, 1000, 5000, 10000, 50000, 100000, 500000}},
+    };
+
+    auto snap = MetricsSnapshot(TentMetrics::instance());
+    for (const auto& s : specs) {
+        auto keys = snap.bucketKeys(s.name);
+        EXPECT_EQ(keys, s.expected_keys)
+            << "histogram " << s.name << " bucket keys mismatch";
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fix C (Red): when latency_buckets is set in config, the histograms must
+// STILL use the compile-time kLatencyBuckets (the config knob is being
+// removed). Today the code reassigns the histograms to the configured
+// buckets, so the bucket keys would be {"1000","2000"} -> assertion fails.
+// After Fix C removes the knob, the latency_buckets field is gone; this test
+// is updated then to drop the config assignment.
+//
+// NOTE: intentionally last — the reassignment below destructively overwrites
+// the singleton's histogram members and cannot be undone without Fix C.
+// ---------------------------------------------------------------------------
+TEST_F(MetricsRecordingTest, BucketsAreCompileTimeDefaultsIgnoringConfig) {
+    // Re-initialize with a config that tries to override buckets.
+    TentMetrics::instance().shutdown();
+    MetricsConfig config;
+    config.enabled = true;
+    config.http_host = "127.0.0.1";
+    config.http_port = getFreeTcpPort();
+    config.report_interval_seconds = 0;
+    config.latency_buckets = {0.001, 0.002};  // would become {1000, 2000} us
+    config.size_buckets = {1, 2};
+    ASSERT_TRUE(TentMetrics::instance().initialize(config).ok());
+    TentMetrics::setEnabled(true);
+
+    // Record one sample so the histogram is non-empty.
+    TentMetrics::instance().recordReadCompleted(4096, 0.001);
+
+    auto snap = MetricsSnapshot(TentMetrics::instance());
+    auto keys = snap.bucketKeys("tent_read_latency_us");
+    ASSERT_FALSE(keys.empty());
+
+    // Compile-time kLatencyBuckets: 100, 500, 1000, 5000, 10000, 50000,
+    // 100000, 500000, 1000000.
+    std::vector<int64_t> expected = {100,  500,   1000,   5000,   10000,
+                                     50000, 100000, 500000, 1000000};
+    EXPECT_EQ(keys, expected)
+        << "latency buckets must be the compile-time defaults, not config-driven";
+}
+
+#else  // !TENT_METRICS_ENABLED
+
+// When metrics are disabled at compile time, the recording path is a no-op
+// and there is nothing to assert on. This test confirms the stub initializes.
+TEST(MetricsRecording, DisabledAtCompileTime) {
+    MetricsConfig config;
+    EXPECT_TRUE(TentMetrics::instance().initialize(config).ok());
+    TentMetrics::instance().shutdown();
+}
+
+#endif  // TENT_METRICS_ENABLED
+
+}  // namespace
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/tests/metrics_recording_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/metrics_recording_test.cpp
@@ -361,8 +361,8 @@ TEST_F(MetricsRecordingTest, CompletedTransferRecordsBytesAndLatency) {
 TEST_F(MetricsRecordingTest, FailedTransferCountsFailureNotBytes) {
     auto before = MetricsSnapshot(TentMetrics::instance());
 
-    TentMetrics::instance().recordReadFailed(4096);
-    TentMetrics::instance().recordWriteFailed(8192);
+    TentMetrics::instance().recordReadFailed();
+    TentMetrics::instance().recordWriteFailed();
 
     auto after = MetricsSnapshot(TentMetrics::instance());
 

--- a/mooncake-transfer-engine/tent/tests/tent_metrics_example.cpp
+++ b/mooncake-transfer-engine/tent/tests/tent_metrics_example.cpp
@@ -121,10 +121,10 @@ int main(int argc, char* argv[]) {
 
         // Simulate some failures
         if (i % 3 == 0) {
-            TENT_RECORD_READ_FAILED(1024);
+            TENT_RECORD_READ_FAILED();
         }
         if (i % 4 == 0) {
-            TENT_RECORD_WRITE_FAILED(512);
+            TENT_RECORD_WRITE_FAILED();
         }
 
         std::cout << "  Iteration " << (i + 1) << ": Read "


### PR DESCRIPTION
## Description

Fixes six design / correctness issues found while reviewing the TENT metrics system (`tent/metrics/`), plus a docs sync. Each change is test-driven.

**Correctness:**
- **Zero-overhead claim was false on the hot path.** `recordTaskCompletionMetrics` called `TentMetrics::instance().record*` directly (not via macros), so when `TENT_METRICS_ENABLED=OFF` every task completion still hit no-op stubs. The whole recording block is now `#if`-gated so the body is empty when disabled, matching the doc claim.
- **MLU sentinel poisoned real data.** An infeasible-at-submit deadline was recorded as `MLU=5.0` into the `tent_deadline_mlu_permille` histogram, indistinguishable from a genuine 5x-over-window sample. Replaced with a dedicated `tent_deadline_infeasible_total` counter.

**Simplicity:**
- **Unused `bytes` parameter.** `recordReadFailed(size_t bytes)` / `recordWriteFailed(size_t bytes)` ignored the argument (failed transfers transfer no bytes). Dropped the parameter and updated all call sites.
- **Parallel-vector ordering contract.** `histograms_` and `histogram_boundaries_` were two vectors whose order had to match by convention; a future contributor updating one without the other would silently produce mislabeled JSON. Collapsed into a single `vector<HistogramEntry>` pairing each histogram with its boundaries.
- **Runtime-configurable buckets removed.** `initialize()` reassigned `histogram_t` members mid-flight when the config supplied `latency_buckets`/`size_buckets` — a code smell that also produced mismatched JSON labels. Buckets are now fixed at compile time (version-controlled), making observability reproducible. (Net **-201 lines**.)

**Docs / build:**
- Synced `metrics.md` (added 6 missing metrics, removed the bucket config, corrected the zero-overhead claim, clarified `*_requests_total` counts success+failure).
- Moved `option(TENT_METRICS_ENABLED)` from the leaf metrics CMakeLists to `tent/CMakeLists.txt` for discoverability.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Three test layers, all green.

**Test commands:**
```bash
# Configure (metrics enabled + tests + tent)
cmake -B build -S mooncake-transfer-engine \
  -DUSE_TENT=ON -DTENT_METRICS_ENABLED=ON -DBUILD_UNIT_TESTS=ON \
  -Dpybind11_INCLUDE_DIR=<extern/pybind11/include>
cmake --build build -j

# Unit + HTTP integration tests
./build/tent/tests/tent_metrics_recording_test      # 9 tests
./build/tent/tests/metrics_config_loader_test        # 26 tests
./build/tent/tests/tent_metrics_http_server_test     # 1 test
./build/tent/tests/causal_chain_test                 # 4 tests (no regression)

# Disabled-build compile check (verifies the #if gates)
cmake -B build_disabled -S mooncake-transfer-engine \
  -DUSE_TENT=ON -DTENT_METRICS_ENABLED=OFF -DBUILD_UNIT_TESTS=ON \
  -Dpybind11_INCLUDE_DIR=<extern/pybind11/include>
cmake --build build_disabled -j --target tent_metrics_recording_test
./build_disabled/tent/tests/tent_metrics_recording_test
```

**Test results:**
- [x] Unit tests pass — recording (9) + config loader (26) + HTTP server (1) + causal chain (4) = 40 tests.
- [x] Integration tests pass — HTTP endpoints (`/metrics`, `/metrics/json`, `/health`) scraped via `coro_http_client`; Prometheus/JSON output asserts on counters and histogram buckets.
- [x] Disabled-build compiles cleanly and the stub test passes (validates the zero-overhead `#if` gating).

The new test file `metrics_recording_test.cpp` uses delta-based assertions (snapshot before/after) so it is robust to the `TentMetrics` singleton's non-resettable counter state, and drives a real `TransferEngineImpl` with a `FakeTransport` to exercise the actual `recordTaskCompletionMetrics` path.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit` on the files touched by this change and all hooks pass (ran on touched files per AGENTS.md guidance; `--all-files` not run to avoid unrelated edits)
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue — *net non-test code change is negative (simplification); the 665-line test file is the bulk of the insertions. Filing left to submitter's judgment.*

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

CodeBuddy (GLM-5.2) was used to implement the fixes, write the tests, and draft this PR. The human submitter has reviewed every changed line and can defend the changes end-to-end.