### PR TITLE
[Store] Implement asynchronous P2P Redis oplog persistence

### DIFF
--- a/mooncake-store/include/ha/oplog/oplog_applier.h
+++ b/mooncake-store/include/ha/oplog/oplog_applier.h
@@ -97,6 +97,8 @@ class OpLogApplier {
     virtual bool ApplyCustomOpLogEntry(const OpLogEntry& entry);
 
    private:
+    bool ApplyOpLogEntryInternal(const OpLogEntry& entry);
+
     /**
      * @brief Check if the entry's sequence order is valid
      * @param entry OpLog entry

--- a/mooncake-store/include/ha/oplog/oplog_applier.h
+++ b/mooncake-store/include/ha/oplog/oplog_applier.h
@@ -91,6 +91,11 @@ class OpLogApplier {
     };
     GapResolveResult TryResolveGapsOnceForPromotion(size_t max_ids = 1024);
 
+   protected:
+    // Subclasses implement backend-specific operations while reusing the
+    // common validation, ordering, gap buffering and timeout-skip machinery.
+    virtual bool ApplyCustomOpLogEntry(const OpLogEntry& entry);
+
    private:
     /**
      * @brief Check if the entry's sequence order is valid

--- a/mooncake-store/include/ha/oplog/oplog_store_factory.h
+++ b/mooncake-store/include/ha/oplog/oplog_store_factory.h
@@ -76,7 +76,9 @@ class OpLogStoreFactory {
         const std::string& oplog_root_dir = kDefaultOpLogRootDir,
         int poll_interval_ms = kDefaultOpLogPollIntervalMs,
         const std::string& password = "", const std::string& username = "",
-        int db_index = 0);
+        int db_index = 0, size_t async_queue_max_entries = 100000,
+        const std::string& async_queue_overflow_mode = "reject",
+        size_t best_effort_max_retries = 3);
 };
 
 }  // namespace mooncake

--- a/mooncake-store/include/ha/oplog/p2p_oplog_applier.h
+++ b/mooncake-store/include/ha/oplog/p2p_oplog_applier.h
@@ -33,13 +33,11 @@ class P2POpLogApplier : public OpLogApplier {
                              const std::string& cluster_id = std::string(),
                              OpLogStore* oplog_store = nullptr);
 
-    /// Override to handle P2P-specific OpTypes.
-    /// Falls back to OpLogApplier::ApplyOpLogEntry for PUT_END, PUT_REVOKE,
-    /// and REMOVE.
-    bool ApplyOpLogEntry(const OpLogEntry& entry) override;
-
     /// Get the underlying P2P metadata store.
     P2PStandbyMetadataStore* GetP2PMetadataStore() const { return p2p_store_; }
+
+   protected:
+    bool ApplyCustomOpLogEntry(const OpLogEntry& entry) override;
 
    private:
     // Apply individual P2P OpTypes. Return true on success.

--- a/mooncake-store/include/ha/oplog/redis_oplog_store.h
+++ b/mooncake-store/include/ha/oplog/redis_oplog_store.h
@@ -16,10 +16,17 @@
 #include <hiredis/hiredis.h>
 
 #include "ha/oplog/oplog_store.h"
+#include "ha/oplog/p2p_oplog_types.h"
 #include "mutex.h"
 #include "redis_util.h"
 
 namespace mooncake {
+
+enum class OpLogAsyncQueueOverflowMode { REJECT, BYPASS };
+
+inline bool IsBestEffortRedisOpLog(OpType type) {
+    return type == OpType_ADD_REPLICA;
+}
 
 class RedisOpLogStore : public OpLogStore {
    public:
@@ -27,7 +34,11 @@ class RedisOpLogStore : public OpLogStore {
                     const std::string& redis_endpoint, bool enable_write,
                     int poll_interval_ms = 1000,
                     const std::string& password = "",
-                    const std::string& username = "", int db_index = 0);
+                    const std::string& username = "", int db_index = 0,
+                    size_t async_queue_max_entries = 100000,
+                    OpLogAsyncQueueOverflowMode async_queue_overflow_mode =
+                        OpLogAsyncQueueOverflowMode::REJECT,
+                    size_t best_effort_max_retries = 3);
     ~RedisOpLogStore() override;
 
     RedisOpLogStore(const RedisOpLogStore&) = delete;
@@ -86,9 +97,14 @@ class RedisOpLogStore : public OpLogStore {
     bool enable_write_;
     int poll_interval_ms_;
 
+    // P2P metadata is memory-first and is not transactionally coupled with its
+    // OpLog. Redis persistence runs on background workers. The queue is
+    // strictly bounded: overflow follows the configured reject/bypass
+    // degradation policy. Once admitted, required entries retry indefinitely,
+    // while best-effort entries use bounded retries.
+    //
     // Redis oplog key model:
-    // - latest: committed contiguous sequence watermark, safe for standby
-    // replay
+    // - latest: committed progress watermark; dropped entries may leave holes
     // - trimmed: highest sequence already removed by cleanup
     // - entry:<seq>: serialized oplog payload
     std::string key_tag_;
@@ -106,12 +122,15 @@ class RedisOpLogStore : public OpLogStore {
     std::map<uint64_t, std::shared_ptr<PendingWrite>> inflight_writes_
         GUARDED_BY(async_mutex_);
     std::set<uint64_t> persisted_sequences_ GUARDED_BY(async_mutex_);
+    std::set<uint64_t> dropped_sequences_ GUARDED_BY(async_mutex_);
     uint64_t committed_sequence_id_ GUARDED_BY(async_mutex_) = 0;
     std::atomic<bool> async_running_{false};
     std::vector<std::thread> async_workers_;
+    size_t async_queue_max_entries_;
+    OpLogAsyncQueueOverflowMode async_queue_overflow_mode_;
+    size_t best_effort_max_retries_;
 
     static constexpr size_t kAsyncWorkerCount = 4;
-    static constexpr size_t kMaxAsyncQueueSize = 100000;
     static constexpr size_t kCleanupBatchSize = 1000;
     static constexpr int kAsyncRetryDelayMs = 100;
     static constexpr int kSyncWaitTimeoutMs = 30000;

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -32,6 +32,9 @@ struct MasterConfig {
     bool enable_oplog = false;
     std::string oplog_store_type = "localfs";
     std::string oplog_data_dir = "/tmp/mooncake_oplog";
+    uint64_t oplog_async_queue_max_entries = 100000;
+    std::string oplog_async_queue_overflow_mode = "reject";
+    uint64_t oplog_best_effort_max_retries = 3;
     bool enable_offload;
     std::string etcd_endpoints;
 
@@ -127,6 +130,9 @@ class MasterServiceSupervisorConfig {
     bool enable_oplog = false;
     std::string oplog_store_type = "localfs";
     std::string oplog_data_dir = "/tmp/mooncake_oplog";
+    uint64_t oplog_async_queue_max_entries = 100000;
+    std::string oplog_async_queue_overflow_mode = "reject";
+    uint64_t oplog_best_effort_max_retries = 3;
     uint32_t max_total_finished_tasks = DEFAULT_MAX_TOTAL_FINISHED_TASKS;
     uint32_t max_total_pending_tasks = DEFAULT_MAX_TOTAL_PENDING_TASKS;
     uint32_t max_total_processing_tasks = DEFAULT_MAX_TOTAL_PROCESSING_TASKS;
@@ -194,6 +200,10 @@ class MasterServiceSupervisorConfig {
         enable_oplog = config.enable_oplog;
         oplog_store_type = config.oplog_store_type;
         oplog_data_dir = config.oplog_data_dir;
+        oplog_async_queue_max_entries = config.oplog_async_queue_max_entries;
+        oplog_async_queue_overflow_mode =
+            config.oplog_async_queue_overflow_mode;
+        oplog_best_effort_max_retries = config.oplog_best_effort_max_retries;
 
         max_total_finished_tasks = config.max_total_finished_tasks;
         max_total_pending_tasks = config.max_total_pending_tasks;
@@ -318,6 +328,9 @@ class WrappedMasterServiceConfig {
     bool enable_oplog = false;
     std::string oplog_store_type = "localfs";
     std::string oplog_data_dir = "/tmp/mooncake_oplog";
+    uint64_t oplog_async_queue_max_entries = 100000;
+    std::string oplog_async_queue_overflow_mode = "reject";
+    uint64_t oplog_best_effort_max_retries = 3;
     std::string redis_endpoint;
     std::string redis_username;
     std::string redis_password;
@@ -367,6 +380,10 @@ class WrappedMasterServiceConfig {
         enable_oplog = config.enable_oplog;
         oplog_store_type = config.oplog_store_type;
         oplog_data_dir = config.oplog_data_dir;
+        oplog_async_queue_max_entries = config.oplog_async_queue_max_entries;
+        oplog_async_queue_overflow_mode =
+            config.oplog_async_queue_overflow_mode;
+        oplog_best_effort_max_retries = config.oplog_best_effort_max_retries;
         redis_endpoint = config.redis_endpoint;
         redis_username = config.redis_username;
         redis_password = config.redis_password;
@@ -421,6 +438,10 @@ class WrappedMasterServiceConfig {
         enable_oplog = config.enable_oplog;
         oplog_store_type = config.oplog_store_type;
         oplog_data_dir = config.oplog_data_dir;
+        oplog_async_queue_max_entries = config.oplog_async_queue_max_entries;
+        oplog_async_queue_overflow_mode =
+            config.oplog_async_queue_overflow_mode;
+        oplog_best_effort_max_retries = config.oplog_best_effort_max_retries;
         redis_endpoint = config.redis_endpoint;
         redis_username = config.redis_username;
         redis_password = config.redis_password;
@@ -470,6 +491,9 @@ class MasterServiceConfigBuilder {
     bool enable_oplog_ = false;
     std::string oplog_store_type_ = "localfs";
     std::string oplog_data_dir_ = "/tmp/mooncake_oplog";
+    uint64_t oplog_async_queue_max_entries_ = 100000;
+    std::string oplog_async_queue_overflow_mode_ = "reject";
+    uint64_t oplog_best_effort_max_retries_ = 3;
     bool enable_offload_ = false;
     std::string cluster_id_ = DEFAULT_CLUSTER_ID;
     std::string root_fs_dir_ = DEFAULT_ROOT_FS_DIR;
@@ -553,6 +577,24 @@ class MasterServiceConfigBuilder {
 
     MasterServiceConfigBuilder& set_oplog_data_dir(const std::string& dir) {
         oplog_data_dir_ = dir;
+        return *this;
+    }
+
+    MasterServiceConfigBuilder& set_oplog_async_queue_max_entries(
+        uint64_t max_entries) {
+        oplog_async_queue_max_entries_ = max_entries;
+        return *this;
+    }
+
+    MasterServiceConfigBuilder& set_oplog_async_queue_overflow_mode(
+        const std::string& mode) {
+        oplog_async_queue_overflow_mode_ = mode;
+        return *this;
+    }
+
+    MasterServiceConfigBuilder& set_oplog_best_effort_max_retries(
+        uint64_t max_retries) {
+        oplog_best_effort_max_retries_ = max_retries;
         return *this;
     }
 
@@ -671,6 +713,9 @@ class MasterServiceConfig {
     bool enable_oplog = false;
     std::string oplog_store_type = "localfs";
     std::string oplog_data_dir = "/tmp/mooncake_oplog";
+    uint64_t oplog_async_queue_max_entries = 100000;
+    std::string oplog_async_queue_overflow_mode = "reject";
+    uint64_t oplog_best_effort_max_retries = 3;
     std::string redis_endpoint;
     std::string redis_username;
     std::string redis_password;
@@ -716,6 +761,10 @@ class MasterServiceConfig {
         enable_oplog = config.enable_oplog;
         oplog_store_type = config.oplog_store_type;
         oplog_data_dir = config.oplog_data_dir;
+        oplog_async_queue_max_entries = config.oplog_async_queue_max_entries;
+        oplog_async_queue_overflow_mode =
+            config.oplog_async_queue_overflow_mode;
+        oplog_best_effort_max_retries = config.oplog_best_effort_max_retries;
         redis_endpoint = config.redis_endpoint;
         redis_username = config.redis_username;
         redis_password = config.redis_password;
@@ -765,6 +814,9 @@ inline MasterServiceConfig MasterServiceConfigBuilder::build() const {
     config.enable_oplog = enable_oplog_;
     config.oplog_store_type = oplog_store_type_;
     config.oplog_data_dir = oplog_data_dir_;
+    config.oplog_async_queue_max_entries = oplog_async_queue_max_entries_;
+    config.oplog_async_queue_overflow_mode = oplog_async_queue_overflow_mode_;
+    config.oplog_best_effort_max_retries = oplog_best_effort_max_retries_;
     config.enable_offload = enable_offload_;
     config.cluster_id = cluster_id_;
     config.root_fs_dir = root_fs_dir_;

--- a/mooncake-store/include/p2p_master_service.h
+++ b/mooncake-store/include/p2p_master_service.h
@@ -84,8 +84,7 @@ class P2PMasterService : public MasterService {
         uint64_t last_applied_sequence_id = 0);
 
     ErrorCode RecordOplog(OpType type, const std::string& key,
-                          const std::string& payload = std::string(),
-                          bool sync = true);
+                          const std::string& payload = std::string());
 
     std::vector<Replica::Descriptor> FilterReplicas(
         const GetReplicaListRequestConfig& config,
@@ -137,7 +136,7 @@ class P2PMasterService : public MasterService {
     // 1. max_replicas_per_key_ == 0 means no limitation
     // 2. max_replicas_per_key_ > 0 means the max client owner count
     uint64_t max_replicas_per_key_;
-    bool async_oplog_{false};
+    bool enable_async_oplog_write_{false};
 };
 
 }  // namespace mooncake

--- a/mooncake-store/include/p2p_master_service.h
+++ b/mooncake-store/include/p2p_master_service.h
@@ -137,7 +137,7 @@ class P2PMasterService : public MasterService {
     // 1. max_replicas_per_key_ == 0 means no limitation
     // 2. max_replicas_per_key_ > 0 means the max client owner count
     uint64_t max_replicas_per_key_;
-    bool async_add_replica_oplog_{false};
+    bool async_oplog_{false};
 };
 
 }  // namespace mooncake

--- a/mooncake-store/src/ha/oplog/oplog_applier.cpp
+++ b/mooncake-store/src/ha/oplog/oplog_applier.cpp
@@ -119,25 +119,12 @@ bool OpLogApplier::ApplyOpLogEntry(const OpLogEntry& entry) {
         return false;
     }
 
-    // Apply the operation based on type
-    switch (entry.op_type) {
-        case OpType::PUT_END:
-            ApplyPutEnd(entry);
-            break;
-        case OpType::PUT_REVOKE:
-            ApplyPutRevoke(entry);
-            break;
-        case OpType::REMOVE:
-            ApplyRemove(entry);
-            break;
-        default:
-            if (!ApplyCustomOpLogEntry(entry)) {
-                LOG(ERROR) << "OpLogApplier: unsupported or failed op_type="
-                           << static_cast<int>(entry.op_type)
-                           << ", sequence_id=" << entry.sequence_id
-                           << ", key=" << entry.object_key;
-                return false;
-            }
+    if (!ApplyOpLogEntryInternal(entry)) {
+        LOG(ERROR) << "OpLogApplier: unsupported or failed op_type="
+                   << static_cast<int>(entry.op_type)
+                   << ", sequence_id=" << entry.sequence_id
+                   << ", key=" << entry.object_key;
+        return false;
     }
 
     // Update expected sequence ID
@@ -155,6 +142,22 @@ bool OpLogApplier::ApplyOpLogEntry(const OpLogEntry& entry) {
 }
 
 bool OpLogApplier::ApplyCustomOpLogEntry(const OpLogEntry&) { return false; }
+
+bool OpLogApplier::ApplyOpLogEntryInternal(const OpLogEntry& entry) {
+    switch (entry.op_type) {
+        case OpType::PUT_END:
+            ApplyPutEnd(entry);
+            return true;
+        case OpType::PUT_REVOKE:
+            ApplyPutRevoke(entry);
+            return true;
+        case OpType::REMOVE:
+            ApplyRemove(entry);
+            return true;
+        default:
+            return ApplyCustomOpLogEntry(entry);
+    }
+}
 
 size_t OpLogApplier::ApplyOpLogEntries(const std::vector<OpLogEntry>& entries) {
     size_t applied_count = 0;
@@ -273,23 +276,7 @@ size_t OpLogApplier::ProcessPendingEntries() {
         }
 
         // Apply outside lock.
-        bool applied = true;
-        switch (entry_copy.op_type) {
-            case OpType::PUT_END:
-                ApplyPutEnd(entry_copy);
-                break;
-            case OpType::PUT_REVOKE:
-                ApplyPutRevoke(entry_copy);
-                break;
-            case OpType::REMOVE:
-                ApplyRemove(entry_copy);
-                break;
-            default:
-                applied = ApplyCustomOpLogEntry(entry_copy);
-                break;
-        }
-
-        if (!applied) {
+        if (!ApplyOpLogEntryInternal(entry_copy)) {
             LOG(ERROR) << "OpLogApplier: failed to apply pending entry"
                        << ", sequence_id=" << entry_copy.sequence_id
                        << ", op_type=" << static_cast<int>(entry_copy.op_type);

--- a/mooncake-store/src/ha/oplog/oplog_applier.cpp
+++ b/mooncake-store/src/ha/oplog/oplog_applier.cpp
@@ -70,6 +70,8 @@ bool OpLogApplier::ApplyOpLogEntry(const OpLogEntry& entry) {
             }
         }
         if (was_skipped) {
+            // TODO(P2P HA): Define type-aware handling for late P2P entries as
+            // part of the standby out-of-order/error-handling work.
             if (entry.op_type == OpType::REMOVE ||
                 entry.op_type == OpType::PUT_REVOKE) {
                 // Safe: ensure we don't keep stale metadata.
@@ -129,11 +131,13 @@ bool OpLogApplier::ApplyOpLogEntry(const OpLogEntry& entry) {
             ApplyRemove(entry);
             break;
         default:
-            LOG(ERROR) << "OpLogApplier: unsupported op_type="
-                       << static_cast<int>(entry.op_type)
-                       << ", sequence_id=" << entry.sequence_id
-                       << ", key=" << entry.object_key;
-            return false;
+            if (!ApplyCustomOpLogEntry(entry)) {
+                LOG(ERROR) << "OpLogApplier: unsupported or failed op_type="
+                           << static_cast<int>(entry.op_type)
+                           << ", sequence_id=" << entry.sequence_id
+                           << ", key=" << entry.object_key;
+                return false;
+            }
     }
 
     // Update expected sequence ID
@@ -149,6 +153,8 @@ bool OpLogApplier::ApplyOpLogEntry(const OpLogEntry& entry) {
 
     return true;
 }
+
+bool OpLogApplier::ApplyCustomOpLogEntry(const OpLogEntry&) { return false; }
 
 size_t OpLogApplier::ApplyOpLogEntries(const std::vector<OpLogEntry>& entries) {
     size_t applied_count = 0;
@@ -172,6 +178,8 @@ void OpLogApplier::Recover(uint64_t last_applied_sequence_id) {
 }
 
 size_t OpLogApplier::ProcessPendingEntries() {
+    // TODO(P2P HA): Drive this periodically in production so a final gap can
+    // time out even when no newer OpLog arrives.
     // Check for missing sequence IDs, possibly skip after timeout, and/or
     // request them.
     uint64_t missing_seq_to_request = 0;
@@ -265,6 +273,7 @@ size_t OpLogApplier::ProcessPendingEntries() {
         }
 
         // Apply outside lock.
+        bool applied = true;
         switch (entry_copy.op_type) {
             case OpType::PUT_END:
                 ApplyPutEnd(entry_copy);
@@ -276,12 +285,24 @@ size_t OpLogApplier::ProcessPendingEntries() {
                 ApplyRemove(entry_copy);
                 break;
             default:
-                LOG(ERROR)
-                    << "OpLogApplier: unsupported op_type in pending entry";
+                applied = ApplyCustomOpLogEntry(entry_copy);
                 break;
         }
 
+        if (!applied) {
+            LOG(ERROR) << "OpLogApplier: failed to apply pending entry"
+                       << ", sequence_id=" << entry_copy.sequence_id
+                       << ", op_type=" << static_cast<int>(entry_copy.op_type);
+            std::lock_guard<std::mutex> lock(pending_mutex_);
+            pending_entries_.emplace(entry_copy.sequence_id,
+                                     std::move(entry_copy));
+            break;
+        }
+
         expected_sequence_id_.store(entry_copy.sequence_id + 1);
+        HAMetricManager::instance().inc_oplog_applied_entries();
+        HAMetricManager::instance().set_oplog_applied_sequence_id(
+            static_cast<int64_t>(entry_copy.sequence_id));
 
         {
             std::lock_guard<std::mutex> lock(pending_mutex_);

--- a/mooncake-store/src/ha/oplog/oplog_store_factory.cpp
+++ b/mooncake-store/src/ha/oplog/oplog_store_factory.cpp
@@ -12,7 +12,10 @@ namespace mooncake {
 std::unique_ptr<OpLogStore> OpLogStoreFactory::Create(
     OpLogStoreType type, const std::string& cluster_id, OpLogStoreRole role,
     const std::string& oplog_root_dir, int poll_interval_ms,
-    const std::string& password, const std::string& username, int db_index) {
+    const std::string& password, const std::string& username, int db_index,
+    size_t async_queue_max_entries,
+    const std::string& async_queue_overflow_mode,
+    size_t best_effort_max_retries) {
     switch (type) {
         case OpLogStoreType::ETCD: {
             // EtcdOpLogStore is not yet ported to this branch.
@@ -37,10 +40,26 @@ std::unique_ptr<OpLogStore> OpLogStoreFactory::Create(
         }
         case OpLogStoreType::REDIS: {
 #ifdef STORE_USE_REDIS
+            if (async_queue_max_entries == 0 || best_effort_max_retries == 0 ||
+                (async_queue_overflow_mode != "reject" &&
+                 async_queue_overflow_mode != "bypass")) {
+                LOG(ERROR) << "OpLogStoreFactory: invalid Redis async OpLog "
+                              "configuration"
+                           << ", queue_max_entries=" << async_queue_max_entries
+                           << ", overflow_mode=" << async_queue_overflow_mode
+                           << ", best_effort_max_retries="
+                           << best_effort_max_retries;
+                return nullptr;
+            }
             bool enable_write = (role == OpLogStoreRole::WRITER);
+            const auto overflow_mode =
+                async_queue_overflow_mode == "bypass"
+                    ? OpLogAsyncQueueOverflowMode::BYPASS
+                    : OpLogAsyncQueueOverflowMode::REJECT;
             auto store = std::make_unique<RedisOpLogStore>(
                 cluster_id, oplog_root_dir, enable_write, poll_interval_ms,
-                password, username, db_index);
+                password, username, db_index, async_queue_max_entries,
+                overflow_mode, best_effort_max_retries);
             if (store->Init() != ErrorCode::OK) {
                 LOG(ERROR)
                     << "OpLogStoreFactory: failed to init RedisOpLogStore"

--- a/mooncake-store/src/ha/oplog/p2p_oplog_applier.cpp
+++ b/mooncake-store/src/ha/oplog/p2p_oplog_applier.cpp
@@ -17,101 +17,23 @@ P2POpLogApplier::P2POpLogApplier(P2PStandbyMetadataStore* p2p_store,
     }
 }
 
-bool P2POpLogApplier::ApplyOpLogEntry(const OpLogEntry& entry) {
-    // Main branch OpTypes — delegate entirely to base class (which handles
-    // validate, checksum, sequence ordering, and dispatch).
-    if (entry.op_type == OpType::PUT_END ||
-        entry.op_type == OpType::PUT_REVOKE ||
-        entry.op_type == OpType::REMOVE ||
-        entry.op_type == OpType::LEASE_RENEW) {
-        return OpLogApplier::ApplyOpLogEntry(entry);
-    }
-
-    // For P2P OpTypes, perform the same validate + checksum + sequence checks
-    // as the base class, then dispatch to P2P-specific apply methods.
-    const bool is_p2p_op = entry.op_type == OpType_ADD_REPLICA ||
-                           entry.op_type == OpType_REMOVE_REPLICA ||
-                           entry.op_type == OpType_MOUNT_SEGMENT ||
-                           entry.op_type == OpType_UNMOUNT_SEGMENT ||
-                           entry.op_type == OpType_REMOVE_ALL ||
-                           entry.op_type == OpType_REGISTER_CLIENT ||
-                           entry.op_type == OpType_UNREGISTER_CLIENT;
-    if (!is_p2p_op) {
-        LOG(ERROR) << "P2POpLogApplier: unknown op_type="
-                   << static_cast<int>(entry.op_type)
-                   << ", sequence_id=" << entry.sequence_id
-                   << ", key=" << entry.object_key;
-        return false;
-    }
-
-    // Validate entry size (DoS protection).
-    std::string size_reason;
-    if (!OpLogManager::ValidateEntrySize(entry, &size_reason)) {
-        LOG(ERROR) << "P2POpLogApplier: entry size rejected, sequence_id="
-                   << entry.sequence_id << ", key=" << entry.object_key
-                   << ", reason=" << size_reason;
-        return false;
-    }
-
-    // Verify checksum.
-    if (!OpLogManager::VerifyChecksum(entry)) {
-        LOG(ERROR) << "P2POpLogApplier: checksum mismatch, sequence_id="
-                   << entry.sequence_id << ", key=" << entry.object_key;
-        HAMetricManager::instance().inc_oplog_checksum_failures();
-        return false;
-    }
-
-    // Sequence ordering check (mirrors base class logic).
-    const uint64_t expected = GetExpectedSequenceId();
-    if (IsSequenceOlder(entry.sequence_id, expected)) {
-        VLOG(2) << "P2POpLogApplier: skip already-applied entry, sequence_id="
-                << entry.sequence_id << ", expected=" << expected
-                << ", key=" << entry.object_key;
-        return true;  // consumed (no-op for duplicates)
-    }
-    if (IsSequenceNewer(entry.sequence_id, expected)) {
-        // Future entry — reject it for later re-delivery.
-        // NOTE: P2POpLogApplier does not manage pending_entries_ itself.
-        // The OpLogReplicator or caller should re-deliver out-of-order
-        // entries after the gap is filled. This matches the simplified
-        // ordering model for P2P's initial HA implementation.
-        LOG(WARNING) << "P2POpLogApplier: out-of-order entry, sequence_id="
-                     << entry.sequence_id << ", expected=" << expected
-                     << ", key=" << entry.object_key;
-        return false;
-    }
-
-    // Dispatch to P2P-specific apply methods.
-    bool ok = false;
+bool P2POpLogApplier::ApplyCustomOpLogEntry(const OpLogEntry& entry) {
     if (entry.op_type == OpType_ADD_REPLICA) {
-        ok = ApplyAddReplica(entry);
+        return ApplyAddReplica(entry);
     } else if (entry.op_type == OpType_REMOVE_REPLICA) {
-        ok = ApplyRemoveReplica(entry);
+        return ApplyRemoveReplica(entry);
     } else if (entry.op_type == OpType_MOUNT_SEGMENT) {
-        ok = ApplyMountSegment(entry);
+        return ApplyMountSegment(entry);
     } else if (entry.op_type == OpType_UNMOUNT_SEGMENT) {
-        ok = ApplyUnmountSegment(entry);
+        return ApplyUnmountSegment(entry);
     } else if (entry.op_type == OpType_REMOVE_ALL) {
-        ok = ApplyRemoveAll(entry);
+        return ApplyRemoveAll(entry);
     } else if (entry.op_type == OpType_REGISTER_CLIENT) {
-        ok = ApplyRegisterClient(entry);
+        return ApplyRegisterClient(entry);
     } else if (entry.op_type == OpType_UNREGISTER_CLIENT) {
-        ok = ApplyUnregisterClient(entry);
+        return ApplyUnregisterClient(entry);
     }
-
-    if (ok) {
-        // Advance expected sequence ID (mirrors base class).
-        // Note: we access the base class atomic directly via Recover(),
-        // which sets expected = last_applied + 1.
-        Recover(entry.sequence_id);
-
-        // Update metrics.
-        HAMetricManager::instance().inc_oplog_applied_entries();
-        HAMetricManager::instance().set_oplog_applied_sequence_id(
-            static_cast<int64_t>(entry.sequence_id));
-    }
-
-    return ok;
+    return false;
 }
 
 bool P2POpLogApplier::ApplyAddReplica(const OpLogEntry& entry) {

--- a/mooncake-store/src/ha/oplog/redis_oplog_store.cpp
+++ b/mooncake-store/src/ha/oplog/redis_oplog_store.cpp
@@ -334,6 +334,9 @@ void RedisOpLogStore::AsyncWriteLoop(size_t worker_id) {
                     attempts >= best_effort_max_retries_) {
                     dropped_sequences_.insert(pending->entry.sequence_id);
                     inflight_writes_.erase(pending->entry.sequence_id);
+                    pending->done = true;
+                    pending->result = ErrorCode::INTERNAL_ERROR;
+                    sync_cv_.notify_all();
                     LOG(ERROR) << "RedisOpLogStore: dropping best-effort oplog"
                                << ", sequence_id=" << pending->entry.sequence_id
                                << ", attempts=" << attempts;
@@ -550,8 +553,8 @@ ErrorCode RedisOpLogStore::ReadOpLogSince(uint64_t start_sequence_id,
     uint64_t next_sequence_id = effective_start + 1;
     while (next_sequence_id <= latest_sequence_id && entries.size() < limit) {
         const uint64_t remaining = latest_sequence_id - next_sequence_id + 1;
-        const size_t batch_size = static_cast<size_t>(
-            std::min<uint64_t>(remaining, static_cast<uint64_t>(limit)));
+        const size_t batch_size = static_cast<size_t>(std::min<uint64_t>(
+            remaining, static_cast<uint64_t>(limit - entries.size())));
         const uint64_t batch_start = next_sequence_id;
 
         for (size_t i = 0; i < batch_size; ++i) {

--- a/mooncake-store/src/ha/oplog/redis_oplog_store.cpp
+++ b/mooncake-store/src/ha/oplog/redis_oplog_store.cpp
@@ -8,9 +8,9 @@
 #include <cstring>
 #include <iomanip>
 #include <sstream>
-#include <string_view>
 
 #include "ha/oplog/oplog_serializer.h"
+#include "ha/oplog/p2p_oplog_types.h"
 #include "ha/oplog/polling_oplog_change_notifier.h"
 
 namespace mooncake {
@@ -40,18 +40,21 @@ std::string SequenceMember(uint64_t value) {
 
 }  // namespace
 
-RedisOpLogStore::RedisOpLogStore(const std::string& cluster_id,
-                                 const std::string& redis_endpoint,
-                                 bool enable_write, int poll_interval_ms,
-                                 const std::string& password,
-                                 const std::string& username, int db_index)
+RedisOpLogStore::RedisOpLogStore(
+    const std::string& cluster_id, const std::string& redis_endpoint,
+    bool enable_write, int poll_interval_ms, const std::string& password,
+    const std::string& username, int db_index, size_t async_queue_max_entries,
+    OpLogAsyncQueueOverflowMode overflow_mode, size_t best_effort_max_retries)
     : cluster_id_(cluster_id),
       redis_endpoint_(redis_endpoint),
       username_(username),
       password_(password),
       db_index_(db_index),
       enable_write_(enable_write),
-      poll_interval_ms_(poll_interval_ms) {
+      poll_interval_ms_(poll_interval_ms),
+      async_queue_max_entries_(async_queue_max_entries),
+      async_queue_overflow_mode_(overflow_mode),
+      best_effort_max_retries_(best_effort_max_retries) {
     if (!NormalizeAndValidateClusterId(cluster_id_)) {
         LOG(FATAL) << "Invalid cluster_id for RedisOpLogStore: '" << cluster_id
                    << "'. Allowed chars: [A-Za-z0-9_.-], max_len=128.";
@@ -155,11 +158,6 @@ std::string RedisOpLogStore::SnapshotKey(const std::string& snapshot_id) const {
     return snapshot_prefix_ + snapshot_id;
 }
 
-// TODO(P2P HA): Redis now uses latest as a committed watermark. Async
-// workers may persist entries out of order, but latest only advances across
-// contiguous successful sequence IDs. A future throughput optimization can add
-// larger pipelined batches per worker; standby should continue to replay only
-// entries <= committed latest.
 ErrorCode RedisOpLogStore::WriteOpLog(const OpLogEntry& entry, bool sync) {
     return EnqueueWrite(entry, sync);
 }
@@ -171,7 +169,7 @@ ErrorCode RedisOpLogStore::EnqueueWrite(const OpLogEntry& entry, bool sync) {
     }
 
     std::shared_ptr<PendingWrite> pending;
-    bool wait_for_completion = sync;
+    const bool wait_for_completion = sync;
     {
         std::lock_guard<std::mutex> lock(async_mutex_);
         if (!async_running_.load()) {
@@ -185,17 +183,23 @@ ErrorCode RedisOpLogStore::EnqueueWrite(const OpLogEntry& entry, bool sync) {
         if (existing != inflight_writes_.end()) {
             pending = existing->second;
         } else {
-            if (!sync && pending_writes_.size() + inflight_writes_.size() >=
-                             kMaxAsyncQueueSize) {
-                wait_for_completion = true;
-                LOG(WARNING) << "RedisOpLogStore: async queue full, falling "
-                                "back to sync write"
-                             << ", sequence_id=" << entry.sequence_id
-                             << ", queue_size=" << pending_writes_.size()
-                             << ", inflight_size=" << inflight_writes_.size();
+            if (!sync && inflight_writes_.size() >= async_queue_max_entries_) {
+                dropped_sequences_.insert(entry.sequence_id);
+                async_cv_.notify_one();
+                LOG(WARNING)
+                    << "RedisOpLogStore: async queue overflow"
+                    << ", sequence_id=" << entry.sequence_id
+                    << ", queue_size=" << inflight_writes_.size() << ", mode="
+                    << (async_queue_overflow_mode_ ==
+                                OpLogAsyncQueueOverflowMode::BYPASS
+                            ? "bypass"
+                            : "reject");
+                return async_queue_overflow_mode_ ==
+                               OpLogAsyncQueueOverflowMode::BYPASS
+                           ? ErrorCode::OK
+                           : ErrorCode::INTERNAL_ERROR;
             }
-            pending =
-                std::make_shared<PendingWrite>(entry, wait_for_completion);
+            pending = std::make_shared<PendingWrite>(entry, sync);
             inflight_writes_[entry.sequence_id] = pending;
             pending_writes_.push_back(pending);
         }
@@ -271,13 +275,17 @@ void RedisOpLogStore::AsyncWriteLoop(size_t worker_id) {
         {
             std::unique_lock<std::mutex> lock(async_mutex_);
             async_cv_.wait(lock, [&] {
-                return !async_running_.load() || !pending_writes_.empty();
+                return !async_running_.load() || !pending_writes_.empty() ||
+                       dropped_sequences_.count(committed_sequence_id_ + 1) !=
+                           0;
             });
             if (!async_running_.load() && pending_writes_.empty()) {
                 break;
             }
-            pending = pending_writes_.front();
-            pending_writes_.pop_front();
+            if (!pending_writes_.empty()) {
+                pending = pending_writes_.front();
+                pending_writes_.pop_front();
+            }
         }
 
         if (!ctx || ctx->err) {
@@ -287,9 +295,25 @@ void RedisOpLogStore::AsyncWriteLoop(size_t worker_id) {
             ctx = CreateConnection();
         }
         // TODO(P2P HA): Batch several queued entries per worker and pipeline
-        // their SET NX commands to reduce Redis round trips. Keep the current
+        // their SET commands to reduce Redis round trips. Keep the current
         // one-entry retry path until batch error handling and partial reply
         // draining are covered by tests.
+        if (!pending) {
+            bool advanced = false;
+            {
+                std::lock_guard<std::mutex> lock(async_mutex_);
+                advanced =
+                    ctx && AdvanceCommittedLatestUnlocked(ctx) == ErrorCode::OK;
+            }
+            if (advanced) continue;
+            if (ctx) {
+                redisFree(ctx);
+                ctx = nullptr;
+            }
+            std::this_thread::sleep_for(
+                std::chrono::milliseconds(kAsyncRetryDelayMs));
+            continue;
+        }
         ErrorCode err = ctx ? PersistEntryNoLatest(ctx, pending->entry)
                             : ErrorCode::INTERNAL_ERROR;
         if (err != ErrorCode::OK) {
@@ -306,6 +330,16 @@ void RedisOpLogStore::AsyncWriteLoop(size_t worker_id) {
                 // Mutable PendingWrite state is protected by async_mutex_.
                 std::lock_guard<std::mutex> lock(async_mutex_);
                 attempts = ++pending->attempts;
+                if (IsBestEffortRedisOpLog(pending->entry.op_type) &&
+                    attempts >= best_effort_max_retries_) {
+                    dropped_sequences_.insert(pending->entry.sequence_id);
+                    inflight_writes_.erase(pending->entry.sequence_id);
+                    LOG(ERROR) << "RedisOpLogStore: dropping best-effort oplog"
+                               << ", sequence_id=" << pending->entry.sequence_id
+                               << ", attempts=" << attempts;
+                    async_cv_.notify_one();
+                    continue;
+                }
             }
             // TODO(P2P HA): Add bounded exponential backoff, jitter, and
             // pending/retry metrics.
@@ -338,52 +372,21 @@ ErrorCode RedisOpLogStore::PersistEntryNoLatest(redisContext* ctx,
     const std::string entry_key = EntryKey(entry.sequence_id);
     const std::string serialized = SerializeOpLogEntry(entry);
     RedisReplyPtr reply((redisReply*)redisCommand(
-        ctx, "SET %b %b NX", entry_key.data(), entry_key.size(),
-        serialized.data(), serialized.size()));
-    if (!reply || reply->type == REDIS_REPLY_ERROR) {
+        ctx, "SET %b %b", entry_key.data(), entry_key.size(), serialized.data(),
+        serialized.size()));
+    if (!reply || reply->type != REDIS_REPLY_STATUS) {
         LOG(ERROR) << "RedisOpLogStore::PersistEntryNoLatest: Redis command "
                       "failed"
                    << ", sequence_id=" << entry.sequence_id;
         return ErrorCode::INTERNAL_ERROR;
     }
-    if (reply->type == REDIS_REPLY_STATUS) {
-        return ErrorCode::OK;
-    }
-    if (reply->type == REDIS_REPLY_NIL) {
-        RedisReplyPtr existing((redisReply*)redisCommand(
-            ctx, "GET %b", entry_key.data(), entry_key.size()));
-        if (!existing || existing->type == REDIS_REPLY_ERROR) {
-            LOG(ERROR) << "RedisOpLogStore::PersistEntryNoLatest: GET existing "
-                          "entry failed"
-                       << ", sequence_id=" << entry.sequence_id;
-            return ErrorCode::INTERNAL_ERROR;
-        }
-        if (existing->type == REDIS_REPLY_STRING &&
-            std::string_view(existing->str, existing->len) == serialized) {
-            return ErrorCode::OK;
-        }
-        if (existing->type == REDIS_REPLY_NIL) {
-            LOG(WARNING) << "RedisOpLogStore::PersistEntryNoLatest: existing "
-                            "entry disappeared before comparison, retrying"
-                         << ", sequence_id=" << entry.sequence_id;
-            return ErrorCode::INTERNAL_ERROR;
-        }
-        LOG(ERROR) << "RedisOpLogStore::PersistEntryNoLatest: conflicting "
-                      "entry already exists"
-                   << ", sequence_id=" << entry.sequence_id;
-        return ErrorCode::INVALID_PARAMS;
-    }
-    LOG(ERROR) << "RedisOpLogStore::PersistEntryNoLatest: unexpected reply "
-                  "type"
-               << ", type=" << reply->type
-               << ", sequence_id=" << entry.sequence_id;
-    return ErrorCode::INTERNAL_ERROR;
+    return ErrorCode::OK;
 }
 
 ErrorCode RedisOpLogStore::AdvanceCommittedLatestUnlocked(redisContext* ctx) {
     uint64_t target = committed_sequence_id_;
-    while (persisted_sequences_.find(target + 1) !=
-           persisted_sequences_.end()) {
+    while (persisted_sequences_.count(target + 1) != 0 ||
+           dropped_sequences_.count(target + 1) != 0) {
         ++target;
     }
     if (target == committed_sequence_id_) {
@@ -403,6 +406,7 @@ ErrorCode RedisOpLogStore::AdvanceCommittedLatestUnlocked(redisContext* ctx) {
     for (uint64_t seq_id = committed_sequence_id_ + 1; seq_id <= target;
          ++seq_id) {
         persisted_sequences_.erase(seq_id);
+        dropped_sequences_.erase(seq_id);
         auto it = inflight_writes_.find(seq_id);
         if (it != inflight_writes_.end()) {
             it->second->done = true;
@@ -542,85 +546,74 @@ ErrorCode RedisOpLogStore::ReadOpLogSince(uint64_t start_sequence_id,
         return ErrorCode::OK;
     }
 
-    std::vector<uint64_t> sequence_ids;
-    const uint64_t available = latest_sequence_id - effective_start;
-    const size_t read_count =
-        static_cast<size_t>(std::min<uint64_t>(available, limit));
-    sequence_ids.reserve(read_count);
-    for (uint64_t sequence_id = effective_start + 1;
-         sequence_id <= latest_sequence_id && sequence_ids.size() < read_count;
-         ++sequence_id) {
-        sequence_ids.push_back(sequence_id);
-    }
+    entries.reserve(limit);
+    uint64_t next_sequence_id = effective_start + 1;
+    while (next_sequence_id <= latest_sequence_id && entries.size() < limit) {
+        const uint64_t remaining = latest_sequence_id - next_sequence_id + 1;
+        const size_t batch_size = static_cast<size_t>(
+            std::min<uint64_t>(remaining, static_cast<uint64_t>(limit)));
+        const uint64_t batch_start = next_sequence_id;
 
-    for (uint64_t sequence_id : sequence_ids) {
-        const std::string entry_key = EntryKey(sequence_id);
-        if (redisAppendCommand(ctx_, "GET %b", entry_key.data(),
-                               entry_key.size()) != REDIS_OK) {
-            LOG(ERROR) << "RedisOpLogStore::ReadOpLogSince: append GET failed"
-                       << ", sequence_id=" << sequence_id;
-            redisFree(ctx_);
-            ctx_ = nullptr;
-            entries.clear();
-            return ErrorCode::INTERNAL_ERROR;
-        }
-    }
-
-    entries.reserve(sequence_ids.size());
-    for (size_t i = 0; i < sequence_ids.size(); ++i) {
-        redisReply* raw_reply = nullptr;
-        if (redisGetReply(ctx_, reinterpret_cast<void**>(&raw_reply)) !=
-                REDIS_OK ||
-            !raw_reply) {
-            LOG(ERROR) << "RedisOpLogStore::ReadOpLogSince: pipeline GET failed"
-                       << ", sequence_id=" << sequence_ids[i];
-            redisFree(ctx_);
-            ctx_ = nullptr;
-            entries.clear();
-            return ErrorCode::INTERNAL_ERROR;
-        }
-        RedisReplyPtr entry_reply(raw_reply);
-        if (entry_reply->type == REDIS_REPLY_NIL) {
-            LOG(ERROR) << "RedisOpLogStore::ReadOpLogSince: missing committed "
-                          "entry"
-                       << ", sequence_id=" << sequence_ids[i]
-                       << ", latest_sequence_id=" << latest_sequence_id;
-            redisFree(ctx_);
-            ctx_ = nullptr;
-            entries.clear();
-            return ErrorCode::OPLOG_ENTRY_NOT_FOUND;
-        }
-        if (entry_reply->type == REDIS_REPLY_ERROR) {
-            LOG(ERROR) << "RedisOpLogStore::ReadOpLogSince: GET failed"
-                       << ", sequence_id=" << sequence_ids[i] << ", error="
-                       << (entry_reply->str ? entry_reply->str : "null");
-            redisFree(ctx_);
-            ctx_ = nullptr;
-            entries.clear();
-            return ErrorCode::INTERNAL_ERROR;
-        }
-        if (entry_reply->type != REDIS_REPLY_STRING) {
-            LOG(ERROR)
-                << "RedisOpLogStore::ReadOpLogSince: unexpected GET reply type"
-                << ", type=" << entry_reply->type
-                << ", sequence_id=" << sequence_ids[i];
-            redisFree(ctx_);
-            ctx_ = nullptr;
-            entries.clear();
-            return ErrorCode::INTERNAL_ERROR;
+        for (size_t i = 0; i < batch_size; ++i) {
+            const uint64_t sequence_id = batch_start + i;
+            const std::string entry_key = EntryKey(sequence_id);
+            if (redisAppendCommand(ctx_, "GET %b", entry_key.data(),
+                                   entry_key.size()) != REDIS_OK) {
+                LOG(ERROR)
+                    << "RedisOpLogStore::ReadOpLogSince: append GET failed"
+                    << ", sequence_id=" << sequence_id;
+                redisFree(ctx_);
+                ctx_ = nullptr;
+                entries.clear();
+                return ErrorCode::INTERNAL_ERROR;
+            }
         }
 
-        OpLogEntry entry;
-        std::string serialized(entry_reply->str, entry_reply->len);
-        if (!DeserializeOpLogEntry(serialized, entry)) {
-            LOG(ERROR) << "RedisOpLogStore::ReadOpLogSince: deserialize failed"
-                       << ", sequence_id=" << sequence_ids[i];
-            redisFree(ctx_);
-            ctx_ = nullptr;
-            entries.clear();
-            return ErrorCode::INTERNAL_ERROR;
+        for (size_t i = 0; i < batch_size; ++i) {
+            const uint64_t sequence_id = batch_start + i;
+            redisReply* raw_reply = nullptr;
+            if (redisGetReply(ctx_, reinterpret_cast<void**>(&raw_reply)) !=
+                    REDIS_OK ||
+                !raw_reply) {
+                LOG(ERROR)
+                    << "RedisOpLogStore::ReadOpLogSince: pipeline GET failed"
+                    << ", sequence_id=" << sequence_id;
+                redisFree(ctx_);
+                ctx_ = nullptr;
+                entries.clear();
+                return ErrorCode::INTERNAL_ERROR;
+            }
+            RedisReplyPtr entry_reply(raw_reply);
+            if (entry_reply->type == REDIS_REPLY_NIL) {
+                continue;
+            }
+            if (entry_reply->type != REDIS_REPLY_STRING) {
+                LOG(ERROR) << "RedisOpLogStore::ReadOpLogSince: unexpected GET "
+                              "reply type"
+                           << ", type=" << entry_reply->type
+                           << ", sequence_id=" << sequence_id;
+                redisFree(ctx_);
+                ctx_ = nullptr;
+                entries.clear();
+                return ErrorCode::INTERNAL_ERROR;
+            }
+
+            if (entries.size() < limit) {
+                OpLogEntry entry;
+                std::string serialized(entry_reply->str, entry_reply->len);
+                if (!DeserializeOpLogEntry(serialized, entry)) {
+                    LOG(ERROR)
+                        << "RedisOpLogStore::ReadOpLogSince: deserialize failed"
+                        << ", sequence_id=" << sequence_id;
+                    redisFree(ctx_);
+                    ctx_ = nullptr;
+                    entries.clear();
+                    return ErrorCode::INTERNAL_ERROR;
+                }
+                entries.push_back(std::move(entry));
+            }
         }
-        entries.push_back(std::move(entry));
+        next_sequence_id += batch_size;
     }
     return ErrorCode::OK;
 }
@@ -692,6 +685,8 @@ ErrorCode RedisOpLogStore::UpdateLatestSequenceId(uint64_t sequence_id) {
         persisted_sequences_.erase(
             persisted_sequences_.begin(),
             persisted_sequences_.upper_bound(sequence_id));
+        dropped_sequences_.erase(dropped_sequences_.begin(),
+                                 dropped_sequences_.upper_bound(sequence_id));
     }
     sync_cv_.notify_all();
     return ErrorCode::OK;

--- a/mooncake-store/src/ha/oplog/redis_oplog_store.cpp
+++ b/mooncake-store/src/ha/oplog/redis_oplog_store.cpp
@@ -169,7 +169,6 @@ ErrorCode RedisOpLogStore::EnqueueWrite(const OpLogEntry& entry, bool sync) {
     }
 
     std::shared_ptr<PendingWrite> pending;
-    const bool wait_for_completion = sync;
     {
         std::lock_guard<std::mutex> lock(async_mutex_);
         if (!async_running_.load()) {
@@ -206,7 +205,7 @@ ErrorCode RedisOpLogStore::EnqueueWrite(const OpLogEntry& entry, bool sync) {
     }
     async_cv_.notify_one();
 
-    if (!wait_for_completion) {
+    if (!sync) {
         return ErrorCode::OK;
     }
 
@@ -374,6 +373,10 @@ ErrorCode RedisOpLogStore::PersistEntryNoLatest(redisContext* ctx,
                                                 const OpLogEntry& entry) {
     const std::string entry_key = EntryKey(entry.sequence_id);
     const std::string serialized = SerializeOpLogEntry(entry);
+    // A previous Primary may leave an uncommitted entry beyond latest; the
+    // current Primary must be able to overwrite it and continue the sequence.
+    // TODO(P2P HA): Atomically reject conflicting overwrites at or below the
+    // committed latest while still allowing overwrites beyond latest.
     RedisReplyPtr reply((redisReply*)redisCommand(
         ctx, "SET %b %b", entry_key.data(), entry_key.size(), serialized.data(),
         serialized.size()));

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -132,6 +132,12 @@ DEFINE_string(oplog_store_type, "localfs",
               "OpLog store backend type. Currently supports localfs");
 DEFINE_string(oplog_data_dir, "/tmp/mooncake_oplog",
               "Root directory for localfs OpLog data");
+DEFINE_uint64(oplog_async_queue_max_entries, 100000,
+              "Maximum number of queued/in-flight asynchronous OpLogs");
+DEFINE_string(oplog_async_queue_overflow_mode, "reject",
+              "Async OpLog queue overflow mode: reject or bypass");
+DEFINE_uint64(oplog_best_effort_max_retries, 3,
+              "Maximum Redis attempts for best-effort OpLogs");
 
 // Redis election backend configuration
 DEFINE_string(election_backend, "etcd",
@@ -204,6 +210,15 @@ void InitMasterConf(const mooncake::DefaultConfig& default_config,
                              FLAGS_oplog_store_type);
     default_config.GetString("oplog_data_dir", &master_config.oplog_data_dir,
                              FLAGS_oplog_data_dir);
+    default_config.GetUInt64("oplog_async_queue_max_entries",
+                             &master_config.oplog_async_queue_max_entries,
+                             FLAGS_oplog_async_queue_max_entries);
+    default_config.GetString("oplog_async_queue_overflow_mode",
+                             &master_config.oplog_async_queue_overflow_mode,
+                             FLAGS_oplog_async_queue_overflow_mode);
+    default_config.GetUInt64("oplog_best_effort_max_retries",
+                             &master_config.oplog_best_effort_max_retries,
+                             FLAGS_oplog_best_effort_max_retries);
     default_config.GetBool("enable_offload", &master_config.enable_offload,
                            FLAGS_enable_offload);
     default_config.GetString("etcd_endpoints", &master_config.etcd_endpoints,
@@ -414,6 +429,27 @@ void LoadConfigFromCmdline(mooncake::MasterConfig& master_config,
          !info.is_default) ||
         !conf_set) {
         master_config.oplog_data_dir = FLAGS_oplog_data_dir;
+    }
+    if ((google::GetCommandLineFlagInfo("oplog_async_queue_max_entries",
+                                        &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.oplog_async_queue_max_entries =
+            FLAGS_oplog_async_queue_max_entries;
+    }
+    if ((google::GetCommandLineFlagInfo("oplog_async_queue_overflow_mode",
+                                        &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.oplog_async_queue_overflow_mode =
+            FLAGS_oplog_async_queue_overflow_mode;
+    }
+    if ((google::GetCommandLineFlagInfo("oplog_best_effort_max_retries",
+                                        &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.oplog_best_effort_max_retries =
+            FLAGS_oplog_best_effort_max_retries;
     }
     if ((google::GetCommandLineFlagInfo("enable_offload", &info) &&
          !info.is_default) ||
@@ -724,6 +760,12 @@ int main(int argc, char* argv[]) {
         << ", enable_oplog=" << master_config.enable_oplog
         << ", oplog_store_type=" << master_config.oplog_store_type
         << ", oplog_data_dir=" << master_config.oplog_data_dir
+        << ", oplog_async_queue_max_entries="
+        << master_config.oplog_async_queue_max_entries
+        << ", oplog_async_queue_overflow_mode="
+        << master_config.oplog_async_queue_overflow_mode
+        << ", oplog_best_effort_max_retries="
+        << master_config.oplog_best_effort_max_retries
         << ", enable_offload=" << master_config.enable_offload
         << ", etcd_endpoints=" << master_config.etcd_endpoints
         << ", client_ttl=" << master_config.client_live_ttl_sec

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -38,7 +38,10 @@ MasterService::MasterService(const MasterServiceConfig& config)
     auto store = OpLogStoreFactory::Create(
         store_type, config.cluster_id, OpLogStoreRole::WRITER, store_location,
         kDefaultOpLogPollIntervalMs, config.redis_password,
-        config.redis_username, config.redis_db_index);
+        config.redis_username, config.redis_db_index,
+        config.oplog_async_queue_max_entries,
+        config.oplog_async_queue_overflow_mode,
+        config.oplog_best_effort_max_retries);
     if (!store) {
         LOG(ERROR) << "MasterService: failed to initialize OpLogStore"
                    << ", type=" << config.oplog_store_type

--- a/mooncake-store/src/p2p_master_service.cpp
+++ b/mooncake-store/src/p2p_master_service.cpp
@@ -13,8 +13,8 @@ namespace mooncake {
 P2PMasterService::P2PMasterService(const MasterServiceConfig& config)
     : MasterService(config),
       max_replicas_per_key_(config.max_replicas_per_key),
-      async_oplog_(ParseOpLogStoreType(config.oplog_store_type) ==
-                   OpLogStoreType::REDIS) {
+      enable_async_oplog_write_(ParseOpLogStoreType(config.oplog_store_type) ==
+                                OpLogStoreType::REDIS) {
     client_manager_ = std::make_shared<P2PClientManager>(
         config.client_live_ttl_sec, config.client_crashed_ttl_sec,
         config.view_version);
@@ -23,7 +23,7 @@ P2PMasterService::P2PMasterService(const MasterServiceConfig& config)
 }
 
 ErrorCode P2PMasterService::RecordOplog(OpType type, const std::string& key,
-                                        const std::string& payload, bool sync) {
+                                        const std::string& payload) {
     // TODO: Record remaining failover-visible P2P mutations: client crash
     // cleanup, heartbeat state transitions, replica eviction/rebalance, and
     // task metadata.
@@ -32,8 +32,8 @@ ErrorCode P2PMasterService::RecordOplog(OpType type, const std::string& key,
         return ErrorCode::OK;
     }
 
-    auto result =
-        manager->AppendAndPersist(type, key, payload, sync && !async_oplog_);
+    auto result = manager->AppendAndPersist(
+        type, key, payload, /*sync=*/!enable_async_oplog_write_);
     if (!result.has_value()) {
         LOG(ERROR) << "P2PMasterService: failed to persist oplog"
                    << ", op_type=" << static_cast<int>(type) << ", key=" << key
@@ -375,6 +375,8 @@ tl::expected<void, ErrorCode> P2PMasterService::InnerAddReplica(
     Replica new_replica(P2PProxyReplicaData(client, segment_res.value(), size),
                         ReplicaStatus::COMPLETE);
 
+    // AddReplica commits the in-memory route first. OpLog is best-effort;
+    // returning an OpLog error could make the client delete its local replica.
     auto it = shard.metadata.find(key);
     if (it != shard.metadata.end()) {
         auto& metadata = *it->second;
@@ -421,14 +423,13 @@ tl::expected<void, ErrorCode> P2PMasterService::InnerAddReplica(
         metadata.replicas_.push_back(std::move(new_replica));
         ErrorCode record_err =
             RecordOplog(OpType_ADD_REPLICA, payload.object_key,
-                        SerializeP2PPayload(payload),
-                        /*sync=*/!async_oplog_);
+                        SerializeP2PPayload(payload));
         if (record_err != ErrorCode::OK) {
             LOG(ERROR) << "AddReplica(P2P): failed to record oplog"
                        << ", client_id=" << client_id
                        << ", segment_id=" << segment_id
-                       << ", error=" << toString(record_err);
-            return tl::make_unexpected(record_err);
+                       << ", error=" << toString(record_err)
+                       << "; keeping the in-memory route";
         }
     } else {
         std::vector<Replica> replicas;
@@ -447,14 +448,13 @@ tl::expected<void, ErrorCode> P2PMasterService::InnerAddReplica(
         OnReplicaAdded(emplace_it->second->replicas_[0]);
         ErrorCode record_err =
             RecordOplog(OpType_ADD_REPLICA, payload.object_key,
-                        SerializeP2PPayload(payload),
-                        /*sync=*/!async_oplog_);
+                        SerializeP2PPayload(payload));
         if (record_err != ErrorCode::OK) {
             LOG(ERROR) << "AddReplica(P2P): failed to record oplog"
                        << ", client_id=" << client_id
                        << ", segment_id=" << segment_id
-                       << ", error=" << toString(record_err);
-            return tl::make_unexpected(record_err);
+                       << ", error=" << toString(record_err)
+                       << "; keeping the in-memory route";
         }
     }
     return {};

--- a/mooncake-store/src/p2p_master_service.cpp
+++ b/mooncake-store/src/p2p_master_service.cpp
@@ -5,6 +5,7 @@
 #include <variant>
 
 #include "ha/oplog/p2p_oplog_types.h"
+#include "ha/oplog/oplog_store_factory.h"
 #include "p2p_client_meta.h"
 
 namespace mooncake {
@@ -12,7 +13,8 @@ namespace mooncake {
 P2PMasterService::P2PMasterService(const MasterServiceConfig& config)
     : MasterService(config),
       max_replicas_per_key_(config.max_replicas_per_key),
-      async_add_replica_oplog_(config.oplog_store_type == "redis") {
+      async_oplog_(ParseOpLogStoreType(config.oplog_store_type) ==
+                   OpLogStoreType::REDIS) {
     client_manager_ = std::make_shared<P2PClientManager>(
         config.client_live_ttl_sec, config.client_crashed_ttl_sec,
         config.view_version);
@@ -30,7 +32,8 @@ ErrorCode P2PMasterService::RecordOplog(OpType type, const std::string& key,
         return ErrorCode::OK;
     }
 
-    auto result = manager->AppendAndPersist(type, key, payload, sync);
+    auto result =
+        manager->AppendAndPersist(type, key, payload, sync && !async_oplog_);
     if (!result.has_value()) {
         LOG(ERROR) << "P2PMasterService: failed to persist oplog"
                    << ", op_type=" << static_cast<int>(type) << ", key=" << key
@@ -40,8 +43,6 @@ ErrorCode P2PMasterService::RecordOplog(OpType type, const std::string& key,
     return ErrorCode::OK;
 }
 
-// XXX(P2P HA): Lifecycle mutations update memory before OpLog persistence,
-// unlike WAL-first designs. Revisit this ordering.
 auto P2PMasterService::RegisterClient(const RegisterClientRequest& req)
     -> tl::expected<RegisterClientResponse, ErrorCode> {
     if (GetClientManager().GetClient(req.client_id)) {
@@ -415,10 +416,13 @@ tl::expected<void, ErrorCode> P2PMasterService::InnerAddReplica(
         payload.client_id = client_id;
         payload.segment_id = segment_id;
         payload.size = size;
+        AddReplicaToSegmentIndex(shard, it->first, new_replica);
+        OnReplicaAdded(new_replica);
+        metadata.replicas_.push_back(std::move(new_replica));
         ErrorCode record_err =
             RecordOplog(OpType_ADD_REPLICA, payload.object_key,
                         SerializeP2PPayload(payload),
-                        /*sync=*/!async_add_replica_oplog_);
+                        /*sync=*/!async_oplog_);
         if (record_err != ErrorCode::OK) {
             LOG(ERROR) << "AddReplica(P2P): failed to record oplog"
                        << ", client_id=" << client_id
@@ -426,9 +430,6 @@ tl::expected<void, ErrorCode> P2PMasterService::InnerAddReplica(
                        << ", error=" << toString(record_err);
             return tl::make_unexpected(record_err);
         }
-        AddReplicaToSegmentIndex(shard, it->first, new_replica);
-        OnReplicaAdded(new_replica);
-        metadata.replicas_.push_back(std::move(new_replica));
     } else {
         std::vector<Replica> replicas;
         replicas.push_back(std::move(new_replica));
@@ -439,10 +440,15 @@ tl::expected<void, ErrorCode> P2PMasterService::InnerAddReplica(
         payload.client_id = client_id;
         payload.segment_id = segment_id;
         payload.size = size;
+        auto emplace_it =
+            shard.metadata.emplace(std::string(key), std::move(new_meta)).first;
+        AddReplicaToSegmentIndex(shard, emplace_it->first,
+                                 emplace_it->second->replicas_[0]);
+        OnReplicaAdded(emplace_it->second->replicas_[0]);
         ErrorCode record_err =
             RecordOplog(OpType_ADD_REPLICA, payload.object_key,
                         SerializeP2PPayload(payload),
-                        /*sync=*/!async_add_replica_oplog_);
+                        /*sync=*/!async_oplog_);
         if (record_err != ErrorCode::OK) {
             LOG(ERROR) << "AddReplica(P2P): failed to record oplog"
                        << ", client_id=" << client_id
@@ -450,11 +456,6 @@ tl::expected<void, ErrorCode> P2PMasterService::InnerAddReplica(
                        << ", error=" << toString(record_err);
             return tl::make_unexpected(record_err);
         }
-        auto emplace_it =
-            shard.metadata.emplace(std::string(key), std::move(new_meta)).first;
-        AddReplicaToSegmentIndex(shard, emplace_it->first,
-                                 emplace_it->second->replicas_[0]);
-        OnReplicaAdded(emplace_it->second->replicas_[0]);
     }
     return {};
 }

--- a/mooncake-store/tests/ha/oplog/p2p_oplog_applier_test.cpp
+++ b/mooncake-store/tests/ha/oplog/p2p_oplog_applier_test.cpp
@@ -5,7 +5,9 @@
 #include <xxhash.h>
 
 #include <cstdint>
+#include <chrono>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "ha/oplog/oplog_manager.h"
@@ -390,11 +392,7 @@ TEST(P2POpLogApplierTest, OutOfOrderEntryRejected) {
     EXPECT_EQ(applier.GetExpectedSequenceId(), 1u);
 }
 
-TEST(P2POpLogApplierTest, OutOfOrderEntryRejectedThenReplaySucceeds) {
-    // P2POpLogApplier does not buffer out-of-order entries (unlike base class
-    // which uses pending_entries_). Out-of-order entries are rejected, and
-    // the caller (OpLogReplicator) is responsible for re-delivering them
-    // after the gap is filled.
+TEST(P2POpLogApplierTest, OutOfOrderEntryBufferedThenGapFillDrainsIt) {
     P2PStandbyMetadataStore store;
     P2POpLogApplier applier(&store, "test-cluster");
 
@@ -413,19 +411,33 @@ TEST(P2POpLogApplierTest, OutOfOrderEntryRejectedThenReplaySucceeds) {
     p2.segment_id = seg;
     p2.size = 2048;
 
-    // seq=2 first — rejected (out-of-order)
+    // seq=2 first — reported pending and buffered by the common applier.
     EXPECT_FALSE(applier.ApplyOpLogEntry(MakeAddReplicaEntry(2, "key2", p2)));
     EXPECT_EQ(store.GetKeyCount(), 0u);
 
-    // seq=1 fills the gap — only key1 applied
+    // seq=1 fills the gap; the common pending queue then applies seq=2.
     EXPECT_TRUE(applier.ApplyOpLogEntry(MakeAddReplicaEntry(1, "key1", p1)));
-    EXPECT_EQ(store.GetKeyCount(), 1u);
-    EXPECT_EQ(applier.GetExpectedSequenceId(), 2u);
-
-    // Caller re-delivers seq=2 — now it succeeds
-    EXPECT_TRUE(applier.ApplyOpLogEntry(MakeAddReplicaEntry(2, "key2", p2)));
     EXPECT_EQ(store.GetKeyCount(), 2u);
     EXPECT_EQ(applier.GetExpectedSequenceId(), 3u);
+}
+
+TEST(P2POpLogApplierTest, MissingEntryTimeoutSkipsGapAndDrainsP2PEntry) {
+    P2PStandbyMetadataStore store;
+    P2POpLogApplier applier(&store, "test-cluster");
+
+    AddReplicaPayload payload;
+    payload.object_key = "after-gap";
+    payload.client_id = MakeUUID(1, 0);
+    payload.segment_id = MakeUUID(10, 0);
+    payload.size = 1024;
+
+    EXPECT_FALSE(
+        applier.ApplyOpLogEntry(MakeAddReplicaEntry(2, "after-gap", payload)));
+    applier.ProcessPendingEntries();  // start the common gap timer
+    std::this_thread::sleep_for(std::chrono::milliseconds(3100));
+    EXPECT_EQ(1u, applier.ProcessPendingEntries());
+    EXPECT_EQ(1u, store.GetKeyCount());
+    EXPECT_EQ(3u, applier.GetExpectedSequenceId());
 }
 
 // ============================================================================

--- a/mooncake-store/tests/ha/oplog/p2p_record_oplog_test.cpp
+++ b/mooncake-store/tests/ha/oplog/p2p_record_oplog_test.cpp
@@ -410,7 +410,7 @@ TEST_F(P2PRecordOplogTest,
     EXPECT_NE(service.GetClientManager().GetClient(req.client_id), nullptr);
 }
 
-TEST_F(P2PRecordOplogTest, AddReplicaDoesNotApplyWhenOplogPersistenceFails) {
+TEST_F(P2PRecordOplogTest, AddReplicaRemainsAppliedWhenOplogPersistenceFails) {
     P2PMasterService service(MakeConfig());
     const UUID client_id{32, 32};
     const UUID segment_id{33, 33};
@@ -428,8 +428,8 @@ TEST_F(P2PRecordOplogTest, AddReplicaDoesNotApplyWhenOplogPersistenceFails) {
     EXPECT_EQ(result.error(), ErrorCode::INTERNAL_ERROR);
 
     auto replicas = service.GetReplicaList(req.key);
-    ASSERT_FALSE(replicas.has_value());
-    EXPECT_EQ(replicas.error(), ErrorCode::OBJECT_NOT_FOUND);
+    ASSERT_TRUE(replicas.has_value());
+    ASSERT_EQ(1u, replicas->replicas.size());
 }
 
 TEST_F(P2PRecordOplogTest, RemoveReplicaDoesNotApplyWhenOplogPersistenceFails) {

--- a/mooncake-store/tests/ha/oplog/p2p_record_oplog_test.cpp
+++ b/mooncake-store/tests/ha/oplog/p2p_record_oplog_test.cpp
@@ -410,7 +410,7 @@ TEST_F(P2PRecordOplogTest,
     EXPECT_NE(service.GetClientManager().GetClient(req.client_id), nullptr);
 }
 
-TEST_F(P2PRecordOplogTest, AddReplicaRemainsAppliedWhenOplogPersistenceFails) {
+TEST_F(P2PRecordOplogTest, AddReplicaSucceedsWhenOplogPersistenceFails) {
     P2PMasterService service(MakeConfig());
     const UUID client_id{32, 32};
     const UUID segment_id{33, 33};
@@ -424,8 +424,7 @@ TEST_F(P2PRecordOplogTest, AddReplicaRemainsAppliedWhenOplogPersistenceFails) {
     req.size = 4096;
 
     auto result = service.AddReplica(req);
-    ASSERT_FALSE(result.has_value());
-    EXPECT_EQ(result.error(), ErrorCode::INTERNAL_ERROR);
+    ASSERT_TRUE(result.has_value());
 
     auto replicas = service.GetReplicaList(req.key);
     ASSERT_TRUE(replicas.has_value());

--- a/mooncake-store/tests/ha/oplog/redis_oplog_store_test.cpp
+++ b/mooncake-store/tests/ha/oplog/redis_oplog_store_test.cpp
@@ -41,6 +41,15 @@ TEST(RedisOpLogStoreStandaloneTest, EndpointRequiresExplicitPort) {
     }
 }
 
+TEST(RedisOpLogStoreStandaloneTest, OnlyAddReplicaIsBestEffort) {
+    EXPECT_TRUE(IsBestEffortRedisOpLog(OpType_ADD_REPLICA));
+    EXPECT_FALSE(IsBestEffortRedisOpLog(OpType_REMOVE_REPLICA));
+    EXPECT_FALSE(IsBestEffortRedisOpLog(OpType_MOUNT_SEGMENT));
+    EXPECT_FALSE(IsBestEffortRedisOpLog(OpType_UNMOUNT_SEGMENT));
+    EXPECT_FALSE(IsBestEffortRedisOpLog(OpType_REGISTER_CLIENT));
+    EXPECT_FALSE(IsBestEffortRedisOpLog(OpType_UNREGISTER_CLIENT));
+}
+
 class RedisOpLogStoreTest : public ::testing::Test {
    protected:
     void SetUp() override {
@@ -256,19 +265,60 @@ TEST_F(RedisOpLogStoreTest, AsyncWriteDoesNotAdvanceLatestPastGap) {
     EXPECT_EQ(2u, latest);
 }
 
-TEST_F(RedisOpLogStoreTest, RewriteExistingSequenceIsIdempotent) {
+TEST_F(RedisOpLogStoreTest, BypassOverflowCreatesReadableGap) {
+    auto writer = std::make_unique<RedisOpLogStore>(
+        cluster_id_, redis_endpoint_, /*enable_write=*/true,
+        /*poll_interval_ms=*/10, redis_password_, redis_username_,
+        /*db_index=*/0, /*async_queue_max_entries=*/1,
+        OpLogAsyncQueueOverflowMode::BYPASS,
+        /*best_effort_max_retries=*/3);
+    ASSERT_EQ(ErrorCode::OK, writer->Init());
+
+    // seq=2 is persisted but retained in-flight because seq=1 is missing,
+    // making the one-entry queue deterministically full.
+    ASSERT_EQ(ErrorCode::OK, writer->WriteOpLog(MakeEntry(2), false));
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    ASSERT_EQ(ErrorCode::OK, writer->WriteOpLog(MakeEntry(1), false));
+
+    uint64_t latest = 0;
+    for (int i = 0; i < 100 && latest != 2; ++i) {
+        ASSERT_EQ(ErrorCode::OK, writer->GetLatestSequenceId(latest));
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    ASSERT_EQ(2u, latest);
+
+    std::vector<OpLogEntry> entries;
+    ASSERT_EQ(ErrorCode::OK, writer->ReadOpLogSince(0, 10, entries));
+    ASSERT_EQ(1u, entries.size());
+    EXPECT_EQ(2u, entries.front().sequence_id);
+}
+
+TEST_F(RedisOpLogStoreTest, FactoryRejectsInvalidAsyncConfiguration) {
+    EXPECT_EQ(nullptr,
+              OpLogStoreFactory::Create(OpLogStoreType::REDIS, cluster_id_,
+                                        OpLogStoreRole::WRITER, redis_endpoint_,
+                                        10, redis_password_, redis_username_, 0,
+                                        0, "reject", 3));
+    EXPECT_EQ(nullptr,
+              OpLogStoreFactory::Create(OpLogStoreType::REDIS, cluster_id_,
+                                        OpLogStoreRole::WRITER, redis_endpoint_,
+                                        10, redis_password_, redis_username_, 0,
+                                        10, "invalid", 3));
+}
+
+TEST_F(RedisOpLogStoreTest, RewriteExistingSequenceOverwritesEntry) {
     auto writer = CreateWriter();
     auto entry = MakeEntry(1);
     ASSERT_EQ(ErrorCode::OK, writer->WriteOpLog(entry, true));
     EXPECT_EQ(ErrorCode::OK, writer->WriteOpLog(entry, true));
 
-    auto conflicting = entry;
-    conflicting.payload = "different_payload";
-    EXPECT_NE(ErrorCode::OK, writer->WriteOpLog(conflicting, true));
+    auto replacement = entry;
+    replacement.payload = "different_payload";
+    EXPECT_EQ(ErrorCode::OK, writer->WriteOpLog(replacement, true));
 
     OpLogEntry stored;
     ASSERT_EQ(ErrorCode::OK, writer->ReadOpLog(1, stored));
-    EXPECT_EQ(entry.payload, stored.payload);
+    EXPECT_EQ(replacement.payload, stored.payload);
 }
 
 TEST_F(RedisOpLogStoreTest, CleanupRemovesOldEntries) {


### PR DESCRIPTION
## Description

  P2P metadata uses a memory-first, non-transactional consistency model. This change makes Redis OpLog persistence asynchronous, keeping metadata mutations on the request path while dispatching OpLog writes to bounded background workers.

  Key changes:

  - Use a bounded asynchronous Redis OpLog queue with configurable `reject` or `bypass` behavior on overflow.
  - Retry admitted required entries indefinitely and use bounded retries for best-effort `ADD_REPLICA` entries.
  - Make `AddReplica` consistently update memory before recording its OpLog.
  - Allow the Redis progress watermark to advance across explicitly dropped entries.
  - Remove the Redis OpLog index and let readers scan sequence keys while skipping holes.
  - Reuse the common `OpLogApplier` ordering path for P2P entries.
  - Add configuration and tests for queue overflow, retries, holes, and P2P replay behavior.
  - Leave explicit TODOs for later standby out-of-order and gap-timeout handling.

  ## Module

  - [ ] Transfer Engine (`mooncake-transfer-engine`)
  - [ ] Mooncake Store (`mooncake-store`)
  - [ ] Mooncake EP (`mooncake-ep`)
  - [ ] Mooncake PG (`mooncake-pg`)
  - [ ] Integration (`mooncake-integration`)
  - [x] P2P Store (`mooncake-p2p-store`)
  - [ ] Python Wheel (`mooncake-wheel`)
  - [ ] Common (`mooncake-common`)
  - [ ] Mooncake RL (`mooncake-rl`)
  - [ ] CI/CD
  - [ ] Docs
  - [ ] Other

  ## Type of Change

  - [ ] Bug fix
  - [x] New feature
  - [x] Refactor
  - [ ] Breaking change
  - [ ] Documentation update
  - [x] Performance improvement
  - [ ] Other

  ## How Has This Been Tested?

  The affected targets were formatted and rebuilt in the development container. Direct P2P/Redis OpLog tests and the Redis HA end-to-end chaos test passed.

  `p2p_client_integration_test` passed 19 of 20 cases. The remaining `LargePutGet` failure is an existing intermittent Transfer Engine data mismatch; isolated repetition observed 14 passes and 6 failures out of 20 runs.

  **Test commands:**

  ```bash
  docker exec mooncake-dev cmake --build /workspace/build-redis-oplog -j4 \
    --target redis_oplog_store_test p2p_oplog_test \
    p2p_master_service_test p2p_client_integration_test \
    redis_chaos_test mooncake_master clientctl

  docker exec mooncake-dev bash -lc '
    cd /workspace/build-redis-oplog &&
    ctest -j1 \
      -R "^(redis_oplog_store_test|p2p_oplog_test|p2p_master_service_test|p2p_client_integration_test|redis_chaos_test)$" \
      --output-on-failure
  '
```
  Test results:

  - [x] Unit tests pass
  - [x] Redis HA end-to-end tests pass
  - [ ] Integration tests pass (one existing intermittent LargePutGet failure)
  - [ ] Manual testing done

  ## Checklist

  - [x] I have performed a self-review of my own code
  - [ ] I have formatted my code using ./scripts/code_format.sh
  - [ ] I have run pre-commit run --all-files and all hooks pass
  - [ ] I have updated the documentation (if applicable)
  - [x] I have added tests to prove my changes are effective
  - [ ] For changes >500 LOC: I have filed an RFC issue

  ## AI Assistance Disclosure

  - [ ] No AI tools were used
  - [x] AI tools were used (specify below)

  OpenAI Codex assisted with implementation, conflict resolution during rebase, code review, formatting, and test execution. The human submitter reviewed the design and implementation decisions.