### PR TITLE
[Docs] Document multi-model KV cache isolation

### DIFF
--- a/docs/source/deployment/index.md
+++ b/docs/source/deployment/index.md
@@ -10,6 +10,7 @@ Kubernetes environments.
 | Guide | Description |
 |-------|-------------|
 | [Mooncake Store Deployment and Tuning](mooncake-store-deployment-guide) | Configure Store clients, metadata services, storage tiers, and production tuning. |
+| [KV Cache Sharing and Isolation](kv-cache-sharing-and-isolation) | Define cache-sharing boundaries across models, releases, request groups, and Mooncake tenants. |
 | [Kubernetes Deployment](kubernetes-deployment-guide/index) | Deploy Mooncake Store and Transfer Engine integrations on Kubernetes. |
 | [SSD Storage](ssd/index) | Configure local SSD offload or a shared NVMe-over-Fabrics storage pool. |
 

--- a/docs/source/deployment/kv-cache-sharing-and-isolation.md
+++ b/docs/source/deployment/kv-cache-sharing-and-isolation.md
@@ -1,0 +1,134 @@
+# KV Cache Sharing and Isolation
+
+## Overview
+
+Mooncake Store treats object keys as opaque strings. The inference framework constructs those keys and therefore defines which requests and instances may reuse the same KV cache entries.
+
+A shared Mooncake Store can safely serve multiple models and releases when each cache-compatible group uses a stable, unique namespace. This is useful for:
+
+- Hosting multiple model families on the same Store cluster.
+- Rolling from one model revision to another without mixing their KV cache.
+- Running canary, A/B, quantized, or fine-tuned variants side by side.
+- Separating cache reuse by request group with `cache_salt`.
+- Applying a Mooncake quota to each logical tenant.
+
+## Choose the Isolation Boundary
+
+The available isolation mechanisms are complementary:
+
+| Boundary | Use it for | Configuration |
+|----------|------------|---------------|
+| Model | Different model families or incompatible model variants | SGLang `--served-model-name`; vLLM derives the name from the model path |
+| Deployment or release | Rolling upgrades, canaries, and environments that use the same model name | SGLang `extra_backend_tag`; vLLM `cache_prefix` |
+| Request group | Reuse within one application, user group, or other isolation domain | vLLM API `cache_salt` |
+| Mooncake tenant | A logical object namespace with its own quota | Store client `tenant_id` and master `--enable_multi_tenants=true` |
+
+Instances should use identical values only when their KV cache entries are compatible and are intended to be shared. Prefill and decode instances in the same deployment must therefore use the same values.
+
+## SGLang
+
+Use an SGLang version that includes [model-aware Mooncake key isolation](https://github.com/sgl-project/sglang/pull/31920), and set a stable, unique `--served-model-name`:
+
+```bash
+python -m sglang.launch_server \
+  --model-path Qwen/Qwen3-8B \
+  --served-model-name qwen3-8b \
+  --enable-hierarchical-cache \
+  --hicache-storage-backend mooncake
+```
+
+All SGLang instances that should share KV cache entries must use the same `--served-model-name`.
+
+For two deployments of the same served model, add a release-specific `extra_backend_tag`:
+
+```bash
+python -m sglang.launch_server \
+  --model-path /models/Qwen3-8B \
+  --served-model-name qwen3-8b \
+  --enable-hierarchical-cache \
+  --hicache-storage-backend mooncake \
+  --hicache-storage-backend-extra-config \
+    '{"extra_backend_tag":"production-2026-07"}'
+```
+
+Keep the tag identical across compatible instances in one release, and change it for a release whose KV cache must not be reused.
+
+## vLLM
+
+The vLLM `MooncakeStoreConnector` automatically uses the final component of the model passed to `vllm serve` as its model identifier. For example, both `Qwen/Qwen3-8B` and `/models/Qwen3-8B` produce `Qwen3-8B`.
+
+Set `cache_prefix` when paths with the same final component must remain separate, or when a deployment needs a release-specific namespace:
+
+```bash
+MOONCAKE_CONFIG_PATH=/path/to/mooncake_config.json \
+vllm serve /models/Qwen3-8B \
+  --kv-transfer-config '{
+    "kv_connector": "MooncakeStoreConnector",
+    "kv_role": "kv_both",
+    "kv_connector_extra_config": {
+      "cache_prefix": "production-2026-07"
+    }
+  }'
+```
+
+All vLLM instances that should share KV cache entries must use the same model and `cache_prefix`.
+
+### Request-Level Isolation with `cache_salt`
+
+vLLM also accepts an optional `cache_salt` in each OpenAI-compatible request:
+
+```json
+{
+  "model": "qwen3-8b",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Summarize this document."
+    }
+  ],
+  "cache_salt": "application-a"
+}
+```
+
+vLLM inserts the salt into the first KV block hash. Because subsequent block hashes depend on the preceding block, the salt affects the Mooncake keys for the request:
+
+- Requests with the same salt can reuse compatible cached prefixes.
+- Requests with different salts use separate cache entries.
+- An omitted or empty salt retains the default shared-cache behavior.
+
+LMCache uses the same isolation-domain convention when it propagates vLLM's `cache_salt` into its cache object identity: one stable salt defines one sharing group. Avoid generating a random salt for every request unless disabling cross-request reuse is intentional.
+
+## Rolling Model Upgrades
+
+During a rolling upgrade, the old and new releases may temporarily use the same Mooncake Store. Give each release a distinct deployment namespace:
+
+| Release | SGLang `extra_backend_tag` | vLLM `cache_prefix` |
+|---------|----------------------------|---------------------|
+| Current | `production-2026-07` | `production-2026-07` |
+| New | `production-2026-08` | `production-2026-08` |
+
+A typical rollout is:
+
+1. Keep all current-release instances on the existing namespace.
+2. Start the new prefill and decode instances with the new namespace.
+3. Warm the new release and gradually shift traffic to it.
+4. Retire the old instances after in-flight requests finish.
+5. Allow old cache entries to leave the Store through the normal eviction or cleanup lifecycle.
+
+This approach prevents the new release from reading KV cache generated by the old release, while preserving cache reuse among instances of the same release. Plan for temporarily higher Store capacity because both releases may be warm at the same time.
+
+Use a new namespace whenever cache compatibility may have changed, including changes to model weights, KV layout, quantization, adapters, or other inference settings that affect generated KV values.
+
+## Mooncake Tenants
+
+Mooncake tenant configuration is independent of the framework-level model, release, and request namespaces. When the master is started with `--enable_multi_tenants=true`, the client `tenant_id` selects a tenant-scoped object namespace and the master applies that tenant's quota during admission.
+
+Use the same `tenant_id` for framework instances that should share one quota and tenant namespace. See [Tenant Quota Management](mooncake-store-deployment-guide.md#tenant-quota-management) for configuration details.
+
+## Operational Checklist
+
+- Use deterministic names that remain stable across restarts.
+- Keep model and release fields identical across compatible prefill, decode, and replica instances.
+- Change the release namespace before introducing a cache-incompatible deployment.
+- Keep `cache_salt` stable within a group that should benefit from prefix reuse.
+- Account for duplicate cache occupancy while old and new releases overlap.

--- a/docs/source/deployment/kv-cache-sharing-and-isolation.md
+++ b/docs/source/deployment/kv-cache-sharing-and-isolation.md
@@ -123,7 +123,7 @@ Use a new namespace whenever cache compatibility may have changed, including cha
 
 Mooncake tenant configuration is independent of the framework-level model, release, and request namespaces. When the master is started with `--enable_multi_tenants=true`, the client `tenant_id` selects a tenant-scoped object namespace and the master applies that tenant's quota during admission.
 
-Use the same `tenant_id` for framework instances that should share one quota and tenant namespace. See [Tenant Quota Management](../mooncake-store-deployment-guide.md#tenant-quota-management) for configuration details.
+Use the same `tenant_id` for framework instances that should share one quota and tenant namespace. See [Tenant Quota Management](mooncake-store-deployment-guide.md#tenant-quota-management) for configuration details.
 
 ## Operational Checklist
 

--- a/docs/source/deployment/kv-cache-sharing-and-isolation/index.md
+++ b/docs/source/deployment/kv-cache-sharing-and-isolation/index.md
@@ -123,7 +123,7 @@ Use a new namespace whenever cache compatibility may have changed, including cha
 
 Mooncake tenant configuration is independent of the framework-level model, release, and request namespaces. When the master is started with `--enable_multi_tenants=true`, the client `tenant_id` selects a tenant-scoped object namespace and the master applies that tenant's quota during admission.
 
-Use the same `tenant_id` for framework instances that should share one quota and tenant namespace. See [Tenant Quota Management](mooncake-store-deployment-guide.md#tenant-quota-management) for configuration details.
+Use the same `tenant_id` for framework instances that should share one quota and tenant namespace. See [Tenant Quota Management](../mooncake-store-deployment-guide.md#tenant-quota-management) for configuration details.
 
 ## Operational Checklist
 

--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -235,6 +235,45 @@ mooncake_master \
 
 The master resolves the current IPv4 address of `eth0` at startup and uses it as the advertised RPC address.
 
+---
+
+### Multi-Model KV Cache Isolation
+
+Mooncake Store treats object keys as opaque strings. When multiple models share one Mooncake Store, configure the model identifier in the inference framework to keep their KV cache entries separate.
+
+#### SGLang
+
+With an SGLang version that includes [model-aware Mooncake key isolation](https://github.com/sgl-project/sglang/pull/31920), set a stable and unique `--served-model-name`:
+
+```bash
+python -m sglang.launch_server \
+  --model-path Qwen/Qwen3-8B \
+  --served-model-name qwen3-8b \
+  --enable-hierarchical-cache \
+  --hicache-storage-backend mooncake
+```
+
+Use the same `--served-model-name` on all SGLang instances that should share KV cache entries.
+
+#### vLLM
+
+The vLLM `MooncakeStoreConnector` automatically uses the final component of the model passed to `vllm serve` as the model identifier, so no separate model-name setting is required. To isolate deployments whose model paths end with the same name, assign each deployment a distinct `cache_prefix`:
+
+```bash
+MOONCAKE_CONFIG_PATH=/path/to/mooncake_config.json \
+vllm serve Qwen/Qwen3-8B \
+  --kv-transfer-config '{
+    "kv_connector": "MooncakeStoreConnector",
+    "kv_role": "kv_both",
+    "kv_connector_extra_config": {
+      "cache_prefix": "qwen3-8b-production"
+    }
+  }'
+```
+
+Use the same model and `cache_prefix` on all vLLM instances that should share KV cache entries.
+
+Separately, enabling `--enable_multi_tenants=true` adds a `tenant_id`-scoped object namespace and per-tenant quota admission. See [Tenant Quota Management](#tenant-quota-management) for configuration details.
 
 ---
 

--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -237,43 +237,11 @@ The master resolves the current IPv4 address of `eth0` at startup and uses it as
 
 ---
 
-### Multi-Model KV Cache Isolation
+### KV Cache Sharing and Isolation
 
-Mooncake Store treats object keys as opaque strings. When multiple models share one Mooncake Store, configure the model identifier in the inference framework to keep their KV cache entries separate.
+Mooncake Store treats object keys as opaque strings, so inference frameworks define the cache-sharing boundary. Configure a stable model identifier for every deployment, and use a separate release prefix or request salt when a finer isolation boundary is needed.
 
-#### SGLang
-
-With an SGLang version that includes [model-aware Mooncake key isolation](https://github.com/sgl-project/sglang/pull/31920), set a stable and unique `--served-model-name`:
-
-```bash
-python -m sglang.launch_server \
-  --model-path Qwen/Qwen3-8B \
-  --served-model-name qwen3-8b \
-  --enable-hierarchical-cache \
-  --hicache-storage-backend mooncake
-```
-
-Use the same `--served-model-name` on all SGLang instances that should share KV cache entries.
-
-#### vLLM
-
-The vLLM `MooncakeStoreConnector` automatically uses the final component of the model passed to `vllm serve` as the model identifier, so no separate model-name setting is required. To isolate deployments whose model paths end with the same name, assign each deployment a distinct `cache_prefix`:
-
-```bash
-MOONCAKE_CONFIG_PATH=/path/to/mooncake_config.json \
-vllm serve Qwen/Qwen3-8B \
-  --kv-transfer-config '{
-    "kv_connector": "MooncakeStoreConnector",
-    "kv_role": "kv_both",
-    "kv_connector_extra_config": {
-      "cache_prefix": "qwen3-8b-production"
-    }
-  }'
-```
-
-Use the same model and `cache_prefix` on all vLLM instances that should share KV cache entries.
-
-Separately, enabling `--enable_multi_tenants=true` adds a `tenant_id`-scoped object namespace and per-tenant quota admission. See [Tenant Quota Management](#tenant-quota-management) for configuration details.
+See [KV Cache Sharing and Isolation](kv-cache-sharing-and-isolation) for SGLang and vLLM configuration, rolling-upgrade examples, and the relationship between model names, `cache_salt`, and Mooncake tenants.
 
 ---
 
@@ -389,6 +357,7 @@ In HA mode, quota admin requests are served only by the active master service. S
 - Scale `--rpc_thread_num` with available CPU cores and workload.
 - Start with default eviction settings; adjust `--eviction_high_watermark_ratio` and `--eviction_ratio` based on memory pressure and object churn.
 - Use `/metrics/summary` during bring-up; integrate `/metrics` with Prometheus/Grafana for production.
+- For multi-model deployments and rolling upgrades, see [KV Cache Sharing and Isolation](kv-cache-sharing-and-isolation).
 - For detailed SSD offload configuration (storage backends, eviction policies, io_uring), see the [SSD Offload guide](ssd/ssd-offload).
 - For NVMe-oF SSD pool configuration see the [NVMe-oF SSD Pool Deployment Guide](ssd/nvmf-ssd-deployment-guide)
 - For experimental 3FS (USRBIO) integration as a persistent storage backend, see the [3FS USRBIO Plugin guide](../getting_started/plugin-usage/3FS-USRBIO-Plugin).
@@ -398,6 +367,7 @@ In HA mode, quota admin requests are served only by the active master service. S
 :maxdepth: 1
 :hidden:
 
+KV Cache Sharing and Isolation<kv-cache-sharing-and-isolation>
 SSD Storage<ssd/index>
 HF3FS Plugin (Experimental)<../getting_started/plugin-usage/3FS-USRBIO-Plugin>
 ../getting_started/observability

--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -358,7 +358,7 @@ In HA mode, quota admin requests are served only by the active master service. S
 :maxdepth: 1
 :hidden:
 
-KV Cache Sharing and Isolation<kv-cache-sharing-and-isolation/index>
+KV Cache Sharing and Isolation<kv-cache-sharing-and-isolation>
 SSD Storage<ssd/index>
 HF3FS Plugin (Experimental)<../getting_started/plugin-usage/3FS-USRBIO-Plugin>
 ../getting_started/observability

--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -237,14 +237,6 @@ The master resolves the current IPv4 address of `eth0` at startup and uses it as
 
 ---
 
-### KV Cache Sharing and Isolation
-
-Mooncake Store treats object keys as opaque strings, so inference frameworks define the cache-sharing boundary. Configure a stable model identifier for every deployment, and use a separate release prefix or request salt when a finer isolation boundary is needed.
-
-See [KV Cache Sharing and Isolation](kv-cache-sharing-and-isolation) for SGLang and vLLM configuration, rolling-upgrade examples, and the relationship between model names, `cache_salt`, and Mooncake tenants.
-
----
-
 ## Metrics Endpoints
 
 The master exposes Prometheus-style metrics on `--metrics_port`:
@@ -357,7 +349,6 @@ In HA mode, quota admin requests are served only by the active master service. S
 - Scale `--rpc_thread_num` with available CPU cores and workload.
 - Start with default eviction settings; adjust `--eviction_high_watermark_ratio` and `--eviction_ratio` based on memory pressure and object churn.
 - Use `/metrics/summary` during bring-up; integrate `/metrics` with Prometheus/Grafana for production.
-- For multi-model deployments and rolling upgrades, see [KV Cache Sharing and Isolation](kv-cache-sharing-and-isolation).
 - For detailed SSD offload configuration (storage backends, eviction policies, io_uring), see the [SSD Offload guide](ssd/ssd-offload).
 - For NVMe-oF SSD pool configuration see the [NVMe-oF SSD Pool Deployment Guide](ssd/nvmf-ssd-deployment-guide)
 - For experimental 3FS (USRBIO) integration as a persistent storage backend, see the [3FS USRBIO Plugin guide](../getting_started/plugin-usage/3FS-USRBIO-Plugin).
@@ -367,7 +358,7 @@ In HA mode, quota admin requests are served only by the active master service. S
 :maxdepth: 1
 :hidden:
 
-KV Cache Sharing and Isolation<kv-cache-sharing-and-isolation>
+KV Cache Sharing and Isolation<kv-cache-sharing-and-isolation/index>
 SSD Storage<ssd/index>
 HF3FS Plugin (Experimental)<../getting_started/plugin-usage/3FS-USRBIO-Plugin>
 ../getting_started/observability


### PR DESCRIPTION
## Description

Add concise multi-model KV cache isolation guidance to the Mooncake Store Deployment & Tuning Guide.

Related upstream change: [sgl-project/sglang#31920](https://github.com/sgl-project/sglang/pull/31920).

The new section explains:

- how SGLang deployments should configure a consistent `--served-model-name`;
- how vLLM derives the model identifier automatically and when to use `cache_prefix`; and
- how optional multi-tenant mode adds a `tenant_id`-scoped object namespace and per-tenant quota admission.

This helps operators prevent unintended KV cache sharing when multiple models or deployments use the same Mooncake Store.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**

```bash
SKIP=mooncake-code-format pre-commit run --files docs/source/deployment/mooncake-store-deployment-guide.md
git diff --check
```

The updated page was also rendered with the existing local Sphinx environment and the generated HTML was inspected for the new headings, command examples, and internal link. The build completed successfully; the remaining warnings were limited to external intersphinx inventories being unavailable in the restricted network environment.

**Test results:**

- [ ] Unit tests pass (not applicable to this documentation-only change)
- [ ] Integration tests pass (not applicable to this documentation-only change)
- [x] Manual testing done as described above

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh` (not applicable)
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation
- [ ] I have added tests to prove my changes are effective (not applicable)
- [ ] For changes >500 LOC: I have filed an RFC issue (not applicable)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specified below)

Codex helped verify the relevant SGLang and vLLM configuration behavior, draft and refine the documentation, and run the checks listed above. I reviewed and edited the generated doc before submission.
