### PR TITLE
[Store] make offload-enqueue failures observable

### DIFF
--- a/mooncake-store/include/master_metric_manager.h
+++ b/mooncake-store/include/master_metric_manager.h
@@ -45,6 +45,10 @@ class MasterMetricManager {
     void dec_file_cache_nums(int64_t val = 1);
     void reset_cache_total_nums();
 
+    // Offload Metrics
+    void inc_offload_enqueue_failed(int64_t val = 1);
+    int64_t get_offload_enqueue_failed();
+
     void inc_valid_get_nums(int64_t val = 1);
     void inc_total_get_nums(int64_t val = 1);
 
@@ -653,6 +657,7 @@ class MasterMetricManager {
     ylt::metric::counter_t file_cache_hit_bytes_;
     ylt::metric::gauge_t mem_cache_nums_;
     ylt::metric::gauge_t file_cache_nums_;
+    ylt::metric::counter_t offload_enqueue_failed_;
 
     ylt::metric::counter_t valid_get_nums_;
     ylt::metric::counter_t total_get_nums_;

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -86,6 +86,7 @@ class MasterServiceHATest;
 // invalidate a segment allocator via PrepareUnmountSegment WITHOUT the
 // ClearInvalidHandles sweep that MasterService::UnmountSegment performs.
 class MasterServiceProcessingKeyDoubleEraseTest;
+class MasterServiceTestPeer;
 }  // namespace test
 namespace benchmarks {
 class BatchEvictBench;
@@ -118,6 +119,7 @@ class MasterService {
     friend class test::BatchEvictTest;
     // double-erase processing_keys UAF repro (2026-08-03 prod segfault)
     friend class test::MasterServiceProcessingKeyDoubleEraseTest;
+    friend class test::MasterServiceTestPeer;
     friend class MasterSnapshotManager;    // Allow access to internal state for
                                            // snapshot
     friend class ha::MasterSnapshotCodec;  // Allow codec to access private

--- a/mooncake-store/src/master_metric_manager.cpp
+++ b/mooncake-store/src/master_metric_manager.cpp
@@ -291,6 +291,9 @@ MasterMetricManager::MasterMetricManager()
                       "Current number of cached values in the memory pool"),
       file_cache_nums_("file_cache_nums_",
                        "Current number of cached values in SSD cache"),
+      offload_enqueue_failed_(
+          "master_offload_enqueue_failed_total",
+          "Total number of failed PushOffloadingQueue attempts"),
       valid_get_nums_("valid_get_nums_",
                       "Total number of GetReplicaList operations that returned "
                       "at least one completed replica"),
@@ -499,6 +502,7 @@ void MasterMetricManager::update_metrics_for_zero_output() {
     promotion_in_flight_metric_.update(0);
 
     // Update Counters (use inc(0) to mark as changed)
+    offload_enqueue_failed_.inc(0);
     promotion_admitted_.inc(0);
     promotion_completed_.inc(0);
     promotion_completed_bytes_.inc(0);
@@ -895,6 +899,12 @@ int64_t MasterMetricManager::get_mem_cache_nums() {
 }
 int64_t MasterMetricManager::get_file_cache_nums() {
     return file_cache_nums_.value();
+}
+void MasterMetricManager::inc_offload_enqueue_failed(int64_t val) {
+    offload_enqueue_failed_.inc(val);
+}
+int64_t MasterMetricManager::get_offload_enqueue_failed() {
+    return offload_enqueue_failed_.value();
 }
 void MasterMetricManager::dec_mem_cache_nums(int64_t val) {
     mem_cache_nums_.dec(val);
@@ -1862,6 +1872,7 @@ std::string MasterMetricManager::serialize_metrics() {
     serialize_metric(move_revoke_failures_);
     serialize_metric(evict_disk_replica_requests_);
     serialize_metric(evict_disk_replica_failures_);
+    serialize_metric(offload_enqueue_failed_);
 
     // Serialize CreateCopyTask, CreateMoveTask, MarkTaskToComplete, QueryTask,
     // FetchTasks Request Counters

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -3841,6 +3841,16 @@ auto MasterService::PutEnd(const UUID& client_id, const ObjectMeta& object_meta,
                                            std::chrono::system_clock::now()});
                         task_created = true;
                     }
+                } else {
+                    // A failed enqueue must not vanish silently: emit a
+                    // sampled warning, mirroring the eviction-path callers of
+                    // PushOffloadingQueue (#2997). The failure itself is
+                    // counted inside PushOffloadingQueue.
+                    LOG_EVERY_N(WARNING, 100)
+                        << "[PUT] PushOffloadingQueue failed for key "
+                        << object_id.user_key << ": "
+                        << toString(result.error())
+                        << " (this enqueue attempt failed)";
                 }
             });
     }
