### PR TITLE
[wheel] add unified release and cleanup APIs

### DIFF
--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -542,12 +542,49 @@ class MooncakeBundleTransfer:
         return self._structured_store.materialize_into(spec, destinations)
 
     @staticmethod
-    def release_result(result: Any) -> None:
+    def release(
+        result: Any, *, type: Literal["dataproto", "dict"] = "dataproto"
+    ) -> None:
         """Release pool-backed buffers in a GET result.
 
-        After get_dataproto / get_dict, ndarray payloads may be backed by
-        the BufferPool. Call this to release those leases deterministically
-        instead of waiting for GC ``__del__``.
+        ``type`` selects the public lifecycle path. DataProto and flat-dict
+        results currently share the same buffer-owner walker, but the split is
+        kept explicit so future type-specific lifecycle rules have a stable
+        dispatch point.
+        """
+        if type == "dataproto":
+            return MooncakeBundleTransfer.release_dataproto(result)
+        if type == "dict":
+            return MooncakeBundleTransfer.release_dict(result)
+        raise ValueError(f"unsupported Mooncake payload type: {type!r}")
+
+    @staticmethod
+    def release_dataproto(result: Any) -> None:
+        """Release pool-backed buffers in a DataProto GET result."""
+        MooncakeBundleTransfer._release_result(result)
+
+    @staticmethod
+    def release_dict(result: Any) -> None:
+        """Release pool-backed buffers in a flat-dict GET result."""
+        MooncakeBundleTransfer._release_result(result)
+
+    @staticmethod
+    def release_result(result: Any) -> None:
+        """Release pool-backed buffers in a DataProto-oriented GET result.
+
+        New code should prefer ``release(..., type=...)``. This compatibility
+        helper keeps the original DataProto-oriented name.
+        """
+        MooncakeBundleTransfer.release_dataproto(result)
+
+    @staticmethod
+    def _release_result(result: Any) -> None:
+        """Release pool-backed buffers in a GET result.
+
+        After get(..., type="dataproto"), get(..., type="dict"),
+        get_dataproto, or get_dict, ndarray payloads may be backed by the
+        BufferPool. Call this to release those leases deterministically instead
+        of waiting for GC ``__del__``.
 
         Works for both flat dicts and nested envelope dicts
         (dataproto: {batch: {...}, non_tensor_batch: {...}, meta_info: {...}}).
@@ -1351,8 +1388,35 @@ class MooncakeBundleTransfer:
                 dict_payload[f"{key}.{name}"] = value
         return dict_payload, metadata
 
+    def cleanup(
+        self, ref: DataProtoRefLike, *, type: Literal["dataproto", "dict"] = "dataproto"
+    ) -> None:
+        """Remove all structured object stages referenced by a structured handle.
+
+        ``type`` selects the public lifecycle path. DataProto and flat-dict
+        refs currently share the same structured-ref cleanup mechanics, but the
+        split is kept explicit so future type-specific lifecycle rules have a
+        stable dispatch point.
+        """
+        if type == "dataproto":
+            return self.cleanup_dataproto(ref)
+        if type == "dict":
+            return self.cleanup_dict(ref)
+        raise ValueError(f"unsupported Mooncake payload type: {type!r}")
+
     def cleanup_dataproto(self, ref: DataProtoRefLike) -> None:
         """Remove all structured object stages referenced by a DataProto handle."""
+        self._cleanup_structured_ref(ref)
+
+    def cleanup_dict(self, ref: DataProtoRefLike) -> None:
+        """Remove all structured object stages referenced by a flat-dict handle.
+
+        Refs returned by ``put(..., type="dict")`` use the same structured
+        handle representation as DataProto refs.
+        """
+        self._cleanup_structured_ref(ref)
+
+    def _cleanup_structured_ref(self, ref: DataProtoRefLike) -> None:
         ref = _resolve_dataproto_ref(ref)
         seen: set[str] = set()
         for stage_ref in ref.stage_refs.values():

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -753,10 +753,17 @@ def test_structured_object_ndarray_read_can_use_buffer_pool() -> None:
     assert store.get_into_ranges_calls == before_range_reads + 1
     assert pool.acquire_sizes == [array.nbytes]
 
-    MooncakeBundleTransfer.release_result(result.objects)
+    MooncakeBundleTransfer.release(result.objects, type="dataproto")
     assert pool.release_count == 1
     MooncakeBundleTransfer.release_result(result.objects)
     assert pool.release_count == 1
+
+    dict_result = transfer.materialize(transfer.read_spec(ref))
+    assert hasattr(dict_result.objects["weights"], "_mooncake_pool_owner")
+    MooncakeBundleTransfer.release(dict_result.objects, type="dict")
+    assert pool.release_count == 2
+    MooncakeBundleTransfer.release_dict(dict_result.objects)
+    assert pool.release_count == 2
 
 
 def test_structured_object_multi_buffer_payload_uses_pool_batch_put() -> None:
@@ -1900,11 +1907,35 @@ def test_unified_put_get_roundtrips_flat_dict() -> None:
     assert result["step"] == 7
 
 
+def test_unified_cleanup_removes_flat_dict_objects() -> None:
+    store, transfer = make_transfer()
+    ref = transfer.put(
+        {
+            "input_ids": np.arange(6, dtype=np.int64).reshape(3, 2),
+            "tokens": [np.asarray([1, 2]), None, np.asarray([3])],
+            "step": 7,
+        },
+        type="dict",
+    )
+
+    assert store.objects
+    transfer.cleanup(ref, type="dict")
+
+    assert store.objects == {}
+
+
 def test_unified_put_rejects_unknown_type() -> None:
     _store, transfer = make_transfer()
 
     with pytest.raises(ValueError, match="unsupported Mooncake payload type"):
         transfer.put({}, type="unknown")  # type: ignore[arg-type]
+
+    ref = transfer.put({"input_ids": np.arange(2)}, type="dict")
+    with pytest.raises(ValueError, match="unsupported Mooncake payload type"):
+        transfer.cleanup(ref, type="unknown")  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="unsupported Mooncake payload type"):
+        MooncakeBundleTransfer.release({}, type="unknown")  # type: ignore[arg-type]
 
 
 @pytest.mark.parametrize(
@@ -1978,9 +2009,19 @@ def test_ref_aliases_match_dataproto_ref_helpers() -> None:
     assert import_ref is import_dataproto_ref
 
 
-def test_release_result_is_available_for_split_api_compatibility() -> None:
+def test_lifecycle_split_helpers_are_available() -> None:
+    _store, transfer = make_transfer()
+
+    assert callable(MooncakeBundleTransfer.release_dataproto)
+    assert callable(MooncakeBundleTransfer.release_dict)
+    assert callable(transfer.cleanup_dataproto)
+    assert callable(transfer.cleanup_dict)
+
+
+def test_unified_release_is_available_for_split_api_compatibility() -> None:
     result = {"tokens": [np.asarray([1, 2]), None]}
 
+    assert MooncakeBundleTransfer.release(result, type="dict") is None
     assert MooncakeBundleTransfer.release_result(result) is None
     assert result["tokens"][0].tolist() == [1, 2]
 
@@ -2883,7 +2924,7 @@ def test_dataproto_helper_cleanup_removes_all_stage_objects() -> None:
     )
 
     assert store.objects
-    transfer.cleanup_dataproto(ref)
+    transfer.cleanup(ref, type="dataproto")
 
     assert store.objects == {}
 


### PR DESCRIPTION
## Description

Add unified structured-object lifecycle APIs to match the existing unified `put(...)` / `get(...)` surface:

- `MooncakeBundleTransfer.release(result, type=...)` dispatches lifecycle handling by payload type.
- `MooncakeBundleTransfer.cleanup(ref, type=...)` dispatches cleanup by payload type.

The type-specific paths are explicit:

- `release_dataproto(result)`
- `release_dict(result)`
- `cleanup_dataproto(ref)`
- `cleanup_dict(ref)`

Today the DataProto and flat-dict implementations share the same private lifecycle mechanics, but the public layering keeps the unified API at the outer layer and keeps DataProto/dict semantics separated. The existing `release_result(result)` helper remains available for compatibility and routes through the DataProto release path.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
PYTHONPATH=mooncake-wheel python3 -m py_compile mooncake-wheel/mooncake/structured_object_store.py mooncake-wheel/tests/test_structured_object_store.py
PYTHONPATH=mooncake-wheel python3 -m pytest -q mooncake-wheel/tests/test_structured_object_store.py -k "buffer_pool or lifecycle_split_helpers_are_available or unified_release_is_available or unified_cleanup_removes_flat_dict_objects or unified_put_rejects_unknown_type or dataproto_helper_cleanup_removes_all_stage_objects"
git diff --check
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

Result:
`6 passed, 2 skipped, 94 deselected in 0.76s`

Notes:
- The two skipped tests are existing torch/CUDA environment skips in this machine.
- A full `test_structured_object_store.py` run was attempted but did not finish promptly in a non-target slow path, so the focused lifecycle/API tests above are used as the validation signal for this small Python-wheel API patch.
- `./scripts/code_format.sh` formats changed C/C++ files only; this PR changes Python files only. `git diff --check` passed.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex was used to add the unified lifecycle dispatch APIs, preserve compatibility helpers, run targeted validation, and prepare this PR description.
