### PR TITLE
[CI/Build] Add ARM64 Non-CUDA release wheels

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -41,6 +41,20 @@ jobs:
         -DSTORE_USE_ETCD=ON -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Release
       artifact-prefix: mooncake-wheel-non-cuda-pre-release
 
+  build-non-cuda-arm64:
+    uses: ./.github/workflows/_build-wheel.yaml
+    with:
+      runner: ubuntu-22.04-arm
+      container: pytorch/manylinuxaarch64-builder:cuda12.8
+      cuda: container
+      cmake-generator: Ninja
+      variant-flag: NON_CUDA_BUILD
+      cmake-args: >-
+        -DBUILD_UNIT_TESTS=OFF -DUSE_HTTP=ON -DUSE_ETCD=ON -DUSE_CUDA=OFF -DWITH_EP=OFF
+        -DSTORE_USE_ETCD=ON -DWITH_STORE_RUST=OFF -DENABLE_SCCACHE=ON
+        -DCMAKE_BUILD_TYPE=Release
+      artifact-prefix: mooncake-wheel-non-cuda-arm64-pre-release
+
   build-cuda13:
     uses: ./.github/workflows/_build-wheel.yaml
     with:
@@ -85,7 +99,13 @@ jobs:
 
   validate-release:
     name: Validate release artifacts
-    needs: [build-cuda, build-non-cuda, build-cuda13, build-cuda-arm64, build-cuda13-arm64]
+    needs:
+      - build-cuda
+      - build-non-cuda
+      - build-non-cuda-arm64
+      - build-cuda13
+      - build-cuda-arm64
+      - build-cuda13-arm64
     runs-on: ubuntu-22.04
     permissions:
       contents: read
@@ -108,8 +128,8 @@ jobs:
           ls -la mooncake-wheel/dist-release/
           wheel_count=$(find mooncake-wheel/dist-release -name "*.whl" | wc -l)
           echo "wheel_count=${wheel_count}" >> "$GITHUB_ENV"
-          if [ "${wheel_count}" -lt 20 ]; then
-            echo "Expected at least 20 wheels (x86: 4 Python versions x 3 variants; arm64: 4 Python versions x 2 CUDA variants), found ${wheel_count}"
+          if [ "${wheel_count}" -lt 24 ]; then
+            echo "Expected at least 24 wheels (4 Python versions x 3 variants x 2 architectures), found ${wheel_count}"
             exit 1
           fi
 

--- a/.github/workflows/release-non-cuda.yaml
+++ b/.github/workflows/release-non-cuda.yaml
@@ -9,6 +9,7 @@ jobs:
   # manylinux2_28 for the toolchain only (USE_CUDA=OFF); keeps the glibc floor
   # aligned with the CUDA wheels.
   build:
+    if: ${{ !contains(github.ref_name, '-') }}
     uses: ./.github/workflows/_build-wheel.yaml
     with:
       runner: ubuntu-22.04
@@ -20,14 +21,29 @@ jobs:
         -DSTORE_USE_ETCD=ON -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Release
       artifact-prefix: mooncake-wheel-non-cuda
 
+  build-arm64:
+    if: ${{ !contains(github.ref_name, '-') }}
+    uses: ./.github/workflows/_build-wheel.yaml
+    with:
+      runner: ubuntu-22.04-arm
+      container: pytorch/manylinuxaarch64-builder:cuda12.8
+      cuda: container
+      cmake-generator: Ninja
+      variant-flag: NON_CUDA_BUILD
+      cmake-args: >-
+        -DBUILD_UNIT_TESTS=OFF -DUSE_HTTP=ON -DUSE_ETCD=ON -DUSE_CUDA=OFF -DWITH_EP=OFF
+        -DSTORE_USE_ETCD=ON -DWITH_STORE_RUST=OFF -DENABLE_SCCACHE=ON
+        -DCMAKE_BUILD_TYPE=Release
+      artifact-prefix: mooncake-wheel-non-cuda-arm64
+
   publish-release:
     if: ${{ !contains(github.ref_name, '-') }}
-    needs: build
+    needs: [build, build-arm64]
     permissions:
       contents: write
       id-token: write
     uses: ./.github/workflows/_publish-wheel.yaml
     with:
-      artifact-pattern: 'mooncake-wheel-non-cuda*'
+      artifact-pattern: 'mooncake-wheel-non-cuda-*'
     secrets:
       pypi-token: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Description

Add ARM64/aarch64 release support for the `mooncake-transfer-engine-non-cuda` Python wheels.

- Add production and pre-release ARM64 Non-CUDA jobs through the existing `_build-wheel.yaml` reusable workflow.
- Use `ubuntu-22.04-arm`, `pytorch/manylinuxaarch64-builder:cuda12.8`, Ninja, and the `NON_CUDA_BUILD` variant.
- Preserve HTTP, transfer-engine etcd, and Store etcd support while keeping `USE_CUDA=OFF` and `WITH_EP=OFF`.
- Disable only the ARM Rust Store bindings with `WITH_STORE_RUST=OFF` because of the known ARM link-ordering issue; fixing Rust bindings is outside this PR.
- Make production publishing wait for both architectures and use a Non-CUDA-specific artifact pattern.
- Skip both production Non-CUDA build jobs for pre-release tags, which are handled by `pre-release.yaml`.
- Make pre-release validation require the new ARM64 artifacts and raise the expected wheel minimum from 20 to 24.

No open issue or PR specifically implementing ARM64 Non-CUDA wheels was found before opening this PR. #2858 is indirectly related because it reports pip falling back to broken legacy sdists when no compatible wheel is available; this change expands ARM wheel coverage but does not fix or remove those stale sdists. The manylinux ARM job follows the architecture/container pattern established by #2968.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

The changed workflows were parsed as YAML, pre-commit passed on both touched files, and the final diff passed Git whitespace validation. A real ARM wheel build was not run locally because this checkout does not provide an ARM runner; the new pre-release job is the runtime validation path before a production tag.

**Test commands:**
```bash
python3 -c 'import pathlib, yaml; paths=[pathlib.Path(".github/workflows/release-non-cuda.yaml"), pathlib.Path(".github/workflows/pre-release.yaml")]; [yaml.safe_load(path.read_text()) for path in paths]'
pre-commit run --files .github/workflows/release-non-cuda.yaml .github/workflows/pre-release.yaml
git diff --check
```

**Test results:**
- [ ] Unit tests pass (not applicable; workflow-only change)
- [ ] Integration tests pass (requires an ARM pre-release workflow run)
- [ ] Manual testing done (no local ARM build was available)

## Checklist

- [ ] I have performed a self-review of my own code (human submitter review required before marking ready)
- [x] I have formatted my code using `./scripts/code_format.sh` (run by pre-commit)
- [ ] I have run `pre-commit run --all-files` and all hooks pass (scoped touched-file run passed)
- [ ] I have updated the documentation (not applicable; no existing support statement became false)
- [ ] I have added tests to prove my changes are effective (not applicable; validation requires an ARM workflow run)
- [ ] For changes >500 LOC: I have filed an RFC issue (not applicable; 41 insertions / 5 deletions)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

OpenAI Codex inspected repository history and policies, implemented the workflow and guard changes, ran validation, and prepared this draft PR. The human submitter must review every changed line and be able to defend the change end-to-end before marking the PR ready.