### PR TITLE
[TENT] Add mixed traffic workloads to tebench

### DIFF
--- a/docs/source/design/tent/tebench.md
+++ b/docs/source/design/tent/tebench.md
@@ -153,6 +153,40 @@ host pair. JSONL records retain `isolated_throughput_gbps` and
 `link_capacity_gbps` alongside the derived values so every metric can be
 recomputed from one record.
 
+### 4.2 Mixed Foreground/Background Traffic
+
+The QoS class flags above use one block size, batch size, and request intent for
+all workers. Use `--workload_classes_json` when classes must generate different
+transfer shapes concurrently, for example latency-sensitive reads competing
+with a bulk KV migration:
+
+```bash
+./tebench \
+  --target_seg_name=<SEG> \
+  --backend=tent \
+  --start_num_threads=8 \
+  --max_num_threads=8 \
+  --workload_classes_json='[
+    {"name":"foreground","threads":2,"block_size":4096,"batch_size":1,
+     "intent_type":"foreground_get","deadline_us":250,"slo_us":300,"weight":4},
+    {"name":"migration","threads":6,"block_size":4194304,"batch_size":2,
+     "intent_type":"migration","slo_us":0,"weight":1}
+  ]' \
+  --qos_link_capacity_gbps=25 \
+  --qos_output_jsonl=mixed-traffic.jsonl
+```
+
+This mode runs one fixed workload instead of sweeping the global block and
+batch size flags. Class thread counts must add up to the fixed benchmark thread
+count. `deadline_us` is optional and controls TENT deadline tagging;
+`slo_us` remains the independent reporting threshold. Per-class
+`transferred_bytes` is included in text and JSONL output so throughput is
+computed from each class's actual transfer size.
+
+`--workload_classes_json` is mutually exclusive with `--qos_classes`,
+`--qos_classes_json`, and the global `--tent_intent_type`. Non-default
+per-class intents and deadlines require the TENT backend.
+
 ## 5. Runtime Configuration
 
 This section summarizes the key runtime options that control workload behavior,
@@ -261,6 +295,8 @@ gpu_id + thread_id
 ### 5.7 QoS Reporting
 
 * `--qos_classes` : class/thread/SLO/weight contract described in Section 4.1
+* `--workload_classes_json` : class-specific transfer shape, intent, deadline,
+  and QoS contract described in Section 4.2
 * `--qos_link_capacity_gbps` : measured usable link capacity in decimal GB/s
 * `--qos_output_jsonl` : append one schema-versioned JSON object per benchmark
   configuration

--- a/mooncake-transfer-engine/benchmark/CMakeLists.txt
+++ b/mooncake-transfer-engine/benchmark/CMakeLists.txt
@@ -68,7 +68,8 @@ set_target_properties(
 
 if(BUILD_UNIT_TESTS)
   add_executable(tebench_qos_metrics_test tests/qos_metrics_test.cpp
-                                          qos_metrics_adapter.cpp utils.cpp)
+                                          qos_metrics_adapter.cpp
+                                          workload_config.cpp utils.cpp)
   if(NOT USE_TENT)
     target_sources(tebench_qos_metrics_test PRIVATE
                    ../tent/src/common/qos_metrics.cpp)

