### PR TITLE
[Wheel] Optimize typed-ragged rollout layout

### DIFF
--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -3765,7 +3765,6 @@ class _BundleManifestStore:
             memoryview(payload),
             len(payload) or 1,
             transfer_policy,
-            pre_registered=False,
             config=config,
         )
         payload_spec["metadata_bytes"] = metadata_bytes

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -668,7 +668,7 @@ class MooncakeBundleTransfer:
         """Materialize a DataProto-like object or flat dict."""
         if type not in {"dataproto", "dict"}:
             raise ValueError(f"unsupported Mooncake payload type: {type!r}")
-        result = self.get_dataproto(
+        result = self._get_dataproto(
             ref,
             fields=fields,
             batch_fields=batch_fields,
@@ -677,6 +677,7 @@ class MooncakeBundleTransfer:
             data_cls=dict if type == "dict" else data_cls,
             destinations=destinations,
             rows=rows,
+            _flat_dict_output=(type == "dict"),
         )
         return _envelope_to_flat_dict(result) if type == "dict" else result
 
@@ -750,6 +751,31 @@ class MooncakeBundleTransfer:
         rows: slice | StructuredMemberSlice | Sequence[int] | None = None,
     ) -> Any:
         """Materialize selected DataProto fields from structured object refs."""
+        return self._get_dataproto(
+            ref,
+            fields=fields,
+            batch_fields=batch_fields,
+            non_tensor_fields=non_tensor_fields,
+            meta_info_keys=meta_info_keys,
+            data_cls=data_cls,
+            destinations=destinations,
+            rows=rows,
+        )
+
+    def _get_dataproto(
+        self,
+        ref: DataProtoRefLike,
+        *,
+        fields: Optional[Sequence[str]] = None,
+        batch_fields: Optional[Sequence[str]] = None,
+        non_tensor_fields: Optional[Sequence[str]] = None,
+        meta_info_keys: Optional[Sequence[str]] = None,
+        data_cls: Optional[Any] = None,
+        destinations: Optional[Mapping[str, Any]] = None,
+        rows: slice | StructuredMemberSlice | Sequence[int] | None = None,
+        _flat_dict_output: bool = False,
+    ) -> Any:
+        """Materialize selected DataProto fields from structured object refs."""
         ref = _resolve_dataproto_ref(ref)
         row_selection = _coerce_dataproto_row_selection(rows, ref.batch_size)
         row_slice = None if row_selection is None else row_selection.member_slice
@@ -814,41 +840,61 @@ class MooncakeBundleTransfer:
                     batch[name] = value
                 else:
                     non_tensor_batch[name] = value
-        for name, location in encoded_requests:
-            stage_ref = ref.stage_refs[location.stage]
-            encoded = ref.encoded_non_tensor[name]
-            if row_selection is None:
-                members = list(encoded["payload_members"].values())
+        if row_selection is None and encoded_requests:
+            by_stage_encoded: dict[str, list[tuple[str, StructuredFieldLocation]]] = {}
+            for name, location in encoded_requests:
+                by_stage_encoded.setdefault(location.stage, []).append((name, location))
+            for stage, entries in by_stage_encoded.items():
+                stage_ref = ref.stage_refs[stage]
+                members: list[str] = []
+                for name, _location in entries:
+                    encoded = ref.encoded_non_tensor[name]
+                    members.extend(encoded["payload_members"].values())
                 result = self.materialize(
                     self.read_spec(stage_ref).select_members(members)
                 )
