### PR TITLE
[Store] Fix silent data corruption in io_uring read path (#3066)

### DIFF
--- a/mooncake-store/src/storage_backend.cpp
+++ b/mooncake-store/src/storage_backend.cpp
@@ -1945,10 +1945,34 @@ tl::expected<void, ErrorCode> BucketStorageBackend::BatchLoad(
                     plan.dest_slice.ptr, aligned_size, aligned_offset);
 
                 if (read_res) {
-                    // Adjust ptr to point to actual data start (no memcpy)
+                    // Verify the aligned read returned enough bytes
+                    // to cover the actual data region.  read_aligned
+                    // reads the full aligned range [aligned_offset,
+                    // aligned_end); the caller-visible data starts at
+                    // offset_in_buffer into that buffer and spans
+                    // plan.dest_slice.size bytes.
+                    size_t min_required =
+                        static_cast<size_t>(offset_in_buffer) +
+                        plan.dest_slice.size;
+                    if (read_res.value() < min_required) {
+                        LOG(ERROR)
+                            << "read_aligned short read for key: " << plan.key
+                            << ", bucket_id=" << plan.bucket_id
+                            << ", expected at least: " << min_required
+                            << " (aligned_size=" << aligned_size
+                            << ", data_size=" << plan.dest_slice.size << ")"
+                            << ", got: " << read_res.value();
+                        return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+                    }
+                    // Adjust ptr to point to actual data start
+                    // (zero-copy: no memcpy, buffer was oversized by
+                    // AllocateBatch to accommodate the aligned read)
                     batch_object.at(plan.key).ptr =
                         static_cast<char*>(plan.dest_slice.ptr) +
                         offset_in_buffer;
+                    // Normalize read_res so the common validation
+                    // below passes.  The real short-read check was
+                    // already done above (min_required).
                     read_res = plan.dest_slice.size;
                 }
             } else

