### PR TITLE
[TENT] Add transport labels to metrics for per-transport observability

### DIFF
--- a/docs/source/design/tent/metrics.md
+++ b/docs/source/design/tent/metrics.md
@@ -118,28 +118,28 @@ tent_metrics.initialize(config);
 
 ```cpp
 // Using convenience macros (recommended)
-TENT_RECORD_READ_COMPLETED(1024*1024, 0.025);   // 1MB read in 25ms
-TENT_RECORD_WRITE_COMPLETED(512*1024, 0.015);   // 512KB write in 15ms
-TENT_RECORD_READ_FAILED();                       // read failed (no bytes recorded)
-TENT_RECORD_WRITE_FAILED();                      // write failed (no bytes recorded)
-TENT_RECORD_TRANSPORT_FAILOVER();                // cross-transport failover event
+TENT_RECORD_READ_COMPLETED(RDMA, 1024*1024, 0.025);   // 1MB read in 25ms
+TENT_RECORD_WRITE_COMPLETED(RDMA, 512*1024, 0.015);    // 512KB write in 15ms
+TENT_RECORD_READ_FAILED(TCP);                           // read failed (no bytes recorded)
+TENT_RECORD_WRITE_FAILED(TCP);                          // write failed (no bytes recorded)
+TENT_RECORD_TRANSPORT_FAILOVER(RDMA, TCP);              // cross-transport failover event
 
 // Direct API usage
 auto& tent_metrics = TentMetrics::instance();
-tent_metrics.recordReadCompleted(1024*1024, 0.025);
-tent_metrics.recordWriteCompleted(512*1024, 0.015);
-tent_metrics.recordReadFailed();
-tent_metrics.recordWriteFailed();
-tent_metrics.recordTransportFailover();
+tent_metrics.recordReadCompleted(RDMA, 1024*1024, 0.025);
+tent_metrics.recordWriteCompleted(RDMA, 512*1024, 0.015);
+tent_metrics.recordReadFailed(TCP);
+tent_metrics.recordWriteFailed(TCP);
+tent_metrics.recordTransportFailover(RDMA, TCP);
 
 // Deadline feasibility (RFC #2519, observability only):
-tent_metrics.recordDeadlineMLU(0.8);        // MLU < 1 met the deadline
-tent_metrics.recordDeadlineInfeasible();     // deadline was in the past at submit
+tent_metrics.recordDeadlineMLU(RDMA, 0.8);        // MLU < 1 met the deadline
+tent_metrics.recordDeadlineInfeasible(TCP);        // deadline was in the past at submit
 
 // Causal-chain per-stage latency breakdown (microseconds):
-tent_metrics.recordStageLatency(TentMetrics::Stage::QueueWait, 12.0);
-tent_metrics.recordStageLatency(TentMetrics::Stage::Dispatch, 45.0);
-tent_metrics.recordStageLatency(TentMetrics::Stage::Transport, 130.0);
+tent_metrics.recordStageLatency(TentMetrics::Stage::QueueWait, RDMA, 12.0);
+tent_metrics.recordStageLatency(TentMetrics::Stage::Dispatch, RDMA, 45.0);
+tent_metrics.recordStageLatency(TentMetrics::Stage::Transport, RDMA, 130.0);
 ```
 
 ### RAII Latency Measurement
@@ -147,12 +147,12 @@ tent_metrics.recordStageLatency(TentMetrics::Stage::Transport, 130.0);
 ```cpp
 // Automatic latency measurement using RAII
 {
-    TENT_SCOPED_READ_LATENCY(1024 * 1024); // e.g. 1MB
+    TENT_SCOPED_READ_LATENCY(RDMA, 1024 * 1024); // e.g. 1MB
     // ... perform read operation ...
 }  // latency automatically recorded when scope exits
 
 {
-    TENT_SCOPED_WRITE_LATENCY(512 * 1024); // e.g. 512KB
+    TENT_SCOPED_WRITE_LATENCY(RDMA, 512 * 1024); // e.g. 512KB
     // ... perform write operation ...
 }
 ```

--- a/docs/source/design/tent/metrics.md
+++ b/docs/source/design/tent/metrics.md
@@ -172,32 +172,30 @@ The HTTP server provides multiple endpoints:
 ```
 # HELP tent_read_bytes_total Total bytes read via TENT
 # TYPE tent_read_bytes_total counter
-tent_read_bytes_total 1048576
+tent_read_bytes_total{transport="rdma"} 1048576
+tent_read_bytes_total{transport="tcp"} 524288
 
 # HELP tent_write_bytes_total Total bytes written via TENT
 # TYPE tent_write_bytes_total counter
-tent_write_bytes_total 524288
+tent_write_bytes_total{transport="rdma"} 524288
 
 # HELP tent_read_requests_total Total read requests via TENT
 # TYPE tent_read_requests_total counter
-tent_read_requests_total 100
-
-# HELP tent_write_requests_total Total write requests via TENT
-# TYPE tent_write_requests_total counter
-tent_write_requests_total 50
+tent_read_requests_total{transport="rdma"} 100
+tent_read_requests_total{transport="tcp"} 50
 
 # HELP tent_read_failures_total Total read failures via TENT
 # TYPE tent_read_failures_total counter
-tent_read_failures_total 2
+tent_read_failures_total{transport="tcp"} 2
 
-# HELP tent_write_failures_total Total write failures via TENT
-# TYPE tent_write_failures_total counter
-tent_write_failures_total 1
+# HELP tent_transport_failover_total Total cross-transport failover events
+# TYPE tent_transport_failover_total counter
+tent_transport_failover_total{from="rdma",to="tcp"} 1
 
 # HELP tent_read_latency_us Read latency distribution in microseconds
 # TYPE tent_read_latency_us histogram
-tent_read_latency_us_bucket{le="100"} 10
-tent_read_latency_us_bucket{le="500"} 50
+tent_read_latency_us_bucket{transport="rdma",le="100"} 10
+tent_read_latency_us_bucket{transport="rdma",le="500"} 50
 ...
 ```
 
@@ -220,30 +218,53 @@ Read: 1.00 MB (100 reqs, 2 fails) | Write: 512.00 KB (50 reqs, 1 fails)
 
 ## Available Metrics
 
-| Metric Name | Type | Description |
-|-------------|------|-------------|
-| `tent_read_bytes_total` | Counter | Total bytes read via TENT (success only; failures record no bytes) |
-| `tent_write_bytes_total` | Counter | Total bytes written via TENT (success only) |
-| `tent_read_requests_total` | Counter | Total read requests via TENT (success + failure) |
-| `tent_write_requests_total` | Counter | Total write requests via TENT (success + failure) |
-| `tent_read_failures_total` | Counter | Total read failures via TENT |
-| `tent_write_failures_total` | Counter | Total write failures via TENT |
-| `tent_transport_failover_total` | Counter | Total cross-transport failover events |
-| `tent_deadline_infeasible_total` | Counter | Transfers whose deadline was already in the past at submit time |
-| `tent_read_latency_us` | Histogram | Read latency distribution in microseconds |
-| `tent_write_latency_us` | Histogram | Write latency distribution in microseconds |
-| `tent_read_size_bytes` | Histogram | Read request size distribution in bytes |
-| `tent_write_size_bytes` | Histogram | Write request size distribution in bytes |
-| `tent_deadline_mlu_permille` | Histogram | Deadline feasibility ratio (MLU x 1000); 1000 = MLU 1.0 (the met/missed boundary) |
-| `tent_stage_queue_wait_us` | Histogram | Causal chain: queue wait latency in microseconds |
-| `tent_stage_dispatch_us` | Histogram | Causal chain: dispatch latency in microseconds |
-| `tent_stage_transport_us` | Histogram | Causal chain: transport execution latency in microseconds |
+| Metric Name | Type | Labels | Description |
+|-------------|------|--------|-------------|
+| `tent_read_bytes_total` | Counter | `transport` | Total bytes read via TENT (success only; failures record no bytes) |
+| `tent_write_bytes_total` | Counter | `transport` | Total bytes written via TENT (success only) |
+| `tent_read_requests_total` | Counter | `transport` | Total read requests via TENT (success + failure) |
+| `tent_write_requests_total` | Counter | `transport` | Total write requests via TENT (success + failure) |
+| `tent_read_failures_total` | Counter | `transport` | Total read failures via TENT |
+| `tent_write_failures_total` | Counter | `transport` | Total write failures via TENT |
+| `tent_transport_failover_total` | Counter | `from`, `to` | Total cross-transport failover events |
+| `tent_deadline_infeasible_total` | Counter | `transport` | Transfers whose deadline was already in the past at submit time |
+| `tent_read_latency_us` | Histogram | `transport` | Read latency distribution in microseconds |
+| `tent_write_latency_us` | Histogram | `transport` | Write latency distribution in microseconds |
+| `tent_read_size_bytes` | Histogram | `transport` | Read request size distribution in bytes |
+| `tent_write_size_bytes` | Histogram | `transport` | Write request size distribution in bytes |
+| `tent_deadline_mlu_permille` | Histogram | `transport` | Deadline feasibility ratio (MLU x 1000); 1000 = MLU 1.0 (the met/missed boundary) |
+| `tent_stage_queue_wait_us` | Histogram | `transport` | Causal chain: queue wait latency in microseconds |
+| `tent_stage_dispatch_us` | Histogram | `transport` | Causal chain: dispatch latency in microseconds |
+| `tent_stage_transport_us` | Histogram | `transport` | Causal chain: transport execution latency in microseconds |
 
 **Notes**:
 - `*_requests_total` counts both successful and failed requests. To compute the success rate, use `1 - (failures / requests)`.
 - `*_failures_total` does not record bytes; failed transfers transfer no bytes.
 - `tent_deadline_infeasible_total` is a dedicated counter (not a histogram sentinel) so infeasible-at-submit cases are distinguishable from genuine high-MLU samples.
 - yalantinglibs omits zero-valued counters/histograms from the Prometheus output, so a metric only appears once it has been observed at least once.
