### PR TITLE
[CI/Build] Add MUSA release backfill workflow

### DIFF
--- a/.github/workflows/release-musa.yaml
+++ b/.github/workflows/release-musa.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/heads/release/{0}', inputs.tag) || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
           fetch-depth: 0
 
       - name: Mark repository as safe
@@ -57,8 +57,12 @@ jobs:
           fi
           git check-ref-format "refs/tags/${RELEASE_TAG}"
           TAG_SHA="$(git rev-parse --verify "refs/tags/${RELEASE_TAG}^{commit}")"
-          echo "Build source: release/${RELEASE_TAG} at $(git rev-parse HEAD)"
-          echo "Release tag: ${RELEASE_TAG} at ${TAG_SHA}"
+          BUILD_SHA="$(git rev-parse HEAD)"
+          if [[ "${BUILD_SHA}" != "${TAG_SHA}" ]]; then
+            echo "::error::Build source ${BUILD_SHA} does not match ${RELEASE_TAG} at ${TAG_SHA}"
+            exit 1
+          fi
+          echo "Build source: ${RELEASE_TAG} at ${BUILD_SHA}"
 
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -163,7 +167,7 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/heads/release/{0}', inputs.tag) || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
 
       - name: Download all wheel artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/release-musa.yaml
+++ b/.github/workflows/release-musa.yaml
@@ -4,10 +4,20 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing release tag to backfill (e.g. v0.3.12)'
+        required: true
+        type: string
+
+concurrency:
+  group: release-musa-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+  cancel-in-progress: false
 
 jobs:
   build:
-    if: ${{ !contains(github.ref_name, '-') }}
+    if: ${{ github.event_name == 'workflow_dispatch' || !contains(github.ref_name, '-') }}
     runs-on: ubuntu-22.04
     container: registry.mthreads.com/mcconline/inference/pytorch:2.9.1.post1-py3.10-musa5.2.0-mp31-devel-ubuntu22.04-amd64
 
@@ -27,11 +37,28 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/heads/release/{0}', inputs.tag) || github.ref }}
           fetch-depth: 0
 
       - name: Mark repository as safe
         shell: bash
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Validate backfill target
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [[ "${RELEASE_TAG}" != v* || "${RELEASE_TAG}" == *-* ]]; then
+            echo "::error::Backfill tag must be a stable release tag starting with v"
+            exit 1
+          fi
+          git check-ref-format "refs/tags/${RELEASE_TAG}"
+          TAG_SHA="$(git rev-parse --verify "refs/tags/${RELEASE_TAG}^{commit}")"
+          echo "Build source: release/${RELEASE_TAG} at $(git rev-parse HEAD)"
+          echo "Release tag: ${RELEASE_TAG} at ${TAG_SHA}"
 
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -123,7 +150,7 @@ jobs:
           path: mooncake-wheel/dist-musa-py${{ steps.generate_tag_release.outputs.python_version_tag }}/*.whl
 
   publish-release:
-    if: ${{ !contains(github.ref_name, '-') }}
+    if: ${{ github.event_name == 'workflow_dispatch' || !contains(github.ref_name, '-') }}
     needs: build
     runs-on: ubuntu-22.04
     environment: pypi
@@ -135,6 +162,8 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/heads/release/{0}', inputs.tag) || github.ref }}
 
       - name: Download all wheel artifacts
         uses: actions/download-artifact@v4
@@ -152,6 +181,7 @@ jobs:
       - name: Upload wheels to GitHub Release
         uses: softprops/action-gh-release@v1
         with:
+          tag_name: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
           files: mooncake-wheel/dist-release/*.whl
 
       - name: Publish package to PyPI


### PR DESCRIPTION
## Description

Add a guarded manual backfill path to the MUSA release workflow on the default branch.

This supports recovery when a released version is missing only its MUSA wheel. A maintainer can manually run the workflow from `main` with a tag such as `v0.3.12`; the workflow definition comes from `main`, while `actions/checkout` builds the exact tagged source from `refs/tags/v0.3.12` and uploads the resulting wheel to the existing `v0.3.12` GitHub Release and PyPI version.

The workflow:

- accepts an existing stable release tag through `workflow_dispatch`;
- checks out the exact target tag for both build and publish jobs;
- validates that the target tag is a stable `v*` tag and already exists;
- verifies that the checked-out build SHA exactly matches the tag commit;
- explicitly passes the target tag to `softprops/action-gh-release`;
- serializes runs per tag so duplicate backfills cannot run concurrently;
- preserves the existing `v*` tag-triggered release behavior.

This intentionally does not move or recreate the existing tag. The default-branch workflow supplies release tooling fixes while the wheel remains reproducible from the original tagged source.

**Dependency:** #3086 should merge first so the default-branch workflow includes the explicit Go setup required by the MUSA build. The two PRs are independent and do not duplicate commits.

Supersedes the closed release-branch approach in #3091.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
pre-commit run --files .github/workflows/release-musa.yaml
git diff --check
RELEASE_TAG=v0.3.12 bash -euo pipefail -c '<tag and build SHA validation commands>'
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (described below)

All applicable pre-commit hooks passed, including `check-yaml`, the Mooncake formatting script, and `codespell`. `git diff --check` passed. The target validation resolved the existing `v0.3.12` tag and verified build/tag SHA equality successfully. The final diff contains only `.github/workflows/release-musa.yaml`. `actionlint` and a full MUSA container release were unavailable locally.

## Checklist

- [ ] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex implemented the guarded default-branch backfill flow, incorporated Qoder's reproducibility feedback, and ran the validations listed above. The human submitter must review every changed line and be able to defend the change before merge.