### PR TITLE
[CI/Build] master image: install ibverbs-providers and publish a CUDA 13 flavor

### DIFF
--- a/.github/workflows/publish-master-image.yaml
+++ b/.github/workflows/publish-master-image.yaml
@@ -4,20 +4,40 @@ name: Publish Master Image
 # run after that version's wheel is published — avoids racing release.yaml, which builds
 # and publishes the wheel in the same v* tag event.
 #
-# Publish flow: validate input -> confirm amd64+arm64 wheels exist -> build multi-arch
-# and push the :<version> tag -> smoke-test amd64 AND arm64 -> only then promote :latest
-# (when requested). :latest is copied from the smoked :<version> digest, so the default
-# pull tag can never point at an image that failed smoke. A failed smoke still leaves the
-# :<version> tag public; since this is manual, delete it from Docker Hub by hand.
+# Two CUDA flavors are published from the same version input, because the wheel ships as
+# two PyPI projects that are versioned in lockstep:
+#   cuda12 -> mooncake-transfer-engine         -> :<version>            (and :latest)
+#   cuda13 -> mooncake-transfer-engine-cuda13  -> :<version>-cuda13     (and :latest-cuda13)
+# The cuda12 tag stays unsuffixed so existing pulls keep working. Each flavor is built
+# from its own Dockerfile (docker/master.Dockerfile, docker/master-cuda13.Dockerfile);
+# those two files must differ only in the CUDA-flavor lines, which `prepare` enforces.
+#
+# Publish flow: validate input -> check the Dockerfiles are in sync -> per flavor: confirm
+# amd64+arm64 wheels exist -> build multi-arch and push the :<version>[-cuda13] tag ->
+# smoke-test amd64 AND arm64 -> only then promote :latest[-cuda13] (when requested).
+# :latest is copied from the smoked :<version> digest, so the default pull tag can never
+# point at an image that failed smoke. A failed smoke still leaves the :<version> tag
+# public; since this is manual, delete it from Docker Hub by hand. The flavors run as
+# independent matrix legs with fail-fast disabled, so one flavor failing never cancels
+# the other mid-push.
 on:
   workflow_dispatch:
     inputs:
       mooncake_version:
-        description: "Published mooncake-transfer-engine version (also the image tag), e.g. 0.3.11.post1"
+        description: "Published wheel version (also the image tag), e.g. 0.3.11.post1. Both PyPI projects use the same version."
         required: true
         type: string
+      flavors:
+        description: "Which CUDA flavor(s) to publish. Keep 'both' unless backfilling a single flavor."
+        required: false
+        default: both
+        type: choice
+        options:
+          - both
+          - cuda12
+          - cuda13
       tag_latest:
-        description: "Also move :latest to this build. Only enable when publishing the newest release (a backfill/retry of an older wheel must NOT move :latest)."
+        description: "Also move :latest (per flavor) to this build. Only enable when publishing the newest release (a backfill/retry of an older wheel must NOT move :latest)."
         required: false
         default: false
         type: boolean
@@ -31,16 +51,16 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  publish-master:
+  # Cheap gate: everything that is flavor-independent runs once, before any runner spends
+  # time on QEMU/buildx. Also emits the flavor matrix consumed by publish-master.
+  prepare:
     runs-on: ubuntu-22.04
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
     env:
-      REPO: docker.io/kvcacheai/mooncake
       # inputs.* placed in env (not interpolated into shell source) — injection-safe.
       MOONCAKE_VERSION: ${{ inputs.mooncake_version }}
