### PR TITLE
[CI]fix(ci): lookup integration artifact by workflow run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -971,7 +971,7 @@ jobs:
     secrets: inherit
 
   integration-test:
-    needs: [build, check-paths]
+    needs: [build, build-wheel-cu13, check-paths]
     if: needs.check-paths.outputs.should-run-downstream == 'true'
     uses: ./.github/workflows/integration-test.yml
     secrets: inherit

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -34,12 +34,34 @@ jobs:
           attempt=1
           while [ $attempt -le $max_attempts ]; do
             echo "Attempt $attempt: Fetching artifact..."
-            if curl -L -fs -o artifact.json -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/${{ github.repository }}/actions/artifacts?per_page=100; then
-              artifact_id=""
-              if jq empty artifact.json >/dev/null 2>&1; then
-                artifact_id=$(jq -r ".artifacts[] | select(.name | contains(\"py312\") ) | select(.name | contains(\"mooncake\") ) | select(.name | contains(\"cu130\") ) | select(.workflow_run.head_sha == \"$SHA\" ) | .id" artifact.json | head -n 1)
+            echo "Target SHA=${SHA}"
+            artifact_id=""
+            run_id=""
+            if curl -L -fs -o runs.json -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" "https://api.github.com/repos/${{ github.repository }}/actions/runs?head_sha=${SHA}&per_page=100"; then
+              if jq empty runs.json >/dev/null 2>&1; then
+                run_id=$(jq -r '.workflow_runs[] | select((.path == ".github/workflows/ci.yml") or (.name == "Build & Test (Linux)")) | .id' runs.json | head -n 1)
               else
-                echo "Failed to download artifact list. Retrying..."
+                echo "Failed to download workflow run list. Retrying..."
+              fi
+              if [ -n "$run_id" ]; then
+                echo "Matched workflow run id $run_id"
+                if curl -L -fs -o artifact.json -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" "https://api.github.com/repos/${{ github.repository }}/actions/runs/${run_id}/artifacts?per_page=100"; then
+                  if jq empty artifact.json >/dev/null 2>&1; then
+                    artifact_id=$(jq -r '.artifacts[] | select(.name | contains("py312") ) | select(.name | contains("mooncake") ) | select(.name | contains("cu130") ) | .id' artifact.json | head -n 1)
+                    if [ -z "$artifact_id" ]; then
+                      echo "Available artifacts in workflow run $run_id:"
+                      jq -r '.artifacts[].name' artifact.json || true
+                    fi
+                  else
+                    echo "Failed to download artifact list. Retrying..."
+                  fi
+                else
+                  echo "Failed to fetch artifacts for workflow run $run_id. Retrying..."
+                fi
+              else
+                echo "Failed to find Build & Test workflow run for SHA $SHA. Retrying..."
+                echo "Available workflow runs for SHA:"
+                jq -r '.workflow_runs[] | "\(.id) \(.name) \(.path) \(.status) \(.conclusion)"' runs.json || true
               fi
               if [ -n "$artifact_id" ]; then
                 echo "Successfully fetched expected artifact id $artifact_id"
@@ -51,7 +73,7 @@ jobs:
                 fi
               fi
             else
-              echo "Failed to fetch artifacts. Retrying..."
+              echo "Failed to fetch workflow runs. Retrying..."
               if [ $attempt -lt $max_attempts ]; then
                 sleep $((attempt * 60))
               fi


### PR DESCRIPTION
## Description




This change fixes the integration test artifact lookup in GitHub Actions.

Previously, the workflow queried the repository-level artifacts API with `per_page=100` and filtered the first page by artifact name and `head_sha`. Since the Mooncake repository has many artifacts, the expected CUDA 13 wheel artifact could be outside the first page, causing the integration test to retry indefinitely even though the artifact had already been uploaded.

The updated workflow first finds the `Build & Test (Linux)` workflow run for the target commit SHA, then queries artifacts from that specific workflow run. This makes the lookup deterministic and avoids repository-level pagination issues.

It also updates the main CI dependency graph so `integration-test` depends on `build-wheel-cu13`, ensuring the integration test only starts after the CUDA 13 wheel artifact has been produced.
## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?




**Test commands:**
```bash
# Example: bash scripts/run_ci_test.sh
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [x] AI tools were used (specify below)