### PR TITLE
[Store] Extract tenant quota table from MasterService

### DIFF
--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -84,7 +84,7 @@ class BatchEvictBench;
  * 2. tenant_quota_policy_mutex_
  * 3. snapshot_mutex_
  * 4. metadata_shards_[shard_idx_].mutex
- * 5. tenant_quota_shards_[shard_idx_].mutex
+ * 5. ShardedTenantQuotaTable internal shard mutex
  * 6. segment_mutex_
  *
  * Strict tenant admission and policy mutation paths that need both
@@ -117,8 +117,6 @@ class MasterService {
     bool IsNoFSegmentMountedForTesting(const UUID& segment_id);
     std::optional<uint32_t> GetNoFHeartbeatFailureCountForTesting(
         const UUID& segment_id);
-    std::optional<TenantQuotaSnapshot> GetTenantQuotaSnapshotForTesting(
-        const TenantId& tenant_id) const;
     bool IsTenantQuotaEnabled() const;
     std::vector<TenantQuotaSnapshot> ListTenantQuotaSnapshots() const;
     std::optional<TenantQuotaSnapshot> GetTenantQuotaSnapshot(
@@ -1296,14 +1294,6 @@ class MasterService {
         ObjectMetadata& metadata,
         const std::function<bool(const Replica&)>& pred_fn);
 
-    static constexpr size_t kNumTenantQuotaShards = 1024;
-    struct TenantQuotaShard {
-        mutable std::mutex mutex;
-        std::unordered_map<TenantId, TenantQuotaState, TenantIdHash> tenants
-            GUARDED_BY(mutex);
-    };
-    std::array<TenantQuotaShard, kNumTenantQuotaShards> tenant_quota_shards_;
-
     std::unordered_map<std::string, std::string> object_group_ids_
         GUARDED_BY(group_routing_mutex_);
     mutable std::unordered_set<std::string> groups_needing_lease_refresh_
@@ -1419,7 +1409,6 @@ class MasterService {
 
     size_t getMetadataShardIndex(const TenantId& tenant_id,
                                  const std::string& key) const;
-    size_t getTenantQuotaShardIndex(const TenantId& tenant_id) const;
     std::optional<std::string> GetGroupRoute(const TenantId& tenant_id,
                                              const std::string& key) const;
     void RegisterGroupMember(TenantState& tenant_state,
@@ -1448,8 +1437,6 @@ class MasterService {
                                         const ReplicateConfig& config) const;
     bool ShouldProtectZeroChargeMetadataCreate(
         uint64_t requested_quota_charge) const;
-    uint64_t ComputeTenantQuotaDeficit(const TenantId& tenant_id,
-                                       uint64_t incoming_quota_charge);
     tl::expected<void, ErrorCode> ReserveTenantQuota(const TenantId& tenant_id,
                                                      uint64_t bytes);
     void CommitTenantQuota(const TenantId& tenant_id, uint64_t bytes);
@@ -1457,8 +1444,6 @@ class MasterService {
     void ReleaseTenantQuota(const TenantId& tenant_id, uint64_t bytes);
     void ReleaseTenantQuotaPartial(const TenantId& tenant_id, uint64_t bytes);
     void CommitAdditionalTenantQuota(const TenantId& tenant_id, uint64_t bytes);
-    void AbortReplicationTaskQuota(const TenantId& tenant_id,
-                                   const ReplicationTask& task);
     void IncrementTenantMetadataObjectCount(const TenantId& tenant_id);
     void DecrementTenantMetadataObjectCount(const TenantId& tenant_id);
     void ReleaseCommittedQuotaCharge(ObjectMetadata& metadata, uint64_t bytes);
@@ -1467,7 +1452,6 @@ class MasterService {
     void LoadTenantQuotaPoliciesFromStoreOrThrow();
     void ApplyTenantQuotaPolicies(const TenantQuotaPolicySnapshot& snapshot);
     TenantQuotaPolicySnapshot BuildTenantQuotaPolicySnapshot() const;
-    uint64_t GetTenantQuotaCapacityBytes();
     std::unordered_map<std::string, ObjectMetadata>::iterator EraseMetadata(
         TenantState& tenant_state,
         std::unordered_map<std::string, ObjectMetadata>::iterator it,
@@ -2013,7 +1997,7 @@ class MasterService {
     const std::string tenant_quota_connector_uri_;
     std::unique_ptr<TenantQuotaPolicyStore> tenant_quota_policy_store_;
     mutable std::mutex tenant_quota_policy_mutex_;
-    mutable std::mutex tenant_quota_recompute_mutex_;
+    ShardedTenantQuotaTable<1024> tenant_quota_table_;
 
     // HTTP metadata server pointer for cleanup on client timeout
     // nullptr means cleanup is disabled

--- a/mooncake-store/include/tenant_quota.h
+++ b/mooncake-store/include/tenant_quota.h
@@ -1,9 +1,14 @@
 #pragma once
 
+#include <algorithm>
+#include <array>
+#include <cstddef>
 #include <cstdint>
 #include <map>
+#include <mutex>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "tenant_id.h"
@@ -12,19 +17,8 @@
 
 namespace mooncake {
 
-struct TenantQuotaState {
-    uint64_t requested_quota_bytes = 0;
-    uint64_t effective_quota_bytes = 0;
-    uint64_t used_bytes = 0;
-    uint64_t reserved_bytes = 0;
-    uint64_t committed_count = 0;
-    uint64_t metadata_object_count = 0;
-    bool has_explicit_policy = false;
-    bool over_quota = false;
-};
-
 struct TenantQuotaSnapshot {
-    std::string tenant_id;
+    TenantId tenant_id;
     uint64_t requested_quota_bytes = 0;
     uint64_t effective_quota_bytes = 0;
     uint64_t used_bytes = 0;
@@ -35,48 +29,382 @@ struct TenantQuotaSnapshot {
     bool over_quota = false;
 };
 
-struct TenantQuotaAssignment {
-    TenantId tenant_id;
-    uint64_t effective_quota_bytes = 0;
+struct TenantQuotaUsage {
+    uint64_t used_bytes = 0;
+    uint64_t committed_count = 0;
+    uint64_t metadata_object_count = 0;
 };
+
+using TenantQuotaPolicyMap = std::map<TenantId, uint64_t>;
+using TenantQuotaUsageMap =
+    std::unordered_map<TenantId, TenantQuotaUsage, TenantIdHash>;
 
 enum class TenantQuotaError {
     kQuotaExceeded,
     kInvalidArgument,
     kAccountingMismatch,
+    kTenantNotRegistered,
+    kTenantNotEmpty,
+    kTenantNotFound,
 };
 
 using TenantQuotaResult = tl::expected<void, TenantQuotaError>;
+using TenantQuotaPolicyResult = tl::expected<uint64_t, TenantQuotaError>;
 
-std::vector<TenantQuotaAssignment> BuildEffectiveQuotaAssignments(
-    const std::map<TenantId, TenantQuotaState>& tenants,
-    uint64_t allocatable_capacity_bytes);
+template <size_t NumShards = 1024>
+class ShardedTenantQuotaTable;
 
+// Single-threaded tenant quota state machine. This class owns quota rules and
+// accounting invariants, but deliberately contains no locking or sharding.
 class TenantQuotaTable {
    public:
-    TenantQuotaResult UpsertTenantPolicy(std::string tenant_id,
+    TenantQuotaResult UpsertTenantPolicy(const TenantId& tenant_id,
                                          uint64_t requested_quota_bytes);
-    void EraseTenantPolicy(std::string tenant_id);
+    TenantQuotaPolicyResult DisableTenantPolicyIfEmpty(
+        const TenantId& tenant_id);
+    void ApplyTenantPolicies(const TenantQuotaPolicyMap& policies);
+    TenantQuotaPolicyMap GetTenantPolicies() const;
 
     void RecomputeEffectiveQuotas(uint64_t allocatable_capacity_bytes);
 
+    bool IsTenantRegistered(const TenantId& tenant_id) const;
     std::optional<TenantQuotaSnapshot> GetTenantSnapshot(
-        std::string tenant_id) const;
+        const TenantId& tenant_id) const;
     std::vector<TenantQuotaSnapshot> ListTenantSnapshots() const;
+    uint64_t ComputeDeficit(const TenantId& tenant_id,
+                            uint64_t incoming_bytes) const;
 
-    TenantQuotaResult Reserve(std::string tenant_id, uint64_t bytes);
-    TenantQuotaResult Commit(std::string tenant_id, uint64_t bytes);
-    TenantQuotaResult Abort(std::string tenant_id, uint64_t bytes);
-    TenantQuotaResult Release(std::string tenant_id, uint64_t bytes);
-    TenantQuotaResult ReleasePartial(std::string tenant_id, uint64_t bytes);
+    TenantQuotaResult Reserve(const TenantId& tenant_id, uint64_t bytes);
+    TenantQuotaResult Commit(const TenantId& tenant_id, uint64_t bytes);
+    TenantQuotaResult CommitAdditional(const TenantId& tenant_id,
+                                       uint64_t bytes);
+    TenantQuotaResult Abort(const TenantId& tenant_id, uint64_t bytes);
+    TenantQuotaResult Release(const TenantId& tenant_id, uint64_t bytes);
+    TenantQuotaResult ReleasePartial(const TenantId& tenant_id, uint64_t bytes);
+
+    void IncrementMetadataObjectCount(const TenantId& tenant_id);
+    TenantQuotaResult DecrementMetadataObjectCount(const TenantId& tenant_id);
+    void RebuildUsage(const TenantQuotaUsageMap& usage);
 
    private:
+    template <size_t>
+    friend class ShardedTenantQuotaTable;
+
+    struct TenantQuotaState {
+        uint64_t requested_quota_bytes = 0;
+        uint64_t effective_quota_bytes = 0;
+        uint64_t used_bytes = 0;
+        uint64_t reserved_bytes = 0;
+        uint64_t committed_count = 0;
+        uint64_t metadata_object_count = 0;
+        bool has_explicit_policy = false;
+        bool over_quota = false;
+    };
+
+    using StateMap = std::map<TenantId, TenantQuotaState>;
+
     TenantQuotaState& GetOrCreateState(const TenantId& tenant_id);
     TenantQuotaSnapshot MakeSnapshot(const TenantId& tenant_id,
                                      const TenantQuotaState& state) const;
-    void RefreshOverQuota(TenantQuotaState* state) const;
+    static bool IsLazyEmptyTenant(const TenantQuotaState& state);
+    static void RefreshOverQuota(TenantQuotaState* state);
+    static std::map<TenantId, uint64_t> BuildEffectiveQuotaAssignments(
+        const std::vector<TenantQuotaSnapshot>& tenants,
+        uint64_t allocatable_capacity_bytes);
+    void ApplyEffectiveQuotas(
+        const std::map<TenantId, uint64_t>& effective_quotas);
+    void EraseIfLazyEmpty(StateMap::iterator it);
 
-    std::map<TenantId, TenantQuotaState> tenants_;
+    StateMap tenants_;
 };
+
+// Thread-safe production wrapper around TenantQuotaTable. Per-tenant
+// operations lock only one shard; cross-shard policy, usage, and recompute
+// operations are serialized by recompute_mutex_.
+template <size_t NumShards>
+class ShardedTenantQuotaTable {
+   public:
+    static_assert(NumShards > 0, "tenant quota table needs at least one shard");
+    static constexpr size_t kNumShards = NumShards;
+
+    TenantQuotaResult UpsertTenantPolicy(const TenantId& tenant_id,
+                                         uint64_t requested_quota_bytes,
+                                         uint64_t allocatable_capacity_bytes);
+    TenantQuotaPolicyResult DisableTenantPolicyIfEmpty(
+        const TenantId& tenant_id);
+    void ApplyTenantPolicies(const TenantQuotaPolicyMap& policies,
+                             uint64_t allocatable_capacity_bytes);
+    TenantQuotaPolicyMap GetTenantPolicies() const;
+
+    void RecomputeEffectiveQuotas(uint64_t allocatable_capacity_bytes);
+
+    bool IsTenantRegistered(const TenantId& tenant_id) const;
+    std::optional<TenantQuotaSnapshot> GetTenantSnapshot(
+        const TenantId& tenant_id) const;
+    std::vector<TenantQuotaSnapshot> ListTenantSnapshots() const;
+    uint64_t ComputeDeficit(const TenantId& tenant_id,
+                            uint64_t incoming_bytes) const;
+
+    TenantQuotaResult Reserve(const TenantId& tenant_id, uint64_t bytes);
+    TenantQuotaResult Commit(const TenantId& tenant_id, uint64_t bytes);
+    TenantQuotaResult CommitAdditional(const TenantId& tenant_id,
+                                       uint64_t bytes);
+    TenantQuotaResult Abort(const TenantId& tenant_id, uint64_t bytes);
+    TenantQuotaResult Release(const TenantId& tenant_id, uint64_t bytes);
+    TenantQuotaResult ReleasePartial(const TenantId& tenant_id, uint64_t bytes);
+
+    void IncrementMetadataObjectCount(const TenantId& tenant_id);
+    TenantQuotaResult DecrementMetadataObjectCount(const TenantId& tenant_id);
+    void RebuildUsage(const TenantQuotaUsageMap& usage,
+                      uint64_t allocatable_capacity_bytes);
+
+   private:
+    struct Shard {
+        mutable std::mutex mutex;
+        TenantQuotaTable table;
+    };
+
+    size_t GetShardIndex(const TenantId& tenant_id) const;
+    Shard& GetShard(const TenantId& tenant_id);
+    const Shard& GetShard(const TenantId& tenant_id) const;
+    void RecomputeEffectiveQuotasLocked(uint64_t allocatable_capacity_bytes);
+
+    std::array<Shard, kNumShards> shards_;
+    mutable std::mutex recompute_mutex_;
+};
+
+template <size_t NumShards>
+TenantQuotaResult ShardedTenantQuotaTable<NumShards>::UpsertTenantPolicy(
+    const TenantId& tenant_id, uint64_t requested_quota_bytes,
+    uint64_t allocatable_capacity_bytes) {
+    std::lock_guard<std::mutex> recompute_lock(recompute_mutex_);
+    auto& shard = GetShard(tenant_id);
+    {
+        std::lock_guard<std::mutex> lock(shard.mutex);
+        auto result =
+            shard.table.UpsertTenantPolicy(tenant_id, requested_quota_bytes);
+        if (!result) {
+            return result;
+        }
+    }
+    RecomputeEffectiveQuotasLocked(allocatable_capacity_bytes);
+    return {};
+}
+
+template <size_t NumShards>
+TenantQuotaPolicyResult
+ShardedTenantQuotaTable<NumShards>::DisableTenantPolicyIfEmpty(
+    const TenantId& tenant_id) {
+    std::lock_guard<std::mutex> recompute_lock(recompute_mutex_);
+    auto& shard = GetShard(tenant_id);
+    std::lock_guard<std::mutex> lock(shard.mutex);
+    return shard.table.DisableTenantPolicyIfEmpty(tenant_id);
+}
+
+template <size_t NumShards>
+void ShardedTenantQuotaTable<NumShards>::ApplyTenantPolicies(
+    const TenantQuotaPolicyMap& policies, uint64_t allocatable_capacity_bytes) {
+    std::lock_guard<std::mutex> recompute_lock(recompute_mutex_);
+    std::array<TenantQuotaPolicyMap, kNumShards> grouped_policies;
+    for (const auto& [tenant_id, requested_quota_bytes] : policies) {
+        grouped_policies[GetShardIndex(tenant_id)].emplace(
+            tenant_id, requested_quota_bytes);
+    }
+
+    for (size_t i = 0; i < kNumShards; ++i) {
+        auto& shard = shards_[i];
+        std::lock_guard<std::mutex> lock(shard.mutex);
+        shard.table.ApplyTenantPolicies(grouped_policies[i]);
+    }
+    RecomputeEffectiveQuotasLocked(allocatable_capacity_bytes);
+}
+
+template <size_t NumShards>
+TenantQuotaPolicyMap ShardedTenantQuotaTable<NumShards>::GetTenantPolicies()
+    const {
+    TenantQuotaPolicyMap policies;
+    for (const auto& shard : shards_) {
+        std::lock_guard<std::mutex> lock(shard.mutex);
+        auto shard_policies = shard.table.GetTenantPolicies();
+        policies.insert(shard_policies.begin(), shard_policies.end());
+    }
+    return policies;
+}
+
+template <size_t NumShards>
+void ShardedTenantQuotaTable<NumShards>::RecomputeEffectiveQuotas(
+    uint64_t allocatable_capacity_bytes) {
+    std::lock_guard<std::mutex> recompute_lock(recompute_mutex_);
+    RecomputeEffectiveQuotasLocked(allocatable_capacity_bytes);
+}
+
+template <size_t NumShards>
+bool ShardedTenantQuotaTable<NumShards>::IsTenantRegistered(
+    const TenantId& tenant_id) const {
+    const auto& shard = GetShard(tenant_id);
+    std::lock_guard<std::mutex> lock(shard.mutex);
+    return shard.table.IsTenantRegistered(tenant_id);
+}
+
+template <size_t NumShards>
+std::optional<TenantQuotaSnapshot>
+ShardedTenantQuotaTable<NumShards>::GetTenantSnapshot(
+    const TenantId& tenant_id) const {
+    const auto& shard = GetShard(tenant_id);
+    std::lock_guard<std::mutex> lock(shard.mutex);
+    return shard.table.GetTenantSnapshot(tenant_id);
+}
+
+template <size_t NumShards>
+std::vector<TenantQuotaSnapshot>
+ShardedTenantQuotaTable<NumShards>::ListTenantSnapshots() const {
+    std::vector<TenantQuotaSnapshot> snapshots;
+    for (const auto& shard : shards_) {
+        std::lock_guard<std::mutex> lock(shard.mutex);
+        auto shard_snapshots = shard.table.ListTenantSnapshots();
+        snapshots.insert(snapshots.end(), shard_snapshots.begin(),
+                         shard_snapshots.end());
+    }
+    std::sort(snapshots.begin(), snapshots.end(),
+              [](const auto& lhs, const auto& rhs) {
+                  return lhs.tenant_id < rhs.tenant_id;
+              });
+    return snapshots;
+}
+
+template <size_t NumShards>
+uint64_t ShardedTenantQuotaTable<NumShards>::ComputeDeficit(
+    const TenantId& tenant_id, uint64_t incoming_bytes) const {
+    const auto& shard = GetShard(tenant_id);
+    std::lock_guard<std::mutex> lock(shard.mutex);
+    return shard.table.ComputeDeficit(tenant_id, incoming_bytes);
+}
+
+template <size_t NumShards>
+TenantQuotaResult ShardedTenantQuotaTable<NumShards>::Reserve(
+    const TenantId& tenant_id, uint64_t bytes) {
+    auto& shard = GetShard(tenant_id);
+    std::lock_guard<std::mutex> lock(shard.mutex);
+    return shard.table.Reserve(tenant_id, bytes);
+}
+
+template <size_t NumShards>
+TenantQuotaResult ShardedTenantQuotaTable<NumShards>::Commit(
+    const TenantId& tenant_id, uint64_t bytes) {
+    auto& shard = GetShard(tenant_id);
+    std::lock_guard<std::mutex> lock(shard.mutex);
+    return shard.table.Commit(tenant_id, bytes);
+}
+
+template <size_t NumShards>
+TenantQuotaResult ShardedTenantQuotaTable<NumShards>::CommitAdditional(
+    const TenantId& tenant_id, uint64_t bytes) {
+    auto& shard = GetShard(tenant_id);
+    std::lock_guard<std::mutex> lock(shard.mutex);
+    return shard.table.CommitAdditional(tenant_id, bytes);
+}
+
+template <size_t NumShards>
+TenantQuotaResult ShardedTenantQuotaTable<NumShards>::Abort(
+    const TenantId& tenant_id, uint64_t bytes) {
+    auto& shard = GetShard(tenant_id);
+    std::lock_guard<std::mutex> lock(shard.mutex);
+    return shard.table.Abort(tenant_id, bytes);
+}
+
+template <size_t NumShards>
+TenantQuotaResult ShardedTenantQuotaTable<NumShards>::Release(
+    const TenantId& tenant_id, uint64_t bytes) {
+    auto& shard = GetShard(tenant_id);
+    std::lock_guard<std::mutex> lock(shard.mutex);
+    return shard.table.Release(tenant_id, bytes);
+}
+
+template <size_t NumShards>
+TenantQuotaResult ShardedTenantQuotaTable<NumShards>::ReleasePartial(
+    const TenantId& tenant_id, uint64_t bytes) {
+    auto& shard = GetShard(tenant_id);
+    std::lock_guard<std::mutex> lock(shard.mutex);
+    return shard.table.ReleasePartial(tenant_id, bytes);
+}
+
+template <size_t NumShards>
+void ShardedTenantQuotaTable<NumShards>::IncrementMetadataObjectCount(
+    const TenantId& tenant_id) {
+    auto& shard = GetShard(tenant_id);
+    std::lock_guard<std::mutex> lock(shard.mutex);
+    shard.table.IncrementMetadataObjectCount(tenant_id);
+}
+
+template <size_t NumShards>
+TenantQuotaResult
+ShardedTenantQuotaTable<NumShards>::DecrementMetadataObjectCount(
+    const TenantId& tenant_id) {
+    auto& shard = GetShard(tenant_id);
+    std::lock_guard<std::mutex> lock(shard.mutex);
+    return shard.table.DecrementMetadataObjectCount(tenant_id);
+}
+
+template <size_t NumShards>
+void ShardedTenantQuotaTable<NumShards>::RebuildUsage(
+    const TenantQuotaUsageMap& usage, uint64_t allocatable_capacity_bytes) {
+    std::lock_guard<std::mutex> recompute_lock(recompute_mutex_);
+    std::array<TenantQuotaUsageMap, kNumShards> grouped_usage;
+    for (const auto& [tenant_id, tenant_usage] : usage) {
+        grouped_usage[GetShardIndex(tenant_id)].emplace(tenant_id,
+                                                        tenant_usage);
+    }
+
+    for (size_t i = 0; i < kNumShards; ++i) {
+        auto& shard = shards_[i];
+        std::lock_guard<std::mutex> lock(shard.mutex);
+        shard.table.RebuildUsage(grouped_usage[i]);
+    }
+    RecomputeEffectiveQuotasLocked(allocatable_capacity_bytes);
+}
+
+template <size_t NumShards>
+size_t ShardedTenantQuotaTable<NumShards>::GetShardIndex(
+    const TenantId& tenant_id) const {
+    return TenantIdHash{}(tenant_id) % kNumShards;
+}
+
+template <size_t NumShards>
+typename ShardedTenantQuotaTable<NumShards>::Shard&
+ShardedTenantQuotaTable<NumShards>::GetShard(const TenantId& tenant_id) {
+    return shards_[GetShardIndex(tenant_id)];
+}
+
+template <size_t NumShards>
+const typename ShardedTenantQuotaTable<NumShards>::Shard&
+ShardedTenantQuotaTable<NumShards>::GetShard(const TenantId& tenant_id) const {
+    return shards_[GetShardIndex(tenant_id)];
+}
+
+template <size_t NumShards>
+void ShardedTenantQuotaTable<NumShards>::RecomputeEffectiveQuotasLocked(
+    uint64_t allocatable_capacity_bytes) {
+    std::vector<TenantQuotaSnapshot> snapshots;
+    for (const auto& shard : shards_) {
+        std::lock_guard<std::mutex> lock(shard.mutex);
+        auto shard_snapshots = shard.table.ListTenantSnapshots();
+        snapshots.insert(snapshots.end(), shard_snapshots.begin(),
+                         shard_snapshots.end());
+    }
+
+    auto effective_quotas = TenantQuotaTable::BuildEffectiveQuotaAssignments(
+        snapshots, allocatable_capacity_bytes);
+    std::array<std::map<TenantId, uint64_t>, kNumShards> grouped_quotas;
+    for (const auto& [tenant_id, effective_quota_bytes] : effective_quotas) {
+        grouped_quotas[GetShardIndex(tenant_id)].emplace(tenant_id,
+                                                         effective_quota_bytes);
+    }
+
+    for (size_t i = 0; i < kNumShards; ++i) {
+        auto& shard = shards_[i];
+        std::lock_guard<std::mutex> lock(shard.mutex);
+        shard.table.ApplyEffectiveQuotas(grouped_quotas[i]);
+    }
+}
 
 }  // namespace mooncake

--- a/mooncake-store/src/master_admin_service.cpp
+++ b/mooncake-store/src/master_admin_service.cpp
@@ -189,7 +189,7 @@ YLT_REFL(HttpTenantQuotaSnapshot, tenant_id, requested_quota_bytes,
 HttpTenantQuotaSnapshot ToHttpTenantQuotaSnapshot(
     const TenantQuotaSnapshot& snapshot) {
     return HttpTenantQuotaSnapshot{
-        .tenant_id = snapshot.tenant_id,
+        .tenant_id = snapshot.tenant_id.value(),
         .requested_quota_bytes = snapshot.requested_quota_bytes,
         .effective_quota_bytes = snapshot.effective_quota_bytes,
         .used_bytes = snapshot.used_bytes,
@@ -411,7 +411,7 @@ std::string MasterAdminServer::BuildTenantQuotaMetricsText() const {
     for (const auto& snapshot : snapshots) {
         requested_sum += snapshot.requested_quota_bytes;
         effective_sum += snapshot.effective_quota_bytes;
-        const auto tenant = EscapePrometheusLabel(snapshot.tenant_id);
+        const auto tenant = EscapePrometheusLabel(snapshot.tenant_id.value());
         tenant_metrics << "mooncake_tenant_quota_requested_bytes{tenant_id=\""
                        << tenant << "\"} " << snapshot.requested_quota_bytes
                        << "\n";

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -114,34 +114,6 @@ bool HasExpectedReplicaAllocation(const ReplicateConfig& config,
            allocated_nof_replicas == config.nof_replica_num;
 }
 
-bool IsLazyEmptyTenantQuotaState(const TenantQuotaState& state) {
-    return !state.has_explicit_policy && state.used_bytes == 0 &&
-           state.reserved_bytes == 0 && state.committed_count == 0 &&
-           state.metadata_object_count == 0;
-}
-
-void RefreshTenantQuotaOverQuota(TenantQuotaState& state) {
-    state.over_quota =
-        (!state.has_explicit_policy && state.metadata_object_count > 0) ||
-        static_cast<unsigned __int128>(state.used_bytes) +
-                state.reserved_bytes >
-            state.effective_quota_bytes;
-}
-
-TenantQuotaSnapshot MakeTenantQuotaSnapshot(const TenantId& tenant_id,
-                                            const TenantQuotaState& state) {
-    return TenantQuotaSnapshot{
-        .tenant_id = tenant_id.value(),
-        .requested_quota_bytes = state.requested_quota_bytes,
-        .effective_quota_bytes = state.effective_quota_bytes,
-        .used_bytes = state.used_bytes,
-        .reserved_bytes = state.reserved_bytes,
-        .committed_count = state.committed_count,
-        .metadata_object_count = state.metadata_object_count,
-        .has_explicit_policy = state.has_explicit_policy,
-        .over_quota = state.over_quota};
-}
-
 tl::expected<std::string, ErrorCode> GetGroupIdForKey(
     const ReplicateConfig& config, size_t key_count, size_t key_index) {
     if (!config.group_ids.has_value()) {
@@ -611,47 +583,19 @@ std::optional<uint32_t> MasterService::GetNoFHeartbeatFailureCountForTesting(
     return it->second.consecutive_failures;
 }
 
-std::optional<TenantQuotaSnapshot>
-MasterService::GetTenantQuotaSnapshotForTesting(
-    const TenantId& tenant_id) const {
-    assert(tenant_id.IsValid());
-    const auto shard_idx = getTenantQuotaShardIndex(tenant_id);
-    const auto& shard = tenant_quota_shards_[shard_idx];
-    std::lock_guard<std::mutex> lock(shard.mutex);
-    auto it = shard.tenants.find(tenant_id);
-    if (it == shard.tenants.end()) {
-        return std::nullopt;
-    }
-    return MakeTenantQuotaSnapshot(tenant_id, it->second);
-}
-
 bool MasterService::IsTenantQuotaEnabled() const {
     return enable_multi_tenants_;
 }
 
 std::vector<TenantQuotaSnapshot> MasterService::ListTenantQuotaSnapshots()
     const {
-    std::vector<TenantQuotaSnapshot> snapshots;
-    for (size_t i = 0; i < kNumTenantQuotaShards; ++i) {
-        const auto& shard = tenant_quota_shards_[i];
-        std::lock_guard<std::mutex> lock(shard.mutex);
-        for (const auto& [tenant_id, state] : shard.tenants) {
-            if (IsLazyEmptyTenantQuotaState(state)) {
-                continue;
-            }
-            snapshots.push_back(MakeTenantQuotaSnapshot(tenant_id, state));
-        }
-    }
-    std::sort(snapshots.begin(), snapshots.end(),
-              [](const auto& lhs, const auto& rhs) {
-                  return lhs.tenant_id < rhs.tenant_id;
-              });
-    return snapshots;
+    return tenant_quota_table_.ListTenantSnapshots();
 }
 
 std::optional<TenantQuotaSnapshot> MasterService::GetTenantQuotaSnapshot(
     const TenantId& tenant_id) const {
-    return GetTenantQuotaSnapshotForTesting(tenant_id);
+    assert(tenant_id.IsValid());
+    return tenant_quota_table_.GetTenantSnapshot(tenant_id);
 }
 
 tl::expected<TenantQuotaSnapshot, ErrorCode>
@@ -698,34 +642,22 @@ MasterService::DeleteTenantQuotaPolicy(const TenantId& tenant_id) {
     const uint64_t requested_quota_bytes = policy_it->second;
 
     auto restore_policy = [&] {
-        auto& shard = tenant_quota_shards_[getTenantQuotaShardIndex(tenant_id)];
-        {
-            std::lock_guard<std::mutex> lock(shard.mutex);
-            auto& state = shard.tenants[tenant_id];
-            state.requested_quota_bytes = requested_quota_bytes;
-            state.has_explicit_policy = true;
-            RefreshTenantQuotaOverQuota(state);
+        auto result = tenant_quota_table_.UpsertTenantPolicy(
+            tenant_id, requested_quota_bytes,
+            GetTenantQuotaAllocatableCapacityBytes());
+        if (!result) {
+            LOG(ERROR) << "failed to restore tenant quota policy tenant="
+                       << tenant_id.value();
         }
-        RecomputeTenantEffectiveQuotas();
     };
 
-    {
-        auto& shard = tenant_quota_shards_[getTenantQuotaShardIndex(tenant_id)];
-        std::lock_guard<std::mutex> lock(shard.mutex);
-        auto quota_it = shard.tenants.find(tenant_id);
-        if (quota_it == shard.tenants.end() ||
-            !quota_it->second.has_explicit_policy) {
-            return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
-        }
-        auto& state = quota_it->second;
-        if (state.used_bytes != 0 || state.reserved_bytes != 0 ||
-            state.committed_count != 0 || state.metadata_object_count != 0) {
-            return tl::make_unexpected(ErrorCode::TENANT_NOT_EMPTY);
-        }
-        state.has_explicit_policy = false;
-        state.requested_quota_bytes = 0;
-        state.effective_quota_bytes = 0;
-        RefreshTenantQuotaOverQuota(state);
+    auto disable_result =
+        tenant_quota_table_.DisableTenantPolicyIfEmpty(tenant_id);
+    if (!disable_result) {
+        return tl::make_unexpected(disable_result.error() ==
+                                           TenantQuotaError::kTenantNotEmpty
+                                       ? ErrorCode::TENANT_NOT_EMPTY
+                                       : ErrorCode::OBJECT_NOT_FOUND);
     }
 
     auto post_mark_snapshot = GetTenantQuotaSnapshot(tenant_id);
@@ -945,11 +877,6 @@ size_t MasterService::getMetadataShardIndex(const TenantId& tenant_id,
     return getShardIndex(it->second);
 }
 
-size_t MasterService::getTenantQuotaShardIndex(
-    const TenantId& tenant_id) const {
-    return TenantIdHash{}(tenant_id) % kNumTenantQuotaShards;
-}
-
 const TenantId& MasterService::ResolveRequestTenantId(
     const TenantId& tenant_id) const {
     assert(tenant_id.IsValid());
@@ -968,11 +895,7 @@ bool MasterService::IsTenantRegistered(const TenantId& tenant_id) const {
     if (!enable_multi_tenants_) {
         return true;
     }
-    const auto& shard =
-        tenant_quota_shards_[getTenantQuotaShardIndex(tenant_id)];
-    std::lock_guard<std::mutex> lock(shard.mutex);
-    auto it = shard.tenants.find(tenant_id);
-    return it != shard.tenants.end() && it->second.has_explicit_policy;
+    return tenant_quota_table_.IsTenantRegistered(tenant_id);
 }
 
 tl::expected<TenantId, ErrorCode> MasterService::ResolveTenantIdForWrite(
@@ -1012,69 +935,23 @@ bool MasterService::TenantHasObjects(const TenantId& tenant_id) const {
 TenantQuotaPolicySnapshot MasterService::BuildTenantQuotaPolicySnapshot()
     const {
     TenantQuotaPolicySnapshot snapshot;
-    for (size_t i = 0; i < kNumTenantQuotaShards; ++i) {
-        const auto& shard = tenant_quota_shards_[i];
-        std::lock_guard<std::mutex> lock(shard.mutex);
-        for (const auto& [tenant_id, state] : shard.tenants) {
-            if (state.has_explicit_policy) {
-                snapshot.tenant_quotas[tenant_id.value()] =
-                    state.requested_quota_bytes;
-            }
-        }
+    for (const auto& [tenant_id, requested_quota_bytes] :
+         tenant_quota_table_.GetTenantPolicies()) {
+        snapshot.tenant_quotas.emplace(tenant_id.value(),
+                                       requested_quota_bytes);
     }
     return snapshot;
 }
 
 void MasterService::ApplyTenantQuotaPolicies(
     const TenantQuotaPolicySnapshot& snapshot) {
-    std::array<std::vector<std::pair<TenantId, uint64_t>>,
-               kNumTenantQuotaShards>
-        grouped_quotas;
+    TenantQuotaPolicyMap policies;
     for (const auto& [tenant_id, requested_quota_bytes] :
          snapshot.tenant_quotas) {
-        TenantId canonical_tenant(tenant_id);
-        grouped_quotas[getTenantQuotaShardIndex(canonical_tenant)].emplace_back(
-            std::move(canonical_tenant), requested_quota_bytes);
+        policies.emplace(TenantId(tenant_id), requested_quota_bytes);
     }
-
-    for (size_t i = 0; i < kNumTenantQuotaShards; ++i) {
-        auto& shard = tenant_quota_shards_[i];
-        std::lock_guard<std::mutex> lock(shard.mutex);
-        for (auto it = shard.tenants.begin(); it != shard.tenants.end();) {
-            const auto policy_it =
-                snapshot.tenant_quotas.find(it->first.value());
-            auto& state = it->second;
-            if (policy_it != snapshot.tenant_quotas.end()) {
-                state.requested_quota_bytes = policy_it->second;
-                state.has_explicit_policy = true;
-                RefreshTenantQuotaOverQuota(state);
-                ++it;
-            } else {
-                state.has_explicit_policy = false;
-                state.requested_quota_bytes = 0;
-                state.effective_quota_bytes = 0;
-                if (IsLazyEmptyTenantQuotaState(state)) {
-                    it = shard.tenants.erase(it);
-                } else {
-                    RefreshTenantQuotaOverQuota(state);
-                    ++it;
-                }
-            }
-        }
-
-        for (const auto& [tenant_id, requested_quota_bytes] :
-             grouped_quotas[i]) {
-            auto [tenant_it, inserted] = shard.tenants.try_emplace(tenant_id);
-            if (!inserted) {
-                continue;
-            }
-            auto& state = tenant_it->second;
-            state.requested_quota_bytes = requested_quota_bytes;
-            state.has_explicit_policy = true;
-            RefreshTenantQuotaOverQuota(state);
-        }
-    }
-    RecomputeTenantEffectiveQuotas();
+    tenant_quota_table_.ApplyTenantPolicies(
+        policies, GetTenantQuotaAllocatableCapacityBytes());
 }
 
 void MasterService::LoadTenantQuotaPoliciesFromStoreOrThrow() {
@@ -1117,32 +994,7 @@ bool MasterService::ShouldProtectZeroChargeMetadataCreate(
     return enable_multi_tenants_ && requested_quota_charge == 0;
 }
 
-uint64_t MasterService::ComputeTenantQuotaDeficit(
-    const TenantId& tenant_id, uint64_t incoming_quota_charge) {
-    uint64_t deficit = incoming_quota_charge;
-    auto& quota_shard =
-        tenant_quota_shards_[getTenantQuotaShardIndex(tenant_id)];
-    std::lock_guard<std::mutex> lock(quota_shard.mutex);
-    auto quota_it = quota_shard.tenants.find(tenant_id);
-    if (quota_it == quota_shard.tenants.end()) {
-        return deficit;
-    }
-
-    const auto& state = quota_it->second;
-    const unsigned __int128 demand =
-        static_cast<unsigned __int128>(state.used_bytes) +
-        state.reserved_bytes + incoming_quota_charge;
-    if (demand <= state.effective_quota_bytes) {
-        return 0;
-    }
-
-    const unsigned __int128 raw_deficit = demand - state.effective_quota_bytes;
-    return raw_deficit > std::numeric_limits<uint64_t>::max()
-               ? std::numeric_limits<uint64_t>::max()
-               : static_cast<uint64_t>(raw_deficit);
-}
-
-uint64_t MasterService::GetTenantQuotaCapacityBytes() {
+uint64_t MasterService::GetTenantQuotaAllocatableCapacityBytes() {
     uint64_t capacity = 0;
     ScopedSegmentAccess segment_access = segment_manager_.getSegmentAccess();
     std::vector<std::pair<Segment, UUID>> segments;
@@ -1158,51 +1010,12 @@ uint64_t MasterService::GetTenantQuotaCapacityBytes() {
     return capacity;
 }
 
-uint64_t MasterService::GetTenantQuotaAllocatableCapacityBytes() {
-    return GetTenantQuotaCapacityBytes();
-}
-
 void MasterService::RecomputeTenantEffectiveQuotas() {
     if (!enable_multi_tenants_) {
         return;
     }
-    std::lock_guard<std::mutex> recompute_lock(tenant_quota_recompute_mutex_);
-    const uint64_t capacity = GetTenantQuotaAllocatableCapacityBytes();
-
-    std::map<TenantId, TenantQuotaState> active_tenants;
-    for (size_t i = 0; i < kNumTenantQuotaShards; ++i) {
-        auto& shard = tenant_quota_shards_[i];
-        std::lock_guard<std::mutex> lock(shard.mutex);
-        for (auto it = shard.tenants.begin(); it != shard.tenants.end();) {
-            const auto& tenant_id = it->first;
-            auto& state = it->second;
-            if (IsLazyEmptyTenantQuotaState(state)) {
-                it = shard.tenants.erase(it);
-                continue;
-            }
-            if (!state.has_explicit_policy) {
-                state.requested_quota_bytes = 0;
-                state.effective_quota_bytes = 0;
-                RefreshTenantQuotaOverQuota(state);
-            }
-            active_tenants.emplace(tenant_id, state);
-            ++it;
-        }
-    }
-
-    for (const auto& assignment :
-         BuildEffectiveQuotaAssignments(active_tenants, capacity)) {
-        auto& shard = tenant_quota_shards_[getTenantQuotaShardIndex(
-            assignment.tenant_id)];
-        std::lock_guard<std::mutex> lock(shard.mutex);
-        auto it = shard.tenants.find(assignment.tenant_id);
-        if (it == shard.tenants.end()) {
-            continue;
-        }
-        auto& state = it->second;
-        state.effective_quota_bytes = assignment.effective_quota_bytes;
-        RefreshTenantQuotaOverQuota(state);
-    }
+    tenant_quota_table_.RecomputeEffectiveQuotas(
+        GetTenantQuotaAllocatableCapacityBytes());
 }
 
 tl::expected<void, ErrorCode> MasterService::ReserveTenantQuota(
@@ -1210,32 +1023,16 @@ tl::expected<void, ErrorCode> MasterService::ReserveTenantQuota(
     if (!enable_multi_tenants_) {
         return {};
     }
-    auto exceeds_effective_quota = [](const TenantQuotaState& state,
-                                      uint64_t additional_bytes) {
-        return static_cast<unsigned __int128>(state.used_bytes) +
-                   state.reserved_bytes + additional_bytes >
-               state.effective_quota_bytes;
-    };
-    auto& shard = tenant_quota_shards_[getTenantQuotaShardIndex(tenant_id)];
-    {
-        std::lock_guard<std::mutex> lock(shard.mutex);
-        auto it = shard.tenants.find(tenant_id);
-        if (it == shard.tenants.end() || !it->second.has_explicit_policy) {
-            return tl::make_unexpected(ErrorCode::TENANT_NOT_REGISTERED);
-        }
-
-        auto& state = it->second;
-        if (bytes == 0) {
-            return {};
-        }
-        if (exceeds_effective_quota(state, bytes)) {
-            return tl::make_unexpected(ErrorCode::TENANT_QUOTA_EXCEEDED);
-        }
-
-        state.reserved_bytes += bytes;
-        RefreshTenantQuotaOverQuota(state);
+    auto result = tenant_quota_table_.Reserve(tenant_id, bytes);
+    if (result) {
         return {};
     }
+    return tl::make_unexpected(
+        result.error() == TenantQuotaError::kTenantNotRegistered
+            ? ErrorCode::TENANT_NOT_REGISTERED
+        : result.error() == TenantQuotaError::kQuotaExceeded
+            ? ErrorCode::TENANT_QUOTA_EXCEEDED
+            : ErrorCode::INTERNAL_ERROR);
 }
 
 void MasterService::CommitTenantQuota(const TenantId& tenant_id,
@@ -1243,30 +1040,10 @@ void MasterService::CommitTenantQuota(const TenantId& tenant_id,
     if (!enable_multi_tenants_ || bytes == 0) {
         return;
     }
-    auto& shard = tenant_quota_shards_[getTenantQuotaShardIndex(tenant_id)];
-    std::lock_guard<std::mutex> lock(shard.mutex);
-    auto it = shard.tenants.find(tenant_id);
-    if (it == shard.tenants.end()) {
+    if (!tenant_quota_table_.Commit(tenant_id, bytes)) {
         LOG(ERROR) << "tenant quota commit mismatch tenant="
-                   << tenant_id.value() << ", bytes=" << bytes
-                   << ", reserved=0";
-        return;
+                   << tenant_id.value() << ", bytes=" << bytes;
     }
-    auto& state = it->second;
-    if (state.reserved_bytes < bytes) {
-        LOG(ERROR) << "tenant quota commit mismatch tenant="
-                   << tenant_id.value() << ", bytes=" << bytes
-                   << ", reserved=" << state.reserved_bytes;
-        return;
-    }
-    state.reserved_bytes -= bytes;
-    if (state.used_bytes > std::numeric_limits<uint64_t>::max() - bytes) {
-        state.used_bytes = std::numeric_limits<uint64_t>::max();
-    } else {
-        state.used_bytes += bytes;
-    }
-    ++state.committed_count;
-    RefreshTenantQuotaOverQuota(state);
 }
 
 void MasterService::AbortTenantQuota(const TenantId& tenant_id,
@@ -1274,34 +1051,9 @@ void MasterService::AbortTenantQuota(const TenantId& tenant_id,
     if (!enable_multi_tenants_ || bytes == 0) {
         return;
     }
-    auto& shard = tenant_quota_shards_[getTenantQuotaShardIndex(tenant_id)];
-    bool recompute_needed = false;
-    {
-        std::lock_guard<std::mutex> lock(shard.mutex);
-        auto it = shard.tenants.find(tenant_id);
-        if (it == shard.tenants.end()) {
-            LOG(ERROR) << "tenant quota abort mismatch tenant="
-                       << tenant_id.value() << ", bytes=" << bytes
-                       << ", reserved=0";
-            return;
-        }
-        auto& state = it->second;
-        if (state.reserved_bytes < bytes) {
-            LOG(ERROR) << "tenant quota abort mismatch tenant="
-                       << tenant_id.value() << ", bytes=" << bytes
-                       << ", reserved=" << state.reserved_bytes;
-            return;
-        }
-        state.reserved_bytes -= bytes;
-        if (IsLazyEmptyTenantQuotaState(state)) {
-            shard.tenants.erase(it);
-            recompute_needed = true;
-        } else {
-            RefreshTenantQuotaOverQuota(state);
-        }
-    }
-    if (recompute_needed) {
-        RecomputeTenantEffectiveQuotas();
+    if (!tenant_quota_table_.Abort(tenant_id, bytes)) {
+        LOG(ERROR) << "tenant quota abort mismatch tenant=" << tenant_id.value()
+                   << ", bytes=" << bytes;
     }
 }
 
@@ -1310,37 +1062,9 @@ void MasterService::ReleaseTenantQuota(const TenantId& tenant_id,
     if (!enable_multi_tenants_ || bytes == 0) {
         return;
     }
-    auto& shard = tenant_quota_shards_[getTenantQuotaShardIndex(tenant_id)];
-    bool recompute_needed = false;
-    {
-        std::lock_guard<std::mutex> lock(shard.mutex);
-        auto it = shard.tenants.find(tenant_id);
-        if (it == shard.tenants.end()) {
-            LOG(ERROR) << "tenant quota release mismatch tenant="
-                       << tenant_id.value() << ", bytes=" << bytes
-                       << ", used=0";
-            return;
-        }
-        auto& state = it->second;
-        if (state.used_bytes < bytes) {
-            LOG(ERROR) << "tenant quota release mismatch tenant="
-                       << tenant_id.value() << ", bytes=" << bytes
-                       << ", used=" << state.used_bytes;
-            return;
-        }
-        state.used_bytes -= bytes;
-        if (state.committed_count > 0) {
-            --state.committed_count;
-        }
-        if (IsLazyEmptyTenantQuotaState(state)) {
-            shard.tenants.erase(it);
-            recompute_needed = true;
-        } else {
-            RefreshTenantQuotaOverQuota(state);
-        }
-    }
-    if (recompute_needed) {
-        RecomputeTenantEffectiveQuotas();
+    if (!tenant_quota_table_.Release(tenant_id, bytes)) {
+        LOG(ERROR) << "tenant quota release mismatch tenant="
+                   << tenant_id.value() << ", bytes=" << bytes;
     }
 }
 
@@ -1349,23 +1073,10 @@ void MasterService::ReleaseTenantQuotaPartial(const TenantId& tenant_id,
     if (!enable_multi_tenants_ || bytes == 0) {
         return;
     }
-    auto& shard = tenant_quota_shards_[getTenantQuotaShardIndex(tenant_id)];
-    std::lock_guard<std::mutex> lock(shard.mutex);
-    auto it = shard.tenants.find(tenant_id);
-    if (it == shard.tenants.end()) {
+    if (!tenant_quota_table_.ReleasePartial(tenant_id, bytes)) {
         LOG(ERROR) << "tenant quota partial release mismatch tenant="
-                   << tenant_id.value() << ", bytes=" << bytes << ", used=0";
-        return;
+                   << tenant_id.value() << ", bytes=" << bytes;
     }
-    auto& state = it->second;
-    if (state.used_bytes < bytes) {
-        LOG(ERROR) << "tenant quota partial release mismatch tenant="
-                   << tenant_id.value() << ", bytes=" << bytes
-                   << ", used=" << state.used_bytes;
-        return;
-    }
-    state.used_bytes -= bytes;
-    RefreshTenantQuotaOverQuota(state);
 }
 
 void MasterService::CommitAdditionalTenantQuota(const TenantId& tenant_id,
@@ -1373,34 +1084,10 @@ void MasterService::CommitAdditionalTenantQuota(const TenantId& tenant_id,
     if (!enable_multi_tenants_ || bytes == 0) {
         return;
     }
-    auto& shard = tenant_quota_shards_[getTenantQuotaShardIndex(tenant_id)];
-    std::lock_guard<std::mutex> lock(shard.mutex);
-    auto it = shard.tenants.find(tenant_id);
-    if (it == shard.tenants.end()) {
+    if (!tenant_quota_table_.CommitAdditional(tenant_id, bytes)) {
         LOG(ERROR) << "tenant quota additional commit mismatch tenant="
-                   << tenant_id.value() << ", bytes=" << bytes
-                   << ", reserved=0";
-        return;
+                   << tenant_id.value() << ", bytes=" << bytes;
     }
-    auto& state = it->second;
-    if (state.reserved_bytes < bytes) {
-        LOG(ERROR) << "tenant quota additional commit mismatch tenant="
-                   << tenant_id.value() << ", bytes=" << bytes
-                   << ", reserved=" << state.reserved_bytes;
-        return;
-    }
-    state.reserved_bytes -= bytes;
-    if (state.used_bytes > std::numeric_limits<uint64_t>::max() - bytes) {
-        state.used_bytes = std::numeric_limits<uint64_t>::max();
-    } else {
-        state.used_bytes += bytes;
-    }
-    RefreshTenantQuotaOverQuota(state);
-}
-
-void MasterService::AbortReplicationTaskQuota(const TenantId& tenant_id,
-                                              const ReplicationTask& task) {
-    AbortTenantQuota(tenant_id, task.reserved_quota_charge_bytes);
 }
 
 void MasterService::IncrementTenantMetadataObjectCount(
@@ -1408,13 +1095,7 @@ void MasterService::IncrementTenantMetadataObjectCount(
     if (!enable_multi_tenants_) {
         return;
     }
-    auto& shard = tenant_quota_shards_[getTenantQuotaShardIndex(tenant_id)];
-    std::lock_guard<std::mutex> lock(shard.mutex);
-    auto& state = shard.tenants[tenant_id];
-    if (state.metadata_object_count < std::numeric_limits<uint64_t>::max()) {
-        ++state.metadata_object_count;
-    }
-    RefreshTenantQuotaOverQuota(state);
+    tenant_quota_table_.IncrementMetadataObjectCount(tenant_id);
 }
 
 void MasterService::DecrementTenantMetadataObjectCount(
@@ -1422,32 +1103,9 @@ void MasterService::DecrementTenantMetadataObjectCount(
     if (!enable_multi_tenants_) {
         return;
     }
-    auto& shard = tenant_quota_shards_[getTenantQuotaShardIndex(tenant_id)];
-    bool recompute_needed = false;
-    {
-        std::lock_guard<std::mutex> lock(shard.mutex);
-        auto it = shard.tenants.find(tenant_id);
-        if (it == shard.tenants.end()) {
-            LOG(WARNING) << "tenant metadata object count decrement mismatch "
-                         << "tenant=" << tenant_id.value();
-            return;
-        }
-        auto& state = it->second;
-        if (state.metadata_object_count > 0) {
-            --state.metadata_object_count;
-        } else {
-            LOG(WARNING) << "tenant metadata object count underflow tenant="
-                         << tenant_id.value();
-        }
-        if (IsLazyEmptyTenantQuotaState(state)) {
-            shard.tenants.erase(it);
-            recompute_needed = true;
-        } else {
-            RefreshTenantQuotaOverQuota(state);
-        }
-    }
-    if (recompute_needed) {
-        RecomputeTenantEffectiveQuotas();
+    if (!tenant_quota_table_.DecrementMetadataObjectCount(tenant_id)) {
+        LOG(WARNING) << "tenant metadata object count decrement mismatch "
+                     << "tenant=" << tenant_id.value();
     }
 }
 
@@ -1471,18 +1129,13 @@ void MasterService::RebuildTenantQuotaUsageFromMetadata() {
         return;
     }
 
-    std::unordered_set<TenantId, TenantIdHash> metadata_tenants;
-    std::unordered_map<TenantId, uint64_t, TenantIdHash> used_by_tenant;
-    std::unordered_map<TenantId, uint64_t, TenantIdHash>
-        committed_count_by_tenant;
-    std::unordered_map<TenantId, uint64_t, TenantIdHash>
-        metadata_count_by_tenant;
+    TenantQuotaUsageMap usage;
     for (size_t i = 0; i < kNumShards; ++i) {
         MetadataShardAccessorRW shard(this, i);
         for (auto& [tenant_id, tenant_state] : shard->tenants) {
-            metadata_tenants.insert(tenant_id);
             for (auto& [_, metadata] : tenant_state.metadata) {
-                metadata_count_by_tenant[tenant_id]++;
+                auto& tenant_usage = usage[tenant_id];
+                ++tenant_usage.metadata_object_count;
                 const uint64_t charge = CompletedMemoryQuotaCharge(metadata);
                 metadata.reserved_quota_charge_bytes = 0;
                 metadata.committed_quota_charge_bytes = charge;
@@ -1490,42 +1143,22 @@ void MasterService::RebuildTenantQuotaUsageFromMetadata() {
                 if (charge == 0) {
                     continue;
                 }
-                used_by_tenant[tenant_id] += charge;
-                committed_count_by_tenant[tenant_id]++;
+                tenant_usage.used_bytes += charge;
+                ++tenant_usage.committed_count;
             }
         }
     }
 
-    for (size_t i = 0; i < kNumTenantQuotaShards; ++i) {
-        auto& shard = tenant_quota_shards_[i];
-        std::lock_guard<std::mutex> lock(shard.mutex);
-        for (auto& [_, state] : shard.tenants) {
-            state.used_bytes = 0;
-            state.reserved_bytes = 0;
-            state.committed_count = 0;
-            state.metadata_object_count = 0;
-        }
-    }
-    for (const auto& tenant_id : metadata_tenants) {
-        auto& shard = tenant_quota_shards_[getTenantQuotaShardIndex(tenant_id)];
-        std::lock_guard<std::mutex> lock(shard.mutex);
-        auto [it, inserted] = shard.tenants.try_emplace(tenant_id);
-        auto& state = it->second;
-        if (inserted || !state.has_explicit_policy) {
-            state.requested_quota_bytes = 0;
-            state.effective_quota_bytes = 0;
-            state.has_explicit_policy = false;
+    for (const auto& [tenant_id, _] : usage) {
+        if (!tenant_quota_table_.IsTenantRegistered(tenant_id)) {
             LOG(WARNING)
                 << "tenant " << tenant_id.value()
                 << " exists in metadata but has no connector quota policy; "
                    "creating orphan quota state";
         }
-        state.used_bytes = used_by_tenant[tenant_id];
-        state.committed_count = committed_count_by_tenant[tenant_id];
-        state.metadata_object_count = metadata_count_by_tenant[tenant_id];
-        RefreshTenantQuotaOverQuota(state);
     }
-    RecomputeTenantEffectiveQuotas();
+    tenant_quota_table_.RebuildUsage(usage,
+                                     GetTenantQuotaAllocatableCapacityBytes());
 }
 
 std::optional<std::string> MasterService::GetGroupRoute(
@@ -3163,8 +2796,8 @@ auto MasterService::PutStart(const UUID& client_id, const std::string& key,
         }
         EvictTenantMemoryForQuota(
             object_id.tenant_id,
-            ComputeTenantQuotaDeficit(object_id.tenant_id,
-                                      requested_quota_charge));
+            tenant_quota_table_.ComputeDeficit(object_id.tenant_id,
+                                               requested_quota_charge));
     }
     return tl::make_unexpected(ErrorCode::TENANT_QUOTA_EXCEEDED);
 }
@@ -3753,8 +3386,8 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
         }
         EvictTenantMemoryForQuota(
             object_id.tenant_id,
-            ComputeTenantQuotaDeficit(object_id.tenant_id,
-                                      requested_quota_charge));
+            tenant_quota_table_.ComputeDeficit(object_id.tenant_id,
+                                               requested_quota_charge));
     }
     return tl::make_unexpected(ErrorCode::TENANT_QUOTA_EXCEEDED);
 }
@@ -4059,7 +3692,7 @@ tl::expected<void, ErrorCode> MasterService::CopyEnd(
                                  task.replica_ids.end(),
                                  replica.id()) != task.replica_ids.end();
             });
-        AbortReplicationTaskQuota(metadata.tenant_id, task);
+        AbortTenantQuota(metadata.tenant_id, task.reserved_quota_charge_bytes);
         accessor.EraseReplicationTask();
         if (!metadata.IsValid()) {
             // Remove the object if it does not have any replicas.
@@ -4151,7 +3784,7 @@ tl::expected<void, ErrorCode> MasterService::CopyRevoke(
             });
     }
 
-    AbortReplicationTaskQuota(metadata.tenant_id, task);
+    AbortTenantQuota(metadata.tenant_id, task.reserved_quota_charge_bytes);
     accessor.EraseReplicationTask();
 
     if (!metadata.IsValid()) {
@@ -4338,7 +3971,7 @@ tl::expected<void, ErrorCode> MasterService::MoveEnd(
                                  task.replica_ids.end(),
                                  replica.id()) != task.replica_ids.end();
             });
-        AbortReplicationTaskQuota(metadata.tenant_id, task);
+        AbortTenantQuota(metadata.tenant_id, task.reserved_quota_charge_bytes);
         accessor.EraseReplicationTask();
         if (!metadata.IsValid()) {
             // Remove the object if it does not have any replicas.
@@ -4360,7 +3993,8 @@ tl::expected<void, ErrorCode> MasterService::MoveEnd(
             LOG(WARNING)
                 << "key=" << key << ", replica_id=" << replica_id
                 << ", move target becomes invalid during data transfer";
-            AbortReplicationTaskQuota(metadata.tenant_id, task);
+            AbortTenantQuota(metadata.tenant_id,
+                             task.reserved_quota_charge_bytes);
             accessor.EraseReplicationTask();
             return tl::make_unexpected(ErrorCode::REPLICA_IS_GONE);
         }
@@ -4382,7 +4016,7 @@ tl::expected<void, ErrorCode> MasterService::MoveEnd(
             std::chrono::system_clock::now() + put_start_release_timeout_sec_);
     }
 
-    AbortReplicationTaskQuota(metadata.tenant_id, task);
+    AbortTenantQuota(metadata.tenant_id, task.reserved_quota_charge_bytes);
     accessor.EraseReplicationTask();
 
     return {};
@@ -4435,7 +4069,7 @@ tl::expected<void, ErrorCode> MasterService::MoveRevoke(
             });
     }
 
-    AbortReplicationTaskQuota(metadata.tenant_id, task);
+    AbortTenantQuota(metadata.tenant_id, task.reserved_quota_charge_bytes);
     accessor.EraseReplicationTask();
 
     if (!metadata.IsValid()) {
@@ -5365,7 +4999,7 @@ size_t MasterService::RunPromotionCandidateRetryForTesting() {
 }
 
 size_t MasterService::CountCandidatesForTesting(const std::string& tenant_id) {
-    const auto normalized = NormalizeTenantId(tenant_id);
+    const TenantId normalized(tenant_id);
     size_t count = 0;
     std::shared_lock<std::shared_mutex> lock(snapshot_mutex_);
     for (size_t i = 0; i < kNumShards; i++) {
@@ -6075,7 +5709,8 @@ void MasterService::DiscardExpiredProcessingReplicas(
             if (metadata_it == tenant_state.metadata.end()) {
                 LOG(ERROR) << "Key " << task_it->first
                            << " was removed with ongoing replication task";
-                AbortReplicationTaskQuota(tenant_it->first, task_it->second);
+                AbortTenantQuota(tenant_it->first,
+                                 task_it->second.reserved_quota_charge_bytes);
                 task_it = tenant_state.replication_tasks.erase(task_it);
                 continue;
             }

--- a/mooncake-store/src/tenant_quota.cpp
+++ b/mooncake-store/src/tenant_quota.cpp
@@ -3,10 +3,6 @@
 #include <algorithm>
 #include <limits>
 
-#include "types.h"
-
-#include <glog/logging.h>
-
 namespace mooncake {
 namespace {
 
@@ -23,146 +19,172 @@ uint64_t SaturatingAdd(uint64_t lhs, uint64_t rhs) {
     return lhs + rhs;
 }
 
-bool IsLazyEmptyTenant(const TenantQuotaState& state) {
-    return !state.has_explicit_policy && state.used_bytes == 0 &&
-           state.reserved_bytes == 0 && state.committed_count == 0 &&
-           state.metadata_object_count == 0;
+std::map<TenantId, uint64_t> BuildEffectiveQuotaAssignmentsImpl(
+    const std::vector<TenantQuotaSnapshot>& tenants,
+    uint64_t allocatable_capacity_bytes) {
+    unsigned __int128 explicit_requested_sum = 0;
+    std::vector<std::pair<TenantId, uint64_t>> explicit_tenants;
+    std::map<TenantId, uint64_t> assigned;
+
+    for (const auto& snapshot : tenants) {
+        const TenantId& tenant_id = snapshot.tenant_id;
+        assigned.emplace(tenant_id, 0);
+        if (snapshot.has_explicit_policy) {
+            explicit_requested_sum += snapshot.requested_quota_bytes;
+            explicit_tenants.emplace_back(tenant_id,
+                                          snapshot.requested_quota_bytes);
+        }
+    }
+
+    if (explicit_requested_sum <= allocatable_capacity_bytes) {
+        for (const auto& [tenant_id, requested_quota_bytes] :
+             explicit_tenants) {
+            assigned[tenant_id] = requested_quota_bytes;
+        }
+        return assigned;
+    }
+
+    std::vector<RemainderShare> shares;
+    shares.reserve(explicit_tenants.size());
+    uint64_t base_assigned = 0;
+    for (const auto& [tenant_id, requested_quota_bytes] : explicit_tenants) {
+        const unsigned __int128 product =
+            static_cast<unsigned __int128>(allocatable_capacity_bytes) *
+            requested_quota_bytes;
+        const uint64_t base =
+            static_cast<uint64_t>(product / explicit_requested_sum);
+        shares.push_back({.tenant_id = tenant_id,
+                          .base = base,
+                          .remainder = product % explicit_requested_sum});
+        base_assigned += base;
+    }
+
+    std::sort(shares.begin(), shares.end(),
+              [](const RemainderShare& lhs, const RemainderShare& rhs) {
+                  if (lhs.remainder != rhs.remainder) {
+                      return lhs.remainder > rhs.remainder;
+                  }
+                  return lhs.tenant_id < rhs.tenant_id;
+              });
+
+    uint64_t remaining = allocatable_capacity_bytes - base_assigned;
+    for (auto& share : shares) {
+        if (remaining > 0) {
+            ++share.base;
+            --remaining;
+        }
+        assigned[share.tenant_id] = share.base;
+    }
+    return assigned;
 }
 
-TenantQuotaResult AccountingMismatch(const char* operation,
-                                     const TenantId& tenant_id,
-                                     uint64_t requested, uint64_t available) {
-    LOG(WARNING) << operation << " accounting mismatch for tenant "
-                 << tenant_id.value() << ": requested=" << requested
-                 << ", available=" << available;
+TenantQuotaResult AccountingMismatch() {
     return tl::make_unexpected(TenantQuotaError::kAccountingMismatch);
 }
 
 }  // namespace
 
-std::vector<TenantQuotaAssignment> BuildEffectiveQuotaAssignments(
-    const std::map<TenantId, TenantQuotaState>& tenants,
+std::map<TenantId, uint64_t> TenantQuotaTable::BuildEffectiveQuotaAssignments(
+    const std::vector<TenantQuotaSnapshot>& tenants,
     uint64_t allocatable_capacity_bytes) {
-    unsigned __int128 explicit_requested_sum = 0;
-    std::vector<TenantId> explicit_tenants;
-
-    for (const auto& [tenant_id, state] : tenants) {
-        if (state.has_explicit_policy) {
-            explicit_tenants.push_back(tenant_id);
-            explicit_requested_sum += state.requested_quota_bytes;
-        }
-    }
-
-    std::map<TenantId, uint64_t> assigned;
-    for (const auto& [tenant_id, _] : tenants) {
-        assigned[tenant_id] = 0;
-    }
-
-    auto distribute = [&](const std::vector<TenantId>& tenant_ids,
-                          uint64_t capacity, unsigned __int128 denominator,
-                          bool proportional_to_requested) {
-        if (tenant_ids.empty() || capacity == 0 || denominator == 0) {
-            return;
-        }
-
-        std::vector<RemainderShare> shares;
-        shares.reserve(tenant_ids.size());
-        uint64_t base_assigned = 0;
-        for (const auto& tenant_id : tenant_ids) {
-            const auto& state = tenants.at(tenant_id);
-            unsigned __int128 numerator =
-                proportional_to_requested ? state.requested_quota_bytes : 1;
-            unsigned __int128 product =
-                static_cast<unsigned __int128>(capacity) * numerator;
-            uint64_t base = static_cast<uint64_t>(product / denominator);
-            unsigned __int128 remainder = product % denominator;
-            shares.push_back({tenant_id, base, remainder});
-            base_assigned += base;
-        }
-
-        std::sort(shares.begin(), shares.end(),
-                  [](const RemainderShare& lhs, const RemainderShare& rhs) {
-                      if (lhs.remainder != rhs.remainder) {
-                          return lhs.remainder > rhs.remainder;
-                      }
-                      return lhs.tenant_id < rhs.tenant_id;
-                  });
-
-        uint64_t remaining = capacity - base_assigned;
-        for (auto& share : shares) {
-            if (remaining > 0) {
-                ++share.base;
-                --remaining;
-            }
-            assigned[share.tenant_id] = share.base;
-        }
-    };
-
-    if (explicit_requested_sum <= allocatable_capacity_bytes) {
-        for (const auto& tenant_id : explicit_tenants) {
-            assigned[tenant_id] = tenants.at(tenant_id).requested_quota_bytes;
-        }
-    } else {
-        distribute(explicit_tenants, allocatable_capacity_bytes,
-                   explicit_requested_sum,
-                   /*proportional_to_requested=*/true);
-    }
-
-    std::vector<TenantQuotaAssignment> result;
-    result.reserve(assigned.size());
-    for (const auto& [tenant_id, effective_quota_bytes] : assigned) {
-        result.push_back({.tenant_id = tenant_id,
-                          .effective_quota_bytes = effective_quota_bytes});
-    }
-    return result;
+    return BuildEffectiveQuotaAssignmentsImpl(tenants,
+                                              allocatable_capacity_bytes);
 }
 
 TenantQuotaResult TenantQuotaTable::UpsertTenantPolicy(
-    std::string tenant_id, uint64_t requested_quota_bytes) {
+    const TenantId& tenant_id, uint64_t requested_quota_bytes) {
     if (requested_quota_bytes == 0) {
         return tl::make_unexpected(TenantQuotaError::kInvalidArgument);
     }
 
-    const TenantId normalized_tenant_id(std::move(tenant_id));
-    auto& state = GetOrCreateState(normalized_tenant_id);
+    auto& state = GetOrCreateState(tenant_id);
     state.requested_quota_bytes = requested_quota_bytes;
     state.has_explicit_policy = true;
+    RefreshOverQuota(&state);
     return {};
 }
 
-void TenantQuotaTable::EraseTenantPolicy(std::string tenant_id) {
-    const TenantId normalized_tenant_id(std::move(tenant_id));
-    auto it = tenants_.find(normalized_tenant_id);
-    if (it == tenants_.end()) {
-        return;
+TenantQuotaPolicyResult TenantQuotaTable::DisableTenantPolicyIfEmpty(
+    const TenantId& tenant_id) {
+    auto it = tenants_.find(tenant_id);
+    if (it == tenants_.end() || !it->second.has_explicit_policy) {
+        return tl::make_unexpected(TenantQuotaError::kTenantNotFound);
     }
+
     auto& state = it->second;
+    if (state.used_bytes != 0 || state.reserved_bytes != 0 ||
+        state.committed_count != 0 || state.metadata_object_count != 0) {
+        return tl::make_unexpected(TenantQuotaError::kTenantNotEmpty);
+    }
+
+    const uint64_t requested_quota_bytes = state.requested_quota_bytes;
     state.requested_quota_bytes = 0;
     state.effective_quota_bytes = 0;
     state.has_explicit_policy = false;
+    RefreshOverQuota(&state);
+    EraseIfLazyEmpty(it);
+    return requested_quota_bytes;
+}
+
+void TenantQuotaTable::ApplyTenantPolicies(
+    const TenantQuotaPolicyMap& policies) {
+    for (auto it = tenants_.begin(); it != tenants_.end();) {
+        auto policy_it = policies.find(it->first);
+        auto& state = it->second;
+        if (policy_it != policies.end()) {
+            state.requested_quota_bytes = policy_it->second;
+            state.has_explicit_policy = true;
+            RefreshOverQuota(&state);
+            ++it;
+            continue;
+        }
+
+        state.requested_quota_bytes = 0;
+        state.effective_quota_bytes = 0;
+        state.has_explicit_policy = false;
+        if (IsLazyEmptyTenant(state)) {
+            it = tenants_.erase(it);
+        } else {
+            RefreshOverQuota(&state);
+            ++it;
+        }
+    }
+
+    for (const auto& [tenant_id, requested_quota_bytes] : policies) {
+        auto [it, inserted] = tenants_.try_emplace(tenant_id);
+        if (!inserted) {
+            continue;
+        }
+        it->second.requested_quota_bytes = requested_quota_bytes;
+        it->second.has_explicit_policy = true;
+        RefreshOverQuota(&it->second);
+    }
+}
+
+TenantQuotaPolicyMap TenantQuotaTable::GetTenantPolicies() const {
+    TenantQuotaPolicyMap policies;
+    for (const auto& [tenant_id, state] : tenants_) {
+        if (state.has_explicit_policy) {
+            policies.emplace(tenant_id, state.requested_quota_bytes);
+        }
+    }
+    return policies;
 }
 
 void TenantQuotaTable::RecomputeEffectiveQuotas(
     uint64_t allocatable_capacity_bytes) {
-    for (auto& [tenant_id, state] : tenants_) {
-        state.effective_quota_bytes = 0;
-    }
+    ApplyEffectiveQuotas(BuildEffectiveQuotaAssignments(
+        ListTenantSnapshots(), allocatable_capacity_bytes));
+}
 
-    for (const auto& assignment :
-         BuildEffectiveQuotaAssignments(tenants_, allocatable_capacity_bytes)) {
-        tenants_.at(assignment.tenant_id).effective_quota_bytes =
-            assignment.effective_quota_bytes;
-    }
-
-    for (auto& [_, state] : tenants_) {
-        RefreshOverQuota(&state);
-    }
+bool TenantQuotaTable::IsTenantRegistered(const TenantId& tenant_id) const {
+    auto it = tenants_.find(tenant_id);
+    return it != tenants_.end() && it->second.has_explicit_policy;
 }
 
 std::optional<TenantQuotaSnapshot> TenantQuotaTable::GetTenantSnapshot(
-    std::string tenant_id) const {
-    const TenantId normalized_tenant_id(std::move(tenant_id));
-    auto it = tenants_.find(normalized_tenant_id);
+    const TenantId& tenant_id) const {
+    auto it = tenants_.find(tenant_id);
     if (it == tenants_.end()) {
         return std::nullopt;
     }
@@ -171,32 +193,47 @@ std::optional<TenantQuotaSnapshot> TenantQuotaTable::GetTenantSnapshot(
 
 std::vector<TenantQuotaSnapshot> TenantQuotaTable::ListTenantSnapshots() const {
     std::vector<TenantQuotaSnapshot> snapshots;
+    snapshots.reserve(tenants_.size());
     for (const auto& [tenant_id, state] : tenants_) {
-        if (IsLazyEmptyTenant(state)) {
-            continue;
+        if (!IsLazyEmptyTenant(state)) {
+            snapshots.push_back(MakeSnapshot(tenant_id, state));
         }
-        snapshots.push_back(MakeSnapshot(tenant_id, state));
     }
     return snapshots;
 }
 
-TenantQuotaResult TenantQuotaTable::Reserve(std::string tenant_id,
+uint64_t TenantQuotaTable::ComputeDeficit(const TenantId& tenant_id,
+                                          uint64_t incoming_bytes) const {
+    auto it = tenants_.find(tenant_id);
+    if (it == tenants_.end()) {
+        return incoming_bytes;
+    }
+
+    const auto& state = it->second;
+    const unsigned __int128 demand =
+        static_cast<unsigned __int128>(state.used_bytes) +
+        state.reserved_bytes + incoming_bytes;
+    if (demand <= state.effective_quota_bytes) {
+        return 0;
+    }
+
+    const unsigned __int128 deficit = demand - state.effective_quota_bytes;
+    return deficit > std::numeric_limits<uint64_t>::max()
+               ? std::numeric_limits<uint64_t>::max()
+               : static_cast<uint64_t>(deficit);
+}
+
+TenantQuotaResult TenantQuotaTable::Reserve(const TenantId& tenant_id,
                                             uint64_t bytes) {
-    const TenantId normalized_tenant_id(std::move(tenant_id));
+    auto it = tenants_.find(tenant_id);
+    if (it == tenants_.end() || !it->second.has_explicit_policy) {
+        return tl::make_unexpected(TenantQuotaError::kTenantNotRegistered);
+    }
     if (bytes == 0) {
-        GetOrCreateState(normalized_tenant_id);
         return {};
     }
 
-    auto it = tenants_.find(normalized_tenant_id);
-    if (it == tenants_.end()) {
-        return tl::make_unexpected(TenantQuotaError::kQuotaExceeded);
-    }
     auto& state = it->second;
-    if (!state.has_explicit_policy) {
-        return tl::make_unexpected(TenantQuotaError::kQuotaExceeded);
-    }
-
     if (static_cast<unsigned __int128>(state.used_bytes) +
             state.reserved_bytes + bytes >
         state.effective_quota_bytes) {
@@ -208,101 +245,154 @@ TenantQuotaResult TenantQuotaTable::Reserve(std::string tenant_id,
     return {};
 }
 
-TenantQuotaResult TenantQuotaTable::Commit(std::string tenant_id,
+TenantQuotaResult TenantQuotaTable::Commit(const TenantId& tenant_id,
                                            uint64_t bytes) {
-    const TenantId normalized_tenant_id(std::move(tenant_id));
-    auto& state = GetOrCreateState(normalized_tenant_id);
+    auto it = tenants_.find(tenant_id);
+    if (it == tenants_.end() || it->second.reserved_bytes < bytes) {
+        return AccountingMismatch();
+    }
     if (bytes == 0) {
         return {};
     }
 
-    if (state.reserved_bytes < bytes) {
-        return AccountingMismatch("Commit", normalized_tenant_id, bytes,
-                                  state.reserved_bytes);
-    }
-
+    auto& state = it->second;
     state.reserved_bytes -= bytes;
     state.used_bytes = SaturatingAdd(state.used_bytes, bytes);
-    ++state.committed_count;
+    if (state.committed_count < std::numeric_limits<uint64_t>::max()) {
+        ++state.committed_count;
+    }
     RefreshOverQuota(&state);
     return {};
 }
 
-TenantQuotaResult TenantQuotaTable::Abort(std::string tenant_id,
-                                          uint64_t bytes) {
-    const TenantId normalized_tenant_id(std::move(tenant_id));
-    auto& state = GetOrCreateState(normalized_tenant_id);
+TenantQuotaResult TenantQuotaTable::CommitAdditional(const TenantId& tenant_id,
+                                                     uint64_t bytes) {
+    auto it = tenants_.find(tenant_id);
+    if (it == tenants_.end() || it->second.reserved_bytes < bytes) {
+        return AccountingMismatch();
+    }
     if (bytes == 0) {
         return {};
     }
 
-    if (state.reserved_bytes < bytes) {
-        return AccountingMismatch("Abort", normalized_tenant_id, bytes,
-                                  state.reserved_bytes);
-    }
-
+    auto& state = it->second;
     state.reserved_bytes -= bytes;
+    state.used_bytes = SaturatingAdd(state.used_bytes, bytes);
     RefreshOverQuota(&state);
     return {};
 }
 
-TenantQuotaResult TenantQuotaTable::Release(std::string tenant_id,
+TenantQuotaResult TenantQuotaTable::Abort(const TenantId& tenant_id,
+                                          uint64_t bytes) {
+    auto it = tenants_.find(tenant_id);
+    if (it == tenants_.end() || it->second.reserved_bytes < bytes) {
+        return AccountingMismatch();
+    }
+    if (bytes == 0) {
+        return {};
+    }
+
+    it->second.reserved_bytes -= bytes;
+    RefreshOverQuota(&it->second);
+    EraseIfLazyEmpty(it);
+    return {};
+}
+
+TenantQuotaResult TenantQuotaTable::Release(const TenantId& tenant_id,
                                             uint64_t bytes) {
-    const TenantId normalized_tenant_id(std::move(tenant_id));
-    auto& state = GetOrCreateState(normalized_tenant_id);
+    auto it = tenants_.find(tenant_id);
+    if (it == tenants_.end() || it->second.used_bytes < bytes ||
+        (bytes != 0 && it->second.committed_count == 0)) {
+        return AccountingMismatch();
+    }
     if (bytes == 0) {
         return {};
     }
 
-    if (state.used_bytes < bytes) {
-        return AccountingMismatch("Release", normalized_tenant_id, bytes,
-                                  state.used_bytes);
-    }
-
+    auto& state = it->second;
     state.used_bytes -= bytes;
-    if (state.committed_count > 0) {
-        --state.committed_count;
-    } else {
-        LOG(WARNING) << "Release found zero committed_count for tenant "
-                     << normalized_tenant_id.value();
-    }
+    --state.committed_count;
     RefreshOverQuota(&state);
+    EraseIfLazyEmpty(it);
     return {};
 }
 
-TenantQuotaResult TenantQuotaTable::ReleasePartial(std::string tenant_id,
+TenantQuotaResult TenantQuotaTable::ReleasePartial(const TenantId& tenant_id,
                                                    uint64_t bytes) {
-    const TenantId normalized_tenant_id(std::move(tenant_id));
-    auto& state = GetOrCreateState(normalized_tenant_id);
+    auto it = tenants_.find(tenant_id);
+    if (it == tenants_.end() || it->second.used_bytes < bytes) {
+        return AccountingMismatch();
+    }
     if (bytes == 0) {
         return {};
     }
 
-    DCHECK_LE(bytes, state.used_bytes);
-    if (state.used_bytes < bytes) {
-        return AccountingMismatch("ReleasePartial", normalized_tenant_id, bytes,
-                                  state.used_bytes);
-    }
-
-    state.used_bytes -= bytes;
-    RefreshOverQuota(&state);
+    it->second.used_bytes -= bytes;
+    RefreshOverQuota(&it->second);
+    EraseIfLazyEmpty(it);
     return {};
 }
 
-TenantQuotaState& TenantQuotaTable::GetOrCreateState(
-    const TenantId& tenant_id) {
-    auto [it, inserted] = tenants_.try_emplace(tenant_id);
-    if (inserted) {
-        it->second.requested_quota_bytes = 0;
-        it->second.effective_quota_bytes = 0;
+void TenantQuotaTable::IncrementMetadataObjectCount(const TenantId& tenant_id) {
+    auto& state = GetOrCreateState(tenant_id);
+    if (state.metadata_object_count < std::numeric_limits<uint64_t>::max()) {
+        ++state.metadata_object_count;
     }
-    return it->second;
+    RefreshOverQuota(&state);
+}
+
+TenantQuotaResult TenantQuotaTable::DecrementMetadataObjectCount(
+    const TenantId& tenant_id) {
+    auto it = tenants_.find(tenant_id);
+    if (it == tenants_.end() || it->second.metadata_object_count == 0) {
+        return AccountingMismatch();
+    }
+
+    --it->second.metadata_object_count;
+    RefreshOverQuota(&it->second);
+    EraseIfLazyEmpty(it);
+    return {};
+}
+
+void TenantQuotaTable::RebuildUsage(const TenantQuotaUsageMap& usage) {
+    for (auto& [_, state] : tenants_) {
+        state.used_bytes = 0;
+        state.reserved_bytes = 0;
+        state.committed_count = 0;
+        state.metadata_object_count = 0;
+    }
+
+    for (const auto& [tenant_id, tenant_usage] : usage) {
+        auto& state = GetOrCreateState(tenant_id);
+        if (!state.has_explicit_policy) {
+            state.requested_quota_bytes = 0;
+            state.effective_quota_bytes = 0;
+        }
+        state.used_bytes = tenant_usage.used_bytes;
+        state.committed_count = tenant_usage.committed_count;
+        state.metadata_object_count = tenant_usage.metadata_object_count;
+        RefreshOverQuota(&state);
+    }
+
+    for (auto it = tenants_.begin(); it != tenants_.end();) {
+        if (IsLazyEmptyTenant(it->second)) {
+            it = tenants_.erase(it);
+        } else {
+            RefreshOverQuota(&it->second);
+            ++it;
+        }
+    }
+}
+
+TenantQuotaTable::TenantQuotaState& TenantQuotaTable::GetOrCreateState(
+    const TenantId& tenant_id) {
+    return tenants_.try_emplace(tenant_id).first->second;
 }
 
 TenantQuotaSnapshot TenantQuotaTable::MakeSnapshot(
     const TenantId& tenant_id, const TenantQuotaState& state) const {
     return TenantQuotaSnapshot{
-        .tenant_id = tenant_id.value(),
+        .tenant_id = tenant_id,
         .requested_quota_bytes = state.requested_quota_bytes,
         .effective_quota_bytes = state.effective_quota_bytes,
         .used_bytes = state.used_bytes,
@@ -314,12 +404,34 @@ TenantQuotaSnapshot TenantQuotaTable::MakeSnapshot(
     };
 }
 
-void TenantQuotaTable::RefreshOverQuota(TenantQuotaState* state) const {
+bool TenantQuotaTable::IsLazyEmptyTenant(const TenantQuotaState& state) {
+    return !state.has_explicit_policy && state.used_bytes == 0 &&
+           state.reserved_bytes == 0 && state.committed_count == 0 &&
+           state.metadata_object_count == 0;
+}
+
+void TenantQuotaTable::RefreshOverQuota(TenantQuotaState* state) {
     state->over_quota =
         (!state->has_explicit_policy && state->metadata_object_count > 0) ||
         static_cast<unsigned __int128>(state->used_bytes) +
                 state->reserved_bytes >
             state->effective_quota_bytes;
+}
+
+void TenantQuotaTable::ApplyEffectiveQuotas(
+    const std::map<TenantId, uint64_t>& effective_quotas) {
+    for (auto& [tenant_id, state] : tenants_) {
+        auto it = effective_quotas.find(tenant_id);
+        state.effective_quota_bytes =
+            it == effective_quotas.end() ? 0 : it->second;
+        RefreshOverQuota(&state);
+    }
+}
+
+void TenantQuotaTable::EraseIfLazyEmpty(StateMap::iterator it) {
+    if (IsLazyEmptyTenant(it->second)) {
+        tenants_.erase(it);
+    }
 }
 
 }  // namespace mooncake

--- a/mooncake-store/tests/master_service_tenant_quota_test.cpp
+++ b/mooncake-store/tests/master_service_tenant_quota_test.cpp
@@ -200,7 +200,7 @@ class MasterServiceTenantQuotaTest : public ::testing::Test {
 
     TenantQuotaSnapshot Snapshot(MasterService& service,
                                  const TenantId& tenant_id) {
-        auto snapshot = service.GetTenantQuotaSnapshotForTesting(tenant_id);
+        auto snapshot = service.GetTenantQuotaSnapshot(tenant_id);
         EXPECT_TRUE(snapshot.has_value());
         return *snapshot;
     }
@@ -282,8 +282,8 @@ TEST_F(MasterServiceTenantQuotaTest,
                     .Remove("shared-key", TenantId("tenant-b"),
                             /*force=*/true)
                     .has_value());
-    EXPECT_FALSE(service.GetTenantQuotaSnapshotForTesting(TenantId("tenant-a"))
-                     .has_value());
+    EXPECT_FALSE(
+        service.GetTenantQuotaSnapshot(TenantId("tenant-a")).has_value());
 }
 
 TEST_F(MasterServiceTenantQuotaTest,
@@ -391,8 +391,8 @@ TEST_F(MasterServiceTenantQuotaTest,
 
     EXPECT_TRUE(service.Remove("cold", TenantId("tenant-b"), /*force=*/true)
                     .has_value());
-    EXPECT_FALSE(service.GetTenantQuotaSnapshotForTesting(TenantId("tenant-b"))
-                     .has_value());
+    EXPECT_FALSE(
+        service.GetTenantQuotaSnapshot(TenantId("tenant-b")).has_value());
 }
 
 TEST_F(MasterServiceTenantQuotaTest,
@@ -528,8 +528,8 @@ TEST_F(MasterServiceTenantQuotaTest,
     ASSERT_FALSE(over.has_value());
     EXPECT_EQ(over.error(), ErrorCode::TENANT_QUOTA_EXCEEDED);
     EXPECT_EQ(Snapshot(service, TenantId("tenant-a")).used_bytes, 80);
-    EXPECT_FALSE(service.GetTenantQuotaSnapshotForTesting(TenantId("tenant-b"))
-                     .has_value());
+    EXPECT_FALSE(
+        service.GetTenantQuotaSnapshot(TenantId("tenant-b")).has_value());
 }
 
 TEST_F(MasterServiceTenantQuotaTest, CopyStartRequiresQuotaForNewReplica) {
@@ -676,8 +676,8 @@ TEST_F(MasterServiceTenantQuotaTest,
     ASSERT_TRUE(delete_result.has_value());
     ASSERT_TRUE(delete_result->has_value()) << toString(delete_result->error());
     EXPECT_FALSE(delete_result->value().has_value());
-    EXPECT_FALSE(service.GetTenantQuotaSnapshotForTesting(TenantId("tenant-a"))
-                     .has_value());
+    EXPECT_FALSE(
+        service.GetTenantQuotaSnapshot(TenantId("tenant-a")).has_value());
 }
 
 TEST_F(MasterServiceTenantQuotaTest,

--- a/mooncake-store/tests/tenant_quota_test.cpp
+++ b/mooncake-store/tests/tenant_quota_test.cpp
@@ -6,14 +6,17 @@
 #include "etcd_helper.h"
 #endif
 
+#include <atomic>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
+#include <functional>
 #include <limits>
 #include <map>
 #include <optional>
 #include <string>
 #include <string_view>
+#include <thread>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -35,14 +38,15 @@ std::string GetTenantQuotaEtcdEndpoints() {
 }
 #endif
 
-TenantQuotaSnapshot Snapshot(const TenantQuotaTable& table,
-                             const std::string& tenant_id) {
-    auto snapshot = table.GetTenantSnapshot(tenant_id);
+template <typename Table>
+TenantQuotaSnapshot Snapshot(const Table& table, const std::string& tenant_id) {
+    auto snapshot = table.GetTenantSnapshot(TenantId(tenant_id));
     EXPECT_TRUE(snapshot.has_value());
     return *snapshot;
 }
 
-uint64_t SumEffectiveQuotas(const TenantQuotaTable& table) {
+template <typename Table>
+uint64_t SumEffectiveQuotas(const Table& table) {
     uint64_t sum = 0;
     for (const auto& snapshot : table.ListTenantSnapshots()) {
         sum += snapshot.effective_quota_bytes;
@@ -98,21 +102,22 @@ void CleanupTenantQuotaEtcdCluster(const std::string& cluster_id) {
 
 void MakeOrphanTenant(TenantQuotaTable* table, const std::string& tenant_id,
                       uint64_t bytes) {
-    ASSERT_TRUE(table->UpsertTenantPolicy(tenant_id, bytes).has_value());
+    const TenantId canonical_tenant(tenant_id);
+    ASSERT_TRUE(table->UpsertTenantPolicy(canonical_tenant, bytes).has_value());
     table->RecomputeEffectiveQuotas(bytes);
-    ASSERT_TRUE(table->Reserve(tenant_id, bytes).has_value());
-    ASSERT_TRUE(table->Commit(tenant_id, bytes).has_value());
-    table->EraseTenantPolicy(tenant_id);
+    ASSERT_TRUE(table->Reserve(canonical_tenant, bytes).has_value());
+    ASSERT_TRUE(table->Commit(canonical_tenant, bytes).has_value());
+    table->ApplyTenantPolicies({});
 }
 
 TEST(TenantQuotaTableTest, NormalizesEmptyExplicitTenantIdToDefault) {
     TenantQuotaTable table;
 
-    ASSERT_TRUE(table.UpsertTenantPolicy("", 1024).has_value());
+    ASSERT_TRUE(table.UpsertTenantPolicy(TenantId(""), 1024).has_value());
     table.RecomputeEffectiveQuotas(4096);
 
     auto snapshot = Snapshot(table, "");
-    EXPECT_EQ(snapshot.tenant_id, "default");
+    EXPECT_EQ(snapshot.tenant_id, TenantId::Default());
     EXPECT_TRUE(snapshot.has_explicit_policy);
     EXPECT_EQ(snapshot.requested_quota_bytes, 1024);
     EXPECT_EQ(snapshot.effective_quota_bytes, 1024);
@@ -121,8 +126,9 @@ TEST(TenantQuotaTableTest, NormalizesEmptyExplicitTenantIdToDefault) {
 TEST(TenantQuotaTableTest, RejectsZeroExplicitQuotaWithoutChangingState) {
     TenantQuotaTable table;
 
-    ASSERT_TRUE(table.UpsertTenantPolicy("tenant-a", 100).has_value());
-    auto result = table.UpsertTenantPolicy("tenant-a", 0);
+    const TenantId tenant_id("tenant-a");
+    ASSERT_TRUE(table.UpsertTenantPolicy(tenant_id, 100).has_value());
+    auto result = table.UpsertTenantPolicy(tenant_id, 0);
 
     ASSERT_FALSE(result.has_value());
     EXPECT_EQ(result.error(), TenantQuotaError::kInvalidArgument);
@@ -131,7 +137,7 @@ TEST(TenantQuotaTableTest, RejectsZeroExplicitQuotaWithoutChangingState) {
     EXPECT_EQ(snapshot.requested_quota_bytes, 100);
 }
 
-TEST(TenantQuotaTableTest, EraseExplicitPolicyCreatesOrphanState) {
+TEST(TenantQuotaTableTest, ApplyPoliciesCreatesOrphanState) {
     TenantQuotaTable table;
     MakeOrphanTenant(&table, "tenant-a", 40);
     table.RecomputeEffectiveQuotas(1000);
@@ -145,45 +151,70 @@ TEST(TenantQuotaTableTest, EraseExplicitPolicyCreatesOrphanState) {
     EXPECT_TRUE(snapshot.over_quota);
 }
 
-TEST(TenantQuotaTableTest, EraseMissingPolicyDoesNotCreateLazyState) {
+TEST(TenantQuotaTableTest, ApplyPoliciesReplacesCanonicalPolicySet) {
+    TenantQuotaTable table;
+    const TenantId tenant_a("tenant-a");
+    const TenantId tenant_b("tenant-b");
+    const TenantId tenant_c("tenant-c");
+    table.ApplyTenantPolicies({{tenant_a, 100}, {tenant_b, 200}});
+    table.IncrementMetadataObjectCount(tenant_a);
+
+    table.ApplyTenantPolicies({{tenant_b, 300}, {tenant_c, 400}});
+
+    EXPECT_FALSE(table.IsTenantRegistered(tenant_a));
+    EXPECT_TRUE(table.IsTenantRegistered(tenant_b));
+    EXPECT_TRUE(table.IsTenantRegistered(tenant_c));
+    EXPECT_TRUE(Snapshot(table, tenant_a.value()).over_quota);
+    EXPECT_EQ(table.GetTenantPolicies(),
+              (TenantQuotaPolicyMap{{tenant_b, 300}, {tenant_c, 400}}));
+}
+
+TEST(TenantQuotaTableTest, DisableMissingPolicyDoesNotCreateLazyState) {
     TenantQuotaTable table;
 
-    table.EraseTenantPolicy("missing");
+    auto result = table.DisableTenantPolicyIfEmpty(TenantId("missing"));
 
-    EXPECT_FALSE(table.GetTenantSnapshot("missing").has_value());
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), TenantQuotaError::kTenantNotFound);
+    EXPECT_FALSE(table.GetTenantSnapshot(TenantId("missing")).has_value());
     EXPECT_TRUE(table.ListTenantSnapshots().empty());
 }
 
 TEST(TenantQuotaTableTest, PolicyMutationDoesNotRecomputeEffectiveQuota) {
     TenantQuotaTable table;
-    ASSERT_TRUE(table.UpsertTenantPolicy("tenant-a", 100).has_value());
+    const TenantId tenant_id("tenant-a");
+    ASSERT_TRUE(table.UpsertTenantPolicy(tenant_id, 100).has_value());
     table.RecomputeEffectiveQuotas(1000);
     EXPECT_EQ(Snapshot(table, "tenant-a").effective_quota_bytes, 100);
 
-    ASSERT_TRUE(table.UpsertTenantPolicy("tenant-a", 200).has_value());
+    ASSERT_TRUE(table.UpsertTenantPolicy(tenant_id, 200).has_value());
     EXPECT_EQ(Snapshot(table, "tenant-a").effective_quota_bytes, 100);
 
     table.RecomputeEffectiveQuotas(1000);
     EXPECT_EQ(Snapshot(table, "tenant-a").effective_quota_bytes, 200);
 }
 
-TEST(TenantQuotaTableTest, ListSnapshotsSortedAndSkipsLazyEmptyTenants) {
+TEST(TenantQuotaTableTest, ListSnapshotsSortedAndCleansLazyEmptyTenants) {
     TenantQuotaTable table;
-    ASSERT_TRUE(table.Reserve("z-empty", 0).has_value());
-    ASSERT_TRUE(table.UpsertTenantPolicy("b", 10).has_value());
-    ASSERT_TRUE(table.UpsertTenantPolicy("a", 10).has_value());
+    ASSERT_TRUE(table.UpsertTenantPolicy(TenantId("z-empty"), 10).has_value());
+    ASSERT_TRUE(
+        table.DisableTenantPolicyIfEmpty(TenantId("z-empty")).has_value());
+    ASSERT_TRUE(table.UpsertTenantPolicy(TenantId("b"), 10).has_value());
+    ASSERT_TRUE(table.UpsertTenantPolicy(TenantId("a"), 10).has_value());
     table.RecomputeEffectiveQuotas(100);
 
     auto snapshots = table.ListTenantSnapshots();
     ASSERT_EQ(snapshots.size(), 2);
-    EXPECT_EQ(snapshots[0].tenant_id, "a");
-    EXPECT_EQ(snapshots[1].tenant_id, "b");
+    EXPECT_EQ(snapshots[0].tenant_id, TenantId("a"));
+    EXPECT_EQ(snapshots[1].tenant_id, TenantId("b"));
 }
 
 TEST(TenantQuotaTableTest, ExplicitTenantsReceiveRequestedWhenCapacityFits) {
     TenantQuotaTable table;
-    ASSERT_TRUE(table.UpsertTenantPolicy("tenant-a", 100).has_value());
-    ASSERT_TRUE(table.UpsertTenantPolicy("tenant-b", 200).has_value());
+    ASSERT_TRUE(
+        table.UpsertTenantPolicy(TenantId("tenant-a"), 100).has_value());
+    ASSERT_TRUE(
+        table.UpsertTenantPolicy(TenantId("tenant-b"), 200).has_value());
 
     table.RecomputeEffectiveQuotas(1000);
 
@@ -195,8 +226,8 @@ TEST(TenantQuotaTableTest, ExplicitTenantsReceiveRequestedWhenCapacityFits) {
 TEST(TenantQuotaTableTest, OverCapacityScalesOnlyExplicitTenants) {
     TenantQuotaTable table;
     MakeOrphanTenant(&table, "orphan", 20);
-    ASSERT_TRUE(table.UpsertTenantPolicy("b", 200).has_value());
-    ASSERT_TRUE(table.UpsertTenantPolicy("a", 100).has_value());
+    ASSERT_TRUE(table.UpsertTenantPolicy(TenantId("b"), 200).has_value());
+    ASSERT_TRUE(table.UpsertTenantPolicy(TenantId("a"), 100).has_value());
 
     table.RecomputeEffectiveQuotas(150);
 
@@ -208,18 +239,252 @@ TEST(TenantQuotaTableTest, OverCapacityScalesOnlyExplicitTenants) {
 
 TEST(TenantQuotaTableTest, LazyEmptyOrphansDoNotAppearInList) {
     TenantQuotaTable table;
-    ASSERT_TRUE(table.UpsertTenantPolicy("team-a", 30).has_value());
-    ASSERT_TRUE(table.UpsertTenantPolicy("ghost", 10).has_value());
-    table.EraseTenantPolicy("ghost");
+    ASSERT_TRUE(table.UpsertTenantPolicy(TenantId("team-a"), 30).has_value());
+    ASSERT_TRUE(table.UpsertTenantPolicy(TenantId("ghost"), 10).has_value());
+    ASSERT_TRUE(
+        table.DisableTenantPolicyIfEmpty(TenantId("ghost")).has_value());
 
     table.RecomputeEffectiveQuotas(100);
 
     EXPECT_EQ(Snapshot(table, "team-a").effective_quota_bytes, 30);
-    EXPECT_EQ(Snapshot(table, "ghost").effective_quota_bytes, 0);
+    EXPECT_FALSE(table.GetTenantSnapshot(TenantId("ghost")).has_value());
 
     auto snapshots = table.ListTenantSnapshots();
     ASSERT_EQ(snapshots.size(), 1);
-    EXPECT_EQ(snapshots[0].tenant_id, "team-a");
+    EXPECT_EQ(snapshots[0].tenant_id, TenantId("team-a"));
+}
+
+TEST(TenantQuotaTableTest, ReserveRequiresRegisteredTenantIncludingZeroBytes) {
+    TenantQuotaTable table;
+
+    auto regular = table.Reserve(TenantId("missing"), 1);
+    auto zero = table.Reserve(TenantId("missing"), 0);
+
+    ASSERT_FALSE(regular.has_value());
+    ASSERT_FALSE(zero.has_value());
+    EXPECT_EQ(regular.error(), TenantQuotaError::kTenantNotRegistered);
+    EXPECT_EQ(zero.error(), TenantQuotaError::kTenantNotRegistered);
+}
+
+TEST(TenantQuotaTableTest, TracksAdditionalCommitAndMetadataCount) {
+    TenantQuotaTable table;
+    const TenantId tenant_id("tenant-a");
+    ASSERT_TRUE(table.UpsertTenantPolicy(tenant_id, 300).has_value());
+    table.RecomputeEffectiveQuotas(300);
+
+    ASSERT_TRUE(table.Reserve(tenant_id, 200).has_value());
+    ASSERT_TRUE(table.Commit(tenant_id, 100).has_value());
+    ASSERT_TRUE(table.CommitAdditional(tenant_id, 100).has_value());
+    table.IncrementMetadataObjectCount(tenant_id);
+
+    auto snapshot = Snapshot(table, "tenant-a");
+    EXPECT_EQ(snapshot.used_bytes, 200);
+    EXPECT_EQ(snapshot.reserved_bytes, 0);
+    EXPECT_EQ(snapshot.committed_count, 1);
+    EXPECT_EQ(snapshot.metadata_object_count, 1);
+}
+
+TEST(TenantQuotaTableTest, AccountingMismatchDoesNotMutateState) {
+    TenantQuotaTable table;
+    const TenantId tenant_id("tenant-a");
+    ASSERT_TRUE(table.UpsertTenantPolicy(tenant_id, 100).has_value());
+    table.RecomputeEffectiveQuotas(100);
+    ASSERT_TRUE(table.Reserve(tenant_id, 10).has_value());
+
+    auto commit = table.Commit(tenant_id, 11);
+    auto abort = table.Abort(tenant_id, 11);
+    auto before_commit = Snapshot(table, "tenant-a");
+    ASSERT_FALSE(commit.has_value());
+    ASSERT_FALSE(abort.has_value());
+    EXPECT_EQ(commit.error(), TenantQuotaError::kAccountingMismatch);
+    EXPECT_EQ(abort.error(), TenantQuotaError::kAccountingMismatch);
+    EXPECT_EQ(before_commit.used_bytes, 0);
+    EXPECT_EQ(before_commit.reserved_bytes, 10);
+
+    ASSERT_TRUE(table.Commit(tenant_id, 10).has_value());
+    auto release = table.Release(tenant_id, 11);
+    auto partial = table.ReleasePartial(tenant_id, 11);
+    ASSERT_FALSE(release.has_value());
+    ASSERT_FALSE(partial.has_value());
+    EXPECT_EQ(release.error(), TenantQuotaError::kAccountingMismatch);
+    EXPECT_EQ(partial.error(), TenantQuotaError::kAccountingMismatch);
+    auto after_commit = Snapshot(table, "tenant-a");
+    EXPECT_EQ(after_commit.used_bytes, 10);
+    EXPECT_EQ(after_commit.committed_count, 1);
+
+    table.RebuildUsage({{tenant_id,
+                         {.used_bytes = 10,
+                          .committed_count = 0,
+                          .metadata_object_count = 1}}});
+    auto inconsistent_release = table.Release(tenant_id, 5);
+    ASSERT_FALSE(inconsistent_release.has_value());
+    EXPECT_EQ(inconsistent_release.error(),
+              TenantQuotaError::kAccountingMismatch);
+    auto after_inconsistent_release = Snapshot(table, "tenant-a");
+    EXPECT_EQ(after_inconsistent_release.used_bytes, 10);
+    EXPECT_EQ(after_inconsistent_release.committed_count, 0);
+}
+
+TEST(TenantQuotaTableTest, DisablePolicyRejectsNonEmptyTenant) {
+    TenantQuotaTable table;
+    const TenantId tenant_id("tenant-a");
+    ASSERT_TRUE(table.UpsertTenantPolicy(tenant_id, 100).has_value());
+    table.RecomputeEffectiveQuotas(100);
+    ASSERT_TRUE(table.Reserve(tenant_id, 1).has_value());
+
+    auto result = table.DisableTenantPolicyIfEmpty(tenant_id);
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), TenantQuotaError::kTenantNotEmpty);
+    EXPECT_TRUE(table.IsTenantRegistered(tenant_id));
+}
+
+TEST(TenantQuotaTableTest, RebuildUsageCreatesAndRemovesOrphans) {
+    TenantQuotaTable table;
+    const TenantId explicit_tenant("tenant-a");
+    const TenantId orphan("orphan");
+    ASSERT_TRUE(table.UpsertTenantPolicy(explicit_tenant, 100).has_value());
+
+    TenantQuotaUsageMap usage{
+        {explicit_tenant,
+         {.used_bytes = 40, .committed_count = 1, .metadata_object_count = 1}},
+        {orphan,
+         {.used_bytes = 20, .committed_count = 1, .metadata_object_count = 1}},
+    };
+    table.RebuildUsage(usage);
+    table.RecomputeEffectiveQuotas(100);
+
+    EXPECT_TRUE(Snapshot(table, "tenant-a").has_explicit_policy);
+    EXPECT_FALSE(Snapshot(table, "orphan").has_explicit_policy);
+    EXPECT_TRUE(Snapshot(table, "orphan").over_quota);
+
+    table.RebuildUsage({});
+    EXPECT_FALSE(table.GetTenantSnapshot(orphan).has_value());
+    EXPECT_TRUE(table.GetTenantSnapshot(explicit_tenant).has_value());
+}
+
+TEST(TenantQuotaTableTest, OverflowChecksDoNotWrapAccounting) {
+    TenantQuotaTable table;
+    const TenantId tenant_id("tenant-a");
+    const uint64_t max = std::numeric_limits<uint64_t>::max();
+    ASSERT_TRUE(table.UpsertTenantPolicy(tenant_id, max).has_value());
+    table.RebuildUsage({{tenant_id,
+                         {.used_bytes = max - 5,
+                          .committed_count = max,
+                          .metadata_object_count = max}}});
+    table.RecomputeEffectiveQuotas(max);
+
+    EXPECT_EQ(table.ComputeDeficit(tenant_id, 10), 5);
+    auto overflow_reserve = table.Reserve(tenant_id, 10);
+    ASSERT_FALSE(overflow_reserve.has_value());
+    EXPECT_EQ(overflow_reserve.error(), TenantQuotaError::kQuotaExceeded);
+
+    ASSERT_TRUE(table.Reserve(tenant_id, 5).has_value());
+    ASSERT_TRUE(table.Commit(tenant_id, 5).has_value());
+    table.IncrementMetadataObjectCount(tenant_id);
+
+    auto snapshot = Snapshot(table, "tenant-a");
+    EXPECT_EQ(snapshot.used_bytes, max);
+    EXPECT_EQ(snapshot.reserved_bytes, 0);
+    EXPECT_EQ(snapshot.committed_count, max);
+    EXPECT_EQ(snapshot.metadata_object_count, max);
+}
+
+TEST(ShardedTenantQuotaTableTest, ConcurrentReserveNeverExceedsQuota) {
+    ShardedTenantQuotaTable<8> table;
+    const TenantId tenant_id("tenant-a");
+    table.ApplyTenantPolicies({{tenant_id, 1000}}, 1000);
+
+    std::atomic<int> successes = 0;
+    std::vector<std::thread> workers;
+    for (int i = 0; i < 20; ++i) {
+        workers.emplace_back([&] {
+            if (table.Reserve(tenant_id, 100).has_value()) {
+                ++successes;
+            }
+        });
+    }
+    for (auto& worker : workers) {
+        worker.join();
+    }
+
+    EXPECT_EQ(successes.load(), 10);
+    EXPECT_EQ(Snapshot(table, "tenant-a").reserved_bytes, 1000);
+}
+
+TEST(ShardedTenantQuotaTableTest, DifferentShardsUpdateIndependently) {
+    using TestTable = ShardedTenantQuotaTable<2>;
+    const TenantId tenant_a("tenant-a");
+    TenantId tenant_b("tenant-b");
+    for (int suffix = 0; TenantIdHash{}(tenant_a) % TestTable::kNumShards ==
+                         TenantIdHash{}(tenant_b) % TestTable::kNumShards;
+         ++suffix) {
+        tenant_b = TenantId("tenant-b-" + std::to_string(suffix));
+    }
+
+    TestTable table;
+    table.ApplyTenantPolicies({{tenant_a, 1000}, {tenant_b, 1000}}, 2000);
+
+    std::atomic<int> failures = 0;
+    auto update = [&](const TenantId& tenant_id) {
+        for (int i = 0; i < 1000; ++i) {
+            if (!table.Reserve(tenant_id, 1) || !table.Abort(tenant_id, 1)) {
+                ++failures;
+            }
+        }
+    };
+    std::thread first(update, std::cref(tenant_a));
+    std::thread second(update, std::cref(tenant_b));
+    first.join();
+    second.join();
+
+    EXPECT_EQ(failures.load(), 0);
+    EXPECT_EQ(Snapshot(table, tenant_a.value()).reserved_bytes, 0);
+    EXPECT_EQ(Snapshot(table, tenant_b.value()).reserved_bytes, 0);
+}
+
+TEST(ShardedTenantQuotaTableTest,
+     DisabledPolicyRejectsRegularAndZeroByteReservations) {
+    ShardedTenantQuotaTable<8> table;
+    const TenantId tenant_id("tenant-a");
+    table.ApplyTenantPolicies({{tenant_id, 100}}, 100);
+    ASSERT_TRUE(table.DisableTenantPolicyIfEmpty(tenant_id).has_value());
+
+    auto regular = table.Reserve(tenant_id, 1);
+    auto zero = table.Reserve(tenant_id, 0);
+
+    ASSERT_FALSE(regular.has_value());
+    ASSERT_FALSE(zero.has_value());
+    EXPECT_EQ(regular.error(), TenantQuotaError::kTenantNotRegistered);
+    EXPECT_EQ(zero.error(), TenantQuotaError::kTenantNotRegistered);
+}
+
+TEST(ShardedTenantQuotaTableTest, RecomputeCanRunWithAccounting) {
+    ShardedTenantQuotaTable<8> table;
+    const TenantId tenant_id("tenant-a");
+    table.ApplyTenantPolicies({{tenant_id, 1000}}, 1000);
+
+    std::atomic<int> failures = 0;
+    std::thread accounting([&] {
+        for (int i = 0; i < 1000; ++i) {
+            if (!table.Reserve(tenant_id, 1) || !table.Abort(tenant_id, 1)) {
+                ++failures;
+            }
+        }
+    });
+    std::thread recompute([&] {
+        for (int i = 0; i < 1000; ++i) {
+            table.RecomputeEffectiveQuotas(1000);
+        }
+    });
+
+    accounting.join();
+    recompute.join();
+
+    EXPECT_EQ(failures.load(), 0);
+    auto snapshot = Snapshot(table, "tenant-a");
+    EXPECT_EQ(snapshot.reserved_bytes, 0);
+    EXPECT_EQ(snapshot.effective_quota_bytes, 1000);
 }
 
 TEST(TenantQuotaPolicyStoreTest, ParsesValidYamlUnits) {


### PR DESCRIPTION
## Description

Refactor the tenant quota in-memory state out of `MasterService` into a dedicated two-layer component:

- `TenantQuotaTable` is a single-threaded core state machine that owns policy state, effective quota calculation, accounting invariants, snapshots, metadata counts, usage rebuilds, and orphan cleanup.
- `ShardedTenantQuotaTable<NumShards>` adds per-tenant sharding and synchronization. `MasterService` explicitly uses 1024 shards.
- `MasterService` keeps quota feature gating, capacity discovery, policy-store persistence, metadata aggregation, error-code mapping, and cross-module transaction orchestration.
- Internal quota state and assignment details are hidden; snapshots use the strong `TenantId` type and convert to strings only at HTTP/metrics boundaries.
- Redundant quota state, shard helpers, recompute locking, and no-op forwarding helpers are removed from `MasterService`.

The refactor preserves existing RPC/Admin formats, configuration, metrics, admission behavior, deterministic proportional quota allocation, policy deletion rollback, and accounting behavior.

This work is covered by the tenant quota design in #2153. It overlaps conceptually with #2112, but differs in scope: #2112 introduces a tenant quota feature and eviction model, while this PR only consolidates the quota behavior already present on current `main`; it does not add a new quota model, API, or configuration.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**

```bash
ctest --test-dir <build-dir> --output-on-failure \
  -R '^(tenant_quota_test|master_service_tenant_quota_test)$'
ctest --test-dir <build-dir> --output-on-failure \
  -R '^(master_admin_server_test|master_metrics_test)$'
pre-commit run --files \
  mooncake-store/include/master_service.h \
  mooncake-store/include/tenant_quota.h \
  mooncake-store/src/master_admin_service.cpp \
  mooncake-store/src/master_service.cpp \
  mooncake-store/src/tenant_quota.cpp \
  mooncake-store/tests/master_service_tenant_quota_test.cpp \
  mooncake-store/tests/tenant_quota_test.cpp
git diff --check
```

**Test results:**

- [x] Unit tests pass
- [x] Integration tests pass
- [ ] Manual testing done

Additional regression coverage during development: `master_service_test` passed all 144 tests.

## Checklist

- [ ] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (not applicable: internal refactor with unchanged public behavior)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: covered by RFC #2153

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex assisted with implementation, test expansion, code review, validation, and PR drafting. The human submitter remains responsible for reviewing and defending the changes end-to-end.