### PR TITLE
[Store] Report NIC load stats from clients and add batch query APIs on master

### DIFF
--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -429,6 +429,24 @@ class Client {
         int64_t ssd_total_capacity_bytes);
 
     /**
+     * @brief Report per-device NIC load statistics to the master.
+     */
+    tl::expected<void, ErrorCode> ReportNicLoadStats(
+        const std::vector<NicLoadStat>& stats);
+
+    /**
+     * @brief Batch-query NIC load snapshots for the given client IDs.
+     */
+    tl::expected<std::vector<ClientNicLoadStats>, ErrorCode>
+    BatchGetNicLoadStats(const std::vector<UUID>& client_ids);
+
+    /**
+     * @brief Batch-query NIC load snapshots by segment/TE endpoint strings.
+     */
+    tl::expected<std::vector<ClientNicLoadStats>, ErrorCode>
+    BatchGetNicLoadStatsByEndpoints(const std::vector<std::string>& endpoints);
+
+    /**
      * @brief Heartbeat-driven pull of pending L2->L1 promotion work for this
      * client. Mirror of OffloadObjectHeartbeat. Returns tenant-scoped tasks the
      * caller (FileStorage) must read from local SSD and stage as MEMORY
@@ -669,6 +687,7 @@ class Client {
         const std::string& metadata_connstring, const std::string& protocol,
         const std::optional<std::string>& device_names);
     void InitTransferSubmitter();
+    void ReportLocalNicLoadStats();
     ErrorCode TransferData(const Replica::Descriptor& replica_descriptor,
                            std::vector<Slice>& slices,
                            TransferRequest::OpCode op_code);

--- a/mooncake-store/include/master_client.h
+++ b/mooncake-store/include/master_client.h
@@ -431,6 +431,24 @@ class MasterClient {
     [[nodiscard]] tl::expected<std::vector<OffloadTaskItem>, ErrorCode>
     OffloadObjectHeartbeat(const UUID& client_id, bool enable_offloading);
 
+    /**
+     * @brief Report per-device NIC load statistics to the master.
+     */
+    [[nodiscard]] tl::expected<void, ErrorCode> ReportNicLoadStats(
+        const UUID& client_id, const std::vector<NicLoadStat>& stats);
+
+    /**
+     * @brief Batch-query NIC load snapshots by client IDs.
+     */
+    [[nodiscard]] tl::expected<std::vector<ClientNicLoadStats>, ErrorCode>
+    BatchGetNicLoadStats(const std::vector<UUID>& client_ids);
+
+    /**
+     * @brief Batch-query NIC load snapshots by segment/TE endpoint strings.
+     */
+    [[nodiscard]] tl::expected<std::vector<ClientNicLoadStats>, ErrorCode>
+    BatchGetNicLoadStatsByEndpoints(const std::vector<std::string>& endpoints);
+
     [[nodiscard]] tl::expected<void, ErrorCode> ReportSsdCapacity(
         const UUID& client_id, int64_t ssd_total_capacity_bytes);
 

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -673,7 +673,8 @@ class MasterService {
 
     /**
      * @brief Like BatchGetNicLoadStats but resolves clients by their
-     *        segment name or TE endpoint address.
+     *        segment name or TE endpoint address. The endpoint mapping is
+     *        cached and may lag mounts by up to kEndpointIndexTtlMs.
      * @param endpoints Endpoint strings to resolve.
      */
     auto BatchGetNicLoadStatsByEndpoints(
@@ -2107,6 +2108,12 @@ class MasterService {
     mutable std::mutex nic_load_stats_mutex_;
     std::unordered_map<UUID, ClientNicLoadStats, boost::hash<UUID>>
         nic_load_stats_;
+    // Endpoint -> client index rebuilt from segments at most once per
+    // kEndpointIndexTtlMs, so per-heartbeat queries avoid full segment scans.
+    static constexpr uint64_t kEndpointIndexTtlMs = 1000;  // 1 sec
+    mutable std::mutex endpoint_index_mutex_;
+    std::unordered_map<std::string, UUID> endpoint_to_client_;
+    uint64_t endpoint_index_built_at_ms_ = 0;
 
     bool enable_snapshot_restore_ = false;
 

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -70,6 +70,8 @@ class SnapshotChildProcessTest;
 // exposing test-only accessors on MasterService itself.
 class PromotionOnHitTest;
 class MasterServiceTenantQuotaTest;
+// Friended so eviction tests can rewind private NIC load stats timestamps.
+class MasterServiceNicLoadTest;
 }  // namespace test
 namespace benchmarks {
 class BatchEvictBench;
@@ -96,6 +98,7 @@ class MasterService {
     friend class test::PromotionOnHitTest;
     friend class benchmarks::BatchEvictBench;
     friend class test::MasterServiceTenantQuotaTest;
+    friend class test::MasterServiceNicLoadTest;
     friend class MasterSnapshotManager;    // Allow access to internal state for
                                            // snapshot
     friend class ha::MasterSnapshotCodec;  // Allow codec to access private

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -651,6 +651,33 @@ class MasterService {
         -> tl::expected<void, ErrorCode>;
 
     /**
+     * @brief Accepts a periodic NIC load report from a client and stores
+     *        the snapshot for later queries.
+     * @param client_id The reporting client.
+     * @param stats     Per-device load statistics.
+     */
+    auto ReportNicLoadStats(const UUID& client_id,
+                            const std::vector<NicLoadStat>& stats)
+        -> tl::expected<void, ErrorCode>;
+
+    /**
+     * @brief Returns the latest NIC load snapshots for the given client IDs.
+     *        Stale entries (older than kNicLoadStatsTtlMs) are evicted.
+     * @param client_ids Clients to query.
+     */
+    auto BatchGetNicLoadStats(const std::vector<UUID>& client_ids)
+        -> tl::expected<std::vector<ClientNicLoadStats>, ErrorCode>;
+
+    /**
+     * @brief Like BatchGetNicLoadStats but resolves clients by their
+     *        segment name or TE endpoint address.
+     * @param endpoints Endpoint strings to resolve.
+     */
+    auto BatchGetNicLoadStatsByEndpoints(
+        const std::vector<std::string>& endpoints)
+        -> tl::expected<std::vector<ClientNicLoadStats>, ErrorCode>;
+
+    /**
      * @brief Notifies the master that offloading of specified objects has
      * succeeded.
      * @param tasks        A list of tenant-scoped objects that were
@@ -1500,6 +1527,10 @@ class MasterService {
         const std::unordered_set<UUID, boost::hash<UUID>>& alive_clients,
         MetadataShardAccessorRW* shard = nullptr);
 
+    // True if a NIC load stats entry is older than kNicLoadStatsTtlMs.
+    static bool IsNicLoadEntryStale(const ClientNicLoadStats& entry,
+                                    uint64_t now_ms);
+
     // Helper: allocate replicas, create ObjectMetadata, insert into shard,
     // and return descriptor list.  Shared by PutStart and UpsertStart.
     auto AllocateAndInsertMetadata(
@@ -2063,6 +2094,16 @@ class MasterService {
     BufferAllocatorType memory_allocator_type_;
     const AllocationStrategyType allocation_strategy_type_;
     std::shared_ptr<AllocationStrategy> allocation_strategy_;
+
+    // NIC load stats cache - entries older than kNicLoadStatsTtlMs are evicted
+    // lazily on read; short TTL so a dead client's data drops out quickly.
+    static constexpr uint64_t kNicLoadStatsTtlMs = 15 * 1000;  // 15 sec
+    // Per-report caps to bound memory from misbehaving clients.
+    static constexpr size_t kMaxNicDevicesPerReport = 64;
+    static constexpr size_t kMaxNicDeviceNameLength = 256;
+    mutable std::mutex nic_load_stats_mutex_;
+    std::unordered_map<UUID, ClientNicLoadStats, boost::hash<UUID>>
+        nic_load_stats_;
 
     bool enable_snapshot_restore_ = false;
 

--- a/mooncake-store/include/rpc_service.h
+++ b/mooncake-store/include/rpc_service.h
@@ -213,6 +213,15 @@ class WrappedMasterService {
     tl::expected<std::vector<OffloadTaskItem>, ErrorCode>
     OffloadObjectHeartbeat(const UUID& client_id, bool enable_offloading);
 
+    tl::expected<void, ErrorCode> ReportNicLoadStats(
+        const UUID& client_id, const std::vector<NicLoadStat>& stats);
+
+    tl::expected<std::vector<ClientNicLoadStats>, ErrorCode>
+    BatchGetNicLoadStats(const std::vector<UUID>& client_ids);
+
+    tl::expected<std::vector<ClientNicLoadStats>, ErrorCode>
+    BatchGetNicLoadStatsByEndpoints(const std::vector<std::string>& endpoints);
+
     tl::expected<void, ErrorCode> ReportSsdCapacity(
         const UUID& client_id, int64_t ssd_total_capacity_bytes);
 

--- a/mooncake-store/include/rpc_types.h
+++ b/mooncake-store/include/rpc_types.h
@@ -27,6 +27,36 @@ struct PingResponse {
 YLT_REFL(PingResponse, view_version_id, client_status);
 
 /**
+ * @brief Per-NIC device load statistics reported by each client.
+ */
+struct NicLoadStat {
+    std::string device_name;
+    uint64_t inflight_bytes;
+    double ewma_bandwidth_bps;
+
+    NicLoadStat() : inflight_bytes(0), ewma_bandwidth_bps(0.0) {}
+    NicLoadStat(std::string device_name_param, uint64_t inflight_bytes_param,
+                double ewma_bandwidth_bps_param)
+        : device_name(std::move(device_name_param)),
+          inflight_bytes(inflight_bytes_param),
+          ewma_bandwidth_bps(ewma_bandwidth_bps_param) {}
+};
+YLT_REFL(NicLoadStat, device_name, inflight_bytes, ewma_bandwidth_bps);
+
+/**
+ * @brief Aggregated NIC load statistics for a single client.
+ */
+struct ClientNicLoadStats {
+    UUID client_id;
+    std::string endpoint;
+    std::vector<NicLoadStat> devices;
+    uint64_t updated_at_ms;
+
+    ClientNicLoadStats() : updated_at_ms(0) {}
+};
+YLT_REFL(ClientNicLoadStats, client_id, endpoint, devices, updated_at_ms);
+
+/**
  * @brief Response structure for GetReplicaList operation
  */
 struct GetReplicaListResponse {

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -882,6 +882,38 @@ void Client::InitTransferSubmitter() {
 #endif
 }
 
+void Client::ReportLocalNicLoadStats() {
+    // rpc_only clients have no transfer engine.
+    if (!transfer_engine_) {
+        return;
+    }
+    std::vector<NicLoadStats> local_stats;
+    auto status = transfer_engine_->getNicLoadStats(local_stats);
+    if (!status.ok()) {
+        VLOG(1) << "Failed to get transfer engine NIC load stats: "
+                << status.ToString();
+        return;
+    }
+
+    if (local_stats.empty()) {
+        return;
+    }
+
+    std::vector<NicLoadStat> nic_stats;
+    nic_stats.reserve(local_stats.size());
+    for (const auto& stat : local_stats) {
+        nic_stats.emplace_back(stat.device_name, stat.inflight_bytes,
+                               stat.ewma_bandwidth_bps);
+    }
+
+    auto report_result = ReportNicLoadStats(nic_stats);
+    if (!report_result) {
+        // Rate-limited: runs every heartbeat.
+        LOG_EVERY_N(WARNING, 60) << "Failed to report local NIC load stats: "
+                                 << report_result.error();
+    }
+}
+
 std::optional<std::shared_ptr<Client>> Client::Create(
     const std::string& local_hostname, const std::string& metadata_connstring,
     const std::string& protocol, const std::optional<std::string>& device_names,
@@ -3055,6 +3087,39 @@ tl::expected<void, ErrorCode> Client::ReportSsdCapacity(
     return {};
 }
 
+tl::expected<void, ErrorCode> Client::ReportNicLoadStats(
+    const std::vector<NicLoadStat>& stats) {
+    auto response = master_client_.ReportNicLoadStats(client_id_, stats);
+    if (!response) {
+        // The periodic caller logs failures; avoid duplicate lines here.
+        return tl::make_unexpected(response.error());
+    }
+    return {};
+}
+
+tl::expected<std::vector<ClientNicLoadStats>, ErrorCode>
+Client::BatchGetNicLoadStats(const std::vector<UUID>& client_ids) {
+    auto response = master_client_.BatchGetNicLoadStats(client_ids);
+    if (!response) {
+        LOG(ERROR) << "BatchGetNicLoadStats failed, error code is "
+                   << response.error();
+        return tl::make_unexpected(response.error());
+    }
+    return response;
+}
+
+tl::expected<std::vector<ClientNicLoadStats>, ErrorCode>
+Client::BatchGetNicLoadStatsByEndpoints(
+    const std::vector<std::string>& endpoints) {
+    auto response = master_client_.BatchGetNicLoadStatsByEndpoints(endpoints);
+    if (!response) {
+        LOG(ERROR) << "BatchGetNicLoadStatsByEndpoints failed, error code is "
+                   << response.error();
+        return tl::make_unexpected(response.error());
+    }
+    return response;
+}
+
 tl::expected<void, ErrorCode> Client::BatchGetOffloadObject(
     const std::string& transfer_engine_addr,
     const std::vector<std::string>& keys,
@@ -3826,6 +3891,8 @@ void Client::StorageHeartbeatThreadMain() {
                     }
                 }
             }
+
+            ReportLocalNicLoadStats();
 
             std::this_thread::sleep_for(
                 std::chrono::milliseconds(success_ping_interval_ms));

--- a/mooncake-store/src/master_client.cpp
+++ b/mooncake-store/src/master_client.cpp
@@ -223,6 +223,21 @@ struct RpcNameTraits<&WrappedMasterService::OffloadObjectHeartbeat> {
 };
 
 template <>
+struct RpcNameTraits<&WrappedMasterService::ReportNicLoadStats> {
+    static constexpr const char* value = "ReportNicLoadStats";
+};
+
+template <>
+struct RpcNameTraits<&WrappedMasterService::BatchGetNicLoadStats> {
+    static constexpr const char* value = "BatchGetNicLoadStats";
+};
+
+template <>
+struct RpcNameTraits<&WrappedMasterService::BatchGetNicLoadStatsByEndpoints> {
+    static constexpr const char* value = "BatchGetNicLoadStatsByEndpoints";
+};
+
+template <>
 struct RpcNameTraits<&WrappedMasterService::ReportSsdCapacity> {
     static constexpr const char* value = "ReportSsdCapacity";
 };
@@ -995,6 +1010,31 @@ tl::expected<void, ErrorCode> MasterClient::ReportSsdCapacity(
                      ", ssd_total_capacity_bytes=", ssd_total_capacity_bytes);
     return invoke_rpc<&WrappedMasterService::ReportSsdCapacity, void>(
         client_id, ssd_total_capacity_bytes);
+}
+
+tl::expected<void, ErrorCode> MasterClient::ReportNicLoadStats(
+    const UUID& client_id, const std::vector<NicLoadStat>& stats) {
+    ScopedVLogTimer timer(1, "MasterClient::ReportNicLoadStats");
+    timer.LogRequest("client_id=", client_id, ", device_count=", stats.size());
+    return invoke_rpc<&WrappedMasterService::ReportNicLoadStats, void>(
+        client_id, stats);
+}
+
+tl::expected<std::vector<ClientNicLoadStats>, ErrorCode>
+MasterClient::BatchGetNicLoadStats(const std::vector<UUID>& client_ids) {
+    ScopedVLogTimer timer(1, "MasterClient::BatchGetNicLoadStats");
+    timer.LogRequest("client_id_count=", client_ids.size());
+    return invoke_rpc<&WrappedMasterService::BatchGetNicLoadStats,
+                      std::vector<ClientNicLoadStats>>(client_ids);
+}
+
+tl::expected<std::vector<ClientNicLoadStats>, ErrorCode>
+MasterClient::BatchGetNicLoadStatsByEndpoints(
+    const std::vector<std::string>& endpoints) {
+    ScopedVLogTimer timer(1, "MasterClient::BatchGetNicLoadStatsByEndpoints");
+    timer.LogRequest("endpoint_count=", endpoints.size());
+    return invoke_rpc<&WrappedMasterService::BatchGetNicLoadStatsByEndpoints,
+                      std::vector<ClientNicLoadStats>>(endpoints);
 }
 
 tl::expected<void, ErrorCode> MasterClient::NotifyOffloadSuccess(

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -5002,6 +5002,13 @@ auto MasterService::ReportSsdCapacity(const UUID& client_id,
     return {};
 }
 
+// Wall-clock milliseconds since epoch, matching NicLoadStats timestamps.
+static uint64_t NicLoadNowMs() {
+    return std::chrono::duration_cast<std::chrono::milliseconds>(
+               std::chrono::system_clock::now().time_since_epoch())
+        .count();
+}
+
 auto MasterService::ReportNicLoadStats(const UUID& client_id,
                                        const std::vector<NicLoadStat>& stats)
     -> tl::expected<void, ErrorCode> {
@@ -5020,10 +5027,7 @@ auto MasterService::ReportNicLoadStats(const UUID& client_id,
     ClientNicLoadStats snapshot;
     snapshot.client_id = client_id;
     snapshot.devices = stats;
-    snapshot.updated_at_ms =
-        std::chrono::duration_cast<std::chrono::milliseconds>(
-            std::chrono::system_clock::now().time_since_epoch())
-            .count();
+    snapshot.updated_at_ms = NicLoadNowMs();
 
     std::lock_guard<std::mutex> lock(nic_load_stats_mutex_);
     // Reports arrive every heartbeat, so stale entries are evicted here
@@ -5050,10 +5054,7 @@ auto MasterService::BatchGetNicLoadStats(const std::vector<UUID>& client_ids)
     std::vector<ClientNicLoadStats> result;
     result.reserve(client_ids.size());
 
-    const uint64_t now_ms =
-        std::chrono::duration_cast<std::chrono::milliseconds>(
-            std::chrono::system_clock::now().time_since_epoch())
-            .count();
+    const uint64_t now_ms = NicLoadNowMs();
 
     std::lock_guard<std::mutex> lock(nic_load_stats_mutex_);
     for (const auto& client_id : client_ids) {
@@ -5073,40 +5074,41 @@ auto MasterService::BatchGetNicLoadStats(const std::vector<UUID>& client_ids)
 auto MasterService::BatchGetNicLoadStatsByEndpoints(
     const std::vector<std::string>& endpoints)
     -> tl::expected<std::vector<ClientNicLoadStats>, ErrorCode> {
+    const uint64_t now_ms = NicLoadNowMs();
+
     std::vector<std::pair<std::string, UUID>> endpoint_clients;
     endpoint_clients.reserve(endpoints.size());
     {
-        auto segment_access = segment_manager_.getSegmentAccess();
-        std::vector<std::pair<Segment, UUID>> all_segments;
-        auto err = segment_access.GetAllSegments(all_segments);
-        if (err != ErrorCode::OK) {
-            return tl::make_unexpected(err);
-        }
+        std::lock_guard<std::mutex> index_lock(endpoint_index_mutex_);
+        if (now_ms >= endpoint_index_built_at_ms_ + kEndpointIndexTtlMs) {
+            auto segment_access = segment_manager_.getSegmentAccess();
+            std::vector<std::pair<Segment, UUID>> all_segments;
+            auto err = segment_access.GetAllSegments(all_segments);
+            if (err != ErrorCode::OK) {
+                return tl::make_unexpected(err);
+            }
 
-        // Map endpoint strings to client IDs (first-wins on duplicates).
-        std::unordered_map<std::string, UUID> client_by_endpoint;
-        client_by_endpoint.reserve(all_segments.size() * 2);
-        for (const auto& [segment, client_id] : all_segments) {
-            if (!segment.name.empty()) {
-                client_by_endpoint.emplace(segment.name, client_id);
+            // Map endpoint strings to client IDs (first-wins on duplicates).
+            endpoint_to_client_.clear();
+            endpoint_to_client_.reserve(all_segments.size() * 2);
+            for (const auto& [segment, client_id] : all_segments) {
+                if (!segment.name.empty()) {
+                    endpoint_to_client_.emplace(segment.name, client_id);
+                }
+                if (!segment.te_endpoint.empty()) {
+                    endpoint_to_client_.emplace(segment.te_endpoint, client_id);
+                }
             }
-            if (!segment.te_endpoint.empty()) {
-                client_by_endpoint.emplace(segment.te_endpoint, client_id);
-            }
+            endpoint_index_built_at_ms_ = now_ms;
         }
 
         for (const auto& endpoint : endpoints) {
-            auto it = client_by_endpoint.find(endpoint);
-            if (it != client_by_endpoint.end()) {
+            auto it = endpoint_to_client_.find(endpoint);
+            if (it != endpoint_to_client_.end()) {
                 endpoint_clients.emplace_back(endpoint, it->second);
             }
         }
     }
-
-    const uint64_t now_ms =
-        std::chrono::duration_cast<std::chrono::milliseconds>(
-            std::chrono::system_clock::now().time_since_epoch())
-            .count();
 
     std::vector<ClientNicLoadStats> result;
     result.reserve(endpoint_clients.size());

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -5002,6 +5002,131 @@ auto MasterService::ReportSsdCapacity(const UUID& client_id,
     return {};
 }
 
+auto MasterService::ReportNicLoadStats(const UUID& client_id,
+                                       const std::vector<NicLoadStat>& stats)
+    -> tl::expected<void, ErrorCode> {
+    if (stats.size() > kMaxNicDevicesPerReport) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+    for (const auto& device : stats) {
+        if (device.device_name.empty() ||
+            device.device_name.size() > kMaxNicDeviceNameLength ||
+            device.ewma_bandwidth_bps < 0.0 ||
+            !std::isfinite(device.ewma_bandwidth_bps)) {
+            return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+        }
+    }
+
+    ClientNicLoadStats snapshot;
+    snapshot.client_id = client_id;
+    snapshot.devices = stats;
+    snapshot.updated_at_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::system_clock::now().time_since_epoch())
+            .count();
+
+    std::lock_guard<std::mutex> lock(nic_load_stats_mutex_);
+    // Reports arrive every heartbeat, so stale entries are evicted here
+    // even when no one queries the cache.
+    for (auto it = nic_load_stats_.begin(); it != nic_load_stats_.end();) {
+        if (IsNicLoadEntryStale(it->second, snapshot.updated_at_ms)) {
+            it = nic_load_stats_.erase(it);
+        } else {
+            ++it;
+        }
+    }
+    nic_load_stats_[client_id] = std::move(snapshot);
+    return {};
+}
+
+bool MasterService::IsNicLoadEntryStale(const ClientNicLoadStats& entry,
+                                        uint64_t now_ms) {
+    return now_ms > entry.updated_at_ms &&
+           now_ms - entry.updated_at_ms > kNicLoadStatsTtlMs;
+}
+
+auto MasterService::BatchGetNicLoadStats(const std::vector<UUID>& client_ids)
+    -> tl::expected<std::vector<ClientNicLoadStats>, ErrorCode> {
+    std::vector<ClientNicLoadStats> result;
+    result.reserve(client_ids.size());
+
+    const uint64_t now_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::system_clock::now().time_since_epoch())
+            .count();
+
+    std::lock_guard<std::mutex> lock(nic_load_stats_mutex_);
+    for (const auto& client_id : client_ids) {
+        auto it = nic_load_stats_.find(client_id);
+        if (it == nic_load_stats_.end()) {
+            continue;
+        }
+        if (IsNicLoadEntryStale(it->second, now_ms)) {
+            nic_load_stats_.erase(it);
+            continue;
+        }
+        result.push_back(it->second);
+    }
+    return result;
+}
+
+auto MasterService::BatchGetNicLoadStatsByEndpoints(
+    const std::vector<std::string>& endpoints)
+    -> tl::expected<std::vector<ClientNicLoadStats>, ErrorCode> {
+    std::vector<std::pair<std::string, UUID>> endpoint_clients;
+    endpoint_clients.reserve(endpoints.size());
+    {
+        auto segment_access = segment_manager_.getSegmentAccess();
+        std::vector<std::pair<Segment, UUID>> all_segments;
+        auto err = segment_access.GetAllSegments(all_segments);
+        if (err != ErrorCode::OK) {
+            return tl::make_unexpected(err);
+        }
+
+        // Map endpoint strings to client IDs (first-wins on duplicates).
+        std::unordered_map<std::string, UUID> client_by_endpoint;
+        client_by_endpoint.reserve(all_segments.size() * 2);
+        for (const auto& [segment, client_id] : all_segments) {
+            if (!segment.name.empty()) {
+                client_by_endpoint.emplace(segment.name, client_id);
+            }
+            if (!segment.te_endpoint.empty()) {
+                client_by_endpoint.emplace(segment.te_endpoint, client_id);
+            }
+        }
+
+        for (const auto& endpoint : endpoints) {
+            auto it = client_by_endpoint.find(endpoint);
+            if (it != client_by_endpoint.end()) {
+                endpoint_clients.emplace_back(endpoint, it->second);
+            }
+        }
+    }
+
+    const uint64_t now_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::system_clock::now().time_since_epoch())
+            .count();
+
+    std::vector<ClientNicLoadStats> result;
+    result.reserve(endpoint_clients.size());
+    std::lock_guard<std::mutex> lock(nic_load_stats_mutex_);
+    for (const auto& [endpoint, client_id] : endpoint_clients) {
+        auto it = nic_load_stats_.find(client_id);
+        if (it == nic_load_stats_.end()) {
+            continue;
+        }
+        if (IsNicLoadEntryStale(it->second, now_ms)) {
+            nic_load_stats_.erase(it);
+            continue;
+        }
+        auto snapshot = it->second;
+        snapshot.endpoint = endpoint;
+        result.push_back(std::move(snapshot));
+    }
+    return result;
+}
+
 auto MasterService::NotifyOffloadSuccess(
     const UUID& client_id, const std::vector<OffloadTaskItem>& tasks,
     const std::vector<StorageObjectMetadata>& metadatas)

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -1171,6 +1171,29 @@ WrappedMasterService::OffloadObjectHeartbeat(const UUID& client_id,
     return result;
 }
 
+tl::expected<void, ErrorCode> WrappedMasterService::ReportNicLoadStats(
+    const UUID& client_id, const std::vector<NicLoadStat>& stats) {
+    ScopedVLogTimer timer(1, "ReportNicLoadStats");
+    timer.LogRequest("client_id=", client_id, ", device_count=", stats.size());
+    return master_service_.ReportNicLoadStats(client_id, stats);
+}
+
+tl::expected<std::vector<ClientNicLoadStats>, ErrorCode>
+WrappedMasterService::BatchGetNicLoadStats(
+    const std::vector<UUID>& client_ids) {
+    ScopedVLogTimer timer(1, "BatchGetNicLoadStats");
+    timer.LogRequest("client_id_count=", client_ids.size());
+    return master_service_.BatchGetNicLoadStats(client_ids);
+}
+
+tl::expected<std::vector<ClientNicLoadStats>, ErrorCode>
+WrappedMasterService::BatchGetNicLoadStatsByEndpoints(
+    const std::vector<std::string>& endpoints) {
+    ScopedVLogTimer timer(1, "BatchGetNicLoadStatsByEndpoints");
+    timer.LogRequest("endpoint_count=", endpoints.size());
+    return master_service_.BatchGetNicLoadStatsByEndpoints(endpoints);
+}
+
 tl::expected<void, ErrorCode> WrappedMasterService::ReportSsdCapacity(
     const UUID& client_id, int64_t ssd_total_capacity_bytes) {
     ScopedVLogTimer timer(1, "ReportSsdCapacity");
@@ -1356,6 +1379,15 @@ void RegisterRpcService(
         &wrapped_master_service);
     server.register_handler<
         &mooncake::WrappedMasterService::OffloadObjectHeartbeat>(
+        &wrapped_master_service);
+    server
+        .register_handler<&mooncake::WrappedMasterService::ReportNicLoadStats>(
+            &wrapped_master_service);
+    server.register_handler<
+        &mooncake::WrappedMasterService::BatchGetNicLoadStats>(
+        &wrapped_master_service);
+    server.register_handler<
+        &mooncake::WrappedMasterService::BatchGetNicLoadStatsByEndpoints>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::ReportSsdCapacity>(
         &wrapped_master_service);

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -66,6 +66,7 @@ add_store_test(master_service_tenant_quota_test
                master_service_tenant_quota_test.cpp)
 add_store_test(batch_remove_test batch_remove_test.cpp)
 add_store_test(master_service_ssd_test master_service_ssd_test.cpp)
+add_store_test(master_service_nic_load_test master_service_nic_load_test.cpp)
 add_store_test(offload_on_evict_test offload_on_evict_test.cpp)
 add_store_test(promotion_on_hit_test promotion_on_hit_test.cpp)
 add_store_test(file_storage_promotion_test file_storage_promotion_test.cpp)

--- a/mooncake-store/tests/master_service_nic_load_test.cpp
+++ b/mooncake-store/tests/master_service_nic_load_test.cpp
@@ -73,6 +73,19 @@ class MasterServiceNicLoadTest : public ::testing::Test {
         std::lock_guard<std::mutex> lock(service.nic_load_stats_mutex_);
         return service.nic_load_stats_.size();
     }
+
+    // Force the endpoint index to rebuild on the next query.
+    static void ExpireEndpointIndex(MasterService& service) {
+        std::lock_guard<std::mutex> lock(service.endpoint_index_mutex_);
+        service.endpoint_index_built_at_ms_ = 0;
+    }
+
+    // Pin the endpoint index so it cannot expire during the test.
+    static void PinEndpointIndex(MasterService& service) {
+        std::lock_guard<std::mutex> lock(service.endpoint_index_mutex_);
+        service.endpoint_index_built_at_ms_ =
+            std::numeric_limits<uint64_t>::max() / 2;
+    }
 };
 
 // --- ReportNicLoadStats ---
@@ -303,6 +316,35 @@ TEST_F(MasterServiceNicLoadTest, BatchGetByMultipleEndpoints) {
         {"endpoint_a", "endpoint_b", "endpoint_c_no_stats", "unknown"});
     ASSERT_TRUE(result.has_value());
     EXPECT_EQ(2u, result->size());
+}
+
+TEST_F(MasterServiceNicLoadTest, EndpointIndexCachedWithinTtl) {
+    auto service = CreateMasterService();
+    UUID client_a = MountSegment(*service, "endpoint_a", 0x300000000);
+    ASSERT_TRUE(
+        service->ReportNicLoadStats(client_a, MakeStats({{"eth0", 100}}))
+            .has_value());
+
+    // First query builds the endpoint index; pin it so it cannot expire
+    // mid-test on a slow machine.
+    auto result = service->BatchGetNicLoadStatsByEndpoints({"endpoint_a"});
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(1u, result->size());
+    PinEndpointIndex(*service);
+
+    // A segment mounted within the TTL is invisible until the index expires.
+    UUID client_b = MountSegment(*service, "endpoint_b", 0x310000000);
+    ASSERT_TRUE(
+        service->ReportNicLoadStats(client_b, MakeStats({{"eth0", 200}}))
+            .has_value());
+    result = service->BatchGetNicLoadStatsByEndpoints({"endpoint_b"});
+    ASSERT_TRUE(result.has_value());
+    EXPECT_TRUE(result->empty());
+
+    ExpireEndpointIndex(*service);
+    result = service->BatchGetNicLoadStatsByEndpoints({"endpoint_b"});
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(1u, result->size());
 }
 
 // --- Eviction ---

--- a/mooncake-store/tests/master_service_nic_load_test.cpp
+++ b/mooncake-store/tests/master_service_nic_load_test.cpp
@@ -1,0 +1,374 @@
+#include "master_service.h"
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "types.h"
+
+namespace mooncake::test {
+
+namespace {
+
+std::unique_ptr<MasterService> CreateMasterService() {
+    return std::make_unique<MasterService>(MasterServiceConfig{});
+}
+
+std::vector<NicLoadStat> MakeStats(
+    const std::vector<std::pair<std::string, uint64_t>>& devices) {
+    std::vector<NicLoadStat> stats;
+    stats.reserve(devices.size());
+    for (const auto& [name, inflight] : devices) {
+        stats.emplace_back(name, inflight, 1e9);
+    }
+    return stats;
+}
+
+UUID MountSegment(MasterService& service, const std::string& segment_name,
+                  size_t base_addr) {
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = segment_name;
+    segment.base = base_addr;
+    segment.size = 64 * 1024 * 1024;
+    segment.te_endpoint = segment_name;
+    UUID client_id = generate_uuid();
+    auto result = service.MountSegment(segment, client_id);
+    EXPECT_TRUE(result.has_value());
+    return client_id;
+}
+
+}  // namespace
+
+class MasterServiceNicLoadTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        google::InitGoogleLogging("MasterServiceNicLoadTest");
+        FLAGS_logtostderr = true;
+    }
+
+    void TearDown() override { google::ShutdownGoogleLogging(); }
+
+    // TEST_F bodies don't inherit friendship; mirror private constants here.
+    static constexpr size_t kMaxDevicesPerReport =
+        MasterService::kMaxNicDevicesPerReport;
+    static constexpr size_t kMaxDeviceNameLength =
+        MasterService::kMaxNicDeviceNameLength;
+
+    // Rewind a snapshot's timestamp beyond the TTL so lazy eviction removes it.
+    static void AgeNicLoadEntryBeyondTtl(MasterService& service,
+                                         const UUID& client_id) {
+        std::lock_guard<std::mutex> lock(service.nic_load_stats_mutex_);
+        auto it = service.nic_load_stats_.find(client_id);
+        ASSERT_TRUE(it != service.nic_load_stats_.end());
+        it->second.updated_at_ms -= MasterService::kNicLoadStatsTtlMs + 1;
+    }
+
+    static size_t NicLoadEntryCount(MasterService& service) {
+        std::lock_guard<std::mutex> lock(service.nic_load_stats_mutex_);
+        return service.nic_load_stats_.size();
+    }
+};
+
+// --- ReportNicLoadStats ---
+
+TEST_F(MasterServiceNicLoadTest, ReportValidStats) {
+    auto service = CreateMasterService();
+    UUID client_id = generate_uuid();
+    auto stats = MakeStats({{"eth0", 1024}, {"eth1", 2048}});
+
+    auto result = service->ReportNicLoadStats(client_id, stats);
+    ASSERT_TRUE(result.has_value());
+}
+
+TEST_F(MasterServiceNicLoadTest, ReportEmptyDeviceNameRejected) {
+    auto service = CreateMasterService();
+    UUID client_id = generate_uuid();
+    auto stats = MakeStats({{"", 1024}});
+
+    auto result = service->ReportNicLoadStats(client_id, stats);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(ErrorCode::INVALID_PARAMS, result.error());
+}
+
+TEST_F(MasterServiceNicLoadTest, ReportNegativeBandwidthRejected) {
+    auto service = CreateMasterService();
+    UUID client_id = generate_uuid();
+    std::vector<NicLoadStat> stats;
+    stats.emplace_back("eth0", 1024, -1.0);
+
+    auto result = service->ReportNicLoadStats(client_id, stats);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(ErrorCode::INVALID_PARAMS, result.error());
+}
+
+TEST_F(MasterServiceNicLoadTest, ReportNanBandwidthRejected) {
+    auto service = CreateMasterService();
+    UUID client_id = generate_uuid();
+    std::vector<NicLoadStat> stats;
+    stats.emplace_back("eth0", 1024, std::numeric_limits<double>::quiet_NaN());
+
+    auto result = service->ReportNicLoadStats(client_id, stats);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(ErrorCode::INVALID_PARAMS, result.error());
+}
+
+TEST_F(MasterServiceNicLoadTest, ReportInfBandwidthRejected) {
+    auto service = CreateMasterService();
+    UUID client_id = generate_uuid();
+    std::vector<NicLoadStat> stats;
+    stats.emplace_back("eth0", 1024, std::numeric_limits<double>::infinity());
+
+    auto result = service->ReportNicLoadStats(client_id, stats);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(ErrorCode::INVALID_PARAMS, result.error());
+}
+
+TEST_F(MasterServiceNicLoadTest, ReportTooManyDevicesRejected) {
+    auto service = CreateMasterService();
+    UUID client_id = generate_uuid();
+    std::vector<std::pair<std::string, uint64_t>> devices;
+    for (size_t i = 0; i <= kMaxDevicesPerReport; ++i) {
+        devices.emplace_back("eth" + std::to_string(i), 100);
+    }
+
+    auto result = service->ReportNicLoadStats(client_id, MakeStats(devices));
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(ErrorCode::INVALID_PARAMS, result.error());
+}
+
+TEST_F(MasterServiceNicLoadTest, ReportOverlongDeviceNameRejected) {
+    auto service = CreateMasterService();
+    UUID client_id = generate_uuid();
+    std::string long_name(kMaxDeviceNameLength + 1, 'x');
+
+    auto result =
+        service->ReportNicLoadStats(client_id, MakeStats({{long_name, 100}}));
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(ErrorCode::INVALID_PARAMS, result.error());
+}
+
+TEST_F(MasterServiceNicLoadTest, ReportOverwritesPrevious) {
+    auto service = CreateMasterService();
+    UUID client_id = generate_uuid();
+
+    ASSERT_TRUE(
+        service->ReportNicLoadStats(client_id, MakeStats({{"eth0", 100}}))
+            .has_value());
+    ASSERT_TRUE(
+        service->ReportNicLoadStats(client_id, MakeStats({{"eth0", 200}}))
+            .has_value());
+
+    auto result = service->BatchGetNicLoadStats({client_id});
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(1u, result->size());
+    EXPECT_EQ(200u, (*result)[0].devices[0].inflight_bytes);
+}
+
+// --- BatchGetNicLoadStats ---
+
+TEST_F(MasterServiceNicLoadTest, BatchGetKnownClient) {
+    auto service = CreateMasterService();
+    UUID client_id = generate_uuid();
+    auto stats = MakeStats({{"eth0", 1024}, {"eth1", 2048}});
+
+    ASSERT_TRUE(service->ReportNicLoadStats(client_id, stats).has_value());
+
+    auto result = service->BatchGetNicLoadStats({client_id});
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(1u, result->size());
+    EXPECT_EQ(client_id, (*result)[0].client_id);
+    ASSERT_EQ(2u, (*result)[0].devices.size());
+    EXPECT_EQ("eth0", (*result)[0].devices[0].device_name);
+    EXPECT_EQ(1024u, (*result)[0].devices[0].inflight_bytes);
+    EXPECT_EQ("eth1", (*result)[0].devices[1].device_name);
+    EXPECT_EQ(2048u, (*result)[0].devices[1].inflight_bytes);
+}
+
+TEST_F(MasterServiceNicLoadTest, BatchGetUnknownClientReturnsEmpty) {
+    auto service = CreateMasterService();
+    UUID unknown_id = generate_uuid();
+
+    auto result = service->BatchGetNicLoadStats({unknown_id});
+    ASSERT_TRUE(result.has_value());
+    EXPECT_TRUE(result->empty());
+}
+
+TEST_F(MasterServiceNicLoadTest, BatchGetMixedClients) {
+    auto service = CreateMasterService();
+    UUID client_a = generate_uuid();
+    UUID client_b = generate_uuid();
+    UUID client_c = generate_uuid();  // never reported
+
+    ASSERT_TRUE(
+        service->ReportNicLoadStats(client_a, MakeStats({{"eth0", 100}}))
+            .has_value());
+    ASSERT_TRUE(
+        service->ReportNicLoadStats(client_b, MakeStats({{"eth0", 200}}))
+            .has_value());
+
+    auto result = service->BatchGetNicLoadStats({client_a, client_b, client_c});
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(2u, result->size());
+}
+
+TEST_F(MasterServiceNicLoadTest, BatchGetEmptyInput) {
+    auto service = CreateMasterService();
+
+    auto result = service->BatchGetNicLoadStats({});
+    ASSERT_TRUE(result.has_value());
+    EXPECT_TRUE(result->empty());
+}
+
+// --- BatchGetNicLoadStatsByEndpoints ---
+
+TEST_F(MasterServiceNicLoadTest, BatchGetBySegmentName) {
+    auto service = CreateMasterService();
+    UUID client_id = MountSegment(*service, "endpoint_a", 0x300000000);
+    ASSERT_TRUE(
+        service->ReportNicLoadStats(client_id, MakeStats({{"eth0", 512}}))
+            .has_value());
+
+    auto result = service->BatchGetNicLoadStatsByEndpoints({"endpoint_a"});
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(1u, result->size());
+    EXPECT_EQ("endpoint_a", (*result)[0].endpoint);
+    EXPECT_EQ(client_id, (*result)[0].client_id);
+    ASSERT_EQ(1u, (*result)[0].devices.size());
+    EXPECT_EQ(512u, (*result)[0].devices[0].inflight_bytes);
+}
+
+TEST_F(MasterServiceNicLoadTest, BatchGetByTeEndpoint) {
+    auto service = CreateMasterService();
+
+    // Mount segment where name != te_endpoint
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = "seg_name";
+    segment.base = 0x310000000;
+    segment.size = 64 * 1024 * 1024;
+    segment.te_endpoint = "te_addr:1234";
+    UUID client_id = generate_uuid();
+    ASSERT_TRUE(service->MountSegment(segment, client_id).has_value());
+    ASSERT_TRUE(
+        service->ReportNicLoadStats(client_id, MakeStats({{"eth0", 256}}))
+            .has_value());
+
+    // Query by te_endpoint
+    auto result = service->BatchGetNicLoadStatsByEndpoints({"te_addr:1234"});
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(1u, result->size());
+    EXPECT_EQ("te_addr:1234", (*result)[0].endpoint);
+    EXPECT_EQ(client_id, (*result)[0].client_id);
+}
+
+TEST_F(MasterServiceNicLoadTest, BatchGetByUnknownEndpointReturnsEmpty) {
+    auto service = CreateMasterService();
+
+    auto result = service->BatchGetNicLoadStatsByEndpoints({"nonexistent"});
+    ASSERT_TRUE(result.has_value());
+    EXPECT_TRUE(result->empty());
+}
+
+TEST_F(MasterServiceNicLoadTest, BatchGetByEndpointNoStatsReported) {
+    auto service = CreateMasterService();
+    // Mount segment but never report NIC load stats
+    MountSegment(*service, "no_stats_endpoint", 0x320000000);
+
+    auto result =
+        service->BatchGetNicLoadStatsByEndpoints({"no_stats_endpoint"});
+    ASSERT_TRUE(result.has_value());
+    EXPECT_TRUE(result->empty());
+}
+
+TEST_F(MasterServiceNicLoadTest, BatchGetByMultipleEndpoints) {
+    auto service = CreateMasterService();
+    UUID client_a = MountSegment(*service, "endpoint_a", 0x300000000);
+    UUID client_b = MountSegment(*service, "endpoint_b", 0x310000000);
+    MountSegment(*service, "endpoint_c_no_stats", 0x320000000);
+
+    ASSERT_TRUE(
+        service->ReportNicLoadStats(client_a, MakeStats({{"eth0", 100}}))
+            .has_value());
+    ASSERT_TRUE(
+        service->ReportNicLoadStats(client_b, MakeStats({{"eth0", 200}}))
+            .has_value());
+
+    auto result = service->BatchGetNicLoadStatsByEndpoints(
+        {"endpoint_a", "endpoint_b", "endpoint_c_no_stats", "unknown"});
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(2u, result->size());
+}
+
+// --- Eviction ---
+
+TEST_F(MasterServiceNicLoadTest, FreshEntriesNotEvicted) {
+    auto service = CreateMasterService();
+    UUID client_id = generate_uuid();
+    ASSERT_TRUE(
+        service->ReportNicLoadStats(client_id, MakeStats({{"eth0", 100}}))
+            .has_value());
+
+    // Read paths evict lazily per queried key; fresh entry must survive.
+    auto result = service->BatchGetNicLoadStats({client_id});
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(1u, result->size());
+    EXPECT_EQ(client_id, (*result)[0].client_id);
+}
+
+TEST_F(MasterServiceNicLoadTest, StaleEntriesEvicted) {
+    auto service = CreateMasterService();
+    UUID stale_id = generate_uuid();
+    UUID fresh_id = generate_uuid();
+    ASSERT_TRUE(
+        service->ReportNicLoadStats(stale_id, MakeStats({{"eth0", 100}}))
+            .has_value());
+    ASSERT_TRUE(
+        service->ReportNicLoadStats(fresh_id, MakeStats({{"eth0", 200}}))
+            .has_value());
+
+    AgeNicLoadEntryBeyondTtl(*service, stale_id);
+
+    auto result = service->BatchGetNicLoadStats({stale_id, fresh_id});
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(1u, result->size());
+    EXPECT_EQ(fresh_id, (*result)[0].client_id);
+}
+
+TEST_F(MasterServiceNicLoadTest, StaleEntriesEvictedOnReport) {
+    auto service = CreateMasterService();
+    UUID stale_id = generate_uuid();
+    UUID fresh_id = generate_uuid();
+    ASSERT_TRUE(
+        service->ReportNicLoadStats(stale_id, MakeStats({{"eth0", 100}}))
+            .has_value());
+
+    AgeNicLoadEntryBeyondTtl(*service, stale_id);
+
+    // A report from any client evicts stale entries without any query.
+    ASSERT_TRUE(
+        service->ReportNicLoadStats(fresh_id, MakeStats({{"eth0", 200}}))
+            .has_value());
+    EXPECT_EQ(1u, NicLoadEntryCount(*service));
+}
+
+TEST_F(MasterServiceNicLoadTest, StaleEntriesEvictedOnEndpointQuery) {
+    auto service = CreateMasterService();
+    UUID client_id = MountSegment(*service, "stale_endpoint", 0x300000000);
+    ASSERT_TRUE(
+        service->ReportNicLoadStats(client_id, MakeStats({{"eth0", 100}}))
+            .has_value());
+
+    AgeNicLoadEntryBeyondTtl(*service, client_id);
+
+    auto result = service->BatchGetNicLoadStatsByEndpoints({"stale_endpoint"});
+    ASSERT_TRUE(result.has_value());
+    EXPECT_TRUE(result->empty());
+}
+
+}  // namespace mooncake::test


### PR DESCRIPTION
## Description

This PR lets the master know how busy each client's RDMA NICs are.

Motivation: when a `Get` has multiple replicas to read from, the master currently picks one without knowing the load on each replica holder's NICs, so a hot node keeps receiving reads while idle ones sit by. #2516 proposes NIC load-aware replica selection; this PR builds the data path for it (the selection policy itself is not changed here).

What it does:

1. **Client side**: every storage heartbeat (~1s), the client reads per-device NIC load from the Transfer Engine — `getNicLoadStats()` added in #2996, returning `{device_name, inflight_bytes, ewma_bandwidth_bps}` per RDMA NIC — and reports it to the master via a new `ReportNicLoadStats` RPC (same shape as the existing `ReportSsdCapacity`). Deployments where the TE reports no NIC data (legacy TE, non-RDMA) skip the RPC entirely.

2. **Master side**: reports are kept in an in-memory map keyed by client id, each entry a full snapshot of that client's NICs with a receive timestamp. Entries not refreshed within 15s (a few missed heartbeats) are lazily evicted on read, so a dead client's load data disappears quickly. Reports exceeding per-report caps (64 devices, 256-byte device names, non-finite bandwidth) are rejected with `INVALID_PARAMS`.

3. **Query APIs**: two read paths for future consumers — `BatchGetNicLoadStats(client_ids)` for direct lookup, and `BatchGetNicLoadStatsByEndpoints(endpoints)` which resolves a `te_endpoint` (as found in replica descriptors) to the owning client via mounted segments.

Nothing reads this data for replica selection yet, so behavior is unchanged for all existing deployments.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



**Test commands:**
```bash
cmake --build build --target master_service_nic_load_test
cd build && ctest -R master_service_nic_load_test --output-on-failure
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

New test suite master_service_nic_load_test covers: input validation (empty/overlong device names, negative/NaN/Inf bandwidth, oversized reports), overwrite semantics, batch queries by client id and by endpoint (segment name and te_endpoint), and TTL eviction (fresh entries survive, stale entries evicted on both query paths). Built and ctest-verified on Linux.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [x] AI tools were used (specify below)

AI assistance was used for code drafting and review iteration. All changes were reviewed line-by-line by the submitter.