### PR TITLE
[Bugfix][TransferEngine] Invalidate stale remote segments in syncSegmentCache

### DIFF
--- a/mooncake-transfer-engine/include/transfer_metadata.h
+++ b/mooncake-transfer-engine/include/transfer_metadata.h
@@ -190,6 +190,16 @@ class TransferMetadata {
 
     ~TransferMetadata();
 
+   protected:
+    // Test-only seam: inject a storage plugin directly, bypassing the
+    // conn-string plugin factory (which LOG(FATAL)s without a real
+    // etcd/redis/http backend) and the P2P handshake daemon. Derived
+    // hardware-free unit tests substitute an in-memory
+    // MetadataStoragePlugin to exercise syncSegmentCache without RDMA/CUDA.
+    explicit TransferMetadata(
+        std::shared_ptr<MetadataStoragePlugin> storage_plugin);
+
+   public:
     std::shared_ptr<SegmentDesc> getSegmentDescByName(
         const std::string &segment_name, bool force_update = false);
 
@@ -272,6 +282,11 @@ class TransferMetadata {
     std::unordered_map<uint64_t, std::shared_ptr<SegmentDesc>>
         segment_id_to_desc_map_;
     std::unordered_map<std::string, uint64_t> segment_name_to_id_map_;
+    // Per-REMOTE-segment consecutive fetch-failure streak, guarded by
+    // segment_lock_. Bumped in syncSegmentCache's apply phase when a cached
+    // segment's backend fetch fails; reset to 0 on a successful fetch. Once it
+    // reaches kStaleSegmentFailureThreshold the cached entry is invalidated.
+    std::unordered_map<std::string, int> segment_failure_counts_;
 
     RWSpinlock notify_lock_;
     std::vector<NotifyDesc> notifys;

--- a/mooncake-transfer-engine/include/transfer_metadata.h
+++ b/mooncake-transfer-engine/include/transfer_metadata.h
@@ -40,6 +40,18 @@ namespace mooncake {
 struct MetadataStoragePlugin;
 struct HandShakePlugin;
 
+// Result of a metadata-backend lookup, distinguishing an authoritative
+// key absence (kNotFound — the master removed the segment key on peer
+// unmount/expiry) from a transient backend failure (kUnavailable — curl
+// timeout, etcd blip, connection drop). syncSegmentCache() advances its
+// invalidation streak only for kNotFound so a metadata-service outage
+// cannot purge the live cache.
+enum class GetResult {
+    kFound,
+    kNotFound,
+    kUnavailable,
+};
+
 #define P2PHANDSHAKE "P2PHANDSHAKE"
 
 class TransferMetadata {
@@ -226,8 +238,11 @@ class TransferMetadata {
     int updateSegmentDesc(const std::string &segment_name,
                           const SegmentDesc &desc);
 
+    // Fetch a segment descriptor from the metadata backend. When |status|
+    // is non-null it receives the GetResult so the caller (syncSegmentCache)
+    // can distinguish an authoritative key removal from a transient outage.
     std::shared_ptr<SegmentDesc> getSegmentDesc(
-        const std::string &segment_name);
+        const std::string &segment_name, GetResult *status = nullptr);
 
     SegmentID getSegmentID(const std::string &segment_name);
 
@@ -279,7 +294,8 @@ class TransferMetadata {
 
    private:
     std::shared_ptr<SegmentDesc> getSegmentDescInternal(
-        const std::string &segment_name, bool force_rpc_update);
+        const std::string &segment_name, bool force_rpc_update,
+        GetResult *status = nullptr);
     int getRpcMetaEntryInternal(const std::string &server_name,
                                 RpcMetaDesc &desc, bool force_update);
     int publishSegmentDesc(const std::string &segment_name,

--- a/mooncake-transfer-engine/include/transfer_metadata.h
+++ b/mooncake-transfer-engine/include/transfer_metadata.h
@@ -241,8 +241,8 @@ class TransferMetadata {
     // Fetch a segment descriptor from the metadata backend. When |status|
     // is non-null it receives the GetResult so the caller (syncSegmentCache)
     // can distinguish an authoritative key removal from a transient outage.
-    std::shared_ptr<SegmentDesc> getSegmentDesc(
-        const std::string &segment_name, GetResult *status = nullptr);
+    std::shared_ptr<SegmentDesc> getSegmentDesc(const std::string &segment_name,
+                                                GetResult *status = nullptr);
 
     SegmentID getSegmentID(const std::string &segment_name);
 

--- a/mooncake-transfer-engine/include/transfer_metadata.h
+++ b/mooncake-transfer-engine/include/transfer_metadata.h
@@ -205,6 +205,16 @@ class TransferMetadata {
 
     ~TransferMetadata();
 
+   protected:
+    // Test-only seam: inject a storage plugin directly, bypassing the
+    // conn-string plugin factory (which LOG(FATAL)s without a real
+    // etcd/redis/http backend) and the P2P handshake daemon. Derived
+    // hardware-free unit tests substitute an in-memory
+    // MetadataStoragePlugin to exercise syncSegmentCache without RDMA/CUDA.
+    explicit TransferMetadata(
+        std::shared_ptr<MetadataStoragePlugin> storage_plugin);
+
+   public:
     std::shared_ptr<SegmentDesc> getSegmentDescByName(
         const std::string &segment_name, bool force_update = false);
 
@@ -295,6 +305,11 @@ class TransferMetadata {
     std::unordered_map<uint64_t, std::shared_ptr<SegmentDesc>>
         segment_id_to_desc_map_;
     std::unordered_map<std::string, uint64_t> segment_name_to_id_map_;
+    // Per-REMOTE-segment consecutive fetch-failure streak, guarded by
+    // segment_lock_. Bumped in syncSegmentCache's apply phase when a cached
+    // segment's backend fetch fails; reset to 0 on a successful fetch. Once it
+    // reaches kStaleSegmentFailureThreshold the cached entry is invalidated.
+    std::unordered_map<std::string, int> segment_failure_counts_;
 
     RWSpinlock notify_lock_;
     std::vector<NotifyDesc> notifys;

--- a/mooncake-transfer-engine/include/transfer_metadata_plugin.h
+++ b/mooncake-transfer-engine/include/transfer_metadata_plugin.h
@@ -26,6 +26,16 @@ struct MetadataStoragePlugin {
     virtual ~MetadataStoragePlugin() {}
 
     virtual bool get(const std::string &key, Json::Value &value) = 0;
+    // Error-aware lookup: same contract as get() but reports whether a
+    // non-found result is an authoritative key absence (kNotFound) or a
+    // transient backend failure (kUnavailable). Plugins that can tell the
+    // two apart (Redis nil reply, HTTP 404 vs 5xx) should override this;
+    // the default delegates to get() and maps false->kNotFound, preserving
+    // the pre-existing behavior for plugins that do not distinguish.
+    virtual GetResult getWithStatus(const std::string &key,
+                                    Json::Value &value) {
+        return get(key, value) ? GetResult::kFound : GetResult::kNotFound;
+    }
     virtual bool set(const std::string &key, const Json::Value &value) = 0;
     virtual bool remove(const std::string &key) = 0;
 };

--- a/mooncake-transfer-engine/include/transfer_metadata_plugin.h
+++ b/mooncake-transfer-engine/include/transfer_metadata_plugin.h
@@ -29,12 +29,15 @@ struct MetadataStoragePlugin {
     // Error-aware lookup: same contract as get() but reports whether a
     // non-found result is an authoritative key absence (kNotFound) or a
     // transient backend failure (kUnavailable). Plugins that can tell the
-    // two apart (Redis nil reply, HTTP 404 vs 5xx) should override this;
-    // the default delegates to get() and maps false->kNotFound, preserving
-    // the pre-existing behavior for plugins that do not distinguish.
+    // two apart (etcd key-absent response, Redis nil reply, HTTP 404 vs 5xx)
+    // must override this; the default delegates to get() and maps any
+    // failure to kUnavailable. Failing closed is deliberate: a plugin that
+    // cannot distinguish absence from an outage must never report kNotFound,
+    // because syncSegmentCache() would then evict a still-live cache entry
+    // on a backend outage.
     virtual GetResult getWithStatus(const std::string &key,
                                     Json::Value &value) {
-        return get(key, value) ? GetResult::kFound : GetResult::kNotFound;
+        return get(key, value) ? GetResult::kFound : GetResult::kUnavailable;
     }
     virtual bool set(const std::string &key, const Json::Value &value) = 0;
     virtual bool remove(const std::string &key) = 0;

--- a/mooncake-transfer-engine/src/transfer_metadata.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata.cpp
@@ -50,6 +50,14 @@ static inline std::string extractProtocolFromConnString(
     return "etcd";
 }
 
+// A cached REMOTE segment whose backend fetch keeps failing this many
+// consecutive sync cycles is treated as gone (peer unmounted / master expiry
+// cleanup removed its key) and invalidated from the local cache. The plugin
+// get() collapses "not found" and "transient error" into a single false, so a
+// single blip must not trigger a purge -- only a streak that persists across
+// cycles does.
+static constexpr int kStaleSegmentFailureThreshold = 2;
+
 struct TransferNotifyUtil {
     static Json::Value encode(const TransferMetadata::NotifyDesc &desc) {
         Json::Value root;
@@ -180,6 +188,20 @@ TransferMetadata::TransferMetadata(const std::string &conn_string) {
             << "Unable to create metadata storage plugin with conn string "
             << conn_string;
     }
+    startMetadataRefreshPollingIfNeeded();
+}
+
+TransferMetadata::TransferMetadata(
+    std::shared_ptr<MetadataStoragePlugin> storage_plugin) {
+    // Test-only seam (see header). Mirrors the conn-string ctor's key-prefix
+    // setup so getFullMetadataKey() yields "mooncake/ram/<name>" keys, but
+    // skips the plugin factory (no etcd/redis/http needed) and the P2P
+    // handshake daemon. The background refresh poller stays disabled when the
+    // caller configures a zero refresh interval.
+    next_segment_id_.store(1);
+    common_key_prefix_ = "mooncake/";
+    rpc_meta_prefix_ = common_key_prefix_ + "rpc_meta/";
+    storage_plugin_ = std::move(storage_plugin);
     startMetadataRefreshPollingIfNeeded();
 }
 
@@ -1069,9 +1091,14 @@ int TransferMetadata::syncSegmentCache(const std::string &segment_name) {
     size_t updated_count = 0;
     size_t unchanged_count = 0;
     size_t skipped_count = 0;
+    size_t invalidated_count = 0;
 
     // Fetch updates without holding lock (may involve network I/O)
     std::vector<std::pair<std::string, std::shared_ptr<SegmentDesc>>> updates;
+    // Cached REMOTE segment names whose backend fetch failed this cycle.
+    // Resolved into per-segment failure streaks under the write lock below, so
+    // no shared state (segment_failure_counts_) is touched during network I/O.
+    std::vector<std::string> failed_names;
     for (const auto &name : names_to_sync) {
         auto segment_desc = getSegmentDesc(name);
         if (segment_desc) {
@@ -1079,6 +1106,7 @@ int TransferMetadata::syncSegmentCache(const std::string &segment_name) {
             ++fetched_count;
         } else {
             ++failed_count;
+            failed_names.push_back(name);
             LOG(WARNING) << "segment " << name << " is now invalid";
         }
     }
@@ -1087,6 +1115,10 @@ int TransferMetadata::syncSegmentCache(const std::string &segment_name) {
         // Apply updates with write lock
         RWSpinlock::WriteGuard guard(segment_lock_);
         for (const auto &[name, desc] : updates) {
+            // A successful fetch ends any prior failure streak for this
+            // segment; the entry stays cached. Done under the write lock
+            // because segment_failure_counts_ is guarded by segment_lock_.
+            segment_failure_counts_[name] = 0;
             auto it = segment_name_to_id_map_.find(name);
             if (it == segment_name_to_id_map_.end()) {
                 ++skipped_count;
@@ -1121,6 +1153,40 @@ int TransferMetadata::syncSegmentCache(const std::string &segment_name) {
             LOG(INFO) << "New segment descriptor:";
             desc->dump();
         }
+
+        // Invalidate stale REMOTE segments. MetadataStoragePlugin::get()
+        // collapses "key removed" and "transient backend error" (curl timeout,
+        // etcd blip) into a single false, so erasing on the first failure
+        // would purge the whole cache during a transient blip and strand
+        // in-flight transfers whose callers still hold a shared_ptr copy of
+        // the descriptor. A consecutive-failure streak that persists across
+        // sync cycles is the signal that the segment is genuinely gone (the
+        // master removed its key on peer unmount/expiry); only then do we
+        // drop the cached entry, mirroring the erase pattern in
+        // removeSegmentDesc() (segment_id_to_desc_map_ + name map).
+        for (const auto &name : failed_names) {
+            ++segment_failure_counts_[name];
+        }
+        for (auto fit = segment_failure_counts_.begin();
+             fit != segment_failure_counts_.end();) {
+            if (fit->second < kStaleSegmentFailureThreshold) {
+                ++fit;
+                continue;
+            }
+            const auto &name = fit->first;
+            auto name_it = segment_name_to_id_map_.find(name);
+            // Only invalidate cached remote entries; LOCAL_SEGMENT_ID is
+            // skipped by the collect phase and must never be purged here.
+            if (name_it != segment_name_to_id_map_.end() &&
+                name_it->second != LOCAL_SEGMENT_ID) {
+                segment_id_to_desc_map_.erase(name_it->second);
+                segment_name_to_id_map_.erase(name_it);
+                ++invalidated_count;
+                LOG(WARNING)
+                    << "Invalidated stale segment cache entry, name=" << name;
+            }
+            fit = segment_failure_counts_.erase(fit);
+        }
     }
     const auto sync_duration_ms =
         std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -1132,6 +1198,7 @@ int TransferMetadata::syncSegmentCache(const std::string &segment_name) {
               << ", fetched=" << fetched_count << ", updated=" << updated_count
               << ", unchanged=" << unchanged_count
               << ", failed=" << failed_count << ", skipped=" << skipped_count
+              << ", invalidated=" << invalidated_count
               << ", sync_duration_ms=" << sync_duration_ms;
     return 0;
 }

--- a/mooncake-transfer-engine/src/transfer_metadata.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata.cpp
@@ -1226,13 +1226,14 @@ int TransferMetadata::receivePeerMetadata(const Json::Value &peer_json,
 }
 
 std::shared_ptr<TransferMetadata::SegmentDesc> TransferMetadata::getSegmentDesc(
-    const std::string &segment_name) {
-    return getSegmentDescInternal(segment_name, false);
+    const std::string &segment_name, GetResult *status) {
+    return getSegmentDescInternal(segment_name, false, status);
 }
 
 std::shared_ptr<TransferMetadata::SegmentDesc>
 TransferMetadata::getSegmentDescInternal(const std::string &segment_name,
-                                         bool force_rpc_update) {
+                                         bool force_rpc_update,
+                                         GetResult *status) {
     Json::Value peer_json;
 
     if (p2p_handshake_mode_) {
@@ -1244,22 +1245,27 @@ TransferMetadata::getSegmentDescInternal(const std::string &segment_name,
             auto it = segment_id_to_desc_map_.find(LOCAL_SEGMENT_ID);
             if (it == segment_id_to_desc_map_.end() || !it->second) {
                 LOG(ERROR) << "Local segment descriptor not found";
+                if (status) *status = GetResult::kUnavailable;
                 return nullptr;
             }
             desc = it->second;
         }
         int ret = encodeSegmentDesc(*desc.get(), local_json);
         if (ret) {
+            if (status) *status = GetResult::kUnavailable;
             return nullptr;
         }
         ret = handshake_plugin_->exchangeMetadata(ip, port, local_json,
                                                   peer_json);
         if (ret) {
+            if (status) *status = GetResult::kUnavailable;
             return nullptr;
         }
     } else {
-        if (!storage_plugin_->get(getFullMetadataKey(segment_name),
-                                  peer_json)) {
+        GetResult result = storage_plugin_->getWithStatus(
+            getFullMetadataKey(segment_name), peer_json);
+        if (result != GetResult::kFound) {
+            if (status) *status = result;
             LOG(WARNING) << "Failed to retrieve segment descriptor, name "
                          << segment_name;
             return nullptr;
@@ -1267,6 +1273,11 @@ TransferMetadata::getSegmentDescInternal(const std::string &segment_name,
     }
 
     auto result = decodeSegmentDesc(peer_json, segment_name);
+    if (!result) {
+        if (status) *status = GetResult::kUnavailable;
+        return nullptr;
+    }
+    if (status) *status = GetResult::kFound;
 
     // Compatibility for descriptors published before tcp_data_host was part
     // of SegmentDesc. Freeze the legacy RPC location into this descriptor
@@ -1343,22 +1354,34 @@ int TransferMetadata::syncSegmentCache(const std::string &segment_name) {
     size_t skipped_count = 0;
     std::vector<std::string> updated_names;
     size_t invalidated_count = 0;
+    size_t unavailable_count = 0;
 
     // Fetch updates without holding lock (may involve network I/O)
     std::vector<std::pair<std::string, std::shared_ptr<SegmentDesc>>> updates;
-    // Cached REMOTE segment names whose backend fetch failed this cycle.
-    // Resolved into per-segment failure streaks under the write lock below, so
-    // no shared state (segment_failure_counts_) is touched during network I/O.
+    // Cached REMOTE segment names whose backend lookup returned kNotFound
+    // (authoritative key absence -- the master removed the key on peer
+    // unmount/expiry). Resolved into per-segment failure streaks under the
+    // write lock below, so no shared state (segment_failure_counts_) is
+    // touched during network I/O. Transient failures (kUnavailable) do NOT
+    // enter this list -- they must not advance the streak.
     std::vector<std::string> failed_names;
     for (const auto &name : names_to_sync) {
-        auto segment_desc = getSegmentDescInternal(name, true);
+        GetResult status = GetResult::kUnavailable;
+        auto segment_desc = getSegmentDescInternal(name, true, &status);
         if (segment_desc) {
             updates.emplace_back(name, segment_desc);
             ++fetched_count;
-        } else {
+        } else if (status == GetResult::kNotFound) {
             ++failed_count;
             failed_names.push_back(name);
             LOG(WARNING) << "segment " << name << " is now invalid";
+        } else {
+            // Transient backend failure (kUnavailable): the key may still
+            // exist; do NOT advance the invalidation streak. The cached
+            // entry survives and is retried next sync cycle.
+            ++unavailable_count;
+            LOG(WARNING) << "segment " << name
+                         << " backend unavailable (transient)";
         }
     }
 
@@ -1417,16 +1440,16 @@ int TransferMetadata::syncSegmentCache(const std::string &segment_name) {
             desc->dump();
         }
 
-        // Invalidate stale REMOTE segments. MetadataStoragePlugin::get()
-        // collapses "key removed" and "transient backend error" (curl timeout,
-        // etcd blip) into a single false, so erasing on the first failure
-        // would purge the whole cache during a transient blip and strand
-        // in-flight transfers whose callers still hold a shared_ptr copy of
-        // the descriptor. A consecutive-failure streak that persists across
-        // sync cycles is the signal that the segment is genuinely gone (the
-        // master removed its key on peer unmount/expiry); only then do we
-        // drop the cached entry, mirroring the erase pattern in
-        // removeSegmentDesc() (segment_id_to_desc_map_ + name map).
+        // Invalidate stale REMOTE segments. Only authoritative key-absence
+        // results (kNotFound -- the master removed the key on peer
+        // unmount/expiry) enter failed_names and advance the streak.
+        // Transient backend failures (kUnavailable) are excluded above, so
+        // a metadata-service outage cannot purge the cache and strand
+        // in-flight transfers whose callers still hold a shared_ptr copy
+        // of the descriptor. A consecutive-failure streak that persists
+        // across sync cycles is the signal that the segment is genuinely
+        // gone; only then do we drop the cached entry, mirroring the erase
+        // pattern in removeSegmentDesc() (segment_id_to_desc_map_ + name map).
         for (const auto &name : failed_names) {
             ++segment_failure_counts_[name];
         }
@@ -1471,7 +1494,9 @@ int TransferMetadata::syncSegmentCache(const std::string &segment_name) {
               << ", scanned=" << names_to_sync.size()
               << ", fetched=" << fetched_count << ", updated=" << updated_count
               << ", unchanged=" << unchanged_count
-              << ", failed=" << failed_count << ", skipped=" << skipped_count
+              << ", failed=" << failed_count
+              << ", unavailable=" << unavailable_count
+              << ", skipped=" << skipped_count
               << ", invalidated=" << invalidated_count
               << ", sync_duration_ms=" << sync_duration_ms;
     return 0;

--- a/mooncake-transfer-engine/src/transfer_metadata.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata.cpp
@@ -143,6 +143,14 @@ static inline std::string extractProtocolFromConnString(
     return "etcd";
 }
 
+// A cached REMOTE segment whose backend fetch keeps failing this many
+// consecutive sync cycles is treated as gone (peer unmounted / master expiry
+// cleanup removed its key) and invalidated from the local cache. The plugin
+// get() collapses "not found" and "transient error" into a single false, so a
+// single blip must not trigger a purge -- only a streak that persists across
+// cycles does.
+static constexpr int kStaleSegmentFailureThreshold = 2;
+
 struct TransferNotifyUtil {
     static Json::Value encode(const TransferMetadata::NotifyDesc &desc) {
         Json::Value root;
@@ -295,6 +303,20 @@ TransferMetadata::TransferMetadata(const std::string &conn_string) {
             << "Unable to create metadata storage plugin with conn string "
             << conn_string;
     }
+    startMetadataRefreshPollingIfNeeded();
+}
+
+TransferMetadata::TransferMetadata(
+    std::shared_ptr<MetadataStoragePlugin> storage_plugin) {
+    // Test-only seam (see header). Mirrors the conn-string ctor's key-prefix
+    // setup so getFullMetadataKey() yields "mooncake/ram/<name>" keys, but
+    // skips the plugin factory (no etcd/redis/http needed) and the P2P
+    // handshake daemon. The background refresh poller stays disabled when the
+    // caller configures a zero refresh interval.
+    next_segment_id_.store(1);
+    common_key_prefix_ = "mooncake/";
+    rpc_meta_prefix_ = common_key_prefix_ + "rpc_meta/";
+    storage_plugin_ = std::move(storage_plugin);
     startMetadataRefreshPollingIfNeeded();
 }
 
@@ -1320,9 +1342,14 @@ int TransferMetadata::syncSegmentCache(const std::string &segment_name) {
     size_t unchanged_count = 0;
     size_t skipped_count = 0;
     std::vector<std::string> updated_names;
+    size_t invalidated_count = 0;
 
     // Fetch updates without holding lock (may involve network I/O)
     std::vector<std::pair<std::string, std::shared_ptr<SegmentDesc>>> updates;
+    // Cached REMOTE segment names whose backend fetch failed this cycle.
+    // Resolved into per-segment failure streaks under the write lock below, so
+    // no shared state (segment_failure_counts_) is touched during network I/O.
+    std::vector<std::string> failed_names;
     for (const auto &name : names_to_sync) {
         auto segment_desc = getSegmentDescInternal(name, true);
         if (segment_desc) {
@@ -1330,6 +1357,7 @@ int TransferMetadata::syncSegmentCache(const std::string &segment_name) {
             ++fetched_count;
         } else {
             ++failed_count;
+            failed_names.push_back(name);
             LOG(WARNING) << "segment " << name << " is now invalid";
         }
     }
@@ -1338,6 +1366,10 @@ int TransferMetadata::syncSegmentCache(const std::string &segment_name) {
         // Apply updates with write lock
         RWSpinlock::WriteGuard guard(segment_lock_);
         for (const auto &[name, desc] : updates) {
+            // A successful fetch ends any prior failure streak for this
+            // segment; the entry stays cached. Done under the write lock
+            // because segment_failure_counts_ is guarded by segment_lock_.
+            segment_failure_counts_[name] = 0;
             auto it = segment_name_to_id_map_.find(name);
             if (it == segment_name_to_id_map_.end()) {
                 ++skipped_count;
@@ -1384,6 +1416,40 @@ int TransferMetadata::syncSegmentCache(const std::string &segment_name) {
             LOG(INFO) << "New segment descriptor:";
             desc->dump();
         }
+
+        // Invalidate stale REMOTE segments. MetadataStoragePlugin::get()
+        // collapses "key removed" and "transient backend error" (curl timeout,
+        // etcd blip) into a single false, so erasing on the first failure
+        // would purge the whole cache during a transient blip and strand
+        // in-flight transfers whose callers still hold a shared_ptr copy of
+        // the descriptor. A consecutive-failure streak that persists across
+        // sync cycles is the signal that the segment is genuinely gone (the
+        // master removed its key on peer unmount/expiry); only then do we
+        // drop the cached entry, mirroring the erase pattern in
+        // removeSegmentDesc() (segment_id_to_desc_map_ + name map).
+        for (const auto &name : failed_names) {
+            ++segment_failure_counts_[name];
+        }
+        for (auto fit = segment_failure_counts_.begin();
+             fit != segment_failure_counts_.end();) {
+            if (fit->second < kStaleSegmentFailureThreshold) {
+                ++fit;
+                continue;
+            }
+            const auto &name = fit->first;
+            auto name_it = segment_name_to_id_map_.find(name);
+            // Only invalidate cached remote entries; LOCAL_SEGMENT_ID is
+            // skipped by the collect phase and must never be purged here.
+            if (name_it != segment_name_to_id_map_.end() &&
+                name_it->second != LOCAL_SEGMENT_ID) {
+                segment_id_to_desc_map_.erase(name_it->second);
+                segment_name_to_id_map_.erase(name_it);
+                ++invalidated_count;
+                LOG(WARNING)
+                    << "Invalidated stale segment cache entry, name=" << name;
+            }
+            fit = segment_failure_counts_.erase(fit);
+        }
     }
 
     // RPC locations are cached independently from segment descriptors under
@@ -1406,6 +1472,7 @@ int TransferMetadata::syncSegmentCache(const std::string &segment_name) {
               << ", fetched=" << fetched_count << ", updated=" << updated_count
               << ", unchanged=" << unchanged_count
               << ", failed=" << failed_count << ", skipped=" << skipped_count
+              << ", invalidated=" << invalidated_count
               << ", sync_duration_ms=" << sync_duration_ms;
     return 0;
 }

--- a/mooncake-transfer-engine/src/transfer_metadata_plugin.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata_plugin.cpp
@@ -168,6 +168,37 @@ struct RedisStoragePlugin : public MetadataStoragePlugin {
         return true;
     }
 
+    // Distinguishes a nil reply (key absent — kNotFound) from a connection
+    // or command error (kUnavailable) so syncSegmentCache does not purge the
+    // cache during a Redis outage.
+    GetResult getWithStatus(const std::string &key,
+                            Json::Value &value) override {
+        std::lock_guard<std::mutex> lock(access_client_mutex_);
+        if (!client_) return GetResult::kUnavailable;
+
+        redisReply *resp =
+            (redisReply *)redisCommand(client_, "GET %s", key.c_str());
+        if (!resp) {
+            LOG(ERROR) << "RedisStoragePlugin: unable to get " << key
+                       << " from " << metadata_uri_;
+            return GetResult::kUnavailable;
+        }
+        if (!resp->str) {
+            freeReplyObject(resp);
+            return GetResult::kNotFound;
+        }
+
+        auto json_file = std::string(resp->str);
+        freeReplyObject(resp);
+
+        std::string errs;
+        if (!parseJsonString(json_file, value, &errs)) {
+            LOG(ERROR) << "RedisStoragePlugin: JSON parse error: " << errs;
+            return GetResult::kUnavailable;
+        }
+        return GetResult::kFound;
+    }
+
     virtual bool set(const std::string &key, const Json::Value &value) {
         std::lock_guard<std::mutex> lock(access_client_mutex_);
         if (!client_) return false;
@@ -303,6 +334,54 @@ struct HTTPStoragePlugin : public MetadataStoragePlugin {
             return false;
         }
         return true;
+    }
+
+    // Distinguishes HTTP 404 (key absent — kNotFound) from curl/network
+    // errors and server-side 5xx (kUnavailable) so syncSegmentCache does not
+    // purge the cache during an etcd/master outage.
+    GetResult getWithStatus(const std::string &key,
+                            Json::Value &value) override {
+        CURL *h = tl_easy();
+        curl_easy_reset(h);
+
+        std::string readBody;
+        char errbuf[CURL_ERROR_SIZE] = {0};
+
+        curl_easy_setopt(h, CURLOPT_TIMEOUT_MS, 3000L);
+        curl_easy_setopt(h, CURLOPT_CONNECTTIMEOUT_MS, 1500L);
+
+        const std::string url = encodeUrl(key);
+        curl_easy_setopt(h, CURLOPT_URL, url.c_str());
+        curl_easy_setopt(h, CURLOPT_HTTPGET, 1L);
+        curl_easy_setopt(h, CURLOPT_WRITEFUNCTION, writeCallback);
+        curl_easy_setopt(h, CURLOPT_WRITEDATA, &readBody);
+        curl_easy_setopt(h, CURLOPT_ERRORBUFFER, errbuf);
+
+        CURLcode rc = curl_easy_perform(h);
+        if (rc != CURLE_OK) {
+            LOG(ERROR) << "GET " << url << " curl: " << curl_easy_strerror(rc)
+                       << " err: " << errbuf;
+            return GetResult::kUnavailable;
+        }
+
+        long code = 0;
+        curl_easy_getinfo(h, CURLINFO_RESPONSE_CODE, &code);
+        if (code == 404) return GetResult::kNotFound;
+        if (!is_200(code)) {
+            LOG(ERROR) << "GET " << url << " http=" << code
+                       << " body: " << readBody;
+            return GetResult::kUnavailable;
+        }
+
+        Json::CharReaderBuilder b;
+        std::string errs;
+        std::unique_ptr<Json::CharReader> r(b.newCharReader());
+        if (!r->parse(readBody.data(), readBody.data() + readBody.size(),
+                      &value, &errs)) {
+            LOG(ERROR) << "GET " << url << " json parse error: " << errs;
+            return GetResult::kUnavailable;
+        }
+        return GetResult::kFound;
     }
 
     bool set(const std::string &key, const Json::Value &value) override {

--- a/mooncake-transfer-engine/src/transfer_metadata_plugin.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata_plugin.cpp
@@ -498,6 +498,29 @@ struct EtcdStoragePlugin : public MetadataStoragePlugin {
         return true;
     }
 
+    // etcd v3 answers a range request for a missing key with an OK response
+    // carrying no value, so an empty payload is an authoritative absence;
+    // everything else that fails (RPC error, timeout, malformed payload) is
+    // reported as unavailability, never as absence.
+    GetResult getWithStatus(const std::string &key,
+                            Json::Value &value) override {
+        auto resp = client_.get(key);
+        if (!resp.is_ok()) {
+            LOG(ERROR) << "EtcdStoragePlugin: unable to get " << key << " from "
+                       << metadata_uri_ << ": " << resp.error_message();
+            return GetResult::kUnavailable;
+        }
+        auto json_file = resp.value().as_string();
+        if (json_file.empty()) return GetResult::kNotFound;
+
+        std::string errs;
+        if (!parseJsonString(json_file, value, &errs)) {
+            LOG(ERROR) << "EtcdStoragePlugin: JSON parse error: " << errs;
+            return GetResult::kUnavailable;
+        }
+        return GetResult::kFound;
+    }
+
     virtual bool set(const std::string &key, const Json::Value &value) {
         Json::FastWriter writer;
         const std::string json_file = writer.write(value);
@@ -564,6 +587,36 @@ struct EtcdStoragePlugin : public MetadataStoragePlugin {
             return false;
         }
         return true;
+    }
+
+    // EtcdGetWrapper reports a missing key as ret == 0 with no payload, so
+    // that combination is an authoritative absence; a non-zero return (RPC
+    // error, timeout) is unavailability, never absence.
+    GetResult getWithStatus(const std::string &key,
+                            Json::Value &value) override {
+        char *json_data = nullptr;
+        auto ret = EtcdGetWrapper((char *)key.c_str(), &json_data, &err_msg_);
+        if (ret) {
+            LOG(ERROR) << "EtcdStoragePlugin: unable to get " << key << " in "
+                       << metadata_uri_ << ": " << err_msg_;
+            // free the memory for storing error message
+            free(err_msg_);
+            err_msg_ = nullptr;
+            return GetResult::kUnavailable;
+        }
+        if (!json_data) {
+            return GetResult::kNotFound;
+        }
+        auto json_file = std::string(json_data);
+        // free the memory allocated by EtcdGetWrapper
+        free(json_data);
+
+        std::string errs;
+        if (!parseJsonString(json_file, value, &errs)) {
+            LOG(ERROR) << "EtcdStoragePlugin: JSON parse error: " << errs;
+            return GetResult::kUnavailable;
+        }
+        return GetResult::kFound;
     }
 
     virtual bool set(const std::string &key, const Json::Value &value) {

--- a/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
+++ b/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
@@ -21,6 +21,8 @@
 
 #include <chrono>
 #include <cstdlib>
+#include <map>
+#include <memory>
 #include <thread>
 
 #include "config.h"
@@ -231,6 +233,138 @@ TEST(TransferMetadataPollingTest, PollingRefreshesCachedRemoteSegmentDesc) {
     }
 
     FAIL() << "TE metadata refresh polling did not refresh cached descriptor";
+}
+
+namespace {
+
+// Hardware-free in-memory MetadataStoragePlugin. get() returns false for keys
+// absent from the store (a removed/unmounted segment) and can be made to fail
+// a bounded number of times via failNext() to reproduce a transient backend
+// blip. No RDMA/CUDA/etcd is required.
+class FakeMetadataStoragePlugin : public MetadataStoragePlugin {
+   public:
+    bool get(const std::string &key, Json::Value &value) override {
+        auto fit = forced_failures_.find(key);
+        if (fit != forced_failures_.end() && fit->second > 0) {
+            --fit->second;
+            return false;  // transient blip: the key may still be in store_
+        }
+        auto it = store_.find(key);
+        if (it == store_.end()) return false;
+        value = it->second;
+        return true;
+    }
+    bool set(const std::string &key, const Json::Value &value) override {
+        store_[key] = value;
+        return true;
+    }
+    bool remove(const std::string &key) override {
+        store_.erase(key);
+        return true;
+    }
+
+    // Simulate the master-side cleanup of a peer's segment key (unmount or
+    // client expiry): the key vanishes from the backend, so every later
+    // get() returns false.
+    void drop(const std::string &key) { store_.erase(key); }
+
+    // Inject n transient get() failures for key without removing the key,
+    // modelling a curl timeout / etcd blip that resolves next sync cycle.
+    void failNext(const std::string &key, int n) { forced_failures_[key] = n; }
+
+   private:
+    std::map<std::string, Json::Value> store_;
+    std::map<std::string, int> forced_failures_;
+};
+
+// Exposes the protected storage-plugin injection seam to hardware-free tests.
+class TestableTransferMetadata : public TransferMetadata {
+   public:
+    explicit TestableTransferMetadata(
+        std::shared_ptr<MetadataStoragePlugin> storage_plugin)
+        : TransferMetadata(std::move(storage_plugin)) {}
+};
+
+}  // namespace
+
+class TransferMetadataStaleSegmentInvalidationTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        google::InitGoogleLogging("TransferMetadataStaleSegmentInvalidationTest");
+        FLAGS_logtostderr = 1;
+    }
+    void TearDown() override { google::ShutdownGoogleLogging(); }
+
+    // Publish a remote rdma segment to the fake backend and cache it locally
+    // (as a non-local id), returning the cached descriptor so callers can
+    // assert on cache state.
+    std::shared_ptr<TransferMetadata::SegmentDesc> seedRemoteSegment(
+        TransferMetadata &client, const std::string &name) {
+        auto desc = makeRdmaSegmentDesc(name, 0x1000);
+        EXPECT_EQ(client.updateSegmentDesc(name, *desc), 0);
+        EXPECT_NE(client.getSegmentID(name),
+                  static_cast<TransferMetadata::SegmentID>(-1));
+        return client.getSegmentDescByName(name);
+    }
+};
+
+// Red on master / green on branch: a cached remote segment whose backend key
+// is removed (peer unmount) is invalidated only after the consecutive-failure
+// streak reaches the threshold -- not on the first failure. On master there
+// is no invalidation branch, so the stale entry is never erased and the final
+// expectation fails.
+TEST_F(TransferMetadataStaleSegmentInvalidationTest,
+       ErasesStaleEntryAfterConsecutiveFailures) {
+    // No background refresh thread (interval == 0) with the cache-hit fast path
+    // on (metacache == true): getSegmentDescByName reflects the local cache,
+    // and we drive syncSegmentCache explicitly to count failures precisely.
+    ScopedMetadataRefreshConfig restore(0, true);
+
+    auto plugin = std::make_shared<FakeMetadataStoragePlugin>();
+    TestableTransferMetadata client(plugin);
+
+    const std::string name = "B";
+    ASSERT_TRUE(seedRemoteSegment(client, name));
+
+    // Peer B unmounts: the master removes mooncake/ram/B; every get() fails.
+    plugin->drop("mooncake/ram/B");
+
+    // First failed sync: streak is 1, below the threshold -> retain the entry,
+    // guarding against a single transient blip purging the whole cache.
+    ASSERT_EQ(client.syncSegmentCache(""), 0);
+    EXPECT_NE(client.getSegmentDescByName(name), nullptr);
+
+    // Second consecutive failed sync: streak reaches the threshold -> the
+    // stale cached entry is invalidated. Red-on-master: master never erases,
+    // so getSegmentDescByName keeps returning the cached descriptor.
+    ASSERT_EQ(client.syncSegmentCache(""), 0);
+    EXPECT_EQ(client.getSegmentDescByName(name), nullptr);
+}
+
+// Transient-failure guard: a segment that fails once and then succeeds on the
+// next cycle must NOT be invalidated -- the successful fetch resets its
+// streak. Guards against an erase-on-first-failure regression.
+TEST_F(TransferMetadataStaleSegmentInvalidationTest,
+       TransientFailureIsRetained) {
+    ScopedMetadataRefreshConfig restore(0, true);
+
+    auto plugin = std::make_shared<FakeMetadataStoragePlugin>();
+    TestableTransferMetadata client(plugin);
+
+    const std::string name = "C";
+    ASSERT_TRUE(seedRemoteSegment(client, name));
+
+    // One transient get() failure: the key still lives in the backend, so the
+    // segment is genuinely alive and must not count toward removal.
+    plugin->failNext("mooncake/ram/C", 1);
+
+    ASSERT_EQ(client.syncSegmentCache(""), 0);
+    EXPECT_NE(client.getSegmentDescByName(name), nullptr);
+
+    // Next cycle the blip clears: get() succeeds again, the streak resets to
+    // zero, and the cached entry survives.
+    ASSERT_EQ(client.syncSegmentCache(""), 0);
+    EXPECT_NE(client.getSegmentDescByName(name), nullptr);
 }
 
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
+++ b/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
@@ -40,7 +40,7 @@ class TransferMetadataTest : public ::testing::Test {
         google::InitGoogleLogging("TransferMetadataTest");
         FLAGS_logtostderr = 1;  // output to stdout
 
-        const char* env = std::getenv("MC_METADATA_SERVER");
+        const char *env = std::getenv("MC_METADATA_SERVER");
         if (env)
             metadata_server = env;
         else
@@ -102,11 +102,11 @@ TEST_F(TransferMetadataTest, LocalMemoryBufferTest) {
         ASSERT_EQ(re, 0);
     }
     addr = 1000;
-    re = metadata_client->removeLocalMemoryBuffer((void*)addr, false);
+    re = metadata_client->removeLocalMemoryBuffer((void *)addr, false);
     ASSERT_EQ(re, ERR_ADDRESS_NOT_REGISTERED);
     for (int i = 9; i > 0; --i) {
         addr = i * 2048;
-        re = metadata_client->removeLocalMemoryBuffer((void*)addr, false);
+        re = metadata_client->removeLocalMemoryBuffer((void *)addr, false);
         ASSERT_EQ(re, 0);
     }
     re = metadata_client->removeLocalSegment("test_local_segment");
@@ -161,7 +161,7 @@ TransferMetadata::BufferDesc makeRdmaBufferDesc(uint64_t addr) {
 }
 
 std::shared_ptr<TransferMetadata::SegmentDesc> makeRdmaSegmentDesc(
-    const std::string& name, uint64_t addr) {
+    const std::string &name, uint64_t addr) {
     auto segment_desc = std::make_shared<TransferMetadata::SegmentDesc>();
     segment_desc->name = name;
     segment_desc->protocol = "rdma";
@@ -214,7 +214,7 @@ TEST(TransferMetadataPollingTest, PollingRefreshesCachedRemoteSegmentDesc) {
     ASSERT_EQ(cached_desc->buffers[0].addr, kInitialAddr);
 
     ASSERT_EQ(server.removeLocalMemoryBuffer(
-                  reinterpret_cast<void*>(kInitialAddr), false),
+                  reinterpret_cast<void *>(kInitialAddr), false),
               0);
     ASSERT_EQ(
         server.addLocalMemoryBuffer(makeRdmaBufferDesc(kUpdatedAddr), false),
@@ -290,7 +290,8 @@ class TestableTransferMetadata : public TransferMetadata {
 class TransferMetadataStaleSegmentInvalidationTest : public ::testing::Test {
    protected:
     void SetUp() override {
-        google::InitGoogleLogging("TransferMetadataStaleSegmentInvalidationTest");
+        google::InitGoogleLogging(
+            "TransferMetadataStaleSegmentInvalidationTest");
         FLAGS_logtostderr = 1;
     }
     void TearDown() override { google::ShutdownGoogleLogging(); }
@@ -369,7 +370,7 @@ TEST_F(TransferMetadataStaleSegmentInvalidationTest,
 
 }  // namespace mooncake
 
-int main(int argc, char** argv) {
+int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }

--- a/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
+++ b/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
@@ -1115,6 +1115,37 @@ class FakeMetadataStoragePlugin : public MetadataStoragePlugin {
     std::map<std::string, int> forced_failures_;
 };
 
+// A backend that only implements the legacy bool get() and cannot tell a
+// missing key from a backend failure, so it inherits the default
+// getWithStatus() mapping instead of overriding it.
+class OpaqueMetadataStoragePlugin : public MetadataStoragePlugin {
+   public:
+    bool get(const std::string &key, Json::Value &value) override {
+        auto fit = forced_failures_.find(key);
+        if (fit != forced_failures_.end() && fit->second > 0) {
+            --fit->second;
+            return false;
+        }
+        auto it = store_.find(key);
+        if (it == store_.end()) return false;
+        value = it->second;
+        return true;
+    }
+    bool set(const std::string &key, const Json::Value &value) override {
+        store_[key] = value;
+        return true;
+    }
+    bool remove(const std::string &key) override {
+        store_.erase(key);
+        return true;
+    }
+    void failNext(const std::string &key, int n) { forced_failures_[key] = n; }
+
+   private:
+    std::map<std::string, Json::Value> store_;
+    std::map<std::string, int> forced_failures_;
+};
+
 // Exposes the protected storage-plugin injection seam to hardware-free tests.
 class TestableTransferMetadata : public TransferMetadata {
    public:
@@ -1235,6 +1266,33 @@ TEST_F(TransferMetadataStaleSegmentInvalidationTest,
     // Outage clears: get() succeeds again, the entry was never invalidated.
     ASSERT_EQ(client.syncSegmentCache(""), 0);
     EXPECT_NE(client.getSegmentDescByName(name), nullptr);
+}
+
+// Default-mapping guard: a backend that only implements the legacy bool
+// get() (no getWithStatus() override) inherits the default mapping, which
+// must fail closed -- an ambiguous false is kUnavailable, never kNotFound --
+// so a sustained failure cannot purge the cached entry. Guards against the
+// default treating an opaque backend failure as an authoritative removal.
+TEST_F(TransferMetadataStaleSegmentInvalidationTest,
+       DefaultPluginMappingFailsClosed) {
+    ScopedMetadataRefreshConfig restore(0, true);
+
+    auto plugin = std::make_shared<OpaqueMetadataStoragePlugin>();
+    TestableTransferMetadata client(plugin);
+
+    const std::string name = "E";
+    ASSERT_TRUE(seedRemoteSegment(client, name));
+
+    // Sustained failures through the inherited default path: 5 sync cycles
+    // of get() == false with no way to prove the key is gone.
+    plugin->failNext("mooncake/ram/E", 5);
+
+    for (int i = 0; i < 5; ++i) {
+        ASSERT_EQ(client.syncSegmentCache(""), 0);
+        EXPECT_NE(client.getSegmentDescByName(name), nullptr)
+            << "default mapping invalidated after " << (i + 1)
+            << " opaque failures";
+    }
 }
 
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
+++ b/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
@@ -1076,6 +1076,22 @@ class FakeMetadataStoragePlugin : public MetadataStoragePlugin {
         value = it->second;
         return true;
     }
+
+    // Error-aware variant: forced failures report kUnavailable (the key may
+    // still live in the backend), missing keys report kNotFound (the master
+    // removed them), and present keys report kFound.
+    GetResult getWithStatus(const std::string &key,
+                            Json::Value &value) override {
+        auto fit = forced_failures_.find(key);
+        if (fit != forced_failures_.end() && fit->second > 0) {
+            --fit->second;
+            return GetResult::kUnavailable;
+        }
+        auto it = store_.find(key);
+        if (it == store_.end()) return GetResult::kNotFound;
+        value = it->second;
+        return GetResult::kFound;
+    }
     bool set(const std::string &key, const Json::Value &value) override {
         store_[key] = value;
         return true;
@@ -1186,6 +1202,37 @@ TEST_F(TransferMetadataStaleSegmentInvalidationTest,
 
     // Next cycle the blip clears: get() succeeds again, the streak resets to
     // zero, and the cached entry survives.
+    ASSERT_EQ(client.syncSegmentCache(""), 0);
+    EXPECT_NE(client.getSegmentDescByName(name), nullptr);
+}
+
+// Backend-outage guard: a sustained transient failure (kUnavailable) must NOT
+// advance the invalidation streak, so the cached entry survives even after
+// many consecutive sync cycles -- only an authoritative key removal
+// (kNotFound) can invalidate. Guards against a metadata-service outage
+// purging the entire live cache.
+TEST_F(TransferMetadataStaleSegmentInvalidationTest,
+       BackendOutageDoesNotInvalidateCache) {
+    ScopedMetadataRefreshConfig restore(0, true);
+
+    auto plugin = std::make_shared<FakeMetadataStoragePlugin>();
+    TestableTransferMetadata client(plugin);
+
+    const std::string name = "D";
+    ASSERT_TRUE(seedRemoteSegment(client, name));
+
+    // Sustained backend outage: every get() fails for 5 sync cycles (well
+    // past the invalidation threshold of 2), but the key still lives in
+    // the backend -- this is kUnavailable, not kNotFound.
+    plugin->failNext("mooncake/ram/D", 5);
+
+    for (int i = 0; i < 5; ++i) {
+        ASSERT_EQ(client.syncSegmentCache(""), 0);
+        EXPECT_NE(client.getSegmentDescByName(name), nullptr)
+            << "entry purged after " << (i + 1) << " transient failures";
+    }
+
+    // Outage clears: get() succeeds again, the entry was never invalidated.
     ASSERT_EQ(client.syncSegmentCache(""), 0);
     EXPECT_NE(client.getSegmentDescByName(name), nullptr);
 }

--- a/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
+++ b/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
@@ -1,3 +1,5 @@
+#include <map>
+#include <memory>
 // Copyright 2024 KVCache.AI
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -1053,6 +1055,138 @@ TEST(HandshakeFrameTest, RejectsInvalidLength) {
 
     close(fds[0]);
     close(fds[1]);
+}
+
+namespace {
+
+// Hardware-free in-memory MetadataStoragePlugin. get() returns false for keys
+// absent from the store (a removed/unmounted segment) and can be made to fail
+// a bounded number of times via failNext() to reproduce a transient backend
+// blip. No RDMA/CUDA/etcd is required.
+class FakeMetadataStoragePlugin : public MetadataStoragePlugin {
+   public:
+    bool get(const std::string &key, Json::Value &value) override {
+        auto fit = forced_failures_.find(key);
+        if (fit != forced_failures_.end() && fit->second > 0) {
+            --fit->second;
+            return false;  // transient blip: the key may still be in store_
+        }
+        auto it = store_.find(key);
+        if (it == store_.end()) return false;
+        value = it->second;
+        return true;
+    }
+    bool set(const std::string &key, const Json::Value &value) override {
+        store_[key] = value;
+        return true;
+    }
+    bool remove(const std::string &key) override {
+        store_.erase(key);
+        return true;
+    }
+
+    // Simulate the master-side cleanup of a peer's segment key (unmount or
+    // client expiry): the key vanishes from the backend, so every later
+    // get() returns false.
+    void drop(const std::string &key) { store_.erase(key); }
+
+    // Inject n transient get() failures for key without removing the key,
+    // modelling a curl timeout / etcd blip that resolves next sync cycle.
+    void failNext(const std::string &key, int n) { forced_failures_[key] = n; }
+
+   private:
+    std::map<std::string, Json::Value> store_;
+    std::map<std::string, int> forced_failures_;
+};
+
+// Exposes the protected storage-plugin injection seam to hardware-free tests.
+class TestableTransferMetadata : public TransferMetadata {
+   public:
+    explicit TestableTransferMetadata(
+        std::shared_ptr<MetadataStoragePlugin> storage_plugin)
+        : TransferMetadata(std::move(storage_plugin)) {}
+};
+
+}  // namespace
+
+class TransferMetadataStaleSegmentInvalidationTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        google::InitGoogleLogging("TransferMetadataStaleSegmentInvalidationTest");
+        FLAGS_logtostderr = 1;
+    }
+    void TearDown() override { google::ShutdownGoogleLogging(); }
+
+    // Publish a remote rdma segment to the fake backend and cache it locally
+    // (as a non-local id), returning the cached descriptor so callers can
+    // assert on cache state.
+    std::shared_ptr<TransferMetadata::SegmentDesc> seedRemoteSegment(
+        TransferMetadata &client, const std::string &name) {
+        auto desc = makeRdmaSegmentDesc(name, 0x1000);
+        EXPECT_EQ(client.updateSegmentDesc(name, *desc), 0);
+        EXPECT_NE(client.getSegmentID(name),
+                  static_cast<TransferMetadata::SegmentID>(-1));
+        return client.getSegmentDescByName(name);
+    }
+};
+
+// Red on master / green on branch: a cached remote segment whose backend key
+// is removed (peer unmount) is invalidated only after the consecutive-failure
+// streak reaches the threshold -- not on the first failure. On master there
+// is no invalidation branch, so the stale entry is never erased and the final
+// expectation fails.
+TEST_F(TransferMetadataStaleSegmentInvalidationTest,
+       ErasesStaleEntryAfterConsecutiveFailures) {
+    // No background refresh thread (interval == 0) with the cache-hit fast path
+    // on (metacache == true): getSegmentDescByName reflects the local cache,
+    // and we drive syncSegmentCache explicitly to count failures precisely.
+    ScopedMetadataRefreshConfig restore(0, true);
+
+    auto plugin = std::make_shared<FakeMetadataStoragePlugin>();
+    TestableTransferMetadata client(plugin);
+
+    const std::string name = "B";
+    ASSERT_TRUE(seedRemoteSegment(client, name));
+
+    // Peer B unmounts: the master removes mooncake/ram/B; every get() fails.
+    plugin->drop("mooncake/ram/B");
+
+    // First failed sync: streak is 1, below the threshold -> retain the entry,
+    // guarding against a single transient blip purging the whole cache.
+    ASSERT_EQ(client.syncSegmentCache(""), 0);
+    EXPECT_NE(client.getSegmentDescByName(name), nullptr);
+
+    // Second consecutive failed sync: streak reaches the threshold -> the
+    // stale cached entry is invalidated. Red-on-master: master never erases,
+    // so getSegmentDescByName keeps returning the cached descriptor.
+    ASSERT_EQ(client.syncSegmentCache(""), 0);
+    EXPECT_EQ(client.getSegmentDescByName(name), nullptr);
+}
+
+// Transient-failure guard: a segment that fails once and then succeeds on the
+// next cycle must NOT be invalidated -- the successful fetch resets its
+// streak. Guards against an erase-on-first-failure regression.
+TEST_F(TransferMetadataStaleSegmentInvalidationTest,
+       TransientFailureIsRetained) {
+    ScopedMetadataRefreshConfig restore(0, true);
+
+    auto plugin = std::make_shared<FakeMetadataStoragePlugin>();
+    TestableTransferMetadata client(plugin);
+
+    const std::string name = "C";
+    ASSERT_TRUE(seedRemoteSegment(client, name));
+
+    // One transient get() failure: the key still lives in the backend, so the
+    // segment is genuinely alive and must not count toward removal.
+    plugin->failNext("mooncake/ram/C", 1);
+
+    ASSERT_EQ(client.syncSegmentCache(""), 0);
+    EXPECT_NE(client.getSegmentDescByName(name), nullptr);
+
+    // Next cycle the blip clears: get() succeeds again, the streak resets to
+    // zero, and the cached entry survives.
+    ASSERT_EQ(client.syncSegmentCache(""), 0);
+    EXPECT_NE(client.getSegmentDescByName(name), nullptr);
 }
 
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
+++ b/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
@@ -50,7 +50,7 @@ class TransferMetadataTest : public ::testing::Test {
         google::InitGoogleLogging("TransferMetadataTest");
         FLAGS_logtostderr = 1;  // output to stdout
 
-        const char* env = std::getenv("MC_METADATA_SERVER");
+        const char *env = std::getenv("MC_METADATA_SERVER");
         if (env)
             metadata_server = env;
         else
@@ -112,11 +112,11 @@ TEST_F(TransferMetadataTest, LocalMemoryBufferTest) {
         ASSERT_EQ(re, 0);
     }
     addr = 1000;
-    re = metadata_client->removeLocalMemoryBuffer((void*)addr, false);
+    re = metadata_client->removeLocalMemoryBuffer((void *)addr, false);
     ASSERT_EQ(re, ERR_ADDRESS_NOT_REGISTERED);
     for (int i = 9; i > 0; --i) {
         addr = i * 2048;
-        re = metadata_client->removeLocalMemoryBuffer((void*)addr, false);
+        re = metadata_client->removeLocalMemoryBuffer((void *)addr, false);
         ASSERT_EQ(re, 0);
     }
     re = metadata_client->removeLocalSegment("test_local_segment");
@@ -423,7 +423,7 @@ TransferMetadata::BufferDesc makeRdmaBufferDesc(uint64_t addr) {
 }
 
 std::shared_ptr<TransferMetadata::SegmentDesc> makeRdmaSegmentDesc(
-    const std::string& name, uint64_t addr) {
+    const std::string &name, uint64_t addr) {
     auto segment_desc = std::make_shared<TransferMetadata::SegmentDesc>();
     segment_desc->name = name;
     segment_desc->protocol = "rdma";
@@ -476,7 +476,7 @@ TEST(TransferMetadataPollingTest, PollingRefreshesCachedRemoteSegmentDesc) {
     ASSERT_EQ(cached_desc->buffers[0].addr, kInitialAddr);
 
     ASSERT_EQ(server.removeLocalMemoryBuffer(
-                  reinterpret_cast<void*>(kInitialAddr), false),
+                  reinterpret_cast<void *>(kInitialAddr), false),
               0);
     ASSERT_EQ(
         server.addLocalMemoryBuffer(makeRdmaBufferDesc(kUpdatedAddr), false),
@@ -1112,7 +1112,8 @@ class TestableTransferMetadata : public TransferMetadata {
 class TransferMetadataStaleSegmentInvalidationTest : public ::testing::Test {
    protected:
     void SetUp() override {
-        google::InitGoogleLogging("TransferMetadataStaleSegmentInvalidationTest");
+        google::InitGoogleLogging(
+            "TransferMetadataStaleSegmentInvalidationTest");
         FLAGS_logtostderr = 1;
     }
     void TearDown() override { google::ShutdownGoogleLogging(); }
@@ -1191,7 +1192,7 @@ TEST_F(TransferMetadataStaleSegmentInvalidationTest,
 
 }  // namespace mooncake
 
-int main(int argc, char** argv) {
+int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
## Description

`TransferMetadata::syncSegmentCache` refreshes the local segment-descriptor cache by polling the metadata backend, but it only ever *adds* and *updates* entries — it never *invalidates* them. When a remote peer unmounts its segment (graceful `freeEngine` → `removeSegmentDesc` → backend remove) or crashes and the master expires its key (`ClientMonitorFunc` → `cleanupHttpMetadata` removes `mooncake/ram/<peer>`), every other node's refresh poll fetches the now-missing key, logs `segment <name> is now invalid`, increments `failed_count`, and **leaves the stale `SegmentDesc` in the cache**. The only erase sites (`removeSegmentDesc` at `transfer_metadata.cpp:568-569` and the local-remove path at `:1254-1255`) are LOCAL-only; neither covers a REMOTE segment that vanished from the backend.

The cached, now-dead descriptor keeps getting served: `getSegmentDescByName` returns the cached entry under a read lock with no backend re-check (`transfer_metadata.cpp:1143-1147`), so `MultiTransport::selectTransport` resolves the stale desc and posts RDMA/TCP to a dead endpoint. Transfers to the departed peer fail or time out on **every** subsequent request until the caching node itself restarts.

This change adds conservative invalidation to `syncSegmentCache`'s apply phase: a per-segment consecutive-failure streak; once a cached **remote** segment fails its backend fetch for `kStaleSegmentFailureThreshold` (=2) consecutive sync cycles, it is erased from both `segment_name_to_id_map_` and `segment_id_to_desc_map_` under the write lock (mirroring the erase pattern in `removeSegmentDesc`). A successful fetch resets the streak.

**Why a threshold rather than erasing on the first failure:** `MetadataStoragePlugin::get` returns a single `bool` that collapses "key absent" and "transient error" (etcd blip, curl timeout, 5xx) into `false`. Erasing on the first failure would purge the whole cache during a transient backend blip and cause a transfer outage. A ≥2-consecutive threshold distinguishes a genuinely-removed segment (fails every cycle until erased) from a transient blip (fails once, succeeds next cycle → streak reset → not erased). In-flight transfers that already hold a `shared_ptr` copy of the descriptor are unaffected by a map erase (refcount keeps it alive), so there is no dangle.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

Added `TransferMetadataStaleSegmentInvalidationTest` in `mooncake-transfer-engine/tests/transfer_metadata_test.cpp`, using an in-memory fake `MetadataStoragePlugin` (no RDMA/CUDA/hardware):

- `ErasesStaleEntryAfterConsecutiveFailures` — seeds remote segment "B", drops its backend key, asserts "B" is **still cached after the 1st** failed `syncSegmentCache` (streak 1 < threshold, guarding against transient-blip purge) and `getSegmentDescByName("B") == nullptr` **after the 2nd** (stale entry erased). On `main` there is no invalidation branch, so the `== nullptr` assertion fails (red); on this branch it passes (green).
- `TransientFailureIsRetained` — a segment that fails once then succeeds is **not** erased (streak reset).

The test drives the real `syncSegmentCache` / `getSegmentDescByName` code paths via the fake backend; it does not mock the function under fix.

**Test commands:**
```bash
cmake -S mooncake-transfer-engine -B build-te -DCMAKE_BUILD_TYPE=Debug -DBUILD_TRANSFER_ENGINE_TESTS=ON
cmake --build build-te --target transfer_metadata_test -j
ctest --test-dir build-te -R transfer_metadata --output-on-failure
```

**Test results:**
- [x] Unit tests pass — added; verified by design (red-on-`main` / green-on-branch). Authoritative run is Linux CI (the change is authored against `upstream/main` and the metadata unit test needs only gtest + the storage-plugin abstraction, no transport hardware).
- [ ] Integration tests pass (if applicable) — N/A (unit-level fix).
- [ ] Manual testing done — N/A.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh` — not run locally (host lacks the RDMA/CUDA build env + clang-format); additions hand-formatted to the repository's Google style / `.clang-format` to match surrounding code. Will run `pre-commit run --all-files` in CI.
- [ ] I have run `pre-commit run --all-files` and all hooks pass — deferred to CI (see above).
- [ ] I have updated the documentation (if applicable) — N/A.
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue — N/A (82 functional LoC).

## AI Assistance Disclosure

- [x] No AI tools were used