### PR TITLE
[CI/Build] Disable unit tests in release wheel builds

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -39,7 +39,7 @@ jobs:
       build-with-ep: '0'
       variant-flag: NON_CUDA_BUILD
       cmake-args: >-
-        -DUSE_HTTP=ON -DUSE_ETCD=ON -DUSE_CUDA=OFF -DWITH_EP=OFF
+        -DBUILD_UNIT_TESTS=OFF -DUSE_HTTP=ON -DUSE_ETCD=ON -DUSE_CUDA=OFF -DWITH_EP=OFF
         -DSTORE_USE_ETCD=ON -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Release
       artifact-prefix: mooncake-wheel-non-cuda-pre-release
 
@@ -68,7 +68,7 @@ jobs:
       cmake-generator: Ninja
       torch-cuda-arch-list: '9.0'
       cmake-args: >-
-        -DUSE_HTTP=ON -DUSE_CUDA=ON -DUSE_MNNVL=ON -DWITH_EP=OFF
+        -DBUILD_UNIT_TESTS=OFF -DUSE_HTTP=ON -DUSE_CUDA=ON -DUSE_MNNVL=ON -DWITH_EP=OFF
         -DWITH_STORE_RUST=OFF -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Release
       artifact-prefix: mooncake-wheel-arm64-pre-release
 
@@ -82,7 +82,7 @@ jobs:
       variant-flag: CU13_BUILD
       torch-cuda-arch-list: '9.0'
       cmake-args: >-
-        -DUSE_HTTP=ON -DUSE_CUDA=ON -DUSE_MNNVL=ON -DWITH_EP=OFF
+        -DBUILD_UNIT_TESTS=OFF -DUSE_HTTP=ON -DUSE_CUDA=ON -DUSE_MNNVL=ON -DWITH_EP=OFF
         -DWITH_STORE_RUST=OFF -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Release
       artifact-prefix: mooncake-wheel-cuda13-arm64-pre-release
 

--- a/.github/workflows/release-cuda13.yaml
+++ b/.github/workflows/release-cuda13.yaml
@@ -33,7 +33,7 @@ jobs:
       variant-flag: CU13_BUILD
       torch-cuda-arch-list: '9.0'
       cmake-args: >-
-        -DUSE_HTTP=ON -DUSE_CUDA=ON -DUSE_MNNVL=ON -DWITH_EP=OFF
+        -DBUILD_UNIT_TESTS=OFF -DUSE_HTTP=ON -DUSE_CUDA=ON -DUSE_MNNVL=ON -DWITH_EP=OFF
         -DWITH_STORE_RUST=OFF -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Release
       artifact-prefix: mooncake-wheel-cuda13-arm64
 

--- a/.github/workflows/release-non-cuda.yaml
+++ b/.github/workflows/release-non-cuda.yaml
@@ -17,7 +17,7 @@ jobs:
       build-with-ep: '0'
       variant-flag: NON_CUDA_BUILD
       cmake-args: >-
-        -DUSE_HTTP=ON -DUSE_ETCD=ON -DUSE_CUDA=OFF -DWITH_EP=OFF
+        -DBUILD_UNIT_TESTS=OFF -DUSE_HTTP=ON -DUSE_ETCD=ON -DUSE_CUDA=OFF -DWITH_EP=OFF
         -DSTORE_USE_ETCD=ON -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Release
       artifact-prefix: mooncake-wheel-non-cuda
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,7 @@ jobs:
       cmake-generator: Ninja
       torch-cuda-arch-list: '9.0'
       cmake-args: >-
-        -DUSE_HTTP=ON -DUSE_CUDA=ON -DUSE_MNNVL=ON -DWITH_EP=OFF
+        -DBUILD_UNIT_TESTS=OFF -DUSE_HTTP=ON -DUSE_CUDA=ON -DUSE_MNNVL=ON -DWITH_EP=OFF
         -DWITH_STORE_RUST=OFF -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Release
       artifact-prefix: mooncake-wheel-arm64
 


### PR DESCRIPTION
## Description

Disable C++ unit-test targets in all reusable release wheel build variants by passing `-DBUILD_UNIT_TESTS=OFF` consistently.

The pre-release non-CUDA and ARM64 jobs were unintentionally using the project default (`BUILD_UNIT_TESTS=ON`). The manylinux environments then compiled test-only targets that are neither run nor packaged into wheels, exposing incompatible GoogleTest headers/libraries and breaking the pre-release run: https://github.com/kvcache-ai/Mooncake/actions/runs/29713667052.

Unit tests can be disabled in release wheel builds because this stage only produces and validates distributable wheel artifacts:

- release workflows do not run `ctest`; compiling the test targets provides no test execution result;
- test binaries have no CMake install rules and `scripts/build_wheel.sh` does not copy them, so they are not included in or consumed from the wheel;
- the regular Linux CI builds the same C++ test targets and runs them with `ctest --output-on-failure`, keeping unit-test coverage in the dedicated test stage;
- rebuilding the same C++ tests in every Python-version release matrix leg adds redundant build time and introduces release-container-only GoogleTest dependencies without changing wheel contents.

This change aligns pre-release and production CUDA 12, CUDA 13, and non-CUDA wheel workflows. Regular CI continues to build and run unit tests.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
pre-commit run --files \
  .github/workflows/pre-release.yaml \
  .github/workflows/release.yaml \
  .github/workflows/release-non-cuda.yaml \
  .github/workflows/release-cuda13.yaml

git diff --check
```

A targeted check also verified that every `_build-wheel.yaml` caller in the four affected workflows includes `BUILD_UNIT_TESTS=OFF`.

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done: YAML/pre-commit and release-call consistency checks passed

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on all files touched by this change and all hooks pass
- [x] Documentation is not applicable
- [x] Additional tests are not applicable for this workflow-only change
- [x] RFC is not applicable; this change is under 500 LOC

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used

Codex helped diagnose the failing GitHub Actions jobs, identify inconsistent release CMake flags, prepare the workflow changes, and run validation. The human submitter must review and understand every changed line before marking this PR ready for review.