### PR TITLE
[TENT] Remove dead metrics config flags and wire validateConfig into initialize()

### DIFF
--- a/docs/source/design/tent/metrics.md
+++ b/docs/source/design/tent/metrics.md
@@ -349,7 +349,7 @@ The `metrics/latency_buckets` and `metrics/size_buckets` config keys, and the `T
 
 The `metrics/enable_prometheus` and `metrics/enable_json` config keys, and the `TENT_METRICS_ENABLE_PROMETHEUS` / `TENT_METRICS_ENABLE_JSON` environment variables, were removed and are now silently ignored. The `/metrics` and `/metrics/json` HTTP endpoints are now registered unconditionally and cannot be toggled independently — both are read-only and served on the same port, so there was no real scenario where a deployment wanted one disabled.
 
-**Migration:** remove these keys from your `transfer-engine.json` and unset the environment variables. If you need to disable the HTTP endpoint entirely, set `metrics/enabled` to `false` (or `TENT_METRICS_ENABLED=false`) to run in log-only mode.
+**Migration:** remove these keys from your `transfer-engine.json` and unset the environment variables. To fully disable the metrics subsystem (no HTTP server, no periodic summary logging, no recording), set `metrics/enabled` to `false` (or `TENT_METRICS_ENABLED=false`). Note that "log-only mode" — where periodic summaries are still logged but `/metrics` is unavailable — only occurs when metrics are enabled but the HTTP port cannot be bound (e.g. port conflict); it is not triggered by `metrics/enabled=false`.
 
 ### Validation
 

--- a/docs/source/design/tent/metrics.md
+++ b/docs/source/design/tent/metrics.md
@@ -65,9 +65,7 @@ TENT metrics configuration is integrated into the main `transfer-engine.json` co
     "http_port": 9100,
     "http_host": "0.0.0.0",
     "http_server_threads": 2,
-    "report_interval_seconds": 30,
-    "enable_prometheus": true,
-    "enable_json": true
+    "report_interval_seconds": 30
   },
   "transports": {
     // ... transport configuration
@@ -88,10 +86,6 @@ TENT_METRICS_HTTP_PORT=9100
 TENT_METRICS_HTTP_HOST=0.0.0.0
 TENT_METRICS_HTTP_SERVER_THREADS=2
 TENT_METRICS_REPORT_INTERVAL=30  # Set to 0 to disable periodic logging
-
-# Output formats
-TENT_METRICS_ENABLE_PROMETHEUS=true
-TENT_METRICS_ENABLE_JSON=true
 ```
 
 ## Quick Start
