### PR TITLE
[Store] Refactor P2P write-route

### DIFF
--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -1015,8 +1015,10 @@ PYBIND11_MODULE(store, m) {
         .def_readwrite("max_candidates",
                        &WriteRouteRequestConfig::max_candidates)
         .def_readwrite("strategy", &WriteRouteRequestConfig::strategy)
-        .def_readwrite("allow_local", &WriteRouteRequestConfig::allow_local)
-        .def_readwrite("prefer_local", &WriteRouteRequestConfig::prefer_local)
+        .def_readwrite("remote_weight", &WriteRouteRequestConfig::remote_weight)
+        .def_readwrite("local_write_waterline",
+                       &WriteRouteRequestConfig::local_write_waterline)
+        .def_readwrite("top_tier_only", &WriteRouteRequestConfig::top_tier_only)
         .def_readwrite("early_return", &WriteRouteRequestConfig::early_return)
         .def_readwrite("tag_filters", &WriteRouteRequestConfig::tag_filters)
         .def_readwrite("priority_limit",

--- a/mooncake-store/conf/p2p_runtime_config.json
+++ b/mooncake-store/conf/p2p_runtime_config.json
@@ -2,8 +2,9 @@
     "write": {
         "max_candidates": 2,
         "strategy": 2,
-        "allow_local": true,
-        "prefer_local": true,
+        "remote_weight": 0.5,
+        "local_write_waterline": 0.5,
+        "top_tier_only": true,
         "early_return": true,
         "tag_filters": [],
         "priority_limit": 0

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -64,7 +64,7 @@ struct MasterConfig {
     std::string cxl_path;
     size_t cxl_size;
     bool enable_cxl = false;
-    uint64_t max_replicas_per_key;
+    uint64_t max_client_per_key;
 
     std::string deployment_mode;
 
@@ -140,7 +140,7 @@ class MasterServiceSupervisorConfig {
         DEFAULT_PENDING_TASK_TIMEOUT_SEC;  // 0 = no timeout(infinite)
     uint64_t processing_task_timeout_sec =
         DEFAULT_PROCESSING_TASK_TIMEOUT_SEC;  // 0 = no timeout(infinite)
-    uint64_t max_replicas_per_key = 1;
+    uint64_t max_client_per_key = 1;
     DeploymentMode deployment_mode = DeploymentMode::CENTRALIZATION;
 
     std::string cxl_path = DEFAULT_CXL_PATH;
@@ -210,7 +210,7 @@ class MasterServiceSupervisorConfig {
         max_total_processing_tasks = config.max_total_processing_tasks;
         pending_task_timeout_sec = config.pending_task_timeout_sec;
         processing_task_timeout_sec = config.processing_task_timeout_sec;
-        max_replicas_per_key = config.max_replicas_per_key;
+        max_client_per_key = config.max_client_per_key;
         if (config.deployment_mode == "Centralization") {
             deployment_mode = DeploymentMode::CENTRALIZATION;
         } else {
@@ -344,7 +344,7 @@ class WrappedMasterServiceConfig {
     uint64_t put_start_release_timeout_sec = DEFAULT_PUT_START_RELEASE_TIMEOUT;
     bool enable_disk_eviction = true;
     uint64_t quota_bytes = 0;
-    uint64_t max_replicas_per_key = 1;
+    uint64_t max_client_per_key = 1;
 
     uint32_t max_total_finished_tasks = DEFAULT_MAX_TOTAL_FINISHED_TASKS;
     uint32_t max_total_pending_tasks = DEFAULT_MAX_TOTAL_PENDING_TASKS;
@@ -394,7 +394,7 @@ class WrappedMasterServiceConfig {
         global_file_segment_size = config.global_file_segment_size;
         enable_disk_eviction = config.enable_disk_eviction;
         quota_bytes = config.quota_bytes;
-        max_replicas_per_key = config.max_replicas_per_key;
+        max_client_per_key = config.max_client_per_key;
 
         // Convert string memory_allocator to BufferAllocatorType enum
         if (config.memory_allocator == "cachelib") {
@@ -453,7 +453,7 @@ class WrappedMasterServiceConfig {
         memory_allocator = config.memory_allocator;
         enable_disk_eviction = config.enable_disk_eviction;
         quota_bytes = config.quota_bytes;
-        max_replicas_per_key = config.max_replicas_per_key;
+        max_client_per_key = config.max_client_per_key;
         put_start_discard_timeout_sec = config.put_start_discard_timeout_sec;
         put_start_release_timeout_sec = config.put_start_release_timeout_sec;
         max_total_finished_tasks = config.max_total_finished_tasks;
@@ -501,7 +501,7 @@ class MasterServiceConfigBuilder {
     BufferAllocatorType memory_allocator_ = BufferAllocatorType::OFFSET;
     bool enable_disk_eviction_ = true;
     uint64_t quota_bytes_ = 0;
-    uint64_t max_replicas_per_key_ = 1;
+    uint64_t max_client_per_key_ = 1;
     uint64_t put_start_discard_timeout_sec_ = DEFAULT_PUT_START_DISCARD_TIMEOUT;
     uint64_t put_start_release_timeout_sec_ = DEFAULT_PUT_START_RELEASE_TIMEOUT;
     uint32_t max_total_finished_tasks_ = DEFAULT_MAX_TOTAL_FINISHED_TASKS;
@@ -625,8 +625,8 @@ class MasterServiceConfigBuilder {
         return *this;
     }
 
-    MasterServiceConfigBuilder& set_max_replicas_per_key(uint64_t limit) {
-        max_replicas_per_key_ = limit;
+    MasterServiceConfigBuilder& set_max_client_per_key(uint64_t limit) {
+        max_client_per_key_ = limit;
         return *this;
     }
 
@@ -737,7 +737,7 @@ class MasterServiceConfig {
         .pending_task_timeout_sec = DEFAULT_PENDING_TASK_TIMEOUT_SEC,
         .processing_task_timeout_sec = DEFAULT_PROCESSING_TASK_TIMEOUT_SEC,
     };
-    uint64_t max_replicas_per_key = 1;
+    uint64_t max_client_per_key = 1;
 
     std::string cxl_path = DEFAULT_CXL_PATH;
     size_t cxl_size = DEFAULT_CXL_SIZE;
@@ -777,7 +777,7 @@ class MasterServiceConfig {
             config.enable_cxl ? cxl_allocator_type : config.memory_allocator;
         enable_disk_eviction = config.enable_disk_eviction;
         quota_bytes = config.quota_bytes;
-        max_replicas_per_key = config.max_replicas_per_key;
+        max_client_per_key = config.max_client_per_key;
         put_start_discard_timeout_sec = config.put_start_discard_timeout_sec;
         put_start_release_timeout_sec = config.put_start_release_timeout_sec;
         task_manager_config.max_total_finished_tasks =
@@ -839,7 +839,7 @@ inline MasterServiceConfig MasterServiceConfigBuilder::build() const {
     config.cxl_path = cxl_path_;
     config.cxl_size = cxl_size_;
     config.enable_cxl = enable_cxl_;
-    config.max_replicas_per_key = max_replicas_per_key_;
+    config.max_client_per_key = max_client_per_key_;
 
     // Logic for client_crashed_ttl_sec
     if (client_crashed_ttl_sec_set_) {

--- a/mooncake-store/include/p2p_client_meta.h
+++ b/mooncake-store/include/p2p_client_meta.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+
 #include "client_meta.h"
 #include "p2p_segment_manager.h"
 #include "p2p_rpc_types.h"
@@ -25,17 +29,19 @@ class P2PClientMeta final : public ClientMeta {
 
    public:
     /**
-     * @brief A wrapper function of collecting write route candidates from this
-     *        client in ForEachClient
-     * @param req The write route request containing filter config
-     * @param candidates Output: collected candidates
-     * @return On error, returns an unexpected ErrorCode.
-     *         Otherwise, returns bool value to indicate whether collected
-     *         candidates are enough. If return `true`, ForEachClient will stop
+     * @brief Evaluate this client as a write-route candidate.
+     *
+     * Performs health check and capacity filtering (tag_filters /
+     * priority_limit / top_tier_only) internally and, on success, returns a
+     * WriteCandidate whose `score` is the raw free ratio (free/total over
+     * eligible tiers).
+     *
+     * @return A populated WriteCandidate when this client is routable;
+     *         std::nullopt when it is not a candidate (unhealthy, no eligible
+     *         tier, or insufficient free capacity).
      */
-    auto CollectWriteRouteCandidates(const WriteRouteRequest& req,
-                                     std::vector<WriteCandidate>& candidates)
-        -> tl::expected<bool, ErrorCode>;
+    std::optional<WriteCandidate> GetWriteRouteCandidate(
+        const WriteRouteRequest& req);
 
    public:
     void DoOnDisconnected() override {}
@@ -50,8 +56,24 @@ class P2PClientMeta final : public ClientMeta {
     }
 
    private:
-    static constexpr size_t INF_PRIORITY = 10000;
+    /// Free/total capacity over the segments eligible for write-route scoring.
+    struct CapacityStat {
+        size_t free = 0;
+        size_t total = 0;
+    };
+    /**
+     * @brief Aggregate free/total over the eligible segments for write-route
+     *        scoring. A segment is eligible when it carries no tag in
+     *        `tag_filters` and its priority is >= `priority_limit`. When
+     *        `top_tier_only` is true, only the highest-priority eligible
+     *        segment(s) contribute (a client may not spill to lower tiers under
+     *        memory pressure). Returns {0,0} when no segment is eligible.
+     */
+    CapacityStat GetWriteScoreCapacity(
+        const std::vector<std::string>& tag_filters, int priority_limit,
+        bool top_tier_only) const;
 
+   private:
     std::string ip_address_;
     uint16_t rpc_port_ = 0;
     std::shared_ptr<P2PSegmentManager> segment_manager_;

--- a/mooncake-store/include/p2p_client_service.h
+++ b/mooncake-store/include/p2p_client_service.h
@@ -277,12 +277,15 @@ class P2PClientService final : public ClientService {
     HeartbeatRequest build_heartbeat_request() override;
 
    private:
+    bool IsLocalWrite(const WriteRouteRequestConfig& cfg) const;
+    bool IsBelowLocalWaterline(const WriteRouteRequestConfig& cfg) const;
+
     std::vector<tl::expected<void, ErrorCode>> InnerBatchPut(
         const std::vector<ObjectKey>& keys,
         std::vector<std::vector<Slice>>& batched_slices,
         const WriteRouteRequestConfig& route_config);
 
-    std::vector<tl::expected<void, ErrorCode>> InnerBatchPutDegraded(
+    std::vector<tl::expected<void, ErrorCode>> InnerBatchPutLocalOnly(
         const std::vector<ObjectKey>& keys,
         std::vector<std::vector<Slice>>& batched_slices);
 
@@ -294,6 +297,7 @@ class P2PClientService final : public ClientService {
     std::vector<tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode>>
     CreatePutHandlesFromRoute(const std::vector<ObjectKey>& keys,
                               std::vector<std::vector<Slice>>& batched_slices,
+                              const std::vector<size_t>& sizes,
                               const WriteRouteRequestConfig& route_config,
                               BatchGetWriteRouteResponse& batch_resp);
 
@@ -306,8 +310,7 @@ class P2PClientService final : public ClientService {
         const std::vector<ObjectKey>& keys);
 
     tl::expected<BatchGetWriteRouteResponse, ErrorCode> BatchFetchWriteRoutes(
-        const std::vector<ObjectKey>& keys,
-        const std::vector<std::vector<Slice>>& batched_slices,
+        const std::vector<ObjectKey>& keys, const std::vector<size_t>& sizes,
         const WriteRouteRequestConfig& config);
 
     struct WriteOp {
@@ -388,7 +391,7 @@ class P2PClientService final : public ClientService {
 
     tl::expected<std::vector<std::unique_ptr<WriteOp>>, ErrorCode>
     BuildWriteOps(std::string_view key, std::vector<Slice>& slices,
-                  const WriteRouteRequestConfig& config,
+                  size_t object_size, const WriteRouteRequestConfig& config,
                   std::vector<WriteCandidate> candidates);
 
     async_simple::coro::Lazy<void> RunWriteWithRetry(

--- a/mooncake-store/include/p2p_master_service.h
+++ b/mooncake-store/include/p2p_master_service.h
@@ -118,9 +118,11 @@ class P2PMasterService : public MasterService {
     void OnReplicaAdded(const Replica& replica) override;
 
    private:
+    using OwnerClientSet = std::unordered_set<UUID, boost::hash<UUID>>;
+
     static auto CollectReplicaOwnerClients(const ObjectMetadata& metadata,
                                            std::string_view key)
-        -> tl::expected<std::unordered_set<UUID, boost::hash<UUID>>, ErrorCode>;
+        -> tl::expected<OwnerClientSet, ErrorCode>;
 
     tl::expected<void, ErrorCode> InnerAddReplica(
         MetadataShard& shard, std::string_view key, const UUID& client_id,
@@ -133,9 +135,9 @@ class P2PMasterService : public MasterService {
     std::shared_ptr<P2PClientManager> client_manager_;
     std::array<P2PMetadataShard, kNumShards> metadata_shards_;
     // for the number of clients owning a key:
-    // 1. max_replicas_per_key_ == 0 means no limitation
-    // 2. max_replicas_per_key_ > 0 means the max client owner count
-    uint64_t max_replicas_per_key_;
+    // 1. max_client_per_key_ == 0 means no limitation
+    // 2. max_client_per_key_ > 0 means the max client owner count
+    uint64_t max_client_per_key_;
     bool enable_async_oplog_write_{false};
 };
 

--- a/mooncake-store/include/p2p_rpc_types.h
+++ b/mooncake-store/include/p2p_rpc_types.h
@@ -18,9 +18,23 @@ struct WriteRouteRequestConfig {
     static constexpr size_t RETURN_ALL_CANDIDATES = 0;
     size_t max_candidates = 2;
     ObjectIterateStrategy strategy = ObjectIterateStrategy::CAPACITY_PRIORITY;
-    bool allow_local = true;   // whether to filter local client
-    bool prefer_local = true;  // enhance the priority of local client
-                               // works only when allow_local==true
+    // Remote-write weight in [0, 1]. Controls local-vs-remote routing via
+    // multiplicative scoring on the master side:
+    //   score = free_ratio * (is_local ? (1 - remote_weight) : remote_weight)
+    //   0   -> local only  (client writes locally);
+    //   0.5 -> pure capacity order (local and remote weighted equally);
+    //   1   -> remote only (master never returns the local client).
+    double remote_weight = 0.5;
+
+    // Local-write waterline in [0, 1]. When the client's local utilization
+    // (1 - free/total over eligible tiers) is below this threshold, the client
+    // writes locally without asking the master. 0 = disabled.
+    double local_write_waterline = 0.5;
+
+    // Capacity metric used when scoring a client:
+    //   false = sum free/total over all tiers;
+    //   true  = only account the highest-priority eligible tier's free/total
+    bool top_tier_only = true;
     bool early_return = true;  // whether to return immediately once candidates
                                // meet conditions of config
 
@@ -29,16 +43,25 @@ struct WriteRouteRequestConfig {
     std::vector<std::string> tag_filters;
     // filter the segments whose priority is lower than priority_limit
     int priority_limit = 0;
+
+    bool IsValid() const {
+        // contradictory:
+        // waterline=0 means "never write locally",
+        // remote_weight=0 means "master only returns local route".
+        return !(local_write_waterline <= 0.0 && remote_weight <= 0.0);
+    }
 };
-YLT_REFL(WriteRouteRequestConfig, max_candidates, strategy, allow_local,
-         prefer_local, early_return, tag_filters, priority_limit);
+YLT_REFL(WriteRouteRequestConfig, max_candidates, strategy, remote_weight,
+         local_write_waterline, top_tier_only, early_return, tag_filters,
+         priority_limit);
 
 inline std::ostream& operator<<(std::ostream& os,
                                 const WriteRouteRequestConfig& config) {
     os << "WriteRouteRequestConfig: { max_candidates: " << config.max_candidates
        << ", strategy: " << config.strategy
-       << ", allow_local: " << (config.allow_local ? "true" : "false")
-       << ", prefer_local: " << (config.prefer_local ? "true" : "false")
+       << ", remote_weight: " << config.remote_weight
+       << ", local_write_waterline: " << config.local_write_waterline
+       << ", top_tier_only: " << (config.top_tier_only ? "true" : "false")
        << ", early_return: " << (config.early_return ? "true" : "false")
        << ", priority_limit: " << config.priority_limit << " }";
     return os;
@@ -60,11 +83,14 @@ YLT_REFL(WriteRouteRequest, key, client_id, size, config);
  * @brief Candidate node for writing route
  */
 struct WriteCandidate {
-    P2PProxyDescriptor replica;
+    UUID client_id;
+    std::string ip_address;
+    uint16_t rpc_port = 0;
     size_t available_capacity = 0;
-    int priority = 0;
+    double score = 0.0;
 };
-YLT_REFL(WriteCandidate, replica, available_capacity, priority);
+YLT_REFL(WriteCandidate, client_id, ip_address, rpc_port, available_capacity,
+         score);
 
 /**
  * @brief Response structure for getting write route.

--- a/mooncake-store/include/p2p_rpc_types.h
+++ b/mooncake-store/include/p2p_rpc_types.h
@@ -45,10 +45,21 @@ struct WriteRouteRequestConfig {
     int priority_limit = 0;
 
     bool IsValid() const {
-        // contradictory:
-        // waterline=0 means "never write locally",
-        // remote_weight=0 means "master only returns local route".
-        return !(local_write_waterline <= 0.0 && remote_weight <= 0.0);
+        // waterline extremes:
+        //   <= 0  -> local-write bypass disabled (forbid local write)
+        //   >= 1  -> always bypass to local when free (forbid remote write)
+        // remote_weight extremes:
+        //   <= 0  -> master only returns local routes (forbid remote routing)
+        //   >= 1  -> master only returns remote routes (forbid local routing)
+        // Two combinations are contradictory (dead end):
+        //   forbid local write  + forbid remote routing
+        //   forbid remote write + forbid local routing (defensive)
+        const bool no_local_write = (local_write_waterline <= 0.0);
+        const bool no_remote_write = (local_write_waterline >= 1.0);
+        const bool no_remote_route = (remote_weight <= 0.0);
+        const bool no_local_route = (remote_weight >= 1.0);
+        return !(no_local_write && no_remote_route) &&
+               !(no_remote_write && no_local_route);
     }
 };
 YLT_REFL(WriteRouteRequestConfig, max_candidates, strategy, remote_weight,

--- a/mooncake-store/include/runtime_config_store.h
+++ b/mooncake-store/include/runtime_config_store.h
@@ -24,13 +24,13 @@ class RuntimeConfigStore {
     ReadRouteConfig getDefaultReadConfig() const;
     Json::Value exportConfig() const;
 
-    void loadFromJson(const Json::Value& root);
-    void updateWriteConfig(const Json::Value& json);
+    bool loadFromJson(const Json::Value& root);
+    bool updateWriteConfig(const Json::Value& json);
     void updateReadConfig(const Json::Value& json);
 
    private:
     static void applyPatch(ReplicateConfig& config, const Json::Value& json);
-    static void applyPatch(WriteRouteRequestConfig& config,
+    static bool applyPatch(WriteRouteRequestConfig& config,
                            const Json::Value& json);
     static void applyPatch(ReadRouteConfig& config, const Json::Value& json);
 

--- a/mooncake-store/include/types.h
+++ b/mooncake-store/include/types.h
@@ -122,6 +122,8 @@ enum class ErrorCode : int32_t {
     CLIENT_ALREADY_EXISTS = -104,     ///< Client already exists.
     CLIENT_UNHEALTHY =
         -105,  ///< Client is not in a healthy state for the operation.
+    NO_AVAILABLE_CANDIDATE =
+        -106,  ///< No available write-route candidate found.
 
     // Handle selection errors (Range: -200 to -299)
     NO_AVAILABLE_HANDLE =

--- a/mooncake-store/src/centralized_client_service.cpp
+++ b/mooncake-store/src/centralized_client_service.cpp
@@ -286,7 +286,11 @@ ErrorCode CentralizedClientService::Init(
 
     StartHttpServer();
 
-    runtime_config_store_->loadFromJson(config.runtime_config_json);
+    if (!runtime_config_store_->loadFromJson(config.runtime_config_json)) {
+        LOG(WARNING) << "runtime config validation failed during startup, "
+                     << "using defaults for invalid fields";
+        return ErrorCode::INVALID_PARAMS;
+    }
 
     if (metrics_) {
         metrics_->StartMetricReporting(config.metric_report_interval_seconds);

--- a/mooncake-store/src/centralized_client_service.cpp
+++ b/mooncake-store/src/centralized_client_service.cpp
@@ -287,8 +287,8 @@ ErrorCode CentralizedClientService::Init(
     StartHttpServer();
 
     if (!runtime_config_store_->loadFromJson(config.runtime_config_json)) {
-        LOG(WARNING) << "runtime config validation failed during startup, "
-                     << "using defaults for invalid fields";
+        LOG(ERROR) << "runtime config validation failed during startup, "
+                   << "init aborted";
         return ErrorCode::INVALID_PARAMS;
     }
 

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -1012,7 +1012,8 @@ void ClientService::RegisterRuntimeConfigHttpMethods() {
             if (!runtime_config_store_->loadFromJson(json)) {
                 resp.set_status_and_content(
                     status_type::bad_request,
-                    "invalid write config: contradictory waterline/remote_weight extremes");
+                    "invalid write config: contradictory "
+                    "waterline/remote_weight extremes");
                 return;
             }
             respond_json(resp, runtime_config_store_->exportConfig());
@@ -1028,7 +1029,8 @@ void ClientService::RegisterRuntimeConfigHttpMethods() {
             if (!runtime_config_store_->updateWriteConfig(json)) {
                 resp.set_status_and_content(
                     status_type::bad_request,
-                    "invalid write config: contradictory waterline/remote_weight extremes");
+                    "invalid write config: contradictory "
+                    "waterline/remote_weight extremes");
                 return;
             }
             LOG(INFO) << "Runtime write config updated via HTTP";

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -1012,7 +1012,7 @@ void ClientService::RegisterRuntimeConfigHttpMethods() {
             if (!runtime_config_store_->loadFromJson(json)) {
                 resp.set_status_and_content(
                     status_type::bad_request,
-                    "invalid write config: waterline<=0 && remote_weight<=0");
+                    "invalid write config: contradictory waterline/remote_weight extremes");
                 return;
             }
             respond_json(resp, runtime_config_store_->exportConfig());
@@ -1028,7 +1028,7 @@ void ClientService::RegisterRuntimeConfigHttpMethods() {
             if (!runtime_config_store_->updateWriteConfig(json)) {
                 resp.set_status_and_content(
                     status_type::bad_request,
-                    "invalid write config: waterline<=0 && remote_weight<=0");
+                    "invalid write config: contradictory waterline/remote_weight extremes");
                 return;
             }
             LOG(INFO) << "Runtime write config updated via HTTP";
@@ -1104,8 +1104,8 @@ void ClientService::RegisterRuntimeConfigHttpMethods() {
                 if (!runtime_config_store_->updateWriteConfig(patch)) {
                     resp.set_status_and_content(
                         status_type::bad_request,
-                        "invalid write config: waterline<=0 && "
-                        "remote_weight<=0");
+                        "invalid write config: contradictory "
+                        "waterline/remote_weight extremes");
                     return;
                 }
             } else {

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -1009,7 +1009,12 @@ void ClientService::RegisterRuntimeConfigHttpMethods() {
                                          coro_http_response& resp) {
             Json::Value json;
             if (!parse_body(req, resp, json)) return;
-            runtime_config_store_->loadFromJson(json);
+            if (!runtime_config_store_->loadFromJson(json)) {
+                resp.set_status_and_content(
+                    status_type::bad_request,
+                    "invalid write config: waterline<=0 && remote_weight<=0");
+                return;
+            }
             respond_json(resp, runtime_config_store_->exportConfig());
         });
 
@@ -1020,7 +1025,12 @@ void ClientService::RegisterRuntimeConfigHttpMethods() {
                                          coro_http_response& resp) {
             Json::Value json;
             if (!parse_body(req, resp, json)) return;
-            runtime_config_store_->updateWriteConfig(json);
+            if (!runtime_config_store_->updateWriteConfig(json)) {
+                resp.set_status_and_content(
+                    status_type::bad_request,
+                    "invalid write config: waterline<=0 && remote_weight<=0");
+                return;
+            }
             LOG(INFO) << "Runtime write config updated via HTTP";
             respond_json(resp, runtime_config_store_->exportConfig()["write"]);
         });
@@ -1037,7 +1047,7 @@ void ClientService::RegisterRuntimeConfigHttpMethods() {
             respond_json(resp, runtime_config_store_->exportConfig()["read"]);
         });
 
-    // GET /config/get?section=write&key=prefer_local — get single field
+    // GET /config/get?section=write&key=remote_weight — get single field
     http_server_->set_http_handler<GET>(
         "/config/get",
         [this, respond_json](coro_http_request& req, coro_http_response& resp) {
@@ -1060,7 +1070,7 @@ void ClientService::RegisterRuntimeConfigHttpMethods() {
             respond_json(resp, full[sec][k]);
         });
 
-    // POST /config/set?section=write&key=prefer_local — set single field
+    // POST /config/set?section=write&key=remote_weight — set single field
     // Body: the JSON value
     http_server_->set_http_handler<POST>(
         "/config/set", [this, parse_json, respond_json](
@@ -1091,7 +1101,13 @@ void ClientService::RegisterRuntimeConfigHttpMethods() {
             Json::Value patch;
             patch[k] = value;
             if (sec == "write") {
-                runtime_config_store_->updateWriteConfig(patch);
+                if (!runtime_config_store_->updateWriteConfig(patch)) {
+                    resp.set_status_and_content(
+                        status_type::bad_request,
+                        "invalid write config: waterline<=0 && "
+                        "remote_weight<=0");
+                    return;
+                }
             } else {
                 runtime_config_store_->updateReadConfig(patch);
             }

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -107,8 +107,9 @@ DEFINE_uint64(
 DEFINE_string(deployment_mode, "Centralization",
               "the deployment mode of mooncake-store, master and client must "
               "run in same mode. Options: Centralization, P2P");
-DEFINE_uint64(max_replicas_per_key, 1,
-              "Maximum number of replicas per key in P2P mode (0 = no limit)");
+DEFINE_uint64(
+    max_client_per_key, 1,
+    "Maximum number of client owners per key in P2P mode (0 = no limit)");
 
 // Task manager configuration
 DEFINE_uint32(max_total_finished_tasks, 10000,
@@ -268,9 +269,9 @@ void InitMasterConf(const mooncake::DefaultConfig& default_config,
     default_config.GetUInt64("processing_task_timeout_sec",
                              &master_config.processing_task_timeout_sec,
                              FLAGS_processing_task_timeout_sec);
-    default_config.GetUInt64("max_replicas_per_key",
-                             &master_config.max_replicas_per_key,
-                             FLAGS_max_replicas_per_key);
+    default_config.GetUInt64("max_client_per_key",
+                             &master_config.max_client_per_key,
+                             FLAGS_max_client_per_key);
     default_config.GetString("deployment_mode", &master_config.deployment_mode,
                              FLAGS_deployment_mode);
 
@@ -564,10 +565,10 @@ void LoadConfigFromCmdline(mooncake::MasterConfig& master_config,
         !conf_set) {
         master_config.deployment_mode = FLAGS_deployment_mode;
     }
-    if ((google::GetCommandLineFlagInfo("max_replicas_per_key", &info) &&
+    if ((google::GetCommandLineFlagInfo("max_client_per_key", &info) &&
          !info.is_default) ||
         !conf_set) {
-        master_config.max_replicas_per_key = FLAGS_max_replicas_per_key;
+        master_config.max_client_per_key = FLAGS_max_client_per_key;
     }
 
     // Redis election backend configuration
@@ -804,7 +805,7 @@ int main(int argc, char* argv[]) {
         << ", enable_cxl=" << master_config.enable_cxl
         << ", cxl_path=" << master_config.cxl_path
         << ", cxl_size=" << master_config.cxl_size
-        << ", max_replicas_per_key=" << master_config.max_replicas_per_key
+        << ", max_client_per_key=" << master_config.max_client_per_key
         << ", deployment_mode=" << master_config.deployment_mode;
 
     if (master_config.deployment_mode != "Centralization" &&

--- a/mooncake-store/src/p2p_client_meta.cpp
+++ b/mooncake-store/src/p2p_client_meta.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <glog/logging.h>
+#include <limits>
 
 namespace mooncake {
 P2PClientMeta::P2PClientMeta(const UUID& client_id,
@@ -74,79 +75,75 @@ size_t P2PClientMeta::GetAvailableCapacity() const {
     return client_capacity_ - client_usage_;
 }
 
-auto P2PClientMeta::CollectWriteRouteCandidates(
-    const WriteRouteRequest& req, std::vector<WriteCandidate>& candidates)
-    -> tl::expected<bool, ErrorCode> {
+P2PClientMeta::CapacityStat P2PClientMeta::GetWriteScoreCapacity(
+    const std::vector<std::string>& tag_filters, int priority_limit,
+    bool top_tier_only) const {
+    // A segment is eligible for scoring if it carries no filtered tag and its
+    // priority is >= priority_limit.
+    auto eligible = [&](const P2PSegmentExtraData& extra) -> bool {
+        if (extra.priority < priority_limit) return false;
+        for (const auto& tag : tag_filters) {
+            if (std::find(extra.tags.begin(), extra.tags.end(), tag) !=
+                extra.tags.end()) {
+                return false;
+            }
+        }
+        return true;
+    };
+
+    CapacityStat all, top;
+    int max_priority = std::numeric_limits<int>::min();
+    segment_manager_->ForEachSegment([&](const Segment& seg) -> bool {
+        const auto& extra = seg.GetP2PExtra();
+        if (!eligible(extra)) return false;
+        const size_t free = seg.size > extra.usage ? seg.size - extra.usage : 0;
+        all.total += seg.size;
+        all.free += free;
+        if (extra.priority > max_priority) {
+            max_priority = extra.priority;
+            top = {free, seg.size};
+        } else if (extra.priority == max_priority) {
+            top.total += seg.size;
+            top.free += free;
+        }
+        return false;  // always continue to next segment
+    });
+    return top_tier_only ? top : all;
+}
+
+// Returns std::nullopt when this client is not a write-route candidate
+std::optional<WriteCandidate> P2PClientMeta::GetWriteRouteCandidate(
+    const WriteRouteRequest& req) {
     SharedMutexLocker lock(&client_mutex_, shared_lock);
 
-    // Check health status under lock protection
+    // Check health status under lock protection.
     auto check_ret = InnerStatusCheck();
     if (!check_ret.has_value()) {
         LOG(WARNING) << "client could not route"
                      << ", client_id: " << client_id_;
-        return false;  // skip unhealthy client, candidaes are not enough
+        // Unhealthy is not an error: the client is simply not a candidate.
+        return std::nullopt;
     }
 
-    // localhost is not allowed, skip current client
-    if (!req.config.allow_local && client_id_ == req.client_id)
-        return false;  // candidaes are not enough
+    // Client-granular routing: the master routes to a client; the client picks
+    // the concrete segment/tier. The score is the raw free ratio; the master
+    // multiplies it by (1-w) for local or w for remote.
+    const CapacityStat cap =
+        GetWriteScoreCapacity(req.config.tag_filters, req.config.priority_limit,
+                              req.config.top_tier_only);
+    if (cap.total == 0) return std::nullopt;  // no eligible tier
+    if (cap.free < req.size)
+        return std::nullopt;  // cannot hold (master's view)
 
-    // iterate segments to find candidates
-    bool trigger_stop_early = false;
-    segment_manager_->ForEachSegment([&](const Segment& seg) -> bool {
-        // In ForEachSegment callback:
-        // 1. return false means continue to process next segment
-        //    (skip current segment or finish processing)
-        // 2. return true means early stop
-        size_t usage = seg.GetP2PExtra().usage;
-        if (seg.size - usage < req.size)
-            return false;  // usage does not enough, candidaes are not enough
+    const double free_ratio = static_cast<double>(cap.free) / cap.total;
 
-        const auto& p2p_extra = seg.GetP2PExtra();
-
-        // exclude segments that contain any tags in tag_filters
-        bool hit_filter_tag = false;
-        for (const auto& tag : req.config.tag_filters) {
-            if (std::find(p2p_extra.tags.begin(), p2p_extra.tags.end(), tag) !=
-                p2p_extra.tags.end()) {
-                hit_filter_tag = true;
-                break;
-            }
-        }
-        if (hit_filter_tag) return false;  // hit excluding tag, skip segment
-
-        if (p2p_extra.priority < req.config.priority_limit)
-            return false;  // priority does not enough, candidaes are not enough
-
-        int priority = p2p_extra.priority;
-        if (req.config.prefer_local && client_id_ == req.client_id) {
-            // hit localhost and prefer local, add infinite priority
-            priority += INF_PRIORITY;
-        }
-
-        WriteCandidate candidate;
-        candidate.available_capacity = seg.size - usage;
-        candidate.priority = priority;
-        candidate.replica.client_id = client_id_;
-        candidate.replica.segment_id = seg.id;
-        candidate.replica.ip_address = ip_address_;
-        candidate.replica.rpc_port = rpc_port_;
-        candidate.replica.object_size = req.size;
-
-        candidates.push_back(std::move(candidate));
-        if (req.config.early_return &&
-            candidates.size() >= req.config.max_candidates &&
-            req.config.max_candidates !=
-                WriteRouteRequestConfig::RETURN_ALL_CANDIDATES) {
-            // current candidates are enough, early stop
-            trigger_stop_early = true;
-            return true;  // stop ForEachSegment
-        }
-        return false;  // process next segment
-    });
-
-    // early stop, if trigger_stop_early == true, stop ForEachClient
-    return trigger_stop_early;
+    WriteCandidate candidate;
+    candidate.client_id = client_id_;
+    candidate.ip_address = ip_address_;
+    candidate.rpc_port = rpc_port_;
+    candidate.available_capacity = cap.free;
+    candidate.score = free_ratio;
+    return candidate;
 }
 
 }  // namespace mooncake

--- a/mooncake-store/src/p2p_client_service.cpp
+++ b/mooncake-store/src/p2p_client_service.cpp
@@ -299,8 +299,8 @@ ErrorCode P2PClientService::Init(const P2PClientConfig& config) {
     ha_manager_->SetReadyForRecovery();
 
     if (!runtime_config_store_->loadFromJson(config.runtime_config_json)) {
-        LOG(WARNING) << "runtime config validation failed during startup, "
-                     << "using defaults for invalid fields";
+        LOG(ERROR) << "runtime config validation failed during startup, "
+                   << "init aborted";
         return ErrorCode::INTERNAL_ERROR;
     }
 
@@ -752,8 +752,10 @@ std::vector<tl::expected<void, ErrorCode>> P2PClientService::BatchPut(
 }
 
 bool P2PClientService::IsLocalWrite(const WriteRouteRequestConfig& cfg) const {
-    return (ha_manager_ && ha_manager_->IsLocalService()) ||
-           cfg.remote_weight <= 0.0 || IsBelowLocalWaterline(cfg);
+    if (ha_manager_ && ha_manager_->IsLocalService()) return true;
+    if (cfg.remote_weight <= 0.0) return true;   // force local
+    if (cfg.remote_weight >= 1.0) return false;  // force remote
+    return IsBelowLocalWaterline(cfg);
 }
 
 bool P2PClientService::IsBelowLocalWaterline(

--- a/mooncake-store/src/p2p_client_service.cpp
+++ b/mooncake-store/src/p2p_client_service.cpp
@@ -4,6 +4,7 @@
 
 #include <csignal>
 #include <algorithm>
+#include <limits>
 #include <coroutine>
 #include <cstring>
 #include <cstdlib>
@@ -297,7 +298,11 @@ ErrorCode P2PClientService::Init(const P2PClientConfig& config) {
     // proceed.
     ha_manager_->SetReadyForRecovery();
 
-    runtime_config_store_->loadFromJson(config.runtime_config_json);
+    if (!runtime_config_store_->loadFromJson(config.runtime_config_json)) {
+        LOG(WARNING) << "runtime config validation failed during startup, "
+                     << "using defaults for invalid fields";
+        return ErrorCode::INTERNAL_ERROR;
+    }
 
     // 12. Apply periodic metric-reporting config
     if (metrics_) {
@@ -705,6 +710,10 @@ std::vector<tl::expected<void, ErrorCode>> P2PClientService::BatchPut(
         LOG(ERROR) << "P2PClientService expects WriteRouteRequestConfig";
         std::fill(results.begin(), results.end(),
                   tl::unexpected(ErrorCode::INVALID_PARAMS));
+    } else if (!route_cfg_ptr->IsValid()) {
+        LOG(ERROR) << "invalid WriteRouteRequestConfig: " << *route_cfg_ptr;
+        std::fill(results.begin(), results.end(),
+                  tl::unexpected(ErrorCode::INVALID_PARAMS));
     } else {
         results = InnerBatchPut(keys, batched_slices, *route_cfg_ptr);
     }
@@ -742,18 +751,60 @@ std::vector<tl::expected<void, ErrorCode>> P2PClientService::BatchPut(
     return results;
 }
 
+bool P2PClientService::IsLocalWrite(const WriteRouteRequestConfig& cfg) const {
+    return (ha_manager_ && ha_manager_->IsLocalService()) ||
+           cfg.remote_weight <= 0.0 || IsBelowLocalWaterline(cfg);
+}
+
+bool P2PClientService::IsBelowLocalWaterline(
+    const WriteRouteRequestConfig& cfg) const {
+    if (cfg.local_write_waterline <= 0.0 || !data_manager_) return false;
+
+    auto tiers = data_manager_->GetTierViews();
+    auto eligible = [&](const TierView& t) {
+        if (t.priority < cfg.priority_limit) return false;
+        for (const auto& tag : cfg.tag_filters)
+            if (std::find(t.tags.begin(), t.tags.end(), tag) != t.tags.end())
+                return false;
+        return true;
+    };
+
+    // Single pass: accumulate all-tier and top-tier stats.
+    size_t all_free = 0, all_total = 0, top_free = 0, top_total = 0;
+    int max_priority = std::numeric_limits<int>::min();
+    for (const auto& t : tiers) {
+        if (!eligible(t)) continue;
+        all_total += t.capacity;
+        all_free += t.free_space;
+        if (t.priority > max_priority) {
+            max_priority = t.priority;
+            top_free = t.free_space;
+            top_total = t.capacity;
+        } else if (t.priority == max_priority) {
+            top_total += t.capacity;
+            top_free += t.free_space;
+        }
+    }
+
+    const size_t total = cfg.top_tier_only ? top_total : all_total;
+    const size_t free = cfg.top_tier_only ? top_free : all_free;
+    if (total == 0) return false;
+    const double utilization = 1.0 - static_cast<double>(free) / total;
+    return utilization < cfg.local_write_waterline;
+}
+
 std::vector<tl::expected<void, ErrorCode>> P2PClientService::InnerBatchPut(
     const std::vector<ObjectKey>& keys,
     std::vector<std::vector<Slice>>& batched_slices,
     const WriteRouteRequestConfig& route_config) {
-    if (ha_manager_ && ha_manager_->IsLocalService()) {
-        return InnerBatchPutDegraded(keys, batched_slices);
+    if (IsLocalWrite(route_config)) {
+        return InnerBatchPutLocalOnly(keys, batched_slices);
     }
     return InnerBatchPutNormal(keys, batched_slices, route_config);
 }
 
 std::vector<tl::expected<void, ErrorCode>>
-P2PClientService::InnerBatchPutDegraded(
+P2PClientService::InnerBatchPutLocalOnly(
     const std::vector<ObjectKey>& keys,
     std::vector<std::vector<Slice>>& batched_slices) {
     // Phase 1: dispatch all local writes.
@@ -825,9 +876,13 @@ P2PClientService::InnerBatchPutNormal(
     const std::vector<ObjectKey>& keys,
     std::vector<std::vector<Slice>>& batched_slices,
     const WriteRouteRequestConfig& route_config) {
+    std::vector<size_t> sizes(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        sizes[i] = ClientService::CalculateSliceSize(batched_slices[i]);
+    }
+
     // Phase 1: fetch write routes from master.
-    auto batch_routes =
-        BatchFetchWriteRoutes(keys, batched_slices, route_config);
+    auto batch_routes = BatchFetchWriteRoutes(keys, sizes, route_config);
     if (!batch_routes) {
         LOG(ERROR) << "BatchGetWriteRoute RPC failed: " << batch_routes.error();
         return std::vector<tl::expected<void, ErrorCode>>(
@@ -837,28 +892,22 @@ P2PClientService::InnerBatchPutNormal(
     // Phase 2:
     // 2.1: async dispatch first-candidate writes for each key
     // 2.2: wrap each key in a retry chain based on rotute
-    auto handles = CreatePutHandlesFromRoute(keys, batched_slices, route_config,
-                                             batch_routes.value());
+    auto handles = CreatePutHandlesFromRoute(
+        keys, batched_slices, sizes, route_config, batch_routes.value());
 
     // Phase 3: wait every retry chain and collect results.
     return CollectResults(handles, keys);
 }
 
 tl::expected<BatchGetWriteRouteResponse, ErrorCode>
-P2PClientService::BatchFetchWriteRoutes(
-    const std::vector<ObjectKey>& keys,
-    const std::vector<std::vector<Slice>>& batched_slices,
-    const WriteRouteRequestConfig& config) {
+P2PClientService::BatchFetchWriteRoutes(const std::vector<ObjectKey>& keys,
+                                        const std::vector<size_t>& sizes,
+                                        const WriteRouteRequestConfig& config) {
     BatchGetWriteRouteRequest req;
     req.client_id = client_id_;
     req.config = config;
-    req.keys.reserve(keys.size());
-    req.sizes.reserve(keys.size());
-    for (size_t i = 0; i < keys.size(); ++i) {
-        req.keys.push_back(keys[i]);
-        req.sizes.push_back(
-            ClientService::CalculateSliceSize(batched_slices[i]));
-    }
+    req.keys.assign(keys.begin(), keys.end());
+    req.sizes = sizes;
     auto batch_route_result = master_client_.BatchGetWriteRoute(req);
     if (!batch_route_result) {
         LOG(ERROR) << "BatchGetWriteRoute RPC failed: "
@@ -872,6 +921,7 @@ std::vector<tl::expected<std::unique_ptr<TaskHandle<void>>, ErrorCode>>
 P2PClientService::CreatePutHandlesFromRoute(
     const std::vector<ObjectKey>& keys,
     std::vector<std::vector<Slice>>& batched_slices,
+    const std::vector<size_t>& sizes,
     const WriteRouteRequestConfig& route_config,
     BatchGetWriteRouteResponse& batch_resp) {
     struct WriteTask {
@@ -889,8 +939,9 @@ P2PClientService::CreatePutHandlesFromRoute(
             tasks.push_back(tl::unexpected(batch_resp.error_codes[i]));
             continue;
         }
-        auto ops = BuildWriteOps(keys[i], batched_slices[i], route_config,
-                                 std::move(batch_resp.responses[i].candidates));
+        auto ops =
+            BuildWriteOps(keys[i], batched_slices[i], sizes[i], route_config,
+                          std::move(batch_resp.responses[i].candidates));
         if (!ops) {
             LOG(ERROR) << "fail to build write ops"
                        << ", key=" << keys[i] << ", error=" << ops.error();
@@ -944,6 +995,7 @@ P2PClientService::CreatePutHandlesFromRoute(
 
 auto P2PClientService::BuildWriteOps(std::string_view key,
                                      std::vector<Slice>& slices,
+                                     size_t object_size,
                                      const WriteRouteRequestConfig& config,
                                      std::vector<WriteCandidate> candidates)
     -> tl::expected<std::vector<std::unique_ptr<WriteOp>>, ErrorCode> {
@@ -964,13 +1016,12 @@ auto P2PClientService::BuildWriteOps(std::string_view key,
 
     std::vector<std::unique_ptr<WriteOp>> write_ops;
     for (auto& candidate : candidates) {
-        auto& proxy = candidate.replica;
-        if (proxy.client_id == client_id_) {
+        if (candidate.client_id == client_id_) {
             // Defensive check: master should not return local candidates when
-            // allow_local=false, but if it does, just skip it.
-            if (!config.allow_local) {
+            // remote_weight>=1 (force remote), but if it does, just skip it.
+            if (config.remote_weight >= 1.0) {
                 LOG(WARNING) << "Master returned local candidate but "
-                                "allow_local=false, skipping";
+                                "remote_weight>=1 (force remote), skipping";
                 continue;
             } else if (!data_manager_.has_value()) {
                 LOG(ERROR) << "Data manager not initialized";
@@ -980,7 +1031,7 @@ auto P2PClientService::BuildWriteOps(std::string_view key,
                 std::make_unique<LocalWriteOp>(&*data_manager_, key, &slices));
         } else {
             std::string endpoint =
-                proxy.ip_address + ":" + std::to_string(proxy.rpc_port);
+                candidate.ip_address + ":" + std::to_string(candidate.rpc_port);
             auto* peer = &GetOrCreatePeerClient(endpoint);
             if (transfer_direction_mode_ == TransferDirectionMode::FORWARD) {
                 if (!data_manager_.has_value()) {
@@ -999,6 +1050,13 @@ auto P2PClientService::BuildWriteOps(std::string_view key,
                     peer, metrics_.get(), write_req, endpoint, &slices,
                     std::move(te_transfer)));
             } else {
+                // segment_id is intentionally left unset: the write route is
+                // client-granular; the remote peer picks the concrete segment.
+                P2PProxyDescriptor proxy;
+                proxy.client_id = candidate.client_id;
+                proxy.ip_address = candidate.ip_address;
+                proxy.rpc_port = candidate.rpc_port;
+                proxy.object_size = object_size;
                 write_ops.push_back(std::make_unique<RemoteReverseWriteOp>(
                     peer, write_req, std::move(proxy),
                     route_cache_ ? &*route_cache_ : nullptr, endpoint));

--- a/mooncake-store/src/p2p_master_service.cpp
+++ b/mooncake-store/src/p2p_master_service.cpp
@@ -2,6 +2,8 @@
 
 #include <glog/logging.h>
 #include <algorithm>
+#include <tuple>
+#include <unordered_map>
 #include <variant>
 
 #include "ha/oplog/p2p_oplog_types.h"
@@ -11,8 +13,7 @@
 namespace mooncake {
 
 P2PMasterService::P2PMasterService(const MasterServiceConfig& config)
-    : MasterService(config),
-      max_replicas_per_key_(config.max_replicas_per_key),
+    : MasterService(config), max_client_per_key_(config.max_client_per_key),
       enable_async_oplog_write_(ParseOpLogStoreType(config.oplog_store_type) ==
                                 OpLogStoreType::REDIS) {
     client_manager_ = std::make_shared<P2PClientManager>(
@@ -185,7 +186,10 @@ std::vector<Replica::Descriptor> P2PMasterService::FilterReplicas(
     const GetReplicaListRequestConfig& config, const ObjectMetadata& metadata) {
     const auto& p2p_config = config.p2p_config ? config.p2p_config.value()
                                                : P2PGetReplicaListConfigExtra();
+    // candidates kept at client granularity
     std::vector<std::pair<uint32_t, Replica::Descriptor>> candidates;
+    std::unordered_map<UUID, size_t, boost::hash<UUID>> best_by_client;
+
     // 1. filter qualified replicas
     for (const auto& replica : metadata.replicas_) {
         if (!replica.is_p2p_proxy_replica()) {
@@ -225,7 +229,17 @@ std::vector<Replica::Descriptor> P2PMasterService::FilterReplicas(
         }
         if (*priority_opt < p2p_config.priority_limit) continue;
 
-        candidates.push_back({*priority_opt, replica.get_descriptor()});
+        // 1.3 client-granularity: keep the highest-priority replica
+        auto cid_opt = replica.get_p2p_client_id();
+        if (!cid_opt) continue;
+        const UUID cid = *cid_opt;
+        auto it = best_by_client.find(cid);
+        if (it == best_by_client.end()) {
+            best_by_client[cid] = candidates.size();
+            candidates.push_back({*priority_opt, replica.get_descriptor()});
+        } else if (*priority_opt > candidates[it->second].first) {
+            candidates[it->second] = {*priority_opt, replica.get_descriptor()};
+        }
     }  // iter replicas over
 
     if (config.max_candidates ==
@@ -240,7 +254,7 @@ std::vector<Replica::Descriptor> P2PMasterService::FilterReplicas(
         return result;
     }
 
-    // 2. the number of qualified replicas is larger than limit,
+    // 3. the number of qualified replicas is larger than limit,
     // choose the best ones.
     std::sort(candidates.begin(), candidates.end(),
               [](const auto& a, const auto& b) { return a.first > b.first; });
@@ -255,65 +269,94 @@ std::vector<Replica::Descriptor> P2PMasterService::FilterReplicas(
 
 auto P2PMasterService::GetWriteRoute(const WriteRouteRequest& req)
     -> tl::expected<WriteRouteResponse, ErrorCode> {
-    // GetWriteRoute represents an external write request. In-client tier
-    // migration updates metadata through AddReplica directly, so once the
-    // owner limit is reached no client can accept another routed write.
-    if (!req.key.empty() && max_replicas_per_key_ > 0) {
+    if (!req.config.IsValid()) {
+        LOG(ERROR) << "invalid write route config: " << req.config
+                   << ", client_id: " << req.client_id;
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    // 1. Collect existing replica owners and enforce the client limit.
+    OwnerClientSet owners;
+    if (!req.key.empty()) {
         MetadataAccessorRO accessor(this, req.key);
         if (accessor.Exists()) {
-            auto& metadata = accessor.Get();
-            auto owner_clients_res =
-                CollectReplicaOwnerClients(metadata, req.key);
-            if (!owner_clients_res.has_value()) {
+            auto res = CollectReplicaOwnerClients(accessor.Get(), req.key);
+            if (!res) {
                 LOG(ERROR) << "failed to collect replica owner clients"
                            << ", key: " << req.key
-                           << ", error: " << owner_clients_res.error();
-                return tl::make_unexpected(owner_clients_res.error());
+                           << ", error: " << res.error();
+                return tl::make_unexpected(res.error());
             }
-            const auto& owner_clients = owner_clients_res.value();
-            if (owner_clients.size() >= max_replicas_per_key_) {
+            if (max_client_per_key_ > 0 && res->size() >= max_client_per_key_) {
                 LOG(WARNING)
                     << "replica owner client num exceeded"
                     << ", key: " << req.key << ", client_id: " << req.client_id
-                    << ", current owner client num: " << owner_clients.size()
-                    << ", max owner client num: " << max_replicas_per_key_;
+                    << ", current: " << res->size()
+                    << ", max: " << max_client_per_key_;
                 return tl::make_unexpected(ErrorCode::REPLICA_NUM_EXCEEDED);
             }
+            owners = std::move(*res);
         }
     }
 
+    // 2. Single pass: collect and score all candidates.
+    //    score = free_ratio * (is_local ? (1 - remote_weight) : remote_weight)
+    const double remote_weight = std::clamp(req.config.remote_weight, 0.0, 1.0);
     std::vector<WriteCandidate> candidates;
-    // find qualified segments across all clients
+    const bool can_early_stop =
+        req.config.early_return &&
+        req.config.max_candidates !=
+            WriteRouteRequestConfig::RETURN_ALL_CANDIDATES;
+
     client_manager_->ForEachClient(
         req.config.strategy,
         [&](const std::shared_ptr<ClientMeta>& client)
             -> tl::expected<bool, ErrorCode> {
-            auto p2p_client = std::static_pointer_cast<P2PClientMeta>(client);
-            if (!p2p_client) {
+            auto p2p = std::static_pointer_cast<P2PClientMeta>(client);
+            if (!p2p) {
                 LOG(ERROR) << "unexpected client meta type";
                 return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
             }
-            return p2p_client->CollectWriteRouteCandidates(req, candidates);
+            const UUID cid = p2p->get_client_id();
+            if (owners.count(cid)) {
+                return false;
+            }
+            const bool is_local = (cid == req.client_id);
+            const double weight =
+                is_local ? (1.0 - remote_weight) : remote_weight;
+            if (weight <= 0.0) {
+                return false;
+            }
+
+            if (auto cand = p2p->GetWriteRouteCandidate(req)) {
+                cand->score *= weight;
+                candidates.push_back(std::move(*cand));
+                if (can_early_stop &&
+                    candidates.size() >= req.config.max_candidates)
+                    return true;
+            }
+            return false;
         });
 
-    WriteRouteResponse response;
+    // 3. Sort by score desc (capacity desc as tiebreaker), then truncate.
     if (candidates.empty()) {
         LOG(ERROR) << "no candidate found for key: " << req.key
                    << ", client_id: " << req.client_id
                    << ", size: " << req.size;
-        return tl::make_unexpected(ErrorCode::SEGMENT_NOT_FOUND);
-    } else {
-        std::sort(candidates.begin(), candidates.end(),
-                  [](const auto& a, const auto& b) {
-                      return a.priority > b.priority;
-                  });
-        if (req.config.max_candidates !=
-                WriteRouteRequestConfig::RETURN_ALL_CANDIDATES &&
-            candidates.size() > req.config.max_candidates) {
-            candidates.resize(req.config.max_candidates);
-        }
-        response.candidates = std::move(candidates);
+        return tl::make_unexpected(ErrorCode::NO_AVAILABLE_CANDIDATE);
     }
+    std::sort(candidates.begin(), candidates.end(),
+              [](const auto& a, const auto& b) {
+                  return std::tie(b.score, b.available_capacity) <
+                         std::tie(a.score, a.available_capacity);
+              });
+    if (req.config.max_candidates !=
+            WriteRouteRequestConfig::RETURN_ALL_CANDIDATES &&
+        candidates.size() > req.config.max_candidates) {
+        candidates.resize(req.config.max_candidates);
+    }
+    WriteRouteResponse response;
+    response.candidates = std::move(candidates);
     return response;
 }
 
@@ -400,17 +443,17 @@ tl::expected<void, ErrorCode> P2PMasterService::InnerAddReplica(
             }
         }
         // AddReplica is also used by in-client tier migration to publish a new
-        // physical replica. Existing owner clients may add replicas, but a new
-        // owner client must still honor max_replicas_per_key_.
-        if (max_replicas_per_key_ > 0 &&
+        // physical replica. Existing owner clients may add replicas on new
+        // segments, but a new owner client must honor max_client_per_key_.
+        if (max_client_per_key_ > 0 &&
             owner_clients.find(client_id) == owner_clients.end() &&
-            owner_clients.size() >= max_replicas_per_key_) {
+            owner_clients.size() >= max_client_per_key_) {
             LOG(WARNING) << "replica owner client num exceeded"
                          << ", key: " << key << ", client_id: " << client_id
                          << ", segment_id: " << segment_id
                          << ", current owner client num:"
                          << owner_clients.size()
-                         << ", max owner client num: " << max_replicas_per_key_;
+                         << ", max owner client num: " << max_client_per_key_;
             return tl::make_unexpected(ErrorCode::REPLICA_NUM_EXCEEDED);
         }
         AddReplicaPayload payload;

--- a/mooncake-store/src/p2p_master_service.cpp
+++ b/mooncake-store/src/p2p_master_service.cpp
@@ -13,7 +13,8 @@
 namespace mooncake {
 
 P2PMasterService::P2PMasterService(const MasterServiceConfig& config)
-    : MasterService(config), max_client_per_key_(config.max_client_per_key),
+    : MasterService(config),
+      max_client_per_key_(config.max_client_per_key),
       enable_async_oplog_write_(ParseOpLogStoreType(config.oplog_store_type) ==
                                 OpLogStoreType::REDIS) {
     client_manager_ = std::make_shared<P2PClientManager>(

--- a/mooncake-store/src/runtime_config_store.cpp
+++ b/mooncake-store/src/runtime_config_store.cpp
@@ -1,6 +1,7 @@
 #include "runtime_config_store.h"
 
 #include <glog/logging.h>
+#include <type_traits>
 
 namespace mooncake {
 
@@ -20,9 +21,20 @@ ReadRouteConfig RuntimeConfigStore::getDefaultReadConfig() const {
     return read_;
 }
 
-void RuntimeConfigStore::updateWriteConfig(const Json::Value& json) {
+bool RuntimeConfigStore::updateWriteConfig(const Json::Value& json) {
     std::unique_lock lock(mu_);
-    std::visit([&json](auto& cfg) { applyPatch(cfg, json); }, write_);
+    bool ok = true;
+    std::visit(
+        [&](auto& cfg) {
+            if constexpr (std::is_same_v<std::decay_t<decltype(cfg)>,
+                                         WriteRouteRequestConfig>) {
+                ok = applyPatch(cfg, json);
+            } else {
+                applyPatch(cfg, json);
+            }
+        },
+        write_);
+    return ok;
 }
 
 void RuntimeConfigStore::updateReadConfig(const Json::Value& json) {
@@ -39,12 +51,22 @@ Json::Value RuntimeConfigStore::exportConfig() const {
     return root;
 }
 
-void RuntimeConfigStore::loadFromJson(const Json::Value& root) {
-    if (root.isNull() || !root.isObject()) return;
+bool RuntimeConfigStore::loadFromJson(const Json::Value& root) {
+    if (root.isNull() || !root.isObject()) return true;
 
     std::unique_lock lock(mu_);
+    bool ok = true;
     if (root.isMember("write")) {
-        std::visit([&](auto& cfg) { applyPatch(cfg, root["write"]); }, write_);
+        std::visit(
+            [&](auto& cfg) {
+                if constexpr (std::is_same_v<std::decay_t<decltype(cfg)>,
+                                             WriteRouteRequestConfig>) {
+                    ok = applyPatch(cfg, root["write"]);
+                } else {
+                    applyPatch(cfg, root["write"]);
+                }
+            },
+            write_);
     }
     if (root.isMember("read")) {
         applyPatch(read_, root["read"]);
@@ -52,6 +74,7 @@ void RuntimeConfigStore::loadFromJson(const Json::Value& root) {
     lock.unlock();
 
     LOG(INFO) << "Loaded runtime config: " << root.toStyledString();
+    return ok;
 }
 
 // --- Patch helpers ---
@@ -90,36 +113,56 @@ void RuntimeConfigStore::applyPatch(ReplicateConfig& config,
     }
 }
 
-void RuntimeConfigStore::applyPatch(WriteRouteRequestConfig& config,
+bool RuntimeConfigStore::applyPatch(WriteRouteRequestConfig& config,
                                     const Json::Value& json) {
-    if (!json.isObject()) return;
+    if (!json.isObject()) return false;
+
+    // Apply the patch to a copy so that a rejected patch leaves the original
+    // config untouched.
+    auto patched = config;
+
     if (json.isMember("max_candidates") && json["max_candidates"].isUInt64()) {
-        config.max_candidates = json["max_candidates"].asUInt64();
+        patched.max_candidates = json["max_candidates"].asUInt64();
     }
     if (json.isMember("strategy") && json["strategy"].isInt()) {
-        config.strategy =
+        patched.strategy =
             static_cast<ObjectIterateStrategy>(json["strategy"].asInt());
     }
-    if (json.isMember("allow_local") && json["allow_local"].isBool()) {
-        config.allow_local = json["allow_local"].asBool();
+    if (json.isMember("remote_weight") && json["remote_weight"].isNumeric()) {
+        double w = json["remote_weight"].asDouble();
+        patched.remote_weight = w < 0.0 ? 0.0 : (w > 1.0 ? 1.0 : w);
     }
-    if (json.isMember("prefer_local") && json["prefer_local"].isBool()) {
-        config.prefer_local = json["prefer_local"].asBool();
+    if (json.isMember("local_write_waterline") &&
+        json["local_write_waterline"].isNumeric()) {
+        double wl = json["local_write_waterline"].asDouble();
+        patched.local_write_waterline = wl < 0.0 ? 0.0 : (wl > 1.0 ? 1.0 : wl);
+    }
+    if (json.isMember("top_tier_only") && json["top_tier_only"].isBool()) {
+        patched.top_tier_only = json["top_tier_only"].asBool();
     }
     if (json.isMember("early_return") && json["early_return"].isBool()) {
-        config.early_return = json["early_return"].asBool();
+        patched.early_return = json["early_return"].asBool();
     }
     if (json.isMember("tag_filters") && json["tag_filters"].isArray()) {
-        config.tag_filters.clear();
+        patched.tag_filters.clear();
         for (const auto& tag : json["tag_filters"]) {
             if (tag.isString()) {
-                config.tag_filters.push_back(tag.asString());
+                patched.tag_filters.push_back(tag.asString());
             }
         }
     }
     if (json.isMember("priority_limit") && json["priority_limit"].isInt()) {
-        config.priority_limit = json["priority_limit"].asInt();
+        patched.priority_limit = json["priority_limit"].asInt();
     }
+
+    if (!patched.IsValid()) {
+        LOG(WARNING) << "write config patch would produce an invalid config"
+                     << ", rejected: " << patched;
+        return false;
+    }
+
+    config = std::move(patched);
+    return true;
 }
 
 void RuntimeConfigStore::applyPatch(ReadRouteConfig& config,
@@ -170,8 +213,9 @@ Json::Value RuntimeConfigStore::toJson(const WriteRouteRequestConfig& config) {
     Json::Value json;
     json["max_candidates"] = Json::Value::UInt64(config.max_candidates);
     json["strategy"] = static_cast<int>(config.strategy);
-    json["allow_local"] = config.allow_local;
-    json["prefer_local"] = config.prefer_local;
+    json["remote_weight"] = config.remote_weight;
+    json["local_write_waterline"] = config.local_write_waterline;
+    json["top_tier_only"] = config.top_tier_only;
     json["early_return"] = config.early_return;
     Json::Value tags(Json::arrayValue);
     for (const auto& tag : config.tag_filters) {

--- a/mooncake-store/src/types.cpp
+++ b/mooncake-store/src/types.cpp
@@ -15,6 +15,7 @@ const std::string& toString(ErrorCode errorCode) noexcept {
         {ErrorCode::SEGMENT_NOT_FOUND, "SEGMENT_NOT_FOUND"},
         {ErrorCode::SEGMENT_ALREADY_EXISTS, "SEGMENT_ALREADY_EXISTS"},
         {ErrorCode::CLIENT_NOT_FOUND, "CLIENT_NOT_FOUND"},
+        {ErrorCode::NO_AVAILABLE_CANDIDATE, "NO_AVAILABLE_CANDIDATE"},
         {ErrorCode::NO_AVAILABLE_HANDLE, "NO_AVAILABLE_HANDLE"},
         {ErrorCode::INVALID_VERSION, "INVALID_VERSION"},
         {ErrorCode::INVALID_KEY, "INVALID_KEY"},

--- a/mooncake-store/tests/e2e/process_handler.cpp
+++ b/mooncake-store/tests/e2e/process_handler.cpp
@@ -128,8 +128,8 @@ bool MasterProcessHandler::start() {
             rpc_address_arg,
             rpc_port_arg,
             "--deployment-mode=" + config_.deployment_mode,
-            "--max-replicas-per-key=" +
-                std::to_string(config_.max_replicas_per_key)};
+            "--max-client-per-key=" +
+                std::to_string(config_.max_client_per_key)};
 
         if (config_.enable_oplog) {
             args.emplace_back("--enable-oplog=true");

--- a/mooncake-store/tests/e2e/process_handler.h
+++ b/mooncake-store/tests/e2e/process_handler.h
@@ -41,7 +41,7 @@ struct MasterRunnerConfig {
     bool enable_oplog = false;
     std::string oplog_store_type = "localfs";
     std::string oplog_data_dir;
-    int max_replicas_per_key = 0;
+    int max_client_per_key = 0;
 };
 
 class MasterProcessHandler {

--- a/mooncake-store/tests/e2e/redis_chaos_test.cpp
+++ b/mooncake-store/tests/e2e/redis_chaos_test.cpp
@@ -374,7 +374,7 @@ class RedisChaosTest : public ::testing::Test {
         config.enable_oplog = true;
         config.oplog_store_type = "redis";
         config.oplog_data_dir = FLAGS_redis_endpoint;
-        config.max_replicas_per_key = 0;
+        config.max_client_per_key = 0;
 
         for (int i = 0; i < kMasterNum; ++i) {
             masters_.emplace_back(std::make_unique<MasterProcessHandler>(

--- a/mooncake-store/tests/ha/oplog/p2p_hot_standby_service_test.cpp
+++ b/mooncake-store/tests/ha/oplog/p2p_hot_standby_service_test.cpp
@@ -38,7 +38,7 @@ class P2PHotStandbyServiceTest : public ::testing::Test {
             .set_cluster_id(kClusterId)
             .set_oplog_store_type("localfs")
             .set_oplog_data_dir(test_dir_.string())
-            .set_max_replicas_per_key(0)
+            .set_max_client_per_key(0)
             .build();
     }
 
@@ -55,7 +55,7 @@ class P2PHotStandbyServiceTest : public ::testing::Test {
         config.oplog_store_type = master_config.oplog_store_type;
         config.oplog_data_dir = master_config.oplog_data_dir;
         config.cluster_id = master_config.cluster_id;
-        config.max_replicas_per_key = master_config.max_replicas_per_key;
+        config.max_client_per_key = master_config.max_client_per_key;
         return config;
     }
 
@@ -271,9 +271,7 @@ TEST_F(P2PHotStandbyServiceTest, RestoreExportedMetadataIntoP2PMasterService) {
     auto route_result = restored_master.GetWriteRoute(route_req);
     ASSERT_TRUE(route_result.has_value()) << toString(route_result.error());
     ASSERT_FALSE(route_result.value().candidates.empty());
-    EXPECT_EQ(route_result.value().candidates[0].replica.client_id, client_id);
-    EXPECT_EQ(route_result.value().candidates[0].replica.segment_id,
-              segment_id);
+    EXPECT_EQ(route_result.value().candidates[0].client_id, client_id);
 
     AddReplica(restored_master, "key-after-restore", client_id, segment_id,
                1024);
@@ -326,9 +324,7 @@ TEST_F(P2PHotStandbyServiceTest, RestorePromotedMetadataIntoWrappedRuntime) {
     auto route_result = promoted_runtime.GetWriteRoute(route_req);
     ASSERT_TRUE(route_result.has_value()) << toString(route_result.error());
     ASSERT_FALSE(route_result.value().candidates.empty());
-    EXPECT_EQ(route_result.value().candidates[0].replica.client_id, client_id);
-    EXPECT_EQ(route_result.value().candidates[0].replica.segment_id,
-              segment_id);
+    EXPECT_EQ(route_result.value().candidates[0].client_id, client_id);
 
     AddReplicaRequest add_req;
     add_req.key = "runtime-key-after-promotion";

--- a/mooncake-store/tests/ha/oplog/p2p_record_oplog_test.cpp
+++ b/mooncake-store/tests/ha/oplog/p2p_record_oplog_test.cpp
@@ -93,7 +93,7 @@ class P2PRecordOplogTest : public ::testing::Test {
             .set_cluster_id(kClusterId)
             .set_oplog_store_type("localfs")
             .set_oplog_data_dir(test_dir_.string())
-            .set_max_replicas_per_key(0)
+            .set_max_client_per_key(0)
             .build();
     }
 

--- a/mooncake-store/tests/ha_integration_test.cpp
+++ b/mooncake-store/tests/ha_integration_test.cpp
@@ -74,9 +74,18 @@ class HAIntegrationTest : public ::testing::Test {
 
     // ---- Helpers ----
 
+    // Default write config for these HA tests: force local placement, matching
+    // the previous local-first default the tests were written against.
+    static WriteRouteRequestConfig LocalWriteConfig() {
+        WriteRouteRequestConfig c;
+        c.remote_weight = 0.0;  // force local write
+        return c;
+    }
+
     static tl::expected<void, ErrorCode> PutData(
         std::shared_ptr<P2PClientService>& client, const std::string& key,
-        const std::string& data, const WriteRouteRequestConfig& config = {}) {
+        const std::string& data,
+        const WriteRouteRequestConfig& config = LocalWriteConfig()) {
         std::vector<Slice> slices;
         slices.emplace_back(Slice{const_cast<char*>(data.data()), data.size()});
         return client->Put(key, slices, config);
@@ -251,9 +260,9 @@ std::shared_ptr<P2PClientService> HAIntegrationTest::client2_ = nullptr;
 
 // A1: Baseline — put from client1 routed to client2, then read back.
 TEST_F(HAIntegrationTest, RemotePutAndGet) {
-    // Put with allow_local=false: master routes to client2
+    // Put with remote_weight=1 (force remote): master routes to client2
     WriteRouteRequestConfig config;
-    config.allow_local = false;
+    config.remote_weight = 1.0;
 
     auto put = PutData(client1_, "a1_client1_remote_baseline", "hello", config);
     ASSERT_TRUE(put.has_value())
@@ -274,8 +283,7 @@ TEST_F(HAIntegrationTest, RemotePutAndGet) {
 // A2: Degraded mode — local Put/Get/IsExist all work; remote-only keys
 //     and nonexistent keys return false for IsExist.
 TEST_F(HAIntegrationTest, DegradedModeLocalOps) {
-    // Write locally on client1 (default config: prefer_local=true, master
-    // now sorts candidates by priority so local segment wins).
+    // Write locally on client1 (default helper config forces a local write).
     auto put_a = PutData(client1_, "a2_client1_local", "local_data");
     ASSERT_TRUE(put_a.has_value());
 

--- a/mooncake-store/tests/ha_integration_test.cpp
+++ b/mooncake-store/tests/ha_integration_test.cpp
@@ -263,6 +263,7 @@ TEST_F(HAIntegrationTest, RemotePutAndGet) {
     // Put with remote_weight=1 (force remote): master routes to client2
     WriteRouteRequestConfig config;
     config.remote_weight = 1.0;
+    config.local_write_waterline = 0.0;
 
     auto put = PutData(client1_, "a1_client1_remote_baseline", "hello", config);
     ASSERT_TRUE(put.has_value())

--- a/mooncake-store/tests/p2p_client_integration_test.cpp
+++ b/mooncake-store/tests/p2p_client_integration_test.cpp
@@ -198,6 +198,7 @@ TEST_F(P2PClientIntegrationTest, ForceLocalWriteBypass) {
         const std::string key = "force_remote_key";
         WriteRouteRequestConfig cfg;
         cfg.remote_weight = 1.0;
+        cfg.local_write_waterline = 0.0;  // disable waterline for force-remote
 
         std::vector<Slice> slices;
         slices.emplace_back(Slice{const_cast<char*>(data.data()), data.size()});
@@ -218,6 +219,53 @@ TEST_F(P2PClientIntegrationTest, ForceLocalWriteBypass) {
         EXPECT_FALSE(get2.has_value())
             << "Force-remote data should not be on client_ locally";
     }
+}
+
+// When local utilization is below the waterline, the client writes locally
+// without asking the master — even with a balanced remote_weight.
+TEST_F(P2PClientIntegrationTest, WaterlineBypassWritesLocal) {
+    const std::string data = "waterline_payload";
+
+    // Local client is nearly empty (64MB DRAM, ~0% utilization).
+    // With waterline=0.5 and remote_weight=0.5 (balanced), the waterline
+    // triggers a local write: data stays on client_, not on client2_.
+    const std::string key = "waterline_bypass_key";
+    WriteRouteRequestConfig cfg;
+    cfg.remote_weight = 0.5;            // balanced
+    cfg.local_write_waterline = 0.5;    // local is < 50% full -> local write
+
+    std::vector<Slice> slices;
+    slices.emplace_back(Slice{const_cast<char*>(data.data()), data.size()});
+    auto put = client_->Put(key, slices, cfg);
+    ASSERT_TRUE(put.has_value())
+        << "Waterline-bypass Put failed: " << static_cast<int>(put.error());
+
+    // Readable on local client.
+    std::vector<char> buf(data.size(), 0);
+    auto get = client_->Get(key, {(void*)buf.data()}, {buf.size()});
+    ASSERT_TRUE(get.has_value());
+    EXPECT_EQ(std::string(buf.data(), buf.size()), data);
+
+    // NOT readable on remote client (data stayed local).
+    std::vector<char> buf2(data.size(), 0);
+    auto get2 = client2_->Get(key, {(void*)buf2.data()}, {buf2.size()});
+    EXPECT_FALSE(get2.has_value())
+        << "Waterline-bypass data should not be on client2_";
+}
+
+// Contradictory config (waterline=0 + remote_weight=0, a dead-end combo)
+// is rejected by BatchPut at the client side.
+TEST_F(P2PClientIntegrationTest, ContradictoryConfigRejected) {
+    const std::string data = "contradictory_payload";
+    WriteRouteRequestConfig cfg;
+    cfg.remote_weight = 0.0;
+    cfg.local_write_waterline = 0.0;  // dead end: forbid local write + forbid remote route
+
+    std::vector<Slice> slices;
+    slices.emplace_back(Slice{const_cast<char*>(data.data()), data.size()});
+    auto put = client_->Put("contradictory_key", slices, cfg);
+    ASSERT_FALSE(put.has_value());
+    EXPECT_EQ(put.error(), ErrorCode::INVALID_PARAMS);
 }
 
 // ============================================================================
@@ -406,6 +454,7 @@ TEST_F(P2PClientIntegrationTest, RemoteBatchPutAndBatchGet) {
         // execute remote Put RPCs.
         WriteRouteRequestConfig remote_put_config;
         remote_put_config.remote_weight = 1.0;  // force remote
+        remote_put_config.local_write_waterline = 0.0;
         remote_put_config.max_candidates =
             WriteRouteRequestConfig::RETURN_ALL_CANDIDATES;
         auto put_results =
@@ -830,6 +879,7 @@ TEST_F(P2PClientIntegrationTest, ForwardRemotePutAndGet) {
 
         WriteRouteRequestConfig route;
         route.remote_weight = 1.0;  // force remote
+        route.local_write_waterline = 0.0;
         route.max_candidates = WriteRouteRequestConfig::RETURN_ALL_CANDIDATES;
 
         std::vector<Slice> slices;
@@ -896,6 +946,7 @@ TEST_F(P2PClientIntegrationTest, ForwardRemoteBatchPutAndBatchGet) {
 
         WriteRouteRequestConfig remote_put_config;
         remote_put_config.remote_weight = 1.0;  // force remote
+        remote_put_config.local_write_waterline = 0.0;
         remote_put_config.max_candidates =
             WriteRouteRequestConfig::RETURN_ALL_CANDIDATES;
 

--- a/mooncake-store/tests/p2p_client_integration_test.cpp
+++ b/mooncake-store/tests/p2p_client_integration_test.cpp
@@ -77,13 +77,16 @@ class P2PClientIntegrationTest : public ::testing::Test {
         master_address_ = master_.master_address();
         LOG(INFO) << "P2P master started at " << master_address_;
 
-        // 2. Create a client
+        // 2. Create two clients
         client_ = CreateP2PClient("localhost:18801");
         ASSERT_NE(client_, nullptr);
-        LOG(INFO) << "P2P client created and registered successfully";
+        client2_ = CreateP2PClient("localhost:18802");
+        ASSERT_NE(client2_, nullptr);
+        LOG(INFO) << "Two P2P clients created and registered successfully";
     }
 
     static void TearDownTestSuite() {
+        client2_.reset();
         client_.reset();
         master_.Stop();
         google::ShutdownGoogleLogging();
@@ -93,12 +96,14 @@ class P2PClientIntegrationTest : public ::testing::Test {
     static InProcP2PMaster master_;
     static std::string master_address_;
     static std::shared_ptr<P2PClientService> client_;
+    static std::shared_ptr<P2PClientService> client2_;
 };
 
 // Static member definitions
 InProcP2PMaster P2PClientIntegrationTest::master_;
 std::string P2PClientIntegrationTest::master_address_;
 std::shared_ptr<P2PClientService> P2PClientIntegrationTest::client_ = nullptr;
+std::shared_ptr<P2PClientService> P2PClientIntegrationTest::client2_ = nullptr;
 
 // ============================================================================
 // Put / Get (local WRITE_LOCAL mode)
@@ -156,6 +161,63 @@ TEST_F(P2PClientIntegrationTest, PutAndGetLocal) {
     EXPECT_TRUE(metrics_after_get.value().find(
                     "mooncake_p2p_local_get_bytes_total " +
                     std::to_string(data.size())) != std::string::npos);
+}
+
+TEST_F(P2PClientIntegrationTest, ForceLocalWriteBypass) {
+    const std::string data = "force_local_payload";
+
+    // remote_weight=0: client_ writes locally, bypassing the master.
+    // Data should be readable on client_ but NOT on client2_.
+    {
+        const std::string key = "force_local_key";
+        WriteRouteRequestConfig cfg;
+        cfg.remote_weight = 0.0;
+
+        std::vector<Slice> slices;
+        slices.emplace_back(Slice{const_cast<char*>(data.data()), data.size()});
+        auto put = client_->Put(key, slices, cfg);
+        ASSERT_TRUE(put.has_value())
+            << "Force-local Put failed: " << static_cast<int>(put.error());
+
+        // Readable on local client.
+        std::vector<char> buf(data.size(), 0);
+        auto get = client_->Get(key, {(void*)buf.data()}, {buf.size()});
+        ASSERT_TRUE(get.has_value());
+        EXPECT_EQ(std::string(buf.data(), buf.size()), data);
+
+        // NOT readable on remote client (data never left client_).
+        std::vector<char> buf2(data.size(), 0);
+        auto get2 = client2_->Get(key, {(void*)buf2.data()}, {buf2.size()});
+        EXPECT_FALSE(get2.has_value())
+            << "Force-local data should not be on client2_";
+    }
+
+    // remote_weight=1: client_ writes to client2_ via master routing.
+    // Data should be readable on client2_ but NOT locally on client_.
+    {
+        const std::string key = "force_remote_key";
+        WriteRouteRequestConfig cfg;
+        cfg.remote_weight = 1.0;
+
+        std::vector<Slice> slices;
+        slices.emplace_back(Slice{const_cast<char*>(data.data()), data.size()});
+        auto put = client_->Put(key, slices, cfg);
+        ASSERT_TRUE(put.has_value())
+            << "Force-remote Put failed: " << static_cast<int>(put.error());
+
+        // Readable on remote client.
+        std::vector<char> buf(data.size(), 0);
+        auto get = client2_->Get(key, {(void*)buf.data()}, {buf.size()});
+        ASSERT_TRUE(get.has_value())
+            << "Force-remote data should be on client2_";
+        EXPECT_EQ(std::string(buf.data(), buf.size()), data);
+
+        // NOT readable locally on client_ (data was written to client2_).
+        std::vector<char> buf2(data.size(), 0);
+        auto get2 = client_->Get(key, {(void*)buf2.data()}, {buf2.size()});
+        EXPECT_FALSE(get2.has_value())
+            << "Force-remote data should not be on client_ locally";
+    }
 }
 
 // ============================================================================
@@ -343,8 +405,7 @@ TEST_F(P2PClientIntegrationTest, RemoteBatchPutAndBatchGet) {
         // Force write route to exclude local candidate so the writer must
         // execute remote Put RPCs.
         WriteRouteRequestConfig remote_put_config;
-        remote_put_config.allow_local = false;
-        remote_put_config.prefer_local = false;
+        remote_put_config.remote_weight = 1.0;  // force remote
         remote_put_config.max_candidates =
             WriteRouteRequestConfig::RETURN_ALL_CANDIDATES;
         auto put_results =
@@ -768,8 +829,7 @@ TEST_F(P2PClientIntegrationTest, ForwardRemotePutAndGet) {
         const std::string payload = "forward_payload_" + mode + "_data";
 
         WriteRouteRequestConfig route;
-        route.allow_local = false;
-        route.prefer_local = false;
+        route.remote_weight = 1.0;  // force remote
         route.max_candidates = WriteRouteRequestConfig::RETURN_ALL_CANDIDATES;
 
         std::vector<Slice> slices;
@@ -835,8 +895,7 @@ TEST_F(P2PClientIntegrationTest, ForwardRemoteBatchPutAndBatchGet) {
         }
 
         WriteRouteRequestConfig remote_put_config;
-        remote_put_config.allow_local = false;
-        remote_put_config.prefer_local = false;
+        remote_put_config.remote_weight = 1.0;  // force remote
         remote_put_config.max_candidates =
             WriteRouteRequestConfig::RETURN_ALL_CANDIDATES;
 

--- a/mooncake-store/tests/p2p_client_integration_test.cpp
+++ b/mooncake-store/tests/p2p_client_integration_test.cpp
@@ -231,8 +231,8 @@ TEST_F(P2PClientIntegrationTest, WaterlineBypassWritesLocal) {
     // triggers a local write: data stays on client_, not on client2_.
     const std::string key = "waterline_bypass_key";
     WriteRouteRequestConfig cfg;
-    cfg.remote_weight = 0.5;            // balanced
-    cfg.local_write_waterline = 0.5;    // local is < 50% full -> local write
+    cfg.remote_weight = 0.5;          // balanced
+    cfg.local_write_waterline = 0.5;  // local is < 50% full -> local write
 
     std::vector<Slice> slices;
     slices.emplace_back(Slice{const_cast<char*>(data.data()), data.size()});
@@ -259,7 +259,8 @@ TEST_F(P2PClientIntegrationTest, ContradictoryConfigRejected) {
     const std::string data = "contradictory_payload";
     WriteRouteRequestConfig cfg;
     cfg.remote_weight = 0.0;
-    cfg.local_write_waterline = 0.0;  // dead end: forbid local write + forbid remote route
+    cfg.local_write_waterline =
+        0.0;  // dead end: forbid local write + forbid remote route
 
     std::vector<Slice> slices;
     slices.emplace_back(Slice{const_cast<char*>(data.data()), data.size()});

--- a/mooncake-store/tests/p2p_client_integration_test.cpp
+++ b/mooncake-store/tests/p2p_client_integration_test.cpp
@@ -166,8 +166,8 @@ TEST_F(P2PClientIntegrationTest, PutAndGetLocal) {
 TEST_F(P2PClientIntegrationTest, ForceLocalWriteBypass) {
     const std::string data = "force_local_payload";
 
-    // remote_weight=0: client_ writes locally, bypassing the master.
-    // Data should be readable on client_ but NOT on client2_.
+    // remote_weight=0: client_ writes locally instead of asking the master
+    // for a remote route.
     {
         const std::string key = "force_local_key";
         WriteRouteRequestConfig cfg;
@@ -185,15 +185,20 @@ TEST_F(P2PClientIntegrationTest, ForceLocalWriteBypass) {
         ASSERT_TRUE(get.has_value());
         EXPECT_EQ(std::string(buf.data(), buf.size()), data);
 
-        // NOT readable on remote client (data never left client_).
-        std::vector<char> buf2(data.size(), 0);
-        auto get2 = client2_->Get(key, {(void*)buf2.data()}, {buf2.size()});
-        EXPECT_FALSE(get2.has_value())
-            << "Force-local data should not be on client2_";
+        // Verify via master that the replica is on client_ (local).
+        auto resp = client_->GetMasterClient().GetReplicaList(key);
+        ASSERT_TRUE(resp.has_value());
+        ASSERT_FALSE(resp->replicas.empty());
+        const auto& desc = resp->replicas[0];
+        ASSERT_TRUE(std::holds_alternative<P2PProxyDescriptor>(
+            desc.descriptor_variant));
+        EXPECT_EQ(
+            std::get<P2PProxyDescriptor>(desc.descriptor_variant).client_id,
+            client_->GetClientID());
     }
 
     // remote_weight=1: client_ writes to client2_ via master routing.
-    // Data should be readable on client2_ but NOT locally on client_.
+    // The replica should be on client2_ (remote), not on client_.
     {
         const std::string key = "force_remote_key";
         WriteRouteRequestConfig cfg;
@@ -213,22 +218,26 @@ TEST_F(P2PClientIntegrationTest, ForceLocalWriteBypass) {
             << "Force-remote data should be on client2_";
         EXPECT_EQ(std::string(buf.data(), buf.size()), data);
 
-        // NOT readable locally on client_ (data was written to client2_).
-        std::vector<char> buf2(data.size(), 0);
-        auto get2 = client_->Get(key, {(void*)buf2.data()}, {buf2.size()});
-        EXPECT_FALSE(get2.has_value())
-            << "Force-remote data should not be on client_ locally";
+        // Verify via master that the replica is on client2_ (remote).
+        auto resp = client_->GetMasterClient().GetReplicaList(key);
+        ASSERT_TRUE(resp.has_value());
+        ASSERT_FALSE(resp->replicas.empty());
+        const auto& desc = resp->replicas[0];
+        ASSERT_TRUE(std::holds_alternative<P2PProxyDescriptor>(
+            desc.descriptor_variant));
+        EXPECT_EQ(
+            std::get<P2PProxyDescriptor>(desc.descriptor_variant).client_id,
+            client2_->GetClientID());
     }
 }
 
 // When local utilization is below the waterline, the client writes locally
-// without asking the master — even with a balanced remote_weight.
 TEST_F(P2PClientIntegrationTest, WaterlineBypassWritesLocal) {
     const std::string data = "waterline_payload";
 
     // Local client is nearly empty (64MB DRAM, ~0% utilization).
     // With waterline=0.5 and remote_weight=0.5 (balanced), the waterline
-    // triggers a local write: data stays on client_, not on client2_.
+    // triggers a local write: data stays on client_.
     const std::string key = "waterline_bypass_key";
     WriteRouteRequestConfig cfg;
     cfg.remote_weight = 0.5;          // balanced
@@ -246,11 +255,15 @@ TEST_F(P2PClientIntegrationTest, WaterlineBypassWritesLocal) {
     ASSERT_TRUE(get.has_value());
     EXPECT_EQ(std::string(buf.data(), buf.size()), data);
 
-    // NOT readable on remote client (data stayed local).
-    std::vector<char> buf2(data.size(), 0);
-    auto get2 = client2_->Get(key, {(void*)buf2.data()}, {buf2.size()});
-    EXPECT_FALSE(get2.has_value())
-        << "Waterline-bypass data should not be on client2_";
+    // Verify via master that the replica is on client_ (local).
+    auto resp = client_->GetMasterClient().GetReplicaList(key);
+    ASSERT_TRUE(resp.has_value());
+    ASSERT_FALSE(resp->replicas.empty());
+    const auto& desc = resp->replicas[0];
+    ASSERT_TRUE(
+        std::holds_alternative<P2PProxyDescriptor>(desc.descriptor_variant));
+    EXPECT_EQ(std::get<P2PProxyDescriptor>(desc.descriptor_variant).client_id,
+              client_->GetClientID());
 }
 
 // Contradictory config (waterline=0 + remote_weight=0, a dead-end combo)

--- a/mooncake-store/tests/p2p_client_meta_test.cpp
+++ b/mooncake-store/tests/p2p_client_meta_test.cpp
@@ -471,14 +471,15 @@ TEST_F(P2PClientMetaExtendedTest, QueryIpCheckHealth) {
 }
 
 // ============================================================
-// CollectWriteRouteCandidates
+// GetWriteRouteCandidate
 // ============================================================
 
-TEST_F(P2PClientMetaTest, CollectCandidatesMultipleSegments) {
+TEST_F(P2PClientMetaTest, GetWriteRouteCandidateAggregatesToOneClient) {
     UUID client_id = {111, 222};
     auto meta = CreateMeta(client_id, "10.0.0.1", 50051);
     meta->Heartbeat();
 
+    // Three segments (tiers) on one client, all empty.
     auto s1 = MakeP2PSegment({1, 1}, "seg1", 10000, 5);
     auto s2 = MakeP2PSegment({2, 2}, "seg2", 20000, 3);
     auto s3 = MakeP2PSegment({3, 3}, "seg3", 30000, 4);
@@ -488,40 +489,19 @@ TEST_F(P2PClientMetaTest, CollectCandidatesMultipleSegments) {
 
     WriteRouteRequest req;
     req.key = "test_key";
-    req.client_id = {999, 999};
+    req.client_id = {999, 999};  // non-local requester
     req.size = 100;
-    req.config.allow_local = true;
     req.config.max_candidates = WriteRouteRequestConfig::RETURN_ALL_CANDIDATES;
-    std::vector<WriteCandidate> candidates;
-    auto result = meta->CollectWriteRouteCandidates(req, candidates);
-    EXPECT_TRUE(result.has_value());
-    ASSERT_EQ(candidates.size(), 3);
-    // Verify specific segments are returned
-    std::set<UUID> returned_ids;
-    for (const auto& cand : candidates)
-        returned_ids.insert(cand.replica.segment_id);
-    EXPECT_TRUE(returned_ids.count(s1.id));
-    EXPECT_TRUE(returned_ids.count(s2.id));
-    EXPECT_TRUE(returned_ids.count(s3.id));
-
-    // 2. Test max_candidates = 2 with early_return = true (Should return 2)
-    // If `early_return`, it will stop when candidates.size() >= max_candidates.
-    // Otherwise, it will continue to process all segments.
-    // Actually, the `max_candidates` limits the candidates number in the
-    // GetWriteRoute() of P2PMasterService, which is the caller of
-    // CollectWriteRouteCandidates().
-    // However, here we are testing CollectWriteRouteCandidates() and the filter
-    // logic is processed in GetWriteRoute(). Thus, if does not set
-    // `early_return`, the `max_candidates` is not used.
-    req.config.max_candidates = 2;
-    req.config.early_return = true;
-    candidates.clear();
-    result = meta->CollectWriteRouteCandidates(req, candidates);
-    EXPECT_TRUE(result.has_value());
-    EXPECT_EQ(candidates.size(), 2);
+    req.config.top_tier_only = false;  // aggregate all tiers
+    auto result = meta->GetWriteRouteCandidate(req);
+    // Client granularity: one candidate per client regardless of tier count.
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->client_id, client_id);
+    // available_capacity aggregates all eligible tiers' free space.
+    EXPECT_EQ(result->available_capacity, 60000u);
 }
 
-TEST_F(P2PClientMetaTest, CollectCandidatesCapacityFilter) {
+TEST_F(P2PClientMetaTest, GetWriteRouteCandidateCapacityGate) {
     UUID client_id = {111, 222};
     auto meta = CreateMeta(client_id, "10.0.0.1", 50051);
     meta->Heartbeat();
@@ -530,20 +510,26 @@ TEST_F(P2PClientMetaTest, CollectCandidatesCapacityFilter) {
     auto s2 = MakeP2PSegment({2, 2}, "large", 1000, 5);  // 1000 bytes
     ASSERT_TRUE(meta->MountSegment(s1).has_value());
     ASSERT_TRUE(meta->MountSegment(s2).has_value());
+    // client-level free = 100 + 1000 = 1100
 
     WriteRouteRequest req;
     req.key = "test_key";
-    req.size = 500;  // Requires 500 bytes
-    req.config.allow_local = true;
 
-    std::vector<WriteCandidate> candidates;
-    auto result = meta->CollectWriteRouteCandidates(req, candidates);
-    EXPECT_TRUE(result.has_value());
-    ASSERT_EQ(candidates.size(), 1);
-    EXPECT_EQ(candidates[0].replica.segment_id, s2.id);
+    // Fits in the client's aggregate free capacity -> a candidate.
+    req.size = 500;
+    auto result = meta->GetWriteRouteCandidate(req);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->available_capacity, 1100u);
+
+    // Larger than the client's total free -> not a candidate.
+    req.size = 2000;
+    result = meta->GetWriteRouteCandidate(req);
+    EXPECT_FALSE(result.has_value());
 }
 
-TEST_F(P2PClientMetaTest, CollectCandidatesAllowLocalFilter) {
+// The client meta does NOT exclude the local client based on remote_weight;
+// that decision belongs to the master. The client only reports its capacity.
+TEST_F(P2PClientMetaTest, GetWriteRouteCandidateLocalAlwaysEligible) {
     UUID client_id = {111, 222};
     auto meta = CreateMeta(client_id, "10.0.0.1", 50051);
     meta->Heartbeat();
@@ -555,22 +541,22 @@ TEST_F(P2PClientMetaTest, CollectCandidatesAllowLocalFilter) {
     req.key = "test_key";
     req.client_id = client_id;  // Same as meta client_id
     req.size = 100;
-    req.config.allow_local = false;  // Disallow local
 
-    std::vector<WriteCandidate> candidates;
-    auto result = meta->CollectWriteRouteCandidates(req, candidates);
-    EXPECT_TRUE(result.has_value());
-    EXPECT_EQ(candidates.size(), 0);
+    // remote_weight does not affect eligibility at the client level.
+    req.config.remote_weight = 1.0;
+    auto result = meta->GetWriteRouteCandidate(req);
+    ASSERT_TRUE(result.has_value());
 
-    // Allow local should return the candidate
-    req.config.allow_local = true;
-    candidates.clear();
-    result = meta->CollectWriteRouteCandidates(req, candidates);
-    EXPECT_TRUE(result.has_value());
-    EXPECT_EQ(candidates.size(), 1);
+    req.config.remote_weight = 0.5;
+    result = meta->GetWriteRouteCandidate(req);
+    ASSERT_TRUE(result.has_value());
+
+    req.config.remote_weight = 0.0;
+    result = meta->GetWriteRouteCandidate(req);
+    ASSERT_TRUE(result.has_value());
 }
 
-TEST_F(P2PClientMetaTest, CollectCandidatesTagFilter) {
+TEST_F(P2PClientMetaTest, GetWriteRouteCandidateTagFilter) {
     UUID client_id = {111, 222};
     auto meta = CreateMeta(client_id, "10.0.0.1", 50051);
     meta->Heartbeat();
@@ -595,104 +581,89 @@ TEST_F(P2PClientMetaTest, CollectCandidatesTagFilter) {
 
     WriteRouteRequest req;
     req.size = 100;
-    req.config.allow_local = true;
     req.config.max_candidates = WriteRouteRequestConfig::RETURN_ALL_CANDIDATES;
 
-    // Filter "ssd": S1, S3 contain "ssd", should be excluded. S2, S4 remain.
+    // tag_filters scope the client's capacity score. Filter "ssd" excludes
+    // S1,S3; S2,S4 remain eligible -> one candidate, capacity = S2+S4 free.
     req.config.tag_filters = {"ssd"};
-    std::vector<WriteCandidate> candidates;
-    auto result = meta->CollectWriteRouteCandidates(req, candidates);
-    EXPECT_TRUE(result.has_value());
-    EXPECT_EQ(candidates.size(), 2);
-    for (const auto& cand : candidates) {
-        EXPECT_TRUE(cand.replica.segment_id == s2.id ||
-                    cand.replica.segment_id == s4.id);
-    }
+    auto result = meta->GetWriteRouteCandidate(req);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->client_id, client_id);
+    EXPECT_EQ(result->available_capacity, 20000u);  // S2 + S4
 
-    // Filter "ssd", "fast": Only S12 remain.
-    req.config.tag_filters = {"ssd", "fast"};
-    candidates.clear();
-    result = meta->CollectWriteRouteCandidates(req, candidates);
-    EXPECT_TRUE(result.has_value());
-    EXPECT_EQ(candidates.size(), 1);
-    EXPECT_TRUE(candidates[0].replica.segment_id == s2.id);
-
-    // Filter "memory": No segment has "memory", none excluded. All 4 remain.
-    req.config.tag_filters = {"memory"};
-    candidates.clear();
-    result = meta->CollectWriteRouteCandidates(req, candidates);
-    EXPECT_TRUE(result.has_value());
-    EXPECT_EQ(candidates.size(), 4);
+    // Every segment carries a filtered tag -> no eligible tier -> not a
+    // candidate.
+    req.config.tag_filters = {"ssd", "fast", "hdd", "slow"};
+    result = meta->GetWriteRouteCandidate(req);
+    EXPECT_FALSE(result.has_value());
 }
 
-TEST_F(P2PClientMetaTest, CollectCandidatesPreferLocalPriorityBoost) {
+// The candidate's score is the client-level free ratio ONLY. The local bias
+// The remote_weight scaling is applied by the master, not here, so this test
+// verifies the raw free ratio is returned regardless of remote_weight. Local
+// bias behavior is covered by P2PMasterServiceTest.
+TEST_F(P2PClientMetaTest, GetWriteRouteCandidateScoreIsRawFreeRatio) {
     UUID client_id = {111, 222};
     auto meta = CreateMeta(client_id, "10.0.0.1", 50051);
     meta->Heartbeat();
     const int base_priority = 10;
-    auto seg = MakeP2PSegment({1, 1}, "seg1", 10000,
-                              base_priority);  // Base priority 10
+    // 10000 total, 5000 used -> free_ratio = 0.5
+    auto seg = MakeP2PSegment({1, 1}, "seg1", 10000, base_priority,
+                              /*usage=*/5000);
     ASSERT_TRUE(meta->MountSegment(seg).has_value());
+    const double free_ratio = 0.5;
 
     WriteRouteRequest req;
     req.size = 100;
 
-    // 1. Local client + prefer_local = true -> Boosted priority
+    // 1. Local client + remote_weight = 0 (force local) -> score is free_ratio
+    //    (the +1 local bias is added by the master, not by the client).
     req.client_id = client_id;
-    req.config.allow_local = true;
-    req.config.prefer_local = true;
+    req.config.remote_weight = 0.0;
+    auto result = meta->GetWriteRouteCandidate(req);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_DOUBLE_EQ(result->score, free_ratio);
 
-    std::vector<WriteCandidate> candidates;
-    auto result = meta->CollectWriteRouteCandidates(req, candidates);
-    EXPECT_TRUE(result.has_value());
-    ASSERT_EQ(candidates.size(), 1);
-    EXPECT_EQ(candidates[0].priority,
-              base_priority + P2PClientMeta::INF_PRIORITY);
+    // 2. Local client + remote_weight = 0.5 (balanced) -> free_ratio, no bias.
+    req.config.remote_weight = 0.5;
+    result = meta->GetWriteRouteCandidate(req);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_DOUBLE_EQ(result->score, free_ratio);
 
-    // 2. Non-local client + prefer_local = true -> No boost
+    // 3. Non-local client -> free_ratio, no bias (never local).
     req.client_id = {999, 999};
-    candidates.clear();
-    result = meta->CollectWriteRouteCandidates(req, candidates);
-    EXPECT_TRUE(result.has_value());
-    ASSERT_EQ(candidates.size(), 1);
-    EXPECT_EQ(candidates[0].priority, base_priority);
+    req.config.remote_weight = 0.0;
+    result = meta->GetWriteRouteCandidate(req);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_DOUBLE_EQ(result->score, free_ratio);
 
-    // 3. Local client + prefer_local = false -> No boost
+    // 4. Local client + remote_weight = 1 -> still a candidate at client level
+    //    (the master applies the weight and decides exclusion).
     req.client_id = client_id;
-    req.config.prefer_local = false;
-    candidates.clear();
-    result = meta->CollectWriteRouteCandidates(req, candidates);
-    EXPECT_TRUE(result.has_value());
-    ASSERT_EQ(candidates.size(), 1);
-    EXPECT_EQ(candidates[0].priority, base_priority);
-
-    // 4. Local client + allow_local = false -> No candidate
-    req.config.allow_local = false;
-    req.config.prefer_local = true;
-    candidates.clear();
-    result = meta->CollectWriteRouteCandidates(req, candidates);
-    EXPECT_TRUE(result.has_value());
-    EXPECT_EQ(candidates.size(), 0);
+    req.config.remote_weight = 1.0;
+    result = meta->GetWriteRouteCandidate(req);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_DOUBLE_EQ(result->score, free_ratio);
 }
 
-TEST_F(P2PClientMetaTest, CollectCandidatesCompositeFilters) {
+TEST_F(P2PClientMetaTest, GetWriteRouteCandidateCompositeFilters) {
     UUID client_id = {111, 222};
     auto meta = CreateMeta(client_id, "10.0.0.1", 50051);
     meta->Heartbeat();
 
-    // S1: Sufficient space, correct tags, low priority
+    // S1: low priority (excluded by priority_limit)
     auto s1 = MakeP2PSegment({1, 1}, "s1", 10000, 1);
     s1.GetP2PExtra().tags = {"ssd"};
 
-    // S2: Sufficient space, wrong tags, high priority
+    // S2: wrong tag (excluded by tag_filters), high priority
     auto s2 = MakeP2PSegment({2, 2}, "s2", 10000, 10);
     s2.GetP2PExtra().tags = {"hdd"};
 
-    // S3: Insufficient space, correct tags, high priority
+    // S3: eligible tier, small
     auto s3 = MakeP2PSegment({3, 3}, "s3", 50, 10);
     s3.GetP2PExtra().tags = {"ssd"};
 
-    // S4: Sufficient space, correct tags, high priority -> The only valid one
+    // S4: eligible tier, large
     auto s4 = MakeP2PSegment({4, 4}, "s4", 10000, 10);
     s4.GetP2PExtra().tags = {"ssd"};
 
@@ -702,16 +673,55 @@ TEST_F(P2PClientMetaTest, CollectCandidatesCompositeFilters) {
     ASSERT_TRUE(meta->MountSegment(s4).has_value());
 
     WriteRouteRequest req;
-    req.size = 100;  // Filter S3
-    req.config.allow_local = true;
-    req.config.priority_limit = 5;     // Filter S1
-    req.config.tag_filters = {"hdd"};  // Filter S2
+    req.size = 100;
+    req.config.priority_limit = 5;     // excludes S1
+    req.config.tag_filters = {"hdd"};  // excludes S2
 
-    std::vector<WriteCandidate> candidates;
-    auto result = meta->CollectWriteRouteCandidates(req, candidates);
-    EXPECT_TRUE(result.has_value());
-    ASSERT_EQ(candidates.size(), 1);
-    EXPECT_EQ(candidates[0].replica.segment_id, s4.id);
+    // Eligible tiers = S3 + S4; client is a candidate with their aggregate
+    // free. (The client itself picks the concrete tier that fits at write
+    // time.)
+    auto result = meta->GetWriteRouteCandidate(req);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->client_id, client_id);
+    EXPECT_EQ(result->available_capacity, 10050u);  // S3(50) + S4(10000)
+}
+
+TEST_F(P2PClientMetaTest, GetWriteScoreCapacity) {
+    UUID client_id = {111, 222};
+    auto meta = CreateMeta(client_id, "10.0.0.1", 50051);
+    meta->Heartbeat();
+
+    // High-priority (10) DRAM tier: small, mostly free.
+    auto dram = MakeP2PSegment({1, 1}, "dram", 1000, /*priority=*/10,
+                               /*usage=*/200);
+    dram.GetP2PExtra().tags = {"fast"};
+    // Low-priority (0) NVMe tier: large, mostly free.
+    auto nvme = MakeP2PSegment({2, 2}, "nvme", 10000, /*priority=*/0,
+                               /*usage=*/1000);
+    ASSERT_TRUE(meta->MountSegment(dram).has_value());
+    ASSERT_TRUE(meta->MountSegment(nvme).has_value());
+
+    // All eligible tiers summed (no filters).
+    auto all = meta->GetWriteScoreCapacity({}, 0, /*top_tier_only=*/false);
+    EXPECT_EQ(all.total, 11000u);
+    EXPECT_EQ(all.free, 800u + 9000u);
+
+    // Only the highest-priority eligible tier (DRAM).
+    auto top = meta->GetWriteScoreCapacity({}, 0, /*top_tier_only=*/true);
+    EXPECT_EQ(top.total, 1000u);
+    EXPECT_EQ(top.free, 800u);
+
+    // priority_limit excludes the NVMe tier -> only DRAM contributes.
+    auto by_priority =
+        meta->GetWriteScoreCapacity({}, 5, /*top_tier_only=*/false);
+    EXPECT_EQ(by_priority.total, 1000u);
+    EXPECT_EQ(by_priority.free, 800u);
+
+    // tag_filters excludes DRAM (carries "fast") -> only NVMe contributes.
+    auto by_tag =
+        meta->GetWriteScoreCapacity({"fast"}, 0, /*top_tier_only=*/false);
+    EXPECT_EQ(by_tag.total, 10000u);
+    EXPECT_EQ(by_tag.free, 9000u);
 }
 
 // ============================================================

--- a/mooncake-store/tests/p2p_master_service_test.cpp
+++ b/mooncake-store/tests/p2p_master_service_test.cpp
@@ -568,7 +568,8 @@ TEST_F(P2PMasterServiceTest, GetWriteRouteLocalOnlyFallbackNoClient) {
     EXPECT_EQ(ErrorCode::NO_AVAILABLE_CANDIDATE, res.error());
 }
 
-// Invalid config (waterline=0 + remote_weight=0) is rejected at entry.
+// Invalid config (waterline=0 + remote_weight=0, a dead-end combo) is
+// rejected at entry.
 TEST_F(P2PMasterServiceTest, GetWriteRouteInvalidConfig) {
     auto service = CreateService();
     auto seg = MakeP2PSegment("seg1", kDefaultSegmentSize, {}, 1);
@@ -580,7 +581,27 @@ TEST_F(P2PMasterServiceTest, GetWriteRouteInvalidConfig) {
     req.client_id = client_id;
     req.size = 1024;
     req.config.remote_weight = 0.0;
-    req.config.local_write_waterline = 0.0;  // contradictory
+    req.config.local_write_waterline = 0.0;  // contradictory: dead end
+
+    auto res = service->GetWriteRoute(req);
+    EXPECT_FALSE(res.has_value());
+    EXPECT_EQ(ErrorCode::INVALID_PARAMS, res.error());
+}
+
+// Invalid config (waterline=1 + remote_weight=1, a dead-end combo) is
+// also rejected at entry.
+TEST_F(P2PMasterServiceTest, GetWriteRouteInvalidConfigSecondContradiction) {
+    auto service = CreateService();
+    auto seg = MakeP2PSegment("seg1", kDefaultSegmentSize, {}, 1);
+    auto client_id = generate_uuid();
+    RegisterP2PClient(*service, client_id, {seg}, "10.0.0.1", 50051);
+
+    WriteRouteRequest req;
+    req.key = "k";
+    req.client_id = client_id;
+    req.size = 1024;
+    req.config.remote_weight = 1.0;
+    req.config.local_write_waterline = 1.0;  // contradictory: dead end
 
     auto res = service->GetWriteRoute(req);
     EXPECT_FALSE(res.has_value());

--- a/mooncake-store/tests/p2p_master_service_test.cpp
+++ b/mooncake-store/tests/p2p_master_service_test.cpp
@@ -49,9 +49,9 @@ class P2PMasterServiceTest : public ::testing::Test {
 
     /// Create the service with given max_replicas config
     std::unique_ptr<P2PMasterService> CreateService(
-        uint64_t max_replicas_per_key = 0) {
+        uint64_t max_client_per_key = 0) {
         auto config = MasterServiceConfig::builder()
-                          .set_max_replicas_per_key(max_replicas_per_key)
+                          .set_max_client_per_key(max_client_per_key)
                           .build();
         return std::make_unique<P2PMasterService>(config);
     }
@@ -139,8 +139,7 @@ TEST_F(P2PMasterServiceTest, GetWriteRouteBasic) {
     auto res = service->GetWriteRoute(req);
     ASSERT_TRUE(res.has_value()) << "GetWriteRoute failed: " << res.error();
     EXPECT_EQ(1, res.value().candidates.size());
-    EXPECT_EQ(client_id, res.value().candidates[0].replica.client_id);
-    EXPECT_EQ(seg.id, res.value().candidates[0].replica.segment_id);
+    EXPECT_EQ(client_id, res.value().candidates[0].client_id);
 }
 
 TEST_F(P2PMasterServiceTest, GetWriteRouteNoCapacity) {
@@ -157,7 +156,7 @@ TEST_F(P2PMasterServiceTest, GetWriteRouteNoCapacity) {
 
     auto res = service->GetWriteRoute(req);
     EXPECT_FALSE(res.has_value());
-    EXPECT_EQ(ErrorCode::SEGMENT_NOT_FOUND, res.error());
+    EXPECT_EQ(ErrorCode::NO_AVAILABLE_CANDIDATE, res.error());
 }
 
 TEST_F(P2PMasterServiceTest, GetWriteRouteTagFilter) {
@@ -183,7 +182,7 @@ TEST_F(P2PMasterServiceTest, GetWriteRouteTagFilter) {
     auto res = service->GetWriteRoute(req);
     ASSERT_TRUE(res.has_value());
     EXPECT_EQ(1, res.value().candidates.size());
-    EXPECT_EQ(client1, res.value().candidates[0].replica.client_id);
+    EXPECT_EQ(client1, res.value().candidates[0].client_id);
 }
 
 TEST_F(P2PMasterServiceTest, GetWriteRoutePriorityFilter) {
@@ -207,32 +206,33 @@ TEST_F(P2PMasterServiceTest, GetWriteRoutePriorityFilter) {
     auto res = service->GetWriteRoute(req);
     ASSERT_TRUE(res.has_value());
     EXPECT_EQ(1, res.value().candidates.size());
-    EXPECT_EQ(client2, res.value().candidates[0].replica.client_id);
+    EXPECT_EQ(client2, res.value().candidates[0].client_id);
 }
 
-TEST_F(P2PMasterServiceTest, GetWriteRouteAllowLocal) {
+TEST_F(P2PMasterServiceTest, GetWriteRouteForceRemoteExcludesLocal) {
     auto service = CreateService();
     auto seg = MakeP2PSegment("seg1", kDefaultSegmentSize, {}, 1);
     auto client_id = generate_uuid();
     RegisterP2PClient(*service, client_id, {seg}, "127.0.0.1", 50051);
 
-    // Same client requesting, allow_local = false — should skip self
+    // Same client requesting, remote_weight = 1 (force remote) — should skip
+    // self
     WriteRouteRequest req;
     req.key = "test_key";
     req.client_id = client_id;
     req.size = 1024;
     req.config.max_candidates = 1;
-    req.config.allow_local = false;
+    req.config.remote_weight = 1.0;
 
     auto res = service->GetWriteRoute(req);
     EXPECT_FALSE(res.has_value());  // only candidate is self, which is skipped
 
-    // allow_local = true — should include self
-    req.config.allow_local = true;
+    // remote_weight < 1 — should include self
+    req.config.remote_weight = 0.5;
     auto res2 = service->GetWriteRoute(req);
     ASSERT_TRUE(res2.has_value());
     EXPECT_EQ(1, res2.value().candidates.size());
-    EXPECT_EQ(client_id, res2.value().candidates[0].replica.client_id);
+    EXPECT_EQ(client_id, res2.value().candidates[0].client_id);
 }
 
 TEST_F(P2PMasterServiceTest, GetWriteRouteEarlyReturn) {
@@ -273,22 +273,22 @@ TEST_F(P2PMasterServiceTest, GetWriteRouteMultipleSegments) {
     RegisterP2PClient(*service, client_id2, {seg2}, "127.0.0.2", 50051);
     RegisterP2PClient(*service, client_id3, {seg3, seg4}, "127.0.0.3", 50051);
 
-    // No filters — should return both segments as candidates
     WriteRouteRequest req;
     req.key = "test_key";
     req.client_id = client_id;
     req.size = 1024;
     req.config.max_candidates = WriteRouteRequestConfig::RETURN_ALL_CANDIDATES;
-    req.config.allow_local = false;
+    req.config.remote_weight =
+        1.0;  // force remote: exclude the requesting client
     req.config.early_return = false;
 
     auto res = service->GetWriteRoute(req);
     ASSERT_TRUE(res.has_value());
-    EXPECT_EQ(3, res.value().candidates.size());
+    EXPECT_EQ(2, res.value().candidates.size());
 }
 
 TEST_F(P2PMasterServiceTest, GetWriteRouteRejectsWhenOwnerClientLimitReached) {
-    auto service = CreateService(/* max_replicas_per_key= */ 2);
+    auto service = CreateService(/* max_client_per_key= */ 2);
     auto owner_seg1 = MakeP2PSegment("owner_seg1", kDefaultSegmentSize, {}, 1);
     auto owner_seg2 = MakeP2PSegment("owner_seg2", kDefaultSegmentSize, {}, 2);
     auto new_owner_seg = MakeP2PSegment("new_owner_seg", kDefaultSegmentSize);
@@ -312,6 +312,279 @@ TEST_F(P2PMasterServiceTest, GetWriteRouteRejectsWhenOwnerClientLimitReached) {
     auto res = service->GetWriteRoute(req);
     EXPECT_FALSE(res.has_value());
     EXPECT_EQ(ErrorCode::REPLICA_NUM_EXCEEDED, res.error());
+}
+
+// A nearly-full local client is visited last under CAPACITY_PRIORITY, but a
+// strong local preference (remote_weight close to 0) still lets it win after
+// sorting. early_return is disabled so all candidates are collected.
+TEST_F(P2PMasterServiceTest, GetWriteRouteLocalFirstBeatsCapacityOrdering) {
+    auto service = CreateService();
+    auto local_seg = MakeP2PSegment("local", 1000, {}, 1);
+    local_seg.GetP2PExtra().usage = 900;  // free 100 -> free_ratio 0.1
+    auto local_id = generate_uuid();
+    RegisterP2PClient(*service, local_id, {local_seg}, "10.0.0.1", 50051);
+
+    // Several near-empty, high-capacity remotes (visited first).
+    for (int i = 0; i < 3; ++i) {
+        auto seg = MakeP2PSegment("remote_" + std::to_string(i), 100000, {}, 1);
+        RegisterP2PClient(*service, generate_uuid(), {seg},
+                          "10.0.0." + std::to_string(i + 2), 50052 + i);
+    }
+
+    WriteRouteRequest req;
+    req.key = "k";
+    req.client_id = local_id;  // the requesting client is the local one
+    req.size = 50;
+    req.config.max_candidates = 1;
+    req.config.early_return = false;  // collect all, then sort
+    req.config.remote_weight = 0.02;  // strong local preference
+
+    auto res = service->GetWriteRoute(req);
+    ASSERT_TRUE(res.has_value()) << res.error();
+    ASSERT_EQ(1u, res.value().candidates.size());
+    EXPECT_EQ(local_id, res.value().candidates[0].client_id);
+}
+
+// With a weak local preference, a much-emptier remote out-scores the
+// nearly-full local client after sorting.
+TEST_F(P2PMasterServiceTest, GetWriteRouteWeightedRemoteCanWin) {
+    auto service = CreateService();
+    auto local_seg = MakeP2PSegment("local", 1000, {}, 1);
+    local_seg.GetP2PExtra().usage = 900;  // free_ratio 0.1
+    auto local_id = generate_uuid();
+    RegisterP2PClient(*service, local_id, {local_seg}, "10.0.0.1", 50051);
+
+    auto remote_seg =
+        MakeP2PSegment("remote", 100000, {}, 1);  // free_ratio 1.0
+    auto remote_id = generate_uuid();
+    RegisterP2PClient(*service, remote_id, {remote_seg}, "10.0.0.2", 50052);
+
+    WriteRouteRequest req;
+    req.key = "k";
+    req.client_id = local_id;
+    req.size = 50;
+    req.config.max_candidates = 1;
+    req.config.early_return = false;  // collect all, then sort
+    req.config.remote_weight = 0.4;   // weak local preference
+
+    auto res = service->GetWriteRoute(req);
+    ASSERT_TRUE(res.has_value()) << res.error();
+    ASSERT_EQ(1u, res.value().candidates.size());
+    EXPECT_EQ(remote_id, res.value().candidates[0].client_id);
+}
+
+// With early_return=true and max_candidates=1, ForEachClient stops after the
+// first eligible candidate. Under CAPACITY_PRIORITY the high-capacity remote
+// is visited first, so it is returned without visiting the local client.
+TEST_F(P2PMasterServiceTest, GetWriteRouteEarlyReturnStopsAtFirstCandidate) {
+    auto service = CreateService();
+    auto local_seg = MakeP2PSegment("local", 1000, {}, 1);
+    local_seg.GetP2PExtra().usage = 900;  // free_ratio 0.1
+    auto local_id = generate_uuid();
+    RegisterP2PClient(*service, local_id, {local_seg}, "10.0.0.1", 50051);
+
+    auto remote_seg =
+        MakeP2PSegment("remote", 100000, {}, 1);  // free_ratio 1.0
+    auto remote_id = generate_uuid();
+    RegisterP2PClient(*service, remote_id, {remote_seg}, "10.0.0.2", 50052);
+
+    WriteRouteRequest req;
+    req.key = "k";
+    req.client_id = local_id;
+    req.size = 50;
+    req.config.max_candidates = 1;
+    req.config.early_return = true;
+    req.config.remote_weight = 0.4;
+
+    auto res = service->GetWriteRoute(req);
+    ASSERT_TRUE(res.has_value()) << res.error();
+    ASSERT_EQ(1u, res.value().candidates.size());
+    // CAPACITY_PRIORITY visits the 100 000-capacity remote first; early stop.
+    EXPECT_EQ(remote_id, res.value().candidates[0].client_id);
+}
+
+// Problem 3: top_tier_only changes which client wins by scoring only the
+// highest-priority tier's free ratio instead of summing all tiers.
+TEST_F(P2PMasterServiceTest, GetWriteRouteTopTierCapacityAffectsScore) {
+    auto service = CreateService();
+
+    // Client A: small high-prio DRAM mostly free; large low-prio NVMe mostly
+    // full.
+    auto a_dram = MakeP2PSegment("a_dram", 1000, {}, 10);
+    a_dram.GetP2PExtra().usage = 100;  // free 900 -> top-tier ratio 0.9
+    auto a_nvme = MakeP2PSegment("a_nvme", 100000, {}, 0);
+    a_nvme.GetP2PExtra().usage = 99000;  // free 1000
+    auto a_id = generate_uuid();
+    RegisterP2PClient(*service, a_id, {a_dram, a_nvme}, "10.0.0.1", 50051);
+
+    // Client B: high-prio DRAM half free; large low-prio NVMe fully free.
+    auto b_dram = MakeP2PSegment("b_dram", 1000, {}, 10);
+    b_dram.GetP2PExtra().usage = 500;  // free 500 -> top-tier ratio 0.5
+    auto b_nvme = MakeP2PSegment("b_nvme", 100000, {}, 0);
+    b_nvme.GetP2PExtra().usage = 0;  // free 100000
+    auto b_id = generate_uuid();
+    RegisterP2PClient(*service, b_id, {b_dram, b_nvme}, "10.0.0.2", 50052);
+
+    WriteRouteRequest req;
+    req.key = "k";
+    req.client_id = generate_uuid();  // non-local requester
+    req.size = 50;
+    req.config.max_candidates = WriteRouteRequestConfig::RETURN_ALL_CANDIDATES;
+    req.config.early_return = false;
+    req.config.remote_weight = 0.5;
+
+    // All tiers: B is much emptier overall -> B wins.
+    req.config.top_tier_only = false;
+    auto res_all = service->GetWriteRoute(req);
+    ASSERT_TRUE(res_all.has_value()) << res_all.error();
+    EXPECT_EQ(b_id, res_all.value().candidates[0].client_id);
+
+    // Top tier only: A's DRAM tier is emptier than B's -> A wins.
+    req.config.top_tier_only = true;
+    auto res_top = service->GetWriteRoute(req);
+    ASSERT_TRUE(res_top.has_value()) << res_top.error();
+    EXPECT_EQ(a_id, res_top.value().candidates[0].client_id);
+}
+
+// A client that already owns the key is excluded from write-route candidates so
+// a write is never routed to create a duplicate replica on it.
+TEST_F(P2PMasterServiceTest, GetWriteRouteExcludesExistingOwner) {
+    auto service = CreateService();  // unlimited owners
+    auto owner_seg = MakeP2PSegment("owner_seg", kDefaultSegmentSize, {}, 1);
+    auto other_seg = MakeP2PSegment("other_seg", kDefaultSegmentSize, {}, 1);
+    auto owner = generate_uuid();
+    auto other = generate_uuid();
+    RegisterP2PClient(*service, owner, {owner_seg}, "10.0.0.1", 50051);
+    RegisterP2PClient(*service, other, {other_seg}, "10.0.0.2", 50052);
+
+    // owner already holds "k".
+    AddReplicaHelper(*service, "k", 1024, owner, owner_seg.id);
+
+    WriteRouteRequest req;
+    req.key = "k";
+    req.client_id = generate_uuid();  // non-local, non-owner requester
+    req.size = 1024;
+    req.config.max_candidates = WriteRouteRequestConfig::RETURN_ALL_CANDIDATES;
+    req.config.early_return = false;
+
+    auto res = service->GetWriteRoute(req);
+    ASSERT_TRUE(res.has_value()) << res.error();
+    ASSERT_EQ(1u, res.value().candidates.size());
+    EXPECT_EQ(other, res.value().candidates[0].client_id);
+    for (const auto& c : res.value().candidates) {
+        EXPECT_NE(owner, c.client_id);
+    }
+}
+
+// Existing owners (including the requesting client itself) are excluded from
+// write-route candidates. Self-overwrite is handled client-side via the local
+// write path (remote_weight=0 bypasses the master entirely).
+TEST_F(P2PMasterServiceTest, GetWriteRouteExcludesSelfOwner) {
+    auto service = CreateService();
+    auto seg = MakeP2PSegment("self_seg", kDefaultSegmentSize, {}, 1);
+    auto self = generate_uuid();
+    RegisterP2PClient(*service, self, {seg}, "10.0.0.1", 50051);
+
+    // self already holds "k".
+    AddReplicaHelper(*service, "k", 1024, self, seg.id);
+
+    WriteRouteRequest req;
+    req.key = "k";
+    req.client_id = self;  // requester is the existing owner
+    req.size = 1024;
+    req.config.max_candidates = 1;
+
+    // The only registered client is the existing owner -> no candidate.
+    auto res = service->GetWriteRoute(req);
+    EXPECT_FALSE(res.has_value());
+    EXPECT_EQ(ErrorCode::NO_AVAILABLE_CANDIDATE, res.error());
+}
+
+// When the client limit is reached, GetWriteRoute rejects all requesters
+// (including existing owners) — the key already has enough owner clients.
+TEST_F(P2PMasterServiceTest, GetWriteRouteRejectsAllWhenOwnerLimitReached) {
+    auto service = CreateService(/* max_client_per_key= */ 1);
+    auto seg_a = MakeP2PSegment("seg_a", kDefaultSegmentSize, {}, 1);
+    auto seg_b = MakeP2PSegment("seg_b", kDefaultSegmentSize, {}, 1);
+    auto owner = generate_uuid();
+    auto other = generate_uuid();
+    RegisterP2PClient(*service, owner, {seg_a}, "10.0.0.1", 50051);
+    RegisterP2PClient(*service, other, {seg_b}, "10.0.0.2", 50052);
+
+    // owner already holds "k" -> 1 owner == limit.
+    AddReplicaHelper(*service, "k", 1024, owner, seg_a.id);
+
+    WriteRouteRequest req;
+    req.key = "k";
+    req.size = 1024;
+    req.config.max_candidates = 1;
+
+    // owner requests write route: rejected (limit reached).
+    req.client_id = owner;
+    auto res = service->GetWriteRoute(req);
+    EXPECT_FALSE(res.has_value());
+    EXPECT_EQ(ErrorCode::REPLICA_NUM_EXCEEDED, res.error());
+
+    // other (non-owner) requests write route: also rejected.
+    req.client_id = other;
+    auto res2 = service->GetWriteRoute(req);
+    EXPECT_FALSE(res2.has_value());
+    EXPECT_EQ(ErrorCode::REPLICA_NUM_EXCEEDED, res2.error());
+}
+
+// w=0 fallback via master: single registered client is returned.
+TEST_F(P2PMasterServiceTest, GetWriteRouteLocalOnlyFallback) {
+    auto service = CreateService();
+    auto seg = MakeP2PSegment("seg1", kDefaultSegmentSize, {}, 1);
+    auto client_id = generate_uuid();
+    RegisterP2PClient(*service, client_id, {seg}, "10.0.0.1", 50051);
+
+    WriteRouteRequest req;
+    req.key = "k";
+    req.client_id = client_id;
+    req.size = 1024;
+    req.config.max_candidates = 1;
+    req.config.remote_weight = 0.0;
+
+    auto res = service->GetWriteRoute(req);
+    ASSERT_TRUE(res.has_value()) << res.error();
+    ASSERT_EQ(1u, res.value().candidates.size());
+    EXPECT_EQ(client_id, res.value().candidates[0].client_id);
+}
+
+// w=0 fallback via master with no registered clients: NO_AVAILABLE_CANDIDATE.
+TEST_F(P2PMasterServiceTest, GetWriteRouteLocalOnlyFallbackNoClient) {
+    auto service = CreateService();
+
+    WriteRouteRequest req;
+    req.key = "k";
+    req.client_id = generate_uuid();  // not registered
+    req.size = 1024;
+    req.config.max_candidates = 1;
+    req.config.remote_weight = 0.0;
+
+    auto res = service->GetWriteRoute(req);
+    EXPECT_FALSE(res.has_value());
+    EXPECT_EQ(ErrorCode::NO_AVAILABLE_CANDIDATE, res.error());
+}
+
+// Invalid config (waterline=0 + remote_weight=0) is rejected at entry.
+TEST_F(P2PMasterServiceTest, GetWriteRouteInvalidConfig) {
+    auto service = CreateService();
+    auto seg = MakeP2PSegment("seg1", kDefaultSegmentSize, {}, 1);
+    auto client_id = generate_uuid();
+    RegisterP2PClient(*service, client_id, {seg}, "10.0.0.1", 50051);
+
+    WriteRouteRequest req;
+    req.key = "k";
+    req.client_id = client_id;
+    req.size = 1024;
+    req.config.remote_weight = 0.0;
+    req.config.local_write_waterline = 0.0;  // contradictory
+
+    auto res = service->GetWriteRoute(req);
+    EXPECT_FALSE(res.has_value());
+    EXPECT_EQ(ErrorCode::INVALID_PARAMS, res.error());
 }
 
 // ============================================================
@@ -367,7 +640,7 @@ TEST_F(P2PMasterServiceTest, AddReplicaDuplicate) {
 }
 
 TEST_F(P2PMasterServiceTest, AddReplicaMaxLimit) {
-    auto service = CreateService(/* max_replicas_per_key= */ 2);
+    auto service = CreateService(/* max_client_per_key= */ 2);
     auto seg1 = MakeP2PSegment("seg1");
     auto seg1_b = MakeP2PSegment("seg1_b");
     auto seg2 = MakeP2PSegment("seg2");
@@ -386,9 +659,13 @@ TEST_F(P2PMasterServiceTest, AddReplicaMaxLimit) {
     // The second owner client is allowed.
     AddReplicaHelper(*service, "key1", 1024, client2, seg2.id);
 
+    // GetReplicaList aggregates per client: client1's two segment-replicas
+    // collapse to one route, plus client2 -> 2 routes. (Both AddReplica calls
+    // on client1 already succeeded above, confirming multiple replicas per
+    // client are allowed.)
     auto get_res = service->GetReplicaList("key1");
     ASSERT_TRUE(get_res.has_value());
-    EXPECT_EQ(3, get_res.value().replicas.size());
+    EXPECT_EQ(2, get_res.value().replicas.size());
 
     // The third owner client should exceed the limit.
     AddReplicaRequest req;
@@ -670,6 +947,28 @@ TEST_F(P2PMasterServiceTest, FilterReplicasWithMaxCandidates) {
               res.value().replicas[0].get_p2p_proxy_descriptor().client_id);
 }
 
+// A client holding the key on multiple segments (tiers) is aggregated into a
+// single read route (representative = highest-priority segment).
+TEST_F(P2PMasterServiceTest, GetReplicaListAggregatesPerClient) {
+    auto service = CreateService();
+    auto seg_hi = MakeP2PSegment("seg_hi", kDefaultSegmentSize, {}, 10);
+    auto seg_lo = MakeP2PSegment("seg_lo", kDefaultSegmentSize, {}, 1);
+    auto client_id = generate_uuid();
+    RegisterP2PClient(*service, client_id, {seg_hi, seg_lo}, "10.0.0.1", 50051);
+    AddReplicaHelper(*service, "key1", 1024, client_id, seg_hi.id);
+    AddReplicaHelper(*service, "key1", 1024, client_id, seg_lo.id);
+
+    auto res = service->GetReplicaList("key1");
+    ASSERT_TRUE(res.has_value());
+    // Two segment-replicas on the same client collapse to one route.
+    EXPECT_EQ(1, res.value().replicas.size());
+    EXPECT_EQ(client_id,
+              res.value().replicas[0].get_p2p_proxy_descriptor().client_id);
+    // Representative is the highest-priority segment.
+    EXPECT_EQ(seg_hi.id,
+              res.value().replicas[0].get_p2p_proxy_descriptor().segment_id);
+}
+
 // ============================================================
 // ExistKey / Remove / RemoveAll Tests
 // ============================================================
@@ -768,14 +1067,16 @@ TEST_F(P2PMasterServiceTest, FullWriteReadCycle) {
     EXPECT_EQ(1, w_res.value().candidates.size());
 
     auto& candidate = w_res.value().candidates[0];
-    EXPECT_EQ(writer_id, candidate.replica.client_id);
+    EXPECT_EQ(writer_id, candidate.client_id);
 
-    // Step 2: Add replica (simulate write completion)
+    // Step 2: Add replica (simulate write completion). The route is
+    // client-only; the client registers the concrete segment it actually wrote
+    // (here seg.id).
     AddReplicaRequest a_req;
     a_req.key = "data_001";
     a_req.size = 4096;
-    a_req.client_id = candidate.replica.client_id;
-    a_req.segment_id = candidate.replica.segment_id;
+    a_req.client_id = candidate.client_id;
+    a_req.segment_id = seg.id;
     auto a_res = service->AddReplica(a_req);
     ASSERT_TRUE(a_res.has_value());
 
@@ -787,8 +1088,8 @@ TEST_F(P2PMasterServiceTest, FullWriteReadCycle) {
     // Step 4: Remove
     RemoveReplicaRequest rm_req;
     rm_req.key = "data_001";
-    rm_req.client_id = candidate.replica.client_id;
-    rm_req.segment_id = candidate.replica.segment_id;
+    rm_req.client_id = candidate.client_id;
+    rm_req.segment_id = seg.id;
     auto rm_res = service->RemoveReplica(rm_req);
     ASSERT_TRUE(rm_res.has_value());
 

--- a/mooncake-store/tests/runtime_config_store_test.cpp
+++ b/mooncake-store/tests/runtime_config_store_test.cpp
@@ -250,7 +250,7 @@ TEST_F(RuntimeConfigTest, ValidateWriteConfigRejectsContradiction) {
         patch["local_write_waterline"] = 1.0;
         EXPECT_FALSE(store.updateWriteConfig(patch));
     }
-    const auto& cfg =
+    const auto cfg =
         std::get<WriteRouteRequestConfig>(store.getDefaultWriteConfig());
     EXPECT_DOUBLE_EQ(cfg.remote_weight, 0.5);
     EXPECT_DOUBLE_EQ(cfg.local_write_waterline, 0.5);
@@ -262,7 +262,7 @@ TEST_F(RuntimeConfigTest, ValidateWriteConfigAllowsValidCombos) {
     patch["remote_weight"] = 0.5;
     patch["local_write_waterline"] = 0.0;
     EXPECT_TRUE(p2p_store().updateWriteConfig(patch));
-    const auto& cfg1 =
+    const auto cfg1 =
         std::get<WriteRouteRequestConfig>(p2p_store().getDefaultWriteConfig());
     EXPECT_DOUBLE_EQ(cfg1.remote_weight, 0.5);
     EXPECT_DOUBLE_EQ(cfg1.local_write_waterline, 0.0);
@@ -272,7 +272,7 @@ TEST_F(RuntimeConfigTest, ValidateWriteConfigAllowsValidCombos) {
     patch2["remote_weight"] = 0.0;
     patch2["local_write_waterline"] = 0.8;
     EXPECT_TRUE(p2p_store().updateWriteConfig(patch2));
-    const auto& cfg2 =
+    const auto cfg2 =
         std::get<WriteRouteRequestConfig>(p2p_store().getDefaultWriteConfig());
     EXPECT_DOUBLE_EQ(cfg2.remote_weight, 0.0);
     EXPECT_DOUBLE_EQ(cfg2.local_write_waterline, 0.8);
@@ -283,7 +283,7 @@ TEST_F(RuntimeConfigTest, ValidateWriteConfigAllowsValidCombos) {
     patch3["remote_weight"] = 1.0;
     patch3["local_write_waterline"] = 0.0;
     EXPECT_TRUE(p2p_store().updateWriteConfig(patch3));
-    const auto& cfg3 =
+    const auto cfg3 =
         std::get<WriteRouteRequestConfig>(p2p_store().getDefaultWriteConfig());
     EXPECT_DOUBLE_EQ(cfg3.remote_weight, 1.0);
     EXPECT_DOUBLE_EQ(cfg3.local_write_waterline, 0.0);
@@ -294,7 +294,7 @@ TEST_F(RuntimeConfigTest, ValidateWriteConfigAllowsValidCombos) {
     patch4["remote_weight"] = 0.0;
     patch4["local_write_waterline"] = 1.0;
     EXPECT_TRUE(p2p_store().updateWriteConfig(patch4));
-    const auto& cfg4 =
+    const auto cfg4 =
         std::get<WriteRouteRequestConfig>(p2p_store().getDefaultWriteConfig());
     EXPECT_DOUBLE_EQ(cfg4.remote_weight, 0.0);
     EXPECT_DOUBLE_EQ(cfg4.local_write_waterline, 1.0);

--- a/mooncake-store/tests/runtime_config_store_test.cpp
+++ b/mooncake-store/tests/runtime_config_store_test.cpp
@@ -132,8 +132,9 @@ TEST_F(RuntimeConfigTest, P2PModeReturnsWriteRouteRequestConfig) {
     auto wc = p2p_store().getDefaultWriteConfig();
     ASSERT_TRUE(std::holds_alternative<WriteRouteRequestConfig>(wc));
     auto& cfg = std::get<WriteRouteRequestConfig>(wc);
-    EXPECT_TRUE(cfg.allow_local);
-    EXPECT_TRUE(cfg.prefer_local);
+    EXPECT_DOUBLE_EQ(cfg.remote_weight, 0.5);
+    EXPECT_DOUBLE_EQ(cfg.local_write_waterline, 0.5);
+    EXPECT_TRUE(cfg.top_tier_only);
     EXPECT_EQ(cfg.max_candidates, 2u);
     auto rc = p2p_store().getDefaultReadConfig();
     EXPECT_EQ(rc.max_candidates, 0u);
@@ -179,17 +180,92 @@ TEST_F(RuntimeConfigTest, UpdateCentralizedPreferredSegments) {
 
 TEST_F(RuntimeConfigTest, UpdateP2PWriteConfigPatch) {
     Json::Value patch;
-    patch["prefer_local"] = false;
+    patch["remote_weight"] = 0.75;
+    patch["top_tier_only"] = true;
     patch["max_candidates"] = 5;
     patch["priority_limit"] = 10;
     p2p_store().updateWriteConfig(patch);
 
     auto wc = p2p_store().getDefaultWriteConfig();
     auto& cfg = std::get<WriteRouteRequestConfig>(wc);
-    EXPECT_FALSE(cfg.prefer_local);
+    EXPECT_DOUBLE_EQ(cfg.remote_weight, 0.75);
+    EXPECT_TRUE(cfg.top_tier_only);
     EXPECT_EQ(cfg.max_candidates, 5u);
     EXPECT_EQ(cfg.priority_limit, 10);
-    EXPECT_TRUE(cfg.allow_local);
+}
+
+TEST_F(RuntimeConfigTest, UpdateP2PWriteConfigRemoteWeightClamped) {
+    Json::Value patch;
+    patch["remote_weight"] = 5.0;  // out of range -> clamped to 1.0
+    p2p_store().updateWriteConfig(patch);
+    EXPECT_DOUBLE_EQ(
+        std::get<WriteRouteRequestConfig>(p2p_store().getDefaultWriteConfig())
+            .remote_weight,
+        1.0);
+
+    Json::Value patch2;
+    patch2["remote_weight"] = -1.0;  // out of range -> clamped to 0.0
+    p2p_store().updateWriteConfig(patch2);
+    EXPECT_DOUBLE_EQ(
+        std::get<WriteRouteRequestConfig>(p2p_store().getDefaultWriteConfig())
+            .remote_weight,
+        0.0);
+}
+
+TEST_F(RuntimeConfigTest, UpdateP2PWriteConfigLocalWriteWaterline) {
+    Json::Value patch;
+    patch["local_write_waterline"] = 0.8;
+    p2p_store().updateWriteConfig(patch);
+    EXPECT_DOUBLE_EQ(
+        std::get<WriteRouteRequestConfig>(p2p_store().getDefaultWriteConfig())
+            .local_write_waterline,
+        0.8);
+
+    // Clamp test
+    Json::Value patch2;
+    patch2["local_write_waterline"] = 2.0;
+    p2p_store().updateWriteConfig(patch2);
+    EXPECT_DOUBLE_EQ(
+        std::get<WriteRouteRequestConfig>(p2p_store().getDefaultWriteConfig())
+            .local_write_waterline,
+        1.0);
+}
+
+TEST_F(RuntimeConfigTest, ValidateWriteConfigRejectsContradiction) {
+    // Use a fresh store to avoid interference from other tests.
+    RuntimeConfigStore store(DeploymentMode::P2P);
+    // waterline=0 + remote_weight=0 is contradictory -> updateWriteConfig
+    // returns false and the config remains unchanged.
+    Json::Value patch;
+    patch["remote_weight"] = 0.0;
+    patch["local_write_waterline"] = 0.0;
+    EXPECT_FALSE(store.updateWriteConfig(patch));
+    const auto& cfg =
+        std::get<WriteRouteRequestConfig>(store.getDefaultWriteConfig());
+    EXPECT_DOUBLE_EQ(cfg.remote_weight, 0.5);
+    EXPECT_DOUBLE_EQ(cfg.local_write_waterline, 0.5);
+}
+
+TEST_F(RuntimeConfigTest, ValidateWriteConfigAllowsValidCombos) {
+    // waterline=0 + remote_weight=0.5 -> OK
+    Json::Value patch;
+    patch["remote_weight"] = 0.5;
+    patch["local_write_waterline"] = 0.0;
+    EXPECT_TRUE(p2p_store().updateWriteConfig(patch));
+    const auto& cfg1 =
+        std::get<WriteRouteRequestConfig>(p2p_store().getDefaultWriteConfig());
+    EXPECT_DOUBLE_EQ(cfg1.remote_weight, 0.5);
+    EXPECT_DOUBLE_EQ(cfg1.local_write_waterline, 0.0);
+
+    // waterline=0.8 + remote_weight=0 -> OK
+    Json::Value patch2;
+    patch2["remote_weight"] = 0.0;
+    patch2["local_write_waterline"] = 0.8;
+    EXPECT_TRUE(p2p_store().updateWriteConfig(patch2));
+    const auto& cfg2 =
+        std::get<WriteRouteRequestConfig>(p2p_store().getDefaultWriteConfig());
+    EXPECT_DOUBLE_EQ(cfg2.remote_weight, 0.0);
+    EXPECT_DOUBLE_EQ(cfg2.local_write_waterline, 0.8);
 }
 
 TEST_F(RuntimeConfigTest, UpdateP2PWriteConfigStrategy) {
@@ -250,7 +326,7 @@ TEST_F(RuntimeConfigTest, UpdateReadConfigP2PExtra) {
 
 TEST_F(RuntimeConfigTest, PatchPreservesUnmentionedFields) {
     Json::Value p1;
-    p1["prefer_local"] = false;
+    p1["remote_weight"] = 0.9;
     p2p_store().updateWriteConfig(p1);
     Json::Value p2;
     p2["max_candidates"] = 7;
@@ -258,7 +334,7 @@ TEST_F(RuntimeConfigTest, PatchPreservesUnmentionedFields) {
 
     auto wc = p2p_store().getDefaultWriteConfig();
     auto& cfg = std::get<WriteRouteRequestConfig>(wc);
-    EXPECT_FALSE(cfg.prefer_local);
+    EXPECT_DOUBLE_EQ(cfg.remote_weight, 0.9);
     EXPECT_EQ(cfg.max_candidates, 7u);
 }
 
@@ -269,14 +345,14 @@ TEST_F(RuntimeConfigTest, PatchPreservesUnmentionedFields) {
 TEST_F(RuntimeConfigTest, LoadFromJsonBothSections) {
     RuntimeConfigStore store(DeploymentMode::P2P);
     Json::Value root;
-    root["write"]["prefer_local"] = false;
+    root["write"]["remote_weight"] = 0.9;
     root["write"]["max_candidates"] = 3;
     root["read"]["max_candidates"] = 8;
     store.loadFromJson(root);
 
     auto wc = store.getDefaultWriteConfig();
     auto& wcfg = std::get<WriteRouteRequestConfig>(wc);
-    EXPECT_FALSE(wcfg.prefer_local);
+    EXPECT_DOUBLE_EQ(wcfg.remote_weight, 0.9);
     EXPECT_EQ(wcfg.max_candidates, 3u);
     EXPECT_EQ(store.getDefaultReadConfig().max_candidates, 8u);
 }
@@ -286,7 +362,7 @@ TEST_F(RuntimeConfigTest, LoadFromJsonNullIsNoOp) {
     store.loadFromJson(Json::Value());
     auto wc = store.getDefaultWriteConfig();
     auto& cfg = std::get<WriteRouteRequestConfig>(wc);
-    EXPECT_TRUE(cfg.prefer_local);
+    EXPECT_DOUBLE_EQ(cfg.remote_weight, 0.5);
     EXPECT_EQ(cfg.max_candidates, 2u);
 }
 
@@ -298,7 +374,8 @@ TEST_F(RuntimeConfigTest, ExportRoundTrip) {
     RuntimeConfigStore s1(DeploymentMode::P2P);
     Json::Value input;
     input["write"]["max_candidates"] = 4;
-    input["write"]["prefer_local"] = false;
+    input["write"]["remote_weight"] = 0.9;
+    input["write"]["local_write_waterline"] = 0.7;
     input["read"]["max_candidates"] = 6;
     s1.loadFromJson(input);
 
@@ -310,7 +387,7 @@ TEST_F(RuntimeConfigTest, ExportRoundTrip) {
     auto& w1 = std::get<WriteRouteRequestConfig>(wc1);
     auto& w2 = std::get<WriteRouteRequestConfig>(wc2);
     EXPECT_EQ(w1.max_candidates, w2.max_candidates);
-    EXPECT_EQ(w1.prefer_local, w2.prefer_local);
+    EXPECT_DOUBLE_EQ(w1.remote_weight, w2.remote_weight);
     EXPECT_EQ(s1.getDefaultReadConfig().max_candidates,
               s2.getDefaultReadConfig().max_candidates);
 }
@@ -331,7 +408,8 @@ TEST_F(RuntimeConfigTest, HttpGetWriteConfig) {
     auto resp = HttpGet(Url("/config/write"));
     ASSERT_EQ(resp.status, 200);
     auto json = ParseJson(resp.body);
-    EXPECT_TRUE(json.isMember("prefer_local"));
+    EXPECT_TRUE(json.isMember("remote_weight"));
+    EXPECT_TRUE(json.isMember("local_write_waterline"));
     EXPECT_TRUE(json.isMember("max_candidates"));
 }
 
@@ -347,10 +425,10 @@ TEST_F(RuntimeConfigTest, HttpGetReadConfig) {
 
 TEST_F(RuntimeConfigTest, HttpUpdateWriteConfig) {
     auto resp = HttpPost(Url("/config/update_write"),
-                         R"({"prefer_local": false, "max_candidates": 5})");
+                         R"({"remote_weight": 0.9, "max_candidates": 5})");
     ASSERT_EQ(resp.status, 200);
     auto json = ParseJson(resp.body);
-    EXPECT_FALSE(json["prefer_local"].asBool());
+    EXPECT_DOUBLE_EQ(json["remote_weight"].asDouble(), 0.9);
     EXPECT_EQ(json["max_candidates"].asUInt64(), 5u);
 
     auto get_json = ParseJson(HttpGet(Url("/config/write")).body);
@@ -452,7 +530,9 @@ TEST_F(RuntimeConfigTest, ApplyPatchIgnoresWrongTypes) {
 
     Json::Value bad;
     bad["max_candidates"] = "not_a_number";
-    bad["prefer_local"] = 123;
+    bad["remote_weight"] = "not_a_number";
+    bad["local_write_waterline"] = "not_a_number";
+    bad["top_tier_only"] = 123;
     bad["strategy"] = Json::Value(Json::arrayValue);
     bad["tag_filters"] = false;
     bad["priority_limit"] = Json::Value(Json::objectValue);
@@ -461,7 +541,9 @@ TEST_F(RuntimeConfigTest, ApplyPatchIgnoresWrongTypes) {
     auto wc = store.getDefaultWriteConfig();
     auto& cfg = std::get<WriteRouteRequestConfig>(wc);
     EXPECT_EQ(cfg.max_candidates, 2u);
-    EXPECT_TRUE(cfg.prefer_local);
+    EXPECT_DOUBLE_EQ(cfg.remote_weight, 0.5);
+    EXPECT_DOUBLE_EQ(cfg.local_write_waterline, 0.5);
+    EXPECT_TRUE(cfg.top_tier_only);
     EXPECT_EQ(cfg.strategy, ObjectIterateStrategy::CAPACITY_PRIORITY);
     EXPECT_TRUE(cfg.tag_filters.empty());
     EXPECT_EQ(cfg.priority_limit, 0);
@@ -489,15 +571,16 @@ TEST_F(RuntimeConfigTest, ApplyPatchIgnoresWrongTypesCentralized) {
 
 TEST_F(RuntimeConfigTest, HttpUpdateWriteConfigWrongTypesNoEffect) {
     HttpPost(Url("/config/update_write"),
-             R"({"max_candidates": 10, "prefer_local": true})");
+             R"({"max_candidates": 10, "remote_weight": 0.9})");
 
-    auto resp = HttpPost(Url("/config/update_write"),
-                         R"({"max_candidates": "bad", "prefer_local": 999})");
+    auto resp =
+        HttpPost(Url("/config/update_write"),
+                 R"({"max_candidates": "bad", "remote_weight": "bad"})");
     ASSERT_EQ(resp.status, 200);
 
     auto json = ParseJson(HttpGet(Url("/config/write")).body);
     EXPECT_EQ(json["max_candidates"].asUInt64(), 10u);
-    EXPECT_TRUE(json["prefer_local"].asBool());
+    EXPECT_DOUBLE_EQ(json["remote_weight"].asDouble(), 0.9);
 }
 
 // ============================================================================
@@ -603,12 +686,12 @@ TEST_F(RuntimeConfigTest, HttpUpdateFullNumberBody) {
 // ============================================================================
 
 TEST_F(RuntimeConfigTest, HttpSetPrimitiveBool) {
-    HttpPost(Url("/config/update_write"), R"({"allow_local": true})");
+    HttpPost(Url("/config/update_write"), R"({"top_tier_only": false})");
     auto resp =
-        HttpPost(Url("/config/set", "section=write&key=allow_local"), "false");
+        HttpPost(Url("/config/set", "section=write&key=top_tier_only"), "true");
     ASSERT_EQ(resp.status, 200);
     auto json = ParseJson(HttpGet(Url("/config/write")).body);
-    EXPECT_FALSE(json["allow_local"].asBool());
+    EXPECT_TRUE(json["top_tier_only"].asBool());
 }
 
 TEST_F(RuntimeConfigTest, HttpSetPrimitiveInt) {
@@ -617,6 +700,30 @@ TEST_F(RuntimeConfigTest, HttpSetPrimitiveInt) {
     ASSERT_EQ(resp.status, 200);
     auto json = ParseJson(HttpGet(Url("/config/write")).body);
     EXPECT_EQ(json["max_candidates"].asUInt64(), 7u);
+}
+
+TEST_F(RuntimeConfigTest, HttpUpdateWriteConfigRejectsInvalid) {
+    // POST /config/update_write with contradictory config -> 400
+    auto resp =
+        HttpPost(Url("/config/update_write"),
+                 R"({"remote_weight": 0.0, "local_write_waterline": 0.0})");
+    EXPECT_EQ(resp.status, 400);
+}
+
+TEST_F(RuntimeConfigTest, HttpSetRejectsInvalid) {
+    // Default waterline=0.5, so setting remote_weight=0 alone is valid.
+    // Then setting waterline=0 while remote_weight=0 is contradictory -> 400.
+    // First ensure waterline is 0.5 (already the default, but be explicit).
+    HttpPost(Url("/config/set", "section=write&key=local_write_waterline"),
+             "0.5");
+    // remote_weight=0 is valid because waterline=0.5 > 0.
+    auto ok =
+        HttpPost(Url("/config/set", "section=write&key=remote_weight"), "0.0");
+    EXPECT_EQ(ok.status, 200);
+    // Now try to set waterline=0 while remote_weight=0 -> 400
+    auto bad = HttpPost(
+        Url("/config/set", "section=write&key=local_write_waterline"), "0.0");
+    EXPECT_EQ(bad.status, 400);
 }
 
 }  // namespace testing

--- a/mooncake-store/tests/runtime_config_store_test.cpp
+++ b/mooncake-store/tests/runtime_config_store_test.cpp
@@ -234,12 +234,22 @@ TEST_F(RuntimeConfigTest, UpdateP2PWriteConfigLocalWriteWaterline) {
 TEST_F(RuntimeConfigTest, ValidateWriteConfigRejectsContradiction) {
     // Use a fresh store to avoid interference from other tests.
     RuntimeConfigStore store(DeploymentMode::P2P);
-    // waterline=0 + remote_weight=0 is contradictory -> updateWriteConfig
-    // returns false and the config remains unchanged.
-    Json::Value patch;
-    patch["remote_weight"] = 0.0;
-    patch["local_write_waterline"] = 0.0;
-    EXPECT_FALSE(store.updateWriteConfig(patch));
+    // Contradiction 1: waterline=0 (forbid local write) + remote_weight=0
+    // (forbid remote routing) -> dead end.
+    {
+        Json::Value patch;
+        patch["remote_weight"] = 0.0;
+        patch["local_write_waterline"] = 0.0;
+        EXPECT_FALSE(store.updateWriteConfig(patch));
+    }
+    // Contradiction 2: waterline=1 (forbid remote write) + remote_weight=1
+    // (forbid local routing) -> dead end (defensive).
+    {
+        Json::Value patch;
+        patch["remote_weight"] = 1.0;
+        patch["local_write_waterline"] = 1.0;
+        EXPECT_FALSE(store.updateWriteConfig(patch));
+    }
     const auto& cfg =
         std::get<WriteRouteRequestConfig>(store.getDefaultWriteConfig());
     EXPECT_DOUBLE_EQ(cfg.remote_weight, 0.5);
@@ -247,7 +257,7 @@ TEST_F(RuntimeConfigTest, ValidateWriteConfigRejectsContradiction) {
 }
 
 TEST_F(RuntimeConfigTest, ValidateWriteConfigAllowsValidCombos) {
-    // waterline=0 + remote_weight=0.5 -> OK
+    // waterline=0 + remote_weight=0.5 -> OK (waterline disabled)
     Json::Value patch;
     patch["remote_weight"] = 0.5;
     patch["local_write_waterline"] = 0.0;
@@ -266,6 +276,28 @@ TEST_F(RuntimeConfigTest, ValidateWriteConfigAllowsValidCombos) {
         std::get<WriteRouteRequestConfig>(p2p_store().getDefaultWriteConfig());
     EXPECT_DOUBLE_EQ(cfg2.remote_weight, 0.0);
     EXPECT_DOUBLE_EQ(cfg2.local_write_waterline, 0.8);
+
+    // waterline=0 + remote_weight=1 -> OK (forbid local write + forbid local
+    // route = force remote from both sides)
+    Json::Value patch3;
+    patch3["remote_weight"] = 1.0;
+    patch3["local_write_waterline"] = 0.0;
+    EXPECT_TRUE(p2p_store().updateWriteConfig(patch3));
+    const auto& cfg3 =
+        std::get<WriteRouteRequestConfig>(p2p_store().getDefaultWriteConfig());
+    EXPECT_DOUBLE_EQ(cfg3.remote_weight, 1.0);
+    EXPECT_DOUBLE_EQ(cfg3.local_write_waterline, 0.0);
+
+    // waterline=1 + remote_weight=0 -> OK (forbid remote write + forbid
+    // remote route = force local from both sides)
+    Json::Value patch4;
+    patch4["remote_weight"] = 0.0;
+    patch4["local_write_waterline"] = 1.0;
+    EXPECT_TRUE(p2p_store().updateWriteConfig(patch4));
+    const auto& cfg4 =
+        std::get<WriteRouteRequestConfig>(p2p_store().getDefaultWriteConfig());
+    EXPECT_DOUBLE_EQ(cfg4.remote_weight, 0.0);
+    EXPECT_DOUBLE_EQ(cfg4.local_write_waterline, 1.0);
 }
 
 TEST_F(RuntimeConfigTest, UpdateP2PWriteConfigStrategy) {
@@ -712,11 +744,11 @@ TEST_F(RuntimeConfigTest, HttpUpdateWriteConfigRejectsInvalid) {
 
 TEST_F(RuntimeConfigTest, HttpSetRejectsInvalid) {
     // Default waterline=0.5, so setting remote_weight=0 alone is valid.
-    // Then setting waterline=0 while remote_weight=0 is contradictory -> 400.
-    // First ensure waterline is 0.5 (already the default, but be explicit).
-    HttpPost(Url("/config/set", "section=write&key=local_write_waterline"),
-             "0.5");
-    // remote_weight=0 is valid because waterline=0.5 > 0.
+    // Then setting waterline=0 while remote_weight=0 is contradictory
+    // (forbid local write + forbid remote route = dead end) -> 400.
+    // First ensure remote_weight is 0.5 (already the default, but be explicit).
+    HttpPost(Url("/config/set", "section=write&key=remote_weight"), "0.5");
+    // remote_weight=0 is valid because waterline=0.5 > 0 (not an extreme).
     auto ok =
         HttpPost(Url("/config/set", "section=write&key=remote_weight"), "0.0");
     EXPECT_EQ(ok.status, 200);

--- a/mooncake-store/tests/test_p2p_server_helpers.h
+++ b/mooncake-store/tests/test_p2p_server_helpers.h
@@ -51,7 +51,7 @@ class InProcP2PMaster {
             wms_cfg.cluster_id = DEFAULT_CLUSTER_ID;
             wms_cfg.root_fs_dir = DEFAULT_ROOT_FS_DIR;
             wms_cfg.memory_allocator = BufferAllocatorType::OFFSET;
-            wms_cfg.max_replicas_per_key = 0;  // no limit for P2P
+            wms_cfg.max_client_per_key = 0;  // no limit for P2P
 
             if (config.client_live_ttl_sec.has_value()) {
                 wms_cfg.client_live_ttl_sec =


### PR DESCRIPTION
## Description

Replaces the boolean allow_local / prefer_local write-route config with a continuous remote_weight ∈ [0, 1] parameter and a new local_write_waterline threshold. Refactors write-route granularity from segment-level to client-level, simplifies the master routing path into a single linear pass, and adds config validation with HTTP 400 error propagation.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

<!-- Describe the tests you've run. Include commands and output if applicable. -->

**Test commands:**
```bash
# Example: bash scripts/run_ci_test.sh
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

<!-- If AI tools were used, please disclose. This helps reviewers focus attention. -->

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

<!-- If AI tools were used, briefly describe which tool and what it helped with.
     The human submitter is responsible for understanding and defending all changes. -->
