### PR TITLE
ci: fix cancel-ci listing that matched no runs

### DIFF
--- a/.github/workflows/cancel-ci.yml
+++ b/.github/workflows/cancel-ci.yml
@@ -9,9 +9,16 @@ name: Cancel Queued and Running CI
 # runs across all workflows and refs in one shot.
 #
 # Adapted from sglang's cancel-pr-workflows-on-close.yml cancellation logic:
-# sweep every non-terminal status (a single status= filter takes one value
-# per request), paginate, force-cancel runs stuck behind approval gates, and
-# run a second pass to catch runs still materializing during the first.
+# fetch recent runs, keep the non-terminal ones, force-cancel runs stuck
+# behind approval gates, and run a second pass to catch runs still
+# materializing during the first.
+#
+# Listing note: query params (branch, per_page, page) are placed directly in
+# the API path rather than via `gh api -f key=value`. `gh api` treats -f/-F
+# fields as a request *body* and, unless the method is pinned, flips GET to
+# POST -- either way the value never reaches the query string, so a status/
+# branch filter silently matches nothing. Status is filtered client-side in
+# jq to avoid that class of bug entirely.
 
 on:
   workflow_dispatch:
@@ -50,53 +57,77 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Non-terminal run statuses. GitHub reports in-flight runs as one of
+          # these; everything else (completed) is terminal.
+          UNFINISHED_RE='^(queued|in_progress|waiting|pending|requested|action_required)$'
+
+          echo "=================================================="
+          echo " Cancel Queued and Running CI"
+          echo "=================================================="
+          echo "Repo:   $REPO"
           if [ -n "$BRANCH" ]; then
-            echo "Scope: branch '$BRANCH'"
+            echo "Scope:  branch '$BRANCH' only"
           else
-            echo "Scope: all branches"
+            echo "Scope:  ALL branches"
           fi
-          echo "Dry run: $DRY_RUN"
+          if [ "$DRY_RUN" = "true" ]; then
+            echo ""
+            echo "  ⚠️  DRY RUN — runs will be LISTED but NOT cancelled."
+            echo "  ⚠️  Re-run with dry_run unchecked to actually cancel."
+          fi
+          echo "=================================================="
           echo ""
 
           FAILURES=0
 
-          # The status filter takes one value per request, so sweep every
-          # non-terminal state (pending/waiting/action_required runs would
-          # otherwise start after we finish). Pass 2 catches runs still
-          # materializing during pass 1. Exclude this run itself.
-          for pass in 1 2; do
-            run_ids=""
-            for status in queued in_progress waiting pending requested action_required; do
-              ids=""
+          # List unfinished runs. Params go in the path (see header note); status
+          # is filtered client-side. Only the most-recent pages can hold in-flight
+          # runs, so a few pages by created-desc order is plenty and stays bounded.
+          list_unfinished() {
+            local ids="" page batch
+            for page in 1 2 3 4 5; do
+              local path="repos/$REPO/actions/runs?per_page=100&page=$page"
+              if [ -n "$BRANCH" ]; then
+                path="$path&branch=$BRANCH"
+              fi
+              batch=""
               for attempt in 1 2 3; do
-                # branch= is optional; when empty gh omits the filter (all branches).
-                args=(-X GET "repos/$REPO/actions/runs" --paginate
-                      -f status="$status" -F per_page=100
-                      --jq ".workflow_runs[] | select(.id != $GITHUB_RUN_ID) | .id")
-                if [ -n "$BRANCH" ]; then
-                  args+=(-f branch="$BRANCH")
-                fi
-                if ids=$(gh api "${args[@]}"); then
+                if batch=$(gh api -X GET "$path" \
+                  --jq ".workflow_runs[]
+                        | select(.id != $GITHUB_RUN_ID)
+                        | select(.status | test(\"$UNFINISHED_RE\"))
+                        | \"\(.id)\t\(.status)\t\(.name)\""); then
                   break
                 fi
-                ids=""
+                batch=""
+                # Runs in a $(...) subshell, so an error annotation is the only
+                # signal that survives; the retries make a hard failure rare.
                 if [ "$attempt" -eq 3 ]; then
-                  echo "::error::Listing $status runs failed after 3 attempts"
-                  FAILURES=1
+                  echo "::error::Listing runs (page $page) failed after 3 attempts" >&2
                 else
                   sleep 5
                 fi
               done
-              run_ids="$run_ids"$'\n'"$ids"
+              ids="$ids"$'\n'"$batch"
             done
-            run_ids=$(echo "$run_ids" | sed '/^$/d' | sort -u)
+            echo "$ids" | sed '/^$/d' | sort -u
+          }
 
-            if [ -z "$run_ids" ]; then
+          # Pass 2 catches runs still materializing during pass 1.
+          for pass in 1 2; do
+            rows=$(list_unfinished)
+
+            if [ -z "$rows" ]; then
               echo "Pass $pass: no unfinished runs found"
               break
             fi
-            echo "Pass $pass: found $(echo "$run_ids" | wc -l | tr -d ' ') unfinished run(s)"
+            echo "Pass $pass: found $(echo "$rows" | wc -l | tr -d ' ') unfinished run(s):"
+            echo "$rows" | while IFS=$'\t' read -r rid rstatus rname; do
+              echo "  • $rid  [$rstatus]  $rname"
+            done
+            echo ""
 
+            run_ids=$(echo "$rows" | cut -f1)
             for run_id in $run_ids; do
               run_url="https://github.com/$REPO/actions/runs/$run_id"
               if [ "$DRY_RUN" = "true" ]; then


### PR DESCRIPTION
The cancel workflow listed unfinished runs with
`gh api -X GET repos/.../actions/runs -f status=$status`. gh treats -f/-F fields as request-body parameters; on a GET they do not reach the query string, so the status filter matched nothing and the workflow always reported "no unfinished runs found" and cancelled nothing (each run finished in a few seconds without ever entering the cancel path).

Fix: put query params (branch, per_page, page) directly in the API path and filter non-terminal status client-side in jq, which is immune to the -f/-F body quirk. Also:
- Fetch the most-recent pages (created-desc) instead of a per-status sweep; in-flight runs are always among the newest, so this stays bounded on busy repos while still covering every unfinished run.
- Print resolved inputs and each matched run (id/status/name) so a no-op is diagnosable at a glance.
- Make the dry-run banner unmistakable so an accidental dry run is not mistaken for a real cancel.

Verified against the live API: the client-side filter correctly matches the in_progress run the old query missed.

## Description



## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



**Test commands:**
```bash
# Example: bash scripts/run_ci_test.sh
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [ ] AI tools were used (specify below)