### PR TITLE
[Wheel] Add native fast-copy PUT hot path

### DIFF
--- a/docs/source/api-reference/python/dataproto-structured-object-transfer.md
+++ b/docs/source/api-reference/python/dataproto-structured-object-transfer.md
@@ -122,6 +122,8 @@ Numeric numpy arrays are stored as structured ndarray members. Contiguous arrays
 
 `non_tensor_batch` object arrays are structured-encoded according to their contents. Numeric scalar object arrays, ragged tensors, bytes, strings, JSON-like values, and selected media payloads have explicit codecs. These fields are serialized by design and should not be treated as zero-copy tensor data.
 
+For typed-ragged ndarray rows, Mooncake copies the rows directly into BufferPool staging memory with the native fast-copy extension and writes each chunk through `batch_put_from`. If the extension or BufferPool path is unavailable, the implementation transparently falls back to the regular copy path. This optimization does not change the stored format or require caller configuration.
+
 ## Materializing into caller buffers
 
 `destinations` can reuse caller-provided buffers:
@@ -162,6 +164,8 @@ transfer.put_structured_object(payload, policy=policy)
 ```
 
 `copy_mode="zero_copy"` requires tensor payloads to be provided as `tensor_object_buffer`; plain torch tensors are rejected because they do not expose a registered tensor-object buffer.
+
+Typed-ragged and other non-tensor structured payloads do not support `copy_mode="zero_copy"`. Use `auto` to enable BufferPool staging and the native fast-copy path when available, or `copy` to force the regular `store.put` path.
 
 ## Cleanup
 

--- a/docs/source/api-reference/python/dataproto-structured-object-transfer.md
+++ b/docs/source/api-reference/python/dataproto-structured-object-transfer.md
@@ -118,7 +118,7 @@ Tensor fields are stored through the best available Mooncake path:
 3. If a tensor-native path is unavailable, Mooncake falls back to a serialized tensor payload.
 4. Scalar tensors use a correctness fallback until the native tensor codec preserves zero-dimensional shape.
 
-Numeric numpy arrays are stored as structured ndarray members. Contiguous arrays can be passed through without copying; non-contiguous arrays are made contiguous before storage. Row slices are materialized through structured range reads when the backend supports them.
+Numeric numpy arrays are stored as structured ndarray members. Non-tensor ndarray PUTs are staged and copied before being written to Mooncake; non-contiguous arrays are made contiguous as part of that staging path. Row slices are materialized through structured range reads when the backend supports them, and `destinations` can still be used on GET to materialize selected fields into caller-provided buffers.
 
 `non_tensor_batch` object arrays are structured-encoded according to their contents. Numeric scalar object arrays, ragged tensors, bytes, strings, JSON-like values, and selected media payloads have explicit codecs. These fields are serialized by design and should not be treated as zero-copy tensor data.
 

--- a/docs/source/api-reference/python/mooncake-store.md
+++ b/docs/source/api-reference/python/mooncake-store.md
@@ -193,9 +193,9 @@ metadata = result.metadata
 
 ### Structured object transfer policy
 
-By default, structured object writes use `BundleTransferPolicy(copy_mode="auto")`. This keeps the existing behavior: Mooncake uses the zero-copy `batch_put_from` fast path when buffer registration is available, and falls back to ordinary `store.put` when the fast path is unavailable.
+By default, structured object writes use `BundleTransferPolicy(copy_mode="auto")`. Non-tensor payloads are staged through a Mooncake BufferPool and written with `batch_put_from` when that path is available; otherwise Mooncake falls back to ordinary `store.put`. Typed-ragged ndarray rows use the native fast-copy extension to copy directly into the staging buffer without an intermediate concatenation.
 
-For very large tensors, buffer registration capacity can be exhausted. If the upper layer does not handle this failure mode yet, force the non-zero-copy path with `copy_mode="copy"`:
+Use `copy_mode="copy"` to force the regular `store.put` path:
 
 ```python
 from mooncake.structured_object_store import BundleTransferPolicy