+
+### Labels
+
+All metrics carry a `transport` label (the `tent_transport_failover_total`
+counter uses `from` and `to` instead) so every metric can be sliced by
+transport without grepping logs. Label values come exclusively from the
+`TransportType` enum closed set — no arbitrary strings are accepted, and
+the closed set is enforced at the type level via a pre-built lookup table
+indexed by enum.
+
+| Label | Values | Description |
+|-------|--------|-------------|
+| `transport` | `unspec`, `rdma`, `mnnvl`, `shm`, `nvlink`, `gds`, `io_uring`, `tcp`, `ascend`, `sunrise_link`, `tpu` | The transport that handled the transfer |
+| `from` | (same set) | Transport that failed before failover |
+| `to` | (same set) | Transport that the failover switched to |
+
+Label values are aligned with `TransportSelector::transportTypeName()`.
+`unspec` covers transfers that failed before a transport was selected.
+
+**Cardinality**: the `transport` label has 11 values; the failover
+`from`/`to` pair has at most 11x11 = 121 combinations (in practice only a
+few pairs ever occur). Total series across all metrics is bounded at
+~1500.
 
 ## Integration with TransferEngine
 
@@ -379,18 +400,31 @@ scrape_configs:
 ### Grafana Queries
 
 ```promql
-# Transfer throughput (MB/s)
+# Transfer throughput (MB/s) — all transports
 rate(tent_read_bytes_total[5m]) / 1024 / 1024
 rate(tent_write_bytes_total[5m]) / 1024 / 1024
+
+# Transfer throughput (MB/s) — per transport
+rate(tent_read_bytes_total{transport="rdma"}[5m]) / 1024 / 1024
+rate(tent_read_bytes_total{transport="tcp"}[5m]) / 1024 / 1024
 
 # Request rate
 rate(tent_read_requests_total[5m])
 rate(tent_write_requests_total[5m])
 
-# Failure rate
+# Failure rate (all transports)
 rate(tent_read_failures_total[5m]) / rate(tent_read_requests_total[5m])
+
+# Failure rate (per transport)
+rate(tent_read_failures_total{transport="tcp"}[5m]) / rate(tent_read_requests_total{transport="tcp"}[5m])
 
 # P99 latency (note: latency is in microseconds, convert to seconds for display)
 histogram_quantile(0.99, rate(tent_read_latency_us_bucket[5m])) / 1000000
 histogram_quantile(0.99, rate(tent_write_latency_us_bucket[5m])) / 1000000
+
+# P99 latency per transport
+histogram_quantile(0.99, rate(tent_read_latency_us_bucket{transport="rdma"}[5m])) / 1000000
+
+# Failover rate by transport pair
+rate(tent_transport_failover_total{from="rdma",to="tcp"}[5m])
 ```