-      # Pinned for the official image: provenance must always be the public PyPI index.
-      # Debug builds against another index belong in a separate workflow that does NOT
-      # push official kvcacheai/mooncake tags.
-      PIP_INDEX_URL: https://pypi.org/simple
+      FLAVORS: ${{ inputs.flavors }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -54,7 +74,79 @@ jobs:
             exit 1
           fi
 
-      # This image is intentionally the CPython 3.12 flavor: master.Dockerfile pins
+      # The two flavors are the same image with a different CUDA runtime, so the two
+      # Dockerfiles are kept byte-identical apart from the CUDA-flavor lines. Normalize
+      # those lines and diff: any other divergence (a runtime package added to one file
+      # only, say) fails here instead of silently shipping one broken flavor.
+      - name: Check the two master Dockerfiles are in sync
+        run: |
+          norm() {
+            sed -E \
+              -e 's#^FROM nvidia/cuda:.* AS cudalibs$#FROM <CUDA_DEVEL> AS cudalibs#' \
+              -e 's#libcudart\.so\.[0-9]+#libcudart.so.<MAJOR>#g' \
+              -e 's#^        mooncake-transfer-engine(-cuda13)?==#        <MOONCAKE_PACKAGE>==#' \
+              "$1"
+          }
+          if ! diff -u <(norm docker/master.Dockerfile) <(norm docker/master-cuda13.Dockerfile); then
+            echo "::error::docker/master.Dockerfile and docker/master-cuda13.Dockerfile differ outside the CUDA-flavor lines" >&2
+            exit 1
+          fi
+          echo "Dockerfiles in sync (only the CUDA-flavor lines differ)"
+
+      - name: Build flavor matrix
+        id: matrix
+        run: |
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import json, os, sys
+          FLAVORS = {
+              "cuda12": {
+                  "flavor": "cuda12",
+                  "package": "mooncake-transfer-engine",
+                  "dockerfile": "docker/master.Dockerfile",
+                  "tag_suffix": "",
+              },
+              "cuda13": {
+                  "flavor": "cuda13",
+                  "package": "mooncake-transfer-engine-cuda13",
+                  "dockerfile": "docker/master-cuda13.Dockerfile",
+                  "tag_suffix": "-cuda13",
+              },
+          }
+          sel = os.environ["FLAVORS"]
+          keys = list(FLAVORS) if sel == "both" else [sel]
+          if any(k not in FLAVORS for k in keys):
+              sys.exit(f"Unknown flavors input: {sel!r}")
+          print("matrix=" + json.dumps([FLAVORS[k] for k in keys]))
+          PY
+          cat "$GITHUB_OUTPUT"
+
+  publish-master:
+    needs: prepare
+    runs-on: ubuntu-22.04
+    strategy:
+      # One flavor failing must not cancel the other: a cancelled leg could be killed
+      # between its push and its smoke test, leaving an untested tag with no verdict.
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.prepare.outputs.matrix) }}
+    env:
+      REPO: docker.io/kvcacheai/mooncake
+      # inputs.*/matrix.* placed in env (not interpolated into shell source) — injection-safe.
+      MOONCAKE_VERSION: ${{ inputs.mooncake_version }}
+      MOONCAKE_PACKAGE: ${{ matrix.package }}
+      IMAGE_TAG: ${{ inputs.mooncake_version }}${{ matrix.tag_suffix }}
+      TAG_SUFFIX: ${{ matrix.tag_suffix }}
+      # Pinned for the official image: provenance must always be the public PyPI index.
+      # Debug builds against another index belong in a separate workflow that does NOT
+      # push official kvcacheai/mooncake tags.
+      PIP_INDEX_URL: https://pypi.org/simple
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      # This image is intentionally the CPython 3.12 flavor: both master Dockerfiles pin
       # python:3.12-slim-trixie, so only cp312 wheels are ABI-compatible. If that base
       # Python is ever bumped (e.g. to 3.13), update the "cp312" match below to match —
       # otherwise this preflight would green-light wheels the image cannot import.
@@ -63,11 +155,12 @@ jobs:
           python3 - <<'PY'
           import json, os, sys, urllib.request
           v = os.environ["MOONCAKE_VERSION"]
-          url = f"https://pypi.org/pypi/mooncake-transfer-engine/{v}/json"
+          pkg = os.environ["MOONCAKE_PACKAGE"]
+          url = f"https://pypi.org/pypi/{pkg}/{v}/json"
           try:
               data = json.load(urllib.request.urlopen(url, timeout=30))
           except Exception as e:
-              sys.exit(f"Cannot fetch PyPI metadata for {v}: {e}")
+              sys.exit(f"Cannot fetch PyPI metadata for {pkg} {v}: {e}")
           arch_ok = {"x86_64": False, "aarch64": False}
           for f in data.get("urls", []):
               fn = f.get("filename", "")
@@ -77,9 +170,9 @@ jobs:
                           arch_ok[arch] = True
           missing = [a for a, ok in arch_ok.items() if not ok]
           if missing:
