### PR TITLE
[CI/Build] Stabilize release wheel builds

### DIFF
--- a/.github/workflows/_build-wheel.yaml
+++ b/.github/workflows/_build-wheel.yaml
@@ -134,6 +134,9 @@ jobs:
           cmake "${gen[@]}" .. $CMAKE_ARGS "${ep[@]}" -DPython3_EXECUTABLE="$(which python3)"
 
       - name: Build project
+        env:
+          # Bound the nested Ninja build used by torch.utils.cpp_extension.
+          MAX_JOBS: "2"
         run: |
           for dir in /usr/local/cuda/lib64/stubs /usr/local/cuda/targets/*/lib/stubs; do
             [ -d "$dir" ] && export LIBRARY_PATH="$dir:${LIBRARY_PATH:-}"

--- a/mooncake-transfer-engine/fabric_allocator.cmake
+++ b/mooncake-transfer-engine/fabric_allocator.cmake
@@ -1,7 +1,7 @@
 function(add_fabric_allocator_build_target)
   set(options)
-  set(oneValueArgs TARGET_NAME BUILD_SCRIPT COMMENT ENABLE_BUILD)
-  set(multiValueArgs BUILD_ARGS)
+  set(oneValueArgs TARGET_NAME BUILD_SCRIPT OUTPUT_NAME COMMENT ENABLE_BUILD)
+  set(multiValueArgs BUILD_ARGS BUILD_DEPENDS)
   cmake_parse_arguments(FAB "${options}" "${oneValueArgs}" "${multiValueArgs}"
                         ${ARGN})
 
@@ -16,25 +16,29 @@ function(add_fabric_allocator_build_target)
         "BUILD_SCRIPT is required for add_fabric_allocator_build_target")
   endif()
 
-  add_custom_target(${FAB_TARGET_NAME} DEPENDS transfer_engine)
-
-  get_target_property(_include_dirs ${FAB_TARGET_NAME} INCLUDE_DIRECTORIES)
-  if(NOT _include_dirs)
-    set(_include_dirs "")
-  endif()
-  string(REPLACE ";" " " _include_dirs_str "${_include_dirs}")
-
   if(FAB_ENABLE_BUILD)
+    if(NOT FAB_OUTPUT_NAME)
+      message(
+        FATAL_ERROR
+          "OUTPUT_NAME is required for enabled fabric allocator build targets")
+    endif()
+
+    set(_output_path "${CMAKE_CURRENT_BINARY_DIR}/${FAB_OUTPUT_NAME}")
+    # Track the allocator artifact so install targets do not rebuild it after a
+    # successful normal build.
     add_custom_command(
-      TARGET ${FAB_TARGET_NAME}
-      POST_BUILD
+      OUTPUT "${_output_path}"
       COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}
       COMMAND bash ${FAB_BUILD_SCRIPT} ${FAB_BUILD_ARGS}
-              ${CMAKE_CURRENT_BINARY_DIR} "${_include_dirs_str}"
+              ${CMAKE_CURRENT_BINARY_DIR} ""
+      DEPENDS ${FAB_BUILD_SCRIPT} ${FAB_BUILD_DEPENDS}
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
       COMMENT "${FAB_COMMENT}"
       VERBATIM)
+    add_custom_target(${FAB_TARGET_NAME} ALL DEPENDS "${_output_path}")
+  else()
+    add_custom_target(${FAB_TARGET_NAME} ALL)
   endif()
 
-  set_property(TARGET ${FAB_TARGET_NAME} PROPERTY EXCLUDE_FROM_ALL FALSE)
+  add_dependencies(${FAB_TARGET_NAME} transfer_engine)
 endfunction()

--- a/mooncake-transfer-engine/fabric_allocator.cmake
+++ b/mooncake-transfer-engine/fabric_allocator.cmake
@@ -28,11 +28,11 @@ function(add_fabric_allocator_build_target)
     # successful normal build.
     add_custom_command(
       OUTPUT "${_output_path}"
-      COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}
-      COMMAND bash ${FAB_BUILD_SCRIPT} ${FAB_BUILD_ARGS}
-              ${CMAKE_CURRENT_BINARY_DIR} ""
-      DEPENDS ${FAB_BUILD_SCRIPT} ${FAB_BUILD_DEPENDS}
-      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+      COMMAND "${CMAKE_COMMAND}" -E make_directory "${CMAKE_CURRENT_BINARY_DIR}"
+      COMMAND bash "${FAB_BUILD_SCRIPT}" ${FAB_BUILD_ARGS}
+              "${CMAKE_CURRENT_BINARY_DIR}" ""
+      DEPENDS "${FAB_BUILD_SCRIPT}" ${FAB_BUILD_DEPENDS}
+      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
       COMMENT "${FAB_COMMENT}"
       VERBATIM)
     add_custom_target(${FAB_TARGET_NAME} ALL DEPENDS "${_output_path}")

--- a/mooncake-transfer-engine/nvlink-allocator/CMakeLists.txt
+++ b/mooncake-transfer-engine/nvlink-allocator/CMakeLists.txt
@@ -1,12 +1,19 @@
 include(${CMAKE_CURRENT_SOURCE_DIR}/../fabric_allocator.cmake)
 
 set(_extra_build_opts "")
+set(_extra_build_depends "")
 if(USE_HIP)
   list(APPEND _extra_build_opts --use-hipcc)
+  list(APPEND _extra_build_depends
+       ${CMAKE_CURRENT_SOURCE_DIR}/../include/gpu_vendor/hip.h)
 elseif(USE_MUSA)
   list(APPEND _extra_build_opts --use-mcc)
+  list(APPEND _extra_build_depends
+       ${CMAKE_CURRENT_SOURCE_DIR}/../include/gpu_vendor/musa.h)
 elseif(USE_MACA)
   list(APPEND _extra_build_opts --use-maca)
+  list(APPEND _extra_build_depends
+       ${CMAKE_CURRENT_SOURCE_DIR}/../include/gpu_vendor/maca.h)
 endif()
 
 set(_enable_nvlink_allocator_build FALSE)
@@ -30,6 +37,7 @@ add_fabric_allocator_build_target(
   ${CMAKE_CURRENT_SOURCE_DIR}/nvlink_allocator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/../include/cuda_alike.h
   ${CMAKE_CURRENT_SOURCE_DIR}/../scripts/allocator_build_common.sh
+  ${_extra_build_depends}
   COMMENT
   "Building nvlink allocator to ${CMAKE_CURRENT_BINARY_DIR}"
   ENABLE_BUILD

--- a/mooncake-transfer-engine/nvlink-allocator/CMakeLists.txt
+++ b/mooncake-transfer-engine/nvlink-allocator/CMakeLists.txt
@@ -22,8 +22,14 @@ add_fabric_allocator_build_target(
   build_nvlink_allocator
   BUILD_SCRIPT
   ${CMAKE_CURRENT_SOURCE_DIR}/build.sh
+  OUTPUT_NAME
+  nvlink_allocator.so
   BUILD_ARGS
   ${_extra_build_opts}
+  BUILD_DEPENDS
+  ${CMAKE_CURRENT_SOURCE_DIR}/nvlink_allocator.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../include/cuda_alike.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/../scripts/allocator_build_common.sh
   COMMENT
   "Building nvlink allocator to ${CMAKE_CURRENT_BINARY_DIR}"
   ENABLE_BUILD

--- a/mooncake-transfer-engine/ubshmem-allocator/CMakeLists.txt
+++ b/mooncake-transfer-engine/ubshmem-allocator/CMakeLists.txt
@@ -10,6 +10,12 @@ add_fabric_allocator_build_target(
   build_ubshmem_allocator
   BUILD_SCRIPT
   ${CMAKE_CURRENT_SOURCE_DIR}/build.sh
+  OUTPUT_NAME
+  ubshmem_fabric_allocator.so
+  BUILD_DEPENDS
+  ${CMAKE_CURRENT_SOURCE_DIR}/ubshmem_fabric_allocator.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../include/cuda_alike.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/../scripts/allocator_build_common.sh
   COMMENT
   "Building ubshmem allocator to ${CMAKE_CURRENT_BINARY_DIR}"
   ENABLE_BUILD

--- a/mooncake-transfer-engine/ubshmem-allocator/CMakeLists.txt
+++ b/mooncake-transfer-engine/ubshmem-allocator/CMakeLists.txt
@@ -15,6 +15,7 @@ add_fabric_allocator_build_target(
   BUILD_DEPENDS
   ${CMAKE_CURRENT_SOURCE_DIR}/ubshmem_fabric_allocator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/../include/cuda_alike.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/../include/gpu_vendor/ubshmem.h
   ${CMAKE_CURRENT_SOURCE_DIR}/../scripts/allocator_build_common.sh
   COMMENT
   "Building ubshmem allocator to ${CMAKE_CURRENT_BINARY_DIR}"


### PR DESCRIPTION
## Description

Stabilize release wheel builds against two independent CI failure modes:

- Limit the nested Ninja build used by `torch.utils.cpp_extension` to `MAX_JOBS=2`, reducing peak memory pressure while compiling Mooncake EP CUDA extensions.
- Model the NVLink and UBSHMEM allocator shared libraries as explicit CMake outputs with source dependencies. This prevents `make install` from rebuilding allocator targets after a successful normal build.

The CUDA 13 release runner previously lost communication while building the Python 3.13 EP extension, consistent with memory pressure from unconstrained nested parallelism. The EFA release build completed the first NVLink allocator link, then `sudo make install` reran the always-dirty custom target after `sudo` removed the CUDA stub library search path, failing with `cannot find -lcuda`.

Related CI failures:

- https://github.com/kvcache-ai/Mooncake/actions/runs/29716668778/job/88271198794
- https://github.com/kvcache-ai/Mooncake/actions/runs/29716668618/job/88271198155

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [x] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
pre-commit run --files .github/workflows/_build-wheel.yaml mooncake-transfer-engine/fabric_allocator.cmake mooncake-transfer-engine/nvlink-allocator/CMakeLists.txt mooncake-transfer-engine/ubshmem-allocator/CMakeLists.txt
git diff --check
```

A temporary Unix Makefiles CMake fixture also exercised the allocator helper and verified that:

1. the initial build generates the allocator once;
2. the install target does not rebuild it;
3. changing an input source rebuilds it exactly once;
4. a subsequent install still does not rebuild it.

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (described above)

A full CUDA/EFA release build requires the corresponding GitHub-hosted CI environment.

## Checklist

- [ ] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (not applicable; no user-facing behavior changed)
- [ ] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue (not applicable; this change is under 500 LOC)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex was used to inspect the failing GitHub Actions logs, identify both root causes, implement the CMake/workflow changes, and run targeted validation. The human submitter must review every changed line and be able to defend the change end-to-end before marking this draft ready for review.