### PR TITLE
Fix/verbs api plog error printing

### DIFF
--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -171,7 +171,7 @@ RdmaContext::RdmaContext(RdmaTransport &engine, const std::string &device_name)
     static std::once_flag g_once_flag;
     auto fork_init = []() {
         int ret = ibv_fork_init();
-        if (ret) PLOG(ERROR) << "RDMA context setup failed: fork compatibility";
+        if (ret) LOG(ERROR) << "RDMA context setup failed: fork compatibility: " << strerror(ret);
     };
     std::call_once(g_once_flag, fork_init);
 }
@@ -335,7 +335,7 @@ int RdmaContext::deconstruct() {
     for (auto &[_, entry] : memory_region_map_) {
         int ret = ibv_dereg_mr(entry.mr);
         if (ret) {
-            PLOG(ERROR) << "Failed to unregister memory region";
+            LOG(ERROR) << "Failed to unregister memory region: " << strerror(ret);
         }
     }
     memory_region_map_.clear();
@@ -345,7 +345,7 @@ int RdmaContext::deconstruct() {
 
         int ret = ibv_destroy_cq(cq_list_[i].native);
         if (ret) {
-            PLOG(ERROR) << "Failed to destroy completion queue";
+            LOG(ERROR) << "Failed to destroy completion queue: " << strerror(ret);
         }
     }
     cq_list_.clear();
@@ -357,22 +357,26 @@ int RdmaContext::deconstruct() {
 
     if (comp_channel_) {
         for (size_t i = 0; i < num_comp_channel_; ++i)
-            if (comp_channel_[i])
-                if (ibv_destroy_comp_channel(comp_channel_[i]))
-                    LOG(ERROR) << "Failed to destroy completion channel";
+            if (comp_channel_[i]) {
+                int ret = ibv_destroy_comp_channel(comp_channel_[i]);
+                if (ret)
+                    LOG(ERROR) << "Failed to destroy completion channel: " << strerror(ret);
+            }
         delete[] comp_channel_;
         comp_channel_ = nullptr;
     }
 
     if (pd_) {
-        if (ibv_dealloc_pd(pd_))
-            PLOG(ERROR) << "Failed to deallocate protection domain";
+        int ret = ibv_dealloc_pd(pd_);
+        if (ret)
+            LOG(ERROR) << "Failed to deallocate protection domain: " << strerror(ret);
         pd_ = nullptr;
     }
 
     if (context_) {
-        if (ibv_close_device(context_))
-            PLOG(ERROR) << "Failed to close device context";
+        int ret = ibv_close_device(context_);
+        if (ret)
+            LOG(ERROR) << "Failed to close device context: " << strerror(ret);
         context_ = nullptr;
     }
 
@@ -953,9 +957,10 @@ bool RdmaContext::reprobeAutoGid(
     }
 
     ibv_port_attr port_attr;
-    if (ibv_query_port(current_context, current_port, &port_attr)) {
-        PLOG(WARNING) << "Failed to reprobe port attributes on " << device_name_
-                      << "/" << static_cast<int>(current_port);
+    int ret = ibv_query_port(current_context, current_port, &port_attr);
+    if (ret) {
+        LOG(WARNING) << "Failed to reprobe port attributes on " << device_name_
+                     << "/" << static_cast<int>(current_port) << ": " << strerror(ret);
         return false;
     }
 
@@ -1067,10 +1072,11 @@ GidRefreshResult RdmaContext::refreshCurrentGid(std::string *previous_gid,
 
     if (auto_gid_selection_enabled) {
         ibv_port_attr port_attr;
-        if (ibv_query_port(current_context, current_port, &port_attr)) {
-            PLOG(WARNING) << "Failed to refresh port attributes on "
-                          << device_name_ << "/"
-                          << static_cast<int>(current_port);
+        int ret = ibv_query_port(current_context, current_port, &port_attr);
+        if (ret) {
+            LOG(WARNING) << "Failed to refresh port attributes on "
+                         << device_name_ << "/"
+                         << static_cast<int>(current_port) << ": " << strerror(ret);
             return GidRefreshResult::FAILED;
         }
 
@@ -1184,10 +1190,11 @@ int RdmaContext::openRdmaDevice(const std::string &device_name, uint8_t port,
         ibv_port_attr attr;
         int ret = ibv_query_port(context, port, &attr);
         if (ret) {
-            PLOG(ERROR) << "Failed to query port " << port << " on "
-                        << device_name;
-            if (ibv_close_device(context)) {
-                PLOG(ERROR) << "ibv_close_device(" << device_name << ") failed";
+            LOG(ERROR) << "Failed to query port " << port << " on "
+                       << device_name << ": " << strerror(ret);
+            int close_ret = ibv_close_device(context);
+            if (close_ret) {
+                LOG(ERROR) << "ibv_close_device(" << device_name << ") failed: " << strerror(close_ret);
             }
             ibv_free_device_list(devices);
             return ERR_CONTEXT;
@@ -1195,8 +1202,9 @@ int RdmaContext::openRdmaDevice(const std::string &device_name, uint8_t port,
 
         if (attr.state != IBV_PORT_ACTIVE) {
             LOG(WARNING) << "Device " << device_name << " port not active";
-            if (ibv_close_device(context)) {
-                PLOG(ERROR) << "ibv_close_device(" << device_name << ") failed";
+            int close_ret = ibv_close_device(context);
+            if (close_ret) {
+                LOG(ERROR) << "ibv_close_device(" << device_name << ") failed: " << strerror(close_ret);
             }
             ibv_free_device_list(devices);
             return ERR_CONTEXT;
@@ -1205,9 +1213,10 @@ int RdmaContext::openRdmaDevice(const std::string &device_name, uint8_t port,
         ibv_device_attr device_attr;
         ret = ibv_query_device(context, &device_attr);
         if (ret) {
-            PLOG(WARNING) << "Failed to query attributes on " << device_name;
-            if (ibv_close_device(context)) {
-                PLOG(ERROR) << "ibv_close_device(" << device_name << ") failed";
+            LOG(WARNING) << "Failed to query attributes on " << device_name << ": " << strerror(ret);
+            int close_ret = ibv_close_device(context);
+            if (close_ret) {
+                LOG(ERROR) << "ibv_close_device(" << device_name << ") failed: " << strerror(close_ret);
             }
             ibv_free_device_list(devices);
             return ERR_CONTEXT;
@@ -1304,10 +1313,11 @@ int RdmaContext::openRdmaDevice(const std::string &device_name, uint8_t port,
         ibv_port_attr port_attr;
         ret = ibv_query_port(context, port, &port_attr);
         if (ret) {
-            PLOG(WARNING) << "Failed to query port attributes on "
-                          << device_name << "/" << port;
-            if (ibv_close_device(context)) {
-                PLOG(ERROR) << "ibv_close_device(" << device_name << ") failed";
+            LOG(WARNING) << "Failed to query port attributes on "
+                         << device_name << "/" << port << ": " << strerror(ret);
+            int close_ret = ibv_close_device(context);
+            if (close_ret) {
+                LOG(ERROR) << "ibv_close_device(" << device_name << ") failed: " << strerror(close_ret);
             }
             ibv_free_device_list(devices);
             return ERR_CONTEXT;
@@ -1348,8 +1358,8 @@ int RdmaContext::openRdmaDevice(const std::string &device_name, uint8_t port,
         // Continue with GID validation
         ret = ibv_query_gid(context, port, gid_index, &gid_);
         if (ret) {
-            PLOG(ERROR) << "Failed to query GID " << gid_index << " on "
-                        << device_name << "/" << port;
+            LOG(ERROR) << "Failed to query GID " << gid_index << " on "
+                       << device_name << "/" << port << ": " << strerror(ret);
             goto cleanup_context_and_devices;
         }
 
@@ -1377,8 +1387,11 @@ int RdmaContext::openRdmaDevice(const std::string &device_name, uint8_t port,
         return 0;
 
     cleanup_context_and_devices:
-        if (ibv_close_device(context)) {
-            PLOG(ERROR) << "ibv_close_device(" << device_name << ") failed";
+        {
+            int close_ret = ibv_close_device(context);
+            if (close_ret) {
+                LOG(ERROR) << "ibv_close_device(" << device_name << ") failed: " << strerror(close_ret);
+            }
         }
         ibv_free_device_list(devices);
         return ERR_CONTEXT;

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -211,8 +211,9 @@ int RdmaEndPoint::deconstructLocked() {
     int result = 0;
     for (size_t i = 0; i < qp_list_.size(); ++i) {
         if (!qp_list_[i]) continue;  // already destroyed in a previous call
-        if (ibv_destroy_qp(qp_list_[i])) {
-            PLOG(ERROR) << "Failed to destroy QP[" << i << "]";
+        int ret = ibv_destroy_qp(qp_list_[i]);
+        if (ret) {
+            LOG(ERROR) << "Failed to destroy QP[" << i << "]: " << strerror(ret);
             result = ERR_ENDPOINT;
         } else {
             qp_list_[i] = nullptr;
@@ -257,9 +258,10 @@ void RdmaEndPoint::beginDestroyLocked() {
         ibv_qp_attr attr;
         memset(&attr, 0, sizeof(attr));
         attr.qp_state = IBV_QPS_ERR;
-        if (ibv_modify_qp(qp_list_[i], &attr, IBV_QP_STATE)) {
-            PLOG(WARNING) << "Failed to modify QP[" << i
-                          << "] to ERR during beginDestroy";
+        int ret = ibv_modify_qp(qp_list_[i], &attr, IBV_QP_STATE);
+        if (ret) {
+            LOG(WARNING) << "Failed to modify QP[" << i
+                         << "] to ERR during beginDestroy: " << strerror(ret);
         }
     }
 }
@@ -987,7 +989,7 @@ int RdmaEndPoint::submitPostSend(
         context_.trackPostedSlices(slice_list, start, wr_count);
         int rc = ibv_post_send(qp_list_[qp_index], wr_list.data(), &bad_wr);
         if (rc) {
-            PLOG(ERROR) << "Failed to ibv_post_send";
+            LOG(ERROR) << "Failed to ibv_post_send: " << strerror(rc);
             const size_t first_failed =
                 bad_wr ? static_cast<size_t>(bad_wr - wr_list.data()) : 0;
             context_.untrackPostedSlices(slice_list, start + first_failed,
@@ -1122,11 +1124,11 @@ int RdmaEndPoint::doSetupConnection(int qp_index, const ibv_gid &peer_gid,
     int ret = ibv_modify_qp(qp, &attr, IBV_QP_STATE);
     if (ret) {
         std::string message = "Failed to modify QP to RESET";
-        PLOG(ERROR) << "[Handshake] " << message;
-        if (reply_msg) *reply_msg = message + ": " + strerror(errno);
+        LOG(ERROR) << "[Handshake] " << message << ": " << strerror(ret);
+        if (reply_msg) *reply_msg = message + ": " + strerror(ret);
         if (failure_info) {
             failure_info->stage = SetupConnectionFailureStage::kReset;
-            failure_info->sys_errno = errno;
+            failure_info->sys_errno = ret;
         }
         return ERR_ENDPOINT;
     }
@@ -1144,11 +1146,11 @@ int RdmaEndPoint::doSetupConnection(int qp_index, const ibv_gid &peer_gid,
     if (ret) {
         std::string message =
             "Failed to modify QP to INIT, check local context port num";
-        PLOG(ERROR) << "[Handshake] " << message;
-        if (reply_msg) *reply_msg = message + ": " + strerror(errno);
+        LOG(ERROR) << "[Handshake] " << message << ": " << strerror(ret);
+        if (reply_msg) *reply_msg = message + ": " + strerror(ret);
         if (failure_info) {
             failure_info->stage = SetupConnectionFailureStage::kInit;
-            failure_info->sys_errno = errno;
+            failure_info->sys_errno = ret;
         }
         return ERR_ENDPOINT;
     }
@@ -1189,21 +1191,22 @@ int RdmaEndPoint::doSetupConnection(int qp_index, const ibv_gid &peer_gid,
     if (ret) {
         std::string message =
             "Failed to modify QP to RTR, check mtu, gid, peer lid, peer qp num";
-        PLOG(ERROR) << "[Handshake] " << message
-                    << ": local=" << context_.nicPath()
-                    << ", peer=" << peer_nic_path_ << ", qp_index=" << qp_index
-                    << ", local_qp=" << qp->qp_num
-                    << ", peer_qp=" << peer_qp_num
-                    << ", local_gid=" << context_.gid()
-                    << ", local_gid_index=" << local_gid_index
-                    << ", peer_gid=" << gidToString(peer_gid)
-                    << ", peer_lid=" << peer_lid
-                    << ", path_mtu=" << attr.path_mtu
-                    << ", port_num=" << static_cast<int>(context_.portNum());
-        if (reply_msg) *reply_msg = message + ": " + strerror(errno);
+        LOG(ERROR) << "[Handshake] " << message
+                   << ": local=" << context_.nicPath()
+                   << ", peer=" << peer_nic_path_ << ", qp_index=" << qp_index
+                   << ", local_qp=" << qp->qp_num
+                   << ", peer_qp=" << peer_qp_num
+                   << ", local_gid=" << context_.gid()
+                   << ", local_gid_index=" << local_gid_index
+                   << ", peer_gid=" << gidToString(peer_gid)
+                   << ", peer_lid=" << peer_lid
+                   << ", path_mtu=" << attr.path_mtu
+                   << ", port_num=" << static_cast<int>(context_.portNum())
+                   << ": " << strerror(ret);
+        if (reply_msg) *reply_msg = message + ": " + strerror(ret);
         if (failure_info) {
             failure_info->stage = SetupConnectionFailureStage::kRtr;
-            failure_info->sys_errno = errno;
+            failure_info->sys_errno = ret;
         }
         return ERR_ENDPOINT;
     }
@@ -1222,11 +1225,11 @@ int RdmaEndPoint::doSetupConnection(int qp_index, const ibv_gid &peer_gid,
                             IBV_QP_MAX_QP_RD_ATOMIC);
     if (ret) {
         std::string message = "Failed to modify QP to RTS";
-        PLOG(ERROR) << "[Handshake] " << message;
-        if (reply_msg) *reply_msg = message + ": " + strerror(errno);
+        LOG(ERROR) << "[Handshake] " << message << ": " << strerror(ret);
+        if (reply_msg) *reply_msg = message + ": " + strerror(ret);
         if (failure_info) {
             failure_info->stage = SetupConnectionFailureStage::kRts;
-            failure_info->sys_errno = errno;
+            failure_info->sys_errno = ret;
         }
         return ERR_ENDPOINT;
     }

--- a/mooncake-transfer-engine/tests/rdma_endpoint_reestablish_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_endpoint_reestablish_test.cpp
@@ -948,8 +948,7 @@ extern "C" int __wrap_ibv_modify_qp(ibv_qp* qp, ibv_qp_attr* attr,
         recordRtrAttempt(device_name, sgid_index, gid_string);
         int injected_errno = injectedRtrErrnoOrZero(device_name, sgid_index);
         if (injected_errno != 0) {
-            errno = injected_errno;
-            return -1;
+            return injected_errno;
         }
     }
     return __real_ibv_modify_qp(qp, attr, attr_mask);

--- a/mooncake-transfer-engine/tests/rdma_endpoint_reestablish_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_endpoint_reestablish_test.cpp
@@ -54,6 +54,7 @@
 #include "common.h"
 #include "transfer_engine.h"
 #include "transport/rdma_transport/rdma_context.h"
+#include "transport/rdma_transport/rdma_endpoint.h"
 #include "transport/rdma_transport/rdma_transport.h"
 #include "transport/rdma_transport/worker_pool.h"
 #include "transport/transport.h"
@@ -592,7 +593,6 @@ TEST_F(RDMAEndpointReestablishTest, SenderSingleRnicDownUsesFallbackLocalRnic) {
     TEContext init_ctx(initiator_server_name, metadata_server,
                        target_segment_name, sender_matrix,
                        RawNicPriorityMatrix{});
-
     ASSERT_TRUE(RdmaTransportTestPeer::setContextActive(
         init_ctx.rdma_transport_, initiator_device_name, false));
     ASSERT_FALSE(RdmaTransportTestPeer::contextActive(init_ctx.rdma_transport_,
@@ -816,6 +816,88 @@ TEST_F(RDMAEndpointReestablishTest,
 
 }  // namespace
 
+#if defined(__has_feature)
+#define MC_HAS_FEATURE(x) __has_feature(x)
+#else
+#define MC_HAS_FEATURE(x) 0
+#endif
+#if defined(__SANITIZE_ADDRESS__) || MC_HAS_FEATURE(address_sanitizer)
+#include <sanitizer/lsan_interface.h>
+#define MC_LSAN_IGNORE_OBJECT(p) __lsan_ignore_object(p)
+#else
+#define MC_LSAN_IGNORE_OBJECT(p) ((void)(p))
+#endif
+
+namespace mooncake {
+class RdmaEndPointTestPeer {
+   public:
+    static void addDummyQp(RdmaEndPoint &endpoint, ibv_qp *qp) {
+        endpoint.qp_list_.push_back(qp);
+    }
+
+    static void clearDummyQp(RdmaEndPoint &endpoint) {
+        endpoint.qp_list_.clear();
+    }
+
+    static int doSetupConnection(RdmaEndPoint &endpoint, int qp_index,
+                                 const ibv_gid &peer_gid, uint16_t peer_lid,
+                                 uint32_t peer_qp_num, int local_gid_index,
+                                 std::string *reply_msg,
+                                 int &out_stage, int &out_sys_errno) {
+        RdmaEndPoint::SetupConnectionFailureInfo failure_info = {};
+        int rc = endpoint.doSetupConnection(qp_index, peer_gid, peer_lid,
+                                            peer_qp_num, local_gid_index,
+                                            reply_msg, &failure_info);
+        out_stage = static_cast<int>(failure_info.stage);
+        out_sys_errno = failure_info.sys_errno;
+        return rc;
+    }
+
+    static int getResetStageValue() {
+        return static_cast<int>(RdmaEndPoint::SetupConnectionFailureStage::kReset);
+    }
+};
+}
+
+extern std::atomic<int> g_inject_modify_qp_error;
+
+namespace {
+
+TEST(RDMAEndpointSetupErrorTest, VerifyVerbsErrorCorrectlyCaptured) {
+    auto* transport = new RdmaTransport();
+    // Ignore memory leak of transport during destruction since it's a test
+    MC_LSAN_IGNORE_OBJECT(transport);
+    auto context = std::make_unique<RdmaContext>(*transport, "unused");
+    auto endpoint = std::make_unique<RdmaEndPoint>(*context);
+
+    // Add a dummy non-null QP pointer to trigger doSetupConnection
+    ibv_qp* dummy_qp = reinterpret_cast<ibv_qp*>(0xdeadbeef);
+    mooncake::RdmaEndPointTestPeer::addDummyQp(*endpoint, dummy_qp);
+
+    // Inject EINVAL error for ibv_modify_qp
+    g_inject_modify_qp_error.store(EINVAL);
+
+    ibv_gid dummy_gid = {};
+    std::string reply_msg;
+    int stage = 0;
+    int sys_errno = 0;
+    int rc = mooncake::RdmaEndPointTestPeer::doSetupConnection(
+        *endpoint, 0, dummy_gid, 0, 0, 0, &reply_msg, stage, sys_errno);
+
+    // Clear injection immediately
+    g_inject_modify_qp_error.store(0);
+
+    // Clear dummy qp so destructor doesn't try to destroy 0xdeadbeef and crash
+    mooncake::RdmaEndPointTestPeer::clearDummyQp(*endpoint);
+
+    EXPECT_EQ(rc, ERR_ENDPOINT);
+    EXPECT_EQ(stage, mooncake::RdmaEndPointTestPeer::getResetStageValue());
+    EXPECT_EQ(sys_errno, EINVAL);
+    EXPECT_TRUE(reply_msg.find("EINVAL") != std::string::npos || reply_msg.find("Invalid argument") != std::string::npos || reply_msg.find("22") != std::string::npos);
+}
+
+}  // namespace
+
 extern "C" int __real__ibv_query_gid_ex(ibv_context* context, uint8_t port_num,
                                         int gid_index,
                                         struct ibv_gid_entry* entry,
@@ -844,8 +926,14 @@ extern "C" int __wrap_ibv_query_gid(ibv_context* context, uint8_t port_num,
 extern "C" int __real_ibv_modify_qp(ibv_qp* qp, ibv_qp_attr* attr,
                                     int attr_mask);
 
+std::atomic<int> g_inject_modify_qp_error{0};
+
 extern "C" int __wrap_ibv_modify_qp(ibv_qp* qp, ibv_qp_attr* attr,
                                     int attr_mask) {
+    int error_to_inject = g_inject_modify_qp_error.load();
+    if (error_to_inject != 0) {
+        return error_to_inject;
+    }
     if (qp != nullptr && attr != nullptr && attr->qp_state == IBV_QPS_RTR &&
         (attr_mask & IBV_QP_AV)) {
         const std::string device_name =


### PR DESCRIPTION
## Description

This PR fixes a critical error-reporting bug where standard InfiniBand Verbs APIs were logged using `PLOG(ERROR)` or `strerror(errno)`. 

### Background & Problem
Most `libibverbs` APIs (e.g., `ibv_modify_qp`, `ibv_destroy_qp`, `ibv_query_port`, etc.) return error codes directly (as negative or positive `int` codes) instead of setting the thread-local global `errno`. 
- Using `PLOG` or `strerror(errno)` to print errors caused the Transfer Engine to log stale/random error messages (e.g., mismatching `"Success [0]"` or historical `errno` values like `"No such file or directory"`), which severely hindered debugging.

### Solution
- Systematically replaced `PLOG` and `strerror(errno)` with `LOG(ERROR) << ... << strerror(ret)` for all `int`-returning Verbs APIs in `rdma_context.cpp` and `rdma_endpoint.cpp`.
- Added a robust unit test case to perform white-box fault injection to verify error captures during QP state transitions.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

### Unit Tests
A dedicated white-box test `VerifyVerbsErrorCorrectlyCaptured` was added inside `mooncake-transfer-engine/tests/rdma_endpoint_reestablish_test.cpp`.
- Utilized symbol wrapping (`__wrap_ibv_modify_qp`) to inject `EINVAL` (22) error.
- Verified that `doSetupConnection` correctly captures the injected error and reports it properly.
- Confirmed that reverting the fix causes the test to fail instantly (stale `sys_errno` captured as 0 and reports `Success [0]`), proving the effectiveness of the test and the fix.

**Test commands:**
```bash
cd build-ci-local
ninja rdma_endpoint_reestablish_test
./mooncake-transfer-engine/tests/rdma_endpoint_reestablish_test --gtest_filter=*VerifyVerbsErrorCorrectlyCaptured*