### PR TITLE
[WIP][TE] Add mooncake.engine allocate_host_buffer API

### DIFF
--- a/docs/source/python-api-reference/transfer-engine.md
+++ b/docs/source/python-api-reference/transfer-engine.md
@@ -119,6 +119,42 @@ Gets the RPC port that the transfer engine is listening on.
 **Returns:**
 - `int`: The RPC port number
 
+### Module-level Host Buffer
+
+These functions are exported from `mooncake.engine` and do **not** require a
+`TransferEngine` instance. They allocate raw host memory for decode offload /
+ACL graph capture. Callers must `register_memory` separately if the buffer will
+be used for TE transfers.
+
+#### allocate_host_buffer()
+
+```python
+from mooncake.engine import allocate_host_buffer
+
+allocate_host_buffer(size, protocol="")
+```
+
+**Parameters:**
+- `size` (int): Buffer size in bytes
+- `protocol` (str): Optional. Empty/`ascend`/`ubshmem` on Ascend builds routes
+  to `ascend_allocate_memory` (fabric mem or `aclrtMallocHost`). Other builds
+  use `aligned_alloc`. Explicit `ascend`/`ubshmem` on non-Ascend builds returns 0.
+
+**Returns:**
+- `int`: Buffer address, or 0 on failure
+
+#### free_host_buffer()
+
+```python
+from mooncake.engine import free_host_buffer
+
+free_host_buffer(ptr, protocol="")
+```
+
+**Parameters:**
+- `ptr` (int): Address returned by `allocate_host_buffer`
+- `protocol` (str): Must match the value used at allocation
+
 ### Buffer Management
 
 #### allocate_managed_buffer()

--- a/mooncake-integration/transfer_engine/transfer_engine_py.cpp
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.cpp
@@ -15,8 +15,10 @@
 #include "transfer_engine_py.h"
 
 #include <cassert>
-#include <numeric>
+#include <cstdlib>
 #include <fstream>
+#include <numeric>
+#include <string>
 
 #include <pybind11/stl.h>
 #include "transport/rpc_communicator/rpc_interface.h"
@@ -45,6 +47,9 @@
 #include <cuda_runtime.h>
 #endif
 
+#if defined(USE_ASCEND_DIRECT) || defined(USE_UBSHMEM)
+#include "ascend_allocator.h"
+#endif
 static void* (*allocateMemory)(size_t) = nullptr;
 static void (*freeMemory)(void*) = nullptr;
 static std::string g_protocol;
