### PR TITLE
[feat] add cache aware proxy example

### DIFF
--- a/mooncake-conductor/example/README.md
+++ b/mooncake-conductor/example/README.md
@@ -1,0 +1,347 @@
+# Conductor Cache-Aware P/D Proxy Example
+
+This example preserves the request flow of Mooncake's vLLM v1 prefill/decode
+proxy and replaces only prefill target selection. At startup the proxy
+registers every configured vLLM KV-event publisher with Conductor. For each
+request it calls `/tokenize`, queries Conductor, and routes prefill to the
+routable `instance_id` with the largest positive `longest_matched` value.
+
+Decode selection remains round robin. Positive cache-hit ties rotate among the
+tied instances. Tokenization failures, Conductor query failures, malformed or
+empty results, and all-zero hits use the proxy's independent prefill
+round-robin fallback.
+
+## Files
+
+- `cache_aware_disagg_proxy.py`: standalone FastAPI proxy.
+- `cache_aware_proxy_config.json`: proxy routing and Conductor registration
+  example.
+- `../tests/cache_aware_proxy/`: CPU-only configuration, client, scheduler,
+  and endpoint tests.
+
+## Install
+
+Build Conductor as described in the main
+[Conductor usage guide](../../docs/source/design/conductor/usage.md). Install
+the proxy's Python dependencies:
+
+```bash
+python3 -m pip install fastapi httpx uvicorn
+```
+
+The proxy does not load a tokenizer model. It uses the root-level `/tokenize`
+route exposed by a configured prefill instance.
+
+## Configure
+
+The proxy accepts exactly one configuration source:
+
+- JSON mode uses `--config` with `cache_aware_proxy_config.json`.
+- CLI mode keeps the existing proxy's prefiller/decoder host and port flags and
+  adds instance IDs, KV-event registrations, Conductor connection settings, and
+  shared Prefill settings.
+
+Do not combine `--config` with CLI topology, connection, or shared Prefill
+flags.
+`--host`, `--port`, and `--log-level` configure the proxy process itself and
+are valid in either mode. Both configuration modes produce the same validated
+`ProxyConfig` before the application starts.
+
+For JSON mode, edit `cache_aware_proxy_config.json` before starting the proxy.
+The file uses this ownership layout:
+
+```text
+conductor
+prefill
+  config
+  instances
+decode
+  instances
+```
+
+- `conductor` contains only the Conductor HTTP `address` and the query and
+  registration timeouts.
+- `prefill.config` contains the model, block size, tenant, LoRA name, and hash
+  profile shared by every Prefill candidate.
+- `prefill.instances` contains the Prefill HTTP targets and the KV-event
+  registrations that the proxy sends to Conductor.
+- `decode.instances` contains the Decode HTTP targets. Decode selection remains
+  round robin and has no Conductor registration in this example.
+
+The single `prefill.config` applies to every entry in `prefill.instances`, so
+the scheduler compares cache locality only among instances in that shared
+model/cache context.
+
+Each prefill entry has two separate kinds of address:
+
+- `http_endpoint` is the vLLM HTTP origin used by the proxy. It must not include
+  `/v1`; the proxy calls `/tokenize` and `/v1/completions` or
+  `/v1/chat/completions` explicitly.
+- `registrations[].endpoint` is the connectable ZeroMQ KV-event address sent to
+  Conductor's `POST /register`. Do not use `*` or `0.0.0.0` here.
+
+`instance_id` joins the two control planes:
+
+```text
+proxy:     instance_id -> vLLM HTTP endpoint
+Conductor: instance_id + dp_rank -> KV-event endpoint and cache state
+```
+
+The following values must match the vLLM deployment:
+
+- request `model` and configured `modelname`;
+- `block_size`;
+- `tenant_id` and `lora_name`;
+- `hash_profile`, especially the exact `PYTHONHASHSEED` string.
+
+Every compatible vLLM process must use the same explicit seed. For example:
+
+```bash
+export PYTHONHASHSEED=0
+```
+
+For data-parallel vLLM, configure one `registrations` entry per DP rank. vLLM
+offsets a TCP KV-event publisher port by rank, so list the actual connectable
+port for each rank. All registrations for one routable engine use the same
+`instance_id`.
+
+CLI mode expresses the same mapping as follows:
+
+- prefiller hosts, ports, and instance IDs correspond by position;
+- repeat `--prefiller-registration INSTANCE_ID DP_RANK EVENT_ENDPOINT` once
+  per publisher rank, including multiple ranks for one instance when needed;
+- `--prefiller-registration` may reference only an ID listed by
+  `--prefiller-instance-ids`;
+- the hash strategy, algorithm, and projection are fixed to `vllm_v1`,
+  `sha256_cbor`, and `low64_be`; supply the deployment-specific seed with
+  `--python-hash-seed`.
+
+The example intentionally does not configure replay. It omits
+`replay_endpoint` from every registration request, and vLLM KV-event
+configuration can omit it as well. Conductor's `/services` response still
+serializes `ReplayEndpoint` as an empty string; that output does not mean the
+proxy submitted the field.
+
+## Start The Services
+
+Use this order so Conductor subscribes before the proxy sends cache-producing
+traffic. Events emitted before registration are not reconstructed.
+
+### 1. Start Conductor
+
+From the repository root:
+
+```bash
+CONDUCTOR_CONFIG_PATH=/dev/stdin \
+  ./build/mooncake-conductor/mooncake_conductor <<'JSON'
+{
+  "http_server_port": 13333,
+  "kvevent_instance": {}
+}
+JSON
+```
+
+`http_server_port` selects the Conductor API port. The empty
+`kvevent_instance` is intentional: this example does not preload static
+subscriptions because the proxy calls `POST /register` for every configured
+prefill publisher during startup. The configuration is supplied inline, so no
+separate empty JSON file is needed.
+
+### 2. Start Prefill And Decode Instances
+
+Start the Mooncake vLLM P/D deployment using the repository's current vLLM
+integration instructions. Each prefill must enable prefix caching and a live
+ZeroMQ KV-event publisher.
+
+Conductor requires the current map-encoded vLLM KV-event schema. Use vLLM main
+at or after commit `5b3807e862fe70f51139ac518a5dd361e57de2e5` (PR #42892,
+2026-06-09), or a build with an equivalent backport. Earlier array-encoded
+events can register successfully but are rejected during event decoding, so
+queries remain at zero hits.
+
+For the first sample prefill, the relevant flags are:
+
+```bash
+export PYTHONHASHSEED=0
+
+vllm serve Qwen/Qwen2.5-7B-Instruct \
+  --served-model-name Qwen/Qwen2.5-7B-Instruct \
+  --port 8100 \
+  --enable-prefix-caching \
+  --prefix-caching-hash-algo sha256_cbor \
+  --block-size 16 \
+  --kv-events-config \
+  '{"enable_kv_cache_events":true,"publisher":"zmq","endpoint":"tcp://*:5557"}' \
+  --kv-transfer-config \
+  '{"kv_connector":"MooncakeConnectorStoreV1","kv_role":"kv_producer"}'
+```
+
+The sample's second prefill uses HTTP port `8101` and KV-event port `5559`.
+If both prefills run on one host, give their Mooncake connectors distinct
+`VLLM_MOONCAKE_BOOTSTRAP_PORT` values, for example `8998` and `8999`, and
+assign each process an available accelerator. Processes on different hosts can
+reuse the same bootstrap port.
+
+Start one or more decode instances with the matching model and Mooncake
+consumer-side KV transfer configuration; the sample uses HTTP port `8200`.
+Keep external inference traffic paused until proxy startup completes.
+
+### 3. Start The Cache-Aware Proxy
+
+Choose one of the following modes.
+
+#### JSON configuration
+
+```bash
+python3 mooncake-conductor/example/cache_aware_disagg_proxy.py \
+  --config mooncake-conductor/example/cache_aware_proxy_config.json \
+  --host 127.0.0.1 \
+  --port 8000 \
+  --log-level INFO
+```
+
+#### Direct CLI configuration
+
+```bash
+python3 mooncake-conductor/example/cache_aware_disagg_proxy.py \
+  --prefiller-hosts 127.0.0.1 127.0.0.1 \
+  --prefiller-ports 8100 8101 \
+  --prefiller-instance-ids prefill-a prefill-b \
+  --prefiller-registration prefill-a 0 tcp://127.0.0.1:5557 \
+  --prefiller-registration prefill-b 0 tcp://127.0.0.1:5559 \
+  --decoder-hosts 127.0.0.1 \
+  --decoder-ports 8200 \
+  --conductor-address http://127.0.0.1:13333 \
+  --modelname Qwen/Qwen2.5-7B-Instruct \
+  --block-size 16 \
+  --tenant-id default \
+  --lora-name '' \
+  --python-hash-seed 0 \
+  --query-timeout-seconds 1.0 \
+  --registration-timeout-seconds 5.0 \
+  --host 127.0.0.1 \
+  --port 8000 \
+  --log-level INFO
+```
+
+Startup is fail-fast. The server does not begin accepting requests unless all
+configured DP-rank registrations succeed. Repeating an identical registration
+is accepted by Conductor's idempotent API.
+
+## Verify Registration
+
+List the active event subscriptions:
+
+```bash
+curl -sS http://127.0.0.1:13333/services
+```
+
+The response must contain every configured `InstanceID`, `DPRank`, `Endpoint`,
+model context, and resolved hash profile. `/services` proves that Conductor
+started the local subscribers; it does not prove that any cache event has
+arrived.
+
+Inspect the instance/rank grouping:
+
+```bash
+curl -sS http://127.0.0.1:13333/global_view
+```
+
+The expected context must show `prefill-a` and `prefill-b` with their configured
+ranks before traffic begins.
+
+## Send A Request
+
+```bash
+curl -N http://127.0.0.1:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "Qwen/Qwen2.5-7B-Instruct",
+    "messages": [{"role": "user", "content": "Explain KV cache locality."}],
+    "max_tokens": 64,
+    "stream": true
+  }'
+```
+
+A positive selection is logged with the query candidates and selected target:
+
+```text
+request_id=... cache_candidates={'prefill-a': 16, 'prefill-b': 48} selected_instance=prefill-b longest_matched=48
+```
+
+A fallback states its reason and selected round-robin target:
+
+```text
+request_id=... cache_aware_fallback reason=all_cache_hits_zero selected_instance=prefill-a
+```
+
+## Diagnose Empty Or Zero Hits
+
+Tokenize a representative prompt through one prefill, then send those token IDs
+to Conductor directly:
+
+```bash
+curl -sS -X POST http://127.0.0.1:13333/query \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "Qwen/Qwen2.5-7B-Instruct",
+    "block_size": 16,
+    "tenant_id": "default",
+    "lora_name": "",
+    "token_ids": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+  }'
+```
+
+If `instances` is empty or every `longest_matched` is zero, compare the request
+model, block size, tenant, LoRA name, cache salt, `PYTHONHASHSEED`, and event
+publisher addresses with the proxy configuration. Only complete token blocks
+are queried. Because this example is live-only, caches created before
+registration do not appear until new matching events arrive.
+
+If `/services` and `/global_view` look correct but hits remain zero after new
+cache-producing requests, confirm that the vLLM build emits the map-encoded
+KV-event schema described above. Released builds that still emit positional
+array events are not compatible with the current Conductor decoder.
+
+## Stop, Replace, Or Roll Back
+
+Stopping or restarting the proxy does not call `/unregister`. A registration
+may be shared by several proxy processes and Conductor cannot tell which proxy
+first created an idempotent registration.
+
+Unregister a rank only when its publisher is removed or replaced:
+
+```bash
+curl -sS -X POST http://127.0.0.1:13333/unregister \
+  -H 'Content-Type: application/json' \
+  -d '{"instance_id":"prefill-a","tenant_id":"default","dp_rank":0}'
+```
+
+Repeat the command for every rank being removed. Before registering a new
+publisher endpoint under the same service key, unregister the old one.
+
+To roll back scheduling behavior, stop this example and run the existing
+round-robin proxy against the same HTTP instances:
+
+```bash
+python3 -m mooncake.vllm_v1_proxy_server \
+  --prefiller-hosts 127.0.0.1 127.0.0.1 \
+  --prefiller-ports 8100 8101 \
+  --decoder-hosts 127.0.0.1 \
+  --decoder-ports 8200
+```
+
+Publisher registrations can remain active while only the proxy implementation
+changes.
+
+## Run The CPU-Only Tests
+
+```bash
+python3 -m unittest discover \
+  -s mooncake-conductor/tests/cache_aware_proxy \
+  -p 'test_*.py' \
+  -v
+```
+
+The tests use in-process FastAPI and HTTPX transports. They do not require a
+GPU, RDMA, vLLM model load, or live Conductor process.