@@ -208,11 +208,9 @@ ref = transfer.put_structured_object(
 
 Available modes:
 
-- `auto`: prefer zero-copy and fall back to regular `store.put` when zero-copy support is unavailable;
-- `copy`: force the non-zero-copy `store.put` path;
-- `zero_copy`: require the zero-copy `batch_put_from` path and raise an error if it is unavailable.
-
-If a caller has already registered a structured member buffer, pass `pre_registered_buffers={"member_name": True}` to avoid duplicate registration. The buffer must be the same writable, contiguous buffer used for transfer; read-only, non-contiguous, or internally copied buffers are rejected.
+- `auto`: prefer BufferPool staging plus `batch_put_from` for non-tensor payloads and fall back to regular `store.put` when that path is unavailable;
+- `copy`: force the regular `store.put` path;
+- `zero_copy`: require payloads to be explicit `tensor_object_buffer` instances; non-tensor structured payloads are rejected.
 
 ### Partial reads
 

--- a/mooncake-wheel/mooncake/_fast_copy.c
+++ b/mooncake-wheel/mooncake/_fast_copy.c
@@ -1,0 +1,194 @@
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <pthread.h>
+
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include <numpy/arrayobject.h>
+
+typedef struct {
+    void **src_ptrs;
+    size_t *src_sizes;
+    int count;
+    char *dst;
+    size_t offset;
+    size_t bytes_copied;
+} ThreadWork;
+
+static void *copy_thread_func(void *arg) {
+    ThreadWork *w = (ThreadWork *)arg;
+    char *d = w->dst + w->offset;
+    size_t off = 0;
+    for (int i = 0; i < w->count; i++) {
+        if (w->src_sizes[i] > 0) {
+            memcpy(d + off, w->src_ptrs[i], w->src_sizes[i]);
+            off += w->src_sizes[i];
+        }
+    }
+    w->bytes_copied = off;
+    return NULL;
+}
+
+static PyObject *concat_arrays_into(PyObject *self, PyObject *args) {
+    PyObject *list_obj;
+    unsigned long long dest_ptr_val;
+    unsigned long long dest_size_val;
+    Py_ssize_t start = 0;
+    Py_ssize_t count = -1;
+    int nthreads = 1;
+    ThreadWork *works = NULL;
+    pthread_t *threads = NULL;
+    char *thread_started = NULL;
+
+    if (!PyArg_ParseTuple(args, "O!KK|nni", &PyList_Type, &list_obj,
+                          &dest_ptr_val, &dest_size_val, &start, &count,
+                          &nthreads))
+        return NULL;
+
+    Py_ssize_t list_len = PyList_GET_SIZE(list_obj);
+    if (start < 0) start = 0;
+    if (start > list_len) start = list_len;
+    if (count < 0 || start + count > list_len) count = list_len - start;
+    if (count == 0) return PyLong_FromSize_t(0);
+    if (nthreads < 1) nthreads = 1;
+    if (nthreads > (int)count) nthreads = (int)count;
+
+    size_t dest_size = (size_t)dest_size_val;
+    void **ptrs = (void **)malloc(count * sizeof(void *));
+    size_t *sizes = (size_t *)malloc(count * sizeof(size_t));
+    PyObject **items = (PyObject **)calloc(count, sizeof(PyObject *));
+    if (!ptrs || !sizes || !items) {
+        free(ptrs);
+        free(sizes);
+        free(items);
+        return PyErr_NoMemory();
+    }
+
+    Py_ssize_t held = 0;
+    size_t total_input_bytes = 0;
+    for (Py_ssize_t i = 0; i < count; i++) {
+        PyObject *item = PyList_GET_ITEM(list_obj, start + i);
+        if (!PyArray_Check(item)) {
+            PyErr_Format(PyExc_TypeError, "arrays[%zd] is not an ndarray",
+                         start + i);
+            goto fail;
+        }
+        Py_INCREF(item);
+        items[held++] = item;
+        PyArrayObject *arr = (PyArrayObject *)item;
+        if (!PyArray_IS_C_CONTIGUOUS(arr)) {
+            PyErr_Format(PyExc_ValueError, "arrays[%zd] is not C-contiguous",
+                         start + i);
+            goto fail;
+        }
+        size_t nbytes = (size_t)PyArray_NBYTES(arr);
+        if (nbytes > SIZE_MAX - total_input_bytes) {
+            PyErr_SetString(PyExc_OverflowError, "array byte sizes overflow");
+            goto fail;
+        }
+        ptrs[i] = PyArray_DATA(arr);
+        sizes[i] = nbytes;
+        total_input_bytes += nbytes;
+    }
+    if (total_input_bytes > dest_size) {
+        PyErr_Format(PyExc_ValueError,
+                     "destination buffer too small: need %zu bytes, got %zu",
+                     total_input_bytes, dest_size);
+        goto fail;
+    }
+
+    /* Partition work across threads. */
+    works = (ThreadWork *)calloc(nthreads, sizeof(ThreadWork));
+    threads = (pthread_t *)malloc(nthreads * sizeof(pthread_t));
+    thread_started = (char *)calloc(nthreads, sizeof(char));
+    if (!works || !threads || !thread_started) {
+        PyErr_NoMemory();
+        goto fail;
+    }
+
+    int n = (int)count;
+    int per_t = (n + nthreads - 1) / nthreads;
+    size_t offset = 0;
+    int actual_threads = 0;
+    for (int t = 0; t < nthreads; t++) {
+        int s = t * per_t;
+        int c = per_t;
+        if (s + c > n) c = n - s;
+        if (c <= 0) break;
+
+        works[t].src_ptrs = ptrs + s;
+        works[t].src_sizes = sizes + s;
+        works[t].count = c;
+        works[t].dst = (char *)(uintptr_t)dest_ptr_val;
+        works[t].offset = offset;
+
+        size_t tb = 0;
+        for (int j = s; j < s + c; j++) tb += sizes[j];
+        offset += tb;
+        actual_threads++;
+    }
+
+    Py_BEGIN_ALLOW_THREADS
+    if (actual_threads == 1) {
+        copy_thread_func(&works[0]);
+    } else {
+        for (int t = 1; t < actual_threads; t++) {
+            if (pthread_create(&threads[t], NULL, copy_thread_func,
+                               &works[t]) != 0) {
+                /* Copy inline if worker creation fails after other workers start. */
+                copy_thread_func(&works[t]);
+            } else {
+                thread_started[t] = 1;
+            }
+        }
+        copy_thread_func(&works[0]);
+        for (int t = 1; t < actual_threads; t++) {
+            if (thread_started[t]) {
+                pthread_join(threads[t], NULL);
+            }
+        }
+    }
+    Py_END_ALLOW_THREADS
+
+    size_t total = 0;
+    for (int t = 0; t < actual_threads; t++) total += works[t].bytes_copied;
+
+    free(ptrs);
+    free(sizes);
+    for (Py_ssize_t i = 0; i < held; i++) Py_DECREF(items[i]);
+    free(items);
+    free(works);
+    free(threads);
+    free(thread_started);
+    return PyLong_FromSize_t(total);
+
+fail:
+    free(ptrs);
+    free(sizes);
+    for (Py_ssize_t i = 0; i < held; i++) Py_DECREF(items[i]);
+    free(items);
+    free(works);
+    free(threads);
+    free(thread_started);
+    return NULL;
+}
+
+static PyMethodDef module_methods[] = {
+    {"concat_arrays_into", concat_arrays_into, METH_VARARGS,
+     "Scatter-copy arrays[start:start+count] into dest_ptr (GIL released)."},
+    {NULL, NULL, 0, NULL}};
+
+static struct PyModuleDef moduledef = {
+    PyModuleDef_HEAD_INIT,
+    "_fast_copy",
+    "Fast scatter-gather copy for ndarray lists.",
+    -1,
+    module_methods,
+};
+
+PyMODINIT_FUNC PyInit__fast_copy(void) {
+    import_array();
+    return PyModule_Create(&moduledef);
+}

--- a/mooncake-wheel/mooncake/_fast_copy.c
+++ b/mooncake-wheel/mooncake/_fast_copy.c
@@ -130,14 +130,15 @@ static PyObject *concat_arrays_into(PyObject *self, PyObject *args) {
         actual_threads++;
     }
 
-    Py_BEGIN_ALLOW_THREADS
+    Py_BEGIN_ALLOW_THREADS;
     if (actual_threads == 1) {
         copy_thread_func(&works[0]);
     } else {
         for (int t = 1; t < actual_threads; t++) {
             if (pthread_create(&threads[t], NULL, copy_thread_func,
                                &works[t]) != 0) {
-                /* Copy inline if worker creation fails after other workers start. */
+                /* Copy inline if worker creation fails after other workers
+                 * start. */
                 copy_thread_func(&works[t]);
             } else {
                 thread_started[t] = 1;
@@ -150,7 +151,7 @@ static PyObject *concat_arrays_into(PyObject *self, PyObject *args) {
             }
         }
     }
-    Py_END_ALLOW_THREADS
+    Py_END_ALLOW_THREADS;
 
     size_t total = 0;
     for (int t = 0; t < actual_threads; t++) total += works[t].bytes_copied;

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -3824,6 +3824,7 @@ class _BundleManifestStore:
             key if num_chunks == 1 else f"{key}/chunk/{idx}"
             for idx in range(num_chunks)
         ]
+
         def _put_chunk_batch(keys, batches):
             for ck, (start, count, size) in zip(keys, batches):
                 lease = pool.acquire(size)
@@ -3837,9 +3838,6 @@ class _BundleManifestStore:
                         batch_put_from, [ck], [lease.ptr], [size], config
                     )
                     transport._check_batch_put_results(results, [ck], "batch_put_from")
-                except Exception:
-                    _cleanup_keys(self._store, [ck], strict=False)
-                    raise
                 finally:
                     lease.release()
 
@@ -3850,17 +3848,17 @@ class _BundleManifestStore:
             and num_chunks >= AUTO_PARALLEL_MIN_CHUNKS
             and total_bytes >= AUTO_PARALLEL_MIN_BYTES
         )
-        if not use_parallel:
-            _put_chunk_batch(chunk_keys, chunk_batches)
-        else:
-            group_count = max(1, min(max_inflight, num_chunks))
-            group_size = (num_chunks + group_count - 1) // group_count
-            groups = [
-                (chunk_keys[s:s + group_size], chunk_batches[s:s + group_size])
-                for s in range(0, num_chunks, group_size)
-            ]
-            futures: list = []
-            try:
+        futures: list = []
+        try:
+            if not use_parallel:
+                _put_chunk_batch(chunk_keys, chunk_batches)
+            else:
+                group_count = max(1, min(max_inflight, num_chunks))
+                group_size = (num_chunks + group_count - 1) // group_count
+                groups = [
+                    (chunk_keys[s:s + group_size], chunk_batches[s:s + group_size])
+                    for s in range(0, num_chunks, group_size)
+                ]
                 with ThreadPoolExecutor(max_workers=len(groups)) as executor:
                     futures = [
                         executor.submit(_put_chunk_batch, gk, gb)
@@ -3868,11 +3866,11 @@ class _BundleManifestStore:
                     ]
                     for f in as_completed(futures):
                         f.result()
-            except Exception:
-                for f in futures:
-                    f.cancel()
-                _cleanup_keys(self._store, chunk_keys, strict=False)
-                raise
+        except Exception:
+            for f in futures:
+                f.cancel()
+            _cleanup_keys(self._store, chunk_keys, strict=False)
+            raise
         payload_spec = {
             "key": key,
             "bytes": total_bytes,

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -19,8 +19,14 @@ except Exception:  # pragma: no cover - depends on built extension
 
 import msgpack as _msgpack
 
-DEFAULT_BUNDLE_CHUNK_BYTES = 512 * 1024**2
-AUTO_PARALLEL_MIN_BYTES = 4 * 1024**3
+# -- C fast-path: concat_arrays_into(list[ndarray], dest_ptr) ----------------
+try:
+    from mooncake._fast_copy import concat_arrays_into as _concat_arrays_into
+except Exception:  # pragma: no cover
+    _concat_arrays_into = None
+
+DEFAULT_BUNDLE_CHUNK_BYTES = 64 * 1024**2
+AUTO_PARALLEL_MIN_BYTES = DEFAULT_BUNDLE_CHUNK_BYTES
 AUTO_PARALLEL_MIN_CHUNKS = 8
 MISSING_OBJECT_ERROR = (
     -704
@@ -155,6 +161,29 @@ class _MultiBufferPayload:
 
 
 @dataclass(frozen=True)
+class _DirectCopyPayload:
+    """Deferred-copy ndarray list copied directly into pool memory at PUT time."""
+    arrays: list[np.ndarray]
+    total_bytes: int
+    dtype: str | None = None
+    shape: tuple[int, ...] | None = None
+
+    @property
+    def nbytes(self) -> int:
+        return self.total_bytes
+
+    @staticmethod
+    def from_flat_arrays(
+        flat_arrays: list[np.ndarray], dtype: np.dtype, total_elems: int,
+    ) -> "_DirectCopyPayload":
+        return _DirectCopyPayload(
+            arrays=flat_arrays,
+            total_bytes=sum(a.nbytes for a in flat_arrays),
+            dtype=np.dtype(dtype).str,
+            shape=(total_elems,),
+        )
+
+
 class _RawDestinationBuffer:
     ptr: int
     size: int
@@ -457,7 +486,6 @@ class MooncakeBundleTransfer:
         chunk_bytes: Optional[int] = None,
         policy: Optional[BundleTransferPolicy] = None,
         max_inflight_put: Optional[int] = None,
-        pre_registered_buffers: Optional[Mapping[str, bool]] = None,
         config: Any = None,
     ) -> RemoteBundleRef:
         """Store raw metadata bytes plus named buffers as a low-level bundle."""
@@ -468,7 +496,6 @@ class MooncakeBundleTransfer:
             chunk_bytes=chunk_bytes,
             policy=policy,
             max_inflight_put=max_inflight_put,
-            pre_registered_buffers=pre_registered_buffers,
             config=config,
         )
 
