### PR TITLE
[TENT] honor device filter via topology/rdma_whitelist

### DIFF
--- a/mooncake-transfer-engine/include/transfer_engine.h
+++ b/mooncake-transfer-engine/include/transfer_engine.h
@@ -212,6 +212,9 @@ class TransferEngine {
     std::shared_ptr<mooncake::tent::TransferEngine> impl_tent_;
     std::shared_ptr<ShutdownToken> shutdown_token_;
     bool use_tent_{false};
+    // Device filter passed at construction, kept so init() can forward it to
+    // TENT via topology/rdma_whitelist (TENT otherwise ignores the filter).
+    std::vector<std::string> tent_device_filter_;
 };
 }  // namespace mooncake
 

--- a/mooncake-transfer-engine/src/transfer_engine.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine.cpp
@@ -382,6 +382,8 @@ TransferEngine::TransferEngine(bool auto_discover,
     }
     if (!use_tent_) {
         impl_ = std::make_shared<TransferEngineImpl>(auto_discover, filter);
+    } else {
+        tent_device_filter_ = filter;
     }
 }
 
@@ -456,6 +458,8 @@ int TransferEngine::init(const std::string& metadata_conn_string,
             if (!type.empty()) config->set("metadata_type", type);
             if (!servers.empty()) config->set("metadata_servers", servers);
         }
+        if (!tent_device_filter_.empty())
+            config->set("topology/rdma_whitelist", tent_device_filter_);
         impl_tent_ = std::make_shared<mooncake::tent::TransferEngine>(config);
         return impl_tent_->available() ? 0 : 1;
     }
@@ -825,7 +829,11 @@ void TransferEngine::setAutoDiscover(bool auto_discover) {
 }
 
 void TransferEngine::setWhitelistFilters(std::vector<std::string>&& filters) {
-    if (!use_tent_) impl_->setWhitelistFilters(std::move(filters));
+    if (!use_tent_) {
+        impl_->setWhitelistFilters(std::move(filters));
+    } else {
+        tent_device_filter_ = std::move(filters);
+    }
 }
 
 int TransferEngine::numContexts() const {


### PR DESCRIPTION
## Description

Under the TENT runtime (`MC_USE_TENT=1`), the device selection passed through
the public API is silently ignored, so users cannot restrict transfers to
specific NICs. The classic→TENT wrapper (`mooncake::TransferEngine`) discards
the `filter` argument in the `use_tent_` branch of the constructor, and `init()`
never writes any device whitelist into the TENT `Config`. As a result
`MOONCAKE_DEVICE` / `TransferEngine(filter)` / `setWhitelistFilters()` have no
effect under TENT, and per-rank / NUMA-local NIC binding is impossible.

TENT already consumes `topology/rdma_whitelist` in its platform probes, but no
public API path fed it. This PR wires the existing filter into that key:

- keep the constructor `filter` in a `tent_device_filter_` member when
  `use_tent_` (previously dropped);
- in `init()`, set `topology/rdma_whitelist` from it before creating the TENT
  engine;
- make `setWhitelistFilters()` also update it on the TENT path.

No new environment variable or public API is introduced; `MOONCAKE_DEVICE` now
behaves consistently in the classic and TENT engines.

### Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

### Type of Change

- [x] Bug fix
- [x] Performance improvement

### How Has This Been Tested?

Tested on an internal 2-node RoCE cluster (5× 200G RDMA NICs per node across 2
NUMA domains), loading DeepSeek-V3.1 (~685GB, TP=8) via P2P remote-instance
weight loading over TENT.

**Filter now takes effect (probe):** with the fix, a minimal `initialize(...)`
harness restricts TENT topology discovery from 5 distinct RDMA NICs down to
exactly the whitelisted NIC(s); without the fix it always discovers all 5.

**End-to-end (10 runs each, bottleneck-rank load time):**

| Binding                         | Load time | vs TENT auto |
|---------------------------------|-----------|--------------|
| TENT auto (baseline)            | 16.8s     | 1.0×         |
| per-rank NUMA-local (this PR)   | 7.7s      | ~2.2× faster |
| per-rank cross-NUMA (misconfig) | 77.5s     | 4.6× slower  |

Per-rank transferred bytes are identical (85.1 GB/rank); only the path changes.

- [ ] Unit tests pass
- [x] Manual testing done (described above)

> Note: the standard CI suite was not run locally as it requires multi-NIC RDMA
> hardware. Happy to add a targeted unit test if maintainers can suggest a
> suitable harness for the TENT config path.

### Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh` (reports the changed files are properly formatted)
- [x] `pre-commit` hooks pass on the changed files (`pre-commit run --files ...`)
- [x] For changes >500 LOC: N/A (change is ~12 LOC)

### AI Assistance Disclosure

- [x] AI tools were used (specify below)

An AI coding assistant helped port the validated patch onto the current `main`,
review the diff, and draft this PR description. All changes were reviewed and
are understood by the submitter, who can defend them end-to-end.