--- a/mooncake-conductor/example/cache_aware_disagg_proxy.py
+++ b/mooncake-conductor/example/cache_aware_disagg_proxy.py
@@ -1,0 +1,1073 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import itertools
+import json
+import logging
+import math
+import os
+import uuid
+from collections.abc import AsyncIterator, Callable, Mapping
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+import httpx
+from fastapi import FastAPI, Request
+from fastapi.responses import StreamingResponse
+
+logger = logging.getLogger(__name__)
+
+SUPPORTED_HASH_PROFILE = {
+    "strategy": "vllm_v1",
+    "algorithm": "sha256_cbor",
+    "index_projection": "low64_be",
+}
+MAX_DP_RANK = (1 << 31) - 1
+DEFAULT_PREFILLER_HOSTS = ("localhost",)
+DEFAULT_PREFILLER_PORTS = (8100,)
+DEFAULT_DECODER_HOSTS = ("localhost",)
+DEFAULT_DECODER_PORTS = (8200,)
+DEFAULT_QUERY_TIMEOUT_SECONDS = 1.0
+DEFAULT_REGISTRATION_TIMEOUT_SECONDS = 5.0
+
+CLI_CONFIG_OPTIONS = (
+    ("prefiller_hosts", "--prefiller-hosts"),
+    ("prefiller_ports", "--prefiller-ports"),
+    ("decoder_hosts", "--decoder-hosts"),
+    ("decoder_ports", "--decoder-ports"),
+    ("prefiller_instance_ids", "--prefiller-instance-ids"),
+    ("prefiller_registrations", "--prefiller-registration"),
+    ("conductor_address", "--conductor-address"),
+    ("modelname", "--modelname"),
+    ("block_size", "--block-size"),
+    ("tenant_id", "--tenant-id"),
+    ("lora_name", "--lora-name"),
+    ("python_hash_seed", "--python-hash-seed"),
+    ("query_timeout_seconds", "--query-timeout-seconds"),
+    ("registration_timeout_seconds", "--registration-timeout-seconds"),
+)
+
+
+class ConfigError(ValueError):
+    """Raised when the example configuration is invalid."""
+
+
+class ConductorProtocolError(RuntimeError):
+    """Raised when Conductor returns an unusable success response."""
+
+
+@dataclass(frozen=True)
+class HashProfileConfig:
+    strategy: str
+    algorithm: str
+    python_hash_seed: str
+    index_projection: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "strategy": self.strategy,
+            "algorithm": self.algorithm,
+            "python_hash_seed": self.python_hash_seed,
+            "index_projection": self.index_projection,
+        }
+
+
+@dataclass(frozen=True)
+class RegistrationConfig:
+    endpoint: str
+    dp_rank: int
+
+
+@dataclass(frozen=True)
+class PrefillInstanceConfig:
+    instance_id: str
+    http_endpoint: str
+    registrations: tuple[RegistrationConfig, ...]
+
+
+@dataclass(frozen=True)
+class DecodeInstanceConfig:
+    http_endpoint: str
+
+
+@dataclass(frozen=True)
+class ConductorConfig:
+    address: str
+    query_timeout_seconds: float
+    registration_timeout_seconds: float
+
+
+@dataclass(frozen=True)
+class PrefillSharedConfig:
+    model_name: str
+    block_size: int
+    tenant_id: str
+    lora_name: str
+    hash_profile: HashProfileConfig
+
+
+@dataclass(frozen=True)
+class PrefillPoolConfig:
+    config: PrefillSharedConfig
+    instances: tuple[PrefillInstanceConfig, ...]
+
+
+@dataclass(frozen=True)
+class DecodePoolConfig:
+    instances: tuple[DecodeInstanceConfig, ...]
+
+
+@dataclass(frozen=True)
+class ProxyConfig:
+    conductor: ConductorConfig
+    prefill: PrefillPoolConfig
+    decode: DecodePoolConfig
+
+
+@dataclass
+class PrefillClient:
+    config: PrefillInstanceConfig
+    client: httpx.AsyncClient
+
+
+@dataclass
+class DecodeClient:
+    config: DecodeInstanceConfig
+    client: httpx.AsyncClient
+
+
+ClientFactory = Callable[[str, float | None], httpx.AsyncClient]
+
+
+def _require_object(value: Any, path: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ConfigError(f"{path} must be a JSON object")
+    return value
+
+
+def _reject_unknown_fields(
+    value: Mapping[str, Any], allowed: set[str], path: str
+) -> None:
+    unknown = sorted(set(value) - allowed)
+    if unknown:
+        raise ConfigError(f"{path} contains unsupported field: {unknown[0]}")
+
+
+def _require_nonempty_string(value: Mapping[str, Any], field: str, path: str) -> str:
+    raw = value.get(field)
+    if not isinstance(raw, str) or not raw:
+        raise ConfigError(f"{path}.{field} must be a non-empty string")
+    return raw
+
+
+def _optional_string(
+    value: Mapping[str, Any], field: str, default: str, path: str
+) -> str:
+    raw = value.get(field, default)
+    if not isinstance(raw, str):
+        raise ConfigError(f"{path}.{field} must be a string")
+    return raw
+
+
+def _positive_number(
+    value: Mapping[str, Any], field: str, default: float, path: str
+) -> float:
+    raw = value.get(field, default)
+    if (
+        isinstance(raw, bool)
+        or not isinstance(raw, (int, float))
+        or not math.isfinite(float(raw))
+        or raw <= 0
+    ):
+        raise ConfigError(f"{path}.{field} must be a positive number")
+    return float(raw)
+
+
+def _http_base_url(raw: str, path: str) -> str:
+    parsed = urlsplit(raw)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ConfigError(f"{path} must be an absolute HTTP URL")
+    if parsed.username or parsed.password:
+        raise ConfigError(f"{path} must not contain user information")
+    if parsed.path not in {"", "/"} or parsed.query or parsed.fragment:
+        raise ConfigError(f"{path} must not contain a path, query, or fragment")
+    return urlunsplit((parsed.scheme, parsed.netloc, "", "", ""))
+
+
+def _parse_hash_profile(raw: Any, path: str) -> HashProfileConfig:
+    value = _require_object(raw, path)
+    allowed = {
+        "strategy",
+        "algorithm",
+        "python_hash_seed",
+        "index_projection",
+    }
+    _reject_unknown_fields(value, allowed, path)
+    for field, expected in SUPPORTED_HASH_PROFILE.items():
+        actual = _require_nonempty_string(value, field, path)
+        if actual != expected:
+            raise ConfigError(f"{path}.{field} must be {expected!r}")
+
+    seed = _require_nonempty_string(value, "python_hash_seed", path)
+    if seed != "random":
+        if not seed.isascii() or any(char < "0" or char > "9" for char in seed):
+            raise ConfigError(
+                f"{path}.python_hash_seed must be 'random' or ASCII decimal text"
+            )
+        if int(seed) > 0xFFFFFFFF:
+            raise ConfigError(f"{path}.python_hash_seed must be in the uint32 range")
+
+    return HashProfileConfig(
+        strategy=value["strategy"],
+        algorithm=value["algorithm"],
+        python_hash_seed=seed,
+        index_projection=value["index_projection"],
+    )
+
+
+def _parse_conductor(raw: Any) -> ConductorConfig:
+    path = "conductor"
+    value = _require_object(raw, path)
+    _reject_unknown_fields(
+        value,
+        {
+            "address",
+            "query_timeout_seconds",
+            "registration_timeout_seconds",
+        },
+        path,
+    )
+    address = _http_base_url(
+        _require_nonempty_string(value, "address", path), f"{path}.address"
+    )
+    return ConductorConfig(
+        address=address,
+        query_timeout_seconds=_positive_number(
+            value, "query_timeout_seconds", 1.0, path
+        ),
+        registration_timeout_seconds=_positive_number(
+            value, "registration_timeout_seconds", 5.0, path
+        ),
+    )
+
+
+def _parse_prefill_shared_config(raw: Any) -> PrefillSharedConfig:
+    path = "prefill.config"
+    value = _require_object(raw, path)
+    _reject_unknown_fields(
+        value,
+        {
+            "modelname",
+            "block_size",
+            "tenant_id",
+            "lora_name",
+            "hash_profile",
+        },
+        path,
+    )
+    model_name = _require_nonempty_string(value, "modelname", path)
+    block_size = value.get("block_size")
+    if (
+        isinstance(block_size, bool)
+        or not isinstance(block_size, int)
+        or block_size <= 0
+    ):
+        raise ConfigError(f"{path}.block_size must be a positive integer")
+    tenant_id = _optional_string(value, "tenant_id", "default", path) or "default"
+    lora_name = _optional_string(value, "lora_name", "", path)
+    if "hash_profile" not in value:
+        raise ConfigError(f"{path}.hash_profile is required")
+
+    return PrefillSharedConfig(
+        model_name=model_name,
+        block_size=block_size,
+        tenant_id=tenant_id,
+        lora_name=lora_name,
+        hash_profile=_parse_hash_profile(value["hash_profile"], f"{path}.hash_profile"),
+    )
+
+
+def _parse_registration(raw: Any, path: str) -> RegistrationConfig:
+    value = _require_object(raw, path)
+    _reject_unknown_fields(value, {"endpoint", "dp_rank"}, path)
+    endpoint = _require_nonempty_string(value, "endpoint", path)
+    dp_rank = value.get("dp_rank")
+    if (
+        isinstance(dp_rank, bool)
+        or not isinstance(dp_rank, int)
+        or dp_rank < 0
+        or dp_rank > MAX_DP_RANK
+    ):
+        raise ConfigError(f"{path}.dp_rank must be a non-negative int")
+    return RegistrationConfig(endpoint=endpoint, dp_rank=dp_rank)
+
+
+def _parse_prefill(raw: Any, index: int) -> PrefillInstanceConfig:
+    path = f"prefill.instances[{index}]"
+    value = _require_object(raw, path)
+    _reject_unknown_fields(
+        value, {"instance_id", "http_endpoint", "registrations"}, path
+    )
+    instance_id = _require_nonempty_string(value, "instance_id", path)
+    http_endpoint = _http_base_url(
+        _require_nonempty_string(value, "http_endpoint", path),
+        f"{path}.http_endpoint",
+    )
+    raw_registrations = value.get("registrations")
+    if not isinstance(raw_registrations, list) or not raw_registrations:
+        raise ConfigError(f"{path}.registrations must be a non-empty array")
+    registrations = tuple(
+        _parse_registration(registration, f"{path}.registrations[{rank_index}]")
+        for rank_index, registration in enumerate(raw_registrations)
+    )
+    ranks = [registration.dp_rank for registration in registrations]
+    if len(ranks) != len(set(ranks)):
+        raise ConfigError(f"{path}.registrations contains a duplicate dp_rank")
+    return PrefillInstanceConfig(
+        instance_id=instance_id,
+        http_endpoint=http_endpoint,
+        registrations=registrations,
+    )
+
+
+def _parse_decode(raw: Any, index: int) -> DecodeInstanceConfig:
+    path = f"decode.instances[{index}]"
+    value = _require_object(raw, path)
+    _reject_unknown_fields(value, {"http_endpoint"}, path)
+    return DecodeInstanceConfig(
+        http_endpoint=_http_base_url(
+            _require_nonempty_string(value, "http_endpoint", path),
+            f"{path}.http_endpoint",
+        )
+    )
+
+
+def _parse_prefill_pool(raw: Any) -> PrefillPoolConfig:
+    path = "prefill"
+    value = _require_object(raw, path)
+    _reject_unknown_fields(value, {"config", "instances"}, path)
+    if "config" not in value:
+        raise ConfigError("prefill.config is required")
+    raw_instances = value.get("instances")
+    if not isinstance(raw_instances, list) or not raw_instances:
+        raise ConfigError("prefill.instances must be a non-empty array")
+    return PrefillPoolConfig(
+        config=_parse_prefill_shared_config(value["config"]),
+        instances=tuple(
+            _parse_prefill(instance, index)
+            for index, instance in enumerate(raw_instances)
+        ),
+    )
+
+
+def _parse_decode_pool(raw: Any) -> DecodePoolConfig:
+    path = "decode"
+    value = _require_object(raw, path)
+    _reject_unknown_fields(value, {"instances"}, path)
+    raw_instances = value.get("instances")
+    if not isinstance(raw_instances, list) or not raw_instances:
+        raise ConfigError("decode.instances must be a non-empty array")
+    return DecodePoolConfig(
+        instances=tuple(
+            _parse_decode(instance, index)
+            for index, instance in enumerate(raw_instances)
+        )
+    )
+
+
+def parse_config(raw: Any) -> ProxyConfig:
+    value = _require_object(raw, "config")
+    _reject_unknown_fields(value, {"conductor", "prefill", "decode"}, "config")
+    for field in ("conductor", "prefill", "decode"):
+        if field not in value:
+            raise ConfigError(f"config.{field} is required")
+
+    conductor = _parse_conductor(value["conductor"])
+    prefill = _parse_prefill_pool(value["prefill"])
+    decode = _parse_decode_pool(value["decode"])
+
+    instance_ids = [instance.instance_id for instance in prefill.instances]
+    if len(instance_ids) != len(set(instance_ids)):
+        raise ConfigError("prefill.instances contains duplicate instance_id")
+
+    event_endpoints: set[str] = set()
+    service_keys: set[tuple[str, int]] = set()
+    for instance in prefill.instances:
+        for registration in instance.registrations:
+            service_key = (instance.instance_id, registration.dp_rank)
+            if service_key in service_keys:
+                raise ConfigError(
+                    "config contains a duplicate registration service key"
+                )
+            service_keys.add(service_key)
+            if registration.endpoint in event_endpoints:
+                raise ConfigError("config contains a duplicate event endpoint")
+            event_endpoints.add(registration.endpoint)
+
+    return ProxyConfig(
+        conductor=conductor,
+        prefill=prefill,
+        decode=decode,
+    )
+
+
+def load_config(path: str | Path) -> ProxyConfig:
+    config_path = Path(path)
+    try:
+        raw = json.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ConfigError(f"failed to load {config_path}: {exc}") from exc
+    return parse_config(raw)
+
+
+def _required_cli_value(args: argparse.Namespace, field: str, option: str) -> Any:
+    value = getattr(args, field)
+    if value is None:
+        raise ConfigError(f"CLI configuration requires {option}")
+    return value
+
+
+def _cli_config_dict(args: argparse.Namespace) -> dict[str, Any]:
+    prefiller_hosts = args.prefiller_hosts or list(DEFAULT_PREFILLER_HOSTS)
+    prefiller_ports = args.prefiller_ports or list(DEFAULT_PREFILLER_PORTS)
+    decoder_hosts = args.decoder_hosts or list(DEFAULT_DECODER_HOSTS)
+    decoder_ports = args.decoder_ports or list(DEFAULT_DECODER_PORTS)
+    instance_ids = _required_cli_value(
+        args, "prefiller_instance_ids", "--prefiller-instance-ids"
+    )
+    raw_registrations = _required_cli_value(
+        args, "prefiller_registrations", "--prefiller-registration"
+    )
+
+    if len(prefiller_hosts) != len(prefiller_ports):
+        raise ConfigError(
+            "number of prefiller hosts must match number of prefiller ports"
+        )
+    if len(decoder_hosts) != len(decoder_ports):
+        raise ConfigError("number of decoder hosts must match number of decoder ports")
+    if len(instance_ids) != len(prefiller_hosts):
+        raise ConfigError(
+            "number of prefiller instance IDs must match number of prefiller hosts"
+        )
+
+    registrations_by_instance: dict[str, list[dict[str, Any]]] = {
+        instance_id: [] for instance_id in instance_ids
+    }
+    for instance_id, dp_rank_text, endpoint in raw_registrations:
+        if instance_id not in registrations_by_instance:
+            raise ConfigError(
+                "--prefiller-registration references unknown instance ID "
+                f"{instance_id!r}"
+            )
+        try:
+            dp_rank = int(dp_rank_text, 10)
+        except (TypeError, ValueError) as exc:
+            raise ConfigError(
+                "--prefiller-registration DP_RANK must be an integer"
+            ) from exc
+        registrations_by_instance[instance_id].append(
+            {"endpoint": endpoint, "dp_rank": dp_rank}
+        )
+
+    conductor_address = _required_cli_value(
+        args, "conductor_address", "--conductor-address"
+    )
+    modelname = _required_cli_value(args, "modelname", "--modelname")
+    block_size = _required_cli_value(args, "block_size", "--block-size")
+    python_hash_seed = _required_cli_value(
+        args, "python_hash_seed", "--python-hash-seed"
+    )
+
+    return {
+        "conductor": {
+            "address": conductor_address,
+            "query_timeout_seconds": (
+                args.query_timeout_seconds
+                if args.query_timeout_seconds is not None
+                else DEFAULT_QUERY_TIMEOUT_SECONDS
+            ),
+            "registration_timeout_seconds": (
+                args.registration_timeout_seconds
+                if args.registration_timeout_seconds is not None
+                else DEFAULT_REGISTRATION_TIMEOUT_SECONDS
+            ),
+        },
+        "prefill": {
+            "config": {
+                "modelname": modelname,
+                "block_size": block_size,
+                "tenant_id": (
+                    args.tenant_id if args.tenant_id is not None else "default"
+                ),
+                "lora_name": args.lora_name if args.lora_name is not None else "",
+                "hash_profile": {
+                    "strategy": SUPPORTED_HASH_PROFILE["strategy"],
+                    "algorithm": SUPPORTED_HASH_PROFILE["algorithm"],
+                    "python_hash_seed": python_hash_seed,
+                    "index_projection": SUPPORTED_HASH_PROFILE["index_projection"],
+                },
+            },
+            "instances": [
+                {
+                    "instance_id": instance_id,
+                    "http_endpoint": f"http://{host}:{port}",
+                    "registrations": registrations_by_instance[instance_id],
+                }
+                for instance_id, host, port in zip(
+                    instance_ids, prefiller_hosts, prefiller_ports, strict=True
+                )
+            ],
+        },
+        "decode": {
+            "instances": [
+                {"http_endpoint": f"http://{host}:{port}"}
+                for host, port in zip(decoder_hosts, decoder_ports, strict=True)
+            ]
+        },
+    }
+
+
+def resolve_config(args: argparse.Namespace) -> ProxyConfig:
+    cli_options = [
+        option
+        for field, option in CLI_CONFIG_OPTIONS
+        if getattr(args, field) is not None
+    ]
+    if args.config is not None:
+        if cli_options:
+            raise ConfigError(
+                "--config cannot be combined with CLI configuration option "
+                f"{cli_options[0]}"
+            )
+        return load_config(args.config)
+    return parse_config(_cli_config_dict(args))
+
+
+def default_client_factory(
+    base_url: str, timeout_seconds: float | None
+) -> httpx.AsyncClient:
+    timeout: httpx.Timeout | None
+    if timeout_seconds is None:
+        timeout = None
+    else:
+        timeout = httpx.Timeout(timeout_seconds)
+    return httpx.AsyncClient(
+        base_url=base_url,
+        timeout=timeout,
+        limits=httpx.Limits(
+            max_connections=None,
+            max_keepalive_connections=None,
+        ),
+    )
+
+
+def _authorization_headers(request_id: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}",
+        "X-Request-Id": request_id,
+    }
+
+
+class ConductorClient:
+    def __init__(
+        self,
+        conductor_config: ConductorConfig,
+        prefill_config: PrefillSharedConfig,
+        client: httpx.AsyncClient,
+    ) -> None:
+        self.conductor_config = conductor_config
+        self.prefill_config = prefill_config
+        self.client = client
+
+    def registration_payloads(
+        self, prefills: tuple[PrefillInstanceConfig, ...]
+    ) -> tuple[dict[str, Any], ...]:
+        payloads: list[dict[str, Any]] = []
+        for prefill in prefills:
+            for registration in prefill.registrations:
+                payloads.append(
+                    {
+                        "endpoint": registration.endpoint,
+                        "type": "vLLM",
+                        "modelname": self.prefill_config.model_name,
+                        "instance_id": prefill.instance_id,
+                        "block_size": self.prefill_config.block_size,
+                        "dp_rank": registration.dp_rank,
+                        "tenant_id": self.prefill_config.tenant_id,
+                        "lora_name": self.prefill_config.lora_name,
+                        "hash_profile": self.prefill_config.hash_profile.as_dict(),
+                    }
+                )
+        return tuple(payloads)
+
+    async def register_all(self, prefills: tuple[PrefillInstanceConfig, ...]) -> None:
+        for payload in self.registration_payloads(prefills):
+            response = await self.client.post(
+                "/register",
+                json=payload,
+                timeout=self.conductor_config.registration_timeout_seconds,
+            )
+            try:
+                response.raise_for_status()
+                body = _response_object(response, "Conductor register")
+                if (
+                    body.get("status") != "registered successfully"
+                    or body.get("instance_id") != payload["instance_id"]
+                ):
+                    raise ConductorProtocolError(
+                        "Conductor register returned an unexpected success body"
+                    )
+            finally:
+                await response.aclose()
+            logger.info(
+                "registered instance_id=%s dp_rank=%s endpoint=%s",
+                payload["instance_id"],
+                payload["dp_rank"],
+                payload["endpoint"],
+            )
+
+    async def query(
+        self,
+        request_data: Mapping[str, Any],
+        token_ids: list[int],
+        request_id: str,
+    ) -> dict[str, Any]:
+        model = request_data.get("model")
+        if not isinstance(model, str) or not model:
+            raise ConductorProtocolError("request model is missing or invalid")
+        payload: dict[str, Any] = {
+            "model": model,
+            "block_size": self.prefill_config.block_size,
+            "token_ids": token_ids,
+            "tenant_id": self.prefill_config.tenant_id,
+            "lora_name": self.prefill_config.lora_name,
+        }
+        if "cache_salt" in request_data:
+            payload["cache_salt"] = request_data["cache_salt"]
+
+        response = await self.client.post(
+            "/query",
+            json=payload,
+            headers={"X-Request-Id": request_id},
+            timeout=self.conductor_config.query_timeout_seconds,
+        )
+        try:
+            response.raise_for_status()
+            return _response_object(response, "Conductor query")
+        finally:
+            await response.aclose()
+
+
+def _response_object(response: httpx.Response, operation: str) -> dict[str, Any]:
+    try:
+        body = response.json()
+    except ValueError as exc:
+        raise ConductorProtocolError(f"{operation} returned invalid JSON") from exc
+    if not isinstance(body, dict):
+        raise ConductorProtocolError(f"{operation} response must be a JSON object")
+    return body
+
+
+class ProxyRuntime:
+    def __init__(
+        self,
+        config: ProxyConfig,
+        client_factory: ClientFactory = default_client_factory,
+    ) -> None:
+        self.config = config
+        self.client_factory = client_factory
+        self.prefill_clients: list[PrefillClient] = []
+        self.decode_clients: list[DecodeClient] = []
+        self.prefill_by_id: Mapping[str, PrefillClient] = MappingProxyType({})
+        self.conductor: ConductorClient | None = None
+        self._conductor_http_client: httpx.AsyncClient | None = None
+        self._tokenizer_iterator: Any = None
+        self._prefill_fallback_iterator: Any = None
+        self._decode_iterator: Any = None
+        self._tie_offsets: dict[tuple[str, ...], int] = {}
+        self.started = False
+
+    async def start(self) -> None:
+        if self.started:
+            return
+        try:
+            self.prefill_clients = []
+            for prefill in self.config.prefill.instances:
+                self.prefill_clients.append(
+                    PrefillClient(
+                        config=prefill,
+                        client=self.client_factory(prefill.http_endpoint, None),
+                    )
+                )
+            self.decode_clients = []
+            for decode in self.config.decode.instances:
+                self.decode_clients.append(
+                    DecodeClient(
+                        config=decode,
+                        client=self.client_factory(decode.http_endpoint, None),
+                    )
+                )
+            self.prefill_by_id = MappingProxyType(
+                {
+                    prefill.config.instance_id: prefill
+                    for prefill in self.prefill_clients
+                }
+            )
+            self._tokenizer_iterator = itertools.cycle(self.prefill_clients)
+            self._prefill_fallback_iterator = itertools.cycle(self.prefill_clients)
+            self._decode_iterator = itertools.cycle(self.decode_clients)
+            self._tie_offsets = {}
+
+            conductor_config = self.config.conductor
+            self._conductor_http_client = self.client_factory(
+                conductor_config.address,
+                conductor_config.query_timeout_seconds,
+            )
+            self.conductor = ConductorClient(
+                conductor_config,
+                self.config.prefill.config,
+                self._conductor_http_client,
+            )
+            await self.conductor.register_all(self.config.prefill.instances)
+            self.started = True
+            logger.info(
+                "initialized %d prefill instances and %d decode instances",
+                len(self.prefill_clients),
+                len(self.decode_clients),
+            )
+        except BaseException:
+            await self.close()
+            raise
+
+    async def close(self) -> None:
+        clients = [prefill.client for prefill in self.prefill_clients]
+        clients.extend(decode.client for decode in self.decode_clients)
+        if self._conductor_http_client is not None:
+            clients.append(self._conductor_http_client)
+        if clients:
+            await asyncio.gather(
+                *(client.aclose() for client in clients), return_exceptions=True
+            )
+        self.started = False
+
+    def _ensure_started(self) -> None:
+        if not self.started or self.conductor is None:
+            raise RuntimeError("proxy runtime is not started")
+
+    def next_decode(self) -> DecodeClient:
+        self._ensure_started()
+        return next(self._decode_iterator)
+
+    def _fallback_prefill(self, request_id: str, reason: str) -> PrefillClient:
+        selected = next(self._prefill_fallback_iterator)
+        logger.warning(
+            "request_id=%s cache_aware_fallback reason=%s selected_instance=%s",
+            request_id,
+            reason,
+            selected.config.instance_id,
+        )
+        return selected
+
+    async def select_prefill(
+        self, request_data: Mapping[str, Any], request_id: str
+    ) -> PrefillClient:
+        self._ensure_started()
+        tokenizer_client = next(self._tokenizer_iterator)
+        try:
+            token_ids = await self._tokenize(tokenizer_client, request_data, request_id)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.debug("request_id=%s tokenization_error=%r", request_id, exc)
+            return self._fallback_prefill(request_id, "tokenization_failed")
+
+        assert self.conductor is not None
+        try:
+            query_result = await self.conductor.query(
+                request_data, token_ids, request_id
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.debug("request_id=%s conductor_query_error=%r", request_id, exc)
+            return self._fallback_prefill(request_id, "conductor_query_failed")
+
+        instances = query_result.get("instances")
+        if not isinstance(instances, dict):
+            return self._fallback_prefill(request_id, "invalid_instances_response")
+
+        candidates: dict[str, int] = {}
+        for instance_id, result in instances.items():
+            if instance_id not in self.prefill_by_id or not isinstance(result, dict):
+                continue
+            longest_matched = result.get("longest_matched")
+            if type(longest_matched) is not int or longest_matched < 0:
+                continue
+            candidates[instance_id] = longest_matched
+
+        if not candidates:
+            return self._fallback_prefill(request_id, "no_routable_cache_result")
+
+        max_hit = max(candidates.values())
+        if max_hit == 0:
+            return self._fallback_prefill(request_id, "all_cache_hits_zero")
+
+        leaders = tuple(
+            sorted(
+                instance_id for instance_id, hit in candidates.items() if hit == max_hit
+            )
+        )
+        offset = self._tie_offsets.get(leaders, 0)
+        selected_id = leaders[offset % len(leaders)]
+        self._tie_offsets[leaders] = offset + 1
+        logger.info(
+            "request_id=%s cache_candidates=%s selected_instance=%s longest_matched=%d",
+            request_id,
+            candidates,
+            selected_id,
+            max_hit,
+        )
+        return self.prefill_by_id[selected_id]
+
+    async def _tokenize(
+        self,
+        client_info: PrefillClient,
+        request_data: Mapping[str, Any],
+        request_id: str,
+    ) -> list[int]:
+        payload = dict(request_data)
+        payload["stream"] = False
+        payload["max_tokens"] = 1
+        if "max_completion_tokens" in payload:
+            payload["max_completion_tokens"] = 1
+        payload.pop("stream_options", None)
+        response = await client_info.client.post(
+            "/tokenize",
+            json=payload,
+            headers=_authorization_headers(request_id),
+            timeout=self.config.conductor.query_timeout_seconds,
+        )
+        try:
+            response.raise_for_status()
+            body = response.json()
+        finally:
+            await response.aclose()
+        if not isinstance(body, dict):
+            raise ValueError("tokenize response must be a JSON object")
+        tokens = body.get("tokens")
+        if not isinstance(tokens, list) or any(
+            type(token) is not int for token in tokens
+        ):
+            raise ValueError("tokenize response tokens must be an integer array")
+        return tokens
+
+    async def send_prefill(
+        self,
+        client_info: PrefillClient,
+        api: str,
+        request_data: Mapping[str, Any],
+        request_id: str,
+    ) -> dict[str, Any]:
+        payload = dict(request_data)
+        payload["kv_transfer_params"] = {
+            "do_remote_decode": True,
+            "do_remote_prefill": False,
+            "remote_engine_id": None,
+            "remote_block_ids": None,
+            "remote_host": None,
+            "remote_port": None,
+        }
+        payload["stream"] = False
+        payload["max_tokens"] = 1
+        if "max_completion_tokens" in payload:
+            payload["max_completion_tokens"] = 1
+        payload.pop("stream_options", None)
+        response = await client_info.client.post(
+            api, json=payload, headers=_authorization_headers(request_id)
+        )
+        try:
+            response.raise_for_status()
+            await response.aread()
+            body = response.json()
+        finally:
+            await response.aclose()
+        if not isinstance(body, dict):
+            raise ValueError("prefill response must be a JSON object")
+        return body
+
+    async def stream_decode(
+        self,
+        client_info: DecodeClient,
+        api: str,
+        request_data: Mapping[str, Any],
+        request_id: str,
+    ) -> AsyncIterator[bytes]:
+        async with client_info.client.stream(
+            "POST",
+            api,
+            json=dict(request_data),
+            headers=_authorization_headers(request_id),
+        ) as response:
+            response.raise_for_status()
+            async for chunk in response.aiter_bytes():
+                yield chunk
+
+
+def create_app(
+    config: ProxyConfig,
+    client_factory: ClientFactory = default_client_factory,
+) -> FastAPI:
+    @asynccontextmanager
+    async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+        runtime = ProxyRuntime(config, client_factory)
+        app.state.proxy_runtime = runtime
+        await runtime.start()
+        try:
+            yield
+        finally:
+            await runtime.close()
+
+    app = FastAPI(lifespan=lifespan)
+
+    async def handle_completions(api: str, request: Request) -> StreamingResponse:
+        runtime: ProxyRuntime = request.app.state.proxy_runtime
+        request_data = await request.json()
+        if not isinstance(request_data, dict):
+            raise ValueError("request body must be a JSON object")
+        request_id = str(uuid.uuid4())
+
+        prefill = await runtime.select_prefill(request_data, request_id)
+        prefill_response = await runtime.send_prefill(
+            prefill, api, request_data, request_id
+        )
+        kv_transfer_params = prefill_response.get("kv_transfer_params", {})
+        if kv_transfer_params:
+            request_data["kv_transfer_params"] = kv_transfer_params
+
+        decode = runtime.next_decode()
+        logger.debug(
+            "request_id=%s using prefill=%s decode=%s",
+            request_id,
+            prefill.config.instance_id,
+            decode.config.http_endpoint,
+        )
+
+        async def generate_stream() -> AsyncIterator[bytes]:
+            async for chunk in runtime.stream_decode(
+                decode, api, request_data, request_id
+            ):
+                yield chunk
+
+        return StreamingResponse(generate_stream(), media_type="application/json")
+
+    @app.post("/v1/completions")
+    async def handle_completion_request(request: Request) -> StreamingResponse:
+        return await handle_completions("/v1/completions", request)
+
+    @app.post("/v1/chat/completions")
+    async def handle_chat_completion_request(request: Request) -> StreamingResponse:
+        return await handle_completions("/v1/chat/completions", request)
+
+    @app.get("/healthcheck")
+    async def healthcheck(request: Request) -> dict[str, Any]:
+        runtime: ProxyRuntime = request.app.state.proxy_runtime
+        return {
+            "status": "ok",
+            "prefill_instances": len(runtime.prefill_clients),
+            "decode_instances": len(runtime.decode_clients),
+        }
+
+    return app
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser("Conductor cache-aware vLLM P/D proxy example")
+    parser.add_argument(
+        "--config",
+        help="Path to proxy JSON config; cannot be combined with CLI config flags",
+    )
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8000)
+    parser.add_argument("--log-level", default="INFO")
+
+    parser.add_argument(
+        "--prefiller-hosts",
+        "--prefiller-host",
+        type=str,
+        nargs="+",
+        help="Prefill HTTP hosts (CLI mode; default: localhost)",
+    )
+    parser.add_argument(
+        "--prefiller-ports",
+        "--prefiller-port",
+        type=int,
+        nargs="+",
+        help="Prefill HTTP ports (CLI mode; default: 8100)",
+    )
+    parser.add_argument(
+        "--decoder-hosts",
+        "--decoder-host",
+        type=str,
+        nargs="+",
+        help="Decode HTTP hosts (CLI mode; default: localhost)",
+    )
+    parser.add_argument(
+        "--decoder-ports",
+        "--decoder-port",
+        type=int,
+        nargs="+",
+        help="Decode HTTP ports (CLI mode; default: 8200)",
+    )
+    parser.add_argument(
+        "--prefiller-instance-ids",
+        "--prefiller-instance-id",
+        nargs="+",
+        help="Instance IDs paired positionally with prefiller hosts and ports",
+    )
+    parser.add_argument(
+        "--prefiller-registration",
+        "--prefill-registration",
+        dest="prefiller_registrations",
+        action="append",
+        nargs=3,
+        metavar=("INSTANCE_ID", "DP_RANK", "EVENT_ENDPOINT"),
+        help="Conductor registration triple; repeat once per prefill DP rank",
+    )
+    parser.add_argument("--conductor-address", help="Conductor HTTP origin")
+    parser.add_argument(
+        "--model", "--modelname", dest="modelname", help="Registered model name"
+    )
+    parser.add_argument("--block-size", type=int)
+    parser.add_argument("--tenant-id")
+    parser.add_argument("--lora-name")
+    parser.add_argument("--python-hash-seed")
+    parser.add_argument("--query-timeout-seconds", type=float)
+    parser.add_argument("--registration-timeout-seconds", type=float)
+
+    args = parser.parse_args(argv)
+    try:
+        args.proxy_config = resolve_config(args)
+    except ConfigError as exc:
+        parser.error(str(exc))
+    return args
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = parse_args(argv)
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
+
+    import uvicorn
+
+    uvicorn.run(create_app(args.proxy_config), host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/mooncake-conductor/example/cache_aware_proxy_config.json
+++ b/mooncake-conductor/example/cache_aware_proxy_config.json
@@ -1,0 +1,50 @@
+{
+  "conductor": {
+    "address": "http://127.0.0.1:13333",
+    "query_timeout_seconds": 1.0,
+    "registration_timeout_seconds": 5.0
+  },
+  "prefill": {
+    "config": {
+      "modelname": "Qwen/Qwen2.5-7B-Instruct",
+      "block_size": 16,
+      "tenant_id": "default",
+      "lora_name": "",
+      "hash_profile": {
+        "strategy": "vllm_v1",
+        "algorithm": "sha256_cbor",
+        "python_hash_seed": "0",
+        "index_projection": "low64_be"
+      }
+    },
+    "instances": [
+      {
+        "instance_id": "prefill-a",
+        "http_endpoint": "http://127.0.0.1:8100",
+        "registrations": [
+          {
+            "endpoint": "tcp://127.0.0.1:5557",
+            "dp_rank": 0
+          }
+        ]
+      },
+      {
+        "instance_id": "prefill-b",
+        "http_endpoint": "http://127.0.0.1:8101",
+        "registrations": [
+          {
+            "endpoint": "tcp://127.0.0.1:5559",
+            "dp_rank": 0
+          }
+        ]
+      }
+    ]
+  },
+  "decode": {
+    "instances": [
+      {
+        "http_endpoint": "http://127.0.0.1:8200"
+      }
+    ]
+  }
+}

--- a/mooncake-conductor/tests/cache_aware_proxy/__init__.py
+++ b/mooncake-conductor/tests/cache_aware_proxy/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Conductor cache-aware proxy example."""

--- a/mooncake-conductor/tests/cache_aware_proxy/_support.py
+++ b/mooncake-conductor/tests/cache_aware_proxy/_support.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import copy
+import json
+import sys
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+EXAMPLE_DIR = Path(__file__).resolve().parents[2] / "example"
+if str(EXAMPLE_DIR) not in sys.path:
+    sys.path.insert(0, str(EXAMPLE_DIR))
+
+import cache_aware_disagg_proxy as proxy  # noqa: E402
+
+
+def valid_config_dict() -> dict[str, Any]:
+    return {
+        "conductor": {
+            "address": "http://conductor.test:13333",
+            "query_timeout_seconds": 0.25,
+            "registration_timeout_seconds": 2.0,
+        },
+        "prefill": {
+            "config": {
+                "modelname": "test-model",
+                "block_size": 16,
+                "tenant_id": "tenant-a",
+                "lora_name": "adapter-a",
+                "hash_profile": {
+                    "strategy": "vllm_v1",
+                    "algorithm": "sha256_cbor",
+                    "python_hash_seed": "0",
+                    "index_projection": "low64_be",
+                },
+            },
+            "instances": [
+                {
+                    "instance_id": "prefill-a",
+                    "http_endpoint": "http://prefill-a.test:8100",
+                    "registrations": [
+                        {"endpoint": "tcp://prefill-a.test:5557", "dp_rank": 0},
+                        {"endpoint": "tcp://prefill-a.test:5558", "dp_rank": 1},
+                    ],
+                },
+                {
+                    "instance_id": "prefill-b",
+                    "http_endpoint": "http://prefill-b.test:8101",
+                    "registrations": [
+                        {"endpoint": "tcp://prefill-b.test:5557", "dp_rank": 0}
+                    ],
+                },
+            ],
+        },
+        "decode": {
+            "instances": [
+                {"http_endpoint": "http://decode-a.test:8200"},
+                {"http_endpoint": "http://decode-b.test:8201"},
+            ]
+        },
+    }
+
+
+def valid_config() -> proxy.ProxyConfig:
+    return proxy.parse_config(valid_config_dict())
+
+
+def cloned_config_dict() -> dict[str, Any]:
+    return copy.deepcopy(valid_config_dict())
+
+
+def request_json(request: httpx.Request) -> dict[str, Any]:
+    body = json.loads(request.content)
+    assert isinstance(body, dict)
+    return body
+
+
+Handler = Callable[[httpx.Request], Awaitable[httpx.Response]]
+
+
+class RecordingClientFactory:
+    def __init__(self, handler: Handler) -> None:
+        self.requests: list[httpx.Request] = []
+        self.clients: list[tuple[str, float | None, httpx.AsyncClient]] = []
+        self._handler = handler
+
+    def __call__(
+        self, base_url: str, timeout_seconds: float | None
+    ) -> httpx.AsyncClient:
+        async def record(request: httpx.Request) -> httpx.Response:
+            self.requests.append(request)
+            return await self._handler(request)
+
+        timeout = None if timeout_seconds is None else httpx.Timeout(timeout_seconds)
+        client = httpx.AsyncClient(
+            base_url=base_url,
+            timeout=timeout,
+            transport=httpx.MockTransport(record),
+        )
+        self.clients.append((base_url, timeout_seconds, client))
+        return client
+
+
+async def registration_success_handler(request: httpx.Request) -> httpx.Response:
+    if request.url.path != "/register":
+        raise AssertionError(f"unexpected request: {request.method} {request.url}")
+    payload = request_json(request)
+    return httpx.Response(
+        200,
+        json={
+            "status": "registered successfully",
+            "instance_id": payload["instance_id"],
+        },
+    )

--- a/mooncake-conductor/tests/cache_aware_proxy/test_cache_aware_proxy_conductor.py
+++ b/mooncake-conductor/tests/cache_aware_proxy/test_cache_aware_proxy_conductor.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import unittest
+
+import httpx
+
+from _support import (
+    RecordingClientFactory,
+    proxy,
+    registration_success_handler,
+    request_json,
+    valid_config,
+)
+
+
+class ConductorClientTest(unittest.IsolatedAsyncioTestCase):
+    async def test_registration_payloads_follow_current_contract(self) -> None:
+        config = valid_config()
+        factory = RecordingClientFactory(registration_success_handler)
+        client = factory(
+            config.conductor.address, config.conductor.query_timeout_seconds
+        )
+        conductor = proxy.ConductorClient(
+            config.conductor, config.prefill.config, client
+        )
+        self.addAsyncCleanup(client.aclose)
+
+        payloads = conductor.registration_payloads(config.prefill.instances)
+
+        self.assertEqual(3, len(payloads))
+        self.assertEqual(
+            {
+                "endpoint": "tcp://prefill-a.test:5557",
+                "type": "vLLM",
+                "modelname": "test-model",
+                "instance_id": "prefill-a",
+                "block_size": 16,
+                "dp_rank": 0,
+                "tenant_id": "tenant-a",
+                "lora_name": "adapter-a",
+                "hash_profile": {
+                    "strategy": "vllm_v1",
+                    "algorithm": "sha256_cbor",
+                    "python_hash_seed": "0",
+                    "index_projection": "low64_be",
+                },
+            },
+            payloads[0],
+        )
+        for payload in payloads:
+            self.assertNotIn("replay_endpoint", payload)
+            self.assertNotIn("cache_salt", payload)
+
+    async def test_runtime_registers_all_ranks_and_does_not_unregister(self) -> None:
+        config = valid_config()
+        factory = RecordingClientFactory(registration_success_handler)
+        runtime = proxy.ProxyRuntime(config, factory)
+
+        await runtime.start()
+        self.assertTrue(runtime.started)
+        self.assertEqual(3, len(factory.requests))
+        self.assertEqual(
+            {"/register"}, {request.url.path for request in factory.requests}
+        )
+
+        await runtime.close()
+        self.assertTrue(all(client.is_closed for _, _, client in factory.clients))
+        self.assertNotIn(
+            "/unregister", [request.url.path for request in factory.requests]
+        )
+
+    async def test_registration_failure_aborts_startup_and_closes_clients(self) -> None:
+        calls = 0
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                return httpx.Response(400, json={"reason": "invalid_registration"})
+            return await registration_success_handler(request)
+
+        factory = RecordingClientFactory(handler)
+        runtime = proxy.ProxyRuntime(valid_config(), factory)
+
+        with self.assertRaises(httpx.HTTPStatusError):
+            await runtime.start()
+
+        self.assertFalse(runtime.started)
+        self.assertEqual(2, calls)
+        self.assertTrue(all(client.is_closed for _, _, client in factory.clients))
+
+    async def test_client_creation_failure_closes_earlier_clients(self) -> None:
+        base_factory = RecordingClientFactory(registration_success_handler)
+        calls = 0
+
+        def failing_factory(
+            base_url: str, timeout_seconds: float | None
+        ) -> httpx.AsyncClient:
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                raise RuntimeError("client creation failed")
+            return base_factory(base_url, timeout_seconds)
+
+        runtime = proxy.ProxyRuntime(valid_config(), failing_factory)
+
+        with self.assertRaisesRegex(RuntimeError, "client creation failed"):
+            await runtime.start()
+
+        self.assertEqual(1, len(base_factory.clients))
+        self.assertTrue(base_factory.clients[0][2].is_closed)
+
+    async def test_registration_rejects_unexpected_success_body(self) -> None:
+        async def handler(request: httpx.Request) -> httpx.Response:
+            payload = request_json(request)
+            return httpx.Response(
+                200,
+                json={"status": "ok", "instance_id": payload["instance_id"]},
+            )
+
+        factory = RecordingClientFactory(handler)
+        runtime = proxy.ProxyRuntime(valid_config(), factory)
+
+        with self.assertRaises(proxy.ConductorProtocolError):
+            await runtime.start()
+        self.assertTrue(all(client.is_closed for _, _, client in factory.clients))
+
+    async def test_query_payload_forwards_optional_cache_salt_and_timeout(self) -> None:
+        async def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"instances": {}})
+
+        config = valid_config()
+        factory = RecordingClientFactory(handler)
+        client = factory(
+            config.conductor.address, config.conductor.query_timeout_seconds
+        )
+        conductor = proxy.ConductorClient(
+            config.conductor, config.prefill.config, client
+        )
+        self.addAsyncCleanup(client.aclose)
+
+        await conductor.query(
+            {"model": "test-model", "prompt": "hello", "cache_salt": "salt-a"},
+            [1, 2, 3],
+            "request-1",
+        )
+        await conductor.query(
+            {"model": "test-model", "prompt": "hello"},
+            [4, 5],
+            "request-2",
+        )
+
+        salted = request_json(factory.requests[0])
+        unsalted = request_json(factory.requests[1])
+        self.assertEqual(
+            {
+                "model": "test-model",
+                "block_size": 16,
+                "token_ids": [1, 2, 3],
+                "tenant_id": "tenant-a",
+                "lora_name": "adapter-a",
+                "cache_salt": "salt-a",
+            },
+            salted,
+        )
+        self.assertNotIn("cache_salt", unsalted)
+        self.assertEqual("request-1", factory.requests[0].headers["x-request-id"])
+        timeout = factory.requests[0].extensions["timeout"]
+        self.assertTrue(all(value == 0.25 for value in timeout.values()))
+
+    async def test_query_rejects_invalid_json_success(self) -> None:
+        async def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=b"not-json")
+
+        config = valid_config()
+        factory = RecordingClientFactory(handler)
+        client = factory(
+            config.conductor.address, config.conductor.query_timeout_seconds
+        )
+        conductor = proxy.ConductorClient(
+            config.conductor, config.prefill.config, client
+        )
+        self.addAsyncCleanup(client.aclose)
+
+        with self.assertRaises(proxy.ConductorProtocolError):
+            await conductor.query({"model": "test-model"}, [1], "request-1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mooncake-conductor/tests/cache_aware_proxy/test_cache_aware_proxy_config.py
+++ b/mooncake-conductor/tests/cache_aware_proxy/test_cache_aware_proxy_config.py
@@ -1,0 +1,386 @@
+from __future__ import annotations
+
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+
+from _support import EXAMPLE_DIR, cloned_config_dict, proxy, valid_config_dict
+
+
+def valid_cli_args() -> list[str]:
+    return [
+        "--prefiller-hosts",
+        "prefill-a.test",
+        "prefill-b.test",
+        "--prefiller-ports",
+        "8100",
+        "8101",
+        "--prefiller-instance-ids",
+        "prefill-a",
+        "prefill-b",
+        "--prefiller-registration",
+        "prefill-a",
+        "0",
+        "tcp://prefill-a.test:5557",
+        "--prefiller-registration",
+        "prefill-a",
+        "1",
+        "tcp://prefill-a.test:5558",
+        "--prefiller-registration",
+        "prefill-b",
+        "0",
+        "tcp://prefill-b.test:5557",
+        "--decoder-hosts",
+        "decode-a.test",
+        "decode-b.test",
+        "--decoder-ports",
+        "8200",
+        "8201",
+        "--conductor-address",
+        "http://conductor.test:13333",
+        "--model",
+        "test-model",
+        "--block-size",
+        "16",
+        "--tenant-id",
+        "tenant-a",
+        "--lora-name",
+        "adapter-a",
+        "--python-hash-seed",
+        "0",
+        "--query-timeout-seconds",
+        "0.25",
+        "--registration-timeout-seconds",
+        "2.0",
+    ]
+
+
+class ConfigTest(unittest.TestCase):
+    def assert_cli_error(self, argv: list[str], message: str) -> None:
+        stderr = io.StringIO()
+        with redirect_stderr(stderr), self.assertRaises(SystemExit) as raised:
+            proxy.parse_args(argv)
+        self.assertEqual(2, raised.exception.code)
+        self.assertIn(message, stderr.getvalue())
+
+    def test_sample_config_loads(self) -> None:
+        sample_path = EXAMPLE_DIR / "cache_aware_proxy_config.json"
+        config = proxy.load_config(sample_path)
+
+        self.assertEqual(
+            ["prefill-a", "prefill-b"],
+            [p.instance_id for p in config.prefill.instances],
+        )
+        self.assertEqual(1, len(config.decode.instances))
+        self.assertEqual("0", config.prefill.config.hash_profile.python_hash_seed)
+
+    def test_valid_multi_rank_config_is_typed_and_normalized(self) -> None:
+        raw = valid_config_dict()
+        raw["prefill"]["config"]["tenant_id"] = ""
+        config = proxy.parse_config(raw)
+
+        self.assertIsInstance(config.conductor, proxy.ConductorConfig)
+        self.assertIsInstance(config.prefill, proxy.PrefillPoolConfig)
+        self.assertIsInstance(config.prefill.config, proxy.PrefillSharedConfig)
+        self.assertIsInstance(config.decode, proxy.DecodePoolConfig)
+        self.assertEqual("default", config.prefill.config.tenant_id)
+        self.assertEqual(
+            (0, 1),
+            tuple(r.dp_rank for r in config.prefill.instances[0].registrations),
+        )
+        self.assertEqual(
+            "http://prefill-a.test:8100",
+            config.prefill.instances[0].http_endpoint,
+        )
+
+    def test_json_and_cli_configuration_are_equivalent(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            config_path = Path(directory) / "proxy.json"
+            config_path.write_text(json.dumps(valid_config_dict()), encoding="utf-8")
+            json_args = proxy.parse_args(
+                [
+                    "--config",
+                    str(config_path),
+                    "--host",
+                    "0.0.0.0",
+                    "--port",
+                    "9000",
+                    "--log-level",
+                    "DEBUG",
+                ]
+            )
+
+        cli_args = proxy.parse_args(valid_cli_args())
+
+        self.assertEqual(json_args.proxy_config, cli_args.proxy_config)
+        self.assertEqual("0.0.0.0", json_args.host)
+        self.assertEqual(9000, json_args.port)
+        self.assertEqual("DEBUG", json_args.log_level)
+
+    def test_cli_mode_preserves_proxy_defaults_and_aliases(self) -> None:
+        config = proxy.parse_args(
+            [
+                "--prefiller-instance-id",
+                "prefill-default",
+                "--prefill-registration",
+                "prefill-default",
+                "0",
+                "tcp://prefill.test:5557",
+                "--conductor-address",
+                "http://conductor.test:13333",
+                "--modelname",
+                "test-model",
+                "--block-size",
+                "16",
+                "--python-hash-seed",
+                "0",
+            ]
+        ).proxy_config
+
+        self.assertEqual(
+            "http://localhost:8100", config.prefill.instances[0].http_endpoint
+        )
+        self.assertEqual(
+            "http://localhost:8200", config.decode.instances[0].http_endpoint
+        )
+
+        alias_args = [
+            {
+                "--prefiller-hosts": "--prefiller-host",
+                "--prefiller-ports": "--prefiller-port",
+                "--decoder-hosts": "--decoder-host",
+                "--decoder-ports": "--decoder-port",
+            }.get(argument, argument)
+            for argument in valid_cli_args()
+        ]
+        self.assertEqual(
+            proxy.parse_config(valid_config_dict()),
+            proxy.parse_args(alias_args).proxy_config,
+        )
+
+    def test_cli_configuration_rejects_ambiguous_mappings(self) -> None:
+        mismatched_ports = valid_cli_args()
+        ports_index = mismatched_ports.index("--prefiller-ports")
+        mismatched_ports.pop(ports_index + 2)
+
+        mismatched_ids = valid_cli_args()
+        ids_index = mismatched_ids.index("--prefiller-instance-ids")
+        mismatched_ids.pop(ids_index + 2)
+
+        unknown_registration = valid_cli_args()
+        registration_index = unknown_registration.index("--prefiller-registration")
+        unknown_registration[registration_index + 1] = "unknown-prefill"
+
+        invalid_rank = valid_cli_args()
+        registration_index = invalid_rank.index("--prefiller-registration")
+        invalid_rank[registration_index + 2] = "rank-zero"
+
+        cases = (
+            (mismatched_ports, "prefiller hosts must match"),
+            (mismatched_ids, "instance IDs must match"),
+            (unknown_registration, "unknown instance ID"),
+            (invalid_rank, "DP_RANK must be an integer"),
+        )
+        for argv, message in cases:
+            with self.subTest(message=message):
+                self.assert_cli_error(argv, message)
+
+    def test_configuration_source_is_required_and_modes_cannot_mix(self) -> None:
+        self.assert_cli_error([], "CLI configuration requires")
+
+        sample_path = EXAMPLE_DIR / "cache_aware_proxy_config.json"
+        for cli_option in (
+            ["--prefiller-hosts", "localhost"],
+            ["--conductor-address", "http://conductor.test:13333"],
+            ["--model", "test-model"],
+        ):
+            with self.subTest(option=cli_option[0]):
+                self.assert_cli_error(
+                    ["--config", str(sample_path), *cli_option],
+                    "--config cannot be combined",
+                )
+
+    def test_missing_sections_and_empty_nested_lists_are_rejected(self) -> None:
+        for field in ("conductor", "prefill", "decode"):
+            with self.subTest(field=field):
+                raw = cloned_config_dict()
+                raw.pop(field)
+                with self.assertRaises(proxy.ConfigError):
+                    proxy.parse_config(raw)
+
+        missing_prefill_config = cloned_config_dict()
+        missing_prefill_config["prefill"].pop("config")
+        with self.assertRaises(proxy.ConfigError):
+            proxy.parse_config(missing_prefill_config)
+
+        for section in ("prefill", "decode"):
+            for replacement in (None, []):
+                with self.subTest(section=section, replacement=replacement):
+                    raw = cloned_config_dict()
+                    if replacement is None:
+                        raw[section].pop("instances")
+                    else:
+                        raw[section]["instances"] = replacement
+                    with self.assertRaises(proxy.ConfigError):
+                        proxy.parse_config(raw)
+
+        empty_registrations = cloned_config_dict()
+        empty_registrations["prefill"]["instances"][0]["registrations"] = []
+        with self.assertRaises(proxy.ConfigError):
+            proxy.parse_config(empty_registrations)
+
+    def test_configuration_domains_and_old_layout_are_rejected(self) -> None:
+        misplaced_configs = []
+        for field in (
+            "modelname",
+            "block_size",
+            "tenant_id",
+            "lora_name",
+            "hash_profile",
+        ):
+            raw = cloned_config_dict()
+            raw["conductor"][field] = raw["prefill"]["config"][field]
+            misplaced_configs.append((f"{field}_under_conductor", raw))
+
+        for field in (
+            "address",
+            "query_timeout_seconds",
+            "registration_timeout_seconds",
+        ):
+            raw = cloned_config_dict()
+            raw["prefill"]["config"][field] = raw["conductor"][field]
+            misplaced_configs.append((f"{field}_under_prefill_config", raw))
+
+        per_instance_config = cloned_config_dict()
+        per_instance_config["prefill"]["instances"][0]["config"] = per_instance_config[
+            "prefill"
+        ]["config"]
+        misplaced_configs.append(("config_under_prefill_instance", per_instance_config))
+
+        for name, raw in misplaced_configs:
+            with self.subTest(name=name), self.assertRaises(proxy.ConfigError):
+                proxy.parse_config(raw)
+
+        old_flat_layout = cloned_config_dict()
+        old_prefill = old_flat_layout.pop("prefill")
+        old_decode = old_flat_layout.pop("decode")
+        old_flat_layout["conductor"].update(old_prefill["config"])
+        old_flat_layout["prefill_instances"] = old_prefill["instances"]
+        old_flat_layout["decode_instances"] = old_decode["instances"]
+
+        with self.assertRaises(proxy.ConfigError):
+            proxy.parse_config(old_flat_layout)
+
+    def test_duplicate_identity_and_endpoint_are_rejected(self) -> None:
+        mutations = []
+
+        duplicate_id = cloned_config_dict()
+        duplicate_id["prefill"]["instances"][1]["instance_id"] = "prefill-a"
+        mutations.append(duplicate_id)
+
+        duplicate_rank = cloned_config_dict()
+        duplicate_rank["prefill"]["instances"][0]["registrations"][1]["dp_rank"] = 0
+        mutations.append(duplicate_rank)
+
+        duplicate_endpoint = cloned_config_dict()
+        duplicate_endpoint["prefill"]["instances"][1]["registrations"][0][
+            "endpoint"
+        ] = "tcp://prefill-a.test:5557"
+        mutations.append(duplicate_endpoint)
+
+        for index, raw in enumerate(mutations):
+            with self.subTest(index=index), self.assertRaises(proxy.ConfigError):
+                proxy.parse_config(raw)
+
+    def test_invalid_rank_and_block_size_are_rejected(self) -> None:
+        cases = []
+        for rank in (-1, True, "0", 1 << 31):
+            raw = cloned_config_dict()
+            raw["prefill"]["instances"][0]["registrations"][0]["dp_rank"] = rank
+            cases.append(raw)
+        for block_size in (0, -1, True, 16.0):
+            raw = cloned_config_dict()
+            raw["prefill"]["config"]["block_size"] = block_size
+            cases.append(raw)
+
+        for index, raw in enumerate(cases):
+            with self.subTest(index=index), self.assertRaises(proxy.ConfigError):
+                proxy.parse_config(raw)
+
+    def test_invalid_timeouts_are_rejected(self) -> None:
+        for field in ("query_timeout_seconds", "registration_timeout_seconds"):
+            for value in (0, -1, True, float("nan"), float("inf")):
+                with self.subTest(field=field, value=value):
+                    raw = cloned_config_dict()
+                    raw["conductor"][field] = value
+                    with self.assertRaises(proxy.ConfigError):
+                        proxy.parse_config(raw)
+
+    def test_missing_fields_and_invalid_urls_are_rejected(self) -> None:
+        cases = []
+
+        missing_event = cloned_config_dict()
+        missing_event["prefill"]["instances"][0]["registrations"][0].pop("endpoint")
+        cases.append(missing_event)
+
+        path_endpoint = cloned_config_dict()
+        path_endpoint["prefill"]["instances"][0]["http_endpoint"] = (
+            "http://prefill-a.test:8100/v1"
+        )
+        cases.append(path_endpoint)
+
+        invalid_conductor = cloned_config_dict()
+        invalid_conductor["conductor"]["address"] = "tcp://conductor.test:13333"
+        cases.append(invalid_conductor)
+
+        missing_profile = cloned_config_dict()
+        missing_profile["prefill"]["config"].pop("hash_profile")
+        cases.append(missing_profile)
+
+        for index, raw in enumerate(cases):
+            with self.subTest(index=index), self.assertRaises(proxy.ConfigError):
+                proxy.parse_config(raw)
+
+    def test_unsupported_hash_profiles_and_seeds_are_rejected(self) -> None:
+        cases = []
+        for field, value in (
+            ("strategy", "other"),
+            ("algorithm", "xxh64"),
+            ("index_projection", "high64_be"),
+            ("python_hash_seed", "-1"),
+            ("python_hash_seed", " 0"),
+            ("python_hash_seed", "4294967296"),
+            ("python_hash_seed", "٠"),
+        ):
+            raw = cloned_config_dict()
+            raw["prefill"]["config"]["hash_profile"][field] = value
+            cases.append(raw)
+
+        unknown = cloned_config_dict()
+        unknown["prefill"]["config"]["hash_profile"]["root_digest"] = "00"
+        cases.append(unknown)
+
+        for index, raw in enumerate(cases):
+            with self.subTest(index=index), self.assertRaises(proxy.ConfigError):
+                proxy.parse_config(raw)
+
+    def test_load_config_reports_invalid_json(self) -> None:
+        invalid = Path(__file__).with_name("invalid-config.json")
+        try:
+            invalid.write_text("{", encoding="utf-8")
+            with self.assertRaises(proxy.ConfigError):
+                proxy.load_config(invalid)
+        finally:
+            invalid.unlink(missing_ok=True)
+
+    def test_sample_config_is_plain_json(self) -> None:
+        sample_path = EXAMPLE_DIR / "cache_aware_proxy_config.json"
+        parsed = json.loads(sample_path.read_text(encoding="utf-8"))
+        self.assertNotIn("replay_endpoint", json.dumps(parsed))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mooncake-conductor/tests/cache_aware_proxy/test_cache_aware_proxy_endpoints.py
+++ b/mooncake-conductor/tests/cache_aware_proxy/test_cache_aware_proxy_endpoints.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import asyncio
+import unittest
+from unittest.mock import patch
+
+import httpx
+
+from _support import RecordingClientFactory, proxy, request_json, valid_config
+
+
+class EndpointTest(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        asyncio.get_running_loop().slow_callback_duration = 1.0
+
+    async def test_completion_preserves_prefill_decode_contract(self) -> None:
+        outbound: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            outbound.append(request)
+            path = request.url.path
+            if request.url.host == "conductor.test" and path == "/register":
+                payload = request_json(request)
+                return httpx.Response(
+                    200,
+                    json={
+                        "status": "registered successfully",
+                        "instance_id": payload["instance_id"],
+                    },
+                )
+            if request.url.host == "conductor.test" and path == "/query":
+                return httpx.Response(
+                    200,
+                    json={
+                        "instances": {
+                            "prefill-a": {"longest_matched": 16},
+                            "prefill-b": {"longest_matched": 32},
+                        }
+                    },
+                )
+            if path == "/tokenize":
+                return httpx.Response(200, json={"tokens": [1, 2, 3]})
+            if request.url.host == "prefill-b.test" and path == "/v1/completions":
+                return httpx.Response(
+                    200,
+                    json={
+                        "kv_transfer_params": {
+                            "remote_engine_id": "engine-b",
+                            "remote_block_ids": [7, 8],
+                        }
+                    },
+                )
+            if request.url.host == "decode-a.test" and path == "/v1/completions":
+                return httpx.Response(200, content=b"decode-completion")
+            raise AssertionError(f"unexpected request: {request.method} {request.url}")
+
+        factory = RecordingClientFactory(handler)
+        app = proxy.create_app(valid_config(), factory)
+        request_body = {
+            "model": "test-model",
+            "prompt": "hello",
+            "max_tokens": 9,
+            "stream": True,
+            "stream_options": {"include_usage": True},
+            "cache_salt": "salt-a",
+        }
+
+        with (
+            patch.dict("os.environ", {"OPENAI_API_KEY": "test-key"}),
+            patch.object(proxy.uuid, "uuid4", return_value="fixed-request-id"),
+        ):
+            async with app.router.lifespan_context(app):
+                transport = httpx.ASGITransport(app=app)
+                async with httpx.AsyncClient(
+                    transport=transport, base_url="http://proxy.test"
+                ) as client:
+                    health = await client.get("/healthcheck")
+                    response = await client.post("/v1/completions", json=request_body)
+
+        self.assertEqual(
+            {"status": "ok", "prefill_instances": 2, "decode_instances": 2},
+            health.json(),
+        )
+        self.assertEqual(b"decode-completion", response.content)
+        self.assertTrue(response.headers["content-type"].startswith("application/json"))
+
+        tokenize = next(
+            request for request in outbound if request.url.path == "/tokenize"
+        )
+        query = next(request for request in outbound if request.url.path == "/query")
+        prefill = next(
+            request
+            for request in outbound
+            if request.url.host == "prefill-b.test"
+            and request.url.path == "/v1/completions"
+        )
+        decode = next(
+            request
+            for request in outbound
+            if request.url.host == "decode-a.test"
+            and request.url.path == "/v1/completions"
+        )
+
+        tokenize_body = request_json(tokenize)
+        self.assertFalse(tokenize_body["stream"])
+        self.assertEqual(1, tokenize_body["max_tokens"])
+        self.assertNotIn("stream_options", tokenize_body)
+
+        self.assertEqual("salt-a", request_json(query)["cache_salt"])
+
+        prefill_body = request_json(prefill)
+        self.assertFalse(prefill_body["stream"])
+        self.assertEqual(1, prefill_body["max_tokens"])
+        self.assertNotIn("stream_options", prefill_body)
+        self.assertEqual(True, prefill_body["kv_transfer_params"]["do_remote_decode"])
+
+        decode_body = request_json(decode)
+        self.assertTrue(decode_body["stream"])
+        self.assertEqual(9, decode_body["max_tokens"])
+        self.assertEqual({"include_usage": True}, decode_body["stream_options"])
+        self.assertEqual(
+            {"remote_engine_id": "engine-b", "remote_block_ids": [7, 8]},
+            decode_body["kv_transfer_params"],
+        )
+
+        for request in (tokenize, query, prefill, decode):
+            self.assertEqual("fixed-request-id", request.headers["x-request-id"])
+        for request in (tokenize, prefill, decode):
+            self.assertEqual("Bearer test-key", request.headers["authorization"])
+        self.assertTrue(all(client.is_closed for _, _, client in factory.clients))
+        self.assertNotIn("/unregister", [request.url.path for request in outbound])
+
+    async def test_chat_completion_fallback_and_decode_round_robin(self) -> None:
+        outbound: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            outbound.append(request)
+            path = request.url.path
+            if request.url.host == "conductor.test" and path == "/register":
+                payload = request_json(request)
+                return httpx.Response(
+                    200,
+                    json={
+                        "status": "registered successfully",
+                        "instance_id": payload["instance_id"],
+                    },
+                )
+            if request.url.host == "conductor.test" and path == "/query":
+                return httpx.Response(
+                    200,
+                    json={
+                        "instances": {
+                            "prefill-a": {"longest_matched": 0},
+                            "prefill-b": {"longest_matched": 0},
+                        }
+                    },
+                )
+            if path == "/tokenize":
+                return httpx.Response(200, json={"tokens": [1]})
+            if (
+                request.url.host.startswith("prefill-")
+                and path == "/v1/chat/completions"
+            ):
+                return httpx.Response(
+                    200,
+                    json={"kv_transfer_params": {"remote_engine_id": request.url.host}},
+                )
+            if (
+                request.url.host.startswith("decode-")
+                and path == "/v1/chat/completions"
+            ):
+                return httpx.Response(200, content=request.url.host.encode())
+            raise AssertionError(f"unexpected request: {request.method} {request.url}")
+
+        factory = RecordingClientFactory(handler)
+        app = proxy.create_app(valid_config(), factory)
+        body = {
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hello"}],
+            "max_completion_tokens": 12,
+            "stream": True,
+            "stream_options": {"include_usage": True},
+        }
+
+        async with app.router.lifespan_context(app):
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(
+                transport=transport, base_url="http://proxy.test"
+            ) as client:
+                first = await client.post("/v1/chat/completions", json=body)
+                second = await client.post("/v1/chat/completions", json=body)
+
+        self.assertEqual(b"decode-a.test", first.content)
+        self.assertEqual(b"decode-b.test", second.content)
+        prefills = [
+            request
+            for request in outbound
+            if request.url.path == "/v1/chat/completions"
+            and request.url.host.startswith("prefill-")
+        ]
+        self.assertEqual(
+            ["prefill-a.test", "prefill-b.test"], [r.url.host for r in prefills]
+        )
+        for request in prefills:
+            payload = request_json(request)
+            self.assertEqual(1, payload["max_completion_tokens"])
+            self.assertNotIn("stream_options", payload)
+
+        decodes = [
+            request
+            for request in outbound
+            if request.url.path == "/v1/chat/completions"
+            and request.url.host.startswith("decode-")
+        ]
+        for request in decodes:
+            payload = request_json(request)
+            self.assertEqual(12, payload["max_completion_tokens"])
+            self.assertEqual({"include_usage": True}, payload["stream_options"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mooncake-conductor/tests/cache_aware_proxy/test_cache_aware_proxy_scheduler.py
+++ b/mooncake-conductor/tests/cache_aware_proxy/test_cache_aware_proxy_scheduler.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import copy
+import unittest
+from unittest.mock import AsyncMock
+
+import httpx
+
+from _support import (
+    RecordingClientFactory,
+    proxy,
+    registration_success_handler,
+    valid_config,
+)
+
+
+class SchedulerTest(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        self.factory = RecordingClientFactory(registration_success_handler)
+        self.runtime = proxy.ProxyRuntime(valid_config(), self.factory)
+        await self.runtime.start()
+        self.runtime._tokenize = AsyncMock(return_value=[1, 2, 3])
+
+    async def asyncTearDown(self) -> None:
+        await self.runtime.close()
+
+    async def test_unique_maximum_and_unknown_instances(self) -> None:
+        self.runtime.conductor.query = AsyncMock(
+            return_value={
+                "instances": {
+                    "unknown": {"longest_matched": 999},
+                    "prefill-a": {"longest_matched": 16},
+                    "prefill-b": {"longest_matched": 32},
+                }
+            }
+        )
+
+        selected = await self.runtime.select_prefill(
+            {"model": "test-model", "prompt": "hello"}, "request-1"
+        )
+
+        self.assertEqual("prefill-b", selected.config.instance_id)
+
+    async def test_positive_ties_rotate_independent_of_response_order(self) -> None:
+        query = AsyncMock(
+            side_effect=[
+                {
+                    "instances": {
+                        "prefill-b": {"longest_matched": 32},
+                        "prefill-a": {"longest_matched": 32},
+                    }
+                },
+                {
+                    "instances": {
+                        "prefill-a": {"longest_matched": 32},
+                        "prefill-b": {"longest_matched": 32},
+                    }
+                },
+                {
+                    "instances": {
+                        "prefill-b": {"longest_matched": 32},
+                        "prefill-a": {"longest_matched": 32},
+                    }
+                },
+            ]
+        )
+        self.runtime.conductor.query = query
+
+        selected = []
+        for index in range(3):
+            result = await self.runtime.select_prefill(
+                {"model": "test-model"}, f"request-{index}"
+            )
+            selected.append(result.config.instance_id)
+
+        self.assertEqual(["prefill-a", "prefill-b", "prefill-a"], selected)
+
+    async def test_all_zero_fallback_has_independent_round_robin(self) -> None:
+        self.runtime.conductor.query = AsyncMock(
+            return_value={
+                "instances": {
+                    "prefill-a": {"longest_matched": 0},
+                    "prefill-b": {"longest_matched": 0},
+                }
+            }
+        )
+
+        selected = []
+        for index in range(3):
+            result = await self.runtime.select_prefill(
+                {"model": "test-model"}, f"request-{index}"
+            )
+            selected.append(result.config.instance_id)
+
+        self.assertEqual(["prefill-a", "prefill-b", "prefill-a"], selected)
+
+    async def test_tokenization_failure_falls_back_without_mutating_request(
+        self,
+    ) -> None:
+        request_data = {
+            "model": "test-model",
+            "prompt": "hello",
+            "stream": True,
+            "stream_options": {"include_usage": True},
+        }
+        original = copy.deepcopy(request_data)
+        self.runtime._tokenize = AsyncMock(side_effect=httpx.ReadTimeout("timeout"))
+        self.runtime.conductor.query = AsyncMock()
+
+        selected = await self.runtime.select_prefill(request_data, "request-1")
+
+        self.assertEqual("prefill-a", selected.config.instance_id)
+        self.assertEqual(original, request_data)
+        self.runtime.conductor.query.assert_not_awaited()
+
+    async def test_query_failure_falls_back(self) -> None:
+        self.runtime.conductor.query = AsyncMock(
+            side_effect=httpx.ReadTimeout("timeout")
+        )
+
+        first = await self.runtime.select_prefill({"model": "test-model"}, "r1")
+        second = await self.runtime.select_prefill({"model": "test-model"}, "r2")
+
+        self.assertEqual(
+            ["prefill-a", "prefill-b"],
+            [first.config.instance_id, second.config.instance_id],
+        )
+
+    async def test_unusable_query_responses_fall_back(self) -> None:
+        responses = [
+            {},
+            {"instances": []},
+            {"instances": {"unknown": {"longest_matched": 100}}},
+            {"instances": {"prefill-a": {"longest_matched": True}}},
+            {"instances": {"prefill-a": {"longest_matched": -1}}},
+            {"instances": {"prefill-a": {"longest_matched": "16"}}},
+        ]
+        self.runtime.conductor.query = AsyncMock(side_effect=responses)
+
+        selected = []
+        for index in range(len(responses)):
+            result = await self.runtime.select_prefill(
+                {"model": "test-model"}, f"request-{index}"
+            )
+            selected.append(result.config.instance_id)
+
+        self.assertEqual(
+            [
+                "prefill-a",
+                "prefill-b",
+                "prefill-a",
+                "prefill-b",
+                "prefill-a",
+                "prefill-b",
+            ],
+            selected,
+        )
+
+    async def test_selection_and_fallback_logs_are_request_scoped(self) -> None:
+        self.runtime.conductor.query = AsyncMock(
+            side_effect=[
+                {
+                    "instances": {
+                        "prefill-a": {"longest_matched": 16},
+                        "prefill-b": {"longest_matched": 32},
+                    }
+                },
+                httpx.ReadTimeout("timeout"),
+            ]
+        )
+
+        with self.assertLogs(proxy.logger, level="INFO") as captured:
+            await self.runtime.select_prefill({"model": "test-model"}, "hit-id")
+            await self.runtime.select_prefill({"model": "test-model"}, "fallback-id")
+
+        output = "\n".join(captured.output)
+        self.assertIn("request_id=hit-id", output)
+        self.assertIn("cache_candidates=", output)
+        self.assertIn("selected_instance=prefill-b", output)
+        self.assertIn("request_id=fallback-id", output)
+        self.assertIn("reason=conductor_query_failed", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

  Add a standalone cache-aware prefill/decode proxy example for Mooncake Conductor #2833 .

  The proxy preserves the existing vLLM disaggregated prefill/decode request flow
  while using Conductor cache information to select the prefill instance:

  - Register configured vLLM KV-event publishers with Conductor during startup.
  - Tokenize incoming requests and query Conductor for prefix-cache matches.
  - Route prefill requests to the instance with the largest positive
  `longest_matched` value.
  - Rotate between instances when multiple candidates have the same cache hit.
  - Fall back to an independent round-robin prefill policy when tokenization or
  Conductor queries fail, results are malformed, or no positive cache hit is
  available.
  - Keep decode instance selection round robin.
  - Support equivalent JSON and command-line configuration modes.
  - Fail startup when any configured Conductor registration is unsuccessful.

  This change also includes:

  - A sample configuration for a two-prefill, one-decode deployment.
  - Setup, configuration, startup, and verification documentation.
  - CPU-only tests covering configuration validation, Conductor integration,
  scheduling behavior, and HTTP endpoints.

  ## Module

  - [ ] Transfer Engine (`mooncake-transfer-engine`)
  - [x] Mooncake Store (`mooncake-store`)
  - [ ] Mooncake EP (`mooncake-ep`)
  - [ ] Mooncake PG (`mooncake-pg`)
  - [ ] Integration (`mooncake-integration`)
  - [ ] P2P Store (`mooncake-p2p-store`)
  - [ ] Python Wheel (`mooncake-wheel`)
  - [ ] Common (`mooncake-common`)
  - [ ] Mooncake RL (`mooncake-rl`)
  - [ ] CI/CD
  - [x] Docs
  - [ ] Other

  ## Type of Change

  - [ ] Bug fix
  - [x] New feature
  - [ ] Refactor
  - [ ] Breaking change
  - [x] Documentation update
  - [ ] Performance improvement
  - [ ] Other

  ## How Has This Been Tested?

  The change includes CPU-only tests for:

  - JSON and CLI configuration parsing and validation.
  - Conductor registration and query handling.
  - Cache-aware prefill selection, tie rotation, and round-robin fallback.
  - Completion and chat-completion proxy endpoints.
  - Prefill/decode request forwarding and KV-transfer parameter propagation.

  **Test commands:**
  ```bash
  python3 -m pytest mooncake-conductor/tests/cache_aware_proxy
```
  Test results:

  - [x] Unit tests pass
  - [x] Integration tests pass (if applicable)
  - [x] Manual testing done (describe below)

  ## Checklist

  - [ ] I have performed a self-review of my own code
  - [ ] I have formatted my code using ./scripts/code_format.sh
  - [ ] I have run pre-commit run --all-files and all hooks pass
  - [x] I have updated the documentation
  - [x] I have added tests to prove my changes are effective
  - [ ] For changes >500 LOC: I have filed an RFC issue

  ## AI Assistance Disclosure

  - [ ] No AI tools were used
  - [x] AI tools were used (specify below)

  AI tools assisted with implementation, test development, and documentation. The
  human submitter has reviewed the changed lines and is responsible for
  understanding and defending the change.