@@ -483,7 +510,6 @@ class MooncakeBundleTransfer:
         chunk_bytes: Optional[int] = None,
         policy: Optional[BundleTransferPolicy] = None,
         max_inflight_put: Optional[int] = None,
-        pre_registered_buffers: Optional[Mapping[str, bool]] = None,
         config: Any = None,
     ) -> RemoteBundleRef:
         """Store a structured object described by JSON metadata plus named members."""
@@ -493,7 +519,6 @@ class MooncakeBundleTransfer:
             chunk_bytes=chunk_bytes,
             policy=policy,
             max_inflight_put=max_inflight_put,
-            pre_registered_buffers=pre_registered_buffers,
             config=config,
         )
 
@@ -2649,7 +2674,6 @@ def _decode_ragged_tensor_values(
         values.append(data[begin:end].reshape(shape))
     return values
 
-
 def _normalize_ragged_tensor_dict_keys(keys: Any) -> list[str]:
     if isinstance(keys, Mapping):
         iterable = keys.keys()
@@ -2822,13 +2846,18 @@ def _encode_typed_ragged_values(
         if array.ndim > 0:
             shapes[row, : array.ndim] = array.shape
     if flat_arrays:
-        buffers = tuple(memoryview(flat.data).cast("B") for flat in flat_arrays)
-        data = _MultiBufferPayload(
-            buffers=buffers,
-            owners=tuple(flat_arrays),
-            dtype=np.dtype(dtype).str,
-            shape=(int(offset),),
-        )
+        if _concat_arrays_into is not None:
+            data = _DirectCopyPayload.from_flat_arrays(
+                flat_arrays, dtype, int(offset)
+            )
+        else:
+            buffers = tuple(memoryview(flat.data).cast("B") for flat in flat_arrays)
+            data = _MultiBufferPayload(
+                buffers=buffers,
+                owners=tuple(flat_arrays),
+                dtype=np.dtype(dtype).str,
+                shape=(int(offset),),
+            )
     else:
         empty = np.empty(0, dtype=dtype)
         data = _MultiBufferPayload(
@@ -2915,7 +2944,6 @@ def _value_to_media_bytes(value: Any) -> tuple[bytes, str | None, dict[str, Any]
             },
         )
     return bytes(value), None, {"kind": "bytes"}
-
 
 def _encode_bytes_like_values(
     values: list[Any],
@@ -3061,17 +3089,12 @@ class _StructuredObjectLayer:
         chunk_bytes: Optional[int],
         policy: Optional[BundleTransferPolicy],
         max_inflight_put: Optional[int],
-        pre_registered_buffers: Optional[Mapping[str, bool]],
         config: Any = None,
     ) -> RemoteBundleRef:
         metadata, buffers = _encode_structured_fields(payload.metadata, payload.buffers)
         transfer_policy = self._bundle_store._policy(
             policy, max_inflight_put=max_inflight_put
         )
-        if transfer_policy.copy_mode != "copy":
-            _validate_pre_registered_structured_buffers(
-                payload.buffers, buffers, pre_registered_buffers
-            )
         return self._bundle_store.put_bundle(
             meta=_encode_structured_metadata(metadata),
             buffers=buffers,
@@ -3079,7 +3102,6 @@ class _StructuredObjectLayer:
             chunk_bytes=chunk_bytes,
             policy=transfer_policy,
             max_inflight_put=None,
-            pre_registered_buffers=pre_registered_buffers,
             config=config,
         )
 
@@ -3344,7 +3366,6 @@ class _BundleManifestStore:
         chunk_bytes: Optional[int],
         policy: Optional[BundleTransferPolicy],
         max_inflight_put: Optional[int],
-        pre_registered_buffers: Optional[Mapping[str, bool]] = None,
         config: Any = None,
     ) -> RemoteBundleRef:
         _validate_key_segment(partition, "partition")
@@ -3358,14 +3379,12 @@ class _BundleManifestStore:
         manifest_key = f"{base_key}/manifest"
         written_keys: list[str] = []
         buffer_specs: dict[str, Any] = {}
-        pre_registered_map = dict(pre_registered_buffers or {})
         try:
             meta_spec, meta_keys = self._put_payload(
                 f"{base_key}/meta",
                 meta_view,
                 target_chunk_bytes,
                 _copy_transfer_policy(transfer_policy),
-                pre_registered=False,
                 config=config,
             )
             written_keys.extend(meta_keys)
@@ -3385,6 +3404,15 @@ class _BundleManifestStore:
                         value,
                         target_chunk_bytes,
                         transfer_policy,
+                        config=config,
+                    )
+                elif isinstance(value, _DirectCopyPayload):
+                    payload_spec, payload_keys = self._put_direct_copy_payload(
+                        payload_key,
+                        value,
+                        target_chunk_bytes,
+                        transfer_policy,
+                        config=config,
                     )
                 else:
                     payload_spec, payload_keys = self._put_payload(
@@ -3392,7 +3420,6 @@ class _BundleManifestStore:
                         _bytes_view(value, name),
                         target_chunk_bytes,
                         transfer_policy,
-                        pre_registered=bool(pre_registered_map.get(name, False)),
                         config=config,
                     )
                 buffer_specs[name] = payload_spec
@@ -3443,7 +3470,6 @@ class _BundleManifestStore:
                 meta_view,
                 target_chunk_bytes,
                 _copy_transfer_policy(transfer_policy),
-                pre_registered=False,
                 config=config,
             )
             written_keys.extend(meta_keys)
@@ -3643,7 +3669,6 @@ class _BundleManifestStore:
                 memoryview(payload),
                 len(payload) or 1,
                 transfer_policy,
-                pre_registered=False,
                 config=config,
             )
             payload_spec["format"] = "torch_save"
@@ -3666,7 +3691,6 @@ class _BundleManifestStore:
         value: memoryview,
         chunk_bytes: int,
         transfer_policy: BundleTransferPolicy,
-        pre_registered: bool,
         config: Any = None,
     ) -> tuple[dict[str, Any], list[str]]:
         if len(value) == 0:
@@ -3676,12 +3700,11 @@ class _BundleManifestStore:
             key if len(chunks) == 1 else f"{key}/chunk/{index}"
             for index in range(len(chunks))
         ]
-        written_keys = self._transport.put_payload_chunks(
+        self._transport.put_multi_buffer_payload_chunks(
             chunk_keys,
-            chunks,
+            [[chunk] for chunk in chunks],
             transfer_policy,
-            pre_registered=pre_registered,
-            config=config,
+            config,
         )
         payload_spec = {
             "key": key,
@@ -3691,7 +3714,7 @@ class _BundleManifestStore:
                 for chunk_key, chunk in zip(chunk_keys, chunks)
             ],
         }
-        return payload_spec, written_keys
+        return payload_spec, list(chunk_keys)
 
     def _put_multi_buffer_payload(
         self,
@@ -3699,27 +3722,25 @@ class _BundleManifestStore:
         value: _MultiBufferPayload,
         chunk_bytes: int,
         transfer_policy: BundleTransferPolicy,
+        config: Any = None,
     ) -> tuple[dict[str, Any], list[str]]:
         total_bytes = value.nbytes
         if total_bytes == 0:
             return {"key": key, "bytes": 0, "chunks": []}, []
         if len(value.buffers) == 1:
             return self._put_payload(
-                key,
-                value.buffers[0],
-                chunk_bytes,
-                transfer_policy,
-                pre_registered=False,
+                key, value.buffers[0], chunk_bytes, transfer_policy, config=config
             )
         chunk_groups = _split_multi_buffer_payload(value.buffers, chunk_bytes)
         chunk_keys = [
             key if len(chunk_groups) == 1 else f"{key}/chunk/{index}"
             for index in range(len(chunk_groups))
         ]
-        written_keys = self._transport.put_multi_buffer_payload_chunks(
+        self._transport.put_multi_buffer_payload_chunks(
             chunk_keys,
             chunk_groups,
             transfer_policy,
+            config,
         )
         payload_spec = {
             "key": key,
@@ -3729,7 +3750,140 @@ class _BundleManifestStore:
                 for chunk_key, group in zip(chunk_keys, chunk_groups)
             ],
         }
