### PR TITLE
[CI/Build] Backport release wheel ELF layout fix

### DIFF
--- a/.github/workflows/_build-wheel.yaml
+++ b/.github/workflows/_build-wheel.yaml
@@ -180,6 +180,22 @@ jobs:
         env:
           VERSION: ${{ env.VERSION }}
 
+      - name: Smoke test repaired wheel
+        run: |
+          smoke_venv=$(mktemp -d)
+          python -m venv "$smoke_venv"
+          "$smoke_venv/bin/python" -m pip install --no-deps \
+            mooncake-wheel/dist-py${{ steps.pytag.outputs.tag }}/*.whl
+
+          export LD_LIBRARY_PATH="/usr/local/lib:${LD_LIBRARY_PATH:-}"
+          for dir in /usr/local/cuda/lib64 \
+                     /usr/local/cuda/lib64/stubs \
+                     /usr/local/cuda/targets/*/lib \
+                     /usr/local/cuda/targets/*/lib/stubs; do
+            [ -d "$dir" ] && export LD_LIBRARY_PATH="$dir:$LD_LIBRARY_PATH"
+          done
+          "$smoke_venv/bin/mooncake_master" --version
+
       - name: Upload Python wheel artifact
         uses: actions/upload-artifact@v4
         with:

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -313,6 +313,9 @@ if(BUILD_SHARED_LIBS)
 endif()
 
 # Master binary
+include(CheckPIESupported)
+check_pie_supported(LANGUAGES CXX)
+
 add_executable(mooncake_master master.cpp)
 
 set(MASTER_EXTRA_INCS)
@@ -350,6 +353,8 @@ add_executable(mooncake_client real_client_main.cpp)
 # Client needs transfer_engine for data transfer operations
 target_link_libraries(mooncake_client PRIVATE mooncake_store transfer_engine
                                               asio_shared)
+set_target_properties(mooncake_master mooncake_client
+                      PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 # Optimize binary sizes only in Release mode
 string(TOUPPER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_UPPER)

--- a/mooncake-transfer-engine/example/CMakeLists.txt
+++ b/mooncake-transfer-engine/example/CMakeLists.txt
@@ -1,5 +1,8 @@
 set(WORKSPACE "${CMAKE_CURRENT_SOURCE_DIR}")
 
+include(CheckPIESupported)
+check_pie_supported(LANGUAGES CXX)
+
 if(USE_HIP)
   file(GLOB EXAMPLE_SOURCES "*.cpp")
   hipify_files(EXAMPLE_SOURCES)
@@ -10,6 +13,8 @@ if(USE_HIP)
 endif()
 
 add_executable(transfer_engine_bench ${WORKSPACE}/transfer_engine_bench.cpp)
+set_target_properties(transfer_engine_bench PROPERTIES POSITION_INDEPENDENT_CODE
+                                                       ON)
 target_link_libraries(transfer_engine_bench PUBLIC transfer_engine)
 if(USE_TENT)
   target_link_libraries(transfer_engine_bench PUBLIC tent_link_group)

--- a/scripts/test_installation.sh
+++ b/scripts/test_installation.sh
@@ -46,6 +46,7 @@ python tests/test_mooncake_config.py
 echo "Verifying mooncake_master entry point..."
 # Check if the mooncake_master entry point is installed and executable
 which mooncake_master || { echo "ERROR: mooncake_master entry point not found!"; exit 1; }
+mooncake_master --version
 echo "Success: mooncake_master entry point found"
 
 # Check if the mooncake_client entry point is installed and executable


### PR DESCRIPTION
## Description

Backport of #3105 to `release/v0.3.12`.

Fixes #3104.

The v0.3.12 CUDA 13 wheel could package `mooncake_master` with a malformed ELF layout that segfaulted in the dynamic loader before `main()`. This backport:

- enables CMake PIE checks and position-independent executables for `mooncake_master`, `mooncake_client`, and `transfer_engine_bench`;
- changes the installation check to execute `mooncake_master --version` instead of only checking that the command exists;
- adds an installed-wheel release smoke test in a fresh virtual environment, including the CUDA library paths used by the build image.

The branch is based directly on `release/v0.3.12` and contains only the release fix, without unrelated commits from `main`.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
cmake --build build --target mooncake_master mooncake_client transfer_engine_bench --parallel 128
file build/mooncake-store/src/mooncake_master build/mooncake-store/src/mooncake_client build/mooncake-transfer-engine/example/transfer_engine_bench
readelf -h build/mooncake-store/src/mooncake_master
PYTHON_VERSION=3.10 OUTPUT_DIR=/tmp/mooncake-release-fixed-wheel VERSION=0.3.12 ./scripts/build_wheel.sh
python3 -m venv /tmp/mooncake-release-wheel-smoke
/tmp/mooncake-release-wheel-smoke/bin/pip install --no-deps /tmp/mooncake-release-fixed-wheel/mooncake_transfer_engine-0.3.12-cp310-cp310-linux_x86_64.whl
LD_LIBRARY_PATH="/usr/local/cuda/lib64:/usr/local/cuda/lib64/stubs" /tmp/mooncake-release-wheel-smoke/bin/mooncake_master --version
SKIP=cmake-format pre-commit run --files .github/workflows/_build-wheel.yaml mooncake-store/src/CMakeLists.txt mooncake-transfer-engine/example/CMakeLists.txt scripts/test_installation.sh
```

**Test results:**
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

All three affected executables are PIE (`Type: DYN`). The complete cp310 wheel built from this release branch installs in a fresh virtual environment, and the installed command exits successfully with:

```text
mooncake_master version 0.3.12 (git: 29fc0c42)
```

The same smoke command against the originally released CUDA 13 cp310 wheel reproduces the dynamic-loader segmentation fault, so the new release-stage check covers the reported regression.

Targeted pre-commit hooks pass. `cmake-format` was skipped because it rewrites unrelated pre-existing regions in the touched CMake files; no unrelated formatting changes are included.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

Documentation and RFC updates are not applicable to this 27-line release fix.

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex helped investigate the malformed wheel ELF, prepare the minimal backport, and run the build, installed-wheel smoke test, and targeted pre-commit checks. The human submitter is responsible for reviewing and defending every changed line.