-                payload = {
-                    payload_name: result.objects[member]
-                    for payload_name, member in encoded["payload_members"].items()
-                }
-                values = _decode_structured_non_tensor_encoded(
-                    encoded, payload, ref.batch_size, encoded.get("metadata")
+                for name, _location in entries:
+                    encoded = ref.encoded_non_tensor[name]
+                    payload = {
+                        payload_name: result.objects[member]
+                        for payload_name, member in encoded["payload_members"].items()
+                    }
+                    values = _decode_structured_non_tensor_encoded(
+                        encoded, payload, ref.batch_size, encoded.get("metadata")
+                    )
+                    non_tensor_batch[name] = (
+                        values
+                        if _flat_dict_output
+                        else _object_array_from_decoded_values(values)
+                    )
+        else:
+            for name, location in encoded_requests:
+                stage_ref = ref.stage_refs[location.stage]
+                encoded = ref.encoded_non_tensor[name]
+                if row_indices is not None:
+                    payload, metadata = self._read_structured_non_tensor_payload_indices(
+                        stage_ref,
+                        encoded,
+                        row_indices,
+                    )
+                    values = _decode_structured_non_tensor_encoded(
+                        encoded, payload, output_rows, metadata
+                    )
+                else:
+                    payload, metadata = self._read_structured_non_tensor_payload_slice(
+                        stage_ref,
+                        encoded,
+                        row_slice,
+                        ref.batch_size,
+                    )
+                    values = _decode_structured_non_tensor_encoded(
+                        encoded, payload, output_rows, metadata
+                    )
+                non_tensor_batch[name] = (
+                    values
+                    if _flat_dict_output
+                    else _object_array_from_decoded_values(values)
                 )
-            elif row_indices is not None:
-                payload, metadata = self._read_structured_non_tensor_payload_indices(
-                    stage_ref,
-                    encoded,
-                    row_indices,
-                )
-                values = _decode_structured_non_tensor_encoded(
-                    encoded, payload, output_rows, metadata
-                )
-            else:
-                payload, metadata = self._read_structured_non_tensor_payload_slice(
-                    stage_ref,
-                    encoded,
-                    row_slice,
-                    ref.batch_size,
-                )
-                values = _decode_structured_non_tensor_encoded(
-                    encoded, payload, output_rows, metadata
-                )
-            non_tensor_batch[name] = _object_array_from_decoded_values(values)
         meta_info = _select_mapping(ref.meta_info, meta_info_keys)
         return _build_dataproto_like_result(
             batch, non_tensor_batch, meta_info, data_cls
@@ -1883,7 +1929,7 @@ def _envelope_to_flat_dict(data: Mapping[str, Any]) -> dict[str, Any]:
     result.update(batch)
     for name, value in non_tensor_batch.items():
         result[name] = (
-            list(value)
+            value.tolist()
             if isinstance(value, np.ndarray) and value.dtype == object
             else value
         )
@@ -5711,14 +5757,24 @@ def _decode_msgpack_ragged_values(payload: dict[str, Any], rows: int) -> list[An
             f"msgpack_ragged nulls length {len(nulls)} does not match rows {rows}"
         )
     raw_data = bytes(data) if not isinstance(data, bytes) else data
+    if rows == 0 or not bool(nulls.any()):
+        unpacker = _msgpack.Unpacker(raw=False)
+        unpacker.feed(raw_data)
+        values = list(unpacker)
+        if len(values) != rows:
+            raise ValueError(
+                f"msgpack_ragged decoded {len(values)} rows, expected {rows}"
+            )
+        return values
+    unpacker = _msgpack.Unpacker(raw=False)
+    unpacker.feed(raw_data)
+    non_null_iter = iter(unpacker)
     values = []
-    for row, is_null in enumerate(nulls):
+    for is_null in nulls:
         if bool(is_null):
             values.append(None)
         else:
-            begin = int(offsets[row])
-            end = int(offsets[row + 1])
-            values.append(_msgpack.unpackb(raw_data[begin:end], raw=False))
+            values.append(next(non_null_iter))
     return values
 
 

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -31,6 +31,8 @@ MISSING_OBJECT_ERROR = (
     -704
 )  # Mooncake remove returns -704 for an already-missing object.
 STRUCTURED_FIELD_SPECS_KEY = "__mooncake_structured_fields__"
+_TYPED_RAGGED_DEFAULT_DTYPE = "int64"
+_RAGGED_TENSOR_DEFAULT_DTYPE = "torch.float32"
 _ENCODING_FALLBACK_ERRORS = (
     TypeError,
     ValueError,
@@ -2598,81 +2600,57 @@ def _encode_ragged_tensor_values(
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     if _torch is None:
         raise RuntimeError("torch is required to encode ragged tensor fields")
-    tensors: list[Any] = []
-    dtype = None
-    max_ndim = 0
+    # Determine torch dtype and convert all values to numpy arrays.
+    torch_dtype = None
+    converted: list[Any] = []
     for value in values:
         if value is None:
-            tensors.append(None)
+            converted.append(None)
             continue
-        tensor = value.detach()
+        if isinstance(value, np.ndarray):
+            if value.dtype == object:
+                raise ValueError("ragged tensor codec requires numeric ndarray values")
+            if not value.flags.writeable:
+                value = value.copy()
+            tensor = _torch.as_tensor(value)
+        else:
+            tensor = value.detach()
         if tensor.device.type != "cpu" or not tensor.is_contiguous():
             tensor = tensor.cpu().contiguous()
-        dtype = tensor.dtype if dtype is None else dtype
-        if tensor.dtype != dtype:
-            raise ValueError(f"mixed tensor dtype: {dtype} vs {tensor.dtype}")
-        max_ndim = max(max_ndim, tensor.dim())
-        tensors.append(tensor)
-    offsets = _torch.zeros(len(tensors) + 1, dtype=_torch.int64)
-    ndims = _torch.zeros(len(tensors), dtype=_torch.int16)
-    shapes = _torch.zeros((len(tensors), max(max_ndim, 1)), dtype=_torch.int64)
-    nulls = np.asarray([tensor is None for tensor in tensors], dtype=np.bool_)
-    flat_parts = []
-    offset = 0
-    for row, tensor in enumerate(tensors):
-        if tensor is None:
-            offsets[row + 1] = offset
-            continue
-        flat = tensor.reshape(-1)
-        flat_parts.append(flat)
-        offset += flat.numel()
-        offsets[row + 1] = offset
-        ndims[row] = tensor.dim()
-        if tensor.dim() > 0:
-            shapes[row, : tensor.dim()] = _torch.tensor(
-                list(tensor.shape), dtype=_torch.int64
-            )
-    data_dtype = dtype or _torch.float32
-    data = (
-        _torch.cat(flat_parts) if flat_parts else _torch.empty((0,), dtype=data_dtype)
-    )
-    payload = {
-        "data": data.numpy(),
-        "offsets": offsets.numpy(),
-        "shapes": shapes.numpy(),
-        "ndims": ndims.numpy(),
-        "nulls": nulls,
-    }
-    return payload, {
-        "dtype": str(data_dtype),
-        "max_ndim": int(max_ndim),
-        "shape_policy": "ragged",
-    }
-
+        if tensor.dtype == _torch.bfloat16:
+            raise ValueError("ragged tensor codec does not support torch.bfloat16")
+        torch_dtype = tensor.dtype if torch_dtype is None else torch_dtype
+        if tensor.dtype != torch_dtype:
+            raise ValueError(f"mixed tensor dtype: {torch_dtype} vs {tensor.dtype}")
+        converted.append(tensor.numpy())
+    data_dtype = torch_dtype or _parse_torch_dtype(_RAGGED_TENSOR_DEFAULT_DTYPE)
+    np_dtype = np.dtype(_torch_dtype_to_numpy(str(data_dtype)))
+    payload, meta = _encode_typed_ragged_values(converted, np_dtype)
+    meta["dtype"] = str(data_dtype)
+    return payload, meta
 
 def _decode_ragged_tensor_values(
-    payload: dict[str, Any],
-    rows: int,
-    metadata: Optional[Mapping[str, Any]] = None,
+    payload: dict[str, Any], rows: int, metadata: Optional[Mapping[str, Any]] = None
 ) -> list[Any]:
     if _torch is None:
         raise RuntimeError("torch is required to decode ragged tensor fields")
-    data = _torch.from_numpy(payload["data"])
-    offsets = payload["offsets"]
-    shapes = payload["shapes"]
-    ndims = payload["ndims"]
-    nulls = payload["nulls"]
-    values = []
-    for row in range(rows):
-        if bool(nulls[row]):
-            values.append(None)
-            continue
-        begin = int(offsets[row])
-        end = int(offsets[row + 1])
-        ndim = int(ndims[row])
-        shape = tuple(int(v) for v in shapes[row, :ndim].tolist())
-        values.append(data[begin:end].reshape(shape))
-    return values
+    # Metadata stores torch dtype strings (e.g. "torch.int64"); convert to numpy
+    # dtype so _decode_typed_ragged_values can parse it.
+    dtype_str = (metadata or {}).get("dtype", _RAGGED_TENSOR_DEFAULT_DTYPE)
+    np_dtype = _torch_dtype_to_numpy(dtype_str)
+    patched_meta = dict(metadata) if metadata else {}
+    patched_meta["dtype"] = str(np_dtype)
+    np_values = _decode_typed_ragged_values(payload, rows, patched_meta)
+    torch_dtype = _parse_torch_dtype(dtype_str)
+    result: list[Any] = []
+    for v in np_values:
+        if v is None:
+            result.append(None)
+        elif isinstance(v, np.ndarray):
+            result.append(_torch.from_numpy(v).to(torch_dtype))
+        else:
+            result.append(_torch.as_tensor(v, dtype=torch_dtype))
+    return result
 
 def _normalize_ragged_tensor_dict_keys(keys: Any) -> list[str]:
     if isinstance(keys, Mapping):
@@ -2819,15 +2797,20 @@ def _encode_typed_ragged_values(
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     if dtype_hint is None:
         source_arrays = [np.asarray(value) for value in values if value is not None]
-        dtype = np.result_type(*source_arrays) if source_arrays else np.dtype(np.int64)
+        dtype = np.result_type(*source_arrays) if source_arrays else np.dtype(_TYPED_RAGGED_DEFAULT_DTYPE)
     else:
         dtype = np.dtype(dtype_hint)
     if dtype.hasobject:
         raise ValueError("typed_ragged codec requires non-object dtype")
+
+    ndarray_encoded = _encode_typed_ragged_ndarray_rows(values, dtype)
+    if ndarray_encoded is not None:
+        return ndarray_encoded
+
     arrays = [
         np.asarray([], dtype=dtype)
         if value is None
-        else np.ascontiguousarray(np.asarray(value, dtype=dtype))
+        else _as_contiguous_array_preserve_ndim(value, dtype)
         for value in values
     ]
     max_ndim = max((array.ndim for array in arrays), default=0)
@@ -2845,27 +2828,33 @@ def _encode_typed_ragged_values(
         ndims[row] = array.ndim
         if array.ndim > 0:
             shapes[row, : array.ndim] = array.shape
+    total_elems = int(offset)
     if flat_arrays:
         if _concat_arrays_into is not None:
-            data = _DirectCopyPayload.from_flat_arrays(
-                flat_arrays, dtype, int(offset)
-            )
+            data = _DirectCopyPayload.from_flat_arrays(flat_arrays, dtype, total_elems)
         else:
             buffers = tuple(memoryview(flat.data).cast("B") for flat in flat_arrays)
             data = _MultiBufferPayload(
                 buffers=buffers,
                 owners=tuple(flat_arrays),
                 dtype=np.dtype(dtype).str,
-                shape=(int(offset),),
+                shape=(total_elems,),
             )
     else:
         empty = np.empty(0, dtype=dtype)
         data = _MultiBufferPayload(
-            buffers=(memoryview(empty.data).cast("B"),),
-            owners=(empty,),
-            dtype=np.dtype(dtype).str,
-            shape=(0,),
+            buffers=(memoryview(empty.data).cast("B"),), owners=(empty,),
+            dtype=np.dtype(dtype).str, shape=(0,),
         )
+    ndarray_rows = [
+        value is not None and isinstance(value, np.ndarray) for value in values
+    ]
+    if all(value is None or is_array for value, is_array in zip(values, ndarray_rows)):
+        row_format = "ndarray"
+    elif any(ndarray_rows):
+        row_format = "mixed"
+    else:
+        row_format = "list"
     return (
         {
             "data": data,
@@ -2874,18 +2863,47 @@ def _encode_typed_ragged_values(
             "ndims": ndims,
             "nulls": nulls,
         },
-        {"dtype": str(dtype), "max_ndim": int(max_ndim), "shape_policy": "ragged"},
+        {
+            "dtype": str(dtype),
+            "max_ndim": int(max_ndim),
+            "shape_policy": "ragged",
+            "row_format": row_format,
+            "ndarray_rows": ndarray_rows if row_format == "mixed" else None,
+        },
     )
-
 
 def _decode_typed_ragged_values(
     payload: dict[str, Any], rows: int, metadata: Optional[Mapping[str, Any]] = None
 ) -> list[Any]:
-    data = payload["data"]
+    raw = payload["data"]
+    dtype_str = (metadata or {}).get("dtype", _TYPED_RAGGED_DEFAULT_DTYPE)
+    np_dtype = np.dtype(dtype_str)
+    # data may arrive as torch.Tensor, bytes, or numpy (pool-backed or typed)
+    if _torch is not None and isinstance(raw, _torch.Tensor):
+        data = raw.numpy()
+    elif isinstance(raw, (bytes, bytearray, memoryview)):
+        data = np.frombuffer(raw, dtype=np_dtype)
+    elif isinstance(raw, np.ndarray):
+        data = raw if raw.dtype == np_dtype else np.frombuffer(raw, dtype=np_dtype)
+    else:
+        data = np.asarray(raw, dtype=np_dtype)
     offsets = payload["offsets"]
     shapes = payload["shapes"]
     ndims = payload["ndims"]
     nulls = payload["nulls"]
+    metadata = metadata or {}
+    row_format = metadata.get("row_format")
+    if (
+        row_format == "ndarray"
+        and metadata.get("physical_layout") == "contiguous_flat"
+    ):
+        fast_values = _decode_typed_ragged_ndarray_rows_fast(
+            data, offsets, shapes, ndims, nulls, rows, metadata
+        )
+        if fast_values is not None:
+            return fast_values
+
+    ndarray_rows = metadata.get("ndarray_rows") or []
     values = []
     for row in range(rows):
         if bool(nulls[row]):
@@ -2895,7 +2913,13 @@ def _decode_typed_ragged_values(
         end = int(offsets[row + 1])
         ndim = int(ndims[row])
         shape = tuple(int(v) for v in shapes[row, :ndim].tolist())
-        values.append(data[begin:end].reshape(shape).tolist())
+        array = data[begin:end].reshape(shape)
+        if row_format == "ndarray" or (
+            row_format == "mixed" and bool(ndarray_rows[row])
+        ):
+            values.append(array)
+        else:
+            values.append(array.tolist())
     return values
 
 
@@ -5338,7 +5362,313 @@ def _normalize_structured_scalar(value: Any) -> Any:
 
 
 
+def _encode_typed_ragged_regular_ndarray_rows(
+    values: list[Any], dtype: np.dtype[Any]
+) -> tuple[dict[str, Any], dict[str, Any]] | None:
+    row_count = len(values)
+    if row_count < 2:
+        return None
+    first = values[0]
+    if (
+        not isinstance(first, np.ndarray)
+        or first.dtype != dtype
+        or not first.flags.c_contiguous
+    ):
+        return None
+    shape = first.shape
+    for value in values[1:]:
+        if (
+            not isinstance(value, np.ndarray)
+            or value.dtype != dtype
+            or not value.flags.c_contiguous
+            or value.shape != shape
+        ):
+            return None
 
+    row_elems = int(first.size)
+    total_elems = row_count * row_elems
+    if row_elems:
+        flat_arrays = [value.reshape(-1) for value in values]
+        if _concat_arrays_into is not None:
+            data = _DirectCopyPayload.from_flat_arrays(flat_arrays, dtype, total_elems)
+        else:
+            data = _MultiBufferPayload(
+                buffers=tuple(memoryview(flat.data).cast("B") for flat in flat_arrays),
+                owners=tuple(flat_arrays),
+                dtype=np.dtype(dtype).str,
+                shape=(total_elems,),
+            )
+    else:
+        data = np.asarray(values, dtype=dtype).reshape(-1)
+    offsets = np.arange(row_count + 1, dtype=np.int64) * row_elems
+    nulls = np.zeros(row_count, dtype=np.bool_)
+    max_ndim = int(first.ndim)
+    if max_ndim == 0:
+        shapes = np.zeros((row_count, 1), dtype=np.int64)
+        ndims = np.zeros(row_count, dtype=np.int16)
+    else:
+        shapes = np.empty((row_count, max_ndim), dtype=np.int64)
+        shapes[:] = shape
+        ndims = np.full(row_count, max_ndim, dtype=np.int16)
+    return (
+        {
+            "data": data,
+            "offsets": offsets,
+            "shapes": shapes,
+            "ndims": ndims,
+            "nulls": nulls,
+        },
+        {
+            "dtype": str(dtype),
+            "max_ndim": max_ndim,
+            "shape_policy": "ragged",
+            "row_format": "ndarray",
+            "ndarray_rows": None,
+            "physical_layout": "contiguous_flat",
+        },
+    )
+
+
+def _encode_typed_ragged_ndarray_rows(
+    values: list[Any], dtype: np.dtype[Any]
+) -> tuple[dict[str, Any], dict[str, Any]] | None:
+    regular_encoded = _encode_typed_ragged_regular_ndarray_rows(values, dtype)
+    if regular_encoded is not None:
+        return regular_encoded
+
+    row_count = len(values)
+    if row_count == 0:
+        return None
+
+    nulls = np.empty(row_count, dtype=np.bool_)
+    lengths = np.empty(row_count, dtype=np.int64)
+    arrays: list[np.ndarray] = []
+    tail_shape: tuple[int, ...] | None = None
+    row_ndim: int | None = None
+    tail_compatible = True
+    saw_scalar = False
+    saw_non_scalar = False
+
+    for row, value in enumerate(values):
+        if value is None:
+            nulls[row] = True
+            lengths[row] = 0
+            continue
+        if not isinstance(value, np.ndarray):
+            return None
+
+        array = _as_contiguous_array_preserve_ndim(value, dtype)
+        arrays.append(array)
+        nulls[row] = False
+        lengths[row] = array.size
+        if array.ndim == 0:
+            saw_scalar = True
+            if saw_non_scalar:
+                tail_compatible = False
+            continue
+
+        saw_non_scalar = True
+        if saw_scalar:
+            tail_compatible = False
+        current_tail = array.shape[1:]
+        if tail_shape is None:
+            tail_shape = current_tail
+            row_ndim = array.ndim
+        elif array.ndim != row_ndim or current_tail != tail_shape:
+            tail_compatible = False
+
+    if tail_compatible and tail_shape is not None and any(dim == 0 for dim in tail_shape):
+        tail_compatible = False
+
+    offsets = np.empty(row_count + 1, dtype=np.int64)
+    offsets[0] = 0
+    np.cumsum(lengths, out=offsets[1:])
+    total_elems = int(offsets[-1])
+    if len(arrays) == 1:
+        flat = arrays[0].reshape(-1)
+        data = _MultiBufferPayload(
+            buffers=(memoryview(flat.data).cast("B"),),
+            owners=(flat,),
+            dtype=np.dtype(dtype).str,
+            shape=(total_elems,),
+        )
+    elif total_elems:
+        flat_arrays = [arr.reshape(-1) for arr in arrays]
+        if _concat_arrays_into is not None:
+            data = _DirectCopyPayload.from_flat_arrays(flat_arrays, dtype, total_elems)
+        else:
+            buffers = tuple(memoryview(flat.data).cast("B") for flat in flat_arrays)
+            data = _MultiBufferPayload(
+                buffers=buffers,
+                owners=tuple(flat_arrays),
+                dtype=np.dtype(dtype).str,
+                shape=(total_elems,),
+            )
+    else:
+        empty = np.empty(0, dtype=dtype)
+        data = _MultiBufferPayload(
+            buffers=(memoryview(empty.data).cast("B"),),
+            owners=(empty,),
+            dtype=np.dtype(dtype).str,
+            shape=(0,),
+        )
+
+    if not arrays or saw_scalar and not saw_non_scalar:
+        max_ndim = 0
+    elif tail_compatible:
+        max_ndim = int(row_ndim or 1)
+    else:
+        max_ndim = max(array.ndim for array in arrays)
+
+    ndims = np.zeros(row_count, dtype=np.int16)
+    if max_ndim == 0:
+        shapes = np.zeros((row_count, 1), dtype=np.int64)
+    elif tail_compatible:
+        shapes = np.zeros((row_count, max_ndim), dtype=np.int64)
+        tail = tail_shape or ()
+        tail_elems = int(np.prod(tail, dtype=np.int64)) if tail else 1
+        shapes[:, 0] = lengths // tail_elems
+        if max_ndim > 1:
+            shapes[:, 1:] = tail
+        ndims[~nulls] = max_ndim
+    else:
+        shapes = np.zeros((row_count, max(max_ndim, 1)), dtype=np.int64)
+        array_index = 0
+        for row, is_null in enumerate(nulls):
+            if bool(is_null):
+                continue
+            array = arrays[array_index]
+            array_index += 1
+            ndims[row] = array.ndim
+            if array.ndim > 0:
+                shapes[row, : array.ndim] = array.shape
+
+    return (
+        {
+            "data": data,
+            "offsets": offsets,
+            "shapes": shapes,
+            "ndims": ndims,
+            "nulls": nulls,
+        },
+        {
+            "dtype": str(dtype),
+            "max_ndim": int(max_ndim),
+            "shape_policy": "ragged",
+            "row_format": "ndarray",
+            "ndarray_rows": None,
+            "physical_layout": "contiguous_flat",
+        },
+    )
+
+
+def _as_contiguous_array_preserve_ndim(value: Any, dtype: np.dtype[Any]) -> np.ndarray:
+    if isinstance(value, np.ndarray) and value.dtype == dtype and value.flags.c_contiguous:
+        return value
+    array = np.asarray(value, dtype=dtype)
+    if array.flags.c_contiguous:
+        return array
+    return np.array(array, dtype=dtype, order="C", copy=True)
+
+
+def _decode_typed_ragged_ndarray_rows_fast(
+    data: np.ndarray,
+    offsets: np.ndarray,
+    shapes: np.ndarray,
+    ndims: np.ndarray,
+    nulls: np.ndarray,
+    rows: int,
+    metadata: Mapping[str, Any],
+) -> list[Any] | None:
+    # Returned ndarray rows are views into data; _OwnerBackedList preserves any
+    # pool owner attached to that data for the lifetime of the row list.
+    max_ndim = int(metadata.get("max_ndim", 0))
+    owner = getattr(data, "_mooncake_pool_owner", None)
+    source = data.view(np.ndarray) if isinstance(data, np.ndarray) else data
+    has_nulls = bool(nulls.any())
+
+    def attach_owner(values: list[Any]) -> list[Any]:
+        if owner is None:
+            return values
+        return _OwnerBackedList(values, owner)
+
+    if max_ndim == 1:
+        if not has_nulls:
+            row_width = _regular_offsets_width(offsets, rows)
+            if row_width is not None:
+                return attach_owner(list(source.reshape((rows, row_width))))
+            begins = offsets[:-1].tolist()
+            ends = offsets[1:].tolist()
+            return attach_owner(
+                [source[b:e] for b, e in zip(begins, ends)]
+            )
+        values: list[Any] = []
+        for row, is_null in enumerate(nulls):
+            if bool(is_null):
+                values.append(None)
+            else:
+                begin = int(offsets[row])
+                end = int(offsets[row + 1])
+                values.append(source[begin:end])
+        return attach_owner(values)
+
+    if max_ndim <= 1 or rows == 0:
+        return None
+
+    non_null_rows = np.flatnonzero(~nulls)
+    if non_null_rows.size == 0:
+        return [None] * rows
+    first_row = int(non_null_rows[0])
+    if int(ndims[first_row]) != max_ndim:
+        return None
+    tail = tuple(int(v) for v in shapes[first_row, 1:max_ndim])
+    if any(dim == 0 for dim in tail):
+        return None
+    for row in non_null_rows:
+        row_index = int(row)
+        if int(ndims[row_index]) != max_ndim:
+            return None
+        if tuple(int(v) for v in shapes[row_index, 1:max_ndim]) != tail:
+            return None
+
+    tail_elems = int(np.prod(tail, dtype=np.int64)) if tail else 1
+    if tail_elems <= 0:
+        return None
+    if int(offsets[-1]) % tail_elems != 0:
+        return None
+    flat_rows = source.reshape((-1, *tail))
+    first_axis_offsets = offsets // tail_elems
+
+    if not has_nulls:
+        row_width = _regular_offsets_width(first_axis_offsets, rows)
+        if row_width is not None:
+            return attach_owner(list(flat_rows.reshape((rows, row_width, *tail))))
+        fa_begins = first_axis_offsets[:-1].tolist()
+        fa_ends = first_axis_offsets[1:].tolist()
+        return attach_owner(
+            [flat_rows[b:e] for b, e in zip(fa_begins, fa_ends)]
+        )
+    values = []
+    for row, is_null in enumerate(nulls):
+        if bool(is_null):
+            values.append(None)
+        else:
+            begin = int(first_axis_offsets[row])
+            end = int(first_axis_offsets[row + 1])
+            values.append(flat_rows[begin:end])
+    return attach_owner(values)
+
+
+def _regular_offsets_width(offsets: np.ndarray, rows: int) -> int | None:
+    if rows <= 0 or int(offsets[0]) != 0:
+        return None
+    total = int(offsets[-1])
+    if total < 0 or total % rows != 0:
+        return None
+    row_width = total // rows
+    if not bool(np.all(offsets[1:] - offsets[:-1] == row_width)):
+        return None
+    return row_width
 
 def _encode_msgpack_ragged_values(
     path: str, values: list[Any]
@@ -5367,8 +5697,6 @@ def _encode_msgpack_ragged_values(
         {"data": buf, "offsets": offsets, "nulls": nulls},
         {},
     )
-
-
 
 def _decode_msgpack_ragged_values(payload: dict[str, Any], rows: int) -> list[Any]:
     data = payload["data"]
@@ -5399,8 +5727,6 @@ class _OwnerBackedList(list):
         super().__init__(values)
         self._mooncake_pool_owner = owner
 
-
-
 class _OwnerBackedObjectArray(np.ndarray):
     def __array_finalize__(self, obj: Any) -> None:
         if obj is not None:
@@ -5412,8 +5738,6 @@ class _OwnerBackedObjectArray(np.ndarray):
         if owner is None:
             return values
         return _OwnerBackedList(values, owner)
-
-
 
 def _object_array_from_decoded_values(values: list[Any]) -> np.ndarray:
     array = np.empty(len(values), dtype=object)
@@ -5722,7 +6046,21 @@ except Exception:  # pragma: no cover
     _torch = None  # type: ignore[assignment]
 
 
+def _parse_torch_dtype(dtype_str: str) -> Any:
+    """Parse torch dtype string (e.g. 'torch.float32') to torch.dtype object."""
+    name = dtype_str.removeprefix("torch.")
+    dtype = getattr(_torch, name, None)
+    if dtype is None or not isinstance(dtype, _torch.dtype):
+        raise ValueError(f"unknown torch dtype: {dtype_str}")
+    return dtype
 
+
+def _torch_dtype_to_numpy(dtype_str: str) -> np.dtype:
+    """Convert value-preserving torch dtypes to numpy dtypes."""
+    torch_dtype = _parse_torch_dtype(dtype_str)
+    if torch_dtype == _torch.bfloat16:
+        raise ValueError("torch.bfloat16 has no value-preserving numpy dtype")
+    return _torch.empty(0, dtype=torch_dtype).numpy().dtype
 
 @dataclass
 class _CodecDecision:

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -1603,9 +1603,9 @@ def test_dataproto_field_schema_encodes_typed_ragged_non_tensor_field() -> None:
     )
     result = transfer.get_dataproto(ref)["non_tensor_batch"]["tokens"]
 
-    assert result[0] == [1, 2]
+    assert result[0].tolist() == [1, 2]
     assert result[1] is None
-    assert result[2] == [3]
+    assert result[2].tolist() == [3]
 
     bad_text = np.asarray([object()], dtype=object)
     with pytest.raises(AttributeError, match="failed to encode.*'text'.*utf8_ragged"):
@@ -1879,7 +1879,8 @@ def test_unified_dict_put_accepts_field_schemas() -> None:
     result = transfer.get(ref, type="dict")
 
     assert np.array_equal(result["input_ids"], np.arange(2))
-    assert result["tokens"] == [[1, 2], None]
+    assert result["tokens"][0].tolist() == [1, 2]
+    assert result["tokens"][1] is None
     assert result["partition"] == [0, 1]
     assert result["response_lengths"] == [2, 0]
     assert result["global_batch_sizes"] == [2]
@@ -2899,7 +2900,11 @@ def test_dataproto_helper_typed_ragged_uses_multi_buffer_put() -> None:
 
     assert ref.encoded_non_tensor["tokens"]["codec"] == "typed_ragged"
     tokens = result["non_tensor_batch"]["tokens"].tolist()
-    assert tokens == [[1, 2], None, [3, 4, 5]]
+    assert [None if row is None else row.tolist() for row in tokens] == [
+        [1, 2],
+        None,
+        [3, 4, 5],
+    ]
     assert rows[0].nbytes + rows[2].nbytes in pool.acquire_sizes
 
 
@@ -2933,7 +2938,11 @@ def test_dataproto_helper_typed_ragged_fast_copy_put() -> None:
     result = transfer.get_dataproto(ref)
 
     tokens = result["non_tensor_batch"]["tokens"].tolist()
-    assert tokens == [[1, 2], None, [3, 4, 5]]
+    assert [None if row is None else row.tolist() for row in tokens] == [
+        [1, 2],
+        None,
+        [3, 4, 5],
+    ]
     assert store.batch_put_from_calls > 0
     assert rows[0].nbytes + rows[2].nbytes in pool.acquire_sizes
 
@@ -2992,6 +3001,77 @@ def test_dataproto_helper_typed_ragged_zero_copy_rejects_source_buffers() -> Non
         )
 
 
+def test_typed_ragged_packs_ndarray_rows_contiguously() -> None:
+    _store, transfer = make_transfer()
+    rows = [
+        np.asarray(7, dtype=np.int32),
+        np.arange(3, dtype=np.int32),
+        None,
+        np.arange(4, dtype=np.int32).reshape(2, 2),
+        np.arange(6, dtype=np.int32).reshape(2, 3),
+    ]
+
+    ref = transfer.put(
+        {"values": rows},
+        field_schemas={
+            "values": FieldSchema(
+                codec="typed_ragged",
+                metadata={"section": "non_tensor_batch"},
+            )
+        },
+        type="dict",
+    )
+    result = transfer.get(ref, type="dict")
+    view = transfer.dataproto_manifest_view(ref)
+
+    encoded = ref.encoded_non_tensor["values"]
+    assert encoded["codec"] == "typed_ragged"
+    assert encoded["metadata"]["physical_layout"] == "contiguous_flat"
+    assert view["non_tensor_fields"]["values"]["spec"]["payload_specs"]["data"][
+        "shape"
+    ] == [14]
+    assert [
+        None if row is None else row.tolist() for row in result["values"]
+    ] == [
+        None if row is None else row.tolist() for row in rows
+    ]
+    assert all(
+        row is None or isinstance(row, np.ndarray) for row in result["values"]
+    )
+    assert result["values"][0].shape == ()
+    assert [row.dtype for row in result["values"] if row is not None] == [
+        np.dtype(np.int32)
+    ] * 4
+    gathered = transfer.get_dataproto(
+        ref, non_tensor_fields=["values"], rows=[4, 2, 0]
+    )
+    assert [
+        None if row is None else row.tolist()
+        for row in gathered["non_tensor_batch"]["values"]
+    ] == [
+        rows[4].tolist(),
+        None,
+        rows[0].tolist(),
+    ]
+    assert gathered["non_tensor_batch"]["values"][2].shape == ()
+
+
+def test_typed_ragged_fast_decodes_equal_shape_ndarray_views() -> None:
+    rows = [np.arange(6, dtype=np.int32).reshape(2, 3) + i * 10 for i in range(3)]
+    payload, metadata = sos._encode_typed_ragged_values(rows, np.dtype(np.int32))
+    multi_buffer = payload["data"]
+    data = np.concatenate(
+        [np.frombuffer(buf, dtype=np.int32) for buf in multi_buffer.buffers]
+    )
+
+    decoded = sos._decode_typed_ragged_values({**payload, "data": data}, 3, metadata)
+
+    assert metadata["physical_layout"] == "contiguous_flat"
+    assert all(isinstance(row, np.ndarray) for row in decoded)
+    assert all(np.shares_memory(row, data) for row in decoded)
+    assert [row.tolist() for row in decoded] == [row.tolist() for row in rows]
+
+
 def test_dataproto_helper_rejects_unsupported_object_non_tensor() -> None:
     _store, transfer = make_transfer()
     data = SimpleDataProto(
@@ -3026,6 +3106,7 @@ def test_dataproto_helper_ragged_tensor_non_tensor_roundtrip() -> None:
     result = transfer.get_dataproto(ref)
 
     assert ref.encoded_non_tensor["ragged"]["codec"] == "ragged_tensor"
+    assert ref.encoded_non_tensor["ragged"]["metadata"]["dtype"] == "torch.float32"
     actual = result["non_tensor_batch"]["ragged"]
     assert torch.equal(actual[0], ragged[0])
     assert actual[1] is None
@@ -3039,6 +3120,11 @@ def test_dataproto_helper_ragged_tensor_non_tensor_roundtrip() -> None:
     ]
     with pytest.raises(ValueError, match="mixed tensor dtype"):
         transfer.put_dataproto(SimpleDataProto(non_tensor_batch={"ragged": mixed}))
+
+    bfloat = np.empty(1, dtype=object)
+    bfloat[0] = torch.zeros(1, dtype=torch.bfloat16)
+    with pytest.raises(ValueError, match="bfloat16"):
+        transfer.put_dataproto(SimpleDataProto(non_tensor_batch={"ragged": bfloat}))
 
 
 def test_dataproto_helper_jagged_nested_batch_tensor_roundtrip() -> None:
@@ -3219,11 +3305,13 @@ def test_dataproto_helper_dict_of_native_object_leaves_uses_recursive_codec() ->
     assert ref.encoded_non_tensor["samples"]["codec"] == "structured_recursive"
     assert actual[0]["media"] == [b"a", b"bc"]
     assert actual[0]["blob"] == b"payload-0"
-    assert actual[0]["scores"] == [1, 2]
+    assert isinstance(actual[0]["scores"], np.ndarray)
+    assert actual[0]["scores"].tolist() == [1, 2]
     assert actual[0]["label"] == "x"
     assert actual[1]["media"] == []
     assert actual[1]["blob"] == b"payload-1"
-    assert actual[1]["scores"] == [3]
+    assert isinstance(actual[1]["scores"], np.ndarray)
+    assert actual[1]["scores"].tolist() == [3]
     assert actual[1]["label"] == "y"
     assert actual[2] == {"label": "missing-native"}
     assert actual[3] is None

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -3072,6 +3072,57 @@ def test_typed_ragged_fast_decodes_equal_shape_ndarray_views() -> None:
     assert [row.tolist() for row in decoded] == [row.tolist() for row in rows]
 
 
+def test_typed_ragged_single_ndarray_row_uses_general_layout() -> None:
+    rows = [np.arange(6, dtype=np.int32).reshape(2, 3)]
+
+    assert sos._encode_typed_ragged_regular_ndarray_rows(
+        rows, np.dtype(np.int32)
+    ) is None
+    payload, metadata = sos._encode_typed_ragged_values(rows, np.dtype(np.int32))
+    multi_buffer = payload["data"]
+    data = np.frombuffer(multi_buffer.buffers[0], dtype=np.int32)
+
+    decoded = sos._decode_typed_ragged_values({**payload, "data": data}, 1, metadata)
+
+    assert metadata["physical_layout"] == "contiguous_flat"
+    assert isinstance(decoded[0], np.ndarray)
+    assert np.shares_memory(decoded[0], data)
+    assert decoded[0].tolist() == rows[0].tolist()
+
+
+def test_typed_ragged_equal_shape_rows_with_nulls_use_general_layout() -> None:
+    rows = [
+        np.arange(6, dtype=np.int32).reshape(2, 3),
+        None,
+        np.arange(6, 12, dtype=np.int32).reshape(2, 3),
+    ]
+
+    assert sos._encode_typed_ragged_regular_ndarray_rows(
+        rows, np.dtype(np.int32)
+    ) is None
+    payload, metadata = sos._encode_typed_ragged_values(rows, np.dtype(np.int32))
+    multi_buffer = payload["data"]
+    data = np.concatenate(
+        [np.frombuffer(buf, dtype=np.int32) for buf in multi_buffer.buffers]
+    )
+
+    decoded = sos._decode_typed_ragged_values({**payload, "data": data}, 3, metadata)
+
+    assert metadata["physical_layout"] == "contiguous_flat"
+    assert decoded[1] is None
+    assert all(
+        row is None or isinstance(row, np.ndarray) for row in decoded
+    )
+    assert all(
+        row is None or np.shares_memory(row, data) for row in decoded
+    )
+    assert [None if row is None else row.tolist() for row in decoded] == [
+        rows[0].tolist(),
+        None,
+        rows[2].tolist(),
+    ]
+
+
 def test_dataproto_helper_rejects_unsupported_object_non_tensor() -> None:
     _store, transfer = make_transfer()
     data = SimpleDataProto(

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -434,6 +434,25 @@ def write_manifest(
     )
 
 
+def test_default_bundle_chunk_tuning_matches_rollout_transfer_target() -> None:
+    assert sos.DEFAULT_BUNDLE_CHUNK_BYTES == 64 * 1024**2
+    assert sos.AUTO_PARALLEL_MIN_BYTES == sos.DEFAULT_BUNDLE_CHUNK_BYTES
+
+
+def test_small_dict_sized_groups_enable_auto_parallel_put() -> None:
+    class SizedBuffer:
+        def __init__(self, size: int) -> None:
+            self._size = size
+
+        def __len__(self) -> int:
+            return self._size
+
+    _store, transfer = make_transfer()
+    groups = [[SizedBuffer(1024**2)] for _ in range(128)]
+    policy = BundleTransferPolicy(max_inflight_put=8)
+    assert transfer._transport._resolve_buffer_group_put_mode(groups, policy) == "parallel"
+
+
 def test_put_object_roundtrips_numpy_and_torch_tensor_fields() -> None:
     torch = pytest.importorskip("torch")
     store, transfer = make_transfer()

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -1814,6 +1814,59 @@ def test_unified_put_get_roundtrips_flat_dict() -> None:
     assert result["step"] == 7
 
 
+def test_unified_dict_get_returns_flat_lists_without_changing_dataproto_shape() -> None:
+    _store, transfer = make_transfer()
+    data = {
+        "tokens": [
+            np.asarray([1, 2], dtype=np.int32),
+            np.asarray([3], dtype=np.int32),
+            np.asarray([4, 5, 6], dtype=np.int32),
+        ],
+        "json": [{"rank": 0}, {"rank": 1}, {"rank": 2}],
+    }
+    schemas = {
+        "tokens": FieldSchema(
+            codec="typed_ragged",
+            metadata={"section": "non_tensor_batch", "dtype": "int32"},
+        ),
+        "json": FieldSchema(
+            codec="msgpack_ragged",
+            metadata={"section": "non_tensor_batch"},
+        ),
+    }
+
+    ref = transfer.put(data, type="dict", field_schemas=schemas)
+
+    flat = transfer.get(ref, type="dict")
+    assert isinstance(flat["tokens"], list)
+    assert isinstance(flat["json"], list)
+    assert [row.tolist() for row in flat["tokens"]] == [[1, 2], [3], [4, 5, 6]]
+    assert flat["json"] == [{"rank": 0}, {"rank": 1}, {"rank": 2}]
+
+    sliced = transfer.get(ref, type="dict", rows=slice(1, 3))
+    assert isinstance(sliced["tokens"], list)
+    assert isinstance(sliced["json"], list)
+    assert [row.tolist() for row in sliced["tokens"]] == [[3], [4, 5, 6]]
+    assert sliced["json"] == [{"rank": 1}, {"rank": 2}]
+
+    envelope = transfer.get_dataproto(ref, data_cls=dict)
+    non_tensor_batch = envelope["non_tensor_batch"]
+    assert isinstance(non_tensor_batch["tokens"], np.ndarray)
+    assert non_tensor_batch["tokens"].dtype == object
+    assert isinstance(non_tensor_batch["json"], np.ndarray)
+    assert non_tensor_batch["json"].dtype == object
+    assert [row.tolist() for row in non_tensor_batch["tokens"]] == [
+        [1, 2],
+        [3],
+        [4, 5, 6],
+    ]
+    assert non_tensor_batch["json"].tolist() == [
+        {"rank": 0},
+        {"rank": 1},
+        {"rank": 2},
+    ]
+
+
 def test_unified_put_rejects_unknown_type() -> None:
     _store, transfer = make_transfer()
 
@@ -3056,13 +3109,24 @@ def test_typed_ragged_packs_ndarray_rows_contiguously() -> None:
     assert gathered["non_tensor_batch"]["values"][2].shape == ()
 
 
+def _typed_ragged_payload_array(
+    payload: dict[str, object], dtype: np.dtype
+) -> np.ndarray:
+    data = payload["data"]
+    arrays = getattr(data, "arrays", None)
+    if arrays is not None:
+        flat_arrays = [
+            np.asarray(array, dtype=dtype).reshape(-1) for array in arrays
+        ]
+        if not flat_arrays:
+            return np.asarray([], dtype=dtype)
+        return np.concatenate(flat_arrays)
+    return np.concatenate([np.frombuffer(buf, dtype=dtype) for buf in data.buffers])
+
 def test_typed_ragged_fast_decodes_equal_shape_ndarray_views() -> None:
     rows = [np.arange(6, dtype=np.int32).reshape(2, 3) + i * 10 for i in range(3)]
     payload, metadata = sos._encode_typed_ragged_values(rows, np.dtype(np.int32))
-    multi_buffer = payload["data"]
-    data = np.concatenate(
-        [np.frombuffer(buf, dtype=np.int32) for buf in multi_buffer.buffers]
-    )
+    data = _typed_ragged_payload_array(payload, np.dtype(np.int32))
 
     decoded = sos._decode_typed_ragged_values({**payload, "data": data}, 3, metadata)
 
@@ -3079,8 +3143,7 @@ def test_typed_ragged_single_ndarray_row_uses_general_layout() -> None:
         rows, np.dtype(np.int32)
     ) is None
     payload, metadata = sos._encode_typed_ragged_values(rows, np.dtype(np.int32))
-    multi_buffer = payload["data"]
-    data = np.frombuffer(multi_buffer.buffers[0], dtype=np.int32)
+    data = _typed_ragged_payload_array(payload, np.dtype(np.int32))
 
     decoded = sos._decode_typed_ragged_values({**payload, "data": data}, 1, metadata)
 
@@ -3101,10 +3164,7 @@ def test_typed_ragged_equal_shape_rows_with_nulls_use_general_layout() -> None:
         rows, np.dtype(np.int32)
     ) is None
     payload, metadata = sos._encode_typed_ragged_values(rows, np.dtype(np.int32))
-    multi_buffer = payload["data"]
-    data = np.concatenate(
-        [np.frombuffer(buf, dtype=np.int32) for buf in multi_buffer.buffers]
-    )
+    data = _typed_ragged_payload_array(payload, np.dtype(np.int32))
 
     decoded = sos._decode_typed_ragged_values({**payload, "data": data}, 3, metadata)
 


### PR DESCRIPTION
## Description

This PR splits the typed-ragged rollout-data layout optimization out of the previous large rollout transfer optimization branch.

RL rollout data often contains large `non_tensor_batch` object arrays whose rows are numpy arrays or tensors with ragged row lengths. The old typed-ragged/ragged-tensor path materialized large intermediate concatenations during encoding and decoded ndarray rows back into Python lists, which adds overhead and loses row type information for downstream rollout consumers.

This change:
- encodes ragged tensor values through the typed-ragged layout path to avoid a large `torch.cat` intermediate for ROLL-style rollout data;
- adds a contiguous typed-ragged physical layout for ndarray rows;
- preserves ndarray row objects on decode and supports partial row reads for slice/index access; decoded ndarray rows are views over the materialized contiguous data buffer, with pool ownership preserved by the returned row list when applicable;
- keeps ragged-tensor metadata as torch dtype strings while using numpy dtype only internally for buffer interpretation;
- explicitly rejects `torch.bfloat16` ragged tensors because there is no value-preserving NumPy dtype for that path;
- keeps this PR independent from the native fast-copy PUT path, which is split into a separate PR. If both PRs are merged, this layout PR should land first and the fast-copy PR can be rebased on top to resolve mechanical conflicts.

Performance validation from the rollout transfer benchmark target:

| Scenario | Baseline behavior | Optimized behavior |
| --- | ---: | ---: |
| ROLL DataProto, 24.31 GB rollout data | ragged tensor encode path regressed to ~7.7s PUT due to large tensor concatenation | PUT avg 2.843s, GET avg 2.583s |

Detailed cross-machine benchmark results:

| Run | PUT | GET |
| ---: | ---: | ---: |
| 1 | 3.120s | 2.615s |
| 2 | 2.683s | 2.564s |
| 3 | 2.726s | 2.571s |
| Avg | 2.843s | 2.583s |

For this ROLL-style typed-ragged DataProto payload, the optimized PUT path is about 2.7x faster than the regressed baseline PUT path (~7.7s -> 2.843s). The optimized GET path transfers and reconstructs the 24.31 GB rollout object in 2.583s on average. The first PUT iteration is included in the average instead of being discarded as warmup.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
cd mooncake-wheel
python -m pytest tests/test_structured_object_store.py -q --tb=short
python -m py_compile mooncake/structured_object_store.py tests/test_structured_object_store.py
git diff --check
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done

Result:
```text
Previous full structured-object validation: 91 passed, 14 skipped
Latest review-fix validation: 7 passed, 1 skipped, 100 deselected
Direct bfloat16 rejection check: passed
py_compile: passed
git diff --check: passed
```

Additional manual validation:
```text
ROLL DataProto cross-machine rollout transfer benchmark, 24.31 GB payload:
PUT: 3120ms / 2683ms / 2726ms, avg 2842.9ms
GET: 2615ms / 2564ms / 2571ms, avg 2583.3ms
Baseline PUT before this layout optimization: ~7.7s

Small flat-dict parameter validation on the PR2671 optimized branch, local TCP store:
Payload shape: many 1 MiB ndarray fields, max_inflight_put=8, put_mode=auto, copy_mode=auto
128 MiB / 128 fields:
  512 MiB chunk + 4 GiB auto threshold: PUT avg 105.3ms, GET avg 48.1ms
  64 MiB chunk + 64 MiB auto threshold: PUT avg 55.8ms, GET avg 32.0ms
192 MiB / 192 fields:
  512 MiB chunk + 4 GiB auto threshold: PUT avg 143.6ms, GET avg 73.0ms
  64 MiB chunk + 64 MiB auto threshold: PUT avg 84.1ms, GET avg 47.7ms
```

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

Note: this focused split is slightly above 500 additions after retaining reviewer-requested typed-ragged/ragged-tensor regression coverage. Python formatting/pre-commit were not used as the validation signal for this focused split to avoid unrelated repository-wide formatting churn; `py_compile`, targeted unit tests, direct bfloat16 validation, and `git diff --check` were used.

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex was used to split this focused PR out of the previous large rollout transfer optimization branch, review the diff, run validation, and prepare the PR description. The human submitter is responsible for understanding and defending all changes.
