### PR TITLE
[TENT] Fix req_map_ leak for single-task batches in ascend transport

### DIFF
--- a/mooncake-transfer-engine/tent/src/transport/ascend/ascend_direct_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/ascend/ascend_direct_transport.cpp
@@ -433,8 +433,10 @@ Status AscendDirectTransport::getTransferStatus(SubBatchRef batch, int task_id,
             disconnect(task.remote_hixl, 10);
             task.status_word = TransferStatusEnum::FAILED;
         }
-        req_map_[task.req_handle] =
-            std::make_pair(task.status_word, task.batch_size - 1);
+        if (task.batch_size > 1) {
+            req_map_[task.req_handle] =
+                std::make_pair(task.status_word, task.batch_size - 1);
+        }
     }
     // Read status AFTER the poll so a just-observed completion/failure is
     // reported on this call rather than one poll cycle late.


### PR DESCRIPTION
## Summary

`AscendDirectTransport::getTransferStatus()` unconditionally inserts a `req_map_` entry with share-count `batch_size - 1` after polling hixl for a terminal status. For **single-task batches** this inserts a dead entry with count 0: the consume path erases an entry only when `--count` reaches 0, so a count that starts at 0 is never consumed — one `req_map_` entry leaks per completed single-task batch.

The TIMEOUT branch in the same function already guards this insert with `if (task.batch_size > 1)`; this PR applies the same guard to the COMPLETED/FAILED path.

## What is NOT changed

- No behavior change for multi-task batches (entry still shared with remaining tasks)
- No change to the consume/erase logic

## Test plan

- [x] Verified the consume path (`--second == 0` then erase) can never remove a count-0 entry
- [x] Guard mirrors the existing TIMEOUT-branch guard in the same function
- [ ] CI