-        return payload_spec, written_keys
+        return payload_spec, list(chunk_keys)
+
+
+    def _put_direct_copy_payload(
+        self,
+        key: str,
+        value: _DirectCopyPayload,
+        chunk_bytes: int,
+        transfer_policy: BundleTransferPolicy,
+        config: Any = None,
+    ) -> tuple[dict[str, Any], list[str]]:
+        if transfer_policy.copy_mode == "zero_copy":
+            raise RuntimeError("zero-copy put requires tensor-object buffers")
+        total_bytes = value.total_bytes
+        if total_bytes == 0:
+            return {"key": key, "bytes": 0, "chunks": []}, []
+        if len(value.arrays) == 1:
+            buf = memoryview(value.arrays[0].data).cast("B")
+            return self._put_payload(
+                key,
+                buf,
+                chunk_bytes,
+                transfer_policy,
+                config=config,
+            )
+        arrays = value.arrays
+        transport = self._transport
+        pool = transport._ensure_buffer_pool()
+        batch_put_from = transport._batch_put_from
+        if pool is None or not callable(batch_put_from):
+            buf = memoryview(np.concatenate(
+                [a.ravel().view(np.uint8) for a in arrays]
+            ).data).cast("B")
+            return self._put_payload(
+                key,
+                buf,
+                chunk_bytes,
+                transfer_policy,
+                config=config,
+            )
+        # Group arrays into chunk-sized batches
+        n = len(arrays)
+        chunk_batches: list[tuple[int, int, int]] = []  # (start, count, bytes)
+        batch_start = 0
+        batch_bytes = 0
+        fallback = False
+        for i in range(n):
+            ab = arrays[i].nbytes
+            if ab > chunk_bytes:
+                fallback = True
+                break
+            if batch_bytes + ab > chunk_bytes and batch_bytes > 0:
+                chunk_batches.append((batch_start, i - batch_start, batch_bytes))
+                batch_start = i
+                batch_bytes = 0
+            batch_bytes += ab
+        if fallback:
+            buf = memoryview(np.concatenate(
+                [a.ravel().view(np.uint8) for a in arrays]
+            ).data).cast("B")
+            return self._put_payload(
+                key,
+                buf,
+                chunk_bytes,
+                transfer_policy,
+                config=config,
+            )
+        if batch_bytes > 0:
+            chunk_batches.append((batch_start, n - batch_start, batch_bytes))
+        num_chunks = len(chunk_batches)
+        chunk_keys = [
+            key if num_chunks == 1 else f"{key}/chunk/{idx}"
+            for idx in range(num_chunks)
+        ]
+        def _put_chunk_batch(keys, batches, nthreads=1):
+            for ck, (start, count, size) in zip(keys, batches):
+                lease = pool.acquire(size)
+                try:
+                    copied = _concat_arrays_into(
+                        arrays, lease.ptr, size, start, count, nthreads
+                    )
+                    if copied != size:
+                        raise RuntimeError(
+                            f"native fast-copy wrote {copied} bytes, expected {size}"
+                        )
+                    results = _batch_put_from_with_optional_config(
+                        batch_put_from, [ck], [lease.ptr], [size], config
+                    )
+                    transport._check_batch_put_results(results, [ck], "batch_put_from")
+                except Exception:
+                    _cleanup_keys(self._store, [ck], strict=False)
+                    raise
+                finally:
+                    lease.release()
+
+        max_inflight = transfer_policy.max_inflight_put
+        use_parallel = (
+            transfer_policy.put_mode != "batch"
+            and max_inflight > 1
+            and num_chunks >= AUTO_PARALLEL_MIN_CHUNKS
+            and total_bytes >= AUTO_PARALLEL_MIN_BYTES
+        )
+        if not use_parallel:
+            _put_chunk_batch(chunk_keys, chunk_batches)
+        else:
+            group_count = max(1, min(max_inflight, num_chunks))
+            group_size = (num_chunks + group_count - 1) // group_count
+            groups = [
+                (chunk_keys[s:s + group_size], chunk_batches[s:s + group_size])
+                for s in range(0, num_chunks, group_size)
+            ]
+            futures: list = []
+            try:
+                with ThreadPoolExecutor(max_workers=len(groups)) as executor:
+                    futures = [
+                        executor.submit(_put_chunk_batch, gk, gb)
+                        for gk, gb in groups
+                    ]
+                    for f in as_completed(futures):
+                        f.result()
+            except Exception:
+                for f in futures:
+                    f.cancel()
+                _cleanup_keys(self._store, chunk_keys, strict=False)
+                raise
+        payload_spec = {
+            "key": key,
+            "bytes": total_bytes,
+            "chunks": [
+                {"key": ck, "bytes": cb[2]}
+                for ck, cb in zip(chunk_keys, chunk_batches)
+            ],
+        }
+        return payload_spec, list(chunk_keys)
 
     def _policy(
         self,
@@ -3888,71 +4042,39 @@ class _MooncakePayloadTransport:
                 return None
         return self._buffer_pool
 
-    def put_payload_chunks(
-        self,
-        chunk_keys: Sequence[str],
-        chunks: Sequence[memoryview],
-        transfer_policy: BundleTransferPolicy,
-        pre_registered: bool,
-        config: Any = None,
-    ) -> list[str]:
-        if transfer_policy.copy_mode == "copy":
-            return self._put_chunks_direct(chunk_keys, chunks, config=config)
-        if not self._has_batch_put_support():
-            if transfer_policy.copy_mode == "zero_copy":
-                raise RuntimeError(
-                    "zero-copy put requested but batch_put_from is unavailable"
-                )
-            return self._put_chunks_direct(chunk_keys, chunks, config=config)
-        put_mode = self._resolve_put_mode(chunks, transfer_policy)
-        if put_mode == "batch":
-            self.batch_put_chunks_from(
-                chunk_keys, chunks, pre_registered=pre_registered, config=config
-            )
-            return list(chunk_keys)
-        return self._put_chunks_parallel(
-            list(chunk_keys),
-            list(chunks),
-            transfer_policy.max_inflight_put,
-            pre_registered=pre_registered,
-            config=config,
-        )
-
     def put_multi_buffer_payload_chunks(
         self,
         chunk_keys: Sequence[str],
         chunk_groups: Sequence[Sequence[memoryview]],
         transfer_policy: BundleTransferPolicy,
+        config: Any = None,
     ) -> list[str]:
         def fallback_to_direct_put() -> list[str]:
             chunks = [memoryview(b"".join(group)) for group in chunk_groups]
-            return self._put_chunks_direct(chunk_keys, chunks)
+            return self._put_chunks_direct(chunk_keys, chunks, config)
 
         if transfer_policy.copy_mode == "zero_copy":
-            # Joining one chunk group costs the same single copy the contiguous
-            # encoder path paid before multi-buffer puts; delegating keeps the
-            # register-source-buffer zero-copy semantics of single-buffer puts.
-            chunks = [memoryview(b"".join(group)) for group in chunk_groups]
-            return self.put_payload_chunks(
-                chunk_keys, chunks, transfer_policy, pre_registered=False
+            raise RuntimeError(
+                "zero-copy put requires tensor-object buffers"
             )
         if transfer_policy.copy_mode == "copy" or self._ensure_buffer_pool() is None:
             return fallback_to_direct_put()
         if all(len(group) == 1 for group in chunk_groups):
             self.batch_put_buffer_groups_from(
-                chunk_keys, [[group[0]] for group in chunk_groups]
+                chunk_keys, [[group[0]] for group in chunk_groups], config
             )
             return list(chunk_keys)
         if not callable(self._batch_put_from):
             return fallback_to_direct_put()
         put_mode = self._resolve_buffer_group_put_mode(chunk_groups, transfer_policy)
         if put_mode == "batch":
-            self.batch_put_buffer_groups_from(chunk_keys, chunk_groups)
+            self.batch_put_buffer_groups_from(chunk_keys, chunk_groups, config)
             return list(chunk_keys)
         return self._put_buffer_groups_parallel(
             list(chunk_keys),
             [list(group) for group in chunk_groups],
             transfer_policy.max_inflight_put,
+            config,
         )
 
     def read_payload(self, payload_spec: Mapping[str, Any]) -> bytes:
@@ -4195,6 +4317,7 @@ class _MooncakePayloadTransport:
         self,
         chunk_keys: Sequence[str],
         chunk_groups: Sequence[Sequence[memoryview]],
+        config: Any = None,
     ) -> None:
         batch_put_from = self._batch_put_from
         if not callable(batch_put_from):
@@ -4209,7 +4332,9 @@ class _MooncakePayloadTransport:
             lease = pool.acquire(size)
             try:
                 _copy_memoryviews_to_lease(group, lease)
-                results = batch_put_from([chunk_key], [lease.ptr], [size])
+                results = _batch_put_from_with_optional_config(
+                    batch_put_from, [chunk_key], [lease.ptr], [size], config
+                )
                 self._check_batch_put_results(results, [chunk_key], "batch_put_from")
             except Exception:
                 _cleanup_keys(self._store, chunk_keys, strict=False)
@@ -4227,40 +4352,6 @@ class _MooncakePayloadTransport:
             )
         for chunk_key, status in zip(chunk_keys, results):
             _check_status(status, operation, chunk_key)
