### PR TITLE
[wheel] restore zero-copy puts for multi-buffer payloads

### DIFF
--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -3897,7 +3897,13 @@ class _MooncakePayloadTransport:
             return self._put_chunks_direct(chunk_keys, chunks)
 
         if transfer_policy.copy_mode == "zero_copy":
-            raise RuntimeError("zero-copy put requires tensor-object buffers")
+            # Joining one chunk group costs the same single copy the contiguous
+            # encoder path paid before multi-buffer puts; delegating keeps the
+            # register-source-buffer zero-copy semantics of single-buffer puts.
+            chunks = [memoryview(b"".join(group)) for group in chunk_groups]
+            return self.put_payload_chunks(
+                chunk_keys, chunks, transfer_policy, pre_registered=False
+            )
         if transfer_policy.copy_mode == "copy" or self._ensure_buffer_pool() is None:
             return fallback_to_direct_put()
         if all(len(group) == 1 for group in chunk_groups):

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -809,6 +809,49 @@ def test_structured_object_multi_buffer_put_cleans_all_chunk_keys_on_failure() -
     assert pool.release_count == 2
 
 
+def test_structured_object_multi_buffer_zero_copy_put_uses_batch_put() -> None:
+    store, transfer = make_transfer()
+    parts = [bytearray(b"ab"), bytearray(b"cd"), bytearray(b"ef")]
+    payload = StructuredObjectPayload(
+        metadata={},
+        buffers={
+            "raw": sos._MultiBufferPayload(
+                buffers=tuple(memoryview(part) for part in parts),
+                owners=tuple(parts),
+            )
+        },
+    )
+
+    ref = transfer.put_structured_object(
+        payload, chunk_bytes=4, policy=BundleTransferPolicy(copy_mode="zero_copy")
+    )
+    result = transfer.materialize(transfer.read_spec(ref))
+
+    raw = result.objects["raw"]
+    raw_bytes = raw if isinstance(raw, bytes) else raw.tobytes()
+    assert raw_bytes == b"abcdef"
+    assert store.batch_put_from_calls > 0
+
+
+def test_structured_object_multi_buffer_zero_copy_requires_batch_put_support() -> None:
+    _store, transfer = make_transfer(MinimalStore())
+    parts = [bytearray(b"ab"), bytearray(b"cd")]
+    payload = StructuredObjectPayload(
+        metadata={},
+        buffers={
+            "raw": sos._MultiBufferPayload(
+                buffers=tuple(memoryview(part) for part in parts),
+                owners=tuple(parts),
+            )
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="zero-copy put requested"):
+        transfer.put_structured_object(
+            payload, policy=BundleTransferPolicy(copy_mode="zero_copy")
+        )
+
+
 def test_structured_object_slice_member_uses_partial_range_reads() -> None:
     store, transfer = make_transfer()
     array = np.arange(96, dtype=np.int16).reshape(12, 8)
@@ -2942,6 +2985,23 @@ def test_dataproto_helper_typed_ragged_uses_multi_buffer_put() -> None:
     assert ref.encoded_non_tensor["tokens"]["codec"] == "typed_ragged"
     assert result["non_tensor_batch"]["tokens"].tolist() == [[1, 2], None, [3, 4, 5]]
     assert rows[0].nbytes + rows[2].nbytes in pool.acquire_sizes
+
+
+def test_dataproto_helper_typed_ragged_zero_copy_put() -> None:
+    store, transfer = make_transfer()
+    rows = np.empty(3, dtype=object)
+    rows[:] = [
+        np.asarray([1, 2], dtype=np.int32),
+        None,
+        np.asarray([3, 4, 5], dtype=np.int32),
+    ]
+    data = SimpleDataProto(non_tensor_batch={"tokens": rows})
+
+    ref = transfer.put_dataproto(data, policy=BundleTransferPolicy(copy_mode="zero_copy"))
+    result = transfer.get_dataproto(ref)
+
+    assert result["non_tensor_batch"]["tokens"].tolist() == [[1, 2], None, [3, 4, 5]]
+    assert store.batch_put_from_calls > 0
 
 
 def test_dataproto_helper_rejects_unsupported_object_non_tensor() -> None:


### PR DESCRIPTION
## What

#3024 moved ragged / bytes-like fields to `_MultiBufferPayload` and made `put_multi_buffer_payload_chunks` raise `RuntimeError("zero-copy put requires tensor-object buffers")` for `copy_mode="zero_copy"`. Before that change the same fields were encoded as one contiguous buffer and zero-copy puts went through the regular batch-put path, so this is a behavior regression: a zero-copy policy on a dataproto with `typed_ragged` (or utf8/json/msgpack ragged) fields now fails where it used to succeed.

Repro on current main (batch-put-capable store):

```python
rows = np.empty(3, dtype=object)
rows[:] = [np.asarray([1, 2], dtype=np.int32), None, np.asarray([3, 4, 5], dtype=np.int32)]
transfer.put_dataproto(SimpleDataProto(non_tensor_batch={"tokens": rows}),
                       policy=BundleTransferPolicy(copy_mode="zero_copy"))
# RuntimeError: zero-copy put requires tensor-object buffers
```

The same snippet on the parent commit of #3024 completes the put.

## Fix

For `copy_mode="zero_copy"`, join each chunk group back into one buffer and delegate to `put_payload_chunks`. Joining costs the same single copy the pre-#3024 contiguous encoder already paid, and chunk boundaries come out identical to the old layout because `_split_multi_buffer_payload` packs groups to exactly `chunk_bytes`. `put_payload_chunks` then registers the source buffers as before and still raises `"zero-copy put requested but batch_put_from is unavailable"` when batch put is missing, so the no-support case keeps its old message and behavior.

The `auto`/`copy` paths and the tensor-object zero-copy path are untouched.

## Tests

- `test_structured_object_multi_buffer_zero_copy_put_uses_batch_put`
- `test_structured_object_multi_buffer_zero_copy_requires_batch_put_support`
- `test_dataproto_helper_typed_ragged_zero_copy_put` (the regression entry point above)

`pytest mooncake-wheel/tests/test_structured_object_store.py`: 78 passed, 25 skipped (torch-dependent).

cc @zxpdemonio in case the larger #2671 rollout already handles this differently.