@@ -352,6 +346,10 @@ The `metrics/latency_buckets` and `metrics/size_buckets` config keys, and the `T
 **Migration:** remove these keys from your `transfer-engine.json` and unset the environment variables. If custom bucket boundaries are required, edit `kLatencyBuckets` / `kSizeBuckets` in `tent/metrics/tent_metrics.h` and rebuild.
 
 > **Note:** the previous runtime-configurable implementation had a latent bug — the JSON output labeled custom buckets with the compile-time default boundaries, so `/metrics/json` was already mislabeled for custom-bucket deployments. Removing the knob fixes this rather than preserving a buggy code path.
+
+The `metrics/enable_prometheus` and `metrics/enable_json` config keys, and the `TENT_METRICS_ENABLE_PROMETHEUS` / `TENT_METRICS_ENABLE_JSON` environment variables, were removed and are now silently ignored. The `/metrics` and `/metrics/json` HTTP endpoints are now registered unconditionally and cannot be toggled independently — both are read-only and served on the same port, so there was no real scenario where a deployment wanted one disabled.
+
+**Migration:** remove these keys from your `transfer-engine.json` and unset the environment variables. If you need to disable the HTTP endpoint entirely, set `metrics/enabled` to `false` (or `TENT_METRICS_ENABLED=false`) to run in log-only mode.
 
 ### Validation
 

--- a/mooncake-transfer-engine/tent/config/transfer-engine.json
+++ b/mooncake-transfer-engine/tent/config/transfer-engine.json
@@ -18,8 +18,6 @@
         "http_host": "0.0.0.0",
         "http_server_threads": 2,
         "report_interval_seconds": 30,
-        "enable_prometheus": true,
-        "enable_json": true,
         "latency_buckets": [
             0.000125, 0.00015, 0.0002, 0.00025, 0.0003, 0.0004, 0.0005,
             0.00075, 0.001, 0.0015, 0.002, 0.003, 0.005, 0.007,

--- a/mooncake-transfer-engine/tent/include/tent/metrics/config_loader.h
+++ b/mooncake-transfer-engine/tent/include/tent/metrics/config_loader.h
@@ -29,8 +29,6 @@ struct MetricsConfig {
     uint16_t http_port = 9100;
     uint16_t http_server_threads = 2;       // HTTP server thread count
     uint32_t report_interval_seconds = 30;  // 0 means disabled
-    bool enable_prometheus = true;
-    bool enable_json = true;
 };
 
 // Helper class to load metrics configuration from various sources
@@ -69,8 +67,6 @@ constexpr const char* METRICS_HTTP_SERVER_THREADS =
     "metrics/http_server_threads";
 constexpr const char* METRICS_REPORT_INTERVAL =
     "metrics/report_interval_seconds";
-constexpr const char* METRICS_ENABLE_PROMETHEUS = "metrics/enable_prometheus";
-constexpr const char* METRICS_ENABLE_JSON = "metrics/enable_json";
 
 // Environment variable names (with TENT_ prefix)
 constexpr const char* ENV_METRICS_ENABLED = "TENT_METRICS_ENABLED";
@@ -80,9 +76,6 @@ constexpr const char* ENV_METRICS_HTTP_SERVER_THREADS =
     "TENT_METRICS_HTTP_SERVER_THREADS";
 constexpr const char* ENV_METRICS_REPORT_INTERVAL =
     "TENT_METRICS_REPORT_INTERVAL";
-constexpr const char* ENV_METRICS_ENABLE_PROMETHEUS =
-    "TENT_METRICS_ENABLE_PROMETHEUS";
-constexpr const char* ENV_METRICS_ENABLE_JSON = "TENT_METRICS_ENABLE_JSON";
 }  // namespace config_keys
 
 }  // namespace tent

--- a/mooncake-transfer-engine/tent/src/metrics/config_loader.cpp
+++ b/mooncake-transfer-engine/tent/src/metrics/config_loader.cpp
@@ -48,18 +48,6 @@ void MetricsConfigLoader::applyEnvironmentOverrides(MetricsConfig& config) {
             config.http_server_threads = static_cast<uint16_t>(threads);
         }
     }
-
-    if (const char* env_val =
-            std::getenv(config_keys::ENV_METRICS_ENABLE_PROMETHEUS)) {
-        config.enable_prometheus =
-            ConfigHelper::parseBool(env_val, config.enable_prometheus);
-    }
-
-    if (const char* env_val =
-            std::getenv(config_keys::ENV_METRICS_ENABLE_JSON)) {
-        config.enable_json =
-            ConfigHelper::parseBool(env_val, config.enable_json);
-    }
 }
 
 MetricsConfig MetricsConfigLoader::loadFromConfig(const Config& config) {
@@ -79,11 +67,6 @@ MetricsConfig MetricsConfigLoader::loadFromConfig(const Config& config) {
     metrics_config.report_interval_seconds =
         config.get(config_keys::METRICS_REPORT_INTERVAL,
                    metrics_config.report_interval_seconds);
-    metrics_config.enable_prometheus =
-        config.get(config_keys::METRICS_ENABLE_PROMETHEUS,
-                   metrics_config.enable_prometheus);
-    metrics_config.enable_json = config.get(config_keys::METRICS_ENABLE_JSON,
-                                            metrics_config.enable_json);
 
     LOG(INFO) << "Loaded metrics config from Config object: enabled="
               << metrics_config.enabled
@@ -127,11 +110,6 @@ MetricsConfig MetricsConfigLoader::loadWithDefaults(const Config* config) {
         metrics_config.report_interval_seconds =
             config->get(config_keys::METRICS_REPORT_INTERVAL,
                         metrics_config.report_interval_seconds);
-        metrics_config.enable_prometheus =
-            config->get(config_keys::METRICS_ENABLE_PROMETHEUS,
-                        metrics_config.enable_prometheus);
-        metrics_config.enable_json = config->get(
-            config_keys::METRICS_ENABLE_JSON, metrics_config.enable_json);
     }
 
     return metrics_config;
@@ -151,16 +129,6 @@ bool MetricsConfigLoader::validateConfig(const MetricsConfig& config,
     if (config.http_server_threads == 0) {
         if (error_msg) {
             *error_msg = "Invalid HTTP server threads: must be > 0";
-        }
-        return false;
-    }
-
-    // Validate at least one output format is enabled
-    if (!config.enable_prometheus && !config.enable_json) {
-        if (error_msg) {
-            *error_msg =
-                "At least one output format (Prometheus or JSON) must be "
-                "enabled";
         }
         return false;
     }

--- a/mooncake-transfer-engine/tent/src/metrics/tent_metrics.cpp
+++ b/mooncake-transfer-engine/tent/src/metrics/tent_metrics.cpp
@@ -37,6 +37,18 @@ Status TentMetrics::initialize(const MetricsConfig& config) {
         return Status::OK();  // Already initialized by another thread
     }
 
+    // Validate configuration before doing anything else. An invalid config
+    // (e.g. port 0, zero HTTP threads) would otherwise cause confusing
+    // failures inside initHttpServer(); fail fast with a clear error instead.
+    std::string error_msg;
+    if (!MetricsConfigLoader::validateConfig(config, &error_msg)) {
+        LOG(ERROR) << "Invalid TENT metrics config: " << error_msg
+                   << "; metrics disabled";
+        initialized_.store(false, std::memory_order_relaxed);
+        return Status::InvalidArgument(
+            "Invalid TENT metrics config: " + error_msg + LOC_MARK);
+    }
+
     config_ = config;
 
     // Set runtime enabled state from config

--- a/mooncake-transfer-engine/tent/src/metrics/tent_metrics.cpp
+++ b/mooncake-transfer-engine/tent/src/metrics/tent_metrics.cpp
@@ -31,22 +31,23 @@ TentMetrics::~TentMetrics() { shutdown(); }
 #if TENT_METRICS_ENABLED
 
 Status TentMetrics::initialize(const MetricsConfig& config) {
-    // Use compare_exchange to prevent race condition during initialization
-    bool expected = false;
-    if (!initialized_.compare_exchange_strong(expected, true)) {
-        return Status::OK();  // Already initialized by another thread
-    }
-
-    // Validate configuration before doing anything else. An invalid config
+    // Validate configuration before touching initialized_. An invalid config
     // (e.g. port 0, zero HTTP threads) would otherwise cause confusing
     // failures inside initHttpServer(); fail fast with a clear error instead.
+    // Validating before the compare_exchange avoids a window where
+    // initialized_ is set to true and then rolled back on failure.
     std::string error_msg;
     if (!MetricsConfigLoader::validateConfig(config, &error_msg)) {
         LOG(ERROR) << "Invalid TENT metrics config: " << error_msg
                    << "; metrics disabled";
-        initialized_.store(false, std::memory_order_relaxed);
         return Status::InvalidArgument(
             "Invalid TENT metrics config: " + error_msg + LOC_MARK);
+    }
+
+    // Use compare_exchange to prevent race condition during initialization
+    bool expected = false;
+    if (!initialized_.compare_exchange_strong(expected, true)) {
+        return Status::OK();  // Already initialized by another thread
     }
 
     config_ = config;

--- a/mooncake-transfer-engine/tent/tests/metrics_config_loader_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/metrics_config_loader_test.cpp
@@ -64,8 +64,6 @@ TEST(MetricsConfigLoaderTest, GetDefaultConfigReturnsExpectedDefaults) {
     EXPECT_EQ(config.http_port, 9100);
     EXPECT_EQ(config.http_server_threads, 2);
     EXPECT_EQ(config.report_interval_seconds, 30);
-    EXPECT_TRUE(config.enable_prometheus);
-    EXPECT_TRUE(config.enable_json);
 }
 
 //------------------------------------------------------------------------------
@@ -79,9 +77,7 @@ TEST(MetricsConfigLoaderTest, LoadFromConfigWithAllValues) {
         "metrics/http_port": 8080,
         "metrics/http_host": "127.0.0.1",
         "metrics/http_server_threads": 4,
-        "metrics/report_interval_seconds": 60,
-        "metrics/enable_prometheus": false,
-        "metrics/enable_json": true
+        "metrics/report_interval_seconds": 60
     })";
     ASSERT_TRUE(config.load(json_content).ok());
 
@@ -92,8 +88,6 @@ TEST(MetricsConfigLoaderTest, LoadFromConfigWithAllValues) {
     EXPECT_EQ(metrics_config.http_host, "127.0.0.1");
     EXPECT_EQ(metrics_config.http_server_threads, 4);
     EXPECT_EQ(metrics_config.report_interval_seconds, 60);
-    EXPECT_FALSE(metrics_config.enable_prometheus);
-    EXPECT_TRUE(metrics_config.enable_json);
 }
 
 TEST(MetricsConfigLoaderTest, LoadFromConfigWithPartialValues) {
@@ -136,8 +130,6 @@ TEST(MetricsConfigLoaderTest, LoadFromEnvironmentWithAllVars) {
     EnvVarGuard g3(config_keys::ENV_METRICS_HTTP_HOST, "192.168.1.1");
     EnvVarGuard g4(config_keys::ENV_METRICS_HTTP_SERVER_THREADS, "8");
     EnvVarGuard g5(config_keys::ENV_METRICS_REPORT_INTERVAL, "120");
-    EnvVarGuard g6(config_keys::ENV_METRICS_ENABLE_PROMETHEUS, "true");
-    EnvVarGuard g7(config_keys::ENV_METRICS_ENABLE_JSON, "false");
 
     MetricsConfig config = MetricsConfigLoader::loadFromEnvironment();
 
@@ -146,8 +138,6 @@ TEST(MetricsConfigLoaderTest, LoadFromEnvironmentWithAllVars) {
     EXPECT_EQ(config.http_host, "192.168.1.1");
     EXPECT_EQ(config.http_server_threads, 8);
     EXPECT_EQ(config.report_interval_seconds, 120);
-    EXPECT_TRUE(config.enable_prometheus);
-    EXPECT_FALSE(config.enable_json);
 }
 
 TEST(MetricsConfigLoaderTest, LoadFromEnvironmentWithPartialVars) {
@@ -228,17 +218,6 @@ TEST(MetricsConfigLoaderTest, ValidateConfigInvalidThreadsZero) {
     EXPECT_FALSE(MetricsConfigLoader::validateConfig(config, &error_msg));
     EXPECT_FALSE(error_msg.empty());
     EXPECT_NE(error_msg.find("threads"), std::string::npos);
-}
-
-TEST(MetricsConfigLoaderTest, ValidateConfigNoOutputFormatEnabled) {
-    MetricsConfig config = MetricsConfigLoader::getDefaultConfig();
-    config.enable_prometheus = false;
-    config.enable_json = false;
-    std::string error_msg;
-
-    EXPECT_FALSE(MetricsConfigLoader::validateConfig(config, &error_msg));
-    EXPECT_FALSE(error_msg.empty());
-    EXPECT_NE(error_msg.find("format"), std::string::npos);
 }
 
 TEST(MetricsConfigLoaderTest, ValidateConfigNullErrorMsg) {
@@ -330,9 +309,6 @@ TEST(ConfigKeysTest, ConfigKeyConstants) {
                  "metrics/http_server_threads");
     EXPECT_STREQ(config_keys::METRICS_REPORT_INTERVAL,
                  "metrics/report_interval_seconds");
-    EXPECT_STREQ(config_keys::METRICS_ENABLE_PROMETHEUS,
-                 "metrics/enable_prometheus");
-    EXPECT_STREQ(config_keys::METRICS_ENABLE_JSON, "metrics/enable_json");
 }
 
 TEST(ConfigKeysTest, EnvVarConstants) {
@@ -344,10 +320,6 @@ TEST(ConfigKeysTest, EnvVarConstants) {
                  "TENT_METRICS_HTTP_SERVER_THREADS");
     EXPECT_STREQ(config_keys::ENV_METRICS_REPORT_INTERVAL,
                  "TENT_METRICS_REPORT_INTERVAL");
-    EXPECT_STREQ(config_keys::ENV_METRICS_ENABLE_PROMETHEUS,
-                 "TENT_METRICS_ENABLE_PROMETHEUS");
-    EXPECT_STREQ(config_keys::ENV_METRICS_ENABLE_JSON,
-                 "TENT_METRICS_ENABLE_JSON");
 }
 
 }  // namespace

--- a/mooncake-transfer-engine/tent/tests/tent_metrics_example.cpp
+++ b/mooncake-transfer-engine/tent/tests/tent_metrics_example.cpp
@@ -78,9 +78,6 @@ int main(int argc, char* argv[]) {
     std::cout << "\nConfiguration:" << std::endl;
     std::cout << "  - HTTP Server: " << config.http_host << ":"
               << config.http_port << std::endl;
-    std::cout << "  - Prometheus: "
-              << (config.enable_prometheus ? "enabled" : "disabled")
-              << std::endl;
     std::cout << "  - Runtime metrics: "
               << (config.enabled ? "enabled" : "disabled") << std::endl;
 


### PR DESCRIPTION
## Description

The TENT metrics system declared several configuration options that had no
effect at runtime, and shipped validation logic that was never invoked.

**Problem 1 — dead config flags.** `MetricsConfig::enable_prometheus` and
`enable_json` (plus their `TENT_METRICS_ENABLE_PROMETHEUS` / `_JSON` env vars
and `metrics/enable_prometheus` / `metrics/enable_json` JSON keys) were parsed
into the config struct and documented, but `registerHttpHandlers()` registered
all HTTP endpoints unconditionally. The flags were silently ignored, so the
configuration surface lied to operators.

**Problem 2 — never-called validation.** `MetricsConfigLoader::validateConfig()`
existed (checking port != 0, threads != 0) but was never invoked from
`TentMetrics::initialize()`. An invalid config would proceed to
`initHttpServer()` and fail with a confusing error instead of a clear
validation message.

**Fix (Occam: remove rather than implement).** The `enable_prometheus` /
`enable_json` flags provide negligible value — `/metrics` and `/metrics/json`
are both read-only on the same port, and there is no realistic scenario where
a deployment wants one disabled but not the other. Removing them is simpler
than honoring them. `validateConfig` is wired into `initialize()` so invalid
configs fail fast with a clear error; on rejection `initialized_` is reset so
the caller can fix the config and retry.

The previously-removed `latency_buckets` / `size_buckets` keys set the project
precedent of silently ignoring removed config keys, with a "Compatibility"
note in `docs/source/design/tent/metrics.md`. The two flags removed here get
the same treatment.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

The change is confined to the config/parsing layer and the `initialize()`
entry point; it does not touch the transfer hot path or any recording logic.
Verification was therefore scoped to the config layer + initialization gate
rather than real-transfer benchmarks.

**Test commands:**
```bash
# Full TENT build with metrics enabled
cmake -DCMAKE_BUILD_TYPE=Debug -DUSE_TENT=ON -DTENT_METRICS_ENABLED=ON \
      -DBUILD_UNIT_TESTS=ON -DUSE_HTTP=ON -DUSE_TCP=ON -DWITH_METRICS=ON \
      -DUSE_CUDA=OFF -DUSE_HIP=OFF -DUSE_ETCD=OFF -DUSE_MNNVL=OFF -DUSE_TPU=OFF \
      -S mooncake-transfer-engine -B mooncake-transfer-engine/build-tent-metrics
