### PR TITLE
[CI] Add TENT_METRICS_ENABLED=ON to tent-ci matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -993,9 +993,15 @@ jobs:
           - name: cuda-on
             cmake_flags: '-DUSE_CUDA=ON -DCMAKE_EXE_LINKER_FLAGS=-L/usr/local/cuda/lib64/stubs'
             need_cuda: true
+            metrics_flags: ''
           - name: cuda-off
             cmake_flags: '-DUSE_CUDA=OFF'
             need_cuda: false
+            metrics_flags: ''
+          - name: cuda-off-metrics-on
+            cmake_flags: '-DUSE_CUDA=OFF'
+            need_cuda: false
+            metrics_flags: '-DTENT_METRICS_ENABLED=ON'
     name: tent-ci (${{ matrix.name }})
     env:
       CI: "true"
@@ -1046,7 +1052,7 @@ jobs:
       run: |
         mkdir build-tent
         cd build-tent
-        cmake -G Ninja .. -DUSE_TENT=ON -DUSE_HTTP=ON -DENABLE_SCCACHE=ON -DBUILD_UNIT_TESTS=ON -DBUILD_EXAMPLES=ON -DENABLE_DEBUG_SYMBOLS=OFF ${{ matrix.cmake_flags }}
+        cmake -G Ninja .. -DUSE_TENT=ON -DUSE_HTTP=ON -DENABLE_SCCACHE=ON -DBUILD_UNIT_TESTS=ON -DBUILD_EXAMPLES=ON -DENABLE_DEBUG_SYMBOLS=OFF ${{ matrix.cmake_flags }} ${{ matrix.metrics_flags }}
       shell: bash
 
     - name: Build project with TENT


### PR DESCRIPTION
## Description

Add a third matrix entry (`cuda-off-metrics-on`) to the `tent-ci` job so both compile-time paths of `TENT_METRICS_ENABLED` are exercised in CI.

Currently `tent-ci` only builds with `TENT_METRICS_ENABLED=OFF` (the CMake default). PR #3029 exposed a compile error in the disabled path that wasn't caught until CI ran — `kTransportLabelNames` was defined outside the `#if TENT_METRICS_ENABLED` guard, which only manifests when `=0`. Both paths need CI coverage.

## Changes

- Added `metrics_flags` field to the existing `cuda-on` and `cuda-off` matrix entries (empty string — no change to their build)
- Added `cuda-off-metrics-on` entry with `metrics_flags: '-DTENT_METRICS_ENABLED=ON'`
- Appended `${{ matrix.metrics_flags }}` to the cmake configure command
- Test step untouched — `need_cuda: false` on the new entry means ctest runs automatically, and `TENT_METRICS_ENABLED=ON` builds the metrics unit tests into ctest

## Matrix after change

| Job | CUDA | METRICS | Tests |
|-----|------|---------|-------|
| cuda-on | ON | OFF | No (no GPU) |
| cuda-off | OFF | OFF | Yes |
| cuda-off-metrics-on | OFF | **ON** | Yes (incl. metrics tests) |

Closes #3040.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [x] For changes >500 LOC: I have filed an RFC issue — N/A (7 lines)

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

An AI coding agent implemented the mechanical edit under human direction. The human submitter has reviewed the change and can defend it end-to-end.