### PR TITLE
[CI/Build] Remove CUDA dependency from mooncake_master

### DIFF
--- a/.github/workflows/_build-wheel.yaml
+++ b/.github/workflows/_build-wheel.yaml
@@ -197,6 +197,20 @@ jobs:
           "$smoke_venv/bin/python" -m pip install --no-deps \
             mooncake-wheel/dist-py${{ steps.pytag.outputs.tag }}/*.whl
 
+          if [ "${VARIANT_FLAG:-}" = "NON_CUDA_BUILD" ]; then
+            site_packages=$("$smoke_venv/bin/python" -c \
+              'import sysconfig; print(sysconfig.get_paths()["purelib"])')
+            while IFS= read -r -d '' binary; do
+              file "$binary" | grep -q ELF || continue
+              if readelf -d "$binary" | grep -Eq \
+                'Shared library: \[(libcuda|libcudart)\.so'; then
+                echo "Non-CUDA wheel binary depends on CUDA: $binary"
+                readelf -d "$binary" | grep 'Shared library:'
+                exit 1
+              fi
+            done < <(find "$site_packages" -type f -print0)
+          fi
+
           export LD_LIBRARY_PATH="/usr/local/lib:${LD_LIBRARY_PATH:-}"
           for dir in /usr/local/cuda/lib64 \
                      /usr/local/cuda/lib64/stubs \

--- a/.github/workflows/_build-wheel.yaml
+++ b/.github/workflows/_build-wheel.yaml
@@ -200,15 +200,13 @@ jobs:
           if [ "${VARIANT_FLAG:-}" = "NON_CUDA_BUILD" ]; then
             site_packages=$("$smoke_venv/bin/python" -c \
               'import sysconfig; print(sysconfig.get_paths()["purelib"])')
-            while IFS= read -r -d '' binary; do
-              file "$binary" | grep -q ELF || continue
-              if readelf -d "$binary" | grep -Eq \
-                'Shared library: \[(libcuda|libcudart)\.so'; then
-                echo "Non-CUDA wheel binary depends on CUDA: $binary"
-                readelf -d "$binary" | grep 'Shared library:'
-                exit 1
-              fi
-            done < <(find "$site_packages" -type f -print0)
+            master="$site_packages/mooncake/mooncake_master"
+            if readelf -d "$master" | grep -Eq \
+              'Shared library: \[(libcuda|libcudart)\.so'; then
+              echo "Non-CUDA mooncake_master depends on CUDA"
+              readelf -d "$master" | grep 'Shared library:'
+              exit 1
+            fi
           fi
 
           export LD_LIBRARY_PATH="/usr/local/lib:${LD_LIBRARY_PATH:-}"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -102,8 +102,23 @@ jobs:
       artifact-prefix: nightly-cuda13-x86
       version-override: ${{ needs.version-stamp.outputs.nightly_version }}
 
+  build-non-cuda-x86:
+    needs: version-stamp
+    uses: ./.github/workflows/_build-wheel.yaml
+    with:
+      runner: ubuntu-22.04
+      container: pytorch/manylinux2_28-builder:cuda12.8
+      python-versions: '["3.10", "3.12"]'
+      cuda: container
+      variant-flag: NON_CUDA_BUILD
+      cmake-args: >-
+        -DBUILD_UNIT_TESTS=OFF -DUSE_HTTP=ON -DUSE_ETCD=ON -DUSE_CUDA=OFF -DWITH_EP=OFF
+        -DSTORE_USE_ETCD=ON -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Release
+      artifact-prefix: nightly-non-cuda-x86
+      version-override: ${{ needs.version-stamp.outputs.nightly_version }}
+
   publish-testpypi:
-    needs: [version-stamp, build-cuda128-x86, build-cuda128-arm64, build-cuda13-x86]
+    needs: [version-stamp, build-cuda128-x86, build-cuda128-arm64, build-cuda13-x86, build-non-cuda-x86]
     if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.skip_publish == 'true') }}
     runs-on: ubuntu-22.04
     environment: nightly
@@ -301,7 +316,7 @@ jobs:
 
   nightly-gate:
     if: always()
-    needs: [build-cuda128-x86, build-cuda128-arm64, build-cuda13-x86, publish-testpypi, nightly-test]
+    needs: [build-cuda128-x86, build-cuda128-arm64, build-cuda13-x86, build-non-cuda-x86, publish-testpypi, nightly-test]
     runs-on: ubuntu-22.04
     steps:
       - name: Check results
@@ -310,6 +325,7 @@ jobs:
           echo "Build CUDA 12.8 x86: ${{ needs.build-cuda128-x86.result }}"
           echo "Build CUDA 12.8 arm64: ${{ needs.build-cuda128-arm64.result }}"
           echo "Build CUDA 13 x86: ${{ needs.build-cuda13-x86.result }}"
+          echo "Build non-CUDA x86: ${{ needs.build-non-cuda-x86.result }}"
           echo "Publish: ${{ needs.publish-testpypi.result }}"
           echo "Test: ${{ needs.nightly-test.result }}"
           # Fail if any build job did not succeed
@@ -323,6 +339,10 @@ jobs:
           fi
           if [ "${{ needs.build-cuda13-x86.result }}" != "success" ]; then
             echo "::error::Build CUDA 13 x86 failed!"
+            exit 1
+          fi
+          if [ "${{ needs.build-non-cuda-x86.result }}" != "success" ]; then
+            echo "::error::Build non-CUDA x86 failed!"
             exit 1
           fi
           if [ "${{ needs.nightly-test.result }}" != "success" ]; then

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -352,6 +352,10 @@ target_link_libraries(
           ${ETCD_WRAPPER_LIB}
           ${MASTER_EXTRA_LIBS}
           asio_shared)
+# mooncake_store is static and propagates optional runtime dependencies to its
+# consumers. The metadata-only master does not use accelerator staging, so drop
+# those dependencies when they do not satisfy any symbols in the final binary.
+target_link_options(mooncake_master PRIVATE "LINKER:--as-needed")
 if(USE_SUNRISE)
   target_link_directories(mooncake_master PRIVATE ${MC_TANGRT_ROOT}/lib)
 endif()
@@ -381,16 +385,19 @@ endif()
 # transfer_engine is PRIVATE-linked, so its CUDA/HIP/Ascend dependencies are not
 # propagated; we must detect and link them independently.
 #
-# A CUDA toolkit may be installed even when USE_CUDA=OFF (for example, in the
-# non-CUDA release builder). Detect it for backend selection, but only enable
-# CUDA staging when CUDA support was explicitly requested.
+# Auto-detect each toolkit regardless of global USE_CUDA/USE_HIP flags, because
+# USE_CUDA may be OFF even when GPU pointers are present (e.g.
+# WITH_NVIDIA_PEERMEM env var uses nvidia-peermem for RDMA without cudart). Each
+# detected toolkit gets both link libraries AND compile definitions, so that
+# AcceleratorDevice implementations and pinned_buffer_pool.h pick the correct
+# backend.
 #
 # NOTE: mooncake_store is a static library (.a). External consumers (Go CGo,
 # Python pybind) that link it must also link the GPU runtime (e.g. -lcudart).
 # Go's build.sh already does this; CI workflows must do the same.
 
 find_package(CUDAToolkit QUIET)
-if(USE_CUDA AND CUDAToolkit_FOUND)
+if(CUDAToolkit_FOUND)
   message(STATUS "mooncake_store: CUDAToolkit detected, enabling D2H staging")
   target_compile_definitions(mooncake_store PRIVATE USE_CUDA)
   target_compile_definitions(mooncake_client PRIVATE USE_CUDA)

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -381,19 +381,16 @@ endif()
 # transfer_engine is PRIVATE-linked, so its CUDA/HIP/Ascend dependencies are not
 # propagated; we must detect and link them independently.
 #
-# Auto-detect each toolkit regardless of global USE_CUDA/USE_HIP flags, because
-# USE_CUDA may be OFF even when GPU pointers are present (e.g.
-# WITH_NVIDIA_PEERMEM env var uses nvidia-peermem for RDMA without cudart). Each
-# detected toolkit gets both link libraries AND compile definitions, so that
-# AcceleratorDevice implementations and pinned_buffer_pool.h pick the correct
-# backend.
+# A CUDA toolkit may be installed even when USE_CUDA=OFF (for example, in the
+# non-CUDA release builder). Detect it for backend selection, but only enable
+# CUDA staging when CUDA support was explicitly requested.
 #
 # NOTE: mooncake_store is a static library (.a). External consumers (Go CGo,
 # Python pybind) that link it must also link the GPU runtime (e.g. -lcudart).
 # Go's build.sh already does this; CI workflows must do the same.
 
 find_package(CUDAToolkit QUIET)
-if(CUDAToolkit_FOUND)
+if(USE_CUDA AND CUDAToolkit_FOUND)
   message(STATUS "mooncake_store: CUDAToolkit detected, enabling D2H staging")
   target_compile_definitions(mooncake_store PRIVATE USE_CUDA)
   target_compile_definitions(mooncake_client PRIVATE USE_CUDA)


### PR DESCRIPTION
## Description

`mooncake-transfer-engine-non-cuda==0.3.12.post1` gives three packaged ELF files a `libcudart.so.12` dependency across CPython 3.10–3.13:

- `mooncake/mooncake_master`
- `mooncake/mooncake_client`
- `mooncake/store.so`

Only the master dependency is accidental. `mooncake_client` and `store.so` contain real CUDA staging references (`cudaMemcpy`, `cudaPointerGetAttributes`, and related APIs), preserving the behavior introduced by #1892 for GPU pointers that can reach Store even when global `USE_CUDA=OFF`. In contrast, `mooncake_master` has no undefined CUDA symbols: it inherits `CUDA::cudart` only because the static `mooncake_store` target propagates optional runtime dependencies to every consumer.

This focused fix:

- keeps Store's toolkit auto-detection and CUDA staging behavior unchanged;
- links the metadata-only `mooncake_master` with `--as-needed`, removing unused cudart from its `DT_NEEDED` entries;
- checks the installed master binary for `libcuda.so*`/`libcudart.so*` during regular non-CUDA wheel smoke tests;
- adds CPython 3.10 and 3.12 `NON_CUDA_BUILD` wheels to the nightly workflow, so the assertion runs nightly and during non-CUDA releases without adding a full wheel build to every PR.

This is narrower than #1839, which proposes general dynamic CUDA library loading. It also complements #3110/#3114: those changes handle the driver stub for CUDA wheel smoke tests, while this PR prevents the non-CUDA master from acquiring an unused CUDA runtime dependency.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
# Configure the exact edge case: USE_CUDA=OFF while a CUDA toolkit is visible.
cmake -S . -B /tmp/mooncake-master-asneeded-build -G Ninja \
  -DCUDAToolkit_ROOT=/usr/local/cuda-12.2 \
  -DBUILD_UNIT_TESTS=OFF -DBUILD_BENCHMARK=OFF \
  -DUSE_HTTP=ON -DUSE_ETCD=OFF -DUSE_CUDA=OFF -DWITH_EP=OFF \
  -DSTORE_USE_ETCD=OFF -DENABLE_SCCACHE=OFF -DWITH_STORE_RUST=OFF \
  -DCMAKE_BUILD_TYPE=Release
cmake --build /tmp/mooncake-master-asneeded-build \
  --target mooncake_master mooncake_client store --parallel 128

# Execute master and inspect all three affected targets.
LD_LIBRARY_PATH=/tmp/mooncake-master-asneeded-build/mooncake-common:/usr/local/lib \
  /tmp/mooncake-master-asneeded-build/mooncake-store/src/mooncake_master --version
readelf -d /tmp/mooncake-master-asneeded-build/mooncake-store/src/mooncake_master
readelf -d /tmp/mooncake-master-asneeded-build/mooncake-store/src/mooncake_client
readelf -d /tmp/mooncake-master-asneeded-build/mooncake-integration/store.cpython-310-x86_64-linux-gnu.so

UV_CACHE_DIR=/tmp/mooncake-uv-cache uvx --from pytest --with pyyaml \
  pytest mooncake-wheel/tests/test_release_wheel_tags.py -q
pre-commit run --files \
  .github/workflows/_build-wheel.yaml .github/workflows/nightly.yml \
  mooncake-store/src/CMakeLists.txt
git diff --check
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

The local configuration reported `mooncake_store: CUDAToolkit detected, enabling D2H staging` despite `USE_CUDA=OFF`, reproducing the release-builder condition. All three targets built successfully. `mooncake_master --version` ran without CUDA on its library path, and `readelf` showed:

- `mooncake_master`: no CUDA dependency
- `mooncake_client`: `libcudart.so.12` retained
- `store.so`: `libcudart.so.12` retained

The targeted workflow test for `nightly.yml:build-non-cuda-x86` passed, and all targeted pre-commit hooks passed. The full workflow configuration suite currently has one unrelated failure from the newly added bare-runner `nightly.yml:build-cuda128-arm64` job on `main`.

## Checklist

- [ ] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

Documentation and an RFC are not applicable to this focused release/build fix.

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex inspected the `v0.3.12.post1` artifacts, distinguished the master's unused transitive dependency from Store's intentional CUDA staging symbols, implemented the scoped linker and CI changes, and ran the validations listed above. The human submitter is responsible for reviewing and defending every changed line.