cmake --build mooncake-transfer-engine/build-tent-metrics -j384

# Config + HTTP + recording test suites
cd mooncake-transfer-engine/build-tent-metrics/tent/tests
./metrics_config_loader_test      # 25/25
./tent_metrics_http_server_test   #  1/1  (port-busy degradation path)
./tent_metrics_recording_test     # 10/10 (real HTTP client scrape)

# validateConfig wiring smoke (temp binary, deleted after run):
# Constructs MetricsConfig with http_port=0, calls initialize(),
# asserts InvalidArgument return + isInitialized()==false + retry-with-valid succeeds.
```

**Test results:**
- [x] Unit tests pass — 36/36 across the 3 suites above
- [ ] Integration tests pass (if applicable) — N/A: config-layer change, no
      transfer-path impact; `tebench` not run because the change does not touch
      transfer or recording code
- [x] Manual testing done — validateConfig smoke confirms the new gate rejects
      `http_port=0` with `InvalidArgument`, resets `initialized_` for retry,
      and accepts a valid config afterward

Full build completed in ~2 min with no errors or warnings on changed files.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable) — Compatibility note added to `docs/source/design/tent/metrics.md`; example config + env var docs updated
- [x] I have added tests to prove my changes are effective — existing config loader tests updated; validateConfig smoke covers the new wiring
- [x] For changes >500 LOC: I have filed an RFC issue — N/A (+19/-81)

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

An AI coding agent implemented the mechanical edits (field removal, validateConfig
wiring, test/doc updates) under human direction. The human submitter has reviewed
every changed line and can defend the change end-to-end: the removal rationale
(dead flags with no behavioral effect), the `validateConfig` wiring (fail-fast at
`initialize()` entry with retry-friendly state reset), and the test coverage.