--- a/mooncake-transfer-engine/benchmark/bench_runner.h
+++ b/mooncake-transfer-engine/benchmark/bench_runner.h
@@ -28,6 +28,8 @@
 
 namespace mooncake {
 namespace tent {
+enum class IntentType : int;
+
 class BenchRunner {
    public:
     BenchRunner() {}
@@ -57,7 +59,8 @@ class BenchRunner {
 
     virtual double runSingleTransfer(uint64_t local_addr, uint64_t target_addr,
                                      uint64_t block_size, uint64_t batch_size,
-                                     OpCode opcode, uint64_t deadline_ns) = 0;
+                                     OpCode opcode, uint64_t deadline_ns,
+                                     IntentType intent_type) = 0;
 };
 
 }  // namespace tent

--- a/mooncake-transfer-engine/benchmark/main.cpp
+++ b/mooncake-transfer-engine/benchmark/main.cpp
@@ -17,15 +17,17 @@
 #include "bench_runner.h"
 #include "qos_metrics_adapter.h"
 #include "te_backend.h"
+#include "workload_config.h"
 #ifdef USE_TENT
 #include "tent_backend.h"
 #endif
 
 using namespace mooncake::tent;
 
-int processBatchSizes(BenchRunner& runner, size_t block_size, size_t batch_size,
-                      int num_threads,
-                      const std::vector<QosClassConfig>& qos_classes) {
+int processBatchSizes(
+    BenchRunner& runner, size_t block_size, size_t batch_size, int num_threads,
+    const std::vector<QosClassConfig>& qos_classes,
+    const std::vector<WorkloadClassConfig>& workload_classes = {}) {
     bool mixed_opcode = false;
     OpCode opcode = READ;
     if (XferBenchConfig::check_consistency || XferBenchConfig::op_type == "mix")
@@ -44,34 +46,53 @@ int processBatchSizes(BenchRunner& runner, size_t block_size, size_t batch_size,
     XferBenchStats tight_stats;
     XferBenchStats loose_stats;
     std::mutex mutex;
+    size_t address_stride_bytes =
+        XferBenchConfig::max_block_size * XferBenchConfig::max_batch_size;
+    if (!workload_classes.empty()) {
+        address_stride_bytes = 0;
+        for (const auto& config : workload_classes) {
+            address_stride_bytes = std::max(
+                address_stride_bytes, config.block_size * config.batch_size);
+        }
+    }
     int rc = runner.runInitiatorTasks([&](int thread_id) -> int {
         runner.pinThread(thread_id);
-        auto max_block_size = XferBenchConfig::max_block_size;
-        auto max_batch_size = XferBenchConfig::max_batch_size;
         auto local_gpu_offset = std::max(0, XferBenchConfig::local_gpu_id);
         auto target_gpu_offset = std::max(0, XferBenchConfig::target_gpu_id);
         uint64_t local_addr = runner.getLocalBufferBase(
-            local_gpu_offset + thread_id, max_block_size, max_batch_size);
+            local_gpu_offset + thread_id, address_stride_bytes, 1);
         uint64_t target_addr = runner.getTargetBufferBase(
-            target_gpu_offset + thread_id, max_block_size, max_batch_size);
+            target_gpu_offset + thread_id, address_stride_bytes, 1);
         const bool qos_enabled = !qos_classes.empty();
         const size_t qos_class =
             qos_enabled ? qosClassForThread(qos_classes, thread_id) : 0;
+        const auto* workload =
+            workload_classes.empty() ? nullptr : &workload_classes[qos_class];
+        const size_t thread_block_size =
+            workload ? workload->block_size : block_size;
+        const size_t thread_batch_size =
+            workload ? workload->batch_size : batch_size;
+        const IntentType intent_type =
+            workload ? workload->intent_type : IntentType::INTENT_UNSPEC;
         const bool tight = XferBenchConfig::deadline_us > 0 &&
                            thread_id < XferBenchConfig::deadline_tight_threads;
         auto deadlineNs = [&]() -> uint64_t {
-            if (!tight) return 0;
+            const uint64_t deadline_us =
+                workload ? workload->deadline_us
+                         : (tight ? XferBenchConfig::deadline_us : 0);
+            if (deadline_us == 0) return 0;
             const auto now =
                 std::chrono::steady_clock::now().time_since_epoch();
             return std::chrono::duration_cast<std::chrono::nanoseconds>(now)
                        .count() +
-                   XferBenchConfig::deadline_us * 1000ull;
+                   deadline_us * 1000ull;
         };
 
         XferBenchTimer timer;
         while (timer.lap_us(false) < 1000000ull) {
-            runner.runSingleTransfer(local_addr, target_addr, block_size,
-                                     batch_size, opcode, deadlineNs());
+            runner.runSingleTransfer(local_addr, target_addr, thread_block_size,
+                                     thread_batch_size, opcode, deadlineNs(),
+                                     intent_type);
         }
         timer.reset();
         std::vector<double> transfer_duration;
@@ -80,27 +101,28 @@ int processBatchSizes(BenchRunner& runner, size_t block_size, size_t batch_size,
                    XferBenchConfig::duration * 1000000ull) {
                 uint8_t pattern = 0;
                 if (XferBenchConfig::check_consistency)
-                    pattern =
-                        fillData((void*)local_addr, block_size * batch_size);
-                auto val = runner.runSingleTransfer(local_addr, target_addr,
-                                                    block_size, batch_size,
-                                                    WRITE, deadlineNs());
+                    pattern = fillData((void*)local_addr,
+                                       thread_block_size * thread_batch_size);
+                auto val = runner.runSingleTransfer(
+                    local_addr, target_addr, thread_block_size,
+                    thread_batch_size, WRITE, deadlineNs(), intent_type);
                 transfer_duration.push_back(val);
-                fillData((void*)local_addr, block_size * batch_size);
-                val = runner.runSingleTransfer(local_addr, target_addr,
-                                               block_size, batch_size, READ,
-                                               deadlineNs());
+                fillData((void*)local_addr,
+                         thread_block_size * thread_batch_size);
+                val = runner.runSingleTransfer(
+                    local_addr, target_addr, thread_block_size,
+                    thread_batch_size, READ, deadlineNs(), intent_type);
                 if (XferBenchConfig::check_consistency)
-                    verifyData((void*)local_addr, block_size * batch_size,
-                               pattern);
+                    verifyData((void*)local_addr,
+                               thread_block_size * thread_batch_size, pattern);
                 transfer_duration.push_back(val);
             }
         } else {
             while (timer.lap_us(false) <
                    XferBenchConfig::duration * 1000000ull) {
-                auto val = runner.runSingleTransfer(local_addr, target_addr,
-                                                    block_size, batch_size,
-                                                    opcode, deadlineNs());
+                auto val = runner.runSingleTransfer(
+                    local_addr, target_addr, thread_block_size,
+                    thread_batch_size, opcode, deadlineNs(), intent_type);
                 transfer_duration.push_back(val);
             }
         }
@@ -119,11 +141,17 @@ int processBatchSizes(BenchRunner& runner, size_t block_size, size_t batch_size,
     });
 
     if (rc != 0) return -1;
-    printStats(block_size, batch_size, stats, num_threads);
+    if (workload_classes.empty())
+        printStats(block_size, batch_size, stats, num_threads);
     if (!qos_classes.empty()) {
+        std::vector<uint64_t> bytes_per_operation;
+        for (const auto& config : workload_classes) {
+            bytes_per_operation.push_back(config.block_size *
+                                          config.batch_size);
+        }
         auto report = calculateQosMetricsFromBenchStats(
             block_size, batch_size, num_threads, qos_classes, &qos_stats,
-            XferBenchConfig::qos_link_capacity_gbps);
+            XferBenchConfig::qos_link_capacity_gbps, bytes_per_operation);
         printQosMetrics(report);
         if (!XferBenchConfig::qos_output_jsonl.empty()) {
             std::string error;
@@ -134,7 +162,7 @@ int processBatchSizes(BenchRunner& runner, size_t block_size, size_t batch_size,
             }
         }
     }
-    if (XferBenchConfig::deadline_us > 0) {
+    if (XferBenchConfig::deadline_us > 0 && workload_classes.empty()) {
         const int tight_threads =
             std::min(num_threads, XferBenchConfig::deadline_tight_threads);
         printDeadlineGroupStats("tight", block_size, batch_size, tight_stats,
@@ -151,13 +179,29 @@ int main(int argc, char* argv[]) {
         "Usage: ./tebench [options]");
     gflags::ParseCommandLineFlags(&argc, &argv, true);
     XferBenchConfig::loadFromFlags();
+    std::vector<WorkloadClassConfig> workload_classes;
     std::vector<QosClassConfig> qos_classes;
+    if (!XferBenchConfig::workload_classes_json.empty() &&
+        (!XferBenchConfig::qos_classes.empty() ||
+         !XferBenchConfig::qos_classes_json.empty())) {
+        LOG(ERROR)
+            << "Use --workload_classes_json or QoS class flags, not both";
+        return EXIT_FAILURE;
+    }
     if (!XferBenchConfig::qos_classes.empty() &&
         !XferBenchConfig::qos_classes_json.empty()) {
         LOG(ERROR) << "Use only one of --qos_classes or --qos_classes_json";
         return EXIT_FAILURE;
     }
-    if (!XferBenchConfig::qos_classes_json.empty()) {
+    if (!XferBenchConfig::workload_classes_json.empty()) {
+        std::string error;
+        if (!parseWorkloadClassesJson(XferBenchConfig::workload_classes_json,
+                                      &workload_classes, &error)) {
+            LOG(ERROR) << "Invalid --workload_classes_json: " << error;
+            return EXIT_FAILURE;
+        }
+        qos_classes = qosClassesFromWorkload(workload_classes);
+    } else if (!XferBenchConfig::qos_classes_json.empty()) {
         std::string error;
         if (!parseQosClassesJson(XferBenchConfig::qos_classes_json,
                                  &qos_classes, &error)) {
@@ -185,6 +229,13 @@ int main(int argc, char* argv[]) {
             LOG(ERROR) << "Invalid QoS classes: " << error;
             return EXIT_FAILURE;
         }
+        if (!workload_classes.empty() &&
+            !validateWorkloadClasses(
+                workload_classes, XferBenchConfig::start_num_threads,
+                XferBenchConfig::total_buffer_size, &error)) {
+            LOG(ERROR) << "Invalid workload classes: " << error;
+            return EXIT_FAILURE;
+        }
     }
     if (XferBenchConfig::qos_link_capacity_gbps < 0.0 ||
         !std::isfinite(XferBenchConfig::qos_link_capacity_gbps)) {
@@ -201,6 +252,22 @@ int main(int argc, char* argv[]) {
         XferBenchConfig::backend != "tent") {
         LOG(ERROR) << "deadline tagging is supported only by the tent backend";
         return EXIT_FAILURE;
+    }
+    if (!workload_classes.empty() &&
+        XferBenchConfig::tent_intent_type != "unspec") {
+        LOG(ERROR) << "--tent_intent_type cannot be combined with per-class "
+                      "intent_type";
+        return EXIT_FAILURE;
+    }
+    if (!workload_classes.empty() && XferBenchConfig::backend != "tent") {
+        for (const auto& config : workload_classes) {
+            if (config.deadline_us != 0 ||
+                config.intent_type != IntentType::INTENT_UNSPEC) {
+                LOG(ERROR) << "per-class deadline_us and intent_type require "
+                              "the tent backend";
+                return EXIT_FAILURE;
+            }
+        }
     }
     std::unique_ptr<BenchRunner> runner;
     if (XferBenchConfig::backend == "classic") {
@@ -223,6 +290,14 @@ int main(int argc, char* argv[]) {
                   << " --backend=" << XferBenchConfig::backend << std::endl
                   << "Press Ctrl-C to terminate\033[0m" << std::endl;
         return runner->runTarget();
+    }
+    if (!workload_classes.empty()) {
+        const int num_threads = XferBenchConfig::start_num_threads;
+        if (runner->startInitiator(num_threads) != 0) return EXIT_FAILURE;
+        const int rc = processBatchSizes(*runner, 0, 0, num_threads,
+                                         qos_classes, workload_classes);
+        runner->stopInitiator();
+        return rc == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
     }
     printStatsHeader();
     bool interrupted = false;

--- a/mooncake-transfer-engine/benchmark/main.cpp
+++ b/mooncake-transfer-engine/benchmark/main.cpp
@@ -259,6 +259,13 @@ int main(int argc, char* argv[]) {
                       "intent_type";
         return EXIT_FAILURE;
     }
+    if (!workload_classes.empty() &&
+        (XferBenchConfig::deadline_us != 0 ||
+         XferBenchConfig::deadline_tight_threads != 0)) {
+        LOG(ERROR) << "--deadline_us and --deadline_tight_threads cannot be "
+                      "combined with per-class workload deadlines";
+        return EXIT_FAILURE;
+    }
     if (!workload_classes.empty() && XferBenchConfig::backend != "tent") {
         for (const auto& config : workload_classes) {
             if (config.deadline_us != 0 ||

--- a/mooncake-transfer-engine/benchmark/qos_metrics_adapter.cpp
+++ b/mooncake-transfer-engine/benchmark/qos_metrics_adapter.cpp
@@ -39,10 +39,17 @@ std::vector<QosClassSample> makeQosClassSamples(
 QosMetricsReport calculateQosMetricsFromBenchStats(
     size_t block_size, size_t batch_size, int num_threads,
     const std::vector<QosClassConfig>& classes,
-    std::vector<XferBenchStats>* stats, double link_capacity_gbps) {
+    std::vector<XferBenchStats>* stats, double link_capacity_gbps,
+    const std::vector<uint64_t>& bytes_per_operation) {
+    auto samples = makeQosClassSamples(classes, stats);
+    if (bytes_per_operation.size() == samples.size()) {
+        for (size_t i = 0; i < samples.size(); ++i) {
+            samples[i].transferred_bytes =
+                bytes_per_operation[i] * samples[i].operations;
+        }
+    }
     return calculateQosMetrics(block_size, batch_size, num_threads, classes,
-                               makeQosClassSamples(classes, stats),
-                               link_capacity_gbps);
+                               samples, link_capacity_gbps);
 }
 
 }  // namespace tent

--- a/mooncake-transfer-engine/benchmark/qos_metrics_adapter.h
+++ b/mooncake-transfer-engine/benchmark/qos_metrics_adapter.h
@@ -30,7 +30,8 @@ std::vector<QosClassSample> makeQosClassSamples(
 QosMetricsReport calculateQosMetricsFromBenchStats(
     size_t block_size, size_t batch_size, int num_threads,
     const std::vector<QosClassConfig>& classes,
-    std::vector<XferBenchStats>* stats, double link_capacity_gbps);
+    std::vector<XferBenchStats>* stats, double link_capacity_gbps,
+    const std::vector<uint64_t>& bytes_per_operation = {});
 
 }  // namespace tent
 }  // namespace mooncake

--- a/mooncake-transfer-engine/benchmark/te_backend.cpp
+++ b/mooncake-transfer-engine/benchmark/te_backend.cpp
@@ -350,8 +350,10 @@ double TEBenchRunner::runSingleTransfer(uint64_t local_addr,
                                         uint64_t target_addr,
                                         uint64_t block_size,
                                         uint64_t batch_size, OpCode opcode,
-                                        uint64_t deadline_ns) {
+                                        uint64_t deadline_ns,
+                                        IntentType intent_type) {
     (void)deadline_ns;
+    (void)intent_type;
     auto batch_id = engine_->allocateBatchID(batch_size);
     std::vector<TransferRequest> requests;
     for (uint64_t i = 0; i < batch_size; ++i) {

--- a/mooncake-transfer-engine/benchmark/te_backend.h
+++ b/mooncake-transfer-engine/benchmark/te_backend.h
@@ -69,7 +69,8 @@ class TEBenchRunner : public BenchRunner {
 
     double runSingleTransfer(uint64_t local_addr, uint64_t target_addr,
                              uint64_t block_size, uint64_t batch_size,
-                             OpCode opcode, uint64_t deadline_ns);
+                             OpCode opcode, uint64_t deadline_ns,
+                             IntentType intent_type);
 
    private:
     int allocateBuffers();

--- a/mooncake-transfer-engine/benchmark/tent_backend.cpp
+++ b/mooncake-transfer-engine/benchmark/tent_backend.cpp
@@ -361,7 +361,8 @@ double TENTBenchRunner::runSingleTransfer(uint64_t local_addr,
                                           uint64_t target_addr,
                                           uint64_t block_size,
                                           uint64_t batch_size, OpCode opcode,
-                                          uint64_t deadline_ns) {
+                                          uint64_t deadline_ns,
+                                          IntentType intent_type) {
     auto batch_id = engine_->allocateBatch(batch_size);
     std::vector<Request> requests;
     for (uint64_t i = 0; i < batch_size; ++i) {
@@ -373,7 +374,9 @@ double TENTBenchRunner::runSingleTransfer(uint64_t local_addr,
         entry.target_offset = target_addr + block_size * i;
         entry.transport_hint = transport_hint_;
         entry.deadline_ns = deadline_ns;
-        entry.intent_type = intent_type_;
+        entry.intent_type = intent_type == IntentType::INTENT_UNSPEC
+                                ? intent_type_
+                                : intent_type;
         requests.emplace_back(entry);
     }
     XferBenchTimer timer;

--- a/mooncake-transfer-engine/benchmark/tent_backend.h
+++ b/mooncake-transfer-engine/benchmark/tent_backend.h
@@ -72,7 +72,8 @@ class TENTBenchRunner : public BenchRunner {
 
     double runSingleTransfer(uint64_t local_addr, uint64_t target_addr,
                              uint64_t block_size, uint64_t batch_size,
-                             OpCode opcode, uint64_t deadline_ns);
+                             OpCode opcode, uint64_t deadline_ns,
+                             IntentType intent_type);
 
    private:
     int allocateBuffers();

--- a/mooncake-transfer-engine/benchmark/tests/qos_metrics_test.cpp
+++ b/mooncake-transfer-engine/benchmark/tests/qos_metrics_test.cpp
@@ -22,6 +22,7 @@
 #include <gtest/gtest.h>
 
 #include "tent/thirdparty/nlohmann/json.h"
+#include "workload_config.h"
 
 namespace mooncake {
 namespace tent {
@@ -90,6 +91,45 @@ TEST(QosMetricsTest, RejectsAmbiguousOrInvalidContracts) {
     EXPECT_FALSE(validateQosClasses(classes, 2, &error));
 }
 
+TEST(QosMetricsTest, ParsesMixedWorkloadClasses) {
+    std::vector<WorkloadClassConfig> classes;
+    std::string error;
+    ASSERT_TRUE(parseWorkloadClassesJson(
+        R"json([
+          {"name":"foreground","threads":2,"block_size":4096,"batch_size":1,
+           "intent_type":"foreground_get","deadline_us":250,
+           "slo_us":300,"weight":4},
+          {"name":"migration","threads":6,"block_size":4194304,"batch_size":2,
+           "intent_type":"migration","slo_us":0,"weight":1}
+        ])json",
+        &classes, &error))
+        << error;
+    ASSERT_EQ(classes.size(), 2);
+    EXPECT_EQ(classes[0].qos.name, "foreground");
+    EXPECT_EQ(classes[0].block_size, 4096u);
+    EXPECT_EQ(classes[0].deadline_us, 250u);
+    EXPECT_EQ(classes[0].intent_type, IntentType::FOREGROUND_GET);
+    EXPECT_EQ(classes[1].intent_type, IntentType::MIGRATION);
+    EXPECT_TRUE(validateWorkloadClasses(classes, 8, 1UL << 30, &error))
+        << error;
+    const auto qos_classes = qosClassesFromWorkload(classes);
+    ASSERT_EQ(qos_classes.size(), 2);
+    EXPECT_EQ(qos_classes[1].threads, 6);
+}
+
+TEST(QosMetricsTest, RejectsInvalidMixedWorkloadClasses) {
+    std::vector<WorkloadClassConfig> classes;
+    std::string error;
+    EXPECT_FALSE(parseWorkloadClassesJson(
+        R"json([{"name":"fg","threads":1,"block_size":0,"batch_size":1,
+                 "intent_type":"foreground_get","slo_us":100,"weight":1}])json",
+        &classes, &error));
+    EXPECT_FALSE(parseWorkloadClassesJson(
+        R"json([{"name":"fg","threads":1,"block_size":4096,"batch_size":1,
+                 "intent_type":"unknown","slo_us":100,"weight":1}])json",
+        &classes, &error));
+}
+
 TEST(QosMetricsTest, CalculatesSloFairnessIsolationAndUtilization) {
     std::vector<QosClassConfig> classes = {
         {"foreground", 1, 100, 2.0, 0.006},
@@ -128,6 +168,26 @@ TEST(QosMetricsTest, CalculatesSloFairnessIsolationAndUtilization) {
     EXPECT_NEAR(*foreground.isolated_throughput_gbps, 0.006, 1e-12);
 
     EXPECT_FALSE(report.classes[1].slo_attainment);
+}
+
+TEST(QosMetricsTest, UsesPerClassTransferredBytes) {
+    std::vector<QosClassConfig> classes = {
+        {"foreground", 1, 0, 1.0, std::nullopt},
+        {"migration", 1, 0, 1.0, std::nullopt},
+    };
+    std::vector<XferBenchStats> stats(2);
+    for (auto& class_stats : stats) {
+        class_stats.total_duration.add(1000.0);
+        class_stats.transfer_duration.add(100.0);
+    }
+
+    const auto report = calculateQosMetricsFromBenchStats(
+        0, 0, 2, classes, &stats, 0.0, {4096, 4UL << 20});
+    ASSERT_EQ(report.classes.size(), 2);
+    EXPECT_EQ(report.classes[0].transferred_bytes, 4096u);
+    EXPECT_EQ(report.classes[1].transferred_bytes, 4UL << 20);
+    EXPECT_NEAR(report.classes[0].throughput_gbps, 0.004096, 1e-12);
+    EXPECT_NEAR(report.classes[1].throughput_gbps, 4.194304, 1e-12);
 }
 
 TEST(QosMetricsTest, UsesNullForUnavailableJsonMetrics) {

--- a/mooncake-transfer-engine/benchmark/utils.cpp
+++ b/mooncake-transfer-engine/benchmark/utils.cpp
@@ -53,10 +53,12 @@ DEFINE_string(qos_output_jsonl, "",
               "Append versioned QoS metric records to this JSONL file.");
 DEFINE_uint64(deadline_us, 0,
               "tent only: relative per-transfer deadline in microseconds for "
-              "tight worker threads (0 disables deadline tagging).");
+              "tight worker threads (0 disables deadline tagging); cannot be "
+              "combined with --workload_classes_json.");
 DEFINE_int32(deadline_tight_threads, 0,
              "tent only: workers [0, N) that carry --deadline_us; remaining "
-             "workers have no deadline.");
+             "workers have no deadline; cannot be combined with "
+             "--workload_classes_json.");
 DEFINE_bool(deadline_bw_arbitration, false,
             "tent only: enable deadline-aware RDMA bandwidth arbitration.");
 DEFINE_int32(local_gpu_id, 0, "Local GPU ID to be used, -1 for all GPUs");

--- a/mooncake-transfer-engine/benchmark/utils.cpp
+++ b/mooncake-transfer-engine/benchmark/utils.cpp
@@ -42,6 +42,11 @@ DEFINE_string(
 DEFINE_string(qos_classes_json, "",
               "QoS classes as a JSON array of objects with name, threads, "
               "slo_us, weight, and optional isolated_gbps fields.");
+DEFINE_string(
+    workload_classes_json, "",
+    "Mixed traffic classes as a JSON array with name, threads, block_size, "
+    "batch_size, intent_type, slo_us, weight, and optional deadline_us and "
+    "isolated_gbps fields. Overrides the block/batch sweep.");
 DEFINE_double(qos_link_capacity_gbps, 0.0,
               "Link capacity in GB/s for total utilization (0 reports N/A).");
 DEFINE_string(qos_output_jsonl, "",
@@ -95,6 +100,7 @@ int XferBenchConfig::max_num_threads = 0;
 int XferBenchConfig::start_num_threads = 0;
 std::string XferBenchConfig::qos_classes;
 std::string XferBenchConfig::qos_classes_json;
+std::string XferBenchConfig::workload_classes_json;
 double XferBenchConfig::qos_link_capacity_gbps = 0.0;
 std::string XferBenchConfig::qos_output_jsonl;
 uint64_t XferBenchConfig::deadline_us = 0;
@@ -129,6 +135,7 @@ void XferBenchConfig::loadFromFlags() {
     max_num_threads = FLAGS_max_num_threads;
     qos_classes = FLAGS_qos_classes;
     qos_classes_json = FLAGS_qos_classes_json;
+    workload_classes_json = FLAGS_workload_classes_json;
     qos_link_capacity_gbps = FLAGS_qos_link_capacity_gbps;
     qos_output_jsonl = FLAGS_qos_output_jsonl;
     deadline_us = FLAGS_deadline_us;

--- a/mooncake-transfer-engine/benchmark/utils.h
+++ b/mooncake-transfer-engine/benchmark/utils.h
@@ -70,6 +70,7 @@ struct XferBenchConfig {
     static int start_num_threads;
     static std::string qos_classes;
     static std::string qos_classes_json;
+    static std::string workload_classes_json;
     static double qos_link_capacity_gbps;
     static std::string qos_output_jsonl;
     static uint64_t deadline_us;

--- a/mooncake-transfer-engine/benchmark/workload_config.cpp
+++ b/mooncake-transfer-engine/benchmark/workload_config.cpp
@@ -1,0 +1,149 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "workload_config.h"
+
+#include <algorithm>
+#include <limits>
+#include <unordered_map>
+
+#include "tent/thirdparty/nlohmann/json.h"
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+bool parseIntentType(const std::string& value, IntentType* intent_type) {
+    static const std::unordered_map<std::string, IntentType> kIntentTypes = {
+        {"unspec", IntentType::INTENT_UNSPEC},
+        {"intent_unspec", IntentType::INTENT_UNSPEC},
+        {"foreground_get", IntentType::FOREGROUND_GET},
+        {"background_prefetch", IntentType::BACKGROUND_PREFETCH},
+        {"migration", IntentType::MIGRATION},
+        {"checkpoint", IntentType::CHECKPOINT},
+        {"weight_loading", IntentType::WEIGHT_LOADING},
+        {"staging_internal", IntentType::STAGING_INTERNAL},
+    };
+    const auto it = kIntentTypes.find(value);
+    if (it == kIntentTypes.end()) return false;
+    *intent_type = it->second;
+    return true;
+}
+
+bool parsePositiveSize(const nlohmann::json& node, const char* field,
+                       const std::string& path, size_t* result,
+                       std::string* error) {
+    if (!node.contains(field) || !node[field].is_number_unsigned()) {
+        *error = path + "." + field + " must be an unsigned integer";
+        return false;
+    }
+    const uint64_t value = node[field].get<uint64_t>();
+    if (value == 0 || value > std::numeric_limits<size_t>::max()) {
+        *error = path + "." + field + " must be positive and fit in size_t";
+        return false;
+    }
+    *result = static_cast<size_t>(value);
+    return true;
+}
+
+}  // namespace
+
+bool parseWorkloadClassesJson(const std::string& spec,
+                              std::vector<WorkloadClassConfig>* classes,
+                              std::string* error) {
+    classes->clear();
+    try {
+        const auto root = nlohmann::json::parse(spec);
+        if (!root.is_array() || root.empty()) {
+            *error = "workload_classes_json must be a non-empty array";
+            return false;
+        }
+        std::vector<QosClassConfig> qos_classes;
+        if (!parseQosClassesJson(spec, &qos_classes, error)) return false;
+
+        for (size_t i = 0; i < root.size(); ++i) {
+            const auto& node = root[i];
+            const std::string path =
+                "workload_classes_json[" + std::to_string(i) + "]";
+
+            WorkloadClassConfig config;
+            config.qos = qos_classes[i];
+            if (!parsePositiveSize(node, "block_size", path, &config.block_size,
+                                   error) ||
+                !parsePositiveSize(node, "batch_size", path, &config.batch_size,
+                                   error)) {
+                return false;
+            }
+            if (config.block_size >
+                std::numeric_limits<size_t>::max() / config.batch_size) {
+                *error = path + " block_size * batch_size overflows size_t";
+                return false;
+            }
+
+            if (node.contains("deadline_us")) {
+                if (!node["deadline_us"].is_number_unsigned()) {
+                    *error = path + ".deadline_us must be an unsigned integer";
+                    return false;
+                }
+                config.deadline_us = node["deadline_us"].get<uint64_t>();
+            }
+            if (!node.contains("intent_type") ||
+                !node["intent_type"].is_string() ||
+                !parseIntentType(node["intent_type"].get<std::string>(),
+                                 &config.intent_type)) {
+                *error = path + ".intent_type is invalid";
+                return false;
+            }
+            classes->push_back(std::move(config));
+        }
+        return true;
+    } catch (const std::exception& e) {
+        *error =
+            std::string("failed to parse workload_classes_json: ") + e.what();
+        return false;
+    }
+}
+
+bool validateWorkloadClasses(const std::vector<WorkloadClassConfig>& classes,
+                             int num_threads, size_t total_buffer_size,
+                             std::string* error) {
+    size_t configured_threads = 0;
+    size_t max_bytes_per_thread = 0;
+    for (const auto& config : classes) {
+        configured_threads += static_cast<size_t>(config.qos.threads);
+        const size_t bytes = config.block_size * config.batch_size;
+        max_bytes_per_thread = std::max(max_bytes_per_thread, bytes);
+    }
+    if (configured_threads != static_cast<size_t>(num_threads)) {
+        *error = "workload class thread count must equal benchmark threads";
+        return false;
+    }
+    if (max_bytes_per_thread > total_buffer_size ||
+        configured_threads > total_buffer_size / max_bytes_per_thread) {
+        *error = "mixed workload address stride exceeds total_buffer_size";
+        return false;
+    }
+    return true;
+}
+
+std::vector<QosClassConfig> qosClassesFromWorkload(
+    const std::vector<WorkloadClassConfig>& classes) {
+    std::vector<QosClassConfig> qos_classes;
+    qos_classes.reserve(classes.size());
+    for (const auto& config : classes) qos_classes.push_back(config.qos);
+    return qos_classes;
+}
+
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/benchmark/workload_config.h
+++ b/mooncake-transfer-engine/benchmark/workload_config.h
@@ -1,0 +1,51 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TEBENCH_WORKLOAD_CONFIG_H
+#define TEBENCH_WORKLOAD_CONFIG_H
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "tent/common/qos_metrics.h"
+#include "tent/common/types.h"
+
+namespace mooncake {
+namespace tent {
+
+struct WorkloadClassConfig {
+    QosClassConfig qos;
+    size_t block_size = 0;
+    size_t batch_size = 0;
+    uint64_t deadline_us = 0;
+    IntentType intent_type = IntentType::INTENT_UNSPEC;
+};
+
+bool parseWorkloadClassesJson(const std::string& spec,
+                              std::vector<WorkloadClassConfig>* classes,
+                              std::string* error);
+
+bool validateWorkloadClasses(const std::vector<WorkloadClassConfig>& classes,
+                             int num_threads, size_t total_buffer_size,
+                             std::string* error);
+
+std::vector<QosClassConfig> qosClassesFromWorkload(
+    const std::vector<WorkloadClassConfig>& classes);
+
+}  // namespace tent
+}  // namespace mooncake
+
+#endif  // TEBENCH_WORKLOAD_CONFIG_H

--- a/mooncake-transfer-engine/tent/include/tent/common/qos_metrics.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/qos_metrics.h
@@ -49,6 +49,7 @@ struct QosClassMetrics {
     double weighted_goodput_gbps = 0.0;
     std::optional<double> isolated_throughput_gbps;
     std::optional<double> isolation_leakage;
+    uint64_t transferred_bytes = 0;
 };
 
 struct QosClassSample {
@@ -56,6 +57,7 @@ struct QosClassSample {
     double total_duration_us = 0.0;
     double p99_us = 0.0;
     std::optional<double> slo_attainment;
+    std::optional<uint64_t> transferred_bytes;
 };
 
 struct QosMetricsReport {

--- a/mooncake-transfer-engine/tent/src/common/qos_metrics.cpp
+++ b/mooncake-transfer-engine/tent/src/common/qos_metrics.cpp
@@ -240,13 +240,16 @@ QosMetricsReport calculateQosMetrics(size_t block_size, size_t batch_size,
         metrics.weight = config.weight;
         metrics.isolated_throughput_gbps = config.isolated_throughput_gbps;
         metrics.operations = sample.operations;
+        metrics.transferred_bytes = sample.transferred_bytes.value_or(
+            static_cast<uint64_t>(block_size) * batch_size *
+            metrics.operations);
         metrics.p99_us = sample.p99_us;
 
         const double duration_s = sample.total_duration_us / 1e6;
-        const double bytes =
-            static_cast<double>(block_size) * batch_size * metrics.operations;
         if (duration_s > 0.0)
-            metrics.throughput_gbps = bytes / 1e9 / duration_s;
+            metrics.throughput_gbps =
+                static_cast<double>(metrics.transferred_bytes) / 1e9 /
+                duration_s;
 
         double attainment = 1.0;
         if (config.slo_us != 0) {
@@ -305,6 +308,7 @@ void printQosMetrics(const QosMetricsReport& report) {
         std::cout << "  [qos-class] name=" << metrics.name
                   << " threads=" << metrics.threads
                   << " operations=" << metrics.operations
+                  << " transferred_bytes=" << metrics.transferred_bytes
                   << " throughput=" << metrics.throughput_gbps
                   << " GB/s p99_us=" << std::setprecision(1) << metrics.p99_us
                   << " slo_attainment=";
@@ -346,6 +350,7 @@ bool appendQosMetricsJsonl(const std::string& path,
             {"slo_us", metrics.slo_us},
             {"weight", metrics.weight},
             {"operations", metrics.operations},
+            {"transferred_bytes", metrics.transferred_bytes},
             {"throughput_gbps", metrics.throughput_gbps},
             {"p99_us", metrics.p99_us},
             {"slo_attainment", optionalJson(metrics.slo_attainment)},


### PR DESCRIPTION
## Description

Add a benchmark-only mixed traffic contract to `tebench` so latency-sensitive foreground requests and bulk KV movement can run concurrently with different block sizes, batch sizes, TENT intents, deadlines, and QoS reporting thresholds.

This extends the QoS metrics baseline from #2845 and provides a concrete workload fixture for the validation matrix discussed in #2866. Existing block/batch sweeps and `--qos_classes` behavior remain unchanged.

Key changes:
- add `--workload_classes_json` with per-class transfer shape, intent, optional deadline, and QoS fields
- attach the selected class intent/deadline to each TENT request
- calculate class throughput from actual transferred bytes for heterogeneous request sizes
- preserve classic backend support for mixed sizes when intents/deadlines are unspecified
- add parser, validation, metric tests, and user documentation

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
cmake -S . -B build-codex-mixed -G Ninja \
  -DUSE_TENT=ON -DBUILD_BENCHMARK=ON -DBUILD_UNIT_TESTS=ON \
  -DBUILD_EXAMPLES=OFF -DUSE_CUDA=OFF -DUSE_HIP=OFF \
  -DCMAKE_BUILD_TYPE=Release
cmake --build build-codex-mixed --target tebench_qos_metrics_test tebench -j 16
ctest --test-dir build-codex-mixed -R tebench_qos_metrics_test --output-on-failure
```

**Remote H20 smoke:**
- Alibaba Cloud Linux host `lingjun-101`, Ubuntu 24.04 build container, GCC 13.3
- `USE_TENT=ON` build passed
- `tebench_qos_metrics_test`: 9/9 passed
- TENT SHM target/initiator mixed run passed with two 4 KiB foreground workers and two 8 MiB migration workers
- observed 396,358 foreground operations (P99 9.0 us) and 3,519 migration operations (P99 587.8 us)
- JSONL contained both classes and non-zero per-class `transferred_bytes`
- RDMA is not claimed by this smoke run

**Test results:**
- [x] Unit tests pass
- [x] Integration tests pass (TENT SHM smoke)
- [x] Manual testing done as described above

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted the changed C++ files with clang-format
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation
- [x] I have added tests to prove my changes are effective
- [x] Change is below the >500 non-test LOC RFC threshold; it also aligns with #2866

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used

Codex assisted with code implementation, test construction, and remote smoke-test orchestration. The human submitter is responsible for reviewing and defending the change.