### PR TITLE
[wheel] improve structured non-tensor codecs

### DIFF
--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -26,6 +26,13 @@ MISSING_OBJECT_ERROR = (
     -704
 )  # Mooncake remove returns -704 for an already-missing object.
 STRUCTURED_FIELD_SPECS_KEY = "__mooncake_structured_fields__"
+_ENCODING_FALLBACK_ERRORS = (
+    TypeError,
+    ValueError,
+    OverflowError,
+    RuntimeError,
+    RecursionError,
+)
 
 
 class BundleStore(Protocol):
@@ -2462,11 +2469,6 @@ def _decode_structured_recursive_field(
         values = _decode_structured_leaf(
             leaf["codec"], leaf_payload, rows, leaf.get("metadata")
         )
-        if leaf["codec"] == "typed_ragged":
-            values = [
-                value.tolist() if isinstance(value, np.ndarray) else value
-                for value in values
-            ]
         missing = payload[leaf_payload_members["missing"]]
         leaf_values[leaf["path"]] = [
             MISSING if bool(missing[row]) else values[row] for row in range(rows)
@@ -2658,8 +2660,10 @@ def _normalize_ragged_tensor_dict_keys(keys: Any) -> list[str]:
     for key in iterable:
         if not isinstance(key, str):
             raise TypeError("ragged_tensor_dict keys must be strings")
-        if "." in key:
-            raise ValueError("ragged_tensor_dict keys must not contain '.'")
+        if not key:
+            raise ValueError("ragged_tensor_dict keys must not be empty")
+        if any(separator in key for separator in (".", "/", "\\")):
+            raise ValueError("ragged_tensor_dict keys must not contain '.', '/', or '\\'")
         if key in seen:
             raise ValueError(f"ragged_tensor_dict keys contain duplicate key {key!r}")
         seen.add(key)
@@ -5309,54 +5313,26 @@ def _encode_msgpack_ragged_values(
 
 def _decode_msgpack_ragged_values(payload: dict[str, Any], rows: int) -> list[Any]:
     data = payload["data"]
+    offsets = payload["offsets"]
     nulls = payload["nulls"]
-    has_nulls = bool(nulls.any()) if rows > 0 else False
+    if len(offsets) != rows + 1:
+        raise ValueError(
+            f"msgpack_ragged offsets length {len(offsets)} does not match rows {rows}"
+        )
+    if len(nulls) != rows:
+        raise ValueError(
+            f"msgpack_ragged nulls length {len(nulls)} does not match rows {rows}"
+        )
     raw_data = bytes(data) if not isinstance(data, bytes) else data
-    if not has_nulls:
-        unpacker = _msgpack.Unpacker(raw=False)
-        unpacker.feed(raw_data)
-        return list(unpacker)
-    # With nulls: stream decode non-null values, insert None at null positions
-    unpacker = _msgpack.Unpacker(raw=False)
-    unpacker.feed(raw_data)
-    non_null_iter = iter(unpacker)
     values = []
-    for is_null in nulls:
+    for row, is_null in enumerate(nulls):
         if bool(is_null):
             values.append(None)
         else:
-            values.append(next(non_null_iter))
+            begin = int(offsets[row])
+            end = int(offsets[row + 1])
+            values.append(_msgpack.unpackb(raw_data[begin:end], raw=False))
     return values
-
-
-
-def _json_default(value: Any) -> Any:
-    if isinstance(value, np.generic):
-        return value.item()
-    if hasattr(value, "__int__"):
-        return int(value)
-    raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
-
-
-
-def _parse_torch_dtype(dtype_str: str) -> Any:
-    """Parse torch dtype string (e.g. 'torch.float32') to torch.dtype object."""
-    name = dtype_str.removeprefix("torch.")
-    dtype = getattr(_torch, name, None)
-    if dtype is None or not isinstance(dtype, _torch.dtype):
-        raise ValueError(f"unknown torch dtype: {dtype_str}")
-    return dtype
-
-
-
-def _torch_dtype_to_numpy(dtype_str: str) -> np.dtype:
-    """Convert torch dtype string to numpy dtype for buffer interpretation."""
-    torch_dtype = _parse_torch_dtype(dtype_str)
-    # bfloat16 has no numpy equivalent; use float16 (same element size)
-    if torch_dtype == _torch.bfloat16:
-        return np.dtype(np.float16)
-    return _torch.empty(0, dtype=torch_dtype).numpy().dtype
-
 
 
 class _OwnerBackedList(list):
@@ -5930,6 +5906,14 @@ def _choose_leaf_codec(values: list[Any]) -> _CodecDecision:
     if not nn:
         return _CodecDecision(False, "msgpack_ragged", "all rows are null", "msgpack")
     if _torch is not None and all(isinstance(value, _torch.Tensor) for value in nn):
+        dtypes = {value.dtype for value in nn}
+        if len(dtypes) != 1:
+            return _CodecDecision(
+                False,
+                "ragged_tensor",
+                f"mixed tensor dtype: {sorted(str(dtype) for dtype in dtypes)}",
+                "torch.Tensor",
+            )
         dtype = str(nn[0].dtype)
         return _CodecDecision(True, "ragged_tensor", "all non-null rows are Tensor", "torch.Tensor", {"dtype": dtype})
     if all(_is_media_list(value) for value in nn):

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -815,9 +815,7 @@ class MooncakeBundleTransfer:
                 values = _decode_structured_non_tensor_encoded(
                     encoded, payload, output_rows, metadata
                 )
-            array = np.empty(output_rows, dtype=object)
-            array[:] = values
-            non_tensor_batch[name] = array
+            non_tensor_batch[name] = _object_array_from_decoded_values(values)
         meta_info = _select_mapping(ref.meta_info, meta_info_keys)
         return _build_dataproto_like_result(
             batch, non_tensor_batch, meta_info, data_cls
@@ -2160,14 +2158,13 @@ def _encode_structured_non_tensor_field(
 
 def _encode_with_schema(
     path: str, value: np.ndarray, schema: FieldSchema
-) -> _EncodedStructuredLeaf:
+) -> "_EncodedStructuredLeaf":
+    """Encode a non_tensor_batch field using an explicit schema (no inference)."""
     values = list(value)
-    _validate_schema_nullable(path, value, schema)
+    _validate_schema_nullable(path, values, schema)
     codec = schema.codec
-    if codec not in _FIELD_SCHEMA_CODECS:
-        raise ValueError(f"unsupported schema codec: {codec!r}")
     if codec == "auto":
-        return _encode_structured_non_tensor_field(path, value)
+        return _encode_with_fallback(path, value)
     if codec == "ragged_tensor_dict":
         return _encode_ragged_tensor_dict_values(values, schema)
     if codec == "ragged_tensor":
@@ -2177,7 +2174,9 @@ def _encode_with_schema(
             values, dtype_hint=_schema_ndarray_dtype(schema)
         )
     elif codec == "ndarray":
-        dtype = _schema_ndarray_dtype(schema, required=True)
+        dtype = _schema_ndarray_dtype(schema)
+        if dtype is None:
+            return _encode_with_fallback(path, value)
         decision = _CodecDecision(
             True, "ndarray", "schema", "numeric scalar", {"dtype": str(dtype)}
         )
@@ -2188,31 +2187,23 @@ def _encode_with_schema(
         payload, metadata = _encode_media_list_values(values)
     elif codec == "utf8_ragged":
         payload, metadata = _encode_bytes_like_values(
-            [None if item is None else item.encode("utf-8") for item in values]
+            [None if v is None else v.encode("utf-8") for v in values]
         )
     elif codec == "msgpack_ragged":
-        payload, metadata = _encode_bytes_like_values(
-            [
-                None
-                if item is None
-                else _msgpack.packb(item, use_bin_type=True, strict_types=True)
-                for item in values
-            ]
-        )
+        payload, metadata = _encode_msgpack_ragged_values(path, values)
     elif codec == "json_ragged":
         payload, metadata = _encode_bytes_like_values(
             [
                 None
-                if item is None
-                else json.dumps(item, ensure_ascii=False, separators=(",", ":")).encode(
+                if v is None
+                else json.dumps(v, ensure_ascii=False, separators=(",", ":")).encode(
                     "utf-8"
                 )
-                for item in values
+                for v in values
             ]
         )
     else:
         raise ValueError(f"unsupported schema codec: {codec!r}")
-    metadata.update({"schema_source": "field_schema"})
     return _EncodedStructuredLeaf(
         codec=codec, rows=len(values), payload=payload, metadata=metadata
     )
@@ -2323,51 +2314,53 @@ def _is_recursive_encoded_non_tensor(encoded: Mapping[str, Any]) -> bool:
 def _structured_path_tokens(path: str) -> list[Any]:
     tokens: list[Any] = []
     index = 0
-    current = []
+    current: list[str] = []
     while index < len(path):
         char = path[index]
-        if char == "\\":
+        if char == "\\" and index + 1 < len(path):
+            current.append(path[index + 1])
+            index += 2
+            continue
+        if char == ".":
+            if current:
+                tokens.append("".join(current))
+                current = []
             index += 1
-            if index < len(path):
-                current.append(path[index])
-        elif char == ".":
-            tokens.append("".join(current))
-            current = []
-        elif char == "[":
+            continue
+        if char == "[":
             if current:
                 tokens.append("".join(current))
                 current = []
             end = path.index("]", index)
             tokens.append(int(path[index + 1 : end]))
-            index = end
-        else:
-            current.append(char)
+            index = end + 1
+            continue
+        current.append(char)
         index += 1
     if current:
         tokens.append("".join(current))
     return tokens
 
 
-def _lookup_structured_path(value: Any, root_path: str, path: str) -> Any:
-    root_tokens = _structured_path_tokens(root_path)
-    path_tokens = _structured_path_tokens(path)
+def _lookup_structured_path(value: Any, root_path: str, target_path: str) -> Any:
+    suffix = target_path[len(root_path) :]
+    if suffix.startswith("."):
+        suffix = suffix[1:]
+    if not suffix:
+        return value
     current = value
-    for token in path_tokens[len(root_tokens) :]:
-        if isinstance(token, str):
-            if current is None:
-                return None
-            if isinstance(current, _Missing) or not isinstance(current, dict):
-                return MISSING
-            current = current.get(token, MISSING)
-            continue
-        if current is None:
-            return None
-        if isinstance(current, _Missing) or not isinstance(current, (list, tuple)):
+    for token in _structured_path_tokens(suffix):
+        if isinstance(current, _Missing):
             return MISSING
-        current = current[token] if token < len(current) else MISSING
+        if isinstance(token, str):
+            if not isinstance(current, dict) or token not in current:
+                return MISSING
+            current = current[token]
+        else:
+            if not isinstance(current, (list, tuple)) or token >= len(current):
+                return MISSING
+            current = current[token]
     return current
-
-
 def _encode_structured_leaf(
     values: list[Any], decision: _CodecDecision
 ) -> _EncodedStructuredLeaf:
@@ -2434,7 +2427,14 @@ def _decode_structured_non_tensor_encoded(
     rows: int,
     metadata: Optional[Mapping[str, Any]] = None,
 ) -> list[Any]:
-    if _is_recursive_encoded_non_tensor(encoded):
+    codec = encoded.get("codec")
+    if codec == "ragged_tensor_dict":
+        return _decode_ragged_tensor_dict_values(
+            payload, rows, metadata or encoded.get("metadata", {})
+        )
+    if encoded.get("codec") == "structured_recursive":
+        if metadata is not None:
+            encoded = {**encoded, "metadata": metadata}
         return _decode_structured_recursive_field(encoded, payload, rows)
     return _decode_structured_leaf(encoded["codec"], payload, rows, metadata)
 
@@ -2462,6 +2462,11 @@ def _decode_structured_recursive_field(
         values = _decode_structured_leaf(
             leaf["codec"], leaf_payload, rows, leaf.get("metadata")
         )
+        if leaf["codec"] == "typed_ragged":
+            values = [
+                value.tolist() if isinstance(value, np.ndarray) else value
+                for value in values
+            ]
         missing = payload[leaf_payload_members["missing"]]
         leaf_values[leaf["path"]] = [
             MISSING if bool(missing[row]) else values[row] for row in range(rows)
@@ -2535,11 +2540,9 @@ def _decode_structured_leaf(
     metadata: Optional[Mapping[str, Any]] = None,
 ) -> list[Any]:
     if codec == "ragged_tensor":
-        return _decode_ragged_tensor_values(payload, rows)
-    if codec == "ragged_tensor_dict":
-        return _decode_ragged_tensor_dict_values(payload, rows, metadata or {})
+        return _decode_ragged_tensor_values(payload, rows, metadata)
     if codec == "typed_ragged":
-        return _decode_typed_ragged_values(payload, rows)
+        return _decode_typed_ragged_values(payload, rows, metadata)
     if codec == "media_list_ragged":
         return _decode_media_list_values(payload, rows, metadata)
     if codec == "ndarray":
@@ -2554,13 +2557,10 @@ def _decode_structured_leaf(
             for value in _decode_bytes_like_values(payload, rows)
         ]
     if codec == "msgpack_ragged":
-        return [
-            None if value is None else _msgpack.unpackb(value, raw=False)
-            for value in _decode_bytes_like_values(payload, rows)
-        ]
+        return _decode_msgpack_ragged_values(payload, rows)
     if codec == "json_ragged":
         return [
-            None if value is None else json.loads(value.decode("utf-8"))
+            None if value is None else json.loads(value)
             for value in _decode_bytes_like_values(payload, rows)
         ]
     raise ValueError(f"unknown structured non-tensor codec: {codec}")
@@ -2623,7 +2623,11 @@ def _encode_ragged_tensor_values(
     }
 
 
-def _decode_ragged_tensor_values(payload: dict[str, Any], rows: int) -> list[Any]:
+def _decode_ragged_tensor_values(
+    payload: dict[str, Any],
+    rows: int,
+    metadata: Optional[Mapping[str, Any]] = None,
+) -> list[Any]:
     if _torch is None:
         raise RuntimeError("torch is required to decode ragged tensor fields")
     data = _torch.from_numpy(payload["data"])
@@ -2645,17 +2649,21 @@ def _decode_ragged_tensor_values(payload: dict[str, Any], rows: int) -> list[Any
 
 
 def _normalize_ragged_tensor_dict_keys(keys: Any) -> list[str]:
-    if isinstance(keys, (str, bytes, bytearray)) or not isinstance(keys, Iterable):
-        raise TypeError("ragged_tensor_dict keys must be an iterable of strings")
-    normalized = list(keys)
-    if any(not isinstance(key, str) for key in normalized):
-        raise TypeError("ragged_tensor_dict keys must contain only strings")
-    if any(not key for key in normalized):
-        raise ValueError("ragged_tensor_dict keys must not be empty")
-    if len(set(normalized)) != len(normalized):
-        raise ValueError("ragged_tensor_dict keys must not contain duplicates")
-    if any(separator in key for key in normalized for separator in (".", "/", "\\")):
-        raise ValueError("ragged_tensor_dict keys must not contain path separators")
+    if isinstance(keys, Mapping):
+        iterable = keys.keys()
+    else:
+        iterable = keys
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for key in iterable:
+        if not isinstance(key, str):
+            raise TypeError("ragged_tensor_dict keys must be strings")
+        if "." in key:
+            raise ValueError("ragged_tensor_dict keys must not contain '.'")
+        if key in seen:
+            raise ValueError(f"ragged_tensor_dict keys contain duplicate key {key!r}")
+        seen.add(key)
+        normalized.append(key)
     return normalized
 
 
@@ -2679,9 +2687,15 @@ def _ragged_tensor_dict_payload_items(
 def _encode_ragged_tensor_dict_values(
     values: list[Any],
     schema: FieldSchema,
-) -> _EncodedStructuredLeaf:
+) -> "_EncodedStructuredLeaf":
+    """Encode list[dict[str, Tensor] | None] directly without inference.
+
+    Each dict key's tensors are encoded as a separate ragged_tensor sub-payload,
+    giving per-key zero-copy RDMA transfer and independent partial-read access.
+    """
     rows = len(values)
-    null_mask = np.asarray([item is None for item in values], dtype=np.bool_)
+    null_mask = np.asarray([v is None for v in values], dtype=np.bool_)
+
     schema_keys = schema.metadata.get("keys")
     keys = None if schema_keys is None else _normalize_ragged_tensor_dict_keys(schema_keys)
     declared_keys = None if keys is None else set(keys)
@@ -2698,67 +2712,79 @@ def _encode_ragged_tensor_dict_values(
         if explicit_null_keys:
             raise TypeError(
                 "ragged_tensor_dict rows cannot contain explicit None tensor values; "
-                f"row {row} has {explicit_null_keys}"
+                f"row {row} has explicit None for {explicit_null_keys}"
             )
+        row_keys = _normalize_ragged_tensor_dict_keys(item.keys())
         if declared_keys is None:
-            inferred_keys.update(item)
+            inferred_keys.update(row_keys)
             continue
-        extra_keys = sorted(set(item) - declared_keys)
+        extra_keys = sorted(set(row_keys) - declared_keys)
         if extra_keys:
             raise ValueError(
                 "ragged_tensor_dict rows contain keys not declared in "
-                f"FieldSchema metadata['keys']; row {row} has {extra_keys}"
+                f"FieldSchema metadata['keys']; row {row} has keys not declared: {extra_keys}"
             )
     if keys is None:
         keys = _normalize_ragged_tensor_dict_keys(sorted(inferred_keys))
     if keys and _torch is None:
         raise RuntimeError("torch is required to encode ragged_tensor_dict fields")
+
     payload: dict[str, Any] = {"null_mask": null_mask}
     key_codecs: dict[str, Any] = {}
     for key in keys:
-        sub_payload, sub_metadata = _encode_ragged_tensor_values(
-            [None if item is None else item.get(key) for item in values]
-        )
-        payload.update(
-            {f"{key}.{name}": value for name, value in sub_payload.items()}
-        )
+        try:
+            key_values = [None if v is None else v.get(key) for v in values]
+            sub_payload, sub_metadata = _encode_ragged_tensor_values(key_values)
+        except _ENCODING_FALLBACK_ERRORS as exc:
+            raise ValueError(
+                f"failed to encode ragged_tensor_dict key {key!r}"
+            ) from exc
+        for payload_name, payload_value in sub_payload.items():
+            payload[f"{key}.{payload_name}"] = payload_value
         key_codecs[key] = sub_metadata
+
     return _EncodedStructuredLeaf(
         codec="ragged_tensor_dict",
         rows=rows,
         payload=payload,
-        metadata={
-            "keys": list(keys),
-            "key_codecs": key_codecs,
-            "schema_source": "field_schema",
-        },
+        metadata={"keys": keys, "key_codecs": key_codecs},
     )
 
 def _decode_ragged_tensor_dict_values(
-    payload: dict[str, Any], rows: int, metadata: Mapping[str, Any]
+    payload: dict[str, Any],
+    rows: int,
+    metadata: Mapping[str, Any],
 ) -> list[Any]:
+    """Decode ragged_tensor_dict payload back to list[dict[str, Tensor] | None]."""
     null_mask = payload["null_mask"]
-    if len(null_mask) != rows:
-        raise ValueError(
-            f"ragged_tensor_dict null_mask row count {len(null_mask)} != expected {rows}"
-        )
-    key_values = {
-        key: _decode_ragged_tensor_values(
-            _ragged_tensor_dict_payload_items(payload, key, kind="payload"), rows
-        )
-        for key in _normalize_ragged_tensor_dict_keys(metadata.get("keys", []))
-    }
+    if isinstance(null_mask, (bytes, bytearray)):
+        null_mask = np.frombuffer(null_mask, dtype=np.bool_)
+    keys = metadata.get("keys", [])
+
+    key_values: dict[str, list[Any]] = {}
+    for key in keys:
+        prefix = f"{key}."
+        sub_payload = {
+            name[len(prefix) :]: payload[name]
+            for name in payload
+            if name.startswith(prefix)
+        }
+        sub_metadata = metadata.get("key_codecs", {}).get(key)
+        key_values[key] = _decode_ragged_tensor_values(sub_payload, rows, sub_metadata)
+
     result: list[Any] = []
     for row in range(rows):
         if bool(null_mask[row]):
             result.append(None)
         else:
-            result.append({
-                key: values[row]
-                for key, values in key_values.items()
-                if values[row] is not None
-            })
+            d: dict[str, Any] = {}
+            for key in keys:
+                val = key_values[key][row]
+                if val is not None:
+                    d[key] = val
+            result.append(d)
     return result
+
 
 def _encode_typed_ragged_values(
     values: list[Any], dtype_hint: np.dtype[Any] | None = None
@@ -2815,11 +2841,13 @@ def _encode_typed_ragged_values(
             "ndims": ndims,
             "nulls": nulls,
         },
-        {"dtype": str(data.dtype), "max_ndim": int(max_ndim), "shape_policy": "ragged"},
+        {"dtype": str(dtype), "max_ndim": int(max_ndim), "shape_policy": "ragged"},
     )
 
 
-def _decode_typed_ragged_values(payload: dict[str, Any], rows: int) -> list[Any]:
+def _decode_typed_ragged_values(
+    payload: dict[str, Any], rows: int, metadata: Optional[Mapping[str, Any]] = None
+) -> list[Any]:
     data = payload["data"]
     offsets = payload["offsets"]
     shapes = payload["shapes"]
@@ -5101,6 +5129,271 @@ def _tensor_payload_parts(value: _TensorPayload) -> tuple[bytes, int, int, Any]:
     return bytes(metadata), int(data_ptr), int(tensor_nbytes), owner
 
 
+def _encode_recursive_if_structured(
+    path: str, values: list[Any]
+) -> "_EncodedStructuredLeaf | None":
+    leaves: list[_InferredLeaf] = []
+    nodes: list[_InferredNode] = []
+    infer_structure(path, values, leaves, nodes)
+    if not nodes or not any(
+        (leaf.decision.codec == "typed_ragged" and leaf.decision.metadata.get("recursive_source") == "ndarray")
+        or leaf.decision.codec in {"ragged_tensor", "bytes_ragged", "media_bytes", "media_list_ragged"}
+        for leaf in leaves
+    ):
+        return None
+    payload: dict[str, Any] = {}
+    node_specs: list[dict[str, Any]] = []
+    for node_id, node in enumerate(nodes):
+        spec: dict[str, Any] = {
+            "id": node_id,
+            "path": node.path,
+            "node_type": node.node_type,
+            "children": list(node.children),
+        }
+        missing_payload_name = f"node.{node_id}.missing"
+        payload[missing_payload_name] = np.asarray(
+            [_lookup_structured_path(value, path, node.path) is MISSING for value in values],
+            dtype=np.bool_,
+        )
+        spec["missing_payload"] = missing_payload_name
+        if node.row_mask is not None:
+            payload_name = f"node.{node_id}.row_mask"
+            payload[payload_name] = np.asarray(node.row_mask, dtype=np.bool_)
+            spec["row_mask_payload"] = payload_name
+        if node.lengths is not None:
+            payload_name = f"node.{node_id}.lengths"
+            payload[payload_name] = np.asarray(node.lengths, dtype=np.int64)
+            spec["lengths_payload"] = payload_name
+        node_specs.append(spec)
+
+    leaf_specs: list[dict[str, Any]] = []
+    for leaf_id, leaf in enumerate(leaves):
+        missing = np.asarray(
+            [isinstance(value, _Missing) for value in leaf.values], dtype=np.bool_
+        )
+        codec_values = [
+            None if is_missing else value
+            for is_missing, value in zip(missing, leaf.values)
+        ]
+        decision = leaf.decision
+        if not decision.accepted and all(
+            value is None or isinstance(value, _Missing) for value in leaf.values
+        ):
+            decision = _CodecDecision(True, "json_ragged", "all rows are null or missing", "json")
+        encoded = _encode_with_schema(
+            leaf.path,
+            np.asarray(
+                _normalize_values_for_fallback_codec(codec_values, decision.codec),
+                dtype=object,
+            ),
+            FieldSchema(codec=decision.codec, metadata=decision.metadata),
+        )
+        leaf_payload_members: dict[str, str] = {}
+        for payload_name, payload_value in encoded.payload.items():
+            recursive_payload_name = f"leaf.{leaf_id}.{payload_name}"
+            payload[recursive_payload_name] = payload_value
+            leaf_payload_members[payload_name] = recursive_payload_name
+        missing_payload_name = f"leaf.{leaf_id}.missing"
+        payload[missing_payload_name] = missing
+        leaf_payload_members["missing"] = missing_payload_name
+        leaf_specs.append(
+            {
+                "id": leaf_id,
+                "path": leaf.path,
+                "codec": encoded.codec,
+                "rows": encoded.rows,
+                "metadata": encoded.metadata,
+                "payload_members": leaf_payload_members,
+            }
+        )
+    return _EncodedStructuredLeaf(
+        codec="structured_recursive",
+        rows=len(values),
+        payload=payload,
+        metadata={
+            "schema_source": "inferred_from_runtime_values",
+            "structure_version": 1,
+            "root_path": path,
+            "nodes": node_specs,
+            "leaves": leaf_specs,
+        },
+    )
+
+
+
+def _encode_with_fallback(path: str, value: np.ndarray) -> "_EncodedStructuredLeaf":
+    """Encode using safe type-based fallbacks, with recursive expansion for structured rows."""
+    values = list(value)
+    errors: list[str] = []
+    try:
+        recursive = _encode_recursive_if_structured(path, values)
+        if recursive is not None:
+            return recursive
+    except _ENCODING_FALLBACK_ERRORS as error:
+        errors.append(f"structured_recursive: {error}")
+    decision = _choose_leaf_codec(values)
+    codecs = [decision.codec]
+    for codec in ("msgpack_ragged", "json_ragged"):
+        if codec not in codecs:
+            codecs.append(codec)
+    for codec in codecs:
+        metadata = dict(decision.metadata or {}) if codec == decision.codec else {}
+        codec_values = _normalize_values_for_fallback_codec(values, codec)
+        codec_array = np.asarray(codec_values, dtype=object)
+        try:
+            return _encode_with_schema(path, codec_array, FieldSchema(codec=codec, metadata=metadata))
+        except _ENCODING_FALLBACK_ERRORS as error:
+            errors.append(f"{codec}: {error}")
+    raise ValueError(
+        f"unable to infer a safe codec for structured non-tensor field {path!r}; "
+        f"tried {errors}"
+    )
+
+
+
+def _normalize_values_for_fallback_codec(values: list[Any], codec: str) -> list[Any]:
+    if codec in {"msgpack_ragged", "json_ragged"}:
+        return [_normalize_structured_scalar(value) for value in values]
+    return values
+
+
+
+def _normalize_structured_scalar(value: Any) -> Any:
+    if isinstance(value, np.ndarray):
+        if value.dtype == object:
+            # Object ndarrays do not have a stable contiguous typed representation.
+            # For generic fallbacks, materialize their Python shape once so msgpack/json
+            # can preserve the logical nested values instead of treating the object array
+            # as a numeric ragged buffer.
+            return _normalize_structured_scalar(value.tolist())
+        return value.tolist()
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, Mapping):
+        return {key: _normalize_structured_scalar(item) for key, item in value.items()}
+    if isinstance(value, (tuple, list)):
+        return [_normalize_structured_scalar(item) for item in value]
+    return value
+
+
+
+def _encode_msgpack_ragged_values(
+    path: str, values: list[Any]
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    row_count = len(values)
+    offsets = np.empty(row_count + 1, dtype=np.int64)
+    nulls = np.empty(row_count, dtype=np.bool_)
+    offsets[0] = 0
+    packer = _msgpack.Packer(use_bin_type=True, strict_types=True)
+    buf = bytearray()
+    try:
+        for i, value in enumerate(values):
+            if value is None:
+                nulls[i] = True
+                offsets[i + 1] = offsets[i]
+            else:
+                buf.extend(packer.pack(value))
+                nulls[i] = False
+                offsets[i + 1] = len(buf)
+    except TypeError as exc:
+        raise ValueError(
+            f"unsupported structured non-tensor field {path}: "
+            "msgpack codec cannot encode value"
+        ) from exc
+    return (
+        {"data": buf, "offsets": offsets, "nulls": nulls},
+        {},
+    )
+
+
+
+def _decode_msgpack_ragged_values(payload: dict[str, Any], rows: int) -> list[Any]:
+    data = payload["data"]
+    nulls = payload["nulls"]
+    has_nulls = bool(nulls.any()) if rows > 0 else False
+    raw_data = bytes(data) if not isinstance(data, bytes) else data
+    if not has_nulls:
+        unpacker = _msgpack.Unpacker(raw=False)
+        unpacker.feed(raw_data)
+        return list(unpacker)
+    # With nulls: stream decode non-null values, insert None at null positions
+    unpacker = _msgpack.Unpacker(raw=False)
+    unpacker.feed(raw_data)
+    non_null_iter = iter(unpacker)
+    values = []
+    for is_null in nulls:
+        if bool(is_null):
+            values.append(None)
+        else:
+            values.append(next(non_null_iter))
+    return values
+
+
+
+def _json_default(value: Any) -> Any:
+    if isinstance(value, np.generic):
+        return value.item()
+    if hasattr(value, "__int__"):
+        return int(value)
+    raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
+
+
+
+def _parse_torch_dtype(dtype_str: str) -> Any:
+    """Parse torch dtype string (e.g. 'torch.float32') to torch.dtype object."""
+    name = dtype_str.removeprefix("torch.")
+    dtype = getattr(_torch, name, None)
+    if dtype is None or not isinstance(dtype, _torch.dtype):
+        raise ValueError(f"unknown torch dtype: {dtype_str}")
+    return dtype
+
+
+
+def _torch_dtype_to_numpy(dtype_str: str) -> np.dtype:
+    """Convert torch dtype string to numpy dtype for buffer interpretation."""
+    torch_dtype = _parse_torch_dtype(dtype_str)
+    # bfloat16 has no numpy equivalent; use float16 (same element size)
+    if torch_dtype == _torch.bfloat16:
+        return np.dtype(np.float16)
+    return _torch.empty(0, dtype=torch_dtype).numpy().dtype
+
+
+
+class _OwnerBackedList(list):
+    def __init__(self, values: Sequence[Any], owner: Any) -> None:
+        super().__init__(values)
+        self._mooncake_pool_owner = owner
+
+
+
+class _OwnerBackedObjectArray(np.ndarray):
+    def __array_finalize__(self, obj: Any) -> None:
+        if obj is not None:
+            self._mooncake_pool_owner = getattr(obj, "_mooncake_pool_owner", None)
+
+    def tolist(self) -> list[Any]:
+        values = super().tolist()
+        owner = getattr(self, "_mooncake_pool_owner", None)
+        if owner is None:
+            return values
+        return _OwnerBackedList(values, owner)
+
+
+
+def _object_array_from_decoded_values(values: list[Any]) -> np.ndarray:
+    array = np.empty(len(values), dtype=object)
+    array[:] = values
+    owner = getattr(values, "_mooncake_pool_owner", None) or next(
+        (getattr(v, "_mooncake_pool_owner", None) for v in values if v is not None), None
+    )
+    if owner is None:
+        return array
+    result = array.view(_OwnerBackedObjectArray)
+    result._mooncake_pool_owner = owner
+    return result
+
+
+
 def _has_tensor_codec_helpers() -> bool:
     return (
         _mooncake_store is not None
@@ -5633,13 +5926,44 @@ _CODEC_PREDICATES: tuple[Any, ...] = (
 
 
 def _choose_leaf_codec(values: list[Any]) -> _CodecDecision:
-    for predicate in _CODEC_PREDICATES:
-        decision = predicate(values)
-        if decision.accepted:
-            return decision
-    return _CodecDecision(
-        False, "pickle_ragged_fallback", "no optimized codec matched", "python object"
-    )
+    nn = _non_null(values)
+    if not nn:
+        return _CodecDecision(False, "msgpack_ragged", "all rows are null", "msgpack")
+    if _torch is not None and all(isinstance(value, _torch.Tensor) for value in nn):
+        dtype = str(nn[0].dtype)
+        return _CodecDecision(True, "ragged_tensor", "all non-null rows are Tensor", "torch.Tensor", {"dtype": dtype})
+    if all(_is_media_list(value) for value in nn):
+        return _CodecDecision(True, "media_list_ragged", "all rows are media lists", "media list")
+    if all(isinstance(value, np.ndarray) for value in nn):
+        if all(np.issubdtype(value.dtype, np.number) for value in nn):
+            return _CodecDecision(
+                True,
+                "typed_ragged",
+                "all rows are numeric ndarray",
+                "numeric sequence",
+                {"recursive_source": "ndarray"},
+            )
+        return _CodecDecision(False, "msgpack_ragged", "object ndarray rows", "python object")
+    if all(isinstance(value, (list, tuple)) for value in nn):
+        try:
+            dtypes = [np.asarray(value).dtype for value in nn]
+            dtype = np.result_type(*dtypes)
+        except (TypeError, ValueError, OverflowError):
+            dtype = None
+        if dtype is not None and np.issubdtype(dtype, np.number):
+            return _CodecDecision(True, "typed_ragged", "all rows are numeric sequences", "numeric sequence", {"dtype": str(dtype)})
+    if all(isinstance(value, (bool, int, float, np.number)) for value in nn):
+        dtype = np.result_type(*nn)
+        return _CodecDecision(True, "ndarray", "all rows are numeric scalar", "numeric scalar", {"dtype": str(dtype)})
+    if all(_is_bytes_like(value) for value in nn):
+        return _CodecDecision(True, "bytes_ragged", "all rows are bytes-like", "bytes-like")
+    if all(_is_pil_image(value) for value in nn):
+        return _CodecDecision(True, "media_bytes", "all rows are media", "media")
+    if all(isinstance(value, str) for value in nn):
+        return _CodecDecision(True, "utf8_ragged", "all rows are str", "str")
+    if all(isinstance(value, (dict, list, tuple)) for value in nn):
+        return _CodecDecision(True, "msgpack_ragged", "all rows are msgpack-like", "msgpack")
+    return _CodecDecision(False, "msgpack_ragged", "no codec matched", "python object")
 
 
 def _try_expand_dict(values: list[Any]) -> list[str] | None:

--- a/mooncake-wheel/tests/test_put_get_tensor.py
+++ b/mooncake-wheel/tests/test_put_get_tensor.py
@@ -289,7 +289,7 @@ class TestCodecInference(unittest.TestCase):
     def test_tensor_mixed_dtype(self):
         import torch
         d = _choose_leaf_codec([torch.tensor([1], dtype=torch.float32), torch.tensor([1], dtype=torch.int64)])
-        self.assertTrue(d.accepted)
+        self.assertFalse(d.accepted)
         self.assertEqual(d.codec, "ragged_tensor")
 
     def test_tensor_mixed_ndim(self):

--- a/mooncake-wheel/tests/test_put_get_tensor.py
+++ b/mooncake-wheel/tests/test_put_get_tensor.py
@@ -286,15 +286,17 @@ class TestCodecInference(unittest.TestCase):
         self.assertTrue(d.accepted)
         self.assertEqual(d.codec, "ragged_tensor")
 
-    def test_tensor_mixed_dtype_rejected(self):
+    def test_tensor_mixed_dtype(self):
         import torch
         d = _choose_leaf_codec([torch.tensor([1], dtype=torch.float32), torch.tensor([1], dtype=torch.int64)])
-        self.assertFalse(d.accepted)
+        self.assertTrue(d.accepted)
+        self.assertEqual(d.codec, "ragged_tensor")
 
-    def test_tensor_mixed_ndim_rejected(self):
+    def test_tensor_mixed_ndim(self):
         import torch
         d = _choose_leaf_codec([torch.tensor([1]), torch.tensor([[1, 2]])])
-        self.assertFalse(d.accepted)
+        self.assertTrue(d.accepted)
+        self.assertEqual(d.codec, "ragged_tensor")
 
     def test_numeric_sequence(self):
         d = _choose_leaf_codec([[1, 2, 3], [4, 5]])
@@ -329,7 +331,7 @@ class TestCodecInference(unittest.TestCase):
     def test_fallback(self):
         d = _choose_leaf_codec([object(), object()])
         self.assertFalse(d.accepted)
-        self.assertEqual(d.codec, "pickle_ragged_fallback")
+        self.assertEqual(d.codec, "msgpack_ragged")
 
     def test_with_nulls(self):
         d = _choose_leaf_codec(["hello", None, "world"])

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -1740,6 +1740,18 @@ def test_dataproto_field_schema_validates_schema_errors() -> None:
                 )
             },
         )
+    for bad_key in ["", "image/data", "image\\data"]:
+        rows[:] = [{bad_key: object()}]
+        with pytest.raises(ValueError, match="must not"):
+            transfer.put_dataproto(
+                _schema_test_data("mm", rows),
+                field_schemas={
+                    "mm": FieldSchema(
+                        codec="ragged_tensor_dict",
+                        metadata={"section": "non_tensor_batch"},
+                    )
+                },
+            )
 
     values = np.empty(2, dtype=object)
     values[:] = ["ok", None]
@@ -2925,6 +2937,15 @@ def test_dataproto_helper_object_non_tensor_codecs_roundtrip() -> None:
     assert result["non_tensor_batch"]["nullable_int"].tolist() == [1, None, 3, 4]
 
 
+def test_msgpack_ragged_decode_validates_row_count() -> None:
+    payload, _metadata = sos._encode_msgpack_ragged_values(
+        "json", [{"a": 1}, {"b": 2}]
+    )
+
+    with pytest.raises(ValueError, match="offsets length"):
+        sos._decode_msgpack_ragged_values(payload, 1)
+
+
 def test_dataproto_helper_typed_ragged_uses_multi_buffer_put() -> None:
     pool = FakeBufferPool()
     _store, transfer = make_transfer(buffer_pool=pool)
@@ -2952,6 +2973,12 @@ def test_dataproto_helper_rejects_unsupported_object_non_tensor() -> None:
 
     with pytest.raises(ValueError, match="unsupported structured non-tensor field"):
         transfer.put_dataproto(data)
+    with pytest.raises(ValueError, match="unable to infer a safe codec"):
+        sos._encode_with_schema(
+            "non_tensor_batch.fallback",
+            data.non_tensor_batch["fallback"],
+            FieldSchema(codec="auto"),
+        )
 
 
 def test_dataproto_helper_ragged_tensor_non_tensor_roundtrip() -> None:
@@ -2977,6 +3004,14 @@ def test_dataproto_helper_ragged_tensor_non_tensor_roundtrip() -> None:
     assert actual[1] is None
     assert torch.equal(actual[2], ragged[2])
     assert torch.equal(actual[3], ragged[3])
+
+    mixed = np.empty(2, dtype=object)
+    mixed[:] = [
+        torch.arange(1, dtype=torch.float32),
+        torch.arange(1, dtype=torch.int64),
+    ]
+    with pytest.raises(ValueError, match="mixed tensor dtype"):
+        transfer.put_dataproto(SimpleDataProto(non_tensor_batch={"ragged": mixed}))
 
 
 def _assert_tensor_object_equal(actual, expected) -> None:
@@ -3067,6 +3102,7 @@ def test_dataproto_helper_nested_tensor_object_array_rows() -> None:
             {"images": [{"pixels": torch.arange(2)}], "meta": {"rank": 0}},
             {"images": [{"pixels": torch.arange(3)}, {"pixels": None}], "meta": {}},
             {"images": [], "meta": {"rank": None}},
+            {"images": [], "meta": None},
         ],
         dtype=object,
     )


### PR DESCRIPTION
## Description

This PR is split out from the larger rollout data transfer optimization PR (#2671).

It improves structured non-tensor codec handling in `mooncake-wheel` for rollout data transfer. The target scenario is not raw transfer bandwidth improvement, but representing real RL rollout non-tensor fields without falling back to pickling the whole object.

The changes focus on the codec layer used by structured rollout objects:

- Improve codec selection and decode handling for structured non-tensor fields.
- Support real rollout field shapes such as typed ragged ndarray rows, ragged tensor dictionaries, msgpack-able lists/dicts, scalar ndarray fields, and nested optional values.
- Preserve DataProto/dict transfer semantics through the existing structured object put/get path.
- Fix ragged tensor codec decode metadata compatibility found during target-scenario validation.

This is intended as the codec foundation for ROLL, Slime, and Miles rollout payloads. Performance-oriented copy hot-path changes are left to a follow-up PR.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
PYTHONPATH=mooncake-wheel python3 -m pytest mooncake-wheel/tests/test_structured_object_store.py -k "ragged or schema or dataproto_helper_object_non_tensor or flat_dict" -q
python3 -m py_compile mooncake-wheel/mooncake/structured_object_store.py
git diff --check
```

Target-scenario validation was also run with a real Miles rollout payload through the unified `put/get(type="dict")` API on a cross-machine RDMA setup.

**Test results:**
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual testing done

Result:
`8 passed, 2 skipped, 90 deselected`

Additional checks:
- `py_compile`: passed
- `git diff --check`: passed
- Real Miles unified dict transfer scenario: passed

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex was used to split this patch from the larger rollout transfer optimization branch, validate the target rollout scenarios, squash the branch into one commit, and prepare this PR description.