-
-    def batch_put_chunks_from(
-        self,
-        chunk_keys: Sequence[str],
-        chunks: Sequence[memoryview],
-        pre_registered: bool,
-        config: Any = None,
-    ) -> None:
-        batch_put_from = self._batch_put_from
-        if not callable(batch_put_from):
-            raise RuntimeError("batch_put_from is unavailable")
-        if not chunk_keys:
-            return
-        prepared_chunks = [_prepare_chunk_source_buffer(chunk) for chunk in chunks]
-        buffer_ptrs = [ptr for _owner, ptr, _size in prepared_chunks]
-        sizes = [size for _owner, _ptr, size in prepared_chunks]
-        registered_ptrs = self._register_buffers(
-            buffer_ptrs, sizes, pre_registered, "bundle source payload"
-        )
-        try:
-            results = _batch_put_from_with_optional_config(
-                batch_put_from, list(chunk_keys), buffer_ptrs, sizes, config
-            )
-            if len(results) != len(chunk_keys):
-                raise RuntimeError(
-                    f"batch_put_from returned {len(results)} results for {len(chunk_keys)} chunks"
-                )
-            for chunk_key, status in zip(chunk_keys, results):
-                _check_status(status, "batch_put_from", chunk_key)
-        except Exception:
-            _cleanup_keys(self._store, chunk_keys, strict=False)
-            raise
-        finally:
-            self._unregister_buffers(registered_ptrs, "bundle source payload")
 
     def _put_chunks_direct(
         self,
@@ -4282,68 +4373,12 @@ class _MooncakePayloadTransport:
             raise
         return list(chunk_keys)
 
-    def _put_chunks_parallel(
-        self,
-        chunk_keys: list[str],
-        chunks: list[memoryview],
-        max_inflight_put: int,
-        pre_registered: bool,
-        config: Any = None,
-    ) -> list[str]:
-        groups = self._group_chunk_ranges(chunk_keys, chunks, max_inflight_put)
-        futures: list[Future[None]] = []
-        try:
-            with ThreadPoolExecutor(
-                max_workers=min(max_inflight_put, len(groups))
-            ) as executor:
-                futures = [
-                    executor.submit(
-                        self.batch_put_chunks_from,
-                        group_keys,
-                        group_chunks,
-                        pre_registered,
-                        config,
-                    )
-                    for group_keys, group_chunks in groups
-                ]
-                for future in as_completed(futures):
-                    future.result()
-        except Exception:
-            for future in futures:
-                future.cancel()
-            for future in futures:
-                if future.done() and not future.cancelled():
-                    try:
-                        future.result()
-                    except Exception:
-                        pass
-            _cleanup_keys(self._store, chunk_keys, strict=False)
-            raise
-        return chunk_keys
-
-    def _group_chunk_ranges(
-        self,
-        chunk_keys: Sequence[str],
-        chunks: Sequence[memoryview],
-        max_inflight_put: int,
-    ) -> list[tuple[list[str], list[memoryview]]]:
-        if not chunk_keys:
-            return []
-        group_count = max(1, min(max_inflight_put, len(chunks)))
-        group_size = (len(chunks) + group_count - 1) // group_count
-        return [
-            (
-                list(chunk_keys[start : start + group_size]),
-                list(chunks[start : start + group_size]),
-            )
-            for start in range(0, len(chunks), group_size)
-        ]
-
     def _put_buffer_groups_parallel(
         self,
         chunk_keys: list[str],
         chunk_groups: list[Sequence[memoryview]],
         max_inflight_put: int,
+        config: Any = None,
     ) -> list[str]:
         groups = self._group_buffer_group_ranges(
             chunk_keys, chunk_groups, max_inflight_put
@@ -4358,6 +4393,7 @@ class _MooncakePayloadTransport:
                         self.batch_put_buffer_groups_from,
                         group_keys,
                         group_chunks,
+                        config,
                     )
                     for group_keys, group_chunks in groups
                 ]
@@ -4747,25 +4783,6 @@ class _MooncakePayloadTransport:
                 if succeeded:
                     raise
 