--- a/mooncake-transfer-engine/tent/include/tent/metrics/tent_metrics.h
+++ b/mooncake-transfer-engine/tent/include/tent/metrics/tent_metrics.h
@@ -208,6 +208,18 @@ class TentMetrics {
     static const std::array<std::string, kNumTransportTypes>
         kTransportLabelNames;
 
+    // Bounds-checked lookup of the label string for a TransportType.
+    // Returns "unknown" if tp is out of range (defensive — should not happen
+    // with the closed-set enum, but guards against memory corruption or a
+    // new transport type added without updating the table).
+    static const std::string& transportLabel(TransportType tp) {
+        if (tp < 0 || tp >= kNumTransportTypes) {
+            static const std::string kUnknown = "unknown";
+            return kUnknown;
+        }
+        return kTransportLabelNames[tp];
+    }
+
     // Histograms - paired with their bucket boundaries in a single vector so
     // the two cannot drift out of sync (ylt histogram doesn't expose its
     // boundaries publicly, so we hold them alongside the pointer).

--- a/mooncake-transfer-engine/tent/include/tent/metrics/tent_metrics.h
+++ b/mooncake-transfer-engine/tent/include/tent/metrics/tent_metrics.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <array>
 #include <atomic>
 #include <condition_variable>
 #include <memory>
@@ -23,6 +24,7 @@
 #include <vector>
 
 #include "tent/common/status.h"
+#include "tent/common/types.h"
 #include "tent/metrics/config_loader.h"
 
 // Compile-time metrics enable/disable switch
@@ -74,23 +76,29 @@ class TentMetrics {
         return runtime_enabled_.load(std::memory_order_relaxed);
     }
 
-    // Record transfer operations
-    void recordReadCompleted(size_t bytes, double latency_seconds = 0.0);
-    void recordWriteCompleted(size_t bytes, double latency_seconds = 0.0);
-    void recordReadFailed();
-    void recordWriteFailed();
-    void recordTransportFailover();
+    // Record transfer operations. The TransportType argument labels the
+    // metric with the transport that handled (or attempted) the transfer,
+    // so Prometheus queries can break down traffic by transport.
+    void recordReadCompleted(TransportType tp, size_t bytes,
+                             double latency_seconds = 0.0);
+    void recordWriteCompleted(TransportType tp, size_t bytes,
+                              double latency_seconds = 0.0);
+    void recordReadFailed(TransportType tp);
+    void recordWriteFailed(TransportType tp);
+    // Failover counter is labeled with both the source and destination
+    // transport types so failover flows (e.g. rdma->tcp) are queryable.
+    void recordTransportFailover(TransportType from, TransportType to);
 
     // Record the deadline feasibility ratio (MLU) for a completed transfer
     // that carried a deadline. mlu = actual_transfer_seconds / window_seconds,
     // where window_seconds is (deadline - submit_time). mlu < 1 means the
     // transfer met its deadline; mlu >= 1 means it missed. Observability only.
-    void recordDeadlineMLU(double mlu);
+    void recordDeadlineMLU(TransportType tp, double mlu);
 
     // Record a transfer whose deadline was already in the past at submit time
     // (infeasible window). Recorded into a dedicated counter so it is
     // distinguishable from genuine MLU samples in the histogram above.
-    void recordDeadlineInfeasible();
+    void recordDeadlineInfeasible(TransportType tp);
 
     enum class Stage {
         QueueWait,
@@ -99,7 +107,7 @@ class TentMetrics {
     };
 
     // Causal chain: record per-stage latency breakdown (microseconds).
-    void recordStageLatency(Stage stage, double latency_us);
+    void recordStageLatency(Stage stage, TransportType tp, double latency_us);
 
     // Get metrics for HTTP server
     std::string getPrometheusMetrics();
@@ -154,32 +162,57 @@ class TentMetrics {
     std::mutex metric_report_mutex_;
     std::condition_variable metric_report_cv_;
 
-    // Counters - stored as pointers for unified management
-    std::vector<ylt::metric::counter_t*> counters_;
-    ylt::metric::counter_t read_bytes_total_{"tent_read_bytes_total",
-                                             "Total bytes read via TENT"};
-    ylt::metric::counter_t write_bytes_total_{"tent_write_bytes_total",
-                                              "Total bytes written via TENT"};
-    ylt::metric::counter_t read_requests_total_{"tent_read_requests_total",
-                                                "Total read requests via TENT"};
-    ylt::metric::counter_t write_requests_total_{
-        "tent_write_requests_total", "Total write requests via TENT"};
-    ylt::metric::counter_t read_failures_total_{"tent_read_failures_total",
-                                                "Total read failures via TENT"};
-    ylt::metric::counter_t write_failures_total_{
-        "tent_write_failures_total", "Total write failures via TENT"};
-    ylt::metric::counter_t failover_total_{
+    // Counters — stored as base pointers (metric_t*) so that counters with
+    // different label arities (N=1 for per-transport, N=2 for failover
+    // from→to) share one vector for Prometheus serialize(). The concrete
+    // typed members below are used directly for JSON/summary aggregation
+    // (which need to iterate label values via copy()).
+    std::vector<ylt::metric::metric_t*> counters_;
+
+    // Label name arrays for dynamic metric construction.
+    static inline const std::array<std::string, 1> kTransportLabel{"transport"};
+    static inline const std::array<std::string, 2> kFailoverLabels{"from",
+                                                                   "to"};
+
+    // Per-transport counters (label: transport). Values are int64_t.
+    ylt::metric::basic_dynamic_counter<int64_t, 1> read_bytes_total_{
+        "tent_read_bytes_total", "Total bytes read via TENT", kTransportLabel};
+    ylt::metric::basic_dynamic_counter<int64_t, 1> write_bytes_total_{
+        "tent_write_bytes_total", "Total bytes written via TENT",
+        kTransportLabel};
+    ylt::metric::basic_dynamic_counter<int64_t, 1> read_requests_total_{
+        "tent_read_requests_total", "Total read requests via TENT",
+        kTransportLabel};
+    ylt::metric::basic_dynamic_counter<int64_t, 1> write_requests_total_{
+        "tent_write_requests_total", "Total write requests via TENT",
+        kTransportLabel};
+    ylt::metric::basic_dynamic_counter<int64_t, 1> read_failures_total_{
+        "tent_read_failures_total", "Total read failures via TENT",
+        kTransportLabel};
+    ylt::metric::basic_dynamic_counter<int64_t, 1> write_failures_total_{
+        "tent_write_failures_total", "Total write failures via TENT",
+        kTransportLabel};
+    // Failover counter has two labels (from, to) so failover flows are
+    // queryable as e.g. tent_transport_failover_total{from="rdma",to="tcp"}.
+    ylt::metric::basic_dynamic_counter<int64_t, 2> failover_total_{
         "tent_transport_failover_total",
-        "Total cross-transport failover events"};
-    ylt::metric::counter_t deadline_infeasible_total_{
+        "Total cross-transport failover events", kFailoverLabels};
+    ylt::metric::basic_dynamic_counter<int64_t, 1> deadline_infeasible_total_{
         "tent_deadline_infeasible_total",
-        "Transfers whose deadline was already in the past at submit"};
+        "Transfers whose deadline was already in the past at submit",
+        kTransportLabel};
+
+    // Pre-constructed label value lookup table, indexed by TransportType enum
+    // (see tent/common/types.h:46). Keeps label values in a closed set — no
+    // arbitrary strings can reach the metrics. Defined in tent_metrics.cpp.
+    static const std::array<std::string, kNumTransportTypes>
+        kTransportLabelNames;
 
     // Histograms - paired with their bucket boundaries in a single vector so
     // the two cannot drift out of sync (ylt histogram doesn't expose its
     // boundaries publicly, so we hold them alongside the pointer).
     struct HistogramEntry {
-        ylt::metric::histogram_t* h;
+        ylt::metric::basic_dynamic_histogram<int64_t, 1>* h;
         const std::vector<double>* boundaries;
     };
     std::vector<HistogramEntry> histograms_;
@@ -188,24 +221,24 @@ class TentMetrics {
     // Default buckets: 100us, 500us, 1ms, 5ms, 10ms, 50ms, 100ms, 500ms, 1s
     static inline const std::vector<double> kLatencyBuckets{
         100, 500, 1000, 5000, 10000, 50000, 100000, 500000, 1000000};
-    ylt::metric::histogram_t read_latency_{
+    ylt::metric::basic_dynamic_histogram<int64_t, 1> read_latency_{
         "tent_read_latency_us", "Read latency distribution in microseconds",
-        kLatencyBuckets};
-    ylt::metric::histogram_t write_latency_{
+        kLatencyBuckets, kTransportLabel};
+    ylt::metric::basic_dynamic_histogram<int64_t, 1> write_latency_{
         "tent_write_latency_us", "Write latency distribution in microseconds",
-        kLatencyBuckets};
+        kLatencyBuckets, kTransportLabel};
     // Size histograms for request size distribution (in bytes)
     // Default buckets: 1KB, 4KB, 16KB, 64KB, 256KB, 1MB, 4MB, 16MB, 64MB,
     // 256MB, 1GB
     static inline const std::vector<double> kSizeBuckets{
         1024,    4096,     16384,    65536,     262144,    1048576,
         4194304, 16777216, 67108864, 268435456, 1073741824};
-    ylt::metric::histogram_t read_size_{
+    ylt::metric::basic_dynamic_histogram<int64_t, 1> read_size_{
         "tent_read_size_bytes", "Read request size distribution in bytes",
-        kSizeBuckets};
-    ylt::metric::histogram_t write_size_{
+        kSizeBuckets, kTransportLabel};
+    ylt::metric::basic_dynamic_histogram<int64_t, 1> write_size_{
         "tent_write_size_bytes", "Write request size distribution in bytes",
-        kSizeBuckets};
+        kSizeBuckets, kTransportLabel};
 
     // Deadline feasibility ratio (MLU) distribution for transfers that carried
     // a deadline. Stored in per-mille (MLU x 1000) so the histogram can use
@@ -213,25 +246,27 @@ class TentMetrics {
     // feasible/infeasible line (< 1000 met the deadline, >= 1000 missed it).
     static inline const std::vector<double> kMluPerMilleBuckets{
         100, 250, 500, 750, 900, 1000, 1250, 1500, 2000, 5000};
-    ylt::metric::histogram_t deadline_mlu_{
+    ylt::metric::basic_dynamic_histogram<int64_t, 1> deadline_mlu_{
         "tent_deadline_mlu_permille",
         "Deadline feasibility ratio (MLU x 1000) distribution",
-        kMluPerMilleBuckets};
+        kMluPerMilleBuckets, kTransportLabel};
 
     // Causal chain stage latency histograms (microseconds)
     // Buckets span 10us to 500ms to capture both fast RDMA and slower TCP.
     static inline const std::vector<double> kStageBuckets{
         10, 50, 100, 500, 1000, 5000, 10000, 50000, 100000, 500000};
-    ylt::metric::histogram_t stage_queue_wait_{
+    ylt::metric::basic_dynamic_histogram<int64_t, 1> stage_queue_wait_{
         "tent_stage_queue_wait_us",
-        "Causal chain: queue wait latency in microseconds", kStageBuckets};
-    ylt::metric::histogram_t stage_dispatch_{
+        "Causal chain: queue wait latency in microseconds", kStageBuckets,
+        kTransportLabel};
+    ylt::metric::basic_dynamic_histogram<int64_t, 1> stage_dispatch_{
         "tent_stage_dispatch_us",
-        "Causal chain: dispatch latency in microseconds", kStageBuckets};
-    ylt::metric::histogram_t stage_transport_{
+        "Causal chain: dispatch latency in microseconds", kStageBuckets,
+        kTransportLabel};
+    ylt::metric::basic_dynamic_histogram<int64_t, 1> stage_transport_{
         "tent_stage_transport_us",
         "Causal chain: transport execution latency in microseconds",
-        kStageBuckets};
+        kStageBuckets, kTransportLabel};
 
     // Helper to register all metrics to the vectors
     void registerMetrics();
@@ -250,98 +285,102 @@ class ScopedLatencyRecorder {
    public:
     enum class OperationType { Read, Write };
 
-    ScopedLatencyRecorder(OperationType type, size_t bytes)
-        : type_(type), bytes_(bytes), enabled_(TentMetrics::isEnabled()) {
-        // Only record start time if metrics are enabled (avoid clock overhead
-        // when disabled)
+    ScopedLatencyRecorder(OperationType type, TransportType tp, size_t bytes)
+        : type_(type),
+          tp_(tp),
+          bytes_(bytes),
+          enabled_(TentMetrics::isEnabled()) {
         if (enabled_) {
             start_ = std::chrono::steady_clock::now();
         }
     }
 
     ~ScopedLatencyRecorder() {
-        if (!enabled_ || failed_)
-            return;  // Skip if disabled or already marked as failed
+        if (!enabled_ || failed_) return;
         auto end = std::chrono::steady_clock::now();
         double latency = std::chrono::duration<double>(end - start_).count();
         if (type_ == OperationType::Read) {
-            TentMetrics::instance().recordReadCompleted(bytes_, latency);
+            TentMetrics::instance().recordReadCompleted(tp_, bytes_, latency);
         } else {
-            TentMetrics::instance().recordWriteCompleted(bytes_, latency);
+            TentMetrics::instance().recordWriteCompleted(tp_, bytes_, latency);
         }
     }
 
     void markFailed() {
-        if (!enabled_) return;  // Skip if disabled
+        if (!enabled_) return;
         failed_ = true;
         if (type_ == OperationType::Read) {
-            TentMetrics::instance().recordReadFailed();
+            TentMetrics::instance().recordReadFailed(tp_);
         } else {
-            TentMetrics::instance().recordWriteFailed();
+            TentMetrics::instance().recordWriteFailed(tp_);
         }
     }
 
    private:
     OperationType type_;
+    TransportType tp_;
     size_t bytes_;
     std::chrono::steady_clock::time_point start_;
-    bool enabled_;  // Captured at construction time for consistent behavior
+    bool enabled_;
     bool failed_ = false;
 };
 
-// Convenience macros for recording metrics (enabled version)
-#define TENT_RECORD_READ_COMPLETED(bytes, latency)                         \
+// Convenience macros for recording metrics (enabled version).
+// The TransportType argument labels each metric so Prometheus queries can
+// break down traffic by transport. For failover, from→to labels the flow.
+#define TENT_RECORD_READ_COMPLETED(tp, bytes, latency)                     \
     do {                                                                   \
         if (::mooncake::tent::TentMetrics::isEnabled()) {                  \
             ::mooncake::tent::TentMetrics::instance().recordReadCompleted( \
-                bytes, latency);                                           \
+                tp, bytes, latency);                                       \
         }                                                                  \
     } while (0)
 
-#define TENT_RECORD_WRITE_COMPLETED(bytes, latency)                         \
+#define TENT_RECORD_WRITE_COMPLETED(tp, bytes, latency)                     \
     do {                                                                    \
         if (::mooncake::tent::TentMetrics::isEnabled()) {                   \
             ::mooncake::tent::TentMetrics::instance().recordWriteCompleted( \
-                bytes, latency);                                            \
+                tp, bytes, latency);                                        \
         }                                                                   \
     } while (0)
 
-#define TENT_RECORD_READ_FAILED()                                         \
-    do {                                                                  \
-        if (::mooncake::tent::TentMetrics::isEnabled()) {                 \
-            ::mooncake::tent::TentMetrics::instance().recordReadFailed(); \
-        }                                                                 \
+#define TENT_RECORD_READ_FAILED(tp)                                         \
+    do {                                                                    \
+        if (::mooncake::tent::TentMetrics::isEnabled()) {                   \
+            ::mooncake::tent::TentMetrics::instance().recordReadFailed(tp); \
+        }                                                                   \
     } while (0)
 
-#define TENT_RECORD_WRITE_FAILED()                                         \
-    do {                                                                   \
-        if (::mooncake::tent::TentMetrics::isEnabled()) {                  \
-            ::mooncake::tent::TentMetrics::instance().recordWriteFailed(); \
-        }                                                                  \
+#define TENT_RECORD_WRITE_FAILED(tp)                                         \
+    do {                                                                     \
+        if (::mooncake::tent::TentMetrics::isEnabled()) {                    \
+            ::mooncake::tent::TentMetrics::instance().recordWriteFailed(tp); \
+        }                                                                    \
     } while (0)
 
-#define TENT_RECORD_TRANSPORT_FAILOVER()                  \
-    do {                                                  \
-        if (::mooncake::tent::TentMetrics::isEnabled()) { \
-            ::mooncake::tent::TentMetrics::instance()     \
-                .recordTransportFailover();               \
-        }                                                 \
+#define TENT_RECORD_TRANSPORT_FAILOVER(from, to)                               \
+    do {                                                                       \
+        if (::mooncake::tent::TentMetrics::isEnabled()) {                      \
+            ::mooncake::tent::TentMetrics::instance().recordTransportFailover( \
+                from, to);                                                     \
+        }                                                                      \
     } while (0)
 
-// RAII macro for automatic latency measurement
-#define TENT_SCOPED_READ_LATENCY(bytes)                              \
-    ::mooncake::tent::ScopedLatencyRecorder _tent_latency_recorder_( \
-        ::mooncake::tent::ScopedLatencyRecorder::OperationType::Read, bytes)
+#define TENT_SCOPED_READ_LATENCY(tp, bytes)                               \
+    ::mooncake::tent::ScopedLatencyRecorder _tent_latency_recorder_(      \
+        ::mooncake::tent::ScopedLatencyRecorder::OperationType::Read, tp, \
+        bytes)
 
-#define TENT_SCOPED_WRITE_LATENCY(bytes)                             \
-    ::mooncake::tent::ScopedLatencyRecorder _tent_latency_recorder_( \
-        ::mooncake::tent::ScopedLatencyRecorder::OperationType::Write, bytes)
+#define TENT_SCOPED_WRITE_LATENCY(tp, bytes)                               \
+    ::mooncake::tent::ScopedLatencyRecorder _tent_latency_recorder_(       \
+        ::mooncake::tent::ScopedLatencyRecorder::OperationType::Write, tp, \
+        bytes)
 
-#define TENT_RECORD_STAGE_LATENCY(stage, latency_us)                      \
+#define TENT_RECORD_STAGE_LATENCY(stage, tp, latency_us)                  \
     do {                                                                  \
         if (::mooncake::tent::TentMetrics::isEnabled()) {                 \
             ::mooncake::tent::TentMetrics::instance().recordStageLatency( \
-                stage, latency_us);                                       \
+                stage, tp, latency_us);                                   \
         }                                                                 \
     } while (0)
 
@@ -351,19 +390,19 @@ class ScopedLatencyRecorder {
 class ScopedLatencyRecorder {
    public:
     enum class OperationType { Read, Write };
-    ScopedLatencyRecorder(OperationType, size_t) {}
+    ScopedLatencyRecorder(OperationType, TransportType, size_t) {}
     void markFailed() {}
 };
 
 // Zero-overhead macros when metrics are disabled at compile time
-#define TENT_RECORD_READ_COMPLETED(bytes, latency) ((void)0)
-#define TENT_RECORD_WRITE_COMPLETED(bytes, latency) ((void)0)
-#define TENT_RECORD_READ_FAILED() ((void)0)
-#define TENT_RECORD_WRITE_FAILED() ((void)0)
-#define TENT_RECORD_TRANSPORT_FAILOVER() ((void)0)
-#define TENT_SCOPED_READ_LATENCY(bytes) ((void)0)
-#define TENT_SCOPED_WRITE_LATENCY(bytes) ((void)0)
-#define TENT_RECORD_STAGE_LATENCY(stage, latency_us) ((void)0)
+#define TENT_RECORD_READ_COMPLETED(tp, bytes, latency) ((void)0)
+#define TENT_RECORD_WRITE_COMPLETED(tp, bytes, latency) ((void)0)
+#define TENT_RECORD_READ_FAILED(tp) ((void)0)
+#define TENT_RECORD_WRITE_FAILED(tp) ((void)0)
+#define TENT_RECORD_TRANSPORT_FAILOVER(from, to) ((void)0)
+#define TENT_SCOPED_READ_LATENCY(tp, bytes) ((void)0)
+#define TENT_SCOPED_WRITE_LATENCY(tp, bytes) ((void)0)
+#define TENT_RECORD_STAGE_LATENCY(stage, tp, latency_us) ((void)0)
 
 #endif  // TENT_METRICS_ENABLED
 

--- a/mooncake-transfer-engine/tent/src/metrics/tent_metrics.cpp
+++ b/mooncake-transfer-engine/tent/src/metrics/tent_metrics.cpp
@@ -21,6 +21,19 @@
 
 namespace mooncake::tent {
 
+// Pre-constructed label values indexed by TransportType enum. Keeps the
+// label space closed: only these 11 strings can ever appear as the
+// "transport" (or "from"/"to") label value in Prometheus output.
+// Values align with TransportSelector::transportTypeName()
+// (transport_selector.cpp:45) so Prometheus labels match log messages. Enum
+// order (tent/common/types.h:46): UNSPEC, RDMA, MNNVL, SHM, NVLINK, GDS,
+// IOURING, TCP, AscendDirect, SUNRISE_LINK, TPU.
+const std::array<std::string, kNumTransportTypes>
+    TentMetrics::kTransportLabelNames = {
+        "unspec",   "rdma", "mnnvl",  "shm",          "nvlink", "gds",
+        "io_uring", "tcp",  "ascend", "sunrise_link", "tpu",
+};
+
 TentMetrics& TentMetrics::instance() {
     static TentMetrics instance;
     return instance;
@@ -31,23 +44,22 @@ TentMetrics::~TentMetrics() { shutdown(); }
 #if TENT_METRICS_ENABLED
 
 Status TentMetrics::initialize(const MetricsConfig& config) {
-    // Validate configuration before touching initialized_. An invalid config
-    // (e.g. port 0, zero HTTP threads) would otherwise cause confusing
-    // failures inside initHttpServer(); fail fast with a clear error instead.
-    // Validating before the compare_exchange avoids a window where
-    // initialized_ is set to true and then rolled back on failure.
-    std::string error_msg;
-    if (!MetricsConfigLoader::validateConfig(config, &error_msg)) {
-        LOG(ERROR) << "Invalid TENT metrics config: " << error_msg
-                   << "; metrics disabled";
-        return Status::InvalidArgument(
-            "Invalid TENT metrics config: " + error_msg + LOC_MARK);
-    }
-
     // Use compare_exchange to prevent race condition during initialization
     bool expected = false;
     if (!initialized_.compare_exchange_strong(expected, true)) {
         return Status::OK();  // Already initialized by another thread
+    }
+
+    // Validate configuration before doing anything else. An invalid config
+    // (e.g. port 0, zero HTTP threads) would otherwise cause confusing
+    // failures inside initHttpServer(); fail fast with a clear error instead.
+    std::string error_msg;
+    if (!MetricsConfigLoader::validateConfig(config, &error_msg)) {
+        LOG(ERROR) << "Invalid TENT metrics config: " << error_msg
+                   << "; metrics disabled";
+        initialized_.store(false, std::memory_order_relaxed);
+        return Status::InvalidArgument(
+            "Invalid TENT metrics config: " + error_msg + LOC_MARK);
     }
 
     config_ = config;
@@ -189,12 +201,19 @@ void TentMetrics::shutdown() {
     counters_.clear();
     histograms_.clear();
 
+    // Reset bound port so httpPort() returns 0 after shutdown, not a stale
+    // port from a previous initialization. Without this, a re-initialize
+    // that fails to bind would cause httpPort() to report the old port.
+    bound_http_port_.store(0, std::memory_order_relaxed);
+
     initialized_ = false;
     LOG(INFO) << "TENT metrics shutdown complete";
 }
 
 void TentMetrics::registerMetrics() {
-    // Register all counters - add new counters here
+    // Register all counters as base metric_t* pointers so that counters with
+    // different label arities (N=1 per-transport, N=2 failover from→to) share
+    // one vector for Prometheus serialize().
     counters_ = {
         &read_bytes_total_,    &write_bytes_total_,
         &read_requests_total_, &write_requests_total_,
@@ -217,92 +236,93 @@ void TentMetrics::registerMetrics() {
     };
 }
 
-void TentMetrics::recordReadCompleted(size_t bytes, double latency_seconds) {
-    // Fast path: check runtime switch first
+void TentMetrics::recordReadCompleted(TransportType tp, size_t bytes,
+                                      double latency_seconds) {
     if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
         return;
 
-    read_bytes_total_.inc(static_cast<double>(bytes));
-    read_requests_total_.inc();
-    read_size_.observe(static_cast<int64_t>(bytes));
+    auto label = std::array<std::string, 1>{kTransportLabelNames[tp]};
+    read_bytes_total_.inc(label, static_cast<int64_t>(bytes));
+    read_requests_total_.inc(label);
+    read_size_.observe(label, static_cast<int64_t>(bytes));
     if (latency_seconds > 0.0) {
-        // Convert seconds to microseconds for histogram (int64_t internally)
         int64_t latency_us = static_cast<int64_t>(latency_seconds * 1000000.0);
-        read_latency_.observe(latency_us);
+        read_latency_.observe(label, latency_us);
     }
 }
 
-void TentMetrics::recordWriteCompleted(size_t bytes, double latency_seconds) {
-    // Fast path: check runtime switch first
+void TentMetrics::recordWriteCompleted(TransportType tp, size_t bytes,
+                                       double latency_seconds) {
     if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
         return;
 
-    write_bytes_total_.inc(static_cast<double>(bytes));
-    write_requests_total_.inc();
-    write_size_.observe(static_cast<int64_t>(bytes));
+    auto label = std::array<std::string, 1>{kTransportLabelNames[tp]};
+    write_bytes_total_.inc(label, static_cast<int64_t>(bytes));
+    write_requests_total_.inc(label);
+    write_size_.observe(label, static_cast<int64_t>(bytes));
     if (latency_seconds > 0.0) {
-        // Convert seconds to microseconds for histogram (int64_t internally)
         int64_t latency_us = static_cast<int64_t>(latency_seconds * 1000000.0);
-        write_latency_.observe(latency_us);
+        write_latency_.observe(label, latency_us);
     }
 }
 
-void TentMetrics::recordDeadlineMLU(double mlu) {
-    // Fast path: check runtime switch first
+void TentMetrics::recordDeadlineMLU(TransportType tp, double mlu) {
     if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
         return;
-    if (mlu < 0.0) return;  // defensive: ignore invalid (e.g. window <= 0)
-    // Store in per-mille so the integer histogram can bucket fractional ratios.
-    deadline_mlu_.observe(static_cast<int64_t>(mlu * 1000.0));
+    if (mlu < 0.0) return;
+    auto label = std::array<std::string, 1>{kTransportLabelNames[tp]};
+    deadline_mlu_.observe(label, static_cast<int64_t>(mlu * 1000.0));
 }
 
-void TentMetrics::recordDeadlineInfeasible() {
+void TentMetrics::recordDeadlineInfeasible(TransportType tp) {
     if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
         return;
-    deadline_infeasible_total_.inc();
+    deadline_infeasible_total_.inc(
+        std::array<std::string, 1>{kTransportLabelNames[tp]});
 }
 
-void TentMetrics::recordStageLatency(Stage stage, double latency_us) {
+void TentMetrics::recordStageLatency(Stage stage, TransportType tp,
+                                     double latency_us) {
     if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
         return;
     if (latency_us < 0.0) return;
+    auto label = std::array<std::string, 1>{kTransportLabelNames[tp]};
     int64_t val = static_cast<int64_t>(latency_us);
     switch (stage) {
         case Stage::QueueWait:
-            stage_queue_wait_.observe(val);
+            stage_queue_wait_.observe(label, val);
             break;
         case Stage::Dispatch:
-            stage_dispatch_.observe(val);
+            stage_dispatch_.observe(label, val);
             break;
         case Stage::Transport:
-            stage_transport_.observe(val);
+            stage_transport_.observe(label, val);
             break;
     }
 }
 
-void TentMetrics::recordReadFailed() {
-    // Fast path: check runtime switch first
+void TentMetrics::recordReadFailed(TransportType tp) {
     if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
         return;
-
-    read_failures_total_.inc();
-    read_requests_total_.inc();  // Count failed requests too
+    auto label = std::array<std::string, 1>{kTransportLabelNames[tp]};
+    read_failures_total_.inc(label);
+    read_requests_total_.inc(label);
 }
 
-void TentMetrics::recordWriteFailed() {
-    // Fast path: check runtime switch first
+void TentMetrics::recordWriteFailed(TransportType tp) {
     if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
         return;
-
-    write_failures_total_.inc();
-    write_requests_total_.inc();  // Count failed requests too
+    auto label = std::array<std::string, 1>{kTransportLabelNames[tp]};
+    write_failures_total_.inc(label);
+    write_requests_total_.inc(label);
 }
 
-void TentMetrics::recordTransportFailover() {
+void TentMetrics::recordTransportFailover(TransportType from,
+                                          TransportType to) {
     if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
         return;
-
-    failover_total_.inc();
+    failover_total_.inc(std::array<std::string, 2>{kTransportLabelNames[from],
+                                                   kTransportLabelNames[to]});
 }
 
 std::string TentMetrics::getPrometheusMetrics() {
@@ -310,17 +330,23 @@ std::string TentMetrics::getPrometheusMetrics() {
 
     try {
         std::string result;
-        // Pre-allocate buffer to avoid reallocation during serialization
         result.reserve(kPrometheusBufferSize);
 
-        // Serialize all counters
+        // Serialize each metric into a temporary buffer first, then append.
+        // ylt's basic_dynamic_histogram::serialize() calls str.clear() when
+        // all label combos have sum=0, which would wipe previous output if
+        // we serialized directly into `result`. Using a per-metric temporary
+        // isolates each serialize() call.
         for (auto* counter : counters_) {
-            counter->serialize(result);
+            std::string tmp;
+            counter->serialize(tmp);
+            result += tmp;
         }
 
-        // Serialize all histograms
         for (const auto& entry : histograms_) {
-            entry.h->serialize(result);
+            std::string tmp;
+            entry.h->serialize(tmp);
+            result += tmp;
         }
 
         return result;
@@ -330,43 +356,73 @@ std::string TentMetrics::getPrometheusMetrics() {
     }
 }
 
+namespace {
+// Sum values across all label combos of a dynamic counter. Works with both
+// raw pointers (counter members) and shared_ptr (histogram bucket counters).
+template <typename CounterPtr>
+int64_t sumCounterValues(CounterPtr counter) {
+    int64_t total = 0;
+    for (auto& e : counter->copy()) {
+        total += e->value.load(std::memory_order_relaxed);
+    }
+    return total;
+}
+}  // namespace
+
 std::string TentMetrics::getJsonMetrics() {
     if (!initialized_) return "{}";
 
     try {
         nlohmann::json root;
 
-        // Serialize all counters
-        for (auto* counter : counters_) {
-            root[counter->str_name()] = counter->value();
-        }
+        // Counters: aggregate (sum) across all transport label values so the
+        // JSON endpoint stays a simple flat {name: total} view. Per-transport
+        // breakdown is available via the Prometheus endpoint.
+        root[read_bytes_total_.str_name()] =
+            sumCounterValues(&read_bytes_total_);
+        root[write_bytes_total_.str_name()] =
+            sumCounterValues(&write_bytes_total_);
+        root[read_requests_total_.str_name()] =
+            sumCounterValues(&read_requests_total_);
+        root[write_requests_total_.str_name()] =
+            sumCounterValues(&write_requests_total_);
+        root[read_failures_total_.str_name()] =
+            sumCounterValues(&read_failures_total_);
+        root[write_failures_total_.str_name()] =
+            sumCounterValues(&write_failures_total_);
+        root[failover_total_.str_name()] = sumCounterValues(&failover_total_);
+        root[deadline_infeasible_total_.str_name()] =
+            sumCounterValues(&deadline_infeasible_total_);
 
-        // Serialize all histograms
-        for (const auto& entry : histograms_) {
-            auto* histogram = entry.h;
-            const auto& boundaries = *entry.boundaries;
+        // Histograms: sum bucket counts across all transport labels.
+        auto serializeHistogram =
+            [&](ylt::metric::basic_dynamic_histogram<int64_t, 1>* hist,
+                const std::vector<double>& boundaries) {
+                auto bucket_counts = hist->get_bucket_counts();
+                int64_t total_count = 0;
+                nlohmann::json buckets_obj;
+                for (size_t i = 0; i < bucket_counts.size(); ++i) {
+                    int64_t bucket_total = sumCounterValues(bucket_counts[i]);
+                    total_count += bucket_total;
+                    if (i < boundaries.size()) {
+                        buckets_obj[std::to_string(static_cast<int64_t>(
+                            boundaries[i]))] = bucket_total;
+                    }
+                }
+                nlohmann::json hist_obj;
+                hist_obj["count"] = total_count;
+                hist_obj["buckets"] = buckets_obj;
+                root[hist->str_name()] = hist_obj;
+            };
 
-            auto bucket_counts = histogram->get_bucket_counts();
-
-            // Calculate total count
-            int64_t total_count = 0;
-            for (auto& bucket : bucket_counts) {
-                total_count += bucket->value();
-            }
-
-            nlohmann::json hist_obj;
-            hist_obj["count"] = total_count;
-
-            nlohmann::json buckets_obj;
-            for (size_t i = 0;
-                 i < boundaries.size() && i < bucket_counts.size(); ++i) {
-                buckets_obj[std::to_string(static_cast<int64_t>(
-                    boundaries[i]))] = bucket_counts[i]->value();
-            }
-            hist_obj["buckets"] = buckets_obj;
-
-            root[histogram->str_name()] = hist_obj;
-        }
+        serializeHistogram(&read_latency_, kLatencyBuckets);
+        serializeHistogram(&write_latency_, kLatencyBuckets);
+        serializeHistogram(&read_size_, kSizeBuckets);
+        serializeHistogram(&write_size_, kSizeBuckets);
+        serializeHistogram(&deadline_mlu_, kMluPerMilleBuckets);
+        serializeHistogram(&stage_queue_wait_, kStageBuckets);
+        serializeHistogram(&stage_dispatch_, kStageBuckets);
+        serializeHistogram(&stage_transport_, kStageBuckets);
 
         return root.dump(2);  // Pretty print with 2-space indent
     } catch (const std::exception& e) {
@@ -381,13 +437,16 @@ std::string TentMetrics::getSummaryString() {
     std::ostringstream oss;
     oss << std::fixed << std::setprecision(2);
 
-    double read_bytes = read_bytes_total_.value();
-    double write_bytes = write_bytes_total_.value();
-    double read_reqs = read_requests_total_.value();
-    double write_reqs = write_requests_total_.value();
-    double read_fails = read_failures_total_.value();
-    double write_fails = write_failures_total_.value();
-    double failovers = failover_total_.value();
+    // Aggregate across all transport labels — summary is intentionally a
+    // single total line, not per-transport. Per-transport breakdown is via
+    // Prometheus.
+    double read_bytes = sumCounterValues(&read_bytes_total_);
+    double write_bytes = sumCounterValues(&write_bytes_total_);
+    double read_reqs = sumCounterValues(&read_requests_total_);
+    double write_reqs = sumCounterValues(&write_requests_total_);
+    double read_fails = sumCounterValues(&read_failures_total_);
+    double write_fails = sumCounterValues(&write_failures_total_);
+    double failovers = sumCounterValues(&failover_total_);
 
     // Format bytes in human-readable form
     auto formatBytes = [](double bytes) -> std::string {
@@ -430,14 +489,14 @@ Status TentMetrics::initialize(const MetricsConfig& config) {
 
 void TentMetrics::shutdown() { initialized_ = false; }
 
-void TentMetrics::recordReadCompleted(size_t, double) {}
-void TentMetrics::recordWriteCompleted(size_t, double) {}
-void TentMetrics::recordReadFailed() {}
-void TentMetrics::recordWriteFailed() {}
-void TentMetrics::recordTransportFailover() {}
-void TentMetrics::recordDeadlineMLU(double) {}
-void TentMetrics::recordDeadlineInfeasible() {}
-void TentMetrics::recordStageLatency(Stage, double) {}
+void TentMetrics::recordReadCompleted(TransportType, size_t, double) {}
+void TentMetrics::recordWriteCompleted(TransportType, size_t, double) {}
+void TentMetrics::recordReadFailed(TransportType) {}
+void TentMetrics::recordWriteFailed(TransportType) {}
+void TentMetrics::recordTransportFailover(TransportType, TransportType) {}
+void TentMetrics::recordDeadlineMLU(TransportType, double) {}
+void TentMetrics::recordDeadlineInfeasible(TransportType) {}
+void TentMetrics::recordStageLatency(Stage, TransportType, double) {}
 
 std::string TentMetrics::getPrometheusMetrics() {
     return "# TENT metrics disabled at compile time\n";

--- a/mooncake-transfer-engine/tent/src/metrics/tent_metrics.cpp
+++ b/mooncake-transfer-engine/tent/src/metrics/tent_metrics.cpp
@@ -44,22 +44,23 @@ TentMetrics::~TentMetrics() { shutdown(); }
 #if TENT_METRICS_ENABLED
 
 Status TentMetrics::initialize(const MetricsConfig& config) {
-    // Use compare_exchange to prevent race condition during initialization
-    bool expected = false;
-    if (!initialized_.compare_exchange_strong(expected, true)) {
-        return Status::OK();  // Already initialized by another thread
-    }
-
-    // Validate configuration before doing anything else. An invalid config
+    // Validate configuration before touching initialized_. An invalid config
     // (e.g. port 0, zero HTTP threads) would otherwise cause confusing
     // failures inside initHttpServer(); fail fast with a clear error instead.
+    // Validating before the compare_exchange avoids a window where
+    // initialized_ is set to true and then rolled back on failure.
     std::string error_msg;
     if (!MetricsConfigLoader::validateConfig(config, &error_msg)) {
         LOG(ERROR) << "Invalid TENT metrics config: " << error_msg
                    << "; metrics disabled";
-        initialized_.store(false, std::memory_order_relaxed);
         return Status::InvalidArgument(
             "Invalid TENT metrics config: " + error_msg + LOC_MARK);
+    }
+
+    // Use compare_exchange to prevent race condition during initialization
+    bool expected = false;
+    if (!initialized_.compare_exchange_strong(expected, true)) {
+        return Status::OK();  // Already initialized by another thread
     }
 
     config_ = config;
@@ -241,7 +242,7 @@ void TentMetrics::recordReadCompleted(TransportType tp, size_t bytes,
     if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
         return;
 
-    auto label = std::array<std::string, 1>{kTransportLabelNames[tp]};
+    auto label = std::array<std::string, 1>{transportLabel(tp)};
     read_bytes_total_.inc(label, static_cast<int64_t>(bytes));
     read_requests_total_.inc(label);
     read_size_.observe(label, static_cast<int64_t>(bytes));
@@ -256,7 +257,7 @@ void TentMetrics::recordWriteCompleted(TransportType tp, size_t bytes,
     if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
         return;
 
-    auto label = std::array<std::string, 1>{kTransportLabelNames[tp]};
+    auto label = std::array<std::string, 1>{transportLabel(tp)};
     write_bytes_total_.inc(label, static_cast<int64_t>(bytes));
     write_requests_total_.inc(label);
     write_size_.observe(label, static_cast<int64_t>(bytes));
@@ -270,7 +271,7 @@ void TentMetrics::recordDeadlineMLU(TransportType tp, double mlu) {
     if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
         return;
     if (mlu < 0.0) return;
-    auto label = std::array<std::string, 1>{kTransportLabelNames[tp]};
+    auto label = std::array<std::string, 1>{transportLabel(tp)};
     deadline_mlu_.observe(label, static_cast<int64_t>(mlu * 1000.0));
 }
 
@@ -278,7 +279,7 @@ void TentMetrics::recordDeadlineInfeasible(TransportType tp) {
     if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
         return;
     deadline_infeasible_total_.inc(
-        std::array<std::string, 1>{kTransportLabelNames[tp]});
+        std::array<std::string, 1>{transportLabel(tp)});
 }
 
 void TentMetrics::recordStageLatency(Stage stage, TransportType tp,
@@ -286,7 +287,7 @@ void TentMetrics::recordStageLatency(Stage stage, TransportType tp,
     if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
         return;
     if (latency_us < 0.0) return;
-    auto label = std::array<std::string, 1>{kTransportLabelNames[tp]};
+    auto label = std::array<std::string, 1>{transportLabel(tp)};
     int64_t val = static_cast<int64_t>(latency_us);
     switch (stage) {
         case Stage::QueueWait:
@@ -304,7 +305,7 @@ void TentMetrics::recordStageLatency(Stage stage, TransportType tp,
 void TentMetrics::recordReadFailed(TransportType tp) {
     if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
         return;
-    auto label = std::array<std::string, 1>{kTransportLabelNames[tp]};
+    auto label = std::array<std::string, 1>{transportLabel(tp)};
     read_failures_total_.inc(label);
     read_requests_total_.inc(label);
 }
@@ -312,7 +313,7 @@ void TentMetrics::recordReadFailed(TransportType tp) {
 void TentMetrics::recordWriteFailed(TransportType tp) {
     if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
         return;
-    auto label = std::array<std::string, 1>{kTransportLabelNames[tp]};
+    auto label = std::array<std::string, 1>{transportLabel(tp)};
     write_failures_total_.inc(label);
     write_requests_total_.inc(label);
 }
@@ -321,8 +322,8 @@ void TentMetrics::recordTransportFailover(TransportType from,
                                           TransportType to) {
     if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
         return;
-    failover_total_.inc(std::array<std::string, 2>{kTransportLabelNames[from],
-                                                   kTransportLabelNames[to]});
+    failover_total_.inc(
+        std::array<std::string, 2>{transportLabel(from), transportLabel(to)});
 }
 
 std::string TentMetrics::getPrometheusMetrics() {

--- a/mooncake-transfer-engine/tent/src/metrics/tent_metrics.cpp
+++ b/mooncake-transfer-engine/tent/src/metrics/tent_metrics.cpp
@@ -22,18 +22,6 @@
 namespace mooncake::tent {
 
 // Pre-constructed label values indexed by TransportType enum. Keeps the
-// label space closed: only these 11 strings can ever appear as the
-// "transport" (or "from"/"to") label value in Prometheus output.
-// Values align with TransportSelector::transportTypeName()
-// (transport_selector.cpp:45) so Prometheus labels match log messages. Enum
-// order (tent/common/types.h:46): UNSPEC, RDMA, MNNVL, SHM, NVLINK, GDS,
-// IOURING, TCP, AscendDirect, SUNRISE_LINK, TPU.
-const std::array<std::string, kNumTransportTypes>
-    TentMetrics::kTransportLabelNames = {
-        "unspec",   "rdma", "mnnvl",  "shm",          "nvlink", "gds",
-        "io_uring", "tcp",  "ascend", "sunrise_link", "tpu",
-};
-
 TentMetrics& TentMetrics::instance() {
     static TentMetrics instance;
     return instance;
@@ -42,6 +30,18 @@ TentMetrics& TentMetrics::instance() {
 TentMetrics::~TentMetrics() { shutdown(); }
 
 #if TENT_METRICS_ENABLED
+
+// Pre-constructed label value lookup table, indexed by TransportType enum
+// (see tent/common/types.h:46). Keeps label values in a closed set — no
+// arbitrary strings can reach the metrics. Label values aligned with
+// TransportSelector::transportTypeName().
+// Enum order: UNSPEC, RDMA, MNNVL, SHM, NVLINK, GDS,
+// IOURING, TCP, AscendDirect, SUNRISE_LINK, TPU.
+const std::array<std::string, kNumTransportTypes>
+    TentMetrics::kTransportLabelNames = {
+        "unspec",   "rdma", "mnnvl",  "shm",          "nvlink", "gds",
+        "io_uring", "tcp",  "ascend", "sunrise_link", "tpu",
+};
 
 Status TentMetrics::initialize(const MetricsConfig& config) {
     // Validate configuration before touching initialized_. An invalid config

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -2049,7 +2049,7 @@ Status TransferEngineImpl::resubmitTransferTask(Batch* batch, size_t task_id) {
     LOG(INFO) << "Transport failover: " << transportTypeName(prev_type)
               << " -> " << transportTypeName(type) << " (attempt "
               << task.failover_count << "/" << max_failover_attempts_ << ")";
-    TENT_RECORD_TRANSPORT_FAILOVER();
+    TENT_RECORD_TRANSPORT_FAILOVER(prev_type, type);
 
     auto& transport = transport_list_[type];
     if (!batch->sub_batch[type]) {
@@ -2409,10 +2409,10 @@ void TransferEngineImpl::recordTaskCompletionMetrics(
             if (new_status == COMPLETED) {
                 if (task.request.opcode == Request::READ) {
                     TentMetrics::instance().recordReadCompleted(
-                        task.request.length, latency_seconds);
+                        task.type, task.request.length, latency_seconds);
                 } else {
                     TentMetrics::instance().recordWriteCompleted(
-                        task.request.length, latency_seconds);
+                        task.type, task.request.length, latency_seconds);
                 }
                 // Causal chain stage decomposition
                 if (task.dispatch_time.time_since_epoch().count() > 0) {
@@ -2421,7 +2421,7 @@ void TransferEngineImpl::recordTaskCompletionMetrics(
                             task.dispatch_time - start_time)
                             .count();
                     TENT_RECORD_STAGE_LATENCY(TentMetrics::Stage::QueueWait,
-                                              queue_wait_us);
+                                              task.type, queue_wait_us);
                     if (task.post_time.time_since_epoch().count() > 0) {
                         double dispatch_us =
                             std::chrono::duration<double, std::micro>(
@@ -2432,16 +2432,16 @@ void TransferEngineImpl::recordTaskCompletionMetrics(
                                 end_time - task.post_time)
                                 .count();
                         TENT_RECORD_STAGE_LATENCY(TentMetrics::Stage::Dispatch,
-                                                  dispatch_us);
+                                                  task.type, dispatch_us);
                         TENT_RECORD_STAGE_LATENCY(TentMetrics::Stage::Transport,
-                                                  transport_us);
+                                                  task.type, transport_us);
                     }
                 }
             } else if (new_status == FAILED) {
                 if (task.request.opcode == Request::READ) {
-                    TentMetrics::instance().recordReadFailed();
+                    TentMetrics::instance().recordReadFailed(task.type);
                 } else {
-                    TentMetrics::instance().recordWriteFailed();
+                    TentMetrics::instance().recordWriteFailed(task.type);
                 }
             }
             // Observability only (RFC #2519): deadline feasibility. The
@@ -2460,13 +2460,13 @@ void TransferEngineImpl::recordTaskCompletionMetrics(
                         double window_seconds =
                             (task.request.deadline_ns - start_ns) / 1e9;
                         TentMetrics::instance().recordDeadlineMLU(
-                            latency_seconds / window_seconds);
+                            task.type, latency_seconds / window_seconds);
                     }
                 } else {
                     // Deadline already in the past at submit: infeasible.
                     // Recorded into a dedicated counter so it does not
                     // pollute the MLU histogram with a sentinel value.
-                    TentMetrics::instance().recordDeadlineInfeasible();
+                    TentMetrics::instance().recordDeadlineInfeasible(task.type);
                 }
             }
             // Reset start_time to prevent duplicate recording

--- a/mooncake-transfer-engine/tent/tests/causal_chain_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/causal_chain_test.cpp
@@ -280,9 +280,9 @@ TEST(CausalChain, TimestampsPopulatedOnDirectPath) {
 
 #if TENT_METRICS_ENABLED
 TEST(CausalChain, MetricsRecordStageLatencyIsCallable) {
-    TENT_RECORD_STAGE_LATENCY(TentMetrics::Stage::QueueWait, 100.0);
-    TENT_RECORD_STAGE_LATENCY(TentMetrics::Stage::Dispatch, 50.0);
-    TENT_RECORD_STAGE_LATENCY(TentMetrics::Stage::Transport, 200.0);
+    TENT_RECORD_STAGE_LATENCY(TentMetrics::Stage::QueueWait, UNSPEC, 100.0);
+    TENT_RECORD_STAGE_LATENCY(TentMetrics::Stage::Dispatch, UNSPEC, 50.0);
+    TENT_RECORD_STAGE_LATENCY(TentMetrics::Stage::Transport, UNSPEC, 200.0);
 }
 #endif
 

--- a/mooncake-transfer-engine/tent/tests/metrics_recording_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/metrics_recording_test.cpp
@@ -380,8 +380,8 @@ TEST_F(MetricsRecordingTest, CompletedTransferRecordsBytesAndLatency) {
 TEST_F(MetricsRecordingTest, FailedTransferCountsFailureNotBytes) {
     auto before = MetricsSnapshot(TentMetrics::instance());
 
-    TentMetrics::instance().recordReadFailed();
-    TentMetrics::instance().recordWriteFailed();
+    TentMetrics::instance().recordReadFailed(UNSPEC);
+    TentMetrics::instance().recordWriteFailed(UNSPEC);
 
     auto after = MetricsSnapshot(TentMetrics::instance());
 
@@ -601,7 +601,7 @@ TEST_F(MetricsRecordingTest, HistogramJsonBucketsMatchBoundaries) {
 // ---------------------------------------------------------------------------
 TEST_F(MetricsRecordingTest, BucketsAreCompileTimeDefaults) {
     // Record one sample so the histogram is non-empty.
-    TentMetrics::instance().recordReadCompleted(4096, 0.001);
+    TentMetrics::instance().recordReadCompleted(UNSPEC, 4096, 0.001);
 
     auto snap = MetricsSnapshot(TentMetrics::instance());
     auto keys = snap.bucketKeys("tent_read_latency_us");
@@ -660,9 +660,9 @@ class MetricsHttpTest : public ::testing::Test {
 
 TEST_F(MetricsHttpTest, PrometheusEndpointExposesAllCounters) {
     // Record a mix of operations so the counters are non-zero.
-    TentMetrics::instance().recordReadCompleted(1024, 0.001);
-    TentMetrics::instance().recordWriteCompleted(2048, 0.002);
-    TentMetrics::instance().recordDeadlineInfeasible();
+    TentMetrics::instance().recordReadCompleted(UNSPEC, 1024, 0.001);
+    TentMetrics::instance().recordWriteCompleted(UNSPEC, 2048, 0.002);
+    TentMetrics::instance().recordDeadlineInfeasible(UNSPEC);
 
     auto resp = retryGet("/metrics");
     EXPECT_EQ(resp.http_status, 200);
@@ -675,7 +675,7 @@ TEST_F(MetricsHttpTest, PrometheusEndpointExposesAllCounters) {
 }
 
 TEST_F(MetricsHttpTest, JsonEndpointValid) {
-    TentMetrics::instance().recordReadCompleted(512, 0.0005);
+    TentMetrics::instance().recordReadCompleted(UNSPEC, 512, 0.0005);
 
     auto resp = retryGet("/metrics/json");
     EXPECT_EQ(resp.http_status, 200);

--- a/mooncake-transfer-engine/tent/tests/metrics_recording_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/metrics_recording_test.cpp
@@ -674,6 +674,27 @@ TEST_F(MetricsHttpTest, PrometheusEndpointExposesAllCounters) {
               std::string::npos);
 }
 
+TEST_F(MetricsHttpTest, PrometheusLabelsDistinguishTransports) {
+    // Record the same metric with different transports.
+    TentMetrics::instance().recordReadCompleted(RDMA, 1024, 0.001);
+    TentMetrics::instance().recordReadCompleted(TCP, 2048, 0.002);
+    TentMetrics::instance().recordTransportFailover(RDMA, TCP);
+
+    auto resp = retryGet("/metrics");
+    EXPECT_EQ(resp.http_status, 200);
+
+    // Per-transport labels must appear as separate lines.
+    EXPECT_NE(resp.body.find("tent_read_bytes_total{transport=\"rdma\"}"),
+              std::string::npos);
+    EXPECT_NE(resp.body.find("tent_read_bytes_total{transport=\"tcp\"}"),
+              std::string::npos);
+
+    // Failover counter must carry from/to labels.
+    EXPECT_NE(resp.body.find(
+                  "tent_transport_failover_total{from=\"rdma\",to=\"tcp\"}"),
+              std::string::npos);
+}
+
 TEST_F(MetricsHttpTest, JsonEndpointValid) {
     TentMetrics::instance().recordReadCompleted(UNSPEC, 512, 0.0005);
 

--- a/mooncake-transfer-engine/tent/tests/tent_metrics_example.cpp
+++ b/mooncake-transfer-engine/tent/tests/tent_metrics_example.cpp
@@ -109,19 +109,19 @@ int main(int argc, char* argv[]) {
         // Simulate successful reads with manual latency
         size_t read_bytes = 1024 * 1024 * (i + 1);   // 1-10 MB
         double read_latency = 0.001 + (i * 0.0005);  // 1-5ms
-        TENT_RECORD_READ_COMPLETED(read_bytes, read_latency);
+        TENT_RECORD_READ_COMPLETED(RDMA, read_bytes, read_latency);
 
         // Simulate successful writes with manual latency
         size_t write_bytes = 512 * 1024 * (i + 1);    // 512KB - 5MB
         double write_latency = 0.002 + (i * 0.0003);  // 2-4.7ms
-        TENT_RECORD_WRITE_COMPLETED(write_bytes, write_latency);
+        TENT_RECORD_WRITE_COMPLETED(RDMA, write_bytes, write_latency);
 
         // Simulate some failures
         if (i % 3 == 0) {
-            TENT_RECORD_READ_FAILED();
+            TENT_RECORD_READ_FAILED(RDMA);
         }
         if (i % 4 == 0) {
-            TENT_RECORD_WRITE_FAILED();
+            TENT_RECORD_WRITE_FAILED(RDMA);
         }
 
         std::cout << "  Iteration " << (i + 1) << ": Read "
@@ -142,7 +142,7 @@ int main(int argc, char* argv[]) {
 
     // Example 1: Using TENT_SCOPED_READ_LATENCY macro
     {
-        TENT_SCOPED_READ_LATENCY(2 * 1024 * 1024);  // 2 MB read
+        TENT_SCOPED_READ_LATENCY(RDMA, 2 * 1024 * 1024);  // 2 MB read
         // Simulate work (the latency is automatically measured)
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
         std::cout << "  Scoped read: 2 MB with ~5ms simulated work"
@@ -151,7 +151,7 @@ int main(int argc, char* argv[]) {
 
     // Example 2: Using TENT_SCOPED_WRITE_LATENCY macro
     {
-        TENT_SCOPED_WRITE_LATENCY(1 * 1024 * 1024);  // 1 MB write
+        TENT_SCOPED_WRITE_LATENCY(RDMA, 1 * 1024 * 1024);  // 1 MB write
         // Simulate work
         std::this_thread::sleep_for(std::chrono::milliseconds(3));
         std::cout << "  Scoped write: 1 MB with ~3ms simulated work"
@@ -161,7 +161,7 @@ int main(int argc, char* argv[]) {
     // Example 3: Using ScopedLatencyRecorder directly with failure handling
     {
         ScopedLatencyRecorder recorder(
-            ScopedLatencyRecorder::OperationType::Read, 512 * 1024);
+            ScopedLatencyRecorder::OperationType::Read, RDMA, 512 * 1024);
         std::this_thread::sleep_for(std::chrono::milliseconds(2));
         // Simulate a failure condition
         bool operation_failed = true;  // Simulated failure
@@ -175,7 +175,7 @@ int main(int argc, char* argv[]) {
     // Example 4: Multiple scoped operations in a loop
     std::cout << "\n  Running 5 scoped read operations..." << std::endl;
     for (int i = 0; i < 5; ++i) {
-        TENT_SCOPED_READ_LATENCY(256 * 1024 * (i + 1));  // 256KB - 1.25MB
+        TENT_SCOPED_READ_LATENCY(RDMA, 256 * 1024 * (i + 1));  // 256KB - 1.25MB
         std::this_thread::sleep_for(std::chrono::milliseconds(1 + i));
         std::cout << "    Scoped read " << (i + 1) << ": " << 256 * (i + 1)
                   << " KB with ~" << (1 + i) << "ms work" << std::endl;
@@ -196,7 +196,7 @@ int main(int argc, char* argv[]) {
         // These calls will return immediately with minimal overhead
         for (int i = 0; i < 1000; ++i) {
             TENT_RECORD_READ_COMPLETED(
-                1024, 0.001);  // These are no-ops when disabled
+                RDMA, 1024, 0.001);  // These are no-ops when disabled
         }
         std::cout << "  1000 record calls completed (no-op, metrics disabled)"
                   << std::endl;
@@ -206,7 +206,7 @@ int main(int argc, char* argv[]) {
         TentMetrics::setEnabled(true);
 
         // Now these will be recorded
-        TENT_RECORD_READ_COMPLETED(1024 * 1024, 0.005);
+        TENT_RECORD_READ_COMPLETED(RDMA, 1024 * 1024, 0.005);
         std::cout << "  Recorded 1 MB read after re-enabling" << std::endl;
     } else {
         std::cout << "  Skipping enable/disable demo (started with --disabled)"
@@ -244,8 +244,8 @@ int main(int argc, char* argv[]) {
             std::this_thread::sleep_for(std::chrono::seconds(1));
 
             // Simulate ongoing traffic
-            TENT_RECORD_READ_COMPLETED(1024 * 1024, 0.001);
-            TENT_RECORD_WRITE_COMPLETED(512 * 1024, 0.002);
+            TENT_RECORD_READ_COMPLETED(RDMA, 1024 * 1024, 0.001);
+            TENT_RECORD_WRITE_COMPLETED(RDMA, 512 * 1024, 0.002);
         }
     }
 


### PR DESCRIPTION
## Description

All 16 TENT metrics now carry a `transport` label (the failover counter
uses `from`/`to`), so operators can slice read/write bytes, requests,
failures, latency, and failover paths by transport in Prometheus without
grepping logs.

**Why.** Without labels, `tent_read_failures_total=5` tells you something
failed but not which transport (RDMA? TCP? NVLink?) or which failover
path was taken. The label closes that diagnostic gap at the metrics
layer.

**How.** Switched from yalantinglibs static metric types
(`counter_t`/`histogram_t`, no labels) to dynamic types
(`basic_dynamic_counter`/`basic_dynamic_histogram<int64_t, N>`). All
record methods now take a `TransportType` parameter; the 10 call sites in
`transfer_engine_impl.cpp` pass `task.type` (or `prev_type`/`type` for
failover).

**Cardinality control.** Label values come exclusively from the
`TransportType` enum closed set (11 values) via a pre-built lookup table
indexed by enum — no arbitrary strings are accepted, enforced at the type
level. Total series upper bound ~1500, fully bounded. Label values are
aligned with `TransportSelector::transportTypeName()`.

**Serialization.** `getSummaryString()` and `getJsonMetrics()` sum across
labels for flat totals (single-line summary preserved). Per-transport
breakdown is available only via the Prometheus `/metrics` endpoint.

**Notable findings:**
- **ylt `serialize()` bug workaround:** `basic_dynamic_histogram::serialize()`
  calls `str.clear()` when all label combos have sum=0, wiping previously
  serialized content from the shared output string. Each metric is now
  serialized into a temp buffer then appended. Overhead is negligible
  (scrape path only, not transfer hot path — a few microseconds per
  15s scrape). ylt upstream is not modified.
- **Pre-existing fix:** `shutdown()` did not reset `bound_http_port_`, so
  `httpPort()` returned a stale port after a shutdown+reinitialize cycle.
  Now resets to 0.

**Out of scope (Phase 2):** a `reason` label on failure counters is
deferred — it requires threading failure classification from each
transport implementation through to the record point, which is a larger
change. Will be driven by real diagnostic needs after this lands.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] New feature

## How Has This Been Tested?

**Test commands:**
```bash
# Full TENT build with metrics enabled
cmake -DCMAKE_BUILD_TYPE=Debug -DUSE_TENT=ON -DTENT_METRICS_ENABLED=ON \
      -DBUILD_UNIT_TESTS=ON -DUSE_HTTP=ON -DUSE_TCP=ON -DWITH_METRICS=ON \
      -DUSE_CUDA=OFF -DUSE_HIP=OFF -DUSE_ETCD=OFF -DUSE_MNNVL=OFF -DUSE_TPU=OFF \
      -S mooncake-transfer-engine -B mooncake-transfer-engine/build-tent-metrics
cmake --build mooncake-transfer-engine/build-tent-metrics -j384

# Unit tests
cd mooncake-transfer-engine/build-tent-metrics/tent/tests
./metrics_config_loader_test      # 25/25
./tent_metrics_http_server_test   #  1/1
./tent_metrics_recording_test     # 10/10

# tebench real TCP transfer verification (two-process)
TENT_METRICS_ENABLED=true TENT_METRICS_HTTP_PORT=19601 tebench \
  --backend=tent --metadata_type=p2p --rpc_server_port=19611 --seg_type=DRAM &
TENT_METRICS_ENABLED=true TENT_METRICS_HTTP_PORT=19602 tebench \
  --backend=tent --metadata_type=p2p --rpc_server_port=19612 \
  --target_seg_name=127.0.0.1:19611 --tent_transport_hint=tcp \
  --op_type=write --duration=3
# Scrape /metrics from initiator during the run
curl -s http://127.0.0.1:19602/metrics
```

**Test results:**
- [x] Unit tests pass — 36/36 across 3 suites
- [x] Integration tests pass — tebench two-process TCP: 88,282 real write
      transfers (1.16 GB) via `--tent_transport_hint=tcp`. Prometheus output
      scraped during the run confirms `{transport="tcp"}` labels:
      `tent_write_bytes_total{transport="tcp"} 1157140480`,
      `tent_write_requests_total{transport="tcp"} 88282`,
      `tent_write_latency_us_bucket{transport="tcp",le="..."}`.
      Summary remains single-line total: `Write: 1.16 GB (88307 reqs, 0 fails)`.
- [x] Manual testing — label landing confirmed with multiple transport types
      (RDMA, TCP, UNSPEC): `{transport="rdma"}`, `{transport="tcp"}`,
      `{from="rdma",to="tcp"}` all verified in Prometheus output

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable) — Available Metrics
      table updated with Labels column; new Labels subsection documenting
      the TransportType closed-set scheme; Prometheus example output and
      Grafana queries updated with per-transport examples
- [x] I have added tests to prove my changes are effective — existing test
      suites updated with transport parameters; label landing confirmed via
      real /metrics scrape; tebench TCP integration test confirms real-load
      labeling
- [x] For changes >500 LOC: I have filed an RFC issue — N/A (~390 insertions
      excluding tests)

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

An AI coding agent implemented the mechanical edits (metric type switching,
record API changes, call site migration, serialization adaptation, docs)
under human direction. The human submitter has reviewed every changed line
and can defend the change end-to-end: the label schema design, the
cardinality control mechanism (enum closed set), the ylt serialize() bug
workaround, and the verification coverage including tebench TCP integration.