### PR TITLE
[CI/Build] Format only changed C++ lines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -852,7 +852,7 @@ jobs:
           fi
         fi
         echo "Comparing against: ${BASE_REF}"
-        ./scripts/code_format.sh --check --base "${BASE_REF}"
+        ./scripts/code_format.sh --check --changed-lines --base "${BASE_REF}"
       shell: bash
 
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
 # Pre-commit hooks configuration for Mooncake
 # Install: pip install -r requirements-dev.txt && pre-commit install
-# Run manually: pre-commit run --all-files
+# Run manually on all files: pre-commit run --all-files
+# Format all C/C++ files explicitly: ./scripts/code_format.sh --all
 # Note: clang-format should already be available (installed via system packages or dependencies.sh)
 # Exclusions: build artifacts, vendored extern code, generated wheels.
 
@@ -26,11 +27,11 @@ repos:
   - repo: local
     hooks:
       - id: mooncake-code-format
-        name: Run Mooncake code format script
-        entry: ./scripts/code_format.sh
+        name: Format staged C/C++ changes
+        entry: ./scripts/code_format.sh --staged
         language: system
-        pass_filenames: false
-        always_run: true
+        files: '\.(c|cc|cpp|cxx|cu|cuh|h|hpp)$'
+        exclude: '^(extern/|build/|.*/build/|FAST25-release/|.*cachelib_memory_allocator/|.*/thirdparty/.*)'
         require_serial: true
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
@@ -48,13 +49,6 @@ repos:
       - id: codespell
         exclude: '^(extern/|FAST25-release/)'
         args: ['--ignore-words-list=te,mooncake,KVCache,cann,hsa']
