### PR TITLE
ci: add manual "Cancel Queued and Running CI" workflow

### DIFF
--- a/.github/workflows/cancel-ci.yml
+++ b/.github/workflows/cancel-ci.yml
@@ -1,0 +1,138 @@
+name: Cancel Queued and Running CI
+
+# Manually cancel every unfinished (queued / running / waiting / pending)
+# workflow run in the repo. Useful for draining runners after a bad push,
+# a runaway matrix, or before urgent maintenance.
+#
+# Unlike the per-workflow `concurrency: cancel-in-progress` settings (which
+# only cancel a run superseded by a newer run on the same ref), this cancels
+# runs across all workflows and refs in one shot.
+#
+# Adapted from sglang's cancel-pr-workflows-on-close.yml cancellation logic:
+# sweep every non-terminal status (a single status= filter takes one value
+# per request), paginate, force-cancel runs stuck behind approval gates, and
+# run a second pass to catch runs still materializing during the first.
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Only cancel runs on this branch (leave empty to cancel across all branches)'
+        required: false
+        type: string
+        default: ''
+      dry_run:
+        description: 'List what would be cancelled without cancelling'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  actions: write   # Needed to cancel runs
+  contents: read   # Needed to read repo info
+
+# Do not let two drain operations fight each other.
+concurrency:
+  group: cancel-ci
+  cancel-in-progress: false
+
+jobs:
+  cancel:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel unfinished runs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ github.event.inputs.branch }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ -n "$BRANCH" ]; then
+            echo "Scope: branch '$BRANCH'"
+          else
+            echo "Scope: all branches"
+          fi
+          echo "Dry run: $DRY_RUN"
+          echo ""
+
+          FAILURES=0
+
+          # The status filter takes one value per request, so sweep every
+          # non-terminal state (pending/waiting/action_required runs would
+          # otherwise start after we finish). Pass 2 catches runs still
+          # materializing during pass 1. Exclude this run itself.
+          for pass in 1 2; do
+            run_ids=""
+            for status in queued in_progress waiting pending requested action_required; do
+              ids=""
+              for attempt in 1 2 3; do
+                # branch= is optional; when empty gh omits the filter (all branches).
+                args=(-X GET "repos/$REPO/actions/runs" --paginate
+                      -f status="$status" -F per_page=100
+                      --jq ".workflow_runs[] | select(.id != $GITHUB_RUN_ID) | .id")
+                if [ -n "$BRANCH" ]; then
+                  args+=(-f branch="$BRANCH")
+                fi
+                if ids=$(gh api "${args[@]}"); then
+                  break
+                fi
+                ids=""
+                if [ "$attempt" -eq 3 ]; then
+                  echo "::error::Listing $status runs failed after 3 attempts"
+                  FAILURES=1
+                else
+                  sleep 5
+                fi
+              done
+              run_ids="$run_ids"$'\n'"$ids"
+            done
+            run_ids=$(echo "$run_ids" | sed '/^$/d' | sort -u)
+
+            if [ -z "$run_ids" ]; then
+              echo "Pass $pass: no unfinished runs found"
+              break
+            fi
+            echo "Pass $pass: found $(echo "$run_ids" | wc -l | tr -d ' ') unfinished run(s)"
+
+            for run_id in $run_ids; do
+              run_url="https://github.com/$REPO/actions/runs/$run_id"
+              if [ "$DRY_RUN" = "true" ]; then
+                echo "  [dry-run] would cancel $run_url"
+                continue
+              fi
+              echo "Cancelling $run_url"
+              if gh run cancel "$run_id" --repo "$REPO" 2>/dev/null; then
+                continue
+              fi
+              # Plain cancel fails for runs stuck behind approval /
+              # deployment protection rules; force-cancel handles those.
+              if gh api -X POST "repos/$REPO/actions/runs/$run_id/force-cancel" >/dev/null 2>&1; then
+                echo "  force-cancelled"
+                continue
+              fi
+              # Finished between listing and cancelling is fine.
+              state=$(gh api "repos/$REPO/actions/runs/$run_id" --jq '.status' 2>/dev/null || echo "unknown")
+              if [ "$state" = "completed" ]; then
+                echo "  already finished, nothing to cancel"
+              else
+                echo "::error::Failed to cancel run $run_id (status: $state)"
+                FAILURES=1
+              fi
+            done
+
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "Pass $pass: dry run, skipping second pass"
+              break
+            fi
+
+            if [ "$pass" -eq 1 ]; then
+              sleep 20
+            fi
+          done
+
+          echo ""
+          echo "✅ Done"
+          exit "$FAILURES"


### PR DESCRIPTION
Add a workflow_dispatch action to cancel every unfinished (queued / running / waiting / pending) workflow run in one shot, for draining runners after a bad push, a runaway matrix, or before maintenance.

The per-workflow `concurrency: cancel-in-progress` settings only cancel a run superseded by a newer run on the same ref; there was no way to cancel all in-flight CI on demand.

Cancellation logic adapted from sglang's cancel-pr-workflows-on-close: sweep every non-terminal status (the API status= filter takes one value per request), paginate, force-cancel runs stuck behind approval gates, and run a second pass to catch runs still materializing. Inputs: an optional `branch` scope (default: all branches) and a `dry_run` toggle.

## Description



## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



**Test commands:**
```bash
# Example: bash scripts/run_ci_test.sh
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [ ] AI tools were used (specify below)