### PR TITLE
[Store] stop steady-state etcd watch goroutine leak in WaitForViewChange (#3059)

### DIFF
--- a/mooncake-store/src/ha/leadership/backends/etcd/etcd_leader_coordinator.cpp
+++ b/mooncake-store/src/ha/leadership/backends/etcd/etcd_leader_coordinator.cpp
@@ -377,29 +377,32 @@ EtcdLeaderCoordinator::WaitForViewChange(
     // allocate ONCE per WaitForViewChange call. The previous per-iteration
     // arming churned Go watch goroutines; when WaitWatchWithPrefixStopped did
     // not complete in time the guard leaked state (UAF-safe) and a goroutine
-    // lingered -- the ~7-threads/min leak in #3059. Re-arm ONLY on WATCH_BROKEN.
+    // lingered -- the ~7-threads/min leak in #3059. Re-arm ONLY on
+    // WATCH_BROKEN.
     auto* state = new ViewChangeWatchState();
     PrefixWatchGuard guard(master_view_key_, state);
 
-    // Arm the watch ONCE before entering the loop. Arm-before-read: the watch is
-    // established at revision R_watch; the first ReadCurrentView observes
+    // Arm the watch ONCE before entering the loop. Arm-before-read: the watch
+    // is established at revision R_watch; the first ReadCurrentView observes
     // R_read >= R_watch. A change at revision C is caught by C < R_read (the
     // read) or C >= R_watch (the watch), and the ranges overlap, so a change
     // between read and watch cannot be missed. start_revision = 0 avoids a
     // possibly-compacted revision. A long-lived watch keeps this for all later
-    // changes; the gap reopens only on re-arm after WATCH_BROKEN (handled below).
+    // changes; the gap reopens only on re-arm after WATCH_BROKEN (handled
+    // below).
     bool watching = false;
     {
-        const auto remaining = std::chrono::duration_cast<std::chrono::milliseconds>(
-            deadline - std::chrono::steady_clock::now());
+        const auto remaining =
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+                deadline - std::chrono::steady_clock::now());
         if (remaining > kViewChangeFallbackPollInterval) {
             // Defensively clear any lingering watch on this key, then arm a new
             // one. Both calls are no-ops when nothing is registered.
             EtcdHelper::CancelWatchWithPrefix(master_view_key_.c_str(),
                                               master_view_key_.size());
-            EtcdHelper::WaitWatchWithPrefixStopped(
-                master_view_key_.c_str(), master_view_key_.size(),
-                kWatchStopTimeoutMs);
+            EtcdHelper::WaitWatchWithPrefixStopped(master_view_key_.c_str(),
+                                                   master_view_key_.size(),
+                                                   kWatchStopTimeoutMs);
             auto watch_err = EtcdHelper::WatchWithPrefixFromRevision(
                 master_view_key_.c_str(), master_view_key_.size(),
                 /*start_revision=*/0, state, &ViewChangeWatchCallback);
@@ -449,9 +452,9 @@ EtcdLeaderCoordinator::WaitForViewChange(
             if (remaining > kViewChangeFallbackPollInterval) {
                 EtcdHelper::CancelWatchWithPrefix(master_view_key_.c_str(),
                                                   master_view_key_.size());
-                EtcdHelper::WaitWatchWithPrefixStopped(
-                    master_view_key_.c_str(), master_view_key_.size(),
-                    kWatchStopTimeoutMs);
+                EtcdHelper::WaitWatchWithPrefixStopped(master_view_key_.c_str(),
+                                                       master_view_key_.size(),
+                                                       kWatchStopTimeoutMs);
                 auto watch_err = EtcdHelper::WatchWithPrefixFromRevision(
                     master_view_key_.c_str(), master_view_key_.size(),
                     /*start_revision=*/0, state, &ViewChangeWatchCallback);

--- a/mooncake-store/src/ha/leadership/backends/etcd/etcd_leader_coordinator.cpp
+++ b/mooncake-store/src/ha/leadership/backends/etcd/etcd_leader_coordinator.cpp
@@ -33,21 +33,27 @@ constexpr int kWatchStopTimeoutMs = 5000;
 
 // Shared state between WaitForViewChange and the etcd watch callback. The
 // callback only flips `changed` and wakes the waiter; the waiter decides what
-// the change means by re-reading the view.
+// the change means by re-reading the view. `watch_healthy` is flipped to false
+// by the callback on WATCH_BROKEN so the waiter re-arms before blocking again.
+// Both flags live under `mutex`.
 struct ViewChangeWatchState {
     std::mutex mutex;
     std::condition_variable cv;
     bool changed = false;
+    bool watch_healthy = true;
 };
 
 // C-style trampoline invoked by the etcd watch goroutine for every event on the
 // watched prefix (PUT / DELETE / WATCH_BROKEN). Any event is treated as "the
 // view may have changed"; the waiter re-reads to find out what actually
-// happened. The watch context outlives every callback because the waiter calls
+// happened. A WATCH_BROKEN (event_type == 2) additionally means the watch
+// stream is gone and must be re-armed before it can deliver again, so the
+// callback flips `watch_healthy` to false to make the waiter re-arm. The watch
+// context outlives every callback because the waiter calls
 // CancelWatchWithPrefix + WaitWatchWithPrefixStopped before it is destroyed.
 void ViewChangeWatchCallback(void* context, const char* /*key*/,
                              size_t /*key_size*/, const char* /*value*/,
-                             size_t /*value_size*/, int /*event_type*/,
+                             size_t /*value_size*/, int event_type,
                              int64_t /*mod_revision*/) {
     auto* state = static_cast<ViewChangeWatchState*>(context);
     if (state == nullptr) {
@@ -55,6 +61,9 @@ void ViewChangeWatchCallback(void* context, const char* /*key*/,
     }
     {
         std::lock_guard<std::mutex> lock(state->mutex);
+        if (event_type == 2) {
+            state->watch_healthy = false;
+        }
         state->changed = true;
     }
     state->cv.notify_all();
@@ -363,6 +372,44 @@ EtcdLeaderCoordinator::WaitForViewChange(
     // same-process clients ever need to watch the same master_view
     // concurrently.
     const auto deadline = std::chrono::steady_clock::now() + timeout;
+
+    // Hoist the per-call watch state and RAII guard OUT of the wait loop:
+    // allocate ONCE per WaitForViewChange call. The previous per-iteration
+    // arming churned Go watch goroutines; when WaitWatchWithPrefixStopped did
+    // not complete in time the guard leaked state (UAF-safe) and a goroutine
+    // lingered -- the ~7-threads/min leak in #3059. Re-arm ONLY on WATCH_BROKEN.
+    auto* state = new ViewChangeWatchState();
+    PrefixWatchGuard guard(master_view_key_, state);
+
+    // Arm the watch ONCE before entering the loop. Arm-before-read: the watch is
+    // established at revision R_watch; the first ReadCurrentView observes
+    // R_read >= R_watch. A change at revision C is caught by C < R_read (the
+    // read) or C >= R_watch (the watch), and the ranges overlap, so a change
+    // between read and watch cannot be missed. start_revision = 0 avoids a
+    // possibly-compacted revision. A long-lived watch keeps this for all later
+    // changes; the gap reopens only on re-arm after WATCH_BROKEN (handled below).
+    bool watching = false;
+    {
+        const auto remaining = std::chrono::duration_cast<std::chrono::milliseconds>(
+            deadline - std::chrono::steady_clock::now());
+        if (remaining > kViewChangeFallbackPollInterval) {
+            // Defensively clear any lingering watch on this key, then arm a new
+            // one. Both calls are no-ops when nothing is registered.
+            EtcdHelper::CancelWatchWithPrefix(master_view_key_.c_str(),
+                                              master_view_key_.size());
+            EtcdHelper::WaitWatchWithPrefixStopped(
+                master_view_key_.c_str(), master_view_key_.size(),
+                kWatchStopTimeoutMs);
+            auto watch_err = EtcdHelper::WatchWithPrefixFromRevision(
+                master_view_key_.c_str(), master_view_key_.size(),
+                /*start_revision=*/0, state, &ViewChangeWatchCallback);
+            if (watch_err == ErrorCode::OK) {
+                watching = true;
+                guard.Arm();
+            }
+        }
+    }
+
     while (true) {
         if (timeout <= std::chrono::milliseconds::zero() ||
             std::chrono::steady_clock::now() >= deadline) {
@@ -377,41 +424,6 @@ EtcdLeaderCoordinator::WaitForViewChange(
             std::chrono::duration_cast<std::chrono::milliseconds>(
                 deadline - std::chrono::steady_clock::now());
 
-        // Arm the watch BEFORE reading the view. The watch is established at
-        // some etcd revision R_watch; the subsequent read observes a revision
-        // R_read >= R_watch. Any change to master_view at revision C is then
-        // caught by exactly one of the two: C < R_read (the read sees it) or
-        // C >= R_watch (the watch delivers it), and the two ranges overlap, so
-        // a change happening between read and watch cannot be missed. The watch
-        // starts from the current revision (start_revision = 0), which also
-        // avoids depending on a possibly-compacted historical revision.
-        //
-        // The watch state is heap-allocated and owned by `guard`. The guard
-        // cancels the watch and waits for the goroutine to exit before
-        // releasing the state in its destructor; if the goroutine fails to stop
-        // in time it leaks the state instead of freeing it, so an in-flight
-        // callback can never reference freed memory (see PrefixWatchGuard).
-        auto* state = new ViewChangeWatchState();
-        PrefixWatchGuard guard(master_view_key_, state);
-
-        bool watching = false;
-        if (remaining > kViewChangeFallbackPollInterval) {
-            // Defensively clear any lingering watch on this key, then arm a new
-            // one. Both calls are no-ops when nothing is registered.
-            EtcdHelper::CancelWatchWithPrefix(master_view_key_.c_str(),
-                                              master_view_key_.size());
-            EtcdHelper::WaitWatchWithPrefixStopped(master_view_key_.c_str(),
-                                                   master_view_key_.size(),
-                                                   kWatchStopTimeoutMs);
-            auto watch_err = EtcdHelper::WatchWithPrefixFromRevision(
-                master_view_key_.c_str(), master_view_key_.size(),
-                /*start_revision=*/0, state, &ViewChangeWatchCallback);
-            if (watch_err == ErrorCode::OK) {
-                watching = true;
-                guard.Arm();
-            }
-        }
-
         auto current_view = ReadCurrentView();
         if (!current_view) {
             return tl::make_unexpected(current_view.error());
@@ -424,6 +436,56 @@ EtcdLeaderCoordinator::WaitForViewChange(
             };
         }
 
+        // WATCH_BROKEN delivered: re-arm AND re-read so the union (watch from
+        // R_rearm) ∪ (read at R_read >= R_rearm) covers the broken window,
+        // preserving the arm-before-read invariant above.
+        bool watch_broken;
+        {
+            std::lock_guard<std::mutex> lock(state->mutex);
+            watch_broken = !state->watch_healthy;
+        }
+        if (watch_broken) {
+            watching = false;
+            if (remaining > kViewChangeFallbackPollInterval) {
+                EtcdHelper::CancelWatchWithPrefix(master_view_key_.c_str(),
+                                                  master_view_key_.size());
+                EtcdHelper::WaitWatchWithPrefixStopped(
+                    master_view_key_.c_str(), master_view_key_.size(),
+                    kWatchStopTimeoutMs);
+                auto watch_err = EtcdHelper::WatchWithPrefixFromRevision(
+                    master_view_key_.c_str(), master_view_key_.size(),
+                    /*start_revision=*/0, state, &ViewChangeWatchCallback);
+                if (watch_err == ErrorCode::OK) {
+                    watching = true;
+                    guard.Arm();
+                }
+            }
+            // Re-read so a change in the broken window is observed by the read.
+            current_view = ReadCurrentView();
+            if (!current_view) {
+                return tl::make_unexpected(current_view.error());
+            }
+            if (!IsSameViewVersion(current_view.value(), known_version)) {
+                return ViewChangeResult{
+                    .changed = true,
+                    .timed_out = false,
+                    .current_view = current_view.value(),
+                };
+            }
+            {
+                std::lock_guard<std::mutex> lock(state->mutex);
+                state->watch_healthy = true;
+                state->changed = false;
+            }
+            if (!watching) {
+                // Re-arm failed (RPC failed, or too little time left): fall
+                // back to a short poll so a change is still picked up.
+                std::this_thread::sleep_for(
+                    std::min(kViewChangeFallbackPollInterval, remaining));
+            }
+            continue;
+        }
+
         if (!watching) {
             // Could not arm a watch (RPC failed, or too little time left).
             // Fall back to a short poll so a change is still picked up.
@@ -432,11 +494,18 @@ EtcdLeaderCoordinator::WaitForViewChange(
             continue;
         }
 
-        // Block until the watch reports an event or the caller's deadline
-        // elapses. Either way we loop and re-read: an event tells us the view
-        // changed (re-read returns it), a timeout falls through to the deadline
-        // check above and returns timed_out.
+        // The watch is long-lived, so `changed` is not implicitly reset each
+        // iteration. If a watch event is pending but the loop-top read saw no
+        // view change (e.g. a sibling-key PUT under the prefix), drain the
+        // stale flag and re-loop: the next read runs at a >= revision and
+        // catches any real change that arrived during the read, while the
+        // long-lived watch still delivers every later change. Unlike
+        // clear-then-wait this drops no event that arrived mid-read.
         std::unique_lock<std::mutex> lock(state->mutex);
+        if (state->changed) {
+            state->changed = false;
+            continue;
+        }
         state->cv.wait_for(lock, remaining,
                            [state]() { return state->changed; });
     }

--- a/mooncake-store/tests/ha/leadership/high_availability_test.cpp
+++ b/mooncake-store/tests/ha/leadership/high_availability_test.cpp
@@ -432,6 +432,63 @@ TEST_F(HighAvailabilityTest, WaitForViewChangeReturnsCurrentViewImmediately) {
     ASSERT_EQ(ErrorCode::OK, coordinator->ReleaseLeadership(session));
 }
 
+// Regression guard for the steady-state watch-churn fix (#3059): WaitForViewChange
+// must arm at most one prefix watch per call (not one per loop iteration) and
+// tear it down cleanly on return, so repeated calls on a stable leader do not
+// accumulate watch state or violate the single-watcher-per-prefix limitation.
+// After a sequence of stable-leader timeouts, a real view change must still be
+// detected promptly by the watch -- proving the single per-call watch is
+// functional and the prefix registration is clean.
+//
+// The WATCH_BROKEN -> re-arm path (event_type == 2) is exercised on the
+// project's Linux CI via an etcd-client-reset integration scenario; this
+// public-API test guards the once-per-call arming/teardown flow that the fix
+// reshaped.
+TEST_F(HighAvailabilityTest,
+       WaitForViewChangeRepeatedStableCallsDoNotBreakChangeDetection) {
+    if (auto skip_reason = GetEtcdSkipReason(); skip_reason.has_value()) {
+        GTEST_SKIP() << *skip_reason;
+    }
+
+    auto coordinator = CreateEtcdCoordinatorOrNull(FLAGS_etcd_endpoints);
+    ASSERT_NE(coordinator, nullptr);
+
+    auto acquire = coordinator->TryAcquireLeadership("0.0.0.0:2222");
+    ASSERT_TRUE(acquire.has_value());
+    ASSERT_EQ(ha::AcquireLeadershipStatus::ACQUIRED, acquire->status);
+    ASSERT_TRUE(acquire->session.has_value());
+    const auto session = *acquire->session;
+
+    auto renew = coordinator->RenewLeadership(session);
+    ASSERT_TRUE(renew.has_value());
+    ASSERT_TRUE(renew.value());
+
+    // Repeated WaitForViewChange calls on a stable leader must each time out
+    // cleanly. Each call arms a single prefix watch and tears it down on
+    // return; if the hoisted-state refactor regressed (watch not armed, not
+    // torn down, or registration collided), these would error, hang, or miss.
+    for (int i = 0; i < 6; ++i) {
+        auto result = coordinator->WaitForViewChange(
+            session.view.view_version, std::chrono::milliseconds(400));
+        ASSERT_TRUE(result.has_value());
+        EXPECT_FALSE(result->changed);
+        EXPECT_TRUE(result->timed_out);
+    }
+
+    // After the repeated calls, the prefix-watch registration must be clean: a
+    // real view change is still detected promptly by the watch, not the
+    // timeout.
+    ASSERT_EQ(ErrorCode::OK, coordinator->ReleaseLeadership(session));
+    const auto start = std::chrono::steady_clock::now();
+    auto changed = coordinator->WaitForViewChange(
+        session.view.view_version, std::chrono::seconds(3));
+    const auto elapsed = std::chrono::steady_clock::now() - start;
+    ASSERT_TRUE(changed.has_value());
+    EXPECT_TRUE(changed->changed);
+    EXPECT_FALSE(changed->current_view.has_value());
+    EXPECT_LT(elapsed, std::chrono::seconds(2));
+}
+
 TEST_F(HighAvailabilityTest, LeadershipMonitorReportsKeepAliveLoss) {
     if (auto skip_reason = GetEtcdSkipReason(); skip_reason.has_value()) {
         GTEST_SKIP() << *skip_reason;

--- a/mooncake-store/tests/ha/leadership/high_availability_test.cpp
+++ b/mooncake-store/tests/ha/leadership/high_availability_test.cpp
@@ -437,13 +437,16 @@ TEST_F(HighAvailabilityTest, WaitForViewChangeReturnsCurrentViewImmediately) {
 // tear it down cleanly on return, so repeated calls on a stable leader do not
 // accumulate watch state or violate the single-watcher-per-prefix limitation.
 // After a sequence of stable-leader timeouts, a real view change must still be
-// detected promptly by the watch -- proving the single per-call watch is
-// functional and the prefix registration is clean.
-//
-// The WATCH_BROKEN -> re-arm path (event_type == 2) is exercised on the
-// project's Linux CI via an etcd-client-reset integration scenario; this
-// public-API test guards the once-per-call arming/teardown flow that the fix
-// reshaped.
+// detected by the long-lived watch. The final leg releases leadership from a
+// concurrent thread while WaitForViewChange is blocked on the watch (not
+// before it, which the synchronous loop-top read would catch regardless of
+// whether the watch is armed), so the change is delivered as a watch DELETE
+// event. The detection latency is then asserted strictly below
+// kViewChangeFallbackPollInterval (200ms): a poll-only regression (watch never
+// armed) would be stranded in a 200ms poll sleep and could not reliably meet
+// the bound, while the event-driven watch delivers in tens of ms. See
+// WaitForViewChangeRearmsAndStillDetectsAfterWatchBroken for the WATCH_BROKEN
+// -> re-arm path.
 TEST_F(HighAvailabilityTest,
        WaitForViewChangeRepeatedStableCallsDoNotBreakChangeDetection) {
     if (auto skip_reason = GetEtcdSkipReason(); skip_reason.has_value()) {
@@ -475,18 +478,112 @@ TEST_F(HighAvailabilityTest,
         EXPECT_TRUE(result->timed_out);
     }
 
-    // After the repeated calls, the prefix-watch registration must be clean: a
-    // real view change is still detected promptly by the watch, not the
-    // timeout.
-    ASSERT_EQ(ErrorCode::OK, coordinator->ReleaseLeadership(session));
-    const auto start = std::chrono::steady_clock::now();
+    // Release leadership from a concurrent thread while the final
+    // WaitForViewChange is blocked on the long-lived prefix watch, so the view
+    // change is delivered as a watch DELETE event -- not caught by the
+    // synchronous loop-top read that a pre-release would make trivial for any
+    // implementation (watch or poll).
+    std::chrono::steady_clock::time_point key_deleted;
+    std::thread releaser([&]() {
+        // Let WaitForViewChange arm the watch and block on the condition var.
+        std::this_thread::sleep_for(std::chrono::milliseconds(300));
+        coordinator->ReleaseLeadership(session);
+        // ReleaseLeadership returns after RevokeLease, which deletes the
+        // master_view key synchronously on the etcd server.
+        key_deleted = std::chrono::steady_clock::now();
+    });
     auto changed = coordinator->WaitForViewChange(
         session.view.view_version, std::chrono::seconds(3));
-    const auto elapsed = std::chrono::steady_clock::now() - start;
+    const auto detected = std::chrono::steady_clock::now();
+    releaser.join();
+
     ASSERT_TRUE(changed.has_value());
     EXPECT_TRUE(changed->changed);
     EXPECT_FALSE(changed->current_view.has_value());
-    EXPECT_LT(elapsed, std::chrono::seconds(2));
+    // Detection latency from key deletion (RevokeLease return) to
+    // WaitForViewChange return. The long-lived watch delivers the DELETE event
+    // in tens of ms; a poll-only regression (watch never armed) would sleep
+    // kViewChangeFallbackPollInterval (200ms) between reads and could not
+    // reliably meet < 150ms. The 150ms bound sits below the 200ms poll floor
+    // with slack for CI jitter on the watch-event delivery path.
+    EXPECT_LT(detected - key_deleted, std::chrono::milliseconds(150));
+}
+
+// Coordinator-level guard for the WATCH_BROKEN -> re-arm + re-read path in
+// WaitForViewChange (the `if (watch_broken)` block in the wait loop): while
+// WaitForViewChange is blocked on the long-lived prefix watch, reset the etcd
+// store client to force a WATCH_BROKEN (event_type == 2). The Go wrapper's
+// cancelAllStorePrefixWatches marks the watch broken before cancelling its
+// context, so the watch goroutine delivers exactly one WATCH_BROKEN callback
+// (the same mechanism as EtcdStoreClientResetTriggersPrefixWatchBrokenAnd
+// Reconnect, but driven through WaitForViewChange's own watch). The
+// coordinator must re-arm the watch and re-read so a subsequent view change
+// is still detected before the deadline -- proving the re-arm path does not
+// drop the watch, deadlock, or crash. (The reset also errors out the
+// keepalive goroutine; the lease remains valid for
+// DEFAULT_MASTER_VIEW_LEASE_TTL_SEC=5s, enough headroom for the explicit
+// ReleaseLeadership below.)
+TEST_F(HighAvailabilityTest, WaitForViewChangeRearmsAndStillDetectsAfterWatchBroken) {
+    if (auto skip_reason = GetEtcdSkipReason(); skip_reason.has_value()) {
+        GTEST_SKIP() << *skip_reason;
+    }
+
+    auto coordinator = CreateEtcdCoordinatorOrNull(FLAGS_etcd_endpoints);
+    ASSERT_NE(coordinator, nullptr);
+
+    auto acquire = coordinator->TryAcquireLeadership("0.0.0.0:1111");
+    ASSERT_TRUE(acquire.has_value());
+    ASSERT_EQ(ha::AcquireLeadershipStatus::ACQUIRED, acquire->status);
+    ASSERT_TRUE(acquire->session.has_value());
+    const auto session = *acquire->session;
+
+    auto renew = coordinator->RenewLeadership(session);
+    ASSERT_TRUE(renew.has_value());
+    ASSERT_TRUE(renew.value());
+
+    // Run WaitForViewChange on a thread with a long timeout so it arms the
+    // long-lived prefix watch and blocks on it. A flag carries the outcome
+    // back across the thread boundary (read after join, which synchronizes).
+    bool view_changed = false;
+    std::thread waiter([&]() {
+        auto result = coordinator->WaitForViewChange(
+            session.view.view_version, std::chrono::seconds(15));
+        view_changed = result.has_value() && result->changed;
+    });
+
+    // Let WaitForViewChange arm the watch and block. The watch is armed
+    // before the loop-top read; give it time to establish server-side (matches
+    // the 500ms settle used by the wrapper-level prefix-watch tests).
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+    // Break the watch by resetting the etcd store client. The Go wrapper
+    // delivers WATCH_BROKEN (event_type == 2) to the registered callback,
+    // which flips watch_healthy=false and wakes WaitForViewChange to re-arm.
+    ASSERT_EQ(ErrorCode::OK,
+              EtcdHelper::ResetEtcdStoreClient(FLAGS_etcd_endpoints));
+
+    // Let the coordinator process WATCH_BROKEN, re-arm the watch, re-read
+    // (view unchanged), reset the flags, and block again on the freshly
+    // re-armed watch. The settle window covers WATCH_BROKEN delivery +
+    // WaitWatchWithPrefixStopped + the new watch's server confirmation.
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+
+    // Now make a real view change: revoke the lease, deleting the master_view
+    // key. The re-armed watch must deliver the DELETE event so WaitForViewChange
+    // returns promptly with changed=true (not via the 15s deadline).
+    const auto change_start = std::chrono::steady_clock::now();
+    ASSERT_EQ(ErrorCode::OK, coordinator->ReleaseLeadership(session));
+    waiter.join();
+    const auto elapsed = std::chrono::steady_clock::now() - change_start;
+
+    EXPECT_TRUE(view_changed)
+        << "WaitForViewChange did not detect the view change after re-arm; "
+           "the WATCH_BROKEN -> re-arm path may have dropped the watch";
+    // Detected well before the 15s deadline. A broken re-arm that left the
+    // watch disarmed would still detect via the 200ms poll fallback within
+    // ~200ms; a path that dropped the watch AND skipped the poll would hit the
+    // 15s deadline. The bound proves neither hang nor crash occurred.
+    EXPECT_LT(elapsed, std::chrono::seconds(3));
 }
 
 TEST_F(HighAvailabilityTest, LeadershipMonitorReportsKeepAliveLoss) {

--- a/mooncake-store/tests/ha/leadership/high_availability_test.cpp
+++ b/mooncake-store/tests/ha/leadership/high_availability_test.cpp
@@ -432,19 +432,20 @@ TEST_F(HighAvailabilityTest, WaitForViewChangeReturnsCurrentViewImmediately) {
     ASSERT_EQ(ErrorCode::OK, coordinator->ReleaseLeadership(session));
 }
 
-// Regression guard for the steady-state watch-churn fix (#3059): WaitForViewChange
-// must arm at most one prefix watch per call (not one per loop iteration) and
-// tear it down cleanly on return, so repeated calls on a stable leader do not
-// accumulate watch state or violate the single-watcher-per-prefix limitation.
-// After a sequence of stable-leader timeouts, a real view change must still be
-// detected by the long-lived watch. The final leg releases leadership from a
-// concurrent thread while WaitForViewChange is blocked on the watch (not
-// before it, which the synchronous loop-top read would catch regardless of
-// whether the watch is armed), so the change is delivered as a watch DELETE
-// event. The detection latency is then asserted strictly below
-// kViewChangeFallbackPollInterval (200ms): a poll-only regression (watch never
-// armed) would be stranded in a 200ms poll sleep and could not reliably meet
-// the bound, while the event-driven watch delivers in tens of ms. See
+// Regression guard for the steady-state watch-churn fix (#3059):
+// WaitForViewChange must arm at most one prefix watch per call (not one per
+// loop iteration) and tear it down cleanly on return, so repeated calls on a
+// stable leader do not accumulate watch state or violate the
+// single-watcher-per-prefix limitation. After a sequence of stable-leader
+// timeouts, a real view change must still be detected by the long-lived watch.
+// The final leg releases leadership from a concurrent thread while
+// WaitForViewChange is blocked on the watch (not before it, which the
+// synchronous loop-top read would catch regardless of whether the watch is
+// armed), so the change is delivered as a watch DELETE event. The detection
+// latency is then asserted strictly below kViewChangeFallbackPollInterval
+// (200ms): a poll-only regression (watch never armed) would be stranded in a
+// 200ms poll sleep and could not reliably meet the bound, while the
+// event-driven watch delivers in tens of ms. See
 // WaitForViewChangeRearmsAndStillDetectsAfterWatchBroken for the WATCH_BROKEN
 // -> re-arm path.
 TEST_F(HighAvailabilityTest,
@@ -492,8 +493,8 @@ TEST_F(HighAvailabilityTest,
         // master_view key synchronously on the etcd server.
         key_deleted = std::chrono::steady_clock::now();
     });
-    auto changed = coordinator->WaitForViewChange(
-        session.view.view_version, std::chrono::seconds(3));
+    auto changed = coordinator->WaitForViewChange(session.view.view_version,
+                                                  std::chrono::seconds(3));
     const auto detected = std::chrono::steady_clock::now();
     releaser.join();
 
@@ -523,7 +524,8 @@ TEST_F(HighAvailabilityTest,
 // keepalive goroutine; the lease remains valid for
 // DEFAULT_MASTER_VIEW_LEASE_TTL_SEC=5s, enough headroom for the explicit
 // ReleaseLeadership below.)
-TEST_F(HighAvailabilityTest, WaitForViewChangeRearmsAndStillDetectsAfterWatchBroken) {
+TEST_F(HighAvailabilityTest,
+       WaitForViewChangeRearmsAndStillDetectsAfterWatchBroken) {
     if (auto skip_reason = GetEtcdSkipReason(); skip_reason.has_value()) {
         GTEST_SKIP() << *skip_reason;
     }
@@ -546,8 +548,8 @@ TEST_F(HighAvailabilityTest, WaitForViewChangeRearmsAndStillDetectsAfterWatchBro
     // back across the thread boundary (read after join, which synchronizes).
     bool view_changed = false;
     std::thread waiter([&]() {
-        auto result = coordinator->WaitForViewChange(
-            session.view.view_version, std::chrono::seconds(15));
+        auto result = coordinator->WaitForViewChange(session.view.view_version,
+                                                     std::chrono::seconds(15));
         view_changed = result.has_value() && result->changed;
     });
 
@@ -569,8 +571,9 @@ TEST_F(HighAvailabilityTest, WaitForViewChangeRearmsAndStillDetectsAfterWatchBro
     std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 
     // Now make a real view change: revoke the lease, deleting the master_view
-    // key. The re-armed watch must deliver the DELETE event so WaitForViewChange
-    // returns promptly with changed=true (not via the 15s deadline).
+    // key. The re-armed watch must deliver the DELETE event so
+    // WaitForViewChange returns promptly with changed=true (not via the 15s
+    // deadline).
     const auto change_start = std::chrono::steady_clock::now();
     ASSERT_EQ(ErrorCode::OK, coordinator->ReleaseLeadership(session));
     waiter.join();


### PR DESCRIPTION
## Summary
Fixes #3059 — a steady-state Go goroutine leak in the HA leader-monitor path.

When the store client runs in HA mode (`MOONCAKE_MASTER=etcd://...`),
`LeaderMonitorThreadMain` calls `EtcdLeaderCoordinator::WaitForViewChange`,
which armed a fresh etcd prefix watch **every iteration** of its wait loop.
Under SGLang PD disaggregation load this churns watch goroutines; when
`WaitWatchWithPrefixStopped` did not complete within `kWatchStopTimeoutMs` (5s)
the guard intentionally leaked the C++ state to avoid a use-after-free
(the leak-on-timeout branch in `PrefixWatchGuard::~PrefixWatchGuard`,
`etcd_leader_coordinator.cpp:101-109`) and the goroutine lingered — the
~7-threads/min accumulation reported in #3059.

## Root cause
`mooncake-store/src/ha/leadership/backends/etcd/etcd_leader_coordinator.cpp` —
per-iteration `new ViewChangeWatchState()` + `PrefixWatchGuard` inside the
`while(true)` of `WaitForViewChange`; the watch was armed and torn down on
every loop iteration.

## Fix (call-scoped, no public-signature change)
- Hoist `ViewChangeWatchState` + `PrefixWatchGuard` out of the `while(true)` so
  the watch is allocated **once per `WaitForViewChange` call** and armed **once
  before the loop**.
- Add `watch_healthy` to `ViewChangeWatchState`; extend `ViewChangeWatchCallback`
  to set it `false` on `event_type == 2` (`WATCH_BROKEN`). The Go wrapper already
  delivers `WATCH_BROKEN` (event_type 2 is documented at
  `etcd_oplog_change_notifier.cpp:225`).
- Re-arm **only on `WATCH_BROKEN`**: `CancelWatchWithPrefix` +
  `WaitWatchWithPrefixStopped` + `WatchWithPrefixFromRevision(0)` **and re-read**
  so the union (watch from R_rearm) ∪ (read at R_read ≥ R_rearm) still covers the
  broken window — the same arm-before-read revision algebra preserved by the
  re-arm block (arm the watch at R_rearm, then read at R_read ≥ R_rearm so the
  union covers the gap; see the comment at `etcd_leader_coordinator.cpp:384-390`).
- Drain stale `changed` flag: because the watch is now long-lived, `changed` is no
  longer implicitly reset each iteration. After a loop-top re-read that sees no
  view change, a pending `changed` (e.g. a sibling-key PUT under the prefix) is
  drained and the loop re-reads at a higher revision — this catches any real
  change that arrived during the read and avoids a tight re-read loop, **without**
  dropping an event that arrived mid-read (which a clear-then-wait would do).

The leak-on-timeout UAF policy in `PrefixWatchGuard` (`:88-110`) and the
`!watching` fallback poll are unchanged. No change to the `WaitForViewChange`
public signature; no coordinator-member lifetime state added. This removes the
steady-state per-iteration churn; the residual leak-on-timeout policy is
intentionally unchanged, so a final `WaitWatchWithPrefixStopped` timeout at
call-end can still leak one state+goroutine per call (rare, not steady-state).

## Tests
Adds two tests to `high_availability_test.cpp`:

- `WaitForViewChangeRepeatedStableCallsDoNotBreakChangeDetection` —
  acquires+renews a leader, calls `WaitForViewChange` 6× on a stable leader
  (each times out cleanly with `!changed && timed_out`), then releases
  leadership from a **concurrent thread while the final `WaitForViewChange` is
  blocked** on the long-lived prefix watch (not before it, which the
  synchronous loop-top read would catch regardless of watch-vs-poll). The
  change is therefore delivered as a watch DELETE event, and the test asserts a
  detection latency strictly below `kViewChangeFallbackPollInterval` (200ms): a
  poll-only regression (watch never armed) would be stranded in a 200ms poll
  sleep and could not reliably meet the bound, while the event-driven watch
  delivers in tens of ms. Guards the once-per-call arm/teardown flow reshaped by
  this change.

- `WaitForViewChangeRearmsAndStillDetectsAfterWatchBroken` — covers the
  `WATCH_BROKEN → re-arm + re-read` path (the `if (watch_broken)` block in the
  wait loop) at the coordinator level. While `WaitForViewChange` is blocked on
  the long-lived prefix watch, it resets the etcd store client to force a
  `WATCH_BROKEN` (event_type 2). The Go wrapper's `cancelAllStorePrefixWatches`
  marks the watch broken before cancelling its context, so exactly one
  `WATCH_BROKEN` callback fires — the same mechanism as the existing
  `EtcdStoreClientResetTriggersPrefixWatchBrokenAndReconnect`
  (`high_availability_test.cpp:637`), which proves `WATCH_BROKEN` is delivered
  by the Go wrapper, but driven here through `WaitForViewChange`'s own watch
  rather than a raw `WatchWithPrefixFromRevision` with a null context. After the
  re-arm settle, it releases leadership (deleting the `master_view` key) and
  asserts the re-armed watch still delivers the change before the deadline —
  proving the re-arm path does not drop the watch, deadlock, or crash. The
  coordinator's re-arm reuses the same `ViewChangeWatchState` +
  `WatchWithPrefixFromRevision` primitive as the initial arm, so the only NEW
  logic is the drain + re-arm-on-broken scheduling (covered by the revision-
  algebra comment + the two tests above). The leak itself is a steady-state
  ~7-threads/min observation under load with no deterministic unit repro; a
  coordinator-level etcd-server-restart integration test (needs fixture support
  to stop/restart the external etcd process) is a desirable follow-up.

## Validation
`clang++ -std=c++17 -fsyntax-only` clean against the project headers (third-party
stubs for glog/ylt/gtest on this host). The full `high_availability_test` runs on
the project's Linux CI (this machine cannot build the C++/RDMA/etcd tree).

Closes #3059.