### PR TITLE
[Store] Handle sparse oplog progress on standby

### DIFF
--- a/mooncake-store/include/ha/oplog/oplog_applier.h
+++ b/mooncake-store/include/ha/oplog/oplog_applier.h
@@ -6,6 +6,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -64,6 +65,11 @@ class OpLogApplier {
      */
     uint64_t GetExpectedSequenceId() const;
 
+    bool IsHealthy() const { return healthy_.load(); }
+    uint64_t GetFailedSequenceId() const { return failed_sequence_id_.load(); }
+    int GetFailedOpType() const { return failed_op_type_.load(); }
+    std::string GetFailureReason() const;
+
     /**
      * @brief Recover from a given sequence ID
      * @param last_applied_sequence_id Last applied sequence ID
@@ -75,6 +81,11 @@ class OpLogApplier {
      * @return Number of entries processed
      */
     size_t ProcessPendingEntries();
+
+    // Mark sequence IDs that the store scanned but did not contain. Confirmed
+    // holes can be skipped without waiting for the generic gap timeout.
+    void ConfirmMissingSequenceIds(
+        const std::vector<uint64_t>& missing_sequence_ids);
 
     // Promotion helper:
     // Try to resolve current gaps ONCE (no waiting) by fetching missing/skipped
@@ -95,6 +106,8 @@ class OpLogApplier {
     // Subclasses implement backend-specific operations while reusing the
     // common validation, ordering, gap buffering and timeout-skip machinery.
     virtual bool ApplyCustomOpLogEntry(const OpLogEntry& entry);
+
+    virtual bool IsBestEffortOpLogEntry(const OpLogEntry& entry) const;
 
    private:
     bool ApplyOpLogEntryInternal(const OpLogEntry& entry);
@@ -131,6 +144,8 @@ class OpLogApplier {
      */
     bool RequestMissingOpLog(uint64_t missing_seq_id);
 
+    bool HandleApplyFailure(const OpLogEntry& entry, const char* reason);
+
     MetadataStore* metadata_store_;
 
     // OpLogStore for requesting missing OpLog entries (optional, not owned)
@@ -148,6 +163,8 @@ class OpLogApplier {
     std::map<uint64_t, std::chrono::steady_clock::time_point>
         missing_sequence_ids_;
 
+    std::set<uint64_t> confirmed_missing_sequence_ids_;
+
     // Sequence IDs we chose to skip (gap-timeout). If the late entry arrives:
     // - REMOVE / PUT_REVOKE: delete the key (safe)
     // - PUT_END: discard (do not resurrect potentially stale metadata)
@@ -157,6 +174,11 @@ class OpLogApplier {
     // Next expected global sequence_id. Read frequently from monitoring thread,
     // updated by watch/apply thread. Use atomic to avoid data races.
     std::atomic<uint64_t> expected_sequence_id_{1};
+    std::atomic<bool> healthy_{true};
+    std::atomic<uint64_t> failed_sequence_id_{0};
+    std::atomic<int> failed_op_type_{-1};
+    mutable std::mutex failure_mutex_;
+    std::string failure_reason_;
 
     // Constants for missing entry handling
     // IMPORTANT: request must happen BEFORE skip, otherwise we will never

--- a/mooncake-store/include/ha/oplog/oplog_change_notifier.h
+++ b/mooncake-store/include/ha/oplog/oplog_change_notifier.h
@@ -3,6 +3,7 @@
 
 #include <cstdint>
 #include <functional>
+#include <vector>
 
 #include "ha/oplog/oplog_manager.h"
 #include "types.h"
@@ -22,6 +23,8 @@ namespace mooncake {
 //   (expected_sequence_id_) and handle gaps, duplicates, and late arrivals
 //   independently.
 //
+//   Entry and maintenance callbacks are invoked serially by the notifier.
+//
 // Implementations: EtcdOpLogChangeNotifier (push via Watch),
 //                  PollingOpLogChangeNotifier (poll via ReadOpLogSince)
 class OpLogChangeNotifier {
@@ -30,9 +33,14 @@ class OpLogChangeNotifier {
 
     using EntryCallback = std::function<void(const OpLogEntry& entry)>;
     using ErrorCallback = std::function<void(ErrorCode error)>;
+    // Runs after each polling cycle with sequence IDs confirmed missing by the
+    // store, including cycles with no new entries.
+    using MaintenanceCallback =
+        std::function<void(const std::vector<uint64_t>&)>;
 
     virtual ErrorCode Start(uint64_t start_sequence_id, EntryCallback on_entry,
-                            ErrorCallback on_error) = 0;
+                            ErrorCallback on_error,
+                            MaintenanceCallback on_maintenance = {}) = 0;
     virtual void Stop() = 0;
     virtual bool IsHealthy() const = 0;
 };

--- a/mooncake-store/include/ha/oplog/oplog_replicator.h
+++ b/mooncake-store/include/ha/oplog/oplog_replicator.h
@@ -70,6 +70,9 @@ class OpLogReplicator {
     bool IsHealthy() const;
 
    private:
+    void AdvanceLastProcessedSequenceId(uint64_t sequence_id);
+    void ReportApplyFailureIfNeeded();
+
     void NotifyStateEvent(StandbyEvent event) {
         if (state_callback_) {
             state_callback_(event);
@@ -80,6 +83,7 @@ class OpLogReplicator {
     OpLogApplier* applier_;
     std::atomic<uint64_t> last_processed_sequence_id_{0};
     std::atomic<bool> running_{false};
+    std::atomic<bool> apply_failure_reported_{false};
 
     ReplicatorStateCallback state_callback_;
 };

--- a/mooncake-store/include/ha/oplog/oplog_store.h
+++ b/mooncake-store/include/ha/oplog/oplog_store.h
@@ -12,6 +12,27 @@
 
 namespace mooncake {
 
+struct OpLogReadProgress {
+    uint64_t last_scanned_sequence_id{0};
+};
+
+inline std::vector<uint64_t> FindMissingSequenceIds(
+    uint64_t start_sequence_id, const std::vector<OpLogEntry>& entries,
+    uint64_t last_scanned_sequence_id) {
+    std::vector<uint64_t> missing_sequence_ids;
+    uint64_t expected_sequence_id = start_sequence_id + 1;
+    for (const auto& entry : entries) {
+        while (expected_sequence_id < entry.sequence_id) {
+            missing_sequence_ids.push_back(expected_sequence_id++);
+        }
+        expected_sequence_id = entry.sequence_id + 1;
+    }
+    while (expected_sequence_id <= last_scanned_sequence_id) {
+        missing_sequence_ids.push_back(expected_sequence_id++);
+    }
+    return missing_sequence_ids;
+}
+
 // Normalize and validate cluster_id for OpLog key prefix construction.
 // Strips trailing slashes, then validates the remaining string.
 // Returns true if valid (or empty after normalization), false otherwise.
@@ -36,6 +57,16 @@ class OpLogStore {
     virtual ErrorCode ReadOpLog(uint64_t sequence_id, OpLogEntry& entry) = 0;
     virtual ErrorCode ReadOpLogSince(uint64_t start_sequence_id, size_t limit,
                                      std::vector<OpLogEntry>& entries) = 0;
+    virtual ErrorCode ReadOpLogSinceWithProgress(
+        uint64_t start_sequence_id, size_t limit,
+        std::vector<OpLogEntry>& entries, OpLogReadProgress& progress) {
+        progress.last_scanned_sequence_id = start_sequence_id;
+        ErrorCode err = ReadOpLogSince(start_sequence_id, limit, entries);
+        if (err == ErrorCode::OK && !entries.empty()) {
+            progress.last_scanned_sequence_id = entries.back().sequence_id;
+        }
+        return err;
+    }
 
     // Sequence ID management
     virtual ErrorCode GetLatestSequenceId(uint64_t& sequence_id) = 0;

--- a/mooncake-store/include/ha/oplog/p2p_hot_standby_service.h
+++ b/mooncake-store/include/ha/oplog/p2p_hot_standby_service.h
@@ -32,6 +32,10 @@ struct P2PStandbySyncStatus {
     uint64_t primary_seq_id{0};
     uint64_t lag_entries{0};
     bool is_connected{false};
+    bool apply_healthy{true};
+    uint64_t failed_sequence_id{0};
+    int failed_op_type{-1};
+    std::string failure_reason;
     StandbyState state{StandbyState::STOPPED};
     std::chrono::milliseconds time_in_state{0};
 };
@@ -54,7 +58,10 @@ class P2PHotStandbyService {
 
     ErrorCode Start(uint64_t baseline_sequence_id = 0);
     void Stop();
-    ErrorCode Promote();
+    // TODO(P2P HA): Expose force promotion only through an explicit operator
+    // CLI/RPC that reports the failed sequence/type/reason and requires
+    // confirmation. The supervisor must not enable it automatically.
+    ErrorCode Promote(bool force = false);
 
     P2PStandbySyncStatus GetSyncStatus() const;
     bool IsReadyForPromotion() const;

--- a/mooncake-store/include/ha/oplog/p2p_oplog_applier.h
+++ b/mooncake-store/include/ha/oplog/p2p_oplog_applier.h
@@ -38,6 +38,7 @@ class P2POpLogApplier : public OpLogApplier {
 
    protected:
     bool ApplyCustomOpLogEntry(const OpLogEntry& entry) override;
+    bool IsBestEffortOpLogEntry(const OpLogEntry& entry) const override;
 
    private:
     // Apply individual P2P OpTypes. Return true on success.

--- a/mooncake-store/include/ha/oplog/p2p_oplog_types.h
+++ b/mooncake-store/include/ha/oplog/p2p_oplog_types.h
@@ -26,6 +26,10 @@ constexpr OpType OpType_REMOVE_ALL = static_cast<OpType>(14);
 constexpr OpType OpType_REGISTER_CLIENT = static_cast<OpType>(15);
 constexpr OpType OpType_UNREGISTER_CLIENT = static_cast<OpType>(16);
 
+inline bool IsBestEffortP2POpLog(OpType type) {
+    return type == OpType_ADD_REPLICA;
+}
+
 // ============================================================================
 // P2P Payload structures for OpLog entries
 // ============================================================================

--- a/mooncake-store/include/ha/oplog/polling_oplog_change_notifier.h
+++ b/mooncake-store/include/ha/oplog/polling_oplog_change_notifier.h
@@ -17,7 +17,8 @@ class PollingOpLogChangeNotifier : public OpLogChangeNotifier {
     ~PollingOpLogChangeNotifier();
 
     ErrorCode Start(uint64_t start_sequence_id, EntryCallback on_entry,
-                    ErrorCallback on_error) override;
+                    ErrorCallback on_error,
+                    MaintenanceCallback on_maintenance = {}) override;
     void Stop() override;
     bool IsHealthy() const override;
 
@@ -29,10 +30,11 @@ class PollingOpLogChangeNotifier : public OpLogChangeNotifier {
 
     EntryCallback on_entry_;
     ErrorCallback on_error_;
+    MaintenanceCallback on_maintenance_;
 
     std::atomic<bool> running_{false};
     std::thread poll_thread_;
-    std::atomic<uint64_t> last_sequence_id_{0};
+    std::atomic<uint64_t> last_scanned_sequence_id_{0};
     std::atomic<bool> healthy_{false};
 
     // For interruptible sleep on Stop()

--- a/mooncake-store/include/ha/oplog/redis_oplog_store.h
+++ b/mooncake-store/include/ha/oplog/redis_oplog_store.h
@@ -24,10 +24,6 @@ namespace mooncake {
 
 enum class OpLogAsyncQueueOverflowMode { REJECT, BYPASS };
 
-inline bool IsBestEffortRedisOpLog(OpType type) {
-    return type == OpType_ADD_REPLICA;
-}
-
 class RedisOpLogStore : public OpLogStore {
    public:
     RedisOpLogStore(const std::string& cluster_id,
@@ -49,6 +45,10 @@ class RedisOpLogStore : public OpLogStore {
     ErrorCode ReadOpLog(uint64_t sequence_id, OpLogEntry& entry) override;
     ErrorCode ReadOpLogSince(uint64_t start_sequence_id, size_t limit,
                              std::vector<OpLogEntry>& entries) override;
+    ErrorCode ReadOpLogSinceWithProgress(uint64_t start_sequence_id,
+                                         size_t limit,
+                                         std::vector<OpLogEntry>& entries,
+                                         OpLogReadProgress& progress) override;
     ErrorCode GetLatestSequenceId(uint64_t& sequence_id) override;
     ErrorCode GetMaxSequenceId(uint64_t& sequence_id) override;
     ErrorCode UpdateLatestSequenceId(uint64_t sequence_id) override;

--- a/mooncake-store/include/standby_state_machine.h
+++ b/mooncake-store/include/standby_state_machine.h
@@ -108,9 +108,10 @@ inline const char* StandbyStateToString(StandbyState state) {
  */
 enum class StandbyEvent : uint8_t {
     // User/system actions
-    START,    // Start() called
-    STOP,     // Stop() called
-    PROMOTE,  // Promote() called
+    START,          // Start() called
+    STOP,           // Stop() called
+    PROMOTE,        // Promote() called
+    FORCE_PROMOTE,  // Operator-approved promotion from a degraded standby
 
     // Connection events
     CONNECTED,          // Successfully connected to etcd
@@ -146,6 +147,8 @@ inline const char* StandbyEventToString(StandbyEvent event) {
             return "STOP";
         case StandbyEvent::PROMOTE:
             return "PROMOTE";
+        case StandbyEvent::FORCE_PROMOTE:
+            return "FORCE_PROMOTE";
         case StandbyEvent::CONNECTED:
             return "CONNECTED";
         case StandbyEvent::CONNECTION_FAILED:

--- a/mooncake-store/src/ha/oplog/oplog_applier.cpp
+++ b/mooncake-store/src/ha/oplog/oplog_applier.cpp
@@ -29,13 +29,17 @@ OpLogApplier::OpLogApplier(MetadataStore* metadata_store,
 }
 
 bool OpLogApplier::ApplyOpLogEntry(const OpLogEntry& entry) {
+    if (!healthy_.load()) {
+        return false;
+    }
+
     // Basic DoS protection: validate key/payload sizes before parsing/applying.
     std::string size_reason;
     if (!OpLogManager::ValidateEntrySize(entry, &size_reason)) {
         LOG(ERROR) << "OpLogApplier: entry size rejected, sequence_id="
                    << entry.sequence_id << ", key=" << entry.object_key
                    << ", reason=" << size_reason;
-        return false;
+        return HandleApplyFailure(entry, "entry size rejected");
     }
 
     // Verify checksum to detect data corruption or tampering.
@@ -45,7 +49,7 @@ bool OpLogApplier::ApplyOpLogEntry(const OpLogEntry& entry) {
             << entry.sequence_id << ", key=" << entry.object_key
             << ". Possible data corruption or tampering. Discarding entry.";
         HAMetricManager::instance().inc_oplog_checksum_failures();
-        return false;
+        return HandleApplyFailure(entry, "checksum mismatch");
     }
 
     // Global ordering only.
@@ -124,7 +128,7 @@ bool OpLogApplier::ApplyOpLogEntry(const OpLogEntry& entry) {
                    << static_cast<int>(entry.op_type)
                    << ", sequence_id=" << entry.sequence_id
                    << ", key=" << entry.object_key;
-        return false;
+        return HandleApplyFailure(entry, "operation apply failed");
     }
 
     // Update expected sequence ID
@@ -159,6 +163,51 @@ bool OpLogApplier::ApplyOpLogEntryInternal(const OpLogEntry& entry) {
     }
 }
 
+bool OpLogApplier::IsBestEffortOpLogEntry(const OpLogEntry&) const {
+    return false;
+}
+
+std::string OpLogApplier::GetFailureReason() const {
+    std::lock_guard<std::mutex> lock(failure_mutex_);
+    return failure_reason_;
+}
+
+bool OpLogApplier::HandleApplyFailure(const OpLogEntry& entry,
+                                      const char* reason) {
+    if (IsBestEffortOpLogEntry(entry)) {
+        LOG(ERROR) << "OpLogApplier: skipping best-effort entry after apply "
+                      "failure"
+                   << ", sequence_id=" << entry.sequence_id
+                   << ", op_type=" << static_cast<int>(entry.op_type)
+                   << ", reason=" << reason;
+        const uint64_t expected = expected_sequence_id_.load();
+        if (IsSequenceNewer(entry.sequence_id, expected)) {
+            std::lock_guard<std::mutex> lock(pending_mutex_);
+            confirmed_missing_sequence_ids_.insert(entry.sequence_id);
+            return false;
+        }
+        if (IsSequenceOlder(entry.sequence_id, expected)) {
+            return true;
+        }
+        expected_sequence_id_.store(entry.sequence_id + 1);
+        ProcessPendingEntries();
+        return true;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(failure_mutex_);
+        failure_reason_ = reason;
+    }
+    failed_op_type_.store(static_cast<int>(entry.op_type));
+    failed_sequence_id_.store(entry.sequence_id);
+    healthy_.store(false);
+    LOG(ERROR) << "OpLogApplier: critical apply failure"
+               << ", sequence_id=" << entry.sequence_id
+               << ", op_type=" << static_cast<int>(entry.op_type)
+               << ", reason=" << reason;
+    return false;
+}
+
 size_t OpLogApplier::ApplyOpLogEntries(const std::vector<OpLogEntry>& entries) {
     size_t applied_count = 0;
     for (const auto& entry : entries) {
@@ -180,9 +229,21 @@ void OpLogApplier::Recover(uint64_t last_applied_sequence_id) {
               << expected_sequence_id_.load();
 }
 
+void OpLogApplier::ConfirmMissingSequenceIds(
+    const std::vector<uint64_t>& missing_sequence_ids) {
+    std::lock_guard<std::mutex> lock(pending_mutex_);
+    const uint64_t expected = expected_sequence_id_.load();
+    for (uint64_t sequence_id : missing_sequence_ids) {
+        if (!IsSequenceOlder(sequence_id, expected)) {
+            confirmed_missing_sequence_ids_.insert(sequence_id);
+        }
+    }
+}
+
 size_t OpLogApplier::ProcessPendingEntries() {
-    // TODO(P2P HA): Drive this periodically in production so a final gap can
-    // time out even when no newer OpLog arrives.
+    if (!healthy_.load()) {
+        return 0;
+    }
     // Check for missing sequence IDs, possibly skip after timeout, and/or
     // request them.
     uint64_t missing_seq_to_request = 0;
@@ -191,11 +252,25 @@ size_t OpLogApplier::ProcessPendingEntries() {
         std::lock_guard<std::mutex> lock(pending_mutex_);
         auto now = std::chrono::steady_clock::now();
         for (;;) {
+            const uint64_t expected = expected_sequence_id_.load();
+            auto confirmed_it = confirmed_missing_sequence_ids_.find(expected);
+            if (confirmed_it != confirmed_missing_sequence_ids_.end()) {
+                confirmed_missing_sequence_ids_.erase(confirmed_it);
+                skipped_sequence_ids_[expected] = now;
+                missing_sequence_ids_.erase(expected);
+                expected_sequence_id_.store(expected + 1);
+                skipped_count++;
+                HAMetricManager::instance().inc_oplog_skipped_entries();
+                LOG(WARNING) << "OpLogApplier: skipped confirmed missing entry "
+                                "seq="
+                             << expected;
+                continue;
+            }
+
             if (pending_entries_.empty()) {
                 break;
             }
             const uint64_t first_pending_seq = pending_entries_.begin()->first;
-            const uint64_t expected = expected_sequence_id_.load();
             if (IsSequenceOlderOrEqual(first_pending_seq, expected)) {
                 break;
             }
@@ -277,9 +352,19 @@ size_t OpLogApplier::ProcessPendingEntries() {
 
         // Apply outside lock.
         if (!ApplyOpLogEntryInternal(entry_copy)) {
+            if (IsBestEffortOpLogEntry(entry_copy)) {
+                LOG(ERROR)
+                    << "OpLogApplier: skipping failed best-effort pending entry"
+                    << ", sequence_id=" << entry_copy.sequence_id
+                    << ", op_type=" << static_cast<int>(entry_copy.op_type);
+                expected_sequence_id_.store(entry_copy.sequence_id + 1);
+                processed_count++;
+                continue;
+            }
             LOG(ERROR) << "OpLogApplier: failed to apply pending entry"
                        << ", sequence_id=" << entry_copy.sequence_id
                        << ", op_type=" << static_cast<int>(entry_copy.op_type);
+            HandleApplyFailure(entry_copy, "pending operation apply failed");
             std::lock_guard<std::mutex> lock(pending_mutex_);
             pending_entries_.emplace(entry_copy.sequence_id,
                                      std::move(entry_copy));

--- a/mooncake-store/src/ha/oplog/oplog_replicator.cpp
+++ b/mooncake-store/src/ha/oplog/oplog_replicator.cpp
@@ -30,14 +30,13 @@ bool OpLogReplicator::StartFromSequenceId(uint64_t start_seq_id) {
         return true;
     }
 
+    apply_failure_reported_.store(false);
+
     auto on_entry = [this](const OpLogEntry& entry) {
         if (applier_->ApplyOpLogEntry(entry)) {
-            uint64_t cur = last_processed_sequence_id_.load();
-            while (IsSequenceNewer(entry.sequence_id, cur) &&
-                   !last_processed_sequence_id_.compare_exchange_weak(
-                       cur, entry.sequence_id)) {
-            }
+            AdvanceLastProcessedSequenceId(entry.sequence_id);
         }
+        ReportApplyFailureIfNeeded();
     };
 
     auto on_error = [this](ErrorCode err) {
@@ -46,7 +45,19 @@ bool OpLogReplicator::StartFromSequenceId(uint64_t start_seq_id) {
         NotifyStateEvent(StandbyEvent::WATCH_BROKEN);
     };
 
-    ErrorCode err = notifier_->Start(start_seq_id, on_entry, on_error);
+    auto on_maintenance =
+        [this](const std::vector<uint64_t>& missing_sequences) {
+            applier_->ConfirmMissingSequenceIds(missing_sequences);
+            applier_->ProcessPendingEntries();
+            ReportApplyFailureIfNeeded();
+            const uint64_t expected = applier_->GetExpectedSequenceId();
+            if (expected > 0) {
+                AdvanceLastProcessedSequenceId(expected - 1);
+            }
+        };
+
+    ErrorCode err =
+        notifier_->Start(start_seq_id, on_entry, on_error, on_maintenance);
     if (err != ErrorCode::OK) {
         LOG(ERROR) << "Failed to start OpLogChangeNotifier, error="
                    << static_cast<int>(err);
@@ -69,12 +80,29 @@ void OpLogReplicator::Stop() {
     LOG(INFO) << "OpLogReplicator stopped";
 }
 
+void OpLogReplicator::AdvanceLastProcessedSequenceId(uint64_t sequence_id) {
+    uint64_t current = last_processed_sequence_id_.load();
+    while (IsSequenceNewer(sequence_id, current) &&
+           !last_processed_sequence_id_.compare_exchange_weak(current,
+                                                              sequence_id)) {
+    }
+}
+
+void OpLogReplicator::ReportApplyFailureIfNeeded() {
+    if (applier_->IsHealthy() || apply_failure_reported_.exchange(true)) {
+        return;
+    }
+    LOG(ERROR) << "OpLogReplicator: critical apply failure"
+               << ", sequence_id=" << applier_->GetFailedSequenceId();
+    NotifyStateEvent(StandbyEvent::FATAL_ERROR);
+}
+
 uint64_t OpLogReplicator::GetLastProcessedSequenceId() const {
     return last_processed_sequence_id_.load();
 }
 
 bool OpLogReplicator::IsHealthy() const {
-    return running_.load() && notifier_->IsHealthy();
+    return running_.load() && notifier_->IsHealthy() && applier_->IsHealthy();
 }
 
 }  // namespace mooncake

--- a/mooncake-store/src/ha/oplog/p2p_hot_standby_service.cpp
+++ b/mooncake-store/src/ha/oplog/p2p_hot_standby_service.cpp
@@ -128,15 +128,22 @@ void P2PHotStandbyService::Stop() {
     }
 }
 
-ErrorCode P2PHotStandbyService::Promote() {
+ErrorCode P2PHotStandbyService::Promote(bool force) {
     std::lock_guard<std::mutex> lock(mutex_);
-    if (!IsReadyForPromotion()) {
+    const bool apply_failed =
+        oplog_applier_ != nullptr && !oplog_applier_->IsHealthy();
+    const bool force_apply_failure =
+        force && apply_failed && GetState() == StandbyState::FAILED;
+    if (!IsReadyForPromotion() && !force_apply_failure) {
         LOG(ERROR) << "P2PHotStandbyService: not ready for promotion"
-                   << ", state=" << StandbyStateToString(GetState());
+                   << ", state=" << StandbyStateToString(GetState())
+                   << ", apply_healthy=" << !apply_failed;
         return ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS;
     }
 
-    auto promote_result = state_machine_.ProcessEvent(StandbyEvent::PROMOTE);
+    auto promote_result = state_machine_.ProcessEvent(
+        force_apply_failure ? StandbyEvent::FORCE_PROMOTE
+                            : StandbyEvent::PROMOTE);
     if (!promote_result.allowed) {
         LOG(ERROR) << "P2PHotStandbyService: cannot promote: "
                    << promote_result.reason;
@@ -149,7 +156,18 @@ ErrorCode P2PHotStandbyService::Promote() {
         oplog_replicator_->Stop();
     }
 
-    auto gaps = oplog_applier_->TryResolveGapsOnceForPromotion();
+    if (force_apply_failure) {
+        LOG(ERROR) << "P2PHotStandbyService: forcing promotion with unapplied "
+                      "OpLog entry"
+                   << ", failed_sequence_id="
+                   << oplog_applier_->GetFailedSequenceId()
+                   << ", latest_applied_sequence_id="
+                   << applied_before_catch_up;
+    }
+
+    auto gaps = force_apply_failure
+                    ? OpLogApplier::GapResolveResult{}
+                    : oplog_applier_->TryResolveGapsOnceForPromotion();
     if (gaps.attempted > 0) {
         LOG(INFO) << "P2PHotStandbyService: promotion gap resolve"
                   << ", attempted=" << gaps.attempted
@@ -157,7 +175,9 @@ ErrorCode P2PHotStandbyService::Promote() {
                   << ", applied_deletes=" << gaps.applied_deletes;
     }
 
-    auto err = FinalCatchUpForPromotionLocked(applied_before_catch_up);
+    auto err = force_apply_failure
+                   ? ErrorCode::OK
+                   : FinalCatchUpForPromotionLocked(applied_before_catch_up);
     if (err != ErrorCode::OK) {
         LOG(ERROR) << "P2PHotStandbyService: final catch-up for promotion "
                       "failed"
@@ -207,8 +227,9 @@ ErrorCode P2PHotStandbyService::FinalCatchUpForPromotionLocked(
 
     for (; batch_count < kMaxCatchUpBatches; ++batch_count) {
         std::vector<OpLogEntry> batch;
-        ErrorCode read_err =
-            catch_up_store->ReadOpLogSince(read_from_seq, kBatchSize, batch);
+        OpLogReadProgress progress;
+        ErrorCode read_err = catch_up_store->ReadOpLogSinceWithProgress(
+            read_from_seq, kBatchSize, batch, progress);
         if (read_err != ErrorCode::OK) {
             LOG(WARNING) << "P2PHotStandbyService: final catch-up read failed"
                          << ", from_seq=" << read_from_seq
@@ -216,15 +237,27 @@ ErrorCode P2PHotStandbyService::FinalCatchUpForPromotionLocked(
                          << ". Proceeding with promotion.";
             break;
         }
-        if (batch.empty()) {
-            break;
-        }
 
         // Keep promotion catch-up best-effort, matching the centralized
-        // HotStandbyService availability-first behavior. Complete gap,
-        // out-of-order, and apply-retry hardening is handled by follow-up PRs.
+        // HotStandbyService availability-first behavior. Confirmed sparse
+        // ranges are skipped while existing entries are applied in order.
         total_applied += oplog_applier_->ApplyOpLogEntries(batch);
-        read_from_seq = batch.back().sequence_id;
+        if (!oplog_applier_->IsHealthy()) {
+            LOG(ERROR) << "P2PHotStandbyService: final catch-up apply failed"
+                       << ", failed_sequence_id="
+                       << oplog_applier_->GetFailedSequenceId()
+                       << ", failed_op_type="
+                       << oplog_applier_->GetFailedOpType();
+            return ErrorCode::INTERNAL_ERROR;
+        }
+        oplog_applier_->ConfirmMissingSequenceIds(FindMissingSequenceIds(
+            read_from_seq, batch, progress.last_scanned_sequence_id));
+        oplog_applier_->ProcessPendingEntries();
+
+        if (progress.last_scanned_sequence_id == read_from_seq) {
+            break;
+        }
+        read_from_seq = progress.last_scanned_sequence_id;
     }
 
     if (batch_count >= kMaxCatchUpBatches) {
@@ -247,6 +280,12 @@ P2PStandbySyncStatus P2PHotStandbyService::GetSyncStatus() const {
     status.time_in_state = state_machine_.GetTimeInCurrentState();
     status.is_connected = state_machine_.IsConnected();
     status.applied_seq_id = GetLocalLastAppliedSequenceIdLocked();
+    if (oplog_applier_) {
+        status.apply_healthy = oplog_applier_->IsHealthy();
+        status.failed_sequence_id = oplog_applier_->GetFailedSequenceId();
+        status.failed_op_type = oplog_applier_->GetFailedOpType();
+        status.failure_reason = oplog_applier_->GetFailureReason();
+    }
 
     if (watcher_oplog_store_) {
         uint64_t latest_seq = 0;

--- a/mooncake-store/src/ha/oplog/p2p_oplog_applier.cpp
+++ b/mooncake-store/src/ha/oplog/p2p_oplog_applier.cpp
@@ -36,6 +36,10 @@ bool P2POpLogApplier::ApplyCustomOpLogEntry(const OpLogEntry& entry) {
     return false;
 }
 
+bool P2POpLogApplier::IsBestEffortOpLogEntry(const OpLogEntry& entry) const {
+    return IsBestEffortP2POpLog(entry.op_type);
+}
+
 bool P2POpLogApplier::ApplyAddReplica(const OpLogEntry& entry) {
     AddReplicaPayload payload;
     if (!DeserializeP2PPayload(entry.payload, payload)) {

--- a/mooncake-store/src/ha/oplog/polling_oplog_change_notifier.cpp
+++ b/mooncake-store/src/ha/oplog/polling_oplog_change_notifier.cpp
@@ -10,16 +10,17 @@ PollingOpLogChangeNotifier::PollingOpLogChangeNotifier(OpLogStore* store,
 
 PollingOpLogChangeNotifier::~PollingOpLogChangeNotifier() { Stop(); }
 
-ErrorCode PollingOpLogChangeNotifier::Start(uint64_t start_sequence_id,
-                                            EntryCallback on_entry,
-                                            ErrorCallback on_error) {
+ErrorCode PollingOpLogChangeNotifier::Start(
+    uint64_t start_sequence_id, EntryCallback on_entry, ErrorCallback on_error,
+    MaintenanceCallback on_maintenance) {
     if (running_.load()) {
         return ErrorCode::INTERNAL_ERROR;
     }
 
     on_entry_ = std::move(on_entry);
     on_error_ = std::move(on_error);
-    last_sequence_id_.store(start_sequence_id);
+    on_maintenance_ = std::move(on_maintenance);
+    last_scanned_sequence_id_.store(start_sequence_id);
     running_.store(true);
     healthy_.store(true);
     poll_thread_ = std::thread(&PollingOpLogChangeNotifier::PollLoop, this);
@@ -42,17 +43,27 @@ bool PollingOpLogChangeNotifier::IsHealthy() const {
 
 void PollingOpLogChangeNotifier::PollLoop() {
     while (running_.load()) {
-        uint64_t last_seq = last_sequence_id_.load();
+        uint64_t last_seq = last_scanned_sequence_id_.load();
         std::vector<OpLogEntry> entries;
-        auto err = store_->ReadOpLogSince(last_seq, kPollBatchSize, entries);
+        OpLogReadProgress progress;
+        auto err = store_->ReadOpLogSinceWithProgress(last_seq, kPollBatchSize,
+                                                      entries, progress);
+        std::vector<uint64_t> missing_sequence_ids;
+        if (err == ErrorCode::OK) {
+            missing_sequence_ids = FindMissingSequenceIds(
+                last_seq, entries, progress.last_scanned_sequence_id);
+        }
 
         if (err == ErrorCode::OK && !entries.empty()) {
             for (const auto& entry : entries) {
                 if (!running_.load()) break;
                 on_entry_(entry);
             }
-            last_sequence_id_.store(entries.back().sequence_id);
+            last_scanned_sequence_id_.store(progress.last_scanned_sequence_id);
             healthy_.store(true);
+            if (on_maintenance_) {
+                on_maintenance_(missing_sequence_ids);
+            }
             // Data available — poll again immediately to drain backlog
             continue;
         } else if (err != ErrorCode::OK) {
@@ -60,6 +71,13 @@ void PollingOpLogChangeNotifier::PollLoop() {
                 on_error_(err);
             }
             healthy_.store(false);
+        }
+
+        if (err == ErrorCode::OK) {
+            last_scanned_sequence_id_.store(progress.last_scanned_sequence_id);
+        }
+        if (on_maintenance_) {
+            on_maintenance_(missing_sequence_ids);
         }
 
         // Interruptible sleep: wakes immediately on Stop()

--- a/mooncake-store/src/ha/oplog/redis_oplog_store.cpp
+++ b/mooncake-store/src/ha/oplog/redis_oplog_store.cpp
@@ -329,7 +329,7 @@ void RedisOpLogStore::AsyncWriteLoop(size_t worker_id) {
                 // Mutable PendingWrite state is protected by async_mutex_.
                 std::lock_guard<std::mutex> lock(async_mutex_);
                 attempts = ++pending->attempts;
-                if (IsBestEffortRedisOpLog(pending->entry.op_type) &&
+                if (IsBestEffortP2POpLog(pending->entry.op_type) &&
                     attempts >= best_effort_max_retries_) {
                     dropped_sequences_.insert(pending->entry.sequence_id);
                     inflight_writes_.erase(pending->entry.sequence_id);
@@ -499,8 +499,17 @@ ErrorCode RedisOpLogStore::ReadOpLogUnlocked(uint64_t sequence_id,
 ErrorCode RedisOpLogStore::ReadOpLogSince(uint64_t start_sequence_id,
                                           size_t limit,
                                           std::vector<OpLogEntry>& entries) {
+    OpLogReadProgress progress;
+    return ReadOpLogSinceWithProgress(start_sequence_id, limit, entries,
+                                      progress);
+}
+
+ErrorCode RedisOpLogStore::ReadOpLogSinceWithProgress(
+    uint64_t start_sequence_id, size_t limit, std::vector<OpLogEntry>& entries,
+    OpLogReadProgress& progress) {
     std::lock_guard<std::mutex> lock(mutex_);
     entries.clear();
+    progress.last_scanned_sequence_id = start_sequence_id;
     if (limit == 0) {
         return ErrorCode::OK;
     }
@@ -548,16 +557,18 @@ ErrorCode RedisOpLogStore::ReadOpLogSince(uint64_t start_sequence_id,
     // together with standby snapshot/bootstrap recovery.
     const uint64_t effective_start =
         std::max(start_sequence_id, trimmed_sequence_id);
+    progress.last_scanned_sequence_id = effective_start;
     if (effective_start >= latest_sequence_id) {
         return ErrorCode::OK;
     }
 
     entries.reserve(limit);
     uint64_t next_sequence_id = effective_start + 1;
-    while (next_sequence_id <= latest_sequence_id && entries.size() < limit) {
+    size_t scanned_count = 0;
+    while (next_sequence_id <= latest_sequence_id && scanned_count < limit) {
         const uint64_t remaining = latest_sequence_id - next_sequence_id + 1;
         const size_t batch_size = static_cast<size_t>(std::min<uint64_t>(
-            remaining, static_cast<uint64_t>(limit - entries.size())));
+            remaining, static_cast<uint64_t>(limit - scanned_count)));
         const uint64_t batch_start = next_sequence_id;
 
         for (size_t i = 0; i < batch_size; ++i) {
@@ -620,6 +631,8 @@ ErrorCode RedisOpLogStore::ReadOpLogSince(uint64_t start_sequence_id,
             }
         }
         next_sequence_id += batch_size;
+        scanned_count += batch_size;
+        progress.last_scanned_sequence_id = next_sequence_id - 1;
     }
     return ErrorCode::OK;
 }

--- a/mooncake-store/src/standby_state_machine.cpp
+++ b/mooncake-store/src/standby_state_machine.cpp
@@ -193,6 +193,9 @@ StateTransitionResult StandbyStateMachine::ValidateTransition(
                 // Allow restart from FAILED state
                 result.allowed = true;
                 result.new_state = StandbyState::CONNECTING;
+            } else if (event == StandbyEvent::FORCE_PROMOTE) {
+                result.allowed = true;
+                result.new_state = StandbyState::PROMOTING;
             }
             break;
     }

--- a/mooncake-store/tests/ha/oplog/oplog_replicator_test.cpp
+++ b/mooncake-store/tests/ha/oplog/oplog_replicator_test.cpp
@@ -7,6 +7,7 @@
 #include <chrono>
 #include <memory>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include <xxhash.h>
@@ -16,6 +17,8 @@
 #include "ha/oplog/oplog_change_notifier.h"
 #include "ha/oplog/oplog_manager.h"
 #include "ha/oplog/oplog_serializer.h"
+#include "ha/oplog/polling_oplog_change_notifier.h"
+#include "mock_oplog_store.h"
 #include "types.h"
 
 namespace mooncake::test {
@@ -41,9 +44,11 @@ class MinimalMockMetadataStore : public MetadataStore {
 class MockOpLogChangeNotifier : public OpLogChangeNotifier {
    public:
     ErrorCode Start(uint64_t /*start_seq*/, EntryCallback on_entry,
-                    ErrorCallback on_error) override {
+                    ErrorCallback on_error,
+                    MaintenanceCallback on_maintenance = {}) override {
         on_entry_ = std::move(on_entry);
         on_error_ = std::move(on_error);
+        on_maintenance_ = std::move(on_maintenance);
         healthy_ = true;
         return ErrorCode::OK;
     }
@@ -57,10 +62,14 @@ class MockOpLogChangeNotifier : public OpLogChangeNotifier {
     void InjectError(ErrorCode err) {
         if (on_error_) on_error_(err);
     }
+    void RunMaintenance(const std::vector<uint64_t>& missing_sequences = {}) {
+        if (on_maintenance_) on_maintenance_(missing_sequences);
+    }
 
    private:
     EntryCallback on_entry_;
     ErrorCallback on_error_;
+    MaintenanceCallback on_maintenance_;
     bool healthy_{false};
 };
 
@@ -82,6 +91,23 @@ OpLogEntry MakeEntry(uint64_t seq, OpType type, const std::string& key,
                     : static_cast<uint32_t>(XXH32(key.data(), key.size(), 0));
     return e;
 }
+
+class SparseReadOpLogStore : public MockOpLogStore {
+   public:
+    ErrorCode ReadOpLogSinceWithProgress(uint64_t start_sequence_id,
+                                         size_t /*limit*/,
+                                         std::vector<OpLogEntry>& entries,
+                                         OpLogReadProgress& progress) override {
+        entries.clear();
+        progress.last_scanned_sequence_id = start_sequence_id;
+        if (start_sequence_id == 0) {
+            entries.push_back(MakeEntry(1, OpType::REMOVE, "key1", ""));
+            entries.push_back(MakeEntry(3, OpType::REMOVE, "key3", ""));
+            progress.last_scanned_sequence_id = 4;
+        }
+        return ErrorCode::OK;
+    }
+};
 
 class OpLogReplicatorTest : public ::testing::Test {
    protected:
@@ -160,6 +186,77 @@ TEST_F(OpLogReplicatorTest, InjectError_NotifiesCallback) {
     Notifier().InjectError(ErrorCode::ETCD_OPERATION_ERROR);
 
     EXPECT_TRUE(error_received);
+}
+
+TEST_F(OpLogReplicatorTest, FatalApplyFailureMarksReplicatorUnhealthy) {
+    bool fatal_error_received = false;
+    replicator_->SetStateCallback([&](StandbyEvent event) {
+        if (event == StandbyEvent::FATAL_ERROR) {
+            fatal_error_received = true;
+        }
+    });
+
+    replicator_->StartFromSequenceId(0);
+    Notifier().InjectEntry(
+        MakeEntry(1, static_cast<OpType>(99), "key1", "payload"));
+
+    EXPECT_TRUE(fatal_error_received);
+    EXPECT_FALSE(replicator_->IsHealthy());
+    EXPECT_EQ(0u, replicator_->GetLastProcessedSequenceId());
+    EXPECT_EQ(1u, applier_->GetFailedSequenceId());
+}
+
+TEST_F(OpLogReplicatorTest, MaintenanceProcessesFinalGap) {
+    replicator_->StartFromSequenceId(0);
+
+    Notifier().InjectEntry(MakeEntry(2, OpType::REMOVE, "key2", ""));
+    EXPECT_EQ(0u, replicator_->GetLastProcessedSequenceId());
+    EXPECT_EQ(1u, applier_->GetExpectedSequenceId());
+
+    Notifier().RunMaintenance();
+    std::this_thread::sleep_for(std::chrono::milliseconds(3100));
+    Notifier().RunMaintenance();
+
+    EXPECT_EQ(2u, replicator_->GetLastProcessedSequenceId());
+    EXPECT_EQ(3u, applier_->GetExpectedSequenceId());
+}
+
+TEST_F(OpLogReplicatorTest, ConfirmedGapIsProcessedImmediately) {
+    replicator_->StartFromSequenceId(0);
+
+    Notifier().InjectEntry(MakeEntry(2, OpType::REMOVE, "key2", ""));
+    Notifier().RunMaintenance({1});
+
+    EXPECT_EQ(2u, replicator_->GetLastProcessedSequenceId());
+    EXPECT_EQ(3u, applier_->GetExpectedSequenceId());
+}
+
+TEST(PollingOpLogChangeNotifierTest, ReportsMiddleAndTrailingGaps) {
+    SparseReadOpLogStore store;
+    PollingOpLogChangeNotifier notifier(&store, /*poll_interval_ms=*/10);
+    std::atomic<int> maintenance_count{0};
+    std::atomic<size_t> max_missing_count{0};
+
+    ASSERT_EQ(
+        ErrorCode::OK,
+        notifier.Start(/*start_sequence_id=*/0, [](const OpLogEntry&) {},
+                       [](ErrorCode) {},
+                       [&](const std::vector<uint64_t>& missing) {
+                           maintenance_count.fetch_add(1);
+                           size_t current = max_missing_count.load();
+                           while (current < missing.size() &&
+                                  !max_missing_count.compare_exchange_weak(
+                                      current, missing.size())) {
+                           }
+                       }));
+
+    for (int i = 0; i < 50 && maintenance_count.load() == 0; ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    notifier.Stop();
+
+    EXPECT_GT(maintenance_count.load(), 0);
+    EXPECT_EQ(2u, max_missing_count.load());
 }
 
 // ========== Utility tests ==========

--- a/mooncake-store/tests/ha/oplog/p2p_hot_standby_service_test.cpp
+++ b/mooncake-store/tests/ha/oplog/p2p_hot_standby_service_test.cpp
@@ -11,6 +11,8 @@
 #include <thread>
 #include <variant>
 
+#include <xxhash.h>
+
 #include "ha/oplog/localfs_oplog_store.h"
 #include "p2p_master_service.h"
 #include "p2p_rpc_service.h"
@@ -218,6 +220,64 @@ TEST_F(P2PHotStandbyServiceTest, PromoteFinalCatchUpExportsLateEntry) {
     auto object_it = exported.objects.find("key-late");
     ASSERT_NE(object_it, exported.objects.end());
     EXPECT_EQ(object_it->second.size, 8192);
+}
+
+TEST_F(P2PHotStandbyServiceTest, PromotionFailsOnFinalCatchUpApplyFailure) {
+    LocalFsOpLogStore writer(kClusterId, test_dir_.string(),
+                             /*enable_batch_write=*/true,
+                             /*poll_interval_ms=*/10);
+    ASSERT_EQ(writer.Init(), ErrorCode::OK);
+
+    auto config = MakeStandbyConfig();
+    config.oplog_poll_interval_ms = 10000;
+    P2PHotStandbyService standby(std::move(config));
+    ASSERT_EQ(standby.Start(), ErrorCode::OK);
+
+    OpLogEntry invalid_entry;
+    invalid_entry.sequence_id = 1;
+    invalid_entry.op_type = OpType_REGISTER_CLIENT;
+    invalid_entry.payload = "invalid-payload";
+    invalid_entry.checksum =
+        XXH32(invalid_entry.payload.data(), invalid_entry.payload.size(), 0);
+    ASSERT_EQ(writer.WriteOpLog(invalid_entry, /*sync=*/true), ErrorCode::OK);
+
+    EXPECT_EQ(standby.Promote(), ErrorCode::INTERNAL_ERROR);
+    EXPECT_EQ(standby.GetState(), StandbyState::FAILED);
+    EXPECT_FALSE(standby.GetSyncStatus().apply_healthy);
+}
+
+TEST_F(P2PHotStandbyServiceTest, ForcePromoteAfterApplyFailure) {
+    LocalFsOpLogStore writer(kClusterId, test_dir_.string(),
+                             /*enable_batch_write=*/true,
+                             /*poll_interval_ms=*/10);
+    ASSERT_EQ(writer.Init(), ErrorCode::OK);
+
+    OpLogEntry invalid_entry;
+    invalid_entry.sequence_id = 1;
+    invalid_entry.op_type = OpType_REGISTER_CLIENT;
+    invalid_entry.payload = "invalid-payload";
+    invalid_entry.checksum =
+        XXH32(invalid_entry.payload.data(), invalid_entry.payload.size(), 0);
+    ASSERT_EQ(writer.WriteOpLog(invalid_entry, /*sync=*/true), ErrorCode::OK);
+
+    P2PHotStandbyService standby(MakeStandbyConfig());
+    ASSERT_EQ(standby.Start(), ErrorCode::OK);
+    for (int i = 0; i < 100 && standby.GetState() != StandbyState::FAILED;
+         ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+
+    auto status = standby.GetSyncStatus();
+    ASSERT_EQ(status.state, StandbyState::FAILED);
+    EXPECT_FALSE(status.apply_healthy);
+    EXPECT_EQ(status.failed_sequence_id, 1u);
+    EXPECT_EQ(status.failed_op_type, static_cast<int>(OpType_REGISTER_CLIENT));
+    EXPECT_EQ(status.failure_reason, "operation apply failed");
+    EXPECT_EQ(standby.Promote(), ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS);
+
+    EXPECT_EQ(standby.Promote(/*force=*/true), ErrorCode::OK);
+    EXPECT_EQ(standby.GetState(), StandbyState::PROMOTED);
+    EXPECT_EQ(standby.GetLatestAppliedSequenceId(), 0u);
 }
 
 TEST_F(P2PHotStandbyServiceTest, RestoreExportedMetadataIntoP2PMasterService) {

--- a/mooncake-store/tests/ha/oplog/p2p_oplog_applier_test.cpp
+++ b/mooncake-store/tests/ha/oplog/p2p_oplog_applier_test.cpp
@@ -451,6 +451,35 @@ TEST(P2POpLogApplierTest, UnknownOpTypeReturnsFalse) {
     // Use an OpType value that doesn't exist
     auto entry = MakeEntry(1, static_cast<OpType>(99), "key1", "");
     EXPECT_FALSE(applier.ApplyOpLogEntry(entry));
+    EXPECT_FALSE(applier.IsHealthy());
+    EXPECT_EQ(1u, applier.GetFailedSequenceId());
+    EXPECT_EQ(99, applier.GetFailedOpType());
+    EXPECT_EQ("operation apply failed", applier.GetFailureReason());
+}
+
+TEST(P2POpLogApplierTest, InvalidAddReplicaIsSkippedAsBestEffort) {
+    P2PStandbyMetadataStore store;
+    P2POpLogApplier applier(&store, "test-cluster");
+
+    auto entry = MakeEntry(1, OpType_ADD_REPLICA, "key1", "invalid");
+    EXPECT_TRUE(applier.ApplyOpLogEntry(entry));
+    EXPECT_TRUE(applier.IsHealthy());
+    EXPECT_EQ(2u, applier.GetExpectedSequenceId());
+    EXPECT_EQ(0u, store.GetKeyCount());
+}
+
+TEST(P2POpLogApplierTest, FutureInvalidAddReplicaPreservesOrdering) {
+    P2PStandbyMetadataStore store;
+    P2POpLogApplier applier(&store, "test-cluster");
+
+    auto invalid = MakeEntry(2, OpType_ADD_REPLICA, "key2", "invalid");
+    EXPECT_FALSE(applier.ApplyOpLogEntry(invalid));
+    EXPECT_EQ(1u, applier.GetExpectedSequenceId());
+
+    EXPECT_TRUE(
+        applier.ApplyOpLogEntry(MakeEntry(1, OpType::REMOVE, "key1", "")));
+    EXPECT_EQ(3u, applier.GetExpectedSequenceId());
+    EXPECT_TRUE(applier.IsHealthy());
 }
 
 }  // namespace mooncake::test

--- a/mooncake-store/tests/ha/oplog/redis_oplog_store_test.cpp
+++ b/mooncake-store/tests/ha/oplog/redis_oplog_store_test.cpp
@@ -42,12 +42,12 @@ TEST(RedisOpLogStoreStandaloneTest, EndpointRequiresExplicitPort) {
 }
 
 TEST(RedisOpLogStoreStandaloneTest, OnlyAddReplicaIsBestEffort) {
-    EXPECT_TRUE(IsBestEffortRedisOpLog(OpType_ADD_REPLICA));
-    EXPECT_FALSE(IsBestEffortRedisOpLog(OpType_REMOVE_REPLICA));
-    EXPECT_FALSE(IsBestEffortRedisOpLog(OpType_MOUNT_SEGMENT));
-    EXPECT_FALSE(IsBestEffortRedisOpLog(OpType_UNMOUNT_SEGMENT));
-    EXPECT_FALSE(IsBestEffortRedisOpLog(OpType_REGISTER_CLIENT));
-    EXPECT_FALSE(IsBestEffortRedisOpLog(OpType_UNREGISTER_CLIENT));
+    EXPECT_TRUE(IsBestEffortP2POpLog(OpType_ADD_REPLICA));
+    EXPECT_FALSE(IsBestEffortP2POpLog(OpType_REMOVE_REPLICA));
+    EXPECT_FALSE(IsBestEffortP2POpLog(OpType_MOUNT_SEGMENT));
+    EXPECT_FALSE(IsBestEffortP2POpLog(OpType_UNMOUNT_SEGMENT));
+    EXPECT_FALSE(IsBestEffortP2POpLog(OpType_REGISTER_CLIENT));
+    EXPECT_FALSE(IsBestEffortP2POpLog(OpType_UNREGISTER_CLIENT));
 }
 
 class RedisOpLogStoreTest : public ::testing::Test {
@@ -291,6 +291,47 @@ TEST_F(RedisOpLogStoreTest, BypassOverflowCreatesReadableGap) {
     ASSERT_EQ(ErrorCode::OK, writer->ReadOpLogSince(0, 10, entries));
     ASSERT_EQ(1u, entries.size());
     EXPECT_EQ(2u, entries.front().sequence_id);
+
+    OpLogReadProgress progress;
+    ASSERT_EQ(ErrorCode::OK,
+              writer->ReadOpLogSinceWithProgress(0, 10, entries, progress));
+    ASSERT_EQ(1u, entries.size());
+    EXPECT_EQ(2u, progress.last_scanned_sequence_id);
+}
+
+TEST_F(RedisOpLogStoreTest, SparseReadLimitsScannedSequenceRange) {
+    auto writer = CreateWriter();
+    ASSERT_EQ(ErrorCode::OK, writer->UpdateLatestSequenceId(2500));
+    ASSERT_EQ(ErrorCode::OK, writer->WriteOpLog(MakeEntry(2500), false));
+
+    OpLogEntry stored;
+    for (int i = 0; i < 100; ++i) {
+        if (writer->ReadOpLog(2500, stored) == ErrorCode::OK) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    ASSERT_EQ(2500u, stored.sequence_id);
+
+    std::vector<OpLogEntry> entries;
+    OpLogReadProgress progress;
+    ASSERT_EQ(ErrorCode::OK,
+              writer->ReadOpLogSinceWithProgress(0, 1000, entries, progress));
+    EXPECT_TRUE(entries.empty());
+    EXPECT_EQ(1000u, progress.last_scanned_sequence_id);
+
+    ASSERT_EQ(ErrorCode::OK,
+              writer->ReadOpLogSinceWithProgress(
+                  progress.last_scanned_sequence_id, 1000, entries, progress));
+    EXPECT_TRUE(entries.empty());
+    EXPECT_EQ(2000u, progress.last_scanned_sequence_id);
+
+    ASSERT_EQ(ErrorCode::OK,
+              writer->ReadOpLogSinceWithProgress(
+                  progress.last_scanned_sequence_id, 1000, entries, progress));
+    ASSERT_EQ(1u, entries.size());
+    EXPECT_EQ(2500u, entries.front().sequence_id);
+    EXPECT_EQ(2500u, progress.last_scanned_sequence_id);
 }
 
 TEST_F(RedisOpLogStoreTest, FactoryRejectsInvalidAsyncConfiguration) {

--- a/mooncake-store/tests/ha/oplog/standby_state_machine_test.cpp
+++ b/mooncake-store/tests/ha/oplog/standby_state_machine_test.cpp
@@ -359,6 +359,16 @@ TEST_F(StandbyStateMachineTest, TestFailedToConnecting) {
     EXPECT_EQ(StandbyState::CONNECTING, machine_->GetState());
 }
 
+TEST_F(StandbyStateMachineTest, TestForcePromoteFromFailed) {
+    machine_->ProcessEvent(StandbyEvent::START);
+    machine_->ProcessEvent(StandbyEvent::FATAL_ERROR);
+
+    auto result = machine_->ProcessEvent(StandbyEvent::FORCE_PROMOTE);
+    EXPECT_TRUE(result.allowed);
+    EXPECT_EQ(StandbyState::FAILED, result.old_state);
+    EXPECT_EQ(StandbyState::PROMOTING, result.new_state);
+}
+
 // ========== Promoted State Tests ==========
 
 TEST_F(StandbyStateMachineTest, TestPromotedToStopped) {


### PR DESCRIPTION
## Description

  Improve P2P standby OpLog handling for sparse Redis sequences and Apply failures.

  - Track Redis scan progress independently from returned entries.
  - Infer and immediately skip confirmed OpLog holes.
  - Periodically process final gaps even when no newer entry arrives.
  - Treat `ADD_REPLICA` Apply failures as best-effort while preserving ordering.
  - Mark critical Apply failures as unhealthy and expose failure details.
  - Prevent normal promotion after a critical Apply failure, with an explicit force-promotion path.
  - Ensure final promotion catch-up continues across empty scan windows and rejects critical Apply failures.
  - Add unit tests for sparse reads, confirmed/final gaps, Apply failures, and promotion behavior.

  ## Module

  - [ ] Transfer Engine (`mooncake-transfer-engine`)
  - [ ] Mooncake Store (`mooncake-store`)
  - [ ] Mooncake EP (`mooncake-ep`)
  - [ ] Mooncake PG (`mooncake-pg`)
  - [ ] Integration (`mooncake-integration`)
  - [x] P2P Store (`mooncake-p2p-store`)
  - [ ] Python Wheel (`mooncake-wheel`)
  - [ ] Common (`mooncake-common`)
  - [ ] Mooncake RL (`mooncake-rl`)
  - [ ] CI/CD
  - [ ] Docs
  - [ ] Other

  ## Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor
  - [ ] Breaking change
  - [ ] Documentation update
  - [ ] Performance improvement
  - [ ] Other

  ## How Has This Been Tested?

  **Test commands:**
  ```bash
  docker exec mooncake-dev bash -lc \
    'cmake --build build-redis-oplog \
      --target p2p_oplog_test redis_oplog_store_test -j2'

  docker exec mooncake-dev bash -lc \
    './build-redis-oplog/mooncake-store/tests/p2p_oplog_test'

  docker exec mooncake-dev bash -lc \
    './build-redis-oplog/mooncake-store/tests/redis_oplog_store_test'
```
  Test results:

  - [ ] Unit tests pass
  - [ ] Integration tests pass (if applicable)
  - [ ] Manual testing done (describe below)

  ## Checklist

  - [x] I have performed a self-review of my own code
  - [ ] I have formatted my code using ./scripts/code_format.sh
  - [ ] I have run pre-commit run --all-files and all hooks pass
  - [x] I have updated the documentation (if applicable)
  - [x] I have added tests to prove my changes are effective
  - [ ] For changes >500 LOC: I have filed an RFC issue

  ## AI Assistance Disclosure

  - [ ] No AI tools were used
  - [x] AI tools were used (specify below)

  Codex was used to analyze the implementation, resolve rebase conflicts, identify promotion edge cases, and add regression tests. The changes were reviewed by the human submitter.