### PR TITLE
[CI/Build] Limit EFA release build parallelism

### DIFF
--- a/.github/workflows/release-efa-non-cuda.yaml
+++ b/.github/workflows/release-efa-non-cuda.yaml
@@ -79,7 +79,7 @@ jobs:
       - name: Build project
         run: |
           cd build
-          make -j
+          make -j3
           sudo make install
         shell: bash
 

--- a/.github/workflows/release-efa.yaml
+++ b/.github/workflows/release-efa.yaml
@@ -90,7 +90,7 @@ jobs:
           export LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH
           export LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LIBRARY_PATH
           cd build
-          make -j
+          make -j3
           sudo make install
         shell: bash
 


### PR DESCRIPTION
## Description

Limit GNU Make parallelism to three jobs in both EFA release workflows. Previously, `make -j` enabled unbounded parallelism, which exhausted GitHub-hosted runner resources: `sccache` shut down, compilation processes were terminated, and the runner reported a shutdown signal.

Failed run: https://github.com/kvcache-ai/Mooncake/actions/runs/29830468751/job/88815399284

The three-job limit matches the memory-aware CMake configuration's recommendation for the hosted runner.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
git diff --check
pre-commit run --files .github/workflows/release-efa.yaml .github/workflows/release-efa-non-cuda.yaml
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done: YAML validation and all applicable pre-commit hooks passed

Runtime validation requires the EFA release workflow.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (not applicable; CI-only change)
- [ ] I have added tests to prove my changes are effective (not applicable; workflow-only change)
- [ ] For changes >500 LOC: I have filed an RFC issue (not applicable)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

An AI coding assistant was used to inspect the failed GitHub Actions logs, identify the unbounded Make parallelism, edit the two workflows, and run validation. The submitter is responsible for reviewing and understanding the changes.