### PR TITLE
[CI/Build] Fix Go setup in MUSA release workflow

### DIFF
--- a/.github/workflows/release-musa.yaml
+++ b/.github/workflows/release-musa.yaml
@@ -38,6 +38,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.25.9'
+          cache: false
+
       - name: Set Python bin
         shell: bash
         run: |
@@ -54,9 +60,21 @@ jobs:
           export PYTHONPATH="${PYTHONPATH:-}"
           export CMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH:-}"
           bash -x dependencies.sh -y
-          echo "PATH=/usr/local/go/bin:/usr/local/musa/bin:${PATH}" >> "$GITHUB_ENV"
+          echo "PATH=/usr/local/musa/bin:${PATH}" >> "$GITHUB_ENV"
           echo "LD_LIBRARY_PATH=/usr/local/musa/lib:${LD_LIBRARY_PATH:-}" >> "$GITHUB_ENV"
           echo "LIBRARY_PATH=/usr/local/musa/lib:${LIBRARY_PATH:-}" >> "$GITHUB_ENV"
+
+      - name: Verify Go toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          GO_BIN="$(command -v go || true)"
+          if [[ -z "${GO_BIN}" ]]; then
+            echo "::error::Go is not available on PATH"
+            exit 1
+          fi
+          echo "Go executable: ${GO_BIN}"
+          "${GO_BIN}" version
 
       - name: Configure project
         shell: bash


### PR DESCRIPTION
## Description

Backport the MUSA release workflow Go toolchain fix to `release/v0.3.12`. The corresponding PR against `main` is #3086.

The v0.3.12 release workflow downloaded Go through `dependencies.sh`, but that script only persisted `/usr/local/go/bin` through `.bashrc`. GitHub Actions build steps did not source `.bashrc`, so `cmake --build` failed with `go: command not found` while producing `libetcd_wrapper.so` ([failed run](https://github.com/kvcache-ai/Mooncake/actions/runs/30011000748/attempts/5)).

This change:

- provisions Go 1.25.9 explicitly with `actions/setup-go@v6`;
- keeps the setup action's job-wide Go `PATH` instead of preferring `/usr/local/go/bin`;
- verifies and prints the resolved Go executable and version before CMake configuration;
- fails early with a clear workflow error when Go is unavailable.

The MUSA build flags, wheel naming, artifact upload, GitHub Release upload, and PyPI publishing behavior are unchanged. The backport branch was created directly from `release/v0.3.12` and contains only this fix.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
pre-commit run --files .github/workflows/release-musa.yaml
git diff --check origin/release/v0.3.12...HEAD
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (described below)

All applicable pre-commit hooks passed, including `check-yaml`, the Mooncake formatting script, and `codespell`. `git diff --check` passed. The backport diff contains only `.github/workflows/release-musa.yaml`. `actionlint` and a full local reproduction of the MUSA release container were unavailable.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex prepared the clean release-branch backport, verified its scope, and ran the validations listed above. The human submitter reviewed every changed line and confirmed the change before publication.