### PR TITLE
[CI/Build] Allow manual MUSA release runs

### DIFF
--- a/.github/workflows/release-musa.yaml
+++ b/.github/workflows/release-musa.yaml
@@ -4,10 +4,16 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing release tag to upload to (e.g. v0.3.12)'
+        required: true
+        type: string
 
 jobs:
   build:
-    if: ${{ !contains(github.ref_name, '-') }}
+    if: ${{ github.event_name == 'workflow_dispatch' || !contains(github.ref_name, '-') }}
     runs-on: ubuntu-22.04
     container: registry.mthreads.com/mcconline/inference/pytorch:2.9.1.post1-py3.10-musa5.2.0-mp31-devel-ubuntu22.04-amd64
 
@@ -32,6 +38,20 @@ jobs:
       - name: Mark repository as safe
         shell: bash
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Validate manual release target
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_REF_NAME}" != "release/${RELEASE_TAG}" ]]; then
+            echo "::error::Run this workflow from release/${RELEASE_TAG}"
+            exit 1
+          fi
+          git check-ref-format "refs/tags/${RELEASE_TAG}"
+          git rev-parse --verify "refs/tags/${RELEASE_TAG}^{commit}"
 
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -141,7 +161,7 @@ jobs:
           path: mooncake-wheel/dist-musa-py${{ steps.generate_tag_release.outputs.python_version_tag }}/*.whl
 
   publish-release:
-    if: ${{ !contains(github.ref_name, '-') }}
+    if: ${{ github.event_name == 'workflow_dispatch' || !contains(github.ref_name, '-') }}
     needs: build
     runs-on: ubuntu-22.04
     environment: pypi
@@ -170,6 +190,7 @@ jobs:
       - name: Upload wheels to GitHub Release
         uses: softprops/action-gh-release@v1
         with:
+          tag_name: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
           files: mooncake-wheel/dist-release/*.whl
 
       - name: Publish package to PyPI


### PR DESCRIPTION
## Description

Add a guarded manual trigger to the MUSA release workflow on `release/v0.3.12`, following the Go toolchain fix merged in #3087.

This change allows a MUSA-only recovery run to build from a selected release branch while uploading the resulting wheel to an existing release tag. For a manual run, the workflow:

- requires an existing target tag such as `v0.3.12`;
- verifies that the selected workflow branch is the matching `release/<tag>` branch;
- verifies that the target tag exists before starting the build;
- passes the target tag explicitly to `softprops/action-gh-release`;
- preserves the existing `v*` tag-triggered release behavior.

The branch/tag distinction is intentional: the build must use the repaired `release/v0.3.12` branch, because the existing `v0.3.12` tag points to the pre-fix commit, while the artifacts still need to be attached to the existing `v0.3.12` GitHub Release.

**Default-branch prerequisite:** GitHub only exposes and accepts `workflow_dispatch` when the workflow supports it on the default branch. This PR prepares `release/v0.3.12`; an equivalent trigger must also be merged into `main` before the workflow can be manually dispatched from the Actions UI or API.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
pre-commit run --files .github/workflows/release-musa.yaml
git diff --check
GITHUB_REF_NAME=release/v0.3.12 RELEASE_TAG=v0.3.12 bash -euo pipefail -c '<manual target validation commands>'
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (described below)

All applicable pre-commit hooks passed, including `check-yaml`, the Mooncake formatting script, and `codespell`. `git diff --check` passed. The manual branch/tag validation resolved the existing `v0.3.12` tag successfully. The final diff contains only `.github/workflows/release-musa.yaml`. `actionlint` and a full MUSA container release were unavailable locally.

## Checklist

- [ ] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex implemented the guarded manual release path, checked GitHub's `workflow_dispatch` default-branch requirements, and ran the validations listed above. The human submitter must review every changed line and be able to defend the change before marking this draft ready for review.