@@ -1103,6 +1108,72 @@ int TransferEnginePy::sendProbe(const std::string& peer_server_name) {
 
 namespace py = pybind11;
 
+namespace {
+
+constexpr size_t kHostBufferAlignment = 4096;
+
+bool IsAscendHostProtocol(const std::string& protocol) {
+    return protocol.empty() || protocol == "ascend" || protocol == "ubshmem";
+}
+
+// Module-level host buffer allocation for decode offload / graph capture.
+// Does not register with TransferEngine; callers use register_memory
+// separately.
+uintptr_t allocateHostBuffer(size_t size, const std::string& protocol = "") {
+    if (size == 0) {
+        return 0;
+    }
+#if defined(USE_ASCEND_DIRECT) || defined(USE_UBSHMEM)
+    if (IsAscendHostProtocol(protocol)) {
+        const std::string effective =
+            protocol.empty() ? std::string("ascend") : protocol;
+        void* ptr = mooncake::ascend_allocate_memory(size, effective);
+        return reinterpret_cast<uintptr_t>(ptr);
+    }
+#else
+    if (protocol == "ascend" || protocol == "ubshmem") {
+        LOG(ERROR) << "allocate_host_buffer protocol='" << protocol
+                   << "' requires Ascend build "
+                      "(USE_ASCEND_DIRECT / USE_UBSHMEM)";
+        return 0;
+    }
+#endif
+    const size_t aligned_size = (size + kHostBufferAlignment - 1) /
+                                kHostBufferAlignment * kHostBufferAlignment;
+    void* ptr = aligned_alloc(kHostBufferAlignment, aligned_size);
+    if (ptr == nullptr) {
+        LOG(ERROR) << "allocate_host_buffer aligned_alloc failed, size="
+                   << aligned_size;
+        return 0;
+    }
+    return reinterpret_cast<uintptr_t>(ptr);
+}
+
+void freeHostBuffer(uintptr_t ptr, const std::string& protocol = "") {
+    if (ptr == 0) {
+        return;
+    }
+    void* p = reinterpret_cast<void*>(ptr);
+#if defined(USE_ASCEND_DIRECT) || defined(USE_UBSHMEM)
+    if (IsAscendHostProtocol(protocol)) {
+        const std::string effective =
+            protocol.empty() ? std::string("ascend") : protocol;
+        mooncake::ascend_free_memory(effective, p);
+        return;
+    }
+#else
+    if (protocol == "ascend" || protocol == "ubshmem") {
+        LOG(ERROR) << "free_host_buffer protocol='" << protocol
+                   << "' requires Ascend build "
+                      "(USE_ASCEND_DIRECT / USE_UBSHMEM)";
+        return;
+    }
+#endif
+    free(p);
+}
+
+}  // namespace
+
 // Implementation of coro_rpc_interface binding function
 void bind_coro_rpc_interface(py::module_& m) {
     // Note: RpcInterface, ReceivedData and ReceivedTensor are already
@@ -1145,6 +1216,17 @@ PYBIND11_MODULE(engine, m) {
 #else
     m.attr("SUPPORT_CUDA") = false;
 #endif
+
+    m.def("allocate_host_buffer", &allocateHostBuffer, py::arg("size"),
+          py::arg("protocol") = "",
+          "Allocate a host buffer for decode offload / graph capture. "
+          "On Ascend builds, empty/ascend/ubshmem routes to "
+          "ascend_allocate_memory (fabric mem or aclrtMallocHost). "
+          "Does not register with TransferEngine. Returns 0 on failure.");
+    m.def("free_host_buffer", &freeHostBuffer, py::arg("ptr"),
+          py::arg("protocol") = "",
+          "Free a buffer returned by allocate_host_buffer. "
+          "protocol must match the value used at allocation.");
 
     py::enum_<TransferEnginePy::TransferOpcode> transfer_opcode(
         m, "TransferOpcode", py::arithmetic());

--- a/mooncake-wheel/tests/test_allocate_host_buffer.py
+++ b/mooncake-wheel/tests/test_allocate_host_buffer.py
@@ -1,0 +1,21 @@
+import unittest
+
+from mooncake.engine import allocate_host_buffer, free_host_buffer
+
+
+class TestAllocateHostBuffer(unittest.TestCase):
+    def test_alloc_free_roundtrip(self):
+        size = 4 * 1024 * 1024
+        ptr = allocate_host_buffer(size)
+        self.assertNotEqual(ptr, 0)
+        free_host_buffer(ptr)
+
+    def test_zero_size_returns_zero(self):
+        self.assertEqual(allocate_host_buffer(0), 0)
+
+    def test_free_null_is_noop(self):
+        free_host_buffer(0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

**WIP / Draft** — host buffer allocation for Mooncake Layerwise KV Pool decode offload.

Add module-level APIs on `mooncake.engine`:

```python
from mooncake.engine import allocate_host_buffer, free_host_buffer
ptr = allocate_host_buffer(size)  # int address; 0 on failure
free_host_buffer(ptr)
```

Motivation (decode offload + ACL graph):
- Need a **fixed** host buffer address for graph capture; allocate once and reuse.
- `TransferEngine.allocate_managed_buffer` still falls back to `malloc` on Ascend and auto-registers with TE.
- This API is **stateless** (no TE instance), does **not** register; callers use `register_memory` separately.

Dispatch:
- Ascend builds (`USE_ASCEND_DIRECT` / `USE_UBSHMEM`): empty/`ascend`/`ubshmem` → `ascend_allocate_memory` (fabric mem or `aclrtMallocHost`)
- Other builds: `aligned_alloc(4096, …)` / `free`
- Explicit `ascend`/`ubshmem` on non-Ascend builds returns 0

Follow-ups before ready for review:
- [ ] Wire into Layerwise / decode-offload call sites
- [ ] Ascend fabric-mem path smoke test
- [ ] Confirm alignment / size requirements with offload graph

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [x] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] PyTorch Backend (`mooncake-pg`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other

## How Has This Been Tested?

- `./scripts/code_format.sh -b upstream/main` — passed
- Ascend Mooncake Store real workload — passed

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `./scripts/code_format.sh` before submitting.
- [x] I have updated the documentation.
- [x] I have added tests to prove my changes are effective.