-
-  - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v20.1.8
-    hooks:
-      - id: clang-format
-        files: '\.(c|cc|cpp|cxx|h|hpp)$'
-        exclude: '^(extern/|build/|.*/build/|FAST25-release/|.*/thirdparty/.*)'
 
   - repo: https://github.com/cheshirekow/cmake-format-precommit
     rev: v0.6.13

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,10 +47,9 @@ Mooncake uses [pre-commit](https://pre-commit.com/) to enforce consistent format
 | Type | Tool | Purpose |
 |------|------|---------|
 | Generic | trailing-whitespace / end-of-file-fixer | Basic hygiene |
-| Project | `./scripts/code_format.sh` | Enforce Mooncake C/C++ formatting script before commit |
+| Project | `./scripts/code_format.sh --staged` | Format staged C/C++ changes before commit |
 | Python | ruff / ruff-format | Lint + format (includes import sorting) |
 | Spelling | codespell | Catch common typos (ignores domain-specific words) |
-| C/C++ | clang-format | Apply style from the repository's `.clang-format` |
 | CMake | cmake-format | Keep build scripts readable |
 | Meta | check-yaml / check-merge-conflict / check-added-large-files | Prevent bad commits |
 
@@ -60,10 +59,15 @@ pip install -r requirements.txt
 pre-commit install
 ```
 
-After installation, every commit will run `./scripts/code_format.sh` automatically. If it rewrites files, re-stage the changes and commit again.
+After installation, every commit formats only the added or modified lines in
+staged C/C++ files. If the hook rewrites a file, review and re-stage it before
+committing again. Use `./scripts/code_format.sh --all` only when intentionally
+formatting the whole project.
 
 #### Usage
-Run on all files (first run will install hook environments):
+Run hooks on all files (the first run installs hook environments). The C/C++
+hook remains limited to staged line ranges; use `./scripts/code_format.sh --all`
+for an intentional whole-project C/C++ format:
 ```bash
 pre-commit run --all-files
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,8 @@ git add .pre-commit-config.yaml
 git commit -m "chore: pre-commit autoupdate"
 ```
 
-If clang-format is missing, install it (Ubuntu example):
+If clang-format or its `git-clang-format` helper is missing, install the LLVM
+20 package (Ubuntu example):
 ```bash
 sudo apt-get update && sudo apt-get install -y clang-format-20
 ```
@@ -93,7 +94,8 @@ But please avoid using `--no-verify` for routine commits to keep code quality hi
 GitHub pull-request and push checks validate only added or modified C/C++ line
 ranges relative to the selected base revision. This avoids failing a focused
 change solely because an otherwise untouched part of the same file has older
-formatting.
+formatting. Changed-line selection is delegated to LLVM's `git-clang-format`
+helper so the local hook and CI use the same Git-aware behavior.
 
 The configuration also supports automatic fixing PRs via `pre-commit.ci` if
 enabled. To activate, add the repository in the pre-commit.ci dashboard; no

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,14 @@ git commit -m "wip: skipping hooks" --no-verify
 But please avoid using `--no-verify` for routine commits to keep code quality high.
 
 #### CI Integration
-The configuration supports automatic fixing PRs via `pre-commit.ci` if enabled. To activate, add the repository in the pre-commit.ci dashboard; no further changes are needed.
+GitHub pull-request and push checks validate only added or modified C/C++ line
+ranges relative to the selected base revision. This avoids failing a focused
+change solely because an otherwise untouched part of the same file has older
+formatting.
+
+The configuration also supports automatic fixing PRs via `pre-commit.ci` if
+enabled. To activate, add the repository in the pre-commit.ci dashboard; no
+further changes are needed.
 
 
 ## Code Quality

--- a/scripts/code_format.sh
+++ b/scripts/code_format.sh
@@ -154,7 +154,8 @@ parse_args() {
 get_staged_line_ranges() {
     local file="$1"
 
-    git diff --cached --unified=0 --diff-filter=ACMR -- "${file}" |
+    git -C "${PROJECT_ROOT}" diff --cached --unified=0 \
+        --diff-filter=ACMR -- "${file}" |
         sed -nE 's/^@@ -[0-9]+(,[0-9]+)? \+([0-9]+)(,([0-9]+))? @@.*/\2 \4/p'
 }
 
@@ -385,8 +386,12 @@ main() {
     if ${STAGED_MODE}; then
         local staged_files=("${INPUT_FILES[@]}")
         if [[ ${#staged_files[@]} -eq 0 ]]; then
-            mapfile -d '' staged_files < <(
-                git diff --cached --name-only -z --diff-filter=ACMR -- \
+            local file
+            while IFS= read -r -d '' file; do
+                staged_files+=("${file}")
+            done < <(
+                git -C "${PROJECT_ROOT}" diff --cached --name-only -z \
+                    --diff-filter=ACMR -- \
                     '*.c' '*.cc' '*.cpp' '*.cxx' '*.cu' '*.cuh' '*.h' '*.hpp'
             )
         fi

--- a/scripts/code_format.sh
+++ b/scripts/code_format.sh
@@ -13,6 +13,7 @@
 #   -a, --all             Format all C/C++ files in the project
 #   -b, --base <branch>   Base branch to compare against (default: origin/main)
 #   -c, --check           Check mode: only report files that need formatting
+#       --staged          Format only added/modified lines staged for commit
 #   -h, --help            Show this help message
 #
 # Examples:
@@ -20,6 +21,7 @@
 #   ./scripts/code_format.sh --all              # Format all C/C++ files
 #   ./scripts/code_format.sh -b origin/dev      # Compare against origin/dev
 #   ./scripts/code_format.sh --check            # Check without modifying files
+#   ./scripts/code_format.sh --staged file.cpp  # Format staged lines (pre-commit)
 # =============================================================================
 
 set -e
@@ -28,6 +30,8 @@ set -e
 BASE_BRANCH="origin/main"
 CHECK_MODE=false
 ALL_MODE=false
+STAGED_MODE=false
+INPUT_FILES=()
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
@@ -116,15 +120,125 @@ parse_args() {
                 CHECK_MODE=true
                 shift
                 ;;
+            --staged)
+                STAGED_MODE=true
+                shift
+                ;;
             -h|--help)
                 usage
                 ;;
-            *)
+            --)
+                shift
+                INPUT_FILES+=("$@")
+                break
+                ;;
+            -*)
                 print_error "Unknown option: $1"
                 usage
                 ;;
+            *)
+                INPUT_FILES+=("$1")
+                shift
+                ;;
         esac
     done
+
+    if ${ALL_MODE} && ${STAGED_MODE}; then
+        print_error "--all and --staged cannot be used together."
+        exit 1
+    fi
+}
+
+# Extract the new-file line ranges from a zero-context staged diff. A pure
+# deletion has a line count of zero and does not need formatting.
+get_staged_line_ranges() {
+    local file="$1"
+
+    git diff --cached --unified=0 --diff-filter=ACMR -- "${file}" |
+        sed -nE 's/^@@ -[0-9]+(,[0-9]+)? \+([0-9]+)(,([0-9]+))? @@.*/\2 \4/p'
+}
+
+# Format only lines added or modified in the index. Pre-commit temporarily
+# stashes unstaged changes, so the working tree matches the staged snapshot
+# while this hook runs.
+format_staged_files() {
+    local clang_format="$1"
+    shift
+    local formatted_count=0
+    local failed_count=0
+
+    print_info "Using $(${clang_format} --version)"
+    print_info "Formatting only staged C/C++ line ranges"
+    echo ""
+
+    local file
+    for file in "$@"; do
+        local excluded=false
+        local pattern
+        for pattern in "${EXCLUDE_DIRS[@]}"; do
+            if [[ "${file}" == *"${pattern}"* ]]; then
+                excluded=true
+                break
+            fi
+        done
+        if ${excluded}; then
+            continue
+        fi
+
+        if [[ ! -f "${PROJECT_ROOT}/${file}" ]]; then
+            continue
+        fi
+
+        local line_args=()
+        local start count end
+        while read -r start count; do
+            [[ -z "${start}" ]] && continue
+            count="${count:-1}"
+            [[ "${count}" -eq 0 ]] && continue
+            end=$((start + count - 1))
+            line_args+=("-lines=${start}:${end}")
+        done < <(get_staged_line_ranges "${file}")
+
+        if [[ ${#line_args[@]} -eq 0 ]]; then
+            continue
+        fi
+
+        if ${CHECK_MODE}; then
+            if ! "${clang_format}" -style=file --dry-run -Werror \
+                "${line_args[@]}" "${PROJECT_ROOT}/${file}" 2>&1; then
+                print_warn "Staged lines need formatting: ${file}"
+                failed_count=$((failed_count + 1))
+            else
+                print_info "OK: ${file}"
+            fi
+        else
+            local before after
+            before=$(git hash-object "${PROJECT_ROOT}/${file}")
+            if "${clang_format}" -style=file -i "${line_args[@]}" \
+                "${PROJECT_ROOT}/${file}"; then
+                after=$(git hash-object "${PROJECT_ROOT}/${file}")
+                if [[ "${before}" == "${after}" ]]; then
+                    print_info "Already formatted: ${file}"
+                else
+                    print_info "Formatted staged lines: ${file}"
+                    formatted_count=$((formatted_count + 1))
+                fi
+            else
+                print_error "Failed to format staged lines: ${file}"
+                failed_count=$((failed_count + 1))
+            fi
+        fi
+    done
+
+    echo ""
+    if ${CHECK_MODE} && [[ ${failed_count} -gt 0 ]]; then
+        print_error "${failed_count} file(s) have unformatted staged lines."
+        return 1
+    fi
+    if ! ${CHECK_MODE}; then
+        print_info "Formatted staged lines in ${formatted_count} file(s)."
+    fi
+    [[ ${failed_count} -eq 0 ]]
 }
 
 # Get list of all C/C++ files in the project
@@ -266,6 +380,18 @@ main() {
     local clang_format
     if ! clang_format="$(find_clang_format)"; then
         exit 1
+    fi
+
+    if ${STAGED_MODE}; then
+        local staged_files=("${INPUT_FILES[@]}")
+        if [[ ${#staged_files[@]} -eq 0 ]]; then
+            mapfile -d '' staged_files < <(
+                git diff --cached --name-only -z --diff-filter=ACMR -- \
+                    '*.c' '*.cc' '*.cpp' '*.cxx' '*.cu' '*.cuh' '*.h' '*.hpp'
+            )
+        fi
+        format_staged_files "${clang_format}" "${staged_files[@]}"
+        return
     fi
 
     # Get files to format

--- a/scripts/code_format.sh
+++ b/scripts/code_format.sh
@@ -245,7 +245,16 @@ format_selected_lines() {
     if ${STAGED_MODE}; then
         command+=(--staged)
     else
-        command+=(--diff_from_common_commit "${BASE_BRANCH}" HEAD)
+        # LLVM 20 implements --diff_from_common_commit with a triple-dot
+        # revision passed to diff-tree, which can produce an empty patch.
+        # Resolve the merge base first and pass two concrete commits instead.
+        local base_commit
+        if ! base_commit=$(git -C "${PROJECT_ROOT}" merge-base \
+            "${BASE_BRANCH}" HEAD); then
+            print_error "Could not determine a merge base for '${BASE_BRANCH}' and HEAD."
+            return 1
+        fi
+        command+=("${base_commit}" HEAD)
     fi
     command+=(-- "${paths[@]}")
 

--- a/scripts/code_format.sh
+++ b/scripts/code_format.sh
@@ -218,9 +218,16 @@ format_selected_lines() {
     echo ""
 
     if ${STAGED_MODE}; then
-        if ! git -C "${PROJECT_ROOT}" diff --quiet --no-ext-diff -- \
-            "${paths[@]}"; then
-            print_error "Cannot process staged lines because a selected file has unstaged changes."
+        local git_status
+        if ! git_status=$(git -C "${PROJECT_ROOT}" status --porcelain=v1 \
+            --untracked-files=no -- "${paths[@]}"); then
+            print_error "Could not inspect staged and unstaged changes."
+            return 1
+        fi
+        # Both porcelain status columns are populated when the same file has
+        # changes in the index and the working tree.
+        if printf '%s\n' "${git_status}" | grep -q '^[^ ][^ ]'; then
+            print_error "Cannot process staged lines because a staged file also has unstaged changes."
             print_info "Stage or stash the unstaged changes, then retry."
             return 1
         fi

--- a/scripts/code_format.sh
+++ b/scripts/code_format.sh
@@ -14,7 +14,7 @@
 #   -b, --base <branch>   Base branch to compare against (default: origin/main)
 #   -c, --check           Check mode: only report files that need formatting
 #       --staged          Format only added/modified lines staged for commit
-#       --changed-lines   Format only lines changed relative to the base branch
+#       --changed-lines   Check lines changed relative to base (requires --check)
 #   -h, --help            Show this help message
 #
 # Examples:
@@ -109,20 +109,14 @@ find_clang_format() {
 }
 
 # Find the LLVM git integration helper. The versioned binary is preferred, but
-# a compatible unversioned helper is safe because clang-format 20 is supplied
-# explicitly through --binary.
+# an unversioned helper is safe because clang-format 20 is passed via --binary.
 find_git_clang_format() {
     local candidates=("git-clang-format-20" "git-clang-format")
     local candidate
     for candidate in "${candidates[@]}"; do
         if command -v "${candidate}" &> /dev/null; then
-            local help_output
-            help_output=$("${candidate}" -h 2>&1 || true)
-            if [[ "${help_output}" == *"--staged"* ]] &&
-                [[ "${help_output}" == *"--diff_from_common_commit"* ]]; then
-                echo "${candidate}"
-                return 0
-            fi
+            echo "${candidate}"
+            return 0
         fi
     done
 
@@ -189,6 +183,10 @@ parse_args() {
         print_error "--staged and --changed-lines cannot be used together."
         exit 1
     fi
+    if ${CHANGED_LINES_MODE} && ! ${CHECK_MODE}; then
+        print_error "--changed-lines requires --check."
+        exit 1
+    fi
 }
 
 # Delegate changed-line selection and index handling to LLVM's git integration.
@@ -199,6 +197,18 @@ format_selected_lines() {
     local git_clang_format="$2"
     shift 2
 
+    # With no explicit filenames, Git pathspecs select supported C/C++ files.
+    # Exclude pathspecs keep vendored sources out in both automatic and explicit
+    # modes without discovering and filtering files in this script.
+    if [[ $# -eq 0 ]]; then
+        set -- '*.c' '*.cc' '*.cpp' '*.cxx' '*.cu' '*.cuh' '*.h' '*.hpp'
+    fi
+    local paths=(
+        "$@"
+        ':(exclude,glob)**/cachelib_memory_allocator/**'
+        ':(exclude,glob)**/thirdparty/**'
+    )
+
     print_info "Using $(${clang_format} --version)"
     if ${STAGED_MODE}; then
         print_info "Formatting only staged C/C++ line ranges"
@@ -207,22 +217,21 @@ format_selected_lines() {
     fi
     echo ""
 
-    local file
-    for file in "$@"; do
-        if ${STAGED_MODE} &&
-            ! git -C "${PROJECT_ROOT}" diff --quiet --no-ext-diff -- "${file}"; then
-            print_error "Cannot process staged lines because '${file}' has unstaged changes."
+    if ${STAGED_MODE}; then
+        if ! git -C "${PROJECT_ROOT}" diff --quiet --no-ext-diff -- \
+            "${paths[@]}"; then
+            print_error "Cannot process staged lines because a selected file has unstaged changes."
             print_info "Stage or stash the unstaged changes, then retry."
             return 1
         fi
-
-        if ${CHANGED_LINES_MODE} &&
-            ! git -C "${PROJECT_ROOT}" diff --quiet --no-ext-diff HEAD -- "${file}"; then
-            print_error "Cannot process committed line ranges because '${file}' has uncommitted changes."
+    else
+        if ! git -C "${PROJECT_ROOT}" diff --quiet --no-ext-diff HEAD -- \
+            "${paths[@]}"; then
+            print_error "Cannot process committed lines because a selected file has uncommitted changes."
             print_info "Commit or stash the local changes, then retry."
             return 1
         fi
-    done
+    fi
 
     local command=(
         "${git_clang_format}"
@@ -236,19 +245,9 @@ format_selected_lines() {
     if ${STAGED_MODE}; then
         command+=(--staged)
     else
-        if ${CHECK_MODE}; then
-            command+=(--diff_from_common_commit "${BASE_BRANCH}" HEAD)
-        else
-            local merge_base
-            if ! merge_base=$(git -C "${PROJECT_ROOT}" merge-base \
-                "${BASE_BRANCH}" HEAD); then
-                print_error "Could not determine a merge base for '${BASE_BRANCH}' and HEAD."
-                return 1
-            fi
-            command+=("${merge_base}")
-        fi
+        command+=(--diff_from_common_commit "${BASE_BRANCH}" HEAD)
     fi
-    command+=(-- "$@")
+    command+=(-- "${paths[@]}")
 
     local status=0
     (
@@ -256,25 +255,11 @@ format_selected_lines() {
         "${command[@]}"
     ) || status=$?
 
-    echo ""
-    if [[ ${status} -eq 0 ]]; then
-        if ${CHECK_MODE}; then
-            print_info "All selected lines are properly formatted."
-        else
-            print_info "Selected lines are already formatted."
-        fi
+    # git-clang-format returns 1 after successfully applying a rewrite. Treat
+    # that as success in apply mode; in check mode it means a diff was found.
+    if ! ${CHECK_MODE} && [[ ${status} -eq 1 ]]; then
         return 0
     fi
-    if [[ ${status} -eq 1 ]]; then
-        if ${CHECK_MODE}; then
-            print_error "Selected lines need formatting."
-            return 1
-        fi
-        print_info "Formatted selected lines."
-        return 0
-    fi
-
-    print_error "git-clang-format failed with exit code ${status}."
     return "${status}"
 }
 
@@ -426,54 +411,12 @@ main() {
             exit 1
         fi
 
-        local selected_files=("${INPUT_FILES[@]}")
-        if [[ ${#selected_files[@]} -eq 0 ]]; then
-            local file
-            if ${STAGED_MODE}; then
-                while IFS= read -r -d '' file; do
-                    selected_files+=("${file}")
-                done < <(
-                    git -C "${PROJECT_ROOT}" diff --cached --name-only -z \
-                        --diff-filter=ACMR -- \
-                        '*.c' '*.cc' '*.cpp' '*.cxx' '*.cu' '*.cuh' '*.h' '*.hpp'
-                )
-            else
-                while IFS= read -r -d '' file; do
-                    selected_files+=("${file}")
-                done < <(
-                    git -C "${PROJECT_ROOT}" diff --name-only -z \
-                        --diff-filter=ACMR "${BASE_BRANCH}"...HEAD -- \
-                        '*.c' '*.cc' '*.cpp' '*.cxx' '*.cu' '*.cuh' '*.h' '*.hpp'
-                )
-            fi
-        fi
-
-        local filtered_files=()
-        local selected_file pattern excluded
-        for selected_file in "${selected_files[@]}"; do
-            excluded=false
-            for pattern in "${EXCLUDE_DIRS[@]}"; do
-                if [[ "${selected_file}" == *"${pattern}"* ]]; then
-                    excluded=true
-                    break
-                fi
-            done
-            if ! ${excluded}; then
-                filtered_files+=("${selected_file}")
-            fi
-        done
-
-        if [[ ${#filtered_files[@]} -eq 0 ]]; then
-            print_info "No selected C/C++ lines to format."
-            return
-        fi
-
         local git_clang_format
         if ! git_clang_format="$(find_git_clang_format)"; then
             exit 1
         fi
         format_selected_lines "${clang_format}" "${git_clang_format}" \
-            "${filtered_files[@]}"
+            "${INPUT_FILES[@]}"
         return
     fi
 

--- a/scripts/code_format.sh
+++ b/scripts/code_format.sh
@@ -14,6 +14,7 @@
 #   -b, --base <branch>   Base branch to compare against (default: origin/main)
 #   -c, --check           Check mode: only report files that need formatting
 #       --staged          Format only added/modified lines staged for commit
+#       --changed-lines   Format only lines changed relative to the base branch
 #   -h, --help            Show this help message
 #
 # Examples:
@@ -22,6 +23,7 @@
 #   ./scripts/code_format.sh -b origin/dev      # Compare against origin/dev
 #   ./scripts/code_format.sh --check            # Check without modifying files
 #   ./scripts/code_format.sh --staged file.cpp  # Format staged lines (pre-commit)
+#   ./scripts/code_format.sh --changed-lines --check  # Check PR-changed lines
 # =============================================================================
 
 set -e
@@ -31,6 +33,7 @@ BASE_BRANCH="origin/main"
 CHECK_MODE=false
 ALL_MODE=false
 STAGED_MODE=false
+CHANGED_LINES_MODE=false
 INPUT_FILES=()
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
@@ -124,6 +127,10 @@ parse_args() {
                 STAGED_MODE=true
                 shift
                 ;;
+            --changed-lines)
+                CHANGED_LINES_MODE=true
+                shift
+                ;;
             -h|--help)
                 usage
                 ;;
@@ -147,6 +154,14 @@ parse_args() {
         print_error "--all and --staged cannot be used together."
         exit 1
     fi
+    if ${ALL_MODE} && ${CHANGED_LINES_MODE}; then
+        print_error "--all and --changed-lines cannot be used together."
+        exit 1
+    fi
+    if ${STAGED_MODE} && ${CHANGED_LINES_MODE}; then
+        print_error "--staged and --changed-lines cannot be used together."
+        exit 1
+    fi
 }
 
 # Extract the new-file line ranges from a zero-context staged diff. A pure
@@ -159,17 +174,39 @@ get_staged_line_ranges() {
         sed -nE 's/^@@ -[0-9]+(,[0-9]+)? \+([0-9]+)(,([0-9]+))? @@.*/\2 \4/p'
 }
 
-# Format only lines added or modified in the index. Pre-commit temporarily
-# stashes unstaged changes, so the working tree matches the staged snapshot
-# while this hook runs.
-format_staged_files() {
+# Extract the new-file line ranges changed between the base branch and HEAD.
+get_changed_line_ranges() {
+    local file="$1"
+
+    git -C "${PROJECT_ROOT}" diff --unified=0 --diff-filter=ACMR \
+        "${BASE_BRANCH}"...HEAD -- "${file}" |
+        sed -nE 's/^@@ -[0-9]+(,[0-9]+)? \+([0-9]+)(,([0-9]+))? @@.*/\2 \4/p'
+}
+
+get_selected_line_ranges() {
+    local file="$1"
+
+    if ${STAGED_MODE}; then
+        get_staged_line_ranges "${file}"
+    else
+        get_changed_line_ranges "${file}"
+    fi
+}
+
+# Format only selected added or modified lines. Pre-commit temporarily stashes
+# unstaged changes, so the working tree normally matches the staged snapshot.
+format_line_range_files() {
     local clang_format="$1"
     shift
     local formatted_count=0
     local failed_count=0
 
     print_info "Using $(${clang_format} --version)"
-    print_info "Formatting only staged C/C++ line ranges"
+    if ${STAGED_MODE}; then
+        print_info "Formatting only staged C/C++ line ranges"
+    else
+        print_info "Formatting only C/C++ line ranges changed against ${BASE_BRANCH}"
+    fi
     echo ""
 
     local file
@@ -186,10 +223,6 @@ format_staged_files() {
             continue
         fi
 
-        if [[ ! -f "${PROJECT_ROOT}/${file}" ]]; then
-            continue
-        fi
-
         local line_args=()
         local start count end
         while read -r start count; do
@@ -198,16 +231,34 @@ format_staged_files() {
             [[ "${count}" -eq 0 ]] && continue
             end=$((start + count - 1))
             line_args+=("-lines=${start}:${end}")
-        done < <(get_staged_line_ranges "${file}")
+        done < <(get_selected_line_ranges "${file}")
 
         if [[ ${#line_args[@]} -eq 0 ]]; then
+            continue
+        fi
+
+        if ${STAGED_MODE} &&
+            ! git -C "${PROJECT_ROOT}" diff --quiet --no-ext-diff -- "${file}"; then
+            print_error "Cannot process staged lines because '${file}' has unstaged changes."
+            print_info "Stage or stash the unstaged changes, then retry."
+            return 1
+        fi
+
+        if ${CHANGED_LINES_MODE} &&
+            ! git -C "${PROJECT_ROOT}" diff --quiet --no-ext-diff HEAD -- "${file}"; then
+            print_error "Cannot process committed line ranges because '${file}' has uncommitted changes."
+            print_info "Commit or stash the local changes, then retry."
+            return 1
+        fi
+
+        if [[ ! -f "${PROJECT_ROOT}/${file}" ]]; then
             continue
         fi
 
         if ${CHECK_MODE}; then
             if ! "${clang_format}" -style=file --dry-run -Werror \
                 "${line_args[@]}" "${PROJECT_ROOT}/${file}" 2>&1; then
-                print_warn "Staged lines need formatting: ${file}"
+                print_warn "Selected lines need formatting: ${file}"
                 failed_count=$((failed_count + 1))
             else
                 print_info "OK: ${file}"
@@ -221,11 +272,11 @@ format_staged_files() {
                 if [[ "${before}" == "${after}" ]]; then
                     print_info "Already formatted: ${file}"
                 else
-                    print_info "Formatted staged lines: ${file}"
+                    print_info "Formatted selected lines: ${file}"
                     formatted_count=$((formatted_count + 1))
                 fi
             else
-                print_error "Failed to format staged lines: ${file}"
+                print_error "Failed to format selected lines: ${file}"
                 failed_count=$((failed_count + 1))
             fi
         fi
@@ -233,11 +284,11 @@ format_staged_files() {
 
     echo ""
     if ${CHECK_MODE} && [[ ${failed_count} -gt 0 ]]; then
-        print_error "${failed_count} file(s) have unformatted staged lines."
+        print_error "${failed_count} file(s) have unformatted selected lines."
         return 1
     fi
     if ! ${CHECK_MODE}; then
-        print_info "Formatted staged lines in ${formatted_count} file(s)."
+        print_info "Formatted selected lines in ${formatted_count} file(s)."
     fi
     [[ ${failed_count} -eq 0 ]]
 }
@@ -383,19 +434,35 @@ main() {
         exit 1
     fi
 
-    if ${STAGED_MODE}; then
-        local staged_files=("${INPUT_FILES[@]}")
-        if [[ ${#staged_files[@]} -eq 0 ]]; then
-            local file
-            while IFS= read -r -d '' file; do
-                staged_files+=("${file}")
-            done < <(
-                git -C "${PROJECT_ROOT}" diff --cached --name-only -z \
-                    --diff-filter=ACMR -- \
-                    '*.c' '*.cc' '*.cpp' '*.cxx' '*.cu' '*.cuh' '*.h' '*.hpp'
-            )
+    if ${STAGED_MODE} || ${CHANGED_LINES_MODE}; then
+        if ${CHANGED_LINES_MODE} &&
+            ! git -C "${PROJECT_ROOT}" rev-parse --verify "${BASE_BRANCH}" &> /dev/null; then
+            print_error "Base branch '${BASE_BRANCH}' not found."
+            exit 1
         fi
-        format_staged_files "${clang_format}" "${staged_files[@]}"
+
+        local selected_files=("${INPUT_FILES[@]}")
+        if [[ ${#selected_files[@]} -eq 0 ]]; then
+            local file
+            if ${STAGED_MODE}; then
+                while IFS= read -r -d '' file; do
+                    selected_files+=("${file}")
+                done < <(
+                    git -C "${PROJECT_ROOT}" diff --cached --name-only -z \
+                        --diff-filter=ACMR -- \
+                        '*.c' '*.cc' '*.cpp' '*.cxx' '*.cu' '*.cuh' '*.h' '*.hpp'
+                )
+            else
+                while IFS= read -r -d '' file; do
+                    selected_files+=("${file}")
+                done < <(
+                    git -C "${PROJECT_ROOT}" diff --name-only -z \
+                        --diff-filter=ACMR "${BASE_BRANCH}"...HEAD -- \
+                        '*.c' '*.cc' '*.cpp' '*.cxx' '*.cu' '*.cuh' '*.h' '*.hpp'
+                )
+            fi
+        fi
+        format_line_range_files "${clang_format}" "${selected_files[@]}"
         return
     fi
 

--- a/scripts/code_format.sh
+++ b/scripts/code_format.sh
@@ -40,6 +40,7 @@ PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 # File extensions to format
 FILE_EXTENSIONS="\.(h|hpp|cpp|cu|cuh|c|cc|cxx)$"
+GIT_CLANG_FORMAT_EXTENSIONS="h,hpp,cpp,cu,cuh,c,cc,cxx"
 
 # Directories to exclude (add more patterns as needed)
 EXCLUDE_DIRS=(
@@ -107,6 +108,32 @@ find_clang_format() {
     return 1
 }
 
+# Find the LLVM git integration helper. The versioned binary is preferred, but
+# a compatible unversioned helper is safe because clang-format 20 is supplied
+# explicitly through --binary.
+find_git_clang_format() {
+    local candidates=("git-clang-format-20" "git-clang-format")
+    local candidate
+    for candidate in "${candidates[@]}"; do
+        if command -v "${candidate}" &> /dev/null; then
+            local help_output
+            help_output=$("${candidate}" -h 2>&1 || true)
+            if [[ "${help_output}" == *"--staged"* ]] &&
+                [[ "${help_output}" == *"--diff_from_common_commit"* ]]; then
+                echo "${candidate}"
+                return 0
+            fi
+        fi
+    done
+
+    {
+        print_error "A compatible git-clang-format helper was not found."
+        print_info "Install the clang-format 20 package, which provides git-clang-format-20."
+        echo "  sudo apt-get install -y clang-format-20"
+    } >&2
+    return 1
+}
+
 # Parse command line arguments
 parse_args() {
     while [[ $# -gt 0 ]]; do
@@ -164,42 +191,13 @@ parse_args() {
     fi
 }
 
-# Extract the new-file line ranges from a zero-context staged diff. A pure
-# deletion has a line count of zero and does not need formatting.
-get_staged_line_ranges() {
-    local file="$1"
-
-    git -C "${PROJECT_ROOT}" diff --cached --unified=0 \
-        --diff-filter=ACMR -- "${file}" |
-        sed -nE 's/^@@ -[0-9]+(,[0-9]+)? \+([0-9]+)(,([0-9]+))? @@.*/\2 \4/p'
-}
-
-# Extract the new-file line ranges changed between the base branch and HEAD.
-get_changed_line_ranges() {
-    local file="$1"
-
-    git -C "${PROJECT_ROOT}" diff --unified=0 --diff-filter=ACMR \
-        "${BASE_BRANCH}"...HEAD -- "${file}" |
-        sed -nE 's/^@@ -[0-9]+(,[0-9]+)? \+([0-9]+)(,([0-9]+))? @@.*/\2 \4/p'
-}
-
-get_selected_line_ranges() {
-    local file="$1"
-
-    if ${STAGED_MODE}; then
-        get_staged_line_ranges "${file}"
-    else
-        get_changed_line_ranges "${file}"
-    fi
-}
-
-# Format only selected added or modified lines. Pre-commit temporarily stashes
-# unstaged changes, so the working tree normally matches the staged snapshot.
-format_line_range_files() {
+# Delegate changed-line selection and index handling to LLVM's git integration.
+# A strict guard is retained because git-clang-format only checks for unstaged
+# changes when formatting would actually rewrite a file.
+format_selected_lines() {
     local clang_format="$1"
-    shift
-    local formatted_count=0
-    local failed_count=0
+    local git_clang_format="$2"
+    shift 2
 
     print_info "Using $(${clang_format} --version)"
     if ${STAGED_MODE}; then
@@ -211,32 +209,6 @@ format_line_range_files() {
 
     local file
     for file in "$@"; do
-        local excluded=false
-        local pattern
-        for pattern in "${EXCLUDE_DIRS[@]}"; do
-            if [[ "${file}" == *"${pattern}"* ]]; then
-                excluded=true
-                break
-            fi
-        done
-        if ${excluded}; then
-            continue
-        fi
-
-        local line_args=()
-        local start count end
-        while read -r start count; do
-            [[ -z "${start}" ]] && continue
-            count="${count:-1}"
-            [[ "${count}" -eq 0 ]] && continue
-            end=$((start + count - 1))
-            line_args+=("-lines=${start}:${end}")
-        done < <(get_selected_line_ranges "${file}")
-
-        if [[ ${#line_args[@]} -eq 0 ]]; then
-            continue
-        fi
-
         if ${STAGED_MODE} &&
             ! git -C "${PROJECT_ROOT}" diff --quiet --no-ext-diff -- "${file}"; then
             print_error "Cannot process staged lines because '${file}' has unstaged changes."
@@ -250,47 +222,60 @@ format_line_range_files() {
             print_info "Commit or stash the local changes, then retry."
             return 1
         fi
-
-        if [[ ! -f "${PROJECT_ROOT}/${file}" ]]; then
-            continue
-        fi
-
-        if ${CHECK_MODE}; then
-            if ! "${clang_format}" -style=file --dry-run -Werror \
-                "${line_args[@]}" "${PROJECT_ROOT}/${file}" 2>&1; then
-                print_warn "Selected lines need formatting: ${file}"
-                failed_count=$((failed_count + 1))
-            else
-                print_info "OK: ${file}"
-            fi
-        else
-            local before after
-            before=$(git hash-object "${PROJECT_ROOT}/${file}")
-            if "${clang_format}" -style=file -i "${line_args[@]}" \
-                "${PROJECT_ROOT}/${file}"; then
-                after=$(git hash-object "${PROJECT_ROOT}/${file}")
-                if [[ "${before}" == "${after}" ]]; then
-                    print_info "Already formatted: ${file}"
-                else
-                    print_info "Formatted selected lines: ${file}"
-                    formatted_count=$((formatted_count + 1))
-                fi
-            else
-                print_error "Failed to format selected lines: ${file}"
-                failed_count=$((failed_count + 1))
-            fi
-        fi
     done
 
+    local command=(
+        "${git_clang_format}"
+        --binary "${clang_format}"
+        --style file
+        --extensions "${GIT_CLANG_FORMAT_EXTENSIONS}"
+    )
+    if ${CHECK_MODE}; then
+        command+=(--diff)
+    fi
+    if ${STAGED_MODE}; then
+        command+=(--staged)
+    else
+        if ${CHECK_MODE}; then
+            command+=(--diff_from_common_commit "${BASE_BRANCH}" HEAD)
+        else
+            local merge_base
+            if ! merge_base=$(git -C "${PROJECT_ROOT}" merge-base \
+                "${BASE_BRANCH}" HEAD); then
+                print_error "Could not determine a merge base for '${BASE_BRANCH}' and HEAD."
+                return 1
+            fi
+            command+=("${merge_base}")
+        fi
+    fi
+    command+=(-- "$@")
+
+    local status=0
+    (
+        cd "${PROJECT_ROOT}"
+        "${command[@]}"
+    ) || status=$?
+
     echo ""
-    if ${CHECK_MODE} && [[ ${failed_count} -gt 0 ]]; then
-        print_error "${failed_count} file(s) have unformatted selected lines."
-        return 1
+    if [[ ${status} -eq 0 ]]; then
+        if ${CHECK_MODE}; then
+            print_info "All selected lines are properly formatted."
+        else
+            print_info "Selected lines are already formatted."
+        fi
+        return 0
     fi
-    if ! ${CHECK_MODE}; then
-        print_info "Formatted selected lines in ${formatted_count} file(s)."
+    if [[ ${status} -eq 1 ]]; then
+        if ${CHECK_MODE}; then
+            print_error "Selected lines need formatting."
+            return 1
+        fi
+        print_info "Formatted selected lines."
+        return 0
     fi
-    [[ ${failed_count} -eq 0 ]]
+
+    print_error "git-clang-format failed with exit code ${status}."
+    return "${status}"
 }
 
 # Get list of all C/C++ files in the project
@@ -462,7 +447,33 @@ main() {
                 )
             fi
         fi
-        format_line_range_files "${clang_format}" "${selected_files[@]}"
+
+        local filtered_files=()
+        local selected_file pattern excluded
+        for selected_file in "${selected_files[@]}"; do
+            excluded=false
+            for pattern in "${EXCLUDE_DIRS[@]}"; do
+                if [[ "${selected_file}" == *"${pattern}"* ]]; then
+                    excluded=true
+                    break
+                fi
+            done
+            if ! ${excluded}; then
+                filtered_files+=("${selected_file}")
+            fi
+        done
+
+        if [[ ${#filtered_files[@]} -eq 0 ]]; then
+            print_info "No selected C/C++ lines to format."
+            return
+        fi
+
+        local git_clang_format
+        if ! git_clang_format="$(find_git_clang_format)"; then
+            exit 1
+        fi
+        format_selected_lines "${clang_format}" "${git_clang_format}" \
+            "${filtered_files[@]}"
         return
     fi
 


### PR DESCRIPTION
## Description

The C/C++ pre-commit and CI format paths previously ran overlapping or overly broad whole-file checks:

- the local `code_format.sh` hook ignored pre-commit filenames and formatted every C/C++ file changed relative to `origin/main`
- the mirrored clang-format hook then formatted each staged C/C++ file in full
- pull-request CI checked every line of each changed C/C++ file, so unrelated pre-existing style debt could fail a focused change

This change adds a `--staged` mode and delegates staged range selection and index handling to LLVM's `git-clang-format`, with clang-format 20 supplied explicitly. It removes the duplicate whole-file clang-format hook. A strict guard still rejects any selected staged file that also has unstaged changes, including cases where no formatting rewrite would otherwise be needed.

It also adds a check-only `--changed-lines` mode for CI. The wrapper resolves the merge base explicitly, then passes that concrete commit and `HEAD` to `git-clang-format --diff`. This avoids LLVM 20's broken `--diff_from_common_commit` path, which can feed a triple-dot revision to `git diff-tree` and silently select no lines. Git pathspecs select supported extensions and exclude vendored directories without duplicating Git's changed-file discovery in the shell script. The existing default and `--all` modes retain their whole-file semantics.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
bash -n scripts/code_format.sh
pre-commit validate-config .pre-commit-config.yaml
git diff --check
pre-commit run --files .github/workflows/ci.yml CONTRIBUTING.md scripts/code_format.sh
```

Isolated Git fixtures were used to verify that:

- the LLVM 20 `--diff_from_common_commit` command incorrectly returns success with no modified files for an unformatted feature change
- the fixed wrapper checks the same feature commit with an explicit merge base, prints the expected formatting diff, and returns status 1
- the fixed wrapper returns status 0 after the feature change is formatted
- the explicit merge base remains correct when the target branch advances after the feature branch diverges
- `--changed-lines` without `--check` is rejected
- `--staged --check` reads the staged snapshot and prints the expected diff
- a selected staged file with unstaged changes fails immediately with the explicit guard
- staged apply mode formats only selected lines and treats a successful rewrite as success
- automatic discovery, explicit filenames, filenames containing spaces, subdirectory execution, and vendored-directory exclusions preserve the expected behavior

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done as described above

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

OpenAI Codex inspected the existing hooks and CI failure mode, implemented the staged and branch-diff workflows, replaced hand-written hunk and file discovery with LLVM's `git-clang-format` plus Git pathspecs, retained the strict mixed-state guard, fixed LLVM 20 changed-line selection by resolving the merge base explicitly, updated contributor documentation, and ran the validation described above. The human submitter should review every changed line and be prepared to defend the change end-to-end.