### PR TITLE
[Store][TENT] Add transfer intent and path observability

### DIFF
--- a/mooncake-store/include/client_metric.h
+++ b/mooncake-store/include/client_metric.h
@@ -103,11 +103,22 @@ Result execute_timed_operation(Operation&& operation, SuccessFn&& success_fn,
 enum class TransferOperationKind { kRead, kWrite };
 
 struct TransferMetric {
+    std::array<std::string, 2> transfer_path_label_names = {"intent", "path"};
+    std::array<std::string, 1> transfer_intent_label_names = {"intent"};
+
     TransferMetric(std::map<std::string, std::string> labels = {})
         : total_read_bytes("mooncake_transfer_read_bytes", "Total bytes read",
                            labels),
           total_write_bytes("mooncake_transfer_write_bytes",
                             "Total bytes written", labels),
+          transfer_path_bytes(
+              "mooncake_store_transfer_path_bytes",
+              "Store transfer bytes by normalized intent and executed path",
+              labels, transfer_path_label_names),
+          unmanaged_transfer_bytes(
+              "mooncake_store_unmanaged_transfer_bytes",
+              "Store transfer bytes executed outside Transfer Engine control",
+              labels, transfer_intent_label_names),
           batch_put_latency_us("mooncake_transfer_batch_put_latency",
                                "Batch Put transfer latency (us)",
                                kLatencyBucket, labels),
@@ -122,6 +133,8 @@ struct TransferMetric {
 
     ylt::metric::counter_t total_read_bytes;
     ylt::metric::counter_t total_write_bytes;
+    ylt::metric::hybrid_counter_2t transfer_path_bytes;
+    ylt::metric::hybrid_counter_1t unmanaged_transfer_bytes;
     ylt::metric::histogram_t batch_put_latency_us;
     ylt::metric::histogram_t batch_get_latency_us;
     ylt::metric::histogram_t get_latency_us;
@@ -130,10 +143,20 @@ struct TransferMetric {
     void serialize(std::string& str) {
         total_read_bytes.serialize(str);
         total_write_bytes.serialize(str);
+        transfer_path_bytes.serialize(str);
+        unmanaged_transfer_bytes.serialize(str);
         batch_put_latency_us.serialize(str);
         batch_get_latency_us.serialize(str);
         get_latency_us.serialize(str);
         put_latency_us.serialize(str);
+    }
+
+    void ObserveTransferPath(const std::string& intent, const std::string& path,
+                             uint64_t bytes, bool transfer_engine_managed) {
+        transfer_path_bytes.inc({intent, path}, bytes);
+        if (!transfer_engine_managed) {
+            unmanaged_transfer_bytes.inc({intent}, bytes);
+        }
     }
 
     std::string summary_metrics(bool include_bandwidth = true) {

--- a/mooncake-store/include/transfer_task.h
+++ b/mooncake-store/include/transfer_task.h
@@ -519,6 +519,28 @@ class FilereadWorkerPool {
     std::shared_ptr<StorageBackend> backend_;
 };
 
+// A bounded, transport-independent intent vocabulary for Store transfers.
+// Phase 0 only records this context. Scheduling behavior remains unchanged.
+enum class StoreTransferIntent {
+    UNSPECIFIED = 0,
+    FOREGROUND_GET,
+    BACKGROUND_PREFETCH,
+    MIGRATION,
+    WEIGHT_LOADING,
+};
+
+struct StoreTransferContext {
+    StoreTransferIntent intent = StoreTransferIntent::UNSPECIFIED;
+};
+
+enum class StoreTransferPath {
+    UNKNOWN = 0,
+    TRANSFER_ENGINE,
+    LOCAL_MEMCPY,
+    NVME_OF,
+    FILE,
+};
+
 /**
  * @brief Submitter class for asynchronous transfer operations
  *
@@ -550,7 +572,8 @@ class TransferSubmitter {
     std::optional<TransferFuture> submit(const Replica::Descriptor& replica,
                                          std::vector<Slice>& slices,
                                          TransferRequest::OpCode op_code,
-                                         void* ptr = nullptr, size_t size = 0);
+                                         void* ptr = nullptr, size_t size = 0,
+                                         StoreTransferContext context = {});
 
     /**
      * @brief Submit a range read: read [src_offset, src_offset+size) from
@@ -558,12 +581,12 @@ class TransferSubmitter {
      */
     std::optional<TransferFuture> submitRangeRead(
         const Replica::Descriptor& replica, std::vector<Slice>& slices,
-        uint64_t src_offset);
+        uint64_t src_offset, StoreTransferContext context = {});
 
     std::optional<TransferFuture> submit_batch(
         const std::vector<Replica::Descriptor>& replicas,
         std::vector<std::vector<Slice>>& all_slices,
-        TransferRequest::OpCode op_code);
+        TransferRequest::OpCode op_code, StoreTransferContext context = {});
 
     std::optional<TransferFuture> submit_batch_get_offload_object(
         const std::string& transfer_engine_addr,
@@ -571,6 +594,11 @@ class TransferSubmitter {
         const std::vector<uint64_t>& pointers,
         const std::unordered_map<std::string, std::vector<Slice>>&
             batched_slices);
+
+    static StoreTransferIntent effectiveIntent(StoreTransferContext context,
+                                               TransferRequest::OpCode op_code);
+    static const char* intentName(StoreTransferIntent intent);
+    static const char* pathName(StoreTransferPath path);
 
     /**
      * @brief Pure comparison helper: returns true iff both endpoints are
@@ -654,7 +682,9 @@ class TransferSubmitter {
      * @brief Calculate total bytes for transfer operation and update metrics
      */
     void updateTransferMetrics(const std::vector<Slice>& slices,
-                               TransferRequest::OpCode op);
+                               TransferRequest::OpCode op,
+                               StoreTransferContext context,
+                               StoreTransferPath path);
 
     std::optional<TransferFuture> submitTransfer(
         std::vector<TransferRequest>& requests);

--- a/mooncake-store/src/transfer_task.cpp
+++ b/mooncake-store/src/transfer_task.cpp
@@ -980,8 +980,10 @@ TransferSubmitter::TransferSubmitter(TransferEngine& engine,
 
 std::optional<TransferFuture> TransferSubmitter::submit(
     const Replica::Descriptor& replica, std::vector<Slice>& slices,
-    TransferRequest::OpCode op_code, void* ptr, size_t size) {
+    TransferRequest::OpCode op_code, void* ptr, size_t size,
+    StoreTransferContext context) {
     std::optional<TransferFuture> future;
+    StoreTransferPath path = StoreTransferPath::UNKNOWN;
 
     if (replica.is_memory_replica()) {
         auto& mem_desc = replica.get_memory_descriptor();
@@ -992,15 +994,21 @@ std::optional<TransferFuture> TransferSubmitter::submit(
         }
 
         if (op_code == TransferRequest::READ) {
+            const auto strategy = selectStrategy(handle, slices);
+            path = strategy == TransferStrategy::LOCAL_MEMCPY
+                       ? StoreTransferPath::LOCAL_MEMCPY
+                       : StoreTransferPath::TRANSFER_ENGINE;
             future = submitMemoryReadOperation(handle, slices, 0);
         } else {
             TransferStrategy strategy = selectStrategy(handle, slices);
 
             switch (strategy) {
                 case TransferStrategy::LOCAL_MEMCPY:
+                    path = StoreTransferPath::LOCAL_MEMCPY;
                     future = submitMemcpyOperation(handle, slices, op_code);
                     break;
                 case TransferStrategy::TRANSFER_ENGINE:
+                    path = StoreTransferPath::TRANSFER_ENGINE;
                     future =
                         submitTransferEngineOperation(handle, slices, op_code);
                     break;
@@ -1011,6 +1019,7 @@ std::optional<TransferFuture> TransferSubmitter::submit(
         }
     } else if (replica.is_nof_replica()) {
 #ifdef USE_NOF
+        path = StoreTransferPath::NVME_OF;
         auto& ssd_desc = replica.get_nof_descriptor();
         auto& handle = ssd_desc.buffer_descriptor;
 
@@ -1024,12 +1033,13 @@ std::optional<TransferFuture> TransferSubmitter::submit(
         return std::nullopt;
 #endif
     } else {
+        path = StoreTransferPath::FILE;
         future = submitFileReadOperation(replica, slices, op_code);
     }
 
     // Update metrics on successful submission
     if (future.has_value()) {
-        updateTransferMetrics(slices, op_code);
+        updateTransferMetrics(slices, op_code, context, path);
     }
 
     return future;
@@ -1038,7 +1048,7 @@ std::optional<TransferFuture> TransferSubmitter::submit(
 std::optional<TransferFuture> TransferSubmitter::submit_batch(
     const std::vector<Replica::Descriptor>& replicas,
     std::vector<std::vector<Slice>>& all_slices,
-    TransferRequest::OpCode op_code) {
+    TransferRequest::OpCode op_code, StoreTransferContext context) {
     std::optional<TransferFuture> future;
     std::vector<TransferRequest> requests;
     for (size_t i = 0; i < replicas.size(); ++i) {
@@ -1071,7 +1081,8 @@ std::optional<TransferFuture> TransferSubmitter::submit_batch(
     // Update metrics on successful submission
     if (future.has_value()) {
         for (auto& slices : all_slices) {
-            updateTransferMetrics(slices, op_code);
+            updateTransferMetrics(slices, op_code, context,
+                                  StoreTransferPath::TRANSFER_ENGINE);
         }
     }
     return future;
@@ -1255,8 +1266,9 @@ std::optional<TransferFuture> TransferSubmitter::submitMemoryReadOperation(
 
 std::optional<TransferFuture> TransferSubmitter::submitRangeRead(
     const Replica::Descriptor& replica, std::vector<Slice>& slices,
-    uint64_t src_offset) {
+    uint64_t src_offset, StoreTransferContext context) {
     std::optional<TransferFuture> future;
+    StoreTransferPath path = StoreTransferPath::UNKNOWN;
 
     if (replica.is_memory_replica()) {
         auto& mem_desc = replica.get_memory_descriptor();
@@ -1271,6 +1283,10 @@ std::optional<TransferFuture> TransferSubmitter::submitRangeRead(
             return std::nullopt;
         }
 
+        const auto strategy = selectStrategy(handle, slices);
+        path = strategy == TransferStrategy::LOCAL_MEMCPY
+                   ? StoreTransferPath::LOCAL_MEMCPY
+                   : StoreTransferPath::TRANSFER_ENGINE;
         future = submitMemoryReadOperation(handle, slices, src_offset);
     } else if (replica.is_nof_replica()) {
         LOG(ERROR) << "Range read not supported for NoF replicas";
@@ -1282,7 +1298,7 @@ std::optional<TransferFuture> TransferSubmitter::submitRangeRead(
     }
 
     if (future.has_value()) {
-        updateTransferMetrics(slices, TransferRequest::READ);
+        updateTransferMetrics(slices, TransferRequest::READ, context, path);
     }
 
     return future;
@@ -1439,8 +1455,53 @@ bool TransferSubmitter::validateTransferParams(
     return true;
 }
 
+StoreTransferIntent TransferSubmitter::effectiveIntent(
+    StoreTransferContext context, TransferRequest::OpCode op_code) {
+    if (context.intent != StoreTransferIntent::UNSPECIFIED) {
+        return context.intent;
+    }
+    if (op_code == TransferRequest::READ) {
+        return StoreTransferIntent::FOREGROUND_GET;
+    }
+    return StoreTransferIntent::UNSPECIFIED;
+}
+
+const char* TransferSubmitter::intentName(StoreTransferIntent intent) {
+    switch (intent) {
+        case StoreTransferIntent::FOREGROUND_GET:
+            return "foreground_get";
+        case StoreTransferIntent::BACKGROUND_PREFETCH:
+            return "background_prefetch";
+        case StoreTransferIntent::MIGRATION:
+            return "migration";
+        case StoreTransferIntent::WEIGHT_LOADING:
+            return "weight_loading";
+        case StoreTransferIntent::UNSPECIFIED:
+        default:
+            return "unspecified";
+    }
+}
+
+const char* TransferSubmitter::pathName(StoreTransferPath path) {
+    switch (path) {
+        case StoreTransferPath::TRANSFER_ENGINE:
+            return "transfer_engine";
+        case StoreTransferPath::LOCAL_MEMCPY:
+            return "local_memcpy";
+        case StoreTransferPath::NVME_OF:
+            return "nvme_of";
+        case StoreTransferPath::FILE:
+            return "file";
+        case StoreTransferPath::UNKNOWN:
+        default:
+            return "unknown";
+    }
+}
+
 void TransferSubmitter::updateTransferMetrics(const std::vector<Slice>& slices,
-                                              TransferRequest::OpCode op_code) {
+                                              TransferRequest::OpCode op_code,
+                                              StoreTransferContext context,
+                                              StoreTransferPath path) {
     size_t total_bytes = 0;
     for (const auto& slice : slices) {
         total_bytes += slice.size;
@@ -1456,6 +1517,11 @@ void TransferSubmitter::updateTransferMetrics(const std::vector<Slice>& slices,
     } else if (op_code == TransferRequest::WRITE) {
         transfer_metric_->total_write_bytes.inc(total_bytes);
     }
+
+    const auto intent = effectiveIntent(context, op_code);
+    transfer_metric_->ObserveTransferPath(
+        intentName(intent), pathName(path), total_bytes,
+        path == StoreTransferPath::TRANSFER_ENGINE);
 }
 
 }  // namespace mooncake

--- a/mooncake-store/tests/client_metrics_test.cpp
+++ b/mooncake-store/tests/client_metrics_test.cpp
@@ -124,6 +124,26 @@ TEST_F(ClientMetricsTest, TransferMetricsSummaryTest) {
     std::cout << "Transfer Metrics Summary:\n" << summary << std::endl;
 }
 
+TEST_F(ClientMetricsTest, TransferPathMetricsSeparateManagedAndUnmanaged) {
+    TransferMetric metrics;
+
+    metrics.ObserveTransferPath("foreground_get", "transfer_engine", 4096,
+                                true);
+    metrics.ObserveTransferPath("background_prefetch", "file", 8192, false);
+
+    std::string serialized;
+    metrics.serialize(serialized);
+
+    EXPECT_NE(serialized.find("mooncake_store_transfer_path_bytes"),
+              std::string::npos);
+    EXPECT_NE(serialized.find("intent=\"foreground_get\""), std::string::npos);
+    EXPECT_NE(serialized.find("path=\"transfer_engine\""), std::string::npos);
+    EXPECT_NE(serialized.find("mooncake_store_unmanaged_transfer_bytes"),
+              std::string::npos);
+    EXPECT_NE(serialized.find("intent=\"background_prefetch\""),
+              std::string::npos);
+}
+
 TEST_F(ClientMetricsTest, MasterClientMetricsSummaryTest) {
     MasterClientMetric metrics;
 

--- a/mooncake-store/tests/transfer_task_test.cpp
+++ b/mooncake-store/tests/transfer_task_test.cpp
@@ -175,6 +175,26 @@ TEST_F(TransferTaskTest, IsSameProcessEndpoint) {
     EXPECT_FALSE(TransferSubmitter::isSameProcessEndpoint("host-a", "host-b"));
 }
 
+TEST_F(TransferTaskTest, StoreTransferIntentNormalization) {
+    EXPECT_EQ(TransferSubmitter::effectiveIntent({}, TransferRequest::READ),
+              StoreTransferIntent::FOREGROUND_GET);
+    EXPECT_EQ(TransferSubmitter::effectiveIntent({}, TransferRequest::WRITE),
+              StoreTransferIntent::UNSPECIFIED);
+
+    StoreTransferContext context{.intent =
+                                     StoreTransferIntent::BACKGROUND_PREFETCH};
+    EXPECT_EQ(
+        TransferSubmitter::effectiveIntent(context, TransferRequest::READ),
+        StoreTransferIntent::BACKGROUND_PREFETCH);
+    EXPECT_STREQ(TransferSubmitter::intentName(context.intent),
+                 "background_prefetch");
+    EXPECT_STREQ(
+        TransferSubmitter::pathName(StoreTransferPath::TRANSFER_ENGINE),
+        "transfer_engine");
+    EXPECT_STREQ(TransferSubmitter::pathName(StoreTransferPath::LOCAL_MEMCPY),
+                 "local_memcpy");
+}
+
 // Test TransferStrategy enum and stream operator
 TEST_F(TransferTaskTest, TransferStrategyEnum) {
     // Test enum values


### PR DESCRIPTION
## Summary

This is the behavior-preserving Phase 0 slice of #2946. It makes Store transfer intent and the actually executed data path observable before any Store-to-TENT scheduling policy is enabled.

- adds a bounded `StoreTransferIntent` context with foreground get, background prefetch, migration, weight loading, and unspecified values;
- normalizes existing READ calls to `foreground_get` while preserving explicit caller intent;
- records Store bytes by `(intent, path)` for Transfer Engine, local memcpy, NVMe-oF, file, and unknown paths;
- records `mooncake_store_unmanaged_transfer_bytes{intent=...}` for bytes outside Transfer Engine control;
- keeps every existing call source-compatible through default arguments;
- does not alter transfer selection, priority, QP choice, admission, or bandwidth behavior.

The bounded vocabulary follows the connector direction in #2865 and intentionally excludes tenant/trace IDs from metric labels.

## Why first

Without path attribution, a future Store QoS result could incorrectly claim protection for local memcpy, file, NVMe-oF, or opaque staging traffic. These metrics establish the enforcement boundary needed by #2946 before enabling LOW/HIGH policy.

## Remote validation

Lingjun H20 `lingjun-101`, fresh branch clone, GCC 13.3, Release-like CMake build, `USE_CUDA=OFF`:

- `transfer_task_test`: **7/7 passed**
- `client_metrics_test`: **15/15 passed**
- total targeted tests: **22/22 passed**

The build ran in a task-owned one-shot dependency container; no existing containers, images, volumes, or networks were changed.

Related: #2946, #2865, #3074.