### PR TITLE
[PG] Forward collectives through the backend shim for PyTorch 2.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -570,6 +570,20 @@ jobs:
         python mooncake-pg/tests/test_pg_collectives.py
       shell: bash
 
+    - name: Test PyTorch 2.13 Single-Buffer Collectives (CPU Only)
+      if: matrix.ubuntu-version == 'ubuntu-22.04' && matrix.python-version == '3.10'
+      env:
+        MC_FORCE_TCP: "true"
+      run: |
+        source test_env/bin/activate
+        python -m pip install --force-reinstall "torch==2.13.0" \
+          --index-url https://download.pytorch.org/whl/cu126 \
+          --extra-index-url https://pypi.org/simple
+        python mooncake-pg/tests/test_pg_collectives.py \
+          TestMooncakePGCollectivesCPU.test_all_gather_into_tensor \
+          TestMooncakePGCollectivesCPU.test_reduce_scatter_sum
+      shell: bash
+
     - name: Test Safetensor Functions
       run: |
         source test_env/bin/activate

--- a/mooncake-pg/include/mooncake_backend.h
+++ b/mooncake-pg/include/mooncake_backend.h
@@ -22,14 +22,20 @@ namespace mooncake {
 // MooncakeBackend, which is defined below.
 class MooncakeBackend;
 
-// Lightweight Backend shim that delegates P2P send/recv back to the owning
+// Lightweight Backend shim that delegates operations back to the owning
 // MooncakeBackend.  PyTorch's P2P dispatch (batch_isend_irecv, isend, irecv)
 // requires getBackend() to return a registered c10d::Backend instance.
 // Since MooncakeBackend inherits from ProcessGroup (not Backend), we register
-// this shim in the ProcessGroup's deviceTypeToBackend_ map so that the P2P
-// path can find it.  The shim holds a non-owning pointer to its owner and
-// delegates only the operations that the P2P dispatch path calls (send, recv,
-// getBackendName, supportsCoalescing).
+// this shim in the ProcessGroup's deviceTypeToBackend_ map.  The shim holds a
+// non-owning pointer to its owner.
+//
+// PyTorch 2.13 added ProcessGroup::all_gather_single and
+// ProcessGroup::reduce_scatter_single, and the deprecated single-buffer
+// aliases now forward to those methods.  They dispatch through c10d/Ops.cpp
+// and ProcessGroup::getBackend(dev), so calls land on this registered shim
+// instead of MooncakeBackend's _allgather_base and _reduce_scatter_base
+// overrides.  Delegate every collective MooncakeBackend implements so the
+// shim exposes the same capabilities as its owner.
 class MooncakeP2PShim final : public ::c10d::Backend {
    public:
     explicit MooncakeP2PShim(MooncakeBackend* owner);
@@ -49,6 +55,50 @@ class MooncakeP2PShim final : public ::c10d::Backend {
 
     c10::intrusive_ptr<c10d::Work> barrier(
         const c10d::BarrierOptions& opts) override;
+
+    // Collective delegation to owner_ (see the class comment for the PyTorch
+    // 2.13 single-buffer dispatch rationale).  Signatures mirror
+    // MooncakeBackend's overrides so the shim re-exposes the same c10d
+    // virtuals.
+    c10::intrusive_ptr<c10d::Work> broadcast(
+        std::vector<at::Tensor>& tensors,
+        const c10d::BroadcastOptions& opts) override;
+
+    c10::intrusive_ptr<c10d::Work> allreduce(
+        std::vector<at::Tensor>& tensors,
+        const c10d::AllreduceOptions& opts) override;
+
+    c10::intrusive_ptr<c10d::Work> allgather(
+        std::vector<std::vector<at::Tensor>>& outputTensors,
+        std::vector<at::Tensor>& inputTensors,
+        const c10d::AllgatherOptions& opts) override;
+
+    c10::intrusive_ptr<c10d::Work> _allgather_base(
+        at::Tensor& outputBuffer, at::Tensor& inputBuffer,
+        const c10d::AllgatherOptions& opts) override;
+
+    c10::intrusive_ptr<c10d::Work> _reduce_scatter_base(
+        at::Tensor& outputBuffer, at::Tensor& inputBuffer,
+        const c10d::ReduceScatterOptions& opts) override;
+
+    c10::intrusive_ptr<c10d::Work> alltoall(
+        std::vector<at::Tensor>& outputTensors,
+        std::vector<at::Tensor>& inputTensors,
+        const c10d::AllToAllOptions& opts) override;
+
+    c10::intrusive_ptr<c10d::Work> reduce(
+        std::vector<at::Tensor>& tensors,
+        const c10d::ReduceOptions& opts) override;
+
+    c10::intrusive_ptr<c10d::Work> gather(
+        std::vector<std::vector<at::Tensor>>& outputTensors,
+        std::vector<at::Tensor>& inputTensors,
+        const c10d::GatherOptions& opts) override;
+
+    c10::intrusive_ptr<c10d::Work> scatter(
+        std::vector<at::Tensor>& outputTensors,
+        std::vector<std::vector<at::Tensor>>& inputTensors,
+        const c10d::ScatterOptions& opts) override;
 
    private:
     // Non-owning: the shim is stored in ProcessGroup's backend maps which are

--- a/mooncake-pg/src/mooncake_backend.cpp
+++ b/mooncake-pg/src/mooncake_backend.cpp
@@ -457,9 +457,9 @@ MooncakeBackend::MooncakeBackend(
         connection_ctx_->waitUntilAllConnected();
     }
 
-    // Register a lightweight Backend shim so that PyTorch's P2P dispatch path
-    // (batch_isend_irecv → _get_backend → getBackend) can find a registered
-    // Backend for this ProcessGroup.  The shim delegates send/recv back to us.
+    // Register a lightweight Backend shim so PyTorch dispatch can find a
+    // registered Backend for this ProcessGroup.  The shim delegates supported
+    // P2P and collective operations back to this backend.
     auto deviceType = isCpu ? c10::DeviceType::CPU : c10::DeviceType::CUDA;
     auto shim = c10::make_intrusive<MooncakeP2PShim>(this);
     setBackend(deviceType, BackendType::CUSTOM, shim);
@@ -502,6 +502,64 @@ c10::intrusive_ptr<c10d::Work> MooncakeP2PShim::recvAnysource(
 c10::intrusive_ptr<c10d::Work> MooncakeP2PShim::barrier(
     const c10d::BarrierOptions& opts) {
     return owner_->barrier(opts);
+}
+
+// ---- MooncakeP2PShim collective delegation ----
+// PyTorch 2.13's all_gather_single and reduce_scatter_single entry points
+// dispatch through the registered Backend. Delegate every supported collective
+// so the shim exposes the same capabilities as its owning MooncakeBackend. See
+// the class comment in mooncake_backend.h for the full rationale.
+
+c10::intrusive_ptr<c10d::Work> MooncakeP2PShim::broadcast(
+    std::vector<at::Tensor>& tensors, const c10d::BroadcastOptions& opts) {
+    return owner_->broadcast(tensors, opts);
+}
+
+c10::intrusive_ptr<c10d::Work> MooncakeP2PShim::allreduce(
+    std::vector<at::Tensor>& tensors, const c10d::AllreduceOptions& opts) {
+    return owner_->allreduce(tensors, opts);
+}
+
+c10::intrusive_ptr<c10d::Work> MooncakeP2PShim::allgather(
+    std::vector<std::vector<at::Tensor>>& outputTensors,
+    std::vector<at::Tensor>& inputTensors, const c10d::AllgatherOptions& opts) {
+    return owner_->allgather(outputTensors, inputTensors, opts);
+}
+
+c10::intrusive_ptr<c10d::Work> MooncakeP2PShim::_allgather_base(
+    at::Tensor& outputBuffer, at::Tensor& inputBuffer,
+    const c10d::AllgatherOptions& opts) {
+    return owner_->_allgather_base(outputBuffer, inputBuffer, opts);
+}
+
+c10::intrusive_ptr<c10d::Work> MooncakeP2PShim::_reduce_scatter_base(
+    at::Tensor& outputBuffer, at::Tensor& inputBuffer,
+    const c10d::ReduceScatterOptions& opts) {
+    return owner_->_reduce_scatter_base(outputBuffer, inputBuffer, opts);
+}
+
+c10::intrusive_ptr<c10d::Work> MooncakeP2PShim::alltoall(
+    std::vector<at::Tensor>& outputTensors,
+    std::vector<at::Tensor>& inputTensors, const c10d::AllToAllOptions& opts) {
+    return owner_->alltoall(outputTensors, inputTensors, opts);
+}
+
+c10::intrusive_ptr<c10d::Work> MooncakeP2PShim::reduce(
+    std::vector<at::Tensor>& tensors, const c10d::ReduceOptions& opts) {
+    return owner_->reduce(tensors, opts);
+}
+
+c10::intrusive_ptr<c10d::Work> MooncakeP2PShim::gather(
+    std::vector<std::vector<at::Tensor>>& outputTensors,
+    std::vector<at::Tensor>& inputTensors, const c10d::GatherOptions& opts) {
+    return owner_->gather(outputTensors, inputTensors, opts);
+}
+
+c10::intrusive_ptr<c10d::Work> MooncakeP2PShim::scatter(
+    std::vector<at::Tensor>& outputTensors,
+    std::vector<std::vector<at::Tensor>>& inputTensors,
+    const c10d::ScatterOptions& opts) {
+    return owner_->scatter(outputTensors, inputTensors, opts);
 }
 
 c10::intrusive_ptr<c10d::Work> MooncakeBackend::send(


### PR DESCRIPTION
## Description

PyTorch 2.13 added new single-buffer all-gather and reduce-scatter methods. These calls go through the backend registered with `ProcessGroup`, which is `MooncakeP2PShim` for Mooncake PG.

The shim did not forward collectives to `MooncakeBackend`, so they fell back to the base c10d implementation and failed with:

```text
RuntimeError: Backend mooncake does not support _reduce_scatter_base
```

The current Mooncake wheel fails while testing the [SGLang PyTorch 2.13 upgrade](https://github.com/sgl-project/sglang/pull/28836), which has already moved to the newly released Mooncake [`v0.3.12.post1`](https://github.com/kvcache-ai/Mooncake/releases/tag/v0.3.12.post1). The fix here makes the shim forward every collective already implemented by `MooncakeBackend`.

- [Failure before the patch](https://github.com/sgl-project/sglang/actions/runs/30149256817/job/89657263767#step:13:7078)
- [Passing job with the patched wheel](https://github.com/sgl-project/sglang/actions/runs/30162050881/job/89689263199?pr=28836#step:13:7590)

cc @ShangmingCai @UNIDY2002

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [x] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

I ran the same two CPU collective tests before and after the patch with Python 3.10 and PyTorch 2.13:

- Wheel without this change: both tests failed.
- Wheel built from this PR: both tests passed.

I also added them to the PyTorch 2.13 CI run. I think it makes sense to keep them there since the extension can build successfully even when these calls are broken at runtime.

**Test commands:**

```bash
./scripts/code_format.sh --check

pre-commit run --files \
  .github/workflows/ci.yml \
  mooncake-pg/include/mooncake_backend.h \
  mooncake-pg/src/mooncake_backend.cpp

MC_FORCE_TCP=true python mooncake-pg/tests/test_pg_collectives.py \
  TestMooncakePGCollectivesCPU.test_all_gather_into_tensor \
  TestMooncakePGCollectivesCPU.test_reduce_scatter_sum
```

**Test results:**

- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing done

## Checklist

- [x] Self-review completed
- [x] Code formatted using `./scripts/code_format.sh`
- [ ] `pre-commit run --all-files` passes
- [ ] Documentation updated (not applicable)
- [x] Tests added to prove the change is effective
- [ ] RFC issue filed for changes over 500 LOC (not applicable)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specified below)

AI tools were used to assist with this change. The changes were reviewed.