### PR TITLE
[TENT] Unify transportTypeName into types.h as single source of truth

### DIFF
--- a/mooncake-integration/transfer_engine/transfer_engine_py.cpp
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.cpp
@@ -22,7 +22,7 @@
 #include "transport/rpc_communicator/rpc_interface.h"
 
 #ifdef USE_TENT
-#include "tent/runtime/transport_selector.h"
+#include "tent/common/types.h"
 #endif
 
 #ifdef USE_EFA
@@ -361,7 +361,7 @@ int TransferEnginePy::freeManagedBuffer(uintptr_t buffer_addr, size_t length) {
 static int parseTransportHint(const std::string& name) {
 #ifdef USE_TENT
     if (name.empty()) return mooncake::tent::UNSPEC;
-    auto type = mooncake::tent::TransportSelector::parseTransportType(name);
+    auto type = mooncake::tent::parseTransportType(name);
     if (type == mooncake::tent::UNSPEC && name != "unspec") {
         throw std::invalid_argument(
             "Unknown transport_hint '" + name +

--- a/mooncake-transfer-engine/benchmark/tent_backend.cpp
+++ b/mooncake-transfer-engine/benchmark/tent_backend.cpp
@@ -221,8 +221,7 @@ TENTBenchRunner::TENTBenchRunner() {
     signal(SIGINT, signalHandlerV1);
     signal(SIGTERM, signalHandlerV1);
     engine_ = std::make_unique<TransferEngine>(loadConfig());
-    transport_hint_ = TransportSelector::parseTransportType(
-        XferBenchConfig::tent_transport_hint);
+    transport_hint_ = parseTransportType(XferBenchConfig::tent_transport_hint);
     intent_type_ = getIntentType(XferBenchConfig::tent_intent_type);
     allocateBuffers();
 }

--- a/mooncake-transfer-engine/tent/include/tent/common/types.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/types.h
@@ -90,9 +90,10 @@ inline const char* transportTypeName(TransportType type) {
             return "sunrise_link";
         case TPU:
             return "tpu";
-        default:
+        case kNumTransportTypes:
             return "unknown";
     }
+    return "unknown";
 }
 
 inline TransportType parseTransportType(const std::string& str) {

--- a/mooncake-transfer-engine/tent/include/tent/common/types.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/types.h
@@ -66,6 +66,50 @@ inline TransportType c_to_transport_hint(int v) {
     return static_cast<TransportType>(v);
 }
 
+inline const char* transportTypeName(TransportType type) {
+    switch (type) {
+        case UNSPEC:
+            return "unspec";
+        case RDMA:
+            return "rdma";
+        case MNNVL:
+            return "mnnvl";
+        case SHM:
+            return "shm";
+        case NVLINK:
+            return "nvlink";
+        case GDS:
+            return "gds";
+        case IOURING:
+            return "io_uring";
+        case TCP:
+            return "tcp";
+        case AscendDirect:
+            return "ascend";
+        case SUNRISE_LINK:
+            return "sunrise_link";
+        case TPU:
+            return "tpu";
+        default:
+            return "unknown";
+    }
+}
+
+inline TransportType parseTransportType(const std::string& str) {
+    if (str == "unspec") return UNSPEC;
+    if (str == "rdma") return RDMA;
+    if (str == "mnnvl") return MNNVL;
+    if (str == "shm") return SHM;
+    if (str == "nvlink") return NVLINK;
+    if (str == "gds") return GDS;
+    if (str == "io_uring") return IOURING;
+    if (str == "tcp") return TCP;
+    if (str == "ascend") return AscendDirect;
+    if (str == "sunrise_link") return SUNRISE_LINK;
+    if (str == "tpu") return TPU;
+    return UNSPEC;
+}
+
 enum class IntentType : int {
     INTENT_UNSPEC = 0,
     FOREGROUND_GET,

--- a/mooncake-transfer-engine/tent/include/tent/metrics/tent_metrics.h
+++ b/mooncake-transfer-engine/tent/include/tent/metrics/tent_metrics.h
@@ -202,24 +202,6 @@ class TentMetrics {
         "Transfers whose deadline was already in the past at submit",
         kTransportLabel};
 
-    // Pre-constructed label value lookup table, indexed by TransportType enum
-    // (see tent/common/types.h:46). Keeps label values in a closed set — no
-    // arbitrary strings can reach the metrics. Defined in tent_metrics.cpp.
-    static const std::array<std::string, kNumTransportTypes>
-        kTransportLabelNames;
-
-    // Bounds-checked lookup of the label string for a TransportType.
-    // Returns "unknown" if tp is out of range (defensive — should not happen
-    // with the closed-set enum, but guards against memory corruption or a
-    // new transport type added without updating the table).
-    static const std::string& transportLabel(TransportType tp) {
-        if (tp < 0 || tp >= kNumTransportTypes) {
-            static const std::string kUnknown = "unknown";
-            return kUnknown;
-        }
-        return kTransportLabelNames[tp];
-    }
-
     // Histograms - paired with their bucket boundaries in a single vector so
     // the two cannot drift out of sync (ylt histogram doesn't expose its
     // boundaries publicly, so we hold them alongside the pointer).

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transport_selector.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transport_selector.h
@@ -185,8 +185,6 @@ class TransportSelector {
      */
     bool isLegacyMode() const { return legacy_mode_; }
 
-    static std::string transportTypeName(TransportType type);
-    static TransportType parseTransportType(const std::string& str);
     static std::optional<std::vector<TransportType>> reorderWithHint(
         const std::vector<TransportType>& raw, TransportType hint);
 

--- a/mooncake-transfer-engine/tent/src/metrics/tent_metrics.cpp
+++ b/mooncake-transfer-engine/tent/src/metrics/tent_metrics.cpp
@@ -21,7 +21,6 @@
 
 namespace mooncake::tent {
 
-// Pre-constructed label values indexed by TransportType enum. Keeps the
 TentMetrics& TentMetrics::instance() {
     static TentMetrics instance;
     return instance;
@@ -30,18 +29,6 @@ TentMetrics& TentMetrics::instance() {
 TentMetrics::~TentMetrics() { shutdown(); }
 
 #if TENT_METRICS_ENABLED
-
-// Pre-constructed label value lookup table, indexed by TransportType enum
-// (see tent/common/types.h:46). Keeps label values in a closed set — no
-// arbitrary strings can reach the metrics. Label values aligned with
-// TransportSelector::transportTypeName().
-// Enum order: UNSPEC, RDMA, MNNVL, SHM, NVLINK, GDS,
-// IOURING, TCP, AscendDirect, SUNRISE_LINK, TPU.
-const std::array<std::string, kNumTransportTypes>
-    TentMetrics::kTransportLabelNames = {
-        "unspec",   "rdma", "mnnvl",  "shm",          "nvlink", "gds",
-        "io_uring", "tcp",  "ascend", "sunrise_link", "tpu",
-};
 
 Status TentMetrics::initialize(const MetricsConfig& config) {
     // Validate configuration before touching initialized_. An invalid config
@@ -242,7 +229,7 @@ void TentMetrics::recordReadCompleted(TransportType tp, size_t bytes,
     if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
         return;
 
-    auto label = std::array<std::string, 1>{transportLabel(tp)};
+    auto label = std::array<std::string, 1>{transportTypeName(tp)};
     read_bytes_total_.inc(label, static_cast<int64_t>(bytes));
     read_requests_total_.inc(label);
     read_size_.observe(label, static_cast<int64_t>(bytes));
@@ -257,7 +244,7 @@ void TentMetrics::recordWriteCompleted(TransportType tp, size_t bytes,
     if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
         return;
 
-    auto label = std::array<std::string, 1>{transportLabel(tp)};
+    auto label = std::array<std::string, 1>{transportTypeName(tp)};
     write_bytes_total_.inc(label, static_cast<int64_t>(bytes));
     write_requests_total_.inc(label);
     write_size_.observe(label, static_cast<int64_t>(bytes));
@@ -271,7 +258,7 @@ void TentMetrics::recordDeadlineMLU(TransportType tp, double mlu) {
     if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
         return;
     if (mlu < 0.0) return;
-    auto label = std::array<std::string, 1>{transportLabel(tp)};
+    auto label = std::array<std::string, 1>{transportTypeName(tp)};
     deadline_mlu_.observe(label, static_cast<int64_t>(mlu * 1000.0));
 }
 
@@ -279,7 +266,7 @@ void TentMetrics::recordDeadlineInfeasible(TransportType tp) {
     if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
         return;
     deadline_infeasible_total_.inc(
-        std::array<std::string, 1>{transportLabel(tp)});
+        std::array<std::string, 1>{transportTypeName(tp)});
 }
 
 void TentMetrics::recordStageLatency(Stage stage, TransportType tp,
@@ -287,7 +274,7 @@ void TentMetrics::recordStageLatency(Stage stage, TransportType tp,
     if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
         return;
     if (latency_us < 0.0) return;
-    auto label = std::array<std::string, 1>{transportLabel(tp)};
+    auto label = std::array<std::string, 1>{transportTypeName(tp)};
     int64_t val = static_cast<int64_t>(latency_us);
     switch (stage) {
         case Stage::QueueWait:
@@ -305,7 +292,7 @@ void TentMetrics::recordStageLatency(Stage stage, TransportType tp,
 void TentMetrics::recordReadFailed(TransportType tp) {
     if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
         return;
-    auto label = std::array<std::string, 1>{transportLabel(tp)};
+    auto label = std::array<std::string, 1>{transportTypeName(tp)};
     read_failures_total_.inc(label);
     read_requests_total_.inc(label);
 }
@@ -313,7 +300,7 @@ void TentMetrics::recordReadFailed(TransportType tp) {
 void TentMetrics::recordWriteFailed(TransportType tp) {
     if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
         return;
-    auto label = std::array<std::string, 1>{transportLabel(tp)};
+    auto label = std::array<std::string, 1>{transportTypeName(tp)};
     write_failures_total_.inc(label);
     write_requests_total_.inc(label);
 }
@@ -322,8 +309,8 @@ void TentMetrics::recordTransportFailover(TransportType from,
                                           TransportType to) {
     if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
         return;
-    failover_total_.inc(
-        std::array<std::string, 2>{transportLabel(from), transportLabel(to)});
+    failover_total_.inc(std::array<std::string, 2>{transportTypeName(from),
+                                                   transportTypeName(to)});
 }
 
 std::string TentMetrics::getPrometheusMetrics() {

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -963,7 +963,7 @@ Status TransferEngineImpl::validateTransportHint(const Request& req,
     if (!transport_list_[req.transport_hint]) {
         return Status::InvalidArgument(
             "transport_hint=" +
-            TransportSelector::transportTypeName(req.transport_hint) +
+            std::string(transportTypeName(req.transport_hint)) +
             " is not enabled in config (request[" +
             std::to_string(request_index) + "])" LOC_MARK);
     }
@@ -1067,34 +1067,6 @@ SelectionResult TransferEngineImpl::getTransportType(const Request& request,
 
     return transport_selector_->select(ctx, transport_list_, transport_index,
                                        hint);
-}
-
-static const char* transportTypeName(TransportType type) {
-    switch (type) {
-        case UNSPEC:
-            return "UNSPEC";
-        case RDMA:
-            return "RDMA";
-        case MNNVL:
-            return "MNNVL";
-        case SHM:
-            return "SHM";
-        case NVLINK:
-            return "NVLINK";
-        case GDS:
-            return "GDS";
-        case IOURING:
-            return "IOURING";
-        case TCP:
-            return "TCP";
-        case AscendDirect:
-            return "AscendDirect";
-        case SUNRISE_LINK:
-            return "SUNRISE_LINK";
-        case TPU:
-            return "TPU";
-    }
-    return "UNKNOWN";
 }
 
 std::string printRequest(const Request& request) {

--- a/mooncake-transfer-engine/tent/src/runtime/transport_selector.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transport_selector.cpp
@@ -25,37 +25,6 @@
 namespace mooncake {
 namespace tent {
 
-// Transport type name mapping
-static const std::unordered_map<std::string, TransportType> kTransportNameMap =
-    {
-        {"unspec", UNSPEC},
-        {"rdma", RDMA},
-        {"mnnvl", MNNVL},
-        {"shm", SHM},
-        {"nvlink", NVLINK},
-        {"gds", GDS},
-        {"io_uring", IOURING},
-        {"tcp", TCP},
-        {"ascend", AscendDirect},
-        {"sunrise_link", SUNRISE_LINK},
-        {"tpu", TPU},
-};
-
-static const std::unordered_map<TransportType, std::string>
-    kTransportTypeNames = {
-        {UNSPEC, "unspec"},
-        {RDMA, "rdma"},
-        {MNNVL, "mnnvl"},
-        {SHM, "shm"},
-        {NVLINK, "nvlink"},
-        {GDS, "gds"},
-        {IOURING, "io_uring"},
-        {TCP, "tcp"},
-        {AscendDirect, "ascend"},
-        {SUNRISE_LINK, "sunrise_link"},
-        {TPU, "tpu"},
-};
-
 // Memory type name mapping for pattern matching
 static const std::string kMemoryTypeCpu = "cpu";
 static const std::string kMemoryTypeCuda = "cuda";
@@ -100,23 +69,6 @@ static std::optional<IntentType> parseIntentType(const json& value) {
     }
 
     return std::nullopt;
-}
-
-std::string TransportSelector::transportTypeName(TransportType type) {
-    auto it = kTransportTypeNames.find(type);
-    if (it != kTransportTypeNames.end()) {
-        return it->second;
-    }
-    return "unknown";
-}
-
-TransportType TransportSelector::parseTransportType(const std::string& str) {
-    auto it = kTransportNameMap.find(str);
-    if (it != kTransportNameMap.end()) {
-        return it->second;
-    }
-    LOG(WARNING) << "Unknown transport type: " << str;
-    return UNSPEC;
 }
 
 std::vector<SelectionPolicy> TransportSelector::getDefaultPolicies() {
@@ -270,8 +222,11 @@ void TransportSelector::loadPolicies() {
         if (policy_json.contains("transports")) {
             for (const auto& transport_str : policy_json["transports"]) {
                 if (!transport_str.is_string()) continue;
-                TransportType type =
-                    parseTransportType(transport_str.get<std::string>());
+                const auto name = transport_str.get<std::string>();
+                TransportType type = parseTransportType(name);
+                if (type == UNSPEC && name != "unspec") {
+                    LOG(WARNING) << "Unknown transport type: " << name;
+                }
                 if (type != UNSPEC) {
                     policy.transports.push_back(type);
                 }

--- a/mooncake-transfer-engine/tent/tests/transport_selector_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/transport_selector_test.cpp
@@ -175,32 +175,30 @@ TEST(TransportSelectorTest, DefaultPoliciesMemorySegment) {
 // ---------------------------------------------------------------------------
 
 TEST(TransportSelectorTest, TransportTypeNameMapping) {
-    EXPECT_EQ(TransportSelector::transportTypeName(UNSPEC), "unspec");
-    EXPECT_EQ(TransportSelector::transportTypeName(RDMA), "rdma");
-    EXPECT_EQ(TransportSelector::transportTypeName(MNNVL), "mnnvl");
-    EXPECT_EQ(TransportSelector::transportTypeName(SHM), "shm");
-    EXPECT_EQ(TransportSelector::transportTypeName(NVLINK), "nvlink");
-    EXPECT_EQ(TransportSelector::transportTypeName(GDS), "gds");
-    EXPECT_EQ(TransportSelector::transportTypeName(IOURING), "io_uring");
-    EXPECT_EQ(TransportSelector::transportTypeName(TCP), "tcp");
-    EXPECT_EQ(TransportSelector::transportTypeName(AscendDirect), "ascend");
-    EXPECT_EQ(TransportSelector::transportTypeName(SUNRISE_LINK),
-              "sunrise_link");
+    EXPECT_STREQ(transportTypeName(UNSPEC), "unspec");
+    EXPECT_STREQ(transportTypeName(RDMA), "rdma");
+    EXPECT_STREQ(transportTypeName(MNNVL), "mnnvl");
+    EXPECT_STREQ(transportTypeName(SHM), "shm");
+    EXPECT_STREQ(transportTypeName(NVLINK), "nvlink");
+    EXPECT_STREQ(transportTypeName(GDS), "gds");
+    EXPECT_STREQ(transportTypeName(IOURING), "io_uring");
+    EXPECT_STREQ(transportTypeName(TCP), "tcp");
+    EXPECT_STREQ(transportTypeName(AscendDirect), "ascend");
+    EXPECT_STREQ(transportTypeName(SUNRISE_LINK), "sunrise_link");
 }
 
 TEST(TransportSelectorTest, ParseTransportType) {
-    EXPECT_EQ(TransportSelector::parseTransportType("unspec"), UNSPEC);
-    EXPECT_EQ(TransportSelector::parseTransportType("rdma"), RDMA);
-    EXPECT_EQ(TransportSelector::parseTransportType("mnnvl"), MNNVL);
-    EXPECT_EQ(TransportSelector::parseTransportType("shm"), SHM);
-    EXPECT_EQ(TransportSelector::parseTransportType("nvlink"), NVLINK);
-    EXPECT_EQ(TransportSelector::parseTransportType("gds"), GDS);
-    EXPECT_EQ(TransportSelector::parseTransportType("io_uring"), IOURING);
-    EXPECT_EQ(TransportSelector::parseTransportType("tcp"), TCP);
-    EXPECT_EQ(TransportSelector::parseTransportType("ascend"), AscendDirect);
-    EXPECT_EQ(TransportSelector::parseTransportType("sunrise_link"),
-              SUNRISE_LINK);
-    EXPECT_EQ(TransportSelector::parseTransportType("unknown"), UNSPEC);
+    EXPECT_EQ(parseTransportType("unspec"), UNSPEC);
+    EXPECT_EQ(parseTransportType("rdma"), RDMA);
+    EXPECT_EQ(parseTransportType("mnnvl"), MNNVL);
+    EXPECT_EQ(parseTransportType("shm"), SHM);
+    EXPECT_EQ(parseTransportType("nvlink"), NVLINK);
+    EXPECT_EQ(parseTransportType("gds"), GDS);
+    EXPECT_EQ(parseTransportType("io_uring"), IOURING);
+    EXPECT_EQ(parseTransportType("tcp"), TCP);
+    EXPECT_EQ(parseTransportType("ascend"), AscendDirect);
+    EXPECT_EQ(parseTransportType("sunrise_link"), SUNRISE_LINK);
+    EXPECT_EQ(parseTransportType("unknown"), UNSPEC);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Consolidate three separate transport name mappings into two `inline`
functions in `types.h`, eliminating manual sync between duplicated data
structures.

**Problem.** The `TransportType` enum (`types.h:46`) had its name mapping
(string ↔ enum) maintained in three independent places:

1. `TransportSelector` — `kTransportTypeNames` / `kTransportNameMap`
   unordered_maps + `transportTypeName()` / `parseTransportType()` static
   methods. Lowercase: `"rdma"`, `"io_uring"`, `"ascend"`.
2. `transfer_engine_impl.cpp` — file-local `static transportTypeName()`
   switch. **Uppercase** with divergent naming: `"RDMA"`, `"IOURING"`,
   `"AscendDirect"`. The same file used both copies (line 966 lowercase,
   lines 1105/2031/2049 uppercase) — a pre-existing inconsistency.
3. `TentMetrics` — `kTransportLabelNames` array + `transportLabel()`
   bounds-checked helper (added in #3029).

Adding a new transport required updating all three independently. A
misalignment between copies would silently produce wrong label values or
log output.

**Fix.** Move both mappings to `types.h` as `inline` functions next to
the enum:

- `transportTypeName(TransportType)` — `switch`-based, returns
  `const char*`. The `-Wswitch` compiler flag now catches a missing enum
  case at compile time, eliminating the "forgot to update the table"
  failure mode.
- `parseTransportType(const std::string&)` — if-else chain, returns
  `TransportType` (UNSPEC for unknown).

All three copies deleted. Callers updated to use the `types.h` free
functions directly.

**Behavioral change:** log output in `transfer_engine_impl.cpp` changes
from uppercase to lowercase (e.g. `RDMA` → `rdma`, `IOURING` →
`io_uring`, `AscendDirect` → `ascend`). This fixes the pre-existing
inconsistency where the same file used two different name functions —
line 966 already used lowercase via `TransportSelector::transportTypeName()`
while lines 1105/2031/2049 used the file-local uppercase version.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Refactor

## How Has This Been Tested?

**Test commands:**
```bash
# Full TENT build with metrics enabled
cmake -S mooncake-transfer-engine -B build-refactor \
      -DCMAKE_BUILD_TYPE=Debug -DUSE_TENT=ON -DTENT_METRICS_ENABLED=ON \
      -DBUILD_UNIT_TESTS=ON -DUSE_HTTP=ON -DUSE_TCP=ON -DWITH_METRICS=ON \
      -DUSE_CUDA=OFF -DUSE_HIP=OFF -DUSE_ETCD=OFF -DUSE_MNNVL=OFF -DUSE_TPU=OFF
cmake --build build-refactor -j384

cd build-refactor/tent/tests
./tent_transport_selector_test   # 31/31
./metrics_config_loader_test     # 25/25
./tent_metrics_http_server_test  #  1/1
./tent_metrics_recording_test    # 11/11
```

**Test results:**
- [x] Unit tests pass — 68/68 across 4 suites
- [ ] Integration tests pass (if applicable) — N/A: pure refactor, no
      behavior change beyond log format
- [x] Manual testing — grep confirmed zero residual references to
      `TransportSelector::transportTypeName`,
      `TransportSelector::parseTransportType`, `kTransportTypeNames`,
      `kTransportNameMap`, `kTransportLabelNames`, `transportLabel(`

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable) — N/A (no user-facing API changes; the label values in Prometheus output are unchanged, only log text casing changes)
- [x] I have added tests to prove my changes are effective — existing `transport_selector_test` covers both `transportTypeName()` (10 cases) and `parseTransportType()` (11 cases) via the types.h functions
- [x] For changes >500 LOC: I have filed an RFC issue — N/A (+81/-146)

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

An AI coding agent implemented the mechanical edits (function migration,
caller updates, test adaptation) under human direction. The human
submitter has reviewed every changed line and can defend the change
end-to-end: the single-source-of-truth design, the `-Wswitch` compile-time
guarantee, the behavioral change in log casing, and the verification
coverage.