### PR TITLE
[CI/Build] Fix CUDA stub release smoke test

### DIFF
--- a/.github/workflows/_build-wheel.yaml
+++ b/.github/workflows/_build-wheel.yaml
@@ -194,6 +194,25 @@ jobs:
                      /usr/local/cuda/targets/*/lib/stubs; do
             [ -d "$dir" ] && export LD_LIBRARY_PATH="$dir:$LD_LIBRARY_PATH"
           done
+
+          # CUDA builder images contain the link-time driver stub but not the
+          # real libcuda.so.1 supplied by an NVIDIA driver. Non-CUDA wheels must
+          # not receive this alias, so an accidental CUDA dependency still fails.
+          if [ "${VARIANT_FLAG:-}" != "NON_CUDA_BUILD" ]; then
+            cuda_stub=
+            for candidate in /usr/local/cuda/lib64/stubs/libcuda.so \
+                             /usr/local/cuda/targets/*/lib/stubs/libcuda.so; do
+              if [ -f "$candidate" ]; then
+                cuda_stub="$candidate"
+                break
+              fi
+            done
+            if [ -n "$cuda_stub" ]; then
+              ln -s "$cuda_stub" "$smoke_venv/libcuda.so.1"
+              export LD_LIBRARY_PATH="$smoke_venv:$LD_LIBRARY_PATH"
+            fi
+          fi
+
           "$smoke_venv/bin/mooncake_master" --version
 
       - name: Upload Python wheel artifact


### PR DESCRIPTION
## Description

Follow-up to #3106 for `release/v0.3.12`.

The installed-wheel smoke executes `mooncake_master --version`, but CUDA builder containers contain the link-time `libcuda.so` stub rather than the driver-provided `libcuda.so.1`. CUDA 12 and CUDA 13 release jobs therefore failed at this step on both x86_64 and aarch64.

This change:

- locates the toolkit stub in `lib64/stubs` or `targets/*/lib/stubs`;
- exposes it as `libcuda.so.1` only inside the temporary smoke environment;
- skips the alias for `NON_CUDA_BUILD`, preserving detection of accidental CUDA dependencies;
- continues executing the installed master binary, covering the original pre-`main()` ELF regression.

The alias is created after wheel repair and outside the artifact path. Smoke runs before artifact upload, and `publish-release` requires every build job to succeed, so a smoke failure blocks PyPI publication.

Failed runs: [CUDA 12](https://github.com/kvcache-ai/Mooncake/actions/runs/30108545321), [CUDA 13](https://github.com/kvcache-ai/Mooncake/actions/runs/30108545213).

EFA, MUSA, and Ascend use separate release workflows and remain outside this focused hotfix.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
# Build an executable with a CUDA driver NEEDED entry.
echo '#include <stdio.h>\nint main(void) { puts("entered main"); return 0; }' \
  | gcc -x c - -o /tmp/mooncake-cuda-loader-smoke \
      -L/usr/local/cuda-13.0/targets/x86_64-linux/lib/stubs \
      -Wl,--no-as-needed -lcuda
cp /tmp/mooncake-cuda-loader-smoke /tmp/mooncake-cuda-loader-smoke-isolated
patchelf --replace-needed libcuda.so.1 libcuda-smoke.so.1 \
  /tmp/mooncake-cuda-loader-smoke-isolated

# Reproduce the missing-library failure, then add the temporary alias.
/tmp/mooncake-cuda-loader-smoke-isolated
stub_runtime_dir=$(mktemp -d)
ln -s /usr/local/cuda-13.0/targets/x86_64-linux/lib/stubs/libcuda.so \
  "$stub_runtime_dir/libcuda-smoke.so.1"
LD_LIBRARY_PATH="$stub_runtime_dir" /tmp/mooncake-cuda-loader-smoke-isolated

# Install and execute a complete repaired v0.3.12 wheel with the alias.
smoke_venv=$(mktemp -d)
python -m venv "$smoke_venv"
"$smoke_venv/bin/python" -m pip install --no-deps \
  /tmp/mooncake-release-fixed-wheel/*.whl
ln -s /usr/local/cuda/lib64/stubs/libcuda.so "$smoke_venv/libcuda.so.1"
LD_LIBRARY_PATH="$smoke_venv:/usr/local/cuda/lib64/stubs:/usr/local/lib" \
  "$smoke_venv/bin/mooncake_master" --version

pre-commit run --files .github/workflows/_build-wheel.yaml
git diff --check
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

The isolated loader test first reproduced `error while loading shared libraries`, then printed `entered main` after adding the alias. The complete repaired wheel installed and printed:

```text
mooncake_master version 0.3.12 (git: 29fc0c42)
```

The exact guarded workflow block was also executed in fresh temporary directories for each variant:

```text
CUDA12: /usr/local/cuda/lib64/stubs/libcuda.so
CU13_BUILD: /usr/local/cuda/lib64/stubs/libcuda.so
NON_CUDA_BUILD: no CUDA alias
```

All targeted pre-commit hooks and `git diff --check` passed.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

Documentation and an RFC are not applicable to this release workflow fix.

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex helped diagnose the release matrices, implement the CUDA smoke alias and Non-CUDA guard, and run the loader, repaired-wheel, YAML, and pre-commit validations. The human submitter is responsible for reviewing and defending every changed line.