--- a/mooncake-store/src/uring_file.cpp
+++ b/mooncake-store/src/uring_file.cpp
@@ -144,6 +144,7 @@ class SharedUringRing {
     tl::expected<size_t, ErrorCode> batch_read(int fd, const ReadDesc* descs,
                                                int cnt) {
         ensure_buf_registered();
+        uint64_t op = ++op_id_;
         size_t total = 0;
         int remaining = cnt;
         int idx = 0;
@@ -162,9 +163,10 @@ class SharedUringRing {
                     io_uring_prep_read_fixed(sqe, fd, d.buf, d.len, d.off, 0);
                 else
                     io_uring_prep_read(sqe, fd, d.buf, d.len, d.off);
+                sqe->user_data = op;
             }
 
-            auto res = collect(batch);
+            auto res = collect(batch, op);
             if (!res) return res;
             total += res.value();
             idx += batch;
@@ -183,9 +185,11 @@ class SharedUringRing {
             LOG(ERROR) << "[SharedUringRing] SQ full (fsync)";
             return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
         }
+        uint64_t op = ++op_id_;
         io_uring_prep_fsync(sqe, fd, IORING_FSYNC_DATASYNC);
+        sqe->user_data = op;
 
-        auto res = collect(1);
+        auto res = collect(1, op);
         if (!res) return tl::make_unexpected(res.error());
         return {};
     }
@@ -253,8 +257,16 @@ class SharedUringRing {
         return value;
     }
 
-    // Drain exactly @expected CQEs and accumulate bytes.
-    tl::expected<size_t, ErrorCode> collect(int expected) {
+    // Drain exactly @expected CQEs matching @op_id and
+    // accumulate bytes.  Stale CQEs (user_data != op_id, e.g. from
+    // a previous batch_read / submit_rw that hit an error and left
+    // in-flight SQEs) are silently consumed and discarded.
+    //
+    // Uses peek-then-wait: after io_uring_submit_and_wait most CQEs
+    // are already available, so io_uring_peek_cqe() succeeds without
+    // a syscall in the common case.  io_uring_wait_cqe() only kicks
+    // in when the ring is unexpectedly drained (stale CQE storms).
+    tl::expected<size_t, ErrorCode> collect(int expected, uint64_t op_id) {
         int ret = io_uring_submit_and_wait(&ring_, expected);
         if (ret < 0) {
             LOG(ERROR) << "[SharedUringRing] io_uring_submit_and_wait: "
@@ -263,9 +275,24 @@ class SharedUringRing {
         }
         size_t total = 0;
         bool err = false;
-        unsigned head, cnt = 0;
-        struct io_uring_cqe* cqe;
-        io_uring_for_each_cqe(&ring_, head, cqe) {
+        int processed = 0;
+
+        while (processed < expected) {
+            struct io_uring_cqe* cqe;
+            int wait_ret = io_uring_peek_cqe(&ring_, &cqe);
+            if (wait_ret == -EAGAIN) {
+                wait_ret = io_uring_wait_cqe(&ring_, &cqe);
+            }
+            if (wait_ret < 0) {
+                LOG(ERROR) << "[SharedUringRing] CQE wait error: "
+                           << strerror(-wait_ret);
+                return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+            }
+            if (cqe->user_data != op_id) {
+                // Stale CQE from a previous failed operation.
+                io_uring_cq_advance(&ring_, 1);
+                continue;
+            }
             if (cqe->res < 0) {
                 LOG(ERROR) << "[SharedUringRing] CQE error: "
                            << strerror(-cqe->res);
@@ -273,9 +300,9 @@ class SharedUringRing {
             } else {
                 total += static_cast<size_t>(cqe->res);
             }
-            ++cnt;
+            io_uring_cq_advance(&ring_, 1);
+            ++processed;
         }
-        io_uring_cq_advance(&ring_, cnt);
         if (err) return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
         return total;
     }
@@ -288,6 +315,7 @@ class SharedUringRing {
             is_write ? ErrorCode::FILE_WRITE_FAIL : ErrorCode::FILE_READ_FAIL;
         const bool fix_buf = (use_fixed_buf && buf_registered_);
 
+        uint64_t op = ++op_id_;
         char* ptr = static_cast<char*>(buf);
         size_t total = 0;
         size_t remaining = len;
@@ -318,6 +346,7 @@ class SharedUringRing {
                     else
                         io_uring_prep_read(sqe, fd, ptr, chunk, cur);
                 }
+                sqe->user_data = op;
 
                 ptr += chunk;
                 cur += static_cast<off_t>(chunk);
@@ -325,7 +354,7 @@ class SharedUringRing {
                 if (remaining == 0) break;
             }
 
-            auto res = collect(static_cast<int>(n));
+            auto res = collect(static_cast<int>(n), op);
             if (!res) return res;
             total += res.value();
             if (!is_write && res.value() == 0) break;  // read EOF
@@ -345,6 +374,7 @@ class SharedUringRing {
             is_write ? ErrorCode::FILE_WRITE_FAIL : ErrorCode::FILE_READ_FAIL;
         const size_t max_io = max_rw_count();
 
+        uint64_t op = ++op_id_;
         size_t total = 0;
         off_t cur = off;
         int remaining = cnt;
@@ -382,12 +412,13 @@ class SharedUringRing {
                 else
                     io_uring_prep_read(sqe, fd, iovs[idx].iov_base,
                                        iovs[idx].iov_len, cur);
+                sqe->user_data = op;
 
                 cur += static_cast<off_t>(iovs[idx].iov_len);
                 ++idx;
             }
 
-            auto res = collect(batch);
+            auto res = collect(batch, op);
             if (!res) return res;
             total += res.value();
             remaining -= batch;
@@ -405,6 +436,7 @@ class SharedUringRing {
     bool buf_register_failed_ = false;  // set on first failure; skip retries
     void* buf_base_ = nullptr;
     size_t buf_size_ = 0;
+    uint64_t op_id_ = 0;  // monotonic ID for stale CQE filtering
 };
 
 // ============================================================================


### PR DESCRIPTION
## Description

Fix silent data corruption in `BucketStorageBackend::BatchLoad` io_uring path when short reads occur. (#3066)

Two bugs:

1. **`read_res` overwritten before validation** (`storage_backend.cpp`): after a successful `read_aligned`, the real IO byte count is replaced with the expected value, making the downstream short-read check dead code.
2. **No stale CQE filtering** (`uring_file.cpp`): `collect()` uses `io_uring_for_each_cqe` to consume all available CQEs regardless of which operation submitted them. Stale CQEs from a previously failed batch can contaminate the current byte count.

**Trigger chain:** 

`BatchLoad` → `read_aligned` → `submit_rw` → `collect()` → `io_uring_for_each_cqe` (consumes all CQEs, no `user_data` filter) → `read_res = plan.dest_slice.size` (overwrites real result) → downstream check dead → short read passes silently → truncated data returned to caller.

**Fix:**

- Add a `min_required` check before pointer adjustment: `read_res.value() >= offset_in_buffer + data_size`. Short reads fail with `FILE_READ_FAIL`.
- Tag each operation with a monotonic `op_id` via `sqe->user_data`, rewrite `collect()` to filter out CQEs with non-matching `user_data`. Uses peek-then-wait to avoid extra syscalls on the common path.

Both fixes are required together: the `user_data` filter prevents stale CQEs from making the byte count coincidentally pass the `min_required` check.

Zero-copy and `AllocateBatch` oversized allocation are unchanged.

Closes #3066.

## Module

- [x] Mooncake Store (`mooncake-store`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

**Test commands:**
```bash
# Bucket backend with io_uring, full verification
./storage_backend_bench --backend=bucket --test=load --use_uring --verify_rate=1 --num_operations=1000
```

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: N/A (~70 lines)

## AI Assistance Disclosure

- [x] AI tools were used

Claude Code was used for code analysis and plan review. All changes reviewed and understood by the submitter.