### PR TITLE
[CI/Build] Fix CUDA stub release smoke test

### DIFF
--- a/.github/workflows/_build-wheel.yaml
+++ b/.github/workflows/_build-wheel.yaml
@@ -188,6 +188,25 @@ jobs:
                      /usr/local/cuda/targets/*/lib/stubs; do
             [ -d "$dir" ] && export LD_LIBRARY_PATH="$dir:$LD_LIBRARY_PATH"
           done
+
+          # CUDA builder images contain the link-time driver stub but not the
+          # real libcuda.so.1 supplied by an NVIDIA driver. Non-CUDA wheels must
+          # not receive this alias, so an accidental CUDA dependency still fails.
+          if [ "${VARIANT_FLAG:-}" != "NON_CUDA_BUILD" ]; then
+            cuda_stub=
+            for candidate in /usr/local/cuda/lib64/stubs/libcuda.so \
+                             /usr/local/cuda/targets/*/lib/stubs/libcuda.so; do
+              if [ -f "$candidate" ]; then
+                cuda_stub="$candidate"
+                break
+              fi
+            done
+            if [ -n "$cuda_stub" ]; then
+              ln -s "$cuda_stub" "$smoke_venv/libcuda.so.1"
+              export LD_LIBRARY_PATH="$smoke_venv:$LD_LIBRARY_PATH"
+            fi
+          fi
+
           "$smoke_venv/bin/mooncake_master" --version
 
       - name: Upload Python wheel artifact


### PR DESCRIPTION
## Description

Add the `main`-branch counterpart of #3110. This follows up on #3105 after the v0.3.12.post1 CUDA 12/13 wheel jobs showed that the installed `mooncake_master` smoke test cannot start in the release builder because only the link-time CUDA stub (`libcuda.so`) is present, while the binary requests the runtime SONAME `libcuda.so.1`.

For CUDA variants, the wheel smoke-test virtualenv now gets a temporary `libcuda.so.1` alias to the builder's CUDA stub and prepends that virtualenv to `LD_LIBRARY_PATH`. The alias is intentionally limited to the smoke-test environment: it is not bundled into the wheel. `NON_CUDA_BUILD` skips this setup.

Because this smoke test runs before artifact upload, a startup failure blocks the downstream PyPI publish jobs.

Observed failures:
- CUDA 12 release build: https://github.com/kvcache-ai/Mooncake/actions/runs/30108545321
- CUDA 13 release build: https://github.com/kvcache-ai/Mooncake/actions/runs/30108545213

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
pre-commit run --files .github/workflows/_build-wheel.yaml
git diff --check origin/main...HEAD

# Local ELF smoke harness: an executable with a libcuda NEEDED entry fails
# without libcuda.so.1, then reaches main after adding the temporary alias.

# Variant-selection harness for CUDA12, CU13_BUILD, and NON_CUDA_BUILD.

# Install the repaired v0.3.12 wheel in a temporary venv and run:
mooncake_master --version
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (described below)

- Targeted pre-commit hooks passed.
- `git diff --check` passed.
- CUDA12 and CU13_BUILD selected `/usr/local/cuda/lib64/stubs/libcuda.so`; NON_CUDA_BUILD created no alias.
- The isolated ELF harness reproduced the missing-SONAME failure and passed with the temporary alias.
- The repaired wheel smoke test printed `mooncake_master version 0.3.12 (git: 29fc0c42)`.
- The patch ID matches the validated release-branch fix in #3110.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh` (not applicable to this workflow-only change)
- [ ] I have run `pre-commit run --all-files` and all hooks pass (targeted hooks passed for the touched workflow)
- [x] I have updated the documentation (not applicable)
- [x] I have added tests to prove my changes are effective (release smoke test now exercises installed binary startup)
- [x] For changes >500 LOC: I have filed an RFC issue (not applicable; 19 LOC)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specified below)

OpenAI Codex assisted with root-cause analysis, the workflow change, local validation, and PR preparation. The human submitter is responsible for reviewing and defending the change.