### PR TITLE
[Bugfix][Store] Reject invalid metadata client IDs

### DIFF
--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -7852,7 +7852,12 @@ MasterService::MetadataSerializer::DeserializeMetadata(
     // Deserialize client_id string
     std::string client_id_str = array[index++].as<std::string>();
     UUID client_id;
-    StringToUuid(client_id_str, client_id);
+    if (!StringToUuid(client_id_str, client_id)) {
+        return tl::unexpected(SerializationError(
+            ErrorCode::DESERIALIZE_FAIL,
+            fmt::format("deserialize ObjectMetadata invalid client_id UUID: {}",
+                        client_id_str)));
+    }
 
     // Deserialize put_start_time
     uint64_t put_start_time_timestamp = array[index++].as<uint64_t>();

--- a/mooncake-store/tests/ha/snapshot/snapshot_child_process_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/snapshot_child_process_test.cpp
@@ -670,10 +670,9 @@ TEST_F(SnapshotChildProcessTest, DeserializeMetadataSkipsInvalidClientId) {
     CreateDefaultService();
     const std::string key = "invalid_client_id_snapshot_key";
 
-    auto deserialize_result = DeserializeMetadataForTest(
-        BuildMetadataPayloadWithClientIdString("not-a-uuid",
-                                               std::string_view(key.data(),
-                                                                key.size())));
+    auto deserialize_result =
+        DeserializeMetadataForTest(BuildMetadataPayloadWithClientIdString(
+            "not-a-uuid", std::string_view(key.data(), key.size())));
     ASSERT_TRUE(deserialize_result.has_value())
         << deserialize_result.error().message;
 

--- a/mooncake-store/tests/ha/snapshot/snapshot_child_process_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/snapshot_child_process_test.cpp
@@ -666,6 +666,19 @@ TEST_F(SnapshotChildProcessTest,
     EXPECT_FALSE(ObjectIsGroupedInMetadata(key, shard_idx));
 }
 
+TEST_F(SnapshotChildProcessTest, DeserializeMetadataSkipsInvalidClientId) {
+    CreateDefaultService();
+    const std::string key = "invalid_client_id_snapshot_key";
+
+    auto deserialize_result = DeserializeMetadataForTest(
+        BuildMetadataPayloadWithClientIdString(
+            "not-a-uuid", std::string_view(key.data(), key.size())));
+    ASSERT_TRUE(deserialize_result.has_value())
+        << deserialize_result.error().message;
+
+    EXPECT_FALSE(KeyExistsInMetadata(service_.get(), key));
+}
+
 TEST_F(SnapshotChildProcessTest, LegacyEtcdConnstringFallbackIsPreserved) {
     MasterConfig legacy_config;
     legacy_config.enable_ha = true;

--- a/mooncake-store/tests/ha/snapshot/snapshot_child_process_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/snapshot_child_process_test.cpp
@@ -669,10 +669,48 @@ TEST_F(SnapshotChildProcessTest,
 TEST_F(SnapshotChildProcessTest, DeserializeMetadataSkipsInvalidClientId) {
     CreateDefaultService();
     const std::string key = "invalid_client_id_snapshot_key";
+    const uint32_t shard_idx = GetShardIndexForTest(key);
+
+    msgpack::sbuffer shard_buffer;
+    MsgpackPacker shard_packer(&shard_buffer);
+    shard_packer.pack_map(1);
+    shard_packer.pack(std::string("metadata"));
+    shard_packer.pack_array(1);
+    shard_packer.pack_array(2);
+    shard_packer.pack(key);
+
+    shard_packer.pack_array(8);
+    shard_packer.pack(std::string("not-a-uuid"));
+    shard_packer.pack(kDefaultTestPutStartTimeMs);
+    shard_packer.pack(kDefaultTestObjectSize);
+    shard_packer.pack(kDefaultTestLeaseTimeoutMs);
+    shard_packer.pack(false);
+    shard_packer.pack(uint64_t{0});
+    shard_packer.pack(uint32_t{1});
+    PackDiskReplica(shard_packer, kDefaultTestDiskFilePath,
+                    kDefaultTestObjectSize);
+
+    auto compressed_shard =
+        zstd_compress(reinterpret_cast<const uint8_t*>(shard_buffer.data()),
+                      shard_buffer.size(), 3);
+
+    msgpack::sbuffer root_buffer;
+    MsgpackPacker root_packer(&root_buffer);
+    root_packer.pack_map(3);
+    root_packer.pack(std::string("shards"));
+    root_packer.pack_map(1);
+    root_packer.pack(shard_idx);
+    root_packer.pack_bin(compressed_shard.size());
+    root_packer.pack_bin_body(
+        reinterpret_cast<const char*>(compressed_shard.data()),
+        compressed_shard.size());
+    root_packer.pack(std::string("discarded_replicas"));
+    root_packer.pack_array(0);
+    root_packer.pack(std::string("replica_next_id"));
+    root_packer.pack(uint64_t{10});
 
     auto deserialize_result =
-        DeserializeMetadataForTest(BuildMetadataPayloadWithClientIdString(
-            "not-a-uuid", std::string_view(key.data(), key.size())));
+        DeserializeMetadataForTest(ToByteVector(root_buffer));
     ASSERT_TRUE(deserialize_result.has_value())
         << deserialize_result.error().message;
 

--- a/mooncake-store/tests/ha/snapshot/snapshot_child_process_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/snapshot_child_process_test.cpp
@@ -671,8 +671,9 @@ TEST_F(SnapshotChildProcessTest, DeserializeMetadataSkipsInvalidClientId) {
     const std::string key = "invalid_client_id_snapshot_key";
 
     auto deserialize_result = DeserializeMetadataForTest(
-        BuildMetadataPayloadWithClientIdString(
-            "not-a-uuid", std::string_view(key.data(), key.size())));
+        BuildMetadataPayloadWithClientIdString("not-a-uuid",
+                                               std::string_view(key.data(),
+                                                                key.size())));
     ASSERT_TRUE(deserialize_result.has_value())
         << deserialize_result.error().message;
 

--- a/mooncake-store/tests/ha/snapshot/snapshot_test_utils.h
+++ b/mooncake-store/tests/ha/snapshot/snapshot_test_utils.h
@@ -167,8 +167,9 @@ inline std::vector<uint8_t> WrapShardIntoMetadataRoot(
     return ToByteVector(root_buffer);
 }
 
-inline std::vector<uint8_t> BuildMetadataPayload(
-    const UUID& client_id, std::string_view object_key = kDefaultTestObjectKey,
+inline std::vector<uint8_t> BuildMetadataPayloadWithClientIdString(
+    std::string_view client_id,
+    std::string_view object_key = kDefaultTestObjectKey,
     std::string_view disk_file_path = kDefaultTestDiskFilePath,
     uint64_t object_size = kDefaultTestObjectSize,
     uint64_t put_start_time_ms = kDefaultTestPutStartTimeMs,
@@ -199,7 +200,7 @@ inline std::vector<uint8_t> BuildMetadataPayload(
     shard_packer.pack(std::string(object_key));
 
     shard_packer.pack_array(array_size);
-    shard_packer.pack(UuidToString(client_id));
+    shard_packer.pack(std::string(client_id));
     shard_packer.pack(put_start_time_ms);
     shard_packer.pack(object_size);
     shard_packer.pack(lease_timeout_ms);
@@ -218,6 +219,18 @@ inline std::vector<uint8_t> BuildMetadataPayload(
     }
 
     return WrapShardIntoMetadataRoot(shard_buffer);
+}
+
+inline std::vector<uint8_t> BuildMetadataPayload(
+    const UUID& client_id, std::string_view object_key = kDefaultTestObjectKey,
+    std::string_view disk_file_path = kDefaultTestDiskFilePath,
+    uint64_t object_size = kDefaultTestObjectSize,
+    uint64_t put_start_time_ms = kDefaultTestPutStartTimeMs,
+    uint64_t lease_timeout_ms = kDefaultTestLeaseTimeoutMs,
+    SnapshotMetadataFormat format = SnapshotMetadataFormat::kLegacy) {
+    return BuildMetadataPayloadWithClientIdString(
+        UuidToString(client_id), object_key, disk_file_path, object_size,
+        put_start_time_ms, lease_timeout_ms, format);
 }
 
 // Builds a metadata payload whose declared replica_count field is set to


### PR DESCRIPTION
## Description

Reject malformed `client_id` values when `MasterService::MetadataSerializer` deserializes object metadata.

### What Problem This Solves

`DeserializeMetadata()` read the serialized `client_id` string and called `StringToUuid(client_id_str, client_id)`, but ignored the boolean result. If snapshot metadata contained a malformed client ID such as `not-a-uuid`, deserialization continued and could construct `ObjectMetadata` with an invalid UUID value instead of treating that entry as corrupt metadata.

A nearby sibling path already handles this strictly: the catalog-backed snapshot provider checks `StringToUuid()` and returns `DESERIALIZE_FAIL` for invalid client UUID strings. Replica msgpack deserialization also rejects invalid client IDs. This PR brings the master metadata deserializer in line with those paths.

### Changes

- Check the return value from `StringToUuid()` in `DeserializeMetadata()`.
- Return `DESERIALIZE_FAIL` with a targeted error message when the serialized metadata client ID is malformed.
- Add a focused snapshot metadata regression test that builds a payload with `client_id = not-a-uuid` and verifies the object key is not restored into metadata.

The existing shard-level behavior is intentionally preserved: `DeserializeShard()` logs a per-object metadata deserialization failure and continues with the remaining entries.

### Evidence

Before this change, the invalid client ID parse result was ignored:

```cpp
UUID client_id;
StringToUuid(client_id_str, client_id);
```

The new test exercises the restore deserialization entry point with a malformed client ID payload:

```cpp
BuildMetadataPayloadWithClientIdString(
    not-a-uuid, std::string_view(key.data(), key.size()))
```

and asserts that the bad entry is skipped instead of being restored:

```cpp
EXPECT_FALSE(KeyExistsInMetadata(service_.get(), key));
```

### Possible call chain / impact

```text
snapshot metadata bytes
  -> MasterService::MetadataSerializer::Deserialize()
  -> DeserializeShard()
  -> DeserializeMetadata()
  -> StringToUuid(client_id_str, client_id)
```

This affects the master metadata restore/deserialization path for malformed persisted metadata. It does not change serialization output, valid UUID handling, replica parsing, or the shard-level policy that skips individual corrupt object entries.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
git diff --check
cmake -S . -B build-store-test -DBUILD_UNIT_TESTS=ON -DWITH_STORE=ON -DWITH_TE=ON -DWITH_STORE_RUST=OFF -DWITH_EP=OFF -DUSE_CUDA=OFF -DUSE_ETCD=OFF -DSTORE_USE_ETCD=OFF -DSTORE_USE_REDIS=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

`git diff --check` passed. The focused CMake configure was attempted in local WSL, but this machine is missing the `yaml-cpp` development package, so the local build/test target could not be configured here.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

`./scripts/code_format.sh` / pre-commit were not run locally because the Windows checkout exposes the shell script with CRLF line endings in WSL and `pre-commit` is not installed in this environment.

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Used ChatGPT Codex to inspect the deserialization path, implement the small guard and regression test, and draft this PR description. The submitter is responsible for reviewing and defending the change.