### PR TITLE
[TransferEngine] Harden socket handshake frame handling

### DIFF
--- a/mooncake-transfer-engine/include/common.h
+++ b/mooncake-transfer-engine/include/common.h
@@ -369,9 +369,13 @@ static inline ssize_t readFully(int fd, void *buf, size_t len) {
     size_t nbytes = len;
     while (nbytes && std::chrono::steady_clock::now() < deadline) {
         ssize_t rc = read(fd, pos, nbytes);
-        if (rc < 0 && (errno == EAGAIN || errno == EINTR))
+        if (rc < 0 && errno == EINTR)
             continue;
-        else if (rc < 0) {
+        else if (rc < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+            LOG(WARNING) << "Socket read timed out: expected " << len
+                         << " bytes, actual " << len - nbytes << " bytes";
+            return len - nbytes;
+        } else if (rc < 0) {
             PLOG(ERROR) << "Socket read failed";
             return rc;
         } else if (rc == 0) {
@@ -452,7 +456,7 @@ static inline std::pair<HandShakeRequestType, std::string> readString(int fd) {
     uint64_t length = 0;
     ssize_t n = readFully(fd, &length, sizeof(length));
     if (n != (ssize_t)sizeof(length)) {
-        LOG(ERROR) << "readString: failed to read length, got: " << n;
+        LOG(WARNING) << "readString: incomplete handshake length, got: " << n;
         return {type, ""};
     }
 

--- a/mooncake-transfer-engine/include/common.h
+++ b/mooncake-transfer-engine/include/common.h
@@ -37,7 +37,6 @@
 #include <string_view>
 #include <thread>
 #include <vector>
-#include <vector>
 
 #include "error.h"
 

--- a/mooncake-transfer-engine/include/common.h
+++ b/mooncake-transfer-engine/include/common.h
@@ -459,20 +459,6 @@ static inline std::pair<HandShakeRequestType, std::string> readString(int fd) {
         return {type, ""};
     }
 
-    const char *prefix = reinterpret_cast<const char *>(&length);
-    auto hasPrefix = [prefix](std::string_view probe) {
-        return std::memcmp(prefix, probe.data(), probe.size()) == 0;
-    };
-    if (hasPrefix("GET ") || hasPrefix("HEAD") || hasPrefix("POST") ||
-        hasPrefix("PUT ") || hasPrefix("DELE") || hasPrefix("OPTI") ||
-        hasPrefix("TRAC") || hasPrefix("PATC") || hasPrefix("CONN") ||
-        hasPrefix("UNKN") ||
-        (static_cast<unsigned char>(prefix[0]) == 0x16 &&
-         static_cast<unsigned char>(prefix[1]) == 0x03)) {
-        LOG(WARNING) << "readString: ignoring non-handshake probe";
-        return {type, ""};
-    }
-
     if (length > kMaxLength) {
         LOG(ERROR) << "readString: too large length from socket: " << length;
         return {type, ""};

--- a/mooncake-transfer-engine/include/common.h
+++ b/mooncake-transfer-engine/include/common.h
@@ -36,6 +36,8 @@
 #include <sstream>
 #include <string_view>
 #include <thread>
+#include <vector>
+#include <vector>
 
 #include "error.h"
 
@@ -61,6 +63,7 @@ enum class HandShakeRequestType {
     Metadata = 1,
     Notify = 2,
     Probe = 3,
+    Invalid = 0xfe,
     // placeholder for old protocol without RequestType
     OldProtocol = 0xff,
 };
@@ -443,13 +446,27 @@ static inline size_t getHandshakeMaxLength() {
 }
 
 static inline std::pair<HandShakeRequestType, std::string> readString(int fd) {
-    HandShakeRequestType type = HandShakeRequestType::Connection;
+    HandShakeRequestType type = HandShakeRequestType::Invalid;
 
     const size_t kMaxLength = getHandshakeMaxLength();
     uint64_t length = 0;
     ssize_t n = readFully(fd, &length, sizeof(length));
     if (n != (ssize_t)sizeof(length)) {
         LOG(ERROR) << "readString: failed to read length, got: " << n;
+        return {type, ""};
+    }
+
+    const char *prefix = reinterpret_cast<const char *>(&length);
+    auto hasPrefix = [prefix](std::string_view probe) {
+        return std::memcmp(prefix, probe.data(), probe.size()) == 0;
+    };
+    if (hasPrefix("GET ") || hasPrefix("HEAD") || hasPrefix("POST") ||
+        hasPrefix("PUT ") || hasPrefix("DELE") || hasPrefix("OPTI") ||
+        hasPrefix("TRAC") || hasPrefix("PATC") || hasPrefix("CONN") ||
+        hasPrefix("UNKN") ||
+        (static_cast<unsigned char>(prefix[0]) == 0x16 &&
+         static_cast<unsigned char>(prefix[1]) == 0x03)) {
+        LOG(WARNING) << "readString: ignoring non-handshake probe";
         return {type, ""};
     }
 

--- a/mooncake-transfer-engine/src/transfer_metadata_plugin.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata_plugin.cpp
@@ -762,6 +762,11 @@ struct SocketHandShakePlugin : public HandShakePlugin {
                 Json::Value local, peer;
 
                 auto [type, json_str] = readString(conn_fd);
+                if (type == HandShakeRequestType::Invalid) {
+                    close(conn_fd);
+                    continue;
+                }
+
                 std::string errs;
                 if (!parseJsonString(json_str, peer, &errs)) {
                     LOG(ERROR)

--- a/mooncake-transfer-engine/src/transfer_metadata_plugin.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata_plugin.cpp
@@ -746,7 +746,7 @@ struct SocketHandShakePlugin : public HandShakePlugin {
                 }
 
                 struct timeval timeout;
-                timeout.tv_sec = 60;
+                timeout.tv_sec = 5;
                 timeout.tv_usec = 0;
                 if (setsockopt(conn_fd, SOL_SOCKET, SO_RCVTIMEO, &timeout,
                                sizeof(timeout))) {

--- a/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
+++ b/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
@@ -251,6 +251,24 @@ TEST(HandshakeFrameTest, ValidFrameRoundTrips) {
     close(fds[1]);
 }
 
+TEST(HandshakeFrameTest, ValidTypedFrameWithTlsLikeNativeEndianLength) {
+    int fds[2];
+    ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+
+    // 790 is encoded as 0x16 0x03 0x00 ... on little-endian machines, which
+    // collides with the first two bytes of a TLS ClientHello record. It is
+    // still a valid native-endian handshake frame length.
+    const std::string payload(789, 'x');
+    ASSERT_EQ(writeString(fds[0], HandShakeRequestType::Metadata, payload), 0);
+
+    auto [type, read_payload] = readString(fds[1]);
+    EXPECT_EQ(type, HandShakeRequestType::Metadata);
+    EXPECT_EQ(read_payload, payload);
+
+    close(fds[0]);
+    close(fds[1]);
+}
+
 TEST(HandshakeFrameTest, OldProtocolFrameStillWorks) {
     int fds[2];
     ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);

--- a/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
+++ b/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
@@ -293,9 +293,9 @@ TEST(HandshakeFrameTest, RejectsTlsProbe) {
     const uint8_t client_hello_prefix[] = {0x16, 0x03, 0x01, 0x05,
                                            0xc2, 0x01, 0x00, 0x05};
 
-    ASSERT_EQ(writeFully(fds[0], client_hello_prefix,
-                         sizeof(client_hello_prefix)),
-              static_cast<ssize_t>(sizeof(client_hello_prefix)));
+    ASSERT_EQ(
+        writeFully(fds[0], client_hello_prefix, sizeof(client_hello_prefix)),
+        static_cast<ssize_t>(sizeof(client_hello_prefix)));
 
     auto [read_type, payload] = readString(fds[1]);
     EXPECT_EQ(read_type, HandShakeRequestType::Invalid);

--- a/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
+++ b/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
@@ -17,7 +17,10 @@
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <gtest/gtest.h>
+#include <arpa/inet.h>
+#include <sys/socket.h>
 #include <sys/time.h>
+#include <unistd.h>
 
 #include <chrono>
 #include <cstdlib>
@@ -231,6 +234,104 @@ TEST(TransferMetadataPollingTest, PollingRefreshesCachedRemoteSegmentDesc) {
     }
 
     FAIL() << "TE metadata refresh polling did not refresh cached descriptor";
+}
+
+TEST(HandshakeFrameTest, ValidFrameRoundTrips) {
+    int fds[2];
+    ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+
+    ASSERT_EQ(writeString(fds[0], HandShakeRequestType::Metadata,
+                          "{\"name\":\"segment\"}"),
+              0);
+    auto [type, payload] = readString(fds[1]);
+    EXPECT_EQ(type, HandShakeRequestType::Metadata);
+    EXPECT_EQ(payload, "{\"name\":\"segment\"}");
+
+    close(fds[0]);
+    close(fds[1]);
+}
+
+TEST(HandshakeFrameTest, OldProtocolFrameStillWorks) {
+    int fds[2];
+    ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+
+    const std::string old_payload = "{\"name\":\"segment\"}";
+    uint64_t old_length = old_payload.size();
+    ASSERT_EQ(writeFully(fds[0], &old_length, sizeof(old_length)),
+              static_cast<ssize_t>(sizeof(old_length)));
+    ASSERT_EQ(writeFully(fds[0], old_payload.data(), old_payload.size()),
+              static_cast<ssize_t>(old_payload.size()));
+
+    auto [type, payload] = readString(fds[1]);
+    EXPECT_EQ(type, HandShakeRequestType::OldProtocol);
+    EXPECT_EQ(payload, old_payload);
+
+    close(fds[0]);
+    close(fds[1]);
+}
+
+TEST(HandshakeFrameTest, RejectsHttpProbe) {
+    int fds[2];
+    ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+
+    const std::string request = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    ASSERT_EQ(writeFully(fds[0], request.data(), request.size()),
+              static_cast<ssize_t>(request.size()));
+
+    auto [type, payload] = readString(fds[1]);
+    EXPECT_EQ(type, HandShakeRequestType::Invalid);
+    EXPECT_TRUE(payload.empty());
+
+    close(fds[0]);
+    close(fds[1]);
+}
+
+TEST(HandshakeFrameTest, RejectsTlsProbe) {
+    int fds[2];
+    ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+
+    const uint8_t client_hello_prefix[] = {0x16, 0x03, 0x01, 0x05,
+                                           0xc2, 0x01, 0x00, 0x05};
+
+    ASSERT_EQ(writeFully(fds[0], client_hello_prefix,
+                         sizeof(client_hello_prefix)),
+              static_cast<ssize_t>(sizeof(client_hello_prefix)));
+
+    auto [read_type, payload] = readString(fds[1]);
+    EXPECT_EQ(read_type, HandShakeRequestType::Invalid);
+    EXPECT_TRUE(payload.empty());
+
+    close(fds[0]);
+    close(fds[1]);
+}
+
+TEST(HandshakeFrameTest, RejectsInvalidLength) {
+    int fds[2];
+    ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+
+    const uint64_t oversized_length = kMaxHandshakeMaxLength + 1;
+    ASSERT_EQ(writeFully(fds[0], &oversized_length, sizeof(oversized_length)),
+              static_cast<ssize_t>(sizeof(oversized_length)));
+
+    auto [oversized_type, oversized_payload] = readString(fds[1]);
+    EXPECT_EQ(oversized_type, HandShakeRequestType::Invalid);
+    EXPECT_TRUE(oversized_payload.empty());
+
+    close(fds[0]);
+    close(fds[1]);
+
+    ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+
+    const uint64_t zero_length = 0;
+    ASSERT_EQ(writeFully(fds[0], &zero_length, sizeof(zero_length)),
+              static_cast<ssize_t>(sizeof(zero_length)));
+
+    auto [zero_type, zero_payload] = readString(fds[1]);
+    EXPECT_EQ(zero_type, HandShakeRequestType::Invalid);
+    EXPECT_TRUE(zero_payload.empty());
+
+    close(fds[0]);
+    close(fds[1]);
 }
 
 }  // namespace mooncake


### PR DESCRIPTION
## Description


Harden the socket handshake frame parser so it rejects invalid-length frames and common non-Mooncake probes before attempting JSON parsing. This avoids listener-side stalls or noisy malformed JSON handling when the handshake port receives incomplete traffic, HTTP probes, TLS probes, or oversized/zero-length frames.

This keeps the existing handshake wire format unchanged for compatibility with versions that have not enabled this patch.


## Module

- [X] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



**Test commands:**
```bash
# Example: bash scripts/run_ci_test.sh
```

**Test results:**
- [X] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [ ] AI tools were used (specify below) CodeX with manual recheck