### PR TITLE
[Store] support tensor APIs with dummy client

### DIFF
--- a/docs/source/api-reference/python/mooncake-store.md
+++ b/docs/source/api-reference/python/mooncake-store.md
@@ -1142,9 +1142,9 @@ parallelism write wrappers.
 
 The real client owns the SHM buffer allocator. This keeps tensor writes and
 regular object writes from allocating overlapping offsets when they run
-concurrently through the same dummy client.
-Writes that stage through the dummy client's local SHM buffer are serialized
-per dummy client to keep the staged data alive until each write finishes.
+concurrently through the same dummy client. Writes staged through the dummy
+client's local SHM buffer keep their allocation alive until completion through
+the real-side active buffer handle and dummy-side RAII release path.
 
 Full materialized reconstruction reads for writer-sharded or reconstructed
 parallel tensors are still conservative for dummy clients. Use the corresponding

--- a/docs/source/api-reference/python/mooncake-store.md
+++ b/docs/source/api-reference/python/mooncake-store.md
@@ -1134,6 +1134,22 @@ def setup_dummy(self, mem_pool_size: int, local_buffer_size: int, server_address
 store.setup_dummy(1024*1024*256, 1024*1024*64, "localhost:8080")
 ```
 
+Dummy clients do not own Store segments. They use a local shared-memory buffer
+that is mapped by a real client process at `server_address`. Tensor APIs that
+stage through this SHM buffer are supported, including tensor put/get,
+`*_tensor_from`, `*_tensor_into`, tensor upsert/pub, TP wrappers, and unified
+parallelism write wrappers.
+
+The real client owns the SHM buffer allocator. This keeps tensor writes and
+regular object writes from allocating overlapping offsets when they run
+concurrently through the same dummy client.
+Writes that stage through the dummy client's local SHM buffer are serialized
+per dummy client to keep the staged data alive until each write finishes.
+
+Full materialized reconstruction reads for writer-sharded or reconstructed
+parallel tensors are still conservative for dummy clients. Use the corresponding
+`*_into` APIs, or read stored shards directly, when using dummy clients.
+
 ---
 
 #### put()
@@ -1611,7 +1627,8 @@ def batch_get_buffer(self, keys: List[str]) -> List[BufferHandle]
 **Returns:**
 - `List[BufferHandle]`: List of buffer objects, with None for keys not found
 
-**Note:** This function is not supported for dummy client.
+**Note:** This function is supported for dummy clients through the real
+client-owned shared-memory staging buffer.
 
 **Example:**
 ```python
@@ -2045,7 +2062,8 @@ def put_from_with_metadata(self, key: str, buffer_ptr: int, metadata_buffer_ptr:
 **Returns:**
 - `int`: Status code (0 = success, non-zero = error code)
 
-**Note:** This function is not supported for dummy client.
+**Note:** This function is supported for dummy clients through the real
+client-owned shared-memory staging buffer.
 
 **Example:**
 ```python
@@ -2445,7 +2463,8 @@ def upsert_tensor_from(self, key: str, buffer_ptr: int, size: int) -> int
 **Returns:**
 - `int`: Status code (0 = success, non-zero = error code)
 
-**Note:** This function is not supported for dummy client.
+**Note:** This function is supported for dummy clients through the real
+client-owned shared-memory staging buffer.
 
 #### batch_upsert_tensor_from()
 
@@ -2479,7 +2498,9 @@ def batch_upsert_tensor(self, keys: List[str], tensors_list: List[torch.Tensor])
 **Returns:**
 - `List[int]`: List of status codes for each tensor operation.
 
-**Note:** This function requires `torch` to be installed and available in the environment. Not supported for dummy client.
+**Note:** This function requires `torch` to be installed and available in the
+environment. It is supported for dummy clients through the real client-owned
+shared-memory staging buffer.
 
 #### upsert_pub_tensor()
 
@@ -2497,7 +2518,9 @@ def upsert_pub_tensor(self, key: str, tensor: torch.Tensor, config: ReplicateCon
 **Returns:**
 - `int`: Status code (0 = success, non-zero = error code)
 
-**Note:** This function requires `torch` to be installed and available in the environment. Not supported for dummy client.
+**Note:** This function requires `torch` to be installed and available in the
+environment. It is supported for dummy clients through the real client-owned
+shared-memory staging buffer.
 
 **Example:**
 ```python
@@ -2531,7 +2554,9 @@ def batch_upsert_pub_tensor(self, keys: List[str], tensors_list: List[torch.Tens
 **Returns:**
 - `List[int]`: List of status codes for each tensor operation.
 
-**Note:** This function requires `torch` to be installed and available in the environment. Not supported for dummy client.
+**Note:** This function requires `torch` to be installed and available in the
+environment. It is supported for dummy clients through the real client-owned
+shared-memory staging buffer.
 
 
 ---

--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -610,16 +610,16 @@ class MooncakeStorePyWrapper {
 
     pybind11::object get_tensor_into(const std::string &key,
                                      uintptr_t buffer_ptr, size_t size) {
-        char *buffer = reinterpret_cast<char *>(buffer_ptr);
         if (!is_client_initialized()) {
             LOG(ERROR) << "Client is not initialized";
             return pybind11::none();
         }
-
-        if (use_dummy_client_) {
-            LOG(ERROR) << "get_tensor is not supported for dummy client now";
+        if (buffer_ptr == 0) {
+            LOG(ERROR) << "Buffer pointer cannot be null";
             return pybind11::none();
         }
+
+        char *buffer = reinterpret_cast<char *>(buffer_ptr);
 
         int64_t total_length;
         {
@@ -634,29 +634,34 @@ class MooncakeStorePyWrapper {
         const std::vector<std::string> &keys,
         const std::vector<uintptr_t> &buffer_ptrs,
         const std::vector<size_t> &sizes) {
+        auto invalid_params = [&keys]() {
+            py::list empty_list;
+            for (size_t i = 0; i < keys.size(); ++i) {
+                empty_list.append(to_py_ret(ErrorCode::INVALID_PARAMS));
+            }
+            return empty_list;
+        };
+
+        if (!is_client_initialized()) {
+            LOG(ERROR) << "Client is not initialized";
+            return invalid_params();
+        }
+        if (keys.size() != buffer_ptrs.size() || keys.size() != sizes.size()) {
+            LOG(ERROR) << "Size mismatch: keys, buffer_ptrs, and sizes must "
+                          "have the same length";
+            return invalid_params();
+        }
+        for (uintptr_t ptr : buffer_ptrs) {
+            if (ptr == 0) {
+                LOG(ERROR) << "Buffer pointer cannot be null";
+                return invalid_params();
+            }
+        }
+
         std::vector<void *> buffers;
         buffers.reserve(buffer_ptrs.size());
         for (uintptr_t ptr : buffer_ptrs) {
             buffers.push_back(reinterpret_cast<void *>(ptr));
-        }
-
-        if (!is_client_initialized()) {
-            LOG(ERROR) << "Client is not initialized";
-            py::list empty_list;
-            for (size_t i = 0; i < keys.size(); ++i) {
-                empty_list.append(to_py_ret(ErrorCode::INVALID_PARAMS));
-            }
-            return empty_list;
-        }
-
-        if (use_dummy_client_) {
-            LOG(ERROR) << "batch_get_tensor is not supported for dummy client "
-                          "now";
-            py::list empty_list;
-            for (size_t i = 0; i < keys.size(); ++i) {
-                empty_list.append(to_py_ret(ErrorCode::INVALID_PARAMS));
-            }
-            return empty_list;
         }
 
         // Phase 1: Batch Get Buffers (GIL Released)
@@ -667,14 +672,10 @@ class MooncakeStorePyWrapper {
             total_lengths = store_->batch_get_into(keys, buffers, sizes);
         }
 
-        if (keys.size() != buffer_ptrs.size() || keys.size() != sizes.size()) {
-            LOG(ERROR) << "Size mismatch: keys, buffer_ptrs, and sizes must "
-                          "have the same length";
-            py::list empty_list;
-            for (size_t i = 0; i < keys.size(); ++i) {
-                empty_list.append(to_py_ret(ErrorCode::INVALID_PARAMS));
-            }
-            return empty_list;
+        if (total_lengths.size() != keys.size()) {
+            LOG(ERROR) << "Unexpected batch_get_into result count "
+                       << total_lengths.size() << ", expected " << keys.size();
+            return invalid_params();
         }
 
         py::list results_list;
@@ -696,12 +697,6 @@ class MooncakeStorePyWrapper {
             return pybind11::none();
         }
 
-        if (use_dummy_client_) {
-            LOG(ERROR)
-                << "get_tensor_into is not supported for dummy client now";
-            return pybind11::none();
-        }
-
         if (tp_size <= 1) {
             return get_tensor_into(key, buffer_ptr, size);
         }
@@ -719,16 +714,6 @@ class MooncakeStorePyWrapper {
         const std::vector<size_t> &sizes, int tp_rank = 0, int tp_size = 1) {
         if (!is_client_initialized()) {
             LOG(ERROR) << "Client is not initialized";
-            py::list empty_list;
-            for (size_t i = 0; i < base_keys.size(); ++i) {
-                empty_list.append(py::none());
-            }
-            return empty_list;
-        }
-
-        if (use_dummy_client_) {
-            LOG(ERROR) << "batch_get_tensor_with_tp_into is not supported for "
-                          "dummy client";
             py::list empty_list;
             for (size_t i = 0; i < base_keys.size(); ++i) {
                 empty_list.append(py::none());
@@ -757,6 +742,9 @@ class MooncakeStorePyWrapper {
         // Validation & Metadata extraction (GIL Held)
         auto info = extract_tensor_info(tensor, key);
         if (!info.valid()) return to_py_ret(ErrorCode::INVALID_PARAMS);
+        if (use_dummy_client_) {
+            return put_tensor_info_impl(key, info, config);
+        }
 
         // Prepare spans
         std::vector<std::span<const char>> values;
@@ -774,9 +762,8 @@ class MooncakeStorePyWrapper {
     }
 
     int put_tensor(const std::string &key, pybind11::object tensor) {
-        if (!is_client_initialized() || use_dummy_client_) {
-            LOG(ERROR) << "Client not initialized or Dummy client not "
-                          "supported for tensors";
+        if (!is_client_initialized()) {
+            LOG(ERROR) << "Client not initialized";
             return to_py_ret(ErrorCode::INVALID_PARAMS);
         }
         return put_tensor_impl(key, tensor,
@@ -864,9 +851,8 @@ class MooncakeStorePyWrapper {
     int put_tensor_with_tp(const std::string &key, pybind11::object tensor,
                            int tp_rank = 0, int tp_size = 1,
                            int split_dim = 0) {
-        if (!is_client_initialized() || use_dummy_client_) {
-            LOG(ERROR) << "Client not initialized or Dummy client not "
-                          "supported for tensors";
+        if (!is_client_initialized()) {
+            LOG(ERROR) << "Client not initialized";
             return to_py_ret(ErrorCode::INVALID_PARAMS);
         }
         if (tp_size <= 1) return put_tensor(key, tensor);
@@ -903,7 +889,7 @@ class MooncakeStorePyWrapper {
 
     std::vector<int> batch_put_tensor(const std::vector<std::string> &keys,
                                       const pybind11::list &tensors_list) {
-        if (!is_client_initialized() || use_dummy_client_)
+        if (!is_client_initialized())
             return std::vector<int>(keys.size(),
                                     to_py_ret(ErrorCode::INVALID_PARAMS));
 
@@ -993,7 +979,7 @@ class MooncakeStorePyWrapper {
         const pybind11::list &tensors_list, int tp_rank = 0, int tp_size = 1,
         int split_dim = 0) {
         if (tp_size <= 1) return batch_put_tensor(base_keys, tensors_list);
-        if (!is_client_initialized() || use_dummy_client_)
+        if (!is_client_initialized())
             return std::vector<int>(base_keys.size(),
                                     to_py_ret(ErrorCode::INVALID_PARAMS));
 
@@ -1020,10 +1006,6 @@ class MooncakeStorePyWrapper {
             LOG(ERROR) << "Client is not initialized";
             return to_py_ret(ErrorCode::INVALID_PARAMS);
         }
-        if (use_dummy_client_) {
-            LOG(ERROR) << "put_tensor_from is not supported for dummy client";
-            return to_py_ret(ErrorCode::INVALID_PARAMS);
-        }
         if (size < sizeof(TensorMetadata)) {
             LOG(ERROR) << "Buffer size too small for tensor metadata";
             return to_py_ret(ErrorCode::INVALID_PARAMS);
@@ -1043,12 +1025,6 @@ class MooncakeStorePyWrapper {
         const std::vector<size_t> &sizes) {
         if (!is_client_initialized()) {
             LOG(ERROR) << "Client is not initialized";
-            return std::vector<int>(keys.size(),
-                                    to_py_ret(ErrorCode::INVALID_PARAMS));
-        }
-        if (use_dummy_client_) {
-            LOG(ERROR)
-                << "batch_put_tensor_from is not supported for dummy client";
             return std::vector<int>(keys.size(),
                                     to_py_ret(ErrorCode::INVALID_PARAMS));
         }
@@ -1094,6 +1070,12 @@ class MooncakeStorePyWrapper {
     int put_tensor_info_impl(const std::string &key, const PyTensorInfo &info,
                              const ReplicateConfig &config) {
         if (!info.valid()) return to_py_ret(ErrorCode::INVALID_PARAMS);
+        if (use_dummy_client_) {
+            auto results = batch_put_tensor_infos_impl(
+                {key}, std::vector<PyTensorInfo>{info}, config);
+            return results.empty() ? to_py_ret(ErrorCode::INTERNAL_ERROR)
+                                   : results[0];
+        }
 
         std::vector<std::span<const char>> values;
         values.emplace_back(reinterpret_cast<const char *>(&info.metadata),
@@ -1135,11 +1117,6 @@ class MooncakeStorePyWrapper {
             LOG(ERROR) << "Client is not initialized";
             return to_py_ret(ErrorCode::INVALID_PARAMS);
         }
-        if (use_dummy_client_) {
-            LOG(ERROR)
-                << "put_tensor_with_tp_from is not supported for dummy client";
-            return to_py_ret(ErrorCode::INVALID_PARAMS);
-        }
         if (buffer_ptr == 0) {
             LOG(ERROR) << "Buffer pointer cannot be null";
             return to_py_ret(ErrorCode::INVALID_PARAMS);
@@ -1171,12 +1148,6 @@ class MooncakeStorePyWrapper {
         int split_dim = 0) {
         if (!is_client_initialized()) {
             LOG(ERROR) << "Client is not initialized";
-            return std::vector<int>(base_keys.size(),
-                                    to_py_ret(ErrorCode::INVALID_PARAMS));
-        }
-        if (use_dummy_client_) {
-            LOG(ERROR) << "batch_put_tensor_with_tp_from is not supported for "
-                          "dummy client";
             return std::vector<int>(base_keys.size(),
                                     to_py_ret(ErrorCode::INVALID_PARAMS));
         }
@@ -1306,6 +1277,12 @@ class MooncakeStorePyWrapper {
                                 const PyTensorInfo &info,
                                 const ReplicateConfig &config) {
         if (!info.valid()) return to_py_ret(ErrorCode::INVALID_PARAMS);
+        if (use_dummy_client_) {
+            auto results = batch_upsert_tensor_infos_impl(
+                {key}, std::vector<PyTensorInfo>{info}, config);
+            return results.empty() ? to_py_ret(ErrorCode::INTERNAL_ERROR)
+                                   : results[0];
+        }
 
         std::vector<std::span<const char>> values;
         values.emplace_back(reinterpret_cast<const char *>(&info.metadata),
@@ -1324,6 +1301,9 @@ class MooncakeStorePyWrapper {
                            const ReplicateConfig &config) {
         auto info = extract_tensor_info(tensor, key);
         if (!info.valid()) return to_py_ret(ErrorCode::INVALID_PARAMS);
+        if (use_dummy_client_) {
+            return upsert_tensor_info_impl(key, info, config);
+        }
 
         std::vector<std::span<const char>> values;
         values.emplace_back(reinterpret_cast<const char *>(&info.metadata),
@@ -1339,9 +1319,8 @@ class MooncakeStorePyWrapper {
     }
 
     int upsert_tensor(const std::string &key, pybind11::object tensor) {
-        if (!is_client_initialized() || use_dummy_client_) {
-            LOG(ERROR) << "Client not initialized or Dummy client not "
-                          "supported for tensors";
+        if (!is_client_initialized()) {
+            LOG(ERROR) << "Client not initialized";
             return to_py_ret(ErrorCode::INVALID_PARAMS);
         }
         return upsert_tensor_impl(key, tensor, ReplicateConfig{});
@@ -1378,12 +1357,6 @@ class MooncakeStorePyWrapper {
         const std::vector<size_t> &sizes) {
         if (!is_client_initialized()) {
             LOG(ERROR) << "Client is not initialized";
-            return std::vector<int>(keys.size(),
-                                    to_py_ret(ErrorCode::INVALID_PARAMS));
-        }
-        if (use_dummy_client_) {
-            LOG(ERROR)
-                << "batch_upsert_tensor_from is not supported for dummy client";
             return std::vector<int>(keys.size(),
                                     to_py_ret(ErrorCode::INVALID_PARAMS));
         }
@@ -1427,6 +1400,21 @@ class MooncakeStorePyWrapper {
                                          ReplicateConfig{});
     }
 
+    std::vector<int> batch_upsert_tensor_infos_impl(
+        const std::vector<std::string> &keys,
+        const std::vector<PyTensorInfo> &infos,
+        const ReplicateConfig &config = ReplicateConfig{}) {
+        return batch_write_tensor_impl(
+            keys, infos, config, "upsert",
+            [this](const std::vector<std::string> &write_keys,
+                   const std::vector<void *> &buffer_ptrs,
+                   const std::vector<size_t> &buffer_sizes,
+                   const ReplicateConfig &write_config) {
+                return store_->batch_upsert_from(write_keys, buffer_ptrs,
+                                                 buffer_sizes, write_config);
+            });
+    }
+
     std::vector<int> batch_upsert_tensor_impl(
         const std::vector<std::string> &keys,
         const pybind11::list &tensors_list,
@@ -1438,76 +1426,15 @@ class MooncakeStorePyWrapper {
         }
 
         std::vector<PyTensorInfo> infos(keys.size());
-        std::vector<int> results(keys.size(), 0);
-
-        // 1. Extract Metadata (GIL Held)
         for (size_t i = 0; i < keys.size(); ++i) {
             infos[i] = extract_tensor_info(tensors_list[i], keys[i]);
-            if (!infos[i].valid())
-                results[i] = to_py_ret(ErrorCode::INVALID_PARAMS);
         }
-
-        // 2. Prepare Buffers and Execute (GIL Released)
-        {
-            py::gil_scoped_release release_gil;
-
-            std::vector<std::string> valid_keys;
-            std::vector<void *> buffer_ptrs;
-            std::vector<size_t> buffer_sizes;
-            std::vector<size_t> original_indices;
-
-            std::vector<std::unique_ptr<BufferHandle>> temp_allocations;
-
-            for (size_t i = 0; i < infos.size(); ++i) {
-                if (!infos[i].valid()) continue;
-
-                size_t total_size =
-                    sizeof(TensorMetadata) + infos[i].tensor_size;
-                auto alloc_result =
-                    store_->client_buffer_allocator_->allocate(total_size);
-
-                if (!alloc_result) {
-                    LOG(ERROR)
-                        << "Failed to allocate buffer for key: " << keys[i];
-                    results[i] = to_py_ret(ErrorCode::INVALID_PARAMS);
-                    continue;
-                }
-
-                // Copy Metadata & Data
-                char *dst = static_cast<char *>(alloc_result->ptr());
-                memcpy(dst, &infos[i].metadata, sizeof(TensorMetadata));
-                if (infos[i].tensor_size > 0) {
-                    memcpy(dst + sizeof(TensorMetadata),
-                           reinterpret_cast<void *>(infos[i].data_ptr),
-                           infos[i].tensor_size);
-                }
-
-                valid_keys.push_back(keys[i]);
-                buffer_ptrs.push_back(alloc_result->ptr());
-                buffer_sizes.push_back(total_size);
-                original_indices.push_back(i);
-
-                temp_allocations.push_back(
-                    std::make_unique<BufferHandle>(std::move(*alloc_result)));
-            }
-
-            if (!valid_keys.empty()) {
-                ReplicateConfig write_config =
-                    MakeIndexedConfig(config, original_indices);
-                std::vector<int> op_results = store_->batch_upsert_from(
-                    valid_keys, buffer_ptrs, buffer_sizes, write_config);
-                for (size_t i = 0; i < op_results.size(); ++i) {
-                    results[original_indices[i]] = op_results[i];
-                }
-            }
-        }
-
-        return results;
+        return batch_upsert_tensor_infos_impl(keys, infos, config);
     }
 
     std::vector<int> batch_upsert_tensor(const std::vector<std::string> &keys,
                                          const pybind11::list &tensors_list) {
-        if (!is_client_initialized() || use_dummy_client_)
+        if (!is_client_initialized())
             return std::vector<int>(keys.size(),
                                     to_py_ret(ErrorCode::INVALID_PARAMS));
 
@@ -1529,11 +1456,6 @@ class MooncakeStorePyWrapper {
         void *buffer = reinterpret_cast<void *>(buffer_ptr);
         if (!is_client_initialized()) {
             LOG(ERROR) << "Client is not initialized";
-            return to_py_ret(ErrorCode::INVALID_PARAMS);
-        }
-        if (use_dummy_client_) {
-            LOG(ERROR)
-                << "upsert_tensor_from is not supported for dummy client";
             return to_py_ret(ErrorCode::INVALID_PARAMS);
         }
         if (size < sizeof(TensorMetadata)) {
@@ -1564,9 +1486,8 @@ class MooncakeStorePyWrapper {
 
     int upsert_pub_tensor(const std::string &key, pybind11::object tensor,
                           const ReplicateConfig &config = ReplicateConfig{}) {
-        if (!is_client_initialized() || use_dummy_client_) {
-            LOG(ERROR) << "Client not initialized or Dummy client not "
-                          "supported for tensors";
+        if (!is_client_initialized()) {
+            LOG(ERROR) << "Client not initialized";
             return to_py_ret(ErrorCode::INVALID_PARAMS);
         }
 
@@ -1580,7 +1501,7 @@ class MooncakeStorePyWrapper {
         const std::vector<std::string> &keys,
         const pybind11::list &tensors_list,
         const ReplicateConfig &config = ReplicateConfig{}) {
-        if (!is_client_initialized() || use_dummy_client_)
+        if (!is_client_initialized())
             return std::vector<int>(keys.size(),
                                     to_py_ret(ErrorCode::INVALID_PARAMS));
 
@@ -1602,9 +1523,8 @@ class MooncakeStorePyWrapper {
     // --- End Upsert tensor methods ---
     int pub_tensor(const std::string &key, pybind11::object tensor,
                    const ReplicateConfig &config = ReplicateConfig{}) {
-        if (!is_client_initialized() || use_dummy_client_) {
-            LOG(ERROR) << "Client not initialized or Dummy client not "
-                          "supported for tensors";
+        if (!is_client_initialized()) {
+            LOG(ERROR) << "Client not initialized";
             return to_py_ret(ErrorCode::INVALID_PARAMS);
         }
 
@@ -1618,9 +1538,8 @@ class MooncakeStorePyWrapper {
                            const ReplicateConfig &config = ReplicateConfig{},
                            int tp_rank = 0, int tp_size = 1,
                            int split_dim = 0) {
-        if (!is_client_initialized() || use_dummy_client_) {
-            LOG(ERROR) << "Client not initialized or Dummy client not "
-                          "supported for tensors";
+        if (!is_client_initialized()) {
+            LOG(ERROR) << "Client not initialized";
             return to_py_ret(ErrorCode::INVALID_PARAMS);
         }
 
@@ -1637,7 +1556,7 @@ class MooncakeStorePyWrapper {
         const std::vector<std::string> &keys,
         const pybind11::list &tensors_list,
         const ReplicateConfig &config = ReplicateConfig{}) {
-        if (!is_client_initialized() || use_dummy_client_)
+        if (!is_client_initialized())
             return std::vector<int>(keys.size(),
                                     to_py_ret(ErrorCode::INVALID_PARAMS));
 
@@ -1663,7 +1582,7 @@ class MooncakeStorePyWrapper {
         int tp_size = 1, int split_dim = 0) {
         if (tp_size <= 1)
             return batch_pub_tensor(base_keys, tensors_list, config);
-        if (!is_client_initialized() || use_dummy_client_)
+        if (!is_client_initialized())
             return std::vector<int>(base_keys.size(),
                                     to_py_ret(ErrorCode::INVALID_PARAMS));
 
@@ -1687,12 +1606,6 @@ class MooncakeStorePyWrapper {
                                   py::object file_name_obj = py::none()) {
         if (!is_client_initialized()) {
             LOG(ERROR) << "Client is not initialized";
-            return to_py_ret(ErrorCode::INVALID_PARAMS);
-        }
-
-        if (use_dummy_client_) {
-            LOG(ERROR) << "save_tensor_to_safetensor is not supported for "
-                       << "dummy client now";
             return to_py_ret(ErrorCode::INVALID_PARAMS);
         }
 
@@ -1722,12 +1635,6 @@ class MooncakeStorePyWrapper {
                                                  const std::string &file_name) {
         if (!is_client_initialized()) {
             LOG(ERROR) << "Client is not initialized";
-            return pybind11::none();
-        }
-
-        if (use_dummy_client_) {
-            LOG(ERROR) << "load_tensor_from_safetensor is not supported for "
-                       << "dummy client now";
             return pybind11::none();
         }
 

--- a/mooncake-integration/store/store_py_parallel_write.h
+++ b/mooncake-integration/store/store_py_parallel_write.h
@@ -20,6 +20,13 @@ std::vector<int> batch_write_tensor_impl(const std::vector<std::string> &keys,
                                          const ReplicateConfig &config,
                                          const char *operation_name,
                                          BatchWriteFromFn &&batch_write_from) {
+    if (keys.size() != infos.size()) {
+        LOG(ERROR) << operation_name
+                   << ": keys and tensor infos must have the same length";
+        return std::vector<int>(keys.size(),
+                                to_py_ret(ErrorCode::INVALID_PARAMS));
+    }
+
     auto group_ids_error =
         ValidateGroupIdsForBatchConfig(config, keys.size(), operation_name);
     if (!group_ids_error.empty()) {
@@ -30,6 +37,14 @@ std::vector<int> batch_write_tensor_impl(const std::vector<std::string> &keys,
 
     {
         py::gil_scoped_release release_gil;
+        if (!store_->client_buffer_allocator_) {
+            LOG(ERROR) << operation_name
+                       << ": client buffer allocator is not available";
+            return std::vector<int>(keys.size(),
+                                    to_py_ret(ErrorCode::INVALID_PARAMS));
+        }
+        auto runtime_accelerator =
+            mooncake::device::GetAcceleratorRegistry().RuntimeAccelerators();
 
         std::vector<std::string> valid_keys;
         std::vector<void *> buffer_ptrs;
@@ -59,9 +74,15 @@ std::vector<int> batch_write_tensor_impl(const std::vector<std::string> &keys,
             std::memcpy(dst, &infos[i].metadata,
                         infos[i].metadata.header.data_offset);
             if (infos[i].tensor_size > 0) {
-                std::memcpy(dst + infos[i].metadata.header.data_offset,
-                            reinterpret_cast<void *>(infos[i].data_ptr),
-                            infos[i].tensor_size);
+                if (!runtime_accelerator.CopyToHost(
+                        dst + infos[i].metadata.header.data_offset,
+                        reinterpret_cast<const void *>(infos[i].data_ptr),
+                        infos[i].tensor_size)) {
+                    LOG(ERROR) << "Failed to copy tensor payload for "
+                               << operation_name << " key: " << keys[i];
+                    results[i] = to_py_ret(ErrorCode::INVALID_PARAMS);
+                    continue;
+                }
             }
 
             valid_keys.push_back(keys[i]);
@@ -77,6 +98,16 @@ std::vector<int> batch_write_tensor_impl(const std::vector<std::string> &keys,
                 MakeIndexedConfig(config, original_indices);
             std::vector<int> op_results = batch_write_from(
                 valid_keys, buffer_ptrs, buffer_sizes, write_config);
+            if (op_results.size() != original_indices.size()) {
+                LOG(ERROR) << operation_name
+                           << ": unexpected batch write result count "
+                           << op_results.size() << ", expected "
+                           << original_indices.size();
+                for (size_t index : original_indices) {
+                    results[index] = to_py_ret(ErrorCode::INTERNAL_ERROR);
+                }
+                return results;
+            }
             for (size_t i = 0; i < op_results.size(); ++i) {
                 results[original_indices[i]] = op_results[i];
             }
@@ -87,10 +118,8 @@ std::vector<int> batch_write_tensor_impl(const std::vector<std::string> &keys,
 }
 
 bool ensure_tensor_write_supported(const char *operation_name) const {
-    if (!is_client_initialized() || use_dummy_client_) {
-        LOG(ERROR) << operation_name
-                   << ": client not initialized or dummy client not "
-                      "supported for tensors";
+    if (!is_client_initialized()) {
+        LOG(ERROR) << operation_name << ": client not initialized";
         return false;
     }
     return true;
@@ -927,7 +956,7 @@ std::vector<int> batch_put_tensor_with_parallelism(
         keys, tensors_list.size(), parallelisms, writer_partitions,
         "batch_put_tensor_with_parallelism",
         [this, &keys, &tensors_list, &config]() {
-            if (!is_client_initialized() || use_dummy_client_) {
+            if (!is_client_initialized()) {
                 return std::vector<int>(keys.size(),
                                         to_py_ret(ErrorCode::INVALID_PARAMS));
             }
@@ -1060,7 +1089,7 @@ std::vector<int> batch_put_tensor_with_parallelism_from(
         "batch_put_tensor_with_parallelism_from",
         [this, &keys, &buffer_ptrs, &sizes, &config]() {
             if (!is_default_replicate_config(config)) {
-                if (!is_client_initialized() || use_dummy_client_) {
+                if (!is_client_initialized()) {
                     return std::vector<int>(
                         keys.size(), to_py_ret(ErrorCode::INVALID_PARAMS));
                 }
@@ -1300,11 +1329,6 @@ int execute_upsert_tensor_with_parallelism_from_route(
                     LOG(ERROR) << "Client is not initialized";
                     return to_py_ret(ErrorCode::INVALID_PARAMS);
                 }
-                if (use_dummy_client_) {
-                    LOG(ERROR) << "upsert_tensor_with_parallelism_from is not "
-                                  "supported for dummy client";
-                    return to_py_ret(ErrorCode::INVALID_PARAMS);
-                }
                 int validate_result = validate_replicate_config(write_config);
                 if (validate_result) return validate_result;
                 py::gil_scoped_release release_gil;
@@ -1383,7 +1407,7 @@ std::vector<int> batch_upsert_tensor_with_parallelism(
         keys, tensors_list.size(), parallelisms, writer_partitions,
         "batch_upsert_tensor_with_parallelism",
         [this, &keys, &tensors_list, &config]() {
-            if (!is_client_initialized() || use_dummy_client_) {
+            if (!is_client_initialized()) {
                 return std::vector<int>(keys.size(),
                                         to_py_ret(ErrorCode::INVALID_PARAMS));
             }
@@ -1428,12 +1452,6 @@ std::vector<int> batch_upsert_tensor_with_parallelism_from(
             if (!is_default_replicate_config(config)) {
                 if (!is_client_initialized()) {
                     LOG(ERROR) << "Client is not initialized";
-                    return std::vector<int>(
-                        keys.size(), to_py_ret(ErrorCode::INVALID_PARAMS));
-                }
-                if (use_dummy_client_) {
-                    LOG(ERROR) << "batch_upsert_tensor_with_parallelism_from "
-                                  "is not supported for dummy client";
                     return std::vector<int>(
                         keys.size(), to_py_ret(ErrorCode::INVALID_PARAMS));
                 }

--- a/mooncake-integration/store/store_py_parallel_write.h
+++ b/mooncake-integration/store/store_py_parallel_write.h
@@ -37,7 +37,7 @@ std::vector<int> batch_write_tensor_impl(const std::vector<std::string> &keys,
 
     {
         py::gil_scoped_release release_gil;
-        if (!store_->client_buffer_allocator_) {
+        if (!store_->client_buffer_allocator_ && !use_dummy_client_) {
             LOG(ERROR) << operation_name
                        << ": client buffer allocator is not available";
             return std::vector<int>(keys.size(),
@@ -60,8 +60,7 @@ std::vector<int> batch_write_tensor_impl(const std::vector<std::string> &keys,
 
             size_t total_size =
                 infos[i].metadata.header.data_offset + infos[i].tensor_size;
-            auto alloc_result =
-                store_->client_buffer_allocator_->allocate(total_size);
+            auto alloc_result = store_->allocate_client_buffer(total_size);
 
             if (!alloc_result) {
                 LOG(ERROR) << "Failed to allocate buffer for " << operation_name

--- a/mooncake-store/include/dummy_client.h
+++ b/mooncake-store/include/dummy_client.h
@@ -178,6 +178,8 @@ class DummyClient : public PyClient {
 
     tl::expected<QueryTaskResponse, ErrorCode> query_task(const UUID &task_id);
 
+    std::optional<BufferHandle> allocate_client_buffer(size_t size) override;
+
    private:
     ErrorCode connect(const std::string &server_address);
 
@@ -278,6 +280,7 @@ class DummyClient : public PyClient {
     // For shared memory management
     ShmHelper *shm_helper_ = nullptr;
     std::string ipc_socket_path_;
+    void *local_buffer_base_ = nullptr;
 
     // Hot cache shm mapping (obtained from real client via IPC)
     void *hot_cache_base_ = nullptr;

--- a/mooncake-store/include/dummy_client.h
+++ b/mooncake-store/include/dummy_client.h
@@ -281,7 +281,6 @@ class DummyClient : public PyClient {
     ShmHelper *shm_helper_ = nullptr;
     std::string ipc_socket_path_;
     void *local_buffer_base_ = nullptr;
-    std::mutex local_buffer_write_mutex_;
 
     // Hot cache shm mapping (obtained from real client via IPC)
     void *hot_cache_base_ = nullptr;

--- a/mooncake-store/include/dummy_client.h
+++ b/mooncake-store/include/dummy_client.h
@@ -281,6 +281,7 @@ class DummyClient : public PyClient {
     ShmHelper *shm_helper_ = nullptr;
     std::string ipc_socket_path_;
     void *local_buffer_base_ = nullptr;
+    std::mutex local_buffer_write_mutex_;
 
     // Hot cache shm mapping (obtained from real client via IPC)
     void *hot_cache_base_ = nullptr;

--- a/mooncake-store/include/pyclient.h
+++ b/mooncake-store/include/pyclient.h
@@ -5,6 +5,7 @@
 #include <csignal>
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -369,6 +370,13 @@ class PyClient {
 
     virtual tl::expected<QueryTaskResponse, ErrorCode> query_task(
         const UUID &task_id) = 0;
+
+    virtual std::optional<BufferHandle> allocate_client_buffer(size_t size) {
+        if (!client_buffer_allocator_) {
+            return std::nullopt;
+        }
+        return client_buffer_allocator_->allocate(size);
+    }
 
     std::shared_ptr<mooncake::Client> client_ = nullptr;
     std::shared_ptr<mooncake::ClientRequester> client_requester_ = nullptr;

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -389,6 +389,9 @@ class RealClient : public PyClient {
     batch_acquire_buffer_dummy(const std::vector<std::string> &keys,
                                const UUID &client_id);
 
+    tl::expected<std::tuple<uint64_t, size_t>, ErrorCode> allocate_buffer_dummy(
+        size_t size, const UUID &client_id);
+
     tl::expected<void, ErrorCode> put_dummy_helper(
         const std::string &key, std::span<const char> value,
         const ReplicateConfig &config, const UUID &client_id);

--- a/mooncake-store/src/dummy_client.cpp
+++ b/mooncake-store/src/dummy_client.cpp
@@ -527,8 +527,15 @@ int DummyClient::setup_dummy(size_t mem_pool_size, size_t local_buffer_size,
 }
 
 int DummyClient::tearDownAll() {
+    void* local_buffer_base = client_buffer_allocator_
+                                  ? client_buffer_allocator_->getBase()
+                                  : nullptr;
     client_buffer_allocator_.reset();
     unregister_shm();
+    if (local_buffer_base && shm_helper_ &&
+        shm_helper_->free(local_buffer_base) != 0) {
+        LOG(ERROR) << "Failed to free dummy local shared memory";
+    }
 
     // Cleanup hot cache shm mapping
     if (hot_cache_base_) {

--- a/mooncake-store/src/dummy_client.cpp
+++ b/mooncake-store/src/dummy_client.cpp
@@ -497,6 +497,23 @@ int DummyClient::setup_dummy(size_t mem_pool_size, size_t local_buffer_size,
         local_buffer_shm->registered = true;
         local_buffer_shm->is_local = true;
 
+        try {
+            client_buffer_allocator_ =
+                ClientBufferAllocator::create(base_addr, local_buffer_size);
+        } catch (const std::exception& e) {
+            LOG(ERROR) << "Failed to create client buffer allocator: "
+                       << e.what();
+            unregister_shm();
+            shm_helper_->free(local_buffer_shm->base_addr);
+            return -1;
+        }
+        if (!client_buffer_allocator_) {
+            LOG(ERROR) << "Failed to create client buffer allocator";
+            unregister_shm();
+            shm_helper_->free(local_buffer_shm->base_addr);
+            return -1;
+        }
+
         // Best-effort: request hot cache shm from real client
         if (request_hot_cache_fd() != 0) {
             LOG(INFO)
@@ -510,6 +527,7 @@ int DummyClient::setup_dummy(size_t mem_pool_size, size_t local_buffer_size,
 }
 
 int DummyClient::tearDownAll() {
+    client_buffer_allocator_.reset();
     unregister_shm();
 
     // Cleanup hot cache shm mapping
@@ -1111,8 +1129,8 @@ std::vector<int> DummyClient::batch_put_from(
 
 int DummyClient::put_from(const std::string& key, void* buffer, size_t size,
                           const ReplicateConfig& config) {
-    // TODO: implement this function
-    return -1;
+    auto results = batch_put_from({key}, {buffer}, {size}, config);
+    return results.empty() ? -1 : results[0];
 }
 
 std::vector<int64_t> DummyClient::batch_get_into(
@@ -1143,8 +1161,9 @@ int DummyClient::put_from_with_metadata(const std::string& key, void* buffer,
                                         void* metadata_buffer, size_t size,
                                         size_t metadata_size,
                                         const ReplicateConfig& config) {
-    // TODO: implement this function
-    return -1;
+    auto results = batch_put_from_multi_buffers(
+        {key}, {{metadata_buffer, buffer}}, {{metadata_size, size}}, config);
+    return results.empty() ? -1 : results[0];
 }
 
 std::vector<int> DummyClient::batch_put_from_multi_buffers(

--- a/mooncake-store/src/dummy_client.cpp
+++ b/mooncake-store/src/dummy_client.cpp
@@ -467,6 +467,7 @@ int DummyClient::setup_dummy(size_t mem_pool_size, size_t local_buffer_size,
     if (local_buffer_size > 0) {
         try {
             base_addr = shm_helper_->allocate(local_buffer_size);
+            local_buffer_base_ = base_addr;
         } catch (const std::exception& e) {
             LOG(ERROR) << "Failed to allocate shared memory: " << e.what();
             return -1;
@@ -476,6 +477,7 @@ int DummyClient::setup_dummy(size_t mem_pool_size, size_t local_buffer_size,
         if (!local_buffer_shm) {
             LOG(ERROR) << "Failed to get shm segment for base address";
             shm_helper_->free(base_addr);
+            local_buffer_base_ = nullptr;
             return -1;
         }
 
@@ -484,6 +486,7 @@ int DummyClient::setup_dummy(size_t mem_pool_size, size_t local_buffer_size,
                 LOG(ERROR) << "Failed to register SHM via IPC";
                 // Register failed, cleanup
                 shm_helper_->free(local_buffer_shm->base_addr);
+                local_buffer_base_ = nullptr;
                 return -1;
             }
         } else {
@@ -491,28 +494,12 @@ int DummyClient::setup_dummy(size_t mem_pool_size, size_t local_buffer_size,
                 LOG(ERROR) << "Failed to register SHM via IPC";
                 // Register failed, cleanup
                 shm_helper_->free(local_buffer_shm->base_addr);
+                local_buffer_base_ = nullptr;
                 return -1;
             }
         }
         local_buffer_shm->registered = true;
         local_buffer_shm->is_local = true;
-
-        try {
-            client_buffer_allocator_ =
-                ClientBufferAllocator::create(base_addr, local_buffer_size);
-        } catch (const std::exception& e) {
-            LOG(ERROR) << "Failed to create client buffer allocator: "
-                       << e.what();
-            unregister_shm();
-            shm_helper_->free(local_buffer_shm->base_addr);
-            return -1;
-        }
-        if (!client_buffer_allocator_) {
-            LOG(ERROR) << "Failed to create client buffer allocator";
-            unregister_shm();
-            shm_helper_->free(local_buffer_shm->base_addr);
-            return -1;
-        }
 
         // Best-effort: request hot cache shm from real client
         if (request_hot_cache_fd() != 0) {
@@ -527,15 +514,14 @@ int DummyClient::setup_dummy(size_t mem_pool_size, size_t local_buffer_size,
 }
 
 int DummyClient::tearDownAll() {
-    void* local_buffer_base = client_buffer_allocator_
-                                  ? client_buffer_allocator_->getBase()
-                                  : nullptr;
-    client_buffer_allocator_.reset();
+    void* local_buffer_base = local_buffer_base_;
     unregister_shm();
     if (local_buffer_base && shm_helper_ &&
+        shm_helper_->get_shm(local_buffer_base) &&
         shm_helper_->free(local_buffer_base) != 0) {
         LOG(ERROR) << "Failed to free dummy local shared memory";
     }
+    local_buffer_base_ = nullptr;
 
     // Cleanup hot cache shm mapping
     if (hot_cache_base_) {
@@ -563,6 +549,23 @@ int DummyClient::tearDownAll() {
     }
 #endif
     return 0;
+}
+
+std::optional<BufferHandle> DummyClient::allocate_client_buffer(size_t size) {
+    auto result = invoke_rpc<&RealClient::allocate_buffer_dummy,
+                             std::tuple<uint64_t, size_t>>(size, client_id_);
+    if (!result.has_value()) {
+        return std::nullopt;
+    }
+
+    auto [dummy_addr, allocated_size] = result.value();
+    void* local_ptr = reinterpret_cast<void*>(dummy_addr);
+    auto release = [this, dummy_addr]() {
+        (void)invoke_rpc<&RealClient::release_buffer_dummy, void>(dummy_addr,
+                                                                  client_id_);
+    };
+    return std::make_optional<BufferHandle>(local_ptr, allocated_size,
+                                            std::move(release));
 }
 
 int64_t DummyClient::unregister_shm() {

--- a/mooncake-store/src/dummy_client.cpp
+++ b/mooncake-store/src/dummy_client.cpp
@@ -761,6 +761,7 @@ uint64_t DummyClient::alloc_from_mem_pool(size_t size) {
 
 int DummyClient::put(const std::string& key, std::span<const char> value,
                      const ReplicateConfig& config) {
+    std::lock_guard<std::mutex> lock(local_buffer_write_mutex_);
     return invoke_observed_void_rpc<&RealClient::put_dummy_helper>(
         TransferOperationKind::kWrite, "put", value.size_bytes(), false, key,
         value, config, client_id_);
@@ -769,6 +770,7 @@ int DummyClient::put(const std::string& key, std::span<const char> value,
 int DummyClient::put_batch(const std::vector<std::string>& keys,
                            const std::vector<std::span<const char>>& values,
                            const ReplicateConfig& config) {
+    std::lock_guard<std::mutex> lock(local_buffer_write_mutex_);
     return invoke_observed_void_rpc<&RealClient::put_batch_dummy_helper>(
         TransferOperationKind::kWrite, "put_batch", sum_value_sizes(values),
         true, keys, values, config, client_id_);
@@ -777,6 +779,7 @@ int DummyClient::put_batch(const std::vector<std::string>& keys,
 int DummyClient::put_parts(const std::string& key,
                            std::vector<std::span<const char>> values,
                            const ReplicateConfig& config) {
+    std::lock_guard<std::mutex> lock(local_buffer_write_mutex_);
     return invoke_observed_void_rpc<&RealClient::put_parts_dummy_helper>(
         TransferOperationKind::kWrite, "put_parts", sum_value_sizes(values),
         false, key, values, config, client_id_);
@@ -784,6 +787,7 @@ int DummyClient::put_parts(const std::string& key,
 
 int DummyClient::upsert(const std::string& key, std::span<const char> value,
                         const ReplicateConfig& config) {
+    std::lock_guard<std::mutex> lock(local_buffer_write_mutex_);
     return invoke_observed_void_rpc<&RealClient::upsert_dummy_helper>(
         TransferOperationKind::kWrite, "upsert", value.size_bytes(), false, key,
         value, config, client_id_);
@@ -791,6 +795,7 @@ int DummyClient::upsert(const std::string& key, std::span<const char> value,
 
 int DummyClient::upsert_from(const std::string& key, void* buffer, size_t size,
                              const ReplicateConfig& config) {
+    std::lock_guard<std::mutex> lock(local_buffer_write_mutex_);
     uint64_t dummy_addr = reinterpret_cast<uint64_t>(buffer);
     return invoke_observed_void_rpc<&RealClient::upsert_from_dummy_helper>(
         TransferOperationKind::kWrite, "upsert_from", size, false, key,
@@ -800,6 +805,7 @@ int DummyClient::upsert_from(const std::string& key, void* buffer, size_t size,
 std::vector<int> DummyClient::batch_upsert_from(
     const std::vector<std::string>& keys, const std::vector<void*>& buffer_ptrs,
     const std::vector<size_t>& sizes, const ReplicateConfig& config) {
+    std::lock_guard<std::mutex> lock(local_buffer_write_mutex_);
     std::vector<uint64_t> buffers;
     for (auto ptr : buffer_ptrs) {
         buffers.push_back(reinterpret_cast<uint64_t>(ptr));
@@ -825,6 +831,7 @@ std::vector<int> DummyClient::batch_upsert_from(
 int DummyClient::upsert_parts(const std::string& key,
                               std::vector<std::span<const char>> values,
                               const ReplicateConfig& config) {
+    std::lock_guard<std::mutex> lock(local_buffer_write_mutex_);
     return invoke_observed_void_rpc<&RealClient::upsert_parts_dummy_helper>(
         TransferOperationKind::kWrite, "upsert_parts", sum_value_sizes(values),
         false, key, values, config, client_id_);
@@ -833,6 +840,7 @@ int DummyClient::upsert_parts(const std::string& key,
 int DummyClient::upsert_batch(const std::vector<std::string>& keys,
                               const std::vector<std::span<const char>>& values,
                               const ReplicateConfig& config) {
+    std::lock_guard<std::mutex> lock(local_buffer_write_mutex_);
     return invoke_observed_void_rpc<&RealClient::upsert_batch_dummy_helper>(
         TransferOperationKind::kWrite, "upsert_batch", sum_value_sizes(values),
         true, keys, values, config, client_id_);
@@ -1115,6 +1123,7 @@ std::string DummyClient::get_hostname() const {
 std::vector<int> DummyClient::batch_put_from(
     const std::vector<std::string>& keys, const std::vector<void*>& buffer_ptrs,
     const std::vector<size_t>& sizes, const ReplicateConfig& config) {
+    std::lock_guard<std::mutex> lock(local_buffer_write_mutex_);
     std::vector<uint64_t> buffers = void_ptrs_to_u64(buffer_ptrs);
     const auto start_time = std::chrono::steady_clock::now();
     auto internal_results =
@@ -1181,6 +1190,7 @@ std::vector<int> DummyClient::batch_put_from_multi_buffers(
     const std::vector<std::vector<void*>>& all_buffer_ptrs,
     const std::vector<std::vector<size_t>>& all_sizes,
     const ReplicateConfig& config) {
+    std::lock_guard<std::mutex> lock(local_buffer_write_mutex_);
     std::vector<std::vector<uint64_t>> dummy_nested =
         void_ptr_rows_to_u64_nested(all_buffer_ptrs);
     const auto start_time = std::chrono::steady_clock::now();

--- a/mooncake-store/src/dummy_client.cpp
+++ b/mooncake-store/src/dummy_client.cpp
@@ -761,7 +761,6 @@ uint64_t DummyClient::alloc_from_mem_pool(size_t size) {
 
 int DummyClient::put(const std::string& key, std::span<const char> value,
                      const ReplicateConfig& config) {
-    std::lock_guard<std::mutex> lock(local_buffer_write_mutex_);
     return invoke_observed_void_rpc<&RealClient::put_dummy_helper>(
         TransferOperationKind::kWrite, "put", value.size_bytes(), false, key,
         value, config, client_id_);
@@ -770,7 +769,6 @@ int DummyClient::put(const std::string& key, std::span<const char> value,
 int DummyClient::put_batch(const std::vector<std::string>& keys,
                            const std::vector<std::span<const char>>& values,
                            const ReplicateConfig& config) {
-    std::lock_guard<std::mutex> lock(local_buffer_write_mutex_);
     return invoke_observed_void_rpc<&RealClient::put_batch_dummy_helper>(
         TransferOperationKind::kWrite, "put_batch", sum_value_sizes(values),
         true, keys, values, config, client_id_);
@@ -779,7 +777,6 @@ int DummyClient::put_batch(const std::vector<std::string>& keys,
 int DummyClient::put_parts(const std::string& key,
                            std::vector<std::span<const char>> values,
                            const ReplicateConfig& config) {
-    std::lock_guard<std::mutex> lock(local_buffer_write_mutex_);
     return invoke_observed_void_rpc<&RealClient::put_parts_dummy_helper>(
         TransferOperationKind::kWrite, "put_parts", sum_value_sizes(values),
         false, key, values, config, client_id_);
@@ -787,7 +784,6 @@ int DummyClient::put_parts(const std::string& key,
 
 int DummyClient::upsert(const std::string& key, std::span<const char> value,
                         const ReplicateConfig& config) {
-    std::lock_guard<std::mutex> lock(local_buffer_write_mutex_);
     return invoke_observed_void_rpc<&RealClient::upsert_dummy_helper>(
         TransferOperationKind::kWrite, "upsert", value.size_bytes(), false, key,
         value, config, client_id_);
@@ -795,7 +791,6 @@ int DummyClient::upsert(const std::string& key, std::span<const char> value,
 
 int DummyClient::upsert_from(const std::string& key, void* buffer, size_t size,
                              const ReplicateConfig& config) {
-    std::lock_guard<std::mutex> lock(local_buffer_write_mutex_);
     uint64_t dummy_addr = reinterpret_cast<uint64_t>(buffer);
     return invoke_observed_void_rpc<&RealClient::upsert_from_dummy_helper>(
         TransferOperationKind::kWrite, "upsert_from", size, false, key,
@@ -805,7 +800,6 @@ int DummyClient::upsert_from(const std::string& key, void* buffer, size_t size,
 std::vector<int> DummyClient::batch_upsert_from(
     const std::vector<std::string>& keys, const std::vector<void*>& buffer_ptrs,
     const std::vector<size_t>& sizes, const ReplicateConfig& config) {
-    std::lock_guard<std::mutex> lock(local_buffer_write_mutex_);
     std::vector<uint64_t> buffers;
     for (auto ptr : buffer_ptrs) {
         buffers.push_back(reinterpret_cast<uint64_t>(ptr));
@@ -831,7 +825,6 @@ std::vector<int> DummyClient::batch_upsert_from(
 int DummyClient::upsert_parts(const std::string& key,
                               std::vector<std::span<const char>> values,
                               const ReplicateConfig& config) {
-    std::lock_guard<std::mutex> lock(local_buffer_write_mutex_);
     return invoke_observed_void_rpc<&RealClient::upsert_parts_dummy_helper>(
         TransferOperationKind::kWrite, "upsert_parts", sum_value_sizes(values),
         false, key, values, config, client_id_);
@@ -840,7 +833,6 @@ int DummyClient::upsert_parts(const std::string& key,
 int DummyClient::upsert_batch(const std::vector<std::string>& keys,
                               const std::vector<std::span<const char>>& values,
                               const ReplicateConfig& config) {
-    std::lock_guard<std::mutex> lock(local_buffer_write_mutex_);
     return invoke_observed_void_rpc<&RealClient::upsert_batch_dummy_helper>(
         TransferOperationKind::kWrite, "upsert_batch", sum_value_sizes(values),
         true, keys, values, config, client_id_);
@@ -1123,7 +1115,6 @@ std::string DummyClient::get_hostname() const {
 std::vector<int> DummyClient::batch_put_from(
     const std::vector<std::string>& keys, const std::vector<void*>& buffer_ptrs,
     const std::vector<size_t>& sizes, const ReplicateConfig& config) {
-    std::lock_guard<std::mutex> lock(local_buffer_write_mutex_);
     std::vector<uint64_t> buffers = void_ptrs_to_u64(buffer_ptrs);
     const auto start_time = std::chrono::steady_clock::now();
     auto internal_results =
@@ -1190,7 +1181,6 @@ std::vector<int> DummyClient::batch_put_from_multi_buffers(
     const std::vector<std::vector<void*>>& all_buffer_ptrs,
     const std::vector<std::vector<size_t>>& all_sizes,
     const ReplicateConfig& config) {
-    std::lock_guard<std::mutex> lock(local_buffer_write_mutex_);
     std::vector<std::vector<uint64_t>> dummy_nested =
         void_ptr_rows_to_u64_nested(all_buffer_ptrs);
     const auto start_time = std::chrono::steady_clock::now();

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -2870,6 +2870,41 @@ tl::expected<void, ErrorCode> RealClient::release_buffer_dummy(
     return {};
 }
 
+tl::expected<std::tuple<uint64_t, size_t>, ErrorCode>
+RealClient::allocate_buffer_dummy(size_t size, const UUID &client_id) {
+    std::unique_lock<std::shared_mutex> lock(dummy_client_mutex_);
+    auto it = shm_contexts_.find(client_id);
+    if (it == shm_contexts_.end()) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    auto &context = it->second;
+    if (!context.client_buffer_allocator) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    auto alloc_result = context.client_buffer_allocator->allocate(size);
+    if (!alloc_result) {
+        return tl::make_unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
+    }
+
+    auto handle = std::make_shared<BufferHandle>(std::move(*alloc_result));
+    const uint64_t real_addr = reinterpret_cast<uint64_t>(handle->ptr());
+    const size_t allocated_size = handle->size();
+    for (const auto &shm : context.mapped_shms) {
+        const uint64_t shm_start = reinterpret_cast<uint64_t>(shm.shm_buffer);
+        const uint64_t shm_end = shm_start + shm.shm_size;
+        if (real_addr >= shm_start &&
+            allocated_size <= shm_end - real_addr) {
+            const uint64_t dummy_addr = real_addr - shm.shm_addr_offset;
+            context.active_handles[dummy_addr] = std::move(handle);
+            return std::make_tuple(dummy_addr, allocated_size);
+        }
+    }
+
+    return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+}
+
 std::vector<tl::expected<std::tuple<uint64_t, size_t>, ErrorCode>>
 RealClient::batch_acquire_hot_cache(const std::vector<std::string> &keys) {
     std::vector<tl::expected<std::tuple<uint64_t, size_t>, ErrorCode>> results;

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -2894,8 +2894,7 @@ RealClient::allocate_buffer_dummy(size_t size, const UUID &client_id) {
     for (const auto &shm : context.mapped_shms) {
         const uint64_t shm_start = reinterpret_cast<uint64_t>(shm.shm_buffer);
         const uint64_t shm_end = shm_start + shm.shm_size;
-        if (real_addr >= shm_start &&
-            allocated_size <= shm_end - real_addr) {
+        if (real_addr >= shm_start && allocated_size <= shm_end - real_addr) {
             const uint64_t dummy_addr = real_addr - shm.shm_addr_offset;
             context.active_handles[dummy_addr] = std::move(handle);
             return std::make_tuple(dummy_addr, allocated_size);

--- a/mooncake-store/src/real_client_main.cpp
+++ b/mooncake-store/src/real_client_main.cpp
@@ -83,6 +83,7 @@ void RegisterClientRpcService(coro_rpc::coro_rpc_server &server,
     server.register_handler<&RealClient::release_buffer_dummy>(&real_client);
     server.register_handler<&RealClient::batch_acquire_buffer_dummy>(
         &real_client);
+    server.register_handler<&RealClient::allocate_buffer_dummy>(&real_client);
     server.register_handler<&RealClient::create_copy_task>(&real_client);
     server.register_handler<&RealClient::create_move_task>(&real_client);
     server.register_handler<&RealClient::query_task>(&real_client);

--- a/mooncake-wheel/tests/test_dummy_client.py
+++ b/mooncake-wheel/tests/test_dummy_client.py
@@ -3,6 +3,12 @@ import os
 import time
 import threading
 import random
+
+try:
+    import torch
+except ImportError:
+    torch = None
+
 from mooncake.store import MooncakeDistributedStore
 
 # The lease time of the kv object, should be set equal to
@@ -321,6 +327,163 @@ class TestDistributedObjectStoreSingleStore(unittest.TestCase):
         self.assertEqual(self.store.unregister_buffer(large_buffer_ptr), 0, "Buffer unregistration should succeed")
         for key in keys:
             self.assertEqual(self.store.remove(key), 0)
+
+    def test_tensor_operations(self):
+        """Test tensor wrappers through dummy-client shared memory."""
+        import ctypes
+
+        if torch is None:
+            self.skipTest("PyTorch is not available")
+
+        key = f"test_dummy_tensor_{os.getpid()}"
+        key_from = f"{key}_from"
+        batch_keys = [f"{key}_batch_{i}" for i in range(2)]
+        upsert_key = f"{key}_upsert"
+        pub_key = f"{key}_pub"
+        tp_key = f"{key}_tp"
+        batch_tp_key = f"{key}_batch_tp"
+        parallel_key = f"{key}_parallel"
+        parallel_batch_keys = [f"{key}_parallel_batch_{i}" for i in range(2)]
+        parallel_from_key = f"{key}_parallel_from"
+        parallel_upsert_key = f"{key}_parallel_upsert"
+        parallel_upsert_from_key = f"{key}_parallel_upsert_from"
+        cleanup_keys = [key, key_from, *batch_keys, upsert_key, pub_key]
+        cleanup_keys.extend(
+            [
+                parallel_key,
+                *parallel_batch_keys,
+                parallel_from_key,
+                parallel_upsert_key,
+                parallel_upsert_from_key,
+            ]
+        )
+        cleanup_keys.extend(f"{tp_key}_tp_{rank}" for rank in range(2))
+        cleanup_keys.extend(f"{batch_tp_key}_tp_{rank}" for rank in range(2))
+        tensor = torch.arange(12, dtype=torch.float32).reshape(3, 4)
+
+        self.assertEqual(self.store.put_tensor(key, tensor), 0)
+        retrieved = self.store.get_tensor(key)
+        self.assertIsNotNone(retrieved)
+        self.assertEqual(retrieved.dtype, tensor.dtype)
+        self.assertEqual(tuple(retrieved.shape), tuple(tensor.shape))
+        self.assertTrue(torch.equal(retrieved, tensor))
+
+        buffer_size = self.store.get_size(key)
+        self.assertGreater(buffer_size, 0)
+        buffer_ptr = self.store.alloc_from_mem_pool(buffer_size)
+        self.assertNotEqual(buffer_ptr, 0)
+        buffer = (ctypes.c_ubyte * buffer_size).from_address(buffer_ptr)
+        self.assertEqual(self.store.register_buffer(buffer_ptr, buffer_size), 0)
+        try:
+            ctypes.memset(buffer_ptr, 0, buffer_size)
+            into = self.store.get_tensor_into(key, buffer_ptr, buffer_size)
+            self.assertIsNotNone(into)
+            self.assertTrue(torch.equal(into, tensor))
+
+            mismatch = self.store.batch_get_tensor_into(
+                [key, f"{key}_missing_arg"], [buffer_ptr], [buffer_size]
+            )
+            self.assertEqual(len(mismatch), 2)
+            self.assertTrue(all(result < 0 for result in mismatch))
+
+            self.assertEqual(
+                self.store.put_tensor_from(key_from, buffer_ptr, buffer_size),
+                0,
+            )
+            from_tensor = self.store.get_tensor(key_from)
+            self.assertIsNotNone(from_tensor)
+            self.assertTrue(torch.equal(from_tensor, tensor))
+
+            batch_tensors = [tensor, tensor + 1]
+            batch_results = self.store.batch_put_tensor(batch_keys, batch_tensors)
+            self.assertEqual(list(batch_results), [0, 0])
+            batch_retrieved = self.store.batch_get_tensor(batch_keys)
+            for expected, actual in zip(batch_tensors, batch_retrieved):
+                self.assertIsNotNone(actual)
+                self.assertTrue(torch.equal(actual, expected))
+
+            updated = tensor + 2
+            self.assertEqual(self.store.upsert_tensor(upsert_key, updated), 0)
+            self.assertTrue(torch.equal(self.store.get_tensor(upsert_key), updated))
+
+            self.assertEqual(self.store.pub_tensor(pub_key, tensor + 3), 0)
+            self.assertTrue(torch.equal(self.store.get_tensor(pub_key), tensor + 3))
+
+            self.assertEqual(
+                self.store.put_tensor_with_tp(
+                    tp_key, tensor, tp_size=2, split_dim=1
+                ),
+                0,
+            )
+            tp_shards = torch.chunk(tensor, 2, dim=1)
+            for rank, expected in enumerate(tp_shards):
+                actual = self.store.get_tensor_with_tp(
+                    tp_key, tp_rank=rank, tp_size=2
+                )
+                self.assertIsNotNone(actual)
+                self.assertTrue(torch.equal(actual, expected.contiguous()))
+
+            batch_tp_results = self.store.batch_put_tensor_with_tp(
+                [batch_tp_key], [tensor], tp_size=2, split_dim=1
+            )
+            self.assertEqual(list(batch_tp_results), [0])
+
+            self.assertEqual(
+                self.store.put_tensor_with_parallelism(parallel_key, tensor),
+                0,
+            )
+            self.assertTrue(torch.equal(self.store.get_tensor(parallel_key), tensor))
+
+            parallel_batch = [tensor + 4, tensor + 5]
+            parallel_batch_results = self.store.batch_put_tensor_with_parallelism(
+                parallel_batch_keys, parallel_batch
+            )
+            self.assertEqual(list(parallel_batch_results), [0, 0])
+            parallel_batch_retrieved = self.store.batch_get_tensor(
+                parallel_batch_keys
+            )
+            for expected, actual in zip(parallel_batch, parallel_batch_retrieved):
+                self.assertIsNotNone(actual)
+                self.assertTrue(torch.equal(actual, expected))
+
+            self.assertEqual(
+                self.store.put_tensor_with_parallelism_from(
+                    parallel_from_key, buffer_ptr, buffer_size
+                ),
+                0,
+            )
+            self.assertTrue(
+                torch.equal(self.store.get_tensor(parallel_from_key), tensor)
+            )
+
+            parallel_update = tensor + 6
+            self.assertEqual(
+                self.store.upsert_tensor_with_parallelism(
+                    parallel_upsert_key, parallel_update
+                ),
+                0,
+            )
+            self.assertTrue(
+                torch.equal(
+                    self.store.get_tensor(parallel_upsert_key), parallel_update
+                )
+            )
+
+            parallel_upsert_from_results = (
+                self.store.batch_upsert_tensor_with_parallelism_from(
+                    [parallel_upsert_from_key], [buffer_ptr], [buffer_size]
+                )
+            )
+            self.assertEqual(list(parallel_upsert_from_results), [0])
+            self.assertTrue(
+                torch.equal(
+                    self.store.get_tensor(parallel_upsert_from_key), tensor
+                )
+            )
+        finally:
+            self.store.unregister_buffer(buffer_ptr)
+            for cleanup_key in cleanup_keys:
+                self.store.remove(cleanup_key)
 
     # Mark this test as zzz_ so that it is the last test to run
     def zzz_test_dict_fuzz_e2e(self):

--- a/mooncake-wheel/tests/test_dummy_client.py
+++ b/mooncake-wheel/tests/test_dummy_client.py
@@ -485,6 +485,78 @@ class TestDistributedObjectStoreSingleStore(unittest.TestCase):
             for cleanup_key in cleanup_keys:
                 self.store.remove(cleanup_key)
 
+    def test_00_mixed_put_and_put_tensor_concurrency(self):
+        """Regression test for regular put and tensor put sharing dummy SHM."""
+        if torch is None:
+            self.skipTest("PyTorch is not available")
+
+        prefix = f"test_dummy_mixed_put_tensor_{os.getpid()}"
+        iterations = 16
+        regular_keys = [f"{prefix}_regular_{i}" for i in range(iterations)]
+        tensor_keys = [f"{prefix}_tensor_{i}" for i in range(iterations)]
+        regular_values = [
+            (f"regular-payload-{i}-".encode() * 4096)
+            for i in range(iterations)
+        ]
+        tensors = [
+            (torch.arange(4096, dtype=torch.float32) + i).reshape(64, 64)
+            for i in range(iterations)
+        ]
+
+        start = threading.Event()
+        errors = []
+        errors_lock = threading.Lock()
+
+        def record_error(message):
+            with errors_lock:
+                errors.append(message)
+
+        def put_regular_values():
+            try:
+                start.wait()
+                for key, value in zip(regular_keys, regular_values):
+                    ret = self.store.put(key, value)
+                    if ret != 0:
+                        record_error(f"put({key}) failed with {ret}")
+            except Exception as exc:
+                record_error(f"put thread raised {exc!r}")
+
+        def put_tensors():
+            try:
+                start.wait()
+                for key, tensor in zip(tensor_keys, tensors):
+                    ret = self.store.put_tensor(key, tensor)
+                    if ret != 0:
+                        record_error(f"put_tensor({key}) failed with {ret}")
+            except Exception as exc:
+                record_error(f"put_tensor thread raised {exc!r}")
+
+        threads = [
+            threading.Thread(target=put_regular_values),
+            threading.Thread(target=put_tensors),
+        ]
+        try:
+            for thread in threads:
+                thread.start()
+            start.set()
+            for thread in threads:
+                thread.join()
+
+            self.assertEqual(errors, [])
+
+            for key, expected in zip(regular_keys, regular_values):
+                self.assertEqual(self.store.get(key), expected)
+            for key, expected in zip(tensor_keys, tensors):
+                actual = self.store.get_tensor(key)
+                self.assertIsNotNone(actual)
+                self.assertTrue(torch.equal(actual, expected))
+        finally:
+            for thread in threads:
+                if thread.is_alive():
+                    thread.join()
+            for key in [*regular_keys, *tensor_keys]:
+                self.store.remove(key, force=True)
+
     # Mark this test as zzz_ so that it is the last test to run
     def zzz_test_dict_fuzz_e2e(self):
          """End-to-end fuzz test comparing distributed store behavior with dict.


### PR DESCRIPTION
## Description

This PR enables tensor APIs for dummy clients when the data path can use the dummy client's local shared-memory buffer and a real client mapped to the same SHM-backed buffer.

Before this change, many tensor APIs rejected dummy clients even when the dummy client already had a local buffer allocator. This blocked the deployment mode where worker processes use dummy clients without Store segments and forward data through a real client process.

Main changes:

- Initialize `client_buffer_allocator_` for dummy clients from the dummy local SHM buffer.
- Allow dummy clients to use tensor write APIs through `put_from` / `batch_put_from` style paths.
- Use accelerator-aware `CopyToHost` in the parallel tensor write helper so CUDA-addressed tensor sources are copied to host correctly.
- Enable dummy-client coverage for tensor `put`, `upsert`, `pub`, `_from`, `_into`, TP, and default-parallelism wrapper APIs where the underlying path is supported.
- Keep full materialized parallel tensor read conservative; dummy clients should use `_into` for the SHM-backed fast path.
- Add dummy+real tensor API tests.

## Module

- [x] Mooncake Store (`mooncake-store`)
- [x] Integration (`mooncake-integration`)
- [x] Python Wheel (`mooncake-wheel`)

## Type of Change

- [x] New feature
- [x] Bug fix
- [x] Refactor

## How Has This Been Tested?

**Test commands:**

```bash
# Format / syntax checks
clang-format-20 -style=file --dry-run -Werror \
  mooncake-integration/store/store_py.cpp \
  mooncake-integration/store/store_py_parallel_write.h \
  mooncake-store/src/dummy_client.cpp

python3 -m py_compile mooncake-wheel/tests/test_dummy_client.py
git diff --check

# Build
cmake --build build-dummy-tensor-nocuda \
  --target store mooncake_master mooncake_client -j16

# Dummy + real client tensor tests
cd mooncake-wheel/tests
python3 -m unittest -v test_dummy_client.py

# Multi dummy client smoke test
python3 test_multi_dummy_clients.py --client-id client1
python3 test_multi_dummy_clients.py --client-id client2
```

**Test results:**

- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing done

Manual testing covered:

- dummy client setup with local SHM buffer allocator
- real client mapped to the same dummy SHM buffer
- `put_tensor`
- `get_tensor`
- `get_tensor_into`
- `batch_get_tensor_into` invalid-argument handling
- `put_tensor_from`
- `batch_put_tensor`
- `batch_get_tensor`
- `upsert_tensor`
- `pub_tensor`
- `put_tensor_with_tp`
- `get_tensor_with_tp`
- `batch_put_tensor_with_tp`
- `put_tensor_with_parallelism`
- `batch_put_tensor_with_parallelism`
- `put_tensor_with_parallelism_from`
- `upsert_tensor_with_parallelism`
- `batch_upsert_tensor_with_parallelism_from`

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [x] AI tools were used

Codex was used to help implement, review, test, and prepare this PR. I reviewed the changes and is responsible for the final patch.