-              sys.exit(f"Missing cp312 wheel(s) for {v}: {missing}. "
+              sys.exit(f"Missing cp312 wheel(s) for {pkg} {v}: {missing}. "
                        "Both amd64 (x86_64) and arm64 (aarch64) must be published first.")
-          print(f"cp312 amd64+arm64 wheels present for {v}")
+          print(f"cp312 amd64+arm64 wheels present for {pkg} {v}")
           PY
 
       - name: Free up disk space
@@ -100,23 +193,23 @@ jobs:
           username: kvcacheai
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # Build multi-arch and push ONLY the immutable :<version> tag. :latest is promoted
-      # in a later step, after smoke passes. provenance/sbom disabled to keep the index
-      # free of unknown/unknown attestation entries (they would otherwise show up in
+      # Build multi-arch and push ONLY the immutable :<version>[-cuda13] tag. :latest is
+      # promoted in a later step, after smoke passes. provenance/sbom disabled to keep the
+      # index free of unknown/unknown attestation entries (they would otherwise show up in
       # `imagetools inspect`).
-      - name: Build and push :<version> (multi-arch)
+      - name: Build and push :<version>${{ matrix.tag_suffix }} (multi-arch)
         id: build
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: docker/master.Dockerfile
+          file: ${{ matrix.dockerfile }}
           platforms: linux/amd64,linux/arm64
           provenance: false
           sbom: false
           build-args: |
             MOONCAKE_VERSION=${{ inputs.mooncake_version }}
             PIP_INDEX_URL=${{ env.PIP_INDEX_URL }}
-          tags: ${{ env.REPO }}:${{ inputs.mooncake_version }}
+          tags: ${{ env.REPO }}:${{ inputs.mooncake_version }}${{ matrix.tag_suffix }}
           push: true
 
       # Smoke tests run AFTER the :<version> push (a failed smoke leaves :<version> public
@@ -129,7 +222,7 @@ jobs:
       - name: Smoke test amd64 (entrypoints)
         run: |
           docker run --rm --platform linux/amd64 \
-            "${REPO}:${MOONCAKE_VERSION}" bash -c '
+            "${REPO}:${IMAGE_TAG}" bash -c '
               set -euo pipefail
               python3 -c "import mooncake.engine, mooncake.store"
               mooncake_master --version
@@ -138,11 +231,11 @@ jobs:
             '
 
       # arm64 is the riskier arch here: the aarch64 wheel is manylinux_2_39 (glibc >= 2.39),
-      # which is the whole reason master.Dockerfile pins a trixie base. Smoke it under QEMU.
+      # which is the whole reason the master Dockerfiles pin a trixie base. Smoke it under QEMU.
       - name: Smoke test arm64 (entrypoints, QEMU)
         run: |
           docker run --rm --platform linux/arm64 \
-            "${REPO}:${MOONCAKE_VERSION}" bash -c '
+            "${REPO}:${IMAGE_TAG}" bash -c '
               set -euo pipefail
               python3 -c "import mooncake.engine, mooncake.store"
               mooncake_master --version
@@ -150,12 +243,13 @@ jobs:
               echo "arm64 ok"
             '
 
-      # Promote :latest ONLY after both arches pass smoke, and only when explicitly
+      # Promote :latest[-cuda13] ONLY after both arches pass smoke, and only when explicitly
       # requested. imagetools create copies the tested :<version> manifest by digest
       # (no rebuild), so :latest can never point at an image that didn't pass smoke.
-      - name: Promote :latest (post-smoke)
+      # Each flavor promotes its own latest tag: cuda12 -> :latest, cuda13 -> :latest-cuda13.
+      - name: Promote :latest${{ matrix.tag_suffix }} (post-smoke)
         if: ${{ inputs.tag_latest }}
         run: |
           docker buildx imagetools create \
-            --tag "${REPO}:latest" \
-            "${REPO}:${MOONCAKE_VERSION}"
+            --tag "${REPO}:latest${TAG_SUFFIX}" \
+            "${REPO}:${IMAGE_TAG}"

--- a/docker/master-cuda13.Dockerfile
+++ b/docker/master-cuda13.Dockerfile
@@ -5,7 +5,7 @@
 # the pip package name). The publish workflow diffs them with those lines normalized.
 
 # Stage cudalibs: take stub libcuda and libcudart from the CUDA devel image
-FROM nvidia/cuda:12.8.1-devel-ubuntu22.04@sha256:a99a1860ba8e2916e5c3e73b72ec4c4301653a84586e05bfc9a2aa2d58027e97 AS cudalibs
+FROM nvidia/cuda:13.0.3-devel-ubuntu22.04@sha256:3869b846a8cc495ce11c172d87cfc0da8874b910d14a9810bec6b6182e9ee9f8 AS cudalibs
 
 # Final image. Must be trixie (glibc 2.41): the aarch64 wheel is manylinux_2_39
 # (needs glibc >= 2.39), which bookworm (2.36) cannot satisfy.
@@ -33,12 +33,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Copy stub libcuda and libcudart into the loader's default path, refresh the link cache
 COPY --from=cudalibs /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/lib/libcuda.so.1
-COPY --from=cudalibs /usr/local/cuda/lib64/libcudart.so.12  /usr/local/lib/libcudart.so.12
+COPY --from=cudalibs /usr/local/cuda/lib64/libcudart.so.13  /usr/local/lib/libcudart.so.13
 RUN ldconfig
 
 # Install mooncake, remove torch EP/PG extensions (ep_*/pg_*), chown the package dir to uid 65532 (all in one layer)
 RUN pip install --no-cache-dir --index-url "${PIP_INDEX_URL}" \
-        mooncake-transfer-engine==${MOONCAKE_VERSION} \
+        mooncake-transfer-engine-cuda13==${MOONCAKE_VERSION} \
     && PKG="$(python3 -c 'import mooncake,os;print(os.path.dirname(mooncake.__file__))')" \
     && rm -f "$PKG"/ep_*.so "$PKG"/pg_*.so \
     && chown -R 65532:65532 "$PKG"


### PR DESCRIPTION
## Description

Two changes to the published master image, kept in one PR because they touch the same file and the second one would otherwise inherit the first one's bug.

**1. Fix `ImportError: libmlx5.so.1` (Publish Master Image is currently red).**

`docker/master.Dockerfile` installs `libibverbs1` but not `ibverbs-providers`, which is the Debian package that owns `/usr/lib/<triplet>/libmlx5.so.1` and the libibverbs provider plugins. Since 0.3.12 the CUDA wheel needs both:

- **Load time** — `engine.so`, `store.so` and `mooncake_master` now carry a hard `DT_NEEDED libmlx5.so.1`, because the transport links `mlx5` for the IBGDA / mlx5dv DevX path (`mooncake-transfer-engine/src/transport/CMakeLists.txt`), and `build_wheel.sh` deliberately passes `--exclude libmlx5.so*` to auditwheel. A wheel cannot declare a system-library dependency, so the image has to provide it — otherwise `import mooncake.engine` fails outright, even for TCP-only use. 0.3.11.post1 did not have this `DT_NEEDED`, which is why the image worked before.
- **Run time** — libibverbs claims devices through the provider plugins from that same package. Without it `ibv_get_device_list()` returns **0 devices** even on a host with mlx5 HCAs and `/dev/infiniband` passed into the container, so RDMA is silently dead rather than loudly broken.

`ibverbs-providers` must come from apt next to `libibverbs1`: both are built from the `rdma-core` source package and share a private provider ABI (encoded in the plugin name, `libmlx5-rdmav34.so`), which Debian enforces with `Depends: libibverbs1 (= same version)`.
Vendoring a libmlx5 into the wheel or dropping in a stub `.so` would break that. Cost of the package is +2 MB (405 MB → 407 MB).

**2. Publish a CUDA 13 flavor.**

The wheel ships as two PyPI projects that are versioned in lockstep, but only the CUDA 12 one was ever imaged:

| flavor | PyPI project | image tag |
| --- | --- | --- |
| cuda12 | `mooncake-transfer-engine` | `:<version>` (and `:latest`) |
| cuda13 | `mooncake-transfer-engine-cuda13` | `:<version>-cuda13` (and `:latest-cuda13`) |

The cuda12 tag stays unsuffixed so existing pulls keep working. Both flavors install into the same `mooncake` package, so they are mutually exclusive and have to be separate tags.

This is not just a different pip package name: the cuda13 wheel's `engine.so` / `mooncake_master` carry `DT_NEEDED libcudart.so.13`, so the `cudalibs` stage and the `libcudart` COPY have to move to a CUDA 13 base as well. The base is pinned to `nvidia/cuda:13.0.3-devel-ubuntu22.04` to match the `pytorch/manylinux2_28-builder:cuda13.0` container that `release-cuda13.yaml` builds the wheel in. The stub `libcuda.so` is unaffected (driver ABI, same soname either way).

Implemented as a second Dockerfile rather than one ARG-parameterised file, to match the existing one-file-per-variant convention in `docker/` (`master`, `mooncake`, `musa`), to keep both base images literal and digest-pinned instead of hidden behind `ARG` in `FROM`, and because three independent ARGs (base / cudart soname / package name) would let a mismatched combination build successfully and only fail at run time. The two files must differ **only** in those three lines, and `prepare` enforces that with a normalize-then-diff check, so a runtime package added to one file but not the other fails CI instead of silently shipping one broken flavor.

The publish workflow gains a `flavors` input (`both` / `cuda12` / `cuda13`, default `both`) and runs the flavors as independent matrix legs with `fail-fast: false`, so one flavor failing can never cancel the other between its push and its smoke test. Each leg does its own PyPI preflight against its own project, its own amd64 + arm64 smoke, and promotes its own `:latest` tag only after both arches pass.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Built and run on a host with 5 × ConnectX HCAs (`mlx5_0..4`, Ubuntu 22.04, glibc 2.35), so the RDMA path could be exercised for real and not just linked. Both images were built for `linux/amd64` from `0.3.12.post1`.

**Test commands:**
```bash
# A/B on the libmlx5 fix: same Dockerfile, only ibverbs-providers differs docker build -f docker/master.Dockerfile --build-arg MOONCAKE_VERSION=0.3.12.post1 -t mc-fixed .
docker run --rm mc-fixed bash -c '
  python3 -c "import mooncake.engine, mooncake.store"
  mooncake_master --version
  mooncake_http_metadata_server --help >/dev/null'

# does libibverbs actually claim the devices?
docker run --rm --user 0 --device /dev/infiniband --ulimit memlock=-1 \
  --entrypoint python3 mc-fixed -c '
import ctypes; ibv = ctypes.CDLL("libibverbs.so.1")
ibv.ibv_get_device_list.restype = ctypes.POINTER(ctypes.c_void_p)
n = ctypes.c_int(); lst = ibv.ibv_get_device_list(ctypes.byref(n)); print("devices:", n.value)'

# both flavors
docker build -f docker/master.Dockerfile        --build-arg MOONCAKE_VERSION=0.3.12.post1 -t mc-cu12 .
docker build -f docker/master-cuda13.Dockerfile --build-arg MOONCAKE_VERSION=0.3.12.post1 -t mc-cu13 .

# the Dockerfile sync check, as run by the prepare job
norm() { sed -E -e 's#^FROM nvidia/cuda:.* AS cudalibs#FROM <CUDA_DEVEL> AS cudalibs#' \
                -e 's#libcudart\.so\.[0-9]+#libcudart.so.<MAJOR>#g' \
                -e 's#^        mooncake-transfer-engine(-cuda13)?==#        <MOONCAKE_PACKAGE>==#' "$1"; }
diff -u <(norm docker/master.Dockerfile) <(norm docker/master-cuda13.Dockerfile)
```

**Test results:**

A/B on the libmlx5 fix — identical Dockerfile, `ibverbs-providers` the only variable:

| check | without the package | with the package |
| --- | --- | --- |
| `import mooncake.engine, mooncake.store` | `ImportError: libmlx5.so.1` | ok |
| `mooncake_master --version` | rc=127, same missing library | `0.3.12.post1 (git: 6041a60)` |
| `mooncake_http_metadata_server --help` | ok (pure Python) | ok |
| `ibv_get_device_list()` with `--device /dev/infiniband` | **0 devices** | **5** (`mlx5_0..4`) |
| `ibv_open_device(mlx5_0)` | — | succeeds |
| image size | 405 MB | 407 MB |

In the failing case `/sys/class/infiniband` still listed `mlx5_0..4` and `/dev/infiniband` was mounted — the devices are there, libibverbs just has no provider to claim them.

Both flavors, after the fix:

| check | cuda12 | cuda13 |
| --- | --- | --- |
| build | ok | ok |
| the three smoke commands | rc=0 | rc=0 |
| installed distribution | `mooncake-transfer-engine 0.3.12.post1` | `mooncake-transfer-engine-cuda13 0.3.12.post1` |
| `ldd engine.so` cudart | `libcudart.so.12 => /usr/local/lib/...` | `libcudart.so.13 => /usr/local/lib/...` |
| `ldd engine.so` libmlx5 | resolved | resolved |
| `ibv_get_device_list()` | — | 5 devices, `ibv_open_device` ok |
| image size | 407 MB | 407 MB |

Dockerfile sync check: passes on this branch, and was negative-controlled by adding a package to one file only — the check fails as intended. The flavor-matrix generator and the per-flavor PyPI preflight were exercised for `both` / `cuda12` / `cuda13` and for an invalid input.

- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (described above)

Not covered locally: the arm64 legs, because the test host has no arm64 binfmt handler registered and installing one was out of scope; arm64 is covered by the workflow's QEMU smoke step, which is unchanged apart from now running per flavor. The local builds also used a regional Debian and PyPI mirror for network reasons — applied identically to both flavors, and not part of the committed files.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue (n/a, ~200 LOC)

The tests here are CI-level rather than unit tests: the new Dockerfile sync check in `prepare`, and the existing entrypoint smoke tests now running per flavor on both arches.

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Claude Code was used to investigate the `libmlx5.so.1` failure (ELF `DT_NEEDED` analysis across 0.3.11.post1 / 0.3.12 / 0.3.12.post1 wheels, tracing it to the mlx5 link added for IBGDA), to draft the Dockerfile and workflow changes, and to run the A/B verification on RDMA hardware. Every changed line has been reviewed by the submitter.