### PR TITLE
[Wheel] Bump version to 0.3.12 on release branch

### DIFF
--- a/mooncake-wheel/pyproject.toml
+++ b/mooncake-wheel/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mooncake-transfer-engine"
-version = "0.3.11.post1"
+version = "0.3.12"
 description = "A KVCache-centric Disaggregated Architecture for large-scale LLM inference and training."
 authors = [
     { name = "Mooncake Authors" }


### PR DESCRIPTION
## Description

Cherry-picks the pyproject version bump from #3081 onto `release/v0.3.12`.

This updates `mooncake-wheel/pyproject.toml` from `0.3.11.post1` to `0.3.12` so artifacts built from the release branch carry the intended release version.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [x] Other: release version synchronization

## How Has This Been Tested?

**Test commands:**
```bash
pre-commit run --files mooncake-wheel/pyproject.toml
python -c 'import tomli, pathlib; p=tomli.loads(pathlib.Path("mooncake-wheel/pyproject.toml").read_text()); assert p["project"]["version"] == "0.3.12"'
```

**Test results:**
- [x] Targeted pre-commit hooks pass
- [x] TOML parsing and version assertion pass
- [ ] Integration tests pass (not applicable for a metadata-only change)

## Checklist

- [x] I have performed a self-review of the changed line
- [x] I have formatted the touched file with the repository pre-commit hooks
- [x] I have run `pre-commit run --files mooncake-wheel/pyproject.toml` and all applicable hooks pass
- [x] Documentation is not applicable to this metadata-only change
- [x] Additional tests are not applicable to this one-line version synchronization
- [x] RFC is not applicable (1-line change)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (Codex identified and cherry-picked the upstream version commit, ran validation, and prepared this PR)

The human submitter should review the changed line before marking this draft ready for review.