### PR TITLE
[Doc] Add MUSA and EFA package badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,21 +9,25 @@
   | <a href="https://kvcache-ai.github.io/Mooncake/" target="_blank"><strong>Documentation</strong></a>
   | <a href="https://kvcache.ai/" target="_blank"><strong>Blog</strong></a>
   | <a href="https://join.slack.com/t/mooncake-project/shared_invite/zt-3qx4x35ea-zSSTqTHItHJs9SCoXLOSPA" target="_blank"><strong>Slack</strong></a>
+  | <a href="https://deepwiki.com/kvcache-ai/Mooncake" target="_blank"><strong>DeepWiki</strong></a>
   <br />
-  <br />
-
-  [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/kvcache-ai/Mooncake)
-  [![PyPI - Downloads](https://static.pepy.tech/badge/mooncake-transfer-engine?period=month)](https://pypi.org/project/mooncake-transfer-engine)
-  [![GitHub commit activity](https://img.shields.io/github/commit-activity/w/kvcache-ai/Mooncake)](https://github.com/kvcache-ai/Mooncake/graphs/commit-activity)
-  [![license](https://img.shields.io/github/license/kvcache-ai/mooncake.svg)](https://github.com/kvcache-ai/Mooncake/blob/main/LICENSE-APACHE)
-  [![Docker](https://img.shields.io/docker/v/kvcacheai/mooncake?label=docker&logo=docker&logoColor=white&color=2496ED)](https://hub.docker.com/r/kvcacheai/mooncake)
   <br />
 
   [![PyPI](https://img.shields.io/pypi/v/mooncake-transfer-engine)](https://pypi.org/project/mooncake-transfer-engine)
+  [![PyPI - Downloads](https://static.pepy.tech/badge/mooncake-transfer-engine?period=month)](https://pypi.org/project/mooncake-transfer-engine)
+  [![license](https://img.shields.io/github/license/kvcache-ai/mooncake.svg)](https://github.com/kvcache-ai/Mooncake/blob/main/LICENSE-APACHE)
+  [![Docker Hub](https://img.shields.io/badge/docker-hub-2496ED?logo=docker&logoColor=white)](https://hub.docker.com/r/kvcacheai/mooncake)
+  <br />
+
   [![PyPI CUDA <=12.9](https://img.shields.io/static/v1?label=pypi&message=CUDA%20%3C%3D12.9&color=76B900)](https://pypi.org/project/mooncake-transfer-engine)
   [![PyPI CUDA 13.0/13.1](https://img.shields.io/static/v1?label=pypi&message=CUDA%2013.0%2F13.1&color=76B900)](https://pypi.org/project/mooncake-transfer-engine-cuda13)
-  [![PyPI Non-CUDA](https://img.shields.io/static/v1?label=pypi&message=non-CUDA&color=00BFFF)](https://pypi.org/project/mooncake-transfer-engine-non-cuda/)
+  [![PyPI MUSA](https://img.shields.io/static/v1?label=pypi&message=MUSA&color=E4002B)](https://pypi.org/project/mooncake-transfer-engine-musa/)
   [![PyPI NPU](https://img.shields.io/static/v1?label=pypi&message=NPU&color=F87171)](https://pypi.org/project/mooncake-transfer-engine-npu/)
+  <br />
+
+  [![PyPI Non-CUDA](https://img.shields.io/static/v1?label=pypi&message=non-CUDA&color=00BFFF)](https://pypi.org/project/mooncake-transfer-engine-non-cuda/)
+  [![PyPI EFA CUDA](https://img.shields.io/static/v1?label=pypi&message=EFA%20%2B%20CUDA&color=FF9900)](https://pypi.org/project/mooncake-transfer-engine-efa/)
+  [![PyPI EFA Non-CUDA](https://img.shields.io/static/v1?label=pypi&message=EFA%20non-CUDA&color=FF9900)](https://pypi.org/project/mooncake-transfer-engine-efa-non-cuda/)
 </div>
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -9,23 +9,21 @@
   | <a href="https://kvcache-ai.github.io/Mooncake/" target="_blank"><strong>Documentation</strong></a>
   | <a href="https://kvcache.ai/" target="_blank"><strong>Blog</strong></a>
   | <a href="https://join.slack.com/t/mooncake-project/shared_invite/zt-3qx4x35ea-zSSTqTHItHJs9SCoXLOSPA" target="_blank"><strong>Slack</strong></a>
-  | <a href="https://deepwiki.com/kvcache-ai/Mooncake" target="_blank"><strong>DeepWiki</strong></a>
   <br />
   <br />
 
-  [![PyPI](https://img.shields.io/pypi/v/mooncake-transfer-engine)](https://pypi.org/project/mooncake-transfer-engine)
+  [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/kvcache-ai/Mooncake)
   [![PyPI - Downloads](https://static.pepy.tech/badge/mooncake-transfer-engine?period=month)](https://pypi.org/project/mooncake-transfer-engine)
   [![license](https://img.shields.io/github/license/kvcache-ai/mooncake.svg)](https://github.com/kvcache-ai/Mooncake/blob/main/LICENSE-APACHE)
   [![Docker Hub](https://img.shields.io/badge/docker-hub-2496ED?logo=docker&logoColor=white)](https://hub.docker.com/r/kvcacheai/mooncake)
   <br />
 
+  [![PyPI](https://img.shields.io/pypi/v/mooncake-transfer-engine)](https://pypi.org/project/mooncake-transfer-engine)
   [![PyPI CUDA <=12.9](https://img.shields.io/static/v1?label=pypi&message=CUDA%20%3C%3D12.9&color=76B900)](https://pypi.org/project/mooncake-transfer-engine)
   [![PyPI CUDA 13.0/13.1](https://img.shields.io/static/v1?label=pypi&message=CUDA%2013.0%2F13.1&color=76B900)](https://pypi.org/project/mooncake-transfer-engine-cuda13)
-  [![PyPI MUSA](https://img.shields.io/static/v1?label=pypi&message=MUSA&color=E4002B)](https://pypi.org/project/mooncake-transfer-engine-musa/)
-  [![PyPI NPU](https://img.shields.io/static/v1?label=pypi&message=NPU&color=F87171)](https://pypi.org/project/mooncake-transfer-engine-npu/)
-  <br />
-
   [![PyPI Non-CUDA](https://img.shields.io/static/v1?label=pypi&message=non-CUDA&color=00BFFF)](https://pypi.org/project/mooncake-transfer-engine-non-cuda/)
+  [![PyPI NPU](https://img.shields.io/static/v1?label=pypi&message=NPU&color=F87171)](https://pypi.org/project/mooncake-transfer-engine-npu/)
+  [![PyPI MUSA](https://img.shields.io/static/v1?label=pypi&message=MUSA&color=E4002B)](https://pypi.org/project/mooncake-transfer-engine-musa/)
   [![PyPI EFA CUDA](https://img.shields.io/static/v1?label=pypi&message=EFA%20%2B%20CUDA&color=FF9900)](https://pypi.org/project/mooncake-transfer-engine-efa/)
   [![PyPI EFA Non-CUDA](https://img.shields.io/static/v1?label=pypi&message=EFA%20non-CUDA&color=FF9900)](https://pypi.org/project/mooncake-transfer-engine-efa-non-cuda/)
 </div>


### PR DESCRIPTION
## Description

This PR refreshes the README badge area to make package variants easier to scan:

- add PyPI links for the MUSA, EFA CUDA, and EFA non-CUDA builds
- group project metadata, accelerator builds, and special-environment builds into separate rows
- move DeepWiki into the primary navigation links
- replace the rate-limited Docker version badge with a stable Docker Hub link
- remove the low-signal weekly commit activity badge

The new layout keeps the project-level status compact while making the available installation targets explicit.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**

```bash
pre-commit run --files README.md
```

**Test results:**

- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done: verified all badge image URLs return HTTP 200

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

OpenAI Codex helped reorganize the badge layout, edit `README.md`, and run the targeted validation. The submitter remains responsible for reviewing and understanding every changed line before the PR is marked ready for review.