### PR TITLE
[CI/Build] Prevent CI out-of-space failures

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -1,0 +1,15 @@
+name: Free runner disk space
+description: Remove preinstalled toolchains that Mooncake CI does not use
+
+runs:
+  using: composite
+  steps:
+    - name: Remove unused runner tools
+      shell: bash
+      run: |
+        sudo rm -rf -- \
+          /usr/share/dotnet \
+          /opt/ghc \
+          /opt/hostedtoolcache/CodeQL \
+          /usr/local/lib/android
+        df -h

--- a/.github/workflows/_build-wheel.yaml
+++ b/.github/workflows/_build-wheel.yaml
@@ -94,9 +94,7 @@ jobs:
 
       - name: Free up disk space
         if: ${{ inputs.container == '' }}
-        run: |
-          sudo rm -rf /usr/share/dotnet /opt/ghc /opt/hostedtoolcache/CodeQL /usr/local/lib/android
-          df -h
+        uses: ./.github/actions/free-disk-space
 
       - name: Install CUDA Toolkit (arm64 SBSA)
         if: ${{ startsWith(inputs.cuda, 'sbsa-') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,10 +57,7 @@ jobs:
       shell: bash
 
     - name: Free up disk space
-      run: |
-        sudo rm -rf /usr/share/dotnet
-        sudo rm -rf /opt/ghc
-        sudo rm -rf /opt/hostedtoolcache/CodeQL
+      uses: ./.github/actions/free-disk-space
 
     - name: Install CUDA Toolkit
       uses: Jimver/cuda-toolkit@v0.2.24
@@ -348,10 +345,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Free up disk space
-      run: |
-        sudo rm -rf /usr/share/dotnet
-        sudo rm -rf /opt/ghc
-        sudo rm -rf /opt/hostedtoolcache/CodeQL
+      uses: ./.github/actions/free-disk-space
 
     - name: Install CUDA Toolkit 13.0 (arm64 SBSA)
       run: |
@@ -462,12 +456,7 @@ jobs:
       shell: bash
 
     - name: Free up disk space
-      run: |
-        sudo rm -rf /usr/share/dotnet
-        sudo rm -rf /opt/ghc
-        sudo rm -rf /opt/hostedtoolcache/CodeQL
-        sudo rm -rf /usr/local/lib/android
-        df -h
+      uses: ./.github/actions/free-disk-space
 
     - name: Install CUDA Toolkit
       uses: Jimver/cuda-toolkit@v0.2.24
@@ -603,6 +592,9 @@ jobs:
       TORCH_CUDA_ARCH_LIST: "8.0;9.0"
       SCCACHE_GHA_ENABLED: "true"
       PIP_NO_CACHE_DIR: "1"
+      MAX_JOBS: "2"
+      EP_TORCH_VERSIONS: "2.11.0;2.12.0;2.12.1"
+      CMAKE_RELWITHDEBINFO_FLAGS: "-O2 -DNDEBUG"
 
     steps:
     - uses: actions/checkout@v4
@@ -615,12 +607,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Free up disk space
-      run: |
-        sudo rm -rf /usr/share/dotnet
-        sudo rm -rf /opt/ghc
-        sudo rm -rf /opt/hostedtoolcache/CodeQL
-        sudo rm -rf /usr/local/lib/android
-        df -h
+      uses: ./.github/actions/free-disk-space
 
     - name: Install CUDA Toolkit
       uses: Jimver/cuda-toolkit@v0.2.24
@@ -659,9 +646,27 @@ jobs:
         cd build
         export PATH=/usr/local/nvidia/bin:/usr/local/nvidia/lib64:$PATH
         export LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH
-        cmake -G Ninja .. -DUSE_ETCD=OFF -DUSE_CXL=ON -DUSE_REDIS=ON -DUSE_HTTP=ON -DWITH_METRICS=ON -DBUILD_UNIT_TESTS=ON -DBUILD_EXAMPLES=ON -DENABLE_SCCACHE=ON -DUSE_CUDA=OFF -DUSE_MNNVL=OFF -DUSE_UB=OFF -DCMAKE_EXE_LINKER_FLAGS="-L/usr/local/cuda/lib64/stubs" -DENABLE_DEBUG_SYMBOLS=OFF
+        cmake -G Ninja .. \
+          -DUSE_ETCD=OFF \
+          -DUSE_CXL=ON \
+          -DUSE_REDIS=ON \
+          -DUSE_HTTP=ON \
+          -DWITH_METRICS=ON \
+          -DBUILD_UNIT_TESTS=ON \
+          -DBUILD_EXAMPLES=ON \
+          -DENABLE_SCCACHE=ON \
+          -DUSE_CUDA=OFF \
+          -DUSE_MNNVL=OFF \
+          -DUSE_UB=OFF \
+          -DCMAKE_EXE_LINKER_FLAGS="-L/usr/local/cuda/lib64/stubs" \
+          "-DCMAKE_C_FLAGS_RELWITHDEBINFO=${CMAKE_RELWITHDEBINFO_FLAGS}" \
+          "-DCMAKE_CXX_FLAGS_RELWITHDEBINFO=${CMAKE_RELWITHDEBINFO_FLAGS}" \
+          -DENABLE_DEBUG_SYMBOLS=OFF
         cmake --build .
         sudo cmake --install .
+        df -h
+        cd ..
+        rm -rf build
         df -h
       shell: bash
 
@@ -669,7 +674,25 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake -G Ninja .. -DUSE_ETCD=ON -DUSE_CXL=ON -DUSE_REDIS=ON -DUSE_HTTP=ON -DWITH_STORE=ON -DWITH_P2P_STORE=ON -DWITH_METRICS=ON -DBUILD_UNIT_TESTS=ON -DBUILD_EXAMPLES=ON -DENABLE_SCCACHE=ON -DUSE_CUDA=ON -DUSE_MNNVL=OFF -DUSE_UB=OFF -DCMAKE_EXE_LINKER_FLAGS="-L/usr/local/cuda/lib64/stubs" -DENABLE_DEBUG_SYMBOLS=OFF
+        # ENABLE_DEBUG_SYMBOLS=OFF alone still leaves CMake's RelWithDebInfo -g.
+        cmake -G Ninja .. \
+          -DUSE_ETCD=ON \
+          -DUSE_CXL=ON \
+          -DUSE_REDIS=ON \
+          -DUSE_HTTP=ON \
+          -DWITH_STORE=ON \
+          -DWITH_P2P_STORE=ON \
+          -DWITH_METRICS=ON \
+          -DBUILD_UNIT_TESTS=ON \
+          -DBUILD_EXAMPLES=ON \
+          -DENABLE_SCCACHE=ON \
+          -DUSE_CUDA=ON \
+          -DUSE_MNNVL=OFF \
+          -DUSE_UB=OFF \
+          -DCMAKE_EXE_LINKER_FLAGS="-L/usr/local/cuda/lib64/stubs" \
+          "-DCMAKE_C_FLAGS_RELWITHDEBINFO=${CMAKE_RELWITHDEBINFO_FLAGS}" \
+          "-DCMAKE_CXX_FLAGS_RELWITHDEBINFO=${CMAKE_RELWITHDEBINFO_FLAGS}" \
+          -DENABLE_DEBUG_SYMBOLS=OFF
       shell: bash
       # TODO: lack USE_NVMEOF,USE_MNNVL
 
@@ -713,13 +736,22 @@ jobs:
         MOONCAKE_STORE_LIB_DIR=$GITHUB_WORKSPACE/build/mooncake-store/src \
         MOONCAKE_STORE_INCLUDE_DIR=$GITHUB_WORKSPACE/mooncake-store/include \
           cargo test --examples --tests --no-run
+        cargo clean
       shell: bash
 
     - name: Configure project
       run: |
         cd build
         rm -r */tests
-        cmake -G Ninja .. -DBUILD_UNIT_TESTS=OFF -DBUILD_EXAMPLES=OFF -DUSE_HTTP=ON -DENABLE_SCCACHE=ON -DUSE_CXL=ON -DWITH_EP=ON -DEP_TORCH_VERSIONS="2.11.0;2.12.0;2.12.1" -DENABLE_DEBUG_SYMBOLS=OFF
+        cmake -G Ninja .. \
+          -DBUILD_UNIT_TESTS=OFF \
+          -DBUILD_EXAMPLES=OFF \
+          -DUSE_HTTP=ON \
+          -DENABLE_SCCACHE=ON \
+          -DUSE_CXL=ON \
+          -DWITH_EP=ON \
+          "-DEP_TORCH_VERSIONS=${EP_TORCH_VERSIONS}" \
+          -DENABLE_DEBUG_SYMBOLS=OFF
       shell: bash
 
     - name: Build project
@@ -780,6 +812,9 @@ jobs:
       with:
         persist-credentials: false
 
+    - name: Free up disk space
+      uses: ./.github/actions/free-disk-space
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
 
@@ -788,6 +823,7 @@ jobs:
         docker build -f docker/mooncake.Dockerfile \
           --build-arg PYTHON_VERSION=3.10 \
           --build-arg EP_TORCH_VERSIONS="2.12.1" \
+          --build-arg CLEAN_BUILD_ARTIFACTS=1 \
           -t mooncake:from-source .
 
   spell-check:
@@ -932,6 +968,7 @@ jobs:
               - 'CMakeLists.txt'
               - 'dependencies.sh'
               - 'scripts/**'
+              - '.github/actions/**'
               - '.github/workflows/**'
             tent:
               - 'mooncake-transfer-engine/**'
@@ -1008,12 +1045,7 @@ jobs:
 
     - name: Free up disk space
       if: matrix.need_cuda
-      run: |
-        sudo rm -rf /usr/share/dotnet
-        sudo rm -rf /opt/ghc
-        sudo rm -rf /opt/hostedtoolcache/CodeQL
-        sudo rm -rf /usr/local/lib/android
-        df -h
+      uses: ./.github/actions/free-disk-space
 
     - name: Install CUDA Toolkit
       if: matrix.need_cuda

--- a/.github/workflows/ci_cu13.yml
+++ b/.github/workflows/ci_cu13.yml
@@ -26,12 +26,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Free up disk space
-      run: |
-        sudo rm -rf /usr/share/dotnet
-        sudo rm -rf /opt/ghc
-        sudo rm -rf /opt/hostedtoolcache/CodeQL
-        sudo rm -rf /usr/local/lib/android
-        df -h
+      uses: ./.github/actions/free-disk-space
 
     - name: Install CUDA Toolkit
       uses: Jimver/cuda-toolkit@v0.2.29

--- a/.github/workflows/ci_efa.yml
+++ b/.github/workflows/ci_efa.yml
@@ -46,12 +46,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Free up disk space
-      run: |
-        sudo rm -rf /usr/share/dotnet
-        sudo rm -rf /opt/ghc
-        sudo rm -rf /opt/hostedtoolcache/CodeQL
-        sudo rm -rf /usr/local/lib/android
-        df -h
+      uses: ./.github/actions/free-disk-space
 
     - name: Install CUDA Toolkit
       if: matrix.use_cuda == 'ON'

--- a/.github/workflows/publish-master-image.yaml
+++ b/.github/workflows/publish-master-image.yaml
@@ -83,12 +83,7 @@ jobs:
           PY
 
       - name: Free up disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo rm -rf /usr/local/lib/android
-          df -h
+        uses: ./.github/actions/free-disk-space
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/release-efa-non-cuda.yaml
+++ b/.github/workflows/release-efa-non-cuda.yaml
@@ -40,11 +40,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Free up disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo rm -rf /usr/local/lib/android
+        uses: ./.github/actions/free-disk-space
 
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9

--- a/.github/workflows/release-efa.yaml
+++ b/.github/workflows/release-efa.yaml
@@ -40,11 +40,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Free up disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo rm -rf /usr/local/lib/android
+        uses: ./.github/actions/free-disk-space
 
       - name: Install CUDA Toolkit
         uses: Jimver/cuda-toolkit@v0.2.24

--- a/docker/mooncake.Dockerfile
+++ b/docker/mooncake.Dockerfile
@@ -9,13 +9,16 @@ ARG UBUNTU_VERSION=22.04
 FROM nvidia/cuda:${CUDA_VERSION}-devel-ubuntu${UBUNTU_VERSION} AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive \
-    PYTHONUNBUFFERED=1
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
 
 ARG PYTHON_VERSION=3.10
 ARG PYPA_INDEX_URL=https://bootstrap.pypa.io
 ARG CMAKE_BUILD_TYPE=Release
 ARG EP_TORCH_VERSIONS="2.12.1"
 ARG TORCH_CUDA_ARCH_LIST="8.0;9.0"
+# CI can opt in to removing /workspace/build from the builder layer.
+ARG CLEAN_BUILD_ARTIFACTS=0
 
 ENV PYTHON_VERSION=${PYTHON_VERSION} \
     BUILD_WITH_EP=1 \
@@ -50,7 +53,9 @@ COPY . /workspace
 # Install Mooncake dependencies (yalantinglibs, Go, etc.)
 RUN bash dependencies.sh -y
 
-# Configure & build Mooncake
+# Configure and build the wheel in one layer, then remove build/ only after
+# auditwheel has resolved libraries from it. The large intermediate tree is
+# therefore not retained in the builder image or BuildKit cache.
 RUN mkdir -p build && \
     cd build && \
     cmake -G Ninja .. \
@@ -63,18 +68,19 @@ RUN mkdir -p build && \
         -DPython3_EXECUTABLE=/usr/bin/python${PYTHON_VERSION} \
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} && \
     export LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LIBRARY_PATH && \
-    cmake --build .
-
-# Build nvlink allocator to make wheel self-contained for CUDA paths
-RUN export PATH=/usr/local/nvidia/bin:/usr/local/nvidia/lib64:$PATH && \
+    cmake --build . && \
+    cd /workspace && \
+    export PATH=/usr/local/nvidia/bin:/usr/local/nvidia/lib64:$PATH && \
     export LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH && \
     export LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LIBRARY_PATH && \
     mkdir -p build/mooncake-transfer-engine/nvlink-allocator && \
     cd mooncake-transfer-engine/nvlink-allocator && \
-    bash build.sh ../../build/mooncake-transfer-engine/nvlink-allocator/
-
-# Build the Python wheel from local sources
-RUN OUTPUT_DIR=dist ./scripts/build_wheel.sh
+    bash build.sh ../../build/mooncake-transfer-engine/nvlink-allocator/ && \
+    cd /workspace && \
+    OUTPUT_DIR=dist ./scripts/build_wheel.sh && \
+    if [ "${CLEAN_BUILD_ARTIFACTS}" = "1" ]; then \
+        rm -rf build; \
+    fi
 
 ###############################################################################
 # Stage 2: install the freshly built wheel into a runtime image


### PR DESCRIPTION
## Description

Fix CI `No space left on device` failures by reducing peak runner and Docker
storage usage. The temporary disk-usage instrumentation used during diagnosis
has been removed; this PR now contains only the resulting CI and Docker fixes.

The main source of pressure was the `build-flags` job reusing one runner for
several large build phases. CMake's default `RelWithDebInfo` flags still added
`-g` even with `ENABLE_DEBUG_SYMBOLS=OFF`, while completed CMake/Rust
artifacts, nested Torch builds, pip caches, preinstalled runner tools, and
Docker intermediate layers remained on disk.

The fix:

- Reuse a small `free-disk-space` composite action to remove preinstalled
  toolchains unused by Mooncake CI.
- Preserve `RelWithDebInfo` optimization and `NDEBUG` behavior while
  removing debug information with `-O2 -DNDEBUG`.
- Remove the completed standalone Transfer Engine build before the full root
  build and clean Rust test artifacts after validation.
- Bound nested Torch extension builds with `MAX_JOBS=2` and disable pip
  caching in the high-pressure build and Docker paths.
- Keep the intentional Torch compatibility matrix at `2.11.0`, `2.12.0`,
  and `2.12.1`; no version or extension artifact is dropped.
- Build CMake, NVLink, and the wheel in one Docker layer. CI opts into removing
  the build tree after the wheel is complete, while normal and
  `--target builder` builds retain it by default.

The EP/PG CMake implementation is unchanged from `main`.

### Measured impact

Measurements collected while diagnosing the issue showed:

- Before the EP matrix, runner usage dropped from 67 GiB to 50 GiB and the
  workspace dropped from 17 GiB to 1.1 GiB.
- The one-layer Docker build reduced runner usage after the build by about
  3 GiB and BuildKit cache usage from 13.33 GB to 9.868 GB.

Measurement runs:

- Baseline: https://github.com/kvcache-ai/Mooncake/actions/runs/29744521176
- Optimized build-flags comparison:
  https://github.com/kvcache-ai/Mooncake/actions/runs/29748158503
- One-layer Docker comparison:
  https://github.com/kvcache-ai/Mooncake/actions/runs/29750311623

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**

```bash
pre-commit run --files <changed workflow and Docker files>
pre-commit run check-yaml --files <changed workflow files>
git diff --check ac010838926e3cff2659465bd9b7bf6c0e9656bf
git diff --exit-code ac010838926e3cff2659465bd9b7bf6c0e9656bf -- <EP/PG CMake files>
```

Additional targeted validation:

- Both `CLEAN_BUILD_ARTIFACTS=0` and `=1` cleanup branches were exercised;
  the default retains `build/` and the CI value removes it.
- The linked optimized build-flags and one-layer Docker runs completed
  successfully.
- The final diff contains only CI/workflow and Docker files; all EP/PG CMake
  files are identical to the merge base.

**Test results:**

- [x] Unit tests pass in the linked GitHub Actions run
- [ ] Integration tests pass (current head CI in progress)
- [x] Manual testing done as described above

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted the changed code
- [ ] I have run `pre-commit run --all-files` (targeted hooks pass)
- [x] I have updated the documentation (not applicable; no user-facing change)
- [ ] I have added repository tests (not applicable to workflow-only behavior)
- [x] For changes >500 LOC: not applicable; the final diff is under 500 LOC

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used

Codex analyzed CI storage measurements and failure phases, implemented and
refined the disk-reduction changes, reviewed the final diff, and ran targeted
validation. The human submitter is responsible for reviewing every changed
line and defending the change end-to-end.