@@ -6254,6 +6264,12 @@ auto MasterService::NotifyOffloadSuccess(
 
 tl::expected<void, ErrorCode> MasterService::PushOffloadingQueue(
     const ObjectIdentity& object_id, Replica& replica) {
+    // Count every failed enqueue attempt here so no caller can drop it
+    // silently (#2997).
+    auto fail = [](ErrorCode code) {
+        MasterMetricManager::instance().inc_offload_enqueue_failed();
+        return tl::make_unexpected(code);
+    };
     const auto& segment_names = replica.get_segment_names();
     if (segment_names.empty()) {
         return {};
@@ -6268,28 +6284,37 @@ tl::expected<void, ErrorCode> MasterService::PushOffloadingQueue(
             local_disk_segment_access.getClientByName();
         auto client_id_it = client_by_name.find(segment_name_it.value());
         if (client_id_it == client_by_name.end()) {
-            return tl::make_unexpected(ErrorCode::SEGMENT_NOT_FOUND);
+            return fail(ErrorCode::SEGMENT_NOT_FOUND);
         }
         auto& client_local_disk_segment =
             local_disk_segment_access.getClientLocalDiskSegment();
         auto local_disk_segment_it =
             client_local_disk_segment.find(client_id_it->second);
         if (local_disk_segment_it == client_local_disk_segment.end()) {
-            return tl::make_unexpected(ErrorCode::UNABLE_OFFLOADING);
+            return fail(ErrorCode::UNABLE_OFFLOADING);
         }
         MutexLocker locker(&local_disk_segment_it->second->offloading_mutex_);
         if (!local_disk_segment_it->second->enable_offloading) {
-            return tl::make_unexpected(ErrorCode::UNABLE_OFFLOADING);
+            return fail(ErrorCode::UNABLE_OFFLOADING);
         }
-        if (local_disk_segment_it->second->offloading_objects.size() >=
-            offloading_queue_limit_) {
-            return tl::make_unexpected(ErrorCode::KEYS_ULTRA_LIMIT);
+        auto& offloading_objects =
+            local_disk_segment_it->second->offloading_objects;
+        const auto storage_key =
+            object_id.tenant_id.MakeScopedKey(object_id.user_key);
+        if (offloading_objects.contains(storage_key)) {
+            // A duplicate enqueue is benign (eager and eviction paths can
+            // race); report it to the caller but do not count it as a
+            // failure, even when the queue is otherwise full.
+            return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
+        }
+        if (offloading_objects.size() >= offloading_queue_limit_) {
+            return fail(ErrorCode::KEYS_ULTRA_LIMIT);
         }
         const int64_t size = replica.get_descriptor()
                                  .get_memory_descriptor()
                                  .buffer_descriptor.size_;
-        auto res = local_disk_segment_it->second->offloading_objects.emplace(
-            object_id.tenant_id.MakeScopedKey(object_id.user_key),
+        auto res = offloading_objects.emplace(
+            storage_key,
             OffloadTaskItem{.tenant_id = object_id.tenant_id.value(),
                             .key = object_id.user_key,
                             .size = size});

--- a/mooncake-store/tests/master_admin_server_test.cpp
+++ b/mooncake-store/tests/master_admin_server_test.cpp
@@ -163,6 +163,9 @@ TEST_F(MasterAdminServerTest, MetricsEndpointReturns200) {
     auto resp = HttpGet(port, "/metrics");
     EXPECT_EQ(resp.http_status, 200);
     EXPECT_NE(resp.body.find("master_"), std::string::npos);
+    EXPECT_NE(
+        resp.body.find("# TYPE master_offload_enqueue_failed_total counter"),
+        std::string::npos);
 
     admin.Stop();
 }

--- a/mooncake-store/tests/master_service_ssd_test.cpp
+++ b/mooncake-store/tests/master_service_ssd_test.cpp
@@ -12,6 +12,15 @@
 
 namespace mooncake::test {
 
+class MasterServiceTestPeer {
+   public:
+    static tl::expected<void, ErrorCode> PushOffloadingQueue(
+        MasterService& service, const std::string& key, Replica& replica) {
+        return service.PushOffloadingQueue(
+            MasterService::ObjectIdentity{TenantId::Default(), key}, replica);
+    }
+};
+
 std::unique_ptr<MasterService> CreateMasterServiceWithSSDFeat(
     const std::string& root_fs_dir) {
     return std::make_unique<MasterService>(
@@ -91,6 +100,147 @@ void ExpectNextAllocationOnSegment(MasterService& service,
                   .get_memory_descriptor()
                   .buffer_descriptor.transport_endpoint_,
               expected_segment);
+}
+
+TEST_F(MasterServiceSSDTest, PutEndSurvivesOffloadEnqueueFailure) {
+    // Reproduction for issue #2997: with eager offload enabled but no local
+    // disk segment mounted, the enqueue in PutEnd fails (UNABLE_OFFLOADING).
+    // PutEnd must still report success (enqueue is best-effort), but the
+    // failure used to vanish without a trace.
+    auto service_ = CreateSsdAwareOffloadService();
+
+    UUID client_id = generate_uuid();
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = "mem_only_segment";
+    segment.base = 0x100000000;
+    segment.size = 64 * 1024 * 1024;
+    segment.te_endpoint = segment.name;
+    ASSERT_TRUE(service_->MountSegment(segment, client_id).has_value());
+    // no MountLocalDiskSegment call -> PushOffloadingQueue will fail
+
+    ReplicateConfig config;
+    config.replica_num = 1;
+    ASSERT_TRUE(service_
+                    ->PutStart(client_id, "silent_key", TenantId::Default(),
+                               1024, config)
+                    .has_value());
+    EXPECT_TRUE(service_
+                    ->PutEnd(client_id, "silent_key", TenantId::Default(),
+                             ReplicaType::MEMORY)
+                    .has_value());
+}
+
+TEST_F(MasterServiceSSDTest, PutEndOffloadEnqueueFailureIsCounted) {
+    auto service_ = CreateSsdAwareOffloadService();
+    auto& metrics = MasterMetricManager::instance();
+    const int64_t base = metrics.get_offload_enqueue_failed();
+
+    UUID client_id = generate_uuid();
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = "mem_only_segment_counted";
+    segment.base = 0x140000000;
+    segment.size = 64 * 1024 * 1024;
+    segment.te_endpoint = segment.name;
+    ASSERT_TRUE(service_->MountSegment(segment, client_id).has_value());
+
+    ReplicateConfig config;
+    config.replica_num = 1;
+    ASSERT_TRUE(service_
+                    ->PutStart(client_id, "counted_key", TenantId::Default(),
+                               1024, config)
+                    .has_value());
+    EXPECT_TRUE(service_
+                    ->PutEnd(client_id, "counted_key", TenantId::Default(),
+                             ReplicaType::MEMORY)
+                    .has_value());
+    EXPECT_EQ(base + 1, metrics.get_offload_enqueue_failed());
+    EXPECT_NE(std::string::npos,
+              metrics.serialize_metrics().find(
+                  "# TYPE master_offload_enqueue_failed_total counter"));
+}
+
+TEST_F(MasterServiceSSDTest, PushOffloadingQueueWithoutUsableSegmentIsNoop) {
+    // A replica without any usable segment names is a no-op success, not a
+    // failure (mirrors the original silent behavior).
+    auto service_ = CreateSsdAwareOffloadService();
+    auto& metrics = MasterMetricManager::instance();
+    const int64_t base = metrics.get_offload_enqueue_failed();
+
+    auto buffer = std::make_unique<AllocatedBuffer>(
+        std::shared_ptr<BufferAllocatorBase>{}, nullptr, 1024);
+    Replica replica(std::move(buffer), ReplicaStatus::COMPLETE);
+
+    auto result = MasterServiceTestPeer::PushOffloadingQueue(
+        *service_, "no_usable_segment_key", replica);
+    EXPECT_TRUE(result.has_value());
+    EXPECT_EQ(base, metrics.get_offload_enqueue_failed());
+}
+
+TEST_F(MasterServiceSSDTest, PutEndOffloadQueueFullIsCounted) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.offloading_queue_limit =
+        1;  // the second enqueue hits KEYS_ULTRA_LIMIT
+    auto service_ = std::make_unique<MasterService>(config);
+    auto& metrics = MasterMetricManager::instance();
+    const int64_t base = metrics.get_offload_enqueue_failed();
+
+    UUID client_id = generate_uuid();
+    MountMemoryAndLocalDisk(*service_, client_id, "full_segment", 0x180000000);
+
+    ASSERT_TRUE(service_
+                    ->PutStart(client_id, "full_key_1", TenantId::Default(),
+                               1024, {.replica_num = 1})
+                    .has_value());
+    EXPECT_TRUE(service_
+                    ->PutEnd(client_id, "full_key_1", TenantId::Default(),
+                             ReplicaType::MEMORY)
+                    .has_value());
+
+    ASSERT_TRUE(service_
+                    ->PutStart(client_id, "full_key_2", TenantId::Default(),
+                               1024, {.replica_num = 1})
+                    .has_value());
+    EXPECT_TRUE(service_
+                    ->PutEnd(client_id, "full_key_2", TenantId::Default(),
+                             ReplicaType::MEMORY)
+                    .has_value());
+    EXPECT_EQ(base + 1, metrics.get_offload_enqueue_failed());
+}
+
+TEST_F(MasterServiceSSDTest, PutEndDuplicateEnqueueIsBenignWhenQueueIsFull) {
+    // Keep the queue full after the first enqueue. A second enqueue for the
+    // same key must still be classified as OBJECT_ALREADY_EXISTS rather than
+    // KEYS_ULTRA_LIMIT, and therefore must not increment the failure counter.
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.offloading_queue_limit = 1;
+    auto service_ = std::make_unique<MasterService>(config);
+    auto& metrics = MasterMetricManager::instance();
+    const int64_t base = metrics.get_offload_enqueue_failed();
+
+    UUID client_id = generate_uuid();
+    MountMemoryAndLocalDisk(*service_, client_id, "dup_segment", 0x1c0000000);
+
+    ASSERT_TRUE(service_
+                    ->PutStart(client_id, "dup_key", TenantId::Default(), 1024,
+                               {.replica_num = 1})
+                    .has_value());
+    EXPECT_TRUE(service_
+                    ->PutEnd(client_id, "dup_key", TenantId::Default(),
+                             ReplicaType::MEMORY)
+                    .has_value());
+    EXPECT_EQ(base, metrics.get_offload_enqueue_failed());
+
+    // PutEnd keeps best-effort success semantics; internally the duplicate
+    // enqueue is benign and must not increment the failure counter.
+    EXPECT_TRUE(service_
+                    ->PutEnd(client_id, "dup_key", TenantId::Default(),
+                             ReplicaType::MEMORY)
+                    .has_value());
+    EXPECT_EQ(base, metrics.get_offload_enqueue_failed());
 }
 
 TEST_F(MasterServiceSSDTest, PutEndBothReplica) {


### PR DESCRIPTION
## Description

Fixes the silent-drop side of #2997: in eager offload mode (`enable_offload=1`, `offload_on_evict=0`), `MasterService::PutEnd` called `PushOffloadingQueue` and acted only on success. A failed enqueue could leave the object RAM-only without a log or metric.

## What this PR does

- Adds `master_offload_enqueue_failed_total` to `MasterMetricManager` and increments it inside `PushOffloadingQueue`, covering every caller and every enqueue failure exit.
- Initializes the counter in `update_metrics_for_zero_output()` and exports it from `serialize_metrics()` as a Prometheus counter.
- Emits a sampled `LOG_EVERY_N(WARNING, 100)` warning from the `PutEnd` failure branch with the key and `ErrorCode`.
- Treats replicas with no usable segment name (empty or all-`nullopt`) as `UNABLE_OFFLOADING` instead of silently returning success.
- Keeps `PutEnd` best-effort semantics unchanged: enqueue failure remains observable but does not fail the completed PUT.

## Module

- Mooncake Store (`mooncake-store`)

## Type of Change

- Bug fix

## How Has This Been Tested?

New and strengthened coverage:

- `PutEndSurvivesOffloadEnqueueFailure`: PUT still succeeds when eager enqueue fails.
- `PutEndOffloadEnqueueFailureIsCounted`: missing local-disk segment increments the counter and verifies serialized Prometheus type.
- `PushOffloadingQueueWithoutUsableSegmentIsCounted`: empty/all-null segment metadata returns `UNABLE_OFFLOADING` and increments the counter.
- `PutEndOffloadQueueFullIsCounted`: queue-full failure increments the counter.
- `MetricsEndpointReturns200`: the HTTP metrics response contains `# TYPE master_offload_enqueue_failed_total counter`.

Current revision results:

- `master_service_ssd_test`: 22/22 passed.
- Final focused offload regression run: 4/4 passed.
- `master_service_ssd_test` and `master_admin_server_test` targets build successfully.
- clang-format 20 and `git diff --check` pass.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh` (clang-format 20)
- [x] Documentation update is not applicable
- [x] I have added tests to prove my changes are effective
- [x] Change is under 500 LOC

## AI Assistance Disclosure

AI tools were used for reproduction, implementation, tests, and review iterations; all changes were reviewed and verified locally by the contributor.