-    def _resolve_put_mode(
-        self,
-        chunks: Sequence[memoryview],
-        transfer_policy: BundleTransferPolicy,
-    ) -> Literal["batch", "parallel"]:
-        if transfer_policy.put_mode == "parallel":
-            return "parallel"
-        if transfer_policy.put_mode == "batch":
-            return "batch"
-        if transfer_policy.max_inflight_put <= 1:
-            return "batch"
-        if len(chunks) < AUTO_PARALLEL_MIN_CHUNKS:
-            return "batch"
-        if sum(len(chunk) for chunk in chunks) < AUTO_PARALLEL_MIN_BYTES:
-            return "batch"
-        if min(transfer_policy.max_inflight_put, len(chunks)) < 2:
-            return "batch"
-        return "parallel"
-
     def _resolve_buffer_group_put_mode(
         self,
         chunk_groups: Sequence[Sequence[memoryview]],
@@ -4785,11 +4802,6 @@ class _MooncakePayloadTransport:
         if min(transfer_policy.max_inflight_put, len(chunk_groups)) < 2:
             return "batch"
         return "parallel"
-
-    def _has_batch_put_support(self) -> bool:
-        return (
-            callable(self._batch_put_from) and self._has_buffer_registration_support()
-        )
 
     def _has_buffer_registration_support(self) -> bool:
         return callable(self._register_buffer) and callable(self._unregister_buffer)
@@ -5103,7 +5115,9 @@ def raw_destination(
 def _encode_structured_field(value: Any) -> tuple[dict[str, Any], Any]:
     if isinstance(value, _TensorObjectBufferPayload):
         return {"encoding": "torch_tensor"}, value
-    if isinstance(value, _MultiBufferPayload):
+    if isinstance(value, _TensorPayload):
+        return _encode_torch_tensor_field(value.tensor)
+    if isinstance(value, (_DirectCopyPayload, _MultiBufferPayload)):
         if value.dtype is not None and value.shape is not None:
             return {
                 "encoding": "ndarray",
@@ -5287,6 +5301,10 @@ def _normalize_structured_scalar(value: Any) -> Any:
 
 
 
+
+
+
+
 def _encode_msgpack_ragged_values(
     path: str, values: list[Any]
 ) -> tuple[dict[str, Any], dict[str, Any]]:
@@ -5442,48 +5460,6 @@ def _tensor_codec_helper(name: str) -> Any:
     return helper
 
 
-def _validate_pre_registered_structured_buffers(
-    original_buffers: Mapping[str, Any],
-    encoded_buffers: Mapping[str, Any],
-    pre_registered_buffers: Optional[Mapping[str, bool]],
-) -> None:
-    if not pre_registered_buffers:
-        return
-    for name, pre_registered in pre_registered_buffers.items():
-        if not pre_registered:
-            continue
-        if name not in original_buffers or name not in encoded_buffers:
-            raise ValueError(f"unknown pre-registered structured buffer: {name}")
-        if not _is_same_writable_buffer(original_buffers[name], encoded_buffers[name]):
-            raise ValueError(
-                f"pre-registered structured buffer {name} must be the same writable contiguous buffer used for transfer"
-            )
-
-
-def _is_same_writable_buffer(original: Any, encoded: Any) -> bool:
-    try:
-        original_view = memoryview(original)
-        encoded_view = memoryview(encoded)
-    except TypeError:
-        return False
-    if not original_view.c_contiguous or not encoded_view.c_contiguous:
-        return False
-    if original_view.readonly or encoded_view.readonly:
-        return False
-    if original_view.nbytes != encoded_view.nbytes:
-        return False
-    if original_view.nbytes == 0:
-        return True
-    try:
-        original_bytes = original_view.cast("B")
-        encoded_bytes = encoded_view.cast("B")
-        original_ptr = ctypes.addressof(ctypes.c_char.from_buffer(original_bytes))
-        encoded_ptr = ctypes.addressof(ctypes.c_char.from_buffer(encoded_bytes))
-    except (BufferError, TypeError, ValueError):
-        return False
-    return original_ptr == encoded_ptr
-
-
 def _structured_field_specs(metadata: Mapping[str, Any]) -> dict[str, Any]:
     field_specs = metadata.get(STRUCTURED_FIELD_SPECS_KEY, {})
     if not isinstance(field_specs, dict):
@@ -5636,6 +5612,8 @@ try:
     import torch as _torch
 except Exception:  # pragma: no cover
     _torch = None  # type: ignore[assignment]
+
+
 
 
 @dataclass

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -3824,13 +3824,11 @@ class _BundleManifestStore:
             key if num_chunks == 1 else f"{key}/chunk/{idx}"
             for idx in range(num_chunks)
         ]
-        def _put_chunk_batch(keys, batches, nthreads=1):
+        def _put_chunk_batch(keys, batches):
             for ck, (start, count, size) in zip(keys, batches):
                 lease = pool.acquire(size)
                 try:
-                    copied = _concat_arrays_into(
-                        arrays, lease.ptr, size, start, count, nthreads
-                    )
+                    copied = _concat_arrays_into(arrays, lease.ptr, size, start, count)
                     if copied != size:
                         raise RuntimeError(
                             f"native fast-copy wrote {copied} bytes, expected {size}"

--- a/mooncake-wheel/pyproject.toml
+++ b/mooncake-wheel/pyproject.toml
@@ -17,7 +17,7 @@
 # source of truth for the long description.
 
 [build-system]
-requires = ["setuptools>=61.0.0", "wheel>=0.37.0"]
+requires = ["setuptools>=61.0.0", "wheel>=0.37.0", "numpy"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/mooncake-wheel/setup.py
+++ b/mooncake-wheel/setup.py
@@ -1,6 +1,6 @@
 import sys
 import platform
-from setuptools import setup, Distribution
+from setuptools import setup, Distribution, Extension
 from wheel.bdist_wheel import bdist_wheel
 
 # ---------------------------------------------------------------------------
@@ -162,10 +162,26 @@ class CustomBdistWheel(bdist_wheel):
         self.plat_name = get_platform()
 
 
+
+# ---------------------------------------------------------------------------
+# C extensions
+# ---------------------------------------------------------------------------
+import numpy as np
+
+_fast_copy_ext = Extension(
+    "mooncake._fast_copy",
+    sources=["mooncake/_fast_copy.c"],
+    include_dirs=[np.get_include()],
+    extra_compile_args=["-O2", "-pthread"],
+    extra_link_args=["-lpthread"],
+)
+
+
 # ---------------------------------------------------------------------------
 # setup()
 # ---------------------------------------------------------------------------
 setup(
     distclass=BinaryDistribution,
     cmdclass={"bdist_wheel": CustomBdistWheel},
+    ext_modules=[_fast_copy_ext],
 )

--- a/mooncake-wheel/setup.py
+++ b/mooncake-wheel/setup.py
@@ -1,5 +1,7 @@
 import sys
 import platform
+
+import numpy as np
 from setuptools import setup, Distribution, Extension
 from wheel.bdist_wheel import bdist_wheel
 
@@ -166,8 +168,6 @@ class CustomBdistWheel(bdist_wheel):
 # ---------------------------------------------------------------------------
 # C extensions
 # ---------------------------------------------------------------------------
-import numpy as np
-
 _fast_copy_ext = Extension(
     "mooncake._fast_copy",
     sources=["mooncake/_fast_copy.c"],

--- a/mooncake-wheel/tests/test_fast_copy.py
+++ b/mooncake-wheel/tests/test_fast_copy.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import ctypes
+import unittest
+
+import numpy as np
+
+try:
+    from mooncake._fast_copy import concat_arrays_into
+except Exception as error:  # pragma: no cover - depends on built extension
+    concat_arrays_into = None
+    _FAST_COPY_IMPORT_ERROR = error
+else:
+    _FAST_COPY_IMPORT_ERROR = None
+
+
+@unittest.skipIf(
+    concat_arrays_into is None,
+    f"native fast-copy extension is unavailable: {_FAST_COPY_IMPORT_ERROR}",
+)
+class FastCopyTests(unittest.TestCase):
+    def test_concat_arrays_into_copies_selected_range(self) -> None:
+        arrays = [
+            np.arange(3, dtype=np.uint8),
+            np.arange(4, dtype=np.uint8) + 10,
+            np.arange(2, dtype=np.uint8) + 20,
+        ]
+        expected = np.concatenate(arrays[1:])
+        destination = ctypes.create_string_buffer(expected.nbytes)
+
+        copied = concat_arrays_into(
+            arrays, ctypes.addressof(destination), len(destination), 1, 2
+        )
+
+        self.assertEqual(copied, expected.nbytes)
+        self.assertEqual(destination.raw[:copied], expected.tobytes())
+
+    def test_concat_arrays_into_rejects_small_destination(self) -> None:
+        arrays = [np.arange(4, dtype=np.uint8), np.arange(4, dtype=np.uint8)]
+        destination = ctypes.create_string_buffer(7)
+
+        with self.assertRaisesRegex(ValueError, "destination buffer too small"):
+            concat_arrays_into(arrays, ctypes.addressof(destination), len(destination))
+
+    def test_concat_arrays_into_rejects_non_contiguous_source(self) -> None:
+        arrays = [np.arange(8, dtype=np.uint8)[::2]]
+        destination = ctypes.create_string_buffer(arrays[0].nbytes)
+
+        with self.assertRaisesRegex(ValueError, "C-contiguous"):
+            concat_arrays_into(arrays, ctypes.addressof(destination), len(destination))
+
+    def test_concat_arrays_into_empty_range_returns_zero(self) -> None:
+        arrays = [np.arange(4, dtype=np.uint8)]
+        destination = ctypes.create_string_buffer(1)
+
+        copied = concat_arrays_into(arrays, ctypes.addressof(destination), 0, 0, 0)
+
+        self.assertEqual(copied, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -589,91 +589,14 @@ def test_bundle_copy_mode_forces_store_put() -> None:
     assert result.objects["payload"] == payload
 
 
-def test_structured_object_copy_mode_skips_pre_registered_validation() -> None:
-    store, transfer = make_transfer()
-    payload = np.arange(64, dtype=np.uint8).reshape(8, 8).T
-
-    ref = transfer.put_structured_object(
-        structured_payload(payload=payload),
-        policy=BundleTransferPolicy(copy_mode="copy"),
-        pre_registered_buffers={"payload": True},
-    )
-
-    assert store.batch_put_from_calls == 0
-    assert store.register_buffer_calls == 0
-    assert store.unregister_buffer_calls == 0
-
-    result = transfer.materialize(transfer.read_spec(ref))
-    assert np.array_equal(result.objects["payload"], payload)
-
-
 def test_bundle_zero_copy_mode_requires_batch_put_support() -> None:
     _store, transfer = make_transfer(MinimalStore())
 
-    with pytest.raises(RuntimeError, match="zero-copy put requested"):
+    with pytest.raises(RuntimeError, match="zero-copy put"):
         transfer.put_structured_object(
             structured_payload(payload=b"data"),
             policy=BundleTransferPolicy(copy_mode="zero_copy"),
         )
-
-
-def test_structured_object_pre_registered_buffers_passthrough() -> None:
-    store, transfer = make_transfer()
-    payload = np.arange(64, dtype=np.uint8).reshape(8, 8)
-    payload_ptr = ctypes.addressof(ctypes.c_char.from_buffer(payload))
-    assert store.register_buffer(payload_ptr, int(payload.nbytes)) == 0
-    store.register_buffer_calls = 0
-    store.unregister_buffer_calls = 0
-
-    ref = transfer.put_structured_object(
-        structured_payload(payload=payload),
-        pre_registered_buffers={"payload": True},
-    )
-
-    assert store.batch_put_from_calls > 0
-    assert store.register_buffer_calls == 0
-    assert store.unregister_buffer_calls == 0
-    assert payload_ptr in store.registered
-
-    result = transfer.materialize(transfer.read_spec(ref))
-    assert np.array_equal(result.objects["payload"], payload)
-    store.unregister_buffer(payload_ptr)
-
-
-def test_structured_object_pre_registered_rejects_copied_buffers() -> None:
-    _store, transfer = make_transfer()
-    non_contiguous = np.arange(64, dtype=np.uint8).reshape(8, 8).T
-
-    with pytest.raises(ValueError, match="pre-registered structured buffer"):
-        transfer.put_structured_object(
-            structured_payload(payload=non_contiguous),
-            pre_registered_buffers={"payload": True},
-        )
-
-    with pytest.raises(ValueError, match="pre-registered structured buffer"):
-        transfer.put_structured_object(
-            structured_payload(payload=b"readonly"),
-            pre_registered_buffers={"payload": True},
-        )
-
-    with pytest.raises(ValueError, match="unknown pre-registered"):
-        transfer.put_structured_object(
-            structured_payload(payload=bytearray(b"data")),
-            pre_registered_buffers={"missing": True},
-        )
-
-
-def test_structured_object_pre_registered_empty_buffer() -> None:
-    _store, transfer = make_transfer()
-    payload = bytearray()
-
-    ref = transfer.put_structured_object(
-        structured_payload(payload=payload),
-        pre_registered_buffers={"payload": True},
-    )
-
-    result = transfer.materialize(transfer.read_spec(ref))
-    assert result.objects["payload"] == b""
 
 
 def test_structured_object_roundtrip() -> None:
@@ -745,6 +668,8 @@ def test_structured_object_ndarray_read_can_use_buffer_pool() -> None:
     payload = structured_payload(weights=array)
 
     ref = transfer.put_structured_object(payload, chunk_bytes=32)
+    pool.acquire_sizes.clear()
+    before_release_count = pool.release_count
     before_range_reads = store.get_into_ranges_calls
     result = transfer.materialize(transfer.read_spec(ref))
 
@@ -754,9 +679,9 @@ def test_structured_object_ndarray_read_can_use_buffer_pool() -> None:
     assert pool.acquire_sizes == [array.nbytes]
 
     MooncakeBundleTransfer.release_result(result.objects)
-    assert pool.release_count == 1
+    assert pool.release_count == before_release_count + 1
     MooncakeBundleTransfer.release_result(result.objects)
-    assert pool.release_count == 1
+    assert pool.release_count == before_release_count + 1
 
 
 def test_structured_object_multi_buffer_payload_uses_pool_batch_put() -> None:
@@ -809,30 +734,6 @@ def test_structured_object_multi_buffer_put_cleans_all_chunk_keys_on_failure() -
     assert pool.release_count == 2
 
 
-def test_structured_object_multi_buffer_zero_copy_put_uses_batch_put() -> None:
-    store, transfer = make_transfer()
-    parts = [bytearray(b"ab"), bytearray(b"cd"), bytearray(b"ef")]
-    payload = StructuredObjectPayload(
-        metadata={},
-        buffers={
-            "raw": sos._MultiBufferPayload(
-                buffers=tuple(memoryview(part) for part in parts),
-                owners=tuple(parts),
-            )
-        },
-    )
-
-    ref = transfer.put_structured_object(
-        payload, chunk_bytes=4, policy=BundleTransferPolicy(copy_mode="zero_copy")
-    )
-    result = transfer.materialize(transfer.read_spec(ref))
-
-    raw = result.objects["raw"]
-    raw_bytes = raw if isinstance(raw, bytes) else raw.tobytes()
-    assert raw_bytes == b"abcdef"
-    assert store.batch_put_from_calls > 0
-
-
 def test_structured_object_multi_buffer_zero_copy_requires_batch_put_support() -> None:
     _store, transfer = make_transfer(MinimalStore())
     parts = [bytearray(b"ab"), bytearray(b"cd")]
@@ -846,7 +747,7 @@ def test_structured_object_multi_buffer_zero_copy_requires_batch_put_support() -
         },
     )
 
-    with pytest.raises(RuntimeError, match="zero-copy put requested"):
+    with pytest.raises(RuntimeError, match="zero-copy put"):
         transfer.put_structured_object(
             payload, policy=BundleTransferPolicy(copy_mode="zero_copy")
         )
@@ -1031,48 +932,6 @@ def test_bundle_remove_recovers_after_transient_batch_failure() -> None:
 
     assert store.objects == {}
     assert store.batch_remove_calls == 1
-
-
-def test_bundle_concurrent_put_and_read_spec_full_read() -> None:
-    store, transfer = make_transfer(GetOnlyStore())
-    payload = bytes(range(128))
-
-    ref = transfer.put_structured_object(
-        structured_payload(payload=payload),
-        chunk_bytes=8,
-        policy=BundleTransferPolicy(max_inflight_put=4, put_mode="parallel"),
-    )
-    result = transfer.materialize(transfer.read_spec(ref))
-
-    assert result.objects["payload"] == payload
-    assert store.max_active_puts > 1
-    assert store.max_active_gets >= 1
-
-
-def test_bundle_duplicate_source_registration_is_tolerated() -> None:
-    store, transfer = make_transfer(StrictRegisterStore())
-    payload = np.arange(64, dtype=np.uint8).reshape(8, 8)
-    payload_ptr = ctypes.addressof(ctypes.c_char.from_buffer(payload))
-    assert store.register_buffer(payload_ptr, int(payload.nbytes)) == 0
-
-    ref = transfer.put_structured_object(structured_payload(payload=payload))
-
-    assert ref.manifest["buffers"]["payload"]["bytes"] == int(payload.nbytes)
-    assert payload_ptr in store.registered
-    store.unregister_buffer(payload_ptr)
-
-
-def test_bundle_partial_register_failure_unwinds_registered_buffers() -> None:
-    store, transfer = make_transfer(FailingRegisterStore(fail_on_register=2))
-    payload = bytes(range(64))
-
-    with pytest.raises(RuntimeError, match="register_buffer"):
-        transfer.put_structured_object(
-            structured_payload(payload=payload), chunk_bytes=32
-        )
-
-    assert store.registered == set()
-    assert store.objects == {}
 
 
 def test_bundle_batch_get_failure_unregisters_buffer() -> None:
@@ -1963,14 +1822,14 @@ def test_unified_put_rejects_unknown_type() -> None:
 
 
 @pytest.mark.parametrize(
-    ("policy", "config_attr"),
+    ("policy", "config_attr", "use_pool"),
     [
-        (BundleTransferPolicy(copy_mode="copy"), "put_configs"),
-        (None, "batch_put_from_configs"),
+        (BundleTransferPolicy(copy_mode="copy"), "put_configs", False),
+        (None, "batch_put_from_configs", True),
     ],
 )
-def test_unified_dict_put_passes_store_config_to_writes(policy, config_attr) -> None:
-    store, transfer = make_transfer()
+def test_unified_dict_put_passes_store_config_to_writes(policy, config_attr, use_pool) -> None:
+    store, transfer = make_transfer(buffer_pool=FakeBufferPool() if use_pool else None)
     config = object()
     data = {"input_ids": np.arange(12, dtype=np.int64).reshape(4, 3)}
     kwargs = {"config": config}
@@ -2026,6 +1885,41 @@ def test_unified_dict_put_accepts_field_schemas() -> None:
     assert result["global_batch_sizes"] == [2]
     assert result["num_microbatches"] == 1
     assert result["step"] == 7
+
+
+def test_release_result_recurses_into_ragged_row_views() -> None:
+    class FakeOwner:
+        def __init__(self) -> None:
+            self.release_count = 0
+
+        def release(self) -> None:
+            self.release_count += 1
+
+    class OwnedArray(np.ndarray):
+        def __new__(cls, data, owner):
+            array = np.asarray(data).view(cls)
+            array._mooncake_pool_owner = owner
+            return array
+
+        def __array_finalize__(self, obj) -> None:
+            if obj is not None:
+                self._mooncake_pool_owner = getattr(
+                    obj, "_mooncake_pool_owner", None
+                )
+
+    owner = FakeOwner()
+    other_owner = FakeOwner()
+    base = OwnedArray(np.arange(6, dtype=np.int64), owner)
+    other = OwnedArray(np.arange(2, dtype=np.int64), other_owner)
+    object_items = np.empty(1, dtype=object)
+    object_items[0] = base[4:5]
+
+    MooncakeBundleTransfer.release_result(
+        {"values": [None, 0, base[:2], {"nested": (base[2:4], object_items)}, other[:1]]}
+    )
+
+    assert owner.release_count == 1
+    assert other_owner.release_count == 1
 
 
 def test_ref_aliases_match_dataproto_ref_helpers() -> None:
@@ -3004,12 +2898,29 @@ def test_dataproto_helper_typed_ragged_uses_multi_buffer_put() -> None:
     result = transfer.get_dataproto(ref)
 
     assert ref.encoded_non_tensor["tokens"]["codec"] == "typed_ragged"
-    assert result["non_tensor_batch"]["tokens"].tolist() == [[1, 2], None, [3, 4, 5]]
+    tokens = result["non_tensor_batch"]["tokens"].tolist()
+    assert tokens == [[1, 2], None, [3, 4, 5]]
     assert rows[0].nbytes + rows[2].nbytes in pool.acquire_sizes
 
 
-def test_dataproto_helper_typed_ragged_zero_copy_put() -> None:
-    store, transfer = make_transfer()
+def test_typed_ragged_uses_direct_copy_payload_when_fast_copy_available() -> None:
+    if sos._concat_arrays_into is None:
+        pytest.skip("native fast-copy extension is unavailable")
+    rows = [
+        np.arange(2, dtype=np.int32),
+        np.arange(3, dtype=np.int32),
+    ]
+
+    payload, metadata = sos._encode_typed_ragged_values(rows, dtype_hint=np.int32)
+
+    assert metadata["shape_policy"] == "ragged"
+    assert isinstance(payload["data"], sos._DirectCopyPayload)
+    assert payload["data"].shape == (5,)
+
+
+def test_dataproto_helper_typed_ragged_fast_copy_put() -> None:
+    pool = FakeBufferPool()
+    store, transfer = make_transfer(buffer_pool=pool)
     rows = np.empty(3, dtype=object)
     rows[:] = [
         np.asarray([1, 2], dtype=np.int32),
@@ -3018,11 +2929,40 @@ def test_dataproto_helper_typed_ragged_zero_copy_put() -> None:
     ]
     data = SimpleDataProto(non_tensor_batch={"tokens": rows})
 
-    ref = transfer.put_dataproto(data, policy=BundleTransferPolicy(copy_mode="zero_copy"))
+    ref = transfer.put_dataproto(data)
     result = transfer.get_dataproto(ref)
 
-    assert result["non_tensor_batch"]["tokens"].tolist() == [[1, 2], None, [3, 4, 5]]
+    tokens = result["non_tensor_batch"]["tokens"].tolist()
+    assert tokens == [[1, 2], None, [3, 4, 5]]
     assert store.batch_put_from_calls > 0
+    assert rows[0].nbytes + rows[2].nbytes in pool.acquire_sizes
+
+
+def test_dataproto_helper_typed_ragged_rejects_short_fast_copy(monkeypatch) -> None:
+    pool = FakeBufferPool()
+    _store, transfer = make_transfer(buffer_pool=pool)
+    rows = np.empty(2, dtype=object)
+    rows[:] = [np.asarray([1, 2], dtype=np.int32), np.asarray([3], dtype=np.int32)]
+
+    monkeypatch.setattr(sos, "_concat_arrays_into", lambda *args: args[2] - 1)
+
+    with pytest.raises(RuntimeError, match="native fast-copy wrote"):
+        transfer.put_dataproto(SimpleDataProto(non_tensor_batch={"tokens": rows}))
+
+
+def test_dataproto_helper_typed_ragged_zero_copy_rejects_source_buffers() -> None:
+    _store, transfer = make_transfer(buffer_pool=FakeBufferPool())
+    rows = np.empty(2, dtype=object)
+    rows[:] = [
+        np.asarray([1, 2], dtype=np.int32),
+        np.asarray([3], dtype=np.int32),
+    ]
+
+    with pytest.raises(RuntimeError, match="zero-copy put"):
+        transfer.put_dataproto(
+            SimpleDataProto(non_tensor_batch={"tokens": rows}),
+            policy=BundleTransferPolicy(copy_mode="zero_copy"),
+        )
 
 
 def test_dataproto_helper_rejects_unsupported_object_non_tensor() -> None:

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -2938,6 +2938,33 @@ def test_dataproto_helper_typed_ragged_fast_copy_put() -> None:
     assert rows[0].nbytes + rows[2].nbytes in pool.acquire_sizes
 
 
+def test_direct_copy_put_rolls_back_all_chunks_on_late_failure() -> None:
+    if sos._concat_arrays_into is None:
+        pytest.skip("native fast-copy extension is unavailable")
+    store = FailingBatchPutStore(fail_on_call=2)
+    pool = FakeBufferPool()
+    _, transfer = make_transfer(store=store, buffer_pool=pool)
+    arrays = [
+        np.asarray([1, 2], dtype=np.int32),
+        np.asarray([3, 4], dtype=np.int32),
+        np.asarray([5, 6], dtype=np.int32),
+    ]
+    payload = sos._DirectCopyPayload.from_flat_arrays(
+        arrays, np.dtype(np.int32), total_elems=6
+    )
+
+    with pytest.raises(RuntimeError, match="batch_put_from"):
+        transfer._bundle_store._put_direct_copy_payload(
+            "payload",
+            payload,
+            chunk_bytes=8,
+            transfer_policy=BundleTransferPolicy(),
+        )
+
+    assert store.objects == {}
+    assert pool.acquire_count == pool.release_count == 2
+
+
 def test_dataproto_helper_typed_ragged_rejects_short_fast_copy(monkeypatch) -> None:
     pool = FakeBufferPool()
     _store, transfer = make_transfer(buffer_pool=pool)

--- a/scripts/build_wheel.sh
+++ b/scripts/build_wheel.sh
@@ -275,7 +275,7 @@ if [ "$NPU_BUILD" = "1" ]; then
     max_attempts=3
     attempt=1
     while [ $attempt -le $max_attempts ]; do
-        if "$PYTHON_CMD" -m pip install --upgrade pip build setuptools wheel auditwheel; then
+        if "$PYTHON_CMD" -m pip install --upgrade pip build setuptools wheel auditwheel numpy; then
             break
         fi
         echo "pip install attempt $attempt/$max_attempts failed, retrying in 5s..."

--- a/scripts/test_installation.sh
+++ b/scripts/test_installation.sh
@@ -38,6 +38,8 @@ echo "Running import structure test..."
 cp -r mooncake-wheel/tests test_env/
 cd test_env
 pip install torch==2.11.0 numpy
+python -c "import mooncake._fast_copy"
+python tests/test_fast_copy.py
 python tests/test_import_structure.py
 
 echo "Running mooncake config test..."


### PR DESCRIPTION
## Description

This PR splits the native fast-copy PUT hot-path optimization out of the previous large rollout transfer optimization branch.

RL rollout transfer has several hot paths made of many small ndarray rows and large object payloads. The previous source-buffer PUT path could rely on temporary source registration and Python-level copy loops, which is expensive for Miles/Slime-style rollout data and makes source-buffer lifetime semantics harder to reason about.

This change:
- adds a small native `_fast_copy` extension for scatter-copying ndarray lists into a destination buffer while releasing the GIL;
- pins ndarray references and validates the destination byte count before the GIL is released, so the native copy path cannot outlive borrowed Python objects or overflow the BufferPool lease;
- introduces `_DirectCopyPayload` so typed-ragged ndarray rows can be copied directly into BufferPool leases at PUT time;
- removes the temporary source-buffer registration PUT path and routes non-tensor structured PUTs through BufferPool staging plus `batch_put_from`;
- keeps tensor-object zero-copy semantics explicit and intentionally rejects source-buffer zero-copy requests for typed-ragged/direct-copy payloads;
- keeps this PR independent from the typed-ragged layout PR (#3113). If both PRs are merged, #3113 should land first and this PR can be rebased on top to resolve the mechanical overlap in `structured_object_store.py`;
- keeps the rollout-transfer tuned defaults used by the optimization branch: 64 MB bundle chunks and parallel PUT threshold aligned with the chunk size. This default change is deliberate for structured/bundle rollout PUTs and remains overridable by caller policy/configuration.

The native extension build uses NumPy headers through the wheel build environment; `pyproject.toml` includes NumPy in the build-system requirements, and the NPU `--no-isolation` wheel build path now installs NumPy before invoking the build backend.

Performance validation from rollout transfer benchmark targets:

| Scenario | Baseline behavior | Optimized behavior |
| --- | ---: | ---: |
| Miles rollout dict, 4 GiB | PUT 14.184s on the slow path before DirectCopy; latest main baseline GET did not finish within 3 minutes | PUT 6.460s, GET 3.942s |
| Slime rollout capture, 17.2 GB | transfer remains on the BufferPool/RDMA hot path | PUT 1.984s, GET 1.709s |

The Miles numbers are for the native fast-copy/BufferPool PUT hot path. The Slime numbers validate that the source-register cleanup and tuned chunk defaults keep the large rollout-object path on the expected RDMA hot path.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [x] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
cd mooncake-wheel
python setup.py build_ext --inplace
python - <<'PY'
from mooncake._fast_copy import concat_arrays_into
print(concat_arrays_into)
PY
python -m unittest -v tests.test_fast_copy
python -m pytest tests/test_structured_object_store.py -q --tb=short
python -m py_compile mooncake/structured_object_store.py tests/test_structured_object_store.py tests/test_fast_copy.py
git diff --check
cd ../docs
make html SPHINXOPTS=-W
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done

Result:
```text
structured-object validation: 76 passed, 25 skipped
late-chunk rollback regression: passed
fast-copy boundary tests: 4 passed
native extension build/import: passed
Sphinx docs strict build: passed
code_format: passed
py_compile: passed
git diff --check: passed
```

Additional manual validation:
```text
Miles rollout dict cross-machine benchmark:
PUT avg: 6460ms
GET avg: 3941.9ms

Slime rollout capture cross-machine benchmark:
17.2 GB PUT: 1984ms
17.2 GB GET: 1708.6ms
```

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

Note: this focused split is slightly above 500 additions after retaining reviewer-requested safety/regression coverage for the native extension boundary. Python formatting/pre-commit were not used as the validation signal for this focused split to avoid unrelated repository-wide formatting churn; native extension build/import, targeted unit tests, `py_compile`, and `git diff --check` were used.

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex was used to split this focused PR out of the previous large rollout transfer optimization branch, review the diff, run validation, and prepare the PR description. The human submitter is responsible for understanding and defending all changes.
